### PR TITLE
Streams: update listpack with new pointer in XDEL

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -724,6 +724,9 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
         p = lpNext(lp,p); /* Seek deleted field. */
         aux = lpGetInteger(p);
         lp = lpReplaceInteger(lp,&p,aux+1);
+
+        /* Update the listpack with the new pointer. */
+        raxInsert(si->stream->rax,si->ri.key,si->ri.key_len,lp,NULL);
     }
 
     /* Update the number of entries counter. */


### PR DESCRIPTION
Hi @antirez , I think we should update the listpack with new pointer in `xdel`, because `lpReplaceInteger` may trigger `zrealloc`.