### PR TITLE
New command listcommands

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -96,7 +96,7 @@ struct redisCommand readonlyCommandTable[] = {
     {"lrange",lrangeCommand,4,0,NULL,1,1,1},
     {"ltrim",ltrimCommand,4,0,NULL,1,1,1},
     {"lrem",lremCommand,4,0,NULL,1,1,1},
-    {"rpoplpush",rpoplpushcommand,3,REDIS_CMD_DENYOOM,NULL,1,2,1},
+    {"rpoplpush",rpoplpushcommand,-3,REDIS_CMD_DENYOOM,NULL,1,2,1},
     {"sadd",saddCommand,3,REDIS_CMD_DENYOOM,NULL,1,1,1},
     {"srem",sremCommand,3,0,NULL,1,1,1},
     {"smove",smoveCommand,4,0,NULL,1,2,1},

--- a/src/redis.c
+++ b/src/redis.c
@@ -1264,7 +1264,7 @@ sds genRedisInfoString(void) {
 
 
 void infoCommand(redisClient *c) {
-  sds info = NULL ; /*genRedisInfoString();*/
+  sds info = genRedisInfoString();
     addReplySds(c,sdscatprintf(sdsempty(),"$%lu\r\n",
         (unsigned long)sdslen(info)));
     addReplySds(c,info);

--- a/src/redis.c
+++ b/src/redis.c
@@ -1287,7 +1287,7 @@ sds gentRedisListCommandsString(void){
 			      "flags:%d\r\n"
 			      "vm_firstkey:%d\r\n"
 			      "vm_lastkey:%d\r\n"
-			      "keystep:%d\r\n",
+			      "vm_keystep:%d\r\n",
 			      c->name,
 			      c->arity,
 			      c->flags,

--- a/src/redis.h
+++ b/src/redis.h
@@ -923,6 +923,7 @@ void flushallCommand(redisClient *c);
 void sortCommand(redisClient *c);
 void lremCommand(redisClient *c);
 void rpoplpushcommand(redisClient *c);
+void listCommands(redisClient *c);
 void infoCommand(redisClient *c);
 void mgetCommand(redisClient *c);
 void monitorCommand(redisClient *c);


### PR DESCRIPTION
Hello Antirez,

I have added the listcommands command which provides a list of the available commands plus some parameters (arity, flags, firstkey,lastkey,keystep).

This command would help me for the new redis python client i am currently writing ( https://github.com/aallamaa/desir ) in order to avoid copy/pasting readonlyCommandTable inside my python code to get the list of available commands.

Thanks in advance,
Kader
