### PR TITLE
Add support for DECR, INCRBY, DECRBY command in Redis Benchmark

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1655,6 +1655,14 @@ int main(int argc, const char **argv) {
             free(cmd);
         }
 
+        if (test_is_selected("incrby")) {
+            long long data = 1;
+            data = data << config.datasize;
+            len = redisFormatCommand(&cmd,"INCRBY key:{tag}:__rand_int__ %lld", data);
+            benchmark("INCRBY",cmd,len);
+            free(cmd);
+        }
+
         if (test_is_selected("lpush")) {
             len = redisFormatCommand(&cmd,"LPUSH mylist:{tag} %s",data);
             benchmark("LPUSH",cmd,len);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1663,6 +1663,14 @@ int main(int argc, const char **argv) {
             free(cmd);
         }
 
+        if (test_is_selected("decrby")) {
+            long long data = 1;
+            data = data << config.datasize;
+            len = redisFormatCommand(&cmd,"DECRBY key:{tag}:__rand_int__ %lld", data);
+            benchmark("DECRBY",cmd,len);
+            free(cmd);
+        }
+
         if (test_is_selected("lpush")) {
             len = redisFormatCommand(&cmd,"LPUSH mylist:{tag} %s",data);
             benchmark("LPUSH",cmd,len);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1649,6 +1649,12 @@ int main(int argc, const char **argv) {
             free(cmd);
         }
 
+        if (test_is_selected("decr")) {
+            len = redisFormatCommand(&cmd,"DECR counter:{tag}:__rand_int__");
+            benchmark("DECR",cmd,len);
+            free(cmd);
+        }
+
         if (test_is_selected("lpush")) {
             len = redisFormatCommand(&cmd,"LPUSH mylist:{tag} %s",data);
             benchmark("LPUSH",cmd,len);


### PR DESCRIPTION
From my perspective, I feel DECR, INCRBY, DECRBY commands are very much used by users in redis community. So adding support for those commands in redis benchmark.