### PR TITLE
Replication: fix memory leak

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1333,6 +1333,7 @@ char *sendSynchronousCommand(int flags, int fd, ...) {
         if (syncWrite(fd,cmd,sdslen(cmd),server.repl_syncio_timeout*1000)
             == -1)
         {
+            va_end(ap);
             sdsfree(cmd);
             return sdscatprintf(sdsempty(),"-Writing to master: %s",
                     strerror(errno));


### PR DESCRIPTION
When `syncWrite` fails, it will leak `ap` because it is not `va_end`-ed. This commit fixes it.