### PR TITLE
Support infinitely repeating commands in redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -847,7 +847,7 @@ static void usage(void) {
 "  -p <port>          Server port (default: 6379).\n"
 "  -s <socket>        Server socket (overrides hostname and port).\n"
 "  -a <password>      Password to use when connecting to the server.\n"
-"  -r <repeat>        Execute specified command N times.\n"
+"  -r <repeat>        Execute specified command N times (-1 to repeat forever).\n"
 "  -i <interval>      When -r is used, waits <interval> seconds per command.\n"
 "                     It is possible to specify sub-second times like -i 0.1.\n"
 "  -n <db>            Database number.\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -657,7 +657,7 @@ static int cliSendCommand(int argc, char **argv, int repeat) {
     for (j = 0; j < argc; j++)
         argvlen[j] = sdslen(argv[j]);
 
-    while(repeat--) {
+    while((repeat > 0) ? repeat-- : repeat) {
         redisAppendCommandArgv(context,argc,(const char**)argv,argvlen);
         while (config.monitor_mode) {
             if (cliReadReply(output_raw) != REDIS_OK) exit(1);


### PR DESCRIPTION
- Documents the behaviour that passing `redis-cli -r -1 ....` will repeat the command forever.
- Fixes this behaviour so it doesn't underflow after many gazillions of operations. ;)
