### PR TITLE
Fix set with ex/px option when propagated to aof

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -536,16 +536,16 @@ void feedAppendOnlyFile(struct redisCommand *cmd, int dictid, robj **argv, int a
         buf = catAppendOnlyGenericCommand(buf,3,tmpargv);
         decrRefCount(tmpargv[0]);
         buf = catAppendOnlyExpireAtCommand(buf,cmd,argv[1],argv[2]);
-    } else if (cmd->proc == setCommand) {
+    } else if (cmd->proc == setCommand && argc > 3) {
         int i;
         robj *exarg = NULL, *pxarg = NULL;
         /* Translate SET [EX seconds][PX milliseconds] to SET and PEXPIREAT */
         buf = catAppendOnlyGenericCommand(buf,3,argv);
         for (i = 3; i < argc; i ++) {
-            if (sdsEncodedObject(argv[i]) && !strcasecmp(argv[i]->ptr, "ex"))
+            if (!strcasecmp(argv[i]->ptr, "ex"))
                 exarg = argv[i+1];
 
-            if (sdsEncodedObject(argv[i]) && !strcasecmp(argv[i]->ptr, "px"))
+            if (!strcasecmp(argv[i]->ptr, "px"))
                 pxarg = argv[i+1];
         }
         serverAssert(!(exarg && pxarg));

--- a/src/server.c
+++ b/src/server.c
@@ -1500,6 +1500,8 @@ void initServerConfig(void) {
     server.rpopCommand = lookupCommandByCString("rpop");
     server.sremCommand = lookupCommandByCString("srem");
     server.execCommand = lookupCommandByCString("exec");
+    server.expireCommand = lookupCommandByCString("expire");
+    server.pexpireCommand = lookupCommandByCString("pexpire");
 
     /* Slow log */
     server.slowlog_log_slower_than = CONFIG_DEFAULT_SLOWLOG_LOG_SLOWER_THAN;

--- a/src/server.h
+++ b/src/server.h
@@ -909,7 +909,8 @@ struct redisServer {
     off_t loading_process_events_interval_bytes;
     /* Fast pointers to often looked up command */
     struct redisCommand *delCommand, *multiCommand, *lpushCommand, *lpopCommand,
-                        *rpopCommand, *sremCommand, *execCommand;
+                        *rpopCommand, *sremCommand, *execCommand, *expireCommand,
+                        *pexpireCommand;
     /* Fields used only for stats */
     time_t stat_starttime;          /* Server start time */
     long long stat_numcommands;     /* Number of processed commands */

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -204,4 +204,19 @@ start_server {tags {"expire"}} {
         catch {r expire foo ""} e
         set e
     } {*not an integer*}
+
+    test {SET - use EX/PX option, TTL should not be reseted after loadaof} {
+        r config set appendonly yes
+        r set foo bar EX 100
+        after 2000
+        r debug loadaof
+        set ttl [r ttl foo]
+        assert {$ttl <= 98 && $ttl > 90}
+
+        r set foo bar PX 100000
+        after 2000
+        r debug loadaof
+        set ttl [r ttl foo]
+        assert {$ttl <= 98 && $ttl > 90}
+    }
 }


### PR DESCRIPTION
Translate set command with ex/px option to set and expireat commands when updating aof.