### PR TITLE
added computer parsable output to redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -159,7 +159,7 @@ static sds cliFormatReply(redisReply *r, char *prefix) {
     sds out = sdsempty();
     switch (r->type) {
     case REDIS_REPLY_ERROR:
-        if (config.tty && !config.bare_output ) out = sdscat(out,"(error) ");
+        if (config.tty && !config.bare_output) out = sdscat(out,"(error) ");
         out = sdscatprintf(out,"%s\n", r->str);
     break;
     case REDIS_REPLY_STATUS:
@@ -173,6 +173,7 @@ static sds cliFormatReply(redisReply *r, char *prefix) {
     case REDIS_REPLY_STRING:
         if (config.raw_output || !config.tty || config.bare_output) {
             out = sdscatlen(out,r->str,r->len);
+			out = sdscat(out, "\n");
         } else {
             /* If you are producing output for the standard output we want
              * a more interesting output with quoted characters and so forth */
@@ -224,9 +225,8 @@ static sds cliFormatReply(redisReply *r, char *prefix) {
     	} else {
 			sds tmp;
     		for (unsigned int i = 0; i < r->elements; i++) {
-				tmp = cliFormatReply(r->element[i],'A');
+				tmp = cliFormatReply(r->element[i],NULL);
 				out = sdscatlen(out,tmp,sdslen(tmp));
-				out = sdscat(out, "\n");
 				sdsfree(tmp);
     		}
     	}


### PR DESCRIPTION
Hello,

I have added new cmdline switch -b (bare format) to the redis-cli. It then prints out results in "bare format", which is almost raw, except there are newlines after each reply/set/list entry etc. This format is easily parsable by e.g. shell scripts, where you can read things line by line. 

I have also changed help printout: now it prints help also on help command (& doesn't try to connect to redis first) and I have also replaced -iv with -vb in the usage(), so that it doesn't list deprecated switch anymore, but the new one instead.

See the changes yourself. I hope redis-cli will finally have parsable output...

BTW., there's maybe a bug in the new redis-cli implementation (that of 2.0.4 works fine) - when I have multi line string and retrieve it via get, it doesn't print \n instead of newlines, but only \ (maybe this is intention)

Best regards,

m. tekel
