### PR TITLE
mark fd as writable when EPOLLERR or EPOLLHUP is returned by epoll_wait.

### DIFF
--- a/src/ae_epoll.c
+++ b/src/ae_epoll.c
@@ -89,6 +89,8 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
 
             if (e->events & EPOLLIN) mask |= AE_READABLE;
             if (e->events & EPOLLOUT) mask |= AE_WRITABLE;
+            if (e->events & EPOLLERR) mask |= AE_WRITABLE;
+            if (e->events & EPOLLHUP) mask |= AE_WRITABLE;
             eventLoop->fired[j].fd = e->data.fd;
             eventLoop->fired[j].mask = mask;
         }


### PR DESCRIPTION
Similar with pull request #520,  to prevent high cpu load as issue #518
