### PR TITLE
fix slave buffer test suite false positives

### DIFF
--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -182,7 +182,7 @@ proc test_slave_buffers {cmd_count payload_len limit_memory pipeline} {
 
             # put the slave to sleep
             set rd_slave [redis_deferring_client]
-            $rd_slave debug sleep 60
+            $rd_slave debug sleep 300
 
             # send some 10mb woth of commands that don't increase the memory usage
             if {$pipeline == 1} {


### PR DESCRIPTION
it looks like on slow machines we're getting:
[err]: slave buffer are counted correctly in tests/unit/maxmemory.tcl
Expected condition '$slave_buf > 2*1024*1024' to be true (16914 > 2*1024*1024)

this is a result of the slave waking up too early and eating the
slave buffer before the traffic and the test ends.