### PR TITLE
TLS: Ignore client cert when tls-auth-clients off.

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -337,9 +337,7 @@ connection *connCreateAcceptedTLS(int fd, int require_auth) {
     conn->c.state = CONN_STATE_ACCEPTING;
 
     if (!require_auth) {
-        /* We still verify certificates if provided, but don't require them.
-         */
-        SSL_set_verify(conn->ssl, SSL_VERIFY_PEER, NULL);
+        SSL_set_verify(conn->ssl, SSL_VERIFY_NONE, NULL);
     }
 
     SSL_set_fd(conn->ssl, conn->c.fd);


### PR DESCRIPTION
This fixes #7437 and basically avoids asking for or verifying client side certificates if `tls-auth-clients` is disabled.