### PR TITLE
Fix typos in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -606,7 +606,7 @@ slave-priority 100
 # deletion of the object. It means that the server stops processing new commands
 # in order to reclaim all the memory associated with an object in a synchronous
 # way. If the key deleted is associated with a small object, the time needed
-# in order to execute th DEL command is very small and comparable to most other
+# in order to execute the DEL command is very small and comparable to most other
 # O(1) or O(log_N) commands in Redis. However if the key is associated with an
 # aggregated value containing millions of elements, the server can block for
 # a long time (even seconds) in order to complete the operation.
@@ -637,7 +637,7 @@ slave-priority 100
 #    it with the specified string.
 # 4) During replication, when a slave performs a full resynchronization with
 #    its master, the content of the whole database is removed in order to
-#    load the RDB file just transfered.
+#    load the RDB file just transferred.
 #
 # In all the above cases the default is to delete objects in a blocking way,
 # like if DEL was called. However you can configure each case specifically


### PR DESCRIPTION
Fix for 2 small typos I noticed in the config file 🙂 