### PR TITLE
Get script error handler only when needed

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -861,9 +861,6 @@ void evalGenericCommand(redisClient *c, int evalsha) {
         funcname[42] = '\0';
     }
 
-    /* Push the pcall error handler function on the stack. */
-    lua_getglobal(lua, "__redis__err__handler");
-
     /* Try to lookup the Lua function */
     lua_getglobal(lua, funcname);
     if (lua_isnil(lua,-1)) {
@@ -872,12 +869,10 @@ void evalGenericCommand(redisClient *c, int evalsha) {
          * body of the function. If this is an EVALSHA call we can just
          * return an error. */
         if (evalsha) {
-            lua_pop(lua,1); /* remove the error handler from the stack. */
             addReply(c, shared.noscripterr);
             return;
         }
         if (luaCreateFunction(c,lua,funcname,c->argv[1]) == REDIS_ERR) {
-            lua_pop(lua,1); /* remove the error handler from the stack. */
             /* The error is sent to the client by luaCreateFunction()
              * itself when it returns REDIS_ERR. */
             return;
@@ -906,6 +901,10 @@ void evalGenericCommand(redisClient *c, int evalsha) {
         lua_sethook(lua,luaMaskCountHook,LUA_MASKCOUNT,100000);
         delhook = 1;
     }
+
+    /* Push the pcall error handler function on the stack. */
+    lua_getglobal(lua,"__redis__err__handler");
+    lua_insert(lua,-2);
 
     /* At this point whether this script was never seen before or if it was
      * already defined, we can call it. We have zero arguments and expect


### PR DESCRIPTION
I believe this change improves scripting.c evalGenericCommand readability.

Instead of pushing the error handler before the function lookup (that needs to clean the stack if it fails), we can get the error handler just before the pcall, using lua_insert to move the error handler function to the proper position in the stack.

Besides avoiding the lua_pop when lookup fails, I believe it's easier to understand why the error handler is now being pushed into the stack, since it is closer to pcall function call and it also explains the -2 pcall argument naturally.
