### PR TITLE
Don't treat unsupported protocols as fatal errors

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1961,6 +1961,10 @@ int listenToPort(int port, int *fds, int *count) {
                 "Creating Server TCP listening socket %s:%d: %s",
                 server.bindaddr[j] ? server.bindaddr[j] : "*",
                 port, server.neterr);
+                if (errno == ENOPROTOOPT     || errno == EPROTONOSUPPORT ||
+                    errno == ESOCKTNOSUPPORT || errno == EPFNOSUPPORT ||
+                    errno == EAFNOSUPPORT    || errno == EADDRNOTAVAIL)
+                    continue;
             return C_ERR;
         }
         anetNonBlock(NULL,fds[*count]);


### PR DESCRIPTION
If we encounter an unsupported protocol in the `bind` list, don't ipso-facto consider it a fatal error. We continue to abort startup if there are no listening sockets at all.

This ensures that the lack of IPv6 support does not prevent Redis from starting on Debian where we try to bind to the `::1` interface by default (via `bind 127.0.0.1 ::1`). A machine with IPv6 disabled (such as some container systems) would simply fail to start Redis after the initiall call to `apt(8)`.

This is similar to the case for where `bind` is not specified (#3894) and was based on the corresponding PR #4108 but also adds `EADDRNOTAVAIL` to the list of errors to catch which I believe is missing from there.

(This issue was raised in Debian as both [#900284](https://bugs.debian.org/900284) & [#914354](https://bugs.debian.org/914354).)