### PR TITLE
Cluster lock fix

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -358,6 +358,11 @@ void clusterSaveConfigOrDie(int do_fsync) {
  * On success REDIS_OK is returned, otherwise an error is logged and
  * the function returns REDIS_ERR to signal a lock was not acquired. */
 int clusterLockConfig(char *filename) {
+/* flock() does not exist on Solaris
+ * and a fcntl-based solution won't help, as we constantly re-open that file,
+ * which will release _all_ locks anyway
+ */
+#if !defined(__sun)
     /* To lock it, we need to open the file in a way it is created if
      * it does not exist, otherwise there is a race condition with other
      * processes. */
@@ -385,6 +390,8 @@ int clusterLockConfig(char *filename) {
     }
     /* Lock acquired: leak the 'fd' by not closing it, so that we'll retain the
      * lock to the file as long as the process exists. */
+#endif /* __sun */
+
     return REDIS_OK;
 }
 

--- a/src/redis.c
+++ b/src/redis.c
@@ -53,7 +53,6 @@
 #include <sys/resource.h>
 #include <sys/utsname.h>
 #include <locale.h>
-#include <sys/sysctl.h>
 #include <sys/socket.h>
 
 /* Our shared "common" objects */


### PR DESCRIPTION
Fixes #2506, #1594 and probably others.

This also removes including the sysctl header, as it is not needed anymore and does not exist on Solaris (added in ec5a0c548b0afbb1bd584b5761bf740460fd20a2, but `getMemorySize` was moved after that to zmalloc.c).

The only thing that remains is a warning about the now unused variable:

```
cluster.c:364:29: warning: unused parameter ‘filename’ [-Wunused-parameter]
```

I could fix that as well if wanted.

Tested on Solaris 11.2 and SmartOS
