### PR TITLE
Update evictionpool if needed

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -97,6 +97,31 @@ unsigned long long estimateObjectIdleTime(robj *o) {
     }
 }
 
+/* Calculate the idle time according to the policy. This is called
+ * idle just because the code initially handled LRU, but is in fact
+ * just a score where an higher score means better candidate. */
+unsigned long long getEvictionIdleTime(void *val) {
+    unsigned long long idle;
+    if (server.maxmemory_policy & MAXMEMORY_FLAG_LRU) {
+        idle = estimateObjectIdleTime(val);
+    } else if (server.maxmemory_policy & MAXMEMORY_FLAG_LFU) {
+        /* When we use an LRU policy, we sort the keys by idle time
+         * so that we expire keys starting from greater idle time.
+         * However when the policy is an LFU one, we have a frequency
+         * estimation, and we want to evict keys with lower frequency
+         * first. So inside the pool we put objects using the inverted
+         * frequency subtracting the actual frequency to the maximum
+         * frequency of 255. */
+        idle = 255-LFUDecrAndReturn(val);
+    } else if (server.maxmemory_policy == MAXMEMORY_VOLATILE_TTL) {
+        /* In this case the sooner the expire the better. */
+        idle = ULLONG_MAX - (long)(val);
+    } else {
+        serverPanic("Unknown eviction policy in evictionPoolPopulate()");
+    }
+    return idle;
+}
+
 /* freeMemoryIfNeeded() gets called when 'maxmemory' is set on the config
  * file to limit the max memory used by the server, before processing a
  * command.
@@ -220,7 +245,6 @@ void evictionPoolPopulate(int dbid, dict *sampledict, dict *keydict, struct evic
     for (j = 0; j < count; j++) {
         unsigned long long idle;
         sds key;
-        robj *o;
         dictEntry *de;
 
         de = samples[j];
@@ -231,30 +255,9 @@ void evictionPoolPopulate(int dbid, dict *sampledict, dict *keydict, struct evic
          * again in the key dictionary to obtain the value object. */
         if (server.maxmemory_policy != MAXMEMORY_VOLATILE_TTL) {
             if (sampledict != keydict) de = dictFind(keydict, key);
-            o = dictGetVal(de);
         }
 
-        /* Calculate the idle time according to the policy. This is called
-         * idle just because the code initially handled LRU, but is in fact
-         * just a score where an higher score means better candidate. */
-        if (server.maxmemory_policy & MAXMEMORY_FLAG_LRU) {
-            idle = estimateObjectIdleTime(o);
-        } else if (server.maxmemory_policy & MAXMEMORY_FLAG_LFU) {
-            /* When we use an LRU policy, we sort the keys by idle time
-             * so that we expire keys starting from greater idle time.
-             * However when the policy is an LFU one, we have a frequency
-             * estimation, and we want to evict keys with lower frequency
-             * first. So inside the pool we put objects using the inverted
-             * frequency subtracting the actual frequency to the maximum
-             * frequency of 255. */
-            idle = 255-LFUDecrAndReturn(o);
-        } else if (server.maxmemory_policy == MAXMEMORY_VOLATILE_TTL) {
-            /* In this case the sooner the expire the better. */
-            idle = ULLONG_MAX - (long)dictGetVal(de);
-        } else {
-            serverPanic("Unknown eviction policy in evictionPoolPopulate()");
-        }
-
+        idle = getEvictionIdleTime(dictGetVal(de));
         evictionPoolInsert(dbid, key, idle, pool);
     }
 }


### PR DESCRIPTION
Update evictionPool every time we call `freeMemoryIfNeeded`,
in case the old candidates is not the best, imagine that:

Time1: we need free memory and populate some keys to evictionPool
       like that: A:10,B:9,C:8
Time2: we delete the bestkey A and free enough memory, then keys
       in evictionPool are: B:9,C:8
Time3: we need free memory again, and the idle time of B is 3,
       but B is already in evctionPool and idle time is 9, so
       we take it as the bestkey to delete, but it is not the
       correct bestkey.

Also we should update evictionPool in case `maxmemory-policy` changed,
because LRU, LFU and TTL has different meanings.

BTW, compare to the whole eviction cycle, update evictionPool before the cycle is not a big deal.