### PR TITLE
Cross initialization error

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5291,9 +5291,12 @@ try_again:
         goto socket_err;
 
     /* Read the RESTORE replies. */
-    int error_from_target = 0;
-    int socket_error = 0;
-    int del_idx = 1; /* Index of the key argument for the replicated DEL op. */
+    int error_from_target;
+    error_from_target = 0;
+    int socket_error;
+    socket_error = 0;
+    int del_idx; 
+    del_idx = 1; /* Index of the key argument for the replicated DEL op. */
 
     /* Allocate the new argument vector that will replace the current command,
      * to propagate the MIGRATE as a DEL command (if no COPY option was given).


### PR DESCRIPTION
This eliminates a cross initialization error when trying to compile redis with g++.

For testing purposes, its useful to be able to compile redis with c++ compiler and add unittesting framework around it. Unlike ansi C, c++ is not tolerant to cross initialization.

i.e. while this is not good coding practice, its still legal in C
```
{
  goto err;
  int a = 5;
err:
  a++; // In C this will compile, but a is undefined.
}
```
In c++ this produce compiler error

while not much better this:
```
{
  goto err;
  int a;
  a = 5;
err:
  a++; // Compile both in C and C++ and is still undefined.
}
```