### PR TITLE
Sentinel: avoid sentinel changes promoted_slave to be its own replica.

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -4308,7 +4308,7 @@ void sentinelFailoverDetectEnd(sentinelRedisInstance *master) {
             sentinelRedisInstance *slave = dictGetVal(de);
             int retval;
 
-            if (slave->flags & (SRI_RECONF_DONE|SRI_RECONF_SENT)) continue;
+            if (slave->flags & (SRI_PROMOTED|SRI_RECONF_DONE|SRI_RECONF_SENT)) continue;
             if (slave->link->disconnected) continue;
 
             retval = sentinelSendSlaveOf(slave,


### PR DESCRIPTION
When sentinel performs failover timeout，`promoted_slave` have a chance to be its own replica.

**Sentinel_Log:**
```c
34109:X 06 Jan 20:56:19.716 # +sdown master simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:56:19.771 # +odown master simulation-test-4 0.0.0.225 6404 #quorum 2/2
34109:X 06 Jan 20:56:19.771 # +new-epoch 41
34109:X 06 Jan 20:56:19.771 # +try-failover master simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:56:19.772 # +vote-for-leader aed5fbc7cc7b8c80b31906e5c032bf0f7d50be9e 41
34109:X 06 Jan 20:56:19.774 # f3e878776ad53ed8fc53aa61c0839878912b09a9 voted for aed5fbc7cc7b8c80b31906e5c032bf0f7d50be9e 41
34109:X 06 Jan 20:56:19.774 # 3d8a949910a43d0d01ae4a7624b44b1f7f030721 voted for aed5fbc7cc7b8c80b31906e5c032bf0f7d50be9e 41
34109:X 06 Jan 20:56:19.848 # +elected-leader master simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:56:19.849 # +failover-state-select-slave master simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:56:19.920 # +selected-slave slave 0.0.0.227:6404 0.0.0.227 6404 @ simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:56:19.920 * +failover-state-send-slaveof-noone slave 0.0.0.227:6404 0.0.0.227 6404 @ simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:56:19.976 * +failover-state-wait-promotion slave 0.0.0.227:6404 0.0.0.227 6404 @ simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:56:20.645 # +promoted-slave slave 0.0.0.227:6404 0.0.0.227 6404 @ simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:56:20.645 # +failover-state-reconf-slaves master simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:56:20.726 * +slave-reconf-sent slave 0.0.0.223:6404 0.0.0.223 6404 @ simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:56:20.885 # -odown master simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:56:21.670 * +slave-reconf-inprog slave 0.0.0.223:6404 0.0.0.223 6404 @ simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:57:45.653 # +failover-end-for-timeout master simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:57:45.653 # +failover-end master simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:57:45.653 * +slave-reconf-sent-be slave 0.0.0.223:6404 0.0.0.223 6404 @ simulation-test-4 0.0.0.225 6404
/* here */
34109:X 06 Jan 20:57:45.653 * +slave-reconf-sent-be slave 0.0.0.227:6404 0.0.0.227 6404 @ simulation-test-4 0.0.0.225 6404
34109:X 06 Jan 20:57:45.738 # +switch-master simulation-test-4 0.0.0.225 6404 0.0.0.227 6404
```

**Redis_Log:**
```c
19096:S 06 Jan 20:56:18.899 * MASTER <-> SLAVE sync started
19096:S 06 Jan 20:56:18.900 # Error condition on socket for SYNC: Connection refused
19096:S 06 Jan 20:56:19.902 * Connecting to MASTER 0.0.0.225:6404
19096:S 06 Jan 20:56:19.902 * MASTER <-> SLAVE sync started
19096:S 06 Jan 20:56:19.902 # Error condition on socket for SYNC: Connection refused
19096:M 06 Jan 20:56:19.976 * Discarding previously cached master state.
19096:M 06 Jan 20:56:19.976 * MASTER MODE enabled (user request from 'id=630 addr=0.0.0.227:55179 fd=12 name=sentinel-aed5fbc7-cmd age=5107 idle=0 flags=x db=0 sub=0 psub=0 multi=3 qbuf=0 qbuf-free=32768 obl=36 oll=0 omem=0 events=r cmd=exec')
19096:M 06 Jan 20:56:19.977 # CONFIG REWRITE executed with success.
19096:M 06 Jan 20:56:21.234 * Slave 0.0.0.223:6404 asks for synchronization
19096:M 06 Jan 20:56:21.234 * Full resync requested by slave 0.0.0.223:6404
19096:M 06 Jan 20:56:21.234 * Starting BGSAVE for SYNC with target: disk
19096:M 06 Jan 20:56:21.446 * Background saving started by pid 24064
24064:C 06 Jan 20:56:48.833 * DB saved on disk
24064:C 06 Jan 20:56:49.022 * RDB: 6 MB of memory used by copy-on-write
19096:M 06 Jan 20:56:49.382 * Background saving terminated with success
19096:M 06 Jan 20:56:50.127 * Synchronization with slave 0.0.0.223:6404 succeeded
19096:S 06 Jan 20:57:45.654 # Connection with slave 0.0.0.223:6404 lost.
/* here */
19096:S 06 Jan 20:57:45.654 * SLAVE OF 0.0.0.227:6404 enabled (user request from 'id=630 addr=0.0.0.227:55179 fd=12 name=sentinel-aed5fbc7-cmd age=5193 idle=0 flags=x db=0 sub=0 psub=0 multi=3 qbuf=0 qbuf-free=32768 obl=36 oll=0 omem=0 events=r cmd=exec')
19096:S 06 Jan 20:57:45.655 # CONFIG REWRITE executed with success.
19096:S 06 Jan 20:57:46.143 * Connecting to MASTER 0.0.0.227:6404
19096:S 06 Jan 20:57:46.143 * MASTER <-> SLAVE sync started
19096:S 06 Jan 20:57:46.143 * Non blocking connect for SYNC fired the event.
19096:S 06 Jan 20:57:46.143 * Master replied to PING, replication can continue...
19096:S 06 Jan 20:57:46.143 * Partial resynchronization not possible (no cached master)
19096:S 06 Jan 20:57:46.143 * Master does not support PSYNC or is in error state (reply: -ERR Can't SYNC while not connected with my master)
19096:S 06 Jan 20:57:46.143 * Retrying with SYNC...
19096:S 06 Jan 20:57:46.143 # MASTER aborted replication with an error: ERR Can't SYNC while not connected with my master
19096:S 06 Jan 20:57:47.145 * Connecting to MASTER 0.0.0.227:6404
19096:S 06 Jan 20:57:47.145 * MASTER <-> SLAVE sync started
19096:S 06 Jan 20:57:47.145 * Non blocking connect for SYNC fired the event.
19096:S 06 Jan 20:57:47.145 * Master replied to PING, replication can continue...
19096:S 06 Jan 20:57:47.145 * Partial resynchronization not possible (no cached master)
19096:S 06 Jan 20:57:47.145 * Master does not support PSYNC or is in error state (reply: -ERR Can't SYNC while not connected with my master)
19096:S 06 Jan 20:57:47.145 * Retrying with SYNC...
19096:S 06 Jan 20:57:47.145 # MASTER aborted replication with an error: ERR Can't SYNC while not connected with my master
```
