### PR TITLE
Fixes for issue #532 (MIGRATE fails for hashes) in 2.6

### DIFF
--- a/src/rdb.h
+++ b/src/rdb.h
@@ -54,7 +54,7 @@
 #define REDIS_RDB_TYPE_HASH_ZIPLIST  13
 
 /* Test if a type is an object type. */
-#define rdbIsObjectType(t) ((t >= 0 && t <= 4) || (t >= 9 && t <= 12))
+#define rdbIsObjectType(t) ((t >= 0 && t <= 4) || (t >= 9 && t <= 13))
 
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
 #define REDIS_RDB_OPCODE_EXPIRETIME_MS 252

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -91,6 +91,26 @@ start_server {tags {"dump"}} {
         }
     }
 
+    test {MIGRATE can correctly transfer hashes} {
+        set first [srv 0 client]
+        r del key
+        r hmset key field1 "item 1" field2 "item 2" field3 "item 3" \
+                    field4 "item 4" field5 "item 5" field6 "item 6"
+        start_server {tags {"repl"}} {
+            set second [srv 0 client]
+            set second_host [srv 0 host]
+            set second_port [srv 0 port]
+
+            assert {[$first exists key] == 1}
+            assert {[$second exists key] == 0}
+            set ret [r -1 migrate $second_host $second_port key 9 10000]
+            assert {$ret eq {OK}}
+            assert {[$first exists key] == 0}
+            assert {[$second exists key] == 1}
+            assert {[$second ttl key] == -1}
+        }
+    }
+
     test {MIGRATE timeout actually works} {
         set first [srv 0 client]
         r set key "Some Value"


### PR DESCRIPTION
Update fixes issue #532 (MIGRATE fails for hashes) as described in this comment
https://github.com/antirez/redis/issues/532#issuecomment-6073545
and adds unit test for the case.
