### PR TITLE
Added interval sets support

### DIFF
--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -1,123 +1,16 @@
-Redis 3.2 release notes
-=======================
+Hello! This file is just a placeholder, since this is the "unstable" branch
+of Redis, the place where all the development happens.
 
---------------------------------------------------------------------------------
-Upgrade urgency levels:
+There is no release notes for this branch, it gets forked into another branch
+every time there is a partial feature freeze in order to eventually create
+a new stable release.
 
-LOW:      No need to upgrade unless there are new features you want to use.
-MODERATE: Program an upgrade of the server, but it's not urgent.
-HIGH:     There is a critical bug that may affect a subset of users. Upgrade!
-CRITICAL: There is a critical bug affecting MOST USERS. Upgrade ASAP.
---------------------------------------------------------------------------------
+Usually "unstable" is stable enough for you to use it in development environments
+however you should never use it in production environments. It is possible
+to download the latest stable release here:
 
---[ Redis 3.2.0 RC1 (version 3.1.101) ] Release date: 23 dec 2015
+    http://download.redis.io/releases/redis-stable.tar.gz
 
-This is the first release candidate of Redis 3.2. The changelog above shows
-what's new in this release. In the next of the following weeks we'll test
-in depth every feature and we'll release new RCs as bugs are discovered
-and fixed. Note that while 3.2 looks solid already, it contains many changes
-to its internals. It's still fresh code compared to 3.0.
+More information is available at http://redis.io
 
-General changes:
-
-* [NEW] Lua scripts "effect replication". Makes possible to write scripts
-        with side effects, use of random commands, and so forth.
-        (Salvatore Sanfilippo)
-* [NEW] Lua scripts selective replication. Makes possible to replicate to
-        slaves and AOF only selected parts of a script. (Design by
-        Yossi Gottlieb and Salvatore Sanfilippo, implemented by Salvatore)
-* [NEW] Geo indexing support via GEOADD, GEORADIUS and other commands.
-        See http://redis.io/commands/geoadd for more information.
-        (Initially implemented in a fork of Redis called "Ardb".
-         Matt Stancliff "imported back" the work to Redis and created the
-         initial API and implementation. Salvatore Sanfilippo modified
-         the API and the implementation, fixed bugs, improved performances
-         and unified the duplicated code with t_zset.c)
-* [NEW] Lua debugger. A complete stepping, remote debugger for Lua scripts.
-        Video here: https://www.youtube.com/watch?v=IMvRfStaoyM
-        (Salvatore Sanfilippo with many feedbacks and testing from
-         Itamar Haber)
-* [NEW] SDS improvements for speed and maximum string length.
-        This makes Redis more memory efficient in different use cases.
-        (Design and implementation by Oran Agra, some additional work
-         by Salvatore Sanfilippo)
-* [NEW] Modify Jemalloc size classes to make certain Redis objects fit
-        better, improving memory efficiency. (Oran Agra)
-* [NEW] Better consistency behavior between masters and slaves for expired
-        keys. The slaves are only able to logically consider a key expired
-        even before receiving the `DEL` command from the master. This avoids
-        the delay there is sometimes between the natural expire of the key
-        and the moment the slave is notified. (Salvatore Sanfilippo)
-* [NEW] Support daemon supervision by upstart or systemd (Pierre-Yves Ritschard)
-* [NEW] New encoding for the List type: Quicklists. Very important memory
-        savings and storage space in RDB gains (up to 10x sometimes).
-        (Design and implementation by Matt Stancliff. RDB storage reworked
-         by Salvatore Sanfilippo)
-* [NEW] SPOP with optional count argument. (Initial implementation by
-        Alon Diamant, mostly reimplemented by Salvatore Sanfilippo for speed
-        and in order to make the replication of a this class of commands,
-        having as logical effect the execution of multiple commands, possible).
-* [NEW] Support for RDB AUX fields. Now RDB files contain additional info
-        like the creation date, version of Redis generating it and so forth.
-        (Salvatore Sanfilippo)
-* [NEW] Faster RDB loading via the RESIZEDB opcode to avoid useless hash tables
-        rehashings. (Salvatore Sanfilippo)
-* [NEW] HSTRLEN command. (@landmime and Salvatore Sanfilippo)
-* [NEW] CONFIG SET/GET implementations refactored, partially rewritten,
-        now exposing more config options. (Salvatore Sanfilippo)
-* [NEW] CLUSTER NODES major speedup. (Salvatore Sanfilippo)
-* [NEW] CLIENT KILL TYPE MASTER, to kill (disconnect) masters from slaves.
-        (Salvatore Sanfilippo)
-* [NEW] Jemalloc updated to 4.0.3 (Salvatore Sanfilippo)
-* [NEW] DEBUG RESTART/CRASH-AND-RECOVER [delay] (Salvatore Sanfilippo)
-* [NEW] CLIENT REPLY command implemented: ON, OFF and SKIP modes.
-        (Salvatore Sanfilippo)
-* [NEW] Crash report produced by Redis on crash improved. (Salvatore Sanfilippo)
-* [NEW] Better memory test on crash. (Salvatore Sanfilippo)
-
-Redis Cluster changes:
-
-All the Redis Cluster changes in 3.2 were backported to 3.0, so there is
-technically nothing new for now in this release. The most important things
-are:
-
-* Cluster rebalancing.
-* A pipelined MIGRATE command which is 10x faster and makes resharding
-  and rebalancing faster.
-* Improved replicas migration.
-* As a side effect of quicklists encoding (see above items), moving big
-  lists between nodes is now a lot faster.
-
-Redis Sentinel changes:
-
-* [NEW] Sentinel connection sharing. Makes Sentinels able to scale to
-        monitor many masters. (Salvatore Sanfilippo)
-* [NEW] New SENTINEL INFO-CACHE command. (Matt Stancliff)
-* More things backported to Redis 3.0 in the past, so no longer news of 3.2.
-
-Migrating from 3.0 to 3.2
-=========================
-
-Redis 3.0 is mostly a strict subset of 3.2, you should not have any problem
-upgrading your application from 3.0 to 3.2. However this is a list of small
-non-backward compatible changes introduced in the 3.2 release:
-
-* The default configuration file now binds to 127.0.0.1.
-* Slaves try to no longer expose stale data about already expired keys.
-* The RDB format changed. Redis 3.2 is still able to read 3.0 (and all the
-  past versions) files, but not the other way around.
-* Behavior on crash may be different. The crash log format changed and
-  the memory test executed is now different.
-
---------------------------------------------------------------------------------
-
-Credits: For each release, a list of changes with the relative author is
-provided. Where not specified the implementation and design is done by
-Salvatore Sanfilippo. Thanks to Redis Labs for making all this possible.
-Also many thanks to all the other contributors and the amazing community
-we have.
-
-Commit messages may contain additional credits.
-
-Cheers,
-Salvatore
+Happy hacking!

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Fixing build problems with dependencies or cached build options
 
 Redis has some dependencies which are included into the `deps` directory.
 `make` does not rebuild dependencies automatically, even if something in the
-source code of dependencies is changes.
+source code of dependencies is changed.
 
 When you update the source code with `git pull` or when code inside the
 dependencies tree is modified in any other way, make sure to use the following
@@ -185,7 +185,263 @@ source distribution.
 Please see the [CONTRIBUTING][2] file in this source distribution for more
 information.
 
-Enjoy!
-
 [1]: https://github.com/antirez/redis/blob/unstable/COPYING
 [2]: https://github.com/antirez/redis/blob/unstable/CONTRIBUTING
+
+Redis internals
+===
+
+If you are reading this README you are likely in front of a Github page
+or you just untarred the Redis distribution tar ball. In both the cases
+you are basically one step away from the source code, so here we explain
+the Redis source code layout, what is in each file as a general idea, the
+most important functions and structures inside the Redis server and so forth.
+We keep all the discussion at an high level without digging into the details
+since this document would be huge otherwise, and our code base changes
+continuously, but a general idea should be a good starting point to
+understand more. Moreover most of the code is heavily commented and easy
+to follow.
+
+Source code layout
+---
+
+The Redis root directory just contains this README, the Makefile which
+actually calls the real Makefile inside the `src` directory, an example
+configuration for Redis and Sentinel. Finally you can find a few shell
+scripts that are used in order to execute the Redis, Redis Cluster and
+Redis Sentinel unit tests, which are implemented inside the `tests`
+directory.
+
+Inside the root directory the are the following important directories:
+
+* `src`: contains the Redis implementation, written in C.
+* `tests`: contains the unit tests, implemented in Tcl.
+* `deps`: contains libraries Redis uses. Everything needed to compile Redis is inside this directory, your system needs to provide just the `libc`, a POSIX compatible interface, and a C compiler. Notably `deps` contains a copy of `jemalloc`, which is the default allocator of Redis under Linux. Note that under `deps` there are also things which started with the Redis project, but for which the main repository is not `anitrez/redis`. an exception to this rule is `deps/geohash-int` which is the low level geocoding library used by Redis: it originated from a different project, but at this point it diverged so much that it is developed as a separated entity directly inside the Redis repository.
+
+There are a few more directories but they are not very important for our goals
+here. We'll focus mostly on `src`, where the Redis implementation is contained,
+exploring what there is inside each file. The order in which files are
+exposed is the logical one to follow in order to disclose different layers
+of complexity incrementally.
+
+Note: lately Redis was refactored quite a bit. Function names and file
+names changed, so you may find that this documentation reflects the
+`unstable` branch more closely. For instance in Redis 3.0 the `server.c`
+and `server.h` files were renamed `redis.c` and `redis.h`. However the overall
+structure is the same. Keep in mind that all the new developments and pull
+requests should be performed against the `unstable` branch.
+
+server.h
+---
+
+The simplest way to understand how a program works, is to understand the
+data structures it uses. So we'll start from the main header file of
+Redis, which is `server.h`.
+
+All the server configuration and in general all the shared state is
+defined in a global structure called `server`, of type `struct redisServer`.
+A few important fields in this structure:
+
+* `server.db` is an array of Redis databases, where data is stored.
+* `server.commands` is the command table.
+* `server.clients` is a linked list of clients connected to the server.
+* `server.master` is a special client, the master, if the instance is a slave.
+
+There are tons of other fields, most fields are commented directly inside
+the structure definition.
+
+Another important Redis data structure is the one defining a client.
+In the past it was called `redisClient`, now just `client`. The structure
+has many fields, here we'll show just the main ones:
+
+    struct client {
+        int fd;
+        sds querybuf;
+        int argc;
+        robj **argv;
+        redisDb *db;
+        int flags;
+        list *reply;
+        char buf[PROTO_REPLY_CHUNK_BYTES];
+        ... many other fields ...
+    }
+
+The client structure defines a *connected client*:
+
+* The `fd` field is the client socket file descriptor.
+* `argc` and `argv` are populated with the command the client is executing, so that functions implementing a given Redis command can read the arguments.
+* `querybuf` accumulates the requests from the client, which are parsed by the Redis server according to the Redis protocol, and executed calling the implementations of the commands the client is executing.
+* `reply` and `buf` are dynamic and static buffers that accumulate the replies the server sends to the client. These buffers are incrementally written to the socket as soon as the file descriptor is writable.
+
+As you can see in the client structure above, arguments in a command
+are described as `robj` structures. The following is the full `robj`
+structure, which defines a *Redis object*:
+
+    typedef struct redisObject {
+        unsigned type:4;
+        unsigned encoding:4;
+        unsigned lru:LRU_BITS; /* lru time (relative to server.lruclock) */
+        int refcount;
+        void *ptr;
+    } robj;
+
+Basically this structure can represent all the basic Redis data types like
+strings, lists, sets, sorted sets and so forth. The interesting thing is that
+it has a `type` field, so that it is possible to know what type a given
+object is, and a `refcount`, so that the same object can be referenced
+in multiple places without allocating it multiple times. Finally the `ptr`
+field points to the actual representation of the object, that may vary
+even for the same type, depending on the `encoding` used.
+
+Redis objects are used extensively in the Redis internals, however in order
+to avoid the overhead of indirect accesses, recently in many places
+we just use plain dynamic strings not wrapped inside a Redis object.
+
+sever.c
+---
+
+This is the entry point of the Redis server, where the `main()` function
+is defined. The following are the most important steps in order to startup
+the Redis server.
+
+* `initServerConfig()` setups the default values of the `server` structure.
+* `initServer()` allocates the data structures needed to operate, setup the listening socket, and so forth.
+* `aeMain()` enters the event loop listening for new connections.
+
+There are two special functions called periodically by the event loop:
+
+1. `serverCron()` is called periodically (according to `server.hz` frequency), and performs tasks that must be performed from time to time, like checking for timedout clients.
+2. `beforeSleep()` is called every time the event loop fired, Redis served a few requests, and is returning back into the event loop.
+
+Inside server.c you can find code that handles other vital things of the Redis server:
+
+* `call()` is used in order to call a given command in the context of a given client.
+* `activeExpireCycle()` handles eviciton of keys with a time to live set via the `EXPIRE` command.
+* `freeMemoryIfNeeded()` is called when a new write command should be performed but Redis is out of memory according to the `maxmemory` directive.
+* The global variable `redisCommandTable` defines all the Redis commands, specifying the name of the command, the function implementing the command, the number of arguments required, and other properties of each command.
+
+networking.c
+---
+
+This file defines all the I/O functions with clients, masters and slaves
+(which in Redis are just special clients):
+
+* `createClient()` allocates and initializes a new client.
+* the `addReply*()` family of functions are used by commands implementations in order to append data to the client structure, that will be transmitted to the client as a reply for a given command executed.
+* `writeToClient()` transmits the data pending in the output buffers to the client, and is called by the *writable event handler* `sendReplyToClient()`.
+* `readQueryFromClient()` is the *readable event handler* and accumulates data from read from the client into the query buffer.
+* `processInputBuffer()` is the entry point in order to parse the client query buffer according to the Redis protocol. Once commands are ready to be processed, it calls `processCommand()` which is defined inside `server.c` in order to actually execute the command.
+* `freeClient()` deallocates, disconnects and removes a client.
+
+aof.c and rdb.c
+---
+
+As you can guess from the names these files implement the RDB and AOF
+persistence for Redis. Redis uses a persistence model based on the `fork()`
+system call in order to create a thread with the same (shared) memory
+content of the main Redis thread. This secondary thread dumps the content
+of the memory on disk. This is used by `rdb.c` to create the snapshots
+on disk and by `aof.c` in order to perform the AOF rewrite when the
+append only file gets too big.
+
+The implementation inside `aof.c` has additional functions in order to
+implement an API that allows commands to append new commands into the AOF
+file as clients execute them.
+
+The `call()` function defined inside `server.c` is responsible to call
+the functions that in turn will write the commands into the AOF.
+
+db.c
+---
+
+Certain Redis commands operate on specific data types, others are general.
+Examples of generic commands are `DEL` and `EXPIRE`. They operate on keys
+and not on their values specifically. All those generic commands are
+defined inside `db.c`.
+
+Moreover `db.c` implements an API in order to perform certain operations
+on the Redis dataset without directly accessing the internal data structures.
+
+The most important functions inside `db.c` which are used in many commands
+implementations are the following:
+
+* `lookupKeyRead()` and `lookupKeyWrite()` are used in order to get a pointer to the value associated to a given key, or `NULL` if the key does not exist.
+* `dbAdd()` and its higher level counterpart `setKey()` create a new key in a Redis database.
+* `dbDelete()` removes a key and its associated value.
+* `emptyDb()` removes an entire single database or all the databases defined.
+
+The rest of the file implements the generic commands exposed to the client.
+
+object.c
+---
+
+The `robj` structure defining Redis objects was already described. Inside
+`object.c` there are all the functions that operate with Redis objects at
+a basic level, like functions to allocate new objects, handle the reference
+counting and so forth. Notable functions inside this file:
+
+* `incrRefcount()` and `decrRefCount()` are used in order to increment or decrement an object reference count. When it drops to 0 the object is finally freed.
+* `createObject()` allocates a new object. There are also specialized functions to allocate string objects having a specific content, like `createStringObjectFromLongLong()` and similar functions.
+
+This file also implements the `OBJECT` command.
+
+replication.c
+---
+
+This is one of the most complex files inside Redis, it is recommended to
+approach it only after getting a bit familiar with the rest of the code base.
+In this file there is the implementation of both the master and slave role
+of Redis.
+
+One of the most important functions inside this file is `replicationFeedSlaves()` that writes commands to the clients representing slave instances connected
+to our master, so that the slaves can get the writes performed by the clients:
+this way their data set will remain synchronized with the one in the master.
+
+This file also implements both the `SYNC` and `PSYNC` commands that are
+used in order to perform the first synchronization between masters and
+slaves, or to continue the replication after a disconnection.
+
+Other C files
+---
+
+* `t_hash.c`, `t_list.c`, `t_set.c`, `t_string.c` and `t_zset.c` contains the implementation of the Redis data types. They implement both an API to access a given data type, and the client commands implementations for these data types.
+* `ae.c` implements the Redis event loop, it's a self contained library which is simple to read and understand.
+* `sds.c` is the Redis string library, check http://github.com/antirez/sds for more information.
+* `anet.c` is a library to use POSIX networking in a simpler way compared to the raw interface exposed by the kernel.
+* `dict.c` is an implementation of a non-blocking hash table which rehashes incrementally.
+* `scripting.c` implements Lua scripting. It is completely self contained from the rest of the Redis implementation and is simple enough to understand if you are familar with the Lua API.
+* `cluster.c` implements the Redis Cluster. Probably a good read only after being very familiar with the rest of the Redis code base. If you want to read `cluster.c` make sure to read the [Redis Cluster specification][3].
+
+[3]: http://redis.io/topics/cluster-spec
+
+Anatomy of a Redis command
+---
+
+All the Redis commands are defined in the following way:
+
+    void foobarCommand(client *c) {
+        printf("%s",c->argv[1]->ptr); /* Do something with the argument. */
+        addReply(c,shared.ok); /* Reply something to the client. */
+    }
+
+The command is then referenced inside `server.c` in the command table:
+
+    {"foobar",foobarCommand,2,"rtF",0,NULL,0,0,0,0,0},
+
+In the above example `2` is the number of arguments the command takes,
+while `"rtF"` are the command flags, as documented in the command table
+top comment inside `server.c`.
+
+After the command operates in some way, it returns a reply to the client,
+usually using `addReply()` or a similar function defined inside `networking.c`.
+
+There are tons of commands implementations inside th Redis source code
+that can serve as examples of actual commands implementations. To write
+a few toy commands can be a good exercise to familiarize with the code base.
+
+There are also many other files not described here,  but it is useless to
+cover everything, we want just to help you with the first steps,
+eventually you'll find your way inside the Redis code base :-)
+
+Enjoy!
+

--- a/redis.conf
+++ b/redis.conf
@@ -35,6 +35,14 @@
 # include /path/to/local.conf
 # include /path/to/other.conf
 
+################################## MODULES #####################################
+
+# Load modules at startup. If the server is not able to load modules
+# it will abort. It is possible to use multiple loadmodule directives.
+#
+# loadmodule /path/to/my_module.so
+# loadmodule /path/to/other_module.so
+
 ################################## NETWORK #####################################
 
 # By default, if no "bind" configuration directive is specified, Redis listens
@@ -60,9 +68,28 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 bind 127.0.0.1
 
+# Protected mode is a layer of security protection, in order to avoid that
+# Redis instances left open on the internet are accessed and exploited.
+#
+# When protected mode is on and if:
+#
+# 1) The server is not binding explicitly to a set of addresses using the
+#    "bind" directive.
+# 2) No password is configured.
+#
+# The server only accepts connections from clients connecting from the
+# IPv4 and IPv6 loopback addresses 127.0.0.1 and ::1, and from Unix domain
+# sockets.
+#
+# By default protected mode is enabled. You should disable it only if
+# you are sure you want clients from other hosts to connect to Redis
+# even if no authentication is configured, nor a specific set of interfaces
+# are explicitly listed using the "bind" directive.
+protected-mode yes
+
 # Accept connections on the specified port, default is 6379 (IANA #815344).
 # If port 0 is specified Redis will not listen on a TCP socket.
-port 6379
+port 12345
 
 # TCP listen() backlog.
 #
@@ -449,7 +476,7 @@ slave-priority 100
 # Please note that changing the name of commands that are logged into the
 # AOF file or transmitted to slaves may cause problems.
 
-################################### LIMITS ####################################
+################################### CLIENTS ####################################
 
 # Set the max number of connected clients at the same time. By default
 # this limit is set to 10000 clients, however if the Redis server is not
@@ -461,6 +488,8 @@ slave-priority 100
 # an error 'max number of clients reached'.
 #
 # maxclients 10000
+
+############################## MEMORY MANAGEMENT ################################
 
 # Don't use more memory than the specified amount of bytes.
 # When the memory limit is reached Redis will try to remove keys
@@ -520,6 +549,55 @@ slave-priority 100
 # true LRU but costs a bit more CPU. 3 is very fast but not very accurate.
 #
 # maxmemory-samples 5
+
+############################# LAZY FREEING ####################################
+
+# Redis has two primitives to delete keys. One is called DEL and is a blocking
+# deletion of the object. It means that the server stops processing new commands
+# in order to reclaim all the memory associated with an object in a synchronous
+# way. If the key deleted is associated with a small object, the time needed
+# in order to execute th DEL command is very small and comparable to most other
+# O(1) or O(log_N) commands in Redis. However if the key is associated with an
+# aggregated value containing millions of elements, the server can block for
+# a long time (even seconds) in order to complete the operation.
+#
+# For the above reasons Redis also offers non blocking deletion primitives
+# such as UNLINK (non blocking DEL) and the ASYNC option of FLUSHALL and
+# FLUSHDB commands, in order to reclaim memory in background. Those commands
+# are executed in constant time. Another thread will incrementally free the
+# object in the background as fast as possible.
+#
+# DEL, UNLINK and ASYNC option of FLUSHALL and FLUSHDB are user-controlled.
+# It's up to the design of the application to understand when it is a good
+# idea to use one or the other. However the Redis server sometimes has to
+# delete keys or flush the whole database as a side effect of other operations.
+# Specifically Redis deletes objects independently of an user call in the
+# following scenarios:
+#
+# 1) On eviction, because of the maxmemory and maxmemory policy configurations,
+#    in order to make room for new data, without going over the specified
+#    memory limit.
+# 2) Because of expire: when a key with an associated time to live (see the
+#    EXPIRE command) must be deleted from memory.
+# 3) Because of a side effect of a command that stores data on a key that may
+#    already exist. For example the RENAME command may delete the old key
+#    content when it is replaced with another one. Similarly SUNIONSTORE
+#    or SORT with STORE option may delete existing keys. The SET command
+#    itself removes any old content of the specified key in order to replace
+#    it with the specified string.
+# 4) During replication, when a slave performs a full resynchronization with
+#    its master, the content of the whole database is removed in order to
+#    load the RDB file just transfered.
+#
+# In all the above cases the default is to delete objects in a blocking way,
+# like if DEL was called. However you can configure each case specifically
+# in order to instead release memory in a non-blocking way like if UNLINK
+# was called, using the following configuration directives:
+
+lazyfree-lazy-eviction no
+lazyfree-lazy-expire no
+lazyfree-lazy-server-del no
+slave-lazy-flush no
 
 ############################## APPEND ONLY MODE ###############################
 
@@ -764,6 +842,39 @@ lua-time-limit 5000
 
 # In order to setup your cluster make sure to read the documentation
 # available at http://redis.io web site.
+
+########################## CLUSTER DOCKER/NAT support  ########################
+
+# In certain deployments, Redis Cluster nodes address discovery fails, because
+# addresses are NAT-ted or because ports are forwarded (the typical case is
+# Docker and other containers).
+#
+# In order to make Redis Cluster working in such environments, a static
+# configuration where each node known its public address is needed. The
+# following two options are used for this scope, and are:
+#
+# * cluster-announce-ip
+# * cluster-announce-port
+# * cluster-announce-bus-port
+#
+# Each instruct the node about its address, client port, and cluster message
+# bus port. The information is then published in the header of the bus packets
+# so that other nodes will be able to correctly map the address of the node
+# publishing the information.
+#
+# If the above options are not used, the normal Redis Cluster auto-detection
+# will be used instead.
+#
+# Note that when remapped, the bus port may not be at the fixed offset of
+# clients port + 10000, so you can specify any port and bus-port depending
+# on how they get remapped. If the bus-port is not set, a fixed offset of
+# 10000 will be used as usually.
+#
+# Example:
+#
+# cluster-announce-ip 10.1.1.5
+# cluster-announce-port 6379
+# cluster-announce-bus-port 6380
 
 ################################## SLOW LOG ###################################
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -117,7 +117,7 @@ endif
 
 REDIS_SERVER_NAME=redis-server
 REDIS_SENTINEL_NAME=redis-sentinel
-REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o geo.o
+REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_iset.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o geo.o
 REDIS_GEOHASH_OBJ=../deps/geohash-int/geohash.o ../deps/geohash-int/geohash_helper.o
 REDIS_CLI_NAME=redis-cli
 REDIS_CLI_OBJ=anet.o adlist.o redis-cli.o zmalloc.o release.o anet.o ae.o crc64.o

--- a/src/aof.c
+++ b/src/aof.c
@@ -916,6 +916,42 @@ int rewriteSortedSetObject(rio *r, robj *key, robj *o) {
     return 1;
 }
 
+
+/* Emit the commands needed to rebuild an interval set object.
+* The function returns 0 on error, 1 on success. */
+int rewriteIntervalSetObject(rio *r, robj *key, robj *o) {
+     long long count = 0, items = isetLength(o);
+ 
+     if (o->encoding == OBJ_ENCODING_AVLTREE) {
+         dictIterator *di = dictGetIterator(((avl *) o->ptr)->dict);
+         dictEntry *de;
+ 
+         while((de = dictNext(di)) != NULL) {
+             robj *eleobj = dictGetKey(de);
+             double **scores = dictGetVal(de);
+ 
+             if (count == 0) {
+                 int cmd_items = (items > AOF_REWRITE_ITEMS_PER_CMD) ?
+                     AOF_REWRITE_ITEMS_PER_CMD : items;
+ 
+                 if (rioWriteBulkCount(r,'*',2+cmd_items*3) == 0) return 0;
+                 if (rioWriteBulkString(r,"IADD",4) == 0) return 0;
+                 if (rioWriteBulkObject(r,key) == 0) return 0;
+             }
+             if (rioWriteBulkDouble(r,(*scores)[0]) == 0) return 0;
+             if (rioWriteBulkDouble(r,(*scores)[1]) == 0) return 0;
+             if (rioWriteBulkObject(r,eleobj) == 0) return 0;
+             if (++count == AOF_REWRITE_ITEMS_PER_CMD) count = 0;
+             items--;
+         }
+         dictReleaseIterator(di);
+     } else {
+         serverPanic("Unknown interval set encoding");
+     }
+     return 1;
+}
+
+
 /* Write either the key or the value of the currently selected item of a hash.
  * The 'hi' argument passes a valid Redis hash iterator.
  * The 'what' filed specifies if to write a key or a value and can be
@@ -1066,6 +1102,8 @@ int rewriteAppendOnlyFile(char *filename) {
                 if (rewriteSortedSetObject(&aof,&key,o) == 0) goto werr;
             } else if (o->type == OBJ_HASH) {
                 if (rewriteHashObject(&aof,&key,o) == 0) goto werr;
+            } else if (o->type == OBJ_ISET) {
+                if (rewriteIntervalSetObject(&aof,&key,o) == 0) goto werr;                 
             } else {
                 serverPanic("Unknown object type");
             }

--- a/src/object.c
+++ b/src/object.c
@@ -188,6 +188,14 @@ robj *createQuicklistObject(void) {
     return o;
 }
 
+robj *createIsetObject(void) {
+    avl *a = avlCreate();
+    robj *o = createObject(OBJ_ISET,a);
+    o->encoding = OBJ_ENCODING_AVLTREE;
+    return o;
+}
+
+
 robj *createZiplistObject(void) {
     unsigned char *zl = ziplistNew();
     robj *o = createObject(OBJ_LIST,zl);
@@ -280,6 +288,10 @@ void freeZsetObject(robj *o) {
     }
 }
 
+void freeIsetObject(robj *o) {
+    avlFree(o->ptr);
+}
+
 void freeHashObject(robj *o) {
     switch (o->encoding) {
     case OBJ_ENCODING_HT:
@@ -307,6 +319,7 @@ void decrRefCount(robj *o) {
         case OBJ_SET: freeSetObject(o); break;
         case OBJ_ZSET: freeZsetObject(o); break;
         case OBJ_HASH: freeHashObject(o); break;
+        case OBJ_ISET: freeIsetObject(o); break;         
         default: serverPanic("Unknown object type"); break;
         }
         zfree(o);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -526,6 +526,9 @@ int rdbSaveObjectType(rio *rdb, robj *o) {
             return rdbSaveType(rdb,RDB_TYPE_HASH);
         else
             serverPanic("Unknown hash encoding");
+    case OBJ_ISET:
+        if (o->encoding == OBJ_ENCODING_AVLTREE)
+            return rdbSaveType(rdb,RDB_TYPE_ISET);
     default:
         serverPanic("Unknown object type");
     }
@@ -653,6 +656,27 @@ ssize_t rdbSaveObject(rio *rdb, robj *o) {
         } else {
             serverPanic("Unknown hash encoding");
         }
+    } else if (o->type == OBJ_ISET) {
+        /* Save an AVL tree */
+        avl * tree = o->ptr;
+        dictIterator *di = dictGetIterator(tree->dict);
+        dictEntry *de;
+        
+        if ((n = rdbSaveLen(rdb,dictSize(tree->dict))) == -1) return -1;
+        nwritten += n;
+        
+        while((de = dictNext(di)) != NULL) {
+            robj *eleobj = dictGetKey(de);
+            double *scores = dictGetVal(de);
+            
+            if ((n = rdbSaveStringObject(rdb,eleobj)) == -1) return -1;
+            nwritten += n;
+            if ((n = rdbSaveDoubleValue(rdb,scores[0])) == -1) return -1;
+            nwritten += n;
+            if ((n = rdbSaveDoubleValue(rdb,scores[1])) == -1) return -1;
+            nwritten += n;
+        }
+        dictReleaseIterator(di);        
 
     } else {
         serverPanic("Unknown object type");
@@ -1095,6 +1119,42 @@ robj *rdbLoadObject(int rdbtype, rio *rdb) {
 
         /* All pairs should be read by now */
         serverAssert(len == 0);
+        
+     } else if (rdbtype == RDB_TYPE_ISET) {
+         /* Read list/set value */
+         
+         size_t isetlen;
+         avl * tree;
+         size_t maxelelen = 0;
+         
+         if ((isetlen = rdbLoadLen(rdb,NULL)) == RDB_LENERR) return NULL;
+         o = createIsetObject();
+         tree = o->ptr;
+         
+         /* Load every single element of the list/set */
+         while(isetlen--) {
+             robj *ele;
+             double score1;
+             double score2;
+             
+             avlNode *inode;
+             
+             if ((ele = rdbLoadEncodedStringObject(rdb)) == NULL) return NULL;
+             ele = tryObjectEncoding(ele);
+             if (rdbLoadDoubleValue(rdb,&score1) == -1) return NULL;
+             if (rdbLoadDoubleValue(rdb,&score2) == -1) return NULL;
+             
+             /* Don't care about integer-encoded strings. */
+             if (ele->encoding == RDB_LOAD_PLAIN &&
+                 sdslen(ele->ptr) > maxelelen)
+                 maxelelen = sdslen(ele->ptr);
+             
+             inode = avlInsert(tree, score1, score2, ele);
+             dictAdd(tree->dict,ele,&inode->scores);
+             incrRefCount(ele); /* Added to dictionary. */
+        }
+        
+        
     } else if (rdbtype == RDB_TYPE_LIST_QUICKLIST) {
         if ((len = rdbLoadLen(rdb,NULL)) == RDB_LENERR) return NULL;
         o = createQuicklistObject();

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -74,6 +74,8 @@
 #define RDB_TYPE_SET    2
 #define RDB_TYPE_ZSET   3
 #define RDB_TYPE_HASH   4
+#define RDB_TYPE_ISET   5
+
 /* NOTE: WHEN ADDING NEW RDB TYPE, UPDATE rdbIsObjectType() BELOW */
 
 /* Object types for encoded objects. */

--- a/src/server.c
+++ b/src/server.c
@@ -171,6 +171,10 @@ struct redisCommand redisCommandTable[] = {
     {"sdiff",sdiffCommand,-2,"rS",0,NULL,1,-1,1,0,0},
     {"sdiffstore",sdiffstoreCommand,-3,"wm",0,NULL,1,-1,1,0,0},
     {"smembers",sinterCommand,2,"rS",0,NULL,1,1,1,0,0},
+    {"iadd",iaddCommand,-5,"wm",0,NULL,1,1,1,0,0},
+    {"irem",iremCommand,-3,"w",0,NULL,1,1,1,0,0},
+    {"irembystab",irembystabCommand,3,"w",0,NULL,1,1,1,0,0},
+    {"istab",istabCommand,-3,"r",0,NULL,1,1,1,0,0},      
     {"sscan",sscanCommand,-3,"rR",0,NULL,1,1,1,0,0},
     {"zadd",zaddCommand,-4,"wmF",0,NULL,1,1,1,0,0},
     {"zincrby",zincrbyCommand,4,"wmF",0,NULL,1,1,1,0,0},
@@ -549,6 +553,18 @@ dictType zsetDictType = {
     dictObjectDestructor, /* key destructor */
     NULL                       /* val destructor */
 };
+
+/* Interval sets hash (node: an avl tree is used in addition to the hash table) */
+dictType isetDictType = {
+    dictEncObjHash, /* hash function */
+    NULL, /* key dup */
+    NULL, /* val dup */
+    dictEncObjKeyCompare, /* key compare */
+    dictObjectDestructor, /* key destructor */
+    NULL /* val destructor */
+};
+
+
 
 /* Db->dict, keys are sds strings, vals are Redis objects. */
 dictType dbDictType = {

--- a/src/t_iset.c
+++ b/src/t_iset.c
@@ -1,0 +1,923 @@
+#include "server.h"
+
+#include <math.h>
+
+/*-----------------------------------------------------------------------------
+ * Interval set API
+ *----------------------------------------------------------------------------*/
+
+/* ISETs are sets using two data structures to hold the same elements
+ * in order to get O(log(N)) INSERT and REMOVE operations into an interval
+ * range data structure.
+ *
+ * The elements are added to an hash table mapping Redis objects to intervals.
+ * At the same time the elements are added to an augmented AVL tree that maps
+ * intervals to Redis objects. */
+
+
+avl *avlCreate(void) {
+    avl *avltree;
+
+    avltree = zmalloc(sizeof(*avltree));
+    avltree->size = 0;
+    avltree->root = NULL;
+
+    avltree->dict = dictCreate(&isetDictType,NULL);
+
+    return avltree;
+}
+
+avlNode *avlCreateNode(double lscore, double rscore, robj *obj) {
+    avlNode *an = zmalloc(sizeof(*an));
+    an->scores[0] = lscore;
+    an->scores[1] = rscore;
+    an->subLeftMax = -INFINITY;
+    an->subRightMax = -INFINITY;
+    an->balance = 0;
+    an->left = NULL;
+    an->right = NULL;
+    an->parent = NULL;
+    an->next = NULL;
+    an->obj = obj;
+
+    if (obj)
+        incrRefCount(obj);
+
+    return an;
+}
+
+void avlFreeNode(avlNode *node, int eraseList) {
+    if (eraseList && node->next)
+        avlFreeNode(node->next, eraseList);
+    if (node->obj)
+        decrRefCount(node->obj);
+    if (node->left)
+        avlFreeNode(node->left, eraseList);
+    if (node->right)
+        avlFreeNode(node->right, eraseList);
+    zfree(node);
+}
+
+void avlFree(avl *tree) {
+    if (tree->root != NULL)
+        avlFreeNode(tree->root,1);
+    dictRelease(tree->dict);
+    zfree(tree);
+}
+
+int avlNodeCmp(avlNode *a, avlNode *b) {
+    if (a->scores[0] < b->scores[0])
+        return -1;
+    else if (a->scores[0] > b->scores[0])
+        return 1;
+    else {
+        if (a->scores[1] > b->scores[1])
+            return -1;
+        else if (a->scores[1] < b->scores[1])
+            return 1;
+        else
+            return 0;
+    }
+}
+
+void avlLeftRotation(avl * tree, avlNode *locNode) {
+    avlNode *newRoot = locNode->right;
+    locNode->right = newRoot->left;
+    if (locNode->right) locNode->right->parent = locNode;
+    newRoot->left = locNode;
+
+    newRoot->parent = locNode->parent;
+    locNode->parent = newRoot;
+    if (newRoot->parent) {
+        if (avlNodeCmp(newRoot->parent,newRoot) > -1)
+            newRoot->parent->left = newRoot;
+        else
+            newRoot->parent->right = newRoot;
+    }
+    // New root
+    else {
+        tree->root = newRoot;
+    }
+}
+
+void avlRightRotation(avl * tree, avlNode *locNode) {
+    avlNode *newRoot = locNode->left;
+    locNode->left = newRoot->right;
+    if (locNode->left) locNode->left->parent = locNode;
+    newRoot->right = locNode;
+
+    newRoot->parent = locNode->parent;
+    locNode->parent = newRoot;
+    if (newRoot->parent) {
+        if(avlNodeCmp(newRoot->parent,newRoot) > -1)
+            newRoot->parent->left = newRoot;
+        else
+            newRoot->parent->right = newRoot;
+    }
+    // New root
+    else {
+        tree->root = newRoot;
+    }
+}
+
+void avlResetBalance(avlNode *locNode) {
+    switch(locNode->balance) {
+        case -1:
+        locNode->left->balance = 0;
+        locNode->right->balance = 1;
+        break;
+        case 0:
+        locNode->left->balance = 0;
+        locNode->right->balance = 0;
+        break;
+        case 1:
+        locNode->left->balance = -1;
+        locNode->right->balance = 0;
+        break;
+    }
+    locNode->balance = 0;
+}
+
+void avlUpdateMaxScores(avlNode *locNode) {
+    double oldNodeMax;
+
+    while (locNode) {
+        if (locNode->left) {
+            oldNodeMax = locNode->left->scores[1];
+            oldNodeMax = (oldNodeMax > locNode->left->subLeftMax) ? oldNodeMax : locNode->left->subLeftMax;
+            oldNodeMax = (oldNodeMax > locNode->left->subRightMax) ? oldNodeMax : locNode->left->subRightMax;
+            locNode->subLeftMax = oldNodeMax;
+        }
+        else {
+            locNode->subLeftMax = -INFINITY;
+        }
+        if (locNode->right) {
+            oldNodeMax = locNode->right->scores[1];
+            oldNodeMax = (oldNodeMax > locNode->right->subLeftMax) ? oldNodeMax : locNode->right->subLeftMax;
+            oldNodeMax = (oldNodeMax > locNode->right->subRightMax) ? oldNodeMax : locNode->right->subRightMax;
+            locNode->subRightMax = oldNodeMax;
+        }
+        else {
+            locNode->subRightMax = -INFINITY;
+        }
+        locNode = locNode->parent;
+    }
+}
+
+int avlInsertNode(avl * tree, avlNode *locNode, avlNode *insertNode) {
+    int diff = avlNodeCmp(locNode, insertNode);
+
+    /* Insert in the left node */
+    if (diff > 0) {
+        if (!locNode->left) {
+            locNode->left = insertNode;
+            insertNode->parent = locNode;
+            locNode->balance = locNode->balance - 1;
+            avlUpdateMaxScores(locNode);
+            return locNode->balance ? 1 : 0;
+        }
+        else {
+            // Left node is occupied, insert it into the subtree
+            if (avlInsertNode(tree,locNode->left,insertNode)) {
+                locNode->balance = locNode->balance - 1;
+                if (locNode->balance == 0)
+                    return 0;
+                else if (locNode->balance == -1)
+                    return 1;
+
+                // Tree is unbalanced at this point
+                // Case 1 at http://www.stanford.edu/~blp/avl/libavl.html/Rebalancing-AVL-Trees.html#index-rebalance-after-AVL-insertion-236
+                if (locNode->left->balance < 0) {
+                    // Left-Left, single right rotation needed
+                    avlRightRotation(tree,locNode);
+
+                    //Both locNode and its parent have a zero balance; see note at the link above
+                    locNode->balance = 0;
+                    locNode->parent->balance = 0;
+
+                    locNode->subLeftMax = locNode->parent->subRightMax;
+                    //XXX: What is this, I don't even?
+                    //     locNode->parent->subRightMax should be the max of the subtree
+                    //     *rooted at locNode*, right?
+                    locNode->parent->subRightMax = -INFINITY;
+                }
+                else {
+                    // Left-Right, left rotation then right rotation needed
+                    avlLeftRotation(tree,locNode->left);
+                    avlRightRotation(tree,locNode);
+                    avlResetBalance(locNode->parent);
+
+                    locNode->subLeftMax = locNode->parent->subRightMax;
+                    locNode->parent->left->subRightMax = locNode->parent->subLeftMax;
+                    locNode->parent->subRightMax = -INFINITY;
+                    locNode->parent->subLeftMax = -INFINITY;
+                }
+
+                avlUpdateMaxScores(locNode->parent);
+            }
+            return 0;
+        }
+    }
+    /* Insert in the right node */
+    else if (diff < 0) {
+        if (!locNode->right) {
+            locNode->right = insertNode;
+            insertNode->parent = locNode;
+            locNode->balance = locNode->balance + 1;
+            avlUpdateMaxScores(locNode);
+            return locNode->balance ? 1 : 0;
+        }
+        else {
+            // Right node is occupied, insert it into the subtree
+            if (avlInsertNode(tree,locNode->right,insertNode)) {
+                locNode->balance = locNode->balance + 1;
+                if (locNode->balance == 0)
+                    return 0;
+                else if (locNode->balance == 1)
+                    return 1;
+
+                // Tree is unbalanced at this point
+                if (locNode->right->balance > 0) {
+                    // Right-Right, single left rotation needed
+                    avlLeftRotation(tree,locNode);
+
+                    locNode->balance = 0;
+                    locNode->parent->balance = 0;
+
+                    locNode->subRightMax = locNode->parent->subLeftMax;
+                    locNode->parent->subLeftMax = -INFINITY;
+                }
+                else {
+                    // Right-Left, right rotation then left rotation needed
+                    avlRightRotation(tree,locNode->right);
+                    avlLeftRotation(tree,locNode);
+                    avlResetBalance(locNode->parent);
+
+                    locNode->subRightMax = locNode->parent->subLeftMax;
+                    locNode->parent->right->subLeftMax = locNode->parent->subRightMax;
+                    locNode->parent->subRightMax = -INFINITY;
+                    locNode->parent->subLeftMax = -INFINITY;
+                }
+
+                avlUpdateMaxScores(locNode->parent);
+            }
+            return 0;
+        }
+    }
+    // These nodes have the same range. We're going to assume that the robj hasn't been
+    // added before to this range, as the caller to avlInsert should check this
+    else {
+        avlNode * tail = locNode;
+        while (tail->next != NULL)
+            tail = tail->next;
+        tail->next = insertNode;
+        return 0;
+    }
+}
+
+avlNode *avlInsert(avl *tree, double lscore, double rscore, robj *obj) {
+    avlNode *an = avlCreateNode(lscore, rscore, obj);
+
+    if (!tree->root)
+        tree->root = an;
+    else
+        avlInsertNode(tree, tree->root, an);
+
+    tree->size = tree->size + 1;
+
+    return an;
+}
+
+void avlRemoveFromParent(avl * tree, avlNode *locNode, avlNode *replacementNode) {
+    if (locNode->parent) {
+        if (locNode->parent->left == locNode)
+            locNode->parent->left = replacementNode;
+        else
+            locNode->parent->right = replacementNode;
+    }
+    else {
+        tree->root = replacementNode;
+    }
+}
+
+int avlRemoveNode(avl * tree, avlNode *locNode, avlNode *delNode, char freeNodeMem, int * removed) {
+    int diff = avlNodeCmp(locNode, delNode);
+    int heightDelta;
+    avlNode *replacementNode;
+
+    // This is the node we want removed
+    if (diff == 0) {
+        // First check to see if there are more than one element being stored here.
+        // If so, find the element, remove it, and update the pointers appropriately.
+        // If not, we can assume that this element is the one desired to be removed,
+        // as the caller to avlRemoveNode should check the dict first to ensure the
+        // obj exists at this point
+        if (locNode->next && freeNodeMem) {
+            avlNode *removeNode = locNode;
+            avlNode *prevNode = NULL;
+
+            // Find the node where the node obj data matches the delNode obj data
+            while (sdscmp(removeNode->obj->ptr,delNode->obj->ptr) != 0) {
+                prevNode = removeNode;
+                removeNode = removeNode->next;
+            }
+            // If the node to be removed is the head, we need to update the locNode
+            if (removeNode == locNode) {
+                locNode->next->parent = locNode->parent;
+                locNode->next->left = locNode->left;
+                locNode->next->right = locNode->right;
+                locNode->next->balance = locNode->balance;
+                locNode->next->subLeftMax = locNode->subLeftMax;
+                locNode->next->subRightMax = locNode->subRightMax;
+
+                // Update the parent and children
+                avlRemoveFromParent(tree,locNode,locNode->next);
+                if (locNode->left)
+                    locNode->left->parent = locNode->next;
+                if (locNode->right)
+                    locNode->right->parent = locNode->next;
+
+                locNode->right = NULL;
+                locNode->left = NULL;
+                avlFreeNode(locNode,0);
+                *removed = 1;
+                return 0;
+            }
+            else {
+                prevNode->next = removeNode->next;
+                avlFreeNode(removeNode,0);
+                *removed = 1;
+                return 0;
+            }
+        }
+        else {
+            // Remove if leaf node or replace with child if only one child
+            if (!locNode->left) {
+                if (!locNode->right) {
+                    avlRemoveFromParent(tree,locNode,NULL);
+                    if (locNode->parent)
+                        avlUpdateMaxScores(locNode->parent);
+                    if (freeNodeMem)
+                        avlFreeNode(locNode,0);
+                    *removed = 1;
+                    return -1;
+                }
+                avlRemoveFromParent(tree,locNode,locNode->right);
+                locNode->right->parent = locNode->parent;
+                if (locNode->parent)
+                    avlUpdateMaxScores(locNode->parent);
+                locNode->right = NULL;
+                if (freeNodeMem)
+                    avlFreeNode(locNode,0);
+                *removed = 1;
+                return -1;
+            }
+            if (!locNode->right) {
+                avlRemoveFromParent(tree,locNode,locNode->left);
+                locNode->left->parent = locNode->parent;
+                if (locNode->parent)
+                    avlUpdateMaxScores(locNode->parent);
+                locNode->left = NULL;
+                if (freeNodeMem)
+                    avlFreeNode(locNode,0);
+                *removed = 1;
+                return -1;
+            }
+
+            // If two children, replace from subtree
+            if (locNode->balance < 0) {
+                // Replace with the node's in-order predecessor
+                replacementNode = locNode->left;
+                while (replacementNode->right)
+                    replacementNode = replacementNode->right;
+            }
+            else {
+                // Replace with the node's in-order successor
+                replacementNode = locNode->right;
+                while (replacementNode->left)
+                    replacementNode = replacementNode->left;
+            }
+
+            // Remove the replacementNode from the tree
+            heightDelta = avlRemoveNode(tree, locNode,replacementNode,0,removed);
+
+            //if the replacement node is a direct child of locNode,
+            //don't set it up to point to itself
+            if (locNode->right) locNode->right->parent = replacementNode;
+            if (locNode->left)  locNode->left->parent = replacementNode;
+
+            replacementNode->left = locNode->left;
+            replacementNode->right = locNode->right;
+            replacementNode->parent = locNode->parent;
+            replacementNode->balance = locNode->balance;
+
+            //Now replace the tree's root with replacementNode if it's the root
+            //otherwise place the replacement under the parent
+            if (locNode == tree->root) {
+                tree->root = replacementNode;
+
+                avlUpdateMaxScores(replacementNode);
+            }
+            else {
+                if (locNode == locNode->parent->left)
+                    locNode->parent->left = replacementNode;
+                else
+                    locNode->parent->right = replacementNode;
+
+                avlUpdateMaxScores(replacementNode);
+            }
+
+            locNode->left = NULL;
+            locNode->right = NULL;
+            if (freeNodeMem)
+                avlFreeNode(locNode,0);
+
+            if (replacementNode->balance == 0)
+                return heightDelta;
+
+            *removed = 1;
+
+            return 0;
+        }
+    }
+
+    // The node is in the left subtree
+    else if (diff > 0) {
+        if (locNode->left) {
+            heightDelta = avlRemoveNode(tree, locNode->left,delNode,freeNodeMem,removed);
+            if (heightDelta) {
+                locNode->balance = locNode->balance + 1;
+                if (locNode->balance == 0)
+                    return -1;
+                else if (locNode->balance == 1)
+                    return 0;
+
+                if (locNode->right->balance == 1) {
+                    avlLeftRotation(tree,locNode);
+                    locNode->parent->balance = 0;
+                    locNode->parent->left->balance = 0;
+
+                    locNode->subRightMax = locNode->parent->subLeftMax;
+                    locNode->parent->subLeftMax = -INFINITY;
+                    avlUpdateMaxScores(locNode->parent);
+
+                    return -1;
+                }
+                else if (locNode->right->balance == 0){
+                    avlLeftRotation(tree,locNode);
+                    locNode->parent->balance = -1;
+                    locNode->parent->left->balance = 1;
+
+                    locNode->subRightMax = locNode->parent->subLeftMax;
+                    locNode->parent->subLeftMax = -INFINITY;
+                    avlUpdateMaxScores(locNode->parent);
+
+                    return 0;
+                }
+                avlRightRotation(tree,locNode->right);
+                avlLeftRotation(tree,locNode);
+                avlResetBalance(locNode->parent);
+
+                locNode->subRightMax = locNode->parent->subLeftMax;
+                locNode->parent->right->subLeftMax = locNode->parent->subRightMax;
+                locNode->parent->subRightMax = -INFINITY;
+                locNode->parent->subLeftMax = -INFINITY;
+
+                avlUpdateMaxScores(locNode->parent);
+
+                return -1;
+            }
+        }
+    }
+
+    // The node is in the right subtree
+    else if (diff < 0) {
+        if (locNode->right) {
+            heightDelta = avlRemoveNode(tree, locNode->right,delNode,freeNodeMem,removed);
+            if (heightDelta) {
+                locNode->balance = locNode->balance - 1;
+                if (locNode->balance == 0)
+                    return 1;
+                else if (locNode->balance == -1)
+                    return 0;
+
+                if (locNode->left->balance == -1) {
+                    avlRightRotation(tree,locNode);
+                    locNode->parent->balance = 0;
+                    locNode->parent->right->balance = 0;
+
+                    locNode->subLeftMax = locNode->parent->subRightMax;
+                    locNode->parent->subRightMax = -INFINITY;
+                    avlUpdateMaxScores(locNode->parent);
+
+                    return -1;
+                }
+                else if (locNode->left->balance == 0){
+                    avlRightRotation(tree,locNode);
+                    locNode->parent->balance = 1;
+                    locNode->parent->right->balance = -1;
+
+                    locNode->subLeftMax = locNode->parent->subRightMax;
+                    locNode->parent->subRightMax = -INFINITY;
+                    avlUpdateMaxScores(locNode->parent);
+
+                    return 0;
+                }
+                avlLeftRotation(tree,locNode->left);
+                avlRightRotation(tree,locNode);
+                avlResetBalance(locNode->parent);
+
+                locNode->subLeftMax = locNode->parent->subRightMax;
+                locNode->parent->left->subRightMax = locNode->parent->subLeftMax;
+
+                locNode->parent->subRightMax = -INFINITY;
+                locNode->parent->subLeftMax = -INFINITY;
+                avlUpdateMaxScores(locNode->parent);
+
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+int avlRemove(avl *tree, double lscore, double rscore, robj * obj) {
+    int removed = 0;
+
+    if (!tree->root)
+        return 0;
+
+    avlNode *delNode = avlCreateNode(lscore, rscore, obj);
+    avlRemoveNode(tree, tree->root, delNode, 1, &removed);
+    avlFreeNode(delNode,0);
+
+    if (removed)
+        tree->size = tree->size - 1;
+
+    if (tree->size == 0)
+        tree->root = NULL;
+
+    return removed;
+}
+
+long long isetLength(robj *obj) {
+    return ((avl *) obj)->size;
+}
+
+/*
+This structure is a simple linked list that is built during the
+avlFind method. On each successful stab, the stabbed node is
+added to the list and the list tail is updated to the new node.
+
+The genericStabCommand maintains a pointer to the list head, which
+is the initial node passed to avlFind.
+*/
+typedef struct avlResultNode {
+    avlNode * data;
+    struct avlResultNode * next;
+} avlResultNode;
+
+avlResultNode *avlCreateResultNode(avlNode *data) {
+    avlResultNode *arn = zmalloc(sizeof(*arn));
+    arn->data = data;
+    arn->next = NULL;
+    return arn;
+}
+
+void avlFreeResults(avlResultNode *node) {
+    if (node->next)
+        avlFreeResults(node->next);
+    zfree(node);
+}
+
+avlResultNode * avlStab(avlNode *node, double min, double max, avlResultNode *results) {
+
+    // If the minimum endpoint of the interval falls to the right of the current node's interval and
+    // any sub-tree intervals, there cannot be an interval match
+    if (min > node->subRightMax && min > node->subLeftMax && min > node->scores[1])
+        return results;
+
+    // Search the node's left subtree
+    if (node->left)
+        results = avlStab(node->left, min, max, results);
+
+    // Check to see if this node overlaps.
+    // For now we're only going to check for containment.
+    if (min >= node->scores[0] && max <= node->scores[1]) {
+        avlResultNode * newResult = avlCreateResultNode(node);
+        newResult->next = results;
+        results = newResult;
+    }
+
+    // If the max endpoint of the interval falls to the left of the start of the current node's
+    // interval, there cannot be an interval match to the right of this node
+    if (max < node->scores[0])
+        return results;
+
+    // Search the node's right subtree
+    if (node->right)
+        results = avlStab(node->right, min, max, results);
+
+    return results;
+}
+
+/*-----------------------------------------------------------------------------
+ * Interval set commands
+ *----------------------------------------------------------------------------*/
+
+void iaddCommand(client *c) {
+    robj *key = c->argv[1];
+    robj *iobj;
+    robj *ele;
+    robj *curobj;
+    double * curscores;
+    double min = 0, max = 0;
+    double *mins, *maxes;
+    int j, elements = (c->argc-2)/3;
+    int added = 0;
+    avlNode * addedNode;
+    dictEntry *de;
+
+    /* 5, 8, 11... arguments */
+    if ((c->argc - 2) % 3) {
+        addReplyError(c,"wrong number of arguments for 'iadd' command");
+        return;
+    }
+
+    /* Start parsing all the scores, we need to emit any syntax error
+     * before executing additions to the sorted set, as the command should
+     * either execute fully or nothing at all. */
+    mins = zmalloc(sizeof(double)*elements);
+    maxes = zmalloc(sizeof(double)*elements);
+    for (j = 0; j < elements; j++) {
+        /* mins are 2, 5, 8... */
+        if (getDoubleFromObjectOrReply(c,c->argv[2+j*3],&mins[j],NULL)
+            != C_OK)
+        {
+            zfree(mins);
+            zfree(maxes);
+            return;
+        }
+        /* maxes are 3, 6, 9... */
+        if (getDoubleFromObjectOrReply(c,c->argv[3+j*3],&maxes[j],NULL)
+            != C_OK)
+        {
+            zfree(mins);
+            zfree(maxes);
+            return;
+        }
+    }
+
+    /* Lookup the key and create the interval tree if does not exist. */
+    iobj = lookupKeyWrite(c->db,key);
+    if (iobj == NULL) {
+        iobj = createIsetObject();
+        dbAdd(c->db,key,iobj);
+    } else {
+        if (iobj->type != OBJ_ISET) {
+            addReply(c,shared.wrongtypeerr);
+            zfree(mins);
+            zfree(maxes);
+            return;
+        }
+    }
+
+    for (j = 0; j < elements; j++) {
+        min = mins[j];
+        max = maxes[j];
+
+        ele = c->argv[4+j*3] = tryObjectEncoding(c->argv[4+j*3]);
+        de = dictFind(((avl *) (iobj->ptr))->dict,ele);
+
+        /* If object is found in iobj */
+
+        if (de != NULL) {
+            curobj = dictGetKey(de);
+            curscores = (double *) dictGetVal(de);
+
+            if (curscores[0] != min || curscores[1] != max) {
+                // remove and re-insert
+                avlRemove((avl *) (iobj->ptr), curscores[0], curscores[1], ele);
+                addedNode = avlInsert((avl *) (iobj->ptr), min, max, ele);
+                dictGetVal(de) = addedNode->scores; /* Update scores ptr. */
+                added++;
+
+                signalModifiedKey(c->db,key);
+                server.dirty++;
+            }
+        } else {
+            /* insert into the tree */
+            /* XXX: do we need the cast here? Answer from Ken! I believe so,
+            as robj.ptr is declared as a void, and avlInsert expects an avl pointer */
+            addedNode = avlInsert((avl *) (iobj->ptr), min, max, ele);
+            serverAssertWithInfo(c,NULL,dictAdd(((avl *) (iobj->ptr))->dict,ele,&addedNode->scores) == DICT_OK);
+            added++;
+            incrRefCount(ele); /* Added to dictionary. */
+            signalModifiedKey(c->db,key);
+            server.dirty++;
+        }
+    }
+
+    zfree(mins);
+    zfree(maxes);
+
+    addReplyLongLong(c,added);
+}
+
+/* This command implements ISTAB, ISTABINTERVAL. */
+void genericStabCommand(client *c, robj *lscoreObj, robj *rscoreObj, int intervalstab) {
+    double lscore, rscore;
+    int withintervals = 0;
+    robj *key = c->argv[1];
+    robj *iobj;
+    avlResultNode * resnode;
+    avlResultNode * reswalker;
+    avlNode * nodewalker;
+    void *replylen = NULL;
+    unsigned long resultslen = 0;
+    avl * tree;
+
+    if (intervalstab) {
+        if (c->argc > 4) {
+            if (!strcasecmp(c->argv[4]->ptr,"withintervals"))
+                withintervals = 1;
+            else {
+                addReply(c,shared.syntaxerr);
+                return;
+            }
+        }
+    } else {
+        if (c->argc > 3) {
+            if (!strcasecmp(c->argv[3]->ptr,"withintervals"))
+                withintervals = 1;
+            else {
+                addReply(c,shared.syntaxerr);
+                return;
+            }
+        }
+    }
+
+    if (getDoubleFromObjectOrReply(c,lscoreObj,&lscore,NULL) != C_OK) {
+        return;
+    }
+
+    if (getDoubleFromObjectOrReply(c,rscoreObj,&rscore,NULL) != C_OK) {
+        return;
+    }
+
+    if ((iobj = lookupKeyReadOrReply(c,key,shared.emptymultibulk)) == NULL ||
+        checkType(c,iobj,OBJ_ISET)) return;
+
+    tree = (avl *) (iobj->ptr);
+    resnode = avlStab(tree->root, lscore, rscore, NULL);
+
+    /* No results. */
+    if (resnode == NULL) {
+        addReply(c, shared.emptymultibulk);
+        return;
+    }
+
+    /* We don't know in advance how many matching elements there are in the
+     * list, so we push this object that will represent the multi-bulk
+     * length in the output buffer, and will "fix" it later */
+    replylen = addDeferredMultiBulkLength(c);
+    reswalker = resnode;
+
+    while (reswalker != NULL) {
+        nodewalker = reswalker->data;
+        while (nodewalker != NULL) {
+            resultslen++;
+            addReplyBulk(c,nodewalker->obj);
+            if (withintervals) {
+                addReplyDouble(c,nodewalker->scores[0]);
+                addReplyDouble(c,nodewalker->scores[1]);
+            }
+            nodewalker = nodewalker->next;
+        }
+        reswalker = reswalker->next;
+    }
+
+    if (withintervals)
+        resultslen *= 3;
+
+    setDeferredMultiBulkLength(c, replylen, resultslen);
+
+    if (resnode)
+        avlFreeResults(resnode);
+}
+
+void istabCommand(client *c) {
+    genericStabCommand(c,c->argv[2],c->argv[2],0);
+}
+
+void istabIntervalCommand(client *c) {
+    genericStabCommand(c,c->argv[2],c->argv[3],1);
+}
+
+void irembystabCommand(client *c) {
+    robj *key = c->argv[1];
+    robj *iobj;
+    long point;
+    avlResultNode * resnode;
+    avlResultNode * reswalker;
+    avlNode * nodewalker;
+    avl * tree;
+    int deleted = 0;
+    dictEntry *de;
+    double *curscores;
+
+    if (getLongFromObjectOrReply(c, c->argv[2], &point, NULL) != C_OK) return;
+
+    if ((iobj = lookupKeyWriteOrReply(c,key,shared.czero)) == NULL ||
+        checkType(c,iobj,OBJ_ISET)) return;
+
+    tree = (avl *) (iobj->ptr);
+    resnode = avlStab(((avl *) (iobj->ptr))->root, point, point, NULL);
+
+    /* No results. */
+    if (resnode == NULL) {
+        addReplyLongLong(c, 0);
+        return;
+    }
+
+    reswalker = resnode;
+
+    while (reswalker != NULL) {
+        nodewalker = reswalker->data;
+        while (nodewalker != NULL) {
+            de = dictFind(tree->dict,nodewalker->obj);
+            if (de != NULL) {
+                deleted++;
+
+                /* delete from the tree */
+                curscores = (double *) dictGetVal(de);
+                serverAssertWithInfo(c,nodewalker->obj,avlRemove(tree,curscores[0],curscores[1],nodewalker->obj));
+
+                /* delete from the hash table */
+                dictDelete(tree->dict,nodewalker->obj);
+                if (htNeedsResize(tree->dict)) dictResize(tree->dict);
+
+                signalModifiedKey(c->db,key);
+                if (dictSize(tree->dict) == 0) {
+                    dbDelete(c->db,key);
+                    break;
+                }
+            }
+            nodewalker = nodewalker->next;
+        }
+        reswalker = reswalker->next;
+    }
+
+    if (resnode)
+        avlFreeResults(resnode);
+
+    if (deleted)
+        server.dirty += deleted;
+
+    addReplyLongLong(c,deleted);
+}
+
+void iremCommand(client *c) {
+    robj *key = c->argv[1];
+    robj *iobj;
+    robj *ele;
+    double *curscores;
+    int deleted = 0, j;
+    dictEntry *de;
+    avl *tree;
+
+    if ((iobj = lookupKeyWriteOrReply(c,key,shared.czero)) == NULL ||
+        checkType(c,iobj,OBJ_ISET)) return;
+
+    tree = (avl *) iobj->ptr;
+
+    for (j = 2; j < c->argc; j++) {
+        ele = c->argv[j] = tryObjectEncoding(c->argv[j]);
+        de = dictFind(tree->dict,ele);
+
+        if (de != NULL) {
+            deleted++;
+
+            /* delete from the tree */
+            curscores = (double *) dictGetVal(de);
+            serverAssertWithInfo(c,c->argv[j],avlRemove(tree,curscores[0],curscores[1],ele));
+
+            /* delete from the hash table */
+            dictDelete(tree->dict,ele);
+            if (htNeedsResize(tree->dict)) dictResize(tree->dict);
+            if (dictSize(tree->dict) == 0) {
+                dbDelete(c->db,key);
+                break;
+            }
+        }
+    }
+
+    if (deleted) {
+        signalModifiedKey(c->db,key);
+        server.dirty += deleted;
+    }
+
+    addReplyLongLong(c,deleted);
+}
+


### PR DESCRIPTION
Ported the Interval sets from http://blog.togo.io/how-to/adding-interval-sets-to-redis/  to 3.2
Added commands iadd,irem,irembystab,istab to allow for easier interval set processing than a manual processing, maintenance and overhead in doing it with ZSETs
