### PR TITLE
i386 __sync_add_and_fetch_4 build error 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -210,8 +210,14 @@ bench: $(REDIS_BENCHMARK_NAME)
 32bit:
 	@echo ""
 	@echo "WARNING: if it fails under Linux you probably need to install libc6-dev-i386"
-	@echo ""
+	@echo "WARINIG: if you meet '__sync_add_and_fetch_4' error, try to 'make 32bitsync'"
 	$(MAKE) CFLAGS="-m32" LDFLAGS="-m32"
+
+32bitsync:
+	@echo ""
+	@echo "WARNING: if it fails under Linux you probably need to install libc6-dev-i386"
+	@echo ""
+	$(MAKE) CFLAGS="-m32 -march=i686" LDFLAGS="-m32"
 
 gcov:
 	$(MAKE) REDIS_CFLAGS="-fprofile-arcs -ftest-coverage -DCOVERAGE_TEST" REDIS_LDFLAGS="-fprofile-arcs -ftest-coverage"

--- a/src/Makefile
+++ b/src/Makefile
@@ -92,9 +92,9 @@ MAKECOLOR="\033[32;1m"
 ENDCOLOR="\033[0m"
 
 ifndef V
-QUIET_CC = @printf '	%b %b\n' $(CCCOLOR)CC$(ENDCOLOR) $(SRCCOLOR)$@$(ENDCOLOR) 1>&2;
-QUIET_LINK = @printf '	%b %b\n' $(LINKCOLOR)LINK$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
-QUIET_INSTALL = @printf '	%b %b\n' $(LINKCOLOR)INSTALL$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
+QUIET_CC = @printf '    %b %b\n' $(CCCOLOR)CC$(ENDCOLOR) $(SRCCOLOR)$@$(ENDCOLOR) 1>&2;
+QUIET_LINK = @printf '    %b %b\n' $(LINKCOLOR)LINK$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
+QUIET_INSTALL = @printf '    %b %b\n' $(LINKCOLOR)INSTALL$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
 endif
 
 REDIS_SERVER_NAME= redis-server

--- a/src/Makefile
+++ b/src/Makefile
@@ -210,7 +210,7 @@ bench: $(REDIS_BENCHMARK_NAME)
 32bit:
 	@echo ""
 	@echo "WARNING: if it fails under Linux you probably need to install libc6-dev-i386"
-	@echo "WARINIG: if you meet '__sync_add_and_fetch_4' error, try to 'make 32bitsync'"
+	@echo "WARNING: if you meet '__sync_add_and_fetch_4' error, try to 'make 32bitsync'"
 	@echo ""
 	$(MAKE) CFLAGS="-m32" LDFLAGS="-m32"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -92,9 +92,9 @@ MAKECOLOR="\033[32;1m"
 ENDCOLOR="\033[0m"
 
 ifndef V
-QUIET_CC = @printf '    %b %b\n' $(CCCOLOR)CC$(ENDCOLOR) $(SRCCOLOR)$@$(ENDCOLOR) 1>&2;
-QUIET_LINK = @printf '    %b %b\n' $(LINKCOLOR)LINK$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
-QUIET_INSTALL = @printf '    %b %b\n' $(LINKCOLOR)INSTALL$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
+QUIET_CC = @printf '	%b %b\n' $(CCCOLOR)CC$(ENDCOLOR) $(SRCCOLOR)$@$(ENDCOLOR) 1>&2;
+QUIET_LINK = @printf '	%b %b\n' $(LINKCOLOR)LINK$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
+QUIET_INSTALL = @printf '	%b %b\n' $(LINKCOLOR)INSTALL$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
 endif
 
 REDIS_SERVER_NAME= redis-server
@@ -210,7 +210,7 @@ bench: $(REDIS_BENCHMARK_NAME)
 32bit:
 	@echo ""
 	@echo "WARNING: if it fails under Linux you probably need to install libc6-dev-i386"
-	@echo "WARNING: if you meet '__sync_add_and_fetch_4' error, try to 'make 32bitsync'"
+	@echo "WARNING: if make fails with undefined reference to '__sync_add_and_fetch_4' , invoke 'make 32bitsync'."
 	@echo ""
 	$(MAKE) CFLAGS="-m32" LDFLAGS="-m32"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -211,6 +211,7 @@ bench: $(REDIS_BENCHMARK_NAME)
 	@echo ""
 	@echo "WARNING: if it fails under Linux you probably need to install libc6-dev-i386"
 	@echo "WARINIG: if you meet '__sync_add_and_fetch_4' error, try to 'make 32bitsync'"
+	@echo ""
 	$(MAKE) CFLAGS="-m32" LDFLAGS="-m32"
 
 32bitsync:


### PR DESCRIPTION
add 32bitsync label for some people who are suffering from __sync_add_and_fetch_4

these days,  many people experienced this build failure and adding CFLAGS=-march=i686 is not intuitive . because make 32bit overload user define CFLAGS. so 32bitsync will be useful for some people who wants to solve this problem.
