### PR TITLE
removing useless LINE_BUFLEN definition in redis-cli.c

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -817,7 +817,6 @@ static char **convertToSds(int count, char** args) {
   return sds;
 }
 
-#define LINE_BUFLEN 4096
 static void repl() {
     sds historyfile = NULL;
     int history = 0;


### PR DESCRIPTION
removing useless LINE_BUFLEN definition in redis-cli.c

it causes misunderstanding about changing redis-cli max line size.

so. I might think it is better removing that line.

(actually, I modified linenoise's LINENOISE_MAX_LINE.)
