### PR TITLE
Updating an -> a in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -93,7 +93,7 @@ port 6379
 
 # TCP listen() backlog.
 #
-# In high requests-per-second environments you need an high backlog in order
+# In high requests-per-second environments you need a high backlog in order
 # to avoid slow clients connections issues. Note that the Linux kernel
 # will silently truncate it to the value of /proc/sys/net/core/somaxconn so
 # make sure to raise both the value of somaxconn and tcp_max_syn_backlog


### PR DESCRIPTION
`a` is correct in this usage.