### PR TITLE
Spelling correction in redis-cli.c

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -336,7 +336,7 @@ static void cliOutputGenericHelp(void) {
         "      \"help <tab>\" to get a list of possible help topics\n"
         "      \"quit\" to exit\n"
         "\n"
-        "To set redis-cli perferences:\n"
+        "To set redis-cli preferences:\n"
         "      \":set hints\" enable online hints\n"
         "      \":set nohints\" disable online hints\n"
         "Set your preferences in ~/.redisclirc\n",


### PR DESCRIPTION
Commit solve the minor fix for issue https://github.com/antirez/redis/issues/3379
