### PR TITLE
Enhanced key-value store using the trie data structure

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -99,7 +99,7 @@ endif
 
 REDIS_SERVER_NAME= redis-server
 REDIS_SENTINEL_NAME= redis-sentinel
-REDIS_SERVER_OBJ= adlist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o
+REDIS_SERVER_OBJ= adlist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o trie.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o
 REDIS_CLI_NAME= redis-cli
 REDIS_CLI_OBJ= anet.o sds.o adlist.o redis-cli.o zmalloc.o release.o anet.o ae.o
 REDIS_BENCHMARK_NAME= redis-benchmark

--- a/src/Makefile
+++ b/src/Makefile
@@ -99,7 +99,7 @@ endif
 
 REDIS_SERVER_NAME= redis-server
 REDIS_SENTINEL_NAME= redis-sentinel
-REDIS_SERVER_OBJ= adlist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o trie.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o
+REDIS_SERVER_OBJ= adlist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o trie.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o t_trie.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o
 REDIS_CLI_NAME= redis-cli
 REDIS_CLI_OBJ= anet.o sds.o adlist.o redis-cli.o zmalloc.o release.o anet.o ae.o
 REDIS_BENCHMARK_NAME= redis-benchmark

--- a/src/object.c
+++ b/src/object.c
@@ -100,6 +100,13 @@ robj *createHashObject(void) {
     return o;
 }
 
+robj *createTrieObject(void) {
+    trie *t = trieCreate();
+    robj *o = createObject(REDIS_TRIE, t);
+    o->encoding = REDIS_ENCODING_RAW;
+    return o;
+}
+
 robj *createZsetObject(void) {
     zset *zs = zmalloc(sizeof(*zs));
     robj *o;
@@ -181,6 +188,10 @@ void freeHashObject(robj *o) {
     }
 }
 
+void freeTrieObject(robj *o) {
+    trieRelease((trie *)o->ptr, decrRefCount);
+}
+
 void incrRefCount(robj *o) {
     o->refcount++;
 }
@@ -196,6 +207,7 @@ void decrRefCount(void *obj) {
         case REDIS_SET: freeSetObject(o); break;
         case REDIS_ZSET: freeZsetObject(o); break;
         case REDIS_HASH: freeHashObject(o); break;
+        case REDIS_TRIE: freeTrieObject(o); break;
         default: redisPanic("Unknown object type"); break;
         }
         zfree(o);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -430,6 +430,8 @@ int rdbSaveObjectType(rio *rdb, robj *o) {
             return rdbSaveType(rdb,REDIS_RDB_TYPE_HASH);
         else
             redisPanic("Unknown hash encoding");
+    case REDIS_TRIE:
+        return rdbSaveType(rdb,REDIS_RDB_TYPE_TRIE);
     default:
         redisPanic("Unknown object type");
     }
@@ -443,6 +445,24 @@ int rdbLoadObjectType(rio *rdb) {
     if ((type = rdbLoadType(rdb)) == -1) return -1;
     if (!rdbIsObjectType(type)) return -1;
     return type;
+}
+
+typedef struct rdbSaveTrieData {
+    rio *rdb;
+    int nwritten;
+} rdbSaveTrieData;
+
+static int rdbSaveTrieNode(trieNode *node, const unsigned char *key,
+    size_t len, void *data)
+{
+    int n;
+    rdbSaveTrieData *rdbData = (rdbSaveTrieData*)data;
+
+    if ((n = rdbSaveRawString(rdbData->rdb,(unsigned char *)key,len)) == -1) return TRIE_ERR;
+    rdbData->nwritten += n;
+    if ((n = rdbSaveStringObject(rdbData->rdb,trieGetVal(node))) == -1) return TRIE_ERR;
+    rdbData->nwritten += n;
+    return TRIE_OK;
 }
 
 /* Save a Redis object. Returns -1 on error, 0 on success. */
@@ -558,7 +578,17 @@ int rdbSaveObject(rio *rdb, robj *o) {
         } else {
             redisPanic("Unknown hash encoding");
         }
+    } else if (o->type == REDIS_TRIE) {
+        trie *t = (trie*)o->ptr;
+        rdbSaveTrieData data;
 
+        if ((n = rdbSaveLen(rdb,trieSize(t))) == -1) return -1;
+        nwritten += n;
+
+        data.nwritten = 0;
+        data.rdb = rdb;
+        if (trieWalk(t, rdbSaveTrieNode, &data) == TRIE_ERR) return -1;
+        nwritten += data.nwritten;
     } else {
         redisPanic("Unknown object type");
     }
@@ -642,7 +672,7 @@ int rdbSave(char *filename) {
             sds keystr = dictGetKey(de);
             robj key, *o = dictGetVal(de);
             long long expire;
-            
+
             initStaticStringObject(key,keystr);
             expire = getExpire(db,&key);
             if (rdbSaveKeyValuePair(&rdb,&key,o,expire,now) == -1) goto werr;
@@ -907,7 +937,33 @@ robj *rdbLoadObject(int rdbtype, rio *rdb) {
 
         /* All pairs should be read by now */
         redisAssert(len == 0);
+    } else if (rdbtype == REDIS_RDB_TYPE_TRIE) {
+        size_t len;
+        int ret;
 
+        len = rdbLoadLen(rdb, NULL);
+        if (len == REDIS_RDB_LENERR) return NULL;
+
+        o = createTrieObject();
+
+        while (len > 0) {
+            robj *field, *value;
+
+            len--;
+            /* Load key/value */
+            field = rdbLoadStringObject(rdb);
+            if (field == NULL) return NULL;
+            value = rdbLoadEncodedStringObject(rdb);
+            if (value == NULL) return NULL;
+
+            value = tryObjectEncoding(value);
+
+            /* Add pair to trie */
+            ret = trieAdd((trie*)o->ptr, field->ptr, sdslen((sds)field->ptr), value);
+            /* The field is not referenced by the trie */
+            decrRefCount(field);
+            redisAssert(ret == TRIE_OK);
+        }
     } else if (rdbtype == REDIS_RDB_TYPE_HASH_ZIPMAP  ||
                rdbtype == REDIS_RDB_TYPE_LIST_ZIPLIST ||
                rdbtype == REDIS_RDB_TYPE_SET_INTSET   ||

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -45,6 +45,7 @@
 #define REDIS_RDB_TYPE_SET    2
 #define REDIS_RDB_TYPE_ZSET   3
 #define REDIS_RDB_TYPE_HASH   4
+#define REDIS_RDB_TYPE_TRIE   5
 
 /* Object types for encoded objects. */
 #define REDIS_RDB_TYPE_HASH_ZIPMAP    9

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -662,6 +662,18 @@ int main(int argc, const char **argv) {
             free(cmd);
         }
 
+        if (test_is_selected("hset")) {
+            len = redisFormatCommand(&cmd,"HSET mytrie foo:rand:000000000000 %s",data);
+            benchmark("HSET",cmd,len);
+            free(cmd);
+        }
+
+        if (test_is_selected("hget")) {
+            len = redisFormatCommand(&cmd,"HGET mytrie foo:rand:000000000000");
+            benchmark("HGET",cmd,len);
+            free(cmd);
+        }
+
         if (test_is_selected("tset")) {
             len = redisFormatCommand(&cmd,"TSET mytrie foo:rand:000000000000 %s",data);
             benchmark("TSET",cmd,len);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -662,6 +662,18 @@ int main(int argc, const char **argv) {
             free(cmd);
         }
 
+        if (test_is_selected("tset")) {
+            len = redisFormatCommand(&cmd,"TSET mytrie foo:rand:000000000000 %s",data);
+            benchmark("TSET",cmd,len);
+            free(cmd);
+        }
+
+        if (test_is_selected("tget")) {
+            len = redisFormatCommand(&cmd,"TGET mytrie foo:rand:000000000000");
+            benchmark("TGET",cmd,len);
+            free(cmd);
+        }
+
         if (test_is_selected("mset")) {
             const char *argv[21];
             argv[0] = "MSET";

--- a/src/redis.c
+++ b/src/redis.c
@@ -190,6 +190,19 @@ struct redisCommand redisCommandTable[] = {
     {"hvals",hvalsCommand,2,"rS",0,NULL,1,1,1,0,0},
     {"hgetall",hgetallCommand,2,"r",0,NULL,1,1,1,0,0},
     {"hexists",hexistsCommand,3,"r",0,NULL,1,1,1,0,0},
+    {"tset",tsetCommand,4,"wm",0,NULL,1,1,1,0,0},
+    {"tsetnx",tsetnxCommand,4,"wm",0,NULL,1,1,1,0,0},
+    {"tget",tgetCommand,3,"r",0,NULL,1,1,1,0,0},
+    {"tmset",tmsetCommand,-4,"wm",0,NULL,1,1,1,0,0},
+    {"tmget",tmgetCommand,-3,"r",0,NULL,1,1,1,0,0},
+    {"tincrby",tincrbyCommand,4,"wm",0,NULL,1,1,1,0,0},
+    {"tincrbyfloat",tincrbyfloatCommand,4,"wm",0,NULL,1,1,1,0,0},
+    {"tdel",tdelCommand,-3,"w",0,NULL,1,1,1,0,0},
+    {"tlen",tlenCommand,2,"r",0,NULL,1,1,1,0,0},
+    {"tkeys",tkeysCommand,-2,"rS",0,NULL,1,1,1,0,0},
+    {"tvals",tvalsCommand,-2,"rS",0,NULL,1,1,1,0,0},
+    {"tgetall",tgetallCommand,-2,"r",0,NULL,1,1,1,0,0},
+    {"texists",texistsCommand,3,"r",0,NULL,1,1,1,0,0},
     {"incrby",incrbyCommand,3,"wm",0,NULL,1,1,1,0,0},
     {"decrby",decrbyCommand,3,"wm",0,NULL,1,1,1,0,0},
     {"incrbyfloat",incrbyfloatCommand,3,"wm",0,NULL,1,1,1,0,0},
@@ -910,7 +923,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
         if ((pid = wait3(&statloc,WNOHANG,NULL)) != 0) {
             int exitcode = WEXITSTATUS(statloc);
             int bysignal = 0;
-            
+
             if (WIFSIGNALED(statloc)) bysignal = WTERMSIG(statloc);
 
             if (pid == server.rdb_child_pid) {
@@ -1191,7 +1204,7 @@ void initServerConfig() {
     server.lpushCommand = lookupCommandByCString("lpush");
     server.lpopCommand = lookupCommandByCString("lpop");
     server.rpopCommand = lookupCommandByCString("rpop");
-    
+
     /* Slow log */
     server.slowlog_log_slower_than = REDIS_SLOWLOG_LOG_SLOWER_THAN;
     server.slowlog_max_len = REDIS_SLOWLOG_MAX_LEN;
@@ -1227,7 +1240,7 @@ void adjustOpenFilesLimit(void) {
          * for our needs. */
         if (oldlimit < maxfiles) {
             rlim_t f;
-            
+
             f = maxfiles;
             while(f > oldlimit) {
                 limit.rlim_cur = f;
@@ -1881,7 +1894,7 @@ sds genRedisInfoString(char *section) {
         if (server.cluster_enabled) mode = "cluster";
         else if (server.sentinel_mode) mode = "sentinel";
         else mode = "standalone";
-    
+
         if (sections++) info = sdscat(info,"\r\n");
         uname(&name);
         info = sdscatprintf(info,

--- a/src/redis.h
+++ b/src/redis.h
@@ -25,6 +25,7 @@
 #include "ae.h"      /* Event driven programming library */
 #include "sds.h"     /* Dynamic safe strings */
 #include "dict.h"    /* Hash tables */
+#include "trie.h"    /* Tries */
 #include "adlist.h"  /* Linked lists */
 #include "zmalloc.h" /* total memory usage aware version of malloc/free */
 #include "anet.h"    /* Networking the easy way */
@@ -94,6 +95,7 @@
 #define REDIS_SET 2
 #define REDIS_ZSET 3
 #define REDIS_HASH 4
+#define REDIS_TRIE 5
 
 /* Objects encoding. Some kind of objects like Strings and Hashes can be
  * internally represented in multiple ways. The 'encoding' field of the object
@@ -959,6 +961,7 @@ void freeListObject(robj *o);
 void freeSetObject(robj *o);
 void freeZsetObject(robj *o);
 void freeHashObject(robj *o);
+void freeTrieObject(robj *o);
 robj *createObject(int type, void *ptr);
 robj *createStringObject(char *ptr, size_t len);
 robj *dupStringObject(robj *o);
@@ -973,6 +976,7 @@ robj *createZiplistObject(void);
 robj *createSetObject(void);
 robj *createIntsetObject(void);
 robj *createHashObject(void);
+robj *createTrieObject(void);
 robj *createZsetObject(void);
 robj *createZsetZiplistObject(void);
 int getLongFromObjectOrReply(redisClient *c, robj *o, long *target, const char *msg);
@@ -1265,6 +1269,19 @@ void hmsetCommand(redisClient *c);
 void hmgetCommand(redisClient *c);
 void hdelCommand(redisClient *c);
 void hlenCommand(redisClient *c);
+void tsetCommand(redisClient *c);
+void tsetnxCommand(redisClient *c);
+void tgetCommand(redisClient *c);
+void tmsetCommand(redisClient *c);
+void tmgetCommand(redisClient *c);
+void tincrbyCommand(redisClient *c);
+void tincrbyfloatCommand(redisClient *c);
+void tdelCommand(redisClient *c);
+void tlenCommand(redisClient *c);
+void tkeysCommand(redisClient *c);
+void tvalsCommand(redisClient *c);
+void tgetallCommand(redisClient *c);
+void texistsCommand(redisClient *c);
 void zremrangebyrankCommand(redisClient *c);
 void zunionstoreCommand(redisClient *c);
 void zinterstoreCommand(redisClient *c);

--- a/src/t_trie.c
+++ b/src/t_trie.c
@@ -265,7 +265,7 @@ static void genericTgetallCommand(redisClient *c, int flags) {
     int multiplier = 0;
     int len = 0;
     tgetAllData cbData;
-    void *replylen;
+    void *replylen = NULL;
 
     if (c->argc > 3) {
         addReplyErrorFormat(c,"wrong number of arguments for '%s' command",

--- a/src/t_trie.c
+++ b/src/t_trie.c
@@ -1,0 +1,314 @@
+#include "redis.h"
+
+static robj *trieTypeLookupWriteOrCreate(redisClient *c, robj *key) {
+    robj *o = lookupKeyWrite(c->db, key);
+
+    if (o == NULL) {
+        o = createTrieObject();
+        dbAdd(c->db,key,o);
+    } else {
+        if (o->type != REDIS_TRIE) {
+            addReply(c,shared.wrongtypeerr);
+            return NULL;
+        }
+    }
+    return o;
+}
+
+static void addTrieFieldToReply(redisClient *c, robj *o, robj *field) {
+    trieNode *node;
+    robj *val;
+
+    if (o == NULL) {
+        addReply(c, shared.nullbulk);
+        return;
+    }
+
+    node = trieFind(o->ptr, field->ptr, sdslen((sds)field->ptr));
+    if (node == NULL) {
+        addReply(c, shared.nullbulk);
+        return ;
+    }
+    val = trieGetVal(node);
+    addReplyBulk(c, val);
+}
+
+void tsetCommand(redisClient *c) {
+    robj *o;
+    int update = 0;
+    const unsigned char *key = c->argv[2]->ptr;
+
+    if ((o = trieTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+
+    c->argv[3] = tryObjectEncoding(c->argv[3]);
+    incrRefCount(c->argv[3]);
+    if (!trieAddOrReplace(o->ptr, key, sdslen((sds)key), c->argv[3],
+        decrRefCount)) {
+        update = 1;
+    }
+    addReply(c, update ? shared.czero : shared.cone);
+    signalModifiedKey(c->db, c->argv[1]);
+    server.dirty++;
+}
+
+void tsetnxCommand(redisClient *c) {
+    robj *o;
+    const unsigned char *key = c->argv[2]->ptr;
+
+    if ((o = trieTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+
+    c->argv[3] = tryObjectEncoding(c->argv[3]);
+    if (trieAdd(o->ptr, key, sdslen((sds)key), c->argv[3]) == TRIE_ERR) {
+        addReply(c, shared.czero);
+    } else {
+        incrRefCount(c->argv[3]);
+        addReply(c, shared.cone);
+        signalModifiedKey(c->db, c->argv[1]);
+        server.dirty++;
+    }
+}
+
+void tmsetCommand(redisClient *c) {
+    int i;
+    robj *o;
+
+    if ((c->argc % 2) == 1) {
+        addReplyError(c,"wrong number of arguments for TMSET");
+        return;
+    }
+
+    if ((o = trieTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+    for (i = 2; i < c->argc; i += 2) {
+        const unsigned char *key = c->argv[i]->ptr;
+
+        c->argv[i+1] = tryObjectEncoding(c->argv[i+1]);
+        incrRefCount(c->argv[i+1]);
+        trieAddOrReplace(o->ptr, key, sdslen((sds)key), c->argv[i+1],
+            decrRefCount);
+    }
+    addReply(c, shared.ok);
+    signalModifiedKey(c->db, c->argv[1]);
+    server.dirty++;
+}
+
+void tgetCommand(redisClient *c) {
+    robj *o;
+
+    if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.nullbulk)) == NULL ||
+        checkType(c, o, REDIS_TRIE)) return;
+
+    addTrieFieldToReply(c, o, c->argv[2]);
+}
+
+void tmgetCommand(redisClient *c) {
+    robj *o;
+    int i;
+
+    /* Don't abort when the key cannot be found. Non-existing keys are empty
+     * hashes, where TMGET should respond with a series of null bulks. */
+    o = lookupKeyRead(c->db, c->argv[1]);
+    if (o != NULL && o->type != REDIS_TRIE) {
+        addReply(c, shared.wrongtypeerr);
+        return;
+    }
+
+    addReplyMultiBulkLen(c, c->argc-2);
+    for (i = 2; i < c->argc; i++) {
+        addTrieFieldToReply(c, o, c->argv[i]);
+    }
+}
+
+void tincrbyCommand(redisClient *c) {
+    long long value, incr, oldvalue;
+    robj *o, *new;
+    const unsigned char *key = c->argv[2]->ptr;
+    trieNode *node;
+
+    if (getLongLongFromObjectOrReply(c,c->argv[3], &incr, NULL) != REDIS_OK) return;
+    if ((o = trieTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+
+    if ((node = trieFind(o->ptr, key, sdslen((sds)key))) != NULL) {
+        if (getLongLongFromObjectOrReply(c, trieGetVal(node), &value,
+            "trie value is not an integer") != REDIS_OK) {
+            return;
+        }
+    } else {
+        value = 0;
+    }
+
+    oldvalue = value;
+    if ((incr < 0 && oldvalue < 0 && incr < (LLONG_MIN-oldvalue)) ||
+        (incr > 0 && oldvalue > 0 && incr > (LLONG_MAX-oldvalue))) {
+        addReplyError(c,"increment or decrement would overflow");
+        return;
+    }
+    value += incr;
+    new = createStringObjectFromLongLong(value);
+    if (node != NULL) {
+        trieReplaceVal(node, new, decrRefCount);
+    } else {
+        trieAdd(o->ptr, key, sdslen((sds)key), new);
+    }
+    addReplyLongLong(c, value);
+    signalModifiedKey(c->db, c->argv[1]);
+    server.dirty++;
+}
+
+void tincrbyfloatCommand(redisClient *c) {
+    double long value, incr;
+    robj *o, *new, *aux;
+    const unsigned char *key = c->argv[2]->ptr;
+    trieNode *node;
+
+    if (getLongDoubleFromObjectOrReply(c, c->argv[3], &incr, NULL) != REDIS_OK) return;
+    if ((o = trieTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+
+    if ((node = trieFind(o->ptr, key, sdslen((sds)key))) != NULL) {
+        if (getLongDoubleFromObjectOrReply(c, trieGetVal(node), &value,
+            "hash value is not a valid float") != REDIS_OK) {
+            return;
+        }
+    } else {
+        value = 0;
+    }
+
+    value += incr;
+    new = createStringObjectFromLongDouble(value);
+    if (node != NULL) {
+        trieReplaceVal(node, new, decrRefCount);
+    } else {
+        trieAdd(o->ptr, key, sdslen((sds)key), new);
+    }
+    addReplyBulk(c, new);
+    signalModifiedKey(c->db, c->argv[1]);
+    server.dirty++;
+
+    /* Always replicate HINCRBYFLOAT as an HSET command with the final value
+     * in order to make sure that differences in float pricision or formatting
+     * will not create differences in replicas or after an AOF restart. */
+    aux = createStringObject("TSET", 4);
+    rewriteClientCommandArgument(c, 0, aux);
+    rewriteClientCommandArgument(c, 3, new);
+}
+
+void tdelCommand(redisClient *c) {
+    robj *o;
+    int j, deleted = 0;
+
+    if ((o = lookupKeyWriteOrReply(c, c->argv[1], shared.czero)) == NULL ||
+        checkType(c, o, REDIS_TRIE)) return;
+
+    for (j = 2; j < c->argc; j++) {
+        if (trieDelete((trie*)o->ptr, c->argv[j]->ptr,
+            sdslen((sds)c->argv[j]->ptr), decrRefCount) == TRIE_OK) {
+            deleted++;
+            if (trieSize((trie*)o->ptr) == 0) {
+                dbDelete(c->db, c->argv[1]);
+                break;
+            }
+        }
+    }
+    if (deleted) {
+        signalModifiedKey(c->db, c->argv[1]);
+        server.dirty += deleted;
+    }
+    addReplyLongLong(c, deleted);
+}
+
+void texistsCommand(redisClient *c) {
+    robj *o;
+    const unsigned char *key = c->argv[2]->ptr;
+    trieNode *node;
+
+    if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.czero)) == NULL ||
+        checkType(c, o, REDIS_TRIE)) return;
+
+    node = trieFind(o->ptr, key, sdslen((sds)key));
+
+    addReply(c, node != NULL ? shared.cone : shared.czero);
+}
+
+void tlenCommand(redisClient *c) {
+    robj *o;
+    if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.czero)) == NULL ||
+        checkType(c, o, REDIS_TRIE)) return;
+
+    addReplyLongLong(c, trieSize((trie *)o->ptr));
+}
+
+/* Private structure used by tgetAllCallback() */
+typedef struct tgetAllData {
+    redisClient *c;
+    int flags;
+    int count;
+} tgetAllData;
+
+/* Callback for trieWalk() used by genericTgetallCommand() */
+static int tgetAllCallback(trieNode *node, const unsigned char *key,
+    size_t len, void *cbData)
+{
+    tgetAllData *data = (tgetAllData *)cbData;
+
+    data->count++;
+    if (data->flags & REDIS_HASH_KEY) {
+        addReplyBulk(data->c, createStringObject((char *)key, len));
+    }
+    if (data->flags & REDIS_HASH_VALUE) {
+        robj *val = trieGetVal(node);
+        addReplyBulk(data->c, val);
+    }
+    return TRIE_OK;
+}
+
+static void genericTgetallCommand(redisClient *c, int flags) {
+    robj *o;
+    int multiplier = 0;
+    int len = 0;
+    tgetAllData cbData;
+    void *replylen;
+
+    if (c->argc > 3) {
+        addReplyErrorFormat(c,"wrong number of arguments for '%s' command",
+            c->cmd->name);
+        return;
+    }
+
+    if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.emptymultibulk)) == NULL
+        || checkType(c, o, REDIS_TRIE)) return;
+
+    if (flags & REDIS_HASH_KEY) multiplier++;
+    if (flags & REDIS_HASH_VALUE) multiplier++;
+
+    if (c->argc > 2) {
+        replylen = addDeferredMultiBulkLength(c);
+    } else {
+        len = trieSize((trie*)o->ptr) * multiplier;
+        addReplyMultiBulkLen(c, len);
+    }
+
+    cbData.c = c;
+    cbData.flags = flags;
+    cbData.count = 0;
+
+    if (c->argc > 2) {
+        const unsigned char *prefix = c->argv[2]->ptr;
+
+        trieWalkFromPrefix(o->ptr, tgetAllCallback, &cbData, prefix,
+            sdslen((sds)prefix));
+        setDeferredMultiBulkLength(c, replylen, cbData.count * multiplier);
+    } else {
+        trieWalk(o->ptr, tgetAllCallback, &cbData);
+    }
+}
+
+void tkeysCommand(redisClient *c) {
+    genericTgetallCommand(c, REDIS_HASH_KEY);
+}
+
+void tvalsCommand(redisClient *c) {
+    genericTgetallCommand(c, REDIS_HASH_VALUE);
+}
+
+void tgetallCommand(redisClient *c) {
+    genericTgetallCommand(c, REDIS_HASH_KEY|REDIS_HASH_VALUE);
+}

--- a/src/trie.c
+++ b/src/trie.c
@@ -1,0 +1,365 @@
+/* Trie data structure implementation
+ *
+ * A Trie is a fast, memory efficient ordered tree data structure used to store
+ * associative arrays.
+ *
+ * Its lookup, insert, delete and replace complexity is O(k), where k is the
+ * length of the key. Unlike hash tables, there are no collisions meaning its
+ * worst case complexity is still O(k) and no re-hashing is required.
+ *
+ * No node in the tree stores the key associated with that node.
+ * Instead, its position in the tree defines the key with which it's associated.
+ * This results in memory savings as common key prefixes are stored only once.
+ *
+ * For instance, the layout of a Trie containig the words "hello" and "hey"
+ * is the following:
+ *
+ *               [\0]
+ *              /
+ *            [h]
+ *             |
+ *            [e]
+ *           /   \
+ *         [l]   [y *]
+ *          |
+ *         [l]
+ *          |
+ *         [o *]
+ *
+ * (*) denotes a final node containing a value
+ *
+ * This implementation uses double-chained trees, in which all children of a
+ * node are placed in a linked list. Each node has a pointer to the next node
+ * as well as to the first child, resulting in a small overhead.
+ *
+ * Copyright (c) 2012, Andrea Luzzardi <aluzzardi at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "trie.h"
+#include "zmalloc.h"
+
+static trieNode *_trieCreateNode(trie *t, const unsigned char key)
+{
+    trieNode *node;
+
+    node = zmalloc(sizeof(*node));
+    trieSetKey(node, key);
+    trieSetVal(node, NULL);
+    node->children = NULL;
+    node->next = NULL;
+    t->size++;
+    return node;
+}
+
+static void _trieDestroyNode(trie *t, trieNode *node)
+{
+    zfree(node);
+    t->size--;
+}
+
+/* Create and initialize an empty Trie */
+trie *trieCreate()
+{
+    trie *t = zmalloc(sizeof(*t));
+    t->size = 0;
+    t->used = 0;
+    t->root = _trieCreateNode(t, '\0');
+    return t;
+}
+
+/* Search the node's children for the given key */
+static trieNode *_trieGetNextState(trieNode *node, const unsigned char key)
+{
+    trieNode *children = node->children;
+
+    while (children != NULL) {
+        if (trieGetKey(children) == key) {
+            return children;
+        }
+        children = children->next;
+    }
+    return NULL;
+}
+
+/* Add a new key to the Trie. If the key already exists, returns TRIE_ERR */
+int trieAdd(trie *t, const unsigned char *key, size_t len, void *val)
+{
+    trieNode *current = t->root;
+
+
+    while (len-- > 0) {
+        trieNode *next = _trieGetNextState(current, *key);
+        if (next == NULL) {
+            next = _trieCreateNode(t, *key);
+            next->next = current->children;
+            current->children = next;
+        }
+        current = next;
+        ++key;
+    }
+
+    /* Make sure the node was *not* already in use.
+    * trieAdd won't replace an already in use node */
+    if (trieNodeIsFinal(current)) {
+        return TRIE_ERR;
+    }
+
+    trieSetVal(current, val);
+    t->used++;
+    return TRIE_OK;
+}
+
+/* Replace an existing key with a new value. If the key doesn't exist,
+ * returns TRIE_ERR */
+int trieReplace(trie *t, const unsigned char *key, size_t len, void *val,
+    trieValDestructor destructor)
+{
+    trieNode *node;
+
+    node = trieFind(t, key, len);
+    if (node == NULL) {
+        return TRIE_ERR;
+    }
+    trieReplaceVal(node, val, destructor);
+    return TRIE_OK;
+}
+
+/* Add OR Replace in a single traversal.
+ * Return 1 if the key was added, 0 if it was replaced.
+ * This could be implemented in a much simpler way by doing a trieFind and
+ * either trieAdd or trieReplace, but that would require two Trie traversals */
+int trieAddOrReplace(trie *t, const unsigned char *key, size_t len, void *val,
+    trieValDestructor destructor)
+{
+    trieNode *current = t->root;
+
+    while (len-- > 0) {
+        trieNode *next = _trieGetNextState(current, *key);
+        if (next == NULL) {
+            next = _trieCreateNode(t, *key);
+            next->next = current->children;
+            current->children = next;
+        }
+        current = next;
+        ++key;
+    }
+    // The entry already existed, replace it
+    if (trieNodeIsFinal(current)) {
+        trieReplaceVal(current, val, destructor);
+        return 0;
+    }
+    trieSetVal(current, val);
+    t->used++;
+    return 1;
+}
+
+/* Low level trieFind() that returns a node even if it's NOT in use.
+ * Callers have to check the node with trieNodeIsFinal() in order to know if
+ * the node holds a value. */
+static trieNode *_trieLookupNode(trie *t, const unsigned char *key, size_t len)
+{
+    trieNode *current = t->root;
+    while (len-- && current != NULL) {
+        current = _trieGetNextState(current, *key);
+        ++key;
+    }
+    return current;
+}
+
+/* Lookup a key by traversing the Trie. */
+trieNode *trieFind(trie *t, const unsigned char *key, size_t len)
+{
+    trieNode *e = _trieLookupNode(t, key, len);
+    if (e == NULL || !trieNodeIsFinal(e)) {
+        return NULL;
+    }
+    return e;
+}
+
+/* Low level function to remove a node from the Trie.
+ * This not only destroys the node, but it also removes it from the tree by
+ * updating the parent or previous node pointers */
+static void _trieRemoveNode(trie *t, trieNode *node, trieNode *parent,
+    trieNode *prev)
+{
+    if (prev == NULL) {
+        parent->children = node->next;
+    } else {
+        prev->next = node->next;
+    }
+    _trieDestroyNode(t, node);
+}
+
+/* Internal implementation of trieDelete that recursively traverses the Trie
+ * in order to find and destroy the target node.
+ * Once the target node is destroyed, it makes sure to destroy any node that
+ * have become useless, that is, nodes that don't hold a value and don't have
+ * any children. */
+static int _trieDelete(trie *t, trieNode *parent, const unsigned char *key,
+    size_t len, int *ret, trieValDestructor destructor)
+{
+    trieNode *node = parent->children;
+    trieNode *prev = NULL;
+
+    /* Find the next node and keep a pointer to the previous one */
+    while (node != NULL && trieGetKey(node) != *key) {
+        prev = node;
+        node = node->next;
+    }
+    /* Make sure we've found the node */
+    if (node == NULL || trieGetKey(node) != *key) return TRIE_ERR;
+
+    /* We've reached our final node (len == 0), delete it */
+    if (len == 0) {
+        if (!trieNodeIsFinal(node)) return TRIE_ERR;
+
+        trieFreeVal(node, destructor);
+        t->used--;
+        *ret = TRIE_OK;
+        if (node->children == NULL) {
+            /* The node is useless, we can safely remove it */
+            _trieRemoveNode(t, node, parent, prev);
+            return TRIE_OK;
+        }
+    } else {
+        /* If we didn't reach the end of the key yet (len > 0),
+        * continue traversing the tree recursively */
+        if (_trieDelete(t, node, ++key, --len, ret, destructor) == TRIE_OK) {
+            /* If _trieDelete() returns TRIE_OK, it means that our child got
+             * destroyed as a result of the delete. If the current node
+             * is useless, then we can safely destroy it as well. */
+            if (!trieNodeIsFinal(node) && node->children == NULL) {
+                _trieRemoveNode(t, node, parent, prev);
+                return TRIE_OK;
+            }
+        }
+    }
+    return TRIE_ERR;
+}
+
+/* Delete an entry from a Trie. If the key wasn't found, returns TRIE_ERR */
+int trieDelete(trie *t, const unsigned char *key, size_t len,
+    trieValDestructor destructor)
+{
+    int ret = TRIE_ERR;
+
+    /* Special casing the root node */
+    if (len == 0 && trieNodeIsFinal(t->root)) {
+        trieFreeVal(t->root, destructor);
+        return TRIE_OK;
+    }
+    _trieDelete(t, t->root, key, --len, &ret, destructor);
+    return ret;
+}
+
+/* Internal function used to traverse a trie from a given node. */
+static int _trieWalkFromNode(trieNode *node, char **buffer, size_t len,
+    trieWalkCallback callback, void *data)
+{
+    /* Reallocate the key buffer if necessary */
+    if (len >= TRIE_WALK_BUFFERSTEP && (len % TRIE_WALK_BUFFERSTEP) == 0) {
+        *buffer = zrealloc(*buffer, sizeof(char) *
+            (len + TRIE_WALK_BUFFERSTEP));
+    }
+
+    while (node != NULL) {
+        trieNode *next = node->next;
+        (*buffer)[len] = trieGetKey(node);
+        if (_trieWalkFromNode(node->children, buffer, len + 1, callback,
+            data) == TRIE_ERR) {
+            return TRIE_ERR;
+        }
+        if (trieNodeIsFinal(node)) {
+            if (callback(node, (const unsigned char *)*buffer, len + 1,
+                data) == TRIE_ERR) {
+                return TRIE_ERR;
+            }
+        }
+        node = next;
+    }
+    return TRIE_OK;
+}
+
+/* Same as trieWalk(), except it starts traversing the Trie from the given
+ * prefix */
+int trieWalkFromPrefix(trie *t, trieWalkCallback callback, void *data,
+    const unsigned char *prefix, size_t len)
+{
+    char *buffer;
+    int ret = TRIE_ERR;
+    trieNode *root = NULL;
+
+    root = _trieLookupNode(t, prefix, len);
+    if (root == NULL) {
+        return TRIE_ERR;
+    }
+
+    buffer = zmalloc(sizeof(char) * TRIE_WALK_BUFFERSTEP *
+        (len / TRIE_WALK_BUFFERSTEP + 1));
+    memcpy(buffer, prefix, len);
+    ret = _trieWalkFromNode(root->children, &buffer, len, callback, data);
+    if (trieNodeIsFinal(root)) {
+        if (callback(root, prefix, len, data) == TRIE_ERR) {
+            return TRIE_ERR;
+        }
+    }
+    zfree(buffer);
+    return ret;
+}
+
+/* Traverse an entire Trie in depth first search. For every final node,
+ * the callback is called with the provided user data */
+int trieWalk(trie *t, trieWalkCallback callback, void *data)
+{
+    return trieWalkFromPrefix(t, callback, data, (const unsigned char *)"", 0);
+}
+
+/* Internal function to release a Trie, starting from a given node. */
+static void _trieReleaseFromNode(trie *t, trieNode *node,
+    trieValDestructor destructor)
+{
+    trieNode *next = NULL;
+
+    while (node != NULL) {
+        next = node->next;
+        _trieReleaseFromNode(t, node->children, destructor);
+        trieFreeVal(node, destructor);
+        _trieDestroyNode(t, node);
+        node = next;
+    }
+}
+
+/* Destroy a Trie, including every value stored in it */
+void trieRelease(trie *t, trieValDestructor destructor)
+{
+    _trieReleaseFromNode(t, t->root, destructor);
+    zfree(t);
+}

--- a/src/trie.h
+++ b/src/trie.h
@@ -1,0 +1,137 @@
+/* Trie data structure implementation
+ *
+ * A Trie is a fast, memory efficient ordered tree data structure used to store
+ * associative arrays.
+ *
+ * Its lookup, insert, delete and replace complexity is O(k), where k is the
+ * length of the key. Unlike hash tables, there are no collisions meaning its
+ * worst case complexity is still O(k) and no re-hashing is required.
+ *
+ * No node in the tree stores the key associated with that node.
+ * Instead, its position in the tree defines the key with which it's associated.
+ * This results in memory savings as common key prefixes are stored only once.
+ *
+ * For instance, the layout of a Trie containig the words "hello" and "hey"
+ * is the following:
+ *
+ *               [\0]
+ *              /
+ *            [h]
+ *             |
+ *            [e]
+ *           /   \
+ *         [l]   [y *]
+ *          |
+ *         [l]
+ *          |
+ *         [o *]
+ *
+ * (*) denotes a final node containing a value
+ *
+ * This implementation uses double-chained trees, in which all children of a
+ * node are placed in a linked list. Each node has a pointer to the next node
+ * as well as to the first child, resulting in a small overhead.
+ *
+ * Copyright (c) 2012, Andrea Luzzardi <aluzzardi at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __TRIE_H
+#define __TRIE_H
+
+#define TRIE_OK 0
+#define TRIE_ERR 1
+
+typedef struct trieNode {
+    unsigned char key;
+    void *val;
+    struct trieNode *next;
+    struct trieNode *children;
+} trieNode;
+
+typedef struct trie {
+    size_t size;
+    size_t used;
+    trieNode *root;
+} trie;
+
+/* Callback used when traversing a Trie. */
+typedef int (*trieWalkCallback)(trieNode *node, const unsigned char *key, size_t len, void *data);
+
+/* Callback used to destroy a Trie value. */
+typedef void (*trieValDestructor)(void *);
+
+/* While traversing a Trie, we need to keep a buffer that holds the full
+ * key. The buffer will be incrementally re-allocated at TRIE_WALK_BUFFERSTEP
+ * size each time. */
+#define TRIE_WALK_BUFFERSTEP 128
+
+/* ------------------------------- Macros ------------------------------------*/
+#define trieGetKey(node) ((node)->key)
+#define trieGetVal(node) ((node)->val)
+
+#define trieSetKey(node, key) do { \
+    node->key = (key); \
+} while(0)
+
+#define trieSetVal(node, _val_) do { \
+    node->val = (_val_); \
+} while(0)
+
+#define trieFreeVal(node, destructor) do { \
+    if (destructor != NULL && node->val != NULL) { \
+        destructor(node->val); \
+    } \
+    node->val = NULL; \
+} while(0)
+
+#define trieReplaceVal(node, _val_, destructor) do { \
+    void *tmp = node->val; \
+    trieSetVal(node, _val_); \
+    if (destructor != NULL && tmp != NULL) { \
+        destructor(tmp); \
+    } \
+} while(0)
+
+#define trieNodeIsFinal(node) \
+    (node->val != NULL)
+
+#define trieSize(t) ((t)->used)
+#define trieAllocatedSize(t) ((t)->size)
+
+/* API */
+trie *trieCreate();
+int trieAdd(trie *t, const unsigned char *key, size_t len, void *val);
+int trieReplace(trie *t, const unsigned char *key, size_t len, void *val, trieValDestructor destructor);
+int trieAddOrReplace(trie *t, const unsigned char *key, size_t len, void *val, trieValDestructor destructor);
+trieNode *trieFind(trie *d, const unsigned char *key, size_t len);
+int trieDelete(trie *d, const unsigned char  *key, size_t len, trieValDestructor destructor);
+int trieWalk(trie *t, trieWalkCallback callback, void *data);
+int trieWalkFromPrefix(trie *t, trieWalkCallback callback, void *data, const unsigned char *prefix, size_t len);
+void trieRelease(trie *t, trieValDestructor destructor);
+
+#endif /* !__TRIE_H */

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -20,6 +20,7 @@ set ::all_tests {
     unit/type/set
     unit/type/zset
     unit/type/hash
+    unit/type/trie
     unit/sort
     unit/expire
     unit/other

--- a/tests/unit/type/trie.tcl
+++ b/tests/unit/type/trie.tcl
@@ -1,50 +1,24 @@
 start_server {tags {"trie"}} {
-    test {TSET/TLEN - Small hash creation} {
-        array set smallhash {}
-        for {set i 0} {$i < 8} {incr i} {
-            set key [randstring 0 8 alpha]
-            set val [randstring 0 8 alpha]
-            if {[info exists smallhash($key)]} {
-                incr i -1
-                continue
-            }
-            r tset smallhash $key $val
-            set smallhash($key) $val
-        }
-        list [r tlen smallhash]
-    } {8}
-
-    test {TSET/TLEN - Big hash creation} {
-        array set bighash {}
+    test {TSET/TLEN} {
+        array set trie {}
         for {set i 0} {$i < 1024} {incr i} {
             set key [randstring 0 8 alpha]
             set val [randstring 0 8 alpha]
-            if {[info exists bighash($key)]} {
+            if {[info exists trie($key)]} {
                 incr i -1
                 continue
             }
-            r tset bighash $key $val
-            set bighash($key) $val
+            r tset trie $key $val
+            set trie($key) $val
         }
-        list [r tlen bighash]
+        list [r tlen trie]
     } {1024}
 
-    test {TGET against the small hash} {
+    test {TGET} {
         set err {}
-        foreach k [array names smallhash *] {
-            if {$smallhash($k) ne [r tget smallhash $k]} {
-                set err "$smallhash($k) != [r tget smallhash $k]"
-                break
-            }
-        }
-        set _ $err
-    } {}
-
-    test {TGET against the big hash} {
-        set err {}
-        foreach k [array names bighash *] {
-            if {$bighash($k) ne [r tget bighash $k]} {
-                set err "$bighash($k) != [r tget bighash $k]"
+        foreach k [array names trie *] {
+            if {$trie($k) ne [r tget trie $k]} {
+                set err "$trie($k) != [r tget trie $k]"
                 break
             }
         }
@@ -53,99 +27,69 @@ start_server {tags {"trie"}} {
 
     test {TGET against non existing key} {
         set rv {}
-        lappend rv [r tget smallhash __123123123__]
-        lappend rv [r tget bighash __123123123__]
+        lappend rv [r tget trie __123123123__]
         set _ $rv
-    } {{} {}}
+    } {{}}
 
     test {TSET in update and insert mode} {
         set rv {}
-        set k [lindex [array names smallhash *] 0]
-        lappend rv [r tset smallhash $k newval1]
-        set smallhash($k) newval1
-        lappend rv [r tget smallhash $k]
-        lappend rv [r tset smallhash __foobar123__ newval]
-        set k [lindex [array names bighash *] 0]
-        lappend rv [r tset bighash $k newval2]
-        set bighash($k) newval2
-        lappend rv [r tget bighash $k]
-        lappend rv [r tset bighash __foobar123__ newval]
-        lappend rv [r tdel smallhash __foobar123__]
-        lappend rv [r tdel bighash __foobar123__]
+        set k [lindex [array names trie *] 0]
+        lappend rv [r tset trie $k newval2]
+        set trie($k) newval2
+        lappend rv [r tget trie $k]
+        lappend rv [r tset trie __foobar123__ newval]
+        lappend rv [r tdel trie __foobar123__]
         set _ $rv
-    } {0 newval1 1 0 newval2 1 1 1}
+    } {0 newval2 1 1}
 
-    test {TSETNX target key missing - small hash} {
-        r tsetnx smallhash __123123123__ foo
-        r tget smallhash __123123123__
+    test {TSETNX target key missing} {
+        r tsetnx trie __123123123__ foo
+        r tget trie __123123123__
     } {foo}
 
-    test {TSETNX target key exists - small hash} {
-        r tsetnx smallhash __123123123__ bar
-        set result [r tget smallhash __123123123__]
-        r tdel smallhash __123123123__
-        set _ $result
-    } {foo}
-
-    test {TSETNX target key missing - big hash} {
-        r tsetnx bighash __123123123__ foo
-        r tget bighash __123123123__
-    } {foo}
-
-    test {TSETNX target key exists - big hash} {
-        r tsetnx bighash __123123123__ bar
-        set result [r tget bighash __123123123__]
-        r tdel bighash __123123123__
+    test {TSETNX target key exists} {
+        r tsetnx trie __123123123__ bar
+        set result [r tget trie __123123123__]
+        r tdel trie __123123123__
         set _ $result
     } {foo}
 
     test {TMSET wrong number of args} {
-        catch {r tmset smallhash key1 val1 key2} err
+        catch {r tmset trie key1 val1 key2} err
         format $err
     } {*wrong number*}
 
-    test {TMSET - small hash} {
+    test {TMSET} {
         set args {}
-        foreach {k v} [array get smallhash] {
+        foreach {k v} [array get trie] {
             set newval [randstring 0 8 alpha]
-            set smallhash($k) $newval
+            set trie($k) $newval
             lappend args $k $newval
         }
-        r tmset smallhash {*}$args
-    } {OK}
-
-    test {TMSET - big hash} {
-        set args {}
-        foreach {k v} [array get bighash] {
-            set newval [randstring 0 8 alpha]
-            set bighash($k) $newval
-            lappend args $k $newval
-        }
-        r tmset bighash {*}$args
+        r tmset trie {*}$args
     } {OK}
 
     test {TMGET against non existing key and fields} {
         set rv {}
         lappend rv [r tmget doesntexist __123123123__ __456456456__]
-        lappend rv [r tmget smallhash __123123123__ __456456456__]
-        lappend rv [r tmget bighash __123123123__ __456456456__]
+        lappend rv [r tmget trie __123123123__ __456456456__]
         set _ $rv
-    } {{{} {}} {{} {}} {{} {}}}
+    } {{{} {}} {{} {}}}
 
     test {TMGET against wrong type} {
         r set wrongtype somevalue
         assert_error "*wrong*" {r tmget wrongtype field1 field2}
     }
 
-    test {TMGET - small hash} {
+    test {TMGET} {
         set keys {}
         set vals {}
-        foreach {k v} [array get smallhash] {
+        foreach {k v} [array get trie] {
             lappend keys $k
             lappend vals $v
         }
         set err {}
-        set result [r tmget smallhash {*}$keys]
+        set result [r tmget trie {*}$keys]
         if {$vals ne $result} {
             set err "$vals != $result"
             break
@@ -153,163 +97,108 @@ start_server {tags {"trie"}} {
         set _ $err
     } {}
 
-    test {TMGET - big hash} {
-        set keys {}
+    test {TKEYS} {
+        lsort [r tkeys trie]
+    } [lsort [array names trie *]]
+
+    test {TVALS} {
         set vals {}
-        foreach {k v} [array get bighash] {
-            lappend keys $k
-            lappend vals $v
-        }
-        set err {}
-        set result [r tmget bighash {*}$keys]
-        if {$vals ne $result} {
-            set err "$vals != $result"
-            break
-        }
-        set _ $err
-    } {}
-
-    test {TKEYS - small hash} {
-        lsort [r tkeys smallhash]
-    } [lsort [array names smallhash *]]
-
-    test {TKEYS - big hash} {
-        lsort [r tkeys bighash]
-    } [lsort [array names bighash *]]
-
-    test {TVALS - small hash} {
-        set vals {}
-        foreach {k v} [array get smallhash] {
+        foreach {k v} [array get trie] {
             lappend vals $v
         }
         set _ [lsort $vals]
-    } [lsort [r tvals smallhash]]
+    } [lsort [r tvals trie]]
 
-    test {TVALS - big hash} {
-        set vals {}
-        foreach {k v} [array get bighash] {
-            lappend vals $v
-        }
-        set _ [lsort $vals]
-    } [lsort [r tvals bighash]]
-
-    test {TGETALL - small hash} {
-        lsort [r tgetall smallhash]
-    } [lsort [array get smallhash]]
-
-    test {TGETALL - big hash} {
-        lsort [r tgetall bighash]
-    } [lsort [array get bighash]]
+    test {TGETALL} {
+        lsort [r tgetall trie]
+    } [lsort [array get trie]]
 
     test {TDEL and return value} {
         set rv {}
-        lappend rv [r tdel smallhash nokey]
-        lappend rv [r tdel bighash nokey]
-        set k [lindex [array names smallhash *] 0]
-        lappend rv [r tdel smallhash $k]
-        lappend rv [r tdel smallhash $k]
-        lappend rv [r tget smallhash $k]
-        unset smallhash($k)
-        set k [lindex [array names bighash *] 0]
-        lappend rv [r tdel bighash $k]
-        lappend rv [r tdel bighash $k]
-        lappend rv [r tget bighash $k]
-        unset bighash($k)
+        lappend rv [r tdel trie nokey]
+        set k [lindex [array names trie *] 0]
+        lappend rv [r tdel trie $k]
+        lappend rv [r tdel trie $k]
+        lappend rv [r tget trie $k]
+        unset trie($k)
         set _ $rv
-    } {0 0 1 0 {} 1 0 {}}
+    } {0 1 0 {}}
 
     test {TDEL - more than a single value} {
         set rv {}
-        r del myhash
-        r tmset myhash a 1 b 2 c 3
-        assert_equal 0 [r tdel myhash x y]
-        assert_equal 2 [r tdel myhash a c f]
-        r tgetall myhash
+        r del mytrie
+        r tmset mytrie a 1 b 2 c 3
+        assert_equal 0 [r tdel mytrie x y]
+        assert_equal 2 [r tdel mytrie a c f]
+        r tgetall mytrie
     } {b 2}
 
-    test {TDEL - hash becomes empty before deleting all specified fields} {
-        r del myhash
-        r tmset myhash a 1 b 2 c 3
-        assert_equal 3 [r tdel myhash a b c d e]
-        assert_equal 0 [r exists myhash]
+    test {TDEL - trie becomes empty before deleting all specified fields} {
+        r del mytrie
+        r tmset mytrie a 1 b 2 c 3
+        assert_equal 3 [r tdel mytrie a b c d e]
+        assert_equal 0 [r exists mytrie]
     }
 
     test {TEXISTS} {
         set rv {}
-        set k [lindex [array names smallhash *] 0]
-        lappend rv [r texists smallhash $k]
-        lappend rv [r texists smallhash nokey]
-        set k [lindex [array names bighash *] 0]
-        lappend rv [r texists bighash $k]
-        lappend rv [r texists bighash nokey]
-    } {1 0 1 0}
+        set k [lindex [array names trie *] 0]
+        lappend rv [r texists trie $k]
+        lappend rv [r texists trie nokey]
+    } {1 0}
 
     test {TINCRBY against non existing database key} {
         r del htest
         list [r tincrby htest foo 2]
     } {2}
 
-    test {TINCRBY against non existing hash key} {
+    test {TINCRBY against non existing trie key} {
         set rv {}
-        r tdel smallhash tmp
-        r tdel bighash tmp
-        lappend rv [r tincrby smallhash tmp 2]
-        lappend rv [r tget smallhash tmp]
-        lappend rv [r tincrby bighash tmp 2]
-        lappend rv [r tget bighash tmp]
-    } {2 2 2 2}
+        r tdel trie tmp
+        lappend rv [r tincrby trie tmp 2]
+        lappend rv [r tget trie tmp]
+    } {2 2}
 
-    test {TINCRBY against hash key created by tincrby itself} {
+    test {TINCRBY against trie key created by tincrby itself} {
         set rv {}
-        lappend rv [r tincrby smallhash tmp 3]
-        lappend rv [r tget smallhash tmp]
-        lappend rv [r tincrby bighash tmp 3]
-        lappend rv [r tget bighash tmp]
-    } {5 5 5 5}
+        lappend rv [r tincrby trie tmp 3]
+        lappend rv [r tget trie tmp]
+    } {5 5}
 
-    test {TINCRBY against hash key originally set with TSET} {
-        r tset smallhash tmp 100
-        r tset bighash tmp 100
-        list [r tincrby smallhash tmp 2] [r tincrby bighash tmp 2]
-    } {102 102}
+    test {TINCRBY against trie key originally set with TSET} {
+        r tset trie tmp 100
+        list [r tincrby trie tmp 2]
+    } {102}
 
     test {TINCRBY over 32bit value} {
-        r tset smallhash tmp 17179869184
-        r tset bighash tmp 17179869184
-        list [r tincrby smallhash tmp 1] [r tincrby bighash tmp 1]
-    } {17179869185 17179869185}
+        r tset trie tmp 17179869184
+        list [r tincrby trie tmp 1]
+    } {17179869185}
 
     test {TINCRBY over 32bit value with over 32bit increment} {
-        r tset smallhash tmp 17179869184
-        r tset bighash tmp 17179869184
-        list [r tincrby smallhash tmp 17179869184] [r tincrby bighash tmp 17179869184]
-    } {34359738368 34359738368}
+        r tset trie tmp 17179869184
+        list [r tincrby trie tmp 17179869184]
+    } {34359738368}
 
-    test {TINCRBY fails against hash value with spaces (left)} {
-        r tset smallhash str " 11"
-        r tset bighash str " 11"
-        catch {r tincrby smallhash str 1} smallerr
-        catch {r tincrby smallhash str 1} bigerr
+    test {TINCRBY fails against trie value with spaces (left)} {
+        r tset trie str " 11"
+        catch {r tincrby trie str 1} bigerr
         set rv {}
-        lappend rv [string match "ERR*not an integer*" $smallerr]
         lappend rv [string match "ERR*not an integer*" $bigerr]
-    } {1 1}
+    } {1}
 
-    test {TINCRBY fails against hash value with spaces (right)} {
-        r tset smallhash str "11 "
-        r tset bighash str "11 "
-        catch {r tincrby smallhash str 1} smallerr
-        catch {r tincrby smallhash str 1} bigerr
+    test {TINCRBY fails against trie value with spaces (right)} {
+        r tset trie str "11 "
+        catch {r tincrby trie str 1} bigerr
         set rv {}
-        lappend rv [string match "ERR*not an integer*" $smallerr]
         lappend rv [string match "ERR*not an integer*" $bigerr]
-    } {1 1}
+    } {1}
 
     test {TINCRBY can detect overflows} {
         set e {}
-        r tset hash n -9223372036854775484
-        assert {[r tincrby hash n -1] == -9223372036854775485}
-        catch {r tincrby hash n -10000} e
+        r tset trie n -9223372036854775484
+        assert {[r tincrby trie n -1] == -9223372036854775485}
+        catch {r tincrby trie n -10000} e
         set e
     } {*overflow*}
 
@@ -318,128 +207,111 @@ start_server {tags {"trie"}} {
         list [r tincrbyfloat htest foo 2.5]
     } {2.5}
 
-    test {TINCRBYFLOAT against non existing hash key} {
+    test {TINCRBYFLOAT against non existing trie key} {
         set rv {}
-        r tdel smallhash tmp
-        r tdel bighash tmp
-        lappend rv [roundFloat [r tincrbyfloat smallhash tmp 2.5]]
-        lappend rv [roundFloat [r tget smallhash tmp]]
-        lappend rv [roundFloat [r tincrbyfloat bighash tmp 2.5]]
-        lappend rv [roundFloat [r tget bighash tmp]]
-    } {2.5 2.5 2.5 2.5}
+        r tdel trie tmp
+        lappend rv [roundFloat [r tincrbyfloat trie tmp 2.5]]
+        lappend rv [roundFloat [r tget trie tmp]]
+    } {2.5 2.5}
 
-    test {TINCRBYFLOAT against hash key created by tincrby itself} {
+    test {TINCRBYFLOAT against trie key created by tincrby itself} {
         set rv {}
-        lappend rv [roundFloat [r tincrbyfloat smallhash tmp 3.5]]
-        lappend rv [roundFloat [r tget smallhash tmp]]
-        lappend rv [roundFloat [r tincrbyfloat bighash tmp 3.5]]
-        lappend rv [roundFloat [r tget bighash tmp]]
-    } {6 6 6 6}
+        lappend rv [roundFloat [r tincrbyfloat trie tmp 3.5]]
+        lappend rv [roundFloat [r tget trie tmp]]
+    } {6 6}
 
-    test {TINCRBYFLOAT against hash key originally set with TSET} {
-        r tset smallhash tmp 100
-        r tset bighash tmp 100
-        list [roundFloat [r tincrbyfloat smallhash tmp 2.5]] \
-             [roundFloat [r tincrbyfloat bighash tmp 2.5]]
-    } {102.5 102.5}
+    test {TINCRBYFLOAT against trie key originally set with TSET} {
+        r tset trie tmp 100
+        list [roundFloat [r tincrbyfloat trie tmp 2.5]]
+    } {102.5}
 
     test {TINCRBYFLOAT over 32bit value} {
-        r tset smallhash tmp 17179869184
-        r tset bighash tmp 17179869184
-        list [r tincrbyfloat smallhash tmp 1] \
-             [r tincrbyfloat bighash tmp 1]
-    } {17179869185 17179869185}
+        r tset trie tmp 17179869184
+        list [r tincrbyfloat trie tmp 1]
+    } {17179869185}
 
     test {TINCRBYFLOAT over 32bit value with over 32bit increment} {
-        r tset smallhash tmp 17179869184
-        r tset bighash tmp 17179869184
-        list [r tincrbyfloat smallhash tmp 17179869184] \
-             [r tincrbyfloat bighash tmp 17179869184]
-    } {34359738368 34359738368}
+        r tset trie tmp 17179869184
+        list [r tincrbyfloat trie tmp 17179869184]
+    } {34359738368}
 
-    test {TINCRBYFLOAT fails against hash value with spaces (left)} {
-        r tset smallhash str " 11"
-        r tset bighash str " 11"
-        catch {r tincrbyfloat smallhash str 1} smallerr
-        catch {r tincrbyfloat smallhash str 1} bigerr
+    test {TINCRBYFLOAT fails against trie value with spaces (left)} {
+        r tset trie str " 11"
+        catch {r tincrbyfloat trie str 1} bigerr
         set rv {}
-        lappend rv [string match "ERR*not*float*" $smallerr]
         lappend rv [string match "ERR*not*float*" $bigerr]
-    } {1 1}
+    } {1}
 
-    test {TINCRBYFLOAT fails against hash value with spaces (right)} {
-        r tset smallhash str "11 "
-        r tset bighash str "11 "
-        catch {r tincrbyfloat smallhash str 1} smallerr
-        catch {r tincrbyfloat smallhash str 1} bigerr
+    test {TINCRBYFLOAT fails against trie value with spaces (right)} {
+        r tset trie str "11 "
+        catch {r tincrbyfloat trie str 1} bigerr
         set rv {}
-        lappend rv [string match "ERR*not*float*" $smallerr]
         lappend rv [string match "ERR*not*float*" $bigerr]
-    } {1 1}
+    } {1}
 
-    test {Hash ziplist regression test for large keys} {
-        r tset hash kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk a
-        r tset hash kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk b
-        r tget hash kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk
+    test {Trie test for large keys} {
+        r tset trie kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk a
+        r tset trie kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk b
+        r tget trie kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk
     } {b}
 
     foreach size {10 512} {
-        test "Hash fuzzing #1 - $size fields" {
+        test "Trie fuzzing #1 - $size fields" {
             for {set times 0} {$times < 10} {incr times} {
-                catch {unset hash}
-                array set hash {}
-                r del hash
+                catch {unset trie}
+                array set trie {}
+                r del trie
 
                 # Create
                 for {set j 0} {$j < $size} {incr j} {
                     set field [randomValue]
                     set value [randomValue]
-                    r tset hash $field $value
-                    set hash($field) $value
+                    r tset trie $field $value
+                    set trie($field) $value
                 }
 
                 # Verify
-                foreach {k v} [array get hash] {
-                    assert_equal $v [r tget hash $k]
+                foreach {k v} [array get trie] {
+                    assert_equal $v [r tget trie $k]
                 }
-                assert_equal [array size hash] [r tlen hash]
+                assert_equal [array size trie] [r tlen trie]
             }
         }
 
-        test "Hash fuzzing #2 - $size fields" {
+        test "Trie fuzzing #2 - $size fields" {
             for {set times 0} {$times < 10} {incr times} {
-                catch {unset hash}
-                array set hash {}
-                r del hash
+                catch {unset trie}
+                array set trie {}
+                r del trie
 
                 # Create
                 for {set j 0} {$j < $size} {incr j} {
                     randpath {
                         set field [randomValue]
                         set value [randomValue]
-                        r tset hash $field $value
-                        set hash($field) $value
+                        r tset trie $field $value
+                        set trie($field) $value
                     } {
                         set field [randomSignedInt 512]
                         set value [randomSignedInt 512]
-                        r tset hash $field $value
-                        set hash($field) $value
+                        r tset trie $field $value
+                        set trie($field) $value
                     } {
                         randpath {
                             set field [randomValue]
                         } {
                             set field [randomSignedInt 512]
                         }
-                        r tdel hash $field
-                        unset -nocomplain hash($field)
+                        r tdel trie $field
+                        unset -nocomplain trie($field)
                     }
                 }
 
                 # Verify
-                foreach {k v} [array get hash] {
-                    assert_equal $v [r tget hash $k]
+                foreach {k v} [array get trie] {
+                    assert_equal $v [r tget trie $k]
                 }
-                assert_equal [array size hash] [r tlen hash]
+                assert_equal [array size trie] [r tlen trie]
             }
         }
     }

--- a/tests/unit/type/trie.tcl
+++ b/tests/unit/type/trie.tcl
@@ -113,6 +113,42 @@ start_server {tags {"trie"}} {
         lsort [r tgetall trie]
     } [lsort [array get trie]]
 
+    test {TKEYS with prefix} {
+        set rv {}
+
+        r del smallhash
+        r tset smallhash prefix1_a 1
+        r tset smallhash prefix1_b 2
+        r tset smallhash prefix2_a 3
+        r tset smallhash prefix2_b 4
+
+        lappend rv [lsort [r tkeys smallhash]]
+        lappend rv [lsort [r tkeys smallhash prefix]]
+        lappend rv [lsort [r tkeys smallhash prefix1]]
+        lappend rv [lsort [r tkeys smallhash prefix2]]
+        lappend rv [lsort [r tkeys smallhash prefix_doesnotexist]]
+    } {{prefix1_a prefix1_b prefix2_a prefix2_b} {prefix1_a prefix1_b prefix2_a prefix2_b} {prefix1_a prefix1_b} {prefix2_a prefix2_b} {}}
+
+    test {TVALS with prefix} {
+        set rv {}
+
+        lappend rv [lsort [r tvals smallhash]]
+        lappend rv [lsort [r tvals smallhash prefix]]
+        lappend rv [lsort [r tvals smallhash prefix1]]
+        lappend rv [lsort [r tvals smallhash prefix2]]
+        lappend rv [lsort [r tvals smallhash prefix_doesnotexist]]
+    } {{1 2 3 4} {1 2 3 4} {1 2} {3 4} {}}
+
+    test {TGETALL with prefix} {
+        set rv {}
+
+        lappend rv [lsort [r tgetall smallhash]]
+        lappend rv [lsort [r tgetall smallhash prefix]]
+        lappend rv [lsort [r tgetall smallhash prefix1]]
+        lappend rv [lsort [r tgetall smallhash prefix2]]
+        lappend rv [lsort [r tgetall smallhash prefix_doesnotexist]]
+    } {{1 2 3 4 prefix1_a prefix1_b prefix2_a prefix2_b} {1 2 3 4 prefix1_a prefix1_b prefix2_a prefix2_b} {1 2 prefix1_a prefix1_b} {3 4 prefix2_a prefix2_b} {}}
+
     test {TDEL and return value} {
         set rv {}
         lappend rv [r tdel trie nokey]

--- a/tests/unit/type/trie.tcl
+++ b/tests/unit/type/trie.tcl
@@ -1,0 +1,470 @@
+start_server {tags {"hash"}} {
+    test {HSET/HLEN - Small hash creation} {
+        array set smallhash {}
+        for {set i 0} {$i < 8} {incr i} {
+            set key [randstring 0 8 alpha]
+            set val [randstring 0 8 alpha]
+            if {[info exists smallhash($key)]} {
+                incr i -1
+                continue
+            }
+            r hset smallhash $key $val
+            set smallhash($key) $val
+        }
+        list [r hlen smallhash]
+    } {8}
+
+    test {Is the small hash encoded with a ziplist?} {
+        assert_encoding ziplist smallhash
+    }
+
+    test {HSET/HLEN - Big hash creation} {
+        array set bighash {}
+        for {set i 0} {$i < 1024} {incr i} {
+            set key [randstring 0 8 alpha]
+            set val [randstring 0 8 alpha]
+            if {[info exists bighash($key)]} {
+                incr i -1
+                continue
+            }
+            r hset bighash $key $val
+            set bighash($key) $val
+        }
+        list [r hlen bighash]
+    } {1024}
+
+    test {Is the big hash encoded with a ziplist?} {
+        assert_encoding hashtable bighash
+    }
+
+    test {HGET against the small hash} {
+        set err {}
+        foreach k [array names smallhash *] {
+            if {$smallhash($k) ne [r hget smallhash $k]} {
+                set err "$smallhash($k) != [r hget smallhash $k]"
+                break
+            }
+        }
+        set _ $err
+    } {}
+
+    test {HGET against the big hash} {
+        set err {}
+        foreach k [array names bighash *] {
+            if {$bighash($k) ne [r hget bighash $k]} {
+                set err "$bighash($k) != [r hget bighash $k]"
+                break
+            }
+        }
+        set _ $err
+    } {}
+
+    test {HGET against non existing key} {
+        set rv {}
+        lappend rv [r hget smallhash __123123123__]
+        lappend rv [r hget bighash __123123123__]
+        set _ $rv
+    } {{} {}}
+
+    test {HSET in update and insert mode} {
+        set rv {}
+        set k [lindex [array names smallhash *] 0]
+        lappend rv [r hset smallhash $k newval1]
+        set smallhash($k) newval1
+        lappend rv [r hget smallhash $k]
+        lappend rv [r hset smallhash __foobar123__ newval]
+        set k [lindex [array names bighash *] 0]
+        lappend rv [r hset bighash $k newval2]
+        set bighash($k) newval2
+        lappend rv [r hget bighash $k]
+        lappend rv [r hset bighash __foobar123__ newval]
+        lappend rv [r hdel smallhash __foobar123__]
+        lappend rv [r hdel bighash __foobar123__]
+        set _ $rv
+    } {0 newval1 1 0 newval2 1 1 1}
+
+    test {HSETNX target key missing - small hash} {
+        r hsetnx smallhash __123123123__ foo
+        r hget smallhash __123123123__
+    } {foo}
+
+    test {HSETNX target key exists - small hash} {
+        r hsetnx smallhash __123123123__ bar
+        set result [r hget smallhash __123123123__]
+        r hdel smallhash __123123123__
+        set _ $result
+    } {foo}
+
+    test {HSETNX target key missing - big hash} {
+        r hsetnx bighash __123123123__ foo
+        r hget bighash __123123123__
+    } {foo}
+
+    test {HSETNX target key exists - big hash} {
+        r hsetnx bighash __123123123__ bar
+        set result [r hget bighash __123123123__]
+        r hdel bighash __123123123__
+        set _ $result
+    } {foo}
+
+    test {HMSET wrong number of args} {
+        catch {r hmset smallhash key1 val1 key2} err
+        format $err
+    } {*wrong number*}
+
+    test {HMSET - small hash} {
+        set args {}
+        foreach {k v} [array get smallhash] {
+            set newval [randstring 0 8 alpha]
+            set smallhash($k) $newval
+            lappend args $k $newval
+        }
+        r hmset smallhash {*}$args
+    } {OK}
+
+    test {HMSET - big hash} {
+        set args {}
+        foreach {k v} [array get bighash] {
+            set newval [randstring 0 8 alpha]
+            set bighash($k) $newval
+            lappend args $k $newval
+        }
+        r hmset bighash {*}$args
+    } {OK}
+
+    test {HMGET against non existing key and fields} {
+        set rv {}
+        lappend rv [r hmget doesntexist __123123123__ __456456456__]
+        lappend rv [r hmget smallhash __123123123__ __456456456__]
+        lappend rv [r hmget bighash __123123123__ __456456456__]
+        set _ $rv
+    } {{{} {}} {{} {}} {{} {}}}
+
+    test {HMGET against wrong type} {
+        r set wrongtype somevalue
+        assert_error "*wrong*" {r hmget wrongtype field1 field2}
+    }
+
+    test {HMGET - small hash} {
+        set keys {}
+        set vals {}
+        foreach {k v} [array get smallhash] {
+            lappend keys $k
+            lappend vals $v
+        }
+        set err {}
+        set result [r hmget smallhash {*}$keys]
+        if {$vals ne $result} {
+            set err "$vals != $result"
+            break
+        }
+        set _ $err
+    } {}
+
+    test {HMGET - big hash} {
+        set keys {}
+        set vals {}
+        foreach {k v} [array get bighash] {
+            lappend keys $k
+            lappend vals $v
+        }
+        set err {}
+        set result [r hmget bighash {*}$keys]
+        if {$vals ne $result} {
+            set err "$vals != $result"
+            break
+        }
+        set _ $err
+    } {}
+
+    test {HKEYS - small hash} {
+        lsort [r hkeys smallhash]
+    } [lsort [array names smallhash *]]
+
+    test {HKEYS - big hash} {
+        lsort [r hkeys bighash]
+    } [lsort [array names bighash *]]
+
+    test {HVALS - small hash} {
+        set vals {}
+        foreach {k v} [array get smallhash] {
+            lappend vals $v
+        }
+        set _ [lsort $vals]
+    } [lsort [r hvals smallhash]]
+
+    test {HVALS - big hash} {
+        set vals {}
+        foreach {k v} [array get bighash] {
+            lappend vals $v
+        }
+        set _ [lsort $vals]
+    } [lsort [r hvals bighash]]
+
+    test {HGETALL - small hash} {
+        lsort [r hgetall smallhash]
+    } [lsort [array get smallhash]]
+
+    test {HGETALL - big hash} {
+        lsort [r hgetall bighash]
+    } [lsort [array get bighash]]
+
+    test {HDEL and return value} {
+        set rv {}
+        lappend rv [r hdel smallhash nokey]
+        lappend rv [r hdel bighash nokey]
+        set k [lindex [array names smallhash *] 0]
+        lappend rv [r hdel smallhash $k]
+        lappend rv [r hdel smallhash $k]
+        lappend rv [r hget smallhash $k]
+        unset smallhash($k)
+        set k [lindex [array names bighash *] 0]
+        lappend rv [r hdel bighash $k]
+        lappend rv [r hdel bighash $k]
+        lappend rv [r hget bighash $k]
+        unset bighash($k)
+        set _ $rv
+    } {0 0 1 0 {} 1 0 {}}
+
+    test {HDEL - more than a single value} {
+        set rv {}
+        r del myhash
+        r hmset myhash a 1 b 2 c 3
+        assert_equal 0 [r hdel myhash x y]
+        assert_equal 2 [r hdel myhash a c f]
+        r hgetall myhash
+    } {b 2}
+
+    test {HDEL - hash becomes empty before deleting all specified fields} {
+        r del myhash
+        r hmset myhash a 1 b 2 c 3
+        assert_equal 3 [r hdel myhash a b c d e]
+        assert_equal 0 [r exists myhash]
+    }
+
+    test {HEXISTS} {
+        set rv {}
+        set k [lindex [array names smallhash *] 0]
+        lappend rv [r hexists smallhash $k]
+        lappend rv [r hexists smallhash nokey]
+        set k [lindex [array names bighash *] 0]
+        lappend rv [r hexists bighash $k]
+        lappend rv [r hexists bighash nokey]
+    } {1 0 1 0}
+
+    test {Is a ziplist encoded Hash promoted on big payload?} {
+        r hset smallhash foo [string repeat a 1024]
+        r debug object smallhash
+    } {*hashtable*}
+
+    test {HINCRBY against non existing database key} {
+        r del htest
+        list [r hincrby htest foo 2]
+    } {2}
+
+    test {HINCRBY against non existing hash key} {
+        set rv {}
+        r hdel smallhash tmp
+        r hdel bighash tmp
+        lappend rv [r hincrby smallhash tmp 2]
+        lappend rv [r hget smallhash tmp]
+        lappend rv [r hincrby bighash tmp 2]
+        lappend rv [r hget bighash tmp]
+    } {2 2 2 2}
+
+    test {HINCRBY against hash key created by hincrby itself} {
+        set rv {}
+        lappend rv [r hincrby smallhash tmp 3]
+        lappend rv [r hget smallhash tmp]
+        lappend rv [r hincrby bighash tmp 3]
+        lappend rv [r hget bighash tmp]
+    } {5 5 5 5}
+
+    test {HINCRBY against hash key originally set with HSET} {
+        r hset smallhash tmp 100
+        r hset bighash tmp 100
+        list [r hincrby smallhash tmp 2] [r hincrby bighash tmp 2]
+    } {102 102}
+
+    test {HINCRBY over 32bit value} {
+        r hset smallhash tmp 17179869184
+        r hset bighash tmp 17179869184
+        list [r hincrby smallhash tmp 1] [r hincrby bighash tmp 1]
+    } {17179869185 17179869185}
+
+    test {HINCRBY over 32bit value with over 32bit increment} {
+        r hset smallhash tmp 17179869184
+        r hset bighash tmp 17179869184
+        list [r hincrby smallhash tmp 17179869184] [r hincrby bighash tmp 17179869184]
+    } {34359738368 34359738368}
+
+    test {HINCRBY fails against hash value with spaces (left)} {
+        r hset smallhash str " 11"
+        r hset bighash str " 11"
+        catch {r hincrby smallhash str 1} smallerr
+        catch {r hincrby smallhash str 1} bigerr
+        set rv {}
+        lappend rv [string match "ERR*not an integer*" $smallerr]
+        lappend rv [string match "ERR*not an integer*" $bigerr]
+    } {1 1}
+
+    test {HINCRBY fails against hash value with spaces (right)} {
+        r hset smallhash str "11 "
+        r hset bighash str "11 "
+        catch {r hincrby smallhash str 1} smallerr
+        catch {r hincrby smallhash str 1} bigerr
+        set rv {}
+        lappend rv [string match "ERR*not an integer*" $smallerr]
+        lappend rv [string match "ERR*not an integer*" $bigerr]
+    } {1 1}
+
+    test {HINCRBY can detect overflows} {
+        set e {}
+        r hset hash n -9223372036854775484
+        assert {[r hincrby hash n -1] == -9223372036854775485}
+        catch {r hincrby hash n -10000} e
+        set e
+    } {*overflow*}
+
+    test {HINCRBYFLOAT against non existing database key} {
+        r del htest
+        list [r hincrbyfloat htest foo 2.5]
+    } {2.5}
+
+    test {HINCRBYFLOAT against non existing hash key} {
+        set rv {}
+        r hdel smallhash tmp
+        r hdel bighash tmp
+        lappend rv [roundFloat [r hincrbyfloat smallhash tmp 2.5]]
+        lappend rv [roundFloat [r hget smallhash tmp]]
+        lappend rv [roundFloat [r hincrbyfloat bighash tmp 2.5]]
+        lappend rv [roundFloat [r hget bighash tmp]]
+    } {2.5 2.5 2.5 2.5}
+
+    test {HINCRBYFLOAT against hash key created by hincrby itself} {
+        set rv {}
+        lappend rv [roundFloat [r hincrbyfloat smallhash tmp 3.5]]
+        lappend rv [roundFloat [r hget smallhash tmp]]
+        lappend rv [roundFloat [r hincrbyfloat bighash tmp 3.5]]
+        lappend rv [roundFloat [r hget bighash tmp]]
+    } {6 6 6 6}
+
+    test {HINCRBYFLOAT against hash key originally set with HSET} {
+        r hset smallhash tmp 100
+        r hset bighash tmp 100
+        list [roundFloat [r hincrbyfloat smallhash tmp 2.5]] \
+             [roundFloat [r hincrbyfloat bighash tmp 2.5]]
+    } {102.5 102.5}
+
+    test {HINCRBYFLOAT over 32bit value} {
+        r hset smallhash tmp 17179869184
+        r hset bighash tmp 17179869184
+        list [r hincrbyfloat smallhash tmp 1] \
+             [r hincrbyfloat bighash tmp 1]
+    } {17179869185 17179869185}
+
+    test {HINCRBYFLOAT over 32bit value with over 32bit increment} {
+        r hset smallhash tmp 17179869184
+        r hset bighash tmp 17179869184
+        list [r hincrbyfloat smallhash tmp 17179869184] \
+             [r hincrbyfloat bighash tmp 17179869184]
+    } {34359738368 34359738368}
+
+    test {HINCRBYFLOAT fails against hash value with spaces (left)} {
+        r hset smallhash str " 11"
+        r hset bighash str " 11"
+        catch {r hincrbyfloat smallhash str 1} smallerr
+        catch {r hincrbyfloat smallhash str 1} bigerr
+        set rv {}
+        lappend rv [string match "ERR*not*float*" $smallerr]
+        lappend rv [string match "ERR*not*float*" $bigerr]
+    } {1 1}
+
+    test {HINCRBYFLOAT fails against hash value with spaces (right)} {
+        r hset smallhash str "11 "
+        r hset bighash str "11 "
+        catch {r hincrbyfloat smallhash str 1} smallerr
+        catch {r hincrbyfloat smallhash str 1} bigerr
+        set rv {}
+        lappend rv [string match "ERR*not*float*" $smallerr]
+        lappend rv [string match "ERR*not*float*" $bigerr]
+    } {1 1}
+
+    test {Hash ziplist regression test for large keys} {
+        r hset hash kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk a
+        r hset hash kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk b
+        r hget hash kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk
+    } {b}
+
+    foreach size {10 512} {
+        test "Hash fuzzing #1 - $size fields" {
+            for {set times 0} {$times < 10} {incr times} {
+                catch {unset hash}
+                array set hash {}
+                r del hash
+
+                # Create
+                for {set j 0} {$j < $size} {incr j} {
+                    set field [randomValue]
+                    set value [randomValue]
+                    r hset hash $field $value
+                    set hash($field) $value
+                }
+
+                # Verify
+                foreach {k v} [array get hash] {
+                    assert_equal $v [r hget hash $k]
+                }
+                assert_equal [array size hash] [r hlen hash]
+            }
+        }
+
+        test "Hash fuzzing #2 - $size fields" {
+            for {set times 0} {$times < 10} {incr times} {
+                catch {unset hash}
+                array set hash {}
+                r del hash
+
+                # Create
+                for {set j 0} {$j < $size} {incr j} {
+                    randpath {
+                        set field [randomValue]
+                        set value [randomValue]
+                        r hset hash $field $value
+                        set hash($field) $value
+                    } {
+                        set field [randomSignedInt 512]
+                        set value [randomSignedInt 512]
+                        r hset hash $field $value
+                        set hash($field) $value
+                    } {
+                        randpath {
+                            set field [randomValue]
+                        } {
+                            set field [randomSignedInt 512]
+                        }
+                        r hdel hash $field
+                        unset -nocomplain hash($field)
+                    }
+                }
+
+                # Verify
+                foreach {k v} [array get hash] {
+                    assert_equal $v [r hget hash $k]
+                }
+                assert_equal [array size hash] [r hlen hash]
+            }
+        }
+    }
+
+    test {Stress test the hash ziplist -> hashtable encoding conversion} {
+        r config set hash-max-ziplist-entries 32
+        for {set j 0} {$j < 100} {incr j} {
+            r del myhash
+            for {set i 0} {$i < 64} {incr i} {
+                r hset myhash [randomValue] [randomValue]
+            }
+            assert {[r object encoding myhash] eq {hashtable}}
+        }
+    }
+}


### PR DESCRIPTION
Hey,

These commits implement the Trie data structure into Redis and provide a new data type which makes use of it.

The main advantages over hash tables are:
- Memory efficient. No node in the tree stores the key associated with that
  node. Instead, its position in the tree defines the key with which it's
  associated. This results in memory savings as common key prefixes are stored
  only once.
- No collisions. One of the biggest problems with hash tables are collisions.
  They yeild a worst case performance of O(N), require constant re-hashing,
  and can be attack vectors, as seen here:
  https://github.com/antirez/redis/issues/663
- Prefix search. Traversing a trie from a given prefix doesn't require walking
  through every node, which opens up a lot of new possibilities.

In addition to the data structure, I've implemented the TRIE data type which
makes use of it.

The TRIE data type is 100% compatible with the HASH type and supports
all of its commands (HGET becomes TGET, HSET becomes TGET and so on).

In fact, the trie unit tests were simply copied from the hash table and
slightly modified.

Additionally, tries support prefix-based traversal for TKEYS, TVALS and
TGETALL with the same performance.

Example:

> tset trie hello xxx
> (integer) 1
> tset trie hey xxx
> (integer) 1
> tset trie foobar xxx
> (integer) 1
> tkeys trie
> 1) "foobar"
> 2) "hey"
> 3) "hello"
> tkeys trie he
> 1) "hey"
> 2) "hello"

This opens up many possibilities, such as using Redis to build an efficient
Auto Complete service.

Performance wise, this implementation delivers about the same performance as
hash tables.

I've run a couple of benchmarks on my laptop, so please don't consider those
as a reference:

./redis-benchmark -n 1000000 -r 1000000 -t HSET,HGET
HSET: 35617.61 requests per second
HGET: 35335.69 requests per second
used_memory_human:75.85M
used_memory_peak_human:80.69M

./redis-benchmark -n 1000000 -r 1000000 -t TSET,TGET
TSET: 36926.26 requests per second
TGET 36587.15 requests per second
used_memory_human:42.31M
used_memory_peak_human:45.01M

While the performance is about the same, it saves more than 50% of memory.

Note that the redis-benchmark test is a little biased:
In real world tests the memory usage will highly depend on the key distribution
and the values it holds.
Because redis-benchmark uses the same key prefix and increments the suffix
of the keys, tries perform very well on it, which might not reflect real-world
usage patterns.

For now, tries live as a separate data type.

If the concept is accepted, 3 things could happen:

1/ Keep it as is - a new data type compatible with hashes that provide some
  extra features.

2/ Make HT-based data types (HASH, SET, ...) use the trie data structure

3/ Whatever the outcome of 1 and 2 are, another possibility is to replace the
   main object database with a Trie. Not only this could lead to improved memory
   efficiency, but the KEYS command could be special cased to take advantage of
   tries for prefix-based lookups (e.g. KEYS foo*).

Please keep in mind that I've just started wrapping my head around Redis
internals, so this should not be considered production ready.

Let me know what you think.
