### PR TITLE
ZFILTERSTORE

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -178,6 +178,7 @@ struct redisCommand redisCommandTable[] = {
     {"zremrangebylex",zremrangebylexCommand,4,"w",0,NULL,1,1,1,0,0},
     {"zunionstore",zunionstoreCommand,-4,"wm",0,zunionInterGetKeys,0,0,0,0,0},
     {"zinterstore",zinterstoreCommand,-4,"wm",0,zunionInterGetKeys,0,0,0,0,0},
+    {"zfilterstore",zfilterstoreCommand,-5,"wm",0,zunionInterGetKeys,0,0,0,0,0},
     {"zrange",zrangeCommand,-4,"r",0,NULL,1,1,1,0,0},
     {"zrangebyscore",zrangebyscoreCommand,-4,"r",0,NULL,1,1,1,0,0},
     {"zrevrangebyscore",zrevrangebyscoreCommand,-4,"r",0,NULL,1,1,1,0,0},

--- a/src/redis.h
+++ b/src/redis.h
@@ -326,6 +326,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define REDIS_OP_UNION 0
 #define REDIS_OP_DIFF 1
 #define REDIS_OP_INTER 2
+#define REDIS_OP_FILTER 3
 
 /* Redis maxmemory strategies */
 #define REDIS_MAXMEMORY_VOLATILE_LRU 0
@@ -1460,6 +1461,7 @@ void hlenCommand(redisClient *c);
 void zremrangebyrankCommand(redisClient *c);
 void zunionstoreCommand(redisClient *c);
 void zinterstoreCommand(redisClient *c);
+void zfilterstoreCommand(redisClient *c);
 void zscanCommand(redisClient *c);
 void hkeysCommand(redisClient *c);
 void hvalsCommand(redisClient *c);


### PR DESCRIPTION
This commit adds the ZFILTERSTORE command, which works like ZUNIONSTORE
except that the command takes an additional "template" argument, and only
values that are in the template are aggregated.

The command allows for a much faster way to rank a subset of members
across a series of input sets, and can replace the following pattern:

ZINTERSTORE tmpset1 2 template input1
ZINTERSTORE tmpset2 2 template input2
ZINTERSTORE tmpset3 2 template input3
ZUNIONSTORE outset 3 tmpset1 tmpset2 tmpset3

The prototype of the command is like so:

ZFILTERSTORE outset num-input-sets template set1 ... setN

I'm not sure if other people use this pattern for filtering and ranking items in a ZSET but it sure seems like one that would be pretty common.  Also, this is the first time I really played around with Redis internals, so just let me know if I'm doing something silly.  I get no complaints from valgrind nor does it appear I'm leaking memory, but it's always possible.

Cheers,
Mike
