### PR TITLE
Check that THP is not set to always (madvise is ok)

### DIFF
--- a/src/latency.c
+++ b/src/latency.c
@@ -71,7 +71,7 @@ int THPIsEnabled(void) {
         return 0;
     }
     fclose(fp);
-    return (strstr(buf,"[never]") == NULL) ? 1 : 0;
+    return (strstr(buf,"[always]") != NULL) ? 1 : 0;
 }
 #endif
 


### PR DESCRIPTION
THP can also be set to madvise, in which case it shouldn't cause
problems for Redis.

Fixes #3895