### PR TITLE
fix bug while sh is NULL

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -89,9 +89,9 @@ sds sdsnewlen(const void *init, size_t initlen) {
     unsigned char *fp; /* flags pointer. */
 
     sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
     if (!init)
         memset(sh, 0, hdrlen+initlen+1);
-    if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
     switch(type) {


### PR DESCRIPTION
If sh is NULL, maybe lead to crash.
So judge the null pointer before memset.
