### PR TITLE
Adds ability to create dir specified in configuration.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -194,6 +194,10 @@ dbfilename dump.rdb
 #
 # The Append Only File will also be created inside this directory.
 #
+# Adding ' mkdir' to the end of the line causes the directory to be created if
+# it does not already exist.
+# dir /var/some/directory mkdir
+#
 # Note that you must specify a directory here, not a file name.
 dir ./
 


### PR DESCRIPTION
Problem:
    Directories can be specified in the configuration which do not exist.
    When this happens the configuration cannot be loaded.

Analysis:
    It would be useful to permit the configuration author to give a
    directive to the 'dir' command which permits the creation of the
    directory. Since configuration needs to be read in any order, this
    directive can be part of the 'dir' command as an optional 3rd
    argument.
