### PR TITLE
Threaded IO: bugfix client kill may crash redis

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3036,16 +3036,22 @@ int handleClientsWithPendingReadsUsingThreads(void) {
     if (tio_debug) printf("I/O READ All threads finshed\n");
 
     /* Run the list of clients again to process the new buffers. */
-    listRewind(server.clients_pending_read,&li);
-    while((ln = listNext(&li))) {
+    while(listLength(server.clients_pending_read)) {
+        ln = listFirst(server.clients_pending_read);
         client *c = listNodeValue(ln);
         c->flags &= ~CLIENT_PENDING_READ;
+        listDelNode(server.clients_pending_read,ln);
+
         if (c->flags & CLIENT_PENDING_COMMAND) {
-            c->flags &= ~ CLIENT_PENDING_COMMAND;
-            processCommandAndResetClient(c);
+            c->flags &= ~CLIENT_PENDING_COMMAND;
+            if (processCommandAndResetClient(c) == C_ERR) {
+                /* If the client is no longer valid, we avoid
+                 * processing the client later. So we just go
+                 * to the next. */
+                continue;
+            }
         }
         processInputBufferAndReplicate(c);
     }
-    listEmpty(server.clients_pending_read);
     return processed;
 }


### PR DESCRIPTION
```
=== REDIS BUG REPORT START: Cut & paste starting from here ===
100338:M 15 Mar 2020 23:10:06.572 # Redis 999.999.999 crashed by signal: 11
100338:M 15 Mar 2020 23:10:06.572 # Crashed running the instruction at: 0x444810
100338:M 15 Mar 2020 23:10:06.572 # Accessing address: 0xffffffffffffffff
100338:M 15 Mar 2020 23:10:06.572 # Failed assertion: <no assertion failed> (<no file>:0)

------ STACK TRACE ------
EIP:
./redis-server *:6379(processInputBuffer+0x10)[0x444810]

Backtrace:
./redis-server *:6379(logStackTrace+0x29)[0x4724a9]
./redis-server *:6379(sigsegvHandler+0xa6)[0x472b46]
/lib64/libpthread.so.0(+0xf620)[0x7fae3d11e620]
./redis-server *:6379(processInputBuffer+0x10)[0x444810]
./redis-server *:6379(handleClientsWithPendingReadsUsingThreads+0x16d)[0x44534d]
./redis-server *:6379(aeProcessEvents+0x3d5)[0x42d805]
./redis-server *:6379(aeMain+0x2b)[0x42d9ab]
./redis-server *:6379(main+0x4c4)[0x42a474]
/lib64/libc.so.6(__libc_start_main+0xf5)[0x7fae3cd63445]
./redis-server *:6379[0x42a6fd]
```

Redis crashes if we send `CLIENT KILL TYPE NORMAL` in io-threads-do-reads mode and io threads are active.

The reason is the way we iterator the `server.clients_pending_read` list:

```c
    /* Run the list of clients again to process the new buffers. */
    listRewind(server.clients_pending_read,&li);
    while((ln = listNext(&li))) {
        client *c = listNodeValue(ln);
        c->flags &= ~CLIENT_PENDING_READ;
        if (c->flags & CLIENT_PENDING_COMMAND) {
            c->flags &= ~ CLIENT_PENDING_COMMAND;
            processCommandAndResetClient(c);
        }
        processInputBufferAndReplicate(c);
    }
```

After `listNext` the iterator has already get the next pointer, but during `processCommand`, some client and the current client may be freed, just like `CLIENT KILL` or write error in `flushSlavesOutputBuffers`.

After PR #6989, list `server.clients_pending_read` never grow during we loop it, so we can just check the list length to end the loop.