### PR TITLE
eviction: reset evictionPool if we used it to free memory

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -256,17 +256,20 @@ void evictionPoolPopulate(int dbid, dict *sampledict, dict *keydict, struct evic
     }
 }
 
+/* Remove the entry from the pool. */
+void removeEntryFromPool(struct evictionPoolEntry *pool, int i) {
+    if (pool[i].key != pool[i].cached)
+        sdsfree(pool[i].key);
+    pool[i].key = NULL;
+    pool[i].idle = 0;
+}
+
 /* Reset the eviction pool. */
 void evictionPoolReset(struct evictionPoolEntry *pool) {
     int i;
     for (i = 0; i < EVPOOL_SIZE; i++) {
         if (pool[i].key == NULL) continue;
-
-        /* Remove the entry from the pool. */
-        if (pool[i].key != pool[i].cached)
-            sdsfree(pool[i].key);
-        pool[i].key = NULL;
-        pool[i].idle = 0;
+        removeEntryFromPool(pool,i);
     }
 }
 
@@ -521,11 +524,7 @@ int freeMemoryIfNeeded(void) {
                             pool[k].key);
                     }
 
-                    /* Remove the entry from the pool. */
-                    if (pool[k].key != pool[k].cached)
-                        sdsfree(pool[k].key);
-                    pool[k].key = NULL;
-                    pool[k].idle = 0;
+                    removeEntryFromPool(pool,k);
 
                     /* If the key exists, is our pick. Otherwise it is
                      * a ghost and we need to try the next element. */


### PR DESCRIPTION
key:idletime

Imagine that:

Time1: we need free memory and populate some keys to evictionPool like that: A:10,B:9,C:8

Time2: we delete the bestkey A and free enough memory, then keys in evictionPool are: B:9,C:8

Time3: we need free memory again, and the idle time of B is 3, but B is already in evctionPool and idle time is 9, so we take it as the bestkey to delete, but it is not the correct bestkey.

So, we should reset evictionPool after eviction to make sure that everytime we enter freeMemoryIfNeeded it is empty.