### PR TITLE
Remove gcc warning when redismodule.h is included by a multi-file module.

### DIFF
--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -182,6 +182,7 @@ void REDISMODULE_API_FUNC(RedisModule_SaveDouble)(RedisModuleIO *io, double valu
 double REDISMODULE_API_FUNC(RedisModule_LoadDouble)(RedisModuleIO *io);
 
 /* This is included inline inside each Redis module. */
+static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int apiver) __attribute__((unused));
 static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int apiver) {
     void *getapifuncptr = ((void**)ctx)[0];
     RedisModule_GetApi = (int (*)(const char *, void *)) (unsigned long)getapifuncptr;


### PR DESCRIPTION
If a module is composed of several files, gcc complains about `RedisModule_Init()` defined but not used in all files except the one implementing RedisModule_OnLoad().
