### PR TITLE
evict: don't care about mem if loading

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -444,9 +444,15 @@ int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *lev
  * Otehrwise if we are over the memory limit, but not enough memory
  * was freed to return back under the limit, the function returns C_ERR. */
 int freeMemoryIfNeeded(void) {
-    /* By default slaves should ignore maxmemory and just be masters excat
-     * copies. */
-    if (server.masterhost && server.repl_slave_ignore_maxmemory) return C_OK;
+    /* By default replicas should ignore maxmemory
+     * and just be masters exact copies.
+     *
+     * And don't care about mem if loading. */
+    if (server.loading ||
+        (server.masterhost && server.repl_slave_ignore_maxmemory))
+    {
+        return C_OK;
+    }
 
     size_t mem_reported, mem_tofree, mem_freed;
     mstime_t latency, eviction_latency;


### PR DESCRIPTION
When loading data, we call processEventsWhileBlocked
to process events and execute commands.
But if we are loading AOF it's dangerous, because
processCommand would call freeMemoryIfNeeded to evict,
and that will break data consistency, see issue #5686.