### PR TITLE
Compare-and-set functionality for XADD

### DIFF
--- a/src/help.h
+++ b/src/help.h
@@ -989,7 +989,7 @@ struct commandHelp {
     14,
     "5.0.0" },
     { "XADD",
-    "key [EXPECTLAST <ID>] [MAXLEN [~|=] <count>] <ID or *> field value [field value] ...",
+    "key [EXPECTLAST id outstrip-limit] [MAXLEN [~|=] count] id-or-* field value [field value] ...",
     "Appends a new entry to a stream",
     14,
     "5.0.0" },

--- a/src/help.h
+++ b/src/help.h
@@ -989,7 +989,7 @@ struct commandHelp {
     14,
     "5.0.0" },
     { "XADD",
-    "key ID field string [field string ...]",
+    "key [EXPECTLAST <ID>] [MAXLEN [~|=] <count>] <ID or *> field value [field value] ...",
     "Appends a new entry to a stream",
     14,
     "5.0.0" },

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1164,9 +1164,10 @@ void streamRewriteApproxMaxlen(client *c, stream *s, int maxlen_arg_idx) {
     decrRefCount(maxlen_obj);
 }
 
-/* XADD key [MAXLEN [~|=] <count>] <ID or *> [field value] [field value] ... */
+/* XADD key [EXPECTLAST <ID>] [MAXLEN [~|=] <count>] <ID or *> field value [field value] ... */
 void xaddCommand(client *c) {
-    streamID id;
+    streamID id, expected_last;
+    int expected_last_given = 0; /* Was EXPECTLAST value specified? */
     int id_given = 0; /* Was an ID different than "*" specified? */
     long long maxlen = -1;  /* If left to -1 no trimming is performed. */
     int approx_maxlen = 0;  /* If 1 only delete whole radix tree nodes, so
@@ -1202,6 +1203,11 @@ void xaddCommand(client *c) {
             }
             i++;
             maxlen_arg_idx = i;
+        } else if (!strcasecmp(opt,"expectlast") && moreargs) {
+            if (streamParseStrictIDOrReply(c,c->argv[i+1],&expected_last,0)
+                != C_OK) return;
+            expected_last_given = 1;
+            i++;
         } else {
             /* If we are here is a syntax error or a valid ID. */
             if (streamParseStrictIDOrReply(c,c->argv[i],&id,0) != C_OK) return;
@@ -1222,6 +1228,18 @@ void xaddCommand(client *c) {
     stream *s;
     if ((o = streamTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
     s = o->ptr;
+
+    streamID last_id = s->last_id;    
+    if (expected_last_given && streamCompareID(&expected_last, &last_id)) {
+        if (s->length) {
+            streamReplyWithRange(c, s, &last_id, &last_id, 1, 0, NULL, NULL,
+                STREAM_RWR_NOACK | STREAM_RWR_RAWENTRIES, NULL);
+        } else {
+            addReplyArrayLen(c,1);
+            addReplyStreamID(c,&last_id);
+        }
+        return;
+    }
 
     /* Append using the low level function and return the ID. */
     if (streamAppendItem(s,c->argv+field_pos,(c->argc-field_pos)/2,

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -61,25 +61,75 @@ start_server {
         assert_equal [lindex $items 1 1] {item 2 value b}
     }
 
-    test {XADD adds into a stream if EXPECTLAST value is equal to the last ID in the stream} {
+    test {XADD adds into a stream, if EXPECTLAST value is equal to the last ID in the stream} {
         r DEL mystream
-        set id1 [r XADD mystream EXPECTLAST 0 * item 1 value a]
-        r XADD mystream EXPECTLAST $id1 * item 2 value b
+        r XADD mystream EXPECTLAST 0 0 1-0 item 1 value a
+        r XADD mystream EXPECTLAST 1-0 0 2-0 item 2 value b
         assert_equal [r XLEN mystream] 2
         set items [r XRANGE mystream - +]
         assert_equal [lindex $items 0 1] {item 1 value a}
         assert_equal [lindex $items 1 1] {item 2 value b}
     }
 
-    test {XADD returns the last entry of the stream, if EXPECTLAST value differs from last entry's ID} {
-        set res [r XADD mystream EXPECTLAST 0 * item 3 value c]
-        assert_equal [dict get $res [dict keys $res]] {item 2 value b}
+    test {XADD returns an error, if EXPECTLAST value differs from the last ID, and outstrip limit == 0} {
+        assert_error "ERR stale EXPECTLAST value" {r XADD mystream EXPECTLAST 0 0 * item 1 value a}
+        assert_error "ERR stale EXPECTLAST value" {r XADD mystream EXPECTLAST 3-0 0 * item 1 value a}
+        # should work also for an empty stream
+        assert_error "ERR stale EXPECTLAST value" {r XADD emptystream EXPECTLAST 0-1 0 * item 1 value a}
+        # nothing has been added to the stream
+        assert_equal [r XLEN mystream] 2
     }
 
-    test {XADD returns zero entry, if the stream is empty, but EXPECTLAST value is not 0-0} {
-        r DEL mystream
-        set id [r XADD mystream EXPECTLAST 1 * item 1 value a]
-        assert {[streamCompareID $id 0-0] == 0}
+    test {XADD returns an empty array, if EXPECTLAST value > last ID, and outstrip limit > 0} {
+        assert_equal [array size [r XADD mystream EXPECTLAST 2-1 1 3-0 item 3 value c]] 0
+        # nothing has been added to the stream
+        assert_equal [r XLEN mystream] 2
+    }
+
+    test {XADD returns an empty array, if the stream is empty, and outstrip limit != 0} {
+        assert_equal [array size [r XADD emptystream EXPECTLAST 0-1 1 * item 1 value a]] 0
+        assert_equal [array size [r XADD emptystream EXPECTLAST 0-1 -1 * item 1 value a]] 0
+        # nothing has been added to the stream
+        assert_equal [r XLEN mystream] 2
+    }
+
+    test {XADD returns an array of entries from stale EXPECTLAST's successor, if outstrip limit > 0} {
+        # adding a bit more entries ("given" section)
+        r XADD mystream 3-0 item 3 value c
+        r XADD mystream 4-0 item 4 value d
+        assert_equal [r XLEN mystream] 4
+
+        set res [r XADD mystream EXPECTLAST 1-0 2 5-0 item 5 value e]
+        assert_equal [llength $res] 2
+        assert_equal [lindex $res 0 1] {item 2 value b}
+        assert_equal [lindex $res 1 1] {item 3 value c}
+
+        set res [r XADD mystream EXPECTLAST 3-0 2 5-0 item 5 value e]
+        assert_equal [llength $res] 1
+        assert_equal [lindex $res 0 1] {item 4 value d}
+        # no more entries
+
+        # nothing has been added to the stream
+        assert_equal [r XLEN mystream] 4
+    }
+
+    test {XADD returns an array of entries from the last one to the first, but limited by (-outstrip), if outstrip limit < 0} {
+        set res [r XADD mystream EXPECTLAST 1-0 -2 5-0 item 5 value e]
+        assert_equal [llength $res] 2
+        assert_equal [lindex $res 0 1] {item 4 value d}
+        assert_equal [lindex $res 1 1] {item 3 value c}
+
+        set res [r XADD mystream EXPECTLAST 555-0 -2 5-0 item 5 value e]
+        assert_equal [llength $res] 2
+        assert_equal [lindex $res 0 1] {item 4 value d}
+        assert_equal [lindex $res 1 1] {item 3 value c}
+
+        set res [r XADD mystream EXPECTLAST 1-0 -222 5-0 item 5 value e]
+        # limited by stream size
+        assert_equal [llength $res] 4
+
+        # nothing has been added to the stream
+        assert_equal [r XLEN mystream] 4
     }
 
     test {XADD IDs are incremental} {


### PR DESCRIPTION
Hi all,

I'd like to suggest a tiny extra feature - CaS logic for XADD command.
It might be useful for optimistic locking, when multiple clients try to append to the same stream. This in its turn can be useful when implementing distributed transactions along with event sourcing and sharding.

I do understand, that the distributed transactions are evil, but sometimes they are really needed, even though one should minimize their usage. Also I understand, that distributed txns can be implemented by different means - e.g. by different sync patterns between client nodes. Even more: CaS for XADD can be implemented via Lua scripts. However the proposed implementation seems more efficient.

The idea is to extend XADD syntax:

`XADD key [EXPECTLAST <ID>] [MAXLEN [~|=] <count>] <ID or *> field value [field value] ...`

1. XADD adds into a stream if EXPECTLAST value is equal to the last ID in the stream.
2. XADD returns the last entry of the stream, if EXPECTLAST value differs from last entry's ID.
3. XADD returns zero entry, if the stream is empty, but EXPECTLAST value is not 0-0.

An example of returned values (as seen in redis-cli):
```
127.0.0.1:6379> xadd mystream EXPECTLAST 0-0 * foo bar
"1547682307135-0"
127.0.0.1:6379> xadd mystream EXPECTLAST 0-0 * hello world
1) "1547682307135-0"
2) 1) "foo"
   2) "bar"
127.0.0.1:6379> FLUSHALL
OK
127.0.0.1:6379> xadd mystream EXPECTLAST 9999-0 * abc def
1) "0-0"
```

The feature is backwards compatible, and should not impact the performance. Also it seems not to violate any clustering logic, key expiration etc.

In addition I will make a pull request for Lettuce (Java Redis client) to support this feature (it's almost done).

Cheers,
Denis