### PR TITLE
Fix typo in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -561,7 +561,7 @@ slave-priority 100
 # maxmemory <bytes>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
-# is reached. You can select among five behaviors:
+# is reached. You can select among eight behaviors:
 #
 # volatile-lru -> Evict using approximated LRU among the keys with an expire set.
 # allkeys-lru -> Evict any key using approximated LRU.


### PR DESCRIPTION
Fix `five behaviors` to `eight behaviors` in [this sentence ](https://github.com/antirez/redis/blob/unstable/redis.conf#L564)