### PR TITLE
Lua replicate_commands() may lead to nested MULTI.

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -536,6 +536,7 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
     if (server.lua_replicate_commands &&
         !server.lua_multi_emitted &&
         server.lua_write_dirty &&
+        !(c->flags & CLIENT_MULTI) &&
         server.lua_repl != PROPAGATE_NONE)
     {
         execCommandPropagateMulti(server.lua_caller);


### PR DESCRIPTION
This happens when replicate_commands() is used when Lua is executed
inside `MULTI`, e.g.:

```
MULTI
EVAL "redis.replicate_commands(); redis.call('SET','a','1');" 0
EXEC
```

The above will result with nested `MULTI/EXEC`, which may lead to invalid
data in AOF/Slaves.