### PR TITLE
Modify master-slave replication

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4559,7 +4559,7 @@ void loadDataFromDisk(void) {
                 (float)(ustime()-start)/1000000);
 
             /* Restore the replication ID / offset from the RDB file. */
-            if ((server.masterhost || (server.cluster_enabled && nodeIsSlave(server.cluster->myself)))&&
+            if ((server.masterhost || server.cluster_enabled)&&
                 rsi.repl_id_is_set &&
                 rsi.repl_offset != -1 &&
                 /* Note that older implementations may save a repl_stream_db


### PR DESCRIPTION
1.Master node restart must be full asynchronous replication
2.Master-slave switching, the slave node becomes the new master node, the original master node restarts, and only full-scale asynchronous replication can be performed.