### PR TITLE
Update jemalloc download url

### DIFF
--- a/deps/update-jemalloc.sh
+++ b/deps/update-jemalloc.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 VER=$1
-URL="http://www.canonware.com/download/jemalloc/jemalloc-${VER}.tar.bz2"
+URL="https://github.com/jemalloc/jemalloc/releases/download/${VER}/jemalloc-${VER}.tar.bz2"
 echo "Downloading $URL"
-curl $URL > /tmp/jemalloc.tar.bz2
+wget $URL -O /tmp/jemalloc.tar.bz2
 tar xvjf /tmp/jemalloc.tar.bz2
 rm -rf jemalloc
 mv jemalloc-${VER} jemalloc


### PR DESCRIPTION
Jemalloc url download pattern is not supported. URL pattern is replaced with the newest version address that is provided by github. curl command is changed with wget command in order to access file on github (amazon servers certification and redirects may cause problem while downloading.)