### PR TITLE
listDup, handle theoretical failure of listAddNodeTail

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -261,13 +261,21 @@ list *listDup(list *orig)
                 listReleaseIterator(iter);
                 return NULL;
             }
-        } else
+	    if (listAddNodeTail(copy, value) == NULL){
+	        if (copy->free)
+		    copy->free(value);
+		listRelease(copy);
+		listReleaseIterator(iter);
+		return NULL;
+	    }
+        } else{
             value = node->value;
-        if (listAddNodeTail(copy, value) == NULL) {
-            listRelease(copy);
-            listReleaseIterator(iter);
-            return NULL;
-        }
+            if (listAddNodeTail(copy, value) == NULL) {
+                listRelease(copy);
+                listReleaseIterator(iter);
+                return NULL;
+            }
+	}
     }
     listReleaseIterator(iter);
     return copy;


### PR DESCRIPTION
**dup** succeed, but **listAddNodeTail** failed, memory may leak.
need release **_value_.
