### PR TITLE
fix assert problem in ZIP_DECODE_PREVLENSIZE macro

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -440,7 +440,7 @@ unsigned int zipStorePrevEntryLength(unsigned char *p, unsigned int len) {
     if ((prevlensize) == 1) {                                                  \
         (prevlen) = (ptr)[0];                                                  \
     } else if ((prevlensize) == 5) {                                           \
-        assert(sizeof((prevlensize)) == 4);                                    \
+        assert(sizeof((prevlen)) == 4);                                    \
         memcpy(&(prevlen), ((char*)(ptr)) + 1, 4);                             \
         memrev32ifbe(&prevlen);                                                \
     }                                                                          \


### PR DESCRIPTION
fix assert problem in ZIP_DECODE_PREVLENSIZE macro(in ziplist.c)
, see issue: https://github.com/antirez/redis/issues/4587