### PR TITLE
expose shared integers

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -340,6 +340,14 @@ hash-max-zipmap-value 512
 # want to free memory asap when possible.
 activerehashing yes
 
+# http://www.pauladamsmith.com/articles/redis_under_the_hood.html
+# "... give users the opportunity, based on knowledge of their applications and 
+# needs, to increase the number of shared integers for greater memory savings.
+# The tradeoff is that Redis statically allocates slightly more memory at 
+# startup time, but this would likely be a small amount compared to the 
+# overall typical database sizes and potential savings."
+shared-integers 10000
+
 ################################## INCLUDES ###################################
 
 # Include one or more other config files here.  This is useful if you

--- a/src/config.c
+++ b/src/config.c
@@ -222,6 +222,8 @@ void loadServerConfig(char *filename) {
             server.list_max_ziplist_value = memtoll(argv[1], NULL);
         } else if (!strcasecmp(argv[0],"set-max-intset-entries") && argc == 2){
             server.set_max_intset_entries = memtoll(argv[1], NULL);
+        } else if (!strcasecmp(argv[0],"shared-integers") && argc == 2){
+            server.shared_integers = memtoll(argv[1], NULL);
         } else {
             err = "Bad directive or wrong number of arguments"; goto loaderr;
         }

--- a/src/redis.c
+++ b/src/redis.c
@@ -707,7 +707,7 @@ void createSharedObjects(void) {
     shared.punsubscribebulk = createStringObject("$12\r\npunsubscribe\r\n",19);
     shared.mbulk3 = createStringObject("*3\r\n",4);
     shared.mbulk4 = createStringObject("*4\r\n",4);
-    for (j = 0; j < REDIS_SHARED_INTEGERS; j++) {
+    for (j = 0; j < server.shared_integers; j++) {
         shared.integers[j] = createObject(REDIS_STRING,(void*)(long)j);
         shared.integers[j]->encoding = REDIS_ENCODING_INT;
     }
@@ -752,6 +752,7 @@ void initServerConfig() {
     server.list_max_ziplist_entries = REDIS_LIST_MAX_ZIPLIST_ENTRIES;
     server.list_max_ziplist_value = REDIS_LIST_MAX_ZIPLIST_VALUE;
     server.set_max_intset_entries = REDIS_SET_MAX_INTSET_ENTRIES;
+    server.shared_integers = REDIS_SHARED_INTEGERS;
     server.shutdown_asap = 0;
 
     updateLRUClock();

--- a/src/redis.h
+++ b/src/redis.h
@@ -466,6 +466,7 @@ struct redisServer {
     FILE *devnull;
     unsigned lruclock:22;        /* clock incrementing every minute, for LRU */
     unsigned lruclock_padding:10;
+    int shared_integers;
 };
 
 typedef struct pubsubPattern {


### PR DESCRIPTION
maybe this is a bad idea, but i was reading [this article](http://www.pauladamsmith.com/articles/redis_under_the_hood.html), and he suggests,

> ... give users the opportunity, based on knowledge of their applications and needs, to increase the number of shared integers for greater memory savings.

also, i noticed in your [redis weekly update no. 4](http://antirez.com/m/p.php?i=209) concerning shared integers, that you mention,

> If you have many small counters, or in general many numbers in this range, this will be a huge win memory-wise. To enlarge the rage there is just to change a define.

so, for fun and experience, i thought i'd add this in. the following commit seems to do it. decreasing the number seems to free up memory. however, if i increase it to more that 10850, i get a signal 10 bus error. i'm not sure why that is. any idea? i don't know much about c programming.

thanks
