### PR TITLE
Replace "whoami" call with call to "id" in install_server.sh

### DIFF
--- a/utils/install_server.sh
+++ b/utils/install_server.sh
@@ -42,8 +42,8 @@ echo "This script will help you easily set up a running redis server
 
 "
 
-#check for root user TODO: replace this with a call to "id"
-if [ `whoami` != "root" ] ; then
+#check for root user
+if [ `id -u` != 0 ] ; then
 	echo "You must run this script as root. Sorry!"
 	exit 1
 fi


### PR DESCRIPTION
`id -u` is in the POSIX and LSB specs [1](http://pubs.opengroup.org/onlinepubs/009695399/utilities/id.html), while `whoami` is not.
Furthermore, the username of UID 0 can be changed (and is sometimes
recommended in a misguided attempt to increase security).

FreeBSD users logged in as `toor` would also slip through the cracks.

```
 http://refspecs.linuxfoundation.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/command.html
```
