### PR TITLE
script: do not accept script flush/load on slave

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2502,11 +2502,14 @@ int processCommand(client *c) {
         return C_OK;
     }
 
-    /* Don't accept write commands if this is a read only slave. But
-     * accept write commands if this is our master. */
+    /* Don't accept write commands and script flush/load if this is a read only slave.
+     * But accept write commands and script flush/load if this is our master. */
     if (server.masterhost && server.repl_slave_ro &&
         !(c->flags & CLIENT_MASTER) &&
-        c->cmd->flags & CMD_WRITE)
+        (c->cmd->flags & CMD_WRITE ||
+         (c->cmd->proc == scriptCommand &&
+          ((c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"flush")) ||
+           (c->argc == 3 && !strcasecmp(c->argv[1]->ptr,"load"))))))
     {
         addReply(c, shared.roslaveerr);
         return C_OK;


### PR DESCRIPTION
If slave accepts `script flush` from a normal client, that may lead to inconsistency between master and slave:

![script](https://user-images.githubusercontent.com/24804835/39794809-d1769d86-537e-11e8-822a-0a70522bf5b2.png)


BTW, let slave contains more scripts than master is not a good idea I think, that may lead to OOM. Slave should not accept `script load` from a normal client.
