### PR TITLE
sdsnewlen check malloc result before memset

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -92,9 +92,9 @@ sds sdsnewlen(const void *init, size_t initlen) {
     unsigned char *fp; /* flags pointer. */
 
     sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
     if (!init)
         memset(sh, 0, hdrlen+initlen+1);
-    if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
     switch(type) {


### PR DESCRIPTION
memset with NULL pointer and non-zero size will cause segmentation fault on Mac OS X, so check malloc result before memset.