### PR TITLE
apply travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+script: make


### PR DESCRIPTION
I think it is better to apply travis ci to redis to prevent build error before releasing.

travis-ci is a free ci server.

and you will be able to check build status after commit.

but in redis, "make test" took too long time, so I just applied 

"scirpt: make" 

if you decide to use travis-ci . you have to register in travis-ci(just using github account)

and turn on your project compile  
