### PR TITLE
Updating sentinel client-reconfig-script state report and sentinel.conf

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -165,7 +165,9 @@ sentinel failover-timeout mymaster 180000
 #
 # <master-name> <role> <state> <from-ip> <from-port> <to-ip> <to-port>
 #
-# <state> is currently always "failover"
+# <state> is currently either "promoted" for when the sentinel has promoted a
+#         slave to master, or "updated" for when it receives an update from
+#         another sentinel.
 # <role> is either "leader" or "observer"
 # 
 # The arguments from-ip, from-port, to-ip, to-port are used to communicate

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2157,7 +2157,7 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
             sentinelEvent(LL_WARNING,"+failover-state-reconf-slaves",
                 ri->master,"%@");
             sentinelCallClientReconfScript(ri->master,SENTINEL_LEADER,
-                "start",ri->master->addr,ri->addr);
+                "promoted",ri->master->addr,ri->addr);
             sentinelForceHelloUpdateForMaster(ri->master);
         } else {
             /* A slave turned into a master. We want to force our view and
@@ -2398,7 +2398,7 @@ void sentinelProcessHelloMessage(char *hello, int hello_len) {
                 old_addr = dupSentinelAddr(master->addr);
                 sentinelResetMasterAndChangeAddress(master, token[5], master_port);
                 sentinelCallClientReconfScript(master,
-                    SENTINEL_OBSERVER,"start",
+                    SENTINEL_OBSERVER,"updated",
                     old_addr,master->addr);
                 releaseSentinelAddr(old_addr);
             }


### PR DESCRIPTION
This changes "start" to either "updated" or "promoted" depending on why
it is being called. It also updates the commentary in sentinel.conf to
explain the difference. This is an operations supporting fix in that it will make operations' job in monitoring Redis and controlling client reconfig more flexible and possibly more robust. It certainly makes it more clear as to what is going on and why.

For more depth and details see Redis issue #3093
