### PR TITLE
fix a bug in sentinel.c about pub/sub link

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1607,9 +1607,8 @@ void sentinelReconnectInstance(sentinelRedisInstance *ri) {
         }
     }
     /* Clear the DISCONNECTED flags only if we have both the connections
-     * (or just the commands connection if this is a slave or a
-     * sentinel instance). */
-    if (ri->cc && (ri->flags & (SRI_SLAVE|SRI_SENTINEL) || ri->pc))
+     * (or just the commands connection if this is a sentinel instance). */
+    if (ri->cc && (ri->flags & SRI_SENTINEL || ri->pc))
         ri->flags &= ~SRI_DISCONNECTED;
 }
 


### PR DESCRIPTION
New sentinel will create pub/sub link (`ri->pc`) for both master instance and slave instance, so we should check pub/sub link for both master instance and slave instance, not just master instance (which old sentinel does).

All testes passed after fix.
