### PR TITLE
Fix an error reply for CLIENT command

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1228,7 +1228,7 @@ void clientCommand(redisClient *c) {
         else
             addReply(c,shared.nullbulk);
     } else {
-        addReplyError(c, "Syntax error, try CLIENT (LIST | KILL ip:port)");
+        addReplyError(c, "Syntax error, try CLIENT (LIST | KILL ip:port | GETNAME | SETNAME connection-name)");
     }
 }
 


### PR DESCRIPTION
Thank you for introducing nice `CLIENT GETNAME` and `CLIENT SETNAME` commands. 

This pull request adds a description of the newly introduced commands to the error reply for syntax errors in `CLIENT` commands.
