### PR TITLE
add check the result of expireIfNeeded

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -60,7 +60,11 @@ robj *lookupKey(redisDb *db, robj *key) {
 robj *lookupKeyRead(redisDb *db, robj *key) {
     robj *val;
 
-    expireIfNeeded(db,key);
+    int retval = expireIfNeeded(db,key);
+    if (retval > 0) {
+        server.stat_keyspace_misses++;
+        return NULL;
+    }
     val = lookupKey(db,key);
     if (val == NULL)
         server.stat_keyspace_misses++;


### PR DESCRIPTION
when we look up a key, we will check the key's expire first,
if the key exceed the time, we don't look up key again, return NULL directly
