### PR TITLE
show client PeerId in verbose mode when connection is closed 

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -870,8 +870,10 @@ void sendReplyToClient(aeEventLoop *el, int fd, void *privdata, int mask) {
         if (errno == EAGAIN) {
             nwritten = 0;
         } else {
-            serverLog(LL_VERBOSE,
-                "Error writing to client: %s", strerror(errno));
+            if (server.verbosity <= LL_VERBOSE) {
+                serverLog(LL_VERBOSE,
+                    "Error writing to client(%s): %s", getClientPeerId(c), strerror(errno));
+            }
             freeClient(c);
             return;
         }
@@ -1192,12 +1194,18 @@ void readQueryFromClient(aeEventLoop *el, int fd, void *privdata, int mask) {
         if (errno == EAGAIN) {
             return;
         } else {
-            serverLog(LL_VERBOSE, "Reading from client: %s",strerror(errno));
+            if (server.verbosity <= LL_VERBOSE) {
+                serverLog(LL_VERBOSE, "Reading from client(%s): %s", getClientPeerId(c), strerror(errno));
+            }
+
             freeClient(c);
             return;
         }
     } else if (nread == 0) {
-        serverLog(LL_VERBOSE, "Client closed connection");
+        if (server.verbosity <= LL_VERBOSE) {
+            serverLog(LL_VERBOSE, "Client(%s) closed connection", getClientPeerId(c));
+        }
+
         freeClient(c);
         return;
     }


### PR DESCRIPTION
adding client PeerId when connection is closed by error.
because this feature needed when checking client's invalid behavior

This only work under VERBOSE(including calling getClientPeerId)

```
24564:M 13 Aug 12:43:35.912 - Client(127.0.0.1:57237) closed connection
```
