### PR TITLE
dict.c/dictRehash: check if rehash ends at last

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -270,6 +270,14 @@ int dictRehash(dict *d, int n) {
         d->ht[0].table[d->rehashidx] = NULL;
         d->rehashidx++;
     }
+    /* Check if we already rehashed the whole table... */
+    if (d->ht[0].used == 0) {
+        zfree(d->ht[0].table);
+        d->ht[0] = d->ht[1];
+        _dictReset(&d->ht[1]);
+        d->rehashidx = -1;
+        return 0;
+    }
     return 1;
 }
 


### PR DESCRIPTION
Without checking if the rehash operation ends at last, protential inconsistency may occur.
e.g. `if (d->ht[0].size == 0)  return *;` (line 409 488 882)
