### PR TITLE
Do not migrate already expired keys.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5146,6 +5146,8 @@ try_again:
         serverAssertWithInfo(c,NULL,rioWriteBulkLongLong(&cmd,dbid));
     }
 
+    int num_keys_non_expired = 0;
+
     /* Create RESTORE payload and generate the protocol to call the command. */
     for (j = 0; j < num_keys; j++) {
         long long ttl = 0;
@@ -5153,8 +5155,10 @@ try_again:
 
         if (expireat != -1) {
             ttl = expireat-mstime();
+            if (ttl < 0) continue;
             if (ttl < 1) ttl = 1;
         }
+        num_keys_non_expired++;
         serverAssertWithInfo(c,NULL,
             rioWriteBulkCount(&cmd,'*',replace ? 5 : 4));
 
@@ -5217,9 +5221,9 @@ try_again:
     int socket_error = 0;
     int del_idx = 1; /* Index of the key argument for the replicated DEL op. */
 
-    if (!copy) newargv = zmalloc(sizeof(robj*)*(num_keys+1));
+    if (!copy) newargv = zmalloc(sizeof(robj*)*(num_keys_non_expired+1));
 
-    for (j = 0; j < num_keys; j++) {
+    for (j = 0; j < num_keys_non_expired; j++) {
         if (syncReadLine(cs->fd, buf2, sizeof(buf2), timeout) <= 0) {
             socket_error = 1;
             break;


### PR DESCRIPTION
There's no need to migrate already expired keys.
These keys should remain and wait for lazy deletion in activeExpireCycle().