### PR TITLE
fix the max length value

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -86,7 +86,7 @@
  * |10000000|qqqqqqqq|rrrrrrrr|ssssssss|tttttttt| - 5 bytes
  *      String value with length greater than or equal to 16384 bytes.
  *      Only the 4 bytes following the first byte represents the length
- *      up to 32^2-1. The 6 lower bits of the first byte are not used and
+ *      up to 2^32-1. The 6 lower bits of the first byte are not used and
  *      are set to zero.
  *      IMPORTANT: The 32 bit number is stored in big endian.
  * |11000000| - 3 bytes


### PR DESCRIPTION
There are 32 bits. So the max value is `2^32-1`. But now it is `32^2-1`.