### PR TITLE
Save global file pointer for log file instead of opening it every time.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -281,7 +281,9 @@ void loadServerConfigFromString(char *config) {
                         "Can't open the log file: %s", strerror(errno));
                     goto loaderr;
                 }
-                fclose(logfp);
+                server.logfp = logfp;
+            } else {
+                server.logfp = stdout;
             }
         } else if (!strcasecmp(argv[0],"always-show-logo") && argc == 2) {
             if ((server.always_show_logo = yesnotoi(argv[1])) == -1) {

--- a/src/server.c
+++ b/src/server.c
@@ -1428,6 +1428,7 @@ void initServerConfig(void) {
     server.saveparams = NULL;
     server.loading = 0;
     server.logfile = zstrdup(CONFIG_DEFAULT_LOGFILE);
+    server.logfp = stdout;
     server.syslog_enabled = CONFIG_DEFAULT_SYSLOG_ENABLED;
     server.syslog_ident = zstrdup(CONFIG_DEFAULT_SYSLOG_IDENT);
     server.syslog_facility = LOG_LOCAL0;

--- a/src/server.h
+++ b/src/server.h
@@ -1085,6 +1085,7 @@ struct redisServer {
     redisOpArray also_propagate;    /* Additional command to propagate. */
     /* Logging */
     char *logfile;                  /* Path of log file */
+    FILE *logfp;                    /* File pointer of log file */
     int syslog_enabled;             /* Is syslog enabled? */
     char *syslog_ident;             /* Syslog ident */
     int syslog_facility;            /* Syslog facility */


### PR DESCRIPTION
1. It's a bit more efficient.
2. If multi threads fopen the same log file every time in serverLogRaw() and use separate file pointers,  the writes of deferent threads may end up interleaved, because each of the threads uses its own lock in FILE object. But with only one FILE object, whole fprintf calls on that FILE will be atomic.