### PR TITLE
Master send TOUCH commands to slaves for reads to keep LRU in sync

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -425,6 +425,21 @@ repl-disable-tcp-nodelay no
 #
 # repl-backlog-ttl 3600
 
+# Master can send TOUCH commands to replicas on some read commands it executed
+# so that the LRU/LFU information on the replicas is not fed only by writes.
+# The term "read commands" here refers to any command accessing the keys which
+# was not replicated, so it includes write commands that didn't do modifications.
+# Value of 100 means one TOUCH for every 100 read commands.
+# Value of 0 means the mechanism is disabled.
+# repl-touch-cmd-ratio 100
+
+# Maximum number of touch commands bytes per second
+# repl-touch-max-rate 32kb
+
+# Force saving LRU to RDB file, even if evictino policy is noeviction.
+# When eviction policy uses LRU or LFU, this setting is ignored.
+# force-repl-lru no
+
 # The replica priority is an integer number published by Redis in the INFO output.
 # It is used by Redis Sentinel in order to select a replica to promote into a
 # master if the master is no longer working correctly.

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1008,6 +1008,8 @@ size_t rdbSavedObjectLen(robj *o) {
 int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime) {
     int savelru = server.maxmemory_policy & MAXMEMORY_FLAG_LRU;
     int savelfu = server.maxmemory_policy & MAXMEMORY_FLAG_LFU;
+    if (!savelru && !savelfu && server.force_repl_lru)
+        savelru = 1;
 
     /* Save the expire time */
     if (expiretime != -1) {

--- a/src/server.c
+++ b/src/server.c
@@ -1119,6 +1119,10 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
                 server.stat_net_input_bytes);
         trackInstantaneousMetric(STATS_METRIC_NET_OUTPUT,
                 server.stat_net_output_bytes);
+        trackInstantaneousMetric(STATS_METRIC_REPL_BYTES,
+                server.master_repl_offset);
+        trackInstantaneousMetric(STATS_METRIC_REPL_TOUCH,
+                server.stat_repl_touch_bytes);
     }
 
     /* We have just LRU_BITS bits per object for LRU information.
@@ -1551,6 +1555,9 @@ void initServerConfig(void) {
     server.active_defrag_cycle_min = CONFIG_DEFAULT_DEFRAG_CYCLE_MIN;
     server.active_defrag_cycle_max = CONFIG_DEFAULT_DEFRAG_CYCLE_MAX;
     server.active_defrag_max_scan_fields = CONFIG_DEFAULT_DEFRAG_MAX_SCAN_FIELDS;
+    server.repl_touch_cmd_ratio = CONFIG_DEFAULT_REPL_TOUCH_CMD_RATIO;
+    server.repl_touch_max_rate = CONFIG_DEFAULT_REPL_TOUCH_MAX_RATE;
+    server.force_repl_lru = 0;
     server.proto_max_bulk_len = CONFIG_DEFAULT_PROTO_MAX_BULK_LEN;
     server.client_max_querybuf_len = PROTO_MAX_QUERYBUF_LEN;
     server.saveparams = NULL;
@@ -1981,6 +1988,8 @@ void resetServerStats(void) {
     server.stat_evictedkeys = 0;
     server.stat_keyspace_misses = 0;
     server.stat_keyspace_hits = 0;
+    server.stat_repl_touch_keys = 0;
+    server.stat_repl_touch_bytes = 0;
     server.stat_active_defrag_hits = 0;
     server.stat_active_defrag_misses = 0;
     server.stat_active_defrag_key_hits = 0;
@@ -2368,6 +2377,116 @@ void preventCommandReplication(client *c) {
     c->flags |= CLIENT_PREVENT_REPL_PROP;
 }
 
+/* Send TOUCH commands to slaves for read keys */
+void maybePropagateTouch(int dirty, long long time, int dbid,
+                         struct redisCommand *cmd, robj **argv, int argc) {
+    static int next_repl_touch = 1;
+    listIter li;
+    listNode *ln;
+    int numkeys = 0, j;
+    int *keys;
+
+    /* Check if the TOUCH mechanism isn't disabled */
+    if (!server.repl_touch_cmd_ratio || server.repl_touch_max_rate <= 0)
+        return;
+
+    /* If the eviction policy isn't LRU/LFU, the this is most likely isn't needed */
+    if (!(server.maxmemory_policy & MAXMEMORY_FLAG_LRU) &&
+        !(server.maxmemory_policy & MAXMEMORY_FLAG_LFU) &&
+        !server.force_repl_lru)
+       return;
+
+    /* Continue only if we're a master with slaves */
+    if (!listLength(server.slaves) || server.masterhost)
+        return;
+
+    /* Skip TYPE and OBJECT, since they don't "touch" the LRU */
+    if (cmd->proc==typeCommand || cmd->proc==objectCommand)
+        return;
+    /* Skip administrative and pubsub, they don't touch keys */
+    if (cmd->flags & (CMD_ADMIN|CMD_PUBSUB))
+        return;
+
+    /* We wanna propagate TOUCH on:
+     * - Read-only commands (such as GET, EXISTS, STRLEN.
+     * - But also on write commands that didn't do any change
+     *   (e.g. SREM that failed to find the field) */
+    int touch_it = (cmd->flags & CMD_READONLY) || ((cmd->flags & CMD_WRITE) && !dirty);
+
+    /* Module commands may be missing the READONLY/WRITE flags, so trust the dirty flag */
+    if (!touch_it && (cmd->flags & CMD_MODULE) &&
+        !(cmd->flags & (CMD_WRITE|CMD_READONLY)) && !dirty)
+            touch_it = 1;
+
+    if (!touch_it)
+        return;
+
+    /* We prefer to skip commands that don't access keys before applying
+     * the selective mechanism, which increments a counter. */
+    if (cmd->firstkey==0 && cmd->getkeys_proc==NULL && !(cmd->flags&CMD_MODULE_GETKEYS))
+        return;
+
+    /* If we got here, it means the read command may need propagation as TOUCH */
+    next_repl_touch--;
+    /* But we don't propagate all, just a sample of them, according to configured ratio.
+     * we still leave some filtering to be done below that point, for the heavier checks */
+    if (next_repl_touch > 0)
+        return;
+
+    /* Try to avoid blowing off the slave buffers:
+     * Don't replicate any touch command if:
+     * - There's a slave currently waiting on bgsave to complete,
+     * - There's a slave with slave buffers over 50% utilized. */
+    listRewind(server.slaves,&li);
+    while((ln = listNext(&li))) {
+        client *slave = ln->value;
+        if (getClientType(slave) != CLIENT_TYPE_SLAVE)
+            continue;
+        if (slave->replstate == SLAVE_STATE_WAIT_BGSAVE_END)
+            return;
+        unsigned long used_mem = getClientOutputBufferMemoryUsage(slave);
+        if (used_mem > server.client_obuf_limits[CLIENT_TYPE_SLAVE].hard_limit_bytes / 2)
+            return;
+    }
+
+    /* Use the internals of the instantaneous metrics for replicated touch bytes
+     * in order to limit the rate of replicated touch bytes per second. */
+    long long msec = (time / 1000) -
+        server.inst_metric[STATS_METRIC_REPL_TOUCH].last_sample_time;
+    long long bytes = server.stat_repl_touch_bytes -
+        server.inst_metric[STATS_METRIC_REPL_TOUCH].last_sample_count;
+    if (msec && bytes * 1000 / msec > server.repl_touch_max_rate)
+        return;
+
+    /* Get the keys (if any) that the command uses.
+     * We rather do that after repl_touch_ratio since getKeysFromCommand may be an overhead. */
+    keys = getKeysFromCommand(cmd,argv,argc,&numkeys);
+    if (!keys)
+        return;
+
+    /* Send TOUCH command to slaves */
+    robj **touch_argv = zmalloc(sizeof(robj*) * (numkeys+1));
+    touch_argv[0] = createStringObject("TOUCH",5);
+    for (j=0; j<numkeys; j++)
+        touch_argv[1+j] = argv[keys[j]];
+    unsigned long long prev_offset = server.master_repl_offset;
+    if (numkeys)
+        replicationFeedSlaves(server.slaves, dbid, touch_argv, 1+numkeys);
+    getKeysFreeResult(keys);
+    decrRefCount(touch_argv[0]);
+    zfree(touch_argv);
+
+    /* Compute some stats */
+    server.stat_repl_touch_keys += numkeys;
+    server.stat_repl_touch_bytes += server.master_repl_offset - prev_offset;
+
+    /* Decide when we wanna replicate the next touch.
+     * It is important to use a random element, since if the user always uses
+     * the same pattern like: GET X; GET Y;
+     * If we have a ratio of 2, we may always hit X, and never Y */
+    next_repl_touch = 1 + random() % (server.repl_touch_cmd_ratio * 2 - 1);
+}
+
 /* Call() is the core of Redis execution of a command.
  *
  * The following flags can be passed:
@@ -2494,6 +2613,8 @@ void call(client *c, int flags) {
          * in an explicit way, so we never replicate them automatically. */
         if (propagate_flags != PROPAGATE_NONE && !(c->cmd->flags & CMD_MODULE))
             propagate(c->cmd,c->db->id,c->argv,c->argc,propagate_flags);
+        else
+            maybePropagateTouch(dirty,start,c->db->id,c->cmd,c->argv,c->argc);
     }
 
     /* Restore the old replication flags, since call() can be executed
@@ -3387,6 +3508,8 @@ sds genRedisInfoString(char *section) {
 
     /* Stats */
     if (allsections || defsections || !strcasecmp(section,"stats")) {
+        float repl_bytes = (float)getInstantaneousMetric(STATS_METRIC_REPL_BYTES)/1024;
+        float repl_touch = (float)getInstantaneousMetric(STATS_METRIC_REPL_TOUCH)/1024;
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info,
             "# Stats\r\n"
@@ -3412,6 +3535,11 @@ sds genRedisInfoString(char *section) {
             "latest_fork_usec:%lld\r\n"
             "migrate_cached_sockets:%ld\r\n"
             "slave_expires_tracked_keys:%zu\r\n"
+            "repl_touch_keys:%llu\r\n"
+            "repl_touch_bytes:%llu\r\n"
+            "instantaneous_repl_kbps:%.2f\r\n"
+            "instantaneous_repl_touch_kbps:%.2f\r\n"
+            "instantaneous_repl_touch_pct:%.2f\r\n"
             "active_defrag_hits:%lld\r\n"
             "active_defrag_misses:%lld\r\n"
             "active_defrag_key_hits:%lld\r\n"
@@ -3438,6 +3566,11 @@ sds genRedisInfoString(char *section) {
             server.stat_fork_time,
             dictSize(server.migrate_cached_sockets),
             getSlaveKeyWithExpireCount(),
+            server.stat_repl_touch_keys,
+            server.stat_repl_touch_bytes,
+            repl_bytes,
+            repl_touch,
+            repl_touch/repl_bytes*100,
             server.stat_active_defrag_hits,
             server.stat_active_defrag_misses,
             server.stat_active_defrag_key_hits,

--- a/src/server.h
+++ b/src/server.h
@@ -166,6 +166,8 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CONFIG_DEFAULT_DEFRAG_CYCLE_MAX 75 /* 75% CPU max (at upper threshold) */
 #define CONFIG_DEFAULT_DEFRAG_MAX_SCAN_FIELDS 1000 /* keys with more than 1000 fields will be processed separately */
 #define CONFIG_DEFAULT_PROTO_MAX_BULK_LEN (512ll*1024*1024) /* Bulk request max size */
+#define CONFIG_DEFAULT_REPL_TOUCH_CMD_RATIO 100 /* Send TOUCH commands to slaves once in every 100 read commands */
+#define CONFIG_DEFAULT_REPL_TOUCH_MAX_RATE (32*1024) /* Maximum TOUCH bytes / sec */
 
 #define ACTIVE_EXPIRE_CYCLE_LOOKUPS_PER_LOOP 20 /* Loopkups per loop. */
 #define ACTIVE_EXPIRE_CYCLE_FAST_DURATION 1000 /* Microseconds */
@@ -178,7 +180,9 @@ typedef long long mstime_t; /* millisecond time type. */
 #define STATS_METRIC_COMMAND 0      /* Number of commands executed. */
 #define STATS_METRIC_NET_INPUT 1    /* Bytes read to network .*/
 #define STATS_METRIC_NET_OUTPUT 2   /* Bytes written to network. */
-#define STATS_METRIC_COUNT 3
+#define STATS_METRIC_REPL_BYTES 3   /* Bytes written to slaves. */
+#define STATS_METRIC_REPL_TOUCH 4   /* Bytes written to slaves for TOUCH cmds. */
+#define STATS_METRIC_COUNT 5
 
 /* Protocol and I/O related defines */
 #define PROTO_MAX_QUERYBUF_LEN  (1024*1024*1024) /* 1GB max query buffer. */
@@ -1000,6 +1004,8 @@ struct redisServer {
     long long stat_evictedkeys;     /* Number of evicted keys (maxmemory) */
     long long stat_keyspace_hits;   /* Number of successful lookups of keys */
     long long stat_keyspace_misses; /* Number of failed lookups of keys */
+    long long stat_repl_touch_keys;         /* total number of touch keys replicated to slaves */
+    long long stat_repl_touch_bytes;        /* total number of touch bytes replicated to slaves */
     long long stat_active_defrag_hits;      /* number of allocations moved */
     long long stat_active_defrag_misses;    /* number of allocations scanned but not moved */
     long long stat_active_defrag_key_hits;  /* number of keys with moved allocations */
@@ -1041,6 +1047,9 @@ struct redisServer {
     int active_defrag_cycle_min;       /* minimal effort for defrag in CPU percentage */
     int active_defrag_cycle_max;       /* maximal effort for defrag in CPU percentage */
     unsigned long active_defrag_max_scan_fields; /* maximum number of fields of set/hash/zset/list to process from within the main dict scan */
+    int repl_touch_cmd_ratio;       /* ratio for sending of TOUCH commands to slaves. (every N read commands) */
+    int repl_touch_max_rate;        /* maximum rate of TOUCH bytes to slaves. (bytes/sec) */
+    int force_repl_lru;             /* force saving LRU to rdb (when noeviction)*/
     size_t client_max_querybuf_len; /* Limit for client query buffer length */
     int dbnum;                      /* Total number of configured DBs */
     int supervised;                 /* 1 if supervised, 0 otherwise. */


### PR DESCRIPTION
Add a mechanism that replicates some of the read commands to the slaves
in order to keep the slave LRU more or less in-sync with the master.
This way, when the slave will be promoted, the LRU/LFU based eviction
will not be based solely on keys that were accessed by write commands.

This commit introduces a mechanism that let's the user control the rate in
which read commands are replicated as TOUCH to slaves, and also metrics to
expose how much of the replication stream is used for TOUCH commands.

This commit also adds a config that forces TOUCH/LRU replication even
in cases where the eviction policy is noeviction.