### PR TITLE
redis-benchmark: bugfix - handle zero liveclients in right way

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -614,7 +614,7 @@ int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData
     UNUSED(id);
     UNUSED(clientData);
 
-    if (config.liveclients == 0) {
+    if (config.liveclients == 0 && config.requests_finished != config.requests) {
         fprintf(stderr,"All clients disconnected... aborting.\n");
         exit(1);
     }


### PR DESCRIPTION
When I use `redis-benchmark`, something unexpected happened, see the end of the result below:

```
====== GET ======
  100001 requests completed in 1.23 seconds
  100 parallel clients
  3 bytes payload
  keep alive: 1

98.23% <= 1 milliseconds
99.95% <= 2 milliseconds
100.00% <= 2 milliseconds
81500.41 requests per second


All clients disconnected... aborting.
```

**All clients disconnected... aborting.** can only appear when we have no liveclients:

```
int showThroughput(...
    if (config.liveclients == 0) {
         fprintf(stderr,"All clients disconnected... aborting.\n");
         exit(1);
     }
}
```

It seems like we lost all connections, but no errors are printed.

`config.liveclients--` happens only when we call `freeClient()`, I check all the codes about `freeClient()` in `redis-benchmark.c` and finally find the problem:

```
static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
    /* Initialize request when nothing was written. */
    if (c->written == 0) {
        /* Enforce upper bound to number of requests. */
        if (config.requests_issued++ >= config.requests) {
            freeClient(c);
            return;
        }
```

We call `freeClient()` when the `config.requests_issued` is greater than `config.requests` or all requests finished.

```
static void clientDone(client c) {
    if (config.requests_finished == config.requests) {
        freeClient(c);
        aeStop(config.el);
        return;
    }
```

But, after `aeStop`, the time event still have chance to execute, that is the problem, I fix it as below:

```
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -614,7 +614,7 @@ int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientDat
     UNUSED(id);
     UNUSED(clientData);

-    if (config.liveclients == 0) {
+    if (config.liveclients == 0 && config.requests_finished != config.requests) {
         fprintf(stderr,"All clients disconnected... aborting.\n");
         exit(1);
     }
```