### PR TITLE
[RESP3, Minor] in networking.c double representation for -infiinity leaves out comma

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -506,7 +506,7 @@ void addReplyDouble(client *c, double d) {
         if (c->resp == 2) {
             addReplyBulkCString(c, d > 0 ? "inf" : "-inf");
         } else {
-            addReplyProto(c, d > 0 ? ",inf\r\n" : "-inf\r\n",
+            addReplyProto(c, d > 0 ? ",inf\r\n" : ",-inf\r\n",
                               d > 0 ? 6 : 7);
         }
     } else {


### PR DESCRIPTION
Tiny edit, the correct double representation for -infinity is `,-inf\r\n`, not `-inf\r\n` - noticed that the `,` was missing from the negative infinity.

See https://github.com/antirez/RESP3/blob/aabbd6b14a9e8a75b8960e04f06720dc5cb94f44/spec.md#L257-L288