### PR TITLE
Allow non-interactive execution of install_server

### DIFF
--- a/utils/install_server.sh
+++ b/utils/install_server.sh
@@ -25,9 +25,25 @@
 #
 ################################################################################
 #
-# Interactive service installer for redis server
-# this generates a redis config file and an /etc/init.d script, and installs them
-# this scripts should be run as root
+# Service installer for redis server, runs interactively by default.
+#
+# To run this script non-interactively (for automation/provisioning purposes),
+# feed the variables into the script. Any missing variables will be prompted!
+# Tip: Environment variables also support command substitution (see REDIS_EXECUTABLE)
+#
+# Example:
+#
+# sudo REDIS_PORT=1234 \
+# 		 REDIS_CONFIG_FILE=/etc/redis/1234.conf \
+# 		 REDIS_LOG_FILE=/var/log/redis_1234.log \
+# 		 REDIS_DATA_DIR=/var/lib/redis/1234 \
+# 		 REDIS_EXECUTABLE=`command -v redis-server` ./utils/install_server.sh
+#
+# This generates a redis config file and an /etc/init.d script, and installs them.
+#
+# /!\ This script should be run as root
+#
+################################################################################
 
 die () {
 	echo "ERROR: $1. Aborting!"


### PR DESCRIPTION
This PR adds the ability to execute the installation script non-interactively, useful for automated provisioning scripts such as Chef, Puppet, Ansible, Salt, etc.
Simply feed the environment variables into the install script to skip the prompts.

For debug and verification purposes, the script will still output the selected config variables.
The plus side is that the environment variables also support command substitution (see REDIS_EXECUTABLE).

```
sudo REDIS_PORT=1234 REDIS_CONFIG_FILE=/etc/redis/1234.conf REDIS_LOG_FILE=/var/log/redis_1234.log REDIS_DATA_DIR=/var/lib/redis/1234 REDIS_EXECUTABLE=`command -v redis-server` ./utils/install_server.sh

Welcome to the redis service installer
This script will help you easily set up a running redis server

Selected config:
Port           : 1234
Config file    : /etc/redis/1234.conf
Log file       : /var/log/redis_1234.log
Data dir       : /var/lib/redis/1234
Executable     : /usr/local/bin/redis-server
Cli Executable : /usr/local/bin/redis-cli
Copied /tmp/1234.conf => /etc/init.d/redis_1234
Installing service...
Successfully added to chkconfig!
Successfully added to runlevels 345!
Starting Redis server...
Installation successful!
```
