### PR TITLE
3.0 empty voter config flag

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -727,6 +727,20 @@ lua-time-limit 5000
 #
 # cluster-require-full-coverage yes
 
+# Similarly to how Redis Sentinel can be run on non-Redis machines for increased
+# cluster and quorum sizes, it is possible to start additional Redis Cluster
+# masters without assigning them slots while setting this option to yes. This
+# will add them to the cluster size count, effectively improving the partition
+# tolerance without actually costing more hardware for additional servers.
+#
+# Most commonly, this can be used to construct a stable Redis Cluster with only
+# two masters: two master and a third only-voting node that serves as a
+# tie-breaker when one of them disconnects from the rest of the cluster.
+#
+# Note: if this node is a slave, it still won't vote.
+#
+# cluster-can-be-empty-voter no
+
 # In order to setup your cluster make sure to read the documentation
 # available at http://redis.io web site.
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -956,7 +956,7 @@ uint64_t clusterGetMaxEpoch(void) {
  * cases:
  *
  * 1) When slots are closed after importing. Otherwise resharding would be
- *    too expansive.
+ *    too expensive.
  * 2) When CLUSTER FAILOVER is called with options that force a slave to
  *    failover its master even if there is not master majority able to
  *    create a new configuration epoch.
@@ -1806,7 +1806,7 @@ int clusterProcessPacket(clusterLink *link) {
 
         /* Many checks are only needed if the set of served slots this
          * instance claims is different compared to the set of slots we have
-         * for it. Check this ASAP to avoid other computational expansive
+         * for it. Check this ASAP to avoid other computational expensive
          * checks later. */
         clusterNode *sender_master = NULL; /* Sender or its master if slave. */
         int dirty_slots = 0; /* Sender claimed slots don't match my view? */
@@ -2654,7 +2654,7 @@ void clusterLogCantFailover(int reason) {
         break;
     }
     lastlog_time = time(NULL);
-    redisLog(REDIS_WARNING,"Currently unable to failover: %s", msg);
+    redisLog(REDIS_WARNING, "Currently unable to failover: %s", msg);
 }
 
 /* This function implements the final part of automatic and manual failovers,
@@ -3280,7 +3280,7 @@ void clusterCron(void) {
         replicationSetMaster(myself->slaveof->ip, myself->slaveof->port);
     }
 
-    /* Abourt a manual failover if the timeout is reached. */
+    /* Abort a manual failover if the timeout is reached. */
     manualFailoverCheckTimeout();
 
     if (nodeIsSlave(myself)) {
@@ -3302,7 +3302,7 @@ void clusterCron(void) {
 /* This function is called before the event handler returns to sleep for
  * events. It is useful to perform operations that must be done ASAP in
  * reaction to events fired but that are not safe to perform inside event
- * handlers, or to perform potentially expansive tasks that we need to do
+ * handlers, or to perform potentially expensive tasks that we need to do
  * a single time before replying to clients. */
 void clusterBeforeSleep(void) {
     /* Handle failover, this is needed when it is likely that there is already

--- a/src/config.c
+++ b/src/config.c
@@ -468,6 +468,13 @@ void loadServerConfigFromString(char *config) {
                 err = "cluster slave validity factor must be zero or positive";
                 goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"cluster-can-be-empty-voter") &&
+                    argc == 2)
+        {
+            if ((server.cluster_can_be_empty_voter = yesnotoi(argv[1])) == -1)
+            {
+                err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
         } else if (!strcasecmp(argv[0],"lua-time-limit") && argc == 2) {
             server.lua_time_limit = strtoll(argv[1],NULL,10);
         } else if (!strcasecmp(argv[0],"slowlog-log-slower-than") &&
@@ -956,6 +963,11 @@ void configSetCommand(redisClient *c) {
 
         if (yn == -1) goto badfmt;
         server.cluster_require_full_coverage = yn;
+    } else if (!strcasecmp(c->argv[2]->ptr,"cluster-can-be-empty-voter")) {
+        int yn = yesnotoi(o->ptr);
+
+        if (yn == -1) goto badfmt;
+        server.cluster_can_be_empty_voter = yn;
     } else if (!strcasecmp(c->argv[2]->ptr,"cluster-node-timeout")) {
         if (getLongLongFromObject(o,&ll) == REDIS_ERR ||
             ll <= 0) goto badfmt;
@@ -1080,6 +1092,8 @@ void configGetCommand(redisClient *c) {
     /* Bool (yes/no) values */
     config_get_bool_field("cluster-require-full-coverage",
             server.cluster_require_full_coverage);
+    config_get_bool_field("cluster-can-be-empty-voter",
+            server.cluster_can_be_empty_voter);
     config_get_bool_field("no-appendfsync-on-rewrite",
             server.aof_no_fsync_on_rewrite);
     config_get_bool_field("slave-serve-stale-data",
@@ -1852,6 +1866,7 @@ int rewriteConfig(char *path) {
     rewriteConfigYesNoOption(state,"cluster-enabled",server.cluster_enabled,0);
     rewriteConfigStringOption(state,"cluster-config-file",server.cluster_configfile,REDIS_DEFAULT_CLUSTER_CONFIG_FILE);
     rewriteConfigYesNoOption(state,"cluster-require-full-coverage",server.cluster_require_full_coverage,REDIS_CLUSTER_DEFAULT_REQUIRE_FULL_COVERAGE);
+    rewriteConfigYesNoOption(state,"cluster-can-be-empty-voter",server.cluster_can_be_empty_voter,REDIS_CLUSTER_DEFAULT_CAN_BE_CAN_BE_EMPTY_VOTER);
     rewriteConfigNumericalOption(state,"cluster-node-timeout",server.cluster_node_timeout,REDIS_CLUSTER_DEFAULT_NODE_TIMEOUT);
     rewriteConfigNumericalOption(state,"cluster-migration-barrier",server.cluster_migration_barrier,REDIS_CLUSTER_DEFAULT_MIGRATION_BARRIER);
     rewriteConfigNumericalOption(state,"cluster-slave-validity-factor",server.cluster_slave_validity_factor,REDIS_CLUSTER_DEFAULT_SLAVE_VALIDITY);

--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -1574,7 +1574,7 @@ module RedisClusterCRC16
     def RedisClusterCRC16.crc16(bytes)
         crc = 0
         bytes.each_byte{|b|
-            crc = ((crc<<8) & 0xffff) ^ XMODEMCRC16Lookup[((crc>>8)^b) & 0xff]
+            crc = ((crc << 8) & 0xffff) ^ XMODEMCRC16Lookup[((crc>>8)^b) & 0xff]
         }
         crc
     end

--- a/src/redis.c
+++ b/src/redis.c
@@ -1489,6 +1489,7 @@ void initServerConfig(void) {
     server.cluster_migration_barrier = REDIS_CLUSTER_DEFAULT_MIGRATION_BARRIER;
     server.cluster_slave_validity_factor = REDIS_CLUSTER_DEFAULT_SLAVE_VALIDITY;
     server.cluster_require_full_coverage = REDIS_CLUSTER_DEFAULT_REQUIRE_FULL_COVERAGE;
+    server.cluster_can_be_empty_voter = REDIS_CLUSTER_DEFAULT_CAN_BE_CAN_BE_EMPTY_VOTER;
     server.cluster_configfile = zstrdup(REDIS_DEFAULT_CLUSTER_CONFIG_FILE);
     server.lua_caller = NULL;
     server.lua_time_limit = REDIS_LUA_TIME_LIMIT;

--- a/src/redis.h
+++ b/src/redis.h
@@ -900,6 +900,8 @@ struct redisServer {
     int cluster_slave_validity_factor; /* Slave max data age for failover. */
     int cluster_require_full_coverage; /* If true, put the cluster down if
                                           there is at least an uncovered slot. */
+    int cluster_can_be_empty_voter; /* If true, node will vote even if it serves
+                                       no slots. */
     /* Scripting */
     lua_State *lua; /* The Lua interpreter. We use just one for all clients */
     redisClient *lua_client;   /* The "fake client" to query Redis from Lua */

--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -47,7 +47,7 @@ proc CI {n field} {
     get_info_field [R $n cluster info] $field
 }
 
-# Assuming nodes are reest, this function performs slots allocation.
+# Assuming nodes are reset, this function performs slots allocation.
 # Only the first 'n' nodes are used.
 proc cluster_allocate_slots {n} {
     set slot 16383

--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -128,3 +128,19 @@ proc cluster_write_test {id} {
     }
     $cluster close
 }
+
+# Set node as a voting master, even if empty
+proc cluster_can_be_empty_voter {id} {
+    set port [get_instance_attrib redis $id port]
+    set r [redis 127.0.0.1 $port]
+    $r config set cluster-can-be-empty-voter yes
+    $r close
+}
+
+# Set node as a voting master, only if not empty
+proc cluster_cant_be_empty_voter {id} {
+    set port [get_instance_attrib redis $id port]
+    set r [redis 127.0.0.1 $port]
+    $r config set cluster-can-be-empty-voter no
+    $r close
+}

--- a/tests/cluster/tests/08-update-msg.tcl
+++ b/tests/cluster/tests/08-update-msg.tcl
@@ -1,5 +1,5 @@
 # Test UPDATE messages sent by other nodes when the currently authorirative
-# master is unavaialble. The test is performed in the following steps:
+# master is unavailable. The test is performed in the following steps:
 #
 # 1) Master goes down.
 # 2) Slave failover and becomes new master.

--- a/tests/cluster/tests/14-voting-empty-masters.tcl
+++ b/tests/cluster/tests/14-voting-empty-masters.tcl
@@ -1,0 +1,104 @@
+# Check the monitoring and failover capabilities, with a single node and
+#   two empty voters.
+
+source "../tests/includes/init-tests.tcl"
+
+### We make sure that the test fails without the empty voters
+
+test "Create a 1-node cluster" {
+    create_cluster 1 1
+}
+
+test "Cluster should start ok" {
+    assert_cluster_state ok
+}
+
+test "Cluster size is 1" {
+    assert {[CI 0 cluster_size] eq 1}
+}
+
+test "Cluster is writable" {
+    cluster_write_test 0
+}
+
+test "Instance #1 is a slave of instance #0" {
+    assert {[RI 1 master_port] eq [get_instance_attrib redis 0 port]}
+}
+
+test "Instance #1 synced with the master" {
+    wait_for_condition 1000 50 {
+        [RI 1 master_link_status] eq {up}
+    } else {
+        fail "Instance #1 master link status is not up"
+    }
+}
+
+test "Killing instance #0" {
+    kill_instance redis 0
+}
+
+test "Instance #1 can't be elected for an automatic failover" {
+    wait_for_condition 1000 60 {
+        [RI 1 role] eq {master}
+    } else {
+        assert {1 eq 1}
+    }
+    assert {[RI 1 role] ne {master}}
+}
+
+### We make sure that the test passes with the empty voters
+
+source "../tests/includes/init-tests.tcl"
+
+test "Create a 1-node cluster" {
+    create_cluster 1 1
+}
+
+test "Cluster should start ok" {
+    assert_cluster_state ok
+}
+
+test "Cluster size is 1" {
+    assert {[CI 0 cluster_size] eq 1}
+}
+
+test "Create two empty voters" {
+    cluster_can_be_empty_voter 2
+    cluster_can_be_empty_voter 3
+}
+
+test "Cluster size is 3" {
+    wait_for_condition 1000 50 {
+        [CI 1 cluster_size] eq 3
+    } else {
+        fail "Cluster size is not 3"
+    }
+}
+
+test "Cluster is writable" {
+    cluster_write_test 0
+}
+
+test "Instance #1 is a slave of instance #0" {
+    assert {[RI 1 master_port] eq [get_instance_attrib redis 0 port]}
+}
+
+test "Instance #1 synced with the master" {
+    wait_for_condition 1000 50 {
+        [RI 1 master_link_status] eq {up}
+    } else {
+        fail "Instance #1 master link status is not up"
+    }
+}
+
+test "Killing instance #0" {
+    kill_instance redis 0
+}
+
+test "Instance #1 is elected for an automatic failover" {
+    wait_for_condition 1000 60 {
+        [RI 1 role] eq {master}
+    } else {
+        fail "Instance #1 was not elected for an automatic failover"
+    }
+}

--- a/tests/cluster/tests/includes/init-tests.tcl
+++ b/tests/cluster/tests/includes/init-tests.tcl
@@ -39,6 +39,7 @@ test "Cluster nodes hard reset" {
         R $id EXEC
         R $id config set cluster-node-timeout $node_timeout
         R $id config set cluster-slave-validity-factor 10
+        R $id config set cluster-can-be-empty-voter no
         R $id config rewrite
     }
 }

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -317,7 +317,7 @@ proc end_tests {} {
         puts "GOOD! No errors."
         exit 0
     } else {
-        puts "WARNING $::failed tests faield."
+        puts "WARNING $::failed tests failed."
         exit 1
     }
 }
@@ -507,4 +507,3 @@ proc restart_instance {type id} {
         }
     }
 }
-


### PR DESCRIPTION
Hi,

Yet another PR from us, this time for allowing empty masters to optionally be part of the "cluster size" (and so, both vote on failovers and epoch changes and be counted as part of the quorum size).

This is a feature that is supported by both Redis Sentinel (and RLEC, and many other systems) and is missing in Redis Cluster.

It has "conflicts" with #3069, which pretty much sum up to "which flag receives the value of 512 and which 1024".

Like #3069, this one also seems to work OK with Redis 3.2 (but we're developing over 3.0 because that's what we are running in production).
