### PR TITLE
Don't write replies if close the client ASAP

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -297,7 +297,13 @@ void ACLFreeUserAndKillClients(user *u) {
              * it in non authenticated mode. */
             c->user = DefaultUser;
             c->authenticated = 0;
-            freeClientAsync(c);
+            /* We will write replies to this client later, so we can't
+             * close it directly even if async. */
+            if (c == server.current_client) {
+                c->flags |= CLIENT_CLOSE_AFTER_COMMAND;
+            } else {
+                freeClientAsync(c);
+            }
         }
     }
     ACLFreeUser(u);

--- a/src/module.c
+++ b/src/module.c
@@ -5530,7 +5530,13 @@ void revokeClientAuthentication(client *c) {
 
     c->user = DefaultUser;
     c->authenticated = 0;
-    freeClientAsync(c);
+    /* We will write replies to this client later, so we can't close it
+     * directly even if async. */
+    if (c == server.current_client) {
+        c->flags |= CLIENT_CLOSE_AFTER_COMMAND;
+    } else {
+        freeClientAsync(c);
+    }
 }
 
 /* Cleanup all clients that have been authenticated with this module. This

--- a/src/networking.c
+++ b/src/networking.c
@@ -223,6 +223,9 @@ int prepareClientToWrite(client *c) {
      * handler since there is no socket at all. */
     if (c->flags & (CLIENT_LUA|CLIENT_MODULE)) return C_OK;
 
+    /* If CLIENT_CLOSE_ASAP flag is set, we need not write anything. */
+    if (c->flags & CLIENT_CLOSE_ASAP) return C_ERR;
+
     /* CLIENT REPLY OFF / SKIP handling: don't send replies. */
     if (c->flags & (CLIENT_REPLY_OFF|CLIENT_REPLY_SKIP)) return C_ERR;
 
@@ -1435,6 +1438,9 @@ int handleClientsWithPendingWrites(void) {
         /* If a client is protected, don't do anything,
          * that may trigger write error or recreate handler. */
         if (c->flags & CLIENT_PROTECTED) continue;
+
+        /* Don't write to clients that are going to be closed anyway. */
+        if (c->flags & CLIENT_CLOSE_ASAP) continue;
 
         /* Try to write buffers to the client socket. */
         if (writeToClient(c,0) == C_ERR) continue;
@@ -3114,6 +3120,14 @@ int handleClientsWithPendingWritesUsingThreads(void) {
     while((ln = listNext(&li))) {
         client *c = listNodeValue(ln);
         c->flags &= ~CLIENT_PENDING_WRITE;
+
+        /* Remove clients from the list of pending writes since
+         * they are going to be closed ASAP. */
+        if (c->flags & CLIENT_CLOSE_ASAP) {
+            listDelNode(server.clients_pending_write, ln);
+            continue;
+        }
+
         int target_id = item_id % server.io_threads_num;
         listAddNodeTail(io_threads_list[target_id],c);
         item_id++;

--- a/src/server.c
+++ b/src/server.c
@@ -3402,6 +3402,13 @@ void call(client *c, int flags) {
     dirty = server.dirty-dirty;
     if (dirty < 0) dirty = 0;
 
+    /* After executing command, we will close the client after writing entire
+     * reply if it is set 'CLIENT_CLOSE_AFTER_COMMAND' flag. */
+    if (!server.loading && c->flags & CLIENT_CLOSE_AFTER_COMMAND) {
+        c->flags &= ~CLIENT_CLOSE_AFTER_COMMAND;
+        c->flags |= CLIENT_CLOSE_AFTER_REPLY;
+    }
+
     /* When EVAL is called loading the AOF we don't want commands called
      * from Lua to go into the slowlog or to populate statistics. */
     if (server.loading && c->flags & CLIENT_LUA)

--- a/src/server.c
+++ b/src/server.c
@@ -3404,7 +3404,7 @@ void call(client *c, int flags) {
 
     /* After executing command, we will close the client after writing entire
      * reply if it is set 'CLIENT_CLOSE_AFTER_COMMAND' flag. */
-    if (!server.loading && c->flags & CLIENT_CLOSE_AFTER_COMMAND) {
+    if (c->flags & CLIENT_CLOSE_AFTER_COMMAND) {
         c->flags &= ~CLIENT_CLOSE_AFTER_COMMAND;
         c->flags |= CLIENT_CLOSE_AFTER_REPLY;
     }

--- a/src/server.h
+++ b/src/server.h
@@ -264,6 +264,8 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
                                              about writes performed by myself.*/
 #define CLIENT_IN_TO_TABLE (1ULL<<38) /* This client is in the timeout table. */
 #define CLIENT_PROTOCOL_ERROR (1ULL<<39) /* Protocol error chatting with it. */
+#define CLIENT_CLOSE_AFTER_COMMAND (1ULL<<40) /* Close after executing commands
+                                               * and writing entire reply. */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -73,12 +73,8 @@ start_server {tags {"obuf-limits"}} {
 
     test {Won't write replies if client output buffer hard limit is enforced} {
         r config set client-output-buffer-limit {normal 100000 0 0}
-        # One item is 1k
-        set item "HelloWord"
-        for {set i 0} {$i < 100} {incr i} {
-            append item "HelloWord"
-        }
         # Total size of all items must be more than 100k
+        set item [string repeat "x" 1000]
         for {set i 0} {$i < 150} {incr i} {
             r lpush mylist $item
         }

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -137,6 +137,7 @@ start_server {tags {"obuf-limits"}} {
         }
 
         # Output buffer limit is enforced during executing transaction
+        r client setname transactionclient
         r set k1 v1
         r multi
         r set k2 v2
@@ -145,6 +146,9 @@ start_server {tags {"obuf-limits"}} {
         r set k3 v3
         r del k1
         catch {[r exec]} e
+        assert_match "*I/O error*" $e
+        set clients [r client list]
+        assert_no_match "*name=transactionclient*" $clients
         reconnect
 
         # Transactions should be executed completely

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -70,4 +70,36 @@ start_server {tags {"obuf-limits"}} {
         assert {$omem >= 100000 && $time_elapsed < 6}
         $rd1 close
     }
+
+    test {Won't write replies if client output buffer hard limit is enforced} {
+        r config set client-output-buffer-limit {normal 100000 0 0}
+        # One item is 1k
+        set item "HelloWord"
+        for {set i 0} {$i < 100} {incr i} {
+            append item "HelloWord"
+        }
+        # Total size of all items must be more than 100k
+        for {set i 0} {$i < 150} {incr i} {
+            r lpush mylist $item
+        }
+        set orig_mem [s used_memory]
+        # Set client name and get all items
+        set rd [redis_deferring_client]
+        $rd client setname mybiglist
+        assert {[$rd read] eq "OK"}
+        $rd lrange mylist 0 -1
+        $rd flush
+        after 100
+
+        # Before we read reply, redis will close this client.
+        set clients [r client list]
+        assert_no_match "*name=mybiglist*" $clients
+        set cur_mem [s used_memory]
+        # 10k just is a deviation threshold
+        assert {$cur_mem < 10000 + $orig_mem}
+
+        # Read nothing
+        set fd [$rd channel]
+        assert {[read $fd] eq {}}
+    }
 }


### PR DESCRIPTION
I config set small memory sizes for "normal" of `client-output-buffer-limit` to limit the memory clients used, but I actually found the memory kept increasing when users executed `smembers` command on a big key.

I also could read some replies exactly when I send redis command by “telnet” even if the client output buffer size is more than the part of `client-output-buffer-limit` I set.

I consider we shouldn't write replies to the client output buffer if we want to close it asap, that will not use unnecessary memory. And we also should remove the client from the list of pending writes, so that we won't `write(2)` replies to the client.