### PR TITLE
Add REDISMODULE_CTX_FLAGS_MULTI_DIRTY.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1842,6 +1842,12 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
          flags |= REDISMODULE_CTX_FLAGS_REPLICATED;
     }
 
+    /* For DIRTY flags, we need the blocked client if used */
+    client *c = ctx->blocked_client ? ctx->blocked_client->client : ctx->client;
+    if (c && (c->flags & (CLIENT_DIRTY_CAS|CLIENT_DIRTY_EXEC))) {
+        flags |= REDISMODULE_CTX_FLAGS_MULTI_DIRTY;
+    }
+
     if (server.cluster_enabled)
         flags |= REDISMODULE_CTX_FLAGS_CLUSTER;
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -110,6 +110,8 @@
 #define REDISMODULE_CTX_FLAGS_REPLICA_IS_ONLINE (1<<17)
 /* There is currently some background process active. */
 #define REDISMODULE_CTX_FLAGS_ACTIVE_CHILD (1<<18)
+/* The next EXEC will fail due to dirty CAS (touched keys). */
+#define REDISMODULE_CTX_FLAGS_MULTI_DIRTY (1<<19)
 
 /* Keyspace changes notification classes. Every class is associated with a
  * character for configuration purposes.


### PR DESCRIPTION
This exposes to modules the fact that the current client has watched keys which are dirty, so a `MULTI/EXEC` sequence is going to fail.
