### PR TITLE
Fix incorrect nonexistent zset reply in GEOHASH/GEOPOS

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -701,8 +701,11 @@ void geohashCommand(client *c) {
     int j;
 
     /* Look up the requested zset */
-    robj *zobj = lookupKeyRead(c->db, c->argv[1]);
-    if (zobj && checkType(c, zobj, OBJ_ZSET)) return;
+    robj *zobj = NULL;
+    if ((NULL == (zobj = lookupKeyReadOrReply(c, c->argv[1], shared.nullbulk)))
+      || checkType(c, zobj, OBJ_ZSET)) {
+       return; /* Reply for missing zset or wrong type already sent */
+    }
 
     /* Geohash elements one after the other, using a null bulk reply for
      * missing elements. */
@@ -754,8 +757,11 @@ void geoposCommand(client *c) {
     int j;
 
     /* Look up the requested zset */
-    robj *zobj = lookupKeyRead(c->db, c->argv[1]);
-    if (zobj && checkType(c, zobj, OBJ_ZSET)) return;
+    robj *zobj = NULL;
+    if ((NULL == (zobj = lookupKeyReadOrReply(c, c->argv[1], shared.nullbulk)))
+      || checkType(c, zobj, OBJ_ZSET)) {
+       return; /* Reply for missing zset or wrong type already sent */
+    }
 
     /* Report elements one after the other, using a null bulk reply for
      * missing elements. */
@@ -797,8 +803,10 @@ void geodistCommand(client *c) {
 
     /* Look up the requested zset */
     robj *zobj = NULL;
-    if ((zobj = lookupKeyReadOrReply(c, c->argv[1], shared.nullbulk))
-        == NULL || checkType(c, zobj, OBJ_ZSET)) return;
+    if ((NULL == (zobj = lookupKeyReadOrReply(c, c->argv[1], shared.nullbulk)))
+      || checkType(c, zobj, OBJ_ZSET)) {
+       return; /* Reply for missing zset or wrong type already sent */
+    }
 
     /* Get the scores. We need both otherwise NULL is returned. */
     double score1, score2, xyxy[4];


### PR DESCRIPTION
Currently, in the case where the underlying zset for a given GEOHASH/GEOPOS command doesn't exist, a loop will be entered, the requested members will be checked (against a nonexistent set), and a nil reply will be sent for each. This is suboptimal and contrary to normal Redis behavior, in which a null bulk reply is returned when the key doesn't exist. This corrects the behavior. @antirez 