### PR TITLE
Fix for #3076 Reverse redirect address parse

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -665,7 +665,7 @@ static int cliReadReply(int output_raw_strings) {
         p = strchr(s+1,' ');    /* MOVED[S]3999[P]127.0.0.1:6381 */
         *p = '\0';
         slot = atoi(s+1);
-        s = strchr(p+1,':');    /* MOVED 3999[P]127.0.0.1[S]6381 */
+        s = strrchr(p+1,':');    /* MOVED 3999[P]127.0.0.1[S]6381 */
         *s = '\0';
         sdsfree(config.hostip);
         config.hostip = sdsnew(p+1);


### PR DESCRIPTION
Fix issue in case the redirect address is in ipv6 format. Parse from behind to extract last part of the response which represents actual port.
