### PR TITLE
Streams: fix xdel memory leak

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -757,6 +757,7 @@ int streamDeleteItem(stream *s, streamID *id) {
         streamIteratorRemoveEntry(&si,&myid);
         deleted = 1;
     }
+    streamIteratorStop(&si);
     return deleted;
 }
 


### PR DESCRIPTION
Hi @antirez, we forgot `streamIteratorStop` after `streamIteratorStart` in `xdel`, that's where memory leak happens I think ...