### PR TITLE
Add a 128 byte k-ordered id generator

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -99,7 +99,7 @@ endif
 
 REDIS_SERVER_NAME= redis-server
 REDIS_SENTINEL_NAME= redis-sentinel
-REDIS_SERVER_OBJ= adlist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o
+REDIS_SERVER_OBJ= adlist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o id.o
 REDIS_CLI_NAME= redis-cli
 REDIS_CLI_OBJ= anet.o sds.o adlist.o redis-cli.o zmalloc.o release.o anet.o ae.o
 REDIS_BENCHMARK_NAME= redis-benchmark

--- a/src/config.c
+++ b/src/config.c
@@ -322,6 +322,11 @@ void loadServerConfigFromString(char *config) {
             server.cluster.configfile = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"lua-time-limit") && argc == 2) {
             server.lua_time_limit = strtoll(argv[1],NULL,10);
+	} else if (!strcasecmp(argv[0], "id-generation-name") && argc == 2) {
+            int len = (strlen(argv[1]) < REDIS_ID_NAMELEN) ?
+                strlen(argv[1]) : REDIS_ID_NAMELEN;
+            bzero(server.id_generation_name, REDIS_ID_NAMESPACE);
+	    memcpy(server.id_generation_name, argv[1], len);
         } else if (!strcasecmp(argv[0],"slowlog-log-slower-than") &&
                    argc == 2)
         {
@@ -575,6 +580,11 @@ void configSetCommand(redisClient *c) {
     } else if (!strcasecmp(c->argv[2]->ptr,"lua-time-limit")) {
         if (getLongLongFromObject(o,&ll) == REDIS_ERR || ll < 0) goto badfmt;
         server.lua_time_limit = ll;
+    } else if (!strcasecmp(c->argv[1]->ptr,"id-generation-name")) {
+        int len = (strlen((char *)o->ptr) < REDIS_ID_NAMELEN) ?
+            strlen((char *)o->ptr) : REDIS_ID_NAMELEN;
+        bzero(server.id_generation_name, REDIS_ID_NAMESPACE);
+        memcpy(server.id_generation_name, o->ptr, len);
     } else if (!strcasecmp(c->argv[2]->ptr,"slowlog-log-slower-than")) {
         if (getLongLongFromObject(o,&ll) == REDIS_ERR) goto badfmt;
         server.slowlog_log_slower_than = ll;
@@ -721,6 +731,7 @@ void configGetCommand(redisClient *c) {
     config_get_string_field("unixsocket",server.unixsocket);
     config_get_string_field("logfile",server.logfile);
     config_get_string_field("pidfile",server.pidfile);
+    config_get_string_field("id-generation-name",server.id_generation_name);
 
     /* Numerical values */
     config_get_numerical_field("maxmemory",server.maxmemory);

--- a/src/id.c
+++ b/src/id.c
@@ -1,0 +1,28 @@
+#include "redis.h"
+#include <sys/time.h>
+
+/* initialized to zero, we depend on wrapping for cycling */
+u_int16_t sequence;
+
+void incridCommand(redisClient *c) {
+    struct timeval tv;
+    sds id_buf;
+
+    if ((gettimeofday(&tv, NULL)) == -1) {
+        addReplyError(c, "cannot get time of day");
+	return;
+    }
+
+    id_buf = sdscatprintf(sdsempty(),
+                          "+0x%08lx%08x%02x%02x%02x%02x%02x%02x%04x\r\n",
+			  tv.tv_sec,
+                          tv.tv_usec,
+                          server.id_generation_name[0],
+                          server.id_generation_name[1],
+                          server.id_generation_name[2],
+                          server.id_generation_name[3],
+                          server.id_generation_name[4],
+                          server.id_generation_name[5],
+                          sequence++);
+    addReplySds(c, id_buf);
+}

--- a/src/redis.c
+++ b/src/redis.c
@@ -47,6 +47,7 @@
 #include <limits.h>
 #include <float.h>
 #include <math.h>
+#include <string.h>
 #include <sys/resource.h>
 #include <sys/utsname.h>
 
@@ -251,7 +252,8 @@ struct redisCommand redisCommandTable[] = {
     {"script",scriptCommand,-2,"ras",0,NULL,0,0,0,0,0},
     {"time",timeCommand,1,"rR",0,NULL,0,0,0,0,0},
     {"bitop",bitopCommand,-4,"wm",0,NULL,2,-1,1,0,0},
-    {"bitcount",bitcountCommand,-2,"r",0,NULL,1,1,1,0,0}
+    {"bitcount",bitcountCommand,-2,"r",0,NULL,1,1,1,0,0},
+    {"incrid",incridCommand,1,"rR",0,NULL,0,0,0,0,0}
 };
 
 /*============================ Utility functions ============================ */
@@ -1201,6 +1203,9 @@ void initServerConfig() {
     /* Slow log */
     server.slowlog_log_slower_than = REDIS_SLOWLOG_LOG_SLOWER_THAN;
     server.slowlog_max_len = REDIS_SLOWLOG_MAX_LEN;
+
+    /* Hostname */
+    (void)gethostname(server.id_generation_name, REDIS_ID_NAMESPACE);
 
     /* Debugging */
     server.assert_failed = "<no assertion failed>";

--- a/src/redis.h
+++ b/src/redis.h
@@ -240,6 +240,10 @@
 #define UNIT_SECONDS 0
 #define UNIT_MILLISECONDS 1
 
+/* ID Generation */
+#define REDIS_ID_NAMELEN 6
+#define REDIS_ID_NAMESPACE 256
+
 /* SHUTDOWN flags */
 #define REDIS_SHUTDOWN_SAVE 1       /* Force SAVE on SHUTDOWN even if no save
                                        points are configured. */
@@ -741,6 +745,8 @@ struct redisServer {
     int assert_line;
     int bug_report_start; /* True if bug report header was already logged. */
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
+    char id_generation_name[REDIS_ID_NAMESPACE];
+         /* hostname to include in generated sequence ids. */
 };
 
 typedef struct pubsubPattern {
@@ -1273,6 +1279,7 @@ void timeCommand(redisClient *c);
 void bitopCommand(redisClient *c);
 void bitcountCommand(redisClient *c);
 void replconfCommand(redisClient *c);
+void incridCommand(redisClient *c);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));


### PR DESCRIPTION
Now that sentinel is coming along I'd like to reintroduce this PR
it operates in the same cluster ordering space (though it is
orders of magnitude simpler). For simple setups avoid the
installation of snowflake or similar tools has a lot of merit.

This was the original PR text:

This is similar to what snowflake and the recent boundary
solution do, but it makes sense to use redis for that type
of use cases for people wanting a simple way to get
incremental ids in distributed systems without an additional
daemon requirement.

Unique IDs are composed as follows:

epoch seconds: 4 bytes
epoch mseconds: 4 bytes
host name: 6 bytes
sequence id: 2 bytes
host name is truncated to 6 chars, so the appropriate config
directive id-generation-name should be set on each machines
wanting to yield ids if truncating hostname do 6 chars does
not suffice.
