### PR TITLE
fix redis-cli prompt

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -614,8 +614,10 @@ error:
  * (matches for ":"), the ip is surrounded by []. IP and port are just
  * separated by colons. This the standard to display addresses within Redis. */
 int anetFormatAddr(char *buf, size_t buf_len, char *ip, int port) {
+    char _port[6];  /* strlen("65535") */
+    snprintf(_port, 6, "%d", port);
     return snprintf(buf,buf_len, strchr(ip,':') ?
-           "[%s]:%d" : "%s:%d", ip, port);
+           "[%s]:%s" : "%s:%s", ip, _port);
 }
 
 /* Like anetFormatAddr() but extract ip and port from the socket's peer. */


### PR DESCRIPTION
When port lengh is bigger thant strlen("65535"), redis-cli prompt seems wrong.
I started a server with port 30001，and connect it with "redis-cli -p 300010000"，while the prompt is "127.0.0.1:300010000>". 
I think it should be "127.0.0.1:30001".