### PR TITLE
Make 'lookupKeyRead‘ return NULL if key is expired and current client is not master

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -60,8 +60,11 @@ robj *lookupKey(redisDb *db, robj *key) {
 robj *lookupKeyRead(redisDb *db, robj *key) {
     robj *val;
 
-    expireIfNeeded(db,key);
-    val = lookupKey(db,key);
+    if (expireIfNeeded(db,key)) {
+        val = NULL;
+    } else {
+        val = lookupKey(db,key);
+    }
     if (val == NULL)
         server.stat_keyspace_misses++;
     else

--- a/src/db.c
+++ b/src/db.c
@@ -60,7 +60,8 @@ robj *lookupKey(redisDb *db, robj *key) {
 robj *lookupKeyRead(redisDb *db, robj *key) {
     robj *val;
 
-    if (expireIfNeeded(db,key)) {
+    /*Make expired keys invisible to non-master clients.*/
+    if (expireIfNeeded(db,key) && server.current_client != server.master) {
         val = NULL;
     } else {
         val = lookupKey(db,key);


### PR DESCRIPTION
fixes https://github.com/antirez/redis/issues/1768
