### PR TITLE
add ESCAN command to scan keys with expire

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -235,6 +235,7 @@ struct redisCommand redisCommandTable[] = {
     {"pexpireat",pexpireatCommand,3,"wF",0,NULL,1,1,1,0,0},
     {"keys",keysCommand,2,"rS",0,NULL,0,0,0,0,0},
     {"scan",scanCommand,-2,"rR",0,NULL,0,0,0,0,0},
+    {"escan",scanCommand,-2,"rR",0,NULL,0,0,0,0,0},
     {"dbsize",dbsizeCommand,1,"rF",0,NULL,0,0,0,0,0},
     {"auth",authCommand,2,"sltF",0,NULL,0,0,0,0,0},
     {"ping",pingCommand,-1,"tF",0,NULL,0,0,0,0,0},


### PR DESCRIPTION
The result contains keys and expire time in millisecond,
like that:

```
127.0.0.1:6379> escan 0
1) "0"
2) 1) "foo"
   2) "1541669049316"
```

And ESCAN only scans expires dict, so it's more efficient
than using SCAN to evict expired keys.