### PR TITLE
Show problem with 'keys' command with specific command sequence.

### DIFF
--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -141,4 +141,15 @@ start_server {tags {"expire"}} {
         set size2 [r dbsize]
         list $size1 $size2
     } {3 0}
+
+    test {5 keys in, 5 keys out} {
+        r flushdb
+        r set a c
+        r expire a 5
+        r set t c
+        r set e c
+        r set s c
+        r set foo b
+        lsort [r keys *]
+    } {a e foo s t}
 }


### PR DESCRIPTION
Hi Redis,

we encountered a small problem when the 'keys' command is misbehaving. Or at least not behaving as we expect. This test has the minimal sequence we need to reproduce.

Piping this to redis-cli gives similar results:

flushall
set a c
set t c
set e c
set s c
set foo b
expire s 5
keys *
