### PR TITLE
fix loading race in psync2 tests

### DIFF
--- a/tests/integration/psync2-pingoff.tcl
+++ b/tests/integration/psync2-pingoff.tcl
@@ -20,6 +20,7 @@ start_server {} {
         $R(1) replicaof $R_host(0) $R_port(0)
         $R(0) set foo bar
         wait_for_condition 50 1000 {
+            [status $R(1) master_link_status] == "up" &&
             [$R(0) dbsize] == 1 && [$R(1) dbsize] == 1
         } else {
             fail "Replicas not replicating from master"

--- a/tests/integration/psync2-reg.tcl
+++ b/tests/integration/psync2-reg.tcl
@@ -28,7 +28,10 @@ start_server {} {
         $R(2) slaveof $R_host(0) $R_port(0)
         $R(0) set foo bar
         wait_for_condition 50 1000 {
-            [$R(1) dbsize] == 1 && [$R(2) dbsize] == 1
+            [status $R(1) master_link_status] == "up" &&
+            [status $R(2) master_link_status] == "up" &&
+            [$R(1) dbsize] == 1 &&
+            [$R(2) dbsize] == 1
         } else {
             fail "Replicas not replicating from master"
         }

--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -67,6 +67,16 @@ start_server {} {
             lappend used $slave_id
         }
 
+        # Wait for replicas to sync. so next loop won't get -LOADING error
+        wait_for_condition 50 1000 {
+            [status $R([expr {($master_id+1)%5}]) master_link_status] == "up" &&
+            [status $R([expr {($master_id+2)%5}]) master_link_status] == "up" &&
+            [status $R([expr {($master_id+3)%5}]) master_link_status] == "up" &&
+            [status $R([expr {($master_id+4)%5}]) master_link_status] == "up"
+        } else {
+            fail "Replica not reconnecting"
+        }
+
         # 3) Increment the counter and wait for all the instances
         # to converge.
         test "PSYNC2: cluster is consistent after failover" {


### PR DESCRIPTION
@antirez another race in the various psync2 tests. they can try to do DBSIZE or GET too early and get -LOADING error.