### PR TITLE
Fixed comments of slowlog duration

### DIFF
--- a/src/slowlog.h
+++ b/src/slowlog.h
@@ -35,7 +35,7 @@ typedef struct slowlogEntry {
     robj **argv;
     int argc;
     long long id;       /* Unique entry identifier. */
-    long long duration; /* Time spent by the query, in nanoseconds. */
+    long long duration; /* Time spent by the query, in microseconds. */
     time_t time;        /* Unix time at which the query was executed. */
 } slowlogEntry;
 


### PR DESCRIPTION
I think unit of slowlog duration is microseconds。
issue: [4054](https://github.com/antirez/redis/issues/4054)