### PR TITLE
fix typo in redis.conf and sentinel.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -658,7 +658,7 @@ activerehashing yes
 #
 # normal -> normal clients
 # slave  -> slave clients and MONITOR clients
-# pubsub -> clients subcribed to at least one pubsub channel or pattern
+# pubsub -> clients subscribed to at least one pubsub channel or pattern
 #
 # The syntax of every client-output-buffer-limit directive is the following:
 #

--- a/sentinel.conf
+++ b/sentinel.conf
@@ -6,7 +6,7 @@ port 26379
 
 # sentinel monitor <master-name> <ip> <redis-port> <quorum>
 #
-# Tells Sentinel to monitor this slave, and to consider it in O_DOWN
+# Tells Sentinel to monitor this master, and to consider it in O_DOWN
 # (Objectively Down) state only if at least <quorum> sentinels agree.
 #
 # Note that whatever is the ODOWN quorum, a Sentinel will require to
@@ -63,7 +63,7 @@ sentinel parallel-syncs mymaster 1
 #   times the failover timeout.
 #
 # - The time needed for a slave replicating to a wrong master according
-#   to a Sentinel currnet configuration, to be forced to replicate
+#   to a Sentinel current configuration, to be forced to replicate
 #   with the right master, is exactly the failover timeout (counting since
 #   the moment a Sentinel detected the misconfiguration).
 #
@@ -102,7 +102,7 @@ sentinel failover-timeout mymaster 180000
 #
 # sentinel notification-script <master-name> <script-path>
 # 
-# Call the specified notification script for any sentienl event that is
+# Call the specified notification script for any sentinel event that is
 # generated in the WARNING level (for instance -sdown, -odown, and so forth).
 # This script should notify the system administrator via email, SMS, or any
 # other messaging system, that there is something wrong with the monitored


### PR DESCRIPTION
checked with aspell, also reviewed all related pull requests in antirez/redis about redis.conf and sentinel.conf,  this pull request covers all of them.
