### PR TITLE
Makefile fix for Mac Os X

### DIFF
--- a/deps/hiredis/Makefile
+++ b/deps/hiredis/Makefile
@@ -21,9 +21,9 @@ else ifeq ($(uname_S),Darwin)
   LDFLAGS?=-L. -Wl,-rpath,.
   OBJARCH?=-arch i386 -arch x86_64
   DYLIBNAME?=libhiredis.dylib
-  DYLIB_MAKE_CMD?=libtool -dynamic -o ${DYLIBNAME} -lm ${DEBUG} - ${OBJ}
+  DYLIB_MAKE_CMD?=/usr/bin/libtool -dynamic -o ${DYLIBNAME} -lm ${DEBUG} - ${OBJ}
   STLIBNAME?=libhiredis.a
-  STLIB_MAKE_CMD?=libtool -static -o ${STLIBNAME} - ${OBJ}
+  STLIB_MAKE_CMD?=/usr/bin/libtool -static -o ${STLIBNAME} - ${OBJ}
 else
   CFLAGS?=-std=c99 -pedantic $(OPTIMIZATION) -fPIC -Wall -W -Wwrite-strings $(ARCH) $(PROF)
   CCLINK?=-lm -pthread


### PR DESCRIPTION
Hi,

I've just tried to execute make and had an error about libtool on my MacBook Pro (10.7.0).

Fixed the libtool error for Mac Os X by updating the Makefile of hiredis.
Src: http://code.google.com/p/redis/issues/detail?id=443

Thank you for Redis!

Best regards,
Pierre Urban
