### PR TITLE
config requirepass now accepts multiple passwords

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -495,11 +495,15 @@ slave-priority 100
 # This should stay commented out for backward compatibility and because most
 # people do not need auth (e.g. they run their own servers).
 #
+# It is possible to take just one or multiple passwords. When multiple
+# passwords are given, the user can be authorized by any of them.
+#
 # Warning: since Redis is pretty fast an outside user can try up to
 # 150k passwords per second against a good box. This means that you should
 # use a very strong password otherwise it will be very easy to break.
 #
 # requirepass foobared
+# requirepass foo bar baz
 
 # Command renaming.
 #

--- a/src/networking.c
+++ b/src/networking.c
@@ -665,7 +665,7 @@ static void acceptCommonHandler(int fd, int flags, char *ip) {
      * user what to do to fix it if needed. */
     if (server.protected_mode &&
         server.bindaddr_count == 0 &&
-        server.requirepass == NULL &&
+        server.requirepass_count == 0 &&
         !(flags & CLIENT_UNIX_SOCKET) &&
         ip != NULL)
     {

--- a/src/server.h
+++ b/src/server.h
@@ -100,6 +100,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CONFIG_DEFAULT_SLOWLOG_LOG_SLOWER_THAN 10000
 #define CONFIG_DEFAULT_SLOWLOG_MAX_LEN 128
 #define CONFIG_DEFAULT_MAX_CLIENTS 10000
+#define CONFIG_AUTHPASS_MAX 16
 #define CONFIG_AUTHPASS_MAX_LEN 512
 #define CONFIG_DEFAULT_SLAVE_PRIORITY 100
 #define CONFIG_DEFAULT_REPL_TIMEOUT 60
@@ -708,7 +709,7 @@ typedef struct client {
     time_t lastinteraction; /* Time of the last interaction, used for timeout */
     time_t obuf_soft_limit_reached_time;
     int flags;              /* Client flags: CLIENT_* macros. */
-    int authenticated;      /* When requirepass is non-NULL. */
+    int authenticated;      /* When requirepass is given. */
     int replstate;          /* Replication state if this is a slave. */
     int repl_put_online_on_ack; /* Install slave write handler on ACK. */
     int repldbfd;           /* Replication DB file descriptor. */
@@ -898,7 +899,8 @@ struct redisServer {
     int shutdown_asap;          /* SHUTDOWN needed ASAP */
     int activerehashing;        /* Incremental rehash in serverCron() */
     int active_defrag_running;  /* Active defragmentation running (holds current scan aggressiveness) */
-    char *requirepass;          /* Pass for AUTH command, or NULL */
+    char *requirepass[CONFIG_AUTHPASS_MAX]; /* Passwords for AUTH command */
+    int requirepass_count;      /* Number of passwords in server.requirepass[] */
     char *pidfile;              /* PID file path */
     int arch_bits;              /* 32 or 64 depending on sizeof(long) */
     int cronloops;              /* Number of times the cron function run */

--- a/tests/unit/auth.tcl
+++ b/tests/unit/auth.tcl
@@ -25,3 +25,43 @@ start_server {tags {"auth"} overrides {requirepass foobar}} {
         r incr foo
     } {101}
 }
+
+start_server {tags {"auth"} overrides {requirepass "foo bar"}} {
+    test {AUTH fails when a wrong password is given} {
+        catch {r auth wrong!} err
+        set _ $err
+    } {ERR*invalid password}
+
+    test {Arbitrary command gives an error when AUTH is required} {
+        catch {r set foo bar} err
+        set _ $err
+    } {NOAUTH*}
+
+    test {AUTH succeeds when the first right password is given} {
+        r auth foo
+    } {OK}
+
+    test {AUTH succeeds when the second right password is given} {
+        r auth bar
+    } {OK}
+
+    test {Once AUTH succeeded we can actually send commands to the server} {
+        r set foo 100
+        r incr foo
+    } {101}
+
+    test {Keep authenticated even when passwords are updated} {
+        r config set requirepass baz
+        r get foo
+    } {101}
+
+    test {AUTH fails for new connections with old passwords} {
+        reconnect
+        catch {r auth foo} err
+        set _ $err
+    } {ERR*invalid password}
+
+    test {AUTH succeeds for new connections with new passwords} {
+        r auth baz
+    } {OK}
+}


### PR DESCRIPTION
We are running Redis in 24/7/365 production where the password must be regularly updated for security reasons. It's nice if we can use multiple passwords to manage both old and new users like this.

```
requirepass pass2016 pass2017 ...
```

This PR offers the feature where the implementation is mostly copied from `bindaddrs`.
All tests have been passed on both `unstable` and `3.2.1` branches.
Thanks.
