### PR TITLE
Fix Redis server crash when Lua command exceeds client output buffer limit.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -805,7 +805,7 @@ void freeClient(redisClient *c) {
  * a context where calling freeClient() is not possible, because the client
  * should be valid for the continuation of the flow of the program. */
 void freeClientAsync(redisClient *c) {
-    if (c->flags & REDIS_CLOSE_ASAP) return;
+    if (c->flags & REDIS_CLOSE_ASAP || c->flags & REDIS_LUA_CLIENT) return;
     c->flags |= REDIS_CLOSE_ASAP;
     listAddNodeTail(server.clients_to_close,c);
 }


### PR DESCRIPTION
The problem seems to exist in all versions (although the crash is a bit different).  A quick script to reproduce the issue:

``` bash
redis-cli CONFIG SET client-output-buffer-limit "normal 8388608 8388608 3"
redis-cli EVAL "redis.call('set', 'bigkey', string.rep('xxxxxxxxxx',2000000))" 0
redis-cli EVAL "redis.call('get', 'bigkey')" 0
echo 'Redis will crash any moment now...'
while true; do
  redis-cli EVAL "redis.call('ping')" 0
  sleep 1
done
```
