### PR TITLE
redis-trib.rb: improve master / replicas associations

### DIFF
--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -744,7 +744,7 @@ class RedisTrib
                     end
 
                     # Return the first node not matching our current master
-                    node = interleaved.find{|n| n.info[:host] != m.info[:host]}
+                    node = interleaved[ (assigned_replicas + 1) % nodes_count ]
 
                     # If we found a node, use it as a best-first match.
                     # Otherwise, we didn't find a node on a different IP, so we


### PR DESCRIPTION
Change the way redis-trib.rb tries to associate replicas with masters, naively trying to avoid replicas on same host as the master #2204 #2436
