### PR TITLE
[Feature] Forkless replication: use aof to FULLRESYNC replication instead of rdb 

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -826,8 +826,10 @@ loaded_ok: /* DB loaded, cleanup and return C_OK to the caller. */
     freeFakeClient(fakeClient);
     server.aof_state = old_aof_state;
     stopLoading();
-    aofUpdateCurrentSize();
-    server.aof_rewrite_base_size = server.aof_current_size;
+    if (server.aof_state == AOF_ON) {
+        aofUpdateCurrentSize();
+        server.aof_rewrite_base_size = server.aof_current_size;
+    }
     return C_OK;
 
 readerr: /* Read error. If feof(fp) is true, fall through to unexpected EOF. */

--- a/src/config.c
+++ b/src/config.c
@@ -379,6 +379,10 @@ void loadServerConfigFromString(char *config) {
                 err = "repl-diskless-sync-delay can't be negative";
                 goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"repl-aof-sync") && argc==2) {
+            if ((server.repl_aof_sync = yesnotoi(argv[1])) == -1) {
+                err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
         } else if (!strcasecmp(argv[0],"repl-backlog-size") && argc == 2) {
             long long size = memtoll(argv[1],NULL);
             if (size <= 0) {
@@ -1071,6 +1075,8 @@ void configSetCommand(client *c) {
     } config_set_bool_field(
       "repl-diskless-sync",server.repl_diskless_sync) {
     } config_set_bool_field(
+      "repl-aof-sync",server.repl_aof_sync) {
+    } config_set_bool_field(
       "cluster-require-full-coverage",server.cluster_require_full_coverage) {
     } config_set_bool_field(
       "cluster-slave-no-failover",server.cluster_slave_no_failover) {
@@ -1447,6 +1453,8 @@ void configGetCommand(client *c) {
             server.repl_disable_tcp_nodelay);
     config_get_bool_field("repl-diskless-sync",
             server.repl_diskless_sync);
+    config_get_bool_field("repl-aof-sync",
+            server.repl_aof_sync);
     config_get_bool_field("aof-rewrite-incremental-fsync",
             server.aof_rewrite_incremental_fsync);
     config_get_bool_field("rdb-save-incremental-fsync",
@@ -2157,6 +2165,7 @@ int rewriteConfig(char *path) {
     rewriteConfigBytesOption(state,"repl-backlog-ttl",server.repl_backlog_time_limit,CONFIG_DEFAULT_REPL_BACKLOG_TIME_LIMIT);
     rewriteConfigYesNoOption(state,"repl-disable-tcp-nodelay",server.repl_disable_tcp_nodelay,CONFIG_DEFAULT_REPL_DISABLE_TCP_NODELAY);
     rewriteConfigYesNoOption(state,"repl-diskless-sync",server.repl_diskless_sync,CONFIG_DEFAULT_REPL_DISKLESS_SYNC);
+    rewriteConfigYesNoOption(state,"repl-aof-sync",server.repl_aof_sync,CONFIG_DEFAULT_REPL_AOF_SYNC);
     rewriteConfigNumericalOption(state,"repl-diskless-sync-delay",server.repl_diskless_sync_delay,CONFIG_DEFAULT_REPL_DISKLESS_SYNC_DELAY);
     rewriteConfigNumericalOption(state,"replica-priority",server.slave_priority,CONFIG_DEFAULT_SLAVE_PRIORITY);
     rewriteConfigNumericalOption(state,"min-replicas-to-write",server.repl_min_slaves_to_write,CONFIG_DEFAULT_MIN_SLAVES_TO_WRITE);

--- a/src/replication.c
+++ b/src/replication.c
@@ -576,8 +576,10 @@ int startBgsaveForReplication(int mincapa) {
     if (rsiptr) {
         if (socket_target)
             retval = rdbSaveToSlavesSockets(rsiptr);
-        else
+        else if (!server.repl_aof_sync)
             retval = rdbSaveBackground(server.rdb_filename,rsiptr);
+        else 
+            retval = C_OK;
     } else {
         serverLog(LL_WARNING,"BGSAVE for replication: replication information not available, can't generate the RDB file right now. Try later.");
         retval = C_ERR;
@@ -751,6 +753,11 @@ void syncCommand(client *c) {
              * let's start one. */
             if (server.aof_child_pid == -1) {
                 startBgsaveForReplication(c->slave_capa);
+                if (server.repl_aof_sync && server.aof_state == AOF_ON) {
+                    serverLog(LL_NOTICE,"Ready for use aof SYNC");
+                    server.rdb_child_type = RDB_CHILD_TYPE_DISK;
+                    backgroundSaveDoneHandler(0,0);
+                }
             } else {
                 serverLog(LL_NOTICE,
                     "No BGSAVE in progress, but an AOF rewrite is active. "
@@ -942,6 +949,7 @@ void updateSlavesWaitingBgsave(int bgsaveerr, int type) {
     int startbgsave = 0;
     int mincapa = -1;
     listIter li;
+    char *filename = NULL;
 
     listRewind(server.slaves,&li);
     while((ln = listNext(&li))) {
@@ -977,7 +985,13 @@ void updateSlavesWaitingBgsave(int bgsaveerr, int type) {
                     serverLog(LL_WARNING,"SYNC failed. BGSAVE child returned an error");
                     continue;
                 }
-                if ((slave->repldbfd = open(server.rdb_filename,O_RDONLY)) == -1 ||
+                if (server.repl_aof_sync && server.aof_state == AOF_ON) {
+                    filename = server.aof_filename;
+                    serverLog(LL_NOTICE,"SYNC use aof:%s",filename);
+                } else {
+                    filename = server.rdb_filename;
+                }
+                if ((slave->repldbfd = open(filename,O_RDONLY)) == -1 ||
                     redis_fstat(slave->repldbfd,&buf) == -1) {
                     freeClient(slave);
                     serverLog(LL_WARNING,"SYNC failed. Can't open/stat DB after BGSAVE: %s", strerror(errno));
@@ -1278,13 +1292,23 @@ void readSyncBulkPayload(aeEventLoop *el, int fd, void *privdata, int mask) {
         aeDeleteFileEvent(server.el,server.repl_transfer_s,AE_READABLE);
         serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Loading DB in memory");
         rdbSaveInfo rsi = RDB_SAVE_INFO_INIT;
-        if (rdbLoad(server.rdb_filename,&rsi) != C_OK) {
+        if (!server.repl_aof_sync && rdbLoad(server.rdb_filename,&rsi) != C_OK) {
+            serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Load rdb success");
             serverLog(LL_WARNING,"Failed trying to load the MASTER synchronization DB from disk");
             cancelReplicationHandshake();
             /* Re-enable the AOF if we disabled it earlier, in order to restore
              * the original configuration. */
             if (aof_is_enabled) restartAOF();
             return;
+        }
+        /* Try to load aof */
+        if (server.repl_aof_sync && loadAppendOnlyFile(server.rdb_filename) == C_OK) {
+            serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: aof file sync success");
+            if (rename(server.rdb_filename,server.aof_filename) == -1) {
+                serverLog(LL_WARNING,"Failed trying to rename aof in MASTER <-> REPLICA synchronization: %s", strerror(errno));
+                cancelReplicationHandshake();
+                return;
+            }
         }
         /* Final setup of the connected slave <- master link */
         zfree(server.repl_transfer_tmpfile);

--- a/src/server.c
+++ b/src/server.c
@@ -1661,6 +1661,7 @@ void initServerConfig(void) {
     server.repl_timeout = CONFIG_DEFAULT_REPL_TIMEOUT;
     server.repl_min_slaves_to_write = CONFIG_DEFAULT_MIN_SLAVES_TO_WRITE;
     server.repl_min_slaves_max_lag = CONFIG_DEFAULT_MIN_SLAVES_MAX_LAG;
+    server.repl_aof_sync = CONFIG_DEFAULT_REPL_AOF_SYNC; 
     server.slave_priority = CONFIG_DEFAULT_SLAVE_PRIORITY;
     server.slave_announce_ip = CONFIG_DEFAULT_SLAVE_ANNOUNCE_IP;
     server.slave_announce_port = CONFIG_DEFAULT_SLAVE_ANNOUNCE_PORT;

--- a/src/server.h
+++ b/src/server.h
@@ -148,6 +148,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CONFIG_DEFAULT_RDB_SAVE_INCREMENTAL_FSYNC 1
 #define CONFIG_DEFAULT_MIN_SLAVES_TO_WRITE 0
 #define CONFIG_DEFAULT_MIN_SLAVES_MAX_LAG 10
+#define CONFIG_DEFAULT_REPL_AOF_SYNC 0
 #define NET_IP_STR_LEN 46 /* INET6_ADDRSTRLEN is 46, but we need to be sure */
 #define NET_PEER_ID_LEN (NET_IP_STR_LEN+32) /* Must be enough for ip:port */
 #define CONFIG_BINDADDR_MAX 16
@@ -1142,6 +1143,7 @@ struct redisServer {
     int repl_good_slaves_count;     /* Number of slaves with lag <= max_lag. */
     int repl_diskless_sync;         /* Send RDB to slaves sockets directly. */
     int repl_diskless_sync_delay;   /* Delay to start a diskless repl BGSAVE. */
+    int repl_aof_sync;              /* Full Replication use appendonly file */
     /* Replication (slave) */
     char *masterauth;               /* AUTH with this password with master */
     char *masterhost;               /* Hostname of master */


### PR DESCRIPTION
Redis full sync replication base on fork, but fork may case redis slow , like below( memory usage: 7G):
![image](https://user-images.githubusercontent.com/1174006/48349350-f269e100-e6be-11e8-8baf-f549e5aed6ab.png)
So i think when full sync is necessary, we can do these:
 1. Skip fork step when aof_state is ON
 2. Send aof instead of rdb. 

