### PR TITLE
Sentinel, when slave come back, too many link->pending_commands because of client setname

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3370,7 +3370,9 @@ void sentinelCheckSubjectivelyDown(sentinelRedisInstance *ri) {
     if (ri->link->cc &&
         (mstime() - ri->link->cc_conn_time) >
         SENTINEL_MIN_LINK_RECONNECT_PERIOD &&
-        ri->link->act_ping_time != 0 && /* Ther is a pending ping... */
+        (ri->link->act_ping_time != 0 || /* There is a pending ping... */
+        ri->link->pending_commands >=
+        SENTINEL_MAX_PENDING_COMMANDS * ri->link->refcount) &&
         /* The pending ping is delayed, and we did not received
          * error replies as well. */
         (mstime() - ri->link->act_ping_time) > (ri->down_after_period/2) &&


### PR DESCRIPTION
@antirez, i use unstable branch to test the new sentinel impl.

when slave come back after shutdown, such as "info-refresh" and "last-ok-ping-reply" never be refreshed because of too many link->pending_commands. no more "info" cmd or "ping" cmd can be send out to the slave. i can reproduce this almost every time when a slave down and wait sentinel's link->pending_commands to grow and then restart inplace.

client setname increment link->pending_commands, and it never reset or decrement, and eventually reach SENTINEL_MAX_PENDING_COMMANDS(default 100) very soon.

i give a pr for this, i test it, it could work, but it maybe not the correct solution,  @antirez, pls review.

after reboot-slave, "sentinel slaves", as below:
especially the "last-ping-sent" stays 0, this means ri->link->act_ping_time is 0.

```
chenlijun@redis00 ~ $ redis-cli -p 19379 sentinel slaves larger_demo-buk-7
1)  1) "name"
    2) "192.168.31.102:6816"
    3) "ip"
    4) "192.168.31.102"
    5) "port"
    6) "6816"
    7) "runid"
    8) "f742290d3fc6fe70d8c5729d13864811cc1cc4e4"
    9) "flags"
   10) "slave"
   11) "link-pending-commands"
   12) "101"
   13) "link-refcount"
   14) "1"
   15) "last-ping-sent"
   16) "0"
   17) "last-ok-ping-reply"
   18) "939725"
   19) "last-ping-reply"
   20) "939725"
   21) "down-after-milliseconds"
   22) "10000"
   23) "info-refresh"
   24) "996028"
   25) "role-reported"
   26) "slave"
   27) "role-reported-time"
   28) "1477908"
   29) "master-link-down-time"
   30) "0"
   31) "master-link-status"
   32) "ok"
   33) "master-host"
   34) "192.168.31.101"
   35) "master-port"
   36) "6816"
   37) "slave-priority"
   38) "100"
   39) "slave-repl-offset"
   40) "183915"
```
