### PR TITLE
Add ccache support to Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -88,6 +88,11 @@ ifeq ($(MALLOC),jemalloc)
 	FINAL_LIBS+= ../deps/jemalloc/lib/libjemalloc.a -ldl
 endif
 
+CCACHE_EXISTS := $(shell which ccache)
+ifdef CCACHE_EXISTS
+    CC := ccache $(CC)
+endif
+
 REDIS_CC=$(QUIET_CC)$(CC) $(FINAL_CFLAGS)
 REDIS_LD=$(QUIET_LINK)$(CC) $(FINAL_LDFLAGS)
 REDIS_INSTALL=$(QUIET_INSTALL)$(INSTALL)


### PR DESCRIPTION
[Continuing the march of Tiny Non-Feature-Impacting Improvements.]

ccache helps when switching between many
branches.  It just caches the previously
built object and puts it in place on an
unchanged re-compile.

You can even do the clever thing of having
a post-checkout hook to automatically re-build
your current directory (the build should happen
in less than a second if you've previously
build the branch you're switching to).
