### PR TITLE
Change LG_QUANTUM whenever jemalloc is updated

### DIFF
--- a/deps/update-jemalloc.sh
+++ b/deps/update-jemalloc.sh
@@ -6,4 +6,13 @@ curl $URL > /tmp/jemalloc.tar.bz2
 tar xvjf /tmp/jemalloc.tar.bz2
 rm -rf jemalloc
 mv jemalloc-${VER} jemalloc
+
+## Change LG_QUANTUM size from 4 to 3 for  AMD64 and I386.
+## https://github.com/antirez/redis/commit/6b836b6b4148a3623e35807e998097865b9ebb3a
+echo "Update LG_QUANTUM values ..."
+for i in _M_IX86 _M_X64
+do
+    sed -i "/$i/!b;n;c#    define LG_QUANTUM		3" jemalloc/include/jemalloc/internal/jemalloc_internal.h.in
+done
+
 echo "Use git status, add all files and commit changes."


### PR DESCRIPTION
When the user wants to build Redis with different jemalloc version. `LG_QUANTUM` can be forgotten to be changed from 4 to 3 easily. Hence, it will be handy if `LG_QUANTUM` is updated whenever `update-jemalloc.sh` is executed.

related issue: #2510 
