### PR TITLE
Opening a non-existent key in module API for writing requires explicit create flag.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1291,6 +1291,9 @@ void *RM_OpenKey(RedisModuleCtx *ctx, robj *keyname, int mode) {
 
     if (mode & REDISMODULE_WRITE) {
         value = lookupKeyWrite(ctx->client->db,keyname);
+        if (!(mode & REDISMODULE_CREATE) && value == NULL) {
+            return NULL;
+        }
     } else {
         value = lookupKeyRead(ctx->client->db,keyname);
         if (value == NULL) {

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -17,6 +17,7 @@
 /* API flags and constants */
 #define REDISMODULE_READ (1<<0)
 #define REDISMODULE_WRITE (1<<1)
+#define REDISMODULE_CREATE (1<<2)
 
 #define REDISMODULE_LIST_HEAD 0
 #define REDISMODULE_LIST_TAIL 1


### PR DESCRIPTION
Addresses #4061. New REDISMODULE_CREATE flag added. It must be combined with REDISMODULE_WRITE to open a non-existent key, otherwise NULL is returned. E.g.: 

`RedisModule_OpenKey(ctx, keyname, REDISMODULE_WRITE | REDISMODULE_CREATE)`

Let me know if this isn't what you think is best or if I can make any improvements!