### PR TITLE
Don't allow EXEC to actually run commands during a busy script

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -134,9 +134,11 @@ void execCommand(client *c) {
      * A failed EXEC in the first case returns a multi bulk nil object
      * (technically it is not an error but a special behavior), while
      * in the second an EXECABORT error is returned. */
-    if (c->flags & (CLIENT_DIRTY_CAS|CLIENT_DIRTY_EXEC)) {
-        addReply(c, c->flags & CLIENT_DIRTY_EXEC ? shared.execaborterr :
-                                                   shared.nullarray[c->resp]);
+    if ((c->flags & (CLIENT_DIRTY_CAS|CLIENT_DIRTY_EXEC)) ||
+        server.lua_timedout)
+    {
+        addReply(c, (c->flags & CLIENT_DIRTY_EXEC) || server.lua_timedout?
+            shared.execaborterr : shared.nullarray[c->resp]);
         discardTransaction(c);
         goto handle_monitor;
     }


### PR DESCRIPTION
We allow EXEC to run during a busy script so that it discards the
transaction state. this happens correctly if you actually tried to schedule
any command while the script is busy.
but if all the commands were already scheduled, and just the EXEC
arrives during the script, we would have executed it and violate the
script atomicity.

this bug was added in ec007559ff703d27916f54ad0a41d154a88d9ac4
which fixed another type of  violation (not clearing the transaction
state of the client connection).

fact is that we must alwasy execute MULTI/EXEC/DISCARD in order to
change the client state, but we need to make sure not to actually
execute the command in that case.