### PR TITLE
Add input validity checking to redis cluster config slot numbers

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -243,6 +243,9 @@ int clusterLoadConfig(char *filename) {
                 *p = '\0';
                 direction = p[1]; /* Either '>' or '<' */
                 slot = atoi(argv[j]+1);
+                if (slot < 0 || slot >= CLUSTER_SLOTS) {
+                    serverPanic("Bad slot number in cluster config file");
+                }
                 p += 3;
                 cn = clusterLookupNode(p);
                 if (!cn) {


### PR DESCRIPTION
Provide a clear error message in the event of a bad slot number
from the redis cluster config file, instead of continuing on and
potentially crashing shortly thereafter when the migrating_slots
arrays are written to.

Resolves https://github.com/antirez/redis/issues/4278