### PR TITLE
Fix HLL corruption bug

### DIFF
--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -701,6 +701,7 @@ int hllSparseSet(robj *o, long index, uint8_t count) {
         first += span;
     }
     if (span == 0) return -1; /* Invalid format. */
+    if (span >= end) return -1; /* Invalid format. */
 
     next = HLL_SPARSE_IS_XZERO(p) ? p+2 : p+1;
     if (next >= end) next = NULL;


### PR DESCRIPTION
The bounds checking was insufficient after the search loop causing us to corrupt data.