### PR TITLE
maybe a bug in sds.c  sdsrange() function？

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -752,7 +752,7 @@ void sdsrange(sds s, ssize_t start, ssize_t end) {
         start = 0;
     }
     if (start && newlen) memmove(s, s+start, newlen);
-    s[newlen] = 0;
+    s[newlen] = '\0';
     sdssetlen(s,newlen);
 }
 


### PR DESCRIPTION
```
if (start && newlen) memmove(s, s+start, newlen);
    s[newlen] = 0;
```
I think it should be `s[newlen] = '\0'`;