### PR TITLE
Fix a couple to compile issues: a typo and a missing symbol.

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -492,7 +492,7 @@ int startBgsaveForReplication(int mincapa) {
     int retval;
     int socket_target = server.repl_diskless_sync && (mincapa & SLAVE_CAPA_EOF);
 
-    redisLog(REIDS_NOTICE,"Starting BGSAVE for SYNC with target: %s",
+    redisLog(REDIS_NOTICE,"Starting BGSAVE for SYNC with target: %s",
         socket_target ? "slaves sockets" : "disk");
 
     if (socket_target)

--- a/src/replication.c
+++ b/src/replication.c
@@ -619,7 +619,7 @@ void syncCommand(redisClient *c) {
             /* Target is disk (or the slave is not capable of supporting
              * diskless replication) and we don't have a BGSAVE in progress,
              * let's start one. */
-            if (startBgsaveForReplication(c->slave_capa) != C_OK) {
+            if (startBgsaveForReplication(c->slave_capa) != REDIS_OK) {
                 redisLog(REDIS_NOTICE,"Replication failed, can't BGSAVE");
                 addReplyError(c,"Unable to perform background save");
                 return;


### PR DESCRIPTION
About the first commit is easy to spot and fix.  

The second commit is an "uneducated" guess, I'm not sure what the error value should be.  Tests pass after both changes, though.

```
replication.c: In function ‘startBgsaveForReplication’:
replication.c:495:14: error: ‘REIDS_NOTICE’ undeclared (first use in this function)
     redisLog(REIDS_NOTICE,"Starting BGSAVE for SYNC with target: %s",
              ^
replication.c:495:14: note: each undeclared identifier is reported only once for each function it appears in
replication.c: In function ‘syncCommand’:
replication.c:622:61: error: ‘C_OK’ undeclared (first use in this function)
             if (startBgsaveForReplication(c->slave_capa) != C_OK) {
                                                             ^
make[1]: *** [replication.o] Erreur 1
make[1]: quittant le répertoire « /home/manu/src/github.com/db/redis/redis/src »
make: *** [all] Erreur 2
```
