### PR TITLE
Deny sort command with store parameter when instance is cluster mode

### DIFF
--- a/src/sort.c
+++ b/src/sort.c
@@ -242,6 +242,11 @@ void sortCommand(redisClient *c) {
             }
             j+=2;
         } else if (!strcasecmp(c->argv[j]->ptr,"store") && leftargs >= 1) {
+            if (server.cluster_enabled) {
+                addReplyError(c,"store option of SORT denied in Cluster mode.");
+                syntax_error++;
+                break;
+            }
             storekey = c->argv[j+1];
             j++;
         } else if (!strcasecmp(c->argv[j]->ptr,"by") && leftargs >= 1) {


### PR DESCRIPTION
It fixes #1645.

Actually it's more natural to throw CROSSSLOT if store parameter's key should stored to other node.
But I respect previous thing, "deny sort parameters related to multi key", and it's very easy to implement.

Please review and comment! Thanks!
