### PR TITLE
Added the help info indicating cluster creation does not support unix sockets as endpoints

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6443,6 +6443,9 @@ static int clusterManagerCommandHelp(int argc, char **argv) {
             }
         }
     }
+    fprintf(stderr, "\nCreate subcommand supports ip:port endpoint only. "
+                    "Cluster creation does not support unix sockets as "
+                    "endpoints.\n\n");
     fprintf(stderr, "\nFor check, fix, reshard, del-node, set-timeout you "
                     "can specify the host and port of any working node in "
                     "the cluster.\n\n");


### PR DESCRIPTION
Hi @antirez , I noticed that current redis-cli only supports using ip:port as an endpoint to create a cluster, but it does not support using unix sockets when creating individual redis servers. I am not sure if it is worth to add this help info for redis-cli to indicate that. Could you take a look when you have time? Thank you!  