### PR TITLE
Use correct github raw url

### DIFF
--- a/utils/generate-command-help.rb
+++ b/utils/generate-command-help.rb
@@ -50,7 +50,7 @@ def commands
   require "json"
   require "uri"
 
-  url = URI.parse "https://raw.github.com/antirez/redis-doc/master/commands.json"
+  url = URI.parse "https://raw.githubusercontent.com/antirez/redis-doc/master/commands.json"
   client = Net::HTTP.new url.host, url.port
   client.use_ssl = true
   response = client.get url.path


### PR DESCRIPTION
Once this is merged and the latest changes to `commands.json` in antirez/redis-doc are merged, `utils/generate-command-help.rb > src/help.h` should be re-run, so we get nice and easy tab-completed help in `redis-cli` again for all available commands.
