### PR TITLE
Fix a possible race condition of sdown event detection if sentinel's connection to master/slave/sentinel became disconnected just after the last PONG and before the next PING.

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3372,6 +3372,8 @@ void sentinelCheckSubjectivelyDown(sentinelRedisInstance *ri) {
 
     if (ri->link->act_ping_time)
         elapsed = mstime() - ri->link->act_ping_time;
+    else if (ri->link->disconnected)
+        elapsed = mstime() - ri->link->last_avail_time;
 
     /* Check if we are in need for a reconnection of one of the
      * links, because we are detecting low activity.


### PR DESCRIPTION
If sentinel's connection to master/slave/sentinel became disconnected just after the last PONG and before the next PING, `sentinelSendPeriodicCommands()` might just return without providing `sentinelSendPing()`, thus `ri->link->act_ping_time` might still stay at `0` and in `sentinelCheckSubjectivelyDown()`, the variable `elapsed` might not be updated for `sdown` event detection. In this case the sentinel might be no longer to set the `sdown` event for the connection that disconnected from and the further operations (e.g. `switch-master`) might not be executed.

So the provided fix is to give it a chance to check if the sentinel's connection status is disconnected, set the elapsed time as the time difference between the last available time and the current time, and have it to compare with the predefined `down_after_period`, to decide if the connection that connects to or disconnected from fits `sdown` event.
