### PR TITLE
Refine the comment of dictRehashMilliseconds func

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -294,7 +294,9 @@ long long timeInMilliseconds(void) {
     return (((long long)tv.tv_sec)*1000)+(tv.tv_usec/1000);
 }
 
-/* Rehash for an amount of time between ms milliseconds and ms+1 milliseconds */
+/* Rehash in ms+"delta" milliseconds. The value of "delta" is larger 
+ * than 0, and is smaller than 1 in most cases. The exact upper bound 
+ * depends on the running time of dictRehash(d,100).*/
 int dictRehashMilliseconds(dict *d, int ms) {
     long long start = timeInMilliseconds();
     int rehashes = 0;


### PR DESCRIPTION
I thought the previous comment is not accurate. If the running time of dictRehash(d,100) > 1 ms, then this function may exceed (ms+1) milliseconds. 
