### PR TITLE
fix typo in redis.h

### DIFF
--- a/src/redis.h
+++ b/src/redis.h
@@ -445,7 +445,7 @@ typedef struct readyList {
 } readyList;
 
 /* With multiplexing we need to take per-client state.
- * Clients are taken in a liked list. */
+ * Clients are taken in a linked list. */
 typedef struct redisClient {
     int fd;
     redisDb *db;


### PR DESCRIPTION
Fixed a tiny typo in the comments of redis.h.

@jbergstroem, I don't know how to remove the unintentional redis.conf in the original PR, so I removed that PR and  started this one.
