### PR TITLE
remove the misleading prompt when connect without ip and port

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -913,10 +913,12 @@ static void repl(void) {
                     strcasecmp(argv[0],"exit") == 0)
                 {
                     exit(0);
-                } else if (argc == 3 && !strcasecmp(argv[0],"connect")) {
+                } else if (!strcasecmp(argv[0],"connect")) {
                     sdsfree(config.hostip);
-                    config.hostip = sdsnew(argv[1]);
-                    config.hostport = atoi(argv[2]);
+                    if(argc == 3){
+                    	config.hostip = sdsnew(argv[1]);
+                    	config.hostport = atoi(argv[2]);
+                    }
                     cliRefreshPrompt();
                     cliConnect(1);
                 } else if (argc == 1 && !strcasecmp(argv[0],"clear")) {


### PR DESCRIPTION
Hi all,

When redis-cli re-connects (for example, reboot server and then reconnect) to redis-server without explicit ip and port, redis-cli will run cliConnect(1) and then send a "connect" command to the server (see redis-cli.c:942).
Then, redis-cli will show an error prompt "(error) ERR unknown command 'connect'", even if the connection is successful.
I think the prompt is misleading, and suggest to modify the codes around redis-cli.c:917, which is straightforward.

Best regards
Min Fu
