### PR TITLE
Enable -a (auth) option for redis-benchmark --cluster

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1000,6 +1000,18 @@ static int fetchClusterConfiguration() {
     clusterNode *firstNode = createClusterNode((char *) config.hostip,
                                                config.hostport);
     if (!firstNode) {success = 0; goto cleanup;}
+    if (config.auth) {
+        reply = redisCommand(ctx, "AUTH %s", config.auth);
+        if (reply && reply->type == REDIS_REPLY_ERROR) {
+            if (config.hostsocket == NULL) {
+                fprintf(stderr, "Cluster node %s:%d replied with error:\n%s\n",
+                        config.hostip, config.hostport, reply->str);
+            } else {
+                fprintf(stderr, "Cluster node %s replied with error:\n%s\n",
+                        config.hostsocket, reply->str);
+            }
+        }
+    };
     reply = redisCommand(ctx, "CLUSTER NODES");
     success = (reply != NULL);
     if (!success) goto cleanup;


### PR DESCRIPTION
Using the `-a` option on **redis-benchmark** when it's launched in cluster mode (`--cluster` option), should allow redis-benchmark to authenticate to Redis. Anyway, the authentication itself is currently performed only inside benchmark's queries.
So, with password-protected cluster, fetching the initial cluster configuration would fail, since the `-a` option is actually ignored during cluster configuration fetching.
This PR will let  **redis-benchmark** to use the password specified in the `-a` option also during cluster configuration fetching, letting it work also with password-protected clusters.

See https://github.com/antirez/redis/pull/5889#issuecomment-565272574