### PR TITLE
Extend REDISMODULE_CTX_FLAGS to indicate if redis is  loading

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1455,6 +1455,9 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
     if (server.cluster_enabled)
         flags |= REDISMODULE_CTX_FLAGS_CLUSTER;
 
+    if (server.loading)
+        flags |= REDISMODULE_CTX_FLAGS_LOADING;
+
     /* Maxmemory and eviction policy */
     if (server.maxmemory > 0) {
         flags |= REDISMODULE_CTX_FLAGS_MAXMEMORY;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -87,6 +87,8 @@
 #define REDISMODULE_CTX_FLAGS_OOM_WARNING (1<<11)
 /* The command was sent over the replication link. */
 #define REDISMODULE_CTX_FLAGS_REPLICATED (1<<12)
+/* Redis is currently loading either from AOF or RDB. */
+#define REDISMODULE_CTX_FLAGS_LOADING (1<<13)
 
 
 #define REDISMODULE_NOTIFY_GENERIC (1<<2)     /* g */


### PR DESCRIPTION
This PR extends `REDISMODULE_CTX_FLAGS` with an additional flag: `REDISMODULE_CTX_FLAGS_LOADING`
indicating that Redis is currently loading, either from RDB or from AOF.

Reason why, In RedisGraph for example, commands such as `GRAPH.QUERY` are executed on dedicated threads using blocked clients,
in the situation where Redis loads from AOF it will reply commands to modules (RedisGraph) which in turn will spawn new threads and block fake clients
this causes Redis to trigger an assertion.

To solve this modules can check for the `REDISMODULE_CTX_FLAGS_LOADING` flag and execute commands on Redis main thread.