### PR TITLE
Fix for Issue 611 (redis get config dir will hang a client forever if the internal redis call to getcwd command fails)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -510,7 +510,7 @@ void configGetCommand(redisClient *c) {
 
         addReplyBulkCString(c,"dir");
         if (getcwd(buf,sizeof(buf)) == NULL) {
-            buf[0] = '\0';
+            addReplyErrorFormat(c,"Getting directory: %s", strerror(errno));
         } else {
             addReplyBulkCString(c,buf);
         }


### PR DESCRIPTION
Give an error message back to the client if getcwd which is part of configGetCommand fails.
