### PR TITLE
Abort in XGROUP if the key is not a stream

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1576,7 +1576,7 @@ NULL
     /* Lookup the key now, this is common for all the subcommands but HELP. */
     if (c->argc >= 4) {
         robj *o = lookupKeyWriteOrReply(c,c->argv[2],shared.nokeyerr);
-        if (o == NULL) return;
+        if (o == NULL || checkType(c,o,OBJ_STREAM)) return;
         s = o->ptr;
         grpname = c->argv[3]->ptr;
 


### PR DESCRIPTION
Fixes segmentation fault in XGROUP if used against a key that is not a stream.

Replicate the crash in current unstable like so:
```bash
127.0.0.1:9999> set foo bar
OK
127.0.0.1:9999> xgroup create foo $
Could not connect to Redis at 127.0.0.1:9999: Connection refused
```