### PR TITLE
Add ULL suffix to CLIENT_TRACKING flag to prevent sign extension

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -239,7 +239,7 @@ typedef long long ustime_t; /* microsecond time type. */
                                           we return single threaded that the
                                           client has already pending commands
                                           to be executed. */
-#define CLIENT_TRACKING (1<<31) /* Client enabled keys tracking in order to
+#define CLIENT_TRACKING (1ULL<<31) /* Client enabled keys tracking in order to
                                    perform client side caching. */
 #define CLIENT_TRACKING_BROKEN_REDIR (1ULL<<32) /* Target client is invalid. */
 


### PR DESCRIPTION
the code in:
        c->flags &= ~(CLIENT_TRACKING|CLIENT_TRACKING_BROKEN_REDIR);
will do sign extension and turn on all the high 31 bits
no damage so far since we don't have any yet