### PR TITLE
fix wrong comments in redis.conf, change default always-show-logo

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -186,8 +186,9 @@ logfile ""
 databases 16
 
 # By default Redis shows an ASCII art logo only when started to log to the
-# standard output and if the standard output is a TTY. Basically this means
-# that normally a logo is displayed only in interactive sessions.
+# standard output and if the standard output is a TTY and syslog logging is
+# disabled. Basically this means that normally a logo is displayed only in
+# interactive sessions.
 #
 # However it is possible to force the pre-4.0 behavior and always show a
 # ASCII art logo in startup logs by setting the following option to yes.

--- a/redis.conf
+++ b/redis.conf
@@ -192,7 +192,7 @@ databases 16
 #
 # However it is possible to force the pre-4.0 behavior and always show a
 # ASCII art logo in startup logs by setting the following option to yes.
-always-show-logo yes
+always-show-logo no
 
 ################################ SNAPSHOTTING  ################################
 #

--- a/redis.conf
+++ b/redis.conf
@@ -930,7 +930,7 @@ lua-time-limit 5000
 # cluster-require-full-coverage yes
 
 # This option, when set to yes, prevents replicas from trying to failover its
-# master during master failures. However the master can still perform a
+# master during master failures. However the replica can still perform a
 # manual failover, if forced to do so.
 #
 # This is useful in different scenarios, especially in the case of multiple


### PR DESCRIPTION
Fix some wrong comments in redis.conf.

1, comment about always-show-logo is not consistent with code
2, comment about cluster-replica-no-failover is wrong since we can only do manualy failover upon replicas