### PR TITLE
Fix hiredis getaddrinfo leak

### DIFF
--- a/deps/hiredis/net.c
+++ b/deps/hiredis/net.c
@@ -300,6 +300,7 @@ static int _redisContextConnectTcp(redisContext *c, const char *addr, int port,
                     break;
                 }
             }
+            freeaddrinfo(bservinfo);
             if (!bound) {
                 char buf[128];
                 snprintf(buf,sizeof(buf),"Can't bind socket: %s",strerror(errno));


### PR DESCRIPTION
Fixed in Redis by 1a5e5b6, but since that part of the hiredis code is largely copy/paste'd from Redis, the fix needs to be ported over too.

Fix confirmed in #2012
