### PR TITLE
Optimize data alignment in a few structures to reduce memory footprint

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -116,9 +116,9 @@ typedef struct clusterState {
     int failover_auth_count;    /* Number of votes received so far. */
     int failover_auth_sent;     /* True if we already asked for votes. */
     int failover_auth_rank;     /* This slave rank for current auth request. */
-    uint64_t failover_auth_epoch; /* Epoch of the current election. */
     int cant_failover_reason;   /* Why a slave is currently not able to
                                    failover. See the CANT_FAILOVER_* macros. */
+    uint64_t failover_auth_epoch; /* Epoch of the current election. */
     /* Manual failover state in common. */
     mstime_t mf_end;            /* Manual failover time limit (ms unixtime).
                                    It is zero if there is no MF in progress. */
@@ -127,11 +127,11 @@ typedef struct clusterState {
     /* Manual failover state of slave. */
     long long mf_master_offset; /* Master offset the slave needs to start MF
                                    or zero if stil not received. */
-    int mf_can_start;           /* If non-zero signal that the manual failover
-                                   can start requesting masters vote. */
     /* The followign fields are used by masters to take state on elections. */
     uint64_t lastVoteEpoch;     /* Epoch of the last vote granted. */
     int todo_before_sleep; /* Things to do in clusterBeforeSleep(). */
+    int mf_can_start;           /* If non-zero signal that the manual failover
+                                   can start requesting masters vote. */
     long long stats_bus_messages_sent;  /* Num of msg sent via cluster bus. */
     long long stats_bus_messages_received; /* Num of msg rcvd via cluster bus.*/
 } clusterState;

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -52,8 +52,8 @@
 static struct config {
     aeEventLoop *el;
     const char *hostip;
-    int hostport;
     const char *hostsocket;
+    int hostport;
     int numclients;
     int liveclients;
     int requests;


### PR DESCRIPTION
By re-ordering a few variables in clusterState in [cluster.h](src/cluster.h) and config in [redis-benchmark.c](src/redis-benchmark.c), we can utilize structure packing to reduce the memory footprint. If I'm not mistaken the first commit should reduce clusterState by 16 bytes and config by 8 bytes. Tables of portions of the original layouts of the structures are listed below. By re-arranging the variables we should be able to eliminate the padding.

**clusterState** ( x = offset of `failover_auth_count`)

<table>
<tr>
<td><b>Variable</b></td><td><b>Offset</b></td>
</tr>
<tr>
<td>failover_auth_count</td><td>x + 0</td>
</tr>
<tr>
<td>failover_auth_sent</td><td>x + 4</td>
</tr>
<tr>
<td>failover_auth_rank</td><td>x + 8</td>
</tr>
<tr>
<td><i>padding</i></td><td>x + 12</td>
</tr>
<tr>
<td>failover_auth_epoch</td><td>x + 16</td>
</tr>
<tr>
<td>cant_failover_reason</td><td>x + 24</td>
</tr>
<tr>
<td><i>padding</i></td><td>x + 28</td>
</tr>
</table>


**config** ( x = offset of `hostport`)

<table>
<tr>
<td><b>Variable</b></td><td><b>Offset</b></td>
</tr>
<tr>
<td>hostport</td><td>x + 0</td>
</tr>
<tr>
<td><i>padding</i></td><td>x + 4</td>
</tr>
<tr>
<td>hosocket</td><td>x + 8</td>
</tr>
</table>


If the actual byte ordering of the variables is important for some reason, I'm sorry and this patch is not appropriate, but I didn't find anything to suggest this is so. Any comments or criticisms are appreciated, as this is my first patch submitted to this project, so I'm definitely a noobie here :smiley: 

I wrote the patch thinking about an x86 64bit machine, so in instances in which a single integer was adjacent to a pointer I considered that to be a 4 byte aligned value with 4 bytes of padding adjacent to a 8 byte aligned value.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/antirez/redis/2825)

<!-- Reviewable:end -->
