### PR TITLE
Add db id and client name to slowlog

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2151,7 +2151,7 @@ void call(client *c, int flags) {
         char *latency_event = (c->cmd->flags & CMD_FAST) ?
                               "fast-command" : "command";
         latencyAddSampleIfNeeded(latency_event,duration/1000);
-        slowlogPushEntryIfNeeded(c->argv,c->argc,duration);
+        slowlogPushEntryIfNeeded(c->argv,c->argc,duration,c->db->id,c->name);
     }
     if (flags & CMD_CALL_STATS) {
         c->lastcmd->microseconds += duration;

--- a/src/slowlog.h
+++ b/src/slowlog.h
@@ -37,11 +37,13 @@ typedef struct slowlogEntry {
     long long id;       /* Unique entry identifier. */
     long long duration; /* Time spent by the query, in nanoseconds. */
     time_t time;        /* Unix time at which the query was executed. */
+    int dbid;           /* Database index the slow command was executed in. */
+    robj *clientName;   /* Name of client who executed command. */
 } slowlogEntry;
 
 /* Exported API */
 void slowlogInit(void);
-void slowlogPushEntryIfNeeded(robj **argv, int argc, long long duration);
+void slowlogPushEntryIfNeeded(robj **argv, int argc, long long duration, int dbid, robj *clientName);
 
 /* Exported commands */
 void slowlogCommand(client *c);


### PR DESCRIPTION
When checking the slowlog for performance issues, it is often hard to tell
where n slow command is coming from. This becomes a lot easier if you have
meaningful client names.

Examples include the name of the app, the name of the host, a unique id
per request.

I also saw that #2043 is requsting the slowlog to include the db number, so I added that as well.