### PR TITLE
Replace atoi with string2i to avoid conversion error.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -419,6 +419,22 @@ int string2l(const char *s, size_t slen, long *lval) {
     return 1;
 }
 
+/* Convert a string into a int. Returns 1 if the string could be parsed into a
+ * (non-overflowing) long, 0 otherwise. The value will be set to the parsed
+ * value when appropriate. */
+int string2i(const char *s, size_t slen, int *val) {
+    long long llval;
+
+    if (!string2ll(s,slen,&llval))
+        return 0;
+
+    if (llval < INT_MIN || llval > INT_MAX)
+        return 0;
+
+    *val = (int)llval;
+    return 1;
+}
+
 /* Convert a string into a double. Returns 1 if the string could be parsed
  * into a (non-overflowing) double, 0 otherwise. The value will be set to
  * the parsed value when appropriate.

--- a/src/util.c
+++ b/src/util.c
@@ -729,6 +729,19 @@ static void test_string2ll(void) {
 
     strcpy(buf,"9223372036854775808"); /* overflow */
     assert(string2ll(buf,strlen(buf),&v) == 0);
+
+    /* none digital */
+    strcpy(buf,"foobared");
+    assert(string2ll(buf,strlen(buf),&v) == 0);
+
+    /* May not start with non-digital. */
+    strcpy(buf,"foobared1");
+    assert(string2ll(buf,strlen(buf),&v) == 0);
+
+    /* May not end with non-digital. */
+    strcpy(buf,"1foobared");
+    assert(string2ll(buf,strlen(buf),&v) == 0);
+
 }
 
 static void test_string2l(void) {
@@ -778,6 +791,79 @@ static void test_string2l(void) {
     strcpy(buf,"2147483648"); /* overflow */
     assert(string2l(buf,strlen(buf),&v) == 0);
 #endif
+
+    /* none digital */
+    strcpy(buf,"foobared");
+    assert(string2l(buf,strlen(buf),&v) == 0);
+
+    /* May not start with non-digital. */
+    strcpy(buf,"foobared1");
+    assert(string2l(buf,strlen(buf),&v) == 0);
+
+    /* May not end with non-digital. */
+    strcpy(buf,"1foobared");
+    assert(string2l(buf,strlen(buf),&v) == 0);
+}
+
+static void test_string2i(void) {
+    char buf[32];
+    int v;
+
+    /* May not start with +. */
+    strcpy(buf,"+1");
+    assert(string2i(buf,strlen(buf),&v) == 0);
+
+    /* May not start with 0. */
+    strcpy(buf,"01");
+    assert(string2i(buf,strlen(buf),&v) == 0);
+
+    strcpy(buf,"-1");
+    assert(string2i(buf,strlen(buf),&v) == 1);
+    assert(v == -1);
+
+    strcpy(buf,"0");
+    assert(string2i(buf,strlen(buf),&v) == 1);
+    assert(v == 0);
+
+    strcpy(buf,"1");
+    assert(string2i(buf,strlen(buf),&v) == 1);
+    assert(v == 1);
+
+    strcpy(buf,"99");
+    assert(string2i(buf,strlen(buf),&v) == 1);
+    assert(v == 99);
+
+    strcpy(buf,"-99");
+    assert(string2i(buf,strlen(buf),&v) == 1);
+    assert(v == -99);
+
+#if INT_MAX != LLONG_MAX
+    strcpy(buf,"-2147483648");
+    assert(string2i(buf,strlen(buf),&v) == 1);
+    assert(v == INT_MIN);
+
+    strcpy(buf,"-2147483649"); /* overflow */
+    assert(string2i(buf,strlen(buf),&v) == 0);
+
+    strcpy(buf,"2147483647");
+    assert(string2i(buf,strlen(buf),&v) == 1);
+    assert(v == INT_MAX);
+
+    strcpy(buf,"2147483648"); /* overflow */
+    assert(string2i(buf,strlen(buf),&v) == 0);
+#endif
+
+    /* none digital */
+    strcpy(buf,"foobared");
+    assert(string2i(buf,strlen(buf),&v) == 0);
+
+    /* May not start with non-digital. */
+    strcpy(buf,"foobared1");
+    assert(string2i(buf,strlen(buf),&v) == 0);
+
+    /* May not end with non-digital. */
+    strcpy(buf,"1foobared");
+    assert(string2i(buf,strlen(buf),&v) == 0);
 }
 
 static void test_ll2string(void) {
@@ -828,6 +914,7 @@ int utilTest(int argc, char **argv) {
 
     test_string2ll();
     test_string2l();
+    test_string2i();
     test_ll2string();
     return 0;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -46,6 +46,7 @@ uint32_t sdigits10(int64_t v);
 int ll2string(char *s, size_t len, long long value);
 int string2ll(const char *s, size_t slen, long long *value);
 int string2l(const char *s, size_t slen, long *value);
+int string2i(const char *s, size_t slen, int *value);
 int string2ld(const char *s, size_t slen, long double *dp);
 int d2string(char *buf, size_t len, double value);
 int ld2string(char *buf, size_t len, long double value, int humanfriendly);


### PR DESCRIPTION
When using atoi to convert string to int, you can not get a right result when the conversion is failed. atoi returns 0 while it unable to convert string to a number (like in atoi("Redis")), which is indistinguishable from atoi("0"). So i create  string2i to make it more correct.