### PR TITLE
Redis Benchmark: Fix coredump because of double free

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -275,7 +275,7 @@ static redisConfig *getRedisConfig(const char *ip, int port,
     for (; i < 2; i++) {
         int res = redisGetReply(c, &r);
         if (reply) freeReplyObject(reply);
-        reply = ((redisReply *) r);
+        reply = res == REDIS_OK ? ((redisReply *) r) : NULL;
         if (res != REDIS_OK || !r) goto fail;
         if (reply->type == REDIS_REPLY_ERROR) {
             fprintf(stderr, "ERROR: %s\n", reply->str);


### PR DESCRIPTION
I find redis-benchmark coredumps when I do some tests by changing parameters of `client-output-buffer-limit`. `reply` will be the last value if the second call 'redisGetReply' fails but the first succeeds, so we will free memory two times. https://github.com/antirez/redis/blob/unstable/src/redis-benchmark.c#L282

The backtrac is shown below.
```
./src/redis-benchmark -p 6381 -t get
ERROR: failed to fetch CONFIG from 127.0.0.1:6381
*** Error in `./src/redis-benchmark': double free or corruption (fasttop): 0x00000000015513d0 ***
======= Backtrace: =========
/usr/local/gcc-8.2/lib/libc.so.6(+0x73940)[0x7f4c4adfb940]
/usr/local/gcc-8.2/lib/libc.so.6(+0x78ed8)[0x7f4c4ae00ed8]
/usr/local/gcc-8.2/lib/libc.so.6(+0x79fd3)[0x7f4c4ae01fd3]
./src/redis-benchmark[0x4117a6]
./src/redis-benchmark(main+0x2bd)[0x40e16d]
/opt/compiler/gcc-8.2/lib/libc.so.6(__libc_start_main+0xee)[0x7f4c4ada9b8e]
./src/redis-benchmark(_start+0x29)[0x40f2f9]
```