### PR TITLE
Modules: rewrite loadmodule and extend LIST reply

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -19,6 +19,7 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/fork \
 --single unit/moduleapi/testrdb \
 --single unit/moduleapi/infotest \
+--single unit/moduleapi/infra \
 --single unit/moduleapi/propagate \
 --single unit/moduleapi/hooks \
 --single unit/moduleapi/misc \

--- a/src/module.c
+++ b/src/module.c
@@ -8476,6 +8476,13 @@ void moduleLoadFromQueue(void) {
                 loadmod->path);
             exit(1);
         }
+        sdsfree(loadmod->path);
+        for (int i = 0; i < loadmod->argc; i++) {
+            decrRefCount(loadmod->argv[i]);
+        }
+        zfree(loadmod->argv);
+        zfree(loadmod);
+        listDelNode(server.loadmodule_queue, ln);
     }
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -8652,11 +8652,19 @@ void addReplyLoadedModules(client *c) {
     while ((de = dictNext(di)) != NULL) {
         sds name = dictGetKey(de);
         struct RedisModule *module = dictGetVal(de);
-        addReplyMapLen(c,2);
+        sds path = module->loadmod->path;
+        addReplyMapLen(c,4);
         addReplyBulkCString(c,"name");
         addReplyBulkCBuffer(c,name,sdslen(name));
         addReplyBulkCString(c,"ver");
         addReplyLongLong(c,module->ver);
+        addReplyBulkCString(c,"path");
+        addReplyBulkCBuffer(c,path,sdslen(path));
+        addReplyBulkCString(c,"args");
+        addReplyArrayLen(c,module->loadmod->argc);
+        for (int i = 0; i < module->loadmod->argc; i++) {
+            addReplyBulk(c,module->loadmod->argv[i]);
+        }
     }
     dictReleaseIterator(di);
 }

--- a/tests/unit/moduleapi/infra.tcl
+++ b/tests/unit/moduleapi/infra.tcl
@@ -1,0 +1,22 @@
+set testmodule [file normalize tests/modules/infotest.so]
+
+test {modules config rewrite} {
+
+    start_server {tags {"modules"}} {
+        r module load $testmodule
+
+        assert_equal [lindex [lindex [r module list] 0] 1] infotest
+
+        r config rewrite
+        restart_server 0 true false
+
+        assert_equal [lindex [lindex [r module list] 0] 1] infotest
+
+        r module unload infotest
+
+        r config rewrite
+        restart_server 0 true false
+
+        assert_equal [llength [r module list]] 0
+    }
+} 


### PR DESCRIPTION
This PR contains three changes:
1. CONFIG REWRITE command will rewrite modules as `loadmodule` options into config file, in case someone uses MODULE LOAD or UNLOAD commands in runtime.
2. free elements in `server.loadmodule_queue` after module loaded from config file or UNLOAD to save memory.
3. show `path` and `args` in MODULE LIST reply.