### PR TITLE
Fix using shared integers when maxmemory is used with decr/incr

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -123,7 +123,10 @@ robj *createStringObject(const char *ptr, size_t len) {
 
 robj *createStringObjectFromLongLong(long long value) {
     robj *o;
-    if (value >= 0 && value < OBJ_SHARED_INTEGERS) {
+    if (!(server.maxmemory_policy & MAXMEMORY_FLAG_NO_SHARED_INTEGERS) &&
+        value >= 0 &&
+        value < OBJ_SHARED_INTEGERS)
+    {
         incrRefCount(shared.integers[value]);
         o = shared.integers[value];
     } else {
@@ -414,8 +417,7 @@ robj *tryObjectEncoding(robj *o) {
          * Note that we avoid using shared integers when maxmemory is used
          * because every object needs to have a private LRU field for the LRU
          * algorithm to work well. */
-        if ((server.maxmemory == 0 ||
-            !(server.maxmemory_policy & MAXMEMORY_FLAG_NO_SHARED_INTEGERS)) &&
+        if (!(server.maxmemory_policy & MAXMEMORY_FLAG_NO_SHARED_INTEGERS) &&
             value >= 0 &&
             value < OBJ_SHARED_INTEGERS)
         {


### PR DESCRIPTION
key `a` will share LRU field with key `b` as following steps:

	127.0.0.1:6379> config set maxmemory 100M
	OK
	127.0.0.1:6379> config set maxmemory-policy allkeys-lfu
	OK
	127.0.0.1:6379> set a 10000
	OK
	127.0.0.1:6379> decr a
	(integer) 9999
	....(repeat get a to increase lfu count)
	127.0.0.1:6379> object freq a
	(integer) 50
	127.0.0.1:6379> set b 10000
	OK
	127.0.0.1:6379> decr b
	(integer) 9999
	127.0.0.1:6379> object freq a
	(integer) 6
	127.0.0.1:6379> object freq b
	(integer) 6