### PR TITLE
Stops redis-cli --pipe from blocking with malformed protocol data (#681)

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1111,6 +1111,11 @@ static void pipeMode(void) {
                 }
             } while(reply);
         }
+        
+        if (errors > 0) {
+            fprintf(stderr, "Error processing protocol data. It is probably malformed.\n");
+            exit(1);
+        }
 
         /* Handle the writable state: we can send protocol to the server. */
         if (mask & AE_WRITABLE) {
@@ -1151,6 +1156,7 @@ static void pipeMode(void) {
                         memcpy(obuf,echo,sizeof(echo)-1);
                         obuf_len = sizeof(echo)-1;
                         obuf_pos = 0;
+                        completed = 1;
                         printf("All data transferred. Waiting for the last reply...\n");
                     } else if (nread == -1) {
                         fprintf(stderr, "Error reading from stdin: %s\n",


### PR DESCRIPTION
This fixes the issue #681. Now, redis-cli exits when the piped data
contains syntax errors.
