### PR TITLE
redismodule.h: Check ModuleNameBusy before calling it

### DIFF
--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -374,7 +374,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(AbortBlock);
 #endif
 
-    if (RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;
+    if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;
     RedisModule_SetModuleAttribs(ctx,name,ver,apiver);
     return REDISMODULE_OK;
 }


### PR DESCRIPTION
Older versions might not have this function.