### PR TITLE
MUL aggregate in zinterstore and zunionstore

### DIFF
--- a/src/help.h
+++ b/src/help.h
@@ -928,7 +928,7 @@ struct commandHelp {
     4,
     "1.2.0" },
     { "ZINTERSTORE",
-    "destination numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX]",
+    "destination numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX|MUL]",
     "Intersect multiple sorted sets and store the resulting sorted set in a new key",
     4,
     "2.0.0" },
@@ -1008,7 +1008,7 @@ struct commandHelp {
     4,
     "1.2.0" },
     { "ZUNIONSTORE",
-    "destination numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX]",
+    "destination numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX|MUL]",
     "Add multiple sorted sets and store the resulting sorted set in a new key",
     4,
     "2.0.0" }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2091,6 +2091,7 @@ int zuiCompareByCardinality(const void *s1, const void *s2) {
 #define REDIS_AGGR_SUM 1
 #define REDIS_AGGR_MIN 2
 #define REDIS_AGGR_MAX 3
+#define REDIS_AGGR_MUL 4
 #define zunionInterDictValue(_e) (dictGetVal(_e) == NULL ? 1.0 : *(double*)dictGetVal(_e))
 
 inline static void zunionInterAggregate(double *target, double val, int aggregate) {
@@ -2104,6 +2105,8 @@ inline static void zunionInterAggregate(double *target, double val, int aggregat
         *target = val < *target ? val : *target;
     } else if (aggregate == REDIS_AGGR_MAX) {
         *target = val > *target ? val : *target;
+    } else if (aggregate == REDIS_AGGR_MUL) {
+        *target = *target * val;
     } else {
         /* safety net */
         serverPanic("Unknown ZUNION/INTER aggregate type");
@@ -2200,6 +2203,8 @@ void zunionInterGenericCommand(client *c, robj *dstkey, int op) {
                     aggregate = REDIS_AGGR_MIN;
                 } else if (!strcasecmp(c->argv[j]->ptr,"max")) {
                     aggregate = REDIS_AGGR_MAX;
+                } else if (!strcasecmp(c->argv[j]->ptr,"mul")) {
+                    aggregate = REDIS_AGGR_MUL;
                 } else {
                     zfree(src);
                     addReply(c,shared.syntaxerr);

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -584,6 +584,11 @@ start_server {tags {"zset"}} {
             assert_equal {a 1 b 2 c 3 d 3} [r zrange zsetc 0 -1 withscores]
         }
 
+        test "ZUNIONSTORE with AGGREGATE MUL - $encoding" {
+            assert_equal 4 [r zunionstore zsetc 2 zseta zsetb aggregate mul]
+            assert_equal {a 1 b 2 d 3 c 6} [r zrange zsetc 0 -1 withscores]
+        }
+
         test "ZINTERSTORE basics - $encoding" {
             assert_equal 2 [r zinterstore zsetc 2 zseta zsetb]
             assert_equal {b 3 c 5} [r zrange zsetc 0 -1 withscores]
@@ -611,6 +616,11 @@ start_server {tags {"zset"}} {
         test "ZINTERSTORE with AGGREGATE MAX - $encoding" {
             assert_equal 2 [r zinterstore zsetc 2 zseta zsetb aggregate max]
             assert_equal {b 2 c 3} [r zrange zsetc 0 -1 withscores]
+        }
+
+        test "ZINTERSTORE with AGGREGATE MUL - $encoding" {
+            assert_equal 2 [r zinterstore zsetc 2 zseta zsetb aggregate mul]
+            assert_equal {b 2 c 6} [r zrange zsetc 0 -1 withscores]
         }
 
         foreach cmd {ZUNIONSTORE ZINTERSTORE} {


### PR DESCRIPTION
Adding MUL aggregate to zset inter/union store is trivial yet it allows weighting one set with another, which is very useful in some applications (e.g., in text mining - weighting term frequency with inverse document frequency).