### PR TITLE
Allow --port rand to get a random unused port.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -123,9 +123,13 @@ void loadServerConfigFromString(char *config) {
                 err = "Invalid tcp-keepalive value"; goto loaderr;
             }
         } else if (!strcasecmp(argv[0],"port") && argc == 2) {
-            server.port = atoi(argv[1]);
-            if (server.port < 0 || server.port > 65535) {
-                err = "Invalid port"; goto loaderr;
+            if(!strcasecmp(argv[1], "rand")) {
+                server.port = -42;
+            } else {
+                server.port = atoi(argv[1]);
+                if (server.port < 0 || server.port > 65535) {
+                    err = "Invalid port"; goto loaderr;
+                }
             }
         } else if (!strcasecmp(argv[0],"tcp-backlog") && argc == 2) {
             server.tcp_backlog = atoi(argv[1]);

--- a/src/redis.c
+++ b/src/redis.c
@@ -1704,7 +1704,17 @@ void initServer() {
     server.db = zmalloc(sizeof(redisDb)*server.dbnum);
 
     /* Open the TCP listening socket for the user commands. */
-    if (server.port != 0 &&
+    if (server.port == -42){
+        /* Redis interprets port 0 to disable TCP 
+           Use -42 to get port 0's default behavior or getting a random open port
+        */
+        if (listenToPort(0,server.ipfd,&server.ipfd_count) == REDIS_ERR)
+            exit(1);
+        struct sockaddr_in sin;
+        socklen_t salen = sizeof(sin);
+        getsockname(server.ipfd[0],(struct sockaddr*)&sin,&salen);
+        server.port = ntohs(sin.sin_port);
+    } else if (server.port != 0 &&
         listenToPort(server.port,server.ipfd,&server.ipfd_count) == REDIS_ERR)
         exit(1);
 


### PR DESCRIPTION
Linux uses port 0 to get this behavior.
Redis already used port 0 to mean "disable TCP"
So this uses port -42 under the hood as a flag.
