### PR TITLE
aeDeleteEventLoop() release aeTimeEvents to avoid memory leak

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -390,7 +390,7 @@ int aeProcessEvents(aeEventLoop *eventLoop, int flags)
             } else {
                 tvp->tv_usec = (shortest->when_ms - now_ms)*1000;
             }
-            if (tvp->tv_sec < 0) tvp->tv_sec = 0;
+            if (tvp->tv_sec < 0) tvp->tv_sec = tvp->tv_usec = 0;
             if (tvp->tv_usec < 0) tvp->tv_usec = 0;
         } else {
             /* If we have to check for events but need to return
@@ -447,7 +447,7 @@ int aeWait(int fd, int mask, long long milliseconds) {
     if ((retval = poll(&pfd, 1, milliseconds))== 1) {
         if (pfd.revents & POLLIN) retmask |= AE_READABLE;
         if (pfd.revents & POLLOUT) retmask |= AE_WRITABLE;
-	if (pfd.revents & POLLERR) retmask |= AE_WRITABLE;
+        if (pfd.revents & POLLERR) retmask |= AE_WRITABLE;
         if (pfd.revents & POLLHUP) retmask |= AE_WRITABLE;
         return retmask;
     } else {

--- a/src/ae.c
+++ b/src/ae.c
@@ -332,6 +332,7 @@ static int processTimeEvents(aeEventLoop *eventLoop) {
              * another linked list). */
             if (retval != AE_NOMORE) {
                 aeAddMillisecondsToNow(retval,&te->when_sec,&te->when_ms);
+                te->id = eventLoop->timeEventNextId++;
             } else {
                 aeDeleteTimeEvent(eventLoop, id);
             }

--- a/src/ae.c
+++ b/src/ae.c
@@ -122,6 +122,13 @@ int aeResizeSetSize(aeEventLoop *eventLoop, int setsize) {
 }
 
 void aeDeleteEventLoop(aeEventLoop *eventLoop) {
+    while(eventLoop->timeEventHead) {
+        aeTimeEvent *te = eventLoop->timeEventHead;
+        eventLoop->timeEventHead = te->next;
+        if (te->finalizerProc)
+            te->finalizerProc(eventLoop, te->clientData);
+        zfree(te);
+    }
     aeApiFree(eventLoop);
     zfree(eventLoop->events);
     zfree(eventLoop->fired);


### PR DESCRIPTION
ae.c/aeDeleteEventLoop: release aeTimeEvents

We malloc memory for registeing aeTimeEvent,
we should also release them to avoid leaking.
