### PR TITLE
Optimize meet process

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1893,6 +1893,8 @@ int clusterProcessPacket(clusterLink *link) {
                 link->node->flags &= ~CLUSTER_NODE_HANDSHAKE;
                 link->node->flags |= flags&(CLUSTER_NODE_MASTER|CLUSTER_NODE_SLAVE);
                 clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
+                /* Request pong to update slots of master node or slaveof slave */
+                clusterSendPing(link,CLUSTERMSG_TYPE_PING);
             } else if (memcmp(link->node->name,hdr->sender,
                         CLUSTER_NAMELEN) != 0)
             {


### PR DESCRIPTION
Send Ping to node after node change from handshake to master/slave, to get pong for slots/slaveof update. This will let the node update slots info fast from cluster-node-timeout/2 time to shoter time.

After meet, the master in new node:
handshake-(100ms+)->master-(timeout/2s+)->master(slots)
                                       |
                                       |
                                       |
                                      \/
handshake-(100ms+)->master-(0s)->master(slots)