### PR TITLE
Cygwin compile fix

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -41,6 +41,12 @@
 #include "bio.h"
 #endif /* HAVE_BACKTRACE */
 
+#ifdef __CYGWIN__
+#ifndef SA_ONSTACK
+#define SA_ONSTACK 0x08000000
+#endif
+#endif
+
 /* ================================= Debugging ============================== */
 
 /* Compute the sha1 of string at 's' with 'len' bytes long.

--- a/src/object.c
+++ b/src/object.c
@@ -32,6 +32,10 @@
 #include <math.h>
 #include <ctype.h>
 
+#ifdef __CYGWIN__
+#define strtold(a,b) ((long double)strtod((a),(b)))
+#endif
+
 robj *createObject(int type, void *ptr) {
     robj *o = zmalloc(sizeof(*o));
     o->type = type;


### PR DESCRIPTION
Included:
- Fix very old issue #232
- Fix lack of `strtold` on cygwin (as reported in various web pages about compiling Redis under cygwin)

Redis can now compile under Cygwin without any end-user patches.

(Also see everybody having the same problems at https://www.google.com/search?q=redis+cygwin+SA_ONSTACK)
