### PR TITLE
Make dbSwapDatabases take args as long

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -997,7 +997,7 @@ void scanDatabaseForReadyLists(redisDb *db) {
  *
  * Returns C_ERR if at least one of the DB ids are out of range, otherwise
  * C_OK is returned. */
-int dbSwapDatabases(int id1, int id2) {
+int dbSwapDatabases(long id1, long id2) {
     if (id1 < 0 || id1 >= server.dbnum ||
         id2 < 0 || id2 >= server.dbnum) return C_ERR;
     if (id1 == id2) return C_OK;


### PR DESCRIPTION
This prevents an integer overflow bug. Closes #5737.