### PR TITLE
Fix childinfo file descriptor leak

### DIFF
--- a/src/childinfo.c
+++ b/src/childinfo.c
@@ -34,6 +34,9 @@
  * RDB / AOF saving process from the child to the parent (for instance
  * the amount of copy on write memory used) */
 void openChildInfoPipe(void) {
+    serverAssert(server.child_info_pipe[0] == -1);
+    serverAssert(server.child_info_pipe[1] == -1);
+
     if (pipe(server.child_info_pipe) == -1) {
         /* On error our two file descriptors should be still set to -1,
          * but we call anyway cloesChildInfoPipe() since can't hurt. */


### PR DESCRIPTION
The leak happens if backgroundSaveDoneHandler() starts a new child
process (via updateSlavesWaitingBgsave()), which open a new ChildInfo
pipe, overwriting the not-yet-closed file descriptors in
server.child_info_pipe.