### PR TITLE
Switch sdsTest #ifdef

### DIFF
--- a/src/sds.h
+++ b/src/sds.h
@@ -267,7 +267,7 @@ void *sds_malloc(size_t size);
 void *sds_realloc(void *ptr, size_t size);
 void sds_free(void *ptr);
 
-#ifdef REDIS_TEST
+#ifdef SDS_TEST_MAIN
 int sdsTest(int argc, char *argv[]);
 #endif
 


### PR DESCRIPTION
The function definition in sds.h was guarded with an #ifdef REDIS_TEST,
but the function itself is guarded with an #ifdef SDS_TEST_MAIN, fix the
definition in the header to match.

Closes #5091