### PR TITLE
Fixed timer warning

### DIFF
--- a/src/modules/hellotimer.c
+++ b/src/modules/hellotimer.c
@@ -40,7 +40,7 @@
 /* Timer callback. */
 void timerHandler(RedisModuleCtx *ctx, void *data) {
     REDISMODULE_NOT_USED(ctx);
-    printf("Fired %s!\n", data);
+    printf("Fired %s!\n", (char *)data);
     RedisModule_Free(data);
 }
 


### PR DESCRIPTION
Fixes a GCC warning for printf, which expects a type char * and not void *