### PR TITLE
extract_varient_from_while_loop

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1569,7 +1569,6 @@ void adjustOpenFilesLimit(void) {
              * to the higher value supported less than maxfiles. */
             bestlimit = maxfiles;
             while(bestlimit > oldlimit) {
-                rlim_t decr_step = 16;
 
                 limit.rlim_cur = bestlimit;
                 limit.rlim_max = bestlimit;
@@ -1578,8 +1577,8 @@ void adjustOpenFilesLimit(void) {
 
                 /* We failed to set file limit to 'bestlimit'. Try with a
                  * smaller limit decrementing by a few FDs per iteration. */
-                if (bestlimit < decr_step) break;
-                bestlimit -= decr_step;
+                if (bestlimit < RLIMIT_DECR_STEP) break;
+                bestlimit -= RLIMIT_DECR_STEP;
             }
 
             /* Assume that the limit we get initially is still valid if

--- a/src/server.h
+++ b/src/server.h
@@ -402,6 +402,8 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CMD_CALL_PROPAGATE (CMD_CALL_PROPAGATE_AOF|CMD_CALL_PROPAGATE_REPL)
 #define CMD_CALL_FULL (CMD_CALL_SLOWLOG | CMD_CALL_STATS | CMD_CALL_PROPAGATE)
 
+#define RLIMIT_DECR_STEP    16
+
 /* Command propagation flags, see propagate() function */
 #define PROPAGATE_NONE 0
 #define PROPAGATE_AOF 1


### PR DESCRIPTION
We don't need to set decr_step = 16 in every loop.
It is always 16. and not changed.
so I extract it as global define.