### PR TITLE
Update redis-check-dump.c

### DIFF
--- a/src/redis-check-dump.c
+++ b/src/redis-check-dump.c
@@ -585,6 +585,7 @@ void printErrorStack(entry *e) {
         /* display truncation at the last 3 chars */
         if (strlen(e->key) > 40) {
             memset(&tmp[37], '.', 3);
+            tmp[40] = '\0';
         }
 
         /* display unprintable characters as ? */


### PR DESCRIPTION
Fixes sprintf reading beyond the end of a buffer if a key gets truncated.
