### PR TITLE
Fix rdbLoadIntegerObject() to create shared objects when needed.

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -288,7 +288,7 @@ void *rdbLoadIntegerObject(rio *rdb, int enctype, int flags, size_t *lenptr) {
         memcpy(p,buf,len);
         return p;
     } else if (encode) {
-        return createStringObjectFromLongLong(val);
+        return createStringObjectFromLongLongForValue(val);
     } else {
         return createObject(OBJ_STRING,sdsfromlonglong(val));
     }


### PR DESCRIPTION
Same issue with incrDecrCommand(). See #5011 .