### PR TITLE
Fix reply bytes calculation error on 32bit platform

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -488,7 +488,7 @@ void trimReplyUnusedTailSpace(client *c) {
         /* take over the allocation's internal fragmentation (at least for
          * memory usage tracking) */
         tail->size = zmalloc_usable(tail) - sizeof(clientReplyBlock);
-        c->reply_bytes += tail->size - old_size;
+        c->reply_bytes = c->reply_bytes + tail->size - old_size;
         listNodeValue(ln) = tail;
     }
 }


### PR DESCRIPTION
Fix #7275.
For this line https://github.com/antirez/redis/blob/unstable/src/networking.c#L491
On 32bit platform, the type of `c->reply_bytes` is unsigned long long, so it is 8 bytes,
the types of `tail->size` and `old_size` are size_t, so it is 4 bytes, `old_size` is exactly bigger that `tail->size`, so the result of  `tail->size - old_size` is very big.
> https://stackoverflow.com/questions/7221409/is-unsigned-integer-subtraction-defined-behavior

But `c->reply_bytes` is 8 bytes, the result will be add at last 4 bytes in `c->reply_bytes`, so `c->reply_bytes` is very big. Redis will coredump when execute `serverAssert(c->reply_bytes < SIZE_MAX-(1024*64));`

BTW, for current unstable branch, tests will exit with errors if we `make 32bit` and `sh runtest`.

There is a test, output is `4294967395`.
```
#include <stdio.h>

int main(void) {
    unsigned long long a;
    unsigned int b, c;

    a = 100;
    b = 1;
    c = 2;
    a += b-c;
    printf("%llu\n", a);

    return 0;
}
```
@antirez @oranagra 