### PR TITLE
add lsb tags requested on debian (http://wiki.debian.org/LSBInitScripts)

### DIFF
--- a/utils/redis_init_script
+++ b/utils/redis_init_script
@@ -1,4 +1,12 @@
 #!/bin/sh
+### BEGIN INIT INFO
+# Provides: redis
+# Required-Start: $local_fs $remote_fs $network $named
+# Required-Stop: $local_fs $remote_fs $network $named
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: Start Redis daemon at boot time
+### END INIT INFO
 #
 # Simple Redis init.d script conceived to work on Linux systems
 # as it does use of the /proc filesystem.


### PR DESCRIPTION
Hi,

The LSB tags are missing on redis init script. It's usefull to build daemons that need redis to be started before.

Output on debian :

```
  $ sudo update-rc.d redis defaults
  insserv: warning: script 'redis' missing LSB tags and overrides
```

You can find more infos here :
http://wiki.debian.org/LSBInitScripts
