### PR TITLE
rdb.c/rdbLoadObject: convert type when needed before pushed to a ziplist

### DIFF
--- a/src/rdb.h
+++ b/src/rdb.h
@@ -93,7 +93,6 @@
 
 int rdbSaveType(rio *rdb, unsigned char type);
 int rdbLoadType(rio *rdb);
-int rdbSaveTime(rio *rdb, time_t t);
 time_t rdbLoadTime(rio *rdb);
 int rdbSaveLen(rio *rdb, uint32_t len);
 uint32_t rdbLoadLen(rio *rdb, int *isencoded);


### PR DESCRIPTION
Small Changes:
1.Convert type when needed before pushed to a ziplist, this can be more efficient when the `field` or `value` is very long, as we can spare the realloc and copy time.
2.Mind for the edge case of get rdb version.

```
    eg: printf("%d\n",atoi(" 03a"));  -> 3
```

3.When the type is `REDIS_RDB_OPCODE_EOF` or `REDIS_RDB_OPCODE_SELECTDB`, and `expiretime` is not -1, a wrong type error may happen.
