### PR TITLE
Fix spelling of "stand alone" in ascii art

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -3381,10 +3381,11 @@ void usage() {
 void redisAsciiArt(void) {
 #include "asciilogo.h"
     char *buf = zmalloc(1024*16);
-    char *mode = "stand alone";
+    char *mode;
 
     if (server.cluster_enabled) mode = "cluster";
     else if (server.sentinel_mode) mode = "sentinel";
+    else mode = "standalone";
 
     snprintf(buf,1024*16,ascii_logo,
         REDIS_VERSION,


### PR DESCRIPTION
Also unified the logic to match `genRedisInfoString`
