### PR TITLE
Cluster: Fix typos

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -90,7 +90,7 @@ int clusterLoadConfig(char *filename) {
    
     if (fp == NULL) return REDIS_ERR;
 
-    /* Parse the file. Note that single liens of the cluster config file can
+    /* Parse the file. Note that single lines of the cluster config file can
      * be really long as they include all the hash slots of the node.
      * This means in the worst possible case, half of the Redis slots will be
      * present in a single line, possibly in importing or migrating state, so
@@ -661,7 +661,7 @@ void clusterRenameNode(clusterNode *node, char *newname) {
  * CLUSTER nodes blacklist
  *
  * The nodes blacklist is just a way to ensure that a given node with a given
- * Node ID is not readded before some time elapsed (this time is specified
+ * Node ID is not readd-ed before some time elapsed (this time is specified
  * in seconds in REDIS_CLUSTER_BLACKLIST_TTL).
  *
  * This is useful when we want to remove a node from the cluster completely:
@@ -882,7 +882,7 @@ int clusterStartHandshake(char *ip, int port) {
 
     /* Add the node with a random address (NULL as first argument to
      * createClusterNode()). Everything will be fixed during the
-     * handskake. */
+     * handshake. */
     n = createClusterNode(NULL,REDIS_NODE_HANDSHAKE|REDIS_NODE_MEET);
     memcpy(n->ip,norm_ip,sizeof(n->ip));
     n->port = port;
@@ -1055,7 +1055,7 @@ void clusterSetNodeAsMaster(clusterNode *n) {
  * node (see the function comments for more info).
  *
  * The 'sender' is the node for which we received a configuration update.
- * Sometimes it is not actaully the "Sender" of the information, like in the case
+ * Sometimes it is not actually the "Sender" of the information, like in the case
  * we receive the info via an UPDATE packet. */
 void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoch,
                                   unsigned char *slots)
@@ -1224,7 +1224,7 @@ int clusterProcessPacket(clusterLink *link) {
                         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG|
                                              CLUSTER_TODO_UPDATE_STATE);
                     }
-                    /* Free this node as we alrady have it. This will
+                    /* Free this node as we already have it. This will
                      * cause the link to be freed as well. */
                     freeClusterNode(link->node);
                     return 0;
@@ -1411,7 +1411,7 @@ int clusterProcessPacket(clusterLink *link) {
             }
         } else {
             redisLog(REDIS_NOTICE,
-                "Ignoring FAIL message from unknonw node %.40s about %.40s",
+                "Ignoring FAIL message from unknown node %.40s about %.40s",
                 hdr->sender, hdr->data.fail.about.nodename);
         }
     } else if (type == CLUSTERMSG_TYPE_PUBLISH) {
@@ -1463,7 +1463,7 @@ int clusterProcessPacket(clusterLink *link) {
         /* If in our current config the node is a slave, set it as a master. */
         if (n->flags & REDIS_NODE_SLAVE) clusterSetNodeAsMaster(n);
 
-        /* Check the bitmap of served slots and udpate our
+        /* Check the bitmap of served slots and update our
          * config accordingly. */
         clusterUpdateSlotsConfigWith(n,reportedConfigEpoch,
             hdr->data.update.nodecfg.slots);
@@ -2460,7 +2460,7 @@ int verifyClusterConfigWithData(void) {
          * assigned to this slot. Fix this condition. */
 
         update_config++;
-        /* Case A: slot is unassigned. Take responsability for it. */
+        /* Case A: slot is unassigned. Take responsibility for it. */
         if (server.cluster->slots[j] == NULL) {
             redisLog(REDIS_WARNING, "I've keys about slot %d that is "
                                     "unassigned. Taking responsability "
@@ -2656,7 +2656,7 @@ void clusterCommand(redisClient *c) {
         int del = !strcasecmp(c->argv[1]->ptr,"delslots");
 
         memset(slots,0,REDIS_CLUSTER_SLOTS);
-        /* Check that all the arguments are parsable and that all the
+        /* Check that all the arguments are parse-able and that all the
          * slots are not already busy. */
         for (j = 2; j < c->argc; j++) {
             if ((slot = getSlotOrReply(c,c->argv[j])) == -1) {
@@ -2754,7 +2754,7 @@ void clusterCommand(redisClient *c) {
             }
             /* If this node was the slot owner and the slot was marked as
              * migrating, assigning the slot to another node will clear
-             * the migratig status. */
+             * the migrating status. */
             if (server.cluster->slots[slot] == server.cluster->myself &&
                 server.cluster->migrating_slots_to[slot])
                 server.cluster->migrating_slots_to[slot] = NULL;
@@ -3058,14 +3058,14 @@ void restoreCommand(redisClient *c) {
  * This sockets are closed when the max number we cache is reached, and also
  * in serverCron() when they are around for more than a few seconds. */
 #define MIGRATE_SOCKET_CACHE_ITEMS 64 /* max num of items in the cache. */
-#define MIGRATE_SOCKET_CACHE_TTL 10 /* close cached socekts after 10 sec. */
+#define MIGRATE_SOCKET_CACHE_TTL 10 /* close cached sockets after 10 sec. */
 
 typedef struct migrateCachedSocket {
     int fd;
     time_t last_use_time;
 } migrateCachedSocket;
 
-/* Return a TCP scoket connected with the target instance, possibly returning
+/* Return a TCP socket connected with the target instance, possibly returning
  * a cached one.
  *
  * This function is responsible of sending errors to the client if a
@@ -3074,7 +3074,7 @@ typedef struct migrateCachedSocket {
  * attempt to free it after usage.
  *
  * If the caller detects an error while using the socket, migrateCloseSocket()
- * should be called so that the connection will be craeted from scratch
+ * should be called so that the connection will be created from scratch
  * the next time. */
 int migrateGetSocket(redisClient *c, robj *host, robj *port, long timeout) {
     int fd;
@@ -3328,7 +3328,7 @@ void askingCommand(redisClient *c) {
     addReply(c,shared.ok);
 }
 
-/* The READONLY command is uesd by clients to enter the read-only mode.
+/* The READONLY command is used by clients to enter the read-only mode.
  * In this mode slaves will not redirect clients as long as clients access
  * with read-only commands to keys that are served by the slave's master. */
 void readonlyCommand(redisClient *c) {

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -12,7 +12,7 @@
 #define REDIS_CLUSTER_PORT_INCR 10000 /* Cluster port = baseport + PORT_INCR */
 #define REDIS_CLUSTER_IPLEN INET6_ADDRSTRLEN /* IPv6 address string length */
 
-/* The following defines are amunt of time, sometimes expressed as
+/* The following defines are amount of time, sometimes expressed as
  * multiplicators of the node timeout value (when ending with MULT). */
 #define REDIS_CLUSTER_DEFAULT_NODE_TIMEOUT 15000
 #define REDIS_CLUSTER_FAIL_REPORT_VALIDITY_MULT 2 /* Fail report validity. */
@@ -42,7 +42,7 @@ typedef struct clusterLink {
 #define REDIS_NODE_HANDSHAKE 32 /* We have still to exchange the first ping */
 #define REDIS_NODE_NOADDR   64  /* We don't know the address of this node */
 #define REDIS_NODE_MEET 128     /* Send a MEET message to this node */
-#define REDIS_NODE_PROMOTED 256 /* Master was a slave propoted by failover */
+#define REDIS_NODE_PROMOTED 256 /* Master was a slave promoted by failover */
 #define REDIS_NODE_NULL_NAME "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
 
 /* This structure represent elements of node->fail_reports. */
@@ -88,7 +88,7 @@ typedef struct clusterState {
     int failover_auth_count;    /* Number of votes received so far. */
     int failover_auth_sent;     /* True if we already asked for votes. */
     uint64_t failover_auth_epoch; /* Epoch of the current election. */
-    /* The followign fields are uesd by masters to take state on elections. */
+    /* The following fields are used by masters to take state on elections. */
     uint64_t last_vote_epoch;   /* Epoch of the last vote granted. */
     int todo_before_sleep; /* Things to do in clusterBeforeSleep(). */
     long long stats_bus_messages_sent;  /* Num of msg sent via cluster bus. */


### PR DESCRIPTION
In line 664 of cluster.c I'm assuming it's past tense of 're-add' and not 'read'.
