### PR TITLE
remove Unnecessary return value and format code

### DIFF
--- a/deps/hiredis/dict.c
+++ b/deps/hiredis/dict.c
@@ -44,7 +44,7 @@
 static int _dictExpandIfNeeded(dict *ht);
 static unsigned long _dictNextPower(unsigned long size);
 static int _dictKeyIndex(dict *ht, const void *key);
-static int _dictInit(dict *ht, dictType *type, void *privDataPtr);
+static void _dictInit(dict *ht, dictType *type, void *privDataPtr);
 
 /* -------------------------- hash functions -------------------------------- */
 
@@ -77,11 +77,10 @@ static dict *dictCreate(dictType *type, void *privDataPtr) {
 }
 
 /* Initialize the hash table */
-static int _dictInit(dict *ht, dictType *type, void *privDataPtr) {
+static void _dictInit(dict *ht, dictType *type, void *privDataPtr) {
     _dictReset(ht);
     ht->type = type;
     ht->privdata = privDataPtr;
-    return DICT_OK;
 }
 
 /* Expand or create the hashtable */

--- a/deps/lua/src/lauxlib.c
+++ b/deps/lua/src/lauxlib.c
@@ -574,7 +574,7 @@ LUALIB_API int luaL_loadfile (lua_State *L, const char *filename) {
     lf.f = freopen(filename, "rb", lf.f);  /* reopen in binary mode */
     if (lf.f == NULL) return errfile(L, "reopen", fnameindex);
     /* skip eventual `#!...' */
-   while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) ;
+    while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) ;
     lf.extraline = 0;
   }
   ungetc(c, lf.f);

--- a/deps/lua/src/ldo.c
+++ b/deps/lua/src/ldo.c
@@ -493,7 +493,7 @@ static void f_parser (lua_State *L, void *ud) {
   Proto *tf;
   Closure *cl;
   struct SParser *p = cast(struct SParser *, ud);
-  int c = luaZ_lookahead(p->z);
+  luaZ_lookahead(p->z);
   luaC_checkGC(L);
   tf = (luaY_parser)(L, p->z,
                                                              &p->buff, p->name);

--- a/deps/lua/src/ltablib.c
+++ b/deps/lua/src/ltablib.c
@@ -137,7 +137,7 @@ static void addfield (lua_State *L, luaL_Buffer *b, int i) {
   if (!lua_isstring(L, -1))
     luaL_error(L, "invalid value (%s) at index %d in table for "
                   LUA_QL("concat"), luaL_typename(L, -1), i);
-    luaL_addvalue(b);
+  luaL_addvalue(b);
 }
 
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -67,7 +67,7 @@ static unsigned int dict_force_resize_ratio = 5;
 static int _dictExpandIfNeeded(dict *ht);
 static unsigned long _dictNextPower(unsigned long size);
 static long _dictKeyIndex(dict *ht, const void *key, uint64_t hash, dictEntry **existing);
-static int _dictInit(dict *ht, dictType *type, void *privDataPtr);
+static void _dictInit(dict *ht, dictType *type, void *privDataPtr);
 
 /* -------------------------- hash functions -------------------------------- */
 
@@ -118,7 +118,7 @@ dict *dictCreate(dictType *type,
 }
 
 /* Initialize the hash table */
-int _dictInit(dict *d, dictType *type,
+void _dictInit(dict *d, dictType *type,
         void *privDataPtr)
 {
     _dictReset(&d->ht[0]);
@@ -127,7 +127,6 @@ int _dictInit(dict *d, dictType *type,
     d->privdata = privDataPtr;
     d->rehashidx = -1;
     d->iterators = 0;
-    return DICT_OK;
 }
 
 /* Resize the table to the minimal size that contains all the elements,


### PR DESCRIPTION
file dict.c:
remove unnecessary return value, it seems that this return value is useless
file lauxlib.c ltablib.c:
code format
file ldo.c:
Compile warnings, remove unused variables
