### PR TITLE
RDB: expand dict if needed when rdb load object

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1427,6 +1427,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb) {
         o = createZsetObject();
         zs = o->ptr;
 
+        if (zsetlen > DICT_HT_INITIAL_SIZE)
+            dictExpand(zs->dict,zsetlen);
+
         /* Load every single element of the sorted set. */
         while(zsetlen--) {
             sds sdsele;
@@ -1494,6 +1497,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb) {
             sdsfree(field);
             sdsfree(value);
         }
+
+        if (o->encoding == OBJ_ENCODING_HT && len > DICT_HT_INITIAL_SIZE)
+            dictExpand(o->ptr,len);
 
         /* Load remaining fields and values into the hash table */
         while (o->encoding == OBJ_ENCODING_HT && len > 0) {


### PR DESCRIPTION
Hi @antirez , maybe we forgot `dictExpand()` when loading `hash` and `zset` just like what `set` does. 

And this can halve the loading time on an `hash` or `zset` object with 5 millions elements:


Loding time without `dictExpand` is `8.375 seconds`:
```
5116:M 22 Apr 22:08:01.534 # Server initialized
5116:M 22 Apr 22:08:09.909 * DB loaded from disk: 8.375 seconds
5116:M 22 Apr 22:08:09.909 * Ready to accept connections
```

Loding time with `dictExpand` is `4.676 seconds`:
```
23014:M 22 Apr 22:27:04.732 # Server initialized
23014:M 22 Apr 22:27:09.409 * DB loaded from disk: 4.676 seconds
23014:M 22 Apr 22:27:09.409 * Ready to accept connections
```