### PR TITLE
fix rdb save by allowing dumping of expire keys

### DIFF
--- a/src/rdb.h
+++ b/src/rdb.h
@@ -142,7 +142,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o);
 size_t rdbSavedObjectLen(robj *o);
 robj *rdbLoadObject(int type, rio *rdb);
 void backgroundSaveDoneHandler(int exitcode, int bysignal);
-int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime, long long now);
+int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime);
 robj *rdbLoadStringObject(rio *rdb);
 ssize_t rdbSaveStringObject(rio *rdb, robj *obj);
 ssize_t rdbSaveRawString(rio *rdb, unsigned char *s, size_t len);


### PR DESCRIPTION
Before this commit, there's a chance that slaves will hold on the expired key, which may consume a lot of memory. Let's see how it happens.

Suppose there are 2 nodes in a partition, one is master A, the other is a slave of A, which is represented as B.
Suppose there are a lot of keys with expire time in master A, and many keys should expire in every moment.

Do the following steps:
**Step1** , a new node C comes in and replicates master A, which makes C a new slave of A. 
**Step2**, Slave C does failover, either by manual or not.

If Step2 does not happen, when a expire key actived, master A would delete the key itself and propagate a DEL to AOF(if appendonly is yes) , backlog and slaves. Then slaves B and C got the DEL command, and do it themselves.
However, when Step2 does happen, since rdb save filters out the expired keys, slave C will not have the expired keys, which could still be there in master A, which may be deleted later because of lazy delete., slave C will not have the chance to delete the expired keys, which were supposed to delete later. Slave B still has the expired keys, since slaves can only delete keys when they are asked by their master, and the expired keys will remain there forever since new master C do not have the expired keys.
@antirez 