### PR TITLE
Fix rpoplpush bug when src and dest is same

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -576,6 +576,13 @@ void rpoplpushCommand(client *c) {
         robj *touchedkey = c->argv[1];
 
         if (dobj && checkType(c,dobj,OBJ_LIST)) return;
+
+        /* the key is expired when src and dest is same */
+        if (!dobj && !sdscmp(c->argv[1]->ptr,c->argv[2]->ptr)) {
+            addReply(c,shared.null[c->resp]);
+            return;
+        }
+
         value = listTypePop(sobj,LIST_TAIL);
         /* We saved touched key, and protect it, since rpoplpushHandlePush
          * may change the client command argument vector (it does not


### PR DESCRIPTION
### Steps to reproduce:
1. In order to reproduce easily, `sleep` is added to the `rpoplpush` to simulate the situation of being expired.

```
void rpoplpushCommand(client *c) {
    robj *sobj, *value;
    if ((sobj = lookupKeyWriteOrReply(c,c->argv[1],shared.nullbulk)) == NULL ||
        checkType(c,sobj,OBJ_LIST)) return;

    if (listTypeLength(sobj) == 0) {
        /* This may only happen after loading very old RDB files. Recent
         * versions of Redis delete keys of empty lists. */
        addReply(c,shared.nullbulk);
    } else {
        sleep(20); // sleep some time, for key be expired

        robj *dobj = lookupKeyWrite(c->db,c->argv[2]);  // will expireIfNeeded
        robj *touchedkey = c->argv[1];

        if (dobj && checkType(c,dobj,OBJ_LIST)) return;
        value = listTypePop(sobj,LIST_TAIL);
        /* We saved touched key, and protect it, since rpoplpushHandlePush
         * may change the client command argument vector (it does not
         * currently). */
        incrRefCount(touchedkey);
        rpoplpushHandlePush(c,c->argv[2],dobj,value);

        /* listTypePop returns an object with its refcount incremented */
        decrRefCount(value);
}
```

2. use redis-cli
```
127.0.0.1:6379> lpush list 1 2 3 4 5
(integer) 5
127.0.0.1:6379> expire list 10
(integer) 1
127.0.0.1:6379> RPOPLPUSH list list
// wait some time, server will coredump
```

3. server stack path
```
    frame #4: 0x000000010206b65f redis-server`getDecodedObject(o=0x0000000000000000) at object.c:510
    frame #5: 0x00000001021087cf redis-server`listTypePush(subject=0x00000001063167e0, value=0x0000000000000000, where=0) at t_list.c:44
    frame #6: 0x00000001021175af redis-server`rpoplpushHandlePush(c=0x000000010997e180, dstkey=0x0000000105fcadb8, dstobj=0x00000001063167e0, value=0x0000000000000000) at t_list.c:559
    frame #7: 0x00000001021180b1 redis-server`rpoplpushCommand(c=0x000000010997e180) at t_list.c:586
    frame #8: 0x0000000101f922e2 redis-server`call(c=0x000000010997e180, flags=15) at server.c:2439
    frame #9: 0x0000000101f9cec5 redis-server`processCommand(c=0x000000010997e180) at server.c:2733
    frame #10: 0x0000000102047641 redis-server`processInputBuffer(c=0x000000010997e180) at networking.c:1470
    frame #11: 0x0000000102048c66 redis-server`processInputBufferAndReplicate(c=0x000000010997e180) at networking.c:1505
    frame #12: 0x000000010202a324 redis-server`readQueryFromClient(el=0x0000000105fcc0f0, fd=9, privdata=0x000000010997e180, mask=1) at networking.c:1587
    frame #13: 0x0000000101f3b621 redis-server`aeProcessEvents(eventLoop=0x0000000105fcc0f0, flags=11) at ae.c:443
    frame #14: 0x0000000101f407df redis-server`aeMain(eventLoop=0x0000000105fcc0f0) at ae.c:501
    frame #15: 0x0000000101fb23bd redis-server`main(argc=5, argv=0x00007ffeedcf0368) at server.c:4200
```

@antirez PING