### PR TITLE
Fix: aof_delayed_fsync is not reset, fixes #2677

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1645,6 +1645,7 @@ void resetServerStats(void) {
     }
     server.stat_net_input_bytes = 0;
     server.stat_net_output_bytes = 0;
+    server.aof_delayed_fsync = 0;
 }
 
 void initServer(void) {


### PR DESCRIPTION
aof_delayed_fsync was not set to 0 when calling CONFIG RESETSTAT.
This might also apply to other branches than 2.8
fixes #2677
