### PR TITLE
Fix client object release inconsistency in replication code

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1044,6 +1044,7 @@ void freeClient(client *c) {
  * should be valid for the continuation of the flow of the program. */
 void freeClientAsync(client *c) {
     if (c->flags & CLIENT_CLOSE_ASAP || c->flags & CLIENT_LUA) return;
+    unlinkClient(c);
     c->flags |= CLIENT_CLOSE_ASAP;
     listAddNodeTail(server.clients_to_close,c);
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -884,9 +884,11 @@ static void freeClientArgv(client *c) {
  * when we resync with our own master and want to force all our slaves to
  * resync with us as well. */
 void disconnectSlaves(void) {
-    while (listLength(server.slaves)) {
-        listNode *ln = listFirst(server.slaves);
-        freeClient((client*)ln->value);
+    listNode *ln;
+    listIter li;
+    listRewind(server.slaves, &li);
+    while ((ln = listNext(&li))) {
+        freeClientAsync((client*)ln->value);
     }
 }
 


### PR DESCRIPTION
Deferring clients prevents timing issues.