### PR TITLE
Update actions/checkout version in Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         platform: [ubuntu-latest, ubuntu-16.04]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: make
       run: make
     - name: test
@@ -23,6 +23,6 @@ jobs:
         platform: [macos-latest, macOS-10.14]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: make
       run: make


### PR DESCRIPTION
# Summary

Proposing updating the version of `actions/checkout` used in the GitHub Actions workflow to the latest - `v2`. Details: https://github.com/actions/checkout#checkout-v2