### PR TITLE
Simplify code in sds.c:sdsrange

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -748,18 +748,15 @@ void sdsrange(sds s, ssize_t start, ssize_t end) {
         end = len+end;
         if (end < 0) end = 0;
     }
-    newlen = (start > end) ? 0 : (end-start)+1;
-    if (newlen != 0) {
-        if (start >= (ssize_t)len) {
-            newlen = 0;
-        } else if (end >= (ssize_t)len) {
-            end = len-1;
-            newlen = (start > end) ? 0 : (end-start)+1;
-        }
-    } else {
-        start = 0;
+    if (end >= (ssize_t)len) {
+        end = len - 1;
     }
-    if (start && newlen) memmove(s, s+start, newlen);
+    if (start >= (ssize_t)len) {
+        newlen = 0;
+    } else {
+        newlen = (start > end) ? 0 : (end-start)+1;
+    }
+    if (newlen) memmove(s, s+start, newlen);
     s[newlen] = 0;
     sdssetlen(s,newlen);
 }


### PR DESCRIPTION
I found that some code for checking the validity of the range(start <= end < len) in the function sdsrange is redundant and not very explicit or readable, so I simplified these code. The code has passed the unit test for sds.c.