### PR TITLE
Fixes segfault on calling trackingGetTotalKeys

### DIFF
--- a/src/tracking.c
+++ b/src/tracking.c
@@ -441,5 +441,6 @@ uint64_t trackingGetTotalItems(void) {
 }
 
 uint64_t trackingGetTotalKeys(void) {
+    if (TrackingTable == NULL) return 0;
     return raxSize(TrackingTable);
 }


### PR DESCRIPTION
... with CSC disabled

Reproducible by calling `INFO`.
