### PR TITLE
Optimized autoMemoryFreed loop

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -580,7 +580,7 @@ void autoMemoryFreed(RedisModuleCtx *ctx, int type, void *ptr) {
     if (!(ctx->flags & REDISMODULE_CTX_AUTO_MEMORY)) return;
 
     int j;
-    for (j = 0; j < ctx->amqueue_used; j++) {
+    for (j = ctx->amqueue_used - 1; j >= 0; j--) {
         if (ctx->amqueue[j].type == type &&
             ctx->amqueue[j].ptr == ptr)
         {
@@ -588,6 +588,9 @@ void autoMemoryFreed(RedisModuleCtx *ctx, int type, void *ptr) {
             /* Optimization: if this is the last element, we can
              * reuse it. */
             if (j == ctx->amqueue_used-1) ctx->amqueue_used--;
+
+            break;
+
         }
     }
 }

--- a/src/module.c
+++ b/src/module.c
@@ -585,12 +585,17 @@ void autoMemoryFreed(RedisModuleCtx *ctx, int type, void *ptr) {
             ctx->amqueue[j].ptr == ptr)
         {
             ctx->amqueue[j].type = REDISMODULE_AM_FREED;
-            /* Optimization: if this is the last element, we can
-             * reuse it. */
-            if (j == ctx->amqueue_used-1) ctx->amqueue_used--;
+            
+            /* Switch the freed element and the top element, to avoid growing
+             * the queue unnecessarily if we allocate/free in a loop */
+            if (j != ctx->amqueue_used-1) {
+                ctx->amqueue[j] = ctx->amqueue[ctx->amqueue_used-1];
+            }
+            /* Reduce the size of the queue because we either moved the top
+             * element elsewhere or freed it */ 
+            ctx->amqueue_used--;
 
             break;
-
         }
     }
 }


### PR DESCRIPTION
This fixes two issues:
1. If we have a lot of objects allocated and we're freeing, it's a better heuristic to start from the recent elements than from the oldest elements if we want to find the element freed.
2. The loop didn't have a `break` after marking the element as freed, making it slow as the element list grew.

In a huge SCAN loop adding this made it run X100 faster
