### PR TITLE
Change arity of HSET to 4

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -202,7 +202,7 @@ struct redisCommand redisCommandTable[] = {
     {"zpopmax",zpopmaxCommand,-2,"wF",0,NULL,1,1,1,0,0},
     {"bzpopmin",bzpopminCommand,-2,"wsF",0,NULL,1,-2,1,0,0},
     {"bzpopmax",bzpopmaxCommand,-2,"wsF",0,NULL,1,-2,1,0,0},
-    {"hset",hsetCommand,-4,"wmF",0,NULL,1,1,1,0,0},
+    {"hset",hsetCommand,4,"wmF",0,NULL,1,1,1,0,0},
     {"hsetnx",hsetnxCommand,4,"wmF",0,NULL,1,1,1,0,0},
     {"hget",hgetCommand,3,"rF",0,NULL,1,1,1,0,0},
     {"hmset",hsetCommand,-4,"wmF",0,NULL,1,1,1,0,0},


### PR DESCRIPTION
This pull request changes the arity of [HSET](https://redis.io/commands/hset) to be in line with the documentation (arity of 4).
Currently HSET has arity of -4 (minimum of 4 arguments), which is incorrect per the documentation. Also, when more than 4 arguments are passed, HSET behaves similarly [HMSET](https://redis.io/commands/hmset) but with an integer reply instead of a simple string.

[The documentation](https://redis.io/commands/hset) says the following about the reply of HSET:

> Integer reply, specifically:
>
> 1 if field is a new field in the hash and value was set.
> 0 if field already exists in the hash and the value was updated.

However, with the current implementation that's not the case:

```
$ ./src/redis-cli
127.0.0.1:6379> help hset

  HSET key field value
  summary: Set the string value of a hash field
  since: 2.0.0
  group: hash

127.0.0.1:6379> hset myhash f1 v1
(integer) 1
127.0.0.1:6379> hset myhash f2 v2 f3 v3
(integer) 2
```



With my proposed changes:


```
$ ./src/redis-cli
127.0.0.1:6379> hset myhash f1 v1
(integer) 1
127.0.0.1:6379> hset myhash f2 v2 f3 v3
(error) ERR wrong number of arguments for 'hset' command
```