### PR TITLE
Return error when password is too long

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -538,7 +538,7 @@ void loadServerConfigFromString(char *config) {
             }
         } else if (!strcasecmp(argv[0],"requirepass") && argc == 2) {
             if (strlen(argv[1]) > CONFIG_AUTHPASS_MAX_LEN) {
-                err = "Password is longer than CONFIG_AUTHPASS_MAX_LEN";
+                err = "Password is longer than " STRINGIFY(CONFIG_AUTHPASS_MAX_LEN);
                 goto loaderr;
             }
             /* The old "requirepass" directive just translates to setting

--- a/src/server.h
+++ b/src/server.h
@@ -2280,4 +2280,8 @@ int populateCommandTableParseFlags(struct redisCommand *c, char *strflags);
 #define redisDebugMark() \
     printf("-- MARK %s:%d --\n", __FILE__, __LINE__)
 
+/* Macros for converting macros to strings */
+#define STRINGIFY_HELPER(x) #x
+#define STRINGIFY(x) STRINGIFY_HELPER(x)
+
 #endif


### PR DESCRIPTION
You can set a password that is too big to be checked and therefor you can never log in with it. This just adds validation and returns an error if you try to set a password that is too big. 

Also added stringify, which I think is a nice macro to have and removes the need for having duplicates for limits. 