### PR TITLE
fix ssl args check for redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1595,15 +1595,15 @@ static int parseOptions(int argc, char **argv) {
 #ifdef USE_OPENSSL
         } else if (!strcmp(argv[i],"--tls")) {
             config.tls = 1;
-        } else if (!strcmp(argv[i],"--sni")) {
+        } else if (!strcmp(argv[i],"--sni") && !lastarg) {
             config.sni = argv[++i];
-        } else if (!strcmp(argv[i],"--cacertdir")) {
+        } else if (!strcmp(argv[i],"--cacertdir") && !lastarg) {
             config.cacertdir = argv[++i];
-        } else if (!strcmp(argv[i],"--cacert")) {
+        } else if (!strcmp(argv[i],"--cacert") && !lastarg) {
             config.cacert = argv[++i];
-        } else if (!strcmp(argv[i],"--cert")) {
+        } else if (!strcmp(argv[i],"--cert") && !lastarg) {
             config.cert = argv[++i];
-        } else if (!strcmp(argv[i],"--key")) {
+        } else if (!strcmp(argv[i],"--key") && !lastarg) {
             config.key = argv[++i];
 #endif
         } else if (!strcmp(argv[i],"-v") || !strcmp(argv[i], "--version")) {
@@ -1701,12 +1701,13 @@ static void usage(void) {
 "  -c                 Enable cluster mode (follow -ASK and -MOVED redirections).\n"
 #ifdef USE_OPENSSL
 "  --tls              Establish a secure TLS connection.\n"
-"  --cacert           CA Certificate file to verify with.\n"
-"  --cacertdir        Directory where trusted CA certificates are stored.\n"
+"  --sni <host>       Server name indication for TLS.\n"
+"  --cacert <file>    CA Certificate file to verify with.\n"
+"  --cacertdir <dir>  Directory where trusted CA certificates are stored.\n"
 "                     If neither cacert nor cacertdir are specified, the default\n"
 "                     system-wide trusted root certs configuration will apply.\n"
-"  --cert             Client certificate to authenticate with.\n"
-"  --key              Private key file to authenticate with.\n"
+"  --cert <file>      Client certificate to authenticate with.\n"
+"  --key <file>       Private key file to authenticate with.\n"
 #endif
 "  --raw              Use raw formatting for replies (default when STDOUT is\n"
 "                     not a tty).\n"


### PR DESCRIPTION
redis-cli doesn't check ssl args, so if we don't pass a value to it, it will cause redis-cli aborted.

```
root@DESKTOP-UVUP1SF:/opt/redis# /opt/redis/src/redis-cli --tls  --cert /opt/myredis/redis.crt   --key /opt/myredis/redis.key   --cacert
zmalloc: Out of memory trying to allocate 18446744073709551608 bytes
Aborted (core dumped)
```

I think we should add `lastarg` check for these args and change ssl args's comments in `redis-cli --help`.

Signed-off-by: lifubang <lifubang@acmcoder.com>