### PR TITLE
Fix race condition in unit/introspection

### DIFF
--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -6,16 +6,17 @@ start_server {tags {"introspection"}} {
     test {MONITOR can log executed commands} {
         set rd [redis_deferring_client]
         $rd monitor
+        assert_match {*OK*} [$rd read]
         r set foo bar
         r get foo
-        list [$rd read] [$rd read] [$rd read]
-    } {*OK*"set" "foo"*"get" "foo"*}
+        list [$rd read] [$rd read]
+    } {*"set" "foo"*"get" "foo"*}
 
     test {MONITOR can log commands issued by the scripting engine} {
         set rd [redis_deferring_client]
         $rd monitor
-        r eval {redis.call('set',KEYS[1],ARGV[1])} 1 foo bar
         $rd read ;# Discard the OK
+        r eval {redis.call('set',KEYS[1],ARGV[1])} 1 foo bar
         assert_match {*eval*} [$rd read]
         assert_match {*lua*"set"*"foo"*"bar"*} [$rd read]
     }


### PR DESCRIPTION
Make sure monitor is attached in one connection before issuing commands to be monitored in another one
