### PR TITLE
Added Memorize to redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -428,7 +428,7 @@ static char **convertToSds(int count, char** args) {
 }
 
 #define LINE_BUFLEN 4096
-#define MEMORIZED_BUFLEN 1
+#define MEMORIZED_BUFLEN 1024
 static void repl() {
     int argc, j;
     char *line;

--- a/src/redis.c
+++ b/src/redis.c
@@ -98,6 +98,7 @@ struct redisCommand readonlyCommandTable[] = {
     {"lrem",lremCommand,4,0,NULL,1,1,1},
     {"rpoplpush",rpoplpushcommand,3,REDIS_CMD_DENYOOM,NULL,1,2,1},
     {"sadd",saddCommand,3,REDIS_CMD_DENYOOM,NULL,1,1,1},
+    {"msadd",msaddCommand,-3,REDIS_CMD_DENYOOM,NULL,1,1,1},
     {"srem",sremCommand,3,0,NULL,1,1,1},
     {"smove",smoveCommand,4,0,NULL,1,2,1},
     {"sismember",sismemberCommand,3,0,NULL,1,1,1},

--- a/src/redis.h
+++ b/src/redis.h
@@ -890,6 +890,7 @@ void ltrimCommand(redisClient *c);
 void typeCommand(redisClient *c);
 void lsetCommand(redisClient *c);
 void saddCommand(redisClient *c);
+void msaddCommand(redisClient *c);
 void sremCommand(redisClient *c);
 void smoveCommand(redisClient *c);
 void sismemberCommand(redisClient *c);

--- a/src/sds.c
+++ b/src/sds.c
@@ -251,6 +251,19 @@ void sdstoupper(sds s) {
     for (j = 0; j < len; j++) s[j] = toupper(s[j]);
 }
 
+int sdsisdigit(sds s) {
+    int len, j;
+
+    len = sdslen(s);
+    if (len == 0) return 0;
+    for (j = 0; j < len; j++) {
+        if (isdigit(s[j]) == 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 int sdscmp(sds s1, sds s2) {
     size_t l1, l2, minlen;
     int cmp;

--- a/src/sds.h
+++ b/src/sds.h
@@ -65,6 +65,7 @@ sds sdscatprintf(sds s, const char *fmt, ...);
 sds sdstrim(sds s, const char *cset);
 sds sdsrange(sds s, int start, int end);
 void sdsupdatelen(sds s);
+int sdsisdigit(sds s);
 int sdscmp(sds s1, sds s2);
 sds *sdssplitlen(char *s, int len, char *sep, int seplen, int *count);
 void sdsfreesplitres(sds *tokens, int count);

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -59,6 +59,58 @@ start_server {
         assert_encoding hashtable myset
     }
 
+    test {MSADD, SISMEMBER, SMEMBERS basics - regular sets} {
+        create_set myset {foo}
+        create_set anotherset {bar}
+        assert_encoding hashtable myset
+        assert_equal 1 [r msadd 2 1 anotherset myset bar]
+        assert_equal 0 [r msadd 2 1 anotherset myset bar]
+        assert_equal 0 [r msadd 1 1 myset bar]
+        assert_equal 1 [r msadd 1 2 anotherset bar baz]
+        assert_equal 2 [r scard myset]
+        assert_equal 1 [r sismember myset foo]
+        assert_equal 1 [r sismember myset bar]
+        assert_equal 0 [r sismember myset baz]
+        assert_equal 0 [r sismember myset bla]
+        assert_equal 0 [r sismember anotherset foo]
+        assert_equal 1 [r sismember anotherset bar]
+        assert_equal 1 [r sismember anotherset baz]
+        assert_equal 0 [r sismember anotherset bla]
+        assert_equal {bar foo} [lsort [r smembers myset]]
+    }
+
+    test {MSADD against non set} {
+        r lpush mylist foo
+        create_set myset {foo}
+        assert_error ERR*kind* {r msadd 1 1 mylist bar}
+        assert_error ERR*kind* {r msadd 2 1 mylist myset bar}
+    }
+
+    test "MSADD a non-integer against an intset" {
+        create_set myset {1 2 3}
+        create_set anotherset {foo}
+        assert_encoding intset myset
+        assert_equal 1 [r msadd 1 1 myset a]
+        assert_equal 2 [r msadd 2 1 myset anotherset b]
+        assert_encoding hashtable myset
+    }
+
+    test "MSADD overflows the maximum allowed integers in an intset" {
+        r del myset
+        for {set i 0} {$i < 512} {incr i} { r sadd myset $i }
+        assert_encoding intset myset
+        assert_equal 1 [r msadd 1 1 myset 512]
+        assert_encoding hashtable myset
+    }
+
+#    test "MSADD creates an intset with more than the maximum allowed" {
+#        r del myset
+#        set var ""
+#        for {set i 0} {$i < 513} {incr i} { append var " " $i }
+#        assert_equal 513 [r msadd 1 513 myset $var]
+#        assert_encoding hashtable myset
+#    }
+
     test "Set encoding after DEBUG RELOAD" {
         r del myintset myhashset mylargeintset
         for {set i 0} {$i <  100} {incr i} { r sadd myintset $i }


### PR DESCRIPTION
Sample input/output

<pre>
redis> set a
(error) ERR wrong number of arguments for 'set' command
redis> set a b
OK
redis> set b c 
OK
redis> get a
"b"
$0 = 'b'
redis> get $0
"c"
$1 = 'c'
redis> get $1
(nil)

redis> sadd set:a 1
(integer) 1
$2 = '1'
redis> sadd set:a 2
(integer) 1
$3 = '1'
redis> sadd set:a 3
(integer) 1
$4 = '1'
redis> sadd set:b 2
(integer) 1
$5 = '1'
redis> sadd set:b 3
(integer) 1
$6 = '1'
redis> sadd set:b 4
(integer) 1
$7 = '1'
redis> sadd set set:a
(integer) 1
$8 = '1'
redis> sadd set set:b
(integer) 1
$9 = '1'
redis> smembers set
1. "set:a"
2. "set:b"
$10 = 'set:a set:b'
redis> sinter $10
1. "2"
2. "3"
$11 = '2 3'
redis> sunion $10
1. "1"
2. "2"
3. "3"
4. "4"
$12 = '1 2 3 4'
redis> 
</pre>
