### PR TITLE
Fix syncWithMaster() for REDIS_REPL_NONE case (github issue #2479)

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1373,6 +1373,8 @@ void syncWithMaster(aeEventLoop *el, int fd, void *privdata, int mask) {
     /* If this event fired after the user turned the instance into a master
      * with SLAVEOF NO ONE we must just return ASAP. */
     if (server.repl_state == REDIS_REPL_NONE) {
+        aeDeleteFileEvent(server.el,fd,AE_READABLE|AE_WRITABLE);
+        server.repl_transfer_s = -1;
         close(fd);
         return;
     }


### PR DESCRIPTION
When "slaveof no one" command is requested by user while the redis is still waiting for the replication stream from its master, redis cancels replication process by just closing the connection with master.
But without aeDeleteFileEvent(), that fd number still remain in the epoll, so this will make redis keep failing to accept new clients because epoll add will fail.
This fix is not just for 2.8 branch but also can be applied to every redis branches.
