### PR TITLE
fix tests/test_helper.tcl with --wait-server option.

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -475,7 +475,6 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         set ::dont_clean 1
     } elseif {$opt eq {--wait-server}} {
         set ::wait_server 1
-        incr j
     } elseif {$opt eq {--timeout}} {
         set ::timeout $arg
         incr j


### PR DESCRIPTION
Issue #5063 added --wait-server option, but can not work properly.