### PR TITLE
Add show-key-distribution and call options

### DIFF
--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -121,7 +121,7 @@ class ClusterNode
         nodes.each{|n|
             # name addr flags role ping_sent ping_recv link_status slots
             split = n.split
-            name,addr,flags,master_id,ping_sent,ping_recv,config_epoch,link_status = split[0..6]
+            name,addr,flags,master_id,ping_sent,ping_srecv,config_epoch,link_status = split[0..6]
             slots = split[8..-1]
             info = {
                 :name => name,
@@ -1142,7 +1142,8 @@ class RedisTrib
     def show_key_distribution(argv,opt)
         load_cluster_info_from_node(argv[0])
         puts "\n\nMaster IP\t\tKeys On Shard"
-        @nodes.each{|n| next if n.has_flag? "slave"
+        @nodes.each{|n| 
+            next if n.has_flag? "slave"
             begin
                 res = n.r.send("DBSIZE")
                 puts "#{n}\t#{res}"

--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -121,7 +121,7 @@ class ClusterNode
         nodes.each{|n|
             # name addr flags role ping_sent ping_recv link_status slots
             split = n.split
-            name,addr,flags,master_id,ping_sent,ping_srecv,config_epoch,link_status = split[0..6]
+            name,addr,flags,master_id,ping_sent,ping_recv,config_epoch,link_status = split[0..6]
             slots = split[8..-1]
             info = {
                 :name => name,


### PR DESCRIPTION
Example runs below:

```
[root@redis-cluster-node1 ~]# ./redis-trib.rb show-key-distribution 10.184.13.42:6379
Connecting to node 10.184.13.42:6379: OK
Connecting to node 10.184.13.41:6379: OK
Connecting to node 10.184.13.38:6379: OK
Connecting to node 10.184.13.34:6379: OK
Connecting to node 10.184.13.40:6379: OK
Connecting to node 10.184.13.4:6379: OK


Master IP       Keys On Shard
10.184.13.42:6379   1827621
10.184.13.41:6379   1659226
10.184.13.40:6379   1835822
```

```
[root@redis-cluster-node1 ~]# ./redis-trib.rb call --slaveonly 10.184.13.42:6379 dbsize
Connecting to node 10.184.13.42:6379: OK
Connecting to node 10.184.13.41:6379: OK
Connecting to node 10.184.13.38:6379: OK
Connecting to node 10.184.13.34:6379: OK
Connecting to node 10.184.13.40:6379: OK
Connecting to node 10.184.13.4:6379: OK
>>> Calling DBSIZE
10.184.13.38:6379: 1827621
10.184.13.34:6379: 1835822
10.184.13.4:6379: 1659226
```

```
[root@redis-cluster-node1 ~]# ./redis-trib.rb call --masteronly 10.184.13.42:6379 dbsize
Connecting to node 10.184.13.42:6379: OK
Connecting to node 10.184.13.41:6379: OK
Connecting to node 10.184.13.38:6379: OK
Connecting to node 10.184.13.34:6379: OK
Connecting to node 10.184.13.40:6379: OK
Connecting to node 10.184.13.4:6379: OK
>>> Calling DBSIZE
10.184.13.42:6379: 1827621
10.184.13.41:6379: 1659226
10.184.13.40:6379: 1835822
```
