### PR TITLE
The function moduleUnregisterUsedAPI removes the wrong linked list node

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -4737,7 +4737,7 @@ int moduleUnregisterUsedAPI(RedisModule *module) {
         RedisModule *used = ln->value;
         listNode *ln = listSearchKey(used->usedby,module);
         if (ln) {
-            listDelNode(module->using,ln);
+            listDelNode(used->usedby,ln);
             count++;
         }
     }
@@ -4837,6 +4837,8 @@ void moduleLoadFromQueue(void) {
 }
 
 void moduleFreeModuleStructure(struct RedisModule *module) {
+    listRelease(module->using);
+    listRelease(module->usedby);
     listRelease(module->types);
     sdsfree(module->name);
     zfree(module);


### PR DESCRIPTION
This PR has not been verified, but I think the code obviously has some problems, so I tried to fix it.