### PR TITLE
delete sdsTest() from REDIS_TEST in server.c to fix build failed

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4718,8 +4718,6 @@ int main(int argc, char **argv) {
             return sha1Test(argc, argv);
         } else if (!strcasecmp(argv[2], "util")) {
             return utilTest(argc, argv);
-        } else if (!strcasecmp(argv[2], "sds")) {
-            return sdsTest(argc, argv);
         } else if (!strcasecmp(argv[2], "endianconv")) {
             return endianconvTest(argc, argv);
         } else if (!strcasecmp(argv[2], "crc64")) {


### PR DESCRIPTION
sdsTest() defined in sds.c did not match the call in server.c, and `make CFLAGS=-DREDIS_TEST` will failed.
Remove it from REDIS_TEST, since test-sds had defined in Makefile.