### PR TITLE
Support daemon supervision by upstart or systemd

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -857,7 +857,7 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
 "  Suspect RAM error? Use redis-server --test-memory to verify it.\n\n"
 );
     /* free(messages); Don't call free() with possibly corrupted memory. */
-    if (server.daemonize) unlink(server.pidfile);
+    if (server.daemonize && server.supervised == 0) unlink(server.pidfile);
 
     /* Make sure we exit with the right signal at the end. So for instance
      * the core will be dumped if enabled. */

--- a/src/redis.c
+++ b/src/redis.c
@@ -3534,9 +3534,6 @@ int redisIsSupervised(void) {
         return 0;
 
     if (upstart_job != NULL) {
-        if (strcmp(upstart_job, "redis") != 0)
-            return 0;
-
         redisLog(REDIS_NOTICE, "supervised by upstart, will stop to signal readyness");
         raise(SIGSTOP);
         unsetenv("UPSTART_JOB");

--- a/src/redis.h
+++ b/src/redis.h
@@ -722,6 +722,7 @@ struct redisServer {
     int active_expire_enabled;      /* Can be disabled for testing purposes. */
     size_t client_max_querybuf_len; /* Limit for client query buffer length */
     int dbnum;                      /* Total number of configured DBs */
+    int supervised;                 /* True if supervised by upstart or systemd */
     int daemonize;                  /* True if running as a daemon */
     clientBufferLimitsConfig client_obuf_limits[REDIS_CLIENT_TYPE_COUNT];
     /* AOF persistence */


### PR DESCRIPTION
Both upstart and systemd provide a way for daemons to
be supervised, as well as a mechanism for them to
signal their readyness status.

This patch provides compatibility with this functionality while
not interfering with other methods.

With this, it will be possible to use `expect stop` with upstart
and `Type=notify` with systemd.

A more detailed explanation of the mechanism can be found here:
http://spootnik.org/entries/2014/11/09_pid-tracking-in-modern-init-systems.html
