### PR TITLE
redis-benchmark can run in cluster mode with ACL

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1009,6 +1009,18 @@ static int fetchClusterConfiguration() {
     clusterNode *firstNode = createClusterNode((char *) config.hostip,
                                                config.hostport);
     if (!firstNode) {success = 0; goto cleanup;}
+
+    /* Maybe we need to authenticate */
+    if (config.auth) {
+        if (config.user == NULL)
+            reply = redisCommand(ctx, "AUTH %s", config.auth);
+        else
+            reply = redisCommand(ctx, "AUTH %s %s", config.user, config.auth);
+        success = (reply != NULL);
+        if (!success) goto cleanup;
+	freeReplyObject(reply);
+    }
+
     reply = redisCommand(ctx, "CLUSTER NODES");
     success = (reply != NULL);
     if (!success) goto cleanup;

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1018,7 +1018,7 @@ static int fetchClusterConfiguration() {
             reply = redisCommand(ctx, "AUTH %s %s", config.user, config.auth);
         success = (reply != NULL);
         if (!success) goto cleanup;
-	freeReplyObject(reply);
+        freeReplyObject(reply);
     }
 
     reply = redisCommand(ctx, "CLUSTER NODES");


### PR DESCRIPTION
When we fetch the cluster configuration, we need to authenticate first if we are running against a password/ACL protected redis instance.

Kindof a follow up to https://github.com/antirez/redis/pull/6665