### PR TITLE
"port 0" should be accepted in configuration

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -66,7 +66,7 @@ void loadServerConfig(char *filename) {
             }
         } else if (!strcasecmp(argv[0],"port") && argc == 2) {
             server.port = atoi(argv[1]);
-            if (server.port < 1 || server.port > 65535) {
+            if (server.port < 0 || server.port > 65535) {
                 err = "Invalid port"; goto loaderr;
             }
         } else if (!strcasecmp(argv[0],"bind") && argc == 2) {


### PR DESCRIPTION
Thanks for adding in support for disabling TCP; that's a feature I really wanted.  It looks like you forgot to tweak the configuration parser, though, so actually specifying a port of 0 was rejected with "Invalid port".  This commit fixes it, so that port=0 is considered valid, as expected.
