### PR TITLE
call freeFakeClientArgv when aof format error

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -762,7 +762,11 @@ int loadAppendOnlyFile(char *filename) {
                 freeFakeClientArgv(fakeClient);
                 goto readerr;
             }
-            if (buf[0] != '$') goto fmterr;
+            if (buf[0] != '$') {
+                fakeClient->argc = j; /* Free up to j-1. */
+                freeFakeClientArgv(fakeClient);
+                goto fmterr;
+            }
             len = strtol(buf+1,NULL,10);
             argsds = sdsnewlen(SDS_NOINIT,len);
             if (len && fread(argsds,len,1,fp) == 0) {


### PR DESCRIPTION
In **_aof.c:675_**

`if (buf[0] != '$') goto fmterr;`

It will goto **_fmterr_** when the aof is bad file format, but the memory of argv isn't freed.  We should free fake client‘s argv firstly.