### PR TITLE
Cast to avoid warning

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -336,7 +336,7 @@ void debugCommand(redisClient *c) {
         dictExpand(c->db->dict,keys);
         for (j = 0; j < keys; j++) {
             snprintf(buf,sizeof(buf),"%s:%lu",
-                (c->argc == 3) ? "key" : c->argv[3]->ptr, j);
+                (c->argc == 3) ? "key" : (char *) c->argv[3]->ptr, j);
             key = createStringObject(buf,strlen(buf));
             if (lookupKeyRead(c->db,key) != NULL) {
                 decrRefCount(key);


### PR DESCRIPTION
Adds a "`(char *)`" cast to avoid the warning:

```
debug.c: In function ‘debugCommand’:
debug.c:339:17: warning: format ‘%s’ expects argument of type ‘char *’, but argument 4 has type ‘void *’ [-Wformat=]
                 (c->argc == 3) ? "key" : c->argv[3]->ptr, j);
                 ^
debug.c:339:17: warning: format ‘%s’ expects argument of type ‘char *’, but argument 4 has type ‘void *’ [-Wformat=]
```

Silly merge.
