### PR TITLE
AOF: remove memmove in aofChildWriteDiffData and record the latency

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -60,7 +60,7 @@ void aofClosePipes(void);
 #define AOF_RW_BUF_BLOCK_SIZE (1024*1024*10)    /* 10 MB per block */
 
 typedef struct aofrwblock {
-    unsigned long used, free;
+    unsigned long used, free, pos;
     char buf[AOF_RW_BUF_BLOCK_SIZE];
 } aofrwblock;
 
@@ -111,15 +111,13 @@ void aofChildWriteDiffData(aeEventLoop *el, int fd, void *privdata, int mask) {
                               AE_WRITABLE);
             break;
         }
-        if (block->used > 0) {
+        if (block->used != block->pos) {
             nwritten = write(server.aof_pipe_write_data_to_child,
-                             block->buf,block->used);
+                             block->buf+block->pos,block->used-block->pos);
             if (nwritten <= 0) break;
-            memmove(block->buf,block->buf+nwritten,block->used-nwritten);
-            block->used -= nwritten;
-            block->free += nwritten;
+            block->pos += nwritten;
         }
-        if (block->used == 0) listDelNode(server.aof_rewrite_buf_blocks,ln);
+        if (block->used == block->pos) listDelNode(server.aof_rewrite_buf_blocks,ln);
     }
     latencyEndMonitor(latency);
     latencyAddSampleIfNeeded("aof-rewrite-write-data-to-child",latency);
@@ -150,6 +148,7 @@ void aofRewriteBufferAppend(unsigned char *s, unsigned long len) {
             block = zmalloc(sizeof(*block));
             block->free = AOF_RW_BUF_BLOCK_SIZE;
             block->used = 0;
+            block->pos = 0;
             listAddNodeTail(server.aof_rewrite_buf_blocks,block);
 
             /* Log every time we cross more 10 or 100 blocks, respectively
@@ -185,9 +184,9 @@ ssize_t aofRewriteBufferWrite(int fd) {
         aofrwblock *block = listNodeValue(ln);
         ssize_t nwritten;
 
-        if (block->used) {
-            nwritten = write(fd,block->buf,block->used);
-            if (nwritten != (ssize_t)block->used) {
+        if (block->used != block->pos) {
+            nwritten = write(fd,block->buf+block->pos,block->used-block->pos);
+            if (nwritten != (ssize_t)(block->used-block->pos)) {
                 if (nwritten == 0) errno = EIO;
                 return -1;
             }


### PR DESCRIPTION
Hi @antirez , after we finish the pipeline optimization by avoiding too many `memmove`, I'am trying to find the others where `memmove` could be avoided, here I think one of them is about `aofrewrite`.

Before the `aofrewrite` we open some pipes, one is `server.aof_pipe_write_data_to_child` we use it to write appending data to child, and `memmove` appears in `aofChildWriteDiffData`:

```c
        if (block->used > 0) {
            nwritten = write(server.aof_pipe_write_data_to_child,
                             block->buf,block->used);
            if (nwritten <= 0) return;
            memmove(block->buf,block->buf+nwritten,block->used-nwritten);
            block->used -= nwritten;
            block->free += nwritten;
        }
```

Normally in most linux, the pipe capacity is 64KB, and the `aofrwblock` size in redis is 10MB, so maybe it's a waste of time to call `memmove`.

At first, to check if it is needed to remove `memmove` I just record the latency of `aofChildWriteDiffData`, see bb18ff4c9ec40ced94cd599a581d581b0eed576e, and here is the result(redis-benchmark -d 1000 -r 10000000 -t set -n 10000000 -l):

```
127.0.0.1:6379> latency latest
1) 1) "aof-rewrite-write-data-to-child"
   2) (integer) 1537270575
   3) (integer) 115
   4) (integer) 119
2) 1) "aof-rewrite-diff-write"
   2) (integer) 1537270570
   3) (integer) 513
   4) (integer) 513
```

We can see the latency, and then to avoid `memmove` I add a `pos` in `aofrwblock` to record the written position, and the latency disappears.

BTW, after that we have to hold the 10MB buffer, but it is not a big deal I think.