### PR TITLE
Diskless replica: backup cluster slots_to_keys info for diskless-load

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -372,7 +372,7 @@ long long emptyDbGeneric(redisDb *dbarray, int dbnum, int flags, void(callback)(
             dictEmpty(dbarray[j].expires,callback);
         }
     }
-    if (server.cluster_enabled) {
+    if (server.cluster_enabled && dbarray == server.db) {
         if (async) {
             slotToKeyFlushAsync();
         } else {

--- a/src/db.c
+++ b/src/db.c
@@ -374,10 +374,13 @@ long long emptyDbGeneric(redisDb *dbarray, int dbnum, int flags, void(callback)(
     }
     if (server.cluster_enabled && dbarray == server.db) {
         if (async) {
-            slotToKeyFlushAsync();
+            slotToKeyFlushAsync(server.cluster->slots_to_keys);
         } else {
-            slotToKeyFlush();
+            slotToKeyFlush(server.cluster->slots_to_keys);
         }
+        server.cluster->slots_to_keys = raxNew();
+        memset(server.cluster->slots_keys_count,0,
+               sizeof(server.cluster->slots_keys_count));
     }
     if (dbnum == -1) flushSlaveKeysWithExpireList();
     return removed;
@@ -1540,11 +1543,8 @@ void slotToKeyDel(robj *key) {
     slotToKeyUpdateKey(key,0);
 }
 
-void slotToKeyFlush(void) {
-    raxFree(server.cluster->slots_to_keys);
-    server.cluster->slots_to_keys = raxNew();
-    memset(server.cluster->slots_keys_count,0,
-           sizeof(server.cluster->slots_keys_count));
+void slotToKeyFlush(rax *slots_to_keys) {
+    raxFree(slots_to_keys);
 }
 
 /* Pupulate the specified array of objects with keys in the specified slot.

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -114,14 +114,9 @@ void emptyDbAsync(redisDb *db) {
 
 /* Empty the slots-keys map of Redis CLuster by creating a new empty one
  * and scheduiling the old for lazy freeing. */
-void slotToKeyFlushAsync(void) {
-    rax *old = server.cluster->slots_to_keys;
-
-    server.cluster->slots_to_keys = raxNew();
-    memset(server.cluster->slots_keys_count,0,
-           sizeof(server.cluster->slots_keys_count));
-    atomicIncr(lazyfree_objects,old->numele);
-    bioCreateBackgroundJob(BIO_LAZY_FREE,NULL,NULL,old);
+void slotToKeyFlushAsync(rax *slots_to_keys) {
+    atomicIncr(lazyfree_objects,slots_to_keys->numele);
+    bioCreateBackgroundJob(BIO_LAZY_FREE,NULL,NULL,slots_to_keys);
 }
 
 /* Release objects from the lazyfree thread. It's just decrRefCount()

--- a/src/server.h
+++ b/src/server.h
@@ -2063,10 +2063,10 @@ void scanGenericCommand(client *c, robj *o, unsigned long cursor);
 int parseScanCursorOrReply(client *c, robj *o, unsigned long *cursor);
 void slotToKeyAdd(robj *key);
 void slotToKeyDel(robj *key);
-void slotToKeyFlush(void);
+void slotToKeyFlush(rax *slots_to_keys);
 int dbAsyncDelete(redisDb *db, robj *key);
 void emptyDbAsync(redisDb *db);
-void slotToKeyFlushAsync(void);
+void slotToKeyFlushAsync(rax *slots_to_keys);
 size_t lazyfreeGetPendingObjectsCount(void);
 void freeObjAsync(robj *o);
 


### PR DESCRIPTION
Hi @antirez and @oranagra , recently I read about the `diskless-load` feature, it's interesting and can help us to save the full-sync time. But there is a little problem about cluster, we forgot the `slots_to_keys` info I think. And that can lead to some wrong result like `CLUSTER COUNTKEYSINSLOT` and `CLUSTER GETKEYSINSLOT` command. Here is a way to fix it, please check.