### PR TITLE
Update pretty printing during debugging to generate valid Lua code for tables

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1882,8 +1882,9 @@ sds ldbCatStackValue(sds s, lua_State *lua, int idx) {
             repr1 = ldbCatStackValue(repr1,lua,-1);
             repr1 = sdscatlen(repr1,"; ",2);
             /* Full repr. */
+            repr2 = sdscatlen(repr2,"[",1);
             repr2 = ldbCatStackValue(repr2,lua,-2);
-            repr2 = sdscatlen(repr2,"=",1);
+            repr2 = sdscatlen(repr2,"]=",2);
             repr2 = ldbCatStackValue(repr2,lua,-1);
             repr2 = sdscatlen(repr2,"; ",2);
             lua_pop(lua,1); /* Stack: table, key. Ready for next iteration. */


### PR DESCRIPTION
It's only slightly more verbose, but is valid Lua code, which simplifies integration with other tools that need to evaluate this information to access variable values.

This patch changes values like `{{3; 4}; "b"={1; 2}}` to `{{3; 4}; ["b"]={1; 2}}`
