### PR TITLE
redis-cli: don't change config.dbnum when select fails

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -684,8 +684,8 @@ static int cliSendCommand(int argc, char **argv, int repeat) {
             free(argvlen);
             return REDIS_ERR;
         } else {
-            /* Store database number when SELECT was successfully executed. */
-            if (!strcasecmp(command,"select") && argc == 2) {
+            /* Store database number when SELECT was successfully executed and replied with no error. */
+            if (!strcasecmp(command,"select") && argc == 2 && config.last_cmd_type != REDIS_REPLY_ERROR) {
                 config.dbnum = atoi(argv[1]);
                 cliRefreshPrompt();
             } else if (!strcasecmp(command,"auth") && argc == 2) {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -133,7 +133,7 @@ static void cliRefreshPrompt(void) {
         len = anetFormatAddr(config.prompt, sizeof(config.prompt),
                            config.hostip, config.hostport);
     /* Add [dbnum] if needed */
-    if (config.dbnum != 0) // && config.last_cmd_type != REDIS_REPLY_ERROR)
+    if (config.dbnum != 0)
         len += snprintf(config.prompt+len,sizeof(config.prompt)-len,"[%d]",
             config.dbnum);
     snprintf(config.prompt+len,sizeof(config.prompt)-len,"> ");

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -133,7 +133,7 @@ static void cliRefreshPrompt(void) {
         len = anetFormatAddr(config.prompt, sizeof(config.prompt),
                            config.hostip, config.hostport);
     /* Add [dbnum] if needed */
-    if (config.dbnum != 0 && config.last_cmd_type != REDIS_REPLY_ERROR)
+    if (config.dbnum != 0) // && config.last_cmd_type != REDIS_REPLY_ERROR)
         len += snprintf(config.prompt+len,sizeof(config.prompt)-len,"[%d]",
             config.dbnum);
     snprintf(config.prompt+len,sizeof(config.prompt)-len,"> ");


### PR DESCRIPTION
It's related to https://github.com/antirez/redis/issues/1812#issuecomment-69802198

From current unstable branch, there's display issue from redis-cli.

```
127.0.0.1:6379> del foo
(integer) 0
127.0.0.1:6379> select 4
OK
127.0.0.1:6379[4]> del foo
(integer) 1
127.0.0.1:6379[4]> set foo bar
OK
127.0.0.1:6379[4]> select 1000
(error) ERR invalid DB index
127.0.0.1:6379> get foo
"bar"
127.0.0.1:6379> select 0
OK
127.0.0.1:6379> get foo
(nil)
```

After patched, it will be changed to below,

```
127.0.0.1:6379> auth foobared
OK
127.0.0.1:6379> del foo
(integer) 0
127.0.0.1:6379> select 4
OK
127.0.0.1:6379[4]> del foo
(integer) 1
127.0.0.1:6379[4]> set foo bar
OK
127.0.0.1:6379[4]> select 1000
(error) ERR invalid DB index
127.0.0.1:6379[4]> get foo
"bar"
127.0.0.1:6379[4]> select 0
OK
127.0.0.1:6379> get foo
(nil)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/antirez/redis/2283)
<!-- Reviewable:end -->
