### PR TITLE
fix corrupt_rdb.c bug.Let the name of input rdb file name be valid.

### DIFF
--- a/utils/corrupt_rdb.c
+++ b/utils/corrupt_rdb.c
@@ -21,8 +21,9 @@ int main(int argc, char **argv) {
     }
 
     srand(time(NULL));
+    char *filename = argv[1];
     cycles = atoi(argv[2]);
-    fd = open("dump.rdb",O_RDWR);
+    fd = open(filename,O_RDWR);
     if (fd == -1) {
         perror("open");
         exit(1);


### PR DESCRIPTION
When you execute a binary program, the name of the RDB file is not valid parameter.
Because the program wrote the name dump.rdb as fix code. 
I made some bugfix, let the name of input rdb file name be valid.