### PR TITLE
Fix GEORADIUS negative unit

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -462,6 +462,7 @@ void georadiusGeneric(client *c, int type) {
     double radius_meters = 0, conversion = 1;
     if ((radius_meters = extractDistanceOrReply(c, c->argv + base_args - 2,
                                                 &conversion)) < 0) {
+        addReplyError(c, "unit radius cannot be less than zero");
         return;
     }
 


### PR DESCRIPTION
Requests will hang on `GEORADIUS` when there is a negative unit specified.

reproduce:

``` bash
geoadd fleet -115 33 truck1   # add a truck
georadius fleet -115 33 -1 m  # hang
```
