### PR TITLE
refactor dbOverwrite to make lazyfree work

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1824,6 +1824,7 @@ int dbAsyncDelete(redisDb *db, robj *key);
 void emptyDbAsync(redisDb *db);
 void slotToKeyFlushAsync(void);
 size_t lazyfreeGetPendingObjectsCount(void);
+void freeObjAsync(robj *o);
 
 /* API to get key arguments from commands */
 int *getKeysFromCommand(struct redisCommand *cmd, robj **argv, int argc, int *numkeys);

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -516,11 +516,7 @@ void spopWithCountCommand(client *c) {
             sdsfree(sdsele);
         }
 
-        /* Assign the new set as the key value. */
-        incrRefCount(set); /* Protect the old set value. */
-        dbOverwrite(c->db,c->argv[1],newset);
-
-        /* Tranfer the old set to the client and release it. */
+        /* Tranfer the old set to the client. */
         setTypeIterator *si;
         si = setTypeInitIterator(set);
         while((encoding = setTypeNext(si,&sdsele,&llele)) != -1) {
@@ -539,7 +535,9 @@ void spopWithCountCommand(client *c) {
             decrRefCount(objele);
         }
         setTypeReleaseIterator(si);
-        decrRefCount(set);
+
+        /* Assign the new set as the key value. */
+        dbOverwrite(c->db,c->argv[1],newset);
     }
 
     /* Don't propagate the command itself even if we incremented the


### PR DESCRIPTION
This PR is about expanding Lazyfree's option `lazyfree-lazy-server-del` to make it be available to `dbOverwrite`.

Keys will be implicitly deleted not only in `dbDelete` like `rename` and `move` commands, but also in `dbOverwrite` like `set` and `bitop` commands, so I think we should implement that.