### PR TITLE
Adding Geo nautical mile unit conversion

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -135,9 +135,11 @@ double extractUnitOrReply(client *c, robj *unit) {
         return 0.3048;
     } else if (!strcmp(u, "mi")) {
         return 1609.34;
+    } else if (!strcmp(u, "nm")) {
+        return 1852;
     } else {
         addReplyError(c,
-            "unsupported unit provided. please use m, km, ft, mi");
+            "unsupported unit provided. please use m, km, ft, mi, nm");
         return -1;
     }
 }

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -152,6 +152,8 @@ start_server {tags {"geo"}} {
         assert {$m > 166274 && $m < 166275}
         set km [r geodist points Palermo Catania km]
         assert {$km > 166.2 && $km < 166.3}
+	set nm [r geodist points Palermo Catania nm]
+	assert {$nm > 89.78 && $nm < 89.79}
     }
 
     test {GEODIST missing elements} {


### PR DESCRIPTION
This code allows you to convert a GEODIST value from meter (default) to nautical mile.

127.0.0.1:6379> GEOADD Sicily 13.361389 38.115556 "Palermo" 15.087269 37.502669 "Catania"
(integer) 2
127.0.0.1:6379> GEODIST Sicily Palermo Catania
"166274.1516"
127.0.0.1:6379> GEODIST Sicily Palermo Catania nm
"89.7809"
