### PR TITLE
ACLs: fix Acls bugs && typo

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -699,6 +699,10 @@ int ACLSetUser(user *u, const char *op, ssize_t oplen) {
         u->flags &= ~USER_FLAG_NOPASS;
         listEmpty(u->passwords);
     } else if (op[0] == '>') {
+        if (oplen-1 > CONFIG_AUTHPASS_MAX_LEN) {
+            errno = EFBIG;
+            return C_ERR;
+        }
         sds newpass = sdsnewlen(op+1,oplen-1);
         listNode *ln = listSearchKey(u->passwords,newpass);
         /* Avoid re-adding the same password multiple times. */
@@ -820,6 +824,8 @@ char *ACLSetUserStringError(void) {
     else if (errno == ENODEV)
         errmsg = "The password you are trying to remove from the user does "
                  "not exist";
+    else if (errno == EFBIG)
+        errmsg = "The password is longer than CONFIG_AUTHPASS_MAX_LEN(512)";
     return errmsg;
 }
 

--- a/src/rax.c
+++ b/src/rax.c
@@ -1035,7 +1035,7 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
 
     /* If this node has no children, the deletion needs to reclaim the
      * no longer used nodes. This is an iterative process that needs to
-     * walk the three upward, deleting all the nodes with just one child
+     * walk the tree upward, deleting all the nodes with just one child
      * that are not keys, until the head of the rax is reached or the first
      * node with more than one child is found. */
 

--- a/src/server.c
+++ b/src/server.c
@@ -3307,7 +3307,7 @@ int processCommand(client *c) {
                         !c->authenticated;
     if (auth_required || DefaultUser->flags & USER_FLAG_DISABLED) {
         /* AUTH and HELLO are valid even in non authenticated state. */
-        if (c->cmd->proc != authCommand || c->cmd->proc == helloCommand) {
+        if (c->cmd->proc != authCommand && c->cmd->proc != helloCommand) {
             flagTransaction(c);
             addReply(c,shared.noautherr);
             return C_OK;


### PR DESCRIPTION
1. fix hello command is invalid in non authenticated state. because we can also use hello designated  AUTH option
```
if (auth_required || DefaultUser->flags & USER_FLAG_DISABLED) {
        /* AUTH and HELLO are valid even in non authenticated state. */
        if (c->cmd->proc != authCommand && c->cmd->proc != helloCommand) {
                // handle err
        }         
}
```
2. when calling ACLSetUser() to set user a password, we shound check if the length of password  is longer than CONFIG_AUTHPASS_MAX_LEN.
```
} else if (op[0] == '>') {
        if (oplen-1 > CONFIG_AUTHPASS_MAX_LEN) {
             // handle
        }
        // add password to list
}
```
3. fix a typo
```
three -> tree
```