### PR TITLE
Buffer Over Read in redis-server 3.2.0 and Later

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -483,8 +483,6 @@ void hashTypeConvertZiplist(robj *o, int enc) {
             value = hashTypeCurrentObjectNewSds(hi,OBJ_HASH_VALUE);
             ret = dictAdd(dict, key, value);
             if (ret != DICT_OK) {
-                serverLogHexDump(LL_WARNING,"ziplist with dup elements dump",
-                    o->ptr,ziplistBlobLen(o->ptr));
                 serverPanic("Ziplist corruption detected");
             }
         }


### PR DESCRIPTION
Dear @antirez ,

I found a yet-undisclosed buffer over read vulnerability in redis-server 3.2.0 and later. I have reproduced this vulnerability by poc/poc.sh  in a Debian system and written a report (README.pdf) about it. A patch is also provided for your reference. You can find the POC and the report at [https://github.com/jingleyang/security_ctf/tree/master/opensource/redis_vul_0906_2016](https://github.com/jingleyang/security_ctf/tree/master/opensource/redis_vul_0906_2016)

This is a brief introduction about this vulnerability:

The last parameter named len in serverLogHexDump() can be controlled by a corrupted rdb database file. A very large value will trigger a buffer over read, resulting sensitive information on the stack, such as password, exposed.

I also reported the issue to the Debian security team (security@debian.org), but I have not got any confirmed reply.

Thank you very much.

Best Regards,
Jingyu
