### PR TITLE
redis-cli: Format reply of 'config get' to make it more readable.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -722,7 +722,7 @@ static void freeHintsCallback(void *ptr) {
 /* Send AUTH command to the server */
 static int cliAuth(void) {
     redisReply *reply;
-    if (config.auth == NULL) return REDIS_OK;
+    if (config.auth == NULL || strlen(config.auth) == 0) return REDIS_OK;
 
     reply = redisCommand(context,"AUTH %s",config.auth);
     if (reply != NULL) {
@@ -1486,7 +1486,7 @@ static int parseOptions(int argc, char **argv) {
         exit(1);
     }
 
-    if (!config.no_auth_warning && config.auth != NULL) {
+    if (!config.no_auth_warning && config.auth && strlen(config.auth) > 0) {
         fputs("Warning: Using a password with '-a' or '-u' option on the command"
               " line interface may not be safe.\n", stderr);
     }
@@ -1798,7 +1798,7 @@ static void repl(void) {
                         config.output = OUTPUT_RAW;
                         return; /* Return to evalMode to restart the session. */
                     } else {
-                        printf("Use 'restart' only in Lua debugging mode.");
+                        printf("Use 'restart' only in Lua debugging mode.\n");
                     }
                 } else if (argc == 3 && !strcasecmp(argv[0],"connect")) {
                     sdsfree(config.hostip);
@@ -2321,7 +2321,7 @@ static int clusterManagerNodeConnect(clusterManagerNode *node) {
      * commands. At the same time this improves the detection of real
      * errors. */
     anetKeepAlive(NULL, node->context->fd, REDIS_CLI_KEEPALIVE_INTERVAL);
-    if (config.auth) {
+    if (config.auth && strlen(config.auth) > 0) {
         redisReply *reply = redisCommand(node->context,"AUTH %s",config.auth);
         int ok = clusterManagerCheckRedisReply(node, reply, NULL);
         if (reply != NULL) freeReplyObject(reply);


### PR DESCRIPTION
When getting the configurations, as shown below, the readability of the output is really poor:
```
127.0.0.1:6379> config get ac*
 1) "active-defrag-threshold-lower"
 2) "10"
 3) "active-defrag-threshold-upper"
 4) "100"
 5) "active-defrag-ignore-bytes"
 6) "104857600"
 7) "active-defrag-cycle-min"
 8) "5"
 9) "active-defrag-cycle-max"
10) "75"
11) "active-defrag-max-scan-fields"
12) "1000"
13) "activerehashing"
14) "yes"
15) "activedefrag"
16) "no"
```
So I formatted the output as follows to make it more readable:
```
127.0.0.1:6379> config get ac*
1) active-defrag-threshold-lower: "10"
2) active-defrag-threshold-upper: "100"
3) active-defrag-ignore-bytes: "104857600"
4) active-defrag-cycle-min: "5"
5) active-defrag-cycle-max: "75"
6) active-defrag-max-scan-fields: "1000"
7) activerehashing: "yes"
8) activedefrag: "no"
```
> Please note that I have two separate commits. I am looking forward to your reply.