### PR TITLE
[M] bug fix of redis-cli for cluster info command

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3090,6 +3090,7 @@ static int clusterManagerNodeLoadInfo(clusterManagerNode *node, int opts,
                 currentNode->flags |= CLUSTER_MANAGER_FLAG_SLAVE;
                 if (master_id == 0) {
                     if (currentNode->replicate) sdsfree(currentNode->replicate);
+                }else{
                     currentNode->replicate = sdsnew(master_id);
                 }
             }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3088,11 +3088,8 @@ static int clusterManagerNodeLoadInfo(clusterManagerNode *node, int opts,
                 currentNode->flags |= CLUSTER_MANAGER_FLAG_FAIL;
             else if (strcmp(flag, "slave") == 0) {
                 currentNode->flags |= CLUSTER_MANAGER_FLAG_SLAVE;
-                if (master_id == 0) {
-                    if (currentNode->replicate) sdsfree(currentNode->replicate);
-                }else{
-                    currentNode->replicate = sdsnew(master_id);
-                }
+                if (currentNode->replicate) sdsfree(currentNode->replicate);
+                currentNode->replicate = sdsnew(master_id);
             }
             listAddNodeTail(currentNode->flags_str, flag);
         }


### PR DESCRIPTION
old: 
localhost:7000 (65de430b...) -> 0 keys | 5461 slots | 0 slaves.
172.27.25.35:7002 (f62a9a8d...) -> 0 keys | 5461 slots | 0 slaves.
172.27.25.35:7001 (5f03bdc2...) -> 0 keys | 5462 slots | 0 slaves.


fixed:
localhost:7000 (65de430b...) -> 0 keys | 5461 slots | 1 slaves.
172.27.25.35:7002 (f62a9a8d...) -> 0 keys | 5461 slots | 1 slaves.
172.27.25.35:7001 (5f03bdc2...) -> 0 keys | 5462 slots | 1 slaves.
