### PR TITLE
Adding wt option in setCommand

### DIFF
--- a/src/rdb.h
+++ b/src/rdb.h
@@ -38,7 +38,7 @@
 
 /* The current RDB version. When the format changes in a way that is no longer
  * backward compatible this number gets incremented. */
-#define REDIS_RDB_VERSION 6
+#define REDIS_RDB_VERSION 7
 
 /* Defines related to the dump file format. To store 32 bits lengths for short
  * keys requires a lot of space, so we check the most significant 2 bits of
@@ -86,6 +86,7 @@
 #define rdbIsObjectType(t) ((t >= 0 && t <= 4) || (t >= 9 && t <= 13))
 
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
+#define REDIS_RDB_OPCODE_TXTIME_MS 251
 #define REDIS_RDB_OPCODE_EXPIRETIME_MS 252
 #define REDIS_RDB_OPCODE_EXPIRETIME 253
 #define REDIS_RDB_OPCODE_SELECTDB   254
@@ -108,7 +109,7 @@ off_t rdbSavedObjectLen(robj *o);
 off_t rdbSavedObjectPages(robj *o);
 robj *rdbLoadObject(int type, rio *rdb);
 void backgroundSaveDoneHandler(int exitcode, int bysignal);
-int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime, long long now);
+int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime, long long now, long long tx);
 robj *rdbLoadStringObject(rio *rdb);
 
 #endif

--- a/src/redis.h
+++ b/src/redis.h
@@ -378,6 +378,7 @@ typedef struct redisObject {
 typedef struct redisDb {
     dict *dict;                 /* The keyspace for this DB */
     dict *expires;              /* Timeout of keys with a timeout set */
+    dict *weights;              /* write protection keys using recent time */
     dict *blocking_keys;        /* Keys with clients waiting for data (BLPOP) */
     dict *ready_keys;           /* Blocked keys that received a PUSH */
     dict *watched_keys;         /* WATCHED keys for MULTI/EXEC CAS */
@@ -475,7 +476,7 @@ struct sharedObjectsStruct {
     *colon, *nullbulk, *nullmultibulk, *queued,
     *emptymultibulk, *wrongtypeerr, *nokeyerr, *syntaxerr, *sameobjecterr,
     *outofrangeerr, *noscripterr, *loadingerr, *slowscripterr, *bgsaveerr,
-    *masterdownerr, *roslaveerr, *execaborterr, *noautherr,
+    *masterdownerr, *roslaveerr, *execaborterr, *noautherr, *weighterror,
     *oomerr, *plus, *messagebulk, *pmessagebulk, *subscribebulk,
     *unsubscribebulk, *psubscribebulk, *punsubscribebulk, *del, *rpop, *lpop,
     *lpush,
@@ -1266,6 +1267,9 @@ void appendServerSaveParams(time_t seconds, int changes);
 void resetServerSaveParams();
 
 /* db.c -- Keyspace access API */
+int removeWeight(redisDb *db, robj *key);
+long long getWeight(redisDb *db, robj *key);
+void setWeight(redisDb *db, robj *key, long long when);
 int removeExpire(redisDb *db, robj *key);
 void propagateExpire(redisDb *db, robj *key);
 int expireIfNeeded(redisDb *db, robj *key);
@@ -1398,6 +1402,7 @@ void pexpireatCommand(redisClient *c);
 void getsetCommand(redisClient *c);
 void ttlCommand(redisClient *c);
 void pttlCommand(redisClient *c);
+void weightCommand(redisClient *c);
 void persistCommand(redisClient *c);
 void slaveofCommand(redisClient *c);
 void debugCommand(redisClient *c);

--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -14,6 +14,26 @@ start_server {tags {"basic"}} {
         r get x
     } {}
 
+    test {SET wt basic} {
+        r set x 123 wt 100000
+        catch {r set x 234 wt 10000} err
+        format $err
+        assert_equal 123 [r get x]
+        r set x 234 wt 100001
+        assert_equal 234 [r get x]
+        r del x
+    } 
+
+    test {weight basic} {
+        r set x 123 wt 100000
+        assert_equal 100000 [r weight x]
+        r del x
+        r set t 123
+        assert_equal 0 [r weight t]
+        r del t
+        assert {[r weight y] == -1}
+    }
+
     test {DEL against a single item} {
         r del x
         r get x


### PR DESCRIPTION
1] spec
- SET has a new option WT, it only will set the key if the new weight is > previous weight with wt option
  - if tx_time value is larger than current weight it will return +OK
  - otherwise return -ERR
  - but it can always update key's value without "wt" option.
  - we should give weight when we use wt option.

``` c
set [key] [value] wt [weight]
```
- Every key has a new property called "tx" like as "expire"
  - we can get tx value using txCommand
  - if key exists but it doesn't have tx_time, it returns 0
  - if key doesn't exist, it returns -1
  - return tx_time

``` c
weight [key]
```

2] weight
- we can use db operation timestamp as weight.
- or we can get global timestamp from other server(such as redis)

3] usage example

``` c
set a 123 wt 1000000
+OK
set a 123 wt 10000 <--- it only will set the key with larger weight
-ERR
weight a
1000000
set a 123 wt 2000000
+OK
weight b
-1
set c 123
+OK
weight c
0
set a 234  <---- exception case.
+OK
```

4] Why this feature is needed?
- when someone wants redis to use a cache, They will do them following these sequence.
  1) read db
  2) write redis
- Normal Scenario.
  
  1) Process A - Read key A(1) from DB at 1ms
  2) Other Proceess - Write key A(2) to DB.
  3) Process B - Read key A(2) from DB at 3ms
  4) Process A - Write set A 1 to Redis at 4ms
  5) Process B - Write set A 2 to Redis at 5ms
- Race Condition Scenario. Key(Value)
  
  1) Process A - Read key A(1) from DB at 1ms
  2) Other Proceess - Write key A(2) to DB.
  3) Process B - Read key A(2) from DB at 3ms
  4) Context-Switching in Process A or Sleep happens.
  5) Process B - Write set A 2 to Redis at 4ms
  6) Process A - Write set A 1 to Redis at 5ms
- Race Condition. consistency is broken.
- Using set wt Scenario.
  
  1) Process A - Read key A(1) from DB at 1ms 
  2) Other Proceess - Write key A(2) to DB.
  3) Process B - Read key A(2) from DB at 3ms
  4) Context-Switching in Process A or Sleep happens.
  5) Process B - Write set A 2 wt 3 to Redis at 4ms
  6) Process A - Write set A 1 wt 1 Redis at 5ms
- but "set A 1 wt 1" failed. it can keep consistency.

5] drawback
 1) it spends more memory to keep db->weights
 2) RDB saving and loading is changed. so previous version redis can't read new rdb.

I believe this feature is very useful when we design cache layer. Thank you.
