### PR TITLE
Adding more details on hset and hdel commands

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4194,4 +4194,37 @@ int main(int argc, char **argv) {
     return 0;
 }
 
+
+/**
+ * @authors Hossein Mobashe
+ * @brief publish changed keys in hset command.
+ */
+sds getMapKeyEvent(int argc, robj **argv, int step)
+{
+    int i = 0;
+    size_t size = strlen(argv[1]->ptr) + 1;
+    for (i = 2; i < argc; i += step) {
+        size += strlen(argv[i]->ptr);
+
+        if (i + step != argc) {
+            size ++;
+        }
+    }
+
+    char event[size];
+    memset(event, 0, size);
+    strcat(event, argv[1]->ptr);
+    strcat(event, "#");
+    for (i = 2; i < argc; i += step) {
+        strcat(event, argv[i]->ptr);
+
+        if (i + step != argc) {
+            strcat(event, "|");
+        }
+    }
+
+    sds eventString = sdsnewlen(event, size);
+    return eventString;
+}
+
 /* The End */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -28,8 +28,6 @@
  */
 
 #include "server.h"
-#include <stdio.h>
-#include <stdlib.h>
 #include <math.h>
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION
We are using `Redis` as our cache server to increase performance of processes. We stored some Java's `HashMap` objects as entry's value. We want to monitor all changes that happened in that `HashMap`.

Redis let us to know about the changes of `HashMap`, but don't tell us about the `keys` involved in changes. For example, If we run the `hset mymap myfield myvalue` in `redis-cli`, Redis will tell us `"pmessage","*","__keyevent@0__:hset","mymap"`.

That's not enough for us. Because `mymap` includes too many entries and getting changes has much cost for us. So, we decided to change the event message of notification and you can see the changes.

Best Regards