### PR TITLE
Support cross compilation on uclibc targets and remove cpp warnings

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -62,7 +62,7 @@
 #endif
 
 /* Test for backtrace() */
-#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || \
+#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__) && !defined(__UCLIBC__)) || \
     defined(__FreeBSD__) || (defined(__OpenBSD__) && defined(USE_BACKTRACE))\
  || defined(__DragonFly__)
 #define HAVE_BACKTRACE 1

--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -55,7 +55,12 @@
 #define _POSIX_C_SOURCE 199506L
 #endif
 
+#ifndef _LARGEFILE_SOURCE
 #define _LARGEFILE_SOURCE
+#endif
+
+#ifndef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 64
+#endif
 
 #endif


### PR DESCRIPTION
This PR upstreams 2 patches that originated in the Buildroot project to:

* support cross-compilation on systems that use uclibc
* remove C preprocessor warnings that are emitted when some configuration options are given from the command line

See also https://github.com/buildroot/buildroot/tree/6ee03e29cf984fb236e1a0923f12d8ea4213aaf6/package/redis