### PR TITLE
Modules - Adding the ability to hook to client's disconnection

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -47,6 +47,7 @@ struct RedisModule {
     int ver;        /* Module version. We use just progressive integers. */
     int apiver;     /* Module API version as requested during initialization.*/
     list *types;    /* Module data types. */
+    void (*disconnectionCallback)(uint64_t); /* Module client disconnection callback */
 };
 typedef struct RedisModule RedisModule;
 
@@ -449,6 +450,16 @@ void RedisModuleCommandDispatcher(client *c) {
     RedisModuleCommandProxy *cp = (void*)(unsigned long)c->cmd->getkeys_proc;
     RedisModuleCtx ctx = REDISMODULE_CTX_INIT;
 
+    /*
+    If module name isn't present in client's modules dictionary,
+    we can assume that it's the first time the client has called a command from this module
+    so we add the module's disconnection callback to the client's disconnection hook.
+    */
+    if (cp->module->disconnectionCallback != NULL &&
+        dictAdd(c->modules_visited, cp->module->name, NULL) != DICT_ERR) {
+            hookToDisconnection(c, cp->module->disconnectionCallback);
+    }
+
     ctx.module = cp->module;
     ctx.client = c;
     cp->func(&ctx,(void**)c->argv,c->argc);
@@ -632,6 +643,23 @@ int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc c
     return REDISMODULE_OK;
 }
 
+/* Registers a callback for clients disconnections
+ * Only clients that have called one of the module's command at least once are hooked
+*/
+int RM_HookToDisconnection(RedisModuleCtx *ctx, void (*cb)(uint64_t)) {
+    if (ctx->module == NULL) {
+        return REDISMODULE_ERR;
+    }
+
+    // Not allowing callback overriding
+    if (ctx->module->disconnectionCallback != NULL) {
+        return REDISMODULE_ERR;
+    }
+
+    ctx->module->disconnectionCallback = cb;
+    return REDISMODULE_OK;
+}
+
 /* Called by RM_Init() to setup the `ctx->module` structure.
  *
  * This is an internal function, Redis modules developers don't need
@@ -642,6 +670,7 @@ void RM_SetModuleAttribs(RedisModuleCtx *ctx, const char *name, int ver, int api
     if (ctx->module != NULL) return;
     module = zmalloc(sizeof(*module));
     module->name = sdsnew((char*)name);
+    module->disconnectionCallback = NULL;
     module->ver = ver;
     module->apiver = apiver;
     module->types = listCreate();
@@ -3494,6 +3523,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(Free);
     REGISTER_API(Strdup);
     REGISTER_API(CreateCommand);
+    REGISTER_API(HookToDisconnection);
     REGISTER_API(SetModuleAttribs);
     REGISTER_API(WrongArity);
     REGISTER_API(ReplyWithLongLong);

--- a/src/modules/API.md
+++ b/src/modules/API.md
@@ -150,6 +150,22 @@ example "write deny-oom". The set of flags are:
                     keys, programmatically creates key names, or any
                     other reason.
 
+## `RM_HookToDisconnection`
+
+    int RM_HookToDisconnection(RedisModuleCtx *ctx, void (*cb)(uint64_t));
+
+Register a new command in the Redis server, that will be handled by
+calling the function pointer 'func' using the RedisModule calling
+convention. The function returns `REDISMODULE_ERR` if the specified command
+name is already busy or a set of invalid flags were passed, otherwise
+`REDISMODULE_OK` is returned and the new command is registered.
+
+This function must be called during the initialization of the module
+inside the `RedisModule_OnLoad()` function. Calling this function outside
+of the initialization function is not defined.
+
+The command function type is the following:
+
 ## `RM_SetModuleAttribs`
 
     void RM_SetModuleAttribs(RedisModuleCtx *ctx, const char *name, int ver, int apiver);

--- a/src/modules/API.md
+++ b/src/modules/API.md
@@ -154,17 +154,10 @@ example "write deny-oom". The set of flags are:
 
     int RM_HookToDisconnection(RedisModuleCtx *ctx, void (*cb)(uint64_t));
 
-Register a new command in the Redis server, that will be handled by
-calling the function pointer 'func' using the RedisModule calling
-convention. The function returns `REDISMODULE_ERR` if the specified command
-name is already busy or a set of invalid flags were passed, otherwise
-`REDISMODULE_OK` is returned and the new command is registered.
+Hooks to a disconnection of a client.
+Whenever a client disconnects from the server, 'cb' will be called with the disconnected client id.
 
-This function must be called during the initialization of the module
-inside the `RedisModule_OnLoad()` function. Calling this function outside
-of the initialization function is not defined.
-
-The command function type is the following:
+Notice: 'cb' won't be called for client that have never interacted with the module.
 
 ## `RM_SetModuleAttribs`
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -66,6 +66,14 @@ int listMatchObjects(void *a, void *b) {
     return equalStringObjects(a,b);
 }
 
+void freeClientDisconnectionCB(void *toFree) {
+    disconnectionCallbackWrapper *wrp = (disconnectionCallbackWrapper*)toFree;
+    if (wrp != NULL) {
+        wrp->cb(wrp->clientId);
+        zfree(wrp);
+    }
+}
+
 client *createClient(int fd) {
     client *c = zmalloc(sizeof(client));
 
@@ -127,7 +135,10 @@ client *createClient(int fd) {
     c->watched_keys = listCreate();
     c->pubsub_channels = dictCreate(&objectKeyPointerValueDictType,NULL);
     c->pubsub_patterns = listCreate();
+    c->modules_visited = dictCreate(&setDictType,NULL);
+    c->client_disconnected = listCreate();
     c->peerid = NULL;
+    listSetFreeMethod(c->client_disconnected, freeClientDisconnectionCB);
     listSetFreeMethod(c->pubsub_patterns,decrRefCountVoid);
     listSetMatchMethod(c->pubsub_patterns,listMatchObjects);
     if (fd != -1) listAddNodeTail(server.clients,c);
@@ -811,6 +822,12 @@ void freeClient(client *c) {
     pubsubUnsubscribeAllPatterns(c,0);
     dictRelease(c->pubsub_channels);
     listRelease(c->pubsub_patterns);
+
+    /* Frees modules dict */
+    dictRelease(c->modules_visited);
+
+    /* Call all disconnection hooks and free list */
+    listRelease(c->client_disconnected);
 
     /* Free data structures. */
     listRelease(c->reply);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -94,6 +94,7 @@ typedef void (*RedisModuleTypeRewriteFunc)(RedisModuleIO *aof, RedisModuleString
 typedef size_t (*RedisModuleTypeMemUsageFunc)(const void *value);
 typedef void (*RedisModuleTypeDigestFunc)(RedisModuleDigest *digest, void *value);
 typedef void (*RedisModuleTypeFreeFunc)(void *value);
+typedef void (*ClientDisconnectionFunc)(uint64_t clientId);
 
 #define REDISMODULE_TYPE_METHOD_VERSION 1
 typedef struct RedisModuleTypeMethods {
@@ -111,7 +112,6 @@ typedef struct RedisModuleTypeMethods {
 
 #define REDISMODULE_API_FUNC(x) (*x)
 
-
 void *REDISMODULE_API_FUNC(RedisModule_Alloc)(size_t bytes);
 void *REDISMODULE_API_FUNC(RedisModule_Realloc)(void *ptr, size_t bytes);
 void REDISMODULE_API_FUNC(RedisModule_Free)(void *ptr);
@@ -119,6 +119,7 @@ void *REDISMODULE_API_FUNC(RedisModule_Calloc)(size_t nmemb, size_t size);
 char *REDISMODULE_API_FUNC(RedisModule_Strdup)(const char *str);
 int REDISMODULE_API_FUNC(RedisModule_GetApi)(const char *, void *);
 int REDISMODULE_API_FUNC(RedisModule_CreateCommand)(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep);
+int REDISMODULE_API_FUNC(RedisModule_HookToDisconnection)(RedisModuleCtx *ctx, ClientDisconnectionFunc disconnectionCallback);
 int REDISMODULE_API_FUNC(RedisModule_SetModuleAttribs)(RedisModuleCtx *ctx, const char *name, int ver, int apiver);
 int REDISMODULE_API_FUNC(RedisModule_WrongArity)(RedisModuleCtx *ctx);
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithLongLong)(RedisModuleCtx *ctx, long long ll);
@@ -225,6 +226,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(Free);
     REDISMODULE_GET_API(Realloc);
     REDISMODULE_GET_API(Strdup);
+    REDISMODULE_GET_API(HookToDisconnection);
     REDISMODULE_GET_API(CreateCommand);
     REDISMODULE_GET_API(SetModuleAttribs);
     REDISMODULE_GET_API(WrongArity);

--- a/src/server.c
+++ b/src/server.c
@@ -3791,4 +3791,12 @@ int main(int argc, char **argv) {
     return 0;
 }
 
+void hookToDisconnection(client *c, void (*cb)(uint64_t)) {
+    disconnectionCallbackWrapper *wrp = zmalloc(sizeof(disconnectionCallbackWrapper));
+    wrp->clientId = c->id;
+    wrp->cb = cb;
+
+    listAddNodeTail(c->client_disconnected, wrp);
+}
+
 /* The End */

--- a/src/server.h
+++ b/src/server.h
@@ -653,6 +653,11 @@ typedef struct readyList {
     robj *key;
 } readyList;
 
+typedef struct disconnectionCallbackWrapper {
+    uint64_t clientId;
+    void (*cb)(uint64_t);
+} disconnectionCallbackWrapper;
+
 /* With multiplexing we need to take per-client state.
  * Clients are taken in a linked list. */
 typedef struct client {
@@ -701,6 +706,9 @@ typedef struct client {
     dict *pubsub_channels;  /* channels a client is interested in (SUBSCRIBE) */
     list *pubsub_patterns;  /* patterns a client is interested in (SUBSCRIBE) */
     sds peerid;             /* Cached peer ID. */
+
+    dict *modules_visited; /* modules visited by client */
+    list *client_disconnected; /* client disconnection hooks/callbacks */
 
     /* Response buffer */
     int bufpos;
@@ -1293,6 +1301,9 @@ uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
 void exitFromChild(int retcode);
 size_t redisPopcount(void *s, long count);
 void redisSetProcTitle(char *title);
+
+/* Hooks */
+void hookToDisconnection(client *c, void (*cb)(uint64_t));
 
 /* networking.c -- Networking and Client related operations */
 client *createClient(int fd);


### PR DESCRIPTION
I had noticed that this feature was missing when i began working on a module that's supposed to act as a simple count server - each client would have the ability to raise the count of some token and when a client disconnects, **his** contribution would be removed.

So here is my contribution for this matter.

Each client is assigned with a list of disconnection callbacks and an hash set of visited modules.
I expose and API - RM_HookToDisconnection that sets a disconnection callback (with client id as argument) to the module under the ctx that was passed to it.

I use the 'RedisModuleCommandDispatcher' (module.c) proxy to add the visited module to the client's visited modules dictionary, if dictAdd returns with no errors (which means that this is the first command that is issued from the client to the module) - i add the callback that was registered by RM_HookToDisconnection to the client's disconnection callbacks list.

The callbacks are called in the freeClient function (networking.c).