### PR TITLE
Remove a useless function declaration in src/redis.h

### DIFF
--- a/src/redis.h
+++ b/src/redis.h
@@ -1151,7 +1151,6 @@ void redisLogFromHandler(int level, const char *msg);
 void usage();
 void updateDictResizePolicy(void);
 int htNeedsResize(dict *dict);
-void oom(const char *msg);
 void populateCommandTable(void);
 void resetCommandTableStats(void);
 


### PR DESCRIPTION
hi, antirez,
In src/redis.h, line 1151, has the code:

void oom(const char *msg);

but I can't find its definition in redis' source code,
so, I remove this useless function declaration.

thanks
