### PR TITLE
Fix quicklist Pop()

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -1372,7 +1372,7 @@ REDIS_STATIC void *_quicklistSaver(unsigned char *data, unsigned int sz) {
     unsigned char *vstr;
     if (data) {
         vstr = zmalloc(sz);
-        memcpy(data, vstr, sz);
+        memcpy(vstr, data, sz);
         return vstr;
     }
     return NULL;

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -1757,7 +1757,8 @@ int quicklistTest(int argc, char *argv[]) {
 
         TEST("pop 1 string from 1") {
             quicklist *ql = quicklistNew(-2, options[_i]);
-            quicklistPushHead(ql, genstr("hello", 331), 32);
+            char *populate = genstr("hello", 331);
+            quicklistPushHead(ql, populate, 32);
             unsigned char *data;
             unsigned int sz;
             long long lv;
@@ -1765,6 +1766,9 @@ int quicklistTest(int argc, char *argv[]) {
             quicklistPop(ql, QUICKLIST_HEAD, &data, &sz, &lv);
             assert(data != NULL);
             assert(sz == 32);
+            if (strcmp(populate, (char *)data))
+                ERR("Pop'd value (%.*s) didn't equal original value (%s)", sz,
+                    data, populate);
             zfree(data);
             ql_verify(ql, 0, 0, 0, 0);
             quicklistRelease(ql);
@@ -1797,6 +1801,9 @@ int quicklistTest(int argc, char *argv[]) {
                 assert(ret == 1);
                 assert(data != NULL);
                 assert(sz == 32);
+                if (strcmp(genstr("hello", 499 - i), (char *)data))
+                    ERR("Pop'd value (%.*s) didn't equal original value (%s)",
+                        sz, data, genstr("hello", 499 - i));
                 zfree(data);
             }
             ql_verify(ql, 0, 0, 0, 0);
@@ -1816,6 +1823,10 @@ int quicklistTest(int argc, char *argv[]) {
                     assert(ret == 1);
                     assert(data != NULL);
                     assert(sz == 32);
+                    if (strcmp(genstr("hello", 499 - i), (char *)data))
+                        ERR("Pop'd value (%.*s) didn't equal original value "
+                            "(%s)",
+                            sz, data, genstr("hello", 499 - i));
                     zfree(data);
                 } else {
                     assert(ret == 0);


### PR DESCRIPTION
The built-in quicklist Pop() is completely busted and needs this fix from emperor1523.  This PR also includes accurate testing instead of dumb testing.

Note: this problem doesn't show up in Redis usage because Redis uses quicklistPopCustom() to provide a custom non-busted allocator.  Perhaps emperor1523 was using quicklist in another codebase and found the problem (or maybe was just reading the source and noticed the memcpy error)?
