### PR TITLE
[add] added ReplyWithRESP to the experimental API

### DIFF
--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -387,6 +387,7 @@ int REDISMODULE_API_FUNC(RedisModule_CommandFilterArgDelete)(RedisModuleCommandF
 int REDISMODULE_API_FUNC(RedisModule_Fork)(RedisModuleForkDoneHandler cb, void *user_data);
 int REDISMODULE_API_FUNC(RedisModule_ExitFromChild)(int retcode);
 int REDISMODULE_API_FUNC(RedisModule_KillForkChild)(int child_pid);
+int REDISMODULE_API_FUNC(RedisModule_ReplyWithRESP)(RedisModuleCtx *ctx, char *prefix, const char *msg);
 #endif
 
 /* This is included inline inside each Redis module. */
@@ -573,6 +574,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(Fork);
     REDISMODULE_GET_API(ExitFromChild);
     REDISMODULE_GET_API(KillForkChild);
+    REDISMODULE_GET_API(ReplyWithRESP);
 #endif
 
     if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;


### PR DESCRIPTION
This PR exposes the module's internal method `replyWithStatus` to the user, altering its name to  `RedisModule_ReplyWithRESP`.

The purpose of it is to make it broader ( now it is only used for simple strings and errors ). With `RedisModule_ReplyWithRESP`, within a module, we will be able to test replying with different versions of RESP and the new types added on RESP 3. 
The change its is not a breaking one, it is a simple addition to the experimental modules API. 