### PR TITLE
fix: dict.c->dictResize()->minimal  type

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -134,7 +134,7 @@ int _dictInit(dict *d, dictType *type,
  * but with the invariant of a USED/BUCKETS ratio near to <= 1 */
 int dictResize(dict *d)
 {
-    int minimal;
+    unsigned long minimal;
 
     if (!dict_can_resize || dictIsRehashing(d)) return DICT_ERR;
     minimal = d->ht[0].used;


### PR DESCRIPTION
minimal type is int.  I think would it is unsigned long.
when d->ht[0].used > 4294967296.  minimal will overflow, become negative. so will not trigger rehash in dictExpand();
but in 64bit system，the ULONG_MAX is 0x7fffffffffffffffL。 I think it should trigger  rehash.