### PR TITLE
broadcast a PONG message when slot's migration is over, which may red…

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4512,6 +4512,9 @@ NULL
                         "configEpoch updated after importing slot %d", slot);
                 }
                 server.cluster->importing_slots_from[slot] = NULL;
+                /* After importing this slot, let the other nodes know as
+                 * soon as possible. */
+                clusterBroadcastPong(CLUSTER_BROADCAST_ALL);
             }
             clusterDelSlot(slot);
             clusterAddSlot(n,slot);


### PR DESCRIPTION
When a slot's migration is over (after the destination node receive the command of "CLUSTER SETSLOT <SLOT> NODE <NODE ID>") , the max delay for other node to know the node who is responsible for the slot is server.cluster_node_timeout/2 (7.5s), which may lead to a client receive moved error for two times. 
So, if broadcast a PONG message when slot's migration is over, the other node will know that as soon as possible.