### PR TITLE
Prevent AUTH from adding to the cli command history

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -987,7 +987,7 @@ static void repl(void) {
     while((line = linenoise(context ? config.prompt : "not connected> ")) != NULL) {
         if (line[0] != '\0') {
             argv = sdssplitargs(line,&argc);
-            if (history) linenoiseHistoryAdd(line);
+            if (history && strcasecmp(argv[0],"auth")) linenoiseHistoryAdd(line);
             if (historyfile) linenoiseHistorySave(historyfile);
 
             if (argv == NULL) {


### PR DESCRIPTION
Fixes the https://github.com/antirez/redis/issues/2412
