### PR TITLE
be consistent with strcasecmp and add a newline in redis-cli.c

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -449,7 +449,7 @@ static void cliOutputHelp(int argc, char **argv) {
     } else if (argc > 0 && argv[0][0] == '@') {
         len = sizeof(commandGroups)/sizeof(char*);
         for (i = 0; i < len; i++) {
-            if (strcasecmp(argv[0]+1,commandGroups[i]) == 0) {
+            if (!strcasecmp(argv[0]+1,commandGroups[i])) {
                 group = i;
                 break;
             }
@@ -466,7 +466,7 @@ static void cliOutputHelp(int argc, char **argv) {
             /* Compare all arguments */
             if (argc == entry->argc) {
                 for (j = 0; j < argc; j++) {
-                    if (strcasecmp(argv[j],entry->argv[j]) != 0) break;
+                    if (strcasecmp(argv[j],entry->argv[j])) break;
                 }
                 if (j == argc) {
                     cliOutputCommandHelp(help,1);
@@ -527,7 +527,7 @@ static char *hintsCallback(const char *buf, int *color, int *bold) {
     for (i = 0; i < helpEntriesLen; i++) {
         if (!(helpEntries[i].type & CLI_HELP_COMMAND)) continue;
 
-        if (strcasecmp(argv[0],helpEntries[i].full) == 0)
+        if (!strcasecmp(argv[0],helpEntries[i].full))
         {
             *color = 90;
             *bold = 0;
@@ -1406,20 +1406,20 @@ static void repl(void) {
                 linenoiseFree(line);
                 continue;
             } else if (argc > 0) {
-                if (strcasecmp(argv[0],"quit") == 0 ||
-                    strcasecmp(argv[0],"exit") == 0)
+                if (!strcasecmp(argv[0],"quit") ||
+                    !strcasecmp(argv[0],"exit"))
                 {
                     exit(0);
                 } else if (argv[0][0] == ':') {
                     cliSetPreferences(argv,argc,1);
                     continue;
-                } else if (strcasecmp(argv[0],"restart") == 0) {
+                } else if (!strcasecmp(argv[0],"restart")) {
                     if (config.eval) {
                         config.eval_ldb = 1;
                         config.output = OUTPUT_RAW;
                         return; /* Return to evalMode to restart the session. */
                     } else {
-                        printf("Use 'restart' only in Lua debugging mode.");
+                        printf("Use 'restart' only in Lua debugging mode.\n");
                     }
                 } else if (argc == 3 && !strcasecmp(argv[0],"connect")) {
                     sdsfree(config.hostip);


### PR DESCRIPTION
While reading through some code I just noticed that generally it seems the preferred use of `strcasecmp` is to simply use the return value from the call in a conditional, but in some cases the result would then be explicitly compared to 0, which seemed superfluous so I thought I'd put up a refactor.

Also when testing my changes there just found that a missing newline on line 1422 would cause the buffered output to not get flushed:
```
127.0.0.1:6379> restart
127.0.0.1:6379> Use 'restart' only in Lua debugging mode.
127.0.0.1:6379> 
```
Adding it seemed to fix that and seems more consistent with how other output is formatted.
```
127.0.0.1:6379> restart
Use 'restart' only in Lua debugging mode.
127.0.0.1:6379> 
```
Hope these tiny refactors are helpful and not just white noise among real patches 😀 .