### PR TITLE
Removed unused alignment/padding calculation from zmalloc macros

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -71,14 +71,10 @@ void zlibc_free(void *ptr) {
 #endif
 
 #define update_zmalloc_stat_alloc(__n) do { \
-    size_t _n = (__n); \
-    if (_n&(sizeof(long)-1)) _n += sizeof(long)-(_n&(sizeof(long)-1)); \
     atomicIncr(used_memory,__n); \
 } while(0)
 
 #define update_zmalloc_stat_free(__n) do { \
-    size_t _n = (__n); \
-    if (_n&(sizeof(long)-1)) _n += sizeof(long)-(_n&(sizeof(long)-1)); \
     atomicDecr(used_memory,__n); \
 } while(0)
 


### PR DESCRIPTION
The alignment/padding calculations in update_zmalloc_stat_(alloc|free) currently do nothing, haven't been used since thread safe mode was removed, and were probably broken years before that as they were used only for incrementation in the thread safe case. As the padding is accounted for in all calls to update_zmalloc_stat_(alloc|free) by the caller either using zmalloc_size or explicit addition of PREFIX_SIZE, they no longer appear to be needed here.

See issue #4739 
