### PR TITLE
MULTI: if client is dirty, just free multi state and donot queue command

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -54,6 +54,10 @@ void freeClientMultiState(client *c) {
 
 /* Add a new command into the MULTI commands queue */
 void queueMultiCommand(client *c) {
+    /* If the client is already dirty, it's unnecessary to queue the command. */
+    if (c->flags & CLIENT_DIRTY_EXEC)
+        return;
+
     multiCmd *mc;
     int j;
 
@@ -77,10 +81,14 @@ void discardTransaction(client *c) {
 }
 
 /* Flag the transacation as DIRTY_EXEC so that EXEC will fail.
+ * And free the client's multi state to save memory.
  * Should be called every time there is an error while queueing a command. */
 void flagTransaction(client *c) {
-    if (c->flags & CLIENT_MULTI)
+    if (c->flags & CLIENT_MULTI) {
         c->flags |= CLIENT_DIRTY_EXEC;
+        freeClientMultiState(c);
+        initClientMultiState(c);
+    }
 }
 
 void multiCommand(client *c) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -1666,7 +1666,7 @@ sds catClientInfoString(sds s, client *client) {
         client->db->id,
         (int) dictSize(client->pubsub_channels),
         (int) listLength(client->pubsub_patterns),
-        (client->flags & CLIENT_MULTI) ? client->mstate.count : -1,
+        (client->flags & CLIENT_MULTI) ? ((client->flags & CLIENT_DIRTY_EXEC) ? -2 : client->mstate.count) : -1,
         (unsigned long long) sdslen(client->querybuf),
         (unsigned long long) sdsavail(client->querybuf),
         (unsigned long long) client->bufpos,


### PR DESCRIPTION
I think if a client is already dirty, it's unnecessary to queue the command, queue the command is just a waste of time and memory.

Also we can free the multi state when flag transaction to save memory.