### PR TITLE
fix undefine behavior of sdsjoin() and sdsjoinsds()

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -377,8 +377,10 @@ sds sdsgrowzero(sds s, size_t len) {
  * After the call, the passed sds string is no longer valid and all the
  * references must be substituted with the new pointer returned by the call. */
 sds sdscatlen(sds s, const void *t, size_t len) {
-    size_t curlen = sdslen(s);
-
+    size_t curlen 
+ 
+    if (s == NULL) return NULL;
+    curlen = sdslen(s);
     s = sdsMakeRoomFor(s,len);
     if (s == NULL) return NULL;
     memcpy(s+curlen, t, len);


### PR DESCRIPTION
sdsjoin() passes return value of sdscat() directly to sdscat() as the first argument, 
Since sdscat() may return NULL, it should can be passed a NULL argument to.

sdsjoinsds() has the same problem, change of sdscatlen() can fix it too.