### PR TITLE
Fix OpenBSD building by adding sys/socket.h to connection.c

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -30,6 +30,8 @@
 #include "server.h"
 #include "connhelpers.h"
 
+#include <sys/socket.h>
+
 /* The connections module provides a lean abstraction of network connections
  * to avoid direct socket and async event management across the Redis code base.
  *


### PR DESCRIPTION
Fixes
```
connection.c:344:30: error: use of undeclared identifier 'SOL_SOCKET'
    if (getsockopt(conn->fd, SOL_SOCKET, SO_ERROR, &sockerr, &errlen) == -1)
```

Hopefully this isn't a duplicate.  I did attempt to find one.