### PR TITLE
fix repeat argument issue and reduce unnessary loop times for redis-cli.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1174,6 +1174,16 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
             } else if (!strcasecmp(command,"auth") && argc == 2) {
                 cliSelect();
             }
+
+
+            /*  Issue the command again if we got redirected in cluster mode  */
+            if  (config.cluster_mode  &&  config.cluster_reissue_command)  {
+                cliConnect(CC_FORCE);
+                config.cluster_reissue_command  =  0;
+                /* for a '-MOVED' or '-ASK' response, we need to issue the command again, so
+                 * add repeat by 1. */
+                repeat++;
+            }
         }
         if (config.interval) usleep(config.interval);
         fflush(stdout); /* Make it grep friendly */
@@ -1543,13 +1553,8 @@ static int issueCommandRepeat(int argc, char **argv, long repeat) {
                 cliPrintContextError();
                 return REDIS_ERR;
             }
-         }
-         /* Issue the command again if we got redirected in cluster mode */
-         if (config.cluster_mode && config.cluster_reissue_command) {
-            cliConnect(CC_FORCE);
-         } else {
-             break;
-        }
+        } else
+            break;
     }
     return REDIS_OK;
 }


### PR DESCRIPTION
We use redis-cli to do incr command many times upon a key , to verify the data consistency  between master and slave when  a manual "cluster failover" is done.  like this: 
`redis-cli -c -p 7002 -r 50000 incr a`

We found that there are some issues about "--repeat" argument in redis-cli,  as follows:
1. when we do a failover, redis server give a redirect response to redis-cli, this will cause 
a wrong "repeat" count in the "cliSendCommand" function. and redis-cli will repeat to send "incr a" more than 50000 times, and we will get a wrong result.
2. also in the "cliSendCommand", there maybe have many unnessary loops which can cause an obviously halt.

Let's see how to reproduce this issue:
1. deploy some redis instances and create a redis cluster（port range: 7000-7005）
2. now all redis have no data, we use redis-cli to connect any master(eg: redis on the port 7005 ) in the cluster and do this:
`redis-cli -c -p 7005 -r 50000 incr a`
3. connect redis-server:7002, which is the slave of redis-server:7005, before the above step 2 finish , we do a manual failover:
`redis-cli -c -p 7002 cluster failover`
After press Enter on my keyboard, i can see an obvious halt for seconds on my terminal screen of redis-cli,  and now "incr a" has already processed 2820 times

4. seconds later after failover is done, redis-cli recover from the halt , and continue to do the rest "incr a" tasks,  at the last,  we can see redis-cli will do "incr a" 50000 times but （50000-2820）times，so the value of "a"  is 52820 but 50000, which is obviously wrong.

This issue last for a long time from redis 3.0, maybe it should be merged on 3.0, 4.0, 5.0 and unstable branches.
