### PR TITLE
Scripting: set lua client with multi flag exactly after multi emitted.

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -554,6 +554,7 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
     {
         execCommandPropagateMulti(server.lua_caller);
         server.lua_multi_emitted = 1;
+        c->flags |= CLIENT_MULTI;
     }
 
     /* Run the command */


### PR DESCRIPTION
Currently, if we use effects replication mode for lua, the lua client is not in CLIENT_MULTI state when executing the first write command but after. I didn't see any flaw for now(it do have an affection in our forked version :-) ), maybe we should still fix this for future concern? @antirez 