### PR TITLE
Cleaned up spelling, grammar, and punctuation in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -10,48 +10,48 @@
 # 1g => 1000000000 bytes
 # 1gb => 1024*1024*1024 bytes
 #
-# units are case insensitive so 1GB 1Gb 1gB are all the same.
+# The units are case insensitive so 1GB, 1Gb, and 1gB are all the same.
 
-# By default Redis does not run as a daemon. Use 'yes' if you need it.
+# By default Redis does not run as a daemon. Use "yes" if you need it.
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
 daemonize no
 
-# When running daemonized, Redis writes a pid file in /var/run/redis.pid by
+# When running as a daemon, Redis writes a pid file in /var/run/redis.pid by
 # default. You can specify a custom pid file location here.
 pidfile /var/run/redis.pid
 
-# Accept connections on the specified port, default is 6379.
-# If port 0 is specified Redis will not listen on a TCP socket.
+# Accept connections on the specified port. The default is 6379.
+# If port 0 is specified, Redis will not listen on a TCP socket.
 port 6379
 
-# If you want you can bind a single interface, if the bind option is not
-# specified all the interfaces will listen for incoming connections.
+# If you want, you can bind a single interface. If the "bind" option is not
+# specified, Redis will listen for incoming connections on all interfaces.
 #
 # bind 127.0.0.1
 
 # Specify the path for the unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen
-# on a unix socket when not specified.
+# on a unix socket when this is not specified.
 #
 # unixsocket /tmp/redis.sock
 
-# Close the connection after a client is idle for N seconds (0 to disable)
+# Close the connection after a client is idle for N seconds (0 to disable).
 timeout 300
 
-# Set server verbosity to 'debug'
-# it can be one of:
-# debug (a lot of information, useful for development/testing)
-# verbose (many rarely useful info, but not a mess like the debug level)
-# notice (moderately verbose, what you want in production probably)
-# warning (only very important / critical messages are logged)
+# Set the verbosity level of the server log. It can be one of:
+# "debug": A lot of information (useful for development/testing).
+# "verbose": Much occasionally useful information, but not a mess like the
+#            "debug" level.
+# "notice": Moderately verbose (probably what you want in production).
+# "warning": Only very important and/or critical messages are logged.
 loglevel verbose
 
-# Specify the log file name. Also 'stdout' can be used to force
+# Specify the name of the log file. Specifying "stdout" as the file will force
 # Redis to log on the standard output. Note that if you use standard
-# output for logging but daemonize, logs will be sent to /dev/null
+# output for logging but daemonize, logs will be sent to /dev/null.
 logfile stdout
 
-# To enable logging to the system logger, just set 'syslog-enabled' to yes,
+# To enable logging to the system logger, just set "syslog-enabled" to yes,
 # and optionally update the other syslog parameters to suit your needs.
 # syslog-enabled no
 
@@ -61,9 +61,9 @@ logfile stdout
 # Specify the syslog facility.  Must be USER or between LOCAL0-LOCAL7.
 # syslog-facility local0
 
-# Set the number of databases. The default database is DB 0, you can select
-# a different one on a per-connection basis using SELECT <dbid> where
-# dbid is a number between 0 and 'databases'-1
+# Set the number of databases. The default database is DB 0, but clients can
+# select a different one on a per-connection basis using "SELECT <dbid>" where
+# dbid is a number between 0 and "databases"-1.
 databases 16
 
 ################################ SNAPSHOTTING  #################################
@@ -80,37 +80,40 @@ databases 16
 #   after 300 sec (5 min) if at least 10 keys changed
 #   after 60 sec if at least 10000 keys changed
 #
-#   Note: you can disable saving at all commenting all the "save" lines.
+#   Note: you can disable saving completely by commenting out all of
+#   the "save" directives.
 
 save 900 1
 save 300 10
 save 60 10000
 
-# Compress string objects using LZF when dump .rdb databases?
-# For default that's set to 'yes' as it's almost always a win.
-# If you want to save some CPU in the saving child set it to 'no' but
-# the dataset will likely be bigger if you have compressible values or keys.
+# Compress string objects using LZF when dumping .rdb databases?
+# The default is "yes", as it's almost always worth it.
+# If you want to save some CPU in the saving child, then set it to "no", but
+# the dataset will likely use more space if you have compressible values or keys.
 rdbcompression yes
 
-# The filename where to dump the DB
+# The filename for the DB dump, relative to the working directory.
 dbfilename dump.rdb
 
 # The working directory.
 #
 # The DB will be written inside this directory, with the filename specified
-# above using the 'dbfilename' configuration directive.
+# above using the "dbfilename" configuration directive.
 # 
-# Also the Append Only File will be created inside this directory.
+# The Append Only File will also be created inside this directory if it is in
+# use.
 # 
 # Note that you must specify a directory here, not a file name.
 dir ./
 
 ################################# REPLICATION #################################
 
-# Master-Slave replication. Use slaveof to make a Redis instance a copy of
+# Master-Slave replication. Use "slaveof" to make a Redis instance a copy of
 # another Redis server. Note that the configuration is local to the slave
 # so for example it is possible to configure the slave to save the DB with a
-# different interval, or to listen to another port, and so on.
+# different interval, or to listen to another port, and so on. This setting
+# can be changed at runtime with the SLAVEOF command.
 #
 # slaveof <masterip> <masterport>
 
@@ -121,16 +124,16 @@ dir ./
 #
 # masterauth <master-password>
 
-# When a slave lost the connection with the master, or when the replication
+# When a slave loses its connection with the master, or when replication
 # is still in progress, the slave can act in two different ways:
 #
-# 1) if slave-serve-stale-data is set to 'yes' (the default) the slave will
-#    still reply to client requests, possibly with out of data data, or the
-#    data set may just be empty if this is the first synchronization.
+# 1) If "slave-serve-stale-data" is set to "yes" (the default), the slave will
+#    still reply to client requests, possibly with out of date data (or the
+#    data set may simply be empty if this is the first synchronization).
 #
-# 2) if slave-serve-stale data is set to 'no' the slave will reply with
-#    an error "SYNC with master in progress" to all the kind of commands
-#    but to INFO and SLAVEOF.
+# 2) If "slave-serve-stale data" is set to "no", the slave will reply with
+#    the error "SYNC with master in progress" to all commands except INFO and
+#    SLAVEOF.
 #
 slave-serve-stale-data yes
 
@@ -140,28 +143,28 @@ slave-serve-stale-data yes
 # commands.  This might be useful in environments in which you do not trust
 # others with access to the host running redis-server.
 #
-# This should stay commented out for backward compatibility and because most
-# people do not need auth (e.g. they run their own servers).
+# This should normally stay commented out for backward compatibility, and
+# because most people do not need auth (e.g. they run their own servers).
 # 
-# Warning: since Redis is pretty fast an outside user can try up to
+# Warning: since Redis is pretty fast, an outside user can try up to
 # 150k passwords per second against a good box. This means that you should
-# use a very strong password otherwise it will be very easy to break.
+# use a very strong password - otherwise it will be very easy to break.
 #
 # requirepass foobared
 
 # Command renaming.
 #
-# It is possilbe to change the name of dangerous commands in a shared
-# environment. For instance the CONFIG command may be renamed into something
-# of hard to guess so that it will be still available for internal-use
-# tools but not available for general clients.
+# It is possible to change the name of dangerous commands in a shared
+# environment. For instance, the CONFIG command may be renamed to something
+# hard to guess so that it will be still available for internal-use
+# tools, but not available for general clients.
 #
 # Example:
 #
 # rename-command CONFIG b840fc02d524045429941cc15f59e41cb7be6c52
 #
-# It is also possilbe to completely kill a command renaming it into
-# an empty string:
+# It is also possible to make a command completely inaccessible by renaming it
+# to an empty string:
 #
 # rename-command CONFIG ""
 
@@ -169,45 +172,45 @@ slave-serve-stale-data yes
 
 # Set the max number of connected clients at the same time. By default there
 # is no limit, and it's up to the number of file descriptors the Redis process
-# is able to open. The special value '0' means no limits.
-# Once the limit is reached Redis will close all the new connections sending
-# an error 'max number of clients reached'.
+# is able to open. The special value "0" means no limits.
+# Once the limit is reached Redis will close all the new connections and send
+# the error "max number of clients reached".
 #
 # maxclients 128
 
 # Don't use more memory than the specified amount of bytes.
-# When the memory limit is reached Redis will try to remove keys with an
+# When the memory limit is reached, Redis will try to remove keys with an
 # EXPIRE set. It will try to start freeing keys that are going to expire
-# in little time and preserve keys with a longer time to live.
+# soon and preserve keys with a longer time to live.
 # Redis will also try to remove objects from free lists if possible.
 #
-# If all this fails, Redis will start to reply with errors to commands
+# If all of this fails, Redis will start to reply with errors to commands
 # that will use more memory, like SET, LPUSH, and so on, and will continue
 # to reply to most read-only commands like GET.
 #
-# WARNING: maxmemory can be a good idea mainly if you want to use Redis as a
+# WARNING: "maxmemory" can be a good idea mainly if you want to use Redis as a
 # 'state' server or cache, not as a real DB. When Redis is used as a real
-# database the memory usage will grow over the weeks, it will be obvious if
+# database the memory usage will grow over time and it will be obvious if
 # it is going to use too much memory in the long run, and you'll have the time
-# to upgrade. With maxmemory after the limit is reached you'll start to get
-# errors for write operations, and this may even lead to DB inconsistency.
+# to upgrade. With "maxmemory", after the limit is reached, you'll start to
+# get errors for write operations, which may even lead to DB inconsistency.
 #
 # maxmemory <bytes>
 
-# MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
-# is reached? You can select among five behavior:
+# MAXMEMORY POLICY: how Redis will select what to remove when "maxmemory"
+# is reached? You can select one of six behaviors:
 # 
-# volatile-lru -> remove the key with an expire set using an LRU algorithm
-# allkeys-lru -> remove any key accordingly to the LRU algorithm
-# volatile-random -> remove a random key with an expire set
-# allkeys->random -> remove a random key, any key
-# volatile-ttl -> remove the key with the nearest expire time (minor TTL)
-# noeviction -> don't expire at all, just return an error on write operations
+# "volatile-lru" Remove keys set to expire using an LRU algorithm.
+# "allkeys-lru" Remove any key chosen by the LRU algorithm.
+# "volatile-random" Remove a random key set to expire.
+# "allkeys-random" Remove any random key.
+# "volatile-ttl": Remove the key with the nearest expire time.
+# "noeviction": Don't expire any keys, just return an error on write operations.
 # 
-# Note: with all the kind of policies, Redis will return an error on write
-#       operations, when there are not suitable keys for eviction.
+# Note: With any of the policies, Redis will return an error on write
+#       operations when there are no keys suitable for eviction.
 #
-#       At the date of writing this commands are: set setnx setex append
+#       At the date of writing, "write operations" are: set setnx setex append
 #       incr decr rpush lpush rpushx lpushx linsert lset rpoplpush sadd
 #       sinter sinterstore sunion sunionstore sdiff sdiffstore zadd zincrby
 #       zunionstore zinterstore hset hsetnx hmset hincrby incrby decrby
@@ -219,26 +222,26 @@ slave-serve-stale-data yes
 
 # LRU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can select as well the sample
-# size to check. For instance for default Redis will check three keys and
-# pick the one that was used less recently, you can change the sample size
+# size to check. For instance, by default Redis will check three keys and
+# pick the one that was used least recently. You can change the sample size
 # using the following configuration directive.
 #
 # maxmemory-samples 3
 
 ############################## APPEND ONLY MODE ###############################
 
-# By default Redis asynchronously dumps the dataset on disk. If you can live
+# By default, Redis asynchronously dumps the dataset on disk. If you can live
 # with the idea that the latest records will be lost if something like a crash
-# happens this is the preferred way to run Redis. If instead you care a lot
-# about your data and don't want to that a single record can get lost you should
-# enable the append only mode: when this mode is enabled Redis will append
+# happens, this is the preferred way to run Redis. If instead you care a lot
+# about your data and don't want any records to be lost, then you should
+# enable the append only mode. When this mode is enabled Redis will append
 # every write operation received in the file appendonly.aof. This file will
 # be read on startup in order to rebuild the full dataset in memory.
 #
 # Note that you can have both the async dumps and the append only file if you
-# like (you have to comment the "save" statements above to disable the dumps).
-# Still if append only mode is enabled Redis will load the data from the
-# log file at startup ignoring the dump.rdb file.
+# like (you have to comment the "save" directives above to disable the dumps).
+# Still, if append only mode is enabled, Redis will load the data from the
+# log file at startup and ignore the dump.rdb file.
 #
 # IMPORTANT: Check the BGREWRITEAOF to check how to rewrite the append
 # log file in background when it gets too big.
@@ -249,21 +252,21 @@ appendonly no
 # appendfilename appendonly.aof
 
 # The fsync() call tells the Operating System to actually write data on disk
-# instead to wait for more data in the output buffer. Some OS will really flush 
-# data on disk, some other OS will just try to do it ASAP.
+# instead of waiting for more data in the output buffer. Some OSes will really
+# flush data on disk, some other OSes will just try to do it ASAP.
 #
 # Redis supports three different modes:
 #
-# no: don't fsync, just let the OS flush the data when it wants. Faster.
-# always: fsync after every write to the append only log . Slow, Safest.
-# everysec: fsync only if one second passed since the last fsync. Compromise.
+# "no": Don't fsync, just let the OS flush the data when it wants. Faster.
+# "always": fsync after every write to the append only log. Slower, but safest.
+# "everysec": fsync only if one second has passed since the last fsync. Compromise.
 #
-# The default is "everysec" that's usually the right compromise between
+# The default is "everysec", as that is usually the right compromise between
 # speed and data safety. It's up to you to understand if you can relax this to
-# "no" that will will let the operating system flush the output buffer when
-# it wants, for better performances (but if you can live with the idea of
-# some data loss consider the default persistence mode that's snapshotting),
-# or on the contrary, use "always" that's very slow but a bit safer than
+# "no", allowing the operating system to flush the output buffer when
+# it wants, for improved performance (but if you can live with the idea of
+# some data loss, consider using the default "snapshotting" persistence mode),
+# or whether you can use "always", which is very slow, but a bit safer than
 # everysec.
 #
 # If unsure, use "everysec".
@@ -279,34 +282,34 @@ appendfsync everysec
 # this currently, as even performing fsync in a different thread will block
 # our synchronous write(2) call.
 #
-# In order to mitigate this problem it's possible to use the following option
+# In order to mitigate this problem, it's possible to use the following option
 # that will prevent fsync() from being called in the main process while a
 # BGSAVE or BGREWRITEAOF is in progress.
 #
-# This means that while another child is saving the durability of Redis is
-# the same as "appendfsync none", that in pratical terms means that it is
-# possible to lost up to 30 seconds of log in the worst scenario (with the
-# default Linux settings).
+# This means that while another child is saving, the durability of Redis is
+# the same as "appendfsync none", which in practical terms means that it is
+# possible to lost up to 30 seconds of log in the worst-case scenario (with
+# the default Linux settings).
 # 
-# If you have latency problems turn this to "yes". Otherwise leave it as
-# "no" that is the safest pick from the point of view of durability.
+# If you have latency problems, then set this to "yes". Otherwise, leave it
+# as "no", as that is the safest choice from the point of view of durability.
 no-appendfsync-on-rewrite no
 
 # Automatic rewrite of the append only file.
-# Redis is able to automatically rewrite the log file implicitly calling
-# BGREWRITEAOF when the AOF log size will growth by the specified percentage.
+# Redis is able to automatically rewrite the log file (implicitly calling
+# BGREWRITEAOF) when the AOF log size grows by the specified percentage.
 # 
 # This is how it works: Redis remembers the size of the AOF file after the
-# latest rewrite (or if no rewrite happened since the restart, the size of
-# the AOF at startup is used).
+# latest rewrite (or at server startup, if no rewrite has happened since
+# the server started).
 #
 # This base size is compared to the current size. If the current size is
-# bigger than the specified percentage, the rewrite is triggered. Also
-# you need to specify a minimal size for the AOF file to be rewritten, this
-# is useful to avoid rewriting the AOF file even if the percentage increase
-# is reached but it is still pretty small.
+# bigger than the specified percentage, the rewrite is triggered. Also,
+# you need to specify a minimum size for the AOF file to be rewritten. This
+# is used to avoid rewriting the AOF file when the file is small, but it
+# has still grown past the specified percentage.
 #
-# Specify a precentage of zero in order to disable the automatic AOF
+# Specify a percentage of zero in order to disable the automatic AOF
 # rewrite feature.
 
 auto-aof-rewrite-percentage 100
@@ -315,13 +318,14 @@ auto-aof-rewrite-min-size 64mb
 ################################ LUA SCRIPTING  ###############################
 
 # Max execution time of a Lua script in milliseconds.
-# This prevents that a programming error generating an infinite loop will block
-# your server forever. Set it to 0 or a negative value for unlimited execution.
+# This prevents programming errors from generating an infinite loop that would
+# block the server forever. Set it to 0 or a negative value for unlimited
+# execution. (The default is equivalent to 60 seconds, or one minute.)
 lua-time-limit 60000
 
 ################################## SLOW LOG ###################################
 
-# The Redis Slow Log is a system to log queries that exceeded a specified
+# The Redis Slow Log is a system to log commands that exceed a specified
 # execution time. The execution time does not include the I/O operations
 # like talking with the client, sending the reply and so forth,
 # but just the time needed to actually execute the command (this is the only
@@ -329,37 +333,39 @@ lua-time-limit 60000
 # other requests in the meantime).
 # 
 # You can configure the slow log with two parameters: one tells Redis
-# what is the execution time, in microseconds, to exceed in order for the
+# the execution time, in microseconds, to exceed in order for the
 # command to get logged, and the other parameter is the length of the
 # slow log. When a new command is logged the oldest one is removed from the
 # queue of logged commands.
 
 # The following time is expressed in microseconds, so 1000000 is equivalent
 # to one second. Note that a negative number disables the slow log, while
-# a value of zero forces the logging of every command.
+# a value of zero forces the logging of every command. (The default is
+# equivalent to 0.01 seconds.)
 slowlog-log-slower-than 10000
 
-# There is no limit to this length. Just be aware that it will consume memory.
-# You can reclaim memory used by the slow log with SLOWLOG RESET.
+# There is no limit to this length. Just be aware that every entry in the
+# slow log will consume memory. You can reclaim the memory used by the slow
+# log by calling SLOWLOG RESET.
 slowlog-max-len 1024
 
 ############################### ADVANCED CONFIG ###############################
 
-# Hashes are encoded in a special way (much more memory efficient) when they
-# have at max a given numer of elements, and the biggest element does not
-# exceed a given threshold. You can configure this limits with the following
-# configuration directives.
+# Hashes are encoded in a special way (which is much more memory efficient)
+# when they have at max a given number of elements, and the size of the largest
+# element does not exceed a given threshold. You can configure these limits
+# with the following configuration directives.
 hash-max-zipmap-entries 512
 hash-max-zipmap-value 64
 
 # Similarly to hashes, small lists are also encoded in a special way in order
 # to save a lot of space. The special representation is only used when
-# you are under the following limits:
+# a list is under the following limits:
 list-max-ziplist-entries 512
 list-max-ziplist-value 64
 
 # Sets have a special encoding in just one case: when a set is composed
-# of just strings that happens to be integers in radix 10 in the range
+# of just strings that happen to be integers in radix 10 in the range
 # of 64 bit signed integers.
 # The following configuration setting sets the limit in the size of the
 # set in order to use this special memory saving encoding.
@@ -375,7 +381,7 @@ zset-max-ziplist-value 64
 # order to help rehashing the main Redis hash table (the one mapping top-level
 # keys to values). The hash table implementation redis uses (see dict.c)
 # performs a lazy rehashing: the more operation you run into an hash table
-# that is rhashing, the more rehashing "steps" are performed, so if the
+# that is rehashing, the more rehashing "steps" are performed, so if the
 # server is idle the rehashing is never complete and some more memory is used
 # by the hash table.
 # 
@@ -384,8 +390,8 @@ zset-max-ziplist-value 64
 #
 # If unsure:
 # use "activerehashing no" if you have hard latency requirements and it is
-# not a good thing in your environment that Redis can reply form time to time
-# to queries with 2 milliseconds delay.
+# not a good thing in your environment that Redis can reply to queries with
+# a 2 millisecond delay from time to time.
 #
 # use "activerehashing yes" if you don't have such hard requirements but
 # want to free memory asap when possible.
@@ -394,8 +400,8 @@ activerehashing yes
 ################################## INCLUDES ###################################
 
 # Include one or more other config files here.  This is useful if you
-# have a standard template that goes to all redis server but also need
-# to customize a few per-server settings.  Include files can include
+# have a standard template that goes to all Redis servers, but you also need
+# to customize a few per-server settings. Include files can include
 # other files, so use this wisely.
 #
 # include /path/to/local.conf


### PR DESCRIPTION
Basically, exactly what it says on the tin. I went through the redis.conf file and corrected spelling errors, cleaned up some of the sentence structure, and made the use of punctuation more consistent (i.e. config directives and values always use double quotes, lists of possible options always have colons followed by complete sentences, etc etc).
