### PR TITLE
Update README for create-cluster

### DIFF
--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -86,10 +86,11 @@ then
     exit 0
 fi
 
-echo "Usage: $0 [start|create|stop|watch|tail|clean]"
+echo "Usage: $0 [start|create|stop|watch|tail|call|clean]"
 echo "start       -- Launch Redis Cluster instances."
 echo "create      -- Create a cluster using redis-trib create."
 echo "stop        -- Stop Redis Cluster instances."
 echo "watch       -- Show CLUSTER NODES output (first 30 lines) of first node."
 echo "tail <id>   -- Run tail -f of instance at base port + ID."
+echo "call        -- Run the given command to each nodes."
 echo "clean       -- Remove all instances data, logs, configs."


### PR DESCRIPTION
Add `call` command usage in README.

``` bash
$ ./create-cluster
Usage: ./create-cluster [start|create|stop|watch|tail|call|clean]
start       -- Launch Redis Cluster instances.
create      -- Create a cluster using redis-trib create.
stop        -- Stop Redis Cluster instances.
watch       -- Show CLUSTER NODES output (first 30 lines) of first node.
tail <id>   -- Run tail -f of instance at base port + ID.
call        -- Run the given command to each nodes.
clean       -- Remove all instances data, logs, configs.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/antirez/redis/3548)

<!-- Reviewable:end -->
