### PR TITLE
rehashing.c: Fix compile error originating from SPOP rewrite

### DIFF
--- a/utils/hashtable/rehashing.c
+++ b/utils/hashtable/rehashing.c
@@ -73,7 +73,7 @@ void stressGetKeys(dict *d, int times) {
     dictEntry **des = zmalloc(sizeof(dictEntry*)*dictSize(d));
     for (j = 0; j < times; j++) {
         int requested = rand() % (dictSize(d)+1);
-        int returned = dictGetRandomKeys(d, des, requested);
+        int returned = dictGetSomeKeys(d, des, requested);
         if (requested != returned) {
             printf("*** ERROR! Req: %d, Ret: %d\n", requested, returned);
             exit(1);


### PR DESCRIPTION
rehashing.c fails to compile as dictGetRandomKeys was removed in the recent SPOP rewrite. This patch uses dictGetSomeKeys to fix the compile error.
