### PR TITLE
Use RELEASENOTES date instead of build date

### DIFF
--- a/src/mkreleasehdr.sh
+++ b/src/mkreleasehdr.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 GIT_SHA1=`(git show-ref --head --hash=8 2> /dev/null || echo 00000000) | head -n1`
 GIT_DIRTY=`git diff --no-ext-diff 2> /dev/null | wc -l`
-BUILD_ID=`uname -n`"-"`date +%s`
+BUILD_ID=`uname -n`"-"`date -r ../00-RELEASENOTES +%s`
 test -f release.h || touch release.h
 (cat release.h | grep SHA1 | grep $GIT_SHA1) && \
 (cat release.h | grep DIRTY | grep $GIT_DIRTY) && exit 0 # Already up-to-date

--- a/src/mkreleasehdr.sh
+++ b/src/mkreleasehdr.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 GIT_SHA1=`(git show-ref --head --hash=8 2> /dev/null || echo 00000000) | head -n1`
 GIT_DIRTY=`git diff --no-ext-diff 2> /dev/null | wc -l`
-BUILD_ID=`uname -n`"-"`date -r ../00-RELEASENOTES +%s`
+BUILD_ID=${HOST:-`uname -n`}"-"`date -r ../00-RELEASENOTES +%s`
 test -f release.h || touch release.h
 (cat release.h | grep SHA1 | grep $GIT_SHA1) && \
 (cat release.h | grep DIRTY | grep $GIT_DIRTY) && exit 0 # Already up-to-date


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.