### PR TITLE
fix a problem in ziplist.c

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -705,16 +705,7 @@ unsigned char *__ziplistDelete(unsigned char *zl, unsigned char *p, unsigned int
 
             /* Update offset for tail */
             ZIPLIST_TAIL_OFFSET(zl) =
-                intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))-totlen);
-
-            /* When the tail contains more than one entry, we need to take
-             * "nextdiff" in account as well. Otherwise, a change in the
-             * size of prevlen doesn't have an effect on the *tail* offset. */
-            zipEntry(p, &tail);
-            if (p[tail.headersize+tail.len] != ZIP_END) {
-                ZIPLIST_TAIL_OFFSET(zl) =
-                   intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+nextdiff);
-            }
+                intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))-totlen+nextdiff);
 
             /* Move tail to the front of the ziplist */
             memmove(first.p,p,


### PR DESCRIPTION
Is there a problem about __ziplistDelete function in ziplist.c as follows:
```bash
            /* When the tail contains more than one entry, we need to take
             * "nextdiff" in account as well. Otherwise, a change in the
             * size of prevlen doesn't have an effect on the *tail* offset. */
            zipEntry(p, &tail);
            if (p[tail.headersize+tail.len] != ZIP_END) {
                ZIPLIST_TAIL_OFFSET(zl) =
                   intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+nextdiff);
            }
```
As we know, ZIPLIST_TAIL_OFFSET macro return the offset of the last item(entry) inside the ziplist.
When the tail contians just one entry instead of more than one entry , should we take "nextdiff"
 in account as well?  issue: https://github.com/antirez/redis/issues/4621

Thanks!