### PR TITLE
LogLog-Beta Algorithm support within HLL

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -688,6 +688,10 @@ void loadServerConfigFromString(char *config) {
                 err = sentinelHandleConfiguration(argv+1,argc-1);
                 if (err) goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"hll-use-loglogbeta") && argc == 2) {
+            if ((server.hll_use_loglogbeta = yesnotoi(argv[1])) == -1) {
+                err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
         } else {
             err = "Bad directive or wrong number of arguments"; goto loaderr;
         }
@@ -980,7 +984,9 @@ void configSetCommand(client *c) {
     } config_set_bool_field(
       "slave-lazy-flush",server.repl_slave_lazy_flush) {
     } config_set_bool_field(
-      "no-appendfsync-on-rewrite",server.aof_no_fsync_on_rewrite) {
+      "no-appendfsync-on-rewrite",server.aof_no_fsync_on_rewrite) { 
+    } config_set_bool_field(
+      "hll-use-loglogbeta",server.hll_use_loglogbeta) {
 
     /* Numerical fields.
      * config_set_numerical_field(name,var,min,max) */
@@ -1245,6 +1251,8 @@ void configGetCommand(client *c) {
             server.lazyfree_lazy_server_del);
     config_get_bool_field("slave-lazy-flush",
             server.repl_slave_lazy_flush);
+    config_get_bool_field("hll-use-loglogbeta",
+            server.hll_use_loglogbeta);
 
     /* Enum values */
     config_get_enum_field("maxmemory-policy",
@@ -1963,6 +1971,7 @@ int rewriteConfig(char *path) {
     rewriteConfigYesNoOption(state,"lazyfree-lazy-expire",server.lazyfree_lazy_expire,CONFIG_DEFAULT_LAZYFREE_LAZY_EXPIRE);
     rewriteConfigYesNoOption(state,"lazyfree-lazy-server-del",server.lazyfree_lazy_server_del,CONFIG_DEFAULT_LAZYFREE_LAZY_SERVER_DEL);
     rewriteConfigYesNoOption(state,"slave-lazy-flush",server.repl_slave_lazy_flush,CONFIG_DEFAULT_SLAVE_LAZY_FLUSH);
+    rewriteConfigYesNoOption(state,"hll-use-loglogbeta",server.hll_use_loglogbeta,CONFIG_DEFAULT_HLL_USE_LOGLOGBETA);
 
     /* Rewrite Sentinel config if in Sentinel mode. */
     if (server.sentinel_mode) rewriteConfigSentinelOption(state);

--- a/src/server.c
+++ b/src/server.c
@@ -1397,6 +1397,7 @@ void initServerConfig(void) {
     server.lazyfree_lazy_eviction = CONFIG_DEFAULT_LAZYFREE_LAZY_EVICTION;
     server.lazyfree_lazy_expire = CONFIG_DEFAULT_LAZYFREE_LAZY_EXPIRE;
     server.lazyfree_lazy_server_del = CONFIG_DEFAULT_LAZYFREE_LAZY_SERVER_DEL;
+    server.hll_use_loglogbeta = CONFIG_DEFAULT_HLL_USE_LOGLOGBETA;
 
     server.lruclock = getLRUClock();
     resetServerSaveParams();

--- a/src/server.h
+++ b/src/server.h
@@ -151,6 +151,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CONFIG_DEFAULT_LAZYFREE_LAZY_EVICTION 0
 #define CONFIG_DEFAULT_LAZYFREE_LAZY_EXPIRE 0
 #define CONFIG_DEFAULT_LAZYFREE_LAZY_SERVER_DEL 0
+#define CONFIG_DEFAULT_HLL_USE_LOGLOGBETA 0
 
 #define ACTIVE_EXPIRE_CYCLE_LOOKUPS_PER_LOOP 20 /* Loopkups per loop. */
 #define ACTIVE_EXPIRE_CYCLE_FAST_DURATION 1000 /* Microseconds */
@@ -1149,6 +1150,7 @@ struct redisServer {
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
     /* System hardware info */
     size_t system_memory_size;  /* Total memory in system as reported by OS */
+    int hll_use_loglogbeta; /* Use loglog-beta algorithm for HLL */
 };
 
 typedef struct pubsubPattern {


### PR DESCRIPTION
LogLog-β is a new algorithm for estimating cardinalities based on LogLog counting. The new algorithm uses only one formula and needs no additional bias corrections for the entire range of cardinalities, therefore, it is more efficient and simpler to implement. 
Refer to https://arxiv.org/pdf/1612.02557.pdf for more details.
This changeset adds the support to compute carinality based on loglog-beta alogorithm and a config option to use the same.

I have tested the changes using PFSELFTEST command with new config option set.
