### PR TITLE
add ability to rename config and slaveof commands in sentinel

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -136,7 +136,7 @@ sentinel failover-timeout mymaster 180000
 # NOTIFICATION SCRIPT
 #
 # sentinel notification-script <master-name> <script-path>
-# 
+#
 # Call the specified notification script for any sentinel event that is
 # generated in the WARNING level (for instance -sdown, -odown, and so forth).
 # This script should notify the system administrator via email, SMS, or any
@@ -160,14 +160,14 @@ sentinel failover-timeout mymaster 180000
 # When the master changed because of a failover a script can be called in
 # order to perform application-specific tasks to notify the clients that the
 # configuration has changed and the master is at a different address.
-# 
+#
 # The following arguments are passed to the script:
 #
 # <master-name> <role> <state> <from-ip> <from-port> <to-ip> <to-port>
 #
 # <state> is currently always "failover"
 # <role> is either "leader" or "observer"
-# 
+#
 # The arguments from-ip, from-port, to-ip, to-port are used to communicate
 # the old address of the master and the new address of the elected slave
 # (now a master).
@@ -178,4 +178,20 @@ sentinel failover-timeout mymaster 180000
 #
 # sentinel client-reconfig-script mymaster /var/redis/reconfig.sh
 
-
+# REDIS INSTANCE COMMAND RENAME
+#
+# sentinel rename-config <config-name>
+# sentinel rename-slaveof <slaveof-name>
+#
+# The two options don't need to be used together, rename-config will
+# modify the CONFIG call to the redis master and slave instances,
+# rename-slaveof will modify the SLAVEOF call to the redis master and
+# slave instances.
+#
+# The options are provided to allow for increased security to the redis
+# cluster in cases where clients may not be allowed to use the CONFIG or
+# SLAVEOF commands.
+#
+# Example:
+#
+# sentinel rename-config RANDOM_STRING


### PR DESCRIPTION
This will address the request made here, https://groups.google.com/forum/#!topic/redis-db/kyMN-bN1MSI, and can address issue #2067 by providing 2 additional configuration options.
