### PR TITLE
 Fix comment about ACLGetCommandPerm() return values in server.h

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1742,7 +1742,7 @@ void receiveChildInfo(void);
 extern rax *Users;
 extern user *DefaultUser;
 void ACLInit(void);
-/* Return values for ACLCheckUserCredentials(). */
+/* Return values for ACLCheckCommandPerm(). */
 #define ACL_OK 0
 #define ACL_DENIED_CMD 1
 #define ACL_DENIED_KEY 2


### PR DESCRIPTION
Tends to issue #5999 - I've verified that the return values _ACL_OK_, _ACL_DENIED_CMD_ & _ACL_DENIED_KEY_ are actually being used by _ACLCheckCommandPerm_() and not by _ACLCheckUserCredentials_() from their definition in **acl.c**. Have changed the comment accordingly to avoid confusion.  Thanks!