### PR TITLE
Truncate short write from the AOF

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -250,6 +250,13 @@ void flushAppendOnlyFile(int force) {
                                    strerror(errno),
                                    (long)nwritten,
                                    (long)sdslen(server.aof_buf));
+
+            if (ftruncate(server.aof_fd, server.aof_current_size) == -1) {
+                redisLog(REDIS_WARNING, "Could not remove short write "
+                         "from the append-only file.  Redis may refuse "
+                         "to load the AOF the next time it starts.  "
+                         "ftruncate: %s", strerror(errno));
+            }
         }
         exit(1);
     }


### PR DESCRIPTION
If Redis only manages to write out a partial buffer, the AOF file won't load back into Redis the next time it starts up.  It is better to discard the short write than waste time running `redis-check-aof`.
