### PR TITLE
Add valgrind-3.6.0 support to unit tests

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -53,6 +53,7 @@ set ::host 127.0.0.1
 set ::port 21111
 set ::traceleaks 0
 set ::valgrind 0
+set ::valgrind_version 0
 set ::verbose 0
 set ::quiet 0
 set ::denytags {}
@@ -372,6 +373,7 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         incr j
     } elseif {$opt eq {--valgrind}} {
         set ::valgrind 1
+        set ::valgrind_version [exec valgrind --version]
     } elseif {$opt eq {--quiet}} {
         set ::quiet 1
     } elseif {$opt eq {--host}} {


### PR DESCRIPTION
## Introduction

I got a machine with `valgrind-3.6.0.SVN-Debian`. Unfortunately, `Valgrind-3.6.0` doesn't have the `show-possibly-lost` flag causing the unit-test to exit with the following error message:

```
ERROR:valgrind: Bad option: --show-possibly-lost=no
valgrind: Use --help for more information or consult the user manual.
```
## Notes
- I've assumed that any version older than 3.6.0 doesn't support the `show-possibly-lost` flag.
- I've added a simple `attention` message in case the machine has old Valgrind version.
- Feel free to share your thoughts.
