### PR TITLE
fix: possible nullptr reference in sds.c

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -95,11 +95,11 @@ sds sdsnewlen(const void *init, size_t initlen) {
     unsigned char *fp; /* flags pointer. */
 
     sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
     if (init==SDS_NOINIT)
         init = NULL;
     else if (!init)
         memset(sh, 0, hdrlen+initlen+1);
-    if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
     switch(type) {

--- a/src/sds.c
+++ b/src/sds.c
@@ -684,9 +684,6 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
 /* Remove the part of the string from left and from right composed just of
  * contiguous characters found in 'cset', that is a null terminted C string.
  *
- * After the call, the modified sds string is no longer valid and all the
- * references must be substituted with the new pointer returned by the call.
- *
  * Example:
  *
  * s = sdsnew("AA...AA.a.aa.aHelloWorld     :::");
@@ -695,7 +692,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
  *
  * Output will be just "Hello World".
  */
-sds sdstrim(sds s, const char *cset) {
+sds sdstrim(sds const s, const char *cset) {
     char *start, *end, *sp, *ep;
     size_t len;
 

--- a/src/sds.c
+++ b/src/sds.c
@@ -692,7 +692,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
  *
  * Output will be just "Hello World".
  */
-sds sdstrim(sds const s, const char *cset) {
+sds sdstrim(sds s, const char *cset) {
     char *start, *end, *sp, *ep;
     size_t len;
 


### PR DESCRIPTION
1. In `sdsNewLen`, it looks like the `sh` check is invalid because before `if (sh == NULL) return NULL;` execute, `memset(sh, 0, hdrlen+initlen+1);` might be executed, I fixed this problem by modifying their order.

2. In `sdstrim`, there is not any instruction will change `sds s`, I think `s` in `sdstrim` won't be changed.