### PR TITLE
add description geodist,geohash,geopos to geo.c

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -43,6 +43,9 @@ int zslValueLteMax(double value, zrangespec *spec);
  *   - geoadd - add coordinates for value to geoset
  *   - georadius - search radius by coordinates in geoset
  *   - georadiusbymember - search radius based on geoset member position
+ *   - geodist - calculate distance between two geoset members
+ *   - geohash - show geoset member position with geohash format
+ *   - geopos - show geoset member position with coordinates
  * ==================================================================== */
 
 /* ====================================================================


### PR DESCRIPTION
Add description geodist,geohash,geopos other than geoadd,georadius,georadiusbymember to geo.c

```
  *   - geoadd - add coordinates for value to geoset
  *   - georadius - search radius by coordinates in geoset
  *   - georadiusbymember - search radius based on geoset member position
+ *   - geodist - calculate distance between two geoset members
+ *   - geohash - show geoset member position with geohash format
+ *   - geopos - show geoset member position with coordinates
```