### PR TITLE
Fix xclaim

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2138,7 +2138,8 @@ void xclaimCommand(client *c) {
     for (int j = 5; j <= last_id_arg; j++) {
         streamID id;
         unsigned char buf[sizeof(streamID)];
-        if (streamParseStrictIDOrReply(c,c->argv[j],&id,0) != C_OK) return;
+        if (streamParseStrictIDOrReply(c,c->argv[j],&id,0) != C_OK)
+            serverPanic("StreamID invalid after check. Should not be possible.");
         streamEncodeID(buf,&id);
 
         /* Lookup the ID in the group PEL. */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2192,7 +2192,7 @@ void xclaimCommand(client *c) {
             arraylen++;
 
             /* Propagate this change. */
-            streamPropagateXCLAIM(c,c->argv[1],group,c->argv[3],c->argv[j],nack);
+            streamPropagateXCLAIM(c,c->argv[1],group,c->argv[2],c->argv[j],nack);
             server.dirty++;
         }
     }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2165,8 +2165,10 @@ void xclaimCommand(client *c) {
 
         if (nack != raxNotFound) {
             /* We need to check if the minimum idle time requested
-             * by the caller is satisfied by this entry. */
-            if (minidle) {
+             * by the caller is satisfied by this entry.
+             * Note that if nack->consumer is NULL, means the NACK
+             * is created by FORCE, we should ignore minidle. */
+            if (nack->consumer && minidle) {
                 mstime_t this_idle = now - nack->delivery_time;
                 if (this_idle < minidle) continue;
             }


### PR DESCRIPTION
1. First, as your comment

    ```c
            /* Technically it could be more correct to update that only after
             * checking for syntax errors, but this option is only used by
             * the replication command that outputs correct syntax. */
    ```

    I know updating `LASTID` is only used by replication, but we cannot prevent user from doing it, so I still believe we should update it after checking.

2. If `XCLAIM` didn't claim any stream entry but did update `LASTID`, this update cannot be propagated.

3. argv in `streamPropagateXCLAIM` should be `group name` not `consumer name`.

4. `XCALIM` should ignore `minidle` if NACK is created by `FORCE`

    Because the NACK created by `FORCE` consumer is NULL, if idletime < minidle the NACK does not belong to any consumer, then redis will crash in `XPENDING`.

Please check @antirez .