### PR TITLE
[RFC] SAVE/BGSAVE: add IPC file-lock to serialize SAVE/BGSAVE across instances

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -163,7 +163,7 @@ stop-writes-on-bgsave-error yes
 # So we design this feature to serialize the SAVE/BGSAVE process across multiple instances.
 # Uncomment the following line to specify the path to the lockfile. 
 #
- lockfile lock.txt
+# lockfile lock.txt
 
 # Compress string objects using LZF when dump .rdb databases?
 # For default that's set to 'yes' as it's almost always a win.

--- a/redis.conf
+++ b/redis.conf
@@ -158,6 +158,13 @@ save 60 10000
 # permissions, and so forth.
 stop-writes-on-bgsave-error yes
 
+# On machines that having multiple redis instaces running on, IO capacities
+# will be throttled if more than one of them SAVE/BGSAVE at the same time.
+# So we design this feature to serialize the SAVE/BGSAVE process across multiple instances.
+# Uncomment the following line to specify the path to the lockfile. 
+#
+ lockfile lock.txt
+
 # Compress string objects using LZF when dump .rdb databases?
 # For default that's set to 'yes' as it's almost always a win.
 # If you want to save some CPU in the saving child set it to 'no' but

--- a/src/config.c
+++ b/src/config.c
@@ -385,6 +385,8 @@ void loadServerConfigFromString(char *config) {
         } else if (!strcasecmp(argv[0],"pidfile") && argc == 2) {
             zfree(server.pidfile);
             server.pidfile = zstrdup(argv[1]);
+        } else if (!strcasecmp(argv[0],"lockfile") && argc == 2) {
+            server.lockfile = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"dbfilename") && argc == 2) {
             if (!pathIsBaseName(argv[1])) {
                 err = "dbfilename can't be a path, just a filename";
@@ -1019,6 +1021,7 @@ void configGetCommand(redisClient *c) {
     config_get_string_field("unixsocket",server.unixsocket);
     config_get_string_field("logfile",server.logfile);
     config_get_string_field("pidfile",server.pidfile);
+    config_get_string_field("lockfile",server.lockfile);
 
     /* Numerical values */
     config_get_numerical_field("maxmemory",server.maxmemory);
@@ -1781,6 +1784,7 @@ int rewriteConfig(char *path) {
 
     rewriteConfigYesNoOption(state,"daemonize",server.daemonize,0);
     rewriteConfigStringOption(state,"pidfile",server.pidfile,REDIS_DEFAULT_PID_FILE);
+    rewriteConfigStringOption(state,"lockfile",server.lockfile,NULL);
     rewriteConfigNumericalOption(state,"port",server.port,REDIS_SERVERPORT);
     rewriteConfigNumericalOption(state,"tcp-backlog",server.tcp_backlog,REDIS_TCP_BACKLOG);
     rewriteConfigBindOption(state);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -719,6 +719,7 @@ werr: /* Write error. */
 int rdbSave(char *filename) {
     char tmpfile[256];
     FILE *fp;
+    int  lock_fd = -1;
     rio rdb;
     int error;
 
@@ -728,6 +729,16 @@ int rdbSave(char *filename) {
         redisLog(REDIS_WARNING, "Failed opening .rdb for saving: %s",
             strerror(errno));
         return REDIS_ERR;
+    }
+
+    /*lock fd*/
+    if(server.lockfile != NULL){
+        lock_fd = open(server.lockfile,O_CREAT,0666);
+        if(lock_fd == -1){
+            redisLog(REDIS_WARNING, "Failed to open lock file: %s",server.lockfile);
+        }else{
+            flock(lock_fd,LOCK_EX);
+        }
     }
 
     rioInitWithFile(&rdb,fp);
@@ -746,7 +757,18 @@ int rdbSave(char *filename) {
     if (rename(tmpfile,filename) == -1) {
         redisLog(REDIS_WARNING,"Error moving temp DB file on the final destination: %s", strerror(errno));
         unlink(tmpfile);
+        /*unlock fd*/
+        if(lock_fd != -1){
+            flock(lock_fd,LOCK_UN);
+            close(lock_fd);
+        }
         return REDIS_ERR;
+    }
+
+    /*unlock fd*/
+    if(lock_fd != -1){
+        flock(lock_fd,LOCK_UN);
+        close(lock_fd);
     }
     redisLog(REDIS_NOTICE,"DB saved on disk");
     server.dirty = 0;
@@ -755,6 +777,11 @@ int rdbSave(char *filename) {
     return REDIS_OK;
 
 werr:
+   /*unlock fd*/ 
+    if(lock_fd != -1){
+        flock(lock_fd,LOCK_UN);
+        close(lock_fd);
+    }
     fclose(fp);
     unlink(tmpfile);
     redisLog(REDIS_WARNING,"Write error saving DB on disk: %s", strerror(errno));

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -31,7 +31,7 @@
 #define __REDIS_RDB_H
 
 #include <stdio.h>
-#include <sys/file.h>
+#include <sys/file.h> /*For LOCK_EX marco in flock */
 #include "rio.h"
 
 /* TBD: include only necessary headers. */

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -31,6 +31,7 @@
 #define __REDIS_RDB_H
 
 #include <stdio.h>
+#include <sys/file.h>
 #include "rio.h"
 
 /* TBD: include only necessary headers. */

--- a/src/redis.c
+++ b/src/redis.c
@@ -1422,6 +1422,7 @@ void initServerConfig(void) {
     server.aof_rewrite_incremental_fsync = REDIS_DEFAULT_AOF_REWRITE_INCREMENTAL_FSYNC;
     server.aof_load_truncated = REDIS_DEFAULT_AOF_LOAD_TRUNCATED;
     server.pidfile = zstrdup(REDIS_DEFAULT_PID_FILE);
+    server.lockfile = NULL;
     server.rdb_filename = zstrdup(REDIS_DEFAULT_RDB_FILENAME);
     server.aof_filename = zstrdup(REDIS_DEFAULT_AOF_FILENAME);
     server.requirepass = NULL;

--- a/src/redis.h
+++ b/src/redis.h
@@ -656,6 +656,7 @@ struct redisServer {
     int activerehashing;        /* Incremental rehash in serverCron() */
     char *requirepass;          /* Pass for AUTH command, or NULL */
     char *pidfile;              /* PID file path */
+    char *lockfile;             /* Path of inter-process lock file */
     int arch_bits;              /* 32 or 64 depending on sizeof(long) */
     int cronloops;              /* Number of times the cron function run */
     char runid[REDIS_RUN_ID_SIZE+1];  /* ID always different at every exec. */


### PR DESCRIPTION
In order to make redis scale on modern SMP machines, we usually spawn multiple instances at the same time. However, when more than one of the SAVE/BGSAVE processes interleaving with each other, disk IO will be throttled. So we add this feature to serialize this io intensive routine to reduce IO contention in our system.
