### PR TITLE
[fix and optimization]fix "memory leak" when the user switches from "appendonly yes" to "appendonly no" and improve the memory efficiency of aof_buf

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -236,6 +236,12 @@ void killAppendOnlyChild(void) {
 void stopAppendOnly(void) {
     serverAssert(server.aof_state != AOF_OFF);
     flushAppendOnlyFile(1);
+    
+    if(sdsalloc(server.aof_buf) > 0){
+        sdsfree(server.aof_buf);
+        server.aof_buf = sdsempty();
+    }
+
     redis_fsync(server.aof_fd);
     close(server.aof_fd);
 
@@ -1781,8 +1787,12 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
 
             /* Clear regular AOF buffer since its contents was just written to
              * the new AOF from the background rewrite buffer. */
-            sdsfree(server.aof_buf);
-            server.aof_buf = sdsempty();
+            if ((sdslen(server.aof_buf)+sdsavail(server.aof_buf)) < 4000) {
+                sdsclear(server.aof_buf);
+            } else {
+                sdsfree(server.aof_buf);
+                server.aof_buf = sdsempty();
+           }
         }
 
         server.aof_lastbgrewrite_status = C_OK;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1175,10 +1175,7 @@ int rdbSaveRio(rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi) {
         if (rdbSaveType(rdb,RDB_OPCODE_SELECTDB) == -1) goto werr;
         if (rdbSaveLen(rdb,j) == -1) goto werr;
 
-        /* Write the RESIZE DB opcode. We trim the size to UINT32_MAX, which
-         * is currently the largest type we are able to represent in RDB sizes.
-         * However this does not limit the actual size of the DB to load since
-         * these sizes are just hints to resize the hash tables. */
+        /* Write the RESIZE DB opcode. */
         uint64_t db_size, expires_size;
         db_size = dictSize(db->dict);
         expires_size = dictSize(db->expires);


### PR DESCRIPTION
1.There is at most about 4k "memory leak" when user switches from "appendonly yes" to "appendonly no"  at runtime using the CONFIG command unless no write commands are sent between aof-rewrite and "config set appendonly no". The memory won't be used until the user switches back.

2.Improve the memory efficiency of server.aof_buf like flushAppendOnlyFile does.