### PR TITLE
exclude replication backlog when computing used memory for key eviction

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -346,9 +346,9 @@ unsigned long LFUDecrAndReturn(robj *o) {
  * server when there is data to add in order to make space if needed.
  * --------------------------------------------------------------------------*/
 
-/* We don't want to count AOF buffers and slaves output buffers as
+/* We don't want to count AOF buffers, replication backlog and slaves output buffers as
  * used memory: the eviction should use mostly data size. This function
- * returns the sum of AOF and slaves buffer. */
+ * returns the sum of AOF and slaves buffer, and replication backlog. */
 size_t freeMemoryGetNotCountedMemory(void) {
     size_t overhead = 0;
     int slaves = listLength(server.slaves);
@@ -366,6 +366,7 @@ size_t freeMemoryGetNotCountedMemory(void) {
     if (server.aof_state != AOF_OFF) {
         overhead += sdslen(server.aof_buf)+aofRewriteBufferSize();
     }
+    if (server.repl_backlog) overhead += zmalloc_size(server.repl_backlog);
     return overhead;
 }
 


### PR DESCRIPTION
Sometimes in order to complete a full resync on a write traffic burst situation, we need to increase the size of replication backlog. 

I have encountered a situation where replication backlog is set to 4GB which caused most of the keys in database evicted. This may be beyond my expectation and other Redis users'.  

So i think exclude the replication backlog when computing used memory is a better idea, after all replication log is kind of cache and shouldn't be considered as part of data set. 