### PR TITLE
Spelling of 'verify' in debug.c

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -838,7 +838,7 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
 "\n=== REDIS BUG REPORT END. Make sure to include from START to END. ===\n\n"
 "       Please report the crash opening an issue on github:\n\n"
 "           http://github.com/antirez/redis/issues\n\n"
-"  Suspect RAM error? Use redis-server --test-memory to veryfy it.\n\n"
+"  Suspect RAM error? Use redis-server --test-memory to verify it.\n\n"
 );
     /* free(messages); Don't call free() with possibly corrupted memory. */
     if (server.daemonize) unlink(server.pidfile);


### PR DESCRIPTION
cc @antirez 

Small fix, and hopefully no one has to see this debug message anyway.
