### PR TITLE
add dict-ht-initial-size to reduce memory size during dictExpand

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -348,6 +348,11 @@ void loadServerConfigFromString(char *config) {
                 err = "repl-backlog-ttl can't be negative ";
                 goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"dict-ht-initial-size") && argc == 2) {
+            server.dict_ht_initial_size = atoi(argv[1]);
+            if (server.dict_ht_initial_size < DICT_HT_INITIAL_SIZE) {
+                server.dict_ht_initial_size = DICT_HT_INITIAL_SIZE;
+            }
         } else if (!strcasecmp(argv[0],"masterauth") && argc == 2) {
             server.masterauth = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"slave-serve-stale-data") && argc == 2) {
@@ -1102,6 +1107,7 @@ void configGetCommand(client *c) {
     config_get_numerical_field("repl-timeout",server.repl_timeout);
     config_get_numerical_field("repl-backlog-size",server.repl_backlog_size);
     config_get_numerical_field("repl-backlog-ttl",server.repl_backlog_time_limit);
+    config_get_numerical_field("dict-ht-initial-size",server.dict_ht_initial_size);
     config_get_numerical_field("maxclients",server.maxclients);
     config_get_numerical_field("watchdog-period",server.watchdog_period);
     config_get_numerical_field("slave-priority",server.slave_priority);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -979,7 +979,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb) {
             o = createSetObject();
             /* It's faster to expand the dict to the right size asap in order
              * to avoid rehashing */
-            if (len > DICT_HT_INITIAL_SIZE)
+            if (len > server.dict_ht_initial_size)
                 dictExpand(o->ptr,len);
         } else {
             o = createIntsetObject();

--- a/src/server.c
+++ b/src/server.c
@@ -672,6 +672,10 @@ dictType replScriptCacheDictType = {
 int htNeedsResize(dict *dict) {
     long long size, used;
 
+    if (server.dict_ht_initial_size != DICT_HT_INITIAL_SIZE) {
+        return 0;
+    }
+
     size = dictSlots(dict);
     used = dictSize(dict);
     return (size && used && size > DICT_HT_INITIAL_SIZE &&
@@ -1593,6 +1597,8 @@ void initServerConfig(void) {
     server.assert_line = 0;
     server.bug_report_start = 0;
     server.watchdog_period = 0;
+
+    server.dict_ht_initial_size = DICT_HT_INITIAL_SIZE;
 }
 
 /* This function will try to raise the max number of open files accordingly to
@@ -1846,6 +1852,9 @@ void initServer(void) {
     /* Create the Redis databases, and initialize other internal state. */
     for (j = 0; j < server.dbnum; j++) {
         server.db[j].dict = dictCreate(&dbDictType,NULL);
+        if (server.dict_ht_initial_size != DICT_HT_INITIAL_SIZE) {
+            dictExpand(server.db[j].dict, server.dict_ht_initial_size);
+        }
         server.db[j].expires = dictCreate(&keyptrDictType,NULL);
         server.db[j].blocking_keys = dictCreate(&keylistDictType,NULL);
         server.db[j].ready_keys = dictCreate(&objectKeyPointerValueDictType,NULL);

--- a/src/server.h
+++ b/src/server.h
@@ -961,6 +961,7 @@ struct redisServer {
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
     /* System hardware info */
     size_t system_memory_size;  /* Total memory in system as reported by OS */
+    unsigned long dict_ht_initial_size;
 };
 
 typedef struct pubsubPattern {


### PR DESCRIPTION
Sometimes, we need set the first dict hashtable size when using at scale.
so I think this is useful.

dict-ht-initial-size is only changed in redis.conf(not config set command)

in redis.conf

``` c
dict-ht-initial-size 102476800
```
