### PR TITLE
Support cross-compiling for uClibc targets

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -62,7 +62,7 @@
 #endif
 
 /* Test for backtrace() */
-#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || \
+#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__) && !defined(__UCLIBC__)) || \
     defined(__FreeBSD__) || (defined(__OpenBSD__) && defined(USE_BACKTRACE))\
  || defined(__DragonFly__)
 #define HAVE_BACKTRACE 1


### PR DESCRIPTION
This patch fixes redis so that it can be compiled
against uclibc.  Patch originates from:

  Support cross-compiling for uClibc targets
  https://github.com/antirez/redis/pull/537
  Mike Steinert, mike.steinert@gmail.com

Signed-off-by: Daniel Price <daniel.price@gmail.com>
[Martin: adapt to 3.0.3]
Signed-off-by: Martin Bark <martin@barkynet.com>
[Titouan: adapt to 5.0.4]
Signed-off-by: Titouan Christophe <titouan.christophe@railnova.eu>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/redis/0001-uclibc.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>