### PR TITLE
Fix not used marco in cluster.c

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2106,7 +2106,7 @@ int clusterProcessPacket(clusterLink *link) {
         resetManualFailover();
         server.cluster->mf_end = mstime() + CLUSTER_MF_TIMEOUT;
         server.cluster->mf_slave = sender;
-        pauseClients(mstime()+(CLUSTER_MF_TIMEOUT*2));
+        pauseClients(mstime()+(CLUSTER_MF_TIMEOUT*CLUSTER_MF_PAUSE_MULT));
         serverLog(LL_WARNING,"Manual failover requested by replica %.40s.",
             sender->name);
     } else if (type == CLUSTERMSG_TYPE_UPDATE) {


### PR DESCRIPTION
CLUSTER_MF_PAUSE_MULT was defined, but not used. Use it in correct place instead of hardcoded value.