### PR TITLE
update block->free after some diff data are written to the child process

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -115,6 +115,7 @@ void aofChildWriteDiffData(aeEventLoop *el, int fd, void *privdata, int mask) {
             if (nwritten <= 0) return;
             memmove(block->buf,block->buf+nwritten,block->used-nwritten);
             block->used -= nwritten;
+            block->free += nwritten;
         }
         if (block->used == 0) listDelNode(server.aof_rewrite_buf_blocks,ln);
     }


### PR DESCRIPTION
This may avoid to create an unnecessary new block in some case.