### PR TITLE
Minor fixes to comments

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -60,7 +60,7 @@
 # instance to everybody on the internet. So by default we uncomment the
 # following bind directive, that will force Redis to listen only on the
 # IPv4 loopback interface address (this means Redis will only be able to
-# accept client connections from the same computer it is running on).
+# accept client connections from the same host that it is running on).
 #
 # IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
 # JUST COMMENT OUT THE FOLLOWING LINE.
@@ -298,9 +298,9 @@ dir ./
 #    still reply to client requests, possibly with out of date data, or the
 #    data set may just be empty if this is the first synchronization.
 #
-# 2) if replica-serve-stale-data is set to 'no' the replica will reply with
+# 2) If replica-serve-stale-data is set to 'no' the replica will reply with
 #    an error "SYNC with master in progress" to all commands except:
-#    INFO, replicaOF, AUTH, PING, SHUTDOWN, REPLCONF, ROLE, CONFIG, SUBSCRIBE,
+#    INFO, REPLICAOF, AUTH, PING, SHUTDOWN, REPLCONF, ROLE, CONFIG, SUBSCRIBE,
 #    UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, PUBLISH, PUBSUB, COMMAND, POST,
 #    HOST and LATENCY.
 #
@@ -1374,4 +1374,3 @@ rdb-save-incremental-fsync yes
 # Maximum number of set/hash/zset/list fields that will be processed from
 # the main dictionary scan
 # active-defrag-max-scan-fields 1000
-

--- a/redis.conf
+++ b/redis.conf
@@ -24,7 +24,7 @@
 # to customize a few per-server settings.  Include files can include
 # other files, so use this wisely.
 #
-# Notice option "include" won't be rewritten by command "CONFIG REWRITE"
+# Note that option "include" won't be rewritten by command "CONFIG REWRITE"
 # from admin or Redis Sentinel. Since Redis always uses the last processed
 # line as value of a configuration directive, you'd better put includes
 # at the beginning of this file to avoid overwriting config change at runtime.
@@ -46,7 +46,7 @@
 ################################## NETWORK #####################################
 
 # By default, if no "bind" configuration directive is specified, Redis listens
-# for connections from all the network interfaces available on the server.
+# for connections from all available network interfaces on the host machine.
 # It is possible to listen to just one or multiple selected interfaces using
 # the "bind" configuration directive, followed by one or more IP addresses.
 #
@@ -58,13 +58,12 @@
 # ~~~ WARNING ~~~ If the computer running Redis is directly exposed to the
 # internet, binding to all the interfaces is dangerous and will expose the
 # instance to everybody on the internet. So by default we uncomment the
-# following bind directive, that will force Redis to listen only into
-# the IPv4 loopback interface address (this means Redis will be able to
-# accept connections only from clients running into the same computer it
-# is running).
+# following bind directive, that will force Redis to listen only on the
+# IPv4 loopback interface address (this means Redis will only be able to
+# accept client connections from the same computer it is running on).
 #
 # IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
-# JUST COMMENT THE FOLLOWING LINE.
+# JUST COMMENT OUT THE FOLLOWING LINE.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 bind 127.0.0.1
 
@@ -93,8 +92,8 @@ port 6379
 
 # TCP listen() backlog.
 #
-# In high requests-per-second environments you need an high backlog in order
-# to avoid slow clients connections issues. Note that the Linux kernel
+# In high requests-per-second environments you need a high backlog in order
+# to avoid slow clients connection issues. Note that the Linux kernel
 # will silently truncate it to the value of /proc/sys/net/core/somaxconn so
 # make sure to raise both the value of somaxconn and tcp_max_syn_backlog
 # in order to get the desired effect.
@@ -118,8 +117,8 @@ timeout 0
 # of communication. This is useful for two reasons:
 #
 # 1) Detect dead peers.
-# 2) Take the connection alive from the point of view of network
-#    equipment in the middle.
+# 2) Force network equipment in the middle to consider the connection to be
+#    alive.
 #
 # On Linux, the specified value (in seconds) is the period used to send ACKs.
 # Note that to close the connection the double of the time is needed.
@@ -143,7 +142,7 @@ daemonize no
 #   supervised auto    - detect upstart or systemd method based on
 #                        UPSTART_JOB or NOTIFY_SOCKET environment variables
 # Note: these supervision methods only signal "process is ready."
-#       They do not enable continuous liveness pings back to your supervisor.
+#       They do not enable continuous pings back to your supervisor.
 supervised no
 
 # If a pid file is specified, Redis writes it where specified at startup
@@ -235,7 +234,7 @@ save 60 10000
 stop-writes-on-bgsave-error yes
 
 # Compress string objects using LZF when dump .rdb databases?
-# For default that's set to 'yes' as it's almost always a win.
+# By default compression is enabled as it's almost always a win.
 # If you want to save some CPU in the saving child set it to 'no' but
 # the dataset will likely be bigger if you have compressible values or keys.
 rdbcompression yes
@@ -300,10 +299,10 @@ dir ./
 #    data set may just be empty if this is the first synchronization.
 #
 # 2) if replica-serve-stale-data is set to 'no' the replica will reply with
-#    an error "SYNC with master in progress" to all the kind of commands
-#    but to INFO, replicaOF, AUTH, PING, SHUTDOWN, REPLCONF, ROLE, CONFIG,
-#    SUBSCRIBE, UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, PUBLISH, PUBSUB,
-#    COMMAND, POST, HOST: and LATENCY.
+#    an error "SYNC with master in progress" to all commands except:
+#    INFO, replicaOF, AUTH, PING, SHUTDOWN, REPLCONF, ROLE, CONFIG, SUBSCRIBE,
+#    UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, PUBLISH, PUBSUB, COMMAND, POST,
+#    HOST and LATENCY.
 #
 replica-serve-stale-data yes
 
@@ -412,14 +411,14 @@ repl-disable-tcp-nodelay no
 #
 # repl-backlog-size 1mb
 
-# After a master has no longer connected replicas for some time, the backlog
-# will be freed. The following option configures the amount of seconds that
-# need to elapse, starting from the time the last replica disconnected, for
-# the backlog buffer to be freed.
+# After a master has no connected replicas for some time, the backlog will be
+# freed. The following option configures the amount of seconds that need to
+# elapse, starting from the time the last replica disconnected, for the backlog
+# buffer to be freed.
 #
 # Note that replicas never free the backlog for timeout, since they may be
 # promoted to masters later, and should be able to correctly "partially
-# resynchronize" with the replicas: hence they should always accumulate backlog.
+# resynchronize" with other replicas: hence they should always accumulate backlog.
 #
 # A value of 0 means to never release the backlog.
 #
@@ -469,8 +468,8 @@ replica-priority 100
 # Another place where this info is available is in the output of the
 # "ROLE" command of a master.
 #
-# The listed IP and address normally reported by a replica is obtained
-# in the following way:
+# The listed IP address and port normally reported by a replica is
+# obtained in the following way:
 #
 #   IP: The address is auto detected by checking the peer address
 #   of the socket used by the replica to connect with the master.
@@ -480,7 +479,7 @@ replica-priority 100
 #   listen for connections.
 #
 # However when port forwarding or Network Address Translation (NAT) is
-# used, the replica may be actually reachable via different IP and port
+# used, the replica may actually be reachable via different IP and port
 # pairs. The following two options can be used by a replica in order to
 # report to its master a specific set of IP and port, so that both INFO
 # and ROLE will report those values.
@@ -500,7 +499,7 @@ replica-priority 100
 # This should stay commented out for backward compatibility and because most
 # people do not need auth (e.g. they run their own servers).
 #
-# Warning: since Redis is pretty fast an outside user can try up to
+# Warning: since Redis is pretty fast, an outside user can try up to
 # 150k passwords per second against a good box. This means that you should
 # use a very strong password otherwise it will be very easy to break.
 #
@@ -598,8 +597,8 @@ replica-priority 100
 
 # LRU, LFU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can tune it for speed or
-# accuracy. For default Redis will check five keys and pick the one that was
-# used less recently, you can change the sample size using the following
+# accuracy. By default Redis will check five keys and pick the one that was
+# used least recently, you can change the sample size using the following
 # configuration directive.
 #
 # The default of 5 produces good enough results. 10 Approximates very closely
@@ -800,8 +799,8 @@ aof-load-truncated yes
 #
 #   [RDB file][AOF tail]
 #
-# When loading Redis recognizes that the AOF file starts with the "REDIS"
-# string and loads the prefixed RDB file, and continues loading the AOF
+# When loading, Redis recognizes that the AOF file starts with the "REDIS"
+# string and loads the prefixed RDB file, then continues loading the AOF
 # tail.
 aof-use-rdb-preamble yes
 
@@ -815,7 +814,7 @@ aof-use-rdb-preamble yes
 #
 # When a long running script exceeds the maximum execution time only the
 # SCRIPT KILL and SHUTDOWN NOSAVE commands are available. The first can be
-# used to stop a script that did not yet called write commands. The second
+# used to stop a script that did not yet call any write commands. The second
 # is the only way to shut down the server in the case a write command was
 # already issued by the script but the user doesn't want to wait for the natural
 # termination of the script.
@@ -847,7 +846,7 @@ lua-time-limit 5000
 
 # Cluster node timeout is the amount of milliseconds a node must be unreachable
 # for it to be considered in failure state.
-# Most other internal time limits are multiple of the node timeout.
+# Most other internal time limits are a multiple of the node timeout.
 #
 # cluster-node-timeout 15000
 
@@ -1208,7 +1207,7 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 # client-query-buffer-limit 1gb
 
 # In the Redis protocol, bulk requests, that are, elements representing single
-# strings, are normally limited ot 512 mb. However you can change this limit
+# strings, are normally limited to 512 mb. However you can change this limit
 # here.
 #
 # proto-max-bulk-len 512mb


### PR DESCRIPTION
Found some parts a little unclear on a first read, which prompted me to have a better look at the file and fix some minor things I noticed.
Fixing minor typos and grammar. There are no changes to configuration options.
These changes are only meant to help the user better understand the explanations to the various configuration options