### PR TITLE
More consistent BITPOS behavior when bit is 0 and end > strlen.

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -516,7 +516,7 @@ void bitposCommand(client *c) {
     long bit, start, end, strlen;
     unsigned char *p;
     char llbuf[32];
-    int end_given = 0;
+    int active_end_given = 0;
 
     /* Parse the bit argument to understand what we are looking for, set
      * or clear bits. */
@@ -553,7 +553,8 @@ void bitposCommand(client *c) {
         if (c->argc == 5) {
             if (getLongFromObjectOrReply(c,c->argv[4],&end,NULL) != C_OK)
                 return;
-            end_given = 1;
+            if (end < strlen)
+                active_end_given = 1;
         } else {
             end = strlen-1;
         }
@@ -587,8 +588,11 @@ void bitposCommand(client *c) {
          *
          * So if redisBitpos() returns the first bit outside the range,
          * we return -1 to the caller, to mean, in the specified range there
-         * is not a single "0" bit. */
-        if (end_given && bit == 0 && pos == bytes*8) {
+         * is not a single "0" bit.
+         *
+         * However, if the end argument given is past the end of the string,
+         * we should consider the end of the string to be zero padded. */
+        if (active_end_given && bit == 0 && pos == bytes*8) {
             addReplyLongLong(c,-1);
             return;
         }

--- a/tests/unit/bitops.tcl
+++ b/tests/unit/bitops.tcl
@@ -307,6 +307,11 @@ start_server {tags {"bitops"}} {
         assert {[r bitpos str 0 0 -1] == -1}
     }
 
+    test {BITPOS bit=0 assumes zero padding if end is beyond string length} {
+        r set str "\xff\xff\xff"
+        r bitpos str 0 0 3
+    } {24}
+
     test {BITPOS bit=1 fuzzy testing using SETBIT} {
         r del str
         set max 524288; # 64k


### PR DESCRIPTION
When calling BITPOS with an end argument, we should still consider the end of a string to be zero-padded if the specified start-end range goes beyond the length of the string. I.e., when end is beyond the length of the string, and when searching for a 0 bit in a string of all 1 bits, we should return the first bit off the end of the string.

For example:

```
> SET foo "\xff\xff"
> BITPOS foo 0
--> returns 16
> BITPOS foo 0 0 -1
--> returns -1
> BITPOS foo 0 0 2
--> returns 16, previously returned -1
```

Includes a test.
