### PR TITLE
1.change failver to 'failover'. 2.set *ptr='\0' once is enough in syn…

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -56,7 +56,7 @@ typedef struct clusterLink {
 #define CLUSTER_NODE_NOADDR   64  /* We don't know the address of this node */
 #define CLUSTER_NODE_MEET 128     /* Send a MEET message to this node */
 #define CLUSTER_NODE_MIGRATE_TO 256 /* Master elegible for replica migration. */
-#define CLUSTER_NODE_NOFAILOVER 512 /* Slave will not try to failver. */
+#define CLUSTER_NODE_NOFAILOVER 512 /* Slave will not try to failover. */
 #define CLUSTER_NODE_NULL_NAME "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
 
 #define nodeIsMaster(n) ((n)->flags & CLUSTER_NODE_MASTER)

--- a/src/syncio.c
+++ b/src/syncio.c
@@ -136,10 +136,10 @@ ssize_t syncReadLine(int fd, char *ptr, ssize_t size, long long timeout) {
             return nread;
         } else {
             *ptr++ = c;
-            *ptr = '\0';
             nread++;
         }
         size--;
     }
+    *ptr = '\0';
     return nread;
 }


### PR DESCRIPTION
please check:
1. set *ptr='\0' once is enough in syncReadLine, will enhance the performance.
2. change 'failver' to 'failover' 