### PR TITLE
Fix compiler warnings on ubuntu 12.10

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -969,7 +969,7 @@ int rewriteAppendOnlyFileBackground(void) {
             if (private_dirty) {
                 redisLog(REDIS_NOTICE,
                     "AOF rewrite: %lu MB of memory used by copy-on-write",
-                    private_dirty/(1024*1024));
+                    (long unsigned int)(private_dirty/(1024*1024)));
             }
             exitFromChild(0);
         } else {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -739,7 +739,7 @@ int rdbSaveBackground(char *filename) {
             if (private_dirty) {
                 redisLog(REDIS_NOTICE,
                     "RDB: %lu MB of memory used by copy-on-write",
-                    private_dirty/(1024*1024));
+                    (long unsigned int)(private_dirty/(1024*1024)));
             }
         }
         exitFromChild((retval == REDIS_OK) ? 0 : 1);

--- a/src/redis.h
+++ b/src/redis.h
@@ -1173,7 +1173,7 @@ struct redisCommand *lookupCommandOrOriginal(sds name);
 void call(redisClient *c, int flags);
 void propagate(struct redisCommand *cmd, int dbid, robj **argv, int argc, int flags);
 void alsoPropagate(struct redisCommand *cmd, int dbid, robj **argv, int argc, int target);
-int prepareForShutdown();
+int prepareForShutdown(int flag);
 #ifdef __GNUC__
 void redisLog(int level, const char *fmt, ...)
     __attribute__((format(printf, 2, 3)));


### PR DESCRIPTION
When compiling on Ubuntu 12.10 (GCC version 4.7.2 (Ubuntu/Linaro 4.7.2-2ubuntu1)) , getting the following warnings:

``` gcc
CC rdb.o
rdb.c: In function ‘rdbSaveBackground’:
rdb.c:742:21: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘size_t’ [-Wformat]
```

``` gcc
CC aof.o
aof.c: In function ‘rewriteAppendOnlyFileBackground’:
aof.c:972:21: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘size_t’ [-Wformat]
```

In order to fix it -- I have done a cast in the mentioned places (it has seemed to me the correct way to fix it).

**EDIT** Although, in ANSI C, you do not have to declare a function prototype, it might cause some undefined behavior.
In `redis.h` we declare `prepareForShutdown` function without arguments, however, in `redis.c` (lines 954 and 1880) and `db.c` (line 365). we call it with one argument (e.g. `prepareShutdown(0)`).
Unless we have some backward compatibility with very old code, I don't see a reason to keep it that way.
