### PR TITLE
Use up-to-date system call to create epoll context

### DIFF
--- a/src/ae_epoll.c
+++ b/src/ae_epoll.c
@@ -45,7 +45,13 @@ static int aeApiCreate(aeEventLoop *eventLoop) {
         zfree(state);
         return -1;
     }
-    state->epfd = epoll_create(1024); /* 1024 is just a hint for the kernel */
+#ifdef EPOLL_CLOEXEC
+    state->epfd = epoll_create1(EPOLL_CLOEXEC);
+#else
+    /* Create the kernel epoll using the old interface.
+     * Since Linux 2.6.8, the size argument is ignored */
+    state->epfd = epoll_create(1024);
+#endif
     if (state->epfd == -1) {
         zfree(state->events);
         zfree(state);


### PR DESCRIPTION
epoll_create() is a deprecated, older variant of epoll_create1(). Older versions
of epoll_create() used to take a size argument to provide a hint about the
number of file descriptors to be watched. Nowadays the kernel dynamically sizes
the required data structures.