### PR TITLE
return the correct proto version

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2522,7 +2522,7 @@ void helloCommand(client *c) {
     addReplyBulkCString(c,REDIS_VERSION);
 
     addReplyBulkCString(c,"proto");
-    addReplyLongLong(c,3);
+    addReplyLongLong(c,ver);
 
     addReplyBulkCString(c,"id");
     addReplyLongLong(c,c->id);


### PR DESCRIPTION
HELLO should return the current proto version. But current code always return 3.