### PR TITLE
allow changing rdbchecksum

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -852,6 +852,16 @@ void configSetCommand(redisClient *c) {
 
         if (flags == -1) goto badfmt;
         server.notify_keyspace_events = flags;
+    } config_set_special_field("rdbchecksum") {
+        if (server.server.loading == 1) {
+            addReplyError(c,
+                "Can't change rdbchecksum in loading rdb");
+            return;
+        }
+
+        int enable = yesnotoi(o->ptr);
+        if (enable == -1) goto badfmt;
+        server.rdb_checksum = enable;
 
     /* Boolean fields.
      * config_set_bool_field(name,var). */


### PR DESCRIPTION
allow chaning rdbchecksum.
Currently, changing rdbchecksum is prohibited.
because if someone change rdbchecksum in loading rdb in ,
it can make somewhat invalid checksum.

so I prohibited changing checksum only in loading rdb. :) 
