### PR TITLE
redis-cli: Re-attach selected DB after auth

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -94,6 +94,7 @@ static struct config {
     sds mb_delim;
     char prompt[128];
     char *eval;
+    int last_cmd_type;
 } config;
 
 static volatile sig_atomic_t force_cancel_loop = 0;
@@ -131,7 +132,7 @@ static void cliRefreshPrompt(void) {
                        strchr(config.hostip,':') ? "[%s]:%d" : "%s:%d",
                        config.hostip, config.hostport);
     /* Add [dbnum] if needed */
-    if (config.dbnum != 0)
+    if (config.dbnum != 0 && config.last_cmd_type != REDIS_REPLY_ERROR)
         len += snprintf(config.prompt+len,sizeof(config.prompt)-len,"[%d]",
             config.dbnum);
     snprintf(config.prompt+len,sizeof(config.prompt)-len,"> ");
@@ -531,6 +532,8 @@ static int cliReadReply(int output_raw_strings) {
     }
 
     reply = (redisReply*)_reply;
+
+    config.last_cmd_type = reply->type;
 
     /* Check if we need to connect to a different node and reissue the
      * request. */
@@ -1887,6 +1890,8 @@ int main(int argc, char **argv) {
     config.stdinarg = 0;
     config.auth = NULL;
     config.eval = NULL;
+    config.last_cmd_type = -1;
+
     if (!isatty(fileno(stdout)) && (getenv("FAKETTY") == NULL))
         config.output = OUTPUT_RAW;
     else

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -320,8 +320,10 @@ static int cliSelect() {
 
     reply = redisCommand(context,"SELECT %d",config.dbnum);
     if (reply != NULL) {
+        int result = REDIS_OK;
+        if (reply->type == REDIS_REPLY_ERROR) result = REDIS_ERR;
         freeReplyObject(reply);
-        return REDIS_OK;
+        return result;
     }
     return REDIS_ERR;
 }
@@ -650,6 +652,8 @@ static int cliSendCommand(int argc, char **argv, int repeat) {
             if (!strcasecmp(command,"select") && argc == 2) {
                 config.dbnum = atoi(argv[1]);
                 cliRefreshPrompt();
+            } else if (!strcasecmp(command,"auth") && argc == 2) {
+                cliSelect();
             }
         }
         if (config.interval) usleep(config.interval);


### PR DESCRIPTION
Fixes previous incorrect behavior:

``` haskell
redis-cli -n 9
AUTH
[operations act on DB 0 because SELECT didn't get re-run]
```

Also fixes error where selecting an invalid DB (`-1`, `9999999`) showed up in the CLI (#1313)

Fixes antirez#1639 and #1313
