### PR TITLE
Return proper error on requests with an unbalanced number of quotes.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -884,6 +884,11 @@ int processInlineBuffer(redisClient *c) {
     aux = sdsnewlen(c->querybuf,querylen);
     argv = sdssplitargs(aux,&argc);
     sdsfree(aux);
+    if (argv == NULL) {
+        addReplyError(c,"Protocol error: unbalanced quotes in request");
+        setProtocolError(c,0);
+        return REDIS_ERR;
+    }
 
     /* Leave data after the first line of the query in the buffer */
     sdsrange(c->querybuf,querylen+2,-1);

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -60,6 +60,14 @@ start_server {tags {"protocol"}} {
         assert_error "*wrong*arguments*ping*" {r ping x y z}
     }
 
+    test "Unbalanced number of quotes" {
+        reconnect
+        r write "set \"\"\"test-key\"\"\" test-value\r\n"
+        r write "ping\r\n"
+        r flush
+        assert_error "*unbalanced*" {r read}
+    }
+
     set c 0
     foreach seq [list "\x00" "*\x00" "$\x00"] {
         incr c


### PR DESCRIPTION
Currently redis simply ignores such lines (as if they were blank). For example:

set """test-key""" value

Would just be ignored.
