### PR TITLE
fix empty string for sentinel rename-command

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3482,6 +3482,11 @@ void sentinelSetCommand(client *c) {
             sds oldname = c->argv[++j]->ptr;
             sds newname = c->argv[++j]->ptr;
 
+            if ((sdslen(oldname) == 0) || (sdslen(newname) == 0)) {
+                badarg = sdslen(newname) ? j-1 : j;
+                goto badfmt;
+            }
+
             /* Remove any older renaming for this command. */
             dictDelete(ri->renamed_commands,oldname);
 


### PR DESCRIPTION
The rename-command should not support an empty string in the command. Here are the reasons:
1. It is useless. rename-command is unlike the others which use an empty string to disable 'sentinel set'. Instead, we need to do it like this: `SENTINEL SET mymaster rename-command PING PING`.

2. Set a renamed command to empty string:  `SENTINEL SET mymaster rename-command PING ""`. Config rewrite process will record the renamed command like this：`sentinel rename-command mymaster ping`. Unfortunately, it is a wrong format. Once restart, sentinel can not startup successfully.