### PR TITLE
fix undefined variable

### DIFF
--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -873,7 +873,7 @@ class RedisTrib
                 source.r.client.call(["migrate",target.info[:host],target.info[:port],"",0,@timeout,:keys,*keys])
             rescue => e
                 if o[:fix] && e.to_s =~ /BUSYKEY/
-                    xputs "*** Target keys #{keys.join(',')} exists. Replacing them for FIX."
+                    xputs "*** Target keys #{keys.join(',')} exist. Replacing them for FIX."
                     source.r.client.call(["migrate",target.info[:host],target.info[:port],"",0,@timeout,:replace,:keys,*keys])
                 else
                     puts ""

--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -873,7 +873,7 @@ class RedisTrib
                 source.r.client.call(["migrate",target.info[:host],target.info[:port],"",0,@timeout,:keys,*keys])
             rescue => e
                 if o[:fix] && e.to_s =~ /BUSYKEY/
-                    xputs "*** Target key #{key} exists. Replacing it for FIX."
+                    xputs "*** Target keys #{keys.join(',')} exists. Replacing them for FIX."
                     source.r.client.call(["migrate",target.info[:host],target.info[:port],"",0,@timeout,:replace,:keys,*keys])
                 else
                     puts ""


### PR DESCRIPTION
ran into an undefined variable

backtrace:

``` ruby
redis-trib.rb:878:in `rescue in move_slot': undefined local variable or method `key' for #<RedisTrib:0x000000014e2978> (NameError)
from redis-trib.rb:872:in `move_slot'
from redis-trib.rb:542:in `fix_open_slot'
from redis-trib.rb:421:in `block in check_open_slots'
from redis-trib.rb:421:in `each'
from redis-trib.rb:421:in `check_open_slots'
from redis-trib.rb:360:in `check_cluster'
from redis-trib.rb:1055:in `fix_cluster_cmd'
from redis-trib.rb:1611:in `<main>'
```
