### PR TITLE
BITOP: propagate only when it really SET or DEL targetkey

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -757,11 +757,12 @@ void bitopCommand(client *c) {
         setKey(c->db,targetkey,o);
         notifyKeyspaceEvent(NOTIFY_STRING,"set",targetkey,c->db->id);
         decrRefCount(o);
+        server.dirty++;
     } else if (dbDelete(c->db,targetkey)) {
         signalModifiedKey(c->db,targetkey);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"del",targetkey,c->db->id);
+        server.dirty++;
     }
-    server.dirty++;
     addReplyLongLong(c,maxlen); /* Return the output string length in bytes. */
 }
 


### PR DESCRIPTION
For example:

    BITOP not targetkey sourcekey

If `targetkey` and `sourcekey` doesn't exist, `BITOP` has no effect,
we do not propagate it, thus can save aof and replica flow.