### PR TITLE
Fixed description in sentinel.conf

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -6,7 +6,7 @@ port 26379
 
 # sentinel monitor <master-name> <ip> <redis-port> <quorum>
 #
-# Tells Sentinel to monitor this slave, and to consider it in O_DOWN
+# Tells Sentinel to monitor this master, and to consider it in O_DOWN
 # (Objectively Down) state only if at least <quorum> sentinels agree.
 #
 # Note that whatever is the ODOWN quorum, a Sentinel will require to


### PR DESCRIPTION
This line is described as mentioning a slave, when it's actually describing a
master
