### PR TITLE
Improve performance of RM_ReplyWithSimpleString and RM_ReplyWi…

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1120,6 +1120,19 @@ int RM_ReplyWithLongLong(RedisModuleCtx *ctx, long long ll) {
     return REDISMODULE_OK;
 }
 
+/* Reply with an error or simple string (status message). Used to implement
+ * ReplyWithSimpleString() and ReplyWithError().
+ * The function always returns REDISMODULE_OK. */
+int replyWithStatus(RedisModuleCtx *ctx, const char *msg, char *prefix) {
+    client *c = moduleGetReplyClient(ctx);
+    if (c == NULL) return REDISMODULE_OK;
+    const size_t len = strlen(msg);
+    addReplyProto(c,"-",1);
+    addReplyProto(c,msg,len);
+    addReplyProto(c,"\r\n",2);
+    return REDISMODULE_OK;
+}
+
 /* Reply with the error 'err'.
  *
  * Note that 'err' must contain all the error, including
@@ -1135,13 +1148,7 @@ int RM_ReplyWithLongLong(RedisModuleCtx *ctx, long long ll) {
  * The function always returns REDISMODULE_OK.
  */
 int RM_ReplyWithError(RedisModuleCtx *ctx, const char *err) {
-    client *c = moduleGetReplyClient(ctx);
-    if (c == NULL) return REDISMODULE_OK;
-    const size_t len = strlen(err);
-    addReplyProto(c,"-",1);
-    addReplyProto(c,err,len);
-    addReplyProto(c,"\r\n",2);
-    return REDISMODULE_OK;
+    return replyWithStatus(ctx,err,"-");
 }
 
 /* Reply with a simple string (+... \r\n in RESP protocol). This replies
@@ -1150,13 +1157,7 @@ int RM_ReplyWithError(RedisModuleCtx *ctx, const char *err) {
  *
  * The function always returns REDISMODULE_OK. */
 int RM_ReplyWithSimpleString(RedisModuleCtx *ctx, const char *msg) {
-    client *c = moduleGetReplyClient(ctx);
-    if (c == NULL) return REDISMODULE_OK;
-    const size_t len = strlen(msg);
-    addReplyProto(c,"+",1);
-    addReplyProto(c,msg,len);
-    addReplyProto(c,"\r\n",2);
-    return REDISMODULE_OK;
+    return replyWithStatus(ctx,msg,"+");
 }
 
 /* Reply with an array type of 'len' elements. However 'len' other calls

--- a/src/module.c
+++ b/src/module.c
@@ -1126,9 +1126,10 @@ int RM_ReplyWithLongLong(RedisModuleCtx *ctx, long long ll) {
 int replyWithStatus(RedisModuleCtx *ctx, const char *msg, char *prefix) {
     client *c = moduleGetReplyClient(ctx);
     if (c == NULL) return REDISMODULE_OK;
-    const size_t len = strlen(msg);
-    addReplyProto(c,"-",1);
-    addReplyProto(c,msg,len);
+    const size_t msgLen = strlen(msg);
+    const size_t prefixLen = strlen(prefix);
+    addReplyProto(c,prefix,prefixLen);
+    addReplyProto(c,msg,msgLen);
     addReplyProto(c,"\r\n",2);
     return REDISMODULE_OK;
 }


### PR DESCRIPTION
# Summary Report 
This PR improves performance of RM_ReplyWithSimpleString and RM_ReplyWithError by making usage addReplyProto instead of addReplySds leading to fewer memory allocations/deallocations. This PR does no change the `module.h` API ( only the auxiliar method replyWithStatus was removed ).

Using callgrind and running 1M commands that only return "+OK\r\n" we can get the average cyles per call of RM_ReplyWithSimpleString:
- using addReplySds 38.38 Cycles per Call 
- using addReplyProto 13.85 Cycles per Call


Focusing on the memory usage, if we compare both callgrind graph outputs we see that, as an example, zmalloc was called 3 times more for implementation of RM_ReplyWithSimpleString with addReplySds implementation vs the implementation with addReplyProto.

----------------------

RM_ReplyWithSimpleString and RM_ReplyWithError are used among all Redis Modules making this change improve the overall performance of all modules commands. 
Focusing on RM_ReplyWithSimpleString, even the simplest command that only returns the RESP OK Code ( "+OK\r\n" ) via calling RM_ReplyWithSimpleString(ctx,"OK"), due to the current implementation of RM_ReplyWithSimpleString we're constantly allocating and deallocating dynamic strings leading to penalties in terms of performance potentially to all commands competing for memory.

## Average cycles per call of RM_ReplyWithSimpleString with addReplySds vs addReplyProto
Using callgrind and running 1M commands that only return "+OK\r\n" we can get the average cyles per call of RM_ReplyWithSimpleString:
- using addReplySds 38.38 Cycles per Call 
- using addReplyProto 13.85 Cycles per Call

## RM_ReplyWithSimpleString call graph with addReplySds vs addReplyProto

Bellow we show the two callgraphs from the implementation of RM_ReplyWithSimpleString(ctx,"OK") using addReplySds vs  RM_ReplyWithSimpleString(ctx,"OK") using addReplyProto.  

 ### RM_ReplyWithSimpleString call graph with addReplySds

![image](https://user-images.githubusercontent.com/5832149/64927286-afa5f780-d800-11e9-9839-e725b48a4199.png)

### RM_ReplyWithSimpleString call graph with addReplyProto
![image](https://user-images.githubusercontent.com/5832149/64927332-673b0980-d801-11e9-9a4f-f9a5df6d8c34.png)


## Allocator/Deallocator #calls
### zmalloc
If we compare both callgrind graph outputs we see that, as an example, zmalloc was called ~3M times for the RM_ReplyWithSimpleString with addReplySds implementation vs 1M times for the RM_ReplyWithSimpleString with addReplyProto implementation.

### zfree
Following the same logic as above, zfree was called ~2M times for the RM_ReplyWithSimpleString with  addReplySds implementation vs ~0 times for the RM_ReplyWithSimpleString with addReplyProto implementation

