### PR TITLE
Call bind(2) before connect(2) if exists "bind ADDR" in redis.conf

### DIFF
--- a/src/anet.h
+++ b/src/anet.h
@@ -40,7 +40,7 @@
 #endif
 
 int anetTcpConnect(char *err, char *addr, int port);
-int anetTcpNonBlockConnect(char *err, char *addr, int port);
+int anetTcpNonBlockConnect(char *err, char *addr, int port, char *bindaddr);
 int anetUnixConnect(char *err, char *path);
 int anetUnixNonBlockConnect(char *err, char *path);
 int anetRead(int fd, char *buf, int count);

--- a/src/migrate.c
+++ b/src/migrate.c
@@ -151,7 +151,7 @@ void migrateCommand(redisClient *c) {
     
     /* Connect */
     fd = anetTcpNonBlockConnect(server.neterr,c->argv[1]->ptr,
-                atoi(c->argv[2]->ptr));
+                atoi(c->argv[2]->ptr), server.bindaddr);
     if (fd == -1) {
         addReplyErrorFormat(c,"Can't connect to target node: %s",
             server.neterr);

--- a/src/replication.c
+++ b/src/replication.c
@@ -670,7 +670,7 @@ error:
 int connectWithMaster(void) {
     int fd;
 
-    fd = anetTcpNonBlockConnect(NULL,server.masterhost,server.masterport);
+    fd = anetTcpNonBlockConnect(NULL,server.masterhost,server.masterport,server.bindaddr);
     if (fd == -1) {
         redisLog(REDIS_WARNING,"Unable to connect to MASTER: %s",
             strerror(errno));


### PR DESCRIPTION
Redis master recognizes slave's IP address by getpeername(2) so that address becomes an address assigned slave's eth0 even if IP aliased (eth0:1) in slave linux box and `bind <IP address assigned eth0:1)` in redis.conf.

This is not a promblem in simple master/slave replication except that `redis-clit -h MASTER info | grep slave` shows wrong slave's IP address.

Now I introduced Redis Sentinel. Sentinel gets slaves address from result of `info` command to master, so sentinel recognizes not slave's eth0:1 but slave's eth0 as slave's IP address.

Sentinel's health check to slave will fail because slave only listen eth0:1. If redis master crashed, sentinel cannot failover because there is no healthy slave.

To fix it, slave calls bind(2) before connect(2) to master if there is `bind <address>` in redis.conf and that address is not local address (127.0.0.0/8).

Could you give me any advice?

```
Redis master:
  IP address:
    eth0:   10.0.0.100

Redis slave:
  IP address:
    eth0:   10.0.0.200
    eth0:1: 10.0.0.201
  redis.conf:
    bind 10.0.0.201

Redis sentinel:
  IP address:
    eth0:   10.0.0.50
  sentinel.conf:
    sentinel monitor mymaster 10.0.0.100 6379 1

$ redis-cli -h 10.0.0.201 slaveof 10.0.0.100 6379

$ redis-cli -h 10.0.0.100 info | grep slave
slave0:10.0.0.200,6379,online  # not 10.0.0.201

$ redis-cli -h 10.0.0.50 sentinel slaves mymaster | grep -A1 ip
ip
10.0.0.200  # not 10.0.0.201

```
