### PR TITLE
Remove unused variable `bothsds`

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -347,7 +347,6 @@ int compareStringObjectsWithFlags(robj *a, robj *b, int flags) {
     redisAssertWithInfo(NULL,a,a->type == REDIS_STRING && b->type == REDIS_STRING);
     char bufa[128], bufb[128], *astr, *bstr;
     size_t alen, blen, minlen;
-    int bothsds = 1;
 
     if (a == b) return 0;
     if (a->encoding != REDIS_ENCODING_RAW) {


### PR DESCRIPTION
In 81e55ec0 the code here changed and now bothsds is not needed anymore.

Fixes the warning:

```
object.c: In function ‘compareStringObjectsWithFlags’:
object.c:350:9: warning: variable ‘bothsds’ set but not used [-Wunused-but-set-variable]
     int bothsds = 1;
         ^
```
