### PR TITLE
Fix keytable size calculation.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -239,6 +239,7 @@ int clusterSaveConfig(int do_fsync) {
     return 0;
 
 err:
+    close(fd);
     sdsfree(ci);
     return -1;
 }

--- a/src/db.c
+++ b/src/db.c
@@ -689,7 +689,7 @@ int *getKeysUsingCommandTable(struct redisCommand *cmd,robj **argv, int argc, in
     }
     last = cmd->lastkey;
     if (last < 0) last = argc+last;
-    keys = zmalloc(sizeof(int)*((last - cmd->firstkey)+1));
+    keys = zmalloc(sizeof(int)*((last - cmd->firstkey)+1) / cmd->keystep);
     for (j = cmd->firstkey; j <= last; j += cmd->keystep) {
         redisAssert(j < argc);
         keys[i++] = j;


### PR DESCRIPTION
The total length should be divided by 'keystep'.
