### PR TITLE
Accept write commands if persisting is disabled

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2519,7 +2519,8 @@ int processCommand(client *c) {
     if (((server.stop_writes_on_bgsave_err &&
           server.saveparamslen > 0 &&
           server.lastbgsave_status == C_ERR) ||
-          server.aof_last_write_status == C_ERR) &&
+          (server.aof_state != AOF_OFF &&
+           server.aof_last_write_status == C_ERR)) &&
         server.masterhost == NULL &&
         (c->cmd->flags & CMD_WRITE ||
          c->cmd->proc == pingCommand))


### PR DESCRIPTION
Accept write commands if persisting is disabled,
event if we do have problems persisting on disk
previously.

"server.aof_state != AOF_OFF" is just the counterpart of "server.saveparamslen > 0".
I think the logic should be consistent.