### PR TITLE
BugFix: PEL is incorrect when consumer is blocked using xreadgroup with NOACK option.

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -382,6 +382,7 @@ void handleClientsBlockedOnKeys(void) {
                              * consumer here. */
                             streamCG *group = NULL;
                             streamConsumer *consumer = NULL;
+                            int noack = 0;
                             if (receiver->bpop.xread_group) {
                                 group = streamLookupCG(s,
                                         receiver->bpop.xread_group->ptr);
@@ -396,6 +397,7 @@ void handleClientsBlockedOnKeys(void) {
                                 consumer = streamLookupConsumer(group,
                                            receiver->bpop.xread_consumer->ptr,
                                            1);
+                                noack = receiver->bpop.xread_group_noack;
                             }
 
                             /* Emit the two elements sub-array consisting of
@@ -412,7 +414,7 @@ void handleClientsBlockedOnKeys(void) {
                             };
                             streamReplyWithRange(receiver,s,&start,NULL,
                                                  receiver->bpop.xread_count,
-                                                 0, group, consumer, 0, &pi);
+                                                 0, group, consumer, noack, &pi);
 
                             /* Note that after we unblock the client, 'gt'
                              * and other receiver->bpop stuff are no longer

--- a/src/networking.c
+++ b/src/networking.c
@@ -140,6 +140,7 @@ client *createClient(int fd) {
     c->bpop.target = NULL;
     c->bpop.xread_group = NULL;
     c->bpop.xread_consumer = NULL;
+    c->bpop.xread_group_noack = 0;
     c->bpop.numreplicas = 0;
     c->bpop.reploffset = 0;
     c->woff = 0;

--- a/src/server.h
+++ b/src/server.h
@@ -665,6 +665,7 @@ typedef struct blockingState {
     robj *xread_group;      /* XREADGROUP group name. */
     robj *xread_consumer;   /* XREADGROUP consumer name. */
     mstime_t xread_retry_time, xread_retry_ttl;
+    int xread_group_noack;
 
     /* BLOCKED_WAIT */
     int numreplicas;        /* Number of replicas we are waiting for ACK. */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1426,6 +1426,7 @@ void xreadCommand(client *c) {
             incrRefCount(consumername);
             c->bpop.xread_group = groupname;
             c->bpop.xread_consumer = consumername;
+            c->bpop.xread_group_noack = noack;
         } else {
             c->bpop.xread_group = NULL;
             c->bpop.xread_consumer = NULL;


### PR DESCRIPTION
This is for issue #5104 .