### PR TITLE
Remove unnecessary return statements

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2866,7 +2866,6 @@ void bytesToHuman(char *s, unsigned long long n) {
     if (n < 1024) {
         /* Bytes */
         sprintf(s,"%lluB",n);
-        return;
     } else if (n < (1024*1024)) {
         d = (double)n/(1024);
         sprintf(s,"%.2fK",d);


### PR DESCRIPTION
Found a small problem while reading the source code D:)~
Signed-off-by: charpty <charpty@gmail.com>