### PR TITLE
fix no-triggered rdb save in swapdb command

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1148,7 +1148,7 @@ void swapdbCommand(client *c) {
         addReplyError(c,"DB index is out of range");
         return;
     } else {
-        server.dirty++;
+        server.dirty += (dictSize(server.db[id1].dict) + dictSize(server.db[id2].dict));
         addReply(c,shared.ok);
     }
 }


### PR DESCRIPTION
127.0.0.1:6500> config get save

"save"
"10 5"
127.0.0.1:6500> dbsize
(integer) 1
127.0.0.1:6500> select 6
OK
127.0.0.1:6500[6]> dbsize
(integer) 5
127.0.0.1:6500[6]> lastsave
(integer) 1582467466
127.0.0.1:6500[6]> swapdb 0 6
OK
127.0.0.1:6500[6]> lastsave
(integer) 1582467466
127.0.0.1:6500[6]> lastsave
(integer) 1582467466
Save conndition is 10s at last 5 changes in DB, Although the size of db0 and db6 have 1 and 5 keys, after swapping db the rdb save was not triggered.