### PR TITLE
proto-max-bulk-len should be greater than 1mb

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1651,7 +1651,7 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 
 # In the Redis protocol, bulk requests, that are, elements representing single
 # strings, are normally limited ot 512 mb. However you can change this limit
-# here.
+# here, but must be 1mb or greater
 #
 # proto-max-bulk-len 512mb
 

--- a/src/config.c
+++ b/src/config.c
@@ -2217,7 +2217,7 @@ standardConfig configs[] = {
     createLongLongConfig("cluster-node-timeout", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.cluster_node_timeout, 15000, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("slowlog-log-slower-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.slowlog_log_slower_than, 10000, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, INTEGER_CONFIG, NULL, NULL),
-    createLongLongConfig("proto-max-bulk-len", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.proto_max_bulk_len, 512ll*1024*1024, MEMORY_CONFIG, NULL, NULL), /* Bulk request max size */
+    createLongLongConfig("proto-max-bulk-len", NULL, MODIFIABLE_CONFIG, 1024*1024, LLONG_MAX, server.proto_max_bulk_len, 512ll*1024*1024, MEMORY_CONFIG, NULL, NULL), /* Bulk request max size */
     createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.repl_backlog_size, 1024*1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 1mb */
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1694,7 +1694,8 @@ int processMultibulkBuffer(client *c) {
             }
 
             ok = string2ll(c->querybuf+c->qb_pos+1,newline-(c->querybuf+c->qb_pos+1),&ll);
-            if (!ok || ll < 0 || ll > server.proto_max_bulk_len) {
+            if (!ok || ll < 0 ||
+                (!(c->flags & CLIENT_MASTER) && ll > server.proto_max_bulk_len)) {
                 addReplyError(c,"Protocol error: invalid bulk length");
                 setProtocolError("invalid bulk length",c);
                 return C_ERR;

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -35,8 +35,8 @@
  *----------------------------------------------------------------------------*/
 
 static int checkStringLength(client *c, long long size) {
-    if (size > 512*1024*1024) {
-        addReplyError(c,"string exceeds maximum allowed size (512MB)");
+    if (!(c->flags & CLIENT_MASTER) && size > server.proto_max_bulk_len) {
+        addReplyError(c,"string exceeds maximum allowed size (proto-max-bulk-len)");
         return C_ERR;
     }
     return C_OK;


### PR DESCRIPTION
Hi, proto-max-bulk-len is a good option for user, we can enlarge string limit by ourselves.

But it introduces some new problems at the same time... just like the action below:

```
127.0.0.1:6379> config get proto-max-bulk-len
1) "proto-max-bulk-len"
2) "536870912"
127.0.0.1:6379> config set proto-max-bulk-len 1
OK
127.0.0.1:6379> ping
(error) ERR Protocol error: invalid bulk length
127.0.0.1:6379> config set proto-max-bulk-len 512mb
(error) ERR Protocol error: invalid bulk length
```

Oops... redis can never execute any commands, so I think `proto-max-bulk-len` must be 512mb or greater.

BTW, string's limit should be replaced with `proto-max-bulk-len` instead of 512MB.