### PR TITLE
Sentinel: fix check when can't send the command to the promoted slave

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3996,7 +3996,7 @@ void sentinelFailoverSendSlaveOfNoOne(sentinelRedisInstance *ri) {
     /* We can't send the command to the promoted slave if it is now
      * disconnected. Retry again and again with this state until the timeout
      * is reached, then abort the failover. */
-    if (ri->link->disconnected) {
+    if (ri->promoted_slave->link->disconnected) {
         if (mstime() - ri->failover_state_change_time > ri->failover_timeout) {
             sentinelEvent(LL_WARNING,"-failover-abort-slave-timeout",ri,"%@");
             sentinelAbortFailover(ri);


### PR DESCRIPTION
ref: https://github.com/antirez/redis/issues/3273

this commit introduce this bug, https://github.com/antirez/redis/commit/1029276c0d46e643a5740120d44a9cce8ba652b9#diff-45b8aaf53e1ac2b9134c1e0ad96a0e03L3684
