### PR TITLE
Fix cluster call reply format readable

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5404,7 +5404,7 @@ static int clusterManagerCommandCall(int argc, char **argv) {
         if (status != REDIS_OK || reply == NULL )
             printf("%s:%d: Failed!\n", n->ip, n->port);
         else {
-            sds formatted_reply = cliFormatReplyTTY(reply, "");
+            sds formatted_reply = cliFormatReplyRaw(reply);
             printf("%s:%d: %s\n", n->ip, n->port, (char *) formatted_reply);
             sdsfree(formatted_reply);
         }


### PR DESCRIPTION
redis-cli --cluster call command return reply in tty format which is hard to read
```
>>> Calling cluster info
192.168.100.213:6379: "cluster_state:ok\r\ncluster_slots_assigned:16384\r\ncluster_slots_ok:16384\r\ncluster_slots_pfail:0\r\ncluster_slots_fail:0\r\ncluster_known_nodes:12\r\ncluster_size:7\r\ncluster_current_epoch:114\r\ncluster_my_epoch:6\r\ncluster_stats_messages_ping_sent:440450\r\ncluster_stats_messages_pong_sent:433341\r\ncluster_stats_messages_meet_sent:2\r\ncluster_stats_messages_fail_sent:2\r\ncluster_stats_messages_update_sent:24\r\ncluster_stats_messages_sent:873819\r\ncluster_stats_messages_ping_received:433332\r\ncluster_stats_messages_pong_received:439186\r\ncluster_stats_messages_meet_received:9\r\ncluster_stats_messages_fail_received:10\r\ncluster_stats_messages_auth-req_received:3\r\ncluster_stats_messages_update_received:219\r\ncluster_stats_messages_received:872759\r\n"
```
It will be more appropriate in format in raw format the same as redis-trib.rb.
```
>>> Calling cluster info
192.168.100.213:6379: cluster_state:ok
cluster_slots_assigned:16384
cluster_slots_ok:16384
cluster_slots_pfail:0
cluster_slots_fail:0
cluster_known_nodes:12
cluster_size:7
cluster_current_epoch:114
cluster_my_epoch:6
cluster_stats_messages_ping_sent:441999
cluster_stats_messages_pong_sent:434877
cluster_stats_messages_meet_sent:2
cluster_stats_messages_fail_sent:2
cluster_stats_messages_update_sent:24
cluster_stats_messages_sent:876904
cluster_stats_messages_ping_received:434868
cluster_stats_messages_pong_received:440735
cluster_stats_messages_meet_received:9
cluster_stats_messages_fail_received:10
cluster_stats_messages_auth-req_received:3
cluster_stats_messages_update_received:219
cluster_stats_messages_received:875844
```