### PR TITLE
Sentinel Password Authentication Fix #3279

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -433,7 +433,8 @@ struct redisCommand sentinelcmds[] = {
     {"info",sentinelInfoCommand,-1,"",0,NULL,0,0,0,0,0},
     {"role",sentinelRoleCommand,1,"l",0,NULL,0,0,0,0,0},
     {"client",clientCommand,-2,"rs",0,NULL,0,0,0,0,0},
-    {"shutdown",shutdownCommand,-1,"",0,NULL,0,0,0,0,0}
+    {"shutdown",shutdownCommand,-1,"",0,NULL,0,0,0,0,0},
+    {"auth",authCommand,2,"sltF",0,NULL,0,0,0,0,0}
 };
 
 /* This function overwrites a few normal Redis config default with Sentinel


### PR DESCRIPTION
Sentinel itself do not have any configs by default to support authentication.

Since sentinel is built kind of wrapper over the redis-server and so all configs are accessible, the authentication feature can be enabled manually adding the configuration `requirepass` in `sentinel.conf`.

And then we need to add the AUTH command to the sentinel's supported command list for it to work properly. Committing same here to fix #3279
