### PR TITLE
Tilde expansion for configuration stanzas.

### DIFF
--- a/src/redis.h
+++ b/src/redis.h
@@ -50,6 +50,7 @@
 #include <netinet/in.h>
 #include <lua.h>
 #include <signal.h>
+#include <pwd.h>
 
 #include "ae.h"      /* Event driven programming library */
 #include "sds.h"     /* Dynamic safe strings */


### PR DESCRIPTION
It has (at least) two uglies that I'm unsure if it's worth finding the right lipstick,
static sizes for the username and path buffers since it's brain damaging to
find those out reliably.

There is another PR for this: #803

The two main problems there is that wordexp() isn't very portable (even if POSIX)
e.g. it isn't available in OpenBSD (yet, I've seen diffs float by though) and as far
as I can tell it does not interact with sudo nicely.
