### PR TITLE
Add quit to the command table

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -304,7 +304,8 @@ struct redisCommand redisCommandTable[] = {
     {"pfdebug",pfdebugCommand,-3,"w",0,NULL,0,0,0,0,0},
     {"post",securityWarningCommand,-1,"lt",0,NULL,0,0,0,0,0},
     {"host:",securityWarningCommand,-1,"lt",0,NULL,0,0,0,0,0},
-    {"latency",latencyCommand,-2,"aslt",0,NULL,0,0,0,0,0}
+    {"latency",latencyCommand,-2,"aslt",0,NULL,0,0,0,0,0},
+    {"quit",NULL,1,"rlt",0,NULL,0,0,0,0,0}
 };
 
 /*============================ Utility functions ============================ */


### PR DESCRIPTION
`quit` is treated explicitely in `processCommand`.
The `COMMAND` command gives a listing of all available commands, _except_ `QUIT` because that one is missing from the large table.

Adding it should be the most unobtrusive way to handle it.

The only breaking thing I can think of: With `QUIT` being in the command table, it's now valid to have `rename-command quit foo` in the config, except it doesn't have a real effect (except that `COMMAND` will report the wrong things now)

@BridgeAR discovered it. 
