### PR TITLE
change function name replicationCacheMaster to replicationCachedMaster

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -670,7 +670,7 @@ void freeClient(redisClient *c) {
                           REDIS_BLOCKED|
                           REDIS_UNBLOCKED)))
         {
-            replicationCacheMaster(c);
+            replicationCachedMaster(c);
             return;
         }
     }

--- a/src/redis.h
+++ b/src/redis.h
@@ -1101,7 +1101,7 @@ void replicationFeedMonitors(redisClient *c, list *monitors, int dictid, robj **
 void updateSlavesWaitingBgsave(int bgsaveerr);
 void replicationCron(void);
 void replicationHandleMasterDisconnection(void);
-void replicationCacheMaster(redisClient *c);
+void replicationCachedMaster(redisClient *c);
 void resizeReplicationBacklog(long long newsize);
 void replicationSetMaster(char *ip, int port);
 void replicationUnsetMaster(void);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1360,7 +1360,7 @@ void replicationSendAck(void) {
  * replicationResurrectCachedMaster() that is used after a successful PSYNC
  * handshake in order to reactivate the cached master.
  */
-void replicationCacheMaster(redisClient *c) {
+void replicationCachedMaster(redisClient *c) {
     listNode *ln;
 
     redisAssert(server.master != NULL && server.cached_master == NULL);


### PR DESCRIPTION
I think it is more suitable to change function name, replicationCacheMaster to replicationCachedMaster
