### PR TITLE
Modules test build changes for Solaris

### DIFF
--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -2,13 +2,29 @@
 # find the OS
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 
-# Compile flags for linux / osx
-ifeq ($(uname_S),Linux)
-	SHOBJ_CFLAGS ?= -W -Wall -fno-common -g -ggdb -std=c99 -O2
-	SHOBJ_LDFLAGS ?= -shared
+# "which" on Solaris is an extremely broken tcsh script
+which = $(firstword $(realpath $(foreach x,$(subst :, ,../../src:${PATH}),${x}/${1})))
+
+# The default is "cc" which isn't always gcc (eg, Solaris).
+# Since SHOBJ_CFLAGS uses the GNU-specific "-ggdb", this choice
+# makes sense.
+CC := $(if $(call which,gcc),gcc,cc)
+
+redis_server_path := $(call which,redis-server)
+
+ifneq (,$(shell file ${redis_server_path} | grep -i 32-bit))
+	32_or_64bit := -m32
 else
-	SHOBJ_CFLAGS ?= -W -Wall -dynamic -fno-common -g -ggdb -std=c99 -O2
-	SHOBJ_LDFLAGS ?= -bundle -undefined dynamic_lookup
+	32_or_64bit := -m64
+endif
+
+# Compile flags
+ifneq ($(uname_S),Mac)
+	SHOBJ_CFLAGS ?= -W -Wall -fno-common -g -ggdb -std=c99 -O2
+	SHOBJ_LDFLAGS ?= -shared ${32_or_64bit}
+else
+	SHOBJ_CFLAGS ?= -W -Wall -dynamic -fno-common -g -ggdb -std=c99 -O2 ${32_or_64bit}
+	SHOBJ_LDFLAGS ?= -bundle -undefined dynamic_lookup ${32_or_64bit}
 endif
 
 TEST_MODULES = \
@@ -26,16 +42,13 @@ TEST_MODULES = \
 
 .PHONY: all
 
-all: $(TEST_MODULES)
-
-32bit:
-	$(MAKE) CFLAGS="-m32" LDFLAGS="-melf_i386"
+all 32bit: $(TEST_MODULES)
 
 %.xo: %.c ../../src/redismodule.h
 	$(CC) -I../../src $(CFLAGS) $(SHOBJ_CFLAGS) -fPIC -c $< -o $@
 
 %.so: %.xo
-	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LDFLAGS) $(LIBS) -lc
+	$(CC) -o $@ $< $(SHOBJ_LDFLAGS) $(LDFLAGS) $(LIBS) -lc
 
 .PHONY: clean
 


### PR DESCRIPTION
* Changed link step to use compiler driver instead of linker so we could just use `-m32` / `-m64` instead of needing to know which emulation target to choose.  This also fixes 32-bit builds for [all?] non-i386 platforms.
* Detect whether Redis was built 32 or 64-bit and select `-m32` / `-m64` accordingly
* Made `32bit` target an alias for `all` since it was no longer needed