### PR TITLE
Issue #2517, smove contract violation

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -343,7 +343,10 @@ void smoveCommand(redisClient *c) {
 
     /* If srcset and dstset are equal, SMOVE is a no-op */
     if (srcset == dstset) {
-        addReply(c,shared.cone);
+        if (setTypeIsMember(srcset,ele))
+            addReply(c,shared.cone);
+        else
+            addReply(c,shared.czero);
         return;
     }
 

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -519,6 +519,7 @@ start_server {
     test "SMOVE non existing key" {
         setup_move
         assert_equal 0 [r smove myset1 myset2 foo]
+        assert_equal 0 [r smove myset1 myset1 foo]
         assert_equal {1 a b} [lsort [r smembers myset1]]
         assert_equal {2 3 4} [lsort [r smembers myset2]]
     }


### PR DESCRIPTION
Uphold the [smove contract](http://redis.io/commands/smove) to return 0 when the element is not a member of the source set, even if source=dest.
