### PR TITLE
fix: fix possible stack overflow in redis-check-aof.c

### DIFF
--- a/src/redis-check-aof.c
+++ b/src/redis-check-aof.c
@@ -37,7 +37,7 @@
     sprintf(error, "0x%16llx: %s", (long long)epos, __buf); \
 }
 
-static char error[1024];
+static char error[2048];
 static off_t epos;
 
 int consumeNewline(char *buf) {


### PR DESCRIPTION
The error is used by sprintf with __buf, the size of __buf is 1024, and the size of error is also 1024.
When the size of error message is near 1024, with the ""0x%16llx: %s",  this will have stack overflow problem.