### PR TITLE
fix zadd crash when no elements are specified

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1521,7 +1521,7 @@ void zaddGenericCommand(client *c, int flags) {
     /* After the options, we expect to have an even number of args, since
      * we expect any number of score-element pairs. */
     elements = c->argc-scoreidx;
-    if (elements % 2) {
+    if (elements % 2 || !elements) {
         addReply(c,shared.syntaxerr);
         return;
     }


### PR DESCRIPTION
`zadd myzset nx CH` consistently crashes the server.
this happens when trying to decide what type of new object to create `sdslen(c->argv[scoreidx+1]->ptr)`