### PR TITLE
Update to directive in redis.conf (missing s)

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -197,7 +197,7 @@ tcp-keepalive 300
 # When choosing a cipher, use the server's preference instead of the client
 # preference. By default, the server follows the client's preference.
 #
-# tls-prefer-server-cipher yes
+# tls-prefer-server-ciphers yes
 
 ################################# GENERAL #####################################
 


### PR DESCRIPTION
@yossigo @antirez - minor update to the redis.conf file to call the directive tls-prefer-server-ciphers. (It is missing the "s" at the end of ciphers.

The directive tls-prefer-server-cipher is actually tls-prefer-server-ciphers in config.c. This results in a failed directive call shown below. This pull request adds the "s" in ciphers so that the directive is able to be properly called in config.c

ubuntu@ip-172-31-16-31:~/redis$ src/redis-server ./redis.conf 

*** FATAL CONFIG FILE ERROR ***
Reading the configuration file, at line 200
>>> 'tls-prefer-server-cipher yes'
Bad directive or wrong number of arguments