### PR TITLE
make struct user anonymous (only typedefed) in server.h

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -732,7 +732,7 @@ typedef struct readyList {
                                            no AUTH is needed, and every
                                            connection is immediately
                                            authenticated. */
-typedef struct user {
+typedef struct {
     sds name;       /* The username as an SDS string. */
     uint64_t flags; /* See USER_FLAG_* */
 


### PR DESCRIPTION
This works because this struct is never referenced by its name,
but always by its type.

This prevents a conflict with struct user from <sys/user.h>
when compiling against uclibc.

Fixes #7195 