### PR TITLE
fix memory error on module unload

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3085,7 +3085,7 @@ int moduleUnload(sds name) {
 
     /* Remove from list of modules. */
     serverLog(LL_NOTICE,"Module %s unloaded",module->name);
-    dictDelete(modules,module->name);
+    dictDeleteNoFree(modules,module->name);
     moduleFreeModuleStructure(module);
 
     return REDISMODULE_OK;


### PR DESCRIPTION
line 3088: dictDelete(modules,module->name);
line 3089: moduleFreeModuleStructure(module);

will free module->name and module twice
