### PR TITLE
Compare integers in ziplist regardless of encoding

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -773,12 +773,11 @@ unsigned int ziplistCompare(unsigned char *p, unsigned char *sstr, unsigned int 
             return 0;
         }
     } else {
-        /* Try to compare encoded values */
+        /* Try to compare encoded values. Don't compare encoding because
+         * different implementations may encoded integers differently. */
         if (zipTryEncoding(sstr,slen,&sval,&sencoding)) {
-            if (entry.encoding == sencoding) {
-                zval = zipLoadInteger(p+entry.headersize,entry.encoding);
-                return zval == sval;
-            }
+          zval = zipLoadInteger(p+entry.headersize,entry.encoding);
+          return zval == sval;
         }
     }
     return 0;


### PR DESCRIPTION
Because of the introduction of new integer encoding types for ziplists in the 2.6 tree, the same integer value may have a different encoding in different versions of the ziplist implementation. This means that the encoding can NOT be used as a fast path in comparing integers.

This results in problems for users running 2.6 RC code, who loaded a data set produced by a 2.4 instance, which contains ziplist encoded sorted sets, where the members are integers in the following ranges:
- `[0, 12]` (immediate encoding)
- `[-2**8, 2**8-1]` (8 bit signed)
- `[-2**24, -2**16-1]`, `[2**16, 2**24-1]` (24 bit signed not in 16 bit signed range)

If so, sorted set code may be unable to find members resulting in duplicate members in sorted sets. While duplicate members in sorted sets are incorrect to begin with, it inevitably leads to a crash.
