### PR TITLE
ZPOP: unblock multiple clients in right way

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -314,8 +314,9 @@ void handleClientsBlockedOnKeys(void) {
                 if (de) {
                     list *clients = dictGetVal(de);
                     int numclients = listLength(clients);
+                    unsigned long zcard = zsetLength(o);
 
-                    while(numclients--) {
+                    while(numclients-- && zcard) {
                         listNode *clientnode = listFirst(clients);
                         client *receiver = clientnode->value;
 
@@ -332,6 +333,7 @@ void handleClientsBlockedOnKeys(void) {
                                      ? ZSET_MIN : ZSET_MAX;
                         unblockClient(receiver);
                         genericZpopCommand(receiver,&rl->key,1,where,1,NULL);
+                        zcard--;
 
                         /* Replicate the command. */
                         robj *argv[2];

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3216,9 +3216,9 @@ void blockingGenericZpopCommand(client *c, int where) {
                 return;
             } else {
                 if (zsetLength(o) != 0) {
-                    /* Non empty zset, this is like a normal Z[REV]POP. */
+                    /* Non empty zset, this is like a normal ZPOP[MIN|MAX]. */
                     genericZpopCommand(c,&c->argv[j],1,where,1,NULL);
-                    /* Replicate it as an Z[REV]POP instead of BZ[REV]POP. */
+                    /* Replicate it as an ZPOP[MIN|MAX] instead of BZPOP[MIN|MAX]. */
                     rewriteClientCommandVector(c,2,
                         where == ZSET_MAX ? shared.zpopmax : shared.zpopmin,
                         c->argv[j]);


### PR DESCRIPTION
If multiple clients blocked on one same sorted set, only one can be unblocked with `ZADD`, others get nil.

Is this a bug or by design? @antirez 