### PR TITLE
Signal systemd readiness atfer Partial Resync

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2172,6 +2172,10 @@ void syncWithMaster(connection *conn) {
 
     if (psync_result == PSYNC_CONTINUE) {
         serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Master accepted a Partial Resynchronization.");
+        if (server.supervised_mode == SUPERVISED_SYSTEMD) {
+            redisCommunicateSystemd("STATUS=MASTER <-> REPLICA sync: Partial Resynchronization accepted. Ready to accept connections.\n");
+            redisCommunicateSystemd("READY=1\n");
+        }
         return;
     }
 


### PR DESCRIPTION
An oversight on my part leads to a situation where a ``redis-server`` replica won't correctly tell its supervising systemd instance that it's in ready state when *Partial Resynchronsiation* finishes successfully. This is a rather common scenario, but my initial suite of experiments/tests apparently failed to cover it. I apologize for any inconvenice this may have caused.

I'd be very thankful for another pair of eyes going over the possible states in ``replication.c:syncWithMaster()`` to maybe spot similar instances of this kind of problem - I'm not certain that the fallback path that's using ''SYNC'' is correctly covered yet, for example.