### PR TITLE
Fix Bug for Client Side Caching: Unexpected Behaviour when Switching between OPTIN/OPTOUT Mode

### DIFF
--- a/src/tracking.c
+++ b/src/tracking.c
@@ -271,7 +271,7 @@ void trackingInvalidateKey(robj *keyobj) {
         trackingRememberKeyToBroadcast(sdskey,sdslen(sdskey));
 
     rax *ids = raxFind(TrackingTable,(unsigned char*)sdskey,sdslen(sdskey));
-    if (ids == raxNotFound) return;;
+    if (ids == raxNotFound) return;
 
     raxIterator ri;
     raxStart(&ri,ids);

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -94,7 +94,7 @@ void disableTracking(client *c) {
         server.tracking_clients--;
         c->flags &= ~(CLIENT_TRACKING|CLIENT_TRACKING_BROKEN_REDIR|
                       CLIENT_TRACKING_BCAST|CLIENT_TRACKING_OPTIN|
-                      CLIENT_TRACKING_OPTOUT);
+                      CLIENT_TRACKING_OPTOUT|CLIENT_TRACKING_CACHING);
     }
 }
 


### PR DESCRIPTION
Before this PR, the following unexpected scenario was seen when we switch from OPTIN/OPTOUT mode:
**Client 1:** 
127.0.0.1:6801> client tracking on redirect 8 optin
OK
127.0.0.1:6801> client caching yes
OK
127.0.0.1:6801> client tracking off
OK
127.0.0.1:6801> client tracking on redirect 8 optout
OK
127.0.0.1:6801> get foo
"bar"

Then we set foo value to a different one in another client:
**Client 2:**
127.0.0.1:6801> set foo barr
OK
127.0.0.1:6801> 

The epected behaviour is in OPTOUT mode, we should get invalidate message as default when the tracking key changes, however this doesn't happen in the redirect channnel..no invalidate message was sent....
**Invalidate Channnel Client**
127.0.0.1:6801> client id
(integer) 8
127.0.0.1:6801> subscribe __redis__:invalidate
Reading messages... (press Ctrl-C to quit)
1) "subscribe"
2) "__redis__:invalidate"
3) (integer) 1


**Reason:**
When we disable the tracking we should clear CLIENT_TRACKING_CACHING flags in as well, inn order to clear the incluence from previous caching status...
