### PR TITLE
fix lfu/lru value error

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -361,7 +361,8 @@ void incrDecrCommand(client *c, long long incr) {
         new = o;
         o->ptr = (void*)((long)value);
     } else {
-        new = createStringObjectFromLongLong(value);
+        new = createObject(OBJ_STRING, sdsfromlonglong(value));
+        new = tryObjectEncoding(new);
         if (o) {
             dbOverwrite(c->db,c->argv[1],new);
         } else {


### PR DESCRIPTION
When using incr/desc command to create a new key, the value object is a shared object, regardless of the maxmemory-policy. We need to check maxmemory-policy first, and use a shared object only if the maxmemory-policy is off.