### PR TITLE
updated http://redis.io/topics/notifications url

### DIFF
--- a/src/notify.c
+++ b/src/notify.c
@@ -30,7 +30,7 @@
 #include "server.h"
 
 /* This file implements keyspace events notification via Pub/Sub ad
- * described at http://redis.io/topics/keyspace-events. */
+ * described at http://redis.io/topics/notifications. */
 
 /* Turn a string representing notification classes into an integer
  * representing notification classes flags xored.


### PR DESCRIPTION
old url http://redis.io/topics/keyspace-events
leads to 'Sorry, I can't find that page :-/'
