### PR TITLE
fix benchmark memleak in loop mode

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -693,8 +693,8 @@ int main(int argc, const char **argv) {
     }
 
     /* Run default benchmark suite. */
+    data = zmalloc(config.datasize+1);
     do {
-        data = zmalloc(config.datasize+1);
         memset(data,'x',config.datasize);
         data[config.datasize] = '\0';
 


### PR DESCRIPTION
Heya,

There's no need to reallocate the data buffer each loop run, in particular because it's never freed and leaks otherwise.
- razzle

P.S.: Even though freeing after the infinite loop would be redundant, it might be a good idea in case a loop iterations limit is introduced later.
