### PR TITLE
Module: add module desc subcommand

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -47,6 +47,7 @@ struct RedisModule {
     int ver;        /* Module version. We use just progressive integers. */
     int apiver;     /* Module API version as requested during initialization.*/
     list *types;    /* Module data types. */
+    sds desc;       /* Module description. */
 };
 typedef struct RedisModule RedisModule;
 
@@ -590,7 +591,7 @@ int commandFlagsFromString(char *s) {
  *                     keys, programmatically creates key names, or any
  *                     other reason.
  */
-int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) {
+int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, const char *desc, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) {
     int flags = strflags ? commandFlagsFromString((char*)strflags) : 0;
     if (flags == -1) return REDISMODULE_ERR;
     if ((flags & CMD_MODULE_NO_CLUSTER) && server.cluster_enabled)
@@ -629,6 +630,8 @@ int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc c
     cp->rediscmd->calls = 0;
     dictAdd(server.commands,sdsdup(cmdname),cp->rediscmd);
     dictAdd(server.orig_commands,sdsdup(cmdname),cp->rediscmd);
+    cp->module->desc = sdscat(cp->module->desc, desc);
+    cp->module->desc = sdscat(cp->module->desc, "\n\n");
     return REDISMODULE_OK;
 }
 
@@ -636,7 +639,7 @@ int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc c
  *
  * This is an internal function, Redis modules developers don't need
  * to use it. */
-void RM_SetModuleAttribs(RedisModuleCtx *ctx, const char *name, int ver, int apiver){
+void RM_SetModuleAttribs(RedisModuleCtx *ctx, const char *name, const char* desc, int ver, int apiver){
     RedisModule *module;
 
     if (ctx->module != NULL) return;
@@ -645,6 +648,7 @@ void RM_SetModuleAttribs(RedisModuleCtx *ctx, const char *name, int ver, int api
     module->ver = ver;
     module->apiver = apiver;
     module->types = listCreate();
+    module->desc = sdscatprintf(sdsempty(),"Module description:\n%s\n\nModule commands:\n", desc);
     ctx->module = module;
 }
 
@@ -3479,6 +3483,16 @@ void moduleCommand(client *c) {
             addReplyLongLong(c,module->ver);
         }
         dictReleaseIterator(di);
+    } else if (!strcasecmp(subcmd,"desc") && c->argc == 3) {
+        dictEntry *de = dictFind(modules, (char*)(c->argv[2]->ptr));
+        if (NULL!=de) {
+           struct RedisModule *module = dictGetVal(de);
+           addReplyString(c, "+", strlen("+"));
+           addReplySds(c, module->desc);
+           addReplyString(c, "\r\n", strlen("\r\n"));
+        } else {
+           addReplyString(c, "-module not found\r\n", strlen("-module not found\r\n"));
+        }
     } else {
         addReply(c,shared.syntaxerr);
     }

--- a/src/modules/API.md
+++ b/src/modules/API.md
@@ -95,7 +95,7 @@ order to report keys, like in the following example:
 
 ## `RM_CreateCommand`
 
-    int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep);
+    int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, const char *desc, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep);
 
 Register a new command in the Redis server, that will be handled by
 calling the function pointer 'func' using the RedisModule calling
@@ -152,7 +152,7 @@ example "write deny-oom". The set of flags are:
 
 ## `RM_SetModuleAttribs`
 
-    void RM_SetModuleAttribs(RedisModuleCtx *ctx, const char *name, int ver, int apiver);
+    void RM_SetModuleAttribs(RedisModuleCtx *ctx, const char *name, const char *desc, int ver, int apiver);
 
 Called by `RM_Init()` to setup the `ctx->module` structure.
 

--- a/src/modules/INTRO.md
+++ b/src/modules/INTRO.md
@@ -67,10 +67,14 @@ simple module that implements a command that outputs a random number.
     }
 
     int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-        if (RedisModule_Init(ctx,"helloworld",1,REDISMODULE_APIVER_1)
+	const char *module_desc = "This is a demo module";
+        if (RedisModule_Init(ctx,"helloworld",module_desc,1,REDISMODULE_APIVER_1)
             == REDISMODULE_ERR) return REDISMODULE_ERR;
 
-        if (RedisModule_CreateCommand(ctx,"helloworld.rand",
+	const char *rand_desc =
+	    "helloworld.rand\n"
+	    "return integer: a rand number";
+        if (RedisModule_CreateCommand(ctx,"helloworld.rand", rand_desc,
             HelloworldRand_RedisCommand) == REDISMODULE_ERR)
             return REDISMODULE_ERR;
 
@@ -101,7 +105,8 @@ It should be the first function called by the module `OnLoad` function.
 The following is the function prototype:
 
     int RedisModule_Init(RedisModuleCtx *ctx, const char *modulename,
-                         int module_version, int api_version);
+                         const char *moduledesc,int module_version,
+			 int api_version);
 
 The `Init` function announces the Redis core that the module has a given
 name, its version (that is reported by `MODULE LIST`), and that is willing
@@ -118,7 +123,7 @@ The second function called, `RedisModule_CreateCommand`, is used in order
 to register commands into the Redis core. The following is the prototype:
 
     int RedisModule_CreateCommand(RedisModuleCtx *ctx, const char *cmdname,
-                                  RedisModuleCmdFunc cmdfunc);
+                           const char *cmddesc,RedisModuleCmdFunc cmdfunc);
 
 As you can see, most Redis modules API calls all take as first argument
 the `context` of the module, so that they have a reference to the module

--- a/src/modules/helloblock.c
+++ b/src/modules/helloblock.c
@@ -111,10 +111,18 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
 
-    if (RedisModule_Init(ctx,"helloblock",1,REDISMODULE_APIVER_1)
+    const char *module_desc =
+	"This module show the implementation of a block redis command.The  \n"
+	"command hello.block show how to execute a block command in certain\n"
+	"timeout.";
+    if (RedisModule_Init(ctx,"helloblock",module_desc,1,REDISMODULE_APIVER_1)
         == REDISMODULE_ERR) return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.block",
+    const char *block_desc =
+	"hello.block <delay> <timeout>\n"
+	"return integer or string: a random number if delay (in seconds) less\n"
+	"than timeout (in ms) otherwise return \"Request timedout\"";
+    if (RedisModule_CreateCommand(ctx,"hello.block", block_desc,
         HelloBlock_RedisCommand,"",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 

--- a/src/modules/hellotype.c
+++ b/src/modules/hellotype.c
@@ -242,7 +242,12 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
 
-    if (RedisModule_Init(ctx,"hellotype",1,REDISMODULE_APIVER_1)
+    const char *module_desc =
+        "This mudule just show the implementation of new data types.The new\n"
+	"data type hellotype is just a linked list of 64 bit integers where\n"
+	"elements are inserted in-place, so it's ordered. There is no pop  \n"
+	"or push operation but just insert.\n";
+    if (RedisModule_Init(ctx,"hellotype",module_desc,1,REDISMODULE_APIVER_1)
         == REDISMODULE_ERR) return REDISMODULE_ERR;
 
     RedisModuleTypeMethods tm = {
@@ -256,15 +261,25 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     HelloType = RedisModule_CreateDataType(ctx,"hellotype",0,&tm);
     if (HelloType == NULL) return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hellotype.insert",
+    const char *insert_desc =
+        "hellotype.insert <key> <value>\n"
+        "return integer: the key length";
+    if (RedisModule_CreateCommand(ctx,"hellotype.insert", insert_desc,
         HelloTypeInsert_RedisCommand,"write deny-oom",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hellotype.range",
+    const char *range_desc =
+        "hellotype.range <key> <first> <count>\n"
+        "return array: list of elements in the specified range.";
+    if (RedisModule_CreateCommand(ctx,"hellotype.range", range_desc,
         HelloTypeRange_RedisCommand,"readonly",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hellotype.len",
+    const char *len_desc =
+        "hellotype.len key\n"
+        "return integer: number of fields in the hellotype, or 0 when key   \n"
+	"does not exist.";
+    if (RedisModule_CreateCommand(ctx,"hellotype.len", len_desc,
         HelloTypeLen_RedisCommand,"readonly",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 

--- a/src/modules/helloworld.c
+++ b/src/modules/helloworld.c
@@ -544,7 +544,11 @@ int HelloLeftPad_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int
 /* This function must be present on each Redis module. It is used in order to
  * register the commands into the Redis server. */
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    if (RedisModule_Init(ctx,"helloworld",1,REDISMODULE_APIVER_1)
+    const char* module_desc =
+	"This module is a basic redis module.It shows how to access redis  \n"
+	"native data (which type is string,list,hash,set,zset) and how to  \n"
+	"manipulate it then send reply to client.";
+    if (RedisModule_Init(ctx,"helloworld",module_desc,1,REDISMODULE_APIVER_1)
         == REDISMODULE_ERR) return REDISMODULE_ERR;
 
     /* Log the list of parameters passing loading the module. */
@@ -553,68 +557,124 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         printf("Module loaded with ARGV[%d] = %s\n", j, s);
     }
 
-    if (RedisModule_CreateCommand(ctx,"hello.simple",
+    const char *simple_desc =
+	"hello.simple\n"
+        "return integer: the currently selected DB id";
+    if (RedisModule_CreateCommand(ctx,"hello.simple", simple_desc,
         HelloSimple_RedisCommand,"readonly",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.push.native",
+    const char *push_native_desc =
+	"hello.push.native <key> <value>\n"
+        "return integer: the length of the list after the operation.";
+    if (RedisModule_CreateCommand(ctx,"hello.push.native", push_native_desc,
         HelloPushNative_RedisCommand,"write deny-oom",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.push.call",
+    const char *push_call_desc =
+	"hello.push.call <key> <value>\n"
+        "return integer: the length of the list after the operation.";
+    if (RedisModule_CreateCommand(ctx,"hello.push.call", push_call_desc,
         HelloPushCall_RedisCommand,"write deny-oom",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.push.call2",
+    const char *push_call2_desc =
+	"hello.push.call2 <key> <value>\n"
+        "return integer: the length of the list after the operation.";
+    if (RedisModule_CreateCommand(ctx,"hello.push.call2", push_call2_desc,
         HelloPushCall2_RedisCommand,"write deny-oom",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.list.sum.len",
+    const char *list_sum_len_desc =
+	"hello.list.sum.len <key>\n"
+        "return integer: the total length of all the items inside a list";
+    if (RedisModule_CreateCommand(ctx,"hello.list.sum.len", list_sum_len_desc,
         HelloListSumLen_RedisCommand,"readonly",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.list.splice",
+    const char *list_splice_desc =
+	"hello.list.splice <srclist> <dstlist> <count>\n"
+        "return integer: the length of the srclist after the operation.";
+    if (RedisModule_CreateCommand(ctx,"hello.list.splice", list_splice_desc,
         HelloListSplice_RedisCommand,"write deny-oom",1,2,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.list.splice.auto",
+    const char *list_splice_auto_desc =
+	"hello.list.splice.auto <srclist> <dstlist> <count>\n"
+        "return integer: the length of the srclist after the operation.";
+    if (RedisModule_CreateCommand(ctx,"hello.list.splice.auto", list_splice_auto_desc,
         HelloListSpliceAuto_RedisCommand,
         "write deny-oom",1,2,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.rand.array",
+    const char *rand_array_desc =
+	"hello.rand.array <count>\n"
+        "return array: outputs <count> random numbers.";
+    if (RedisModule_CreateCommand(ctx,"hello.rand.array", rand_array_desc,
         HelloRandArray_RedisCommand,"readonly",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.repl1",
+    const char *repl1_desc =
+	"hello.repl1\n"
+        "return integer: 0";
+    if (RedisModule_CreateCommand(ctx,"hello.repl1", repl1_desc,
         HelloRepl1_RedisCommand,"write",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.repl2",
+    const char *repl2_desc =
+	"hello.repl2 <list-key>\n"
+        "return integer: increase all the elements (that must have a numerical\n"
+        " value) by 1, returning the sum of all the elements in the list\n";
+    if (RedisModule_CreateCommand(ctx,"hello.repl2", repl2_desc,
         HelloRepl2_RedisCommand,"write",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.toggle.case",
+    const char *toggle_case_desc =
+	"hello.toggle.case <key>\n"
+        "return string: toggle the case of each character of the key from  \n"
+	"lower to upper case or the other way around, then return OK";
+    if (RedisModule_CreateCommand(ctx,"hello.toggle.case", toggle_case_desc,
         HelloToggleCase_RedisCommand,"write",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.more.expire",
+    const char *more_expire_desc =
+	"hello.more.expire <key> <milliseconds>\n"
+        "return string: if the key has already an associated TTL, extends  \n"
+	"it by <milliseconds> milliseconds otherwise do nothing,return OK";
+    if (RedisModule_CreateCommand(ctx,"hello.more.expire", more_expire_desc,
         HelloMoreExpire_RedisCommand,"write",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.zsumrange",
+    const char *zsumrange_desc =
+	"hello.zsumrange <key> <startscore> <endscore>\n"
+        "return array: compute the sum of scores in key from <startscore> to\n"
+	"<endscore>, then the sum from <endscore> to <startscore>, return an\n"
+	"array with two sum number as elements";
+    if (RedisModule_CreateCommand(ctx,"hello.zsumrange", zsumrange_desc,
         HelloZsumRange_RedisCommand,"readonly",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.lexrange",
+    const char *lexrange_desc =
+	"hello.lexrange <key> <min_lex> <max_lex> <min_age> <max_age>\n"
+        "return string: all the sorted set items that are lexicographically\n"
+        "between the specified range.";
+    if (RedisModule_CreateCommand(ctx,"hello.lexrange", lexrange_desc,
         HelloLexRange_RedisCommand,"readonly",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.hcopy",
+    const char *hcopy_desc =
+	"hello.hcopy <key> <srcfield> <dstfield>\n"
+	"return integer: 1 if the copy is performed (srcfield exists)\n"
+	"otherwise 0.";
+    if (RedisModule_CreateCommand(ctx,"hello.hcopy", hcopy_desc,
         HelloHCopy_RedisCommand,"write deny-oom",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"hello.leftpad",
+    const char *leftpad_desc =
+	"hello.leftpad <str> <len> <ch>\n"
+        "return string: if the <str> len less than <len> expand <str>\n"
+	"to <len> with <ch>,otherwise do nothing,return new <str>";
+    if (RedisModule_CreateCommand(ctx,"hello.leftpad", leftpad_desc,
         HelloLeftPad_RedisCommand,"",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 

--- a/src/modules/testmodule.c
+++ b/src/modules/testmodule.c
@@ -210,26 +210,44 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
 
-    if (RedisModule_Init(ctx,"test",1,REDISMODULE_APIVER_1)
+    const char *module_desc =
+	"This module show the implementation of a unit tests";
+    if (RedisModule_Init(ctx,"test",module_desc,1,REDISMODULE_APIVER_1)
         == REDISMODULE_ERR) return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"test.call",
+    const char *call_desc =
+	"test.call [value ...]\n"
+        "return string: OK";
+    if (RedisModule_CreateCommand(ctx,"test.call", call_desc,
         TestCall,"write deny-oom",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"test.string.append",
+    const char *string_append_desc =
+	"test.string.append [value ...]\n"
+        "return string: foobar";
+    if (RedisModule_CreateCommand(ctx,"test.string.append", string_append_desc,
         TestStringAppend,"write deny-oom",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"test.string.append.am",
+    const char *string_append_am_desc =
+	"test.string.append.am [value ...]\n"
+        "return string: foobar";
+    if (RedisModule_CreateCommand(ctx,"test.string.append.am", string_append_am_desc,
         TestStringAppendAM,"write deny-oom",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"test.string.printf",
+    const char *string_printf_desc =
+	"test.string.printf [value ...]\n"
+        "return string: Got <count> args, arg[1]:<arg1> ,arg[2]:...";
+    if (RedisModule_CreateCommand(ctx,"test.string.printf", string_printf_desc,
         TestStringPrintf,"write deny-oom",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"test.it",
+    const char *it_desc =
+	"test.it\n"
+        "return string: \"ALL TESTS PASSED\" if all case pass otherwise  \"\n"
+	"SOME TEST NOT PASSED! Check server logs\"";
+    if (RedisModule_CreateCommand(ctx,"test.it", it_desc,
         TestIt,"readonly",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -118,8 +118,8 @@ void REDISMODULE_API_FUNC(RedisModule_Free)(void *ptr);
 void *REDISMODULE_API_FUNC(RedisModule_Calloc)(size_t nmemb, size_t size);
 char *REDISMODULE_API_FUNC(RedisModule_Strdup)(const char *str);
 int REDISMODULE_API_FUNC(RedisModule_GetApi)(const char *, void *);
-int REDISMODULE_API_FUNC(RedisModule_CreateCommand)(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep);
-int REDISMODULE_API_FUNC(RedisModule_SetModuleAttribs)(RedisModuleCtx *ctx, const char *name, int ver, int apiver);
+int REDISMODULE_API_FUNC(RedisModule_CreateCommand)(RedisModuleCtx *ctx, const char *name, const char *desc, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep);
+int REDISMODULE_API_FUNC(RedisModule_SetModuleAttribs)(RedisModuleCtx *ctx, const char *name, const char *desc, int ver, int apiver);
 int REDISMODULE_API_FUNC(RedisModule_WrongArity)(RedisModuleCtx *ctx);
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithLongLong)(RedisModuleCtx *ctx, long long ll);
 int REDISMODULE_API_FUNC(RedisModule_GetSelectedDb)(RedisModuleCtx *ctx);
@@ -216,8 +216,8 @@ int REDISMODULE_API_FUNC(RedisModule_AbortBlock)(RedisModuleBlockedClient *bc);
 long long REDISMODULE_API_FUNC(RedisModule_Milliseconds)(void);
 
 /* This is included inline inside each Redis module. */
-static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int apiver) __attribute__((unused));
-static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int apiver) {
+static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, const char* desc,int ver, int apiver) __attribute__((unused));
+static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, const char* desc,int ver, int apiver) {
     void *getapifuncptr = ((void**)ctx)[0];
     RedisModule_GetApi = (int (*)(const char *, void *)) (unsigned long)getapifuncptr;
     REDISMODULE_GET_API(Alloc);
@@ -323,7 +323,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(AbortBlock);
     REDISMODULE_GET_API(Milliseconds);
 
-    RedisModule_SetModuleAttribs(ctx,name,ver,apiver);
+    RedisModule_SetModuleAttribs(ctx,name,desc,ver,apiver);
     return REDISMODULE_OK;
 }
 


### PR DESCRIPTION
Redis has a lot of commands, users can use those commands to access
redis data.People get to know the commands by reading redis document
(https://redis.io/commands) .

Redis module is a wonderful feature which make it possible for user
to create custom commands.But when a module is loaded in redis, we
don't know what commands in the module, unless we have read the
module's source code or the module released with document.

A brief description about the module and the commands in the module
is needed.So the new module subcommand 'module desc' is very useful.
The module and its commands' brief description will be shown to
users by run 'module desc name'.

In order to make the module subcommand work properly, module developers
should provide the module description when call RedisModule_Init and
function description when call  RedisModule_CreateCommand.

A new desc parameter added to RedisModule_Init,so the function changed
to:
    int RedisModule_Init(RedisModuleCtx *ctx, const char *modulename,
		         const char *moduledesc,int module_version,
		         int api_version);

A new desc parameter added to RedisModule_CreateCommand, so the function
changed to:
    int RedisModule_CreateCommand(RedisModuleCtx *ctx, const char *cmdname,
		          const char *cmddesc,RedisModuleCmdFunc cmdfunc);