### PR TITLE
Link resolv library in Solaris

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -57,7 +57,7 @@ DEBUG=-g -ggdb
 ifeq ($(uname_S),SunOS)
 	INSTALL=cp -pf
 	FINAL_CFLAGS+= -D__EXTENSIONS__ -D_XPG6
-	FINAL_LIBS+= -ldl -lnsl -lsocket -lpthread
+	FINAL_LIBS+= -ldl -lnsl -lsocket -lresolv -lpthread
 else ifeq ($(uname_S),Darwin)
 	
 else


### PR DESCRIPTION
For some Solaris flavours, the inet_aton in in resolv library. Unlink this library will introduce link error.
