### PR TITLE
Fix typo (unsupproted => unsupported) in error message

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1658,7 +1658,7 @@ int listenToPort(int port, int *fds, int *count) {
                 (*count)++;
             } else if (errno == EAFNOSUPPORT) {
                 unsupported++;
-                serverLog(LL_WARNING,"Not listening to IPv6: unsupproted");
+                serverLog(LL_WARNING,"Not listening to IPv6: unsupported");
             }
 
             if (*count == 1 || unsupported) {
@@ -1670,7 +1670,7 @@ int listenToPort(int port, int *fds, int *count) {
                     (*count)++;
                 } else if (errno == EAFNOSUPPORT) {
                     unsupported++;
-                    serverLog(LL_WARNING,"Not listening to IPv4: unsupproted");
+                    serverLog(LL_WARNING,"Not listening to IPv4: unsupported");
                 }
             }
             /* Exit the loop if we were able to bind * on IPv4 and IPv6,


### PR DESCRIPTION
Small typo fix