### PR TITLE
load rdb if aof not exist

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -3057,9 +3057,8 @@ int checkForSentinelMode(int argc, char **argv) {
 /* Function called at startup to load RDB or AOF file in memory. */
 void loadDataFromDisk(void) {
     long long start = ustime();
-    if (server.aof_state == REDIS_AOF_ON) {
-        if (loadAppendOnlyFile(server.aof_filename) == REDIS_OK)
-            redisLog(REDIS_NOTICE,"DB loaded from append only file: %.3f seconds",(float)(ustime()-start)/1000000);
+    if ((server.aof_state == REDIS_AOF_ON) && (loadAppendOnlyFile(server.aof_filename) == REDIS_OK) ) {
+        redisLog(REDIS_NOTICE,"DB loaded from append only file: %.3f seconds",(float)(ustime()-start)/1000000);
     } else {
         if (rdbLoad(server.rdb_filename) == REDIS_OK) {
             redisLog(REDIS_NOTICE,"DB loaded from disk: %.3f seconds",


### PR DESCRIPTION
when **Both** rdb and aof is enabled, redis can not load data from rdb file.

we do backup with rdb because it is compressed. 
when I want to recover from backup, I just copy the rdb file, make sure aof file is not exists, 
but redis does not load the rdb file.
