### PR TITLE
info: show slaves and normal clients' buffer

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1430,7 +1430,7 @@ void readQueryFromClient(aeEventLoop *el, int fd, void *privdata, int mask) {
     }
 }
 
-void getClientsMaxBuffers(unsigned long *longest_output_list,
+void getNormalClientsMaxBuffers(unsigned long *longest_output_list,
                           unsigned long *biggest_input_buffer) {
     client *c;
     listNode *ln;
@@ -1440,6 +1440,8 @@ void getClientsMaxBuffers(unsigned long *longest_output_list,
     listRewind(server.clients,&li);
     while ((ln = listNext(&li)) != NULL) {
         c = listNodeValue(ln);
+        if (c->flags & CLIENT_SLAVE)
+            continue;
 
         if (listLength(c->reply) > lol) lol = listLength(c->reply);
         if (sdslen(c->querybuf) > bib) bib = sdslen(c->querybuf);

--- a/src/server.c
+++ b/src/server.c
@@ -2816,7 +2816,7 @@ sds genRedisInfoString(char *section) {
 
     getrusage(RUSAGE_SELF, &self_ru);
     getrusage(RUSAGE_CHILDREN, &c_ru);
-    getClientsMaxBuffers(&lol,&bib);
+    getNormalClientsMaxBuffers(&lol,&bib);
 
     /* Server */
     if (allsections || defsections || !strcasecmp(section,"server")) {

--- a/src/server.h
+++ b/src/server.h
@@ -1361,7 +1361,7 @@ void copyClientOutputBuffer(client *dst, client *src);
 size_t sdsZmallocSize(sds s);
 size_t getStringObjectSdsUsedMemory(robj *o);
 void *dupClientReplyValue(void *o);
-void getClientsMaxBuffers(unsigned long *longest_output_list,
+void getNormalClientsMaxBuffers(unsigned long *longest_output_list,
                           unsigned long *biggest_input_buffer);
 char *getClientPeerId(client *client);
 sds catClientInfoString(sds s, client *client);


### PR DESCRIPTION
I think these two infos are useful, and maybe more informations we should show in `info` command.

BTW, why we take `overhead` memory into `bytes_per_key`?
```
    /* Metrics computed after subtracting the startup memory from
     * the total memory. */
    size_t net_usage = 1;
    if (zmalloc_used > mh->startup_allocated)
        net_usage = zmalloc_used - mh->startup_allocated;
    mh->dataset_perc = (float)mh->dataset*100/net_usage;
    mh->bytes_per_key = mh->total_keys ? (net_usage / mh->total_keys) : 0;
```
I think just take `dataset` into account is enough and evident.