### PR TITLE
Fix redis-cli help display one more arg.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -536,7 +536,7 @@ static void cliIntegrateHelp(void) {
             ch->params = sdscat(ch->params,"key ");
             args--;
         }
-        while(args--) ch->params = sdscat(ch->params,"arg ");
+        while(--args > 0) ch->params = sdscat(ch->params,"arg ");
         if (entry->element[1]->integer < 0)
             ch->params = sdscat(ch->params,"...options...");
         ch->summary = "Help not available";


### PR DESCRIPTION
As redisCommand::arity which means number of arguments includes the cmdname's count.
But redis-cli help info exclude cmdname, so one more `arg` display as follows:

    127.0.0.1:6379> swapdb arg arg arg

should display as:

    127.0.0.1:6379> swapdb arg arg

The same issue also exists during those commands which still not  been defined in commands.json.