### PR TITLE
Added support for logging from detached thread safe contexts

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3269,8 +3269,7 @@ void RM_LogRaw(RedisModule *module, const char *levelstr, const char *fmt, va_li
  * a few lines of text.
  */
 void RM_Log(RedisModuleCtx *ctx, const char *levelstr, const char *fmt, ...) {
-    //if (!ctx->module) return;   /* Can only log if module is initialized */
-
+    
     va_list ap;
     va_start(ap, fmt);
     RM_LogRaw(ctx->module,levelstr,fmt,ap);

--- a/src/modules/helloblock.c
+++ b/src/modules/helloblock.c
@@ -176,6 +176,12 @@ int HelloKeys_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     return REDISMODULE_OK;
 }
 
+void logFromDetachedContext() {
+    RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
+    RedisModule_Log(ctx, "notice", "Logging from a detached context");
+    RedisModule_FreeThreadSafeContext(ctx);
+}
+
 /* This function must be present on each Redis module. It is used in order to
  * register the commands into the Redis server. */
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -191,6 +197,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_CreateCommand(ctx,"hello.keys",
         HelloKeys_RedisCommand,"",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
-
+    
+    logFromDetachedContext();
+    
     return REDISMODULE_OK;
 }


### PR DESCRIPTION
This solves the issue of logging from a context that was initialized with `RedisModule_GetThreadSafeContext(NULL);` by putting a default string instead of the module name.