### PR TITLE
fix recently added time sensitive tests failing with valgrind

### DIFF
--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -241,7 +241,7 @@ start_server {tags {"cli"}} {
 
     test_nontty_cli "Connecting as a replica" {
         set fd [open_cli "--replica"]
-        wait_for_condition 50 500 {
+        wait_for_condition 200 500 {
             [string match {*slave0:*state=online*} [r info]]
         } else {
             fail "redis-cli --replica did not connect"

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -50,15 +50,21 @@ start_server {tags {"latency-monitor"}} {
 
     test {LATENCY of expire events are correctly collected} {
         r config set latency-monitor-threshold 20
+        r flushdb
+        if {$::valgrind} {set count 100000} else {set count 1000000}
         r eval {
             local i = 0
-            while (i < 1000000) do
-                redis.call('sadd','mybigkey',i)
+            while (i < tonumber(ARGV[1])) do
+                redis.call('sadd',KEYS[1],i)
                 i = i+1
              end
-        } 0
-        r pexpire mybigkey 1
-        after 500
+        } 1 mybigkey $count
+        r pexpire mybigkey 50
+        wait_for_condition 5 100 {
+            [r dbsize] == 0
+        } else {
+            fail "key wasn't expired"
+        }
         assert_match {*expire-cycle*} [r latency latest]
     }
 }


### PR DESCRIPTION
interestingly the latency monitor test fails because valgrind is slow
enough so that the time inside PEXPIRE command from the moment of
the first mstime() call to get the basetime until checkAlreadyExpired
calls mstime() again is more than 1ms, and that test was too sensitive.

using this opportunity to speed up the test (unrelated to the failure)
the fix is just the longer time passed to PEXPIRE.