### PR TITLE
cli: Only print elapsed time on OUTPUT_STANDARD.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1344,7 +1344,9 @@ static void repl(void) {
                     }
 
                     elapsed = mstime()-start_time;
-                    if (elapsed >= 500) {
+                    if (elapsed >= 500 &&
+                        config.output == OUTPUT_STANDARD)
+                    {
                         printf("(%.2fs)\n",(double)elapsed/1000);
                     }
                 }


### PR DESCRIPTION
Fixes #3647 

I tested this by running a script which spinlocks for three seconds. With existing behaviour, each of these would print a line containing the time elapsed.

```bash
$ echo 'evalsha d367aeb6cc5b4d74c4eda50408bd10efbe3aeb18 0' | ./src/redis-cli     
(nil)
(3.00s)

$ echo 'evalsha d367aeb6cc5b4d74c4eda50408bd10efbe3aeb18 0' | ./src/redis-cli --csv
NIL                                     

$ echo 'evalsha d367aeb6cc5b4d74c4eda50408bd10efbe3aeb18 0' | ./src/redis-cli --raw

# empty output
```

It was mentioned in #3647 that it might be a good idea to always print the elapsed time when using the standard output format. I played with this for a little while, but most commands run so fast that the elapsed time is written as 0, so I left that logic as-is.