### PR TITLE
Read auth string from config file on shutdown

### DIFF
--- a/utils/redis_init_script.tpl
+++ b/utils/redis_init_script.tpl
@@ -16,7 +16,8 @@ case "$1" in
         else
             PID=$(cat $PIDFILE)
             echo "Stopping ..."
-            $CLIEXEC -p $REDISPORT shutdown
+            AUTH=$(sed -n '/^requirepass /{s/[^ ]*/-a/;p;q;}' $CONF)
+            $CLIEXEC -p $REDISPORT $AUTH shutdown
             while [ -x /proc/${PID} ]
             do
                 echo "Waiting for Redis to shutdown ..."


### PR DESCRIPTION
Reads the requirepass line from the config file, munges
it into a flag/param if found, and adds it to the call to
redis-cli on service stop.

sed command explained:
-n              do not print each line after processing it
/^requirepass /{...}    on lines starting with requirepass, do:
  s/[^ ]*/-a/;      substitute up to the first space with -a flag
  p;            print the processed line
  q;            quit sed
