### PR TITLE
Don't notify change when set same bit twice with SETBIT (Fix issue #1314)

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -291,8 +291,8 @@ void saddCommand(redisClient *c) {
     if (added) {
         signalModifiedKey(c->db,c->argv[1]);
         notifyKeyspaceEvent(REDIS_NOTIFY_SET,"sadd",c->argv[1],c->db->id);
+        server.dirty += added;
     }
-    server.dirty += added;
     addReplyLongLong(c,added);
 }
 


### PR DESCRIPTION
Don't change `dirty` or notify for a change when we set the same bit twice with `setbit`.

`setbit` should work like [`sadd`](https://github.com/antirez/redis/blob/73a809b1591378e1042a1028d0b8e10217e6e7c7/src/t_set.c#L250) which also doesn't mark anything dirty or send any notification when nothing changes.
