### PR TITLE
Typo: commad

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -971,10 +971,10 @@ int expireIfNeeded(redisDb *db, robj *key) {
  * Expires Commands
  *----------------------------------------------------------------------------*/
 
-/* This is the generic command implementation for EXPIRE, PEXPIRE, EXPIREAT
- * and PEXPIREAT. Because the commad second argument may be relative or absolute
- * the "basetime" argument is used to signal what the base time is (either 0
- * for *AT variants of the command, or the current time for relative expires).
+/* This is the generic command implementation for EXPIRE, PEXPIRE, EXPIREAT and
+ * PEXPIREAT. Because the second argument may be relative or absolute the
+ * "basetime" argument is used to signal what the base time is (either 0 for
+ * AT variants of the command, or the current time for relative expires).
  *
  * unit is either UNIT_SECONDS or UNIT_MILLISECONDS, and is only used for
  * the argv[2] parameter. The basetime is always specified in milliseconds. */


### PR DESCRIPTION
Fixes the slightly odd English sentence "Because the commad second
argument may be relative or absolute..." by removing the word "commad".

Reformatted for 80 characters.
