### PR TITLE
Fixing issue #4592 by loading node info before running move_slot, whi…

### DIFF
--- a/src/redis-trib.rb
+++ b/src/redis-trib.rb
@@ -1084,6 +1084,8 @@ class RedisTrib
         # Set the new node as the owner of the slot in all the known nodes.
         if !o[:cold]
             @nodes.each{|n|
+                # Load node info in case this node became a slave before the slot could be moved.
+                n.load_info
                 next if n.has_flag?("slave")
                 n.r.cluster("setslot",slot,"node",target.info[:name])
             }


### PR DESCRIPTION
See https://github.com/antirez/redis/issues/4592

We discovered that there is a small chance that a rebalance will fail because one of the cluster nodes becomes a slave while slots are being moved. This is magnified when many rebalances need to occur back to back (autoscaling up/down)

We've been using the following fix, which loads node info before the move_slot command is run, allowing it to be skipped if the node became a slave before the rebalance was complete.