### PR TITLE
Fixed redis.conf documentation; two -> three

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -915,7 +915,7 @@ lua-time-limit 5000
 #
 # In order to make Redis Cluster working in such environments, a static
 # configuration where each node known its public address is needed. The
-# following two options are used for this scope, and are:
+# following three options are used for this scope, and are:
 #
 # * cluster-announce-ip
 # * cluster-announce-port


### PR DESCRIPTION
Three options are listed, not two.