### PR TITLE
Make some defaults explicit in the sentinel.conf for package maintainers

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -4,6 +4,31 @@
 # The port that this sentinel instance will run on
 port 26379
 
+# By default Redis Sentinel does not run as a daemon. Use 'yes' if you need it.
+# Note that Redis will write a pid file in /var/run/redis-sentinel.pid when
+# daemonized.
+daemonize no
+
+# When running daemonized, Redis Sentinel writes a pid file in
+# /var/run/redis-sentinel.pid by default. You can specify a custom pid file
+# location here.
+pidfile /var/run/redis-sentinel.pid
+
+# By default Redis Sentinel listens for connections from all the network
+# interfaces available on the server. It is possible to listen to just one or
+# multiple interfaces using the "bind" configuration directive, followed by one
+# or more IP addresses.
+#
+# Examples:
+#
+# bind 192.168.1.100 10.0.0.1
+# bind 127.0.0.1
+
+# Specify the log file name. Also the empty string can be used to force
+# Sentinel to log on the standard output. Note that if you use standard
+# output for logging but daemonize, logs will be sent to /dev/null
+logfile ""
+
 # sentinel announce-ip <ip>
 # sentinel announce-port <port>
 #


### PR DESCRIPTION
This may look a little pointless (and it is a complete no-op change here)
but as package maintainers need to modify these lines to actually
daemonize (etc. etc) but it's far preferable if the diff is restricted to
actually changing just that bit, not adding docs, etc. The less diff the
better, in general.

Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
