### PR TITLE
Fix Issues in blocking commands in cluster mode.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5438,6 +5438,7 @@ int clusterRedirectBlockedClientIfNeeded(client *c) {
                     clusterRedirectClient(c,node,slot,
                         CLUSTER_REDIR_MOVED);
                 }
+                dictReleaseIterator(di);
                 return 1;
             }
         }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5418,8 +5418,9 @@ int clusterRedirectBlockedClientIfNeeded(client *c) {
             return 1;
         }
 
+        /* All keys must belong to the same slot, so check first key only. */
         di = dictGetIterator(c->bpop.keys);
-        while((de = dictNext(di)) != NULL) {
+        if ((de = dictNext(di)) != NULL) {
             robj *key = dictGetKey(de);
             int slot = keyHashSlot((char*)key->ptr, sdslen(key->ptr));
             clusterNode *node = server.cluster->slots[slot];

--- a/src/server.c
+++ b/src/server.c
@@ -152,7 +152,7 @@ struct redisCommand redisCommandTable[] = {
     {"linsert",linsertCommand,5,"wm",0,NULL,1,1,1,0,0},
     {"rpop",rpopCommand,2,"wF",0,NULL,1,1,1,0,0},
     {"lpop",lpopCommand,2,"wF",0,NULL,1,1,1,0,0},
-    {"brpop",brpopCommand,-3,"ws",0,NULL,1,1,1,0,0},
+    {"brpop",brpopCommand,-3,"ws",0,NULL,1,-2,1,0,0},
     {"brpoplpush",brpoplpushCommand,4,"wms",0,NULL,1,2,1,0,0},
     {"blpop",blpopCommand,-3,"ws",0,NULL,1,-2,1,0,0},
     {"llen",llenCommand,2,"rF",0,NULL,1,1,1,0,0},


### PR DESCRIPTION
1. Redis command table entry for brpop command looks to be incorrect. As a result of this, we are not checking all the keys in the command for slot and not giving CROSSSLOT error correctly.
2. We can get rid of a loop to check slot for all keys client is blocked on. Slot must be same for all the keys.
3. dictIterator is not freed in case of redirection. 

Current behavior:
127.0.0.1:8000> cluster keyslot b
(integer) 3300
127.0.0.1:8000> cluster keyslot f
(integer) 3168
127.0.0.1:8000> brpop b f 0
[blocked]

After Fix:
127.0.0.1:8000> brpop b f 0
(error) CROSSSLOT Keys in request don't hash to the same slot