### PR TITLE
Add matrix datatype

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -107,7 +107,7 @@ endif
 
 REDIS_SERVER_NAME=redis-server
 REDIS_SENTINEL_NAME=redis-sentinel
-REDIS_SERVER_OBJ=adlist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o
+REDIS_SERVER_OBJ=adlist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o matrix.o t_matrix.o
 REDIS_CLI_NAME=redis-cli
 REDIS_CLI_OBJ=anet.o sds.o adlist.o redis-cli.o zmalloc.o release.o anet.o ae.o crc64.o
 REDIS_BENCHMARK_NAME=redis-benchmark

--- a/src/Makefile.dep
+++ b/src/Makefile.dep
@@ -116,6 +116,9 @@ t_set.o: t_set.c redis.h fmacros.h config.h ../deps/lua/src/lua.h \
 t_string.o: t_string.c redis.h fmacros.h config.h ../deps/lua/src/lua.h \
  ../deps/lua/src/luaconf.h ae.h sds.h dict.h adlist.h zmalloc.h anet.h \
  ziplist.h intset.h version.h util.h rdb.h rio.h
+t_matrix.o: t_matrix.c redis.h fmacros.h config.h ../deps/lua/src/lua.h \
+ ../deps/lua/src/luaconf.h ae.h sds.h dict.h adlist.h zmalloc.h anet.h \
+ ziplist.h intset.h version.h util.h rdb.h rio.h matrix.h
 t_zset.o: t_zset.c redis.h fmacros.h config.h ../deps/lua/src/lua.h \
  ../deps/lua/src/luaconf.h ae.h sds.h dict.h adlist.h zmalloc.h anet.h \
  ziplist.h intset.h version.h util.h rdb.h rio.h

--- a/src/db.c
+++ b/src/db.c
@@ -621,6 +621,7 @@ void typeCommand(redisClient *c) {
         case REDIS_SET: type = "set"; break;
         case REDIS_ZSET: type = "zset"; break;
         case REDIS_HASH: type = "hash"; break;
+        case REDIS_MATRIX: type = "matrix"; break;
         default: type = "unknown"; break;
         }
     }

--- a/src/matrix.c
+++ b/src/matrix.c
@@ -1,0 +1,126 @@
+#include "matrix.h"
+#include "zmalloc.h"
+#include <stdio.h>
+#include <string.h>
+
+long long reshapedIndex(matrix *m, long long index[]) {
+    long long idx = 0;
+
+    for (int i = 0; i < m->dims; i++) {
+        idx += index[i];
+
+        if (i < m->dims-1)
+            idx *= m->shape[i+1];
+    }
+    return idx;
+}
+
+void matrixPrint(matrix *m) {
+    long long i;
+    printf("dims:\t%lld\n", m->dims);
+
+    printf("shape:\t[ ");
+    for (i = 0; i<m->dims; i++) {
+        printf("%lld ", m->shape[i]);
+    }
+    printf("]\n");
+
+    printf("values:\t[ ");
+    for (i = 0; i < m->size; i++) {
+        printf("%f ", m->values[i]->value);
+    }
+    printf("]\n");
+}
+
+matrix *matrixZero(long long dims, long long shape[]) {
+    int i;
+    matrix *matrix = matrixCreate(dims, shape);
+
+    for (i = 0; i < matrix->size; i++) {
+        matrix->values[i] = zmalloc(sizeof(scalar));
+        matrix->values[i]->value = 0.0;
+        matrix->values[i]->reference_count = 1;
+    }
+    return matrix;
+}
+
+matrix *matrixCreate(long long dims, long long shape[]) {
+    struct matrix *matrix;
+    int i;
+
+    if ((matrix = zmalloc(sizeof(*matrix))) == NULL)
+        return NULL;
+
+    matrix->dims = dims;
+
+    if ((matrix->shape = zmalloc(dims * sizeof(long long))) == NULL)
+        return NULL;
+    memcpy(matrix->shape, shape, dims * sizeof(long long));
+
+    matrix->size = 1;
+
+    for (i = 0; i < dims; i++) matrix->size *= shape[i];
+
+    if ((matrix->values = zmalloc(matrix->size * sizeof(scalar *))) == NULL)
+        return NULL;
+
+    return matrix;
+}
+
+matrix *matrixSlice(matrix *m, long long dims, long long *index) {
+    long long i, j, begin = 1, end = 0, stride = 1, newdims = 0;
+    long long beg_idx[dims], end_idx[dims], newshape[dims];
+    matrix *sub;
+
+    for (i = 0; i < dims; i++) {
+        if (index[i] == -1) {
+            newshape[newdims++] = m->shape[i];
+            beg_idx[i] = 0;
+            end_idx[i] = m->shape[i] - 1;
+        } else {
+            stride += i * (m->shape[i] - 1);
+            beg_idx[i] = index[i];
+            end_idx[i] = index[i];
+        }
+    }
+
+    sub = matrixCreate(newdims, newshape);
+
+    begin = reshapedIndex(m, beg_idx);
+    end = reshapedIndex(m, end_idx);
+
+    for (i = begin, j = 0; i <= end; i += stride, j++) {
+        scalarRetain(sub->values[j] = m->values[i]);
+    }
+
+    return sub;
+}
+
+void matrixFree(matrix *matrix) {
+    int i;
+    for (i = 0; i < matrix->size; i++) {
+        scalarRelease(matrix->values[i]);
+    }
+    zfree(matrix->values);
+    zfree(matrix->shape);
+    zfree(matrix);
+}
+
+void scalarRelease(scalar *scalar) {
+    if (scalar->reference_count <= 0) printf("scalarRelease against refcount <= 0");
+    if (scalar->reference_count == 1) zfree(scalar);
+    else --scalar->reference_count;
+}
+
+void scalarRetain(scalar *scalar) {
+    ++scalar->reference_count;
+}
+
+int matrixSetValues(matrix *matrix, double value, int stride) {
+    long long i;
+
+    for (i = 0; i < matrix->size; i += stride) {
+        matrix->values[i]->value = value;
+    }
+    return 1; // TODO: error handling
+}

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -1,0 +1,25 @@
+#ifndef __MATRIX_H__
+#define __MATRIX_H__
+
+typedef struct scalar {
+  double value;
+  int reference_count;
+} scalar;
+
+typedef struct matrix {
+    long long dims;
+    long long *shape;
+    long long size;
+    scalar **values;
+} matrix;
+
+matrix *matrixZero(long long dims, long long shape[]);
+matrix *matrixCreate(long long dims, long long shape[]);
+void matrixFree(matrix *matrix);
+void matrixPrint(matrix *m);
+matrix *matrixSlice(matrix *matrix, long long dims, long long index[]);
+void scalarRelease(scalar *scalar);
+void scalarRetain(scalar *scalar);
+int matrixSetValues(matrix *m, double value, int stride);
+
+#endif /* __MATRIX_H__ */

--- a/src/networking.c
+++ b/src/networking.c
@@ -540,6 +540,20 @@ void addReplyBulkLongLong(redisClient *c, long long ll) {
     addReplyBulkCBuffer(c,buf,len);
 }
 
+/* Add a double as a bulk reply */
+void addReplyBulkDouble(redisClient *c, double d) {
+    char dbuf[128];
+    int slen;
+    if (isinf(d)) {
+        /* Libc in odd systems (Hi Solaris!) will format infinite in a
+         * different way, so better to handle it in an explicit way. */
+        addReplyBulkCString(c, d > 0 ? "inf" : "-inf");
+    } else {
+        slen = snprintf(dbuf,sizeof(dbuf),"%.17g",d);
+        addReplyBulkCBuffer(c,dbuf,slen);
+    }
+}
+
 /* Copy 'src' client output buffers into 'dst' client output buffers.
  * The function takes care of freeing the old output buffers of the
  * destination client. */

--- a/src/object.c
+++ b/src/object.c
@@ -170,6 +170,17 @@ robj *createZiplistObject(void) {
     return o;
 }
 
+robj *createMatrixObject(long long dims, long long shape[]) {
+    matrix *m = matrixZero(dims, shape);
+    robj *o = createObject(REDIS_MATRIX,m);
+    o->encoding = REDIS_ENCODING_MATRIX;
+    return o;
+}
+
+void freeMatrixObject(robj *o) {
+    matrixFree(o->ptr);
+}
+
 robj *createSetObject(void) {
     dict *d = dictCreate(&setDictType,NULL);
     robj *o = createObject(REDIS_SET,d);
@@ -285,6 +296,7 @@ void decrRefCount(robj *o) {
         case REDIS_SET: freeSetObject(o); break;
         case REDIS_ZSET: freeZsetObject(o); break;
         case REDIS_HASH: freeHashObject(o); break;
+        case REDIS_MATRIX: freeMatrixObject(o); break;
         default: redisPanic("Unknown object type"); break;
         }
         zfree(o);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -74,6 +74,7 @@
 #define REDIS_RDB_TYPE_SET    2
 #define REDIS_RDB_TYPE_ZSET   3
 #define REDIS_RDB_TYPE_HASH   4
+#define REDIS_RDB_TYPE_MATRIX 5
 
 /* Object types for encoded objects. */
 #define REDIS_RDB_TYPE_HASH_ZIPMAP    9
@@ -83,7 +84,7 @@
 #define REDIS_RDB_TYPE_HASH_ZIPLIST  13
 
 /* Test if a type is an object type. */
-#define rdbIsObjectType(t) ((t >= 0 && t <= 4) || (t >= 9 && t <= 13))
+#define rdbIsObjectType(t) ((t >= 0 && t <= 5) || (t >= 9 && t <= 13))
 
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
 #define REDIS_RDB_OPCODE_EXPIRETIME_MS 252

--- a/src/redis.c
+++ b/src/redis.c
@@ -276,7 +276,9 @@ struct redisCommand redisCommandTable[] = {
     {"pfmerge",pfmergeCommand,-2,"wm",0,NULL,1,-1,1,0,0},
     {"pfgetreg",pfgetregCommand,2,"r",0,NULL,0,0,0,0,0},
     {"xget",xgetCommand,-3,"r",0,NULL,1,1,1,0,0},
-    {"xset",xsetCommand,-4,"wm",0,NULL,1,1,1,0,0}
+    {"xset",xsetCommand,-4,"wm",0,NULL,1,1,1,0,0},
+    {"xzeros",xzerosCommand,-3,"wm",0,NULL,1,1,1,0,0},
+    {"xones",xonesCommand,-3,"wm",0,NULL,1,1,1,0,0}
 };
 
 struct evictionPoolEntry *evictionPoolAlloc(void);

--- a/src/redis.c
+++ b/src/redis.c
@@ -278,7 +278,8 @@ struct redisCommand redisCommandTable[] = {
     {"xget",xgetCommand,-3,"r",0,NULL,1,1,1,0,0},
     {"xset",xsetCommand,-4,"wm",0,NULL,1,1,1,0,0},
     {"xzeros",xzerosCommand,-3,"wm",0,NULL,1,1,1,0,0},
-    {"xones",xonesCommand,-3,"wm",0,NULL,1,1,1,0,0}
+    {"xones",xonesCommand,-3,"wm",0,NULL,1,1,1,0,0},
+    {"xeye",xeyeCommand,4,"wm",0,NULL,1,1,1,0,0},
 };
 
 struct evictionPoolEntry *evictionPoolAlloc(void);

--- a/src/redis.c
+++ b/src/redis.c
@@ -274,7 +274,9 @@ struct redisCommand redisCommandTable[] = {
     {"pfadd",pfaddCommand,-2,"wm",0,NULL,1,1,1,0,0},
     {"pfcount",pfcountCommand,2,"w",0,NULL,1,1,1,0,0},
     {"pfmerge",pfmergeCommand,-2,"wm",0,NULL,1,-1,1,0,0},
-    {"pfgetreg",pfgetregCommand,2,"r",0,NULL,0,0,0,0,0}
+    {"pfgetreg",pfgetregCommand,2,"r",0,NULL,0,0,0,0,0},
+    {"xget",xgetCommand,-3,"r",0,NULL,1,1,1,0,0},
+    {"xset",xsetCommand,-4,"wm",0,NULL,1,1,1,0,0}
 };
 
 struct evictionPoolEntry *evictionPoolAlloc(void);

--- a/src/redis.h
+++ b/src/redis.h
@@ -974,6 +974,7 @@ void addReplyBulk(redisClient *c, robj *obj);
 void addReplyBulkCString(redisClient *c, char *s);
 void addReplyBulkCBuffer(redisClient *c, void *p, size_t len);
 void addReplyBulkLongLong(redisClient *c, long long ll);
+void addReplyBulkDouble(redisClient *c, double d);
 void acceptHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void addReply(redisClient *c, robj *obj);
 void addReplySds(redisClient *c, sds s);

--- a/src/redis.h
+++ b/src/redis.h
@@ -55,6 +55,7 @@
 #include "sds.h"     /* Dynamic safe strings */
 #include "dict.h"    /* Hash tables */
 #include "adlist.h"  /* Linked lists */
+#include "matrix.h"  /* Matrices */
 #include "zmalloc.h" /* total memory usage aware version of malloc/free */
 #include "anet.h"    /* Networking the easy way */
 #include "ziplist.h" /* Compact list data structure */

--- a/src/redis.h
+++ b/src/redis.h
@@ -1472,6 +1472,7 @@ void xgetCommand(redisClient *c);
 void xsetCommand(redisClient *c);
 void xzerosCommand(redisClient *c);
 void xonesCommand(redisClient *c);
+void xeyeCommand(redisClient *c);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));

--- a/src/redis.h
+++ b/src/redis.h
@@ -1470,6 +1470,8 @@ void pfmergeCommand(redisClient *c);
 void pfgetregCommand(redisClient *c);
 void xgetCommand(redisClient *c);
 void xsetCommand(redisClient *c);
+void xzerosCommand(redisClient *c);
+void xonesCommand(redisClient *c);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));

--- a/src/redis.h
+++ b/src/redis.h
@@ -170,6 +170,7 @@
 #define REDIS_SET 2
 #define REDIS_ZSET 3
 #define REDIS_HASH 4
+#define REDIS_MATRIX 5
 
 /* Objects encoding. Some kind of objects like Strings and Hashes can be
  * internally represented in multiple ways. The 'encoding' field of the object
@@ -183,6 +184,7 @@
 #define REDIS_ENCODING_INTSET 6  /* Encoded as intset */
 #define REDIS_ENCODING_SKIPLIST 7  /* Encoded as skiplist */
 #define REDIS_ENCODING_EMBSTR 8  /* Embedded sds string encoding */
+#define REDIS_ENCODING_MATRIX 9
 
 /* Defines related to the dump file format. To store 32 bits lengths for short
  * keys requires a lot of space, so we check the most significant 2 bits of
@@ -363,7 +365,8 @@
 #define REDIS_NOTIFY_ZSET (1<<7)        /* z */
 #define REDIS_NOTIFY_EXPIRED (1<<8)     /* x */
 #define REDIS_NOTIFY_EVICTED (1<<9)     /* e */
-#define REDIS_NOTIFY_ALL (REDIS_NOTIFY_GENERIC | REDIS_NOTIFY_STRING | REDIS_NOTIFY_LIST | REDIS_NOTIFY_SET | REDIS_NOTIFY_HASH | REDIS_NOTIFY_ZSET | REDIS_NOTIFY_EXPIRED | REDIS_NOTIFY_EVICTED)      /* A */
+#define REDIS_NOTIFY_MATRIX (1<<10)     /* e */
+#define REDIS_NOTIFY_ALL (REDIS_NOTIFY_GENERIC | REDIS_NOTIFY_STRING | REDIS_NOTIFY_LIST | REDIS_NOTIFY_SET | REDIS_NOTIFY_HASH | REDIS_NOTIFY_ZSET | REDIS_NOTIFY_EXPIRED | REDIS_NOTIFY_EVICTED | REDIS_NOTIFY_MATRIX)      /* A */
 
 /* Using the following macro you can run code inside serverCron() with the
  * specified period, specified in milliseconds.
@@ -1052,6 +1055,7 @@ void freeListObject(robj *o);
 void freeSetObject(robj *o);
 void freeZsetObject(robj *o);
 void freeHashObject(robj *o);
+void freeMatrixObject(robj *o);
 robj *createObject(int type, void *ptr);
 robj *createStringObject(char *ptr, size_t len);
 robj *createRawStringObject(char *ptr, size_t len);
@@ -1070,6 +1074,7 @@ robj *createIntsetObject(void);
 robj *createHashObject(void);
 robj *createZsetObject(void);
 robj *createZsetZiplistObject(void);
+robj *createMatrixObject(long long size, long long *shape);
 int getLongFromObjectOrReply(redisClient *c, robj *o, long *target, const char *msg);
 int checkType(redisClient *c, robj *o, int type);
 int getLongLongFromObjectOrReply(redisClient *c, robj *o, long long *target, const char *msg);
@@ -1463,6 +1468,8 @@ void pfaddCommand(redisClient *c);
 void pfcountCommand(redisClient *c);
 void pfmergeCommand(redisClient *c);
 void pfgetregCommand(redisClient *c);
+void xgetCommand(redisClient *c);
+void xsetCommand(redisClient *c);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));

--- a/src/t_matrix.c
+++ b/src/t_matrix.c
@@ -1,0 +1,105 @@
+#include "redis.h"
+
+void addReplyMatrixShape(redisClient *c, matrix *matrix) {
+    addReplyMultiBulkLen(c,matrix->dims);
+    for (int i = 0; i < matrix->dims; i++) {
+        addReplyBulkLongLong(c,matrix->shape[i]);
+    }
+}
+
+void addReplyMatrixContent(redisClient *c, matrix *m) {
+    long long i, size = 1, reply_length = 1 + m->dims;
+
+    for (i = 0; i < m->dims; i++) {
+        size *= m->shape[i];
+    }
+
+    reply_length += size;
+
+    addReplyMultiBulkLen(c,reply_length);
+    addReplyBulkLongLong(c,m->dims);
+
+    for (i = 0; i < m->dims; i++) {
+        addReplyBulkLongLong(c,m->shape[i]);
+    }
+
+    for (i = 0; i < size; i++) {
+        addReplyBulkDouble(c,m->values[i]->value);
+    }
+}
+
+void xgetCommand(redisClient *c) {
+    robj *xobj = lookupKeyWrite(c->db,c->argv[1]);
+    long long dims = 0;
+    dims = (long long)c->argc - 2;
+    long long index[dims];
+
+    if (!xobj) {
+        addReply(c,shared.nokeyerr);
+        return;
+    }
+
+    if (xobj && xobj->type != REDIS_MATRIX) {
+        addReply(c,shared.wrongtypeerr);
+        return;
+    }
+
+    matrix *m = xobj->ptr;
+
+    if (dims > m->dims) {
+        addReply(c,shared.outofrangeerr);
+        return;
+    }
+
+    for (int j = 0; j < dims; j++) {
+        getLongLongFromObjectOrReply(c,c->argv[j+2],&index[j],NULL);
+    }
+
+    matrix *sub = matrixSlice(m, dims, index);
+
+    addReplyMatrixContent(c,sub);
+    matrixFree(sub);
+}
+
+void xsetCommand(redisClient *c) {
+    long long dims = c->argc - 3;
+    long long index[dims], shape[dims];
+    double value;
+
+    getDoubleFromObjectOrReply(c,c->argv[c->argc-1],&value,NULL);
+
+    for (int j = 0; j < dims; j++) {
+        getLongLongFromObjectOrReply(c,c->argv[j+2],&index[j],NULL);
+        shape[j] = index[j]+1;
+    }
+
+    robj *xobj = lookupKeyWrite(c->db,c->argv[1]);
+
+    if (xobj && xobj->type != REDIS_MATRIX) {
+        addReply(c,shared.wrongtypeerr);
+        return;
+    }
+
+    if (!xobj) {
+        xobj = createMatrixObject(dims,shape);
+        dbAdd(c->db,c->argv[1],xobj);
+        incrRefCount(xobj);
+    }
+
+    matrix *m = xobj->ptr;
+
+    if (dims > m->dims) {
+        addReply(c,shared.outofrangeerr);
+        return;
+    }
+
+    matrix *sub = matrixSlice(m, dims, index);
+
+    matrixSetValues(sub,value,1);
+
+    notifyKeyspaceEvent(REDIS_NOTIFY_MATRIX,"xset",c->argv[1],c->db->id);
+    server.dirty += 1;
+
+    addReplyMatrixShape(c,m);
+    matrixFree(sub);
+}

--- a/src/t_matrix.c
+++ b/src/t_matrix.c
@@ -139,3 +139,10 @@ void xzerosCommand(redisClient *c) {
 void xonesCommand(redisClient *c) {
   createMatrixGenericCommand(c,1,1);
 }
+
+void xeyeCommand(redisClient *c) {
+  long long size;
+  getLongLongFromObjectOrReply(c,c->argv[2],&size,NULL);
+
+  createMatrixGenericCommand(c,1,size + 1);
+}

--- a/src/t_matrix.c
+++ b/src/t_matrix.c
@@ -1,7 +1,8 @@
 #include "redis.h"
 
 void addReplyMatrixShape(redisClient *c, matrix *matrix) {
-    addReplyMultiBulkLen(c,matrix->dims);
+    addReplyMultiBulkLen(c,matrix->dims + 1);
+    addReplyBulkLongLong(c,matrix->dims);
     for (int i = 0; i < matrix->dims; i++) {
         addReplyBulkLongLong(c,matrix->shape[i]);
     }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -24,6 +24,7 @@ set ::all_tests {
     unit/type/set
     unit/type/zset
     unit/type/hash
+    unit/type/matrix
     unit/sort
     unit/expire
     unit/other

--- a/tests/unit/type/matrix.tcl
+++ b/tests/unit/type/matrix.tcl
@@ -1,0 +1,14 @@
+start_server {
+    tags {"matrix"}
+} {
+
+    test {XSET} {
+        assert_equal {2 2} [r xset xsetmat1 1 1 3]
+        assert_equal {100 100 3} [r xset xsetmat2 99 99 2 255]
+    }
+
+    test {XGET} {
+        assert_equal {4 4} [r xset xgetmat 3 3 1]
+        assert_equal {2 4 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1} [r xget xgetmat -1 -1]
+    }
+}

--- a/tests/unit/type/matrix.tcl
+++ b/tests/unit/type/matrix.tcl
@@ -21,4 +21,9 @@ start_server {
       assert_equal {4 4} [r xones xonesmat 4 4]
       assert_equal {2 4 4 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1} [r xget xonesmat -1 -1]
     }
+
+    test {XEYE} {
+      assert_equal {4 4} [r xeye identitymat 4 4]
+      assert_equal {2 4 4 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1} [r xget identitymat -1 -1]
+    }
 }

--- a/tests/unit/type/matrix.tcl
+++ b/tests/unit/type/matrix.tcl
@@ -11,4 +11,14 @@ start_server {
         assert_equal {4 4} [r xset xgetmat 3 3 1]
         assert_equal {2 4 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1} [r xget xgetmat -1 -1]
     }
+
+    test {XZEROS} {
+      assert_equal {4 4} [r xzeros xzerosmat 4 4]
+      assert_equal {2 4 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0} [r xget xzerosmat -1 -1]
+    }
+
+    test {XONES} {
+      assert_equal {4 4} [r xones xonesmat 4 4]
+      assert_equal {2 4 4 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1} [r xget xonesmat -1 -1]
+    }
 }

--- a/tests/unit/type/matrix.tcl
+++ b/tests/unit/type/matrix.tcl
@@ -3,27 +3,27 @@ start_server {
 } {
 
     test {XSET} {
-        assert_equal {2 2} [r xset xsetmat1 1 1 3]
-        assert_equal {100 100 3} [r xset xsetmat2 99 99 2 255]
+        assert_equal {2 2 2} [r xset xsetmat1 1 1 3]
+        assert_equal {3 100 100 3} [r xset xsetmat2 99 99 2 255]
     }
 
     test {XGET} {
-        assert_equal {4 4} [r xset xgetmat 3 3 1]
+        assert_equal {2 4 4} [r xset xgetmat 3 3 1]
         assert_equal {2 4 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1} [r xget xgetmat -1 -1]
     }
 
     test {XZEROS} {
-      assert_equal {4 4} [r xzeros xzerosmat 4 4]
+      assert_equal {2 4 4} [r xzeros xzerosmat 4 4]
       assert_equal {2 4 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0} [r xget xzerosmat -1 -1]
     }
 
     test {XONES} {
-      assert_equal {4 4} [r xones xonesmat 4 4]
+      assert_equal {2 4 4} [r xones xonesmat 4 4]
       assert_equal {2 4 4 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1} [r xget xonesmat -1 -1]
     }
 
     test {XEYE} {
-      assert_equal {4 4} [r xeye identitymat 4 4]
+      assert_equal {2 4 4} [r xeye identitymat 4 4]
       assert_equal {2 4 4 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1} [r xget identitymat -1 -1]
     }
 }


### PR DESCRIPTION
:warning: Work in progress
- Adds support for n-dimensional double arrays
- Supports RDB persistence
- Adds commands
  - XSET KEY INDEX[ INDEX[ ...]] VALUE - sets values in subregion selected by index, creates matrix at KEY with dimensions based on INDEX if doesn't exist
  - XGET KEY INDEX[ INDEX[ ...]] - returns subregion selected by INDEX, -1 for any dimension index means "entire dimension"
  - XZEROS KEY SHAPE [SHAPE [...]] - creates a zero-valued nd array
  - XONES KEY SHAPE [SHAPE [...]] - creates a one-valued nd array
  - XEYE KEY SIZE - creates a 2d identity matrix of size SIZE
- Would like to add basic linear algebra commands
  - XSCALE matrixkey SCALAR [newmatrix]
  - XDOT matrixkeya matrixkeyb [newmatrix]
  - etc…

Examples:

```
redis 127.0.0.1:6379> xzeros mat 3 3
1) "2"
2) "3"
3) "3"
redis 127.0.0.1:6379> xget mat -1 -1
 1) "2"
 2) "3"
 3) "3"
 4) "0"
 5) "0"
 6) "0"
 7) "0"
 8) "0"
 9) "0"
10) "0"
11) "0"
12) "0"
redis 127.0.0.1:6379> xset mat -1 0 1
1) "2"
2) "3"
3) "3"
redis 127.0.0.1:6379> xget mat -1 -1
 1) "2"
 2) "3"
 3) "3"
 4) "1"
 5) "0"
 6) "0"
 7) "1"
 8) "0"
 9) "0"
10) "1"
11) "0"
12) "0"
redis 127.0.0.1:6379> xget mat -1 0
1) "1"
2) "3"
3) "1"
4) "1"
5) "1"
redis 127.0.0.1:6379> xget mat 0 -1
1) "1"
2) "3"
3) "1"
4) "0"
5) "0"
```

```
redis 127.0.0.1:6379> xeye identitymat 2 2
1) "2"
2) "2"
3) "2"
redis 127.0.0.1:6379> xget identitymat -1 -1
1) "2"
2) "2"
3) "2"
4) "1"
5) "0"
6) "0"
7) "1"
```

Closes #370
