### PR TITLE
MULTI: OOM err if cannot free enough memory in MULTI/EXEC context

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2619,8 +2619,11 @@ int processCommand(client *c) {
         if (server.current_client == NULL) return C_ERR;
 
         /* It was impossible to free enough memory, and the command the client
-         * is trying to execute is denied during OOM conditions? Error. */
-        if ((c->cmd->flags & CMD_DENYOOM) && out_of_memory) {
+         * is trying to execute is denied during OOM conditions or the client
+         * is in MULTI/EXEC context? Error. */
+        if (out_of_memory &&
+            (c->cmd->flags & CMD_DENYOOM ||
+             (c->flags & CLIENT_MULTI && c->cmd->proc != execCommand))) {
             flagTransaction(c);
             addReply(c, shared.oomerr);
             return C_OK;


### PR DESCRIPTION
Hi @antirez , I think we should just return OOM error if it is impossible to free enough memory and the client is in MULT/EXEC context, because `queueMultiCommand` holds the args memory, moreover `used_memory` can grow unlimited.