### PR TITLE
networking: flushSlavesOutputBuffers bugfix

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2468,7 +2468,6 @@ void flushSlavesOutputBuffers(void) {
     listRewind(server.slaves,&li);
     while((ln = listNext(&li))) {
         client *slave = listNodeValue(ln);
-        int events;
 
         /* Note that the following will not flush output buffers of slaves
          * in STATE_ONLINE but having put_online_on_ack set to true: in this
@@ -2476,9 +2475,8 @@ void flushSlavesOutputBuffers(void) {
          * of put_online_on_ack is to postpone the moment it is installed.
          * This is what we want since slaves in this state should not receive
          * writes before the first ACK. */
-        events = aeGetFileEvents(server.el,slave->fd);
-        if (events & AE_WRITABLE &&
-            slave->replstate == SLAVE_STATE_ONLINE &&
+        if (slave->replstate == SLAVE_STATE_ONLINE &&
+            !slave->repl_put_online_on_ack &&
             clientHasPendingReplies(slave))
         {
             writeToClient(slave->fd,slave,0);


### PR DESCRIPTION
Now we use `clients_pending_write` list as write handler at first, then not all clients need install a write file event, so we can just check `replstate` and `repl_put_online_on_ack`.

@antirez please check.