### PR TITLE
Mark extern definition of SDS_NOINIT in sds.h

### DIFF
--- a/src/sds.h
+++ b/src/sds.h
@@ -34,7 +34,7 @@
 #define __SDS_H
 
 #define SDS_MAX_PREALLOC (1024*1024)
-const char *SDS_NOINIT;
+extern const char *SDS_NOINIT;
 
 #include <sys/types.h>
 #include <stdarg.h>


### PR DESCRIPTION
This helps avoiding multiple definition of this variable, its also
defined globally in sds.c


Signed-off-by: Khem Raj <raj.khem@gmail.com>