### PR TITLE
Speed dict lookup by caching computed hash value in dictEntry

### DIFF
--- a/src/dict.h
+++ b/src/dict.h
@@ -46,6 +46,7 @@
 
 typedef struct dictEntry {
     void *key;
+    uint64_t hash;
     union {
         void *val;
         uint64_t u64;


### PR DESCRIPTION
1. Add caching of computed hash value in dictEntry and use it to speed up lookups.
2. dict-benchmark updated to generate keys and shuffle them outside of benchmark.
**Improvements as measured by dict-benchmark for 5,000,000 keys** 

Benchmark (avg of 12 runs) | Before | After | Improve(ms)| Improve(%)
-----|--|--|--|-----
Inserting|2430|2146| 284|12%
Linear access|543|402|141|26%
Linear access 2nd round|542|402|141|26%
Random access existing|943|855|88|9%
Access missing|2002|1649|353|18%
Removing & adding|3030|2676|354|12%

Tested on
- OS: Ubuntu 20.04 LTS x86_64
- Kernel: 5.4.0-33-generic
- CPU: Intel i5-7500 (4) @ 3.800GHz
- Memory: 3737MiB / 15921MiB