### PR TITLE
Prevent possible integer overflow (hiredis)

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1000,6 +1000,18 @@ static int fetchClusterConfiguration() {
     clusterNode *firstNode = createClusterNode((char *) config.hostip,
                                                config.hostport);
     if (!firstNode) {success = 0; goto cleanup;}
+    if (config.auth) {
+        reply = redisCommand(ctx, "AUTH %s", config.auth);
+        if (reply && reply->type == REDIS_REPLY_ERROR) {
+            if (config.hostsocket == NULL) {
+                fprintf(stderr, "Cluster node %s:%d replied with error:\n%s\n",
+                        config.hostip, config.hostport, reply->str);
+            } else {
+                fprintf(stderr, "Cluster node %s replied with error:\n%s\n",
+                        config.hostsocket, reply->str);
+            }
+        }
+    };
     reply = redisCommand(ctx, "CLUSTER NODES");
     success = (reply != NULL);
     if (!success) goto cleanup;


### PR DESCRIPTION
Elements count in multi-bulk replies is read into a `long long` variable inside `processAggregateItem`.
In file deps/hiredis/read.c, line 423:

`long long elements;`

...

`string2ll(p, len, &elements)`

Anyway, later (line 482), its value is copied inside the `elements` member of a struct `redisReadTask`:

`cur->elements = elements;`

Since the `elements` member was declared as an `int`, an integer overflow could happen.

Declaring the element as `size_t` is safe since even if size_t was a 32bit, there's a check at line 442 that prevents writing values bigger than it can accept.

`        
       if (elements < -1 || (LLONG_MAX > SIZE_MAX && elements > SIZE_MAX)) {
            __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
                    "Multi-bulk length out of range");
            return REDIS_ERR;
        }
`
