### PR TITLE
Add `SO_BUSY_POLL` support

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -100,6 +100,14 @@ port 6379
 # in order to get the desired effect.
 tcp-backlog 511
 
+# SO_BUSY_POLL
+#
+# Sets the approximate time in microseconds to busy poll on a blocking
+# receive when there is no data. Available since 3.11 linux kernel.
+# This can cause higher CPU usage, but lower latency if it's a critical factor
+# in some cases. The default 0.
+busy-polling 0
+
 # Unix socket.
 #
 # Specify the path for the Unix socket that will be used to listen for

--- a/src/anet.c
+++ b/src/anet.c
@@ -235,6 +235,16 @@ int anetResolveIP(char *err, char *host, char *ipbuf, size_t ipbuf_len) {
     return anetGenericResolve(err,host,ipbuf,ipbuf_len,ANET_IP_ONLY);
 }
 
+int anetSetBusyPoll(char *err, int fd, int busy_poll) {
+    if (busy_poll > 0) {
+        if (setsockopt(fd, SOL_SOCKET, SO_BUSY_POLL, &busy_poll, sizeof(busy_poll)) == -1) {
+            anetSetError(err, "setsockopt SO_BUSY_POLL: %s", strerror(errno));
+            return ANET_ERR;
+        }
+    }
+    return ANET_OK;
+}
+
 static int anetSetReuseAddr(char *err, int fd) {
     int yes = 1;
     /* Make sure connection-intensive things like the redis benckmark

--- a/src/anet.h
+++ b/src/anet.h
@@ -76,5 +76,6 @@ int anetSockName(int fd, char *ip, size_t ip_len, int *port);
 int anetFormatAddr(char *fmt, size_t fmt_len, char *ip, int port);
 int anetFormatPeer(int fd, char *fmt, size_t fmt_len);
 int anetFormatSock(int fd, char *fmt, size_t fmt_len);
+int anetSetBusyPoll(char *err, int fd, int busy_poll);
 
 #endif

--- a/src/config.c
+++ b/src/config.c
@@ -1258,6 +1258,7 @@ void configGetCommand(client *c) {
     config_get_numerical_field("cluster-announce-port",server.cluster_announce_port);
     config_get_numerical_field("cluster-announce-bus-port",server.cluster_announce_bus_port);
     config_get_numerical_field("tcp-backlog",server.tcp_backlog);
+    config_get_numerical_field("busy-polling",server.busy_polling);
     config_get_numerical_field("databases",server.dbnum);
     config_get_numerical_field("repl-ping-slave-period",server.repl_ping_slave_period);
     config_get_numerical_field("repl-timeout",server.repl_timeout);
@@ -1953,6 +1954,7 @@ int rewriteConfig(char *path) {
     rewriteConfigNumericalOption(state,"cluster-announce-port",server.cluster_announce_port,CONFIG_DEFAULT_CLUSTER_ANNOUNCE_PORT);
     rewriteConfigNumericalOption(state,"cluster-announce-bus-port",server.cluster_announce_bus_port,CONFIG_DEFAULT_CLUSTER_ANNOUNCE_BUS_PORT);
     rewriteConfigNumericalOption(state,"tcp-backlog",server.tcp_backlog,CONFIG_DEFAULT_TCP_BACKLOG);
+    rewriteConfigNumericalOption(state,"busy-polling",server.busy_polling,CONFIG_DEFAULT_BUSY_POLL);
     rewriteConfigBindOption(state);
     rewriteConfigStringOption(state,"unixsocket",server.unixsocket,NULL);
     rewriteConfigOctalOption(state,"unixsocketperm",server.unixsocketperm,CONFIG_DEFAULT_UNIX_SOCKET_PERM);

--- a/src/networking.c
+++ b/src/networking.c
@@ -78,6 +78,8 @@ client *createClient(int fd) {
         anetEnableTcpNoDelay(NULL,fd);
         if (server.tcpkeepalive)
             anetKeepAlive(NULL,fd,server.tcpkeepalive);
+        if (server.busy_polling)
+            anetSetBusyPoll(NULL,fd,server.busy_polling);
         if (aeCreateFileEvent(server.el,fd,AE_READABLE,
             readQueryFromClient, c) == AE_ERR)
         {

--- a/src/server.h
+++ b/src/server.h
@@ -81,6 +81,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CONFIG_MAX_HZ            500
 #define CONFIG_DEFAULT_SERVER_PORT        6379    /* TCP port */
 #define CONFIG_DEFAULT_TCP_BACKLOG       511     /* TCP listen backlog */
+#define CONFIG_DEFAULT_BUSY_POLL 0 /* SO_BUSY_POLL */
 #define CONFIG_DEFAULT_CLIENT_TIMEOUT       0       /* default client timeout: infinite */
 #define CONFIG_DEFAULT_DBNUM     16
 #define CONFIG_MAX_LINE    1024
@@ -878,6 +879,7 @@ struct redisServer {
     /* Networking */
     int port;                   /* TCP listening port */
     int tcp_backlog;            /* TCP listen() backlog */
+    int busy_polling;           /* SO_BUSY_POLL */
     char *bindaddr[CONFIG_BINDADDR_MAX]; /* Addresses we should bind to */
     int bindaddr_count;         /* Number of addresses in server.bindaddr[] */
     char *unixsocket;           /* UNIX socket path */


### PR DESCRIPTION
Add `SO_BUSY_POLL` support.
Benchmarks example. Port 6379 is without busy polling, 6380 with:
```
% ./target/release/rpc-perf --server 127.0.0.1:6379 --config configs/default.toml --protocol redis | grep Latency:
2017-01-23 22:20:59.994 INFO  [rpc-perf] Latency: min: 649593 ns max: 184280941 ns
2017-01-23 22:21:10.074 INFO  [rpc-perf] Latency: min: 707265 ns max: 192334005 ns
2017-01-23 22:21:20.153 INFO  [rpc-perf] Latency: min: 605029 ns max: 143076099 ns
2017-01-23 22:21:30.257 INFO  [rpc-perf] Latency: min: 614466 ns max: 209513874 ns
2017-01-23 22:21:40.341 INFO  [rpc-perf] Latency: min: 722469 ns max: 111132279 ns

% ./target/release/rpc-perf --server 127.0.0.1:6380 --config configs/default.toml --protocol redis | grep Latency:
2017-01-23 22:22:46.682 INFO  [rpc-perf] Latency: min: 587727 ns max: 208842785 ns
2017-01-23 22:22:56.789 INFO  [rpc-perf] Latency: min: 579863 ns max: 26625442 ns
2017-01-23 22:23:06.881 INFO  [rpc-perf] Latency: min: 458752 ns max: 127641060 ns
2017-01-23 22:23:16.985 INFO  [rpc-perf] Latency: min: 601359 ns max: 126902862 ns
2017-01-23 22:23:27.079 INFO  [rpc-perf] Latency: min: 702022 ns max: 116500988 ns
```
To verify if polling is set (systemtap):
```
%{
#include <asm-generic/socket.h>
%}

probe kernel.function("sys_setsockopt").return
{
        if ($optname == %{ SO_BUSY_POLL %} && $return == 0)
                printf("%s busy_poll: %d\n", execname(), user_int($optval));
}
redis-server-bp busy_poll: 50
```