### PR TITLE
fix compile warning in gcc 5.3.1 with changing structure members initializer

### DIFF
--- a/src/geohash.c
+++ b/src/geohash.c
@@ -211,7 +211,7 @@ int geohashDecodeAreaToLongLat(const GeoHashArea *area, double *xy) {
 }
 
 int geohashDecodeToLongLatType(const GeoHashBits hash, double *xy) {
-    GeoHashArea area = {{0}};
+    GeoHashArea area = {0};
     if (!xy || !geohashDecodeType(hash, &area))
         return 0;
     return geohashDecodeAreaToLongLat(&area, xy);

--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -107,10 +107,10 @@ int geohashBoundingBox(double longitude, double latitude, double radius_meters,
 
 GeoHashRadius geohashGetAreasByRadius(double longitude, double latitude, double radius_meters) {
     GeoHashRange long_range, lat_range;
-    GeoHashRadius radius = {{0}};
+    GeoHashRadius radius = {0};
     GeoHashBits hash = {0,0};
-    GeoHashNeighbors neighbors = {{0}};
-    GeoHashArea area = {{0}};
+    GeoHashNeighbors neighbors = {0};
+    GeoHashArea area = {0};
     double min_lon, max_lon, min_lat, max_lat;
     double bounds[4];
     int steps;


### PR DESCRIPTION
fix compile warning in gcc 5.3.1 in ubuntu 16.04
