### PR TITLE
replication: need handle -NOPERM error after send ping

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2158,6 +2158,7 @@ void syncWithMaster(connection *conn) {
          * both. */
         if (err[0] != '+' &&
             strncmp(err,"-NOAUTH",7) != 0 &&
+            strncmp(err,"-NOPERM",7) != 0 &&
             strncmp(err,"-ERR operation not permitted",28) != 0)
         {
             serverLog(LL_WARNING,"Error reply to PING from master: '%s'",err);


### PR DESCRIPTION
replica should handle -NOPERM error after in `REPL_STATE_RECEIVE_PONG` state, in case default user disable PING command.