### PR TITLE
HINCRBY - Enhanced to support multiple fields increment with differen…

### DIFF
--- a/src/help.h
+++ b/src/help.h
@@ -509,7 +509,7 @@ struct commandHelp {
     5,
     "2.0.0" },
     { "HINCRBY",
-    "key field increment",
+    "key field increment [field2 increment2 ...] [SV|CNT|V|KV]",
     "Increment the integer value of a hash field by the given number",
     5,
     "2.0.0" },

--- a/src/server.c
+++ b/src/server.c
@@ -514,7 +514,7 @@ struct redisCommand redisCommandTable[] = {
      "read-only fast @hash",
      0,NULL,1,1,1,0,0,0},
 
-    {"hincrby",hincrbyCommand,4,
+    {"hincrby",hincrbyCommand,-4,
      "write use-memory fast @hash",
      0,NULL,1,1,1,0,0,0},
 

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -262,6 +262,26 @@ start_server {tags {"hash"}} {
         list [r hincrby htest foo 2]
     } {2}
 
+    test {HINCRBY against non existing database key, multi, ret kv} {
+        r del htest
+        list [r hincrby htest foo 2 boo 3 kv]
+    } {{foo 2 boo 3}}
+
+    test {HINCRBY against non existing database key, multi, ret default=kv} {
+        r del htest
+        list [r hincrby htest foo 2 boo 3]
+    } {{foo 2 boo 3}}
+
+	test {HINCRBY against non existing database key, multi, ret v} {
+        r del htest
+        list [r hincrby htest foo 2 boo 3 v]
+    } {{2 3}}
+
+	test {HINCRBY against non existing database key, multi, ret cnt} {
+        r del htest
+        list [r hincrby htest foo 2 boo 3 cnt]
+    } {2}
+
     test {HINCRBY against non existing hash key} {
         set rv {}
         r hdel smallhash tmp
@@ -272,6 +292,17 @@ start_server {tags {"hash"}} {
         lappend rv [r hget bighash tmp]
     } {2 2 2 2}
 
+    test {HINCRBY against non existing hash key, multi, ret kv} {
+        set rv {}
+        r hdel smallhash tmp tmp2
+        r hdel bighash tmp rst
+        lappend rv [r hincrby smallhash tmp 2 tmp2 3 kv]
+        lappend rv [r hget smallhash tmp2]
+        lappend rv [r hget smallhash tmp]
+        lappend rv [r hincrby bighash tmp 2 rst 1 kv]
+        lappend rv [r hget bighash rst]
+    } {{tmp 2 tmp2 3} 3 2 {tmp 2 rst 1} 1}
+
     test {HINCRBY against hash key created by hincrby itself} {
         set rv {}
         lappend rv [r hincrby smallhash tmp 3]
@@ -279,6 +310,14 @@ start_server {tags {"hash"}} {
         lappend rv [r hincrby bighash tmp 3]
         lappend rv [r hget bighash tmp]
     } {5 5 5 5}
+
+	test {HINCRBY against hash key created by hincrby itself, multi, ret kv} {
+        set rv {}
+        lappend rv [r hincrby smallhash tmp2 2 kv]
+        lappend rv [r hget smallhash tmp2]
+        lappend rv [r hincrby bighash tmp 3 rst 2 kv]
+        lappend rv [r hget bighash tmp]
+    } {{tmp2 5} 5 {tmp 8 rst 3} 8}
 
     test {HINCRBY against hash key originally set with HSET} {
         r hset smallhash tmp 100


### PR DESCRIPTION
…t result output styles with backward compatibility of syntax.

Points of PR:
1) HINCRBY shall support it's classic syntax.
2) HINCRBY shall be capable of changeding multiple fields by their own incr values:
     HINCRBY key f1 i1 f2 i2 f3 i3 ...
3) HINCRBY shall have optional last argument of specifying return type.
   There are 4 return types supported:
      Single value - Same as currently returned by HINCRBY, for multi-fields will return first field value after change
      Ammount - Will return ammount of changed fields.
      Values - Will return array of field values after change in same order as in request
      Key-Values - Will return array of field keys followed by values after change in same order as in request.

PR was developed for stable 6.0 branch(Not unstable). Shall not be any problem to forward-port it.