### PR TITLE
Implements SETNXEX

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -121,6 +121,7 @@ struct redisCommand redisCommandTable[] = {
     {"set",setCommand,-3,"wm",0,noPreloadGetKeys,1,1,1,0,0},
     {"setnx",setnxCommand,3,"wm",0,noPreloadGetKeys,1,1,1,0,0},
     {"setex",setexCommand,4,"wm",0,noPreloadGetKeys,1,1,1,0,0},
+    {"setnxex",setnxexCommand,4,"wm",0,noPreloadGetKeys,1,1,1,0,0},
     {"psetex",psetexCommand,4,"wm",0,noPreloadGetKeys,1,1,1,0,0},
     {"append",appendCommand,3,"wm",0,NULL,1,1,1,0,0},
     {"strlen",strlenCommand,2,"r",0,NULL,1,1,1,0,0},

--- a/src/redis.h
+++ b/src/redis.h
@@ -1235,6 +1235,7 @@ void echoCommand(redisClient *c);
 void setCommand(redisClient *c);
 void setnxCommand(redisClient *c);
 void setexCommand(redisClient *c);
+void setnxexCommand(redisClient *c);
 void psetexCommand(redisClient *c);
 void getCommand(redisClient *c);
 void delCommand(redisClient *c);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -137,6 +137,11 @@ void setexCommand(redisClient *c) {
     setGenericCommand(c,REDIS_SET_NO_FLAGS,c->argv[1],c->argv[3],c->argv[2],UNIT_SECONDS,NULL,NULL);
 }
 
+void setnxexCommand(redisClient *c) {
+    c->argv[3] = tryObjectEncoding(c->argv[3]);
+    setGenericCommand(c,REDIS_SET_NX,c->argv[1],c->argv[3],c->argv[2],UNIT_SECONDS,shared.cone,shared.czero);
+}
+
 void psetexCommand(redisClient *c) {
     c->argv[3] = tryObjectEncoding(c->argv[3]);
     setGenericCommand(c,REDIS_SET_NO_FLAGS,c->argv[1],c->argv[3],c->argv[2],UNIT_MILLISECONDS,NULL,NULL);

--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -261,6 +261,21 @@ start_server {tags {"basic"}} {
         assert_equal 20 [r get x]
     }
 
+    test "SETNXEX target key missing" {
+	r del novar
+	assert_equal 1 [r setnxex novar 100 foobared]
+	assert_equal "foobared" [r get novar]
+	assert {[r ttl novar] > 95 && [r ttl novar] <= 100}
+    }
+
+    test "SETNXEX target key exists" {
+	r del novar
+	r setnxex novar 20 foobared
+	after 10000
+	assert_equal 0 [r setnxex novar 100 foobared]
+	assert {[r ttl novar] > 0 && [r ttl novar] <= 11}
+    }
+
     test {EXISTS} {
         set res {}
         r set newkey test
@@ -292,7 +307,7 @@ start_server {tags {"basic"}} {
         catch {r foobaredcommand} err
         string match ERR* $err
     } {1}
-    
+
     test {RENAME basic usage} {
         r set mykey hello
         r rename mykey mykey1


### PR DESCRIPTION
This commit introduces the SETNXEX command. Since SETNX is typically
used as a lock, it is nice to be able to specify the expiry of the lock
at the time of creation. The key and ttl should not be reset if the key
exists.

Signed-off-by: Aaron Bedra aaron@aaronbedra.com
