### PR TITLE
Typo fix in comments and compile warning

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -748,10 +748,10 @@ unsigned char *lpSeek(unsigned char *lp, long index) {
     if (numele != LP_HDR_NUMELE_UNKNOWN) {
         if (index < 0) index = (long)numele+index;
         if (index < 0) return NULL; /* Index still < 0 means out of range. */
-        if (index >= numele) return NULL; /* Out of range the other side. */
+        if ((uint32_t)index >= numele) return NULL; /* Out of range the other side. */
         /* We want to scan right-to-left if the element we are looking for
          * is past the half of the listpack. */
-        if (index > numele/2) {
+        if ((uint32_t)index > numele/2) {
             forward = 0;
             /* Left to right scanning always expects a negative index. Convert
              * our index to negative form. */

--- a/src/module.c
+++ b/src/module.c
@@ -59,7 +59,7 @@ struct AutoMemEntry {
     int type;
 };
 
-/* AutMemEntry type field values. */
+/* AutoMemEntry type field values. */
 #define REDISMODULE_AM_KEY 0
 #define REDISMODULE_AM_STRING 1
 #define REDISMODULE_AM_REPLY 2


### PR DESCRIPTION
Typo fix in comments AutMemEntry -> AutoMemEntry
And Fix following compile warning..
'''
listpack.c: In function ‘lpSeek’:
listpack.c:751:19: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if (index >= numele) return NULL; /* Out of range the other side. */
                   ^~
listpack.c:754:19: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if (index > numele/2) {
'''