### PR TITLE
fix potential unwanted fullresync in chained replication

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -2070,7 +2070,7 @@ int processCommand(redisClient *c) {
 
         /* It was impossible to free enough memory, and the command the client
          * is trying to execute is denied during OOM conditions? Error. */
-        if ((c->cmd->flags & CMD_DENYOOM) && retval == REDIS_ERR) {
+        if ((c->cmd->flags & REDIS_CMD_DENYOOM) && retval == REDIS_ERR) {
             flagTransaction(c);
             addReply(c, shared.oomerr);
             return REDIS_OK;

--- a/src/redis.h
+++ b/src/redis.h
@@ -284,10 +284,10 @@ typedef long long mstime_t; /* millisecond time type. */
  * In SEND_BULK and ONLINE state the slave receives new updates
  * in its output queue. In the WAIT_BGSAVE state instead the server is waiting
  * to start the next background saving in order to send updates to it. */
-#define REDIS_REPL_WAIT_BGSAVE_START 14 /* We need to produce a new RDB file. */
-#define REDIS_REPL_WAIT_BGSAVE_END 15 /* Waiting RDB file creation to finish. */
-#define REDIS_REPL_SEND_BULK 16 /* Sending RDB file to slave. */
-#define REDIS_REPL_ONLINE 17 /* RDB file transmitted, sending just updates. */
+#define REDIS_REPL_WAIT_BGSAVE_START 15 /* We need to produce a new RDB file. */
+#define REDIS_REPL_WAIT_BGSAVE_END 16 /* Waiting RDB file creation to finish. */
+#define REDIS_REPL_SEND_BULK 17 /* Sending RDB file to slave. */
+#define REDIS_REPL_ONLINE 18 /* RDB file transmitted, sending just updates. */
 
 /* Slave capabilities. */
 #define SLAVE_CAPA_NONE 0

--- a/src/redis.h
+++ b/src/redis.h
@@ -273,11 +273,12 @@ typedef long long mstime_t; /* millisecond time type. */
 #define REDIS_REPL_RECEIVE_PORT 7 /* Wait for REPLCONF reply */
 #define REDIS_REPL_SEND_CAPA 8 /* Send REPLCONF capa */
 #define REDIS_REPL_RECEIVE_CAPA 9 /* Wait for REPLCONF reply */
-#define REDIS_REPL_SEND_PSYNC 10 /* Send PSYNC */
-#define REDIS_REPL_RECEIVE_PSYNC 11 /* Wait for PSYNC reply */
+#define REDIS_REPL_RESEND_CAPA 10 /* Resend REPLCONF capa to confirm master is ready */
+#define REDIS_REPL_SEND_PSYNC 11 /* Send PSYNC */
+#define REDIS_REPL_RECEIVE_PSYNC 12 /* Wait for PSYNC reply */
 /* --- End of handshake states --- */
-#define REDIS_REPL_TRANSFER 12 /* Receiving .rdb from master */
-#define REDIS_REPL_CONNECTED 13 /* Connected to master */
+#define REDIS_REPL_TRANSFER 13 /* Receiving .rdb from master */
+#define REDIS_REPL_CONNECTED 14 /* Connected to master */
 
 /* State of slaves from the POV of the master. Used in client->replstate.
  * In SEND_BULK and ONLINE state the slave receives new updates


### PR DESCRIPTION
We found a issue about chained replication in our product environment. 

Let's say A -> B -> C three nodes chained replication. When network trembled, B disconnect with A and C disconnected with B, B and C reconnect and request resync with their master at the same time. C sent 'psync' and wait B's reply, if B is in it's handshake status, B will reply "-ERR Can't SYNC while not connected with my master". In this condition,  C will give up psync, free it's cached_master and perform full sync with B.

The attachment show how to reproduce the issue.
[redis-fix.txt](https://github.com/antirez/redis/files/71462/redis-fix.txt)
