### PR TITLE
Added config: slaves refuse sync if too little data

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -227,6 +227,12 @@ slave-read-only yes
 # be a good idea.
 repl-disable-tcp-nodelay no
 
+# Set a minimum allowed size, in bytes, that will be allowed to be loaded by
+# a Slave from a Master. This can prevent an empty Master from wiping out
+# a Slave's data set.
+#
+# repl-min-transfer-size 0
+
 # The slave priority is an integer number published by Redis in the INFO output.
 # It is used by Redis Sentinel in order to select a slave to promote into a
 # master if the master is no longer working correctly.

--- a/src/config.c
+++ b/src/config.c
@@ -249,6 +249,8 @@ void loadServerConfigFromString(char *config) {
             if ((server.repl_disable_tcp_nodelay = yesnotoi(argv[1])) == -1) {
                 err = "argument must be 'yes' or 'no'"; goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"repl-min-transfer-size") && argc == 2) {
+            server.repl_min_transfer_size = memtoll(argv[1],NULL);
         } else if (!strcasecmp(argv[0],"masterauth") && argc == 2) {
         	server.masterauth = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"slave-serve-stale-data") && argc == 2) {

--- a/src/redis.c
+++ b/src/redis.c
@@ -1236,6 +1236,7 @@ void initServerConfig() {
     server.repl_down_since = 0; /* Never connected, repl is down since EVER. */
     server.repl_disable_tcp_nodelay = 0;
     server.slave_priority = REDIS_DEFAULT_SLAVE_PRIORITY;
+    server.repl_min_transfer_size = 0;
 
     /* Client output buffer limits */
     server.client_obuf_limits[REDIS_CLIENT_LIMIT_CLASS_NORMAL].hard_limit_bytes = 0;

--- a/src/redis.h
+++ b/src/redis.h
@@ -617,6 +617,7 @@ struct redisServer {
     redisClient *master;     /* Client that is master for this slave */
     int repl_syncio_timeout; /* Timeout for synchronous I/O calls */
     int repl_state;          /* Replication status if the instance is a slave */
+    off_t repl_min_transfer_size; /* Minimum allowed size of RDB to read from master during sync. */
     off_t repl_transfer_size; /* Size of RDB to read from master during sync. */
     off_t repl_transfer_read; /* Amount of RDB read from master during sync. */
     off_t repl_transfer_last_fsync_off; /* Offset when we fsync-ed last time. */

--- a/src/replication.c
+++ b/src/replication.c
@@ -383,6 +383,11 @@ void readSyncBulkPayload(aeEventLoop *el, int fd, void *privdata, int mask) {
             goto error;
         }
         server.repl_transfer_size = strtol(buf+1,NULL,10);
+        if (server.repl_transfer_size < server.repl_min_transfer_size) {
+            redisLog(REDIS_WARNING,"Bad RDB from MASTER, the transfer size of %ld is less than minimum allowed %ld bytes",
+                server.repl_transfer_size, server.repl_min_transfer_size);
+            goto error;
+        }
         redisLog(REDIS_NOTICE,
             "MASTER <-> SLAVE sync: receiving %ld bytes from master",
             server.repl_transfer_size);


### PR DESCRIPTION
Add a configuration option for slaves to refuse syncing to a master if there is not enough data in the master. Based on 2.6, would likely need changes for 2.8/unstable with the partial-sync changes.

ie:
repl-min-transfer-size 1g
