### PR TITLE
Fixed init script stop function

### DIFF
--- a/utils/redis_init_script
+++ b/utils/redis_init_script
@@ -24,7 +24,7 @@ case "$1" in
 		PID=$(cat $PIDFILE)
                 echo -n "Stopping ...\n"
                 echo -n "SHUTDOWN\r\n" | nc localhost $REDISPORT &
-                while [ -x /proc/${PIDFILE} ]
+                while [ -x /proc/${PID} ]
                 do
                     echo "Waiting for Redis to shutdown ..."
                     sleep 1


### PR DESCRIPTION
Wrong variable was being used for the stop function in the init script. Should be /proc/{PID} where PID is the actual PID inside the .pid file.
