### PR TITLE
[Feature request] Added support to specify hostnames in the bind directive in redis.conf

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -55,6 +55,7 @@ void resetServerSaveParams() {
 }
 
 void loadServerConfigFromString(char *config) {
+    char buf[32];
     char *err = NULL;
     int linenum = 0, totlines, i;
     sds *lines;
@@ -103,6 +104,11 @@ void loadServerConfigFromString(char *config) {
             }
         } else if (!strcasecmp(argv[0],"bind") && argc == 2) {
             server.bindaddr = zstrdup(argv[1]);
+
+            if(anetResolve(NULL,server.bindaddr,buf) == ANET_OK) {
+                server.bindaddr = zstrdup(buf);
+            }
+
         } else if (!strcasecmp(argv[0],"unixsocket") && argc == 2) {
             server.unixsocket = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"unixsocketperm") && argc == 2) {


### PR DESCRIPTION
Hi, 

Specifying a host name as opposed to an IP address in redis.conf, throws an invalid bind address error. This patch provides a simple mechanism (using tools already found in anet.c) to allow host names. 

It would be probably better to use getaddrinfo, since gethostbyname is deprecated, but that would mean to rewrite a big part of anet.c.

Cheers,
