### PR TITLE
fix intrinsic-latency bug

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7601,7 +7601,7 @@ static void intrinsicLatencyModeStop(int s) {
 static void intrinsicLatencyMode(void) {
     long long test_end, run_time, max_latency = 0, runs = 0;
 
-    run_time = config.intrinsic_latency_duration*1000000;
+    run_time = (long long)config.intrinsic_latency_duration*1000000;
     test_end = ustime() + run_time;
     signal(SIGINT, intrinsicLatencyModeStop);
 


### PR DESCRIPTION
when I use `redis-cli --intrinsic-latency 3600`, it exits immediately。
like this: 
```
Max latency so far: 1 microseconds.

20 total runs (avg latency: -34748364.8000 microseconds / -34748364800.00 nanoseconds per run).
Worst run took -0x longer than the average latency.
```

I try to print the value of variable 'run_time' , and find that it's a negative number。
```
run_time so far: -694967296 microseconds.
start so far: 1554346634769841 microseconds.
end so far: 1554346634769844 microseconds.
Max latency so far: 3 microseconds.
test_end so far: 1554345939802543 microseconds.

1 total runs (avg latency: -694967296.0000 microseconds / -694967296000.00 nanoseconds per run).
Worst run took -0x longer than the average latency.
```

I fix it by changing the code `run_time = (long long)config.intrinsic_latency_duration*1000000;`