### PR TITLE
Always enable command history in redis-cli run on a TTY

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1386,8 +1386,9 @@ static void repl(void) {
     /* Only use history and load the rc file when stdin is a tty. */
     if (isatty(fileno(stdin))) {
         historyfile = getDotfilePath(REDIS_CLI_HISTFILE_ENV,REDIS_CLI_HISTFILE_DEFAULT);
+        //keep in-memory history always regardless if history file can be determined
+        history = 1;
         if (historyfile != NULL) {
-            history = 1;
             linenoiseHistoryLoad(historyfile);
         }
         cliLoadPreferences();


### PR DESCRIPTION
This change originates from [my Windows fork of Redis 4.0.2](https://github.com/tporadowski/redis) where original ```redis-cli.c``` code could not successfully determine path to ```.rediscli_history``` file due to absence of ```HOME``` environment variable on Windows platform. This prevented usage of command history altogether, which can be just always kept in-memory when ```redis-cli``` runs on a TTY. I suppose chances are rather low that ```HOME``` variable is not found on *nix systems, but it's possible ;)

Original commit message:
- when redis-cli is running on a TTY - always enable command history buffering, regardless if history file path can be successfully determined