### PR TITLE
Modules: make unloading module more safe

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2104,7 +2104,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
 
     /* Check if there are clients unblocked by modules that implement
      * blocking commands. */
-    moduleHandleBlockedClients();
+    if (moduleCount()) moduleHandleBlockedClients();
 
     /* Try to process pending commands for clients that were just unblocked. */
     if (listLength(server.unblocked_clients))


### PR DESCRIPTION
Hi, @antirez 

As we know if a module exports module-side data types, unload it is not allowed.

This rule is the same with blocked clients in module I think, because we use background threads to implement module blocked clients, and it's not safe to unload a module if there are background threads running:

```
127.0.0.1:6379> module load modules/helloblock.so
OK
127.0.0.1:6379> hello.block 10 1
Request timedout
127.0.0.1:6379> module unload helloblock
OK
```

After 10 seconds redis crashed. So it's necessary to check if any blocked clients running in this module when unload it.

Moreover, after that we can ensure that if no modules, then no module blocked clients even module unloaded.

So, we can call `moduleHandleBlockedClients` only when we have modules.