### PR TITLE
Add log when server dies of SIGTERM during loading

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3780,6 +3780,7 @@ static void sigShutdownHandler(int sig) {
         rdbRemoveTempFile(getpid());
         exit(1); /* Exit with an error since this was not a clean shutdown. */
     } else if (server.loading) {
+        serverLogFromHandler(LL_WARNING, "Received shutdown signal during loading, exiting now.");
         exit(0);
     }
 


### PR DESCRIPTION
this is very confusing to see the server disappears as if it got SIGKILL when it was not the case.