### PR TITLE
Support password rotation: allow Redis to accept an alternative password

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -501,6 +501,15 @@ slave-priority 100
 #
 # requirepass foobared
 
+# Allow Redis to accept an alternative password. It is effective only when
+# requirepass is set.
+#
+# This can be used to achieve password rotation with no downtime in production:
+# Set requirepass-alt to the current password, requirepass to a new password.
+# Ask all clients to switch to the new password, then remove requirepass-alt.
+#
+# requirepass-alt foobared2
+
 # Command renaming.
 #
 # It is possible to change the name of dangerous commands in a shared

--- a/src/config.c
+++ b/src/config.c
@@ -497,6 +497,12 @@ void loadServerConfigFromString(char *config) {
                 goto loaderr;
             }
             server.requirepass = zstrdup(argv[1]);
+        } else if (!strcasecmp(argv[0],"requirepass-alt") && argc == 2) {
+            if (strlen(argv[1]) > CONFIG_AUTHPASS_MAX_LEN) {
+                err = "Password is longer than CONFIG_AUTHPASS_MAX_LEN";
+                goto loaderr;
+            }
+            server.requirepass_alt = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"pidfile") && argc == 2) {
             zfree(server.pidfile);
             server.pidfile = zstrdup(argv[1]);
@@ -862,6 +868,10 @@ void configSetCommand(client *c) {
         if (sdslen(o->ptr) > CONFIG_AUTHPASS_MAX_LEN) goto badfmt;
         zfree(server.requirepass);
         server.requirepass = ((char*)o->ptr)[0] ? zstrdup(o->ptr) : NULL;
+    } config_set_special_field("requirepass-alt") {
+        if (sdslen(o->ptr) > CONFIG_AUTHPASS_MAX_LEN) goto badfmt;
+        zfree(server.requirepass_alt);
+        server.requirepass_alt = ((char*)o->ptr)[0] ? zstrdup(o->ptr) : NULL;
     } config_set_special_field("masterauth") {
         zfree(server.masterauth);
         server.masterauth = ((char*)o->ptr)[0] ? zstrdup(o->ptr) : NULL;
@@ -1238,6 +1248,7 @@ void configGetCommand(client *c) {
     /* String values */
     config_get_string_field("dbfilename",server.rdb_filename);
     config_get_string_field("requirepass",server.requirepass);
+    config_get_string_field("requirepass-alt",server.requirepass_alt);
     config_get_string_field("masterauth",server.masterauth);
     config_get_string_field("cluster-announce-ip",server.cluster_announce_ip);
     config_get_string_field("unixsocket",server.unixsocket);
@@ -2022,6 +2033,7 @@ int rewriteConfig(char *path) {
     rewriteConfigNumericalOption(state,"min-slaves-to-write",server.repl_min_slaves_to_write,CONFIG_DEFAULT_MIN_SLAVES_TO_WRITE);
     rewriteConfigNumericalOption(state,"min-slaves-max-lag",server.repl_min_slaves_max_lag,CONFIG_DEFAULT_MIN_SLAVES_MAX_LAG);
     rewriteConfigStringOption(state,"requirepass",server.requirepass,NULL);
+    rewriteConfigStringOption(state,"requirepass-alt",server.requirepass_alt,NULL);
     rewriteConfigNumericalOption(state,"maxclients",server.maxclients,CONFIG_DEFAULT_MAX_CLIENTS);
     rewriteConfigBytesOption(state,"maxmemory",server.maxmemory,CONFIG_DEFAULT_MAXMEMORY);
     rewriteConfigBytesOption(state,"proto-max-bulk-len",server.proto_max_bulk_len,CONFIG_DEFAULT_PROTO_MAX_BULK_LEN);

--- a/src/server.c
+++ b/src/server.c
@@ -1462,6 +1462,7 @@ void initServerConfig(void) {
     server.rdb_filename = zstrdup(CONFIG_DEFAULT_RDB_FILENAME);
     server.aof_filename = zstrdup(CONFIG_DEFAULT_AOF_FILENAME);
     server.requirepass = NULL;
+    server.requirepass_alt = NULL;
     server.rdb_compression = CONFIG_DEFAULT_RDB_COMPRESSION;
     server.rdb_checksum = CONFIG_DEFAULT_RDB_CHECKSUM;
     server.stop_writes_on_bgsave_err = CONFIG_DEFAULT_STOP_WRITES_ON_BGSAVE_ERROR;
@@ -2719,7 +2720,9 @@ int time_independent_strcmp(char *a, char *b) {
 void authCommand(client *c) {
     if (!server.requirepass) {
         addReplyError(c,"Client sent AUTH, but no password is set");
-    } else if (!time_independent_strcmp(c->argv[1]->ptr, server.requirepass)) {
+    } else if (!time_independent_strcmp(c->argv[1]->ptr, server.requirepass) ||
+               /* If client is using alternative password. */
+               (server.requirepass_alt && !time_independent_strcmp(c->argv[1]->ptr, server.requirepass_alt))) {
       c->authenticated = 1;
       addReply(c,shared.ok);
     } else {

--- a/src/server.h
+++ b/src/server.h
@@ -919,6 +919,7 @@ struct redisServer {
     int activerehashing;        /* Incremental rehash in serverCron() */
     int active_defrag_running;  /* Active defragmentation running (holds current scan aggressiveness) */
     char *requirepass;          /* Pass for AUTH command, or NULL */
+    char *requirepass_alt;      /* Alternative password for AUTH command, or NULL */
     char *pidfile;              /* PID file path */
     int arch_bits;              /* 32 or 64 depending on sizeof(long) */
     int cronloops;              /* Number of times the cron function run */

--- a/src/server.h
+++ b/src/server.h
@@ -998,6 +998,8 @@ struct redisServer {
     long long stat_net_output_bytes; /* Bytes written to network. */
     size_t stat_rdb_cow_bytes;      /* Copy on write bytes during RDB saving. */
     size_t stat_aof_cow_bytes;      /* Copy on write bytes during AOF rewrite. */
+    long long stat_password_matches;      /* Number of password matches */
+    long long stat_alt_password_matches;  /* Number of alternative password matches */
     /* The following two are used to track instantaneous metrics, like
      * number of operations per second, network traffic. */
     struct {

--- a/tests/unit/auth.tcl
+++ b/tests/unit/auth.tcl
@@ -25,3 +25,30 @@ start_server {tags {"auth"} overrides {requirepass foobar}} {
         r incr foo
     } {101}
 }
+
+start_server {tags {"auth"} overrides {requirepass foo requirepass-alt bar}} {
+    test {AUTH fails when a wrong password is given} {
+        catch {r auth wrong!} err
+        set _ $err
+    } {ERR*invalid password}
+
+    test {Arbitrary command gives an error when AUTH is required} {
+        catch {r set foo bar} err
+        set _ $err
+    } {NOAUTH*}
+
+    test {AUTH succeeds when the right password is given} {
+        r auth foo
+    } {OK}
+
+    test {AUTH succeeds when the right alternative password is given} {
+        r auth bar
+    } {OK}
+}
+
+start_server {tags {"auth"} overrides {requirepass-alt foobar}} {
+    test {Alternative password is not effective if requirepass is not set} {
+        catch {r auth foobar} err
+        set _ $err
+    } {ERR*no password*}
+}


### PR DESCRIPTION
Reference: #4942 

Introduces a `requirepass-alt` option, in order to achieve password rotation with no downtime. Here's our solution:

1. Set `requirepass-alt <old-password>`, and `requirepass <new-password>`
2. Notify all users to switch to the new password
3. Confirm that old password is not used, then remove `requirepass-alt`

To help server admin check if all clients do start to use the new password, we count the number of requirepass/requirepass-alt matches, and show it in the INFO STATS section.