### PR TITLE
remove unnecessary condition

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -621,8 +621,7 @@ static int _dictExpandIfNeeded(dict *d)
         (dict_can_resize ||
          d->ht[0].used/d->ht[0].size > dict_force_resize_ratio))
     {
-        return dictExpand(d, ((d->ht[0].size > d->ht[0].used) ?
-                                    d->ht[0].size : d->ht[0].used)*2);
+        return dictExpand(d, d->ht[0].used*2);
     }
     return DICT_OK;
 }


### PR DESCRIPTION
it is @erbenmo 's idea.

and I am sure it is unnecessary condition

here is no case d->ht[0].size > d->ht[0].used in the line which calls dictExpand. It just needs d->ht[0].used \* 2
