### PR TITLE
add DEBUG LOAD command

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -314,6 +314,7 @@ void debugCommand(client *c) {
 "OBJECT <key> -- Show low level info about key and associated value.",
 "PANIC -- Crash the server simulating a panic.",
 "POPULATE <count> [prefix] [size] -- Create <count> string keys named key:<num>. If a prefix is specified is used instead of the 'key' prefix.",
+"LOAD -- load the persistent file to memory (without flashing).",
 "RELOAD -- Save the RDB on disk and reload it back in memory.",
 "RESTART -- Graceful restart: save config, db, restart.",
 "SDSLEN <key> -- Show low level SDS string info representing key and value.",
@@ -352,6 +353,10 @@ NULL
         serverAssertWithInfo(c,c->argv[0],1 == 2);
     } else if (!strcasecmp(c->argv[1]->ptr,"log") && c->argc == 3) {
         serverLog(LL_WARNING, "DEBUG LOG: %s", (char*)c->argv[2]->ptr);
+        addReply(c,shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr,"load")) {
+        loadDataFromDisk();
+        serverLog(LL_WARNING,"DB loaded by DEBUG LOAD");
         addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"reload")) {
         rdbSaveInfo rsi, *rsiptr;

--- a/src/debug.c
+++ b/src/debug.c
@@ -355,6 +355,7 @@ NULL
         serverLog(LL_WARNING, "DEBUG LOG: %s", (char*)c->argv[2]->ptr);
         addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"load")) {
+        emptyDb(-1,EMPTYDB_NO_FLAGS,NULL);
         loadDataFromDisk();
         serverLog(LL_WARNING,"DB loaded by DEBUG LOAD");
         addReply(c,shared.ok);

--- a/src/server.h
+++ b/src/server.h
@@ -1825,6 +1825,7 @@ int zslLexValueLteMax(sds value, zlexrangespec *spec);
 /* Core functions */
 int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *level);
 size_t freeMemoryGetNotCountedMemory();
+void loadDataFromDisk(void);
 int freeMemoryIfNeeded(void);
 int freeMemoryIfNeededAndSafe(void);
 int processCommand(client *c);


### PR DESCRIPTION
hi, as we discussed, adding a DEBUG command like RELOAD that doesn't first save to disk.
can be used by power users to load data without the need to restart the process.

i decided to support AOF too in this function and also concluded it will be more powerful if it won't flush the database (emptyDb) before loading the file (people can use it to load multiple rdb / aof files)

please note however, that FLUSHALL command saves an empty RDB or adds a flush command to the AOF, so if someone wishes to do a combination of FLUSHALL and then DEBUG LOAD, he'll have to put the file he wishes to load in the right location only after the FLUSHALL.
still since this is a debug command i feel making it more raw and powerful is the right thing, if you think otherwise let me know.
