### PR TITLE
Fix Issue #1340

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -594,6 +594,9 @@ int getLongLongFromObject(robj *o, long long *target) {
             if (isspace(((char*)o->ptr)[0]) || eptr[0] != '\0' ||
                 errno == ERANGE)
                 return REDIS_ERR;
+
+            if(eptr != o->ptr + sdslen(o->ptr))
+                return REDIS_ERR;
         } else if (o->encoding == REDIS_ENCODING_INT) {
             value = (long)o->ptr;
         } else {

--- a/src/object.c
+++ b/src/object.c
@@ -589,12 +589,13 @@ int getLongLongFromObject(robj *o, long long *target) {
     } else {
         redisAssertWithInfo(NULL,o,o->type == REDIS_STRING);
         if (sdsEncodedObject(o)) {
+            if(sdslen(o->ptr) == 0)
+                return REDIS_ERR;
             errno = 0;
             value = strtoll(o->ptr, &eptr, 10);
             if (isspace(((char*)o->ptr)[0]) || eptr[0] != '\0' ||
                 errno == ERANGE)
                 return REDIS_ERR;
-
             if(eptr != o->ptr + sdslen(o->ptr))
                 return REDIS_ERR;
         } else if (o->encoding == REDIS_ENCODING_INT) {

--- a/src/sds.c
+++ b/src/sds.c
@@ -43,7 +43,7 @@
  * The string is always null-termined (all the sds strings are, always) so
  * even if you create an sds string with:
  *
- * mystring = sdsnewlen("abc",3");
+ * mystring = sdsnewlen("abc",3);
  *
  * You can print the string with printf() as there is an implicit \0 at the
  * end of the string. However the string is binary safe and can contain


### PR DESCRIPTION
In short:

Check that all bytes are consumed out of the string by `stroll`.

Check that the empty string is not passed to `stroll`, just fail instead.

If you require any additional code formatting changes or tests to be written to accept this change, please let me know.
