### PR TITLE
Simplify and optimize function setKey()

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -116,11 +116,7 @@ void dbOverwrite(redisDb *db, robj *key, robj *val) {
  * 2) clients WATCHing for the destination key notified.
  * 3) The expire time of the key is reset (the key is made persistent). */
 void setKey(redisDb *db, robj *key, robj *val) {
-    if (lookupKeyWrite(db,key) == NULL) {
-        dbAdd(db,key,val);
-    } else {
-        dbOverwrite(db,key,val);
-    }
+    dictReplace(db->dict, key->ptr, val);
     incrRefCount(val);
     removeExpire(db,key);
     signalModifiedKey(db,key);

--- a/src/db.c
+++ b/src/db.c
@@ -116,7 +116,8 @@ void dbOverwrite(redisDb *db, robj *key, robj *val) {
  * 2) clients WATCHing for the destination key notified.
  * 3) The expire time of the key is reset (the key is made persistent). */
 void setKey(redisDb *db, robj *key, robj *val) {
-    dictReplace(db->dict, key->ptr, val);
+    if (dictReplace(db->dict, key->ptr, val))
+        incrRefCount(key);
     incrRefCount(val);
     removeExpire(db,key);
     signalModifiedKey(db,key);

--- a/src/db.c
+++ b/src/db.c
@@ -116,8 +116,10 @@ void dbOverwrite(redisDb *db, robj *key, robj *val) {
  * 2) clients WATCHing for the destination key notified.
  * 3) The expire time of the key is reset (the key is made persistent). */
 void setKey(redisDb *db, robj *key, robj *val) {
+    if (server.rdb_child_pid == -1 && server.aof_child_pid == -1)
+        val->lru = server.lruclock;
     if (dictReplace(db->dict, key->ptr, val))
-        incrRefCount(key);
+        key->ptr = sdsdup(key->ptr);
     incrRefCount(val);
     removeExpire(db,key);
     signalModifiedKey(db,key);


### PR DESCRIPTION
1. The function setKey() call dictFind() 3 times before actually write db->dict !! 
2. No need to call expireIfNeeded(), if the key is in db->expires, its value will be overwrite and it will be removed from db->expires eventually.
