### PR TITLE
Typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Other C files
 * `sds.c` is the Redis string library, check http://github.com/antirez/sds for more information.
 * `anet.c` is a library to use POSIX networking in a simpler way compared to the raw interface exposed by the kernel.
 * `dict.c` is an implementation of a non-blocking hash table which rehashes incrementally.
-* `scripting.c` implements Lua scripting. It is completely self contained from the rest of the Redis implementation and is simple enough to understand if you are familar with the Lua API.
+* `scripting.c` implements Lua scripting. It is completely self contained from the rest of the Redis implementation and is simple enough to understand if you are familiar with the Lua API.
 * `cluster.c` implements the Redis Cluster. Probably a good read only after being very familiar with the rest of the Redis code base. If you want to read `cluster.c` make sure to read the [Redis Cluster specification][3].
 
 [3]: http://redis.io/topics/cluster-spec

--- a/redis.conf
+++ b/redis.conf
@@ -610,7 +610,7 @@ replica-priority 100
 #
 # aclfile /etc/redis/users.acl
 
-# IMPORTANT NOTE: starting with Redis 6 "requirepass" is just a compatiblity
+# IMPORTANT NOTE: starting with Redis 6 "requirepass" is just a compatibility
 # layer on top of the new ACL system. The option effect will be just setting
 # the password for the default user. Clients will still authenticate using
 # AUTH <password> as usually, or more explicitly with AUTH default <password>
@@ -1375,7 +1375,7 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 # client-query-buffer-limit 1gb
 
 # In the Redis protocol, bulk requests, that are, elements representing single
-# strings, are normally limited ot 512 mb. However you can change this limit
+# strings, are normally limited to 512 mb. However you can change this limit
 # here.
 #
 # proto-max-bulk-len 512mb

--- a/sentinel.conf
+++ b/sentinel.conf
@@ -239,6 +239,6 @@ sentinel deny-scripts-reconfig yes
 # SENTINEL SET can also be used in order to perform this configuration at runtime.
 #
 # In order to set a command back to its original name (undo the renaming), it
-# is possible to just rename a command to itsef:
+# is possible to just rename a command to itself:
 #
 # SENTINEL rename-command mymaster CONFIG CONFIG


### PR DESCRIPTION
s/familar/familiar/
s/compatiblity/compatibility/
s/ ot / to /
s/itsef/itself/

PS: Are you interested in typo fixes also for source code/tests? (I limited the fixes to docs + conf files in this PR)