### PR TITLE
prohibit to run freeMemoryIfNeed when it is slave

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -2304,6 +2304,8 @@ void monitorCommand(redisClient *c) {
  * used by the server.
  */
 int freeMemoryIfNeeded(void) {
+    if (server.masterhost) return REDIS_OK;
+
     size_t mem_used, mem_tofree, mem_freed;
     int slaves = listLength(server.slaves);
 


### PR DESCRIPTION
Situation: 
    when Slave's maxmemory and maxmemory-policy are different from Master's
    some datum are in Master but they aren't in Slave.

How:
    for consistency between master and slave. it is better to turn off slave's freememoryIfNeed.

Why::
    1] at the first time, I considered to copy master's maxmemory and maxmemory-policy setting 
    when they sync for the first time. but it can cause some troubles. because Master and Slave uses memory
    differently. 

```
2] even though, they uses same maxmemory-policy, slave can perform "LRU or Expire" itself.
```

In conclusion, Skipping freememoryIfNeed in slave is better.
