### PR TITLE
Print error info if failed opening config file

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -546,7 +546,8 @@ void loadServerConfig(char *filename, char *options) {
         } else {
             if ((fp = fopen(filename,"r")) == NULL) {
                 serverLog(LL_WARNING,
-                    "Fatal error, can't open config file '%s'", filename);
+                    "Fatal error, can't open config file '%s': %s",
+                    filename, strerror(errno));
                 exit(1);
             }
         }


### PR DESCRIPTION
Thank you @djmgit for discovering this problem in issue https://github.com/antirez/redis/issues/6857
I consider that we just print `strerror` info because `fopen `will set `errno` if fails. And that includes all error cases.