### PR TITLE
sds: avoid implicit casting

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -436,7 +436,7 @@ sds sdscpy(sds s, const char *t) {
  * The function returns the length of the null-terminated string
  * representation stored at 's'. */
 #define SDS_LLSTR_SIZE 21
-int sdsll2str(char *s, long long value) {
+size_t sdsll2str(char *s, long long value) {
     char *p, aux;
     unsigned long long v;
     size_t l;
@@ -468,7 +468,7 @@ int sdsll2str(char *s, long long value) {
 }
 
 /* Identical sdsll2str(), but for unsigned long long type. */
-int sdsull2str(char *s, unsigned long long v) {
+size_t sdsull2str(char *s, unsigned long long v) {
     char *p, aux;
     size_t l;
 
@@ -502,7 +502,7 @@ int sdsull2str(char *s, unsigned long long v) {
  */
 sds sdsfromlonglong(long long value) {
     char buf[SDS_LLSTR_SIZE];
-    int len = sdsll2str(buf,value);
+    size_t len = sdsll2str(buf,value);
 
     return sdsnewlen(buf,len);
 }


### PR DESCRIPTION
Happy to see 4.0.7 released.

Many 32 bit overflows are fixed, but still remains some others just like #4594 and #4519, especially #4594 which can result in redis crash.

This PR fixes some implicit casting in `sds.c`, it's not a critical bug, just avoid warning.