### PR TITLE
CLIENT TRACKING Command Fix: Add More Checking for OPTIN/OPTOUT mode

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2314,6 +2314,14 @@ NULL
                 return;
             }
 
+            if ((options & CLIENT_TRACKING_OPTIN) && (options & CLIENT_TRACKING_OPTOUT))
+            {
+                addReplyError(c,
+                "You can't specify both OPTIN mode and OPTOUT mode");
+                zfree(prefix);
+                return;
+            }
+
             enableTracking(c,redir,options,prefix,numprefix);
         } else if (!strcasecmp(c->argv[2]->ptr,"off")) {
             disableTracking(c);

--- a/src/networking.c
+++ b/src/networking.c
@@ -2314,10 +2314,21 @@ NULL
                 return;
             }
 
-            if ((options & CLIENT_TRACKING_OPTIN) && (options & CLIENT_TRACKING_OPTOUT))
+            if (options & CLIENT_TRACKING_OPTIN && options & CLIENT_TRACKING_OPTOUT)
             {
                 addReplyError(c,
                 "You can't specify both OPTIN mode and OPTOUT mode");
+                zfree(prefix);
+                return;
+            }
+
+            if ((options & CLIENT_TRACKING_OPTIN && c->flags & CLIENT_TRACKING_OPTOUT) ||
+                (options & CLIENT_TRACKING_OPTOUT && c->flags & CLIENT_TRACKING_OPTIN))
+            {
+                addReplyError(c,
+                "You can't switch OPTIN/OPTOUT mode before disabling "
+                "tracking for this client, and then re-enabling it with "
+                "a different mode.");
                 zfree(prefix);
                 return;
             }


### PR DESCRIPTION
This PR including two more checks when enabling tracking:

1. Check OPTIN OPTOUT mode should not both been provided.

2. Check for do not let user directly switch optin/optout mode before disabling the tracking, if we did not do so, when the previous mode do CLIENT CACHING YES directly follows a switching mode command(client tracking on OPTIN/OPTOUT), the flag in previous mode will affect next, similar to PR:https://github.com/antirez/redis/pull/7019