### PR TITLE
remove unnesessary include

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -29,7 +29,6 @@
 
 #include "server.h"
 #include "cluster.h"
-#include "atomicvar.h"
 
 #include <signal.h>
 #include <ctype.h>


### PR DESCRIPTION
db.c seems not to use atomicvar.h. So I removed including atomicvar.h.