### PR TITLE
Having 10240 file descriptors is not enough for our current usage.

### DIFF
--- a/src/ae.h
+++ b/src/ae.h
@@ -33,7 +33,7 @@
 #ifndef __AE_H__
 #define __AE_H__
 
-#define AE_SETSIZE (1024*10)    /* Max number of fd supported */
+#define AE_SETSIZE (1024*100)    /* Max number of fd supported */
 
 #define AE_OK 0
 #define AE_ERR -1


### PR DESCRIPTION
Can we increase this limit. Better yet can it be made configurable?
