### PR TITLE
Overhead is the allocated size of the AOF buffer, not its length

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -364,7 +364,7 @@ size_t freeMemoryGetNotCountedMemory(void) {
         }
     }
     if (server.aof_state != AOF_OFF) {
-        overhead += sdslen(server.aof_buf)+aofRewriteBufferSize();
+        overhead += sdsalloc(server.aof_buf)+aofRewriteBufferSize();
     }
     return overhead;
 }

--- a/src/object.c
+++ b/src/object.c
@@ -1011,7 +1011,7 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
 
     mem = 0;
     if (server.aof_state != AOF_OFF) {
-        mem += sdslen(server.aof_buf);
+        mem += sdsalloc(server.aof_buf);
         mem += aofRewriteBufferSize();
     }
     mh->aof_buffer = mem;


### PR DESCRIPTION
`freeMemoryGetNotCountedMemory()` uses `sdslen(server.aof_buf)` when trying to remove memory that is not used as part of the main database, where it should use `sdsalloc` instead. This causes AOF to induce eviction although it is unecessary, and could end up resulting in OOM errors being returned to the client if there is not enough evictable keys available.

We were trying to debug why Redis was returning a OOM error on a write spike on a old 3.2.11 server with AOF enabled, and code review led us to this. We haven't confirmed that it solves the problem. I'm uploading this for discussion.