### PR TITLE
fix slowness in dictGetRandomKeys during rehashing

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -663,34 +663,36 @@ dictEntry *dictGetRandomKey(dict *d)
  * at producing N elements, and the elements are guaranteed to be non
  * repeating. */
 unsigned int dictGetRandomKeys(dict *d, dictEntry **des, unsigned int count) {
-    int j; /* internal hash table id, 0 or 1. */
+    int j = 0; /* internal hash table id, 0 or 1. */
     unsigned int stored = 0;
 
+    if (dictSize(d) == 0) return 0;
     if (dictSize(d) < count) count = dictSize(d);
-    while(stored < count) {
-        for (j = 0; j < 2; j++) {
-            /* Pick a random point inside the hash table 0 or 1. */
-            unsigned int i = random() & d->ht[j].sizemask;
-            int size = d->ht[j].size;
-
-            /* Make sure to visit every bucket by iterating 'size' times. */
-            while(size--) {
-                dictEntry *he = d->ht[j].table[i];
-                while (he) {
-                    /* Collect all the elements of the buckets found non
-                     * empty while iterating. */
-                    *des = he;
-                    des++;
-                    he = he->next;
-                    stored++;
-                    if (stored == count) return stored;
-                }
-                i = (i+1) & d->ht[j].sizemask;
-            }
-            /* If there is only one table and we iterated it all, we should
-             * already have 'count' elements. Assert this condition. */
-            assert(dictIsRehashing(d) != 0);
+    /* Pick a random point inside the hash table. */
+    unsigned int i = random() & d->ht[j].sizemask;
+    /* when rehashing, if we got an index that was already moved, go to the other hash table */
+    if (i < d->rehashidx) j = 1;
+    int size = d->ht[j].size;
+    /* Make sure to visit every bucket by iterating 'size' times. */
+    while(size--) {
+        dictEntry *he = d->ht[j].table[i];
+        while (he) {
+            /* Collect all the elements of the buckets found non
+             * empty while iterating. */
+            *des = he;
+            des++;
+            he = he->next;
+            stored++;
+            if (stored == count) return stored;
         }
+        if (d->rehashidx!=-1) {
+            /* when reaching the rehash index or out of bound, switch to the other hash table */
+            i++;
+            if (j==1 && (i>=d->rehashidx)) j=0;
+            if (i>=d->ht[j].size) j=1, i=0;
+        }
+        else
+            i = (i+1) & d->ht[0].sizemask;
     }
     return stored; /* Never reached. */
 }

--- a/src/dict.c
+++ b/src/dict.c
@@ -669,7 +669,7 @@ unsigned int dictGetRandomKeys(dict *d, dictEntry **des, unsigned int count) {
     if (dictSize(d) == 0) return 0;
     if (dictSize(d) < count) count = dictSize(d);
     /* Pick a random point inside the hash table. */
-    unsigned int i = random() & d->ht[j].sizemask;
+    int i = random() & d->ht[j].sizemask;
     /* when rehashing, if we got an index that was already moved, go to the other hash table */
     if (i < d->rehashidx) j = 1;
     int size = d->ht[j].size;
@@ -689,7 +689,7 @@ unsigned int dictGetRandomKeys(dict *d, dictEntry **des, unsigned int count) {
             /* when reaching the rehash index or out of bound, switch to the other hash table */
             i++;
             if (j==1 && (i>=d->rehashidx)) j=0;
-            if (i>=d->ht[j].size) j=1, i=0;
+            if (i>=(int)d->ht[j].size) j=1, i=0;
         }
         else
             i = (i+1) & d->ht[0].sizemask;


### PR DESCRIPTION
When LRU based eviction happens during rehashing of a very large dictionary, a call to dictGetRandomKeys will usually hang for a VERY long time since it jumps to an empty area in the hash table and then scans the next index of the table until it finds something.

Since the dict rehashing (in my case from 2^24 to 2^25) consumes a good deal of memory, there's a good chance it will start a massive eviction, repeated calls to a very slow function will make the server hang for a VERY VERY long time.

With this fix the random function is coupled with the rehashing mechanism, it knows which indexes should be taken from the first hash table and which from the second.
