### PR TITLE
Solaris build fixes

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -26,7 +26,9 @@
 
 /* Test for backtrace() */
 #if defined(__APPLE__) || defined(__linux__) || defined(__sun)
+#if !defined(__SunOS_5_10) /* Solaris 10 does not contain backtrace() */
 #define HAVE_BACKTRACE 1
+#endif
 #endif
 
 /* Test for polling API */

--- a/src/memtest.c
+++ b/src/memtest.c
@@ -5,6 +5,7 @@
 #include <limits.h>
 #include <errno.h>
 #include <termios.h>
+#include <unistd.h>
 #include <sys/ioctl.h>
 
 #if (ULONG_MAX == 4294967295UL)

--- a/src/solarisfixes.h
+++ b/src/solarisfixes.h
@@ -16,7 +16,7 @@
 #define isinf(x) \
      __extension__ ({ __typeof (x) __x_i = (x); \
      __builtin_expect(!isnan(__x_i) && !isfinite(__x_i), 0); })
+#endif /* __GNUC__ */
 
 #define u_int uint
 #define u_int32_t uint32_t
-#endif /* __GNUC__ */


### PR DESCRIPTION
This fixes a few build issues on Solaris 5.10 with gcc as well as native compiler.
