### PR TITLE
Fix: case when SPOP with count>MAXINT, setTypeRandomElements() will get ...

### DIFF
--- a/src/redis.h
+++ b/src/redis.h
@@ -1266,7 +1266,7 @@ void setTypeReleaseIterator(setTypeIterator *si);
 int setTypeNext(setTypeIterator *si, robj **objele, int64_t *llele);
 robj *setTypeNextObject(setTypeIterator *si);
 int setTypeRandomElement(robj *setobj, robj **objele, int64_t *llele);
-int setTypeRandomElements(robj *set, int count, robj *aux_set);
+unsigned long setTypeRandomElements(robj *set, unsigned long count, robj *aux_set);
 unsigned long setTypeSize(robj *subject);
 void setTypeConvert(robj *subject, int enc);
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -225,11 +225,11 @@ int setTypeRandomElement(robj *setobj, robj **objele, int64_t *llele) {
  * at producing N elements, and the elements are guaranteed to be non
  * repeating. 
  */
-int setTypeRandomElements(robj *set, int count, robj *aux_set) {
-    int set_size;
-    int elements_to_return = count;
-    int elements_copied = 0;
-    int current_element = 0;
+unsigned long setTypeRandomElements(robj *set, unsigned long count, robj *aux_set) {
+    unsigned long set_size;
+    unsigned long elements_to_return = count;
+    unsigned long elements_copied = 0;
+    unsigned long current_element = 0;
 
     /* Like all setType* functions, we assume good behavior on part of the caller,
      * so no extra parameter checks are made. */
@@ -480,7 +480,7 @@ void scardCommand(redisClient *c) {
 void spopWithCountCommand(redisClient *c) {
     long l;
     unsigned long count, size;
-    int elements_returned;
+    unsigned long elements_returned;
     robj *set, *aux, *aux_set;
     int64_t llele;
 


### PR DESCRIPTION
...negative count argument due to signed/unsigned mismatch.

setTypeRandomElements() now returns unsigned long, and also uses unsigned long for anything related to count of members.
spopWithCountCommand() now uses unsigned long elements_returned instead of int, for values returned from setTypeRandomElements()
