### PR TITLE
Prevent write amplification in some cases

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1991,6 +1991,7 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
 
     /* Process line by line. */
     lines = sdssplitlen(info,strlen(info),"\r\n",2,&numlines);
+    int flush_config = 0;
     for (j = 0; j < numlines; j++) {
         sentinelRedisInstance *slave;
         sds l = lines[j];
@@ -2043,7 +2044,7 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
                             atoi(port), ri->quorum, ri)) != NULL)
                 {
                     sentinelEvent(LL_NOTICE,"+slave",slave,"%@");
-                    sentinelFlushConfig();
+                    flush_config = 1;
                 }
             }
         }
@@ -2098,6 +2099,7 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
                 ri->slave_repl_offset = strtoull(l+18,NULL,10);
         }
     }
+    if (flush_config) { sentinelFlushConfig(); }
     ri->info_refresh = mstime();
     sdsfreesplitres(lines,numlines);
 


### PR DESCRIPTION
Old version rewrites the config file immediately after each slave is found -- there's no good reason to do that, especially on startup (e.g. 10 slaves on 10 monitored servers each == 100 config writes already...)
