### PR TITLE
Fail on start when invalid maxmemory value is set in config file.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -384,8 +384,9 @@ void loadServerConfigFromString(char *config) {
                 err = "Invalid max clients limit"; goto loaderr;
             }
         } else if (!strcasecmp(argv[0],"maxmemory") && argc == 2) {
-            server.maxmemory = memtoll(argv[1],NULL);
-            if (server.maxmemory == 0) {
+            int maxmemory_err = 0;
+            server.maxmemory = memtoll(argv[1],&maxmemory_err);
+            if (maxmemory_err) {
                 err = "Invalid maxmemory value";
                 goto loaderr;
             }

--- a/src/config.c
+++ b/src/config.c
@@ -385,6 +385,10 @@ void loadServerConfigFromString(char *config) {
             }
         } else if (!strcasecmp(argv[0],"maxmemory") && argc == 2) {
             server.maxmemory = memtoll(argv[1],NULL);
+            if (server.maxmemory == 0) {
+                err = "Invalid maxmemory value";
+                goto loaderr;
+            }
         } else if (!strcasecmp(argv[0],"maxmemory-policy") && argc == 2) {
             server.maxmemory_policy =
                 configEnumGetValue(maxmemory_policy_enum,argv[1]);


### PR DESCRIPTION
Hello!

If invalid value is present for maxmemory option in config file, it is silently ignored and maxmemory is set to  `0` (infinite). Anyway invalid value can't be set via `CONFIG SET` command.

We had some issues with oom killed redis thanks to this since our config was generated by script and by mistake it was using decimal number for maxmemory value. Instead of warning or fail on start we got actually started redis with infinite memory limit and it got killed later by oom.

I have not found any tests for similar `check and fail` so I have not added test for this. Feel free to point me to some place where this test should be added if it is needed.