### PR TITLE
Make the protocol-version argument of HELLO optional

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2763,7 +2763,7 @@ void helloCommand(client *c) {
     long long ver;
 
     if (getLongLongFromObject(c->argv[1],&ver) != C_OK ||
-        ver < 2 || ver > 3)
+        (ver != 0 && ver < 2) || ver > 3)
     {
         addReplyError(c,"-NOPROTO unsupported protocol version");
         return;
@@ -2797,7 +2797,7 @@ void helloCommand(client *c) {
     }
 
     /* Let's switch to the specified RESP mode. */
-    c->resp = ver;
+    if (ver != 0) c->resp = ver;
     addReplyMapLen(c,6 + !server.sentinel_mode);
 
     addReplyBulkCString(c,"server");
@@ -2807,7 +2807,7 @@ void helloCommand(client *c) {
     addReplyBulkCString(c,REDIS_VERSION);
 
     addReplyBulkCString(c,"proto");
-    addReplyLongLong(c,ver);
+    addReplyLongLong(c,c->resp);
 
     addReplyBulkCString(c,"id");
     addReplyLongLong(c,c->id);

--- a/src/networking.c
+++ b/src/networking.c
@@ -2758,18 +2758,17 @@ NULL
     }
 }
 
-/* HELLO <protocol-version> [AUTH <user> <password>] [SETNAME <name>] */
+/* HELLO [protocol-version] [AUTH <user> <password>] [SETNAME <name>] */
 void helloCommand(client *c) {
-    long long ver;
+    long long ver = 0;
 
-    if (getLongLongFromObject(c->argv[1],&ver) != C_OK ||
-        (ver != 0 && ver < 2) || ver > 3)
-    {
+    if (c->argc >= 2 && getLongLongFromObject(c->argv[1],&ver) == C_OK &&
+            (ver < 2 || ver > 3)) {
         addReplyError(c,"-NOPROTO unsupported protocol version");
         return;
     }
 
-    for (int j = 2; j < c->argc; j++) {
+    for (int j = ver == 0 ? 1 : 2; j < c->argc; j++) {
         int moreargs = (c->argc-1) - j;
         const char *opt = c->argv[j]->ptr;
         if (!strcasecmp(opt,"AUTH") && moreargs >= 2) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -2769,6 +2769,11 @@ void helloCommand(client *c) {
         return;
     }
 
+    if (!ver && next_arg < c->argc) {
+        addReplyError(c,"Authentication needs to provide an protocol version");
+        return;
+    }
+
     for (int j = next_arg; j < c->argc; j++) {
         int moreargs = (c->argc-1) - j;
         const char *opt = c->argv[j]->ptr;

--- a/src/networking.c
+++ b/src/networking.c
@@ -2796,7 +2796,7 @@ void helloCommand(client *c) {
     }
 
     /* Let's switch to the specified RESP mode. */
-    if (!!ver) c->resp = ver;
+    if (ver) c->resp = ver;
     addReplyMapLen(c,6 + !server.sentinel_mode);
 
     addReplyBulkCString(c,"server");

--- a/src/networking.c
+++ b/src/networking.c
@@ -2770,7 +2770,7 @@ void helloCommand(client *c) {
     }
 
     if (!ver && next_arg < c->argc) {
-        addReplyError(c,"Authentication needs to provide an protocol version");
+        addReplyError(c,"Need to provide an protocol version for other arguments");
         return;
     }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -2763,7 +2763,7 @@ void helloCommand(client *c) {
     long long ver = 0;
     int next_arg = 1;
 
-    if (c->argc >= 2 && getLongLongFromObject(c->argv[1],&ver) == C_OK &&
+    if (c->argc >= 2 && getLongLongFromObject(c->argv[next_arg++],&ver) == C_OK &&
             (ver < 2 || ver > 3)) {
         addReplyError(c,"-NOPROTO unsupported protocol version");
         return;

--- a/src/networking.c
+++ b/src/networking.c
@@ -2768,7 +2768,7 @@ void helloCommand(client *c) {
         return;
     }
 
-    for (int j = ver == 0 ? 1 : 2; j < c->argc; j++) {
+    for (int j = !ver ? 1 : 2; j < c->argc; j++) {
         int moreargs = (c->argc-1) - j;
         const char *opt = c->argv[j]->ptr;
         if (!strcasecmp(opt,"AUTH") && moreargs >= 2) {
@@ -2796,7 +2796,7 @@ void helloCommand(client *c) {
     }
 
     /* Let's switch to the specified RESP mode. */
-    if (ver != 0) c->resp = ver;
+    if (!!ver) c->resp = ver;
     addReplyMapLen(c,6 + !server.sentinel_mode);
 
     addReplyBulkCString(c,"server");

--- a/src/networking.c
+++ b/src/networking.c
@@ -2765,7 +2765,7 @@ void helloCommand(client *c) {
 
     if (c->argc >= 2) {
         if (getLongLongFromObjectOrReply(c, c->argv[next_arg++], &ver,
-	    "The second argument should the protocol version if provided") != C_OK) {
+	    "Protocol version is not an integer or out of range") != C_OK) {
             return;
 	}
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -2765,9 +2765,9 @@ void helloCommand(client *c) {
 
     if (c->argc >= 2) {
         if (getLongLongFromObjectOrReply(c, c->argv[next_arg++], &ver,
-	    "Protocol version is not an integer or out of range") != C_OK) {
+            "Protocol version is not an integer or out of range") != C_OK) {
             return;
-	}
+        }
 
         if (ver < 2 || ver > 3) {
             addReplyError(c,"-NOPROTO unsupported protocol version");

--- a/src/networking.c
+++ b/src/networking.c
@@ -2763,15 +2763,16 @@ void helloCommand(client *c) {
     long long ver = 0;
     int next_arg = 1;
 
-    if (c->argc >= 2 && getLongLongFromObject(c->argv[next_arg++],&ver) == C_OK &&
-            (ver < 2 || ver > 3)) {
-        addReplyError(c,"-NOPROTO unsupported protocol version");
-        return;
-    }
+    if (c->argc >= 2) {
+        if (getLongLongFromObjectOrReply(c, c->argv[next_arg++], &ver,
+	    "The second argument should the protocol version if provided") != C_OK) {
+            return;
+	}
 
-    if (!ver && next_arg < c->argc) {
-        addReplyError(c,"Need to provide an protocol version for other arguments");
-        return;
+        if (ver < 2 || ver > 3) {
+            addReplyError(c,"-NOPROTO unsupported protocol version");
+            return;
+        }
     }
 
     for (int j = next_arg; j < c->argc; j++) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -2758,7 +2758,7 @@ NULL
     }
 }
 
-/* HELLO [protocol-version] [AUTH <user> <password>] [SETNAME <name>] */
+/* HELLO [<protocol-version> [AUTH <user> <password>] [SETNAME <name>] ] */
 void helloCommand(client *c) {
     long long ver = 0;
     int next_arg = 1;

--- a/src/networking.c
+++ b/src/networking.c
@@ -2769,7 +2769,7 @@ void helloCommand(client *c) {
         return;
     }
 
-    for (int j = !ver ? 1 : 2; j < c->argc; j++) {
+    for (int j = next_arg; j < c->argc; j++) {
         int moreargs = (c->argc-1) - j;
         const char *opt = c->argv[j]->ptr;
         if (!strcasecmp(opt,"AUTH") && moreargs >= 2) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -2761,6 +2761,7 @@ NULL
 /* HELLO [protocol-version] [AUTH <user> <password>] [SETNAME <name>] */
 void helloCommand(client *c) {
     long long ver = 0;
+    int next_arg = 1;
 
     if (c->argc >= 2 && getLongLongFromObject(c->argv[1],&ver) == C_OK &&
             (ver < 2 || ver > 3)) {

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -469,7 +469,7 @@ struct redisCommand sentinelcmds[] = {
     {"client",clientCommand,-2,"admin random @connection",0,NULL,0,0,0,0,0},
     {"shutdown",shutdownCommand,-1,"admin",0,NULL,0,0,0,0,0},
     {"auth",authCommand,-2,"no-auth fast @connection",0,NULL,0,0,0,0,0},
-    {"hello",helloCommand,-2,"no-auth fast @connection",0,NULL,0,0,0,0,0},
+    {"hello",helloCommand,-1,"no-auth fast @connection",0,NULL,0,0,0,0,0},
     {"acl",aclCommand,-2,"admin",0,NULL,0,0,0,0,0,0},
     {"command",commandCommand,-1, "random @connection", 0,NULL,0,0,0,0,0,0}
 };

--- a/src/server.c
+++ b/src/server.c
@@ -869,7 +869,7 @@ struct redisCommand redisCommandTable[] = {
      "admin no-script random ok-loading ok-stale @connection",
      0,NULL,0,0,0,0,0,0},
 
-    {"hello",helloCommand,-2,
+    {"hello",helloCommand,-1,
      "no-auth no-script fast no-monitor ok-loading ok-stale no-slowlog @connection",
      0,NULL,0,0,0,0,0,0},
 

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -135,6 +135,26 @@ start_server {tags {"tracking"}} {
         assert {[lindex $reply 2] eq {proto 3}}
     }
 
+    test {HELLO without protover} {
+        set reply [r HELLO 3]
+        assert {[lindex $reply 2] eq {proto 3}}
+
+        set reply [r HELLO]
+        assert {[lindex $reply 2] eq {proto 3}}
+
+        set reply [r HELLO]
+        assert {[lindex $reply 2] eq {proto 3}}
+
+        set reply [r HELLO 2]
+        assert {[lindex $reply 2] eq {proto 2}}
+
+        set reply [r HELLO]
+        assert {[lindex $reply 2] eq {proto 2}}
+
+        set reply [r HELLO]
+        assert {[lindex $reply 2] eq {proto 2}}
+    }
+
     test {RESP3 based basic invalidation} {
         r CLIENT TRACKING off
         r CLIENT TRACKING on

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -156,6 +156,9 @@ start_server {tags {"tracking"}} {
         set reply [r HELLO]
         assert {[lindex $reply 4] eq "proto"}
         assert {[lindex $reply 5] eq 2}
+        
+        # restore RESP3 for next test
+        r HELLO 3
     }
 
     test {RESP3 based basic invalidation} {

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -146,13 +146,16 @@ start_server {tags {"tracking"}} {
         assert {[lindex $reply 2] eq {proto 3}}
 
         set reply [r HELLO 2]
-        assert {[lindex $reply 6] eq 2}
+        assert {[lindex $reply 4] eq "proto"}
+        assert {[lindex $reply 5] eq 2}
 
         set reply [r HELLO]
-        assert {[lindex $reply 6] eq 2}
+        assert {[lindex $reply 4] eq "proto"}
+        assert {[lindex $reply 5] eq 2}
 
         set reply [r HELLO]
-        assert {[lindex $reply 6] eq 2}
+        assert {[lindex $reply 4] eq "proto"}
+        assert {[lindex $reply 5] eq 2}
     }
 
     test {RESP3 based basic invalidation} {

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -146,13 +146,13 @@ start_server {tags {"tracking"}} {
         assert {[lindex $reply 2] eq {proto 3}}
 
         set reply [r HELLO 2]
-        assert {[lindex $reply 2] eq {proto 2}}
+        assert {[lindex $reply 6] eq 2}
 
         set reply [r HELLO]
-        assert {[lindex $reply 2] eq {proto 2}}
+        assert {[lindex $reply 6] eq 2}
 
         set reply [r HELLO]
-        assert {[lindex $reply 2] eq {proto 2}}
+        assert {[lindex $reply 6] eq 2}
     }
 
     test {RESP3 based basic invalidation} {


### PR DESCRIPTION
As discussed in https://github.com/antirez/redis/issues/7364, it is good
to have a HELLO command variant, which does not switch the current proto
version of a redis server.

While `HELLO` will work, it introduced a certain difficulty on parsing
options of the command. We will need to offset the index of authentication
and setname option by -1.

So 0 is marked a special version meaning non-switching. And we do not
need to change the code much.