### PR TITLE
fix deps/lua compile warning

### DIFF
--- a/deps/lua/src/ldo.c
+++ b/deps/lua/src/ldo.c
@@ -493,10 +493,9 @@ static void f_parser (lua_State *L, void *ud) {
   Proto *tf;
   Closure *cl;
   struct SParser *p = cast(struct SParser *, ud);
-  int c = luaZ_lookahead(p->z);
+  luaZ_lookahead(p->z);
   luaC_checkGC(L);
-  tf = (luaY_parser)(L, p->z,
-                                                             &p->buff, p->name);
+  tf = (luaY_parser)(L, p->z, &p->buff, p->name);
   cl = luaF_newLclosure(L, tf->nups, hvalue(gt(L)));
   cl->l.p = tf;
   for (i = 0; i < tf->nups; i++)  /* initialize eventual upvalues */


### PR DESCRIPTION
ldo.c: In function ‘f_parser’:
ldo.c:496:7: warning: unused variable ‘c’ [-Wunused-variable]
   int c = luaZ_lookahead(p->z);
          ^