### PR TITLE
remove ineffective loop in dictGetSomeKeys.

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -705,8 +705,10 @@ unsigned int dictGetSomeKeys(dict *d, dictEntry **des, unsigned int count) {
                  * table, there will be no elements in both tables up to
                  * the current rehashing index, so we jump if possible.
                  * (this happens when going from big to small table). */
-                if (i >= d->ht[1].size) i = d->rehashidx;
-                else continue;
+                if (i >= d->ht[1].size) 
+                    i = d->rehashidx;
+                else 
+                    continue;
             }
             if (i >= d->ht[j].size) continue; /* Out of range for this table. */
             dictEntry *he = d->ht[j].table[i];

--- a/src/dict.c
+++ b/src/dict.c
@@ -706,7 +706,7 @@ unsigned int dictGetSomeKeys(dict *d, dictEntry **des, unsigned int count) {
                  * the current rehashing index, so we jump if possible.
                  * (this happens when going from big to small table). */
                 if (i >= d->ht[1].size) i = d->rehashidx;
-                continue;
+                else continue;
             }
             if (i >= d->ht[j].size) continue; /* Out of range for this table. */
             dictEntry *he = d->ht[j].table[i];


### PR DESCRIPTION
When we need free some memory, we first choose some keys to free. In dictGetSomeKeys,  the first loop check may be useless. 
Suppose we are in rehash that going from big to small table. The first table  has size 32, the second is  16, the  rehashidx is 27, and the first point is 20.  We get the first loop is useless.