### PR TITLE
[ci skip] Improve supervised upstart config docs

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -111,6 +111,7 @@ daemonize no
 # supervision tree. Options:
 #   supervised no      - no supervision interaction
 #   supervised upstart - signal upstart by putting Redis into SIGSTOP mode
+#                        requires "expect stop" in your upstart job config
 #   supervised systemd - signal systemd by writing READY=1 to $NOTIFY_SOCKET
 #   supervised auto    - detect upstart or systemd method based on
 #                        UPSTART_JOB or NOTIFY_SOCKET environment variables


### PR DESCRIPTION
This mentions that "expect stop" is required for supervised upstart to work correctly.

See http://upstart.ubuntu.com/cookbook/#expect-stop for an explanation.
