### PR TITLE
Removed duplicate boundary conditions in geohash to check north/south pole

### DIFF
--- a/src/geohash.c
+++ b/src/geohash.c
@@ -135,11 +135,6 @@ int geohashEncode(const GeoHashRange *long_range, const GeoHashRange *lat_range,
     hash->bits = 0;
     hash->step = step;
 
-    if (latitude < lat_range->min || latitude > lat_range->max ||
-        longitude < long_range->min || longitude > long_range->max) {
-        return 0;
-    }
-
     double lat_offset =
         (latitude - lat_range->min) / (lat_range->max - lat_range->min);
     double long_offset =

--- a/src/geohash.c
+++ b/src/geohash.c
@@ -127,8 +127,10 @@ int geohashEncode(const GeoHashRange *long_range, const GeoHashRange *lat_range,
 
     /* Return an error when trying to index outside the supported
      * constraints. */
-    if (longitude > 180 || longitude < -180 ||
-        latitude > 85.05112878 || latitude < -85.05112878) return 0;
+    if (latitude < lat_range->min || latitude > lat_range->max ||
+        longitude < long_range->min || longitude > long_range->max) {
+        return 0;
+    }
 
     hash->bits = 0;
     hash->step = step;


### PR DESCRIPTION
Before Change:
The boundary conditions to check for North and South poles are checked twice in geohashEncode function of geohash.c. 

After Change:
I've replaced the check having hard coded constants with the lat_range &  lon_range variables. These variables are set  to the same boundary constants by geohashGetCoordRange function.

Impact:
No external impact as only the duplicated condition is removed. 
How? The lat_range and lon_range variables are always set before calling geohashEncode in geohashEncodeType by calling geohashGetCoordRange. 
Why? The dependency of calling geohashGetCoordRange before geohashEncode always has to be there because the same lat_range & lon_range variables are used to calculate offsets later inside geohashEncode.