### PR TITLE
cmsgpack: pass correct osize values to lua allocator

### DIFF
--- a/deps/lua/src/lua_cmsgpack.c
+++ b/deps/lua/src/lua_cmsgpack.c
@@ -119,10 +119,10 @@ mp_buf *mp_buf_new(lua_State *L) {
 
 void mp_buf_append(mp_buf *buf, const unsigned char *s, size_t len) {
     if (buf->free < len) {
-        size_t newlen = buf->len+len;
+        size_t newsize = (buf->len+len)*2;
 
-        buf->b = (unsigned char*)mp_realloc(buf->L, buf->b, buf->len, newlen*2);
-        buf->free = newlen;
+        buf->b = (unsigned char*)mp_realloc(buf->L, buf->b, buf->len + buf->free, newsize);
+        buf->free = newsize - buf->len;
     }
     memcpy(buf->b+buf->len,s,len);
     buf->len += len;
@@ -130,7 +130,7 @@ void mp_buf_append(mp_buf *buf, const unsigned char *s, size_t len) {
 }
 
 void mp_buf_free(mp_buf *buf) {
-    mp_realloc(buf->L, buf->b, buf->len, 0); /* realloc to 0 = free */
+    mp_realloc(buf->L, buf->b, buf->len + buf->free, 0); /* realloc to 0 = free */
     mp_realloc(buf->L, buf, sizeof(*buf), 0);
 }
 


### PR DESCRIPTION
LUA allocator should always receive a correct value for osize when calling reaclloc/free. This enables customizing the LUA allocator and adding things like accounting of used memory. Currently the cmsgpack extension erroneously passes only 'buf->len' instead of 'buf->len + buf->free' to mp_realloc/mp_buf_append which is wrong.
Additionally it turns out mp_buf_append doesn't correctly update the free size size after allocating x2 of the needed size.
