### PR TITLE
Fixing inject: it was failing when there was 1 or >2 sources

### DIFF
--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -319,7 +319,7 @@ class RedisTrib
         #    divisibility. Like we have 3 nodes and need to get 10 slots, we take
         #    4 from the first, and 3 from the rest. So the biggest is always the first.
         sources = sources.sort{|a,b| b.slots.length <=> a.slots.length}
-        source_tot_slots = sources.inject {|a,b| a.slots.length+b.slots.length}
+        source_tot_slots = sources.inject(0) {|sum,source| sum+source.slots.length}
         sources.each_with_index{|s,i|
             # Every node will provide a number of slots proportional to the
             # slots it has assigned.


### PR DESCRIPTION
I've been playing around with Redis Cluster and got this error when I used only one source during a reshard:

```
redis-trib.rb:327:in `/': ClusterNode can't be coerced into Float (TypeError)
from redis-trib.rb:327:in `block in compute_reshard_table'
from redis-trib.rb:324:in `each'
from redis-trib.rb:324:in `each_with_index'
from redis-trib.rb:324:in `compute_reshard_table'
from redis-trib.rb:434:in `reshard_cluster_cmd'
from redis-trib.rb:493:in `<main>'
```

This commit fixes this exception.
