### PR TITLE
Preserve client->id for blocked clients.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3866,7 +3866,10 @@ RedisModuleCtx *RM_GetThreadSafeContext(RedisModuleBlockedClient *bc) {
      * in order to keep things like the currently selected database and similar
      * things. */
     ctx->client = createClient(-1);
-    if (bc) selectDb(ctx->client,bc->dbid);
+    if (bc) {
+        selectDb(ctx->client,bc->dbid);
+        ctx->client->id = bc->client->id;
+    }
     return ctx;
 }
 


### PR DESCRIPTION
Currently `client->id` as returned by `RM_GetClientId()` is wrong for blocked clients.

Hi @antirez I came across unclear behavior in `RM_BlockClient()` which, if called from Lua or inside `MULTI` will allocate and return a blocked client but return an error.  As it is now it seems like a bug... I would expect the error to be immediate with no blocked client returned (NULL), is there some other (undocumented) intention to this behavior?