### PR TITLE
Add cluster bind comment

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -62,6 +62,12 @@ tcp-backlog 511
 # If you give "--bind" as an option to redis-server, that option overrides
 # all "bind" directives in redis.conf.
 #
+# Redis Cluster uses the first "bind" IP address as the address to advertise
+# this instance to your entire Redis Cluster.
+# The first "bind" IP address must be reachable from all other instances,
+# so don't list 127.0.0.1 or ::1 first if you run Redis Cluster
+# on multiple hosts.
+#
 # Examples:
 #
 # bind 192.168.1.100 10.0.0.1 fdf2:8c30:36ae:303c::7

--- a/redis.conf
+++ b/redis.conf
@@ -57,11 +57,15 @@ tcp-backlog 511
 # available on the server. It is possible to listen to just one or multiple
 # interfaces using the "bind" configuration directive, followed by one or
 # more IP addresses.
+# All addresses must be specified in one "bind" directive.  If more than
+# one "bind" directive is listed, the last one wins and overrides all others.
+# If you give "--bind" as an option to redis-server, that option overrides
+# all "bind" directives in redis.conf.
 #
 # Examples:
 #
-# bind 192.168.1.100 10.0.0.1
-# bind 127.0.0.1
+# bind 192.168.1.100 10.0.0.1 fdf2:8c30:36ae:303c::7
+# bind 127.0.0.1 ::1
 
 # Specify the path for the Unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen


### PR DESCRIPTION
Update redis.conf with notes about how "bind" works in general and with cluster.

(Somehow, these extra 12 lines of comments expanded into over 60 lines of commit notes.)
