### PR TITLE
Add repl-sync-eval-as-multi option

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -257,6 +257,13 @@ repl-disable-tcp-nodelay no
 #
 # repl-backlog-ttl 3600
 
+# Sometimes scripts are large and make a lot of reads but produce very few writes.
+# In such case it is a lot better to replicate only commands executed by script
+# instead of replicating script itself. Commands are wrapped into multi/exec
+# so they provide same atomicity guarantees as lua scripting.
+#
+# repl-sync-eval-as-multi no
+
 # The slave priority is an integer number published by Redis in the INFO output.
 # It is used by Redis Sentinel in order to select a slave to promote into a
 # master if the master is no longer working correctly.

--- a/src/config.c
+++ b/src/config.c
@@ -276,6 +276,10 @@ void loadServerConfigFromString(char *config) {
                 err = "repl-backlog-ttl can't be negative ";
                 goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"repl-sync-eval-as-multi") && argc == 2) {
+            if ((server.repl_sync_eval_as_multi = yesnotoi(argv[1])) == -1) {
+                err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
         } else if (!strcasecmp(argv[0],"masterauth") && argc == 2) {
         	server.masterauth = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"slave-serve-stale-data") && argc == 2) {
@@ -831,6 +835,11 @@ void configSetCommand(redisClient *c) {
     } else if (!strcasecmp(c->argv[2]->ptr,"repl-backlog-ttl")) {
         if (getLongLongFromObject(o,&ll) == REDIS_ERR || ll < 0) goto badfmt;
         server.repl_backlog_time_limit = ll;
+    } else if (!strcasecmp(c->argv[2]->ptr,"repl-sync-eval-as-multi")) {
+        int yn = yesnotoi(o->ptr);
+
+        if (yn == -1) goto badfmt;
+        server.repl_sync_eval_as_multi = yn;
     } else if (!strcasecmp(c->argv[2]->ptr,"watchdog-period")) {
         if (getLongLongFromObject(o,&ll) == REDIS_ERR || ll < 0) goto badfmt;
         if (ll)
@@ -963,6 +972,7 @@ void configGetCommand(redisClient *c) {
     config_get_numerical_field("repl-timeout",server.repl_timeout);
     config_get_numerical_field("repl-backlog-size",server.repl_backlog_size);
     config_get_numerical_field("repl-backlog-ttl",server.repl_backlog_time_limit);
+    config_get_bool_field("repl-sync-eval-as-multi", server.repl_sync_eval_as_multi);
     config_get_numerical_field("maxclients",server.maxclients);
     config_get_numerical_field("watchdog-period",server.watchdog_period);
     config_get_numerical_field("slave-priority",server.slave_priority);
@@ -1694,6 +1704,7 @@ int rewriteConfig(char *path) {
     rewriteConfigNumericalOption(state,"repl-timeout",server.repl_timeout,REDIS_REPL_TIMEOUT);
     rewriteConfigBytesOption(state,"repl-backlog-size",server.repl_backlog_size,REDIS_DEFAULT_REPL_BACKLOG_SIZE);
     rewriteConfigBytesOption(state,"repl-backlog-ttl",server.repl_backlog_time_limit,REDIS_DEFAULT_REPL_BACKLOG_TIME_LIMIT);
+    rewriteConfigYesNoOption(state,"repl-sync-eval-as-multi",server.repl_sync_eval_as_multi,0);
     rewriteConfigYesNoOption(state,"repl-disable-tcp-nodelay",server.repl_disable_tcp_nodelay,REDIS_DEFAULT_REPL_DISABLE_TCP_NODELAY);
     rewriteConfigNumericalOption(state,"slave-priority",server.slave_priority,REDIS_DEFAULT_SLAVE_PRIORITY);
     rewriteConfigStringOption(state,"requirepass",server.requirepass,NULL);

--- a/src/redis.h
+++ b/src/redis.h
@@ -159,6 +159,7 @@
 #define REDIS_CMD_STALE 1024                /* "t" flag */
 #define REDIS_CMD_SKIP_MONITOR 2048         /* "M" flag */
 #define REDIS_CMD_ASKING 4096               /* "k" flag */
+#define REDIS_CMD_EVAL 8192                 /* "e" flag */
 
 /* Object types */
 #define REDIS_STRING 0
@@ -709,6 +710,7 @@ struct redisServer {
     int repl_min_slaves_to_write;   /* Min number of slaves to write. */
     int repl_min_slaves_max_lag;    /* Max lag of <count> slaves to write. */
     int repl_good_slaves_count;     /* Number of slaves with lag <= max_lag. */
+    int repl_sync_eval_as_multi;    /* Instead of EVAL replicate MULTI/EXEC */
     /* Replication (slave) */
     char *masterauth;               /* AUTH with this password with master */
     char *masterhost;               /* Hostname of master */


### PR DESCRIPTION
Sometimes it is better to replicate command executed by script intead of script itself.
Setting repl-sync-eval-as-multi to "yes" will replace all script commands with
multi/exec block containing all write commands executed by script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/antirez/redis/1353)
<!-- Reviewable:end -->
