### PR TITLE
Only ignore sigpipe in interactive mode

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1916,8 +1916,6 @@ int main(int argc, char **argv) {
     argc -= firstarg;
     argv += firstarg;
 
-    signal(SIGPIPE, SIG_IGN);
-
     /* Latency mode */
     if (config.latency_mode) {
         if (cliConnect(0) == REDIS_ERR) exit(1);
@@ -1966,6 +1964,9 @@ int main(int argc, char **argv) {
 
     /* Start interactive mode when no command is provided */
     if (argc == 0 && !config.eval) {
+        /* Ignore SIGPIPE in interactive mode to force a reconnect */
+        signal(SIGPIPE, SIG_IGN);
+
         /* Note that in repl mode we don't abort on connection error.
          * A new attempt will be performed for every command send. */
         cliConnect(0);


### PR DESCRIPTION
This allows shell pipes to correctly end redis-cli.

Tested with `redis-cli monitor | head -n20` and redis-benchmark.
Before: It hang.
After: It correctly exits after 20 lines.

Ref #2066 
