### PR TITLE
Grammar and typo fixes in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -241,7 +241,7 @@ repl-disable-tcp-nodelay no
 # resync is enough, just passing the portion of data the slave missed while
 # disconnected.
 #
-# The biggest the replication backlog, the longer the time the slave can be
+# The bigger the replication backlog, the longer the time the slave can be
 # disconnected and later be able to perform a partial resynchronization.
 #
 # The backlog is only allocated once there is at least a slave connected.
@@ -280,7 +280,7 @@ slave-priority 100
 # The lag in seconds, that must be <= the specified value, is calculated from
 # the last ping received from the slave, that is usually sent every second.
 #
-# This option does not GUARANTEES that N replicas will accept the write, but
+# This option does not GUARANTEE that N replicas will accept the write, but
 # will limit the window of exposure for lost writes in case not enough slaves
 # are available, to the specified number of seconds.
 #
@@ -343,7 +343,7 @@ slave-priority 100
 
 # Don't use more memory than the specified amount of bytes.
 # When the memory limit is reached Redis will try to remove keys
-# accordingly to the eviction policy selected (see maxmemmory-policy).
+# according to the eviction policy selected (see maxmemory-policy).
 #
 # If Redis can't remove keys according to the policy, or if the policy is
 # set to 'noeviction', Redis will start to reply with errors to commands
@@ -370,14 +370,14 @@ slave-priority 100
 # is reached. You can select among five behaviors:
 # 
 # volatile-lru -> remove the key with an expire set using an LRU algorithm
-# allkeys-lru -> remove any key accordingly to the LRU algorithm
+# allkeys-lru -> remove any key according to the LRU algorithm
 # volatile-random -> remove a random key with an expire set
 # allkeys-random -> remove a random key, any key
 # volatile-ttl -> remove the key with the nearest expire time (minor TTL)
 # noeviction -> don't expire at all, just return an error on write operations
 # 
 # Note: with any of the above policies, Redis will return an error on write
-#       operations, when there are not suitable keys for eviction.
+#       operations, when there are no suitable keys for eviction.
 #
 #       At the date of writing this commands are: set setnx setex append
 #       incr decr rpush lpush rpushx lpushx linsert lset rpoplpush sadd
@@ -423,13 +423,13 @@ appendonly no
 # appendfilename appendonly.aof
 
 # The fsync() call tells the Operating System to actually write data on disk
-# instead to wait for more data in the output buffer. Some OS will really flush 
+# instead of waiting for more data in the output buffer. Some OS will really flush 
 # data on disk, some other OS will just try to do it ASAP.
 #
 # Redis supports three different modes:
 #
 # no: don't fsync, just let the OS flush the data when it wants. Faster.
-# always: fsync after every write to the append only log . Slow, Safest.
+# always: fsync after every write to the append only log. Slow, Safest.
 # everysec: fsync only one time every second. Compromise.
 #
 # The default is "everysec", as that's usually the right compromise between
@@ -497,11 +497,11 @@ auto-aof-rewrite-min-size 64mb
 # still in execution after the maximum allowed time and will start to
 # reply to queries with an error.
 #
-# When a long running script exceed the maximum execution time only the
+# When a long running script exceeds the maximum execution time only the
 # SCRIPT KILL and SHUTDOWN NOSAVE commands are available. The first can be
 # used to stop a script that did not yet called write commands. The second
-# is the only way to shut down the server in the case a write commands was
-# already issue by the script but the user don't want to wait for the natural
+# is the only way to shut down the server in the case a write command was
+# already issued by the script but the user doesn't want to wait for the natural
 # termination of the script.
 #
 # Set it to 0 or a negative value for unlimited execution without warnings.
@@ -518,7 +518,7 @@ lua-time-limit 5000
 # Every cluster node has a cluster configuration file. This file is not
 # intended to be edited by hand. It is created and updated by Redis nodes.
 # Every Redis Cluster node requires a different cluster configuration file.
-# Make sure that instances running in the same system does not have
+# Make sure that instances running in the same system do not have
 # overlapping cluster configuration file names.
 #
 # cluster-config-file nodes-6379.conf
@@ -584,8 +584,8 @@ slowlog-max-len 128
 #  A     Alias for g$lshzxe, so that the "AKE" string means all the events.
 #
 #  The "notify-keyspace-events" takes as argument a string that is composed
-#  by zero or multiple characters. The empty string means that notifications
-#  are disabled at all.
+#  of zero or multiple characters. The empty string means that notifications
+#  are disabled.
 #
 #  Example: to enable list and generic events, from the point of view of the
 #           event name, use:
@@ -617,7 +617,7 @@ list-max-ziplist-entries 512
 list-max-ziplist-value 64
 
 # Sets have a special encoding in just one case: when a set is composed
-# of just strings that happens to be integers in radix 10 in the range
+# of just strings that happen to be integers in radix 10 in the range
 # of 64 bit signed integers.
 # The following configuration setting sets the limit in the size of the
 # set in order to use this special memory saving encoding.
@@ -638,11 +638,11 @@ zset-max-ziplist-value 64
 # by the hash table.
 # 
 # The default is to use this millisecond 10 times every second in order to
-# active rehashing the main dictionaries, freeing memory when possible.
+# actively rehash the main dictionaries, freeing memory when possible.
 #
 # If unsure:
 # use "activerehashing no" if you have hard latency requirements and it is
-# not a good thing in your environment that Redis can reply form time to time
+# not a good thing in your environment that Redis can reply from time to time
 # to queries with 2 milliseconds delay.
 #
 # use "activerehashing yes" if you don't have such hard requirements but
@@ -658,7 +658,7 @@ activerehashing yes
 #
 # normal -> normal clients
 # slave  -> slave clients and MONITOR clients
-# pubsub -> clients subcribed to at least one pubsub channel or pattern
+# pubsub -> clients subscribed to at least one pubsub channel or pattern
 #
 # The syntax of every client-output-buffer-limit directive is the following:
 #
@@ -691,7 +691,7 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 # never requested, and so forth.
 #
 # Not all tasks are performed with the same frequency, but Redis checks for
-# tasks to perform accordingly to the specified "hz" value.
+# tasks to perform according to the specified "hz" value.
 #
 # By default "hz" is set to 10. Raising the value will use more CPU when
 # Redis is idle, but at the same time will make Redis more responsive when
@@ -712,7 +712,7 @@ aof-rewrite-incremental-fsync yes
 ################################## INCLUDES ###################################
 
 # Include one or more other config files here.  This is useful if you
-# have a standard template that goes to all Redis server but also need
+# have a standard template that goes to all Redis servers but also need
 # to customize a few per-server settings.  Include files can include
 # other files, so use this wisely.
 #


### PR DESCRIPTION
A handful of small typo and grammar fixes in redis.conf.
