### PR TITLE
fix description about ziplist, the code is ok

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -86,7 +86,7 @@
  * |10000000|qqqqqqqq|rrrrrrrr|ssssssss|tttttttt| - 5 bytes
  *      String value with length greater than or equal to 16384 bytes.
  *      Only the 4 bytes following the first byte represents the length
- *      up to 32^2-1. The 6 lower bits of the first byte are not used and
+ *      up to 2^32-1. The 6 lower bits of the first byte are not used and
  *      are set to zero.
  *      IMPORTANT: The 32 bit number is stored in big endian.
  * |11000000| - 3 bytes

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -194,7 +194,7 @@
 #define ZIP_BIG_PREVLEN 254 /* Max number of bytes of the previous entry, for
                                the "prevlen" field prefixing each entry, to be
                                represented with just a single byte. Otherwise
-                               it is represented as FF AA BB CC DD, where
+                               it is represented as FE AA BB CC DD, where
                                AA BB CC DD are a 4 bytes unsigned integer
                                representing the previous entry len. */
 


### PR DESCRIPTION
1. fix description about ZIP_BIG_PREVLEN, this is similar to antirez#4705
2. fix description about ziplist entry encoding field, the max length should be 2^32 - 1 when encoding is 5 bytes