### PR TITLE
Backport #4497 to redis 4

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -67,6 +67,16 @@ int listMatchObjects(void *a, void *b) {
     return equalStringObjects(a,b);
 }
 
+/* This function links the client to the global linked list of clients.
+ * unlinkClient() does the opposite, among other things. */
+void linkClient(client *c) {
+    listAddNodeTail(server.clients,c);
+    /* Note that we remember the linked list node where the client is stored,
+     * this way removing the client in unlinkClient() will not require
+     * a linear scan, but just a constant time operation. */
+    c->client_list_node = listLast(server.clients);
+}
+
 client *createClient(int fd) {
     client *c = zmalloc(sizeof(client));
 
@@ -133,14 +143,10 @@ client *createClient(int fd) {
     c->pubsub_channels = dictCreate(&objectKeyPointerValueDictType,NULL);
     c->pubsub_patterns = listCreate();
     c->peerid = NULL;
+    c->client_list_node = NULL;
     listSetFreeMethod(c->pubsub_patterns,decrRefCountVoid);
     listSetMatchMethod(c->pubsub_patterns,listMatchObjects);
-    if (fd != -1) {
-        listAddNodeTail(server.clients,c);
-        c->client_list_node = listLast(server.clients);
-    } else {
-        c->client_list_node = NULL;
-    }
+    if (fd != -1) linkClient(c);
     initClientMultiState(c);
     return c;
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -135,7 +135,12 @@ client *createClient(int fd) {
     c->peerid = NULL;
     listSetFreeMethod(c->pubsub_patterns,decrRefCountVoid);
     listSetMatchMethod(c->pubsub_patterns,listMatchObjects);
-    if (fd != -1) listAddNodeTail(server.clients,c);
+    if (fd != -1) {
+        listAddNodeTail(server.clients,c);
+        c->client_list_node = listLast(server.clients);
+    } else {
+        c->client_list_node = NULL;
+    }
     initClientMultiState(c);
     return c;
 }
@@ -752,9 +757,10 @@ void unlinkClient(client *c) {
      * fd is already set to -1. */
     if (c->fd != -1) {
         /* Remove from the list of active clients. */
-        ln = listSearchKey(server.clients,c);
-        serverAssert(ln != NULL);
-        listDelNode(server.clients,ln);
+        if (c->client_list_node) {
+            listDelNode(server.clients,c->client_list_node);
+            c->client_list_node = NULL;
+        }
 
         /* Unregister async I/O handlers and close the socket. */
         aeDeleteFileEvent(server.el,c->fd,AE_READABLE);

--- a/src/replication.c
+++ b/src/replication.c
@@ -2214,8 +2214,7 @@ void replicationResurrectCachedMaster(int newfd) {
     server.repl_down_since = 0;
 
     /* Re-add to the list of clients. */
-    listAddNodeTail(server.clients,server.master);
-    server.master->client_list_node = listLast(server.clients);
+    linkClient(server.master);
     if (aeCreateFileEvent(server.el, newfd, AE_READABLE,
                           readQueryFromClient, server.master)) {
         serverLog(LL_WARNING,"Error resurrecting the cached master, impossible to add the readable handler: %s", strerror(errno));

--- a/src/replication.c
+++ b/src/replication.c
@@ -2215,6 +2215,7 @@ void replicationResurrectCachedMaster(int newfd) {
 
     /* Re-add to the list of clients. */
     listAddNodeTail(server.clients,server.master);
+    server.master->client_list_node = listLast(server.clients);
     if (aeCreateFileEvent(server.el, newfd, AE_READABLE,
                           readQueryFromClient, server.master)) {
         serverLog(LL_WARNING,"Error resurrecting the cached master, impossible to add the readable handler: %s", strerror(errno));

--- a/src/server.h
+++ b/src/server.h
@@ -1394,6 +1394,7 @@ int handleClientsWithPendingWrites(void);
 int clientHasPendingReplies(client *c);
 void unlinkClient(client *c);
 int writeToClient(int fd, client *c, int handler_installed);
+void linkClient(client *c);
 
 #ifdef __GNUC__
 void addReplyErrorFormat(client *c, const char *fmt, ...)

--- a/src/server.h
+++ b/src/server.h
@@ -723,6 +723,7 @@ typedef struct client {
     dict *pubsub_channels;  /* channels a client is interested in (SUBSCRIBE) */
     list *pubsub_patterns;  /* patterns a client is interested in (SUBSCRIBE) */
     sds peerid;             /* Cached peer ID. */
+    listNode *client_list_node; /* list node in client list */
 
     /* Response buffer */
     int bufpos;


### PR DESCRIPTION
We are currently running redis4.0.11 with roughly 30K connections, but we have a lot of very shortlived connections. In very unfortunate situations, our flamegraphs reveals that most of the time was beeing spent in `unlinkClient`.

![image](https://user-images.githubusercontent.com/801405/48494970-fac83600-e7fc-11e8-90f6-c52f09192c5f.png)

By applying this patch we were able to reduce the latency by a significant margin (currently getting accurate numbers for posterity), but I think back-porting this into redis4 is a win either way.

Thanks!