### PR TITLE
Add hostname to INFO SERVER

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2764,6 +2764,7 @@ sds genRedisInfoString(char *section) {
             "redis_build_id:%llx\r\n"
             "redis_mode:%s\r\n"
             "os:%s %s %s\r\n"
+            "hostname:%s\r\n"
             "arch_bits:%d\r\n"
             "multiplexing_api:%s\r\n"
             "gcc_version:%d.%d.%d\r\n"
@@ -2782,6 +2783,7 @@ sds genRedisInfoString(char *section) {
             (unsigned long long) redisBuildId(),
             mode,
             name.sysname, name.release, name.machine,
+            name.nodename,
             server.arch_bits,
             aeGetApiName(),
 #ifdef __GNUC__


### PR DESCRIPTION
It is common to connect via VIPs and/or proxies.  This allows tooling to know the hostname without having to perform gymnastics.