### PR TITLE
Fixed the header guard in zipmap.h

### DIFF
--- a/src/zipmap.h
+++ b/src/zipmap.h
@@ -32,7 +32,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _ZIMMAP_H
+#ifndef _ZIPMAP_H
 #define _ZIPMAP_H
 
 unsigned char *zipmapNew(void);


### PR DESCRIPTION
Currently the header guard incorrectly checks the variable _ZIMMAP_H instead of _ZIPMAP_H. This pull request fixes that.
