### PR TITLE
Fix redis-trib.rb will fail when migrate a slot with key.

### DIFF
--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -935,11 +935,11 @@ class RedisTrib
             keys = source.r.cluster("getkeysinslot",slot,o[:pipeline])
             break if keys.length == 0
             begin
-                source.r.client.call(["migrate",target.info[:host],target.info[:port],"",0,@timeout,:keys,*keys])
+                source.r.call(["migrate",target.info[:host],target.info[:port],"",0,@timeout,:keys,*keys])
             rescue => e
                 if o[:fix] && e.to_s =~ /BUSYKEY/
                     xputs "*** Target key exists. Replacing it for FIX."
-                    source.r.client.call(["migrate",target.info[:host],target.info[:port],"",0,@timeout,:replace,:keys,*keys])
+                    source.r.call(["migrate",target.info[:host],target.info[:port],"",0,@timeout,:replace,:keys,*keys])
                 else
                     puts ""
                     xputs "[ERR] Calling MIGRATE: #{e}"
@@ -1483,7 +1483,7 @@ class RedisTrib
                     cmd = ["migrate",target.info[:host],target.info[:port],k,0,@timeout]
                     cmd << :copy if use_copy
                     cmd << :replace if use_replace
-                    source.client.call(cmd)
+                    source.call(cmd)
                 rescue => e
                     puts e
                 else


### PR DESCRIPTION
The redis-trib.rb call the wrong function which is command client with empty arguments when migrate keys in a slot.