### PR TITLE
clean REDIS_DIRTY_CAS when discard Command runs. otherwise the next MULT...

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -57,7 +57,7 @@ void discardCommand(redisClient *c) {
 
     freeClientMultiState(c);
     initClientMultiState(c);
-    c->flags &= (~REDIS_MULTI);
+    c->flags &= ~(REDIS_MULTI|REDIS_DIRTY_CAS);;
     unwatchAllKeys(c);
     addReply(c,shared.ok);
 }


### PR DESCRIPTION
...I/EXEC may fail in the same RedisClient
