### PR TITLE
Fix a prototype inconsitency of `_serverAssert` between redisassert.h  and redis.h

### DIFF
--- a/src/redisassert.h
+++ b/src/redisassert.h
@@ -43,7 +43,7 @@
 #define assert(_e) ((_e)?(void)0 : (_serverAssert(#_e,__FILE__,__LINE__),_exit(1)))
 #define panic(...) _serverPanic(__FILE__,__LINE__,__VA_ARGS__),_exit(1)
 
-void _serverAssert(char *estr, char *file, int line);
+void _serverAssert(const char *estr, const char *file, int line);
 void _serverPanic(const char *file, int line, const char *msg, ...);
 
 #endif


### PR DESCRIPTION
It causes compilation error when includes both include files from single file.