### PR TITLE
A string with 21 chars is not representable as a 64-bit integer.

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -385,10 +385,10 @@ robj *tryObjectEncoding(robj *o) {
      if (o->refcount > 1) return o;
 
     /* Check if we can represent this string as a long integer.
-     * Note that we are sure that a string larger than 21 chars is not
+     * Note that we are sure that a string larger than 20 chars is not
      * representable as a 32 nor 64 bit integer. */
     len = sdslen(s);
-    if (len <= 21 && string2l(s,len,&value)) {
+    if (len <= 20 && string2l(s,len,&value)) {
         /* This object is encodable as a long. Try to use a shared object.
          * Note that we avoid using shared integers when maxmemory is used
          * because every object needs to have a private LRU field for the LRU


### PR DESCRIPTION
A 64-bit integer ranges from -9223372036854775808 and 9223372036854775807. The maximum number of chars is 20 (not 21).  Therefore, a string with 21 chars is not necessarily tried to convert to a 64-bit integer.
