### PR TITLE
Add optional tls verification

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -159,10 +159,12 @@ tcp-keepalive 300
 # By default, clients (including replica servers) on a TLS port are required
 # to authenticate using valid client side certificates.
 #
-# It is possible to disable authentication using "tls-auth-clients no".
-# If Redis requests client's certificate but not requires it, "tls-auth-clients option" shouled be used.
+# If "no" is specified, client certificates are not required and not accepted.
+# If "optional" is specified, client certificates are accepted and must be
+# valid if provided, but are not required.
 #
 # tls-auth-clients no
+# tls-auth-clients optional
 
 # By default, a Redis replica does not attempt to establish a TLS connection
 # with its master.

--- a/redis.conf
+++ b/redis.conf
@@ -159,7 +159,8 @@ tcp-keepalive 300
 # By default, clients (including replica servers) on a TLS port are required
 # to authenticate using valid client side certificates.
 #
-# It is possible to disable authentication using this directive.
+# It is possible to disable authentication using "tls-auth-clients no".
+# If Redis requests client's certificate but not requires it, "tls-auth-clients option" shouled be used.
 #
 # tls-auth-clients no
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -670,7 +670,8 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
 
-        connection *conn = server.tls_cluster ? connCreateAcceptedTLS(cfd,1) : connCreateAcceptedSocket(cfd);
+        connection *conn = server.tls_cluster ?
+            connCreateAcceptedTLS(cfd, TLS_CLIENT_AUTH_YES) : connCreateAcceptedSocket(cfd);
         connNonBlock(conn);
         connEnableTcpNoDelay(conn);
 

--- a/src/config.c
+++ b/src/config.c
@@ -98,10 +98,11 @@ configEnum repl_diskless_load_enum[] = {
     {NULL, 0}
 };
 
-configEnum tls_auth_enum[] = {
-    {"no", 0},
-    {"yes", 1},
-    {"option", 2},
+configEnum tls_auth_clients_enum[] = {
+    {"no", TLS_CLIENT_AUTH_NO},
+    {"yes", TLS_CLIENT_AUTH_YES},
+    {"optional", TLS_CLIENT_AUTH_OPTIONAL},
+    {NULL, 0}
 };
 /* Output buffer limits presets. */
 clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT] = {
@@ -2223,7 +2224,7 @@ standardConfig configs[] = {
     createIntConfig("tls-port", NULL, IMMUTABLE_CONFIG, 0, 65535, server.tls_port, 0, INTEGER_CONFIG, NULL, NULL), /* TCP port. */
     createBoolConfig("tls-cluster", NULL, MODIFIABLE_CONFIG, server.tls_cluster, 0, NULL, NULL),
     createBoolConfig("tls-replication", NULL, MODIFIABLE_CONFIG, server.tls_replication, 0, NULL, NULL),
-    createEnumConfig("tls-auth-clients", NULL, MODIFIABLE_CONFIG, tls_auth_enum, server.tls_auth_clients, 1, NULL, NULL),
+    createEnumConfig("tls-auth-clients", NULL, MODIFIABLE_CONFIG, tls_auth_clients_enum, server.tls_auth_clients, TLS_CLIENT_AUTH_YES, NULL, NULL),
     createBoolConfig("tls-prefer-server-ciphers", NULL, MODIFIABLE_CONFIG, server.tls_ctx_config.prefer_server_ciphers, 0, NULL, updateTlsCfgBool),
     createStringConfig("tls-cert-file", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.cert_file, NULL, NULL, updateTlsCfg),
     createStringConfig("tls-key-file", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.key_file, NULL, NULL, updateTlsCfg),

--- a/src/config.c
+++ b/src/config.c
@@ -98,6 +98,11 @@ configEnum repl_diskless_load_enum[] = {
     {NULL, 0}
 };
 
+configEnum tls_auth_enum[] = {
+    {"no", 0},
+    {"yes", 1},
+    {"option", 2},
+};
 /* Output buffer limits presets. */
 clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT] = {
     {0, 0, 0}, /* normal */
@@ -2218,7 +2223,7 @@ standardConfig configs[] = {
     createIntConfig("tls-port", NULL, IMMUTABLE_CONFIG, 0, 65535, server.tls_port, 0, INTEGER_CONFIG, NULL, NULL), /* TCP port. */
     createBoolConfig("tls-cluster", NULL, MODIFIABLE_CONFIG, server.tls_cluster, 0, NULL, NULL),
     createBoolConfig("tls-replication", NULL, MODIFIABLE_CONFIG, server.tls_replication, 0, NULL, NULL),
-    createBoolConfig("tls-auth-clients", NULL, MODIFIABLE_CONFIG, server.tls_auth_clients, 1, NULL, NULL),
+    createEnumConfig("tls-auth-clients", NULL, MODIFIABLE_CONFIG, tls_auth_enum, server.tls_auth_clients, 1, NULL, NULL),
     createBoolConfig("tls-prefer-server-ciphers", NULL, MODIFIABLE_CONFIG, server.tls_ctx_config.prefer_server_ciphers, 0, NULL, updateTlsCfgBool),
     createStringConfig("tls-cert-file", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.cert_file, NULL, NULL, updateTlsCfg),
     createStringConfig("tls-key-file", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.key_file, NULL, NULL, updateTlsCfg),

--- a/src/server.h
+++ b/src/server.h
@@ -358,6 +358,11 @@ typedef long long ustime_t; /* microsecond time type. */
 #define REPL_DISKLESS_LOAD_WHEN_DB_EMPTY 1
 #define REPL_DISKLESS_LOAD_SWAPDB 2
 
+/* TLS Client Authentication */
+#define TLS_CLIENT_AUTH_NO 0
+#define TLS_CLIENT_AUTH_YES 1
+#define TLS_CLIENT_AUTH_OPTIONAL 2
+
 /* Sets operations codes */
 #define SET_OP_UNION 0
 #define SET_OP_DIFF 1

--- a/src/tls.c
+++ b/src/tls.c
@@ -336,11 +336,16 @@ connection *connCreateAcceptedTLS(int fd, int require_auth) {
     conn->c.fd = fd;
     conn->c.state = CONN_STATE_ACCEPTING;
 
-    switch(require_auth){
-    case 0:  SSL_set_verify(conn->ssl, SSL_VERIFY_NONE, NULL);break;
-    case 1:  SSL_set_verify(conn->ssl, SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);break;
-    case 2:  SSL_set_verify(conn->ssl, SSL_VERIFY_PEER, NULL);break;
-    default: serverPanic("unknow require_auth type");
+    switch (require_auth) {
+        case TLS_CLIENT_AUTH_NO:
+            SSL_set_verify(conn->ssl, SSL_VERIFY_NONE, NULL);
+            break;
+        case TLS_CLIENT_AUTH_OPTIONAL:
+            SSL_set_verify(conn->ssl, SSL_VERIFY_PEER, NULL);
+            break;
+        default: /* TLS_CLIENT_AUTH_YES, also fall-secure */
+            SSL_set_verify(conn->ssl, SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+            break;
     }
 
     SSL_set_fd(conn->ssl, conn->c.fd);

--- a/src/tls.c
+++ b/src/tls.c
@@ -336,8 +336,11 @@ connection *connCreateAcceptedTLS(int fd, int require_auth) {
     conn->c.fd = fd;
     conn->c.state = CONN_STATE_ACCEPTING;
 
-    if (!require_auth) {
-        SSL_set_verify(conn->ssl, SSL_VERIFY_NONE, NULL);
+    switch(require_auth){
+    case 0:  SSL_set_verify(conn->ssl, SSL_VERIFY_NONE, NULL);break;
+    case 1:  SSL_set_verify(conn->ssl, SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);break;
+    case 2:  SSL_set_verify(conn->ssl, SSL_VERIFY_PEER, NULL);break;
+    default: serverPanic("unknow require_auth type");
     }
 
     SSL_set_fd(conn->ssl, conn->c.fd);

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -21,7 +21,19 @@ start_server {tags {"tls"}} {
             catch {$s PING} e
             assert_match {PONG} $e
 
+            r CONFIG SET tls-auth-clients optional
+
+            set s [redis [srv 0 host] [srv 0 port]]
+            ::tls::import [$s channel]
+            catch {$s PING} e
+            assert_match {PONG} $e
+
             r CONFIG SET tls-auth-clients yes
+
+            set s [redis [srv 0 host] [srv 0 port]]
+            ::tls::import [$s channel]
+            catch {$s PING} e
+            assert_match {*error*} $e
         }
 
         test {TLS: Verify tls-protocols behaves as expected} {


### PR DESCRIPTION
In TLS there are three common scene
1. Server doesn't need client certificate.
2. Server requires client's certificate and verifies it and abort the connection if verify fail.  
3. Server requests client's certificate not mandatorily. 

Scene 3 can be used in access control in the future. Server can grants or denies some client operation based on whether client sends the certificate or not.   