### PR TITLE
The werr goto is no longer used on fclose(fp) failure to avoid calling fclose twice.

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1225,7 +1225,11 @@ int rewriteAppendOnlyFile(char *filename) {
     /* Make sure data will not remain on the OS's output buffers */
     if (fflush(fp) == EOF) goto werr;
     if (fsync(fileno(fp)) == -1) goto werr;
-    if (fclose(fp) == EOF) goto werr;
+    if (fclose(fp) == EOF) {
+        serverLog(LL_WARNING,"Error closing append only file: %s", strerror(errno));
+        unlink(tmpfile);
+        return C_ERR;
+    }
 
     /* Use RENAME to make sure the DB file is changed atomically only
      * if the generate DB file is ok. */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1016,7 +1016,11 @@ int rdbSave(char *filename, rdbSaveInfo *rsi) {
     /* Make sure data will not remain on the OS's output buffers */
     if (fflush(fp) == EOF) goto werr;
     if (fsync(fileno(fp)) == -1) goto werr;
-    if (fclose(fp) == EOF) goto werr;
+    if (fclose(fp) == EOF) {
+        serverLog(LL_WARNING,"Error closing DB file: %s", strerror(errno));
+        unlink(tmpfile);
+        return C_ERR;
+    }
 
     /* Use RENAME to make sure the DB file is changed atomically only
      * if the generate DB file is ok. */


### PR DESCRIPTION
Addresses #4095. 

Before this change, going to werr when fclose(fp) failed resulted in calling fclose(fp) twice and undefined behavior.

My earlier idea was to create a second goto statement after werr that skipped the fclose, but this didn't work well because serverLog needs to be called before fclose.