### PR TITLE
Make it possible to call RedisModule_FreeString() without a context.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -718,7 +718,7 @@ RedisModuleString *RM_CreateStringFromString(RedisModuleCtx *ctx, const RedisMod
  * from the pool of string to release at the end. */
 void RM_FreeString(RedisModuleCtx *ctx, RedisModuleString *str) {
     decrRefCount(str);
-    autoMemoryFreed(ctx,REDISMODULE_AM_STRING,str);
+    if (ctx != NULL) autoMemoryFreed(ctx,REDISMODULE_AM_STRING,str);
 }
 
 /* Every call to this function, will make the string 'str' requiring


### PR DESCRIPTION
When implementing a module data type, callbacks are made without a
RedisModuleCtx so it becomes impossible to free previously allocated
strings when necessary (e.g. on a free callback).

The other alternative is to push the context on all callbacks but it may
be reasonable to require that modules with custom data types will not
rely on auto memory for internal types.
