### PR TITLE
dict expand take more space than expected

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -61,6 +61,7 @@
  * the number of elements and the buckets > dict_force_resize_ratio. */
 static int dict_can_resize = 1;
 static unsigned int dict_force_resize_ratio = 5;
+#define DICT_EXPAND_RATIO 0.75
 
 /* -------------------------- private prototypes ---------------------------- */
 
@@ -926,7 +927,7 @@ static int _dictExpandIfNeeded(dict *d)
      * table (global setting) or we should avoid it but the ratio between
      * elements/buckets is over the "safe" threshold, we resize doubling
      * the number of buckets. */
-    if (d->ht[0].used >= d->ht[0].size &&
+    if (d->ht[0].used >= d->ht[0].size * DICT_EXPAND_RATIO &&
         (dict_can_resize ||
          d->ht[0].used/d->ht[0].size > dict_force_resize_ratio))
     {


### PR DESCRIPTION
Symptom：
In Production Environment,we found the used_memory of master(about 19G) is larger than the used_memory of slave (about 17G), but
the dbsize of them (about 68,000,000) is equal. After I run flushall there used_memory go down to equal.
Analysis：
when the dbsize is almost reach to 67108864, slave ask for sync to master, at the same time clients send write command to master, the dbsize is just reach to 67108864, but now master's dict_can_resize = 0( because server.rdb_child_pid != -1), then expand is delayed, when rdb is finished, dbsize is larger than 67108864, then _dictNextPower of master become 67108864 * 4, but _dictNextPower of slave is 67108864 * 2.
Difference = (67108864 * 4 - 67108864 * 2 ) * 8B * 2 (because expired_dict and dict)