### PR TITLE
allow writable command even aof_last_write_status == C_ERR

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2427,8 +2427,8 @@ int processCommand(client *c) {
 
     /* Don't accept write commands if there are problems persisting on disk
      * and if this is a master instance. */
-    if (((server.stop_writes_on_bgsave_err &&
-          server.saveparamslen > 0 &&
+    if (server.stop_writes_on_bgsave_err &&
+          ((server.saveparamslen > 0 &&
           server.lastbgsave_status == C_ERR) ||
           server.aof_last_write_status == C_ERR) &&
         server.masterhost == NULL &&


### PR DESCRIPTION
If someone set config set stop-writes-on-bgsave-error no,
 then even though creating RDB fails, Redis allow Writable commands.

but currently, if aof_last_write_status is C_ERR, Redis always prohibits writable commands.

so. I think we should support redis can allow writable commands by admin.

so I think It is better that allow writable command when stop-writes-on-bgsave-error is no,
event though aof_last_write_status is C_ERR.
