### PR TITLE
#5299 Fix blocking XREAD for streams that ran dry

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1436,7 +1436,7 @@ void xreadCommand(client *c) {
                  * synchronously in case the group top item delivered is smaller
                  * than what the stream has inside. */
                 streamID *last = &groups[i]->last_id;
-                if (streamCompareID(&s->last_id, last) > 0) {
+                if (s->length && (streamCompareID(&s->last_id, last) > 0)) {
                     serve_synchronously = 1;
                     *gt = *last;
                 }
@@ -1444,7 +1444,7 @@ void xreadCommand(client *c) {
         } else {
             /* For consumers without a group, we serve synchronously if we can
              * actually provide at least one item from the stream. */
-            if (streamCompareID(&s->last_id, gt) > 0) {
+            if (s->length && (streamCompareID(&s->last_id, gt) > 0)) {
                 serve_synchronously = 1;
             }
         }


### PR DESCRIPTION
The conclusion, that a xread request can be answered syncronously in
case that the stream's last_id is larger than the passed last-received-id
parameter, assumes, that there must be entries present, which could be
returned immediately.
This assumption fails for empty streams that actually contained some
entries which got removed by xdel, ... .

As result, the client is answered synchronously with an empty result,
instead of blocking for new entries to arrive.
An additional check for a non-empty stream is required.