### PR TITLE
assign client's woff before execute current command

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2565,8 +2565,8 @@ int processCommand(client *c) {
         queueMultiCommand(c);
         addReply(c,shared.queued);
     } else {
-        call(c,CMD_CALL_FULL);
         c->woff = server.master_repl_offset;
+        call(c,CMD_CALL_FULL);
         if (listLength(server.ready_keys))
             handleClientsBlockedOnKeys();
     }


### PR DESCRIPTION
`c->woff` should be assigned before `call`, or the offset is not the latest, it's the offset when the client do the last command and may be way behind the current offset.