### PR TITLE
Fix incorrect comment for checkForSentinelMode function

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3825,7 +3825,7 @@ void setupSignalHandlers(void) {
 void memtest(size_t megabytes, int passes);
 
 /* Returns 1 if there is --sentinel among the arguments or if
- * argv[0] is exactly "redis-sentinel". */
+ * argv[0] contains "redis-sentinel". */
 int checkForSentinelMode(int argc, char **argv) {
     int j;
 


### PR DESCRIPTION
The comment should be "argv[0] contains ..." since `strstr()` is used.
