### PR TITLE
Update EVALSHA help

### DIFF
--- a/src/help.h
+++ b/src/help.h
@@ -172,7 +172,7 @@ struct commandHelp {
     "2.6.0" },
     { "EVALSHA",
     "sha1 numkeys key [key ...] arg [arg ...]",
-    "Execute a Lua script server side",
+    "Execute a cached Lua script server side by its SHA1 digest",
     10,
     "2.6.0" },
     { "EXEC",


### PR DESCRIPTION
EVAL and EVALSHA descriptions are currently equal. This update adds the information that for EVALSHA the script should already be cached and that it's called by its SHA-1 digest.
