### PR TITLE
fix LC_COLLATE issue #176

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -189,6 +189,8 @@ void loadServerConfigFromString(char *config) {
             if (server.maxclients < 1) {
                 err = "Invalid max clients limit"; goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"locale") && argc == 2) {
+            server.locale = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"maxmemory") && argc == 2) {
             server.maxmemory = memtoll(argv[1],NULL);
         } else if (!strcasecmp(argv[0],"maxmemory-policy") && argc == 2) {

--- a/src/redis.c
+++ b/src/redis.c
@@ -49,6 +49,8 @@
 #include <math.h>
 #include <sys/resource.h>
 #include <sys/utsname.h>
+#include <locale.h>
+#include <stdlib.h>
 
 /* Our shared "common" objects */
 
@@ -1235,6 +1237,10 @@ void initServerConfig() {
     server.assert_line = 0;
     server.bug_report_start = 0;
     server.watchdog_period = 0;
+    server.locale = getenv("LC_COLLATE");
+    if( server.locale == NULL ){
+        server.locale = zstrdup("en_US.utf8"); 
+    }
 }
 
 /* This function will try to raise the max number of open files accordingly to
@@ -2672,6 +2678,7 @@ int main(int argc, char **argv) {
     if (server.daemonize) createPidFile();
     redisAsciiArt();
 
+    setlocale( LC_COLLATE, server.locale );
     if (!server.sentinel_mode) {
         /* Things only needed when not running in Sentinel mode. */
         redisLog(REDIS_WARNING,"Server started, Redis version " REDIS_VERSION);

--- a/src/redis.h
+++ b/src/redis.h
@@ -796,6 +796,8 @@ struct redisServer {
     int assert_line;
     int bug_report_start; /* True if bug report header was already logged. */
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
+    /* locale */
+    char *locale;
 };
 
 typedef struct pubsubPattern {


### PR DESCRIPTION
sortCompare has a bug in sort.c

if server.sort_alpha is true, sort_alpha has nothing to do with sort_bypattern.

so it has to compare with strcoll instead of compareStringObject.

and add locale config parameter to set locale easily.
