### PR TITLE
Added support for getting RSS from /proc/self/psinfo on Solaris

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -17,6 +17,8 @@
 /* Test for proc filesystem */
 #ifdef __linux__
 #define HAVE_PROCFS 1
+#elif __sun
+#define HAVE_PROC_PSINFO 1
 #endif
 
 /* Test for task_info() */


### PR DESCRIPTION
RSS used by the process can be obtained from /proc/self/psinfo on
Solaris and Illumos based systems.
