### PR TITLE
Tcmalloc flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -121,7 +121,7 @@ redis-benchmark: dependencies $(BENCHOBJ)
 	$(CC) -o $(BENCHPRGNAME) $(CCOPT) $(DEBUG) $(BENCHOBJ) ../deps/hiredis/libhiredis.a
 
 redis-benchmark.o:
-	$(CC) -c $(CFLAGS) -I../deps/hiredis $(DEBUG) $(COMPILE_TIME) $<
+	$(CC) -c $(CFLAGS) $(CCLINK) -I../deps/hiredis $(DEBUG) $(COMPILE_TIME) $<
 
 redis-cli: dependencies $(CLIOBJ)
 	$(CC) -o $(CLIPRGNAME) $(CCOPT) $(DEBUG) $(CLIOBJ) ../deps/hiredis/libhiredis.a ../deps/linenoise/linenoise.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,6 +18,9 @@ endif
 ifeq ($(USE_TCMALLOC),yes)
   CCLINK+= -ltcmalloc
   CFLAGS+= -DUSE_TCMALLOC
+else ifeq ($(USE_TCMALLOC_MINIMAL),yes)
+  CCLINK+= -ltcmalloc_minimal
+  CFLAGS+= -DUSE_TCMALLOC
 endif
 CCOPT= $(CFLAGS) $(CCLINK) $(ARCH) $(PROF)
 


### PR DESCRIPTION
I had to change the redis-benchmark target slightly to successfully build against tcmalloc. I don't actually use redis-benchmark, but perhaps this is a problem for others attempting to use redis-server with tcmalloc.
