### PR TITLE
Added cluster host and protected mode variables to the create cluster script.

### DIFF
--- a/utils/create-cluster/README
+++ b/utils/create-cluster/README
@@ -16,7 +16,7 @@ To create a cluster, follow these steps:
 number of instances you want to create.
 2. Use "./create-cluster start" in order to run the instances.
 3. Use "./create-cluster create" in order to execute redis-cli --cluster create, so that
-an actual Redis cluster will be created.
+an actual Redis cluster will be created. (If you're accessing your setup via a local container, ensure that the CLUSTER_HOST value is changed to your local IP)
 4. Now you are ready to play with the cluster. AOF files and logs for each instances are created in the current directory.
 
 In order to stop a cluster:

--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 # Settings
+CLUSTER_HOST=127.0.0.1
 PORT=30000
 TIMEOUT=2000
 NODES=6
 REPLICAS=1
+PROTECTED_MODE=yes
 
 # You may want to put the above config parameters into config.sh in order to
 # override the defaults without modifying this script.
@@ -22,7 +24,7 @@ then
     while [ $((PORT < ENDPORT)) != "0" ]; do
         PORT=$((PORT+1))
         echo "Starting $PORT"
-        ../../src/redis-server --port $PORT --cluster-enabled yes --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes
+        ../../src/redis-server --port $PORT  --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes
     done
     exit 0
 fi
@@ -32,7 +34,7 @@ then
     HOSTS=""
     while [ $((PORT < ENDPORT)) != "0" ]; do
         PORT=$((PORT+1))
-        HOSTS="$HOSTS 127.0.0.1:$PORT"
+        HOSTS="$HOSTS $CLUSTER_HOST:$PORT"
     done
     ../../src/redis-cli --cluster create $HOSTS --cluster-replicas $REPLICAS
     exit 0


### PR DESCRIPTION
The changes to the cluster script involve the addition of the following:

1. The CLUSTER_HOST variable:  The host variable has been added instead of using static localhost.  This allows the user to easily change the value of the hosts being created. This is useful when the cluster is being tested on a local environment alongside a local container setup. Failing to change this causes issues wherein the container's localhost doesn't map to the machine's localhost, resulting in a RedisClusterException with the message "Can't communicate with any node in the cluster".
Issue example:
https://stackoverflow.com/questions/35599977/redisclusterexception-with-phpredis-when-connecting-to-redis-cluster-which-is-no

2. The PROTECTED_MODE variable: The variable will help users toggle protected mode for the clusters easily during setup.

3. Additions to the README file.