### PR TITLE
INFO output: Add maxmemory_policy and total system memory

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1004,6 +1004,20 @@ badfmt: /* Bad format errors */
     } \
 } while(0);
 
+char *maxmemoryToString() {
+    char *s;
+    switch(server.maxmemory_policy) {
+    case REDIS_MAXMEMORY_VOLATILE_LRU: s = "volatile-lru"; break;
+    case REDIS_MAXMEMORY_VOLATILE_TTL: s = "volatile-ttl"; break;
+    case REDIS_MAXMEMORY_VOLATILE_RANDOM: s = "volatile-random"; break;
+    case REDIS_MAXMEMORY_ALLKEYS_LRU: s = "allkeys-lru"; break;
+    case REDIS_MAXMEMORY_ALLKEYS_RANDOM: s = "allkeys-random"; break;
+    case REDIS_MAXMEMORY_NO_EVICTION: s = "noeviction"; break;
+    default: s = "unknown"; break;
+    }
+    return s;
+}
+
 void configGetCommand(redisClient *c) {
     robj *o = c->argv[2];
     void *replylen = addDeferredMultiBulkLength(c);
@@ -1112,19 +1126,8 @@ void configGetCommand(redisClient *c) {
         matches++;
     }
     if (stringmatch(pattern,"maxmemory-policy",0)) {
-        char *s;
-
-        switch(server.maxmemory_policy) {
-        case REDIS_MAXMEMORY_VOLATILE_LRU: s = "volatile-lru"; break;
-        case REDIS_MAXMEMORY_VOLATILE_TTL: s = "volatile-ttl"; break;
-        case REDIS_MAXMEMORY_VOLATILE_RANDOM: s = "volatile-random"; break;
-        case REDIS_MAXMEMORY_ALLKEYS_LRU: s = "allkeys-lru"; break;
-        case REDIS_MAXMEMORY_ALLKEYS_RANDOM: s = "allkeys-random"; break;
-        case REDIS_MAXMEMORY_NO_EVICTION: s = "noeviction"; break;
-        default: s = "unknown"; break; /* too harmless to panic */
-        }
         addReplyBulkCString(c,"maxmemory-policy");
-        addReplyBulkCString(c,s);
+        addReplyBulkCString(c,maxmemoryToString());
         matches++;
     }
     if (stringmatch(pattern,"appendfsync",0)) {

--- a/src/redis.c
+++ b/src/redis.c
@@ -2664,6 +2664,7 @@ sds genRedisInfoString(char *section) {
         char hmem[64];
         char peak_hmem[64];
         size_t zmalloc_used = zmalloc_used_memory();
+        char *evict_policy = maxmemoryToString();
 
         /* Peak memory is updated from time to time by serverCron() so it
          * may happen that the instantaneous value is slightly bigger than
@@ -2684,7 +2685,8 @@ sds genRedisInfoString(char *section) {
             "used_memory_peak_human:%s\r\n"
             "used_memory_lua:%lld\r\n"
             "mem_fragmentation_ratio:%.2f\r\n"
-            "mem_allocator:%s\r\n",
+            "mem_allocator:%s\r\n"
+            "maxmemory_policy:%s\r\n",
             zmalloc_used,
             hmem,
             server.resident_set_size,
@@ -2692,7 +2694,8 @@ sds genRedisInfoString(char *section) {
             peak_hmem,
             ((long long)lua_gc(server.lua,LUA_GCCOUNT,0))*1024LL,
             zmalloc_get_fragmentation_ratio(server.resident_set_size),
-            ZMALLOC_LIB
+            ZMALLOC_LIB,
+            evict_policy
             );
     }
 

--- a/src/redis.c
+++ b/src/redis.c
@@ -52,6 +52,7 @@
 #include <sys/resource.h>
 #include <sys/utsname.h>
 #include <locale.h>
+#include <sys/sysctl.h>
 
 /* Our shared "common" objects */
 
@@ -287,6 +288,7 @@ struct redisCommand redisCommandTable[] = {
 };
 
 struct evictionPoolEntry *evictionPoolAlloc(void);
+static size_t getMemorySize(void);
 
 /*============================ Utility functions ============================ */
 
@@ -1724,6 +1726,7 @@ void initServer(void) {
     server.clients_waiting_acks = listCreate();
     server.get_ack_from_slaves = 0;
     server.clients_paused = 0;
+    server.system_memory_size = getMemorySize();
 
     createSharedObjects();
     adjustOpenFilesLimit();
@@ -2444,7 +2447,6 @@ void timeCommand(redisClient *c) {
     addReplyBulkLongLong(c,tv.tv_usec);
 }
 
-
 /* Helper function for addReplyCommand() to output flags. */
 int addReplyCommandFlag(redisClient *c, struct redisCommand *cmd, int f, char *reply) {
     if (cmd->flags & f) {
@@ -2533,6 +2535,54 @@ void commandCommand(redisClient *c) {
         addReplyError(c, "Unknown subcommand or wrong number of arguments.");
         return;
     }
+}
+
+/**
+ * Returns the size of physical memory (RAM) in bytes.
+ * It looks ugly, but this is the cleanest way to achive cross platform results.
+ * Cleaned up from:
+ * http://nadeausoftware.com/articles/2012/09/c_c_tip_how_get_physical_memory_size_system
+ */
+size_t getMemorySize() {
+#if defined(__unix__) || defined(__unix) || defined(unix) || \
+    (defined(__APPLE__) && defined(__MACH__))
+#if defined(CTL_HW) && (defined(HW_MEMSIZE) || defined(HW_PHYSMEM64))
+    int mib[2];
+    mib[0] = CTL_HW;
+#if defined(HW_MEMSIZE)
+    mib[1] = HW_MEMSIZE;            /* OSX. --------------------- */
+#elif defined(HW_PHYSMEM64)
+    mib[1] = HW_PHYSMEM64;          /* NetBSD, OpenBSD. --------- */
+#endif
+    int64_t size = 0;               /* 64-bit */
+    size_t len = sizeof(size);
+    if (sysctl( mib, 2, &size, &len, NULL, 0) == 0)
+        return (size_t)size;
+    return 0L;          /* Failed? */
+
+#elif defined(_SC_PHYS_PAGES) && defined(_SC_PAGESIZE)
+    /* FreeBSD, Linux, OpenBSD, and Solaris. -------------------- */
+    return (size_t)sysconf(_SC_PHYS_PAGES) * (size_t)sysconf(_SC_PAGESIZE);
+
+#elif defined(CTL_HW) && (defined(HW_PHYSMEM) || defined(HW_REALMEM))
+    /* DragonFly BSD, FreeBSD, NetBSD, OpenBSD, and OSX. -------- */
+    int mib[2];
+    mib[0] = CTL_HW;
+#if defined(HW_REALMEM)
+    mib[1] = HW_REALMEM;        /* FreeBSD. ----------------- */
+#elif defined(HW_PYSMEM)
+    mib[1] = HW_PHYSMEM;        /* Others. ------------------ */
+#endif
+    unsigned int size = 0;      /* 32-bit */
+    size_t len = sizeof(size);
+    if (sysctl(mib, 2, &size, &len, NULL, 0) == 0)
+        return (size_t)size;
+    return 0L;          /* Failed? */
+#endif /* sysctl and sysconf variants */
+
+#else
+    return 0L;          /* Unknown OS. */
+#endif
 }
 
 /* Convert an amount of bytes into a human readable string in the form
@@ -2663,7 +2713,9 @@ sds genRedisInfoString(char *section) {
     if (allsections || defsections || !strcasecmp(section,"memory")) {
         char hmem[64];
         char peak_hmem[64];
+        char total_system_hmem[64];
         size_t zmalloc_used = zmalloc_used_memory();
+        size_t total_system_mem = server.system_memory_size;
         char *evict_policy = maxmemoryToString();
 
         /* Peak memory is updated from time to time by serverCron() so it
@@ -2675,6 +2727,8 @@ sds genRedisInfoString(char *section) {
 
         bytesToHuman(hmem,zmalloc_used);
         bytesToHuman(peak_hmem,server.stat_peak_memory);
+        bytesToHuman(total_system_hmem,total_system_mem);
+
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info,
             "# Memory\r\n"
@@ -2683,6 +2737,8 @@ sds genRedisInfoString(char *section) {
             "used_memory_rss:%zu\r\n"
             "used_memory_peak:%zu\r\n"
             "used_memory_peak_human:%s\r\n"
+            "total_system_memory:%lu\r\n"
+            "total_system_memory_human:%s\r\n"
             "used_memory_lua:%lld\r\n"
             "mem_fragmentation_ratio:%.2f\r\n"
             "mem_allocator:%s\r\n"
@@ -2692,6 +2748,8 @@ sds genRedisInfoString(char *section) {
             server.resident_set_size,
             server.stat_peak_memory,
             peak_hmem,
+            (unsigned long)total_system_mem,
+            total_system_hmem,
             ((long long)lua_gc(server.lua,LUA_GCCOUNT,0))*1024LL,
             zmalloc_get_fragmentation_ratio(server.resident_set_size),
             ZMALLOC_LIB,

--- a/src/redis.h
+++ b/src/redis.h
@@ -1244,6 +1244,7 @@ void closeListeningSockets(int unlink_unix_socket);
 void updateCachedTime(void);
 void resetServerStats(void);
 unsigned int getLRUClock(void);
+char *maxmemoryToString(void);
 
 /* Set data type */
 robj *setTypeCreate(robj *value);

--- a/src/redis.h
+++ b/src/redis.h
@@ -897,6 +897,7 @@ struct redisServer {
     int assert_line;
     int bug_report_start; /* True if bug report header was already logged. */
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
+    size_t system_memory_size;  /* Total memory in system as reported by OS */
 };
 
 typedef struct pubsubPattern {


### PR DESCRIPTION
Add some useful config and system data we can use in crash output.

My first attempt at getting system memory involved the very clean OS X `sysctl` interface.  After I committed it, it seemed a bit _too_ easy.  On further inspection, of course, there's no cross-platform stable way of getting system memory.  

I ended up tweaking a [very comprehensive memory discovery function](http://nadeausoftware.com/articles/2012/09/c_c_tip_how_get_physical_memory_size_system) and it works great.

New output sample:

``` haskell
# Memory
used_memory:1009056
used_memory_human:985.41K
used_memory_rss:1712128
used_memory_peak:1009056
used_memory_peak_human:985.41K
total_system_memory:17179869184
total_system_memory_human:16.00G
used_memory_lua:33792
mem_fragmentation_ratio:1.70
mem_allocator:libc
maxmemory_policy:noeviction
```
