### PR TITLE
fix stream config typo

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1115,7 +1115,7 @@ hll-sparse-max-bytes 3000
 # max entires limit by setting max-bytes to 0 and max-entries to the desired
 # value.
 stream-node-max-bytes 4096
-stream-node-max-entires 100
+stream-node-max-entries 100
 
 # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
 # order to help rehashing the main Redis hash table (the one mapping top-level


### PR DESCRIPTION
A typo in redis.conf which causes startup errror.