### PR TITLE
Added BITFIELD_RO variants for read-only operations.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -238,6 +238,10 @@ struct redisCommand redisCommandTable[] = {
      "write use-memory @bitmap",
      0,NULL,1,1,1,0,0,0},
 
+    {"bitfield_ro",bitfieldroCommand,-2,
+     "read-only fast @bitmap",
+     0,NULL,1,1,1,0,0,0},
+
     {"setrange",setrangeCommand,4,
      "write use-memory @string",
      0,NULL,1,1,1,0,0,0},

--- a/src/server.h
+++ b/src/server.h
@@ -2171,6 +2171,7 @@ void existsCommand(client *c);
 void setbitCommand(client *c);
 void getbitCommand(client *c);
 void bitfieldCommand(client *c);
+void bitfieldroCommand(client *c);
 void setrangeCommand(client *c);
 void getrangeCommand(client *c);
 void incrCommand(client *c);

--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -199,3 +199,34 @@ start_server {tags {"bitops"}} {
         r del mystring
     }
 }
+
+start_server {tags {"repl"}} {
+    start_server {} {
+        set master [srv -1 client]
+        set master_host [srv -1 host]
+        set master_port [srv -1 port]
+        set slave [srv 0 client]
+
+        test {setup slave} {
+            $slave slaveof $master_host $master_port
+            wait_for_condition 50 100 {
+                [s 0 master_link_status] eq {up}
+            } else {
+                fail "Replication not started."
+            }
+        }
+
+        test {write on master, read on slave} {
+            $master del bits
+            assert_equal 0 [$master bitfield bits set u8 0 255]
+            assert_equal 255 [$master bitfield bits set u8 0 100]
+            wait_for_ofs_sync $master $slave
+            assert_equal 100 [$slave bitfield_ro bits get u8 0]
+        }
+
+        test {bitfield_ro with write option} {
+            catch {$slave bitfield_ro bits set u8 0 100 get u8 0} err
+            assert_match {*ERR bitfield_ro only support get subcommand*} $err
+        }
+    }
+}


### PR DESCRIPTION
@antirez Hello

We encountered some massive read by using the `BITFIELD` command of many users, which is much similar to `GEORADIUS` case. 

It can't be scattered to read-only slaves, please refer to #4084, I searched the previous `Issues` and `PR`, but no relevant discussion found. Hereby I submitted the `PR` accordingly.

By introducing a new command `BITFIELD_RO`, the performance increases dramatically in read-write separated Redis. 

The `BITFIELD get xxx` is going to be executed in slaves by special proxies, especially in the scenario of more reading and less writing.

PR is listed above, please advise!

I will check whether other APIs have mixed read and write permissions, please let us know if there's the further job.