### PR TITLE
server.c typo: modules system dictionary type comment

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -680,8 +680,8 @@ dictType clusterNodesBlackListDictType = {
     NULL                        /* val destructor */
 };
 
-/* Modules system dictionary type. Keys are prefixed function
- * name, values are function pointer. */
+/* Modules system dictionary type. Keys are module name,
+ * values are pointer to RedisModule struct. */
 dictType modulesDictType = {
     dictSdsCaseHash,            /* hash function */
     NULL,                       /* key dup */

--- a/src/server.c
+++ b/src/server.c
@@ -680,9 +680,8 @@ dictType clusterNodesBlackListDictType = {
     NULL                        /* val destructor */
 };
 
-/* Cluster re-addition blacklist. This maps node IDs to the time
- * we can re-add this node. The goal is to avoid readding a removed
- * node for some time. */
+/* Modules system dictionary type. Keys are prefixed function
+ * name, values are function pointer. */
 dictType modulesDictType = {
     dictSdsCaseHash,            /* hash function */
     NULL,                       /* key dup */


### PR DESCRIPTION
I found struct ```modulesDictType```'s comment just copy from struct ```clusterNodesBlackListDictType``` in **server.c.**

Signed-off-by: charpty <charpty@gmail.com>