### PR TITLE
Fixing init.d script

### DIFF
--- a/utils/redis_init_script
+++ b/utils/redis_init_script
@@ -5,6 +5,8 @@
 
 ### BEGIN INIT INFO
 # Provides:     redis_6379
+# Required-Start:       $remote_fs $syslog
+# Required-Stop:        $remote_fs $syslog
 # Default-Start:        2 3 4 5
 # Default-Stop:         0 1 6
 # Short-Description:    Redis data structure server


### PR DESCRIPTION
Updating init.d script to include `Required-Start` and `Required-Stop`
per Debian requirements to include LSB style dependency information in the
init.d scripts.

This fixes error `redis insserv: Script redis_6379 is broken: incomplete
LSB comment` recieved during installation proccess.