### PR TITLE
fix comparison in zsl/zzlIsInLexRange (#5516)

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -652,7 +652,7 @@ int zslIsInLexRange(zskiplist *zsl, zlexrangespec *range) {
     zskiplistNode *x;
 
     /* Test for ranges that will always be empty. */
-    if (sdscmplex(range->min,range->max) > 1 ||
+    if (sdscmplex(range->min,range->max) > 0 ||
             (sdscmp(range->min,range->max) == 0 &&
             (range->minex || range->maxex)))
         return 0;
@@ -927,7 +927,7 @@ int zzlIsInLexRange(unsigned char *zl, zlexrangespec *range) {
     unsigned char *p;
 
     /* Test for ranges that will always be empty. */
-    if (sdscmplex(range->min,range->max) > 1 ||
+    if (sdscmplex(range->min,range->max) > 0 ||
             (sdscmp(range->min,range->max) == 0 &&
             (range->minex || range->maxex)))
         return 0;


### PR DESCRIPTION
zslIsInLexRange and zzlIsInLexRange both have any early check to escape
if `min > max`.   The underlying function does a `memcmp` which returns
0, integer greater than 0, or integer less than 0.  However, these
only escape if the compare result is `> 1`.

The specific output of `memcmp` is implementation-dependent, but on
many systems, it will return 1 if the inputs differ by 1.

Due to the rest of the algorithm, the zsl/zzlIsInLexRange functions have
operated properly.  This change however is more correct (thus if the
rest of the function changes, it will continue to work properly) and gives
a slight performance improvement for this edge case.