### PR TITLE
Streams: ID of xclaim command should start from the sixth argument.

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1988,7 +1988,7 @@ void xclaimCommand(client *c) {
      * the client successfully claimed some message, so it should be
      * executed in a "all or nothing" fashion. */
     int j;
-    for (j = 4; j < c->argc; j++) {
+    for (j = 5; j < c->argc; j++) {
         streamID id;
         if (streamParseIDOrReply(NULL,c->argv[j],&id,0) != C_OK) break;
     }


### PR DESCRIPTION
Error is not found because that `min-idle-time` is kind of a valid stream id. But i think we'd better make it accurate and right :-). @antirez 