### PR TITLE
Add last_eviction_age statistic to INFO

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1686,6 +1686,7 @@ void resetServerStats(void) {
     server.stat_numconnections = 0;
     server.stat_expiredkeys = 0;
     server.stat_evictedkeys = 0;
+    server.last_eviction_age = 0;
     server.stat_keyspace_misses = 0;
     server.stat_keyspace_hits = 0;
     server.stat_fork_time = 0;
@@ -2796,6 +2797,7 @@ sds genRedisInfoString(char *section) {
             "sync_partial_err:%lld\r\n"
             "expired_keys:%lld\r\n"
             "evicted_keys:%lld\r\n"
+            "last_eviction_age:%lld\r\n"
             "keyspace_hits:%lld\r\n"
             "keyspace_misses:%lld\r\n"
             "pubsub_channels:%ld\r\n"
@@ -2811,6 +2813,7 @@ sds genRedisInfoString(char *section) {
             server.stat_sync_partial_err,
             server.stat_expiredkeys,
             server.stat_evictedkeys,
+            server.last_eviction_age,
             server.stat_keyspace_hits,
             server.stat_keyspace_misses,
             dictSize(server.pubsub_channels),
@@ -3291,6 +3294,7 @@ int freeMemoryIfNeeded(void) {
                 delta -= (long long) zmalloc_used_memory();
                 mem_freed += delta;
                 server.stat_evictedkeys++;
+                server.last_eviction_age = bestval;
                 notifyKeyspaceEvent(REDIS_NOTIFY_EVICTED, "evicted",
                     keyobj, db->id);
                 decrRefCount(keyobj);

--- a/src/redis.h
+++ b/src/redis.h
@@ -696,6 +696,7 @@ struct redisServer {
     long long stat_numconnections;  /* Number of connections received */
     long long stat_expiredkeys;     /* Number of expired keys */
     long long stat_evictedkeys;     /* Number of evicted keys (maxmemory) */
+    long long last_eviction_age;    /* Age of last evicted key */
     long long stat_keyspace_hits;   /* Number of successful lookups of keys */
     long long stat_keyspace_misses; /* Number of failed lookups of keys */
     size_t stat_peak_memory;        /* Max used memory record */


### PR DESCRIPTION
When using Redis as an LRU cache it is helpful to know how old item was that was most recently evicted.

We care about having at least 24 hours worth of data in the Redis LRU, so we monitor this statistic to gauge how old the current dataset roughly is: If the most recently evicted key is younger than 24 hours we need to change our setup.
