### PR TITLE
Fix tests/cluster/cluster.tcl about wrong usage of lrange.

### DIFF
--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -21,7 +21,7 @@ proc get_cluster_nodes id {
             pong_recv [lindex $args 5] \
             config_epoch [lindex $args 6] \
             linkstate [lindex $args 7] \
-            slots [lrange $args 8 -1] \
+            slots [lrange $args 8 end] \
         ]
         lappend nodes $node
     }


### PR DESCRIPTION
It's trivial, but may help if you gonna use it to write cluster related tcl tests.