### PR TITLE
fix compile error for struct msghdr in FreeBSD 10

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -54,6 +54,7 @@
 #include <sys/utsname.h>
 #include <locale.h>
 #include <sys/sysctl.h>
+#include <sys/socket.h>
 
 /* Our shared "common" objects */
 


### PR DESCRIPTION
fix compile error with struct msghdr  in FreeBSD 10

I test build and run ./runtest, it works well.
