### PR TITLE
Handle huge ranges.

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -255,7 +255,7 @@ void getrangeCommand(redisClient *c) {
     if (end < 0) end = strlen+end;
     if (start < 0) start = 0;
     if (end < 0) end = 0;
-    if ((unsigned)end >= strlen) end = strlen-1;
+    if ((size_t)end >= strlen) end = strlen-1;
 
     /* Precondition: end >= 0 && end < strlen, so the only condition where
      * nothing can be returned is: start > end. */

--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -769,4 +769,9 @@ start_server {tags {"basic"}} {
         r keys *
         r keys *
     } {dlskeriewrioeuwqoirueioqwrueoqwrueqw}
+
+    test {GETRANGE with huge ranges, Github issue #1844} {
+        r set foo bar
+        r getrange foo 0 4294967297
+    } {bar}
 }


### PR DESCRIPTION
Previously the end was casted to a smaller type which resulted in a wrong check and failed with values larger than handled by unsigned.

Fixes #1844
