### PR TITLE
Update the comment for OBJ_ENCODING_EMBSTR_SIZE_LIMIT's value

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -111,7 +111,7 @@ robj *createEmbeddedStringObject(const char *ptr, size_t len) {
  * OBJ_ENCODING_EMBSTR_SIZE_LIMIT, otherwise the RAW encoding is
  * used.
  *
- * The current limit of 39 is chosen so that the biggest string object
+ * The current limit of 44 is chosen so that the biggest string object
  * we allocate as EMBSTR will still fit into the 64 byte arena of jemalloc. */
 #define OBJ_ENCODING_EMBSTR_SIZE_LIMIT 44
 robj *createStringObject(const char *ptr, size_t len) {


### PR DESCRIPTION
The value of OBJ_ENCODING_EMBSTR_SIZE_LIMIT is 44 now instead of 39.