### PR TITLE
PSYNC: Avoid replication backlog free in role change and create backlog before psync

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1943,6 +1943,11 @@ void replicationUnsetMaster(void) {
     if (server.masterhost == NULL) return; /* Nothing to do. */
     sdsfree(server.masterhost);
     server.masterhost = NULL;
+
+    /* Update repl_no_slaves_since timestamp when role changed from 
+     * slave to master, avoid replication backlog free in replication cron. */
+    server.repl_no_slaves_since = server.unixtime;
+
     /* When a slave is turned into a master, the current replication ID
      * (that was inherited from the master at synchronization time) is
      * used as secondary ID up to the current offset, and a new replication

--- a/src/replication.c
+++ b/src/replication.c
@@ -1776,6 +1776,9 @@ void syncWithMaster(aeEventLoop *el, int fd, void *privdata, int mask) {
 
     if (psync_result == PSYNC_CONTINUE) {
         serverLog(LL_NOTICE, "MASTER <-> SLAVE sync: Master accepted a Partial Resynchronization.");
+        /* Create backlog before psync begin if this slave psync with
+         * master after server startup. */
+        if (server.repl_backlog == NULL) createReplicationBacklog();
         return;
     }
 


### PR DESCRIPTION
1 Update repl_no_slaves_since timestamp when role changed from slave to master, avoid replication backlog free in replication cron(role changed to master and repl-backlog-ttl is done with no slaves connected, so it will free backlog result in fullsync). 
2 Create backlog before psync begin if this slave psync with master after server startup.