### PR TITLE
Fix bug in maxmemoryToString function

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -126,8 +126,8 @@ const char *configEnumGetNameOrUnknown(configEnum *ce, int val) {
 }
 
 /* Used for INFO generation. */
-const char *maxmemoryToString(void) {
-    return configEnumGetNameOrUnknown(maxmemory_policy_enum,server.maxmemory);
+const char *maxmemoryPolicyToString(void) {
+    return configEnumGetNameOrUnknown(maxmemory_policy_enum,server.maxmemory_policy);
 }
 
 /*-----------------------------------------------------------------------------

--- a/src/server.c
+++ b/src/server.c
@@ -2752,7 +2752,7 @@ sds genRedisInfoString(char *section) {
         char maxmemory_hmem[64];
         size_t zmalloc_used = zmalloc_used_memory();
         size_t total_system_mem = server.system_memory_size;
-        const char *evict_policy = maxmemoryToString();
+        const char *maxmemory_policy = maxmemoryPolicyToString();
         long long memory_lua = (long long)lua_gc(server.lua,LUA_GCCOUNT,0)*1024;
 
         /* Peak memory is updated from time to time by serverCron() so it
@@ -2799,7 +2799,7 @@ sds genRedisInfoString(char *section) {
             used_memory_lua_hmem,
             server.maxmemory,
             maxmemory_hmem,
-            evict_policy,
+            maxmemory_policy,
             zmalloc_get_fragmentation_ratio(server.resident_set_size),
             ZMALLOC_LIB
             );


### PR DESCRIPTION
- Fix bug in `maxmemoryToString` function
- Change function name to `maxmemoryPolicyToString`
- Change var name from `evict_policy` to `maxmemory_policy`
