### PR TITLE
ae_kqueue.c: alloc enough space for events

### DIFF
--- a/src/ae_kqueue.c
+++ b/src/ae_kqueue.c
@@ -120,6 +120,11 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
                 eventLoop->setsize * AE_KIND, NULL);
     }
 
+    /* FUTURE OPTIMIZATIONS:
+     * Sort stat->events by ident at first.  O(nlgn)
+     * Because retval is usually very small, current
+     * way is not a very bad substitute.     O(n^2)
+     */
     if (retval > 0) {
         int i, j;
 


### PR DESCRIPTION
- In kqueue, {`ident`, `filter`} identify an unique event.
  As we now care for EVFILT_READ and EVFIT_WRITE, the event kind is AE_KIND == 2. 
  We should alloc "sizeof(kevent) \* setsize \* AE_KIND" bytes for "events" of aeApiState to satisfy the ceil of unique event amount.
- `kqueue` may return events `{fd1, EVFILT_READ},{fd2, EVFIT_WRITE}...{*.*}`, and fd1 can equals to fd2.
  To keep consistency with other implements of `aeApiPoll`, we should merge them into one event in `eventLoop->fired`
  ---
  ## TEST CODE

``` c
#include<sys/types.h>
#include<sys/event.h>
#include<sys/time.h>
#include<fcntl.h>
#include<unistd.h>
#include<stdio.h>

int main()
{
    struct kevent events[4];
    int kq = kqueue();
    int fd = open("hw", O_RDWR);
    EV_SET(events, fd, EVFILT_READ, EV_ADD, 0, 0, NULL);
    kevent(kq, events, 1, NULL, 0, NULL);
    EV_SET(events, fd, EVFILT_WRITE, EV_ADD, 0, 0, NULL);
    kevent(kq, events, 1, NULL, 0, NULL);
    printf("%d\n", kevent(kq, NULL, 0, events, 4, NULL));
    return 0;
}
```

---

``` c
# echo "hello world" > hw
# gcc kqueue.c
# ./a.out
```
## RESULT

`printf("%d\n", kevent(kq, NULL, 0, events, 4, NULL));` outputs 2.
We care EVFILT_READ and EVFIT_WRITE on a single fd, and it finally return 2 events.
