### PR TITLE
Fix error "repl-backlog-size must be 1 or greater"

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -240,7 +240,7 @@ void loadServerConfigFromString(char *config) {
                 err = "argument must be 'yes' or 'no'"; goto loaderr;
             }
         } else if (!strcasecmp(argv[0],"repl-backlog-size") && argc == 2) {
-            long long size = strtoll(argv[0],NULL,10);
+            long long size = strtoll(argv[1],NULL,10);
             if (size <= 0) {
                 err = "repl-backlog-size must be 1 or greater.";
                 goto loaderr;


### PR DESCRIPTION
The parameter repl-backlog-size is not parsed correctly in the configuration file.
argv[0](always 0) is parsed instead of argv[1].

This means that any custom configuration for repl-backlog-size gives error message "repl-backlog-size must be 1 or greater"
