### PR TITLE
Allowing slave to serve read only commands

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1982,7 +1982,8 @@ int processCommand(redisClient *c) {
      * 2) The command has no key arguments. */
     if (server.cluster_enabled &&
         !(c->flags & REDIS_MASTER) &&
-        !(c->cmd->getkeys_proc == NULL && c->cmd->firstkey == 0))
+        !(c->cmd->getkeys_proc == NULL && c->cmd->firstkey == 0) &&
+		!(server.masterhost != NULL && c->cmd->flags == REDIS_CMD_READONLY))
     {
         int hashslot;
 


### PR DESCRIPTION
This is a fix for issue 1406 - https://github.com/antirez/redis/issues/1406 

Checking if the server is slave and the command is read only, in that case allowing it to proceed with returning data
