### PR TITLE
Adds Lua transaction support

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -652,6 +652,11 @@ aof-load-truncated yes
 # Set it to 0 or a negative value for unlimited execution without warnings.
 lua-time-limit 5000
 
+# Lua scripts can be run transactionally using EVALTXN or EVALSHATXN. Setting
+# lua-all-transactions to 'yes' will force Lua script execution with EVAL and
+# EVALSHA to use the same semantics as EVALTXN and EVALSHATXN.
+lua-all-transactions no
+
 ################################ REDIS CLUSTER  ###############################
 #
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -249,6 +249,9 @@ typedef struct {
                                             master is up. */
 
 /* ---------------------- API exported outside cluster.c -------------------- */
+void prepareRollback(struct redisCommand *cmd, client *c);
+void restoreFromRollback(client *c);
+void cleanRollbackBuffer();
 clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, int argc, int *hashslot, int *ask);
 int clusterRedirectBlockedClientIfNeeded(client *c);
 void clusterRedirectClient(client *c, clusterNode *n, int hashslot, int error_code);

--- a/src/config.c
+++ b/src/config.c
@@ -523,6 +523,11 @@ void loadServerConfigFromString(char *config) {
             }
         } else if (!strcasecmp(argv[0],"lua-time-limit") && argc == 2) {
             server.lua_time_limit = strtoll(argv[1],NULL,10);
+        } else if (!strcasecmp(argv[0],"lua-all-transactions") && argc == 2) {
+            if ((server.lua_all_transactions = yesnotoi(argv[1])) == -1)
+            {
+                err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
         } else if (!strcasecmp(argv[0],"slowlog-log-slower-than") &&
                    argc == 2)
         {
@@ -875,6 +880,9 @@ void configSetCommand(client *c) {
       "activerehashing",server.activerehashing) {
     } config_set_bool_field(
       "stop-writes-on-bgsave-error",server.stop_writes_on_bgsave_err) {
+    } config_set_bool_field(
+      "lua-all-transactions",server.lua_all_transactions) {
+
 
     /* Numerical fields.
      * config_set_numerical_field(name,var,min,max) */

--- a/src/server.h
+++ b/src/server.h
@@ -63,6 +63,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #include "latency.h" /* Latency monitor API */
 #include "sparkline.h" /* ASII graphs API */
 #include "quicklist.h"
+#include "rio.h"     /* Io object for rollback */
 
 /* Following includes allow test functions to be called from Redis main() */
 #include "zipmap.h"
@@ -654,6 +655,15 @@ typedef struct redisOpArray {
     int numops;
 } redisOpArray;
 
+/* Defines the information necessary to restore a key that (may have) changed as
+ * part of a Lua script execution under the EVALTXN or EVALSHATXN commands. */
+typedef struct {
+    robj *key;
+    long long ttl;
+    rio *dump;
+    void *next;
+} rollbackItem;
+
 /*-----------------------------------------------------------------------------
  * Global server state
  *----------------------------------------------------------------------------*/
@@ -920,6 +930,13 @@ struct redisServer {
     int lua_timedout;     /* True if we reached the time limit for script
                              execution. */
     int lua_kill;         /* Kill the script if true. */
+    int lua_all_transactions; /* True if all scripts should be executed as a
+                                 transaction. */
+    rollbackItem* lua_rollback;  /* The list of commands to execute to restore
+                                   the keyspace state to just prior to the Lua
+                                   script execution. */
+    int lua_rolled_back;  /* The last Lua call got rolled back, don't propagate
+                             this call. */
     /* Latency monitor */
     long long latency_monitor_threshold;
     dict *latency_events;


### PR DESCRIPTION
Adds 2 commands: `EVALTXN` and `EVALSHATXN` - runs Lua scripts in a transaction
Adds 1 script sub-comand: `SCRIPT ROLLBACK` - kills scripts that have written if they are execued as a transaction
Adds 1 configuration option: `lua-all-transactions` - for specifying that all `EVAL`/`EVALSHA` should be transactions too
