### PR TITLE
MULTI: some commands should not be allowed in multi/exec

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -577,6 +577,7 @@ int commandFlagsFromString(char *s) {
         else if (!strcasecmp(t,"admin")) flags |= CMD_ADMIN;
         else if (!strcasecmp(t,"deny-oom")) flags |= CMD_DENYOOM;
         else if (!strcasecmp(t,"deny-script")) flags |= CMD_NOSCRIPT;
+        else if (!strcasecmp(t,"deny-multi")) flags |= CMD_NOMULTI;
         else if (!strcasecmp(t,"allow-loading")) flags |= CMD_LOADING;
         else if (!strcasecmp(t,"pubsub")) flags |= CMD_PUBSUB;
         else if (!strcasecmp(t,"random")) flags |= CMD_RANDOM;

--- a/src/server.h
+++ b/src/server.h
@@ -211,13 +211,14 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CMD_NOSCRIPT (1<<6)         /* "s" flag */
 #define CMD_RANDOM (1<<7)           /* "R" flag */
 #define CMD_SORT_FOR_SCRIPT (1<<8)  /* "S" flag */
-#define CMD_LOADING (1<<9)          /* "l" flag */
-#define CMD_STALE (1<<10)           /* "t" flag */
-#define CMD_SKIP_MONITOR (1<<11)    /* "M" flag */
-#define CMD_ASKING (1<<12)          /* "k" flag */
-#define CMD_FAST (1<<13)            /* "F" flag */
-#define CMD_MODULE_GETKEYS (1<<14)  /* Use the modules getkeys interface. */
-#define CMD_MODULE_NO_CLUSTER (1<<15) /* Deny on Redis Cluster. */
+#define CMD_NOMULTI (1<<9)          /* "x" flag */
+#define CMD_LOADING (1<<10)         /* "l" flag */
+#define CMD_STALE (1<<11)           /* "t" flag */
+#define CMD_SKIP_MONITOR (1<<12)    /* "M" flag */
+#define CMD_ASKING (1<<13)          /* "k" flag */
+#define CMD_FAST (1<<14)            /* "F" flag */
+#define CMD_MODULE_GETKEYS (1<<15)  /* Use the modules getkeys interface. */
+#define CMD_MODULE_NO_CLUSTER (1<<16) /* Deny on Redis Cluster. */
 
 /* AOF states */
 #define AOF_OFF 0             /* AOF is off */
@@ -782,7 +783,7 @@ struct sharedObjectsStruct {
     *emptymultibulk, *wrongtypeerr, *nokeyerr, *syntaxerr, *sameobjecterr,
     *outofrangeerr, *noscripterr, *loadingerr, *slowscripterr, *bgsaveerr,
     *masterdownerr, *roslaveerr, *execaborterr, *noautherr, *noreplicaserr,
-    *busykeyerr, *oomerr, *plus, *messagebulk, *pmessagebulk, *subscribebulk,
+    *busykeyerr, *oomerr, *nomultierr, *plus, *messagebulk, *pmessagebulk, *subscribebulk,
     *unsubscribebulk, *psubscribebulk, *punsubscribebulk, *del, *unlink,
     *rpop, *lpop, *lpush, *rpoplpush, *zpopmin, *zpopmax, *emptyscan,
     *select[PROTO_SHARED_SELECT_CMDS],


### PR DESCRIPTION
Hi @antirez , we had a discussion about forbidden some commands in lua script in #4835.

But now I just found some commands are dangerous in multi/exec too... for instance:

We have a master instance listening on port 6379, and an replica listening on 7788, then execute `REPLICAOF` command in multi/exec on master:

```
127.0.0.1:6379> multi
OK
127.0.0.1:6379> replicaof 127.0.0.1 1234
QUEUED
127.0.0.1:6379> set a b
QUEUED
127.0.0.1:6379> set c d
QUEUED
127.0.0.1:6379> replicaof no one
QUEUED
127.0.0.1:6379> exec
1) OK
2) OK
3) OK
4) OK
127.0.0.1:6379> keys *
1) "c"
2) "a"
```

But the replica has nothing:
```
127.0.0.1:7788> keys *
(empty list or set)
127.0.0.1:7788> quit
```

It's because in multi/exec after `REPLICAOF 127.0.0.1 1234` the master became an replica, then write commands would not be replicated, neither the `repl_backlog`.

So, I think we should forbid some replication commands like `REPLICAOF`, `SYNC`, `PSYNC`.

I know this is a corner case, but it really can lead to data inconsistency between master and replica.