### PR TITLE
sds funcation sdsnewlen  bug

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -92,9 +92,9 @@ sds sdsnewlen(const void *init, size_t initlen) {
     unsigned char *fp; /* flags pointer. */
 
     sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
     if (!init)
         memset(sh, 0, hdrlen+initlen+1);
-    if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
     switch(type) {

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -146,7 +146,7 @@
 #define ZIPLIST_END_SIZE        (sizeof(uint8_t))
 #define ZIPLIST_ENTRY_HEAD(zl)  ((zl)+ZIPLIST_HEADER_SIZE)
 #define ZIPLIST_ENTRY_TAIL(zl)  ((zl)+intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl)))
-#define ZIPLIST_ENTRY_END(zl)   ((zl)+intrev32ifbe(ZIPLIST_BYTES(zl))-1)
+#define ZIPLIST_ENTRY_END(zl)   ((zl)+intrev32ifbe(ZIPLIST_BYTES(zl))-ZIPLIST_END_SIZE)
 
 /* We know a positive increment can only be 1 because entries can only be
  * pushed one at a time. */


### PR DESCRIPTION
funcation sdsnewlen is not static , so it is the API for the sds.  but when s_malloc is faild and init is null , memset a null pointer can make the program crash .