### PR TITLE
ZPOP should return an empty array if COUNT=0

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3140,7 +3140,10 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
     if (countarg) {
         if (getLongFromObjectOrReply(c,countarg,&count,NULL) != C_OK)
             return;
-        if (count < 0) count = 1;
+        if (count <= 0) {
+            addReplyNullArray(c);
+            return;
+        }
     }
 
     /* Check type and break on the first error, otherwise identify candidate. */


### PR DESCRIPTION
Instead of popping the entire zset. This is actually a bug caused by `while (--count)` which never ends if count=0 (server is not stuck in an infinite loop because it breaks the loop if all elements were popped)

before this commit:
```
127.0.0.1:6379> ZADD z 1 m1 2 m2 3 m3
(integer) 3
127.0.0.1:6379> ZPOPMAX z 0
1) "m3"
2) "3"
3) "m2"
4) "2"
5) "m1"
6) "1"
```

after:
```
127.0.0.1:6379> ZADD z 1 m1 2 m2 3 m3
(integer) 3
127.0.0.1:6379> ZPOPMAX z 0
(nil)
```