### PR TITLE
Cluster: Restore proper trib master iteration

### DIFF
--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -572,6 +572,7 @@ class RedisTrib
                         nodes_count -= 1
                         i += 1
                         puts "Adding replica #{slave} to #{m}"
+                        break
                     }
                 end
             }


### PR DESCRIPTION
This got removed in 2e5c394 during a new feature addition.

The prior commit had "break if masters.length == masters_count"
but we are guaranteed to aready have that condition met since
otherwise we would haven't gotten this far.

Without this break statement, it's possible some masters may
be forgotten and have zero replicas while other masters have
more than their requested number of replicas.

Thanks to carlos for pointing out this regression at:
https://groups.google.com/forum/#!topic/redis-db/_WVVqDw5B7c
