### PR TITLE
fix to latency monitor reporting wrong max latency

### DIFF
--- a/src/latency.c
+++ b/src/latency.c
@@ -115,6 +115,7 @@ void latencyAddSample(char *event, mstime_t latency) {
     if (ts->samples[prev].time == now) {
         if (latency > ts->samples[prev].latency)
             ts->samples[prev].latency = latency;
+        if (latency > ts->max) ts->max = latency;
         return;
     }
 


### PR DESCRIPTION
in some cases LATENCY HISTORY reported latency that was
higher than the max latency reported by LATENCY LATEST / DOCTOR