### PR TITLE
Unify to uppercase the headline

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -781,7 +781,7 @@ slowlog-max-len 128
 # "CONFIG SET latency-monitor-threshold <milliseconds>" if needed.
 latency-monitor-threshold 0
 
-############################# Event notification ##############################
+############################# EVENT NOTIFICATION ##############################
 
 # Redis can notify Pub/Sub clients about events happening in the key space.
 # This feature is documented at http://redis.io/topics/notifications


### PR DESCRIPTION
All other headline are uppercase, but "Event notification" is not. 
