### PR TITLE
fix minor typos

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -263,7 +263,7 @@ repl-disable-tcp-nodelay no
 #
 # A slave with a low priority number is considered better for promotion, so
 # for instance if there are three slaves with priority 10, 100, 25 Sentinel will
-# pick the one wtih priority 10, that is the lowest.
+# pick the one with priority 10, that is the lowest.
 #
 # However a special priority of 0 marks the slave as not able to perform the
 # role of master, so a slave with priority of 0 will never be selected by
@@ -343,7 +343,7 @@ slave-priority 100
 
 # Don't use more memory than the specified amount of bytes.
 # When the memory limit is reached Redis will try to remove keys
-# accordingly to the eviction policy selected (see maxmemmory-policy).
+# accordingly to the eviction policy selected (see maxmemory-policy).
 #
 # If Redis can't remove keys according to the policy, or if the policy is
 # set to 'noeviction', Redis will start to reply with errors to commands


### PR DESCRIPTION
I spotted two typos in the comments of the redis.conf which I fixed in this commit
