### PR TITLE
Redis CLI: Fix broken interval and repeat behaviour (incluing in cluster mode)

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1141,7 +1141,7 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
     for (j = 0; j < argc; j++)
         argvlen[j] = sdslen(argv[j]);
 
-    while(repeat-- > 0) {
+    while(repeat < 0 || repeat-- > 0) {
         redisAppendCommandArgv(context,argc,(const char**)argv,argvlen);
         while (config.monitor_mode) {
             if (cliReadReply(output_raw) != REDIS_OK) exit(1);
@@ -1175,6 +1175,11 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
             } else if (!strcasecmp(command,"auth") && argc == 2) {
                 cliSelect();
             }
+        }
+        if (config.cluster_reissue_command){
+            /* If we need to reissue the command, break to prevent a
+               further 'repeat' number of dud interations */
+            break;
         }
         if (config.interval) usleep(config.interval);
         fflush(stdout); /* Make it grep friendly */
@@ -1569,12 +1574,12 @@ static int issueCommandRepeat(int argc, char **argv, long repeat) {
                 cliPrintContextError();
                 return REDIS_ERR;
             }
-         }
-         /* Issue the command again if we got redirected in cluster mode */
-         if (config.cluster_mode && config.cluster_reissue_command) {
+        }
+        /* Issue the command again if we got redirected in cluster mode */
+        if (config.cluster_mode && config.cluster_reissue_command) {
             cliConnect(CC_FORCE);
-         } else {
-             break;
+        } else {
+            break;
         }
     }
     return REDIS_OK;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1141,6 +1141,8 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
     for (j = 0; j < argc; j++)
         argvlen[j] = sdslen(argv[j]);
 
+    /* Negative repeat is allowed and causes infinite loop,
+       works well with the interval option. */
     while(repeat < 0 || repeat-- > 0) {
         redisAppendCommandArgv(context,argc,(const char**)argv,argvlen);
         while (config.monitor_mode) {


### PR DESCRIPTION
This addresses two problems, one where infinite (negative) repeat count is broken for all types for Redis, and another problem specific to cluster mode (where redirection is needed).

This fix now allows for and works correctly with negative (i.e. -1) repeat values passed with `-r` argument to redis-cli as documented [here](https://redis.io/topics/rediscli#continuously-run-the-same-command).

This broken behaviour exists currently (e504583b7806d946da9c3627784d551a742be4d0), and redis-cli will just exit immediately with repeat `-r <= 0` as opposed to send commands indefinitely as it should with `-r < 0`

The repeat feature seems to have regressed as a in 95b988b6c69083fff3e00271653c2239d482ea0d (though that commit removed a would-be long integer wrap-around to error) I've commented to hopefully prevent this happening again...

Additionally, this fix prevents a `repeat * interval` seconds hang spent doing nothing at the start before issuing commands in cluster mode (`-c`), where the command needed to redirect to a slot on another node, as commands were failing and waiting to be reissued but the sequence was fully repeated before being reissued. For example,

        redis-cli -c -r 10 -i 0.5 INCR test_key_not_on_6379

Would wrongly hang and show nothing for 5 seconds (10 * 0.5) before showing

        (integer) 1
        (integer) 2
        (integer) 3
        (integer) 4
        (integer) 5
        (integer) 6
        (integer) 7
        (integer) 8
        (integer) 9
        (integer) 10

at half second intervals as intended. Now it'll just hit one command needing a reissue before redirecting and running properly.

I can't think of an easy way to test the (rare) case where a key changes slot and therefore node mid-repeat, but it should work just fine.

Additionally there's a small white-space fix I noticed near this part of the code.