### PR TITLE
Handle binary safe string for REQUIREPASS and MASTERAUTH directives

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1804,6 +1804,7 @@ error:
  */
 #define SYNC_CMD_READ (1<<0)
 #define SYNC_CMD_WRITE (1<<1)
+#define SYNC_CMD_WRITE_SDS (1<<2)
 #define SYNC_CMD_FULL (SYNC_CMD_READ|SYNC_CMD_WRITE)
 char *sendSynchronousCommand(int flags, connection *conn, ...) {
 
@@ -1821,8 +1822,13 @@ char *sendSynchronousCommand(int flags, connection *conn, ...) {
         while(1) {
             arg = va_arg(ap, char*);
             if (arg == NULL) break;
-
-            cmdargs = sdscatprintf(cmdargs,"$%zu\r\n%s\r\n",strlen(arg),arg);
+            if (flags & SYNC_CMD_WRITE_SDS) {
+                cmdargs = sdscatprintf(cmdargs,"$%zu\r\n", sdslen((sds)arg));
+                cmdargs = sdscatsds(cmdargs, (sds)arg);
+                cmdargs = sdscat(cmdargs, "\r\n");
+            } else {
+                cmdargs = sdscatprintf(cmdargs,"$%zu\r\n%s\r\n",strlen(arg),arg);
+            }
             argslen++;
         }
 
@@ -2135,13 +2141,20 @@ void syncWithMaster(connection *conn) {
     /* AUTH with the master if required. */
     if (server.repl_state == REPL_STATE_SEND_AUTH) {
         if (server.masteruser && server.masterauth) {
-            err = sendSynchronousCommand(SYNC_CMD_WRITE,conn,"AUTH",
-                                         server.masteruser,server.masterauth,NULL);
+            sds masteruser = sdsnew(server.masteruser);
+            sds auth = sdsnew("AUTH");
+            err = sendSynchronousCommand(SYNC_CMD_WRITE | SYNC_CMD_WRITE_SDS, conn, auth,
+                                         masteruser, server.masterauth, NULL);
+            sdsfree(masteruser);
+            sdsfree(auth);
             if (err) goto write_error;
             server.repl_state = REPL_STATE_RECEIVE_AUTH;
             return;
         } else if (server.masterauth) {
-            err = sendSynchronousCommand(SYNC_CMD_WRITE,conn,"AUTH",server.masterauth,NULL);
+            sds auth = sdsnew("AUTH");
+            err = sendSynchronousCommand(SYNC_CMD_WRITE | SYNC_CMD_WRITE_SDS, conn, auth,
+                    server.masterauth, NULL);
+            sdsfree(auth);
             if (err) goto write_error;
             server.repl_state = REPL_STATE_RECEIVE_AUTH;
             return;

--- a/src/server.h
+++ b/src/server.h
@@ -1283,7 +1283,7 @@ struct redisServer {
     int repl_diskless_sync_delay;   /* Delay to start a diskless repl BGSAVE. */
     /* Replication (slave) */
     char *masteruser;               /* AUTH with this user and masterauth with master */
-    char *masterauth;               /* AUTH with this password with master */
+    sds masterauth;                 /* AUTH with this password with master */
     char *masterhost;               /* Hostname of master */
     int masterport;                 /* Port of master */
     int repl_timeout;               /* Timeout after N seconds of master idle */

--- a/tests/unit/auth.tcl
+++ b/tests/unit/auth.tcl
@@ -25,3 +25,43 @@ start_server {tags {"auth"} overrides {requirepass foobar}} {
         r incr foo
     } {101}
 }
+
+start_server {tags {"auth_binary_password"}} {
+    test {AUTH fails when binary password is wrong} {
+        r config set requirepass "abc\x00def"
+        catch {r auth abc} err
+        set _ $err
+    } {WRONGPASS*}
+
+    test {AUTH succeeds when binary password is correct} {
+        r config set requirepass "abc\x00def"
+        r auth "abc\x00def"
+    } {OK}
+
+    start_server {tags {"masterauth"}} {
+        set master [srv -1 client]
+        set master_host [srv -1 host]
+        set master_port [srv -1 port]
+        set slave [srv 0 client]
+
+        test {MASTERAUTH test with binary password} {
+            $master config set requirepass "abc\x00def"
+
+            # Configure the replica with masterauth
+            $slave slaveof $master_host $master_port
+            $slave config set masterauth "abc"
+
+            # sleep for 3 seconds and verify replica is not in sync with master
+            $slave debug sleep 3
+            assert_equal {down} [s 0 master_link_status]
+            
+            # Test replica with the correct masterauth
+            $slave config set masterauth "abc\x00def"
+            wait_for_condition 50 100 {
+                [s 0 master_link_status] eq {up}
+            } else {
+                fail "Can't turn the instance into a replica"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Make REQUIREPASS and MASTERAUTH directives handle binary safe strings. Previously neither server.requirepass or server.masterauth handles binary safe SDS strings. This leads to inconsistencies in client experience around password authentication. 

i.e. On master

> config set requirepass "ab\x00cd"
OK
> AUTH ab
OK
> AUTH "ab\x00cd"
(error) WRONGPASS invalid username-password pair


After the fix. 

> config set requirepass "ab\x00cd"
OK
> AUTH ab
(error) WRONGPASS invalid username-password pair
> AUTH "ab\x00cd"
OK

Same goes for MASTERAUTH. 