### PR TITLE
Remove unimplemented prototype acceptHandler

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1383,7 +1383,6 @@ void sendReplyToClient(aeEventLoop *el, int fd, void *privdata, int mask);
 void *addDeferredMultiBulkLength(client *c);
 void setDeferredMultiBulkLength(client *c, void *node, long length);
 void processInputBuffer(client *c);
-void acceptHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void acceptTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void acceptUnixHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void readQueryFromClient(aeEventLoop *el, int fd, void *privdata, int mask);


### PR DESCRIPTION
Stumbled upon it while learning the codebase.
For validation, built Redis with the change and `make test` was happy. 