### PR TITLE
testsuite run the defrag latency test solo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     - name: test
       run: |
         sudo apt-get install tcl8.5
-        ./runtest --clients 2 --verbose
+        ./runtest --verbose
     - name: module api test
-      run: ./runtest-moduleapi --clients 2 --verbose
+      run: ./runtest-moduleapi --verbose
 
   build-ubuntu-old:
     runs-on: ubuntu-16.04

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -36,6 +36,7 @@ start_server {tags {"memefficiency"}} {
     }
 }
 
+run_solo {defrag} {
 start_server {tags {"defrag"}} {
     if {[string match {*jemalloc*} [s mem_allocator]]} {
         test "Active defrag" {
@@ -328,3 +329,4 @@ start_server {tags {"defrag"}} {
         } {1}
     }
 }
+} ;# run_solo


### PR DESCRIPTION
this test is time sensitive and it sometimes fail to pass below the
latency threshold, even on strong machines.

this test was the reson we're running just 2 parallel tests in the
github actions CI, revering this.