### PR TITLE
Silence _BSD_SOURCE warnings in glibc 2.20 and forward

### DIFF
--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -34,6 +34,7 @@
 
 #if defined(__linux__)
 #define _GNU_SOURCE
+#define _DEFAULT_SOURCE
 #endif
 
 #if defined(_AIX)


### PR DESCRIPTION
See https://sourceware.org/glibc/wiki/Release/2.20#Packaging_Changes

This change should probably go into hiredis as well.
