### PR TITLE
Replica always reports master's config epoch in CLUSTER NODES output.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4005,11 +4005,15 @@ sds clusterGenNodeDescription(clusterNode *node) {
     else
         ci = sdscatlen(ci," - ",3);
 
+    unsigned long long nodeEpoch = node->configEpoch;
+    if (nodeIsSlave(node) && node->slaveof) {
+        nodeEpoch = node->slaveof->configEpoch;
+    }
     /* Latency from the POV of this node, config epoch, link status */
     ci = sdscatprintf(ci,"%lld %lld %llu %s",
         (long long) node->ping_sent,
         (long long) node->pong_received,
-        (unsigned long long) node->configEpoch,
+        nodeEpoch,
         (node->link || node->flags & CLUSTER_NODE_MYSELF) ?
                     "connected" : "disconnected");
 


### PR DESCRIPTION
The CLUSTER NODES command is intended to report only the master's config epoch on replicas in cluster mode. However, that is not what is implemented currently. Replicas are reporting their own individual epochs. This commit fixes it.

See documentation https://redis.io/commands/cluster-nodes

Tested and it works.

Before fix:

127.0.0.1:6382> cluster nodes
6cb6540c43dd83bb07ec1db191b90063b3374ac0 127.0.0.1:6379@16379 master - 0 1544216055000 1 connected 1-3
ec1d5360e7270bf833fa675fbeea3fadd91b179a 127.0.0.1:6380@16380 master - 0 1544216056277 2 connected 4-6
129fd991448e44502cb4a62cb08a873c514cfd4f 127.0.0.1:6382@16382 myself,slave ec1d5360e7270bf833fa675fbeea3fadd91b179a 0 1544216053000 3 connected
ff9c9805d1e3c83cfa04df00b918e5bf1bc57b9b 127.0.0.1:6381@16381 slave 6cb6540c43dd83bb07ec1db191b90063b3374ac0 0 1544216055264 1 connected

After fix:

127.0.0.1:6382> cluster nodes 3f8969fac2c3dc652d02cca4905bb739c7ed98f4 127.0.0.1:6381@16381 slave 8492f9a7d36ab632610da9aee75491466658cd67 0 1544212190000 1 connected
8492f9a7d36ab632610da9aee75491466658cd67 127.0.0.1:6379@16379 master - 0 1544212190160 1 connected 1-3
9dfbd151548a44ecf8a5dd39c69e830bca5cbd6a 127.0.0.1:6380@16380 master - 0 1544212191172 0 connected 4-6
666925840c9780bf852bfbde46ae36fbbc44e67c 127.0.0.1:6382@16382 myself,slave 9dfbd151548a44ecf8a5dd39c69e830bca5cbd6a 0 1544212189000 0 connected