### PR TITLE
Use absolute path for 'logfile' when loading

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -271,7 +271,7 @@ void loadServerConfigFromString(char *config) {
             FILE *logfp;
 
             zfree(server.logfile);
-            server.logfile = zstrdup(argv[1]);
+            server.logfile = getAbsolutePath(argv[1]);
             if (server.logfile[0] != '\0') {
                 /* Test if we are able to open the file. The server will not
                  * be able to abort just for this problem later... */

--- a/src/db.c
+++ b/src/db.c
@@ -90,7 +90,7 @@ robj *lookupKey(redisDb *db, robj *key, int flags) {
  *  LOOKUP_NONE (or zero): no special flags are passed.
  *  LOOKUP_NOTOUCH: don't alter the last access time of the key.
  *
- * Note: this function also returns NULL is the key is logically expired
+ * Note: this function also returns NULL if the key is logically expired
  * but still existing, in case this is a slave, since this API is called only
  * for read operations. Even if the key expiry is master-driven, we can
  * correctly report a key is expired on slaves even if the master is lagging


### PR DESCRIPTION
If the 'logfile' is a relative path, when loading 'dir', the chdir changes the working directory to the new path. And it is possibly different from the path specified by ‘logfile’.