### PR TITLE
modify the read buf size according to the write buf size PROTO_IOBUF_LEN 

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1352,7 +1352,7 @@ void disklessLoadRestoreBackups(redisDb *backup, int restore, int empty_db_flags
 /* Asynchronously read the SYNC payload we receive from a master */
 #define REPL_MAX_WRITTEN_BEFORE_FSYNC (1024*1024*8) /* 8 MB */
 void readSyncBulkPayload(connection *conn) {
-    char buf[4096];
+    char buf[PROTO_IOBUF_LEN];
     ssize_t nread, readlen, nwritten;
     int use_diskless_load = useDisklessLoad();
     redisDb *diskless_load_backup = NULL;


### PR DESCRIPTION
read buffer size is set to 4096, while the write buffer is set to PROTO_IOBUF_LEN(16384).
So the read buffer size can also be modified to 16384 , this will take less time for large data sync.