### PR TITLE
Allow modules to handle RDB loading errors.

### DIFF
--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -140,6 +140,9 @@ typedef uint64_t RedisModuleTimerID;
 /* Do filter RedisModule_Call() commands initiated by module itself. */
 #define REDISMODULE_CMDFILTER_NOSELF    (1<<0)
 
+/* Declare that the module can handle errors with RedisModule_SetIOFlags */
+#define REDISMODULE_HANDLE_IO_ERRORS    (1<<0)
+
 /* ------------------------- End of common defines ------------------------ */
 
 #ifndef REDISMODULE_CORE
@@ -271,6 +274,9 @@ RedisModuleType *REDISMODULE_API_FUNC(RedisModule_CreateDataType)(RedisModuleCtx
 int REDISMODULE_API_FUNC(RedisModule_ModuleTypeSetValue)(RedisModuleKey *key, RedisModuleType *mt, void *value);
 RedisModuleType *REDISMODULE_API_FUNC(RedisModule_ModuleTypeGetType)(RedisModuleKey *key);
 void *REDISMODULE_API_FUNC(RedisModule_ModuleTypeGetValue)(RedisModuleKey *key);
+void REDISMODULE_API_FUNC(RedisModule_SetIOFlags)(RedisModuleIO *io, int flags);
+int REDISMODULE_API_FUNC(RedisModule_GetIOFlags)(RedisModuleIO *io);
+int REDISMODULE_API_FUNC(RedisModule_IsIOError)(RedisModuleIO *io);
 void REDISMODULE_API_FUNC(RedisModule_SaveUnsigned)(RedisModuleIO *io, uint64_t value);
 uint64_t REDISMODULE_API_FUNC(RedisModule_LoadUnsigned)(RedisModuleIO *io);
 void REDISMODULE_API_FUNC(RedisModule_SaveSigned)(RedisModuleIO *io, int64_t value);
@@ -444,6 +450,9 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ModuleTypeSetValue);
     REDISMODULE_GET_API(ModuleTypeGetType);
     REDISMODULE_GET_API(ModuleTypeGetValue);
+    REDISMODULE_GET_API(SetIOFlags);
+    REDISMODULE_GET_API(GetIOFlags);
+    REDISMODULE_GET_API(IsIOError);
     REDISMODULE_GET_API(SaveUnsigned);
     REDISMODULE_GET_API(LoadUnsigned);
     REDISMODULE_GET_API(SaveSigned);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -140,8 +140,8 @@ typedef uint64_t RedisModuleTimerID;
 /* Do filter RedisModule_Call() commands initiated by module itself. */
 #define REDISMODULE_CMDFILTER_NOSELF    (1<<0)
 
-/* Declare that the module can handle errors with RedisModule_SetIOFlags */
-#define REDISMODULE_HANDLE_IO_ERRORS    (1<<0)
+/* Declare that the module can handle errors with RedisModule_SetModuleOptions. */
+#define REDISMODULE_OPTIONS_HANDLE_IO_ERRORS    (1<<0)
 
 /* ------------------------- End of common defines ------------------------ */
 
@@ -274,9 +274,8 @@ RedisModuleType *REDISMODULE_API_FUNC(RedisModule_CreateDataType)(RedisModuleCtx
 int REDISMODULE_API_FUNC(RedisModule_ModuleTypeSetValue)(RedisModuleKey *key, RedisModuleType *mt, void *value);
 RedisModuleType *REDISMODULE_API_FUNC(RedisModule_ModuleTypeGetType)(RedisModuleKey *key);
 void *REDISMODULE_API_FUNC(RedisModule_ModuleTypeGetValue)(RedisModuleKey *key);
-void REDISMODULE_API_FUNC(RedisModule_SetIOFlags)(RedisModuleIO *io, int flags);
-int REDISMODULE_API_FUNC(RedisModule_GetIOFlags)(RedisModuleIO *io);
 int REDISMODULE_API_FUNC(RedisModule_IsIOError)(RedisModuleIO *io);
+void REDISMODULE_API_FUNC(RedisModule_SetModuleOptions)(RedisModuleCtx *ctx, int options);
 void REDISMODULE_API_FUNC(RedisModule_SaveUnsigned)(RedisModuleIO *io, uint64_t value);
 uint64_t REDISMODULE_API_FUNC(RedisModule_LoadUnsigned)(RedisModuleIO *io);
 void REDISMODULE_API_FUNC(RedisModule_SaveSigned)(RedisModuleIO *io, int64_t value);
@@ -450,9 +449,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ModuleTypeSetValue);
     REDISMODULE_GET_API(ModuleTypeGetType);
     REDISMODULE_GET_API(ModuleTypeGetValue);
-    REDISMODULE_GET_API(SetIOFlags);
-    REDISMODULE_GET_API(GetIOFlags);
     REDISMODULE_GET_API(IsIOError);
+    REDISMODULE_GET_API(SetModuleOptions);
     REDISMODULE_GET_API(SaveUnsigned);
     REDISMODULE_GET_API(LoadUnsigned);
     REDISMODULE_GET_API(SaveSigned);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1118,8 +1118,11 @@ static int useDisklessLoad() {
     int enabled = server.repl_diskless_load == REPL_DISKLESS_LOAD_SWAPDB ||
            (server.repl_diskless_load == REPL_DISKLESS_LOAD_WHEN_DB_EMPTY && dbTotalServerKeyCount()==0);
     /* Check all modules handle read errors, otherwise it's not safe to use diskless load. */
-    if (enabled && !moduleAllDatatypesHandleErrors())
+    if (enabled && !moduleAllDatatypesHandleErrors()) {
+        serverLog(LL_WARNING,
+            "Skipping diskless-load because there are modules that don't handle read errors.");
         enabled = 0;
+    }
     return enabled;
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -1115,8 +1115,12 @@ void restartAOFAfterSYNC() {
 
 static int useDisklessLoad() {
     /* compute boolean decision to use diskless load */
-    return server.repl_diskless_load == REPL_DISKLESS_LOAD_SWAPDB ||
+    int enabled = server.repl_diskless_load == REPL_DISKLESS_LOAD_SWAPDB ||
            (server.repl_diskless_load == REPL_DISKLESS_LOAD_WHEN_DB_EMPTY && dbTotalServerKeyCount()==0);
+    /* Check all modules handle read errors, otherwise it's not safe to use diskless load. */
+    if (enabled && !moduleAllDatatypesHandleErrors())
+        enabled = 0;
+    return enabled;
 }
 
 /* Helper function for readSyncBulkPayload() to make backups of the current

--- a/src/server.h
+++ b/src/server.h
@@ -599,6 +599,7 @@ typedef struct RedisModuleIO {
                          * 2 (current version with opcodes annotation). */
     struct RedisModuleCtx *ctx; /* Optional context, see RM_GetContextFromIO()*/
     struct redisObject *key;    /* Optional name of key processed */
+    int flags;          /* flags declaring capabilities or behavior */
 } RedisModuleIO;
 
 /* Macro to initialize an IO context. Note that the 'ver' field is populated
@@ -611,6 +612,7 @@ typedef struct RedisModuleIO {
     iovar.ver = 0; \
     iovar.key = keyptr; \
     iovar.ctx = NULL; \
+    iovar.flags = 0; \
 } while(0);
 
 /* This is a structure used to export DEBUG DIGEST capabilities to Redis

--- a/src/server.h
+++ b/src/server.h
@@ -599,7 +599,6 @@ typedef struct RedisModuleIO {
                          * 2 (current version with opcodes annotation). */
     struct RedisModuleCtx *ctx; /* Optional context, see RM_GetContextFromIO()*/
     struct redisObject *key;    /* Optional name of key processed */
-    int flags;          /* flags declaring capabilities or behavior */
 } RedisModuleIO;
 
 /* Macro to initialize an IO context. Note that the 'ver' field is populated
@@ -612,7 +611,6 @@ typedef struct RedisModuleIO {
     iovar.ver = 0; \
     iovar.key = keyptr; \
     iovar.ctx = NULL; \
-    iovar.flags = 0; \
 } while(0);
 
 /* This is a structure used to export DEBUG DIGEST capabilities to Redis
@@ -1530,6 +1528,7 @@ void moduleAcquireGIL(void);
 void moduleReleaseGIL(void);
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
 void moduleCallCommandFilters(client *c);
+int moduleAllDatatypesHandleErrors();
 
 /* Utils */
 long long ustime(void);

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -56,7 +56,67 @@ tags "modules" {
         }
     }
 
+    tags {repl} {
+        test {diskless loading short read with module} {
+            start_server [list overrides [list loadmodule "$testmodule"]] {
+                set replica [srv 0 client]
+                set replica_host [srv 0 host]
+                set replica_port [srv 0 port]
+                start_server [list overrides [list loadmodule "$testmodule"]] {
+                    set master [srv 0 client]
+                    set master_host [srv 0 host]
+                    set master_port [srv 0 port]
 
-    # TODO: test short read handling
+                    # Set master and replica to use diskless replication
+                    $master config set repl-diskless-sync yes
+                    $master config set rdbcompression no
+                    $replica config set repl-diskless-load swapdb
+                    for {set k 0} {$k < 30} {incr k} {
+                        r testrdb.set.key key$k [string repeat A [expr {int(rand()*1000000)}]]
+                    }
 
+                    # Start the replication process...
+                    $master config set repl-diskless-sync-delay 0
+                    $replica replicaof $master_host $master_port
+
+                    # kill the replication at various points
+                    set attempts 3
+                    if {$::accurate} { set attempts 10 }
+                    for {set i 0} {$i < $attempts} {incr i} {
+                        # wait for the replica to start reading the rdb
+                        # using the log file since the replica only responds to INFO once in 2mb
+                        wait_for_log_message -1 "*Loading DB in memory*" 5 2000 1
+
+                        # add some additional random sleep so that we kill the master on a different place each time
+                        after [expr {int(rand()*100)}]
+
+                        # kill the replica connection on the master
+                        set killed [$master client kill type replica]
+
+                        if {[catch {
+                            set res [wait_for_log_message -1 "*Internal error in RDB*" 5 100 10]
+                            if {$::verbose} {
+                                puts $res
+                            }
+                        }]} {
+                            puts "failed triggering short read"
+                            # force the replica to try another full sync
+                            $master client kill type replica
+                            $master set asdf asdf
+                            # the side effect of resizing the backlog is that it is flushed (16k is the min size)
+                            $master config set repl-backlog-size [expr {16384 + $i}]
+                        }
+                        # wait for loading to stop (fail)
+                        wait_for_condition 100 10 {
+                            [s -1 loading] eq 0
+                        } else {
+                            fail "Replica didn't disconnect"
+                        }
+                    }
+                    # enable fast shutdown
+                    $master config set rdb-key-save-delay 0
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This is especially needed in diskless loading, were a short read could have
caused redis to exit. now the module can handle the error and return to the
caller gracefully.

this fixes #5326