### PR TITLE
Prevents SLOWLOG GETting negative values

### DIFF
--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -158,6 +158,11 @@ void slowlogCommand(client *c) {
             getLongFromObjectOrReply(c,c->argv[2],&count,NULL) != C_OK)
             return;
 
+        if (count < 0) {
+            addReplyError(c,"value is out of range");
+            return;
+        }
+
         listRewind(server.slowlog,&li);
         totentries = addDeferredMultiBulkLength(c);
         while(count-- && (ln = listNext(&li))) {


### PR DESCRIPTION
The current behavior returns the entire slowlog and is not documented. This breaks backward compatability, so monitoring scripts relying on it may malfunction.

Risk: low :)