### PR TITLE
[New Feature] Showing Using Swap Memory in Redis in Info Command Memory Status

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -981,6 +981,9 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     /* Sample the RSS here since this is a relatively slow call. */
     server.resident_set_size = zmalloc_get_rss();
 
+    /* Sample the Swap Memorys since this is a relatively slow call. */
+    server.swap_memory = zmalloc_get_swap();
+
     /* We received a SIGTERM, shutting down here in a safe way, as it is
      * not ok doing so inside the signal handler. */
     if (server.shutdown_asap) {
@@ -1828,6 +1831,7 @@ void initServer(void) {
     server.stat_rdb_cow_bytes = 0;
     server.stat_aof_cow_bytes = 0;
     server.resident_set_size = 0;
+    server.swap_memory = 0;
     server.lastbgsave_status = C_OK;
     server.aof_last_write_status = C_OK;
     server.aof_last_write_errno = 0;
@@ -2829,6 +2833,7 @@ sds genRedisInfoString(char *section) {
         char total_system_hmem[64];
         char used_memory_lua_hmem[64];
         char used_memory_rss_hmem[64];
+        char swap_memory_hmem[64];
         char maxmemory_hmem[64];
         size_t zmalloc_used = zmalloc_used_memory();
         size_t total_system_mem = server.system_memory_size;
@@ -2848,6 +2853,7 @@ sds genRedisInfoString(char *section) {
         bytesToHuman(total_system_hmem,total_system_mem);
         bytesToHuman(used_memory_lua_hmem,memory_lua);
         bytesToHuman(used_memory_rss_hmem,server.resident_set_size);
+        bytesToHuman(swap_memory_hmem,server.swap_memory);
         bytesToHuman(maxmemory_hmem,server.maxmemory);
 
         if (sections++) info = sdscat(info,"\r\n");
@@ -2857,6 +2863,8 @@ sds genRedisInfoString(char *section) {
             "used_memory_human:%s\r\n"
             "used_memory_rss:%zu\r\n"
             "used_memory_rss_human:%s\r\n"
+            "swap_memory:%zu\r\n"
+            "swap_memory_human:%s\r\n"
             "used_memory_peak:%zu\r\n"
             "used_memory_peak_human:%s\r\n"
             "used_memory_peak_perc:%.2f%%\r\n"
@@ -2878,6 +2886,8 @@ sds genRedisInfoString(char *section) {
             hmem,
             server.resident_set_size,
             used_memory_rss_hmem,
+            server.swap_memory,
+            swap_memory_hmem,
             server.stat_peak_memory,
             peak_hmem,
             mh->peak_perc,

--- a/src/server.h
+++ b/src/server.h
@@ -920,6 +920,7 @@ struct redisServer {
     long long slowlog_log_slower_than; /* SLOWLOG time limit (to get logged) */
     unsigned long slowlog_max_len;     /* SLOWLOG max number of items logged */
     size_t resident_set_size;       /* RSS sampled in serverCron(). */
+    size_t swap_memory;             /* swap_memory sampled in serverCron(). */
     long long stat_net_input_bytes; /* Bytes read from network. */
     long long stat_net_output_bytes; /* Bytes written to network. */
     size_t stat_rdb_cow_bytes;      /* Copy on write bytes during RDB saving. */

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -405,4 +405,8 @@ size_t zmalloc_get_memory_size(void) {
 #endif
 }
 
-
+size_t zmalloc_get_swap() {
+    size_t swap = 0;
+    swap = zmalloc_get_smap_bytes_by_field("Swap:", getpid());
+    return swap;
+}

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -75,6 +75,7 @@ void zmalloc_enable_thread_safeness(void);
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t));
 float zmalloc_get_fragmentation_ratio(size_t rss);
 size_t zmalloc_get_rss(void);
+size_t zmalloc_get_swap(void);
 size_t zmalloc_get_private_dirty(long pid);
 size_t zmalloc_get_smap_bytes_by_field(char *field, long pid);
 size_t zmalloc_get_memory_size(void);


### PR DESCRIPTION
Swap Memory is a factor to affect performance of redis.
So I just add 

redis:6379> info Memory
# Memory
used_memory:2164072904
used_memory_human:2.02G
used_memory_rss:1929404416
used_memory_rss_human:1.80G
swap_memory:292462592
swap_memory_human:278.91M
used_memory_peak:2164072904
used_memory_peak_human:2.02G
......
