### PR TITLE
add jemalloc-bg-thread config in redis conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1781,6 +1781,9 @@ rdb-save-incremental-fsync yes
 # the main dictionary scan
 # active-defrag-max-scan-fields 1000
 
+# Jemalloc background thread for purging will be enabled by default
+jemalloc-bg-thread yes
+
 # It is possible to pin different threads and processes of Redis to specific
 # CPUs in your system, in order to maximize the performances of the server.
 # This is useful both in order to pin different Redis threads in different


### PR DESCRIPTION
jemalloc-bg-thread config was introduced in https://github.com/antirez/redis/pull/6145, this pr add this configuration in redis.conf