### PR TITLE
exit activeExpireCycle() and activeDefragCycle() ASAP if variable 'elapsed' appears to be negative

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -558,9 +558,10 @@ void activeDefragCycle(void) {
             cursor = dictScan(db->dict, cursor, defragScanCallback, defragDictBucketCallback, db);
             /* Once in 16 scan iterations, or 1000 pointer reallocations
              * (if we have a lot of pointers in one hash bucket), check if we
-             * reached the tiem limit. */
+             * reached the time limit. */
             if (cursor && (++iterations > 16 || server.stat_active_defrag_hits - defragged > 1000)) {
-                if ((ustime() - start) > timelimit) {
+                long long elapsed = ustime()-start;
+                if (elapsed < 0 || elapsed > timelimit) {
                     return;
                 }
                 iterations = 0;

--- a/src/expire.c
+++ b/src/expire.c
@@ -207,7 +207,7 @@ void activeExpireCycle(int type) {
                 long long elapsed = ustime()-start;
 
                 latencyAddSampleIfNeeded("expire-cycle",elapsed/1000);
-                if (elapsed > timelimit) timelimit_exit = 1;
+                if (elapsed < 0 || elapsed > timelimit) timelimit_exit = 1;
             }
             if (timelimit_exit) return;
             /* We don't repeat the cycle if there are less than 25% of keys


### PR DESCRIPTION
In activeExpireCycle(),variable **_timelimit_** is used as a condition of exiting the loop to limit the cpu usage.When **_elapsed_**(calculated by ustime()-start) is greater than **_timelimit_**,the method returns immediately.

However if the system clock happens to be adjusted forward a lot during the loop,the cpu usage will become unpredictable.The probability of above case may be very small,but since redis is single-threaded,I think it is better to exit the loop as soon as possible if **_elapsed_** appears to be negative.