### PR TITLE
move getClientsMaxBuffers func into  info clients command

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2866,7 +2866,6 @@ sds genRedisInfoString(char *section) {
 
     getrusage(RUSAGE_SELF, &self_ru);
     getrusage(RUSAGE_CHILDREN, &c_ru);
-    getClientsMaxBuffers(&lol,&bib);
 
     /* Server */
     if (allsections || defsections || !strcasecmp(section,"server")) {
@@ -2936,6 +2935,7 @@ sds genRedisInfoString(char *section) {
 
     /* Clients */
     if (allsections || defsections || !strcasecmp(section,"clients")) {
+        getClientsMaxBuffers(&lol,&bib);
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info,
             "# Clients\r\n"


### PR DESCRIPTION
The genRedisInfoString function use getClientsMaxBuffers for calculating clients longest output list and biggest input buffer, getClientsMaxBuffers  will check every client for these information. When there are too many clients (it's common when clients use short connections scenario), check every client will consume a lot of time.   For info command, the raw genRedisInfoString function call getClientsMaxBuffers every time, which is unnecessary for info server, info  memory, etc. So it is better for info default, info all, info clients calling  genRedisInfoString, the other command don't.