### PR TITLE
fix #3953

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1317,6 +1317,8 @@ static void repl(void) {
                     if (config.eval) {
                         config.eval_ldb = 1;
                         config.output = OUTPUT_RAW;
+                        sdsfreesplitres(argv,argc);
+                        linenoiseFree(line);
                         return; /* Return to evalMode to restart the session. */
                     } else {
                         printf("Use 'restart' only in Lua debugging mode.");


### PR DESCRIPTION
`sdsfreesplitres` and `linenoiseFree` are used to free string memory of command, but they haven't applied in "restart" command handling, add deallocation before leaving repl function.