### PR TITLE
Fix issue #356 - server.maxclients could be minus!

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1404,11 +1404,10 @@ void adjustOpenFilesLimit(void) {
                 } else {
                     server.maxclients = 0;
                     redisLog(REDIS_WARNING,"Unable to set the max number of "
-                                "files limit to the smallest files number for"
-                                " running Redis %d (%s), setting the max "
-                                "clients configuration to %d",
-                                (int)REDIS_ESSENTIAL_FD, strerror(errno),
-                                (int)server.maxclients);
+                                "files limit to the smallest files number (%d) for"
+                                " running Redis (%s). ",
+                                (int)REDIS_ESSENTIAL_FD, strerror(errno));
+                    exit(1);
                 }
             } else {
                 redisLog(REDIS_NOTICE,"Max number of open files set to %d",


### PR DESCRIPTION
## Introduction

This is my attempt to fix issue #356.
## Tests

Unfortunately, I have no idea how to set limit on fd through TCL script. I did look it up on Google, but haven't found any useful link. Anyway, I did manual testing -- 

running: `ulimit -n 1024 && ./redis-server`; expecting to get

```
Unable to set the max number of files limit to 10032 (Operation not permitted), 
setting the max clients configuration to 912.
```

running: `ulimit -n 32 && ./redis-server`; expecting to get

```
Unable to set the max number of files limit to 10032 (Operation not permitted), 
setting the max clients configuration to 0.
```

running: `ulimit -n 16 && ./redis-server`; expecting to exit Redis with this message

```
Unable to set the max number of files limit to the smallest files number (32) for
running Redis (Operation not permitted)
```
## Notes
- Feel free to share your thoughts.
