### PR TITLE
Bringup redis-server if at least 1 ip is up

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1694,7 +1694,7 @@ int listenToPort(int port, int *fds, int *count) {
 
     if (working_set == 0) {
         serverLog(LL_WARNING,
-            "Could not bind to any specied addresses");
+            "Could not bind to any specified addresses");
         return C_ERR;
     }
     return C_OK;


### PR DESCRIPTION
The earlier behavior was to exit out if bind to any ip failed. The new
behavior allows redis-server to come up if even a single bind succeeds.
