### PR TITLE
wrong declaration for function "prepareForShutdown" int server.h

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1632,7 +1632,7 @@ void forceCommandPropagation(client *c, int flags);
 void preventCommandPropagation(client *c);
 void preventCommandAOF(client *c);
 void preventCommandReplication(client *c);
-int prepareForShutdown();
+int prepareForShutdown(int flags);
 #ifdef __GNUC__
 void serverLog(int level, const char *fmt, ...)
     __attribute__((format(printf, 2, 3)));


### PR DESCRIPTION
should be `int prepareForShutdown(int flags)`