### PR TITLE
PSYNC2 fix - promoted slave should hold on to it's backlog

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1970,6 +1970,11 @@ void replicationUnsetMaster(void) {
      * with PSYNC version 2, there is no need for full resync after a
      * master switch. */
     server.slaveseldb = -1;
+
+    /* We need to remember the time when we became a master and lost all
+     * attached slaves (if we had any), as after some time we'll free the
+     * replication backlog. */
+    server.repl_no_slaves_since = server.unixtime;
 }
 
 /* This function is called when the slave lose the connection with the


### PR DESCRIPTION
after a slave is promoted (assuming it has no slaves
and it booted over an hour ago), it will lose it's replication
backlog at the next replication cron, rather than waiting for slaves
to connect to it.
so on a simple master/slave faiover, if the new slave doesn't connect
immediately, it may be too later and PSYNC2 will fail.

```98355:M 16 Jan 10:08:11.384 # Connection with master lost.
98355:M 16 Jan 10:08:11.384 * Caching the disconnected master state.
98355:M 16 Jan 10:08:11.384 * Discarding previously cached master state.
98355:M 16 Jan 10:08:11.384 * MASTER MODE enabled (user request from 'id=6 addr=127.0.0.1:53740 fd=9 name= age=0 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=32768 obl=0 oll=0 omem=0 events=r cmd=slaveof')
98488:M 16 Jan 10:08:11.384 # Connection with slave 127.0.0.1:12345 lost.
98355:M 16 Jan 10:08:12.283 * Replication backlog freed after 3600 seconds without connected slaves.
```