### PR TITLE
Add tests for stringmatch

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -1461,20 +1461,6 @@ static void ql_info(quicklist *ql) {
 #endif
 }
 
-/* Return the UNIX time in microseconds */
-static long long ustime(void) {
-    struct timeval tv;
-    long long ust;
-
-    gettimeofday(&tv, NULL);
-    ust = ((long long)tv.tv_sec) * 1000000;
-    ust += tv.tv_usec;
-    return ust;
-}
-
-/* Return the UNIX time in milliseconds */
-static long long mstime(void) { return ustime() / 1000; }
-
 /* Iterate over an entire quicklist.
  * Print the list if 'print' == 1.
  *

--- a/src/server.c
+++ b/src/server.c
@@ -3690,8 +3690,10 @@ int main(int argc, char **argv) {
             return sha1Test(argc, argv);
         } else if (!strcasecmp(argv[2], "util")) {
             return utilTest(argc, argv);
+#ifdef SDS_TEST_MAIN
         } else if (!strcasecmp(argv[2], "sds")) {
             return sdsTest(argc, argv);
+#endif
         } else if (!strcasecmp(argv[2], "endianconv")) {
             return endianconvTest(argc, argv);
         } else if (!strcasecmp(argv[2], "crc64")) {

--- a/src/server.c
+++ b/src/server.c
@@ -396,22 +396,6 @@ err:
     if (!log_to_stdout) close(fd);
 }
 
-/* Return the UNIX time in microseconds */
-long long ustime(void) {
-    struct timeval tv;
-    long long ust;
-
-    gettimeofday(&tv, NULL);
-    ust = ((long long)tv.tv_sec)*1000000;
-    ust += tv.tv_usec;
-    return ust;
-}
-
-/* Return the UNIX time in milliseconds */
-mstime_t mstime(void) {
-    return ustime()/1000;
-}
-
 /* After an RDB dump or AOF rewrite we exit from children using _exit() instead of
  * exit(), because the latter may interact with the same file objects used by
  * the parent process. However if we are testing the coverage normal exit() is

--- a/src/server.h
+++ b/src/server.h
@@ -49,8 +49,6 @@
 #include <lua.h>
 #include <signal.h>
 
-typedef long long mstime_t; /* millisecond time type. */
-
 #include "ae.h"      /* Event driven programming library */
 #include "sds.h"     /* Dynamic safe strings */
 #include "dict.h"    /* Hash tables */
@@ -1321,8 +1319,6 @@ void moduleAcquireGIL(void);
 void moduleReleaseGIL(void);
 
 /* Utils */
-long long ustime(void);
-long long mstime(void);
 void getRandomHexChars(char *p, unsigned int len);
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
 void exitFromChild(int retcode);

--- a/src/util.c
+++ b/src/util.c
@@ -43,6 +43,22 @@
 #include "util.h"
 #include "sha1.h"
 
+/* Return the UNIX time in microseconds */
+long long ustime(void) {
+    struct timeval tv;
+    long long ust;
+
+    gettimeofday(&tv, NULL);
+    ust = ((long long)tv.tv_sec)*1000000;
+    ust += tv.tv_usec;
+    return ust;
+}
+
+/* Return the UNIX time in milliseconds */
+mstime_t mstime(void) {
+    return ustime()/1000;
+}
+
 /* Glob-style pattern matching. */
 int stringmatchlen(const char *pattern, int patternLen,
         const char *string, int stringLen, int nocase)

--- a/src/util.c
+++ b/src/util.c
@@ -735,6 +735,8 @@ static void test_stringmatch(void) {
     test_stringmatch_helper("a.*.c.*.e", "a.b.c.d.d", 0);
     test_stringmatch_helper("a.*.c.*.e", "aa.bb.cc.dd.ee", 0);
     test_stringmatch_helper("a.*.c.*.e", "a.bb.c.dd.e", 1);
+    test_stringmatch_helper("a*c*e", "a.b.c.d.e", 1);
+    test_stringmatch_helper("a***e", "abcde", 1);
 }
 
 static void test_string2ll(void) {

--- a/src/util.h
+++ b/src/util.h
@@ -33,6 +33,10 @@
 #include <stdint.h>
 #include "sds.h"
 
+typedef long long mstime_t; /* millisecond time type. */
+
+long long ustime(void);
+long long mstime(void);
 int stringmatchlen(const char *p, int plen, const char *s, int slen, int nocase);
 int stringmatch(const char *p, const char *s, int nocase);
 long long memtoll(const char *p, int *err);


### PR DESCRIPTION
Only add add sds tests to `redis-server test` if SDS_TEST_MAIN is defined.
Moved `ustime` and `mstime` to util.[ch] and removed duplicate implementation from `quicklist.c`
Added tests from `stringmatch` including timing.