### PR TITLE
Fix bitfield.tcl error message

### DIFF
--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -226,7 +226,7 @@ start_server {tags {"repl"}} {
 
         test {bitfield_ro with write option} {
             catch {$slave bitfield_ro bits set u8 0 100 get u8 0} err
-            assert_match {*ERR bitfield_ro only support get subcommand*} $err
+            assert_match {*ERR BITFIELD_RO only support the GET subcommand*} $err
         }
     }
 }


### PR DESCRIPTION
@antirez Thank you very much for accepting BITFIELD_RO #6951, but due to [Minor changes](https://github.com/antirez/redis/commit/38514e3c8dd9ad6c0b788c25afa7db38aa26f5c3) to BITFIELD_RO PR , the tcl test failed, so I submitted this fix.

If this is not the best test method, please tell me how to modify it.