### PR TITLE
Fix test framework to detect proper server PID

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -236,7 +236,7 @@ proc start_server {options {code undefined}} {
     
     # find out the pid
     while {![info exists pid]} {
-        regexp {\[(\d+)\]} [exec cat $stdout] _ pid
+        regexp {PID:\s(\d+)} [exec cat $stdout] _ pid
         after 100
     }
 


### PR DESCRIPTION
Previously the PID format was:
`[PID] Timestamp`

But it recently changed to:
`PID:X Timestamp`

The tcl testing framework was grabbing the PID from `\[\d+\]`, but
that's not valid anymore.

Now we grab the pid from `"PID: <PID>"` in the part of Redis startup
output to the right of the ASCII logo.
