### PR TITLE
add channelCommand used for any command related for channel Operation

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -433,6 +433,7 @@ struct redisCommand sentinelcmds[] = {
     {"info",sentinelInfoCommand,-1,"",0,NULL,0,0,0,0,0},
     {"role",sentinelRoleCommand,1,"l",0,NULL,0,0,0,0,0},
     {"client",clientCommand,-2,"rs",0,NULL,0,0,0,0,0},
+    {"channel",channelCommand,-2,"rs",0,NULL,0,0,0,0,0},
     {"shutdown",shutdownCommand,-1,"",0,NULL,0,0,0,0,0}
 };
 

--- a/src/server.c
+++ b/src/server.c
@@ -279,6 +279,7 @@ struct redisCommand redisCommandTable[] = {
     {"object",objectCommand,-2,"r",0,NULL,2,2,2,0,0},
     {"memory",memoryCommand,-2,"r",0,NULL,0,0,0,0,0},
     {"client",clientCommand,-2,"as",0,NULL,0,0,0,0,0},
+    {"channel",channelCommand,-2,"as",0,NULL,0,0,0,0,0},
     {"eval",evalCommand,-3,"s",0,evalGetKeys,0,0,0,0,0},
     {"evalsha",evalShaCommand,-3,"s",0,evalGetKeys,0,0,0,0,0},
     {"slowlog",slowlogCommand,-2,"a",0,NULL,0,0,0,0,0},

--- a/src/server.h
+++ b/src/server.h
@@ -1387,6 +1387,9 @@ void getClientsMaxBuffers(unsigned long *longest_output_list,
 char *getClientPeerId(client *client);
 sds catClientInfoString(sds s, client *client);
 sds getAllClientsInfoString(void);
+sds getAllChannelList();
+sds getAllClientsChannelString();
+sds catClientChannelString(sds s, client *client);
 void rewriteClientCommandVector(client *c, int argc, ...);
 void rewriteClientCommandArgument(client *c, int i, robj *newval);
 void replaceClientCommandVector(client *c, int argc, robj **argv);
@@ -1990,6 +1993,7 @@ void dumpCommand(client *c);
 void objectCommand(client *c);
 void memoryCommand(client *c);
 void clientCommand(client *c);
+void channelCommand(client *c);
 void evalCommand(client *c);
 void evalShaCommand(client *c);
 void scriptCommand(client *c);


### PR DESCRIPTION
In Alibaba, we faced a problem that there were so many clients sub to a specific Channel. 
In our case, different client subscribed to different Channel. So the "client list" command cannot tell what which group a client in.
So we're recommended to get the client list for Channel.

I added a new Command "Channel" , so we can put any channel command  into it.  
In this code, I added two new command : 
1.  channel list 
     list all channel that a server contains separated by \n

`client 1:SUBSCRIBE abcd`
`client 2:SUBSCRIBE cdef.1234.`

so that 

`127.0.0.1:6379> channel list
"cdef.1234.\nabcd\n"`

2. channel listall [option]
    without [option] , it will list all clients and all channel that client subscribed to

`127.0.0.1:6379> channel listall`
`"id=3 addr=127.0.0.1:61572 channel=abcd\n\nid=5 addr=127.0.0.1:61574 channel=cdef.1234.\n"
`
    
with[option], it will list the clients that subscribed to the specific channel

`127.0.0.1:6379> channel listall abcd`
`"id=3 addr=127.0.0.1:61572 fd=8 name= age=115 idle=106 flags=N db=0 sub=1 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=subscribe\n"`

all data separated by \n

have fun:)