### PR TITLE
Recalculate hardcoded variables from $::instances_count in sentinel tests

### DIFF
--- a/tests/sentinel/tests/06-ckquorum.tcl
+++ b/tests/sentinel/tests/06-ckquorum.tcl
@@ -20,15 +20,16 @@ test "CKQUORUM detects quorum cannot be reached" {
 test "CKQUORUM detects failover authorization cannot be reached" {
     set orig_quorum [expr {$num_sentinels/2+1}]
     S 0 SENTINEL SET mymaster quorum 1
-    kill_instance sentinel 1
-    kill_instance sentinel 2
-    kill_instance sentinel 3
+    for {set i 0} {$i < $orig_quorum} {incr i} {
+        kill_instance sentinel [expr {$i + 1}]    
+    }
+
     after 5000
     catch {[S 0 SENTINEL CKQUORUM mymaster]} err
     assert_match "*NOQUORUM*" $err
     S 0 SENTINEL SET mymaster quorum $orig_quorum
-    restart_instance sentinel 1
-    restart_instance sentinel 2
-    restart_instance sentinel 3
+    for {set i 0} {$i < $orig_quorum} {incr i} {
+        restart_instance sentinel [expr {$i + 1}]    
+    }
 }
 

--- a/tests/sentinel/tests/06-ckquorum.tcl
+++ b/tests/sentinel/tests/06-ckquorum.tcl
@@ -21,7 +21,7 @@ test "CKQUORUM detects failover authorization cannot be reached" {
     set orig_quorum [expr {$num_sentinels/2+1}]
     S 0 SENTINEL SET mymaster quorum 1
     for {set i 0} {$i < $orig_quorum} {incr i} {
-        kill_instance sentinel [expr {$i + 1}]    
+        kill_instance sentinel [expr {$i + 1}]
     }
 
     after 5000
@@ -29,7 +29,7 @@ test "CKQUORUM detects failover authorization cannot be reached" {
     assert_match "*NOQUORUM*" $err
     S 0 SENTINEL SET mymaster quorum $orig_quorum
     for {set i 0} {$i < $orig_quorum} {incr i} {
-        restart_instance sentinel [expr {$i + 1}]    
+        restart_instance sentinel [expr {$i + 1}]
     }
 }
 

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -18,7 +18,7 @@ test "(init) Remove old master entry from sentinels" {
     }
 }
 
-set redis_slaves 4
+set redis_slaves [expr $::instances_count - 1]
 test "(init) Create a master-slaves cluster of [expr $redis_slaves+1] instances" {
     create_redis_master_slave_cluster [expr {$redis_slaves+1}]
 }


### PR DESCRIPTION
It is not enough to change `$::instances_count` to run sentinel tests on more instances than five because some tests assume that there are exactly five instances. These changes refactor such tests.  