### PR TITLE
Streams: lookupKey[Read->Write]OrReply in xdel and xtrim

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2056,7 +2056,7 @@ void xclaimCommand(client *c) {
 void xdelCommand(client *c) {
     robj *o;
 
-    if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.czero)) == NULL
+    if ((o = lookupKeyWriteOrReply(c,c->argv[1],shared.czero)) == NULL
         || checkType(c,o,OBJ_STREAM)) return;
     stream *s = o->ptr;
 
@@ -2097,7 +2097,7 @@ void xtrimCommand(client *c) {
 
     /* If the key does not exist, we are ok returning zero, that is, the
      * number of elements removed from the stream. */
-    if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.czero)) == NULL
+    if ((o = lookupKeyWriteOrReply(c,c->argv[1],shared.czero)) == NULL
         || checkType(c,o,OBJ_STREAM)) return;
     stream *s = o->ptr;
 


### PR DESCRIPTION
Maybe using `lookupKeyWriteOrReply` in `xdel` and `xtrim` is more appropriate.