### PR TITLE
Watch modules unloaded

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -644,6 +644,7 @@ struct client *createFakeClient(void) {
     c->reply_bytes = 0;
     c->obuf_soft_limit_reached_time = 0;
     c->watched_keys = listCreate();
+    c->watched_modules = listCreate();
     c->peerid = NULL;
     listSetFreeMethod(c->reply,decrRefCountVoid);
     listSetDupMethod(c->reply,dupClientReplyValue);
@@ -663,6 +664,7 @@ void freeFakeClient(struct client *c) {
     sdsfree(c->querybuf);
     listRelease(c->reply);
     listRelease(c->watched_keys);
+    listRelease(c->watched_modules);
     freeClientMultiState(c);
     zfree(c);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -4014,6 +4014,10 @@ int moduleUnload(sds name) {
 void moduleCommand(client *c) {
     char *subcmd = c->argv[1]->ptr;
 
+    if (c->flags & CLIENT_MULTI) {
+        addReplyError(c,"MODULE inside MULTI is not allowed");
+        return;
+    }
     if (!strcasecmp(subcmd,"load") && c->argc >= 3) {
         robj **argv = NULL;
         int argc = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -2559,7 +2559,8 @@ int processCommand(client *c) {
     /* Exec the command */
     if (c->flags & CLIENT_MULTI &&
         c->cmd->proc != execCommand && c->cmd->proc != discardCommand &&
-        c->cmd->proc != multiCommand && c->cmd->proc != watchCommand)
+        c->cmd->proc != multiCommand && c->cmd->proc != watchCommand &&
+        c->cmd->proc != moduleCommand)
     {
         queueMultiCommand(c);
         addReply(c,shared.queued);

--- a/src/server.c
+++ b/src/server.c
@@ -678,9 +678,7 @@ dictType clusterNodesBlackListDictType = {
     NULL                        /* val destructor */
 };
 
-/* Cluster re-addition blacklist. This maps node IDs to the time
- * we can re-add this node. The goal is to avoid readding a removed
- * node for some time. */
+/* Modules dict type. */
 dictType modulesDictType = {
     dictSdsCaseHash,            /* hash function */
     NULL,                       /* key dup */
@@ -1337,7 +1335,7 @@ void createSharedObjects(void) {
     shared.oomerr = createObject(OBJ_STRING,sdsnew(
         "-OOM command not allowed when used memory > 'maxmemory'.\r\n"));
     shared.execaborterr = createObject(OBJ_STRING,sdsnew(
-        "-EXECABORT Transaction discarded because of previous errors.\r\n"));
+        "-EXECABORT Transaction discarded because of previous errors or queued modules unloaded.\r\n"));
     shared.noreplicaserr = createObject(OBJ_STRING,sdsnew(
         "-NOREPLICAS Not enough good slaves to write.\r\n"));
     shared.busykeyerr = createObject(OBJ_STRING,sdsnew(
@@ -1934,6 +1932,7 @@ void initServer(void) {
         server.db[j].defrag_later = listCreate();
     }
     evictionPoolAlloc(); /* Initialize the LRU keys pool. */
+    server.watched_modules = dictCreate(&keylistDictType,NULL);
     server.pubsub_channels = dictCreate(&keylistDictType,NULL);
     server.pubsub_patterns = listCreate();
     listSetFreeMethod(server.pubsub_patterns,freePubsubPattern);

--- a/src/server.h
+++ b/src/server.h
@@ -733,6 +733,7 @@ typedef struct client {
     blockingState bpop;     /* blocking state */
     long long woff;         /* Last write global replication offset. */
     list *watched_keys;     /* Keys WATCHED for MULTI/EXEC CAS */
+    list *watched_modules;  /* modules WATCHED for MULTI/EXEC, in case of module unloaded */
     dict *pubsub_channels;  /* channels a client is interested in (SUBSCRIBE) */
     list *pubsub_patterns;  /* patterns a client is interested in (SUBSCRIBE) */
     sds peerid;             /* Cached peer ID. */
@@ -925,6 +926,7 @@ struct redisServer {
     int always_show_logo;       /* Show logo even for non-stdout logging. */
     /* Modules */
     dict *moduleapi;            /* Exported APIs dictionary for modules. */
+    dict *watched_modules;      /* WATCHED modules for MULTI/EXEC, in case of module unloaded. */
     list *loadmodule_queue;     /* List of modules to load at startup. */
     int module_blocked_pipe[2]; /* Pipe used to awake the event loop if a
                                    client blocked on a module command needs
@@ -1467,6 +1469,11 @@ void touchWatchedKeysOnFlush(int dbid);
 void discardTransaction(client *c);
 void flagTransaction(client *c);
 void execCommandPropagateMulti(client *c);
+/* WATCH module unloaded */
+void watchForModule(client *c, robj *module);
+void unwatchAllModules(client *c);
+void touchWatchedModule(robj * module);
+sds getModuleNameByCommand(struct redisCommand *cmd);
 
 /* Redis object implementation */
 void decrRefCount(robj *o);

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -46,6 +46,14 @@ start_server {tags {"multi"}} {
         set _ $err
     } {*ERR WATCH*}
 
+    test {MODULE inside MULTI is not allowed} {
+        set err {}
+        r multi
+        catch {[r module unload x]} err
+        r exec
+        set _ $err
+    } {*ERR MODULE*}
+
     test {EXEC fails if there are errors while queueing commands #1} {
         r del foo1 foo2
         r multi


### PR DESCRIPTION
We should watch modules which queued commands belong to, in case of the module unloaded.

At first I think we can check if the command exists by `lookupCommand()` function, but that will introduce a new problem: we cannot guarantee the command in `server.commands` is the original queued command, maybe it's a new module's command with the same name.

So, the watch mechanism is a better way, see more details in #4826.