### PR TITLE
fix function listCreate comment in adlist.c

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -33,11 +33,7 @@
 #include "adlist.h"
 #include "zmalloc.h"
 
-/* Create a new list. The created list can be freed with
- * AlFreeList(), but private value of every node need to be freed
- * by the user before to call AlFreeList().
- *
- * On error, NULL is returned. Otherwise the pointer to the new list. */
+/* On error, NULL is returned. Otherwise the pointer to the new list. */
 list *listCreate(void)
 {
     struct list *list;


### PR DESCRIPTION
the comment of function listCreate in adlist.c mention that use function AlFreeList to free the list, but function AlFreeList do not exist in the whole repo.
so maybe these comment should be delete.