### PR TITLE
Changed file locking method to use fcntl instead of flock. Solaris doesn't really do flock

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -348,7 +348,7 @@ void clusterSaveConfigOrDie(int do_fsync) {
     }
 }
 
-/* Lock the cluster config using flock(), and leaks the file descritor used to
+/* Lock the cluster config using fcntl(), and leaks the file descriptor used to
  * acquire the lock so that the file will be locked forever.
  *
  * This works because we always update nodes.conf with a new version
@@ -369,7 +369,13 @@ int clusterLockConfig(char *filename) {
         return REDIS_ERR;
     }
 
-    if (flock(fd,LOCK_EX|LOCK_NB) == -1) {
+    struct flock lock;
+    lock.l_start = 0;
+    lock.l_len = 0;
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+
+    if (fcntl(fd, F_SETLK, &lock) == -1) {
         if (errno == EWOULDBLOCK) {
             redisLog(REDIS_WARNING,
                  "Sorry, the cluster configuration file %s is already used "


### PR DESCRIPTION
Unable to build `cluster.c` on Solaris 10 - `flock` doesn't appear to be properly implemented on Solaris. `fcntl` works OK though. I've tested the change on Solaris 10 and on OSX
