### PR TITLE
fix rdb function rdbLoadIntegerObject comment

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -260,7 +260,7 @@ int rdbEncodeInteger(long long value, unsigned char *enc) {
 
 /* Loads an integer-encoded object with the specified encoding type "enctype".
  * The returned value changes according to the flags, see
- * rdbGenerincLoadStringObject() for more info. */
+ * rdbGenericLoadStringObject() for more info. */
 void *rdbLoadIntegerObject(rio *rdb, int enctype, int flags, size_t *lenptr) {
     int plain = flags & RDB_LOAD_PLAIN;
     int sds = flags & RDB_LOAD_SDS;


### PR DESCRIPTION
when I read the source code of redis，the comment of function rdbLoadIntegerObject in the file of  `rdb.c` have a wrong place.  I can't find the the `rdbGenerincLoadStringObject` function in the whole project , it should be rdbGenericLoadStringObject. This may be a trivial point.