### PR TITLE
fix segmentfault when server start in unstable branch

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2185,7 +2185,6 @@ void initServer(void) {
     if (server.cluster_enabled) clusterInit();
     replicationScriptCacheInit();
     scriptingInit(1);
-    ACLInit();
     slowlogInit();
     latencyMonitorInit();
     bioInit();
@@ -4023,6 +4022,9 @@ int main(int argc, char **argv) {
     dictSetHashFunctionSeed((uint8_t*)hashseed);
     server.sentinel_mode = checkForSentinelMode(argc,argv);
     initServerConfig();
+
+    /* ACLInit should run before calling moduleInitModulesSystem */
+    ACLInit();
     moduleInitModulesSystem();
 
     /* Store the executable path and arguments in a safe place in order


### PR DESCRIPTION
@antirez current unstable branch code occurs segmentation fault when it starts to run.
because of Users variable is null.(so current version is always crashed)

ACLInit() should be called before moduleInit. because module code acl to call network code.

so I fixed it.