### PR TITLE
Fix a bug to delay bgsave while AOF rewrite in progress for replication

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -676,7 +676,7 @@ void syncCommand(client *c) {
             /* Target is disk (or the slave is not capable of supporting
              * diskless replication) and we don't have a BGSAVE in progress,
              * let's start one. */
-            if (server.aof_child_pid != -1) {
+            if (server.aof_child_pid == -1) {
                 startBgsaveForReplication(c->slave_capa);
             } else {
                 serverLog(LL_NOTICE,


### PR DESCRIPTION
The logic implemented in code was inconsistent with the intention that BGSAVE to be delayed when AOF rewrite was in progress as part of 3.2.2 release. I am attempting to fix this bug. 
