### PR TITLE
Fixed a serverPanic when sending an invalid command to a monitor client

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -365,7 +365,7 @@ void addReplyErrorLength(client *c, const char *s, size_t len) {
      * Where the master must propagate the first change even if the second
      * will produce an error. However it is useful to log such events since
      * they are rare and may hint at errors in a script or a bug in Redis. */
-    if (c->flags & (CLIENT_MASTER|CLIENT_SLAVE)) {
+    if (c->flags & (CLIENT_MASTER|CLIENT_SLAVE) && !(c->flags & CLIENT_MONITOR)) {
         char* to = c->flags & CLIENT_MASTER? "master": "replica";
         char* from = c->flags & CLIENT_MASTER? "replica": "master";
         char *cmdname = c->lastcmd ? c->lastcmd->name : "<unknown>";


### PR DESCRIPTION
This happens when you send any invalid command to a monitor client. We saw clients doing this when they were trying to escape telnet connections using monitor, not a great experience.

Reproduction:
```
telnet localhost 6379
Trying ::1...
Connected to localhost (::1).
Escape character is '^]'.
MONITOR
+OK
hi redis
Connection closed by foreign host.
```

Do you want TCL tests for issues like these to prevent regressions in the future?