### PR TITLE
Replaced "Google Group" with "Reddit Group"

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -8,7 +8,7 @@ each source file that you contribute.
 # IMPORTANT: HOW TO USE REDIS GITHUB ISSUES
 
 * Github issues SHOULD ONLY BE USED to report bugs, and for DETAILED feature
-  requests. Everything else belongs to the Redis Google Group.
+  requests. Everything else belongs to the Redis Reddit Group.
 
   PLEASE DO NOT POST GENERAL QUESTIONS that are not about bugs or suspected
   bugs in the Github issues system. We'll be very happy to help you and provide


### PR DESCRIPTION
There isn't any link to the Google group. Shouldn't it be "Redis Reddit Group" rather than "Redis Google Group"?