### PR TITLE
fix wrong counts for bytes written to clients

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -934,7 +934,7 @@ int writeToClient(int fd, client *c, int handler_installed) {
          *
          * However if we are over the maxmemory limit we ignore that and
          * just deliver as much data as it is possible to deliver. */
-        server.stat_net_output_bytes += totwritten;
+        server.stat_net_output_bytes += nwritten;
         if (totwritten > NET_MAX_WRITES_PER_EVENT &&
             (server.maxmemory == 0 ||
              zmalloc_used_memory() < server.maxmemory)) break;


### PR DESCRIPTION
Redis counts more bytes than it actually wrote when dealing with pending replies, and this would make 
 metrics of instantaneous_output_kbps and total_net_output_bytes increase very fast.

In src/networking.c writeToClient function:

```
while(clientHasPendingReplies(c)) {
    //...
    nwritten = write(/*...*/);
    totwritten += nwritten;
    //...
    server.stat_net_output_bytes += totwritten;
}

```
and totwritten is counted(and not reset) each time the loop runs.
