### PR TITLE
Added authentication to stop verb

### DIFF
--- a/utils/redis_init_script.tpl
+++ b/utils/redis_init_script.tpl
@@ -15,7 +15,7 @@ case "$1" in
             echo "$PIDFILE does not exist, process is not running"
         else
             PID=$(cat $PIDFILE)
-            AUTH=$(grep -Po "^requirepass +\K[^ ]*" $CONF)
+            AUTH=$(grep ^requirepass $CONF | awk '{print $2}')
             if [ "$AUTH" != "" ]
             then
                 AUTH="-a $AUTH"

--- a/utils/redis_init_script.tpl
+++ b/utils/redis_init_script.tpl
@@ -15,8 +15,13 @@ case "$1" in
             echo "$PIDFILE does not exist, process is not running"
         else
             PID=$(cat $PIDFILE)
+            AUTH=$(grep -Po "^requirepass +\K[^ ]*" $CONF)
+            if [ "$AUTH" != "" ]
+            then
+                AUTH="-a $AUTH"
+            fi
             echo "Stopping ..."
-            $CLIEXEC -p $REDISPORT shutdown
+            $CLIEXEC -p $REDISPORT $AUTH shutdown
             while [ -x /proc/${PID} ]
             do
                 echo "Waiting for Redis to shutdown ..."

--- a/utils/redis_init_script.tpl
+++ b/utils/redis_init_script.tpl
@@ -15,8 +15,8 @@ case "$1" in
             echo "$PIDFILE does not exist, process is not running"
         else
             PID=$(cat $PIDFILE)
-            AUTH=$(grep ^requirepass $CONF | awk '{print $2}')
-            if [ "$AUTH" != "" ]
+            AUTH=$(awk '/^requirepass/ { print $2 }' $CONF)
+            if [ -n "$AUTH" ]
             then
                 AUTH="-a $AUTH"
             fi


### PR DESCRIPTION
stop fails when trying to call redis-cli if `requirepass` is present in the conf file. This prevents some servers (e.g. my VM :)) from shutting down.
