### PR TITLE
log client name in MONITOR

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -278,9 +278,9 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     if (c->flags & CLIENT_LUA) {
         cmdrepr = sdscatprintf(cmdrepr,"[%d lua] ",dictid);
     } else if (c->flags & CLIENT_UNIX_SOCKET) {
-        cmdrepr = sdscatprintf(cmdrepr,"[%d unix:%s] ",dictid,server.unixsocket);
+        cmdrepr = sdscatprintf(cmdrepr,"[%d unix:%s%s%s] ",dictid,server.unixsocket, c->name ? " " : "", c->name ? (char*)c->name->ptr : "");
     } else {
-        cmdrepr = sdscatprintf(cmdrepr,"[%d %s] ",dictid,getClientPeerId(c));
+        cmdrepr = sdscatprintf(cmdrepr,"[%d %s%s%s] ",dictid,getClientPeerId(c), c->name ? " " : "", c->name ? (char*)c->name->ptr : "");
     }
 
     for (j = 0; j < argc; j++) {


### PR DESCRIPTION
See conversation at https://twitter.com/Habbie/status/784404440661057536

I did not find a neat way to do this in Redis, for lack of comment syntax in commands. So here is my alternative - make MONITOR log client names. I did not touch the Lua call because it appears it does not have the client name. Suggestions on that welcome.

Passes all tests, which tells me MONITOR is not actually part of the tests today..