### PR TITLE
fix MEMORY USAGE to make it more accurate

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -796,7 +796,8 @@ size_t objectComputeSize(robj *o, size_t sample_size) {
             d = ((zset*)o->ptr)->dict;
             zskiplist *zsl = ((zset*)o->ptr)->zsl;
             zskiplistNode *znode = zsl->header->level[0].forward;
-            asize = sizeof(*o)+sizeof(zset)+(sizeof(struct dictEntry*)*dictSlots(d));
+            asize = sizeof(*o)+sizeof(zset)+sizeof(*d)+sizeof(*zsl)
+                +(sizeof(struct dictEntry*)*dictSlots(d));
             while(znode != NULL && samples < sample_size) {
                 elesize += sdsAllocSize(znode->ele);
                 elesize += sizeof(struct dictEntry) + zmalloc_size(znode);


### PR DESCRIPTION
When object type is OBJ_ZSET and encoding is OBJ_ENCODING_SKIPLIST, MEMORY USAGE can not get the right size. @antirez 