### PR TITLE
Fix the incorrect warning when password is provided on the command line

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1643,7 +1643,7 @@ static int parseOptions(int argc, char **argv) {
     }
 
     if (!config.no_auth_warning && config.auth != NULL) {
-        fputs("Warning: Using a password with '-a' or '-u' option on the command"
+        fputs("Warning: Using a password with '-a' or '--pass' option on the command"
               " line interface may not be safe.\n", stderr);
     }
 

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1643,7 +1643,7 @@ static int parseOptions(int argc, char **argv) {
     }
 
     if (!config.no_auth_warning && config.auth != NULL) {
-        fputs("Warning: Using a password with '-a' or '--pass' option on the command"
+        fputs("Warning: Using a password with '-u', '-a' or '--pass' option on the command"
               " line interface may not be safe.\n", stderr);
     }
 


### PR DESCRIPTION
Fix for issue #6883