### PR TITLE
add 24 bytes tiny size class to jemalloc

### DIFF
--- a/deps/jemalloc/include/jemalloc/internal/size_classes.sh
+++ b/deps/jemalloc/include/jemalloc/internal/size_classes.sh
@@ -6,7 +6,7 @@
 lg_qmin=3
 lg_qmax=4
 
-# The range of tiny size classes is [2^lg_tmin..2^(lg_q-1)].
+# The range of tiny size classes is [2^lg_tmin..2^(lg_q+1)].
 lg_tmin=3
 
 # Range of page sizes.
@@ -48,11 +48,11 @@ while [ ${lg_q} -le ${lg_qmax} ] ; do
       echo "#define	SIZE_CLASSES							\\"
 
       # Tiny size classes.
-      while [ ${sz} -lt ${q} ] ; do
+      while [ ${sz} -lt $((${q}*2)) ] ; do
         echo "    SIZE_CLASS(${bin},	${delta},	${sz})					\\"
         bin=$((${bin} + 1))
         psz=${sz}
-        sz=$((${sz} + ${sz}))
+        sz=$((${sz} + ${t}))
         delta=$((${sz} - ${psz}))
       done
       # Quantum-multiple size classes.  For each doubling of sz, as many as 4


### PR DESCRIPTION
dictEntry struct, listNode struct, and maybe others, consume 24 bytes each.
but since jemalloc doesn't have a pool for 24 bytes allocations they are taken from the 32 bytes pool, and produce about 33% internal fragmentation overhead.

This patch adds a 24 bytes pool size class to jemalloc.

**test (with relatively short strings)**
debug populate 10000000
original code's used_memory: 1254709872
with patch used_memory: 1094714048
memory optimization: **14%**
