### PR TITLE
Scripting: forbid non deterministic WRITE commands

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -425,6 +425,11 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
      * Instead we take the other branch of the IF statement setting an expire
      * (possibly in the past) and wait for an explicit DEL from the master. */
     if (when <= mstime() && !server.loading && !server.masterhost) {
+        if (c->flags & CLIENT_LUA && !server.lua_replicate_commands) {
+            addReplyError(c,"Delete a key by *expire* is not allowed from scripts");
+            return;
+        }
+
         robj *aux;
 
         int deleted = server.lazyfree_lazy_expire ? dbAsyncDelete(c->db,key) :

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -479,6 +479,8 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
         goto cleanup;
     }
 
+    if (cmd->flags & CMD_RANDOM) server.lua_random_dirty = 1;
+
     /* Write commands are forbidden against read-only slaves, or if a
      * command marked as non-deterministic was already called in the context
      * of this script. */
@@ -521,7 +523,6 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
         }
     }
 
-    if (cmd->flags & CMD_RANDOM) server.lua_random_dirty = 1;
     if (cmd->flags & CMD_WRITE) server.lua_write_dirty = 1;
 
     /* If this is a Redis Cluster node, we need to make sure Lua is not

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -460,6 +460,7 @@ start_server {tags {"scripting"}} {
 
     test {Correct handling of reused argv (issue #1939)} {
         r eval {
+              redis.replicate_commands()
               for i = 0, 10 do
                   redis.call('SET', 'a', '1')
                   redis.call('MGET', 'a', 'b', 'c')


### PR DESCRIPTION
Some non deterministic WRITE commands like `SPOP` should not be allowed in lua script.