### PR TITLE
Added BITPOS command to return offsets of set bits in a key.

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -410,3 +410,91 @@ void bitcountCommand(redisClient *c) {
         addReplyLongLong(c,redisPopcount(p+start,bytes));
     }
 }
+
+/* BITPOS key [start end limit] */
+void bitposCommand(redisClient *c) {
+    robj *o;
+    long start, end, limit = -1, strlen;
+    void *replylen = NULL;
+    unsigned char *p, byte;
+    char llbuf[32];
+    unsigned long bytecount = 0;
+    unsigned long bitcount = 0;
+
+    /* Lookup, check for type, and return 0 for non existing keys. */
+    if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.emptymultibulk)) == NULL ||
+        checkType(c,o,REDIS_STRING)) return;
+
+    /* Set the 'p' pointer to the string, that can be just a stack allocated
+     * array if our string was integer encoded. */
+    if (o->encoding == REDIS_ENCODING_INT) {
+        p = (unsigned char*) llbuf;
+        strlen = ll2string(llbuf,sizeof(llbuf),(long)o->ptr);
+    } else {
+        p = (unsigned char*) o->ptr;
+        strlen = sdslen(o->ptr);
+    }
+
+    /* Parse start/end range if any. */
+    if (c->argc == 5) {
+        if (getLongFromObjectOrReply(c,c->argv[4],&limit,NULL) != REDIS_OK)
+            return;
+    }
+    if (c->argc >= 4) {
+        if (getLongFromObjectOrReply(c,c->argv[2],&start,NULL) != REDIS_OK)
+            return;
+        if (getLongFromObjectOrReply(c,c->argv[3],&end,NULL) != REDIS_OK)
+            return;
+    } else if (c->argc == 3) {
+        if (getLongFromObjectOrReply(c,c->argv[2],&start,NULL) != REDIS_OK)
+            return;
+        end = strlen-1;
+    } else if (c->argc == 2) {
+        /* The whole string. */
+        start = 0;
+        end = strlen-1;
+    } else {
+        /* Syntax error. */
+        addReply(c,shared.syntaxerr);
+        return;
+    }
+
+    /* Convert negative indexes */
+    if (start < 0) start = strlen+start;
+    if (end < 0) end = strlen+end;
+    if (start < 0) start = 0;
+    if (end < 0) end = 0;
+    if (end >= strlen) end = strlen-1;
+
+    /* Precondition: end >= 0 && end < strlen, so the only condition where
+     * zero can be returned is: start > end. */
+    if (start > end) {
+        addReply(c,shared.emptymultibulk);
+        return;
+    }
+
+    p = (p + start);
+    bytecount = (end - start + 1);
+    replylen = addDeferredMultiBulkLength(c);
+
+    /* iterate over bytes */
+    while (bytecount--) {
+        unsigned int i = 128, pos = 0;
+        byte = *p++;
+        while (byte && limit) {
+            if (byte & i) {
+                addReplyBulkLongLong(c, (start * 8 + pos));
+                byte &= ~(1 << (7 - pos));
+                ++bitcount;
+                --limit;
+                limit = (((-1) > (limit)) ? (-1) : (limit));
+            }
+            i >>= 1;
+            pos++;
+        }
+        start++;
+    }
+
+    setDeferredMultiBulkLength(c, replylen, bitcount);
+}
+

--- a/src/redis.c
+++ b/src/redis.c
@@ -258,7 +258,8 @@ struct redisCommand redisCommandTable[] = {
     {"script",scriptCommand,-2,"ras",0,NULL,0,0,0,0,0},
     {"time",timeCommand,1,"rR",0,NULL,0,0,0,0,0},
     {"bitop",bitopCommand,-4,"wm",0,NULL,2,-1,1,0,0},
-    {"bitcount",bitcountCommand,-2,"r",0,NULL,1,1,1,0,0}
+    {"bitcount",bitcountCommand,-2,"r",0,NULL,1,1,1,0,0},
+    {"bitpos",bitposCommand,-2,"r",0,NULL,1,1,1,0,0}
 };
 
 /*============================ Utility functions ============================ */

--- a/src/redis.h
+++ b/src/redis.h
@@ -1520,6 +1520,7 @@ void scriptCommand(redisClient *c);
 void timeCommand(redisClient *c);
 void bitopCommand(redisClient *c);
 void bitcountCommand(redisClient *c);
+void bitposCommand(redisClient *c);
 void replconfCommand(redisClient *c);
 
 #if defined(__GNUC__)


### PR DESCRIPTION
This pull request adds a command, BITPOS key [start] [end] [limit], which returns a bulk reply containing the offsets of set bits in the given key.
