### PR TITLE
 Bugfix: xadd command ID parse

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -917,8 +917,10 @@ int string2ull(const char *s, unsigned long long *value) {
         return 1;
     }
     errno = 0;
-    *value = strtoull(s,NULL,10);
-    if (errno == EINVAL || errno == ERANGE) return 0; /* strtoull() failed. */
+    char *endptr = NULL;
+    *value = strtoull(s,&endptr,10);
+    if (errno == EINVAL || errno == ERANGE || !(*s != '\0' && *endptr == '\0'))
+        return 0; /* strtoull() failed. */
     return 1; /* Conversion done! */
 }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -999,11 +999,10 @@ void xaddCommand(client *c) {
             maxlen_arg_idx = i;
         } else {
             /* If we are here is a syntax error or a valid ID. */
-            if (streamParseIDOrReply(NULL,c->argv[i],&id,0) == C_OK) {
+            if (streamParseIDOrReply(c,c->argv[i],&id,0) == C_OK) {
                 id_given = 1;
                 break;
             } else {
-                addReply(c,shared.syntaxerr);
                 return;
             }
         }


### PR DESCRIPTION
strtoull() in libc may not set errno to EINVAL when the string contains invalid digits(tested with glibc 2.20 and 2.24) and string2ull() in t_stream.c will return wrong value.

```
> xadd s1 maxlen 5 invalidid sdf dsf
(error) ERR The ID specified in XADD is equal or smaller than the target stream top item
```

the above command should return `(error) ERR Invalid stream ID specified as stream command argument`