### PR TITLE
Add logging to diagnose filesystem-related fopen failures in rdbLoad()

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1755,7 +1755,11 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi) {
     rio rdb;
     int retval;
 
-    if ((fp = fopen(filename,"r")) == NULL) return C_ERR;
+    if ((fp = fopen(filename,"r")) == NULL) {
+        serverLog(LL_WARNING, "Failed trying to load rdb from file (%s): %s",
+            filename, strerror(errno));
+      return C_ERR;
+    }
     startLoading(fp);
     rioInitWithFile(&rdb,fp);
     retval = rdbLoadRio(&rdb,rsi);


### PR DESCRIPTION
Given this is seemingly the only failure case in #4747 without a useful error message, this modification appears necessary as well as useful to identify filesystem-related load failures during rdbLoad.