### PR TITLE
redis-check-dump: Prevent a segfault if len is so big we can't malloc it that big.

### DIFF
--- a/src/redis-check-dump.c
+++ b/src/redis-check-dump.c
@@ -335,6 +335,7 @@ char* loadStringObject() {
     if (len == REDIS_RDB_LENERR) return NULL;
 
     char *buf = malloc(sizeof(char) * (len+1));
+    if (buf == NULL) return NULL;
     buf[len] = '\0';
     if (!readBytes(buf, len)) {
         free(buf);


### PR DESCRIPTION
Found by The Mayhem Team (Alexandre Rebert, Thanassis Avgerinos,
Sang Kil Cha, David Brumley, Manuel Egele) Cylab, Carnegie Mellon
University. See http://bugs.debian.org/716259 for more.
