### PR TITLE
Close listening TCP/Unix sockets on shutdown

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -56,6 +56,14 @@ static void anetSetError(char *err, const char *fmt, ...)
     va_end(ap);
 }
 
+int anetClose(int fd)
+{
+    if (fd > 0) {
+        if (close(fd) != 0) return ANET_ERR;
+    }
+    return ANET_OK;
+}
+
 int anetNonBlock(char *err, int fd)
 {
     int flags;

--- a/src/anet.h
+++ b/src/anet.h
@@ -39,6 +39,8 @@
 #define AF_LOCAL AF_UNIX
 #endif
 
+int anetClose(int fd);
+
 int anetTcpConnect(char *err, char *addr, int port);
 int anetTcpNonBlockConnect(char *err, char *addr, int port);
 int anetUnixConnect(char *err, char *path);

--- a/src/redis.c
+++ b/src/redis.c
@@ -1162,6 +1162,9 @@ int prepareForShutdown() {
     } else {
         redisLog(REDIS_WARNING,"Not saving DB.");
     }
+    /* Close listening TCP or Unix sockets */
+    anetClose(server.ipfd);
+    anetClose(server.sofd);
     if (server.daemonize) unlink(server.pidfile);
     redisLog(REDIS_WARNING,"Server exit now, bye bye...");
     return REDIS_OK;


### PR DESCRIPTION
Hello!

I have a problem in production with restarting redis.
We ask redis to stop, and it stops (pid file is absent), but when we start new redis instance it cannot bind to a port (port is still open). Seems like we launch new redis instance during this short time - between unlinking pid file and calling exit(0). Of course we could put sleep(1) into our restarting code but I think it's better to clean-up stuff in redis.

In this change I'm closing listening sockets in prepareForShutdown function.
Seems like it resolves our issue.
