### PR TITLE
Put detailed error message for auth command

### DIFF
--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -11,7 +11,7 @@ start_server {tags {"acl"}} {
         r ACL setuser newuser >passwd1
         catch {r AUTH newuser passwd1} err
         set err
-    } {*WRONGPASS*}
+    } {*DISABLEDUSER*}
 
     test {Enabling the user allows the login} {
         r ACL setuser newuser on +acl


### PR DESCRIPTION
Put detailed error message for auth command for the following three error scenarios:
**Disabled User:**
acl setuser foo
OK
127.0.0.1:6379> auth foo 11
(error) DISABLEDUSER The user name specified was disabled

**Wrong Password:**
127.0.0.1:6379> ACL SETUSER alice on >p1pp0 ~cached:* +get
OK
127.0.0.1:6379> auth alice 333
(error) WRONGPASS The password specified for auth is not correct

**Wrong User:**
127.0.0.1:6379> auth ee 555
(error) WRONGUSER The user name specified for auth does not exist

passed make test:
  189 seconds - integration/replication
  223 seconds - integration/replication-psync

\o/ All tests passed without errors!

Cleanup: may take some time... OK