### PR TITLE
Fix format strings serverLogObjectDebugInfo to use unsigned

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -938,8 +938,8 @@ void _serverAssertPrintClientInfo(const client *c) {
 }
 
 void serverLogObjectDebugInfo(const robj *o) {
-    serverLog(LL_WARNING,"Object type: %d", o->type);
-    serverLog(LL_WARNING,"Object encoding: %d", o->encoding);
+    serverLog(LL_WARNING,"Object type: %u", o->type);
+    serverLog(LL_WARNING,"Object encoding: %u", o->encoding);
     serverLog(LL_WARNING,"Object refcount: %d", o->refcount);
 #if UNSAFE_CRASH_REPORT
     /* This code is now disabled. o->ptr may be unreliable to print. in some


### PR DESCRIPTION
See https://github.com/antirez/disque/commit/97ae9fbbf302da5d1c358bda666a76a5e79f5cdc and https://github.com/antirez/disque/pull/129/files
