### PR TITLE
bugfix: double close s in anetV6Only and _anetTcpServer

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -456,7 +456,6 @@ static int anetV6Only(char *err, int s) {
     int yes = 1;
     if (setsockopt(s,IPPROTO_IPV6,IPV6_V6ONLY,&yes,sizeof(yes)) == -1) {
         anetSetError(err, "setsockopt: %s", strerror(errno));
-        close(s);
         return ANET_ERR;
     }
     return ANET_OK;


### PR DESCRIPTION
Before fix, the 's' will be double close if setsockopt return -1.