### PR TITLE
DISCARD should not fail during OOM

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3411,7 +3411,7 @@ int processCommand(client *c) {
          * is in MULTI/EXEC context? Error. */
         if (out_of_memory &&
             (c->cmd->flags & CMD_DENYOOM ||
-             (c->flags & CLIENT_MULTI && c->cmd->proc != execCommand))) {
+             (c->flags & CLIENT_MULTI && c->cmd->proc != execCommand && c->cmd->proc != discardCommand))) {
             flagTransaction(c);
             addReply(c, shared.oomerr);
             return C_OK;

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -306,4 +306,18 @@ start_server {tags {"multi"}} {
         }
         close_replication_stream $repl
     }
+
+    test {DISCARD should not fail during OOM} {
+        set rd [redis_deferring_client]
+        $rd config set maxmemory 1
+        assert  {[$rd read] eq {OK}}
+        r multi
+        catch {r set x 1} e
+        assert_match {OOM*} $e
+        r discard
+        $rd config set maxmemory 0
+        assert  {[$rd read] eq {OK}}
+        $rd close
+        r ping
+    } {PONG}
 }


### PR DESCRIPTION
discard command should not fail during OOM, otherwise client MULTI state
will not be cleared.