### PR TITLE
Add sleep interval to redis-cli --scan option

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2385,6 +2385,7 @@ static void scanMode(void) {
                 printf("%s\n", reply->element[1]->element[j]->str);
         }
         freeReplyObject(reply);
+        if (config.interval) usleep(config.interval);
     } while(cur != 0);
 
     exit(0);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1113,8 +1113,8 @@ static void usage(void) {
 "  -r <repeat>        Execute specified command N times.\n"
 "  -i <interval>      When -r is used, waits <interval> seconds per command.\n"
 "                     It is possible to specify sub-second times like -i 0.1.\n"
-"                     This interval is also used in --scan and --stat per cycle.\n
-"                     and in --bigkeys, --memkeys, and --hotkeys per 100 cycles.\n
+"                     This interval is also used in --scan and --stat per cycle.\n"
+"                     and in --bigkeys, --memkeys, and --hotkeys per 100 cycles.\n"
 "  -n <db>            Database number.\n"
 "  -x                 Read last argument from STDIN.\n"
 "  -d <delimiter>     Multi-bulk delimiter in for raw formatting (default: \\n).\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1085,7 +1085,7 @@ static int parseOptions(int argc, char **argv) {
 
 static sds readArgFromStdin(void) {
     char buf[1024];
-    sds arg = sdsempty(); 
+    sds arg = sdsempty();
 
     while(1) {
         int nread = read(fileno(stdin),buf,1024);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1085,7 +1085,7 @@ static int parseOptions(int argc, char **argv) {
 
 static sds readArgFromStdin(void) {
     char buf[1024];
-    sds arg = sdsempty();
+    sds arg = sdsempty();, 
 
     while(1) {
         int nread = read(fileno(stdin),buf,1024);
@@ -1113,6 +1113,8 @@ static void usage(void) {
 "  -r <repeat>        Execute specified command N times.\n"
 "  -i <interval>      When -r is used, waits <interval> seconds per command.\n"
 "                     It is possible to specify sub-second times like -i 0.1.\n"
+"                     This interval is also used in --scan and --stat per cycle.\n
+"                     and in --bigkeys, --memkeys, and --hotkeys per 100 cycles.\n
 "  -n <db>            Database number.\n"
 "  -x                 Read last argument from STDIN.\n"
 "  -d <delimiter>     Multi-bulk delimiter in for raw formatting (default: \\n).\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1085,7 +1085,7 @@ static int parseOptions(int argc, char **argv) {
 
 static sds readArgFromStdin(void) {
     char buf[1024];
-    sds arg = sdsempty();, 
+    sds arg = sdsempty(); 
 
     while(1) {
         int nread = read(fileno(stdin),buf,1024);


### PR DESCRIPTION
Adding -i option (sleep interval) of repeat and bigkeys  to redis-cli --scan.
When the keyspace contains many already expired keys scanning the dataset with redis-cli --scan can impact the performance