### PR TITLE
FIX: coredump in redis-benchmark

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1294,7 +1294,7 @@ int parseOptions(int argc, const char **argv) {
                 if (*p < '0' || *p > '9') goto invalid;
             }
             config.randomkeys = 1;
-            config.randomkeys_keyspacelen = atoi(argv[++i]);
+            config.randomkeys_keyspacelen = atoi(next);
             if (config.randomkeys_keyspacelen < 0)
                 config.randomkeys_keyspacelen = 0;
         } else if (!strcmp(argv[i],"-q")) {


### PR DESCRIPTION
redis-benchmark would core dump when the `-r` is the last arg


```c
Core was generated by `./redis-benchmark -p 7666 -a foobared -r 1000000'.
Program terminated with signal 11, Segmentation fault.
#0  0x00007f1409bfad47 in ____strtoll_l_internal () from /lib64/libc.so.6
Missing separate debuginfos, use: debuginfo-install glibc-2.17-157.el7.x86_64
(gdb) bt
#0  0x00007f1409bfad47 in ____strtoll_l_internal () from /lib64/libc.so.6
#1  0x00000000004118b1 in parseOptions (argc=argc@entry=7, argv=argv@entry=0x7fffe938b378) at redis-benchmark.c:1297
#2  0x000000000040c149 in main (argc=7, argv=0x7fffe938b378) at redis-benchmark.c:1495
(gdb) f 1
#1  0x00000000004118b1 in parseOptions (argc=argc@entry=7, argv=argv@entry=0x7fffe938b378) at redis-benchmark.c:1297
1297	            config.randomkeys_keyspacelen = atoi(argv[++i]);
(gdb) p argv[i]
$1 = 0x0
```