### PR TITLE
Anet.c: close unused fd

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -463,13 +463,15 @@ static int _anetTcpServer(char *err, int port, char *bindaddr, int af, int backl
             continue;
 
         if (af == AF_INET6 && anetV6Only(err,s) == ANET_ERR) goto error;
-        if (anetSetReuseAddr(err,s) == ANET_ERR) goto error;
+        if (anetSetReuseAddr(err,s) == ANET_ERR) {
+            close(s);
+            goto error;
+        }
         if (anetListen(err,s,p->ai_addr,p->ai_addrlen,backlog) == ANET_ERR) goto error;
         goto end;
     }
     if (p == NULL) {
         anetSetError(err, "unable to bind socket");
-        goto error;
     }
 
 error:

--- a/src/anet.c
+++ b/src/anet.c
@@ -614,8 +614,14 @@ int anetSockName(int fd, char *ip, size_t ip_len, int *port) {
 
     if (getsockname(fd,(struct sockaddr*)&sa,&salen) == -1) {
         if (port) *port = 0;
-        ip[0] = '?';
-        ip[1] = '\0';
+        if (ip) {
+            if (ip_len >= 2) {
+                ip[0] = '?';
+                ip[1] = '\0';
+            } else if (ip_len == 1) {
+                ip[0] = '\0';
+            }
+        }
         return -1;
     }
     if (sa.ss_family == AF_INET) {

--- a/src/anet.c
+++ b/src/anet.c
@@ -361,9 +361,9 @@ int anetUnixGenericConnect(char *err, char *path, int flags)
 
     sa.sun_family = AF_LOCAL;
     strncpy(sa.sun_path,path,sizeof(sa.sun_path)-1);
-    if (flags & ANET_CONNECT_NONBLOCK) {
-        if (anetNonBlock(err,s) != ANET_OK)
-            return ANET_ERR;
+    if (flags & ANET_CONNECT_NONBLOCK && anetNonBlock(err,s) != ANET_OK) {
+        close(s);
+        return ANET_ERR;
     }
     if (connect(s,(struct sockaddr*)&sa,sizeof(sa)) == -1) {
         if (errno == EINPROGRESS &&


### PR DESCRIPTION
- anetUnixGenericConnect: close fd when anetNonBlock failed
  - anetNonBlock doesn't close fd when error happens.
-  _anetTcpServer: close fd when anetSetReuseAddr failed
  - anetV6Only and anetListen close fd inside when failed, anetSetReuseAddr only reports error but doesn't close it.
- anetSockName: check ip and ip_len before write to ip
