### PR TITLE
Add correct exit value to failed tests

### DIFF
--- a/tests/cluster/run.tcl
+++ b/tests/cluster/run.tcl
@@ -22,4 +22,5 @@ proc main {} {
 if {[catch main e]} {
     puts $::errorInfo
     cleanup
+    exit 1
 }

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -18,4 +18,5 @@ proc main {} {
 if {[catch main e]} {
     puts $::errorInfo
     cleanup
+    exit 1
 }


### PR DESCRIPTION
Sentinel tests are currently failing, but it took me a while to notice because the return value from sentinel (and cluster) testing wasn't triggering an error.  I applied this commit to my travis-ci branch and now the tests show as failed.

See https://travis-ci.org/mattsta/redis (also, ci.redis.io has stopped updating again and nobody seems to notice.  Adding automatic travis CI testing sure would catch a lot of problems without resorting to manual testing :octocat:)
