### PR TITLE
Don't print a newline on nil values

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -518,7 +518,7 @@ static sds cliFormatReplyCSV(redisReply *r) {
         out = sdscatrepr(out,r->str,r->len);
     break;
     case REDIS_REPLY_NIL:
-        out = sdscat(out,"NIL\n");
+        out = sdscat(out,"NIL");
     break;
     case REDIS_REPLY_ARRAY:
         for (i = 0; i < r->elements; i++) {


### PR DESCRIPTION
Printing a newline here breaks the expectations one might have on the CSV output
