### PR TITLE
Try to report source of bad Lua API calls

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -152,9 +152,20 @@ char *redisProtocolToLuaType_MultiBulk(lua_State *lua, char *reply) {
 }
 
 void luaPushError(lua_State *lua, char *error) {
+    lua_Debug dbg;
+
     lua_newtable(lua);
     lua_pushstring(lua,"err");
-    lua_pushstring(lua, error);
+
+    /* Attempt to figure out where this function was called, if possible */
+    if(lua_getstack(lua, 1, &dbg) && lua_getinfo(lua, "nSl", &dbg)) {
+        sds msg = sdscatprintf(sdsempty(), "%s: %d: %s",
+            dbg.source, dbg.currentline, error);
+        lua_pushstring(lua, msg);
+        sdsfree(msg);
+    } else {
+        lua_pushstring(lua, error);
+    }
     lua_settable(lua,-3);
 }
 
@@ -866,9 +877,10 @@ void evalGenericCommand(redisClient *c, int evalsha) {
         delhook = 1;
     }
 
-    /* At this point whatever this script was never seen before or if it was
+    /* At this point whether this script was never seen before or if it was
      * already defined, we can call it. We have zero arguments and expect
      * a single return value. */
+
     err = lua_pcall(lua,0,1,0);
 
     /* Perform some cleanup that we need to do both on error and success. */


### PR DESCRIPTION
Okay. Sorry for spamming up the issues a little, I haven't contributed anything on github for a long time. This pull request will attempt to find the source of bad calls to the Redis Lua API, and should address issue #1121.

For instance, here is an example of it correctly reporting the source line of an error.

> redis 127.0.0.1:6379> eval "\n\n\n\nredis.call(\"del\")" 0
> (error) ERR Error running script (call to f_02e4b6c5f49751ef9096706ae82901bb51bf59f2): @user_script: 5: Wrong number of args calling Redis command From Lua script 
