### PR TITLE
Fix: check SSL_new fail

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -671,6 +671,15 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
         }
 
         connection *conn = server.tls_cluster ? connCreateAcceptedTLS(cfd,1) : connCreateAcceptedSocket(cfd);
+
+        /* Only connCreateAcceptedTLS will fail up to now.
+         * We close connection inside creation API.
+         */
+        if (!conn) {
+            serverLog(LL_VERBOSE,
+                "Error inner accepting cluster node: %s", server.neterr);
+            return;
+        }
         connNonBlock(conn);
         connEnableTcpNoDelay(conn);
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -801,7 +801,7 @@ void addReplySubcommandSyntaxError(client *c) {
     sdsfree(cmd);
 }
 
-/* Append 'src' client output buffers into 'dst' client output buffers. 
+/* Append 'src' client output buffers into 'dst' client output buffers.
  * This function clears the output buffers of 'src' */
 void AddReplyFromClient(client *dst, client *src) {
     if (prepareClientToWrite(dst) != C_OK)
@@ -896,6 +896,8 @@ void clientAcceptHandler(connection *conn) {
 static void acceptCommonHandler(connection *conn, int flags, char *ip) {
     client *c;
     UNUSED(ip);
+
+    if (!conn) return;
 
     /* Limit the number of connections we take at the same time.
      *


### PR DESCRIPTION
To fix #7565 

(1). Redis miss the return value check of `SSL_new`.  

(2). It' disgusting for redis to check whether `ssl` is null if `connCreateAcceptedxxx `  returns an allocated `conn` with null `ssl` item, so I just free the `conn` inside the the `connCreateAcceptedxxx ` . May be we should add such api like `connSuccess(xx)` to check the connection.  

(3). Since (2), I think the TLS will not be the only protocol to be used in the future which means `connCreateAcceptedxxx` is likely to return null  and `acceptCommonHandler` should be protected.  

more detail:

![image](https://user-images.githubusercontent.com/5129205/88508582-c072ec80-d011-11ea-8dd2-3bf5e56e9ac7.png)
