### PR TITLE
Bringup redis-server if at least 1 ip is up

### DIFF
--- a/src/redis.c
+++ b/src/redis.c
@@ -1667,6 +1667,7 @@ void checkTcpBacklogSettings(void) {
  * one of the IPv4 or IPv6 protocols. */
 int listenToPort(int port, int *fds, int *count) {
     int j;
+    int working_set = 0;
 
     /* Force binding of 0.0.0.0 if no bind address is specified, always
      * entering the loop if j == 0. */
@@ -1705,10 +1706,17 @@ int listenToPort(int port, int *fds, int *count) {
                 "Creating Server TCP listening socket %s:%d: %s",
                 server.bindaddr[j] ? server.bindaddr[j] : "*",
                 port, server.neterr);
-            return REDIS_ERR;
+        } else {
+            anetNonBlock(NULL,fds[*count]);
+            (*count)++;
+            working_set++;
         }
-        anetNonBlock(NULL,fds[*count]);
-        (*count)++;
+    }
+
+    if (working_set == 0) {
+        redisLog(REDIS_WARNING,
+            "Could not bind to any specied addresses");
+        return REDIS_ERR;
     }
     return REDIS_OK;
 }


### PR DESCRIPTION
The earlier behavior was to exit out if bind to any ip failed. The new
behavior allows redis-server to come up if even a single bind succeeds.
