### PR TITLE
Fix XTRIM and XADD with MAXLEN inconsistency

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1114,8 +1114,7 @@ int streamParseStrictIDOrReply(client *c, robj *o, streamID *id, uint64_t missin
     return streamGenericParseIDOrReply(c,o,id,missing_seq,1);
 }
 
-
-/* XADD key [MAXLEN <count>] <ID or *> [field value] [field value] ... */
+/* XADD key [MAXLEN [~|=] <count>] <ID or *> [field value] [field value] ... */
 void xaddCommand(client *c) {
     streamID id;
     int id_given = 0; /* Was an ID different than "*" specified? */
@@ -1140,6 +1139,8 @@ void xaddCommand(client *c) {
             /* Check for the form MAXLEN ~ <count>. */
             if (moreargs >= 2 && next[0] == '~' && next[1] == '\0') {
                 approx_maxlen = 1;
+                i++;
+            } else if (moreargs >= 2 && next[0] == '=' && next[1] == '\0') {
                 i++;
             }
             if (getLongLongFromObjectOrReply(c,c->argv[i+1],&maxlen,NULL)
@@ -1187,9 +1188,22 @@ void xaddCommand(client *c) {
     notifyKeyspaceEvent(NOTIFY_STREAM,"xadd",c->argv[1],c->db->id);
     server.dirty++;
 
-    /* Notify xtrim event if needed. */
-    if (maxlen >= 0 && streamTrimByLength(s,maxlen,approx_maxlen)) {
-        notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
+    if (maxlen >= 0) {
+        /* Notify xtrim event if needed. */
+        if (streamTrimByLength(s,maxlen,approx_maxlen)) {
+            notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
+        }
+
+        /* Rewrite approximated MAXLEN as specified s->length. */
+        if (approx_maxlen) {
+            robj *maxlen_obj = createStringObjectFromLongLong(s->length);
+            rewriteClientCommandArgument(c,maxlen_arg_idx,maxlen_obj);
+            decrRefCount(maxlen_obj);
+
+            robj *equal_obj = createStringObject("=",1);
+            rewriteClientCommandArgument(c,maxlen_arg_idx-1,equal_obj);
+            decrRefCount(equal_obj);
+        }
     }
 
     /* Let's rewrite the ID argument with the one actually generated for
@@ -2174,7 +2188,7 @@ void xdelCommand(client *c) {
  *
  * List of options:
  *
- * MAXLEN [~] <count>       -- Trim so that the stream will be capped at
+ * MAXLEN [~|=] <count>     -- Trim so that the stream will be capped at
  *                             the specified length. Use ~ before the
  *                             count in order to demand approximated trimming
  *                             (like XADD MAXLEN option).
@@ -2196,6 +2210,7 @@ void xtrimCommand(client *c) {
     long long maxlen = -1;  /* If left to -1 no trimming is performed. */
     int approx_maxlen = 0;  /* If 1 only delete whole radix tree nodes, so
                                the maxium length is not applied verbatim. */
+    int maxlen_arg_idx = 0; /* Index of the count in MAXLEN, for rewriting. */
 
     /* Parse options. */
     int i = 2; /* Start of options. */
@@ -2210,6 +2225,8 @@ void xtrimCommand(client *c) {
             if (moreargs >= 2 && next[0] == '~' && next[1] == '\0') {
                 approx_maxlen = 1;
                 i++;
+            } else if (moreargs >= 2 && next[0] == '=' && next[1] == '\0') {
+                i++;
             }
             if (getLongLongFromObjectOrReply(c,c->argv[i+1],&maxlen,NULL)
                 != C_OK) return;
@@ -2219,6 +2236,7 @@ void xtrimCommand(client *c) {
                 return;
             }
             i++;
+            maxlen_arg_idx = i;
         } else {
             addReply(c,shared.syntaxerr);
             return;
@@ -2239,6 +2257,17 @@ void xtrimCommand(client *c) {
         signalModifiedKey(c->db,c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
         server.dirty += deleted;
+
+        /* Rewrite approximated MAXLEN as specified s->length. */
+        if (approx_maxlen) {
+            robj *maxlen_obj = createStringObjectFromLongLong(s->length);
+            rewriteClientCommandArgument(c,maxlen_arg_idx,maxlen_obj);
+            decrRefCount(maxlen_obj);
+
+            robj *equal_obj = createStringObject("=",1);
+            rewriteClientCommandArgument(c,maxlen_arg_idx-1,equal_obj);
+            decrRefCount(equal_obj);
+        }
     }
     addReplyLongLong(c,deleted);
 }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2192,7 +2192,7 @@ void xtrimCommand(client *c) {
 
     /* Argument parsing. */
     int trim_strategy = TRIM_STRATEGY_NONE;
-    long long maxlen = 0;   /* 0 means no maximum length. */
+    long long maxlen = -1;  /* If left to -1 no trimming is performed. */
     int approx_maxlen = 0;  /* If 1 only delete whole radix tree nodes, so
                                the maxium length is not applied verbatim. */
 
@@ -2211,6 +2211,11 @@ void xtrimCommand(client *c) {
             }
             if (getLongLongFromObjectOrReply(c,c->argv[i+1],&maxlen,NULL)
                 != C_OK) return;
+
+            if (maxlen < 0) {
+                addReplyError(c,"The MAXLEN argument must be >= 0.");
+                return;
+            }
             i++;
         } else {
             addReply(c,shared.syntaxerr);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1135,6 +1135,7 @@ void xaddCommand(client *c) {
              * creation. */
             break;
         } else if (!strcasecmp(opt,"maxlen") && moreargs) {
+            approx_maxlen = 0;
             char *next = c->argv[i+1]->ptr;
             /* Check for the form MAXLEN ~ <count>. */
             if (moreargs >= 2 && next[0] == '~' && next[1] == '\0') {
@@ -2202,6 +2203,7 @@ void xtrimCommand(client *c) {
         int moreargs = (c->argc-1) - i; /* Number of additional arguments. */
         char *opt = c->argv[i]->ptr;
         if (!strcasecmp(opt,"maxlen") && moreargs) {
+            approx_maxlen = 0;
             trim_strategy = TRIM_STRATEGY_MAXLEN;
             char *next = c->argv[i+1]->ptr;
             /* Check for the form MAXLEN ~ <count>. */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1186,18 +1186,9 @@ void xaddCommand(client *c) {
     notifyKeyspaceEvent(NOTIFY_STREAM,"xadd",c->argv[1],c->db->id);
     server.dirty++;
 
-    /* Remove older elements if MAXLEN was specified. */
-    if (maxlen >= 0) {
-        if (!streamTrimByLength(s,maxlen,approx_maxlen)) {
-            /* If no trimming was performed, for instance because approximated
-             * trimming length was specified, rewrite the MAXLEN argument
-             * as zero, so that the command is propagated without trimming. */
-            robj *zeroobj = createStringObjectFromLongLong(0);
-            rewriteClientCommandArgument(c,maxlen_arg_idx,zeroobj);
-            decrRefCount(zeroobj);
-        } else {
-            notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
-        }
+    /* Notify xtrim event if needed. */
+    if (maxlen >= 0 && streamTrimByLength(s,maxlen,approx_maxlen)) {
+        notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
     }
 
     /* Let's rewrite the ID argument with the one actually generated for


### PR DESCRIPTION
Bugs reported:

1. XADD with MAXLEN > stream length will lead to inconsistency:

    ```c
            if (!streamTrimByLength(s,maxlen,approx_maxlen)) {
                /* If no trimming was performed, for instance because approximated
                 * trimming length was specified, rewrite the MAXLEN argument
                 * as zero, so that the command is propagated without trimming. */
                robj *zeroobj = createStringObjectFromLongLong(0);
                rewriteClientCommandArgument(c,maxlen_arg_idx,zeroobj);
                decrRefCount(zeroobj);
            }
    ```

    If `maxlen` > stream length or in some cases using `approx_maxlen`, no trimming was performed, but we should not propagate zero `maxlen`, because `MAXLEN 0` means deleting all entries from stream.

2. XADD/XTRIM with multi MAXLEN may behave wrong:

    `XTRIM key MAXLEN ~ 10 MAXLEN 100`, what we want is the last `MAXLEN`: `XTRIM key MAXLEN 100`, but actually redis take it as `XTRIM key MAXLEN ~ 100`.

3. Propagating approximated MAXLEN may lead to inconsistency:

    Slaves and rebooting redis may have different radix tree struct, by different stream* config options. So propagating approximated `MAXLEN` to AOF/slaves may lead to date inconsistency.

    Here I rewrite `~` as `=` to make `maxlen` specified.

4. MAXLEN in XTRIM should not < 0.

