### PR TITLE
Raise argument errors correctly in lua redis.call calls.

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -200,7 +200,7 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
     if (argc == 0) {
         luaPushError(lua,
             "Please specify at least one argument for redis.call()");
-        return 1;
+        goto err;
     }
 
     /* Build the arguments vector */
@@ -223,7 +223,7 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
         zfree(argv);
         luaPushError(lua,
             "Lua redis() command arguments must be strings or integers");
-        return 1;
+        goto err;
     }
 
     /* Setup our fake client for command execution */
@@ -323,6 +323,7 @@ cleanup:
         decrRefCount(c->argv[j]);
     zfree(c->argv);
 
+err:
     if (raise_error) {
         /* If we are here we should have an error in the stack, in the
          * form of a table with an "err" field. Extract the string to


### PR DESCRIPTION
This fixes issue #651 "redis.call doesn't throw lua error when passed nil arguments". I had some trouble debugging a script which came down to me inadvertently passing a boolean to a redis.call. I was confused as to why I was getting a table back from an HGET call. I understand if this is intentional, but it would be nice for the documentation to be updated in that case to be more clear.
