### PR TITLE
Adds a "Modules" section to `INFO`

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -5244,6 +5244,25 @@ void addReplyLoadedModules(client *c) {
     dictReleaseIterator(di);
 }
 
+/* Helper function for the INFO command: adds loaded modules as to info's
+ * output.
+ * 
+ * After the call, the passed sds info string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds genModulesInfoString(sds info) {
+    dictIterator *di = dictGetIterator(modules);
+    dictEntry *de;
+
+    while ((de = dictNext(di)) != NULL) {
+        sds name = dictGetKey(de);
+        struct RedisModule *module = dictGetVal(de);
+
+        info = sdscatprintf(info, "module:name=%s,ver=%d\r\n", name, module->ver);
+    }
+    dictReleaseIterator(di);
+    return info;
+}
+
 /* Redis MODULE command.
  *
  * MODULE LOAD <path> [args...] */

--- a/src/server.c
+++ b/src/server.c
@@ -4291,6 +4291,13 @@ sds genRedisInfoString(char *section) {
         (long)c_ru.ru_utime.tv_sec, (long)c_ru.ru_utime.tv_usec);
     }
 
+    /* Modules */
+    if (allsections || defsections || !strcasecmp(section,"modules")) {
+        if (sections++) info = sdscat(info,"\r\n");
+        info = sdscatprintf(info,"# Modules\r\n");
+        info = genModulesInfoString(info);
+    }
+
     /* Command statistics */
     if (allsections || !strcasecmp(section,"commandstats")) {
         if (sections++) info = sdscat(info,"\r\n");

--- a/src/server.h
+++ b/src/server.h
@@ -2268,6 +2268,7 @@ void bugReportStart(void);
 void serverLogObjectDebugInfo(const robj *o);
 void sigsegvHandler(int sig, siginfo_t *info, void *secret);
 sds genRedisInfoString(char *section);
+sds genModulesInfoString(sds info);
 void enableWatchdog(int period);
 void disableWatchdog(void);
 void watchdogScheduleSignal(int period);


### PR DESCRIPTION
Fixes #6012.

As long as "INFO is broken", this should be adequate IMO. Once we rework
`INFO`, perhaps into RESP3, this implementation should be revisited.