### PR TITLE
Fix infinite loop: redis-cli should not use hostsock when cluster return redirection

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -515,7 +515,8 @@ static int cliConnect(int force) {
             redisFree(context);
         }
 
-        if (config.hostsocket == NULL) {
+        if (config.hostsocket == NULL ||
+            (config.cluster_mode && config.cluster_reissue_command)) {
             context = redisConnect(config.hostip,config.hostport);
         } else {
             context = redisConnectUnix(config.hostsocket);


### PR DESCRIPTION
### Problem

`redis-cli` via unixsock run into infinite loop when cluster returns redirection.

### Scenario
1. connect to server via unixsock
2. run some cluster command, and got some redirection like `MOVED`
3. redis-cli sets `config.host` and `config.port` and `reissue`
4. but `cliConnect` always uses `config.hostsocket` if exists
5. goto 1

#### unstable (and 3.2, ...)

``` shell
% ./redis-cli --version
redis-cli 999.999.999 (git:6712bce9)

% ./redis-cli -s /tmp/redis.sock get foo
(error) MOVED 12182 127.0.0.1:6003

% ./redis-cli -c -s /tmp/redis.sock get foo
# infinite loop
```

#### This PR

``` shell
% ./redis-cli --version
redis-cli 999.999.999 (git:e25cf19e)

% ./redis-cli -s /tmp/redis.sock get foo
(error) MOVED 12182 127.0.0.1:6003

% ./redis-cli -c -s /tmp/redis.sock get foo
(nil)
```

Thanks.
