### PR TITLE
Make blocking list commands send keyspace notifications

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -283,6 +283,7 @@ void handleClientsBlockedOnKeys(void) {
 
                 if (listTypeLength(o) == 0) {
                     dbDelete(rl->db,rl->key);
+                    notifyKeyspaceEvent(NOTIFY_GENERIC,"del",rl->key,rl->db->id);
                 }
                 /* We don't call signalModifiedKey() as it was already called
                  * when an element was pushed on the list. */


### PR DESCRIPTION
After a client is unblocked (not by timeout), appropriate keyspace notifications should be sent.