### PR TITLE
Notify systemd on sentinel startup

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5111,6 +5111,10 @@ int main(int argc, char **argv) {
     } else {
         InitServerLast();
         sentinelIsRunning();
+        if (server.supervised_mode == SUPERVISED_SYSTEMD) {
+            redisCommunicateSystemd("STATUS=Ready to accept connections\n");
+            redisCommunicateSystemd("READY=1\n");
+        }
     }
 
     /* Warning the user about suspicious maxmemory setting. */


### PR DESCRIPTION
Systemd notify rework only notifies systemd on redis startup, not on sentinel startup, so systemd with notify=systemd never successfully starts.