### PR TITLE
Force no external diff tools for dirty flag computation

### DIFF
--- a/src/mkreleasehdr.sh
+++ b/src/mkreleasehdr.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 GIT_SHA1=`(git show-ref --head --hash=8 2> /dev/null || echo 00000000) | head -n1`
-GIT_DIRTY=`git diff 2> /dev/null | wc -l`
+GIT_DIRTY=`git diff --no-ext-diff 2> /dev/null | wc -l`
 test -f release.h || touch release.h
 (cat release.h | grep SHA1 | grep $GIT_SHA1) && \
 (cat release.h | grep DIRTY | grep $GIT_DIRTY) && exit 0 # Already uptodate


### PR DESCRIPTION
When an external diff tool is defined the make process gets hung waiting for the diff tool to exit. It never shows up anywhere (probably due to running under `...`).
