### PR TITLE
Threaded IO: add io-threads-name config and apply pthread_setname on IO threads

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -375,6 +375,17 @@ void loadServerConfigFromString(char *config) {
             if (server.io_threads_num < 1 || server.io_threads_num > 512) {
                 err = "Invalid number of I/O threads"; goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"io-threads-do-reads") && argc == 2) {
+            if ((server.io_threads_do_reads = yesnotoi(argv[1])) == -1) {
+                err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
+        } else if (!strcasecmp(argv[0],"io-threads-name") && argc == 2) {
+            if (strlen(argv[1]) > REDIS_PTHREAD_SETNAME_MAX_LEN) {
+                err = "io-threads-name is longer than " REDIS_PTHREAD_SETNAME_MAX_LEN_STR;
+                goto loaderr;
+            }
+            zfree(server.io_threads_name);
+            server.io_threads_name = zstrdup(argv[1]);
         } else if (!strcasecmp(argv[0],"include") && argc == 2) {
             loadServerConfig(argv[1],NULL);
         } else if (!strcasecmp(argv[0],"maxclients") && argc == 2) {
@@ -1294,6 +1305,7 @@ void configGetCommand(client *c) {
     config_get_string_field("pidfile",server.pidfile);
     config_get_string_field("slave-announce-ip",server.slave_announce_ip);
     config_get_string_field("replica-announce-ip",server.slave_announce_ip);
+    config_get_string_field("io-threads-name",server.io_threads_name);
 
     /* Numerical values */
     config_get_numerical_field("maxmemory",server.maxmemory);
@@ -2122,6 +2134,7 @@ int rewriteConfig(char *path) {
     rewriteConfigUserOption(state);
     rewriteConfigNumericalOption(state,"databases",server.dbnum,CONFIG_DEFAULT_DBNUM);
     rewriteConfigNumericalOption(state,"io-threads",server.io_threads_num,CONFIG_DEFAULT_IO_THREADS_NUM);
+    rewriteConfigStringOption(state,"io-threads-name",server.io_threads_name,CONFIG_DEFAULT_IO_THREADS_NAME);
     rewriteConfigYesNoOption(state,"stop-writes-on-bgsave-error",server.stop_writes_on_bgsave_err,CONFIG_DEFAULT_STOP_WRITES_ON_BGSAVE_ERROR);
     rewriteConfigYesNoOption(state,"rdbcompression",server.rdb_compression,CONFIG_DEFAULT_RDB_COMPRESSION);
     rewriteConfigYesNoOption(state,"rdbchecksum",server.rdb_checksum,CONFIG_DEFAULT_RDB_CHECKSUM);

--- a/src/config.c
+++ b/src/config.c
@@ -2121,7 +2121,10 @@ int rewriteConfig(char *path) {
     rewriteConfigSaveOption(state);
     rewriteConfigUserOption(state);
     rewriteConfigNumericalOption(state,"databases",server.dbnum,CONFIG_DEFAULT_DBNUM);
-    rewriteConfigNumericalOption(state,"io-threads",server.dbnum,CONFIG_DEFAULT_IO_THREADS_NUM);
+    rewriteConfigNumericalOption(state,"io-threads",server.io_threads_num,CONFIG_DEFAULT_IO_THREADS_NUM);
+    rewriteConfigYesNoOption(state,"stop-writes-on-bgsave-error",server.stop_writes_on_bgsave_err,CONFIG_DEFAULT_STOP_WRITES_ON_BGSAVE_ERROR);
+    rewriteConfigYesNoOption(state,"rdbcompression",server.rdb_compression,CONFIG_DEFAULT_RDB_COMPRESSION);
+    rewriteConfigYesNoOption(state,"rdbchecksum",server.rdb_checksum,CONFIG_DEFAULT_RDB_CHECKSUM);
     rewriteConfigStringOption(state,"dbfilename",server.rdb_filename,CONFIG_DEFAULT_RDB_FILENAME);
     rewriteConfigDirOption(state);
     rewriteConfigSlaveofOption(state,"replicaof");

--- a/src/config.h
+++ b/src/config.h
@@ -226,4 +226,16 @@ void setproctitle(const char *fmt, ...);
 #define USE_ALIGNED_ACCESS
 #endif
 
+/* Test for pthread naming. */
+#if defined(__linux)
+#define REDIS_PTHREAD_SETNAME_MAX_LEN 15
+#define REDIS_PTHREAD_SETNAME_MAX_LEN_STR "15"
+#define redis_pthread_setname(tid, name) pthread_setname_np(tid, name)
+#else
+/* pthread_setname is not supported, allow the configuration, but skip setting */
+#define REDIS_PTHREAD_SETNAME_MAX_LEN 15
+#define REDIS_PTHREAD_SETNAME_MAX_LEN_STR "15"
+#define redis_pthread_setname(tid, name) 0
+#endif
+
 #endif

--- a/src/networking.c
+++ b/src/networking.c
@@ -2647,6 +2647,9 @@ void initThreadedIO(void) {
             serverLog(LL_WARNING,"Fatal: Can't initialize IO thread.");
             exit(1);
         }
+        if (redis_pthread_setname(tid, server.io_threads_name) != 0) {
+            serverLog(LL_WARNING,"Unable to set name of IO thread.");
+        }
         io_threads[i] = tid;
     }
 }

--- a/src/server.c
+++ b/src/server.c
@@ -2319,6 +2319,7 @@ void initServerConfig(void) {
     server.lua_time_limit = LUA_SCRIPT_TIME_LIMIT;
     server.io_threads_num = CONFIG_DEFAULT_IO_THREADS_NUM;
     server.io_threads_do_reads = CONFIG_DEFAULT_IO_THREADS_DO_READS;
+    server.io_threads_name = zstrdup(CONFIG_DEFAULT_IO_THREADS_NAME);
 
     server.lruclock = getLRUClock();
     resetServerSaveParams();

--- a/src/server.h
+++ b/src/server.h
@@ -89,6 +89,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CONFIG_DEFAULT_DBNUM     16
 #define CONFIG_DEFAULT_IO_THREADS_NUM 1         /* Single threaded by default */
 #define CONFIG_DEFAULT_IO_THREADS_DO_READS 0    /* Read + parse from threads? */
+#define CONFIG_DEFAULT_IO_THREADS_NAME "redis-server-io"
 #define CONFIG_MAX_LINE    1024
 #define CRON_DBS_PER_CALL 16
 #define NET_MAX_WRITES_PER_EVENT (1024*64)
@@ -1094,6 +1095,7 @@ struct redisServer {
                                    queries. Will still serve RESP2 queries. */
     int io_threads_num;         /* Number of IO threads to use. */
     int io_threads_do_reads;    /* Read and parse from IO threads? */
+    char *io_threads_name;      /* Name assigned to IO pthreads */
 
     /* RDB / AOF loading information */
     int loading;                /* We are loading data from disk if true */


### PR DESCRIPTION
Just learned this was live at RedisDay NYC... so started checking it out and noticed this copy-paste-modify bug for `io-threads`.