### PR TITLE
Updated redis benchmark with us precision support

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -443,6 +443,7 @@ static int ipow(int base, int exp) {
 
 static void showLatencyReport(void) {
     int i, curlat = 0;
+    int usbetweenlat = ipow(10, MAX_LATENCY_PRECISION-config.precision);
     float perc, reqpersec;
 
     reqpersec = (float)config.requests_finished/((float)config.totlatency/1000);
@@ -457,8 +458,8 @@ static void showLatencyReport(void) {
 
         qsort(config.latency,config.requests,sizeof(long long),compareLatency);
         for (i = 0; i < config.requests; i++) {
-            if (config.latency[i]/ipow(10, MAX_LATENCY_PRECISION-config.precision) != curlat || i == (config.requests-1)) {
-                curlat = config.latency[i]/ipow(10, MAX_LATENCY_PRECISION-config.precision);
+            if (config.latency[i]/usbetweenlat != curlat || i == (config.requests-1)) {
+                curlat = config.latency[i]/usbetweenlat;
                 perc = ((float)(i+1)*100)/config.requests;
                 printf("%.2f%% <= %.*f milliseconds\n", perc, config.precision, curlat/pow(10.0, config.precision));
             }


### PR DESCRIPTION
Gives a slightly more useful result if you care about sub ms results, the default is the same behavior as before. 

./src/redis-benchmark -t set --precision 1 -n 500 -P 1
====== SET ======
  500 requests completed in 0.01 seconds
  50 parallel clients
  3 bytes payload
  keep alive: 1

0.20% <= 0.2 milliseconds
0.80% <= 0.3 milliseconds
30.80% <= 0.4 milliseconds
84.80% <= 0.5 milliseconds
94.60% <= 0.6 milliseconds
98.60% <= 0.7 milliseconds
100.00% <= 0.7 milliseconds
55555.56 requests per second
