### PR TITLE
expires: refactoring judgment about whether a key is expired

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1207,7 +1207,7 @@ int keyIsExpired(redisDb *db, robj *key) {
      * only the first time it is accessed and not in the middle of the
      * script execution, making propagation to slaves / AOF consistent.
      * See issue #1525 on Github for more information. */
-    mstime_t now = server.lua_caller ? server.lua_time_start : mstime();
+    mstime_t now = server.lua_caller ? server.lua_time_start : server.cmd_start_mstime;
 
     return now > when;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -3602,6 +3602,7 @@ int processCommand(client *c) {
         queueMultiCommand(c);
         addReply(c,shared.queued);
     } else {
+        server.cmd_start_mstime = mstime();
         call(c,CMD_CALL_FULL);
         c->woff = server.master_repl_offset;
         if (listLength(server.ready_keys))

--- a/src/server.h
+++ b/src/server.h
@@ -1401,6 +1401,7 @@ struct redisServer {
     time_t timezone;            /* Cached timezone. As set by tzset(). */
     int daylight_active;        /* Currently in daylight saving time. */
     long long mstime;           /* 'unixtime' with milliseconds resolution. */
+    mstime_t cmd_start_mstime;
     /* Pubsub */
     dict *pubsub_channels;  /* Map channels to list of subscribed clients */
     list *pubsub_patterns;  /* A list of pubsub_patterns */


### PR DESCRIPTION
Recently I met a case can lead to redis crash. In detail, it's about expire time and multi keys command on same key.

For example, `RPOPLPUSH` can pop from list A and push to list B, even A and B is the same list, like `RPOPLPUSH xxx xxx` and here is the problem. If the list is with expire time, `RPOPLPUSH` may access freed memory.

Say list `xxx` with expire time `E`.

1. Get the source object from `xxx` and hold it in `sobj` before time `E`.
```c
void rpoplpushCommand(client *c) {
    robj *sobj, *value;
    if ((sobj = lookupKeyWriteOrReply(c,c->argv[1],shared.null[c->resp]))
        == NULL || checkType(c,sobj,OBJ_LIST)) return;
```

2. Get the dest object from `xxx` after time `E`.
```c
        robj *dobj = lookupKeyWrite(c->db,c->argv[2]);
        robj *touchedkey = c->argv[1];
```

   Now list `xxx` reach the expire time and has been deleted.

3. Pop value from `sobj`, but it's already freed, redis crashed.
```c
        value = listTypePop(sobj,LIST_TAIL);
```

The root cause I think is `expireIfNeeded()` function in different `lookupKey*()` use different time even in one command. So to fix it I introduce a new arg `server. cmd_start_mstime` means the start time of a command just like `lua_time_start`.

Notice:

1. All commands in transaction just use the `exec`'s start time, and it's reasonable I think.
2. Not sure the effects about modules.