### PR TITLE
SCAN iter parsing changed from atoi to chartoull

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1584,7 +1584,7 @@ static redisReply *sendScan(unsigned long long *it) {
     assert(reply->element[1]->type == REDIS_REPLY_ARRAY);
 
     /* Update iterator */
-    *it = atoi(reply->element[0]->str);
+    *it = strtoull(reply->element[0]->str, NULL, 10);
 
     return reply;
 }


### PR DESCRIPTION
redis-cli --bigkeys does not scan all redis keyspace in case the returned iterator is larger than int.
