### PR TITLE
Inconsistent RDB saving when in Sentinel mode

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -963,14 +963,6 @@ void shutdownCommand(client *c) {
             return;
         }
     }
-    /* When SHUTDOWN is called while the server is loading a dataset in
-     * memory we need to make sure no attempt is performed to save
-     * the dataset on shutdown (otherwise it could overwrite the current DB
-     * with half-read data).
-     *
-     * Also when in Sentinel mode clear the SAVE flag and force NOSAVE. */
-    if (server.loading || server.sentinel_mode)
-        flags = (flags & ~SHUTDOWN_SAVE) | SHUTDOWN_NOSAVE;
     if (prepareForShutdown(flags) == C_OK) exit(0);
     addReplyError(c,"Errors trying to SHUTDOWN. Check logs.");
 }

--- a/src/server.c
+++ b/src/server.c
@@ -3680,6 +3680,15 @@ void closeListeningSockets(int unlink_unix_socket) {
 }
 
 int prepareForShutdown(int flags) {
+    /* When SHUTDOWN is called while the server is loading a dataset in
+     * memory we need to make sure no attempt is performed to save
+     * the dataset on shutdown (otherwise it could overwrite the current DB
+     * with half-read data).
+     *
+     * Also when in Sentinel mode clear the SAVE flag and force NOSAVE. */
+    if (server.loading || server.sentinel_mode)
+        flags = (flags & ~SHUTDOWN_SAVE) | SHUTDOWN_NOSAVE;
+
     int save = flags & SHUTDOWN_SAVE;
     int nosave = flags & SHUTDOWN_NOSAVE;
 


### PR DESCRIPTION
**Issue description:**
When Redis is running in **Sentinel mode** - shutting down of the server behaves differently in case of:
  1. `SHUTDOWN` command - saving of RDB is explicitly disabled via checking `(server.loading || server.sentinel_mode)`, which sets `SHUTDOWN_NOSAVE` flag
  1. `SIGINT/SIGTERM signal` - although `SHUTDOWN_NOFLAGS` is being used in call to `prepareForShutdown()` - using improper configuration file that defines at least 1 `save ...` option triggers RDB saving, thus in turn could lead to overwriting of an existing RDB file with an empty one (as loading data is skipped in Sentinel mode).

**Steps to reproduce:**
This can be easily reproduced by running e.g. `redis-server redis.conf --port 9876 --sentinel` (using default `redis.conf` with `save ...` options) and then stopping it via `ctrl+c` - RDB is saved although it must not.

**Issue elimination:**
This change moves the check mentioned in regard to `SHUTDOWN` command to `prepareForShutdown()`, so Sentinel mode is checked consistently in both cases.