### PR TITLE
when a slave responds with an error on commands that come from master, log it

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -371,6 +371,8 @@ void addReplyErrorLength(client *c, const char *s, size_t len) {
     addReplyString(c,"-ERR ",5);
     addReplyString(c,s,len);
     addReplyString(c,"\r\n",2);
+    if (c->flags & CLIENT_MASTER)
+        serverLog(LL_WARNING,"Error sent to master: %s", s);
 }
 
 void addReplyError(client *c, const char *err) {


### PR DESCRIPTION
since slave isn't replying to it's master, these errors go unnoticed.
since we don't expect the master to send garbadge to the slave, this should be safe.
(as long as we don't log OOM errors there)

Antirez, please consider if you want to add this. it helped us uncover some problems.