### PR TITLE
Add support for IPv6

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -23,11 +23,13 @@ pidfile /var/run/redis.pid
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.
 port 6379
+# port6 6379
 
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for incoming connections.
 #
 # bind 127.0.0.1
+# bind6 ::1
 
 # Specify the path for the unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen

--- a/src/anet.c
+++ b/src/anet.c
@@ -402,7 +402,7 @@ int anetUnixAccept(char *err, int s) {
 }
 
 int anetPeerToString(int fd, char *ip, size_t ip_len, int *port) {
-    struct sockaddr_in sa;
+    struct sockaddr_storage sa;
     socklen_t salen = sizeof(sa);
 
     if (getpeername(fd,(struct sockaddr*)&sa,&salen) == -1) {
@@ -411,13 +411,20 @@ int anetPeerToString(int fd, char *ip, size_t ip_len, int *port) {
         ip[1] = '\0';
         return -1;
     }
-    if (ip) inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),ip,ip_len);
-    if (port) *port = ntohs(sa.sin_port);
+    if (sa.ss_family == AF_INET) {
+        struct sockaddr_in *s = (struct sockaddr_in *)&sa;
+        if (ip) inet_ntop(AF_INET,(void*)&(s->sin_addr),ip,ip_len);
+        if (port) *port = ntohs(s->sin_port);
+    } else {
+        struct sockaddr_in6 *s = (struct sockaddr_in6 *)&sa;
+        if (ip) inet_ntop(AF_INET6,(void*)&(s->sin6_addr),ip,ip_len);
+        if (port) *port = ntohs(s->sin6_port);
+    }
     return 0;
 }
 
 int anetSockName(int fd, char *ip, size_t ip_len, int *port) {
-    struct sockaddr_in sa;
+    struct sockaddr_storage sa;
     socklen_t salen = sizeof(sa);
 
     if (getsockname(fd,(struct sockaddr*)&sa,&salen) == -1) {
@@ -426,7 +433,14 @@ int anetSockName(int fd, char *ip, size_t ip_len, int *port) {
         ip[1] = '\0';
         return -1;
     }
-    if (ip) inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),ip,ip_len);
-    if (port) *port = ntohs(sa.sin_port);
+    if (sa.ss_family == AF_INET) {
+        struct sockaddr_in *s = (struct sockaddr_in *)&sa;
+        if (ip) inet_ntop(AF_INET,(void*)&(s->sin_addr),ip,ip_len);
+        if (port) *port = ntohs(s->sin_port);
+    } else {
+        struct sockaddr_in6 *s = (struct sockaddr_in6 *)&sa;
+        if (ip) inet_ntop(AF_INET6,(void*)&(s->sin6_addr),ip,ip_len);
+        if (port) *port = ntohs(s->sin6_port);
+    }
     return 0;
 }

--- a/src/anet.c
+++ b/src/anet.c
@@ -301,23 +301,37 @@ static int anetListen(char *err, int s, struct sockaddr *sa, socklen_t len) {
 
 int anetTcpServer(char *err, int port, char *bindaddr)
 {
-    int s;
-    struct sockaddr_in sa;
+    int s, rv;
+    char _port[6];  /* strlen("65535") */
+    struct addrinfo hints, *servinfo, *p;
 
-    if ((s = anetCreateSocket(err,AF_INET)) == ANET_ERR)
-        return ANET_ERR;
+    snprintf(_port,6,"%d",port);
+    memset(&hints,0,sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;    /* No effect if bindaddr != NULL */
 
-    memset(&sa,0,sizeof(sa));
-    sa.sin_family = AF_INET;
-    sa.sin_port = htons(port);
-    sa.sin_addr.s_addr = htonl(INADDR_ANY);
-    if (bindaddr && inet_aton(bindaddr, &sa.sin_addr) == 0) {
-        anetSetError(err, "invalid bind address");
-        close(s);
+    if ((rv = getaddrinfo(bindaddr,_port,&hints,&servinfo)) != 0) {
+        anetSetError(err, "%s", gai_strerror(rv));
         return ANET_ERR;
     }
-    if (anetListen(err,s,(struct sockaddr*)&sa,sizeof(sa)) == ANET_ERR)
-        return ANET_ERR;
+    for (p = servinfo; p != NULL; p = p->ai_next) {
+        if ((s = socket(p->ai_family,p->ai_socktype,p->ai_protocol)) == -1)
+            continue;
+
+        if (anetListen(err,s,p->ai_addr,p->ai_addrlen) == ANET_ERR)
+            goto error;    /* could continue here? */
+        goto end;
+    }
+    if (p == NULL) {
+        anetSetError(err, "unable to bind socket");
+        goto error;
+    }
+
+error:
+    s = ANET_ERR;
+end:
+    freeaddrinfo(servinfo);
     return s;
 }
 

--- a/src/anet.c
+++ b/src/anet.c
@@ -301,6 +301,16 @@ static int anetListen(char *err, int s, struct sockaddr *sa, socklen_t len) {
     return ANET_OK;
 }
 
+static int anetV6Only(char *err, int s) {
+    int yes = 1;
+    if (setsockopt(s,IPPROTO_IPV6,IPV6_V6ONLY,&yes,sizeof(yes)) == -1) {
+        anetSetError(err, "setsockopt: %s", strerror(errno));
+        close(s);
+        return ANET_ERR;
+    }
+    return ANET_OK;
+}
+
 int anetTcpServer(char *err, int port, char *bindaddr)
 {
     int s, rv;

--- a/src/anet.c
+++ b/src/anet.c
@@ -106,22 +106,26 @@ int anetTcpKeepAlive(char *err, int fd)
     return ANET_OK;
 }
 
-int anetResolve(char *err, char *host, char *ipbuf)
+int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len)
 {
-    struct sockaddr_in sa;
+    struct addrinfo hints, *info;
+    void *addr;
+    int rv;
 
-    sa.sin_family = AF_INET;
-    if (inet_aton(host, &sa.sin_addr) == 0) {
-        struct hostent *he;
+    memset(&hints,0,sizeof(hints));
+    hints.ai_family = AF_INET;
 
-        he = gethostbyname(host);
-        if (he == NULL) {
-            anetSetError(err, "can't resolve: %s", host);
-            return ANET_ERR;
-        }
-        memcpy(&sa.sin_addr, he->h_addr, sizeof(struct in_addr));
+    if ((rv = getaddrinfo(host, NULL, &hints, &info)) != 0) {
+        anetSetError(err, "%s", gai_strerror(rv));
+        return ANET_ERR;
     }
-    strcpy(ipbuf,inet_ntoa(sa.sin_addr));
+    if (info->ai_family == AF_INET) {
+        struct sockaddr_in *sa = (struct sockaddr_in *)info->ai_addr;
+        addr = &(sa->sin_addr);
+    }
+
+    inet_ntop(info->ai_family, addr, ipbuf, ipbuf_len);
+    freeaddrinfo(info);
     return ANET_OK;
 }
 

--- a/src/anet.c
+++ b/src/anet.c
@@ -311,7 +311,7 @@ static int anetV6Only(char *err, int s) {
     return ANET_OK;
 }
 
-int anetTcpServer(char *err, int port, char *bindaddr)
+static int _anetTcpServer(char *err, int port, char *bindaddr, int af)
 {
     int s, rv;
     char _port[6];  /* strlen("65535") */
@@ -319,7 +319,7 @@ int anetTcpServer(char *err, int port, char *bindaddr)
 
     snprintf(_port,6,"%d",port);
     memset(&hints,0,sizeof(hints));
-    hints.ai_family = AF_INET;
+    hints.ai_family = af;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_flags = AI_PASSIVE;    /* No effect if bindaddr != NULL */
 
@@ -330,6 +330,9 @@ int anetTcpServer(char *err, int port, char *bindaddr)
     for (p = servinfo; p != NULL; p = p->ai_next) {
         if ((s = socket(p->ai_family,p->ai_socktype,p->ai_protocol)) == -1)
             continue;
+
+        if (AF_INET6 == af && anetV6Only(err,s) == ANET_ERR)
+            goto error;    /* could continue here? */
 
         if (anetListen(err,s,p->ai_addr,p->ai_addrlen) == ANET_ERR)
             goto error;    /* could continue here? */
@@ -345,6 +348,16 @@ error:
 end:
     freeaddrinfo(servinfo);
     return s;
+}
+
+int anetTcpServer(char *err, int port, char *bindaddr)
+{
+    return _anetTcpServer(err, port, bindaddr, AF_INET);
+}
+
+int anetTcp6Server(char *err, int port, char *bindaddr)
+{
+    return _anetTcpServer(err, port, bindaddr, AF_INET6);
 }
 
 int anetUnixServer(char *err, char *path, mode_t perm)

--- a/src/anet.c
+++ b/src/anet.c
@@ -374,13 +374,20 @@ static int anetGenericAccept(char *err, int s, struct sockaddr *sa, socklen_t *l
 
 int anetTcpAccept(char *err, int s, char *ip, size_t ip_len, int *port) {
     int fd;
-    struct sockaddr_in sa;
+    struct sockaddr_storage sa;
     socklen_t salen = sizeof(sa);
     if ((fd = anetGenericAccept(err,s,(struct sockaddr*)&sa,&salen)) == ANET_ERR)
         return ANET_ERR;
 
-    if (ip) inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),ip,ip_len);
-    if (port) *port = ntohs(sa.sin_port);
+    if (sa.ss_family == AF_INET) {
+        struct sockaddr_in *s = (struct sockaddr_in *)&sa;
+        if (ip) inet_ntop(AF_INET,(void*)&(s->sin_addr),ip,ip_len);
+        if (port) *port = ntohs(s->sin_port);
+    } else {
+        struct sockaddr_in6 *s = (struct sockaddr_in6 *)&sa;
+        if (ip) inet_ntop(AF_INET6,(void*)&(s->sin6_addr),ip,ip_len);
+        if (port) *port = ntohs(s->sin6_port);
+    }
     return fd;
 }
 

--- a/src/anet.c
+++ b/src/anet.c
@@ -370,14 +370,14 @@ static int anetGenericAccept(char *err, int s, struct sockaddr *sa, socklen_t *l
     return fd;
 }
 
-int anetTcpAccept(char *err, int s, char *ip, int *port) {
+int anetTcpAccept(char *err, int s, char *ip, size_t ip_len, int *port) {
     int fd;
     struct sockaddr_in sa;
     socklen_t salen = sizeof(sa);
     if ((fd = anetGenericAccept(err,s,(struct sockaddr*)&sa,&salen)) == ANET_ERR)
         return ANET_ERR;
 
-    if (ip) strcpy(ip,inet_ntoa(sa.sin_addr));
+    if (ip) inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),ip,ip_len);
     if (port) *port = ntohs(sa.sin_port);
     return fd;
 }
@@ -392,7 +392,7 @@ int anetUnixAccept(char *err, int s) {
     return fd;
 }
 
-int anetPeerToString(int fd, char *ip, int *port) {
+int anetPeerToString(int fd, char *ip, size_t ip_len, int *port) {
     struct sockaddr_in sa;
     socklen_t salen = sizeof(sa);
 
@@ -402,12 +402,12 @@ int anetPeerToString(int fd, char *ip, int *port) {
         ip[1] = '\0';
         return -1;
     }
-    if (ip) strcpy(ip,inet_ntoa(sa.sin_addr));
+    if (ip) inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),ip,ip_len);
     if (port) *port = ntohs(sa.sin_port);
     return 0;
 }
 
-int anetSockName(int fd, char *ip, int *port) {
+int anetSockName(int fd, char *ip, size_t ip_len, int *port) {
     struct sockaddr_in sa;
     socklen_t salen = sizeof(sa);
 
@@ -417,7 +417,7 @@ int anetSockName(int fd, char *ip, int *port) {
         ip[1] = '\0';
         return -1;
     }
-    if (ip) strcpy(ip,inet_ntoa(sa.sin_addr));
+    if (ip) inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),ip,ip_len);
     if (port) *port = ntohs(sa.sin_port);
     return 0;
 }

--- a/src/anet.c
+++ b/src/anet.c
@@ -164,7 +164,7 @@ static int anetTcpGenericConnect(char *err, char *addr, int port, int flags)
 
     snprintf(_port,6,"%d",port);
     memset(&hints,0,sizeof(hints));
-    hints.ai_family = AF_INET;
+    hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
 
     if ((rv = getaddrinfo(addr,_port,&hints,&servinfo)) != 0) {

--- a/src/anet.c
+++ b/src/anet.c
@@ -109,11 +109,11 @@ int anetTcpKeepAlive(char *err, int fd)
 int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len)
 {
     struct addrinfo hints, *info;
-    void *addr;
     int rv;
 
     memset(&hints,0,sizeof(hints));
-    hints.ai_family = AF_INET;
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;  /* specify socktype to avoid dups */
 
     if ((rv = getaddrinfo(host, NULL, &hints, &info)) != 0) {
         anetSetError(err, "%s", gai_strerror(rv));
@@ -121,10 +121,12 @@ int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len)
     }
     if (info->ai_family == AF_INET) {
         struct sockaddr_in *sa = (struct sockaddr_in *)info->ai_addr;
-        addr = &(sa->sin_addr);
+        inet_ntop(AF_INET, &(sa->sin_addr), ipbuf, ipbuf_len);
+    } else {
+        struct sockaddr_in6 *sa = (struct sockaddr_in6 *)info->ai_addr;
+        inet_ntop(AF_INET6, &(sa->sin6_addr), ipbuf, ipbuf_len);
     }
 
-    inet_ntop(info->ai_family, addr, ipbuf, ipbuf_len);
     freeaddrinfo(info);
     return ANET_OK;
 }

--- a/src/anet.c
+++ b/src/anet.c
@@ -129,17 +129,24 @@ int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len)
     return ANET_OK;
 }
 
+static int anetSetReuseAddr(char *err, int fd) {
+    int yes = 1;
+    /* Make sure connection-intensive things like the redis benckmark
+     * will be able to close/open sockets a zillion of times */
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) == -1) {
+        anetSetError(err, "setsockopt SO_REUSEADDR: %s", strerror(errno));
+        return ANET_ERR;
+    }
+    return ANET_OK;
+}
+
 static int anetCreateSocket(char *err, int domain) {
-    int s, on = 1;
+    int s;
     if ((s = socket(domain, SOCK_STREAM, 0)) == -1) {
         anetSetError(err, "creating socket: %s", strerror(errno));
         return ANET_ERR;
     }
-
-    /* Make sure connection-intensive things like the redis benckmark
-     * will be able to close/open sockets a zillion of times */
-    if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == -1) {
-        anetSetError(err, "setsockopt SO_REUSEADDR: %s", strerror(errno));
+    if (anetSetReuseAddr(err,s) == ANET_ERR) {
         return ANET_ERR;
     }
     return s;

--- a/src/anet.h
+++ b/src/anet.h
@@ -47,12 +47,12 @@ int anetRead(int fd, char *buf, int count);
 int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len);
 int anetTcpServer(char *err, int port, char *bindaddr);
 int anetUnixServer(char *err, char *path, mode_t perm);
-int anetTcpAccept(char *err, int serversock, char *ip, int *port);
+int anetTcpAccept(char *err, int serversock, char *ip, size_t ip_len, int *port);
 int anetUnixAccept(char *err, int serversock);
 int anetWrite(int fd, char *buf, int count);
 int anetNonBlock(char *err, int fd);
 int anetTcpNoDelay(char *err, int fd);
 int anetTcpKeepAlive(char *err, int fd);
-int anetPeerToString(int fd, char *ip, int *port);
+int anetPeerToString(int fd, char *ip, size_t ip_len, int *port);
 
 #endif

--- a/src/anet.h
+++ b/src/anet.h
@@ -44,7 +44,7 @@ int anetTcpNonBlockConnect(char *err, char *addr, int port);
 int anetUnixConnect(char *err, char *path);
 int anetUnixNonBlockConnect(char *err, char *path);
 int anetRead(int fd, char *buf, int count);
-int anetResolve(char *err, char *host, char *ipbuf);
+int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len);
 int anetTcpServer(char *err, int port, char *bindaddr);
 int anetUnixServer(char *err, char *path, mode_t perm);
 int anetTcpAccept(char *err, int serversock, char *ip, int *port);

--- a/src/anet.h
+++ b/src/anet.h
@@ -55,5 +55,6 @@ int anetNonBlock(char *err, int fd);
 int anetTcpNoDelay(char *err, int fd);
 int anetTcpKeepAlive(char *err, int fd);
 int anetPeerToString(int fd, char *ip, size_t ip_len, int *port);
+int anetSockName(int fd, char *ip, size_t ip_len, int *port);
 
 #endif

--- a/src/anet.h
+++ b/src/anet.h
@@ -46,6 +46,7 @@ int anetUnixNonBlockConnect(char *err, char *path);
 int anetRead(int fd, char *buf, int count);
 int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len);
 int anetTcpServer(char *err, int port, char *bindaddr);
+int anetTcp6Server(char *err, int port, char *bindaddr);
 int anetUnixServer(char *err, char *path, mode_t perm);
 int anetTcpAccept(char *err, int serversock, char *ip, size_t ip_len, int *port);
 int anetUnixAccept(char *err, int serversock);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1242,11 +1242,12 @@ void clusterCommand(redisClient *c) {
 
     if (!strcasecmp(c->argv[1]->ptr,"meet") && c->argc == 4) {
         clusterNode *n;
-        struct sockaddr_in sa;
+        struct sockaddr_storage sa;
         long port;
 
         /* Perform sanity checks on IP/port */
-        if (inet_pton(AF_INET,c->argv[0]->ptr,&(sa.sin_addr)) == 0) {
+        if ((inet_pton(AF_INET,c->argv[0]->ptr,&(((struct sockaddr_in *)&sa)->sin_addr)) ||
+             inet_pton(AF_INET6,c->argv[0]->ptr,&(((struct sockaddr_in6 *)&sa)->sin6_addr))) == 0) {
             addReplyError(c,"Invalid IP address in MEET");
             return;
         }
@@ -1260,7 +1261,9 @@ void clusterCommand(redisClient *c) {
         /* Finally add the node to the cluster with a random name, this 
          * will get fixed in the first handshake (ping/pong). */
         n = createClusterNode(NULL,REDIS_NODE_HANDSHAKE|REDIS_NODE_MEET);
-        inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),n->ip,REDIS_CLUSTER_IPLEN);
+        sa.ss_family == AF_INET ?
+            inet_ntop(AF_INET,(void*)&(((struct sockaddr_in *)&sa)->sin_addr),n->ip,REDIS_CLUSTER_IPLEN) :
+            inet_ntop(AF_INET6,(void*)&(((struct sockaddr_in6 *)&sa)->sin6_addr),n->ip,REDIS_CLUSTER_IPLEN);
         n->port = port;
         clusterAddNode(n);
         addReply(c,shared.ok);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -247,7 +247,7 @@ void freeClusterLink(clusterLink *link) {
 
 void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     int cport, cfd;
-    char cip[128];
+    char cip[128];      /* Could use INET6_ADDRSTRLEN here, but its smaller */
     clusterLink *link;
     REDIS_NOTUSED(el);
     REDIS_NOTUSED(mask);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1,6 +1,8 @@
 #include "redis.h"
 #include "endianconv.h"
 
+#include <sys/types.h>
+#include <sys/socket.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -474,7 +474,7 @@ void nodeIp2String(char *buf, clusterLink *link) {
 
     if (getpeername(link->fd, (struct sockaddr*) &sa, &salen) == -1)
         redisPanic("getpeername() failed.");
-    strncpy(buf,inet_ntoa(sa.sin_addr),sizeof(link->node->ip));
+    inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),buf,sizeof(link->node->ip));
 }
 
 
@@ -1251,7 +1251,7 @@ void clusterCommand(redisClient *c) {
         /* Finally add the node to the cluster with a random name, this 
          * will get fixed in the first handshake (ping/pong). */
         n = createClusterNode(NULL,REDIS_NODE_HANDSHAKE|REDIS_NODE_MEET);
-        strncpy(n->ip,inet_ntoa(sa.sin_addr),sizeof(n->ip));
+        inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),n->ip,sizeof(n->ip));
         n->port = port;
         clusterAddNode(n);
         addReply(c,shared.ok);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -251,7 +251,7 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     REDIS_NOTUSED(mask);
     REDIS_NOTUSED(privdata);
 
-    cfd = anetTcpAccept(server.neterr, fd, cip, &cport);
+    cfd = anetTcpAccept(server.neterr, fd, cip, sizeof(cip), &cport);
     if (cfd == AE_ERR) {
         redisLog(REDIS_VERBOSE,"Accepting cluster node: %s", server.neterr);
         return;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -474,7 +474,7 @@ void nodeIp2String(char *buf, clusterLink *link) {
 
     if (getpeername(link->fd, (struct sockaddr*) &sa, &salen) == -1)
         redisPanic("getpeername() failed.");
-    inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),buf,sizeof(link->node->ip));
+    inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),buf,16);
 }
 
 
@@ -1251,7 +1251,7 @@ void clusterCommand(redisClient *c) {
         /* Finally add the node to the cluster with a random name, this 
          * will get fixed in the first handshake (ping/pong). */
         n = createClusterNode(NULL,REDIS_NODE_HANDSHAKE|REDIS_NODE_MEET);
-        inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),n->ip,sizeof(n->ip));
+        inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),n->ip,16);
         n->port = port;
         clusterAddNode(n);
         addReply(c,shared.ok);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1237,7 +1237,7 @@ void clusterCommand(redisClient *c) {
         long port;
 
         /* Perform sanity checks on IP/port */
-        if (inet_aton(c->argv[2]->ptr,&sa.sin_addr) == 0) {
+        if (inet_pton(AF_INET,c->argv[0]->ptr,&(sa.sin_addr)) == 0) {
             addReplyError(c,"Invalid IP address in MEET");
             return;
         }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -474,7 +474,7 @@ void nodeIp2String(char *buf, clusterLink *link) {
 
     if (getpeername(link->fd, (struct sockaddr*) &sa, &salen) == -1)
         redisPanic("getpeername() failed.");
-    inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),buf,16);
+    inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),buf,REDIS_CLUSTER_IPLEN);
 }
 
 
@@ -1251,7 +1251,7 @@ void clusterCommand(redisClient *c) {
         /* Finally add the node to the cluster with a random name, this 
          * will get fixed in the first handshake (ping/pong). */
         n = createClusterNode(NULL,REDIS_NODE_HANDSHAKE|REDIS_NODE_MEET);
-        inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),n->ip,16);
+        inet_ntop(sa.sin_family,(void*)&(sa.sin_addr),n->ip,REDIS_CLUSTER_IPLEN);
         n->port = port;
         clusterAddNode(n);
         addReply(c,shared.ok);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -258,6 +258,7 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
         redisLog(REDIS_VERBOSE,"Accepting cluster node: %s", server.neterr);
         return;
     }
+    /* IPV6: might want to wrap a v6 address in [] */
     redisLog(REDIS_VERBOSE,"Accepted cluster node %s:%d", cip, cport);
     /* We need to create a temporary node in order to read the incoming
      * packet in a valid contest. This node will be released once we

--- a/src/config.c
+++ b/src/config.c
@@ -57,6 +57,13 @@ void loadServerConfigFromString(char *config) {
             }
         } else if (!strcasecmp(argv[0],"bind") && argc == 2) {
             server.bindaddr = zstrdup(argv[1]);
+        } else if (!strcasecmp(argv[0],"port6") && argc == 2) {
+            server.port6 = atoi(argv[1]);
+            if (server.port6 < 0 || server.port6 > 65535) {
+                err = "Invalid port"; goto loaderr;
+            }
+        } else if (!strcasecmp(argv[0],"bind6") && argc == 2) {
+            server.bindaddr6 = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"unixsocket") && argc == 2) {
             server.unixsocket = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"unixsocketperm") && argc == 2) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -518,7 +518,7 @@ void acceptTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     REDIS_NOTUSED(mask);
     REDIS_NOTUSED(privdata);
 
-    cfd = anetTcpAccept(server.neterr, fd, cip, &cport);
+    cfd = anetTcpAccept(server.neterr, fd, cip, sizeof(cip), &cport);
     if (cfd == AE_ERR) {
         redisLog(REDIS_WARNING,"Accepting client connection: %s", server.neterr);
         return;
@@ -1065,7 +1065,7 @@ sds getClientInfoString(redisClient *client) {
     int port;
     int emask;
 
-    anetPeerToString(client->fd,ip,&port);
+    anetPeerToString(client->fd,ip,sizeof(ip),&port);
     p = flags;
     if (client->flags & REDIS_SLAVE) {
         if (client->flags & REDIS_MONITOR)
@@ -1142,7 +1142,7 @@ void clientCommand(redisClient *c) {
             int port;
 
             client = listNodeValue(ln);
-            if (anetPeerToString(client->fd,ip,&port) == -1) continue;
+            if (anetPeerToString(client->fd,ip,sizeof(ip),&port) == -1) continue;
             snprintf(addr,sizeof(addr),"%s:%d",ip,port);
             if (strcmp(addr,c->argv[2]->ptr) == 0) {
                 addReply(c,shared.ok);

--- a/src/networking.c
+++ b/src/networking.c
@@ -513,7 +513,7 @@ static void acceptCommonHandler(int fd) {
 
 void acceptTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     int cport, cfd;
-    char cip[128];
+    char cip[128];      /* Could use INET6_ADDRSTRLEN here, but its smaller */
     REDIS_NOTUSED(el);
     REDIS_NOTUSED(mask);
     REDIS_NOTUSED(privdata);

--- a/src/networking.c
+++ b/src/networking.c
@@ -1061,7 +1061,7 @@ void getClientsMaxBuffers(unsigned long *longest_output_list,
 
 /* Turn a Redis client into an sds string representing its state. */
 sds getClientInfoString(redisClient *client) {
-    char ip[32], flags[16], events[3], *p;
+    char ip[INET6_ADDRSTRLEN], flags[16], events[3], *p;
     int port;
     int emask;
 
@@ -1138,7 +1138,8 @@ void clientCommand(redisClient *c) {
     } else if (!strcasecmp(c->argv[1]->ptr,"kill") && c->argc == 3) {
         listRewind(server.clients,&li);
         while ((ln = listNext(&li)) != NULL) {
-            char ip[32], addr[64];
+            /* addr size 64 > INET6_ADDRSTRLEN + : + strlen("65535") */
+            char ip[INET6_ADDRSTRLEN], addr[64];
             int port;
 
             client = listNodeValue(ln);

--- a/src/networking.c
+++ b/src/networking.c
@@ -1144,6 +1144,7 @@ void clientCommand(redisClient *c) {
 
             client = listNodeValue(ln);
             if (anetPeerToString(client->fd,ip,sizeof(ip),&port) == -1) continue;
+            /* IPV6: might want to wrap a v6 address in [] */
             snprintf(addr,sizeof(addr),"%s:%d",ip,port);
             if (strcmp(addr,c->argv[2]->ptr) == 0) {
                 addReply(c,shared.ok);

--- a/src/redis.c
+++ b/src/redis.c
@@ -2141,7 +2141,7 @@ sds genRedisInfoString(char *section) {
             while((ln = listNext(&li))) {
                 redisClient *slave = listNodeValue(ln);
                 char *state = NULL;
-                char ip[32];
+                char ip[INET6_ADDRSTRLEN];
                 int port;
 
                 if (anetPeerToString(slave->fd,ip,sizeof(ip),&port) == -1) continue;

--- a/src/redis.c
+++ b/src/redis.c
@@ -2132,7 +2132,7 @@ sds genRedisInfoString(char *section) {
                 char ip[32];
                 int port;
 
-                if (anetPeerToString(slave->fd,ip,&port) == -1) continue;
+                if (anetPeerToString(slave->fd,ip,sizeof(ip),&port) == -1) continue;
                 switch(slave->replstate) {
                 case REDIS_REPL_WAIT_BGSAVE_START:
                 case REDIS_REPL_WAIT_BGSAVE_END:

--- a/src/redis.c
+++ b/src/redis.c
@@ -1284,6 +1284,13 @@ void initServer() {
             exit(1);
         }
     }
+    if (server.port6 != 0) {
+        server.ip6fd = anetTcp6Server(server.neterr,server.port6,server.bindaddr6);
+        if (server.ip6fd == ANET_ERR) {
+            redisLog(REDIS_WARNING, "Opening port: %s", server.neterr);
+            exit(1);
+        }
+    }
     if (server.unixsocket != NULL) {
         unlink(server.unixsocket); /* don't care if this fails */
         server.sofd = anetUnixServer(server.neterr,server.unixsocket,server.unixsocketperm);
@@ -1292,7 +1299,7 @@ void initServer() {
             exit(1);
         }
     }
-    if (server.ipfd < 0 && server.sofd < 0) {
+    if (server.ipfd < 0 && server.ip6fd < 0 && server.sofd < 0) {
         redisLog(REDIS_WARNING, "Configured to not listen anywhere, exiting.");
         exit(1);
     }
@@ -1337,6 +1344,8 @@ void initServer() {
     aeCreateTimeEvent(server.el, 1, serverCron, NULL, NULL);
     if (server.ipfd > 0 && aeCreateFileEvent(server.el,server.ipfd,AE_READABLE,
         acceptTcpHandler,NULL) == AE_ERR) redisPanic("Unrecoverable error creating server.ipfd file event.");
+    if (server.ip6fd > 0 && aeCreateFileEvent(server.el,server.ip6fd,AE_READABLE,
+        acceptTcpHandler,NULL) == AE_ERR) redisPanic("Unrecoverable error creating server.ip6fd file event.");
     if (server.sofd > 0 && aeCreateFileEvent(server.el,server.sofd,AE_READABLE,
         acceptUnixHandler,NULL) == AE_ERR) redisPanic("Unrecoverable error creating server.sofd file event.");
 
@@ -2492,6 +2501,119 @@ void redisAsciiArt(void) {
     redisLogRaw(REDIS_NOTICE|REDIS_LOG_RAW,buf);
     zfree(buf);
 }
+
+int main(int argc, char **argv) {
+    long long start;
+
+    initServerConfig();
+    if (argc == 2) {
+        if (strcmp(argv[1], "-v") == 0 ||
+            strcmp(argv[1], "--version") == 0) version();
+        if (strcmp(argv[1], "--help") == 0) usage();
+        resetServerSaveParams();
+        loadServerConfig(argv[1]);
+    } else if ((argc > 2)) {
+        usage();
+    } else {
+        redisLog(REDIS_WARNING,"Warning: no config file specified, using the default config. In order to specify a config file use 'redis-server /path/to/redis.conf'");
+    }
+    if (server.daemonize) daemonize();
+    initServer();
+    if (server.daemonize) createPidFile();
+    redisAsciiArt();
+    redisLog(REDIS_NOTICE,"Server started, Redis version " REDIS_VERSION);
+#ifdef __linux__
+    linuxOvercommitMemoryWarning();
+#endif
+    start = ustime();
+    if (server.appendonly) {
+        if (loadAppendOnlyFile(server.appendfilename) == REDIS_OK)
+            redisLog(REDIS_NOTICE,"DB loaded from append only file: %.3f seconds",(float)(ustime()-start)/1000000);
+    } else {
+        if (rdbLoad(server.dbfilename) == REDIS_OK)
+            redisLog(REDIS_NOTICE,"DB loaded from disk: %.3f seconds",(float)(ustime()-start)/1000000);
+    }
+    if (server.ipfd > 0)
+        redisLog(REDIS_NOTICE,"The server is now ready to accept connections on port %d", server.port);
+    if (server.ip6fd > 0)
+        redisLog(REDIS_NOTICE,"The server is now ready to accept IPv6 connections on port %d", server.port6);
+    if (server.sofd > 0)
+        redisLog(REDIS_NOTICE,"The server is now ready to accept connections at %s", server.unixsocket);
+    aeSetBeforeSleepProc(server.el,beforeSleep);
+    aeMain(server.el);
+    aeDeleteEventLoop(server.el);
+    return 0;
+}
+
+#ifdef HAVE_BACKTRACE
+static void *getMcontextEip(ucontext_t *uc) {
+#if defined(__FreeBSD__)
+    return (void*) uc->uc_mcontext.mc_eip;
+#elif defined(__dietlibc__)
+    return (void*) uc->uc_mcontext.eip;
+#elif defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_6)
+  #if __x86_64__
+    return (void*) uc->uc_mcontext->__ss.__rip;
+  #else
+    return (void*) uc->uc_mcontext->__ss.__eip;
+  #endif
+#elif defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)
+  #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
+    return (void*) uc->uc_mcontext->__ss.__rip;
+  #else
+    return (void*) uc->uc_mcontext->__ss.__eip;
+  #endif
+#elif defined(__i386__)
+    return (void*) uc->uc_mcontext.gregs[14]; /* Linux 32 */
+#elif defined(__X86_64__) || defined(__x86_64__)
+    return (void*) uc->uc_mcontext.gregs[16]; /* Linux 64 */
+#elif defined(__ia64__) /* Linux IA64 */
+    return (void*) uc->uc_mcontext.sc_ip;
+#else
+    return NULL;
+#endif
+}
+
+static void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
+    void *trace[100];
+    char **messages = NULL;
+    int i, trace_size = 0;
+    ucontext_t *uc = (ucontext_t*) secret;
+    sds infostring;
+    struct sigaction act;
+    REDIS_NOTUSED(info);
+
+    redisLog(REDIS_WARNING,
+        "======= Ooops! Redis %s got signal: -%d- =======", REDIS_VERSION, sig);
+    infostring = genRedisInfoString("all");
+    redisLogRaw(REDIS_WARNING, infostring);
+    /* It's not safe to sdsfree() the returned string under memory
+     * corruption conditions. Let it leak as we are going to abort */
+
+    trace_size = backtrace(trace, 100);
+    /* overwrite sigaction with caller's address */
+    if (getMcontextEip(uc) != NULL) {
+        trace[1] = getMcontextEip(uc);
+    }
+    messages = backtrace_symbols(trace, trace_size);
+
+    for (i=1; i<trace_size; ++i)
+        redisLog(REDIS_WARNING,"%s", messages[i]);
+
+    /* free(messages); Don't call free() with possibly corrupted memory. */
+    if (server.daemonize) unlink(server.pidfile);
+
+    /* Make sure we exit with the right signal at the end. So for instance
+     * the core will be dumped if enabled. */
+    sigemptyset (&act.sa_mask);
+    /* When the SA_SIGINFO flag is set in sa_flags then sa_sigaction
+     * is used. Otherwise, sa_handler is used */
+    act.sa_flags = SA_NODEFER | SA_ONSTACK | SA_RESETHAND;
+    act.sa_handler = SIG_DFL;
+    sigaction (sig, &act, NULL);
+    kill(getpid(),sig);
+}
+#endif /* HAVE_BACKTRACE */
 
 static void sigtermHandler(int sig) {
     REDIS_NOTUSED(sig);

--- a/src/redis.c
+++ b/src/redis.c
@@ -1086,10 +1086,13 @@ void initServerConfig() {
     server.runid[REDIS_RUN_ID_SIZE] = '\0';
     server.arch_bits = (sizeof(long) == 8) ? 64 : 32;
     server.port = REDIS_SERVERPORT;
+    server.port6 = 0;                   /* Disable IPv6 by default */
     server.bindaddr = NULL;
+    server.bindaddr6 = NULL;
     server.unixsocket = NULL;
     server.unixsocketperm = 0;
     server.ipfd = -1;
+    server.ip6fd = -1;
     server.sofd = -1;
     server.dbnum = REDIS_DEFAULT_DBNUM;
     server.verbosity = REDIS_NOTICE;

--- a/src/redis.h
+++ b/src/redis.h
@@ -467,6 +467,7 @@ typedef struct redisOpArray {
 #define REDIS_CLUSTER_NEEDHELP 2    /* The cluster works, but needs some help */
 #define REDIS_CLUSTER_NAMELEN 40    /* sha1 hex length */
 #define REDIS_CLUSTER_PORT_INCR 10000 /* Cluster port = baseport + PORT_INCR */
+#define REDIS_CLUSTER_IPLEN INET_ADDRSTRLEN /* IPv4 address string length */
 
 struct clusterNode;
 
@@ -500,7 +501,7 @@ struct clusterNode {
     time_t pong_received;   /* Unix time we received the pong */
     char *configdigest;         /* Configuration digest of this node */
     time_t configdigest_ts;     /* Configuration digest timestamp */
-    char ip[16];                /* Latest known IP address of this node */
+    char ip[REDIS_CLUSTER_IPLEN]; /* Latest known IP address of this node */
     int port;                   /* Latest known port of this node */
     clusterLink *link;          /* TCP/IP link with this node */
 };

--- a/src/redis.h
+++ b/src/redis.h
@@ -607,10 +607,13 @@ struct redisServer {
     int sentinel_mode;          /* True if this instance is a Sentinel. */
     /* Networking */
     int port;                   /* TCP listening port */
+    int port6;                  /* TCP v6 listening port */
     char *bindaddr;             /* Bind address or NULL */
+    char *bindaddr6;            /* Bind v6 address or NULL */
     char *unixsocket;           /* UNIX socket path */
     mode_t unixsocketperm;      /* UNIX socket permission */
     int ipfd;                   /* TCP socket file descriptor */
+    int ip6fd;                  /* TCP v6 socket file descriptor */
     int sofd;                   /* Unix socket file descriptor */
     int cfd;                    /* Cluster bus lisetning socket */
     list *clients;              /* List of active clients */

--- a/src/redis.h
+++ b/src/redis.h
@@ -467,7 +467,7 @@ typedef struct redisOpArray {
 #define REDIS_CLUSTER_NEEDHELP 2    /* The cluster works, but needs some help */
 #define REDIS_CLUSTER_NAMELEN 40    /* sha1 hex length */
 #define REDIS_CLUSTER_PORT_INCR 10000 /* Cluster port = baseport + PORT_INCR */
-#define REDIS_CLUSTER_IPLEN INET_ADDRSTRLEN /* IPv4 address string length */
+#define REDIS_CLUSTER_IPLEN INET6_ADDRSTRLEN /* IPv6 address string length */
 
 struct clusterNode;
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -56,7 +56,7 @@ void replicationFeedMonitors(redisClient *c, list *monitors, int dictid, robj **
     if (c->flags & REDIS_LUA_CLIENT) {
         cmdrepr = sdscatprintf(cmdrepr,"[%d lua] ", dictid);
     } else {
-        anetPeerToString(c->fd,ip,&port);
+        anetPeerToString(c->fd,ip,sizeof(ip),&port);
         cmdrepr = sdscatprintf(cmdrepr,"[%d %s:%d] ", dictid,ip,port);
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -48,7 +48,7 @@ void replicationFeedMonitors(redisClient *c, list *monitors, int dictid, robj **
     int j, port;
     sds cmdrepr = sdsnew("+");
     robj *cmdobj;
-    char ip[32];
+    char ip[INET6_ADDRSTRLEN];
     struct timeval tv;
 
     gettimeofday(&tv,NULL);

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -425,7 +425,7 @@ sentinelAddr *createSentinelAddr(char *hostname, int port) {
         errno = EINVAL;
         return NULL;
     }
-    if (anetResolve(NULL,hostname,buf) == ANET_ERR) {
+    if (anetResolve(NULL,hostname,buf,sizeof(buf)) == ANET_ERR) {
         errno = ENOENT;
         return NULL;
     }

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1761,14 +1761,13 @@ void sentinelPingInstance(sentinelRedisInstance *ri) {
                (now - ri->last_pub_time) > SENTINEL_PUBLISH_PERIOD)
     {
         /* PUBLISH hello messages only to masters. */
-        struct sockaddr_in sa;
-        socklen_t salen = sizeof(sa);
-
-        if (getsockname(ri->cc->c.fd,(struct sockaddr*)&sa,&salen) != -1) {
+        char ip[INET6_ADDRSTRLEN];
+        if (anetSockName(ri->cc->c.fd,ip,sizeof(ip),NULL) != -1) {
             char myaddr[128];
 
+            // FIXME: IPv6 will break this due to nested : characters -geoffgarside
             snprintf(myaddr,sizeof(myaddr),"%s:%d:%s:%d",
-                inet_ntoa(sa.sin_addr), server.port, server.runid,
+                ip, server.port, server.runid,
                 (ri->flags & SRI_CAN_FAILOVER) != 0);
             retval = redisAsyncCommand(ri->cc,
                 sentinelPublishReplyCallback, NULL, "PUBLISH %s %s",


### PR DESCRIPTION
This branch builds on the commits in pull request #60 to add IPv6 support, unfortunately I can't work out how to have github add a pull request against another pull request so unfortunately this one includes the commits from the addrinfo branch in pull request #60. If #60 is pulled first I can close and re-submit the this pull request, provided theres interest in it of course.

There is currently one part of redis which I've not yet touched with respect to IPv6 as I wanted to know how best to proceed.

The `anetTcpServer` function is currently used to create an IPv4 listening socket. This could be changed to create an IPv6 socket which then disables `V6ONLY` socket option so that it accepts IPv4 connections as well, seen in netstat as tcp46.

Some operating systems by default require separate stack sockets, such that you have to create an IPv4 socket and an IPv6 socket. These operating systems can usually be configured to allow dual-stack sockets, but it does require additional work by the administrator.

I believe separate sockets would be the desired implementation in redis. Were this the case then `anetTcpServer` would continue to return IPv4 sockets and another function `anetTcp6Server` would return IPv6 sockets. The IPv6 socket would then sit along side the `ipfd` descriptor as `ip6fd` or something similar.

Does this seem acceptable?
