### PR TITLE
redis-cli CSV output incorrect if keys have errors

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -506,7 +506,7 @@ static sds cliFormatReplyCSV(redisReply *r) {
     switch (r->type) {
     case REDIS_REPLY_ERROR:
         out = sdscat(out,"(error) ");
-        out = sdscatlen(out,r->str,strlen(r->str));
+        out = sdscatrepr(out,r->str,strlen(r->str));
     break;
     case REDIS_REPLY_STATUS:
         out = sdscatrepr(out,r->str,r->len);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -518,7 +518,7 @@ static sds cliFormatReplyCSV(redisReply *r) {
         out = sdscatrepr(out,r->str,r->len);
     break;
     case REDIS_REPLY_NIL:
-        out = sdscat(out,"NIL\n");
+        out = sdscat(out,"NIL");
     break;
     case REDIS_REPLY_ARRAY:
         for (i = 0; i < r->elements; i++) {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -474,8 +474,8 @@ static sds cliFormatReplyRaw(redisReply *r) {
         /* Nothing... */
         break;
     case REDIS_REPLY_ERROR:
+        out = sdscat(out, "(error) ");
         out = sdscatlen(out,r->str,r->len);
-        out = sdscatlen(out,"\n",1);
         break;
     case REDIS_REPLY_STATUS:
     case REDIS_REPLY_STRING:
@@ -505,8 +505,8 @@ static sds cliFormatReplyCSV(redisReply *r) {
     sds out = sdsempty();
     switch (r->type) {
     case REDIS_REPLY_ERROR:
-        out = sdscat(out,"ERROR,");
-        out = sdscatrepr(out,r->str,strlen(r->str));
+        out = sdscat(out,"(error) ");
+        out = sdscatlen(out,r->str,strlen(r->str));
     break;
     case REDIS_REPLY_STATUS:
         out = sdscatrepr(out,r->str,r->len);


### PR DESCRIPTION
These changes keeps consistency output of redis-cli.
1.  Remove disused new line
2. Before (num:1 key has a value, but hoge key doesn't)
   $ redis-cli --csv mget num:1 hoge
   "1",NIL
   $ redis-cli --csv mget hoge num;1
   NIL
   ,"1"
- After 
  $ redis-cli --csv mget num:1 hoge
  "1",NIL
  $ redis-cli --csv mget hoge num;1
  NIL,"1"
1. Conform format of error output to another output type(raw, no-raw, csv)
2. Before (Each output format are unsynchronized)
   $ redis-cli --raw gget
   ERR unknown command 'gget'

$ redis-cli --no-raw gget
(error) ERR unknown command 'gget'
$ redis-cli --csv gget
ERROR,"ERR unknown command 'gget'"

-After (All output type show error in same format)
$ redis-cli --csv gget
(error) ERR unknown command 'gget'
