### PR TITLE
Fix infinite loop ulimit

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -600,7 +600,7 @@ void configSetCommand(redisClient *c) {
     } else if (!strcasecmp(c->argv[2]->ptr,"maxclients")) {
         int orig_value = server.maxclients;
 
-        if (getLongLongFromObject(o,&ll) == REDIS_ERR || ll < 0) goto badfmt;
+        if (getLongLongFromObject(o,&ll) == REDIS_ERR || ll < 1) goto badfmt;
 
         /* Try to check if the OS is capable of supporting so many FDs. */
         server.maxclients = ll;

--- a/src/redis.c
+++ b/src/redis.c
@@ -1491,20 +1491,20 @@ void initServerConfig() {
 
 /* This function will try to raise the max number of open files accordingly to
  * the configured max number of clients. It also reserves a number of file
- * descriptors (REDIS_EVENTLOOP_FDSET_INCR) for extra operations of
+ * descriptors (REDIS_MIN_RESERVED_FDS) for extra operations of
  * persistence, listening sockets, log files and so forth.
  *
  * If it will not be possible to set the limit accordingly to the configured
  * max number of clients, the function will do the reverse setting
  * server.maxclients to the value that we can actually handle. */
 void adjustOpenFilesLimit(void) {
-    rlim_t maxfiles = server.maxclients+REDIS_EVENTLOOP_FDSET_INCR;
+    rlim_t maxfiles = server.maxclients+REDIS_MIN_RESERVED_FDS;
     struct rlimit limit;
 
     if (getrlimit(RLIMIT_NOFILE,&limit) == -1) {
         redisLog(REDIS_WARNING,"Unable to obtain the current NOFILE limit (%s), assuming 1024 and setting the max clients configuration accordingly.",
             strerror(errno));
-        server.maxclients = 1024-REDIS_EVENTLOOP_FDSET_INCR;
+        server.maxclients = 1024-REDIS_MIN_RESERVED_FDS;
     } else {
         rlim_t oldlimit = limit.rlim_cur;
 
@@ -1518,7 +1518,7 @@ void adjustOpenFilesLimit(void) {
                 limit.rlim_cur = f;
                 limit.rlim_max = f;
                 if (setrlimit(RLIMIT_NOFILE,&limit) != -1) break;
-                f -= REDIS_EVENTLOOP_FDSET_INCR;
+                f -= REDIS_MIN_RESERVED_FDS;
                 if (f > limit.rlim_cur) {
                     /* Instead of getting smaller, f just got bigger.
                      * That means it wrapped around its unsigned floor
@@ -1534,7 +1534,7 @@ void adjustOpenFilesLimit(void) {
             if (f < oldlimit) f = oldlimit;
             if (f != maxfiles) {
                 int old_maxclients = server.maxclients;
-                server.maxclients = f-REDIS_EVENTLOOP_FDSET_INCR;
+                server.maxclients = f-REDIS_MIN_RESERVED_FDS;
                 if (server.maxclients < 1) {
                     redisLog(REDIS_WARNING,"Your current 'ulimit -n' "
                         "of %llu is not enough for Redis to start. "

--- a/src/redis.c
+++ b/src/redis.c
@@ -1519,6 +1519,17 @@ void adjustOpenFilesLimit(void) {
                 limit.rlim_max = f;
                 if (setrlimit(RLIMIT_NOFILE,&limit) != -1) break;
                 f -= REDIS_EVENTLOOP_FDSET_INCR;
+                if (f > limit.rlim_cur) {
+                    /* Instead of getting smaller, f just got bigger.
+                     * That means it wrapped around its unsigned floor
+                     * and is now closer to 2^64.  We can't help anymore. */
+                    redisLog(REDIS_WARNING,"Failed to set max file limit. "
+                        "You requested maxclients of %d "
+                        "but your 'ulimit -n' is set to %llu. "
+                        "Please increase your 'ulimit -n' to at least %llu.",
+                        server.maxclients, oldlimit, maxfiles);
+                    exit(1);
+                }
             }
             if (f < oldlimit) f = oldlimit;
             if (f != maxfiles) {

--- a/src/redis.c
+++ b/src/redis.c
@@ -1490,21 +1490,21 @@ void initServerConfig() {
 }
 
 /* This function will try to raise the max number of open files accordingly to
- * the configured max number of clients. It will also account for 32 additional
- * file descriptors as we need a few more for persistence, listening
- * sockets, log files and so forth.
+ * the configured max number of clients. It also reserves a number of file
+ * descriptors (REDIS_EVENTLOOP_FDSET_INCR) for extra operations of
+ * persistence, listening sockets, log files and so forth.
  *
  * If it will not be possible to set the limit accordingly to the configured
  * max number of clients, the function will do the reverse setting
  * server.maxclients to the value that we can actually handle. */
 void adjustOpenFilesLimit(void) {
-    rlim_t maxfiles = server.maxclients+32;
+    rlim_t maxfiles = server.maxclients+REDIS_EVENTLOOP_FDSET_INCR;
     struct rlimit limit;
 
     if (getrlimit(RLIMIT_NOFILE,&limit) == -1) {
         redisLog(REDIS_WARNING,"Unable to obtain the current NOFILE limit (%s), assuming 1024 and setting the max clients configuration accordingly.",
             strerror(errno));
-        server.maxclients = 1024-32;
+        server.maxclients = 1024-REDIS_EVENTLOOP_FDSET_INCR;
     } else {
         rlim_t oldlimit = limit.rlim_cur;
 
@@ -1518,11 +1518,11 @@ void adjustOpenFilesLimit(void) {
                 limit.rlim_cur = f;
                 limit.rlim_max = f;
                 if (setrlimit(RLIMIT_NOFILE,&limit) != -1) break;
-                f -= 128;
+                f -= REDIS_EVENTLOOP_FDSET_INCR;
             }
             if (f < oldlimit) f = oldlimit;
             if (f != maxfiles) {
-                server.maxclients = f-32;
+                server.maxclients = f-REDIS_EVENTLOOP_FDSET_INCR;
                 redisLog(REDIS_WARNING,"Unable to set the max number of files limit to %d (%s), setting the max clients configuration to %d.",
                     (int) maxfiles, strerror(errno), (int) server.maxclients);
             } else {

--- a/src/redis.c
+++ b/src/redis.c
@@ -1534,6 +1534,7 @@ void adjustOpenFilesLimit(void) {
             if (f < oldlimit) f = oldlimit;
             if (f != maxfiles) {
                 int old_maxclients = server.maxclients;
+                int original_errno = errno;
                 server.maxclients = f-REDIS_MIN_RESERVED_FDS;
                 if (server.maxclients < 1) {
                     redisLog(REDIS_WARNING,"Your current 'ulimit -n' "
@@ -1547,7 +1548,7 @@ void adjustOpenFilesLimit(void) {
                     old_maxclients, maxfiles);
                 redisLog(REDIS_WARNING,"Redis can't set maximum open files "
                     "to %llu because of OS error: %s.",
-                    maxfiles, strerror(errno));
+                    maxfiles, strerror(original_errno));
                 redisLog(REDIS_WARNING,"Current maximum open files is %llu. "
                     "maxclients has been reduced to %d to compensate for "
                     "low ulimit. "

--- a/src/redis.c
+++ b/src/redis.c
@@ -1522,12 +1522,30 @@ void adjustOpenFilesLimit(void) {
             }
             if (f < oldlimit) f = oldlimit;
             if (f != maxfiles) {
+                int old_maxclients = server.maxclients;
                 server.maxclients = f-REDIS_EVENTLOOP_FDSET_INCR;
-                redisLog(REDIS_WARNING,"Unable to set the max number of files limit to %d (%s), setting the max clients configuration to %d.",
-                    (int) maxfiles, strerror(errno), (int) server.maxclients);
+                if (server.maxclients < 1) {
+                    redisLog(REDIS_WARNING,"Your current 'ulimit -n' "
+                        "of %llu is not enough for Redis to start. "
+                        "Please increase your open file limit to at least "
+                        "%llu. Exiting.", oldlimit, maxfiles);
+                    exit(1);
+                }
+                redisLog(REDIS_WARNING,"You requested maxclients of %d "
+                    "requiring at least %llu max file descriptors.",
+                    old_maxclients, maxfiles);
+                redisLog(REDIS_WARNING,"Redis can't set maximum open files "
+                    "to %llu because of OS error: %s.",
+                    maxfiles, strerror(errno));
+                redisLog(REDIS_WARNING,"Current maximum open files is %llu. "
+                    "maxclients has been reduced to %d to compensate for "
+                    "low ulimit. "
+                    "If you need higher maxclients increase 'ulimit -n'.",
+                    oldlimit, server.maxclients);
             } else {
-                redisLog(REDIS_NOTICE,"Max number of open files set to %d",
-                    (int) maxfiles);
+                redisLog(REDIS_NOTICE,"Increased maximum number of open files "
+                    "to %llu (it was originally set to %llu).",
+                    maxfiles, oldlimit);
             }
         }
     }

--- a/src/redis.h
+++ b/src/redis.h
@@ -123,6 +123,7 @@
 #define REDIS_IP_STR_LEN INET6_ADDRSTRLEN
 #define REDIS_PEER_ID_LEN (REDIS_IP_STR_LEN+32) /* Must be enough for ip:port */
 #define REDIS_BINDADDR_MAX 16
+#define REDIS_MIN_RESERVED_FDS 32
 
 #define ACTIVE_EXPIRE_CYCLE_LOOKUPS_PER_LOOP 20 /* Loopkups per loop. */
 #define ACTIVE_EXPIRE_CYCLE_FAST_DURATION 1000 /* Microseconds */
@@ -139,9 +140,9 @@
 #define REDIS_LONGSTR_SIZE      21          /* Bytes needed for long -> str */
 #define REDIS_AOF_AUTOSYNC_BYTES (1024*1024*32) /* fdatasync every 32MB */
 /* When configuring the Redis eventloop, we setup it so that the total number
- * of file descriptors we can handle are server.maxclients + FDSET_INCR
+ * of file descriptors we can handle are server.maxclients + RESERVED_FDS + FDSET_INCR
  * that is our safety margin. */
-#define REDIS_EVENTLOOP_FDSET_INCR 128
+#define REDIS_EVENTLOOP_FDSET_INCR (REDIS_MIN_RESERVED_FDS+96)
 
 /* Hash table parameters */
 #define REDIS_HT_MINFILL        10      /* Minimal hash table fill 10% */

--- a/src/redis.h
+++ b/src/redis.h
@@ -786,7 +786,7 @@ struct redisServer {
     list *clients_waiting_acks;         /* Clients waiting in WAIT command. */
     int get_ack_from_slaves;            /* If true we send REPLCONF GETACK. */
     /* Limits */
-    unsigned int maxclients;        /* Max number of simultaneous clients */
+    int maxclients;                 /* Max number of simultaneous clients */
     unsigned long long maxmemory;   /* Max number of memory bytes to use */
     int maxmemory_policy;           /* Policy for key eviction */
     int maxmemory_samples;          /* Pricision of random sampling */


### PR DESCRIPTION
This series of patches fixes:
- two unsigned integer wraparounds
- one infinite loop
- one configuration parsing error
- one automatic reconfiguration error edge case
- error messages, hopefully making them more useful

I'm unsure about one change: instead of reserving `server.maxclients+32` fds, I changed it to  `server.maxclients+REDIS_EVENTLOOP_FDSET_INCR` to equal how the server event loop is configured at https://github.com/antirez/redis/blob/unstable/src/redis.c#L1639

Thanks to @bs3g for spontaneously closing #1227 which made me look at #356 too.  Sorry I couldn't use the patches in #1227, but all of those fixes eventually got implemented in these commits.
## New ulimit Error Message Output

``` haskell
matt@ununoctium:~/repos/redis/src% ./redis-server
[9326] 23 Mar 00:04:16.675 # Failed to set max file limit. You requested maxclients of 10000 but your 'ulimit -n' is set to 3. Please increase your 'ulimit -n' to at least 10128.

matt@ununoctium:~/repos/redis/src% ./redis-server 
[9719] 22 Mar 20:05:01.768 # Your current 'ulimit -n' of 32 is not enough for Redis to start. Please increase your open file limit to at least 10128. Exiting.

matt@ununoctium:~/repos/redis/src% ulimit -n 129
matt@ununoctium:~/repos/redis/src% ./redis-server 
[9991] 22 Mar 20:05:31.896 # You requested maxclients of 10000 requiring at least 10128 max file descriptors.
[9991] 22 Mar 20:05:31.896 # Redis can't set maximum open files to 10128 because of OS error: Operation not permitted.
[9991] 22 Mar 20:05:31.896 # Current maximum open files is 129. maxclients has been reduced to 1 to compensate for low ulimit. If you need higher maxclients increase 'ulimit -n'.

matt@ununoctium:~/repos/redis/src% ulimit -n 3000
matt@ununoctium:~/repos/redis/src% ./redis-server 
[10234] 22 Mar 20:05:58.653 # You requested maxclients of 10000 requiring at least 10128 max file descriptors.
[10234] 22 Mar 20:05:58.653 # Redis can't set maximum open files to 10128 because of OS error: Operation not permitted.
[10234] 22 Mar 20:05:58.653 # Current maximum open files is 3000. maxclients has been reduced to 2872 to compensate for low ulimit. If you need higher maxclients increase 'ulimit -n'.

umatt@ununoctium:~/repos/redis/src% ulimit -n 12000
matt@ununoctium:~/repos/redis/src% ./redis-server 
[starts normally]
```
