### PR TITLE
Add max_memory and max_memory_human to INFO command

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1938,9 +1938,11 @@ sds genRedisInfoString(char *section) {
     if (allsections || defsections || !strcasecmp(section,"memory")) {
         char hmem[64];
         char peak_hmem[64];
+        char max_hmem[64];
 
         bytesToHuman(hmem,zmalloc_used_memory());
         bytesToHuman(peak_hmem,server.stat_peak_memory);
+        bytesToHuman(max_hmem,server.maxmemory);
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info,
             "# Memory\r\n"
@@ -1951,7 +1953,9 @@ sds genRedisInfoString(char *section) {
             "used_memory_peak_human:%s\r\n"
             "used_memory_lua:%lld\r\n"
             "mem_fragmentation_ratio:%.2f\r\n"
-            "mem_allocator:%s\r\n",
+            "mem_allocator:%s\r\n"
+            "max_memory:%zu\r\n"
+            "max_memory_human:%s\r\n",
             zmalloc_used_memory(),
             hmem,
             zmalloc_get_rss(),
@@ -1959,7 +1963,9 @@ sds genRedisInfoString(char *section) {
             peak_hmem,
             ((long long)lua_gc(server.lua,LUA_GCCOUNT,0))*1024LL,
             zmalloc_get_fragmentation_ratio(),
-            ZMALLOC_LIB
+            ZMALLOC_LIB,
+            server.maxmemory,
+            max_hmem
             );
     }
 


### PR DESCRIPTION
This pull request adds `max_memory` and `max_memory_human` to the `INFO` command's output.

Redis hosting providers often disable or rename the `CONFIG` command to lock down the Redis instance to a specific configuration based on a customer's plan. This makes it difficult to programmatically get the actual max memory (and subsequently the memory utilization) of the Redis instance.

Addresses #355
