### PR TITLE
Fix for Issue##3020 (With no bindaddr given, server should give error if it cannot bind both IPv4 and IPv6)

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1781,13 +1781,20 @@ int listenToPort(int port, int *fds, int *count) {
             if (fds[*count] != ANET_ERR) {
                 anetNonBlock(NULL,fds[*count]);
                 (*count)++;
-            }
+		} else {
+			serverLog(LL_WARNING,"Server couldn't connect to :: on port %d using IPv6. Make sure that the port is free", port);
+			return C_ERR;
+	    	}
+
             fds[*count] = anetTcpServer(server.neterr,port,NULL,
                 server.tcp_backlog);
             if (fds[*count] != ANET_ERR) {
                 anetNonBlock(NULL,fds[*count]);
                 (*count)++;
-            }
+		} else {
+			serverLog(LL_WARNING,"Server couldn't connect to 0.0.0.0 on %d using IPv4. Make sure that the port is free", port);
+			return C_ERR;
+		}
             /* Exit the loop if we were able to bind * on IPv4 or IPv6,
              * otherwise fds[*count] will be ANET_ERR and we'll print an
              * error and return to the caller with an error. */


### PR DESCRIPTION
Fixed following issue :
https://github.com/antirez/redis/issues/3020 (With no bindaddr given, server should give error if it cannot bind both IPv4 and IPv6)

Earlier behavior 
listenToPort function was returning success if it can bind any one of IPv4 or IPv6 on not setting the bind option. This is confusing for the user, since there's no indication anywhere that the server tried and failed to bind on one of the interfaces, in case the port is free on IPv6 interface, but busy on IPv4 interface.

Reason
The "listenToPort" was deciding if the connection is successful by checking for the value of "count" to be non-zero. Both IPv4 & IPv6 connection attempts increment this value, and so even if one failed, the count is greater than 0, and hence connection is shown to be successful, and no error message is given.

Changed behavior
Now after both the connection attempts, if "ANET_ERR" is returned, a check is added to give an error message and to return a "C_ERR" to the calling function, the same behavior that is displayed when the server is started by specifying 0.0.0.0 or :: (defaults) as bind address.
