### PR TITLE
Can't stop Redis when configured with a password

### DIFF
--- a/utils/redis_init_script.tpl
+++ b/utils/redis_init_script.tpl
@@ -15,7 +15,7 @@ case "$1" in
             echo "$PIDFILE does not exist, process is not running"
         else
             PID=$(cat $PIDFILE)
-            AUTH=$(grep "^requirepass" $CONF | cut -d " " -f 2)
+            AUTH=$(grep -Po "^requirepass +\K[^ ]*" $CONF)
             if [ "$AUTH" != "" ]
             then
                 AUTH="-a $AUTH"

--- a/utils/redis_init_script.tpl
+++ b/utils/redis_init_script.tpl
@@ -15,8 +15,13 @@ case "$1" in
             echo "$PIDFILE does not exist, process is not running"
         else
             PID=$(cat $PIDFILE)
+            AUTH=$(grep "^requirepass" $CONF | cut -d " " -f 2)
+            if [ "$AUTH" != "" ]
+            then
+                AUTH="-a $AUTH"
+            fi
             echo "Stopping ..."
-            $CLIEXEC -p $REDISPORT shutdown
+            $CLIEXEC -p $REDISPORT $AUTH shutdown
             while [ -x /proc/${PID} ]
             do
                 echo "Waiting for Redis to shutdown ..."


### PR DESCRIPTION
This fix adds authentication to the stop verb (if configured in the conf file). Without this, the server (i.e. my VM) won't shutdown as it keeps waiting for Redis to stop. 

An alternative approach would be to sigterm the process but I didn't want to change the current logic too much.
