### PR TITLE
redis-sentinel crash if ckquorum command is executed without args

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3041,6 +3041,7 @@ void sentinelCommand(redisClient *c) {
         sentinelRedisInstance *ri;
         int usable;
 
+        if (c->argc != 3) goto numargserr;
         if ((ri = sentinelGetMasterByNameOrReplyError(c,c->argv[2]))
             == NULL) return;
         int result = sentinelIsQuorumReachable(ri,&usable);


### PR DESCRIPTION
Sentinel die if you run ckquorum without <master> arg. I included one step to verify number of args sent. 
