### PR TITLE
fix null pointer access with no file pointer

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -402,7 +402,8 @@ void getRandomHexChars(char *p, unsigned int len) {
     /* Turn it into hex digits taking just 4 bits out of 8 for every byte. */
     for (j = 0; j < len; j++)
         p[j] = charset[p[j] & 0x0F];
-    fclose(fp);
+    if (fp)
+        fclose(fp);
 }
 
 /* Given the filename, return the absolute path as an SDS string, or NULL


### PR DESCRIPTION
I happen to be working on a system that lacks urandom. While the code does try
to handle this case and artificially create some bytes if the file pointer is
empty, it does try to close it unconditionally, leading to a segfault.

Closes #1671
