### PR TITLE
redis-benchmark: Enforce upper bound to numbers of requests for pipeline

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -264,10 +264,11 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     /* Initialize request when nothing was written. */
     if (c->written == 0) {
         /* Enforce upper bound to number of requests. */
-        if (config.requests_issued++ >= config.requests) {
+        if (config.requests_issued >= config.requests) {
             freeClient(c);
             return;
         }
+        config.requests_issued += config.pipeline;
 
         /* Really initialize: randomize keys and set start time. */
         if (config.randomkeys) randomizeClientKey(c);


### PR DESCRIPTION
Before commit there are no more than <-P numreq>*<-c clients>(such as 2450) redunant requests during pipeline mode.

    $redis-benchmark -n 100000 -P 50 -q incr foo;redis-cli get foo
    incr foo: 2173913.00 requests per second
    "102450"

After commit redunant nums reduce to no more than <-P numreq>.