### PR TITLE
Consider buffers in expiration size

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1436,6 +1436,36 @@ void rewriteClientCommandArgument(redisClient *c, int i, robj *newval) {
     }
 }
 
+/* Get size of allocated output buffers for all clients */
+unsigned long allClientsOutputBufferMemoryUsage() {
+    listNode *ln;
+    listIter li;
+    unsigned long mem_output_buffers = 0;
+
+    listRewind(server.clients,&li);
+    while ((ln = listNext(&li)) != NULL) {
+        redisClient *c = listNodeValue(ln);
+        mem_output_buffers += getClientOutputBufferMemoryUsage(c);
+    }
+
+    return mem_output_buffers;
+}
+
+/* Get size of input buffers for all clients */
+unsigned long allClientsInputBufferMemoryUsage() {
+    listNode *ln;
+    listIter li;
+    unsigned long mem_input_buffers = 0;
+
+    listRewind(server.clients,&li);
+    while ((ln = listNext(&li)) != NULL) {
+        redisClient *c = listNodeValue(ln);
+        mem_input_buffers += sdslen(c->querybuf);
+    }
+
+    return mem_input_buffers;
+}
+
 /* This function returns the number of bytes that Redis is virtually
  * using to store the reply still not read by the client.
  * It is "virtual" since the reply output list may contain objects that

--- a/src/redis.c
+++ b/src/redis.c
@@ -2420,7 +2420,9 @@ sds genRedisInfoString(char *section) {
     if (allsections || defsections || !strcasecmp(section,"memory")) {
         char hmem[64];
         char peak_hmem[64];
+        char client_output_hmem[64];
         size_t zmalloc_used = zmalloc_used_memory();
+        unsigned long client_output_mem;
 
         /* Peak memory is updated from time to time by serverCron() so it
          * may happen that the instantaneous value is slightly bigger than
@@ -2429,8 +2431,11 @@ sds genRedisInfoString(char *section) {
         if (zmalloc_used > server.stat_peak_memory)
             server.stat_peak_memory = zmalloc_used;
 
+        client_output_mem = allClientsOutputBufferMemoryUsage();
+
         bytesToHuman(hmem,zmalloc_used);
         bytesToHuman(peak_hmem,server.stat_peak_memory);
+        bytesToHuman(client_output_hmem,client_output_mem);
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info,
             "# Memory\r\n"
@@ -2440,6 +2445,8 @@ sds genRedisInfoString(char *section) {
             "used_memory_peak:%zu\r\n"
             "used_memory_peak_human:%s\r\n"
             "used_memory_lua:%lld\r\n"
+            "used_memory_output_buffers:%lu\r\n"
+            "used_memory_output_buffers_human:%s\r\n"
             "mem_fragmentation_ratio:%.2f\r\n"
             "mem_allocator:%s\r\n",
             zmalloc_used,
@@ -2448,6 +2455,8 @@ sds genRedisInfoString(char *section) {
             server.stat_peak_memory,
             peak_hmem,
             ((long long)lua_gc(server.lua,LUA_GCCOUNT,0))*1024LL,
+            client_output_mem,
+            client_output_hmem,
             zmalloc_get_fragmentation_ratio(),
             ZMALLOC_LIB
             );

--- a/src/redis.c
+++ b/src/redis.c
@@ -2828,6 +2828,8 @@ int freeMemoryIfNeeded(void) {
         mem_used -= aofRewriteBufferSize();
     }
 
+    mem_used -= allClientsOutputBufferMemoryUsage();
+
     /* Check if we are over the memory limit. */
     if (mem_used <= server.maxmemory) return REDIS_OK;
 

--- a/src/redis.h
+++ b/src/redis.h
@@ -968,6 +968,8 @@ sds getClientInfoString(redisClient *client);
 sds getAllClientsInfoString(void);
 void rewriteClientCommandVector(redisClient *c, int argc, ...);
 void rewriteClientCommandArgument(redisClient *c, int i, robj *newval);
+unsigned long allClientsOutputBufferMemoryUsage();
+unsigned long allClientsInputBufferMemoryUsage();
 unsigned long getClientOutputBufferMemoryUsage(redisClient *c);
 void freeClientsInAsyncFreeQueue(void);
 void asyncCloseClientOnOutputBufferLimitReached(redisClient *c);


### PR DESCRIPTION
This may be more of a philosophical difference than an objective argument, but should we assume `maxmemory` is primarily our dataset size or all Redis memory usage even for transient allocations (temporary buffers)?

If maxmemory is _all_ memory usage, then read-only clients can forcibly evict keys by growing large pipeline output buffers (large output buffer = large total memory usage = over maxmemory limit = evict keys).

The patches in this PR:
- allow us to see the aggregate output buffer size in INFO output
- ignore output buffer size when determining if we are over memory limits (just like we do with Replica buffers and AOF buffers).
