### PR TITLE
Add support for systemd watchdog protocol

### DIFF
--- a/README
+++ b/README
@@ -66,6 +66,18 @@ If you want to see a more verbose output use the following:
 
     % make V=1
 
+Systemd watchdog support
+------------------------
+
+Redis support systemd watchdog protocol, to restart it automatically
+if the process is stuck or not responding. You need to have a version
+209 or newer of systemd, and compile Redis with:
+
+    % make HAVE_SYSTEMD=1
+
+By default, this will be a non operation unless systemd unit is configured
+to use a watchdog.
+
 Running Redis
 -------------
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -82,6 +82,11 @@ ifeq ($(MALLOC),tcmalloc_minimal)
 	FINAL_LIBS+= -ltcmalloc_minimal
 endif
 
+ifdef HAVE_SYSTEMD
+    FINAL_CFLAGS+= -DHAVE_SYSTEMD
+    FINAL_LIBS+= -lsystemd-daemon
+endif
+
 ifeq ($(MALLOC),jemalloc)
 	DEPENDENCY_TARGETS+= jemalloc
 	FINAL_CFLAGS+= -DUSE_JEMALLOC -I../deps/jemalloc/include


### PR DESCRIPTION
Systemd use a regular message on a socket to see if a process is alive,
and restart it if needed. In order to achieve that, a timer is added to
the main loop to notify systemd that we are still alive. This doesn't
add any overhead on a non-systemd enabled system, and requires to be
configured by the sysadmin, in the systemd unit file to be used.
See http://0pointer.de/blog/projects/watchdog.html for details.

This requires a version newer than 209, due to usage of sd_watchdog_enabled
function, and require to pass HAVE_SYSTEMD=1 to the Makefile.
