### PR TITLE
Fix memory usage list bug

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -739,7 +739,7 @@ size_t objectComputeSize(robj *o, size_t sample_size) {
                 elesize += sizeof(quicklistNode)+ziplistBlobLen(node->zl);
                 samples++;
             } while ((node = node->next) && samples < sample_size);
-            asize += (double)elesize/samples*listTypeLength(o);
+            asize += (double)elesize/samples*ql->len;
         } else if (o->encoding == OBJ_ENCODING_ZIPLIST) {
             asize = sizeof(*o)+ziplistBlobLen(o->ptr);
         } else {


### PR DESCRIPTION
When using the command MEMORY USAGE to estimate a list key, weird stuff came out as below:
```
127.0.0.1:6379> keys *
1) "mylist"
127.0.0.1:6379> info memory
# Memory
used_memory:1038371263
used_memory_human:990.27M
used_memory_rss:1045626880
used_memory_rss_human:997.19M
used_memory_peak:1038371263
used_memory_peak_human:990.27M
used_memory_peak_perc:100.00%
used_memory_overhead:884838
used_memory_startup:835104
used_memory_dataset:1037486425
used_memory_dataset_perc:100.00%
total_system_memory:67467202560
total_system_memory_human:62.83G
used_memory_lua:37888
used_memory_lua_human:37.00K
maxmemory:0
maxmemory_human:0B
maxmemory_policy:noeviction
mem_fragmentation_ratio:1.01
mem_allocator:libc
active_defrag_running:0
lazyfree_pending_objects:0

127.0.0.1:6379> llen mylist
(integer) 10000159

127.0.0.1:6379> memory usage mylist
(integer) 70265117278

127.0.0.1:6379> debug object mylist
Value at:0x7ace78 refcount:1 encoding:quicklist serializedlength:23291534 lru:5174912 lru_seconds_idle:175 ql_nodes:126585 ql_avg_node:79.00 ql_ziplist_max:-2 ql_compressed:0 ql_uncompressed_size:1031408812

```
Obviously, it's not the right estimation. By checking the source code, I found the sizeof quicklist should be used instead of the total number of ziplist entry.

After fixing this, we can get the right memory usage estimation as below:

```
127.0.0.1:6379> memory usage mylist
(integer) 889436925
(3.10s)

127.0.0.1:6379> memory usage mylist samples 10000
(integer) 1035392366
(5.96s)
```
  