### PR TITLE
Fix install_server.sh for CentOS/RHEL

### DIFF
--- a/utils/install_server.sh
+++ b/utils/install_server.sh
@@ -159,7 +159,7 @@ REDIS_CHKCONFIG_INFO=\
 # Description: Redis daemon\n
 ### END INIT INFO\n\n"
 
-if [ !`which chkconfig` ] ; then 
+if [ ! `which chkconfig` ] ; then 
 	#combine the header and the template (which is actually a static footer)
 	echo $REDIS_INIT_HEADER > $TMP_FILE && cat $INIT_TPL_FILE >> $TMP_FILE || die "Could not write init script to $TMP_FILE"
 else
@@ -173,7 +173,7 @@ echo "Copied $TMP_FILE => $INIT_SCRIPT_DEST"
 
 #Install the service
 echo "Installing service..."
-if [ !`which chkconfig` ] ; then 
+if [ ! `which chkconfig` ] ; then 
 	#if we're not a chkconfig box assume we're able to use update-rc.d
 	update-rc.d redis_$REDIS_PORT defaults && echo "Success!"
 else


### PR DESCRIPTION
The check to see if chkconfig exists is missing a space after `!`, so on CentOS/RHEL, the script will still try to use update-rc.d:

```
Installing service...
./install_server.sh: line 178: update-rc.d: command not found
```

This patch changes two occurrences (lines 162 and 176) of :

```
if [ !`which chkconfig` ] ; then 
```

to

```
if [ ! `which chkconfig` ] ; then 
```
