### PR TITLE
skip rdbLoad when it is slave and waking up

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -3147,7 +3147,9 @@ int main(int argc, char **argv) {
     #ifdef __linux__
         linuxOvercommitMemoryWarning();
     #endif
-        loadDataFromDisk();
+        if (server.masterhost == NULL) {
+            loadDataFromDisk();
+        }
         if (server.cluster_enabled) {
             if (verifyClusterConfigWithData() == REDIS_ERR) {
                 redisLog(REDIS_WARNING,


### PR DESCRIPTION
Because slave will send sync command to Master.
and that time It will load RDB.
so Slave doesn't need to load RDB when it start.
