### PR TITLE
Create temporary rdb and aof files in the target directories.

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -687,7 +687,8 @@ int rewriteAppendOnlyFile(char *filename) {
 
     /* Note that we have to use a different temp name here compared to the
      * one used by rewriteAppendOnlyFileBackground() function. */
-    snprintf(tmpfile,256,"temp-rewriteaof-%d.aof", (int) getpid());
+    copydir(tmpfile, server.aof_filename, sizeof(tmpfile));
+    snprintf(tmpfile+strlen(tmpfile),256,"temp-rewriteaof-%d.aof", (int) getpid());
     fp = fopen(tmpfile,"w");
     if (!fp) {
         redisLog(REDIS_WARNING, "Opening the temp file for AOF rewrite in rewriteAppendOnlyFile(): %s", strerror(errno));
@@ -801,7 +802,8 @@ int rewriteAppendOnlyFileBackground(void) {
         /* Child */
         if (server.ipfd > 0) close(server.ipfd);
         if (server.sofd > 0) close(server.sofd);
-        snprintf(tmpfile,256,"temp-rewriteaof-bg-%d.aof", (int) getpid());
+        copydir(tmpfile,server.aof_filename,sizeof(tmpfile));
+        snprintf(tmpfile+strlen(tmpfile),256-strlen(tmpfile),"temp-rewriteaof-bg-%d.aof", (int) getpid());
         if (rewriteAppendOnlyFile(tmpfile) == REDIS_OK) {
             exitFromChild(0);
         } else {
@@ -847,7 +849,8 @@ void bgrewriteaofCommand(redisClient *c) {
 void aofRemoveTempFile(pid_t childpid) {
     char tmpfile[256];
 
-    snprintf(tmpfile,256,"temp-rewriteaof-bg-%d.aof", (int) childpid);
+    copydir(tmpfile,server.aof_filename,sizeof(tmpfile));    
+    snprintf(tmpfile+strlen(tmpfile),256-strlen(tmpfile),"temp-rewriteaof-bg-%d.aof", (int) childpid);
     unlink(tmpfile);
 }
 
@@ -880,7 +883,8 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
 
         /* Flush the differences accumulated by the parent to the
          * rewritten AOF. */
-        snprintf(tmpfile,256,"temp-rewriteaof-bg-%d.aof",
+        copydir(tmpfile,server.aof_filename,sizeof(tmpfile));
+        snprintf(tmpfile+strlen(tmpfile),256-strlen(tmpfile),"temp-rewriteaof-bg-%d.aof",
             (int)server.aof_child_pid);
         newfd = open(tmpfile,O_WRONLY|O_APPEND);
         if (newfd == -1) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -605,7 +605,8 @@ int rdbSave(char *filename) {
     rio rdb;
     uint64_t cksum;
 
-    snprintf(tmpfile,256,"temp-%d.rdb", (int) getpid());
+    copydir(tmpfile, server.rdb_filename, sizeof(tmpfile));
+    snprintf(tmpfile+strlen(tmpfile),256-strlen(tmpfile),"temp-%d.rdb", (int) getpid());
     fp = fopen(tmpfile,"w");
     if (!fp) {
         redisLog(REDIS_WARNING, "Failed opening .rdb for saving: %s",
@@ -718,7 +719,8 @@ int rdbSaveBackground(char *filename) {
 void rdbRemoveTempFile(pid_t childpid) {
     char tmpfile[256];
 
-    snprintf(tmpfile,256,"temp-%d.rdb", (int) childpid);
+    copydir(tmpfile, server.rdb_filename, sizeof(tmpfile));
+    snprintf(tmpfile+strlen(tmpfile),256-strlen(tmpfile),"temp-%d.rdb", (int) childpid);
     unlink(tmpfile);
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -375,6 +375,28 @@ void getRandomHexChars(char *p, unsigned int len) {
     fclose(fp);
 }
 
+/* Copy directory part of filename */
+int copydir(char *target, const char *src, int target_len)
+{
+    const char *p;
+    int len;
+    
+    if (!(p = strrchr(src, '/'))) {
+        *target = '\0';
+        return 0;
+    }
+
+    len = p - src + 1;
+    if (len >= target_len)
+        len = target_len - 1;
+    
+    memcpy(target, src, len);
+    target[len] = '\0';
+
+    return len;
+}
+
+
 #ifdef UTIL_TEST_MAIN
 #include <assert.h>
 

--- a/src/util.h
+++ b/src/util.h
@@ -8,5 +8,7 @@ int ll2string(char *s, size_t len, long long value);
 int string2ll(const char *s, size_t slen, long long *value);
 int string2l(const char *s, size_t slen, long *value);
 int d2string(char *buf, size_t len, double value);
+int copydir(char *target, const char *src, int target_len);
+
 
 #endif


### PR DESCRIPTION
It is useful to specify a full path for rdb and aof files, however the temporary files still get created in the current directory and this can later lead to very slow rename operations (that require re-copying the temporary file to a different filesystem).
