### PR TITLE
return C_OK when got enough memory after wait for objects lazyfreed

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -558,8 +558,9 @@ cant_free:
      * last thing we can try: check if the lazyfree thread has jobs in queue
      * and wait... */
     while(bioPendingJobsOfType(BIO_LAZY_FREE)) {
-        if (((mem_reported - zmalloc_used_memory()) + mem_freed) >= mem_tofree)
-            break;
+        if (((mem_reported - zmalloc_used_memory()) + mem_freed) >= mem_tofree) {
+            return C_OK;
+        }
         usleep(1000);
     }
     return C_ERR;

--- a/src/evict.c
+++ b/src/evict.c
@@ -558,9 +558,8 @@ cant_free:
      * last thing we can try: check if the lazyfree thread has jobs in queue
      * and wait... */
     while(bioPendingJobsOfType(BIO_LAZY_FREE)) {
-        if (((mem_reported - zmalloc_used_memory()) + mem_freed) >= mem_tofree) {
+        if (((mem_reported - zmalloc_used_memory()) + mem_freed) >= mem_tofree)
             return C_OK;
-        }
         usleep(1000);
     }
     return C_ERR;


### PR DESCRIPTION
in `freeMemoryIfNeeded`, when enter `cant_free`, the original implentation is to wait for object to be lazyfreed to free.   
but when finally we got enough memory, redis return `C_ERR` which can be avoided.