### PR TITLE
Fix warning in redis.c for sentinel config load

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -2596,7 +2596,7 @@ int main(int argc, char **argv) {
         loadServerConfig(configfile,options);
         sdsfree(options);
     } else {
-        redisLog(REDIS_WARNING,"Warning: no config file specified, using the default config. In order to specify a config file use 'redis-server /path/to/redis.conf'");
+        redisLog(REDIS_WARNING, "Warning: no config file specified, using the default config. In order to specify a config file use %s /path/to/%s.conf", argv[0], server.sentinel_mode ? "sentinel" : "redis");
     }
     if (server.daemonize) daemonize();
     initServer();


### PR DESCRIPTION
Currently if you load redis-sentinel without a config file, it tells you to use redis-server instead. This fixes the warning.

Took a suggestion from @pietern to use argv[0] - this was initially to avoid checking redis.sentinel_mode, but I like this compromise because it provides both the exact string used to start the binary + the right name of the conf file.
