### PR TITLE
Fix 'salve' typos to 'slave'

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1425,7 +1425,7 @@ void backgroundSaveDoneHandlerDisk(int exitcode, int bysignal) {
 }
 
 /* A background saving child (BGSAVE) terminated its work. Handle this.
- * This function covers the case of RDB -> Salves socket transfers for
+ * This function covers the case of RDB -> Slaves socket transfers for
  * diskless replication. */
 void backgroundSaveDoneHandlerSocket(int exitcode, int bysignal) {
     uint64_t *ok_slaves;

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -113,7 +113,7 @@ foreach dl {no yes} {
                 start_server {} {
                     lappend slaves [srv 0 client]
                     test "Connect multiple slaves at the same time (issue #141), diskless=$dl" {
-                        # Send SALVEOF commands to slaves
+                        # Send SLAVEOF commands to slaves
                         [lindex $slaves 0] slaveof $master_host $master_port
                         [lindex $slaves 1] slaveof $master_host $master_port
                         [lindex $slaves 2] slaveof $master_host $master_port


### PR DESCRIPTION
Fix 'salve' typos to 'slave'
