### PR TITLE
SCAN: New Feature `SCAN cursor [TYPE type]` modifier suggested in issue #6107

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -613,7 +613,7 @@ int parseScanCursorOrReply(client *c, robj *o, unsigned long *cursor) {
 }
 
 /* This command implements SCAN, HSCAN and SSCAN commands.
- * If object 'o' is passed, then it must be a Hash or Set object, otherwise
+ * If object 'o' is passed, then it must be a Hash, Set or Zset object, otherwise
  * if 'o' is NULL the command will operate on the dictionary associated with
  * the current database.
  *
@@ -629,6 +629,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long cursor) {
     listNode *node, *nextnode;
     long count = 10;
     sds pat = NULL;
+    sds typename = NULL;
     int patlen = 0, use_pattern = 0;
     dict *ht;
 
@@ -665,6 +666,10 @@ void scanGenericCommand(client *c, robj *o, unsigned long cursor) {
             use_pattern = !(pat[0] == '*' && patlen == 1);
 
             i += 2;
+        } else if (!strcasecmp(c->argv[i]->ptr, "type") && o == NULL && j >= 2) {
+            /* SCAN for a particular type only applies to the db dict */
+            typename = c->argv[i+1]->ptr;
+            i+= 2;
         } else {
             addReply(c,shared.syntaxerr);
             goto cleanup;
@@ -757,6 +762,31 @@ void scanGenericCommand(client *c, robj *o, unsigned long cursor) {
                 len = ll2string(buf,sizeof(buf),(long)kobj->ptr);
                 if (!stringmatchlen(pat, patlen, buf, len, 0)) filter = 1;
             }
+        }
+
+        /* Filter an element if it isn't the type we want. */
+        if (!filter && o == NULL && typename){
+            robj* typecheck;
+            char *type;
+            typecheck = lookupKeyReadWithFlags(c->db, kobj, LOOKUP_NOTOUCH);
+            if (typecheck == NULL) {
+                type = "none";
+            } else {
+                switch(typecheck->type) {
+                case OBJ_STRING: type = "string"; break;
+                case OBJ_LIST: type = "list"; break;
+                case OBJ_SET: type = "set"; break;
+                case OBJ_ZSET: type = "zset"; break;
+                case OBJ_HASH: type = "hash"; break;
+                case OBJ_STREAM: type = "stream"; break;
+                case OBJ_MODULE: {
+                    moduleValue *mv = typecheck->ptr;
+                    type = mv->type->name;
+                }; break;
+                default: type = "unknown"; break;
+                }
+            }
+            if (strcasecmp((char*) typename, type)) filter = 1;
         }
 
         /* Filter element if it is an expired key. */

--- a/src/db.c
+++ b/src/db.c
@@ -767,7 +767,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long cursor) {
         /* Filter an element if it isn't the type we want. */
         if (!filter && o == NULL && typename){
             robj* typecheck = lookupKeyReadWithFlags(c->db, kobj, LOOKUP_NOTOUCH);
-            char* type = typeNameCanonicalize(typecheck);
+            char* type = getObjectTypeName(typecheck);
             if (strcasecmp((char*) typename, type)) filter = 1;
         }
 
@@ -827,7 +827,7 @@ void lastsaveCommand(client *c) {
     addReplyLongLong(c,server.lastsave);
 }
 
-char* typeNameCanonicalize(robj *o) {
+char* getObjectTypeName(robj *o) {
     char* type;
     if (o == NULL) {
         type = "none";
@@ -852,7 +852,7 @@ char* typeNameCanonicalize(robj *o) {
 void typeCommand(client *c) {
     robj *o;
     o = lookupKeyReadWithFlags(c->db,c->argv[1],LOOKUP_NOTOUCH);
-    addReplyStatus(c, typeNameCanonicalize(o));
+    addReplyStatus(c, getObjectTypeName(o));
 }
 
 void shutdownCommand(client *c) {

--- a/src/server.h
+++ b/src/server.h
@@ -646,7 +646,7 @@ typedef struct redisObject {
     void *ptr;
 } robj;
 
-/* The 'cannonical' name for a type as enumerated above is given by the
+/* The 'canonical' name for a type as enumerated above is given by the
  * below function. Native types are checked against the OBJ_STRING,
  * OBJ_LIST, OBJ_* defines, and Module types have their registered name
  * returned.*/

--- a/src/server.h
+++ b/src/server.h
@@ -646,6 +646,12 @@ typedef struct redisObject {
     void *ptr;
 } robj;
 
+/* The 'cannonical' name for a type as enumerated above is given by the
+ * below function. Native types are checked against the OBJ_STRING,
+ * OBJ_LIST, OBJ_* defines, and Module types have their registered name
+ * returned.*/
+char* typeNameCanonicalize(robj*);
+
 /* Macro used to initialize a Redis object allocated on the stack.
  * Note that this macro is taken near the structure definition to make sure
  * we'll update it when the structure is changed, to avoid bugs like

--- a/src/server.h
+++ b/src/server.h
@@ -646,11 +646,10 @@ typedef struct redisObject {
     void *ptr;
 } robj;
 
-/* The 'canonical' name for a type as enumerated above is given by the
- * below function. Native types are checked against the OBJ_STRING,
- * OBJ_LIST, OBJ_* defines, and Module types have their registered name
- * returned.*/
-char* typeNameCanonicalize(robj*);
+/* The a string name for an object's type as listed above
+ * Native types are checked against the OBJ_STRING, OBJ_LIST, OBJ_* defines,
+ * and Module types have their registered name returned. */
+char *getObjectTypeName(robj*);
 
 /* Macro used to initialize a Redis object allocated on the stack.
  * Note that this macro is taken near the structure definition to make sure


### PR DESCRIPTION
Extends the `SCAN` (but not `ZSCAN`, `HSCAN` etc.) API to

```
SCAN cursor [MATCH pattern] [COUNT count] [TYPE type]
```

This allows scanning the DB for keys of a single type, which may be useful for finding streams, garbage collection, migrations etc.

The feature was suggested by @gkorland in #6107.

The argument `type` is the string you get when asking Redis for the `TYPE` of a key, so works with modules as well as the native types. A quirk to be aware of here is that the GEO commands are backed by ZSETs not their own type, so they're not distinguishable from other ZSETs. Similarly, Hyperloglogs, bitmaps and bit fields are backed by strings so are also not distinguishable.

Additionally, for sparse types that are rare in the DB, this has the same behaviour as `MATCH` in that it may return many empty results before giving something, even for large `COUNTs`.

Also adds tests to check basic functionality of this optional `TYPE` keyword, and also tested with a module (redisgraph). Checked quickly with valgrind, no issues.

Copies name the type name canonicalisation code from `typeCommand`, perhaps this would be better factored out to prevent the two diverging and both needing to be edited to add new `OBJ_*` types, but this is a little fiddly/messy with C string, so I haven't addressed it.

The [redis-doc](https://github.com/antirez/redis-doc/blob/master/commands.json) repo will need to be updated with this new arg if accepted.

Many thanks as always 👍