### PR TITLE
Prevent dictRehashMilliseconds rehashing when safe iterator present

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -239,6 +239,8 @@ long long timeInMilliseconds(void) {
 
 /* Rehash for an amount of time between ms milliseconds and ms+1 milliseconds */
 int dictRehashMilliseconds(dict *d, int ms) {
+    if (d->iterators > 0) return 0;
+
     long long start = timeInMilliseconds();
     int rehashes = 0;
 


### PR DESCRIPTION
When a safe iterator is present, dictionary rehashing is supposed to be suspended.  However the ```dictRehashMilliseconds()``` function bypasses this check.  This probably doesn't affect any existing code as this function is only called on the main dictionary.  However for completeness/correctness this should be fixed.