### PR TITLE
Added Required-Start and Required-Stop directives to the init script

### DIFF
--- a/utils/redis_init_script
+++ b/utils/redis_init_script
@@ -5,6 +5,8 @@
 
 ### BEGIN INIT INFO
 # Provides:     redis_6379
+# Required-Start: $local_fs $remote_fs $network $syslog $named
+# Required-Stop: $local_fs $remote_fs $network $syslog $named
 # Default-Start:        2 3 4 5
 # Default-Stop:         0 1 6
 # Short-Description:    Redis data structure server


### PR DESCRIPTION
In order to have a LSB-Core-compliant init script and avoid possible dependency issues (I've just run into one, with systemd hanging on Redis service stop request), Required-Start and Required-Stop directives should be set with the appropriate dependencies.
Here I included some basic virtual facilities.

See also:
[http://refspecs.linuxfoundation.org/LSB_3.1.0/LSB-Core-generic/LSB-Core-generic/initscrcomconv.html](http://refspecs.linuxfoundation.org/LSB_3.1.0/LSB-Core-generic/LSB-Core-generic/initscrcomconv.html)
[http://refspecs.linuxfoundation.org/LSB_3.1.0/LSB-Core-generic/LSB-Core-generic/facilname.html](http://refspecs.linuxfoundation.org/LSB_3.1.0/LSB-Core-generic/LSB-Core-generic/facilname.html)