### PR TITLE
Store the length of the static argv when first allocated.

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -224,6 +224,7 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
     /* Build the arguments vector */
     if (!argv) {
         argv = zmalloc(sizeof(robj*)*argc);
+        argv_size = argc;
     } else if (argv_size < argc) {
         argv = zrealloc(argv,sizeof(robj*)*argc);
         argv_size = argc;

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -358,6 +358,18 @@ start_server {tags {"scripting"}} {
             return redis.call("get", "key")
         } 0
     } {12039611435714932082}
+
+    test {Correct handling of reused argv (issue #1939)} {
+        r eval {
+              for i = 0, 10 do
+                  redis.call('SET', 'a', '1')
+                  redis.call('MGET', 'a', 'b', 'c')
+                  redis.call('EXPIRE', 'a', 0)
+                  redis.call('GET', 'a')
+                  redis.call('MGET', 'a', 'b', 'c')
+              end
+        } 0
+    }
 }
 
 # Start a new server since the last test in this stanza will kill the


### PR DESCRIPTION
This fixes a bug introduced by this commit:

8237d88

The length of the static argv is not stored when it is first created; only when extended. On the first occasion this is relatively harmless (since the initialised length was 0), but on any subsequent "first" allocation - eg after having been cleared here: https://github.com/antirez/redis/blob/8237d88f48e0843839eb530c408686d66bcae6ab/src/scripting.c#L352

then a new allocated argv implicitly inherits the length of the last freed one. Where the new argv is smaller than the last freed one, and then later reused without extension at any length greater than its actual length, memory is overwritten.

This fixes issue #1939.

See also related issue #1943.
