### PR TITLE
redis-cli: allow enable cluster mode during a CLI session

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -967,10 +967,22 @@ static void repl(void) {
                     strcasecmp(argv[0],"exit") == 0)
                 {
                     exit(0);
-                } else if (argc == 3 && !strcasecmp(argv[0],"connect")) {
-                    sdsfree(config.hostip);
-                    config.hostip = sdsnew(argv[1]);
-                    config.hostport = atoi(argv[2]);
+                } else if ((!strcasecmp(argv[0],"enable") ||
+                            !strcasecmp(argv[0],"en"))) {
+                    if (argc == 2 && !strcasecmp(argv[1],"cluster"))
+                        config.cluster_mode = 1;
+                } else if ((!strcasecmp(argv[0],"disable") ||
+                            !strcasecmp(argv[0],"dis") ||
+                            !strcasecmp(argv[0],"no"))) {
+                    if (argc == 2 && !strcasecmp(argv[1],"cluster"))
+                        config.cluster_mode = 0;
+                } else if ((!strcasecmp(argv[0],"connect") ||
+                            !strcasecmp(argv[0],"con"))) {
+                    if (argc >= 2) {
+                        sdsfree(config.hostip);
+                        config.hostip = sdsnew(argv[1]);
+                    }
+                    if (argc == 3) config.hostport = atoi(argv[2]);
                     cliRefreshPrompt();
                     cliConnect(1);
                 } else if (argc == 1 && !strcasecmp(argv[0],"clear")) {


### PR DESCRIPTION
Also add an alias for connect to "con" because typing "connect"
takes too long.

New cli commands (with shorthand options):
- enable/en cluster = enable cluster mode
- disable/dis/no cluster = disable cluster mode

Example usage:
127.0.0.1:7000> get a
(error) MOVED 15495 127.0.0.1:7002
127.0.0.1:7000> en cluster
127.0.0.1:7000> get a
-> Redirected to slot [15495] located at 127.0.0.1:7002
(nil)
127.0.0.1:7002>

(The first "get" fails with MOVED, then we "en cluster" to enable
cluster redirect following, then the second "get" follows the
MOVED and works.)

This commit also keeps client-only commands on the client
so they don't leak to the server.

Fixes #2112 as well
