### PR TITLE
Fix ziplist length updates on bigendian platforms

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -150,7 +150,7 @@
 /* We know a positive increment can only be 1 because entries can only be
  * pushed one at a time. */
 #define ZIPLIST_INCR_LENGTH(zl,incr) { \
-    if (ZIPLIST_LENGTH(zl) < UINT16_MAX) \
+    if (intrev16ifbe(ZIPLIST_LENGTH(zl)) < UINT16_MAX) \
         ZIPLIST_LENGTH(zl) = intrev16ifbe(intrev16ifbe(ZIPLIST_LENGTH(zl))+incr); \
 }
 


### PR DESCRIPTION
Adds call to intrev16ifbe to ensure ZIPLIST_LENGTH is compared correctly
