### PR TITLE
fix rewrite config: auto-aof-rewrite-min-size

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1057,8 +1057,6 @@ void configSetCommand(client *c) {
     } config_set_numerical_field(
       "auto-aof-rewrite-percentage",server.aof_rewrite_perc,0,LLONG_MAX){
     } config_set_numerical_field(
-      "auto-aof-rewrite-min-size",server.aof_rewrite_min_size,0,LLONG_MAX) {
-    } config_set_numerical_field(
       "hash-max-ziplist-entries",server.hash_max_ziplist_entries,0,LLONG_MAX) {
     } config_set_numerical_field(
       "hash-max-ziplist-value",server.hash_max_ziplist_value,0,LLONG_MAX) {
@@ -1136,6 +1134,8 @@ void configSetCommand(client *c) {
         }
     } config_set_memory_field("repl-backlog-size",ll) {
         resizeReplicationBacklog(ll);
+    } config_set_memory_field("auto-aof-rewrite-min-size",ll) {
+        server.aof_rewrite_min_size = ll;
 
     /* Enumeration fields.
      * config_set_enum_field(name,var,enum_var) */


### PR DESCRIPTION
I found that using 'config set auto-aof-rewrite-min-size <value>' and '<value>' can only be number which mean that I can only rewrite auto-aof-rewrite-min-size by bytes, which is not convenient.

**Full Demo**
```
127.0.0.1:6379> config get auto-aof-rewrite-min-size
1) "auto-aof-rewrite-min-size"
2) "67108864"
127.0.0.1:6379> config set auto-aof-rewrite-min-size 65mb
(error) ERR Invalid argument '65mb' for CONFIG SET 'auto-aof-rewrite-min-size'
```

I fixed that by changing the code a little bit. After fixing, it behaves like this:
```
127.0.0.1:6379> config get auto-aof-rewrite-min-size
1) "auto-aof-rewrite-min-size"
2) "67108864"
127.0.0.1:6379> config set auto-aof-rewrite-min-size 65mb
OK
127.0.0.1:6379> config get auto-aof-rewrite-min-size
1) "auto-aof-rewrite-min-size"
2) "68157440"
```