### PR TITLE
moduleRDBLoadError, add key name, and use panic rather than exit

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3649,14 +3649,15 @@ void moduleRDBLoadError(RedisModuleIO *io) {
         io->error = 1;
         return;
     }
-    serverLog(LL_WARNING,
+    serverPanic(
         "Error loading data from RDB (short read or EOF). "
         "Read performed by module '%s' about type '%s' "
-        "after reading '%llu' bytes of a value.",
+        "after reading '%llu' bytes of a value "
+        "for key named: '%s'.",
         io->type->module->name,
         io->type->name,
-        (unsigned long long)io->bytes);
-    exit(1);
+        (unsigned long long)io->bytes,
+        io->key? (char*)io->key->ptr: "(null)");
 }
 
 /* Returns 0 if there's at least one registered data type that did not declare


### PR DESCRIPTION
using panic rather than exit means you get s stack trace of the code
path that experianced the error, and possibly other info.