### PR TITLE
Fix sleep interval in bigkeys

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2095,8 +2095,8 @@ static void findBigKeys(void) {
 
     /* Status message */
     printf("\n# Scanning the entire keyspace to find biggest keys as well as\n");
-    printf("# average sizes per key type.  You can use -i 0.1 to sleep 0.1 sec\n");
-    printf("# per 100 SCAN commands (not usually needed).\n\n");
+    printf("# average sizes per key type.  You can use -i 0.01 to sleep 0.01 sec\n");
+    printf("# per SCAN command (not usually needed).\n\n");
 
     /* New up sds strings to keep track of overall biggest per type */
     for(i=0;i<TYPE_NONE; i++) {
@@ -2167,9 +2167,7 @@ static void findBigKeys(void) {
         }
 
         /* Sleep if we've been directed to do so */
-        if(sampled && (sampled %100) == 0 && config.interval) {
-            usleep(config.interval);
-        }
+        if (config.interval) usleep(config.interval);
 
         freeReplyObject(reply);
     } while(it != 0);


### PR DESCRIPTION
bigkeys sleep is defined each 100 scanned keys, and it is checked it only between scan cycles. In cases that scan does not return exactly 10 keys it will stop sleeping. In addition the comment was sleep each 100 SCANs but it was 100 keys or 10 SCANs.

My proposal is to change the sleep to be carried every scan, and modify the suggestion to 0.01 secs as an interval.