### PR TITLE
test-server: only listen to 127.0.0.1

### DIFF
--- a/tests/assets/default.conf
+++ b/tests/assets/default.conf
@@ -5,6 +5,7 @@ daemonize no
 pidfile /var/run/redis.pid
 port 6379
 timeout 0
+bind 127.0.0.1
 loglevel verbose
 logfile ''
 databases 16

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -186,7 +186,7 @@ proc test_server_main {} {
     if {!$::quiet} {
         puts "Starting test server at port $port"
     }
-    socket -server accept_test_clients $port
+    socket -server accept_test_clients -myaddr 127.0.0.1 $port
 
     # Start the client instances
     set ::clients_pids {}


### PR DESCRIPTION
It makes no sense to listen to 0.0.0.0 for make test.
