### PR TITLE
Redis lua int64

### DIFF
--- a/src/Makefile.dep
+++ b/src/Makefile.dep
@@ -71,11 +71,14 @@ replication.o: replication.c redis.h fmacros.h config.h \
   adlist.h zmalloc.h anet.h ziplist.h intset.h version.h util.h rdb.h \
   rio.h
 rio.o: rio.c fmacros.h rio.h sds.h util.h crc64.h
-scripting.o: scripting.c redis.h fmacros.h config.h ../deps/lua/src/lua.h \
+scripting.o: scripting.c int64.c redis.h fmacros.h config.h ../deps/lua/src/lua.h \
   ../deps/lua/src/luaconf.h ae.h sds.h dict.h adlist.h zmalloc.h anet.h \
   ziplist.h intset.h version.h util.h rdb.h rio.h sha1.h rand.h \
   ../deps/lua/src/lauxlib.h ../deps/lua/src/lua.h \
   ../deps/lua/src/lualib.h
+
+int64.o: ../deps/lua/src/lua.h ../deps/lua/src/lauxlib.h
+
 sds.o: sds.c sds.h zmalloc.h
 sentinel.o: sentinel.c redis.h fmacros.h config.h ../deps/lua/src/lua.h \
   ../deps/lua/src/luaconf.h ae.h sds.h dict.h adlist.h zmalloc.h anet.h \

--- a/src/int64.c
+++ b/src/int64.c
@@ -1,3 +1,8 @@
+/*
+ * NOTE: This implementation is mainly based on: https://github.com/cloudwu/lua-int64
+ *
+ */
+
 #include <lua.h>
 #include <lauxlib.h>
 #include <stdint.h>

--- a/src/int64.c
+++ b/src/int64.c
@@ -1,0 +1,333 @@
+#include <lua.h>
+#include <lauxlib.h>
+#include <stdint.h>
+#include <math.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+static int64_t
+_int64(lua_State *lua, int index) {
+    int type = lua_type(lua, index);
+    int64_t n = 0;
+
+    switch(type) {
+        case LUA_TNUMBER: {
+            lua_Number d = lua_tonumber(lua, index);
+            n = (int64_t)d;
+            break;
+        }
+        case LUA_TSTRING: {
+            int negative = 0;
+            size_t len = 0;
+            uint64_t n64 = 0;
+
+            const uint8_t * str = (const uint8_t *)lua_tolstring(lua, index, &len);
+            if (len <= 0 || len > 19) {
+                return luaL_error(lua, "The string (length = %d) is not an int64 string", len);
+            }
+
+            size_t i = 0;
+            if (str[i] == '-') {
+                negative = 1;
+                ++i;
+            }
+
+            for (; i < len; i++) {
+                char c = str[i];
+                if ( c > '9' || c < '0' ) {
+                    return luaL_error(lua, "Bad format input: %s", str);
+                }
+                n64 = (uint64_t)(str[i] - '0') + 10 * n64;
+            }
+
+            n = (int64_t)n64;
+
+            if (negative) {
+                n = 0 - n;
+            }
+
+            break;
+        }
+        case LUA_TLIGHTUSERDATA: {
+            void * p = lua_touserdata(lua, index);
+            n = (intptr_t)p;
+            break;
+        }
+        default: {
+            return luaL_error(lua, "argument %d error type %s", index, lua_typename(lua, type));
+        }
+    }
+    return n;
+}
+
+static inline void
+_pushint64(lua_State *lua, int64_t n) {
+    void * p = (void *)(intptr_t)n;
+    lua_pushlightuserdata(lua, p);
+}
+
+static int
+int64Add(lua_State *lua) {
+    int64_t a = _int64(lua, 1);
+    int64_t b = _int64(lua, 2);
+    _pushint64(lua, a + b);
+    
+    return 1;
+}
+
+static int
+int64Sub(lua_State *lua) {
+    int64_t a = _int64(lua, 1);
+    int64_t b = _int64(lua, 2);
+    _pushint64(lua, a - b);
+    
+    return 1;
+}
+
+static int
+int64Mul(lua_State *lua) {
+    int64_t a = _int64(lua, 1);
+    int64_t b = _int64(lua, 2);
+    _pushint64(lua, a * b);
+    
+    return 1;
+}
+
+static int
+int64Div(lua_State *lua) {
+    int64_t a = _int64(lua, 1);
+    int64_t b = _int64(lua, 2);
+    if (b == 0) {
+        return luaL_error(lua, "div by zero");
+    }
+    _pushint64(lua, a / b);
+    
+    return 1;
+}
+
+static int
+int64Mod(lua_State *lua) {
+    int64_t a = _int64(lua, 1);
+    int64_t b = _int64(lua, 2);
+    if (b == 0) {
+        return luaL_error(lua, "mod by zero");
+    }
+    _pushint64(lua, a % b);
+    
+    return 1;
+}
+
+static int64_t
+_pow64(int64_t a, int64_t b) {
+
+    if (b == 1) {
+        return a;
+    }
+
+    int64_t a2 = a * a;
+    if (b % 2 == 1) {
+        return _pow64(a2, b / 2) * a;
+    } else {
+        return _pow64(a2, b / 2);
+    }
+
+}
+
+static int
+int64Pow(lua_State *lua) {
+
+    int64_t a = _int64(lua, 1);
+    int64_t b = _int64(lua, 2);
+    int64_t p;
+
+    if (b > 0) {
+        p = _pow64(a, b);
+    } else if (b == 0) {
+        p = 1;
+    } else {
+        return luaL_error(lua, "pow by nagtive number %d",(int)b);
+    } 
+    _pushint64(lua, p);
+
+    return 1;
+}
+
+static int
+int64Unm(lua_State *lua) {
+    int64_t a = _int64(lua, 1);
+    _pushint64(lua, -a);
+
+    return 1;
+}
+
+static int
+int64New(lua_State *lua) {
+    int top = lua_gettop(lua);
+    int64_t n;
+    switch(top) {
+        case 0 : 
+            lua_pushlightuserdata(lua, NULL);
+            break;
+        case 1 :
+            n = _int64(lua, 1);
+            _pushint64(lua, n);
+            break;
+        default: {
+            int base = luaL_checkinteger(lua, 2);
+            if (base < 2) {
+                luaL_error(lua, "base must be >= 2");
+            }
+            const char * str = luaL_checkstring(lua, 1);
+            n = strtoll(str, NULL, base);
+            _pushint64(lua, n);
+            break;
+        }
+    }
+    return 1;
+}
+
+static int
+int64Eq(lua_State *lua) {
+    int64_t a = _int64(lua, 1);
+    int64_t b = _int64(lua, 2);
+    lua_pushboolean(lua, a == b);
+    return 1;
+}
+
+static int
+int64Lt(lua_State *lua) {
+    int64_t a = _int64(lua, 1);
+    int64_t b = _int64(lua, 2);
+    lua_pushboolean(lua, a < b);
+
+    return 1;
+}
+
+static int
+int64Le(lua_State *lua) {
+    int64_t a = _int64(lua, 1);
+    int64_t b = _int64(lua, 2);
+    lua_pushboolean(lua, a <= b);
+
+    return 1;
+}
+
+static int
+int64Len(lua_State *lua) {
+    int64_t a = _int64(lua, 1);
+    lua_pushnumber(lua,(lua_Number)a);
+
+    return 1;
+}
+
+static int
+tostring(lua_State *lua) {
+    static char hex[16] = "0123456789ABCDEF";
+    uintptr_t n = (uintptr_t)lua_touserdata(lua, 1);
+
+    int base = 0;
+
+    if (lua_gettop(lua) == 1) {
+        base = 10;
+    } else {
+        base = luaL_checkinteger(lua, 2); 
+    }
+
+    int shift, mask;
+
+    switch (base) {
+        case 10: {
+            int64_t dec = (int64_t)n;
+
+            luaL_Buffer b;
+            luaL_buffinit(lua , &b);
+            if (dec < 0) {
+                luaL_addchar(&b, '-');
+                dec = -dec;
+            }
+
+            int buffer[32];
+            int i;
+            for (i = 0; i < 32; i++) {
+                buffer[i] = dec % 10;
+                dec /= 10;
+                if (dec == 0)
+                    break;
+            }
+
+            while (i >= 0) {
+                luaL_addchar(&b, hex[buffer[i]]);
+                --i;
+            }
+            luaL_pushresult(&b);
+            return 1;
+        }
+        case 2:
+            shift = 1;
+            mask = 1;
+            break;
+        case 8:
+            shift = 3;
+            mask = 7;
+            break;
+        case 16:
+            shift = 4;
+            mask = 0xf;
+            break;
+        default:
+            return luaL_error(lua, "Unsupport base %d", base);
+            break;
+    }
+
+    int i;
+    char buffer[64];
+    for (i = 0; i < 64; i += shift) {
+        buffer[i/shift] = hex[(n>>(64-shift-i)) & mask];
+    }
+
+    lua_pushlstring(lua, buffer, 64 / shift);
+    return 1;
+}
+
+static void
+_make_mt(lua_State *lua) {
+    luaL_Reg lib[] = {
+        { "__add", int64Add },
+        { "__sub", int64Sub },
+        { "__mul", int64Mul },
+        { "__div", int64Div },
+        { "__mod", int64Mod },
+        { "__unm", int64Unm },
+        { "__pow", int64Pow },
+        { "__eq", int64Eq },
+        { "__lt", int64Lt },
+        { "__le", int64Le },
+        { "__len", int64Len },
+        { "__tostring", tostring },
+        { NULL, NULL },
+    };
+    luaL_register(lua, "int64", lib);
+}
+
+int
+luaopen_int64(lua_State *lua) {
+
+    if (sizeof(intptr_t)!=sizeof(int64_t)) {
+        return luaL_error(lua, "Only support 64bit architecture");
+    }
+
+    lua_pushlightuserdata(lua, NULL);
+    _make_mt(lua);
+    lua_setmetatable(lua, -2);
+    lua_pop(lua, 1);
+
+    lua_newtable(lua);
+    lua_pushcfunction(lua, int64New);
+    lua_setfield(lua, -2, "new");
+    lua_pushcfunction(lua, tostring);
+    lua_setfield(lua, -2, "tostring");
+    lua_setglobal(lua, "int64"); 
+
+    return 1;
+}
+

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -45,6 +45,7 @@ char *redisProtocolToLuaType_MultiBulk(lua_State *lua, char *reply);
 int redis_math_random (lua_State *L);
 int redis_math_randomseed (lua_State *L);
 void sha1hex(char *digest, char *script, size_t len);
+int luaopen_int64(lua_State *L);
 
 /* Take a Redis reply in the Redis protocol format and convert it into a
  * Lua type. Thanks to this function, and the introduction of not connected
@@ -540,6 +541,8 @@ void scriptingInit(void) {
 
     luaLoadLibraries(lua);
     luaRemoveUnsupportedFunctions(lua);
+
+    luaopen_int64(lua);
 
     /* Initialize a dictionary we use to map SHAs to scripts.
      * This is useful for replication, as we need to replicate EVALSHA

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -30,6 +30,122 @@ start_server {tags {"scripting"}} {
         set _ $e
     } {this is an error}
 
+    test {EVAL - Lua int64 -> Reids int64 type support} {
+        r eval { 
+            local a = int64.new('1')
+            return type(a)
+        } 0
+    } {userdata}
+
+    test {EVAL - Lua int64 -> Redis int64 type conversion} {
+        r eval {
+            return {
+                int64.tostring(int64.new('1')),
+                int64.tostring(int64.new(1024)),
+                int64.tostring(int64.new('-1')),
+                int64.tostring(int64.new('f', 16))
+            }
+        } 0
+    } {1 1024 -1 15}
+
+    test {EVAL - Lua int64 -> Redis int64 support} {
+        r eval {
+            local a = int64.new('2147483648')
+            local b = int64.new('9223372036854775807')
+            return {
+                int64.tostring(a + b),
+                int64.tostring(b - a),
+            }
+        } 0
+    } {-9223372034707292161 9223372034707292159}
+
+    test {EVAL - Lua int64 -> Redis negative int64 support} {
+        r eval {
+            local a = int64.new('-1')
+            local b = int64.new('10')
+            return {
+                int64.tostring(a + b),
+                int64.tostring(b - a),
+                int64.tostring(b * a),
+                int64.tostring(b / a),
+            }
+        } 0
+    } {9 11 -10 -10}
+
+    test {EVAL - Lua int64 -> Redis int64 addition support} {
+        r eval {
+            local a = int64.new('1')
+            local b = int64.new('10')
+            return {
+                int64.tostring(a + b)
+            }
+        } 0
+    } {11}
+
+    test {EVAL - Lua int64 -> Redis int64 subtraction support} {
+        r eval {
+            local a = int64.new('1')
+            local b = int64.new('10')
+            return {
+                int64.tostring(a - b)
+            }
+        } 0
+    } {-9}
+
+    test {EVAL - Lua int64 -> Redis int64 multiplication support} {
+        r eval {
+            local a = int64.new('1')
+            local b = int64.new('10')
+            local c = int64.new('0')
+            return {
+                int64.tostring(a * b),
+                int64.tostring(a * c),
+            }
+        } 0
+    } {10 0}
+
+    test {EVAL - Lua int64 -> Redis int64 division support} {
+        r eval {
+            local a = int64.new('1')
+            local b = int64.new('10')
+            return {
+                int64.tostring(b / a),
+            }
+        } 0
+    } {10}
+
+    test {EVAL - Lua int64 -> Redis int64 division exception} {
+        set e {}
+        catch {
+            r eval {
+                local a = int64.new('0')
+                local b = int64.new('10')
+                int64.tostring(b / a)
+            } 0
+        } e
+        set e
+    } {*div by zero}
+
+    test {EVAL - Lua int64 -> Redis int64 compare support} {
+        r eval {
+            local a = int64.new('-1')
+            local b = int64.new('10')
+            local c = int64.new('0')
+            return {
+                a > b,
+                b > a,
+                a < c,
+                c < a,
+                a == a,
+                a == b,
+                a >= c,
+                c >= a,
+                a <= c,
+                c <= a,
+            }
+        } 0
+    } {{} 1 1 {} 1 {} {} 1 1 {}}
+
     test {EVAL - Lua table -> Redis protocol type conversion} {
         r eval {return {1,2,3,'ciao',{1,2}}} 0
     } {1 2 3 ciao {1 2}}


### PR DESCRIPTION
@antire,

I added int64 support for redis lua in this patch. 

Currently, “number" is the only type in lua to define numerical object, which is actually a "double". The integer returned from redis will be conversed to "number"; the return value of "tonumber" lua function is also a "number". However, the conversion from a 64bit "int" to a "double" may cause loss of data.

In some cases, we'd like to use "int64" type, and do some calculation in lua script(i.e. incremental id). So I added this support for redis, and want to merge it to redis, since it is a common requirement. 

Pls let me know if you have any comments, thx.
