### PR TITLE
adding NULL check error code to clusterLoadConfig()

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -67,6 +67,8 @@ int clusterLoadConfig(char *filename) {
     while(fgets(line,maxline,fp) != NULL) {
         int argc;
         sds *argv = sdssplitargs(line,&argc);
+        if (argv == NULL) goto fmterr;
+
         clusterNode *n, *master;
         char *p, *s;
 


### PR DESCRIPTION
add NULL check code to clusterLoadConfig()

There are two cases 
1] zmalloc can return NULL
2] sdssplitargs can return NULL
