### PR TITLE
Fixes reply of SPOP w/ COUNT when key doesn't exist

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -415,7 +415,7 @@ void spopWithCountCommand(client *c) {
 
     /* Make sure a key with the name inputted exists, and that it's type is
      * indeed a set. Otherwise, return nil */
-    if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.emptymultibulk))
+    if ((set = lookupKeyReadOrReply(c,c->argv[1],shared.nullbulk))
         == NULL || checkType(c,set,OBJ_SET)) return;
 
     /* If count is zero, serve an empty multibulk ASAP to avoid special


### PR DESCRIPTION
In order to maintain consistency with the rest of the API and docs.

Fixes #4709