### PR TITLE
Bugfix data inconsistency after aof rewrite, and add XSTREAM command.

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1121,23 +1121,39 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
     streamID id;
     int64_t numfields;
 
-    /* Reconstruct the stream data using XADD commands. */
-    while(streamIteratorGetID(&si,&id,&numfields)) {
-        /* Emit a two elements array for each item. The first is
-         * the ID, the second is an array of field-value pairs. */
+    if (s->length) {
+        /* Reconstruct the stream data using XADD commands. */
+        while(streamIteratorGetID(&si,&id,&numfields)) {
+            /* Emit a two elements array for each item. The first is
+             * the ID, the second is an array of field-value pairs. */
 
-        /* Emit the XADD <key> <id> ...fields... command. */
-        if (rioWriteBulkCount(r,'*',3+numfields*2) == 0) return 0;
-        if (rioWriteBulkString(r,"XADD",4) == 0) return 0;
-        if (rioWriteBulkObject(r,key) == 0) return 0;
-        if (rioWriteBulkStreamID(r,&id) == 0) return 0;
-        while(numfields--) {
-            unsigned char *field, *value;
-            int64_t field_len, value_len;
-            streamIteratorGetField(&si,&field,&value,&field_len,&value_len);
-            if (rioWriteBulkString(r,(char*)field,field_len) == 0) return 0;
-            if (rioWriteBulkString(r,(char*)value,value_len) == 0) return 0;
+            /* Emit the XADD <key> <id> ...fields... command. */
+            if (rioWriteBulkCount(r,'*',3+numfields*2) == 0) return 0;
+            if (rioWriteBulkString(r,"XADD",4) == 0) return 0;
+            if (rioWriteBulkObject(r,key) == 0) return 0;
+            if (rioWriteBulkStreamID(r,&id) == 0) return 0;
+            while(numfields--) {
+                unsigned char *field, *value;
+                int64_t field_len, value_len;
+                streamIteratorGetField(&si,&field,&value,&field_len,&value_len);
+                if (rioWriteBulkString(r,(char*)field,field_len) == 0) return 0;
+                if (rioWriteBulkString(r,(char*)value,value_len) == 0) return 0;
+            }
         }
+        /* Append XSTREAM SETID after XADD, make sure lastid is correct,
+         * in case of XDEL lastid. */
+        if (rioWriteBulkCount(r,'*',4) == 0) return 0;
+        if (rioWriteBulkString(r,"XSTREAM",7) == 0) return 0;
+        if (rioWriteBulkString(r,"SETID",5) == 0) return 0;
+        if (rioWriteBulkObject(r,key) == 0) return 0;
+        if (rioWriteBulkStreamID(r,&s->last_id) == 0) return 0;
+    } else {
+        /* Using XSTREAM CREATE if the stream is empty. */
+        if (rioWriteBulkCount(r,'*',4) == 0) return 0;
+        if (rioWriteBulkString(r,"XSTREAM",7) == 0) return 0;
+        if (rioWriteBulkString(r,"CREATE",6) == 0) return 0;
+        if (rioWriteBulkObject(r,key) == 0) return 0;
+        if (rioWriteBulkStreamID(r,&s->last_id) == 0) return 0;
     }
 
     /* Create all the stream consumer groups. */

--- a/src/server.c
+++ b/src/server.c
@@ -314,6 +314,7 @@ struct redisCommand redisCommandTable[] = {
     {"xread",xreadCommand,-4,"rs",0,xreadGetKeys,1,1,1,0,0},
     {"xreadgroup",xreadCommand,-7,"ws",0,xreadGetKeys,1,1,1,0,0},
     {"xgroup",xgroupCommand,-2,"wm",0,NULL,2,2,1,0,0},
+    {"xstream",xstreamCommand,-2,"wmFR",0,NULL,2,2,1,0,0},
     {"xack",xackCommand,-4,"wF",0,NULL,1,1,1,0,0},
     {"xpending",xpendingCommand,-3,"r",0,NULL,1,1,1,0,0},
     {"xclaim",xclaimCommand,-6,"wF",0,NULL,1,1,1,0,0},

--- a/src/server.h
+++ b/src/server.h
@@ -2107,6 +2107,7 @@ void xrevrangeCommand(client *c);
 void xlenCommand(client *c);
 void xreadCommand(client *c);
 void xgroupCommand(client *c);
+void xstreamCommand(client *c);
 void xackCommand(client *c);
 void xpendingCommand(client *c);
 void xclaimCommand(client *c);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1746,6 +1746,71 @@ NULL
     }
 }
 
+/* XSTREAM CREATE <key> <id or *>
+ * XSTREAM SETID <key> <id or $> */
+void xstreamCommand(client *c) {
+    const char *help[] = {
+"CREATE <key> <id or *>  -- Create a new empty stream.",
+"SETID  <key> <id or $>  -- Set the current stream ID.",
+"HELP                    -- Prints this help.",
+NULL
+    };
+    stream *s = NULL;
+    char *opt = c->argv[1]->ptr; /* Subcommand name. */
+
+    /* Dispatch the different subcommands. */
+    if (!strcasecmp(opt,"CREATE") && c->argc == 4) {
+        robj *o = lookupKeyWrite(c->db,c->argv[2]);
+        if (o) {
+            addReplySds(c,
+                sdsnew("-BUSYSTREAM Stream already exists\r\n"));
+            return;
+        } else {
+            streamID id;
+            if (!strcmp(c->argv[3]->ptr,"*")) {
+                id.ms = mstime();
+                id.seq = 0;
+            } else if (streamParseStrictIDOrReply(c,c->argv[3],&id,0) != C_OK) {
+                return;
+            }
+
+            o = createStreamObject();
+            s = o->ptr;
+            s->last_id = id;
+            dbAdd(c->db,c->argv[2],o);
+
+            addReply(c,shared.ok);
+            server.dirty++;
+            notifyKeyspaceEvent(NOTIFY_STREAM,"xstream-create",
+                                c->argv[2],c->db->id);
+        }
+    } else if (!strcasecmp(opt,"SETID") && c->argc == 4) {
+        robj *o = lookupKeyWriteOrReply(c,c->argv[2],shared.nokeyerr);
+        if (o == NULL || checkType(c,o,OBJ_STREAM)) return;
+        s = o->ptr;
+        streamID id;
+        if (!strcmp(c->argv[3]->ptr,"$")) {
+            id = s->last_id;
+        } else if (streamParseStrictIDOrReply(c,c->argv[3],&id,0) != C_OK) {
+            return;
+        }
+        if (streamCompareID(&id,&s->last_id) < 0) {
+            addReplyError(c,"The ID specified in XSTREAM SETID is smaller than the "
+                            "target stream top item");
+            return;
+        }
+        s->last_id = id;
+        addReply(c,shared.ok);
+        server.dirty++;
+        notifyKeyspaceEvent(NOTIFY_STREAM,"xstream-setid",
+                            c->argv[2],c->db->id);
+    } else if (!strcasecmp(opt,"HELP")) {
+        addReplyHelp(c, help);
+    } else {
+        addReplySubcommandSyntaxError(c);
+    }
+}
+
 /* XACK <key> <group> <id> <id> ... <id>
  *
  * Acknowledge a message as processed. In practical terms we just check the

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1779,6 +1779,10 @@ NULL
             s->last_id = id;
             dbAdd(c->db,c->argv[2],o);
 
+            robj *idarg = createObjectFromStreamID(&id);
+            rewriteClientCommandArgument(c,3,idarg);
+            decrRefCount(idarg);
+
             addReply(c,shared.ok);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM,"xstream-create",


### PR DESCRIPTION
Bug report:

1. After aofrewrite, empty stream cannot be rewritten into AOF even it has consumer groups.
2. After xdel last id and aofrewrite, stream's last id will be incorrect.

Bug located:

```c
    /* Reconstruct the stream data using XADD commands. */
    while(streamIteratorGetID(&si,&id,&numfields)) {
        /* Emit a two elements array for each item. The first is
         * the ID, the second is an array of field-value pairs. */
         /* Emit the XADD <key> <id> ...fields... command. */
        if (rioWriteBulkCount(r,'*',3+numfields*2) == 0) return 0;
        if (rioWriteBulkString(r,"XADD",4) == 0) return 0;
        if (rioWriteBulkObject(r,key) == 0) return 0;
        if (rioWriteBulkStreamID(r,&id) == 0) return 0;
```

We can see that empty stream cannot go into the loop, and `lastid` is the last entry not last generated id.

To fix these, I added a new command `XSTREAM` with subcommands `CREATE` to create empty stream and `SETID` to set last-generated-id.

Please check @antirez .