### PR TITLE
Add redis-cli and redis-benchmark dependencies for test target.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -238,10 +238,10 @@ distclean: clean
 
 .PHONY: distclean
 
-test: $(REDIS_SERVER_NAME) $(REDIS_CHECK_AOF_NAME)
+test: $(REDIS_SERVER_NAME) $(REDIS_CHECK_AOF_NAME) $(REDIS_CLI_NAME) $(REDIS_BENCHMARK_NAME)
 	@(cd ..; ./runtest)
 
-test-sentinel: $(REDIS_SENTINEL_NAME)
+test-sentinel: $(REDIS_SENTINEL_NAME) $(REDIS_CLI_NAME)
 	@(cd ..; ./runtest-sentinel)
 
 check: test


### PR DESCRIPTION
Run test directly without make first cause such errors:
    "src/redis-benchmark": no such file or directory
    "src/redis-cli": no such file or directory
Add dependencies in Makefile for test maybe more reasonable.