### PR TITLE
Initial implementation of the module I/O filter API

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1321,12 +1321,12 @@ int ACLSaveToFile(const char *filename) {
     }
 
     /* Write it. */
-    if (write(fd,acl,sdslen(acl)) != (ssize_t)sdslen(acl)) {
+    if (writeNoFilter(fd,acl,sdslen(acl)) != (ssize_t)sdslen(acl)) {
         serverLog(LL_WARNING,"Writing ACL file for ACL SAVE: %s",
             strerror(errno));
         goto cleanup;
     }
-    close(fd); fd = -1;
+    closeNoFilter(fd); fd = -1;
 
     /* Let's replace the new file with the old one. */
     if (rename(tmpfilename,filename) == -1) {
@@ -1338,7 +1338,7 @@ int ACLSaveToFile(const char *filename) {
     retval = C_OK; /* If we reached this point, everything is fine. */
 
 cleanup:
-    if (fd != -1) close(fd);
+    if (fd != -1) closeNoFilter(fd);
     if (tmpfilename) unlink(tmpfilename);
     sdsfree(tmpfilename);
     sdsfree(acl);

--- a/src/bio.c
+++ b/src/bio.c
@@ -185,7 +185,7 @@ void *bioProcessBackgroundJobs(void *arg) {
 
         /* Process the job accordingly to its type. */
         if (type == BIO_CLOSE_FILE) {
-            close((long)job->arg1);
+            closeNoFilter((long)job->arg1);
         } else if (type == BIO_AOF_FSYNC) {
             redis_fsync((long)job->arg1);
         } else if (type == BIO_LAZY_FREE) {

--- a/src/childinfo.c
+++ b/src/childinfo.c
@@ -50,8 +50,8 @@ void closeChildInfoPipe(void) {
     if (server.child_info_pipe[0] != -1 ||
         server.child_info_pipe[1] != -1)
     {
-        close(server.child_info_pipe[0]);
-        close(server.child_info_pipe[1]);
+        closeNoFilter(server.child_info_pipe[0]);
+        closeNoFilter(server.child_info_pipe[1]);
         server.child_info_pipe[0] = -1;
         server.child_info_pipe[1] = -1;
     }
@@ -64,7 +64,7 @@ void sendChildInfo(int ptype) {
     server.child_info_data.magic = CHILD_INFO_MAGIC;
     server.child_info_data.process_type = ptype;
     ssize_t wlen = sizeof(server.child_info_data);
-    if (write(server.child_info_pipe[1],&server.child_info_data,wlen) != wlen) {
+    if (writeNoFilter(server.child_info_pipe[1],&server.child_info_data,wlen) != wlen) {
         /* Nothing to do on error, this will be detected by the other side. */
     }
 }
@@ -73,7 +73,7 @@ void sendChildInfo(int ptype) {
 void receiveChildInfo(void) {
     if (server.child_info_pipe[0] == -1) return;
     ssize_t wlen = sizeof(server.child_info_data);
-    if (read(server.child_info_pipe[0],&server.child_info_data,wlen) == wlen &&
+    if (readNoFilter(server.child_info_pipe[0],&server.child_info_data,wlen) == wlen &&
         server.child_info_data.magic == CHILD_INFO_MAGIC)
     {
         if (server.child_info_data.process_type == CHILD_INFO_TYPE_RDB) {

--- a/src/config.c
+++ b/src/config.c
@@ -2175,7 +2175,7 @@ int rewriteConfigOverwriteFile(char *configfile, sds content) {
      *    exist), get the size. */
     if (fd == -1) return -1; /* errno set by open(). */
     if (fstat(fd,&sb) == -1) {
-        close(fd);
+        closeNoFilter(fd);
         return -1; /* errno set by fstat(). */
     }
 
@@ -2191,7 +2191,7 @@ int rewriteConfigOverwriteFile(char *configfile, sds content) {
     }
 
     /* 3) Write the new content using a single write(2). */
-    if (write(fd,content_padded,strlen(content_padded)) == -1) {
+    if (writeNoFilter(fd,content_padded,strlen(content_padded)) == -1) {
         retval = -1;
         goto cleanup;
     }
@@ -2205,7 +2205,7 @@ int rewriteConfigOverwriteFile(char *configfile, sds content) {
 
 cleanup:
     sdsfree(content_padded);
-    close(fd);
+    closeNoFilter(fd);
     return retval;
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -1133,7 +1133,7 @@ int openDirectLogFiledes(void) {
 /* Used to close what closeDirectLogFiledes() returns. */
 void closeDirectLogFiledes(int fd) {
     int log_to_stdout = server.logfile[0] == '\0';
-    if (!log_to_stdout) close(fd);
+    if (!log_to_stdout) closeNoFilter(fd);
 }
 
 /* Logs the stack trace using the backtrace() call. This function is designed
@@ -1150,10 +1150,10 @@ void logStackTrace(ucontext_t *uc) {
     if (getMcontextEip(uc) != NULL) {
         char *msg1 = "EIP:\n";
         char *msg2 = "\nBacktrace:\n";
-        if (write(fd,msg1,strlen(msg1)) == -1) {/* Avoid warning. */};
+        if (writeNoFilter(fd,msg1,strlen(msg1)) == -1) {/* Avoid warning. */};
         trace[0] = getMcontextEip(uc);
         backtrace_symbols_fd(trace, 1, fd);
-        if (write(fd,msg2,strlen(msg2)) == -1) {/* Avoid warning. */};
+        if (writeNoFilter(fd,msg2,strlen(msg2)) == -1) {/* Avoid warning. */};
     }
 
     /* Write symbols to log file */
@@ -1248,17 +1248,17 @@ int memtest_test_linux_anonymous_maps(void) {
             "*** Preparing to test memory region %lx (%lu bytes)\n",
                 (unsigned long) start_vect[regions],
                 (unsigned long) size_vect[regions]);
-        if (write(fd,logbuf,strlen(logbuf)) == -1) { /* Nothing to do. */ }
+        if (writeNoFilter(fd,logbuf,strlen(logbuf)) == -1) { /* Nothing to do. */ }
         regions++;
     }
 
     int errors = 0;
     for (j = 0; j < regions; j++) {
-        if (write(fd,".",1) == -1) { /* Nothing to do. */ }
+        if (writeNoFilter(fd,".",1) == -1) { /* Nothing to do. */ }
         errors += memtest_preserving_test((void*)start_vect[j],size_vect[j],1);
-        if (write(fd, errors ? "E" : "O",1) == -1) { /* Nothing to do. */ }
+        if (writeNoFilter(fd, errors ? "E" : "O",1) == -1) { /* Nothing to do. */ }
     }
-    if (write(fd,"\n",1) == -1) { /* Nothing to do. */ }
+    if (writeNoFilter(fd,"\n",1) == -1) { /* Nothing to do. */ }
 
     /* NOTE: It is very important to close the file descriptor only now
      * because closing it before may result into unmapping of some memory

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2163,7 +2163,7 @@ void backgroundSaveDoneHandlerSocket(int exitcode, int bysignal) {
     if (!bysignal && exitcode == 0) {
         int readlen = sizeof(uint64_t);
 
-        if (read(server.rdb_pipe_read_result_from_child, ok_slaves, readlen) ==
+        if (readNoFilter(server.rdb_pipe_read_result_from_child, ok_slaves, readlen) ==
                  readlen)
         {
             readlen = ok_slaves[0]*sizeof(uint64_t)*2;
@@ -2172,7 +2172,7 @@ void backgroundSaveDoneHandlerSocket(int exitcode, int bysignal) {
              * uint64_t element in the array. */
             ok_slaves = zrealloc(ok_slaves,sizeof(uint64_t)+readlen);
             if (readlen &&
-                read(server.rdb_pipe_read_result_from_child, ok_slaves+1,
+                readNoFilter(server.rdb_pipe_read_result_from_child, ok_slaves+1,
                      readlen) != readlen)
             {
                 ok_slaves[0] = 0;
@@ -2180,8 +2180,8 @@ void backgroundSaveDoneHandlerSocket(int exitcode, int bysignal) {
         }
     }
 
-    close(server.rdb_pipe_read_result_from_child);
-    close(server.rdb_pipe_write_result_to_parent);
+    closeNoFilter(server.rdb_pipe_read_result_from_child);
+    closeNoFilter(server.rdb_pipe_write_result_to_parent);
 
     /* We can continue the replication process with all the slaves that
      * correctly received the full payload. Others are terminated. */
@@ -2360,7 +2360,7 @@ int rdbSaveToSlavesSockets(rdbSaveInfo *rsi) {
              * process with all the childre that were waiting. */
             msglen = sizeof(uint64_t)*(1+2*numfds);
             if (*len == 0 ||
-                write(server.rdb_pipe_write_result_to_parent,msg,msglen)
+                writeNoFilter(server.rdb_pipe_write_result_to_parent,msg,msglen)
                 != msglen)
             {
                 retval = C_ERR;
@@ -2391,8 +2391,8 @@ int rdbSaveToSlavesSockets(rdbSaveInfo *rsi) {
                     }
                 }
             }
-            close(pipefds[0]);
-            close(pipefds[1]);
+            closeNoFilter(pipefds[0]);
+            closeNoFilter(pipefds[1]);
             closeChildInfoPipe();
         } else {
             server.stat_fork_time = ustime()-start;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -138,6 +138,17 @@ typedef uint64_t RedisModuleTimerID;
 /* Do filter RedisModule_Call() commands initiated by module itself. */
 #define REDISMODULE_CMDFILTER_NOSELF    (1<<0)
 
+/* I/O Filter Functions */
+enum MODULE_FD_EVENT
+{
+    MODULE_FD_ACCEPT,
+    MODULE_FD_CLOSE,
+    MODULE_FD_OPEN,
+};
+typedef int (*fn_module_fdevt)(int fd, enum MODULE_FD_EVENT evt, void (*after)(int, uint64_t), uint64_t arg);
+typedef int (*fn_module_fdrd)(int fd, void *buf, size_t cb, ssize_t *pccbRead);
+typedef int (*fn_module_fdwr)(int fd, const void *buf, size_t cb, ssize_t *pccbWritten);
+
 /* ------------------------- End of common defines ------------------------ */
 
 #ifndef REDISMODULE_CORE
@@ -354,6 +365,10 @@ const RedisModuleString *REDISMODULE_API_FUNC(RedisModule_CommandFilterArgGet)(R
 int REDISMODULE_API_FUNC(RedisModule_CommandFilterArgInsert)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg);
 int REDISMODULE_API_FUNC(RedisModule_CommandFilterArgReplace)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg);
 int REDISMODULE_API_FUNC(RedisModule_CommandFilterArgDelete)(RedisModuleCommandFilterCtx *fctx, int pos);
+
+int REDISMODULE_API_FUNC(RedisModule_RegisterFdEventFilter)(fn_module_fdevt fn);
+int REDISMODULE_API_FUNC(RedisModule_RegisterFdRdFilter)(int fd, fn_module_fdrd fn);
+int REDISMODULE_API_FUNC(RedisModule_RegisterFdWrFilter)(int fd, fn_module_fdwr fn);
 #endif
 
 /* This is included inline inside each Redis module. */
@@ -524,6 +539,9 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(CommandFilterArgInsert);
     REDISMODULE_GET_API(CommandFilterArgReplace);
     REDISMODULE_GET_API(CommandFilterArgDelete);
+    REDISMODULE_GET_API(RegisterFdEventFilter);
+    REDISMODULE_GET_API(RegisterFdRdFilter);
+    REDISMODULE_GET_API(RegisterFdWrFilter);
 #endif
 
     if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;

--- a/src/rio.c
+++ b/src/rio.c
@@ -202,7 +202,7 @@ static size_t rioFdsetWrite(rio *r, const void *buf, size_t len) {
              * of short writes. */
             size_t nwritten = 0;
             while(nwritten != count) {
-                retval = write(r->io.fdset.fds[j],p+nwritten,count-nwritten);
+                retval = writeWithFilters(r->io.fdset.fds[j],p+nwritten,count-nwritten);
                 if (retval <= 0) {
                     /* With blocking sockets, which is the sole user of this
                      * rio target, EWOULDBLOCK is returned only because of

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1670,7 +1670,7 @@ void ldbSendLogs(void) {
         proto = sdscatlen(proto,"\r\n",2);
         listDelNode(ldb.logs,ln);
     }
-    if (write(ldb.fd,proto,sdslen(proto)) == -1) {
+    if (writeNoFilter(ldb.fd,proto,sdslen(proto)) == -1) {
         /* Avoid warning. We don't check the return value of write()
          * since the next read() will catch the I/O error and will
          * close the debugging session. */
@@ -2332,7 +2332,7 @@ int ldbRepl(lua_State *lua) {
     while(1) {
         while((argv = ldbReplParseCommand(&argc)) == NULL) {
             char buf[1024];
-            int nread = read(ldb.fd,buf,sizeof(buf));
+            int nread = readNoFilter(ldb.fd,buf,sizeof(buf));
             if (nread <= 0) {
                 /* Make sure the script runs without user input since the
                  * client is no longer connected. */

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1936,11 +1936,11 @@ void sentinelFlushConfig(void) {
     if (rewrite_status == -1) goto werr;
     if ((fd = open(server.configfile,O_RDONLY)) == -1) goto werr;
     if (fsync(fd) == -1) goto werr;
-    if (close(fd) == EOF) goto werr;
+    if (closeNoFilter(fd) == EOF) goto werr;
     return;
 
 werr:
-    if (fd != -1) close(fd);
+    if (fd != -1) closeNoFilter(fd);
     serverLog(LL_WARNING,"WARNING: Sentinel was not able to save the new configuration on disk!!!: %s", strerror(errno));
 }
 

--- a/src/syncio.c
+++ b/src/syncio.c
@@ -58,7 +58,7 @@ ssize_t syncWrite(int fd, char *ptr, ssize_t size, long long timeout) {
 
         /* Optimistically try to write before checking if the file descriptor
          * is actually writable. At worst we get EAGAIN. */
-        nwritten = write(fd,ptr,size);
+        nwritten = writeWithFilters(fd,ptr,size);
         if (nwritten == -1) {
             if (errno != EAGAIN) return -1;
         } else {
@@ -95,7 +95,7 @@ ssize_t syncRead(int fd, char *ptr, ssize_t size, long long timeout) {
 
         /* Optimistically try to read before checking if the file descriptor
          * is actually readable. At worst we get EAGAIN. */
-        nread = read(fd,ptr,size);
+        nread = readWithFilters(fd,ptr,size);
         if (nread == 0) return -1; /* short read. */
         if (nread == -1) {
             if (errno != EAGAIN) return -1;


### PR DESCRIPTION
This is based upon discussions in the modssl project.  This change allows modules to filter socket I/O so they can do interesting things like support SSL encryption.  I've explicitly overriden the read/write system calls to readWithFilter, writeWithFilter, etc.  This is to be explicit however it would be possible to just override them with a #define and reduce the churn.

Note: Replication and Cluster support are not yet tested.  Coming soon.