### PR TITLE
va_list 'ap' was opened but not closed by va_end()

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1334,6 +1334,7 @@ char *sendSynchronousCommand(int flags, int fd, ...) {
             == -1)
         {
             sdsfree(cmd);
+            va_end(ap);
             return sdscatprintf(sdsempty(),"-Writing to master: %s",
                     strerror(errno));
         }


### PR DESCRIPTION
@antirez va_list 'ap' was opened but not closed by va_end()