### PR TITLE
Refactoring to call aeDeleteFileEvent twice as once

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -581,8 +581,7 @@ clusterLink *createClusterLink(clusterNode *node) {
  * with this link will have the 'link' field set to NULL. */
 void freeClusterLink(clusterLink *link) {
     if (link->fd != -1) {
-        aeDeleteFileEvent(server.el, link->fd, AE_WRITABLE);
-        aeDeleteFileEvent(server.el, link->fd, AE_READABLE);
+        aeDeleteFileEvent(server.el, link->fd, AE_READABLE|AE_WRITABLE);
     }
     sdsfree(link->sndbuf);
     sdsfree(link->rcvbuf);


### PR DESCRIPTION
We don't need to call aeDeleteFileEvent twice.
we can remove one system call to merge these conditions.