### PR TITLE
fix typo in zipmap.h, _ZIMMAP_H should be _ZIPMAP_H

### DIFF
--- a/src/zipmap.h
+++ b/src/zipmap.h
@@ -32,7 +32,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _ZIMMAP_H
+#ifndef _ZIPMAP_H
 #define _ZIPMAP_H
 
 unsigned char *zipmapNew(void);


### PR DESCRIPTION
hello, there should be typo in zipmap header file, below:

``` c
#ifndef _ZIMMAP_H // this should be _ZIPMAP_H not _ZIMMAP_H
#define _ZIPMAP_H
```

this bug is found in redis 2.2, 2.4, 2.6

thanks~ 
