### PR TITLE
use monotonic clocksource for relative time

### DIFF
--- a/deps/hiredis/test.c
+++ b/deps/hiredis/test.c
@@ -38,9 +38,15 @@ static int tests = 0, fails = 0;
 #define test_cond(_c) if(_c) printf("\033[0;32mPASSED\033[0;0m\n"); else {printf("\033[0;31mFAILED\033[0;0m\n"); fails++;}
 
 static long long usec(void) {
+#ifdef CLOCK_MONOTONIC
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (ts.tv_sec * 1000000ULL) + (ts.tv_nsec / 1000ULL);
+#else
     struct timeval tv;
     gettimeofday(&tv,NULL);
     return (((long long)tv.tv_sec)*1000000)+tv.tv_usec;
+#endif
 }
 
 static redisContext *select_database(redisContext *c) {

--- a/src/Makefile
+++ b/src/Makefile
@@ -117,11 +117,11 @@ endif
 
 REDIS_SERVER_NAME=redis-server
 REDIS_SENTINEL_NAME=redis-sentinel
-REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o
+REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o redis.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o time.o
 REDIS_CLI_NAME=redis-cli
-REDIS_CLI_OBJ=anet.o sds.o adlist.o redis-cli.o zmalloc.o release.o anet.o ae.o crc64.o
+REDIS_CLI_OBJ=anet.o sds.o adlist.o redis-cli.o zmalloc.o release.o anet.o ae.o crc64.o time.o
 REDIS_BENCHMARK_NAME=redis-benchmark
-REDIS_BENCHMARK_OBJ=ae.o anet.o redis-benchmark.o sds.o adlist.o zmalloc.o redis-benchmark.o
+REDIS_BENCHMARK_OBJ=ae.o anet.o redis-benchmark.o sds.o adlist.o zmalloc.o redis-benchmark.o time.o
 REDIS_CHECK_RDB_NAME=redis-check-rdb
 REDIS_CHECK_AOF_NAME=redis-check-aof
 REDIS_CHECK_AOF_OBJ=redis-check-aof.o

--- a/src/ae.c
+++ b/src/ae.c
@@ -41,6 +41,7 @@
 #include <errno.h>
 
 #include "ae.h"
+#include "time.h"
 #include "zmalloc.h"
 #include "config.h"
 
@@ -179,11 +180,9 @@ int aeGetFileEvents(aeEventLoop *eventLoop, int fd) {
 
 static void aeGetTime(long *seconds, long *milliseconds)
 {
-    struct timeval tv;
-
-    gettimeofday(&tv, NULL);
-    *seconds = tv.tv_sec;
-    *milliseconds = tv.tv_usec/1000;
+    long long msec = mstime();
+    *seconds = msec / 1000ULL;
+    *milliseconds = msec % 1000ULL;
 }
 
 static void aeAddMillisecondsToNow(long long milliseconds, long *sec, long *ms) {

--- a/src/dict.c
+++ b/src/dict.c
@@ -44,6 +44,7 @@
 #include <ctype.h>
 
 #include "dict.h"
+#include "time.h"
 #include "zmalloc.h"
 #include "redisassert.h"
 
@@ -287,21 +288,14 @@ int dictRehash(dict *d, int n) {
     return 1;
 }
 
-long long timeInMilliseconds(void) {
-    struct timeval tv;
-
-    gettimeofday(&tv,NULL);
-    return (((long long)tv.tv_sec)*1000)+(tv.tv_usec/1000);
-}
-
 /* Rehash for an amount of time between ms milliseconds and ms+1 milliseconds */
 int dictRehashMilliseconds(dict *d, int ms) {
-    long long start = timeInMilliseconds();
+    long long start = mstime();
     int rehashes = 0;
 
     while(dictRehash(d,100)) {
         rehashes += 100;
-        if (timeInMilliseconds()-start > ms) break;
+        if (mstime()-start > ms) break;
     }
     return rehashes;
 }

--- a/src/intset.c
+++ b/src/intset.c
@@ -303,12 +303,6 @@ static void ok(void) {
     printf("OK\n");
 }
 
-static long long usec(void) {
-    struct timeval tv;
-    gettimeofday(&tv,NULL);
-    return (((long long)tv.tv_sec)*1000000)+tv.tv_usec;
-}
-
 #define assert(_e) ((_e)?(void)0:(_assert(#_e,__FILE__,__LINE__),exit(1)))
 static void _assert(char *estr, char *file, int line) {
     printf("\n\n=== ASSERTION FAILED ===\n");
@@ -465,10 +459,10 @@ int intsetTest(int argc, char **argv) {
         is = createSet(bits,size);
         checkConsistency(is);
 
-        start = usec();
+        start = ustime();
         for (i = 0; i < num; i++) intsetSearch(is,rand() % ((1<<bits)-1),NULL);
         printf("%ld lookups, %ld element set, %lldusec\n",
-               num,size,usec()-start);
+               num,size,ustime()-start);
     }
 
     printf("Stress add+delete: "); {

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -32,6 +32,7 @@
 #include "quicklist.h"
 #include "zmalloc.h"
 #include "ziplist.h"
+#include "time.h"
 #include "util.h" /* for ll2string */
 #include "lzf.h"
 
@@ -1459,20 +1460,6 @@ static void ql_info(quicklist *ql) {
     UNUSED(ql);
 #endif
 }
-
-/* Return the UNIX time in microseconds */
-static long long ustime(void) {
-    struct timeval tv;
-    long long ust;
-
-    gettimeofday(&tv, NULL);
-    ust = ((long long)tv.tv_sec) * 1000000;
-    ust += tv.tv_usec;
-    return ust;
-}
-
-/* Return the UNIX time in milliseconds */
-static long long mstime(void) { return ustime() / 1000; }
 
 /* Iterate over an entire quicklist.
  * Print the list if 'print' == 1.

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -44,6 +44,7 @@
 #include "hiredis.h"
 #include "sds.h"
 #include "adlist.h"
+#include "time.h"
 #include "zmalloc.h"
 
 #define REDIS_NOTUSED(V) ((void) V)
@@ -101,26 +102,6 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 static void createMissingClients(client c);
 
 /* Implementation */
-static long long ustime(void) {
-    struct timeval tv;
-    long long ust;
-
-    gettimeofday(&tv, NULL);
-    ust = ((long)tv.tv_sec)*1000000;
-    ust += tv.tv_usec;
-    return ust;
-}
-
-static long long mstime(void) {
-    struct timeval tv;
-    long long mst;
-
-    gettimeofday(&tv, NULL);
-    mst = ((long long)tv.tv_sec)*1000;
-    mst += tv.tv_usec/1000;
-    return mst;
-}
-
 static void freeClient(client c) {
     listNode *ln;
     aeDeleteFileEvent(config.el,c->context->fd,AE_WRITABLE);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -48,6 +48,7 @@
 
 #include "hiredis.h"
 #include "sds.h"
+#include "time.h"
 #include "zmalloc.h"
 #include "linenoise.h"
 #include "help.h"
@@ -123,20 +124,6 @@ char *redisGitDirty(void);
 /*------------------------------------------------------------------------------
  * Utility functions
  *--------------------------------------------------------------------------- */
-
-static long long ustime(void) {
-    struct timeval tv;
-    long long ust;
-
-    gettimeofday(&tv, NULL);
-    ust = ((long long)tv.tv_sec)*1000000;
-    ust += tv.tv_usec;
-    return ust;
-}
-
-static long long mstime(void) {
-    return ustime()/1000;
-}
 
 static void cliRefreshPrompt(void) {
     int len;

--- a/src/redis.c
+++ b/src/redis.c
@@ -381,22 +381,6 @@ err:
     if (!log_to_stdout) close(fd);
 }
 
-/* Return the UNIX time in microseconds */
-long long ustime(void) {
-    struct timeval tv;
-    long long ust;
-
-    gettimeofday(&tv, NULL);
-    ust = ((long long)tv.tv_sec)*1000000;
-    ust += tv.tv_usec;
-    return ust;
-}
-
-/* Return the UNIX time in milliseconds */
-long long mstime(void) {
-    return ustime()/1000;
-}
-
 /* After an RDB dump or AOF rewrite we exit from children using _exit() instead of
  * exit(), because the latter may interact with the same file objects used by
  * the parent process. However if we are testing the coverage normal exit() is

--- a/src/redis.h
+++ b/src/redis.h
@@ -59,6 +59,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #include "ziplist.h" /* Compact list data structure */
 #include "intset.h"  /* Compact integer set structure */
 #include "version.h" /* Version macro */
+#include "time.h"    /* Timespan measurement functions */
 #include "util.h"    /* Misc functions useful in many places */
 #include "latency.h" /* Latency monitor API */
 #include "sparkline.h" /* ASII graphs API */
@@ -1030,8 +1031,6 @@ extern dictType replScriptCacheDictType;
  *----------------------------------------------------------------------------*/
 
 /* Utils */
-long long ustime(void);
-long long mstime(void);
 void getRandomHexChars(char *p, unsigned int len);
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
 void exitFromChild(int retcode);

--- a/src/time.c
+++ b/src/time.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/time.h>
+#include <time.h>
+
+#include "time.h"
+
+/* Current time in usecs, used for timespan measurement. */
+long long ustime(void)
+{
+    struct timeval tv;
+    gettimeofday(&tv,NULL);
+    return (((long long)tv.tv_sec)*1000000)+tv.tv_usec;
+}
+
+long long mstime(void)
+{
+	return ustime() / 1000ULL;
+}

--- a/src/time.c
+++ b/src/time.c
@@ -35,9 +35,20 @@
 /* Current time in usecs, used for timespan measurement. */
 long long ustime(void)
 {
+#ifdef CLOCK_MONOTONIC
+    /* High-resolution monotonically-increasing clock source. Not affected by
+     * system clock changes. */
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (ts.tv_sec * 1000000ULL) + (ts.tv_nsec / 1000ULL);
+#else
+    /* High-resolution clock source, affected by system clock changes. Not
+     * ideal for timespan calculation, as it will potentially jump forwards or
+     * backwards. */
     struct timeval tv;
     gettimeofday(&tv,NULL);
     return (((long long)tv.tv_sec)*1000000)+tv.tv_usec;
+#endif
 }
 
 long long mstime(void)

--- a/src/time.h
+++ b/src/time.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __REDIS_TIME_H
+#define __REDIS_TIME_H
+
+long long ustime(void);
+long long mstime(void);
+
+#endif

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1110,12 +1110,6 @@ static unsigned char *createIntList() {
     return zl;
 }
 
-static long long usec(void) {
-    struct timeval tv;
-    gettimeofday(&tv,NULL);
-    return (((long long)tv.tv_sec)*1000000)+tv.tv_usec;
-}
-
 static void stress(int pos, int num, int maxsize, int dnum) {
     int i,j,k;
     unsigned char *zl;
@@ -1128,13 +1122,13 @@ static void stress(int pos, int num, int maxsize, int dnum) {
         }
 
         /* Do num times a push+pop from pos */
-        start = usec();
+        start = ustime();
         for (k = 0; k < num; k++) {
             zl = ziplistPush(zl,(unsigned char*)"quux",4,pos);
             zl = ziplistDeleteRange(zl,0,1);
         }
-        printf("List size: %8d, bytes: %8d, %dx push+pop (%s): %6lld usec\n",
-            i,intrev32ifbe(ZIPLIST_BYTES(zl)),num,posstr[pos],usec()-start);
+        printf("List size: %8d, bytes: %8d, %dx push+pop (%s): %6lld ustime\n",
+            i,intrev32ifbe(ZIPLIST_BYTES(zl)),num,posstr[pos],ustime()-start);
         zfree(zl);
     }
 }


### PR DESCRIPTION
This patch series does two things:
- Unify the numerous declarations of millisecond/microsecond resolution timestamp functions into a single location (adding time.c and time.h)
- Use CLOCK_MONOTONIC when it's available (see justification in commit message). As far as I'm aware, this is a Linux-only thing. All other platforms will continue to use gettimeofday().
