### PR TITLE
Add SENTINEL INFO-CACHE [masters...]

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -190,6 +190,7 @@ typedef struct sentinelRedisInstance {
      * are set to NULL no script is executed. */
     char *notification_script;
     char *client_reconfig_script;
+    sds info; /* cached INFO output */
 } sentinelRedisInstance;
 
 /* Main state. */
@@ -983,6 +984,7 @@ sentinelRedisInstance *createSentinelRedisInstance(char *name, int flags, char *
     ri->promoted_slave = NULL;
     ri->notification_script = NULL;
     ri->client_reconfig_script = NULL;
+    ri->info = NULL;
 
     /* Role */
     ri->role_reported = ri->flags & (SRI_MASTER|SRI_SLAVE);
@@ -1015,6 +1017,7 @@ void releaseSentinelRedisInstance(sentinelRedisInstance *ri) {
     sdsfree(ri->slave_master_host);
     sdsfree(ri->leader);
     sdsfree(ri->auth_pass);
+    sdsfree(ri->info);
     releaseSentinelAddr(ri->addr);
 
     /* Clear state into the master if needed. */
@@ -1784,6 +1787,10 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
     sds *lines;
     int numlines, j;
     int role = 0;
+
+    /* cache full INFO output for instance */
+    sdsfree(ri->info);
+    ri->info = sdsnew(info);
 
     /* The following fields must be reset to a given value in the case they
      * are not found at all in the INFO output. */
@@ -2777,6 +2784,68 @@ void sentinelCommand(redisClient *c) {
     } else if (!strcasecmp(c->argv[1]->ptr,"set")) {
         if (c->argc < 3 || c->argc % 2 == 0) goto numargserr;
         sentinelSetCommand(c);
+    } else if (!strcasecmp(c->argv[1]->ptr,"info-cache")) {
+        if (c->argc < 2) goto numargserr;
+        /* Reply format:
+         *   1.) master name
+         *   2.) 1.) info from master
+         *       2.) info from replica
+         *       .
+         *       .
+         *   3.) next master name ...
+         *   4.) 1.) info from master
+         *       2.) info from replica
+         *       .
+         *       .
+         */
+        dictType copy_keeper = instancesDictType;
+        copy_keeper.valDestructor = NULL;
+        dict *masters_local = NULL;
+        int needs_cleanup = 0;
+        if (c->argc == 2) {
+            masters_local = sentinel.masters;
+        } else {
+            masters_local = dictCreate(&copy_keeper, NULL);
+            needs_cleanup = 1;
+
+            for (int i = 2; i < c->argc; i++) {
+                sentinelRedisInstance *ri;
+                ri = sentinelGetMasterByName(c->argv[i]->ptr);
+                if (!ri) continue; /* ignore non-existing names */
+                dictAdd(masters_local, ri->name, ri);
+            }
+        }
+
+        /* Now we can iterate over individually requested masters the
+         * same way we iterate over the entire sentinel->masters dict. */
+        addReplyMultiBulkLen(c,dictSize(masters_local) * 2);
+
+        dictIterator  *di;
+        dictEntry *de;
+        di = dictGetIterator(masters_local);
+        while ((de = dictNext(di)) != NULL) {
+            sentinelRedisInstance *ri = dictGetVal(de);
+            addReplyBulkCBuffer(c,ri->name,strlen(ri->name));
+            addReplyMultiBulkLen(c,dictSize(ri->slaves) + 1); /* +1 for self */
+            if (ri->info)
+                addReplyBulkCBuffer(c,ri->info,sdslen(ri->info));
+            else
+                addReply(c,shared.nullbulk);
+
+            dictIterator *sdi;
+            dictEntry *sde;
+            sdi = dictGetIterator(ri->slaves);
+            while ((sde = dictNext(sdi)) != NULL) {
+                sentinelRedisInstance *sri = dictGetVal(sde);
+                if (sri->info)
+                    addReplyBulkCBuffer(c,sri->info,sdslen(sri->info));
+                else
+                    addReply(c,shared.nullbulk);
+            }
+            dictReleaseIterator(sdi);
+        }
+        dictReleaseIterator(di);
+        if (needs_cleanup) dictRelease(masters_local);
     } else {
         addReplyErrorFormat(c,"Unknown sentinel subcommand '%s'",
                                (char*)c->argv[1]->ptr);


### PR DESCRIPTION
Sentinel queries the INFO from every master and from every replica of
every master.

We can cache the INFO results in Sentinel so Sentinel can be a single
place to quickly get all INFO output for an entire Sentinel monitoring
group.

This commit gives us SENTINEL INFO-CACHE in two forms:
- SENTINEL INFO-CACHE — returns all masters and all replicas
- SENTINEL INFO-CACHE master0 master1 ... masterN — vararg specific masters

Results are returned as a multibulk reply with two top-level entries
for each master.  The first entry for each master is the name of the master.
The second entry is a nested multibulk reply with the contents of INFO,
first for the master, then an additional entry for each of the
replicas.

Names are up for debate.  I also considered calling it `SENTINEL INFO` but that could be confused with regular `INFO` too easily.
## Example Output
### Query single master

``` haskell
matt@ununoctium:~/repos/redis/src% ./redis-cli -p 26379 sentinel info-cache foo
1) "foo"
2) 1) "# Server\r\nredis_version:2.9.999\r\nredis_git_sha1:0ed2c601\r\nredis_git_dirty:1\r\nredis_build_id:249db2940eda69a4\r\nredis_mode:standalone\r\nos:Darwin 14.0.0 x86_64\r\narch_bits:64\r\nmultiplexing_api:kqueue\r\ngcc_version:4.2.1\r\nprocess_id:30382\r\nrun_id:ff52291af6738e6b39dfa86f1bc023880c820b60\r\ntcp_port:3333\r\nuptime_in_seconds:807\r\nuptime_in_days:0\r\nhz:10\r\nlru_clock:7134590\r\nconfig_file:\r\n\r\n# Clients\r\nconnected_clients:2\r\nclient_longest_output_list:0\r\nclient_biggest_input_buf:0\r\nblocked_clients:0\r\n\r\n# Memory\r\nused_memory:57748768\r\nused_memory_human:55.07M\r\nused_memory_rss:61313024\r\nused_memory_peak:57782032\r\nused_memory_peak_human:55.11M\r\nused_memory_lua:35840\r\nmem_fragmentation_ratio:1.06\r\nmem_allocator:libc\r\n\r\n# Persistence\r\nloading:0\r\nrdb_changes_since_last_save:0\r\nrdb_bgsave_in_progress:0\r\nrdb_last_save_time:1416419940\r\nrdb_last_bgsave_status:ok\r\nrdb_last_bgsave_time_sec:1\r\nrdb_current_bgsave_time_sec:-1\r\naof_enabled:0\r\naof_rewrite_in_progress:0\r\naof_rewrite_scheduled:0\r\naof_last_rewrite_time_sec:-1\r\naof_current_rewrite_time_sec:-1\r\naof_last_bgrewrite_status:ok\r\naof_last_write_status:ok\r\n\r\n# Stats\r\ntotal_connections_received:3\r\ntotal_commands_processed:1887\r\ninstantaneous_ops_per_sec:2\r\nrejected_connections:0\r\nsync_full:1\r\nsync_partial_ok:0\r\nsync_partial_err:0\r\nexpired_keys:0\r\nevicted_keys:0\r\nkeyspace_hits:0\r\nkeyspace_misses:0\r\npubsub_channels:1\r\npubsub_patterns:0\r\nlatest_fork_usec:952\r\nmigrate_cached_sockets:0\r\n\r\n# Replication\r\nrole:master\r\nconnected_slaves:1\r\nslave0:ip=127.0.0.1,port=6379,state=online,offset=45888,lag=0\r\nmaster_repl_offset:45888\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:2\r\nrepl_backlog_histlen:45887\r\n\r\n# CPU\r\nused_cpu_sys:0.42\r\nused_cpu_user:0.52\r\nused_cpu_sys_children:0.04\r\nused_cpu_user_children:0.12\r\n\r\n# Cluster\r\ncluster_enabled:0\r\n\r\n# Keyspace\r\ndb0:keys=616,expires=0,avg_ttl=0\r\n"
   2) "# Server\r\nredis_version:2.9.999\r\nredis_git_sha1:0ed2c601\r\nredis_git_dirty:1\r\nredis_build_id:249db2940eda69a4\r\nredis_mode:standalone\r\nos:Darwin 14.0.0 x86_64\r\narch_bits:64\r\nmultiplexing_api:kqueue\r\ngcc_version:4.2.1\r\nprocess_id:30382\r\nrun_id:ff52291af6738e6b39dfa86f1bc023880c820b60\r\ntcp_port:3333\r\nuptime_in_seconds:807\r\nuptime_in_days:0\r\nhz:10\r\nlru_clock:7134590\r\nconfig_file:\r\n\r\n# Clients\r\nconnected_clients:2\r\nclient_longest_output_list:0\r\nclient_biggest_input_buf:0\r\nblocked_clients:0\r\n\r\n# Memory\r\nused_memory:57748768\r\nused_memory_human:55.07M\r\nused_memory_rss:61313024\r\nused_memory_peak:57782032\r\nused_memory_peak_human:55.11M\r\nused_memory_lua:35840\r\nmem_fragmentation_ratio:1.06\r\nmem_allocator:libc\r\n\r\n# Persistence\r\nloading:0\r\nrdb_changes_since_last_save:0\r\nrdb_bgsave_in_progress:0\r\nrdb_last_save_time:1416419940\r\nrdb_last_bgsave_status:ok\r\nrdb_last_bgsave_time_sec:1\r\nrdb_current_bgsave_time_sec:-1\r\naof_enabled:0\r\naof_rewrite_in_progress:0\r\naof_rewrite_scheduled:0\r\naof_last_rewrite_time_sec:-1\r\naof_current_rewrite_time_sec:-1\r\naof_last_bgrewrite_status:ok\r\naof_last_write_status:ok\r\n\r\n# Stats\r\ntotal_connections_received:3\r\ntotal_commands_processed:1887\r\ninstantaneous_ops_per_sec:2\r\nrejected_connections:0\r\nsync_full:1\r\nsync_partial_ok:0\r\nsync_partial_err:0\r\nexpired_keys:0\r\nevicted_keys:0\r\nkeyspace_hits:0\r\nkeyspace_misses:0\r\npubsub_channels:1\r\npubsub_patterns:0\r\nlatest_fork_usec:952\r\nmigrate_cached_sockets:0\r\n\r\n# Replication\r\nrole:master\r\nconnected_slaves:1\r\nslave0:ip=127.0.0.1,port=6379,state=online,offset=45888,lag=0\r\nmaster_repl_offset:45888\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:2\r\nrepl_backlog_histlen:45887\r\n\r\n# CPU\r\nused_cpu_sys:0.42\r\nused_cpu_user:0.52\r\nused_cpu_sys_children:0.04\r\nused_cpu_user_children:0.12\r\n\r\n# Cluster\r\ncluster_enabled:0\r\n\r\n# Keyspace\r\ndb0:keys=616,expires=0,avg_ttl=0\r\n"
```
### Query all masters

(kinda boring because I only have one pair)

``` haskell
matt@ununoctium:~/repos/redis/src% ./redis-cli -p 26379 sentinel info-cache
1) "foo"
2) 1) "# Server\r\nredis_version:2.9.999\r\nredis_git_sha1:0ed2c601\r\nredis_git_dirty:1\r\nredis_build_id:249db2940eda69a4\r\nredis_mode:standalone\r\nos:Darwin 14.0.0 x86_64\r\narch_bits:64\r\nmultiplexing_api:kqueue\r\ngcc_version:4.2.1\r\nprocess_id:30382\r\nrun_id:ff52291af6738e6b39dfa86f1bc023880c820b60\r\ntcp_port:3333\r\nuptime_in_seconds:988\r\nuptime_in_days:0\r\nhz:10\r\nlru_clock:7134771\r\nconfig_file:\r\n\r\n# Clients\r\nconnected_clients:2\r\nclient_longest_output_list:0\r\nclient_biggest_input_buf:0\r\nblocked_clients:0\r\n\r\n# Memory\r\nused_memory:57748768\r\nused_memory_human:55.07M\r\nused_memory_rss:61321216\r\nused_memory_peak:57782032\r\nused_memory_peak_human:55.11M\r\nused_memory_lua:35840\r\nmem_fragmentation_ratio:1.06\r\nmem_allocator:libc\r\n\r\n# Persistence\r\nloading:0\r\nrdb_changes_since_last_save:0\r\nrdb_bgsave_in_progress:0\r\nrdb_last_save_time:1416419940\r\nrdb_last_bgsave_status:ok\r\nrdb_last_bgsave_time_sec:1\r\nrdb_current_bgsave_time_sec:-1\r\naof_enabled:0\r\naof_rewrite_in_progress:0\r\naof_rewrite_scheduled:0\r\naof_last_rewrite_time_sec:-1\r\naof_current_rewrite_time_sec:-1\r\naof_last_bgrewrite_status:ok\r\naof_last_write_status:ok\r\n\r\n# Stats\r\ntotal_connections_received:3\r\ntotal_commands_processed:2338\r\ninstantaneous_ops_per_sec:1\r\nrejected_connections:0\r\nsync_full:1\r\nsync_partial_ok:0\r\nsync_partial_err:0\r\nexpired_keys:0\r\nevicted_keys:0\r\nkeyspace_hits:0\r\nkeyspace_misses:0\r\npubsub_channels:1\r\npubsub_patterns:0\r\nlatest_fork_usec:952\r\nmigrate_cached_sockets:0\r\n\r\n# Replication\r\nrole:master\r\nconnected_slaves:1\r\nslave0:ip=127.0.0.1,port=6379,state=online,offset=57262,lag=1\r\nmaster_repl_offset:57262\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:2\r\nrepl_backlog_histlen:57261\r\n\r\n# CPU\r\nused_cpu_sys:0.51\r\nused_cpu_user:0.57\r\nused_cpu_sys_children:0.04\r\nused_cpu_user_children:0.12\r\n\r\n# Cluster\r\ncluster_enabled:0\r\n\r\n# Keyspace\r\ndb0:keys=616,expires=0,avg_ttl=0\r\n"
   2) "# Server\r\nredis_version:2.9.999\r\nredis_git_sha1:0ed2c601\r\nredis_git_dirty:1\r\nredis_build_id:249db2940eda69a4\r\nredis_mode:standalone\r\nos:Darwin 14.0.0 x86_64\r\narch_bits:64\r\nmultiplexing_api:kqueue\r\ngcc_version:4.2.1\r\nprocess_id:30382\r\nrun_id:ff52291af6738e6b39dfa86f1bc023880c820b60\r\ntcp_port:3333\r\nuptime_in_seconds:988\r\nuptime_in_days:0\r\nhz:10\r\nlru_clock:7134771\r\nconfig_file:\r\n\r\n# Clients\r\nconnected_clients:2\r\nclient_longest_output_list:0\r\nclient_biggest_input_buf:0\r\nblocked_clients:0\r\n\r\n# Memory\r\nused_memory:57748768\r\nused_memory_human:55.07M\r\nused_memory_rss:61321216\r\nused_memory_peak:57782032\r\nused_memory_peak_human:55.11M\r\nused_memory_lua:35840\r\nmem_fragmentation_ratio:1.06\r\nmem_allocator:libc\r\n\r\n# Persistence\r\nloading:0\r\nrdb_changes_since_last_save:0\r\nrdb_bgsave_in_progress:0\r\nrdb_last_save_time:1416419940\r\nrdb_last_bgsave_status:ok\r\nrdb_last_bgsave_time_sec:1\r\nrdb_current_bgsave_time_sec:-1\r\naof_enabled:0\r\naof_rewrite_in_progress:0\r\naof_rewrite_scheduled:0\r\naof_last_rewrite_time_sec:-1\r\naof_current_rewrite_time_sec:-1\r\naof_last_bgrewrite_status:ok\r\naof_last_write_status:ok\r\n\r\n# Stats\r\ntotal_connections_received:3\r\ntotal_commands_processed:2338\r\ninstantaneous_ops_per_sec:1\r\nrejected_connections:0\r\nsync_full:1\r\nsync_partial_ok:0\r\nsync_partial_err:0\r\nexpired_keys:0\r\nevicted_keys:0\r\nkeyspace_hits:0\r\nkeyspace_misses:0\r\npubsub_channels:1\r\npubsub_patterns:0\r\nlatest_fork_usec:952\r\nmigrate_cached_sockets:0\r\n\r\n# Replication\r\nrole:master\r\nconnected_slaves:1\r\nslave0:ip=127.0.0.1,port=6379,state=online,offset=57262,lag=1\r\nmaster_repl_offset:57262\r\nrepl_backlog_active:1\r\nrepl_backlog_size:1048576\r\nrepl_backlog_first_byte_offset:2\r\nrepl_backlog_histlen:57261\r\n\r\n# CPU\r\nused_cpu_sys:0.51\r\nused_cpu_user:0.57\r\nused_cpu_sys_children:0.04\r\nused_cpu_user_children:0.12\r\n\r\n# Cluster\r\ncluster_enabled:0\r\n\r\n# Keyspace\r\ndb0:keys=616,expires=0,avg_ttl=0\r\n"
```
#### Better formatting

``` haskell
matt@ununoctium:~/repos/redis/src% echo "$(./redis-cli -p 26379 sentinel info-cache)"
foo
# Server
redis_version:2.9.999
redis_git_sha1:0ed2c601
redis_git_dirty:1
redis_build_id:249db2940eda69a4
redis_mode:standalone
os:Darwin 14.0.0 x86_64
arch_bits:64
multiplexing_api:kqueue
gcc_version:4.2.1
process_id:30382
run_id:ff52291af6738e6b39dfa86f1bc023880c820b60
tcp_port:3333
uptime_in_seconds:1801
uptime_in_days:0
hz:10
lru_clock:7135584
config_file:

# Clients
connected_clients:2
client_longest_output_list:0
client_biggest_input_buf:0
blocked_clients:0

# Memory
used_memory:57748784
used_memory_human:55.07M
used_memory_rss:61378560
used_memory_peak:57782048
used_memory_peak_human:55.11M
used_memory_lua:35840
mem_fragmentation_ratio:1.06
mem_allocator:libc

# Persistence
loading:0
rdb_changes_since_last_save:0
rdb_bgsave_in_progress:0
rdb_last_save_time:1416419940
rdb_last_bgsave_status:ok
rdb_last_bgsave_time_sec:1
rdb_current_bgsave_time_sec:-1
aof_enabled:0
aof_rewrite_in_progress:0
aof_rewrite_scheduled:0
aof_last_rewrite_time_sec:-1
aof_current_rewrite_time_sec:-1
aof_last_bgrewrite_status:ok
aof_last_write_status:ok

# Stats
total_connections_received:3
total_commands_processed:4376
instantaneous_ops_per_sec:2
rejected_connections:0
sync_full:1
sync_partial_ok:0
sync_partial_err:0
expired_keys:0
evicted_keys:0
keyspace_hits:0
keyspace_misses:0
pubsub_channels:1
pubsub_patterns:0
latest_fork_usec:952
migrate_cached_sockets:0

# Replication
role:master
connected_slaves:1
slave0:ip=127.0.0.1,port=6379,state=online,offset=108672,lag=1
master_repl_offset:108672
repl_backlog_active:1
repl_backlog_size:1048576
repl_backlog_first_byte_offset:2
repl_backlog_histlen:108671

# CPU
used_cpu_sys:0.90
used_cpu_user:0.76
used_cpu_sys_children:0.04
used_cpu_user_children:0.12

# Cluster
cluster_enabled:0

# Keyspace
db0:keys=616,expires=0,avg_ttl=0

# Server
redis_version:2.9.999
redis_git_sha1:0ed2c601
redis_git_dirty:1
redis_build_id:249db2940eda69a4
redis_mode:standalone
os:Darwin 14.0.0 x86_64
arch_bits:64
multiplexing_api:kqueue
gcc_version:4.2.1
process_id:30382
run_id:ff52291af6738e6b39dfa86f1bc023880c820b60
tcp_port:3333
uptime_in_seconds:1801
uptime_in_days:0
hz:10
lru_clock:7135584
config_file:

# Clients
connected_clients:2
client_longest_output_list:0
client_biggest_input_buf:0
blocked_clients:0

# Memory
used_memory:57748784
used_memory_human:55.07M
used_memory_rss:61378560
used_memory_peak:57782048
used_memory_peak_human:55.11M
used_memory_lua:35840
mem_fragmentation_ratio:1.06
mem_allocator:libc

# Persistence
loading:0
rdb_changes_since_last_save:0
rdb_bgsave_in_progress:0
rdb_last_save_time:1416419940
rdb_last_bgsave_status:ok
rdb_last_bgsave_time_sec:1
rdb_current_bgsave_time_sec:-1
aof_enabled:0
aof_rewrite_in_progress:0
aof_rewrite_scheduled:0
aof_last_rewrite_time_sec:-1
aof_current_rewrite_time_sec:-1
aof_last_bgrewrite_status:ok
aof_last_write_status:ok

# Stats
total_connections_received:3
total_commands_processed:4376
instantaneous_ops_per_sec:2
rejected_connections:0
sync_full:1
sync_partial_ok:0
sync_partial_err:0
expired_keys:0
evicted_keys:0
keyspace_hits:0
keyspace_misses:0
pubsub_channels:1
pubsub_patterns:0
latest_fork_usec:952
migrate_cached_sockets:0

# Replication
role:master
connected_slaves:1
slave0:ip=127.0.0.1,port=6379,state=online,offset=108672,lag=1
master_repl_offset:108672
repl_backlog_active:1
repl_backlog_size:1048576
repl_backlog_first_byte_offset:2
repl_backlog_histlen:108671

# CPU
used_cpu_sys:0.90
used_cpu_user:0.76
used_cpu_sys_children:0.04
used_cpu_user_children:0.12

# Cluster
cluster_enabled:0

# Keyspace
db0:keys=616,expires=0,avg_ttl=0
```
