### PR TITLE
Simple Condition Change - expireIfNeeded

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -879,8 +879,6 @@ int rewriteAppendOnlyFile(char *filename) {
             o = dictGetVal(de);
             initStaticStringObject(key,keystr);
 
-            expiretime = getExpire(db,&key);
-
             /* Save the key and associated value */
             if (o->type == REDIS_STRING) {
                 /* Emit a SET command */
@@ -900,7 +898,9 @@ int rewriteAppendOnlyFile(char *filename) {
             } else {
                 redisPanic("Unknown object type");
             }
+
             /* Save the expire time */
+            expiretime = getExpire(db,&key);
             if (expiretime != -1) {
                 char cmd[]="*3\r\n$9\r\nPEXPIREAT\r\n";
                 /* If this key is already expired skip it */

--- a/src/db.c
+++ b/src/db.c
@@ -520,7 +520,6 @@ int expireIfNeeded(redisDb *db, robj *key) {
     when = getExpire(db,key);
     if (when < 0) return 0; /* No expire for this key */
 
-
     /* If we are running in the context of a slave, return ASAP:
      * the slave key expiration is controlled by the master that will
      * send us synthesized DEL operations for expired keys.

--- a/src/db.c
+++ b/src/db.c
@@ -512,12 +512,14 @@ void propagateExpire(redisDb *db, robj *key) {
 }
 
 int expireIfNeeded(redisDb *db, robj *key) {
-    long long when = getExpire(db,key);
-
-    if (when < 0) return 0; /* No expire for this key */
+    long long when;
 
     /* Don't expire anything while loading. It will be done later. */
     if (server.loading) return 0;
+
+    when = getExpire(db,key);
+    if (when < 0) return 0; /* No expire for this key */
+
 
     /* If we are running in the context of a slave, return ASAP:
      * the slave key expiration is controlled by the master that will

--- a/src/debug.c
+++ b/src/debug.c
@@ -139,7 +139,6 @@ void computeDatasetDigest(unsigned char *final) {
 
             aux = htonl(o->type);
             mixDigest(digest,&aux,sizeof(aux));
-            expiretime = getExpire(db,keyobj);
 
             /* Save the key and associated value */
             if (o->type == REDIS_STRING) {
@@ -235,6 +234,7 @@ void computeDatasetDigest(unsigned char *final) {
                 redisPanic("Unknown object type");
             }
             /* If the key has an expire, add it to the mix */
+            expiretime = getExpire(db,keyobj);
             if (expiretime != -1) xorDigest(digest,"!!expire!!",10);
             /* We can finally xor the key-val digest to the final digest */
             xorDigest(final,digest,20);


### PR DESCRIPTION
redis doesn't need to call getExpire before check server.loading.
so moving call getExpire after server.loading check statement.
