### PR TITLE
Eliminate dead code in readQueryFromClient

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1184,17 +1184,13 @@ void readQueryFromClient(aeEventLoop *el, int fd, void *privdata, int mask) {
     } else if (nread == 0) {
         redisLog(REDIS_VERBOSE, "Client closed connection");
         freeClient(c);
-        return;
-    }
-    if (nread) {
-        sdsIncrLen(c->querybuf,nread);
-        c->lastinteraction = server.unixtime;
-        if (c->flags & REDIS_MASTER) c->reploff += nread;
-        server.stat_net_input_bytes += nread;
-    } else {
         server.current_client = NULL;
         return;
     }
+    sdsIncrLen(c->querybuf,nread);
+    c->lastinteraction = server.unixtime;
+    if (c->flags & REDIS_MASTER) c->reploff += nread;
+    server.stat_net_input_bytes += nread;
     if (sdslen(c->querybuf) > server.client_max_querybuf_len) {
         sds ci = catClientInfoString(sdsempty(),c), bytes = sdsempty();
 


### PR DESCRIPTION
Found this one this morning; the code in here was dead because `nread` is checked for `0` right above. This was causing the `server.current_client` from not being reset to `NULL` when the client closed the connection.
