### PR TITLE
aof rewrite contains lua

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1195,6 +1195,15 @@ int rewriteAppendOnlyFileRio(rio *aof) {
         dictReleaseIterator(di);
         di = NULL;
     }
+    char scriptloadcmd[]="*3\r\n$6\r\nSCRIPT\r\n$4\r\nLOAD\r\n";
+    di = dictGetIterator(server.lua_scripts);
+    while((de = dictNext(di)) != NULL) {
+        robj* script=dictGetVal(de);
+        if (rioWrite(aof,scriptloadcmd,sizeof(scriptloadcmd)-1) == 0) goto werr;
+        if (rioWriteBulkObject(aof,script) == 0) goto werr;
+    }
+    dictReleaseIterator(di);
+    di = NULL;
     return C_OK;
 
 werr:


### PR DESCRIPTION
I try to achieve a serial number generator that can match different rules using Redis. I write the rules of the sequence number generation by writing the Lua function. These Lua scripts are persisted into Redis through AOF and are part of the initialization during deployment. These scripts have a total of about 200K. 

When I was doing a stress test, the AOF file was rewritten, and I noticed that the scripts has gone with the wind in the rewritten file. This means that if all nodes is downed (e.g. server relocation), the script will no longer exist. In this scenario, both data and the script need to persist. 

Then I modified the method in aof.c ,adding lua_script to the rewrite scope and test it through. 
