### PR TITLE
Fix a few typos and improve grammar of redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -39,8 +39,8 @@ port 6379
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout 0
 
-# Set server verbosity to 'debug'
-# it can be one of:
+# Specify the server verbosity level.
+# This can be one of:
 # debug (a lot of information, useful for development/testing)
 # verbose (many rarely useful info, but not a mess like the debug level)
 # notice (moderately verbose, what you want in production probably)
@@ -59,7 +59,7 @@ logfile stdout
 # Specify the syslog identity.
 # syslog-ident redis
 
-# Specify the syslog facility.  Must be USER or between LOCAL0-LOCAL7.
+# Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
 # syslog-facility local0
 
 # Set the number of databases. The default database is DB 0, you can select
@@ -114,7 +114,7 @@ stop-writes-on-bgsave-error yes
 # the dataset will likely be bigger if you have compressible values or keys.
 rdbcompression yes
 
-# Since verison 5 of RDB a CRC64 checksum is placed at the end of the file.
+# Since version 5 of RDB a CRC64 checksum is placed at the end of the file.
 # This makes the format more resistant to corruption but there is a performance
 # hit to pay (around 10%) when saving and loading RDB files, so you can disable it
 # for maximum performances.
@@ -131,7 +131,7 @@ dbfilename dump.rdb
 # The DB will be written inside this directory, with the filename specified
 # above using the 'dbfilename' configuration directive.
 # 
-# Also the Append Only File will be created inside this directory.
+# The Append Only File will also be created inside this directory.
 # 
 # Note that you must specify a directory here, not a file name.
 dir ./
@@ -152,7 +152,7 @@ dir ./
 #
 # masterauth <master-password>
 
-# When a slave lost the connection with the master, or when the replication
+# When a slave loses its connection with the master, or when the replication
 # is still in progress, the slave can act in two different ways:
 #
 # 1) if slave-serve-stale-data is set to 'yes' (the default) the slave will
@@ -230,14 +230,14 @@ slave-priority 100
 #
 # It is possible to change the name of dangerous commands in a shared
 # environment. For instance the CONFIG command may be renamed into something
-# of hard to guess so that it will be still available for internal-use
-# tools but not available for general clients.
+# hard to guess so that it will still be available for internal-use tools
+# but not available for general clients.
 #
 # Example:
 #
 # rename-command CONFIG b840fc02d524045429941cc15f59e41cb7be6c52
 #
-# It is also possible to completely kill a command renaming it into
+# It is also possible to completely kill a command by renaming it into
 # an empty string:
 #
 # rename-command CONFIG ""
@@ -281,7 +281,7 @@ slave-priority 100
 # maxmemory <bytes>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
-# is reached? You can select among five behavior:
+# is reached. You can select among five behaviors:
 # 
 # volatile-lru -> remove the key with an expire set using an LRU algorithm
 # allkeys-lru -> remove any key accordingly to the LRU algorithm
@@ -290,7 +290,7 @@ slave-priority 100
 # volatile-ttl -> remove the key with the nearest expire time (minor TTL)
 # noeviction -> don't expire at all, just return an error on write operations
 # 
-# Note: with all the kind of policies, Redis will return an error on write
+# Note: with any of the above policies, Redis will return an error on write
 #       operations, when there are not suitable keys for eviction.
 #
 #       At the date of writing this commands are: set setnx setex append
@@ -346,7 +346,7 @@ appendonly no
 # always: fsync after every write to the append only log . Slow, Safest.
 # everysec: fsync only one time every second. Compromise.
 #
-# The default is "everysec" that's usually the right compromise between
+# The default is "everysec", as that's usually the right compromise between
 # speed and data safety. It's up to you to understand if you can relax this to
 # "no" that will let the operating system flush the output buffer when
 # it wants, for better performances (but if you can live with the idea of
@@ -374,9 +374,9 @@ appendfsync everysec
 # that will prevent fsync() from being called in the main process while a
 # BGSAVE or BGREWRITEAOF is in progress.
 #
-# This means that while another child is saving the durability of Redis is
-# the same as "appendfsync none", that in practical terms means that it is
-# possible to lost up to 30 seconds of log in the worst scenario (with the
+# This means that while another child is saving, the durability of Redis is
+# the same as "appendfsync none". In practical terms, this means that it is
+# possible to lose up to 30 seconds of log in the worst scenario (with the
 # default Linux settings).
 # 
 # If you have latency problems turn this to "yes". Otherwise leave it as
@@ -385,10 +385,10 @@ no-appendfsync-on-rewrite no
 
 # Automatic rewrite of the append only file.
 # Redis is able to automatically rewrite the log file implicitly calling
-# BGREWRITEAOF when the AOF log size will growth by the specified percentage.
+# BGREWRITEAOF when the AOF log size grows by the specified percentage.
 # 
 # This is how it works: Redis remembers the size of the AOF file after the
-# latest rewrite (or if no rewrite happened since the restart, the size of
+# latest rewrite (if no rewrite has happened since the restart, the size of
 # the AOF at startup is used).
 #
 # This base size is compared to the current size. If the current size is
@@ -423,7 +423,7 @@ lua-time-limit 5000
 
 ################################ REDIS CLUSTER  ###############################
 #
-# Normal Redis instances can't be part of a Redis Cluster, only nodes that are
+# Normal Redis instances can't be part of a Redis Cluster; only nodes that are
 # started as cluster nodes can. In order to start a Redis instance as a
 # cluster node enable the cluster support uncommenting the following:
 #
@@ -589,7 +589,7 @@ activerehashing yes
 # Instead there is a default limit for pubsub and slave clients, since
 # subscribers and slaves receive data in a push fashion.
 #
-# Both the hard or the soft limit can be disabled just setting it to zero.
+# Both the hard or the soft limit can be disabled by setting them to zero.
 client-output-buffer-limit normal 0 0 0
 client-output-buffer-limit slave 256mb 64mb 60
 client-output-buffer-limit pubsub 32mb 8mb 60
@@ -598,7 +598,7 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 # closing connections of clients in timeot, purging expired keys that are
 # never requested, and so forth.
 #
-# Not all tasks are perforemd with the same frequency, but Redis checks for
+# Not all tasks are performed with the same frequency, but Redis checks for
 # tasks to perform accordingly to the specified "hz" value.
 #
 # By default "hz" is set to 10. Raising the value will use more CPU when


### PR DESCRIPTION
Make several edits to the example redis.conf configuration file for
improved flow and grammar.

Signed-off-by: David Celis me@davidcel.is
