### PR TITLE
Allow passing arguments to modules on load.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -155,13 +155,13 @@ void resetServerSaveParams(void) {
 
 void queueLoadModule(sds path, sds *argv, int argc)
 {
-    struct loadmodule *loadmod = zmalloc(sizeof(struct loadmodule)+sizeof(sds)*argc);
+    struct loadmodule *loadmod = zmalloc(sizeof(struct loadmodule)+sizeof(robj*)*argc);
     int i;
 
     loadmod->path = sdsnew(path);
     loadmod->argc = argc;
     for (i = 0; i < argc; i++) {
-        loadmod->argv[i] = sdsnew(argv[i]);
+        loadmod->argv[i] = createStringObject(argv[i],sdslen(argv[i]));
     }
     listAddNodeTail(server.loadmodule_queue,loadmod);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -3011,16 +3011,12 @@ void moduleCommand(client *c) {
     char *subcmd = c->argv[1]->ptr;
 
     if (!strcasecmp(subcmd,"load") && c->argc >= 3) {
-        sds *argv = NULL;
+        robj **argv = NULL;
         int argc = 0;
-        int i;
 
         if (c->argc > 3) {
             argc = c->argc - 3;
-            argv = zmalloc(sizeof(sds)*argc);
-            for (i=0; i<argc; i++) {
-                argv[i] = (sds) c->argv[i+3]->ptr;
-            }
+            argv = &c->argv[3];
         }
 
         if (moduleLoad(c->argv[2]->ptr,(void **)argv,argc) == C_OK)
@@ -3028,8 +3024,6 @@ void moduleCommand(client *c) {
         else
             addReplyError(c,
                 "Error loading the extension. Please check the server logs.");
-        if (argv)
-            zfree(argv);
     } else if (!strcasecmp(subcmd,"unload") && c->argc == 3) {
         if (moduleUnload(c->argv[2]->ptr) == C_OK)
             addReply(c,shared.ok);

--- a/src/module.c
+++ b/src/module.c
@@ -2897,11 +2897,11 @@ void moduleLoadFromQueue(void) {
 
     listRewind(server.loadmodule_queue,&li);
     while((ln = listNext(&li))) {
-        sds modulepath = ln->value;
-        if (moduleLoad(modulepath) == C_ERR) {
+        struct loadmodule *loadmod = ln->value;
+        if (moduleLoad(loadmod->path,(void **)loadmod->argv,loadmod->argc) == C_ERR) {
             serverLog(LL_WARNING,
                 "Can't load module from %s: server aborting",
-                modulepath);
+                loadmod->path);
             exit(1);
         }
     }
@@ -2915,8 +2915,8 @@ void moduleFreeModuleStructure(struct RedisModule *module) {
 
 /* Load a module and initialize it. On success C_OK is returned, otherwise
  * C_ERR is returned. */
-int moduleLoad(const char *path) {
-    int (*onload)(void *);
+int moduleLoad(const char *path, void **module_argv, int module_argc) {
+    int (*onload)(void *, void **, int);
     void *handle;
     RedisModuleCtx ctx = REDISMODULE_CTX_INIT;
 
@@ -2925,14 +2925,14 @@ int moduleLoad(const char *path) {
         serverLog(LL_WARNING, "Module %s failed to load: %s", path, dlerror());
         return C_ERR;
     }
-    onload = (int (*)(void *))(unsigned long) dlsym(handle,"RedisModule_OnLoad");
+    onload = (int (*)(void *, void **, int))(unsigned long) dlsym(handle,"RedisModule_OnLoad");
     if (onload == NULL) {
         serverLog(LL_WARNING,
             "Module %s does not export RedisModule_OnLoad() "
             "symbol. Module not loaded.",path);
         return C_ERR;
     }
-    if (onload((void*)&ctx) == REDISMODULE_ERR) {
+    if (onload((void*)&ctx,module_argv,module_argc) == REDISMODULE_ERR) {
         if (ctx.module) moduleFreeModuleStructure(ctx.module);
         dlclose(handle);
         serverLog(LL_WARNING,
@@ -3006,16 +3006,30 @@ int moduleUnload(sds name) {
 
 /* Redis MODULE command.
  *
- * MODULE LOAD <path> */
+ * MODULE LOAD <path> [args...] */
 void moduleCommand(client *c) {
     char *subcmd = c->argv[1]->ptr;
 
-    if (!strcasecmp(subcmd,"load") && c->argc == 3) {
-        if (moduleLoad(c->argv[2]->ptr) == C_OK)
+    if (!strcasecmp(subcmd,"load") && c->argc >= 3) {
+        sds *argv = NULL;
+        int argc = 0;
+        int i;
+
+        if (c->argc > 3) {
+            argc = c->argc - 3;
+            argv = zmalloc(sizeof(sds)*argc);
+            for (i=0; i<argc; i++) {
+                argv[i] = (sds) c->argv[i+3]->ptr;
+            }
+        }
+
+        if (moduleLoad(c->argv[2]->ptr,(void **)argv,argc) == C_OK)
             addReply(c,shared.ok);
         else
             addReplyError(c,
                 "Error loading the extension. Please check the server logs.");
+        if (argv)
+            zfree(argv);
     } else if (!strcasecmp(subcmd,"unload") && c->argc == 3) {
         if (moduleUnload(c->argv[2]->ptr) == C_OK)
             addReply(c,shared.ok);

--- a/src/server.h
+++ b/src/server.h
@@ -686,7 +686,7 @@ struct saveparam {
 struct loadmodule {
     sds path;
     int argc;
-    sds argv[];
+    robj *argv[];
 };
 
 struct sharedObjectsStruct {

--- a/src/server.h
+++ b/src/server.h
@@ -683,6 +683,12 @@ struct saveparam {
     int changes;
 };
 
+struct loadmodule {
+    sds path;
+    int argc;
+    sds argv[];
+};
+
 struct sharedObjectsStruct {
     robj *crlf, *ok, *err, *emptybulk, *czero, *cone, *cnegone, *pong, *space,
     *colon, *nullbulk, *nullmultibulk, *queued,
@@ -1156,7 +1162,7 @@ extern dictType modulesDictType;
 
 /* Modules */
 void moduleInitModulesSystem(void);
-int moduleLoad(const char *path);
+int moduleLoad(const char *path, void **argv, int argc);
 void moduleLoadFromQueue(void);
 int *moduleGetCommandKeysViaAPI(struct redisCommand *cmd, robj **argv, int argc, int *numkeys);
 moduleType *moduleTypeLookupModuleByID(uint64_t id);


### PR DESCRIPTION
There is a need to provide modules with configuration data.  In some cases it must be done at load time, so creating a custom module config command doesn't work.

I also considered using the current Redis config file/CONFIG commands but I don't see how this can be done in a simple and clean way.

The best alternative I came up with is simply passing arguments at load time.  This works well in all module loading approaches (i.e. MODULE LOAD command or config argument) and is even quite elegant (IMHO) at the API level because the RedisModule_OnLoad prototype is then equivalent to command callbacks.

The only problem I see is breaking the API but I believe it may be acceptable to do in this early stage.
