### PR TITLE
init server.hz early to avoid div by 0 during config file loading

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2266,6 +2266,7 @@ void createSharedObjects(void) {
 void initServerConfig(void) {
     int j;
 
+    server.hz = CONFIG_DEFAULT_HZ;
     updateCachedTime(1);
     getRandomHexChars(server.runid,CONFIG_RUN_ID_SIZE);
     server.runid[CONFIG_RUN_ID_SIZE] = '\0';


### PR DESCRIPTION
since the refactory of config.c, it was initialized from config_hz in initServer
but apparently that's too late since the config file loading creates objects
which call LRU_CLOCK