### PR TITLE
Redis-Benchmark: avoid potentical memmory leaking

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -303,7 +303,7 @@ fail:
     else fprintf(stderr, "%s\n", hostsocket);
     freeReplyObject(reply);
     redisFree(c);
-    zfree(cfg);
+    freeRedisConfig(cfg);
     return NULL;
 }
 static void freeRedisConfig(redisConfig *cfg) {


### PR DESCRIPTION
Similar to PR: https://github.com/antirez/redis/pull/7204, there is another problem in this part of code, if first CONFIG GET succeeds but second fails, we also need to free cfg->save, therefore freeRedisConfig function shoud be used during the failed clean up