### PR TITLE
testsuite may leave servers alive on error

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -396,6 +396,9 @@ proc start_server {options {code undefined}} {
             # fetch srv back from the server list, in case it was restarted by restart_server (new PID)
             set srv [lindex $::servers end]
 
+            # pop the server object
+            set ::servers [lrange $::servers 0 end-1]
+
             # Kill the server without checking for leaks
             dict set srv "skipleaks" 1
             kill_server $srv


### PR DESCRIPTION
in cases where you have
```
test name {
  start_server {
    start_server {
      assert
    }
  }
}
```
the exception will be thrown to the test proc, and the servers are
supposed to be killed on the way out. but it seems there was always a
bug of not cleaning the server stack, and recently (#7404) we started
relying on that stack in order to kill them, so with that bug sometimes
we would have tried to kill the same server twice, and leave one alive.

luckly, in most cases the pattern is:
```
start_server {
  test name {
  }
}
```