### PR TITLE
Don't assume the __x86_64__ pointer size to avoid warnings on x32

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -803,7 +803,7 @@ static void *getMcontextEip(ucontext_t *uc) {
     #endif
 #elif defined(__linux__)
     /* Linux */
-    #if defined(__i386__)
+    #if defined(__i386__) || defined(__ILP32__)
     return (void*) uc->uc_mcontext.gregs[14]; /* Linux 32 */
     #elif defined(__X86_64__) || defined(__x86_64__)
     return (void*) uc->uc_mcontext.gregs[16]; /* Linux 64 */
@@ -915,7 +915,7 @@ void logRegisters(ucontext_t *uc) {
 /* Linux */
 #elif defined(__linux__)
     /* Linux x86 */
-    #if defined(__i386__)
+    #if defined(__i386__) || defined(__ILP32__)
     serverLog(LL_WARNING,
     "\n"
     "EAX:%08lx EBX:%08lx ECX:%08lx EDX:%08lx\n"


### PR DESCRIPTION
`__x86_64__` is defined on the on the x32 architecture and the conditionals in `debug.c` therefore assume the size of `(void*)` etc:

```
debug.c: In function 'getMcontextEip':
debug.c:757:12: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
     return (void*) uc->uc_mcontext.gregs[16]; /* Linux 64 */
            ^
debug.c: In function 'logRegisters':
debug.c:920:21: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
    logStackContent((void**)uc->uc_mcontext.gregs[15]);
```

We can remedy this by checking for `__ILP32__` first. See:

  https://wiki.debian.org/ArchitectureSpecificsMemo

... for more info.