### PR TITLE
Expire: Update comment of activeExpireCycle function

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -92,7 +92,7 @@ int activeExpireCycleTryExpire(redisDb *db, dictEntry *de, long long now) {
  *
  * If type is ACTIVE_EXPIRE_CYCLE_SLOW, that normal expire cycle is
  * executed, where the time limit is a percentage of the REDIS_HZ period
- * as specified by the REDIS_EXPIRELOOKUPS_TIME_PERC define. */
+ * as specified by the ACTIVE_EXPIRE_CYCLE_SLOW_TIME_PERC define. */
 
 void activeExpireCycle(int type) {
     /* This function has some global state in order to continue the work


### PR DESCRIPTION
The macro REDIS_EXPIRELOOKUPS_TIME_PERC has been replaced by
ACTIVE_EXPIRE_CYCLE_SLOW_TIME_PERC in commit 6500fabfb881a7ffaadfbff74ab801c55d4591fc.