### PR TITLE
Extend REDISMODULE_CTX_FLAGS to indicate if command was sent by master

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1391,6 +1391,9 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
          flags |= REDISMODULE_CTX_FLAGS_LUA;
         if (ctx->client->flags & CLIENT_MULTI)
          flags |= REDISMODULE_CTX_FLAGS_MULTI;
+        /* Module command recieved from MASTER, is replicated. */
+        if (ctx->client->flags & CLIENT_MASTER)
+         flags |= REDISMODULE_CTX_FLAGS_REPLICATED;
     }
 
     if (server.cluster_enabled)

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -85,6 +85,9 @@
 #define REDISMODULE_CTX_FLAGS_OOM (1<<10)
 /* Less than 25% of memory available according to maxmemory. */
 #define REDISMODULE_CTX_FLAGS_OOM_WARNING (1<<11)
+/* The command was sent over the replication link. */
+#define REDISMODULE_CTX_FLAGS_REPLICATED (1<<12)
+
 
 #define REDISMODULE_NOTIFY_GENERIC (1<<2)     /* g */
 #define REDISMODULE_NOTIFY_STRING (1<<3)      /* $ */


### PR DESCRIPTION
Use-case, In RedisGraph the command `GRAPH.QUERY` handles both READ and WRITE queries as such the command is registered with the `write` flag.

As a result SLAVE instances can't handle the `GRAPH.QUERY` command unless we enable the `slave-read-only` configuration, in which case clients can send both read and **write** queries to a slave causing inconsistency.

This PR allows a SLAVE to inspect the source of an incoming request by checking a new flag: `REDISMODULE_CTX_FLAGS_REPLICATED`, this indicates that the command was sent as part of a replication by its MASTER, by doing so we're able to protect ourselves from reaching inconsistency while scaling out reads.

A simpler approach would have been extending RedisGraph API by introducing a new command GRAPH.READ_QUERY but we prefer to keep our API to a minimum, also I believe others will benefit from this change.