### PR TITLE
Cluster: fix clusterNode.name len and the print fmt.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -341,6 +341,7 @@ clusterNode *createClusterNode(char *nodename, int flags) {
         memcpy(node->name, nodename, REDIS_CLUSTER_NAMELEN);
     else
         getRandomHexChars(node->name, REDIS_CLUSTER_NAMELEN);
+    node->name[REDIS_CLUSTER_NAMELEN] = '\0';
     node->flags = flags;
     memset(node->slots,0,sizeof(node->slots));
     node->numslots = 0;
@@ -1548,7 +1549,7 @@ void clusterCron(void) {
         }
     }
     if (min_ping_node) {
-        redisLog(REDIS_DEBUG,"Pinging node %40s", min_ping_node->name);
+        redisLog(REDIS_DEBUG,"Pinging node %.40s", min_ping_node->name);
         clusterSendPing(min_ping_node->link, CLUSTERMSG_TYPE_PING);
     }
 

--- a/src/redis.h
+++ b/src/redis.h
@@ -562,7 +562,7 @@ struct clusterNodeFailReport {
 } typedef clusterNodeFailReport;
 
 struct clusterNode {
-    char name[REDIS_CLUSTER_NAMELEN]; /* Node name, hex string, sha1-size */
+    char name[REDIS_CLUSTER_NAMELEN+1]; /* Node name, hex string, sha1-size */
     int flags;      /* REDIS_NODE_... */
     unsigned char slots[REDIS_CLUSTER_SLOTS/8]; /* slots handled by this node */
     int numslots;   /* Number of slots handled by this node */


### PR DESCRIPTION
the output "Pinging node %40s" may contains unprintable character.

I just fix it like server.runid or server.repl_master_runid
I think this may be better :-)
