### PR TITLE
 Fix a thread sync problem

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -144,12 +144,12 @@ int aeCreateFileEvent(aeEventLoop *eventLoop, int fd, int mask,
 
     if (aeApiAddEvent(eventLoop, fd, mask) == -1)
         return AE_ERR;
-    fe->mask |= mask;
     if (mask & AE_READABLE) fe->rfileProc = proc;
     if (mask & AE_WRITABLE) fe->wfileProc = proc;
     fe->clientData = clientData;
     if (fd > eventLoop->maxfd)
         eventLoop->maxfd = fd;
+    fe->mask |= mask;
     return AE_OK;
 }
 


### PR DESCRIPTION
issue #4371 The event library has a thread bug
When thread 1 add file event to thread 2 and thread 1 run on line 147, while thread 2 is calling file event (rfileProc or wfileProc), but the variable rfileProc, wfileProc and clientData of fe is old version, is from last registrar, not current, then thread 2 would call wrong callback funtion with wrong clientData. At last, the program may crash.