### PR TITLE
t_zset.c/zslIsInLexRange: empty ranges condition correct

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -564,7 +564,7 @@ int zslIsInLexRange(zskiplist *zsl, zlexrangespec *range) {
     zskiplistNode *x;
 
     /* Test for ranges that will always be empty. */
-    if (compareStringObjectsForLexRange(range->min,range->max) > 1 ||
+    if (compareStringObjectsForLexRange(range->min,range->max) > 0 ||
             (compareStringObjects(range->min,range->max) == 0 &&
             (range->minex || range->maxex)))
         return 0;
@@ -841,7 +841,7 @@ int zzlIsInLexRange(unsigned char *zl, zlexrangespec *range) {
     unsigned char *p;
 
     /* Test for ranges that will always be empty. */
-    if (compareStringObjectsForLexRange(range->min,range->max) > 1 ||
+    if (compareStringObjectsForLexRange(range->min,range->max) > 0 ||
             (compareStringObjects(range->min,range->max) == 0 &&
             (range->minex || range->maxex)))
         return 0;


### PR DESCRIPTION
Mind for the case:

```
int main(int argc, char *argv[])
{
    char *test1 = "ababb";
    printf("%d\n", memcmp(test1+1, test1, 1));
    printf("%d\n", memcmp(test1+2, test1, 3));
    return 0;
}
```

---

Output:

```
1
1
```

---

As `compareStringObjectsForLexRange()` calls `memcmp()` to compare two string.
The special case `memcpy("abb","aba",3) == 1` .
So the edge case may cause potential bugs. :-)
