### PR TITLE
Fix automatic rewrite starting too early

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -699,7 +699,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
          {
             int base = server.auto_aofrewrite_base_size ?
                             server.auto_aofrewrite_base_size : 1;
-            long long growth = (server.appendonly_current_size*100/base);
+            long long growth = (server.appendonly_current_size*100/base) - 100;
             if (growth >= server.auto_aofrewrite_perc) {
                 redisLog(REDIS_NOTICE,"Starting automatic rewriting of AOF on %lld%% growth",growth);
                 rewriteAppendOnlyFileBackground();


### PR DESCRIPTION
I think this was how it was intended. Just a small typo in the growth calculation. Ignore if intended or already fixed.
