### PR TITLE
Fix call to migrate.

### DIFF
--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -705,7 +705,12 @@ class RedisTrib
             keys = source.r.cluster("getkeysinslot",slot,10)
             break if keys.length == 0
             keys.each{|key|
-                source.r.migrate(target.info[:host],target.info[:port],key,0,1000)
+                source.r.migrate(key, {
+                    :host    => target.info[:host],
+                    :port    => target.info[:port],
+                    :db      => 0,
+                    :timeout => 1000
+                })
                 print "." if o[:verbose]
                 STDOUT.flush
             }


### PR DESCRIPTION
The redis-rb client takes the additional info as an options hash, not as additional arguments.

I'm using redis-rb v3.0.7, which takes only two arguments, see https://github.com/redis/redis-rb/blob/master/lib/redis.rb#L399
I couldn't find the code that it ever took 5 arguments, so I think this code in redis-trib.rb should have never worked.
