### PR TITLE
add dbnum checking for replication

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -270,6 +270,8 @@ typedef long long mstime_t; /* millisecond time type. */
 #define REPL_STATE_RECEIVE_PONG 3 /* Wait for PING reply */
 #define REPL_STATE_SEND_AUTH 4 /* Send AUTH to master */
 #define REPL_STATE_RECEIVE_AUTH 5 /* Wait for AUTH reply */
+#define REPL_STATE_REQUEST_DBNUM 16 /* Send REPLCONF getdbnum */
+#define REPL_STATE_RECEIVE_DBNUM 17 /* Wait REPLCONF reply */
 #define REPL_STATE_SEND_PORT 6 /* Send REPLCONF listening-port */
 #define REPL_STATE_RECEIVE_PORT 7 /* Wait for REPLCONF reply */
 #define REPL_STATE_SEND_IP 8 /* Send REPLCONF ip-address */


### PR DESCRIPTION
When the slave dbnum is less than it's master, the master some keys maybe insert into the wrong slave db.
So i think the dbnum between master and it's slaves must be same, and this can be checked at the replication handshake.