### PR TITLE
Modules: handle NULL pointer in BlockClient

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -5333,6 +5333,13 @@ void unblockClientFromModule(client *c) {
     bc->client = NULL;
 }
 
+/* The default timeout callback for blocked module client. */
+int moduleBlockedClientDefaultTimeout(RedisModuleCtx *ctx, void **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    return RM_ReplyWithError(ctx, "ERR blocked module command timed out, but timeout callback is NULL");
+}
+
 /* Block a client in the context of a module: this function implements both
  * RM_BlockClient() and RM_BlockClientOnKeys() depending on the fact the
  * keys are passed or not.
@@ -5370,7 +5377,7 @@ RedisModuleBlockedClient *moduleBlockClient(RedisModuleCtx *ctx, RedisModuleCmdF
     bc->client = (islua || ismulti) ? NULL : c;
     bc->module = ctx->module;
     bc->reply_callback = reply_callback;
-    bc->timeout_callback = timeout_callback;
+    bc->timeout_callback = timeout_callback ? timeout_callback : moduleBlockedClientDefaultTimeout;
     bc->disconnect_callback = NULL; /* Set by RM_SetDisconnectCallback() */
     bc->free_privdata = free_privdata;
     bc->privdata = privdata;

--- a/src/module.c
+++ b/src/module.c
@@ -5760,6 +5760,7 @@ void moduleBlockedClientTimedOut(client *c) {
     ctx.blocked_client = bc;
     ctx.blocked_privdata = bc->privdata;
     bc->timeout_callback(&ctx,(void**)c->argv,c->argc);
+    moduleHandlePropagationAfterCommandCallback(&ctx);
     moduleFreeContext(&ctx);
     if (!bc->blocked_on_keys) {
         updateStatsOnUnblock(c, bc->background_duration, 0);


### PR DESCRIPTION
Redis may crash if we pass a NULL `timeout_callback` to module API `RedisModule_BlockClient`, because we doesn't check the `timeout_callback` when the client really reach the timeout.

The `timeout_callback` can only be executed when it is not NULL, and we should reply -1 to client
 when `timeout_callback` is NULL to tell client that timeout occurs.