### PR TITLE
change argument name for deleteDict() and dictDeleteNoFree() in dict.c

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -446,12 +446,12 @@ static int dictGenericDelete(dict *d, const void *key, int nofree)
     return DICT_ERR; /* not found */
 }
 
-int dictDelete(dict *ht, const void *key) {
-    return dictGenericDelete(ht,key,0);
+int dictDelete(dict *d, const void *key) {
+    return dictGenericDelete(d,key,0);
 }
 
-int dictDeleteNoFree(dict *ht, const void *key) {
-    return dictGenericDelete(ht,key,1);
+int dictDeleteNoFree(dict *d, const void *key) {
+    return dictGenericDelete(d,key,1);
 }
 
 /* Destroy an entire dictionary */


### PR DESCRIPTION
Since two methods in dict.h both use `dict *d` as argument, but the dict.c uses `dict *ht`, so I guess using  `d` will make it more clear that it represents dictionary rather than hash table.
