### PR TITLE
added error counters via INFO commandstats and errorstats

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2301,6 +2301,7 @@ NULL
     } else if (!strcasecmp(c->argv[1]->ptr,"resetstat") && c->argc == 2) {
         resetServerStats();
         resetCommandTableStats();
+        resetErrorTableStats();
         addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"rewrite") && c->argc == 2) {
         if (server.configfile == NULL) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -356,6 +356,16 @@ void addReplyErrorLength(client *c, const char *s, size_t len) {
     addReplyProto(c,s,len);
     addReplyProto(c,"\r\n",2);
 
+    struct redisError *err = lookupError(shared.all_errors);
+    if (err!=NULL) {
+        err->calls++;
+    }
+
+    struct redisCommand *real_cmd = c->cmd;
+    if (real_cmd!=NULL) {
+        real_cmd->failed_calls++;
+    }
+
     /* Sometimes it could be normal that a slave replies to a master with
      * an error and this function gets called. Actually the error will never
      * be sent because addReply*() against master clients has no effect...
@@ -374,6 +384,7 @@ void addReplyErrorLength(client *c, const char *s, size_t len) {
                              "to its %s: '%s' after processing the command "
                              "'%s'", from, to, s, cmdname);
     }
+
 }
 
 void addReplyError(client *c, const char *err) {


### PR DESCRIPTION
this PR pushes forward the observability on overall error statistics and command statistics within redis-server. 
It extends `INFO COMMANDSTATS` to have failed-calls in addition to calls ( so we can keep track of errors that happen from the command itself, broken by command ) and adds a new section to `INFO`, named `ERRORSTATS` that enables keeping track of all errors that happened even outside `processCommand`.
This PR also fixes `RM_ReplyWithError` so that it can be correctly identified as an error reply. 

## info commandstats 
Right now all errors are aggregate as [simple error](https://gist.github.com/antirez/2bc68a9e9e45395e297d288453d5d54c#simple-types)
```
$ redis-cli 
127.0.0.1:6379> set a
(error) ERR wrong number of arguments for 'set' command
127.0.0.1:6379> LINDEX a
(error) ERR wrong number of arguments for 'lindex' command
127.0.0.1:6379> LINDEX x
(error) ERR wrong number of arguments for 'lindex' command
127.0.0.1:6379> LSET a
(error) ERR wrong number of arguments for 'lset' command
127.0.0.1:6379> info commandstats
# Commandstats
cmdstat_command:calls=1,failed_calls=0,usec=1532,usec_per_call=1532.00
cmdstat_lset:calls=0,failed_calls=1,usec=0,usec_per_call=0.00
cmdstat_lindex:calls=0,failed_calls=2,usec=0,usec_per_call=0.00
cmdstat_set:calls=0,failed_calls=1,usec=0,usec_per_call=0.00
```
## info errorstats 
Right now all errors are aggregate as [simple error](https://gist.github.com/antirez/2bc68a9e9e45395e297d288453d5d54c#simple-types). In the future we can extend to different types of errors ( but it will imply changing `addReplyErrorLength` )
```
$ redis-cli 
127.0.0.1:6379> set a
(error) ERR wrong number of arguments for 'set' command
127.0.0.1:6379> LINDEX a
(error) ERR wrong number of arguments for 'lindex' command
127.0.0.1:6379> LINDEX x
(error) ERR wrong number of arguments for 'lindex' command
127.0.0.1:6379> LSET a
(error) ERR wrong number of arguments for 'lset' command
127.0.0.1:6379> info errorstats
# Errorstats
errorstat_all_errors:calls=4
```



