### PR TITLE
Standard geohash range

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -712,28 +712,7 @@ void geohashCommand(client *c) {
         if (!zobj || zsetScore(zobj, c->argv[j]->ptr, &score) == C_ERR) {
             addReply(c,shared.nullbulk);
         } else {
-            /* The internal format we use for geocoding is a bit different
-             * than the standard, since we use as initial latitude range
-             * -85,85, while the normal geohashing algorithm uses -90,90.
-             * So we have to decode our position and re-encode using the
-             * standard ranges in order to output a valid geohash string. */
-
-            /* Decode... */
-            double xy[2];
-            if (!decodeGeohash(score,xy)) {
-                addReply(c,shared.nullbulk);
-                continue;
-            }
-
-            /* Re-encode */
-            GeoHashRange r[2];
-            GeoHashBits hash;
-            r[0].min = -180;
-            r[0].max = 180;
-            r[1].min = -90;
-            r[1].max = 90;
-            geohashEncode(&r[0],&r[1],xy[0],xy[1],26,&hash);
-
+            GeoHashBits hash = { .bits = (uint64_t)score, .step = GEO_STEP_MAX };
             char buf[12];
             int i;
             for (i = 0; i < 11; i++) {

--- a/src/geohash.h
+++ b/src/geohash.h
@@ -47,8 +47,8 @@ extern "C" {
 #define GEO_STEP_MAX 26 /* 26*2 = 52 bits. */
 
 /* Limits from EPSG:900913 / EPSG:3785 / OSGEO:41001 */
-#define GEO_LAT_MIN -85.05112878
-#define GEO_LAT_MAX 85.05112878
+#define GEO_LAT_MIN -90
+#define GEO_LAT_MAX 90
 #define GEO_LONG_MIN -180
 #define GEO_LONG_MAX 180
 

--- a/src/geohash.h
+++ b/src/geohash.h
@@ -45,8 +45,6 @@ extern "C" {
 #define RANGEPISZERO(r) (r == NULL || RANGEISZERO(*r))
 
 #define GEO_STEP_MAX 26 /* 26*2 = 52 bits. */
-
-/* Limits from EPSG:900913 / EPSG:3785 / OSGEO:41001 */
 #define GEO_LAT_MIN -90
 #define GEO_LAT_MAX 90
 #define GEO_LONG_MIN -180

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -87,7 +87,7 @@ start_server {tags {"geo"}} {
 
     test {Check geoset values} {
         r zrange nyc 0 -1 withscores
-    } {{wtc one} 1791873972053020 {union square} 1791875485187452 {central park n/q/r} 1791875761332224 4545 1791875796750882 {lic market} 1791875804419201 q4 1791875830079666 jfk 1791895905559723}
+    } {{wtc one} 1790792717967708 {union square} 1790794228219197 {central park n/q/r} 1790794506182737 4545 1790794539058999 {lic market} 1790794547385489 q4 1790794583519667 jfk 1790816808657070}
 
     test {GEORADIUS simple (sorted)} {
         r georadius nyc -73.9798091 40.7598464 3 km asc
@@ -95,7 +95,7 @@ start_server {tags {"geo"}} {
 
     test {GEORADIUS withdist (sorted)} {
         r georadius nyc -73.9798091 40.7598464 3 km withdist asc
-    } {{{central park n/q/r} 0.7750} {4545 2.3651} {{union square} 2.7697}}
+    } {{{central park n/q/r} 0.7750} {4545 2.3652} {{union square} 2.7695}}
 
     test {GEORADIUS with COUNT} {
         r georadius nyc -73.9798091 40.7598464 10 km COUNT 3
@@ -121,7 +121,7 @@ start_server {tags {"geo"}} {
 
     test {GEORADIUSBYMEMBER withdist (sorted)} {
         r georadiusbymember nyc "wtc one" 7 km withdist
-    } {{{wtc one} 0.0000} {{union square} 3.2544} {{central park n/q/r} 6.7000} {4545 6.1975} {{lic market} 6.8969}}
+    } {{{wtc one} 0.0000} {{union square} 3.2545} {{central park n/q/r} 6.7000} {4545 6.1974} {{lic market} 6.8969}}
 
     test {GEOHASH is able to return geohash strings} {
         # Example from Wikipedia.


### PR DESCRIPTION
Suggestion: Change GEO_LAT_MIN and GEO_LAT_MAX default values (geohash.h) to use the same range as in the Geohash standard, instead of EPSG:3785. This removes the need to decode/reencode hash values each time the geohashCommand (geo.c) is called. Need to adjusted the unit tests. Preexisting stored geo data would have to be adjusted