### PR TITLE
hickup, re-fix dictEncObjKeyCompare

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1223,11 +1223,11 @@ int dictEncObjKeyCompare(void *privdata, const void *key1,
      * good reasons, because it would incrRefCount() the object, which
      * is invalid. So we check to make sure dictFind() works with static
      * objects as well. */
-    if (!sdsEncodedObject(o1)) o1 = getDecodedObject(o1);
-    if (!sdsEncodedObject(o2)) o2 = getDecodedObject(o2);
+    if (o1->refcount != OBJ_STATIC_REFCOUNT) o1 = getDecodedObject(o1);
+    if (o2->refcount != OBJ_STATIC_REFCOUNT) o2 = getDecodedObject(o2);
     cmp = dictSdsKeyCompare(privdata,o1->ptr,o2->ptr);
-    if (o1!=key1) decrRefCount(o1);
-    if (o2!=key2) decrRefCount(o2);
+    if (o1->refcount != OBJ_STATIC_REFCOUNT) decrRefCount(o1);
+    if (o2->refcount != OBJ_STATIC_REFCOUNT) decrRefCount(o2);
     return cmp;
 }
 


### PR DESCRIPTION
come to think of it, in theory (not in practice), getDecodedObject can
return the same original object with refcount incremented, so the
pointer comparision in the previous commit was invalid.
so now instead of checking the encoding, we explicitly check the
refcount.