### PR TITLE
Small probability memory out of bounds

### DIFF
--- a/src/siphash.c
+++ b/src/siphash.c
@@ -76,7 +76,7 @@ int siptlw(int c) {
     U32TO8_LE((p) + 4, (uint32_t)((v) >> 32));
 
 #ifdef UNALIGNED_LE_CPU
-#define U8TO64_LE(p) (*((uint64_t*)(p)))
+#define U8TO64_LE(p) (((uint64_t)(*p)))
 #else
 #define U8TO64_LE(p)                                                           \
     (((uint64_t)((p)[0])) | ((uint64_t)((p)[1]) << 8) |                        \


### PR DESCRIPTION
(gdb) bt
#0  0x00007fb37633d4c7 in kill () from /lib64/libc.so.6
#1  0x000000000046d5ee in sigsegvHandler (sig=11, info=<optimized out>, secret=<optimized out>) at debug.c:1120
#2  <signal handler called>
#3  siphash (in=0x7fb36c400000 <Address 0x7fb36c400000 out of bounds>, inlen=<optimized out>, k=<optimized out>) at siphash.c:136
#4  0x000000000042b081 in dictAddRaw (d=d@entry=0x7fb36f818120, key=0x7fb35f2891f0, existing=existing@entry=0x0) at dict.c:302