### PR TITLE
Modules: Keyspace notifications with native types API

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -22,4 +22,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/hooks \
 --single unit/moduleapi/misc \
 --single unit/moduleapi/blockonkeys \
+--single unit/moduleapi/nativenotify \
 "${@}"

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -174,6 +174,9 @@ typedef uint64_t RedisModuleTimerID;
  * RedisModule_CloseKey, and the module needs to do that when manually when keys
  * are modified from the user's sperspective, to invalidate WATCH. */
 #define REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED (1<<1)
+/* When set Redis will notify all default keyspace events when using the native
+ * type API functions (e.g. RM_HashSet will notify "hset"). */
+#define REDISMODULE_OPTION_NOTIFY_NATIVE_KEYSPACE_EVENTS (1<<2)
 
 /* Server events definitions. */
 #define REDISMODULE_EVENT_REPLICATION_ROLE_CHANGED 0

--- a/src/server.h
+++ b/src/server.h
@@ -1910,7 +1910,7 @@ void addReplyCommandCategories(client *c, struct redisCommand *cmd);
 
 /* Output flags. */
 #define ZADD_NOP (1<<3)     /* Operation not performed because of conditionals.*/
-#define ZADD_NAN (1<<4)     /* Only touch elements already existing. */
+#define ZADD_NAN (1<<4)     /* The resulting score is not a number. */
 #define ZADD_ADDED (1<<5)   /* The element was new and was added. */
 #define ZADD_UPDATED (1<<6) /* The element already existed, score updated. */
 

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -19,7 +19,8 @@ TEST_MODULES = \
     propagate.so \
     misc.so \
     hooks.so \
-    blockonkeys.so
+    blockonkeys.so \
+	nativenotify.so
 
 .PHONY: all
 

--- a/tests/modules/nativenotify.c
+++ b/tests/modules/nativenotify.c
@@ -1,0 +1,236 @@
+#define REDISMODULE_EXPERIMENTAL_API
+#include "redismodule.h"
+
+#include <string.h>
+#include <assert.h>
+#include <unistd.h>
+
+int notify_callback(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
+    const char *ckey = RedisModule_StringPtrLen(key, NULL);
+    if (strcmp(ckey, "notifications") == 0) {
+        /* Prevent recursion. */
+        return REDISMODULE_OK;
+    }
+    RedisModule_Log(ctx, "notice", "Got event type %d, event %s, key %s", type, event);
+    RedisModule_Call(ctx, "HINCRBY", "ccc", "notifications", event, "1");
+    return REDISMODULE_OK;
+}
+
+/* NN.SET <key> <value> - Wrapper of native string API */
+int nn_set(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 3)
+        return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+    RedisModule_StringSet(key, argv[2]);
+
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/* NN.TRUNCATE <key> <length> - Wrapper of native string API */
+int nn_truncate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 3)
+        return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_STRING && type != REDISMODULE_KEYTYPE_EMPTY)
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+
+    long long length;
+    if (RedisModule_StringToLongLong(argv[2], &length) == REDISMODULE_ERR)
+        return RedisModule_ReplyWithError(ctx, "Invalid length");
+
+    RedisModule_StringTruncate(key, length);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/* NN.RPUSH <key> <ele> - Wrapper of native list API */
+int nn_rpush(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 3)
+        return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_LIST && type != REDISMODULE_KEYTYPE_EMPTY)
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+
+    RedisModule_ListPush(key, REDISMODULE_LIST_TAIL, argv[2]);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/* NN.LPUSH <key> <ele> - Wrapper of native list API */
+int nn_lpush(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 3)
+        return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_LIST && type != REDISMODULE_KEYTYPE_EMPTY)
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+
+    RedisModule_ListPush(key, REDISMODULE_LIST_HEAD, argv[2]);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/* NN.RPOP <key> - Wrapper of native list API */
+int nn_rpop(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 2)
+        return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_LIST && type != REDISMODULE_KEYTYPE_EMPTY)
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+
+    RedisModule_ListPop(key, REDISMODULE_LIST_TAIL);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/* NN.LPOP <key> - Wrapper of native list API */
+int nn_lpop(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 2)
+        return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_LIST && type != REDISMODULE_KEYTYPE_EMPTY)
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+
+    RedisModule_ListPop(key, REDISMODULE_LIST_HEAD);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/* NN.ZADD <key> <score> <ele> - Wrapper of native zset API */
+int nn_zadd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 4)
+        return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_ZSET && type != REDISMODULE_KEYTYPE_EMPTY)
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+
+    double score;
+    if (RedisModule_StringToDouble(argv[2], &score) == REDISMODULE_ERR)
+        return RedisModule_ReplyWithError(ctx, "Invalid score");
+
+    RedisModule_ZsetAdd(key, score, argv[3], NULL);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/* NN.ZINCRBY <key> <score> <ele> - Wrapper of native zset API */
+int nn_zincrby(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 4)
+        return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_ZSET && type != REDISMODULE_KEYTYPE_EMPTY)
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+
+    double score;
+    if (RedisModule_StringToDouble(argv[2], &score) == REDISMODULE_ERR)
+        return RedisModule_ReplyWithError(ctx, "Invalid score");
+
+    RedisModule_ZsetIncrby(key, score, argv[3], NULL, NULL);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/* NN.ZREM <key> <ele> - Wrapper of native zset API */
+int nn_zrem(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 3)
+        return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_ZSET && type != REDISMODULE_KEYTYPE_EMPTY)
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+
+    RedisModule_ZsetRem(key, argv[2], NULL);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/* NN.HSET <key> <field> <value> - Wrapper of native zset API */
+int nn_hset(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 4)
+        return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_HASH && type != REDISMODULE_KEYTYPE_EMPTY)
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+
+    RedisModule_HashSet(key, REDISMODULE_HASH_NONE, argv[2], argv[3], NULL);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/* NN.HDEL <key> <field> - Wrapper of native zset API */
+int nn_hdel(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 3)
+        return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_HASH && type != REDISMODULE_KEYTYPE_EMPTY)
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+
+    RedisModule_HashSet(key, REDISMODULE_HASH_NONE, argv[2], REDISMODULE_HASH_DELETE, NULL);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx, "nn", 1, REDISMODULE_APIVER_1)== REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"nn.set",nn_set,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"nn.truncate",nn_truncate,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"nn.rpush",nn_rpush,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"nn.lpush",nn_lpush,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"nn.rpop",nn_rpop,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"nn.lpop",nn_lpop,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"nn.zadd",nn_zadd,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"nn.zincrby",nn_zincrby,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"nn.zrem",nn_zrem,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"nn.hset",nn_hset,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"nn.hdel",nn_hdel,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    RedisModule_SetModuleOptions(ctx, REDISMODULE_OPTION_NOTIFY_NATIVE_KEYSPACE_EVENTS);
+
+    RedisModule_SubscribeToKeyspaceEvents(ctx, REDISMODULE_NOTIFY_ALL, notify_callback);
+    return REDISMODULE_OK;
+}

--- a/tests/unit/moduleapi/nativenotify.tcl
+++ b/tests/unit/moduleapi/nativenotify.tcl
@@ -1,0 +1,128 @@
+set testmodule [file normalize tests/modules/nativenotify.so]
+
+start_server {tags {"modules"}} {
+    r module load $testmodule
+
+    test {Module API native notifications: SET} {
+        r nn.set k a
+        r nn.set k b
+        r nn.set k c
+        assert_equal [r hget notifications set] 3
+        r del k notifications
+    }
+
+    test {Module API native notifications: TRUNCATE} {
+        r nn.set k abcdefg
+        r nn.truncate k 10
+        r nn.truncate k 5
+        # Same length, no notification
+        r nn.truncate k 5
+        # New key
+        r nn.truncate k2 7
+        assert_equal [r hget notifications set] 4
+        r del k k2 notifications
+    }
+
+    test {Module API native notifications: List PUSH} {
+        r nn.rpush k a
+        r nn.lpush k a
+        assert_equal [r hget notifications rpush] 1
+        assert_equal [r hget notifications lpush] 1
+        r nn.rpush k b
+        r nn.lpush k b
+        r nn.rpush k c
+        r nn.lpush k c
+        assert_equal [r hget notifications rpush] 3
+        assert_equal [r hget notifications lpush] 3
+        r del k notifications
+    }
+
+    test {Module API native notifications: List POP} {
+        r nn.lpush k a
+        r nn.lpush k b
+        r nn.lpush k c
+        assert_equal [r hget notifications lpush] 3
+        r nn.lpop k
+        r nn.rpop k
+        assert_equal [r hget notifications lpop] 1
+        assert_equal [r hget notifications rpop] 1
+        assert_equal [r hget notifications del] ""
+        r nn.lpop k
+        assert_equal [r hget notifications lpop] 2
+        assert_equal [r hget notifications del] 1
+        r nn.lpop k
+        assert_equal [r hget notifications lpop] 2
+        assert_equal [r hget notifications del] 1
+        r del k notifications
+    }
+
+    test {Module API native notifications: ZADD} {
+        r nn.zadd k 10 a
+        r nn.zadd k 10 b
+        r nn.zadd k 10 c
+        # Same element, no notification
+        r nn.zadd k 10 c
+        assert_equal [r hget notifications zadd] 3
+        r del k notifications
+    }
+
+    test {Module API native notifications: ZINCRBY} {
+        r nn.zincrby k 10 a
+        r nn.zincrby k 10 b
+        r nn.zincrby k 10 c
+        # Same elemant, should be a notification
+        r nn.zincrby k 10 c
+        assert_equal [r hget notifications zincr] 4
+        r del k notifications
+    }
+
+    test {Module API native notifications: ZREM} {
+        r nn.zadd k 10 a
+        r nn.zadd k 10 b
+        r nn.zadd k 10 c
+        assert_equal [r hget notifications zadd] 3
+        r nn.zrem k a
+        r nn.zrem k b
+        assert_equal [r hget notifications zrem] 2
+        # Empty key
+        r nn.zrem k2 whatever
+        # Non existent element
+        r nn.zrem k whatever
+        # Last element
+        r nn.zrem k c
+        assert_equal [r hget notifications zrem] 3
+        assert_equal [r hget notifications del] 1
+        r del k notifications
+    }
+
+    test {Module API native notifications: HSET} {
+        r nn.hset k f1 a
+        r nn.hset k f2 b
+        r nn.hset k f3 c
+        # Same elemant, should be a notification
+        r nn.hset k f3 c
+        assert_equal [r hget notifications hset] 4
+        r del k notifications
+    }
+
+    test {Module API native notifications: HDEL} {
+        r nn.hset k f1 a
+        r nn.hset k f2 b
+        r nn.hset k f3 c
+        # Same elemant, should be a notification
+        r nn.hset k f3 c
+        assert_equal [r hget notifications hset] 4
+        r nn.hdel k f1
+        r nn.hdel k f2
+        assert_equal [r hget notifications hdel] 2
+        # Empty key
+        r nn.hdel k2 whatever
+        # Non existent element
+        r nn.hdel k whatever
+        # Last element
+        r nn.hdel k f3
+        assert_equal [r hget notifications hdel] 3
+        assert_equal [r hget notifications del] 1
+        r del k notifications
+    }
+}


### PR DESCRIPTION
Fixes GitHub issue #6544

Other unrelated changes:
1. Update comment of ZADD_NAN
2. Remove dead code in RM_ZsetIncrby: If zsetAdd indeed signals
   ZADD_NAN, it returns 0 (early exit)
3. Bugfix: When RM_ZsetRem deletes the last element it should
   call moduleDelKeyIfEmpty