### PR TITLE
remove unused condition

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -497,7 +497,7 @@ void scanGenericCommand(redisClient *c, robj *o, unsigned long cursor) {
         int filter = 0;
 
         /* Filter element if it does not match the pattern. */
-        if (!filter && use_pattern) {
+        if (use_pattern) {
             if (sdsEncodedObject(kobj)) {
                 if (!stringmatchlen(pat, patlen, kobj->ptr, sdslen(kobj->ptr), 0))
                     filter = 1;


### PR DESCRIPTION
There is no need to check "filter" first time.
because filter is always 0.

so !filter is always 1 in first if statement.
