### PR TITLE
[Feature] Add disk IO & network IO speed control for master send rdb to slave

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -135,6 +135,7 @@ client *createClient(int fd) {
     c->slave_capa = SLAVE_CAPA_NONE;
     c->reply = listCreate();
     c->reply_bytes = 0;
+    c->last_send_bulk_time = 0;
     c->obuf_soft_limit_reached_time = 0;
     listSetFreeMethod(c->reply,freeClientReplyValue);
     listSetDupMethod(c->reply,dupClientReplyValue);

--- a/src/server.c
+++ b/src/server.c
@@ -1665,6 +1665,7 @@ void initServerConfig(void) {
     server.slave_announce_ip = CONFIG_DEFAULT_SLAVE_ANNOUNCE_IP;
     server.slave_announce_port = CONFIG_DEFAULT_SLAVE_ANNOUNCE_PORT;
     server.master_repl_offset = 0;
+    server.max_send_bulk_rate = CONFIG_DEFAULT_MAX_SEND_BULK_RATE;
 
     /* Replication partial resync backlog */
     server.repl_backlog = NULL;

--- a/src/server.h
+++ b/src/server.h
@@ -100,6 +100,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define AOF_READ_DIFF_INTERVAL_BYTES (1024*10)
 #define CONFIG_DEFAULT_SLOWLOG_LOG_SLOWER_THAN 10000
 #define CONFIG_DEFAULT_SLOWLOG_MAX_LEN 128
+#define CONFIG_DEFAULT_MAX_SEND_BULK_RATE 0
 #define CONFIG_DEFAULT_MAX_CLIENTS 10000
 #define CONFIG_AUTHPASS_MAX_LEN 512
 #define CONFIG_DEFAULT_SLAVE_PRIORITY 100
@@ -746,6 +747,7 @@ typedef struct client {
     long long psync_initial_offset; /* FULLRESYNC reply offset other slaves
                                        copying this slave output buffer
                                        should use. */
+    long long last_send_bulk_time;      /* Last send bulk to slave time(ms) */
     char replid[CONFIG_RUN_ID_SIZE+1]; /* Master replication ID (if master). */
     int slave_listening_port; /* As configured with: SLAVECONF listening-port */
     char slave_ip[NET_IP_STR_LEN]; /* Optionally given by REPLCONF ip-address */
@@ -1021,6 +1023,7 @@ struct redisServer {
     struct malloc_stats cron_malloc_stats; /* sampled in serverCron(). */
     long long stat_net_input_bytes; /* Bytes read from network. */
     long long stat_net_output_bytes; /* Bytes written to network. */
+    int max_send_bulk_rate;             /* Bytes write to network limit, unit is bytes/sec */
     size_t stat_rdb_cow_bytes;      /* Copy on write bytes during RDB saving. */
     size_t stat_aof_cow_bytes;      /* Copy on write bytes during AOF rewrite. */
     /* The following two are used to track instantaneous metrics, like


### PR DESCRIPTION
relative issue: https://github.com/antirez/redis/issues/5501
add a config "max-send-bulk-rate" (unit is bytes/second) to limit master send rdb to slave