### PR TITLE
add supervised_mode setting code when upstart_job env is set

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4899,6 +4899,7 @@ int redisIsSupervised(int mode) {
         const char *notify_socket = getenv("NOTIFY_SOCKET");
 
         if (upstart_job) {
+            server.supervised_mode = SUPERVISED_UPSTART;
             redisSupervisedUpstart();
         } else if (notify_socket) {
             server.supervised_mode = SUPERVISED_SYSTEMD;


### PR DESCRIPTION
There is no code to set supervised_mode when upstart_job environment is set.