### PR TITLE
Make redis test suite tcl version agnostic, v2

### DIFF
--- a/runtest
+++ b/runtest
@@ -1,9 +1,14 @@
 #!/bin/sh
-TCL=tclsh8.5
-which $TCL
-if [ "$?" != "0" ]
+TCL_VERSIONS="8.5 8.6"
+TCLSH=""
+
+for VERSION in $TCL_VERSIONS; do
+	TCL=`which tclsh$VERSION 2>/dev/null` && TCLSH=$TCL
+done
+
+if [ -z $TCLSH ]
 then
-    echo "You need '$TCL' in order to run the Redis test"
+    echo "You need tcl 8.5 or newer in order to run the Redis test"
     exit 1
 fi
-$TCL tests/test_helper.tcl $*
+$TCLSH tests/test_helper.tcl $*

--- a/tests/integration/replication-4.tcl
+++ b/tests/integration/replication-4.tcl
@@ -1,5 +1,6 @@
 proc start_bg_complex_data {host port db ops} {
-    exec tclsh8.5 tests/helpers/bg_complex_data.tcl $host $port $db $ops &
+    set tclsh [info nameofexecutable]
+    exec $tclsh tests/helpers/bg_complex_data.tcl $host $port $db $ops &
 }
 
 proc stop_bg_complex_data {handle} {

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -78,7 +78,8 @@ start_server {tags {"repl"}} {
 }
 
 proc start_write_load {host port seconds} {
-    exec tclsh8.5 tests/helpers/gen_write_load.tcl $host $port $seconds &
+    set tclsh [info nameofexecutable]
+    exec $tclsh tests/helpers/gen_write_load.tcl $host $port $seconds &
 }
 
 proc stop_write_load {handle} {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -2,6 +2,8 @@
 # This softare is released under the BSD License. See the COPYING file for
 # more information.
 
+package require Tcl 8.5
+
 set tcl_precision 17
 source tests/support/redis.tcl
 source tests/support/server.tcl

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -178,6 +178,7 @@ proc find_available_port start {
 
 proc test_server_main {} {
     cleanup
+    set tclsh [info nameofexecutable]
     # Open a listening socket, trying different ports in order to find a
     # non busy one.
     set port [find_available_port 11111]
@@ -191,7 +192,7 @@ proc test_server_main {} {
     set start_port [expr {$::port+100}]
     for {set j 0} {$j < $::numclients} {incr j} {
         set start_port [find_available_port $start_port]
-        set p [exec tclsh8.5 [info script] {*}$::argv \
+        set p [exec $tclsh [info script] {*}$::argv \
             --client $port --port $start_port &]
         lappend ::clients_pids $p
         incr start_port 10


### PR DESCRIPTION
Updated pull request of https://github.com/antirez/redis/pull/877, with a different approach, using `info nameofexecutable` to get current running version of tcl.

shell script changes tested on OS X, linux (gentoo), openbsd and freebsd.
