### PR TITLE
Make history file private #3284

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1287,7 +1287,11 @@ static void repl(void) {
         if (line[0] != '\0') {
             argv = cliSplitArgs(line,&argc);
             if (history) linenoiseHistoryAdd(line);
-            if (historyfile) linenoiseHistorySave(historyfile);
+            if (historyfile) {
+                mode_t cur_mask = umask(S_IRWXG | S_IRWXO);
+                linenoiseHistorySave(historyfile);
+                umask(cur_mask);
+            }
 
             if (argv == NULL) {
                 printf("Invalid argument(s)\n");


### PR DESCRIPTION
The default CLI history file (`.rediscli_history`) is being written with default user file creation mask, which makes the file readable by group and others. This type of file may contain sensible information and should not be world-readable.

Closes #3284
