### PR TITLE
client side caching: free space tracking table when calling flushdb

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -478,7 +478,7 @@ void signalModifiedKey(client *c, redisDb *db, robj *key) {
 
 void signalFlushedDb(int dbid) {
     touchWatchedKeysOnFlush(dbid);
-    trackingInvalidateKeysOnFlush(dbid);
+    trackingInvalidateKeysOnFlush();
 }
 
 /*-----------------------------------------------------------------------------

--- a/src/server.h
+++ b/src/server.h
@@ -1692,7 +1692,7 @@ void enableTracking(client *c, uint64_t redirect_to, uint64_t options, robj **pr
 void disableTracking(client *c);
 void trackingRememberKeys(client *c);
 void trackingInvalidateKey(client *c, robj *keyobj);
-void trackingInvalidateKeysOnFlush(int dbid);
+void trackingInvalidateKeysOnFlush();
 void trackingLimitUsedSlots(void);
 uint64_t trackingGetTotalItems(void);
 uint64_t trackingGetTotalKeys(void);

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -353,7 +353,7 @@ void freeTrackingRadixTree(void *rt) {
     raxFree(rt);
 }
 
-void trackingInvalidateKeysOnFlush(int dbid) {
+void trackingInvalidateKeysOnFlush() {
     if (server.tracking_clients) {
         listNode *ln;
         listIter li;
@@ -366,8 +366,8 @@ void trackingInvalidateKeysOnFlush(int dbid) {
         }
     }
 
-    /* In case of FLUSHALL, reclaim all the memory used by tracking. */
-    if (dbid == -1 && TrackingTable) {
+    /* reclaim all the memory used by tracking. */
+    if (TrackingTable) {
         raxFreeWithCallback(TrackingTable,freeTrackingRadixTree);
         TrackingTable = raxNew();
         TrackingTableTotalItems = 0;


### PR DESCRIPTION
In trackingInvalidateKeysOnFlush function, since we already send caching invalidation message to all tracking clients to flush all client side caches, therefore there is no need to maintain previous record of tracking, no matter whether FLUSHALL was called or not ..