### PR TITLE
fix sort order with `store` param in sort command

### DIFF
--- a/src/sort.c
+++ b/src/sort.c
@@ -165,7 +165,7 @@ int sortCompare(const void *s1, const void *s2) {
             } else {
                 /* We have both the objects, compare them. */
                 if (server.sort_store) {
-                    cmp = compareStringObjects(so1->u.cmpobj,so2->u.cmpobj);
+                    cmp = collateStringObjects(so1->u.cmpobj,so2->u.cmpobj);
                 } else {
                     /* Here we can use strcoll() directly as we are sure that
                      * the objects are decoded string objects. */
@@ -174,11 +174,7 @@ int sortCompare(const void *s1, const void *s2) {
             }
         } else {
             /* Compare elements directly. */
-            if (server.sort_store) {
-                cmp = compareStringObjects(so1->obj,so2->obj);
-            } else {
-                cmp = collateStringObjects(so1->obj,so2->obj);
-            }
+            cmp = collateStringObjects(so1->obj,so2->obj);
         }
     }
     return server.sort_desc ? -cmp : cmp;


### PR DESCRIPTION
My LC_COLLATE is zh_CN.UTF-8, but sort command with `store` param is sorted with memory encoding order.

127.0.0.1:6379> hset test:a prop 爸爸
1
127.0.0.1:6379> hset test:b prop 妈妈
1
127.0.0.1:6379> hset test:c prop 爷爷
1
127.0.0.1:6379> hset test:d prop 奶奶
1
127.0.0.1:6379> hset test:e prop 姑姑
1
127.0.0.1:6379> lpush test a b c d e
5
127.0.0.1:6379> sort test by test:*->prop alpha
a
e
b
d
c
127.0.0.1:6379> sort test by test:*->prop alpha store test1
5
127.0.0.1:6379> lrange test1 0 -1
d
b
e
c
a
