### PR TITLE
Implements sendfile for redis.

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -133,6 +133,12 @@ void setproctitle(const char *fmt, ...);
 /* Byte ordering detection */
 #include <sys/types.h> /* This will likely define BYTE_ORDER */
 
+/* Define redis_sendfile. */
+#if defined(__linux__) || (defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_5))
+#define HAVE_SENDFILE 1
+ssize_t redis_sendfile(int out_fd, int in_fd, off_t offset, size_t count);
+#endif
+
 #ifndef BYTE_ORDER
 #if (BSD >= 199103)
 # include <machine/endian.h>


### PR DESCRIPTION
I implement `sendfile` for redis, but now only support Linux and macOS since I only have these two operation systems. For performance, it may couldn't save time but can reduce CPU usage.

If we implement it on BSD systems, please notice that `sendfile` may return -1 and errno set is to EAGAIN even if some bytes have been sent successfully and the the len argument is set correctly when using a socket marked for non-blocking I/O just like on macOS.