### PR TITLE
Not over-allocate client query buffer when reading large objects.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1468,7 +1468,7 @@ int processMultibulkBuffer(client *c) {
                     c->qb_pos = 0;
                     /* Hint the sds library about the amount of bytes this string is
                      * going to contain. */
-                    c->querybuf = sdsMakeRoomFor(c->querybuf,ll+2);
+                    c->querybuf = sdsMakeRoomFor(c->querybuf,ll+2-sdslen(c->querybuf));
                 }
             }
             c->bulklen = ll;


### PR DESCRIPTION
In response to large client query buffer optimization introduced in https://github.com/antirez/redis/commit/1898e6ce7fad3fb1a5a6d469c281a23d0b000c7f. The calculation of the amount of remaining bytes we need to write to the query buffer was calculated wrong, as a result we are unnecessarily growing the client query buffer by sdslen(c->querybuf) always. This fix corrects that behavior. 

Please note the previous behavior prior to the before-mentioned change was correctly calculating the remaining additional bytes, and this change makes that calculate to be consistent. 