### PR TITLE
fix zslRandomLevel - trivial but it has potential bug.

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -99,9 +99,12 @@ void zslFree(zskiplist *zsl) {
  * levels are less likely to be returned. */
 int zslRandomLevel(void) {
     int level = 1;
-    while ((random()&0xFFFF) < (ZSKIPLIST_P * 0xFFFF))
+    while ((level < ZSKIPLIST_MAXLEVEL) && 
+           ((random()&0xFFFF) < (ZSKIPLIST_P * 0xFFFF))) {
         level += 1;
-    return (level<ZSKIPLIST_MAXLEVEL) ? level : ZSKIPLIST_MAXLEVEL;
+    }
+
+    return level;
 }
 
 zskiplistNode *zslInsert(zskiplist *zsl, double score, robj *obj) {


### PR DESCRIPTION
I think it is trivial and It might not be happened.

but it can be run with infinity loop when (random()&0xFFFF) < (ZSKIPLIST_P \* 0xFFFF) is always True.

and it can be looped more than ZSKIPLIST_MAXLEVEL

```
while ((random()&0xFFFF) < (ZSKIPLIST_P * 0xFFFF)) 
```

so this patch will make it loop less or equals than ZSKIPLIST_MAXLEVEL
