### PR TITLE
Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: c 
+
+compiler:
+  - clang
+  - gcc
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ compiler:
   - gcc
 
 before_script:
-    - if [$TRAVIS_OS_NAME = linux]; then  sudo apt-get install -qq tcl8.5; fi
-    - if [$TRAVIS_OS_NAME = osx] ; then brew update; brew tap homebrew/dupes; brew install tcl-tk;fi
+    - if [$TRAVIS_OS_NAME == linux]; then  sudo apt-get install -qq tcl8.5; fi
+    - if [$TRAVIS_OS_NAME == osx] ; then brew update; brew tap homebrew/dupes; brew install tcl-tk;fi
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ compiler:
 
 before_script:
     - if [$TRAVIS_OS_NAME = linux]; then  sudo apt-get install -qq tcl8.5; fi
+    - if [$TRAVIS_OS_NAME = osx] ; then brew update; brew tap homebrew/dupes; brew install tcl-tk;fi
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: c 
+os:
+   - linux
+   - osx
 
 compiler:
   - clang
   - gcc
 
 before_script:
- - sudo apt-get install -qq tcl8.5
+    - if [$TRAVIS_OS_NAME = linux]; then  sudo apt-get install -qq tcl8.5; fi
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ compiler:
   - gcc
 
 before_script:
-    - if [$TRAVIS_OS_NAME == "linux"]; then  sudo apt-get install -qq tcl8.5; fi
-    - if [$TRAVIS_OS_NAME == "osx"] ; then brew update; brew tap homebrew/dupes; brew install tcl-tk;fi
+    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then  sudo apt-get install -qq tcl8.5; fi
+    - if [ "$TRAVIS_OS_NAME" == "osx" ] ; then brew update; brew tap homebrew/dupes; brew install tcl-tk;fi
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
   - gcc
 
 before_script:
- - sudo apt-get install tclsh
+ - sudo apt-get install -qq tcl8.5
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ compiler:
   - clang
   - gcc
 
-
+script:
+  - make
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ compiler:
   - gcc
 
 before_script:
-    - if [$TRAVIS_OS_NAME == linux]; then  sudo apt-get install -qq tcl8.5; fi
-    - if [$TRAVIS_OS_NAME == osx] ; then brew update; brew tap homebrew/dupes; brew install tcl-tk;fi
+    - if [$TRAVIS_OS_NAME == "linux"]; then  sudo apt-get install -qq tcl8.5; fi
+    - if [$TRAVIS_OS_NAME == "osx"] ; then brew update; brew tap homebrew/dupes; brew install tcl-tk;fi
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ compiler:
   - clang
   - gcc
 
+before_script:
+ - sudo apt-get install tclsh
+
 script:
   - make
   - make test


### PR DESCRIPTION
I found that redis currently is running all integration test on http://ci.redis.io/ 

I guess this runs only after the code is merged into branch.

Adding travis, will help to make sure all pull requests minimum compile at clang and gcc and basic tests are working . 

I can add support for osx build too as a followup to this patch request once approved.

This makes changes for the other developer to test easier too.

Look at https://travis-ci.org/PradheepShrinivasan/redis/builds/81863361 for an example.
