### PR TITLE
Expose used memory to modules via redismodule api

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -5905,10 +5905,10 @@ size_t RM_MallocSize(void* ptr){
  * 0 - no memory limit
  * 100 and above, memory limit reached.
  */
-float RM_GetUsedMemoryPercentage(){
+float RM_GetUsedMemoryRatio(){
     float level;
     getMaxmemoryState(NULL, NULL, NULL, &level);
-    return level * 100;
+    return level;
 }
 
 /* --------------------------------------------------------------------------
@@ -6991,6 +6991,6 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(BlockClientOnKeys);
     REGISTER_API(SignalKeyAsReady);
     REGISTER_API(GetBlockedClientReadyKey);
-    REGISTER_API(GetUsedMemoryPercentage);
+    REGISTER_API(GetUsedMemoryRatio);
     REGISTER_API(MallocSize);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -5903,7 +5903,7 @@ size_t RM_MallocSize(void* ptr){
  * Return the a number between 0 to 1 indicating
  * the amount of memory currently used.
  * 0 - no memory limit
- * 100 and above, memory limit reached.
+ * 1 and above, memory limit reached.
  */
 float RM_GetUsedMemoryRatio(){
     float level;

--- a/src/module.c
+++ b/src/module.c
@@ -5891,6 +5891,26 @@ int RM_CommandFilterArgDelete(RedisModuleCommandFilterCtx *fctx, int pos)
     return REDISMODULE_OK;
 }
 
+/*
+ * For a given pointer, return The amount of memory
+ * allocated for this pointer.
+ */
+size_t RM_MallocSize(void* ptr){
+    return zmalloc_size(ptr);
+}
+
+/*
+ * Return the a number between 0 to 1 indicating
+ * the amount of memory currently used.
+ * 0 - no memory limit
+ * 1 and above, memory limit reached.
+ */
+float RM_GetUsedMemoryPercentage(){
+    float level;
+    getMaxmemoryState(NULL, NULL, NULL, &level);
+    return level;
+}
+
 /* --------------------------------------------------------------------------
  * Module fork API
  * -------------------------------------------------------------------------- */
@@ -6971,4 +6991,6 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(BlockClientOnKeys);
     REGISTER_API(SignalKeyAsReady);
     REGISTER_API(GetBlockedClientReadyKey);
+    REGISTER_API(GetUsedMemoryPercentage);
+    REGISTER_API(MallocSize);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -5903,12 +5903,12 @@ size_t RM_MallocSize(void* ptr){
  * Return the a number between 0 to 1 indicating
  * the amount of memory currently used.
  * 0 - no memory limit
- * 1 and above, memory limit reached.
+ * 100 and above, memory limit reached.
  */
 float RM_GetUsedMemoryPercentage(){
     float level;
     getMaxmemoryState(NULL, NULL, NULL, &level);
-    return level;
+    return level * 100;
 }
 
 /* --------------------------------------------------------------------------

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -633,7 +633,7 @@ int REDISMODULE_API_FUNC(RedisModule_CommandFilterArgDelete)(RedisModuleCommandF
 int REDISMODULE_API_FUNC(RedisModule_Fork)(RedisModuleForkDoneHandler cb, void *user_data);
 int REDISMODULE_API_FUNC(RedisModule_ExitFromChild)(int retcode);
 int REDISMODULE_API_FUNC(RedisModule_KillForkChild)(int child_pid);
-float REDISMODULE_API_FUNC(RedisModule_GetUsedMemoryPercentage)();
+float REDISMODULE_API_FUNC(RedisModule_GetUsedMemoryRatio)();
 size_t REDISMODULE_API_FUNC(RedisModule_MallocSize)(void* ptr);
 #endif
 
@@ -844,7 +844,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(Fork);
     REDISMODULE_GET_API(ExitFromChild);
     REDISMODULE_GET_API(KillForkChild);
-    REDISMODULE_GET_API(GetUsedMemoryPercentage);
+    REDISMODULE_GET_API(GetUsedMemoryRatio);
     REDISMODULE_GET_API(MallocSize);
 #endif
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -633,6 +633,8 @@ int REDISMODULE_API_FUNC(RedisModule_CommandFilterArgDelete)(RedisModuleCommandF
 int REDISMODULE_API_FUNC(RedisModule_Fork)(RedisModuleForkDoneHandler cb, void *user_data);
 int REDISMODULE_API_FUNC(RedisModule_ExitFromChild)(int retcode);
 int REDISMODULE_API_FUNC(RedisModule_KillForkChild)(int child_pid);
+float REDISMODULE_API_FUNC(RedisModule_GetUsedMemoryPercentage)();
+size_t REDISMODULE_API_FUNC(RedisModule_MallocSize)(void* ptr);
 #endif
 
 #define RedisModule_IsAOFClient(id) ((id) == UINT64_MAX)
@@ -842,6 +844,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(Fork);
     REDISMODULE_GET_API(ExitFromChild);
     REDISMODULE_GET_API(KillForkChild);
+    REDISMODULE_GET_API(GetUsedMemoryPercentage);
+    REDISMODULE_GET_API(MallocSize);
 #endif
 
     if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;


### PR DESCRIPTION
Hey @antirez.

I added 2 small functions to the redismodule.h api.

The first allows to get the allocated memory for a given pointer. I thought it will be a good idea that modules could create their own allocators and keep stats about the amount of memory used by them, so if we see high memory usage on a database that has multiple modules, we can easily see for each module, how many memory it consume.

The second return the amount of memory currently used (in percentage). It allows modules that have some GC mechanism (like redisearch) to make a better decision on when to start collecting garbage.

Let me know what you think.
Thanks.