### PR TITLE
Del event loop

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -135,6 +135,13 @@ void aeDeleteEventLoop(aeEventLoop *eventLoop) {
     aeApiFree(eventLoop);
     zfree(eventLoop->events);
     zfree(eventLoop->fired);
+    /* Free time event. */
+    aeTimeEvent *next_te, *te = eventLoop->timeEventHead;
+    while (te) {
+        next_te = te->next;
+        zfree(te);
+        te = next_te;
+    }
     zfree(eventLoop);
 }
 


### PR DESCRIPTION
Freeing time events when we delete event loop to avoid avoid valgrind warning. 
And I think that should be fixed, because it also can be used in other projects such as `redis-cluster-proxy`