### PR TITLE
Fixes compilation on MacOS 10.8.5, Clang tags/Apple/clang-421.0.57

### DIFF
--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -51,7 +51,7 @@
 #ifndef __ATOMIC_VAR_H
 #define __ATOMIC_VAR_H
 
-#if defined(__ATOMIC_RELAXED)
+#if defined(__ATOMIC_RELAXED) && (!defined(__clang__) || __apple_build_version__ > 4210057)
 /* Implementation using __atomic macros. */
 
 #define atomicIncr(var,count,mutex) __atomic_add_fetch(&var,(count),__ATOMIC_RELAXED)


### PR DESCRIPTION
Redis fails to compile on MacOS 10.8.5 with Clang 4, version 421.0.57
(based on LLVM 3.1svn).

When compiling zmalloc.c, we get these warnings:

```
    CC zmalloc.o
zmalloc.c:109:5: warning: implicit declaration of function '__atomic_add_fetch' is invalid in C99 [-Wimplicit-function-declaration]
    update_zmalloc_stat_alloc(zmalloc_size(ptr));
    ^
zmalloc.c:75:9: note: expanded from macro 'update_zmalloc_stat_alloc'
        atomicIncr(used_memory,__n,used_memory_mutex); \
        ^
./atomicvar.h:57:37: note: expanded from macro 'atomicIncr'
#define atomicIncr(var,count,mutex) __atomic_add_fetch(&var,(count),__ATOMIC_RELAXED)
                                    ^
zmalloc.c:145:5: warning: implicit declaration of function '__atomic_sub_fetch' is invalid in C99 [-Wimplicit-function-declaration]
    update_zmalloc_stat_free(oldsize);
    ^
zmalloc.c:85:9: note: expanded from macro 'update_zmalloc_stat_free'
        atomicDecr(used_memory,__n,used_memory_mutex); \
        ^
./atomicvar.h:58:37: note: expanded from macro 'atomicDecr'
#define atomicDecr(var,count,mutex) __atomic_sub_fetch(&var,(count),__ATOMIC_RELAXED)
                                    ^
zmalloc.c:205:9: warning: implicit declaration of function '__atomic_load_n' is invalid in C99 [-Wimplicit-function-declaration]
        atomicGet(used_memory,um,used_memory_mutex);
        ^
./atomicvar.h:60:14: note: expanded from macro 'atomicGet'
    dstvar = __atomic_load_n(&var,__ATOMIC_RELAXED); \
             ^
3 warnings generated.
```

Also on lazyfree.c:

```
    CC lazyfree.o
lazyfree.c:68:13: warning: implicit declaration of function '__atomic_add_fetch' is invalid in C99 [-Wimplicit-function-declaration]
            atomicIncr(lazyfree_objects,1,lazyfree_objects_mutex);
            ^
./atomicvar.h:57:37: note: expanded from macro 'atomicIncr'
#define atomicIncr(var,count,mutex) __atomic_add_fetch(&var,(count),__ATOMIC_RELAXED)
                                    ^
lazyfree.c:111:5: warning: implicit declaration of function '__atomic_sub_fetch' is invalid in C99 [-Wimplicit-function-declaration]
    atomicDecr(lazyfree_objects,1,lazyfree_objects_mutex);
    ^
./atomicvar.h:58:37: note: expanded from macro 'atomicDecr'
#define atomicDecr(var,count,mutex) __atomic_sub_fetch(&var,(count),__ATOMIC_RELAXED)
                                    ^
2 warnings generated.
```

Then in the linking stage:

```
    LINK redis-server
Undefined symbols for architecture x86_64:
  "___atomic_add_fetch", referenced from:
      _zmalloc in zmalloc.o
      _zcalloc in zmalloc.o
      _zrealloc in zmalloc.o
      _dbAsyncDelete in lazyfree.o
      _emptyDbAsync in lazyfree.o
      _slotToKeyFlushAsync in lazyfree.o
  "___atomic_load_n", referenced from:
      _zmalloc_used_memory in zmalloc.o
      _zmalloc_get_fragmentation_ratio in zmalloc.o
  "___atomic_sub_fetch", referenced from:
      _zrealloc in zmalloc.o
      _zfree in zmalloc.o
      _lazyfreeFreeObjectFromBioThread in lazyfree.o
      _lazyfreeFreeDatabaseFromBioThread in lazyfree.o
      _lazyfreeFreeSlotsMapFromBioThread in lazyfree.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [redis-server] Error 1
make: *** [all] Error 2
```

With this patch, the compilation is sucessful, no warnings.

Running `make test` we get a almost clean bill of health. Test pass with
one exception:

```
[err]: Check for memory leaks (pid 52793) in tests/unit/dump.tcl
[err]: Check for memory leaks (pid 53103) in tests/unit/auth.tcl
[err]: Check for memory leaks (pid 53117) in tests/unit/auth.tcl
[err]: Check for memory leaks (pid 53131) in tests/unit/protocol.tcl
[err]: Check for memory leaks (pid 53145) in tests/unit/protocol.tcl
[ok]: Check for memory leaks (pid 53160)
[err]: Check for memory leaks (pid 53175) in tests/unit/scan.tcl
[ok]: Check for memory leaks (pid 53189)
[err]: Check for memory leaks (pid 53221) in tests/unit/type/incr.tcl
.
.
.
```

Full debug log (289MB, uncompressed) available at
https://dl.dropboxusercontent.com/u/75548/logs/redis-debug-log-macos-10.8.5.log.xz

Most if not all of the memory leak tests fail. Not sure if this is
related. They are the only ones that fail. I belive they are not related,
but just the memory leak detector is not working properly on 10.8.5.

Signed-off-by: Pedro Melo melo@simplicidade.org
