### PR TITLE
Object ttl command that does not change the object idletime

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -764,7 +764,7 @@ void objectCommand(redisClient *c) {
                 == NULL) return;
         addReplyLongLong(c, (long long) rdbSavedObjectLen(o));
     } else {
-        addReplyError(c,"Syntax error. Try OBJECT (refcount|encoding|idletime|ttl)");
+        addReplyError(c,"Syntax error. Try OBJECT (refcount|encoding|idletime|ttl|serializedlength)");
     }
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -717,7 +717,7 @@ long long estimateObjectTtl(redisDb *db, robj *key) {
     expire = dictGetSignedIntegerVal(de);
 
     ttl = expire-mstime();
-    if (ttl < 0) ttl = 0;
+    if (ttl < 0) return -1;
 
     return ((ttl+500)/1000); // in fashion of ttlGenericCommand, change from ms to s
 }

--- a/src/object.c
+++ b/src/object.c
@@ -739,7 +739,7 @@ robj *objectCommandLookupOrReply(redisClient *c, robj *key, robj *reply) {
 }
 
 /* Object command allows to inspect the internals of an Redis Object.
- * Usage: OBJECT <refcount|encoding|idletime|ttl> <key> */
+ * Usage: OBJECT <refcount|encoding|idletime|ttl|serializedlength> <key> */
 void objectCommand(redisClient *c) {
     robj *o;
 
@@ -759,6 +759,10 @@ void objectCommand(redisClient *c) {
         if ((o = objectCommandLookupOrReply(c,c->argv[2],shared.nullbulk))
                 == NULL) return;
         addReplyLongLong(c,estimateObjectTtl(c->db, c->argv[2]));
+    } else if (!strcasecmp(c->argv[1]->ptr,"serializedlength") && c->argc == 3) {
+        if ((o = objectCommandLookupOrReply(c,c->argv[2],shared.nullbulk))
+                == NULL) return;
+        addReplyLongLong(c, (long long) rdbSavedObjectLen(o));
     } else {
         addReplyError(c,"Syntax error. Try OBJECT (refcount|encoding|idletime|ttl)");
     }

--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -803,4 +803,44 @@ start_server {tags {"basic"}} {
         r set foo bar
         r getrange foo 0 4294967297
     } {bar}
+
+    test {OBJECT SERIALIZEDLENGTH correct value strings} {
+        # The serializedlength of strings should be the length of the string + 1 (zero byte)
+        r set foo val
+        assert {[r object serializedlength foo] == 4}
+        r set foo valval
+        assert {[r object serializedlength foo] == 7}
+        r set foo valvalval
+        assert {[r object serializedlength foo] == 10}
+    }
+    
+    test {OBJECT TTL does not affect the TTL} {
+        r del mykey
+        r set mykey foo
+        # No expire set, both should return -1
+        assert {[r object ttl mykey] == -1}
+        assert {[r ttl mykey] == -1}
+        r expire mykey 100
+        
+        # After setting the expire to 100 seconds, both methods should return a TTL right below 100 seconds
+        assert {[r ttl mykey] > 95 && [r ttl mykey] <= 100}
+        assert {[r object ttl mykey] > 95 && [r object ttl mykey] <= 100}
+        assert {[r object idletime mykey] <= 5}
+
+        # Now sleep for 5 seconds
+        r debug sleep 5
+        
+        # The idletime should be at least 5 seconds
+        assert {[r object idletime mykey]  >= 5}
+        
+        # The TTL should be right below 95 seconds
+        assert {[r object ttl mykey] > 90 && [r object ttl mykey] <= 95}
+        
+        # The idletime should be intact
+        assert {[r object idletime mykey]  >= 5}
+        
+        # Now notice that when running the regular TTL command we affect the idletime 
+        assert {[r ttl mykey] > 90 && [r ttl mykey] <= 95}
+        assert {[r object idletime mykey]  == 0}
+    }
 }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -198,34 +198,4 @@ start_server {tags {"expire"}} {
         r set foo b
         lsort [r keys *]
     } {a e foo s t}
-    
-    test {OBJECT TTL does not affect the TTL of the key} {
-        r del mykey
-        r set mykey foo
-        # No expire set, both should return -1
-        assert {[r object ttl mykey] == -1}
-        assert {[r ttl mykey] == -1}
-        r expire mykey 100
-        
-        # After setting the expire to 100 seconds, both methods should return a TTL right below 100 seconds
-        assert {[r ttl mykey] > 95 && [r ttl mykey] <= 100}
-        assert {[r object ttl mykey] > 95 && [r object ttl mykey] <= 100}
-        assert {[r object idletime mykey] <= 5}
-
-        # Now sleep for 5 seconds
-        r debug sleep 5
-        
-        # The idletime should be at least 5 seconds
-        assert {[r object idletime mykey]  >= 5}
-        
-        # The TTL should be right below 95 seconds
-        assert {[r object ttl mykey] > 90 && [r object ttl mykey] <= 95}
-        
-        # The idletime should be intact
-        assert {[r object idletime mykey]  >= 5}
-        
-        # Now notice that when running the regular TTL command we affect the idletime 
-        assert {[r ttl mykey] > 90 && [r ttl mykey] <= 95}
-        assert {[r object idletime mykey]  == 0}
-    }
 }


### PR DESCRIPTION
The regular TTL command sets the idletime to zero. This command returns the TTL in seconds without modifying the idletime.
This can be useful when you are fetching information about objects but don't want to touch them at the same time.
