### PR TITLE
Fixed comment in clusterMsg version field

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -232,7 +232,7 @@ union clusterMsgData {
 typedef struct {
     char sig[4];        /* Siganture "RCmb" (Redis Cluster message bus). */
     uint32_t totlen;    /* Total length of this message */
-    uint16_t ver;       /* Protocol version, currently set to 0. */
+    uint16_t ver;       /* Protocol version, currently set to 1. */
     uint16_t port;      /* TCP base port number. */
     uint16_t type;      /* Message type */
     uint16_t count;     /* Only used for some kind of messages. */


### PR DESCRIPTION
CLUSTER_PROTO_VER is defined as 1, so the comment seems to be wrong as it is referring to version 0.
Message header is built using CLUSTER_PROTO_VER: https://github.com/antirez/redis/blob/unstable/src/cluster.c#L2204
@antirez for review