### PR TITLE
Prevents default save configuration being reset...

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5035,7 +5035,6 @@ int main(int argc, char **argv) {
                 "Sentinel needs config file on disk to save state.  Exiting...");
             exit(1);
         }
-        resetServerSaveParams();
         loadServerConfig(configfile,options);
         sdsfree(options);
     }


### PR DESCRIPTION
...when using any command line argument.

Fixes #5629

Probably a breaking change because who knows how many users are currently relying on this behavior :/