### PR TITLE
Prevent Redis crash: Don't free still-in-use object

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -406,7 +406,8 @@ cleanup:
         {
             struct sdshdr *sh = (void*)(((char*)(o->ptr))-(sizeof(struct sdshdr)));
 
-            if (cached_objects[j]) decrRefCount(cached_objects[j]);
+            if (cached_objects[j] && cached_objects[j] != o)
+                decrRefCount(cached_objects[j]);
             cached_objects[j] = o;
             cached_objects_len[j] = sh->free + sh->len;
         } else {


### PR DESCRIPTION
The following Lua script will crash the Redis instance. It uses the [lua-redis-debugger](https://github.com/RedisLabs/redis-lua-debugger), but the crash is not due to the way this hacks into the Lua sandbox, I just didn't reduce the test case for now.

``` lua
rld.start()
redis.call("KEYS", "*")
rld.stop()
```

Testing:

```
$ redis-cli --eval rld.lua
"rld v0.1.0 loaded to Redis"
$ redis-cli --eval iter.lua
Error: Server closed the connection(gdb) bt
```

Full crash log is [in a Gist](https://gist.github.com/badboy/1cdcc3380c50dd30a5c3).

Backtrace:

```
(gdb) bt
#0  0x00007eff16a01dc7 in kill () from /usr/lib/libc.so.6
#1  0x0000000000461ae9 in sigsegvHandler (sig=11, info=0x7ffff9198f70, secret=0x7ffff9198e40) at debug.c:919
#2  <signal handler called>
#3  0x00007eff16af53ba in __memcpy_avx_unaligned () from /usr/lib/libc.so.6
#4  0x000000000046fa2f in luaRedisGenericCommand (lua=0x170f6e0, raise_error=1) at scripting.c:257
#5  0x00000000004700f7 in luaRedisCallCommand (lua=0x170f6e0) at scripting.c:435
#6  0x000000000048e1c8 in luaD_precall ()
#7  0x000000000049719a in luaV_execute ()
#8  0x000000000048e61d in luaD_call ()
#9  0x000000000048bf95 in lua_call ()
#10 0x000000000048de20 in luaD_callhook ()
#11 0x000000000048df46 in luaD_poscall ()
#12 0x000000000048e1ec in luaD_precall ()
#13 0x000000000049719a in luaV_execute ()
#14 0x000000000048e61d in luaD_call ()
#15 0x000000000048d968 in luaD_rawrunprotected ()
#16 0x000000000048e77b in luaD_pcall ()
#17 0x000000000048c01a in lua_pcall ()
#18 0x00000000004717c1 in evalGenericCommand (c=0x171eda8, evalsha=0) at scripting.c:1006
#19 0x00000000004719ee in evalCommand (c=0x171eda8) at scripting.c:1075
#20 0x0000000000421f08 in call (c=0x171eda8, flags=7) at redis.c:2049
#21 0x0000000000422a57 in processCommand (c=0x171eda8) at redis.c:2309
#22 0x000000000043162a in processInputBuffer (c=0x171eda8) at networking.c:1143
#23 0x0000000000431923 in readQueryFromClient (el=0x16f6e48, fd=7, privdata=0x171eda8, mask=1) at networking.c:1208
#24 0x000000000041ab7e in aeProcessEvents (eventLoop=0x16f6e48, flags=3) at ae.c:412
#25 0x000000000041ad08 in aeMain (eventLoop=0x16f6e48) at ae.c:455
#26 0x00000000004265f3 in main (argc=3, argv=0x7ffff9199d68) at redis.c:3832
```

Turns out if the cached object is unchanged in the client's args, it might first free it, then re-assign it.
I'm not sure the fix is actually the best one (I'm not even a 100% sure why this argument caching might be necessary), but atleast it prevents the crash.

valgrind still complains about a memory leak in the scripting code (either line 255 or 261), so there might still be something wrong.

Thanks to @markuman who actually triggered the crash, I just tracked it down.
