### PR TITLE
fix a bufferoverflow bug

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2268,7 +2268,7 @@ static clusterManagerNode *clusterManagerNewNode(char *ip, int port) {
 static sds clusterManagerGetNodeRDBFilename(clusterManagerNode *node) {
     assert(config.cluster_manager_command.backup_dir);
     sds filename = sdsnew(config.cluster_manager_command.backup_dir);
-    if (filename[sdslen(filename)] - 1 != '/')
+    if (filename[sdslen(filename) - 1] != '/')
         filename = sdscat(filename, "/");
     filename = sdscatprintf(filename, "redis-node-%s-%d-%s.rdb", node->ip,
                             node->port, node->name);


### PR DESCRIPTION
This commit will fix bufferoverflow or wrong semantic bug in the source file redis-cli.c #5908 . Can anyone help to check it? Thanks. 