### PR TITLE
avoid probable unnecessary loop in zslRandomLevel, fixed two typos

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -154,7 +154,7 @@ REDIS_CHECK_AOF_NAME=redis-check-aof
 
 all: $(REDIS_SERVER_NAME) $(REDIS_SENTINEL_NAME) $(REDIS_CLI_NAME) $(REDIS_BENCHMARK_NAME) $(REDIS_CHECK_RDB_NAME) $(REDIS_CHECK_AOF_NAME)
 	@echo ""
-	@echo "Hint: It's a good idea to run 'make test' ;)"
+	@echo "Hint: It's a good idea to run 'make test' :)"
 	@echo ""
 
 Makefile.dep:

--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -1,7 +1,7 @@
 /* This file implements atomic counters using __atomic or __sync macros if
  * available, otherwise synchronizing different threads using a mutex.
  *
- * The exported interaface is composed of three macros:
+ * The exported interface is composed of three macros:
  *
  * atomicIncr(var,count) -- Increment the atomic counter
  * atomicGetIncr(var,oldvalue_var,count) -- Get and increment the atomic counter

--- a/src/intset.c
+++ b/src/intset.c
@@ -123,7 +123,7 @@ static uint8_t intsetSearch(intset *is, int64_t value, uint32_t *pos) {
     } else {
         /* Check for the case where we know we cannot find the value,
          * but do know the insert position. */
-        if (value > _intsetGet(is,intrev32ifbe(is->length)-1)) {
+        if (value > _intsetGet(is,max)) {
             if (pos) *pos = intrev32ifbe(is->length);
             return 0;
         } else if (value < _intsetGet(is,0)) {

--- a/src/lzf_c.c
+++ b/src/lzf_c.c
@@ -42,7 +42,7 @@
  * don't play with this unless you benchmark!
  * the data format is not dependent on the hash function.
  * the hash function might seem strange, just believe me,
- * it works ;)
+ * it works :)
  */
 #ifndef FRST
 # define FRST(p) (((p[0]) << 8) | p[1])

--- a/src/object.c
+++ b/src/object.c
@@ -185,7 +185,7 @@ robj *createStringObjectFromLongDouble(long double value, int humanfriendly) {
 /* Duplicate a string object, with the guarantee that the returned object
  * has the same encoding as the original one.
  *
- * This function also guarantees that duplicating a small integere object
+ * This function also guarantees that duplicating a small integer object
  * (or a string object that contains a representation of a small integer)
  * will always result in a fresh object that is unshared (refcount == 1).
  *

--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -40,7 +40,7 @@
  * container: 2 bits, NONE=1, ZIPLIST=2.
  * recompress: 1 bit, bool, true if node is temporarry decompressed for usage.
  * attempted_compress: 1 bit, boolean, used for verifying during testing.
- * extra: 12 bits, free for future use; pads out the remainder of 32 bits */
+ * extra: 10 bits, free for future use; pads out the remainder of 32 bits */
 typedef struct quicklistNode {
     struct quicklistNode *prev;
     struct quicklistNode *next;

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -65,7 +65,7 @@ static int checkStringLength(client *c, long long size) {
 #define OBJ_SET_PX (1<<3)     /* Set if time in ms in given */
 
 void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire, int unit, robj *ok_reply, robj *abort_reply) {
-    long long milliseconds = 0; /* initialized to avoid any harmness warning */
+    long long milliseconds = 0; /* initialized to avoid any harmless warning */
 
     if (expire) {
         if (getLongLongFromObjectOrReply(c, expire, &milliseconds, NULL) != C_OK)

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -313,7 +313,7 @@ void msetGenericCommand(client *c, int nx) {
         for (j = 1; j < c->argc; j += 2) {
             if (lookupKeyWrite(c->db,c->argv[j]) != NULL) {
                 busykeys++;
-                
+                break;
             }
         }
         if (busykeys) {

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -313,6 +313,7 @@ void msetGenericCommand(client *c, int nx) {
         for (j = 1; j < c->argc; j += 2) {
             if (lookupKeyWrite(c->db,c->argv[j]) != NULL) {
                 busykeys++;
+                
             }
         }
         if (busykeys) {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -121,9 +121,9 @@ void zslFree(zskiplist *zsl) {
  * levels are less likely to be returned. */
 int zslRandomLevel(void) {
     int level = 1;
-    while ((random()&0xFFFF) < (ZSKIPLIST_P * 0xFFFF))
+    while (level < ZSKIPLIST_MAXLEVEL && (random()&0xFFFF) < (ZSKIPLIST_P * 0xFFFF))
         level += 1;
-    return (level<ZSKIPLIST_MAXLEVEL) ? level : ZSKIPLIST_MAXLEVEL;
+    return level;
 }
 
 /* Insert a new node in the skiplist. Assumes the element does not already


### PR DESCRIPTION
the zslRandomLevel fuction may cause unnecessary loop, changed it so it only loops for at most ZSKIPLIST_MAXLEVEL times;

fixed two :) emoticon typos