### PR TITLE
Fix slave failover timeout

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2699,7 +2699,7 @@ void clusterHandleSlaveFailover(void) {
      * Retry is two times the Timeout.
      */
     auth_timeout = server.cluster_node_timeout*2;
-    if (auth_timeout < 2000) auth_timeout = 2000;
+    if (auth_timeout > 2000) auth_timeout = 2000;
     auth_retry_time = auth_timeout*2;
 
     /* Pre conditions to run the function, that must be met both in case


### PR DESCRIPTION
Fix this typo (maybe?)

```
 * Timeout is MIN(NODE_TIMEOUT*2,2000) milliseconds.
 * Retry is two times the Timeout.
 */
auth_timeout = server.cluster_node_timeout*2;
if (auth_timeout < 2000) auth_timeout = 2000;
auth_retry_time = auth_timeout*2;
```
