### PR TITLE
optimize the sdssplitlen function

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -832,17 +832,17 @@ sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *c
         return tokens;
     }
     for (j = 0; j < (len-(seplen-1)); j++) {
-        /* make sure there is room for the next element and the final one */
-        if (slots < elements+2) {
-            sds *newtokens;
-
-            slots *= 2;
-            newtokens = s_realloc(tokens,sizeof(sds)*slots);
-            if (newtokens == NULL) goto cleanup;
-            tokens = newtokens;
-        }
         /* search the separator */
         if ((seplen == 1 && *(s+j) == sep[0]) || (memcmp(s+j,sep,seplen) == 0)) {
+            /* make sure there is room for the next element and the final one */
+            if (slots < elements+2) {
+                sds *newtokens;
+
+                slots *= 2;
+                newtokens = s_realloc(tokens,sizeof(sds)*slots);
+                if (newtokens == NULL) goto cleanup;
+                tokens = newtokens;
+            }
             tokens[elements] = sdsnewlen(s+start,j-start);
             if (tokens[elements] == NULL) goto cleanup;
             elements++;


### PR DESCRIPTION
I think that checking whether the slots is enough should be done after the separator found, since if the separator is not found, it's possible that the slots is already enough, and it's not needed to allocate more memory for the tokens.
I've found that these codes which I'm trying to modify were existed since the 0.07 version (10 years ago, the first commit), so I'm not sure whether I'm right. And I did an experiment:
1. cp sds.h sds.c in my workspace.
2. create file "traced_malloc.h" with the following codes:
<pre>void *traced_malloc(size_t size) {
  void *p = malloc(size);
  printf("%016X = %s(%llu)\n", p, __FUNCTION__, size);
  return p;
}

void *traced_realloc(void *ptr, size_t size) {
  void *p = realloc(ptr, size);
  printf("%016X = %s(%016X, %llu)\n", p, __FUNCTION__, ptr, size);
  return p;
}

void traced_free(void *ptr) {
  printf("%s(%016X)\n", __FUNCTION__, ptr);
  free(ptr);
}</pre>
3. create file "sdsalloc.h" with the following codes:
<pre>#include "traced_malloc.h"
#define s_malloc traced_malloc
#define s_realloc traced_realloc
#define s_free traced_free</pre>
4. create file "main.c" with the following codes:
<pre>#include "sds.h"

int main () {
  const char *s = "a,b,c,d,e";
  const char *sep = ",";
  sds *elements;
  int count;
  int i;

  printf("===============\n");
  printf("s = \"%s\", sep = \"%s\"\n", s, sep);
  elements = sdssplitlen(s, strlen(s), sep, strlen(sep), &count);
  printf("elements(count = %d):\n", count);
  for (i = 0; i < count; i++) {
    printf("%s\n", elements[i]);
  }
  sdsfreesplitres(elements, count);
  printf("---------------\n");
  return 0;
}</pre>
5. run shell command: gcc -O2 main.c sds.c && (./a.out ; rm a.out)
And the result is:
<pre>===============
s = "a,b,c,d,e", sep = ","
00000000024CF010 = traced_malloc(40)
00000000024CF040 = traced_malloc(3)
00000000024CF060 = traced_malloc(3)
00000000024CF080 = traced_malloc(3)
00000000024CF0A0 = traced_malloc(3)
00000000024CF0C0 = traced_realloc(00000000024CF010, 80)
00000000024CF120 = traced_malloc(3)
elements(count = 5):
a
b
c
d
e
traced_free(00000000024CF120)
traced_free(00000000024CF0A0)
traced_free(00000000024CF080)
traced_free(00000000024CF060)
traced_free(00000000024CF040)
traced_free(00000000024CF0C0)
---------------</pre>
It calls a s_realloc to set the memory used by tokens up to 80B( 10 * sizeof(sds) ), while it should only need 40B( 5 * sizeof(sds) ).
6. fix the file "sds.c" with my new code.
7. run shell command again: gcc -O2 main.c sds.c && (./a.out ; rm a.out)
And the result is:
<pre>===============
s = "a,b,c,d,e", sep = ","
0000000001AB9010 = traced_malloc(40)
0000000001AB9040 = traced_malloc(3)
0000000001AB9060 = traced_malloc(3)
0000000001AB9080 = traced_malloc(3)
0000000001AB90A0 = traced_malloc(3)
0000000001AB90C0 = traced_malloc(3)
elements(count = 5):
a
b
c
d
e
traced_free(0000000001AB90C0)
traced_free(0000000001AB90A0)
traced_free(0000000001AB9080)
traced_free(0000000001AB9060)
traced_free(0000000001AB9040)
traced_free(0000000001AB9010)
---------------</pre>
There's no s_realloc called, and the memory used by tokens is 40B ( 5 * sizeof(sds) ). It seems worked.

So, I create the pull request. Look forward to your reply. Thanks.