### PR TITLE
fix for crash during panic before all threads are up

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -266,7 +266,7 @@ void bioKillThreads(void) {
     int err, j;
 
     for (j = 0; j < BIO_NUM_OPS; j++) {
-        if (pthread_cancel(bio_threads[j]) == 0) {
+        if (bio_threads[j] && pthread_cancel(bio_threads[j]) == 0) {
             if ((err = pthread_join(bio_threads[j],NULL)) != 0) {
                 serverLog(LL_WARNING,
                     "Bio thread for job type #%d can be joined: %s",


### PR DESCRIPTION
If there's a panic before all threads have been started (say, if file descriptor 0 is closed at exec), the panic response will crash here again.