### PR TITLE
Add MKSTREAM to XGROUP command help

### DIFF
--- a/src/help.h
+++ b/src/help.h
@@ -1004,7 +1004,7 @@ struct commandHelp {
     14,
     "5.0.0" },
     { "XGROUP",
-    "[CREATE key groupname id-or-$] [SETID key id-or-$] [DESTROY key groupname] [DELCONSUMER key groupname consumername]",
+    "[CREATE key groupname id-or-$] [SETID key id-or-$] [DESTROY key groupname] [DELCONSUMER key groupname consumername] [MKSTREAM]",
     "Create, destroy, and manage consumer groups.",
     14,
     "5.0.0" },


### PR DESCRIPTION
Wanted to add the `MKSTREAM` option to the `XGROUP CREATE` subcommand. I added the option to the docs previously in https://github.com/antirez/redis-doc/pull/1211

This PR adds it officially to `redis-cli` help syntax.