### PR TITLE
use gcc sync builtins for memory counter when possible

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -67,18 +67,18 @@
 #endif
 
 #ifdef HAVE_ATOMIC
-#define update_zmalloc_stat_add(__n) __sync_add_and_fetch(&used_memory, __n)
-#define update_zmalloc_stat_sub(__n) __sync_sub_and_fetch(&used_memory, __n)
+#define update_zmalloc_stat_add(__n) __sync_add_and_fetch(&used_memory, (__n))
+#define update_zmalloc_stat_sub(__n) __sync_sub_and_fetch(&used_memory, (__n))
 #else
 #define update_zmalloc_stat_add(__n) do { \
     pthread_mutex_lock(&used_memory_mutex); \
-    used_memory += __n; \
+    used_memory += (__n); \
     pthread_mutex_unlock(&used_memory_mutex); \
 } while(0)
 
 #define update_zmalloc_stat_sub(__n) do { \
     pthread_mutex_lock(&used_memory_mutex); \
-    used_memory -= __n; \
+    used_memory -= (__n); \
     pthread_mutex_unlock(&used_memory_mutex); \
 } while(0)
 


### PR DESCRIPTION
Implementation of issue #357. Currently allow __sync builtins only for GCC && (i386||amd64), but for other architectures and/or clang it should be OK too.

It has huge performance benefits. Tested on otherwise idle machine, 1 run for heatup, result is best of 3 test (best by SET performance) with: ./redis-benchmark -q -P 16 -n 10000000 -t set,get,incr,lpush,lpop,sadd,spop

before:
SET: 715870.88 requests per second
GET: 929627.25 requests per second
INCR: 765931.38 requests per second
LPUSH: 773993.81 requests per second
LPOP: 770653.50 requests per second
SADD: 796178.31 requests per second
SPOP: 1056747.25 requests per second

with sync builtins:
SET: 832986.25 requests per second 
GET: 1110864.25 requests per second
INCR: 911743.25 requests per second
LPUSH: 941353.62 requests per second
LPOP: 961723.44 requests per second
SADD: 1015228.38 requests per second
SPOP: 1317523.00 requests per second
