### PR TITLE
reduce one line and remove compile warning for configEnumLoad

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -38,6 +38,8 @@
  * Config file name-value maps.
  *----------------------------------------------------------------------------*/
 
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
+
 typedef struct configEnum {
     const char *name;
     const int val;
@@ -1856,7 +1858,7 @@ int rewriteConfig(char *path) {
  * Configs that fit one of the major types and require no special handling
  *----------------------------------------------------------------------------*/
 #define LOADBUF_SIZE 256
-static char loadbuf[LOADBUF_SIZE];
+static char loadbuf[LOADBUF_SIZE+4];
 
 #define MODIFIABLE_CONFIG 1
 #define IMMUTABLE_CONFIG 0
@@ -1985,10 +1987,8 @@ static int configEnumLoad(typeData data, sds *argv, int argc, char **err) {
             enumNode++;
         }
 
-        enumerr[sdslen(enumerr) - 2] = '\0';
-
         /* Make sure we don't overrun the fixed buffer */
-        enumerr[LOADBUF_SIZE - 1] = '\0';
+        enumerr[MIN(sdslen(enumerr) - 2, LOADBUF_SIZE-1)] = '\0';
         strncpy(loadbuf, enumerr, LOADBUF_SIZE);
 
         sdsfree(enumerr);


### PR DESCRIPTION
There are two issues.
1] compiler warning
 strncpy with LOADBUF_SIZE can cause compiler warning.
 because before of it, it intentionally added '\0' at LOADBUF_SIZE-1 offset.

 It just allocates 4 bytes more for loadbuf.

2] two assignment '\0' end of enumerr.
 using MIN macro, we can reduce it as one. 

Thanks.