### PR TITLE
Accelerate release client when have a lot of short connections

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -135,7 +135,10 @@ client *createClient(int fd) {
     c->peerid = NULL;
     listSetFreeMethod(c->pubsub_patterns,decrRefCountVoid);
     listSetMatchMethod(c->pubsub_patterns,listMatchObjects);
-    if (fd != -1) listAddNodeTail(server.clients,c);
+    if (fd != -1) {
+        listAddNodeTail(server.clients,c);
+        c->active_node = listIndex(server.clients,-1);
+    }
     initClientMultiState(c);
     return c;
 }
@@ -743,7 +746,7 @@ void unlinkClient(client *c) {
      * fd is already set to -1. */
     if (c->fd != -1) {
         /* Remove from the list of active clients. */
-        ln = listSearchKey(server.clients,c);
+        ln = c->active_node;
         serverAssert(ln != NULL);
         listDelNode(server.clients,ln);
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -2200,6 +2200,7 @@ void replicationResurrectCachedMaster(int newfd) {
 
     /* Re-add to the list of clients. */
     listAddNodeTail(server.clients,server.master);
+    server.master->active_node = listIndex(server.clients,-1);
     if (aeCreateFileEvent(server.el, newfd, AE_READABLE,
                           readQueryFromClient, server.master)) {
         serverLog(LL_WARNING,"Error resurrecting the cached master, impossible to add the readable handler: %s", strerror(errno));

--- a/src/server.h
+++ b/src/server.h
@@ -722,6 +722,7 @@ typedef struct client {
     dict *pubsub_channels;  /* channels a client is interested in (SUBSCRIBE) */
     list *pubsub_patterns;  /* patterns a client is interested in (SUBSCRIBE) */
     sds peerid;             /* Cached peer ID. */
+    listNode *active_node;  /* Cached listNode of current client in server.clients list */
 
     /* Response buffer */
     int bufpos;


### PR DESCRIPTION
Cache the listNode pointer in server.clients list of current the client, so we can simple use it when free the client.
Mainly in a large number of short-connected scenarios, traversing the active clients list consumes CPU.

This is my test report, please check.
[Test-Result.txt](https://github.com/antirez/redis/files/1202276/Test-Result.txt)


Signed-off-by: Bo Cai <charpty@gmail.com>