### PR TITLE
fix test for sdsrange in sds.c

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -811,32 +811,43 @@ int main(void) {
         test_cond("sdstrim() correctly trims characters",
             sdslen(x) == 4 && memcmp(x,"ciao\0",5) == 0)
 
-        y = sdsrange(sdsdup(x),1,1);
+        y = sdsdup(x);
+        sdsrange(y,1,1);
         test_cond("sdsrange(...,1,1)",
             sdslen(y) == 1 && memcmp(y,"i\0",2) == 0)
 
         sdsfree(y);
-        y = sdsrange(sdsdup(x),1,-1);
+
+        y = sdsdup(x);
+        sdsrange(y,1,-1);
         test_cond("sdsrange(...,1,-1)",
             sdslen(y) == 3 && memcmp(y,"iao\0",4) == 0)
 
         sdsfree(y);
-        y = sdsrange(sdsdup(x),-2,-1);
+
+        y = sdsdup(x);
+        sdsrange(y,-2,-1);
         test_cond("sdsrange(...,-2,-1)",
             sdslen(y) == 2 && memcmp(y,"ao\0",3) == 0)
 
         sdsfree(y);
-        y = sdsrange(sdsdup(x),2,1);
+        
+        y = sdsdup(x);
+        sdsrange(y,2,1);
         test_cond("sdsrange(...,2,1)",
             sdslen(y) == 0 && memcmp(y,"\0",1) == 0)
 
         sdsfree(y);
-        y = sdsrange(sdsdup(x),1,100);
+
+        y = sdsdup(x);
+        sdsrange(y,1,100);
         test_cond("sdsrange(...,1,100)",
             sdslen(y) == 3 && memcmp(y,"iao\0",4) == 0)
 
         sdsfree(y);
-        y = sdsrange(sdsdup(x),100,100);
+
+        y = sdsdup(x);
+        sdsrange(y,100,100);
         test_cond("sdsrange(...,100,100)",
             sdslen(y) == 0 && memcmp(y,"\0",1) == 0)
 


### PR DESCRIPTION
in sds.c

main function has invalid tests for sdsrange.

so I fixed it to be able to build.

This is not important. but it might need for consistency for usage of sdsrange

``` c
1 - Create a string and obtain the length: PASSED
2 - Create a string with specified length: PASSED
3 - Strings concatenation: PASSED
4 - sdscpy() against an originally longer string: PASSED
5 - sdscpy() against an originally shorter string: PASSED
6 - sdscatprintf() seems working in the base case: PASSED
7 - sdstrim() correctly trims characters: PASSED
8 - sdsrange(...,1,1): PASSED
9 - sdsrange(...,1,-1): PASSED
10 - sdsrange(...,-2,-1): PASSED
11 - sdsrange(...,2,1): PASSED
12 - sdsrange(...,1,100): PASSED
13 - sdsrange(...,100,100): PASSED
14 - sdscmp(foo,foa): PASSED
15 - sdscmp(bar,bar): PASSED
16 - sdscmp(bar,bar): PASSED
17 - sdsnew() free/len buffers: PASSED
18 - sdsMakeRoomFor(): PASSED
19 - sdsIncrLen() -- content: PASSED
20 - sdsIncrLen() -- len: PASSED
21 - sdsIncrLen() -- free: PASSED
21 tests, 21 passed, 0 failed
```
