### PR TITLE
change the order of two line

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -339,9 +339,9 @@ size_t zmalloc_get_smap_bytes_by_field(char *field) {
     char line[1024];
     size_t bytes = 0;
     FILE *fp = fopen("/proc/self/smaps","r");
-    int flen = strlen(field);
-
     if (!fp) return 0;
+
+    int flen = strlen(field);
     while(fgets(line,sizeof(line),fp) != NULL) {
         if (strncmp(line,field,flen) == 0) {
             char *p = strchr(line,'k');


### PR DESCRIPTION
if fp is a NULL pointer,why do we waste time computing strlen(field)
sorry for my bad English
