### PR TITLE
using dns address  for the configuration of "sentinel announce-ip" and "replicaof"

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2348,7 +2348,7 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
         /* if the config of master host of a slave is master`s hostname (ie, master_host: redis-0-svc),
          * it should convert hostname to ip  */
         sentinelAddr *slave_master_addr = createSentinelAddr(ri->slave_master_host, ri->slave_master_port);
-        if (strcasecmp(slave_master_addr->ip, ri->master->addr->ip))
+        if (!slave_master_addr || strcasecmp(slave_master_addr->ip, ri->master->addr->ip))
         {
             mstime_t wait_time = ri->master->failover_timeout;
 


### PR DESCRIPTION
When we deploy redis in kubernetes, each pod corresponds to a redis instance or sentinel instance, using the dns address as the pod's fixed external address, we found:
1. When sentinel is configured with "sentinel announce-ip sentinel-0-svc", sentinel-0-svc is this sentinel`s dns address, sentinel will always report the "+sentinel-address-switch" log when it is started.
2. When slave is configured with "replicaof redis-0-svc",  redis-0-svc is the master redis instance`s dns address, sentinel will report the “+slave” log first, followed by the “+fix-slave-config“ log，this will cause the slave to re-initiate replication to the master.

So, in these scenarios, should first convert the dns address (or hostname) to the ip address.