### PR TITLE
Include select.h to fix unknown type name 'fd_set' compile error in ae_select (MSYS2)

### DIFF
--- a/src/ae_select.c
+++ b/src/ae_select.c
@@ -29,6 +29,7 @@
  */
 
 
+#include <sys/select.h>
 #include <string.h>
 
 typedef struct aeApiState {


### PR DESCRIPTION
Fix a building-on-MSYS2 `error: unknown type name ‘fd_set’`

This resolves the following errors/warnings:

```
In file included from ae.c:58:0:
ae_select.c:35:5: error: unknown type name ‘fd_set’
     fd_set rfds, wfds;
     ^
ae_select.c:38:5: error: unknown type name ‘fd_set’
     fd_set _rfds, _wfds;
     ^
ae_select.c: In function ‘aeApiCreate’:
ae_select.c:45:5: warning: implicit declaration of function ‘FD_ZERO’ [-Wimplicit-function-declaration]
     FD_ZERO(&state->rfds);
     ^
ae_select.c: In function ‘aeApiResize’:
ae_select.c:53:20: error: ‘FD_SETSIZE’ undeclared (first use in this function)
     if (setsize >= FD_SETSIZE) return -1;
                    ^
ae_select.c:53:20: note: each undeclared identifier is reported only once for each function it appears in
ae_select.c: In function ‘aeApiAddEvent’:
ae_select.c:64:29: warning: implicit declaration of function ‘FD_SET’ [-Wimplicit-function-declaration]
     if (mask & AE_READABLE) FD_SET(fd,&state->rfds);
                             ^
ae_select.c: In function ‘aeApiDelEvent’:
ae_select.c:72:29: warning: implicit declaration of function ‘FD_CLR’ [-Wimplicit-function-declaration]
     if (mask & AE_READABLE) FD_CLR(fd,&state->rfds);
                             ^
ae_select.c: In function ‘aeApiPoll’:
ae_select.c:80:46: error: ‘fd_set’ undeclared (first use in this function)
     memcpy(&state->_rfds,&state->rfds,sizeof(fd_set));
                                              ^
ae_select.c:83:14: warning: implicit declaration of function ‘select’ [-Wimplicit-function-declaration]
     retval = select(eventLoop->maxfd+1,
              ^
ae_select.c:91:43: warning: implicit declaration of function ‘FD_ISSET’ [-Wimplicit-function-declaration]
             if (fe->mask & AE_READABLE && FD_ISSET(j,&state->_rfds))
                                           ^
```

This was encountered when building https://github.com/armon/statsite/pull/165 using MSYS2 (for Windows).

The fix was recommended here: https://github.com/Claudio-Sjo/HID_linux_xbmc_driver/issues/1.

I verified this change did not break the build on Linux; haven't had a chance to check Mac OS X yet.
