### PR TITLE
Sentinel: Add initial quorum bounds check

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2736,6 +2736,12 @@ void sentinelCommand(redisClient *c) {
             != REDIS_OK) return;
         if (getLongFromObjectOrReply(c,c->argv[4],&port,"Invalid port")
             != REDIS_OK) return;
+
+        if (quorum <= 0) {
+            addReplyError(c, "Quorum must be 1 or greater.");
+            return;
+        }
+
         /* Make sure the IP field is actually a valid IP before passing it
          * to createSentinelRedisInstance(), otherwise we may trigger a
          * DNS lookup at runtime. */


### PR DESCRIPTION
Without this commit, Redis can generate an invalid config:

``` haskell
127.0.0.1:26379> sentinel monitor bob-master 127.0.0.1 6379 0
```

Sentinel accepts that command, but then after a restart, we get...

```
*** FATAL CONFIG FILE ERROR ***
Reading the configuration file, at line 4
>>> 'sentinel monitor bob-master 127.0.0.1 6379 0'
Quorum must be 1 or greater.
```
