### PR TITLE
Fix bad handling of unexpected yesno option

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -672,6 +672,9 @@ void loadServerConfigFromString(char *config) {
             server.lua_time_limit = strtoll(argv[1],NULL,10);
         } else if (!strcasecmp(argv[0],"lua-replicate-commands") && argc == 2) {
             server.lua_always_replicate_commands = yesnotoi(argv[1]);
+            if ((server.lua_always_replicate_commands = yesnotoi(argv[1])) == -1) {
+                err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
         } else if (!strcasecmp(argv[0],"slowlog-log-slower-than") &&
                    argc == 2)
         {


### PR DESCRIPTION
Fix bad handling of unexpected option while loading config "lua-replicate-commands".