### PR TITLE
lazyfree & eviction: record latency generated by lazyfree eviction

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -450,9 +450,10 @@ int freeMemoryIfNeeded(void) {
     if (server.masterhost && server.repl_slave_ignore_maxmemory) return C_OK;
 
     size_t mem_reported, mem_tofree, mem_freed;
-    mstime_t latency, eviction_latency;
+    mstime_t latency, eviction_latency, lazyfree_latency;
     long long delta;
     int slaves = listLength(server.slaves);
+    int result = C_ERR;
 
     /* When clients are paused the dataset should be static not just from the
      * POV of clients not being able to write, but also from the POV of
@@ -463,10 +464,10 @@ int freeMemoryIfNeeded(void) {
 
     mem_freed = 0;
 
+    latencyStartMonitor(latency);
     if (server.maxmemory_policy == MAXMEMORY_NO_EVICTION)
         goto cant_free; /* We need to free memory, but policy forbids. */
 
-    latencyStartMonitor(latency);
     while (mem_freed < mem_tofree) {
         int j, k, i;
         static unsigned int next_db = 0;
@@ -572,7 +573,6 @@ int freeMemoryIfNeeded(void) {
             signalModifiedKey(NULL,db,keyobj);
             latencyEndMonitor(eviction_latency);
             latencyAddSampleIfNeeded("eviction-del",eviction_latency);
-            latencyRemoveNestedEvent(latency,eviction_latency);
             delta -= (long long) zmalloc_used_memory();
             mem_freed += delta;
             server.stat_evictedkeys++;
@@ -601,25 +601,30 @@ int freeMemoryIfNeeded(void) {
                 }
             }
         } else {
-            latencyEndMonitor(latency);
-            latencyAddSampleIfNeeded("eviction-cycle",latency);
             goto cant_free; /* nothing to free... */
         }
     }
-    latencyEndMonitor(latency);
-    latencyAddSampleIfNeeded("eviction-cycle",latency);
-    return C_OK;
+    result = C_OK;
 
 cant_free:
     /* We are here if we are not able to reclaim memory. There is only one
      * last thing we can try: check if the lazyfree thread has jobs in queue
      * and wait... */
-    while(bioPendingJobsOfType(BIO_LAZY_FREE)) {
-        if (((mem_reported - zmalloc_used_memory()) + mem_freed) >= mem_tofree)
-            break;
-        usleep(1000);
+    if (result != C_OK) {
+        latencyStartMonitor(lazyfree_latency);
+        while(bioPendingJobsOfType(BIO_LAZY_FREE)) {
+            if (getMaxmemoryState(NULL,NULL,NULL,NULL) == C_OK) {
+                result = C_OK;
+                break;
+            }
+            usleep(1000);
+        }
+        latencyEndMonitor(lazyfree_latency);
+        latencyAddSampleIfNeeded("eviction-lazyfree",lazyfree_latency);
     }
-    return C_ERR;
+    latencyEndMonitor(latency);
+    latencyAddSampleIfNeeded("eviction-cycle",latency);
+    return result;
 }
 
 /* This is a wrapper for freeMemoryIfNeeded() that only really calls the


### PR DESCRIPTION
Hi @antirez 

There are some problems about lazyfree eviction I think:

1. We forgot the latency generated by waiting for `BIO_LAZY_FREE`

   It's necessary to record this kind of latency.

2. Maybe we misuse `latencyRemoveNestedEvent `

    In my opinion the `eviction-cycle` should contains all latencies, including `eviction-del` and `eviction-lazyfree`, or we may lose the accumulated latency, for example:

    ```
    127.0.0.1:6379> latency latest
       1) 1) "command"
       2) (integer) 1523431788
       3) (integer) 10
       4) (integer) 10
    2) 1) "eviction-cycle"
       2) (integer) 1523431892
       3) (integer) 23
       4) (integer) 23
    3) 1) "eviction-del"
       2) (integer) 1523431892
       3) (integer) 11
       4) (integer) 47
    ```

    We can see than eviction-del's latency is greater than eviction-cycle's, and if `latency-monitor-threshold` is smaller than eviction-del's, the evict latency will be lost.

    So we should not remove `eviction-del` from `eviction-cycle` I think.

3. The last problem is about `cant_free`

    When we goto `cant_free`, we wait for `BIO_LAZY_FREE` finished or break if already freed enough memory.

    But, we use `mem_freed` duplicately.

    ```
        while(bioPendingJobsOfType(BIO_LAZY_FREE)) {
            if (((mem_reported - zmalloc_used_memory()) + mem_freed) >= mem_tofree)
                break;
            usleep(1000);
        }
    ```

    I think we can replace it with the new function `getMaxmemoryState()`.