### PR TITLE
Fix typo in top level README.md => s/sever/server/

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Redis objects are used extensively in the Redis internals, however in order
 to avoid the overhead of indirect accesses, recently in many places
 we just use plain dynamic strings not wrapped inside a Redis object.
 
-sever.c
+server.c
 ---
 
 This is the entry point of the Redis server, where the `main()` function


### PR DESCRIPTION
Just noticed this typo while reading the top level README.md.

Thanks for making redis btw, using it everyday lately and it's a great piece of software, zero configuration for most people, very reliable, powerful and easy to use.
