### PR TITLE
Use standrad isxdigit instead of custom helper function.

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -975,8 +975,8 @@ sds *sdssplitargs(const char *line, int *argc) {
             while(!done) {
                 if (inq) {
                     if (*p == '\\' && *(p+1) == 'x' &&
-                                             is_hex_digit(*(p+2)) &&
-                                             is_hex_digit(*(p+3)))
+                                             isxdigit(*(p+2)) &&
+                                             isxdigit(*(p+3)))
                     {
                         unsigned char byte;
 


### PR DESCRIPTION
Function is in std lib, already in use by lstrlib.c and on relevant platforms implemented 
in using table lookup and not a 3-range check