### PR TITLE
list iterator NULL pointer fix(bug #3014 fix)

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -220,6 +220,8 @@ void listRewindTail(list *list, listIter *li) {
  * */
 listNode *listNext(listIter *iter)
 {
+    if (iter == NULL) return NULL;
+
     listNode *current = iter->next;
 
     if (current != NULL) {


### PR DESCRIPTION
Fix for potential crash when list iterator argument for function listNext is NULL. fix for issue #3014 
