### PR TITLE
 Suggest a new persistence method from Redis.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -215,9 +215,9 @@ always-show-logo yes
 #
 #   save ""
 
-save 900 1
-save 300 10
-save 60 10000
+#save 900 1
+#save 300 10
+#save 60 10000
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.
@@ -670,6 +670,9 @@ slave-lazy-flush no
 # Please check http://redis.io/topics/persistence for more information.
 
 appendonly no
+
+aofmode with_rdb
+#rdb_only / aof_only / with_rdb
 
 # The name of the append only file (default: "appendonly.aof")
 

--- a/src/aof.c
+++ b/src/aof.c
@@ -1626,3 +1626,33 @@ cleanup:
     if (server.aof_state == AOF_WAIT_REWRITE)
         server.aof_rewrite_scheduled = 1;
 }
+
+void aofmodeCommand(client *c){
+    /* TODO : add a comment */
+    if (server.aof_state == AOF_OFF) {
+        serverLog(LL_WARNING, "AOF not enabled. please AOF ON");
+        addReplyStatusFormat(c,"AOF not enabled. please AOF ON(config set appendonly yes)");
+        return;
+    }
+    int mode = aofmode((char*)c->argv[1]->ptr);
+
+    switch(mode) {
+    case REDIS_AOFMODE_AOF_ONLY:
+        server.aof_with_rdb_state = REDIS_AOF_WITH_RDB_OFF;
+        serverLog(LL_WARNING, "AOFMODE : aof_only");
+        addReplyStatusFormat(c,"AOFMODE : AOF_ONLY");
+        break;
+    case REDIS_AOFMODE_WITH_RDB:
+        server.aof_with_rdb_state = REDIS_AOF_WITH_RDB_ON;
+        serverLog(LL_WARNING, "AOFMODE : with_rdb");
+        addReplyStatusFormat(c,"AOFMODE : WITH_RDB");
+        break;
+    case REDIS_AOFMODE_RDB_ONLY:
+        server.aof_with_rdb_state = REDIS_AOF_WITH_RDB_OFF;
+        serverLog(LL_WARNING, "AOFMODE : rdb_only");
+        addReplyStatusFormat(c,"AOFMODE : RDB_ONLY");
+        break;
+    default:
+        addReplyErrorFormat(c,"Invalid Argument '%s': argument must be 'aof_only' or 'with_rdb'",(char*)c->argv[1]->ptr);
+    }
+}

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -119,6 +119,8 @@
 #define RDB_SAVE_NONE 0
 #define RDB_SAVE_AOF_PREAMBLE (1<<0)
 
+#define RDB_SAVE_AOF_WITH_RDB (1<<1)
+
 int rdbSaveType(rio *rdb, unsigned char type);
 int rdbLoadType(rio *rdb);
 int rdbSaveTime(rio *rdb, time_t t);
@@ -148,5 +150,8 @@ int rdbSaveBinaryFloatValue(rio *rdb, float val);
 int rdbLoadBinaryFloatValue(rio *rdb, float *val);
 int rdbLoadRio(rio *rdb, rdbSaveInfo *rsi, int loading_aof);
 rdbSaveInfo *rdbPopulateSaveInfo(rdbSaveInfo *rsi);
+
+int rdbSaveWithoutRename();
+void aof_with_rdb_DoneHandler(int exitcode, int bysignal);
 
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -1116,8 +1116,15 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
                             server.aof_rewrite_base_size : 1;
             long long growth = (server.aof_current_size*100/base) - 100;
             if (growth >= server.aof_rewrite_perc) {
+            /* TODO : aof_with_rdb function call */
+            	if(server.aof_with_rdb_state == REDIS_AOF_WITH_RDB_ON){
+            		serverLog(LL_NOTICE, "aof_with_rdb mode on");
+                    aof_with_rdb();
+            	}
+            else {
                 serverLog(LL_NOTICE,"Starting automatic rewriting of AOF on %lld%% growth",growth);
                 rewriteAppendOnlyFileBackground();
+               }
             }
          }
     }
@@ -3065,6 +3072,10 @@ sds genRedisInfoString(char *section) {
                 server.aof_delayed_fsync);
         }
 
+        /* aof_only, aof_with_rdb mode check */
+        info = sdscatprintf(info,
+            "aof_with_rdb_mode:%d\r\n", server.aof_with_rdb_state);
+
         if (server.loading) {
             double perc;
             time_t eta, elapsed;
@@ -3555,8 +3566,20 @@ int checkForSentinelMode(int argc, char **argv) {
 
 /* Function called at startup to load RDB or AOF file in memory. */
 void loadDataFromDisk(void) {
+
+	if(server.aof_with_rdb_state == REDIS_AOF_WITH_RDB_ON) {
+        serverLog(LL_NOTICE, "aof_with_rdb on");
+        loadData_aof_with_rdb();
+        return;
+
+	}//fix later
+    else if (server.aof_with_rdb_state == REDIS_AOF_WITH_RDB_OFF && server.aof_state == AOF_ON)
+        serverLog(LL_NOTICE, "aof_only on!");
+    else
+    	serverLog(LL_NOTICE, "rdb_only off!");
+
     long long start = ustime();
-    if (server.aof_state == AOF_ON) {
+    if (server.aof_state == AOF_ON || server.aof_with_rdb_state ==  REDIS_AOF_WITH_RDB_ON) {
         if (loadAppendOnlyFile(server.aof_filename) == C_OK)
             serverLog(LL_NOTICE,"DB loaded from append only file: %.3f seconds",(float)(ustime()-start)/1000000);
     } else {
@@ -3587,6 +3610,80 @@ void loadDataFromDisk(void) {
             exit(1);
         }
     }
+}
+
+void loadData_aof_with_rdb(void) {
+	serverLog(LL_NOTICE, "AOF with RDB Start");
+long long start = ustime();
+bool temp_aof = false, temp_rdb = false, aof = false, rdb = false;
+
+if (access(REDIS_DEFAULT_TEMP_AOF_FILENAME, F_OK) == 0) temp_aof = true;
+if (access(REDIS_DEFAULT_TEMP_RDB_FILENAME, F_OK) == 0) temp_rdb = true;
+if (access(server.aof_filename, F_OK) == 0) aof = true;
+if (access(server.rdb_filename, F_OK) == 0) rdb = true;
+
+if (aof && temp_aof && rdb && !temp_rdb) {
+    start = ustime();
+    if (rdbLoad(server.rdb_filename, NULL) == C_OK) {
+    	serverLog(LL_NOTICE,"DB loaded from disk: %.3f seconds",
+            (float)(ustime()-start)/1000000);
+    }
+    start = ustime();
+    if (loadAppendOnlyFile(server.aof_filename) == C_OK) {
+    	serverLog(LL_NOTICE,"DB loaded from append only file: %.3f seconds",(float)(ustime()-start)/1000000);
+    }
+    start = ustime();
+    if (loadAppendOnlyFile(REDIS_DEFAULT_TEMP_AOF_FILENAME) == C_OK) {
+    	serverLog(LL_NOTICE,"DB loaded from temp append only file: %.3f seconds",(float)(ustime()-start)/1000000);
+    }
+}
+else if (aof && !temp_aof && rdb && !temp_rdb){
+
+    start = ustime();
+    if (rdbLoad(server.rdb_filename, NULL) == C_OK) {
+    serverLog(LL_NOTICE,"DB loaded from disk: %.3f seconds",
+        (float)(ustime()-start)/1000000);
+    }
+    start = ustime();
+    if (loadAppendOnlyFile(server.aof_filename) == C_OK)
+        serverLog(LL_NOTICE,"DB loaded from append only file: %.3f seconds",(float)(ustime()-start)/1000000);
+}
+else if (aof && temp_aof && rdb && temp_rdb) {
+    start = ustime();
+    if (rdbLoad(server.rdb_filename, NULL) == C_OK) {
+    	serverLog(LL_NOTICE,"DB loaded from disk: %.3f seconds",
+            (float)(ustime()-start)/1000000);
+    }
+    start = ustime();
+    if (loadAppendOnlyFile(server.aof_filename) == C_OK) {
+    	serverLog(LL_NOTICE,"DB loaded from append only file: %.3f seconds",(float)(ustime()-start)/1000000);
+    }
+    start = ustime();
+    if (loadAppendOnlyFile(REDIS_DEFAULT_TEMP_AOF_FILENAME) == C_OK) {
+    	serverLog(LL_NOTICE,"DB loaded from temp append only file: %.3f seconds",(float)(ustime()-start)/1000000);
+    }
+}
+else if (aof && !temp_aof && rdb && temp_rdb) {
+    start = ustime();
+    if (rdbLoad(REDIS_DEFAULT_TEMP_RDB_FILENAME, NULL) == C_OK) {
+    	serverLog(LL_NOTICE,"temp DB loaded from disk: %.3f seconds",
+            (float)(ustime()-start)/1000000);
+    }
+    start = ustime();
+    if (loadAppendOnlyFile(server.aof_filename) == C_OK) {
+    	serverLog(LL_NOTICE,"DB loaded from append only file: %.3f seconds",(float)(ustime()-start)/1000000);
+    }
+}
+else {
+    start = ustime();
+    if (rdbLoad(REDIS_DEFAULT_TEMP_RDB_FILENAME, NULL) == C_OK) {
+    	serverLog(LL_NOTICE,"DB loaded from disk: %.3f seconds",
+        (float)(ustime()-start)/1000000);
+    }
+    start = ustime();
+    if (loadAppendOnlyFile(server.aof_filename) == C_OK)
+    	serverLog(LL_NOTICE,"DB loaded from append only file: %.3f seconds",(float)(ustime()-start)/1000000);
+}
 }
 
 void redisOutOfMemoryHandler(size_t allocation_size) {

--- a/src/server.c
+++ b/src/server.c
@@ -56,6 +56,8 @@
 #include <locale.h>
 #include <sys/socket.h>
 
+#include <stdbool.h>
+
 /* Our shared "common" objects */
 
 struct sharedObjectsStruct shared;
@@ -304,7 +306,8 @@ struct redisCommand redisCommandTable[] = {
     {"pfdebug",pfdebugCommand,-3,"w",0,NULL,0,0,0,0,0},
     {"post",securityWarningCommand,-1,"lt",0,NULL,0,0,0,0,0},
     {"host:",securityWarningCommand,-1,"lt",0,NULL,0,0,0,0,0},
-    {"latency",latencyCommand,-2,"aslt",0,NULL,0,0,0,0,0}
+    {"latency",latencyCommand,-2,"aslt",0,NULL,0,0,0,0,0},
+    {"aofmode",aofmodeCommand,2,"ar",0,NULL,0,0,0,0,0}
 };
 
 /*============================ Utility functions ============================ */
@@ -1382,6 +1385,9 @@ void initServerConfig(void) {
     server.syslog_ident = zstrdup(CONFIG_DEFAULT_SYSLOG_IDENT);
     server.syslog_facility = LOG_LOCAL0;
     server.daemonize = CONFIG_DEFAULT_DAEMONIZE;
+    
+    server.aof_with_rdb_state = REDIS_AOF_WITH_RDB_OFF;
+    
     server.supervised = 0;
     server.supervised_mode = SUPERVISED_NONE;
     server.aof_state = AOF_OFF;

--- a/src/server.h
+++ b/src/server.h
@@ -125,6 +125,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CONFIG_DEFAULT_RDB_COMPRESSION 1
 #define CONFIG_DEFAULT_RDB_CHECKSUM 1
 #define CONFIG_DEFAULT_RDB_FILENAME "dump.rdb"
+#define REDIS_DEFAULT_TEMP_RDB_FILENAME "temp.rdb"
 #define CONFIG_DEFAULT_REPL_DISKLESS_SYNC 0
 #define CONFIG_DEFAULT_REPL_DISKLESS_SYNC_DELAY 5
 #define CONFIG_DEFAULT_SLAVE_SERVE_STALE_DATA 1
@@ -137,6 +138,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CONFIG_DEFAULT_LFU_LOG_FACTOR 10
 #define CONFIG_DEFAULT_LFU_DECAY_TIME 1
 #define CONFIG_DEFAULT_AOF_FILENAME "appendonly.aof"
+#define REDIS_DEFAULT_TEMP_AOF_FILENAME "temp.aof"
 #define CONFIG_DEFAULT_AOF_NO_FSYNC_ON_REWRITE 0
 #define CONFIG_DEFAULT_AOF_LOAD_TRUNCATED 1
 #define CONFIG_DEFAULT_AOF_USE_RDB_PREAMBLE 0
@@ -216,6 +218,8 @@ typedef long long mstime_t; /* millisecond time type. */
 #define AOF_OFF 0             /* AOF is off */
 #define AOF_ON 1              /* AOF is on */
 #define AOF_WAIT_REWRITE 2    /* AOF waits rewrite to start appending */
+
+#define AOF_WAIT_AOF_WITH_RDB 3
 
 #define REDIS_AOF_WITH_RDB_OFF 0              /* AOF_WITH_RDB is on */
 #define REDIS_AOF_WITH_RDB_ON 1              /* AOF_WITH_RDB is on */
@@ -415,6 +419,8 @@ typedef long long mstime_t; /* millisecond time type. */
 #define RDB_CHILD_TYPE_NONE 0
 #define RDB_CHILD_TYPE_DISK 1     /* RDB is written to disk. */
 #define RDB_CHILD_TYPE_SOCKET 2   /* RDB is written to slave socket. */
+
+#define RDB_CHILD_TYPE_AOF_WITH_RDB 3
 
 /* Keyspace changes notification classes. Every class is associated with a
  * character for configuration purposes. */

--- a/src/server.h
+++ b/src/server.h
@@ -217,6 +217,9 @@ typedef long long mstime_t; /* millisecond time type. */
 #define AOF_ON 1              /* AOF is on */
 #define AOF_WAIT_REWRITE 2    /* AOF waits rewrite to start appending */
 
+#define REDIS_AOF_WITH_RDB_OFF 0              /* AOF_WITH_RDB is on */
+#define REDIS_AOF_WITH_RDB_ON 1              /* AOF_WITH_RDB is on */
+
 /* Client flags */
 #define CLIENT_SLAVE (1<<0)   /* This client is a slave server */
 #define CLIENT_MASTER (1<<1)  /* This client is a master server */
@@ -1052,6 +1055,9 @@ struct redisServer {
     } child_info_data;
     /* Propagation of commands in AOF / replication */
     redisOpArray also_propagate;    /* Additional command to propagate. */
+   
+    int aof_with_rdb_state;
+    
     /* Logging */
     char *logfile;                  /* Path of log file */
     int syslog_enabled;             /* Is syslog enabled? */
@@ -2001,6 +2007,8 @@ void latencyCommand(client *c);
 void moduleCommand(client *c);
 void securityWarningCommand(client *c);
 
+void aofmodeCommand(client *c);
+
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));
 void free(void *ptr) __attribute__ ((deprecated));
@@ -2028,5 +2036,11 @@ void xorDigest(unsigned char *digest, void *ptr, size_t len);
     printf("DEBUG %s:%d > " fmt "\n", __FILE__, __LINE__, __VA_ARGS__)
 #define redisDebugMark() \
     printf("-- MARK %s:%d --\n", __FILE__, __LINE__)
+
+#define REDIS_AOFMODE_AOF_ONLY 0
+#define REDIS_AOFMODE_WITH_RDB 1
+#define REDIS_AOFMODE_RDB_ONLY 2
+
+int aofmode(char *s);
 
 #endif

--- a/src/server.h
+++ b/src/server.h
@@ -1531,6 +1531,9 @@ void startLoading(FILE *fp);
 void loadingProgress(off_t pos);
 void stopLoading(void);
 
+void loadData_aof_with_rdb(void);
+void aof_with_rdb(void);
+
 /* RDB persistence */
 #include "rdb.h"
 int rdbSaveRio(rio *rdb, int *error, int flags, rdbSaveInfo *rsi);


### PR DESCRIPTION
Hello. I do research on Redis, and I recently developed a new persistence method that improves AOF-PREAMBLE.
The proposed method was designed to reduce memory usage and improve the performance of Redis. This persistence method is called LESS, uses a mixture of AOF and RDB. It seems to similar to AOF-PREAMBLE but detailed behavior is different from AOF-PREAMBLE.

I worked on the Redis 4 version of the module. So I asked for a PR from 4.0. 

As the paper on the LESS module has been published, I will give you a link to the paper for your understanding. Please review it.

https://ieeexplore.ieee.org/document/8679377

*I'm not used to open-source activities. Please tell me if the method of PR is wrong.