### PR TITLE
Provides simple multiplatform memory clearance.

### DIFF
--- a/src/sha1.c
+++ b/src/sha1.c
@@ -26,6 +26,7 @@ A million repetitions of "a"
 #include <stdint.h>
 #include "solarisfixes.h"
 #include "sha1.h"
+#include "zmalloc.h"
 #include "config.h"
 
 #define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))
@@ -192,8 +193,8 @@ void SHA1Final(unsigned char digest[20], SHA1_CTX* context)
          ((context->state[i>>2] >> ((3-(i & 3)) * 8) ) & 255);
     }
     /* Wipe variables */
-    memset(context, '\0', sizeof(*context));
-    memset(&finalcount, '\0', sizeof(finalcount));
+    zbzero(context, sizeof(*context));
+    zbzero(&finalcount, sizeof(finalcount));
 }
 /* ================ end of sha1.c ================ */
 

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -205,6 +205,13 @@ void zfree(void *ptr) {
 #endif
 }
 
+void zbzero(void *ptr, size_t size) {
+    size_t i;
+    volatile unsigned char *p = (volatile unsigned char *)ptr;
+
+    for(i = 0; i < size; i ++) p[i] = '\0';
+}
+
 char *zstrdup(const char *s) {
     size_t l = strlen(s)+1;
     char *p = zmalloc(l);

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -81,6 +81,7 @@ void *zmalloc(size_t size);
 void *zcalloc(size_t size);
 void *zrealloc(void *ptr, size_t size);
 void zfree(void *ptr);
+void zbzero(void *ptr, size_t size);
 char *zstrdup(const char *s);
 size_t zmalloc_used_memory(void);
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t));


### PR DESCRIPTION
Depending on compiler optimisations, memset might not suffice
to guarantee hashing context's clearance.