### PR TITLE
Initialize char* to NULL to remove compiler warning

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1332,7 +1332,7 @@ void rewriteConfigOctalOption(struct rewriteConfigState *state, char *option, in
  * specified. See how the function is used for more information. */
 void rewriteConfigEnumOption(struct rewriteConfigState *state, char *option, int value, ...) {
     va_list ap;
-    char *enum_name, *matching_name;
+    char *enum_name, *matching_name = NULL;
     int enum_val, def_val, force;
     sds line;
     
@@ -1357,7 +1357,7 @@ void rewriteConfigEnumOption(struct rewriteConfigState *state, char *option, int
 void rewriteConfigSyslogfacilityOption(struct rewriteConfigState *state) {
     int value = server.syslog_facility, j;
     int force = value != LOG_LOCAL0;
-    char *name, *option = "syslog-facility";
+    char *name = NULL, *option = "syslog-facility";
     sds line;
 
     for (j = 0; validSyslogFacilities[j].name; j++) {


### PR DESCRIPTION
This removes the following compiler warnings:

```
config.c: In function ‘rewriteConfigEnumOption’:
config.c:1352:10: warning: ‘matching_name’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     line = sdscatprintf(sdsempty(),"%s %s",option,matching_name);
          ^
config.c: In function ‘rewriteConfigSyslogfacilityOption’:
config.c:1369:10: warning: ‘name’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     line = sdscatprintf(sdsempty(),"%s %s",option,name);
          ^
```
