### PR TITLE
Seed SipHash with 128-bit key

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4787,9 +4787,9 @@ int main(int argc, char **argv) {
     srand(time(NULL)^getpid());
     gettimeofday(&tv,NULL);
 
-    char hashseed[16];
-    getRandomHexChars(hashseed,sizeof(hashseed));
-    dictSetHashFunctionSeed((uint8_t*)hashseed);
+    uint8_t hashseed[16];
+    getRandomBytes(hashseed,sizeof(hashseed));
+    dictSetHashFunctionSeed(hashseed);
     server.sentinel_mode = checkForSentinelMode(argc,argv);
     initServerConfig();
     ACLInit(); /* The ACL subsystem must be initialized ASAP because the


### PR DESCRIPTION
I'm working on an instructional presentation presenting the nuts-and-bolts of how Redis works, and I've come across what I think is a mistake in the keying/seeding of SipHash.

I've dug into this to the best of my ability, but I'm not a cryptographer, and there may be something I've missed as to Redis' approach.

SipHash expects a 128-bit key, and Redis indeed generates 128-bits (16 random bytes), but restricts them to ASCII hex characters 0-9a-f, effectively giving us only 4 bits-per-byte of key material, and 64 bits overall.  Considering Redis uses SipHash 1-2, I think using the full key space would be beneficial.

Thanks