### PR TITLE
Make EXISTS consistent with GET for expiry on slaves

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1739,10 +1739,10 @@ robj *objectCommandLookup(client *c, robj *key);
 robj *objectCommandLookupOrReply(client *c, robj *key, robj *reply);
 #define LOOKUP_NONE 0
 #define LOOKUP_NOTOUCH (1<<0)
+#define LOOKUP_NOSTATS (1<<1)
 void dbAdd(redisDb *db, robj *key, robj *val);
 void dbOverwrite(redisDb *db, robj *key, robj *val);
 void setKey(redisDb *db, robj *key, robj *val);
-int dbExists(redisDb *db, robj *key);
 robj *dbRandomKey(redisDb *db);
 int dbSyncDelete(redisDb *db, robj *key);
 int dbDelete(redisDb *db, robj *key);


### PR DESCRIPTION
While reading the code, I noticed the EXISTS command just calls `expireIfNeeded()` and `dictFind()` (via `dbExists()`), instead of going through `lookupKeyReadWithFlags()` like the other read-only commands. That means that EXISTS behaves differently from GET with keys that exist on the slave but are "logically expired", meaning the master hasn't yet had a chance to delete the expired key on the slave (see #1768).

I tried fixing this by having `existsCommand()` call `lookupKeyReadWithFlags()`, with a new flag `LOOKUP_NOSTATS` that disables updating the hits/misses stats. By passing `LOOKUP_NOTOUCH | LOOKUP_NOSTATS`, we should get the exact same behavior as before, but with the extra key expiry logic included.

I don't know if this is a bug or intentional, but I had fun fixing it and thought a PR might be helpful.