### PR TITLE
linenoise: Fix signed char issue on unsigned char archs

### DIFF
--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -819,7 +819,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
 
     if (write(l.ofd,prompt,l.plen) == -1) return -1;
     while(1) {
-        char c;
+        signed char c;
         int nread;
         char seq[3];
 


### PR DESCRIPTION
On some architectures like powerpc or arm*, char is unsigned.
There is an if (c < 0) check a few lines below which is always
false on these architectures.