### PR TITLE
replication.c/readSyncBulkPayload(): retry is -1 when AOF fatal happen

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1047,7 +1047,7 @@ void readSyncBulkPayload(aeEventLoop *el, int fd, void *privdata, int mask) {
                 redisLog(REDIS_WARNING,"Failed enabling the AOF after successful master synchronization! Trying it again in one second.");
                 sleep(1);
             }
-            if (!retry) {
+            if (retry == -1) {
                 redisLog(REDIS_WARNING,"FATAL: this slave instance finished the synchronization with its master, but the AOF can't be turned on. Exiting now.");
                 exit(1);
             }

--- a/src/replication.c
+++ b/src/replication.c
@@ -1360,6 +1360,7 @@ void syncWithMaster(aeEventLoop *el, int fd, void *privdata, int mask) {
         redisLog(REDIS_WARNING,
             "Can't create readable event for SYNC: %s (fd=%d)",
             strerror(errno),fd);
+        close(dfd);
         goto error;
     }
 


### PR DESCRIPTION
A little oversight. :-)
### Test Code

``` c
int main()
{                         
    int retry = 10;       
    while(retry--);                 
    printf("%d\n", retry);                                                
}
```
### Output

``` c
-1
```
