### PR TITLE
crash log - add hex dump of function code

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -39,6 +39,9 @@
 #include <ucontext.h>
 #include <fcntl.h>
 #include "bio.h"
+#include <unistd.h>
+#define _GNU_SOURCE
+#include <dlfcn.h>
 #endif /* HAVE_BACKTRACE */
 
 #ifdef __CYGWIN__
@@ -669,6 +672,8 @@ static void *getMcontextEip(ucontext_t *uc) {
     return (void*) uc->uc_mcontext.gregs[16]; /* Linux 64 */
     #elif defined(__ia64__) /* Linux IA64 */
     return (void*) uc->uc_mcontext.sc_ip;
+    #elif defined(__arm__) /* Linux ARM */
+    return (void*) uc->uc_mcontext.arm_pc;
     #endif
 #else
     return NULL;
@@ -1035,6 +1040,23 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
 );
     /* free(messages); Don't call free() with possibly corrupted memory. */
     if (server.daemonize && server.supervised == 0) unlink(server.pidfile);
+
+    if (eip != NULL) {
+        Dl_info info;
+        if (dladdr(eip, &info) != 0)
+        {
+            serverLog(LL_WARNING,
+                "symbol: %s (base %p), in module: %s (base: %p)",
+                info.dli_sname, info.dli_saddr, info.dli_fname, info.dli_fbase);
+            size_t len = (long)eip - (long)info.dli_saddr;
+            long sz = sysconf(_SC_PAGESIZE);
+            if (len < 1<<13) { /* we don't have functions over 8k (verified) */
+                long end = ((long)eip + sz) & ~(sz-1); /* round up to page boundary */
+                len = end - (long)info.dli_saddr;
+                serverLogHexDump(LL_WARNING, "dump of function", info.dli_saddr ,len);
+            }
+        }
+    }
 
     /* Make sure we exit with the right signal at the end. So for instance
      * the core will be dumped if enabled. */


### PR DESCRIPTION
$ redis-cli debug segfault

```
21175:M 04 Jul 23:31:50.719 # symbol: debugCommand (base 0x462a10), in module: /home/oran/work/redis/src/redis-server 127.0.0.1:6379 (base: 0x400000)
21175:M 04 Jul 23:31:50.719 # dump of function (hexdump):
415741564155415455534889fb4881ec58100000448b673064488b042528000000488984244810000031c04183fc010f847b0300004c8b6f38be28984e00498b4508488b68084889efe882cefbff85c00f84fa010000beaf2d4f004889efe86dcefbff85c00f8465010000beb82d4f004889efe858cefbff85c00f8488010000bec02d4f004889efe843cefbff85c00f8473010000be1bce4f004889efe82ecefbff85c00f845e040000bed22d4f004889efe819cefbff85c00f84f70c0000bee02d4f004889efe804cefbff85c00f84ec030000be032e4f004889efe8efcdfbff85c00f84d7020000be0d9c4e004889efe8dacdfbff85c00f85420300004183fc030f842b060000be8b2e4f004889efe8bbcdfbff85c0750e418d4424fd83f8010f86c9060000bea52e4f004889efe89ccdfbff85c0750a4183fc020f8424080000beac2e4f004889efe881cdfbff85c00f85d90300004183fc030f84c0080000bec42e4f004889efe862cdfbff85c00f855a040000662e0f1f840000000000bee52e4f004889efe843cdfbff85c0750a4183fc020f8412090000be4f2f4f004889efe828cdfbff85c00f85a00400004183fc030f84140800004889eabee8274f004889df31c0e8345dfdffeb0a6690c60425ffffffff78488b8424481000006448330425280000000f85010b00004881c4581000005b5d415c415d415e415fc30f1f80000000004531f64183fc0248c7442430000000000f8f520100004889efbeb82d4f00e8a5ccfbff83f8014c89f619ff83e703e88584fcffbe80264f004889dfe8485afdffeb8e660f1f4400004889dfe88838fdff4889dfbe18204f004889c5e8c864fdff4889dfbe50204f00e8bb64fdff4889dfbe80204f00e8ae64fdff4889dfbeb8204f00e8a164fdff4889dfbe10214f00e89464fdff4889dfbe38214f00e88764fdff4889dfbe78214f00e87a64fdff4889dfbec0214f00e86d64fdff4889dfbe08224f00e86064fdff4889dfbe58224f00e85364fdff4889dfbee0224f00e84664fdff4889dfbe30234f00e83964fdff4889dfbe78234f00e82c64fdff4889dfbe30244f00e81f64fdff4889dfbee8244f00e81264fdff4889dfbe70254f00e80564fdff4889dfbeb8254f00e8f863fdff4889dfbe08264f00e8eb63fdff4889dfbe40264f00e8de63fdffba130000004889ee4889dfe86e70fdffe971feffff660f1f840000000000498b7510488d54243031c94889dfe8ed9dfdff85c00f854dfeffff488b4424304885c00f8887000000488b53384989c6488b5208488b6a08e971feffff0f1f00bed01f4f00e8d658fdffe919feffff90833d311a2d00010f845703000031d231f6bfffffffffe855c7fdff488b3d1e1a2d00e8e9cbffff85c00f85b900000048c705b61a2d0000000000bee0264f00bf0300000031c0e82550fcff488b35061e2d004889dfe85651fdffe9b9fdffff90488b433848c744243000000000488b4008488b6808e9e4fdffff660f1f440000be692e4f004889efe883cafbff85c00f85b3fcffff4183fc030f85a9fcffff498b4510488b7008488b4310488b38e80d3bfcff4885c00f8479080000488b5008488b280fb602a80f7508a8700f84fd060000be702e4f004889dfe8f157fdffe934fdffff0f1f4000488b35711d2d004889dfe8b950fdffe91cfdffff0f1f4000488b3d111a2d00e85437feff85c075d831d231f6bfffffffffe852c6fdff488b3df3192d00e83649feff85c00f8428020000beb8264f004889dfe89157fdffe9d4fcffff0f1f400048c7c7ffffffffe86ce5fcff4889c7e854e7fcff488b35f51c2d004889dfe84550fdffe9a8fcffffbeb22e4f004889efe893c9fbff85c0753f4183fc030f8535fcffff498b451031f6ba0a000000488b7808e861d0fbff488b35b21c2d004889df890525182d00e8fc4ffdffe95ffcffff0f1f8000000000bec42e4f004889efe843c9fbff85c0753f4183fc030f85e5fbffff498b451031f6ba0a000000488b7808e811d0fbff488b35621c2d004889df8905ed1b2d00e8ac4ffdffe90ffcffff0f1f8000000000bec1e34e004889efe8f3c8fbff85c00f859bfbffff4183fc030f8591fbffffbe

```

$ xxd -r -p ~/temp/dump.hex ~/temp/dump.bin

```
$ objdump -D -b binary -m i386:x86-64 ~/temp/dump.bin |head
/home/oran/temp/dump.bin:     file format binary

Disassembly of section .data:

0000000000000000 <.data>:
       0:   41 57                   push   %r15
       2:   41 56                   push   %r14
       4:   41 55                   push   %r13

```
