### PR TITLE
info: show slaves and normal clients' buffers

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2938,6 +2938,8 @@ sds genRedisInfoString(char *section) {
             "used_memory_peak_perc:%.2f%%\r\n"
             "used_memory_overhead:%zu\r\n"
             "used_memory_startup:%zu\r\n"
+            "used_memory_clients_normal:%zu\r\n"
+            "used_memory_clients_slaves:%zu\r\n"
             "used_memory_dataset:%zu\r\n"
             "used_memory_dataset_perc:%.2f%%\r\n"
             "total_system_memory:%lu\r\n"
@@ -2960,6 +2962,8 @@ sds genRedisInfoString(char *section) {
             mh->peak_perc,
             mh->overhead_total,
             mh->startup_allocated,
+            mh->clients_normal,
+            mh->clients_slaves,
             mh->dataset,
             mh->dataset_perc,
             (unsigned long)total_system_mem,


### PR DESCRIPTION
I think these two infos are useful, and maybe more informations we should show in `info` command.

BTW, why we take `overhead` memory into `bytes_per_key`?
```
    /* Metrics computed after subtracting the startup memory from
     * the total memory. */
    size_t net_usage = 1;
    if (zmalloc_used > mh->startup_allocated)
        net_usage = zmalloc_used - mh->startup_allocated;
    mh->dataset_perc = (float)mh->dataset*100/net_usage;
    mh->bytes_per_key = mh->total_keys ? (net_usage / mh->total_keys) : 0;
```
I think just take `dataset` into account is enough and evident.