### PR TITLE
5 short clusterables

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3442,6 +3442,74 @@ int getSlotOrReply(redisClient *c, robj *o) {
     return (int) slot;
 }
 
+void clusterReplyMultiBulkSlots(redisClient *c) {
+    /* Format: 1) 1) start slot
+     *            2) end slot
+     *            3) 1) master IP
+     *               2) master port
+     *            4) 1) replica IP
+     *               2) replica port
+     *           ... continued until done
+     */
+
+    int repliedRangeCount = 0;
+    void *slotreplylen = addDeferredMultiBulkLength(c);
+
+    dictEntry *de;
+    dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
+    while((de = dictNext(di)) != NULL) {
+        clusterNode *node = dictGetVal(de);
+        int j = 0, start = -1;
+
+        /* If node is down or not a master, skip it. */
+        if (node->flags & REDIS_NODE_FAIL || !(node->flags & REDIS_NODE_MASTER))
+            continue;
+
+        for (j = 0; j < REDIS_CLUSTER_SLOTS; j++) {
+            int bit;
+
+            if ((bit = clusterNodeGetSlotBit(node,j)) != 0) {
+                if (start == -1) start = j;
+            }
+            if (start != -1 && (!bit || j == REDIS_CLUSTER_SLOTS-1)) {
+                if (bit && j == REDIS_CLUSTER_SLOTS-1) j++;
+
+                /* nested size: slots (2) + master (1) + slaves */
+                addReplyMultiBulkLen(c, 2 + 1 + node->numslaves);
+
+                /* If slot exists in output map, add to it's list.
+                 * else, create a new output map for this slot */
+                if (start == j-1) {
+                    addReplyLongLong(c, start); /* only one slot; low==high */
+                    addReplyLongLong(c, start);
+                } else {
+                    addReplyLongLong(c, start); /* low */
+                    addReplyLongLong(c, j-1);   /* high */
+                }
+                start = -1;
+
+                /* First node reply position is always the master */
+                addReplyMultiBulkLen(c, 2);
+                addReplyBulkCString(c, node->ip);
+                addReplyLongLong(c, node->port);
+
+                /* Remaining nodes in reply are replicas for slot range */
+                int i;
+                for (i = 0; i < node->numslaves; i++) {
+                    /* This loop is copy/pasted from clusterGenNodeDescription()
+                     * with modifications for per-slot node aggregation */
+                    addReplyMultiBulkLen(c, 2);
+                    addReplyBulkCString(c, node->slaves[i]->ip);
+                    addReplyLongLong(c, node->slaves[i]->port);
+                }
+                repliedRangeCount++;
+            }
+        }
+    }
+    dictReleaseIterator(di);
+    setDeferredMultiBulkLength(c, slotreplylen, repliedRangeCount);
+}
+
 void clusterCommand(redisClient *c) {
     if (server.cluster_enabled == 0) {
         addReplyError(c,"This instance has cluster support disabled");
@@ -3473,6 +3541,9 @@ void clusterCommand(redisClient *c) {
         o = createObject(REDIS_STRING,ci);
         addReplyBulk(c,o);
         decrRefCount(o);
+    } else if (!strcasecmp(c->argv[1]->ptr,"slots") && c->argc == 2) {
+        /* CLUSTER SLOTS */
+        clusterReplyMultiBulkSlots(c);
     } else if (!strcasecmp(c->argv[1]->ptr,"flushslots") && c->argc == 2) {
         /* CLUSTER FLUSHSLOTS */
         if (dictSize(server.db[0].dict) != 0) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2229,6 +2229,15 @@ void clusterPropagatePublish(robj *channel, robj *message) {
     clusterSendPublish(NULL, channel, message);
 }
 
+/* This is an extremely poor version of sentinelEvent() */
+void clusterPublishStateUpdate() {
+    robj *channel = createObject(REDIS_STRING, sdsnew("__cluster__:state"));
+    robj *msg = createObject(REDIS_STRING,
+        sdscatprintf(sdsempty(), "changed:%llu",
+        (unsigned long long)server.cluster->currentEpoch));
+    clusterPropagatePublish(channel, msg);
+}
+
 /* -----------------------------------------------------------------------------
  * SLAVE node specific functions
  * -------------------------------------------------------------------------- */
@@ -2589,6 +2598,9 @@ void clusterHandleSlaveFailover(void) {
 
         /* 6) If there was a manual failover in progress, clear the state. */
         resetManualFailover();
+
+        /* 7) PUBLISH a notice about the cluster state update */
+        clusterPublishStateUpdate();
     }
 }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -427,6 +427,13 @@ void clusterInit(void) {
          * by the createClusterNode() function. */
         myself = server.cluster->myself =
             createClusterNode(NULL,REDIS_NODE_MYSELF|REDIS_NODE_MASTER);
+        if (server.bindaddr_count) {
+            /* If we have a bind directive, use configuration from
+             * redis.conf as IP:Port of myself. */
+            strncpy(server.cluster->myself->ip,
+                    server.bindaddr[0], REDIS_IP_STR_LEN);
+            server.cluster->myself->port = server.port;
+        }
         redisLog(REDIS_NOTICE,"No cluster configuration found, I'm %.40s",
             myself->name);
         clusterAddNode(myself);

--- a/src/redis.c
+++ b/src/redis.c
@@ -273,6 +273,7 @@ struct redisCommand redisCommandTable[] = {
     {"bitcount",bitcountCommand,-2,"r",0,NULL,1,1,1,0,0},
     {"bitpos",bitposCommand,-3,"r",0,NULL,1,1,1,0,0},
     {"wait",waitCommand,3,"rs",0,NULL,0,0,0,0,0},
+    {"commands",commandsCommand,0,"rlt",0,NULL,0,0,0,0,0},
     {"pfselftest",pfselftestCommand,1,"r",0,NULL,0,0,0,0,0},
     {"pfadd",pfaddCommand,-2,"wm",0,NULL,1,1,1,0,0},
     {"pfcount",pfcountCommand,-2,"w",0,NULL,1,1,1,0,0},
@@ -2394,6 +2395,73 @@ void timeCommand(redisClient *c) {
     addReplyBulkLongLong(c,tv.tv_sec);
     addReplyBulkLongLong(c,tv.tv_usec);
 }
+
+
+static int replyCmdFlag(redisClient *c,
+                        struct redisCommand *cmd, int f, char *reply) {
+    if (cmd->flags & f) {
+        addReplyStatus(c, reply);
+        return 1;
+    }
+    return 0;
+}
+static void replyCmd(redisClient *c, struct redisCommand *cmd) {
+    if (!cmd) {
+        addReply(c, shared.nullbulk);
+    } else {
+        /* We are adding: command name, arg count, flags, first, last, offset */
+        addReplyMultiBulkLen(c, 6);
+        addReplyBulkCString(c, cmd->name);
+        addReplyLongLong(c, cmd->arity);
+
+        int flagcount = 0;
+        void *flaglen = addDeferredMultiBulkLength(c);
+        flagcount += replyCmdFlag(c,cmd,REDIS_CMD_WRITE, "write");
+        flagcount += replyCmdFlag(c,cmd,REDIS_CMD_READONLY, "readonly");
+        flagcount += replyCmdFlag(c,cmd,REDIS_CMD_DENYOOM, "denyoom");
+        flagcount += replyCmdFlag(c,cmd,REDIS_CMD_ADMIN, "admin");
+        flagcount += replyCmdFlag(c,cmd,REDIS_CMD_PUBSUB, "pubsub");
+        flagcount += replyCmdFlag(c,cmd,REDIS_CMD_NOSCRIPT, "noscript");
+        flagcount += replyCmdFlag(c,cmd,REDIS_CMD_RANDOM, "random");
+        flagcount += replyCmdFlag(c,cmd,REDIS_CMD_SORT_FOR_SCRIPT,"scriptsort");
+        flagcount += replyCmdFlag(c,cmd,REDIS_CMD_LOADING, "loading");
+        flagcount += replyCmdFlag(c,cmd,REDIS_CMD_STALE, "stale");
+        flagcount += replyCmdFlag(c,cmd,REDIS_CMD_SKIP_MONITOR, "skipmonitor");
+        flagcount += replyCmdFlag(c,cmd,REDIS_CMD_ASKING, "asking");
+        if (cmd->getkeys_proc) {
+            addReplyStatus(c, "movablekeys");
+            flagcount += 1;
+        }
+        setDeferredMultiBulkLength(c, flaglen, flagcount);
+
+        addReplyLongLong(c, cmd->firstkey);
+        addReplyLongLong(c, cmd->lastkey);
+        addReplyLongLong(c, cmd->keystep);
+    }
+}
+void commandsCommand(redisClient *c) {
+    dictIterator *di;
+    dictEntry *de;
+
+    if (c->argc > 2 && !strcasecmp(c->argv[1]->ptr, "info")) {
+        int i;
+        addReplyMultiBulkLen(c, c->argc-2);
+        for (i = 2; i < c->argc; i++) {
+            replyCmd(c, dictFetchValue(server.commands, c->argv[i]->ptr));
+        }
+    } else if (c->argc > 2) {
+        addReplyError(c, "Unknown subcommand.");
+        return;
+    } else {
+        addReplyMultiBulkLen(c, dictSize(server.commands));
+        di = dictGetIterator(server.commands);
+        while ((de = dictNext(di)) != NULL) {
+            replyCmd(c, dictGetVal(de));
+        }
+        dictReleaseIterator(di);
+    }
+}
+
 
 /* Convert an amount of bytes into a human readable string in the form
  * of 100B, 2G, 100M, 4K, and so forth. */

--- a/src/redis.h
+++ b/src/redis.h
@@ -1324,6 +1324,7 @@ uint64_t redisBuildId(void);
 void authCommand(redisClient *c);
 void pingCommand(redisClient *c);
 void echoCommand(redisClient *c);
+void commandsCommand(redisClient *c);
 void setCommand(redisClient *c);
 void setnxCommand(redisClient *c);
 void setexCommand(redisClient *c);


### PR DESCRIPTION
Yesterday I wrote a quick note about adding cluster support to clients, but it raised some interesting issues.

Here's an attempt at fixing some cluster implementation difficulties.

Four new things:
- Use the local bind IP (if available) instead of reporting `:0` for the `myself` IP
- Provide a `CLUSTER SLOTS` command with Redis-formatted output of the relevant parts of `CLUSTER NODES`
- Add `COMMANDS` so clients can discover key position information for each command, allowing better client-side key to slot mapping.
- `PUBLISH` to `__cluster__:state` when the cluster state changes so clients can automatically re-fetch their node map without waiting for timeouts or failures.  Channel name was chosen arbitrarily.  Open to suggestions for proper naming.

For more details, see each individual commit message/essay.
