### PR TITLE
Optimized LTRIM

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -162,7 +162,7 @@ list *listInsertNode(list *list, listNode *old_node, void *value, int after) {
 }
 
 
-/* Optimized to removes the numbers of nodes starting from the head.
+/* Optimized to remove the specified number of nodes starting from the head.
  * It's up to the caller to free the private value of the nodes.
  *
  * This function can't fail. */
@@ -189,7 +189,7 @@ void listDelHead(list *list, unsigned long nu)
 }
 
 
-/* Optimized to removes the numbers of nodes starting from the tail.
+/* Optimized to remove the specified number of nodes starting from the tail.
  * It's up to the caller to free the private value of the nodes.
  *
  * This function can't fail. */

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -75,6 +75,9 @@ void listRelease(list *list);
 list *listAddNodeHead(list *list, void *value);
 list *listAddNodeTail(list *list, void *value);
 list *listInsertNode(list *list, listNode *old_node, void *value, int after);
+
+void listDelHead(list *list, unsigned long nu);
+void listDelTail(list *list, unsigned long nu);
 void listDelNode(list *list, listNode *node);
 listIter *listGetIterator(list *list, int direction);
 listNode *listNext(listIter *iter);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -588,9 +588,8 @@ void lrangeCommand(redisClient *c) {
 
 void ltrimCommand(redisClient *c) {
     robj *o;
-    long start, end, llen, j, ltrim, rtrim;
+    long start, end, llen, ltrim, rtrim;
     list *list;
-    listNode *ln;
 
     if ((getLongFromObjectOrReply(c, c->argv[2], &start, NULL) != REDIS_OK) ||
         (getLongFromObjectOrReply(c, c->argv[3], &end, NULL) != REDIS_OK)) return;
@@ -622,14 +621,8 @@ void ltrimCommand(redisClient *c) {
         o->ptr = ziplistDeleteRange(o->ptr,-rtrim,rtrim);
     } else if (o->encoding == REDIS_ENCODING_LINKEDLIST) {
         list = o->ptr;
-        for (j = 0; j < ltrim; j++) {
-            ln = listFirst(list);
-            listDelNode(list,ln);
-        }
-        for (j = 0; j < rtrim; j++) {
-            ln = listLast(list);
-            listDelNode(list,ln);
-        }
+        listDelHead(list, ltrim);
+        listDelTail(list, rtrim);
     } else {
         redisPanic("Unknown list encoding");
     }


### PR DESCRIPTION
When several consecutive nodes are removed from the tail or head of a given list, the new algorithm reduces the overhead of removing nodes one by one and the intermediary operations (set new head/tail, update links...).
