### PR TITLE
fix: fix the if condition in clusterManagerShowClusterInfo

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2841,7 +2841,7 @@ static void clusterManagerShowClusterInfo(void) {
                     replicas++;
             }
             redisReply *reply = CLUSTER_MANAGER_COMMAND(node, "DBSIZE");
-            if (reply != NULL || reply->type == REDIS_REPLY_INTEGER)
+            if (reply != NULL && reply->type == REDIS_REPLY_INTEGER)
                 dbsize = reply->integer;
             if (dbsize < 0) {
                 char *err = "";


### PR DESCRIPTION
The if condition in clusterManagerShowClusterInfo is:
if (reply != NULL || reply->type == REDIS_REPLY_INTEGER)

The "||" will lead this judgement condition to the wrong path:
1. if reply==NULL, the redis-cli will crash because of null pointer;
2. if reply!=NULL, the "reply->type == REDIS_REPLY_INTEGER" will not be executed, and after that "dbsize = reply->integer;" will always be executed.

I think "&&" should be here instead.