### PR TITLE
remove compile warning bioKillThreads

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -37,6 +37,7 @@
 #include <execinfo.h>
 #include <ucontext.h>
 #include <fcntl.h>
+#include "bio.h"
 #endif /* HAVE_BACKTRACE */
 
 /* ================================= Debugging ============================== */


### PR DESCRIPTION
in debug.c, lack of including "bio.h" 
it can cause compile warning. and it can potentially cause compile error 
