### PR TITLE
Fix for IPv6-only systems failing this check

### DIFF
--- a/deps/hiredis/net.c
+++ b/deps/hiredis/net.c
@@ -263,20 +263,14 @@ static int _redisContextConnectTcp(redisContext *c, const char *addr, int port,
 
     snprintf(_port, 6, "%d", port);
     memset(&hints,0,sizeof(hints));
-    hints.ai_family = AF_INET;
+    hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
 
-    /* Try with IPv6 if no IPv4 address was found. We do it in this order since
-     * in a Redis client you can't afford to test if you have IPv6 connectivity
-     * as this would add latency to every connect. Otherwise a more sensible
-     * route could be: Use IPv6 if both addresses are available and there is IPv6
-     * connectivity. */
+    /* You have to always check for IPv6 since you don't know if you're
+     * running on an IPv6-only system */
     if ((rv = getaddrinfo(addr,_port,&hints,&servinfo)) != 0) {
-         hints.ai_family = AF_INET6;
-         if ((rv = getaddrinfo(addr,_port,&hints,&servinfo)) != 0) {
-            __redisSetError(c,REDIS_ERR_OTHER,gai_strerror(rv));
-            return REDIS_ERR;
-        }
+        __redisSetError(c,REDIS_ERR_OTHER,gai_strerror(rv));
+        return REDIS_ERR;
     }
     for (p = servinfo; p != NULL; p = p->ai_next) {
         if ((s = socket(p->ai_family,p->ai_socktype,p->ai_protocol)) == -1)


### PR DESCRIPTION
- Changing AF_INET to AF_UNSPEC
- Only use AF_UNSPEC for the check, removing the IPv4-centric code
- Depending on the environment, getaddrinfo() result might be cached by
  e.g. nscd

The original code caused problems on our IPv6-only production systems.
I tested the patch on other systems, both dual-stack and single-stack deployments and see no issues introduced.
