### PR TITLE
Added feature to free the "slaves".

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -535,6 +535,7 @@ int clusterNodeAddSlave(clusterNode *master, clusterNode *slave) {
 
 void clusterNodeResetSlaves(clusterNode *n) {
     zfree(n->slaves);
+    n->slaves = NULL;
     n->numslaves = 0;
 }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -332,7 +332,8 @@ void freeClusterLink(clusterLink *link) {
     sdsfree(link->rcvbuf);
     if (link->node)
         link->node->link = NULL;
-    close(link->fd);
+    if (link->fd != -1)
+        close(link->fd);
     zfree(link);
 }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -218,6 +218,7 @@ int clusterLoadConfig(char *filename) {
 
 fmterr:
     redisLog(REDIS_WARNING,"Unrecoverable error: corrupted cluster config file.");
+    zfree(line);
     fclose(fp);
     exit(1);
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -239,6 +239,7 @@ int clusterSaveConfig(int do_fsync) {
     return 0;
 
 err:
+    close(fd);
     sdsfree(ci);
     return -1;
 }


### PR DESCRIPTION
Added feature to free the "slaves".

when called clusterNodeResetSlaves function before call clusterNodeAddSlaves function,
if the "slaves" was free and do not set "NULL", will see error when called zrealloc().
