### PR TITLE
fix randstring bug in ziplist.c

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1041,7 +1041,8 @@ void pop(unsigned char *zl, int where) {
 }
 
 int randstring(char *target, unsigned int min, unsigned int max) {
-    int p, len = min+rand()%(max-min+1);
+    int p = 0;
+    int len = min+rand()%(max-min+1);
     int minval, maxval;
     switch(rand() % 3) {
     case 0:


### PR DESCRIPTION
p is not initialized. but After fixing it, I found no one use randstring

but It is obviously bug. so I sent a patch.
