### PR TITLE
show_slave_info_with_log

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -411,6 +411,9 @@ need_full_resync:
 
 /* SYNC ad PSYNC command implemenation. */
 void syncCommand(redisClient *c) {
+    char ip[REDIS_IP_STR_LEN];
+    int port;
+
     /* ignore SYNC if already slave or in monitor mode */
     if (c->flags & REDIS_SLAVE) return;
 
@@ -430,7 +433,14 @@ void syncCommand(redisClient *c) {
         return;
     }
 
-    redisLog(REDIS_NOTICE,"Slave asks for synchronization");
+                
+    if (anetPeerToString(c->fd,ip,sizeof(ip),&port) == -1) {
+        redisLog(REDIS_NOTICE,"Slave asks for synchronization");
+    } else {
+        redisLog(REDIS_NOTICE,"Slave(%s:%d) asks for synchronization",
+                 ip, c->slave_listening_port);
+    }
+
 
     /* Try a partial resynchronization if this is a PSYNC command.
      * If it fails, we continue with usual full resynchronization, however


### PR DESCRIPTION
Show slave info in master log.

before 

``` c
[3878] 16 Nov 19:06:18.900 * Slave asks for synchronization
```

after

``` c
[3878] 16 Nov 19:06:18.900 * Slave(127.0.0.1:6380) asks for synchronization
```
