### PR TITLE
Bugfix: xadd comand <field,value> arity check

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1009,7 +1009,7 @@ void xaddCommand(client *c) {
     int field_pos = i+1;
 
     /* Check arity. */
-    if ((c->argc - field_pos) < 2 || (c->argc-field_pos % 2) == 1) {
+    if ((c->argc - field_pos) < 2 || ((c->argc-field_pos) % 2) == 1) {
         addReplyError(c,"wrong number of arguments for XADD");
         return;
     }


### PR DESCRIPTION
missing parenthesis causes wrong arithmetic priority.