### PR TITLE
new Lua memory limit

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1479,6 +1479,9 @@ void initServerConfig(void) {
     server.cluster_configfile = zstrdup(REDIS_DEFAULT_CLUSTER_CONFIG_FILE);
     server.lua_caller = NULL;
     server.lua_time_limit = REDIS_LUA_TIME_LIMIT;
+    server.lua_memory_limit = REDIS_LUA_MEMORY_LIMIT;
+    server.lua_gc_threshold = REDIS_LUA_GC_THRESHOLD;
+    server.lua_gc_used_memory = 0;
     server.lua_client = NULL;
     server.lua_timedout = 0;
     server.migrate_cached_sockets = dictCreate(&migrateCacheDictType,NULL);

--- a/src/redis.h
+++ b/src/redis.h
@@ -362,6 +362,9 @@ typedef long long mstime_t; /* millisecond time type. */
 
 /* Scripting */
 #define REDIS_LUA_TIME_LIMIT 5000 /* milliseconds */
+#define REDIS_LUA_MEMORY_LIMIT (1024*1024*1024) /* bytes */
+#define REDIS_LUA_MEMORY_MIN (1024*100) /* bytes */
+#define REDIS_LUA_GC_THRESHOLD 75 /* percentage */
 
 /* Units */
 #define UNIT_SECONDS 0
@@ -908,6 +911,9 @@ struct redisServer {
     redisClient *lua_caller;   /* The client running EVAL right now, or NULL */
     dict *lua_scripts;         /* A dictionary of SHA1 -> Lua scripts */
     mstime_t lua_time_limit;  /* Script timeout in milliseconds */
+    unsigned long long lua_memory_limit;  /* Script memory limit */
+    int lua_gc_threshold; /* Script gc threashold */
+    unsigned long long lua_gc_used_memory;
     mstime_t lua_time_start;  /* Start time of script, milliseconds time */
     int lua_write_dirty;  /* True if a write command was called during the
                              execution of the current script. */

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -637,12 +637,62 @@ void scriptingEnableGlobalsProtection(lua_State *lua) {
     sdsfree(code);
 }
 
+/*
+ * parameters:
+ * ud - opaque pointer passed to lua_newstate
+ * ptr - pointer to the block being allocated/reallocated/freed
+ * osize - original size of the block
+ * nsize - the new size of the block
+ * 
+ * NOTE:
+ * ptr is NULL if and only if osize is zero.
+ * When nsize is zero, the allocator must return NULL
+ * if osize is not zero, it should free the block pointed to by ptr.
+ * When nsize is not zero, the allocator returns NULL if and only if it cannot fill the request.
+ * When nsize is not zero and osize is zero, the allocator should behave like malloc.
+ * When nsize and osize are not zero, the allocator behaves like realloc.
+ * 
+ * if server.lua_memory_limit is 0, then the limmitation is disabled
+ */ 
+static void *l_alloc_restricted (void *ud, void *ptr, size_t osize, size_t nsize) {
+    REDIS_NOTUSED(ud);
+    if (ptr == NULL && osize!= 0)
+        return NULL;
+
+    if (nsize == 0) {
+        if (osize != 0) {
+            zlibc_free(ptr);
+            server.lua_gc_used_memory -= osize;
+        }
+        return NULL;
+    } else {
+        if ( server.lua_memory_limit && server.lua_gc_used_memory + (nsize - osize) > server.lua_memory_limit ) {
+            redisLog(REDIS_WARNING,"Lua stack reach it's defined size limit");
+            return NULL;
+        }
+
+        if ( osize == 0)
+            ptr = zlibc_malloc(nsize);
+        else
+            ptr = zlibc_realloc(ptr, nsize);
+
+        if (ptr) {
+            server.lua_gc_used_memory += (nsize - osize);
+            return ptr;
+        } else
+            return NULL;
+    }
+}
+
 /* Initialize the scripting environment.
  * It is possible to call this function to reset the scripting environment
  * assuming that we call scriptingRelease() before.
  * See scriptingReset() for more information. */
 void scriptingInit(void) {
-    lua_State *lua = lua_open();
+    int* ud = zmalloc(sizeof(int));
+    *ud = 0;
+    server.lua_gc_used_memory = 0; 
+    lua_State* lua = lua_newstate(l_alloc_restricted, ud);
 
     luaLoadLibraries(lua);
     luaRemoveUnsupportedFunctions(lua);
@@ -926,6 +976,18 @@ void evalGenericCommand(redisClient *c, int evalsha) {
     char funcname[43];
     long long numkeys;
     int delhook = 0, err;
+    unsigned int tempLuaMem = server.lua_gc_used_memory ;
+
+    if ( server.lua_memory_limit && server.lua_gc_threshold >= 0 ) {
+        int gc_occupied_mem_percentage = ( (float)server.lua_gc_used_memory / server.lua_memory_limit ) * 100;
+        while ( gc_occupied_mem_percentage > server.lua_gc_threshold ||
+            (server.lua_memory_limit - server.lua_gc_used_memory) < REDIS_LUA_MEMORY_MIN) {
+            lua_gc(lua,LUA_GCSTEP,10);
+            if ( server.lua_gc_used_memory == tempLuaMem ) // check if we reached our min limit
+                break;								// if we can't free more memory
+            tempLuaMem = server.lua_gc_used_memory;
+        }
+    }
 
     /* We want the same PRNG sequence at every call so that our PRNG is
      * not affected by external state. */

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -39,6 +39,14 @@ void zlibc_free(void *ptr) {
     free(ptr);
 }
 
+void* zlibc_malloc(size_t size){
+	return( malloc(size) );
+}
+
+void* zlibc_realloc(void *ptr, size_t size){
+	return( realloc(ptr, size) );
+}
+
 #include <string.h>
 #include <pthread.h>
 #include "config.h"

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -79,6 +79,8 @@ size_t zmalloc_get_private_dirty(void);
 size_t zmalloc_get_smap_bytes_by_field(char *field);
 size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
+void *zlibc_malloc(size_t size);
+void *zlibc_realloc(void *ptr, size_t size);
 
 #ifndef HAVE_MALLOC_SIZE
 size_t zmalloc_size(void *ptr);


### PR DESCRIPTION
Lua memory usage is not limited and a script can crash redis.
The issue is solved with the addition of new memory allocator that uses a new configurable lua-memory-limit.

**Implementation details:**
currently we are using Lua 5.1.5. In this version the GC cannot be called from within the allocator, thus scripts that doesn't suppose to cross the memory limit can fail on low memory,
Scenarios:
1. setting memory limit to X, and running a script that allocates large array of X/2, and then run it again, will fail with memory limit message.
2. setting memory limit to X, allocating large array of X/2, release it and allocating new array of size X/2 at the same script will fail with memory limit message.

to improve the first scenario we added a new configurable lua-gc-threshold, which is tested before we run the script, if the Lua stack cross the threshold we initiate GC cycle to release some memory. 

the second issue was resolved in Lua 5.2 with the emergency garbage collector feature and memory limit gc parameter.
