### PR TITLE
Couple BSD_SOURCE with DEFAULT_SOURCE for recent GNU libc compat

### DIFF
--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -30,6 +30,7 @@
 #ifndef _REDIS_FMACRO_H
 #define _REDIS_FMACRO_H
 
+#define _DEFAULT_SOURCE
 #define _BSD_SOURCE
 
 #if defined(__linux__)


### PR DESCRIPTION
Recent versions of GNU libc will emit warnings when _BSD_SOURCE
is defined without _DEFAULT_SOURCE is not.
The rationale from libc's standpoint here is that _BSD_SOURCE and
_SVID_SOURCE will now be merged in the single _DEFAULT_SOURCE
macros.
Without this, the build breaks at -Werror.
