### PR TITLE
Optimize listpack for stream usage to avoid repeated reallocs

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -702,7 +702,8 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *ele, uint32_t size, un
     unsigned char *dst = lp + poff; /* May be updated after reallocation. */
 
     /* Realloc before: we need more room. */
-    if (new_listpack_bytes > lp_malloc_size(lp)) {
+    if (new_listpack_bytes > old_listpack_bytes &&
+        new_listpack_bytes > lp_malloc_size(lp)) {
         if ((lp = lp_realloc(lp,new_listpack_bytes)) == NULL) return NULL;
         dst = lp + poff;
     }

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -220,8 +220,8 @@ int lpStringToInt64(const char *s, unsigned long slen, int64_t *value) {
 
 /* Create a new, empty listpack.
  * On success the new listpack is returned, otherwise an error is returned. */
-unsigned char *lpNew(void) {
-    unsigned char *lp = lp_malloc(LP_HDR_SIZE+1);
+unsigned char *lpNew(size_t capacity) {
+    unsigned char *lp = lp_malloc(capacity > LP_HDR_SIZE+1 ? capacity : LP_HDR_SIZE+1);
     if (lp == NULL) return NULL;
     lpSetTotalBytes(lp,LP_HDR_SIZE+1);
     lpSetNumElements(lp,0);
@@ -702,7 +702,7 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *ele, uint32_t size, un
     unsigned char *dst = lp + poff; /* May be updated after reallocation. */
 
     /* Realloc before: we need more room. */
-    if (new_listpack_bytes > old_listpack_bytes) {
+    if (new_listpack_bytes > lp_malloc_size(lp)) {
         if ((lp = lp_realloc(lp,new_listpack_bytes)) == NULL) return NULL;
         dst = lp + poff;
     }

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -219,7 +219,10 @@ int lpStringToInt64(const char *s, unsigned long slen, int64_t *value) {
 }
 
 /* Create a new, empty listpack.
- * On success the new listpack is returned, otherwise an error is returned. */
+ * On success the new listpack is returned, otherwise an error is returned.
+ * Pre-allocate at least `capacity` bytes of memory,
+ * over-allocated memory can be shrinked by `lpShrinkToFit`.
+ * */
 unsigned char *lpNew(size_t capacity) {
     unsigned char *lp = lp_malloc(capacity > LP_HDR_SIZE+1 ? capacity : LP_HDR_SIZE+1);
     if (lp == NULL) return NULL;

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -234,6 +234,16 @@ void lpFree(unsigned char *lp) {
     lp_free(lp);
 }
 
+/* Shrink the memory to fit. */
+unsigned char* lpShrinkToFit(unsigned char *lp) {
+    size_t size = lpGetTotalBytes(lp);
+    if (size < lp_malloc_size(lp)) {
+        return lp_realloc(lp, size);
+    } else {
+        return lp;
+    }
+}
+
 /* Given an element 'ele' of size 'size', determine if the element can be
  * represented inside the listpack encoded as integer, and returns
  * LP_ENCODING_INT if so. Otherwise returns LP_ENCODING_STR if no integer

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -47,6 +47,7 @@
 
 unsigned char *lpNew(size_t capacity);
 void lpFree(unsigned char *lp);
+unsigned char* lpShrinkToFit(unsigned char *lp);
 unsigned char *lpInsert(unsigned char *lp, unsigned char *ele, uint32_t size, unsigned char *p, int where, unsigned char **newp);
 unsigned char *lpAppend(unsigned char *lp, unsigned char *ele, uint32_t size);
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -35,6 +35,7 @@
 #ifndef __LISTPACK_H
 #define __LISTPACK_H
 
+#include <stdlib.h>
 #include <stdint.h>
 
 #define LP_INTBUF_SIZE 21 /* 20 digits of -2^63 + 1 null term = 21. */
@@ -44,7 +45,7 @@
 #define LP_AFTER 1
 #define LP_REPLACE 2
 
-unsigned char *lpNew(void);
+unsigned char *lpNew(size_t capacity);
 void lpFree(unsigned char *lp);
 unsigned char *lpInsert(unsigned char *lp, unsigned char *ele, uint32_t size, unsigned char *p, int where, unsigned char **newp);
 unsigned char *lpAppend(unsigned char *lp, unsigned char *ele, uint32_t size);

--- a/src/listpack_malloc.h
+++ b/src/listpack_malloc.h
@@ -42,4 +42,5 @@
 #define lp_malloc zmalloc
 #define lp_realloc zrealloc
 #define lp_free zfree
+#define lp_malloc_size zmalloc_size
 #endif

--- a/src/listpack_malloc.h
+++ b/src/listpack_malloc.h
@@ -42,5 +42,5 @@
 #define lp_malloc zmalloc
 #define lp_realloc zrealloc
 #define lp_free zfree
-#define lp_malloc_size zmalloc_size
+#define lp_malloc_size zmalloc_usable_size
 #endif

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -509,7 +509,13 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
             lp = NULL;
         } else if (server.stream_node_max_entries) {
             int64_t count = lpGetInteger(lpFirst(lp));
-            if (count >= server.stream_node_max_entries) lp = NULL;
+            if (count >= server.stream_node_max_entries) {
+                // Shrink extra pre-allocated memory
+                lp = lpShrinkToFit(lp);
+                if (ri.data != lp)
+                    raxInsert(s->rax,ri.key,ri.key_len,lp,NULL);
+                lp = NULL;
+            }
         }
     }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -523,7 +523,10 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
     if (lp == NULL) {
         master_id = id;
         streamEncodeID(rax_key,&id);
-        /* Create the listpack having the master entry ID and fields. */
+        /* Create the listpack having the master entry ID and fields.
+         * Allocate max bytes when creating listpack to avoid realloc on every XADD.
+         * When listpack reaches max number of entries, shrink the allocation.
+         */
         lp = lpNew(server.stream_node_max_bytes);
         lp = lpAppendInteger(lp,1); /* One item, the one we are adding. */
         lp = lpAppendInteger(lp,0); /* Zero deleted so far. */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -534,7 +534,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
          * When listpack reaches max number of entries, we'll shrink the
          * allocation to fit the data. */
         size_t prealloc = STREAM_LISTPACK_MAX_PRE_ALLOCATE;
-        if (server.stream_node_max_bytes > 0 && server.stream_node_max_bytes < STREAM_LISTPACK_MAX_PRE_ALLOCATE) {
+        if (server.stream_node_max_bytes > 0 && server.stream_node_max_bytes < prealloc) {
             prealloc = server.stream_node_max_bytes;
         }
         lp = lpNew(prealloc);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -514,7 +514,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
         } else if (server.stream_node_max_entries) {
             int64_t count = lpGetInteger(lpFirst(lp));
             if (count >= server.stream_node_max_entries) {
-                // Shrink extra pre-allocated memory
+                /* Shrink extra pre-allocated memory */
                 lp = lpShrinkToFit(lp);
                 if (ri.data != lp)
                     raxInsert(s->rax,ri.key,ri.key_len,lp,NULL);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -518,7 +518,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
         master_id = id;
         streamEncodeID(rax_key,&id);
         /* Create the listpack having the master entry ID and fields. */
-        lp = lpNew();
+        lp = lpNew(server.stream_node_max_bytes);
         lp = lpAppendInteger(lp,1); /* One item, the one we are adding. */
         lp = lpAppendInteger(lp,0); /* Zero deleted so far. */
         lp = lpAppendInteger(lp,numfields);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -528,9 +528,11 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
         master_id = id;
         streamEncodeID(rax_key,&id);
         /* Create the listpack having the master entry ID and fields.
-         * Allocate max bytes when creating listpack to avoid realloc on every XADD.
-         * When listpack reaches max number of entries, shrink the allocation.
-         */
+         * Pre-allocate some bytes when creating listpack to avoid realloc on
+         * every XADD. Since listpack.c uses malloc_size, it'll grow in steps,
+         * and won't realloc on every XADD.
+         * When listpack reaches max number of entries, we'll shrink the
+         * allocation to fit the data. */
         size_t prealloc = STREAM_LISTPACK_MAX_PRE_ALLOCATE;
         if (server.stream_node_max_bytes > 0 && server.stream_node_max_bytes < STREAM_LISTPACK_MAX_PRE_ALLOCATE) {
             prealloc = server.stream_node_max_bytes;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -43,8 +43,8 @@
  * avoid malloc allocation.*/
 #define STREAMID_STATIC_VECTOR_LEN 8
 
-/* Max pre-allocation for listpack
- */
+/* Max pre-allocation for listpack. This is done to avoid abuse of a user
+ * setting stream_node_max_bytes to a huge number. */
 #define STREAM_LISTPACK_MAX_PRE_ALLOCATE 4096
 
 void streamFreeCG(streamCG *cg);


### PR DESCRIPTION
See issue #6279.

> EDITED for final solution and benchmark numbers.

## Solution

- Pre-allocate `min(stream-node-max-bytes, 4096)` bytes of memory for new listpack.
- When current listpack reached `stream-node-max-entries` limit, reallocate the listpack to exact memory it needs.

## Result
```
$ ./redis-server-new --save no
$ redis-benchmark -P 100 -n 1000000 xadd test '*' a 1 b 2
====== xadd test * a 1 b 2 ======
  1000000 requests completed in 1.48 seconds
  50 parallel clients
  3 bytes payload
  keep alive: 1

0.14% <= 1 milliseconds
0.25% <= 3 milliseconds
0.29% <= 4 milliseconds
0.36% <= 5 milliseconds
0.93% <= 6 milliseconds
59.04% <= 7 milliseconds
93.64% <= 8 milliseconds
98.86% <= 9 milliseconds
99.81% <= 10 milliseconds
100.00% <= 10 milliseconds
675675.69 requests per second
```

```
$ ./redis-server-old --save no
$ redis-benchmark -P 100 -n 1000000 xadd test '*' a 1 b 2
====== xadd test * a 1 b 2 ======
  1000000 requests completed in 1.68 seconds
  50 parallel clients
  3 bytes payload
  keep alive: 1

0.01% <= 1 milliseconds
0.04% <= 3 milliseconds
0.05% <= 4 milliseconds
0.33% <= 5 milliseconds
0.35% <= 7 milliseconds
62.48% <= 8 milliseconds
93.05% <= 9 milliseconds
98.55% <= 10 milliseconds
99.32% <= 11 milliseconds
99.98% <= 12 milliseconds
100.00% <= 12 milliseconds
595592.62 requests per second
```