### PR TITLE
Flag HGETALL as sorted

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -205,7 +205,7 @@ struct redisCommand redisCommandTable[] = {
     {"hstrlen",hstrlenCommand,3,"rF",0,NULL,1,1,1,0,0},
     {"hkeys",hkeysCommand,2,"rS",0,NULL,1,1,1,0,0},
     {"hvals",hvalsCommand,2,"rS",0,NULL,1,1,1,0,0},
-    {"hgetall",hgetallCommand,2,"r",0,NULL,1,1,1,0,0},
+    {"hgetall",hgetallCommand,2,"rS",0,NULL,1,1,1,0,0},
     {"hexists",hexistsCommand,3,"rF",0,NULL,1,1,1,0,0},
     {"hscan",hscanCommand,-3,"rR",0,NULL,1,1,1,0,0},
     {"incrby",incrbyCommand,3,"wmF",0,NULL,1,1,1,0,0},


### PR DESCRIPTION
HGETALL returns all keys and values in any order. When consistency is important, it should be sorted.

Most people will use the keys to identify the values so it is not a big deal, but it seems incorrect not to sort since it is not required.
