### PR TITLE
Fix zset extreme value zscan printing

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -381,7 +381,7 @@ void scanCallback(void *privdata, const dictEntry *de) {
     } else if (o->type == REDIS_ZSET) {
         key = dictGetKey(de);
         incrRefCount(key);
-        val = createStringObjectFromLongDouble(*(double*)dictGetVal(de));
+        val = createStringObjectFromDouble(*(double *)dictGetVal(de));
     } else {
         redisPanic("Type not handled in SCAN callback.");
     }

--- a/src/object.c
+++ b/src/object.c
@@ -120,16 +120,7 @@ robj *createStringObjectFromLongDouble(long double value) {
      * that is "non surprising" for the user (that is, most small decimal
      * numbers will be represented in a way that when converted back into
      * a string are exactly the same as what the user typed.) */
-    len = snprintf(buf,sizeof(buf),"%.17Lf", value);
-    /* Now remove trailing zeroes after the '.' */
-    if (strchr(buf,'.') != NULL) {
-        char *p = buf+len-1;
-        while(*p == '0') {
-            p--;
-            len--;
-        }
-        if (*p == '.') len--;
-    }
+    len = snprintf(buf,sizeof(buf),"%.17Lg", value);
     return createStringObject(buf,len);
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -124,6 +124,23 @@ robj *createStringObjectFromLongDouble(long double value) {
     return createStringObject(buf,len);
 }
 
+robj *createStringObjectFromDouble(double value) {
+    char *d;
+    char buf[64];
+    int len;
+
+    if (isinf(value)) {
+        /* Libc in odd systems (Hi Solaris!) will format infinite in a
+         * different way, so better to handle it in an explicit way. */
+          d = value > 0 ? "inf" : "-inf";
+        len = value > 0 ? 3 : 4;
+    } else {
+        d = buf;
+        len = snprintf(buf,sizeof(buf),"%.17g", value);
+    }
+    return createStringObject(d,len);
+}
+
 /* Duplicate a string object, with the guarantee that the returned object
  * has the same encoding as the original one.
  *

--- a/src/redis.h
+++ b/src/redis.h
@@ -1117,6 +1117,7 @@ robj *getDecodedObject(robj *o);
 size_t stringObjectLen(robj *o);
 robj *createStringObjectFromLongLong(long long value);
 robj *createStringObjectFromLongDouble(long double value);
+robj *createStringObjectFromDouble(double value);
 robj *createListObject(void);
 robj *createZiplistObject(void);
 robj *createSetObject(void);


### PR DESCRIPTION
As discovered in #2175, ZSCAN + bigger-than-ziplist-zset can print the wrong values since we are trying to print a double as a long double.  Let's not do that.
