### PR TITLE
Documentation regarding upstart failing to shutdown redis-server

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -29,6 +29,10 @@ port 6379
 # interfaces using the "bind" configuration directive, followed by one or
 # more IP addresses.
 #
+# On Linux, default init scripts may fail to shutdown redis-server if "bind"
+# does not include 127.0.0.1. Shutdown functionality can be fixed by adding 
+# the -h argument. Example: $CLIEXEC -h $REDISHOST -p $REDISPORT shutdown
+#
 # Examples:
 #
 # bind 192.168.1.100 10.0.0.1

--- a/utils/redis_init_script
+++ b/utils/redis_init_script
@@ -4,6 +4,7 @@
 # as it does use of the /proc filesystem.
 
 REDISPORT=6379
+REDISHOST=127.0.0.1
 EXEC=/usr/local/bin/redis-server
 CLIEXEC=/usr/local/bin/redis-cli
 
@@ -27,7 +28,7 @@ case "$1" in
         else
                 PID=$(cat $PIDFILE)
                 echo "Stopping ..."
-                $CLIEXEC -p $REDISPORT shutdown
+                $CLIEXEC -h $REDISHOST -p $REDISPORT shutdown
                 while [ -x /proc/${PID} ]
                 do
                     echo "Waiting for Redis to shutdown ..."

--- a/utils/redis_init_script.tpl
+++ b/utils/redis_init_script.tpl
@@ -16,6 +16,7 @@ case "$1" in
         else
                 PID=$(cat $PIDFILE)
                 echo "Stopping ..."
+                # Add "-h [bind address]" if Redis *does not* listen on localhost
                 $CLIEXEC -p $REDISPORT shutdown
                 while [ -x /proc/${PID} ]
                 do


### PR DESCRIPTION
With upstart, the server will not shutdown if bind does not include 127.0.0.1. See https://groups.google.com/forum/#!topic/redis-db/DYLxoMbNzlQ (zero replies as of now).
