### PR TITLE
lazyfree: add a new configuration lazyfree-lazy-user-del 

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -924,7 +924,9 @@ replica-priority 100
 #    or SORT with STORE option may delete existing keys. The SET command
 #    itself removes any old content of the specified key in order to replace
 #    it with the specified string.
-# 4) During replication, when a replica performs a full resynchronization with
+# 4) The DEL command itself, and normally it's not easy to replace DEL with
+#    UNLINK in user's codes.
+# 5) During replication, when a replica performs a full resynchronization with
 #    its master, the content of the whole database is removed in order to
 #    load the RDB file just transferred.
 #
@@ -936,6 +938,7 @@ replica-priority 100
 lazyfree-lazy-eviction no
 lazyfree-lazy-expire no
 lazyfree-lazy-server-del no
+lazyfree-lazy-user-del no
 replica-lazy-flush no
 
 ############################## APPEND ONLY MODE ###############################

--- a/src/config.c
+++ b/src/config.c
@@ -2147,6 +2147,7 @@ standardConfig configs[] = {
     createBoolConfig("lazyfree-lazy-eviction", NULL, MODIFIABLE_CONFIG, server.lazyfree_lazy_eviction, 0, NULL, NULL),
     createBoolConfig("lazyfree-lazy-expire", NULL, MODIFIABLE_CONFIG, server.lazyfree_lazy_expire, 0, NULL, NULL),
     createBoolConfig("lazyfree-lazy-server-del", NULL, MODIFIABLE_CONFIG, server.lazyfree_lazy_server_del, 0, NULL, NULL),
+    createBoolConfig("lazyfree-lazy-user-del", NULL, MODIFIABLE_CONFIG, server.lazyfree_lazy_user_del , 0, NULL, NULL),
     createBoolConfig("repl-disable-tcp-nodelay", NULL, MODIFIABLE_CONFIG, server.repl_disable_tcp_nodelay, 0, NULL, NULL),
     createBoolConfig("repl-diskless-sync", NULL, MODIFIABLE_CONFIG, server.repl_diskless_sync, 0, NULL, NULL),
     createBoolConfig("gopher-enabled", NULL, MODIFIABLE_CONFIG, server.gopher_enabled, 0, NULL, NULL),

--- a/src/db.c
+++ b/src/db.c
@@ -536,7 +536,7 @@ void delGenericCommand(client *c, int lazy) {
 }
 
 void delCommand(client *c) {
-    delGenericCommand(c,0);
+    delGenericCommand(c,server.lazyfree_lazy_user_del);
 }
 
 void unlinkCommand(client *c) {

--- a/src/server.h
+++ b/src/server.h
@@ -1375,6 +1375,7 @@ struct redisServer {
     int lazyfree_lazy_eviction;
     int lazyfree_lazy_expire;
     int lazyfree_lazy_server_del;
+    int lazyfree_lazy_user_del;
     /* Latency monitor */
     long long latency_monitor_threshold;
     dict *latency_events;


### PR DESCRIPTION
Hi @antirez , there are some scenarios that users wanna use lazyfree especially `UNLINK`, but it's difficult to change their project codes, so I think maybe we can expand the effect of `lazyfree-lazy-server-del` to `DEL` command.

BTW, it's unnecessary to add a new configuration IMHO.