### PR TITLE
HSETNX can lead coding type change even when skipped due to NX

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -514,11 +514,11 @@ void hashTypeConvert(robj *o, int enc) {
 void hsetnxCommand(client *c) {
     robj *o;
     if ((o = hashTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
-    hashTypeTryConversion(o,c->argv,2,3);
 
     if (hashTypeExists(o, c->argv[2]->ptr)) {
         addReply(c, shared.czero);
     } else {
+        hashTypeTryConversion(o,c->argv,2,3);
         hashTypeSet(o,c->argv[2]->ptr,c->argv[3]->ptr,HASH_SET_COPY);
         addReply(c, shared.cone);
         signalModifiedKey(c->db,c->argv[1]);


### PR DESCRIPTION
1. Add one key-value pair to myhash, which the length of key and value both less than hash-max-ziplist-value, for example:
>hset myhash key value

2. Then execute the following command
>hsetnx myhash key value1 (the length greater than hash-max-ziplist-value)

3. This will add nothing, but the code type of "myhash" changed from ziplist to dict even there are only one key-value pair in "myhash", and both of them less than hash-max-ziplist-value.