### PR TITLE
Avoid duplicate exit function call

### DIFF
--- a/src/memtest.c
+++ b/src/memtest.c
@@ -356,5 +356,4 @@ void memtest(size_t megabytes, int passes) {
     printf("Please if you are still in doubt use the following two tools:\n");
     printf("1) memtest86: http://www.memtest86.com/\n");
     printf("2) memtester: http://pyropus.ca/software/memtester/\n");
-    exit(0);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -5111,7 +5111,7 @@ void moduleInitModulesSystem(void) {
     server.loadmodule_queue = listCreate();
     modules = dictCreate(&modulesDictType,NULL);
 
-    /* Set up the keyspace notification susbscriber list and static client */
+    /* Set up the keyspace notification subscriber list and static client */
     moduleKeyspaceSubscribers = listCreate();
     moduleFreeContextReusedClient = createClient(-1);
     moduleFreeContextReusedClient->flags |= CLIENT_MODULE;

--- a/src/module.c
+++ b/src/module.c
@@ -5111,7 +5111,7 @@ void moduleInitModulesSystem(void) {
     server.loadmodule_queue = listCreate();
     modules = dictCreate(&modulesDictType,NULL);
 
-    /* Set up the keyspace notification subscriber list and static client */
+    /* Set up the keyspace notification susbscriber list and static client */
     moduleKeyspaceSubscribers = listCreate();
     moduleFreeContextReusedClient = createClient(-1);
     moduleFreeContextReusedClient->flags |= CLIENT_MODULE;


### PR DESCRIPTION
It turns out main function call `exit` after memtest, but memtest also called `exit`. 

```c
memtest(atoi(argv[2]),50);
exit(0);
```