### PR TITLE
Scripting: Fix regression from #1118

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -200,6 +200,11 @@ void luaSortArray(lua_State *lua) {
     lua_pop(lua,1);             /* Stack: array (sorted) */
 }
 
+int luaReallyIsString(lua_State *L, int index) {
+    int t = lua_type(L, index);
+    return t == LUA_TSTRING;
+}
+
 #define LUA_CMD_OBJCACHE_SIZE 32
 #define LUA_CMD_OBJCACHE_MAX_LEN 64
 int luaRedisGenericCommand(lua_State *lua, int raise_error) {
@@ -234,7 +239,7 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
         size_t obj_len;
         char dbuf[64];
 
-        if (lua_isnumber(lua,j+1)) {
+        if (!luaReallyIsString(lua, j+1) && lua_isnumber(lua, j+1)) {
             /* We can't use lua_tolstring() for number -> string conversion
              * since Lua uses a format specifier that loses precision. */
             lua_Number num = lua_tonumber(lua,j+1);

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -347,6 +347,13 @@ start_server {tags {"scripting"}} {
               return redis.call("get","foo")
         } 0
     } {9007199254740991}
+
+    test {String containing number precision test (regression of issue #1118)} {
+        r eval {
+            redis.call("set", "key", "12039611435714932082")
+            return redis.call("get", "key")
+        } 0
+    } {12039611435714932082}
 }
 
 # Start a new server since the last test in this stanza will kill the


### PR DESCRIPTION
The new check-for-number behavior for Lua arguments broke
users who use large strings of just integers.

The Lua number check would convert the string to a number, but
that breaks user data because
Lua numbers have limited precision compared to an arbitrarily
precise number wrapped in a string.

Regression fixed and new test added.

Fixes #1118 again.
