### PR TITLE
Update src/config.h

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -25,7 +25,7 @@
 #endif
 
 /* Test for backtrace() */
-#if defined(__APPLE__) || defined(__linux__) || defined(__sun)
+#if defined(__APPLE__) || defined(__linux__)
 #define HAVE_BACKTRACE 1
 #endif
 


### PR DESCRIPTION
Hi, antirez:
    Solaris platform doesn't support HAVE_BACKTRACE, so this will introduce compile error in Solaris platform. So I suggest remove (__sun) definition.
    Please help to check it, thanks very much!!
Best Regards
Nan Xiao
