### PR TITLE
chkconfig in install_server.sh doesn't work because of a typo

### DIFF
--- a/utils/install_server.sh
+++ b/utils/install_server.sh
@@ -166,7 +166,7 @@ if [[ ! `which chkconfig` ]] ; then
 else
 	# we're chkconfig, so lets add to chkconfig and put in runlevel 345
 	chkconfig --add redis_$REDIS_PORT && echo "Successfully added to chkconfig!"
-	chkconfig--level 345 redis_$REDIS_PORT on && echo "Successfully added to runlevels 345!"
+	chkconfig --level 345 redis_$REDIS_PORT on && echo "Successfully added to runlevels 345!"
 fi
 	
 /etc/init.d/redis_$REDIS_PORT start || die "Failed starting service..."


### PR DESCRIPTION
In install_server.sh, the chkconfig command that set redis to start on runlevels 3, 4, and 5 never executes because of a missing space.
