### PR TITLE
more strict check in rioConnRead

### DIFF
--- a/src/rio.c
+++ b/src/rio.c
@@ -201,7 +201,7 @@ static size_t rioConnRead(rio *r, void *buf, size_t len) {
             /* Make sure the caller didn't request to read past the limit.
              * If they didn't we'll buffer till the limit, if they did, we'll
              * return an error. */
-            if (r->io.conn.read_limit >= r->io.conn.read_so_far + needs)
+            if (r->io.conn.read_limit >= r->io.conn.read_so_far + len)
                 toread = r->io.conn.read_limit - r->io.conn.read_so_far - buffered;
             else {
                 errno = EOVERFLOW;


### PR DESCRIPTION
Hi @oranagra just see #7557 is merged, so I open a new one to discuss. I know it is harmless, but I think we should be strict and correct.

I think the check should be `if (r->io.conn.read_limit >= r->io.conn.read_so_far + len)`, since `r->io.conn.read_so_far` is updated out of the loop, or do I misunderstand something?
