### PR TITLE
Generic locking mechanism.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ PREFIX= /usr/local
 INSTALL_BIN= $(PREFIX)/bin
 INSTALL= cp -p
 
-OBJ = adlist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o vm.o pubsub.o multi.o debug.o sort.o intset.o syncio.o
+OBJ = adlist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o vm.o pubsub.o multi.o debug.o sort.o intset.o syncio.o locking.o
 BENCHOBJ = ae.o anet.o redis-benchmark.o sds.o adlist.o zmalloc.o
 CLIOBJ = anet.o sds.o adlist.o redis-cli.o zmalloc.o release.o
 CHECKDUMPOBJ = redis-check-dump.o lzf_c.o lzf_d.o
@@ -54,6 +54,7 @@ aof.o: aof.c redis.h fmacros.h config.h ae.h sds.h dict.h adlist.h \
 chprgname.o: chprgname.c
 config.o: config.c redis.h fmacros.h config.h ae.h sds.h dict.h adlist.h \
   zmalloc.h anet.h zipmap.h ziplist.h intset.h version.h
+locking.o: locking.c redis.h
 db.o: db.c redis.h fmacros.h config.h ae.h sds.h dict.h adlist.h \
   zmalloc.h anet.h zipmap.h ziplist.h intset.h version.h
 debug.o: debug.c redis.h fmacros.h config.h ae.h sds.h dict.h adlist.h \

--- a/src/dict.h
+++ b/src/dict.h
@@ -144,6 +144,9 @@ void dictDisableResize(void);
 int dictRehash(dict *d, int n);
 int dictRehashMilliseconds(dict *d, int ms);
 
+/* Hash Functions */
+unsigned int dictIdentityHashFunction(unsigned int key);
+
 /* Hash table types */
 extern dictType dictTypeHeapStringCopyKey;
 extern dictType dictTypeHeapStrings;

--- a/src/help.h
+++ b/src/help.h
@@ -13,7 +13,8 @@ static char *commandGroups[] = {
     "pubsub",
     "transactions",
     "connection",
-    "server"
+    "server",
+    "lock"
 };
 
 struct commandHelp {
@@ -632,7 +633,17 @@ struct commandHelp {
     "destination numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX]",
     "Add multiple sorted sets and store the resulting sorted set in a new key",
     4,
-    "1.3.10" }
+    "1.3.10" },
+    { "GRAB",
+    "key timeout",
+    "Grabs a lock on key and blocks until all other clients have released the lock or disconnected.",
+    10,
+    "2.2.X" },
+    { "RELEASE",
+    "key",
+    "Releases a lock on key allowing other clients to continue",
+    10,
+    "2.2.X" },
 };
 
 #endif

--- a/src/locking.c
+++ b/src/locking.c
@@ -1,0 +1,148 @@
+#include "redis.h"
+
+/*-----------------------------------------------------------------------------
+ * Generic locking (grab and release) commands
+ *----------------------------------------------------------------------------*/
+
+int grabLockForKey(redisClient *c, robj *key)
+{
+	dictEntry *de;
+
+    de = dictFind(c->db->locked_keys,key);
+	if (de == NULL) {
+		int retval;
+		robj *kt;
+
+		kt = dupStringObject(key);
+		/* Add the client structure to the locked_keys dict */
+		retval = dictAdd(c->db->locked_keys,key,c);
+		incrRefCount(key);
+		redisAssert(retval == DICT_OK);
+
+		if (c->lock.keys == NULL) {
+			c->lock.keys = listCreate();
+			listSetMatchMethod(c->lock.keys,listMatchObjects);
+		}
+		listAddNodeTail(c->lock.keys, kt);
+		return 1;
+	} else {
+		redisClient *locker = dictGetEntryVal(de);
+		if (c == locker) {
+			/* Silently allow locking an already locked key */
+			return 1;
+		}
+		return 0;
+	}
+}
+
+int releaseLockForKey(redisClient* c, robj* key) {
+	dictEntry *de;
+	listNode *ln;
+
+	if (c->lock.keys == NULL) {
+		/* If no keys are locked, return */
+		return 0;
+	} else {
+		de = dictFind(c->db->locked_keys,key);
+		redisAssert(de != NULL);
+		redisClient *locker = dictGetEntryVal(de);
+		if (locker == c) {
+			/* We are the locker, so release the lock */
+			dictDelete(c->db->locked_keys,key);
+			ln = listSearchKey(c->lock.keys,key);
+			redisAssert(ln != NULL);
+			decrRefCount(listNodeValue(ln));
+			listDelNode(c->lock.keys,ln);
+			return 1;
+		} else {
+			/* This is not our lock */
+			return 0;
+		}
+	}
+}
+
+void handOffLock(redisClient *c, robj *key) {
+	struct dictEntry *de;
+	int retval;
+    redisClient *receiver;
+    list *clients;
+	listIter *iter;
+    listNode *ln;
+
+	de = dictFind(c->db->blocking_keys,key);
+	if (de != NULL) {
+
+		clients = dictGetEntryVal(de);
+
+		iter = listGetIterator(clients, AL_START_HEAD);
+        while ((ln = listNext(iter)) != NULL) {
+			receiver = listNodeValue(ln);
+			if (receiver->block.type != REDIS_BLOCK_LOCK)
+				continue;
+
+			/* Hand off the lock to the next client */
+			retval = grabLockForKey(receiver,key);
+			redisAssert(retval == 1);
+
+			unblockClientWaitingData(receiver, ln);
+
+			/* Tell the waiting client it is unblocked */
+			addReply(receiver, shared.ok);
+			break;
+		}
+		listReleaseIterator(iter);
+	}
+}
+void releaseClientLocks(redisClient *c) {
+	if (c->lock.keys) {
+		listNode *ln;
+		listIter *iter = listGetIterator(c->lock.keys, AL_START_HEAD);
+		while ((ln = listNext(iter)) != NULL) {
+			robj *key = dupStringObject(listNodeValue(ln));
+			releaseLockForKey(c, key);
+			handOffLock(c, key);
+			decrRefCount(key);
+		}
+		listReleaseIterator(iter);
+		listRelease(c->lock.keys);
+	}
+}
+
+void grabCommand(redisClient *c) {
+	time_t timeout;
+	robj *key;
+
+	if (c->flags & REDIS_MULTI) {
+		addReplyError(c,"GRAB inside MULTI is not allowed");
+		return;
+	}
+
+	if (getTimeoutFromObjectOrReply(c, c->argv[2],&timeout) != REDIS_OK)
+		return;
+
+	key = c->argv[1];
+
+	if (grabLockForKey(c, key)==1) {
+		addReply(c,shared.ok);
+	} else {
+		blockForKeys(c, c->argv + 1, 1, timeout, NULL, REDIS_BLOCK_LOCK);
+	}
+}
+
+void releaseCommand(redisClient* c) {
+	robj *key;
+
+	if (c->flags & REDIS_MULTI) {
+		addReplyError(c,"RELEASE inside MULTI is not allowed");
+		return;
+	}
+
+	key = c->argv[1];
+
+	if (releaseLockForKey(c,key)==1) {
+		handOffLock(c, key);
+		addReply(c,shared.ok);
+	} else {
+		addReplyError(c,"RELEASE failed! Key not Locked by us");
+	}
+}

--- a/src/networking.c
+++ b/src/networking.c
@@ -41,10 +41,10 @@ redisClient *createClient(int fd) {
     c->reply = listCreate();
     listSetFreeMethod(c->reply,decrRefCount);
     listSetDupMethod(c->reply,dupClientReplyValue);
-    c->bpop.keys = NULL;
-    c->bpop.count = 0;
-    c->bpop.timeout = 0;
-    c->bpop.target = NULL;
+    c->block.keys = NULL;
+    c->block.count = 0;
+    c->block.timeout = 0;
+    c->block.target = NULL;
     c->io_keys = listCreate();
     c->watched_keys = listCreate();
     listSetFreeMethod(c->io_keys,decrRefCount);
@@ -620,7 +620,7 @@ void closeTimedoutClients(void) {
             redisLog(REDIS_VERBOSE,"Closing idle client");
             freeClient(c);
         } else if (c->flags & REDIS_BLOCKED) {
-            if (c->bpop.timeout != 0 && c->bpop.timeout < now) {
+            if (c->block.timeout != 0 && c->block.timeout < now) {
                 addReply(c,shared.nullmultibulk);
                 unblockClientWaitingData(c);
             }

--- a/src/networking.c
+++ b/src/networking.c
@@ -439,6 +439,8 @@ void freeClient(redisClient *c) {
     if (c->flags & REDIS_BLOCKED)
         unblockClientWaitingData(c, NULL);
 
+	/* Release Client Locks */
+	releaseClientLocks(c);
     /* UNWATCH all the keys */
     unwatchAllKeys(c);
     listRelease(c->watched_keys);

--- a/src/networking.c
+++ b/src/networking.c
@@ -437,7 +437,7 @@ void freeClient(redisClient *c) {
     sdsfree(c->querybuf);
     c->querybuf = NULL;
     if (c->flags & REDIS_BLOCKED)
-        unblockClientWaitingData(c);
+        unblockClientWaitingData(c, NULL);
 
     /* UNWATCH all the keys */
     unwatchAllKeys(c);
@@ -622,7 +622,7 @@ void closeTimedoutClients(void) {
         } else if (c->flags & REDIS_BLOCKED) {
             if (c->block.timeout != 0 && c->block.timeout < now) {
                 addReply(c,shared.nullmultibulk);
-                unblockClientWaitingData(c);
+                unblockClientWaitingData(c, NULL);
             }
         }
     }

--- a/src/redis.c
+++ b/src/redis.c
@@ -580,7 +580,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     }
 
     /* Close connections of timedout clients */
-    if ((server.maxidletime && !(loops % 100)) || server.bpop_blocked_clients)
+    if ((server.maxidletime && !(loops % 100)) || server.blocked_clients)
         closeTimedoutClients();
 
     /* Check if a background saving or AOF rewrite in progress terminated */
@@ -784,7 +784,7 @@ void initServerConfig() {
     server.rdbcompression = 1;
     server.activerehashing = 1;
     server.maxclients = 0;
-    server.bpop_blocked_clients = 0;
+    server.blocked_clients = 0;
     server.maxmemory = 0;
     server.maxmemory_policy = REDIS_MAXMEMORY_VOLATILE_LRU;
     server.maxmemory_samples = 3;
@@ -1208,7 +1208,7 @@ sds genRedisInfoString(void) {
         listLength(server.clients)-listLength(server.slaves),
         listLength(server.slaves),
         lol, bib,
-        server.bpop_blocked_clients,
+        server.blocked_clients,
         zmalloc_used_memory(),
         hmem,
         zmalloc_get_rss(),

--- a/src/redis.h
+++ b/src/redis.h
@@ -144,6 +144,10 @@
 #define REDIS_UNBLOCKED 256 /* This client was unblocked and is stored in
                                server.unblocked_clients */
 
+/* Client Blocking state type */
+#define REDIS_BLOCK_BPOP 0  /* a BPOP Block */
+#define REDIS_BLOCK_LOCK 1  /* a LOCK Block */
+
 /* Client request types */
 #define REDIS_REQ_INLINE 1
 #define REDIS_REQ_MULTIBULK 2
@@ -296,6 +300,7 @@ typedef struct blockingState {
     robj **keys;            /* The key we are waiting to terminate a blocking
                              * operation such as BLPOP. Otherwise NULL. */
     int count;              /* Number of blocking keys */
+    int type;               /* Type of block */
     time_t timeout;         /* Blocking operation timeout. If UNIX current time
                              * is >= timeout then the operation timed out. */
     robj *target;           /* The key that should receive the element,
@@ -684,7 +689,7 @@ void listTypeInsert(listTypeEntry *entry, robj *value, int where);
 int listTypeEqual(listTypeEntry *entry, robj *o);
 void listTypeDelete(listTypeEntry *entry);
 void listTypeConvert(robj *subject, int enc);
-void unblockClientWaitingData(redisClient *c);
+void unblockClientWaitingData(redisClient *c, listNode *ln);
 int handleClientsWaitingListPush(redisClient *c, robj *key, robj *ele);
 void popGenericCommand(redisClient *c, int where);
 

--- a/src/redis.h
+++ b/src/redis.h
@@ -309,7 +309,7 @@ typedef struct blockingState {
 } blockingState;
 
 typedef struct lockState {
-    list *keys;             /* The list of keys we have locked. Otherwise NULL*/
+    dict *keys;             /* The list of keys we have locked for each DB. Otherwise NULL*/
 } lockState;
 
 /* With multiplexing we need to take per-clinet state.
@@ -706,6 +706,7 @@ int grabLockForKey(redisClient *c, robj *key);
 int releaseLockForKey(redisClient *c, robj *key);
 void releaseClientLocks(redisClient *c);
 int getTimeoutFromObjectOrReply(redisClient *c, robj *object, time_t *timeout);
+void dictListDestructor(void *privdata, void *val);
 
 /* MULTI/EXEC/WATCH... */
 void unwatchAllKeys(redisClient *c);

--- a/src/redis.h
+++ b/src/redis.h
@@ -325,7 +325,7 @@ typedef struct redisClient {
     long repldboff;         /* replication DB file offset */
     off_t repldbsize;       /* replication DB file size */
     multiState mstate;      /* MULTI/EXEC state */
-    blockingState bpop;   /* blocking state */
+    blockingState block;    /* blocking state */
     list *io_keys;          /* Keys this client is waiting to be loaded from the
                              * swap file in order to continue. */
     list *watched_keys;     /* Keys WATCHED for MULTI/EXEC CAS */
@@ -435,7 +435,7 @@ struct redisServer {
     int maxmemory_policy;
     int maxmemory_samples;
     /* Blocked clients */
-    unsigned int bpop_blocked_clients;
+    unsigned int blocked_clients;
     unsigned int vm_blocked_clients;
     list *unblocked_clients;
     /* Sort parameters - qsort_r() is only available under BSD so we

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -715,10 +715,10 @@ void blockForKeys(redisClient *c, robj **keys, int numkeys, time_t timeout, robj
     list *l;
     int j;
 
-    c->bpop.keys = zmalloc(sizeof(robj*)*numkeys);
-    c->bpop.count = numkeys;
-    c->bpop.timeout = timeout;
-    c->bpop.target = target;
+    c->block.keys = zmalloc(sizeof(robj*)*numkeys);
+    c->block.count = numkeys;
+    c->block.timeout = timeout;
+    c->block.target = target;
 
     if (target != NULL) {
         incrRefCount(target);
@@ -726,7 +726,7 @@ void blockForKeys(redisClient *c, robj **keys, int numkeys, time_t timeout, robj
 
     for (j = 0; j < numkeys; j++) {
         /* Add the key in the client structure, to map clients -> keys */
-        c->bpop.keys[j] = keys[j];
+        c->block.keys[j] = keys[j];
         incrRefCount(keys[j]);
 
         /* And in the other "side", to map keys -> clients */
@@ -746,7 +746,7 @@ void blockForKeys(redisClient *c, robj **keys, int numkeys, time_t timeout, robj
     }
     /* Mark the client as a blocked client */
     c->flags |= REDIS_BLOCKED;
-    server.bpop_blocked_clients++;
+    server.blocked_clients++;
 }
 
 /* Unblock a client that's waiting in a blocking operation such as BLPOP */
@@ -755,27 +755,27 @@ void unblockClientWaitingData(redisClient *c) {
     list *l;
     int j;
 
-    redisAssert(c->bpop.keys != NULL);
+    redisAssert(c->block.keys != NULL);
     /* The client may wait for multiple keys, so unblock it for every key. */
-    for (j = 0; j < c->bpop.count; j++) {
+    for (j = 0; j < c->block.count; j++) {
         /* Remove this client from the list of clients waiting for this key. */
-        de = dictFind(c->db->blocking_keys,c->bpop.keys[j]);
+        de = dictFind(c->db->blocking_keys,c->block.keys[j]);
         redisAssert(de != NULL);
         l = dictGetEntryVal(de);
         listDelNode(l,listSearchKey(l,c));
         /* If the list is empty we need to remove it to avoid wasting memory */
         if (listLength(l) == 0)
-            dictDelete(c->db->blocking_keys,c->bpop.keys[j]);
-        decrRefCount(c->bpop.keys[j]);
+            dictDelete(c->db->blocking_keys,c->block.keys[j]);
+        decrRefCount(c->block.keys[j]);
     }
 
     /* Cleanup the client structure */
-    zfree(c->bpop.keys);
-    c->bpop.keys = NULL;
-    c->bpop.target = NULL;
+    zfree(c->block.keys);
+    c->block.keys = NULL;
+    c->block.target = NULL;
     c->flags &= ~REDIS_BLOCKED;
     c->flags |= REDIS_UNBLOCKED;
-    server.bpop_blocked_clients--;
+    server.blocked_clients--;
     listAddNodeTail(server.unblocked_clients,c);
 }
 
@@ -813,7 +813,7 @@ int handleClientsWaitingListPush(redisClient *c, robj *key, robj *ele) {
         ln = listFirst(clients);
         redisAssert(ln != NULL);
         receiver = ln->value;
-        dstkey = receiver->bpop.target;
+        dstkey = receiver->block.target;
 
         /* This should remove the first element of the "clients" list. */
         unblockClientWaitingData(receiver);


### PR DESCRIPTION
Based on the "BPOP" commands this adds a generic locking command (similar to advisory locks in mysql).

Basic usage is

> C1: GRAB sesskey.AE123 0
> 
> C1: OK
> 
> C2: GRAB sesskey.AE123 0
> 
> C1: RELEASE sesskey.AE123
> 
> C1: OK
> 
> C2: OK

Also if a client disconnects all of it's locks are released.

A client MAY lock multiple keys.

Some things I don't like about how it's implemented right now.
I've kludged in some "reserving" of the Key in (doing a dbAdd of a 0 value) and checking to make sure it's a REDIS_STRING (so as to not conflict with BPOP). However this has a few issues.

the lock does nothing to prevent working with the actual key (and really shouldn't). So another client can delete and readd the key as a REDIS_LIST and screw things up.

Ideally I need to create a separate blocking system from the BPOP blocks, or adjust how they are stored so that BPOP will ignore GRAB blocks and GRAB will ignore BPOP locks.

Any thoughts on this are very welcome.
