### PR TITLE
remove unused function anetTcpKeepAlive

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -169,16 +169,6 @@ int anetSetSendBuffer(char *err, int fd, int buffsize)
     return ANET_OK;
 }
 
-int anetTcpKeepAlive(char *err, int fd)
-{
-    int yes = 1;
-    if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes)) == -1) {
-        anetSetError(err, "setsockopt SO_KEEPALIVE: %s", strerror(errno));
-        return ANET_ERR;
-    }
-    return ANET_OK;
-}
-
 /* Set the socket send timeout (SO_SNDTIMEO socket option) to the specified
  * number of milliseconds, or disable it if the 'ms' argument is zero. */
 int anetSendTimeout(char *err, int fd, long long ms) {

--- a/src/anet.c
+++ b/src/anet.c
@@ -459,7 +459,7 @@ static int anetListen(char *err, int s, struct sockaddr *sa, socklen_t len, int 
 static int anetV6Only(char *err, int s) {
     int yes = 1;
     if (setsockopt(s,IPPROTO_IPV6,IPV6_V6ONLY,&yes,sizeof(yes)) == -1) {
-        anetSetError(err, "setsockopt: %s", strerror(errno));
+        anetSetError(err, "setsockopt IPV6_V6ONLY: %s", strerror(errno));
         close(s);
         return ANET_ERR;
     }

--- a/src/anet.h
+++ b/src/anet.h
@@ -68,7 +68,6 @@ int anetNonBlock(char *err, int fd);
 int anetBlock(char *err, int fd);
 int anetEnableTcpNoDelay(char *err, int fd);
 int anetDisableTcpNoDelay(char *err, int fd);
-int anetTcpKeepAlive(char *err, int fd);
 int anetSendTimeout(char *err, int fd, long long ms);
 int anetRecvTimeout(char *err, int fd, long long ms);
 int anetPeerToString(int fd, char *ip, size_t ip_len, int *port);


### PR DESCRIPTION
The function `anetTcpKeepAlive` is actually never used , and we have been using `anetKeepAlive` instead, so it can be removed.

And in function `anetV6Only` the error message does not contain the  optname(`IPV6_V6ONLY`), so added it.