### PR TITLE
Missing glibc 2.6 prereq for HAVE_ATOMIC dependency

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -187,7 +187,7 @@ void setproctitle(const char *fmt, ...);
 
 #if (__i386 || __amd64) && __GNUC__
 #define GNUC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#if GNUC_VERSION >= 40100
+#if (GNUC_VERSION >= 40100 && __GLIBC_PREREQ(2, 6))
 #define HAVE_ATOMIC
 #endif
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -187,8 +187,10 @@ void setproctitle(const char *fmt, ...);
 
 #if (__i386 || __amd64) && __GNUC__
 #define GNUC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
 #if (GNUC_VERSION >= 40100 && __GLIBC_PREREQ(2, 6))
 #define HAVE_ATOMIC
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
We have an environment where GCC > 4.0.1 (4.1.2) but glibc < 2.6 (2.5) (I know, weird).  Thus linking would fail because even though HAVE_ATOMIC was set to true, there is no 'sync_add_and_fetch' .  The simple one-line change is to also require glibc 2.6.
