### PR TITLE
Fix issue #6141: cluster rebalance does not support binary key

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3222,7 +3222,7 @@ static redisReply *clusterManagerMigrateKeysInReply(clusterManagerNode *source,
         redisReply *entry = reply->element[i];
         size_t idx = i + offset;
         assert(entry->type == REDIS_REPLY_STRING);
-        argv[idx] = (char *) sdsnew(entry->str);
+        argv[idx] = (char *) sdsnewlen(entry->str, entry->len);
         argv_len[idx] = entry->len;
         if (dots) dots[i] = '.';
     }


### PR DESCRIPTION
In function clusterManagerMigrateKeysInReply, each key from a command's result is copied to the new command, but the function used to allocate memory is `sdsnew`. This command assumes the keys are NULL-terminated. 

By changing it to `sdsnewlen` and passing the real key length, the issue is fixed.