### PR TITLE
Switch hash function to SipHash.

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -640,6 +640,7 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     ucontext_t *uc = (ucontext_t*) secret;
     sds infostring, clients;
     struct sigaction act;
+    int i;
     REDIS_NOTUSED(info);
 
     bugReportStart();
@@ -656,8 +657,12 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     /* Log INFO and CLIENT LIST */
     redisLog(REDIS_WARNING, "--- INFO OUTPUT");
     infostring = genRedisInfoString("all");
-    infostring = sdscatprintf(infostring, "hash_init_value: %u\n",
-        dictGetHashFunctionSeed());
+
+    infostring = sdscatprintf(infostring, "hash_init_value: ");
+    for (i = 0; i < 16; i++)
+        infostring = sdscatprintf(infostring, "%02x", dictGetHashFunctionSeed()[i]);
+    infostring = sdscatprintf(infostring, "\n");
+
     redisLogRaw(REDIS_WARNING, infostring);
     redisLog(REDIS_WARNING, "--- CLIENT LIST OUTPUT");
     clients = getAllClientsInfoString();

--- a/src/dict.c
+++ b/src/dict.c
@@ -103,18 +103,14 @@ uint8_t *dictGetHashFunctionSeed(void) {
 unsigned int dictGenHashFunction(const unsigned char *buf, int len) {
     uint64_t n = len;
     uint64_t v0, v1, v2, v3;
-    uint64_t k0, k1;
     uint64_t mi, mask, length;
     size_t i, k;
-    
-  
-    k0 = *((uint64_t*)(dict_hash_function_seed + 0));
-    k1 = *((uint64_t*)(dict_hash_function_seed + 8));
+    uint64_t *key = (uint64_t*)dict_hash_function_seed;
 
-    v0 = k0 ^ 0x736f6d6570736575ULL;
-    v1 = k1 ^ 0x646f72616e646f6dULL;
-    v2 = k0 ^ 0x6c7967656e657261ULL;
-    v3 = k1 ^ 0x7465646279746573ULL;
+    v0 = key[0] ^ 0x736f6d6570736575ULL;
+    v1 = key[1] ^ 0x646f72616e646f6dULL;
+    v2 = key[0] ^ 0x6c7967656e657261ULL;
+    v3 = key[1] ^ 0x7465646279746573ULL;
 
 #define rotl64(x, c) ( ((x) << (c)) ^ ((x) >> (64-(c))) )
 
@@ -160,7 +156,7 @@ unsigned int dictGenHashFunction(const unsigned char *buf, int len) {
 
 /* And a case insensitive hash function (based on djb hash) */
 unsigned int dictGenCaseHashFunction(const unsigned char *buf, int len) {
-    unsigned int hash = (unsigned int)dict_hash_function_seed;
+    unsigned int hash = 5381;
 
     while (len--)
         hash = ((hash << 5) + hash) + (tolower(*buf++)); /* hash * 33 + c */

--- a/src/dict.h
+++ b/src/dict.h
@@ -155,15 +155,15 @@ dictEntry *dictNext(dictIterator *iter);
 void dictReleaseIterator(dictIterator *iter);
 dictEntry *dictGetRandomKey(dict *d);
 void dictPrintStats(dict *d);
-unsigned int dictGenHashFunction(const void *key, int len);
+unsigned int dictGenHashFunction(const unsigned char *buf, int len);
 unsigned int dictGenCaseHashFunction(const unsigned char *buf, int len);
 void dictEmpty(dict *d);
 void dictEnableResize(void);
 void dictDisableResize(void);
 int dictRehash(dict *d, int n);
 int dictRehashMilliseconds(dict *d, int ms);
-void dictSetHashFunctionSeed(unsigned int initval);
-unsigned int dictGetHashFunctionSeed(void);
+void dictSetHashFunctionSeed(uint8_t *seed);
+uint8_t *dictGetHashFunctionSeed(void);
 
 /* Hash table types */
 extern dictType dictTypeHeapStringCopyKey;


### PR DESCRIPTION
SipHash is a cryptographically strong MAC designed for use in hash tables. Previously
Redis switched to murmur2 to try to prevent hash flooding DoS attacks:

https://github.com/antirez/redis/commit/da920e75d4836897b9a7109b6d4743e201cd8a4f

Unfortunately, murmur2 and murmur3 are both easy to attack, as there are algorithms which
can quickly generate arbitrarily many keys that all hash to the same value regardless of
what the seed is:

https://www.131002.net/siphash/murmur2collisions-20120821.tar.gz

By switching to SipHash, we get strong resistance to this kind of attack, without any
noticeable slowdown on either redis-benchmark or "DEBUG POPULATE 1000000". According to
the SUPERCOP benchmarks, this good hash performance holds true for both large and small
keys across all CPU architectures and models tested:

http://bench.cr.yp.to/impl-auth/siphash24.html

This patch also switches to using /dev/urandom as a source of high-quality randomness for
key generation on server startup, unless it is unavailable, in which case time and pid
are used instead.
