### PR TITLE
Properly reset errno for rdbLoad

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4703,6 +4703,7 @@ void loadDataFromDisk(void) {
             serverLog(LL_NOTICE,"DB loaded from append only file: %.3f seconds",(float)(ustime()-start)/1000000);
     } else {
         rdbSaveInfo rsi = RDB_SAVE_INFO_INIT;
+        errno = 0; /* Prevent a stale value from affecting error checking */
         if (rdbLoad(server.rdb_filename,&rsi,RDBFLAGS_NONE) == C_OK) {
             serverLog(LL_NOTICE,"DB loaded from disk: %.3f seconds",
                 (float)(ustime()-start)/1000000);


### PR DESCRIPTION
When loading from an rdb, redis aborts on any file error except for ENOENT (File not found). However, the function rdbLoad can fail for other reasons such as parsing issues. You can therefor run into the unlikely state of a previous non-terminal failure producing a a ENOENT error code and then rdbLoad failing because of a parsing issue which doesn't set errno. This results in a partially up server with partially loaded data. 

I did run into this somehow while testing with a corrupted RDB, but I don't remember this specific details, so it's not purely theoretical. 