### PR TITLE
Initialize client->id to CLIENT_ID_AOF in createFakeClient()

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -570,6 +570,7 @@ struct client *createFakeClient(void) {
 
     selectDb(c,0);
     c->fd = -1;
+    c->id = CLIENT_ID_AOF;
     c->name = NULL;
     c->querybuf = sdsempty();
     c->querybuf_peak = 0;

--- a/src/module.c
+++ b/src/module.c
@@ -1244,8 +1244,9 @@ int RM_ReplicateVerbatim(RedisModuleCtx *ctx) {
  * 2. The ID increases monotonically. Clients connecting to the server later
  *    are guaranteed to get IDs greater than any past ID previously seen.
  *
- * Valid IDs are from 1 to 2^64-1. If 0 is returned it means there is no way
- * to fetch the ID in the context the function was currently called. */
+ * Valid IDs are from 1 to 2^64-1 excluding the high special ids (CLIENT_ID_*).
+ * If 0 is returned it means there is no way to fetch the ID in the context the
+ * function was currently called. */
 unsigned long long RM_GetClientId(RedisModuleCtx *ctx) {
     if (ctx->client == NULL) return 0;
     return ctx->client->id;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -58,6 +58,9 @@
 #define REDISMODULE_HASH_CFIELDS    (1<<2)
 #define REDISMODULE_HASH_EXISTS     (1<<3)
 
+/* Client special IDs. */
+#define REDISMODULE_CLIENT_ID_AOF UINT64_MAX
+
 /* A special pointer that we can use between the core and the module to signal
  * field deletion, and that is impossible to be a valid pointer. */
 #define REDISMODULE_HASH_DELETE ((RedisModuleString*)(long)1)

--- a/src/server.h
+++ b/src/server.h
@@ -270,6 +270,9 @@ typedef long long mstime_t; /* millisecond time type. */
                                     buffer configuration. Just the first
                                     three: normal, slave, pubsub. */
 
+/* Client special IDs. */
+#define CLIENT_ID_AOF UINT64_MAX
+
 /* Slave replication state. Used in server.repl_state for slaves to remember
  * what to do next. */
 #define REPL_STATE_NONE 0 /* No active replication */


### PR DESCRIPTION
Client id is accessible to modules via RedisModule_GetClientId() and should be initialised when loading data from AOF.