### PR TITLE
Bugfix for the \n case in processInlineBuffer

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -868,7 +868,7 @@ int processInlineBuffer(redisClient *c) {
     char *newline;
     int argc, j;
     sds *argv, aux;
-    size_t querylen;
+    size_t querylen, offset;
 
     /* Search for end of line */
     newline = strchr(c->querybuf,'\n');
@@ -882,9 +882,12 @@ int processInlineBuffer(redisClient *c) {
         return REDIS_ERR;
     }
 
+    offset = 1;
     /* Handle the \r\n case. */
-    if (newline && newline != c->querybuf && *(newline-1) == '\r')
+    if (newline && newline != c->querybuf && *(newline-1) == '\r') {
         newline--;
+        offset++;
+    }
 
     /* Split the input buffer up to the \r\n */
     querylen = newline-(c->querybuf);
@@ -904,7 +907,7 @@ int processInlineBuffer(redisClient *c) {
         c->repl_ack_time = server.unixtime;
 
     /* Leave data after the first line of the query in the buffer */
-    sdsrange(c->querybuf,querylen+2,-1);
+    sdsrange(c->querybuf,querylen+offset,-1);
 
     /* Setup argv array on client structure */
     if (c->argv) zfree(c->argv);


### PR DESCRIPTION
The 'querylen+2' in 'sdsrange(c->querybuf,querylen+2,-1)' is for the \r\n case.
And it will be  'querylen+1' for \n case.
