### PR TITLE
Bugfix: [redis-sentinel] running script count error when notification-script return 1

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -832,8 +832,8 @@ void sentinelCollectTerminatedScripts(void) {
             }
             listDelNode(sentinel.scripts_queue,ln);
             sentinelReleaseScriptJob(sj);
-            sentinel.running_scripts--;
         }
+        sentinel.running_scripts--;
     }
 }
 


### PR DESCRIPTION
When notification-script return 1, the running_scripts count will not decrease to right number, so running_scripts will soon grow to SENTINEL_SCRIPT_MAX_RUNNING, and notification-script will never be called