### PR TITLE
Update per-slot key counts post-insertion/deletion

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1475,15 +1475,18 @@ void slotToKeyUpdateKey(robj *key, int add) {
     unsigned char *indexed = buf;
     size_t keylen = sdslen(key->ptr);
 
-    server.cluster->slots_keys_count[hashslot] += add ? 1 : -1;
     if (keylen+2 > 64) indexed = zmalloc(keylen+2);
     indexed[0] = (hashslot >> 8) & 0xff;
     indexed[1] = hashslot & 0xff;
     memcpy(indexed+2,key->ptr,keylen);
     if (add) {
-        raxInsert(server.cluster->slots_to_keys,indexed,keylen+2,NULL,NULL);
+        if (raxInsert(server.cluster->slots_to_keys,indexed,keylen+2,NULL,NULL) == 1) {
+            server.cluster->slots_keys_count[hashslot] += 1; // Increment the count only if a new key is inserted
+        }
     } else {
-        raxRemove(server.cluster->slots_to_keys,indexed,keylen+2,NULL);
+        if (raxRemove(server.cluster->slots_to_keys,indexed,keylen+2,NULL) ==  1) {
+            server.cluster->slots_keys_count[hashslot] -= 1; // Decrement the count only if an existing key is found and deleted
+        }
     }
     if (indexed != buf) zfree(indexed);
 }


### PR DESCRIPTION
Currently in Redis Cluster mode, the "slotToKeyUpdateKey" function which is responsible for bookkeeping per-slot key counts is updating the counts before actual key insertion or deletion.     

Therefore, if "slotToKeyUpdateKey" is called to insert an existing key or to delete a non-existing key, the per-slot key counts will not be accurate anymore. While there isn't a scenario where this could actually happen today, having the correctness of a function relies implicitly and entirely on the behaviors and decisions of its callers is not robust, hence the proposed change here.

Nan Yan
Amazon