### PR TITLE
Add key-hit and key-miss to keyspace notification.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -634,7 +634,7 @@ slowlog-max-len 128
 #  z     Sorted set commands
 #  x     Expired events (events generated every time a key expires)
 #  e     Evicted events (events generated when a key is evicted for maxmemory)
-#  k     Key hit event. (events generated when a data of the key is readed)
+#  k     Key hit event. (events generated when a data of the key is read)
 #  m     Key miss events (events generated when a key is not exists in db)
 #  A     Alias for g$lshzxe, so that the "AKE" string means all the events.
 #        (Key hit events and key miss events are not included this Alias.

--- a/redis.conf
+++ b/redis.conf
@@ -634,7 +634,11 @@ slowlog-max-len 128
 #  z     Sorted set commands
 #  x     Expired events (events generated every time a key expires)
 #  e     Evicted events (events generated when a key is evicted for maxmemory)
+#  k     Key hit event. (events generated when a data of the key is readed)
+#  m     Key miss events (events generated when a key is not exists in db)
 #  A     Alias for g$lshzxe, so that the "AKE" string means all the events.
+#        (Key hit events and key miss events are not included this Alias.
+#         That must add particularly in the config string like "AKEkm".)
 #
 #  The "notify-keyspace-events" takes as argument a string that is composed
 #  by zero or multiple characters. The empty string means that notifications

--- a/src/db.c
+++ b/src/db.c
@@ -62,10 +62,13 @@ robj *lookupKeyRead(redisDb *db, robj *key) {
 
     expireIfNeeded(db,key);
     val = lookupKey(db,key);
-    if (val == NULL)
+    if (val == NULL) {
+        notifyKeyspaceEvent(REDIS_NOTIFY_KEYMISS, "key-miss", key, db->id);
         server.stat_keyspace_misses++;
-    else
+    } else {
+        notifyKeyspaceEvent(REDIS_NOTIFY_KEYHIT, "key-hit", key, db->id);
         server.stat_keyspace_hits++;
+    }
     return val;
 }
 

--- a/src/notify.c
+++ b/src/notify.c
@@ -52,6 +52,8 @@ int keyspaceEventsStringToFlags(char *classes) {
         case 'z': flags |= REDIS_NOTIFY_ZSET; break;
         case 'x': flags |= REDIS_NOTIFY_EXPIRED; break;
         case 'e': flags |= REDIS_NOTIFY_EVICTED; break;
+        case 'k': flags |= REDIS_NOTIFY_KEYHIT; break;
+        case 'm': flags |= REDIS_NOTIFY_KEYMISS; break;
         case 'K': flags |= REDIS_NOTIFY_KEYSPACE; break;
         case 'E': flags |= REDIS_NOTIFY_KEYEVENT; break;
         default: return -1;
@@ -79,6 +81,8 @@ sds keyspaceEventsFlagsToString(int flags) {
         if (flags & REDIS_NOTIFY_ZSET) res = sdscatlen(res,"z",1);
         if (flags & REDIS_NOTIFY_EXPIRED) res = sdscatlen(res,"x",1);
         if (flags & REDIS_NOTIFY_EVICTED) res = sdscatlen(res,"e",1);
+        if (flags & REDIS_NOTIFY_KEYHIT) res = sdscatlen(res,"k",1);
+        if (flags & REDIS_NOTIFY_KEYMISS) res = sdscatlen(res,"m",1);
     }
     if (flags & REDIS_NOTIFY_KEYSPACE) res = sdscatlen(res,"K",1);
     if (flags & REDIS_NOTIFY_KEYEVENT) res = sdscatlen(res,"E",1);

--- a/src/redis.h
+++ b/src/redis.h
@@ -365,6 +365,10 @@
 #define REDIS_NOTIFY_ZSET (1<<7)        /* z */
 #define REDIS_NOTIFY_EXPIRED (1<<8)     /* x */
 #define REDIS_NOTIFY_EVICTED (1<<9)     /* e */
+#define REDIS_NOTIFY_KEYHIT (1<<10)     /* k */
+#define REDIS_NOTIFY_KEYMISS (1<<11)    /* m */
+/* Todo : need to have a decision, whether REDIS_NOTIFY_KEYHIT and
+   REDIS_NOTIFY_KEYMISS are been included to REDIS_NOTIFY_ALL or not. */
 #define REDIS_NOTIFY_ALL (REDIS_NOTIFY_GENERIC | REDIS_NOTIFY_STRING | REDIS_NOTIFY_LIST | REDIS_NOTIFY_SET | REDIS_NOTIFY_HASH | REDIS_NOTIFY_ZSET | REDIS_NOTIFY_EXPIRED | REDIS_NOTIFY_EVICTED)      /* A */
 
 /* Using the following macro you can run code inside serverCron() with the


### PR DESCRIPTION
Hi,

I have committed small changes for adding `key-hit` and `key-miss` notification.

Redis has keyspace notification feature, but doesn't contain key hit (read) miss event. I think, this change can provide to track that on server side.

```
k : Key hit event. (events generated when a data of the key is read)
m : Key miss events (events generated when a key is not exists in db)
```

I didn't put above 2 event into `A` alias, due to avoid side effects to current users. These probably flow many events enough.

Thanks.
Jinoos
