### PR TITLE
Support for multiple log destinations and syslog

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -55,7 +55,6 @@ loglevel verbose
 #       daemonize, logs will be sent to /dev/null
 #
 # logdest stdout
-logdest stderr syslog
 
 # Specify the syslog identity.
 # logident redis

--- a/redis.conf
+++ b/redis.conf
@@ -45,10 +45,26 @@ timeout 300
 # warning (only very important / critical messages are logged)
 loglevel verbose
 
-# Specify the log file name. Also 'stdout' can be used to force
-# Redis to log on the standard output. Note that if you use standard
-# output for logging but daemonize, logs will be sent to /dev/null
-logfile stdout
+# Specify the log destinations. Must be one or more of the following:
+# stdout - standard output
+# stderr - standard error
+# file - a custom log file (must also be set by logfile)
+# syslog - the system logger
+#
+# NOTE: If you use standard output or standard error for logging but
+#       daemonize, logs will be sent to /dev/null
+#
+# logdest stdout
+logdest stderr syslog
+
+# Specify the syslog identity.
+# logident redis
+
+# Specify the syslog facility.  Must be between LOCAL0-LOCAL7.
+# logfacility LOCAL0
+
+# Specify the log file name.
+# logfile /var/log/redis.log
 
 # Set the number of databases. The default database is DB 0, you can select
 # a different one on a per-connection basis using SELECT <dbid> where

--- a/src/redis.h
+++ b/src/redis.h
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <pthread.h>
+#include <syslog.h>
 
 #include "ae.h"     /* Event driven programming library */
 #include "sds.h"    /* Dynamic safe strings */
@@ -173,6 +174,12 @@
 #define REDIS_SORT_ASC 1
 #define REDIS_SORT_DESC 2
 #define REDIS_SORTKEY_MAX 1024
+
+/* Log flags */
+#define REDIS_LOG_STDOUT    0x01
+#define REDIS_LOG_STDERR    0x02
+#define REDIS_LOG_FILE      0x04
+#define REDIS_LOG_SYSLOG    0x08
 
 /* Log levels */
 #define REDIS_DEBUG 0
@@ -402,6 +409,9 @@ struct redisServer {
     struct saveparam *saveparams;
     int saveparamslen;
     char *logfile;
+    int logdest;
+    char *logident;
+    int logfacility;
     char *dbfilename;
     char *appendfilename;
     char *requirepass;


### PR DESCRIPTION
This branch contains support for multiple simultaneous log destinations (file, file+stdout, stdout+syslog) and additionally includes added support for logging to stderr and syslog.

While the configuration values have changed, the default behavior (logging to stdout) has been maintained.
