### PR TITLE
Fix LUA_OBJCACHE segfault.

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -237,7 +237,9 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
         if (obj_s == NULL) break; /* Not a string. */
 
         /* Try to use a cached object. */
-        if (cached_objects[j] && cached_objects_len[j] >= obj_len) {
+        if (j < LUA_CMD_OBJCACHE_SIZE && cached_objects[j] && 
+            cached_objects_len[j] >= obj_len) 
+        {
             char *s = cached_objects[j]->ptr;
             struct sdshdr *sh = (void*)(s-(sizeof(struct sdshdr)));
 


### PR DESCRIPTION
When scanning the argument list inside of a redis.call() invocation
for pre-cached values, there was no check being done that the
argument we were on was in fact within the bounds of the cache size.

So if a redis.call() command was ever executed with more than 32
arguments (current cache size #define setting) redis-server could
segfault.
