### PR TITLE
optimize the method: _dictNextPower for big size

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -940,7 +940,8 @@ static unsigned long _dictNextPower(unsigned long size)
 {
   unsigned long prev;
   unsigned long iter = size;
-
+  
+  if (size >= LONG_MAX) return LONG_MAX + 1LU;
   while (iter) {
       prev = iter;
       iter = iter & (iter - 1);

--- a/src/dict.c
+++ b/src/dict.c
@@ -938,14 +938,14 @@ static int _dictExpandIfNeeded(dict *d)
 /* Our hash table capability is a power of two */
 static unsigned long _dictNextPower(unsigned long size)
 {
-    unsigned long i = DICT_HT_INITIAL_SIZE;
+  unsigned long prev;
+  unsigned long iter = size;
 
-    if (size >= LONG_MAX) return LONG_MAX + 1LU;
-    while(1) {
-        if (i >= size)
-            return i;
-        i *= 2;
-    }
+  while (iter) {
+      prev = iter;
+      iter = iter & (iter - 1);
+  }
+  return prev == size ? prev : prev << 1;
 }
 
 /* Returns the index of a free slot that can be populated with


### PR DESCRIPTION
Performance Testing：
```
#include <stdio.h>
#include <limits.h>
#include <time.h>

/* Our hash table capability is a power of two */
static unsigned long _dictNextPower(unsigned long size) {
    unsigned long prev;
    unsigned long iter = size;
    if (size >= LONG_MAX) return LONG_MAX + 1LU;
    while (iter) {
        prev = iter;
        iter = iter & (iter - 1);
    }
    return prev == size ? prev : prev << 1;
}

/* Our hash table capability is a power of two */
static unsigned long _dictNextPower2(unsigned long size) {
    unsigned long i = 4;

    if (size >= LONG_MAX) return LONG_MAX;
    while (1) {
        if (i >= size)
            return i;
        i *= 2;
    }
}

int main(void) {
    int start;
    int end;
    start = time((time_t *) NULL);
    for (int i = 0; i < 1000000000; ++i) {
        _dictNextPower2(i);
    }
    end = time((time_t *) NULL);
    printf("%d\n", end - start);

    start = time((time_t *) NULL);
    for (int j = 0; j < 1000000000; ++j) {
        _dictNextPower(j);
    }
    end = time((time_t *) NULL);
    printf("%d\n", end - start);
    return 0;
}
```

print：
```
68
42
```

the algorithm avoid unnecessary calculation,for example:
`when size = 129(10000001)`
for old algorithm,from 4 to 256（result）,need 6 step,but the new algorithm just need 2 step。
1.use value&(value-1) get highest bits value.until value = 0,and prev = 128(10000000)
2.if prev == value ,return prev.
3.else result = prev<<1 (100000000)