### PR TITLE
fix multiple unblock for clientsArePaused()

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2126,9 +2126,9 @@ int clientsArePaused(void) {
         while ((ln = listNext(&li)) != NULL) {
             c = listNodeValue(ln);
 
-            /* Don't touch slaves and blocked clients. The latter pending
-             * requests be processed when unblocked. */
-            if (c->flags & (CLIENT_SLAVE|CLIENT_BLOCKED)) continue;
+            /* Don't touch slaves and blocked or unblocked clients.
+             * The latter pending requests be processed when unblocked. */
+            if (c->flags & (CLIENT_SLAVE|CLIENT_BLOCKED|CLIENT_UNBLOCKED)) continue;
             c->flags |= CLIENT_UNBLOCKED;
             listAddNodeTail(server.unblocked_clients,c);
         }

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1367,7 +1367,7 @@ void evalGenericCommand(client *c, int evalsha) {
          * script timeout was detected. */
         aeCreateFileEvent(server.el,c->fd,AE_READABLE,
                           readQueryFromClient,c);
-        if (server.masterhost && server.master) {
+        if (server.masterhost && server.master && !(server.master->flags & CLIENT_UNBLOCKED)) {
             server.master->flags |= CLIENT_UNBLOCKED;
             listAddNodeTail(server.unblocked_clients,server.master);
         }


### PR DESCRIPTION
hi, @antirez 

Client may unblocked more than once in the function `clientsArePaused()`, when we apply `BLPOP`, `LPUSH`, `CLIENT PAUSE` successively, and then the stack is:

```
aeProcessEvents()
|----rfileProc(readQueryFromClient)
        |----processInputBuffer()
                |----processCommand() client A: BLPOP
                |----processCommand() client B: LPUSH, then client A will be unblocked
                |----processCommand() client C: CLIENT PAUSE
|----processTimeEvents()
        |----serverCron
                |----updateCachedTime()
                |----clientsArePaused() OK, now we will put all clients including unblocked client A
                                        in unblocked clients queue, so client A will be unblocked twice.
|----beforeSleep()
        |----processUnblockedClients() Here client A will be processed twice.
```

Because in function `serverCron()` we call `clientsArePaused` after `updateCachedTime`, so that may let redis reach `server.clients_pause_end_time` and unblock the `BLPOP` client twice in one eventLoop.

Moreover, now client MASTER maybe unblocked in Lua timedout context in #5297, we should consider it seriously.