### PR TITLE
Add lcov support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -226,10 +226,10 @@ redis-check-aof: .make-prerequisites $(CHECKAOFOBJ)
 %.o: %.c .make-prerequisites
 	$(QUIET_CC)$(CC) -c $(CFLAGS) $(DEBUG) $(COMPILE_TIME) -I../deps/lua/src $<
 
-.PHONY: all clean distclean
+.PHONY: all clean distclean lcov
 
 clean:
-	rm -rf $(PRGNAME) $(BENCHPRGNAME) $(CLIPRGNAME) $(CHECKDUMPPRGNAME) $(CHECKAOFPRGNAME) *.o *.gcda *.gcno *.gcov
+	rm -rf $(PRGNAME) $(BENCHPRGNAME) $(CLIPRGNAME) $(CHECKDUMPPRGNAME) $(CHECKAOFPRGNAME) *.o *.gcda *.gcno *.gcov redis.info lcov-html
 
 distclean: clean
 	-(cd ../deps && $(MAKE) distclean)
@@ -240,6 +240,12 @@ dep:
 
 test: redis-server redis-check-aof
 	@(cd ..; ./runtest)
+
+lcov:
+	$(MAKE) clean gcov
+	@(set -e; cd ..; ./runtest --clients 1)
+	@geninfo -o redis.info .
+	@genhtml --legend -o lcov-html redis.info
 
 bench:
 	./redis-benchmark

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -97,7 +97,7 @@ start_server {tags {"repl"}} {
                     [lindex $slaves 2] slaveof $master_host $master_port
 
                     # Wait for all the three slaves to reach the "online" state
-                    set retry 100
+                    set retry 500
                     while {$retry} {
                         set info [r -3 info]
                         if {[string match {*slave0:*,online*slave1:*,online*slave2:*,online*} $info]} {

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -46,11 +46,16 @@ proc kill_server config {
     }
 
     # kill server and wait for the process to be totally exited
+    catch {exec kill $pid}
     while {[is_alive $config]} {
-        if {[incr wait 10] % 1000 == 0} {
+        incr wait 10
+
+        if {$wait >= 5000} {
+            puts "Forcing process $pid to exit..."
+            catch {exec kill -KILL $pid}
+        } elseif {$wait % 1000 == 0} {
             puts "Waiting for process $pid to exit..."
         }
-        catch {exec kill $pid}
         after 10
     }
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -345,6 +345,7 @@ proc print_help_screen {} {
         "--quiet            Don't show individual tests."
         "--single <unit>    Just execute the specified unit (see next option)."
         "--list-tests       List all the available test units."
+        "--clients <num>    Number of test clients (16)."
         "--force-failure    Force the execution of a test that always fails."
         "--help             Print this help screen."
     } "\n"]
@@ -389,6 +390,9 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     } elseif {$opt eq {--client}} {
         set ::client 1
         set ::test_server_port $arg
+        incr j
+    } elseif {$opt eq {--clients}} {
+        set ::numclients $arg
         incr j
     } elseif {$opt eq {--help}} {
         print_help_screen


### PR DESCRIPTION
This contains few changes to testsuite (regarding how the redis is ended, because for coverage/profiling there's need to exit cleanly). LCOV report can be generated by simply "make lcov", source is then cleaned, builded with coverage support, test suite is run in single-client mode and lcov report is generated and saved to src/lcov-html directory.

This report is standalone set of static html files, it would be nice to have them as part of redis CI :-)
