### PR TITLE
Add travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: c
+compiler:
+  - clang
+  - gcc
+addons:
+  apt:
+    packages:
+      - tcl
+script: make && make test
+notifications:
+  email: false


### PR DESCRIPTION
This will allow to run build and test on [travis-ci.org](https://travis-ci.org/cyberdelia/redis/builds/112161629).
Once enable on the repo, it will allow for a quick health overview for each PR, branches and commit.
