### PR TITLE
ae_epoll/aeApiDelEvent: update events' mask

### DIFF
--- a/src/ae_epoll.c
+++ b/src/ae_epoll.c
@@ -92,6 +92,7 @@ static void aeApiDelEvent(aeEventLoop *eventLoop, int fd, int delmask) {
     aeApiState *state = eventLoop->apidata;
     struct epoll_event ee;
     int mask = eventLoop->events[fd].mask & (~delmask);
+    eventLoop->events[fd].mask = mask;
 
     ee.events = 0;
     if (mask & AE_READABLE) ee.events |= EPOLLIN;


### PR DESCRIPTION
After we delete an event, we should also update the events' mask,
because next add and delete operation will depend on events' mask.
