### PR TITLE
Removes dofile() from Lua

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -451,6 +451,8 @@ void luaLoadLibraries(lua_State *lua) {
 void luaRemoveUnsupportedFunctions(lua_State *lua) {
     lua_pushnil(lua);
     lua_setglobal(lua,"loadfile");
+    lua_pushnil(lua);
+    lua_setglobal(lua,"dofile");
 }
 
 /* This function installs metamethods in the global table _G that prevent


### PR DESCRIPTION
Removed dofile function from the Lua environment. 

dofile() called without arguments reads from STDIN and blocks and never finishes.

dofile called with file arguments can be used to determine if files exist or not, as well as it's probably not good to read scripts from disk for atomic operations.
