### PR TITLE
Add optional unload callback to redis module

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -47,6 +47,7 @@ struct RedisModule {
     int ver;        /* Module version. We use just progressive integers. */
     int apiver;     /* Module API version as requested during initialization.*/
     list *types;    /* Module data types. */
+    int (*unload)(void *) /* Module unload entry */;
 };
 typedef struct RedisModule RedisModule;
 
@@ -658,6 +659,7 @@ void RM_SetModuleAttribs(RedisModuleCtx *ctx, const char *name, int ver, int api
     module->ver = ver;
     module->apiver = apiver;
     module->types = listCreate();
+    module->unload = NULL;
     ctx->module = module;
 }
 
@@ -3669,6 +3671,7 @@ int moduleLoad(const char *path, void **module_argv, int module_argc) {
     /* Redis module loaded! Register it. */
     dictAdd(modules,ctx.module->name,ctx.module);
     ctx.module->handle = handle;
+    ctx.module->unload = (int (*)(void *))(unsigned long) dlsym(handle,"RedisModule_Unload");
     serverLog(LL_NOTICE,"Module '%s' loaded from %s",ctx.module->name,path);
     moduleFreeContext(&ctx);
     return C_OK;
@@ -3681,6 +3684,7 @@ int moduleLoad(const char *path, void **module_argv, int module_argc) {
  * ENONET: No such module having the specified name.
  * EBUSY: The module exports a new data type and can only be reloaded. */
 int moduleUnload(sds name) {
+    RedisModuleCtx ctx = REDISMODULE_CTX_INIT;
     struct RedisModule *module = dictFetchValue(modules,name);
 
     if (module == NULL) {
@@ -3691,6 +3695,15 @@ int moduleUnload(sds name) {
     if (listLength(module->types)) {
         errno = EBUSY;
         return REDISMODULE_ERR;
+    }
+
+    if (module->unload != NULL) {
+      ctx.module = module;
+      ctx.client = NULL;
+      if (module->unload(&ctx) != REDISMODULE_OK) {
+        errno = EBUSY;
+        return REDISMODULE_ERR;
+      }
     }
 
     /* Unregister all the commands registered by this module. */

--- a/src/modules/INTRO.md
+++ b/src/modules/INTRO.md
@@ -66,6 +66,11 @@ simple module that implements a command that outputs a random number.
         return REDISMODULE_OK;
     }
 
+    int RedisModule_Unload(RedisModuleCtx *ctx) {
+        RedisModule_Log(ctx, "notice", "unloading module helloword");
+        return REDISMODULE_OK;
+    }
+
     int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         if (RedisModule_Init(ctx,"helloworld",1,REDISMODULE_APIVER_1)
             == REDISMODULE_ERR) return REDISMODULE_ERR;
@@ -82,7 +87,10 @@ HELLOWORLD.RAND. This function is specific of that module. However the
 other function called `RedisModule_OnLoad()` must be present in each
 Redis module. It is the entry point for the module to be initialized,
 register its commands, and potentially other private data structures
-it uses.
+it uses. When there is an optional function called `RedisModule_Unload`
+present in Redis module, it will be called before it's actually unloaded.
+Returning value other than `REDISMODULE_OK` can prevent module from being
+unloaded.
 
 Note that it is a good idea for modules to call commands with the
 name of the module followed by a dot, and finally the command name,

--- a/src/modules/helloworld.c
+++ b/src/modules/helloworld.c
@@ -540,6 +540,11 @@ int HelloLeftPad_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int
     return REDISMODULE_OK;
 }
 
+int RedisModule_Unload(RedisModuleCtx *ctx) {
+    RedisModule_Log(ctx, "notice", "unloading module helloword");
+    return REDISMODULE_OK;
+}
+
 /* This function must be present on each Redis module. It is used in order to
  * register the commands into the Redis server. */
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {


### PR DESCRIPTION
Add optional unload callback to redis module to make it possible to perform
cleanup steps before it's actually being unloaded. For example, stop
running background threads.
