### PR TITLE
Force SIGSEGV without HAVE_BACKTRACE (unstable)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -25,7 +25,7 @@
 #endif
 
 /* Test for backtrace() */
-#if defined(__APPLE__) || defined(__linux__)
+#if defined(__APPLE__) || defined(__linux__) || defined(__sun)
 #define HAVE_BACKTRACE 1
 #endif
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -314,8 +314,8 @@ void _redisAssert(char *estr, char *file, int line) {
     server.assert_file = file;
     server.assert_line = line;
     redisLog(REDIS_WARNING,"(forcing SIGSEGV to print the bug report.)");
-    *((char*)-1) = 'x';
 #endif
+    *((char*)-1) = 'x';
 }
 
 void _redisAssertPrintClientInfo(redisClient *c) {
@@ -384,9 +384,9 @@ void _redisPanic(char *msg, char *file, int line) {
     redisLog(REDIS_WARNING,"Guru Meditation: %s #%s:%d",msg,file,line);
 #ifdef HAVE_BACKTRACE
     redisLog(REDIS_WARNING,"(forcing SIGSEGV in order to print the stack trace)");
+#endif
     redisLog(REDIS_WARNING,"------------------------------------------------");
     *((char*)-1) = 'x';
-#endif
 }
 
 void bugReportStart(void) {


### PR DESCRIPTION
When `HAVE_BACKTRACE` is not defined, both `redisAssert` and `redisPanic` should still segfault. Also, define `HAVE_BACKTRACE` on Solaris.
