### PR TITLE
RESP: support process inline commands that split with \n

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1083,7 +1083,7 @@ void resetClient(client *c) {
  * with the error and close the connection. */
 int processInlineBuffer(client *c) {
     char *newline;
-    int argc, j;
+    int argc, j, next=1;
     sds *argv, aux;
     size_t querylen;
 
@@ -1100,7 +1100,7 @@ int processInlineBuffer(client *c) {
     }
 
     /* Handle the \r\n case. */
-    if (newline && newline != c->querybuf && *(newline-1) == '\r')
+    if (newline && newline != c->querybuf && *(newline-1) == '\r' && ++next)
         newline--;
 
     /* Split the input buffer up to the \r\n */
@@ -1121,7 +1121,7 @@ int processInlineBuffer(client *c) {
         c->repl_ack_time = server.unixtime;
 
     /* Leave data after the first line of the query in the buffer */
-    sdsrange(c->querybuf,querylen+2,-1);
+    sdsrange(c->querybuf,querylen+next,-1);
 
     /* Setup argv array on client structure */
     if (argc) {


### PR DESCRIPTION
Hi, 
When I wrote a script for Redis, I found a small problem.
When I use '\n', Redis will lose the first letter of the next command.

![image](https://user-images.githubusercontent.com/8869963/36060073-7b382c38-0e7c-11e8-999b-235a5e9abf70.png)

Signed-off-by: charpty <charpty@gmail.com>