### PR TITLE
[Trivial] remove compile warning for renderCanvas

### DIFF
--- a/src/lolwut6.c
+++ b/src/lolwut6.c
@@ -59,6 +59,7 @@ static sds renderCanvas(lwCanvas *canvas) {
             case 1: ce = "0;90;100m"; break;   /* Gray 1 */
             case 2: ce = "0;37;47m"; break;    /* Gray 2 */
             case 3: ce = "0;97;107m"; break;   /* White */
+            default: ce = "0;30;40m"; break;   /* Black as default */
             }
             text = sdscatprintf(text,"\033[%s \033[0m",ce);
         }


### PR DESCRIPTION
To remove compile warning for lolwut6.c
just adding default value as 0.
I found lwGetPixel returns 0, when x,y is outside of valid position.