### PR TITLE
Fix race bug (between flushAppendOnly and fsync thread)

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -187,7 +187,7 @@ void *bioProcessBackgroundJobs(void *arg) {
         if (type == BIO_CLOSE_FILE) {
             close((long)job->arg1);
         } else if (type == BIO_AOF_FSYNC) {
-            redis_fsync((long)job->arg1);
+            fsyncAppendOnlyFile((long)job->arg1);
         } else if (type == BIO_LAZY_FREE) {
             /* What we free changes depending on what arguments are set:
              * arg1 -> free the object at pointer.

--- a/src/server.c
+++ b/src/server.c
@@ -2782,6 +2782,7 @@ void initServer(void) {
     server.child_info_data.magic = 0;
     aofRewriteBufferReset();
     server.aof_buf = sdsempty();
+    server.aof_fsync_offset = 0;
     server.lastsave = time(NULL); /* At startup we consider the DB saved. */
     server.lastbgsave_try = 0;    /* At startup we never tried to BGSAVE. */
     server.rdb_save_time_last = -1;
@@ -3537,7 +3538,7 @@ int prepareForShutdown(int flags) {
         /* Append only file: flush buffers and fsync() the AOF at exit */
         serverLog(LL_NOTICE,"Calling fsync() on the AOF file.");
         flushAppendOnlyFile(1);
-        redis_fsync(server.aof_fd);
+        fsyncAppendOnlyFile(server.aof_fd);
     }
 
     /* Create a new RDB file before exiting. */

--- a/src/server.h
+++ b/src/server.h
@@ -1134,12 +1134,13 @@ struct redisServer {
     /* AOF persistence */
     int aof_state;                  /* AOF_(ON|OFF|WAIT_REWRITE) */
     int aof_fsync;                  /* Kind of fsync() policy */
+    volatile off_t aof_fsync_offset;/* Minimum guaranteed AOF offset synced on disk */
     char *aof_filename;             /* Name of the AOF file */
     int aof_no_fsync_on_rewrite;    /* Don't fsync if a rewrite is in prog. */
     int aof_rewrite_perc;           /* Rewrite AOF if % growth is > M and... */
     off_t aof_rewrite_min_size;     /* the AOF file is at least N bytes. */
     off_t aof_rewrite_base_size;    /* AOF size on latest startup or rewrite. */
-    off_t aof_current_size;         /* AOF current size. */
+    volatile off_t aof_current_size;/* AOF current size. */
     int aof_rewrite_scheduled;      /* Rewrite once BGSAVE terminates. */
     pid_t aof_child_pid;            /* PID if rewriting process */
     list *aof_rewrite_buf_blocks;   /* Hold changes during an AOF rewrite. */
@@ -1731,6 +1732,7 @@ void aofRewriteBufferReset(void);
 unsigned long aofRewriteBufferSize(void);
 ssize_t aofReadDiffFromParent(void);
 void killAppendOnlyChild(void);
+void fsyncAppendOnlyFile(int fd);
 
 /* Child info */
 void openChildInfoPipe(void);


### PR DESCRIPTION
Tail of the AOF may never be synced to disk (until shutdown)

Consider the following scenario:
1. server executes INCR x - it is fed to aof_buf, beforeSleep is called,
flushAppendOnly, aof_buf is written to file and cleared, background
fsync thread starts (and ends), server.aof_last_fsync is set.
2. server executes INCR y (less than a second after INCR x) - it is fed
to aof_buf, beforeSleep is called, flushAppendOnly, aof_buf is written
to file and cleared, background fsync thread does not start because
it's been less than a second since server.aof_last_fsync was set.
3. on the next beforeSleep flushAppendOnly returns immediately
 because aof_buf is empty, without starting a sync and so on..

In order to fix the above we remember the last synced offset and
call fsync in flushAppendOnly if it's not as expected (different
from aof_current_size) even if aof_buf is empty

We use atomic operation on aof_current_size and aof_fsync_offset
because now they are read/written from 2 parallel threads (may
not be atomic in 32bit systems)