### PR TITLE
fix cluster node description showing wrong slot allocation

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3131,7 +3131,7 @@ sds clusterGenNodeDescription(clusterNode *node) {
             if (start == -1) start = j;
         }
         if (start != -1 && (!bit || j == REDIS_CLUSTER_SLOTS-1)) {
-            if (j == REDIS_CLUSTER_SLOTS-1) j++;
+            if (bit && j == REDIS_CLUSTER_SLOTS-1) j++;
 
             if (start == j-1) {
                 ci = sdscatprintf(ci," %d",start);


### PR DESCRIPTION
The 'cluster nodes' command shows wrong slot allocation if we have the following slot distribution:
master-a: 0-16382
master-b: 16383
Current output:
master-a: 0-16383
master-b: 16383
(both nodes showing 16383!)

See also: https://gist.github.com/kingsumos/11185353
