### PR TITLE
Close all FDs inherited from previous processes when forking to enter daemon mode

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -2872,6 +2872,7 @@ void daemonize(void) {
     if (fork() != 0) exit(0); /* parent exits */
     setsid(); /* create a new session */
 
+    /* Close all File Descriptors inherited from the parent process. */
     for (i = 3; i < sysconf(_SC_OPEN_MAX); i++)
        	close(i);
 

--- a/src/redis.c
+++ b/src/redis.c
@@ -51,6 +51,7 @@
 #include <sys/resource.h>
 #include <sys/utsname.h>
 #include <locale.h>
+#include <unistd.h>
 
 /* Our shared "common" objects */
 
@@ -2866,10 +2867,13 @@ void createPidFile(void) {
 }
 
 void daemonize(void) {
-    int fd;
+    int fd, i;
 
     if (fork() != 0) exit(0); /* parent exits */
     setsid(); /* create a new session */
+
+    for (i = 3; i < sysconf(_SC_OPEN_MAX); i++)
+       	close(i);
 
     /* Every output goes to /dev/null. If Redis is daemonized but
      * the 'logfile' is set to 'stdout' in the configuration file


### PR DESCRIPTION
When redis is started from php/apache it inherits all open file descriptors of apache/php, which creates a problem when stopping apache - the FDs, including connections to apache ports (80, 443,...),  remain in use by redis and apache can't get restarted without stopping redis.
This patch closes all open file descriptors inherited from any process when going into daemon mode.
