### PR TITLE
Add isinf() fix to lua_cmsgpack.c

### DIFF
--- a/deps/lua/src/lua_cmsgpack.c
+++ b/deps/lua/src/lua_cmsgpack.c
@@ -18,6 +18,11 @@
     #define LUACMSGPACK_MAX_NESTING  16 /* Max tables nesting. */
 #endif
 
+/* Workaround for Solaris platforms missing isinf() */
+#if !defined(isinf) && (defined(USE_INTERNAL_ISINF) || defined(MISSING_ISINF))
+#define isinf(x) (!isnan(x) && isnan((x) - (x)))
+#endif
+
 /* Check if float or double can be an integer without loss of precision */
 #define IS_INT_TYPE_EQUIVALENT(x, T) (!isinf(x) && (T)(x) == (x))
 


### PR DESCRIPTION
Commit https://github.com/antirez/lua-cmsgpack/commit/1852b23068efeda00d9ead61f1e721ecfb667af5 broke cmsgpack building on Solaris.

There was a comment saying "In the lua-cmsgpack there was this that I fixed a few days ago since 
it broken build in Solaris: The above should not pass reviews."

But, the new one shouldn't pass reviews either since it also broke.  :)

We can use the workaround from lua_cjson to implement `isinf()` here too.   (assuming solaris has isnan()?  if not, we need the entire Redis solarisfixes.h too)

It would be nice to avoid including "../../../../src/solarixfixes.h" since we can't include that inside the lua_cmsgpack upstream (unless we do something drastic like copy and paste it over).

My solaris test image doesn't trigger the problem, so I can't fully test right now.

Though, my solaris build does throw new warnings at us (it's a 32 bit VM):

``` haskell
In file included from ae.c:50:0:
ae_evport.c: In function ‘aeApiResize’:
ae_evport.c:97:37: warning: unused parameter ‘eventLoop’
ae_evport.c:97:52: warning: unused parameter ‘setsize’
ae_evport.c: In function ‘aeApiPoll’:
ae_evport.c:297:19: warning: comparison between signed and unsigned integer expressions
    CC anet.o
    CC dict.o
    CC redis.o
    CC sds.o
    CC zmalloc.o
    CC lzf_c.o
    CC lzf_d.o
    CC pqsort.o
    CC zipmap.o
    CC sha1.o
    CC ziplist.o
    CC release.o
    CC networking.o
    CC util.o
    CC object.o
    CC db.o
db.c: In function ‘scanGenericCommand’:
db.c:418:9: warning: ‘pat’ may be used uninitialized in this function
db.c:419:9: warning: ‘patlen’ may be used uninitialized in this function
    CC replication.o
    CC rdb.o
rdb.c: In function ‘rdbSaveBackground’:
rdb.c:801:9: warning: format ‘%d’ expects type ‘int’, but argument 3 has type ‘pid_t’
rdb.c: In function ‘rdbSaveToSlavesSockets’:
rdb.c:1510:9: warning: format ‘%d’ expects type ‘int’, but argument 3 has type ‘pid_t’
    CC t_string.o
    CC t_list.o
    CC t_set.o
    CC t_zset.o
    CC t_hash.o
    CC config.o
config.c: In function ‘configGetCommand’:
config.c:1124:9: warning: format ‘%o’ expects type ‘unsigned int’, but argument 4 has type ‘mode_t’
    CC aof.o
aof.c: In function ‘rewriteAppendOnlyFileBackground’:
aof.c:1115:13: warning: format ‘%d’ expects type ‘int’, but argument 3 has type ‘pid_t’
    CC pubsub.o
    CC multi.o
    CC debug.o
debug.c: In function ‘watchdogSignalHandler’:
debug.c:901:60: warning: unused parameter ‘secret’
```
