### PR TITLE
ignore empty valgrind reports

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -17,9 +17,14 @@ proc check_valgrind_errors stderr {
     set buf [read $fd]
     close $fd
 
+    # look for stack trace and other errors
     if {[regexp -- { at 0x} $buf] ||
-        (![regexp -- {definitely lost: 0 bytes} $buf] &&
-         ![regexp -- {no leaks are possible} $buf])} {
+        [regexp -- {Warning} $buf] ||
+        [regexp -- {Invalid} $buf] ||
+        [regexp -- {Mismatched} $buf] ||
+        [regexp -- {uninitialized} $buf] ||
+        [regexp -- {has a fishy} $buf] ||
+        [regexp -- {overlap} $buf]} {
         send_data_packet $::test_server_fd err "Valgrind error: $buf\n"
     }
 }


### PR DESCRIPTION
sometimes valgrind report is completely empty, not reporting anytying,
and we need to ignore it.

example:
*** [err]: Valgrind error: ==46468== Memcheck, a memory error detector
==46468== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==46468== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==46468== Command: src/redis-server ./tests/tmp/redis.conf.5351.333
==46468==