### PR TITLE
Initialize help only in repl mode

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1273,6 +1273,11 @@ static void repl(void) {
     int argc;
     sds *argv;
 
+    /* Initialize the help and, if possible, use the COMMAND command in order
+     * to retrieve missing entries. */
+    cliInitHelp();
+    cliIntegrateHelp();
+
     config.interactive = 1;
     linenoiseSetMultiLine(1);
     linenoiseSetCompletionCallback(completionCallback);
@@ -2605,11 +2610,6 @@ int main(int argc, char **argv) {
     firstarg = parseOptions(argc,argv);
     argc -= firstarg;
     argv += firstarg;
-
-    /* Initialize the help and, if possible, use the COMMAND command in order
-     * to retrieve missing entries. */
-    cliInitHelp();
-    cliIntegrateHelp();
 
     /* Latency mode */
     if (config.latency_mode) {


### PR DESCRIPTION
Currently, everytime a command is launched through redis-cli it will first send the `COMMAND` command. This is unnecessary overhead, so I just removed initialization until it is really needed.