### PR TITLE
Added conversion to nautical miles

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -135,9 +135,11 @@ double extractUnitOrReply(client *c, robj *unit) {
         return 0.3048;
     } else if (!strcmp(u, "mi")) {
         return 1609.34;
+    } else if (!strcmp(u, "nm")) {
+        return 1852;
     } else {
         addReplyError(c,
-            "unsupported unit provided. please use m, km, ft, mi");
+            "unsupported unit provided. please use m, km, ft, mi, nm");
         return -1;
     }
 }


### PR DESCRIPTION
Nautical Miles = Air Miles
A nautical mile is a unit of measurement defined as exactly 1852 meters (about 6,076.1 feet or 1.1508 statute miles). Historically, it was defined as one minute of latitude, which is equivalent to one sixtieth of a degree of latitude.