### PR TITLE
Improve variable naming for stream id parsing

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -634,7 +634,7 @@ int string2ull(const char *s, unsigned long long *value) {
 }
 
 /* Parse a stream ID in the format given by clients to Redis, that is
- * <ms>.<seq>, and converts it into a streamID structure. If
+ * <ms>-<seq>, and converts it into a streamID structure. If
  * the specified ID is invalid C_ERR is returned and an error is reported
  * to the client, otherwise C_OK is returned. The ID may be in incomplete
  * form, just stating the milliseconds time part of the stream. In such a case
@@ -659,13 +659,13 @@ int streamParseIDOrReply(client *c, robj *o, streamID *id, uint64_t missing_seq)
         return C_OK;
     }
 
-    /* Parse <ms>.<seq> form. */
-    char *dot = strchr(buf,'-');
-    if (dot) *dot = '\0';
+    /* Parse <ms>-<seq> form. */
+    char *sep = strchr(buf,'-');
+    if (sep) *sep = '\0';
     uint64_t ms, seq;
     if (string2ull(buf,&ms) == 0) goto invalid;
-    if (dot && string2ull(dot+1,&seq) == 0) goto invalid;
-    if (!dot) seq = missing_seq;
+    if (sep && string2ull(sep+1,&seq) == 0) goto invalid;
+    if (!sep) seq = missing_seq;
     id->ms = ms;
     id->seq = seq;
     return C_OK;


### PR DESCRIPTION
It also updates comments to match stream id format.

@antirez, this supersedes #4351. As discussed there, I'm using `sep` instead of the actual separator name.

HTH, thanks.