### PR TITLE
implement ZISMEMBER for zset

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -177,6 +177,7 @@ struct redisCommand redisCommandTable[] = {
     {"zrevrange",zrevrangeCommand,-4,"r",0,NULL,1,1,1,0,0},
     {"zcard",zcardCommand,2,"r",0,NULL,1,1,1,0,0},
     {"zscore",zscoreCommand,3,"r",0,NULL,1,1,1,0,0},
+    {"zismember",zismemberCommand,3,"r",0,NULL,1,1,1,0,0},
     {"zrank",zrankCommand,3,"r",0,NULL,1,1,1,0,0},
     {"zrevrank",zrevrankCommand,3,"r",0,NULL,1,1,1,0,0},
     {"hset",hsetCommand,4,"wm",0,NULL,1,1,1,0,0},

--- a/src/redis.h
+++ b/src/redis.h
@@ -1428,6 +1428,7 @@ void zrevrangeCommand(redisClient *c);
 void zcardCommand(redisClient *c);
 void zremCommand(redisClient *c);
 void zscoreCommand(redisClient *c);
+void zismemberCommand(redisClient *c);
 void zremrangebyscoreCommand(redisClient *c);
 void multiCommand(redisClient *c);
 void execCommand(redisClient *c);


### PR DESCRIPTION
ZISMEMBER for zset are same as SISMEMBER for set: it determine if a given value is a member of a zset.

Format: `ZISMEMBER <key> <member>`

Return values:
- If `key` not exists, return `0` .
- If `key` exists, and `member` are `key`'s member, return `1` , else return `0` .

Time complexity: O(1)

Example:

```
redis 127.0.0.1:6379> FLUSHDB
OK
redis 127.0.0.1:6379> ZISMEMBER number pi
(integer) 0
redis 127.0.0.1:6379> ZADD number 3.14 pi
(integer) 1
redis 127.0.0.1:6379> ZISMEMBER number pi
(integer) 1
redis 127.0.0.1:6379> ZISMEMBER number e
(integer) 0
```
