### PR TITLE
sdstrim remove excessive check

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -691,7 +691,7 @@ sds sdstrim(sds s, const char *cset) {
     ep = end = s+sdslen(s)-1;
     while(sp <= end && strchr(cset, *sp)) sp++;
     while(ep > sp && strchr(cset, *ep)) ep--;
-    len = (sp > ep) ? 0 : ((ep-sp)+1);
+    len = (ep-sp)+1;
     if (s != sp) memmove(s, sp, len);
     s[len] = '\0';
     sdssetlen(s,len);


### PR DESCRIPTION
Hi, I found a small problem:
there is no need to compare the value of ep and sp
```
    sp = start = s;
    // the only way that make ep > sp is sdslen(s) == 0
    // so when ep > sp,must exist ep-sp == -1
    ep = end = s+sdslen(s)-1;
    while(sp <= end && strchr(cset, *sp)) sp++;
    while(ep > sp && strchr(cset, *ep)) ep--;
    // -1 + 1 already equals 0
    len = (sp > ep) ? 0 : ((ep-sp)+1);
```
So I think there is no need to determine the size of ep and sp, I am not really sure, is that right?

Signed-off-by: Bo Cai <charpty@gmail.com>