### PR TITLE
Fix slowlog config

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1122,7 +1122,7 @@ void configSetCommand(client *c) {
     } config_set_numerical_field(
       "lua-time-limit",server.lua_time_limit,0,LONG_MAX) {
     } config_set_numerical_field(
-      "slowlog-log-slower-than",server.slowlog_log_slower_than,0,LLONG_MAX) {
+      "slowlog-log-slower-than",server.slowlog_log_slower_than,-1,LLONG_MAX) {
     } config_set_numerical_field(
       "slowlog-max-len",ll,0,LONG_MAX) {
       /* Cast to unsigned. */

--- a/src/latency.c
+++ b/src/latency.c
@@ -294,7 +294,7 @@ sds createLatencyReport(void) {
 
         /* Potentially commands. */
         if (!strcasecmp(event,"command")) {
-            if (server.slowlog_log_slower_than == 0) {
+            if (server.slowlog_log_slower_than < 0) {
                 advise_slowlog_enabled = 1;
                 advices++;
             } else if (server.slowlog_log_slower_than/1000 >

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -78,4 +78,14 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         set e [lindex [r slowlog get] 0]
         assert_equal {lastentry_client} [lindex $e 5]
     }
+
+    test {SLOWLOG - can be disabled} {
+        r config set slowlog-log-slower-than 1
+        r slowlog reset
+        assert_equal [r slowlog len] 1 
+        r config set slowlog-log-slower-than -1
+        r slowlog reset
+        r debug sleep 0.2
+        assert_equal [r slowlog len] 0
+    }
 }


### PR DESCRIPTION
I noticed that there's an inconsistency of slowlog-log-slower-than.
See
https://github.com/antirez/redis/blob/d4182a0a0d36c97c42603fdd8ff6db750ec26580/src/slowlog.c#L124
and
https://github.com/antirez/redis/blob/d4182a0a0d36c97c42603fdd8ff6db750ec26580/src/latency.c#L297-L299

I believe this is a mistake. After digging into the code history, I found that slowlog log would be disabled if we set slowlog-log-slower-than to -1. And redis take every command as slowlog when slowlog-log-slower-than set to 0.
@antirez 