### PR TITLE
Adds latency sample as "aof-write" for "aof-fsync-always"

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -503,6 +503,7 @@ try_fsync:
         redis_fsync(server.aof_fd); /* Let's try to get this data on the disk */
         latencyEndMonitor(latency);
         latencyAddSampleIfNeeded("aof-fsync-always",latency);
+        latencyAddSampleIfNeeded("aof-write",latency);
         server.aof_fsync_offset = server.aof_current_size;
         server.aof_last_fsync = server.unixtime;
     } else if ((server.aof_fsync == AOF_FSYNC_EVERYSEC &&


### PR DESCRIPTION
Based on the same logic described in the comment in flushAppendOnlyFile:

>  We also use an additional event name to save all samples which is useful for graphing / monitoring purposes.