### PR TITLE
Update dict.c

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -269,6 +269,14 @@ int dictRehash(dict *d, int n) {
         }
         d->ht[0].table[d->rehashidx] = NULL;
         d->rehashidx++;
+        /* Check if we already rehashed the whole table... */
+        if (d->ht[0].used == 0) {
+            zfree(d->ht[0].table);
+            d->ht[0] = d->ht[1];
+            _dictReset(&d->ht[1]);
+            d->rehashidx = -1;
+            return 0;
+        }
     }
     return 1;
 }


### PR DESCRIPTION
in the method dictRehash  , the check "if rehashed the whole table..." is only in the begin of the while loop,
so there is a case that the while loop ended,   ht[0].size = 0, ht[1].size > 0, d->rehashidx != -1, 
in this case, ht[0].size =0 but the dict is not empty.

in the api method "dictFind","dictGenericDelete", there are two lines beloew:
A:  if (d->ht[0].size == 0) return DICT_ERR;
B:  if (dictIsRehashing(d)) _dictRehashStep(d);
in that case it should not be return DICT_ERR in the line A.

slove methods:
1. in the method dictRehash:  add the check "if rehashed the whole table..." not only in the begin of the while loop, but also in the end of the loop
2. change the order of lines A and B in the method "dictFind","dictGenericDelete"
