### PR TITLE
Lua-based maxmemory eviction policies

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -511,6 +511,7 @@ slave-priority 100
 #        end
 #     end
 #     if not bestkey
+#     then
 #        -- We couldn't find anything to remove; return an error
 #         return false
 #     end

--- a/redis.conf
+++ b/redis.conf
@@ -455,6 +455,7 @@ slave-priority 100
 # volatile-random -> remove a random key with an expire set
 # allkeys-random -> remove a random key, any key
 # volatile-ttl -> remove the key with the nearest expire time (minor TTL)
+# script -> Call the Lua script specified by maxmemory-script
 # noeviction -> don't expire at all, just return an error on write operations
 #
 # Note: with any of the above policies, Redis will return an error on write
@@ -480,6 +481,57 @@ slave-priority 100
 # true LRU but costs a bit more CPU. 3 is very fast but not very accurate.
 #
 # maxmemory-samples 5
+
+# SHA of script to run to when maxmemory is reached
+#
+# This allows finer-grained and application-specific control over exactly what data
+# to keep in Redis and what to remove when the maxmemory limit is reached
+# instead of simply removing entire keys based on TTL or LRU.
+#
+# Scripts must return "true" if they removed items and "false" otherwise. If a
+# script cannot remove any data, an OOM result is returned to clients on write
+# operations.
+#
+# For example, to remove the lowest ranked member of a random sorted set:
+#
+#     local bestkey = nil
+#     local bestval = 0
+#     for s = 1, 5 do
+#        local key = redis.call("RANDOMKEY")
+#        local type_ = redis.call("TYPE", key)
+#        if type_.ok == "zset"
+#        then
+#            local tail = redis.call("ZRANGE", key, "0", "0", "WITHSCORES")
+#            local val = tonumber(tail[2])
+#            if not bestkey or val < bestval
+#            then
+#                bestkey = key
+#                bestval = val
+#            end
+#        end
+#     end
+#     if not bestkey
+#        -- We couldn't find anything to remove; return an error
+#         return false
+#     end
+#     redis.call("ZREMRANGEBYRANK", bestkey, "0", "0")
+#     return true
+#
+# Note: as scripts are not persisted across restarts of Redis, you must
+# reload your script on startup using SCRIPT LOAD. Furthermore, to avoid
+# race conditions where either the script, policy or maxmemory settings
+# are not configured in sync it is recommended you leave "maxmemory-policy
+# script", "maxmemory-script" and "maxmemory" at their default values in
+# redis.conf and configure them at runtime with CONFIG SET once Redis has
+# started. For example:
+#
+#     $ /etc/init.d/redis-server start
+#     $ SHA="$(redis-cli -x SCRIPT LOAD < /path/to/script.lua)"
+#     $ redis-cli CONFIG SET maxmemory-policy script
+#     $ redis-cli CONFIG SET maxmemory-script ${SHA}
+#     $ redis-cli CONFIG SET maxmemory <maxmemory>
+#
+# maxmemory-script <sha>
 
 ############################## APPEND ONLY MODE ###############################
 

--- a/redis.conf
+++ b/redis.conf
@@ -448,7 +448,7 @@ slave-priority 100
 # maxmemory <bytes>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
-# is reached. You can select among five behaviors:
+# is reached. You can select among seven behaviors:
 #
 # volatile-lru -> remove the key with an expire set using an LRU algorithm
 # allkeys-lru -> remove any key according to the LRU algorithm

--- a/src/redis.h
+++ b/src/redis.h
@@ -340,7 +340,8 @@ typedef long long mstime_t; /* millisecond time type. */
 #define REDIS_MAXMEMORY_VOLATILE_RANDOM 2
 #define REDIS_MAXMEMORY_ALLKEYS_LRU 3
 #define REDIS_MAXMEMORY_ALLKEYS_RANDOM 4
-#define REDIS_MAXMEMORY_NO_EVICTION 5
+#define REDIS_MAXMEMORY_SCRIPT 5
+#define REDIS_MAXMEMORY_NO_EVICTION 6
 #define REDIS_DEFAULT_MAXMEMORY_POLICY REDIS_MAXMEMORY_NO_EVICTION
 
 /* Scripting */
@@ -846,6 +847,7 @@ struct redisServer {
     unsigned long long maxmemory;   /* Max number of memory bytes to use */
     int maxmemory_policy;           /* Policy for key eviction */
     int maxmemory_samples;          /* Pricision of random sampling */
+    char *maxmemory_script;         /* SHA of script for maxmemory-policy script */
     /* Blocked clients */
     unsigned int bpop_blocked_clients; /* Number of clients blocked by lists */
     list *unblocked_clients; /* list of clients to unblock before next loop */
@@ -894,6 +896,8 @@ struct redisServer {
                              execution of the current script. */
     int lua_timedout;     /* True if we reached the time limit for script
                              execution. */
+    int lua_maxmemory_script; /* True if we we are currently running a custom
+                                 maxmemory-script function. */
     int lua_kill;         /* Kill the script if true. */
     /* Latency monitor */
     long long latency_monitor_threshold;
@@ -1359,6 +1363,7 @@ void sentinelIsRunning(void);
 
 /* Scripting */
 void scriptingInit(void);
+int scriptingEviction(redisDb *db);
 
 /* Blocked clients */
 void processUnblockedClients(void);

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -302,9 +302,10 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
 
     /* Write commands are forbidden against read-only slaves, or if a
      * command marked as non-deterministic was already called in the context
-     * of this script. */
+     * of this script. We always allow write commands when runnning a
+     * maxmemory-script function. */
     if (cmd->flags & REDIS_CMD_WRITE) {
-        if (server.lua_random_dirty) {
+        if (server.lua_random_dirty && server.lua_maxmemory_script == 0) {
             luaPushError(lua,
                 "Write commands not allowed after non deterministic commands");
             goto cleanup;
@@ -326,9 +327,10 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
     /* If we reached the memory limit configured via maxmemory, commands that
      * could enlarge the memory usage are not allowed, but only if this is the
      * first write in the context of this script, otherwise we can't stop
-     * in the middle. */
+     * in the middle. We never run during a maxmemory-script run to avoid
+     * recursion. */
     if (server.maxmemory && server.lua_write_dirty == 0 &&
-        (cmd->flags & REDIS_CMD_DENYOOM))
+        (cmd->flags & REDIS_CMD_DENYOOM) && server.lua_maxmemory_script == 0)
     {
         if (freeMemoryIfNeeded() == REDIS_ERR) {
             luaPushError(lua, shared.oomerr->ptr);
@@ -1176,4 +1178,91 @@ void scriptCommand(redisClient *c) {
     } else {
         addReplyError(c, "Unknown SCRIPT subcommand or wrong # of args.");
     }
+}
+
+int scriptingEviction(redisDb *db) {
+    /* Run our custom maxmemory-script
+     *
+     * We eeturn REDIS_OK if we freed an item and REDIS_ERR if there was an
+     * error or we failed to delete anything. */
+
+    int j, err;
+    char *sha = server.maxmemory_script;
+    char funcname[43];
+    lua_State *lua = server.lua;
+
+    if (server.maxmemory_script == NULL) {
+        redisLog(REDIS_WARNING,"maxmemory-policy script requires maxmemory-script");
+        return REDIS_ERR;
+    }
+
+    /* Create internal function name, converting to lowercase */
+    funcname[0] = 'f';
+    funcname[1] = '_';
+    for (j = 0; j < 40; j++)
+        funcname[j+2] = (sha[j] >= 'A' && sha[j] <= 'Z') ?
+            sha[j]+('a'-'A') : sha[j];
+    funcname[42] = '\0';
+
+    /* Push the pcall error handler function on the stack */
+    lua_getglobal(lua, "__redis__err__handler");
+
+    /* Lookup function */
+    lua_getglobal(lua, funcname);
+    if (lua_isnil(lua,-1)) {
+        redisLog(REDIS_WARNING,"Could not find maxmemory-script script %s", sha);
+        lua_pop(lua,1);
+        return REDIS_ERR;
+    }
+
+    /* Select database */
+    selectDb(server.lua_client,db->id);
+
+    /* Call script, disabling purity/randomness detection */
+    server.lua_maxmemory_script = 1;
+    err = lua_pcall(lua,0,1,-2);
+    server.lua_maxmemory_script = 0;
+
+    /* Call the Lua garbage collector from time to time to avoid a
+     * full cycle performed by Lua, which adds too latency.
+     *
+     * The call is performed every LUA_GC_CYCLE_PERIOD executed commands
+     * (and for LUA_GC_CYCLE_PERIOD collection steps) because calling it
+     * for every command uses too much CPU. */
+    #define LUA_GC_CYCLE_PERIOD 50
+    {
+        static long gc_count = 0;
+
+        gc_count++;
+        if (gc_count == LUA_GC_CYCLE_PERIOD) {
+            lua_gc(lua,LUA_GCSTEP,LUA_GC_CYCLE_PERIOD);
+            gc_count = 0;
+        }
+    }
+
+    int retval = REDIS_ERR;
+
+    if (err) {
+        redisLog(REDIS_WARNING,"Error running maxmemory-script %s: %s\n",
+            sha, lua_tostring(lua,-1));
+        goto cleanup;
+    }
+
+    if (lua_type(lua,-1) != LUA_TBOOLEAN) {
+        redisLog(REDIS_WARNING,"Error running maxmemory-script %s: "
+            "did not return return a boolean", sha);
+        goto cleanup;
+    }
+
+    /* Error if we returned false; we couldn't find anything to remove */
+    if (!lua_toboolean(lua,-1)) goto cleanup;
+
+    /* We found something to free */
+    retval = REDIS_OK;
+
+cleanup:
+    /* Consume reply and remove error handler */
+    lua_pop(lua,2);
+
+    return retval;
 }

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1183,7 +1183,7 @@ void scriptCommand(redisClient *c) {
 int scriptingEviction(redisDb *db) {
     /* Run our custom maxmemory-script
      *
-     * We eeturn REDIS_OK if we freed an item and REDIS_ERR if there was an
+     * We return REDIS_OK if we freed an item and REDIS_ERR if there was an
      * error or we failed to delete anything. */
 
     int j, err;


### PR DESCRIPTION
This allows finer-grained and application-specific control over exactly what data
to keep in Redis and what to remove when the maxmemory limit is reached
instead of simply removing entire keys based on TTL or LRU.

Scripts must return "true" if they removed items and "false" otherwise. If a
script cannot remove any data, an OOM result is returned to clients on write
operations.

(See the newly added "maxmemory-script" entry in redis.conf for more
documentation.)

Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
