### PR TITLE
fix redis-benchmark memory leak

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -196,6 +196,8 @@ static void readHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
                     exit(1);
                 }
 
+				freeReplyObject(reply);
+
                 if (config.requests_finished < config.requests)
                     config.latency[config.requests_finished++] = c->latency;
                 c->pending--;

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -196,7 +196,7 @@ static void readHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
                     exit(1);
                 }
 
-				freeReplyObject(reply);
+                freeReplyObject(reply);
 
                 if (config.requests_finished < config.requests)
                     config.latency[config.requests_finished++] = c->latency;


### PR DESCRIPTION
in redis-benchmark there's memory leak due to not freeing reply objects. 

Fun fact: with memory leak fixed I get even better numbers from benchmark, probably due to less work for memory allocator. Maybe time to retest those blogpost numbers ;-)
