### PR TITLE
fix sdsnewlen s_malloc fail, null pointer operator.

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -92,9 +92,9 @@ sds sdsnewlen(const void *init, size_t initlen) {
     unsigned char *fp; /* flags pointer. */
 
     sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
     if (!init)
         memset(sh, 0, hdrlen+initlen+1);
-    if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
     switch(type) {


### PR DESCRIPTION
hi, sdsnewlen s_malloc call failed, sh == NULL, and memset(sh, 0, ...) cause segment fault