### PR TITLE
fix zslGetRank bug

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -434,7 +434,7 @@ unsigned long zslGetRank(zskiplist *zsl, double score, sds ele) {
         }
 
         /* x might be equal to zsl->header, so test if obj is non-NULL */
-        if (x->ele && sdscmp(x->ele,ele) == 0) {
+        if (x->ele && x->score == score && sdscmp(x->ele,ele) == 0) {
             return rank;
         }
     }


### PR DESCRIPTION
**Issue:**
This PR is a fix for #3081

**Reproduce Step:**
The following code has printed 1 instead of 0.

```
// file name: test_t_zset.c
#include "server.h"
#include <stdio.h>
    
int main()
{       
        zskiplist* zsl = zslCreate();
        zslInsert(zsl, 2, sdsnewlen("test", 4));
        zslInsert(zsl, 4, sdsnewlen("test", 4));
        int res = zslGetRank(zsl, 3, sdsnewlen("test", 4));
        printf("%d\n", res);
        zslFree(zsl);
        return 0;
} 
```

To compile and run this piece of code. You can:

1. change [main()](https://github.com/antirez/redis/blob/unstable/src/server.c#L3646) to any other name in server.c
2.  add test_t_zset.o to [REDIS_SERVER_OBJ](https://github.com/antirez/redis/blob/unstable/src/Makefile#L142).
3. make -f [Makefile ](https://github.com/antirez/redis/blob/unstable/src/Makefile)
4. run redis-server