### PR TITLE
Put restriction on maximum including of config files.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -81,7 +81,7 @@ void resetServerSaveParams(void) {
     server.saveparamslen = 0;
 }
 
-void loadServerConfigFromString(char *config) {
+void loadServerConfigFromString(char *config, int depth) {
     char *err = NULL;
     int linenum = 0, totlines, i;
     int slaveof_linenum = 0;
@@ -220,7 +220,7 @@ void loadServerConfigFromString(char *config) {
                 err = "Invalid number of databases"; goto loaderr;
             }
         } else if (!strcasecmp(argv[0],"include") && argc == 2) {
-            loadServerConfig(argv[1],NULL);
+            loadServerConfig(argv[1],NULL,depth+1);
         } else if (!strcasecmp(argv[0],"maxclients") && argc == 2) {
             server.maxclients = atoi(argv[1]);
             if (server.maxclients < 1) {
@@ -587,9 +587,14 @@ loaderr:
  * Both filename and options can be NULL, in such a case are considered
  * empty. This way loadServerConfig can be used to just load a file or
  * just load a string. */
-void loadServerConfig(char *filename, char *options) {
+void loadServerConfig(char *filename, char *options, int depth) {
     sds config = sdsempty();
     char buf[REDIS_CONFIGLINE_MAX+1];
+
+	if (depth > 10) {
+		redisLog(REDIS_WARNING, "Fatal error, can't open config '%s' due to maximum nesting depth exceeded", filename);
+		exit(1);
+	}
 
     /* Load the file content */
     if (filename) {
@@ -613,7 +618,7 @@ void loadServerConfig(char *filename, char *options) {
         config = sdscat(config,"\n");
         config = sdscat(config,options);
     }
-    loadServerConfigFromString(config);
+    loadServerConfigFromString(config,depth);
     sdsfree(config);
 }
 

--- a/src/redis.c
+++ b/src/redis.c
@@ -3796,7 +3796,7 @@ int main(int argc, char **argv) {
         }
         if (configfile) server.configfile = getAbsolutePath(configfile);
         resetServerSaveParams();
-        loadServerConfig(configfile,options);
+        loadServerConfig(configfile,options,0);
         sdsfree(options);
     } else {
         redisLog(REDIS_WARNING, "Warning: no config file specified, using the default config. In order to specify a config file use %s /path/to/%s.conf", argv[0], server.sentinel_mode ? "sentinel" : "redis");

--- a/src/redis.h
+++ b/src/redis.h
@@ -1321,7 +1321,7 @@ int keyspaceEventsStringToFlags(char *classes);
 sds keyspaceEventsFlagsToString(int flags);
 
 /* Configuration */
-void loadServerConfig(char *filename, char *options);
+void loadServerConfig(char *filename, char *options, int depth);
 void appendServerSaveParams(time_t seconds, int changes);
 void resetServerSaveParams(void);
 struct rewriteConfigState; /* Forward declaration to export API. */


### PR DESCRIPTION
Previously there was  possible of endless loop about loading config file.
If the main config file redis.conf includes itself, the redis-server will never start.
To avoid this, we put restriction of maximum number of including file as 10 for now.
