### PR TITLE
Evicting strategy update

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2356,7 +2356,7 @@ int processCommand(client *c) {
      * First we try to free some memory if possible (if there are volatile
      * keys in the dataset). If there are not the only thing we can do
      * is returning an error. */
-    if (server.maxmemory) {
+    if (server.maxmemory && server.masterhost == NULL) {
         int retval = freeMemoryIfNeeded();
         /* freeMemoryIfNeeded may flush slave output buffers. This may result
          * into a slave, that may be the active client, to be freed. */

--- a/src/server.h
+++ b/src/server.h
@@ -167,6 +167,8 @@ typedef long long mstime_t; /* millisecond time type. */
 #define ACTIVE_EXPIRE_CYCLE_SLOW 0
 #define ACTIVE_EXPIRE_CYCLE_FAST 1
 
+#define ACTIVE_EVICT_PER_CALL 5 /* maximum key evcict per call if memory reached */
+
 /* Instantaneous metrics tracking. */
 #define STATS_METRIC_SAMPLES 16     /* Number of samples per metric. */
 #define STATS_METRIC_COMMAND 0      /* Number of commands executed. */


### PR DESCRIPTION

#### 1.Slave Evicting

slave should not perform evicting , even if it reaches it`s "maxmemory"

The way Redis calculate how much memory should be released is  how much memory we have used in the entire instance minus "maxmemory" directive . But master and slave may not always have exactly the same memory usage, there are always some slightly different !(for example : slave have much more connection than master) 

If slave have reached it`s "maxmemory", but master did not, then some keys would be evicted from slave, but still existing in master. It might be fine if our key was just a simply string and we never use commands like "INCR" or "DECR", but considering if the key is a more complex key, a "list" for example, this would result data was incomplete between master and slave 

The way we fix this was disable memory eviction if the current instance is a slave. The evicting shall be performed by master and replicate to slave

### 2. maximum evicting 
The way we evicting key if "maxmemory" reached was calculate how much memory should be release as a "memory_to_be_free" variable, and keep deleting objects till there are exactly "memory_to_be_free" bytes of memory was freed. 

There are special cases : the "memory_to_be_free" variable may be a too big value. 
for example :

* dict rehashing 
    
    This really happens in our product environment ! And was the major motivation of this update. Redis would always perform rehash size of a hash table was reached a specific number . And as the size of hash table grows, the rehashing memory allocation grows too. If the size reaches "8013608" ， 128Mb of memory shall be alloced at once. The "memory_to_be_free" variable would be about 128Mb, in the next call of "freeMemoryIfNeeded()", that`s were could block Redis. 
    
* manual config change

    User changes "maxmemory" to a smaller value would also block server. But that`s acceptable
    

I set a maximum iterate limitation for "freeMemoryIfNeeded()". The value was set to 5, which means 5 keys shall be evicted at most per call . 






