### PR TITLE
Use geohash limit defines in constraint check

### DIFF
--- a/src/geohash.c
+++ b/src/geohash.c
@@ -127,8 +127,8 @@ int geohashEncode(const GeoHashRange *long_range, const GeoHashRange *lat_range,
 
     /* Return an error when trying to index outside the supported
      * constraints. */
-    if (longitude > 180 || longitude < -180 ||
-        latitude > 85.05112878 || latitude < -85.05112878) return 0;
+    if (longitude > GEO_LONG_MAX || longitude < GEO_LONG_MIN ||
+        latitude > GEO_LAT_MAX || latitude < GEO_LAT_MIN) return 0;
 
     hash->bits = 0;
     hash->step = step;


### PR DESCRIPTION
This is the very essence of a trivial, 'drive-by' PR. Use it if it's useful.

Was studying the geohash code and noticed some literals where there probably should have been `#define`d constants.

All tests passed locally. Probably good to merge this PR before #4291!