### PR TITLE
Keep different clusters from mixing

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1545,6 +1545,13 @@ int clusterProcessPacket(clusterLink *link) {
     redisLog(REDIS_DEBUG,"--- Processing packet of type %d, %lu bytes",
         type, (unsigned long) totlen);
 
+    /* if both nodes in "ok" clusters, they shouldn't have to meet each other */
+    if (hdr->state == REDIS_CLUSTER_OK
+            && server.cluster->state == REDIS_CLUSTER_OK
+            && type == CLUSTERMSG_TYPE_MEET) {
+        return 1;
+    }
+
     /* Perform sanity checks */
     if (totlen < 16) return 1; /* At least signature, version, totlen, count. */
     if (ntohs(hdr->ver) != CLUSTER_PROTO_VER)


### PR DESCRIPTION
I'd like to know if there is any way to [prevent different redis clusters from mixing via CLUSTER MEET](http://stackoverflow.com/questions/33093456/prevent-different-redis-clusters-from-mixing-via-cluster-meet) but got no answer so I decide to make one.

UPDATED: I didn't notice there is a `state` member in `clusterMsg`. It seems fine to use this field, so that no need to change protocol anymore.

When a node receives a MEET message, it would not response if both the cluster of sender and the cluster of itself are in the OK state, thus keeping two difference cluster from accidentally mixing.

Thanks for reviewing. From a department running dozens of clusters...
