### PR TITLE
Made brpoplpush and spop with count atomic when replicating

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -523,11 +523,8 @@ void moduleHandlePropagationAfterCommandCallback(RedisModuleCtx *ctx) {
     /* Handle the replication of the final EXEC, since whatever a command
      * emits is always wrapped around MULTI/EXEC. */
     if (ctx->flags & REDISMODULE_CTX_MULTI_EMITTED) {
-        robj *propargv[1];
-        propargv[0] = createStringObject("EXEC",4);
-        alsoPropagate(server.execCommand,c->db->id,propargv,1,
+        alsoPropagate(server.execCommand,c->db->id,&shared.exec,1,
             PROPAGATE_AOF|PROPAGATE_REPL);
-        decrRefCount(propargv[0]);
     }
 }
 

--- a/src/multi.c
+++ b/src/multi.c
@@ -106,11 +106,8 @@ void discardCommand(client *c) {
 /* Send a MULTI command to all the slaves and AOF file. Check the execCommand
  * implementation for more information. */
 void execCommandPropagateMulti(client *c) {
-    robj *multistring = createStringObject("MULTI",5);
-
-    propagate(server.multiCommand,c->db->id,&multistring,1,
+    propagate(server.multiCommand,c->db->id,&shared.multi,1,
               PROPAGATE_AOF|PROPAGATE_REPL);
-    decrRefCount(multistring);
 }
 
 void execCommand(client *c) {

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1450,11 +1450,8 @@ void evalGenericCommand(client *c, int evalsha) {
     if (server.lua_replicate_commands) {
         preventCommandPropagation(c);
         if (server.lua_multi_emitted) {
-            robj *propargv[1];
-            propargv[0] = createStringObject("EXEC",4);
-            alsoPropagate(server.execCommand,c->db->id,propargv,1,
+            alsoPropagate(server.execCommand,c->db->id,&shared.exec,1,
                 PROPAGATE_AOF|PROPAGATE_REPL);
-            decrRefCount(propargv[0]);
         }
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -2181,6 +2181,8 @@ void createSharedObjects(void) {
     shared.rpoplpush = createStringObject("RPOPLPUSH",9);
     shared.zpopmin = createStringObject("ZPOPMIN",7);
     shared.zpopmax = createStringObject("ZPOPMAX",7);
+    shared.multi = createStringObject("MULTI",5);
+    shared.exec = createStringObject("EXEC",4);
     for (j = 0; j < OBJ_SHARED_INTEGERS; j++) {
         shared.integers[j] =
             makeObjectShared(createObject(OBJ_STRING,(void*)(long)j));

--- a/src/server.h
+++ b/src/server.h
@@ -870,6 +870,7 @@ struct sharedObjectsStruct {
     *busykeyerr, *oomerr, *plus, *messagebulk, *pmessagebulk, *subscribebulk,
     *unsubscribebulk, *psubscribebulk, *punsubscribebulk, *del, *unlink,
     *rpop, *lpop, *lpush, *rpoplpush, *zpopmin, *zpopmax, *emptyscan,
+    *multi, *exec,
     *select[PROTO_SHARED_SELECT_CMDS],
     *integers[OBJ_SHARED_INTEGERS],
     *mbulkhdr[OBJ_SHARED_BULKHDR_LEN], /* "*<value>\r\n" */


### PR DESCRIPTION
Two locations in Redis where commands that are replicated as multiple commands are not done so atomically. This can lead to a state on a replica, or AOF in some cases, that was never seen on the master if the output is not fully flushed.

The SPOP was converted to a transactions of SREM commands incase you have a large set and are dumping a lot of items because you might overwhelm the querybuf if you send it as a single SREM command. This could be optimized more.

For the blocking brpoplpush, I don't entirely know why it's not propagated as just an rpoplpush, so I just stuck with the original implementation, but that may be something that is a simpler fix. 