### PR TITLE
Redis Module hooks for global RDB AUX field handling

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -2756,6 +2756,30 @@ void RM_EmitAOF(RedisModuleIO *io, const char *cmdname, const char *fmt, ...) {
 }
 
 /* --------------------------------------------------------------------------
+ * Logging
+ * -------------------------------------------------------------------------- */
+
+/* Produces a log message to the standard Redis log. */
+void RM_Log(RedisModuleCtx *ctx, int level, const char *fmt, ...)
+{
+    va_list ap;
+    char msg[LOG_MAX_LEN];
+    size_t name_len;
+
+    if ((level&0xff) < server.verbosity) return;
+    if (!ctx->module) return;   /* Can only log if module is initialized */
+
+    name_len = snprintf(msg, sizeof(msg),"%s: ", ctx->module->name);
+
+    va_start(ap, fmt);
+    vsnprintf(msg + name_len, sizeof(msg) - name_len, fmt, ap);
+    va_end(ap);
+
+    serverLogRaw(level,msg);
+}
+
+
+/* --------------------------------------------------------------------------
  * Modules API internals
  * -------------------------------------------------------------------------- */
 
@@ -2873,6 +2897,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(SaveDouble);
     REGISTER_API(LoadDouble);
     REGISTER_API(EmitAOF);
+    REGISTER_API(Log);
 }
 
 /* Global initialization at Redis startup. */

--- a/src/modules/API.md
+++ b/src/modules/API.md
@@ -1115,3 +1115,11 @@ by a module. The command works exactly like `RedisModule_Call()` in the way
 the parameters are passed, but it does not return anything as the error
 handling is performed by Redis itself.
 
+## `RM_Log`
+
+    void RM_Log(RedisModuleCtx *ctx, int level, const char *fmt, ...);
+
+Produce a log message into the standard Redis log. All standard Redis logging
+configuration applies here. Messages can only be logged after a module has
+initialized, and are prefixed by the name of the module.  Log level is
+specified using the REDISMODULE_LOG_* macros.

--- a/src/modules/API.md
+++ b/src/modules/API.md
@@ -7,16 +7,7 @@
 Use like malloc(). Memory allocated with this function is reported in
 Redis INFO memory, used for keys eviction according to maxmemory settings
 and in general is taken into account as memory allocated by Redis.
-You should avoid using malloc().
-
-## `RM_Calloc`
-
-    void *RM_Calloc(size_t nmemb, size_t size);
-
-Use like calloc(). Memory allocated with this function is reported in
-Redis INFO memory, used for keys eviction according to maxmemory settings
-and in general is taken into account as memory allocated by Redis.
-You should avoid using calloc() directly.
+You should avoid to use malloc().
 
 ## `RM_Realloc`
 
@@ -192,7 +183,7 @@ enabling automatic memory management.
 
     RedisModuleString *RM_CreateStringFromString(RedisModuleCtx *ctx, const RedisModuleString *str);
 
-Like `RedisModule_CreatString()`, but creates a string starting from another
+Like `RedisModule_CreatString()`, but creates a string starting from an existing
 RedisModuleString.
 
 The returned string must be released with `RedisModule_FreeString()` or by
@@ -211,7 +202,7 @@ from the pool of string to release at the end.
 
 ## `RM_StringPtrLen`
 
-    const char *RM_StringPtrLen(const RedisModuleString *str, size_t *len);
+    const char *RM_StringPtrLen(RedisModuleString *str, size_t *len);
 
 Given a string module object, this function returns the string pointer
 and length of the string. The returned pointer and length should only
@@ -219,7 +210,7 @@ be used for read only accesses and never modified.
 
 ## `RM_StringToLongLong`
 
-    int RM_StringToLongLong(const RedisModuleString *str, long long *ll);
+    int RM_StringToLongLong(RedisModuleString *str, long long *ll);
 
 Convert the string into a long long integer, storing it at `*ll`.
 Returns `REDISMODULE_OK` on success. If the string can't be parsed
@@ -228,7 +219,7 @@ is returned.
 
 ## `RM_StringToDouble`
 
-    int RM_StringToDouble(const RedisModuleString *str, double *d);
+    int RM_StringToDouble(RedisModuleString *str, double *d);
 
 Convert the string into a double, storing it at `*d`.
 Returns `REDISMODULE_OK` on success or `REDISMODULE_ERR` if the string is
@@ -1133,12 +1124,6 @@ is only called in the context of the aof_rewrite method of data types exported
 by a module. The command works exactly like `RedisModule_Call()` in the way
 the parameters are passed, but it does not return anything as the error
 handling is performed by Redis itself.
-
-## `RM_Log`
-
-    void RM_Log(RedisModuleCtx *ctx, int level, const char *fmt, ...);
-
-Produces a log message to the standard Redis log.
 
 ## `RM_Log`
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -826,6 +826,7 @@ int rdbSaveInfoAuxFields(rio *rdb) {
     if (rdbSaveAuxFieldStrInt(rdb,"redis-bits",redis_bits) == -1) return -1;
     if (rdbSaveAuxFieldStrInt(rdb,"ctime",time(NULL)) == -1) return -1;
     if (rdbSaveAuxFieldStrInt(rdb,"used-mem",zmalloc_used_memory()) == -1) return -1;
+    if (moduleHookRDBAuxSave(rdb) == -1) return -1;
     return 1;
 }
 
@@ -1472,7 +1473,7 @@ int rdbLoad(char *filename) {
                 serverLog(LL_NOTICE,"RDB '%s': %s",
                     (char*)auxkey->ptr,
                     (char*)auxval->ptr);
-            } else {
+            } else if (moduleHookRDBAuxLoad(auxkey, auxval) <= 0) {
                 /* We ignore fields we don't understand, as by AUX field
                  * contract. */
                 serverLog(LL_DEBUG,"Unrecognized RDB AUX field: '%s'",

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -131,5 +131,6 @@ ssize_t rdbSaveRawString(rio *rdb, unsigned char *s, size_t len);
 void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr);
 int rdbSaveBinaryDoubleValue(rio *rdb, double val);
 int rdbLoadBinaryDoubleValue(rio *rdb, double *val);
+int rdbSaveAuxFieldStrStr(rio *rdb, char *key, char *val);
 
 #endif

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -68,13 +68,6 @@
 #define REDISMODULE_POSITIVE_INFINITE (1.0/0.0)
 #define REDISMODULE_NEGATIVE_INFINITE (-1.0/0.0)
 
-/* Logging levels */
-#define REDISMODULE_LOG_DEBUG 0
-#define REDISMODULE_LOG_VERBOSE 1
-#define REDISMODULE_LOG_NOTICE 2
-#define REDISMODULE_LOG_WARNING 3
-
-
 /* ------------------------- End of common defines ------------------------ */
 
 #ifndef REDISMODULE_CORE

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -68,6 +68,13 @@
 #define REDISMODULE_POSITIVE_INFINITE (1.0/0.0)
 #define REDISMODULE_NEGATIVE_INFINITE (-1.0/0.0)
 
+/* Logging levels */
+#define REDISMODULE_LOG_DEBUG 0
+#define REDISMODULE_LOG_VERBOSE 1
+#define REDISMODULE_LOG_NOTICE 2
+#define REDISMODULE_LOG_WARNING 3
+
+
 /* ------------------------- End of common defines ------------------------ */
 
 #ifndef REDISMODULE_CORE
@@ -180,6 +187,7 @@ RedisModuleString *REDISMODULE_API_FUNC(RedisModule_LoadString)(RedisModuleIO *i
 char *REDISMODULE_API_FUNC(RedisModule_LoadStringBuffer)(RedisModuleIO *io, size_t *lenptr);
 void REDISMODULE_API_FUNC(RedisModule_SaveDouble)(RedisModuleIO *io, double value);
 double REDISMODULE_API_FUNC(RedisModule_LoadDouble)(RedisModuleIO *io);
+void REDISMODULE_API_FUNC(RedisModule_Log)(RedisModuleCtx *ctx, int level, const char *fmt, ...);
 
 /* This is included inline inside each Redis module. */
 static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int apiver) {
@@ -269,6 +277,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(SaveDouble);
     REDISMODULE_GET_API(LoadDouble);
     REDISMODULE_GET_API(EmitAOF);
+    REDISMODULE_GET_API(Log);
 
     RedisModule_SetModuleAttribs(ctx,name,ver,apiver);
     return REDISMODULE_OK;

--- a/src/server.h
+++ b/src/server.h
@@ -1167,6 +1167,8 @@ void moduleLoadFromQueue(void);
 int *moduleGetCommandKeysViaAPI(struct redisCommand *cmd, robj **argv, int argc, int *numkeys);
 moduleType *moduleTypeLookupModuleByID(uint64_t id);
 void moduleTypeNameByID(char *name, uint64_t moduleid);
+int moduleHookRDBAuxSave(rio *rdb);
+int moduleHookRDBAuxLoad(robj *key, robj *value);
 
 /* Utils */
 long long ustime(void);


### PR DESCRIPTION
@antirez The core requirement here is to be able to store and retrieve from RDB global state which is not associated with a specific key.

I've also took the opportunity to propose a more generic mechanism that can be later extended to support additional hooks.  The guide line here was to avoid per-hook prototype while still providing type safety (i.e. avoid passing void*'s all over).
