### PR TITLE
Fix misspellings of "function" in four places in the code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ There are two special functions called periodically by the event loop:
 Inside server.c you can find code that handles other vital things of the Redis server:
 
 * `call()` is used in order to call a given command in the context of a given client.
-* `activeExpireCycle()` handles eviciton of keys with a time to live set via the `EXPIRE` command.
+* `activeExpireCycle()` handles eviction of keys with a time to live set via the `EXPIRE` command.
 * `freeMemoryIfNeeded()` is called when a new write command should be performed but Redis is out of memory according to the `maxmemory` directive.
 * The global variable `redisCommandTable` defines all the Redis commands, specifying the name of the command, the function implementing the command, the number of arguments required, and other properties of each command.
 

--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -21,7 +21,7 @@
  *
  * Never use return value from the macros, instead use the AtomicGetIncr()
  * if you need to get the current value and increment it atomically, like
- * in the followign example:
+ * in the following example:
  *
  *  long oldvalue;
  *  atomicGetIncr(myvar,oldvalue,1);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -170,7 +170,7 @@ typedef struct clusterState {
                                    or zero if stil not received. */
     int mf_can_start;           /* If non-zero signal that the manual failover
                                    can start requesting masters vote. */
-    /* The followign fields are used by masters to take state on elections. */
+    /* The following fields are used by masters to take state on elections. */
     uint64_t lastVoteEpoch;     /* Epoch of the last vote granted. */
     int todo_before_sleep; /* Things to do in clusterBeforeSleep(). */
     /* Messages received and sent by type. */

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -137,7 +137,7 @@ robj *activeDefragStringOb(robj* ob, long *defragged) {
 }
 
 /* Defrag helper for dictEntries to be used during dict iteration (called on
- * each step). Teturns a stat of how many pointers were moved. */
+ * each step). Returns a stat of how many pointers were moved. */
 long dictIterDefragEntry(dictIterator *iter) {
     /* This function is a little bit dirty since it messes with the internals
      * of the dict and it's iterator, but the benefit is that it is very easy

--- a/src/dict.c
+++ b/src/dict.c
@@ -1112,7 +1112,7 @@ size_t _dictGetStatsHt(char *buf, size_t bufsize, dictht *ht, int tableid) {
             i, clvector[i], ((float)clvector[i]/ht->size)*100);
     }
 
-    /* Unlike snprintf(), teturn the number of characters actually written. */
+    /* Unlike snprintf(), return the number of characters actually written. */
     if (bufsize) buf[bufsize-1] = '\0';
     return strlen(buf);
 }

--- a/src/evict.c
+++ b/src/evict.c
@@ -41,7 +41,7 @@
 /* To improve the quality of the LRU approximation we take a set of keys
  * that are good candidate for eviction across freeMemoryIfNeeded() calls.
  *
- * Entries inside the eviciton pool are taken ordered by idle time, putting
+ * Entries inside the eviction pool are taken ordered by idle time, putting
  * greater idle times to the right (ascending order).
  *
  * When an LFU policy is used instead, a reverse frequency indication is used

--- a/src/expire.c
+++ b/src/expire.c
@@ -331,7 +331,7 @@ void expireSlaveKeys(void) {
         else
             dictDelete(slaveKeysWithExpire,keyname);
 
-        /* Stop conditions: found 3 keys we cna't expire in a row or
+        /* Stop conditions: found 3 keys we can't expire in a row or
          * time limit was reached. */
         cycles++;
         if (noexpire > 3) break;

--- a/src/networking.c
+++ b/src/networking.c
@@ -166,7 +166,7 @@ client *createClient(int fd) {
     return c;
 }
 
-/* This funciton puts the client in the queue of clients that should write
+/* This function puts the client in the queue of clients that should write
  * their output buffers to the socket. Note that it does not *yet* install
  * the write handler, to start clients are put in a queue of clients that need
  * to write, so we try to do that before returning in the event loop (see the
@@ -1290,7 +1290,7 @@ void resetClient(client *c) {
     }
 }
 
-/* This funciton is used when we want to re-enter the event loop but there
+/* This function is used when we want to re-enter the event loop but there
  * is the risk that the client we are dealing with will be freed in some
  * way. This happens for instance in:
  *

--- a/src/replication.c
+++ b/src/replication.c
@@ -1141,7 +1141,7 @@ redisDb *disklessLoadMakeBackups(void) {
  * the 'restore' argument (the number of DBs to replace) is non-zero.
  *
  * When instead the loading succeeded we want just to free our old backups,
- * in that case the funciton will do just that when 'restore' is 0. */
+ * in that case the function will do just that when 'restore' is 0. */
 void disklessLoadRestoreBackups(redisDb *backup, int restore, int empty_db_flags)
 {
     if (restore) {

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -269,7 +269,7 @@ void trackingLimitUsedSlots(void) {
     /* Let's start at a random position, and perform linear probing, in order
      * to improve cache locality. However once we are able to find an used
      * slot, jump again randomly, in order to avoid creating big holes in the
-     * table (that will make this funciton use more resourced later). */
+     * table (that will make this function use more resources later). */
     while(effort > 0) {
         unsigned int idx = rand() % TRACKING_TABLE_SIZE;
         do {

--- a/utils/create-cluster/README
+++ b/utils/create-cluster/README
@@ -1,4 +1,4 @@
-Create-custer is a small script used to easily start a big number of Redis
+create-cluster is a small script used to easily start a big number of Redis
 instances configured to run in cluster mode. Its main goal is to allow manual
 testing in a condition which is not easy to replicate with the Redis cluster
 unit tests, for example when a lot of instances are needed in order to trigger


### PR DESCRIPTION
Fix misspellings of "function" in four places in the code.