### PR TITLE
Fix typo in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -657,7 +657,7 @@ client-output-buffer-limit slave 256mb 64mb 60
 client-output-buffer-limit pubsub 32mb 8mb 60
 
 # Redis calls an internal function to perform many background tasks, like
-# closing connections of clients in timeot, purging expired keys that are
+# closing connections of clients in timeout, purging expired keys that are
 # never requested, and so forth.
 #
 # Not all tasks are performed with the same frequency, but Redis checks for


### PR DESCRIPTION
Fix spelling of timeout
