### PR TITLE
BITCOUNT: fix segmentation fault.

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -357,7 +357,7 @@ void bitcountCommand(redisClient *c) {
         if (end < 0) end = strlen+end;
         if (start < 0) start = 0;
         if (end < 0) end = 0;
-        if ((unsigned)end >= strlen) end = strlen-1;
+        if (end >= strlen) end = strlen-1;
     } else if (c->argc == 2) {
         /* The whole string. */
         start = 0;


### PR DESCRIPTION
remove unsafe and unnecessary cast.
until now, this cast may lead segmentation fault when end > UINT_MAX
# example

setbit foo 0 1
bitcount  foo 0 4294967295
=> ok
bitcount  foo 0 4294967296
=> cause segmentation fault.
