### PR TITLE
fix invalid user permission keyword and invalid reset to user->allowed_commands

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -153,7 +153,7 @@ int ACLSetUser(user *u, const char *op) {
     } else if (!strcasecmp(op,"allkeys") ||
                !strcasecmp(op,"~*"))
     {
-        memset(u->allowed_subcommands,255,sizeof(u->allowed_commands));
+        memset(u->allowed_commands,255,sizeof(u->allowed_commands));
         u->flags |= USER_FLAG_ALLKEYS;
     } else {
         return C_ERR;
@@ -165,7 +165,7 @@ int ACLSetUser(user *u, const char *op) {
 void ACLInit(void) {
     Users = raxNew();
     DefaultUser = ACLCreateUser("default",7);
-    ACLSetUser(DefaultUser,"+@all");
+    ACLSetUser(DefaultUser,"allkeys");
     ACLSetUser(DefaultUser,"on");
 }
 


### PR DESCRIPTION
There are two issues in ACLInit to call ACLSetUser.
1] using allkeys instead of "+@all"
 -> it is not +@all, in code, there is "allkeys", so I changed. but in RCP1, I think it is better to use +#all

2] invalid reset code
 -> I think memset needs allowed_commands, not allowed_subcommand. so it can cause crash.

@antirez 
