### PR TITLE
Added a monotonic clock read.

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -89,7 +89,7 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
 
     if (tval > 0) {
         if (unit == UNIT_SECONDS) tval *= 1000;
-        tval += mstime();
+        tval += mstime_monotonic();
     }
     *timeout = tval;
 

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -138,12 +138,18 @@ static int cliConnect(int force);
  *--------------------------------------------------------------------------- */
 
 static long long ustime(void) {
-    struct timeval tv;
     long long ust;
-
+#ifdef CLOCK_MONOTONIC
+   struct timespec tv;
+   clock_gettime(CLOCK_MONOTONIC, &tv);
+   ust = ((long long)tv.tv_sec) *1000000;
+   ust += (tv.tv_nsec / 1000);
+#else
+    struct timeval tv;
     gettimeofday(&tv, NULL);
     ust = ((long long)tv.tv_sec)*1000000;
     ust += tv.tv_usec;
+#endif
     return ust;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -417,6 +417,18 @@ mstime_t mstime(void) {
     return ustime()/1000;
 }
 
+/* Return the UNIX monotonic time in milliseconds */
+mstime_t mstime_monotonic(void) {
+#if CLOCK_MONOTONIC
+    struct timespec tv;
+    
+    clock_gettime(CLOCK_MONOTONIC, &tv);
+    return ((tv.tv_sec*1000)+(tv.tv_nsec/1000000));
+#else
+    return mstime();
+#endif
+}
+
 /* After an RDB dump or AOF rewrite we exit from children using _exit() instead of
  * exit(), because the latter may interact with the same file objects used by
  * the parent process. However if we are testing the coverage normal exit() is

--- a/src/server.h
+++ b/src/server.h
@@ -1343,6 +1343,7 @@ void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid)
 /* Utils */
 long long ustime(void);
 long long mstime(void);
+long long monotonic_mstime(void);
 void getRandomHexChars(char *p, unsigned int len);
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
 void exitFromChild(int retcode);


### PR DESCRIPTION
The monotonic clock can be used for block requests
or user timeouts as settimeofday does not affect
this clock.

This was based on tycho:monotonic-clock work but with a smaller scope. 