### PR TITLE
Replace logfile relative path with absolute path

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -271,7 +271,11 @@ void loadServerConfigFromString(char *config) {
             FILE *logfp;
 
             zfree(server.logfile);
-            server.logfile = zstrdup(argv[1]);
+            if (argv[1][0] != '\0') {
+                server.logfile = getAbsolutePath(argv[1]);
+            } else {
+                server.logfile = zstrdup(argv[1]);
+            }
             if (server.logfile[0] != '\0') {
                 /* Test if we are able to open the file. The server will not
                  * be able to abort just for this problem later... */


### PR DESCRIPTION
If the 'logfile' is a relative path, when loading 'dir', the chdir changes the working directory to the new path. And it is possibly different from the path specified by ‘logfile’ and there will be two log files.