### PR TITLE
Describe process for security bug contributions

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -7,18 +7,18 @@ each source file that you contribute.
 
 # IMPORTANT: HOW TO USE REDIS GITHUB ISSUES
 
-* Github issues SHOULD ONLY BE USED to report bugs, and for DETAILED feature
-  requests. Everything else belongs to the Redis Google Group:
+Github issues SHOULD ONLY BE USED to report bugs, and for DETAILED feature
+requests. Everything else belongs to the Redis Google Group:
       
-      https://groups.google.com/forum/m/#!forum/Redis-db
+    https://groups.google.com/forum/m/#!forum/Redis-db
 
-  PLEASE DO NOT POST GENERAL QUESTIONS that are not about bugs or suspected
-  bugs in the Github issues system. We'll be very happy to help you and provide
-  all the support in the mailing list.
+PLEASE DO NOT POST GENERAL QUESTIONS that are not about bugs or suspected
+bugs in the Github issues system. We'll be very happy to help you and provide
+all the support in the mailing list.
 
-  There is also an active community of Redis users at Stack Overflow:
+There is also an active community of Redis users at Stack Overflow:
 
-      http://stackoverflow.com/questions/tagged/redis
+    http://stackoverflow.com/questions/tagged/redis
 
 # How to provide a patch for a new feature
 

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -20,6 +20,26 @@ There is also an active community of Redis users at Stack Overflow:
 
     http://stackoverflow.com/questions/tagged/redis
 
+# Reporting Security Bugs
+
+*If you are reporting a security bug*, please contact the core team privately
+by emailing redis@redis.io. Your report will be acknowledged by a core team
+member and once the report has been reviewed you will receive a more detailed
+response including next steps.
+
+If you do not receive a reply you can escalate to the Redis Google Group,
+linked above. Because this group is a public space please do not disclose the
+issue in detail, only say that you are trying to reach the core team for a
+security issue.
+
+Redis follows a responsible disclosure process:
+
+1. Reports are reviewed and analyzed privately
+2. Patches are prepared for supported versions of Redis
+3. Vendor lists are notified with an embargo date to reduce the public impact
+4. We push a fix release and your bug can be posted publicly with credit in
+   release notes and the version history (and our thanks!)
+
 # How to provide a patch for a new feature
 
 1. If it is a major feature or a semantical change, please don't start coding

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ of the BSD license that you can find in the [COPYING][1] file included in the Re
 source distribution.
 
 Please see the [CONTRIBUTING][2] file in this source distribution for more
-information.
+information, including details on our process for security bugs/vulnerabilities.
 
 [1]: https://github.com/redis/redis/blob/unstable/COPYING
 [2]: https://github.com/redis/redis/blob/unstable/CONTRIBUTING


### PR DESCRIPTION
Process proposal for vulnerability review and disclosure, as mentioned in #7497.

My goals for this:
* Lightweight for the core team who already have a lot of issues to slog through
* Clear and fair for security researchers and contributors

I added a reference in the README so people doing a quick search on the GitHub page will know where to look.