### PR TITLE
Optimize __ziplistCascadeUpdate algorithm

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -179,7 +179,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <mach/memory_object_types.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -668,9 +668,12 @@ unsigned char *__ziplistCascadeUpdate(unsigned char *zl, unsigned char *p) {
 
     /* Update tail offset after loop. */
     if (tail == zl + prevoffset) {
-        /* Tail entry is included so increment tail by extra-delta. */
-        ZIPLIST_TAIL_OFFSET(zl) =
-            intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+extra-delta);
+        /* No need to update tail offset if there is only the
+         * tail entry to update. */
+        if (extra - delta != 0) {
+            ZIPLIST_TAIL_OFFSET(zl) =
+                intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+extra-delta);
+        }
     } else {
         ZIPLIST_TAIL_OFFSET(zl) =
             intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+extra);

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -2015,7 +2015,7 @@ int ziplistTest(int argc, char **argv) {
         verify(zl, e);
 
         assert(e[0].prevrawlensize == 1 && e[0].prevrawlen == 0);
-        compareHelper(zl, 'a', s1, 0);
+        assert(compareHelper(zl, 'a', s1, 0));
         ziplistRepr(zl);
 
         /* No expand. */
@@ -2023,10 +2023,10 @@ int ziplistTest(int argc, char **argv) {
         verify(zl, e);
 
         assert(e[0].prevrawlensize == 1 && e[0].prevrawlen == 0);
-        compareHelper(zl, 'b', s1, 0);
+        assert(compareHelper(zl, 'b', s1, 0));
 
         assert(e[1].prevrawlensize == 1 && e[1].prevrawlen == strEntryBytesSmall(s1));
-        compareHelper(zl, 'a', s1, 1);
+        assert(compareHelper(zl, 'a', s1, 1));
 
         ziplistRepr(zl);
 
@@ -2035,13 +2035,13 @@ int ziplistTest(int argc, char **argv) {
         verify(zl, e);
 
         assert(e[0].prevrawlensize == 1 && e[0].prevrawlen == 0);
-        compareHelper(zl, 'c', s2, 0);
+        assert(compareHelper(zl, 'c', s2, 0));
 
         assert(e[1].prevrawlensize == 5 && e[1].prevrawlen == strEntryBytesSmall(s2));
-        compareHelper(zl, 'b', s1, 1);
+        assert(compareHelper(zl, 'b', s1, 1));
 
         assert(e[2].prevrawlensize == 5 && e[2].prevrawlen == strEntryBytesLarge(s1));
-        compareHelper(zl, 'a', s1, 2);
+        assert(compareHelper(zl, 'a', s1, 2));
 
         ziplistRepr(zl);
 
@@ -2050,16 +2050,16 @@ int ziplistTest(int argc, char **argv) {
         verify(zl, e);
 
         assert(e[0].prevrawlensize == 1 && e[0].prevrawlen == 0);
-        compareHelper(zl, 'd', s2, 0);
+        assert(compareHelper(zl, 'd', s2, 0));
 
         assert(e[1].prevrawlensize == 5 && e[1].prevrawlen == strEntryBytesSmall(s2));
-        compareHelper(zl, 'c', s2, 1);
+        assert(compareHelper(zl, 'c', s2, 1));
 
         assert(e[2].prevrawlensize == 5 && e[2].prevrawlen == strEntryBytesLarge(s2));
-        compareHelper(zl, 'b', s1, 2);
+        assert(compareHelper(zl, 'b', s1, 2));
 
         assert(e[3].prevrawlensize == 5 && e[3].prevrawlen == strEntryBytesLarge(s1));
-        compareHelper(zl, 'a', s1, 3);
+        assert(compareHelper(zl, 'a', s1, 3));
 
         ziplistRepr(zl);
 
@@ -2069,13 +2069,13 @@ int ziplistTest(int argc, char **argv) {
         verify(zl, e);
 
         assert(e[0].prevrawlensize == 1 && e[0].prevrawlen == 0);
-        compareHelper(zl, 'd', s2, 0);
+        assert(compareHelper(zl, 'd', s2, 0));
 
         assert(e[1].prevrawlensize == 5 && e[1].prevrawlen == strEntryBytesSmall(s2));
-        compareHelper(zl, 'c', s2, 1);
+        assert(compareHelper(zl, 'c', s2, 1));
 
         assert(e[2].prevrawlensize == 5 && e[2].prevrawlen == strEntryBytesLarge(s2));
-        compareHelper(zl, 'a', s1, 2);
+        assert(compareHelper(zl, 'a', s1, 2));
 
         ziplistRepr(zl);
 

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -668,13 +668,14 @@ unsigned char *__ziplistCascadeUpdate(unsigned char *zl, unsigned char *p) {
 
     /* Update tail offset after loop. */
     if (tail == zl + prevoffset) {
-        /* No need to update tail offset if there is only the
-         * tail entry to update. */
+        /* When the the last entry we need to update is also the tail, update tail offset
+         * unless this is the only entry that was updated (so the tail offset didn't change). */
         if (extra - delta != 0) {
             ZIPLIST_TAIL_OFFSET(zl) =
                 intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+extra-delta);
         }
     } else {
+        /* Update the tail offset in cases where the last entry we updated is not the tail. */
         ZIPLIST_TAIL_OFFSET(zl) =
             intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+extra);
     }
@@ -697,7 +698,7 @@ unsigned char *__ziplistCascadeUpdate(unsigned char *zl, unsigned char *p) {
                 rawlen - cur.prevrawlensize);
         p -= (rawlen + delta);
         if (cur.prevrawlen == 0) {
-            /* Update cur's prevlen with firstentrylen. */
+            /* "cur" is the previous head entry, update its prevlen with firstentrylen. */
             zipStorePrevEntryLength(p, firstentrylen);
         } else {
             /* An entry's prevlen can only increment 4 bytes. */

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1447,17 +1447,6 @@ int ziplistTest(int argc, char **argv) {
     ziplistRepr(zl);
 
     zfree(zl);
-    {
-        char data[ZIP_BIG_PREVLEN];
-        zl = ziplistNew();
-        time_t start = time(NULL);
-        for (int i = 0; i < 100000; i++) {
-            zl = ziplistPush(zl, (unsigned char*)data, ZIP_BIG_PREVLEN-4, ZIPLIST_TAIL);
-        }
-        zl = ziplistPush(zl, (unsigned char*)data, ZIP_BIG_PREVLEN-3, ZIPLIST_HEAD);
-        printf("benchmark __ziplistCascadeUpdate elapsed %zd\n", time(NULL)-start);
-        zfree(zl);
-    }
 
     printf("Get element at index 3:\n");
     {
@@ -1973,6 +1962,19 @@ int ziplistTest(int argc, char **argv) {
     {
         stress(ZIPLIST_HEAD,100000,16384,256);
         stress(ZIPLIST_TAIL,100000,16384,256);
+    }
+
+    printf("Stress __ziplistCascadeUpdate:\n");
+    {
+        char data[ZIP_BIG_PREVLEN];
+        zl = ziplistNew();
+        for (int i = 0; i < 100000; i++) {
+            zl = ziplistPush(zl, (unsigned char*)data, ZIP_BIG_PREVLEN-4, ZIPLIST_TAIL);
+        }
+        unsigned long long start = usec();
+        zl = ziplistPush(zl, (unsigned char*)data, ZIP_BIG_PREVLEN-3, ZIPLIST_HEAD);
+        printf("Done. usec=%lld\n\n", usec()-start);
+        zfree(zl);
     }
 
     return 0;

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1450,7 +1450,7 @@ int ziplistTest(int argc, char **argv) {
             zl = ziplistPush(zl, (unsigned char*)data, ZIP_BIG_PREVLEN-4, ZIPLIST_TAIL);
         }
         zl = ziplistPush(zl, (unsigned char*)data, ZIP_BIG_PREVLEN-3, ZIPLIST_HEAD);
-        printf("benchmark __ziplistCascadeUpdat elapsed %zd\n", time(NULL)-start);
+        printf("benchmark __ziplistCascadeUpdate elapsed %zd\n", time(NULL)-start);
         zfree(zl);
     }
 

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -184,7 +184,6 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
-#include "adlist.h"
 #include "zmalloc.h"
 #include "util.h"
 #include "ziplist.h"

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1439,6 +1439,17 @@ int ziplistTest(int argc, char **argv) {
     ziplistRepr(zl);
 
     zfree(zl);
+    {
+        char data[ZIP_BIG_PREVLEN];
+        zl = ziplistNew();
+        time_t start = time(NULL);
+        for (int i = 0; i < 100000; i++) {
+            zl = ziplistPush(zl, (unsigned char*)data, ZIP_BIG_PREVLEN-4, ZIPLIST_TAIL);
+        }
+        zl = ziplistPush(zl, (unsigned char*)data, ZIP_BIG_PREVLEN-3, ZIPLIST_HEAD);
+        printf("benchmark __ziplistCascadeUpdat elapsed %zd\n", time(NULL)-start);
+        zfree(zl);
+    }
 
     printf("Get element at index 3:\n");
     {

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -666,11 +666,14 @@ unsigned char *__ziplistCascadeUpdate(unsigned char *zl, unsigned char *p) {
     /* Extra bytes is zero all update has been done(or no need to update). */
     if (extra == 0) return zl;
 
-    /* Update tail offset when there is more than one entry to update
-     * or the only one entry is not the tail. */
-    if (cnt != 1 || tail != zl + prevoffset) {
+    /* Update tail offset after loop. */
+    if (tail == zl + prevoffset) {
+        /* Tail entry is included so increment tail by extra-delta. */
         ZIPLIST_TAIL_OFFSET(zl) =
-            intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+delta);
+            intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+extra-delta);
+    } else {
+        ZIPLIST_TAIL_OFFSET(zl) =
+            intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+extra);
     }
 
     /* Now "p" points at the first unchanged byte in original ziplist,


### PR DESCRIPTION
Dear sir:
Current implementation of __ziplistCascadeUpdate is of O(n^2) time complexity. I try to optimize it with an algorithm of O(n) time complexity.
Here is the basic idea: 
1. loop ziplist to find how many extra bytes need to update the whole list
2. resize ziplist once and do update job from back to front

This PR has passed make test.