### PR TITLE
Delete unnecessary connection

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6672,9 +6672,6 @@ int main(int argc, char **argv) {
         /* Ignore SIGPIPE in interactive mode to force a reconnect */
         signal(SIGPIPE, SIG_IGN);
 
-        /* Note that in repl mode we don't abort on connection error.
-         * A new attempt will be performed for every command send. */
-        cliConnect(0);
         repl();
     }
 


### PR DESCRIPTION
1. The 'cliConnect' is duplicated with the one called by 'cliIntegrateHelp',  it is unnecessary.
2. Because of that, when client could not connect to the redis server, there will be two connection error log:
```
$ ~/redis-cli
Could not connect to Redis at 127.0.0.1:6379: Connection refused
Could not connect to Redis at 127.0.0.1:6379: Connection refused
not connected>
```