### PR TITLE
remove MAGIC NUMBER timeout 1000

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1772,7 +1772,7 @@ try_again:
         return;
     if (getLongFromObjectOrReply(c,c->argv[4],&dbid,NULL) != REDIS_OK)
         return;
-    if (timeout <= 0) timeout = 1000;
+    if (timeout <= 0) timeout = DEFAULT_REDIS_CLUSTER_TIMEOUT;
 
     /* Check if the key is here. If not we reply with success as there is
      * nothing to migrate (for instance the key expired in the meantime), but

--- a/src/redis.h
+++ b/src/redis.h
@@ -91,6 +91,7 @@
 #define REDIS_REPL_PING_SLAVE_PERIOD 10
 #define REDIS_RUN_ID_SIZE 40
 #define REDIS_OPS_SEC_SAMPLES 16
+#define DEFAULT_REDIS_CLUSTER_TIMEOUT   1000
 
 /* Protocol and I/O related defines */
 #define REDIS_MAX_QUERYBUF_LEN  (1024*1024*1024) /* 1GB max query buffer. */


### PR DESCRIPTION
Remove cluster timeout 1000 to define DEFAULT_REDIS_CLUSTER_TIMEOUT
