### PR TITLE
Default unixsocketperm changed from 755 to 700, to be less confusing.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -68,7 +68,7 @@ tcp-backlog 511
 # on a unix socket when not specified.
 #
 # unixsocket /tmp/redis.sock
-# unixsocketperm 755
+# unixsocketperm 700
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout 0


### PR DESCRIPTION
According to manuals "Connecting to the socket object requires
read/write permission."
http://man7.org/linux/man-pages/man7/unix.7.html

Permissions 0755 are confusing.
