### PR TITLE
Update redis_init_script.tpl

### DIFF
--- a/utils/redis_init_script.tpl
+++ b/utils/redis_init_script.tpl
@@ -26,11 +26,12 @@ case "$1" in
         fi
         ;;
     status)
-        if [ ! -f $PIDFILE ]
+        PID=$(cat $PIDFILE)
+        if [ ! -x /proc/${PID} ]
         then
             echo 'Redis is not running'
         else
-            echo "Redis is running ($(<$PIDFILE))"
+            echo "Redis is running ($PID)"
         fi
         ;;
     restart)


### PR DESCRIPTION
status command currently reports success when redis has crashed and the pid file still exists. Changing to check the actual process is running.
