### PR TITLE
Tracking: add CLIENT TRACKINGINFO subcommand

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2690,7 +2690,7 @@ NULL
             addReplyLongLong(c,-1);
         }
     } else if (!strcasecmp(c->argv[1]->ptr,"trackinginfo") && c->argc == 2) {
-        addReplyMapLen(c,5);
+        addReplyMapLen(c,3);
 
         /* Flags */
         addReplyBulkCString(c,"flags");

--- a/src/networking.c
+++ b/src/networking.c
@@ -2705,10 +2705,18 @@ NULL
         if (c->flags & CLIENT_TRACKING_OPTIN) {
             addReplyBulkCString(c,"optin");
             numflags++;
+            if (c->flags & CLIENT_TRACKING_CACHING) {
+                addReplyBulkCString(c,"caching-yes");
+                numflags++;        
+            }
         }
         if (c->flags & CLIENT_TRACKING_OPTOUT) {
             addReplyBulkCString(c,"optout");
             numflags++;
+            if (c->flags & CLIENT_TRACKING_CACHING) {
+                addReplyBulkCString(c,"caching-no");
+                numflags++;        
+            }
         }
         if (c->flags & CLIENT_TRACKING_NOLOOP) {
             addReplyBulkCString(c,"noloop");
@@ -2741,26 +2749,6 @@ NULL
             raxStop(&ri);
         } else {
             addReplyArrayLen(c,0);
-        }
-
-        /* Opt mode */
-        addReplyBulkCString(c,"opt-mode");
-        if (c->flags & CLIENT_TRACKING_OPTIN) {
-            addReplyBulkCString(c,"optin");
-        } else if (c->flags & CLIENT_TRACKING_OPTOUT) {
-            addReplyBulkCString(c,"optout");
-        } else {
-            addReplyNull(c);
-        }
-
-        /* Caching */
-        addReplyBulkCString(c,"caching");
-        if (c->flags & CLIENT_TRACKING_OPTIN) {
-            addReplyBulkCString(c,c->flags & CLIENT_TRACKING_CACHING ? "yes" : "no");
-        } else if (c->flags & CLIENT_TRACKING_OPTOUT) {
-            addReplyBulkCString(c,c->flags & CLIENT_TRACKING_CACHING ? "no" : "yes");
-        } else {
-            addReplyNull(c);
         }
     } else {
         addReplyErrorFormat(c, "Unknown subcommand or wrong number of arguments for '%s'. Try CLIENT HELP", (char*)c->argv[1]->ptr);

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -407,10 +407,6 @@ start_server {tags {"tracking"}} {
         assert_equal {-1} $redirect
         set prefixes [dict get $res prefixes]
         assert_equal {} $prefixes
-        set opt [dict get $res opt-mode]
-        assert_equal {} $opt
-        set caching [dict get $res caching]
-        assert_equal {} $caching
     }
 
     test {CLIENT TRACKINGINFO provides reasonable results when tracking on} {
@@ -422,10 +418,6 @@ start_server {tags {"tracking"}} {
         assert_equal {0} $redirect
         set prefixes [dict get $res prefixes]
         assert_equal {} $prefixes
-        set opt [dict get $res opt-mode]
-        assert_equal {} $opt
-        set caching [dict get $res caching]
-        assert_equal {} $caching
     }
 
     test {CLIENT TRACKINGINFO provides reasonable results when tracking on with options} {
@@ -437,10 +429,6 @@ start_server {tags {"tracking"}} {
         assert_equal $redir_id $redirect
         set prefixes [dict get $res prefixes]
         assert_equal {} $prefixes
-        set opt [dict get $res opt-mode]
-        assert_equal {} $opt
-        set caching [dict get $res caching]
-        assert_equal {} $caching
     }
 
     test {CLIENT TRACKINGINFO provides reasonable results when tracking optin} {
@@ -453,15 +441,11 @@ start_server {tags {"tracking"}} {
         assert_equal {0} $redirect
         set prefixes [dict get $res prefixes]
         assert_equal {} $prefixes
-        set opt [dict get $res opt-mode]
-        assert_equal {optin} $opt
-        set caching [dict get $res caching]
-        assert_equal {no} $caching
 
         r CLIENT CACHING yes
         set res [r client trackinginfo]
-        set caching [dict get $res caching]
-        assert_equal {yes} $caching
+        set flags [dict get $res flags]
+        assert_equal {on optin caching-yes} $flags
     }
 
     test {CLIENT TRACKINGINFO provides reasonable results when tracking optout} {
@@ -474,15 +458,11 @@ start_server {tags {"tracking"}} {
         assert_equal {0} $redirect
         set prefixes [dict get $res prefixes]
         assert_equal {} $prefixes
-        set opt [dict get $res opt-mode]
-        assert_equal {optout} $opt
-        set caching [dict get $res caching]
-        assert_equal {yes} $caching
 
         r CLIENT CACHING no
         set res [r client trackinginfo]
-        set caching [dict get $res caching]
-        assert_equal {no} $caching
+        set flags [dict get $res flags]
+        assert_equal {on optout caching-no} $flags
     }
 
     test {CLIENT TRACKINGINFO provides reasonable results when tracking bcast mode} {
@@ -495,10 +475,6 @@ start_server {tags {"tracking"}} {
         assert_equal {0} $redirect
         set prefixes [lsort [dict get $res prefixes]]
         assert_equal {bar foo} $prefixes
-        set opt [dict get $res opt-mode]
-        assert_equal {} $opt
-        set caching [dict get $res caching]
-        assert_equal {} $caching
     }
 
     $rd_redirection close

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -398,6 +398,109 @@ start_server {tags {"tracking"}} {
         assert {$total_prefixes == 1}
     }
 
+    test {CLIENT TRACKINGINFO provides reasonable results when tracking off} {
+        r CLIENT TRACKING off
+        set res [r client trackinginfo]
+        set flags [dict get $res flags]
+        assert_equal {off} $flags
+        set redirect [dict get $res redirect]
+        assert_equal {-1} $redirect
+        set prefixes [dict get $res prefixes]
+        assert_equal {} $prefixes
+        set opt [dict get $res opt-mode]
+        assert_equal {} $opt
+        set caching [dict get $res caching]
+        assert_equal {} $caching
+    }
+
+    test {CLIENT TRACKINGINFO provides reasonable results when tracking on} {
+        r CLIENT TRACKING on
+        set res [r client trackinginfo]
+        set flags [dict get $res flags]
+        assert_equal {on} $flags
+        set redirect [dict get $res redirect]
+        assert_equal {0} $redirect
+        set prefixes [dict get $res prefixes]
+        assert_equal {} $prefixes
+        set opt [dict get $res opt-mode]
+        assert_equal {} $opt
+        set caching [dict get $res caching]
+        assert_equal {} $caching
+    }
+
+    test {CLIENT TRACKINGINFO provides reasonable results when tracking on with options} {
+        r CLIENT TRACKING on REDIRECT $redir_id noloop
+        set res [r client trackinginfo]
+        set flags [dict get $res flags]
+        assert_equal {on noloop} $flags
+        set redirect [dict get $res redirect]
+        assert_equal $redir_id $redirect
+        set prefixes [dict get $res prefixes]
+        assert_equal {} $prefixes
+        set opt [dict get $res opt-mode]
+        assert_equal {} $opt
+        set caching [dict get $res caching]
+        assert_equal {} $caching
+    }
+
+    test {CLIENT TRACKINGINFO provides reasonable results when tracking optin} {
+        r CLIENT TRACKING off
+        r CLIENT TRACKING on optin
+        set res [r client trackinginfo]
+        set flags [dict get $res flags]
+        assert_equal {on optin} $flags
+        set redirect [dict get $res redirect]
+        assert_equal {0} $redirect
+        set prefixes [dict get $res prefixes]
+        assert_equal {} $prefixes
+        set opt [dict get $res opt-mode]
+        assert_equal {optin} $opt
+        set caching [dict get $res caching]
+        assert_equal {no} $caching
+
+        r CLIENT CACHING yes
+        set res [r client trackinginfo]
+        set caching [dict get $res caching]
+        assert_equal {yes} $caching
+    }
+
+    test {CLIENT TRACKINGINFO provides reasonable results when tracking optout} {
+        r CLIENT TRACKING off
+        r CLIENT TRACKING on optout
+        set res [r client trackinginfo]
+        set flags [dict get $res flags]
+        assert_equal {on optout} $flags
+        set redirect [dict get $res redirect]
+        assert_equal {0} $redirect
+        set prefixes [dict get $res prefixes]
+        assert_equal {} $prefixes
+        set opt [dict get $res opt-mode]
+        assert_equal {optout} $opt
+        set caching [dict get $res caching]
+        assert_equal {yes} $caching
+
+        r CLIENT CACHING no
+        set res [r client trackinginfo]
+        set caching [dict get $res caching]
+        assert_equal {no} $caching
+    }
+
+    test {CLIENT TRACKINGINFO provides reasonable results when tracking bcast mode} {
+        r CLIENT TRACKING off
+        r CLIENT TRACKING on BCAST PREFIX foo PREFIX bar
+        set res [r client trackinginfo]
+        set flags [dict get $res flags]
+        assert_equal {on bcast} $flags
+        set redirect [dict get $res redirect]
+        assert_equal {0} $redirect
+        set prefixes [lsort [dict get $res prefixes]]
+        assert_equal {bar foo} $prefixes
+        set opt [dict get $res opt-mode]
+        assert_equal {} $opt
+        set caching [dict get $res caching]
+        assert_equal {} $caching
+    }
+
     $rd_redirection close
     $rd close
 }


### PR DESCRIPTION
Now we have a lot of options for client tracking, I think we need a way to show the tracking status.

This PR reply an txt, maybe map is better, not sure.