### PR TITLE
Add fall-through for bytesToHuman for very large values (just print the bytes)

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1890,7 +1890,14 @@ void bytesToHuman(char *s, unsigned long long n) {
     } else if (n < (1024LL*1024*1024*1024)) {
         d = (double)n/(1024LL*1024*1024);
         sprintf(s,"%.2fG",d);
+    } else if (n < (1024LL*1024*1024*1024*1024)) {
+        d = (double)n/(1024LL*1024*1024*1024);
+        sprintf(s,"%.2fT",d);
+    } else if (n < (1024LL*1024*1024*1024*1024*1024)) {
+        d = (double)n/(1024LL*1024*1024*1024*1024);
+        sprintf(s,"%.2fP",d);
     } else {
+        /* Let's hope we never need this */
         sprintf(s,"%lluB",n);
     }
 }

--- a/src/redis.c
+++ b/src/redis.c
@@ -1890,6 +1890,8 @@ void bytesToHuman(char *s, unsigned long long n) {
     } else if (n < (1024LL*1024*1024*1024)) {
         d = (double)n/(1024LL*1024*1024);
         sprintf(s,"%.2fG",d);
+    } else {
+        sprintf(s,"%lluB",n);
     }
 }
 


### PR DESCRIPTION
We have seen an issue where an instance had a very large peak memory usage: `used_memory_peak:18446744073706301432`. The `bytesToHuman()` function can't stringify that properly (we get: `used_memory_peak_human:\x90\f\x83\xFB\x83\u007F`) so here's a version that resorts to simply printing the bytes for too-large values.
