### PR TITLE
fix binary search http://googleresearch.blogspot.de/2006/06/extra-extra-...

### DIFF
--- a/src/intset.c
+++ b/src/intset.c
@@ -133,7 +133,7 @@ static uint8_t intsetSearch(intset *is, int64_t value, uint32_t *pos) {
     }
 
     while(max >= min) {
-        mid = (min+max)/2;
+        mid = ((unsigned int)min+(unsigned int)max)>>1;
         cur = _intsetGet(is,mid);
         if (value > cur) {
             min = mid+1;


### PR DESCRIPTION
Fixes calculating the binary search pivot index calculation for large values, c.f. [Extra, Extra - Read All About It: Nearly All Binary Searches and Mergesorts are Broken](http://googleresearch.blogspot.de/2006/06/extra-extra-read-all-about-it-nearly.html)
