### PR TITLE
Glob patterns in "include"

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -374,8 +374,8 @@ loaderr:
  * The function appends the additional configuration directives stored
  * in the 'options' string to the config file before loading.
  *
- * Both filename and options can be NULL, in such a case are considered
- * emtpy. This way loadServerConfig can be used to just load a file or
+ * Both filename and options can be NULL, in such a case they are considered
+ * empty. This way loadServerConfig can be used to just load a file or
  * just load a string. */
 void loadServerConfig(char *filename, char *options) {
     sds config = sdsempty();

--- a/src/redis.h
+++ b/src/redis.h
@@ -21,6 +21,7 @@
 #include <netinet/in.h>
 #include <lua.h>
 #include <signal.h>
+#include <glob.h>
 
 #include "ae.h"      /* Event driven programming library */
 #include "sds.h"     /* Dynamic safe strings */


### PR DESCRIPTION
Support glob patterns in the 'include' config directive.

This allows e.g. to create a /etc/redis/conf.d directory,
where distribution packages can drop their config files,
and source everything from it with

  include /etc/redis/conf.d/*.conf
