### PR TITLE
To avoid compiler warnings

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1830,6 +1830,7 @@ void aclCommand(client *c) {
             case ACL_DENIED_CMD: reasonstr="command"; break;
             case ACL_DENIED_KEY: reasonstr="key"; break;
             case ACL_DENIED_AUTH: reasonstr="auth"; break;
+            default: reasonstr="unknown";
             }
             addReplyBulkCString(c,reasonstr);
 


### PR DESCRIPTION
To avoid compiler warnings in ` acl.c`
```
acl.c: In function ‘aclCommand’:
acl.c:1834:13: warning: ‘reasonstr’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             addReplyBulkCString(c,reasonstr);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
We set `reasonstr` is "unknown" defaultly.