### PR TITLE
fix cluster failover time out

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2579,7 +2579,7 @@ void replicationCron(void) {
 
     /* First, send PING according to ping_slave_period. */
     if ((replication_cron_loops % server.repl_ping_slave_period) == 0 &&
-        listLength(server.slaves))
+        listLength(server.slaves) && !clientsArePaused())
     {
         ping_argv[0] = createStringObject("PING",4);
         replicationFeedSlaves(server.slaves, server.slaveseldb,


### PR DESCRIPTION
Master may send "PING" to slave when client pause will let the manual cluster failover timeout or the other slave do full sync with new master.