### PR TITLE
fix missed dlclose leak in module.c

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3939,6 +3939,7 @@ int moduleLoad(const char *path, void **module_argv, int module_argc) {
     }
     onload = (int (*)(void *, void **, int))(unsigned long) dlsym(handle,"RedisModule_OnLoad");
     if (onload == NULL) {
+        dlclose(handle);
         serverLog(LL_WARNING,
             "Module %s does not export RedisModule_OnLoad() "
             "symbol. Module not loaded.",path);


### PR DESCRIPTION
Before returning error. We should call dlclose(handle);

