### PR TITLE
Memory leak in redis-check-dump

### DIFF
--- a/src/redis-check-dump.c
+++ b/src/redis-check-dump.c
@@ -600,6 +600,7 @@ void process() {
             /* advance position */
             positions[0] = positions[1];
         }
+        free(entry.key);
     }
 
     /* because there is another potential error,


### PR DESCRIPTION
I fixed a small memory leak I found with valgrind.
entry.key is not released in redis-check-dump.
Here is a patch to fix the leak:

```
*** src/redis-check-dump.c.orig 2011-10-18 20:25:55.000000000 +0900
--- src/redis-check-dump.c      2011-10-18 20:16:59.000000000 +0900
***************
*** 600,605 ****
--- 600,606 ----
              /* advance position */
              positions[0] = positions[1];
          }
+         free(entry.key);
      }

      /* because there is another potential error,
```

I am using 2.4.1.
When using redis as memcached with 50,000,000+ unique keys, it will be critical issue to check dumped file.
