### PR TITLE
Cluster manager fix cmd

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3833,7 +3833,7 @@ static int clusterManagerFixOpenSlot(int slot) {
         while ((ln = listNext(&li)) != NULL) {
             clusterManagerNode *n = ln->value;
             if (n == owner) continue;
-            reply = CLUSTER_MANAGER_COMMAND(n, "CLUSTER DELSLOT %d", slot);
+            reply = CLUSTER_MANAGER_COMMAND(n, "CLUSTER DELSLOTS %d", slot);
             success = clusterManagerCheckRedisReply(n, reply, NULL);
             if (reply) freeReplyObject(reply);
             if (!success) goto cleanup;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3307,8 +3307,8 @@ static sds clusterManagerGetConfigSignature(clusterManagerNode *node) {
                 nodename = token;
                 tot_size = (p - token);
                 name_len = tot_size++; // Make room for ':' in tot_size
-            } else if (i == 8) break;
-            i++;
+            }
+            if (++i == 8) break;
         }
         if (i != 8) continue;
         if (nodename == NULL) continue;
@@ -3347,7 +3347,7 @@ static sds clusterManagerGetConfigSignature(clusterManagerNode *node) {
             char *sp = cfg + name_len;
             *(sp++) = ':';
             for (i = 0; i < c; i++) {
-                if (i > 0) *(sp++) = '|';
+                if (i > 0) *(sp++) = ',';
                 int slen = strlen(slots[i]);
                 memcpy(sp, slots[i], slen);
                 sp += slen;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3749,7 +3749,7 @@ static int clusterManagerFixOpenSlot(int slot) {
     clusterManagerLogInfo(">>> Fixing open slot %d\n", slot);
     /* Try to obtain the current slot owner, according to the current
      * nodes configuration. */
-    int success = 1, keys_in_multiple_nodes = 0;
+    int success = 1;
     list *owners = listCreate();
     list *migrating = listCreate();
     list *importing = listCreate();
@@ -3772,7 +3772,6 @@ static int clusterManagerFixOpenSlot(int slot) {
                                       "in non-owner node %s:%d!\n", slot,
                                       n->ip, n->port);
                 listAddNodeTail(owners, n);
-                keys_in_multiple_nodes = 1;
             }
             if (r) freeReplyObject(r);
             if (!success) goto cleanup;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3775,7 +3775,7 @@ static int clusterManagerFixOpenSlot(int slot) {
     }
     printf("Set as migrating in: %s\n", migrating_str);
     printf("Set as importing in: %s\n", importing_str);
-    /* If there is no slot owner, set as owner the slot with the biggest
+    /* If there is no slot owner, set as owner the node with the biggest
      * number of keys, among the set of migrating / importing nodes. */
     if (owner == NULL) {
         clusterManagerLogInfo(">>> Nobody claims ownership, "
@@ -3848,8 +3848,8 @@ static int clusterManagerFixOpenSlot(int slot) {
         if (!success) goto cleanup;
     }
     int move_opts = CLUSTER_MANAGER_OPT_VERBOSE;
-    /* Case 1: The slot is in migrating state in one slot, and in
-     *         importing state in 1 slot. That's trivial to address. */
+    /* Case 1: The slot is in migrating state in one node, and in
+     *         importing state in 1 node. That's trivial to address. */
     if (listLength(migrating) == 1 && listLength(importing) == 1) {
         clusterManagerNode *src = listFirst(migrating)->value;
         clusterManagerNode *dst = listFirst(importing)->value;


### PR DESCRIPTION
This PR tries to improve the "fix" subcommand of redis-cli's cluster manager, by trying to cover more situations.

More specifically:

- Fix Open Slot: it now checks if there are non-owner nodes that for some reason could have keys for the open slot, and it considers them to be "owners". These nodes are then set to importing state and finally they migrate keys to the "owner" node (the node having more keys related to the slot).
- Fix Open Slot: it also fixes nodes that for some reason could remain in "migrating" state and that are owner of the slot.
- Fix Open Slots/Fix Slots Coverage: it now set the slot to unassigned state on the owner itself before assigning it, in order to avoid errors due to the fact that the owner has already assigned the slot to another node. It also ensure that the other nodes are always updated so that they assign the slot to the new owner.
- Move Slot: it now checks for "slot not served" error and retries to move the slot after assigning it to the target node.

Thanks to @funny-falcon for having reported many uncovered situations in his PR [#5270](https://github.com/antirez/redis/pull/5270).