### PR TITLE
Fix out of update help info in tcl tests.

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -170,8 +170,6 @@ proc parse_options {} {
                 -keyfile "$::tlsdir/redis.key"
             set ::tls 1
         } elseif {$opt eq "--help"} {
-            puts "Hello, I'm sentinel.tcl and I run Sentinel unit tests."
-            puts "\nOptions:"
             puts "--single <pattern>      Only runs tests specified by pattern."
             puts "--pause-on-error        Pause for manual inspection on error."
             puts "--fail                  Simulate a test failure."


### PR DESCRIPTION
Before this commit, the output of "./runtest-cluster --help" is incorrect.
After this commit, the format of the following 3 output is consistent:
./runtest --help
./runtest-cluster --help
./runtest-sentinel --help