### PR TITLE
Fix replicated module commands in MULTI/EXEC blocks.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1111,6 +1111,9 @@ int RM_ReplyWithDouble(RedisModuleCtx *ctx, double d) {
  * in the context of a command execution. EXEC will be handled by the
  * RedisModuleCommandDispatcher() function. */
 void moduleReplicateMultiIfNeeded(RedisModuleCtx *ctx) {
+    /* Skip this if client explicitly wrap the command with MULTI */
+    if (ctx->client->flags & CLIENT_MULTI) return;
+
     if (ctx->flags & REDISMODULE_CTX_MULTI_EMITTED) return;
     execCommandPropagateMulti(ctx->client);
     ctx->flags |= REDISMODULE_CTX_MULTI_EMITTED;


### PR DESCRIPTION
The problem is easily reproduced:

```
MULTI
<some module command>
EXEC
```

Would result with two pairs of MULTI/EXEC wrapping the module replicated commands.