### PR TITLE
Fix a mistake in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -441,7 +441,7 @@ repl-disable-tcp-nodelay no
 replica-priority 100
 
 # It is possible for a master to stop accepting writes if there are less than
-# N replicas connected, having a lag less or equal than M seconds.
+# N replicas connected, having a lag greater or equal than M seconds.
 #
 # The N replicas need to be in "online" state.
 #


### PR DESCRIPTION
After we set the `min-replicas-to-write` and `min-replicas-max-lag`,   the  master can stop accepting writes if there are less than `min-replicas-to-write` replicas connected, having a lag greater or equal than `min-replicas-max-lag` seconds