### PR TITLE
Optimize lua log level judgment

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -959,6 +959,7 @@ int luaLogCommand(lua_State *lua) {
         lua_pushstring(lua, "Invalid debug level.");
         return lua_error(lua);
     }
+    if (level < server.verbosity) return 0;
 
     /* Glue together all the arguments */
     log = sdsempty();


### PR DESCRIPTION
Judge the log level in advance，avoid log string splicing.

