### PR TITLE
Wrap IPv6 in brackets in the prompt.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -116,7 +116,8 @@ static void cliRefreshPrompt(void) {
         len = snprintf(config.prompt,sizeof(config.prompt),"redis %s",
                        config.hostsocket);
     else
-        len = snprintf(config.prompt,sizeof(config.prompt),"redis %s:%d",
+        len = snprintf(config.prompt,sizeof(config.prompt),
+                       strchr(config.hostip,':') ? "[%s]:%d" : "%s:%d",
                        config.hostip, config.hostport);
     /* Add [dbnum] if needed */
     if (config.dbnum != 0)


### PR DESCRIPTION
There are atleast two more places where `config.hostip` is printed (an error message and in `cliReadReply`). Should I fix them aswell or just the []-wrapping be a function?
