### PR TITLE
Return non-zero exit code from redis-cli when run in non-REPL mode

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1066,6 +1066,10 @@ static int cliReadReply(int output_raw_strings) {
                 out = sdscat(out,"\n");
             }
         }
+        if (reply->type == REDIS_REPLY_ERROR && !config.interactive) {
+            fwrite(out,sdslen(out),1,stderr);
+            exit(1);
+        }
         fwrite(out,sdslen(out),1,stdout);
         sdsfree(out);
     }


### PR DESCRIPTION
Fixes #5458, but definitely breaks backward "compatibility" although undocumented and apparently wrong. Should be considered for backporting :)

Signed-off-by: Itamar Haber <itamar@redislabs.com>