### PR TITLE
reset ops per sec samples and timer as well

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -887,6 +887,9 @@ void configCommand(redisClient *c) {
         server.stat_rejected_conn = 0;
         server.stat_fork_time = 0;
         server.aof_delayed_fsync = 0;
+        server.ops_sec_last_sample_time = mstime();
+        server.ops_sec_last_sample_ops = 0;
+        memset(server.ops_sec_samples, 0, sizeof server.ops_sec_samples);
         resetCommandTableStats();
         addReply(c,shared.ok);
     } else {


### PR DESCRIPTION
Both ops per sec samples and timer were not reset by "CONFIG RESETSTAT"
which means:
    1) sometimes user can see negative value for instanteneous ops per
    sec stat
    2) that same value can show measurements from before RESETSTAT

This commit fixes both issues
