### PR TITLE
Fix outdated information on max memory policies

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -811,7 +811,7 @@ replica-priority 100
 # maxmemory <bytes>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
-# is reached. You can select among eight behaviors:
+# is reached. You can select one from the following behaviors:
 #
 # volatile-lru -> Evict using approximated LRU, only keys with an expire set.
 # allkeys-lru -> Evict any key using approximated LRU.

--- a/redis.conf
+++ b/redis.conf
@@ -811,7 +811,7 @@ replica-priority 100
 # maxmemory <bytes>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
-# is reached. You can select among five behaviors:
+# is reached. You can select among eight behaviors:
 #
 # volatile-lru -> Evict using approximated LRU, only keys with an expire set.
 # allkeys-lru -> Evict any key using approximated LRU.


### PR DESCRIPTION
Noticed this when reading the redis config.

The doc lists five behaviors, which at one point in time was correct. 3 years ago, additional behaviors were added.