### PR TITLE
bio: fix bioWaitStepOfType.

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -204,14 +204,14 @@ void *bioProcessBackgroundJobs(void *arg) {
         }
         zfree(job);
 
-        /* Unblock threads blocked on bioWaitStepOfType() if any. */
-        pthread_cond_broadcast(&bio_step_cond[type]);
-
         /* Lock again before reiterating the loop, if there are no longer
          * jobs to process we'll block again in pthread_cond_wait(). */
         pthread_mutex_lock(&bio_mutex[type]);
         listDelNode(bio_jobs[type],ln);
         bio_pending[type]--;
+
+        /* Unblock threads blocked on bioWaitStepOfType() if any. */
+        pthread_cond_broadcast(&bio_step_cond[type]);
     }
 }
 


### PR DESCRIPTION
If there is only one job and the thread calling bioWaitStepOfType() acquires the lock before decreasing bio_pending, the thread will wait even if there is no job. If the thread is the only thread creating jobs, it will cause deadlock.