### PR TITLE
USDT support for Redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ src/configs
 redis.ds
 src/redis.conf
 src/nodes.conf
+src/redis_dtrace.h
 deps/lua/src/lua
 deps/lua/src/luac
 deps/lua/src/liblua.a

--- a/src/Makefile
+++ b/src/Makefile
@@ -156,6 +156,10 @@ ifeq ($(MALLOC),jemalloc)
 	FINAL_LIBS := ../deps/jemalloc/lib/libjemalloc.a $(FINAL_LIBS)
 endif
 
+ifeq ($(BUILD_USDT),yes)
+    FINAL_CFLAGS+=-DUSE_USDT
+endif
+
 ifeq ($(BUILD_TLS),yes)
     FINAL_CFLAGS+=-DUSE_OPENSSL $(OPENSSL_CFLAGS)
     FINAL_LDFLAGS+=$(OPENSSL_LDFLAGS)
@@ -188,6 +192,7 @@ REDIS_BENCHMARK_NAME=redis-benchmark
 REDIS_BENCHMARK_OBJ=ae.o anet.o redis-benchmark.o adlist.o dict.o zmalloc.o siphash.o redis-benchmark.o
 REDIS_CHECK_RDB_NAME=redis-check-rdb
 REDIS_CHECK_AOF_NAME=redis-check-aof
+REDIS_DEPENDENCIES=
 
 all: $(REDIS_SERVER_NAME) $(REDIS_SENTINEL_NAME) $(REDIS_CLI_NAME) $(REDIS_BENCHMARK_NAME) $(REDIS_CHECK_RDB_NAME) $(REDIS_CHECK_AOF_NAME)
 	@echo ""
@@ -199,6 +204,12 @@ Makefile.dep:
 
 ifeq (0, $(words $(findstring $(MAKECMDGOALS), $(NODEPS))))
 -include Makefile.dep
+endif
+
+DTRACE=/usr/bin/dtrace # FIXME
+
+ifeq ($(BUILD_USDT),yes)
+    REDIS_DEPENDENCIES+=redis_dtrace.o
 endif
 
 .PHONY: all
@@ -231,8 +242,17 @@ ifneq ($(strip $(PREV_FINAL_LDFLAGS)), $(strip $(FINAL_LDFLAGS)))
 .make-prerequisites: persist-settings
 endif
 
+redis_dtrace.h: redis_dtrace.d
+	${DTRACE} -h -s redis_dtrace.d
+	sed -e 's,void \*,const void \*,g' redis_dtrace.h | \
+            sed -e 's,char \*,const char \*,g' | tr '\t' ' ' > redis_dtrace.tmp
+	mv redis_dtrace.tmp redis_dtrace.h
+
+redis_dtrace.o: $(REDIS_SERVER_OBJ)
+	$(DTRACE) -G -o redis_dtrace.o -s redis_dtrace.d $(REDIS_SERVER_OBJ)
+
 # redis-server
-$(REDIS_SERVER_NAME): $(REDIS_SERVER_OBJ)
+$(REDIS_SERVER_NAME): $(REDIS_SERVER_OBJ) $(REDIS_DEPENDENCIES)
 	$(REDIS_LD) -o $@ $^ ../deps/hiredis/libhiredis.a ../deps/lua/src/liblua.a $(FINAL_LIBS)
 
 # redis-sentinel

--- a/src/Makefile
+++ b/src/Makefile
@@ -156,8 +156,11 @@ ifeq ($(MALLOC),jemalloc)
 	FINAL_LIBS := ../deps/jemalloc/lib/libjemalloc.a $(FINAL_LIBS)
 endif
 
+DTRACE=/usr/bin/dtrace # FIXME autodetect or bail?
+TRACE_DEPENDENCIES=
 ifeq ($(BUILD_USDT),yes)
     FINAL_CFLAGS+=-DUSE_USDT
+    TRACE_DEPENDENCIES+=redis_dtrace.o
 endif
 
 ifeq ($(BUILD_TLS),yes)
@@ -192,7 +195,6 @@ REDIS_BENCHMARK_NAME=redis-benchmark
 REDIS_BENCHMARK_OBJ=ae.o anet.o redis-benchmark.o adlist.o dict.o zmalloc.o siphash.o redis-benchmark.o
 REDIS_CHECK_RDB_NAME=redis-check-rdb
 REDIS_CHECK_AOF_NAME=redis-check-aof
-REDIS_DEPENDENCIES=
 
 all: $(REDIS_SERVER_NAME) $(REDIS_SENTINEL_NAME) $(REDIS_CLI_NAME) $(REDIS_BENCHMARK_NAME) $(REDIS_CHECK_RDB_NAME) $(REDIS_CHECK_AOF_NAME)
 	@echo ""
@@ -204,12 +206,6 @@ Makefile.dep:
 
 ifeq (0, $(words $(findstring $(MAKECMDGOALS), $(NODEPS))))
 -include Makefile.dep
-endif
-
-DTRACE=/usr/bin/dtrace # FIXME
-
-ifeq ($(BUILD_USDT),yes)
-    REDIS_DEPENDENCIES+=redis_dtrace.o
 endif
 
 .PHONY: all
@@ -252,7 +248,7 @@ redis_dtrace.o: $(REDIS_SERVER_OBJ)
 	$(DTRACE) -G -o redis_dtrace.o -s redis_dtrace.d $(REDIS_SERVER_OBJ)
 
 # redis-server
-$(REDIS_SERVER_NAME): $(REDIS_SERVER_OBJ) $(REDIS_DEPENDENCIES)
+$(REDIS_SERVER_NAME): $(REDIS_SERVER_OBJ) $(TRACE_DEPENDENCIES)
 	$(REDIS_LD) -o $@ $^ ../deps/hiredis/libhiredis.a ../deps/lua/src/liblua.a $(FINAL_LIBS)
 
 # redis-sentinel

--- a/src/redis_dtrace.d
+++ b/src/redis_dtrace.d
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) <2019> whoever, I don't care
+ */
+provider redis {
+   /**
+    * Fired before a command is called
+    * @param id the command
+    */
+   probe call__start(int cmd_id);
+
+   /**
+    * Fired after a command is called
+    * @param id the command
+    */
+   probe call__end(int cmd_id);
+
+};
+
+#pragma D attributes Unstable/Unstable/Common provider redis provider
+#pragma D attributes Private/Private/Common provider redis module
+#pragma D attributes Private/Private/Common provider redis function
+#pragma D attributes Unstable/Unstable/Common provider redis name
+#pragma D attributes Unstable/Unstable/Common provider redis args

--- a/src/server.c
+++ b/src/server.c
@@ -3187,9 +3187,9 @@ void call(client *c, int flags) {
     dirty = server.dirty;
     updateCachedTime(0);
     start = server.ustime;
-    REDIS_CALL_START(real_cmd->id);
+    TRACE_CALL_START(real_cmd->id);
     c->cmd->proc(c);
-    REDIS_CALL_END(real_cmd->id);
+    TRACE_CALL_END(real_cmd->id);
     duration = ustime()-start;
     dirty = server.dirty-dirty;
     if (dirty < 0) dirty = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -3187,7 +3187,9 @@ void call(client *c, int flags) {
     dirty = server.dirty;
     updateCachedTime(0);
     start = server.ustime;
+    REDIS_CALL_START(real_cmd->id);
     c->cmd->proc(c);
+    REDIS_CALL_END(real_cmd->id);
     duration = ustime()-start;
     dirty = server.dirty-dirty;
     if (dirty < 0) dirty = 0;

--- a/src/server.h
+++ b/src/server.h
@@ -34,6 +34,7 @@
 #include "config.h"
 #include "solarisfixes.h"
 #include "rio.h"
+#include "trace.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/trace.h
+++ b/src/trace.h
@@ -12,7 +12,11 @@
 #define REDIS_CALL_END_ENABLED() (0)
 #endif
 
-#define UNLIKELY(x)    __builtin_expect(!!(x), 0)
+#ifdef __GNUC__
+#  define UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#  define UNLIKELY(x) !!(x)
+#endif
 
 #define REDIS_USDT_PROBE_HOOK(name, ...) if (UNLIKELY(REDIS_##name##_ENABLED())) { REDIS_##name(__VA_ARGS__); }
 

--- a/src/trace.h
+++ b/src/trace.h
@@ -12,4 +12,14 @@
 #define REDIS_CALL_END_ENABLED() (0)
 #endif
 
+#define UNLIKELY(x)    __builtin_expect(!!(x), 0)
+
+#define REDIS_USDT_PROBE_HOOK(name, ...) if (UNLIKELY(REDIS_##name##_ENABLED())) { REDIS_##name(__VA_ARGS__); }
+
+#define TRACE_CALL_START(arg0)\
+  REDIS_USDT_PROBE_HOOK(CALL_START, arg0)
+
+#define TRACE_CALL_END(arg0)\
+  REDIS_USDT_PROBE_HOOK(CALL_END, arg0)
+
 #endif

--- a/src/trace.h
+++ b/src/trace.h
@@ -1,0 +1,15 @@
+#ifndef TRACE_H
+#define TRACE_H
+
+#ifdef USE_USDT
+// If USDT is enabled, use the generated header
+#include "redis_dtrace.h"
+#else
+// If USDT isn't enabled, create stub macros
+#define REDIS_CALL_START(arg0)
+#define REDIS_CALL_START_ENABLED() (0)
+#define REDIS_CALL_END(arg0)
+#define REDIS_CALL_END_ENABLED() (0)
+#endif
+
+#endif

--- a/tracing.md
+++ b/tracing.md
@@ -1,0 +1,136 @@
+USDT Support -- Work In Progress
+===============================
+
+This document is intended to be a helpful overview for tracing Redis through
+optional built-in static tracepoints.
+
+Getting Started
+---------------
+
+### Building
+
+To build with USDT support you'll need either Dtrace or the Systemtap USDT
+development libraries (e.g. systemtap-sdt-dev on Debian/Ubuntu). On Solaris,
+BSD, etc the usual Dtrace faculties most of these distributions ship with
+should be fine.
+
+Run with `make BUILD_USDT=yes`.
+
+### Tests
+
+FIXME would need dtrace and bpftrace test cases?
+
+### Manually checking for tracepoints
+
+On Linux, inspect the elf notes of the Redis server:
+
+```
+$ readelf --notes src/redis-server
+
+Displaying notes found in: .note.ABI-tag
+  Owner                 Data size       Description
+  GNU                  0x00000010       NT_GNU_ABI_TAG (ABI version tag)
+    OS: Linux, ABI: 3.2.0
+
+Displaying notes found in: .note.stapsdt
+  Owner                 Data size       Description
+  stapsdt              0x00000036       NT_STAPSDT (SystemTap probe descriptors)
+    Provider: redis
+    Name: call__start
+    Location: 0x0000000000044400, Base: 0x000000000018f970, Semaphore: 0x00000000001d10b2
+    Arguments: -4@80(%r12)
+  stapsdt              0x00000034       NT_STAPSDT (SystemTap probe descriptors)
+    Provider: redis
+    Name: call__end
+    Location: 0x0000000000044410, Base: 0x000000000018f970, Semaphore: 0x00000000001d10b4
+    Arguments: -4@80(%r12)
+```
+
+Adding new probes
+-----------------------
+
+New probes are added in the dtrace macro format:
+
+```c
+   /**
+    * Fired before a command is called
+    * @param id the command
+    */
+   probe my__probe(int my_arg);
+```
+
+This specifies the tracepoint signature, which can be called later like:
+
+```c
+a = 1
+TRACE_MY_PROBE(a);
+```
+
+If collecting an argument would be expensive, then it can be guarded with:
+
+```c
+if(UNLIKELY(REDIS_CALL_START_ENABLED())
+{
+...
+// expensive code to get an expensive_arg
+...
+
+  TRACE_CALL_START(expensive_arg);
+}
+```
+
+On Linux a maximum of only 6 arguments is supported so as a best practice is
+to not exceed 6 arguments to a tracepoint
+
+Performance
+==========
+
+Well-placed USDT tracepoints can help to solve performance problems. There is
+a cost associated with executing a USDT tracepoint that should be considered
+when tracing them.
+
+In some cases where overhead is necessary, the long-term benefit of performance
+gains may outweigh the short-term risk of performance losses while Redis is
+instrumented.
+
+Userspace Overhead
+---------------
+
+To minimize userspace overhead, the UNLIKELY macro is used to assist branch
+prediction and prevent instruction pipeline flushing. All TRACE macro calls
+are wrapped in an `UNLIKELY(REDIS_##name##_ENABLED())` check by default.
+This helps to ensure that if a tracepoint isn't attached to, it won't affect
+performance at all.
+
+If data for a tracepoint would be expensive, conditionally gathering this data
+can be gated by this same sort of check. This can allow for flexible data
+collection, but can also make the cost of executing a probe measurable,
+especially if the code being probed runs frequently.
+
+Kernel overhead
+---------------
+
+Each time a tracepoint is executed with a probe attached to it, the Kernel will
+run code in order to collect this information for a debugger like dtrace, gdb,
+or bpftrace.
+
+On Linux, this is easy to model, examining the disassembly of an eBPF probe
+shows the instructions that would be executed on each tracepoint probe
+invocation.
+
+In general, the overhead should be lower than other methods to obtain this
+data.
+
+
+To-Do List
+==========
+
+Connection tracing
+-----------------------
+
+Base this off of memcached connection tracepoints
+
+
+Trace command processing
+-----------------------
+


### PR DESCRIPTION
An initial WIP/draft at providing USDT / dtrace support to Redis per https://github.com/antirez/redis/issues/93

Tested only on Linux for now, but it generates the correct ELF notes:

```
Displaying notes found in: .note.stapsdt
  Owner                 Data size       Description
  stapsdt              0x00000036       NT_STAPSDT (SystemTap probe descriptors)
    Provider: redis
    Name: call__start
    Location: 0x0000000000044003, Base: 0x000000000018f970, Semaphore: 0x00000000001d10b2
    Arguments: -4@80(%rbx)
  stapsdt              0x00000034       NT_STAPSDT (SystemTap probe descriptors)
    Provider: redis
    Name: call__end
    Location: 0x000000000004400e, Base: 0x000000000018f970, Semaphore: 0x00000000001d10b4
    Arguments: -4@80(%rbx)

```

# To do

* [ ] Documentation to enable this and basic usage
* [ ] Some basic useful probes, picking up from https://github.com/antirez/redis/compare/unstable...videlalvaro:dtrace and looking at eg memcached probe definitions for inspiration, finding the best spot for these in Redis to start off.
* [ ] Add tests for at least ensuring probes were built in through, eg, readelf on linux. Ideally an e2e test?


