### PR TITLE
New config option: auth-maxtries, which disconnects the client after a c...

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -430,6 +430,15 @@ slave-priority 100
 #
 # requirepass foobared
 
+# Only allow clients to fail AUTH a certain number of times before they are
+# disconnected. This allows you to use iptables or equivalent to limit the
+# number of connections to redis and mitigate the abovementioned password
+# guessing attack.
+#
+# Set to 0 (or leave commented) to disable disconnection.
+#
+# auth-maxtries 3
+
 # Command renaming.
 #
 # It is possible to change the name of dangerous commands in a shared

--- a/src/config.c
+++ b/src/config.c
@@ -448,6 +448,8 @@ void loadServerConfigFromString(char *config) {
                 goto loaderr;
             }
             server.requirepass = zstrdup(argv[1]);
+        } else if (!strcasecmp(argv[0],"auth-maxtries") && argc == 2) {
+            server.auth_maxtries = strtol(argv[1], NULL, 10);
         } else if (!strcasecmp(argv[0],"pidfile") && argc == 2) {
             zfree(server.pidfile);
             server.pidfile = zstrdup(argv[1]);
@@ -909,6 +911,8 @@ void configSetCommand(client *c) {
     } config_set_numerical_field(
       "timeout",server.maxidletime,0,LONG_MAX) {
     } config_set_numerical_field(
+      "auth-maxtries",server.auth_maxtries,0,UINT_MAX) {
+    } config_set_numerical_field(
       "auto-aof-rewrite-percentage",server.aof_rewrite_perc,0,LLONG_MAX){
     } config_set_numerical_field(
       "auto-aof-rewrite-min-size",server.aof_rewrite_min_size,0,LLONG_MAX) {
@@ -1065,6 +1069,7 @@ void configGetCommand(client *c) {
     config_get_string_field("pidfile",server.pidfile);
 
     /* Numerical values */
+    config_get_numerical_field("auth-maxtries",server.auth_maxtries);
     config_get_numerical_field("maxmemory",server.maxmemory);
     config_get_numerical_field("maxmemory-samples",server.maxmemory_samples);
     config_get_numerical_field("timeout",server.maxidletime);
@@ -1817,6 +1822,7 @@ int rewriteConfig(char *path) {
     rewriteConfigNumericalOption(state,"min-slaves-to-write",server.repl_min_slaves_to_write,CONFIG_DEFAULT_MIN_SLAVES_TO_WRITE);
     rewriteConfigNumericalOption(state,"min-slaves-max-lag",server.repl_min_slaves_max_lag,CONFIG_DEFAULT_MIN_SLAVES_MAX_LAG);
     rewriteConfigStringOption(state,"requirepass",server.requirepass,NULL);
+    rewriteConfigNumericalOption(state,"auth-maxtries",server.auth_maxtries,CONFIG_DEFAULT_AUTH_MAXTRIES);
     rewriteConfigNumericalOption(state,"maxclients",server.maxclients,CONFIG_DEFAULT_MAX_CLIENTS);
     rewriteConfigBytesOption(state,"maxmemory",server.maxmemory,CONFIG_DEFAULT_MAXMEMORY);
     rewriteConfigEnumOption(state,"maxmemory-policy",server.maxmemory_policy,maxmemory_policy_enum,CONFIG_DEFAULT_MAXMEMORY_POLICY);

--- a/src/networking.c
+++ b/src/networking.c
@@ -103,6 +103,7 @@ client *createClient(int fd) {
     c->flags = 0;
     c->ctime = c->lastinteraction = server.unixtime;
     c->authenticated = 0;
+    c->auth_tries = 0;
     c->replstate = REPL_STATE_NONE;
     c->repl_put_online_on_ack = 0;
     c->reploff = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -2659,6 +2659,10 @@ void authCommand(client *c) {
     } else {
       c->authenticated = 0;
       addReplyError(c,"invalid password");
+      c->auth_tries++;
+      if (server.auth_maxtries != 0 && c->auth_tries >= server.auth_maxtries) {
+        c->flags |= CLIENT_CLOSE_AFTER_REPLY;
+      }
     }
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -94,6 +94,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define AOF_REWRITE_ITEMS_PER_CMD 64
 #define CONFIG_DEFAULT_SLOWLOG_LOG_SLOWER_THAN 10000
 #define CONFIG_DEFAULT_SLOWLOG_MAX_LEN 128
+#define CONFIG_DEFAULT_AUTH_MAXTRIES 0
 #define CONFIG_DEFAULT_MAX_CLIENTS 10000
 #define CONFIG_AUTHPASS_MAX_LEN 512
 #define CONFIG_DEFAULT_SLAVE_PRIORITY 100
@@ -585,6 +586,7 @@ typedef struct client {
     time_t obuf_soft_limit_reached_time;
     int flags;              /* Client flags: CLIENT_* macros. */
     int authenticated;      /* When requirepass is non-NULL. */
+    unsigned int auth_tries; /* Times the client has tried to authenticate */
     int replstate;          /* Replication state if this is a slave. */
     int repl_put_online_on_ack; /* Install slave write handler on ACK. */
     int repldbfd;           /* Replication DB file descriptor. */
@@ -793,6 +795,7 @@ struct redisServer {
     int supervised_mode;            /* See SUPERVISED_* */
     int daemonize;                  /* True if running as a daemon */
     clientBufferLimitsConfig client_obuf_limits[CLIENT_TYPE_OBUF_COUNT];
+    unsigned int auth_maxtries;     /* Number of AUTHs allowed (0=infinite) */
     /* AOF persistence */
     int aof_state;                  /* AOF_(ON|OFF|WAIT_REWRITE) */
     int aof_fsync;                  /* Kind of fsync() policy */

--- a/tests/unit/auth.tcl
+++ b/tests/unit/auth.tcl
@@ -25,3 +25,14 @@ start_server {tags {"auth"} overrides {requirepass foobar}} {
         r incr foo
     } {101}
 }
+
+start_server {tags {"auth"} overrides {requirepass foobar auth-maxtries 1}} {
+    test {AUTH fails when wrong password given, but does not disconnect} {
+        catch {r auth wrong!} err
+        set _ $err
+    } {ERR*invalid password}
+    
+    test {AUTH fails and disconnects when wrong password given again} {
+        assert_error * {r auth wrong}
+    }
+}


### PR DESCRIPTION
New config option: auth-maxtries, which disconnects the client after a certain number of failed AUTH attempts. The host can then be configured (with iptables, or equivalent) to rate-limit the number of incoming connections, reducing the number of passwords that can be tried per second significantly.
