### PR TITLE
lsetCommand: merge delete and insert operations to reduce the number of memory allocations.

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -669,8 +669,7 @@ int quicklistReplaceAtIndex(quicklist *quicklist, long index, void *data,
     quicklistEntry entry;
     if (likely(quicklistIndex(quicklist, index, &entry))) {
         /* quicklistIndex provides an uncompressed node */
-        entry.node->zl = ziplistDelete(entry.node->zl, &entry.zi);
-        entry.node->zl = ziplistInsert(entry.node->zl, entry.zi, data, sz);
+        entry.node->zl = ziplistReplace(entry.node->zl, &entry.zi, data, sz);
         quicklistNodeUpdateSz(entry.node);
         quicklistCompress(quicklist, entry.node);
         return 1;

--- a/src/ziplist.h
+++ b/src/ziplist.h
@@ -44,6 +44,7 @@ unsigned int ziplistGet(unsigned char *p, unsigned char **sval, unsigned int *sl
 unsigned char *ziplistInsert(unsigned char *zl, unsigned char *p, unsigned char *s, unsigned int slen);
 unsigned char *ziplistDelete(unsigned char *zl, unsigned char **p);
 unsigned char *ziplistDeleteRange(unsigned char *zl, int index, unsigned int num);
+unsigned char *ziplistReplace(unsigned char *zl, unsigned char **p, unsigned char *s, unsigned int slen);
 unsigned int ziplistCompare(unsigned char *p, unsigned char *s, unsigned int slen);
 unsigned char *ziplistFind(unsigned char *p, unsigned char *vstr, unsigned int vlen, unsigned int skip);
 unsigned int ziplistLen(unsigned char *zl);


### PR DESCRIPTION
The following tests all passed

                   The End

Execution time of different units:
  1 seconds - unit/type/incr
  1 seconds - unit/printver
  1 seconds - unit/auth
  2 seconds - unit/keyspace
  2 seconds - unit/protocol
  1 seconds - unit/quit
  2 seconds - unit/multi
  4 seconds - unit/type/stream-cgroups
  12 seconds - unit/type/hash
  14 seconds - unit/type/list
  13 seconds - unit/other
  14 seconds - unit/scan
  14 seconds - unit/expire
  16 seconds - unit/type/string
  16 seconds - unit/type/set
  2 seconds - integration/convert-zipmap-hash-on-load
  1 seconds - integration/logging
  4 seconds - integration/rdb
  8 seconds - integration/aof
  1 seconds - unit/pubsub
  26 seconds - unit/type/zset
  3 seconds - unit/slowlog
  27 seconds - unit/sort
  0 seconds - unit/introspection
  27 seconds - integration/block-repl
  2 seconds - unit/limits
  7 seconds - unit/introspection-2
  12 seconds - unit/scripting
  3 seconds - unit/bitfield
  23 seconds - integration/psync2-reg
  10 seconds - unit/bitops
  36 seconds - integration/replication-2
  51 seconds - unit/dump
  51 seconds - unit/type/list-2
  3 seconds - unit/lazyfree
  35 seconds - integration/psync2
  7 seconds - unit/wait
  23 seconds - unit/pendingquerybuf
  87 seconds - unit/type/stream
  74 seconds - integration/replication-4
  88 seconds - unit/aofrw
  82 seconds - integration/replication-3
  66 seconds - unit/geo
  116 seconds - unit/type/list-3
  73 seconds - unit/hyperloglog
  114 seconds - integration/replication-psync
  107 seconds - unit/maxmemory
  134 seconds - integration/replication
  108 seconds - unit/memefficiency
  164 seconds - unit/obuf-limits

\o/ All tests passed without errors!

Cleanup: may take some time... OK
make[1]: Leaving directory '/home/wubo/redis/src'

