### PR TITLE
issue #1098 - shutdown nosave

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -352,7 +352,7 @@ void shutdownCommand(redisClient *c) {
     if (c->argc > 2) {
         addReply(c,shared.syntaxerr);
         return;
-    } else if (c->argc == 2) {
+    } if (c->argc == 2) {
         if (!strcasecmp(c->argv[1]->ptr,"nosave")) {
             flags |= REDIS_SHUTDOWN_NOSAVE;
         } else if (!strcasecmp(c->argv[1]->ptr,"save")) {
@@ -361,7 +361,17 @@ void shutdownCommand(redisClient *c) {
             addReply(c,shared.syntaxerr);
             return;
         }
+    } else {
+        addReply(c,shared.syntaxerr);
+        return;
     }
+
+    if (server.loading && 
+        (flags & REDIS_SHUTDOWN_NOSAVE) != REDIS_SHUTDOWN_NOSAVE) {
+        addReply(c, shared.loadingerr);
+        return;
+    }    
+
     if (prepareForShutdown(flags) == REDIS_OK) exit(0);
     addReplyError(c,"Errors trying to SHUTDOWN. Check logs.");
 }

--- a/src/redis.c
+++ b/src/redis.c
@@ -215,7 +215,7 @@ struct redisCommand redisCommandTable[] = {
     {"save",saveCommand,1,"ars",0,NULL,0,0,0,0,0},
     {"bgsave",bgsaveCommand,1,"ar",0,NULL,0,0,0,0,0},
     {"bgrewriteaof",bgrewriteaofCommand,1,"ar",0,NULL,0,0,0,0,0},
-    {"shutdown",shutdownCommand,-1,"ar",0,NULL,0,0,0,0,0},
+    {"shutdown",shutdownCommand,-1,"arl",0,NULL,0,0,0,0,0},
     {"lastsave",lastsaveCommand,1,"rR",0,NULL,0,0,0,0,0},
     {"type",typeCommand,2,"r",0,NULL,1,1,1,0,0},
     {"multi",multiCommand,1,"rs",0,NULL,0,0,0,0,0},


### PR DESCRIPTION
issue #1098: allowing shutdown nosave while server status is server.loading

``` c
1] allow shutdown command to pass to check server.loading
2] and if it is not "nosave", then return "server.loading error"
3] if argv is larger than 2, return "syntax error"
```
