### PR TITLE
FIX[The config  "repl-diskless-sync-delay" may have no effect]

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1268,7 +1268,13 @@ void updateSlavesWaitingBgsave(int bgsaveerr, int type) {
             }
         }
     }
-    if (startbgsave) startBgsaveForReplication(mincapa);
+    
+    if (startbgsave){
+        if(server.repl_diskless_sync && (mincapa & SLAVE_CAPA_EOF))
+            return;
+        else
+            startBgsaveForReplication(mincapa);
+    }
 }
 
 /* Change the current instance replication ID with a new, random one.


### PR DESCRIPTION
When diskless replication is enabled, the config item "repl-diskless-sync-delay" may no longer have any effect under following situation:
1.The master enables diskless replication and sets "repl-diskless-sync-delay";
2.A client connects to this master and starts BGSAVE;
3.BGSAVE starts;
4.A slave with EOF capa connects to this master and asks for a full sync;
5.BGSAVE ends and the signal handler starts a new BGSAVE for replication(in updateSlavesWaitingBgsave()),the new BGSAVE is socket target.
6.repl-diskless-sync-delay expires now.