### PR TITLE
[trivial] sizeup error buf for redis-check-aof.c

### DIFF
--- a/src/redis-check-aof.c
+++ b/src/redis-check-aof.c
@@ -33,11 +33,11 @@
 
 #define ERROR(...) { \
     char __buf[1024]; \
-    sprintf(__buf, __VA_ARGS__); \
-    sprintf(error, "0x%16llx: %s", (long long)epos, __buf); \
+    snprintf(__buf, sizeof(__buf)-1, __VA_ARGS__); \
+    snprintf(error, sizeof(error)-1, "0x%16llx: %s", (long long)epos, __buf); \
 }
 
-static char error[1024];
+static char error[1048];
 static off_t epos;
 
 int consumeNewline(char *buf) {


### PR DESCRIPTION
if we use 1023 bytes string for ERROR macro.
It can cause buffer overrun.