### PR TITLE
Check for NULL before dereferencing

### DIFF
--- a/deps/hiredis/sds.c
+++ b/deps/hiredis/sds.c
@@ -157,7 +157,9 @@ sds sdsRemoveFreeSpace(sds s) {
 
     sh = (void*) (s-(sizeof(struct sdshdr)));
     sh = zrealloc(sh, sizeof(struct sdshdr)+sh->len+1);
-    sh->free = 0;
+    if (sh) {
+	sh->free = 0;
+    }    
     return sh->buf;
 }
 

--- a/deps/lua/src/lauxlib.c
+++ b/deps/lua/src/lauxlib.c
@@ -571,6 +571,7 @@ LUALIB_API int luaL_loadfile (lua_State *L, const char *filename) {
     if (c == '\n') c = getc(lf.f);
   }
   if (c == LUA_SIGNATURE[0] && filename) {  /* binary file? */
+    fclose(lf.f);
     lf.f = freopen(filename, "rb", lf.f);  /* reopen in binary mode */
     if (lf.f == NULL) return errfile(L, "reopen", fnameindex);
     /* skip eventual `#!...' */
@@ -586,6 +587,7 @@ LUALIB_API int luaL_loadfile (lua_State *L, const char *filename) {
     return errfile(L, "read", fnameindex);
   }
   lua_remove(L, fnameindex);
+  fclose(lf.f);
   return status;
 }
 

--- a/deps/lua/src/lfunc.c
+++ b/deps/lua/src/lfunc.c
@@ -22,30 +22,36 @@
 
 Closure *luaF_newCclosure (lua_State *L, int nelems, Table *e) {
   Closure *c = cast(Closure *, luaM_malloc(L, sizeCclosure(nelems)));
-  luaC_link(L, obj2gco(c), LUA_TFUNCTION);
-  c->c.isC = 1;
-  c->c.env = e;
-  c->c.nupvalues = cast_byte(nelems);
+  if (c) {
+  	luaC_link(L, obj2gco(c), LUA_TFUNCTION);
+  	c->c.isC = 1;
+  	c->c.env = e;
+  	c->c.nupvalues = cast_byte(nelems);
+  }
   return c;
 }
 
 
 Closure *luaF_newLclosure (lua_State *L, int nelems, Table *e) {
   Closure *c = cast(Closure *, luaM_malloc(L, sizeLclosure(nelems)));
-  luaC_link(L, obj2gco(c), LUA_TFUNCTION);
-  c->l.isC = 0;
-  c->l.env = e;
-  c->l.nupvalues = cast_byte(nelems);
-  while (nelems--) c->l.upvals[nelems] = NULL;
+  if (c) { 
+    luaC_link(L, obj2gco(c), LUA_TFUNCTION);
+    c->l.isC = 0;
+    c->l.env = e;
+    c->l.nupvalues = cast_byte(nelems);
+    while (nelems--) c->l.upvals[nelems] = NULL;
+  }
   return c;
 }
 
 
 UpVal *luaF_newupval (lua_State *L) {
   UpVal *uv = luaM_new(L, UpVal);
-  luaC_link(L, obj2gco(uv), LUA_TUPVAL);
-  uv->v = &uv->u.value;
-  setnilvalue(uv->v);
+  if (uv) {
+    luaC_link(L, obj2gco(uv), LUA_TUPVAL);
+    uv->v = &uv->u.value;
+    setnilvalue(uv->v);
+  }
   return uv;
 }
 
@@ -114,26 +120,28 @@ void luaF_close (lua_State *L, StkId level) {
 
 Proto *luaF_newproto (lua_State *L) {
   Proto *f = luaM_new(L, Proto);
-  luaC_link(L, obj2gco(f), LUA_TPROTO);
-  f->k = NULL;
-  f->sizek = 0;
-  f->p = NULL;
-  f->sizep = 0;
-  f->code = NULL;
-  f->sizecode = 0;
-  f->sizelineinfo = 0;
-  f->sizeupvalues = 0;
-  f->nups = 0;
-  f->upvalues = NULL;
-  f->numparams = 0;
-  f->is_vararg = 0;
-  f->maxstacksize = 0;
-  f->lineinfo = NULL;
-  f->sizelocvars = 0;
-  f->locvars = NULL;
-  f->linedefined = 0;
-  f->lastlinedefined = 0;
-  f->source = NULL;
+  if (f) {
+    luaC_link(L, obj2gco(f), LUA_TPROTO);
+    f->k = NULL;
+    f->sizek = 0;
+    f->p = NULL;
+    f->sizep = 0;
+    f->code = NULL;
+    f->sizecode = 0;
+    f->sizelineinfo = 0;
+    f->sizeupvalues = 0;
+    f->nups = 0;
+    f->upvalues = NULL;
+    f->numparams = 0;
+    f->is_vararg = 0;
+    f->maxstacksize = 0;
+    f->lineinfo = NULL;
+    f->sizelocvars = 0;
+    f->locvars = NULL;
+    f->linedefined = 0;
+    f->lastlinedefined = 0;
+    f->source = NULL;
+  }
   return f;
 }
 

--- a/deps/lua/src/lstate.c
+++ b/deps/lua/src/lstate.c
@@ -118,15 +118,17 @@ static void close_state (lua_State *L) {
 
 lua_State *luaE_newthread (lua_State *L) {
   lua_State *L1 = tostate(luaM_malloc(L, state_size(lua_State)));
-  luaC_link(L, obj2gco(L1), LUA_TTHREAD);
-  preinit_state(L1, G(L));
-  stack_init(L1, L);  /* init stack */
-  setobj2n(L, gt(L1), gt(L));  /* share table of globals */
-  L1->hookmask = L->hookmask;
-  L1->basehookcount = L->basehookcount;
-  L1->hook = L->hook;
-  resethookcount(L1);
-  lua_assert(iswhite(obj2gco(L1)));
+  if (L1) {
+    luaC_link(L, obj2gco(L1), LUA_TTHREAD);
+    preinit_state(L1, G(L));
+    stack_init(L1, L);  /* init stack */
+    setobj2n(L, gt(L1), gt(L));  /* share table of globals */
+    L1->hookmask = L->hookmask;
+    L1->basehookcount = L->basehookcount;
+    L1->hook = L->hook;
+    resethookcount(L1);
+    lua_assert(iswhite(obj2gco(L1)));
+  }
   return L1;
 }
 

--- a/deps/lua/src/lstring.c
+++ b/deps/lua/src/lstring.c
@@ -54,20 +54,22 @@ static TString *newlstr (lua_State *L, const char *str, size_t l,
   if (l+1 > (MAX_SIZET - sizeof(TString))/sizeof(char))
     luaM_toobig(L);
   ts = cast(TString *, luaM_malloc(L, (l+1)*sizeof(char)+sizeof(TString)));
-  ts->tsv.len = l;
-  ts->tsv.hash = h;
-  ts->tsv.marked = luaC_white(G(L));
-  ts->tsv.tt = LUA_TSTRING;
-  ts->tsv.reserved = 0;
-  memcpy(ts+1, str, l*sizeof(char));
-  ((char *)(ts+1))[l] = '\0';  /* ending 0 */
-  tb = &G(L)->strt;
-  h = lmod(h, tb->size);
-  ts->tsv.next = tb->hash[h];  /* chain new entry */
-  tb->hash[h] = obj2gco(ts);
-  tb->nuse++;
-  if (tb->nuse > cast(lu_int32, tb->size) && tb->size <= MAX_INT/2)
-    luaS_resize(L, tb->size*2);  /* too crowded */
+  if (ts) {
+    ts->tsv.len = l;
+    ts->tsv.hash = h;
+    ts->tsv.marked = luaC_white(G(L));
+    ts->tsv.tt = LUA_TSTRING;
+    ts->tsv.reserved = 0;
+    memcpy(ts+1, str, l*sizeof(char));
+    ((char *)(ts+1))[l] = '\0';  /* ending 0 */
+    tb = &G(L)->strt;
+    h = lmod(h, tb->size);
+    ts->tsv.next = tb->hash[h];  /* chain new entry */
+    tb->hash[h] = obj2gco(ts);
+    tb->nuse++;
+    if (tb->nuse > cast(lu_int32, tb->size) && tb->size <= MAX_INT/2)
+      luaS_resize(L, tb->size*2);  /* too crowded */
+  }
   return ts;
 }
 
@@ -98,14 +100,16 @@ Udata *luaS_newudata (lua_State *L, size_t s, Table *e) {
   if (s > MAX_SIZET - sizeof(Udata))
     luaM_toobig(L);
   u = cast(Udata *, luaM_malloc(L, s + sizeof(Udata)));
-  u->uv.marked = luaC_white(G(L));  /* is not finalized */
-  u->uv.tt = LUA_TUSERDATA;
-  u->uv.len = s;
-  u->uv.metatable = NULL;
-  u->uv.env = e;
-  /* chain it on udata list (after main thread) */
-  u->uv.next = G(L)->mainthread->next;
-  G(L)->mainthread->next = obj2gco(u);
+  if (u) {
+    u->uv.marked = luaC_white(G(L));  /* is not finalized */
+    u->uv.tt = LUA_TUSERDATA;
+    u->uv.len = s;
+    u->uv.metatable = NULL;
+    u->uv.env = e;
+    /* chain it on udata list (after main thread) */
+    u->uv.next = G(L)->mainthread->next;
+    G(L)->mainthread->next = obj2gco(u);
+  }
   return u;
 }
 

--- a/deps/lua/src/ltable.c
+++ b/deps/lua/src/ltable.c
@@ -357,16 +357,18 @@ static void rehash (lua_State *L, Table *t, const TValue *ek) {
 
 Table *luaH_new (lua_State *L, int narray, int nhash) {
   Table *t = luaM_new(L, Table);
-  luaC_link(L, obj2gco(t), LUA_TTABLE);
-  t->metatable = NULL;
-  t->flags = cast_byte(~0);
-  /* temporary values (kept only if some malloc fails) */
-  t->array = NULL;
-  t->sizearray = 0;
-  t->lsizenode = 0;
-  t->node = cast(Node *, dummynode);
-  setarrayvector(L, t, narray);
-  setnodevector(L, t, nhash);
+  if (t) {
+    luaC_link(L, obj2gco(t), LUA_TTABLE);
+    t->metatable = NULL;
+    t->flags = cast_byte(~0);
+    /* temporary values (kept only if some malloc fails) */
+    t->array = NULL;
+    t->sizearray = 0;
+    t->lsizenode = 0;
+    t->node = cast(Node *, dummynode);
+    setarrayvector(L, t, narray);
+    setnodevector(L, t, nhash);
+  }
   return t;
 }
 

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -1145,7 +1145,9 @@ int quicklistNext(quicklistIter *iter, quicklistEntry *entry) {
             nextFn = ziplistPrev;
             offset_update = -1;
         }
-        iter->zi = nextFn(iter->current->zl, iter->zi);
+        if (nextFn) {
+		iter->zi = nextFn(iter->current->zl, iter->zi);	
+	}
         iter->offset += offset_update;
     }
 


### PR DESCRIPTION
I found various spots where we may dereference a pointer and it could be NULL.
Not sure what the behaviour should be in the case of it being NULL, feel free to modify or comment.

Also found  `lf.f`potentially being leaked in `deps/lua/src/lauxlib.c`
