### PR TITLE
Handle exit without _exit

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -794,6 +794,10 @@ int rewriteAppendOnlyFileBackground(void) {
     long long start;
 
     if (server.aof_child_pid != -1) return REDIS_ERR;
+
+    /* Flush all output buffers before fork() */
+    fflush(NULL);
+
     start = ustime();
     if ((childpid = fork()) == 0) {
         char tmpfile[256];
@@ -803,9 +807,9 @@ int rewriteAppendOnlyFileBackground(void) {
         if (server.sofd > 0) close(server.sofd);
         snprintf(tmpfile,256,"temp-rewriteaof-bg-%d.aof", (int) getpid());
         if (rewriteAppendOnlyFile(tmpfile) == REDIS_OK) {
-            _exit(0);
+            exit(0);
         } else {
-            _exit(1);
+            exit(1);
         }
     } else {
         /* Parent */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -683,6 +683,9 @@ int rdbSaveBackground(char *filename) {
 
     server.dirty_before_bgsave = server.dirty;
 
+    /* Flush all output buffers before fork() */
+    fflush(NULL);
+
     start = ustime();
     if ((childpid = fork()) == 0) {
         int retval;
@@ -691,7 +694,7 @@ int rdbSaveBackground(char *filename) {
         if (server.ipfd > 0) close(server.ipfd);
         if (server.sofd > 0) close(server.sofd);
         retval = rdbSave(filename);
-        _exit((retval == REDIS_OK) ? 0 : 1);
+        exit((retval == REDIS_OK) ? 0 : 1);
     } else {
         /* Parent */
         server.stat_fork_time = ustime()-start;

--- a/src/redis.c
+++ b/src/redis.c
@@ -2271,6 +2271,9 @@ void createPidFile(void) {
 void daemonize(void) {
     int fd;
 
+    /* Flush output buffers before fork  */
+    fflush(NULL);
+
     if (fork() != 0) exit(0); /* parent exits */
     setsid(); /* create a new session */
 


### PR DESCRIPTION
Instead of using _exit in rdb/aof childs, just flush buffers of buffered IO before fork, then exit() is just fine. It's much cleaner aproach and it also fixe issue with not generating coverage from those slaves.
