### PR TITLE
Build improvements

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -54,8 +54,8 @@ linenoise: .make-prerequisites
 .PHONY: linenoise
 
 ifeq ($(uname_S),SunOS)
-  # Make isinf() available
-  LUA_CFLAGS= -D__C99FEATURES__=1
+	# Make isinf() available
+	LUA_CFLAGS= -D__C99FEATURES__=1
 endif
 
 LUA_CFLAGS+= -O2 -Wall -DLUA_ANSI $(CFLAGS)

--- a/deps/lua/src/Makefile
+++ b/deps/lua/src/Makefile
@@ -7,7 +7,7 @@
 # Your platform. See PLATS for possible values.
 PLAT= none
 
-CC= gcc
+CC?= gcc
 CFLAGS= -O2 -Wall $(MYCFLAGS)
 AR= ar rcu
 RANLIB= ranlib

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,22 +24,22 @@ OPT= $(OPTIMIZATION)
 
 # Default allocator
 ifeq ($(uname_S),Linux)
-  MALLOC=jemalloc
+	MALLOC=jemalloc
 else
-  MALLOC=libc
+	MALLOC=libc
 endif
 
 # Backwards compatibility for selecting an allocator
 ifeq ($(USE_TCMALLOC),yes)
-  MALLOC=tcmalloc
+	MALLOC=tcmalloc
 endif
 
 ifeq ($(USE_TCMALLOC_MINIMAL),yes)
-  MALLOC=tcmalloc_minimal
+	MALLOC=tcmalloc_minimal
 endif
 
 ifeq ($(USE_JEMALLOC),yes)
-  MALLOC=jemalloc
+	MALLOC=jemalloc
 endif
 
 # Override default settings if possible
@@ -65,19 +65,19 @@ endif
 FINAL_CFLAGS+= -I../deps/hiredis -I../deps/linenoise -I../deps/lua/src
 
 ifeq ($(MALLOC),tcmalloc)
-  FINAL_CFLAGS+= -DUSE_TCMALLOC
-  FINAL_LIBS+= -ltcmalloc
+	FINAL_CFLAGS+= -DUSE_TCMALLOC
+	FINAL_LIBS+= -ltcmalloc
 endif
 
 ifeq ($(MALLOC),tcmalloc_minimal)
-  FINAL_CFLAGS+= -DUSE_TCMALLOC
-  FINAL_LIBS+= -ltcmalloc_minimal
+	FINAL_CFLAGS+= -DUSE_TCMALLOC
+	FINAL_LIBS+= -ltcmalloc_minimal
 endif
 
 ifeq ($(MALLOC),jemalloc)
-  DEPENDENCY_TARGETS+= jemalloc
-  FINAL_CFLAGS+= -DUSE_JEMALLOC -I../deps/jemalloc/include
-  FINAL_LIBS+= ../deps/jemalloc/lib/libjemalloc.a -ldl
+	DEPENDENCY_TARGETS+= jemalloc
+	FINAL_CFLAGS+= -DUSE_JEMALLOC -I../deps/jemalloc/include
+	FINAL_LIBS+= ../deps/jemalloc/lib/libjemalloc.a -ldl
 endif
 
 REDIS_CC=$(QUIET_CC)$(CC) $(FINAL_CFLAGS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,9 +18,9 @@ OPTIMIZATION?=-O2
 DEPENDENCY_TARGETS=hiredis linenoise lua
 
 # Default settings
-STD= -std=c99 -pedantic
-WARN= -Wall
-OPT= $(OPTIMIZATION)
+STD=-std=c99 -pedantic
+WARN=-Wall
+OPT=$(OPTIMIZATION)
 
 # Default allocator
 ifeq ($(uname_S),Linux)
@@ -85,8 +85,8 @@ REDIS_LD=$(QUIET_LINK)$(CC) $(FINAL_LDFLAGS)
 REDIS_INSTALL=$(QUIET_INSTALL)$(INSTALL)
 
 PREFIX?=/usr/local
-INSTALL_BIN= $(PREFIX)/bin
-INSTALL= cp -pf
+INSTALL_BIN=$(PREFIX)/bin
+INSTALL=cp -pf
 
 CCCOLOR="\033[34m"
 LINKCOLOR="\033[34;1m"
@@ -101,17 +101,17 @@ QUIET_LINK = @printf '    %b %b\n' $(LINKCOLOR)LINK$(ENDCOLOR) $(BINCOLOR)$@$(EN
 QUIET_INSTALL = @printf '    %b %b\n' $(LINKCOLOR)INSTALL$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
 endif
 
-REDIS_SERVER_NAME= redis-server
-REDIS_SENTINEL_NAME= redis-sentinel
-REDIS_SERVER_OBJ= adlist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o
-REDIS_CLI_NAME= redis-cli
-REDIS_CLI_OBJ= anet.o sds.o adlist.o redis-cli.o zmalloc.o release.o anet.o ae.o crc64.o
-REDIS_BENCHMARK_NAME= redis-benchmark
-REDIS_BENCHMARK_OBJ= ae.o anet.o redis-benchmark.o sds.o adlist.o zmalloc.o redis-benchmark.o
-REDIS_CHECK_DUMP_NAME= redis-check-dump
-REDIS_CHECK_DUMP_OBJ= redis-check-dump.o lzf_c.o lzf_d.o crc64.o
-REDIS_CHECK_AOF_NAME= redis-check-aof
-REDIS_CHECK_AOF_OBJ= redis-check-aof.o
+REDIS_SERVER_NAME=redis-server
+REDIS_SENTINEL_NAME=redis-sentinel
+REDIS_SERVER_OBJ=adlist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o
+REDIS_CLI_NAME=redis-cli
+REDIS_CLI_OBJ=anet.o sds.o adlist.o redis-cli.o zmalloc.o release.o anet.o ae.o crc64.o
+REDIS_BENCHMARK_NAME=redis-benchmark
+REDIS_BENCHMARK_OBJ=ae.o anet.o redis-benchmark.o sds.o adlist.o zmalloc.o redis-benchmark.o
+REDIS_CHECK_DUMP_NAME=redis-check-dump
+REDIS_CHECK_DUMP_OBJ=redis-check-dump.o lzf_c.o lzf_d.o crc64.o
+REDIS_CHECK_AOF_NAME=redis-check-aof
+REDIS_CHECK_AOF_OBJ=redis-check-aof.o
 
 all: $(REDIS_SERVER_NAME) $(REDIS_SENTINEL_NAME) $(REDIS_CLI_NAME) $(REDIS_BENCHMARK_NAME) $(REDIS_CHECK_DUMP_NAME) $(REDIS_CHECK_AOF_NAME)
 	@echo ""

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,16 +45,20 @@ endif
 # Override default settings if possible
 -include .make-settings
 
+FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
+FINAL_LDFLAGS=$(LDFLAGS) $(REDIS_LDFLAGS) $(DEBUG)
+FINAL_LIBS=-lm
+DEBUG=-g -ggdb
+
 ifeq ($(uname_S),SunOS)
-  FINAL_CFLAGS= $(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS) -D__EXTENSIONS__ -D_XPG6
-  FINAL_LDFLAGS= $(LDFLAGS) $(REDIS_LDFLAGS) -g -ggdb
-  FINAL_LIBS= -ldl -lnsl -lsocket -lm -lpthread
-  DEBUG= -g -ggdb
+	FINAL_CFLAGS+= -D__EXTENSIONS__ -D_XPG6
+	FINAL_LIBS+= -ldl -lnsl -lsocket -lpthread
+else ifeq ($(uname_S),Darwin)
+	
 else
-  FINAL_CFLAGS= $(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
-  FINAL_LDFLAGS= $(LDFLAGS) $(REDIS_LDFLAGS) -g -rdynamic -ggdb
-  FINAL_LIBS= -lm -pthread
-  DEBUG= -g -rdynamic -ggdb
+	FINAL_LDFLAGS+= -rdynamic
+	FINAL_LIBS+= -pthread
+	DEBUG+= -rdynamic
 endif
 
 # Include paths to dependencies

--- a/src/Makefile
+++ b/src/Makefile
@@ -58,7 +58,6 @@ else ifeq ($(uname_S),Darwin)
 else
 	FINAL_LDFLAGS+= -rdynamic
 	FINAL_LIBS+= -pthread
-	DEBUG+= -rdynamic
 endif
 
 # Include paths to dependencies

--- a/src/Makefile
+++ b/src/Makefile
@@ -231,7 +231,7 @@ src/help.h:
 	@../utils/generate-command-help.rb > help.h
 
 install: all
-	mkdir -p $(INSTALL_BIN)
+	@mkdir -p $(INSTALL_BIN)
 	$(REDIS_INSTALL) $(REDIS_SERVER_NAME) $(INSTALL_BIN)
 	$(REDIS_INSTALL) $(REDIS_BENCHMARK_NAME) $(INSTALL_BIN)
 	$(REDIS_INSTALL) $(REDIS_CLI_NAME) $(INSTALL_BIN)

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,6 +22,10 @@ STD=-std=c99 -pedantic
 WARN=-Wall
 OPT=$(OPTIMIZATION)
 
+PREFIX?=/usr/local
+INSTALL_BIN=$(PREFIX)/bin
+INSTALL=install
+
 # Default allocator
 ifeq ($(uname_S),Linux)
 	MALLOC=jemalloc
@@ -51,6 +55,7 @@ FINAL_LIBS=-lm
 DEBUG=-g -ggdb
 
 ifeq ($(uname_S),SunOS)
+	INSTALL=cp -pf
 	FINAL_CFLAGS+= -D__EXTENSIONS__ -D_XPG6
 	FINAL_LIBS+= -ldl -lnsl -lsocket -lpthread
 else ifeq ($(uname_S),Darwin)
@@ -82,10 +87,6 @@ endif
 REDIS_CC=$(QUIET_CC)$(CC) $(FINAL_CFLAGS)
 REDIS_LD=$(QUIET_LINK)$(CC) $(FINAL_LDFLAGS)
 REDIS_INSTALL=$(QUIET_INSTALL)$(INSTALL)
-
-PREFIX?=/usr/local
-INSTALL_BIN=$(PREFIX)/bin
-INSTALL=cp -pf
 
 CCCOLOR="\033[34m"
 LINKCOLOR="\033[34;1m"

--- a/src/Makefile
+++ b/src/Makefile
@@ -200,6 +200,8 @@ distclean: clean
 test: $(REDIS_SERVER_NAME) $(REDIS_CHECK_AOF_NAME)
 	@(cd ..; ./runtest)
 
+check: test
+
 lcov:
 	$(MAKE) gcov
 	@(set -e; cd ..; ./runtest --clients 1)


### PR DESCRIPTION
Here's a couple of minor changes to the build system. Besides spaces, tabs and nits it provides two benefits:
- Avoid build warnings (-pthread, -rdynamic)
- Pass CC to Lua build (CC=clang would still invoke gcc for lua)
- use `install` instead of `cp -pf` where applicable

Possibly adding this as well:
- [ ] Fix silent "make install" output (currently says INSTALL install, since $@ is target)
