### PR TITLE
Fix implicit declaration of ioctl on Solaris

### DIFF
--- a/src/memtest.c
+++ b/src/memtest.c
@@ -35,6 +35,7 @@
 #include <errno.h>
 #include <termios.h>
 #include <sys/ioctl.h>
+#include <stropts.h>
 #include "config.h"
 
 #if (ULONG_MAX == 4294967295UL)


### PR DESCRIPTION
`ioctl` is defined in either `unistd.h` or `stropts.h` on Solaris
and in either `sys/ioctl.h` or `stropts.h` on Linux.

By simply including `stropts.h` we are warning-free on both systems.
