### PR TITLE
redis-cli --rdb fails if server sends a ping

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -958,8 +958,8 @@ unsigned long long sendSync(int fd) {
             fprintf(stderr,"Error reading bulk length while SYNCing\n");
             exit(1);
         }
-        if (*p == '\n') break;
-        p++;
+        if (*p == '\n' && p != buf) break;
+        if (*p != '\n') p++;
     }
     *p = '\0';
     if (buf[0] == '-') {


### PR DESCRIPTION
Redis pings slaves in "pre-synchronization stage" with newlines. (See
https://github.com/antirez/redis/blob/2.6.9/src/replication.c#L814)
However, redis-cli does not expect this - it sees the newline as the end
of the bulk length line, and ends up returning 0 as bulk the length.
This manifests as the following when running redis-cli:

```
$ ./src/redis-cli --rdb some_file
SYNC sent to master, writing 0 bytes to 'some_file'
Transfer finished with success.
```

With this commit, we just ignore leading newlines while reading the bulk
length line.

To reproduce the problem, load enough data into Redis so that the
preparation of the RDB snapshot takes long enough for a ping to occur
while redis-cli is waiting for the data.
