### PR TITLE
fix typo in rdb.c: fiil -> fill.

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2065,7 +2065,7 @@ eoferr: /* unexpected end of file is handled here with a fatal exit */
  * output is initialized and finalized.
  *
  * If you pass an 'rsi' structure initialied with RDB_SAVE_OPTION_INIT, the
- * loading code will fiil the information fields in the structure. */
+ * loading code will fill the information fields in the structure. */
 int rdbLoad(char *filename, rdbSaveInfo *rsi) {
     FILE *fp;
     rio rdb;


### PR DESCRIPTION
Is it a typo?