### PR TITLE
Prevent (some) race conditions between connections.

### DIFF
--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -89,11 +89,13 @@ start_server {tags {"pubsub"}} {
 
     test "PUBLISH/SUBSCRIBE after UNSUBSCRIBE without arguments" {
         set rd1 [redis_deferring_client]
-        assert_equal {1 2 3} [subscribe $rd1 {chan1 chan2 chan3}]
+        assert_equal {1 2 3} [subscribe $rd1 {chan4 chan5 chan6}]
         unsubscribe $rd1
-        assert_equal 0 [r publish chan1 hello]
-        assert_equal 0 [r publish chan2 hello]
-        assert_equal 0 [r publish chan3 hello]
+        # wait for command response to be sure it was handled
+        $rd1 read
+        assert_equal 0 [r publish chan4 hello]
+        assert_equal 0 [r publish chan5 hello]
+        assert_equal 0 [r publish chan6 hello]
 
         # clean up clients
         $rd1 close
@@ -162,11 +164,13 @@ start_server {tags {"pubsub"}} {
 
     test "PUBLISH/PSUBSCRIBE after PUNSUBSCRIBE without arguments" {
         set rd1 [redis_deferring_client]
-        assert_equal {1 2 3} [psubscribe $rd1 {chan1.* chan2.* chan3.*}]
+        assert_equal {1 2 3} [psubscribe $rd1 {chan4.* chan5.* chan6.*}]
         punsubscribe $rd1
-        assert_equal 0 [r publish chan1.hi hello]
-        assert_equal 0 [r publish chan2.hi hello]
-        assert_equal 0 [r publish chan3.hi hello]
+        # wait for command response to be sure it was handled
+        $rd1 read
+        assert_equal 0 [r publish chan4.hi hello]
+        assert_equal 0 [r publish chan5.hi hello]
+        assert_equal 0 [r publish chan6.hi hello]
 
         # clean up clients
         $rd1 close

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -312,6 +312,13 @@ start_server {
       set rd1 [redis_deferring_client]
       set rd2 [redis_deferring_client]
 
+      # there is an inherent race here, but at least verify rd1/rd2 are
+      # connected before racing them against r.
+      $rd1 ping
+      assert_equal {PONG} [$rd1 read]
+      $rd2 ping
+      assert_equal {PONG} [$rd2 read]
+
       r del list1 list2 list3
 
       $rd1 brpoplpush list1 list2 0
@@ -327,6 +334,11 @@ start_server {
     test "Circular BRPOPLPUSH" {
       set rd1 [redis_deferring_client]
       set rd2 [redis_deferring_client]
+
+      $rd1 ping
+      assert_equal {PONG} [$rd1 read]
+      $rd2 ping
+      assert_equal {PONG} [$rd2 read]
 
       r del list1 list2
 


### PR DESCRIPTION
Apparently there are quite situations in the test suite where different connections race each other.  In a regular "make test" it probably never shows up, but once we leverage (portions of) the test suite and use remote servers things come up.

Not sure it's such a high priority to fix but here are few recent fixes we had to do and some clarifications:
In pubsub.tcl:
1. Consecutive pubsub tests using the same channels may fail, as the socket disconnection of a previous test may not be complete and thus the server may still count it as a live subscription.
2. UNSUBSCRIBE on a deferring client races and may lose to commands that execute on the main connection.

In list.tcl:
There is an inherent race between the DEL, BRPOPLPUSH and LRANGE.  Unfortunately, there's no easy way to tell BRPOPLPUSH was received (unless we look at INFO - too complex), but the PING in the beginning reduces the chances significantly as we can at least be sure the 3 connections are established when the race starts.
