### PR TITLE
command prompt help: add stdin config usage

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4469,6 +4469,7 @@ void usage(void) {
     fprintf(stderr,"       ./redis-server --test-memory <megabytes>\n\n");
     fprintf(stderr,"Examples:\n");
     fprintf(stderr,"       ./redis-server (run the server with default conf)\n");
+    fprintf(stderr,"       echo 'maxmemory 128mb' | ./redis-server -\n");
     fprintf(stderr,"       ./redis-server /etc/redis/6379.conf\n");
     fprintf(stderr,"       ./redis-server --port 7777\n");
     fprintf(stderr,"       ./redis-server --port 7777 --replicaof 127.0.0.1 8888\n");


### PR DESCRIPTION
I have added an example about how to pass configuration using `stdin`. I am thinking about expanding this example a little and make it shows how to add more than one config line or the current example is enough ?

Signed-off-by: Mostafa Hussein <mostafa.hussein91@gmail.com>