### PR TITLE
issue #7034 - add support for AUTH with u/p for Migrate command

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5098,11 +5098,11 @@ void migrateCloseTimedoutSockets(void) {
     dictReleaseIterator(di);
 }
 
-/* MIGRATE host port key dbid timeout [COPY | REPLACE | AUTH password]
+/* MIGRATE host port key dbid timeout [COPY | REPLACE | AUTH [username] password]
  *
  * On in the multiple keys form:
  *
- * MIGRATE host port "" dbid timeout [COPY | REPLACE | AUTH password] KEYS key1
+ * MIGRATE host port "" dbid timeout [COPY | REPLACE | AUTH [username] password] KEYS key1
  * key2 ... keyN */
 void migrateCommand(client *c) {
     migrateCachedSocket *cs;

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -365,4 +365,32 @@ start_server {tags {"dump"}} {
             assert_match {*WRONGPASS*} $err
         }
     }
+
+    test {MIGRATE AUTH: correct and wrong username and password cases} {
+        set first [srv 0 client]
+        r del list
+        r lpush list a b c d
+        start_server {tags {"repl"}} {
+            set second [srv 0 client]
+            set second_host [srv 0 host]
+            set second_port [srv 0 port]
+            $second config set requirepass foobar
+            $second auth foobar
+
+            assert {[$first exists list] == 1}
+            assert {[$second exists list] == 0}
+            set ret [r -1 migrate $second_host $second_port list 9 5000 AUTH default foobar]
+            assert {$ret eq {OK}}
+            assert {[$second exists list] == 1}
+            assert {[$second lrange list 0 -1] eq {d c b a}}
+
+            r -1 lpush list a b c d
+            $second config set requirepass foobar2
+            catch {r -1 migrate $second_host $second_port list 9 5000 AUTH default foobar} err
+            assert_match {*WRONGPASS*} $err
+
+            catch {r -1 migrate $second_host $second_port list 9 5000 AUTH default2 foobar2} err
+            assert_match {*WRONGPASS*} $err
+        }
+    } 
 }


### PR DESCRIPTION
* The support for complete `AUTH` with u/p for the `MIGRATE` command
* It does not work if the password is one of the command parameter ( `copy`, `replace`, `keys` )

*Note: this is my first contribution in C... *