### PR TITLE
New goto statement added to avoid double fclose

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1225,7 +1225,7 @@ int rewriteAppendOnlyFile(char *filename) {
     /* Make sure data will not remain on the OS's output buffers */
     if (fflush(fp) == EOF) goto werr;
     if (fsync(fileno(fp)) == -1) goto werr;
-    if (fclose(fp) == EOF) goto werr;
+    if (fclose(fp) == EOF) goto werr_no_fclose;
 
     /* Use RENAME to make sure the DB file is changed atomically only
      * if the generate DB file is ok. */
@@ -1238,8 +1238,9 @@ int rewriteAppendOnlyFile(char *filename) {
     return C_OK;
 
 werr:
-    serverLog(LL_WARNING,"Write error writing append only file on disk: %s", strerror(errno));
     fclose(fp);
+werr_no_fclose:
+    serverLog(LL_WARNING,"Write error writing append only file on disk: %s", strerror(errno));
     unlink(tmpfile);
     return C_ERR;
 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1016,7 +1016,7 @@ int rdbSave(char *filename, rdbSaveInfo *rsi) {
     /* Make sure data will not remain on the OS's output buffers */
     if (fflush(fp) == EOF) goto werr;
     if (fsync(fileno(fp)) == -1) goto werr;
-    if (fclose(fp) == EOF) goto werr;
+    if (fclose(fp) == EOF) goto werr_no_fclose;
 
     /* Use RENAME to make sure the DB file is changed atomically only
      * if the generate DB file is ok. */
@@ -1040,8 +1040,9 @@ int rdbSave(char *filename, rdbSaveInfo *rsi) {
     return C_OK;
 
 werr:
-    serverLog(LL_WARNING,"Write error saving DB on disk: %s", strerror(errno));
     fclose(fp);
+werr_no_fclose:
+    serverLog(LL_WARNING,"Write error saving DB on disk: %s", strerror(errno));
     unlink(tmpfile);
     return C_ERR;
 }


### PR DESCRIPTION
This addresses. 

This was a small enough potential solution to present in a PR. Most of the clean up in werr is moved to werr_no_fclose. This seems like a easy enough fix. 

My only reservation is whether errno might be misleading if fclose fails after the werr goto and before passing it to serverLog. What do you think?