### PR TITLE
Feature: zaddnx - Issue #1128

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -164,6 +164,7 @@ struct redisCommand redisCommandTable[] = {
     {"sdiffstore",sdiffstoreCommand,-3,"wm",0,NULL,1,-1,1,0,0},
     {"smembers",sinterCommand,2,"rS",0,NULL,1,1,1,0,0},
     {"zadd",zaddCommand,-4,"wm",0,NULL,1,1,1,0,0},
+    {"zaddnx",zaddCommand,-4,"wm",0,NULL,1,1,1,0,0},
     {"zincrby",zincrbyCommand,4,"wm",0,NULL,1,1,1,0,0},
     {"zrem",zremCommand,-3,"w",0,NULL,1,1,1,0,0},
     {"zremrangebyscore",zremrangebyscoreCommand,4,"w",0,NULL,1,1,1,0,0},

--- a/src/redis.h
+++ b/src/redis.h
@@ -1404,6 +1404,7 @@ void debugCommand(redisClient *c);
 void msetCommand(redisClient *c);
 void msetnxCommand(redisClient *c);
 void zaddCommand(redisClient *c);
+void zaddnxCommand(redisClient *c);
 void zincrbyCommand(redisClient *c);
 void zrangeCommand(redisClient *c);
 void zrangebyscoreCommand(redisClient *c);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -838,7 +838,7 @@ void zsetConvert(robj *zobj, int encoding) {
  *----------------------------------------------------------------------------*/
 
 /* This generic command implements both ZADD and ZINCRBY. */
-void zaddGenericCommand(redisClient *c, int incr) {
+void zaddGenericCommand(redisClient *c, int incr, int nx) {
     static char *nanerr = "resulting score is not a number (NaN)";
     robj *key = c->argv[1];
     robj *ele;
@@ -852,6 +852,8 @@ void zaddGenericCommand(redisClient *c, int incr) {
         addReply(c,shared.syntaxerr);
         return;
     }
+
+    if (incr) nx = 0;
 
     /* Start parsing all the scores, we need to emit any syntax error
      * before executing additions to the sorted set, as the command should
@@ -889,6 +891,8 @@ void zaddGenericCommand(redisClient *c, int incr) {
             /* Prefer non-encoded element when dealing with ziplists. */
             ele = c->argv[3+j*2];
             if ((eptr = zzlFind(zobj->ptr,ele,&curscore)) != NULL) {
+                if (nx) continue;
+
                 if (incr) {
                     score += curscore;
                     if (isnan(score)) {
@@ -923,6 +927,8 @@ void zaddGenericCommand(redisClient *c, int incr) {
             ele = c->argv[3+j*2] = tryObjectEncoding(c->argv[3+j*2]);
             de = dictFind(zs->dict,ele);
             if (de != NULL) {
+                if (nx) continue;
+
                 curobj = dictGetKey(de);
                 curscore = *(double*)dictGetVal(de);
 
@@ -974,11 +980,15 @@ cleanup:
 }
 
 void zaddCommand(redisClient *c) {
-    zaddGenericCommand(c,0);
+    zaddGenericCommand(c,0,0);
+}
+
+void zaddnxCommand(redisClient *c) {
+    zaddGenericCommand(c,0,1);
 }
 
 void zincrbyCommand(redisClient *c) {
-    zaddGenericCommand(c,1);
+    zaddGenericCommand(c,1,0);
 }
 
 void zremCommand(redisClient *c) {

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -754,6 +754,17 @@ start_server {tags {"zset"}} {
         }
     }
 
+    test {ZADDNX basic} {
+        set ret [r zaddnx mykey 1 one 2 two 3 three] 
+        assert {$ret == 3}
+        
+        set ret [r zaddnx mykey 3 one] 
+        assert {$ret == 0}
+
+        set ret [r zaddnx mykey 2 one 4 four] 
+        assert {$ret == 1}
+    }
+
     tags {"slow"} {
         stressers ziplist
         stressers skiplist


### PR DESCRIPTION
New Feature : ZADDNX

1] spec
- if data exists in ZSET, just skip.
- if data doesn't exists in ZSET, add data into ZSET

2] Usage

``` c
redis 127.0.0.1:6379> zaddnx mykey 1 one 2 two 3 three
(integer) 3
redis 127.0.0.1:6379> zaddnx mykey 3 one
(integer) 0
redis 127.0.0.1:6379> zaddnx mykey 2 one 4 four
(integer) 1
```
