### PR TITLE
redis-cli: Check for EAGAIN and EINTR after read()

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1092,6 +1092,7 @@ unsigned long long sendSync(int fd) {
     /* Read $<payload>\r\n, making sure to read just up to "\n" */
     p = buf;
     while(1) {
+        errno = 0;
         nread = read(fd,p,1);
         if (nread <= 0) {
             int block_mode = context->flags & REDIS_BLOCK;
@@ -1124,6 +1125,7 @@ static void slaveMode(void) {
     while(payload) {
         ssize_t nread;
 
+        errno = 0;
         nread = read(fd,buf,(payload > sizeof(buf)) ? sizeof(buf) : payload);
         if (nread <= 0) {
             int block_mode = context->flags & REDIS_BLOCK;
@@ -1172,6 +1174,7 @@ static void getRDB(void) {
     while(payload) {
         ssize_t nread, nwritten;
 
+        errno = 0;
         nread = read(s,buf,(payload > sizeof(buf)) ? sizeof(buf) : payload);
         if (nread <= 0) {
             int block_mode = context->flags & REDIS_BLOCK;


### PR DESCRIPTION
In accordance with the man page of read(2) syscall:
http://man7.org/linux/man-pages/man2/read.2.html

when it returns -1 there are three possible issues:
1. errno == EINTR. This indicates that a signal was received before any
    bytes were read and read() can be reissued.
2. errno == EAGAIN. File descriptor from which we read is marked as
    nonblocking and the read() would block because no data is currently
    available.
3. Otherwise there is a more serious error. Simply reissuing the read is
    unlikely to succeed.

According with the man page of signals(7):
http://man7.org/linux/man-pages/man7/signal.7.html

there are two possible solutions to properly handle interuptions of syscalls:
1. Provide behavior compatible with BSD signal semantics by using
    SA_RESTART flag with signal handlers.
2. Check errno each time after syscall returns error and reissue it if needed.
