### PR TITLE
Fix 9 warnings about type specifiers under Linux

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1173,8 +1173,8 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                 {
                     redisLog(REDIS_WARNING,
                         "I received an update for slot %d. "
-                        "%.40s claims it with config %llu, "
-                        "I've it assigned to myself with config %llu. "
+                        "%.40s claims it with config %"PRIu64", "
+                        "I've it assigned to myself with config %"PRIu64". "
                         "I've still keys about this slot! "
                         "Putting the slot in IMPORTING state. "
                         "Please run the 'redis-trib fix' command.",

--- a/src/redis.c
+++ b/src/redis.c
@@ -1540,25 +1540,25 @@ void adjustOpenFilesLimit(void) {
                 server.maxclients = f-REDIS_MIN_RESERVED_FDS;
                 if (server.maxclients < 1) {
                     redisLog(REDIS_WARNING,"Your current 'ulimit -n' "
-                        "of %llu is not enough for Redis to start. "
+                        "of %"PRIu64" is not enough for Redis to start. "
                         "Please increase your open file limit to at least "
-                        "%llu. Exiting.", oldlimit, maxfiles);
+                        "%"PRIu64". Exiting.", oldlimit, maxfiles);
                     exit(1);
                 }
                 redisLog(REDIS_WARNING,"You requested maxclients of %d "
-                    "requiring at least %llu max file descriptors.",
+                    "requiring at least %"PRIu64" max file descriptors.",
                     old_maxclients, maxfiles);
                 redisLog(REDIS_WARNING,"Redis can't set maximum open files "
-                    "to %llu because of OS error: %s.",
+                    "to %"PRIu64" because of OS error: %s.",
                     maxfiles, strerror(setrlimit_error));
-                redisLog(REDIS_WARNING,"Current maximum open files is %llu. "
-                    "maxclients has been reduced to %d to compensate for "
-                    "low ulimit. "
+                redisLog(REDIS_WARNING,"Current maximum open files is "
+                    "%"PRIu64". maxclients has been reduced to %d to "
+                    "compensate for low ulimit. "
                     "If you need higher maxclients increase 'ulimit -n'.",
                     oldlimit, server.maxclients);
             } else {
                 redisLog(REDIS_NOTICE,"Increased maximum number of open files "
-                    "to %llu (it was originally set to %llu).",
+                    "to %"PRIu64" (it was originally set to %"PRIu64").",
                     maxfiles, oldlimit);
             }
         }


### PR DESCRIPTION
Under some 64-bit Linux, 64-bit types are unsigned long.
Under 64-bit OS X and some other Linux, 64-bit types are unsigned long long.

This makes manually specifying format types impossible unless you
cast or use system-provided specifiers.

Let's use the system provided C99 format type specifier abstraction so
the system provides `%lu` or `%llu` depending on what works on that system.

Before this patch, `unstable` fails `gcc` and `clang` `-Werror` compiles: https://travis-ci.org/mattsta/redis/builds/21894346

Using this patch, the warnings go away and all tests pass now: https://travis-ci.org/mattsta/redis/builds/21896098
