### PR TITLE
Fix memcpy of id from key to be slightly safer.

### DIFF
--- a/src/tracking.c
+++ b/src/tracking.c
@@ -164,7 +164,7 @@ void trackingInvalidateSlot(uint64_t slot) {
     raxSeek(&ri,"^",NULL,0);
     while(raxNext(&ri)) {
         uint64_t id;
-        memcpy(&id,ri.key,ri.key_len);
+        memcpy(&id,ri.key,sizeof(id));
         client *c = lookupClientByID(id);
         if (c == NULL || !(c->flags & CLIENT_TRACKING)) continue;
         sendTrackingMessage(c,slot);


### PR DESCRIPTION
The memcpy from the key to the id relies on the fact that this key
*should* be 8 bytes long as it was entered as such a few lines up the
code.

BUT if someone will change the code to the point this is no longer true,
current code can trash the stack which makes debugging very hard
while this fix will result in some garbage id, or even page fault.
Both are preferable to stack mangaling.