### PR TITLE
Return early in XPENDING if sent a nonexistent consumer group.

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1728,8 +1728,10 @@ void xpendingCommand(client *c) {
 
         /* If a consumer name was mentioned but it does not exist, we can
          * just return an empty array. */
-        if (consumername && consumer == NULL)
+        if (consumername && consumer == NULL) {
             addReplyMultiBulkLen(c,0);
+            return;
+        }
 
         rax *pel = consumer ? consumer->pel : group->pel;
         unsigned char startkey[sizeof(streamID)];


### PR DESCRIPTION
Apologies if I am misunderstanding but I think we want to return early here when given a nonexistent consumer group.

Without the early return, I was seeing `*0\r\n*0\r\n` from Redis which was causing redis-cli to get out of sync.

Cheers!
Mike