### PR TITLE
Remove privdata in "dict structure.

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -168,6 +168,7 @@ static void _dictReset(dictht *ht)
 dict *dictCreate(dictType *type,
         void *privDataPtr)
 {
+    DICT_NOTUSED(privDataPtr);
     dict *d = zmalloc(sizeof(*d));
 
     _dictInit(d,type);

--- a/src/dict.c
+++ b/src/dict.c
@@ -63,7 +63,7 @@ static unsigned int dict_force_resize_ratio = 5;
 static int _dictExpandIfNeeded(dict *ht);
 static unsigned long _dictNextPower(unsigned long size);
 static int _dictKeyIndex(dict *ht, const void *key);
-static int _dictInit(dict *ht, dictType *type, void *privDataPtr);
+static int _dictInit(dict *ht, dictType *type);
 
 /* -------------------------- hash functions -------------------------------- */
 
@@ -170,18 +170,16 @@ dict *dictCreate(dictType *type,
 {
     dict *d = zmalloc(sizeof(*d));
 
-    _dictInit(d,type,privDataPtr);
+    _dictInit(d,type);
     return d;
 }
 
 /* Initialize the hash table */
-int _dictInit(dict *d, dictType *type,
-        void *privDataPtr)
+int _dictInit(dict *d, dictType *type)
 {
     _dictReset(&d->ht[0]);
     _dictReset(&d->ht[1]);
     d->type = type;
-    d->privdata = privDataPtr;
     d->rehashidx = -1;
     d->iterators = 0;
     return DICT_OK;
@@ -462,7 +460,7 @@ int _dictClear(dict *d, dictht *ht, void(callback)(void *)) {
     for (i = 0; i < ht->size && ht->used > 0; i++) {
         dictEntry *he, *nextHe;
 
-        if (callback && (i & 65535) == 0) callback(d->privdata);
+        if (callback && (i & 65535) == 0) callback(NULL);
 
         if ((he = ht->table[i]) == NULL) continue;
         while(he) {

--- a/src/dict.h
+++ b/src/dict.h
@@ -75,7 +75,6 @@ typedef struct dictht {
 
 typedef struct dict {
     dictType *type;
-    void *privdata;
     dictht ht[2];
     long rehashidx; /* rehashing not in progress if rehashidx == -1 */
     unsigned long iterators; /* number of iterators currently running */
@@ -102,11 +101,11 @@ typedef void (dictScanFunction)(void *privdata, const dictEntry *de);
 /* ------------------------------- Macros ------------------------------------*/
 #define dictFreeVal(d, entry) \
     if ((d)->type->valDestructor) \
-        (d)->type->valDestructor((d)->privdata, (entry)->v.val)
+        (d)->type->valDestructor(NULL, (entry)->v.val)
 
 #define dictSetVal(d, entry, _val_) do { \
     if ((d)->type->valDup) \
-        entry->v.val = (d)->type->valDup((d)->privdata, _val_); \
+        entry->v.val = (d)->type->valDup(NULL, _val_); \
     else \
         entry->v.val = (_val_); \
 } while(0)
@@ -122,18 +121,18 @@ typedef void (dictScanFunction)(void *privdata, const dictEntry *de);
 
 #define dictFreeKey(d, entry) \
     if ((d)->type->keyDestructor) \
-        (d)->type->keyDestructor((d)->privdata, (entry)->key)
+        (d)->type->keyDestructor(NULL, (entry)->key)
 
 #define dictSetKey(d, entry, _key_) do { \
     if ((d)->type->keyDup) \
-        entry->key = (d)->type->keyDup((d)->privdata, _key_); \
+        entry->key = (d)->type->keyDup(NULL, _key_); \
     else \
         entry->key = (_key_); \
 } while(0)
 
 #define dictCompareKeys(d, key1, key2) \
     (((d)->type->keyCompare) ? \
-        (d)->type->keyCompare((d)->privdata, key1, key2) : \
+        (d)->type->keyCompare(NULL, key1, key2) : \
         (key1) == (key2))
 
 #define dictHashKey(d, key) (d)->type->hashFunction(key)


### PR DESCRIPTION
I have read the source code of Redis for a mouth,and I found that the "dict“ structure field which called privdata didn't use in the source code.So I remove the structure filed(privdata),and modify some macros and functions related in "dict.h" and "dict.c".The modify has pass the "make test".
