### PR TITLE
Make test target self-contained

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -304,10 +304,10 @@ distclean: clean
 
 .PHONY: distclean
 
-test: $(REDIS_SERVER_NAME) $(REDIS_CHECK_AOF_NAME)
+test: $(REDIS_SERVER_NAME) $(REDIS_CLI_NAME) $(REDIS_BENCHMARK_NAME) $(REDIS_CHECK_AOF_NAME)
 	@(cd ..; ./runtest)
 
-test-sentinel: $(REDIS_SENTINEL_NAME)
+test-sentinel: $(REDIS_SENTINEL_NAME) $(REDIS_CLI_NAME)
 	@(cd ..; ./runtest-sentinel)
 
 check: test


### PR DESCRIPTION
This enables us to run `make test` after a `make clean`, but also
makes sure that any redis-cli change will be used in a test run.
Same for `make test-sentinel`