### PR TITLE
Call propagate instead of writing directly to AOF/replicas

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1194,9 +1194,7 @@ void propagateExpire(redisDb *db, robj *key, int lazy) {
     incrRefCount(argv[0]);
     incrRefCount(argv[1]);
 
-    if (server.aof_state != AOF_OFF)
-        feedAppendOnlyFile(server.delCommand,db->id,argv,2);
-    replicationFeedSlaves(server.slaves,db->id,argv,2);
+    propagate(server.delCommand,db->id,argv,2,PROPAGATE_AOF|PROPAGATE_REPL);
 
     decrRefCount(argv[0]);
     decrRefCount(argv[1]);


### PR DESCRIPTION
Use higher-level API to funnel all generic propagation through single function call.