### PR TITLE
fix leak in module api rdb test

### DIFF
--- a/tests/modules/testrdb.c
+++ b/tests/modules/testrdb.c
@@ -18,8 +18,11 @@ void *testrdb_type_load(RedisModuleIO *rdb, int encver) {
     RedisModuleString *str = RedisModule_LoadString(rdb);
     float f = RedisModule_LoadFloat(rdb);
     long double ld = RedisModule_LoadLongDouble(rdb);
-    if (RedisModule_IsIOError(rdb))
+    if (RedisModule_IsIOError(rdb)) {
+        RedisModuleCtx *ctx = RedisModule_GetContextFromIO(rdb);
+        RedisModule_FreeString(ctx, str);
         return NULL;
+    }
     /* Using the values only after checking for io errors. */
     assert(count==1);
     assert(encver==1);


### PR DESCRIPTION
recently added more reads into that function, if a later read fails, i must
either free what's already allocated, or return the pointer so that the free
callback will release it.