### PR TITLE
Fix anomalous behavior

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -115,7 +115,7 @@ void setCommand(client *c) {
             flags |= OBJ_SET_XX;
         } else if ((a[0] == 'e' || a[0] == 'E') &&
                    (a[1] == 'x' || a[1] == 'X') && a[2] == '\0' &&
-                   !(flags & OBJ_SET_PX) && next)
+                   !(flags & OBJ_SET_EX) && next)
         {
             flags |= OBJ_SET_EX;
             unit = UNIT_SECONDS;
@@ -123,7 +123,7 @@ void setCommand(client *c) {
             j++;
         } else if ((a[0] == 'p' || a[0] == 'P') &&
                    (a[1] == 'x' || a[1] == 'X') && a[2] == '\0' &&
-                   !(flags & OBJ_SET_EX) && next)
+                   !(flags & OBJ_SET_PX) && next)
         {
             flags |= OBJ_SET_PX;
             unit = UNIT_MILLISECONDS;
@@ -133,6 +133,11 @@ void setCommand(client *c) {
             addReply(c,shared.syntaxerr);
             return;
         }
+    }
+
+    if ((flags & OBJ_SET_EX) && (flags & OBJ_SET_PX)) {
+        addReply(c,shared.syntaxerr);
+        return;
     }
 
     c->argv[2] = tryObjectEncoding(c->argv[2]);

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -419,4 +419,13 @@ start_server {tags {"string"}} {
         r set foo bar
         r getrange foo 0 4294967297
     } {bar}
+
+    test {Anomalous behavior with EX option} {
+        r del foo
+        catch {
+            r set foo bar ex 10 ex 100
+        }
+        set ttl [r ttl foo]
+        assert_equal $ttl -2
+    }
 }

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -428,4 +428,13 @@ start_server {tags {"string"}} {
         set ttl [r ttl foo]
         assert_equal $ttl -2
     }
+
+    test {Anomalous behavior with PX option} {
+        r del foo
+        catch {
+            r set foo bar px 10000 px 100000
+        }
+        set ttl [r ttl foo]
+        assert_equal $ttl -2
+    }
 }


### PR DESCRIPTION
There's an anomalous behavior with SET command.
`set foo bar ex 10 ex 100`
`set foo bar px 10000 px 100000`
