### PR TITLE
Improve error checking of the bind() call on ipv6 sockets

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1705,7 +1705,9 @@ int listenToPort(int port, int *fds, int *count) {
             if (fds[*count] != ANET_ERR) {
                 anetNonBlock(NULL,fds[*count]);
                 (*count)++;
-            } else if (errno == EAFNOSUPPORT) {
+            } else if (errno == ENOPROTOOPT     || errno == EPROTONOSUPPORT ||
+                       errno == ESOCKTNOSUPPORT || errno == EPFNOSUPPORT ||
+                       errno == EAFNOSUPPORT) {
                 unsupported++;
                 serverLog(LL_WARNING,"Not listening to IPv6: unsupproted");
             }
@@ -1717,7 +1719,9 @@ int listenToPort(int port, int *fds, int *count) {
                 if (fds[*count] != ANET_ERR) {
                     anetNonBlock(NULL,fds[*count]);
                     (*count)++;
-                } else if (errno == EAFNOSUPPORT) {
+                } else if (errno == ENOPROTOOPT     || errno == EPROTONOSUPPORT ||
+                           errno == ESOCKTNOSUPPORT || errno == EPFNOSUPPORT ||
+                           errno == EAFNOSUPPORT) {
                     unsupported++;
                     serverLog(LL_WARNING,"Not listening to IPv4: unsupproted");
                 }


### PR DESCRIPTION
Extend the error check to EPROTONOSUPPORT to which errno is set in
certain contexts (especially some containers) and to other error codes
which may be reported in more situations, adopting the same list used
in the ISC DHCP implementation upon socket() and bind() calls.

Solves issue #3894 