### PR TITLE
fixed redis-cli security issue with world readable history file

### DIFF
--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -94,6 +94,7 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "linenoise.h"
 
@@ -596,6 +597,8 @@ int linenoiseHistorySave(char *filename) {
     int j;
     
     if (fp == NULL) return -1;
+    chmod(filename, S_IRUSR|S_IWUSR);
+    
     for (j = 0; j < history_len; j++)
         fprintf(fp,"%s\n",history[j]);
     fclose(fp);
@@ -612,7 +615,7 @@ int linenoiseHistoryLoad(char *filename) {
     char buf[LINENOISE_MAX_LINE];
     
     if (fp == NULL) return -1;
-
+    
     while (fgets(buf,LINENOISE_MAX_LINE,fp) != NULL) {
         char *p;
         


### PR DESCRIPTION
the redis-cli history file (in linenoise) is created with the default OS umask value which makes it world readable in most systems and could potentially expose authentication credentials to other users.

PS: I think AUTH commands shouldn't be logged in the history file at all
