### PR TITLE
Minor Update to Password Removal Error Message

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -694,7 +694,7 @@ void ACLAddAllowedSubcommand(user *u, unsigned long id, const char *sub) {
  *         fully added.
  * EEXIST: You are adding a key pattern after "*" was already added. This is
  *         almost surely an error on the user side.
- * ENODEV: The password you are trying to remove from the user does not exist.
+ * ENODEV: The username and password combination you are trying to remove does not exist.
  * EBADMSG: The hash you are trying to add is not a valid hash. 
  */
 int ACLSetUser(user *u, const char *op, ssize_t oplen) {
@@ -888,8 +888,8 @@ char *ACLSetUserStringError(void) {
                  "effect. Try 'resetkeys' to start with an empty "
                  "list of patterns";
     else if (errno == ENODEV)
-        errmsg = "The password you are trying to remove from the user does "
-                 "not exist";
+        errmsg = "The username and password combination you are trying to "
+                 "remove does not exist";
     else if (errno == EBADMSG)
         errmsg = "The password hash must be exactly 64 characters and contain "
                  "only lowercase hexadecimal characters";


### PR DESCRIPTION
The error message defined by ENODEV also appears for the use case where a password is attempted to be removed from a user that does not exist. This PR suggests minor changes to the error message to suggest that it may not just be that the password does not exist but also that the username does not exist.

Example Below:

```
127.0.0.1:6379> acl list
1) "user default on nopass ~* +@all"
2) "user kyle off #e66637277baf5cbf0199da7785b76afe9ce2adcdbb45cbdd14a438a428402517 #8b75b5b7eb1db071c9f2c7e649a5e6d07afd94f9b765f1f77a6fd4dd3a6c21a5 -@all"
127.0.0.1:6379> acl setuser IDoNotExist <fakepassword
(error) ERR Error in ACL SETUSER modifier '<fakepassword': The password you are trying to remove from the user does not exist
```