### PR TITLE
Fix crash on SPARC due to improper alignment of allocated memory

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -38,7 +38,7 @@
 #ifdef HAVE_MALLOC_SIZE
 #define PREFIX_SIZE (0)
 #else
-#if defined(__sun)
+#if defined(__sun) || defined(__sparc) || defined(__sparc__)
 #define PREFIX_SIZE (sizeof(long long))
 #else
 #define PREFIX_SIZE (sizeof(size_t))


### PR DESCRIPTION
I believe that you should be able to drop 'defined(__sun)' completely
from this clause, as Solaris on x86 hardware probably does not have
strict alignment requirements, but I don't have a way to test that.

Thanks to Jurij Smakov jurij@wooyd.org.

Signed-off-by: Chris Lamb lamby@debian.org
