### PR TITLE
improve fync operation in sentinel and cluster mode

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -352,7 +352,7 @@ int clusterSaveConfig(int do_fsync) {
     if (write(fd,ci,sdslen(ci)) != (ssize_t)sdslen(ci)) goto err;
     if (do_fsync) {
         server.cluster->todo_before_sleep &= ~CLUSTER_TODO_FSYNC_CONFIG;
-        fsync(fd);
+        redis_fsync(fd);
     }
 
     /* Truncate the file if needed to remove the final \n padding that

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1958,7 +1958,7 @@ void sentinelFlushConfig(void) {
 
     if (rewrite_status == -1) goto werr;
     if ((fd = open(server.configfile,O_RDONLY)) == -1) goto werr;
-    if (fsync(fd) == -1) goto werr;
+    if (redis_fsync(fd) == -1) goto werr;
     if (close(fd) == EOF) goto werr;
     return;
 


### PR DESCRIPTION
In Sentinel and Cluster mode, currently fsync was used for sync the current sentinel/cluster state into disk, however when the state change very frequently or failover happens in short period, fsync could be a potential bottleneck, an example of this is https://github.com/antirez/redis/issues/6807, as a simple improvement, we can use fdatasync rather than fsync to reduce one disk write in linux environment, this was predefined in redis_fsync marco..