### PR TITLE
restore stats parameter for expire in Issue #1026.

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -573,8 +573,11 @@ void expireGenericCommand(redisClient *c, long long basetime, int unit) {
 
     /* No key, return zero. */
     if (lookupKeyRead(c->db,key) == NULL) {
+        server.stat_keyspace_misses--;
         addReply(c,shared.czero);
         return;
+    } else {
+        server.stat_keyspace_hits--;
     }
 
     /* EXPIRE with negative TTL, or EXPIREAT with a timestamp into the past


### PR DESCRIPTION
1] Problem: to fix issue #1026, dictfind is changed to lookupKeyRead
 but, in lookupKeyRead, it changes server.stat_keyspace_misses and server.stat_keyspace_hits

2] Patch:
 so, this patch just decrease  server.stat_keyspace_misses and server.stat_keyspace_hits by 1, accoding to cases.
