### PR TITLE
2.4

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -75,6 +75,7 @@ void loadServerConfig(char *filename) {
         } else if (!strcasecmp(argv[0],"unixsocket") && argc == 2) {
             server.unixsocket = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"unixsocketperm") && argc == 2) {
+            errno = 0;
             server.unixsocketperm = (mode_t)strtol(argv[1], NULL, 8);
             if (errno || server.unixsocketperm > 0777) {
                 err = "Invalid socket file permissions"; goto loaderr;


### PR DESCRIPTION
I apologize, I screwed up in my commit by not setting errno to zero before checking it after the strtol call.  The other uses of it in config.c check to see if there was an err before checking errno, so it is safe to assume errno is set correctly.  In my case, it is not.  On my test system, it worked because there weren't any errors before I checked.  But on the two very different production Linux servers I use (Ubuntu 10.10 and CentOS 5.6), something is generating a "File/Directory not found" (errno == 2) before it gets to my code and thus it fails every time.  Here is the very simple fix.
