### PR TITLE
Implement dropping user/group privileges for redis-server.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -225,6 +225,9 @@ void loadServerConfigFromString(char *config) {
             if ((server.daemonize = yesnotoi(argv[1])) == -1) {
                 err = "argument must be 'yes' or 'no'"; goto loaderr;
             }
+		} else if (!strcasecmp(argv[0],"user") && argc == 2) {
+			zfree(server.user);
+			server.user = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"appendonly") && argc == 2) {
             int yes;
 

--- a/src/redis.h
+++ b/src/redis.h
@@ -622,6 +622,7 @@ struct redisServer {
     size_t client_max_querybuf_len; /* Limit for client query buffer length */
     int dbnum;                      /* Total number of configured DBs */
     int daemonize;                  /* True if running as a daemon */
+    char *user;                     /* username to drop privileges down to (if started as root) */
     clientBufferLimitsConfig client_obuf_limits[REDIS_CLIENT_LIMIT_NUM_CLASSES];
     /* AOF persistence */
     int aof_state;                  /* REDIS_AOF_(ON|OFF|WAIT_REWRITE) */


### PR DESCRIPTION
It is not a good advice to just invoke sudo or su to run redis-server
in non-root, nor is it good to run it just as root.
However, there are environments/circumstances, where
start-stop-daemon/startproc are not meant to be used,
e.g. when writing platform independant resource agents,
or, when you have to keep the dependencies as low as possible.

This patch adds a new configuration variable "user" that gets one
string argument, and the redis-server tries to drop its
group and user privileges down to this user and this user's groups
and exits early on failure.

I would also like to get this commit cherry-picked to 2.x branches,
especially 2.2, since this is, what Ubuntu 12.04 is shipping with.
