### PR TITLE
redis-cli argument number condition bugfix

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -545,7 +545,7 @@ static void cliIntegrateHelp(void) {
             ch->params = sdscat(ch->params,"key ");
             args--;
         }
-        while(args--) ch->params = sdscat(ch->params,"arg ");
+        while(args-- > 0) ch->params = sdscat(ch->params,"arg ");
         if (entry->element[1]->integer < 0)
             ch->params = sdscat(ch->params,"...options...");
         ch->summary = "Help not available";


### PR DESCRIPTION
### Steps to reproduce the issue:
1. load a redis module, `helloworld.so` from redis source for example
2. start a new redis-cli, the redis-cli process will enter an infinite loop and exhaust CPU to 100%

## infinite loop reason
1. argument number of a command loaded from module is always -1. https://github.com/antirez/redis/blob/unstable/src/module.c#L663
2. If the command from a module sets firstkey = 1, lastkey = 1,  args will be reduced to -1 before the while loop condition

What's more, passing a variable `arity` as argument number of a command in `RedisModule_CreateCommand` api may be a better solution, but it breaks compatibility of existing modules.