### PR TITLE
Help subcommands

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4065,7 +4065,34 @@ void clusterCommand(client *c) {
         return;
     }
 
-    if (!strcasecmp(c->argv[1]->ptr,"meet") && (c->argc == 4 || c->argc == 5)) {
+    if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
+        const char *help[] = {
+            "addslots <slot> [slot ...] -- Assign slots to current node.",
+            "bumpepoch -- Advance the cluster config epoch.",
+            "count-failure-reports <node-id> -- Return number of failure reports for <node-id>.",
+            "countkeysinslot <slot> - Return the number of keys in <slot>.",
+            "delslots <slot> [slot ...] -- Delete slots information from current node.",
+            "failover [force|takeover] -- Promote current slave node to being a master.",
+            "forget <node-id> -- Remove a node from the cluster.",
+            "getkeysinslot <slot> <count> -- Return key names stored by current node in a slot.",
+            "flushslots -- Delete current node own slots information.",
+            "info - Return onformation about the cluster.",
+            "keyslot <key> -- Return the hash slot for <key>.",
+            "meet <ip> <port> [bus-port] -- Connect nodes into a working cluster.",
+            "myid -- Return the node id.",
+            "nodes -- Return cluster configuration seen by node. Output format:",
+            "    <id> <ip:port> <flags> <master> <pings> <pongs> <epoch> <link> <slot> ... <slot>",
+            "replicate <node-id> -- Configure current node as slave to <node-id>.",
+            "reset [hard|soft] -- Reset current node (default: soft).",
+            "set-config-epoch <epoch> - Set config epoch of current node.",
+            "setslot <slot> (importing|migrating|stable|node <node-id>) -- Set slot state.",
+            "slaves <node-id> -- Return <node-id> slaves.",
+            "slots -- Return information about slots range mappings. Each range is made of:",
+            "    start, end, master and replicas IP addresses, ports and ids",
+            NULL
+        };
+        addReplyHelp(c, help);
+    } else if (!strcasecmp(c->argv[1]->ptr,"meet") && (c->argc == 4 || c->argc == 5)) {
         /* CLUSTER MEET <ip> <port> [cport] */
         long long port, cport;
 
@@ -4258,7 +4285,7 @@ void clusterCommand(client *c) {
             clusterAddSlot(n,slot);
         } else {
             addReplyError(c,
-                "Invalid CLUSTER SETSLOT action or number of arguments");
+                "Invalid CLUSTER SETSLOT action or number of arguments. Try CLUSTER help");
             return;
         }
         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG|CLUSTER_TODO_UPDATE_STATE);
@@ -4608,7 +4635,9 @@ void clusterCommand(client *c) {
         clusterReset(hard);
         addReply(c,shared.ok);
     } else {
-        addReplyError(c,"Wrong CLUSTER subcommand or number of arguments");
+         addReplyErrorFormat(c, "Unknown subcommand or wrong number of arguments for '%s'. Try CLUSTER help",
+            (char*)c->argv[1]->ptr);
+        return;
     }
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -2065,19 +2065,24 @@ void configCommand(client *c) {
         return;
     }
 
-    if (!strcasecmp(c->argv[1]->ptr,"set")) {
-        if (c->argc != 4) goto badarity;
+    if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
+        const char *help[] = {
+            "get <pattern> -- Return parameters matching the glob-like <pattern> and their values.",
+            "set <parameter> <value> -- Set parameter to value.",
+            "resetstat -- Reset statistics reported by INFO.",
+            "rewrite -- Rewrite the configuration file.",
+            NULL
+        };
+        addReplyHelp(c, help);
+    } else if (!strcasecmp(c->argv[1]->ptr,"set") && c->argc == 4) {
         configSetCommand(c);
-    } else if (!strcasecmp(c->argv[1]->ptr,"get")) {
-        if (c->argc != 3) goto badarity;
+    } else if (!strcasecmp(c->argv[1]->ptr,"get") && c->argc == 3) {
         configGetCommand(c);
-    } else if (!strcasecmp(c->argv[1]->ptr,"resetstat")) {
-        if (c->argc != 2) goto badarity;
+    } else if (!strcasecmp(c->argv[1]->ptr,"resetstat") && c->argc == 2) {
         resetServerStats();
         resetCommandTableStats();
         addReply(c,shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr,"rewrite")) {
-        if (c->argc != 2) goto badarity;
+    } else if (!strcasecmp(c->argv[1]->ptr,"rewrite") && c->argc == 2) {
         if (server.configfile == NULL) {
             addReplyError(c,"The server is running without a config file");
             return;
@@ -2090,12 +2095,8 @@ void configCommand(client *c) {
             addReply(c,shared.ok);
         }
     } else {
-        addReplyError(c,
-            "CONFIG subcommand must be one of GET, SET, RESETSTAT, REWRITE");
+         addReplyErrorFormat(c, "Unknown subcommand or wrong number of arguments for '%s'. Try SLOWLOG help",
+            (char*)c->argv[1]->ptr);
+        return;
     }
-    return;
-
-badarity:
-    addReplyErrorFormat(c,"Wrong number of arguments for CONFIG %s",
-        (char*) c->argv[1]->ptr);
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -267,48 +267,29 @@ void debugCommand(client *c) {
         return;
     }
 
-    if (!strcasecmp(c->argv[1]->ptr,"help")) {
-        void *blenp = addDeferredMultiBulkLength(c);
-        int blen = 0;
-        blen++; addReplyStatus(c,
-        "DEBUG <subcommand> arg arg ... arg. Subcommands:");
-        blen++; addReplyStatus(c,
-        "segfault -- Crash the server with sigsegv.");
-        blen++; addReplyStatus(c,
-        "panic -- Crash the server simulating a panic.");
-        blen++; addReplyStatus(c,
-        "restart  -- Graceful restart: save config, db, restart.");
-        blen++; addReplyStatus(c,
-        "crash-and-recovery <milliseconds> -- Hard crash and restart after <milliseconds> delay.");
-        blen++; addReplyStatus(c,
-        "assert   -- Crash by assertion failed.");
-        blen++; addReplyStatus(c,
-        "reload   -- Save the RDB on disk and reload it back in memory.");
-        blen++; addReplyStatus(c,
-        "loadaof  -- Flush the AOF buffers on disk and reload the AOF in memory.");
-        blen++; addReplyStatus(c,
-        "object <key> -- Show low level info about key and associated value.");
-        blen++; addReplyStatus(c,
-        "sdslen <key> -- Show low level SDS string info representing key and value.");
-        blen++; addReplyStatus(c,
-        "ziplist <key> -- Show low level info about the ziplist encoding.");
-        blen++; addReplyStatus(c,
-        "populate <count> [prefix] [size] -- Create <count> string keys named key:<num>. If a prefix is specified is used instead of the 'key' prefix.");
-        blen++; addReplyStatus(c,
-        "digest   -- Outputs an hex signature representing the current DB content.");
-        blen++; addReplyStatus(c,
-        "sleep <seconds> -- Stop the server for <seconds>. Decimals allowed.");
-        blen++; addReplyStatus(c,
-        "set-active-expire (0|1) -- Setting it to 0 disables expiring keys in background when they are not accessed (otherwise the Redis behavior). Setting it to 1 reenables back the default.");
-        blen++; addReplyStatus(c,
-        "lua-always-replicate-commands (0|1) -- Setting it to 1 makes Lua replication defaulting to replicating single commands, without the script having to enable effects replication.");
-        blen++; addReplyStatus(c,
-        "error <string> -- Return a Redis protocol error with <string> as message. Useful for clients unit tests to simulate Redis errors.");
-        blen++; addReplyStatus(c,
-        "structsize -- Return the size of different Redis core C structures.");
-        blen++; addReplyStatus(c,
-        "htstats <dbid> -- Return hash table statistics of the specified Redis database.");
-        setDeferredMultiBulkLength(c,blenp,blen);
+    if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
+        const char *help[] = {
+            "assert -- Crash by assertion failed.",
+            "crash-and-recovery <milliseconds> -- Hard crash and restart after <milliseconds> delay.",
+            "digest -- Outputs an hex signature representing the current DB content.",
+            "htstats <dbid> -- Return hash table statistics of the specified Redis database.",
+            "loadaof -- Flush the AOF buffers on disk and reload the AOF in memory.",
+            "lua-always-replicate-commands (0|1) -- Setting it to 1 makes Lua replication defaulting to replicating single commands, without the script having to enable effects replication.",
+            "object <key> -- Show low level info about key and associated value.",
+            "panic -- Crash the server simulating a panic.",
+            "populate <count> [prefix] [size] -- Create <count> string keys named key:<num>. If a prefix is specified is used instead of the 'key' prefix.",
+            "reload -- Save the RDB on disk and reload it back in memory.",
+            "restart -- Graceful restart: save config, db, restart.",
+            "sdslen <key> -- Show low level SDS string info representing key and value.",
+            "segfault -- Crash the server with sigsegv.",
+            "set-active-expire (0|1) -- Setting it to 0 disables expiring keys in background when they are not accessed (otherwise the Redis behavior). Setting it to 1 reenables back the default.",
+            "sleep <seconds> -- Stop the server for <seconds>. Decimals allowed.",
+            "structsize -- Return the size of different Redis core C structures.",
+            "ziplist <key> -- Show low level info about the ziplist encoding.",
+            "error <string> -- Return a Redis protocol error with <string> as message. Useful for clients unit tests to simulate Redis errors.",
+            NULL
+        };
+        addReplyHelp(c, help);
     } else if (!strcasecmp(c->argv[1]->ptr,"segfault")) {
         *((char*)-1) = 'x';
     } else if (!strcasecmp(c->argv[1]->ptr,"panic")) {
@@ -550,8 +531,9 @@ void debugCommand(client *c) {
 
         addReplyBulkSds(c,stats);
     } else {
-        addReplyErrorFormat(c, "Unknown DEBUG subcommand or wrong number of arguments for '%s'",
+        addReplyErrorFormat(c, "Unknown subcommand or wrong number of arguments for '%s'. Try DEBUG help",
             (char*)c->argv[1]->ptr);
+        return;
     }
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1580,7 +1580,22 @@ void clientCommand(client *c) {
     listIter li;
     client *client;
 
-    if (!strcasecmp(c->argv[1]->ptr,"list") && c->argc == 2) {
+    if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
+        const char *help[] = {
+            "getname -- Return the name of the current connection.",
+            "kill <ip:port> -- Kill connection made from <ip:port>.",
+            "kill <option> <value> [option value ...] -- Kill connections. Options are:",
+            "     addr <ip:port> -- Kill connection made from <ip:port>.",
+            "     type (normal|master|slave|pubsub) -- Kill connections by type.",
+            "     skipme (yes|no) -- Skip killing current connection (default: yes).",
+            "list -- Return information about client connections.",
+            "pause <timeout> -- Suspend all Redis clients for <timout> milliseconds.",
+            "reply (on|off|skip) -- Control the replies sent to the current connection.",
+            "setname <name> -- Assign the name <name> to the current connection.",
+            NULL
+        };
+        addReplyHelp(c, help);
+    } else if (!strcasecmp(c->argv[1]->ptr,"list") && c->argc == 2) {
         /* CLIENT LIST */
         sds o = getAllClientsInfoString();
         addReplyBulkCBuffer(c,o,sdslen(o));
@@ -1726,8 +1741,9 @@ void clientCommand(client *c) {
         pauseClients(duration);
         addReply(c,shared.ok);
     } else {
-        addReplyError(c, "Syntax error, try CLIENT (LIST | KILL | GETNAME | SETNAME | PAUSE | REPLY)");
-    }
+         addReplyErrorFormat(c, "Unknown subcommand or wrong number of arguments for '%s'. Try CLIENT help",
+            (char*)c->argv[1]->ptr);
+        return;    }
 }
 
 /* This callback is bound to POST and "Host:" command names. Those are not

--- a/src/networking.c
+++ b/src/networking.c
@@ -604,19 +604,17 @@ void addReplyHelp(client *c, const char **help) {
     sds cmd = sdsnew((char*) c->argv[0]->ptr);
     void *blenp = addDeferredMultiBulkLength(c);
     int blen = 0;
-    int hlen = 0;
 
     sdstoupper(cmd);
     addReplyStatusFormat(c,
         "%s <subcommand> arg arg ... arg. Subcommands are:",cmd);
-    blen++;
     sdsfree(cmd);
     
-    while (help[hlen]) {
-        addReplyStatus(c,help[hlen++]);
-        blen++;
+    while (help[blen]) {
+        addReplyStatus(c,help[blen++]);
     }
 
+    blen += 1;  /* Account for the header line(s). */
     setDeferredMultiBulkLength(c,blenp,blen);
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -610,11 +610,9 @@ void addReplyHelp(client *c, const char **help) {
         "%s <subcommand> arg arg ... arg. Subcommands are:",cmd);
     sdsfree(cmd);
     
-    while (help[blen]) {
-        addReplyStatus(c,help[blen++]);
-    }
+    while (help[blen]) addReplyStatus(c,help[blen++]);
 
-    blen += 1;  /* Account for the header line(s). */
+    blen++;  /* Account for the header line(s). */
     setDeferredMultiBulkLength(c,blenp,blen);
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -584,6 +584,30 @@ void addReplyBulkLongLong(client *c, long long ll) {
     addReplyBulkCBuffer(c,buf,len);
 }
 
+/* Add an array of strings as a bulk reply with a heading.
+ * This function is typically invoked by from commands that support
+ * subcommands in response to the 'help' subcommand. The help array
+ * is terminated by NULL sentinel. */
+void addReplyHelp(client *c, const char **help) {
+    sds cmd = sdsnew((char*) c->argv[0]->ptr);
+    void *blenp = addDeferredMultiBulkLength(c);
+    int blen = 0;
+    int hlen = 0;
+
+    sdstoupper(cmd);
+    addReplyStatusFormat(c,
+        "%s <subcommand> arg arg ... arg. Subcommands are:",cmd);
+    blen++;
+    sdsfree(cmd);
+    
+    while (help[hlen]) {
+        addReplyStatus(c,help[hlen++]);
+        blen++;
+    }
+
+    setDeferredMultiBulkLength(c,blenp,blen);
+}
+
 /* Copy 'src' client output buffers into 'dst' client output buffers.
  * The function takes care of freeing the old output buffers of the
  * destination client. */

--- a/src/object.c
+++ b/src/object.c
@@ -1016,20 +1016,15 @@ robj *objectCommandLookupOrReply(client *c, robj *key, robj *reply) {
 void objectCommand(client *c) {
     robj *o;
 
-    if (!strcasecmp(c->argv[1]->ptr,"help") && c->argc == 2) {
-        void *blenp = addDeferredMultiBulkLength(c);
-        int blen = 0;
-        blen++; addReplyStatus(c,
-        "OBJECT <subcommand> key. Subcommands:");
-        blen++; addReplyStatus(c,
-        "refcount -- Return the number of references of the value associated with the specified key.");
-        blen++; addReplyStatus(c,
-        "encoding -- Return the kind of internal representation used in order to store the value associated with a key.");
-        blen++; addReplyStatus(c,
-        "idletime -- Return the number of seconds since the object stored at the specified key is idle.");
-        blen++; addReplyStatus(c,
-        "freq -- Return the inverse logarithmic access frequency counter of the object stored at the specified key.");
-        setDeferredMultiBulkLength(c,blenp,blen);
+    if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
+        const char *help[] = {
+            "encoding <key> -- Return the kind of internal representation used in order to store the value associated with a key.",
+            "freq <key> -- Return the access frequency index of the key. The returned integer is proportional to the logarithm of the recent access frequency of the key.",
+            "idletime <key> -- Return the idle time of the key, that is the approximated number of seconds elapsed since the last access to the key.",
+            "refcount <key> -- Return the number of references of the value associated with the specified key.",
+            NULL
+        };
+        addReplyHelp(c, help);
     } else if (!strcasecmp(c->argv[1]->ptr,"refcount") && c->argc == 3) {
         if ((o = objectCommandLookupOrReply(c,c->argv[2],shared.nullbulk))
                 == NULL) return;
@@ -1057,6 +1052,7 @@ void objectCommand(client *c) {
     } else {
         addReplyErrorFormat(c, "Unknown subcommand or wrong number of arguments for '%s'. Try OBJECT help",
             (char *)c->argv[1]->ptr);
+        return;
     }
 }
 

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -325,8 +325,16 @@ void publishCommand(client *c) {
 
 /* PUBSUB command for Pub/Sub introspection. */
 void pubsubCommand(client *c) {
-    if (!strcasecmp(c->argv[1]->ptr,"channels") &&
-        (c->argc == 2 || c->argc ==3))
+    if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
+        const char *help[] = {
+            "channels [<pattern>] -- Return the currently active channels matching a pattern (default: all).",
+            "numpat -- Return number of subscriptions to patterns.",
+            "numsub [channel-1 .. channel-N] -- Returns the number of subscribers for the specified channels (excluding patterns, default: none).",
+            NULL
+        };
+        addReplyHelp(c, help);
+    } else if (!strcasecmp(c->argv[1]->ptr,"channels") &&
+        (c->argc == 2 || c->argc == 3))
     {
         /* PUBSUB CHANNELS [<pattern>] */
         sds pat = (c->argc == 2) ? NULL : c->argv[2]->ptr;
@@ -364,8 +372,8 @@ void pubsubCommand(client *c) {
         /* PUBSUB NUMPAT */
         addReplyLongLong(c,listLength(server.pubsub_patterns));
     } else {
-        addReplyErrorFormat(c,
-            "Unknown PUBSUB subcommand or wrong number of arguments for '%s'",
+        addReplyErrorFormat(c, "Unknown subcommand or wrong number of arguments for '%s'. Try PUBSUB help",
             (char*)c->argv[1]->ptr);
+        return;
     }
 }

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1430,7 +1430,17 @@ void evalShaCommand(client *c) {
 }
 
 void scriptCommand(client *c) {
-    if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"flush")) {
+    if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
+        const char *help[] = {
+            "debug (yes|sync|no) -- Set the debug mode for subsequent scripts executed.",
+            "exists sha1 [sha1 ...] -- Return information about the existence of the scripts in the script cache.",
+            "flush -- Flush the Lua scripts cache.",
+            "kill -- Kill the currently executing Lua script.",
+            "load script -- Load a script into the scripts cache, without executing it.",
+            NULL
+        };
+        addReplyHelp(c, help);
+    } else if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"flush")) {
         scriptingReset();
         addReply(c,shared.ok);
         replicationScriptCacheFlush();
@@ -1489,9 +1499,12 @@ void scriptCommand(client *c) {
             c->flags |= CLIENT_LUA_DEBUG_SYNC;
         } else {
             addReplyError(c,"Use SCRIPT DEBUG yes/sync/no");
+            return;
         }
     } else {
-        addReplyError(c, "Unknown SCRIPT subcommand or wrong # of args.");
+        addReplyErrorFormat(c, "Unknown subcommand or wrong number of arguments for '%s'. Try SCRIPT help",
+            (char*)c->argv[1]->ptr);
+        return;
     }
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -1357,6 +1357,7 @@ void addReplyDouble(client *c, double d);
 void addReplyHumanLongDouble(client *c, long double d);
 void addReplyLongLong(client *c, long long ll);
 void addReplyMultiBulkLen(client *c, long length);
+void addReplyHelp(client *c, const char **help);
 void copyClientOutputBuffer(client *dst, client *src);
 size_t sdsZmallocSize(sds s);
 size_t getStringObjectSdsUsedMemory(robj *o);

--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -140,7 +140,15 @@ void slowlogReset(void) {
 /* The SLOWLOG command. Implements all the subcommands needed to handle the
  * Redis slow log. */
 void slowlogCommand(client *c) {
-    if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"reset")) {
+    if (!strcasecmp(c->argv[1]->ptr,"help") && c->argc == 2) {
+        const char *help[] = {
+            "get [count] -- Return the top entries from the slowlog (default: 10).",
+            "len -- Return the length of the slowlog.",
+            "reset -- Reset the slowlog.",
+            NULL
+        };
+        addReplyHelp(c, help);
+    } else if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"reset")) {
         slowlogReset();
         addReply(c,shared.ok);
     } else if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"len")) {
@@ -177,7 +185,8 @@ void slowlogCommand(client *c) {
         }
         setDeferredMultiBulkLength(c,totentries,sent);
     } else {
-        addReplyError(c,
-            "Unknown SLOWLOG subcommand or wrong # of args. Try GET, RESET, LEN.");
+         addReplyErrorFormat(c, "Unknown subcommand or wrong number of arguments for '%s'. Try SLOWLOG help",
+            (char*)c->argv[1]->ptr);
+        return;
     }
 }

--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -142,7 +142,8 @@ void slowlogReset(void) {
 void slowlogCommand(client *c) {
     if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
         const char *help[] = {
-            "get [count] -- Return the top entries from the slowlog (default: 10).",
+            "get [count] -- Return top entries from the slowlog (default: 10). Entries are made of:",
+            "    id, timestamp, time in microseconds, arguments array, client IP and port, client name",
             "len -- Return the length of the slowlog.",
             "reset -- Reset the slowlog.",
             NULL

--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -140,7 +140,7 @@ void slowlogReset(void) {
 /* The SLOWLOG command. Implements all the subcommands needed to handle the
  * Redis slow log. */
 void slowlogCommand(client *c) {
-    if (!strcasecmp(c->argv[1]->ptr,"help") && c->argc == 2) {
+    if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
         const char *help[] = {
             "get [count] -- Return the top entries from the slowlog (default: 10).",
             "len -- Return the length of the slowlog.",


### PR DESCRIPTION
This adds a new `addReplyHelp` helper that's used by commands
when returning a help text. The following commands have been
helped and sorted: DEBUG, OBJECT, COMMAND, PUBSUB, SCRIPT, 
SLOWLOG, CLUSTER and CONFIG.

Once merged, the relevant PR to redis-doc needs to be made.