### PR TITLE
Networking

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -72,12 +72,12 @@ redisClient *createClient(int fd) {
      * in the context of a client. When commands are executed in other
      * contexts (for instance a Lua script) we need a non connected client. */
     if (fd != -1) {
-        anetNonBlock(NULL,fd);
-        anetEnableTcpNoDelay(NULL,fd);
-        if (server.tcpkeepalive)
-            anetKeepAlive(NULL,fd,server.tcpkeepalive);
-        if (aeCreateFileEvent(server.el,fd,AE_READABLE,
-            readQueryFromClient, c) == AE_ERR)
+        if (anetNonBlock(NULL,fd) == ANET_ERR ||
+            anetEnableTcpNoDelay(NULL,fd) == ANET_ERR ||
+            (server.tcpkeepalive &&
+                anetKeepAlive(NULL,fd,server.tcpkeepalive) == ANET_ERR) ||
+            (aeCreateFileEvent(server.el,fd,AE_READABLE,
+                                readQueryFromClient, c) == AE_ERR))
         {
             close(fd);
             zfree(c);

--- a/src/networking.c
+++ b/src/networking.c
@@ -46,9 +46,12 @@ size_t zmalloc_size_sds(sds s) {
 size_t getStringObjectSdsUsedMemory(robj *o) {
     redisAssertWithInfo(NULL,o,o->type == REDIS_STRING);
     switch(o->encoding) {
-    case REDIS_ENCODING_RAW: return zmalloc_size_sds(o->ptr);
-    case REDIS_ENCODING_EMBSTR: return sdslen(o->ptr);
-    default: return 0; /* Just integer encoding for now. */
+        case REDIS_ENCODING_RAW:
+            return zmalloc_size_sds(o->ptr);
+        case REDIS_ENCODING_EMBSTR:
+            return sdslen(o->ptr) + sizeof(struct sdshdr) + 1;
+        default:
+            return 0; /* Just integer encoding for now. */
     }
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -495,17 +495,7 @@ void addReplyBulkLen(redisClient *c, robj *obj) {
     if (sdsEncodedObject(obj)) {
         len = sdslen(obj->ptr);
     } else {
-        long n = (long)obj->ptr;
-
-        /* Compute how many bytes will take this integer as a radix 10 string */
-        len = 1;
-        if (n < 0) {
-            len++;
-            n = -n;
-        }
-        while((n = n/10) != 0) {
-            len++;
-        }
+        len = sdigits10((long)obj->ptr);
     }
 
     if (len < REDIS_SHARED_BULKHDR_LEN)


### PR DESCRIPTION
- correct size for EMBSTR
  
  The amount of memory used by the sds string at object->ptr for a REDIS_ENCODING_EMBSTR object is:
  sdslen(o->ptr) + sizeof(struct sdshdr) + 1;
- replace a code block with existing sdigits10
