### PR TITLE
Reduce spurious PFAIL/FAIL states upon delayed PONG receival

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1382,6 +1382,13 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
     clusterMsgDataGossip *g = (clusterMsgDataGossip*) hdr->data.ping.gossip;
     clusterNode *sender = link->node ? link->node : clusterLookupNode(hdr->sender);
 
+    // Consider PING packet from the sender as proof of liveness similarly to the receival of
+    // PONG reply.
+    if (sender && sender->ping_sent) {
+        sender->ping_sent = 0;
+        sender->pong_received = mstime();
+    }
+
     while(count--) {
         uint16_t flags = ntohs(g->flags);
         clusterNode *node;


### PR DESCRIPTION
During PUB/SUB heavy load, the cluster bus becomes overloaded. As a result PONG packets got delayed, which in turn causes spurious PFAIL states, then FAIL and then CLUSTER-DOWN state.
This PR mitigates this issue by treating pings as proof of liveness in addition to PONG replies by resetting `ping_sent` timer.