### PR TITLE
SDS: Possible segfault in sdsnewlen

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -95,11 +95,11 @@ sds sdsnewlen(const void *init, size_t initlen) {
     unsigned char *fp; /* flags pointer. */
 
     sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
     if (init==SDS_NOINIT)
         init = NULL;
     else if (!init)
         memset(sh, 0, hdrlen+initlen+1);
-    if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
     switch(type) {


### PR DESCRIPTION
The new sh should be checked right after it is malloced.
Or if it is set to NULL, and init pointer is not set, the memset call will
cause segment fault.

Change-Id: I50f883d3061462e75174aca560eac300513f5245
Signed-off-by: Jun He <jun.he@arm.com>