### PR TITLE
Add no auth warning option

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -4867,7 +4867,7 @@ static int clusterManagerCommandRebalance(int argc, char **argv) {
     }
     /* Calculate the slots balance for each node. It's the number of
      * slots the node should lose (if positive) or gain (if negative)
-     * in order to be balanced. */  
+     * in order to be balanced. */
     int threshold_reached = 0, total_balance = 0;
     float threshold = config.cluster_manager_command.threshold;
     i = 0;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1467,7 +1467,10 @@ static void usage(void) {
 "                     line interface.\n"
 "  --help             Output this help and exit.\n"
 "  --version          Output version and exit.\n"
-"\n"
+"\n",
+    version, REDIS_CLI_DEFAULT_PIPE_TIMEOUT);
+    /* Using another fprintf call to avoid -Woverlength-strings compile warning */
+    fprintf(stderr,
 "Cluster Manager Commands:\n"
 "  Use --cluster help to list all available cluster manager commands.\n"
 "\n"
@@ -1484,8 +1487,7 @@ static void usage(void) {
 "When no command is given, redis-cli starts in interactive mode.\n"
 "Type \"help\" in interactive mode for information on available commands\n"
 "and settings.\n"
-"\n",
-        version, REDIS_CLI_DEFAULT_PIPE_TIMEOUT);
+"\n");
     sdsfree(version);
     exit(1);
 }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -220,6 +220,7 @@ static struct config {
     int last_cmd_type;
     int verbose;
     clusterManagerCommand cluster_manager_command;
+    int no_auth_warning;
 } config;
 
 /* User preferences. */
@@ -1235,8 +1236,9 @@ static int parseOptions(int argc, char **argv) {
             config.interval = seconds*1000000;
         } else if (!strcmp(argv[i],"-n") && !lastarg) {
             config.dbnum = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--no-auth-warning")) {
+            config.no_auth_warning = 1;
         } else if (!strcmp(argv[i],"-a") && !lastarg) {
-            fputs("Warning: Using a password with '-a' option on the command line interface may not be safe.\n", stderr);
             config.auth = argv[++i];
         } else if (!strcmp(argv[i],"-u") && !lastarg) {
             parseRedisUri(argv[++i]);
@@ -1387,6 +1389,12 @@ static int parseOptions(int argc, char **argv) {
         fprintf(stderr,"Try %s --help for more information.\n", argv[0]);
         exit(1);
     }
+
+    if (!config.no_auth_warning) {
+        fputs("Warning: Using a password with '-a' or '-u' option on the command"
+              " line interface may not be safe.\n", stderr);
+    }
+
     return i;
 }
 
@@ -6555,6 +6563,7 @@ int main(int argc, char **argv) {
     config.enable_ldb_on_eval = 0;
     config.last_cmd_type = -1;
     config.verbose = 0;
+    config.no_auth_warning = 0;
     config.cluster_manager_command.name = NULL;
     config.cluster_manager_command.argc = 0;
     config.cluster_manager_command.argv = NULL;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -4867,7 +4867,7 @@ static int clusterManagerCommandRebalance(int argc, char **argv) {
     }
     /* Calculate the slots balance for each node. It's the number of
      * slots the node should lose (if positive) or gain (if negative)
-     * in order to be balanced. */	
+     * in order to be balanced. */  
     int threshold_reached = 0, total_balance = 0;
     float threshold = config.cluster_manager_command.threshold;
     i = 0;
@@ -4879,9 +4879,9 @@ static int clusterManagerCommandRebalance(int argc, char **argv) {
                         n->weight);
         n->balance = n->slots_count - expected;
         total_balance += n->balance;
-	/* Compute the percentage of difference between the
-	 * expected number of slots and the real one, to see
-	 * if it's over the threshold specified by the user. */
+        /* Compute the percentage of difference between the
+         * expected number of slots and the real one, to see
+         * if it's over the threshold specified by the user. */
         int over_threshold = 0;
         if (threshold > 0) {
             if (n->slots_count > 0) {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1463,6 +1463,8 @@ static void usage(void) {
 "  --cluster <command> [args...] [opts...]\n"
 "                     Cluster Manager command and arguments (see below).\n"
 "  --verbose          Verbose mode.\n"
+"  --no-auth-warning  Don't show warning message when using password on command\n"
+"                     line interface.\n"
 "  --help             Output this help and exit.\n"
 "  --version          Output version and exit.\n"
 "\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1390,7 +1390,7 @@ static int parseOptions(int argc, char **argv) {
         exit(1);
     }
 
-    if (!config.no_auth_warning) {
+    if (!config.no_auth_warning && config.auth != NULL) {
         fputs("Warning: Using a password with '-a' or '-u' option on the command"
               " line interface may not be safe.\n", stderr);
     }


### PR DESCRIPTION
This is for issue #5073.

Using `--no-auth-warning` option won't output warning message even if you use a `password` on command line interface.