### PR TITLE
Fix expiration issues when loading AOF

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -476,6 +476,9 @@ int expireIfNeeded(redisDb *db, robj *key) {
 
     if (when < 0) return 0; /* No expire for this key */
 
+    /* Don't expire anything while loading. It will be done later. */
+    if (server.loading) return 0;
+
     /* If we are running in the context of a slave, return ASAP:
      * the slave key expiration is controlled by the master that will
      * send us synthesized DEL operations for expired keys.
@@ -513,7 +516,7 @@ void expireGenericCommand(redisClient *c, robj *key, robj *param, long offset) {
         addReply(c,shared.czero);
         return;
     }
-    if (seconds <= 0) {
+    if (seconds <= 0 && !server.loading) {
         if (dbDelete(c->db,key)) server.dirty++;
         addReply(c, shared.cone);
         signalModifiedKey(c->db,key);

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -101,4 +101,22 @@ tags {"aof"} {
             assert_equal 1 [$client scard set]
         }
     }
+
+    ## Test that EXPIREAT is loaded correctly
+    create_aof {
+        append_to_aof [formatCommand rpush list foo]
+        append_to_aof [formatCommand expireat list 1000]
+        append_to_aof [formatCommand rpush list bar]
+    }
+
+    start_server_aof [list dir $server_path] {
+        test "AOF+EXPIRE: Server should have been started" {
+            assert_equal 1 [is_alive $srv]
+        }
+
+        test "AOF+EXPIRE: List should be empty" {
+            set client [redis [dict get $srv host] [dict get $srv port]]
+            assert_equal 0 [$client llen list]
+        }
+    }
 }


### PR DESCRIPTION
See the discussion on the mailing list (Redis crash with 'appendonly yes' and message queue using lpush/brpop). It's a small change, but fixes at least two issues related to the combination of expiration and append-only files.
