### PR TITLE
Used portable type when printing CRC mismatch errors

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2291,8 +2291,8 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi) {
             if (cksum == 0) {
                 serverLog(LL_WARNING,"RDB file was saved with checksum disabled: no check performed.");
             } else if (cksum != expected) {
-                serverLog(LL_WARNING,"Wrong RDB checksum expected: (%llx) but "
-                    "got (%llx). Aborting now.",expected,cksum);
+                serverLog(LL_WARNING,"Wrong RDB checksum. Expected: (%" PRIx64 ") but "
+                    "got: (%" PRIx64 "). Aborting now.",expected,cksum);
                 rdbExitReportCorruptRDB("RDB CRC error");
             }
         }


### PR DESCRIPTION
TIL what a uint64_t actually is.