### PR TITLE
redis-cli segfaults with single numeric argument greater than zero

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -693,7 +693,7 @@ static void repl() {
                     int repeat, skipargs = 0;
 
                     repeat = atoi(argv[0]);
-                    if (repeat) {
+                    if (argc > 1 && repeat) {
                         skipargs = 1;
                     } else {
                         repeat = 1;


### PR DESCRIPTION
Fixed a small bug that caused redis-cli to segfault when given single numeric parameter greater than zero.  
