### PR TITLE
add malloc_usable_size for libc malloc

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -882,13 +882,13 @@ typedef struct rdbSaveInfo {
 
 #define RDB_SAVE_INFO_INIT {-1,0,"000000000000000000000000000000",-1}
 
-typedef struct malloc_stats {
+struct malloc_stats {
     size_t zmalloc_used;
     size_t process_rss;
     size_t allocator_allocated;
     size_t allocator_active;
     size_t allocator_resident;
-} malloc_stats;
+};
 
 /*-----------------------------------------------------------------------------
  * Global server state
@@ -995,7 +995,7 @@ struct redisServer {
     long long slowlog_entry_id;     /* SLOWLOG current entry ID */
     long long slowlog_log_slower_than; /* SLOWLOG time limit (to get logged) */
     unsigned long slowlog_max_len;     /* SLOWLOG max number of items logged */
-    malloc_stats cron_malloc_stats; /* sampled in serverCron(). */
+    struct malloc_stats cron_malloc_stats; /* sampled in serverCron(). */
     long long stat_net_input_bytes; /* Bytes read from network. */
     long long stat_net_output_bytes; /* Bytes written to network. */
     size_t stat_rdb_cow_bytes;      /* Copy on write bytes during RDB saving. */

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -63,6 +63,11 @@
 
 #ifndef ZMALLOC_LIB
 #define ZMALLOC_LIB "libc"
+#ifdef __GLIBC__
+#include <malloc.h>
+#define HAVE_MALLOC_SIZE 1
+#define zmalloc_size(p) malloc_usable_size(p)
+#endif
 #endif
 
 /* We can enable the Redis defrag capabilities only if we are using Jemalloc


### PR DESCRIPTION
this reduces the extra 8 bytes we save before each pointer.
but more importantly maybe, it makes the valgrind runs to be more similiar
to our normal runs.

note: the change in malloc_stats struct in server.h is to eliminate an name conflict.
structs that are not typedefed are resolved from a separate name space.