### PR TITLE
ACL: fix redis crash after LOAD aclfile

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1415,19 +1415,6 @@ void aclCommand(client *c) {
         } else {
             addReplyNull(c);
         }
-    } else if (!strcasecmp(sub,"load") && c->argc == 2) {
-        if (server.acl_filename[0] == '\0') {
-            addReplyError(c,"This Redis instance is not configured to use an ACL file. You may want to specify users via the ACL SETUSER command and then issue a CONFIG REWRITE (assuming you have a Redis configuration file set) in order to store users in the Redis configuration.");
-            return;
-        } else {
-            sds errors = ACLLoadFromFile(server.acl_filename);
-            if (errors == NULL) {
-                addReply(c,shared.ok);
-            } else {
-                addReplyError(c,errors);
-                sdsfree(errors);
-            }
-        }
     } else if (!strcasecmp(sub,"help")) {
         const char *help[] = {
 "LIST                              -- Show user details in config file format.",

--- a/src/server.h
+++ b/src/server.h
@@ -1747,6 +1747,7 @@ char *ACLSetUserStringError(void);
 int ACLLoadConfiguredUsers(void);
 sds ACLDescribeUser(user *u);
 void ACLLoadUsersAtStartup(void);
+sds ACLLoadFromFile(const char *filename);
 
 /* Sorted sets data type */
 


### PR DESCRIPTION
After command `ACL LOAD`, we should kill the old users clients just like what `deluser` does, or redis will crash.

Moreover, the subcommand `ACL LOAD` is dangerous IMO, so maybe move it to `debug` command is better I think.