### PR TITLE
Set fd to writable when poll(2) detects POLLERR or POLLHUP event. 

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -385,6 +385,8 @@ int aeWait(int fd, int mask, long long milliseconds) {
     if ((retval = poll(&pfd, 1, milliseconds))== 1) {
         if (pfd.revents & POLLIN) retmask |= AE_READABLE;
         if (pfd.revents & POLLOUT) retmask |= AE_WRITABLE;
+	if (pfd.revents & POLLERR) retmask |= AE_WRITABLE;
+        if (pfd.revents & POLLHUP) retmask |= AE_WRITABLE;
         return retmask;
     } else {
         return retval;


### PR DESCRIPTION
This fixes issue #518
