### PR TITLE
Pass custom CONFIG\SLAVEOF command names to Sentinel

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -71,6 +71,22 @@ sentinel monitor mymaster 127.0.0.1 6379 2
 #
 # sentinel auth-pass mymaster MySUPER--secret-0123passw0rd
 
+# sentinel config-command <master-name> <command-name>
+# sentinel slaveof-command <master-name> <command-name>
+#
+# Set the command name(s) to use with the master and slaves. Useful if the
+# CONFIG and/or SLAVEOF commands have been renamed using 'rename-command'
+# in the Redis instances for security reasons.
+#
+# Note that all the command names are also used for slaves, so it is not
+# possible to set different command names in master and slave instances
+# if you want to be able to control these instances with Sentinel.
+#
+# Example:
+#
+# sentinel config-command mymaster MyCONFIG--command-cf53fdc2
+# sentinel slaveof-command mymaster MySLAVEOF--command-48a43ac4
+
 # sentinel down-after-milliseconds <master-name> <milliseconds>
 #
 # Number of milliseconds the master (or any attached slave or sentinel) should


### PR DESCRIPTION
Initial patch from #2733

Sentinel currently fails when Redis is configured with custom CONFIG and/or SLAVEOF command names, two of the commonly renamed commands when Redis is being used in a multi-tenancy environment. This PR allows Sentinel to receive custom config names for these params.
