### PR TITLE
Fix redis-cli rare crash.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -275,6 +275,10 @@ static void cliIntegrateHelp(void) {
      * don't already match what we have. */
     for (size_t j = 0; j < reply->elements; j++) {
         redisReply *entry = reply->element[j];
+        if (entry->type != REDIS_REPLY_ARRAY || entry->elements < 4 ||
+            entry->element[0]->type != REDIS_REPLY_STRING ||
+            entry->element[1]->type != REDIS_REPLY_INTEGER ||
+            entry->element[3]->type != REDIS_REPLY_INTEGER) return;
         char *cmdname = entry->element[0]->str;
         int i;
 


### PR DESCRIPTION
This happens if the server (mysteriously) returns an unexpected response
to the COMMAND command.