### PR TITLE
Fix key extraction for SORT

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1076,7 +1076,7 @@ int *evalGetKeys(struct redisCommand *cmd, robj **argv, int argc, int *numkeys) 
  * follow in SQL-alike style. Here we parse just the minimum in order to
  * correctly identify keys in the "STORE" option. */
 int *sortGetKeys(struct redisCommand *cmd, robj **argv, int argc, int *numkeys) {
-    int i, j, num, *keys;
+    int i, j, num, *keys, found_store = 0;
     REDIS_NOTUSED(cmd);
 
     num = 0;
@@ -1107,12 +1107,13 @@ int *sortGetKeys(struct redisCommand *cmd, robj **argv, int argc, int *numkeys) 
                 /* Note: we don't increment "num" here and continue the loop
                  * to be sure to process the *last* "STORE" option if multiple
                  * ones are provided. This is same behavior as SORT. */
+                found_store = 1;
                 keys[num] = i+1; /* <store-key> */
                 break;
             }
         }
     }
-    *numkeys = num;
+    *numkeys = num + found_store;
     return keys;
 }
 

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -95,6 +95,14 @@ start_server {
         assert_encoding ziplist sort-res
     }
 
+    test "SORT extracts STORE correctly" {
+        r command getkeys sort abc store def
+    } {abc def}
+
+    test "SORT extracts multiple STORE correctly" {
+        r command getkeys sort abc store invalid store stillbad store def
+    } {abc def}
+
     test "SORT DESC" {
         assert_equal [lsort -decreasing -integer $result] [r sort tosort DESC]
     }


### PR DESCRIPTION
We only want to use the last STORE key, but we have to record
we actually found a STORE key so we can increment the final return
key count.

Test added to prevent further regression.

(As noted in antirez/redis-doc#392)
