### PR TITLE
modify time_independent_strcmp to make auth command faster.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2837,20 +2837,17 @@ int writeCommandsDeniedByDiskError(void) {
  * can avoid leaking any information about the password length and any
  * possible branch misprediction related leak.
  */
+#define CONFIG_AUTHPASS_MAX_LEN2LONG_WORD (CONFIG_AUTHPASS_MAX_LEN/sizeof(unsigned long long))
 unsigned long long time_independent_strcmp(char *a, char *b) {
-    char bufa[CONFIG_AUTHPASS_MAX_LEN], bufb[CONFIG_AUTHPASS_MAX_LEN];
+    unsigned long long bufa[CONFIG_AUTHPASS_MAX_LEN2LONG_WORD], bufb[CONFIG_AUTHPASS_MAX_LEN2LONG_WORD];
     /* The above two strlen perform len(a) + len(b) operations where either
      * a or b are fixed (our password) length, and the difference is only
      * relative to the length of the user provided string, so no information
      * leak is possible in the following two lines of code. */
     unsigned int alen = strlen(a);
     unsigned int blen = strlen(b);
-    unsigned long long *bufap, *bufbp;
     unsigned int j;
     unsigned long long diff = 0;
-
-    bufap = (unsigned long long*)bufa;
-    bufbp = (unsigned long long*)bufb;
 
     /* We can't compare strings longer than our static buffers.
      * Note that this will never pass the first test in practical circumstances
@@ -2866,8 +2863,8 @@ unsigned long long time_independent_strcmp(char *a, char *b) {
 
     /* Always compare all the chars in the two buffers without
      * conditional expressions. */
-    for (j = 0; j < sizeof(bufa) / sizeof(unsigned long long); j++) {
-        diff |= (bufap[j] ^ bufbp[j]);
+    for (j = 0; j < CONFIG_AUTHPASS_MAX_LEN2LONG_WORD; j++) {
+        diff |= (bufa[j] ^ bufb[j]);
     }
     /* Length must be equal as well. */
     diff |= alen ^ blen;

--- a/src/server.c
+++ b/src/server.c
@@ -2837,7 +2837,7 @@ int writeCommandsDeniedByDiskError(void) {
  * can avoid leaking any information about the password length and any
  * possible branch misprediction related leak.
  */
-int time_independent_strcmp(char *a, char *b) {
+unsigned long long time_independent_strcmp(char *a, char *b) {
     char bufa[CONFIG_AUTHPASS_MAX_LEN], bufb[CONFIG_AUTHPASS_MAX_LEN];
     /* The above two strlen perform len(a) + len(b) operations where either
      * a or b are fixed (our password) length, and the difference is only
@@ -2845,8 +2845,12 @@ int time_independent_strcmp(char *a, char *b) {
      * leak is possible in the following two lines of code. */
     unsigned int alen = strlen(a);
     unsigned int blen = strlen(b);
+    unsigned long long *bufap, *bufbp;
     unsigned int j;
-    int diff = 0;
+    unsigned long long diff = 0;
+
+    bufap = (unsigned long long*)bufa;
+    bufbp = (unsigned long long*)bufb;
 
     /* We can't compare strings longer than our static buffers.
      * Note that this will never pass the first test in practical circumstances
@@ -2862,8 +2866,8 @@ int time_independent_strcmp(char *a, char *b) {
 
     /* Always compare all the chars in the two buffers without
      * conditional expressions. */
-    for (j = 0; j < sizeof(bufa); j++) {
-        diff |= (bufa[j] ^ bufb[j]);
+    for (j = 0; j < sizeof(bufa) / sizeof(unsigned long long); j++) {
+        diff |= (bufap[j] ^ bufbp[j]);
     }
     /* Length must be equal as well. */
     diff |= alen ^ blen;


### PR DESCRIPTION
In short connection scenario, if password is set,  it must auth password every time when create a connection. 

In raw time_independent_strcmp we have to do 512 char to char xor.  In this PR, this  reduce to 64 unsigned long long to unsigned long long xor. 

I make a test in my machine. For 100 million time_independent_strcmp costs  73514 milli sec, and in this PR  time_independent_strcmp costs 16436 milli sec, 4.4 times faster.
