### PR TITLE
Add repl-diskless-load-bgsave for databases with no traffic

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -393,6 +393,17 @@ repl-diskless-sync-delay 5
 #                 sufficient memory, if you don't have it, you risk an OOM kill.
 repl-diskless-load disabled
 
+# When diskless load and snapshots ('save') are both enabled, we need to generate
+# a snapshot after a replica syncs (in normal replication, the rdb from the master
+# is saved to the disk before being loaded)
+#
+# Options are:
+# always: always trigger a bgsave after replication.
+# never: don't trigger any bgsave, wait for changes to accumulate and trigger one.
+# when-old: trigger bgsave only if the rdb file on disk is missing or older
+#           than the lowest 'save' config's seconds (default).
+repl-diskless-load-bgsave when-old
+
 # Replicas send PINGs to server in a predefined interval. It's possible to change
 # this interval with the repl_ping_replica_period option. The default value is 10
 # seconds.

--- a/src/server.c
+++ b/src/server.c
@@ -2347,6 +2347,7 @@ void initServerConfig(void) {
     server.repl_disable_tcp_nodelay = CONFIG_DEFAULT_REPL_DISABLE_TCP_NODELAY;
     server.repl_diskless_sync = CONFIG_DEFAULT_REPL_DISKLESS_SYNC;
     server.repl_diskless_load = CONFIG_DEFAULT_REPL_DISKLESS_LOAD;
+    server.repl_diskless_load_bgsave = CONFIG_DEFAULT_DISKLESS_LOAD_BGSAVE;
     server.repl_diskless_sync_delay = CONFIG_DEFAULT_REPL_DISKLESS_SYNC_DELAY;
     server.repl_ping_slave_period = CONFIG_DEFAULT_REPL_PING_SLAVE_PERIOD;
     server.repl_timeout = CONFIG_DEFAULT_REPL_TIMEOUT;

--- a/src/server.h
+++ b/src/server.h
@@ -383,6 +383,11 @@ typedef long long mstime_t; /* millisecond time type. */
 #define SUPERVISED_SYSTEMD 2
 #define SUPERVISED_UPSTART 3
 
+#define DISKLESS_LOAD_BGSAVE_NEVER 0
+#define DISKLESS_LOAD_BGSAVE_WHEN_OLD 1
+#define DISKLESS_LOAD_BGSAVE_ALWAYS 2
+#define CONFIG_DEFAULT_DISKLESS_LOAD_BGSAVE DISKLESS_LOAD_BGSAVE_WHEN_OLD
+
 /* Anti-warning macro... */
 #define UNUSED(V) ((void) V)
 
@@ -1262,6 +1267,8 @@ struct redisServer {
     int repl_diskless_sync;         /* Master send RDB to slaves sockets directly. */
     int repl_diskless_load;         /* Slave parse RDB directly from the socket.
                                      * see REPL_DISKLESS_LOAD_* enum */
+    int repl_diskless_load_bgsave;  /* When snapshots ('save') are enabled,
+                                     * see DISKLESS_LOAD_BGSAVE_ */
     int repl_diskless_sync_delay;   /* Delay to start a diskless repl BGSAVE. */
     /* Replication (slave) */
     char *masteruser;               /* AUTH with this user and masterauth with master */


### PR DESCRIPTION
since the introduction of repl-diskless-load, a slave that finished loading
an rdb from it's master doesn't have an rdb snapshot on the disk.
if the database is completely stale (no traffic), then it'll never create one,
and if all the master and slave will fail, we'll have a complete data loss.

this commit introduces a mechanism that will trigger a bgsave, by default only
if the persistent file on the disk is either missing or older than the save interval.

we rather not trigger bgsave on every sync, that the whole purpose of diskless slave
was to to reduce replication time, and avoid unnecessary disk access.