### PR TITLE
Enabled background and reply time tracking on blocked clients

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -22,6 +22,7 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/hooks \
 --single unit/moduleapi/misc \
 --single unit/moduleapi/blockonkeys \
+--single unit/moduleapi/blockonbackground \
 --single unit/moduleapi/scan \
 --single unit/moduleapi/datatype \
 --single unit/moduleapi/auth \

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -61,6 +61,8 @@
  */
 
 #include "server.h"
+#include "slowlog.h"
+#include "latency.h"
 
 int serveClientBlockedOnList(client *receiver, robj *key, robj *dstkey, redisDb *db, robj *value, int where);
 

--- a/src/server.h
+++ b/src/server.h
@@ -795,6 +795,9 @@ typedef struct client {
     size_t sentlen;         /* Amount of bytes already sent in the current
                                buffer or object being sent. */
     time_t ctime;           /* Client creation time. */
+    time_t duration;        /* Current command duration. Used for measuring latency of blocking/non-blocking cmds */
+    time_t background_start_time; /* Time of the start of background work, used for blocking command doing background work */
+    time_t background_duration; /* Current command background time duration. Used for measuring latency of blocking/non-blocking cmds */
     time_t lastinteraction; /* Time of the last interaction, used for timeout */
     time_t obuf_soft_limit_reached_time;
     uint64_t flags;         /* Client flags: CLIENT_* macros. */

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -20,6 +20,7 @@ TEST_MODULES = \
     misc.so \
     hooks.so \
     blockonkeys.so \
+    blockonbackground.so \
     scan.so \
     datatype.so \
     auth.so

--- a/tests/modules/blockonbackground.c
+++ b/tests/modules/blockonbackground.c
@@ -1,0 +1,103 @@
+#define REDISMODULE_EXPERIMENTAL_API
+#include "redismodule.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#define UNUSED(x) (void)(x)
+
+/* Reply callback for blocking command BLOCK.DEBUG */
+int HelloBlock_Reply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    int *myint = RedisModule_GetBlockedClientPrivateData(ctx);
+    return RedisModule_ReplyWithLongLong(ctx,*myint);
+}
+
+/* Timeout callback for blocking command BLOCK.DEBUG */
+int HelloBlock_Timeout(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    return RedisModule_ReplyWithSimpleString(ctx,"Request timedout");
+}
+
+/* Private data freeing callback for BLOCK.DEBUG command. */
+void HelloBlock_FreeData(RedisModuleCtx *ctx, void *privdata) {
+    UNUSED(ctx);
+    RedisModule_Free(privdata);
+}
+
+/* The thread entry point that actually executes the blocking part
+ * of the command BLOCK.DEBUG. */
+void *HelloBlock_ThreadMain(void *arg) {
+    void **targ = arg;
+    RedisModuleBlockedClient *bc = targ[0];
+    long long delay = (unsigned long)targ[1];
+    RedisModule_Free(targ);
+
+    sleep(delay);
+    int *r = RedisModule_Alloc(sizeof(int));
+    *r = rand();
+    RedisModule_UnblockClient(bc,r);
+    return NULL;
+}
+
+void HelloBlock_Disconnected(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc) {
+    RedisModule_Log(ctx,"warning","Blocked client %p disconnected!",
+        (void*)bc);
+}
+
+/* BLOCK.DEBUG <delay> <timeout> -- Block for <count> seconds, then reply with
+ * a random number. Timeout is the command timeout, so that you can test
+ * what happens when the delay is greater than the timeout. */
+int HelloBlock_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    long long delay;
+    long long timeout;
+
+    if (RedisModule_StringToLongLong(argv[1],&delay) != REDISMODULE_OK) {
+        return RedisModule_ReplyWithError(ctx,"ERR invalid count");
+    }
+
+    if (RedisModule_StringToLongLong(argv[2],&timeout) != REDISMODULE_OK) {
+        return RedisModule_ReplyWithError(ctx,"ERR invalid count");
+    }
+    timeout=timeout*1000;
+
+    pthread_t tid;
+    RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx,HelloBlock_Reply,HelloBlock_Timeout,HelloBlock_FreeData,timeout);
+
+    /* Here we set a disconnection handler, however since this module will
+     * block in sleep() in a thread, there is not much we can do in the
+     * callback, so this is just to show you the API. */
+    RedisModule_SetDisconnectCallback(bc,HelloBlock_Disconnected);
+
+    /* Now that we setup a blocking client, we need to pass the control
+     * to the thread. However we need to pass arguments to the thread:
+     * the delay and a reference to the blocked client handle. */
+    void **targ = RedisModule_Alloc(sizeof(void*)*2);
+    targ[0] = bc;
+    targ[1] = (void*)(unsigned long) delay;
+
+    if (pthread_create(&tid,NULL,HelloBlock_ThreadMain,targ) != 0) {
+        RedisModule_AbortBlock(bc);
+        return RedisModule_ReplyWithError(ctx,"-ERR Can't start thread");
+    }
+    return REDISMODULE_OK;
+}
+
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+
+    if (RedisModule_Init(ctx,"block",1,REDISMODULE_APIVER_1)
+        == REDISMODULE_ERR) return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"block.debug",
+        HelloBlock_RedisCommand,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    return REDISMODULE_OK;
+}

--- a/tests/unit/moduleapi/blockonbackground.tcl
+++ b/tests/unit/moduleapi/blockonbackground.tcl
@@ -1,0 +1,15 @@
+set testmodule [file normalize tests/modules/blockonbackground.so]
+
+start_server {tags {"modules"}} {
+    r module load $testmodule
+
+    test {SLOWLOG - check that logs commands taking more time than specified including the background time} {
+        r config set slowlog-log-slower-than 100000
+        r ping
+        assert_equal [r slowlog len] 0
+        r block.debug 0 10
+        assert_equal [r slowlog len] 0
+        r block.debug 2 10
+        assert_equal [r slowlog len] 1
+    }
+}


### PR DESCRIPTION
This PR enables tracking the time spend on background work and on a consequent reply after it (red denoted letters on the diagram ). Currently, on a blocking command we're only keeping track of the time spent on `Call()` as seen on the following simplified diagram:

![image](https://user-images.githubusercontent.com/5832149/86420964-20ef6200-bcd0-11ea-89cc-bb29689427b8.png)

This PR enables tracking time of the background tasks and on replies after it, opening the door for properly tracking commands that rely on background work via the slowlog and commandstats.
The time spent blocked waiting for key changes, or blocked on synchronous replication is not accounted for. 

To test for this feature we've added a `unit/moduleapi/blockonbackground` test that relies on a module that blocks the client and sleeps on the background for a given time. 

You can quickly test this feature in the following manner:

## current behaviour ( not tracking time spent on background ):
```
127.0.0.1:6379> config set slowlog-log-slower-than 100000
OK
127.0.0.1:6379> slowlog len
(integer) 0
127.0.0.1:6379> block.debug 0 10
(integer) 343176910
127.0.0.1:6379> slowlog len
(integer) 0
127.0.0.1:6379> block.debug 2 10
(integer) 1207730440
(2.00s)
127.0.0.1:6379> slowlog len
(integer) 0
```

## new behaviour ( tracking time spend on background ):

```
127.0.0.1:6379> config set slowlog-log-slower-than 100000
OK
127.0.0.1:6379> slowlog len
(integer) 0
127.0.0.1:6379> block.debug 0 10
(integer) 1471490433
127.0.0.1:6379> slowlog len
(integer) 0
127.0.0.1:6379> block.debug 2 10
(integer) 1127835047
(2.00s)
127.0.0.1:6379> slowlog len
(integer) 1
127.0.0.1:6379> slowlog get 1
1) 1) (integer) 0
   2) (integer) 1593712320
   3) (integer) 2053204
   4) 1) "block.debug"
      2) "2"
      3) "10"
   5) "127.0.0.1:51818"
   6) ""
```

