### PR TITLE
Check key expiration before deleting

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -280,6 +280,7 @@ void delCommand(redisClient *c) {
     int deleted = 0, j;
 
     for (j = 1; j < c->argc; j++) {
+        expireIfNeeded(c->db,c->argv[j]);
         if (dbDelete(c->db,c->argv[j])) {
             signalModifiedKey(c->db,c->argv[j]);
             notifyKeyspaceEvent(REDIS_NOTIFY_GENERIC,

--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -261,6 +261,14 @@ start_server {tags {"basic"}} {
         assert_equal 20 [r get x]
     }
 
+    test "DEL against expired key" {
+        r debug set-active-expire 0
+        r setex keyExpire 1 valExpire
+        after 1100
+        assert_equal 0 [r del keyExpire]
+        r debug set-active-expire 1
+    }
+
     test {EXISTS} {
         set res {}
         r set newkey test


### PR DESCRIPTION
Deleting an expired key should return 0, not success.

Fixes #1648

With active expiration, most keys on a lightly used server _will_ expire soon after their expiration time.  Only on loaded servers or servers with manually disabled active expiration (via debug) will the problem of successfully deleting keys that shouldn't exist show itself.
