### PR TITLE
expire command may cause data inconsistent.

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -440,11 +440,13 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         addReply(c, shared.cone);
         return;
     } else {
-        robj *expire_when;
         setExpire(c,c->db,key,when);
-        expire_when = createStringObjectFromLongLong(when);
-        rewriteClientCommandVector(c,3,shared.pexpireat,key,expire_when);
-        decrRefCount(expire_when);
+        if (basetime > 0) {
+            robj *expire_when;
+            expire_when = createStringObjectFromLongLong(when);
+            rewriteClientCommandVector(c,3,shared.pexpireat,key,expire_when);
+            decrRefCount(expire_when);
+        }
         addReply(c,shared.cone);
         signalModifiedKey(c->db,key);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);

--- a/src/expire.c
+++ b/src/expire.c
@@ -440,12 +440,10 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         addReply(c, shared.cone);
         return;
     } else {
-        robj *expire_when, *pexpireat;
+        robj *expire_when;
         setExpire(c,c->db,key,when);
-        pexpireat = createStringObject("PEXPIREAT", 9);
         expire_when = createStringObjectFromLongLong(when);
-        rewriteClientCommandVector(c,3,pexpireat,key, expire_when);
-        decrRefCount(pexpireat);
+        rewriteClientCommandVector(c,3,shared.pexpireat,key,expire_when);
         decrRefCount(expire_when);
         addReply(c,shared.cone);
         signalModifiedKey(c->db,key);

--- a/src/expire.c
+++ b/src/expire.c
@@ -440,7 +440,13 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         addReply(c, shared.cone);
         return;
     } else {
+        robj *expire_when, *pexpireat;
         setExpire(c,c->db,key,when);
+        pexpireat = createStringObject("PEXPIREAT", 9);
+        expire_when = createStringObjectFromLongLong(when);
+        rewriteClientCommandVector(c,3,pexpireat,key, expire_when);
+        decrRefCount(pexpireat);
+        decrRefCount(expire_when);
         addReply(c,shared.cone);
         signalModifiedKey(c->db,key);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);

--- a/src/server.c
+++ b/src/server.c
@@ -1478,7 +1478,7 @@ void createSharedObjects(void) {
     shared.lpush = createStringObject("LPUSH",5);
     shared.zpopmin = createStringObject("ZPOPMIN",7);
     shared.zpopmax = createStringObject("ZPOPMAX",7);
-    shared.pexpireat = createStringObject("PEXPIREAT", 9);
+    shared.pexpireat = createStringObject("PEXPIREAT",9);
     for (j = 0; j < OBJ_SHARED_INTEGERS; j++) {
         shared.integers[j] =
             makeObjectShared(createObject(OBJ_STRING,(void*)(long)j));

--- a/src/server.c
+++ b/src/server.c
@@ -1478,6 +1478,7 @@ void createSharedObjects(void) {
     shared.lpush = createStringObject("LPUSH",5);
     shared.zpopmin = createStringObject("ZPOPMIN",7);
     shared.zpopmax = createStringObject("ZPOPMAX",7);
+    shared.pexpireat = createStringObject("PEXPIREAT", 9);
     for (j = 0; j < OBJ_SHARED_INTEGERS; j++) {
         shared.integers[j] =
             makeObjectShared(createObject(OBJ_STRING,(void*)(long)j));

--- a/src/server.h
+++ b/src/server.h
@@ -779,7 +779,7 @@ struct sharedObjectsStruct {
     *masterdownerr, *roslaveerr, *execaborterr, *noautherr, *noreplicaserr,
     *busykeyerr, *oomerr, *plus, *messagebulk, *pmessagebulk, *subscribebulk,
     *unsubscribebulk, *psubscribebulk, *punsubscribebulk, *del, *unlink,
-    *rpop, *lpop, *lpush, *zpopmin, *zpopmax, *emptyscan,
+    *rpop, *lpop, *lpush, *zpopmin, *zpopmax, *emptyscan, *pexpireat,
     *select[PROTO_SHARED_SELECT_CMDS],
     *integers[OBJ_SHARED_INTEGERS],
     *mbulkhdr[OBJ_SHARED_BULKHDR_LEN], /* "*<value>\r\n" */


### PR DESCRIPTION
Consider following commands order:

1. set key 10
2. expire key 120

Usually the master and slave have different expire time point and the differ should be very small. But If the expire command is not replicated to slave and some network problem happens or slave down. 
When slave reboot, it send psync2 to master, and psync is accepted.  In this scenario, the differ may be large and slave have newer expire time point. More serious, if failover happens,   the slave becomes new master, a user may find that a already expired key  which is in old master that could visit in new master.

Data  inconsistent happens.
