### PR TITLE
fix #2883, #2857 pipe fds leak when fork() failed on bg aof rw

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1307,6 +1307,7 @@ int rewriteAppendOnlyFileBackground(void) {
             serverLog(LL_WARNING,
                 "Can't rewrite append only file in background: fork: %s",
                 strerror(errno));
+            aofClosePipes();
             return C_ERR;
         }
         serverLog(LL_NOTICE,

--- a/tests/unit/aofrw.tcl
+++ b/tests/unit/aofrw.tcl
@@ -208,3 +208,51 @@ start_server {tags {"aofrw"}} {
         }
     }
 }
+
+start_server {tags {"aofrw"}} {
+    # Enable the AOF
+    r config set appendonly yes
+    r config set auto-aof-rewrite-percentage 0 ; # Disable auto-rewrite.
+    waitForBgrewriteaof r
+
+    proc get_pipes_count {pid} {
+        try {
+            set pipes [exec lsof -p $pid | grep -s FIFO | wc -l]
+            return $pipes
+        } trap CHILDSTATUS {results options} {
+            return 0
+        }
+    }
+
+    test {AOF rewrite must not leak on failed fork()} {
+        set pid [srv 0 pid]
+        set pipes [get_pipes_count $pid]
+        if {$::verbose} {
+            puts "Checking pipes on normal bgrewriteaof ($pipes)..."
+        }
+        assert_equal 0 $pipes
+
+        # set nproc limit 0
+        exec prlimit --nproc=0 --pid=$pid
+
+        # exec bgrewriteaof
+        if {![catch {r bgrewriteaof}]} {
+            fail "bgrewriteaof must fail in nproc=0 condition"
+        }
+
+        # check bgrewriteaof failed as intended
+        wait_for_condition 50 100 {
+            [string match {*Can't*rewrite*append*fork*} [exec tail -n5 < [srv 0 stdout]]]
+        } else {
+            puts [exec tail -n5 < [srv 0 stdout]]]
+            fail "bgrewriteaof must fail in nproc=0 condition"
+        }
+
+        # check pipes not leaked
+        set pipes [get_pipes_count $pid]
+        if {$::verbose} {
+            puts "Checking pipes on failed bgrewriteaof ($pipes)..."
+        }
+        assert_equal 0 $pipes
+    }
+}


### PR DESCRIPTION
The bug described in #2883, #2857 is a pipes file descriptors leak on failed fork() in aof.c.

Corresponding Tcl test is ongoing.

To verify behavior:
- run redis_server
- get pid
- $ prlimit --nproc=0 --pid ${pid}
- $ echo "BGREWRITEAOF" | ./redis-cli
  will result into ERR
- lsof +E -p ${pid} | grep FIFO

before patch there will be leaked pipes.
