### PR TITLE
add configfile path to proctitle

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -3324,11 +3324,14 @@ void redisSetProcTitle(char *title) {
     if (server.cluster_enabled) server_mode = " [cluster]";
     else if (server.sentinel_mode) server_mode = " [sentinel]";
 
-    setproctitle("%s %s:%d%s",
+    char *configfile = server.configfile ? server.configfile : "[default configuration]";
+
+    setproctitle("%s %s:%d%s %s",
         title,
         server.bindaddr_count ? server.bindaddr[0] : "*",
         server.port,
-        server_mode);
+        server_mode,
+        configfile);
 #else
     REDIS_NOTUSED(title);
 #endif


### PR DESCRIPTION
Just a small change to proctitle, showing which configuration file was used to start the server, or when it is using the default configuration.
The results will be like that

```
./redis-server *:6379 /tmp/redis.conf
./redis-server *:6379 [default configuration]
./redis-server *:6379 [cluster] /tmp/redis.conf
./redis-server *:6379 [sentinel] [default configuration]
```
