### PR TITLE
Typo correction: "faield" --> "failed"

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -318,7 +318,7 @@ proc end_tests {} {
         puts "GOOD! No errors."
         exit 0
     } else {
-        puts "WARNING $::failed tests faield."
+        puts "WARNING $::failed tests failed."
         exit 1
     }
 }


### PR DESCRIPTION
Typo correction: "faield" --> "failed"
