### PR TITLE
sentinel read-only relay master monitor mode.

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -52,6 +52,22 @@ dir /tmp
 # The valid charset is A-z 0-9 and the three characters ".-_".
 sentinel monitor mymaster 127.0.0.1 6379 2
 
+# sentinel candidate-slave <master-name> <ip> <redis-port>
+# 
+# Tells sentinel to select this explicit slave for failover promotion 
+# instead of choosing one of the connected slaves of the master.
+#
+# This config enables a new monitor mode in sentinel to monitor read-only relay masters 
+# in cross-datacenter replication setups where there are read-only relay masters replicating 
+# from writeable masters in other datacenters and the relay masters have slaves connected to them 
+# locally for reads scaling. When such relay masters becomes unavailable, we want the slaves to be 
+# switched to the other relay master in the local colo instead of making them sync from a cross-colo master.
+#
+# Also, if this config is set, sentinel does not send 'slaveof no one' to the promoted slave, 
+# as the promoted slave would be an another local relay master replicating from an another master.
+#
+# sentinel candidate-slave mymaster 127.0.0.1 6380
+ 
 # sentinel auth-pass <master-name> <password>
 #
 # Set the password to use to authenticate with the master and slaves.

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -5,11 +5,11 @@
 cd tests/sentinel
 source ../instances.tcl
 
-set ::instances_count 5 ; # How many instances we use at max.
+set ::instances_count 6 ; # How many instances we use at max.
 
 proc main {} {
     parse_options
-    spawn_instance sentinel $::sentinel_base_port $::instances_count
+    spawn_instance sentinel $::sentinel_base_port [expr { $::instances_count - 1}]
     spawn_instance redis $::redis_base_port $::instances_count
     run_tests
     cleanup

--- a/tests/sentinel/tests/07-monitor-read-only-relay-master.tcl
+++ b/tests/sentinel/tests/07-monitor-read-only-relay-master.tcl
@@ -1,0 +1,123 @@
+# Initialization tests -- most units will start including this.
+
+test "(init) Restart killed instances" {
+    foreach type {redis sentinel} {
+        foreach_${type}_id id {
+            if {[get_instance_attrib $type $id pid] == -1} {
+                puts -nonewline "$type/$id "
+                flush stdout
+                restart_instance $type $id
+            }
+        }
+    }
+}
+
+test "(init) Remove old master entry from sentinels" {
+    foreach_sentinel_id id {
+        catch {S $id SENTINEL REMOVE mymaster}
+    }
+}
+
+set redis_slaves 2
+test "(init) Create a master-relay_masters-slaves cluster of [expr $redis_slaves+4] instances" {
+    create_redis_relay_master_slave_cluster [expr {$redis_slaves+4}]
+}
+set relay_master_id 2
+set relay_master_fallback_id 3
+
+test "(init) Sentinels can start monitoring a master" {
+    set sentinels [llength $::sentinel_instances]
+    set quorum [expr {$sentinels/2+1}]
+    foreach_sentinel_id id {
+        S $id SENTINEL MONITOR mymaster \
+              [get_instance_attrib redis $relay_master_id host] \
+              [get_instance_attrib redis $relay_master_id port] $quorum
+    }
+    foreach_sentinel_id id {
+        assert {[S $id sentinel master mymaster] ne {}}
+        S $id SENTINEL candidate-slave mymaster \
+              [get_instance_attrib redis $relay_master_fallback_id host] \
+              [get_instance_attrib redis $relay_master_fallback_id port]
+        S $id SENTINEL SET mymaster down-after-milliseconds 2000
+        S $id SENTINEL SET mymaster failover-timeout 20000
+        S $id SENTINEL SET mymaster parallel-syncs 10
+    }
+}
+
+test "(init) Sentinels can talk with the master" {
+    foreach_sentinel_id id {
+        wait_for_condition 1000 50 {
+            [catch {S $id SENTINEL GET-MASTER-ADDR-BY-NAME mymaster}] == 0
+        } else {
+            fail "Sentinel $id can't talk with the master."
+        }
+    }
+}
+
+test "(init) Sentinels are able to auto-discover other sentinels" {
+    set sentinels [llength $::sentinel_instances]
+    foreach_sentinel_id id {
+        wait_for_condition 1000 50 {
+            [dict get [S $id SENTINEL MASTER mymaster] num-other-sentinels] == ($sentinels-1)
+        } else {
+            fail "At least some sentinel can't detect some other sentinel"
+        }
+    }
+}
+
+test "(init) Sentinels are able to auto-discover slaves" {
+    foreach_sentinel_id id {
+        wait_for_condition 1000 50 {
+            [dict get [S $id SENTINEL MASTER mymaster] num-slaves] == $redis_slaves
+        } else {
+            fail "At least some sentinel can't detect some slave"
+        }
+    }
+}
+
+# Check the basic monitoring and failover capabilities.
+
+test "Basic failover works if the relay master is down" {
+    set old_port [RI $relay_master_id tcp_port]
+    set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
+    assert {[lindex $addr 1] == $old_port}
+    assert {[RI $relay_master_fallback_id connected_slaves] == 0}
+    kill_instance redis $relay_master_id
+    foreach_sentinel_id id {
+        wait_for_condition 1000 50 {
+            [lindex [S $id SENTINEL GET-MASTER-ADDR-BY-NAME mymaster] 1] != $old_port
+        } else {
+            fail "At least one Sentinel did not received failover info"
+        }
+    }
+    restart_instance redis $relay_master_id
+    set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
+}
+
+test "New relay master has all the slaves pointing to it" {
+    wait_for_condition 1000 50 {
+        [RI $relay_master_fallback_id connected_slaves] == $redis_slaves
+    } else {
+        fail "Redis ID $relay_master_fallback_id don't have all slaves connected"
+    }   
+}
+
+test "All the slaves of relay now point to the new relay master" {
+    foreach_redis_id id {
+        if {$id > 3} {
+            wait_for_condition 1000 50 {
+                [RI $id master_port] == [lindex $addr 1]
+            } else {
+                fail "Redis ID $id not configured to replicate with new relay master"
+            }
+        }
+    }
+}
+
+test "The old relay master eventually gets reconfigured as a candidate slave" {
+    wait_for_condition 1000 50 {
+        [lindex [split [dict get [S 0 SENTINEL MASTER mymaster] candidate-slave] :] 1] == $old_port   
+    } else {
+        fail "Old master not reconfigured as candidate slave of new relay master"
+    }
+}

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -18,7 +18,7 @@ test "(init) Remove old master entry from sentinels" {
     }
 }
 
-set redis_slaves 4
+set redis_slaves 5
 test "(init) Create a master-slaves cluster of [expr $redis_slaves+1] instances" {
     create_redis_master_slave_cluster [expr {$redis_slaves+1}]
 }


### PR DESCRIPTION
@antirez 
we are running sentinel with this feature internally. please see if it is feasible to merge. the patch is against 3.0 branch. but i think it can apply to 2.8 branch also. 

this change enables a new monitor mode in sentinel to monitor read-only
relay masters in cross-DC replication setups which are replicating from
writeable masters in master DC(s) and the relay masters have slave
connected to them locally in local DC for read scaling. when such a relay master
becomes unavailable, we want the slaves connected to it to be switched to the other
relay master in the local DC instead of making them sync from a cross DC
master, automatically by sentinel.

Introduces a new sentinel config:
'sentinel candidate-slave my-master hostname port'
the default sentinel failover mode chooses one of the connected slaves
of the old master and promotes it as master during failover. this
new config specifies the explicit candidate slave to be chosen as new
master for the connected slaves of the old relay master. Also, if this
config is set, sentinel does not sent 'slaveof no one' to the promoted
slave, as the the promoted slave is expected to be an another relay master
replicating from a cross DC master.
A relay master is deemed down when it is either:
- not replying to ping, or
- master_link_status of relay master is down
  and the other sentinels monitoring the same relay master also agrees on
  the above condition.
