### PR TITLE
PSYNC2: make partial sync possible after master reboot

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1703,6 +1703,7 @@ void clearReplicationId2(void);
 void chopReplicationBacklog(void);
 void replicationCacheMasterUsingMyself(void);
 void feedReplicationBacklog(void *ptr, size_t len);
+void createReplicationBacklog(void);
 
 /* Generic persistence functions */
 void startLoading(FILE *fp);


### PR DESCRIPTION
Hi @antirez, recently I have a talk with @braveHeart1996 about PSYNC2 who opened an issue #6030 .

Although the fix in PR #6031 is not right, but one interesting idea is that can we allow a master to load replication info?

Maybe we can load the replication info as a secondary ID and offset, just like what `replicaof no one` does, give a chance to replicas to partial resynchronizations with the rebooted master.

Just for discussion.