### PR TITLE
adding auth to redis-benchmark

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -74,6 +74,7 @@ static struct config {
     int loop;
     int idlemode;
     char *tests;
+    char *auth;
 } config;
 
 typedef struct _client {
@@ -271,6 +272,14 @@ static client createClient(char *cmd, size_t len) {
     c->context->reader->maxbuf = 0;
     /* Queue N requests accordingly to the pipeline size. */
     c->obuf = sdsempty();
+
+    if (config.auth) {
+        char *buf = NULL;
+        int len = redisFormatCommand(&buf, "AUTH %s", config.auth);
+        c->obuf = sdscatlen(c->obuf, buf, len);
+        free(buf);
+    }
+
     for (j = 0; j < config.pipeline; j++)
         c->obuf = sdscatlen(c->obuf,cmd,len);
     c->randlen = 0;
@@ -296,9 +305,19 @@ static client createClient(char *cmd, size_t len) {
 
 static void createMissingClients(client c) {
     int n = 0;
+    char *cmd = c->obuf;
+    int len = sdslen(c->obuf);
+
+    if (config.auth) {
+        char *buf = NULL;
+        int tmplen = redisFormatCommand(&buf, "AUTH %s", config.auth);
+        cmd += tmplen;
+        len -= tmplen;
+        free(buf);
+    }
 
     while(config.liveclients < config.numclients) {
-        createClient(c->obuf,sdslen(c->obuf)/config.pipeline);
+        createClient(cmd,len/config.pipeline);
 
         /* Listen backlog is quite limited on most systems */
         if (++n > 64) {
@@ -387,6 +406,9 @@ int parseOptions(int argc, const char **argv) {
         } else if (!strcmp(argv[i],"-s")) {
             if (lastarg) goto invalid;
             config.hostsocket = strdup(argv[++i]);
+        } else if (!strcmp(argv[i],"-a") ) {
+            if (lastarg) goto invalid;
+            config.auth = strdup(argv[++i]);
         } else if (!strcmp(argv[i],"-d")) {
             if (lastarg) goto invalid;
             config.datasize = atoi(argv[++i]);
@@ -444,6 +466,7 @@ usage:
 " -h <hostname>      Server hostname (default 127.0.0.1)\n"
 " -p <port>          Server port (default 6379)\n"
 " -s <socket>        Server socket (overrides host and port)\n"
+" -a <password>      Password for Redis Auth\n"
 " -c <clients>       Number of parallel connections (default 50)\n"
 " -n <requests>      Total number of requests (default 10000)\n"
 " -d <size>          Data size of SET/GET value in bytes (default 2)\n"
@@ -535,6 +558,7 @@ int main(int argc, const char **argv) {
     config.hostport = 6379;
     config.hostsocket = NULL;
     config.tests = NULL;
+    config.auth = NULL;
 
     i = parseOptions(argc,argv);
     argc -= i;


### PR DESCRIPTION
Adding auth to redis-benchmark

``` c
-a <password>      Password for Redis Auth

src/redis-benchmark -t set -n 1000000 -r 100000000 -a redis
```

I might think some people want this kind of functionality.
