### PR TITLE
Implements the PFADDXX command

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -274,6 +274,7 @@ struct redisCommand redisCommandTable[] = {
     {"wait",waitCommand,3,"rs",0,NULL,0,0,0,0,0},
     {"pfselftest",pfselftestCommand,1,"r",0,NULL,0,0,0,0,0},
     {"pfadd",pfaddCommand,-2,"wm",0,NULL,1,1,1,0,0},
+    {"pfaddxx",pfaddxxCommand,-2,"wm",0,NULL,1,1,1,0,0},
     {"pfcount",pfcountCommand,-2,"w",0,NULL,1,1,1,0,0},
     {"pfmerge",pfmergeCommand,-2,"wm",0,NULL,1,-1,1,0,0},
     {"pfdebug",pfdebugCommand,-3,"w",0,NULL,0,0,0,0,0}

--- a/src/redis.h
+++ b/src/redis.h
@@ -1467,6 +1467,7 @@ void replconfCommand(redisClient *c);
 void waitCommand(redisClient *c);
 void pfselftestCommand(redisClient *c);
 void pfaddCommand(redisClient *c);
+void pfaddxxCommand(redisClient *c);
 void pfcountCommand(redisClient *c);
 void pfmergeCommand(redisClient *c);
 void pfdebugCommand(redisClient *c);

--- a/tests/unit/hyperloglog.tcl
+++ b/tests/unit/hyperloglog.tcl
@@ -25,6 +25,11 @@ start_server {tags {"hll"}} {
         r pfadd hll ""
     }
 
+    test {PFADDXX returns nil when key doesn't exist} {
+        r del hll
+        r pfaddxx hll
+    } {}
+
     # Note that the self test stresses much better the
     # cardinality estimation error. We are testing just the
     # command implementation itself here.


### PR DESCRIPTION
This commit implements the PFADDXX command, which has the same
semantics as PFADD but will return an error if the key doesn't
already exist.

References #1735
