### PR TITLE
[Bug Fix] sentinel can't connect other sentinel when other has multiple ip and bind just one ip of them.

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2073,21 +2073,30 @@ void sentinelReceiveHelloMessages(redisAsyncContext *c, void *reply, void *privd
  * Returns REDIS_OK if the PUBLISH was queued correctly, otherwise
  * REDIS_ERR is returned. */
 int sentinelSendHello(sentinelRedisInstance *ri) {
+    char *sendip;
     char ip[REDIS_IP_STR_LEN];
     char payload[REDIS_IP_STR_LEN+1024];
     int retval;
     sentinelRedisInstance *master = (ri->flags & SRI_MASTER) ? ri : ri->master;
     sentinelAddr *master_addr = sentinelGetCurrentMasterAddress(master);
 
+    sendip = ip;
+    if (server.bindaddr_count == 0) {
     /* Try to obtain our own IP address. */
-    if (anetSockName(ri->cc->c.fd,ip,sizeof(ip),NULL) == -1) return REDIS_ERR;
+        if (anetSockName(ri->cc->c.fd,ip,sizeof(ip),NULL) == -1) {
+             return REDIS_ERR;
+        }
+    } else {
+        sendip = server.bindaddr[0];
+    }
+
     if (ri->flags & SRI_DISCONNECTED) return REDIS_ERR;
 
     /* Format and send the Hello message. */
     snprintf(payload,sizeof(payload),
         "%s,%d,%s,%llu," /* Info about this sentinel. */
         "%s,%s,%d,%llu", /* Info about current master. */
-        ip, server.port, server.runid,
+        sendip, server.port, server.runid,
         (unsigned long long) sentinel.current_epoch,
         /* --- */
         master->name,master_addr->ip,master_addr->port,


### PR DESCRIPTION
hi @antirez.

I found a bug when I read redis sentinel code.
Situation:
 Sentinel has multiple ip, and bind only one of them.

for exmaple.
Sentinel has ip [192.168.1.13, 192.168.1.14]
and it binds 192.168.1.13

and it will broadcast its ip with Hello Message.
But at that time, we don't know what ip is connected with Redis Master.
so it can send other ip 192.168.1.14 with Hello Message. like below.

``` c
192.168.1.14,26379,runid,0,mymaster,192.168.1.8,6379,0
```

so It caues connection failed.

1] condition 1, A has multiple ip, B has just a ip
 -> A can connect B.
 -> But b can't

2] condition 2, A has multiple ip, B has multiple ip
 -> A can't, B can't

so it can cause some unexpectable situation.
so sentinel should return bined ip in conf with Hello Message.
