### PR TITLE
add config rewrite feature for sentinel

### DIFF
--- a/src/redis.h
+++ b/src/redis.h
@@ -1324,6 +1324,9 @@ char *redisGitSHA1(void);
 char *redisGitDirty(void);
 uint64_t redisBuildId(void);
 
+/* config */
+int rewriteConfigOverwriteFile(char *configfile, sds content);
+
 /* Commands prototypes */
 void authCommand(redisClient *c);
 void pingCommand(redisClient *c);


### PR DESCRIPTION
currently, sentinel doesn't have "config rewrite" feature.

so I add "config rewrite" feature for sentinel.

only add "config rewrite" for compatibility with redis-server.
