### PR TITLE
Update src/redis-benchmark.c

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -201,7 +201,10 @@ static void readHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
                 if (config.requests_finished < config.requests)
                     config.latency[config.requests_finished++] = c->latency;
                 c->pending--;
-                if (c->pending == 0) clientDone(c);
+                if (c->pending == 0) {
+                    clientDone(c);
+                    break;
+                }
             } else {
                 break;
             }


### PR DESCRIPTION
The code of current implementation:

if (c->pending == 0) clientDone(c);
In clientDone function, the c's memory has been freed, then the loop will continue: while(c->pending). The memory of c has been freed now, so c->pending is invalid (c is an invalid pointer now), and this will cause memory dump in some platforams(eg: Solaris).

So I think the code should be modified as:
if (c->pending == 0)
{
clientDone(c);
break;
}
and this will not lead to while(c->pending).
