### PR TITLE
Optimize the command of cluster slots

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4191,10 +4191,16 @@ void clusterReplyMultiBulkSlots(client *c) {
     while((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
         int j = 0, start = -1;
+        int i, nested_elements = 0;
 
         /* Skip slaves (that are iterated when producing the output of their
          * master) and  masters not serving any slot. */
         if (!nodeIsMaster(node) || node->numslots == 0) continue;
+
+        for(i = 0; i < node->numslaves; i++) {
+            if (nodeFailed(node->slaves[i])) continue;
+            nested_elements++;
+        }
 
         for (j = 0; j < CLUSTER_SLOTS; j++) {
             int bit, i;
@@ -4203,8 +4209,7 @@ void clusterReplyMultiBulkSlots(client *c) {
                 if (start == -1) start = j;
             }
             if (start != -1 && (!bit || j == CLUSTER_SLOTS-1)) {
-                int nested_elements = 3; /* slots (2) + master addr (1). */
-                void *nested_replylen = addReplyDeferredLen(c);
+                addReplyArrayLen(c, nested_elements + 3); /* slots (2) + master addr (1). */
 
                 if (bit && j == CLUSTER_SLOTS-1) j++;
 
@@ -4234,9 +4239,7 @@ void clusterReplyMultiBulkSlots(client *c) {
                     addReplyBulkCString(c, node->slaves[i]->ip);
                     addReplyLongLong(c, node->slaves[i]->port);
                     addReplyBulkCBuffer(c, node->slaves[i]->name, CLUSTER_NAMELEN);
-                    nested_elements++;
                 }
-                setDeferredArrayLen(c, nested_replylen, nested_elements);
                 num_masters++;
             }
         }

--- a/tests/cluster/tests/15-cluster-slots.tcl
+++ b/tests/cluster/tests/15-cluster-slots.tcl
@@ -1,0 +1,44 @@
+source "../tests/includes/init-tests.tcl"
+
+proc cluster_allocate_mixedSlots {n} {
+    set slot 16383
+    while {$slot >= 0} {
+        set node [expr {$slot % $n}]
+        lappend slots_$node $slot
+        incr slot -1
+    }
+    for {set j 0} {$j < $n} {incr j} {
+        R $j cluster addslots {*}[set slots_${j}]
+    }
+}
+
+proc create_cluster_with_mixedSlot {masters slaves} {
+    cluster_allocate_mixedSlots $masters
+    if {$slaves} {
+        cluster_allocate_slaves $masters $slaves
+    }
+    assert_cluster_state ok
+}
+
+test "Create a 5 nodes cluster" {
+    create_cluster_with_mixedSlot 5 15
+}
+
+test "Cluster is up" {
+    assert_cluster_state ok
+}
+
+test "Cluster is writable" {
+    cluster_write_test 0
+}
+
+test "Instance #5 is a slave" {
+    assert {[RI 5 role] eq {slave}}
+}
+
+test "client do not break when cluster slot" {
+    R 0 config set client-output-buffer-limit "normal 33554432 16777216 60"
+    if { [catch {R 0 cluster slots}] } {
+        fail "output overflow when cluster slots"
+    }
+}


### PR DESCRIPTION
In cluster, when the distribution of slots is too decentralized, the command of "cluster slots" will cause the client breaked. The reason is that  the function of addReplyDeferredLen is called many times in a for-loop, when addReplyDeferredLen is called, a size of 16K memory will be allocated, but only a small part of memory is used. As a result, the memory which is allocated  is far greater than is actual used, the client's output buf reaches the hard limit and the connection of client to server is breaked. For example, in the test of tests/cluster/tests/15-cluster-slots.tcl, when put the result of cluster slots to a file, the size of file is about 400k, but the client's output buf is more than 40M.