### PR TITLE
fix comments forgotten in #285 (zipmap -> ziplist)

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -539,7 +539,7 @@ dictType commandTableDictType = {
     NULL                       /* val destructor */
 };
 
-/* Hash type hash table (note that small hashes are represented with zipmaps) */
+/* Hash type hash table (note that small hashes are represented with ziplists) */
 dictType hashDictType = {
     dictEncObjHash,             /* hash function */
     NULL,                       /* key dup */

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -739,10 +739,10 @@ unsigned char *ziplistPrev(unsigned char *zl, unsigned char *p) {
     }
 }
 
-/* Get entry pointer to by 'p' and store in either 'e' or 'v' depending
+/* Get entry pointed to by 'p' and store in either 'e' or 'v' depending
  * on the encoding of the entry. 'e' is always set to NULL to be able
  * to find out whether the string pointer or the integer value was set.
- * Return 0 if 'p' points to the end of the zipmap, 1 otherwise. */
+ * Return 0 if 'p' points to the end of the ziplist, 1 otherwise. */
 unsigned int ziplistGet(unsigned char *p, unsigned char **sstr, unsigned int *slen, long long *sval) {
     zlentry entry;
     if (p == NULL || p[0] == ZIP_END) return 0;


### PR DESCRIPTION
Small hashes are now encoded as ziplists. I stumbled upon these leftover comments in the source this weekend and they confused me ;)
