### PR TITLE
Improve error message for multibulk length

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1637,9 +1637,14 @@ int processMultibulkBuffer(client *c) {
          * so go ahead and find out the multi bulk length. */
         serverAssertWithInfo(c,NULL,c->querybuf[c->qb_pos] == '*');
         ok = string2ll(c->querybuf+1+c->qb_pos,newline-(c->querybuf+1+c->qb_pos),&ll);
-        if (!ok || ll > 1024*1024) {
+        if (!ok) {
             addReplyError(c,"Protocol error: invalid multibulk length");
             setProtocolError("invalid mbulk count",c);
+            return C_ERR;
+        }
+        else if (ll > 1024*1024) {
+            addReplyError(c,"Protocol error: multibulk length too large");
+            setProtocolError("mbulk count too large",c);
             return C_ERR;
         }
 

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -17,7 +17,7 @@ start_server {tags {"protocol"}} {
         reconnect
         r write "*20000000\r\n"
         r flush
-        assert_error "*invalid multibulk length*" {r read}
+        assert_error "*multibulk length too large*" {r read}
     }
 
     test "Wrong multibulk payload header" {


### PR DESCRIPTION
If you use send a redis command with too many arguments (example: MSET) you will get the message:

Protocol error: invalid multibulk length

I had to google to figure out what that means (and apparently so do other people) so I made the error message better.