### PR TITLE
sentinel:fix vote counter

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3307,7 +3307,7 @@ char *sentinelGetLeader(sentinelRedisInstance *master, uint64_t epoch) {
     di = dictGetIterator(master->sentinels);
     while((de = dictNext(di)) != NULL) {
         sentinelRedisInstance *ri = dictGetVal(de);
-        if (ri->leader != NULL && ri->leader_epoch == sentinel.current_epoch)
+        if (ri->leader != NULL && ri->leader_epoch == epoch)
             sentinelLeaderIncr(counters,ri->leader);
     }
     dictReleaseIterator(di);


### PR DESCRIPTION
hi, i think there is a bug in sentinelGetLeader。
in line 3311,sentinelLeaderIncr incr 1 to ri->leader, but not because ri->leader_epoch is the specified epoch.

in a situation such as below:
1, sentinel1 and sentinel2 try to failover a same epoch 3349.
2, sentinel1 got most votes then continue.
3, sentinel2 not got most votes then wait.
4, before elected timeout, sentinel2 ask other sentinel is-master-down-by-addr with updated new current_epoch 3352.
5, most sentinels vote for sentinel2 because of new req epoch 3352.
6, sentinel2 use failover_epoch 3349 pass to sentinelGetLeader.
line 3310 ri->leader_epoch == sentinel.current_epoch is true, 
but it's true for 3352 not for failover_epoch 3349,because at this time other sentinel's ri->leader_epoch are 3352 and sentinel2's sentinel.current_epoch is also 3352.
7, sentinelGetLeader success, sentinel2 also have a failover with epoch 3349, and i think this conflict with the sentinel1.
