### PR TITLE
Fix unidentical function declaration in bio.c. 

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -86,7 +86,7 @@ struct bio_job {
 void *bioProcessBackgroundJobs(void *arg);
 void lazyfreeFreeObjectFromBioThread(robj *o);
 void lazyfreeFreeDatabaseFromBioThread(dict *ht1, dict *ht2);
-void lazyfreeFreeSlotsMapFromBioThread(zskiplist *sl);
+void lazyfreeFreeSlotsMapFromBioThread(rax *rt);
 
 /* Make sure we have enough stack to perform all the things we do in the
  * main thread. */


### PR DESCRIPTION
lazyfree.c:  void lazyfreeFreeSlotsMapFromBioThread(rax *rt);
