### PR TITLE
Fix bug of tcl test using external server

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -159,9 +159,12 @@ proc start_server {options {code undefined}} {
     if {$::external} {
         if {[llength $::servers] == 0} {
             set srv {}
+            # In test_server_main(tests/test_helper.tcl:215~218), increase the value of start_port
+            # and assign it to ::port through the `--port` option, so we need to reduce it.
+            set baseport [expr {$::port-100}]
             dict set srv "host" $::host
-            dict set srv "port" $::port
-            set client [redis $::host $::port 0 $::tls]
+            dict set srv "port" $baseport
+            set client [redis $::host $baseport 0 $::tls]
             dict set srv "client" $client
             $client select 9
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -505,6 +505,9 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     } elseif {$opt eq {--host}} {
         set ::external 1
         set ::host $arg
+        # If we use an external server, we can only set numclients to 1,
+        # otherwise the port will be miscalculated.
+        set ::numclients 1
         incr j
     } elseif {$opt eq {--port}} {
         set ::port $arg


### PR DESCRIPTION
### Steps to reproduce:

1. Run tcl test with external server

```
➜  redis git:(unstable) ✗ ./runtest --host $external_ip --port 6379 --single unit/type/string
Cleanup: may take some time... OK
Starting test server at port 11111
[ready]: 64884
Testing unit/printver
[ready]: 64880
Testing unit/dump
[ready]: 64883
Testing unit/auth
[ready]: 64881
Testing unit/protocol
[exception]: Executing test client: couldn't open socket: connection refused.
couldn't open socket: connection refused
    while executing
"socket $server $port"
    (procedure "redis" line 7)
    invoked from within
"redis $::host $::port 0 $::tls"
    (procedure "start_server" line 9)
    invoked from within
"start_server {tags {"dump"}} {
    test {DUMP / RESTORE are able to serialize / unserialize a simple key} {
        r set foo bar
        set encoded ..."
    (file "tests/unit/dump.tcl" line 1)
    invoked from within
"source $path"
    (procedure "execute_tests" line 4)
    invoked from within
"execute_tests $data"
    (procedure "test_client_main" line 10)
    invoked from within
"test_client_main $::test_server_port "
```
Similar to this question，[using external redis server for testing tcl scripts](https://stackoverflow.com/questions/10390008/using-external-redis-server-for-testing-tcl-scripts).

### Reason

1. In `test_server_main`,`::port` will be reset via the `--port` option
```
    set start_port [expr {$::port+100}]
    for {set j 0} {$j < $::numclients} {incr j} {
        set start_port [find_available_port $start_port]  // Calculate new start_port
        set p [exec $tclsh [info script] {*}$::argv \
            --client $port --port $start_port &]      // --port will reset ::port
        lappend ::clients_pids $p
        incr start_port 10
    }
```

2. When connecting to Redis in `start_server`,  the `::port` error, increased by 100
```
    if {$::external} {
        if {[llength $::servers] == 0} {
            set srv {}
            dict set srv "host" $::host 
            dict set srv "port" $::port  // the port is increased by 100
            set client [redis $::host $::port 0 $::tls]
            dict set srv "client" $client
            $client select 9

            # append the server to the stack
            lappend ::servers $srv
        }
        uplevel 1 $code
        return
    }
```

### Fix
see the PR.

### Result
```
➜  redis git:(fix-tcl-test-host-option) ✗ ./runtest --host $ip --port 6379 --single unit/type/string
Cleanup: may take some time... OK
Starting test server at port 11111
[ready]: 65696
Testing unit/type/string
[ok]: SET and GET an item
[ok]: SET and GET an empty item
...
```


### Notice

1. This fix only supports the case where `:: numclients` is 1. Of course, if you use an external server, setting`::numclients` too large doesn't make sense, because there is only one server.
2. Some test cases fail, for example `overrides {requirepass foobar}` needs to pass parameters, but the external server has already started at this time.


@antirez Please review in your free time, thank you.