### PR TITLE
Optimize hgetall latency for large hash table

### DIFF
--- a/src/dict.h
+++ b/src/dict.h
@@ -96,6 +96,7 @@ typedef struct dictIterator {
 
 typedef void (dictScanFunction)(void *privdata, const dictEntry *de);
 typedef void (dictScanBucketFunction)(void *privdata, dictEntry **bucketref);
+typedef void (dictEachFunction)(void *privdata, const dictEntry **entries, const int number);
 
 /* This is the initial size of every hash table */
 #define DICT_HT_INITIAL_SIZE     4
@@ -178,6 +179,7 @@ int dictRehashMilliseconds(dict *d, int ms);
 void dictSetHashFunctionSeed(uint8_t *seed);
 uint8_t *dictGetHashFunctionSeed(void);
 unsigned long dictScan(dict *d, unsigned long v, dictScanFunction *fn, dictScanBucketFunction *bucketfn, void *privdata);
+void dictEach(dict *d, dictEachFunction *fn, void *privdata);
 unsigned int dictGetHash(dict *d, const void *key);
 dictEntry **dictFindEntryRefByPtrAndHash(dict *d, const void *oldptr, unsigned int hash);
 


### PR DESCRIPTION
A hash gets converted to dict encoding if it's getting, depends on the configuration, more than 512 entries by default.  Iterating such a large hash table using the iteration api takes quite some cpu cycles and generated more cache misses then necessary. This merge request uses a dedicated iterate all function to traverse the whole dict to generate hgetall, hkeys and hvals response, which can reduce latency by 1 ~ 5% depends on size of the dict.

The code to generate test data and benchmark the difference [can be found here](https://gist.github.com/sunxiaoguang/f92c705bff965eb6854da1e5ffb7b4af). Please use the '[optimize_hgetall_unstable_comparaison](https://github.com/sunxiaoguang/redis/tree/optimize_hgetall_unstable_comparaison)' branch which contains commands for both the original implementation and new implementation for reference.

Some test run of the benchmark program on a E5-2670 v3 server demonstrate for a 16000 fields hash table (the test h5) the new way can save couple hundreds of microseconds on average for a hgetall call. Running the same test on servers with less cache can observe some more improvements as the iterator way access data in a more scattered way therefore renders cache less efficient.
