### PR TITLE
remove compile warning for build_id

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1936,7 +1936,7 @@ sds genRedisInfoString(char *section) {
             "redis_version:%s\r\n"
             "redis_git_sha1:%s\r\n"
             "redis_git_dirty:%d\r\n"
-            "redis_build_id:%llx\r\n"
+            "redis_build_id:%" PRIx64 "\r\n"
             "redis_mode:%s\r\n"
             "os:%s %s %s\r\n"
             "arch_bits:%d\r\n"
@@ -2502,7 +2502,7 @@ void daemonize(void) {
 }
 
 void version() {
-    printf("Redis server v=%s sha=%s:%d malloc=%s bits=%d build=%llx\n",
+    printf("Redis server v=%s sha=%s:%d malloc=%s bits=%d build=%" PRIx64 "\n",
         REDIS_VERSION,
         redisGitSHA1(),
         atoi(redisGitDirty()) > 0,


### PR DESCRIPTION
This is another way to remove compile warning for redis.c

I think many times about this.

``` c
redis.c: In function ‘genRedisInfoString’:
redis.c:1966:13: warning: format ‘%llx’ expects argument of type ‘long long unsigned int’, but argument 6 has type ‘uint64_t’ [-Wformat]
redis.c: In function ‘version’:
redis.c:2506:9: warning: format ‘%llx’ expects argument of type ‘long long unsigned int’, but argument 7 has type ‘uint64_t’ [-Wformat]

```

but it looks bad. 
