### PR TITLE
Fixes a (potential) memory leak and a (potential) resource leak:

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1494,11 +1494,11 @@ void rewriteConfigMarkAsProcessed(struct rewriteConfigState *state, const char *
  * If the old file does not exist at all, an empty state is returned. */
 struct rewriteConfigState *rewriteConfigReadOldFile(char *path) {
     FILE *fp = fopen(path,"r");
+    if (fp == NULL && errno != ENOENT) return NULL;
+
     struct rewriteConfigState *state = zmalloc(sizeof(*state));
     char buf[CONFIG_MAX_LINE+1];
     int linenum = -1;
-
-    if (fp == NULL && errno != ENOENT) return NULL;
 
     state->option_to_line = dictCreate(&optionToLineDictType,NULL);
     state->rewritten = dictCreate(&optionSetDictType,NULL);

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -321,6 +321,7 @@ eoferr: /* unexpected end of file is handled here with a fatal exit */
     } else {
         rdbCheckError("Unexpected EOF reading RDB file");
     }
+    fclose(fp);
     return 1;
 }
 


### PR DESCRIPTION
I ran the infer static analyser. It found some small issues (mostly false alarms). Here are two that I could easily fix:

* Memory was allocated after which a file was checked. It leaks when the file could not be openened, fixed by checking the file before allocating memory.
	modified:   src/config.c
* Adds an fclose in the case of errors.
	modified:   src/redis-check-rdb.c