### PR TITLE
diffrent fix for runtest --host --port

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -159,12 +159,9 @@ proc start_server {options {code undefined}} {
     if {$::external} {
         if {[llength $::servers] == 0} {
             set srv {}
-            # In test_server_main(tests/test_helper.tcl:215~218), increase the value of start_port
-            # and assign it to ::port through the `--port` option, so we need to reduce it.
-            set baseport [expr {$::port-100}]
             dict set srv "host" $::host
-            dict set srv "port" $baseport
-            set client [redis $::host $baseport 0 $::tls]
+            dict set srv "port" $::port
+            set client [redis $::host $::port 0 $::tls]
             dict set srv "client" $client
             $client select 9
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -212,13 +212,19 @@ proc test_server_main {} {
 
     # Start the client instances
     set ::clients_pids {}
-    set start_port [expr {$::port+100}]
-    for {set j 0} {$j < $::numclients} {incr j} {
-        set start_port [find_available_port $start_port]
+    if {$::external} {
         set p [exec $tclsh [info script] {*}$::argv \
-            --client $port --port $start_port &]
+            --client $port --port $::port &]
         lappend ::clients_pids $p
-        incr start_port 10
+    } else {
+        set start_port [expr {$::port+100}]
+        for {set j 0} {$j < $::numclients} {incr j} {
+            set start_port [find_available_port $start_port]
+            set p [exec $tclsh [info script] {*}$::argv \
+                --client $port --port $start_port &]
+            lappend ::clients_pids $p
+            incr start_port 10
+        }
     }
 
     # Setup global state for the test server
@@ -506,9 +512,6 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     } elseif {$opt eq {--host}} {
         set ::external 1
         set ::host $arg
-        # If we use an external server, we can only set numclients to 1,
-        # otherwise the port will be miscalculated.
-        set ::numclients 1
         incr j
     } elseif {$opt eq {--port}} {
         set ::port $arg


### PR DESCRIPTION
after merging RC3 into our fork i found that the fix of #6974 broke our fork.
the reason is that we already had a different fix for these problems locally, and these two collide.
looking at the difference, i must admit that i don't like the +100 -100 fix and reference to specific line numbers in other files.

note that the big bulk of change in test_helper.tcl is just indentation.