### PR TITLE
Simple change just using slaves instead of server.slaves

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -244,7 +244,7 @@ void replicationFeedSlaves(list *slaves, int dictid, robj **argv, int argc) {
     }
 
     /* Write the command to every slave. */
-    listRewind(server.slaves,&li);
+    listRewind(slaves,&li);
     while((ln = listNext(&li))) {
         client *slave = ln->value;
 


### PR DESCRIPTION
in replicationFeedSlaves in replication.c 
we don't need to listrewind for server.slaves
just we can use slaves parameters
