### PR TITLE
Make redis test suite tcl version agnostic

### DIFF
--- a/runtest
+++ b/runtest
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL=tclsh8.5
+TCL=tclsh
 which $TCL
 if [ "$?" != "0" ]
 then

--- a/tests/integration/replication-4.tcl
+++ b/tests/integration/replication-4.tcl
@@ -1,5 +1,5 @@
 proc start_bg_complex_data {host port db ops} {
-    exec tclsh8.5 tests/helpers/bg_complex_data.tcl $host $port $db $ops &
+    exec tclsh tests/helpers/bg_complex_data.tcl $host $port $db $ops &
 }
 
 proc stop_bg_complex_data {handle} {

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -78,7 +78,7 @@ start_server {tags {"repl"}} {
 }
 
 proc start_write_load {host port seconds} {
-    exec tclsh8.5 tests/helpers/gen_write_load.tcl $host $port $seconds &
+    exec tclsh tests/helpers/gen_write_load.tcl $host $port $seconds &
 }
 
 proc stop_write_load {handle} {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -189,7 +189,7 @@ proc test_server_main {} {
     set start_port [expr {$::port+100}]
     for {set j 0} {$j < $::numclients} {incr j} {
         set start_port [find_available_port $start_port]
-        set p [exec tclsh8.5 [info script] {*}$::argv \
+        set p [exec tclsh [info script] {*}$::argv \
             --client $port --port $start_port &]
         lappend ::clients_pids $p
         incr start_port 10

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -2,6 +2,8 @@
 # This softare is released under the BSD License. See the COPYING file for
 # more information.
 
+package require Tcl 8.5
+
 set tcl_precision 17
 source tests/support/redis.tcl
 source tests/support/server.tcl


### PR DESCRIPTION
Just ran the test suite against tcl 8.6.0, which worked nicely. The test suite currently uses `tclsh8.5` everywhere, so I made calls to `tclsh` instead. Since there's currently a 8.5 requirement, I added a check for that.
