### PR TITLE
make active defrag test more stable

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -867,9 +867,8 @@ void defragDictBucketCallback(void *privdata, dictEntry **bucketref) {
  * or not, a false detection can cause the defragmenter to waste a lot of CPU
  * without the possibility of getting any results. */
 float getAllocatorFragmentation(size_t *out_frag_bytes) {
-    size_t resident = server.cron_malloc_stats.allocator_resident;
-    size_t active = server.cron_malloc_stats.allocator_active;
-    size_t allocated = server.cron_malloc_stats.allocator_allocated;
+    size_t resident, active, allocated;
+    zmalloc_get_allocator_info(&allocated, &active, &resident);
     float frag_pct = ((float)active / allocated)*100 - 100;
     size_t frag_bytes = active - allocated;
     float rss_pct = ((float)resident / allocated)*100 - 100;

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -41,7 +41,7 @@ start_server {tags {"defrag"}} {
         test "Active defrag" {
             r config set activedefrag no
             r config set active-defrag-threshold-lower 5
-            r config set active-defrag-cycle-min 25
+            r config set active-defrag-cycle-min 65
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 2mb
             r config set maxmemory 100mb
@@ -66,9 +66,10 @@ start_server {tags {"defrag"}} {
                 }
 
                 # Wait for the active defrag to stop working.
-                wait_for_condition 100 100 {
+                wait_for_condition 150 100 {
                     [s active_defrag_running] eq 0
                 } else {
+                    after 120 ;# serverCron only updates the info once in 100ms
                     puts [r info memory]
                     puts [r memory malloc-stats]
                     fail "defrag didn't stop."
@@ -175,6 +176,7 @@ start_server {tags {"defrag"}} {
                 wait_for_condition 500 100 {
                     [s active_defrag_running] eq 0
                 } else {
+                    after 120 ;# serverCron only updates the info once in 100ms
                     puts [r info memory]
                     puts [r memory malloc-stats]
                     fail "defrag didn't stop."


### PR DESCRIPTION
on slower machines, the active defrag test tended to fail.
although the fragmentation ratio was below the treshold, the defragger was
still in the middle of a scan cycle.

this commit changes:
- the defragger uses the current fragmentation state, rather than the cache one
  that is updated by server cron every 100ms. this actually fixes a bug of
  starting one excess scan cycle
- the test lets the defragger use more CPU cycles, in hope that the defrag
  will be faster, but also give it more time before we give up.