### PR TITLE
Support Redis Cluster Proxy PROXY INFO command

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1292,7 +1292,11 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
         (argc == 3 && !strcasecmp(command,"latency") &&
                        !strcasecmp(argv[1],"graph")) ||
         (argc == 2 && !strcasecmp(command,"latency") &&
-                       !strcasecmp(argv[1],"doctor")))
+                       !strcasecmp(argv[1],"doctor")) ||
+        /* Format PROXY INFO command for Redis Cluster Proxy:
+         * https://github.com/artix75/redis-cluster-proxy */
+        (argc >= 2 && !strcasecmp(command,"proxy") &&
+                       !strcasecmp(argv[1],"info")))
     {
         output_raw = 1;
     }


### PR DESCRIPTION
Redis Cluster Proxy (https://github.com/RedisLabs/redis-cluster-proxy) is a proxy for Redis Clusters.
It has an internal command named `PROXY` that can be used to perform various proxy-related tasks,
via different subcommands.

One of these is `PROXY INFO` that works in a similar fashion to the classic `INFO` command in Redis but returning proxy-related info.

This pull request allows formatting the output from`PROXY INFO` as a raw string, in the same way of the output from Redis `INFO` command.