### PR TITLE
Threaded IO: handle pending reads clients ASAP after event loop

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2088,6 +2088,9 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
 void beforeSleep(struct aeEventLoop *eventLoop) {
     UNUSED(eventLoop);
 
+    /* We should handle pending reads clients ASAP after event loop. */
+    handleClientsWithPendingReadsUsingThreads();
+
     /* Handle TLS pending data. (must be done before flushAppendOnlyFile) */
     tlsProcessPendingData();
     /* If tls still has pending unread data don't sleep at all. */
@@ -2157,7 +2160,6 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
 void afterSleep(struct aeEventLoop *eventLoop) {
     UNUSED(eventLoop);
     if (moduleCount()) moduleAcquireGIL();
-    handleClientsWithPendingReadsUsingThreads();
 }
 
 /* =========================== Server initialization ======================== */


### PR DESCRIPTION
Move `handleClientsWithPendingReadsUsingThreads` from `afterSleep` to `beforeSleep`, because the `afterSleep` is processed after the next system call `epoll_wait` and that may delay the pending reads clients processed, I think the right place to handle the clients is after the current event loop ASAP. This can get 10% performance improvement. 