### PR TITLE
Swapped arguments

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1831,9 +1831,9 @@ static void intrinsicLatencyMode(void) {
 
         if (end > test_end) {
             printf("\n%lld total runs (avg %lld microseconds per run).\n",
-                runs, run_time/runs);
-            printf("Worst run took %.02fx times the avarege.\n",
-                (double) max_latency / (run_time/runs));
+                runs, runs/run_time);
+            printf("Worst run took %.02f times the average.\n",
+                (double) max_latency / (runs/run_time));
             exit(0);
         }
     }


### PR DESCRIPTION
It's runs per time, not the other way around.
It reported wrong results before (avg: 0, infx times the average).

(also fixes a typo)
