### PR TITLE
SORT with STORE removes key if result is empty. This fixes issue #227.

### DIFF
--- a/src/sort.c
+++ b/src/sort.c
@@ -367,9 +367,14 @@ void sortCommand(redisClient *c) {
                 }
             }
         }
-        if (outputlen) setKey(c->db,storekey,sobj);
+        if (outputlen) {
+            setKey(c->db,storekey,sobj);
+            server.dirty += outputlen;
+        } else if (dbDelete(c->db,storekey)) {
+            signalModifiedKey(c->db,storekey);
+            server.dirty++;
+        }
         decrRefCount(sobj);
-        server.dirty += outputlen;
         addReplyLongLong(c,outputlen);
     }
 

--- a/tests/unit/cas.tcl
+++ b/tests/unit/cas.tcl
@@ -25,6 +25,16 @@ start_server {tags {"cas"}} {
         r exec
     } {}
 
+    test {EXEC fail on WATCHed key modified by SORT with STORE even if the result is empty} {
+        r flushdb
+        r lpush foo bar
+        r watch foo
+        r sort emptylist store foo
+        r multi
+        r ping
+        r exec
+    } {}
+
     test {After successful EXEC key is no longer watched} {
         r set x 30
         r watch x

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -150,6 +150,13 @@ start_server {
         r exists zap
     } {0}
 
+    test "SORT with STORE removes key if result is empty (github issue 227)" {
+        r flushdb
+        r lpush foo bar
+        r sort emptylist store foo
+        r exists foo
+    } {0}
+
     tags {"slow"} {
         set num 100
         set res [create_random_dataset $num lpush]


### PR DESCRIPTION
Hi! I love redis, thank you for developing it. I've noticed this ticket lying around, so I coded a patch. Hope that helps.
