### PR TITLE
Missing assert removal from sdsIncrLen()

### DIFF
--- a/deps/hiredis/sds.c
+++ b/deps/hiredis/sds.c
@@ -206,7 +206,6 @@ void sdsIncrLen(sds s, int incr) {
         assert(sh->len >= (unsigned int)(-incr));
     sh->len += incr;
     sh->free -= incr;
-    assert(sh->free >= 0);
     s[sh->len] = '\0';
 }
 


### PR DESCRIPTION
Companion for 8eeb1802ec42682a614a5ebca318a0ba44ca7c03, but dealing with hiredis.
