### PR TITLE
Optimization: safer localtime implementation

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -343,9 +343,11 @@ void serverLogRaw(int level, const char *msg) {
         struct timeval tv;
         int role_char;
         pid_t pid = getpid();
+        struct tm tm;
 
         gettimeofday(&tv,NULL);
-        off = strftime(buf,sizeof(buf),"%d %b %H:%M:%S.",localtime(&tv.tv_sec));
+        localtime_nolock(&tv.tv_sec, &tm);
+        off = strftime(buf,sizeof(buf),"%d %b %H:%M:%S.",&tm);
         snprintf(buf+off,sizeof(buf)-off,"%03d",(int)tv.tv_usec/1000);
         if (server.sentinel_mode) {
             role_char = 'X'; /* Sentinel. */
@@ -2029,6 +2031,7 @@ void initServer(void) {
     latencyMonitorInit();
     bioInit();
     server.initial_memory_usage = zmalloc_used_memory();
+    tzset(); /* init timezone on start */
 }
 
 /* Populates the Redis Command Table starting from the hard coded list

--- a/src/util.c
+++ b/src/util.c
@@ -39,6 +39,7 @@
 #include <float.h>
 #include <stdint.h>
 #include <errno.h>
+#include <time.h>
 
 #include "util.h"
 #include "sha1.h"
@@ -671,6 +672,80 @@ sds getAbsolutePath(char *filename) {
  * environments where Redis runs. */
 int pathIsBaseName(char *path) {
     return strchr(path,'/') == NULL && strchr(path,'\\') == NULL;
+}
+
+/* localtime delete tzset, only call tzset one time
+ */
+int localtime_nolock(const time_t *t, struct tm *tp) {
+    static const unsigned short int mon_yday[2][13] = {
+        /* Normal years.  */
+        { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 },
+        /* Leap years.  */
+        { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 }
+    };
+
+#define SECS_PER_HOUR   (60 * 60)
+#define SECS_PER_DAY    (SECS_PER_HOUR * 24)
+#define ISLEAP(year)    ((year) % 4 == 0 && ((year) % 100 != 0 || (year) % 400 == 0))
+#define DIV(a, b)       ((a) / (b) - ((a) % (b) < 0))
+#define LEAPS_THRU_END_OF(y) (DIV (y, 4) - DIV (y, 100) + DIV (y, 400))
+
+    long int                days, rem, y;
+    const unsigned short int *ip;
+
+    days = *t / SECS_PER_DAY;
+    rem = *t % SECS_PER_DAY;
+    rem -= timezone;
+
+    while (rem < 0) {
+        rem += SECS_PER_DAY;
+        --days;
+    }
+
+    while (rem >= SECS_PER_DAY) {
+        rem -= SECS_PER_DAY;
+        ++days;
+    }
+
+    tp->tm_hour = rem / SECS_PER_HOUR;
+    rem %= SECS_PER_HOUR;
+    tp->tm_min = rem / 60;
+    tp->tm_sec = rem % 60;
+    /* January 1, 1970 was a Thursday.  */
+    tp->tm_wday = (4 + days) % 7;
+
+    if (tp->tm_wday < 0)
+        tp->tm_wday += 7;
+
+    y = 1970;
+
+    while (days < 0 || days >= (ISLEAP (y) ? 366 : 365)) {
+        /* Guess a corrected year, assuming 365 days per year.  */
+        long int                yg = y + days / 365 - (days % 365 < 0);
+
+        /* Adjust DAYS and Y to match the guessed year.  */
+        days -= ((yg - y) * 365
+                 + LEAPS_THRU_END_OF (yg - 1)
+                 - LEAPS_THRU_END_OF (y - 1));
+        y = yg;
+    }
+
+    tp->tm_year = y - 1900;
+
+    if (tp->tm_year != y - 1900) {
+        return 0;
+    }
+
+    tp->tm_yday = days;
+    ip = mon_yday[ISLEAP(y)];
+
+    for (y = 11; days < (long int) ip[y]; --y)
+        continue;
+
+    days -= ip[y];
+    tp->tm_mon = y;
+    tp->tm_mday = days + 1;
+    return 1;
 }
 
 #ifdef REDIS_TEST

--- a/src/util.h
+++ b/src/util.h
@@ -31,6 +31,7 @@
 #define __REDIS_UTIL_H
 
 #include <stdint.h>
+#include <time.h>
 #include "sds.h"
 
 /* The maximum number of characters needed to represent a long double
@@ -51,6 +52,7 @@ int d2string(char *buf, size_t len, double value);
 int ld2string(char *buf, size_t len, long double value, int humanfriendly);
 sds getAbsolutePath(char *filename);
 int pathIsBaseName(char *path);
+int localtime_nolock(const time_t *t, struct tm *tp);
 
 #ifdef REDIS_TEST
 int utilTest(int argc, char **argv);


### PR DESCRIPTION
Curently, Redis uses localtime() in its log function to format time, but it's not thread safe.

localtime_r() is thread safe, but it isn't safe for the bgsave subprocess if localtime_r() is called in another thread(like bio thread or thread created in redis module), because global shared lock is used in localtime_r() and localtime().