### PR TITLE
Fixed stack trace generation on aarch64

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,7 +39,7 @@ endif
 endif
 
 # To get ARM stack traces if Redis crashes we need a special C flag.
-ifneq (,$(findstring armv,$(uname_M)))
+ifneq (,$(filter aarch64 armv,$(uname_M)))
         CFLAGS+=-funwind-tables
 endif
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -673,6 +673,8 @@ static void *getMcontextEip(ucontext_t *uc) {
     return (void*) uc->uc_mcontext.sc_ip;
     #elif defined(__arm__) /* Linux ARM */
     return (void*) uc->uc_mcontext.arm_pc;
+    #elif defined(__aarch64__) /* Linux AArch64 */
+    return (void*) uc->uc_mcontext.pc;
     #endif
 #else
     return NULL;


### PR DESCRIPTION
Added aarch64 CFLAGS to generate stack trace.