### PR TITLE
fix bug : compile warning of Linux ARM or other case

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -507,7 +507,7 @@ static void *getMcontextEip(ucontext_t *uc) {
     #elif defined(__ia64__) /* Linux IA64 */
     return (void*) uc->uc_mcontext.sc_ip;
     #else /* other Linux for example Linux arm */
-    redisLog(REDIS_DEBUG, "%x", (unsigned int)uc);
+    (void)uc;
     return NULL;
     #endif
 #else

--- a/src/debug.c
+++ b/src/debug.c
@@ -506,6 +506,9 @@ static void *getMcontextEip(ucontext_t *uc) {
     return (void*) uc->uc_mcontext.gregs[16]; /* Linux 64 */
     #elif defined(__ia64__) /* Linux IA64 */
     return (void*) uc->uc_mcontext.sc_ip;
+    #else /* other Linux for example Linux arm */
+    redisLog(REDIS_DEBUG, "%x", (unsigned int)uc);
+    return NULL;
     #endif
 #else
     return NULL;


### PR DESCRIPTION
When it into '#elif defined(**linux**)'branch.Here only have three(**i386**、 **X86_64** || **x86_64** or **ia64**)branch.If your compile environment are not these three, for example arm-linux-gnueabi-gcc, it does not deal with it. When you compile the project, there will be a warning like this:
In function 'getMcontextEip':
warning: no return statement in function returning non-void [-Wreturn-type]
}
warning: unused parameter 'uc' [-Wunused-parameter]

I think it should be added '#else' branch after '#elif defined(**ia64**)'.So we can deal with it used some simple method for example (void) uc parameter and return NULL.It can elimination the compile warning, even if now we do not do further processing with the "#else" branch.

I hope this method will handle this bug and can elimination the compile warning.
