### PR TITLE
CRITICAL BUG: 4.0.5 crash when load duplicate lua script

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1147,32 +1147,11 @@ int redis_math_randomseed (lua_State *L) {
  *
  *   f_<hex sha1 sum>
  *
- * If 'funcname' is NULL, the function name is created by the function
- * on the fly doing the SHA1 of the body, this means that passing the funcname
- * is just an optimization in case it's already at hand.
- *
- * if 'allow_dup' is true, the function can be called with a script already
- * in memory without crashing in assert(). In this case C_OK is returned.
- *
- * The function increments the reference count of the 'body' object as a
- * side effect of a successful call.
- *
  * On success C_OK is returned, and nothing is left on the Lua stack.
  * On error C_ERR is returned and an appropriate error is set in the
  * client context. */
-int luaCreateFunction(client *c, lua_State *lua, char *funcname, robj *body, int allow_dup) {
+int luaCreateFunction(client *c, lua_State *lua, char *funcname, robj *body) {
     sds funcdef = sdsempty();
-    char fname[43];
-
-    if (funcname == NULL) {
-        fname[0] = 'f';
-        fname[1] = '_';
-        sha1hex(fname+2,body->ptr,sdslen(body->ptr));
-        funcname = fname;
-    }
-
-    if (allow_dup && dictFind(server.lua_scripts,funcname+2) != NULL)
-        return C_OK;
 
     funcdef = sdscat(funcdef,"function ");
     funcdef = sdscatlen(funcdef,funcname,42);
@@ -1308,7 +1287,7 @@ void evalGenericCommand(client *c, int evalsha) {
             addReply(c, shared.noscripterr);
             return;
         }
-        if (luaCreateFunction(c,lua,funcname,c->argv[1],0) == C_ERR) {
+        if (luaCreateFunction(c,lua,funcname,c->argv[1]) == C_ERR) {
             lua_pop(lua,1); /* remove the error handler from the stack. */
             /* The error is sent to the client by luaCreateFunction()
              * itself when it returns C_ERR. */
@@ -1480,7 +1459,7 @@ void scriptCommand(client *c) {
         sha1hex(funcname+2,c->argv[2]->ptr,sdslen(c->argv[2]->ptr));
         sha = sdsnewlen(funcname+2,40);
         if (dictFind(server.lua_scripts,sha) == NULL) {
-            if (luaCreateFunction(c,server.lua,funcname,c->argv[2],0)
+            if (luaCreateFunction(c,server.lua,funcname,c->argv[2])
                     == C_ERR) {
                 sdsfree(sha);
                 return;

--- a/src/server.h
+++ b/src/server.h
@@ -1794,7 +1794,8 @@ void scriptingInit(int setup);
 int ldbRemoveChild(pid_t pid);
 void ldbKillForkedSessions(void);
 int ldbPendingChildren(void);
-int luaCreateFunction(client *c, lua_State *lua, char *funcname, robj *body, int allow_dup);
+int luaCreateFunction(client *c, lua_State *lua, char *funcname, robj *body);
+void sha1hex(char *digest, char *script, size_t len);
 
 /* Blocked clients */
 void processUnblockedClients(void);


### PR DESCRIPTION
In function `luaCreateFunction`, `dictFind` needs a `sds` but a `char*` is given.

```
int luaCreateFunction(client *c, lua_State *lua, char *funcname, robj *body, int allow_dup) {
    sds funcdef = sdsempty();
    char fname[43];

    if (funcname == NULL) {
        fname[0] = 'f';
        fname[1] = '_';
        sha1hex(fname+2,body->ptr,sdslen(body->ptr));
        funcname = fname;
    }

    if (allow_dup && dictFind(server.lua_scripts,funcname+2) != NULL)
        return C_OK;
```

And I think we did too much work about fix the lua problem, just fix it as `script load` is the simplest way.

This a critical bug, please check it @antirez 
