### PR TITLE
Add missing fclose()

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1257,6 +1257,7 @@ void cliLoadPreferences(void) {
             if (argc > 0) cliSetPreferences(argv,argc,0);
             sdsfreesplitres(argv,argc);
         }
+        fclose(fp);
     }
     sdsfree(rcfile);
 }


### PR DESCRIPTION
add missing `fclose()` in `src/redis-cli.c:cliLoadPreferences()`
