### PR TITLE
Fix type warning

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1316,12 +1316,12 @@ int rdbLoad(char *filename) {
                 /* All the fields with a name staring with '%' are considered
                  * information fields and are logged at startup with a log
                  * level of NOTICE. */
-                redisLog(REDIS_NOTICE,"RDB '%s': %s", auxkey->ptr, auxval->ptr);
+                redisLog(REDIS_NOTICE,"RDB '%s': %s", (char *) auxkey->ptr, (char *) auxval->ptr);
             } else {
                 /* We ignore fields we don't understand, as by AUX field
                  * contract. */
                 redisLog(REDIS_DEBUG,"Unrecognized RDB AUX field: '%s'",
-                    auxkey->ptr);
+                    (char *) auxkey->ptr);
             }
 
             decrRefCount(auxkey);


### PR DESCRIPTION
Added "(char *)" casts to avoid warnings during make, stating that a char \* was expected where a void \* was found.
