### PR TITLE
bitmask OR function on hash field

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -200,6 +200,7 @@ struct redisCommand redisCommandTable[] = {
     {"hmget",hmgetCommand,-3,"r",0,NULL,1,1,1,0,0},
     {"hincrby",hincrbyCommand,4,"wmF",0,NULL,1,1,1,0,0},
     {"hincrbyfloat",hincrbyfloatCommand,4,"wmF",0,NULL,1,1,1,0,0},
+    {"hmergebitmask",hmergebitmaskCommand,4,"wm",0,NULL,1,1,1,0,0},
     {"hdel",hdelCommand,-3,"wF",0,NULL,1,1,1,0,0},
     {"hlen",hlenCommand,2,"rF",0,NULL,1,1,1,0,0},
     {"hkeys",hkeysCommand,2,"rS",0,NULL,1,1,1,0,0},

--- a/src/redis.h
+++ b/src/redis.h
@@ -1520,6 +1520,7 @@ void hgetallCommand(redisClient *c);
 void hexistsCommand(redisClient *c);
 void hscanCommand(redisClient *c);
 void configCommand(redisClient *c);
+void hmergebitmaskCommand(redisClient *c);
 void hincrbyCommand(redisClient *c);
 void hincrbyfloatCommand(redisClient *c);
 void subscribeCommand(redisClient *c);


### PR DESCRIPTION
Added a new command:
HMERGEBITMASK key field value

the command executes bitwise OR operation between the current value of the hash field and the one passed in the call.
Not existing Keys are automatically added and hash fields are considered as zeroed string. Hash field are automatically expanded to match the size of the value when necessary

Note: the patch was made by a friend (Vincenzo), I am not taking credit for his work just sharing in his place.
