### PR TITLE
Fix the firstkey, lastkey, and keystep of moduleCommand

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -123,7 +123,7 @@ struct redisServer server; /* server global state */
  *    are not fast commands.
  */
 struct redisCommand redisCommandTable[] = {
-    {"module",moduleCommand,-2,"as",0,NULL,1,1,1,0,0},
+    {"module",moduleCommand,-2,"as",0,NULL,0,0,0,0,0},
     {"get",getCommand,2,"rF",0,NULL,1,1,1,0,0},
     {"set",setCommand,-3,"wm",0,NULL,1,1,1,0,0},
     {"setnx",setnxCommand,3,"wmF",0,NULL,1,1,1,0,0},


### PR DESCRIPTION
The `module` command cannot be properly called in the cluster mode due to its wrong `firstkey`, `lastkey`, and `keystep` in `redisCommandTable`.
