### PR TITLE
Add SIGINT handler

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -3276,17 +3276,12 @@ static void sigShutdownHandler(int sig) {
 
 void setupSignalHandlers(void) {
     struct sigaction act;
-
-    /* When the SA_SIGINFO flag is set in sa_flags then sa_sigaction is used.
-     * Otherwise, sa_handler is used. */
     sigemptyset(&act.sa_mask);
-    act.sa_flags = 0;
-    act.sa_handler = sigShutdownHandler;
-    sigaction(SIGTERM, &act, NULL);
+
+    signal(SIGTERM, sigShutdownHandler);
     signal(SIGINT, sigShutdownHandler);
 
 #ifdef HAVE_BACKTRACE
-    sigemptyset(&act.sa_mask);
     act.sa_flags = SA_NODEFER | SA_RESETHAND | SA_SIGINFO;
     act.sa_sigaction = sigsegvHandler;
     sigaction(SIGSEGV, &act, NULL);

--- a/src/redis.c
+++ b/src/redis.c
@@ -3256,10 +3256,21 @@ void redisAsciiArt(void) {
     zfree(buf);
 }
 
-static void sigtermHandler(int sig) {
-    REDIS_NOTUSED(sig);
+static void sigShutdownHandler(int sig) {
+    char *msg;
 
-    redisLogFromHandler(REDIS_WARNING,"Received SIGTERM, scheduling shutdown...");
+    switch (sig) {
+    case SIGINT:
+        msg = "Received SIGINT scheduling shutdown...";
+        break;
+    case SIGTERM:
+        msg = "Received SIGTERM scheduling shutdown...";
+        break;
+    default:
+        msg = "Received shutdown signal, scheduling shutdown...";
+    };
+
+    redisLogFromHandler(REDIS_WARNING, msg);
     server.shutdown_asap = 1;
 }
 
@@ -3270,8 +3281,9 @@ void setupSignalHandlers(void) {
      * Otherwise, sa_handler is used. */
     sigemptyset(&act.sa_mask);
     act.sa_flags = 0;
-    act.sa_handler = sigtermHandler;
+    act.sa_handler = sigShutdownHandler;
     sigaction(SIGTERM, &act, NULL);
+    signal(SIGINT, sigShutdownHandler);
 
 #ifdef HAVE_BACKTRACE
     sigemptyset(&act.sa_mask);


### PR DESCRIPTION
When we CTRL-C from a foreground redis-server, it should shutdown cleanly instead of just exiting immediately.

The slightly obtuse switch statement in the signal handler preserves the original log output.
