### PR TITLE
Fix unstable tests on slow machines.

### DIFF
--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -33,7 +33,7 @@ start_server {tags {"dump"}} {
         set now [clock milliseconds]
         r restore foo [expr $now+3000] $encoded absttl
         set ttl [r pttl foo]
-        assert {$ttl >= 2998 && $ttl <= 3000}
+        assert {$ttl >= 2990 && $ttl <= 3000}
         r get foo
     } {bar}
     
@@ -44,7 +44,7 @@ start_server {tags {"dump"}} {
         r config set maxmemory-policy allkeys-lru
         r restore foo 0 $encoded idletime 1000
         set idle [r object idletime foo]
-        assert {$idle >= 1000 && $idle <= 1002}
+        assert {$idle >= 1000 && $idle <= 1010}
         r get foo
     } {bar}
     

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -201,7 +201,7 @@ start_server {tags {"defrag"}} {
                 assert {$frag < 1.1}
                 # due to high fragmentation, 10hz, and active-defrag-cycle-max set to 75,
                 # we expect max latency to be not much higher than 75ms
-                assert {$max_latency <= 80}
+                assert {$max_latency <= 120}
             }
             # verify the data isn't corrupted or changed
             set newdigest [r debug digest]


### PR DESCRIPTION
Few tests had borderline thresholds that were adjusted.

The slave buffers test had two issues, preventing the slave buffer from growing:
1) the slave didn't necessarily go to sleep on time, or woke up too early,
   now using SIGSTOP to make sure it goes to sleep exactly when we want.
2) the master disconnected the slave on timeout