### PR TITLE
patch config.h for sync_file_range

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -56,12 +56,13 @@
  * the plain fsync() call. */
 #ifdef __linux__
 #include <linux/version.h>
+#include <features.h>
 #ifdef __GLIBC__
-#if (LINUX_VERSION_CODE >= 0x020617 && GLIBC_VERSION_AT_LEAST(2, 6))
+#if (LINUX_VERSION_CODE >= 0x020611 && __GLIBC_PREREQ(2, 6))
 #define HAVE_SYNC_FILE_RANGE 1
 #endif
 #else
-#if (LINUX_VERSION_CODE >= 0x020617)
+#if (LINUX_VERSION_CODE >= 0x020611)
 #define HAVE_SYNC_FILE_RANGE 1
 #endif
 #endif


### PR DESCRIPTION
Have to change 0x020617 -> 0x020611 (it is hex code)
__GLIBC_PREREQ is better, linux supports this function.
