### PR TITLE
Fix update dict resize policy

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -221,6 +221,8 @@ static void killAppendOnlyChild(void) {
     server.aof_rewrite_time_start = -1;
     /* Close pipes used for IPC between the two processes. */
     aofClosePipes();
+
+    updateDictResizePolicy();
 }
 
 /* Called when the user switches from "appendonly yes" to "appendonly no"

--- a/src/db.c
+++ b/src/db.c
@@ -451,6 +451,7 @@ void flushallCommand(client *c) {
     if (server.rdb_child_pid != -1) {
         kill(server.rdb_child_pid,SIGUSR1);
         rdbRemoveTempFile(server.rdb_child_pid);
+        updateDictResizePolicy();
     }
     if (server.saveparamslen > 0) {
         /* Normally rdbSave() will reset dirty, but we don't want this here

--- a/src/replication.c
+++ b/src/replication.c
@@ -1255,6 +1255,7 @@ void readSyncBulkPayload(aeEventLoop *el, int fd, void *privdata, int mask) {
                     (long) server.rdb_child_pid);
             kill(server.rdb_child_pid,SIGUSR1);
             rdbRemoveTempFile(server.rdb_child_pid);
+            updateDictResizePolicy();
         }
 
         if (rename(server.repl_transfer_tmpfile,server.rdb_filename) == -1) {


### PR DESCRIPTION
In our product environment, we found that master hold much less memory than its slave. 
Redis infos of the 2 nodes showed that master's dict struct hold more memory.

How did it happen?
1, Master began aof rewrite, which disabled dict resize policy.
2, Someone set appendonly to "no" before aof rewrite ended, which killed aof rewrite process. 
     Unfortunately, dict resize policy remained disabled.
3, Later, much more keys inserted into db, and slave expanded dict, while master did not, which made master hold less memory than its slave.