### PR TITLE
Refactored configs into types that can be generic

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -363,7 +363,7 @@ void loadServerConfigFromString(char *config) {
             }
         } else if (!strcasecmp(argv[0],"maxmemory") && argc == 2) {
             server.maxmemory = memtoll(argv[1],NULL);
-	    } else if ((!strcasecmp(argv[0],"client-query-buffer-limit")) && argc == 2) {
+        } else if ((!strcasecmp(argv[0],"client-query-buffer-limit")) && argc == 2) {
              server.client_max_querybuf_len = memtoll(argv[1],NULL);
         } else if ((!strcasecmp(argv[0],"slaveof") ||
                     !strcasecmp(argv[0],"replicaof")) && argc == 3) {

--- a/src/config.c
+++ b/src/config.c
@@ -662,8 +662,8 @@ void loadServerConfig(char *filename, char *options) {
 #define config_set_special_field(_name) \
     } else if (!strcasecmp(c->argv[2]->ptr,_name)) {
 
-#define config_set_special_field_with_alias(_name,_name2) \
-    } else if (!strcasecmp(c->argv[2]->ptr,_name) || \
+#define config_set_special_field_with_alias(_name1,_name2) \
+    } else if (!strcasecmp(c->argv[2]->ptr,_name1) || \
                !strcasecmp(c->argv[2]->ptr,_name2)) {
 
 #define config_set_else } else
@@ -855,9 +855,9 @@ void configSetCommand(client *c) {
     /* Numerical fields.
      * config_set_numerical_field(name,var,min,max) */
     } config_set_numerical_field(
-      "repl-backlog-ttl",server.repl_backlog_time_limit,0,LONG_MAX) {
-    } config_set_numerical_field(
       "stream-node-max-entries",server.stream_node_max_entries,0,LLONG_MAX) {
+    } config_set_numerical_field(
+      "repl-backlog-ttl",server.repl_backlog_time_limit,0,LONG_MAX) {
     } config_set_numerical_field(
       "min-slaves-to-write",server.repl_min_slaves_to_write,0,INT_MAX) {
         refreshGoodSlavesCount();
@@ -891,8 +891,8 @@ void configSetCommand(client *c) {
             }
             freeMemoryIfNeededAndSafe();
         }
-     } config_set_memory_field(
-       "client-query-buffer-limit",server.client_max_querybuf_len) {
+    } config_set_memory_field(
+      "client-query-buffer-limit",server.client_max_querybuf_len) {
     } config_set_memory_field("repl-backlog-size",ll) {
         resizeReplicationBacklog(ll);
     } config_set_memory_field("auto-aof-rewrite-min-size",ll) {
@@ -1811,8 +1811,8 @@ int rewriteConfig(char *path) {
     rewriteConfigBytesOption(state,"client-query-buffer-limit",server.client_max_querybuf_len,PROTO_MAX_QUERYBUF_LEN);
     rewriteConfigYesNoOption(state,"appendonly",server.aof_enabled,0);
     rewriteConfigStringOption(state,"appendfilename",server.aof_filename,CONFIG_DEFAULT_AOF_FILENAME);
-    rewriteConfigYesNoOption(state,"cluster-enabled",server.cluster_enabled,0);
     rewriteConfigBytesOption(state,"auto-aof-rewrite-min-size",server.aof_rewrite_min_size,AOF_REWRITE_MIN_SIZE);
+    rewriteConfigYesNoOption(state,"cluster-enabled",server.cluster_enabled,0);
     rewriteConfigStringOption(state,"cluster-config-file",server.cluster_configfile,CONFIG_DEFAULT_CLUSTER_CONFIG_FILE);
     rewriteConfigNotifykeyspaceeventsOption(state);
     rewriteConfigNumericalOption(state,"stream-node-max-entries",server.stream_node_max_entries,OBJ_STREAM_NODE_MAX_ENTRIES);
@@ -1981,8 +1981,8 @@ static int configEnumLoad(typeData data, sds *argv, int argc, char **err) {
         sds enumerr = sdsnew("argument must be one of the following: ");
         configEnum *enumNode = data.enumd.enum_value;
         while(enumNode->name != NULL) {
-            sdscatlen(enumerr, enumNode->name, strlen(enumNode->name));
-            sdscatlen(enumerr, ", ", 2);
+            enumerr = sdscatlen(enumerr, enumNode->name, strlen(enumNode->name));
+            enumerr = sdscatlen(enumerr, ", ", 2);
             enumNode++;
         }
 


### PR DESCRIPTION
This is a follow to a previous PR that made the boolean types more generic. 

The current approach will give you warnings if you use the wrong types, which I see as a big benefit.

I think you could make the case that configs really only need two functions, get and set, since load is just a fancy get and rewrite is just a load, get, set, but this does allow them to be more generic. This just leaves it a little more generic though, and isn't a huge cost. 

The result of this PR, is that to add a config you will just need to add it to server.h, initialize it in server.c, and then add it to block config at the bottom for using regular integers, enums, strings, or bools. 

The last thing to call out is a couple of weird values which may seem like they can be refactored, but don't naturally fit into the system:
repl-backlog-ttl: is a time_t type
client-query-buffer-limit: Is an atomic type
syslog-enabled: Doesn't have a get