### PR TITLE
redis-check-*: output msg correct

### DIFF
--- a/src/redis-check-aof.c
+++ b/src/redis-check-aof.c
@@ -39,7 +39,7 @@
 #define ERROR(...) { \
     char __buf[1024]; \
     sprintf(__buf, __VA_ARGS__); \
-    sprintf(error, "0x%16llx: %s", (long long)epos, __buf); \
+    sprintf(error, "0x%016llx: %s", (long long)epos, __buf); \
 }
 
 static char error[1024];
@@ -60,7 +60,7 @@ int readLong(FILE *fp, char prefix, long *target) {
         return 0;
     }
     if (buf[0] != prefix) {
-        ERROR("Expected prefix '%c', got: '%c'",buf[0],prefix);
+        ERROR("Expected prefix '%c', got: '%c'",prefix,buf[0]);
         return 0;
     }
     *target = strtol(buf+1,&eptr,10);

--- a/src/redis-check-dump.c
+++ b/src/redis-check-dump.c
@@ -676,7 +676,11 @@ void process(void) {
     if (entry.type != REDIS_EOF) {
         /* last byte should be EOF, add error */
         errors.level = 0;
-        SHIFT_ERROR(positions[0].offset, "Expected EOF, got %s", types[entry.type]);
+        char const *entrytype = "UNKNOWN";
+        if (entry.type>=0 && entry.type<MAX_TYPES_NUM &&
+                strlen(types[entry.type])!=0)
+            entrytype=types[entry.type];
+        SHIFT_ERROR(positions[0].offset, "Expected EOF, got %s", entrytype);
 
         /* this is an EOF error so reset type */
         entry.type = -1;


### PR DESCRIPTION
Just correct some output msg in redis-check-*

To keep consistence with zmalloc, just exit when memory is not enough in redis-check-dump.
Mind for the edge case of dump_version, loadDoubleValue & printErrorStack.
:-)
