### PR TITLE
remove compile warning

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1948,7 +1948,7 @@ sds genRedisInfoString(char *section) {
             REDIS_VERSION,
             redisGitSHA1(),
             strtol(redisGitDirty(),NULL,10) > 0,
-            redisBuildId(),
+            (long long unsigned int)redisBuildId(),
             mode,
             name.sysname, name.release, name.machine,
             server.arch_bits,
@@ -2502,7 +2502,7 @@ void version() {
         atoi(redisGitDirty()) > 0,
         ZMALLOC_LIB,
         sizeof(long) == 4 ? 32 : 64,
-        redisBuildId());
+        (long long unsigned int)redisBuildId());
     exit(0);
 }
 


### PR DESCRIPTION
This patch just removes the following build warning messages:

``` c
    CC dict.o
    CC redis.o
redis.c: In function ‘genRedisInfoString’:
redis.c:1967:13: warning: format ‘%llx’ expects argument of type ‘long long unsigned int’, but argument 6 has type ‘uint64_t’ [-Wformat]
redis.c: In function ‘version’:
redis.c:2505:9: warning: format ‘%llx’ expects argument of type ‘long long unsigned int’, but argument 7 has type ‘uint64_t’ [-Wformat]
    CC sds.o
    CC zmalloc.o
```

and now

``` c
    CC dict.o
    CC redis.o
    CC sds.o
    CC zmalloc.o
```
