### PR TITLE
getting pid fixes

### DIFF
--- a/utils/whatisdoing.sh
+++ b/utils/whatisdoing.sh
@@ -3,7 +3,7 @@
 #!/bin/bash
 nsamples=1
 sleeptime=0
-pid=$(ps auxww | grep 'redis-server' | grep -v grep | awk '{print $2}')
+pid=$(ps auxww | grep '[r]edis-server' | awk '{print $2}')
 
 for x in $(seq 1 $nsamples)
   do

--- a/utils/whatisdoing.sh
+++ b/utils/whatisdoing.sh
@@ -3,7 +3,7 @@
 #!/bin/bash
 nsamples=1
 sleeptime=0
-pid=$(pidof redis-server)
+pid=$(ps auxww | grep 'redis-server' | grep -v grep | awk '{print $2}')
 
 for x in $(seq 1 $nsamples)
   do


### PR DESCRIPTION
``` sh
$ ~ pidof redis-server
# nothing

$ ~ ps aux | grep [r]edis
redis      593  0.0  0.0  36900  5564 ?        Ssl  Dec02   1:37 /usr/bin/redis-server 127.0.0.1:6379
klay     15927  0.0  0.0  16772  6068 pts/6    S+   13:58   0:00 redis-cli

$ ~ uname -a
Linux edge 3.17.4-1-ARCH #1 SMP PREEMPT Fri Nov 21 21:14:42 CET 2014 x86_64 GNU/Linux
```
