### PR TITLE
Fix a bug in srandmemberWithCountCommand()

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -469,7 +469,7 @@ void srandmemberWithCountCommand(redisClient *c) {
      * The number of requested elements is greater than the number of
      * elements inside the set: simply return the whole set. */
     if (count >= size) {
-        sunionDiffGenericCommand(c,c->argv,c->argc-1,NULL,REDIS_OP_UNION);
+        sunionDiffGenericCommand(c,c->argv+1,1,NULL,REDIS_OP_UNION);
         return;
     }
 


### PR DESCRIPTION
In CASE 2, the call sunionDiffGenericCommand will involve the string "srandmember" 

> sadd foo one
> (integer 1)
> sadd srandmember two
> (integer 2)
> srandmember foo 3
> 1)"one"
> 2)"two"
