### PR TITLE
Add no-slowlog to acl command to prevent passwords

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -999,7 +999,7 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,0,0,0,0,0,0},
 
     {"acl",aclCommand,-2,
-     "admin no-script ok-loading ok-stale",
+     "admin no-script no-slowlog ok-loading ok-stale",
      0,NULL,0,0,0,0,0,0}
 };
 


### PR DESCRIPTION
Adding no-slowlog to acl command to prevent acl passwords from showing in slowlog to close #6515

@antirez @itamarhaber  - let me know if you agree w/ this. 