### PR TITLE
CRITICAL BUG: should disconnect multi state clients when master turns into replica

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1895,7 +1895,6 @@ void unblockClient(client *c);
 void queueClientForReprocessing(client *c);
 void replyToBlockedClientTimedOut(client *c);
 int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int unit);
-void disconnectAllBlockedClients(void);
 void handleClientsBlockedOnKeys(void);
 void signalKeyAsReady(redisDb *db, robj *key);
 void blockForKeys(client *c, int btype, robj **keys, int numkeys, mstime_t timeout, robj *target, streamID *ids);


### PR DESCRIPTION
Hi @antirez , there is an dangerous scenario when a mater turns into replica:

We have two instance, both run in master mode, master A listens on 6379 and master B listens on 7788.

1. At first send half multi to master B:
```
127.0.0.1:7788> multi
OK
127.0.0.1:7788> set a b
QUEUED
127.0.0.1:7788> set c d
QUEUED
```

2. And then turn master B into replica of master A:
```
127.0.0.1:7788> replicaof 127.0.0.1 6379
OK
```

3. Execute the multi:
```
127.0.0.1:7788> exec
1) OK
2) OK
```

Unfortunately, instance B has two keys more than master A now.

To fix it I think we can disconnect the multi state clients when master turns into replica, just like what blocked clients do.