### PR TITLE
fixes to flushSlaveKeysWithExpireList

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -377,7 +377,7 @@ long long emptyDbGeneric(redisDb *dbarray, int dbnum, int flags, void(callback)(
             slotToKeyFlush();
         }
     }
-    if (dbnum == -1) flushSlaveKeysWithExpireList();
+    flushSlaveKeysWithExpireList(dbnum);
     return removed;
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -2195,6 +2195,8 @@ void replicaofCommand(client *c) {
             /* Restart the AOF subsystem in case we shut it down during a sync when
              * we were still a slave. */
             if (server.aof_enabled && server.aof_state == AOF_OFF) restartAOFAfterSYNC();
+            /* forget slave expire keys (that info exists in the normal expires dict too) */
+            flushSlaveKeysWithExpireList(-1);
         }
     } else {
         long port;

--- a/src/server.h
+++ b/src/server.h
@@ -2085,7 +2085,7 @@ void blockForKeys(client *c, int btype, robj **keys, int numkeys, mstime_t timeo
 void activeExpireCycle(int type);
 void expireSlaveKeys(void);
 void rememberSlaveKeyWithExpire(redisDb *db, robj *key);
-void flushSlaveKeysWithExpireList(void);
+void flushSlaveKeysWithExpireList(int dbnum);
 size_t getSlaveKeyWithExpireCount(void);
 
 /* evict.c -- maxmemory handling and LRU eviction. */


### PR DESCRIPTION
* call it when a slave is promoted to a master, otherwise it'll just stay
  and occupy memory needlessly.
* it wasn't flushed on FLUSHDB (even on a server with just one db)
* in case of FLUSHDB on a multi db server, we probably still want to purge
  parts of this dict