### PR TITLE
append -lrt to FINAL_LIBS for linux

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -100,7 +100,7 @@ ifeq ($(uname_S),FreeBSD)
 else
 	# All the other OSes (notably Linux)
 	FINAL_LDFLAGS+= -rdynamic
-	FINAL_LIBS+=-ldl -pthread
+	FINAL_LIBS+=-ldl -pthread -lrt
 endif
 endif
 endif


### PR DESCRIPTION
Hi @antirez ,

It's really a big change that you upgrade jemalloc to 5.0.1, but unfortunately after the upgrade I met a link error:

 ```
../deps/jemalloc/lib/libjemalloc.a(nstime.o): In function `nstime_get':
/home/zhaozhao.zz/antirez/redis/deps/jemalloc/src/nstime.c:119: undefined reference to `clock_gettime'
collect2: ld returned 1 exit status
make: *** [redis-server] Error 1
```

I checked the function from man page:
```
NAME
       clock_getres, clock_gettime, clock_settime - clock and time functions

SYNOPSIS
       #include <time.h>

       int clock_getres(clockid_t clk_id, struct timespec *res);

       int clock_gettime(clockid_t clk_id, struct timespec *tp);

       int clock_settime(clockid_t clk_id, const struct timespec *tp);

       Link with -lrt.

   Feature Test Macro Requirements for glibc (see feature_test_macros(7)):

       clock_getres(), clock_gettime(), clock_settime(): _POSIX_C_SOURCE >= 199309L
```

My os is linux 2.6.32. So, I think we should append `-lrt` to `FINAL_LIBS` for linux.

BTW, I guess your os is ubuntu and glibc is after 2.17, then you didn't met this problem:

![image](https://user-images.githubusercontent.com/24804835/40544088-a15cb1ac-6059-11e8-85cf-f8248070dc03.png)
 