### PR TITLE
fixed free of blocked client before refering to it

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3217,8 +3217,8 @@ void moduleHandleBlockedClients(void) {
         }
         if (bc->privdata && bc->free_privdata)
             bc->free_privdata(bc->privdata);
-        zfree(bc);
         if (c != NULL) unblockClient(c);
+        zfree(bc);
 
         /* Lock again before to iterate the loop. */
         pthread_mutex_lock(&moduleUnblockedClientsMutex);


### PR DESCRIPTION
`unblockClient(c);` triggered `unblockClientFromModule` which refered to the blocked context after it's been freed, resulting in possible crash and an error in valgrind. 

Reversing the order of lines fixes this.