### PR TITLE
fix for not creating master and slave on same host

### DIFF
--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -700,6 +700,8 @@ class RedisTrib
         nodes_count -= masters.length
 
         masters.each{|m| puts m}
+        
+        interleaved.push interleaved.shift
 
         # Alloc slots on masters
         slots_per_node = ClusterHashSlots.to_f / masters_count


### PR DESCRIPTION
redis-trib.rb may allocate the slave and master in the same host. This is very common issue faced by many of us especially when we have **odd** number of nodes. I have made one change to avoid this situation.