### PR TITLE
Surpress warning by casting void* to char*

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1316,12 +1316,13 @@ int rdbLoad(char *filename) {
                 /* All the fields with a name staring with '%' are considered
                  * information fields and are logged at startup with a log
                  * level of NOTICE. */
-                redisLog(REDIS_NOTICE,"RDB '%s': %s", auxkey->ptr, auxval->ptr);
+                redisLog(REDIS_NOTICE,"RDB '%s': %s", (char*)auxkey->ptr,
+                        (char*)auxval->ptr);
             } else {
                 /* We ignore fields we don't understand, as by AUX field
                  * contract. */
                 redisLog(REDIS_DEBUG,"Unrecognized RDB AUX field: '%s'",
-                    auxkey->ptr);
+                    (char*)auxkey->ptr);
             }
 
             zfree(auxkey);


### PR DESCRIPTION
Fixes the following warning:

```
rdb.c: In function ‘rdbLoad’:
rdb.c:1319:17: warning: format ‘%s’ expects argument of type ‘char *’, but argument 3 has type ‘void *’ [-Wformat=]
                 redisLog(REDIS_NOTICE,"RDB '%s': %s", auxkey->ptr, auxval->ptr);
                 ^
rdb.c:1319:17: warning: format ‘%s’ expects argument of type ‘char *’, but argument 4 has type ‘void *’ [-Wformat=]
rdb.c:1324:21: warning: format ‘%s’ expects argument of type ‘char *’, but argument 3 has type ‘void *’ [-Wformat=]
                     auxkey->ptr);             
```
