### PR TITLE
Always pidfile if defined

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1432,7 +1432,7 @@ void initServerConfig(void) {
     server.aof_flush_postponed_start = 0;
     server.aof_rewrite_incremental_fsync = REDIS_DEFAULT_AOF_REWRITE_INCREMENTAL_FSYNC;
     server.aof_load_truncated = REDIS_DEFAULT_AOF_LOAD_TRUNCATED;
-    server.pidfile = zstrdup(REDIS_DEFAULT_PID_FILE);
+    server.pidfile = NULL;
     server.rdb_filename = zstrdup(REDIS_DEFAULT_RDB_FILENAME);
     server.aof_filename = zstrdup(REDIS_DEFAULT_AOF_FILENAME);
     server.requirepass = NULL;
@@ -3385,6 +3385,10 @@ void linuxMemoryWarnings(void) {
 #endif /* __linux__ */
 
 void createPidFile(void) {
+    /* If pidfile requested, but no pidfile defined, use
+     * default pidfile path */
+    if (!server.pidfile) server.pidfile = zstrdup(REDIS_DEFAULT_PID_FILE);
+
     /* Try to write the pid file in a best-effort way. */
     FILE *fp = fopen(server.pidfile,"w");
     if (fp) {

--- a/src/redis.c
+++ b/src/redis.c
@@ -2372,7 +2372,7 @@ int prepareForShutdown(int flags) {
             return REDIS_ERR;
         }
     }
-    if (server.daemonize) {
+    if (server.daemonize || server.pidfile) {
         redisLog(REDIS_NOTICE,"Removing the pid file.");
         unlink(server.pidfile);
     }
@@ -3725,9 +3725,10 @@ int main(int argc, char **argv) {
     }
 
     server.supervised = redisIsSupervised();
-    if (server.daemonize && server.supervised == 0) daemonize();
+    int background = server.daemonize && server.supervised == 0;
+    if (background) daemonize();
     initServer();
-    if (server.daemonize && server.supervised == 0) createPidFile();
+    if (background || server.pidfile) createPidFile();
     redisSetProcTitle(argv[0]);
     redisAsciiArt();
 


### PR DESCRIPTION
This is a continuation of #463 

It's useful to have a pidfile be created even when Redis is in the foreground for various reasons.

These commits will always write the pidfile if `pidfile` is given in the configuration.

Two modes:
- foreground: If `pidfile` is not given in the configuration, then no pidfile is written.
- daemonize: If no `pidfile` in configuration, the default location is used (`#define REDIS_DEFAULT_PID_FILE "/var/run/redis.pid"`).  This is the current behavior.
