### PR TITLE
[fix] bgrewriteaof should be forbidden when aof is off

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1629,6 +1629,8 @@ int rewriteAppendOnlyFileBackground(void) {
 }
 
 void bgrewriteaofCommand(client *c) {
+    if(server.aof_state == AOF_OFF)
+        addReplyError(c,"AOF is off, can not exec this command");
     if (server.aof_child_pid != -1) {
         addReplyError(c,"Background append only file rewriting already in progress");
     } else if (hasActiveChildProcess()) {


### PR DESCRIPTION
When aof is off,the bgrewriteaof command should be forbidden. 
If aof is off and a person A execute the bgrewrite command, after that anther person B decides to modify the appendonly to yes in redis.conf file and restart the server, we will get mistake. In this case, we expect the db is empty, but we may get a A-bgrewriteaof edition. The server will load the appendonly.aof created by A.