### PR TITLE
fix clusterManagerGetAntiAffinityScore double free otypes

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2471,9 +2471,10 @@ static int clusterManagerGetAntiAffinityScore(clusterManagerNodeArray *ipnodes,
             }
             // Master type 'm' is always set as the first character of the
             // types string.
+            otypes = sdsdup(otypes);
             if (!node->replicate) types = sdscatprintf(otypes, "m%s", otypes);
             else types = sdscat(otypes, "s");
-            if (types != otypes) dictReplace(related, key, types);
+            dictReplace(related, key, types);
         }
         /* Now it's trivial to check, for each related group having the
          * same host, what is their local score. */


### PR DESCRIPTION
Both `sdscat` and `dictReplace` are free `otypes`. This issue can be detected by AddressSanitizer.

Below is a clang AddressSanitizer patch for Makefile. Reproduce crash by command `redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002`.

--------------------------------------------------------------------------------
diff --git a/src/Makefile b/src/Makefile                                                                          
index adf32d55..a8909577 100644                                  
--- a/src/Makefile                                                             
+++ b/src/Makefile                            
@@ -73,7 +73,9 @@ endif
 -include .make-settings

 FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
+FINAL_CFLAGS+=-fsanitize=address
 FINAL_LDFLAGS=$(LDFLAGS) $(REDIS_LDFLAGS) $(DEBUG)
+FINAL_LDFLAGS+=-fsanitize=address
 FINAL_LIBS=-lm
 DEBUG=-g -ggdb