### PR TITLE
fix typo

### DIFF
--- a/utils/lru/test-lru.rb
+++ b/utils/lru/test-lru.rb
@@ -49,7 +49,7 @@ inserted = r.dbsize
 first_set_max_id = id
 puts "#{r.dbsize} keys inserted"
 
-# Access keys sequencially
+# Access keys sequentially
 
 puts "Access keys sequentially"
 (1..first_set_max_id).each{|id|

--- a/utils/lru/test-lru.rb
+++ b/utils/lru/test-lru.rb
@@ -51,7 +51,7 @@ puts "#{r.dbsize} keys inserted"
 
 # Access keys sequencially
 
-puts "Access keys sequencially"
+puts "Access keys sequentially"
 (1..first_set_max_id).each{|id|
     r.get(id)
 #    sleep 0.001


### PR DESCRIPTION
Fixed a typo - "secuentially" is actually spelled as "sequentially".
