### PR TITLE
Calling getDecodedObject before hashTypeSet to fix RM_Call segfault

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -517,7 +517,11 @@ void hsetCommand(client *c) {
 
     if ((o = hashTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
     hashTypeTryConversion(o,c->argv,2,3);
-    update = hashTypeSet(o,c->argv[2]->ptr,c->argv[3]->ptr,HASH_SET_COPY);
+    robj* field = getDecodedObject(c->argv[2]);
+    robj* value = getDecodedObject(c->argv[3]);
+    update = hashTypeSet(o,field->ptr,value->ptr,HASH_SET_COPY);
+    decrRefCount(field);
+    decrRefCount(value);
     addReply(c, update ? shared.czero : shared.cone);
     signalModifiedKey(c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);


### PR DESCRIPTION
This pull request corrects the following bug (fixes #3888):
- Using `RedisModule_Call` write commands on a `HASH` data type passing a `'l' (long long)` formatter on `field` or `value` results in a segmentation fault.

I wrote a [simple redis module](https://github.com/aviggiano/pr-redis) to better explain the problem. 
The fix consists of calling `getDecodedObject` before the `hashTypeSet` call in the `hsetCommand` function. The `getDecodedObject` properly decodes a `(void*)(long long)` to a `sds` when the object is of type `OBJ_ENCODING_INT`, which is the case of this issue.

Note: I'm not sure if this bug exists in other commands, since some of them use `getDecodedObject` internally (such as those from the `LIST` data type) and others do not (e.g. `HASH` write commands). It would be probably better to change all data types write calls to pass a `robj` instead of a `sds` as a function argument, but I wasn't not sure about how @antirez would feel about this structural change. 

*****

Dive deeping into the crash: 
1. The `RM_Call` command would call the [`moduleCreateArgvFromUserFormat`](https://github.com/antirez/redis/blob/unstable/src/module.c#L2457) function to parse the clients' command arguments
2. The `moduleCreateArgvFromUserFormat` command would create a list of `robj`. Those with the `long long` formatter would have an `->encoding` of type `OBJ_ENCODING_INT` and `->ptr` equals to `(void*) (long long) ll`.
3. The `hsetCommand` would eventually be called and would then call [`hashTypeSet`](https://github.com/antirez/redis/blob/unstable/src/t_hash.c#L520) passing `argv[ ]->ptr` which would be received as an `sds`
4. Any `sds` function call to the encoded `void*` would result in a segmentation fault. 

```
# server
$ gdb ./redis/src/redis-server
...
(gdb) r --loadmodule ./pr-redis/pr-redis.so
...
32666:M 29 Mar 13:51:41.091 * Module 'PR_REDIS' loaded from ./pr-redis/pr-redis.so
32666:M 29 Mar 13:51:41.091 * Ready to accept connections
Thread 1 "redis-server" received signal SIGSEGV, Segmentation fault.
hashTypeSet (o=0x7ffff6a6f4e0, field=0x7ffff6a1c0f3 "field", 
    value=0x1 <error: Cannot access memory at address 0x1>, flags=flags@entry=0)
    at t_hash.c:231
231	            zl = ziplistPush(zl, (unsigned char*)value, sdslen(value),
(gdb) bt
#0  hashTypeSet (o=0x7ffff6a6f4e0, field=0x7ffff6a1c0f3 "field", 
    value=0x1 <error: Cannot access memory at address 0x1>, flags=flags@entry=0)
    at t_hash.c:231
#1  0x000000000045a4c3 in hsetCommand (c=0x7ffff6b394c0) at t_hash.c:520
#2  0x000000000042b736 in call (c=c@entry=0x7ffff6b394c0, flags=3) at server.c:2152
#3  0x0000000000492dde in RM_Call (ctx=0x7fffffffc7b0, cmdname=<optimized out>, 
    fmt=0x7ffff4ffc23a "ssl") at module.c:2502
#4  0x00007ffff4ffb5e0 in CrashCommand () from ./pr-redis/pr-redis.so
#5  0x000000000049268f in RedisModuleCommandDispatcher (c=<optimized out>) at module.c:454
#6  0x000000000042b736 in call (c=c@entry=0x7ffff6b1ae00, flags=flags@entry=15)
    at server.c:2152
#7  0x000000000042be37 in processCommand (c=0x7ffff6b1ae00) at server.c:2432
#8  0x000000000043ba1d in processInputBuffer (c=0x7ffff6b1ae00) at networking.c:1299
#9  0x00000000004256a8 in aeProcessEvents (eventLoop=eventLoop@entry=0x7ffff6a300a0, 
    flags=flags@entry=3) at ae.c:412
#10 0x0000000000425a4b in aeMain (eventLoop=0x7ffff6a300a0) at ae.c:455
#11 0x0000000000422765 in main (argc=<optimized out>, argv=0x7fffffffcac8) at server.c:3791
```

```
# client
$ redis-cli
127.0.0.1:6379> CRASH
Could not connect to Redis at 127.0.0.1:6379: Connection refused
(53.54s)
not connected> 
```
