### PR TITLE
fix disconnectSlaves, to try to free each slave.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1019,7 +1019,6 @@ void disconnectSlaves(void) {
     listNode *ln;
     listRewind(server.slaves,&li);
     while((ln = listNext(&li))) {
-        listNode *ln = listFirst(server.slaves);
         freeClient((client*)ln->value);
     }
 }


### PR DESCRIPTION
the recent change in that loop (iteration rather than waiting for it to
be empty) was intended to avoid an endless loop in case some slave would
refuse to be freed.

but the lookup of the first client remained, which would have caused it
to try the first one again and again instead of moving on.