### PR TITLE
Change to stop loading RDB during diskless replication when the master is disconnected

### DIFF
--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -33,7 +33,7 @@
 #include <stdarg.h>
 
 void createSharedObjects(void);
-void rdbLoadProgressCallback(rio *r, const void *buf, size_t len);
+int rdbLoadProgressCallback(rio *r, const void *buf, size_t len);
 int rdbCheckMode = 0;
 
 struct {

--- a/src/rio.c
+++ b/src/rio.c
@@ -384,8 +384,9 @@ void rioFreeFd(rio *r) {
 
 /* This function can be installed both in memory and file streams when checksum
  * computation is needed. */
-void rioGenericUpdateChecksum(rio *r, const void *buf, size_t len) {
+int rioGenericUpdateChecksum(rio *r, const void *buf, size_t len) {
     r->cksum = crc64(r->cksum,buf,len);
+    return 1;
 }
 
 /* Set the file-based rio object to auto-fsync every 'bytes' file written.

--- a/src/rio.h
+++ b/src/rio.h
@@ -53,7 +53,7 @@ struct _rio {
      * designed so that can be called with the current checksum, and the buf
      * and len fields pointing to the new block of data to add to the checksum
      * computation. */
-    void (*update_cksum)(struct _rio *, const void *buf, size_t len);
+    int (*update_cksum)(struct _rio *, const void *buf, size_t len);
 
     /* The current checksum and flags (see RIO_FLAG_*) */
     uint64_t cksum, flags;
@@ -104,7 +104,12 @@ static inline size_t rioWrite(rio *r, const void *buf, size_t len) {
     if (r->flags & RIO_FLAG_WRITE_ERROR) return 0;
     while (len) {
         size_t bytes_to_write = (r->max_processing_chunk && r->max_processing_chunk < len) ? r->max_processing_chunk : len;
-        if (r->update_cksum) r->update_cksum(r,buf,bytes_to_write);
+
+        if (r->update_cksum && (!r->update_cksum(r,buf,bytes_to_write))) {
+            r->flags |= RIO_FLAG_WRITE_ERROR;
+            return 0;
+        }
+
         if (r->write(r,buf,bytes_to_write) == 0) {
             r->flags |= RIO_FLAG_WRITE_ERROR;
             return 0;
@@ -124,7 +129,12 @@ static inline size_t rioRead(rio *r, void *buf, size_t len) {
             r->flags |= RIO_FLAG_READ_ERROR;
             return 0;
         }
-        if (r->update_cksum) r->update_cksum(r,buf,bytes_to_read);
+
+        if (r->update_cksum && (!r->update_cksum(r,buf,bytes_to_read))) {
+            r->flags |= RIO_FLAG_READ_ERROR;
+            return 0;
+        }
+
         buf = (char*)buf + bytes_to_read;
         len -= bytes_to_read;
         r->processed_bytes += bytes_to_read;
@@ -172,7 +182,7 @@ size_t rioWriteBulkDouble(rio *r, double d);
 struct redisObject;
 int rioWriteBulkObject(rio *r, struct redisObject *obj);
 
-void rioGenericUpdateChecksum(rio *r, const void *buf, size_t len);
+int rioGenericUpdateChecksum(rio *r, const void *buf, size_t len);
 void rioSetAutoSync(rio *r, off_t bytes);
 
 #endif


### PR DESCRIPTION
While loading the data during diskless replication, the replica can receive a message on cluster bus stating that master
of this node has changed. This message will be processed when rdbLoadRio yields to process file based events. When the
message is processed, the connection with the current master is closed. This cleans up the ssl state related to FD used
for replicating data from the old master. So when the control came back to rdbLoadRio, it tries to perform a read on
the FD who's connection has been freed. This causes a crash.