### PR TITLE
3.0 cant be master config flag

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -727,6 +727,20 @@ lua-time-limit 5000
 #
 # cluster-require-full-coverage yes
 
+# Usually all Redis Clusters are eligible to self-election for the master role
+# during a master failover. If however a node should be forbidden from electing
+# itself as a master, you can change cluster-can-be-elected-as-master to yes.
+#
+# Note that this node can still become a master from other operations (e.g.
+# from CLUSTER RESET SOFT or even from CLUSTER FAILOVER), only not from a
+# automatic failover process.
+#
+# Also note that this will also make it not be counted towards the
+# cluster-migration-barrier (which only affects automatic slave migrations), and
+# in general not participate in automatic slave migrations.
+#
+# cluster-can-be-elected-as-master yes
+
 # In order to setup your cluster make sure to read the documentation
 # available at http://redis.io web site.
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -956,7 +956,7 @@ uint64_t clusterGetMaxEpoch(void) {
  * cases:
  *
  * 1) When slots are closed after importing. Otherwise resharding would be
- *    too expansive.
+ *    too expensive.
  * 2) When CLUSTER FAILOVER is called with options that force a slave to
  *    failover its master even if there is not master majority able to
  *    create a new configuration epoch.
@@ -1806,7 +1806,7 @@ int clusterProcessPacket(clusterLink *link) {
 
         /* Many checks are only needed if the set of served slots this
          * instance claims is different compared to the set of slots we have
-         * for it. Check this ASAP to avoid other computational expansive
+         * for it. Check this ASAP to avoid other computational expensive
          * checks later. */
         clusterNode *sender_master = NULL; /* Sender or its master if slave. */
         int dirty_slots = 0; /* Sender claimed slots don't match my view? */
@@ -2654,7 +2654,7 @@ void clusterLogCantFailover(int reason) {
         break;
     }
     lastlog_time = time(NULL);
-    redisLog(REDIS_WARNING,"Currently unable to failover: %s", msg);
+    redisLog(REDIS_WARNING, "Currently unable to failover: %s", msg);
 }
 
 /* This function implements the final part of automatic and manual failovers,
@@ -3280,7 +3280,7 @@ void clusterCron(void) {
         replicationSetMaster(myself->slaveof->ip, myself->slaveof->port);
     }
 
-    /* Abourt a manual failover if the timeout is reached. */
+    /* Abort a manual failover if the timeout is reached. */
     manualFailoverCheckTimeout();
 
     if (nodeIsSlave(myself)) {
@@ -3302,7 +3302,7 @@ void clusterCron(void) {
 /* This function is called before the event handler returns to sleep for
  * events. It is useful to perform operations that must be done ASAP in
  * reaction to events fired but that are not safe to perform inside event
- * handlers, or to perform potentially expansive tasks that we need to do
+ * handlers, or to perform potentially expensive tasks that we need to do
  * a single time before replying to clients. */
 void clusterBeforeSleep(void) {
     /* Handle failover, this is needed when it is likely that there is already

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -16,6 +16,7 @@
 #define REDIS_CLUSTER_DEFAULT_NODE_TIMEOUT 15000
 #define REDIS_CLUSTER_DEFAULT_SLAVE_VALIDITY 10 /* Slave max data age factor. */
 #define REDIS_CLUSTER_DEFAULT_REQUIRE_FULL_COVERAGE 1
+#define REDIS_CLUSTER_DEFAULT_CAN_BE_ELECTED_AS_MASTER 1
 #define REDIS_CLUSTER_FAIL_REPORT_VALIDITY_MULT 2 /* Fail report validity. */
 #define REDIS_CLUSTER_FAIL_UNDO_TIME_MULT 2 /* Undo fail if master is back. */
 #define REDIS_CLUSTER_FAIL_UNDO_TIME_ADD 10 /* Some additional time. */
@@ -55,6 +56,8 @@ typedef struct clusterLink {
 #define REDIS_NODE_NOADDR   64  /* We don't know the address of this node */
 #define REDIS_NODE_MEET 128     /* Send a MEET message to this node */
 #define REDIS_NODE_MIGRATE_TO 256 /* Master elegible for replica migration. */
+#define REDIS_NODE_CANT_BE_MASTER 512 /* Node not elegible for automatic
+                                         failover. */
 #define REDIS_NODE_NULL_NAME "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
 
 #define nodeIsMaster(n) ((n)->flags & REDIS_NODE_MASTER)
@@ -64,6 +67,7 @@ typedef struct clusterLink {
 #define nodeWithoutAddr(n) ((n)->flags & REDIS_NODE_NOADDR)
 #define nodeTimedOut(n) ((n)->flags & REDIS_NODE_PFAIL)
 #define nodeFailed(n) ((n)->flags & REDIS_NODE_FAIL)
+#define nodeCanBeMaster(n) !((n)->flags & REDIS_NODE_CANT_BE_MASTER)
 
 /* Reasons why a slave is not able to failover. */
 #define REDIS_CLUSTER_CANT_FAILOVER_NONE 0
@@ -71,6 +75,7 @@ typedef struct clusterLink {
 #define REDIS_CLUSTER_CANT_FAILOVER_WAITING_DELAY 2
 #define REDIS_CLUSTER_CANT_FAILOVER_EXPIRED 3
 #define REDIS_CLUSTER_CANT_FAILOVER_WAITING_VOTES 4
+#define REDIS_CLUSTER_CANT_FAILOVER_CANT_BE_ELECTED 5
 #define REDIS_CLUSTER_CANT_FAILOVER_RELOG_PERIOD (60*5) /* seconds. */
 
 /* This structure represent elements of node->fail_reports. */

--- a/src/config.c
+++ b/src/config.c
@@ -468,6 +468,13 @@ void loadServerConfigFromString(char *config) {
                 err = "cluster slave validity factor must be zero or positive";
                 goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"cluster-can-be-elected-as-master") &&
+                    argc == 2)
+        {
+            if ((server.cluster_can_be_elected_as_master = yesnotoi(argv[1])) == -1)
+            {
+                err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
         } else if (!strcasecmp(argv[0],"lua-time-limit") && argc == 2) {
             server.lua_time_limit = strtoll(argv[1],NULL,10);
         } else if (!strcasecmp(argv[0],"slowlog-log-slower-than") &&
@@ -956,6 +963,11 @@ void configSetCommand(redisClient *c) {
 
         if (yn == -1) goto badfmt;
         server.cluster_require_full_coverage = yn;
+    } else if (!strcasecmp(c->argv[2]->ptr,"cluster-can-be-elected-as-master")) {
+        int yn = yesnotoi(o->ptr);
+
+        if (yn == -1) goto badfmt;
+        server.cluster_can_be_elected_as_master = yn;
     } else if (!strcasecmp(c->argv[2]->ptr,"cluster-node-timeout")) {
         if (getLongLongFromObject(o,&ll) == REDIS_ERR ||
             ll <= 0) goto badfmt;
@@ -1080,6 +1092,8 @@ void configGetCommand(redisClient *c) {
     /* Bool (yes/no) values */
     config_get_bool_field("cluster-require-full-coverage",
             server.cluster_require_full_coverage);
+    config_get_bool_field("cluster-can-be-elected-as-master",
+            server.cluster_can_be_elected_as_master);
     config_get_bool_field("no-appendfsync-on-rewrite",
             server.aof_no_fsync_on_rewrite);
     config_get_bool_field("slave-serve-stale-data",
@@ -1852,6 +1866,7 @@ int rewriteConfig(char *path) {
     rewriteConfigYesNoOption(state,"cluster-enabled",server.cluster_enabled,0);
     rewriteConfigStringOption(state,"cluster-config-file",server.cluster_configfile,REDIS_DEFAULT_CLUSTER_CONFIG_FILE);
     rewriteConfigYesNoOption(state,"cluster-require-full-coverage",server.cluster_require_full_coverage,REDIS_CLUSTER_DEFAULT_REQUIRE_FULL_COVERAGE);
+    rewriteConfigYesNoOption(state,"cluster-can-be-elected-as-master",server.cluster_can_be_elected_as_master,REDIS_CLUSTER_DEFAULT_CAN_BE_ELECTED_AS_MASTER);
     rewriteConfigNumericalOption(state,"cluster-node-timeout",server.cluster_node_timeout,REDIS_CLUSTER_DEFAULT_NODE_TIMEOUT);
     rewriteConfigNumericalOption(state,"cluster-migration-barrier",server.cluster_migration_barrier,REDIS_CLUSTER_DEFAULT_MIGRATION_BARRIER);
     rewriteConfigNumericalOption(state,"cluster-slave-validity-factor",server.cluster_slave_validity_factor,REDIS_CLUSTER_DEFAULT_SLAVE_VALIDITY);

--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -1574,7 +1574,7 @@ module RedisClusterCRC16
     def RedisClusterCRC16.crc16(bytes)
         crc = 0
         bytes.each_byte{|b|
-            crc = ((crc<<8) & 0xffff) ^ XMODEMCRC16Lookup[((crc>>8)^b) & 0xff]
+            crc = ((crc << 8) & 0xffff) ^ XMODEMCRC16Lookup[((crc>>8)^b) & 0xff]
         }
         crc
     end

--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -858,7 +858,7 @@ class RedisTrib
                 master = get_node_by_name(n.info[:replicate])
                 if !master
                     xputs "*** WARNING: #{n} claims to be slave of unknown node ID #{n.info[:replicate]}."
-                else
+                elsif !n.has_flag?('cant-be-master')
                     master.info[:replicas] << n
                 end
             end

--- a/src/redis.c
+++ b/src/redis.c
@@ -1489,6 +1489,7 @@ void initServerConfig(void) {
     server.cluster_migration_barrier = REDIS_CLUSTER_DEFAULT_MIGRATION_BARRIER;
     server.cluster_slave_validity_factor = REDIS_CLUSTER_DEFAULT_SLAVE_VALIDITY;
     server.cluster_require_full_coverage = REDIS_CLUSTER_DEFAULT_REQUIRE_FULL_COVERAGE;
+    server.cluster_can_be_elected_as_master = REDIS_CLUSTER_DEFAULT_CAN_BE_ELECTED_AS_MASTER;
     server.cluster_configfile = zstrdup(REDIS_DEFAULT_CLUSTER_CONFIG_FILE);
     server.lua_caller = NULL;
     server.lua_time_limit = REDIS_LUA_TIME_LIMIT;

--- a/src/redis.h
+++ b/src/redis.h
@@ -900,6 +900,9 @@ struct redisServer {
     int cluster_slave_validity_factor; /* Slave max data age for failover. */
     int cluster_require_full_coverage; /* If true, put the cluster down if
                                           there is at least an uncovered slot. */
+    int cluster_can_be_elected_as_master; /* If true, node can be elected to be
+                                             a master during an automatic
+                                             failover. */
     /* Scripting */
     lua_State *lua; /* The Lua interpreter. We use just one for all clients */
     redisClient *lua_client;   /* The "fake client" to query Redis from Lua */

--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -47,7 +47,7 @@ proc CI {n field} {
     get_info_field [R $n cluster info] $field
 }
 
-# Assuming nodes are reest, this function performs slots allocation.
+# Assuming nodes are reset, this function performs slots allocation.
 # Only the first 'n' nodes are used.
 proc cluster_allocate_slots {n} {
     set slot 16383

--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -13,6 +13,7 @@ proc get_cluster_nodes id {
         if {$l eq {}} continue
         set args [split $l]
         set node [dict create \
+            test_id $id \
             id [lindex $args 0] \
             addr [lindex $args 1] \
             flags [split [lindex $args 2] ,] \
@@ -127,4 +128,20 @@ proc cluster_write_test {id} {
         assert {[$cluster get key.$j] eq "$prefix.$j"}
     }
     $cluster close
+}
+
+# Set node as eligible for automation failover
+proc cluster_can_be_elected_as_master {id} {
+    set port [get_instance_attrib redis $id port]
+    set r [redis 127.0.0.1 $port]
+    $r config set cluster-can-be-elected-as-master yes
+    $r close
+}
+
+# Set node as not eligible for automation failover
+proc cluster_cant_be_elected_as_master {id} {
+    set port [get_instance_attrib redis $id port]
+    set r [redis 127.0.0.1 $port]
+    $r config set cluster-can-be-elected-as-master no
+    $r close
 }

--- a/tests/cluster/tests/08-update-msg.tcl
+++ b/tests/cluster/tests/08-update-msg.tcl
@@ -1,5 +1,5 @@
 # Test UPDATE messages sent by other nodes when the currently authorirative
-# master is unavaialble. The test is performed in the following steps:
+# master is unavailable. The test is performed in the following steps:
 #
 # 1) Master goes down.
 # 2) Slave failover and becomes new master.

--- a/tests/cluster/tests/12-failover-with-slave-that-cant-be-master.tcl
+++ b/tests/cluster/tests/12-failover-with-slave-that-cant-be-master.tcl
@@ -1,0 +1,90 @@
+# Check the can-be-elected-as-master configuration option
+# and automatic failover.
+
+source "../tests/includes/init-tests.tcl"
+
+test "Create a 3 nodes cluster" {
+    create_cluster 3 6
+}
+
+test "Cluster is up" {
+    assert_cluster_state ok
+}
+
+test "Cluster is writable" {
+    cluster_write_test 0
+}
+
+test "Instance #3 is a slave of instance #0" {
+    assert {[RI 3 master_port] eq [get_instance_attrib redis 0 port]}
+}
+
+test "Instance #6 is a slave of instance #0" {
+    assert {[RI 6 master_port] eq [get_instance_attrib redis 0 port]}
+}
+
+test "Instance #3 synced with the master" {
+    wait_for_condition 1000 50 {
+        [RI 3 master_link_status] eq {up}
+    } else {
+        fail "Instance #3 master link status is not up"
+    }
+}
+
+test "Instance #6 synced with the master" {
+    wait_for_condition 1000 50 {
+        [RI 6 master_link_status] eq {up}
+    } else {
+        fail "Instance #6 master link status is not up"
+    }
+}
+
+test "Marking instance #3 as \"can't be master\"" {
+    cluster_cant_be_elected_as_master 3
+}
+
+set current_epoch [CI 3 cluster_current_epoch]
+
+test "Killing one master node" {
+    kill_instance redis 0
+}
+
+test "Wait for failover" {
+    wait_for_condition 1000 50 {
+        [CI 3 cluster_current_epoch] > $current_epoch
+    } else {
+        fail "No failover detected"
+    }
+}
+
+test "Cluster should eventually be up again" {
+    assert_cluster_state ok
+}
+
+test "Cluster is writable" {
+    cluster_write_test 6
+}
+
+test "Instance #3 is a slave of instance #6" {
+    assert {[RI 3 master_port] eq [get_instance_attrib redis 6 port]}
+}
+
+test "Instance #6 is now a master" {
+    assert {[RI 6 role] eq {master}}
+}
+
+test "Restarting the previously killed master node" {
+    restart_instance redis 0
+}
+
+test "Instance #0 gets converted into a slave" {
+    wait_for_condition 1000 50 {
+        [RI 0 role] eq {slave}
+    } else {
+        fail "Old master was not converted into slave"
+    }
+}
+
+test "Instance #0 is a slave of instance #6" {
+    assert {[RI 0 master_port] eq [get_instance_attrib redis 6 port]}
+}

--- a/tests/cluster/tests/13-migration-with-slave-that-cant-be-master.tcl
+++ b/tests/cluster/tests/13-migration-with-slave-that-cant-be-master.tcl
@@ -1,0 +1,91 @@
+# Check the can-be-elected-as-master configuration option
+# and automatic slave migration.
+
+source "../tests/includes/init-tests.tcl"
+
+test "Create a 3 nodes cluster" {
+    create_cluster 3 6
+}
+
+test "Cluster is up" {
+    assert_cluster_state ok
+}
+
+test "Cluster is writable" {
+    cluster_write_test 0
+}
+
+test "Instance #3 is a slave of instance #0" {
+    assert {[RI 3 master_port] eq [get_instance_attrib redis 0 port]}
+}
+
+test "Instance #6 is a slave of instance #0" {
+    assert {[RI 6 master_port] eq [get_instance_attrib redis 0 port]}
+}
+
+test "Instance #3 synced with the master" {
+    wait_for_condition 1000 50 {
+        [RI 3 master_link_status] eq {up}
+    } else {
+        fail "Instance #3 master link status is not up"
+    }
+}
+
+test "Instance #6 synced with the master" {
+    wait_for_condition 1000 50 {
+        [RI 6 master_link_status] eq {up}
+    } else {
+        fail "Instance #6 master link status is not up"
+    }
+}
+
+test "Killing Instance #4" {
+    kill_instance redis 4
+}
+
+test "Killing Instance #5" {
+    kill_instance redis 5
+}
+
+proc comp.nodes.id {x y} {
+    string compare [dict get $x id] [dict get $y id]
+}
+
+set slaves [lsort -command comp.nodes.id [list [get_myself 3] [get_myself 6]]]
+set first_id [dict get [lindex $slaves 0] test_id]
+set second_id [dict get [lindex $slaves 1] test_id]
+
+test "Marking second instance as \"can't be master\"" {
+    cluster_cant_be_elected_as_master $second_id
+}
+
+after 100
+
+test "Killing instance #7" {
+    kill_instance redis 7
+}
+
+test "First instance is not a slave of instance #1" {
+    wait_for_condition 1000 60 {
+        [RI $first_id master_port] eq [get_instance_attrib redis 1 port]
+    } else {
+        assert {1 eq 1}
+    }
+    assert {[RI $first_id master_port] ne [get_instance_attrib redis 1 port]}
+}
+
+test "Second instance is not a slave of instance #1" {
+    assert {[RI $second_id master_port] ne [get_instance_attrib redis 1 port]}
+}
+
+test "Unmarking first instance as \"can't be master\"" {
+    cluster_can_be_elected_as_master $second_id
+}
+
+test "First instance is a slave of instance #1" {
+    wait_for_condition 1000 60 {
+        [RI $first_id master_port] eq [get_instance_attrib redis 1 port]
+    } else {
+        fail "Second instance is not a slave of instance #1"
+    }
+}

--- a/tests/cluster/tests/includes/init-tests.tcl
+++ b/tests/cluster/tests/includes/init-tests.tcl
@@ -39,6 +39,7 @@ test "Cluster nodes hard reset" {
         R $id EXEC
         R $id config set cluster-node-timeout $node_timeout
         R $id config set cluster-slave-validity-factor 10
+        R $id config set cluster-can-be-elected-as-master yes
         R $id config rewrite
     }
 }

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -317,7 +317,7 @@ proc end_tests {} {
         puts "GOOD! No errors."
         exit 0
     } else {
-        puts "WARNING $::failed tests faield."
+        puts "WARNING $::failed tests failed."
         exit 1
     }
 }
@@ -507,4 +507,3 @@ proc restart_instance {type id} {
         }
     }
 }
-


### PR DESCRIPTION
Hi Salvatore,

This is the patch that we're using.

It technically works, and with basic renaming rules, also works for 3.2. We're using this one over 3.0, for a tiny bit more stability.

Waiting to hear your comments.

As discussed on https://www.reddit.com/r/redis/comments/43zwkc/heterogeneous_redis_cluster_roles/
