### PR TITLE
fix: After disk full and reset appendonly, the service cannot be restored

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -280,6 +280,7 @@ int startAppendOnly(void) {
     server.aof_state = AOF_WAIT_REWRITE;
     server.aof_last_fsync = server.unixtime;
     server.aof_fd = newfd;
+    server.aof_last_write_status = C_OK;
     return C_OK;
 }
 


### PR DESCRIPTION
Test:
1,redis-cli config set appendonly yes
2,dd ->txt.file //disk full
3,redis-cli set key1 value1 //result: ok
4,redis-cli set key2 value2 //result:err
5,redis-cli config set appendonly no
6,redis-cli config set appendonly yes
7,redis-cli set key3 value3 //result:err
8,rm txt.file  //disk free
9,redis-cli set key4 value4 //result:err
...error