### PR TITLE
Redis Module hooks for global RDB AUX field handling.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -32,7 +32,7 @@ struct RedisModule {
     int ver;        /* Module version. We use just progressive integers. */
     int apiver;     /* Module API version as requested during initialization.*/
     list *types;    /* Module data types. */
-    RedisModuleHookFunc hooks[REDISMODULE_HOOK_MAX];	/* Registered hooks */
+    RedisModuleHookFunc hooks[REDISMODULE_HOOK_MAX+1];	/* Registered hooks */
 };
 typedef struct RedisModule RedisModule;
 
@@ -2898,6 +2898,7 @@ int moduleInvokeHook(int hook_type, RedisModuleHookArg *arg, int ignore_errors) 
             moduleFreeContext(&ctx);
         }
     }
+    dictReleaseIterator(di);
 
     return ret;
 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -826,6 +826,7 @@ int rdbSaveInfoAuxFields(rio *rdb) {
     if (rdbSaveAuxFieldStrInt(rdb,"redis-bits",redis_bits) == -1) return -1;
     if (rdbSaveAuxFieldStrInt(rdb,"ctime",time(NULL)) == -1) return -1;
     if (rdbSaveAuxFieldStrInt(rdb,"used-mem",zmalloc_used_memory()) == -1) return -1;
+    if (moduleHookRDBAuxSave(rdb) == -1) return -1;
     return 1;
 }
 
@@ -1472,7 +1473,7 @@ int rdbLoad(char *filename) {
                 serverLog(LL_NOTICE,"RDB '%s': %s",
                     (char*)auxkey->ptr,
                     (char*)auxval->ptr);
-            } else {
+            } else if (moduleHookRDBAuxLoad(auxkey, auxval) <= 0) {
                 /* We ignore fields we don't understand, as by AUX field
                  * contract. */
                 serverLog(LL_DEBUG,"Unrecognized RDB AUX field: '%s'",

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -131,5 +131,6 @@ ssize_t rdbSaveRawString(rio *rdb, unsigned char *s, size_t len);
 void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr);
 int rdbSaveBinaryDoubleValue(rio *rdb, double val);
 int rdbLoadBinaryDoubleValue(rio *rdb, double *val);
+int rdbSaveAuxFieldStrStr(rio *rdb, char *key, char *val);
 
 #endif

--- a/src/server.h
+++ b/src/server.h
@@ -1167,6 +1167,8 @@ void moduleLoadFromQueue(void);
 int *moduleGetCommandKeysViaAPI(struct redisCommand *cmd, robj **argv, int argc, int *numkeys);
 moduleType *moduleTypeLookupModuleByID(uint64_t id);
 void moduleTypeNameByID(char *name, uint64_t moduleid);
+int moduleHookRDBAuxSave(rio *rdb);
+int moduleHookRDBAuxLoad(robj *key, robj *value);
 
 /* Utils */
 long long ustime(void);


### PR DESCRIPTION
The core requirement here is to be able to store and retrieve from RDB global state which is not associated with a specific key.

I've also took the opportunity to propose a more generic mechanism that can be later extended to support additional hooks. The guide line here was to avoid per-hook prototype while still providing type safety (i.e. avoid passing void*'s all over).
