### PR TITLE
Handle 'SLAVEOF NO ONE' from master without segfaulting

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -652,8 +652,12 @@ void freeClient(redisClient *c) {
     /* Case 2: we lost the connection with the master. */
     if (c->flags & REDIS_MASTER) {
         server.master = NULL;
-        server.repl_state = REDIS_REPL_CONNECT;
         server.repl_down_since = server.unixtime;
+
+        /* If server.masterhost is NULL the user called SLAVEOF NO ONE so
+	 * we shouldn't reconnect */
+	if (server.masterhost != NULL) server.repl_state = REDIS_REPL_CONNECT;
+
         /* We lost connection with our master, force our slaves to resync
          * with us as well to load the new data set.
          *


### PR DESCRIPTION
Patch for issue #954

Changes slaveofCommand to set flag REDIS_CLOSE_AFTER_REPLY instead of freeing client
immediately when client is the replication master. Allows master to send 'SLAVEOF NO ONE'
without slave crashing with a segfault.
