### PR TITLE
Redis Benchmark: make test data better

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1269,6 +1269,17 @@ static void updateClusterSlotsConfiguration() {
     pthread_mutex_unlock(&config.is_updating_slots_mutex);
 }
 
+/* Generate random data for redis benchmark. See #7196. */
+static void genBenchmarkRandomData(char *data, int count) {
+    static uint32_t state = 1234;
+    int i = 0;
+
+    while (count--) {
+        state = (state*1103515245+12345);
+        data[i++] = '0'+((state>>16)&63);
+    }
+}
+
 /* Returns number of consumed options. */
 int parseOptions(int argc, const char **argv) {
     int i;
@@ -1619,7 +1630,7 @@ int main(int argc, const char **argv) {
     /* Run default benchmark suite. */
     data = zmalloc(config.datasize+1);
     do {
-        memset(data,'x',config.datasize);
+        genBenchmarkRandomData(data, config.datasize);
         data[config.datasize] = '\0';
 
         if (test_is_selected("ping_inline") || test_is_selected("ping"))


### PR DESCRIPTION
Instead of using the same character 'x' in redis-benchmark, use random characters.