### PR TITLE
Renamed more things to common server name

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -465,7 +465,7 @@ sds catAppendOnlyGenericCommand(sds dst, int argc, robj **argv) {
  * This command is used in order to translate EXPIRE and PEXPIRE commands
  * into PEXPIREAT command so that we retain precision in the append only
  * file, and the time is always absolute and not relative. */
-sds catAppendOnlyExpireAtCommand(sds buf, struct redisCommand *cmd, robj *key, robj *seconds) {
+sds catAppendOnlyExpireAtCommand(sds buf, struct serverCommand *cmd, robj *key, robj *seconds) {
     long long when;
     robj *argv[3];
 
@@ -495,7 +495,7 @@ sds catAppendOnlyExpireAtCommand(sds buf, struct redisCommand *cmd, robj *key, r
     return buf;
 }
 
-void feedAppendOnlyFile(struct redisCommand *cmd, int dictid, robj **argv, int argc) {
+void feedAppendOnlyFile(struct serverCommand *cmd, int dictid, robj **argv, int argc) {
     sds buf = sdsempty();
     robj *tmpargv[3];
 
@@ -629,7 +629,7 @@ int loadAppendOnlyFile(char *filename) {
         robj **argv;
         char buf[128];
         sds argsds;
-        struct redisCommand *cmd;
+        struct serverCommand *cmd;
 
         /* Serve the clients from time to time */
         if (!(loops++ % 1000)) {
@@ -1252,7 +1252,7 @@ int rewriteAppendOnlyFileBackground(void) {
 
         /* Child */
         closeListeningSockets(0);
-        redisSetProcTitle("redis-aof-rewrite");
+        serverSetProcTitle("redis-aof-rewrite");
         snprintf(tmpfile,256,"temp-rewriteaof-bg-%d.aof", (int) getpid());
         if (rewriteAppendOnlyFile(tmpfile) == C_OK) {
             size_t private_dirty = zmalloc_get_private_dirty();

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -58,7 +58,7 @@ static int getBitOffsetFromArgument(client *c, robj *o, size_t *offset) {
 /* Count number of bits set in the binary array pointed by 's' and long
  * 'count' bytes. The implementation of this function is required to
  * work with a input string length up to 512 MB. */
-size_t redisPopcount(void *s, long count) {
+static size_t popcount(void *s, long count) {
     size_t bits = 0;
     unsigned char *p = s;
     uint32_t *p4;
@@ -506,7 +506,7 @@ void bitcountCommand(client *c) {
     } else {
         long bytes = end-start+1;
 
-        addReplyLongLong(c,redisPopcount(p+start,bytes));
+        addReplyLongLong(c,popcount(p+start,bytes));
     }
 }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4784,7 +4784,7 @@ void readwriteCommand(client *c) {
  * not bound to any node. In this case the cluster global state should be
  * already "down" but it is fragile to rely on the update of the global state,
  * so we also handle it here. */
-clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, int argc, int *hashslot, int *error_code) {
+clusterNode *getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int *hashslot, int *error_code) {
     clusterNode *n = NULL;
     robj *firstkey = NULL;
     int multiple_keys = 0;
@@ -4817,7 +4817,7 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
     /* Check that all the keys are in the same hash slot, and obtain this
      * slot and the node associated. */
     for (i = 0; i < ms->count; i++) {
-        struct redisCommand *mcmd;
+        struct serverCommand *mcmd;
         robj **margv;
         int margc, *keyindex, numkeys, j;
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -249,7 +249,7 @@ typedef struct {
                                             master is up. */
 
 /* ---------------------- API exported outside cluster.c -------------------- */
-clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, int argc, int *hashslot, int *ask);
+clusterNode *getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int *hashslot, int *ask);
 int clusterRedirectBlockedClientIfNeeded(client *c);
 void clusterRedirectClient(client *c, clusterNode *n, int hashslot, int error_code);
 

--- a/src/config.c
+++ b/src/config.c
@@ -479,7 +479,7 @@ void loadServerConfigFromString(char *config) {
         } else if (!strcasecmp(argv[0],"hll-sparse-max-bytes") && argc == 2) {
             server.hll_sparse_max_bytes = memtoll(argv[1], NULL);
         } else if (!strcasecmp(argv[0],"rename-command") && argc == 3) {
-            struct redisCommand *cmd = lookupCommand(argv[1]);
+            struct serverCommand *cmd = lookupCommand(argv[1]);
             int retval;
 
             if (!cmd) {

--- a/src/db.c
+++ b/src/db.c
@@ -1093,7 +1093,7 @@ void persistCommand(client *c) {
 
 /* The base case is to use the keys position as given in the command table
  * (firstkey, lastkey, step). */
-int *getKeysUsingCommandTable(struct redisCommand *cmd,robj **argv, int argc, int *numkeys) {
+int *getKeysUsingCommandTable(struct serverCommand *cmd,robj **argv, int argc, int *numkeys) {
     int j, i = 0, last, *keys;
     UNUSED(argv);
 
@@ -1118,12 +1118,12 @@ int *getKeysUsingCommandTable(struct redisCommand *cmd,robj **argv, int argc, in
  * so the actual return value is an heap allocated array of integers. The
  * length of the array is returned by reference into *numkeys.
  *
- * 'cmd' must be point to the corresponding entry into the redisCommand
+ * 'cmd' must be point to the corresponding entry into the serverCommand
  * table, according to the command name in argv[0].
  *
  * This function uses the command table if a command-specific helper function
  * is not required, otherwise it calls the command-specific function. */
-int *getKeysFromCommand(struct redisCommand *cmd, robj **argv, int argc, int *numkeys) {
+int *getKeysFromCommand(struct serverCommand *cmd, robj **argv, int argc, int *numkeys) {
     if (cmd->getkeys_proc) {
         return cmd->getkeys_proc(cmd,argv,argc,numkeys);
     } else {
@@ -1139,7 +1139,7 @@ void getKeysFreeResult(int *result) {
 /* Helper function to extract keys from following commands:
  * ZUNIONSTORE <destkey> <num-keys> <key> <key> ... <key> <options>
  * ZINTERSTORE <destkey> <num-keys> <key> <key> ... <key> <options> */
-int *zunionInterGetKeys(struct redisCommand *cmd, robj **argv, int argc, int *numkeys) {
+int *zunionInterGetKeys(struct serverCommand *cmd, robj **argv, int argc, int *numkeys) {
     int i, num, *keys;
     UNUSED(cmd);
 
@@ -1168,7 +1168,7 @@ int *zunionInterGetKeys(struct redisCommand *cmd, robj **argv, int argc, int *nu
 /* Helper function to extract keys from the following commands:
  * EVAL <script> <num-keys> <key> <key> ... <key> [more stuff]
  * EVALSHA <script> <num-keys> <key> <key> ... <key> [more stuff] */
-int *evalGetKeys(struct redisCommand *cmd, robj **argv, int argc, int *numkeys) {
+int *evalGetKeys(struct serverCommand *cmd, robj **argv, int argc, int *numkeys) {
     int i, num, *keys;
     UNUSED(cmd);
 
@@ -1196,7 +1196,7 @@ int *evalGetKeys(struct redisCommand *cmd, robj **argv, int argc, int *numkeys) 
  * The first argument of SORT is always a key, however a list of options
  * follow in SQL-alike style. Here we parse just the minimum in order to
  * correctly identify keys in the "STORE" option. */
-int *sortGetKeys(struct redisCommand *cmd, robj **argv, int argc, int *numkeys) {
+int *sortGetKeys(struct serverCommand *cmd, robj **argv, int argc, int *numkeys) {
     int i, j, num, *keys, found_store = 0;
     UNUSED(cmd);
 

--- a/src/multi.c
+++ b/src/multi.c
@@ -115,7 +115,7 @@ void execCommand(client *c) {
     int j;
     robj **orig_argv;
     int orig_argc;
-    struct redisCommand *orig_cmd;
+    struct serverCommand *orig_cmd;
     int must_propagate = 0; /* Need to propagate MULTI/EXEC to AOF / slaves? */
 
     if (!(c->flags & CLIENT_MULTI)) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -942,7 +942,7 @@ int handleClientsWithPendingWrites(void) {
 
 /* resetClient prepare the client to process the next command */
 void resetClient(client *c) {
-    redisCommandProc *prevcmd = c->cmd ? c->cmd->proc : NULL;
+    serverCommandProc *prevcmd = c->cmd ? c->cmd->proc : NULL;
 
     freeClientArgv(c);
     c->reqtype = 0;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -902,7 +902,7 @@ int rdbSaveBackground(char *filename) {
 
         /* Child */
         closeListeningSockets(0);
-        redisSetProcTitle("redis-rdb-bgsave");
+        serverSetProcTitle("redis-rdb-bgsave");
         retval = rdbSave(filename);
         if (retval == C_OK) {
             size_t private_dirty = zmalloc_get_private_dirty();
@@ -1598,7 +1598,7 @@ int rdbSaveToSlavesSockets(void) {
         zfree(fds);
 
         closeListeningSockets(0);
-        redisSetProcTitle("redis-rdb-to-slaves");
+        serverSetProcTitle("redis-rdb-to-slaves");
 
         retval = rdbSaveRioWithEOFMark(&slave_sockets,NULL);
         if (retval == C_OK && rioFlush(&slave_sockets) == 0)

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -347,7 +347,7 @@ void luaReplyToRedisReply(client *c, lua_State *lua) {
 #define LUA_CMD_OBJCACHE_MAX_LEN 64
 int luaRedisGenericCommand(lua_State *lua, int raise_error) {
     int j, argc = lua_gettop(lua);
-    struct redisCommand *cmd;
+    struct serverCommand *cmd;
     client *c = server.lua_client;
     sds reply;
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -422,7 +422,7 @@ void sentinelSetCommand(client *c);
 void sentinelPublishCommand(client *c);
 void sentinelRoleCommand(client *c);
 
-struct redisCommand sentinelcmds[] = {
+struct serverCommand sentinelcmds[] = {
     {"ping",pingCommand,1,"",0,NULL,0,0,0,0,0},
     {"sentinel",sentinelCommand,-2,"",0,NULL,0,0,0,0,0},
     {"subscribe",subscribeCommand,-2,"",0,NULL,0,0,0,0,0},
@@ -451,7 +451,7 @@ void initSentinel(void) {
     dictEmpty(server.commands,NULL);
     for (j = 0; j < sizeof(sentinelcmds)/sizeof(sentinelcmds[0]); j++) {
         int retval;
-        struct redisCommand *cmd = sentinelcmds+j;
+        struct serverCommand *cmd = sentinelcmds+j;
 
         retval = dictAdd(server.commands, sdsnew(cmd->name), cmd);
         serverAssert(retval == DICT_OK);


### PR DESCRIPTION
This commit renames more things to the general server name instead of redis.
This is the next step for a common core between redis based applications such as [disque](https://github.com/antirez/disque) and [discnt](https://github.com/erikdubbelboer/discnt)
