### PR TITLE
pqsort.c: change the simple swap method to XOR algorithm

### DIFF
--- a/src/pqsort.c
+++ b/src/pqsort.c
@@ -76,12 +76,12 @@ swapfunc(char *a, char *b, size_t n, int swaptype)
 		swapcode(char, a, b, n)
 }
 
-#define swap(a, b)						\
-	if (swaptype == 0) {					\
-		long t = *(long *)(void *)(a);			\
-		*(long *)(void *)(a) = *(long *)(void *)(b);	\
-		*(long *)(void *)(b) = t;			\
-	} else							\
+#define swap(a, b)															\
+	if (swaptype == 0) {													\
+		*(long *)(void *)(a) = *(long *)(void *)(a) ^ *(long *)(void *)(b); \
+		*(long *)(void *)(b) = *(long *)(void *)(a) ^ *(long *)(void *)(b);	\
+		*(long *)(void *)(a) = *(long *)(void *)(a) ^ *(long *)(void *)(b);	\
+	} else																	\
 		swapfunc(a, b, es, swaptype)
 
 #define vecswap(a, b, n) if ((n) > 0) swapfunc((a), (b), (size_t)(n), swaptype)


### PR DESCRIPTION
pqsort.c: replace the simple swap method (when swaptype is 0) with the XOR algorithm to save some memory, since it's used a lot (long temp variable).
I know it's based on the NetBSD implementation, but why not optimize a little more?

Inspired by looking at #968 and pqsort.c
