### PR TITLE
Added config: slaves refuse sync if too little data

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -273,6 +273,12 @@ slave-read-only yes
 # be a good idea.
 repl-disable-tcp-nodelay no
 
+# Set a minimum allowed size, in bytes, that will be allowed to be loaded by
+# a Slave from a Master. This can prevent an empty Master from wiping out
+# a Slave's data set.
+#
+# repl-min-transfer-size 0
+
 # Set the replication backlog size. The backlog is a buffer that accumulates
 # slave data when slaves are disconnected for some time, so that when a slave
 # wants to reconnect again, often a full resync is not needed, but a partial

--- a/src/config.c
+++ b/src/config.c
@@ -280,6 +280,8 @@ void loadServerConfigFromString(char *config) {
                 err = "repl-backlog-ttl can't be negative ";
                 goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"repl-min-transfer-size") && argc == 2) {
+            server.repl_min_transfer_size = memtoll(argv[1],NULL);
         } else if (!strcasecmp(argv[0],"masterauth") && argc == 2) {
         	server.masterauth = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"slave-serve-stale-data") && argc == 2) {

--- a/src/redis.c
+++ b/src/redis.c
@@ -1395,6 +1395,7 @@ void initServerConfig(void) {
     server.repl_disable_tcp_nodelay = REDIS_DEFAULT_REPL_DISABLE_TCP_NODELAY;
     server.slave_priority = REDIS_DEFAULT_SLAVE_PRIORITY;
     server.master_repl_offset = 0;
+    server.repl_min_transfer_size = 0;
 
     /* Replication partial resync backlog */
     server.repl_backlog = NULL;

--- a/src/redis.h
+++ b/src/redis.h
@@ -737,6 +737,7 @@ struct redisServer {
     redisClient *cached_master; /* Cached master to be reused for PSYNC. */
     int repl_syncio_timeout; /* Timeout for synchronous I/O calls */
     int repl_state;          /* Replication status if the instance is a slave */
+    off_t repl_min_transfer_size; /* Minimum allowed size of RDB to read from master during sync. */
     off_t repl_transfer_size; /* Size of RDB to read from master during sync. */
     off_t repl_transfer_read; /* Amount of RDB read from master during sync. */
     off_t repl_transfer_last_fsync_off; /* Offset when we fsync-ed last time. */

--- a/src/replication.c
+++ b/src/replication.c
@@ -763,6 +763,11 @@ void readSyncBulkPayload(aeEventLoop *el, int fd, void *privdata, int mask) {
             goto error;
         }
         server.repl_transfer_size = strtol(buf+1,NULL,10);
+        if (server.repl_transfer_size < server.repl_min_transfer_size) {
+            redisLog(REDIS_WARNING,"Bad RDB from MASTER, the transfer size of %lld is less than minimum allowed %lld bytes",
+            server.repl_transfer_size, server.repl_min_transfer_size);
+            goto error;
+        }
         redisLog(REDIS_NOTICE,
             "MASTER <-> SLAVE sync: receiving %lld bytes from master",
             (long long) server.repl_transfer_size);


### PR DESCRIPTION
Add a configuration option for slaves to refuse syncing to a master if there is not enough data in the master. Based on 2.8, basically a rebase of https://github.com/antirez/redis/pull/1247

ie:
repl-min-transfer-size 1g
