### PR TITLE
sinterstore: add missing keyspace del event when any source set not exists.

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -809,6 +809,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
             if (dstkey) {
                 if (dbDelete(c->db,dstkey)) {
                     signalModifiedKey(c->db,dstkey);
+                    notifyKeyspaceEvent(NOTIFY_GENERIC,"del",dstkey,c->db->id);
                     server.dirty++;
                 }
                 addReply(c,shared.czero);


### PR DESCRIPTION

```
sadd s1 a b 
sinterstore s1 s2 
```

generates no del keyspace events.

this patch fixes sinterstore by add missing keyspace del event when any source set not exists.