### PR TITLE
Fix typo

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -408,7 +408,7 @@ void exitFromChild(int retcode) {
 /*====================== Hash table type implementation  ==================== */
 
 /* This is a hash table type that uses the SDS dynamic strings library as
- * keys and radis objects as values (objects can hold SDS strings,
+ * keys and redis objects as values (objects can hold SDS strings,
  * lists, sets). */
 
 void dictVanillaFree(void *privdata, void *val)


### PR DESCRIPTION
Fun fact: this typo seems to have been in the [first commit](https://github.com/antirez/redis/commit/ed9b544e10b84cd43348ddfab7068b610a5df1f7).

Our long-lived nightmare will finally come to an end.
