### PR TITLE
Remove uint64_t to unsigned long long conversion and use Portable format string

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2320,10 +2320,10 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi) {
             if (cksum == 0) {
                 serverLog(LL_WARNING,"RDB file was saved with checksum disabled: no check performed.");
             } else if (cksum != expected) {
-                serverLog(LL_WARNING,"Wrong RDB checksum expected: (%llx) but "
-                    "got (%llx). Aborting now.",
-                        (unsigned long long)expected,
-                        (unsigned long long)cksum);
+                serverLog(LL_WARNING,"Wrong RDB checksum expected: (%" PRIx64 ") but "
+                    "got (%" PRIx64 "). Aborting now.",
+                        expected,
+                        cksum);
                 rdbExitReportCorruptRDB("RDB CRC error");
             }
         }


### PR DESCRIPTION
usually uint64_t is lx on 64 bit systems and llx on 32bit systems
PRIx64 is the portable llx/lx