### PR TITLE
suggest zregCommand to search sorted set with regexp(stringmatchlen)

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -177,6 +177,7 @@ struct redisCommand redisCommandTable[] = {
     {"zscore",zscoreCommand,3,"r",0,NULL,1,1,1,0,0},
     {"zrank",zrankCommand,3,"r",0,NULL,1,1,1,0,0},
     {"zrevrank",zrevrankCommand,3,"r",0,NULL,1,1,1,0,0},
+    {"zreg",zregCommand,3,"rS",0,NULL,0,0,0,0,0},
     {"hset",hsetCommand,4,"wm",0,NULL,1,1,1,0,0},
     {"hsetnx",hsetnxCommand,4,"wm",0,NULL,1,1,1,0,0},
     {"hget",hgetCommand,3,"r",0,NULL,1,1,1,0,0},

--- a/src/redis.h
+++ b/src/redis.h
@@ -1303,6 +1303,7 @@ void hlenCommand(redisClient *c);
 void zremrangebyrankCommand(redisClient *c);
 void zunionstoreCommand(redisClient *c);
 void zinterstoreCommand(redisClient *c);
+void zregCommand(redisClient *c);
 void hkeysCommand(redisClient *c);
 void hvalsCommand(redisClient *c);
 void hgetallCommand(redisClient *c);

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -24,6 +24,18 @@ start_server {tags {"zset"}} {
             assert_encoding $encoding ztmp
         }
 
+        test "ZREG - $encoding" {
+            r del ztmp 
+            r zadd ztmp 1 1
+            r zadd ztmp 2 2
+            r zadd ztmp 3 one
+            r zadd ztmp 4 two
+            r zadd ztmp 5 three
+            assert_equal {1 2 one two three} [r zreg ztmp *]
+            assert_equal {one two} [r zreg ztmp *o*]
+            assert_equal {2} [r zreg ztmp 2]
+        }
+
         test "ZSET basic ZADD and score update - $encoding" {
             r del ztmp
             r zadd ztmp 10 x


### PR DESCRIPTION
1. Why?
   some users use KEYS command to search special keyspaces. and they uses KEYS Command in production. so it can cause many problems. because KEYS command has to visit all keys. so for example, if redis has more than 1M~10M keys, it can't process other commands well.
   so. there is alternative. storing key name in the sorted set or other collections. but it is not useful because it doesn;t support regexp like KEYS. and I choose Sorted Set, Inserting and Deleting function has to be fast to use in above situation.

2.How?
 so I suggest zregCommand like KEYS. it can use like this.

``` c
zreg keyname <regexp>
```

Thank you.
