### PR TITLE
Delete a useless variable in src/object.c

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -347,13 +347,11 @@ int compareStringObjectsWithFlags(robj *a, robj *b, int flags) {
     redisAssertWithInfo(NULL,a,a->type == REDIS_STRING && b->type == REDIS_STRING);
     char bufa[128], bufb[128], *astr, *bstr;
     size_t alen, blen, minlen;
-    int bothsds = 1;
 
     if (a == b) return 0;
     if (a->encoding != REDIS_ENCODING_RAW) {
         alen = ll2string(bufa,sizeof(bufa),(long) a->ptr);
         astr = bufa;
-        bothsds = 0;
     } else {
         astr = a->ptr;
         alen = sdslen(astr);
@@ -361,7 +359,6 @@ int compareStringObjectsWithFlags(robj *a, robj *b, int flags) {
     if (b->encoding != REDIS_ENCODING_RAW) {
         blen = ll2string(bufb,sizeof(bufb),(long) b->ptr);
         bstr = bufb;
-        bothsds = 0;
     } else {
         bstr = b->ptr;
         blen = sdslen(bstr);


### PR DESCRIPTION
In commit 81e55ec0, the last return statement:

   return bothsds ? sdscmp(astr,bstr) : strcmp(astr,bstr);

was deleted, which result in the variable 'bothsds' to be useless.

This patch clean up the useless variable and correct the compiler
warning.
