### PR TITLE
sentinel: fix randomized sentinelTimer.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1320,9 +1320,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     }
 
     /* Run the Sentinel timer if we are in sentinel mode. */
-    run_with_period(100) {
-        if (server.sentinel_mode) sentinelTimer();
-    }
+    if (server.sentinel_mode) sentinelTimer();
 
     /* Cleanup expired MIGRATE cached sockets. */
     run_with_period(1000) {


### PR DESCRIPTION
Sentinel uses randomized hz from 10 to 19 to avoid split-vote, but sentinelTimer is called every 100ms, so it is called every serverCron.