### PR TITLE
tiny optimization.

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -891,7 +891,7 @@ int rewriteSortedSetObject(rio *r, robj *key, robj *o) {
                 int cmd_items = (items > AOF_REWRITE_ITEMS_PER_CMD) ?
                     AOF_REWRITE_ITEMS_PER_CMD : items;
 
-                if (rioWriteBulkCount(r,'*',2+cmd_items*2) == 0) return 0;
+                if (rioWriteBulkCount(r,'*',2 + (cmd_items << 1)) == 0) return 0;
                 if (rioWriteBulkString(r,"ZADD",4) == 0) return 0;
                 if (rioWriteBulkObject(r,key) == 0) return 0;
             }
@@ -918,7 +918,7 @@ int rewriteSortedSetObject(rio *r, robj *key, robj *o) {
                 int cmd_items = (items > AOF_REWRITE_ITEMS_PER_CMD) ?
                     AOF_REWRITE_ITEMS_PER_CMD : items;
 
-                if (rioWriteBulkCount(r,'*',2+cmd_items*2) == 0) return 0;
+                if (rioWriteBulkCount(r,'*',2 + (cmd_items << 1)) == 0) return 0;
                 if (rioWriteBulkString(r,"ZADD",4) == 0) return 0;
                 if (rioWriteBulkObject(r,key) == 0) return 0;
             }
@@ -972,7 +972,7 @@ int rewriteHashObject(rio *r, robj *key, robj *o) {
             int cmd_items = (items > AOF_REWRITE_ITEMS_PER_CMD) ?
                 AOF_REWRITE_ITEMS_PER_CMD : items;
 
-            if (rioWriteBulkCount(r,'*',2+cmd_items*2) == 0) return 0;
+            if (rioWriteBulkCount(r,'*',2 + (cmd_items << 1)) == 0) return 0;
             if (rioWriteBulkString(r,"HMSET",5) == 0) return 0;
             if (rioWriteBulkObject(r,key) == 0) return 0;
         }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1989,7 +1989,7 @@ int clusterProcessPacket(clusterLink *link) {
         resetManualFailover();
         server.cluster->mf_end = mstime() + CLUSTER_MF_TIMEOUT;
         server.cluster->mf_slave = sender;
-        pauseClients(mstime()+(CLUSTER_MF_TIMEOUT*2));
+        pauseClients(mstime()+(CLUSTER_MF_TIMEOUT << 1));
         serverLog(LL_WARNING,"Manual failover requested by slave %.40s.",
             sender->name);
     } else if (type == CLUSTERMSG_TYPE_UPDATE) {
@@ -2302,7 +2302,7 @@ void clusterSendPing(clusterLink *link, int type) {
         if (this == myself) continue;
 
         /* Give a bias to FAIL/PFAIL nodes. */
-        if (maxiterations > wanted*2 &&
+        if (maxiterations > (wanted << 1) &&
             !(this->flags & (CLUSTER_NODE_PFAIL|CLUSTER_NODE_FAIL)))
             continue;
 
@@ -2589,7 +2589,7 @@ void clusterSendFailoverAuthIfNeeded(clusterNode *node, clusterMsg *request) {
                 "Failover auth denied to %.40s: "
                 "can't vote about this master before %lld milliseconds",
                 node->name,
-                (long long) ((server.cluster_node_timeout*2)-
+                (long long) ((server.cluster_node_timeout << 1)-
                              (mstime() - node->slaveof->voted_time)));
         return;
     }
@@ -2777,9 +2777,9 @@ void clusterHandleSlaveFailover(void) {
      * Timeout is MIN(NODE_TIMEOUT*2,2000) milliseconds.
      * Retry is two times the Timeout.
      */
-    auth_timeout = server.cluster_node_timeout*2;
+    auth_timeout = server.cluster_node_timeout << 1;
     if (auth_timeout < 2000) auth_timeout = 2000;
-    auth_retry_time = auth_timeout*2;
+    auth_retry_time = auth_timeout << 1;
 
     /* Pre conditions to run the function, that must be met both in case
      * of an automatic or manual failover:

--- a/src/config.c
+++ b/src/config.c
@@ -1335,7 +1335,7 @@ void configGetCommand(client *c) {
         sdsfree(aux);
         matches++;
     }
-    setDeferredMultiBulkLength(c,replylen,matches*2);
+    setDeferredMultiBulkLength(c,replylen,matches << 1);
 }
 
 /*-----------------------------------------------------------------------------

--- a/src/db.c
+++ b/src/db.c
@@ -1139,7 +1139,7 @@ int *sortGetKeys(struct redisCommand *cmd, robj **argv, int argc, int *numkeys) 
     UNUSED(cmd);
 
     num = 0;
-    keys = zmalloc(sizeof(int)*2); /* Alloc 2 places for the worst case. */
+    keys = zmalloc(sizeof(int) << 1); /* Alloc 2 places for the worst case. */
 
     keys[num++] = 1; /* <sort-key> is always present. */
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -942,7 +942,7 @@ static int _dictExpandIfNeeded(dict *d)
         (dict_can_resize ||
          d->ht[0].used/d->ht[0].size > dict_force_resize_ratio))
     {
-        return dictExpand(d, d->ht[0].used*2);
+        return dictExpand(d, d->ht[0].used << 1);
     }
     return DICT_OK;
 }

--- a/src/evict.c
+++ b/src/evict.c
@@ -320,9 +320,9 @@ unsigned long LFUDecrAndReturn(robj *o) {
     unsigned long ldt = o->lru >> 8;
     unsigned long counter = o->lru & 255;
     if (LFUTimeElapsed(ldt) >= server.lfu_decay_time && counter) {
-        if (counter > LFU_INIT_VAL*2) {
-            counter /= 2;
-            if (counter < LFU_INIT_VAL*2) counter = LFU_INIT_VAL*2;
+        if (counter > (LFU_INIT_VAL << 1)) {
+            counter >>= 1;
+            if (counter < (LFU_INIT_VAL << 1)) counter = LFU_INIT_VAL << 1;
         } else {
             counter--;
         }

--- a/src/expire.c
+++ b/src/expire.c
@@ -110,7 +110,7 @@ void activeExpireCycle(int type) {
          * for time limt. Also don't repeat a fast cycle for the same period
          * as the fast cycle total duration itself. */
         if (!timelimit_exit) return;
-        if (start < last_fast_cycle + ACTIVE_EXPIRE_CYCLE_FAST_DURATION*2) return;
+        if (start < last_fast_cycle + (ACTIVE_EXPIRE_CYCLE_FAST_DURATION << 1)) return;
         last_fast_cycle = start;
     }
 

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1092,8 +1092,8 @@ robj *createHLLObject(void) {
     sds s;
     uint8_t *p;
     int sparselen = HLL_HDR_SIZE +
-                    (((HLL_REGISTERS+(HLL_SPARSE_XZERO_MAX_LEN-1)) /
-                     HLL_SPARSE_XZERO_MAX_LEN)*2);
+                    (((HLL_REGISTERS + (HLL_SPARSE_XZERO_MAX_LEN-1)) /
+                     HLL_SPARSE_XZERO_MAX_LEN) << 1);
     int aux;
 
     /* Populate the sparse representation with as many XZERO opcodes as

--- a/src/memtest.c
+++ b/src/memtest.c
@@ -100,7 +100,7 @@ int memtest_addressing(unsigned long *l, size_t bytes, int interactive) {
         *p = (unsigned long)p;
         p++;
         if ((j & 0xffff) == 0 && interactive)
-            memtest_progress_step(j,words*2,'A');
+            memtest_progress_step(j,words << 1,'A');
     }
     /* Test */
     p = l;
@@ -115,7 +115,7 @@ int memtest_addressing(unsigned long *l, size_t bytes, int interactive) {
         }
         p++;
         if ((j & 0xffff) == 0 && interactive)
-            memtest_progress_step(j+words,words*2,'A');
+            memtest_progress_step(j+words,words << 1,'A');
     }
     return 0;
 }
@@ -285,7 +285,7 @@ int memtest_preserving_test(unsigned long *m, size_t bytes, int passes) {
     int errors = 0;
 
     if (bytes & 4095) return 0; /* Can't test across 4k page boundaries. */
-    if (bytes < 4096*2) return 0; /* Can't test a single page. */
+    if (bytes < (4096 << 1)) return 0; /* Can't test a single page. */
 
     while(left) {
         /* If we have to test a single final page, go back a single page

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -353,7 +353,7 @@ void pubsubCommand(client *c) {
         /* PUBSUB NUMSUB [Channel_1 ... Channel_N] */
         int j;
 
-        addReplyMultiBulkLen(c,(c->argc-2)*2);
+        addReplyMultiBulkLen(c,(c->argc-2) << 1);
         for (j = 2; j < c->argc; j++) {
             list *l = dictFetchValue(server.pubsub_channels,c->argv[j]);
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1599,7 +1599,7 @@ void backgroundSaveDoneHandlerSocket(int exitcode, int bysignal) {
         if (read(server.rdb_pipe_read_result_from_child, ok_slaves, readlen) ==
                  readlen)
         {
-            readlen = ok_slaves[0]*sizeof(uint64_t)*2;
+            readlen = ok_slaves[0]*sizeof(uint64_t) << 1;
 
             /* Make space for enough elements as specified by the first
              * uint64_t element in the array. */

--- a/src/sds.c
+++ b/src/sds.c
@@ -501,7 +501,7 @@ sds sdsfromlonglong(long long value) {
 sds sdscatvprintf(sds s, const char *fmt, va_list ap) {
     va_list cpy;
     char staticbuf[1024], *buf = staticbuf, *t;
-    size_t buflen = strlen(fmt)*2;
+    size_t buflen = strlen(fmt) << 1;
 
     /* We try to start using a static buffer for speed.
      * If not possible we revert to heap allocation. */

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1981,7 +1981,7 @@ int sentinelMasterLooksSane(sentinelRedisInstance *master) {
         master->flags & SRI_MASTER &&
         master->role_reported == SRI_MASTER &&
         (master->flags & (SRI_S_DOWN|SRI_O_DOWN)) == 0 &&
-        (mstime() - master->info_refresh) < SENTINEL_INFO_PERIOD*2;
+        (mstime() - master->info_refresh) < (SENTINEL_INFO_PERIOD << 1);
 }
 
 /* Process the INFO output from masters. */
@@ -2819,7 +2819,7 @@ void addReplySentinelRedisInstance(client *c, sentinelRedisInstance *ri) {
         fields++;
     }
 
-    setDeferredMultiBulkLength(c,mbl,fields*2);
+    setDeferredMultiBulkLength(c,mbl,fields << 1);
 }
 
 /* Output a number of instances contained inside a dictionary as
@@ -3445,7 +3445,7 @@ void sentinelCheckSubjectivelyDown(sentinelRedisInstance *ri) {
         (ri->flags & SRI_MASTER &&
          ri->role_reported == SRI_SLAVE &&
          mstime() - ri->role_reported_time >
-          (ri->down_after_period+SENTINEL_INFO_PERIOD*2)))
+          (ri->down_after_period+(SENTINEL_INFO_PERIOD << 1))))
     {
         /* Is subjectively down */
         if ((ri->flags & SRI_S_DOWN) == 0) {
@@ -3826,11 +3826,11 @@ int sentinelStartFailoverIfNeeded(sentinelRedisInstance *master) {
 
     /* Last failover attempt started too little time ago? */
     if (mstime() - master->failover_start_time <
-        master->failover_timeout*2)
+        (master->failover_timeout << 1))
     {
         if (master->failover_delay_logged != master->failover_start_time) {
             time_t clock = (master->failover_start_time +
-                            master->failover_timeout*2) / 1000;
+                            (master->failover_timeout << 1)) / 1000;
             char ctimebuf[26];
 
             ctime_r(&clock,ctimebuf);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1546,7 +1546,7 @@ void zaddGenericCommand(client *c, int flags) {
      * either execute fully or nothing at all. */
     scores = zmalloc(sizeof(double)*elements);
     for (j = 0; j < elements; j++) {
-        if (getDoubleFromObjectOrReply(c,c->argv[scoreidx+j*2],&scores[j],NULL)
+        if (getDoubleFromObjectOrReply(c,c->argv[scoreidx + (j << 1)],&scores[j],NULL)
             != C_OK) goto cleanup;
     }
 
@@ -1574,7 +1574,7 @@ void zaddGenericCommand(client *c, int flags) {
         score = scores[j];
         int retflags = flags;
 
-        ele = c->argv[scoreidx+1+j*2]->ptr;
+        ele = c->argv[scoreidx + 1 + (j << 1)]->ptr;
         int retval = zsetAdd(zobj, score, ele, &retflags, &newscore);
         if (retval == 0) {
             addReplyError(c,nanerr);
@@ -2396,7 +2396,7 @@ void zrangeGenericCommand(client *c, int reverse) {
     rangelen = (end-start)+1;
 
     /* Return the result in form of a multi-bulk reply */
-    addReplyMultiBulkLen(c, withscores ? (rangelen*2) : rangelen);
+    addReplyMultiBulkLen(c, withscores ? (rangelen << 1) : rangelen);
 
     if (zobj->encoding == OBJ_ENCODING_ZIPLIST) {
         unsigned char *zl = zobj->ptr;

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -141,8 +141,8 @@
 /* Utility macros */
 #define ZIPLIST_BYTES(zl)       (*((uint32_t*)(zl)))
 #define ZIPLIST_TAIL_OFFSET(zl) (*((uint32_t*)((zl)+sizeof(uint32_t))))
-#define ZIPLIST_LENGTH(zl)      (*((uint16_t*)((zl)+sizeof(uint32_t)*2)))
-#define ZIPLIST_HEADER_SIZE     (sizeof(uint32_t)*2+sizeof(uint16_t))
+#define ZIPLIST_LENGTH(zl)      (*((uint16_t*)((zl)+(sizeof(uint32_t) << 1))))
+#define ZIPLIST_HEADER_SIZE     ((sizeof(uint32_t) << 1)+sizeof(uint16_t))
 #define ZIPLIST_END_SIZE        (sizeof(uint8_t))
 #define ZIPLIST_ENTRY_HEAD(zl)  ((zl)+ZIPLIST_HEADER_SIZE)
 #define ZIPLIST_ENTRY_TAIL(zl)  ((zl)+intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl)))


### PR DESCRIPTION
change multiplying by power of two into shift operation.

I 'ack'ed all the source files and change the multiply operation with multiplier of power of 2 (for example a \* 2) into equivalent shift operation (a << 1) that I believe more efficient.
Unit test is performed after change and there was 1 err among 43 tests.
I think it's not due to the change that I made because I saw same error before
I make a change. but still I'm afraid patch contains erroneous points. please
review my humble patch
