### PR TITLE
PSYNC2: safe free backlog when reach the time limit and others

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1999,6 +1999,9 @@ void bgsaveCommand(client *c) {
         }
     }
 
+    rdbSaveInfo rsi, *rsiptr;
+    rsiptr = rdbPopulateSaveInfo(&rsi);
+
     if (server.rdb_child_pid != -1) {
         addReplyError(c,"Background save already in progress");
     } else if (server.aof_child_pid != -1) {
@@ -2011,7 +2014,7 @@ void bgsaveCommand(client *c) {
                 "Use BGSAVE SCHEDULE in order to schedule a BGSAVE whenever "
                 "possible.");
         }
-    } else if (rdbSaveBackground(server.rdb_filename,NULL) == C_OK) {
+    } else if (rdbSaveBackground(server.rdb_filename,rsiptr) == C_OK) {
         addReplyStatus(c,"Background saving started");
     } else {
         addReply(c,shared.err);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2045,15 +2045,12 @@ rdbSaveInfo *rdbPopulateSaveInfo(rdbSaveInfo *rsi) {
      * scenario which can make repl_stream_db be -1, that is the instance is
      * a master, and it have repl_backlog, but server.slaveseldb is -1. */
     if (!server.masterhost && server.repl_backlog) {
-        rsi->repl_stream_db = server.slaveseldb;
-        /* Note that server.slaveseldb may be -1, it means that this master
-         * didn't apply any write commands after a full synchronization,
-         * so we can leave the currently selected DB set to -1, because the
-         * next write command must generate a SELECT statement. This allows
-         * a restarted slave to reload replication ID/offset even the repl_stream_db
-         * is -1, but we should not do that, because older implementations
-         * may save a repl_stream_db as -1 in a wrong way. Maybe we can fix
-         * it in the next release version. */
+        rsi->repl_stream_db = server.slaveseldb == -1 ? 0 : server.slaveseldb;
+        /* Note that when server.slaveseldb is -1, it means that this master
+         * didn't apply any write commands after a full synchronization.
+         * So we can let repl_stream_db be 0, this allows a restarted slave
+         * to reload replication ID/offset, it's safe because the next write
+         * command must generate a SELECT statement. */
         return rsi;
     }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2054,10 +2054,24 @@ rdbSaveInfo *rdbPopulateSaveInfo(rdbSaveInfo *rsi) {
         return rsi;
     }
 
-    /* If the instance is a slave we need a connected master in order to
-     * fetch the currently selected DB. */
+    /* If the instance is a slave we need a connected master
+     * in order to fetch the currently selected DB. */
     if (server.master) {
         rsi->repl_stream_db = server.master->db->id;
+        return rsi;
+    }
+    /* It is useful to persist cached_master's db id inside RDB file.
+     * When a slave lost master's connection, server.master will be
+     * cached as server.cached_master, after that a slave can not
+     * increment the master_repl_offset because slave only apply data
+     * from connected master, so the cached_master can hold right
+     * replication info. But please note that this action is safe
+     * only after we fix the free backlog problem, because when a master
+     * turn to be a slave, it will use itself as the server.cached_master,
+     * that is dangerous if we didn't use a new replication ID after
+     * free backlog. */
+    if (server.cached_master) {
+        rsi->repl_stream_db = server.cached_master->db->id;
         return rsi;
     }
     return NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -3536,7 +3536,8 @@ void loadDataFromDisk(void) {
                 rsi.repl_id_is_set &&
                 rsi.repl_offset != -1 &&
                 /* Note that older implementations may save a repl_stream_db
-                 * of -1 inside the RDB file. */
+                 * of -1 inside the RDB file in a wrong way, see more information
+                 * in function rdbPopulateSaveInfo. */
                 rsi.repl_stream_db != -1)
             {
                 memcpy(server.replid,rsi.repl_id,sizeof(server.replid));


### PR DESCRIPTION
This PR is a bugfix for issue #4407 .

1. Safe free backlog when reach the time limit 

    When we free the backlog, we should use a new
replication ID and clear the ID2. Since without
backlog we can not increment master_repl_offset
even do write commands, that may lead to inconsistency
when we try to connect a "slave-before" master
(if this master is our slave before, our replid
equals the master's replid2). As the master have our
history, so we can match the master's replid2 and
second_replid_offset, that make partial sync work,
but the data is inconsistent.

2. Fix the missing of rdbSaveInfo for BGSAVE

3. Clarify the scenario when repl_stream_db can be -1

4. Make `repl_stream_db` never be -1

    
    It means that after this change all the replication
info in RDB is valid, and it can distinguish us from
the older version.