### PR TITLE
Add SignalModifiedKey hook in XGROUP CREATE with MKSTREAM option

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1845,6 +1845,7 @@ NULL
             o = createStreamObject();
             dbAdd(c->db,c->argv[2],o);
             s = o->ptr;
+            signalModifiedKey(c,c->db,c->argv[2]);
         }
 
         streamCG *cg = streamCreateCG(s,grpname,sdslen(grpname),&id);


### PR DESCRIPTION
Before this commit, the XGROUP subfunction such as add/delete consumer group in stream object doesn't call SignalModifiedKey hook, although the stream object in keyspace is updated. This commit added the SignalModifiedKey hook in these related functions which changes the stream object in keyspace.
