### PR TITLE
initialize client woff with server.master_repl_offset

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -152,7 +152,7 @@ client *createClient(int fd) {
     c->bpop.xread_group_noack = 0;
     c->bpop.numreplicas = 0;
     c->bpop.reploffset = 0;
-    c->woff = 0;
+    c->woff = server.master_repl_offset;
     c->watched_keys = listCreate();
     c->pubsub_channels = dictCreate(&objectKeyPointerValueDictType,NULL);
     c->pubsub_patterns = listCreate();


### PR DESCRIPTION
Initialize client `woff` with `server.master_repl_offset`, in case `0` write offset.

BTW, now `woff` is only used in `wait` command, and it seems that `server.master_repl_offset` is enough here, will it be useful in the future?