### PR TITLE
Add unit test for stream XCLAIM command.

### DIFF
--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -108,6 +108,54 @@ start_server {
         assert {$c == 5}
     }
 
+    test {XCLAIM can claim PEL items from another consumer} {
+        # Add 3 items into the stream, and create a consumer group
+        r del mystream
+        set id1 [r XADD mystream * a 1]
+        set id2 [r XADD mystream * b 2]
+        set id3 [r XADD mystream * c 3]
+        r XGROUP CREATE mystream mygroup 0
+
+        # Client 1 reads item 1 from the stream without acknowledgements.
+        # Client 2 then claims pending item 1 from the PEL of client 1
+        set reply [
+            r XREADGROUP GROUP mygroup client1 count 1 STREAMS mystream >
+        ]
+        assert {[llength [lindex $reply 0 1 0 1]] == 2}
+        assert {[lindex $reply 0 1 0 1] eq {a 1}}
+        r debug sleep 0.2
+        set reply [
+            r XCLAIM mystream mygroup client2 10 $id1
+        ]
+        assert {[llength [lindex $reply 0 1]] == 2}
+        assert {[lindex $reply 0 1] eq {a 1}}
+
+        # Client 1 reads another 2 items from stream
+        r XREADGROUP GROUP mygroup client1 count 2 STREAMS mystream >
+        r debug sleep 0.2
+
+        # Delete item 2 from the stream. Now client 1 has PEL that contains
+        # only item 3. Try to use client 2 to claim the deleted item 2
+        # from the PEL of client 1, this should return nil
+        r XDEL mystream $id2
+        set reply [
+            r XCLAIM mystream mygroup client2 10 $id2
+        ]
+        assert {[llength $reply] == 1}
+        assert_equal "" [lindex $reply 0]
+
+        # Delete item 3 from the stream. Now client 1 has PEL that is empty.
+        # Try to use client 2 to claim the deleted item 3 from the PEL
+        # of client 1, this should return nil
+        r debug sleep 0.2
+        r XDEL mystream $id3
+        set reply [
+            r XCLAIM mystream mygroup client2 10 $id3
+        ]
+        assert {[llength $reply] == 1}
+        assert_equal "" [lindex $reply 0]
+    }
+
     start_server {} {
         set master [srv -1 client]
         set master_host [srv -1 host]


### PR DESCRIPTION
Adding unit test for XCLAIM command for redis streams. The test covers the following:

- A happy scenario of one client claiming a pending item from another client
- 2 failure scenarios as mentioned in the v5.0.1 XCLAIM bug fix. This test passes on v5.0.1, but fails on v5.0.0 due to the bug. 
https://github.com/antirez/redis/commit/1ed821e28d19f58a44720761e1675cc324c2f458