### PR TITLE
Add test for fixing failed slot migration, and fix fixing tool.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5425,6 +5425,11 @@ static int clusterManagerCommandReshard(int argc, char **argv) {
             goto cleanup;
         }
     }
+    // Bump epoch and broadcast for better stability
+    // Result is not checked for compatibility with previous redis versions.
+    redisReply *reply = CLUSTER_MANAGER_COMMAND(target, "CLUSTER BUMPEPOCH "
+            "BROADCAST");
+    if (reply) freeReplyObject(reply);
 cleanup:
     listRelease(sources);
     clusterManagerReleaseReshardTable(table);
@@ -5601,7 +5606,12 @@ static int clusterManagerCommandRebalance(int argc, char **argv) {
                     printf("#");
                     fflush(stdout);
                 }
-
+                // Bump epoch and broadcast for better stability
+                // Result is not checked for compatibility with previous
+                // redis versions.
+                redisReply *reply = CLUSTER_MANAGER_COMMAND(dst, "CLUSTER "
+                        "BUMPEPOCH BROADCAST");
+                if (reply) freeReplyObject(reply);
             }
             printf("\n");
 end_move:

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -4493,6 +4493,27 @@ static int clusterManagerCheckCluster(int quiet) {
         if (do_fix) {
             /* Fix open slots. */
             dictReleaseIterator(iter);
+            /* First, iterate through hosts and fix slots that should be
+               imported. */
+            listRewind(cluster_manager.nodes, &li);
+            while ((ln = listNext(&li)) != NULL) {
+                clusterManagerNode *n = ln->value;
+                if (n->importing == NULL) {
+                    continue;
+                }
+                for (i = 0; i < n->importing_count; i += 2) {
+                    sds slot = n->importing[i];
+                    result = clusterManagerFixOpenSlot(atoi(slot));
+                    if (!result) break;
+                    dictDelete(open_slots, slot);
+                }
+                redisReply *reply = CLUSTER_MANAGER_COMMAND(n, "CLUSTER "
+                        "BUMPEPOCH BROADCAST");
+                // old version doesn't recognize BROADCAST,
+                // so doesn't check answer
+                if (reply) freeReplyObject(reply);
+            }
+
             iter = dictGetIterator(open_slots);
             while ((entry = dictNext(iter)) != NULL) {
                 sds slot = (sds) dictGetKey(entry);

--- a/tests/cluster/tests/14-fix-slot-migration.tcl
+++ b/tests/cluster/tests/14-fix-slot-migration.tcl
@@ -1,0 +1,152 @@
+# Test fix of half migrated slot.
+# If old slot owner already received 'setslot <slotid> node <newowner>' command,
+# but new owner didn't, then where is now "owner" and it is still 'importing' in new owner.
+# Since new owner alread has slots, it fails to accept "CLUSTER ADDSLOTS" command.
+
+source "../tests/includes/init-tests.tcl"
+
+test "Create a 2 nodes cluster" {
+    create_cluster 2 0
+}
+
+test "Cluster is up" {
+    assert_cluster_state ok
+}
+
+set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+catch {unset nodefrom}
+catch {unset nodeto}
+proc reset_cluster {} {
+    uplevel 1 {
+        $cluster refresh_nodes_map
+        array set nodefrom [$cluster masternode_for_slot 609]
+        array set nodeto [$cluster masternode_notfor_slot 609]
+    }
+}
+
+proc fix_cluster {} {
+    uplevel 1 {
+        set code [catch {
+            exec ../../../src/redis-cli --cluster fix $nodefrom(addr) << yes
+        } result]
+        if {$code != 0 && $::verbose} {
+            puts $result
+        }
+        assert {$code == 0}
+        assert_cluster_state ok
+        wait_for_condition 1000 10 {
+            [catch {exec ../../../src/redis-cli --cluster check $nodefrom(addr)} _] == 0
+        } else {
+            fail "Cluster could not settle with configuration"
+        }
+    }
+}
+
+reset_cluster
+
+test "Set key" {
+    # 'aga' key is in 609 slot
+    $cluster set aga xyz
+}
+
+test "Key is accessible" {
+    assert {[$cluster get aga] eq "xyz"}
+}
+
+test "Fix doesn't need to fix anything" {
+    set code [catch {exec ../../../src/redis-cli --cluster fix $nodefrom(addr) << yes} result]
+    assert {$code == 0}
+}
+
+test "Key is accessible" {
+    assert {[$cluster get aga] eq "xyz"}
+}
+
+test "Half init migration in 'migrating'" {
+    $nodefrom(link) cluster setslot 609 migrating $nodeto(id)
+}
+
+test "Fix cluster" {
+    fix_cluster
+}
+
+test "Key is accessible" {
+    assert {[$cluster get aga] eq "xyz"}
+}
+
+test "Half init migration in 'importing'" {
+    $nodeto(link) cluster setslot 609 importing $nodefrom(id)
+}
+
+test "Fix cluster" {
+    fix_cluster
+}
+
+test "Key is accessible" {
+    assert {[$cluster get aga] eq "xyz"}
+}
+
+test "Init migration and move key" {
+    $nodefrom(link) cluster setslot 609 migrating $nodeto(id)
+    $nodeto(link) cluster setslot 609 importing $nodefrom(id)
+    $nodefrom(link) migrate $nodeto(host) $nodeto(port) aga 0 10000
+}
+
+test "Key is accessible" {
+    assert {[$cluster get aga] eq "xyz"}
+}
+
+test "Fix cluster" {
+    fix_cluster
+}
+
+test "Key is accessible" {
+    assert {[$cluster get aga] eq "xyz"}
+}
+
+reset_cluster
+
+test "Move key again" {
+    $nodefrom(link) cluster setslot 609 migrating $nodeto(id)
+    $nodeto(link) cluster setslot 609 importing $nodefrom(id)
+    $nodefrom(link) migrate $nodeto(host) $nodeto(port) aga 0 10000
+}
+
+test "Key is accessible" {
+    assert {[$cluster get aga] eq "xyz"}
+}
+
+test "Half-finish migration" {
+    # half finish migration on 'migrating' node
+    $nodefrom(link) cluster setslot 609 node $nodeto(id)
+}
+
+test "Fix cluster" {
+    fix_cluster
+}
+
+reset_cluster
+
+test "Move key back" {
+    # 'aga' key is in 609 slot
+    $nodefrom(link) cluster setslot 609 migrating $nodeto(id)
+    $nodeto(link) cluster setslot 609 importing $nodefrom(id)
+    $nodefrom(link) migrate $nodeto(host) $nodeto(port) aga 0 10000
+}
+
+test "Key is accessible" {
+    assert {[$cluster get aga] eq "xyz"}
+}
+
+test "Half-finish migration" {
+    # Now we half finish 'importing' node
+    $nodeto(link) cluster setslot 609 node $nodeto(id)
+}
+
+test "Fix cluster again" {
+    fix_cluster
+}
+
+test "Key is accessible" {
+    assert {[$cluster get aga] eq "xyz"}
+}

--- a/tests/cluster/tests/15-fix-many-slot-migration.tcl
+++ b/tests/cluster/tests/15-fix-many-slot-migration.tcl
@@ -1,0 +1,76 @@
+source "../tests/includes/init-tests.tcl"
+
+test "Create a 10 nodes cluster" {
+    create_cluster 10 10
+}
+
+test "Cluster is up" {
+    assert_cluster_state ok
+}
+
+set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+catch {unset nodefrom}
+catch {unset nodeto}
+proc reset_cluster {} {
+    uplevel 1 {
+        $cluster refresh_nodes_map
+    }
+}
+
+proc get_nodes {slot} {
+    uplevel 1 {
+        array set nodefrom [$cluster masternode_for_slot $slot]
+        array set nodeto [$cluster masternode_notfor_slot $slot]
+    }
+}
+
+proc fix_cluster {} {
+    uplevel 1 {
+        set code [catch {
+            exec ../../../src/redis-cli --cluster fix $nodefrom(addr) << yes
+        } result]
+        if {$code != 0 && $::verbose} {
+            puts $result
+        }
+        assert {$code == 0}
+        assert_cluster_state ok
+        wait_for_condition 1000 10 {
+            [catch {exec ../../../src/redis-cli --cluster check $nodefrom(addr)} _] == 0
+        } else {
+            fail "Cluster could not settle with configuration"
+        }
+    }
+}
+
+reset_cluster
+
+test "Set many keys" {
+    for {set i 0} {$i < 40000} {incr i} {
+        $cluster set key:$i val:$i
+    }
+}
+
+test "Keys are accessible" {
+    for {set i 0} {$i < 40000} {incr i} {
+        assert { [$cluster get key:$i] eq "val:$i" }
+    }
+}
+
+test "Init migration of many slots" {
+    for {set slot 0} {$slot < 1000} {incr slot} {
+        get_nodes $slot
+        $nodefrom(link) cluster setslot $slot migrating $nodeto(id)
+        $nodeto(link) cluster setslot $slot importing $nodefrom(id)
+    }
+}
+
+test "Fix cluster" {
+    fix_cluster
+}
+
+test "Keys are accessible" {
+    for {set i 0} {$i < 40000} {incr i} {
+        assert { [$cluster get key:$i] eq "val:$i" }
+    }
+}
+

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -148,6 +148,8 @@ proc parse_options {} {
             set ::simulate_error 1
         } elseif {$opt eq {--valgrind}} {
             set ::valgrind 1
+        } elseif {$opt eq {--verbose}} {
+            set ::verbose 1
         } elseif {$opt eq "--help"} {
             puts "Hello, I'm sentinel.tcl and I run Sentinel unit tests."
             puts "\nOptions:"

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -176,8 +176,10 @@ proc ::redis_cluster::__method__masternode_for_slot {id slot} {
 proc ::redis_cluster::__method__masternode_notfor_slot {id slot} {
     # Get the node mapped to this slot.
     set node_addr [dict get $::redis_cluster::slots($id) $slot]
-    dict for {addr node} $::redis_cluster::nodes($id) {
-        if {$node_addr ne $addr} {
+    set addrs [dict keys $::redis_cluster::nodes($id)]
+    foreach addr [lshuffle $addrs] {
+        set node [dict get $::redis_cluster::nodes($id) $addr]
+        if {$node_addr ne $addr && [dict get $node slaveof] eq "-"} {
             return $node
         }
     }

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -386,16 +386,16 @@ proc stop_write_load {handle} {
 
 proc K { x y } { set x } 
 
-# Shuffle a list. From Tcl wiki. Originally from Steve Cohen that improved
-# other versions. Code should be under public domain.
+# Shuffle a list with Fisher-Yates algorithm.
 proc lshuffle {list} {
     set n [llength $list]
-    while {$n>0} {
+    while {$n>1} {
         set j [expr {int(rand()*$n)}]
-        lappend slist [lindex $list $j]
         incr n -1
-        set temp [lindex $list $n]
-        set list [lreplace [K $list [set list {}]] $j $j $temp]
+        if {$n==$j} continue
+        set v [lindex $list $j]
+        lset list $j [lindex $list $n]
+        lset list $n $v
     }
-    return $slist
+    return $list
 }


### PR DESCRIPTION
Currently, `redis-cli --cluster fix` usually does a bad things when tries to fix half-inited or half-finished slot migration.
Add more special cases for all usual migration issues:
1. when migration is half inited on "migrating" node
2. when migration is half inited on "importing" node
3. migration is inited, but not finished (already were existed and worked, but moved a bit higher)
4. migration is half finished on "migrating" node
5. migration is half finished on "importing" node