### PR TITLE
When a new slave node is added, the method clustercron will cause the orphaned masters to misjudge

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3621,7 +3621,7 @@ void clusterCron(void) {
          * the orphaned masters. Note that it does not make sense to try
          * a migration if there is no master with at least *two* working
          * slaves. */
-        if (orphaned_masters && max_slaves >= 2 && this_slaves == max_slaves)
+        if (orphaned_masters && max_slaves >= 2 && this_slaves == max_slaves && server.repl_state == REPL_STATE_CONNECTED)
             clusterHandleSlaveMigration(max_slaves);
     }
 


### PR DESCRIPTION
When a new slave node is added, the method clustercron will cause the orphaned masters to misjudge，because server.cluster->nodes information is incomplete，Therefore, it may not have been an orphaned master that was misjudged as an orphaned master. The newly added slave migrate will be added to the misjudged orphaned master
The add node command is as follows：
redis-cli --cluster add-node 192.168.10.31:8002 192.168.10.11:8000 --cluster-slave --cluster-master-id 71f401777dbdad2b2a06ff7a0286f519e0949a70
 