### PR TITLE
2.6

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -443,6 +443,13 @@ set-max-intset-entries 512
 zset-max-ziplist-entries 128
 zset-max-ziplist-value 64
 
+# The INCRBYFLOAT and HINCRBYFLOAT commands save the result encoded as 
+# a string (as a decimal or in scientific notation) with some maximum decimal
+# precision. The internal precision of these commands is machine-dependent, 
+# but for most machines is at least 19 decimal digits. A value less than the
+# internal precision will round the result and hide floating point imprecision.
+# incrbyfloat-precision 17
+
 # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
 # order to help rehashing the main Redis hash table (the one mapping top-level
 # keys to values). The hash table implementation Redis uses (see dict.c)

--- a/src/config.c
+++ b/src/config.c
@@ -278,6 +278,8 @@ void loadServerConfigFromString(char *config) {
             server.zset_max_ziplist_entries = memtoll(argv[1], NULL);
         } else if (!strcasecmp(argv[0],"zset-max-ziplist-value") && argc == 2) {
             server.zset_max_ziplist_value = memtoll(argv[1], NULL);
+        } else if (!strcasecmp(argv[0],"incrbyfloat-precision") && argc == 2) {
+            longDoubleFormatString(atoi(argv[1]), server.string_from_long_double_format);
         } else if (!strcasecmp(argv[0],"rename-command") && argc == 3) {
             struct redisCommand *cmd = lookupCommand(argv[1]);
             int retval;
@@ -542,6 +544,9 @@ void configSetCommand(redisClient *c) {
     } else if (!strcasecmp(c->argv[2]->ptr,"zset-max-ziplist-value")) {
         if (getLongLongFromObject(o,&ll) == REDIS_ERR || ll < 0) goto badfmt;
         server.zset_max_ziplist_value = ll;
+    } else if (!strcasecmp(c->argv[2]->ptr,"incrbyfloat-precision")) {
+        if (getLongLongFromObject(o,&ll) == REDIS_ERR || ll < 0) goto badfmt;
+        longDoubleFormatString((int)ll, server.string_from_long_double_format);
     } else if (!strcasecmp(c->argv[2]->ptr,"lua-time-limit")) {
         if (getLongLongFromObject(o,&ll) == REDIS_ERR || ll < 0) goto badfmt;
         server.lua_time_limit = ll;

--- a/src/object.c
+++ b/src/object.c
@@ -56,16 +56,7 @@ robj *createStringObjectFromLongDouble(long double value) {
      * that is "non surprising" for the user (that is, most small decimal
      * numbers will be represented in a way that when converted back into
      * a string are exactly the same as what the user typed.) */
-    len = snprintf(buf,sizeof(buf),"%.17Lf", value);
-    /* Now remove trailing zeroes after the '.' */
-    if (strchr(buf,'.') != NULL) {
-        char *p = buf+len-1;
-        while(*p == '0') {
-            p--;
-            len--;
-        }
-        if (*p == '.') len--;
-    }
+    len = snprintf(buf,sizeof(buf),"%.17Lg", value);
     return createStringObject(buf,len);
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -51,12 +51,7 @@ robj *createStringObjectFromLongDouble(long double value) {
     char buf[256];
     int len;
 
-    /* We use 17 digits precision since with 128 bit floats that precision
-     * after rouding is able to represent most small decimal numbers in a way
-     * that is "non surprising" for the user (that is, most small decimal
-     * numbers will be represented in a way that when converted back into
-     * a string are exactly the same as what the user typed.) */
-    len = snprintf(buf,sizeof(buf),"%.17Lg", value);
+    len = snprintf(buf,sizeof(buf), server.string_from_long_double_format, value);
     return createStringObject(buf,len);
 }
 

--- a/src/redis.c
+++ b/src/redis.c
@@ -1038,6 +1038,7 @@ void initServerConfig() {
     server.set_max_intset_entries = REDIS_SET_MAX_INTSET_ENTRIES;
     server.zset_max_ziplist_entries = REDIS_ZSET_MAX_ZIPLIST_ENTRIES;
     server.zset_max_ziplist_value = REDIS_ZSET_MAX_ZIPLIST_VALUE;
+    longDoubleFormatString(REDIS_STRING_MAX_FLOAT_DIGITS_AFTER_DECIMAL, server.string_from_long_double_format);
     server.shutdown_asap = 0;
     server.repl_ping_slave_period = REDIS_REPL_PING_SLAVE_PERIOD;
     server.repl_timeout = REDIS_REPL_TIMEOUT;

--- a/src/redis.h
+++ b/src/redis.h
@@ -216,6 +216,15 @@
 #define REDIS_ZSET_MAX_ZIPLIST_ENTRIES 128
 #define REDIS_ZSET_MAX_ZIPLIST_VALUE 64
 
+/* Floating point to string conversions */
+/* We use 17 digits precision since with 80 bit floats (the default long
+ * double on x86) that precision) after rouding is able to represent most
+ * small decimal numbers in a way that is "non surprising" for the user
+ * (that is, most small decimal numbers will be represented in a way that
+ * when converted back into a string are exactly the same as what
+ * the user typed.) */
+#define REDIS_STRING_MAX_FLOAT_DIGITS_AFTER_DECIMAL 17
+
 /* Sets operations codes */
 #define REDIS_OP_UNION 0
 #define REDIS_OP_DIFF 1
@@ -567,6 +576,8 @@ struct redisServer {
     size_t set_max_intset_entries;
     size_t zset_max_ziplist_entries;
     size_t zset_max_ziplist_value;
+    /* INCRBYFLOAT and HINCRBYFLOAT precision */
+    char string_from_long_double_format[128]; /* format string for LongDoubleObject to stringObject conversion */
     time_t unixtime;        /* Unix time sampled every second. */
     /* Pubsub */
     dict *pubsub_channels;  /* Map channels to list of subscribed clients */
@@ -694,6 +705,7 @@ extern dictType hashDictType;
 long long ustime(void);
 long long mstime(void);
 void getRandomHexChars(char *p, unsigned int len);
+void longDoubleFormatString(int precision, char *format);
 
 /* networking.c -- Networking and Client related operations */
 redisClient *createClient(int fd);

--- a/src/util.c
+++ b/src/util.c
@@ -329,6 +329,12 @@ int d2string(char *buf, size_t len, double value) {
     return len;
 }
 
+/* Generate format string for sprintf conversion of long double to string 
+ * with given amount for precision past the decimal point */
+void longDoubleFormatString(int precision, char *format) {
+    snprintf(format, 128, "%%.%iLf", precision);
+}
+
 /* Generate the Redis "Run ID", a SHA1-sized random number that identifies a
  * given execution of Redis, so that if you are talking with an instance
  * having run_id == A, and you reconnect and it has run_id == B, you can be


### PR DESCRIPTION
Fixed INCRBYFLOAT and HINCRBYFLOAT encoding to use scientific notation when necessary.
Removed hardcoded 17-digit precision limit, added _incrbyfloat-precision_ config (Defaulting to 17). Different machines will perform double double arithmetic with different levels of precision; it therefore seems fitting to let the user decide with what precision redis should store double doubles.
