### PR TITLE
Redis fixes 28102013

### DIFF
--- a/deps/hiredis/sds.h
+++ b/deps/hiredis/sds.h
@@ -57,10 +57,8 @@ static inline size_t sdsavail(const sds s) {
 sds sdsnewlen(const void *init, size_t initlen);
 sds sdsnew(const char *init);
 sds sdsempty(void);
-size_t sdslen(const sds s);
 sds sdsdup(const sds s);
 void sdsfree(sds s);
-size_t sdsavail(const sds s);
 sds sdsgrowzero(sds s, size_t len);
 sds sdscatlen(sds s, const void *t, size_t len);
 sds sdscat(sds s, const char *t);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -68,7 +68,7 @@ void clusterDoBeforeSleep(int flags);
  * (which is not saved on permanent storage) to the greatest configEpoch found
  * in the loaded nodes (configEpoch is stored on permanent storage as soon as
  * it changes for some node). */
-void clusterSetStartupEpoch() {
+static void clusterSetStartupEpoch(void) {
     dictIterator *di;
     dictEntry *de;
 

--- a/src/config.c
+++ b/src/config.c
@@ -73,7 +73,7 @@ void appendServerSaveParams(time_t seconds, int changes) {
     server.saveparamslen++;
 }
 
-void resetServerSaveParams() {
+void resetServerSaveParams(void) {
     zfree(server.saveparams);
     server.saveparams = NULL;
     server.saveparamslen = 0;

--- a/src/db.c
+++ b/src/db.c
@@ -170,7 +170,7 @@ int dbDelete(redisDb *db, robj *key) {
     }
 }
 
-long long emptyDb() {
+long long emptyDb(void) {
     int j;
     long long removed = 0;
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -751,7 +751,6 @@ unsigned long dictScan(dict *d,
 {
     dictht *t0, *t1;
     const dictEntry *de;
-    unsigned long s0, s1;
     unsigned long m0, m1;
 
     if (!dictIsRehashing(d)) {
@@ -775,8 +774,6 @@ unsigned long dictScan(dict *d,
             t1 = &d->ht[0];
         }
 
-        s0 = t0->size;
-        s1 = t1->size;
         m0 = t0->sizemask;
         m1 = t1->sizemask;
 

--- a/src/rand.c
+++ b/src/rand.c
@@ -43,6 +43,8 @@
 
 #include <stdint.h>
 
+#include "rand.h"
+
 #define N	16
 #define MASK	((1 << (N - 1)) + (1 << (N - 1)) - 1)
 #define LOW(x)	((unsigned)(x) & MASK)

--- a/src/rand.c
+++ b/src/rand.c
@@ -66,9 +66,9 @@
 #define HI_BIT	(1L << (2 * N - 1))
 
 static uint32_t x[3] = { X0, X1, X2 }, a[3] = { A0, A1, A2 }, c = C;
-static void next();
+static void next(void);
 
-int32_t redisLrand48() {
+int32_t redisLrand48(void) {
     next();
     return (((int32_t)x[2] << (N - 1)) + (x[1] >> 1));
 }
@@ -77,7 +77,7 @@ void redisSrand48(int32_t seedval) {
     SEED(X0, LOW(seedval), HIGH(seedval));
 }
 
-static void next() {
+static void next(void) {
     uint32_t p[2], q[2], r[2], carry0, carry1;
 
     MUL(a[0], x[0], p);

--- a/src/rand.h
+++ b/src/rand.h
@@ -30,7 +30,7 @@
 #ifndef REDIS_RANDOM_H
 #define REDIS_RANDOM_H
 
-int32_t redisLrand48();
+int32_t redisLrand48(void);
 void redisSrand48(int32_t seedval);
 
 #define REDIS_LRAND48_MAX INT32_MAX

--- a/src/redis-check-dump.c
+++ b/src/redis-check-dump.c
@@ -166,7 +166,7 @@ int readBytes(void *target, long num) {
     return 1;
 }
 
-int processHeader() {
+static int processHeader(void) {
     char buf[10] = "_________";
     int dump_version;
 
@@ -206,7 +206,7 @@ int loadType(entry *e) {
     return 0;
 }
 
-int peekType() {
+static int peekType(void) {
     unsigned char t;
     if (readBytes(&t, -1) && (checkType(t)))
         return t;
@@ -287,7 +287,7 @@ char *loadIntegerObject(int enctype) {
     return buf;
 }
 
-char* loadLzfStringObject() {
+static char* loadLzfStringObject(void) {
     unsigned int slen, clen;
     char *c, *s;
 
@@ -311,7 +311,7 @@ char* loadLzfStringObject() {
 }
 
 /* returns NULL when not processable, char* when valid */
-char* loadStringObject() {
+static char* loadStringObject(void) {
     uint32_t offset = CURR_OFFSET;
     int isencoded;
     uint32_t len;
@@ -360,7 +360,7 @@ int processStringObject(char** store) {
     return 1;
 }
 
-double* loadDoubleValue() {
+static double* loadDoubleValue(void) {
     char buf[256];
     unsigned char len;
     double* val;
@@ -483,7 +483,7 @@ int loadPair(entry *e) {
     return 1;
 }
 
-entry loadEntry() {
+static entry loadEntry(void) {
     entry e = { NULL, -1, 0 };
     uint32_t length, offset[4];
 
@@ -600,7 +600,7 @@ void printErrorStack(entry *e) {
     }
 }
 
-void process() {
+static void process(void) {
     uint64_t num_errors = 0, num_valid_ops = 0, num_valid_bytes = 0;
     entry entry;
     int dump_version = processHeader();

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -91,7 +91,7 @@ static struct config {
     char *eval;
 } config;
 
-static void usage();
+static void usage(void);
 char *redisGitSHA1(void);
 char *redisGitDirty(void);
 
@@ -146,7 +146,7 @@ typedef struct {
 static helpEntry *helpEntries;
 static int helpEntriesLen;
 
-static sds cliVersion() {
+static sds cliVersion(void) {
     sds version;
     version = sdscatprintf(sdsempty(), "%s", REDIS_VERSION);
 
@@ -160,7 +160,7 @@ static sds cliVersion() {
     return version;
 }
 
-static void cliInitHelp() {
+static void cliInitHelp(void) {
     int commandslen = sizeof(commandHelp)/sizeof(struct commandHelp);
     int groupslen = sizeof(commandGroups)/sizeof(char*);
     int i, len, pos = 0;
@@ -199,7 +199,7 @@ static void cliOutputCommandHelp(struct commandHelp *help, int group) {
 }
 
 /* Print generic help. */
-static void cliOutputGenericHelp() {
+static void cliOutputGenericHelp(void) {
     sds version = cliVersion();
     printf(
         "redis-cli %s\r\n"
@@ -290,7 +290,7 @@ static void completionCallback(const char *buf, linenoiseCompletions *lc) {
  *--------------------------------------------------------------------------- */
 
 /* Send AUTH command to the server */
-static int cliAuth() {
+static int cliAuth(void) {
     redisReply *reply;
     if (config.auth == NULL) return REDIS_OK;
 
@@ -303,7 +303,7 @@ static int cliAuth() {
 }
 
 /* Send SELECT dbnum to the server */
-static int cliSelect() {
+static int cliSelect(void) {
     redisReply *reply;
     if (config.dbnum == 0) return REDIS_OK;
 
@@ -354,7 +354,7 @@ static int cliConnect(int force) {
     return REDIS_OK;
 }
 
-static void cliPrintContextError() {
+static void cliPrintContextError(void) {
     if (context == NULL) return;
     fprintf(stderr,"Error: %s\n",context->errstr);
 }
@@ -765,7 +765,7 @@ static sds readArgFromStdin(void) {
     return arg;
 }
 
-static void usage() {
+static void usage(void) {
     sds version = cliVersion();
     fprintf(stderr,
 "redis-cli %s\n"
@@ -827,7 +827,7 @@ static char **convertToSds(int count, char** args) {
 }
 
 #define LINE_BUFLEN 4096
-static void repl() {
+static void repl(void) {
     sds historyfile = NULL;
     int history = 0;
     char *line;
@@ -1412,7 +1412,7 @@ void bytesToHuman(char *s, long long n) {
     }
 }
 
-static void statMode() {
+static void statMode(void) {
     redisReply *reply;
     long aux, requests = 0;
     int i = 0;

--- a/src/redis.c
+++ b/src/redis.c
@@ -1293,7 +1293,7 @@ void createSharedObjects(void) {
     }
 }
 
-void initServerConfig() {
+static void initServerConfig(void) {
     int j;
 
     getRandomHexChars(server.runid,REDIS_RUN_ID_SIZE);
@@ -1536,7 +1536,7 @@ int listenToPort(int port, int *fds, int *count) {
     return REDIS_OK;
 }
 
-void initServer() {
+static void initServer(void) {
     int j;
 
     signal(SIGHUP, SIG_IGN);
@@ -2883,7 +2883,7 @@ void daemonize(void) {
     }
 }
 
-void version() {
+static void version(void) {
     printf("Redis server v=%s sha=%s:%d malloc=%s bits=%d build=%llx\n",
         REDIS_VERSION,
         redisGitSHA1(),
@@ -2894,7 +2894,7 @@ void version() {
     exit(0);
 }
 
-void usage() {
+void usage(void) {
     fprintf(stderr,"Usage: ./redis-server [/path/to/redis.conf] [options]\n");
     fprintf(stderr,"       ./redis-server - (read config from stdin)\n");
     fprintf(stderr,"       ./redis-server -v or --version\n");

--- a/src/redis.h
+++ b/src/redis.h
@@ -1102,7 +1102,7 @@ void call(redisClient *c, int flags);
 void propagate(struct redisCommand *cmd, int dbid, robj **argv, int argc, int flags);
 void alsoPropagate(struct redisCommand *cmd, int dbid, robj **argv, int argc, int target);
 void forceCommandPropagation(redisClient *c, int flags);
-int prepareForShutdown();
+int prepareForShutdown(int flags);
 #ifdef __GNUC__
 void redisLog(int level, const char *fmt, ...)
     __attribute__((format(printf, 2, 3)));

--- a/src/redis.h
+++ b/src/redis.h
@@ -1111,7 +1111,7 @@ void redisLog(int level, const char *fmt, ...);
 #endif
 void redisLogRaw(int level, const char *msg);
 void redisLogFromHandler(int level, const char *msg);
-void usage();
+void usage(void);
 void updateDictResizePolicy(void);
 int htNeedsResize(dict *dict);
 void oom(const char *msg);
@@ -1168,7 +1168,7 @@ sds keyspaceEventsFlagsToString(int flags);
 /* Configuration */
 void loadServerConfig(char *filename, char *options);
 void appendServerSaveParams(time_t seconds, int changes);
-void resetServerSaveParams();
+void resetServerSaveParams(void);
 
 /* db.c -- Keyspace access API */
 int removeExpire(redisDb *db, robj *key);
@@ -1187,7 +1187,7 @@ void setKey(redisDb *db, robj *key, robj *val);
 int dbExists(redisDb *db, robj *key);
 robj *dbRandomKey(redisDb *db);
 int dbDelete(redisDb *db, robj *key);
-long long emptyDb();
+long long emptyDb(void);
 int selectDb(redisClient *c, int id);
 void signalModifiedKey(redisDb *db, robj *key);
 void signalFlushedDb(int dbid);


### PR DESCRIPTION
Hi Antirez,

The following is a set of patches to fix and enforce function prototypes, there is also a patch to remove dead code from src/dict.c:dictScan() . You will find the diff stat below.

I've made these changes since I'm using redis in an internal project, and I'm enforcing some CFLAGS. These changes will also improve the code quality of redis.

Thanks for redis!

diff stat against my branch redis-fixes-28102013

git diff --stat origin/unstable..redis-fixes-28102013 
 deps/hiredis/sds.h     |  2 --
 src/cluster.c          |  2 +-
 src/config.c           |  2 +-
 src/db.c               |  2 +-
 src/dict.c             |  3 ---
 src/rand.c             |  8 +++++---
 src/rand.h             |  2 +-
 src/redis-check-dump.c | 14 +++++++-------
 src/redis-cli.c        | 20 ++++++++++----------
 src/redis.c            |  8 ++++----
 src/redis.h            |  8 ++++----
 11 files changed, 34 insertions(+), 37 deletions(-)
