### PR TITLE
Detect a state where a module command is run inside an AOF loading

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1273,6 +1273,8 @@ int RM_GetSelectedDb(RedisModuleCtx *ctx) {
  * 
  *  * REDISMODULE_CTX_FLAGS_MULTI: The command is running inside a transaction
  * 
+ *  * REDISMODULE_CTX_FLAGS_AOFLOADING: The command is running by an AOF load
+ * 
  *  * REDISMODULE_CTX_FLAGS_MASTER: The Redis instance is a master
  * 
  *  * REDISMODULE_CTX_FLAGS_SLAVE: The Redis instance is a slave
@@ -1313,8 +1315,15 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
     }
 
     /* Persistence flags */
-    if (server.aof_state != AOF_OFF)
+    if (server.aof_state != AOF_OFF) {
         flags |= REDISMODULE_CTX_FLAGS_AOF;
+
+        /* AOF is enabled and we are in LOADING state. 
+         * This means the current client is actually Redis loading the AOF */
+        if (server.loading) {
+            flags |= REDISMODULE_CTX_FLAGS_AOF_LOADING;
+        }
+    }
     if (server.saveparamslen > 0)
         flags |= REDISMODULE_CTX_FLAGS_RDB;
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -73,13 +73,15 @@
 /* The instance is running in cluster mode */
 #define REDISMODULE_CTX_FLAGS_CLUSTER 0x0020
 /* The instance has AOF enabled */
-#define REDISMODULE_CTX_FLAGS_AOF 0x0040 //
+#define REDISMODULE_CTX_FLAGS_AOF 0x0040
 /* The instance has RDB enabled */
-#define REDISMODULE_CTX_FLAGS_RDB 0x0080 //
+#define REDISMODULE_CTX_FLAGS_RDB 0x0080
 /* The instance has Maxmemory set */
 #define REDISMODULE_CTX_FLAGS_MAXMEMORY 0x0100
 /* Maxmemory is set and has an eviction policy that may delete keys */
 #define REDISMODULE_CTX_FLAGS_EVICT 0x0200 
+/* The command is running from the context of a loading AOF file */
+#define REDISMODULE_CTX_FLAGS_AOF_LOADING 0x0400
 
 
 /* A special pointer that we can use between the core and the module to signal


### PR DESCRIPTION
This PR adds the `REDISMODULE_CTX_FLAGS_AOF_LOADING` to the module context flags, when the client running a module command is redis itself loading an AOF file. See #3994 