### PR TITLE
return nokeyerr when geo set key not exist

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -432,7 +432,7 @@ void georadiusGeneric(client *c, int type) {
 
     /* Look up the requested zset */
     robj *zobj = NULL;
-    if ((zobj = lookupKeyReadOrReply(c, key, shared.emptymultibulk)) == NULL ||
+    if ((zobj = lookupKeyReadOrReply(c, key, shared.nokeyerr)) == NULL ||
         checkType(c, zobj, OBJ_ZSET)) {
         return;
     }


### PR DESCRIPTION
return nokeyerr but not emptymultibulk when geo set key not exist, so that user can distinguish two case: geo key not exist and there is not data around the coordinates.
