### PR TITLE
Add low-level module PubSub publish command

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3600,6 +3600,11 @@ void *RM_GetBlockedClientPrivateData(RedisModuleCtx *ctx) {
     return ctx->blocked_privdata;
 }
 
+/* Publish a message into a PubSub channel. Returns the number of listeners that received it */
+int RM_Publish(RedisModuleString *channel, RedisModuleString *message) {  
+    return pubsubPublishMessage(channel, message);
+}
+
 /* --------------------------------------------------------------------------
  * Thread Safe Contexts
  * -------------------------------------------------------------------------- */
@@ -4037,4 +4042,5 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(DigestAddStringBuffer);
     REGISTER_API(DigestAddLongLong);
     REGISTER_API(DigestEndSequence);
+    REGISTER_API(Publish);
 }

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -251,6 +251,7 @@ RedisModuleCtx *REDISMODULE_API_FUNC(RedisModule_GetThreadSafeContext)(RedisModu
 void REDISMODULE_API_FUNC(RedisModule_FreeThreadSafeContext)(RedisModuleCtx *ctx);
 void REDISMODULE_API_FUNC(RedisModule_ThreadSafeContextLock)(RedisModuleCtx *ctx);
 void REDISMODULE_API_FUNC(RedisModule_ThreadSafeContextUnlock)(RedisModuleCtx *ctx);
+int REDISMODULE_API_FUNC(RedisModule_Publish)(RedisModuleString *channel, RedisModuleString *message);
 #endif
 
 /* This is included inline inside each Redis module. */
@@ -372,6 +373,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(IsBlockedTimeoutRequest);
     REDISMODULE_GET_API(GetBlockedClientPrivateData);
     REDISMODULE_GET_API(AbortBlock);
+    REDISMODULE_GET_API(Publish);
 #endif
 
     if (RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;


### PR DESCRIPTION
This is my go at a low-level API version for PUBLISH.

As you can see it doesn't include much. Interestingly there was no need for a module context to publish, so the command doesn't accept a RedisModuleCtx at all. It looks weird, so if you think that for the sake of consistency or future proofing we should keep it there - I'll add it as an unused parameter for now. 

Also proper testing is not really possible from within the test module as we can't subscribe. So the test just checks that publishing works and that since there are no listeners the return value is 0. I've subscribed manually and saw the messages being received to the client. 