### PR TITLE
Implements [B]Z[REV]POP and the respective unit tests

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -169,7 +169,9 @@ void dbAdd(redisDb *db, robj *key, robj *val) {
     int retval = dictAdd(db->dict, copy, val);
 
     serverAssertWithInfo(NULL,key,retval == DICT_OK);
-    if (val->type == OBJ_LIST) signalKeyAsReady(db, key);
+    if (val->type == OBJ_LIST ||
+        val->type == OBJ_ZSET)
+        signalKeyAsReady(db, key);
     if (server.cluster_enabled) slotToKeyAdd(key);
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -198,6 +198,10 @@ struct redisCommand redisCommandTable[] = {
     {"zrank",zrankCommand,3,"rF",0,NULL,1,1,1,0,0},
     {"zrevrank",zrevrankCommand,3,"rF",0,NULL,1,1,1,0,0},
     {"zscan",zscanCommand,-3,"rR",0,NULL,1,1,1,0,0},
+    {"zpop",zpopCommand,-2,"wF",0,NULL,1,-1,1,0,0},
+    {"zrevpop",zrevpopCommand,-2,"wF",0,NULL,1,-1,1,0,0},
+    {"bzpop",bzpopCommand,-2,"wsF",0,NULL,1,-2,1,0,0},
+    {"bzrevpop",bzrevpopCommand,-2,"wsF",0,NULL,1,-2,1,0,0},
     {"hset",hsetCommand,-4,"wmF",0,NULL,1,1,1,0,0},
     {"hsetnx",hsetnxCommand,4,"wmF",0,NULL,1,1,1,0,0},
     {"hget",hgetCommand,3,"rF",0,NULL,1,1,1,0,0},
@@ -1369,6 +1373,8 @@ void createSharedObjects(void) {
     shared.rpop = createStringObject("RPOP",4);
     shared.lpop = createStringObject("LPOP",4);
     shared.lpush = createStringObject("LPUSH",5);
+    shared.zpop = createStringObject("ZPOP",4);
+    shared.zrevpop = createStringObject("ZREVPOP",7);
     for (j = 0; j < OBJ_SHARED_INTEGERS; j++) {
         shared.integers[j] =
             makeObjectShared(createObject(OBJ_STRING,(void*)(long)j));
@@ -1562,6 +1568,8 @@ void initServerConfig(void) {
     server.lpushCommand = lookupCommandByCString("lpush");
     server.lpopCommand = lookupCommandByCString("lpop");
     server.rpopCommand = lookupCommandByCString("rpop");
+    server.zpopCommand = lookupCommandByCString("zpop");
+    server.zrevpopCommand = lookupCommandByCString("zrevpop");
     server.sremCommand = lookupCommandByCString("srem");
     server.execCommand = lookupCommandByCString("exec");
     server.expireCommand = lookupCommandByCString("expire");

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -648,6 +648,79 @@ start_server {tags {"zset"}} {
                 }
             }
         }
+
+        test "Basic Z\[REV\]POP with a single key - $encoding" {
+            r del zset
+            assert_equal {} [r zpop zset]
+            create_zset zset {-1 a 1 b 2 c 3 d 4 e}
+            assert_equal {zset -1 a} [r zpop zset]
+            assert_equal {zset 1 b} [r zpop zset]
+            assert_equal {zset 4 e} [r zrevpop zset]
+            assert_equal {zset 3 d} [r zrevpop zset]
+            assert_equal {zset 2 c} [r zpop zset]
+            assert_equal 0 [r exists zset]
+            r set foo bar
+            assert_error "*WRONGTYPE*" {r zpop foo}
+        }
+
+        test "Z\[REV\]POP with multiple keys - $encoding" {
+            r del z1 z2 z3 foo
+            r set foo bar
+            assert_equal {} [r zpop z1 z2 z3]
+            assert_error "*WRONGTYPE*" {r zpop z1 foo}
+            create_zset z1 {0 a 1 b 2 c}
+            assert_equal {z1 0 a} [r zpop z1 z2 z3]
+            assert_equal {z1 1 b} [r zpop z3 z2 z1]
+            create_zset z3 {0 a 1 b 2 c}
+            assert_equal {z3 2 c} [r zrevpop z3 z2 z1]
+            assert_equal 1 [r exists z1]
+            assert_equal 1 [r exists z3]
+        }
+
+        test "BZ\[REV\]POP with a single existing sorted set - $encoding" {
+            set rd [redis_deferring_client]
+            create_zset zset {0 a 1 b 2 c}
+
+            $rd bzpop zset 5
+            assert_equal {zset 0 a} [$rd read]
+            $rd bzpop zset 5
+            assert_equal {zset 1 b} [$rd read]
+            $rd bzrevpop zset 5
+            assert_equal {zset 2 c} [$rd read]
+            assert_equal 0 [r exists zset]
+        }
+
+        test "BZ\[REV\]POP with multiple existing sorted sets - $encoding" {
+            set rd [redis_deferring_client]
+            create_zset z1 {0 a 1 b 2 c}
+            create_zset z2 {3 d 4 e 5 f}
+
+            $rd bzpop z1 z2 5
+            assert_equal {z1 0 a} [$rd read]
+            $rd bzrevpop z1 z2 5
+            assert_equal {z1 2 c} [$rd read]
+            assert_equal 1 [r zcard z1]
+            assert_equal 3 [r zcard z2]
+
+            $rd bzrevpop z2 z1 5
+            assert_equal {z2 5 f} [$rd read]
+            $rd bzpop z2 z1 5
+            assert_equal {z2 3 d} [$rd read]
+            assert_equal 1 [r zcard z1]
+            assert_equal 1 [r zcard z2]
+        }
+
+        test "BZ\[REV\]POP second sorted set has members - $encoding" {
+            set rd [redis_deferring_client]
+            r del z1
+            create_zset z2 {3 d 4 e 5 f}
+            $rd bzrevpop z1 z2 5
+            assert_equal {z2 5 f} [$rd read]
+            $rd bzpop z2 z1 5
+            assert_equal {z2 3 d} [$rd read]
+            assert_equal 0 [r zcard z1]
+            assert_equal 1 [r zcard z2]
+        }
     }
 
     basics ziplist
@@ -1024,6 +1097,91 @@ start_server {tags {"zset"}} {
                 }
             }
             assert_equal {} $err
+        }
+
+        test "BZPOP, ZADD + DEL should not awake blocked client" {
+            set rd [redis_deferring_client]
+            r del zset
+
+            $rd bzpop zset 0
+            r multi
+            r zadd zset 0 foo
+            r del zset
+            r exec
+            r del zset
+            r zadd zset 1 bar
+            $rd read
+        } {zset 1 bar}
+
+        test "BZPOP, ZADD + DEL + SET should not awake blocked client" {
+            set rd [redis_deferring_client]
+            r del list
+
+            r del zset
+
+            $rd bzpop zset 0
+            r multi
+            r zadd zset 0 foo
+            r del zset
+            r set zset foo
+            r exec
+            r del zset
+            r zadd zset 1 bar
+            $rd read
+        } {zset 1 bar}
+
+        test "BZPOP with same key multiple times should work" {
+            set rd [redis_deferring_client]
+            r del z1 z2
+
+            # Data arriving after the BZPOP.
+            $rd bzpop z1 z2 z2 z1 0
+            r zadd z1 0 a
+            assert_equal [$rd read] {z1 0 a}
+            $rd bzpop z1 z2 z2 z1 0
+            r zadd z2 1 b
+            assert_equal [$rd read] {z2 1 b}
+
+            # Data already there.
+            r zadd z1 0 a
+            r zadd z2 1 b
+            $rd bzpop z1 z2 z2 z1 0
+            assert_equal [$rd read] {z1 0 a}
+            $rd bzpop z1 z2 z2 z1 0
+            assert_equal [$rd read] {z2 1 b}
+        }
+
+        test "MULTI/EXEC is isolated from the point of view of BZPOP" {
+            set rd [redis_deferring_client]
+            r del zset
+            $rd bzpop zset 0
+            r multi
+            r zadd zset 0 a
+            r zadd zset 1 b
+            r zadd zset 2 c
+            r exec
+            $rd read
+        } {zset 0 a}
+
+        test "BZPOP with variadic ZADD" {
+            set rd [redis_deferring_client]
+            r del zset
+            if {$::valgrind} {after 100}
+            $rd bzpop zset 0
+            if {$::valgrind} {after 100}
+            assert_equal 2 [r zadd zset -1 foo 1 bar]
+            if {$::valgrind} {after 100}
+            assert_equal {zset -1 foo} [$rd read]
+            assert_equal {bar} [r zrange zset 0 -1]
+        }
+
+        test "BZPOP with zero timeout should block indefinitely" {
+            set rd [redis_deferring_client]
+            r del zset
+            $rd bzpop zset 0
+            after 1000
+            r zadd zset 0 foo
+            assert_equal {zset 0 foo} [$rd read]
         }
     }
 


### PR DESCRIPTION
An implementation of the
[Ze POP Redis Module](https://github.com/itamarhaber/zpop) as core
Redis commands.

Resolves #1861.

@antirez per our RedisConf discussion. Does it make sense IYO to put
effort into designing the zset equivalent of `BRPOPLPUSH`?