### PR TITLE
change src/adlist.c:listJoin()

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -345,15 +345,17 @@ void listRotate(list *list) {
 /* Add all the elements of the list 'o' at the end of the
  * list 'l'. The list 'other' remains empty but otherwise valid. */
 void listJoin(list *l, list *o) {
-    if (o->head)
-        o->head->prev = l->tail;
-
     if (l->tail)
         l->tail->next = o->head;
     else
         l->head = o->head;
 
-    l->tail = o->tail;
+    if (o->head)
+    {
+        o->head->prev = l->tail;
+        l->tail = o->tail;
+    }
+
     l->len += o->len;
 
     /* Setup other as an empty list. */


### PR DESCRIPTION
In listJoin(), when list 'l' is not empty and list 'o' is empty, 'tail' point of list 'l' is NULL.