### PR TITLE
Increment delivery counter on XCLAIM unless RETRYCOUNT specified

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2279,8 +2279,12 @@ void xclaimCommand(client *c) {
             /* Update the consumer and idle time. */
             nack->consumer = consumer;
             nack->delivery_time = deliverytime;
-            /* Set the delivery attempts counter if given. */
-            if (retrycount >= 0) nack->delivery_count = retrycount;
+            /* Set the delivery attempts counter if given, otherwise autoincrement */
+            if (retrycount >= 0) {
+                nack->delivery_count = retrycount;
+            } else {
+                nack->delivery_count++;
+            }
             /* Add the entry in the new consumer local PEL. */
             raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
             /* Send the reply for this entry. */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2279,10 +2279,11 @@ void xclaimCommand(client *c) {
             /* Update the consumer and idle time. */
             nack->consumer = consumer;
             nack->delivery_time = deliverytime;
-            /* Set the delivery attempts counter if given, otherwise autoincrement */
+            /* Set the delivery attempts counter if given, otherwise 
+             * autoincrement unless JUSTID option provided */
             if (retrycount >= 0) {
                 nack->delivery_count = retrycount;
-            } else {
+            } else if (!justid) {
                 nack->delivery_count++;
             }
             /* Add the entry in the new consumer local PEL. */

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -195,6 +195,35 @@ start_server {
         assert_equal "" [lindex $reply 0]
     }
 
+    test {XCLAIM increments delivery count} {
+        # Add 3 items into the stream, and create a consumer group
+        r del mystream
+        set id1 [r XADD mystream * a 1]
+        set id2 [r XADD mystream * b 2]
+        set id3 [r XADD mystream * c 3]
+        r XGROUP CREATE mystream mygroup 0
+
+        # Client 1 reads item 1 from the stream without acknowledgements.
+        # Client 2 then claims pending item 1 from the PEL of client 1
+        set reply [
+            r XREADGROUP GROUP mygroup client1 count 1 STREAMS mystream >
+        ]
+        assert {[llength [lindex $reply 0 1 0 1]] == 2}
+        assert {[lindex $reply 0 1 0 1] eq {a 1}}
+        r debug sleep 0.2
+        set reply [
+            r XCLAIM mystream mygroup client2 10 $id1
+        ]
+        assert {[llength [lindex $reply 0 1]] == 2}
+        assert {[lindex $reply 0 1] eq {a 1}}
+
+        set reply [
+            r XPENDING mystream mygroup - + 10
+        ]
+        assert {[llength [lindex $reply 0]] == 4}
+        assert {[lindex $reply 0 3] == 2}
+    }
+
     start_server {} {
         set master [srv -1 client]
         set master_host [srv -1 host]


### PR DESCRIPTION
The [`XCLAIM` docs](https://redis.io/commands/xclaim) state:

> Moreover, as a side effect, **XCLAIM will increment the count of attempted deliveries of the message**. In this way messages that cannot be processed for some reason, for instance because the consumers crash attempting to process them, will start to have a larger counter and can be detected inside the system.

This PR makes the code match the documentation - with added semantics for `JUSTID` - whilst still allowing `RETRYCOUNT` to be specified manually. A [separate PR](antirez/redis-doc#1093) has been opened for clarifying documentation

My understanding of the way `streamPropagateXCLAIM()` works is that this change will safely propagate to replicas since retry count is pulled directly from the `streamNACK` struct.

Fixes #5194 