### PR TITLE
TLS: Propagate and handle SSL_new() failures.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -670,7 +670,17 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
 
-        connection *conn = server.tls_cluster ? connCreateAcceptedTLS(cfd,1) : connCreateAcceptedSocket(cfd);
+        connection *conn = server.tls_cluster ?
+            connCreateAcceptedTLS(cfd,1) : connCreateAcceptedSocket(cfd);
+
+        /* Make sure connection is not in an error state */
+        if (connGetState(conn) != CONN_STATE_ACCEPTING) {
+            serverLog(LL_VERBOSE,
+                "Error creating an accepting connection for cluster node: %s",
+                    connGetLastError(conn));
+            connClose(conn);
+            return;
+        }
         connNonBlock(conn);
         connEnableTcpNoDelay(conn);
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -85,8 +85,12 @@ connection *connCreateSocket() {
 /* Create a new socket-type connection that is already associated with
  * an accepted connection.
  *
- * The socket is not read for I/O until connAccept() was called and
+ * The socket is not ready for I/O until connAccept() was called and
  * invoked the connection-level accept handler.
+ *
+ * Callers should use connGetState() and verify the created connection
+ * is not in an error state (which is not possible for a socket connection,
+ * but could but possible with other protocols).
  */
 connection *connCreateAcceptedSocket(int fd) {
     connection *conn = connCreateSocket();

--- a/src/tls.c
+++ b/src/tls.c
@@ -359,9 +359,6 @@ connection *connCreateAcceptedTLS(int fd, int require_auth) {
     conn->c.fd = fd;
     conn->c.state = CONN_STATE_ACCEPTING;
 
-    /* Ugly but necessary.
-     * We have to attach fd into connection so that connClose works well
-     */
     if (!conn->ssl) {
         updateTLSError(conn);
         conn->c.state = CONN_STATE_ERROR;


### PR DESCRIPTION
The connection API may create an accepted connection object in an error
state, and callers are expected to check it before attempting to use it.

This is an improvement over #7569 provided by @mrpre

Co-authored-by: mrpre <mrpre@163.com>