### PR TITLE
several bugfixes to diskless replication

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -911,6 +911,16 @@ void unlinkClient(client *c) {
             c->client_list_node = NULL;
         }
 
+        /* In the case of diskless replication the fork is writing to the
+         * sockets and just closing the fd isn't enough, if we don't also
+         * shutdown the socket the fork will continue to write to the slave
+         * and the salve will only find out that it was disconnected when
+         * it will finish reading the rdb. */
+        if ((c->flags & CLIENT_SLAVE) &&
+            (c->replstate == SLAVE_STATE_WAIT_BGSAVE_END)) {
+            shutdown(c->fd, SHUT_RDWR);
+        }
+
         /* Unregister async I/O handlers and close the socket. */
         aeDeleteFileEvent(server.el,c->fd,AE_READABLE);
         aeDeleteFileEvent(server.el,c->fd,AE_WRITABLE);

--- a/src/replication.c
+++ b/src/replication.c
@@ -593,6 +593,7 @@ int startBgsaveForReplication(int mincapa) {
             client *slave = ln->value;
 
             if (slave->replstate == SLAVE_STATE_WAIT_BGSAVE_START) {
+                slave->replstate = REPL_STATE_NONE;
                 slave->flags &= ~CLIENT_SLAVE;
                 listDelNode(server.slaves,ln);
                 addReplyError(slave,


### PR DESCRIPTION
old title: several bugfixes to diskless replication and the CAPA mechanism

1) in diskless replication - master not notifing the slave that rdb transfer terminated on error, and lets slave wait for replication timeout

2) when the main process disconnected a slave due to slave buffer overflow, the rdbsave child kept streaming the rdb, and the slave only found out about it after reading the entire rdb.


3) [redundant fix, commit removed from the PR]
when starting a replication for a certain mincapa, we must take care to exclude slaves that didn't declare that capa, otherwise they may get something that they can't handle



@guybe7 these are your fixes, please add details if i messed them up.