### PR TITLE
Client side caching fixes

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2044,7 +2044,7 @@ void clientCommand(client *c) {
 "REPLY (on|off|skip)    -- Control the replies sent to the current connection.",
 "SETNAME <name>         -- Assign the name <name> to the current connection.",
 "UNBLOCK <clientid> [TIMEOUT|ERROR] -- Unblock the specified blocked client.",
-"TRACKING (on|off) [REDIRECT <id>] -- Enable client keys tracking for client side caching.",
+"TRACKING (on|off) [REDIRECT <id>] [BCAST] [PREFIX first] [PREFIX second] ... -- Enable client keys tracking for client side caching.",
 "GETREDIR               -- Return the client ID we are redirecting to when tracking is enabled.",
 NULL
         };
@@ -2234,17 +2234,22 @@ NULL
             if (!strcasecmp(c->argv[j]->ptr,"redirect") && moreargs) {
                 j++;
                 if (getLongLongFromObjectOrReply(c,c->argv[j],&redir,NULL) !=
-                    C_OK) return;
+                    C_OK)
+                {
+                    zfree(prefix);
+                    return;
+                }
                 /* We will require the client with the specified ID to exist
                  * right now, even if it is possible that it gets disconnected
                  * later. Still a valid sanity check. */
                 if (lookupClientByID(redir) == NULL) {
                     addReplyError(c,"The client ID you want redirect to "
                                     "does not exist");
+                    zfree(prefix);
                     return;
                 }
             } else if (!strcasecmp(c->argv[j]->ptr,"bcast")) {
-                bcast++;
+                bcast = 1;
             } else if (!strcasecmp(c->argv[j]->ptr,"prefix") && moreargs) {
                 j++;
                 prefix = zrealloc(prefix,sizeof(robj*)*(numprefix+1));

--- a/src/networking.c
+++ b/src/networking.c
@@ -2233,6 +2233,13 @@ NULL
 
             if (!strcasecmp(c->argv[j]->ptr,"redirect") && moreargs) {
                 j++;
+                if (redir != 0) {
+                    addReplyError(c,"A client can only redirect to a single "
+                                    "other client");
+                    zfree(prefix);
+                    return;
+                }
+
                 if (getLongLongFromObjectOrReply(c,c->argv[j],&redir,NULL) !=
                     C_OK)
                 {


### PR DESCRIPTION
The specific bugs:
1. If you call flushall, it deletes the tracking table so all subsequent calls fail. I fixed it by initializing a new one. Easy repro is just run flushall twice after tracking a client. 
2. You can do client tracking on bcast bcast to enable bcast, but issuing that again fails, so I made that consistent by setting bcast = 1. It's a minor thing.
3. Some cases memory might get leaked in client command if you construct a command with errors. 

Updated documentation to remove some references to slots and replace with keys, and updated the client help. 

There is also a second commit which is something I initially thought you could do while reading the API, which is to redirect to multiple clients, so I also added throwing a message so no one also tries that. (I'm not sure why some one would)