### PR TITLE
Feature to reverse the remaining slave list prior to assignment

### DIFF
--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -608,6 +608,9 @@ class RedisTrib
         # all nodes will be used.
         assignment_verbose = false
 
+        # Reverse remaining slaves for more even distribution
+        interleaved = interleaved.reverse()
+
         [:requested,:unused].each do |assign|
             masters.each do |m|
                 assigned_replicas = 0


### PR DESCRIPTION
Prior to the change:

redis-trib.rb create --replicas 1 172.22.68.50:7000 172.22.68.50:7001 172.22.68.51:7000 172.22.68.51:7001 172.22.68.52:7000 172.22.68.52:7001
....
Using 3 masters:
172.22.68.50:7000
172.22.68.51:7000
172.22.68.52:7000
Adding replica 172.22.68.51:7001 to 172.22.68.50:7000
Adding replica 172.22.68.50:7001 to 172.22.68.51:7000
Adding replica 172.22.68.52:7001 to 172.22.68.52:7000

After the change:

172.22.68.50:7000
172.22.68.51:7000
172.22.68.52:7000
Adding replica 172.22.68.52:7001 to 172.22.68.50:7000
Adding replica 172.22.68.50:7001 to 172.22.68.51:7000
Adding replica 172.22.68.51:7001 to 172.22.68.52:7000
