### PR TITLE
Add cluster-config-file locking

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1417,6 +1417,7 @@ void initServerConfig() {
     server.cluster_node_timeout = REDIS_CLUSTER_DEFAULT_NODE_TIMEOUT;
     server.cluster_migration_barrier = REDIS_CLUSTER_DEFAULT_MIGRATION_BARRIER;
     server.cluster_configfile = zstrdup(REDIS_DEFAULT_CLUSTER_CONFIG_FILE);
+    server.cluster_configfile_fp = NULL;
     server.lua_caller = NULL;
     server.lua_time_limit = REDIS_LUA_TIME_LIMIT;
     server.lua_client = NULL;

--- a/src/redis.h
+++ b/src/redis.h
@@ -820,6 +820,7 @@ struct redisServer {
     int cluster_enabled;      /* Is cluster enabled? */
     mstime_t cluster_node_timeout; /* Cluster node timeout. */
     char *cluster_configfile; /* Cluster auto-generated config file name. */
+    FILE *cluster_configfile_fp; /* fp of open cluster config file we flock() */
     struct clusterState *cluster;  /* State of the cluster */
     int cluster_migration_barrier; /* Cluster replicas migration barrier. */
     /* Scripting */


### PR DESCRIPTION
This is a first attempt at fixing the ongoing problem of people
launching multiple Redis Cluster instances in the same directory
with default options (which makes all instances use the same
"nodes.conf" which breaks their cluster).

This commit uses a `flock` approach to the problem.  Another
valid solution would be to use an external lock file.  Another
valid pattern would be to obtain the lock in `clusterInit`
instead of where we read/create the config in `clusterLoadConfig`. 

Do we allow runtime moving of cluster-config-file?  If so,
this commit doesn't handle that case yet.  Actually, I just
checked, and the 'set' command doesn't work at all in
a cluster because:

``` haskell
127.0.0.1:37446> set cluster-config-file poo.conf
(error) MOVED 13508 127.0.0.1:19029
127.0.0.1:37446> debug cmdkeys set cluster-config-file poo.conf
1) "cluster-config-file"
```
