### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: c
+
+# Two compilers because clang and GCC output different errors.
+compiler:
+    - clang
+    - gcc
+
+# env lets us spawn one VM per value of a variable.
+# TEST_TARGET runs make test and make test-sentinel concurrently
+# REDIS_CFLAGS fails to compile on warning to alert us about... warnings.
+# What gets run:
+# {gcc,   make -j REDIS_CFLAGS="",      make test}
+# {gcc,   make -j REDIS_CFLAGS="",      make test-sentinel}
+# {gcc,   make -j REDIS_CFLAGS=-Werror, make}  # The last make is a noop
+# {clang, make -j REDIS_CFLAGS="",      make test}
+# {clang, make -j REDIS_CFLAGS="",      make test-sentinel}
+# {clang, make -j REDIS_CFLAGS=-Werror, make}  # The last make is a noop
+env:
+    - TEST_TARGET=test
+    - TEST_TARGET=test-sentinel
+    - REDIS_CFLAGS="-Werror"
+
+# Redis testing needs tcl
+install:
+    - sudo apt-get install tcl -y
+
+# We start from inside src so -j is evaluated properly
+script: cd src; make -j REDIS_CFLAGS=$REDIS_CFLAGS && make $TEST_TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,13 @@ compiler:
 env:
     - TEST_TARGET=test
     - TEST_TARGET=test-sentinel
+    - TEST_TARGET=test-cluster-bring-up
     - REDIS_CFLAGS="-Werror"
 
 # Redis testing needs tcl
 install:
     - sudo apt-get install tcl -y
+    - gem install redis
 
 # We start from inside src so -j is evaluated properly
 script: cd src; make -j REDIS_CFLAGS=$REDIS_CFLAGS && make $TEST_TARGET

--- a/src/Makefile
+++ b/src/Makefile
@@ -207,6 +207,9 @@ test: $(REDIS_SERVER_NAME) $(REDIS_CHECK_AOF_NAME)
 test-sentinel: $(REDIS_SENTINEL_NAME)
 	@(cd ..; ./runtest-sentinel)
 
+test-cluster-bring-up: $(REDIS_SERVER_NAME)
+	@(../tests/integration/runtest-automated-cluster-bring-up)
+
 check: test
 
 lcov:

--- a/tests/integration/runtest-automated-cluster-bring-up
+++ b/tests/integration/runtest-automated-cluster-bring-up
@@ -1,0 +1,111 @@
+#!/bin/bash -x
+
+# This test is designed for run-and-walk-away
+# automated testing.  It provides no pretty
+# diagnostic output.
+
+set -e
+
+here=`dirname $0`
+RUNPATH="/tmp/redis-test-cluster/"
+REDIS="$here/../../src/redis-server"
+TRIB="$here/../../src/redis-trib.rb"
+
+# Homebrew doesn't link coreutils properly.  Try to manually discover them.
+POTENTIAL_UTILS=$(eval echo /usr/local/Cellar/coreutils/*/libexec/gnubin/|tail -1)
+PATH=$POTENTIAL_UTILS:$PATH
+
+LOCAL_IP=127.0.0.1
+case $OSTYPE in
+    solaris*) NET_IP=`/sbin/ifconfig net0 |grep inet |tal -1| awk '{printf $2}'` ;;
+    darwin*) NET_IP=`/sbin/ifconfig |grep inet |tail -1| awk '{printf $2}'` ;;
+    linux*) NET_IP=`/sbin/ifconfig |grep "inet addr" |grep -v 127.0.0.1 | tail -1 |awk '{printf $2}' |awk -F: '{printf $2}'` ;;
+esac
+
+TIMEOUT=`which timeout` 
+if [[ $? == 0 ]]; then
+    TIMEOUT="$TIMEOUT 30"
+else
+    TIMEOUT=""
+fi
+
+spawnClusterInstances() {
+    IP=$1
+    RANGE=$2
+    for port in $(eval echo $RANGE); do
+        PLACE="$RUNPATH"/$port
+        mkdir -p "$PLACE"
+        rm -f $PLACE/*.conf $PLACE/*.rdb
+        $REDIS --dir "$PLACE" --bind $IP --cluster-enabled yes --port $port &
+    done
+}
+
+stopClusterInstances() {
+    RANGE=$*
+    for port in $(eval echo $RANGE); do
+        PLACE="$RUNPATH/$port"
+        echo "Cleaning up instance $port at $PLACE"
+        # Redis refuses to write pidfiles if we aren't daemonized
+        REDIS_PID=`ps auxww|grep redis-server|grep :$port|awk '{print $2}'`
+        if [[ ! -z $REDIS_PID ]]; then
+            kill -9 $REDIS_PID
+        fi
+        rm -f $PLACE/{*.conf,*.rdb}
+    done
+}
+
+createClusterWithInstancesAndReplicas() {
+    LOCAL_COUNT=$1
+    NET_COUNT=$2
+    REPLICAS=$3
+
+    LOCAL_LOW=7001
+    LOCAL_HIGH=$(($LOCAL_LOW+$LOCAL_COUNT-1))
+
+    NET_LOW=8001
+    NET_HIGH=$(($NET_LOW+$NET_COUNT-1))
+
+    LOCAL_PORT_RANGE={$LOCAL_LOW..$LOCAL_HIGH}
+    NET_PORT_RANGE={$NET_LOW..$NET_HIGH}
+
+#    LOCAL_PORTS=$(eval seq $LOCAL_LOW $LOCAL_HIGH)
+#    NET_PORTS=$(eval seq $NET_LOW $NET_HIGH)
+
+    # Stop before run in case the previous run aborted early
+    # and left lingering redis-server cluster process around
+    stopClusterInstances $LOCAL_PORT_RANGE $NET_PORT_RANGE
+
+    spawnClusterInstances $LOCAL_IP $LOCAL_PORT_RANGE
+    spawnClusterInstances $NET_IP $NET_PORT_RANGE
+
+    echo yes |$TIMEOUT "$TRIB" create --replicas $REPLICAS $(eval echo $LOCAL_IP:$LOCAL_PORT_RANGE $NET_IP:$NET_PORT_RANGE)
+
+    stopClusterInstances $LOCAL_PORT_RANGE $NET_PORT_RANGE
+}
+
+echo "Testing 0 replicas (all masters)"
+for replicaCount in 0; do
+    for localIPCount in {3..5}; do
+        for netIPCount in {1..3}; do
+             createClusterWithInstancesAndReplicas $localIPCount $netIPCount $replicaCount
+        done
+    done
+done
+
+echo "Testing 1 replicas"
+for replicaCount in 1; do
+    for localIPCount in {3..6}; do
+        for netIPCount in {3..6}; do
+             createClusterWithInstancesAndReplicas $localIPCount $netIPCount $replicaCount
+        done
+    done
+done
+
+echo "Testing 2 to 5 replicas"
+for replicaCount in {2..5}; do
+    for localIPCount in {9..15}; do
+        for netIPCount in {9..15}; do
+             createClusterWithInstancesAndReplicas $localIPCount $netIPCount $replicaCount
+        done
+    done
+done


### PR DESCRIPTION
As much as I enjoy being a human continuous integration system, perhaps we can automate it for better and quicker coverage?

By adding this one tiny YAML file (yes, it's sad to pollute the repository with an ugly external configuration file, but that's just how it works), we can have six VMs launched and running Redis unit tests after every push.  Why six VMs?  {gcc,clang}{make test,make test-sentinel} + {gcc,clang}{make REDIS_CFLAGS=-Werror} = 6 VMs.

For example output, see https://travis-ci.org/mattsta/redis/builds/21050931 — you can see we currently have one failing test because of the `gcc -Werror` fixed in antirez/redis#1617

Travis CI will run on each push to any branch.  Just sign up at https://travis-ci.org/, login with github credentials, then enable it for your Redis repository.  By default, it will also build and report on pull requests too.
