### PR TITLE
remove_warning in db.c

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -450,8 +450,8 @@ void scanGenericCommand(redisClient *c, robj *o, unsigned long cursor) {
     list *keys = listCreate();
     listNode *node, *nextnode;
     long count = 10;
-    sds pat;
-    int patlen, use_pattern = 0;
+    sds pat = NULL;
+    int patlen = 0, use_pattern = 0;
     dict *ht;
 
     /* Object must be NULL (to iterate keys names), or the type of the object


### PR DESCRIPTION
just remove some compile warning in CentOS 5.x(gcc version 4.1.2 20080704)

before

``` c
db.c: In function ‘scanGenericCommand’:
db.c:419: warning: ‘patlen’ may be used uninitialized in this function
db.c:418: warning: ‘pat’ may be used uninitialized in this function
```
