### PR TITLE
fix sentinelVoteLeader

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3244,8 +3244,13 @@ char *sentinelVoteLeader(sentinelRedisInstance *master, uint64_t req_epoch, char
 
     if (master->leader_epoch < req_epoch && sentinel.current_epoch <= req_epoch)
     {
-        sdsfree(master->leader);
-        master->leader = sdsnew(req_runid);
+        mstime_t time_since_last_vote = mstime() - master->failover_start_time;
+        if (time_since_last_vote > master->failover_timeout ||
+            strcasecmp(req_runid,server.runid) == 0 ||
+            master->leader == NULL) {
+            sdsfree(master->leader);
+            master->leader = sdsnew(req_runid);
+        }
         master->leader_epoch = sentinel.current_epoch;
         sentinelFlushConfig();
         sentinelEvent(REDIS_WARNING,"+vote-for-leader",master,"%s %llu",


### PR DESCRIPTION
there is a rarely situation, two sentinels will failover the same master almost at the same time with different epoch。
such as below:
sentinel0 failover the master with epoch 1 first, sentinel got the most others sentinel's votes but not sentinel1's.
sentinel1 got the new epoch elsewhere but not because voting to sentinel0。so sentinel also has a sentinel.current_epoch = 1.
then sentinel1 ++current_epoch, so current_epoch = 2, ask all other sentinels to vote。the other sentinels will vote to sentinel1.
so sentinel1 also got the most sentinels confirm and continue to failover the same master.

my patch is that sentinel will vote for the same sentinel between a failover timeout, this can fix the above issue.

i test this in my test env.
