### PR TITLE
bugfix for ZPOP: fix the wrong keyc, should be 1

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3080,8 +3080,8 @@ void zscanCommand(client *c) {
  * use the 'count' argument to return multiple items if available. */
 void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey, robj *countarg) {
     int idx;
-    robj *key;
-    robj *zobj;
+    robj *key = NULL;
+    robj *zobj = NULL;
     sds ele;
     double score;
     long count = 1;
@@ -3185,7 +3185,7 @@ void zpopminCommand(client *c) {
         addReply(c,shared.syntaxerr);
         return;
     }
-    genericZpopCommand(c,&c->argv[1],c->argc-1,ZSET_MIN,0,
+    genericZpopCommand(c,&c->argv[1],1,ZSET_MIN,0,
         c->argc == 3 ? c->argv[2] : NULL);
 }
 
@@ -3195,7 +3195,7 @@ void zpopmaxCommand(client *c) {
         addReply(c,shared.syntaxerr);
         return;
     }
-    genericZpopCommand(c,&c->argv[1],c->argc-1,ZSET_MAX,0,
+    genericZpopCommand(c,&c->argv[1],1,ZSET_MAX,0,
         c->argc == 3 ? c->argv[2] : NULL);
 }
 


### PR DESCRIPTION
Hi, @antirez 

From the format of zpop:
```c
/* ZPOPMIN key [<count>] */
/* ZMAXPOP key [<count>] */
```
We can only pop one single key, right?

But, we send a wrong number to function `genericZpopCommand`, that may result in wrong pop:

```
127.0.0.1:6379> zadd 10 1 a 2 b 3 c
(integer) 3
127.0.0.1:6379> zpopmin x 1
(empty list or set)
127.0.0.1:6379> zpopmin x 10
1) "1"
2) "a"
3) "2"
4) "b"
5) "3"
6) "c"
```

I think the `keyc` should always be 1.