### PR TITLE
Update Redis.conf to include ability to use hashes

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -687,6 +687,10 @@ replica-priority 100
 #               For example >mypass will add "mypass" to the list.
 #               This directive clears the "nopass" flag (see later).
 #  <<password>  Remove this password from the list of valid passwords.
+#  #<hash>      Add a SHA256 hash of the password for the acl user.
+#               This is useful when you do not want to save a cleartext
+#               password in your redis.conf file.
+#  !<hash>      Remove this SHA256 hash from the list of valid passwords.
 #  nopass       All the set passwords of the user are removed, and the user
 #               is flagged as requiring no password: it means that every
 #               password will work against this user. If this directive is


### PR DESCRIPTION
Adding the ability to hash passwords stored in the Redis.conf file to the documentation.

I think this will be useful to clarify functionality for security-conscious users.