### PR TITLE
2.4: Fix building with tcmalloc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -35,12 +35,14 @@ else
 endif
 
 ifeq ($(USE_TCMALLOC),yes)
+  USE_JEMALLOC=no
   ALLOC_DEP=
   ALLOC_LINK=-ltcmalloc
   ALLOC_FLAGS=-DUSE_TCMALLOC
 endif
 
 ifeq ($(USE_TCMALLOC_MINIMAL),yes)
+  USE_JEMALLOC=no
   ALLOC_DEP=
   ALLOC_LINK=-ltcmalloc_minimal
   ALLOC_FLAGS=-DUSE_TCMALLOC


### PR DESCRIPTION
Since the 2.4 branch still uses the "old style" malloc checks, we need to set `USE_JEMALLOC=no` if `USE_TCMALLOC` is defined since `USE_JEMALLOC` gets set if Linux is the host os
