### PR TITLE
Replicate readonly scripts with SCRIPT LOAD.

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -960,6 +960,18 @@ void evalGenericCommand(redisClient *c, int evalsha) {
             rewriteClientCommandArgument(c,1,script);
             forceCommandPropagation(c,REDIS_PROPAGATE_REPL|REDIS_PROPAGATE_AOF);
         }
+    } else if (!server.lua_write_dirty &&
+               !replicationScriptCacheExists(c->argv[1]->ptr)) {
+        robj *script = createStringObject("SCRIPT", 6);
+        robj *load = createStringObject("LOAD", 4);
+
+        /* Rewrite as SCRIPT LOAD.  Note that SHA1 expansion has already
+         * been done here.
+         */
+        rewriteClientCommandVector(c, 3, script, load, c->argv[1]);
+        decrRefCount(script);
+        decrRefCount(load);
+        forceCommandPropagation(c,REDIS_PROPAGATE_REPL|REDIS_PROPAGATE_AOF);
     }
 }
 

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -429,5 +429,14 @@ start_server {tags {"scripting repl"}} {
                 fail "Expected 1 in x, but value is '[r -1 get x]'"
             }
         }
+
+        test {readonly EVAL is replicated to slaves} {
+            r eval {return 100} 0
+            wait_for_condition 50 100 {
+                [r -1 script exists 22cd37f569ce84333afb93ba232d04d5aa6bb87a] eq {1}
+            } else {
+                fail "Script never replicated to slave"
+            }
+        }
     }
 }


### PR DESCRIPTION
There is an inconsistency in the way read-only scripts are replicated:
- On EVAL, a script won't be replicated if it's read-only.
- On EVALSHA it will always be replicated unless it's already in the replication cache (i.e. known to be replicated).

In the following sequence, the EVALSHA on the slave fails:

```
master> EVAL <some readonly script>
slave> EVALSHA <sha1 of script>
```

In the following sequence, it will succeed:

```
master> EVAL <some readonly script>
master> EVALSHA <sha1 of script>
slave> EVALSHA <sha1 of script>
```

The proposed solution is to simply use SCRIPT LOAD on read-only EVAL if the script was not previously cached.
