### PR TITLE
Add slave IP details during a sync

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -589,6 +589,22 @@ error:
     return -1;
 }
 
+int anetFormatIP(char *fmt, size_t fmt_len, char *ip, int port) {
+    if (port >= 0)
+        return snprintf(fmt,fmt_len,
+            strchr(ip,':') ? "[%s]:%d" : "%s:%d", ip, port);
+    else
+        return snprintf(fmt, fmt_len, strchr(ip,':') ? "[%s]" : "%s", ip);
+}
+
+int anetFormatPeer(int fd, char *fmt, size_t fmt_len) {
+    char ip[INET6_ADDRSTRLEN];
+    int port;
+
+    anetPeerToString(fd,ip,sizeof(ip),&port);
+    return anetFormatIP(fmt, fmt_len, ip, port);
+}
+
 int anetSockName(int fd, char *ip, size_t ip_len, int *port) {
     struct sockaddr_storage sa;
     socklen_t salen = sizeof(sa);
@@ -609,4 +625,12 @@ int anetSockName(int fd, char *ip, size_t ip_len, int *port) {
         if (port) *port = ntohs(s->sin6_port);
     }
     return 0;
+}
+
+int anetFormatSock(int fd, char *fmt, size_t fmt_len) {
+    char ip[INET6_ADDRSTRLEN];
+    int port;
+
+    anetSockName(fd,ip,sizeof(ip),&port);
+    return anetFormatIP(fmt, fmt_len, ip, port);
 }

--- a/src/anet.h
+++ b/src/anet.h
@@ -70,5 +70,8 @@ int anetSendTimeout(char *err, int fd, long long ms);
 int anetPeerToString(int fd, char *ip, size_t ip_len, int *port);
 int anetKeepAlive(char *err, int fd, int interval);
 int anetSockName(int fd, char *ip, size_t ip_len, int *port);
+int anetFormatIP(char *fmt, size_t fmt_len, char *ip, int port);
+int anetFormatPeer(int fd, char *fmt, size_t fmt_len);
+int anetFormatSock(int fd, char *fmt, size_t fmt_len);
 
 #endif

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1552,8 +1552,10 @@ int clusterProcessPacket(clusterLink *link) {
                 strcmp(ip,myself->ip))
             {
                 memcpy(myself->ip,ip,REDIS_IP_STR_LEN);
+
+                anetFormatIP(ip, sizeof(ip), myself->ip, -1);
                 redisLog(REDIS_WARNING,"IP address for this node updated to %s",
-                    myself->ip);
+                    ip);
                 clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
             }
         }

--- a/src/networking.c
+++ b/src/networking.c
@@ -1219,17 +1219,6 @@ void getClientsMaxBuffers(unsigned long *longest_output_list,
     *biggest_input_buffer = bib;
 }
 
-/* This is a helper function for genClientPeerId().
- * It writes the specified ip/port to "peerid" as a null termiated string
- * in the form ip:port if ip does not contain ":" itself, otherwise
- * [ip]:port format is used (for IPv6 addresses basically). */
-void formatPeerId(char *peerid, size_t peerid_len, char *ip, int port) {
-    if (strchr(ip,':'))
-        snprintf(peerid,peerid_len,"[%s]:%d",ip,port);
-    else
-        snprintf(peerid,peerid_len,"%s:%d",ip,port);
-}
-
 /* A Redis "Peer ID" is a colon separated ip:port pair.
  * For IPv4 it's in the form x.y.z.k:port, example: "127.0.0.1:1234".
  * For IPv6 addresses we use [] around the IP part, like in "[::1]:1234".
@@ -1238,24 +1227,17 @@ void formatPeerId(char *peerid, size_t peerid_len, char *ip, int port) {
  * A Peer ID always fits inside a buffer of REDIS_PEER_ID_LEN bytes, including
  * the null term.
  *
- * The function returns REDIS_OK on succcess, and REDIS_ERR on failure.
- *
  * On failure the function still populates 'peerid' with the "?:0" string
  * in case you want to relax error checking or need to display something
  * anyway (see anetPeerToString implementation for more info). */
-int genClientPeerId(redisClient *client, char *peerid, size_t peerid_len) {
-    char ip[REDIS_IP_STR_LEN];
-    int port;
-
+static void genClientPeerId(redisClient *client, char *peerid,
+                            size_t peerid_len) {
     if (client->flags & REDIS_UNIX_SOCKET) {
         /* Unix socket client. */
         snprintf(peerid,peerid_len,"%s:0",server.unixsocket);
-        return REDIS_OK;
     } else {
         /* TCP client. */
-        int retval = anetPeerToString(client->fd,ip,sizeof(ip),&port);
-        formatPeerId(peerid,peerid_len,ip,port);
-        return (retval == -1) ? REDIS_ERR : REDIS_OK;
+        anetFormatPeer(client->fd,peerid,peerid_len);
     }
 }
 

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -130,9 +130,8 @@ static void cliRefreshPrompt(void) {
         len = snprintf(config.prompt,sizeof(config.prompt),"redis %s",
                        config.hostsocket);
     else
-        len = snprintf(config.prompt,sizeof(config.prompt),
-                       strchr(config.hostip,':') ? "[%s]:%d" : "%s:%d",
-                       config.hostip, config.hostport);
+        len = anetFormatIP(config.prompt, sizeof(config.prompt),
+                           config.hostip, config.hostport);
     /* Add [dbnum] if needed */
     if (config.dbnum != 0 && config.last_cmd_type != REDIS_REPLY_ERROR)
         len += snprintf(config.prompt+len,sizeof(config.prompt)-len,"[%d]",

--- a/src/replication.c
+++ b/src/replication.c
@@ -56,7 +56,7 @@ char *replicationGetSlaveName(redisClient *c) {
     buf[0] = '\0';
     if (anetPeerToString(c->fd,ip,sizeof(ip),NULL) != -1) {
         if (c->slave_listening_port)
-            snprintf(buf,sizeof(buf),"%s:%d",ip,c->slave_listening_port);
+            anetFormatIP(buf,sizeof(buf),ip,c->slave_listening_port);
         else
             snprintf(buf,sizeof(buf),"%s:<unknown-slave-port>",ip);
     } else {

--- a/src/sds.c
+++ b/src/sds.c
@@ -962,6 +962,15 @@ sds sdsjoin(char **argv, int argc, char *sep) {
     return join;
 }
 
+sds sdsformatip(char *ip, int port) {
+    if (port >= 0)
+        return sdscatfmt(sdsempty(),
+            strchr(ip,':') ? "[%s]:%i" : "%s:%i", ip, port);
+    else
+        return sdscatfmt(sdsempty(),
+            strchr(ip,':') ? "[%s]" : "%s", ip);
+}
+
 #ifdef SDS_TEST_MAIN
 #include <stdio.h>
 #include "testhelp.h"

--- a/src/sds.h
+++ b/src/sds.h
@@ -91,6 +91,7 @@ sds sdscatrepr(sds s, const char *p, size_t len);
 sds *sdssplitargs(const char *line, int *argc);
 sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen);
 sds sdsjoin(char **argv, int argc, char *sep);
+sds sdsformatip(char *ip, int port);
 
 /* Low level functions exposed to the user API */
 sds sdsMakeRoomFor(sds s, size_t addlen);

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -897,7 +897,7 @@ sentinelRedisInstance *createSentinelRedisInstance(char *name, int flags, char *
     sentinelRedisInstance *ri;
     sentinelAddr *addr;
     dict *table = NULL;
-    char slavename[128], *sdsname;
+    char slavename[REDIS_PEER_ID_LEN], *sdsname;
 
     redisAssert(flags & (SRI_MASTER|SRI_SLAVE|SRI_SENTINEL));
     redisAssert((flags & SRI_MASTER) || master != NULL);
@@ -908,9 +908,7 @@ sentinelRedisInstance *createSentinelRedisInstance(char *name, int flags, char *
 
     /* For slaves and sentinel we use ip:port as name. */
     if (flags & (SRI_SLAVE|SRI_SENTINEL)) {
-        snprintf(slavename,sizeof(slavename),
-            strchr(hostname,':') ? "[%s]:%d" : "%s:%d",
-            hostname,port);
+        anetFormatIP(slavename, sizeof(slavename), hostname, port);
         name = slavename;
     }
 
@@ -1035,9 +1033,7 @@ sentinelRedisInstance *sentinelRedisInstanceLookupSlave(
     sentinelRedisInstance *slave;
 
     redisAssert(ri->flags & SRI_MASTER);
-    key = sdscatprintf(sdsempty(),
-        strchr(ip,':') ? "[%s]:%d" : "%s:%d",
-        ip,port);
+    key = sdsformatip(ip, port);
     slave = dictFetchValue(ri->slaves,key);
     sdsfree(key);
     return slave;


### PR DESCRIPTION
If you have multiple replicas sync at the same time, you can't tell which replica is causing which action.

See the "Before" box below — two cluster replicas are attached and sync'ing at once, but you can't tell which is which.

Before:

``` haskell
17204:M 23 Oct 13:31:11.256 # IP address for this node updated to ::1
17204:M 23 Oct 13:31:15.958 # Cluster state changed: ok
17204:M 23 Oct 13:31:18.421 * Slave asks for synchronization 
17204:M 23 Oct 13:31:18.421 * Full resync requested by slave.
17204:M 23 Oct 13:31:18.421 * Starting BGSAVE for SYNC
17204:M 23 Oct 13:31:18.421 * Background saving started by pid 17333
17333:C 23 Oct 13:31:18.422 * DB saved on disk
17204:M 23 Oct 13:31:18.439 * Slave asks for synchronization 
17204:M 23 Oct 13:31:18.439 * Full resync requested by slave.
17204:M 23 Oct 13:31:18.439 * Waiting for end of BGSAVE for SYNC
17204:M 23 Oct 13:31:18.475 * Background saving terminated with success
17204:M 23 Oct 13:31:18.475 * Synchronization with slave succeeded
17204:M 23 Oct 13:31:18.475 * Synchronization with slave succeeded
```

After:

``` haskell
22172:M 23 Oct 14:18:27.602 # IP address for this node updated to [::1]
22172:M 23 Oct 14:18:27.645 # Cluster state changed: ok
22172:M 23 Oct 14:18:30.619 * Slave asks for synchronization from [::1]:59696
22172:M 23 Oct 14:18:30.619 * Full resync requested by slave from [::1]:59696
22172:M 23 Oct 14:18:30.619 * Starting BGSAVE for SYNC
22172:M 23 Oct 14:18:30.619 * Background saving started by pid 22238
22238:C 23 Oct 14:18:30.620 * DB saved on disk
22172:M 23 Oct 14:18:30.637 * Slave asks for synchronization from [::1]:59698
22172:M 23 Oct 14:18:30.637 * Full resync requested by slave from [::1]:59698
22172:M 23 Oct 14:18:30.637 * Waiting for end of BGSAVE for SYNC
22172:M 23 Oct 14:18:30.675 * Background saving terminated with success
22172:M 23 Oct 14:18:30.675 * Synchronization with slave succeeded from [::1]:59696
22172:M 23 Oct 14:18:30.675 * Synchronization with slave succeeded from [::1]:59698
```

I thought this would be a quick one or two line change, but I ended up refactoring all the IP formatting code.  Some of the "format an IP properly" code was getting copy/pasted around (since it's just one or two lines), but we can make a nicer interface for it.

Now we have achieved the goal of eradicating any copy/paste use of `strchr(ip, ':')` outside of formatting functions and config parsing.
