### PR TITLE
Fix client kill all with id 0 or with skipme

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1537,6 +1537,7 @@ void clientCommand(client *c) {
         listRewind(server.clients,&li);
         while ((ln = listNext(&li)) != NULL) {
             client = listNodeValue(ln);
+            if (!addr && type == -1 && id == 0) continue;
             if (addr && strcmp(getClientPeerId(client),addr) != 0) continue;
             if (type != -1 && getClientType(client) != type) continue;
             if (id != 0 && client->id != id) continue;


### PR DESCRIPTION
This commit fixes two kill all issues:
1. Client kill id 0
2. Client kill skipme no (or client kill skipme yes)
