### PR TITLE
Cluster port error out

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -329,6 +329,19 @@ void clusterInit(void) {
 
     /* We need a listening TCP port for our cluster messaging needs. */
     server.cfd_count = 0;
+
+    /* Port sanity check II
+       The other handshake port check is triggered too late to stop
+       us from trying to use a too-high cluster port number.
+    */
+    if (server.port > (65535-REDIS_CLUSTER_PORT_INCR)) {
+        redisLog(REDIS_WARNING, "Redis port number too high. "
+                   "Cluster communication port is 10,000 port "
+                   "numbers higher than your Redis port. "
+                   "Your Redis port number must be "
+                   "lower than 55535.");
+    }
+
     if (listenToPort(server.port+REDIS_CLUSTER_PORT_INCR,
         server.cfd,&server.cfd_count) == REDIS_ERR)
     {

--- a/src/redis.c
+++ b/src/redis.c
@@ -1581,7 +1581,7 @@ int listenToPort(int port, int *fds, int *count) {
             redisLog(REDIS_WARNING,
                 "Creating Server TCP listening socket %s:%d: %s",
                 server.bindaddr[j] ? server.bindaddr[j] : "*",
-                server.port, server.neterr);
+                port, server.neterr);
             return REDIS_ERR;
         }
         (*count)++;


### PR DESCRIPTION
I spent a few hours thinking my system had gone crazy before diving into the code and finding the hard-coded cluster port offset.  (I was starting Redis on really high ports.)

Ideally we should use randomly-assigned cluster ports (just pass 0 as the port on `listenToPort` for the OS to assign a free port).
