### PR TITLE
bitcount bug:return non-zero value when start > end (both negative)

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -768,6 +768,10 @@ void bitcountCommand(client *c) {
         /* Convert negative indexes */
         if (start < 0) start = strlen+start;
         if (end < 0) end = strlen+end;
+        if ((start < 0) && (end < 0) && (start > end)) {
+            addReply(c,shared.czero);
+            return;
+        }
         if (start < 0) start = 0;
         if (end < 0) end = 0;
         if (end >= strlen) end = strlen-1;


### PR DESCRIPTION
There are some points to be considerd  when start/end index are both negative and bigger than strlen.
For example ,when we send 2 command to redis:
    set key 1111;
   ① bitcount key -6 -7  or ② bitcount key -5 -5_
- ① should return 0 for logic consistency, (bitcount key -3 -4 returns 0).
- but ②'s return value varies when we treat out-of-range area as 0 or we just treat negative index(bigger than strlen) as 0.
