### PR TITLE
Update server.c   Added a line of output daemonize pid code

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3703,6 +3703,7 @@ void daemonize(void) {
     int fd;
 
     if (fork() != 0) exit(0); /* parent exits */
+    serverLog(LL_WARNING, "Reids daemonize pid=%d, good luck", (int)getpid());/*ggz:out real pid*/
     setsid(); /* create a new session */
 
     /* Every output goes to /dev/null. If Redis is daemonized but

--- a/src/server.c
+++ b/src/server.c
@@ -3703,7 +3703,7 @@ void daemonize(void) {
     int fd;
 
     if (fork() != 0) exit(0); /* parent exits */
-    serverLog(LL_WARNING, "Reids daemonize pid=%d, good luck", (int)getpid());/*ggz:out real pid*/
+    serverLog(LL_WARNING, "Redis daemonize pid=%d, good luck", (int)getpid());/*ggz:out real pid*/
     setsid(); /* create a new session */
 
     /* Every output goes to /dev/null. If Redis is daemonized but


### PR DESCRIPTION
fix the PID of the shell output is inconsistent with redis_6379.pid
eg:
```
$ /etc/init.d/redis_6379 start
Starting Redis server...
2702:C 26 Nov 2018 13:57:40.848 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
2702:C 26 Nov 2018 13:57:40.849 # Redis version=5.0.2, bits=64, commit=00000000, modified=0, pid=2702, just started
2702:C 26 Nov 2018 13:57:40.849 # Configuration loaded
```
>pid is 2702
```
$ cat /var/run/redis_6379.pid 
2703
```
>pid is 2703


Thanks to @AngusP for helping me locate the cause of this problem. I tried to modify the source code according to his prompts. After exit(0), before setsid(), I added the code to output pid, and then I was surprised to find that I could successfully output the correct pid.
```
void daemonize(void) {
    int fd;

    if (fork() != 0) exit(0); /* parent exits */
    serverLog(LL_WARNING, "Reids daemonize pid=%d, good luck", (int)getpid());/*ggz+out real pid*/
    setsid(); /* create a new session */

    /* Every output goes to /dev/null. If Redis is daemonized but
     * the 'logfile' is set to 'stdout' in the configuration file
     * it will not log at all. */
    if ((fd = open("/dev/null", O_RDWR, 0)) != -1) {
        dup2(fd, STDIN_FILENO);
        dup2(fd, STDOUT_FILENO);
        dup2(fd, STDERR_FILENO);
        if (fd > STDERR_FILENO) close(fd);
    }
}
```
The test is as follows:
```
$ /etc/init.d/redis_6379 start
Starting Redis server...
17334:C 28 Nov 2018 00:42:17.354 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
17334:C 28 Nov 2018 00:42:17.354 # Redis version=5.0.2, bits=64, commit=00000000, modified=0, pid=17334, just started
17334:C 28 Nov 2018 00:42:17.354 # Configuration loaded
17335:C 28 Nov 2018 00:42:17.355 # Reids daemonize pid=17335, good luck

$ cat /var/run/redis_6379.pid 
17335
```
I used redis-5.0.2 on ubuntu18.04 and centos7.2. tested can be output normally. But I don't know if it is reliable. Maybe more tests are needed.
