### PR TITLE
Resolve some compilation warnings with recent gcc versions

### DIFF
--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -429,12 +429,12 @@ uint64_t MurmurHash64A (const void * key, int len, unsigned int seed) {
     }
 
     switch(len & 7) {
-    case 7: h ^= (uint64_t)data[6] << 48;
-    case 6: h ^= (uint64_t)data[5] << 40;
-    case 5: h ^= (uint64_t)data[4] << 32;
-    case 4: h ^= (uint64_t)data[3] << 24;
-    case 3: h ^= (uint64_t)data[2] << 16;
-    case 2: h ^= (uint64_t)data[1] << 8;
+    case 7: h ^= (uint64_t)data[6] << 48; /*FALLTHROUGH*/
+    case 6: h ^= (uint64_t)data[5] << 40; /*FALLTHROUGH*/
+    case 5: h ^= (uint64_t)data[4] << 32; /*FALLTHROUGH*/
+    case 4: h ^= (uint64_t)data[3] << 24; /*FALLTHROUGH*/
+    case 3: h ^= (uint64_t)data[2] << 16; /*FALLTHROUGH*/
+    case 2: h ^= (uint64_t)data[1] << 8;  /*FALLTHROUGH*/
     case 1: h ^= (uint64_t)data[0];
             h *= m;
     };

--- a/src/siphash.c
+++ b/src/siphash.c
@@ -142,12 +142,12 @@ uint64_t siphash(const uint8_t *in, const size_t inlen, const uint8_t *k) {
     }
 
     switch (left) {
-    case 7: b |= ((uint64_t)in[6]) << 48;
-    case 6: b |= ((uint64_t)in[5]) << 40;
-    case 5: b |= ((uint64_t)in[4]) << 32;
-    case 4: b |= ((uint64_t)in[3]) << 24;
-    case 3: b |= ((uint64_t)in[2]) << 16;
-    case 2: b |= ((uint64_t)in[1]) << 8;
+    case 7: b |= ((uint64_t)in[6]) << 48; /*FALLTHROUGH*/
+    case 6: b |= ((uint64_t)in[5]) << 40; /*FALLTHROUGH*/
+    case 5: b |= ((uint64_t)in[4]) << 32; /*FALLTHROUGH*/
+    case 4: b |= ((uint64_t)in[3]) << 24; /*FALLTHROUGH*/
+    case 3: b |= ((uint64_t)in[2]) << 16; /*FALLTHROUGH*/
+    case 2: b |= ((uint64_t)in[1]) << 8;  /*FALLTHROUGH*/
     case 1: b |= ((uint64_t)in[0]); break;
     case 0: break;
     }
@@ -202,12 +202,12 @@ uint64_t siphash_nocase(const uint8_t *in, const size_t inlen, const uint8_t *k)
     }
 
     switch (left) {
-    case 7: b |= ((uint64_t)siptlw(in[6])) << 48;
-    case 6: b |= ((uint64_t)siptlw(in[5])) << 40;
-    case 5: b |= ((uint64_t)siptlw(in[4])) << 32;
-    case 4: b |= ((uint64_t)siptlw(in[3])) << 24;
-    case 3: b |= ((uint64_t)siptlw(in[2])) << 16;
-    case 2: b |= ((uint64_t)siptlw(in[1])) << 8;
+    case 7: b |= ((uint64_t)siptlw(in[6])) << 48; /*FALLTHROUGH*/
+    case 6: b |= ((uint64_t)siptlw(in[5])) << 40; /*FALLTHROUGH*/
+    case 5: b |= ((uint64_t)siptlw(in[4])) << 32; /*FALLTHROUGH*/
+    case 4: b |= ((uint64_t)siptlw(in[3])) << 24; /*FALLTHROUGH*/
+    case 3: b |= ((uint64_t)siptlw(in[2])) << 16; /*FALLTHROUGH*/
+    case 2: b |= ((uint64_t)siptlw(in[1])) << 8;  /*FALLTHROUGH*/
     case 1: b |= ((uint64_t)siptlw(in[0])); break;
     case 0: break;
     }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1221,7 +1221,7 @@ void xreadCommand(client *c) {
                 addReplyErrorFormat(c, "-NOGROUP No such key '%s' or consumer "
                                        "group '%s' in XREADGROUP with GROUP "
                                        "option",
-                                    key->ptr,groupname->ptr);
+                                    (char *)key->ptr,(char *)groupname->ptr);
                 goto cleanup;
             }
             groups[id_idx] = group;
@@ -1485,7 +1485,7 @@ NULL
         {
             addReplyErrorFormat(c, "-NOGROUP No such consumer group '%s' "
                                    "for key name '%s'",
-                                   grpname, c->argv[2]->ptr);
+                                   grpname,(char *)c->argv[2]->ptr);
             return;
         }
     }
@@ -1611,7 +1611,7 @@ void xpendingCommand(client *c) {
     {
         addReplyErrorFormat(c, "-NOGROUP No such key '%s' or consumer "
                                "group '%s'",
-                               key->ptr,groupname->ptr);
+                               (char *)key->ptr,(char *)groupname->ptr);
         return;
     }
 
@@ -1787,8 +1787,8 @@ void xclaimCommand(client *c) {
      * is mandatory. */
     if (o == NULL || group == NULL) {
         addReplyErrorFormat(c,"-NOGROUP No such key '%s' or "
-                              "consumer group '%s'", c->argv[1]->ptr,
-                              c->argv[2]->ptr);
+                              "consumer group '%s'", (char *)c->argv[1]->ptr,
+                              (char *)c->argv[2]->ptr);
         return;
     }
 
@@ -1973,7 +1973,7 @@ NULL
         if (cg == NULL) {
             addReplyErrorFormat(c, "-NOGROUP No such consumer group '%s' "
                                    "for key name '%s'",
-                                   c->argv[3]->ptr, key->ptr);
+                                   (char *)c->argv[3]->ptr,(char *)key->ptr);
             return;
         }
 


### PR DESCRIPTION
With default options gcc will complain about cascading case
switch statements, annotate these to indicate this is being
used intentionally in hyperloglog.c and siphash.c

The recent streams code has some cases where void pointers
are passed under "%s" to printf-alike error handling code;
these can be safely cast to character pointers here.