### PR TITLE
return error when  parsing conf file is failed.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -73,6 +73,10 @@ void loadServerConfigFromString(char *config) {
 
         /* Split into arguments */
         argv = sdssplitargs(lines[i],&argc);
+        if (argv == NULL) {
+            err = "can't parse this line";
+            goto loaderr;
+        }
         sdstolower(argv[0]);
 
         /* Execute config directives */


### PR DESCRIPTION
issue: https://github.com/antirez/redis/issues/934

before

``` c
charsyam@ubuntu:~/projects/redis-charsyam$ !s
src/redis-server redis.conf 
Segmentation fault (core dumped)
```

after

``` c
*** FATAL CONFIG FILE ERROR ***
Reading the configuration file, at line 243
>>> 'requirepass 'pass'
can't parse this line
```
