### PR TITLE
linenoise: accept both of ASCII CR and LF as line delimiters.

### DIFF
--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -160,14 +160,15 @@ enum KEY_ACTION{
 	CTRL_F = 6,         /* Ctrl-f */
 	CTRL_H = 8,         /* Ctrl-h */
 	TAB = 9,            /* Tab */
-	CTRL_K = 11,        /* Ctrl+k */
-	CTRL_L = 12,        /* Ctrl+l */
-	ENTER = 13,         /* Enter */
+	CTRL_J = 10,        /* Ctrl-j (\n) */
+	CTRL_K = 11,        /* Ctrl-k */
+	CTRL_L = 12,        /* Ctrl-l */
+	CTRL_M = 13,        /* Enter (\r) */
 	CTRL_N = 14,        /* Ctrl-n */
 	CTRL_P = 16,        /* Ctrl-p */
 	CTRL_T = 20,        /* Ctrl-t */
-	CTRL_U = 21,        /* Ctrl+u */
-	CTRL_W = 23,        /* Ctrl+w */
+	CTRL_U = 21,        /* Ctrl-u */
+	CTRL_W = 23,        /* Ctrl-w */
 	ESC = 27,           /* Escape */
 	BACKSPACE =  127    /* Backspace */
 };
@@ -812,7 +813,8 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
         }
 
         switch(c) {
-        case ENTER:    /* enter */
+	case CTRL_J:	/* line feed */
+        case CTRL_M:    /* enter, carriage return */
             history_len--;
             free(history[history_len]);
             if (mlmode) linenoiseEditMoveEnd(&l);


### PR DESCRIPTION
* Ctrl-J (\n) is now accepted as new line delimiter. This is in alignment with most cli-based input mechanisms.
* Some cosmetic changes to comments.