### PR TITLE
fixbug: prohibiting infinite aof rewrite when aof size is smaller

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1080,7 +1080,8 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
          }
 
          /* Trigger an AOF rewrite if needed */
-         if (server.rdb_child_pid == -1 &&
+         if (server.aof_state != AOF_OFF &&
+             server.rdb_child_pid == -1 &&
              server.aof_child_pid == -1 &&
              server.aof_rewrite_perc &&
              server.aof_current_size > server.aof_rewrite_min_size)


### PR DESCRIPTION
1] symptom
 Even though, AOF is disabled, Infinite AOF Rewriting is happend.

2] Precondition
 appendonly no
 aof_current_size > aof_request_min_size

3] Why?
 current aof rewriting rule doesn't check AOF is disabled.
 it checks only server.aof_current_size > server.aof_rewrite_min_size and growth > percent

 and AOF is disabled, after rewriting AOF, it doesn't update aof_current_size

4] solution?
 The easiest way is just check AOF state when check aof rewriting.
 and other solution is just updating aof_current_size in all codes.
 But I think this is more intutive solution :)
