### PR TITLE
slave buffers were wasteful and incorrectly counted causing eviction

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -35,13 +35,6 @@
 
 static void setProtocolError(const char *errstr, client *c, long pos);
 
-/* Return the size consumed from the allocator, for the specified SDS string,
- * including internal fragmentation. This function is used in order to compute
- * the client output buffer size. */
-size_t sdsZmallocSize(sds s) {
-    void *sh = sdsAllocPtr(s);
-    return zmalloc_size(sh);
-}
 
 /* Return the amount of memory used by the sds string at object->ptr
  * for a string object. */
@@ -233,84 +226,80 @@ int _addReplyToBuffer(client *c, const char *s, size_t len) {
     return C_OK;
 }
 
-void _addReplyObjectToList(client *c, robj *o) {
+/* This method copies the input data, caller is responsible of freeing it */
+void _addReplyStringToList(client *c, const char *s, size_t len) {
     if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return;
 
-    if (listLength(c->reply) == 0) {
-        sds s = sdsdup(o->ptr);
-        listAddNodeTail(c->reply,s);
-        c->reply_bytes += sdslen(s);
-    } else {
-        listNode *ln = listLast(c->reply);
-        sds tail = listNodeValue(ln);
+    listNode *ln = listLast(c->reply);
+    sds tail = ln? listNodeValue(ln): NULL;
+    /* It is possible that we have a tail list node, but no tail sds.
+     * if addDeferredMultiBulkLength() was used. */
 
-        /* Append to this object when possible. If tail == NULL it was
-         * set via addDeferredMultiBulkLength(). */
-        if (tail && sdslen(tail)+sdslen(o->ptr) <= PROTO_REPLY_CHUNK_BYTES) {
-            tail = sdscatsds(tail,o->ptr);
-            listNodeValue(ln) = tail;
-            c->reply_bytes += sdslen(o->ptr);
-        } else {
-            sds s = sdsdup(o->ptr);
-            listAddNodeTail(c->reply,s);
-            c->reply_bytes += sdslen(s);
+    /* Append to tail string when possible. */
+    if (tail) {
+        if (sdsavail(tail) >= len) {
+            /* We can encode the entire new string inside the existing tail's free space */
+            tail = sdscatlen(tail,s,len);
+            serverAssert(tail == listNodeValue(ln));
+            len = 0;
+            /* No need to adjust c->reply_bytes */
+        } else if (sdslen(tail) < PROTO_REPLY_CHUNK_BYTES) {
+            /* We can fit at least part of the new string into the tail (considering the limit).
+             * but check if the target sds is already at the desired size, so that we can
+             * avoid sdsMallocSize (which is slow) the realloc attempt */
+            if (sdsalloc(tail) != PROTO_REPLY_CHUNK_BYTES) {
+                /* We can grow the existing tail to include at least part of the new string,
+                 * make sure to grow to at least PROTO_REPLY_CHUNK_BYTES */
+                c->reply_bytes -= sdsMallocSize(tail);
+                tail = sdsMakeRoomForExact(tail, PROTO_REPLY_CHUNK_BYTES - sdslen(tail));
+                listNodeValue(ln) = tail;
+                c->reply_bytes += sdsGrowToMallocSize(tail);
+            }
+            /* Copy the part we can fit into the tail, and leave the rest for a new node */
+            size_t avail = sdsavail(tail);
+            size_t copy = avail >= len? len: avail;
+            tail = sdscatlen(tail,s,copy);
+            serverAssert(tail == listNodeValue(ln));
+            s += copy;
+            len -= copy;
         }
+    }
+    if (len) {
+        /* Create a new node, make sure it is allocated to at least PROTO_REPLY_CHUNK_BYTES */
+        size_t extra = len < PROTO_REPLY_CHUNK_BYTES? PROTO_REPLY_CHUNK_BYTES - len: 0;
+        sds node = sdsnewalloc(s,len,extra);
+        listAddNodeTail(c->reply,node);
+        c->reply_bytes += sdsGrowToMallocSize(node);
     }
     asyncCloseClientOnOutputBufferLimitReached(c);
 }
 
 /* This method takes responsibility over the sds. When it is no longer
- * needed it will be free'd, otherwise it ends up in a robj. */
+ * needed it will be free'd. */
 void _addReplySdsToList(client *c, sds s) {
     if (c->flags & CLIENT_CLOSE_AFTER_REPLY) {
         sdsfree(s);
         return;
     }
 
-    if (listLength(c->reply) == 0) {
+    listNode *ln = listLast(c->reply);
+    sds tail = ln? listNodeValue(ln): NULL;
+    /* It is possible that we have a tail list node, but no tail sds.
+     * if addDeferredMultiBulkLength() was used. */
+
+    /* Create a new node when necessary. */
+    if (!tail || sdslen(s) > PROTO_REPLY_CHUNK_BYTES * 4) {
+        /* If we have to start a new node,
+         * or, on big strings, create a new node, don't do any realloc or memcpy
+         * the relative size of the wasted memory is small. */
         listAddNodeTail(c->reply,s);
-        c->reply_bytes += sdslen(s);
+        c->reply_bytes += sdsGrowToMallocSize(s);
     } else {
-        listNode *ln = listLast(c->reply);
-        sds tail = listNodeValue(ln);
-
-        /* Append to this object when possible. If tail == NULL it was
-         * set via addDeferredMultiBulkLength(). */
-        if (tail && sdslen(tail)+sdslen(s) <= PROTO_REPLY_CHUNK_BYTES) {
-            tail = sdscatsds(tail,s);
-            listNodeValue(ln) = tail;
-            c->reply_bytes += sdslen(s);
-            sdsfree(s);
-        } else {
-            listAddNodeTail(c->reply,s);
-            c->reply_bytes += sdslen(s);
-        }
-    }
-    asyncCloseClientOnOutputBufferLimitReached(c);
-}
-
-void _addReplyStringToList(client *c, const char *s, size_t len) {
-    if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return;
-
-    if (listLength(c->reply) == 0) {
-        sds node = sdsnewlen(s,len);
-        listAddNodeTail(c->reply,node);
-        c->reply_bytes += len;
-    } else {
-        listNode *ln = listLast(c->reply);
-        sds tail = listNodeValue(ln);
-
-        /* Append to this object when possible. If tail == NULL it was
-         * set via addDeferredMultiBulkLength(). */
-        if (tail && sdslen(tail)+len <= PROTO_REPLY_CHUNK_BYTES) {
-            tail = sdscatlen(tail,s,len);
-            listNodeValue(ln) = tail;
-            c->reply_bytes += len;
-        } else {
-            sds node = sdsnewlen(s,len);
-            listAddNodeTail(c->reply,node);
-            c->reply_bytes += len;
-        }
+        /* we can encode the new string inside the existing tail's free space, */
+        /* or split the string, let _addReplyStringToList handle it. */
+        _addReplyStringToList(c, (const char*)s, sdslen(s));
+        sdsfree(s);
+        return; /* asyncCloseClientOnOutputBufferLimitReached already triggered */
     }
     asyncCloseClientOnOutputBufferLimitReached(c);
 }
@@ -332,7 +321,7 @@ void addReply(client *c, robj *obj) {
      * messing with its page. */
     if (sdsEncodedObject(obj)) {
         if (_addReplyToBuffer(c,obj->ptr,sdslen(obj->ptr)) != C_OK)
-            _addReplyObjectToList(c,obj);
+            _addReplyStringToList(c,obj->ptr,sdslen(obj->ptr));
     } else if (obj->encoding == OBJ_ENCODING_INT) {
         /* Optimization: if there is room in the static buffer for 32 bytes
          * (more than the max chars a 64 bit integer can take as string) we
@@ -349,7 +338,7 @@ void addReply(client *c, robj *obj) {
         }
         obj = getDecodedObject(obj);
         if (_addReplyToBuffer(c,obj->ptr,sdslen(obj->ptr)) != C_OK)
-            _addReplyObjectToList(c,obj);
+            _addReplyStringToList(c,obj->ptr,sdslen(obj->ptr));
         decrRefCount(obj);
     } else {
         serverPanic("Wrong obj->encoding in addReply()");
@@ -454,21 +443,19 @@ void setDeferredMultiBulkLength(client *c, void *node, long length) {
     /* Abort when *node is NULL: when the client should not accept writes
      * we return NULL in addDeferredMultiBulkLength() */
     if (node == NULL) return;
+    serverAssert(!listNodeValue(ln));
 
     len = sdscatprintf(sdsnewlen("*",1),"%ld\r\n",length);
     listNodeValue(ln) = len;
-    c->reply_bytes += sdslen(len);
-    if (ln->next != NULL) {
-        next = listNodeValue(ln->next);
-
+    if (ln->next != NULL && (next = listNodeValue(ln->next))) {
         /* Only glue when the next node is non-NULL (an sds in this case) */
-        if (next != NULL) {
-            len = sdscatsds(len,next);
-            listDelNode(c->reply,ln->next);
-            listNodeValue(ln) = len;
-            /* No need to update c->reply_bytes: we are just moving the same
-             * amount of bytes from one node to another. */
-        }
+        c->reply_bytes -= sdsMallocSize(next);
+        len = sdscatsds(len,next);
+        c->reply_bytes += sdsMallocSize(len);
+        listDelNode(c->reply,ln->next);
+        listNodeValue(ln) = len;
+    } else {
+        c->reply_bytes += sdsMallocSize(len);
     }
     asyncCloseClientOnOutputBufferLimitReached(c);
 }
@@ -626,11 +613,20 @@ void addReplyHelp(client *c, const char **help) {
  * The function takes care of freeing the old output buffers of the
  * destination client. */
 void copyClientOutputBuffer(client *dst, client *src) {
+    listIter li;
+    listNode *ln;
     listRelease(dst->reply);
     dst->reply = listDup(src->reply);
     memcpy(dst->buf,src->buf,src->bufpos);
     dst->bufpos = src->bufpos;
-    dst->reply_bytes = src->reply_bytes;
+    /* we have to re-compute the reply_bytes, since there's a chance
+     * sdsMallocSize give a different size after sdsdup */
+    dst->reply_bytes = 0;
+    listRewind(dst->reply,&li);
+    while((ln = listNext(&li))) {
+        sds o = listNodeValue(ln);
+        dst->reply_bytes += sdsMallocSize(o);
+    }
 }
 
 /* Return true if the specified client has pending reply buffers to write to
@@ -951,6 +947,7 @@ int writeToClient(int fd, client *c, int handler_installed) {
             objlen = sdslen(o);
 
             if (objlen == 0) {
+                c->reply_bytes -= sdsMallocSize(o);
                 listDelNode(c->reply,listFirst(c->reply));
                 continue;
             }
@@ -962,9 +959,9 @@ int writeToClient(int fd, client *c, int handler_installed) {
 
             /* If we fully sent the object on head go to the next one */
             if (c->sentlen == objlen) {
+                c->reply_bytes -= sdsMallocSize(o);
                 listDelNode(c->reply,listFirst(c->reply));
                 c->sentlen = 0;
-                c->reply_bytes -= objlen;
                 /* If there are no longer objects in the list, we expect
                  * the count of reply bytes to be exactly zero. */
                 if (listLength(c->reply) == 0)
@@ -1871,11 +1868,7 @@ void rewriteClientCommandArgument(client *c, int i, robj *newval) {
  * the caller wishes. The main usage of this function currently is
  * enforcing the client output length limits. */
 unsigned long getClientOutputBufferMemoryUsage(client *c) {
-    unsigned long list_item_size = sizeof(listNode)+5;
-    /* The +5 above means we assume an sds16 hdr, may not be true
-     * but is not going to be a problem. */
-
-    return c->reply_bytes + (list_item_size*listLength(c->reply));
+    return c->reply_bytes + sizeof(listNode)*listLength(c->reply);
 }
 
 /* Get the class of a client, used in order to enforce limits to different

--- a/src/replication.c
+++ b/src/replication.c
@@ -2140,6 +2140,7 @@ void replicationCacheMaster(client *c) {
     server.master->read_reploff = server.master->reploff;
     if (c->flags & CLIENT_MULTI) discardTransaction(c);
     listEmpty(c->reply);
+    c->reply_bytes = 0;
     c->bufpos = 0;
     resetClient(c);
 

--- a/src/sds.h
+++ b/src/sds.h
@@ -216,6 +216,7 @@ static inline void sdssetalloc(sds s, size_t newlen) {
 }
 
 sds sdsnewlen(const void *init, size_t initlen);
+sds sdsnewalloc(const void *init, size_t initlen, size_t extra);
 sds sdsnew(const char *init);
 sds sdsempty(void);
 sds sdsdup(const sds s);
@@ -254,10 +255,13 @@ sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
 
 /* Low level functions exposed to the user API */
 sds sdsMakeRoomFor(sds s, size_t addlen);
+sds sdsMakeRoomForExact(sds s, size_t addlen);
 void sdsIncrLen(sds s, ssize_t incr);
 sds sdsRemoveFreeSpace(sds s);
 size_t sdsAllocSize(sds s);
 void *sdsAllocPtr(sds s);
+size_t sdsMallocSize(sds s);
+size_t sdsGrowToMallocSize(sds s);
 
 /* Export the allocator used by SDS to the program using SDS.
  * Sometimes the program SDS is linked to, may use a different set of
@@ -266,6 +270,7 @@ void *sdsAllocPtr(sds s);
 void *sds_malloc(size_t size);
 void *sds_realloc(void *ptr, size_t size);
 void sds_free(void *ptr);
+size_t sds_malloc_size(void *ptr);
 
 #ifdef REDIS_TEST
 int sdsTest(int argc, char *argv[]);

--- a/src/sdsalloc.h
+++ b/src/sdsalloc.h
@@ -40,3 +40,4 @@
 #define s_malloc zmalloc
 #define s_realloc zrealloc
 #define s_free zfree
+#define s_malloc_size zmalloc_size

--- a/src/server.c
+++ b/src/server.c
@@ -2998,6 +2998,11 @@ sds genRedisInfoString(char *section) {
             "maxmemory_human:%s\r\n"
             "maxmemory_policy:%s\r\n"
             "mem_fragmentation_ratio:%.2f\r\n"
+            "mem_not_counted_for_evict:%zu\r\n"
+            "mem_replication_backlog:%zu\r\n"
+            "mem_clients_slaves:%zu\r\n"
+            "mem_clients_normal:%zu\r\n"
+            "mem_aof_buffer:%zu\r\n"
             "mem_allocator:%s\r\n"
             "active_defrag_running:%d\r\n"
             "lazyfree_pending_objects:%zu\r\n",
@@ -3020,6 +3025,11 @@ sds genRedisInfoString(char *section) {
             maxmemory_hmem,
             evict_policy,
             mh->fragmentation,
+            freeMemoryGetNotCountedMemory(),
+            mh->repl_backlog,
+            mh->clients_slaves,
+            mh->clients_normal,
+            mh->aof_buffer,
             ZMALLOC_LIB,
             server.active_defrag_running,
             lazyfreeGetPendingObjectsCount()

--- a/src/server.h
+++ b/src/server.h
@@ -179,7 +179,7 @@ typedef long long mstime_t; /* millisecond time type. */
 /* Protocol and I/O related defines */
 #define PROTO_MAX_QUERYBUF_LEN  (1024*1024*1024) /* 1GB max query buffer. */
 #define PROTO_IOBUF_LEN         (1024*16)  /* Generic I/O buffer size */
-#define PROTO_REPLY_CHUNK_BYTES (16*1024) /* 16k output buffer */
+#define PROTO_REPLY_CHUNK_BYTES (16*1024 - 6) /* 16k output buffer (minus sds header, so that we don't have internal fragmentation) */
 #define PROTO_INLINE_MAX_SIZE   (1024*64) /* Max size of inline reads */
 #define PROTO_MBULK_BIG_ARG     (1024*32)
 #define LONG_STR_SIZE      21          /* Bytes needed for long -> str + '\0' */
@@ -1379,7 +1379,7 @@ void addReplyLongLong(client *c, long long ll);
 void addReplyMultiBulkLen(client *c, long length);
 void addReplyHelp(client *c, const char **help);
 void copyClientOutputBuffer(client *dst, client *src);
-size_t sdsZmallocSize(sds s);
+#define sdsZmallocSize sdsMallocSize
 size_t getStringObjectSdsUsedMemory(robj *o);
 void *dupClientReplyValue(void *o);
 void getClientsMaxBuffers(unsigned long *longest_output_list,
@@ -1619,6 +1619,7 @@ int zslLexValueGteMin(sds value, zlexrangespec *spec);
 int zslLexValueLteMax(sds value, zlexrangespec *spec);
 
 /* Core functions */
+size_t freeMemoryGetNotCountedMemory();
 int freeMemoryIfNeeded(void);
 int processCommand(client *c);
 void setupSignalHandlers(void);

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -142,3 +142,95 @@ start_server {tags {"maxmemory"}} {
         }
     }
 }
+
+proc test_slave_buffers {cmd_count payload_len limit_memory pipeline} {
+    start_server {tags {"maxmemory"}} {
+        start_server {} {
+            set slave [srv 0 client]
+            set slave_host [srv 0 host]
+            set slave_port [srv 0 port]
+            set master [srv -1 client]
+            set master_host [srv -1 host]
+            set master_port [srv -1 port]
+
+            # add 100 keys of 100k (10MB total)
+            for {set j 0} {$j < 100} {incr j} {
+                $master setrange "key:$j" 100000 asdf
+            }
+
+            $master config set maxmemory-policy allkeys-random
+            $master config set client-output-buffer-limit "slave 100000000 100000000 60"
+            $master config set repl-backlog-size [expr {10*1024}]
+
+            $slave slaveof $master_host $master_port
+            wait_for_condition 50 100 {
+                [s 0 master_link_status] eq {up}
+            } else {
+                fail "Replication not started."
+            }
+
+            # measure used memory after the slave connected and set maxmemory
+            set orig_used [s -1 used_memory]
+            set orig_client_buf [s -1 mem_clients_normal]
+            set orig_mem_not_counted_for_evict [s -1 mem_not_counted_for_evict]
+            set orig_used_no_repl [expr {$orig_used - $orig_mem_not_counted_for_evict}]
+            set limit [expr {$orig_used - $orig_mem_not_counted_for_evict + 20*1024}]
+
+            if {$limit_memory==1} {
+                $master config set maxmemory $limit
+            }
+
+            # put the slave to sleep
+            set rd_slave [redis_deferring_client]
+            $rd_slave debug sleep 60
+
+            # send some 10mb woth of commands that don't increase the memory usage
+            if {$pipeline == 1} {
+                set rd_master [redis_deferring_client -1]
+                for {set k 0} {$k < $cmd_count} {incr k} {
+                    $rd_master setrange key:0 0 [string repeat A $payload_len]
+                }
+                for {set k 0} {$k < $cmd_count} {incr k} {
+                    #$rd_master read
+                }
+            } else {
+                for {set k 0} {$k < $cmd_count} {incr k} {
+                    $master setrange key:0 0 [string repeat A $payload_len]
+                }
+            }
+
+            set new_used [s -1 used_memory]
+            set slave_buf [s -1 mem_clients_slaves]
+            set client_buf [s -1 mem_clients_normal]
+            set mem_not_counted_for_evict [s -1 mem_not_counted_for_evict]
+            set used_no_repl [expr {$new_used - $mem_not_counted_for_evict}]
+            set delta [expr {($used_no_repl - $client_buf) - ($orig_used_no_repl - $orig_client_buf)}]
+
+            assert {[$master dbsize] == 100}
+            assert {$slave_buf > 2*1024*1024} ;# some of the data may have been pushed to the OS buffers
+            assert {$delta < 50*1024 && $delta > -50*1024} ;# 1 byte unaccounted for, with 1M commands will consume some 1MB
+
+            $master client kill type slave
+            set killed_used [s -1 used_memory]
+            set killed_slave_buf [s -1 mem_clients_slaves]
+            set killed_mem_not_counted_for_evict [s -1 mem_not_counted_for_evict]
+            set killed_used_no_repl [expr {$killed_used - $killed_mem_not_counted_for_evict}]
+            set delta_no_repl [expr {$killed_used_no_repl - $used_no_repl}]
+            assert {$killed_slave_buf == 0}
+            assert {$delta_no_repl > -50*1024 && $delta_no_repl < 50*1024} ;# 1 byte unaccounted for, with 1M commands will consume some 1MB
+        }
+    }
+}
+
+test {slave buffer are counted correctly} {
+    # we wanna use many small commands, and we don't wanna wait long
+    # so we need to use a pipeline (redis_deferring_client)
+    # that may cause query buffer to fill and induce eviction, so we disable it
+    test_slave_buffers 1000000 10 0 1
+}
+
+test {slave buffer don't induce eviction} {
+    # test again with fewer (and bigger) commands without pipeline, but with eviction
+    test_slave_buffers 100000 100 1 0
+}
+


### PR DESCRIPTION
- slave buffers didn't count internal fragmentation and sds unused space,
  this caused them to induce eviction although we didn't mean for it.
- slave buffers were consuming about twice the memory of what they actually needed
  this was mainly due to sdsMakeRoomFor growing to twice as much as needed each time
  but networking.c never storing more than 16k and usually less since wasn't able to
  store half of the new string into one buffer and the other half into the next.
- inefficient performance due to starting from a small string and reallocing many times.

what i changed:
- counting slave buffers size with zmalloc_size
- when creating a new sds reply node from char*, preallocate it to 16k
- when creating a new sds reply node from an existing sds, keep the sds (without memcpy)
  but grow the logical size of the sds so that it takes over it's internal fragmentation
- when appending a new reply to the buffer, first fill all the unused space of the previous
  node before starting a new one

other changes:
- bugfix in sdsReqType creating 64bit headers on 32bit systems
- additional intefaces for sds library in order to support the above listed changes
- expose mem_not_counted_for_evict info field for the benefit of the test suite
- add a test to make sure slave buffers are counted correctly and that they don't cause eviction