### PR TITLE
Fix potential crash after CONFIG SET maxclients.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2094,12 +2094,6 @@ static int updateMaxclients(long long val, long long prev, char **err) {
     /* Try to check if the OS is capable of supporting so many FDs. */
     if (val > prev) {
         adjustOpenFilesLimit();
-        if (server.maxclients != val) {
-            static char msg[128];
-            sprintf(msg, "The operating system is not able to handle the specified number of clients, try with %d", server.maxclients);
-            *err = msg;
-            return 0;
-        }
         if ((unsigned int) aeGetSetSize(server.el) <
             server.maxclients + CONFIG_FDSET_INCR)
         {
@@ -2109,6 +2103,12 @@ static int updateMaxclients(long long val, long long prev, char **err) {
                 *err = "The event loop API used by Redis is not able to handle the specified number of clients";
                 return 0;
             }
+        }
+        if (server.maxclients != val) {
+            static char msg[128];
+            sprintf(msg, "The operating system is not able to handle the specified number of clients, try with %d", server.maxclients);
+            *err = msg;
+            return 0;
         }
     }
     return 1;


### PR DESCRIPTION
Funcion adjustOpenFilesLimit() has an implicit parameter, which is server.maxclients.
This function aims to ajust maximum file descriptor number according to server.maxclients
by best effort, which is "bestlimit" could be lower than "maxfiles" but greater than "oldlimit".
When we try to increase "maxclients" using CONFIG SET command, we could increase maximum
file descriptor number to a bigger value without calling aeResizeSetSize the same time.
When later more and more clients connect to server, the allocated fd could be bigger and bigger,
and eventually exceeds events size of aeEventLoop.events, which would cause server crash.

In order to fix the above problem, we should ensure eventloop size after calling adjustOpenFilesLimit().

When dynamically set "maxclients", we consider it as failed when resulting "maxclients" is not the
same as expected.