### PR TITLE
add current_timestamp in info command

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2851,7 +2851,8 @@ sds genRedisInfoString(char *section) {
             "hz:%d\r\n"
             "lru_clock:%ld\r\n"
             "executable:%s\r\n"
-            "config_file:%s\r\n",
+            "config_file:%s\r\n"
+            "current_timestamp:%jd\r\n",
             REDIS_VERSION,
             redisGitSHA1(),
             strtol(redisGitDirty(),NULL,10) > 0,
@@ -2874,7 +2875,8 @@ sds genRedisInfoString(char *section) {
             server.hz,
             (unsigned long) lruclock,
             server.executable ? server.executable : "",
-            server.configfile ? server.configfile : "");
+            server.configfile ? server.configfile : "",
+            server.unixtime);
     }
 
     /* Clients */


### PR DESCRIPTION
adding current_timestamp in info command.
for monitoring, if we add current_timestamp we can sort info result with current_timestamp.

why not used uptime.
when redis server is down, redis uptime will be set as 0, so sometimes it is hard to sort in some time range. 