### PR TITLE
networking: current_client should not be NULL when trim qb_pos

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1470,7 +1470,7 @@ void processInputBuffer(client *c) {
     }
 
     /* Trim to pos */
-    if (c->qb_pos) {
+    if (server.current_client != NULL && c->qb_pos) {
         sdsrange(c->querybuf,c->qb_pos,-1);
         c->qb_pos = 0;
     }


### PR DESCRIPTION
Hi @antirez , we should check `current_client` after `processCommand`, in case free slave which is the `current_client` when flush slave output buffers in `freeMemoryIfNeeded`, please check this.