### PR TITLE
Nodes.conf does not update IP address of a node when IP changes after restart

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1368,6 +1368,7 @@ struct redisServer {
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
     /* System hardware info */
     size_t system_memory_size;  /* Total memory in system as reported by OS */
+    int refreshIP;
 };
 
 typedef struct pubsubPattern {


### PR DESCRIPTION
hi, I deploy redis cluster on kubernetes and face the same problem as https://github.com/antirez/redis/issues/4645

some way may solve it: 
1 https://github.com/antirez/redis/issues/5417
   I have test         command: ["redis-server"]   args: ["/conf/redis.conf", "--cluster-announce-ip", "$(POD_IP)"]
ip is right in src/redis-cli -p 6379 cluster nodes, but not save into node.conf


2  https://github.com/antirez/redis/issues/4645

3 give the restart pod a meet command from another node of the cluster,
   it would trigger a ip-refresh action, It is not a good way as it is already a member of the cluster
https://github.com/antirez/redis/blob/684b140a1355bbad45df4e13109c8cd6edb0960e/src/cluster.c#L1748

So I add a refreshIP flag in redisServer struct and triger once for refreshing myself-ip
not use changing the node.conf way in  https://github.com/antirez/redis/issues/4645 because there may be more than one ips on the same machine
