### PR TITLE
[Feature Request] supporting RCP1(User Access Control List)

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -501,6 +501,11 @@ slave-priority 100
 #
 # requirepass foobared
 
+# To support ACL(Access-Control-List)
+# if you set users-file, requirepass will be set as NULL
+# and it is just allowed to execute added Commands by module
+# users-file ./users-file-example
+
 # Command renaming.
 #
 # It is possible to change the name of dangerous commands in a shared

--- a/src/Makefile
+++ b/src/Makefile
@@ -144,7 +144,7 @@ endif
 
 REDIS_SERVER_NAME=redis-server
 REDIS_SENTINEL_NAME=redis-sentinel
-REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o redis-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o
+REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o redis-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o acls.o
 REDIS_CLI_NAME=redis-cli
 REDIS_CLI_OBJ=anet.o adlist.o redis-cli.o zmalloc.o release.o anet.o ae.o crc64.o
 REDIS_BENCHMARK_NAME=redis-benchmark

--- a/src/acls.c
+++ b/src/acls.c
@@ -1,0 +1,340 @@
+/*
+ * User Access Control List
+ *
+ * Copyright (c) 2018, DaeMyung Kang <charsyam at naver dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "server.h"
+
+/*
+ * redisCommmands has aclid
+ * and client has acls to allow using each command.
+ * it consists of four 8 bytes. if the bit is 1, client can use it
+ * if it is 0, client can't use it
+ * for ex, aclid of module command is 0, so 0th bit of acls is set.
+ * client can use it
+ */
+
+struct ACLGroup aclGroups[] = {
+    {"readonly", CMD_READONLY, 0, 0, {0, 0, 0, 0}},
+    {"write", CMD_WRITE, 0, 0, {0, 0, 0, 0}},
+    {"slow", CMD_READONLY|CMD_WRITE, CMD_FAST, 0, {0, 0, 0, 0}},
+    {"admin", CMD_ADMIN, 0, 0, {0, 0, 0, 0}},
+    {"string", 0, 0, CMD_TYPE_STRING, {0, 0, 0, 0}},
+    {"list", 0, 0, CMD_TYPE_LIST, {0, 0, 0, 0}},
+    {"set", 0, 0, CMD_TYPE_SET, {0, 0, 0, 0}},
+    {"zset", 0, 0, CMD_TYPE_ZSET, {0, 0, 0, 0}},
+    {"hash", 0, 0, CMD_TYPE_HASH, {0, 0, 0, 0}},
+    {"hyperloglog", 0, 0, CMD_TYPE_HYPERLOGLOG, {0, 0, 0, 0}},
+    {"scan", 0, 0, CMD_TYPE_SCAN, {0, 0, 0, 0}},
+    {"pubsub", 0, 0, CMD_TYPE_PUBSUB, {0, 0, 0, 0}},
+    {"transaction", 0, 0, CMD_TYPE_TRANSACTION, {0, 0, 0, 0}},
+    {"scripting", 0, 0, CMD_TYPE_SCRIPTING, {0, 0, 0, 0}},
+    {"geo", 0, 0, CMD_TYPE_GEO, {0, 0, 0, 0}},
+    {"stream", 0, 0, CMD_TYPE_STREAM, {0, 0, 0, 0}},
+    {"all", 0, 0, 0, {0, 0, 0, 0}}
+};
+
+static void userACLDestructure(void *privdata, void *val)
+{
+    DICT_NOTUSED(privdata);
+
+    if (val == NULL) return; /* Lazy freeing will set value to NULL. */
+    userACL *user = (userACL *)val;
+
+    sdsfree(user->name);
+    sdsfree(user->passwd);
+    zfree(user);
+}
+
+/* user acl table, sds string -> userACL struct pointer. */
+dictType userACLDictType = {
+    dictSdsCaseHash,            /* hash function */
+    NULL,                       /* key dup */
+    NULL,                       /* val dup */
+    dictSdsKeyCaseCompare,      /* key compare */
+    NULL,                       /* key destructor */
+    userACLDestructure          /* val destructor */
+};
+
+int getNumberOfACLGroups() {
+    return (sizeof(aclGroups)/sizeof(struct ACLGroup));
+}
+
+void initACLs(ACLPermission acls) {
+    memset(acls, 0, sizeof(ACLPermission));
+}
+
+void setACLs(ACLPermission tar, ACLPermission src) {
+    memcpy(tar, src, sizeof(ACLPermission));
+}
+
+static void addACLs(ACLPermission src, ACLPermission tar) {
+    for (int i = 0; i < ACL_ARRAY_NUM; i++) {
+        src[i] |= tar[i];
+    }
+}
+
+static void removeACLs(ACLPermission src, ACLPermission tar) {
+    acl_t v = 0;
+    for (int i = 0; i < ACL_ARRAY_NUM; i++) {
+        v = ~tar[i];
+        src[i] &= v;
+    }
+}
+
+static int getACLsFromCommand(char *cmdName, ACLPermission acls) {
+    struct redisCommand *cmd;
+
+    sds name = sdsnew(cmdName);
+    cmd = lookupCommandOrOriginal(name);
+    sdsfree(name);
+    if (cmd == NULL) {
+        return 0;
+    }
+
+    acls[CMD_ACL_INDEX(cmd->aclid)] = CMD_ACL_VALUE(cmd->aclid);
+    return 1;
+}
+
+static int getACLsFromGroup(char *groupName, ACLPermission acls) {
+    int numgroups = getNumberOfACLGroups();
+
+    for (int i = 0; i < numgroups; i++) {
+        ACLGroup *acl = aclGroups + i;
+
+        if (strcmp(acl->name, groupName) == 0) {
+            setACLs(acls, acl->acls);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int parseACL(int argc, char *argv[], ACLPermission acls, int dryrun) {
+    int op;
+    int group;
+
+    if (dryrun == 0) {
+        memset(acls, 0, sizeof(ACLPermission));
+    }
+
+    char *cmdName;
+    char *acl;
+
+    for (int i = 0; i < argc; i++) {
+        ACLPermission tmpACLs;
+        initACLs(tmpACLs);
+
+        acl = argv[2+i];
+
+        if (acl[0] != '+' && acl[0] != '-') {
+            serverLog(LL_WARNING, "Fatal error, acl rule has to start + or - %s", acl);
+            return -1;
+        }
+
+        if (acl[0] == '+') {
+            op = 1;
+        } else {
+            op = 0;
+        }
+
+        if (acl[1] == '#') {
+            group = 1;
+            cmdName = &acl[2];
+        } else {
+            group = 0;
+            cmdName = &acl[1];
+        }
+
+        if (group) {
+            if (getACLsFromGroup(cmdName, tmpACLs) == -1) {
+                serverLog(LL_WARNING, "Fatal error, group is not exist: %s", cmdName);
+                return -1;
+            }
+        } else {
+            if (getACLsFromCommand(cmdName, tmpACLs) == -1) {
+                serverLog(LL_WARNING, "Fatal error, command is not exist: %s", cmdName);
+                return -1;
+            }
+        }
+
+        if (dryrun == 0) {
+            if (op) {
+                addACLs(acls, tmpACLs);
+            } else {
+                removeACLs(acls, tmpACLs);
+            }
+        }
+    }
+
+    return 1;
+}
+
+static void addUserACL(char *name, char *passwd, ACLPermission acls, dict *acls_dict) {
+    sds key = sdsnew(name);
+    dictEntry *de = dictFind(acls_dict,key);
+    if (de != NULL) {
+        sdsfree(key);
+        return;
+    }
+
+    userACL *user = zmalloc(sizeof(*user));
+    user->name = key;
+    user->passwd = sdsnew(passwd);
+    setACLs(user->acls, acls);
+    dictAdd(acls_dict, user->name, user);
+}
+
+static void reloadACLs(ACLPermission default_acls, dict *acls_dict) {
+    dict *old = server.acls;
+
+    setACLs(server.default_acls, default_acls);
+    server.acls = acls_dict;
+
+    dictRelease(old);
+}
+
+static int parse(char *acls, int dryrun) {
+    char *err = NULL;
+    int linenum = 0, totlines, i;
+    sds *lines;
+
+    lines = sdssplitlen(acls,strlen(acls),"\n",1,&totlines);
+    dict *tmpACLsDict = dictCreate(&userACLDictType,NULL);
+    ACLPermission default_acls;
+
+    for (i = 0; i < totlines; i++) {
+        sds *argv;
+        int argc;
+
+        linenum = i+1;
+        lines[i] = sdstrim(lines[i]," \t\r\n");
+
+        /* Skip comments and blank lines */
+        if (lines[i][0] == '#' || lines[i][0] == '\0') continue;
+
+        /* Split into arguments */
+        argv = sdssplitargs(lines[i],&argc);
+        if (argv == NULL) {
+            err = "Unbalanced quotes in configuration line";
+            goto loaderr;
+        }
+
+        /* Skip this line if the resulting command vector is empty. */
+        if (argc == 0) {
+            sdsfreesplitres(argv,argc);
+            continue;
+        }
+
+        sdstolower(argv[0]);
+
+        if (argc < 2) {
+            err = "params count is more than 2 in configuration line";
+            goto loaderr;
+        }
+
+        if (parseACL(argc-2, argv, NULL, 1) == -1) {
+            goto loaderr;
+        }
+
+        if (dryrun == 0) {
+            ACLPermission acls;
+            parseACL(argc-2, argv, acls, 0);
+
+            if (strcmp(argv[0], ACL_DEFAULT_USER_NAME) == 0) {
+                if (strlen(argv[1]) != 0) {
+                    serverLog(LL_WARNING, "%s passwd setting will be ignored", ACL_DEFAULT_USER_NAME);
+                }
+                setACLs(default_acls, acls);
+            } else {
+                addUserACL(argv[0], argv[1], acls, tmpACLsDict);
+            }
+        }
+        sdsfreesplitres(argv,argc);
+    }
+
+    sdsfreesplitres(lines, totlines);
+    reloadACLs(default_acls, tmpACLsDict);
+    return 0;
+
+loaderr:
+    if (tmpACLsDict) {
+        dictRelease(tmpACLsDict);
+    }
+
+    serverLog(LL_WARNING, "Fatal error, user-file is NULL\n"
+            "Reading the acls file, at line %d\n"
+            ">>> '%s'\n%s\n"
+            ,linenum, lines[i], err);
+    return -1;
+}
+
+int loadACLs(const char *filename) {
+    if (filename == NULL) {
+        serverLog(LL_WARNING, "Fatal error, user-file is NULL");
+        return -1;
+    }
+
+    sds acls = sdsempty();
+    char buf[CONFIG_MAX_LINE+1];
+
+    /* Load the file content */
+    if (filename) {
+        FILE *fp;
+
+        if ((fp = fopen(filename,"r")) == NULL) {
+            serverLog(LL_WARNING,
+                    "Fatal error, can't open config file '%s'", filename);
+                return -1;
+        }
+
+        while(fgets(buf,CONFIG_MAX_LINE+1,fp) != NULL) {
+            acls = sdscat(acls,buf);
+        }
+
+        fclose(fp);
+    }
+
+    //dryrun to check user-file
+    if (parse(acls, 1) == -1) {
+        return -1;
+    }
+
+    parse(acls, 0);
+    sdsfree(acls);
+    return 0;
+}
+
+userACL *getUserACL(char *userName) {
+    sds name = sdsnew(userName);
+    userACL *user = dictFetchValue(server.acls, name);
+    sdsfree(name);
+    return user;
+}

--- a/src/networking.c
+++ b/src/networking.c
@@ -146,6 +146,7 @@ client *createClient(int fd) {
     c->pubsub_patterns = listCreate();
     c->peerid = NULL;
     c->client_list_node = NULL;
+    setACLs(c->acls, server.default_acls);
     listSetFreeMethod(c->pubsub_patterns,decrRefCountVoid);
     listSetMatchMethod(c->pubsub_patterns,listMatchObjects);
     if (fd != -1) linkClient(c);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1640,7 +1640,12 @@ void syncWithMaster(aeEventLoop *el, int fd, void *privdata, int mask) {
     /* AUTH with the master if required. */
     if (server.repl_state == REPL_STATE_SEND_AUTH) {
         if (server.masterauth) {
-            err = sendSynchronousCommand(SYNC_CMD_WRITE,fd,"AUTH",server.masterauth,NULL);
+            if (server.masteruser) {
+                err = sendSynchronousCommand(SYNC_CMD_WRITE,fd,"AUTH",server.masteruser,server.masterauth,NULL);
+            } else {
+                err = sendSynchronousCommand(SYNC_CMD_WRITE,fd,"AUTH",server.masterauth,NULL);
+            }
+
             if (err) goto write_error;
             server.repl_state = REPL_STATE_RECEIVE_AUTH;
             return;

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -192,6 +192,7 @@ typedef struct sentinelRedisInstance {
     dict *slaves;       /* Slaves for this master instance. */
     unsigned int quorum;/* Number of sentinels that need to agree on failure. */
     int parallel_syncs; /* How many slaves to reconfigure at same time. */
+    char *auth_user;    /* User to use for AUTH against master & slaves. */
     char *auth_pass;    /* Password to use for AUTH against master & slaves. */
 
     /* Slave specific. */
@@ -368,6 +369,7 @@ sentinelRedisInstance *sentinelSelectSlave(sentinelRedisInstance *master);
 void sentinelScheduleScriptExecution(char *path, ...);
 void sentinelStartFailover(sentinelRedisInstance *master);
 void sentinelDiscardReplyCallback(redisAsyncContext *c, void *reply, void *privdata);
+void sentinelAuthReplyCallback(redisAsyncContext *c, void *reply, void *privdata);
 int sentinelSendSlaveOf(sentinelRedisInstance *ri, char *host, int port);
 char *sentinelVoteLeader(sentinelRedisInstance *master, uint64_t req_epoch, char *req_runid, uint64_t *leader_epoch);
 void sentinelFlushConfig(void);
@@ -1194,6 +1196,7 @@ sentinelRedisInstance *createSentinelRedisInstance(char *name, int flags, char *
     ri->down_after_period = master ? master->down_after_period :
                             SENTINEL_DEFAULT_DOWN_AFTER;
     ri->master_link_down_time = 0;
+    ri->auth_user = NULL;
     ri->auth_pass = NULL;
     ri->slave_priority = SENTINEL_DEFAULT_SLAVE_PRIORITY;
     ri->slave_reconf_sent_time = 0;
@@ -1251,6 +1254,7 @@ void releaseSentinelRedisInstance(sentinelRedisInstance *ri) {
     sdsfree(ri->client_reconfig_script);
     sdsfree(ri->slave_master_host);
     sdsfree(ri->leader);
+    sdsfree(ri->auth_user);
     sdsfree(ri->auth_pass);
     sdsfree(ri->info);
     releaseSentinelAddr(ri->addr);
@@ -1621,6 +1625,10 @@ char *sentinelHandleConfiguration(char **argv, int argc) {
             return "Client reconfiguration script seems non existing or "
                    "non executable.";
         ri->client_reconfig_script = sdsnew(argv[2]);
+   } else if (!strcasecmp(argv[0],"auth-user")) {
+        ri = sentinelGetMasterByName(argv[1]);
+        if (!ri) return "No such master with specified name.";
+        ri->auth_user = sdsnew(argv[2]);
    } else if (!strcasecmp(argv[0],"auth-pass") && argc == 3) {
         /* auth-pass <name> <password> */
         ri = sentinelGetMasterByName(argv[1]);
@@ -1758,6 +1766,14 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             rewriteConfigRewriteLine(state,"sentinel",line,1);
         }
 
+        /* sentinel auth-user */
+        if (master->auth_user) {
+            line = sdscatprintf(sdsempty(),
+                "sentinel auth-user %s %s",
+                master->name, master->auth_user);
+            rewriteConfigRewriteLine(state,"sentinel",line,1);
+        }
+
         /* sentinel auth-pass */
         if (master->auth_pass) {
             line = sdscatprintf(sdsempty(),
@@ -1871,12 +1887,25 @@ werr:
  * to the instance as if it fails Sentinel will detect the instance down,
  * will disconnect and reconnect the link and so forth. */
 void sentinelSendAuthIfNeeded(sentinelRedisInstance *ri, redisAsyncContext *c) {
+    char *auth_user = (ri->flags & SRI_MASTER) ? ri->auth_user :
+                                                 ri->master->auth_user;
     char *auth_pass = (ri->flags & SRI_MASTER) ? ri->auth_pass :
                                                  ri->master->auth_pass;
 
     if (auth_pass) {
-        if (redisAsyncCommand(c, sentinelDiscardReplyCallback, ri, "AUTH %s",
-            auth_pass) == C_OK) ri->link->pending_commands++;
+        if (auth_user) {
+            if (redisAsyncCommand(c, sentinelAuthReplyCallback, ri, "AUTH %s %s",
+                auth_user, auth_pass) == C_OK) {
+                ri->link->pending_commands++;
+                serverLog(LL_NOTICE, "Request Auth With ACLs %s:%d", ri->addr->ip, ri->addr->port);
+            }
+        } else {
+            if (redisAsyncCommand(c, sentinelAuthReplyCallback, ri, "AUTH %s",
+                auth_pass) == C_OK) {
+                ri->link->pending_commands++;
+                serverLog(LL_NOTICE, "Request Auth %s:%d", ri->addr->ip, ri->addr->port);
+            }
+        }
     }
 }
 
@@ -2248,6 +2277,19 @@ void sentinelInfoReplyCallback(redisAsyncContext *c, void *reply, void *privdata
 
     if (r->type == REDIS_REPLY_STRING)
         sentinelRefreshInstanceInfo(ri,r->str);
+}
+
+void sentinelAuthReplyCallback(redisAsyncContext *c, void *reply, void *privdata) {
+    instanceLink *link = c->data;
+    redisReply *r;
+    UNUSED(privdata);
+
+    if (link) link->pending_commands--;
+
+    r = reply;
+    if (r && r->type == REDIS_REPLY_ERROR) {
+        serverLog(LL_WARNING, "Auth Failed: %s", r->str);
+    }
 }
 
 /* Just discard the reply. We use this when we are not monitoring the return
@@ -3347,6 +3389,11 @@ void sentinelSetCommand(client *c) {
             }
             sdsfree(ri->client_reconfig_script);
             ri->client_reconfig_script = strlen(value) ? sdsnew(value) : NULL;
+            changes++;
+       } else if (!strcasecmp(option,"auth-user")) {
+            /* auth-user <user> */
+            sdsfree(ri->auth_user);
+            ri->auth_user = strlen(value) ? sdsnew(value) : NULL;
             changes++;
        } else if (!strcasecmp(option,"auth-pass")) {
             /* auth-pass <password> */

--- a/src/server.c
+++ b/src/server.c
@@ -125,204 +125,262 @@ volatile unsigned long lru_clock; /* Server global current LRU time. */
  *    are not fast commands.
  */
 struct redisCommand redisCommandTable[] = {
-    {"module",moduleCommand,-2,"as",0,NULL,0,0,0,0,0},
-    {"get",getCommand,2,"rF",0,NULL,1,1,1,0,0},
-    {"set",setCommand,-3,"wm",0,NULL,1,1,1,0,0},
-    {"setnx",setnxCommand,3,"wmF",0,NULL,1,1,1,0,0},
-    {"setex",setexCommand,4,"wm",0,NULL,1,1,1,0,0},
-    {"psetex",psetexCommand,4,"wm",0,NULL,1,1,1,0,0},
-    {"append",appendCommand,3,"wm",0,NULL,1,1,1,0,0},
-    {"strlen",strlenCommand,2,"rF",0,NULL,1,1,1,0,0},
-    {"del",delCommand,-2,"w",0,NULL,1,-1,1,0,0},
-    {"unlink",unlinkCommand,-2,"wF",0,NULL,1,-1,1,0,0},
-    {"exists",existsCommand,-2,"rF",0,NULL,1,-1,1,0,0},
-    {"setbit",setbitCommand,4,"wm",0,NULL,1,1,1,0,0},
-    {"getbit",getbitCommand,3,"rF",0,NULL,1,1,1,0,0},
-    {"bitfield",bitfieldCommand,-2,"wm",0,NULL,1,1,1,0,0},
-    {"setrange",setrangeCommand,4,"wm",0,NULL,1,1,1,0,0},
-    {"getrange",getrangeCommand,4,"r",0,NULL,1,1,1,0,0},
-    {"substr",getrangeCommand,4,"r",0,NULL,1,1,1,0,0},
-    {"incr",incrCommand,2,"wmF",0,NULL,1,1,1,0,0},
-    {"decr",decrCommand,2,"wmF",0,NULL,1,1,1,0,0},
-    {"mget",mgetCommand,-2,"rF",0,NULL,1,-1,1,0,0},
-    {"rpush",rpushCommand,-3,"wmF",0,NULL,1,1,1,0,0},
-    {"lpush",lpushCommand,-3,"wmF",0,NULL,1,1,1,0,0},
-    {"rpushx",rpushxCommand,-3,"wmF",0,NULL,1,1,1,0,0},
-    {"lpushx",lpushxCommand,-3,"wmF",0,NULL,1,1,1,0,0},
-    {"linsert",linsertCommand,5,"wm",0,NULL,1,1,1,0,0},
-    {"rpop",rpopCommand,2,"wF",0,NULL,1,1,1,0,0},
-    {"lpop",lpopCommand,2,"wF",0,NULL,1,1,1,0,0},
-    {"brpop",brpopCommand,-3,"ws",0,NULL,1,-2,1,0,0},
-    {"brpoplpush",brpoplpushCommand,4,"wms",0,NULL,1,2,1,0,0},
-    {"blpop",blpopCommand,-3,"ws",0,NULL,1,-2,1,0,0},
-    {"llen",llenCommand,2,"rF",0,NULL,1,1,1,0,0},
-    {"lindex",lindexCommand,3,"r",0,NULL,1,1,1,0,0},
-    {"lset",lsetCommand,4,"wm",0,NULL,1,1,1,0,0},
-    {"lrange",lrangeCommand,4,"r",0,NULL,1,1,1,0,0},
-    {"ltrim",ltrimCommand,4,"w",0,NULL,1,1,1,0,0},
-    {"lrem",lremCommand,4,"w",0,NULL,1,1,1,0,0},
-    {"rpoplpush",rpoplpushCommand,3,"wm",0,NULL,1,2,1,0,0},
-    {"sadd",saddCommand,-3,"wmF",0,NULL,1,1,1,0,0},
-    {"srem",sremCommand,-3,"wF",0,NULL,1,1,1,0,0},
-    {"smove",smoveCommand,4,"wF",0,NULL,1,2,1,0,0},
-    {"sismember",sismemberCommand,3,"rF",0,NULL,1,1,1,0,0},
-    {"scard",scardCommand,2,"rF",0,NULL,1,1,1,0,0},
-    {"spop",spopCommand,-2,"wRF",0,NULL,1,1,1,0,0},
-    {"srandmember",srandmemberCommand,-2,"rR",0,NULL,1,1,1,0,0},
-    {"sinter",sinterCommand,-2,"rS",0,NULL,1,-1,1,0,0},
-    {"sinterstore",sinterstoreCommand,-3,"wm",0,NULL,1,-1,1,0,0},
-    {"sunion",sunionCommand,-2,"rS",0,NULL,1,-1,1,0,0},
-    {"sunionstore",sunionstoreCommand,-3,"wm",0,NULL,1,-1,1,0,0},
-    {"sdiff",sdiffCommand,-2,"rS",0,NULL,1,-1,1,0,0},
-    {"sdiffstore",sdiffstoreCommand,-3,"wm",0,NULL,1,-1,1,0,0},
-    {"smembers",sinterCommand,2,"rS",0,NULL,1,1,1,0,0},
-    {"sscan",sscanCommand,-3,"rR",0,NULL,1,1,1,0,0},
-    {"zadd",zaddCommand,-4,"wmF",0,NULL,1,1,1,0,0},
-    {"zincrby",zincrbyCommand,4,"wmF",0,NULL,1,1,1,0,0},
-    {"zrem",zremCommand,-3,"wF",0,NULL,1,1,1,0,0},
-    {"zremrangebyscore",zremrangebyscoreCommand,4,"w",0,NULL,1,1,1,0,0},
-    {"zremrangebyrank",zremrangebyrankCommand,4,"w",0,NULL,1,1,1,0,0},
-    {"zremrangebylex",zremrangebylexCommand,4,"w",0,NULL,1,1,1,0,0},
-    {"zunionstore",zunionstoreCommand,-4,"wm",0,zunionInterGetKeys,0,0,0,0,0},
-    {"zinterstore",zinterstoreCommand,-4,"wm",0,zunionInterGetKeys,0,0,0,0,0},
-    {"zrange",zrangeCommand,-4,"r",0,NULL,1,1,1,0,0},
-    {"zrangebyscore",zrangebyscoreCommand,-4,"r",0,NULL,1,1,1,0,0},
-    {"zrevrangebyscore",zrevrangebyscoreCommand,-4,"r",0,NULL,1,1,1,0,0},
-    {"zrangebylex",zrangebylexCommand,-4,"r",0,NULL,1,1,1,0,0},
-    {"zrevrangebylex",zrevrangebylexCommand,-4,"r",0,NULL,1,1,1,0,0},
-    {"zcount",zcountCommand,4,"rF",0,NULL,1,1,1,0,0},
-    {"zlexcount",zlexcountCommand,4,"rF",0,NULL,1,1,1,0,0},
-    {"zrevrange",zrevrangeCommand,-4,"r",0,NULL,1,1,1,0,0},
-    {"zcard",zcardCommand,2,"rF",0,NULL,1,1,1,0,0},
-    {"zscore",zscoreCommand,3,"rF",0,NULL,1,1,1,0,0},
-    {"zrank",zrankCommand,3,"rF",0,NULL,1,1,1,0,0},
-    {"zrevrank",zrevrankCommand,3,"rF",0,NULL,1,1,1,0,0},
-    {"zscan",zscanCommand,-3,"rR",0,NULL,1,1,1,0,0},
-    {"zpopmin",zpopminCommand,-2,"wF",0,NULL,1,-1,1,0,0},
-    {"zpopmax",zpopmaxCommand,-2,"wF",0,NULL,1,-1,1,0,0},
-    {"bzpopmin",bzpopminCommand,-2,"wsF",0,NULL,1,-2,1,0,0},
-    {"bzpopmax",bzpopmaxCommand,-2,"wsF",0,NULL,1,-2,1,0,0},
-    {"hset",hsetCommand,-4,"wmF",0,NULL,1,1,1,0,0},
-    {"hsetnx",hsetnxCommand,4,"wmF",0,NULL,1,1,1,0,0},
-    {"hget",hgetCommand,3,"rF",0,NULL,1,1,1,0,0},
-    {"hmset",hsetCommand,-4,"wmF",0,NULL,1,1,1,0,0},
-    {"hmget",hmgetCommand,-3,"rF",0,NULL,1,1,1,0,0},
-    {"hincrby",hincrbyCommand,4,"wmF",0,NULL,1,1,1,0,0},
-    {"hincrbyfloat",hincrbyfloatCommand,4,"wmF",0,NULL,1,1,1,0,0},
-    {"hdel",hdelCommand,-3,"wF",0,NULL,1,1,1,0,0},
-    {"hlen",hlenCommand,2,"rF",0,NULL,1,1,1,0,0},
-    {"hstrlen",hstrlenCommand,3,"rF",0,NULL,1,1,1,0,0},
-    {"hkeys",hkeysCommand,2,"rS",0,NULL,1,1,1,0,0},
-    {"hvals",hvalsCommand,2,"rS",0,NULL,1,1,1,0,0},
-    {"hgetall",hgetallCommand,2,"r",0,NULL,1,1,1,0,0},
-    {"hexists",hexistsCommand,3,"rF",0,NULL,1,1,1,0,0},
-    {"hscan",hscanCommand,-3,"rR",0,NULL,1,1,1,0,0},
-    {"incrby",incrbyCommand,3,"wmF",0,NULL,1,1,1,0,0},
-    {"decrby",decrbyCommand,3,"wmF",0,NULL,1,1,1,0,0},
-    {"incrbyfloat",incrbyfloatCommand,3,"wmF",0,NULL,1,1,1,0,0},
-    {"getset",getsetCommand,3,"wm",0,NULL,1,1,1,0,0},
-    {"mset",msetCommand,-3,"wm",0,NULL,1,-1,2,0,0},
-    {"msetnx",msetnxCommand,-3,"wm",0,NULL,1,-1,2,0,0},
-    {"randomkey",randomkeyCommand,1,"rR",0,NULL,0,0,0,0,0},
-    {"select",selectCommand,2,"lF",0,NULL,0,0,0,0,0},
-    {"swapdb",swapdbCommand,3,"wF",0,NULL,0,0,0,0,0},
-    {"move",moveCommand,3,"wF",0,NULL,1,1,1,0,0},
-    {"rename",renameCommand,3,"w",0,NULL,1,2,1,0,0},
-    {"renamenx",renamenxCommand,3,"wF",0,NULL,1,2,1,0,0},
-    {"expire",expireCommand,3,"wF",0,NULL,1,1,1,0,0},
-    {"expireat",expireatCommand,3,"wF",0,NULL,1,1,1,0,0},
-    {"pexpire",pexpireCommand,3,"wF",0,NULL,1,1,1,0,0},
-    {"pexpireat",pexpireatCommand,3,"wF",0,NULL,1,1,1,0,0},
-    {"keys",keysCommand,2,"rS",0,NULL,0,0,0,0,0},
-    {"scan",scanCommand,-2,"rR",0,NULL,0,0,0,0,0},
-    {"dbsize",dbsizeCommand,1,"rF",0,NULL,0,0,0,0,0},
-    {"auth",authCommand,2,"sltF",0,NULL,0,0,0,0,0},
-    {"ping",pingCommand,-1,"tF",0,NULL,0,0,0,0,0},
-    {"echo",echoCommand,2,"F",0,NULL,0,0,0,0,0},
-    {"save",saveCommand,1,"as",0,NULL,0,0,0,0,0},
-    {"bgsave",bgsaveCommand,-1,"a",0,NULL,0,0,0,0,0},
-    {"bgrewriteaof",bgrewriteaofCommand,1,"a",0,NULL,0,0,0,0,0},
-    {"shutdown",shutdownCommand,-1,"alt",0,NULL,0,0,0,0,0},
-    {"lastsave",lastsaveCommand,1,"RF",0,NULL,0,0,0,0,0},
-    {"type",typeCommand,2,"rF",0,NULL,1,1,1,0,0},
-    {"multi",multiCommand,1,"sF",0,NULL,0,0,0,0,0},
-    {"exec",execCommand,1,"sM",0,NULL,0,0,0,0,0},
-    {"discard",discardCommand,1,"sF",0,NULL,0,0,0,0,0},
-    {"sync",syncCommand,1,"ars",0,NULL,0,0,0,0,0},
-    {"psync",syncCommand,3,"ars",0,NULL,0,0,0,0,0},
-    {"replconf",replconfCommand,-1,"aslt",0,NULL,0,0,0,0,0},
-    {"flushdb",flushdbCommand,-1,"w",0,NULL,0,0,0,0,0},
-    {"flushall",flushallCommand,-1,"w",0,NULL,0,0,0,0,0},
-    {"sort",sortCommand,-2,"wm",0,sortGetKeys,1,1,1,0,0},
-    {"info",infoCommand,-1,"lt",0,NULL,0,0,0,0,0},
-    {"monitor",monitorCommand,1,"as",0,NULL,0,0,0,0,0},
-    {"ttl",ttlCommand,2,"rF",0,NULL,1,1,1,0,0},
-    {"touch",touchCommand,-2,"rF",0,NULL,1,1,1,0,0},
-    {"pttl",pttlCommand,2,"rF",0,NULL,1,1,1,0,0},
-    {"persist",persistCommand,2,"wF",0,NULL,1,1,1,0,0},
-    {"slaveof",slaveofCommand,3,"ast",0,NULL,0,0,0,0,0},
-    {"role",roleCommand,1,"lst",0,NULL,0,0,0,0,0},
-    {"debug",debugCommand,-2,"as",0,NULL,0,0,0,0,0},
-    {"config",configCommand,-2,"lat",0,NULL,0,0,0,0,0},
-    {"subscribe",subscribeCommand,-2,"pslt",0,NULL,0,0,0,0,0},
-    {"unsubscribe",unsubscribeCommand,-1,"pslt",0,NULL,0,0,0,0,0},
-    {"psubscribe",psubscribeCommand,-2,"pslt",0,NULL,0,0,0,0,0},
-    {"punsubscribe",punsubscribeCommand,-1,"pslt",0,NULL,0,0,0,0,0},
-    {"publish",publishCommand,3,"pltF",0,NULL,0,0,0,0,0},
-    {"pubsub",pubsubCommand,-2,"pltR",0,NULL,0,0,0,0,0},
-    {"watch",watchCommand,-2,"sF",0,NULL,1,-1,1,0,0},
-    {"unwatch",unwatchCommand,1,"sF",0,NULL,0,0,0,0,0},
-    {"cluster",clusterCommand,-2,"a",0,NULL,0,0,0,0,0},
-    {"restore",restoreCommand,-4,"wm",0,NULL,1,1,1,0,0},
-    {"restore-asking",restoreCommand,-4,"wmk",0,NULL,1,1,1,0,0},
-    {"migrate",migrateCommand,-6,"w",0,migrateGetKeys,0,0,0,0,0},
-    {"asking",askingCommand,1,"F",0,NULL,0,0,0,0,0},
-    {"readonly",readonlyCommand,1,"F",0,NULL,0,0,0,0,0},
-    {"readwrite",readwriteCommand,1,"F",0,NULL,0,0,0,0,0},
-    {"dump",dumpCommand,2,"r",0,NULL,1,1,1,0,0},
-    {"object",objectCommand,-2,"r",0,NULL,2,2,1,0,0},
-    {"memory",memoryCommand,-2,"r",0,NULL,0,0,0,0,0},
-    {"client",clientCommand,-2,"as",0,NULL,0,0,0,0,0},
-    {"eval",evalCommand,-3,"s",0,evalGetKeys,0,0,0,0,0},
-    {"evalsha",evalShaCommand,-3,"s",0,evalGetKeys,0,0,0,0,0},
-    {"slowlog",slowlogCommand,-2,"a",0,NULL,0,0,0,0,0},
-    {"script",scriptCommand,-2,"s",0,NULL,0,0,0,0,0},
-    {"time",timeCommand,1,"RF",0,NULL,0,0,0,0,0},
-    {"bitop",bitopCommand,-4,"wm",0,NULL,2,-1,1,0,0},
-    {"bitcount",bitcountCommand,-2,"r",0,NULL,1,1,1,0,0},
-    {"bitpos",bitposCommand,-3,"r",0,NULL,1,1,1,0,0},
-    {"wait",waitCommand,3,"s",0,NULL,0,0,0,0,0},
-    {"command",commandCommand,0,"lt",0,NULL,0,0,0,0,0},
-    {"geoadd",geoaddCommand,-5,"wm",0,NULL,1,1,1,0,0},
-    {"georadius",georadiusCommand,-6,"w",0,georadiusGetKeys,1,1,1,0,0},
-    {"georadius_ro",georadiusroCommand,-6,"r",0,georadiusGetKeys,1,1,1,0,0},
-    {"georadiusbymember",georadiusbymemberCommand,-5,"w",0,georadiusGetKeys,1,1,1,0,0},
-    {"georadiusbymember_ro",georadiusbymemberroCommand,-5,"r",0,georadiusGetKeys,1,1,1,0,0},
-    {"geohash",geohashCommand,-2,"r",0,NULL,1,1,1,0,0},
-    {"geopos",geoposCommand,-2,"r",0,NULL,1,1,1,0,0},
-    {"geodist",geodistCommand,-4,"r",0,NULL,1,1,1,0,0},
-    {"pfselftest",pfselftestCommand,1,"a",0,NULL,0,0,0,0,0},
-    {"pfadd",pfaddCommand,-2,"wmF",0,NULL,1,1,1,0,0},
-    {"pfcount",pfcountCommand,-2,"r",0,NULL,1,-1,1,0,0},
-    {"pfmerge",pfmergeCommand,-2,"wm",0,NULL,1,-1,1,0,0},
-    {"pfdebug",pfdebugCommand,-3,"w",0,NULL,0,0,0,0,0},
-    {"xadd",xaddCommand,-5,"wmF",0,NULL,1,1,1,0,0},
-    {"xrange",xrangeCommand,-4,"r",0,NULL,1,1,1,0,0},
-    {"xrevrange",xrevrangeCommand,-4,"r",0,NULL,1,1,1,0,0},
-    {"xlen",xlenCommand,2,"rF",0,NULL,1,1,1,0,0},
-    {"xread",xreadCommand,-3,"rs",0,xreadGetKeys,1,1,1,0,0},
-    {"xreadgroup",xreadCommand,-3,"ws",0,xreadGetKeys,1,1,1,0,0},
-    {"xgroup",xgroupCommand,-2,"wm",0,NULL,2,2,1,0,0},
-    {"xack",xackCommand,-3,"wF",0,NULL,1,1,1,0,0},
-    {"xpending",xpendingCommand,-3,"r",0,NULL,1,1,1,0,0},
-    {"xclaim",xclaimCommand,-5,"wF",0,NULL,1,1,1,0,0},
-    {"xinfo",xinfoCommand,-2,"r",0,NULL,2,2,1,0,0},
-    {"xdel",xdelCommand,-2,"wF",0,NULL,1,1,1,0,0},
-    {"xtrim",xtrimCommand,-2,"wF",0,NULL,1,1,1,0,0},
-    {"post",securityWarningCommand,-1,"lt",0,NULL,0,0,0,0,0},
-    {"host:",securityWarningCommand,-1,"lt",0,NULL,0,0,0,0,0},
-    {"latency",latencyCommand,-2,"aslt",0,NULL,0,0,0,0,0}
+    {"module",moduleCommand,-2,"as",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"get",getCommand,2,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"set",setCommand,-3,"wm",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"setnx",setnxCommand,3,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"setex",setexCommand,4,"wm",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"psetex",psetexCommand,4,"wm",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"append",appendCommand,3,"wm",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"strlen",strlenCommand,2,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"del",delCommand,-2,"w",0,NULL,1,-1,1,0,0,CMD_TYPE_NONE,0},
+    {"unlink",unlinkCommand,-2,"wF",0,NULL,1,-1,1,0,0,CMD_TYPE_NONE,0},
+    {"exists",existsCommand,-2,"rF",0,NULL,1,-1,1,0,0,CMD_TYPE_NONE,0},
+    {"setbit",setbitCommand,4,"wm",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"getbit",getbitCommand,3,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"bitfield",bitfieldCommand,-2,"wm",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"setrange",setrangeCommand,4,"wm",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"getrange",getrangeCommand,4,"r",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"substr",getrangeCommand,4,"r",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"incr",incrCommand,2,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"decr",decrCommand,2,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"mget",mgetCommand,-2,"rF",0,NULL,1,-1,1,0,0,CMD_TYPE_STRING,0},
+    {"rpush",rpushCommand,-3,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"lpush",lpushCommand,-3,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"rpushx",rpushxCommand,-3,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"lpushx",lpushxCommand,-3,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"linsert",linsertCommand,5,"wm",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"rpop",rpopCommand,2,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"lpop",lpopCommand,2,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"brpop",brpopCommand,-3,"ws",0,NULL,1,-2,1,0,0,CMD_TYPE_LIST,0},
+    {"brpoplpush",brpoplpushCommand,4,"wms",0,NULL,1,2,1,0,0,CMD_TYPE_LIST,0},
+    {"blpop",blpopCommand,-3,"ws",0,NULL,1,-2,1,0,0,CMD_TYPE_LIST,0},
+    {"llen",llenCommand,2,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"lindex",lindexCommand,3,"r",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"lset",lsetCommand,4,"wm",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"lrange",lrangeCommand,4,"r",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"ltrim",ltrimCommand,4,"w",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"lrem",lremCommand,4,"w",0,NULL,1,1,1,0,0,CMD_TYPE_LIST,0},
+    {"rpoplpush",rpoplpushCommand,3,"wm",0,NULL,1,2,1,0,0,CMD_TYPE_LIST,0},
+    {"sadd",saddCommand,-3,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_SET,0},
+    {"srem",sremCommand,-3,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_SET,0},
+    {"smove",smoveCommand,4,"wF",0,NULL,1,2,1,0,0,CMD_TYPE_SET,0},
+    {"sismember",sismemberCommand,3,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_SET,0},
+    {"scard",scardCommand,2,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_SET,0},
+    {"spop",spopCommand,-2,"wRF",0,NULL,1,1,1,0,0,CMD_TYPE_SET,0},
+    {"srandmember",srandmemberCommand,-2,"rR",0,NULL,1,1,1,0,0,CMD_TYPE_SET,0},
+    {"sinter",sinterCommand,-2,"rS",0,NULL,1,-1,1,0,0,CMD_TYPE_SET,0},
+    {"sinterstore",sinterstoreCommand,-3,"wm",0,NULL,1,-1,1,0,0,CMD_TYPE_SET,0},
+    {"sunion",sunionCommand,-2,"rS",0,NULL,1,-1,1,0,0,CMD_TYPE_SET,0},
+    {"sunionstore",sunionstoreCommand,-3,"wm",0,NULL,1,-1,1,0,0,CMD_TYPE_SET,0},
+    {"sdiff",sdiffCommand,-2,"rS",0,NULL,1,-1,1,0,0,CMD_TYPE_SET,0},
+    {"sdiffstore",sdiffstoreCommand,-3,"wm",0,NULL,1,-1,1,0,0,CMD_TYPE_SET,0},
+    {"smembers",sinterCommand,2,"rS",0,NULL,1,1,1,0,0,CMD_TYPE_SET,0},
+    {"sscan",sscanCommand,-3,"rR",0,NULL,1,1,1,0,0,CMD_TYPE_SET|CMD_TYPE_SCAN,0},
+    {"zadd",zaddCommand,-4,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zincrby",zincrbyCommand,4,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zrem",zremCommand,-3,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zremrangebyscore",zremrangebyscoreCommand,4,"w",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zremrangebyrank",zremrangebyrankCommand,4,"w",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zremrangebylex",zremrangebylexCommand,4,"w",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zunionstore",zunionstoreCommand,-4,"wm",0,zunionInterGetKeys,0,0,0,0,0,CMD_TYPE_ZSET,0},
+    {"zinterstore",zinterstoreCommand,-4,"wm",0,zunionInterGetKeys,0,0,0,0,0,CMD_TYPE_ZSET,0},
+    {"zrange",zrangeCommand,-4,"r",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zrangebyscore",zrangebyscoreCommand,-4,"r",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zrevrangebyscore",zrevrangebyscoreCommand,-4,"r",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zrangebylex",zrangebylexCommand,-4,"r",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zrevrangebylex",zrevrangebylexCommand,-4,"r",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zcount",zcountCommand,4,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zlexcount",zlexcountCommand,4,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zrevrange",zrevrangeCommand,-4,"r",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zcard",zcardCommand,2,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zscore",zscoreCommand,3,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zrank",zrankCommand,3,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zrevrank",zrevrankCommand,3,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zscan",zscanCommand,-3,"rR",0,NULL,1,1,1,0,0,CMD_TYPE_ZSET|CMD_TYPE_SCAN,0},
+    {"zpopmin",zpopminCommand,-2,"wF",0,NULL,1,-1,1,0,0,CMD_TYPE_ZSET,0},
+    {"zpopmax",zpopmaxCommand,-2,"wF",0,NULL,1,-1,1,0,0,CMD_TYPE_ZSET,0},
+    {"bzpopmin",bzpopminCommand,-2,"wsF",0,NULL,1,-2,1,0,0,CMD_TYPE_ZSET,0},
+    {"bzpopmax",bzpopmaxCommand,-2,"wsF",0,NULL,1,-2,1,0,0,CMD_TYPE_ZSET,0},
+    {"hset",hsetCommand,-4,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hsetnx",hsetnxCommand,4,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hget",hgetCommand,3,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hmset",hsetCommand,-4,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hmget",hmgetCommand,-3,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hincrby",hincrbyCommand,4,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hincrbyfloat",hincrbyfloatCommand,4,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hdel",hdelCommand,-3,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hlen",hlenCommand,2,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hstrlen",hstrlenCommand,3,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hkeys",hkeysCommand,2,"rS",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hvals",hvalsCommand,2,"rS",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hgetall",hgetallCommand,2,"r",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hexists",hexistsCommand,3,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_HASH,0},
+    {"hscan",hscanCommand,-3,"rR",0,NULL,1,1,1,0,0,CMD_TYPE_HASH|CMD_TYPE_SCAN,0},
+    {"incrby",incrbyCommand,3,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"decrby",decrbyCommand,3,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"incrbyfloat",incrbyfloatCommand,3,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"getset",getsetCommand,3,"wm",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"mset",msetCommand,-3,"wm",0,NULL,1,-1,2,0,0,CMD_TYPE_STRING,0},
+    {"msetnx",msetnxCommand,-3,"wm",0,NULL,1,-1,2,0,0,CMD_TYPE_STRING,0},
+    {"randomkey",randomkeyCommand,1,"rR",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"select",selectCommand,2,"lF",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"swapdb",swapdbCommand,3,"wF",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"move",moveCommand,3,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"rename",renameCommand,3,"w",0,NULL,1,2,1,0,0,CMD_TYPE_NONE,0},
+    {"renamenx",renamenxCommand,3,"wF",0,NULL,1,2,1,0,0,CMD_TYPE_NONE,0},
+    {"expire",expireCommand,3,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"expireat",expireatCommand,3,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"pexpire",pexpireCommand,3,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"pexpireat",pexpireatCommand,3,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"keys",keysCommand,2,"rS",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"scan",scanCommand,-2,"rR",0,NULL,0,0,0,0,0,CMD_TYPE_SCAN,0},
+    {"dbsize",dbsizeCommand,1,"rF",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"auth",authCommand,-2,"sltF",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"ping",pingCommand,-1,"tF",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"echo",echoCommand,2,"F",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"save",saveCommand,1,"as",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"bgsave",bgsaveCommand,-1,"a",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"bgrewriteaof",bgrewriteaofCommand,1,"a",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"shutdown",shutdownCommand,-1,"alt",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"lastsave",lastsaveCommand,1,"RF",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"type",typeCommand,2,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"multi",multiCommand,1,"sF",0,NULL,0,0,0,0,0,CMD_TYPE_TRANSACTION,0},
+    {"exec",execCommand,1,"sM",0,NULL,0,0,0,0,0,CMD_TYPE_TRANSACTION,0},
+    {"discard",discardCommand,1,"sF",0,NULL,0,0,0,0,0,CMD_TYPE_TRANSACTION,0},
+    {"sync",syncCommand,1,"ars",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"psync",syncCommand,3,"ars",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"replconf",replconfCommand,-1,"aslt",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"flushdb",flushdbCommand,-1,"w",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"flushall",flushallCommand,-1,"w",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"sort",sortCommand,-2,"wm",0,sortGetKeys,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"info",infoCommand,-1,"lt",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"monitor",monitorCommand,1,"as",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"ttl",ttlCommand,2,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"touch",touchCommand,-2,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"pttl",pttlCommand,2,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"persist",persistCommand,2,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"slaveof",slaveofCommand,3,"ast",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"role",roleCommand,1,"lst",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"debug",debugCommand,-2,"as",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"config",configCommand,-2,"lat",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"subscribe",subscribeCommand,-2,"pslt",0,NULL,0,0,0,0,0,CMD_TYPE_PUBSUB,0},
+    {"unsubscribe",unsubscribeCommand,-1,"pslt",0,NULL,0,0,0,0,0,CMD_TYPE_PUBSUB,0},
+    {"psubscribe",psubscribeCommand,-2,"pslt",0,NULL,0,0,0,0,0,CMD_TYPE_PUBSUB,0},
+    {"punsubscribe",punsubscribeCommand,-1,"pslt",0,NULL,0,0,0,0,0,CMD_TYPE_PUBSUB,0},
+    {"publish",publishCommand,3,"pltF",0,NULL,0,0,0,0,0,CMD_TYPE_PUBSUB,0},
+    {"pubsub",pubsubCommand,-2,"pltR",0,NULL,0,0,0,0,0,CMD_TYPE_PUBSUB,0},
+    {"watch",watchCommand,-2,"sF",0,NULL,1,-1,1,0,0,CMD_TYPE_TRANSACTION,0},
+    {"unwatch",unwatchCommand,1,"sF",0,NULL,0,0,0,0,0,CMD_TYPE_TRANSACTION,0},
+    {"cluster",clusterCommand,-2,"a",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"restore",restoreCommand,-4,"wm",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"restore-asking",restoreCommand,-4,"wmk",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"migrate",migrateCommand,-6,"w",0,migrateGetKeys,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"asking",askingCommand,1,"F",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"readonly",readonlyCommand,1,"F",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"readwrite",readwriteCommand,1,"F",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"dump",dumpCommand,2,"r",0,NULL,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"object",objectCommand,-2,"r",0,NULL,2,2,2,0,0,CMD_TYPE_NONE,0},
+    {"memory",memoryCommand,-2,"r",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"client",clientCommand,-2,"as",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"eval",evalCommand,-3,"s",0,evalGetKeys,0,0,0,0,0,CMD_TYPE_SCRIPTING,0},
+    {"evalsha",evalShaCommand,-3,"s",0,evalGetKeys,0,0,0,0,0,CMD_TYPE_SCRIPTING,0},
+    {"slowlog",slowlogCommand,-2,"a",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"script",scriptCommand,-2,"s",0,NULL,0,0,0,0,0,CMD_TYPE_SCRIPTING,0},
+    {"time",timeCommand,1,"RF",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"bitop",bitopCommand,-4,"wm",0,NULL,2,-1,1,0,0,CMD_TYPE_STRING,0},
+    {"bitcount",bitcountCommand,-2,"r",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"bitpos",bitposCommand,-3,"r",0,NULL,1,1,1,0,0,CMD_TYPE_STRING,0},
+    {"wait",waitCommand,3,"s",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"command",commandCommand,0,"lt",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"geoadd",geoaddCommand,-5,"wm",0,NULL,1,1,1,0,0,CMD_TYPE_GEO,0},
+    {"georadius",georadiusCommand,-6,"w",0,georadiusGetKeys,1,1,1,0,0,CMD_TYPE_GEO,0},
+    {"georadius_ro",georadiusroCommand,-6,"r",0,georadiusGetKeys,1,1,1,0,0,CMD_TYPE_NONE,0},
+    {"georadiusbymember",georadiusbymemberCommand,-5,"w",0,georadiusGetKeys,1,1,1,0,0,CMD_TYPE_GEO,0},
+    {"georadiusbymember_ro",georadiusbymemberroCommand,-5,"r",0,georadiusGetKeys,1,1,1,0,0,CMD_TYPE_GEO,0},
+    {"geohash",geohashCommand,-2,"r",0,NULL,1,1,1,0,0,CMD_TYPE_GEO,0},
+    {"geopos",geoposCommand,-2,"r",0,NULL,1,1,1,0,0,CMD_TYPE_GEO,0},
+    {"geodist",geodistCommand,-4,"r",0,NULL,1,1,1,0,0,CMD_TYPE_GEO,0},
+    {"pfselftest",pfselftestCommand,1,"a",0,NULL,0,0,0,0,0,CMD_TYPE_HYPERLOGLOG,0},
+    {"pfadd",pfaddCommand,-2,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_HYPERLOGLOG,0},
+    {"pfcount",pfcountCommand,-2,"r",0,NULL,1,-1,1,0,0,CMD_TYPE_HYPERLOGLOG,0},
+    {"pfmerge",pfmergeCommand,-2,"wm",0,NULL,1,-1,1,0,0,CMD_TYPE_HYPERLOGLOG,0},
+    {"pfdebug",pfdebugCommand,-3,"w",0,NULL,0,0,0,0,0,CMD_TYPE_HYPERLOGLOG,0},
+    {"xadd",xaddCommand,-5,"wmF",0,NULL,1,1,1,0,0,CMD_TYPE_STREAM,0},
+    {"xrange",xrangeCommand,-4,"r",0,NULL,1,1,1,0,0,CMD_TYPE_STREAM,0},
+    {"xrevrange",xrevrangeCommand,-4,"r",0,NULL,1,1,1,0,0,CMD_TYPE_STREAM,0},
+    {"xlen",xlenCommand,2,"rF",0,NULL,1,1,1,0,0,CMD_TYPE_STREAM,0},
+    {"xread",xreadCommand,-3,"rs",0,xreadGetKeys,1,1,1,0,0,CMD_TYPE_STREAM,0},
+    {"xreadgroup",xreadCommand,-3,"ws",0,xreadGetKeys,1,1,1,0,0,CMD_TYPE_STREAM,0},
+    {"xgroup",xgroupCommand,-2,"wm",0,NULL,2,2,1,0,0,CMD_TYPE_STREAM,0},
+    {"xack",xackCommand,-3,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_STREAM,0},
+    {"xpending",xpendingCommand,-3,"r",0,NULL,1,1,1,0,0,CMD_TYPE_STREAM,0},
+    {"xclaim",xclaimCommand,-5,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_STREAM,0},
+    {"xinfo",xinfoCommand,-2,"r",0,NULL,2,2,1,0,0,CMD_TYPE_STREAM,0},
+    {"xdel",xdelCommand,-2,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_STREAM,0},
+    {"xtrim",xtrimCommand,-2,"wF",0,NULL,1,1,1,0,0,CMD_TYPE_STREAM,0},
+    {"post",securityWarningCommand,-1,"lt",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"host:",securityWarningCommand,-1,"lt",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0},
+    {"latency",latencyCommand,-2,"aslt",0,NULL,0,0,0,0,0,CMD_TYPE_NONE,0}
 };
+
+/*============================ ACL functions ============================ */
+
+/* 
+ * initializeGroupACLs builds ACLGroups that follow RCP-1
+ */
+
+void initializeGroupACLs() {
+    int numcommands = sizeof(redisCommandTable)/sizeof(struct redisCommand);
+    int numgroups = getNumberOfACLGroups() - 1;
+
+    acl_t aclvalue;
+    int aclindex;
+    int i, j;
+
+    int flag_match;
+    int rflag_match;
+
+    struct redisCommand *cmd;
+    struct ACLGroup *group;
+    struct ACLGroup *allGroup = aclGroups + numgroups;
+
+    for (i = 0; i < numgroups + 1; i++) {
+        group = aclGroups + i;
+        initACLs(group->acls);
+    }
+
+    int count = 0;
+    for (i = 0; i < numcommands; i++) {
+        cmd = redisCommandTable+i;
+        cmd->aclid = count;
+        aclindex = CMD_ACL_INDEX(count);
+        aclvalue = CMD_ACL_VALUE(count);
+        count++;
+
+        for (j = 0; j < numgroups; j++) {
+            group = aclGroups + j;
+
+            if (group->type == 0) {
+                // when having flags set true
+                flag_match = group->flags == 0 ? 1 : ((cmd->flags & group->flags) > 0);
+
+                // when not having any reverse flags set true
+                rflag_match = group->rflags == 0 ? 0 : ((cmd->flags & group->rflags) > 0);
+
+                if (flag_match == 1 && rflag_match == 0) {
+                    group->acls[aclindex] |= aclvalue;
+                }
+            } else if (group->type != 0 && (cmd->types & group->type) == group->type) {
+                group->acls[aclindex] |= aclvalue;
+            }
+        }
+
+        allGroup->acls[aclindex] |= aclvalue;
+    }
+
+    setACLs(server.default_acls, allGroup->acls);
+} 
 
 /*============================ Utility functions ============================ */
 
@@ -1351,6 +1409,8 @@ void createSharedObjects(void) {
     shared.space = createObject(OBJ_STRING,sdsnew(" "));
     shared.colon = createObject(OBJ_STRING,sdsnew(":"));
     shared.plus = createObject(OBJ_STRING,sdsnew("+"));
+    shared.notallowedacl = createObject(OBJ_STRING,sdsnew(
+        "-ACL Not allowed ACL command.\r\n"));
 
     for (j = 0; j < PROTO_SHARED_SELECT_CMDS; j++) {
         char dictid_str[64];
@@ -1514,6 +1574,7 @@ void initServerConfig(void) {
     appendServerSaveParams(60,10000); /* save after 1 minute and 10000 changes */
 
     /* Replication related */
+    server.masteruser = NULL;
     server.masterauth = NULL;
     server.masterhost = NULL;
     server.masterport = 6379;
@@ -1562,6 +1623,7 @@ void initServerConfig(void) {
      * redis.conf using the rename-command directive. */
     server.commands = dictCreate(&commandTableDictType,NULL);
     server.orig_commands = dictCreate(&commandTableDictType,NULL);
+    server.acls = dictCreate(&userACLDictType,NULL);
     populateCommandTable();
     server.delCommand = lookupCommandByCString("del");
     server.multiCommand = lookupCommandByCString("multi");
@@ -1589,6 +1651,10 @@ void initServerConfig(void) {
     server.assert_line = 0;
     server.bug_report_start = 0;
     server.watchdog_period = 0;
+
+    /* ACL */
+    server.acl_filename = NULL;
+    server.use_cmd_acls = 0;
 }
 
 extern char **environ;
@@ -2032,6 +2098,14 @@ void initServer(void) {
         server.maxmemory_policy = MAXMEMORY_NO_EVICTION;
     }
 
+    initializeGroupACLs();
+    if (server.use_cmd_acls) {
+        if (loadACLs(server.acl_filename) == -1) {
+            serverLog(LL_WARNING,"Warning: Fail to Loading users-file, so not to use acls");
+            server.use_cmd_acls = 0;
+        }
+    }
+
     if (server.cluster_enabled) clusterInit();
     replicationScriptCacheInit();
     scriptingInit(1);
@@ -2388,6 +2462,16 @@ void call(client *c, int flags) {
     server.stat_numcommands++;
 }
 
+#define HAS_PERMISSION(acls, index, permission) ((acls[index] & permission) == permission)
+int isAllowedACL(client *c) {
+    // allow commands in Modules
+    if (c->cmd->proc == authCommand || (c->cmd->flags & CMD_MODULE) == CMD_MODULE) {
+        return 1;
+    }
+
+    return HAS_PERMISSION(c->acls, CMD_ACL_INDEX(c->cmd->aclid), CMD_ACL_VALUE(c->cmd->aclid));
+}
+
 /* If this function gets called we already read a whole
  * command, arguments are in the client argv/argc fields.
  * processCommand() execute the command or prepare the
@@ -2475,6 +2559,13 @@ int processCommand(client *c) {
             addReply(c, shared.oomerr);
             return C_OK;
         }
+    }
+
+    // Checking client can use this command
+    if (isAllowedACL(c) == 0) {
+        flagTransaction(c);
+        addReply(c, shared.notallowedacl);
+        return C_OK;        
     }
 
     /* Don't accept write commands if there are problems persisting on disk
@@ -2716,15 +2807,45 @@ int time_independent_strcmp(char *a, char *b) {
     return diff; /* If zero strings are the same. */
 }
 
+int checkpasswd(char *passwd1, char *passwd2) {
+    return strcmp(passwd1, passwd2) == 0;
+}
+
 void authCommand(client *c) {
-    if (!server.requirepass) {
-        addReplyError(c,"Client sent AUTH, but no password is set");
-    } else if (!time_independent_strcmp(c->argv[1]->ptr, server.requirepass)) {
-      c->authenticated = 1;
-      addReply(c,shared.ok);
+    if (server.use_cmd_acls && c->argc != 3) {
+        addReplyError(c, "wrong number of arguments for 'auth(use_cmd_acl)' command");
+        return;
+    } else if (server.use_cmd_acls == 0 && c->argc != 2) {
+        addReplyError(c, "wrong number of arguments for 'auth' command");
+        return;
+    } 
+
+    if (c->argc == 2) {
+        if (!server.requirepass) {
+            addReplyError(c,"Client sent AUTH, but no password is set");
+        } else if (!time_independent_strcmp(c->argv[1]->ptr, server.requirepass)) {
+            c->authenticated = 1;
+            addReply(c,shared.ok);
+        } else {
+            c->authenticated = 0;
+            addReplyError(c,"invalid password");
+        }
     } else {
-      c->authenticated = 0;
-      addReplyError(c,"invalid password");
+        char *userName = c->argv[1]->ptr;
+        if (strcasecmp(userName, ACL_DEFAULT_USER_NAME) == 0) {
+            addReplyError(c,"You can't AUTH with default");
+            return;
+        }
+
+        userACL *user = getUserACL(userName);
+        if (user != NULL && checkpasswd(user->passwd, c->argv[2]->ptr)) {
+            setACLs(c->acls, user->acls); 
+            c->authenticated = 1;
+            addReply(c,shared.ok);
+        } else {
+            c->authenticated = 0;
+            addReplyError(c,"invalid user or password");
+        }
     }
 }
 

--- a/tests/assets/users-file
+++ b/tests/assets/users-file
@@ -1,0 +1,8 @@
+alltest "alltest" +#all
+allnotping "allnotping" +#all -ping
+allnotzset "allnotzset" +#all -#zset
+zsethash "zsethash" +#zset +#hash
+zsethashping "zsethashping" +#zset +#hash +ping
+slowtest "slowtest" +#slow
+pinginfo "pinginfo" +ping +info
+default "" +select

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -15,6 +15,7 @@ set ::all_tests {
     unit/printver
     unit/dump
     unit/auth
+    unit/acls
     unit/protocol
     unit/keyspace
     unit/scan

--- a/tests/unit/acls.tcl
+++ b/tests/unit/acls.tcl
@@ -1,0 +1,157 @@
+set server_path [tmpdir "server.auth_with_acls"]
+
+exec cp tests/assets/users-file $server_path
+start_server [list overrides [list "dir" $server_path "users-file" "users-file"]] {
+    # automatically default test ran with select command
+
+    test {AUTH fails when a wrong protocol} {
+        catch {r auth wrong!} err
+        set _ $err
+    } {ERR wrong number of arguments for 'auth(use_cmd_acl)' command}
+
+    test {AUTH fails when a wrong id and pw} {
+        catch {r auth wrongid! wrongpw!} err
+        set _ $err
+    } {ERR invalid user or password}
+
+    test {run with alltest user} {
+        catch {r auth alltest alltest} err
+        set _ $err
+    } {OK}
+
+    test {Once AUTH succeeded we can actually send commands to the server} {
+        r set foo 100
+        r incr foo
+    } {101}
+}
+
+exec cp tests/assets/users-file $server_path
+start_server [list overrides [list "dir" $server_path "users-file" "users-file"]] {
+    # automatically default test ran with select command
+
+    test {AUTH fails when a wrong protocol} {
+        catch {r auth wrong!} err
+        set _ $err
+    } {ERR wrong number of arguments for 'auth(use_cmd_acl)' command}
+
+    test {AUTH fails when a wrong id and pw} {
+        catch {r auth wrongid! wrongpw!} err
+        set _ $err
+    } {ERR invalid user or password}
+
+    test {run with allnotping user} {
+        catch {r auth allnotping allnotping} err
+        set _ $err
+    } {OK}
+
+    test {Once AUTH succeeded we can actually send commands to the server} {
+        r set foo 100
+        r incr foo
+    } {101}
+
+    test {ACL fails with ping} {
+        catch {r ping} err
+        set _ $err
+    } {ACL Not allowed ACL command.}
+}
+
+exec cp tests/assets/users-file $server_path
+start_server [list overrides [list "dir" $server_path "users-file" "users-file"]] {
+    # automatically default test ran with select command
+
+    test {AUTH fails when a wrong protocol} {
+        catch {r auth wrong!} err
+        set _ $err
+    } {ERR wrong number of arguments for 'auth(use_cmd_acl)' command}
+
+    test {AUTH fails when a wrong id and pw} {
+        catch {r auth wrongid! wrongpw!} err
+        set _ $err
+    } {ERR invalid user or password}
+
+    test {run with allnotzset user} {
+        catch {r auth allnotzset allnotzset} err
+        set _ $err
+    } {OK}
+
+    test {Once AUTH succeeded we can actually send commands to the server} {
+        r set foo 100
+        r incr foo
+    } {101}
+
+    test {ACL fails with ping} {
+        catch {r zadd ss 100 abcd} err
+        set _ $err
+    } {ACL Not allowed ACL command.}
+}
+
+exec cp tests/assets/users-file $server_path
+start_server [list overrides [list "dir" $server_path "users-file" "users-file"]] {
+    # automatically default test ran with select command
+
+    test {AUTH fails when a wrong protocol} {
+        catch {r auth wrong!} err
+        set _ $err
+    } {ERR wrong number of arguments for 'auth(use_cmd_acl)' command}
+
+    test {AUTH fails when a wrong id and pw} {
+        catch {r auth wrongid! wrongpw!} err
+        set _ $err
+    } {ERR invalid user or password}
+
+    test {run with zsethash user} {
+        catch {r auth zsethash zsethash} err
+        set _ $err
+    } {OK}
+
+    test {ACL fails with set} {
+        catch {r set foo 100} err
+        set _ $err
+    } {ACL Not allowed ACL command.}
+
+    test {Once AUTH succeeded we can actually send commands to the server : zadd} {
+        r zadd ss 100 abcd
+    } {1}
+
+    test {Once AUTH succeeded we can actually send commands to the server : hset} {
+        r hset hh abcd 100
+    } {1}
+
+    test {Once AUTH succeeded we can actually send commands to the server : hget} {
+        r hget hh abcd
+    } {100}
+
+    test {ACL fails with info} {
+        catch {r info} err
+        set _ $err
+    } {ACL Not allowed ACL command.}
+}
+
+exec cp tests/assets/users-file $server_path
+start_server [list overrides [list "dir" $server_path "users-file" "users-file"]] {
+    # automatically default test ran with select command
+
+    test {AUTH fails when a wrong protocol} {
+        catch {r auth wrong!} err
+        set _ $err
+    } {ERR wrong number of arguments for 'auth(use_cmd_acl)' command}
+
+    test {AUTH fails when a wrong id and pw} {
+        catch {r auth wrongid! wrongpw!} err
+        set _ $err
+    } {ERR invalid user or password}
+
+    test {run with slowtest user} {
+        catch {r auth slowtest slowtest} err
+        set _ $err
+    } {OK}
+
+    test {Once AUTH succeeded we can actually send commands to the server : set} {
+        r set foo 100
+    } {OK}
+
+    test {ACL fails with exists} {
+        catch {r info} err
+        set _ $err
+    } {ACL Not allowed ACL command.}
+}

--- a/users-file-example
+++ b/users-file-example
@@ -1,0 +1,7 @@
+antirez "my password" +#all
+charsyam "passwd" +#all -#zset -#set -ping
+slowtest "test" +#slow
+zset "zset" +#zset +#hash
+dup1 "dup1" +ping
+dup1 "dup1" +#all
+default "" +ping +info


### PR DESCRIPTION
Hi, @dvirsky (cc @antirez), it's too late to apply your reviews.

# Design 
 It follows RCP 1 https://github.com/redis/redis-rcp/blob/master/RCP1.md

## Why does it take to merge command acls and group acls.
 ACLs is not determistic, it can affect by order, 
 and some commands can be in multiple group.
 let's see the examples.

```
+#READONLY -#ZSET +#SLOW // we can use zrange
+#READONLY +#SLOW -#ZSET // we can't use zrange
```

 so I think to merge ACLs is more clear to make acls and make it to check easiler
 
# Tests
 I added tests in tests/unit/acls.tcl

# Compliance with RCP-1
## group
 It follows RCP 1.
 it only added more group RCP was written before redis has geo and stream
 so it has geo and stream group to support those commands.

## modules
 actullay, in RCP 1, there is no spec of MODULES.
 so I implemented, anyone can use commands in module.

# Supporting slaves and sentinels
 I added auth code for slaves and sentinels

# hashed passwords
 currenlty, not support hashed passwords.
 but it is very easy to support, redis always has sha1.c
 