### PR TITLE
revert an accidental test code change done as part of the tls project

### DIFF
--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -4,7 +4,7 @@ set ::tlsdir "tests/tls"
 
 proc gen_write_load {host port seconds tls} {
     set start_time [clock seconds]
-    set r [redis $host $port 0 $tls]
+    set r [redis $host $port 1 $tls]
     $r select 9
     while 1 {
         $r set [expr rand()] [expr rand()]


### PR DESCRIPTION
it seems that commit b087dd1db60ed23d9e59304deb0b1599437f6e23 accidentially changed
gen_write_load to not use deferred client, which causes them to be slower and not
generate high load which they should, making some tests less effecitive