### PR TITLE
Fix rio.c read and write system call

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -58,7 +58,7 @@ static void anetSetError(char *err, const char *fmt, ...)
     va_end(ap);
 }
 
-int anetSetBlock(char *err, int fd, int non_block) {
+static int anetSetBlock(char *err, int fd, int non_block) {
     int flags;
 
     /* Set the socket blocking (if non_block is zero) or non-blocking.
@@ -159,7 +159,7 @@ int anetDisableTcpNoDelay(char *err, int fd)
 }
 
 
-int anetSetSendBuffer(char *err, int fd, int buffsize)
+static int anetSetSendBuffer(char *err, int fd, int buffsize)
 {
     if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &buffsize, sizeof(buffsize)) == -1)
     {


### PR DESCRIPTION
In the unix os, read and write system call can sometimes return a negative value if it was interrupted by a signal when they are manipulate a socket. In this case, just call the function again. It has been mentioned many times in the Stevens's book apue and unp1.