### PR TITLE
Delete client nodes faster in unlinkClient

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -131,6 +131,26 @@ list *listAddNodeTail(list *list, void *value)
     return list;
 }
 
+listNode *listAddAndReturnNode(list *list, void *value)
+{
+    listNode *node;
+
+    if ((node = zmalloc(sizeof(*node))) == NULL)
+        return NULL;
+    node->value = value;
+    if (list->len == 0) {
+        list->head = list->tail = node;
+        node->prev = node->next = NULL;
+    } else {
+        node->prev = list->tail;
+        node->next = NULL;
+        list->tail->next = node;
+        list->tail = node;
+    }
+    list->len++;
+    return node;
+}
+
 list *listInsertNode(list *list, listNode *old_node, void *value, int after) {
     listNode *node;
 

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -75,6 +75,7 @@ void listRelease(list *list);
 void listEmpty(list *list);
 list *listAddNodeHead(list *list, void *value);
 list *listAddNodeTail(list *list, void *value);
+listNode *listAddAndReturnNode(list *list, void *value);
 list *listInsertNode(list *list, listNode *old_node, void *value, int after);
 void listDelNode(list *list, listNode *node);
 listIter *listGetIterator(list *list, int direction);

--- a/src/networking.c
+++ b/src/networking.c
@@ -135,7 +135,9 @@ client *createClient(int fd) {
     c->peerid = NULL;
     listSetFreeMethod(c->pubsub_patterns,decrRefCountVoid);
     listSetMatchMethod(c->pubsub_patterns,listMatchObjects);
-    if (fd != -1) listAddNodeTail(server.clients,c);
+    if (fd != -1) {
+    	c->list_node = listAddAndReturnNode(server.clients,c);
+    }
     initClientMultiState(c);
     return c;
 }
@@ -743,7 +745,7 @@ void unlinkClient(client *c) {
      * fd is already set to -1. */
     if (c->fd != -1) {
         /* Remove from the list of active clients. */
-        ln = listSearchKey(server.clients,c);
+        ln = c->list_node;
         serverAssert(ln != NULL);
         listDelNode(server.clients,ln);
 

--- a/src/server.h
+++ b/src/server.h
@@ -722,6 +722,7 @@ typedef struct client {
     dict *pubsub_channels;  /* channels a client is interested in (SUBSCRIBE) */
     list *pubsub_patterns;  /* patterns a client is interested in (SUBSCRIBE) */
     sds peerid;             /* Cached peer ID. */
+    listNode* list_node;    /* Pointer to the node in clients list */
 
     /* Response buffer */
     int bufpos;


### PR DESCRIPTION
This commit contains following changes:
1 Add a node pointer member in client structure

2 Add a helper function in adlist to return the
client node after appending a new client object

3 When about to delete the client node in list,
We use clients's node pointer instead of iterating
the whole list by listSearchKey function

This commit looks like a workaround but it actually
works in production. When redis is dealing with 
short connections(connect. do stuff, disconnect),
this change could make redis perform 8% more qps. 