### PR TITLE
Reduce rdb loading time

### DIFF
--- a/src/rdb.h
+++ b/src/rdb.h
@@ -86,7 +86,6 @@
 #define rdbIsObjectType(t) ((t >= 0 && t <= 4) || (t >= 9 && t <= 13))
 
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
-#define REDIS_RDB_OPCODE_DB_DICT_SIZE 251
 #define REDIS_RDB_OPCODE_EXPIRETIME_MS 252
 #define REDIS_RDB_OPCODE_EXPIRETIME 253
 #define REDIS_RDB_OPCODE_SELECTDB   254

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -86,6 +86,7 @@
 #define rdbIsObjectType(t) ((t >= 0 && t <= 4) || (t >= 9 && t <= 13))
 
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
+#define REDIS_RDB_OPCODE_DB_DICT_SIZE 251
 #define REDIS_RDB_OPCODE_EXPIRETIME_MS 252
 #define REDIS_RDB_OPCODE_EXPIRETIME 253
 #define REDIS_RDB_OPCODE_SELECTDB   254


### PR DESCRIPTION
when saving rdb, save db dict size also.
when loading rdb, load db dict size and expand db dict with this dict
size value.
so avoid several db dict table expansion & rehash while loading datas.
because of rdb file compatibility, added new rdb opcode RDB_OPCODE_DB_DICT_SIZE

test result

data count : 9,463,389   (with 'set' command only)
rdb file size : 312,382,550 bytes

before
average loading time : 9.924 seconds
table expansion count : 23

after
average loading time : 6.998 seconds.  (29.4% reduction)
table expansion count : 1
