### PR TITLE
Use getaddrinfo(3) and inet_ntop/inet_pton

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -301,23 +301,37 @@ static int anetListen(char *err, int s, struct sockaddr *sa, socklen_t len) {
 
 int anetTcpServer(char *err, int port, char *bindaddr)
 {
-    int s;
-    struct sockaddr_in sa;
+    int s, rv;
+    char _port[6];  /* strlen("65535") */
+    struct addrinfo hints, *servinfo, *p;
 
-    if ((s = anetCreateSocket(err,AF_INET)) == ANET_ERR)
-        return ANET_ERR;
+    snprintf(_port,6,"%d",port);
+    memset(&hints,0,sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;    /* No effect if bindaddr != NULL */
 
-    memset(&sa,0,sizeof(sa));
-    sa.sin_family = AF_INET;
-    sa.sin_port = htons(port);
-    sa.sin_addr.s_addr = htonl(INADDR_ANY);
-    if (bindaddr && inet_aton(bindaddr, &sa.sin_addr) == 0) {
-        anetSetError(err, "invalid bind address");
-        close(s);
+    if ((rv = getaddrinfo(bindaddr,_port,&hints,&servinfo)) != 0) {
+        anetSetError(err, "%s", gai_strerror(rv));
         return ANET_ERR;
     }
-    if (anetListen(err,s,(struct sockaddr*)&sa,sizeof(sa)) == ANET_ERR)
-        return ANET_ERR;
+    for (p = servinfo; p != NULL; p = p->ai_next) {
+        if ((s = socket(p->ai_family,p->ai_socktype,p->ai_protocol)) == -1)
+            continue;
+
+        if (anetListen(err,s,p->ai_addr,p->ai_addrlen) == ANET_ERR)
+            goto error;    /* could continue here? */
+        goto end;
+    }
+    if (p == NULL) {
+        anetSetError(err, "unable to bind socket");
+        goto error;
+    }
+
+error:
+    s = ANET_ERR;
+end:
+    freeaddrinfo(servinfo);
     return s;
 }
 

--- a/src/anet.c
+++ b/src/anet.c
@@ -106,22 +106,26 @@ int anetTcpKeepAlive(char *err, int fd)
     return ANET_OK;
 }
 
-int anetResolve(char *err, char *host, char *ipbuf)
+int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len)
 {
-    struct sockaddr_in sa;
+    struct addrinfo hints, *info;
+    void *addr;
+    int rv;
 
-    sa.sin_family = AF_INET;
-    if (inet_aton(host, &sa.sin_addr) == 0) {
-        struct hostent *he;
+    memset(&hints,0,sizeof(hints));
+    hints.ai_family = AF_INET;
 
-        he = gethostbyname(host);
-        if (he == NULL) {
-            anetSetError(err, "can't resolve: %s", host);
-            return ANET_ERR;
-        }
-        memcpy(&sa.sin_addr, he->h_addr, sizeof(struct in_addr));
+    if ((rv = getaddrinfo(host, NULL, &hints, &info)) != 0) {
+        anetSetError(err, "%s", gai_strerror(rv));
+        return ANET_ERR;
     }
-    strcpy(ipbuf,inet_ntoa(sa.sin_addr));
+    if (info->ai_family == AF_INET) {
+        struct sockaddr_in *sa = (struct sockaddr_in *)info->ai_addr;
+        addr = &(sa->sin_addr);
+    }
+
+    inet_ntop(info->ai_family, addr, ipbuf, ipbuf_len);
+    freeaddrinfo(info);
     return ANET_OK;
 }
 

--- a/src/anet.c
+++ b/src/anet.c
@@ -370,14 +370,14 @@ static int anetGenericAccept(char *err, int s, struct sockaddr *sa, socklen_t *l
     return fd;
 }
 
-int anetTcpAccept(char *err, int s, char *ip, int *port) {
+int anetTcpAccept(char *err, int s, char *ip, size_t ip_len, int *port) {
     int fd;
     struct sockaddr_in sa;
     socklen_t salen = sizeof(sa);
     if ((fd = anetGenericAccept(err,s,(struct sockaddr*)&sa,&salen)) == ANET_ERR)
         return ANET_ERR;
 
-    if (ip) strcpy(ip,inet_ntoa(sa.sin_addr));
+    if (ip) inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),ip,ip_len);
     if (port) *port = ntohs(sa.sin_port);
     return fd;
 }
@@ -392,7 +392,7 @@ int anetUnixAccept(char *err, int s) {
     return fd;
 }
 
-int anetPeerToString(int fd, char *ip, int *port) {
+int anetPeerToString(int fd, char *ip, size_t ip_len, int *port) {
     struct sockaddr_in sa;
     socklen_t salen = sizeof(sa);
 
@@ -402,12 +402,12 @@ int anetPeerToString(int fd, char *ip, int *port) {
         ip[1] = '\0';
         return -1;
     }
-    if (ip) strcpy(ip,inet_ntoa(sa.sin_addr));
+    if (ip) inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),ip,ip_len);
     if (port) *port = ntohs(sa.sin_port);
     return 0;
 }
 
-int anetSockName(int fd, char *ip, int *port) {
+int anetSockName(int fd, char *ip, size_t ip_len, int *port) {
     struct sockaddr_in sa;
     socklen_t salen = sizeof(sa);
 
@@ -417,7 +417,7 @@ int anetSockName(int fd, char *ip, int *port) {
         ip[1] = '\0';
         return -1;
     }
-    if (ip) strcpy(ip,inet_ntoa(sa.sin_addr));
+    if (ip) inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),ip,ip_len);
     if (port) *port = ntohs(sa.sin_port);
     return 0;
 }

--- a/src/anet.c
+++ b/src/anet.c
@@ -129,17 +129,24 @@ int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len)
     return ANET_OK;
 }
 
+static int anetSetReuseAddr(char *err, int fd) {
+    int yes = 1;
+    /* Make sure connection-intensive things like the redis benckmark
+     * will be able to close/open sockets a zillion of times */
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) == -1) {
+        anetSetError(err, "setsockopt SO_REUSEADDR: %s", strerror(errno));
+        return ANET_ERR;
+    }
+    return ANET_OK;
+}
+
 static int anetCreateSocket(char *err, int domain) {
-    int s, on = 1;
+    int s;
     if ((s = socket(domain, SOCK_STREAM, 0)) == -1) {
         anetSetError(err, "creating socket: %s", strerror(errno));
         return ANET_ERR;
     }
-
-    /* Make sure connection-intensive things like the redis benckmark
-     * will be able to close/open sockets a zillion of times */
-    if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == -1) {
-        anetSetError(err, "setsockopt SO_REUSEADDR: %s", strerror(errno));
+    if (anetSetReuseAddr(err,s) == ANET_ERR) {
         return ANET_ERR;
     }
     return s;

--- a/src/anet.h
+++ b/src/anet.h
@@ -47,12 +47,12 @@ int anetRead(int fd, char *buf, int count);
 int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len);
 int anetTcpServer(char *err, int port, char *bindaddr);
 int anetUnixServer(char *err, char *path, mode_t perm);
-int anetTcpAccept(char *err, int serversock, char *ip, int *port);
+int anetTcpAccept(char *err, int serversock, char *ip, size_t ip_len, int *port);
 int anetUnixAccept(char *err, int serversock);
 int anetWrite(int fd, char *buf, int count);
 int anetNonBlock(char *err, int fd);
 int anetTcpNoDelay(char *err, int fd);
 int anetTcpKeepAlive(char *err, int fd);
-int anetPeerToString(int fd, char *ip, int *port);
+int anetPeerToString(int fd, char *ip, size_t ip_len, int *port);
 
 #endif

--- a/src/anet.h
+++ b/src/anet.h
@@ -44,7 +44,7 @@ int anetTcpNonBlockConnect(char *err, char *addr, int port);
 int anetUnixConnect(char *err, char *path);
 int anetUnixNonBlockConnect(char *err, char *path);
 int anetRead(int fd, char *buf, int count);
-int anetResolve(char *err, char *host, char *ipbuf);
+int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len);
 int anetTcpServer(char *err, int port, char *bindaddr);
 int anetUnixServer(char *err, char *path, mode_t perm);
 int anetTcpAccept(char *err, int serversock, char *ip, int *port);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1,6 +1,8 @@
 #include "redis.h"
 #include "endianconv.h"
 
+#include <sys/types.h>
+#include <sys/socket.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -474,7 +474,7 @@ void nodeIp2String(char *buf, clusterLink *link) {
 
     if (getpeername(link->fd, (struct sockaddr*) &sa, &salen) == -1)
         redisPanic("getpeername() failed.");
-    strncpy(buf,inet_ntoa(sa.sin_addr),sizeof(link->node->ip));
+    inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),buf,sizeof(link->node->ip));
 }
 
 
@@ -1251,7 +1251,7 @@ void clusterCommand(redisClient *c) {
         /* Finally add the node to the cluster with a random name, this 
          * will get fixed in the first handshake (ping/pong). */
         n = createClusterNode(NULL,REDIS_NODE_HANDSHAKE|REDIS_NODE_MEET);
-        strncpy(n->ip,inet_ntoa(sa.sin_addr),sizeof(n->ip));
+        inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),n->ip,sizeof(n->ip));
         n->port = port;
         clusterAddNode(n);
         addReply(c,shared.ok);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -251,7 +251,7 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     REDIS_NOTUSED(mask);
     REDIS_NOTUSED(privdata);
 
-    cfd = anetTcpAccept(server.neterr, fd, cip, &cport);
+    cfd = anetTcpAccept(server.neterr, fd, cip, sizeof(cip), &cport);
     if (cfd == AE_ERR) {
         redisLog(REDIS_VERBOSE,"Accepting cluster node: %s", server.neterr);
         return;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -474,7 +474,7 @@ void nodeIp2String(char *buf, clusterLink *link) {
 
     if (getpeername(link->fd, (struct sockaddr*) &sa, &salen) == -1)
         redisPanic("getpeername() failed.");
-    inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),buf,sizeof(link->node->ip));
+    inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),buf,16);
 }
 
 
@@ -1251,7 +1251,7 @@ void clusterCommand(redisClient *c) {
         /* Finally add the node to the cluster with a random name, this 
          * will get fixed in the first handshake (ping/pong). */
         n = createClusterNode(NULL,REDIS_NODE_HANDSHAKE|REDIS_NODE_MEET);
-        inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),n->ip,sizeof(n->ip));
+        inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),n->ip,16);
         n->port = port;
         clusterAddNode(n);
         addReply(c,shared.ok);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1237,7 +1237,7 @@ void clusterCommand(redisClient *c) {
         long port;
 
         /* Perform sanity checks on IP/port */
-        if (inet_aton(c->argv[2]->ptr,&sa.sin_addr) == 0) {
+        if (inet_pton(AF_INET,c->argv[0]->ptr,&(sa.sin_addr)) == 0) {
             addReplyError(c,"Invalid IP address in MEET");
             return;
         }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -474,7 +474,7 @@ void nodeIp2String(char *buf, clusterLink *link) {
 
     if (getpeername(link->fd, (struct sockaddr*) &sa, &salen) == -1)
         redisPanic("getpeername() failed.");
-    inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),buf,16);
+    inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),buf,REDIS_CLUSTER_IPLEN);
 }
 
 
@@ -1251,7 +1251,7 @@ void clusterCommand(redisClient *c) {
         /* Finally add the node to the cluster with a random name, this 
          * will get fixed in the first handshake (ping/pong). */
         n = createClusterNode(NULL,REDIS_NODE_HANDSHAKE|REDIS_NODE_MEET);
-        inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),n->ip,16);
+        inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),n->ip,REDIS_CLUSTER_IPLEN);
         n->port = port;
         clusterAddNode(n);
         addReply(c,shared.ok);

--- a/src/networking.c
+++ b/src/networking.c
@@ -518,7 +518,7 @@ void acceptTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     REDIS_NOTUSED(mask);
     REDIS_NOTUSED(privdata);
 
-    cfd = anetTcpAccept(server.neterr, fd, cip, &cport);
+    cfd = anetTcpAccept(server.neterr, fd, cip, sizeof(cip), &cport);
     if (cfd == AE_ERR) {
         redisLog(REDIS_WARNING,"Accepting client connection: %s", server.neterr);
         return;
@@ -1065,7 +1065,7 @@ sds getClientInfoString(redisClient *client) {
     int port;
     int emask;
 
-    anetPeerToString(client->fd,ip,&port);
+    anetPeerToString(client->fd,ip,sizeof(ip),&port);
     p = flags;
     if (client->flags & REDIS_SLAVE) {
         if (client->flags & REDIS_MONITOR)
@@ -1142,7 +1142,7 @@ void clientCommand(redisClient *c) {
             int port;
 
             client = listNodeValue(ln);
-            if (anetPeerToString(client->fd,ip,&port) == -1) continue;
+            if (anetPeerToString(client->fd,ip,sizeof(ip),&port) == -1) continue;
             snprintf(addr,sizeof(addr),"%s:%d",ip,port);
             if (strcmp(addr,c->argv[2]->ptr) == 0) {
                 addReply(c,shared.ok);

--- a/src/redis.c
+++ b/src/redis.c
@@ -2132,7 +2132,7 @@ sds genRedisInfoString(char *section) {
                 char ip[32];
                 int port;
 
-                if (anetPeerToString(slave->fd,ip,&port) == -1) continue;
+                if (anetPeerToString(slave->fd,ip,sizeof(ip),&port) == -1) continue;
                 switch(slave->replstate) {
                 case REDIS_REPL_WAIT_BGSAVE_START:
                 case REDIS_REPL_WAIT_BGSAVE_END:

--- a/src/redis.h
+++ b/src/redis.h
@@ -467,6 +467,7 @@ typedef struct redisOpArray {
 #define REDIS_CLUSTER_NEEDHELP 2    /* The cluster works, but needs some help */
 #define REDIS_CLUSTER_NAMELEN 40    /* sha1 hex length */
 #define REDIS_CLUSTER_PORT_INCR 10000 /* Cluster port = baseport + PORT_INCR */
+#define REDIS_CLUSTER_IPLEN INET_ADDRSTRLEN /* IPv4 address string length */
 
 struct clusterNode;
 
@@ -500,7 +501,7 @@ struct clusterNode {
     time_t pong_received;   /* Unix time we received the pong */
     char *configdigest;         /* Configuration digest of this node */
     time_t configdigest_ts;     /* Configuration digest timestamp */
-    char ip[16];                /* Latest known IP address of this node */
+    char ip[REDIS_CLUSTER_IPLEN]; /* Latest known IP address of this node */
     int port;                   /* Latest known port of this node */
     clusterLink *link;          /* TCP/IP link with this node */
 };

--- a/src/replication.c
+++ b/src/replication.c
@@ -56,7 +56,7 @@ void replicationFeedMonitors(redisClient *c, list *monitors, int dictid, robj **
     if (c->flags & REDIS_LUA_CLIENT) {
         cmdrepr = sdscatprintf(cmdrepr,"[%d lua] ", dictid);
     } else {
-        anetPeerToString(c->fd,ip,&port);
+        anetPeerToString(c->fd,ip,sizeof(ip),&port);
         cmdrepr = sdscatprintf(cmdrepr,"[%d %s:%d] ", dictid,ip,port);
     }
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -425,7 +425,7 @@ sentinelAddr *createSentinelAddr(char *hostname, int port) {
         errno = EINVAL;
         return NULL;
     }
-    if (anetResolve(NULL,hostname,buf) == ANET_ERR) {
+    if (anetResolve(NULL,hostname,buf,sizeof(buf)) == ANET_ERR) {
         errno = ENOENT;
         return NULL;
     }


### PR DESCRIPTION
Using getaddrinfo(3) simplifies the socket creation process and is also required for supporting IPv6. The IP address formatting and parsing functions inet_ntop(3) and inet_pton(3) support both IPv4 and IPv6 string formats.

I'm also working on an ipv6 branch which depends on this branch, I've decided to separate them as the addrinfo code should be of use even without ipv6 support.

The `make test` suite currently passes.
