### PR TITLE
Initialize client->id to 0 in createFakeClient()

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -570,6 +570,7 @@ struct client *createFakeClient(void) {
 
     selectDb(c,0);
     c->fd = -1;
+    c->id = 0; /* Fake id for a fake client. */
     c->name = NULL;
     c->querybuf = sdsempty();
     c->querybuf_peak = 0;


### PR DESCRIPTION
Client id is accessible to modules via RedisModule_GetClientId() and should be initialised when loading data from AOF.