### PR TITLE
ttl returns -2 when the remaining time is 0

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -464,10 +464,10 @@ void ttlGenericCommand(client *c, int output_ms) {
     expire = getExpire(c->db,c->argv[1]);
     if (expire != -1) {
         ttl = expire-mstime();
-        if (ttl < 0) ttl = 0;
+        if (ttl <= 0) ttl = -2;
     }
-    if (ttl == -1) {
-        addReplyLongLong(c,-1);
+    if (ttl == -1 || ttl == -2) {
+        addReplyLongLong(c,ttl);
     } else {
         addReplyLongLong(c,output_ms ? ttl : ((ttl+500)/1000));
     }
@@ -504,4 +504,3 @@ void touchCommand(client *c) {
         if (lookupKeyRead(c->db,c->argv[j]) != NULL) touched++;
     addReplyLongLong(c,touched);
 }
-

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -128,6 +128,14 @@ start_server {tags {"expire"}} {
         assert {$ttl > 8 && $ttl <= 10}
     }
 
+    test {TTL returns -2 when tiem is 0} {
+        r del x
+        r setex x 1 somevalue
+        after 1000
+        set ttl [r ttl x]
+        assert {$ttl == -2}
+    }
+
     test {PTTL returns time to live in milliseconds} {
         r del x
         r setex x 1 somevalue


### PR DESCRIPTION
Currently redis set funtions (etc: incrbyfloat) treat the key as
expriration(-2) when the expired time is 0. So ttl must return
-2 in this case to consistent with document (return -2 when expired)