### PR TITLE
[bug] bgsave process inherits sockets

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -901,6 +901,7 @@ int rdbSaveBackground(char *filename) {
         int retval;
 
         /* Child */
+        closeInheritSockets();
         closeListeningSockets(0);
         redisSetProcTitle("redis-rdb-bgsave");
         retval = rdbSave(filename);

--- a/src/server.c
+++ b/src/server.c
@@ -2436,6 +2436,30 @@ int processCommand(client *c) {
 
 /*================================== Shutdown =============================== */
 
+void closeInheritSockets(void) {
+    int i, num;
+    listIter li;
+    listNode *ln;
+    client *c;
+
+    list *inhert_lists[] = {
+        server.clients,
+        server.slaves,
+        server.monitors,
+        server.clients_to_close,
+        server.unblocked_clients,
+        server.clients_pending_write
+    }; 
+    num = sizeof(inhert_lists) / sizeof(inhert_lists[0]);
+    for (i = 0; i < num; i++) {
+        listRewind(inhert_lists[i], &li);
+        while((ln = listNext(&li))) {
+            c = listNodeValue(ln);
+            close(c->fd);
+        }
+    }
+}
+
 /* Close listening sockets. Also unlink the unix domain socket if
  * unlink_unix_socket is non-zero. */
 void closeListeningSockets(int unlink_unix_socket) {

--- a/src/server.h
+++ b/src/server.h
@@ -1322,6 +1322,7 @@ void oom(const char *msg);
 void populateCommandTable(void);
 void resetCommandTableStats(void);
 void adjustOpenFilesLimit(void);
+void closeInheritSockets(void);
 void closeListeningSockets(int unlink_unix_socket);
 void updateCachedTime(void);
 void resetServerStats(void);


### PR DESCRIPTION
redis bgsave process close listen sockets at fork, but didn't close other connected sockets. and it may cause client block util bgsave exit, as those sockets were inherits by bgsave process.

And it may cause client timeout  if bgsave take too long.
### You can reproduce it easily
#### server
1. set timetout = 1s in redis.conf.
2. sleep N(for exmple 30) seconds in `rdbSaveBackground`.
#### client
1. send bgsave command to server.
2. after 1s, as we set timeout 1s, and it will be evicted.
3. send command to server again, and it will be blocked util bgsave process exit, and get a rst package.
