### PR TITLE
Add scripts to help with releases

### DIFF
--- a/utils/lint.sh
+++ b/utils/lint.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Exit on any command failure
+set -e
+
+branch=$1
+
+target="/tmp/redis-$RANDOM"
+
+# Sanity check our random dir doesn't already exist
+while [[ -d "$target" ]]; do
+    target="/tmp/redis-$RANDOM"
+done
+
+here=`dirname $0`
+
+git clone "$here/.." "$target"
+
+pushd "$target"
+
+if [[ ! -z $branch ]]; then
+    git checkout $branch
+else
+    git checkout unstable
+fi
+
+# We should make with clang and gcc since they
+# output different warnings, *but* we can't
+# know which compilers the target system will
+# have.  clang + gcc?  clang + gcc-4.9? ...
+make -j REDIS_CFLAGS="-Werror"
+
+./runtest
+
+./runtest-cluster
+
+./runtest-sentinel
+
+popd
+
+rm -rf "$target"
+
+echo "Passed building and running all tests!"

--- a/utils/tag.sh
+++ b/utils/tag.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+branch=$1
+tag=$2
+
+# branch can obviously be a generic
+# git ref, but branch is cleaner terminology
+if [[ (-z $branch) || (-z $tag) ]]; then
+    echo "$0 [source branch] [tag]"
+    exit 1
+fi
+
+here=`dirname $0`
+
+"$here/lint.sh" $branch
+
+if [[ $? == 0 ]]; then
+    echo "Tagging $branch as $tag"
+    git tag -f "$tag"
+fi


### PR DESCRIPTION
Let's help tag releases from clean checkout sources. 

New scripts:
- utils/lint.sh [branch]
  - checks out clean repo from current dir
  - builds
  - runs tests (runtest, runtest-cluster, runtest-sentinel)
  - aborts on _any_ error
- utils/tag.sh [branch] [tag]
  - runs lint.sh on branch
  - if all tests pass, tags the branch
