### PR TITLE
performance boost by caching hash value in dictEntry

### DIFF
--- a/src/dict.h
+++ b/src/dict.h
@@ -45,6 +45,7 @@
 #define DICT_NOTUSED(V) ((void) V)
 
 typedef struct dictEntry {
+    unsigned int hash;
     void *key;
     union {
         void *val;


### PR DESCRIPTION
the idea is to cache hash value in dictEntry, to get following effects
- less dictHashKey() call
- less memory fetch when we're following linked list, since entry->key is not followed if hash value is different. (this happens a lot when hash table size is not too big)

experiment result
SET P16
org : 788022.06 814000.81   799808  793021.44   807297.94
patched : 827472.06 734537.94   829668.94   826446.25   823316.31

GET P16
org : 1064282.62    1064282.62  941708.25   1054963.62  1106806.88
patched : 1141943.62    1147183.62  1143510.62  1112842.25  1122460.38

GET P16 1M keys
org : 1305312.62    1297185.12  1310959.62  1299883 1286008.25
patched : 1334044.88    1336898.38  1322051.75  1320829.5   1319957.75

i'm seeing a few % overall performance boost.
benchmark command used for testing
SET P16 - redis-benchmark -t set -r 100000 -n 10000000 -P 16
GET P16 - redis-benchmark -t get -r 100000 -n 10000000 -P 16
GET P16 1M keys - redis-benchmark -t get -r 1000000 -n 10000000 -P 16

GET P16 1M keys is to test a situation where a lot of non-existent keys are being queried - more hash value mismatches ( more linked list traversal )
GET tests are performed after SET

I didn't test other ops thoroughly but not much difference.

any ideas?
