### PR TITLE
expires & blocking: handle ready keys as call()

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -514,6 +514,9 @@ void handleClientsBlockedOnKeys(void) {
              * we can safely call signalKeyAsReady() against this key. */
             dictDelete(rl->db->ready_keys,rl->key);
 
+            server.call_depth++;
+            updateCachedTime(0);
+
             /* Serve clients blocked on list key. */
             robj *o = lookupKeyWrite(rl->db,rl->key);
 
@@ -529,6 +532,8 @@ void handleClientsBlockedOnKeys(void) {
                  * module is trying to accomplish right now. */
                 serveClientsBlockedOnKeyByModule(rl);
             }
+
+            server.call_depth++;
 
             /* Free this item. */
             decrRefCount(rl->key);


### PR DESCRIPTION
Expand for #6537 , the same problem also happens in `handleClientsBlockedOnKeys()`, here are the codes:

1. When a key is signaled as ready and handle it, at first we lookup the key and hold the pointer.
```c
void handleClientsBlockedOnKeys(void) {
    while(listLength(server.ready_keys) != 0) {
        list *l;
        l = server.ready_keys;
        server.ready_keys = listCreate();

        while(listLength(l) != 0) {
            listNode *ln = listFirst(l);
            readyList *rl = ln->value;
...
            robj *o = lookupKeyWrite(rl->db,rl->key);
```

2. If the object is a list, we step into `serveClientsBlockedOnListKey`
```c
            if (o != NULL) {
                if (o->type == OBJ_LIST)
                    serveClientsBlockedOnListKey(o,rl);
``` 

3. And then we step into `serveClientBlockedOnList`
```c
int serveClientBlockedOnList(client *receiver, robj *key, robj *dstkey, redisDb *db, robj *value, int where)
{
    if (dstkey == NULL) {
...
    } else {
        /* BRPOPLPUSH */
        robj *dstobj =
            lookupKeyWrite(receiver->db,dstkey);
```

4. Now the list maybe expired and deleted if src and dest are same, then go back to `serveClientsBlockedOnListKey` and process the reset thing, but object o is already freed, and we access the freed memory then crash.
```c
    if (listTypeLength(o) == 0) {
        dbDelete(rl->db,rl->key);
        notifyKeyspaceEvent(NOTIFY_GENERIC,"del",rl->key,rl->db->id);
    }
```

To fix it, I think we can ready keys just like `call()` function.