### PR TITLE
[BugFix] Fix out of array index range for findBigKeys in redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2077,6 +2077,7 @@ static void pipeMode(void) {
 #define TYPE_ZSET   4
 #define TYPE_STREAM 5
 #define TYPE_NONE   6
+#define TYPE_MAX_KEYS TYPE_NONE
 
 static redisReply *sendScan(unsigned long long *it) {
     redisReply *reply = redisCommand(context, "SCAN %llu", *it);
@@ -2222,9 +2223,9 @@ static void getKeySizes(redisReply *keys, int *types,
 }
 
 static void findBigKeys(void) {
-    unsigned long long biggest[5] = {0}, counts[5] = {0}, totalsize[5] = {0};
+    unsigned long long biggest[TYPE_MAX_KEYS] = {0}, counts[TYPE_MAX_KEYS] = {0}, totalsize[TYPE_MAX_KEYS] = {0};
     unsigned long long sampled = 0, total_keys, totlen=0, *sizes=NULL, it=0;
-    sds maxkeys[5] = {0};
+    sds maxkeys[TYPE_MAX_KEYS] = {0};
     char *typename[] = {"string","list","set","hash","zset","stream"};
     char *typeunit[] = {"bytes","items","members","fields","members"};
     redisReply *reply, *keys;


### PR DESCRIPTION
TYPE_NONE is 6
but array is allocated with 5.
it causes index range issue.