### PR TITLE
Fix xreadgroup with '$' ID.

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1365,7 +1365,7 @@ void xreadCommand(client *c) {
             }
             continue;
         } else if (strcmp(c->argv[i]->ptr,">") == 0) {
-            if (!xreadgroup || groupname == NULL) {
+            if (!xreadgroup) {
                 addReplyError(c,"The > ID can be specified only when calling "
                                 "XREADGROUP using the GROUP <group> "
                                 "<consumer> option.");

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1351,6 +1351,11 @@ void xreadCommand(client *c) {
         }
 
         if (strcmp(c->argv[i]->ptr,"$") == 0) {
+            if (xreadgroup) {
+                addReplyError(c,"The $ ID can be specified only when calling "
+                              "XREAD without GROUP option.");
+                goto cleanup;
+            }
             if (o) {
                 stream *s = o->ptr;
                 ids[id_idx] = s->last_id;


### PR DESCRIPTION
Redis will always return an empty result when '$' ID is specified with xreadgroup command, i think it's meaningless.