### PR TITLE
WIP: Add support to fallback to all results of  getaddrinfo() (ipv6/ ipv4 dual-stack, DNS-RR)

### DIFF
--- a/deps/hiredis/net.c
+++ b/deps/hiredis/net.c
@@ -319,21 +319,21 @@ static int _redisContextConnectTcp(redisContext *c, const char *addr, int port,
 
     snprintf(_port, 6, "%d", port);
     memset(&hints,0,sizeof(hints));
-    hints.ai_family = AF_INET;
+    hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
 
-    /* Try with IPv6 if no IPv4 address was found. We do it in this order since
-     * in a Redis client you can't afford to test if you have IPv6 connectivity
-     * as this would add latency to every connect. Otherwise a more sensible
-     * route could be: Use IPv6 if both addresses are available and there is IPv6
-     * connectivity. */
+    /* In an earlier version, IPv6 was only tried if no IPv4 address was
+     * available, to reduce latency for Redis clients. This breaks setups with
+     * e.g. AAAA records but not IPv6 connectivity. Therefore, we're just using
+     * the regular addrinfo struct returned by getaddrinfo() instead and loop
+     * over the the responses in the order the kernel gave us.
+     * Hopefully, the latency introduced by this isn't too bad.
+     */
     if ((rv = getaddrinfo(c->tcp.host,_port,&hints,&servinfo)) != 0) {
-         hints.ai_family = AF_INET6;
-         if ((rv = getaddrinfo(addr,_port,&hints,&servinfo)) != 0) {
-            __redisSetError(c,REDIS_ERR_OTHER,gai_strerror(rv));
-            return REDIS_ERR;
-        }
+        __redisSetError(c,REDIS_ERR_OTHER,gai_strerror(rv));
+        return REDIS_ERR;
     }
+
     for (p = servinfo; p != NULL; p = p->ai_next) {
 addrretry:
         if ((s = socket(p->ai_family,p->ai_socktype,p->ai_protocol)) == -1)

--- a/deps/hiredis/net.c
+++ b/deps/hiredis/net.c
@@ -411,6 +411,17 @@ wait_for_ready:
 
         c->flags |= REDIS_CONNECTED;
 
+        /* This is needed because c->err is set using __redisSetError on
+        * connection failures. This can be called by various functions.
+        * We shall have a clear function that would ideally clean the struct
+        * of all past errors which have been put into or somehow only set the
+        * error flag and message after looping through all IP addresses and
+        * not finding any REDIS_OK.
+        * Also, we're cleaning c->errstr, analogue to redisReconnect()
+        */
+        c->err = 0;
+        memset(c->errstr, '\0', strlen(c->errstr));
+
         freeaddrinfo(servinfo);
         return REDIS_OK;  // Need to return REDIS_OK if alright
     }

--- a/deps/hiredis/net.c
+++ b/deps/hiredis/net.c
@@ -402,13 +402,6 @@ wait_for_ready:
         if (redisSetTcpNoDelay(c) != REDIS_OK)
             continue;
 
-        if (p == NULL) {
-            char buf[128];
-            snprintf(buf,sizeof(buf),"Can't create socket: %s",strerror(errno));
-            __redisSetError(c,REDIS_ERR_OTHER,buf);
-            continue;
-        }
-
         c->flags |= REDIS_CONNECTED;
 
         /* This is needed because c->err is set using __redisSetError on

--- a/src/anet.c
+++ b/src/anet.c
@@ -280,16 +280,25 @@ static int anetTcpGenericConnect(char *err, char *addr, int port,
          * the next entry in servinfo. */
         if ((s = socket(p->ai_family,p->ai_socktype,p->ai_protocol)) == -1)
             continue;
-        if (anetSetReuseAddr(err,s) == ANET_ERR) goto error;
-        if (flags & ANET_CONNECT_NONBLOCK && anetNonBlock(err,s) != ANET_OK)
-            goto error;
+
+        if (anetSetReuseAddr(err,s) == ANET_ERR) {
+            close(s);
+            continue;
+        }
+
+        if (flags & ANET_CONNECT_NONBLOCK && anetNonBlock(err,s) != ANET_OK) {
+            close(s);
+            continue;
+        }
+
         if (source_addr) {
             int bound = 0;
             /* Using getaddrinfo saves us from self-determining IPv4 vs IPv6 */
             if ((rv = getaddrinfo(source_addr, NULL, &hints, &bservinfo)) != 0)
             {
                 anetSetError(err, "%s", gai_strerror(rv));
-                goto error;
+                close(s);
+                continue;
             }
             for (b = bservinfo; b != NULL; b = b->ai_next) {
                 if (bind(s,b->ai_addr,b->ai_addrlen) != -1) {
@@ -300,42 +309,26 @@ static int anetTcpGenericConnect(char *err, char *addr, int port,
             freeaddrinfo(bservinfo);
             if (!bound) {
                 anetSetError(err, "bind: %s", strerror(errno));
-                goto error;
+                close(s);
+                continue;
             }
         }
+
         if (connect(s,p->ai_addr,p->ai_addrlen) == -1) {
             /* If the socket is non-blocking, it is ok for connect() to
              * return an EINPROGRESS error here. */
-            if (errno == EINPROGRESS && flags & ANET_CONNECT_NONBLOCK)
-                goto end;
+            if (errno == EINPROGRESS && flags & ANET_CONNECT_NONBLOCK) {
+                freeaddrinfo(servinfo);
+                return s;
+            }
+
             close(s);
-            s = ANET_ERR;
             continue;
         }
-
-        /* If we ended an iteration of the for loop without errors, we
-         * have a connected socket. Let's return to the caller. */
-        goto end;
-    }
-    if (p == NULL)
-        anetSetError(err, "creating socket: %s", strerror(errno));
-
-error:
-    if (s != ANET_ERR) {
-        close(s);
-        s = ANET_ERR;
     }
 
-end:
     freeaddrinfo(servinfo);
-
-    /* Handle best effort binding: if a binding address was used, but it is
-     * not possible to create a socket, try again without a binding address. */
-    if (s == ANET_ERR && source_addr && (flags & ANET_CONNECT_BE_BINDING)) {
-        return anetTcpGenericConnect(err,addr,port,NULL,flags);
-    } else {
-        return s;
-    }
+    return -1;
 }
 
 int anetTcpConnect(char *err, char *addr, int port)

--- a/src/anet.h
+++ b/src/anet.h
@@ -32,6 +32,7 @@
 #define ANET_H
 
 #include <sys/types.h>
+#include <netdb.h>
 
 #define ANET_OK 0
 #define ANET_ERR -1
@@ -56,8 +57,8 @@ int anetTcpNonBlockBestEffortBindConnect(char *err, char *addr, int port, char *
 int anetUnixConnect(char *err, char *path);
 int anetUnixNonBlockConnect(char *err, char *path);
 int anetRead(int fd, char *buf, int count);
-int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len);
-int anetResolveIP(char *err, char *host, char *ipbuf, size_t ipbuf_len);
+int anetResolve(char *err, char *host, struct addrinfo **info);
+int anetResolveIP(char *err, char *host, struct addrinfo **info);
 int anetTcpServer(char *err, int port, char *bindaddr, int backlog);
 int anetTcp6Server(char *err, int port, char *bindaddr, int backlog);
 int anetUnixServer(char *err, char *path, mode_t perm, int backlog);

--- a/src/networking.c
+++ b/src/networking.c
@@ -125,7 +125,7 @@ client *createClient(int fd) {
     c->repl_ack_off = 0;
     c->repl_ack_time = 0;
     c->slave_listening_port = 0;
-    c->slave_ip[0] = '\0';
+    c->slave_hostname[0] = '\0';
     c->slave_capa = SLAVE_CAPA_NONE;
     c->reply = listCreate();
     c->reply_bytes = 0;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1724,7 +1724,7 @@ void backgroundSaveDoneHandlerDisk(int exitcode, int bysignal) {
 }
 
 /* A background saving child (BGSAVE) terminated its work. Handle this.
- * This function covers the case of RDB -> Salves socket transfers for
+ * This function covers the case of RDB -> Slaves socket transfers for
  * diskless replication. */
 void backgroundSaveDoneHandlerSocket(int exitcode, int bysignal) {
     uint64_t *ok_slaves;

--- a/src/replication.c
+++ b/src/replication.c
@@ -584,7 +584,7 @@ int startBgsaveForReplication(int mincapa) {
     }
 
     /* If we failed to BGSAVE, remove the slaves waiting for a full
-     * resynchorinization from the list of salves, inform them with
+     * resynchorinization from the list of slaves, inform them with
      * an error about what happened, close the connection ASAP. */
     if (retval == C_ERR) {
         serverLog(LL_WARNING,"BGSAVE for replication failed");
@@ -604,7 +604,7 @@ int startBgsaveForReplication(int mincapa) {
     }
 
     /* If the target is socket, rdbSaveToSlavesSockets() already setup
-     * the salves for a full resync. Otherwise for disk target do it now.*/
+     * the slaves for a full resync. Otherwise for disk target do it now.*/
     if (!socket_target) {
         listRewind(server.slaves,&li);
         while((ln = listNext(&li))) {
@@ -1344,7 +1344,7 @@ char *sendSynchronousCommand(int flags, int fd, ...) {
         }
         cmd = sdscatlen(cmd,"\r\n",2);
         va_end(ap);
-        
+
         /* Transfer command to the server. */
         if (syncWrite(fd,cmd,sdslen(cmd),server.repl_syncio_timeout*1000)
             == -1)

--- a/src/server.c
+++ b/src/server.c
@@ -2180,7 +2180,7 @@ void preventCommandReplication(client *c) {
  * CMD_CALL_STATS       Populate command stats.
  * CMD_CALL_PROPAGATE_AOF   Append command to AOF if it modified the dataset
  *                          or if the client flags are forcing propagation.
- * CMD_CALL_PROPAGATE_REPL  Send command to salves if it modified the dataset
+ * CMD_CALL_PROPAGATE_REPL  Send command to slaves if it modified the dataset
  *                          or if the client flags are forcing propagation.
  * CMD_CALL_PROPAGATE   Alias for PROPAGATE_AOF|PROPAGATE_REPL.
  * CMD_CALL_FULL        Alias for SLOWLOG|STATS|PROPAGATE.

--- a/src/server.c
+++ b/src/server.c
@@ -3236,14 +3236,14 @@ sds genRedisInfoString(char *section) {
             while((ln = listNext(&li))) {
                 client *slave = listNodeValue(ln);
                 char *state = NULL;
-                char ip[NET_IP_STR_LEN], *slaveip = slave->slave_ip;
+                char hostname[NET_IP_STR_LEN], *slavehostname = slave->slave_hostname;
                 int port;
                 long lag = 0;
 
-                if (slaveip[0] == '\0') {
-                    if (anetPeerToString(slave->fd,ip,sizeof(ip),&port) == -1)
+                if (slavehostname[0] == '\0') {
+                    if (anetPeerToString(slave->fd,hostname,sizeof(hostname),&port) == -1)
                         continue;
-                    slaveip = ip;
+                    slavehostname = hostname;
                 }
                 switch(slave->replstate) {
                 case SLAVE_STATE_WAIT_BGSAVE_START:
@@ -3264,7 +3264,7 @@ sds genRedisInfoString(char *section) {
                 info = sdscatprintf(info,
                     "slave%d:ip=%s,port=%d,state=%s,"
                     "offset=%lld,lag=%ld\r\n",
-                    slaveid,slaveip,slave->slave_listening_port,state,
+                    slaveid,slavehostname,slave->slave_listening_port,state,
                     slave->repl_ack_off, lag);
                 slaveid++;
             }

--- a/src/server.h
+++ b/src/server.h
@@ -145,7 +145,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CONFIG_DEFAULT_MIN_SLAVES_TO_WRITE 0
 #define CONFIG_DEFAULT_MIN_SLAVES_MAX_LAG 10
 #define NET_IP_STR_LEN 46 /* INET6_ADDRSTRLEN is 46, but we need to be sure */
-#define NET_PEER_ID_LEN (NET_IP_STR_LEN+32) /* Must be enough for ip:port */
+#define NET_PEER_ID_LEN (NET_IP_STR_LEN+32) /* Must be enough for hostname:port */
 #define CONFIG_BINDADDR_MAX 16
 #define CONFIG_MIN_RESERVED_FDS 32
 #define CONFIG_DEFAULT_LATENCY_MONITOR_THRESHOLD 0
@@ -713,7 +713,7 @@ typedef struct client {
                                        should use. */
     char replid[CONFIG_RUN_ID_SIZE+1]; /* Master replication ID (if master). */
     int slave_listening_port; /* As configured with: SLAVECONF listening-port */
-    char slave_ip[NET_IP_STR_LEN]; /* Optionally given by REPLCONF ip-address */
+    char slave_hostname[NET_IP_STR_LEN]; /* Optionally given by REPLCONF ip-address */
     int slave_capa;         /* Slave capabilities: SLAVE_CAPA_* bitwise OR. */
     multiState mstate;      /* MULTI/EXEC state */
     int btype;              /* Type of blocking op if CLIENT_BLOCKED. */

--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -180,7 +180,7 @@ start_server {} {
         set slave_id [expr {($master_id+1)%5}]
         set sync_count [status $R($master_id) sync_full]
 
-        # Make sure to replicate the first EVAL while the salve is online
+        # Make sure to replicate the first EVAL while the slave is online
         # so that it's part of the scripts the master believes it's safe
         # to propagate as EVALSHA.
         $R($master_id) EVAL {return redis.call("incr","__mycounter")} 0


### PR DESCRIPTION
This pull request introduces support to store hostnames in the `sentinelAddr` struct instead of resolved IP adresses.

This fixes the issue of:

1. Changing IP adresses (when a DNS hostname is given in the configuration file)
2. Dual-Stack setups where one ip version might be not available (e.g. an `AAAA` record is set, but the connection can only be established via ipv4 (or vice-versa)), or other networking problems.

It seems to me that after `getaddrinfo()` the correct behaviour should be to iterate over all `addrinfo` structs using `ai_next` until a connection succeeds. This behaviour is mostly already implemented, but overridden by some (apparently conciously chosen) decisions. 

The comments mention performance reasons and an reduced amount of DNS lookups, so this might introduce some overhead. At least in our setup, an additional DNS request upon a (re)-connect seems to be less of an issue than problems with the dual-stack setup.

This fixes (or at least should fix): 
- https://github.com/antirez/redis/issues/6358
- https://github.com/antirez/redis/issues/6345

Test are green, but this wasn't extensively tested in production yet. 

Opinions welcome!


NOTE: This PR is against the `4.0` branch, as this is the currently shipped version with Ubuntu 18.04 LTS, but can be easily rebased upon request on `unstable` or `5.0`. 

NOTE: This patch includes some changes to `hiredis`. I've included them here for now, but it might be wise to add an additional pull request to https://github.com/redis/hiredis if this turns out to be a good idea. 