### PR TITLE
remove unnessary codes

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -757,16 +757,14 @@ void sendReplyToClient(aeEventLoop *el, int fd, void *privdata, int mask) {
             (server.maxmemory == 0 ||
              zmalloc_used_memory() < server.maxmemory)) break;
     }
-    if (nwritten == -1) {
-        if (errno == EAGAIN) {
-            nwritten = 0;
-        } else {
-            redisLog(REDIS_VERBOSE,
+
+    if (nwritten == -1 && errno != EAGAIN) {
+        redisLog(REDIS_VERBOSE,
                 "Error writing to client: %s", strerror(errno));
-            freeClient(c);
-            return;
-        }
+        freeClient(c);
+        return;
     }
+
     if (totwritten > 0) c->lastinteraction = server.unixtime;
     if (c->bufpos == 0 && listLength(c->reply) == 0) {
         c->sentlen = 0;

--- a/src/util.c
+++ b/src/util.c
@@ -391,8 +391,6 @@ void getRandomHexChars(char *p, unsigned int len) {
         }
         if (l >= sizeof(pid)) {
             memcpy(x,&pid,sizeof(pid));
-            l -= sizeof(pid);
-            x += sizeof(pid);
         }
         /* Finally xor it with rand() output, that was already seeded with
          * time() at startup. */


### PR DESCRIPTION
remove unnecessary codes
1. nwritten = 0; is not necessary.
- not anti warning.
1. variabless l, j is not used after that position.
