### PR TITLE
fix the bug of rioConnRead

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -59,7 +59,6 @@ proc spawn_instance {type base_port count {conf {}}} {
     for {set j 0} {$j < $count} {incr j} {
         set port [find_available_port $base_port]
         incr base_port
-        puts "Starting $type #$j at port $port"
 
         # Create a directory for this instance.
         set dirname "${type}_${j}"
@@ -92,10 +91,30 @@ proc spawn_instance {type base_port count {conf {}}} {
         close $cfg
 
         # Finally exec it and remember the pid for later cleanup.
-        set pid [exec_instance $type $cfgfile]
-        lappend ::pids $pid
+        set retry 100
+        while {$retry} {
+            set pid [exec_instance $type $cfgfile]
+            after 1000
 
-        # Check availability
+            # Check availability
+            if {[server_is_up 127.0.0.1 $port 100] == 0} {
+                puts "Starting $type #$j at port $port failed, try another"
+                incr retry -1
+                set port [find_available_port [expr {$port+[randomInt 10]}]]
+                set cfg [open $cfgfile a+]
+                puts $cfg "port $port"
+                if {$::tls} {
+                    puts $cfg "tls-port $port"
+                }
+                close $cfg
+            } else {
+                puts "Starting $type #$j at port $port"
+                lappend ::pids $pid
+                break
+            }  
+        }
+
+        # Check availability finally
         if {[server_is_up 127.0.0.1 $port 100] == 0} {
             abort_sentinel_test "Problems starting $type #$j: ping timeout"
         }


### PR DESCRIPTION
In the function of rioConnRead, read_so_far is the size of redis get out from the connection buf, buffered is the size of connection buf left, so read_so_far+buffered is the total size of redis read from network. read_limit should compare to read_so_far+buffered instead of read_so_far-buffered.