### PR TITLE
Sentinel: fix bufsize to support IPv6 address

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -455,7 +455,7 @@ void sentinelIsRunning(void) {
  *  EINVAL: Invalid port number.
  */
 sentinelAddr *createSentinelAddr(char *hostname, int port) {
-    char buf[32];
+    char buf[REDIS_IP_STR_LEN];
     sentinelAddr *sa;
 
     if (port <= 0 || port > 65535) {
@@ -2682,7 +2682,7 @@ void sentinelCommand(redisClient *c) {
         /* SENTINEL MONITOR <name> <ip> <port> <quorum> */
         sentinelRedisInstance *ri;
         long quorum, port;
-        char buf[32];
+        char buf[REDIS_IP_STR_LEN];
 
         if (c->argc != 6) goto numargserr;
         if (getLongFromObjectOrReply(c,c->argv[5],&quorum,"Invalid quorum")


### PR DESCRIPTION
As `char[32]` is not sufficient for an IPv6 address, I changed it to `char[REDIS_IP_STR_LEN]`, which makes sentinels to run on IPv6 network.
