### PR TITLE
Fail SYNC if background save child aborted due to a signal.

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1221,7 +1221,7 @@ void backgroundSaveDoneHandler(int exitcode, int bysignal) {
     server.rdb_save_time_start = -1;
     /* Possibly there are slaves waiting for a BGSAVE in order to be served
      * (the first stage of SYNC is a bulk transfer of dump.rdb) */
-    updateSlavesWaitingBgsave(exitcode == 0 ? REDIS_OK : REDIS_ERR);
+    updateSlavesWaitingBgsave((!bysignal && exitcode == 0) ? REDIS_OK : REDIS_ERR);
 }
 
 void saveCommand(redisClient *c) {


### PR DESCRIPTION
Currently only exit code is tested, but slaves should get an error also when the child exits because of a signal (e.g. KILL by OOM killer, etc.).

I think not testing this may even result with corrupted replication:
1. BGSAVE child aborts, so there's no new rdb file.
2. The main process thinks the BGSAVE completed and sends an OLD RDB to the slave.
3. The slave loads an old RDB and proceeds to apply the slave output buffer content, but is actually missing everything that was written in-between.
