### PR TITLE
Making deleting users better defined and update documentation

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1304,7 +1304,7 @@ void ACLLoadUsersAtStartup(void) {
  * ACL USERS
  * ACL CAT [<category>]
  * ACL SETUSER <username> ... acl rules ...
- * ACL DELUSER <username>
+ * ACL DELUSER <username> [...]
  * ACL GETUSER <username>
  */
 void aclCommand(client *c) {
@@ -1332,6 +1332,10 @@ void aclCommand(client *c) {
                 addReplyError(c,"The 'default' user cannot be removed");
                 return;
             }
+        }
+
+        for (int j = 2; j < c->argc; j++) {
+            sds username = c->argv[j]->ptr;
             user *u;
             if (raxRemove(Users,(unsigned char*)username,
                           sdslen(username),
@@ -1469,7 +1473,7 @@ void aclCommand(client *c) {
 "USERS                             -- List all the registered usernames.",
 "SETUSER <username> [attribs ...]  -- Create or modify a user.",
 "GETUSER <username>                -- Get the user details.",
-"DELUSER <username>                -- Delete a user.",
+"DELUSER <username> [...]          -- Delete a list of users.",
 "CAT                               -- List available categories.",
 "CAT <category>                    -- List commands inside category.",
 "WHOAMI                            -- Return the current connection username.",


### PR DESCRIPTION
If a client attempts to delete multiple user, and one of them is the default, it will delete all the users in the list before default but not after. I think this is inconsistent behavior and having any user being the default should cause no users to be deleted and an error get returned.

Also, documentation wasn't consistent with implementation.