### PR TITLE
lazyfree: fix memory leak for lazyfree-lazy-server-del

### DIFF
--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -64,9 +64,10 @@ int dbAsyncDelete(redisDb *db, robj *key) {
         robj *val = dictGetVal(de);
         size_t free_effort = lazyfreeGetFreeEffort(val);
 
-        /* If releasing the object is too much work, let's put it into the
-         * lazy free list. */
-        if (free_effort > LAZYFREE_THRESHOLD) {
+        /* If releasing the object is too much work and the refcount
+         * is 1, that means the object really needs to be freed,
+         * let's put it into the lazy free list. */
+        if (free_effort > LAZYFREE_THRESHOLD && val->refcount == 1) {
             atomicIncr(lazyfree_objects,1);
             bioCreateBackgroundJob(BIO_LAZY_FREE,val,NULL,NULL);
             dictSetVal(db->dict,de,NULL);


### PR DESCRIPTION
Hi, @antirez 

We have talked about lazyfree's memory leak problem in issue #4323 , and already fixed a bug about `FLUSHALL ASYNC` and `SLOWLOG`, but now I find another problem...about `lazyfree-lazy-server-del`.

The `lazyfree-lazy-server-del` works in `rename` and `move` command, more accurately it's in `dbDelete()`
```
int dbDelete(redisDb *db, robj *key) {
    return server.lazyfree_lazy_server_del ? dbAsyncDelete(db,key) :
                                             dbSyncDelete(db,key);
}
```

Take `move` command as an example:
```
void moveCommand(client *c) {
...
    o = lookupKeyWrite(c->db,c->argv[1]);
...
    incrRefCount(o);

    /* OK! key moved, free the entry in the source DB */
    dbDelete(src,c->argv[1]);
...
}
```

From the codes above, `o` is the source object, we call `incrRefCount` to increase `o->refcount`, after that and before lazyfree works `o->refcount` is 2...that is the problem which means that we create a race about the shared object, and may result in memory leak.

This PR fixed the memory leak, please check.