### PR TITLE
Fix propagation from a thread-safe module context.

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1658,6 +1658,7 @@ struct redisCommand *lookupCommandOrOriginal(sds name);
 void call(client *c, int flags);
 void propagate(struct redisCommand *cmd, int dbid, robj **argv, int argc, int flags);
 void alsoPropagate(struct redisCommand *cmd, int dbid, robj **argv, int argc, int target);
+void handleAlsoPropagate(int flags);
 void forceCommandPropagation(client *c, int flags);
 void preventCommandPropagation(client *c);
 void preventCommandAOF(client *c);


### PR DESCRIPTION
Calls such as `RM_Replicate()` on a thread-safe context would push data to `server.also_propagate` but this would never be processed as `call()` swaps it and starts with a fresh array.