### PR TITLE
Feature optimize close client

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -131,6 +131,32 @@ list *listAddNodeTail(list *list, void *value)
     return list;
 }
 
+/* Add a new node to the list, to tail, containing the specified 'value'
+ * pointer as value.
+ *
+ * On error, NULL is returned and no operation is performed (i.e. the
+ * list remains unaltered).
+ * On success the 'listNode' pointer insert into the list is returned. */
+listNode *listAddNodeTailReturnNode(list *list, void *value)
+{
+    listNode *node;
+
+    if ((node = zmalloc(sizeof(*node))) == NULL)
+        return NULL;
+    node->value = value;
+    if (list->len == 0) {
+        list->head = list->tail = node;
+        node->prev = node->next = NULL;
+    } else {
+        node->prev = list->tail;
+        node->next = NULL;
+        list->tail->next = node;
+        list->tail = node;
+    }
+    list->len++;
+    return node;
+}
+
 list *listInsertNode(list *list, listNode *old_node, void *value, int after) {
     listNode *node;
 

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -75,6 +75,7 @@ void listRelease(list *list);
 void listEmpty(list *list);
 list *listAddNodeHead(list *list, void *value);
 list *listAddNodeTail(list *list, void *value);
+listNode *listAddNodeTailReturnNode(list *list, void *value);
 list *listInsertNode(list *list, listNode *old_node, void *value, int after);
 void listDelNode(list *list, listNode *node);
 listIter *listGetIterator(list *list, int direction);

--- a/src/networking.c
+++ b/src/networking.c
@@ -747,8 +747,6 @@ void unlinkClient(client *c) {
             listDelNode(server.clients,c->client_list_node);
             c->client_list_node = NULL;
         }
-        serverAssert(ln != NULL);
-        listDelNode(server.clients,ln);
 
         /* Unregister async I/O handlers and close the socket. */
         aeDeleteFileEvent(server.el,c->fd,AE_READABLE);

--- a/src/networking.c
+++ b/src/networking.c
@@ -135,7 +135,7 @@ client *createClient(int fd) {
     c->peerid = NULL;
     listSetFreeMethod(c->pubsub_patterns,decrRefCountVoid);
     listSetMatchMethod(c->pubsub_patterns,listMatchObjects);
-    if (fd != -1) listAddNodeTail(server.clients,c);
+    if (fd != -1) c->client_list_node = listAddNodeTailReturnNode(server.clients,c);
     initClientMultiState(c);
     return c;
 }
@@ -743,7 +743,10 @@ void unlinkClient(client *c) {
      * fd is already set to -1. */
     if (c->fd != -1) {
         /* Remove from the list of active clients. */
-        ln = listSearchKey(server.clients,c);
+        if (c->client_list_node) {
+            listDelNode(server.clients,c->client_list_node);
+            c->client_list_node = NULL;
+        }
         serverAssert(ln != NULL);
         listDelNode(server.clients,ln);
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -2205,7 +2205,7 @@ void replicationResurrectCachedMaster(int newfd) {
     server.repl_state = REPL_STATE_CONNECTED;
 
     /* Re-add to the list of clients. */
-    listAddNodeTail(server.clients,server.master);
+    server.master->client_list_node = listAddNodeTailReturnNode(server.clients,server.master);
     if (aeCreateFileEvent(server.el, newfd, AE_READABLE,
                           readQueryFromClient, server.master)) {
         serverLog(LL_WARNING,"Error resurrecting the cached master, impossible to add the readable handler: %s", strerror(errno));

--- a/src/server.h
+++ b/src/server.h
@@ -722,6 +722,7 @@ typedef struct client {
     dict *pubsub_channels;  /* channels a client is interested in (SUBSCRIBE) */
     list *pubsub_patterns;  /* patterns a client is interested in (SUBSCRIBE) */
     sds peerid;             /* Cached peer ID. */
+    listNode *client_list_node; /* list node in client list */
 
     /* Response buffer */
     int bufpos;


### PR DESCRIPTION
The vanilla version use listSearchKey(server.clients,c) to find a client when free a client, it costs too much cpu cycle and has bad performance, in the new code we use client_list_node to save the node of  the double linked list, so we can remove the node from the list immediately. the complexity of algorithm change from o(N) to o(1). it has 30 percent performance improvement in short connection benchmark test.

