### PR TITLE
fix typo of redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -246,7 +246,7 @@ slave-serve-stale-data yes
 # volatile-lru -> remove the key with an expire set using an LRU algorithm
 # allkeys-lru -> remove any key accordingly to the LRU algorithm
 # volatile-random -> remove a random key with an expire set
-# allkeys->random -> remove a random key, any key
+# allkeys-random -> remove a random key, any key
 # volatile-ttl -> remove the key with the nearest expire time (minor TTL)
 # noeviction -> don't expire at all, just return an error on write operations
 # 


### PR DESCRIPTION
Due to a typo,  copy&paste did't work.
