### PR TITLE
Clarify the "Creating Server TCP listening socket" error message

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1958,7 +1958,7 @@ int listenToPort(int port, int *fds, int *count) {
         }
         if (fds[*count] == ANET_ERR) {
             serverLog(LL_WARNING,
-                "Creating Server TCP listening socket %s:%d: %s",
+                "Could not create server TCP listening socket %s:%d: %s",
                 server.bindaddr[j] ? server.bindaddr[j] : "*",
                 port, server.neterr);
             return C_ERR;


### PR DESCRIPTION
This really helps spot it in the logs, otherwise it does not look like a warning/error. For example:

```
Creating Server TCP listening socket ::1:6379: bind: Cannot assign requested address
```
... is not nearly as clear as:

```
Could not create server TCP listening listening socket ::1:6379: bind: Cannot assign requested address
```