### PR TITLE
Fix choose a random master node for slot assignment

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3505,7 +3505,7 @@ static clusterManagerNode *clusterManagerNodeWithLeastReplicas() {
     return node;
 }
 
-/* This fucntion returns a random master node, return NULL if none */
+/* This function returns a random master node, return NULL if none */
 
 static clusterManagerNode *clusterManagerNodeMasterRandom() {
     int master_count = 0;


### PR DESCRIPTION
It will choose a slave node for node assignment and result in an `incorrect` cluster configuration status.