### PR TITLE
Added a refcount on timer events to prevent deletion of recursive timer events

### DIFF
--- a/src/ae.h
+++ b/src/ae.h
@@ -86,6 +86,8 @@ typedef struct aeTimeEvent {
     void *clientData;
     struct aeTimeEvent *prev;
     struct aeTimeEvent *next;
+    int refcount; /* refcount to prevent timer events from being
+  		   * freed in recursive time event calls. */
 } aeTimeEvent;
 
 /* A fired event */


### PR DESCRIPTION
The problem is if from the timer job you recursively call aeProcessTimeEvents(). The timer event can be freed in the cursive call, but been descending the stack the timer event will still be referenced. 

Redis doesn't use this anywhere, but we did and it's maybe worth sharing since I know other individuals pull source from Redis. 