### PR TITLE
Add config and module API for AvoidReplicaTraffic

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1880,6 +1880,14 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
     return flags;
 }
 
+/* Returns true when the module should avoid actions that cause traffic to replicas.
+ * This is required during manual failover when waiting for the replica
+ * to be in perfect sync with the master. Modules doing background operations
+ * which are not a result of user traffic should check this flag periodically. */
+int RM_AvoidReplicaTraffic() {
+    return clientsArePaused();
+}
+
 /* Change the currently selected DB. Returns an error if the id
  * is out of range.
  *
@@ -7392,6 +7400,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(KeyAtPos);
     REGISTER_API(GetClientId);
     REGISTER_API(GetContextFlags);
+    REGISTER_API(AvoidReplicaTraffic);
     REGISTER_API(PoolAlloc);
     REGISTER_API(CreateDataType);
     REGISTER_API(ModuleTypeSetValue);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -522,6 +522,7 @@ unsigned long long REDISMODULE_API_FUNC(RedisModule_GetClientId)(RedisModuleCtx 
 int REDISMODULE_API_FUNC(RedisModule_GetClientInfoById)(void *ci, uint64_t id);
 int REDISMODULE_API_FUNC(RedisModule_PublishMessage)(RedisModuleCtx *ctx, RedisModuleString *channel, RedisModuleString *message);
 int REDISMODULE_API_FUNC(RedisModule_GetContextFlags)(RedisModuleCtx *ctx);
+int REDISMODULE_API_FUNC(RedisModule_AvoidReplicaTraffic)();
 void *REDISMODULE_API_FUNC(RedisModule_PoolAlloc)(RedisModuleCtx *ctx, size_t bytes);
 RedisModuleType *REDISMODULE_API_FUNC(RedisModule_CreateDataType)(RedisModuleCtx *ctx, const char *name, int encver, RedisModuleTypeMethods *typemethods);
 int REDISMODULE_API_FUNC(RedisModule_ModuleTypeSetValue)(RedisModuleKey *key, RedisModuleType *mt, void *value);
@@ -753,6 +754,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(KeyAtPos);
     REDISMODULE_GET_API(GetClientId);
     REDISMODULE_GET_API(GetContextFlags);
+    REDISMODULE_GET_API(AvoidReplicaTraffic);
     REDISMODULE_GET_API(PoolAlloc);
     REDISMODULE_GET_API(CreateDataType);
     REDISMODULE_GET_API(ModuleTypeSetValue);


### PR DESCRIPTION
This is useful to tell redis and modules to try to avoid doing things that may
increment the replication offset, and should be used when draining a master
and waiting for replicas to be in perfect sync before a failover.