### PR TITLE
Make CLUSTER command safer.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4469,6 +4469,10 @@ NULL
                     (char*)c->argv[4]->ptr);
                 return;
             }
+            if (nodeIsSlave(n)) {
+                addReplyError(c, "CLUSTER SETSLOT <SLOT> NODE <NODE ID> not allowed to set slot to replica");
+                return;
+            }
             /* If this hash slot was served by 'myself' before to switch
              * make sure there are no longer local keys for this hash slot. */
             if (server.cluster->slots[slot] == myself && n != myself) {


### PR DESCRIPTION
When processing CLUSTER SETSLOT <SLOT> NODE <NODE ID>, it won't check the role
of the specified node, thus causing route inconsistency between the processing
node and others. Worse still, the slot ownership information on that node won't
change until another migrating of that slot would happen later on.