### PR TITLE
Optimize rdb hash object loading

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -246,6 +246,13 @@ robj *createHashObject(void) {
     return o;
 }
 
+robj *createHashDictObject(void) {
+    dict *dict = dictCreate(&hashDictType, NULL);
+    robj *o = createObject(OBJ_HASH, dict);
+    o->encoding = OBJ_ENCODING_HT;
+    return o;
+}
+
 robj *createZsetObject(void) {
     zset *zs = zmalloc(sizeof(*zs));
     robj *o;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1496,10 +1496,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb) {
 
         if (len > server.hash_max_ziplist_entries) {
             o = createHashDictObject();
-            // avoid rehashing
-            if (len > DICT_HT_INITIAL_SIZE) {
-                dictExpand(o->ptr, len);
-            }
         } else {
             o = createHashObject();
         }

--- a/src/server.h
+++ b/src/server.h
@@ -1544,6 +1544,7 @@ robj *createZiplistObject(void);
 robj *createSetObject(void);
 robj *createIntsetObject(void);
 robj *createHashObject(void);
+robj *createHashDictObject(void);
 robj *createZsetObject(void);
 robj *createZsetZiplistObject(void);
 robj *createStreamObject(void);


### PR DESCRIPTION
Create a hash object with hash table encoding directly just as the set object loading did.

Avoid a type conversion from ziplist to hash table if the threshold is exceeded.