### PR TITLE
Update ae_select.c

### DIFF
--- a/src/ae_select.c
+++ b/src/ae_select.c
@@ -83,20 +83,18 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
 
     retval = select(eventLoop->maxfd+1,
                 &state->_rfds,&state->_wfds,NULL,tvp);
-    if (retval > 0) {
-        for (j = 0; j <= eventLoop->maxfd; j++) {
-            int mask = 0;
-            aeFileEvent *fe = &eventLoop->events[j];
+    for (j = 0; numevents < retval && j <= eventLoop->maxfd; j++) {
+        int mask = 0;
+        aeFileEvent *fe = &eventLoop->events[j];
 
-            if (fe->mask == AE_NONE) continue;
-            if (fe->mask & AE_READABLE && FD_ISSET(j,&state->_rfds))
-                mask |= AE_READABLE;
-            if (fe->mask & AE_WRITABLE && FD_ISSET(j,&state->_wfds))
-                mask |= AE_WRITABLE;
-            eventLoop->fired[numevents].fd = j;
-            eventLoop->fired[numevents].mask = mask;
-            numevents++;
-        }
+        if (fe->mask == AE_NONE) continue;
+        if (fe->mask & AE_READABLE && FD_ISSET(j,&state->_rfds))
+            mask |= AE_READABLE;
+        if (fe->mask & AE_WRITABLE && FD_ISSET(j,&state->_wfds))
+            mask |= AE_WRITABLE;
+        eventLoop->fired[numevents].fd = j;
+        eventLoop->fired[numevents].mask = mask;
+        numevents++;
     }
     return numevents;
 }


### PR DESCRIPTION
Reduce the number of select rounds.
On success select()  return the number of file descriptors contained in the three returned descriptor sets ( readfds,  writefds, exceptfds) which may be zero if the timeout expires before anything interesting happens.  On error, -1 is returned, and errno is set to indicate the error; the file descriptor sets are unmodified, and timeout becomes undefined.