### PR TITLE
Prepend $DESTDIR to $INSTALL_BIN to allow redis binaries to be installed to a different filesystem location

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,7 +23,8 @@ WARN=-Wall -W
 OPT=$(OPTIMIZATION)
 
 PREFIX?=/usr/local
-INSTALL_BIN=$(PREFIX)/bin
+DESTDIR?=
+INSTALL_BIN=$(DESTDIR)$(PREFIX)/bin
 INSTALL=install
 
 # Default allocator


### PR DESCRIPTION
Honoring `$DESTDIR` is useful for staged installs (https://www.gnu.org/prep/standards/html_node/DESTDIR.html)
