### PR TITLE
Clean temp AOF file

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1396,6 +1396,8 @@ void aofRemoveTempFile(pid_t childpid) {
 
     snprintf(tmpfile,256,"temp-rewriteaof-bg-%d.aof", (int) childpid);
     unlink(tmpfile);
+    snprintf(tmpfile, 256, "temp-rewriteaof-%d.aof", (int) childpid);
+    unlink(tmpfile);
 }
 
 /* Update the server.aof_current_size field explicitly using stat(2)

--- a/src/server.c
+++ b/src/server.c
@@ -2524,6 +2524,7 @@ int prepareForShutdown(int flags) {
             serverLog(LL_WARNING,
                 "There is a child rewriting the AOF. Killing it!");
             kill(server.aof_child_pid,SIGUSR1);
+            aofRemoveTempFile(server.aof_child_pid);
         }
         /* Append only file: fsync() the AOF and exit */
         serverLog(LL_NOTICE,"Calling fsync() on the AOF file.");


### PR DESCRIPTION
Redis-server terminate by signal such as sigint, If server is performing AOF rewrite. It will create temp file.  Then server exit but leave AOF temp file not be deleted.
Fix it like RDB temp file clear.