### PR TITLE
fixes to diskless replication.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -149,7 +149,7 @@ int prepareClientToWrite(redisClient *c) {
     if (c->fd <= 0) return REDIS_ERR; /* Fake client */
     if (c->bufpos == 0 && listLength(c->reply) == 0 &&
         (c->replstate == REDIS_REPL_NONE ||
-         c->replstate == REDIS_REPL_ONLINE) &&
+         c->replstate == REDIS_REPL_ONLINE) && !c->repl_put_online_on_ack &&
         aeCreateFileEvent(server.el, c->fd, AE_WRITABLE,
         sendReplyToClient, c) == AE_ERR) return REDIS_ERR;
     return REDIS_OK;

--- a/src/replication.c
+++ b/src/replication.c
@@ -773,6 +773,7 @@ void updateSlavesWaitingBgsave(int bgsaveerr, int type) {
                  * is technically online now. */
                 slave->replstate = REDIS_REPL_ONLINE;
                 slave->repl_put_online_on_ack = 1;
+                slave->repl_ack_time = server.unixtime;
             } else {
                 if (bgsaveerr != REDIS_OK) {
                     freeClient(slave);


### PR DESCRIPTION
master was closing the connection if the RDB transfer took long time.
and also sent PINGs to the slave before it got the initial ACK, in which case the slave wouldn't be able to find the EOF marker.
