### PR TITLE
fixing install with chkconfig

### DIFF
--- a/utils/install_server.sh
+++ b/utils/install_server.sh
@@ -159,7 +159,7 @@ REDIS_CHKCONFIG_INFO=\
 # Description: Redis daemon\n
 ### END INIT INFO\n\n"
 
-if [ !`which chkconfig` ] ; then 
+if [ ! $(which chkconfig) ] ; then 
 	#combine the header and the template (which is actually a static footer)
 	echo $REDIS_INIT_HEADER > $TMP_FILE && cat $INIT_TPL_FILE >> $TMP_FILE || die "Could not write init script to $TMP_FILE"
 else
@@ -173,7 +173,7 @@ echo "Copied $TMP_FILE => $INIT_SCRIPT_DEST"
 
 #Install the service
 echo "Installing service..."
-if [ !`which chkconfig` ] ; then 
+if [ ! $(which chkconfig) ] ; then 
 	#if we're not a chkconfig box assume we're able to use update-rc.d
 	update-rc.d redis_$REDIS_PORT defaults && echo "Success!"
 else


### PR DESCRIPTION
Syntax correction of 2 lines of bash code.

Problem: 
    The install_server.sh does not create a valid init script according to chkconfig on centos 6.5

How to reproduce/debug: 
    sudo bash -x ./install_server.sh

output:
Welcome to the redis service installer
This script will help you easily set up a running redis server
Please select the redis port for this instance: [6379] 
Selecting default: 6379
Please select the redis config file name [/etc/redis/6379.conf] /etc/redis.conf
Selected default - /etc/redis/6379.conf
Please select the redis log file name [/var/log/redis_6379.log] /var/log/redis/redis.conf
Selected default - /var/log/redis_6379.log
Please select the data directory for this instance [/var/lib/redis/6379] /var/lib/redis
Selected default - /var/lib/redis/6379
which: no redis-server in (/sbin:/bin:/usr/sbin:/usr/bin)
Please select the redis executable path [] /usr/local/bin/redis-server
which: no redis-cli in (/sbin:/bin:/usr/sbin:/usr/bin)
s#^port [0-9]{4}$#port 6379#;s#^logfile .+$#logfile /var/log/redis_6379.log#;s#^dir .+$#dir /var/lib/redis/6379#;s#^pidfile .+$#pidfile /var/run/redis_6379.pid#;s#^daemonize no$#daemonize yes#;
Copied /tmp/6379.conf => /etc/init.d/redis_6379
Installing service...
service redis_6379 does not support chkconfig
service redis_6379 does not support chkconfig
 exists, process is already running or crashed
Installation successful!

Proof of problem:
      the chkconfig headers are not included in the init script.

Root cause:
    Invalid syntax
     if [ !`which chkconfig` ];
    -bash: !`which: event not found

Suggested fix:
    change syntax to
    if [ ! $(which chkconfig) ];
