### PR TITLE
redis.conf: Fix typo in explanation of the `bind` directive

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -51,7 +51,7 @@
 # is running).
 #
 # IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
-# JUST UNCOMMENT THE FOLLOWING LINE.
+# JUST COMMENT THE FOLLOWING LINE.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 bind 127.0.0.1
 


### PR DESCRIPTION
To listen on all interfaces one has to _comment_ the `bind` directive.

This fixes a typo introduced in 0aa5acc8f31a45ba4ee625227bae80e125fd8bdb
