### PR TITLE
Zsl random level

### DIFF
--- a/src/redis.h
+++ b/src/redis.h
@@ -178,7 +178,7 @@
 #define REDIS_NOTUSED(V) ((void) V)
 
 #define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^32 elements */
-#define ZSKIPLIST_P 0.25      /* Skiplist P = 1/4 */
+#define ZSKIPLIST_F 2      /* Skiplist P = 1/2^F */
 
 /* Append only defines */
 #define APPENDFSYNC_NO 0

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -66,9 +66,15 @@ void zslFree(zskiplist *zsl) {
 
 int zslRandomLevel(void) {
     int level = 1;
-    while ((random()&0xFFFF) < (ZSKIPLIST_P * 0xFFFF))
-        level += 1;
-    return (level<ZSKIPLIST_MAXLEVEL) ? level : ZSKIPLIST_MAXLEVEL;
+    unsigned long b = 0xFFFF;
+
+    for(int i = 0; i < ZSKIPLIST_F; ++i){
+        b &= random();
+    }
+
+    b = ((b + 1) ^ b) - 1;
+    level += __builtin_popcount(b);
+    return level;
 }
 
 zskiplistNode *zslInsert(zskiplist *zsl, double score, robj *obj) {


### PR DESCRIPTION
I've rewritten zslRandomLevel to use two calls (for p=0.25) to random() regardless of the resulting node level.
