### PR TITLE
disable THP for redis-server self process

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -224,4 +224,12 @@ void setproctitle(const char *fmt, ...);
 #define USE_ALIGNED_ACCESS
 #endif
 
+/* since linux 3.15, kernel support prctl PR_SET_THP_DISABLE
+& PR_SET_THP_DISABLE */
+#ifdef __linux__
+#if (LINUX_VERSION_CODE >= 0x031500)
+#define HAVE_PRCTL_THP_DISABLE 1
+#endif
+#endif
+
 #endif

--- a/src/latency.h
+++ b/src/latency.h
@@ -63,7 +63,9 @@ struct latencyStats {
 
 void latencyMonitorInit(void);
 void latencyAddSample(char *event, mstime_t latency);
-int THPIsEnabled(void);
+int THPKernelIsEnabled(void);
+int THPProcIsEnabled(void);
+int THPProcDisable(void);
 
 /* Latency monitoring macros. */
 

--- a/src/server.c
+++ b/src/server.c
@@ -3520,8 +3520,12 @@ void linuxMemoryWarnings(void) {
     if (linuxOvercommitMemoryValue() == 0) {
         serverLog(LL_WARNING,"WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.");
     }
-    if (THPIsEnabled()) {
-        serverLog(LL_WARNING,"WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.");
+
+    /* check THP kernel firstly, this config control khugepaged
+     * running or not. then try to disable THP for self process */
+    if (THPKernelIsEnabled()) {
+        if (THPProcIsEnabled() && (THPProcDisable() < 0))
+            serverLog(LL_WARNING,"WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.");
     }
 }
 #endif /* __linux__ */


### PR DESCRIPTION
since linux 3.15, linux could get / set the state of the
"THP disable" flag for the calling thread. we can use this API
to disable THP for self process without modifing any global
kernel config.

changes in this patch :
1, modify API THPIsEnabled to THPKernelIsEnabled, it means that
this API gets the global kernel THP config.
2, add new API THPProcIsEnabled, this API could get process self
THP config by prctl(PR_GET_THP_DISABLE...).
3, add new API THPProcDisable, this API could disable self THP
config.
4, server checks kernel THP config firstly, because this config
control khungepaged running or not. if kernel THP is enabled,
try to disable THP for self process.

about THP side effect :
according to http://www.antirez.com/news/84, we can see that
redis latency spikes are caused by linux kernel THP feature.
I have tested on E3-2650 v3, and found that 2M huge page costs
about 0.25ms to fix COW page fault.

tests this patch :
this patch has been tested on ubuntu-1804(linux 4.15) and centos-7
(linux 3.10), and work well.

Signed-off-by: zhenwei pi <p_ace@126.com>