### PR TITLE
removed obsolete warning as per - https://github.com/antirez/redis/is…

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -824,13 +824,7 @@ aof-use-rdb-preamble yes
 lua-time-limit 5000
 
 ################################ REDIS CLUSTER  ###############################
-#
-# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-# WARNING EXPERIMENTAL: Redis Cluster is considered to be stable code, however
-# in order to mark it as "mature" we need to wait for a non trivial percentage
-# of users to deploy it in production.
-# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-#
+
 # Normal Redis instances can't be part of a Redis Cluster; only nodes that are
 # started as cluster nodes can. In order to start a Redis instance as a
 # cluster node enable the cluster support uncommenting the following:


### PR DESCRIPTION
As per the below issue redis cluster is pretty mush stable on production now
https://github.com/antirez/redis/issues/5291
Hence removing the warning in redis.cong