### PR TITLE
fix infinite loop by randomkey if the slave only has expired key.

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -150,6 +150,10 @@ robj *dbRandomKey(redisDb *db) {
         if (dictFind(db->expires,key)) {
             if (expireIfNeeded(db,keyobj)) {
                 decrRefCount(keyobj);
+                /* Escaping from infinite loop by RANDOMKEY if slave has only expired key. */
+                if (server.masterhost != NULL && dictSize(db->dict) == dictSize(db->expires)) {
+                    return NULL;
+                }
                 continue; /* search for another key. This expired. */
             }
         }


### PR DESCRIPTION
I encountered redis instance hanged.

My application had been executing `RANDOMKEY` to slave instance continuously.
Suddenly the instance did not response to any command using CPU 100%.

I attached redis process and found the instance reiterated in `dbRandomKey` loop.

In fact, the `db` has only 40 keys and those are all expired.
The logic in `expireIfNeeded` did not delete any expired key in case of instance is slave
and `dbRandomKey` tried to find other key again.

I fixed it to return NULL if the instance is slave and the size of db and expired is equal.
