### PR TITLE
Fixed installation script for the chkconfig check, fixed init.d template...

### DIFF
--- a/utils/install_server.sh
+++ b/utils/install_server.sh
@@ -146,12 +146,12 @@ REDIS_CHKCONFIG_INFO=\
 # Description: Redis daemon\n
 ### END INIT INFO\n\n"
 
-if [[ ! `which chkconfig` ]] ; then 
+if [ ! `which chkconfig` ] ; then 
 	#combine the header and the template (which is actually a static footer)
-	echo -e $REDIS_INIT_HEADER > $TMP_FILE && cat $INIT_TPL_FILE >> $TMP_FILE || die "Could not write init script to $TMP_FILE"
+	echo -n $REDIS_INIT_HEADER > $TMP_FILE && cat $INIT_TPL_FILE >> $TMP_FILE || die "Could not write init script to $TMP_FILE"
 else
 	#if we're a box with chkconfig on it we want to include info for chkconfig
-	echo -e $REDIS_INIT_HEADER $REDIS_CHKCONFIG_INFO > $TMP_FILE && cat $INIT_TPL_FILE >> $TMP_FILE || die "Could not write init script to $TMP_FILE"
+	echo -n $REDIS_INIT_HEADER $REDIS_CHKCONFIG_INFO > $TMP_FILE && cat $INIT_TPL_FILE >> $TMP_FILE || die "Could not write init script to $TMP_FILE"
 fi
 
 #copy to /etc/init.d
@@ -160,7 +160,7 @@ echo "Copied $TMP_FILE => $INIT_SCRIPT_DEST"
 
 #Install the service
 echo "Installing service..."
-if [[ ! `which chkconfig` ]] ; then 
+if [ ! `which chkconfig` ] ; then 
 	#if we're not a chkconfig box assume we're able to use update-rc.d
 	update-rc.d redis_$REDIS_PORT defaults && echo "Success!"
 else


### PR DESCRIPTION
The current state doesnt allow a clean installation of redis on an ubuntu box.

As fixed, it's a smooth process.

Tested on Ubuntu 10.04.
