### PR TITLE
bugfix of redis-cli for bigkeys param.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5832,8 +5832,12 @@ static void getKeyTypes(redisReply *keys, int *types) {
     unsigned int i;
 
     /* Pipeline TYPE commands */
+    static const char *type_buf[2] = {"TYPE", ""};
+    static size_t type_len[2] = {4, 0};
     for(i=0;i<keys->elements;i++) {
-        redisAppendCommand(context, "TYPE %s", keys->element[i]->str);
+        type_buf[1] = keys->element[i]->str;
+        type_len[1] = keys->element[i]->len;
+        redisAppendCommandArgv(context, 2, type_buf, type_len);
     }
 
     /* Retrieve types */
@@ -5866,13 +5870,18 @@ static void getKeySizes(redisReply *keys, int *types,
     unsigned int i;
 
     /* Pipeline size commands */
+    const char *type_buf[2];
+    size_t type_len[2];
     for(i=0;i<keys->elements;i++) {
         /* Skip keys that were deleted */
         if(types[i]==TYPE_NONE)
             continue;
 
-        redisAppendCommand(context, "%s %s", sizecmds[types[i]],
-            keys->element[i]->str);
+        type_buf[0] = sizecmds[types[i]];
+        type_buf[1] = keys->element[i]->str;
+        type_len[0] = strlen(type_buf[0]);
+        type_len[1] = keys->element[i]->len;
+        redisAppendCommandArgv(context, 2, type_buf, type_len);
     }
 
     /* Retreive sizes */
@@ -5968,13 +5977,16 @@ static void findBigKeys(void) {
             sampled++;
 
             if(biggest[type]<sizes[i]) {
+                /* Keep track of biggest key name for this type */
+                sdsclear(maxkeys[type]);
+                maxkeys[type] = sdscatrepr(maxkeys[type], keys->element[i]->str, keys->element[i]->len);
+                sdstrim(maxkeys[type], "\"");
+
                 printf(
                    "[%05.2f%%] Biggest %-6s found so far '%s' with %llu %s\n",
-                   pct, typename[type], keys->element[i]->str, sizes[i],
+                   pct, typename[type], maxkeys[type], sizes[i],
                    typeunit[type]);
 
-                /* Keep track of biggest key name for this type */
-                maxkeys[type] = sdscpy(maxkeys[type], keys->element[i]->str);
                 if(!maxkeys[type]) {
                     fprintf(stderr, "Failed to allocate memory for key!\n");
                     exit(1);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5980,7 +5980,8 @@ static void findBigKeys(void) {
                 /* Keep track of biggest key name for this type */
                 sdsclear(maxkeys[type]);
                 maxkeys[type] = sdscatrepr(maxkeys[type], keys->element[i]->str, keys->element[i]->len);
-                sdstrim(maxkeys[type], "\"");
+                /* Remove the start and end '"' added by sdscatrepr */
+                sdsrange(maxkeys[type], 1, -2);
 
                 printf(
                    "[%05.2f%%] Biggest %-6s found so far '%s' with %llu %s\n",

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5980,11 +5980,9 @@ static void findBigKeys(void) {
                 /* Keep track of biggest key name for this type */
                 sdsclear(maxkeys[type]);
                 maxkeys[type] = sdscatrepr(maxkeys[type], keys->element[i]->str, keys->element[i]->len);
-                /* Remove the start and end '"' added by sdscatrepr */
-                sdsrange(maxkeys[type], 1, -2);
 
                 printf(
-                   "[%05.2f%%] Biggest %-6s found so far '%s' with %llu %s\n",
+                   "[%05.2f%%] Biggest %-6s found so far %s with %llu %s\n",
                    pct, typename[type], maxkeys[type], sizes[i],
                    typeunit[type]);
 
@@ -6024,7 +6022,7 @@ static void findBigKeys(void) {
     /* Output the biggest keys we found, for types we did find */
     for(i=0;i<TYPE_NONE;i++) {
         if(sdslen(maxkeys[i])>0) {
-            printf("Biggest %6s found '%s' has %llu %s\n", typename[i], maxkeys[i],
+            printf("Biggest %6s found %s has %llu %s\n", typename[i], maxkeys[i],
                biggest[i], typeunit[i]);
         }
     }


### PR DESCRIPTION
Use the following code to set two keys into redis:

\#!/usr/bin/env python
\# -*- coding: utf-8 -*-

import struct
import socket

def format_binary_request(key):
    key_len = struct.pack("!H", len(key))
    packet = key_len + key
    return packet

s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
s1.connect(("127.0.0.1", 6379))

my_key = format_binary_request("hell-redis")

key=("$%d\r\n") % (len(my_key))
key = key + my_key + "\r\n"

s1.sendall("*3\r\n$3\r\nset\r\n" + key + "$2\r\nHI\r\n")
print s1.recv(1024)
s1.sendall("*2\r\n$3\r\nget\r\n" + key)
print s1.recv(1024)

s1.sendall("*3\r\n$3\r\nset\r\n$4\r\ntest\r\n$1\r\nI\r\n")
print s1.recv(1024)
s1.sendall("*2\r\n$3\r\nget\r\n$4\r\ntest\r\n")
print s1.recv(1024)

we get:
./bin/redis-cli   -p 6379
127.0.0.1:9379> randomkey
"\x00\nhell-redis"
127.0.0.1:9379> randomkey
"test"

the first key is '\x00\nhell-redis', which is unprintable, not ascii character starting, and has value length 2. the  second key is 'test',  which has a value length 1. It's obvious that the biggest key is '\x00\nhell-redis' .But when use redis-cli  -p 6379 --bigkeys, i get the following info:

\# Scanning the entire keyspace to find biggest keys as well as
\# average sizes per key type.  You can use -i 0.1 to sleep 0.1 sec
\# per 100 SCAN commands (not usually needed).

[00.00%] Biggest string found so far 'test' with 1 bytes

-------- summary -------

Sampled 1 keys in the keyspace!
Total key length in bytes is 4 (avg len 4.00)

Biggest string found 'test' has 1 bytes

1 strings with 1 bytes (100.00% of keys, avg size 1.00)
0 lists with 0 items (00.00% of keys, avg size 0.00)
0 sets with 0 members (00.00% of keys, avg size 0.00)
0 hashs with 0 fields (00.00% of keys, avg size 0.00)
0 zsets with 0 members (00.00% of keys, avg size 0.00)
0 streams with 0 entries (00.00% of keys, avg size 0.00)

the following is the modification:

\# Scanning the entire keyspace to find biggest keys as well as
\# average sizes per key type.  You can use -i 0.1 to sleep 0.1 sec
\# per 100 SCAN commands (not usually needed).

[00.00%] Biggest string found so far 'test' with 1 bytes
[00.00%] Biggest string found so far '\x00\nhell-redis' with 2 bytes

-------- summary -------

Sampled 2 keys in the keyspace!
Total key length in bytes is 16 (avg len 8.00)

Biggest string found '\x00\nhell-redis' has 2 bytes

2 strings with 3 bytes (100.00% of keys, avg size 1.50)
0 lists with 0 items (00.00% of keys, avg size 0.00)
0 sets with 0 members (00.00% of keys, avg size 0.00)
0 hashs with 0 fields (00.00% of keys, avg size 0.00)
0 zsets with 0 members (00.00% of keys, avg size 0.00)
0 streams with 0 entries (00.00% of keys, avg size 0.00)