### PR TITLE
Typo fixes in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -268,7 +268,7 @@ slave-read-only yes
 repl-diskless-sync no
 
 # When diskless replication is enabled, it is possible to configure the delay
-# the server waits in order to spawn the child that trnasfers the RDB via socket
+# the server waits in order to spawn the child that transfers the RDB via socket
 # to the slaves.
 #
 # This is important since once the transfer starts, it is not possible to serve
@@ -756,7 +756,7 @@ slowlog-max-len 128
 # By default latency monitoring is disabled since it is mostly not needed
 # if you don't have latency issues, and collecting data has a performance
 # impact, that while very small, can be measured under big load. Latency
-# monitoring can easily be enalbed at runtime using the command
+# monitoring can easily be enabled at runtime using the command
 # "CONFIG SET latency-monitor-threshold <milliseconds>" if needed.
 latency-monitor-threshold 0
 


### PR DESCRIPTION
Fix two typos in redis.conf:
- "trnasfers" --> "transfers"
- "enalbed" --> "enabled"
