### PR TITLE
RM_ReplyWithCString was missing registration

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -5389,6 +5389,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ReplySetArrayLength);
     REGISTER_API(ReplyWithString);
     REGISTER_API(ReplyWithStringBuffer);
+    REGISTER_API(ReplyWithCString);
     REGISTER_API(ReplyWithNull);
     REGISTER_API(ReplyWithCallReply);
     REGISTER_API(ReplyWithDouble);


### PR DESCRIPTION
@antirez this needs to be cherry picked to 5.0 too. (currently broken)