### PR TITLE
Fix zrealloc to behave similarly to je_realloc when size is 0

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -147,6 +147,10 @@ void *zrealloc(void *ptr, size_t size) {
     size_t oldsize;
     void *newptr;
 
+    if (size == 0 && ptr!=NULL) {
+        zfree(ptr);
+        return NULL;
+    }
     if (ptr == NULL) return zmalloc(size);
 #ifdef HAVE_MALLOC_SIZE
     oldsize = zmalloc_size(ptr);


### PR DESCRIPTION
According to C11, the behavior of realloc with size 0 is now deprecated.
it can either behave as free(ptr) and return NULL, or return a valid pointer.
But in zmalloc it can lead to zmalloc_oom_handler and panic.

Note that this can affect modules that use it, and modules can even pass the allocation function to other libraries they use, which may rely on the scenario crash instead.

It looks like both glibc allocator and jemalloc behave like so:
  realloc(malloc(32),0) returns NULL
  realloc(NULL,0) returns a valid pointer

This commit changes zmalloc to behave the same