### PR TITLE
Typo and grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Redis is often referred as a *data structures* server. What this means is that R
 
 Data structures implemented into Redis have a few special properties:
 
-* Redis cares to store them on disk, even if they are always served and modified into the server memory. This means that Redis is fast, but that is also non-volatile.
+* Redis cares to store them on disk, even if they are always served and modified into the server memory. This means that Redis is fast, but that it is also non-volatile.
 * Implementation of data structures stress on memory efficiency, so data structures inside Redis will likely use less memory compared to the same data structure modeled using an high level programming language.
 * Redis offers a number of features that are natural to find in a database, like replication, tunable levels of durability, cluster, high availability.
 
@@ -48,7 +48,7 @@ Fixing build problems with dependencies or cached build options
 
 Redis has some dependencies which are included into the `deps` directory.
 `make` does not rebuild dependencies automatically, even if something in the
-source code of dependencies is changes.
+source code of the dependencies is changed.
 
 When you update the source code with `git pull` or when code inside the
 dependencies tree is modified in any other way, make sure to use the following

--- a/redis.conf
+++ b/redis.conf
@@ -51,7 +51,7 @@
 # is running).
 #
 # IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
-# JUST UNCOMMENT THE FOLLOWING LINE.
+# JUST COMMENT OUT THE FOLLOWING LINE.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 bind 127.0.0.1
 


### PR DESCRIPTION
readme.md: 2 grammar and typo changes
redis.conf: changed "uncomment"  to "comment out", as the word used was opposite of the intended meaning.
