### PR TITLE
Hides `config set` from cli history for sensitive directives

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1957,7 +1957,8 @@ static void repl(void) {
                 }
             }
 
-            /* Won't save auth or acl setuser commands in history file */
+            /* Won't save 'auth', 'acl setuser' or 'config set requirepass'
+            * commands in history file */
             int dangerous = 0;
             if (argv && argc > 0) {
                 if (!strcasecmp(argv[skipargs], "auth")) {
@@ -1966,6 +1967,11 @@ static void repl(void) {
                            !strcasecmp(argv[skipargs], "acl") &&
                            !strcasecmp(argv[skipargs+1], "setuser"))
                 {
+                    dangerous = 1;
+                } else if (skipargs+2 < argc &&
+                           !strcasecmp(argv[skipargs], "config") &&
+                           !strcasecmp(argv[skipargs+1], "set") &&
+                           !strcasecmp(argv[skipargs+2], "requirepass")) {
                     dangerous = 1;
                 }
             }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1971,7 +1971,9 @@ static void repl(void) {
                 } else if (skipargs+2 < argc &&
                            !strcasecmp(argv[skipargs], "config") &&
                            !strcasecmp(argv[skipargs+1], "set") &&
-                           !strcasecmp(argv[skipargs+2], "requirepass")) {
+                           (!strcasecmp(argv[skipargs+2], "requirepass") ||
+                           !strcasecmp(argv[skipargs+2], "masterauth") ||
+                           !strcasecmp(argv[skipargs+2], "masteruser"))) {
                     dangerous = 1;
                 }
             }


### PR DESCRIPTION
Fixes #7081.

Hides `CONFIG SET requirepass/masterauth/masteruser`.

The next command that needs to be hidden should trigger a refactoring of the "dangerous" conditional logic to use some sort of stack struct with the hidden commands perhaps.