### PR TITLE
Updated acl setuser to be all or nothing

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1378,18 +1378,33 @@ void aclCommand(client *c) {
     char *sub = c->argv[1]->ptr;
     if (!strcasecmp(sub,"setuser") && c->argc >= 3) {
         sds username = c->argv[2]->ptr;
+        /* Create a temporary user to validate and stage all changes against before
+         * applying to an existing user or creating a new user. If all arguments 
+         * are valid the user parameters will all be applied together. If there are
+         * any errors then none of the changes will be applied. */
+        user *tempu = ACLCreateUnlinkedUser();
+
         user *u = ACLGetUserByName(username,sdslen(username));
-        if (!u) u = ACLCreateUser(username,sdslen(username));
-        serverAssert(u != NULL);
+        if (u) ACLCopyUser(tempu, u);
+
         for (int j = 3; j < c->argc; j++) {
-            if (ACLSetUser(u,c->argv[j]->ptr,sdslen(c->argv[j]->ptr)) != C_OK) {
+            if (ACLSetUser(tempu,c->argv[j]->ptr,sdslen(c->argv[j]->ptr)) != C_OK) {
                 char *errmsg = ACLSetUserStringError();
                 addReplyErrorFormat(c,
                     "Error in ACL SETUSER modifier '%s': %s",
                     (char*)c->argv[j]->ptr, errmsg);
+
+                ACLFreeUser(tempu);
                 return;
             }
         }
+
+        if (!u) u = ACLCreateUser(username,sdslen(username));
+        serverAssert(u != NULL);
+
+        ACLCopyUser(u, tempu);
+        ACLFreeUser(tempu);
+
         addReply(c,shared.ok);
     } else if (!strcasecmp(sub,"deluser") && c->argc >= 3) {
         int deleted = 0;


### PR DESCRIPTION
This is similar to the ACL DELUSER change. ACL SETUSER will partially apply changes when there is an error. This gives an ambiguous response back to user and may cause unintended behavior.

This implementation is a lot slower, (~220K RPS vs ~150K RPS) but I think it is a clean way to do it and is comparable to the AOF implementation. Another implementation would be to copy the user at the beginning and on error copy everything back if there is an error and delete it if there is a new user. It's faster (~190K RPS) but I generally think doing all validation then applying is cleaner.

% redis-cli
127.0.0.1:6379> acl list
1) "user bob2 off -@all"
2) "user default on nopass ~* +@all"
127.0.0.1:6379> acl list
1) "user default on nopass ~* +@all"
127.0.0.1:6379> 
127.0.0.1:6379> 
127.0.0.1:6379> acl setuser test1
OK
127.0.0.1:6379> acl setuser test1 +get +set
OK
127.0.0.1:6379> acl setuser test2 +get +set
OK
127.0.0.1:6379> acl list
1) "user default on nopass ~* +@all"
2) "user test1 off -@all +get +set"
3) "user test2 off -@all +get +set"
127.0.0.1:6379> acl setuser test3 +get +wrong
(error) ERR Error in ACL SETUSER modifier '+wrong': Unknown command or category name in ACL
127.0.0.1:6379> acl setuser test4
OK
127.0.0.1:6379> acl setuser test4 +get +wrong
(error) ERR Error in ACL SETUSER modifier '+wrong': Unknown command or category name in ACL
127.0.0.1:6379> acl list
1) "user default on nopass ~* +@all"
2) "user test1 off -@all +get +set"
3) "user test2 off -@all +get +set"
4) "user test4 off -@all"
127.0.0.1:6379>