### PR TITLE
Fixed typo in word avarege in result message of --intrinsic-latency analyzer

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1832,7 +1832,7 @@ static void intrinsicLatencyMode(void) {
         if (end > test_end) {
             printf("\n%lld total runs (avg %lld microseconds per run).\n",
                 runs, run_time/runs);
-            printf("Worst run took %.02fx times the avarege.\n",
+            printf("Worst run took %.02fx times the average.\n",
                 (double) max_latency / (run_time/runs));
             exit(0);
         }


### PR DESCRIPTION
If you run the --intrinsic-latency analyzer you will get a output like:

```
$ redis-cli -p 6380 --intrinsic-latency 60
Max latency so far: 5 microseconds.
Max latency so far: 9 microseconds.
Max latency so far: 121 microseconds.
Max latency so far: 122 microseconds.

24586821 total runs (avg 2 microseconds per run).
Worst run took 61.00x times the avarege.
```

In this message the word "avarege" seems to got a typo. The correct word seems to be "average".
This PR will fix this.
