### PR TITLE
log original incrbyfloat and hincrbyfloat command in slowlog

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -628,17 +628,6 @@ void hincrbyfloatCommand(client *c) {
     signalModifiedKey(c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH,"hincrbyfloat",c->argv[1],c->db->id);
     server.dirty++;
-
-    /* Always replicate HINCRBYFLOAT as an HSET command with the final value
-     * in order to make sure that differences in float pricision or formatting
-     * will not create differences in replicas or after an AOF restart. */
-    robj *aux, *newobj;
-    aux = createStringObject("HSET",4);
-    newobj = createRawStringObject(buf,len);
-    rewriteClientCommandArgument(c,0,aux);
-    decrRefCount(aux);
-    rewriteClientCommandArgument(c,3,newobj);
-    decrRefCount(newobj);
 }
 
 static void addHashFieldToReply(client *c, robj *o, sds field) {

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -400,7 +400,7 @@ void decrbyCommand(client *c) {
 
 void incrbyfloatCommand(client *c) {
     long double incr, value;
-    robj *o, *new, *aux;
+    robj *o, *new;
 
     o = lookupKeyWrite(c->db,c->argv[1]);
     if (o != NULL && checkType(c,o,OBJ_STRING)) return;
@@ -422,14 +422,6 @@ void incrbyfloatCommand(client *c) {
     notifyKeyspaceEvent(NOTIFY_STRING,"incrbyfloat",c->argv[1],c->db->id);
     server.dirty++;
     addReplyBulk(c,new);
-
-    /* Always replicate INCRBYFLOAT as a SET command with the final value
-     * in order to make sure that differences in float precision or formatting
-     * will not create differences in replicas or after an AOF restart. */
-    aux = createStringObject("SET",3);
-    rewriteClientCommandArgument(c,0,aux);
-    decrRefCount(aux);
-    rewriteClientCommandArgument(c,2,new);
 }
 
 void appendCommand(client *c) {


### PR DESCRIPTION
 Quick fix for [#3841](https://github.com/antirez/redis/issues/3841).
`127.0.0.1:6379> SLOWLOG get 5
1) 1) (integer) 3
   2) (integer) 1491321639
   3) (integer) 30
   4) 1) "incrbyfloat"
      2) "foo"
      3) "3.14"
2) 1) (integer) 2
   2) (integer) 1491321633
   3) (integer) 21
   4) 1) "hincrbyfloat"
      2) "bar"
      3) "x"
      4) "3.4"
3) 1) (integer) 1
   2) (integer) 1491321632
   3) (integer) 51
   4) 1) "hincrbyfloat"
      2) "bar"
      3) "x"
      4) "3.4"
4) 1) (integer) 0
   2) (integer) 1491321629
   3) (integer) 9
   4) 1) "config"
      2) "set"
      3) "slowlog-log-slower-than"
      4) "0"`