### PR TITLE
Fix bug on KEYS command where pattern starts with * followed by \x00

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -602,7 +602,7 @@ void keysCommand(client *c) {
     void *replylen = addReplyDeferredLen(c);
 
     di = dictGetSafeIterator(c->db->dict);
-    allkeys = (pattern[0] == '*' && pattern[1] == '\0');
+    allkeys = (pattern[0] == '*' && plen == 1);
     while((de = dictNext(di)) != NULL) {
         sds key = dictGetKey(de);
         robj *keyobj;


### PR DESCRIPTION
Redis returns all keys if I use `KEYS` to pattern-match using a pattern that starts with *, followed by a null character.

Steps to reproduce:

1. On an empty database, do:
SET notZeroTerm 1
SET "zeroTerm\x00" 1
SET "zeroMid\x00End" 1

2. Do `KEYS "*\x00"`
**Expected:** 
"zeroTerm\x00"
**Actual:**
"zeroMid\x00End"
"notZeroTerm"
"zeroTerm\x00"

3. Do `KEYS "*\x00*"` to match keys that include a null character
**Expected:**
"zeroMid\x00End"
"zeroTerm\x00"
**Actual:**
"zeroMid\x00End"
"notZeroTerm"
"zeroTerm\x00"

The fix is a one-line correction in `db.c`

This bug is not present when using `SCAN`