### PR TITLE
Add ability to create clusters with specific replica groups

### DIFF
--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -52,7 +52,7 @@ class ClusterNode
     def initialize(addr)
         s = addr.split(":")
         if s.length < 2
-           puts "Invalid IP or Port (given as #{addr}) - use IP:Port format"
+           xputs "[ERR] Invalid IP or Port (given as #{addr}) - use IP:Port"
            exit 1
         end
         port = s.pop # removes port from split array
@@ -468,7 +468,7 @@ class RedisTrib
     # more nodes. This function fixes this condition by migrating keys where
     # it seems more sensible.
     def fix_open_slot(slot)
-        puts ">>> Fixing open slot #{slot}"
+        xputs ">>> Fixing open slot #{slot}"
 
         # Try to obtain the current slot owner, according to the current
         # nodes configuration.
@@ -858,7 +858,7 @@ class RedisTrib
         load_cluster_info_from_node(argv[0])
         check_cluster
         if @errors.length != 0
-            puts "*** Please fix your cluster problems before resharding"
+            xputs "*** Please fix your cluster problems before resharding"
             exit 1
         end
 
@@ -931,7 +931,7 @@ class RedisTrib
         end
 
         if sources.length == 0
-            puts "*** No source nodes given, operation aborted"
+            xputs "*** No source nodes given, operation aborted"
             exit 1
         end
 
@@ -975,10 +975,10 @@ class RedisTrib
     def check_create_parameters
         masters = @nodes.length/(@replicas+1)
         if masters < 3
-            puts "*** ERROR: Invalid configuration for cluster creation."
-            puts "*** Redis Cluster requires at least 3 master nodes."
-            puts "*** This is not possible with #{@nodes.length} nodes and #{@replicas} replicas per node."
-            puts "*** At least #{3*(@replicas+1)} nodes are required."
+            xputs "*** ERROR: Invalid configuration for cluster creation."
+            xputs "*** Redis Cluster requires at least 3 master nodes."
+            xputs "*** This is not possible with #{@nodes.length} nodes and #{@replicas} replicas per node."
+            xputs "*** At least #{3*(@replicas+1)} nodes are required."
             exit 1
         end
     end
@@ -1367,7 +1367,7 @@ end
 rt = RedisTrib.new
 cmd_spec = COMMANDS[ARGV[0].downcase]
 if !cmd_spec
-    puts "Unknown redis-trib subcommand '#{ARGV[0]}'"
+    xputs "[ERR] Unknown redis-trib subcommand '#{ARGV[0]}'"
     exit 1
 end
 

--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -23,6 +23,7 @@
 
 require 'rubygems'
 require 'redis'
+require 'resolv'
 
 ClusterHashSlots = 16384
 
@@ -55,7 +56,8 @@ class ClusterNode
            exit 1
         end
         port = s.pop # removes port from split array
-        ip = s.join(":") # if s.length > 1 here, it's IPv6, so restore address
+        ip = s.join(":") =~ Resolv::IPv4::Regex ? s.join(":") : Resolv.getaddresses(s.join(":"))[1]
+
         @r = nil
         @info = {}
         @info[:host] = ip

--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -41,7 +41,7 @@ def xputs(s)
         color=nil
     end
 
-    color = nil if ENV['TERM'] != "xterm"
+    color = nil if not ENV['TERM'].start_with? "xterm"
     print "\033[#{color}m" if color
     print s
     print "\033[0m" if color

--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -121,7 +121,7 @@ class ClusterNode
         nodes.each{|n|
             # name addr flags role ping_sent ping_recv link_status slots
             split = n.split
-            name,addr,flags,master_id,ping_sent,ping_recv,config_epoch,link_status = split[0..6]
+            name,addr,flags,master_id,ping_sent,ping_recv,_config_epoch,link_status = split[0..6]
             slots = split[8..-1]
             info = {
                 :name => name,
@@ -719,7 +719,7 @@ class RedisTrib
                 fnode.load_info()
                 add_node(fnode)
             rescue => e
-                xputs "[ERR] Unable to load info for node #{fnode}"
+                xputs "[ERR] Unable to load info for node #{fnode}: #{e}"
             end
         }
         populate_nodes_replicas_info
@@ -1218,9 +1218,9 @@ class RedisTrib
 
         # Enforce mandatory options
         if ALLOWED_OPTIONS[cmd]
-            ALLOWED_OPTIONS[cmd].each {|option,val|
-                if !options[option] && val == :required
-                    puts "Option '--#{option}' is required "+ \
+            ALLOWED_OPTIONS[cmd].each {|opt,val|
+                if !options[opt] && val == :required
+                    puts "Option '--#{opt}' is required "+ \
                          "for subcommand '#{cmd}'"
                     exit 1
                 end
@@ -1341,7 +1341,6 @@ ALLOWED_OPTIONS={
 def show_help
     puts "Usage: redis-trib <command> <options> <arguments ...>\n\n"
     COMMANDS.each{|k,v|
-        o = ""
         puts "  #{k.ljust(15)} #{v[2]}"
         if ALLOWED_OPTIONS[k]
             ALLOWED_OPTIONS[k].each{|optname,has_arg|

--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -306,6 +306,7 @@ class RedisTrib
     def initialize
         @nodes = []
         @fix = false
+        @mode = :default
         @errors = []
     end
 
@@ -355,7 +356,10 @@ class RedisTrib
 
     def check_cluster
         xputs ">>> Performing Cluster Check (using node #{@nodes[0]})"
-        show_nodes
+        if (@mode != :create)
+            show_nodes
+            print_readable_map
+        end
         check_config_consistency
         check_open_slots
         check_slots_coverage
@@ -1021,6 +1025,7 @@ class RedisTrib
     end
 
     def start_cluster(ask=:no)
+        @mode = :create
         show_nodes
         print_readable_map
         if ask == :verify

--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -56,7 +56,12 @@ class ClusterNode
            exit 1
         end
         port = s.pop # removes port from split array
-        ip = s.join(":") =~ Resolv::IPv4::Regex ? s.join(":") : Resolv.getaddresses(s.join(":"))[1]
+        host = s.join(":") # restore any :'s we deleted above for IPv6 addresses
+        ip = if host =~ Resolv::IPv4::Regex || host =~ Resolv::IPv6::Regex
+                 host
+             else
+                 Resolv.getaddress host
+             end
 
         @r = nil
         @info = {}

--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -24,6 +24,7 @@
 require 'rubygems'
 require 'redis'
 require 'resolv'
+require 'yaml'
 
 ClusterHashSlots = 16384
 
@@ -49,7 +50,7 @@ def xputs(s)
 end
 
 class ClusterNode
-    def initialize(addr)
+    def initialize(addr, local_name=nil)
         s = addr.split(":")
         if s.length < 2
            xputs "[ERR] Invalid IP or Port (given as #{addr}) - use IP:Port"
@@ -71,6 +72,8 @@ class ClusterNode
         @info[:migrating] = {}
         @info[:importing] = {}
         @info[:replicate] = false
+        @info[:replicas] = []
+        @info[:local_name] = local_name
         @dirty = false # True if we need to flush slots info into node.
         @friends = []
     end
@@ -81,6 +84,10 @@ class ClusterNode
 
     def slots
         @info[:slots]
+    end
+
+    def lname
+        @info[:local_name]
     end
 
     def has_flag?(flag)
@@ -184,9 +191,10 @@ class ClusterNode
         @dirty = true
     end
 
-    def set_as_replica(node_id)
-        @info[:replicate] = node_id
+    def set_as_replica(master)
+        @info[:replicate] = master.info[:name] # "name" is random node ID
         @dirty = true
+        master.info[:replicas].push self
     end
 
     def flush_node_config
@@ -214,7 +222,7 @@ class ClusterNode
         @dirty = false
     end
 
-    def info_string
+    def slots_as_range
         # We want to display the hash slots assigned to this node
         # as ranges, like in: "1-5,8-9,20-25,30"
         #
@@ -245,6 +253,10 @@ class ClusterNode
         slots = slots.map{|x|
             x.count == 1 ? x.first.to_s : "#{x.first}-#{x.last}"
         }.join(",")
+    end
+
+    def info_string
+        slots = slots_as_range
 
         role = self.has_flag?("master") ? "M" : "S"
 
@@ -306,7 +318,16 @@ class RedisTrib
     end
 
     def add_node(node)
-        @nodes << node
+        @nodes.each do |n|
+            if node.to_s == n.to_s
+                xputs "[ERR] Duplicate node detected -- #{n}"
+                if (n.lname)
+                    xputs "[ERR] IP/Port of #{n.lname} conflicts with #{node.lname}"
+                end
+                exit 3
+            end
+        end
+        @nodes.push node
     end
 
     def cluster_error(msg)
@@ -543,9 +564,27 @@ class RedisTrib
         print "\n"
     end
 
-    def alloc_slots
+    def alloc_slots_for_masters(masters)
+        masters_count = masters.length
+
+        # Alloc slots on masters
+        slots_per_node = ClusterHashSlots.to_f / masters_count
+        first = 0
+        cursor = 0.0
+        masters.each_with_index do |master,masternum|
+            last = (cursor+slots_per_node-1).round
+            if last > ClusterHashSlots || masternum == masters.length-1
+                last = ClusterHashSlots-1
+            end
+            last = first if last < first # Min step is 1.
+            master.add_slots first..last
+            first = last+1
+            cursor += slots_per_node
+        end
+    end
+
+    def alloc_slots_automatic(masters_count)
         nodes_count = @nodes.length
-        masters_count = @nodes.length / (@replicas+1)
         masters = []
 
         # The first step is to split instances by IP. This is useful as
@@ -589,20 +628,7 @@ class RedisTrib
 
         masters.each{|m| puts m}
 
-        # Alloc slots on masters
-        slots_per_node = ClusterHashSlots.to_f / masters_count
-        first = 0
-        cursor = 0.0
-        masters.each_with_index{|n,masternum|
-            last = (cursor+slots_per_node-1).round
-            if last > ClusterHashSlots || masternum == masters.length-1
-                last = ClusterHashSlots-1
-            end
-            last = first if last < first # Min step is 1.
-            n.add_slots first..last
-            first = last+1
-            cursor += slots_per_node
-        }
+        alloc_slots_for_masters masters
 
         # Select N replicas for every master.
         # We try to split the replicas among all the IPs with spare nodes
@@ -643,7 +669,7 @@ class RedisTrib
                     else
                         slave = interleaved.shift
                     end
-                    slave.set_as_replica(m.info[:name])
+                    slave.set_as_replica m
                     nodes_count -= 1
                     assigned_replicas += 1
                     puts "Adding replica #{slave} to #{m}"
@@ -973,37 +999,36 @@ class RedisTrib
     # the number of nodes and the specified replicas have a valid configuration
     # where there are at least three master nodes and enough replicas per node.
     def check_create_parameters
-        masters = @nodes.length/(@replicas+1)
-        if masters < 3
+        masters_count = @nodes.length/(@replicas+1)
+        if masters_count < 3
             xputs "*** ERROR: Invalid configuration for cluster creation."
             xputs "*** Redis Cluster requires at least 3 master nodes."
             xputs "*** This is not possible with #{@nodes.length} nodes and #{@replicas} replicas per node."
             xputs "*** At least #{3*(@replicas+1)} nodes are required."
             exit 1
         end
+        masters_count
     end
 
-    def create_cluster_cmd(argv,opt)
-        opt = {'replicas' => 0}.merge(opt)
-        @replicas = opt['replicas'].to_i
+    def create_node_verify(hostport, local_name=nil)
+        node = ClusterNode.new(hostport, local_name)
+        node.connect(:abort => true)
+        node.assert_cluster
+        node.load_info
+        node.assert_empty
+        add_node(node)
+        node
+    end
 
-        xputs ">>> Creating cluster"
-        argv[0..-1].each{|n|
-            node = ClusterNode.new(n)
-            node.connect(:abort => true)
-            node.assert_cluster
-            node.load_info
-            node.assert_empty
-            add_node(node)
-        }
-        check_create_parameters
-        xputs ">>> Performing hash slots allocation on #{@nodes.length} nodes..."
-        alloc_slots
+    def start_cluster(ask=:no)
         show_nodes
-        yes_or_die "Can I set the above configuration?"
+        print_readable_map
+        if ask == :verify
+            yes_or_die "Can I set the above configuration?"
+        end
+        xputs ">>> Updating nodes configuration"
         flush_nodes_config
-        xputs ">>> Nodes configuration updated"
-        xputs ">>> Assign a different config epoch to each node"
+        xputs ">>> Assigning a different config epoch to each node"
         assign_config_epoch
         xputs ">>> Sending CLUSTER MEET messages to join the cluster"
         join_cluster
@@ -1014,6 +1039,111 @@ class RedisTrib
         wait_cluster_join
         flush_nodes_config # Useful for the replicas
         check_cluster
+    end
+
+    def create_cluster_cmd(argv,opt)
+        opt = {'replicas' => 0}.merge(opt)
+        @replicas = opt['replicas'].to_i
+
+        xputs ">>> Creating cluster"
+        argv[0..-1].each{|n| create_node_verify(n)}
+        masters_count = check_create_parameters
+        xputs ">>> Performing hash slot allocation on #{masters_count} nodes..."
+        alloc_slots_automatic masters_count
+        start_cluster :verify
+    end
+
+    def print_readable_map
+        def localname(node)
+            node.lname ? "(#{node.lname}) " : ""
+        end
+
+        puts "Printing human readable map of cluster topology..."
+        @nodes.each do |node|
+            replica_count = node.info[:replicas].length
+            if (replica_count > 0)
+                puts "Group for hash slots #{node.slots_as_range} (#{replica_count+1} nodes):"
+                puts "\t#{localname node}#{node} (master)"
+                node.info[:replicas].each do |replica|
+                    puts "\t#{localname replica}#{replica} (replica)"
+                end
+            end
+        end
+    end
+
+    def create_cluster_by_file_cmd(argv, opt)
+        conf = argv[0]
+        xputs ">>> Creating cluster using file #{conf}"
+
+        parsed = YAML.load(File.open(conf))
+        # YAML gives us:
+        #   - list of nodes (logical name + hostname/ip + port)
+        #   - groups of specific master=>[replica] parings
+
+        debug = false
+        if (debug)
+            puts parsed
+        end
+
+        # Generate a name=>node map for easy node lookup
+        nodes_by_name = {}
+        parsed["nodes"].each do |node|
+            # YAML + Ruby means bare IPv6 addresses turn into symbols.
+            # Symbols don't work as IP addresses, so let's force-convert
+            # any symbols in a hash back into a string (with the ':' prepended).
+            node.each do |k,v|
+                if v.is_a? Symbol
+                    v = ":#{v.to_s}"
+                    node[k] = v
+                end
+            end
+            nodes_by_name[node["name"]] = node
+        end
+
+        def create_node_from_desc(node, replicas)
+            ipport = nil
+            if (node["addr"])
+                ipport = node["addr"]
+            else
+                ipport = "#{node["host"]}:#{node["port"]}"
+            end
+            if replicas[ipport]
+                xputs "[ERR] Node for #{ipport} already exists as a replica!"
+                exit 3
+            else
+                create_node_verify(ipport, node["name"])
+            end
+        end
+
+        # For each replication group
+        #   create master ClusterNode
+        #   For each replica of master
+        #     create replica ClusterNode
+        #     assign replica to master
+        masters = []
+        replicas_created = {}
+        parsed["topology"].each do |group|
+            # Create master for this group
+            master = create_node_from_desc nodes_by_name[group["master"]], replicas_created
+            masters.push master
+            group["replicas"].each do |replica|
+                node_desc = nodes_by_name[replica]
+
+                # Create replica
+                puts "Adding replica #{node_desc["name"]} to #{master.lname}..."
+                node = create_node_from_desc nodes_by_name[replica], replicas_created
+                replicas_created[node.to_s] = true
+
+                # Assign replica to master
+                node.set_as_replica master
+            end
+        end
+
+        # Create slot map for all masters
+        alloc_slots_for_masters masters
+
+        # Send configuration to all live nodes
+        start_cluster
     end
 
     def addnode_cluster_cmd(argv,opt)
@@ -1327,6 +1457,7 @@ end
 
 COMMANDS={
     "create"  => ["create_cluster_cmd", -2, "host1:port1 ... hostN:portN"],
+    "create-by-file"  => ["create_cluster_by_file_cmd", 2, "<cluster.yaml>"],
     "check"   => ["check_cluster_cmd", 2, "host:port"],
     "fix"     => ["fix_cluster_cmd", 2, "host:port"],
     "reshard" => ["reshard_cluster_cmd", 2, "host:port"],

--- a/utils/cluster.yaml
+++ b/utils/cluster.yaml
@@ -1,0 +1,31 @@
+# Example cluster description to use with: redis-trib.rb create-by-file
+# nodes are: (name, host, port) OR (name, addr)
+#   - 'host' and 'addr' may contain hostnames or IPv4/6 addresses
+# topology groups are: (master, replicas)
+---
+nodes:
+  - name: node-1
+    host: 127.0.0.1
+    port: 7001
+  - name: node-2
+    addr: ::1:7002
+  - name: node-3
+    host: ::1
+    port: 7003
+  - name: node-4
+    host: localhost
+    port: 7004
+  - name: node-5
+    addr: 127.0.0.1:7005
+  - name: node-6
+    addr: localhost:7000
+topology:
+  - master: node-1
+    replicas:
+    - node-2
+  - master: node-3
+    replicas:
+    - node-4
+  - master: node-5
+    replicas:
+    - node-6


### PR DESCRIPTION
This allows cluster setup with explicit master->replica mappings as defined in a [cluster description file](https://github.com/mattsta/redis/blob/4cf74fbdcb7f8303bffab5d8d01b5861ff4bec00/utils/cluster.yaml).

Runnable with: `redis-trib.rb create-by-file cluster.yaml`

Also fixes redis-trib color console printing.
Also adds color to more error/status messages.
Also removes some ruby warnings.
Also lets trib resolve node hostnames during creation.
Also improves node printing during cluster bring-up (still prints old output, but prints new version too).
### Cluster Runtime Description Before

``` haskell
M: eff0a5a1ab4c88ec5ac82c7ad2454f29cacc2658 127.0.0.1:7000
   slots:0-2047 (2048 slots) master
   3 additional replica(s)
M: 877172731246edc7f2dbe41eaf8ba20e6ea372cb 127.0.0.1:7001
   slots:2048-4095 (2048 slots) master
   3 additional replica(s)
M: a41fc5a04acc26cb810c8e0acfe97a45bfe4c15a 127.0.0.1:7002
   slots:4096-6143 (2048 slots) master
   3 additional replica(s)
M: dfca5a55f5648ae6ada1b84c8dbba03edb781676 127.0.0.1:7003
   slots:6144-8191 (2048 slots) master
   3 additional replica(s)
M: 47c050cfb5c1640f978ec679b4ae9efaa1523d72 127.0.0.1:7004
   slots:8192-10239 (2048 slots) master
   3 additional replica(s)
M: 75e45bdc38fe06d14e8cef1cf22b6fc623c5d5a8 127.0.0.1:7005
   slots:10240-12287 (2048 slots) master
   3 additional replica(s)
M: 33c47662dd44d1ba1f8f223d69c325abfe0e8f45 127.0.0.1:7006
   slots:12288-14335 (2048 slots) master
   3 additional replica(s)
M: 65a713bde85e21827c0b6650eb8f33ef96c01985 127.0.0.1:7007
   slots:14336-16383 (2048 slots) master
   3 additional replica(s)
S: 585c0512857e97386a65f4b9ffd0124baf0d76f4 127.0.0.1:7008
   replicates eff0a5a1ab4c88ec5ac82c7ad2454f29cacc2658
S: 807319fbf8b5141252a9e689905cd0da951f953e 127.0.0.1:7009
   replicates eff0a5a1ab4c88ec5ac82c7ad2454f29cacc2658
S: 4501c5f9ecb11946c188f4d78c39cf4220975889 127.0.0.1:7010
   replicates eff0a5a1ab4c88ec5ac82c7ad2454f29cacc2658
S: 442f990cdc7a8d29a90b89ed837c72d2193f0ec3 127.0.0.1:7011
   replicates 877172731246edc7f2dbe41eaf8ba20e6ea372cb
S: e988042cde1b06b96a6300095a4912cbb16461e4 127.0.0.1:7012
   replicates 877172731246edc7f2dbe41eaf8ba20e6ea372cb
S: 2bd0c954448b536cd33f9c85b3e1f4e2357ca29d 127.0.0.1:7013
   replicates 877172731246edc7f2dbe41eaf8ba20e6ea372cb
S: 69c7a059db580d945c2dd55a4a93490785d39679 127.0.0.1:7014
   replicates a41fc5a04acc26cb810c8e0acfe97a45bfe4c15a
S: 54f92d1f7c832c5dc160028a8a3c8317b3dd2f75 127.0.0.1:7015
   replicates a41fc5a04acc26cb810c8e0acfe97a45bfe4c15a
S: 85b2f191b79338c59c17337c5f37580680f2efca 127.0.0.1:7016
   replicates a41fc5a04acc26cb810c8e0acfe97a45bfe4c15a
S: 847b61222c3c7934b0c10015968a54d9c2a62938 127.0.0.1:7017
   replicates dfca5a55f5648ae6ada1b84c8dbba03edb781676
S: 145f793e5c666e27172f96aa35a9624575b408b3 127.0.0.1:7018
   replicates dfca5a55f5648ae6ada1b84c8dbba03edb781676
S: ba8c4144d3b18dc608f680a52092ad208dfa1911 127.0.0.1:7019
   replicates dfca5a55f5648ae6ada1b84c8dbba03edb781676
S: f5973d4895bf62c8911fca2b72431da460d19247 127.0.0.1:7020
   replicates 47c050cfb5c1640f978ec679b4ae9efaa1523d72
S: b912afc49eaee3428d67e75ff043a0f83c35cb96 127.0.0.1:7021
   replicates 47c050cfb5c1640f978ec679b4ae9efaa1523d72
S: 3d52805418349fd9515483f7de35fa21f4ea9be1 127.0.0.1:7022
   replicates 47c050cfb5c1640f978ec679b4ae9efaa1523d72
S: 19306285b525dc70433be07845b5c33f94ff29d2 127.0.0.1:7023
   replicates 75e45bdc38fe06d14e8cef1cf22b6fc623c5d5a8
S: 216cd1d90a6e302ef61c4f46b6580380da1a876d 127.0.0.1:7024
   replicates 75e45bdc38fe06d14e8cef1cf22b6fc623c5d5a8
S: e693dd85787cebdb7f2732f170795e59c746c770 127.0.0.1:7025
   replicates 75e45bdc38fe06d14e8cef1cf22b6fc623c5d5a8
S: 674f92b784dc62fee42821dbe32bf21189385664 127.0.0.1:7026
   replicates 33c47662dd44d1ba1f8f223d69c325abfe0e8f45
S: b27657df429698960960062d6e7a080cf88de173 127.0.0.1:7027
   replicates 33c47662dd44d1ba1f8f223d69c325abfe0e8f45
S: f056df2e2c225ab8463d98ceb36b5a194937135f 127.0.0.1:7028
   replicates 33c47662dd44d1ba1f8f223d69c325abfe0e8f45
S: 8dd0a934accec4beb1e2870ac3b93eaf6b576bee 127.0.0.1:7029
   replicates 65a713bde85e21827c0b6650eb8f33ef96c01985
S: 4466a813653100eaa2503b91a3411db9a7deafa8 127.0.0.1:7030
   replicates 65a713bde85e21827c0b6650eb8f33ef96c01985
S: 1e42d346e29ce010b26b4b9a53acb38ae9264d7c 127.0.0.1:7031
   replicates 65a713bde85e21827c0b6650eb8f33ef96c01985
```
### Cluster Runtime Description After

``` haskell
Printing human readable map of cluster topology...
Group for hash slots 0-2047 (4 nodes):
    127.0.0.1:7000 (master)
    127.0.0.1:7008 (replica)
    127.0.0.1:7009 (replica)
    127.0.0.1:7010 (replica)
Group for hash slots 2048-4095 (4 nodes):
    127.0.0.1:7001 (master)
    127.0.0.1:7011 (replica)
    127.0.0.1:7012 (replica)
    127.0.0.1:7013 (replica)
Group for hash slots 4096-6143 (4 nodes):
    127.0.0.1:7002 (master)
    127.0.0.1:7014 (replica)
    127.0.0.1:7015 (replica)
    127.0.0.1:7016 (replica)
Group for hash slots 6144-8191 (4 nodes):
    127.0.0.1:7003 (master)
    127.0.0.1:7017 (replica)
    127.0.0.1:7018 (replica)
    127.0.0.1:7019 (replica)
Group for hash slots 8192-10239 (4 nodes):
    127.0.0.1:7004 (master)
    127.0.0.1:7020 (replica)
    127.0.0.1:7021 (replica)
    127.0.0.1:7022 (replica)
Group for hash slots 10240-12287 (4 nodes):
    127.0.0.1:7005 (master)
    127.0.0.1:7023 (replica)
    127.0.0.1:7024 (replica)
    127.0.0.1:7025 (replica)
Group for hash slots 12288-14335 (4 nodes):
    127.0.0.1:7006 (master)
    127.0.0.1:7026 (replica)
    127.0.0.1:7027 (replica)
    127.0.0.1:7028 (replica)
Group for hash slots 14336-16383 (4 nodes):
    127.0.0.1:7007 (master)
    127.0.0.1:7029 (replica)
    127.0.0.1:7030 (replica)
    127.0.0.1:7031 (replica)
```
