### PR TITLE
adding objectComputeSize, mem-overhead, total_keyname_size facilities…

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -115,6 +115,8 @@ robj *lookupKeyWriteOrReply(client *c, robj *key, robj *reply) {
 void dbAdd(redisDb *db, robj *key, robj *val) {
     sds copy = sdsdup(key->ptr);
     int retval = dictAdd(db->dict, copy, val);
+    if (retval==DICT_OK)
+        db->total_keyname_size += sdsAllocSize(copy);
 
     serverAssertWithInfo(NULL,key,retval == DICT_OK);
     if (val->type == OBJ_LIST) signalListAsReady(db, key);
@@ -182,15 +184,18 @@ robj *dbRandomKey(redisDb *db) {
 
 /* Delete a key, value, and associated expiration entry if any, from the DB */
 int dbSyncDelete(redisDb *db, robj *key) {
+    dictEntry toFree;
     /* Deleting an entry from the expires dict will not free the sds of
      * the key, because it is shared with the main dictionary. */
     if (dictSize(db->expires) > 0) dictDelete(db->expires,key->ptr);
-    if (dictDelete(db->dict,key->ptr) == DICT_OK) {
+    if (dictDeleteNoFree(db->dict,key->ptr, &toFree) == DICT_OK) {
+        db->total_keyname_size -= sdsAllocSize(dictGetKey(&toFree)); /* we must get the size of the real pointer stored in the db */
         if (server.cluster_enabled) slotToKeyDel(key);
+        sdsfree(dictGetKey(&toFree));
+        decrRefCount(dictGetVal(&toFree));
         return 1;
-    } else {
-        return 0;
     }
+    return 0;
 }
 
 /* This is a wrapper whose behavior depends on the Redis lazy free
@@ -262,13 +267,15 @@ long long emptyDb(int dbnum, int flags, void(callback)(void*)) {
     }
 
     for (j = 0; j < server.dbnum; j++) {
+        redisDb *db = server.db+j;
         if (dbnum != -1 && dbnum != j) continue;
-        removed += dictSize(server.db[j].dict);
+        removed += dictSize(db->dict);
+        db->total_keyname_size = 0;
         if (async) {
-            emptyDbAsync(&server.db[j]);
+            emptyDbAsync(db);
         } else {
-            dictEmpty(server.db[j].dict,callback);
-            dictEmpty(server.db[j].expires,callback);
+            dictEmpty(db->dict,callback);
+            dictEmpty(db->expires,callback);
         }
     }
     if (server.cluster_enabled) {
@@ -340,6 +347,7 @@ void flushdbCommand(client *c) {
     if (getFlushCommandFlags(c,&flags) == C_ERR) return;
     signalFlushedDb(c->db->id);
     server.dirty += emptyDb(c->db->id,flags,NULL);
+    c->db->total_keyname_size = 0;
     addReply(c,shared.ok);
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -305,6 +305,10 @@ void debugCommand(client *c) {
         "jemalloc info  -- Show internal jemalloc statistics.");
         blen++; addReplyStatus(c,
         "jemalloc purge -- Force jemalloc to release unused memory.");
+        blen++; addReplyStatus(c,
+        "key-ram-size <keyname> -- calculate the ram used for storing the object");
+        blen++; addReplyStatus(c,
+        "mem-overhead -- prints ram overheads used by dicts, buffers, etc.");
         setDeferredMultiBulkLength(c,blenp,blen);
     } else if (!strcasecmp(c->argv[1]->ptr,"segfault")) {
         *((char*)-1) = 'x';
@@ -542,6 +546,88 @@ void debugCommand(client *c) {
 #else
         addReplyErrorFormat(c, "jemalloc support not available");
 #endif
+    } else if(!strcasecmp(c->argv[1]->ptr,"key-ram-size") && c->argc == 3) {
+        dictEntry *de;
+        robj *val;
+        size_t size;
+
+        if ((de = dictFind(c->db->dict,c->argv[2]->ptr)) == NULL) {
+            addReplyLongLong(c, 0);
+            return;
+        }
+        val = dictGetVal(de);
+        size = objectComputeSize(val) + sdsAllocSize(dictGetKey(de));
+        addReplyLongLong(c, size);
+    } else if (!strcasecmp(c->argv[1]->ptr,"mem-overhead")) {
+        sds info = sdsempty();
+        int j;
+        size_t mem_total = 0;
+        size_t mem = 0;
+        size_t zmalloc_used = zmalloc_used_memory();
+        
+        info = sdscatprintf(info, "total allocated: %zu\n", zmalloc_used);
+
+        mem = 0;
+        if (server.repl_backlog)
+            mem += zmalloc_size(server.repl_backlog);
+        info = sdscatprintf(info, "repl_backlog: %zu\n", mem);  mem_total+=mem;
+        
+        mem = 0;
+        if (listLength(server.slaves)) {
+            listIter li;
+            listNode *ln;
+
+            listRewind(server.slaves,&li);
+            while((ln = listNext(&li))) {
+                client *client = listNodeValue(ln);
+                mem += getClientOutputBufferMemoryUsage(client);
+                mem += sdsAllocSize(client->querybuf);
+                mem += sizeof(client);
+            }
+        }
+        info = sdscatprintf(info, "slaves: %zu\n", mem);  mem_total+=mem;
+
+        mem = 0;
+        if (listLength(server.clients)) {
+            listIter li;
+            listNode *ln;
+
+            listRewind(server.clients,&li);
+            while((ln = listNext(&li))) {
+                client *client = listNodeValue(ln);
+                if (client->flags & CLIENT_SLAVE)
+                    continue;
+                mem += getClientOutputBufferMemoryUsage(client);
+                mem += sdsAllocSize(client->querybuf);
+                mem += sizeof(client);
+            }
+        }
+        info = sdscatprintf(info, "other clients: %zu\n", mem);  mem_total+=mem;
+        
+        mem = 0;
+        if (server.aof_state != AOF_OFF) {
+            mem += sdslen(server.aof_buf);
+            mem += aofRewriteBufferSize();
+        }
+        info = sdscatprintf(info, "AOF: %zu\n", mem);  mem_total+=mem;
+        
+        for (j = 0; j < server.dbnum; j++) {
+            redisDb *db = server.db+j;
+            long long keyscount = dictSize(db->dict);
+            if (keyscount==0) continue;
+            info = sdscatprintf(info, "db: %d\n", j);
+            mem = db->total_keyname_size;
+            info = sdscatprintf(info, " key names: %zu\n", mem);  mem_total+=mem;
+            mem = dictSize(db->dict) * sizeof(dictEntry) + dictSlots(db->dict) * sizeof(dictEntry*);
+            info = sdscatprintf(info, " db->dict: %zu\n", mem);  mem_total+=mem;
+            mem = dictSize(db->dict) * sizeof(robj);
+            info = sdscatprintf(info, " db->dict robj: %zu\n", mem);  mem_total+=mem;
+            mem = dictSize(db->expires) * sizeof(dictEntry) + dictSlots(db->expires) * sizeof(dictEntry*);
+            info = sdscatprintf(info, " expires: %zu\n", mem);  mem_total+=mem;
+        }
+        info = sdscatprintf(info, "total RAM overhead: %zu\n", mem_total);
+        info = sdscatprintf(info, "RAM left for values: %zu\n", zmalloc_used-mem_total);
+        addReplyStatus(c,info);
     } else {
         addReplyErrorFormat(c, "Unknown DEBUG subcommand or wrong number of arguments for '%s'",
             (char*)c->argv[1]->ptr);
@@ -568,7 +654,7 @@ void _serverAssertPrintClientInfo(client *c) {
 
     bugReportStart();
     serverLog(LL_WARNING,"=== ASSERTION FAILED CLIENT CONTEXT ===");
-    serverLog(LL_WARNING,"client->flags = %d", c->flags);
+    serverLog(LL_WARNING,"client->flags = 0x%x", c->flags);
     serverLog(LL_WARNING,"client->fd = %d", c->fd);
     serverLog(LL_WARNING,"client->argc = %d", c->argc);
     for (j=0; j < c->argc; j++) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -423,12 +423,14 @@ void debugCommand(client *c) {
             addReplyError(c,"Not an sds encoded string.");
         } else {
             addReplyStatusFormat(c,
-                "key_sds_len:%lld, key_sds_avail:%lld, "
-                "val_sds_len:%lld, val_sds_avail:%lld",
+                "key_sds_len:%lld, key_sds_avail:%lld, key_zmalloc: %lld, "
+                "val_sds_len:%lld, val_sds_avail:%lld, val_zmalloc: %lld",
                 (long long) sdslen(key),
                 (long long) sdsavail(key),
+                (long long) sdsZmallocSize(key),
                 (long long) sdslen(val->ptr),
-                (long long) sdsavail(val->ptr));
+                (long long) sdsavail(val->ptr),
+                (long long) getStringObjectSdsUsedMemory(val));
         }
     } else if (!strcasecmp(c->argv[1]->ptr,"populate") &&
                (c->argc == 3 || c->argc == 4)) {

--- a/src/dict.h
+++ b/src/dict.h
@@ -106,19 +106,19 @@ typedef void (dictScanFunction)(void *privdata, const dictEntry *de);
 
 #define dictSetVal(d, entry, _val_) do { \
     if ((d)->type->valDup) \
-        entry->v.val = (d)->type->valDup((d)->privdata, _val_); \
+        (entry)->v.val = (d)->type->valDup((d)->privdata, _val_); \
     else \
-        entry->v.val = (_val_); \
+        (entry)->v.val = (_val_); \
 } while(0)
 
 #define dictSetSignedIntegerVal(entry, _val_) \
-    do { entry->v.s64 = _val_; } while(0)
+    do { (entry)->v.s64 = _val_; } while(0)
 
 #define dictSetUnsignedIntegerVal(entry, _val_) \
-    do { entry->v.u64 = _val_; } while(0)
+    do { (entry)->v.u64 = _val_; } while(0)
 
 #define dictSetDoubleVal(entry, _val_) \
-    do { entry->v.d = _val_; } while(0)
+    do { (entry)->v.d = _val_; } while(0)
 
 #define dictFreeKey(d, entry) \
     if ((d)->type->keyDestructor) \
@@ -126,15 +126,21 @@ typedef void (dictScanFunction)(void *privdata, const dictEntry *de);
 
 #define dictSetKey(d, entry, _key_) do { \
     if ((d)->type->keyDup) \
-        entry->key = (d)->type->keyDup((d)->privdata, _key_); \
+        (entry)->key = (d)->type->keyDup((d)->privdata, _key_); \
     else \
-        entry->key = (_key_); \
+        (entry)->key = (_key_); \
 } while(0)
 
 #define dictCompareKeys(d, key1, key2) \
     (((d)->type->keyCompare) ? \
         (d)->type->keyCompare((d)->privdata, key1, key2) : \
         (key1) == (key2))
+
+#define dictAllocEntry(d) \
+    (zmalloc(sizeof(dictEntry)))
+
+#define dictFreeEntry(d, p) \
+    (zfree(p))
 
 #define dictHashKey(d, key) (d)->type->hashFunction(key)
 #define dictGetKey(he) ((he)->key)
@@ -150,11 +156,12 @@ typedef void (dictScanFunction)(void *privdata, const dictEntry *de);
 dict *dictCreate(dictType *type, void *privDataPtr);
 int dictExpand(dict *d, unsigned long size);
 int dictAdd(dict *d, void *key, void *val);
-dictEntry *dictAddRaw(dict *d, void *key);
+dictEntry *dictMove(dict *src, dict *dst, void *key);
+dictEntry *dictAddRaw(dict *d, void *key, dictEntry **getExisting);
 int dictReplace(dict *d, void *key, void *val);
 dictEntry *dictReplaceRaw(dict *d, void *key);
 int dictDelete(dict *d, const void *key);
-int dictDeleteNoFree(dict *d, const void *key);
+int dictDeleteNoFree(dict *d, const void *key, dictEntry *copyOfEntry);
 void dictRelease(dict *d);
 dictEntry * dictFind(dict *d, const void *key);
 void *dictFetchValue(dict *d, const void *key);

--- a/src/object.c
+++ b/src/object.c
@@ -732,3 +732,109 @@ void objectCommand(client *c) {
     }
 }
 
+/* returns the size in bytes consumed by the key's value in RAM */
+size_t objectComputeSize(robj *o) {
+    robj *ele;
+    list *l;
+    listNode *ln;
+    dict *d;
+    dictIterator *di;
+    listIter li;
+    struct dictEntry *de;
+    size_t asize = 0, elesize;
+
+    if (o->type == OBJ_STRING) {
+        if(o->encoding == OBJ_ENCODING_INT) {
+            asize = sizeof(*o);
+        }
+        else if(o->encoding == OBJ_ENCODING_RAW) {
+            asize = sdsAllocSize(o->ptr)+sizeof(*o);
+        } else if(o->encoding == OBJ_ENCODING_EMBSTR) {
+            asize = sdslen(o->ptr)+2+sizeof(*o);
+        } else {
+            serverPanic("Unknown string encoding");
+        }
+    } else if (o->type == OBJ_LIST) {
+        if (o->encoding == OBJ_ENCODING_QUICKLIST) {
+            quicklist *ql = o->ptr;
+            quicklistNode *node = ql->head;
+            asize = sizeof(*o)+sizeof(quicklist);
+            do {
+                asize += sizeof(quicklistNode)+ziplistBlobLen(node->zl);
+            } while ((node = node->next));
+        } else if (o->encoding == OBJ_ENCODING_ZIPLIST) {
+            asize = sizeof(*o)+ziplistBlobLen(o->ptr);
+        } else if (o->encoding == OBJ_ENCODING_LINKEDLIST) {
+            l = o->ptr;
+            asize = sizeof(*o)+sizeof(list);
+            listRewind(l,&li);
+            while((ln = listNext(&li))) {
+                ele = ln->value;
+                elesize = (ele->encoding == OBJ_ENCODING_RAW) ?
+                                (sizeof(*o)+sdsAllocSize(ele->ptr)) : sizeof(*o);
+                asize += (sizeof(listNode)+elesize);
+            }
+        } else {
+            serverPanic("Unknown list encoding");
+        }
+    } else if (o->type == OBJ_SET) {
+        if (o->encoding == OBJ_ENCODING_HT) {
+            d = o->ptr;
+            di = dictGetIterator(d);
+            asize = sizeof(*o)+sizeof(dict)+(sizeof(struct dictEntry*)*dictSlots(d));
+            while((de = dictNext(di)) != NULL) {
+                ele = dictGetKey(de);
+                elesize = (ele->encoding == OBJ_ENCODING_RAW) ?
+                                (sizeof(*o)+sdsAllocSize(ele->ptr)) : sizeof(*o);
+                asize += (sizeof(struct dictEntry)+elesize);
+            }
+            dictReleaseIterator(di);
+        } else if (o->encoding == OBJ_ENCODING_INTSET) {
+            intset *is = o->ptr;
+            asize = sizeof(*o)+sizeof(*is)+is->encoding*is->length;
+        } else {
+            serverPanic("Unknown set encoding");
+        }
+    } else if (o->type == OBJ_ZSET) {
+        if (o->encoding == OBJ_ENCODING_ZIPLIST) {
+            asize = sizeof(*o)+(ziplistBlobLen(o->ptr));
+        } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
+            d = ((zset*)o->ptr)->dict;
+            di = dictGetIterator(d);
+            asize = sizeof(*o)+sizeof(zset)+(sizeof(struct dictEntry*)*dictSlots(d));
+            while((de = dictNext(di)) != NULL) {
+                ele = dictGetKey(de);
+                elesize = (ele->encoding == OBJ_ENCODING_RAW) ?
+                                (sizeof(*o)+sdsAllocSize(ele->ptr)) : sizeof(*o);
+                asize += (sizeof(struct dictEntry)+elesize);
+                asize += sizeof(zskiplistNode)*dictSize(d);
+            }
+            dictReleaseIterator(di);
+        } else {
+            serverPanic("Unknown sorted set encoding");
+        }
+    } else if (o->type == OBJ_HASH) {
+        if (o->encoding == OBJ_ENCODING_ZIPLIST) {
+            asize = sizeof(*o)+(ziplistBlobLen(o->ptr));
+        } else if (o->encoding == OBJ_ENCODING_HT) {
+            d = o->ptr;
+            di = dictGetIterator(d);
+            asize = sizeof(*o)+sizeof(dict)+(sizeof(struct dictEntry*)*dictSlots(d));
+            while((de = dictNext(di)) != NULL) {
+                ele = dictGetKey(de);
+                elesize = (ele->encoding == OBJ_ENCODING_RAW) ?
+                                (sizeof(*o)+sdsAllocSize(ele->ptr)) : sizeof(*o);
+                ele = dictGetVal(de);
+                elesize = (ele->encoding == OBJ_ENCODING_RAW) ?
+                                (sizeof(*o)+sdsAllocSize(ele->ptr)) : sizeof(*o);
+                asize += (sizeof(struct dictEntry)+elesize);
+            }
+            dictReleaseIterator(di);
+        } else {
+            serverPanic("Unknown hash encoding");
+        }
+    } else {
+        serverPanic("Unknown object type");
+    }
+    return asize;
+}

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3626,15 +3626,14 @@ struct sentinelLeader {
 /* Helper function for sentinelGetLeader, increment the counter
  * relative to the specified runid. */
 int sentinelLeaderIncr(dict *counters, char *runid) {
-    dictEntry *de = dictFind(counters,runid);
+    dictEntry *existing, *de;
     uint64_t oldval;
-
-    if (de) {
-        oldval = dictGetUnsignedIntegerVal(de);
-        dictSetUnsignedIntegerVal(de,oldval+1);
+    de = dictAddRaw(counters,runid,&existing);
+    if (existing) {
+        oldval = dictGetUnsignedIntegerVal(existing);
+        dictSetUnsignedIntegerVal(existing,oldval+1);
         return oldval+1;
     } else {
-        de = dictAddRaw(counters,runid);
         serverAssert(de != NULL);
         dictSetUnsignedIntegerVal(de,1);
         return 1;

--- a/src/server.h
+++ b/src/server.h
@@ -1128,6 +1128,8 @@ void addReplyHumanLongDouble(client *c, long double d);
 void addReplyLongLong(client *c, long long ll);
 void addReplyMultiBulkLen(client *c, long length);
 void copyClientOutputBuffer(client *dst, client *src);
+size_t sdsZmallocSize(sds s);
+size_t getStringObjectSdsUsedMemory(robj *o);
 void *dupClientReplyValue(void *o);
 void getClientsMaxBuffers(unsigned long *longest_output_list,
                           unsigned long *biggest_input_buffer);

--- a/src/server.h
+++ b/src/server.h
@@ -511,6 +511,7 @@ typedef struct redisDb {
     dict *blocking_keys;        /* Keys with clients waiting for data (BLPOP) */
     dict *ready_keys;           /* Blocked keys that received a PUSH */
     dict *watched_keys;         /* WATCHED keys for MULTI/EXEC CAS */
+    size_t total_keyname_size;  /* total RAM size consumed by keynames */
     struct evictionPoolEntry *eviction_pool;    /* Eviction pool of keys */
     int id;                     /* Database ID */
     long long avg_ttl;          /* Average TTL, just for stats */
@@ -1234,6 +1235,7 @@ int compareStringObjects(robj *a, robj *b);
 int collateStringObjects(robj *a, robj *b);
 int equalStringObjects(robj *a, robj *b);
 unsigned long long estimateObjectIdleTime(robj *o);
+size_t objectComputeSize(robj *o);
 #define sdsEncodedObject(objptr) (objptr->encoding == OBJ_ENCODING_RAW || objptr->encoding == OBJ_ENCODING_EMBSTR)
 
 /* Synchronous I/O with timeout */

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -53,7 +53,7 @@ int setTypeAdd(robj *subject, sds value) {
     long long llval;
     if (subject->encoding == OBJ_ENCODING_HT) {
         dict *ht = subject->ptr;
-        dictEntry *de = dictAddRaw(ht,value);
+        dictEntry *de = dictAddRaw(ht,value, NULL);
         if (de) {
             dictSetKey(ht,de,sdsdup(value));
             dictSetVal(ht,de,NULL);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2262,7 +2262,7 @@ void zunionInterGenericCommand(client *c, robj *dstkey, int op) {
     } else if (op == SET_OP_UNION) {
         dict *accumulator = dictCreate(&setAccumulatorDictType,NULL);
         dictIterator *di;
-        dictEntry *de;
+        dictEntry *de, *existing;
         double score;
 
         if (setnum) {
@@ -2282,17 +2282,17 @@ void zunionInterGenericCommand(client *c, robj *dstkey, int op) {
                 score = src[i].weight * zval.score;
                 if (isnan(score)) score = 0;
 
-                /* Search for this element in the accumulating dictionary. */
-                de = dictFind(accumulator,zuiSdsFromValue(&zval));
+                /* Search/Add for this element in the accumulating dictionary. */
+                de = dictAddRaw(accumulator,zuiSdsFromValue(&zval),&existing);
                 /* If we don't have it, we need to create a new entry. */
-                if (de == NULL) {
+                if (!existing) {
                     tmp = zuiNewSdsFromValue(&zval);
                     /* Remember the longest single element encountered,
                      * to understand if it's possible to convert to ziplist
                      * at the end. */
                      if (sdslen(tmp) > maxelelen) maxelelen = sdslen(tmp);
-                    /* Add the element with its initial score. */
-                    de = dictAddRaw(accumulator,tmp);
+                    /* Update the element that was added with its initial score, and its own key allocation. */
+                    dictSetKey(accumulator, de, tmp);
                     dictSetDoubleVal(de,score);
                 } else {
                     /* Update the score with the score of the new instance
@@ -2301,7 +2301,7 @@ void zunionInterGenericCommand(client *c, robj *dstkey, int op) {
                      * Here we access directly the dictEntry double
                      * value inside the union as it is a big speedup
                      * compared to using the getDouble/setDouble API. */
-                    zunionInterAggregate(&de->v.d,score,aggregate);
+                    zunionInterAggregate(&existing->v.d,score,aggregate);
                 }
             }
             zuiClearIterator(&src[i]);


### PR DESCRIPTION
Hi,
These are some improvements and optimizations which may required a closer inspection.
- DEBUG MEM-OVERHEAD
- DEBUG KEY-RAM-SIZE (objectComputeSize)
- INFO MEMORY (added ram-overhead and key-overhead)
- optimizations to avoid double dict lookup (hashing, strcmp, etc)

i had to do quite a lot changes to adapt this code from my 3.2 to the unstable (since it's so different). i hope i got it right.
if you want to backport these to 3.2 / 3.0 maybe i can help.

please first look at sentinel.c / lazyfree.c / zset.c to see the benefit of not doing key hashing / lookup twice (find+del / find+add) before you look at the massive changes in dict.c.
this way you'll know if you think it wroth to do a careful review of how i did that.

the changes in dict.c are explained at the bottom.

BTW, i only applied these optimizations on a few random places, i guess there are many other places in the code which do find+del / find+add in which we can do that optimization.

besides the places in redis code that call find+add, the original implementation of dictReplace had repeated lookup internally (fixed)

the code in objectComputeSize() needs your review, i'm not 100% sure it is correct.

the code in debug.c looks a bit dirty since i originally wrote it for my own debugging, please feel free to refactor / rename it if you choose to accept it.

here's a description of the changes in dict.c (i'm quite sure there are no bugs there):
- add dictMove can be used to move an entry from one dict to the other without double key-hashing and memory allocation overheads.
- avoid repeated key-hashing like find followed by add or by delete (see previous implementation of dictReplace)
- responsibilities and scope of _dictKeyIndex and dictGenericDelete changed so that they are flexible and better serve wrapper functions.
- dictDeleteNoFree can optionally return a copy of the dictEntry it deleted (someone can use it instead of doing dictFind before calling dictDelete)
- dictAddRaw optionally returns the pre-existing entry in case the add failed (so someone doesn't need to call find when it fails if he needs the entry)
- comment improvements on function names: dictReplace = "Add or Overwrite", dictReplaceRaw = "Add or Find", etc.
