### PR TITLE
Cluster Manager: create command checks for issues during "CLUSTER MEET"

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3413,11 +3413,12 @@ static void clusterManagerWaitForClusterJoin(void) {
         sleep(1);
         if (++counter > check_after) {
             dict *status = clusterManagerGetLinkStatus();
+            dictIterator *iter = NULL;
             if (status != NULL && dictSize(status) > 0) {
                 printf("\n");
                 clusterManagerLogErr("Warning: %d node(s) may "
                                      "be unreachable\n", dictSize(status));
-                dictIterator *iter = dictGetIterator(status);
+                iter = dictGetIterator(status);
                 dictEntry *entry;
                 while ((entry = dictNext(iter)) != NULL) {
                     sds nodeaddr = (sds) dictGetKey(entry);
@@ -3447,11 +3448,11 @@ static void clusterManagerWaitForClusterJoin(void) {
                                          "from standard instance port.\n");
                     listEmpty(from);
                 }
-                dictReleaseIterator(iter);
-                dictRelease(status);
             }
+            if (iter != NULL) dictReleaseIterator(iter);
+            if (status != NULL) dictRelease(status);
             counter = 0;
-        } 
+        }
     }
     printf("\n");
 }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3889,7 +3889,7 @@ static list *clusterManagerGetDisconnectedLinks(clusterManagerNode *node) {
                             (strstr(link_status, "disconnected")));
         int handshaking = (strstr(flags, "handshake") != NULL);
         if (disconnected || handshaking) {
-            clusterManagerLink *link = malloc(sizeof(*link)); 
+            clusterManagerLink *link = zmalloc(sizeof(*link)); 
             link->node_name = sdsnew(nodename);
             link->node_addr = sdsnew(addr);
             link->connected = 0;
@@ -3908,6 +3908,7 @@ cleanup:
 static dict *clusterManagerGetLinkStatus(void) {
     if (cluster_manager.nodes == NULL) return NULL;
     dictType dtype = clusterManagerDictType;
+    dtype.keyDestructor = dictSdsDestructor;
     dtype.valDestructor = dictListDestructor;
     dict *status = dictCreate(&dtype, NULL);
     listIter li;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3437,11 +3437,11 @@ static void clusterManagerWaitForClusterJoin(void) {
                     if (parseClusterNodeAddress(nodeaddr, &node_ip,
                         &node_port, &node_bus_port) && node_bus_port) {
                         clusterManagerLogErr(" - The port %d of node %s may "
-                                             "be unreachable from:\n",
+                                             "be unreachable by:\n",
                                              node_bus_port, node_ip);
                     } else {
                         clusterManagerLogErr(" - Node %s may be unreachable "
-                                             "from:\n", nodeaddr);
+                                             "by:\n", nodeaddr);
                     }
                     listIter li;
                     listNode *ln;
@@ -3454,7 +3454,7 @@ static void clusterManagerWaitForClusterJoin(void) {
                     clusterManagerLogErr("Cluster bus ports must be reachable "
                                          "by every node.\nRemember that "
                                          "cluster bus ports are different "
-                                         "from standard instance port.\n");
+                                         "from standard instance ports.\n");
                     listEmpty(from);
                 }
             }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3413,8 +3413,8 @@ cleanup:
 /* Wait until the cluster configuration is consistent. */
 static void clusterManagerWaitForClusterJoin(void) {
     printf("Waiting for the cluster to join\n");
-    int counter = 0, 
-        check_after = CLUSTER_JOIN_CHECK_AFTER + 
+    int counter = 0,
+        check_after = CLUSTER_JOIN_CHECK_AFTER +
                       (int)(listLength(cluster_manager.nodes) * 0.15f);
     while(!clusterManagerIsConfigConsistent()) {
         printf(".");
@@ -3434,11 +3434,11 @@ static void clusterManagerWaitForClusterJoin(void) {
                     char *node_ip = NULL;
                     int node_port = 0, node_bus_port = 0;
                     list *from = (list *) dictGetVal(entry);
-                    if (parseClusterNodeAddress(nodeaddr, &node_ip, 
+                    if (parseClusterNodeAddress(nodeaddr, &node_ip,
                         &node_port, &node_bus_port) && node_bus_port) {
                         clusterManagerLogErr(" - The port %d of node %s may "
-                                             "be unreachable from:\n", 
-                                             node_bus_port, node_ip); 
+                                             "be unreachable from:\n",
+                                             node_bus_port, node_ip);
                     } else {
                         clusterManagerLogErr(" - Node %s may be unreachable "
                                              "from:\n", nodeaddr);
@@ -3873,12 +3873,12 @@ static list *clusterManagerGetDisconnectedLinks(clusterManagerNode *node) {
     char *lines = reply->str, *p, *line;
     while ((p = strstr(lines, "\n")) != NULL) {
         int i = 0;
-        *p = '\0'; 
+        *p = '\0';
         line = lines;
         lines = p + 1;
         char *nodename = NULL, *addr = NULL, *flags = NULL, *link_status = NULL;
         while ((p = strchr(line, ' ')) != NULL) {
-            *p = '\0'; 
+            *p = '\0';
             char *token = line;
             line = p + 1;
             if (i == 0) nodename = token;
@@ -3889,12 +3889,10 @@ static list *clusterManagerGetDisconnectedLinks(clusterManagerNode *node) {
             i++;
         }
         if (i == 7) link_status = line;
-        
-        if (nodename == NULL || addr == NULL || flags == NULL || 
-            link_status == NULL) 
-            continue;
+        if (nodename == NULL || addr == NULL || flags == NULL ||
+            link_status == NULL) continue;
         if (strstr(flags, "myself") != NULL) continue;
-        int disconnected = ((strstr(flags, "disconnected") != NULL) || 
+        int disconnected = ((strstr(flags, "disconnected") != NULL) ||
                             (strstr(link_status, "disconnected")));
         int handshaking = (strstr(flags, "handshake") != NULL);
         if (disconnected || handshaking) {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3437,11 +3437,11 @@ static void clusterManagerWaitForClusterJoin(void) {
                     if (parseClusterNodeAddress(nodeaddr, &node_ip,
                         &node_port, &node_bus_port) && node_bus_port) {
                         clusterManagerLogErr(" - The port %d of node %s may "
-                                             "be unreachable by:\n",
+                                             "be unreachable from:\n",
                                              node_bus_port, node_ip);
                     } else {
                         clusterManagerLogErr(" - Node %s may be unreachable "
-                                             "by:\n", nodeaddr);
+                                             "from:\n", nodeaddr);
                     }
                     listIter li;
                     listNode *ln;


### PR DESCRIPTION
Sometimes the cluster creation (using `redis-cli --cluster create`) cannot complete its task and gets stuck into an endless wait, since some nodes in the cluster could be unreachable during the "join" phase (when "CLUSTER MEET" command is invoked an all the nodes), ie. because their bus ports could be behind a firewall.

This PR introduces some checks that allow users to better understand what is happening, helping them to fix the problem.
These checks are performed every N seconds (the interval duration depends on the number of nodes).
If some node is found to be in handshaking or disconnected state after the "waiting interval", users are warned with an alert like the one below:

```
Warning: 1 node(s) may be unreachable
 - The port 17001 of node 127.0.0.1 may be unreachable from:
   127.0.0.1:7000
   localhost:7002
   localhost:7003
   127.0.0.1:7004
   127.0.0.1:7005
   localhost:7006
Cluster bus ports must be reachable by every node.
Remember that cluster bus ports are different from standard instance port.
```

If this kind of issues are detected, redis-cli keeps trying to join the cluster (in some cases the problem could automatically disappear after some time or the users could manually fix it).
