### PR TITLE
Fix supporting RDB version for redis-check-rdb.

### DIFF
--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -122,7 +122,7 @@ int processHeader(void) {
     }
 
     dump_version = (int)strtol(buf + 5, NULL, 10);
-    if (dump_version < 1 || dump_version > 6) {
+    if (dump_version < 1 || dump_version > REDIS_RDB_VERSION) {
         ERROR("Unknown RDB format version: %d", dump_version);
     }
     return dump_version;


### PR DESCRIPTION
The RDB version is updated to 7 by commit 101b3a6e42e84e5cb423ef413225d8b8d8cc0bbc, 
but Redis has processed version 7 as invalid version by now.
In unstable branch, redis-check-rdb always failed as follows.

$ bin/redis-check-rdb data/dump.rdb
48433:C 20 Feb 01:57:33.767 # Checking RDB file data/dump.rdb
48433:C 20 Feb 01:57:33.767 # Unknown RDB format version: 7

Please give me comments.
