### PR TITLE
Add sum and sumfloat commands to sum keys. 

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -137,6 +137,8 @@ struct redisCommand redisCommandTable[] = {
     {"incr",incrCommand,2,"wmF",0,NULL,1,1,1,0,0},
     {"decr",decrCommand,2,"wmF",0,NULL,1,1,1,0,0},
     {"mget",mgetCommand,-2,"r",0,NULL,1,-1,1,0,0},
+    {"sum",sumCommand,-2,"r",0,NULL,1,-1,1,0,0},
+    {"sumfloat",sumfloatCommand,-2,"r",0,NULL,1,-1,1,0,0},
     {"rpush",rpushCommand,-3,"wmF",0,NULL,1,1,1,0,0},
     {"lpush",lpushCommand,-3,"wmF",0,NULL,1,1,1,0,0},
     {"rpushx",rpushxCommand,3,"wmF",0,NULL,1,1,1,0,0},

--- a/src/redis.h
+++ b/src/redis.h
@@ -1419,6 +1419,8 @@ void lremCommand(redisClient *c);
 void rpoplpushCommand(redisClient *c);
 void infoCommand(redisClient *c);
 void mgetCommand(redisClient *c);
+void sumCommand(redisClient *c);
+void sumfloatCommand(redisClient *c);
 void monitorCommand(redisClient *c);
 void expireCommand(redisClient *c);
 void expireatCommand(redisClient *c);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -284,6 +284,42 @@ void mgetCommand(redisClient *c) {
     }
 }
 
+void sumCommand(redisClient *c) {
+    long long value = 0.0, cur_value = 0.0;
+    int j;
+
+    for (j = 1; j < c->argc; j++) {
+        robj *o = lookupKeyRead(c->db,c->argv[j]);
+        if (o == NULL) {
+            continue;
+        }
+        if (getLongLongFromObject(o,&cur_value) != REDIS_OK)
+            continue;
+        else {
+            value+=cur_value;
+        }
+    }
+    addReplyLongLong(c, value);
+}
+
+void sumfloatCommand(redisClient *c) {
+    long double value = 0.0, cur_value = 0.0;
+    int j;
+
+    for (j = 1; j < c->argc; j++) {
+        robj *o = lookupKeyRead(c->db,c->argv[j]);
+        if (o == NULL) {
+            continue;
+        }
+        if (getLongDoubleFromObject(o,&cur_value) != REDIS_OK)
+            continue;
+        else {
+            value+=cur_value;
+        }
+    }
+    addReplyDouble(c, value);
+}
+
 void msetGenericCommand(redisClient *c, int nx) {
     int j, busykeys = 0;
 

--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -450,6 +450,32 @@ start_server {tags {"basic"}} {
         format $res
     } {hello world foo bared}
 
+    test {SUM} {
+        r flushdb
+        r set foo 0.9
+        r set bar 1
+        r set baz BAZ
+        set res {}
+        lappend res [r sum foo bar]
+        lappend res [r sum foo bar baz]
+        lappend res [r sum nonexisting1 nonexisting2 baz]
+        lappend res [r sum foo nonexisting1 baz]
+        format $res
+    } {1 1 0 0}
+
+    test {SUMFLOAT} {
+        r flushdb
+        r set foo 0.1
+        r set bar 1
+        r set baz BAZ
+        set res {}
+        lappend res [roundFloat [r sumfloat foo bar]]
+        lappend res [roundFloat [r sumfloat foo bar baz]]
+        lappend res [roundFloat [r sumfloat nonexisting1 nonexisting2 baz]]
+        lappend res [roundFloat [r sumfloat foo nonexisting1 baz]]
+        format $res
+    } {1.1 1.1 0 0.1}
+
     test {MGET} {
         r flushdb
         r set foo BAR


### PR DESCRIPTION
I suggest to add this usefull(at least for us) and simple command. It just returns a sum of a bunch of numeric keys. All non-integer (non-numeric for sumfloat) and non-existing keys are ignored. This behaviour is discussable (for example we can return an error if there is at least one non-numeric or non-integer key), but I personally tried to be consistent with other commands (for example mget command will return nil for non-string key). I would be glad to make a pull request to documentation if you find it usefull too. Many thanks.
