### PR TITLE
Update pretty printing in debugging to generate valid Lua code for userdata-like types.

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1911,11 +1911,11 @@ sds ldbCatStackValue(sds s, lua_State *lua, int idx) {
         else if (t == LUA_TUSERDATA) typename = "userdata";
         else if (t == LUA_TTHREAD) typename = "thread";
         else if (t == LUA_TLIGHTUSERDATA) typename = "light-userdata";
-        s = sdscatprintf(s,"%s@%p",typename,p);
+        s = sdscatprintf(s,"\"%s@%p\"",typename,p);
         }
         break;
     default:
-        s = sdscat(s,"<unknown-lua-type>");
+        s = sdscat(s,"\"<unknown-lua-type>\"");
         break;
     }
     return s;


### PR DESCRIPTION
This helps with processing of the pretty printed results for Lua datatypes (similar to what #2954 does for tables).
