### PR TITLE
adding a sentinel command: "flushconfig" per RCP4

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2775,6 +2775,10 @@ void sentinelCommand(redisClient *c) {
             sentinelEvent(REDIS_WARNING,"+monitor",ri,"%@ quorum %d",ri->quorum);
             addReply(c,shared.ok);
         }
+    } else if (!strcasecmp(c->argv[1]->ptr,"flushconfig")) {
+        sentinelFlushConfig();
+        addReply(c,shared.ok);
+        return;
     } else if (!strcasecmp(c->argv[1]->ptr,"remove")) {
         /* SENTINEL REMOVE <name> */
         sentinelRedisInstance *ri;


### PR DESCRIPTION
This new command triggers a config flush to save the in-memory config to
disk. This is useful for cases of a configuration management system or a
package manager wiping out your sentinel config while the process is
still running - and has not yet been restarted. It can also be useful
for scripting a backup and migrate or clone of a running sentinel.

For additional reasons and details see: https://github.com/therealbill/redis-rcp/blob/master/RCP4.md as it implements RCP4.
