### PR TITLE
build: Add BSDMakefile for !gmake

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,0 +1,11 @@
+# pmake might add -J (private)
+FLAGS=${.MAKEFLAGS:C/\-J ([0-9]+,?)+//W}
+
+all: .DEFAULT
+.DEFAULT:
+	@which gmake > /dev/null 2>&1 ||\
+		(echo "GMake is required for node.js to build.\
+			Install and try again" && exit 1)
+	@gmake ${.FLAGS} ${.TARGETS}
+
+.PHONY: test

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ optimizations (for debugging purposes), and other similar build time options,
 those options are cached indefinitely until you issue a `make distclean`
 command.
 
+Finally, you will need `gmake`.
+
 Fixing problems building 32 bit binaries
 ---------
 


### PR DESCRIPTION
This will redirect `make` on systems where gmake isn't the "default" `make` and exit if `gmake` isn't available, similar to how I did it [for node.js](https://github.com/nodejs/node/blob/master/BSDmakefile).

Also make a small note under troubleshooting build issues that we require `gmake`.
