### PR TITLE
Add missing fclose()

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1807,6 +1807,7 @@ static void getRDB(void) {
     }
     close(s); /* Close the file descriptor ASAP as fsync() may take time. */
     fsync(fd);
+    close(fd);
     fprintf(stderr,"Transfer finished with success.\n");
     exit(0);
 }


### PR DESCRIPTION
add missing `fclose()` in `src/redis-cli.c : getRDB()`