### PR TITLE
Set ZSKIPLIST_MAXLEVEL to 32

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -335,7 +335,7 @@ typedef long long ustime_t; /* microsecond time type. */
 /* Anti-warning macro... */
 #define UNUSED(V) ((void) V)
 
-#define ZSKIPLIST_MAXLEVEL 64 /* Should be enough for 2^64 elements */
+#define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
 #define ZSKIPLIST_P 0.25      /* Skiplist P = 1/4 */
 
 /* Append only defines */


### PR DESCRIPTION
The optimal value given 2^64 elements and p=0.25 is:
`log base[1/p] 2^64 = 32`

Using `ZSKIPLIST_MAXLEVEL` = 64 instead of 32, we are:

- allocating 512 bytes per sorted set that are _never_ used. This is on the header node.
- a similar waste on the stack on every function where we have `zskiplistNode *update[ZSKIPLIST_MAXLEVEL]`
- the chance a node would get an unnecessarily high level because we are not capping where we should

The probability that a particular element reaches a level at least `k` is `p^k`, and the probability that any of the `n` elements reaches a level at least `k` is `n·p^k`.

It follows that if we use N = 2^64 as an upper bound on the number of elements in the skip list, the probability that **any of these** 2^64 elements reaches `level 33` is 1/4, `level 34` is 1/16, and so forth. 

It is in these cases, level > 32, that we want to cap the level in `int zslRandomLevel(void)`. As of now, even if we were able to create a zset of 2^64 elements, the probability of the cap `return (level<ZSKIPLIST_MAXLEVEL) ? level : ZSKIPLIST_MAXLEVEL` kicking in is 1/(2^64)

To illustrate, this is an actual level distribution I got on a sorted set of 2^20 = 1,048,576 elements:

Level | Elements
-- | --
1 | 786874
2 | 196554
3 | 48861
4 | 12271
5 | 2983
6 | 761
7 | 196
8 | 54
9 | 19
10 | 1
11 | 2

Note we don't get even close to the 20th level, and these two elements in the 11th level are the ones we should have capped to the 10th level if we were targeting a max capacity of 2^20 elements.

