### PR TITLE
Add NX/XX/GT/LT options to EXPIRE command group

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -499,7 +499,10 @@ int checkAlreadyExpired(long long when) {
  * for *AT variants of the command, or the current time for relative expires).
  *
  * unit is either UNIT_SECONDS or UNIT_MILLISECONDS, and is only used for
- * the argv[2] parameter. The basetime is always specified in milliseconds. */
+ * the argv[2] parameter. The basetime is always specified in milliseconds.
+ *
+ * Optional arguments supported:
+ * - NX: only set when no previous expiry set. */
 void expireGenericCommand(client *c, long long basetime, int unit) {
     robj *key = c->argv[1], *param = c->argv[2];
     long long when; /* unix time in milliseconds when the key will expire. */

--- a/src/expire.c
+++ b/src/expire.c
@@ -521,8 +521,7 @@ void parseExtendedExpireArguments(client *c, int *flags) {
  * unit is either UNIT_SECONDS or UNIT_MILLISECONDS, and is only used for
  * the argv[2] parameter. The basetime is always specified in milliseconds.
  *
- * Optional arguments supported:
- * - NX: only set when no previous expiry set. */
+ * Additional flags are supported parsed via parseExtendedExpireArguments */
 void expireGenericCommand(client *c, long long basetime, int unit) {
     robj *key = c->argv[1], *param = c->argv[2];
     long long when; /* unix time in milliseconds when the key will expire. */

--- a/src/server.c
+++ b/src/server.c
@@ -677,19 +677,19 @@ struct redisCommand redisCommandTable[] = {
      "write fast @keyspace",
      0,NULL,1,2,1,0,0,0},
 
-    {"expire",expireCommand,3,
+    {"expire",expireCommand,-3,
      "write fast @keyspace",
      0,NULL,1,1,1,0,0,0},
 
-    {"expireat",expireatCommand,3,
+    {"expireat",expireatCommand,-3,
      "write fast @keyspace",
      0,NULL,1,1,1,0,0,0},
 
-    {"pexpire",pexpireCommand,3,
+    {"pexpire",pexpireCommand,-3,
      "write fast @keyspace",
      0,NULL,1,1,1,0,0,0},
 
-    {"pexpireat",pexpireatCommand,3,
+    {"pexpireat",pexpireatCommand,-3,
      "write fast @keyspace",
      0,NULL,1,1,1,0,0,0},
 

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -604,83 +604,75 @@ start_server {tags {"expire"}} {
 
     test {EXPIRE with NX option on a key with ttl} {
         r SET foo bar EX 100000
-        r EXPIRE foo 200000 NX
-    } {0}
+        assert_equal [r EXPIRE foo 200000 NX] 0
+        assert_range [r TTL foo] 50000 100000
+    } {}
 
     test {EXPIRE with NX option on a key without ttl} {
         r SET foo bar
-        r EXPIRE foo 200000 NX
-    } {1}
-
-    test {EXPIREAT with NX option on a key with ttl} {
-        r SET foo bar EX 100000
-        r EXPIREAT foo 200000 NX
-    } {0}
-
-    test {EXPIREAT with NX option on a key without ttl} {
-        r SET foo bar
-        r EXPIREAT foo 200000 NX
-    } {1}
+        assert_equal [r EXPIRE foo 200000 NX] 1
+        assert_range [r TTL foo] 100000 200000
+    } {}
 
     test {PEXPIRE with NX option on a key with ttl} {
         r SET foo bar EX 100000
-        r PEXPIRE foo 200000 NX
-    } {0}
+        assert_equal [r PEXPIRE foo 200000 NX] 0
+        assert_range [r TTL foo] 50 100
+    } {}
 
     test {PEXPIRE with NX option on a key without ttl} {
         r SET foo bar
-        r PEXPIRE foo 200000 NX
-    } {1}
-
-    test {PEXPIREAT with NX option on a key with ttl} {
-        r SET foo bar EX 100000
-        r PEXPIREAT foo 200000 NX
-    } {0}
-
-    test {PEXPIREAT with NX option on a key without ttl} {
-        r SET foo bar
-        r PEXPIREAT foo 200000 NX
-    } {1}
+        assert_equal [r PEXPIRE foo 200000 NX] 1
+        assert_range [r TTL foo] 100 200
+    } {}
 
     test {EXPIRE with XX option on a key with ttl} {
         r SET foo bar EX 100000
-        r EXPIRE foo 200000 XX
+        assert_equal [r EXPIRE foo 200000 XX] 1
+        assert_range [r TTL foo] 100000 200000
     } {1}
 
     test {EXPIRE with XX option on a key without ttl} {
         r SET foo bar
-        r EXPIRE foo 200000 XX
+        assert_equal [r EXPIRE foo 200000 XX] 0
+        assert_range [r TTL foo] 50000 100000
     } {0}
 
     test {EXPIRE with GT option} {
         r SET foo bar EX 100000
-        r EXPIRE foo 200000 GT
-    } {1}
+        assert_equal [r EXPIRE foo 200000 GT] 1
+        assert_range [r TTL foo] 100000 200000
+    } {}
 
     test {EXPIRE with GT option} {
         r SET foo bar EX 200000
-        r EXPIRE foo 100000 GT
-    } {0}
+        assert_equal [r EXPIRE foo 100000 GT] 0
+        assert_range [r TTL foo] 100000 200000
+    } {}
 
     test {EXPIRE with LT option} {
         r SET foo bar EX 100000
-        r EXPIRE foo 200000 LT
-    } {0}
+        assert_equal [r EXPIRE foo 200000 LT] 0
+        assert_range [r TTL foo] 50000 100000
+    } {}
 
     test {EXPIRE with LT option} {
         r SET foo bar EX 200000
-        r EXPIRE foo 100000 LT
-    } {1}
+        assert_equal [r EXPIRE foo 100000 LT] 1
+        assert_range [r TTL foo] 50000 100000
+    } {}
 
     test {EXPIRE with GT option on a key without ttl} {
         r SET foo bar
-        r EXPIRE foo 200000 GT
-    } {0}
+        assert_equal [r EXPIRE foo 200000 GT] 0
+        assert_equal [r TTL foo] -1
+    } {}
 
     test {EXPIRE with LT option on a key without ttl} {
         r SET foo bar
-        r EXPIRE foo 200000 LT
-    } {0}
+        assert_equal [r EXPIRE foo 100000 LT] 1
+        assert_range [r TTL foo] 50000 100000
+    } {}
 
     test {EXPIRE with LT and XX option on a key without ttl} {
         r SET foo bar
@@ -706,4 +698,14 @@ start_server {tags {"expire"}} {
         catch {r EXPIRE foo 200000 NX XX} e
         set e
     } {ERR NX and XX, GT or LT options at the same time are not compatible}
+
+    test {EXPIRE with unsupported options} {
+        catch {r EXPIRE foo 200000 AB} e
+        set e
+    } {ERR Unsupported option AB}
+
+    test {EXPIRE with unsupported options} {
+        catch {r EXPIRE foo 200000 XX AB} e
+        set e
+    } {ERR Unsupported option AB}
 }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -601,4 +601,44 @@ start_server {tags {"expire"}} {
            {del foo}
         }
     } {} {needs:repl}
+
+    test {EXPIRE with NX option on a key with ttl} {
+        r SET foo bar EX 100
+        r EXPIRE foo 200 NX
+    } {0}
+
+    test {EXPIRE with NX option on a key without ttl} {
+        r SET foo bar
+        r EXPIRE foo 200 NX
+    } {1}
+
+    test {EXPIREAT with NX option on a key with ttl} {
+        r SET foo bar EX 100
+        r EXPIREAT foo 200 NX
+    } {0}
+
+    test {EXPIREAT with NX option on a key without ttl} {
+        r SET foo bar
+        r EXPIREAT foo 200 NX
+    } {1}
+
+    test {PEXPIRE with NX option on a key with ttl} {
+        r SET foo bar EX 100
+        r PEXPIRE foo 200 NX
+    } {0}
+
+    test {PEXPIRE with NX option on a key without ttl} {
+        r SET foo bar
+        r PEXPIRE foo 200 NX
+    } {1}
+
+    test {PEXPIREAT with NX option on a key with ttl} {
+        r SET foo bar EX 100
+        r PEXPIREAT foo 200 NX
+    } {0}
+
+    test {PEXPIREAT with NX option on a key without ttl} {
+        r SET foo bar
+        r PEXPIREAT foo 200 NX
+    } {1}
 }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -603,115 +603,123 @@ start_server {tags {"expire"}} {
     } {} {needs:repl}
 
     test {EXPIRE with NX option on a key with ttl} {
-        r SET foo bar EX 100000
-        assert_equal [r EXPIRE foo 200000 NX] 0
-        assert_range [r TTL foo] 50000 100000
+        r SET foo bar EX 100
+        assert_equal [r EXPIRE foo 200 NX] 0
+        assert_range [r TTL foo] 50 100
     } {}
 
     test {EXPIRE with NX option on a key without ttl} {
         r SET foo bar
-        assert_equal [r EXPIRE foo 200000 NX] 1
-        assert_range [r TTL foo] 100000 200000
-    } {}
-
-    test {PEXPIRE with NX option on a key with ttl} {
-        r SET foo bar EX 100000
-        assert_equal [r PEXPIRE foo 200000 NX] 0
-        assert_range [r TTL foo] 50000 100000
-    } {}
-
-    test {PEXPIRE with NX option on a key without ttl} {
-        r SET foo bar
-        assert_equal [r PEXPIRE foo 200000 NX] 1
+        assert_equal [r EXPIRE foo 200 NX] 1
         assert_range [r TTL foo] 100 200
     } {}
 
     test {EXPIRE with XX option on a key with ttl} {
-        r SET foo bar EX 100000
-        assert_equal [r EXPIRE foo 200000 XX] 1
-        assert_range [r TTL foo] 100000 200000
+        r SET foo bar EX 100
+        assert_equal [r EXPIRE foo 200 XX] 1
+        assert_range [r TTL foo] 100 200
     } {}
 
     test {EXPIRE with XX option on a key without ttl} {
         r SET foo bar
-        assert_equal [r EXPIRE foo 200000 XX] 0
+        assert_equal [r EXPIRE foo 200 XX] 0
         assert_equal [r TTL foo] -1
     } {}
 
-    test {EXPIRE with GT option} {
-        r SET foo bar EX 100000
-        assert_equal [r EXPIRE foo 200000 GT] 1
-        assert_range [r TTL foo] 100000 200000
+    test {EXPIRE with GT option on a key with lower ttl} {
+        r SET foo bar EX 100
+        assert_equal [r EXPIRE foo 200 GT] 1
+        assert_range [r TTL foo] 100 200
     } {}
 
-    test {EXPIRE with GT option} {
-        r SET foo bar EX 200000
-        assert_equal [r EXPIRE foo 100000 GT] 0
-        assert_range [r TTL foo] 100000 200000
-    } {}
-
-    test {EXPIRE with LT option} {
-        r SET foo bar EX 100000
-        assert_equal [r EXPIRE foo 200000 LT] 0
-        assert_range [r TTL foo] 50000 100000
-    } {}
-
-    test {EXPIRE with LT option} {
-        r SET foo bar EX 200000
-        assert_equal [r EXPIRE foo 100000 LT] 1
-        assert_range [r TTL foo] 50000 100000
+    test {EXPIRE with GT option on a key with higher ttl} {
+        r SET foo bar EX 200
+        assert_equal [r EXPIRE foo 100 GT] 0
+        assert_range [r TTL foo] 100 200
     } {}
 
     test {EXPIRE with GT option on a key without ttl} {
         r SET foo bar
-        assert_equal [r EXPIRE foo 200000 GT] 0
+        assert_equal [r EXPIRE foo 200 GT] 0
         assert_equal [r TTL foo] -1
+    } {}
+
+    test {EXPIRE with LT option on a key with higher ttl} {
+        r SET foo bar EX 100
+        assert_equal [r EXPIRE foo 200 LT] 0
+        assert_range [r TTL foo] 50 100
+    } {}
+
+    test {EXPIRE with LT option on a key with lower ttl} {
+        r SET foo bar EX 200
+        assert_equal [r EXPIRE foo 100 LT] 1
+        assert_range [r TTL foo] 50 100
     } {}
 
     test {EXPIRE with LT option on a key without ttl} {
         r SET foo bar
-        assert_equal [r EXPIRE foo 100000 LT] 1
-        assert_range [r TTL foo] 50000 100000
+        assert_equal [r EXPIRE foo 100 LT] 1
+        assert_range [r TTL foo] 50 100
+    } {}
+
+    test {EXPIRE with LT and XX option on a key with ttl} {
+        r SET foo bar EX 200
+        assert_equal [r EXPIRE foo 100 LT XX] 1
+        assert_range [r TTL foo] 50 100
     } {}
 
     test {EXPIRE with LT and XX option on a key without ttl} {
         r SET foo bar
-        r EXPIRE foo 200000 LT XX
-    } {0}
+        assert_equal [r EXPIRE foo 200 LT XX] 0
+        assert_equal [r TTL foo] -1
+    } {}
 
-    test {EXPIRE with conflict options} {
-        catch {r EXPIRE foo 200000 LT GT} e
+    test {EXPIRE with conflicting options: LT GT} {
+        catch {r EXPIRE foo 200 LT GT} e
         set e
     } {ERR GT and LT options at the same time are not compatible}
 
-    test {EXPIRE with conflict options} {
-        catch {r EXPIRE foo 200000 NX GT} e
+    test {EXPIRE with conflicting options: NX GT} {
+        catch {r EXPIRE foo 200 NX GT} e
         set e
     } {ERR NX and XX, GT or LT options at the same time are not compatible}
 
-    test {EXPIRE with conflict options} {
-        catch {r EXPIRE foo 200000 NX LT} e
+    test {EXPIRE with conflicting options: NX LT} {
+        catch {r EXPIRE foo 200 NX LT} e
         set e
     } {ERR NX and XX, GT or LT options at the same time are not compatible}
 
-    test {EXPIRE with conflict options} {
-        catch {r EXPIRE foo 200000 NX XX} e
+    test {EXPIRE with conflicting options: NX XX} {
+        catch {r EXPIRE foo 200 NX XX} e
         set e
     } {ERR NX and XX, GT or LT options at the same time are not compatible}
 
     test {EXPIRE with unsupported options} {
-        catch {r EXPIRE foo 200000 AB} e
+        catch {r EXPIRE foo 200 AB} e
         set e
     } {ERR Unsupported option AB}
 
     test {EXPIRE with unsupported options} {
-        catch {r EXPIRE foo 200000 XX AB} e
+        catch {r EXPIRE foo 200 XX AB} e
         set e
     } {ERR Unsupported option AB}
 
     test {EXPIRE with negative expiry} {
-        r SET foo bar EX 100000
-        assert_equal [r EXPIRE foo -10000 LT] 1
+        r SET foo bar EX 100
+        assert_equal [r EXPIRE foo -10 LT] 1
         assert_equal [r TTL foo] -2
+    } {}
+
+    test {EXPIRE with negative expiry on a non-valitale key} {
+        r SET foo bar
+        assert_equal [r EXPIRE foo -10 LT] 1
+        assert_equal [r TTL foo] -2
+    } {}
+
+    test {EXPIRE with non-existed key} {
+        assert_equal [r EXPIRE none 100 NX] 0
+        assert_equal [r EXPIRE none 100 XX] 0
+        assert_equal [r EXPIRE none 100 GT] 0
+        assert_equal [r EXPIRE none 100 LT] 0
     } {}
 }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -617,7 +617,7 @@ start_server {tags {"expire"}} {
     test {PEXPIRE with NX option on a key with ttl} {
         r SET foo bar EX 100000
         assert_equal [r PEXPIRE foo 200000 NX] 0
-        assert_range [r TTL foo] 50 100
+        assert_range [r TTL foo] 50000 100000
     } {}
 
     test {PEXPIRE with NX option on a key without ttl} {
@@ -630,13 +630,13 @@ start_server {tags {"expire"}} {
         r SET foo bar EX 100000
         assert_equal [r EXPIRE foo 200000 XX] 1
         assert_range [r TTL foo] 100000 200000
-    } {1}
+    } {}
 
     test {EXPIRE with XX option on a key without ttl} {
         r SET foo bar
         assert_equal [r EXPIRE foo 200000 XX] 0
-        assert_range [r TTL foo] 50000 100000
-    } {0}
+        assert_equal [r TTL foo] -1
+    } {}
 
     test {EXPIRE with GT option} {
         r SET foo bar EX 100000
@@ -708,4 +708,10 @@ start_server {tags {"expire"}} {
         catch {r EXPIRE foo 200000 XX AB} e
         set e
     } {ERR Unsupported option AB}
+
+    test {EXPIRE with negative expiry} {
+        r SET foo bar EX 100000
+        assert_equal [r EXPIRE foo -10000 LT] 1
+        assert_equal [r TTL foo] -2
+    } {}
 }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -603,42 +603,107 @@ start_server {tags {"expire"}} {
     } {} {needs:repl}
 
     test {EXPIRE with NX option on a key with ttl} {
-        r SET foo bar EX 100
-        r EXPIRE foo 200 NX
+        r SET foo bar EX 100000
+        r EXPIRE foo 200000 NX
     } {0}
 
     test {EXPIRE with NX option on a key without ttl} {
         r SET foo bar
-        r EXPIRE foo 200 NX
+        r EXPIRE foo 200000 NX
     } {1}
 
     test {EXPIREAT with NX option on a key with ttl} {
-        r SET foo bar EX 100
-        r EXPIREAT foo 200 NX
+        r SET foo bar EX 100000
+        r EXPIREAT foo 200000 NX
     } {0}
 
     test {EXPIREAT with NX option on a key without ttl} {
         r SET foo bar
-        r EXPIREAT foo 200 NX
+        r EXPIREAT foo 200000 NX
     } {1}
 
     test {PEXPIRE with NX option on a key with ttl} {
-        r SET foo bar EX 100
-        r PEXPIRE foo 200 NX
+        r SET foo bar EX 100000
+        r PEXPIRE foo 200000 NX
     } {0}
 
     test {PEXPIRE with NX option on a key without ttl} {
         r SET foo bar
-        r PEXPIRE foo 200 NX
+        r PEXPIRE foo 200000 NX
     } {1}
 
     test {PEXPIREAT with NX option on a key with ttl} {
-        r SET foo bar EX 100
-        r PEXPIREAT foo 200 NX
+        r SET foo bar EX 100000
+        r PEXPIREAT foo 200000 NX
     } {0}
 
     test {PEXPIREAT with NX option on a key without ttl} {
         r SET foo bar
-        r PEXPIREAT foo 200 NX
+        r PEXPIREAT foo 200000 NX
     } {1}
+
+    test {EXPIRE with XX option on a key with ttl} {
+        r SET foo bar EX 100000
+        r EXPIRE foo 200000 XX
+    } {1}
+
+    test {EXPIRE with XX option on a key without ttl} {
+        r SET foo bar
+        r EXPIRE foo 200000 XX
+    } {0}
+
+    test {EXPIRE with GT option} {
+        r SET foo bar EX 100000
+        r EXPIRE foo 200000 GT
+    } {1}
+
+    test {EXPIRE with GT option} {
+        r SET foo bar EX 200000
+        r EXPIRE foo 100000 GT
+    } {0}
+
+    test {EXPIRE with LT option} {
+        r SET foo bar EX 100000
+        r EXPIRE foo 200000 LT
+    } {0}
+
+    test {EXPIRE with LT option} {
+        r SET foo bar EX 200000
+        r EXPIRE foo 100000 LT
+    } {1}
+
+    test {EXPIRE with GT option on a key without ttl} {
+        r SET foo bar
+        r EXPIRE foo 200000 GT
+    } {0}
+
+    test {EXPIRE with LT option on a key without ttl} {
+        r SET foo bar
+        r EXPIRE foo 200000 LT
+    } {0}
+
+    test {EXPIRE with LT and XX option on a key without ttl} {
+        r SET foo bar
+        r EXPIRE foo 200000 LT XX
+    } {0}
+
+    test {EXPIRE with conflict options} {
+        catch {r EXPIRE foo 200000 LT GT} e
+        set e
+    } {ERR GT and LT options at the same time are not compatible}
+
+    test {EXPIRE with conflict options} {
+        catch {r EXPIRE foo 200000 NX GT} e
+        set e
+    } {ERR NX and XX, GT or LT options at the same time are not compatible}
+
+    test {EXPIRE with conflict options} {
+        catch {r EXPIRE foo 200000 NX LT} e
+        set e
+    } {ERR NX and XX, GT or LT options at the same time are not compatible}
+
+    test {EXPIRE with conflict options} {
+        catch {r EXPIRE foo 200000 NX XX} e
+        set e
+    } {ERR NX and XX, GT or LT options at the same time are not compatible}
 }


### PR DESCRIPTION
Add NX, XX, GT, and LT flags to EXPIRE, PEXPIRE, EXPIREAT, PEXAPIREAT.
- NX - only modify the TTL if no TTL is currently set 
- XX - only modify the TTL if there is a TTL currently set 
- GT - only increase the TTL (considering non-volatile keys as infinite expire time)
- LT - only decrease the TTL (considering non-volatile keys as infinite expire time)
return value of the command is 0 when the operation was skipped due to one of these flags.

---------

Just some quick work to add an `NX` option to expire commands. This allows expiration to be set for only once, just like setnx. In our application, we have some zsets and hashes that update frequently, but expire at a fixed time defined at its creation.

Searched issue history, I also found some others who had similar requirements: #1840 

This is just the first commit. If you think it's OK I will add docs and tests for this feature. Thanks!

EDIT: spelling
