### PR TITLE
Limit key size unstable

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -224,6 +224,8 @@ void loadServerConfigFromString(char *config) {
             if (server.maxclients < 1) {
                 err = "Invalid max clients limit"; goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"max-key-size") && argc == 2) {
+            server.max_key_size = memtoll(argv[1],NULL);
         } else if (!strcasecmp(argv[0],"maxmemory") && argc == 2) {
             server.maxmemory = memtoll(argv[1],NULL);
         } else if (!strcasecmp(argv[0],"maxmemory-policy") && argc == 2) {
@@ -762,6 +764,9 @@ void configSetCommand(redisClient *c) {
             addReplyErrorFormat(c,"Changing directory: %s", strerror(errno));
             return;
         }
+    } else if (!strcasecmp(c->argv[2]->ptr,"max-key-size")) {
+        if (getLongLongFromObject(o,&ll) == REDIS_ERR || ll < 0) goto badfmt;
+        server.max_key_size = ll;
     } else if (!strcasecmp(c->argv[2]->ptr,"hash-max-ziplist-entries")) {
         if (getLongLongFromObject(o,&ll) == REDIS_ERR || ll < 0) goto badfmt;
         server.hash_max_ziplist_entries = ll;
@@ -1027,6 +1032,7 @@ void configGetCommand(redisClient *c) {
     config_get_numerical_field("cluster-node-timeout",server.cluster_node_timeout);
     config_get_numerical_field("cluster-migration-barrier",server.cluster_migration_barrier);
     config_get_numerical_field("cluster-slave-validity-factor",server.cluster_slave_validity_factor);
+    config_get_numerical_field("max-key-size", server.max_key_size)
 
     /* Bool (yes/no) values */
     config_get_bool_field("no-appendfsync-on-rewrite",
@@ -1772,6 +1778,7 @@ int rewriteConfig(char *path) {
     rewriteConfigStringOption(state,"requirepass",server.requirepass,NULL);
     rewriteConfigNumericalOption(state,"maxclients",server.maxclients,REDIS_MAX_CLIENTS);
     rewriteConfigBytesOption(state,"maxmemory",server.maxmemory,REDIS_DEFAULT_MAXMEMORY);
+    rewriteConfigBytesOption(state,"max-key-size",server.max_key_size,REDIS_DEFAULT_MAX_KEY_SIZE);
     rewriteConfigEnumOption(state,"maxmemory-policy",server.maxmemory_policy,
         "volatile-lru", REDIS_MAXMEMORY_VOLATILE_LRU,
         "allkeys-lru", REDIS_MAXMEMORY_ALLKEYS_LRU,

--- a/src/redis.c
+++ b/src/redis.c
@@ -2151,6 +2151,29 @@ int processCommand(redisClient *c) {
         }
     }
 
+    if (c->cmd->flags & REDIS_CMD_WRITE) {
+      int numkeys, i;
+      int *keys = getKeysFromCommand(c->cmd, c->argv, c->argc, &numkeys);
+      robj *long_key = NULL;
+
+      for (i = 0; i < numkeys; i++) {
+        if (stringObjectLen(c->argv[keys[i]]) > 1024) {
+          long_key = c->argv[keys[i]];
+          break;
+        }
+      }
+
+      getKeysFreeResult(keys);
+
+      if (long_key) {
+        flagTransaction(c);
+        addReplyErrorFormat(c,"The key used is too long it was '%zu' characters, the maximum is 1024",
+           stringObjectLen(long_key));
+
+        return REDIS_OK;
+      }
+    }
+
     /* Handle the maxmemory directive.
      *
      * First we try to free some memory if possible (if there are volatile

--- a/src/redis.h
+++ b/src/redis.h
@@ -129,6 +129,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define REDIS_BINDADDR_MAX 16
 #define REDIS_MIN_RESERVED_FDS 32
 #define REDIS_DEFAULT_LATENCY_MONITOR_THRESHOLD 0
+#define REDIS_DEFAULT_MAX_KEY_SIZE 0
 
 #define ACTIVE_EXPIRE_CYCLE_LOOKUPS_PER_LOOP 20 /* Loopkups per loop. */
 #define ACTIVE_EXPIRE_CYCLE_FAST_DURATION 1000 /* Microseconds */
@@ -873,6 +874,7 @@ struct redisServer {
     int assert_line;
     int bug_report_start; /* True if bug report header was already logged. */
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
+    size_t max_key_size; /* Largest key size */
 };
 
 typedef struct pubsubPattern {

--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -53,6 +53,7 @@ start_server {tags {"basic"}} {
     } [string repeat "abcd" 1000000]
 
     test {Very big key in SET} {
+        r config set max-key-size 1024
         set buf [string repeat "abcd" 1000000]
         catch {r set $buf "foo"} err
         format $err

--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -52,6 +52,12 @@ start_server {tags {"basic"}} {
         r get foo
     } [string repeat "abcd" 1000000]
 
+    test {Very big key in SET} {
+        set buf [string repeat "abcd" 1000000]
+        catch {r set $buf "foo"} err
+        format $err
+    } {ERR*}
+
     tags {"slow"} {
         test {Very big payload random access} {
             set err {}


### PR DESCRIPTION
same as #1968 but PRing against unstable.
## Problem

I've observed redis servers eat up all the machines memory and get into swapping causing issues on the clients, when a bug or just careless usage introduces very large keys (100s of MBs).
## What is here?

This adds the `max-key-size` config option, when the value of that option is not null keys longer than the number in bytes defined will be rejected.

I'm PRing against 2.8, I can move it to 3.x if there is interest.

Topic on the google group: https://groups.google.com/forum/#!topic/redis-db/aLxpHURnA8Q

/cc @csfrancis, @fbogsany

what do you think ? @antirez @pietern @badboy
