### PR TITLE
Add support for USE_SYSTEM_JEMALLOC flag

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -36,7 +36,9 @@ distclean:
 	-(cd hiredis && $(MAKE) clean) > /dev/null || true
 	-(cd linenoise && $(MAKE) clean) > /dev/null || true
 	-(cd lua && $(MAKE) clean) > /dev/null || true
+ifneq ($(USE_SYSTEM_JEMALLOC),yes)
 	-(cd jemalloc && [ -f Makefile ] && $(MAKE) distclean) > /dev/null || true
+endif
 	-(rm -f .make-*)
 
 .PHONY: distclean

--- a/src/Makefile
+++ b/src/Makefile
@@ -120,9 +120,14 @@ ifeq ($(MALLOC),tcmalloc_minimal)
 endif
 
 ifeq ($(MALLOC),jemalloc)
+ifeq ($(USE_SYSTEM_JEMALLOC),yes)
+	FINAL_CFLAGS+= -DUSE_JEMALLOC -I/usr/include/jemalloc/include
+	FINAL_LIBS := -ljemalloc $(FINAL_LIBS)
+else
 	DEPENDENCY_TARGETS+= jemalloc
 	FINAL_CFLAGS+= -DUSE_JEMALLOC -I../deps/jemalloc/include
 	FINAL_LIBS := ../deps/jemalloc/lib/libjemalloc.a $(FINAL_LIBS)
+endif
 endif
 
 REDIS_CC=$(QUIET_CC)$(CC) $(FINAL_CFLAGS)

--- a/src/object.c
+++ b/src/object.c
@@ -36,6 +36,11 @@
 #define strtold(a,b) ((long double)strtod((a),(b)))
 #endif
 
+#if defined(USE_JEMALLOC) && (USE_SYSTEM_JEMALLOC == yes)
+#define je_mallctl mallctl
+#define je_malloc_stats_print malloc_stats_print
+#endif
+
 /* ===================== Creation and parsing of objects ==================== */
 
 robj *createObject(int type, void *ptr) {

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -63,12 +63,22 @@ void zlibc_free(void *ptr) {
 #define realloc(ptr,size) tc_realloc(ptr,size)
 #define free(ptr) tc_free(ptr)
 #elif defined(USE_JEMALLOC)
+#if USE_SYSTEM_JEMALLOC == yes
+#define malloc(size) malloc(size)
+#define calloc(count,size) calloc(count,size)
+#define realloc(ptr,size) realloc(ptr,size)
+#define free(ptr) free(ptr)
+#define mallocx(size,flags) mallocx(size,flags)
+#define dallocx(ptr,flags) dallocx(ptr,flags)
+#define je_mallctl mallctl
+#else
 #define malloc(size) je_malloc(size)
 #define calloc(count,size) je_calloc(count,size)
 #define realloc(ptr,size) je_realloc(ptr,size)
 #define free(ptr) je_free(ptr)
 #define mallocx(size,flags) je_mallocx(size,flags)
 #define dallocx(ptr,flags) je_dallocx(ptr,flags)
+#endif
 #endif
 
 #define update_zmalloc_stat_alloc(__n) do { \

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -50,7 +50,11 @@
 #include <jemalloc/jemalloc.h>
 #if (JEMALLOC_VERSION_MAJOR == 2 && JEMALLOC_VERSION_MINOR >= 1) || (JEMALLOC_VERSION_MAJOR > 2)
 #define HAVE_MALLOC_SIZE 1
+#if USE_SYSTEM_JEMALLOC == yes
+#define zmalloc_size(p) malloc_usable_size(p)
+#else
 #define zmalloc_size(p) je_malloc_usable_size(p)
+#endif
 #else
 #error "Newer version of jemalloc required"
 #endif


### PR DESCRIPTION
This allows easy support for using distribution-suppled
libraries where the usage of embedded code copies is
frowned upon.