### PR TITLE
Optimize repl stream

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1336,6 +1336,10 @@ int processMultibulkBuffer(client *c) {
                 c->bulklen >= PROTO_MBULK_BIG_ARG &&
                 sdslen(c->querybuf) == (size_t)(c->bulklen+2))
             {
+                if (c->flags & CLIENT_MASTER) {
+                    replicationFeedSlavesFromMasterStream(server.slaves,
+                            c->querybuf, sdslen(c->querybuf));
+                }
                 c->argv[c->argc++] = createObject(OBJ_STRING,c->querybuf);
                 sdsIncrLen(c->querybuf,-2); /* remove CRLF */
                 /* Assume that if we saw a fat argument we'll see another one

--- a/src/networking.c
+++ b/src/networking.c
@@ -839,6 +839,7 @@ void freeClient(client *c) {
      * some unexpected state, by checking its flags. */
     if (server.master && c->flags & CLIENT_MASTER) {
         serverLog(LL_WARNING,"Connection with master lost.");
+        undoReplicationBacklogIfNeeded();
         if (!(c->flags & (CLIENT_CLOSE_AFTER_REPLY|
                           CLIENT_CLOSE_ASAP|
                           CLIENT_BLOCKED|

--- a/src/networking.c
+++ b/src/networking.c
@@ -127,7 +127,6 @@ client *createClient(int fd) {
     c->bufpos = 0;
     c->qb_pos = 0;
     c->querybuf = sdsempty();
-    c->pending_querybuf = sdsempty();
     c->querybuf_peak = 0;
     c->reqtype = 0;
     c->argc = 0;
@@ -858,7 +857,6 @@ void freeClient(client *c) {
 
     /* Free the query buffer */
     sdsfree(c->querybuf);
-    sdsfree(c->pending_querybuf);
     c->querybuf = NULL;
 
     /* Deallocate structures used to block on blocking ops. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -1308,18 +1308,21 @@ int processMultibulkBuffer(client *c) {
 
             c->qb_pos = newline-c->querybuf+2;
             if (ll >= PROTO_MBULK_BIG_ARG) {
-                size_t qblen;
-
                 /* If we are going to read a large object from network
                  * try to make it likely that it will start at c->querybuf
                  * boundary so that we can optimize object creation
-                 * avoiding a large copy of data. */
-                trimQueryBufToPosition(c);
-                qblen = sdslen(c->querybuf);
-                /* Hint the sds library about the amount of bytes this string is
-                 * going to contain. */
-                if (qblen < (size_t)ll+2)
-                    c->querybuf = sdsMakeRoomFor(c->querybuf,ll+2-qblen);
+                 * avoiding a large copy of data.
+                 *
+                 * But only when the data we have not parsed is less than
+                 * or equal to ll+2. If the data length is greater than
+                 * ll+2, trimming querybuf is just a waste of time, because
+                 * at this time the querybuf contains not only our bulk. */
+                if (sdslen(c->querybuf)-c->qb_pos <= (size_t)ll+2) {
+                    trimQueryBufToPosition(c);
+                    /* Hint the sds library about the amount of bytes this string is
+                     * going to contain. */
+                    c->querybuf = sdsMakeRoomFor(c->querybuf,ll+2);
+                }
             }
             c->bulklen = ll;
         }

--- a/src/replication.c
+++ b/src/replication.c
@@ -2144,7 +2144,6 @@ void replicationCacheMaster(client *c) {
      * offsets, including pending transactions, already populated arguments,
      * pending outputs to the master. */
     sdsclear(server.master->querybuf);
-    sdsclear(server.master->pending_querybuf);
     server.master->read_reploff = server.master->reploff;
     if (c->flags & CLIENT_MULTI) discardTransaction(c);
     listEmpty(c->reply);

--- a/src/replication.c
+++ b/src/replication.c
@@ -119,6 +119,25 @@ void freeReplicationBacklog(void) {
     server.repl_backlog = NULL;
 }
 
+void undoReplicationBacklogIfNeeded(void) {
+    serverAssert(server.master != NULL && server.cached_master == NULL);
+    if (server.master->reploff != server.master_repl_offset) {
+        serverLog(LL_WARNING,"We have partial command in replication backlog, undo it.");
+        if (server.master->reploff+1 < server.repl_backlog_off ||
+            server.master->reploff+1 > (server.repl_backlog_off + server.repl_backlog_histlen)) {
+            serverLog(LL_WARNING,"Unable to undo, just free replication backlog.");
+            freeReplicationBacklog();
+        } else {
+            long long undo = server.master_repl_offset - server.master->reploff;
+            server.repl_backlog_histlen -= undo;
+            server.repl_backlog_idx -= undo;
+            if (server.repl_backlog_idx < 0) server.repl_backlog_idx += server.repl_backlog_size;
+        }
+        server.master_repl_offset = server.master->reploff;
+        disconnectSlaves();
+    }
+}
+
 /* Add data to the replication backlog.
  * This function also increments the global replication offset stored at
  * server.master_repl_offset, because there is no case where we want to feed

--- a/src/server.c
+++ b/src/server.c
@@ -866,22 +866,6 @@ int clientsCronResizeQueryBuffer(client *c) {
      * cycle. */
     c->querybuf_peak = 0;
 
-    /* Clients representing masters also use a "pending query buffer" that
-     * is the yet not applied part of the stream we are reading. Such buffer
-     * also needs resizing from time to time, otherwise after a very large
-     * transfer (a huge value or a big MIGRATE operation) it will keep using
-     * a lot of memory. */
-    if (c->flags & CLIENT_MASTER) {
-        /* There are two conditions to resize the pending query buffer:
-         * 1) Pending Query buffer is > LIMIT_PENDING_QUERYBUF.
-         * 2) Used length is smaller than pending_querybuf_size/2 */
-        size_t pending_querybuf_size = sdsAllocSize(c->pending_querybuf);
-        if(pending_querybuf_size > LIMIT_PENDING_QUERYBUF &&
-           sdslen(c->pending_querybuf) < (pending_querybuf_size/2))
-        {
-            c->pending_querybuf = sdsRemoveFreeSpace(c->pending_querybuf);
-        }
-    }
     return 0;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -189,8 +189,6 @@ typedef long long mstime_t; /* millisecond time type. */
 #define LONG_STR_SIZE      21          /* Bytes needed for long -> str + '\0' */
 #define REDIS_AUTOSYNC_BYTES (1024*1024*32) /* fdatasync every 32MB */
 
-#define LIMIT_PENDING_QUERYBUF (4*1024*1024) /* 4mb */
-
 /* When configuring the server eventloop, we setup it so that the total number
  * of file descriptors we can handle are server.maxclients + RESERVED_FDS +
  * a few more to stay safe. Since RESERVED_FDS defaults to 32, we add 96
@@ -712,10 +710,6 @@ typedef struct client {
     robj *name;             /* As set by CLIENT SETNAME. */
     sds querybuf;           /* Buffer we use to accumulate client queries. */
     size_t qb_pos;          /* The position we have read in querybuf. */
-    sds pending_querybuf;   /* If this client is flagged as master, this buffer
-                               represents the yet not applied portion of the
-                               replication stream that we are receiving from
-                               the master. */
     size_t querybuf_peak;   /* Recent (100ms or more) peak of querybuf size. */
     int argc;               /* Num of arguments of current command. */
     robj **argv;            /* Arguments of current command. */

--- a/src/server.h
+++ b/src/server.h
@@ -1582,6 +1582,7 @@ void clearReplicationId2(void);
 void chopReplicationBacklog(void);
 void replicationCacheMasterUsingMyself(void);
 void feedReplicationBacklog(void *ptr, size_t len);
+void undoReplicationBacklogIfNeeded(void);
 
 /* Generic persistence functions */
 void startLoading(FILE *fp);


### PR DESCRIPTION
After PR #5244 we record the position we have read in querybuf,
so we can use querybuf+qb_pos to feed replication stream
instead of pending_querybuf. The middle slave still performs as
a proxy, because the data in pending_querybuf is just a copy of
querybuf. Maybe querybuf+qb_pos will propagate partial command
if the command contains some large objects, but it's safe because
redis increment read_reploff only after processCommand succeed.

Thanks to @0xtonyxia suggestion.