### PR TITLE
fix data inconsistency when eviction happens on slave side

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -458,6 +458,10 @@ int freeMemoryIfNeeded(void) {
 
     mem_freed = 0;
 
+    /* Eviction can only happen on master, or it may cause inconsistency. */
+    if (server.masterhost)
+        goto cant_free;
+
     if (server.maxmemory_policy == MAXMEMORY_NO_EVICTION)
         goto cant_free; /* We need to free memory, but policy forbids. */
 


### PR DESCRIPTION
Both master and slave can trigger eviction when used memory
reaches maxmemory, which causes inconsistency. After introducing
PSYN2, used memory gap between master and slave has reduced as
slave now has backlog as master had.