### PR TITLE
[fix] overflow guard on setGenericCommand TTL conversion from seconds to milliseconds

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -76,9 +76,9 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
             return;
         }
         if (unit == UNIT_SECONDS){
-            if (milliseconds > INT_MAX / 1000){ /* Overflow. */
+            if (milliseconds > INT_MAX / 1000){
                 addReplyErrorFormat(c,"expire time value is out of range in %s",c->cmd->name);
-            }else{
+            } else {
                 milliseconds *= 1000;
             }
         }

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -75,7 +75,13 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
             addReplyErrorFormat(c,"invalid expire time in %s",c->cmd->name);
             return;
         }
-        if (unit == UNIT_SECONDS) milliseconds *= 1000;
+        if (unit == UNIT_SECONDS){
+            if (milliseconds > INT_MAX / 1000){ /* Overflow. */
+                addReplyErrorFormat(c,"expire time value is out of range in %s",c->cmd->name);
+            }else{
+                milliseconds *= 1000;
+            }
+        }
     }
 
     if ((flags & OBJ_SET_NX && lookupKeyWrite(c->db,key) != NULL) ||

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -419,4 +419,9 @@ start_server {tags {"string"}} {
         r set foo bar
         r getrange foo 0 4294967297
     } {bar}
+
+    test {Overflow guard on SET with TTL conversion from sec to ms, Github issue #6800} {
+        assert {[r set a b px 9223372036854775807] eq {OK}}
+        assert_error "*out of range*" {r set a b ex 9223372036854775807}
+    }
 }


### PR DESCRIPTION
On `SET` if we specify the expire time in milliseconds this will never happen due to the overflow guard on `getLongLongFromObjectOrReply->getLongLongFromObject->string2ll`
See example bellow
```
127.0.0.1:6379> SET a b PX 9223372036854775806
OK
127.0.0.1:6379> SET a b PX 9223372036854775807
(error) ERR value is not an integer or out of range
127.0.0.1:6379> SET a b EX 9223372036854775807
OK
```
The issue here is that we don't check for overflow when we internally convert from seconds to milliseconds.
fixes #6800 