### PR TITLE
Use the standard predefined identifier __func__ (since C99)

### DIFF
--- a/src/debugmacro.h
+++ b/src/debugmacro.h
@@ -34,7 +34,7 @@
 #define D(...)                                                               \
     do {                                                                     \
         FILE *fp = fopen("/tmp/log.txt","a");                                \
-        fprintf(fp,"%s:%s:%d:\t", __FILE__, __FUNCTION__, __LINE__);         \
+        fprintf(fp,"%s:%s:%d:\t", __FILE__, __func__, __LINE__);             \
         fprintf(fp,__VA_ARGS__);                                             \
         fprintf(fp,"\n");                                                    \
         fclose(fp);                                                          \


### PR DESCRIPTION
Fix warning: ISO C does not support '**FUNCTION**' predefined identifier
[-Wpedantic]
