### PR TITLE
disable Lua's dofile

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -578,6 +578,8 @@ void luaLoadLibraries(lua_State *lua) {
 void luaRemoveUnsupportedFunctions(lua_State *lua) {
     lua_pushnil(lua);
     lua_setglobal(lua,"loadfile");
+    lua_pushnil(lua);
+    lua_setglobal(lua,"dofile");
 }
 
 /* This function installs metamethods in the global table _G that prevent


### PR DESCRIPTION
`dofile` is a potential vector for attack. Also discussed in https://github.com/antirez/redis/issues/1725 and http://www.agarri.fr/kom/archives/2014/09/11/trying_to_hack_redis_via_http_requests/index.htm
