### PR TITLE
merge 2 aeDeleteFileEvent calls to one in freeClusterLink()

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -267,8 +267,7 @@ clusterLink *createClusterLink(clusterNode *node) {
  * with this link will have the 'link' field set to NULL. */
 void freeClusterLink(clusterLink *link) {
     if (link->fd != -1) {
-        aeDeleteFileEvent(server.el, link->fd, AE_WRITABLE);
-        aeDeleteFileEvent(server.el, link->fd, AE_READABLE);
+        aeDeleteFileEvent(server.el, link->fd, AE_READABLE|AE_WRITABLE);
     }
     sdsfree(link->sndbuf);
     sdsfree(link->rcvbuf);


### PR DESCRIPTION
Don't need to call aeDeleteFileEvent()  twice.
