### PR TITLE
remove redundant if condition

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -468,8 +468,7 @@ int masterTryPartialResynchronization(client *c) {
     {
         /* Run id "?" is used by slaves that want to force a full resync. */
         if (master_replid[0] != '?') {
-            if (strcasecmp(master_replid, server.replid) &&
-                strcasecmp(master_replid, server.replid2))
+            if (strcasecmp(master_replid, server.replid2))
             {
                 serverLog(LL_NOTICE,"Partial resynchronization not accepted: "
                     "Replication ID mismatch (Replica asked for '%s', my "


### PR DESCRIPTION
The if condition "strcasecmp(master_replid, server.replid)" is already checked by the outer if statement, so no need to check again.