### PR TITLE
(Minor) Corrected display message from "Redis Sentinel" to "Redis Cluster"

### DIFF
--- a/runtest-cluster
+++ b/runtest-cluster
@@ -8,7 +8,7 @@ done
 
 if [ -z $TCLSH ]
 then
-    echo "You need tcl 8.5 or newer in order to run the Redis Sentinel test"
+    echo "You need tcl 8.5 or newer in order to run the Redis Cluster test"
     exit 1
 fi
 $TCLSH tests/cluster/run.tcl $*


### PR DESCRIPTION
(Minor) Changed display message from "Redis Sentinel" to "Redis Cluster". The script is for testing Redis Cluster (Redis Sentinel has another test script).
