### PR TITLE
fix to use command name when SETEX/PSETEX fail

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -49,7 +49,9 @@ void setGenericCommand(redisClient *c, int nx, robj *key, robj *val, robj *expir
         if (getLongLongFromObjectOrReply(c, expire, &milliseconds, NULL) != REDIS_OK)
             return;
         if (milliseconds <= 0) {
-            addReplyError(c,"invalid expire time in SETEX");
+            char buf[128];
+            sprintf( buf, "invalid expire time in %s", (char *)(c->argv[0]->ptr) );
+            addReplyError(c,buf);
             return;
         }
         if (unit == UNIT_SECONDS) milliseconds *= 1000;


### PR DESCRIPTION
when using SETEX/PSETEX and when their expire time is less than 0
their error message are the same.

``` c
redis 127.0.0.1:6379> SETEX mykey -1 "Hello"
(error) ERR invalid expire time in SETEX
(5.60s)
redis 127.0.0.1:6379> PSETEX mykey -1 "Hello"
(error) ERR invalid expire time in SETEX
(3.69s)
```

so I changed to use their own names when PSETEX fails

``` c
redis 127.0.0.1:6379> SETEX mykey -1 "Hello"
(error) ERR invalid expire time in SETEX
redis 127.0.0.1:6379> PSETEX mykey -1 "Hello"
(error) ERR invalid expire time in PSETEX
redis 127.0.0.1:6379> 
```
