### PR TITLE
include stdint.h for unit64_t definition

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -30,6 +30,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 /* This function provide us access to the original libc free(). This is useful
  * for instance to free results obtained by backtrace_symbols(). We need


### PR DESCRIPTION
When building on RHEL 7.5:

```
BUILDSTDERR: zmalloc.c: In function 'zmalloc_get_allocator_info':
BUILDSTDERR: zmalloc.c:304:5: error: unknown type name 'uint64_t'
BUILDSTDERR:      uint64_t epoch = 1;
BUILDSTDERR:      ^
```