### PR TITLE
Fix typo in redis.conf for replica-ignore-maxmemory parameter.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -625,7 +625,7 @@ replica-priority 100
 # memory to never hit a real out-of-memory condition before the master hits
 # the configured maxmemory setting.
 #
-# replica-ingore-maxmemory yes
+# replica-ignore-maxmemory yes
 
 ############################# LAZY FREEING ####################################
 


### PR DESCRIPTION
Fix a typo in redis.conf documentation for 'replica-ignore-maxmemory' parameter.