### PR TITLE
Enhance the process title.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -751,6 +751,7 @@ void freeClient(redisClient *c) {
         if (c->flags & REDIS_SLAVE && listLength(server.slaves) == 0)
             server.repl_no_slaves_since = server.unixtime;
         refreshGoodSlavesCount();
+		redisSetProcTitle("redis-server");
     }
 
     /* Master/slave cleanup Case 2:

--- a/src/redis.c
+++ b/src/redis.c
@@ -3611,6 +3611,8 @@ void redisSetProcTitle(char *title) {
     char *server_mode = "";
     if (server.cluster_enabled) server_mode = " [cluster]";
     else if (server.sentinel_mode) server_mode = " [sentinel]";
+	else if ((!server.masterhost) && (listLength(server.slaves) != 0)) server_mode = " [master]";
+	else if (server.masterhost ) server_mode = " [slave]";
 
     setproctitle("%s %s:%d%s",
         title,

--- a/src/replication.c
+++ b/src/replication.c
@@ -670,6 +670,7 @@ void putSlaveOnline(redisClient *slave) {
     refreshGoodSlavesCount();
     redisLog(REDIS_NOTICE,"Synchronization with slave %s succeeded",
         replicationGetSlaveName(slave));
+	redisSetProcTitle("redis-server");
 }
 
 void sendBulkToSlave(aeEventLoop *el, int fd, void *privdata, int mask) {
@@ -1448,6 +1449,7 @@ void replicationSetMaster(char *ip, int port) {
     replicationDiscardCachedMaster(); /* Don't try a PSYNC. */
     freeReplicationBacklog(); /* Don't allow our chained slaves to PSYNC. */
     cancelReplicationHandshake();
+	redisSetProcTitle("redis-server");
     server.repl_state = REDIS_REPL_CONNECT;
     server.master_repl_offset = 0;
     server.repl_down_since = 0;
@@ -1489,6 +1491,7 @@ void slaveofCommand(redisClient *c) {
         if (server.masterhost) {
             replicationUnsetMaster();
             redisLog(REDIS_NOTICE,"MASTER MODE enabled (user request)");
+			redisSetProcTitle("redis-server");
         }
     } else {
         long port;


### PR DESCRIPTION
When the replication is established between master server
and slave server, process title outputs each role like follows.

masahiko 60103  0.0  0.5 137480  9628 ?        Ssl  00:19   0:00 redis-server *:8000 [master]
masahiko 60128  0.0  0.3 137480  7588 ?        Ssl  00:19   0:00 redis-server *:8001 [slave]

Please give me feedbacks!
