### PR TITLE
use dlmopen for modules to clearly separate symbol namespace

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -29,6 +29,7 @@
 
 #include "server.h"
 #include "cluster.h"
+#define _GNU_SOURCE
 #include <dlfcn.h>
 
 #define REDISMODULE_CORE 1
@@ -5143,7 +5144,7 @@ int moduleLoad(const char *path, void **module_argv, int module_argc) {
     void *handle;
     RedisModuleCtx ctx = REDISMODULE_CTX_INIT;
 
-    handle = dlopen(path,RTLD_NOW|RTLD_LOCAL);
+    handle = dlmopen(LM_ID_NEWLM,path,RTLD_NOW|RTLD_LOCAL);
     if (handle == NULL) {
         serverLog(LL_WARNING, "Module %s failed to load: %s", path, dlerror());
         return C_ERR;

--- a/src/module.c
+++ b/src/module.c
@@ -29,7 +29,6 @@
 
 #include "server.h"
 #include "cluster.h"
-#define _GNU_SOURCE
 #include <dlfcn.h>
 
 #define REDISMODULE_CORE 1
@@ -5144,7 +5143,12 @@ int moduleLoad(const char *path, void **module_argv, int module_argc) {
     void *handle;
     RedisModuleCtx ctx = REDISMODULE_CTX_INIT;
 
+#ifdef __GLIBC__
     handle = dlmopen(LM_ID_NEWLM,path,RTLD_NOW|RTLD_LOCAL);
+#else
+    handle = dlopen(path,RTLD_NOW|RTLD_LOCAL);
+#endif
+
     if (handle == NULL) {
         serverLog(LL_WARNING, "Module %s failed to load: %s", path, dlerror());
         return C_ERR;


### PR DESCRIPTION
A module using same symbols as redis will end up calling functions in redis before its own.

I believe this is a bug and that isolation of namespaces is necessary, allowing for instance to embed Lua inside a module without interfering with the interpreter already present in Redis (see [Zenroom's module](https://github.com/DECODEproject/zenroom/wiki/Redis))

To fix I suggest to use `dlmopen(3)` on `_GNU_SOURCE` capable systems for complete isolation of runtime symbol namespace resolution. Attached is a very small patch based on redis 5.0.5

The problem addressed is also [debated here](https://bugzilla.redhat.com/show_bug.cgi?id=1621927) and mainly affects Linux based systems (GNU libc)