### PR TITLE
adding GT parameter to SET command

### DIFF
--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -777,6 +777,11 @@ start_server {tags {"basic"}} {
         r set foo bar2 GT
     } {bar}
     
+    test {Extended SET GT option with no previous value} {
+        r del foo
+        r set foo bar GT
+    } {}
+    
     test {Extended SET GET with NX option should result in syntax err} {
       catch {r set foo bar NX GT} err1
       catch {r set foo bar NX GT} err2

--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -770,7 +770,21 @@ start_server {tags {"basic"}} {
         set v2 [r set foo 2 xx]
         list $v1 $v2 [r get foo]
     } {{} OK 2}
-
+    
+    test {Extended SET GT option} {
+        r del foo
+        r set foo bar
+        r set foo bar2 GT
+    } {bar}
+    
+    test {Extended SET GET with NX option should result in syntax err} {
+      catch {r set foo bar NX GT} err1
+      catch {r set foo bar NX GT} err2
+      format $err1
+      format $err2
+      list $err1 $err2
+    } {*syntax err* *syntax err*}
+    
     test {Extended SET EX option} {
         r del foo
         r set foo bar ex 10


### PR DESCRIPTION
Closes #2349

Parameter added in order to retrieve the value before setting the new value.

With this option we can replace the `GETSET` command because we can do the same with only the `SET` command.

@antirez @mattsta  I'm closing the #2351 after our discussion because we changed the implementation completely. Can you review it please?
