### PR TITLE
allowing-sort-readonly

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -232,7 +232,7 @@ struct redisCommand redisCommandTable[] = {
     {"replconf",replconfCommand,-1,"arslt",0,NULL,0,0,0,0,0},
     {"flushdb",flushdbCommand,1,"w",0,NULL,0,0,0,0,0},
     {"flushall",flushallCommand,1,"w",0,NULL,0,0,0,0,0},
-    {"sort",sortCommand,-2,"wm",0,NULL,1,1,1,0,0},
+    {"sort",sortCommand,-2,"m",0,NULL,1,1,1,0,0},
     {"info",infoCommand,-1,"rlt",0,NULL,0,0,0,0,0},
     {"monitor",monitorCommand,1,"ars",0,NULL,0,0,0,0,0},
     {"ttl",ttlCommand,2,"r",0,NULL,1,1,1,0,0},

--- a/src/sort.c
+++ b/src/sort.c
@@ -257,6 +257,16 @@ void sortCommand(redisClient *c) {
         j++;
     }
 
+    /* Deny writing in read only slave */
+    if (server.masterhost && server.repl_slave_ro &&
+            !(c->flags & REDIS_MASTER) && storekey)
+    {
+        decrRefCount(sortval);
+        listRelease(operations);
+        addReply(c, shared.roslaveerr);
+        return;
+    }
+
     /* For the STORE option, or when SORT is called from a Lua script,
      * we want to force a specific ordering even when no explicit ordering
      * was asked (SORT BY nosort). This guarantees that replication / AOF


### PR DESCRIPTION
Allowing sort command in read-only-slave(sorry. some of my mistake. I broke my former branch. so I recreate.)

1] removing "w" attribute from sort Command
2] and prohibit writing with store option in sortCommand when it is read only slave.

but. I might think this is not a good approach. because it is weak that someone add new option to new option.

so. how about add some other command only to store it's result to list.(ex. sortAndStore)

``` c
127.0.0.1:6380> sort key desc
1) "20"
2) "10"
3) "5"
4) "4"
5) "3"
6) "2"
7) "1"
127.0.0.1:6380> sort key desc store k
(error) READONLY You can't write against a read only slave.
127.0.0.1:6380> 
```
