### PR TITLE
Code cleanup, resolve an issue identified by cppcheck

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -504,7 +504,9 @@ robj *lookupStringForBitCommand(client *c, size_t maxbit) {
  * If the source object is NULL the function is guaranteed to return NULL
  * and set 'len' to 0. */
 unsigned char *getObjectReadOnlyString(robj *o, long *len, char *llbuf) {
-    serverAssert(o->type == OBJ_STRING);
+    if (o) {
+        serverAssert(o->type == OBJ_STRING);
+    }
     unsigned char *p = NULL;
 
     /* Set the 'p' pointer to the string, that can be just a stack allocated

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -504,9 +504,7 @@ robj *lookupStringForBitCommand(client *c, size_t maxbit) {
  * If the source object is NULL the function is guaranteed to return NULL
  * and set 'len' to 0. */
 unsigned char *getObjectReadOnlyString(robj *o, long *len, char *llbuf) {
-    if (o) {
-        serverAssert(o->type == OBJ_STRING);
-    }
+    serverAssert(!o || o->type == OBJ_STRING);
     unsigned char *p = NULL;
 
     /* Set the 'p' pointer to the string, that can be just a stack allocated


### PR DESCRIPTION
[src/bitops.c:512] -> [src/bitops.c:507]: (warning) Either the condition 'if(o&&o->encoding==1)' is redundant or there is possible null pointer dereference: o.