### PR TITLE
AOF: discard if we lost EXEC when loading aof

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -158,7 +158,7 @@ void execCommand(client *c) {
             must_propagate = 1;
         }
 
-        call(c,CMD_CALL_FULL);
+        call(c,server.loading ? CMD_CALL_NONE : CMD_CALL_FULL);
 
         /* Commands may alter argc/argv, restore mstate. */
         c->mstate.commands[j].argc = c->argc;


### PR DESCRIPTION
If we lost EXEC when loading aof, I think we should discard the transaction, or it will break the atomicity.