### PR TITLE
[Minor] Fix build warnings on Linux

### DIFF
--- a/deps/hiredis/read.c
+++ b/deps/hiredis/read.c
@@ -31,6 +31,7 @@
 
 #include "fmacros.h"
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #ifndef _MSC_VER
 #include <unistd.h>

--- a/src/redis-check-aof.c
+++ b/src/redis-check-aof.c
@@ -37,7 +37,7 @@
     snprintf(error, sizeof(error), "0x%16llx: %s", (long long)epos, __buf); \
 }
 
-static char error[1024];
+static char error[1044];
 static off_t epos;
 
 int consumeNewline(char *buf) {


### PR DESCRIPTION
#### 1. Implicit declaration of strcasecmp in hiredis/read.c

This code is in `deps/hiredis/read.c` but seemingly not in the [redis/hiredis](https://github.com/redis/hiredis) repo.
Including `<strings.h>` clears the warning. See also [hiredis/#18](https://github.com/redis/hiredis/pull/18)

```
read.c: In function ‘processLineItem’:
read.c:295:21: warning: implicit declaration of function ‘strcasecmp’; [-Wimplicit-function-declaration]
                 if (strcasecmp(buf,",inf") == 0) {
                     ^~~~~~~~~~
```

#### 2. Enlarge error buffer in redis-check-aof.c

snprintf into error (size 1024) has a format string allowing sizeof(__buff) (1024) plus the full expansion of `"0x%16llx: "` which adds a further 20 characters. `snprintf` would prevent an overflow but the compiler warns against this truncation; enalrging the buffer by 20 chars clears this warning.

See also #5940 and b78ac354f41e370a4dc21ac01981cb0ccd0a1b7d

```
redis-check-aof.c:37:36: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
     snprintf(error, sizeof(error), "0x%16llx: %s", (long long)epos, __buf); \
                                    ^~~~~~~~~~~~~~
```

----

All tests pass bar the ongoing coincidental fail of Client output buffer hard limit is enforced in tests/unit/obuf-limits.tcl

```
Linux 5.0.5-200.fc29.x86_64 #1 SMP Wed Mar 27 20:58:04 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux

gcc (GCC) 8.3.1 20190223 (Red Hat 8.3.1-2)
```