### PR TITLE
Add Dynamic Process Title Support

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -59,6 +59,10 @@ bind 127.0.0.1
 # If port 0 is specified Redis will not listen on a TCP socket.
 port 6379
 
+# Name for this Redis instance.
+# Only used to customize process title.
+# name "userdb-01"
+
 # TCP listen() backlog.
 #
 # In high requests-per-second environments you need an high backlog in order

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -360,6 +360,7 @@ void clusterSaveConfigOrDie(int do_fsync) {
         redisLog(REDIS_WARNING,"Fatal: can't update cluster config file.");
         exit(1);
     }
+    PROCTITLE_UPDATE();
 }
 
 /* Lock the cluster config using flock(), and leaks the file descritor used to
@@ -3641,6 +3642,55 @@ sds clusterGenNodesDescription(int filter) {
     }
     dictReleaseIterator(di);
     return ci;
+}
+
+/* Return a string describing the cluster state of this node.
+ * String looks like:
+ *   (epoch: <number>; replicas <count>; slots: <slot ranges>)
+ * The 'replicas' field does not show up with no replicas.
+ * The 'slots' field does not show up for replicas.
+ */
+sds clusterSelfDesc(void) {
+    clusterNode *node = server.cluster->myself;
+
+    sds ci = sdscatprintf(sdsempty(), "(epoch: %llu", node->configEpoch);
+
+    if (node->numslaves)
+        ci = sdscatprintf(ci, "; replicas: %d", node->numslaves);
+
+    if (node->slaveof)
+        ci = sdscatprintf(ci, "; %s from %s:%d",
+            (node->link || node->flags & REDIS_NODE_MYSELF) ?
+            "replicating" : "disconnected",
+            server.masterhost, server.masterport);
+
+    if (node->numslots) {
+        ci = sdscat(ci, "; slots:");
+
+        if (node->slaveof) node = node->slaveof;
+
+        /* Slots served by this instance */
+        int start = -1, j;
+
+        for (j = 0; j < REDIS_CLUSTER_SLOTS; j++) {
+            int bit;
+            if ((bit = clusterNodeGetSlotBit(node,j)) != 0) {
+                if (start == -1) start = j;
+            }
+            if (start != -1 && (!bit || j == REDIS_CLUSTER_SLOTS-1)) {
+                if (bit && j == REDIS_CLUSTER_SLOTS-1) j++;
+
+                if (start == j-1) {
+                    ci = sdscatprintf(ci," %d",start);
+                } else {
+                    ci = sdscatprintf(ci," %d-%d",start,j-1);
+                }
+                start = -1;
+            }
+        }
+    }
+
+    return sdscatlen(ci, ")", 1);
 }
 
 /* -----------------------------------------------------------------------------

--- a/src/config.c
+++ b/src/config.c
@@ -555,6 +555,8 @@ void loadServerConfigFromString(char *config) {
                 err = sentinelHandleConfiguration(argv+1,argc-1);
                 if (err) goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"name") && argc == 2) {
+            server.name = zstrdup(argv[1]);
         } else {
             err = "Bad directive or wrong number of arguments"; goto loaderr;
         }
@@ -977,6 +979,9 @@ void configSetCommand(redisClient *c) {
         if (getLongLongFromObject(o,&ll) == REDIS_ERR ||
             ll < 0) goto badfmt;
         server.cluster_slave_validity_factor = ll;
+    } else if (!strcasecmp(c->argv[2]->ptr,"name")) {
+        zfree(server.name);
+        server.name = zstrdup(((char*)o->ptr)[0] ? o->ptr : "");
     } else {
         addReplyErrorFormat(c,"Unsupported CONFIG parameter: %s",
             (char*)c->argv[2]->ptr);
@@ -1076,6 +1081,7 @@ void configGetCommand(redisClient *c) {
     config_get_string_field("unixsocket",server.unixsocket);
     config_get_string_field("logfile",server.logfile);
     config_get_string_field("pidfile",server.pidfile);
+    config_get_string_field("name",server.name);
 
     /* Numerical values */
     config_get_numerical_field("maxmemory",server.maxmemory);
@@ -1832,6 +1838,7 @@ int rewriteConfig(char *path) {
 
     rewriteConfigYesNoOption(state,"daemonize",server.daemonize,0);
     rewriteConfigStringOption(state,"pidfile",server.pidfile,REDIS_DEFAULT_PID_FILE);
+    rewriteConfigStringOption(state,"name",server.name,REDIS_DEFAULT_SERVER_NAME);
     rewriteConfigNumericalOption(state,"port",server.port,REDIS_SERVERPORT);
     rewriteConfigNumericalOption(state,"tcp-backlog",server.tcp_backlog,REDIS_TCP_BACKLOG);
     rewriteConfigBindOption(state);

--- a/src/config.c
+++ b/src/config.c
@@ -982,6 +982,7 @@ void configSetCommand(redisClient *c) {
     } else if (!strcasecmp(c->argv[2]->ptr,"name")) {
         zfree(server.name);
         server.name = zstrdup(((char*)o->ptr)[0] ? o->ptr : "");
+        PROCTITLE_UPDATE();
     } else {
         addReplyErrorFormat(c,"Unsupported CONFIG parameter: %s",
             (char*)c->argv[2]->ptr);

--- a/src/config.c
+++ b/src/config.c
@@ -557,6 +557,10 @@ void loadServerConfigFromString(char *config) {
             }
         } else if (!strcasecmp(argv[0],"name") && argc == 2) {
             server.name = zstrdup(argv[1]);
+        } else if (!strcasecmp(argv[0],"proctitle-dynamic") && argc == 2) {
+            if ((server.proctitle_enable = yesnotoi(argv[1])) == -1) {
+                err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
         } else {
             err = "Bad directive or wrong number of arguments"; goto loaderr;
         }

--- a/src/redis.c
+++ b/src/redis.c
@@ -1508,6 +1508,9 @@ void initServerConfig(void) {
     server.repl_backlog_time_limit = REDIS_DEFAULT_REPL_BACKLOG_TIME_LIMIT;
     server.repl_no_slaves_since = time(NULL);
 
+    /* Process Title Customization */
+    server.name = REDIS_DEFAULT_SERVER_NAME;
+
     /* Client output buffer limits */
     for (j = 0; j < REDIS_CLIENT_TYPE_COUNT; j++)
         server.client_obuf_limits[j] = clientBufferLimitsDefaults[j];

--- a/src/redis.h
+++ b/src/redis.h
@@ -136,6 +136,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define REDIS_BINDADDR_MAX 16
 #define REDIS_MIN_RESERVED_FDS 32
 #define REDIS_DEFAULT_LATENCY_MONITOR_THRESHOLD 0
+#define REDIS_DEFAULT_SERVER_NAME ""
 
 #define ACTIVE_EXPIRE_CYCLE_LOOKUPS_PER_LOOP 20 /* Loopkups per loop. */
 #define ACTIVE_EXPIRE_CYCLE_FAST_DURATION 1000 /* Microseconds */

--- a/src/redis.h
+++ b/src/redis.h
@@ -928,6 +928,10 @@ struct redisServer {
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
     /* System hardware info */
     size_t system_memory_size;  /* Total memory in system as reported by OS */
+    /* Process Title Formatting */
+    char *argv0;          /* Server's initial argv[0] */
+    char *name;           /* Name for server configured by the user */
+    int update_proctitle; /* Flag for serverCron() to update title */
 };
 
 typedef struct pubsubPattern {
@@ -1010,6 +1014,8 @@ typedef struct {
 #define REDIS_HASH_KEY 1
 #define REDIS_HASH_VALUE 2
 
+#define PROCTITLE_UPDATE() (server.update_proctitle = 1)
+
 /*-----------------------------------------------------------------------------
  * Extern declarations
  *----------------------------------------------------------------------------*/
@@ -1037,7 +1043,7 @@ void getRandomHexChars(char *p, unsigned int len);
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
 void exitFromChild(int retcode);
 size_t redisPopcount(void *s, long count);
-void redisSetProcTitle(char *title);
+void redisSetProcTitle(char *comment);
 
 /* networking.c -- Networking and Client related operations */
 redisClient *createClient(int fd);
@@ -1194,6 +1200,7 @@ int replicationCountAcksByOffset(long long offset);
 void replicationSendNewlineToMaster(void);
 long long replicationGetSlaveOffset(void);
 char *replicationGetSlaveName(redisClient *c);
+char *slaveDesc(void);
 
 /* Generic persistence functions */
 void startLoading(FILE *fp);
@@ -1375,6 +1382,7 @@ void clusterCron(void);
 void clusterPropagatePublish(robj *channel, robj *message);
 void migrateCloseTimedoutSockets(void);
 void clusterBeforeSleep(void);
+sds clusterSelfDesc(void);
 
 /* Sentinel */
 void initSentinelConfig(void);
@@ -1382,6 +1390,7 @@ void initSentinel(void);
 void sentinelTimer(void);
 char *sentinelHandleConfiguration(char **argv, int argc);
 void sentinelIsRunning(void);
+sds sentinelWatchingMasters(void);
 
 /* redis-check-rdb */
 int redis_check_rdb(char *rdbfilename);

--- a/src/redis.h
+++ b/src/redis.h
@@ -931,7 +931,8 @@ struct redisServer {
     /* Process Title Formatting */
     char *argv0;          /* Server's initial argv[0] */
     char *name;           /* Name for server configured by the user */
-    int update_proctitle; /* Flag for serverCron() to update title */
+    int proctitle_update; /* Boolean for serverCron() to update title */
+    int proctitle_enable; /* Boolean to enable custom procititle support */
 };
 
 typedef struct pubsubPattern {
@@ -1014,7 +1015,7 @@ typedef struct {
 #define REDIS_HASH_KEY 1
 #define REDIS_HASH_VALUE 2
 
-#define PROCTITLE_UPDATE() (server.update_proctitle = 1)
+#define PROCTITLE_UPDATE() (server.proctitle_update = 1)
 
 /*-----------------------------------------------------------------------------
  * Extern declarations

--- a/src/replication.c
+++ b/src/replication.c
@@ -495,6 +495,7 @@ void syncCommand(redisClient *c) {
     if (!strcasecmp(c->argv[0]->ptr,"psync")) {
         if (masterTryPartialResynchronization(c) == REDIS_OK) {
             server.stat_sync_partial_ok++;
+            PROCTITLE_UPDATE();
             return; /* No full resync needed, return. */
         } else {
             char *master_runid = c->argv[1]->ptr;
@@ -579,6 +580,7 @@ void syncCommand(redisClient *c) {
     listAddNodeTail(server.slaves,c);
     if (listLength(server.slaves) == 1 && server.repl_backlog == NULL)
         createReplicationBacklog();
+    PROCTITLE_UPDATE();
     return;
 }
 
@@ -1036,6 +1038,7 @@ void readSyncBulkPayload(aeEventLoop *el, int fd, void *privdata, int mask) {
         close(server.repl_transfer_fd);
         replicationCreateMasterClient(server.repl_transfer_s);
         redisLog(REDIS_NOTICE, "MASTER <-> SLAVE sync: Finished with success");
+        PROCTITLE_UPDATE();
         /* Restart the AOF subsystem now that we finished the sync. This
          * will trigger an AOF rewrite, and when done will start appending
          * to the new file. */
@@ -1252,6 +1255,7 @@ void syncWithMaster(aeEventLoop *el, int fd, void *privdata, int mask) {
         /* Send the PING, don't check for errors at all, we have the timeout
          * that will take care about this. */
         syncWrite(fd,"PING\r\n",6,100);
+        PROCTITLE_UPDATE();
         return;
     }
 
@@ -1370,12 +1374,14 @@ void syncWithMaster(aeEventLoop *el, int fd, void *privdata, int mask) {
     server.repl_transfer_fd = dfd;
     server.repl_transfer_lastio = server.unixtime;
     server.repl_transfer_tmpfile = zstrdup(tmpfile);
+    PROCTITLE_UPDATE();
     return;
 
 error:
     close(fd);
     server.repl_transfer_s = -1;
     server.repl_state = REDIS_REPL_CONNECT;
+    PROCTITLE_UPDATE();
     return;
 }
 
@@ -1512,6 +1518,19 @@ void slaveofCommand(redisClient *c) {
     addReply(c,shared.ok);
 }
 
+char *slaveDesc(void) {
+    char *slavestate;
+    switch(server.repl_state) {
+    case REDIS_REPL_NONE: slavestate = "none"; break;
+    case REDIS_REPL_CONNECT: slavestate = "connect"; break;
+    case REDIS_REPL_CONNECTING: slavestate = "connecting"; break;
+    case REDIS_REPL_RECEIVE_PONG: /* see next */
+    case REDIS_REPL_TRANSFER: slavestate = "sync"; break;
+    case REDIS_REPL_CONNECTED: slavestate = "connected"; break;
+    default: slavestate = "unknown"; break;
+    }
+    return slavestate;
+}
 /* ROLE command: provide information about the role of the instance
  * (master or slave) and additional information related to replication
  * in an easy to process format. */
@@ -1541,22 +1560,11 @@ void roleCommand(redisClient *c) {
         }
         setDeferredMultiBulkLength(c,mbcount,slaves);
     } else {
-        char *slavestate = NULL;
-
         addReplyMultiBulkLen(c,5);
         addReplyBulkCBuffer(c,"slave",5);
         addReplyBulkCString(c,server.masterhost);
         addReplyLongLong(c,server.masterport);
-        switch(server.repl_state) {
-        case REDIS_REPL_NONE: slavestate = "none"; break;
-        case REDIS_REPL_CONNECT: slavestate = "connect"; break;
-        case REDIS_REPL_CONNECTING: slavestate = "connecting"; break;
-        case REDIS_REPL_RECEIVE_PONG: /* see next */
-        case REDIS_REPL_TRANSFER: slavestate = "sync"; break;
-        case REDIS_REPL_CONNECTED: slavestate = "connected"; break;
-        default: slavestate = "unknown"; break;
-        }
-        addReplyBulkCString(c,slavestate);
+        addReplyBulkCString(c,slaveDesc());
         addReplyLongLong(c,server.master ? server.master->reploff : -1);
     }
 }
@@ -1940,6 +1948,7 @@ long long replicationGetSlaveOffset(void) {
 
 /* Replication cron function, called 1 time per second. */
 void replicationCron(void) {
+    int state_updated = 0;
     /* Non blocking connection timeout? */
     if (server.masterhost &&
         (server.repl_state == REDIS_REPL_CONNECTING ||
@@ -1948,6 +1957,7 @@ void replicationCron(void) {
     {
         redisLog(REDIS_WARNING,"Timeout connecting to the MASTER...");
         undoConnectWithMaster();
+        state_updated = 1;
     }
 
     /* Bulk transfer I/O timeout? */
@@ -1956,6 +1966,7 @@ void replicationCron(void) {
     {
         redisLog(REDIS_WARNING,"Timeout receiving bulk data from MASTER... If the problem persists try to set the 'repl-timeout' parameter in redis.conf to a larger value.");
         replicationAbortSyncTransfer();
+        state_updated = 1;
     }
 
     /* Timed out master when we are an already connected slave? */
@@ -1964,6 +1975,7 @@ void replicationCron(void) {
     {
         redisLog(REDIS_WARNING,"MASTER timeout: no data nor PING received...");
         freeClient(server.master);
+        state_updated = 1;
     }
 
     /* Check if we should connect to a MASTER */
@@ -1972,6 +1984,7 @@ void replicationCron(void) {
             server.masterhost, server.masterport);
         if (connectWithMaster() == REDIS_OK) {
             redisLog(REDIS_NOTICE,"MASTER <-> SLAVE sync started");
+            state_updated = 1;
         }
     }
 
@@ -2105,4 +2118,6 @@ void replicationCron(void) {
 
     /* Refresh the number of slaves with lag <= min-slaves-max-lag. */
     refreshGoodSlavesCount();
+
+    if (state_updated) PROCTITLE_UPDATE();
 }


### PR DESCRIPTION
This implements a dynamically updating process title based on the state of the Redis server.

The format of the new process title is:

```
{{executable}} {{name}} {{config}} {{ip0}}:{{port}} {{mode}} {{role}} {{state}}
```

where:

``` haskell
executable is: argv[0]
name is: [name] | <empty>
config is : config file path | <empty>
[Note: the name and config policy is (name xor config) - If a name is set, the config path is absent.]
mode is: cluster | sentinel | <empty> (empty if regular master/replica or master-with-no-replicas setup)
role is: master | replica | <empty> (empty if standalone master with no replicas)
state is: live cluster node description | live replica description | live sentinel description | <empty> (empty if no replica _or_ if a forked background process)
```

You can see example output based on different scenarios at https://gist.github.com/mattsta/7512d430b3cc43bd669e

Creation History:
- In commit 6356cf6808be9ea88ab97be33ebf1576eeb57da6, Redis changed the way it shows up in process lists.  Previously, the format was the launch command line.  After commit 6356cf6808be9ea88ab97be33ebf1576eeb57da6, then format became "redis-server ip:port" — which is _largely_ not useful in many scenarios!
  - personal note: When I have 10 Redis processes running on my server, I like to see them by logical name (typically the name of the config file shows is the name of the server), but having 10 servers with only port identifiers makes me consult _another_ lookup table to figure out what things are doing (or grep through pid files then match pid file contents to pid file names... it's not pretty).
- We've had people complaining about the change for a while.  See https://github.com/antirez/redis/issues/694 and https://github.com/antirez/redis/issues/1979
- So, after first suggesting this [back in April](https://github.com/antirez/redis/issues/694#issuecomment-41324583), I finally got around to adding a dynamic updating proctitle interface.

Implementation History:
- I started out by allowing a user-specified format string (double curly bracket formatting).  But, the format parsing code was [too ugly](https://github.com/mattsta/redis/blob/proctitle/src/redis.c#L3668-L3722), so I scrapped it in favor of [static content positions](https://github.com/mattsta/redis/blob/proctitle-noformat/src/redis.c#L3684-L3712).
- I added (or refactored out) unique state information reporters for each major mode of Redis ([master/replica](https://github.com/mattsta/redis/blob/proctitle-noformat/src/replication.c#L1514-L1526), [sentinel](https://github.com/mattsta/redis/blob/proctitle-noformat/src/sentinel.c#L2919-L2967), [cluster](https://github.com/mattsta/redis/blob/proctitle-noformat/src/cluster.c#L3560-L3607)).  I tried to select the best information to show for each mode, but we can always add or remove information as necessary.  (For example, I included cluster epoch in the cluster instance output, but not really sure why... it just looks neat.)
- The dynamic title updating is [triggered in serverCron()](https://github.com/mattsta/redis/blob/proctitle-noformat/src/redis.c#L1251-L1256) meaning:
  - to update the process title, functions call `PROCTITLE_UPDATE()` which just sets `server.update_proctitle = 1`
  - the server title update can lag server state by a second or two
  - if a process updates state multiple times, the state will only be read at most once per second (this prevents Redis from flapping the title unnecessarily).
  - Cluster and Sentinel both write out all state changes to config files — and it was very simple to just add the process title update flag to one place in the config writing code to trigger title updates too (since we know the state changed when the config updater is called).
  - Replication state tracking is a bit more tricky; it required adding `PROCTITLE_UPDATE()` triggers in a few different places since there's no centralized "replication state updated" hook.
  - Sentinel state tracking required some additional non-config-file-update-based triggers because internal per-node state (especially transitional states) aren't written out to the state/config files.
- I added a [very simple "server instance name" config option](https://github.com/mattsta/redis/commit/d9daeb778a1457867c39efd25e9d66eb894b6002) before people [started complaining about it](https://groups.google.com/forum/#!searchin/redis-db/instance$20name/redis-db/kEDe3IixFoo/moMjEOF6VFgJ).  We can either keep it, remove it, or refactor it into something more extensible.  I'd like to go further and have arbitrary "config metadata" per-instance, but that's out of the scope of what's needed for a simple process title name.

So, here it is.

If you've got free time and want to help double check everything here: try it out, try to make it crash, try to find any remaining edge cases where state updates don't get reflected in the title (meaning we need more `PROCTITLE_UPDATE()` calls somewhere), and try to think of any pathological conditions where the title updates could cause problems.

:shipit: 
