### PR TITLE
MULTI: execute the UNWATCH command instead of queue it in multi context

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -332,6 +332,10 @@ void watchCommand(client *c) {
 }
 
 void unwatchCommand(client *c) {
+    if (c->flags & CLIENT_MULTI) {
+        addReplyError(c,"UNWATCH inside MULTI is not allowed");
+        return;
+    }
     unwatchAllKeys(c);
     c->flags &= (~CLIENT_DIRTY_CAS);
     addReply(c,shared.ok);

--- a/src/server.c
+++ b/src/server.c
@@ -2721,7 +2721,8 @@ int processCommand(client *c) {
     /* Exec the command */
     if (c->flags & CLIENT_MULTI &&
         c->cmd->proc != execCommand && c->cmd->proc != discardCommand &&
-        c->cmd->proc != multiCommand && c->cmd->proc != watchCommand)
+        c->cmd->proc != multiCommand && c->cmd->proc != watchCommand &&
+        c->cmd->proc !=unwatchCommand)
     {
         queueMultiCommand(c);
         addReply(c,shared.queued);


### PR DESCRIPTION
Hi @antirez , I'm a little confused about the UNWATCH command:

```
127.0.0.1:6379> multi
OK
127.0.0.1:6379> set a b
QUEUED
127.0.0.1:6379> unwatch
QUEUED
127.0.0.1:6379> exec
1) OK
2) OK
```

It seems that in multi context the UNWATCH is only queued not executed, so it becomes useless no matter the watched key is touched before or after the UNWATCH.

Maybe we should execute the UNWATCH instead of queue it?