### PR TITLE
Clarification on the bug that was fixed in PR #7539.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3430,13 +3430,8 @@ void rejectCommandFormat(client *c, const char *fmt, ...) {
     sdsfree(s);
 }
 
-/* A command that uses keys but has no pre-determined key position arguments.
- *
- * This function was introduced in PR #7539. Before that PR, processCommand()
- * did not notice that cmd could be a module command which is designed to use
- * 0 number of keys, just like some non-module command, e.g. `flushall`, `info`
- * and so on, and handled it for the purpose of cluster redirect it as if it
- * does use any keys. */
+/* Returns 1 for commands that may have key names in their arguments, but have
+ * no pre-determined key positions. */
 static int cmdHasMovableKeys(struct redisCommand *cmd) {
     return (cmd->getkeys_proc && !(cmd->flags & CMD_MODULE)) ||
             cmd->flags & CMD_MODULE_GETKEYS;

--- a/src/server.c
+++ b/src/server.c
@@ -3430,7 +3430,13 @@ void rejectCommandFormat(client *c, const char *fmt, ...) {
     sdsfree(s);
 }
 
-/* A command that uses keys but has no pre-determined key position arguments. */
+/* A command that uses keys but has no pre-determined key position arguments.
+ *
+ * This function was introduced in PR #7539. Before that PR, processCommand()
+ * did not notice that cmd could be a module command which is designed to use
+ * 0 number of keys, just like some non-module command, e.g. `flushall`, `info`
+ * and so on, and handled it for the purpose of cluster redirect it as if it
+ * does use any keys. */
 static int cmdHasMovableKeys(struct redisCommand *cmd) {
     return (cmd->getkeys_proc && !(cmd->flags & CMD_MODULE)) ||
             cmd->flags & CMD_MODULE_GETKEYS;


### PR DESCRIPTION
Before that PR, processCommand() did not notice that cmd could be a module
command in which case getkeys_proc member has a different meaning.

The outcome was that a module command which doesn't take any key names in its
arguments (similar to SLOWLOG) would be handled as if it might have key name arguments
(similar to MEMORY), would consider cluster redirect but will end up with 0 keys
after an excessive call to getKeysFromCommand, and eventually do the right thing.