### PR TITLE
fix impl of aof-child whitelist SIGUSR1 feature.

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1797,14 +1797,15 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
         serverLog(LL_VERBOSE,
             "Background AOF rewrite signal handler took %lldus", ustime()-now);
     } else if (!bysignal && exitcode != 0) {
+        server.aof_lastbgrewrite_status = C_ERR;
+
+        serverLog(LL_WARNING,
+            "Background AOF rewrite terminated with error");
+    } else {
         /* SIGUSR1 is whitelisted, so we have a way to kill a child without
          * tirggering an error condition. */
         if (bysignal != SIGUSR1)
             server.aof_lastbgrewrite_status = C_ERR;
-        serverLog(LL_WARNING,
-            "Background AOF rewrite terminated with error");
-    } else {
-        server.aof_lastbgrewrite_status = C_ERR;
 
         serverLog(LL_WARNING,
             "Background AOF rewrite terminated by signal %d", bysignal);


### PR DESCRIPTION
if aof-rewrite child killed by SIGUSR1, redis-server should NOT flag `sever.aof_lastbgrewrite_status`
as `C_ERR`, but current impl will flag `server.aof_lastbgrewrite_status` as `C_ERR`. 

This PR fix the impl  aof-child whitelist SIGUSR1 feature.

see issue #6696 