### PR TITLE
WIP: Support zset-fifo-order

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1283,6 +1283,9 @@ set-max-intset-entries 512
 # elements of a sorted set are below the following limits:
 zset-max-ziplist-entries 128
 zset-max-ziplist-value 64
+# When multiple elements have the same score, they are ordered
+# lexicographically. If enable this flag, they are ordered by the added order.
+zset-fifo-order no
 
 # HyperLogLog sparse representation bytes limit. The limit includes the
 # 16 bytes header. When an HyperLogLog using the sparse representation crosses

--- a/src/config.c
+++ b/src/config.c
@@ -617,6 +617,10 @@ void loadServerConfigFromString(char *config) {
             server.zset_max_ziplist_entries = memtoll(argv[1], NULL);
         } else if (!strcasecmp(argv[0],"zset-max-ziplist-value") && argc == 2) {
             server.zset_max_ziplist_value = memtoll(argv[1], NULL);
+        } else if (!strcasecmp(argv[0],"zset-fifo-order") && argc == 2) {
+            if ((server.zset_fifo_order = yesnotoi(argv[1])) == -1) {
+                err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
         } else if (!strcasecmp(argv[0],"hll-sparse-max-bytes") && argc == 2) {
             server.hll_sparse_max_bytes = memtoll(argv[1], NULL);
         } else if (!strcasecmp(argv[0],"rename-command") && argc == 3) {

--- a/src/server.h
+++ b/src/server.h
@@ -1287,6 +1287,7 @@ struct redisServer {
     size_t set_max_intset_entries;
     size_t zset_max_ziplist_entries;
     size_t zset_max_ziplist_value;
+    int zset_fifo_order;
     size_t hll_sparse_max_bytes;
     size_t stream_node_max_bytes;
     int64_t stream_node_max_entries;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -142,6 +142,7 @@ zskiplistNode *zslInsert(zskiplist *zsl, double score, sds ele) {
         while (x->level[i].forward &&
                 (x->level[i].forward->score < score ||
                     (x->level[i].forward->score == score &&
+                    !server.zset_fifo_order &&
                     sdscmp(x->level[i].forward->ele,ele) < 0)))
         {
             rank[i] += x->level[i].span;
@@ -1066,7 +1067,7 @@ unsigned char *zzlInsert(unsigned char *zl, sds ele, double score) {
              * maintain ordering. */
             zl = zzlInsertAt(zl,eptr,ele,score);
             break;
-        } else if (s == score) {
+        } else if (s == score && !server.zset_fifo_order) {
             /* Ensure lexicographical ordering for elements. */
             if (zzlCompareElements(eptr,(unsigned char*)ele,sdslen(ele)) > 0) {
                 zl = zzlInsertAt(zl,eptr,ele,score);


### PR DESCRIPTION
Redis zset sort elements with the same value lexicographically.
However, in some occasion, we need a fifo order. 

If set the `zset-fifo-order` to `yes`,
```
127.0.0.1:6379> ZADD a 1 d 1 c 1 b
(integer) 0
127.0.0.1:6379> ZRANGE a 0 -1
1) "d"
2) "c"
3) "b"
```