### PR TITLE
Remove unused variables and assignments, and unnecessary conditions

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1234,7 +1234,7 @@ void readQueryFromClient(aeEventLoop *el, int fd, void *privdata, int mask) {
      * at the risk of requiring more read(2) calls. This way the function
      * processMultiBulkBuffer() can avoid copying buffers to create the
      * Redis Object representing the argument. */
-    if (c->reqtype == PROTO_REQ_MULTIBULK && c->multibulklen && c->bulklen != -1
+    if (c->reqtype == PROTO_REQ_MULTIBULK && c->multibulklen
         && c->bulklen >= PROTO_MBULK_BIG_ARG)
     {
         int remaining = (unsigned)(c->bulklen+2)-sdslen(c->querybuf);

--- a/src/sds.c
+++ b/src/sds.c
@@ -578,7 +578,7 @@ sds sdscatprintf(sds s, const char *fmt, ...) {
  */
 sds sdscatfmt(sds s, char const *fmt, ...) {
     size_t initlen = sdslen(s);
-    const char *f = fmt;
+    const char *f;
     int i;
     va_list ap;
 
@@ -681,10 +681,10 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
  * Output will be just "Hello World".
  */
 sds sdstrim(sds s, const char *cset) {
-    char *start, *end, *sp, *ep;
+    char *end, *sp, *ep;
     size_t len;
 
-    sp = start = s;
+    sp = s;
     ep = end = s+sdslen(s)-1;
     while(sp <= end && strchr(cset, *sp)) sp++;
     while(ep > sp && strchr(cset, *ep)) ep--;
@@ -1219,7 +1219,6 @@ int sdsTest(void) {
             memcmp(y,"\"\\a\\n\\x00foo\\r\"",15) == 0)
 
         {
-            unsigned int oldfree;
             char *p;
             int step = 10, j, i;
 
@@ -1238,7 +1237,7 @@ int sdsTest(void) {
                 test_cond("sdsMakeRoomFor() len", sdslen(x) == oldlen);
                 if (type != SDS_TYPE_5) {
                     test_cond("sdsMakeRoomFor() free", sdsavail(x) >= step);
-                    oldfree = sdsavail(x);
+                    sdsavail(x);
                 }
                 p = x+oldlen;
                 for (j = 0; j < step; j++) {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1061,7 +1061,7 @@ unsigned char *zzlDeleteRangeByScore(unsigned char *zl, zrangespec *range, unsig
 }
 
 unsigned char *zzlDeleteRangeByLex(unsigned char *zl, zlexrangespec *range, unsigned long *deleted) {
-    unsigned char *eptr, *sptr;
+    unsigned char *eptr;
     unsigned long num = 0;
 
     if (deleted != NULL) *deleted = 0;
@@ -1071,7 +1071,7 @@ unsigned char *zzlDeleteRangeByLex(unsigned char *zl, zlexrangespec *range, unsi
 
     /* When the tail of the ziplist is deleted, eptr will point to the sentinel
      * byte and ziplistNext will return NULL. */
-    while ((sptr = ziplistNext(zl,eptr)) != NULL) {
+    while (ziplistNext(zl,eptr) != NULL) {
         if (zzlLexValueLteMax(eptr,range)) {
             /* Delete both the element and the score. */
             zl = ziplistDelete(zl,&eptr);

--- a/src/util.c
+++ b/src/util.c
@@ -601,8 +601,6 @@ void getRandomHexChars(char *p, unsigned int len) {
         }
         if (l >= sizeof(pid)) {
             memcpy(x,&pid,sizeof(pid));
-            l -= sizeof(pid);
-            x += sizeof(pid);
         }
         /* Finally xor it with rand() output, that was already seeded with
          * time() at startup, and convert to hex digits. */


### PR DESCRIPTION
This is just the result of fixing some of the warnings that CppCheck generates for codes in src directory.
