### PR TITLE
add close(s) when error return

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -481,7 +481,7 @@ static int _anetTcpServer(char *err, int port, char *bindaddr, int af, int backl
             continue;
 
         if (af == AF_INET6 && anetV6Only(err,s) == ANET_ERR) goto error;
-        if (anetSetReuseAddr(err,s) == ANET_ERR) goto error;
+        if (anetSetReuseAddr(err,s) == ANET_ERR) { close(s); goto error; }
         if (anetListen(err,s,p->ai_addr,p->ai_addrlen,backlog) == ANET_ERR) goto error;
         goto end;
     }


### PR DESCRIPTION
add close(s) when error return, otherwise it could leak socket s after `anetSetReuseAddr` returns ANET_ERR.