### PR TITLE
add daily github actions with libc malloc and valgrind, fix leaks and timing issues

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,48 @@
+name: Daily
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+
+jobs:
+  test-jemalloc:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1200
+    steps:
+    - uses: actions/checkout@v1
+    - name: make
+      run: make
+    - name: test
+      run: |
+        sudo apt-get install tcl8.5
+        ./runtest --accurate --verbose
+    - name: module api test
+      run: ./runtest-moduleapi --verbose
+
+  test-libc-malloc:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1200
+    steps:
+    - uses: actions/checkout@v1
+    - name: make
+      run: make MALLOC=libc
+    - name: test
+      run: |
+        sudo apt-get install tcl8.5
+        ./runtest --accurate --verbose
+    - name: module api test
+      run: ./runtest-moduleapi --verbose
+
+  test-valgrind:
+    runs-on: ubuntu-latest
+    timeout-minutes: 14400
+    steps:
+    - uses: actions/checkout@v1
+    - name: make
+      run: make valgrind
+    - name: test
+      run: |
+        sudo apt-get install tcl8.5 valgrind -y
+        ./runtest --valgrind --verbose --clients 1
+    - name: module api test
+      run: ./runtest-moduleapi --valgrind --verbose --clients 1

--- a/src/debug.c
+++ b/src/debug.c
@@ -1636,7 +1636,7 @@ void enableWatchdog(int period) {
         /* Watchdog was actually disabled, so we have to setup the signal
          * handler. */
         sigemptyset(&act.sa_mask);
-        act.sa_flags = SA_ONSTACK | SA_SIGINFO;
+        act.sa_flags = SA_SIGINFO;
         act.sa_sigaction = watchdogSignalHandler;
         sigaction(SIGALRM, &act, NULL);
     }

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -54,6 +54,12 @@ tags {"aof"} {
 
         set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
 
+        wait_for_condition 50 100 {
+            [catch {$client ping} e] == 0
+        } else {
+            fail "Loading DB is taking too much time."
+        }
+
         test "Truncated AOF loaded: we expect foo to be equal to 5" {
             assert {[$client get foo] eq "5"}
         }
@@ -70,6 +76,12 @@ tags {"aof"} {
         }
 
         set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+
+        wait_for_condition 50 100 {
+            [catch {$client ping} e] == 0
+        } else {
+            fail "Loading DB is taking too much time."
+        }
 
         test "Truncated AOF loaded: we expect foo to be equal to 6 now" {
             assert {[$client get foo] eq "6"}

--- a/tests/integration/replication-3.tcl
+++ b/tests/integration/replication-3.tcl
@@ -118,7 +118,7 @@ start_server {tags {"repl"}} {
             # correctly the RDB file: such file will contain "lua" AUX
             # sections with scripts already in the memory of the master.
 
-            wait_for_condition 50 100 {
+            wait_for_condition 500 100 {
                 [s -1 master_link_status] eq {up}
             } else {
                 fail "Replication not started."


### PR DESCRIPTION
* fix memlry leaks with diskless replica short read.
* fix a few timing issues with valgrind runs
* fix issue with valgrind and watchdog schedule signal

about the valgrind WD issue:
the stack trace test in logging.tcl, has issues with valgrind:
==28808== Can't extend stack to 0x1ffeffdb38 during signal delivery for thread 1:
==28808==   too small or bad protection modes

it seems to be some valgrind bug with SA_ONSTACK.
SA_ONSTACK seems unneeded since WD is not recursive (SA_NODEFER was removed),
also, not sure if it's even valid without a call to sigaltstack()