### PR TITLE
dictIterator::index: int -> long to avoid overflows. Closes #1929

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -576,7 +576,7 @@ dictEntry *dictNext(dictIterator *iter)
                     iter->fingerprint = dictFingerprint(iter->d);
             }
             iter->index++;
-            if (iter->index >= (signed) ht->size) {
+            if (iter->index >= (signed long) ht->size) {
                 if (dictIsRehashing(iter->d) && iter->table == 0) {
                     iter->table++;
                     iter->index = 0;

--- a/src/dict.c
+++ b/src/dict.c
@@ -576,7 +576,7 @@ dictEntry *dictNext(dictIterator *iter)
                     iter->fingerprint = dictFingerprint(iter->d);
             }
             iter->index++;
-            if (iter->index >= (signed long) ht->size) {
+            if (iter->index >= ht->size) {
                 if (dictIsRehashing(iter->d) && iter->table == 0) {
                     iter->table++;
                     iter->index = 0;

--- a/src/dict.h
+++ b/src/dict.h
@@ -87,7 +87,8 @@ typedef struct dict {
  * should be called while iterating. */
 typedef struct dictIterator {
     dict *d;
-    int table, index, safe;
+    int table, safe;
+    long index;
     dictEntry *entry, *nextEntry;
     long long fingerprint; /* unsafe iterator fingerprint for misuse detection */
 } dictIterator;


### PR DESCRIPTION
For reasoning, see #1929.

All tests pass, and everything runs as expected.

`int -> long` change needs to be made in `deps/hiredis/dict.h` also, but a PR will me made to it's repo.
