### PR TITLE
Fix valgrind errors

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1082,6 +1082,7 @@ int rewriteAppendOnlyFile(char *filename) {
             }
         }
         dictReleaseIterator(di);
+        di = NULL;
     }
 
     /* Do an initial slow fsync here while the parent is still sending

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -828,6 +828,7 @@ void freeClusterNode(clusterNode *n) {
     if (n->slaveof) clusterNodeRemoveSlave(n->slaveof, n);
     if (n->link) freeClusterLink(n->link);
     listRelease(n->fail_reports);
+    zfree(n->slaves);
     zfree(n);
 }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -783,8 +783,11 @@ int clusterNodeRemoveSlave(clusterNode *master, clusterNode *slave) {
 
     for (j = 0; j < master->numslaves; j++) {
         if (master->slaves[j] == slave) {
-            memmove(master->slaves+j,master->slaves+(j+1),
-                (master->numslaves-1)-j);
+            if ((j+1) < master->numslaves) {
+                int remaining_slaves = (master->numslaves - j) - 1;
+                memmove(master->slaves+j,master->slaves+(j+1),
+                        (sizeof(*master->slaves) * remaining_slaves));
+            }
             master->numslaves--;
             return REDIS_OK;
         }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -535,6 +535,8 @@ void clusterReset(int hard) {
         oldname = sdsnewlen(myself->name, REDIS_CLUSTER_NAMELEN);
         dictDelete(server.cluster->nodes,oldname);
         sdsfree(oldname);
+        dictRelease(server.cluster->nodes);
+        server.cluster->nodes = dictCreate(&clusterNodesDictType,NULL);
         getRandomHexChars(myself->name, REDIS_CLUSTER_NAMELEN);
         clusterAddNode(myself);
     }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -404,7 +404,7 @@ int clusterLockConfig(char *filename) {
 void clusterInit(void) {
     int saveconf = 0;
 
-    server.cluster = zmalloc(sizeof(clusterState));
+    server.cluster = zcalloc(sizeof(*server.cluster));
     server.cluster->myself = NULL;
     server.cluster->currentEpoch = 0;
     server.cluster->state = REDIS_CLUSTER_FAIL;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1234,7 +1234,7 @@ void nodeIp2String(char *buf, clusterLink *link) {
  * The function returns 0 if the node address is still the same,
  * otherwise 1 is returned. */
 int nodeUpdateAddressIfNeeded(clusterNode *node, clusterLink *link, int port) {
-    char ip[REDIS_IP_STR_LEN];
+    char ip[REDIS_IP_STR_LEN] = {0};
 
     /* We don't proceed if the link is the same as the sender link, as this
      * function is designed to see if the node link is consistent with the

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2796,6 +2796,7 @@ void clusterHandleSlaveMigration(int max_slaves) {
             }
         }
     }
+    dictReleaseIterator(di);
 
     /* Step 4: perform the migration if there is a target, and if I'm the
      * candidate. */

--- a/tests/cluster/tests/includes/init-tests.tcl
+++ b/tests/cluster/tests/includes/init-tests.tcl
@@ -28,8 +28,8 @@ test "Cluster nodes are reachable" {
 test "Cluster nodes hard reset" {
     foreach_redis_id id {
         catch {R $id flushall} ; # May fail for readonly slaves.
-        R $id cluster reset hard
-        R $id cluster set-config-epoch [expr {$id+1}]
+#        R $id cluster reset hard
+        R $id cluster set-config-epoch [expr {$id+1}] reset-hard
         R $id config set cluster-node-timeout 3000
         R $id config set cluster-slave-validity-factor 10
         R $id config rewrite


### PR DESCRIPTION
These commits are suggestions about how to fix failures found by valgrind.  They are only suggestions because Redis Cluster is a 4,700 line file and I'm not sure I know what's going on with everything there.

The biggest problem we have: a cluster 'node' is represented by a pointer to a node struct.  But, this single pointer gets stored in up to _5+_ different places (global nodes dict, `master->slaves` array, `slave->masterof` reference back to the slave's master (one copy of the pointer on each slave), importing slots, migrating slots, (and maybe other places!)).  We must remove _all_ references to the node when the node is free'd or else we get combinations of double free and/or segfaults when another function tries to access node data again.  These double free and segfault problems were happening in _multiple places_ throughout the cluster code because our cleanup functions aren't centralized.

I'd suggest adding _one_ place to attach a node reference and and _one_ place to clear all of them if possible.  Right now, 'node' pointers are being directly set throughout the 4,700 line file and I can't really figure out how to account for everything. (an alternate fix: reference nodes by _name_ everywhere instead of pointer values.  Then if we try to use a node later, but it doesn't exist, we get a "not found" value instead of accessing a dead pointer.)

Related fixes for the "too many copies of a node pointer" are:
- https://github.com/mattsta/redis/commit/0286d7a4e2c3b87dea591cb7f30bd7ea8edf9b94 tries to fix slaves retaining a bad 'slaveof' pointer after the master is deleted.  I'm not sure if `clusterSetNodeAsMaster()` is the correct thing to do, but  when the master is deleted, the slave can't remain a slave.
- https://github.com/mattsta/redis/commit/ba8888a4a709d0a64d76f81888a1bf2b27fb9700 is a fix because our node pointer cleanup functions were 50% in the reset function and 50% in the free function.
- https://github.com/mattsta/redis/commit/e5e5ccd3a85557d7aa1b104a2960565aaca2ba82 is me giving up and just deleting everything because something was still being left behind.

I'm not confident[1] I've found all the 'stale node pointer' cleanup locations yet.  We probably need better API infrastructure around setting and clearing these pointers.

[1]: continued testing shows I _haven't_ found all the places where stale pointers are being kept, but I'm out of idea on how to track them down.  We are still reading free'd pointers in places (shows up when running valgrind against tests in `06-slave-stop-cond.tcl` and `08-update-msg.tcl`). — the remaining bad reads all happen when accessing a master node pointer from a `slaveof` pointer in `clusterNodeRemoveSlave()`, except the `slaveof` isn't valid anymore.  For some reason, the master node gets free'd and the replicas don't get their `->slaveof` reset to NULL.  This results in reading and writing to free'd memory since we have no indication the pointer is now invalid.

Other fixes here:
- https://github.com/mattsta/redis/commit/b2c4ebd6be728d56f08764a0cc1a276e7767cf29 was actually fixed by initializing `server.cluster->mf_end = 0;` in 6274a6789deaeea35951e5409e94e4ff77de645a, but I had this fix already committed locally.  Can be thrown away if not wanted.
- https://github.com/mattsta/redis/commit/1cab67a52f919cb339a5f4a01782cfdc08f52dfd fixes more potential sending of uninitialized bytes.
- ~~https://github.com/mattsta/redis/commit/0f9d99dc695cff1b49a932eaaf736ba3acf29a51 fixes a memory leak~~ Fixed in https://github.com/antirez/redis/commit/4433f5a7f24350cb398ae448fca691a53a51a155.
- https://github.com/mattsta/redis/commit/7e74a66674db60a8931bf04f73d5f7bc44d27ef8 fixes a double free.
- https://github.com/mattsta/redis/commit/51ed0b90707ea7f18550f0b11af89930971ae05f fixes slightly incorrect pointer math and a missing bounds check. (verify this is actually correct now)
- https://github.com/mattsta/redis/commit/18b8b88f6e02ceeb5edccbeab9b1eebe13e66c74 attempts to fix an interesting problem: the time delay between a `CLUSTER RESET HARD` and `CLUSTER SET-CONFIG-EPOCH` can allow the reset node to re-discover other nodes.  This commit adds an option to set the config epoch immediately after an atomic reset hard so no other nodes can re-join between.  (I'm not sure if this is the _actual_ fix, but it seems likely.)

To get this testing working, I had to increase timeouts all throughout the testing code (timeouts of "retry 100 times, 50 ms apart" isn't long enough.  A better retry value is up to 500 times at 300 ms delay).  All those changes are in commits at https://github.com/mattsta/redis/commits/add-travis-ci, but they aren't committed back here because they are mostly useful for running valgrind tests where the Redis interaction slow down considerably.

The valgrind tests _also_ introduce more slowness where the Sentinel tests can fail with `NOGOODSLAVE No suitable slave to promote` errors, but I haven't been able to track down if that's a sentinel timeout issue, a test timeout issue, or a sentinel code issue.

I think that's all for now.

**update**  of course, after I posted this, my test server showed another error!
- https://github.com/mattsta/redis/commit/dcbffbccf27b76bf13edc8d6dc7cf7a4d03ea251 fixes a memory leak due to not releasing an iterator.

More suggestions:
- It would be nice if we could run each of the cluster tests individually (`--single 01, 02, 03, ...`) because then we can run them in parallel (the tests don't depend on each other).  Some of our errors are hiding because an early test fails then other tests don't run at all.
