### PR TITLE
Add new commands lpushnx and rpushnx

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -282,6 +282,14 @@ struct redisCommand redisCommandTable[] = {
      "write use-memory fast @list",
      0,NULL,1,1,1,0,0,0},
 
+    {"rpushnx",rpushnxCommand,-3,
+     "write use-memory fast @list",
+     0,NULL,1,1,1,0,0,0},
+
+    {"lpushnx",lpushnxCommand,-3,
+     "write use-memory fast @list",
+     0,NULL,1,1,1,0,0,0},
+
     {"linsert",linsertCommand,5,
      "write use-memory @list",
      0,NULL,1,1,1,0,0,0},

--- a/src/server.h
+++ b/src/server.h
@@ -2246,6 +2246,8 @@ void lpushCommand(client *c);
 void rpushCommand(client *c);
 void lpushxCommand(client *c);
 void rpushxCommand(client *c);
+void lpushnxCommand(client *c);
+void rpushnxCommand(client *c);
 void linsertCommand(client *c);
 void lpopCommand(client *c);
 void rpopCommand(client *c);


### PR DESCRIPTION
Add two new commands to redis:

- lpushnx - Prepend an element to a list only if the list not exists
- rpushnx - Append an element to a list only if the list not exists

One of the use case is when there is multiple instance of a service that does some work by reading args from list,
but for the first start up the service need to initialize the tasks so it add to list only if no other instance add to the list before.