### PR TITLE
Critical: Fix server crash and data inconsistency in some cases.

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -347,7 +347,11 @@ NULL
         serverLog(LL_WARNING,"DB reloaded by DEBUG RELOAD");
         addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"loadaof")) {
-        if (server.aof_state == AOF_ON) flushAppendOnlyFile(1);
+        if (server.aof_state == AOF_OFF) {
+            addReply(c, shared.err);
+            return;
+        }
+        flushAppendOnlyFile(1);
         emptyDb(-1,EMPTYDB_NO_FLAGS,NULL);
         if (loadAppendOnlyFile(server.aof_filename) != C_OK) {
             addReply(c,shared.err);


### PR DESCRIPTION
Fix DEBUG LOADAOF so that redis-server will not crash unexpectedly
and will not be inconsistent after we call debug loadaof.
Before this commit, there were 2 problems:

1, When appendonly is set to no and there is not a appendonly file,
   redis-server will crash if we call DEBUG LOADAOF.
2, When appendonly is set to no and there is a appendonly file,
   redis-server will hold different data after loading  appendonly
   file.
@antirez 