### PR TITLE
bugfix: replace lastcmd with cmd when rewrite BRPOPLPUSH as RPOPLPUSH

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -596,7 +596,7 @@ void rpoplpushCommand(client *c) {
         signalModifiedKey(c->db,touchedkey);
         decrRefCount(touchedkey);
         server.dirty++;
-        if (c->lastcmd->proc == brpoplpushCommand) {
+        if (c->cmd->proc == brpoplpushCommand) {
             rewriteClientCommandVector(c,3,shared.rpoplpush,c->argv[1],c->argv[2]);
         }
     }


### PR DESCRIPTION
There are two problems if we use lastcmd:

1. BRPOPLPUSH cannot be rewrited as RPOPLPUSH in multi/exec
    In mulit/exec context, the lastcmd is exec.
2. Redis will crash when execute RPOPLPUSH loading from AOF
    In fakeClient, the lastcmd is NULL.

This is introduced in commit 8a1219d93b3a9e3349c6f6726bf9923fcf2a40e5, sorry for that...