### PR TITLE
Makefile should build dependencies before install.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ default: all
 .DEFAULT:
 	cd src && $(MAKE) $@
 
-install:
+deps:
+	cd deps && $(MAKE) $@
+
+install: deps
 	cd src && $(MAKE) $@
 
 .PHONY: install


### PR DESCRIPTION
https://github.com/antirez/redis/issues/722

This fix proposes to make the `install` rule to depends on a new one,
named `deps`, that builds first all dependencies.

Tested on Ubuntu 12.0.4.3 LTS.
