### PR TITLE
redis-cli prompt bug fix

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -794,6 +794,7 @@ static void repl() {
                     sdsfree(config.hostip);
                     config.hostip = sdsnew(argv[1]);
                     config.hostport = atoi(argv[2]);
+                    cliRefreshPrompt();
                     cliConnect(1);
                 } else if (argc == 1 && !strcasecmp(argv[0],"clear")) {
                     linenoiseClearScreen();


### PR DESCRIPTION
after failing connect to server through redis-cli 

and try to redis server using "redis-server"

It couldn't update the redis-cli prompt 

before:

``` c
charsyam@ubuntu:~/projects/redis-charsyam/src$ redis-cli -p 3000
Could not connect to Redis at 127.0.0.1:3000: Connection refused
not connected> connect 127.0.0.1 6379
redis 127.0.0.1:3000> <-- it isn't updated.
```

applying this patch.

``` c
charsyam@ubuntu:~/projects/redis-charsyam/src$ ./redis-cli -p 3000
Could not connect to Redis at 127.0.0.1:3000: Connection refused
not connected> connect 127.0.0.1 6379
redis 127.0.0.1:6379>
```

It is updated well.
