### PR TITLE
fixing aofrewrite bug

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -884,6 +884,11 @@ int rewriteAppendOnlyFile(char *filename) {
 
             expiretime = getExpire(db,&key);
 
+            /* If this key is already expired skip it */
+            if (expiretime != -1 && expiretime < now) {
+                continue;
+            }
+
             /* Save the key and associated value */
             if (o->type == REDIS_STRING) {
                 /* Emit a SET command */
@@ -906,8 +911,6 @@ int rewriteAppendOnlyFile(char *filename) {
             /* Save the expire time */
             if (expiretime != -1) {
                 char cmd[]="*3\r\n$9\r\nPEXPIREAT\r\n";
-                /* If this key is already expired skip it */
-                if (expiretime < now) continue;
                 if (rioWrite(&aof,cmd,sizeof(cmd)-1) == 0) goto werr;
                 if (rioWriteBulkObject(&aof,&key) == 0) goto werr;
                 if (rioWriteBulkLongLong(&aof,expiretime) == 0) goto werr;


### PR DESCRIPTION
``` c
When key has expiretime which is smaller than now(), it just add "*3\r\n$3\r\nSET\r\n" and
not to add "PEXPIREAT"
```

This patch is based on REDIS-DB group's topic: https://groups.google.com/forum/?fromgroups=#!topic/redis-db/Kvh2FAGK4Uk

and I think it is a bug. Thank you.
