### PR TITLE
Updated redis-benchmark so it doesn't show 1 value above 2ms 

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1,4 +1,4 @@
-/* Redis benchmark utility.
+/* Redis benchmark utility. 
  *
  * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
  * All rights reserved.
@@ -461,18 +461,18 @@ static void showLatencyReport(void) {
             if (config.latency[i]/usbetweenlat != curlat ||
                 i == (config.requests-1))
             {
-                curlat = config.latency[i]/usbetweenlat;
-                perc = ((float)(i+1)*100)/config.requests;
-                printf("%.2f%% <= %.*f milliseconds\n", perc, config.precision,
-                    curlat/pow(10.0, config.precision));
-
                 /* After the 2 milliseconds latency to have percentages split
                  * by decimals will just add a lot of noise to the output. */
-                if (config.latency[i] > 2000) {
+                if (config.latency[i] >= 2000) {
                     config.precision = 0;
                     usbetweenlat = ipow(10,
                         MAX_LATENCY_PRECISION-config.precision);
                 }
+
+                curlat = config.latency[i]/usbetweenlat;
+                perc = ((float)(i+1)*100)/config.requests;
+                printf("%.2f%% <= %.*f milliseconds\n", perc, config.precision,
+                    curlat/pow(10.0, config.precision));
             }
         }
         printf("%.2f requests per second\n\n", reqpersec);


### PR DESCRIPTION
You introduced a minor inaccuracy when integrating my last pull request. This fixes it.

 % ./src/redis-benchmark -c 100 -n 1000000 -P 5 set a 5
====== set a 5 ======
  1000000 requests completed in 4.09 seconds
  100 parallel clients
  3 bytes payload
  keep alive: 1

0.00% <= 0.5 milliseconds
0.01% <= 0.6 milliseconds
0.17% <= 0.7 milliseconds
1.38% <= 0.8 milliseconds
4.24% <= 0.9 milliseconds
8.66% <= 1.0 milliseconds
14.89% <= 1.1 milliseconds
20.72% <= 1.2 milliseconds
26.50% <= 1.3 milliseconds
32.85% <= 1.4 milliseconds
39.99% <= 1.5 milliseconds
47.55% <= 1.6 milliseconds
56.15% <= 1.7 milliseconds
64.85% <= 1.8 milliseconds
72.33% <= 1.9 milliseconds
78.13% <= 2.0 milliseconds
82.75% <= 2.1 milliseconds <----- This guy being here makes the below one wrong
82.75% <= 2 milliseconds
99.81% <= 3 milliseconds
99.94% <= 4 milliseconds
99.95% <= 16 milliseconds
99.96% <= 17 milliseconds
99.98% <= 18 milliseconds
100.00% <= 19 milliseconds
100.00% <= 19 milliseconds
244498.77 requests per second
To


With change
% ./src/redis-benchmark --precision 1 -c 100 -n 1000000 -P 5 set a 5
====== set a 5 ======
  1000000 requests completed in 3.91 seconds
  100 parallel clients
  3 bytes payload
  keep alive: 1

0.00% <= 0.5 milliseconds
0.01% <= 0.6 milliseconds
0.31% <= 0.7 milliseconds
2.22% <= 0.8 milliseconds
6.36% <= 0.9 milliseconds
12.76% <= 1.0 milliseconds
22.33% <= 1.1 milliseconds
30.76% <= 1.2 milliseconds
38.03% <= 1.3 milliseconds
45.16% <= 1.4 milliseconds
52.57% <= 1.5 milliseconds
59.81% <= 1.6 milliseconds
67.43% <= 1.7 milliseconds
74.60% <= 1.8 milliseconds
80.36% <= 1.9 milliseconds
84.73% <= 2 milliseconds
99.85% <= 3 milliseconds
99.99% <= 4 milliseconds
100.00% <= 4 milliseconds
255754.47 requests per second