### PR TITLE
t_list.c/listTypeDelete: mind for the edge case of ziplist

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -249,8 +249,14 @@ void listTypeDelete(listTypeEntry *entry) {
         li->subject->ptr = ziplistDelete(li->subject->ptr,&p);
 
         /* Update position of the iterator depending on the direction */
-        if (li->direction == REDIS_TAIL)
+        if (li->direction == REDIS_TAIL) {
+            /* If the deleted element is the last one of the ziplist,
+             * set zi NULL instead of a pointer to ZIP_END */
+            unsigned char *zl = li->subject->ptr;
+            if ((size_t)(p - zl) == ziplistBlobLen(zl) - 1)
+                p = NULL;
             li->zi = p;
+        }
         else
             li->zi = ziplistPrev(li->subject->ptr,p);
     } else if (entry->li->encoding == REDIS_ENCODING_LINKEDLIST) {

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -521,6 +521,9 @@ static unsigned char *__ziplistDelete(unsigned char *zl, unsigned char *p, unsig
     int nextdiff = 0;
     zlentry first, tail;
 
+    if (p[0] == ZIP_END)
+        return zl;
+
     first = zipEntry(p);
     for (i = 0; p[0] != ZIP_END && i < num; i++) {
         p += zipRawEntryLength(p);


### PR DESCRIPTION
When deleting the last one of a list of ziplist type.
If the direction is REDIS_TAIL the next, li->zi is set to ZIP_END, but logically it should be NULL.

This cause the li run another more time for ZIP_END. 
In t_list.c the problem doesn't appear, because listTypeDelete deal with the ZIP_END condition. :-)
