### PR TITLE
Limit key size

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1374,6 +1374,7 @@ void initServerConfig() {
     server.lua_timedout = 0;
     server.next_client_id = 1; /* Client IDs, start from 1 .*/
     server.loading_process_events_interval_bytes = (1024*1024*2);
+    server.max_key_size = REDIS_DEFAULT_MAX_KEY_SIZE;
 
     updateLRUClock();
     resetServerSaveParams();
@@ -2018,13 +2019,13 @@ int processCommand(redisClient *c) {
         return REDIS_OK;
     }
 
-    if (c->cmd->flags & REDIS_CMD_WRITE) {
+    if (server.max_key_size && c->cmd->flags & REDIS_CMD_WRITE) {
       int numkeys, i;
       int *keys = getKeysFromCommand(c->cmd, c->argv, c->argc, &numkeys, c->cmd->flags);
       robj *long_key = NULL;
 
       for (i = 0; i < numkeys; i++) {
-        if (stringObjectLen(c->argv[keys[i]]) > 1024) {
+        if (stringObjectLen(c->argv[keys[i]]) > server.max_key_size) {
           long_key = c->argv[keys[i]];
           break;
         }
@@ -2034,8 +2035,8 @@ int processCommand(redisClient *c) {
 
       if (long_key) {
         flagTransaction(c);
-        addReplyErrorFormat(c,"The key used is too long it was '%zu' characters, the maximum is 1024",
-           stringObjectLen(long_key));
+        addReplyErrorFormat(c,"The key used is too long it was '%zu' characters, the maximum is %zu",
+           stringObjectLen(long_key), server.max_key_size);
 
         return REDIS_OK;
       }

--- a/src/redis.h
+++ b/src/redis.h
@@ -129,6 +129,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define REDIS_BINDADDR_MAX 16
 #define REDIS_MIN_RESERVED_FDS 32
 #define REDIS_DEFAULT_LATENCY_MONITOR_THRESHOLD 0
+#define REDIS_DEFAULT_MAX_KEY_SIZE 0
 
 #define ACTIVE_EXPIRE_CYCLE_LOOKUPS_PER_LOOP 20 /* Loopkups per loop. */
 #define ACTIVE_EXPIRE_CYCLE_FAST_DURATION 1000 /* Microseconds */
@@ -803,6 +804,7 @@ struct redisServer {
     int assert_line;
     int bug_report_start; /* True if bug report header was already logged. */
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
+    size_t max_key_size; /* Largest key size */
 };
 
 typedef struct pubsubPattern {

--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -53,6 +53,7 @@ start_server {tags {"basic"}} {
     } [string repeat "abcd" 1000000]
 
     test {Very big key in SET} {
+        r config set max-key-size 1024
         set buf [string repeat "abcd" 1000000]
         catch {r set $buf "foo"} err
         format $err

--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -52,6 +52,12 @@ start_server {tags {"basic"}} {
         r get foo
     } [string repeat "abcd" 1000000]
 
+    test {Very big key in SET} {
+        set buf [string repeat "abcd" 1000000]
+        catch {r set $buf "foo"} err
+        format $err
+    } {ERR*}
+
     tags {"slow"} {
         test {Very big payload random access} {
             set err {}


### PR DESCRIPTION
## Problem

I've observed redis servers eat up all the machines memory and get into swapping causing issues on the clients, when a bug or just careless usage introduces very large keys (100s of MBs).
## What is here?

This adds the `max-key-size` config option, when the value of that option is not null keys longer than the number in bytes defined will be rejected.

I'm PRing against 2.8, I can move it to 3.x if there is interest.

Topic on the google group: https://groups.google.com/forum/#!topic/redis-db/aLxpHURnA8Q

/cc @csfrancis, @fbosany

what do you think ? @antirez @pietern 
