### PR TITLE
Fix nagating of which command result in install_server.sh

### DIFF
--- a/utils/install_server.sh
+++ b/utils/install_server.sh
@@ -157,7 +157,7 @@ REDIS_CHKCONFIG_INFO=\
 # Description: Redis daemon\n
 ### END INIT INFO\n\n"
 
-if [ !`which chkconfig` ] ; then 
+if [ ! `which chkconfig` ] ; then 
 	#combine the header and the template (which is actually a static footer)
 	echo $REDIS_INIT_HEADER > $TMP_FILE && cat $INIT_TPL_FILE >> $TMP_FILE || die "Could not write init script to $TMP_FILE"
 else
@@ -171,7 +171,7 @@ echo "Copied $TMP_FILE => $INIT_SCRIPT_DEST"
 
 #Install the service
 echo "Installing service..."
-if [ !`which chkconfig` ] ; then 
+if [ ! `which chkconfig` ] ; then 
 	#if we're not a chkconfig box assume we're able to use update-rc.d
 	update-rc.d redis_$REDIS_PORT defaults && echo "Success!"
 else


### PR DESCRIPTION
If you install redis w/ install_server.sh on RHEL(or its flavors), you'll end up with the following error:

```
$ sudo ./install_server.sh
Welcome to the redis service installer
This script will help you easily set up a running redis server
...
Installing service...
./install_server.sh: line 176: update-rc.d: command not found
 exists, process is already running or crashed
Installation successful!
```

This happens because negation of which command result is not handled correctly.
