### PR TITLE
Streams: x[rev]range should take only one count

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1164,17 +1164,13 @@ void xrangeGenericCommand(client *c, int rev) {
 
     /* Parse the COUNT option if any. */
     if (c->argc > 4) {
-        for (int j = 4; j < c->argc; j++) {
-            int additional = c->argc-j-1;
-            if (strcasecmp(c->argv[j]->ptr,"COUNT") == 0 && additional >= 1) {
-                if (getLongLongFromObjectOrReply(c,c->argv[j+1],&count,NULL)
-                    != C_OK) return;
-                if (count < 0) count = 0;
-                j++; /* Consume additional arg. */
-            } else {
-                addReply(c,shared.syntaxerr);
-                return;
-            }
+        if (c->argc == 6 && strcasecmp(c->argv[4]->ptr,"COUNT") == 0) {
+            if (getLongLongFromObjectOrReply(c,c->argv[5],&count,NULL)
+                != C_OK) return;
+            if (count < 0) count = 0;
+        } else {
+            addReply(c,shared.syntaxerr);
+            return;
         }
     }
 


### PR DESCRIPTION
Hi, @antirez 

Using a loop to parse the count option in `XRANGE` is not necessary I think, it's easy to misuse:

```
127.0.0.1:6379> xadd key * a b
1528299254819-0
127.0.0.1:6379> xadd key * a b
1528299257281-0
127.0.0.1:6379> xrange key - + count 10 count 1
1) 1) 1528297838306-0
   2) 1) "a"
      2) "b"
```

Only the last `count 1` works.

And `XREAD[GROUP]` also has the same problem:

```
127.0.0.1:6379> XREADGROUP GROUP mygroup Alice block 1 COUNT 10 COUNT 1 STREAMS mystream 0
1) 1) "mystream"
   2) 1) 1) 1528303462729-0
         2) 1) "message"
            2) "banana"
```