### PR TITLE
fix: old gcc without atomic support compile failed

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -320,12 +320,17 @@ void loadServerConfigFromString(char *config) {
             }
             if(COMPILED_WITHOUT_ATOMIC_SUPPORT && server.io_threads_num > 1){
                 err = "The redis is compiled without atomic support. "
-                      "Need to recompile with gcc 4.9 version or newer.";
+                      "Need to recompile with gcc 5 version or newer.";
                 goto loaderr;
             }
         } else if (!strcasecmp(argv[0],"io-threads-do-reads") && argc == 2) {
             if ((server.io_threads_do_reads = yesnotoi(argv[1])) == -1) {
                 err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
+            if(COMPILED_WITHOUT_ATOMIC_SUPPORT && server.io_threads_do_reads == 1){
+                err = "The redis is compiled without atomic support. "
+                      "Need to recompile with gcc 5 version or newer.";
+                goto loaderr;
             }
         } else if (!strcasecmp(argv[0],"include") && argc == 2) {
             loadServerConfig(argv[1],NULL);

--- a/src/config.c
+++ b/src/config.c
@@ -318,6 +318,11 @@ void loadServerConfigFromString(char *config) {
             if (server.io_threads_num < 1 || server.io_threads_num > 512) {
                 err = "Invalid number of I/O threads"; goto loaderr;
             }
+            if(COMPILED_WITHOUT_ATOMIC_SUPPORT && server.io_threads_num > 1){
+                err = "The redis is compiled without atomic support. "
+                      "Need to recompile with gcc 4.9 version or newer.";
+                goto loaderr;
+            }
         } else if (!strcasecmp(argv[0],"io-threads-do-reads") && argc == 2) {
             if ((server.io_threads_do_reads = yesnotoi(argv[1])) == -1) {
                 err = "argument must be 'yes' or 'no'"; goto loaderr;

--- a/src/server.h
+++ b/src/server.h
@@ -77,6 +77,11 @@ typedef long long mstime_t; /* millisecond time type. */
 #define C_OK                    0
 #define C_ERR                   -1
 
+/* _Atomic Macro for old gcc without __STDC_NO_ATOMICS__ */
+#ifndef __STDC_NO_ATOMICS__
+#define _Atomic
+#endif
+
 /* Static server configuration */
 #define CONFIG_DEFAULT_DYNAMIC_HZ 1             /* Adapt hz to # of clients.*/
 #define CONFIG_DEFAULT_HZ        10             /* Time interrupt calls/sec. */

--- a/src/server.h
+++ b/src/server.h
@@ -78,8 +78,11 @@ typedef long long mstime_t; /* millisecond time type. */
 #define C_ERR                   -1
 
 /* _Atomic Macro for old gcc without __STDC_NO_ATOMICS__ */
-#ifndef __STDC_NO_ATOMICS__
+#ifdef __STDC_NO_ATOMICS__
 #define _Atomic
+#define COMPILED_WITHOUT_ATOMIC_SUPPORT 1
+#else
+#define COMPILED_WITHOUT_ATOMIC_SUPPORT 0 
 #endif
 
 /* Static server configuration */

--- a/src/server.h
+++ b/src/server.h
@@ -78,7 +78,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define C_ERR                   -1
 
 /* _Atomic Macro for old gcc without __STDC_NO_ATOMICS__ */
-#ifdef __STDC_NO_ATOMICS__
+#if (__GNUC__ < 5)
 #define _Atomic
 #define COMPILED_WITHOUT_ATOMIC_SUPPORT 1
 #else


### PR DESCRIPTION
**Problem:**
When use old gcc version, compile operation goes wrong as following:
In file included from server.c:30:0:
server.h:1026:5: error: expected specifier-qualifier-list before ‘_Atomic’
     _Atomic unsigned int lruclock; /* Clock for LRU eviction */

**Environment**
gcc --version:
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib64/gcc/x86_64-suse-linux/4.8/lto-wrapper
Target: x86_64-suse-linux
Configured with: ../configure --prefix=/usr --infodir=/usr/share/info --mandir=/usr/share/man --libdir=/usr/lib64 --libexecdir=/usr/lib64 --enable-languages=c,c++,objc,fortran,obj-c++,java,ada --enable-checking=release --with-gxx-include-dir=/usr/include/c++/4.8 --enable-ssp --disable-libssp --disable-plugin --with-bugurl=http://bugs.opensuse.org/ --with-pkgversion='SUSE Linux' --disable-libgcj --disable-libmudflap --with-slibdir=/lib64 --with-system-zlib --enable-__cxa_atexit --enable-libstdcxx-allocator=new --disable-libstdcxx-pch --enable-version-specific-runtime-libs --enable-linker-build-id --enable-linux-futex --program-suffix=-4.8 --without-system-libunwind --with-arch-32=i586 --with-tune=generic --build=x86_64-suse-linux --host=x86_64-suse-linux
Thread model: posix
gcc version 4.8.5 (SUSE Linux)

**Reason:**
In old gcc version like 4.7/8, there is a bug that miss the macro like [__STDC_NO_ATOMICS__
[https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53769](url)

And in [https://github.com/antirez/redis/commit/dd5b105c73a02389987e457cebbeaa801ba16977](url), we have used the "_Atomic", so old gcc version, compile operation will go wrong.
