### PR TITLE
Removing duplicated code to set max latency 

### DIFF
--- a/src/latency.c
+++ b/src/latency.c
@@ -109,19 +109,19 @@ void latencyAddSample(char *event, mstime_t latency) {
         dictAdd(server.latency_events,zstrdup(event),ts);
     }
 
+    if (latency > ts->max) ts->max = latency;
+
     /* If the previous sample is in the same second, we update our old sample
      * if this latency is > of the old one, or just return. */
     prev = (ts->idx + LATENCY_TS_LEN - 1) % LATENCY_TS_LEN;
     if (ts->samples[prev].time == now) {
         if (latency > ts->samples[prev].latency)
             ts->samples[prev].latency = latency;
-        if (latency > ts->max) ts->max = latency;
         return;
     }
 
     ts->samples[ts->idx].time = time(NULL);
     ts->samples[ts->idx].latency = latency;
-    if (latency > ts->max) ts->max = latency;
 
     ts->idx++;
     if (ts->idx == LATENCY_TS_LEN) ts->idx = 0;


### PR DESCRIPTION
we can remove duplicated code to move setting max latency code in front of function. 