### PR TITLE
Replicas aren't allowed to run the replicaof command

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2038,6 +2038,14 @@ void replicaofCommand(client *c) {
     } else {
         long port;
 
+        if (c->flags & CLIENT_SLAVE)
+        {
+            /* If a client is already a replica they cannot run this command,
+	     * because it involves flushing all replicas (including this client) */
+            addReplyError(c, "Command is not valid when client is a replica.");
+            return;
+        }
+
         if ((getLongFromObjectOrReply(c, c->argv[2], &port, NULL) != C_OK))
             return;
 


### PR DESCRIPTION
Running the replicaof command when the client is already a replica puts us in a bad state.