### PR TITLE
Fix assert

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -940,7 +940,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb) {
 
             /* Add pair to hash table */
             ret = dictAdd((dict*)o->ptr, field, value);
-            redisAssert(ret == REDIS_OK);
+            redisAssert(ret == DICT_OK);
         }
 
         /* All pairs should be read by now */


### PR DESCRIPTION
dictAdd returns DICT_OK (value: 1), but there was an assert
checking for REDIS_OK (value: 0) instead.

I'm not sure what was breaking because of this.  Is it just on a seldom-used code path?
