### PR TITLE
Add MHGET - command to get fields from multiple hashes

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -514,6 +514,10 @@ struct redisCommand redisCommandTable[] = {
      "read-only fast @hash",
      0,NULL,1,1,1,0,0,0},
 
+    {"mhget",mhgetCommand,-2,
+     "read-only fast @hash",
+     0,NULL,1,-1,1,0,0,0},
+
     {"hincrby",hincrbyCommand,4,
      "write use-memory fast @hash",
      0,NULL,1,1,1,0,0,0},

--- a/src/server.h
+++ b/src/server.h
@@ -2321,6 +2321,7 @@ void hsetnxCommand(client *c);
 void hgetCommand(client *c);
 void hmsetCommand(client *c);
 void hmgetCommand(client *c);
+void mhgetCommand(client *c);
 void hdelCommand(client *c);
 void hlenCommand(client *c);
 void hstrlenCommand(client *c);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -703,6 +703,27 @@ void hmgetCommand(client *c) {
     }
 }
 
+void mhgetCommand(client *c) {
+    robj *o;
+    int i;
+
+    if ((c->argc % 2) == 0) {
+        addReplyError(c,"wrong number of arguments for MHGET");
+        return;
+    }
+
+    addReplyArrayLen(c,(c->argc-1) / 2);
+
+    for (i = 1; i < c->argc; i += 2) {
+        o = lookupKeyRead(c->db, c->argv[i]);
+        if (o == NULL || o->type != OBJ_HASH) {
+            addReplyNull(c);
+        } else {
+            addHashFieldToReply(c, o, c->argv[i+1]->ptr);
+        }
+    }
+}
+
 void hdelCommand(client *c) {
     robj *o;
     int j, deleted = 0, keyremoved = 0;

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -177,6 +177,46 @@ start_server {tags {"hash"}} {
         set _ $err
     } {}
 
+    test {MHGET against non existing key and fields} {
+        set rv {}
+        lappend rv [r mhget doesntexist __123123123__ notthiseither __456456456__]
+        lappend rv [r mhget smallhash __123123123__]
+        lappend rv [r mhget bighash __123123123__ bighash __456456456__]
+        set _ $rv
+    } {{{} {}} {{}} {{} {}}}
+
+    test {MHGET against wrong type returns nil} {
+        r set wrongtype somevalue
+        r mhget wrongtype __123123123__
+    } {{}}
+
+    test {MHGET wrong argument count} {
+        assert_error "*wrong*" {r mhget key}
+        assert_error "*wrong*" {r mhget key val key}
+    }
+
+    test {MHGET - small and big hash} {
+        set keys {}
+        set vals {}
+        foreach {k v} [array get smallhash] {
+            lappend keys "smallhash"
+            lappend keys $k
+            lappend vals $v
+        }
+        foreach {k v} [array get bighash] {
+            lappend keys "bighash"
+            lappend keys $k
+            lappend vals $v
+        }
+        set err {}
+        set result [r mhget {*}$keys]
+        if {$vals ne $result} {
+            set err "$vals != $result"
+            break
+        }
+        set _ $err
+    } {}
+
     test {HKEYS - small hash} {
         lsort [r hkeys smallhash]
     } [lsort [array names smallhash *]]


### PR DESCRIPTION
This PR adds a new command, which is a mix of MGET and HGET. It allows you to query for fields from multiple hashes in one command:

```
MHGET key field [key field ...]
```

I find this useful in a few cases. The main use-case I have currently is that we store user experiment assignments in Redis, as one hash per experiment, one field per user, value is the assignment group. By having the hash be per experiment, we can easily drop the hash once the experiment is over (we actually `HSCAN` through the hash to delete fields in batches before dropping the key, to not pay the `O(N)` cost in a single query). The drawback of this structure is that we need to execute several `HGET` commands to get all experiment assignments for a specific user. (We have usually <20 active experiments, but 10s of millions of active users).

I thought I'd propose a specific command for this use-case. I apologize for not going through the flow recommended in the contributing guidelines, of posting to the mailing list first. I wanted to build something, code in C again after a long break. If this isn't deemed a fit in Redis I don't consider the hour I spent coding and learning the codebase wasted. If you think it's worth posting about this on the mailing list to solicit more feedback I'm more than happy to do so.

I think `MHGET` is slightly unfortunate as a command name. All other hash commands start with `H`. Perhaps `HMHGET` could work?