### PR TITLE
Add naming of databases

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -320,6 +320,13 @@ void selectCommand(redisClient *c) {
     }
 }
 
+void dbnameCommand(redisClient *c) {
+    sds name = c->argv[1]->ptr;
+    c->db->name = sdsnewlen(name,sdslen(name));
+
+    addReply(c,shared.ok);
+}
+
 void randomkeyCommand(redisClient *c) {
     robj *key;
 

--- a/src/redis.c
+++ b/src/redis.c
@@ -223,6 +223,7 @@ struct redisCommand redisCommandTable[] = {
     {"keys",keysCommand,2,"rS",0,NULL,0,0,0,0,0},
     {"scan",scanCommand,-2,"rR",0,NULL,0,0,0,0,0},
     {"dbsize",dbsizeCommand,1,"rF",0,NULL,0,0,0,0,0},
+    {"dbname",dbnameCommand,2,"w",0,NULL,0,0,0,0,0},
     {"auth",authCommand,2,"rsltF",0,NULL,0,0,0,0,0},
     {"ping",pingCommand,-1,"rtF",0,NULL,0,0,0,0,0},
     {"echo",echoCommand,2,"rF",0,NULL,0,0,0,0,0},
@@ -1759,6 +1760,7 @@ void initServer() {
         server.db[j].eviction_pool = evictionPoolAlloc();
         server.db[j].id = j;
         server.db[j].avg_ttl = 0;
+        server.db[j].name = sdsnewlen("",0);
     }
     server.pubsub_channels = dictCreate(&keylistDictType,NULL);
     server.pubsub_patterns = listCreate();
@@ -2974,8 +2976,8 @@ sds genRedisInfoString(char *section) {
             vkeys = dictSize(server.db[j].expires);
             if (keys || vkeys) {
                 info = sdscatprintf(info,
-                    "db%d:keys=%lld,expires=%lld,avg_ttl=%lld\r\n",
-                    j, keys, vkeys, server.db[j].avg_ttl);
+                    "db%d:keys=%lld,expires=%lld,avg_ttl=%lld,name=%s\r\n",
+                    j, keys, vkeys, server.db[j].avg_ttl, server.db[j].name);
             }
         }
     }

--- a/src/redis.h
+++ b/src/redis.h
@@ -447,6 +447,7 @@ typedef struct redisDb {
     struct evictionPoolEntry *eviction_pool;    /* Eviction pool of keys */
     int id;                     /* Database ID */
     long long avg_ttl;          /* Average TTL, just for stats */
+    sds name;                   /* Database name */
 } redisDb;
 
 /* Client MULTI/EXEC state */
@@ -1343,6 +1344,7 @@ char *redisGitDirty(void);
 uint64_t redisBuildId(void);
 
 /* Commands prototypes */
+void dbnameCommand(redisClient *c);
 void authCommand(redisClient *c);
 void pingCommand(redisClient *c);
 void echoCommand(redisClient *c);


### PR DESCRIPTION
Firstly, I'm not a C developer so this might not be the best way to add this feature.  It's not yet ready for merging, I've got a few questions below that I'd like to sort out before it's in a mergeable state.

This adds the ability to name databases:

```
set a 1
dbname site-cache
select 1
set a 1
dbname sessions
info
```

leads to

```
db0:keys=1,expires=0,avg_ttl=0,name=site-cache
db1:keys=1,expires=0,avg_ttl=0,name=sessions
```

The reason for adding this was so I could quickly see at a glance what a database is being used for.

Questions:
1. Would this feature be wanted?
2. How do I go about getting the name to save and persist between restarts?
3. How do I get the name to sync to slaves?
