### PR TITLE
Add cluster-bus-port to allow running in non-docker, multi-tenant environments

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1291,6 +1291,16 @@ lua-time-limit 5000
 
 ########################## CLUSTER DOCKER/NAT support  ########################
 
+# This option specifies the local port number that the cluster bus port
+# should be opened on. It defaults to the client port + 1000 if not set.
+#
+# This can be helpful when running Redis Cluster in a multi-tenant environment
+# that does not offer port remapping tools such as Docker networking. Redis will
+# announce this port to be used by other Redis instances, if cluster-announce-port
+# is not explictly set to override this.
+# 
+# cluster-bus-port 16379
+
 # In certain deployments, Redis Cluster nodes address discovery fails, because
 # addresses are NAT-ted or because ports are forwarded (the typical case is
 # Docker and other containers).

--- a/src/config.c
+++ b/src/config.c
@@ -2167,7 +2167,8 @@ standardConfig configs[] = {
     createIntConfig("timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.maxidletime, 0, INTEGER_CONFIG, NULL, NULL), /* Default client timeout: infinite */
     createIntConfig("replica-announce-port", "slave-announce-port", MODIFIABLE_CONFIG, 0, 65535, server.slave_announce_port, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("tcp-backlog", NULL, IMMUTABLE_CONFIG, 0, INT_MAX, server.tcp_backlog, 511, INTEGER_CONFIG, NULL, NULL), /* TCP listen backlog. */
-    createIntConfig("cluster-announce-bus-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_bus_port, 0, INTEGER_CONFIG, NULL, NULL), /* Default: Use +10000 offset. */
+    createIntConfig("cluster-bus-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_bus_port, 0, INTEGER_CONFIG, NULL, NULL), /* Default: Use +10000 offset. */
+    createIntConfig("cluster-announce-bus-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_bus_port, 0, INTEGER_CONFIG, NULL, NULL), /* Default: cluster-bus-port if set, otherwise use +10000 offset. */
     createIntConfig("cluster-announce-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_port, 0, INTEGER_CONFIG, NULL, NULL), /* Use server.port */
     createIntConfig("repl-timeout", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.repl_timeout, 60, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("repl-ping-replica-period", "repl-ping-slave-period", MODIFIABLE_CONFIG, 1, INT_MAX, server.repl_ping_slave_period, 10, INTEGER_CONFIG, NULL, NULL),

--- a/src/server.h
+++ b/src/server.h
@@ -1379,6 +1379,7 @@ struct redisServer {
     int cluster_slave_no_failover;  /* Prevent slave from starting a failover
                                        if the master is in failure state. */
     char *cluster_announce_ip;  /* IP address to announce on cluster bus. */
+    int cluster_bus_port;          /* bus port to bind on */
     int cluster_announce_port;     /* base port to announce on cluster bus. */
     int cluster_announce_bus_port; /* bus port to announce on cluster bus. */
     int cluster_module_flags;      /* Set of flags that Redis modules are able


### PR DESCRIPTION
In our specific environment we run many different Redis instances+clusters in a multi-tenant environment where we do not have control over which ports we get assigned but rather have to work with that we get. Usually this is a perfect usecase for the port remapping that's provided by Docker but sadly we can't rely on that in our case for a multitude of reasons. 

This change adds a `cluster-bus-port` option that allows the user to override the actual port that the cluster bus port listens on. This allows us to not only announce a different cluster port but also actually listen on any port. 

As for the announcement/propagation of the port within the Redis cluster, this is now the priority:
- If `cluster-announce-bus-port` is set, then that port is announced. You can set both `cluster-bus-port` but still announce another port with `cluster-announce-bus-port`.
- If `cluster-bus-port` is set, then that port is announced
- In the default case, we both bind & announce the client port + 10000

I've done a manual validation of this changeset with a config file that looks like this:
```
port 7000
cluster-bus-port 6000
cluster-enabled yes
cluster-config-file nodes.conf
cluster-node-timeout 5000
appendonly yes
```

I've looked at adding automated testing for this but it appears to have a pretty significant effort given that the setup logic is in the base testing code. Please advise on how to proceed there.