### PR TITLE
KEYS command, reduce excess malloc and memcpy

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1725,6 +1725,7 @@ int rewriteConfig(char *path);
 int removeExpire(redisDb *db, robj *key);
 void propagateExpire(redisDb *db, robj *key, int lazy);
 int expireIfNeeded(redisDb *db, robj *key);
+int expireIfNeededSds(redisDb *db, sds key);
 long long getExpire(redisDb *db, robj *key);
 void setExpire(client *c, redisDb *db, robj *key, long long when);
 robj *lookupKey(redisDb *db, robj *key, int flags);


### PR DESCRIPTION
Following the changes in redis 4.0, keys command became inefficient.
it creates an robj from the sds to send it to the output buffer, but
the output buffer can't use that robj now, and it copies the memory again.

The other reason this code needs an robj is for expireIfNeeded,
which needs the robj in heap only if it decides to expire that key.

This commit adds a version of expireIfNeededSds that creates a heap
based robj only if it needs one. This function can be used in places
that don't already have an robj in hand, and only have an sds.