### PR TITLE
Fix redis-trib import SCAN call

### DIFF
--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -1137,7 +1137,7 @@ class RedisTrib
         # right node as needed.
         cursor = nil
         while cursor != 0
-            cursor,keys = source.scan(cursor,:count,1000)
+            cursor,keys = source.scan(cursor, :count => 1000)
             cursor = cursor.to_i
             keys.each{|k|
                 # Migrate keys using the MIGRATE command.


### PR DESCRIPTION
Syntax error against redis-db client caused imports to fail.

Reported at https://groups.google.com/forum/#!topic/redis-db/W2na8mYS_t0
