### PR TITLE
EAGAIN not handled for TLS during diskless load

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1526,6 +1526,10 @@ void readSyncBulkPayload(connection *conn) {
 
         nread = connRead(conn,buf,readlen);
         if (nread <= 0) {
+            if (connGetState(conn) == CONN_STATE_CONNECTED) {
+                /* equivalent to EAGAIN */
+                return;
+            }
             serverLog(LL_WARNING,"I/O error trying to sync with MASTER: %s",
                 (nread == -1) ? strerror(errno) : "connection lost");
             cancelReplicationHandshake();


### PR DESCRIPTION
For TLS, we might not have read in a full frame, so there is data on the connection so epoll fires, but there isn't enough data to actually read from the socket. 

Not sure how common this is, we have some testing that randomly fragments TLS packets to catch some of this stuff. I don't think this can happen for TCP. 