### PR TITLE
Use typedef'd mstime_t instead of time_t

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2155,7 +2155,7 @@ void xclaimCommand(client *c) {
 
     /* If we stopped because some IDs cannot be parsed, perhaps they
      * are trailing options. */
-    time_t now = mstime();
+    mstime_t now = mstime();
     streamID last_id = {0,0};
     int propagate_last_id = 0;
     for (; j < c->argc; j++) {


### PR DESCRIPTION
This fixes an overflow on 32-bit systems.

Reproduce like so:
```bash
redis-cli flushdb
xadd s * field value /* returns <id1> */
redis-cli xgroup create s group1 0
redis-cli xadd s * field value /* returns <id2> */
redis-cli xreadgroup GROUP group1 Mike STREAMS s 0 /* Returns 2 messages */

# Claim a message and then issue XPENDING
redis-cli xclaim s group1 Antirez 0 <id1> <id2>
redis-cli xpending s group1 0 + 1 Antirez

1) 1) "1541284058948-0"
   2) "Antirez"
   3) (integer) 1541893270887 /* Wrong time when sizeof(time_t) == 4 */
   4) (integer) 1
```