### PR TITLE
Setting server.dbnum = 1, when cluster_enabled is set

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -196,6 +196,8 @@ void loadServerConfigFromString(char *config) {
             server.dbnum = atoi(argv[1]);
             if (server.dbnum < 1) {
                 err = "Invalid number of databases"; goto loaderr;
+            } else if (server.cluster_enabled) {
+                server.dbnum = 1;
             }
         } else if (!strcasecmp(argv[0],"include") && argc == 2) {
             loadServerConfig(argv[1],NULL);

--- a/src/redis.c
+++ b/src/redis.c
@@ -1397,6 +1397,9 @@ void initServer() {
     createSharedObjects();
     adjustOpenFilesLimit();
     server.el = aeCreateEventLoop(server.maxclients+1024);
+
+    if (server.cluster_enabled) server.dbnum = 1;
+
     server.db = zmalloc(sizeof(redisDb)*server.dbnum);
 
     if (server.port != 0) {


### PR DESCRIPTION
when cluster_enabled is 1, redis just uses only 1 db(db idx = 0)

so we don't need to set dbnum = 16.
