### PR TITLE
Show failing or failed nodes as 'disconnected' in 'CLUSTER NODES'

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -614,14 +614,15 @@ void clusterReset(int hard) {
  * CLUSTER communication link
  * -------------------------------------------------------------------------- */
 
-clusterLink *createClusterLink(clusterNode *node) {
+clusterLink *createClusterLink(clusterNode *node, connection *conn) {
+    serverAssert(conn);
     clusterLink *link = zmalloc(sizeof(*link));
     link->ctime = mstime();
     link->sndbuf = sdsempty();
     link->rcvbuf = zmalloc(link->rcvbuf_alloc = RCVBUF_INIT_LEN);
     link->rcvbuf_len = 0;
     link->node = node;
-    link->conn = NULL;
+    link->conn = conn;
     return link;
 }
 
@@ -629,10 +630,10 @@ clusterLink *createClusterLink(clusterNode *node) {
  * This function will just make sure that the original node associated
  * with this link will have the 'link' field set to NULL. */
 void freeClusterLink(clusterLink *link) {
-    if (link->conn) {
-        connClose(link->conn);
-        link->conn = NULL;
-    }
+    serverAssert(link->conn);
+    connClose(link->conn);
+    link->conn = NULL;
+
     sdsfree(link->sndbuf);
     zfree(link->rcvbuf);
     if (link->node)
@@ -655,8 +656,7 @@ static void clusterConnAcceptHandler(connection *conn) {
      * Initially the link->node pointer is set to NULL as we don't know
      * which node is, but the right node is references once we know the
      * node identity. */
-    link = createClusterLink(NULL);
-    link->conn = conn;
+    link = createClusterLink(NULL, conn);
     connSetPrivateData(conn, link);
 
     /* Register read handler */
@@ -3545,8 +3545,8 @@ void clusterCron(void) {
         }
 
         if (node->link == NULL) {
-            clusterLink *link = createClusterLink(node);
-            link->conn = server.tls_cluster ? connCreateTLS() : connCreateSocket();
+            connection *conn = server.tls_cluster ? connCreateTLS() : connCreateSocket();
+            clusterLink *link = createClusterLink(node, conn);
             connSetPrivateData(link->conn, link);
             if (connConnect(link->conn, node->ip, node->cport, NET_FIRST_BIND_ADDR,
                         clusterLinkConnectHandler) == -1) {
@@ -4169,7 +4169,8 @@ sds clusterGenNodeDescription(clusterNode *node) {
         (long long) node->ping_sent,
         (long long) node->pong_received,
         nodeEpoch,
-        (node->link || node->flags & CLUSTER_NODE_MYSELF) ?
+        ((node->link && connGetState(node->link->conn) == CONN_STATE_CONNECTED) ||
+         node->flags & CLUSTER_NODE_MYSELF) ?
                     "connected" : "disconnected");
 
     /* Slots served by this instance */


### PR DESCRIPTION
#### Summary

`CLUSTER NODES` output shows a permanently disconnected node as still `connected` because the criteria it uses for determining link status is incomplete. Redis relies on connection timeouts to infer node failures. So it's actually inconsistent to display a `fail?` or `fail` nodes with a `connected` link-status in `CLUSTER NODES`.

#### Reproducing the issue
1. Setup a 2-shards Redis cluster of 3 nodes - 6379, 6380, 6381, with 6379 and 6381 being the two masters, and 6380 being a replica of 6379.     
2. Use gdb to stop the world of replica 6380. Its disconnection will be detected by both masters thus marked as `FAIL` on the cluster bus.
3. Use gdb to stop the world of master 6381. Its disconnection will be detected by the only remaining master thus marked as `PFAIL` on the cluster bus.
4. `CLUSTER NODES` on 6379 will keep showing both disconnected nodes as `connected` indefinitely, even if they are lost forever.
```text
127.0.0.1:6379> cluster nodes
01288731f8cddffee4ec21a561ed13e7f0062247 10.184.175.155:6379@16379 myself,master - 0 1570909171000 1 connected
408830c623566a9e959e47b139f4356606766190 10.184.175.155:6381@16381 master,fail? - 1570909177125 1570909176123 2 connected
4905e35bcdd1082182a3e3dec190367919bd955e 10.184.175.155:6380@16380 slave,fail 01288731f8cddffee4ec21a561ed13e7f0062247 1570909148039 1570909146081 1 connected
```       

#### Root cause analysis         
Currently, the only condition Redis uses to decide if a node is shown as `connected` or `disconnected` is whether or not the node has a non-nil outgoing link: https://github.com/antirez/redis/blob/unstable/src/cluster.c#L4017

However, Redis makes sure that every known node would always have a non-nil outgoing link: https://github.com/antirez/redis/blob/unstable/src/cluster.c#L3406. Even though Redis also frees timed-out links from time to time: https://github.com/antirez/redis/blob/unstable/src/cluster.c#L3514,  any freed link would be immediately re-established in the very next `clusterCron` run, making it practically impossible to reliably observe any known node without a link. Therefore, even effectively disconnected, nodes will always show up as `connected`.

#### Solution

In Redis cluster, any node that can't be reached by the local node for more than a predefined duration would be marked as either `PFAIL` or `FAIL` on the local node. This is exactly the definition of `disconnected`. Therefore, I think it's best to leverage these flags to fix the issue -  a node is only shown as `connected` if it has a non-nil outgoing link and not marked as `FAIL` or `PFAIL`.

Under the same setup as aforementioned, `CLUSTER NODES` output after the fix:         
```text
127.0.0.1:6379> cluster nodes
afd24bfbfc19314bc18772400117c2e661f906a5 10.184.175.155:6381@16381 master,fail? - 1570906841238 1570906840237 0 disconnected
a1f8441542351443aa7b1c17809150fae9487f1d 10.184.175.155:6379@16379 myself,master - 0 1570906839000 2 connected
067c4ab8fd2a7aedd58742a3b3140bc5cf1ef49e 10.184.175.155:6380@16380 slave,fail a1f8441542351443aa7b1c17809150fae9487f1d 1570906783079 1570906781073 2 disconnected
```       

Thanks,
Nan Yan
Amazon