### PR TITLE
A fix to XPENDING's count underflow

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1892,7 +1892,7 @@ void xackCommand(client *c) {
     addReplyLongLong(c,acknowledged);
 }
 
-/* XPENDING <key> <group> [<start> <stop> <count>] [<consumer>]
+/* XPENDING <key> <group> [<start> <stop> <count> [<consumer>]]
  *
  * If start and stop are omitted, the command just outputs information about
  * the amount of pending messages for the key/group pair, together with

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1921,6 +1921,7 @@ void xpendingCommand(client *c) {
     if (c->argc >= 6) {
         if (getLongLongFromObjectOrReply(c,c->argv[5],&count,NULL) == C_ERR)
             return;
+        if (count < 0) count = 0;
         if (streamParseIDOrReply(c,c->argv[3],&startid,0) == C_ERR)
             return;
         if (streamParseIDOrReply(c,c->argv[4],&endid,UINT64_MAX) == C_ERR)


### PR DESCRIPTION
This fix is important, but I feel it isn't complete yet.

Currently, with the fix, passing 0 or a negative count will return 0 results. However, other "COUNT" arguments in Redis behave differently. Specifically, `X[REV]RANGE` will treat such counts as "all".

@antirez - what would be the way to resolve this?
1. Leave as is (i.e. inconsistent behavior)
2. Document XRANGE's count behavior, and make XPENDING behave the same
3. Make XRANGE return 0 results for such counts

Also, @RoeyPrat found about the error in the documented syntax so if it makes sense I'll try to do a matching PR to the docs.