### PR TITLE
Have sds buffers store sizes as unsigned

### DIFF
--- a/src/sds.h
+++ b/src/sds.h
@@ -39,8 +39,8 @@
 typedef char *sds;
 
 struct sdshdr {
-    int len;
-    int free;
+    unsigned int len;
+    unsigned int free;
     char buf[];
 };
 


### PR DESCRIPTION
@tnm tried to run KEYS against a slave of the GitHub production redis database with redis-cli today and we ran into a segfault in redis-cli after an sds buffer overflowed 2GB len. Seems reasonable to make it unsigned since the size should never be negative?
