### PR TITLE
Define _XOPEN_SOURCE appropriately on NetBSD.

### DIFF
--- a/deps/hiredis/fmacros.h
+++ b/deps/hiredis/fmacros.h
@@ -7,7 +7,7 @@
 
 #if defined(__sun__)
 #define _POSIX_C_SOURCE 200112L
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #define _XOPEN_SOURCE 600
 #else
 #define _XOPEN_SOURCE

--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -36,7 +36,7 @@
 #define _GNU_SOURCE
 #endif
 
-#if defined(__linux__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #define _XOPEN_SOURCE 700
 #else
 #define _XOPEN_SOURCE


### PR DESCRIPTION
At least with NetBSD 5 and 6, _XOPEN_SOURCE needs to be defined as it is for Linux. My inclination would be to use this definition as the default and special case the systems where it doesn't work, but this change works for me. I've tested this on both NetBSD 5 and 6, on 32- and 64-bit systems.

Full disclosure: to link on 32-bit systems, I also had to add a -march setting to CFLAGS. Otherwise I get an undefined error for __sync_add_and_fetch_4. I think that's just a general gcc issue and I don't have a patch for it.

Thanks.
