### PR TITLE
Fix latency rdb string bug

### DIFF
--- a/src/latency.c
+++ b/src/latency.c
@@ -342,7 +342,7 @@ sds createLatencyReport(void) {
         }
 
         if (!strcasecmp(event,"aof-fstat") ||
-            !strcasecmp(event,"rdb-unlik-temp-file")) {
+            !strcasecmp(event,"rdb-unlink-temp-file")) {
             advise_disk_contention = 1;
             advise_local_disk = 1;
             advices += 2;


### PR DESCRIPTION
The other mention of this string in rdb.c is spelled correctly already: https://github.com/antirez/redis/blob/acc2336fd189ddf9e97b0fc589c43ae26a1fd153/src/rdb.c#L1419
