### PR TITLE
PSYNC2: second_replid_offset should be real meaningful offset

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2531,14 +2531,14 @@ void replicationUnsetMaster(void) {
 
     sdsfree(server.masterhost);
     server.masterhost = NULL;
+    if (server.master) freeClient(server.master);
+    replicationDiscardCachedMaster();
+    cancelReplicationHandshake();
     /* When a slave is turned into a master, the current replication ID
      * (that was inherited from the master at synchronization time) is
      * used as secondary ID up to the current offset, and a new replication
      * ID is created to continue with a new replication history. */
     shiftReplicationId();
-    if (server.master) freeClient(server.master);
-    replicationDiscardCachedMaster();
-    cancelReplicationHandshake();
     /* Disconnecting all the slaves is required: we need to inform slaves
      * of the replication ID change (see shiftReplicationId() call). However
      * the slaves will be able to partially resync with us, so it will be


### PR DESCRIPTION
After adjustMeaningfulReplOffset(), all the other related variable should be updated, including server.second_replid_offset.

Or the old version redis like 5.0 may receive wrong data from replication stream, cause redis 5.0 can sync with redis 6.0, but doesn't know meaningful offset.

Here is the original issue:

> Hi all, I've read this thread, all the fixes makes sense and can work well for redis 6.0, but for old version redis 5.0, there is still a problem, it's about `server. second_replid_offset`.
> 
> Redis 5.0 can sync with redis 6.0, but doesn't know meaningful offset, so the old version redis 5.0 may receive wrong data from replication stream, for example:
> 
> 1. We have three instances, `R6A` `R6B` is redis 6, and `R6B` is an replica of `R6A`, and `R5` is redis 5 replica of `R6B`.
> 2. Now replication offset is 126 in all the three instance, and `R6A` `R6B`'s meaningful offset is 60, but `R5` doesn't know the meaningful offset.
> 3. Then we send `replicaof no one` to `R6B` promote it to be master, and `R6B` would store `replid2` and `second_replid_offset` with 60, and disconnect `R5`.
> 4. After that before `R5` reconnect with `R6B`, we append some commands to `R6B` increasing the offset to 130, and `R5` try psync replid2 126 to `R6B`, it works but `R5` will receive wrong data.
> 
> To fix it, I think after adjustMeaningfulReplOffset(), all the other related variable should be updated like `server.second_replid_offset`, see PR #7320
> 
> Moreover, should we increase `RDB_VERSION`? Then redis 5 cannot sync with redis 6, but redis 6.0 doesn't change any data types.

@QuChen88 's question:

> @soloestoy I don't know what you mean specifically about "receiving the wrong data". Can you please be more specific as to what data with R5 receive from R6B? i.e. from which offset will the new master R6B send the data to R5? Or will the PSYNC request be rejected and force a full sync? It would be helpful to implement a test case that would reproduce this hypothetical scenario.
> 
> I just walked through the code for the method shiftReplicationId(), it is setting `server. second_replid_offset` to be `server.master_repl_offset+1`. My understanding is that this will not introduce any regression for older redis versions that don't support meaningful offset feature to PSYNC with redis 6.0. Please correct me if I am wrong.

And my reply:

> @QuChen88 no full sync, psync can work in step 4, but offset 126 which `R5` expect to get from `R6B` is not correct, cause `R6B` has rollback offset to meaningful offset `60`, but backlog doesn't know that, so data from `126` to `130` in `R6B`'s backlog will be send to `R5`, but what `R5` want is data from `60` to `130`.

