### PR TITLE
Optimize data alignment for a few more structs

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -78,10 +78,10 @@ int spectrum_palette_size;
 static redisContext *context;
 static struct config {
     char *hostip;
-    int hostport;
     char *hostsocket;
     long repeat;
     long interval;
+    int hostport;
     int dbnum;
     int interactive;
     int shutdown;
@@ -108,10 +108,10 @@ static struct config {
     int stdinarg; /* get last arg from stdin. (-x option) */
     char *auth;
     int output; /* output mode, see OUTPUT_* defines */
+    int last_cmd_type;
     sds mb_delim;
     char prompt[128];
     char *eval;
-    int last_cmd_type;
 } config;
 
 static volatile sig_atomic_t force_cancel_loop = 0;

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -161,7 +161,6 @@ typedef struct instanceLink {
 } instanceLink;
 
 typedef struct sentinelRedisInstance {
-    int flags;      /* See SRI_... defines */
     char *name;     /* Master name from the point of view of this sentinel. */
     char *runid;    /* Run ID of this instance, or unique ID if is a Sentinel.*/
     uint64_t config_epoch;  /* Configuration epoch. */
@@ -177,6 +176,7 @@ typedef struct sentinelRedisInstance {
     mstime_t o_down_since_time; /* Objectively down since time. */
     mstime_t down_after_period; /* Consider it down after that period. */
     mstime_t info_refresh;  /* Time at which we received INFO output from it. */
+    int flags;      /* See SRI_... defines */
 
     /* Role and the first time we observed it.
      * This is useful in order to delay replacing what the instance reports
@@ -196,21 +196,22 @@ typedef struct sentinelRedisInstance {
 
     /* Slave specific. */
     mstime_t master_link_down_time; /* Slave replication link down time. */
-    int slave_priority; /* Slave priority according to its INFO output. */
     mstime_t slave_reconf_sent_time; /* Time at which we sent SLAVE OF <new> */
     struct sentinelRedisInstance *master; /* Master instance if it's slave. */
     char *slave_master_host;    /* Master host as reported by INFO */
     int slave_master_port;      /* Master port as reported by INFO */
     int slave_master_link_status; /* Master link status as reported by INFO */
     unsigned long long slave_repl_offset; /* Slave replication offset. */
+    int slave_priority; /* Slave priority according to its INFO output. */
+
     /* Failover */
+    int failover_state; /* See SENTINEL_FAILOVER_STATE_* defines. */
     char *leader;       /* If this is a master instance, this is the runid of
                            the Sentinel that should perform the failover. If
                            this is a Sentinel, this is the runid of the Sentinel
                            that this Sentinel voted as leader. */
     uint64_t leader_epoch; /* Epoch of the 'leader' field. */
     uint64_t failover_epoch; /* Epoch of the currently started failover. */
-    int failover_state; /* See SENTINEL_FAILOVER_STATE_* defines. */
     mstime_t failover_state_change_time;
     mstime_t failover_start_time;   /* Last failover attempt start time. */
     mstime_t failover_timeout;      /* Max time to refresh failover state. */


### PR DESCRIPTION
Similar to my prior pull request I found a few more structures that will have padding resulting in a few extra bytes on an 64 bit machine. I couldn't find any instances in which changing the ordering would have any harmful consequences. I also probably could have added this to my first pull request, but I prefer separate requests. Let me know if this is not the "redis way of doing things".

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/antirez/redis/2829)

<!-- Reviewable:end -->
