### PR TITLE
Fix memory usage list

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -739,7 +739,7 @@ size_t objectComputeSize(robj *o, size_t sample_size) {
                 elesize += sizeof(quicklistNode)+ziplistBlobLen(node->zl);
                 samples++;
             } while ((node = node->next) && samples < sample_size);
-            asize += (double)elesize/samples*listTypeLength(o);
+            asize += (double)elesize/samples*ql->len;
         } else if (o->encoding == OBJ_ENCODING_ZIPLIST) {
             asize = sizeof(*o)+ziplistBlobLen(o->ptr);
         } else {

--- a/src/object.c
+++ b/src/object.c
@@ -1250,3 +1250,15 @@ void memoryCommand(client *c) {
         addReplyError(c,"Syntax error. Try MEMORY HELP");
     }
 }
+
+size_t getQueryBufferSize(void){
+        listNode *ln;
+        size_t qbufsize = 0;
+        listIter *iter = listGetIterator(server.clients,AL_START_HEAD);
+        while ((ln = listNext(iter)) != NULL) {
+                client *c = listNodeValue(ln);
+                qbufsize += sdsAllocSize(c->querybuf);
+        }
+
+        return qbufsize;
+}

--- a/src/server.c
+++ b/src/server.c
@@ -2951,9 +2951,12 @@ sds genRedisInfoString(char *section) {
         char total_system_hmem[64];
         char used_memory_lua_hmem[64];
         char used_memory_rss_hmem[64];
+	char used_memory_dataset_hmem[64];
+        char used_memory_query_buffer_hmem[64];
         char maxmemory_hmem[64];
         size_t zmalloc_used = zmalloc_used_memory();
         size_t total_system_mem = server.system_memory_size;
+	size_t query_buffer_mem = getQueryBufferSize();
         const char *evict_policy = evictPolicyToString();
         long long memory_lua = (long long)lua_gc(server.lua,LUA_GCCOUNT,0)*1024;
         struct redisMemOverhead *mh = getMemoryOverheadData();
@@ -2971,6 +2974,8 @@ sds genRedisInfoString(char *section) {
         bytesToHuman(used_memory_lua_hmem,memory_lua);
         bytesToHuman(used_memory_rss_hmem,server.resident_set_size);
         bytesToHuman(maxmemory_hmem,server.maxmemory);
+        bytesToHuman(used_memory_dataset_hmem,mh->dataset);
+        bytesToHuman(used_memory_query_buffer_hmem,query_buffer_mem);
 
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info,
@@ -2985,7 +2990,10 @@ sds genRedisInfoString(char *section) {
             "used_memory_overhead:%zu\r\n"
             "used_memory_startup:%zu\r\n"
             "used_memory_dataset:%zu\r\n"
+	    "used_memory_dataset_human:%s\r\n"
             "used_memory_dataset_perc:%.2f%%\r\n"
+            "used_memory_query_buffer: %lu\r\n"
+            "used_memory_query_buffer_human: %s\r\n"
             "total_system_memory:%lu\r\n"
             "total_system_memory_human:%s\r\n"
             "used_memory_lua:%lld\r\n"
@@ -3007,7 +3015,10 @@ sds genRedisInfoString(char *section) {
             mh->overhead_total,
             mh->startup_allocated,
             mh->dataset,
+            used_memory_dataset_hmem,
             mh->dataset_perc,
+            query_buffer_mem,
+            used_memory_query_buffer_hmem,
             (unsigned long)total_system_mem,
             total_system_hmem,
             memory_lua,

--- a/src/server.h
+++ b/src/server.h
@@ -1650,6 +1650,7 @@ unsigned int LRU_CLOCK(void);
 const char *evictPolicyToString(void);
 struct redisMemOverhead *getMemoryOverheadData(void);
 void freeMemoryOverheadData(struct redisMemOverhead *mh);
+size_t getQueryBufferSize(void);
 
 #define RESTART_SERVER_NONE 0
 #define RESTART_SERVER_GRACEFULLY (1<<0)     /* Do proper shutdown. */


### PR DESCRIPTION
When using the command MEMORY USAGE to estimate a list key, wired stuff came out as below:

```

127.0.0.1:6379> keys *
1) "mylist"
127.0.0.1:6379> info memory
# Memory
used_memory:1038371263
used_memory_human:990.27M
used_memory_rss:1045626880
used_memory_rss_human:997.19M
used_memory_peak:1038371263
used_memory_peak_human:990.27M
used_memory_peak_perc:100.00%
used_memory_overhead:884838
used_memory_startup:835104
used_memory_dataset:1037486425
used_memory_dataset_perc:100.00%
total_system_memory:67467202560
total_system_memory_human:62.83G
used_memory_lua:37888
used_memory_lua_human:37.00K
maxmemory:0
maxmemory_human:0B
maxmemory_policy:noeviction
mem_fragmentation_ratio:1.01
mem_allocator:libc
active_defrag_running:0
lazyfree_pending_objects:0

127.0.0.1:6379> llen mylist
(integer) 10000159

127.0.0.1:6379> memory usage mylist
(integer) 70265117278

127.0.0.1:6379> debug object mylist
Value at:0x7ace78 refcount:1 encoding:quicklist serializedlength:23291534 lru:5174912 lru_seconds_idle:175 ql_nodes:126585 ql_avg_node:79.00 ql_ziplist_max:-2 ql_compressed:0 ql_uncompressed_size:1031408812

```

Obviously, it's not the right estimation. By checking the source code, I found the sizeof quicklist should be used instead of the total number of ziplist entry.

After fixing this, we can get the right memory usage estimation as below:

```
127.0.0.1:6379> memory usage mylist
(integer) 889436925
(3.10s)

127.0.0.1:6379> memory usage mylist samples 10000
(integer) 1035392366
(5.96s)
```


