### PR TITLE
The initial seed should be set before any call of random()

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4040,6 +4040,7 @@ int main(int argc, char **argv) {
     tzset(); /* Populates 'timezone' global. */
     zmalloc_set_oom_handler(redisOutOfMemoryHandler);
     srand(time(NULL)^getpid());
+    srandom(time(NULL)^getpid());
     gettimeofday(&tv,NULL);
 
     char hashseed[16];


### PR DESCRIPTION
zslRandomLevel() returns the predictable value.

The random() function is called in dict.c, t_zset.c, cluster.c, but no srandom() can be found.

https://github.com/antirez/redis/blob/5bfd8ae25301820ae3c321a838263925e70849b5/src/t_zset.c#L122-L127
https://github.com/antirez/redis/blob/5bfd8ae25301820ae3c321a838263925e70849b5/src/cluster.c#L3018-L3023
https://github.com/antirez/redis/blob/5bfd8ae25301820ae3c321a838263925e70849b5/src/dict.c#L622-L645
