### PR TITLE
Abort when opening the RDB file results in an error other than ENOENT.

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1069,7 +1069,6 @@ int rdbLoad(char *filename) {
 
     fp = fopen(filename,"r");
     if (!fp) {
-        errno = ENOENT;
         return REDIS_ERR;
     }
     rioInitWithFile(&rdb,fp);

--- a/src/redis.c
+++ b/src/redis.c
@@ -2736,7 +2736,7 @@ void loadDataFromDisk(void) {
             redisLog(REDIS_NOTICE,"DB loaded from disk: %.3f seconds",
                 (float)(ustime()-start)/1000000);
         } else if (errno != ENOENT) {
-            redisLog(REDIS_WARNING,"Fatal error loading the DB. Exiting.");
+            redisLog(REDIS_WARNING,"Fatal error loading the DB: %s. Exiting.",strerror(errno));
             exit(1);
         }
     }


### PR DESCRIPTION
This fixes cases where the RDB file does exist but can't be accessed for
any reason. For instance, when the Redis process doesn't have enough
permissions on the file.
