### PR TITLE
Replace some unnecessary calls to echo and cat in tests

### DIFF
--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -35,7 +35,7 @@ tags {"aof"} {
             set pattern "*Unexpected end of file reading the append only file*"
             set retry 10
             while {$retry} {
-                set result [exec cat [dict get $srv stdout] | tail -n1]
+                set result [exec tail -n1 < [dict get $srv stdout]]
                 if {[string match $pattern $result]} {
                     break
                 }
@@ -59,7 +59,7 @@ tags {"aof"} {
             set pattern "*Bad file format reading the append only file*"
             set retry 10
             while {$retry} {
-                set result [exec cat [dict get $srv stdout] | tail -n1]
+                set result [exec tail -n1 < [dict get $srv stdout]]
                 if {[string match $pattern $result]} {
                     break
                 }
@@ -81,7 +81,7 @@ tags {"aof"} {
     }
 
     test "Short read: Utility should be able to fix the AOF" {
-        set result [exec echo y | src/redis-check-aof --fix $aof_path]
+        set result [exec src/redis-check-aof --fix $aof_path << "y\n"]
         assert_match "*Successfully truncated AOF*" $result
     }
 

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -252,7 +252,7 @@ proc start_server {options {code undefined}} {
 
         while 1 {
             # check that the server actually started and is ready for connections
-            if {[exec cat $stdout | grep "ready to accept" | wc -l] > 0} {
+            if {[exec grep "ready to accept" | wc -l < $stdout] > 0} {
                 break
             }
             after 10

--- a/tests/unit/aofrw.tcl
+++ b/tests/unit/aofrw.tcl
@@ -7,7 +7,7 @@ start_server {tags {"aofrw"}} {
         r bgrewriteaof
         r config set appendonly no
         r exec
-        set result [exec cat [srv 0 stdout] | tail -n1]
+        set result [exec tail -n1 < [srv 0 stdout] ]
     } {*Killing*AOF*child*}
 
     foreach d {string int} {


### PR DESCRIPTION
Tcl's exec can send data to stdout itself, no need to call cat/echo for that usually.

See also this message at stackoverflow:  http://stackoverflow.com/questions/10188886/redis-error-when-running-tcl-helper-script-on-windows-7-32bit-edition 

There are quite a few [exec cat $something] calls in the tests that could be replaced by simple open/read/close calls too.
