### PR TITLE
Reduce "Received SIGUSR1" log level to LL_VERBOSE

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4768,7 +4768,7 @@ void setupSignalHandlers(void) {
  * accepting writes because of a write error condition. */
 static void sigKillChildHandler(int sig) {
     UNUSED(sig);
-    serverLogFromHandler(LL_WARNING, "Received SIGUSR1 in child, exiting now.");
+    serverLogFromHandler(LL_VERBOSE, "Received SIGUSR1 in child, exiting now.");
     exitFromChild(SERVER_CHILD_NOERROR_RETVAL);
 }
 


### PR DESCRIPTION
Modules are using this Module API to terminate forked process this event is not a warning and might happen often.