### PR TITLE
Add Query Buffer used memory metric into INFO

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -1250,3 +1250,15 @@ void memoryCommand(client *c) {
         addReplyError(c,"Syntax error. Try MEMORY HELP");
     }
 }
+
+size_t getQueryBufferSize(void){
+        listNode *ln;
+        size_t qbufsize = 0;
+        listIter *iter = listGetIterator(server.clients,AL_START_HEAD);
+        while ((ln = listNext(iter)) != NULL) {
+                client *c = listNodeValue(ln);
+                qbufsize += sdsAllocSize(c->querybuf);
+        }
+
+        return qbufsize;
+}

--- a/src/server.c
+++ b/src/server.c
@@ -2951,9 +2951,12 @@ sds genRedisInfoString(char *section) {
         char total_system_hmem[64];
         char used_memory_lua_hmem[64];
         char used_memory_rss_hmem[64];
+	char used_memory_dataset_hmem[64];
+        char used_memory_query_buffer_hmem[64];
         char maxmemory_hmem[64];
         size_t zmalloc_used = zmalloc_used_memory();
         size_t total_system_mem = server.system_memory_size;
+	size_t query_buffer_mem = getQueryBufferSize();
         const char *evict_policy = evictPolicyToString();
         long long memory_lua = (long long)lua_gc(server.lua,LUA_GCCOUNT,0)*1024;
         struct redisMemOverhead *mh = getMemoryOverheadData();
@@ -2971,6 +2974,8 @@ sds genRedisInfoString(char *section) {
         bytesToHuman(used_memory_lua_hmem,memory_lua);
         bytesToHuman(used_memory_rss_hmem,server.resident_set_size);
         bytesToHuman(maxmemory_hmem,server.maxmemory);
+        bytesToHuman(used_memory_dataset_hmem,mh->dataset);
+        bytesToHuman(used_memory_query_buffer_hmem,query_buffer_mem);
 
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info,
@@ -2985,7 +2990,10 @@ sds genRedisInfoString(char *section) {
             "used_memory_overhead:%zu\r\n"
             "used_memory_startup:%zu\r\n"
             "used_memory_dataset:%zu\r\n"
+	    "used_memory_dataset_human:%s\r\n"
             "used_memory_dataset_perc:%.2f%%\r\n"
+            "used_memory_query_buffer: %lu\r\n"
+            "used_memory_query_buffer_human: %s\r\n"
             "total_system_memory:%lu\r\n"
             "total_system_memory_human:%s\r\n"
             "used_memory_lua:%lld\r\n"
@@ -3007,7 +3015,10 @@ sds genRedisInfoString(char *section) {
             mh->overhead_total,
             mh->startup_allocated,
             mh->dataset,
+            used_memory_dataset_hmem,
             mh->dataset_perc,
+            query_buffer_mem,
+            used_memory_query_buffer_hmem,
             (unsigned long)total_system_mem,
             total_system_hmem,
             memory_lua,

--- a/src/server.h
+++ b/src/server.h
@@ -1650,6 +1650,7 @@ unsigned int LRU_CLOCK(void);
 const char *evictPolicyToString(void);
 struct redisMemOverhead *getMemoryOverheadData(void);
 void freeMemoryOverheadData(struct redisMemOverhead *mh);
+size_t getQueryBufferSize(void);
 
 #define RESTART_SERVER_NONE 0
 #define RESTART_SERVER_GRACEFULLY (1<<0)     /* Do proper shutdown. */


### PR DESCRIPTION
In case of the query buffer abuse, it's often confusing to get such the memory metrics:

> 127.0.0.1:6379> info memory
> # Memory
> used_memory:5873901248
> **used_memory_human:5.47G**
> used_memory_rss:5255127040
> used_memory_rss_human:4.89G
> used_memory_peak:5873902224
> used_memory_peak_human:5.47G
> used_memory_peak_perc:100.00%
> used_memory_overhead:5121658606
> used_memory_startup:765576
> used_memory_dataset:752242642
> used_memory_dataset_perc:12.81%
> total_system_memory:67467202560
> total_system_memory_human:62.83G
> used_memory_lua:37888
> used_memory_lua_human:37.00K
> maxmemory:1073741824
> **maxmemory_human:1.00G**
> maxmemory_policy:noeviction
> mem_fragmentation_ratio:0.89
> mem_allocator:jemalloc-4.0.3
> active_defrag_running:0
> lazyfree_pending_objects:0

In this pr, three metrics have been added. They can give a big help for users to know where his memory goes:

> 127.0.0.1:6379> info memory
> # Memory
> used_memory:6122779168
> used_memory_human:5.70G
> used_memory_rss:6439333888
> used_memory_rss_human:6.00G
> used_memory_peak:6122779168
> used_memory_peak_human:5.70G
> used_memory_peak_perc:100.00%
> used_memory_overhead:5122885286
> used_memory_startup:765960
> used_memory_dataset:999893898
> **used_memory_dataset_human:953.57M**
> used_memory_dataset_perc:16.33%
> **used_memory_query_buffer: 5120033374
> used_memory_query_buffer_human: 4.77G**
> total_system_memory:67467202560
> total_system_memory_human:62.83G
> used_memory_lua:37888
> used_memory_lua_human:37.00K
> maxmemory:1073741824
> maxmemory_human:1.00G
> maxmemory_policy:noeviction
> mem_fragmentation_ratio:1.05
> mem_allocator:jemalloc-4.0.3
> active_defrag_running:0
> lazyfree_pending_objects:0
  