### PR TITLE
use safe macro (non empty) in memrev64ifbe to eliminate empty if warning

### DIFF
--- a/src/endianconv.h
+++ b/src/endianconv.h
@@ -46,9 +46,9 @@ uint64_t intrev64(uint64_t v);
 /* variants of the function doing the actual convertion only if the target
  * host is big endian */
 #if (BYTE_ORDER == LITTLE_ENDIAN)
-#define memrev16ifbe(p)
-#define memrev32ifbe(p)
-#define memrev64ifbe(p)
+#define memrev16ifbe(p) ((void)(0))
+#define memrev32ifbe(p) ((void)(0))
+#define memrev64ifbe(p) ((void)(0))
 #define intrev16ifbe(v) (v)
 #define intrev32ifbe(v) (v)
 #define intrev64ifbe(v) (v)


### PR DESCRIPTION
i was getting the following warning:
```
rdb.c: In function ‘rdbLoadMillisecondTime’:
rdb.c:133:27: warning: suggest braces around empty body in an ‘if’ statement [-Wempty-body]
         memrev64ifbe(&t64); /* Convert in big endian if the system is BE. */
```
for the following code:
```
    if (rdbver >= 9) /* Check the top comment of this function. */
        memrev64ifbe(&t64); /* Convert in big endian if the system is BE. */
    return (long long)t64;
```
this fix will also reduce the chance for some future bug in which an empty statement inside an 'if' can cause the 'if' to unintendedly catch the next line.