### PR TITLE
Give the type 'void' to functions have no argument.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -73,7 +73,7 @@ void appendServerSaveParams(time_t seconds, int changes) {
     server.saveparamslen++;
 }
 
-void resetServerSaveParams() {
+void resetServerSaveParams(void) {
     zfree(server.saveparams);
     server.saveparams = NULL;
     server.saveparamslen = 0;

--- a/src/rand.c
+++ b/src/rand.c
@@ -66,7 +66,7 @@
 #define HI_BIT	(1L << (2 * N - 1))
 
 static uint32_t x[3] = { X0, X1, X2 }, a[3] = { A0, A1, A2 }, c = C;
-static void next();
+static void next(void);
 
 int32_t redisLrand48() {
     next();
@@ -77,7 +77,7 @@ void redisSrand48(int32_t seedval) {
     SEED(X0, LOW(seedval), HIGH(seedval));
 }
 
-static void next() {
+static void next(void) {
     uint32_t p[2], q[2], r[2], carry0, carry1;
 
     MUL(a[0], x[0], p);

--- a/src/redis-check-dump.c
+++ b/src/redis-check-dump.c
@@ -166,7 +166,7 @@ int readBytes(void *target, long num) {
     return 1;
 }
 
-int processHeader() {
+int processHeader(void) {
     char buf[10] = "_________";
     int dump_version;
 
@@ -600,7 +600,7 @@ void printErrorStack(entry *e) {
     }
 }
 
-void process() {
+void process(void) {
     uint64_t num_errors = 0, num_valid_ops = 0, num_valid_bytes = 0;
     entry entry;
     int dump_version = processHeader();

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -95,7 +95,7 @@ static struct config {
     char *eval;
 } config;
 
-static void usage();
+static void usage(void);
 static void slaveMode(void);
 char *redisGitSHA1(void);
 char *redisGitDirty(void);
@@ -155,7 +155,7 @@ typedef struct {
 static helpEntry *helpEntries;
 static int helpEntriesLen;
 
-static sds cliVersion() {
+static sds cliVersion(void) {
     sds version;
     version = sdscatprintf(sdsempty(), "%s", REDIS_VERSION);
 
@@ -169,7 +169,7 @@ static sds cliVersion() {
     return version;
 }
 
-static void cliInitHelp() {
+static void cliInitHelp(void) {
     int commandslen = sizeof(commandHelp)/sizeof(struct commandHelp);
     int groupslen = sizeof(commandGroups)/sizeof(char*);
     int i, len, pos = 0;
@@ -208,7 +208,7 @@ static void cliOutputCommandHelp(struct commandHelp *help, int group) {
 }
 
 /* Print generic help. */
-static void cliOutputGenericHelp() {
+static void cliOutputGenericHelp(void) {
     sds version = cliVersion();
     printf(
         "redis-cli %s\r\n"
@@ -363,7 +363,7 @@ static int cliConnect(int force) {
     return REDIS_OK;
 }
 
-static void cliPrintContextError() {
+static void cliPrintContextError(void) {
     if (context == NULL) return;
     fprintf(stderr,"Error: %s\n",context->errstr);
 }
@@ -790,7 +790,7 @@ static sds readArgFromStdin(void) {
     return arg;
 }
 
-static void usage() {
+static void usage(void) {
     sds version = cliVersion();
     fprintf(stderr,
 "redis-cli %s\n"
@@ -858,7 +858,7 @@ static char **convertToSds(int count, char** args) {
 }
 
 #define LINE_BUFLEN 4096
-static void repl() {
+static void repl(void) {
     sds historyfile = NULL;
     int history = 0;
     char *line;
@@ -1661,7 +1661,7 @@ void bytesToHuman(char *s, long long n) {
     }
 }
 
-static void statMode() {
+static void statMode(void) {
     redisReply *reply;
     long aux, requests = 0;
     int i = 0;
@@ -1747,7 +1747,7 @@ static void statMode() {
  * Scan mode
  *--------------------------------------------------------------------------- */
 
-static void scanMode() {
+static void scanMode(void) {
     redisReply *reply;
     unsigned long long cur = 0;
 

--- a/src/redis.c
+++ b/src/redis.c
@@ -1340,7 +1340,7 @@ void createSharedObjects(void) {
     }
 }
 
-void initServerConfig() {
+void initServerConfig(void) {
     int j;
 
     getRandomHexChars(server.runid,REDIS_RUN_ID_SIZE);
@@ -1610,7 +1610,7 @@ void resetServerStats(void) {
     server.ops_sec_last_sample_ops = 0;
 }
 
-void initServer() {
+void initServer(void) {
     int j;
 
     signal(SIGHUP, SIG_IGN);
@@ -3121,7 +3121,7 @@ void daemonize(void) {
     }
 }
 
-void version() {
+void version(void) {
     printf("Redis server v=%s sha=%s:%d malloc=%s bits=%d build=%llx\n",
         REDIS_VERSION,
         redisGitSHA1(),
@@ -3132,7 +3132,7 @@ void version() {
     exit(0);
 }
 
-void usage() {
+void usage(void) {
     fprintf(stderr,"Usage: ./redis-server [/path/to/redis.conf] [options]\n");
     fprintf(stderr,"       ./redis-server - (read config from stdin)\n");
     fprintf(stderr,"       ./redis-server -v or --version\n");

--- a/src/redis.h
+++ b/src/redis.h
@@ -1168,7 +1168,7 @@ void redisLog(int level, const char *fmt, ...);
 #endif
 void redisLogRaw(int level, const char *msg);
 void redisLogFromHandler(int level, const char *msg);
-void usage();
+void usage(void);
 void updateDictResizePolicy(void);
 int htNeedsResize(dict *dict);
 void oom(const char *msg);
@@ -1228,7 +1228,7 @@ sds keyspaceEventsFlagsToString(int flags);
 /* Configuration */
 void loadServerConfig(char *filename, char *options);
 void appendServerSaveParams(time_t seconds, int changes);
-void resetServerSaveParams();
+void resetServerSaveParams(void);
 struct rewriteConfigState; /* Forward declaration to export API. */
 void rewriteConfigRewriteLine(struct rewriteConfigState *state, char *option, sds line, int force);
 int rewriteConfig(char *path);


### PR DESCRIPTION
According to the C standard, it is desirable to give the type 'void' to functions have no argument.
