### PR TITLE
Feature: xadd command support create an empty stream

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -302,7 +302,7 @@ struct redisCommand redisCommandTable[] = {
     {"pfcount",pfcountCommand,-2,"r",0,NULL,1,-1,1,0,0},
     {"pfmerge",pfmergeCommand,-2,"wm",0,NULL,1,-1,1,0,0},
     {"pfdebug",pfdebugCommand,-3,"w",0,NULL,0,0,0,0,0},
-    {"xadd",xaddCommand,-5,"wmF",0,NULL,1,1,1,0,0},
+    {"xadd",xaddCommand,-3,"wmF",0,NULL,1,1,1,0,0},
     {"xrange",xrangeCommand,-4,"r",0,NULL,1,1,1,0,0},
     {"xrevrange",xrevrangeCommand,-4,"r",0,NULL,1,1,1,0,0},
     {"xlen",xlenCommand,2,"rF",0,NULL,1,1,1,0,0},

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -890,12 +890,14 @@ size_t streamReplyWithRangeFromConsumerPEL(client *c, stream *s, streamID *start
 
 /* Look the stream at 'key' and return the corresponding stream object.
  * The function creates a key setting it to an empty stream if needed. */
-robj *streamTypeLookupWriteOrCreate(client *c, robj *key) {
+robj *streamTypeLookupWriteOrCreate(client *c, robj *key, int *existed) {
     robj *o = lookupKeyWrite(c->db,key);
     if (o == NULL) {
+        if (existed) *existed = 0;
         o = createStreamObject();
         dbAdd(c->db,key,o);
     } else {
+        if (existed) *existed = 1;
         if (o->type != OBJ_STREAM) {
             addReply(c,shared.wrongtypeerr);
             return NULL;
@@ -965,7 +967,19 @@ invalid:
     return C_ERR;
 }
 
-/* XADD key [MAXLEN <count>] <ID or *> [field value] [field value] ... */
+void createEmptyStream(client *c) {
+    int existed = 0;
+
+    if (streamTypeLookupWriteOrCreate(c,c->argv[1],&existed) == NULL) return;
+    if (!existed) {
+        notifyKeyspaceEvent(NOTIFY_STREAM,"xadd",c->argv[1],c->db->id);
+        server.dirty++;
+    }
+
+    addReply(c, shared.ok);
+}
+
+/* XADD key [MAXLEN <count>] <ID or * or ^> [field value] [field value] ... */
 void xaddCommand(client *c) {
     streamID id;
     int id_given = 0; /* Was an ID different than "*" specified? */
@@ -973,6 +987,7 @@ void xaddCommand(client *c) {
     int approx_maxlen = 0;  /* If 1 only delete whole radix tree nodes, so
                                the maxium length is not applied verbatim. */
     int maxlen_arg_idx = 0; /* Index of the count in MAXLEN, for rewriting. */
+    int create_stream = 0;
 
     /* Parse options. */
     int i = 2; /* This is the first argument position where we could
@@ -983,6 +998,10 @@ void xaddCommand(client *c) {
         if (opt[0] == '*' && opt[1] == '\0') {
             /* This is just a fast path for the common case of auto-ID
              * creation. */
+            break;
+        } else if (opt[0] == '^' && opt[1] == '\0') {
+            /* special ID '^' means that we want to create an empty stream */
+            create_stream = 1;
             break;
         } else if (!strcasecmp(opt,"maxlen") && moreargs) {
             char *next = c->argv[i+1]->ptr;
@@ -1006,6 +1025,16 @@ void xaddCommand(client *c) {
             }
         }
     }
+
+    if (create_stream) {
+        if (c->argc != 3) {
+            addReplyError(c,"Wrong number of arguments for creating empty stream using XADD");
+            return;
+        }
+        createEmptyStream(c);
+        return;
+    }
+
     int field_pos = i+1;
 
     /* Check arity. */
@@ -1017,7 +1046,7 @@ void xaddCommand(client *c) {
     /* Lookup the stream at key. */
     robj *o;
     stream *s;
-    if ((o = streamTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
+    if ((o = streamTypeLookupWriteOrCreate(c,c->argv[1],NULL)) == NULL) return;
     s = o->ptr;
 
     /* Append using the low level function and return the ID. */


### PR DESCRIPTION
Using a special id '^' to indicate that an empty stream will be created, just like the special meaning of ID '*'.
This's is PR for issue #4824 . Set up a consumer group with an empty stream before any messages coming sounds quite  reasonable. :)