### PR TITLE
fix(sentinel): sentinel.running_scripts not reset

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -859,6 +859,7 @@ void sentinelCollectTerminatedScripts(void) {
             sj->pid = 0;
             sj->start_time = mstime() +
                              sentinelScriptRetryDelay(sj->retry_num);
+            sentinel.running_scripts--;
         } else {
             /* Otherwise let's remove the script, but log the event if the
              * execution did not terminated in the best of the ways. */


### PR DESCRIPTION
when trigger a always fail scripts, sentinel.running_scripts will increase ten times, however it
only decrease one times onretry the maximum. and it will't reset, when it become
SENTINEL_SCRIPT_MAX_RUNNING, sentinel don't trigger scripts.

The  issue  recurrent is very easy.
for example：
1. when script always returns an exit code of "1";
2. sentinel will retry then script. 
3. After a while time, sentinel info will become:
```
# Sentinel
sentinel_masters:1
sentinel_tilt:0
sentinel_running_scripts:9
sentinel_scripts_queue_length:0
```
4. this means retry  ten times. but only decrease one times.
5. if the script trigger two times and more..
6. next normal request will't trigger.


I think it's unreasonable. sentinel_running_scripts should decrease when every exce fail.