### PR TITLE
linenoise: Fix command matching

### DIFF
--- a/deps/linenoise/example.c
+++ b/deps/linenoise/example.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
             printf("echo: '%s'\n", line);
             linenoiseHistoryAdd(line); /* Add to the history. */
             linenoiseHistorySave("history.txt"); /* Save the history on disk. */
-        } else if (!strncmp(line,"/historylen",11)) {
+        } else if (!strncmp(line,"/historylen ", 12)) {
             /* The "/historylen" command will change the history len. */
             int len = atoi(line+11);
             linenoiseHistorySetMaxLen(len);


### PR DESCRIPTION
Any command starting with `/historylen` (e.g. `/historylength`) matched,
and `atoi` failed.