### PR TITLE
WIP eviction: reset evictionPool when maxmemory-policy has changed

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -903,6 +903,7 @@ void configSetCommand(client *c) {
     robj *o;
     long long ll;
     int err;
+    int old_maxmemory_policy = server.maxmemory_policy;
     serverAssertWithInfo(c,c->argv[2],sdsEncodedObject(c->argv[2]));
     serverAssertWithInfo(c,c->argv[3],sdsEncodedObject(c->argv[3]));
     o = c->argv[3];
@@ -1265,6 +1266,7 @@ void configSetCommand(client *c) {
       "loglevel",server.verbosity,loglevel_enum) {
     } config_set_enum_field(
       "maxmemory-policy",server.maxmemory_policy,maxmemory_policy_enum) {
+        if (server.maxmemory_policy != old_maxmemory_policy) evictionPoolReset();
     } config_set_enum_field(
       "appendfsync",server.aof_fsync,aof_fsync_enum) {
 

--- a/src/evict.c
+++ b/src/evict.c
@@ -256,6 +256,14 @@ void evictionPoolPopulate(int dbid, dict *sampledict, dict *keydict, struct evic
     }
 }
 
+/* Remove the entry from the pool. */
+void removeEntryFromPool(struct evictionPoolEntry *pool, int i) {
+    if (pool[i].key != pool[i].cached)
+        sdsfree(pool[i].key);
+    pool[i].key = NULL;
+    pool[i].idle = 0;
+}
+
 /* Reset the eviction pool. */
 void evictionPoolReset(void) {
     struct evictionPoolEntry *pool = EvictionPoolLRU;
@@ -263,11 +271,7 @@ void evictionPoolReset(void) {
     for (i = 0; i < EVPOOL_SIZE; i++) {
         if (pool[i].key == NULL) continue;
 
-        /* Remove the entry from the pool. */
-        if (pool[i].key != pool[i].cached)
-            sdsfree(pool[i].key);
-        pool[i].key = NULL;
-        pool[i].idle = 0;
+        removeEntryFromPool(pool,i);
     }
 }
 
@@ -525,11 +529,7 @@ int freeMemoryIfNeeded(void) {
                             pool[k].key);
                     }
 
-                    /* Remove the entry from the pool. */
-                    if (pool[k].key != pool[k].cached)
-                        sdsfree(pool[k].key);
-                    pool[k].key = NULL;
-                    pool[k].idle = 0;
+                    removeEntryFromPool(pool,k);
 
                     /* If the key exists, is our pick. Otherwise it is
                      * a ghost and we need to try the next element. */

--- a/src/evict.c
+++ b/src/evict.c
@@ -256,6 +256,21 @@ void evictionPoolPopulate(int dbid, dict *sampledict, dict *keydict, struct evic
     }
 }
 
+/* Reset the eviction pool. */
+void evictionPoolReset(void) {
+    struct evictionPoolEntry *pool = EvictionPoolLRU;
+    int i;
+    for (i = 0; i < EVPOOL_SIZE; i++) {
+        if (pool[i].key == NULL) continue;
+
+        /* Remove the entry from the pool. */
+        if (pool[i].key != pool[i].cached)
+            sdsfree(pool[i].key);
+        pool[i].key = NULL;
+        pool[i].idle = 0;
+    }
+}
+
 /* ----------------------------------------------------------------------------
  * LFU (Least Frequently Used) implementation.
 

--- a/src/server.h
+++ b/src/server.h
@@ -1727,6 +1727,7 @@ unsigned int LRU_CLOCK(void);
 const char *evictPolicyToString(void);
 struct redisMemOverhead *getMemoryOverheadData(void);
 void freeMemoryOverheadData(struct redisMemOverhead *mh);
+void evictionPoolReset(void);
 
 #define RESTART_SERVER_NONE 0
 #define RESTART_SERVER_GRACEFULLY (1<<0)     /* Do proper shutdown. */


### PR DESCRIPTION
Hi @antirez , `LRU`, `LFU` and `TTL` has different meanings, so if the `maxmemory-policy` has changed, we should reset eviction pool.