### PR TITLE
cluster.c remove "if (nodeIsMaster(myself))" judgement before clusterSendFail in markNodeAsFailingIfNeeded, avoiding slave failover requires twice vote requests

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1255,7 +1255,7 @@ void markNodeAsFailingIfNeeded(clusterNode *node) {
 
     /* Broadcast the failing node name to everybody, forcing all the other
      * reachable nodes to flag the node as FAIL. */
-    if (nodeIsMaster(myself)) clusterSendFail(node->name);
+    clusterSendFail(node->name);
     clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE|CLUSTER_TODO_SAVE_CONFIG);
 }
 


### PR DESCRIPTION
https://github.com/antirez/redis/issues/7395   
 I remove "if (nodeIsMaster(myself))" judgement before clusterSendFail in markNodeAsFailingIfNeeded, and solved the problem in the above issue.
When a slave receive pfails about it's dead master from majority masters, the slave will mark  the dead master as fail, and next clusterCron the slave detect the flags of it's master is fail , so it start a slave failover. But if the slave can't send the fail message to the other node, all other masters may reject to vote as they don't receive the fail broadcast.
