### PR TITLE
redis-cli: fix prompt after shutdown command

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -487,8 +487,11 @@ static int cliReadReply(int output_raw_strings) {
     int output = 1;
 
     if (redisGetReply(context,&_reply) != REDIS_OK) {
-        if (config.shutdown)
+        if (config.shutdown) {
+            redisFree(context);
+            context = NULL;
             return REDIS_OK;
+        }
         if (config.interactive) {
             /* Filter cases where we should reconnect */
             if (context->err == REDIS_ERR_IO && errno == ECONNRESET)


### PR DESCRIPTION
Fix redis-cli prompt to state `not connected` after a `SHUTDOWN` command is sent.

Original scenario (before fix):

```
redis 127.0.0.1:6379> KEYS *
1) "aaa"
redis 127.0.0.1:6379> SHUTDOWN
redis 127.0.0.1:6379> KEYS *
redis 127.0.0.1:6379> GET aaa
redis 127.0.0.1:6379> 
```

Same scenario after redis-cli fix:

```
redis 127.0.0.1:6379> KEYS *
1) "aaa"
redis 127.0.0.1:6379> SHUTDOWN
not connected> KEYS *
Could not connect to Redis at 127.0.0.1:6379: Connection refused
not connected> GET aaa
Could not connect to Redis at 127.0.0.1:6379: Connection refused
not connected> 
```
