### PR TITLE
AOF & script: we should flush aof before reply to client when lua timedout

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2023,6 +2023,7 @@ int processEventsWhileBlocked(void) {
     int count = 0;
     while (iterations--) {
         int events = 0;
+        if (!server.loading && server.aof_fsync == AOF_FSYNC_ALWAYS) flushAppendOnlyFile(0);
         events += aeProcessEvents(server.el, AE_FILE_EVENTS|AE_DONT_WAIT);
         events += handleClientsWithPendingWrites();
         if (!events) break;


### PR DESCRIPTION
Hi, @antirez 

To guarantee the concept of `AOF_FSYNC_ALWAYS` we add a flag `AE_BARRIER`, but there is still a scenario which may break the concept.

That is when we reach `lua_timedout` we will call `processEventsWhileBlocked`, but this function reply to client without `flushAppendOnlyFile` (events in the same eventloop with `eval` command).

Should we `flushAppendonlyFile` in the `lua_timedout` condition?