### PR TITLE
Adding acllog-max-len to Redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -741,9 +741,8 @@ replica-priority 100
 #
 # The ACL Log tracks failed commands and authentication events associated
 # with ACLs. The ACL Log is useful to troubleshoot failed commands blocked 
-# by ACLs. The ACL Log is stored in and consumes memory. There is no limit
-# to its length.You can reclaim memory with ACL LOG RESET or set a maximum
-# length below.
+# by ACLs. The ACL Log is stored in memory. You can reclaim memory with 
+# ACL LOG RESET. Define the maximum entry length of the ACL Log below.
 acllog-max-len 128
 
 # Using an external ACL file

--- a/redis.conf
+++ b/redis.conf
@@ -737,6 +737,15 @@ replica-priority 100
 # For more information about ACL configuration please refer to
 # the Redis web site at https://redis.io/topics/acl
 
+# ACL LOG
+#
+# The ACL Log tracks failed commands and authentication events associated
+# with ACLs. The ACL Log is useful to troubleshoot failed commands blocked 
+# by ACLs. The ACL Log is stored in and consumes memory. There is no limit
+# to its length.You can reclaim memory with ACL LOG RESET or set a maximum
+# length below.
+acllog-max-len 128
+
 # Using an external ACL file
 #
 # Instead of configuring users here in this file, it is possible to use


### PR DESCRIPTION
While playing with ACLs I noticed that acllog-max-len wasn't in the redis.conf, but was a supported config. 

This PR documents and adds the directive to the redis.conf file.