### PR TITLE
Fix a bug in cluster.c that causes redis-trib.rb the invalid byte sequence error.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -331,6 +331,8 @@ clusterNode *createClusterNode(char *nodename, int flags) {
     node->ping_sent = node->pong_received = 0;
     node->configdigest = NULL;
     node->configdigest_ts = 0;
+    node->ip[0] = '\0';
+    node->port = 0;
     node->link = NULL;
     return node;
 }


### PR DESCRIPTION
Hi, I am looking forward to Redis Cluster, and now trying some features.

I found that redis-trib.rb does not work on my environment (Ubuntu 12.10 + GCC 4.7.2) because of an error as follows.

```
% ruby redis-trib.rb create 127.0.0.1:6379 127.0.0.1:6380 127.0.0.1:6381
Creating cluster
Connecting to node 127.0.0.1:6379: OK
redis-trib.rb:95:in `split': invalid byte sequence in US-ASCII (ArgumentError)
        from redis-trib.rb:95:in `load_info'
        from redis-trib.rb:450:in `block in create_cluster_cmd'
        from redis-trib.rb:446:in `each'
        from redis-trib.rb:446:in `create_cluster_cmd'
        from redis-trib.rb:492:in `<main>'
```

This is because of the uninitialized fields _ip_ and _port_ of the _clusterNode_ for _myself_. We can also check this by the CLUSTER NODES command.

```
% redis-cli
redis 127.0.0.1:6379> CLUSTER NODES
04c162326adf4c1266b91ae19715e3b51fdb329f ?:-259964664 myself - 0 0 connected
                                         ^^^^^^^^^^^^
```

This commit adds the code to initialize the _ip_ and _port_ fields in the _createClusterNode_ function. I hope that this pull request will help people try Redis Cluster.
