### PR TITLE
Add ziplistDeleteRangeFromOffset

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -234,8 +234,7 @@ int hashTypeDelete(robj *o, robj *field) {
         if (fptr != NULL) {
             fptr = ziplistFind(fptr, field->ptr, sdslen(field->ptr), 1);
             if (fptr != NULL) {
-                zl = ziplistDelete(zl,&fptr);
-                zl = ziplistDelete(zl,&fptr);
+                zl = ziplistDeleteRangeFromOffset(zl,&fptr,2);
                 o->ptr = zl;
                 deleted = 1;
             }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -635,8 +635,7 @@ unsigned char *zzlDelete(unsigned char *zl, unsigned char *eptr) {
     unsigned char *p = eptr;
 
     /* TODO: add function to ziplist API to delete N elements from offset. */
-    zl = ziplistDelete(zl,&p);
-    zl = ziplistDelete(zl,&p);
+    zl = ziplistDeleteRangeFromOffset(zl,&p,2);
     return zl;
 }
 
@@ -719,8 +718,7 @@ unsigned char *zzlDeleteRangeByScore(unsigned char *zl, zrangespec range, unsign
         score = zzlGetScore(sptr);
         if (zslValueLteMax(score,&range)) {
             /* Delete both the element and the score. */
-            zl = ziplistDelete(zl,&eptr);
-            zl = ziplistDelete(zl,&eptr);
+            zl = ziplistDeleteRangeFromOffset(zl,&eptr,2);
             num++;
         } else {
             /* No longer in range. */

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -767,12 +767,12 @@ unsigned char *ziplistInsert(unsigned char *zl, unsigned char *p, unsigned char 
     return __ziplistInsert(zl,p,s,slen);
 }
 
-/* Delete a single entry from the ziplist, pointed to by *p.
+/* Delete 'num' entries from the ziplist, pointed to by *p.
  * Also update *p in place, to be able to iterate over the
  * ziplist, while deleting entries. */
-unsigned char *ziplistDelete(unsigned char *zl, unsigned char **p) {
+unsigned char *ziplistDeleteRangeFromOffset(unsigned char *zl, unsigned char **p, unsigned int num) {
     size_t offset = *p-zl;
-    zl = __ziplistDelete(zl,*p,1);
+    zl = __ziplistDelete(zl,*p,num);
 
     /* Store pointer to current element in p, because ziplistDelete will
      * do a realloc which might result in a different "zl"-pointer.
@@ -781,6 +781,14 @@ unsigned char *ziplistDelete(unsigned char *zl, unsigned char **p) {
     *p = zl+offset;
     return zl;
 }
+
+/* Delete a single entry from the ziplist, pointed to by *p.
+ * Also update *p in place, to be able to iterate over the
+ * ziplist, while deleting entries. */
+unsigned char *ziplistDelete(unsigned char *zl,unsigned char **p) {
+    return ziplistDeleteRangeFromOffset(zl, p, 1);
+}
+
 
 /* Delete a range of entries from the ziplist. */
 unsigned char *ziplistDeleteRange(unsigned char *zl, unsigned int index, unsigned int num) {

--- a/src/ziplist.h
+++ b/src/ziplist.h
@@ -40,6 +40,7 @@ unsigned int ziplistGet(unsigned char *p, unsigned char **sval, unsigned int *sl
 unsigned char *ziplistInsert(unsigned char *zl, unsigned char *p, unsigned char *s, unsigned int slen);
 unsigned char *ziplistDelete(unsigned char *zl, unsigned char **p);
 unsigned char *ziplistDeleteRange(unsigned char *zl, unsigned int index, unsigned int num);
+unsigned char *ziplistDeleteRangeFromOffset(unsigned char *zl, unsigned char **p, unsigned int num);
 unsigned int ziplistCompare(unsigned char *p, unsigned char *s, unsigned int slen);
 unsigned char *ziplistFind(unsigned char *p, unsigned char *vstr, unsigned int vlen, unsigned int skip);
 unsigned int ziplistLen(unsigned char *zl);


### PR DESCRIPTION
Added `ziplistDeleteRangeFromOffset` allowing to remove more than one entry from ziplist starting from a given entry in the ziplist.
Changed `ziplistDelete` to return result from `ziplistDeleteRangeFromOffset` call. 
In addition, replaced every `ziplistDelete` double-call to a single `ziplistDeleteRangeFromOffset` call.

These changes were made due to a "TODO" request in the code.

Tests - I have run `make test` to approve that my changes haven't caused new problems.
