### PR TITLE
Make zscore transparently varargs

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -456,7 +456,7 @@ struct redisCommand redisCommandTable[] = {
      "read-only fast @sortedset",
      0,NULL,1,1,1,0,0,0},
 
-    {"zscore",zscoreCommand,3,
+    {"zscore",zscoreCommand,-3,
      "read-only fast @sortedset",
      0,NULL,1,1,1,0,0,0},
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3079,10 +3079,14 @@ void zscoreCommand(client *c) {
     if ((zobj = lookupKeyReadOrReply(c,key,shared.null[c->resp])) == NULL ||
         checkType(c,zobj,OBJ_ZSET)) return;
 
-    if (zsetScore(zobj,c->argv[2]->ptr,&score) == C_ERR) {
-        addReplyNull(c);
-    } else {
-        addReplyDouble(c,score);
+    if (c->argc > 3) addReplyArrayLen(c, c->argc-2);
+
+    for (i=2; i < c->argc; i++) {
+        if (zsetScore(zobj,c->argv[i]->ptr,&score) == C_ERR) {
+            addReplyNull(c);
+        } else {
+            addReplyDouble(c,score);
+        }
     }
 }
 


### PR DESCRIPTION
Hashes have hmget, maybe just make hget varargs too? Probably a very similar change.