### PR TITLE
Fix bug of sds.c

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -469,10 +469,11 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
             s = sdsMakeRoomFor(s,1);
             sh = (void*) (s-(sizeof(struct sdshdr)));
         }
-
         switch(*f) {
         case '%':
             next = *(f+1);
+			if(next == 0)
+				break;
             f++;
             switch(next) {
             case 's':


### PR DESCRIPTION
For the sdscatfmt function in sds.c, when the parameter fmt ended up with '%', the behavior is undefined. This commit fix this bug.
