### PR TITLE
Add "count" command

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -280,6 +280,31 @@ void keysCommand(redisClient *c) {
     setDeferredMultiBulkLength(c,replylen,numkeys);
 }
 
+void countCommand(redisClient *c) {
+    dictIterator *di;
+    dictEntry *de;
+    sds pattern = c->argv[1]->ptr;
+    int plen = sdslen(pattern), allkeys;
+    unsigned long numkeys = 0;
+
+    di = dictGetSafeIterator(c->db->dict);
+    allkeys = (pattern[0] == '*' && pattern[1] == '\0');
+    while((de = dictNext(di)) != NULL) {
+        sds key = dictGetKey(de);
+        robj *keyobj;
+
+        if (allkeys || stringmatchlen(pattern,plen,key,sdslen(key),0)) {
+            keyobj = createStringObject(key,sdslen(key));
+            if (expireIfNeeded(c->db,keyobj) == 0) {
+                numkeys++;
+            }
+            decrRefCount(keyobj);
+        }
+    }
+    dictReleaseIterator(di);
+    addReplyLongLong(c,numkeys);
+}
+
 void dbsizeCommand(redisClient *c) {
     addReplyLongLong(c,dictSize(c->db->dict));
 }

--- a/src/redis.c
+++ b/src/redis.c
@@ -205,6 +205,7 @@ struct redisCommand redisCommandTable[] = {
     {"pexpire",pexpireCommand,3,"w",0,NULL,1,1,1,0,0},
     {"pexpireat",pexpireatCommand,3,"w",0,NULL,1,1,1,0,0},
     {"keys",keysCommand,2,"rS",0,NULL,0,0,0,0,0},
+    {"count",countCommand,2,"r",0,NULL,0,0,0,0,0},
     {"dbsize",dbsizeCommand,1,"r",0,NULL,0,0,0,0,0},
     {"auth",authCommand,2,"rs",0,NULL,0,0,0,0,0},
     {"ping",pingCommand,1,"r",0,NULL,0,0,0,0,0},

--- a/src/redis.h
+++ b/src/redis.h
@@ -1160,6 +1160,7 @@ void incrbyfloatCommand(redisClient *c);
 void selectCommand(redisClient *c);
 void randomkeyCommand(redisClient *c);
 void keysCommand(redisClient *c);
+void countCommand(redisClient *c);
 void dbsizeCommand(redisClient *c);
 void lastsaveCommand(redisClient *c);
 void saveCommand(redisClient *c);


### PR DESCRIPTION
Hey,

I was writing some tests for a project I was working on today, and realized that this command didn't exist (I thought it did, for some reason). I figured I would code it up for my own use.

This function basically re-implements the `keysCommand`, but returns the amount of matched keys instead of the keys themselves. The same functionality is possible by simply checking the number of keys in the response to a `keys` query on the client, but implementing it server-side saves resources, saves a step, and feels natural.

```
redis 127.0.0.1:6379> count *
(integer) 0
redis 127.0.0.1:6379> set foo bar
OK
redis 127.0.0.1:6379> set baz qux
OK
redis 127.0.0.1:6379> count *
(integer) 2
redis 127.0.0.1:6379> count f*
(integer) 1
```

If this has been previously discussed (I don't keep up-to-date with the mailing list) and found to be superfluous, or if you just don't want it in Redis, I totally understand. If you okay this command, I can provide documentation and tests in the next day or two.

Looking forward to your thoughts.
