### PR TITLE
Support cross-compiling for uClibc targets

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -139,7 +139,7 @@ persist-settings: distclean
 	echo REDIS_LDFLAGS=$(REDIS_LDFLAGS) >> .make-settings
 	echo PREV_FINAL_CFLAGS=$(FINAL_CFLAGS) >> .make-settings
 	echo PREV_FINAL_LDFLAGS=$(FINAL_LDFLAGS) >> .make-settings
-	-(cd ../deps && $(MAKE) $(DEPENDENCY_TARGETS))
+	-(cd ../deps && $(MAKE) CC=$(CC) $(DEPENDENCY_TARGETS))
 
 .PHONY: persist-settings
 

--- a/src/config.h
+++ b/src/config.h
@@ -30,6 +30,10 @@
 #ifndef __CONFIG_H
 #define __CONFIG_H
 
+#ifdef __unix
+#include <features.h>
+#endif
+
 #ifdef __APPLE__
 #include <AvailabilityMacros.h>
 #endif
@@ -56,7 +60,7 @@
 #endif
 
 /* Test for backtrace() */
-#if defined(__APPLE__) || defined(__linux__)
+#if (defined(__APPLE__) || defined(__linux__)) && !defined(__UCLIBC__)
 #define HAVE_BACKTRACE 1
 #endif
 


### PR DESCRIPTION
Disable backtrace support in src/config.h if uClibc is detected.

Tested on the following platforms:
- sh4-linux-uclibc (GCC 4.1.1, uClibc 0.9.29)
- mipsel-linux-uclibc (GCC 4.4.5, uClibc 0.9.29)

To cross-compile:

```
$ make CC=mipsel-linux-gcc MALLOC=libc
```

edit: updated commit message to include `__UCLIBC_SUBLEVEL__` in version
