### PR TITLE
Reset the ttl for additional keys

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4841,6 +4841,7 @@ try_again:
 
     /* Create RESTORE payload and generate the protocol to call the command. */
     for (j = 0; j < num_keys; j++) {
+        ttl = 0;
         expireat = getExpire(c->db,kv[j]);
         if (expireat != -1) {
             ttl = expireat-mstime();


### PR DESCRIPTION
Before, if a previous key had a TTL set but the current one didn't, the
TTL was reused and thus resulted in wrong expirations set.

This behaviour was experienced, when `MigrateDefaultPipeline` in
redis-trib was set to >1

Fixes #3655