### PR TITLE
suppress external diff program when using git diff.

### DIFF
--- a/src/mkreleasehdr.sh
+++ b/src/mkreleasehdr.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 GIT_SHA1=`(git show-ref --head --hash=8 2> /dev/null || echo 00000000) | head -n1`
-GIT_DIRTY=`git diff 2> /dev/null | wc -l`
+GIT_DIRTY=`git diff --no-ext-diff 2> /dev/null | wc -l`
 BUILD_ID=`uname -n`"-"`date +%s`
 test -f release.h || touch release.h
 (cat release.h | grep SHA1 | grep $GIT_SHA1) && \


### PR DESCRIPTION
I had local changes and I use vimdiff as an external diff program. When I issued make it just hang in vimdiff. The switch suppresses external configured programs.  
