### PR TITLE
Tracking flushdb

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -417,6 +417,7 @@ void signalModifiedKey(redisDb *db, robj *key) {
 
 void signalFlushedDb(int dbid) {
     touchWatchedKeysOnFlush(dbid);
+    if (server.tracking_clients) trackingInvalidateKeysOnFlush(dbid);
 }
 
 /*-----------------------------------------------------------------------------

--- a/src/server.h
+++ b/src/server.h
@@ -1638,6 +1638,7 @@ void enableTracking(client *c, uint64_t redirect_to);
 void disableTracking(client *c);
 void trackingRememberKeys(client *c);
 void trackingInvalidateKey(robj *keyobj);
+void trackingInvalidateKeysOnFlush(int dbid);
 
 /* List data type */
 void listTypeTryConversion(robj *subject, robj *value);

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -167,7 +167,7 @@ void trackingInvalidateKey(robj *keyobj) {
         uint64_t id;
         memcpy(&id,ri.key,ri.key_len);
         client *c = lookupClientByID(id);
-        if (c == NULL) continue;
+        if (c == NULL || !(c->flags & CLIENT_TRACKING)) continue;
         sendTrackingMessage(c,hash);
     }
     raxStop(&ri);


### PR DESCRIPTION
Hi @antirez , I think Client side caching also needs tracking `flushdb`, send a special hash -1 to clients to tell them all keys are invalidate.