### PR TITLE
Fixed replication authentication with whitespace password

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1317,7 +1317,7 @@ char *sendSynchronousCommand(int flags, int fd, ...) {
 
     /* Create the command to send to the master, we use redis binary
      * protocol to make sure correct arguments are sent. This function
-     * is not safe for all binary data.*/
+     * is not safe for all binary data. */
     if (flags & SYNC_CMD_WRITE) {
         char *arg;
         va_list ap;


### PR DESCRIPTION
Using a password with a space in it will cause replication based authentication to fail with:
"18866:S 19 Jun 06:00:00.371 # Unable to AUTH to MASTER: -ERR wrong number of arguments for 'auth' command" 

Reproduction:
./redis-server --port 6378 --requirepass "Broken Password" &
./redis-server --port 6379 --masterauth "Broken Password" --slaveof 127.0.01 6378 &
sleep 1
pkill -9 redis-server

The proposed solution just wraps the AUTH command that is sent to the master to make sure it isn't parsed as a command with separate arguments.