### PR TITLE
Fixed objectComputeSize reporting very high memory usage for lists

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -723,7 +723,7 @@ size_t objectComputeSize(robj *o, size_t sample_size) {
                 elesize += sizeof(quicklistNode)+ziplistBlobLen(node->zl);
                 samples++;
             } while ((node = node->next) && samples < sample_size);
-            asize += (double)elesize/samples*listTypeLength(o);
+            asize += (double)elesize/samples*ql->len;
         } else if (o->encoding == OBJ_ENCODING_ZIPLIST) {
             asize = sizeof(*o)+ziplistBlobLen(o->ptr);
         } else {


### PR DESCRIPTION
Redis memory usage command reports incorrect usage for list. Steps to reproduce the issue 

1. Run redis server 
./redis-server --daemonize yes 
2. Create a list with 100000 elements with each item of 5 bytes. 
for i in {1..100000}; do echo "lpush key foooo"; done | ./redis-cli 
./redis-cli llen key 
(integer) 100000 
3. Check memory usage, it is reporting very high memory usage (~700MB) for the list 
./redis-cli memory usage key 
(integer) 759180081 

It is using "total count of all entries in all ziplists", I think it should be "number of quicklistNodes" 

After the fix, memory usage returned is correct (5 bytes * 100000 + overhead)
./redis-cli memory usage key                                                                                                                                                          
(integer) 652975