### PR TITLE
Fix nanosecond conversion

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2331,7 +2331,7 @@ static void intrinsicLatencyMode(void) {
         }
 
         double avg_us = (double)run_time/runs;
-        double avg_ns = avg_us * 10e3;
+        double avg_ns = avg_us * 1e3;
         if (force_cancel_loop || end > test_end) {
             printf("\n%lld total runs "
                 "(avg latency: "


### PR DESCRIPTION
1 microsecond = 1000 nanoseconds
1e3 = 1000
10e3 = 10000
