### PR TITLE
Add the ability to reset 'requirepass' by setting it to '' or ""

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -250,7 +250,11 @@ void loadServerConfig(char *filename) {
         {
             server.auto_aofrewrite_min_size = memtoll(argv[1],NULL);
         } else if (!strcasecmp(argv[0],"requirepass") && argc == 2) {
-            server.requirepass = zstrdup(argv[1]);
+            if (!strcasecmp(argv[1],"''") || !strcasecmp(argv[1],'""')) {
+                server.requirepass = NULL;
+            } else {
+                server.requirepass = zstrdup(argv[1]);
+            }
         } else if (!strcasecmp(argv[0],"pidfile") && argc == 2) {
             zfree(server.pidfile);
             server.pidfile = zstrdup(argv[1]);


### PR DESCRIPTION
It is currently not possible to reset the password by using CONFIG SET. Once setup via 

```
CONFIG SET requirepass secret
```

there is no way to get rid of it again. I'm not quite sure if this is perfect for every use-case, but I think setting it to an empty string should reset it.

```
CONFIG SET requirepass ""
```
