### PR TITLE
geo: consistency for hash/pos/dist results for non-existent keys vs elements

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -147,6 +147,18 @@ robj *lookupKeyReadOrReply(client *c, robj *key, robj *reply) {
     return o;
 }
 
+robj *lookupKeyReadOrMultiReply(client *c, robj *key, robj *reply, int nreps) {
+    robj *o = lookupKeyRead(c->db, key);
+    int j;
+    if (!o) {
+        addReplyMultiBulkLen(c,nreps);
+        for (j = 0; j < nreps; j++) {
+            addReply(c,reply);
+        }
+    }
+    return o;
+}
+
 robj *lookupKeyWriteOrReply(client *c, robj *key, robj *reply) {
     robj *o = lookupKeyWrite(c->db, key);
     if (!o) addReply(c,reply);

--- a/src/geo.c
+++ b/src/geo.c
@@ -662,7 +662,7 @@ void geohashCommand(client *c) {
 
     /* Look up the requested zset */
     robj *zobj = NULL;
-    if ((zobj = lookupKeyReadOrReply(c, c->argv[1], shared.emptymultibulk))
+    if ((zobj = lookupKeyReadOrMultiReply(c, c->argv[1], shared.nullbulk, c->argc-2))
         == NULL || checkType(c, zobj, OBJ_ZSET)) return;
 
     /* Geohash elements one after the other, using a null bulk reply for
@@ -716,7 +716,7 @@ void geoposCommand(client *c) {
 
     /* Look up the requested zset */
     robj *zobj = NULL;
-    if ((zobj = lookupKeyReadOrReply(c, c->argv[1], shared.emptymultibulk))
+    if ((zobj = lookupKeyReadOrMultiReply(c, c->argv[1], shared.nullmultibulk, c->argc-2))
         == NULL || checkType(c, zobj, OBJ_ZSET)) return;
 
     /* Report elements one after the other, using a null bulk reply for
@@ -759,7 +759,7 @@ void geodistCommand(client *c) {
 
     /* Look up the requested zset */
     robj *zobj = NULL;
-    if ((zobj = lookupKeyReadOrReply(c, c->argv[1], shared.emptybulk))
+    if ((zobj = lookupKeyReadOrReply(c, c->argv[1], shared.nullbulk))
         == NULL || checkType(c, zobj, OBJ_ZSET)) return;
 
     /* Get the scores. We need both otherwise NULL is returned. */

--- a/src/server.h
+++ b/src/server.h
@@ -1608,6 +1608,7 @@ robj *lookupKey(redisDb *db, robj *key, int flags);
 robj *lookupKeyRead(redisDb *db, robj *key);
 robj *lookupKeyWrite(redisDb *db, robj *key);
 robj *lookupKeyReadOrReply(client *c, robj *key, robj *reply);
+robj *lookupKeyReadOrMultiReply(client *c, robj *key, robj *reply, int nreps);
 robj *lookupKeyWriteOrReply(client *c, robj *key, robj *reply);
 robj *lookupKeyReadWithFlags(redisDb *db, robj *key, int flags);
 #define LOOKUP_NONE 0


### PR DESCRIPTION
re: Issue #3512 
Returning nullbulk instead of emptybulk for geodist seems very reasonable.
Before:

```
127.0.0.1:6379> geoadd mygeoset 8.66 49.52 Weinheim
(integer) 1
127.0.0.1:6379> geodist mygeoset Weinheim Weinheim
"0.0000"
127.0.0.1:6379> geodist mygeoset Weinheim Unknown
(nil)
127.0.0.1:6379> geodist unknownset Weinheim Unknown
""
```

After:

```
127.0.0.1:6379> geodist unknownset Weinheim Unknown
(nil)
```

I'm less certain about the design intent for geo{pos,hash} but chose to add a db helper to return a multi-reply consistent in cardinality with the case of a key that is devoid of the target elements. eg.

Before:

```
127.0.0.1:6379> geohash Sicily Palermo Unknown Catania
1) "sqc8b49rny0"
2) (nil)
3) "sqdtr74hyu0"
127.0.0.1:6379> geohash unknownset Palermo Unknown Catania
(empty list or set)
```

After:

```
127.0.0.1:6379> geohash unknownset Palermo Unknown Catania
1) (nil)
2) (nil)
3) (nil)
```

I deferred making any changes at all to the georadius family of commands, pending feedback from @antirez 
