### PR TITLE
Include sys/wait.h to avoid compiler warning

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -36,6 +36,7 @@
 #include <ctype.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <sys/wait.h>
 
 extern char **environ;
 


### PR DESCRIPTION
gcc warned about an implicit declaration of function 'wait3'. 
Including this header fixes this.

There's another warning, but I'm not sure what's the best way to fix this:

```
sentinel.c: In function 'createSentinelRedisInstance':
sentinel.c:564:17: warning: 'table' may be used uninitialized in this function [-Wmaybe-uninitialized]
```
