### PR TITLE
fix georadius returns multiple replies

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -156,9 +156,13 @@ double extractDistanceOrReply(client *c, robj **argv,
         return -1;
     }
 
+    if (distance < 0) {
+        addReplyError(c,"radius cannot be negative");
+        return -1;
+    }
+    
     double to_meters = extractUnitOrReply(c,argv[1]);
     if (to_meters < 0) {
-        addReplyError(c,"radius cannot be negative");
         return -1;
     }
 
@@ -465,7 +469,6 @@ void georadiusGeneric(client *c, int type) {
     double radius_meters = 0, conversion = 1;
     if ((radius_meters = extractDistanceOrReply(c, c->argv + base_args - 2,
                                                 &conversion)) < 0) {
-        addReplyError(c,"radius must be >= 0");
         return;
     }
 


### PR DESCRIPTION
> geoadd asdf 1 2 asdf
> (integer) 1
> georadius asdf 1 2 3 fv
> (error) ERR unsupported unit provided. please use m, km, ft, mi
> ping
> (error) ERR radius cannot be negative
> ping
> (error) ERR radius must be >= 0
> ping
> PONG
