### PR TITLE
Fix wrong repldboff type which causes dropped replication in rare cases.

### DIFF
--- a/src/redis.h
+++ b/src/redis.h
@@ -399,7 +399,7 @@ typedef struct redisClient {
     int authenticated;      /* when requirepass is non-NULL */
     int replstate;          /* replication state if this is a slave */
     int repldbfd;           /* replication DB file descriptor */
-    long repldboff;         /* replication DB file offset */
+    off_t repldboff;        /* replication DB file offset */
     off_t repldbsize;       /* replication DB file size */
     int slave_listening_port; /* As configured with: SLAVECONF listening-port */
     multiState mstate;      /* MULTI/EXEC state */


### PR DESCRIPTION
Having a 'long' offset to an 'off_t' sized data block is wrong when size is greater than 2GB and less than 4GB, on a 32-bit process.  This results with replication being interrupted after transferring the first 2GB.
