### PR TITLE
Refactored manual computation of object length

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -636,23 +636,7 @@ void addReplyNullArray(client *c) {
 
 /* Create the length prefix of a bulk reply, example: $2234 */
 void addReplyBulkLen(client *c, robj *obj) {
-    size_t len;
-
-    if (sdsEncodedObject(obj)) {
-        len = sdslen(obj->ptr);
-    } else {
-        long n = (long)obj->ptr;
-
-        /* Compute how many bytes will take this integer as a radix 10 string */
-        len = 1;
-        if (n < 0) {
-            len++;
-            n = -n;
-        }
-        while((n = n/10) != 0) {
-            len++;
-        }
-    }
+    size_t len = stringObjectLen(obj);
 
     if (len < OBJ_SHARED_BULKHDR_LEN)
         addReply(c,shared.bulkhdr[len]);


### PR DESCRIPTION
The logic here is the same as the logic used for computing string length. This change just removes the duplicated logic. The stringObjectLen also has a check to make sure a string object is passed in which is missing here.