### PR TITLE
improve efficiency of _dictNextPower by using bit trick

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -938,14 +938,20 @@ static int _dictExpandIfNeeded(dict *d)
 /* Our hash table capability is a power of two */
 static unsigned long _dictNextPower(unsigned long size)
 {
-    unsigned long i = DICT_HT_INITIAL_SIZE;
+    if (size <= DICT_HT_INITIAL_SIZE) return DICT_HT_INITIAL_SIZE;
 
-    if (size >= LONG_MAX) return LONG_MAX;
-    while(1) {
-        if (i >= size)
-            return i;
-        i *= 2;
-    }
+    size--;
+    size |= size >> 1;
+    size |= size >> 2;
+    size |= size >> 4;
+    size |= size >> 8;
+    size |= size >> 16;
+#if __x86_64__ || __ppc64__ || _WIN64
+    size |= size >> 32;
+#endif
+    size++;
+
+    return size;
 }
 
 /* Returns the index of a free slot that can be populated with


### PR DESCRIPTION
note that the previous implementation uses LONG_MAX which is not a power of 2, not even an even number

Antirez, i know i already pushed this PR in the past, please consider it again. even if a small improvement in efficiency, there's no good reason not to take it.
a small function with that name, doesn't need to have readable implementation.