### PR TITLE
Proposal for src/redis.c:

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1664,7 +1664,7 @@ int prepareForShutdown(int flags) {
             return REDIS_ERR;
         }
     }
-    if (server.daemonize) {
+    if (server.daemonize || server.pidfile) {
         redisLog(REDIS_NOTICE,"Removing the pid file.");
         unlink(server.pidfile);
     }
@@ -2443,7 +2443,7 @@ int main(int argc, char **argv) {
     }
     if (server.daemonize) daemonize();
     initServer();
-    if (server.daemonize) createPidFile();
+    if (server.daemonize || server.pidfile) createPidFile();
     redisAsciiArt();
     redisLog(REDIS_WARNING,"Server started, Redis version " REDIS_VERSION);
 #ifdef __linux__


### PR DESCRIPTION
If the config file has either specified "daemonize yes" or "pidfile [/path/to/redis.pid]" then it should create  pidfile.

Some background for this is: I usually run redis via daemontools. That entails running redis-server on the foreground. Given that, I'd also want redis-server to create a pidfile so other processes (e.g. nagios) can run checks for that.
