### PR TITLE
Reserve one loopback connection for administrators possibly

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -892,6 +892,24 @@ void clientAcceptHandler(connection *conn) {
                           c);
 }
 
+/* Return C_OK if the connection comes from the loopback interface and
+ * current clients count (include the cluster bus connections) is the same
+ * as the 'maxclients'. For administrators, there will be a chance to adjust
+ * 'maxclients' or do somethings when client number has reached 'maxclients'. */
+int canAcceptLoopbackConnection(connection *conn, unsigned long clients_count) {
+    if (clients_count == server.maxclients) {
+        char cip[NET_IP_STR_LEN+1] = { 0 };
+        connPeerToString(conn, cip, sizeof(cip)-1, NULL);
+
+        if (!strcmp(cip, "127.0.0.1") || !strcmp(cip, "::1")) {
+            serverLog(LL_VERBOSE,
+                "Accept the loopback connection from %s", cip);
+            return C_OK;
+        }
+    }
+    return C_ERR;
+}
+
 #define MAX_ACCEPTS_PER_CALL 1000
 static void acceptCommonHandler(connection *conn, int flags, char *ip) {
     client *c;
@@ -912,8 +930,11 @@ static void acceptCommonHandler(connection *conn, int flags, char *ip) {
      * Admission control will happen before a client is created and connAccept()
      * called, because we don't want to even start transport-level negotiation
      * if rejected. */
-    if (listLength(server.clients) + getClusterConnectionsCount()
-        >= server.maxclients)
+    int ac_admin = C_ERR;
+    unsigned long clients_count = listLength(server.clients) +
+                                  getClusterConnectionsCount();
+    if (clients_count >= server.maxclients &&
+        (ac_admin = canAcceptLoopbackConnection(conn, clients_count)) == C_ERR)
     {
         char *err;
         if (server.cluster_enabled)
@@ -945,6 +966,9 @@ static void acceptCommonHandler(connection *conn, int flags, char *ip) {
 
     /* Last chance to keep flags */
     c->flags |= flags;
+
+    /* Set administrator flag for the client. */
+    if (ac_admin == C_OK) c->flags |= CLIENT_ONLY_ADMIN;
 
     /* Initiate accept.
      *

--- a/src/server.c
+++ b/src/server.c
@@ -3509,6 +3509,20 @@ int processCommand(client *c) {
         }
     }
 
+    /* Check if this connection is reserved for administrators, if yes, users
+     * only can execute administrative commands and auth command, so that,
+     * normal clients can't disturb administrators to do somethings when client
+     * number has reached 'maxclients'. */
+    if (c->flags & CLIENT_ONLY_ADMIN) {
+        if (!(c->cmd->flags & CMD_ADMIN) && c->cmd->proc != authCommand) {
+            addReplyErrorFormat(c, "You only can execute administrative commands"
+                " and auth command based on this connection, but '%s' is not one",
+                c->cmd->name);
+            c->flags |= CLIENT_CLOSE_AFTER_REPLY;
+            return C_ERR;
+        }
+    }
+
     /* Check if the user can run this command according to the current
      * ACLs. */
     int acl_keypos;

--- a/src/server.h
+++ b/src/server.h
@@ -113,7 +113,10 @@ typedef long long ustime_t; /* microsecond time type. */
 #define NET_IP_STR_LEN 46 /* INET6_ADDRSTRLEN is 46, but we need to be sure */
 #define NET_PEER_ID_LEN (NET_IP_STR_LEN+32) /* Must be enough for ip:port */
 #define CONFIG_BINDADDR_MAX 16
-#define CONFIG_MIN_RESERVED_FDS 32
+#define CONFIG_MIN_RESERVED_FDS 64 /* We reserve a number of file descriptors
+                                    * for extra operations of persistence, listening
+                                    * sockets, log files, pipes, one extra client
+                                    * connection and so forth. */
 
 #define ACTIVE_EXPIRE_CYCLE_SLOW 0
 #define ACTIVE_EXPIRE_CYCLE_FAST 1
@@ -256,6 +259,8 @@ typedef long long ustime_t; /* microsecond time type. */
                                              about writes performed by myself.*/
 #define CLIENT_IN_TO_TABLE (1ULL<<38) /* This client is in the timeout table. */
 #define CLIENT_PROTOCOL_ERROR (1ULL<<39) /* Protocol error chatting with it. */
+#define CLIENT_ONLY_ADMIN (1ULL<<40)  /* This client only can execute administrative
+                                       * commands and auth command. */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/tests/unit/limits.tcl
+++ b/tests/unit/limits.tcl
@@ -4,18 +4,75 @@ start_server {tags {"limits"} overrides {maxclients 10}} {
     } else {
         set expected_code "*ERR max*reached*"
     }
+    r config set requirepass 123
     test {Check if maxclients works refusing connections} {
         set c 0
         catch {
             while {$c < 50} {
-                incr c
-                set rd [redis_deferring_client]
-                $rd ping
+                set rd [redis [srv 0 "host"] [srv 0 "port"] 1 $::tls]
+                $rd auth 123
                 $rd read
+                incr c
                 after 100
             }
         } e
         assert {$c > 8 && $c <= 10}
         set e
     } $expected_code
+}
+
+start_server {tags {"maxclients"} overrides {maxclients 10}} {
+    r config set requirepass 123
+    test {Only admin commands based on the last connection} {
+        for {set c 0} {$c < 9} {incr c} {
+            set rd [redis [srv 0 "host"] [srv 0 "port"] 1 $::tls]
+            $rd auth 123
+            $rd read
+            after 100
+        }
+        # Can't execute 'set' command
+        set admin_set [redis [srv 0 "host"] [srv 0 "port"] 1 $::tls]
+        $admin_set auth 123
+        $admin_set read
+        catch {
+            $admin_set set a b
+            $admin_set read
+        } e
+        assert_match {*only can execute administrative commands*} $e
+
+        # Execute 'config' command, and we can create a new connection
+        # because last connection is closed by server
+        set admin_config [redis [srv 0 "host"] [srv 0 "port"] 1 $::tls]
+        $admin_config auth 123
+        $admin_config read
+        # Incr maxclients
+        $admin_config config set maxclients 20
+        $admin_config read
+
+        # We can create a new connection to execute 'set' command
+        set rd [redis [srv 0 "host"] [srv 0 "port"] 1 $::tls]
+        $rd auth 123
+        $rd read
+        $rd set a b
+        $rd read
+
+        # Only extra 9 connection remaining
+        if {$::tls} {
+            set expected_code "*I/O error*"
+        } else {
+            set expected_code "*ERR max*reached*"
+        }
+        set c 0
+        catch {
+            while {$c < 50} {
+                set rd [redis [srv 0 "host"] [srv 0 "port"] 1 $::tls]
+                $rd auth 123
+                $rd read
+                incr c
+                after 100
+            }
+        } e
+        assert {$c == 9}
+        assert_match $expected_code $e
+    }
 }


### PR DESCRIPTION
As we know, we couldn't connect to redis when client number has reached 'maxclients'. In the case, we may want to adjust `maxclients` but we can't. Maybe, most of clients come from other machines, so we can regard one loopback connection as an admin connection with a specific IP. Administrators may connect to redis and do somethings, that also is safe because we must login to the machine running the redis server.
For `fd`, we use one extra `fd`, but I think `CONFIG_MIN_RESERVED_FDS` is enough. There is no need to reserve more connections, even more connections will be run out if clients on the same machine keep making connections to redis. 
I know it can't solve the problem 100%, but there will be a chance that we can do something temporarily when client number has reached 'maxclients'.