### PR TITLE
Fix cli prompt for failed select command

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -120,7 +120,7 @@ static void cliRefreshPrompt(void) {
                        strchr(config.hostip,':') ? "[%s]:%d" : "%s:%d",
                        config.hostip, config.hostport);
     /* Add [dbnum] if needed */
-    if (config.dbnum != 0)
+    if (config.dbnum > 0)
         len += snprintf(config.prompt+len,sizeof(config.prompt)-len,"[%d]",
             config.dbnum);
     snprintf(config.prompt+len,sizeof(config.prompt)-len,"> ");


### PR DESCRIPTION
Select command with negative integer as a input makes redis-cli to
refresh its prompt wrongly.

For example:
    [root@anup-centos-6 src]# ./redis-cli
    127.0.0.1:6379> select -1
    (error) ERR invalid DB index
    127.0.0.1:6379[-1]>

The patch fixes this problem.

Signed-off-by: Anup Shendkar anupshendkar@gmail.com
