### PR TITLE
Fix FTBFS on kfreebsd.

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -34,7 +34,7 @@
 #define HAVE_EPOLL 1
 #endif
 
-#if (defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__)
+#if (defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__) || defined(__FreeBSD_kernel__)
 #define HAVE_KQUEUE 1
 #endif
 

--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -3,7 +3,7 @@
 
 #define _BSD_SOURCE
 
-#ifdef __linux__
+#ifdef __GLIBC__
 #define _XOPEN_SOURCE 700
 #else
 #define _XOPEN_SOURCE


### PR DESCRIPTION
This might break someone using some specialist libc under linux (dietlibc?)
but they probably have bigger problems.

Also add support for kqueue under this architecture.

Signed-off-by: Chris Lamb lamby@debian.org
