### PR TITLE
Disallow eval with negative key count

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -910,6 +910,9 @@ void evalGenericCommand(redisClient *c, int evalsha) {
     if (numkeys > (c->argc - 3)) {
         addReplyError(c,"Number of keys can't be greater than number of args");
         return;
+    } else if (numkeys < 0) {
+        addReplyError(c,"Number of keys can't be negative");
+        return;
     }
 
     /* We obtain the script SHA1, then check if this function is already

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -358,6 +358,12 @@ start_server {tags {"scripting"}} {
             return redis.call("get", "key")
         } 0
     } {12039611435714932082}
+
+    test {Verify negative arg count is error instead of crash (issue #1842)} {
+        r eval {
+            return "hello"
+        } -12
+    } {table {ERR Number of keys can't be negative}}
 }
 
 # Start a new server since the last test in this stanza will kill the


### PR DESCRIPTION
Negative key count causes segfault in Lua functions.

Fixes #1842
