### PR TITLE
see #7544, added RedisModule_HoldString api.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1139,22 +1139,24 @@ void RM_RetainString(RedisModuleCtx *ctx, RedisModuleString *str) {
 }
 
 /**
- * This function should be used as a replacement for RedisModule_RetainString.
- * The main difference is that this function will always succeed while
- * RedisModule_RetainString might fail with assert.
- *
- * The function returns a pointer to RedisModuleString which owned by the caller.
- * The caller needs to call RedisModule_FreeString on the returned
- * pointer (unless auto memory is set on the given ctx, in this case
- * it is possible to either free the RedisModuleString or let the auto
- * memory free it automatically).
- *
- * This function is more efficient than RM_CreateStringFromString because,
- * if possible, it does not copy the underline RedisModuleString.
- * The disadvantage is that it might not be possible to use
- * RedisModule_StringAppendBuffer on the returned RedisModuleString.
- *
- * It is possible to call this function with a NULL context.
+* This function can be used instead of RedisModule_RetainString().
+* The main difference between the two is that this function will always
+* succeed, whereas RedisModule_RetainString() may fail because of an
+* assertion.
+* 
+* The function returns a pointer to RedisModuleString, which is owned
+* by the caller. It requires a call to RedisModule_FreeString() to free
+* the string when automatic memory management is disabled for the context.
+* When automatic memory management is enabled, you can either call
+* RedisModule_FreeString() or let the automation free it.
+* 
+* This function is more efficient than RedisModule_CreateStringFromString()
+* because whenever possible, it avoids copying the underlying
+* RedisModuleString. The disadvantage of using this function is that it
+* might not be possible to use RedisModule_StringAppendBuffer() on the
+* returned RedisModuleString.
+* 
+* It is possible to call this function with a NULL context.
  */
 RedisModuleString* RM_HoldString(RedisModuleCtx *ctx, RedisModuleString *str) {
     if (str->refcount == OBJ_STATIC_REFCOUNT) {

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -569,6 +569,7 @@ void REDISMODULE_API_FUNC(RedisModule__Assert)(const char *estr, const char *fil
 void REDISMODULE_API_FUNC(RedisModule_LatencyAddSample)(const char *event, mstime_t latency);
 int REDISMODULE_API_FUNC(RedisModule_StringAppendBuffer)(RedisModuleCtx *ctx, RedisModuleString *str, const char *buf, size_t len);
 void REDISMODULE_API_FUNC(RedisModule_RetainString)(RedisModuleCtx *ctx, RedisModuleString *str);
+RedisModuleString* REDISMODULE_API_FUNC(RedisModule_HoldString)(RedisModuleCtx *ctx, RedisModuleString *str);
 int REDISMODULE_API_FUNC(RedisModule_StringCompare)(RedisModuleString *a, RedisModuleString *b);
 RedisModuleCtx *REDISMODULE_API_FUNC(RedisModule_GetContextFromIO)(RedisModuleIO *io);
 const RedisModuleString *REDISMODULE_API_FUNC(RedisModule_GetKeyNameFromIO)(RedisModuleIO *io);
@@ -807,6 +808,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(LatencyAddSample);
     REDISMODULE_GET_API(StringAppendBuffer);
     REDISMODULE_GET_API(RetainString);
+    REDISMODULE_GET_API(HoldString);
     REDISMODULE_GET_API(StringCompare);
     REDISMODULE_GET_API(GetContextFromIO);
     REDISMODULE_GET_API(GetKeyNameFromIO);

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -11,12 +11,12 @@ tags "modules" {
             r zadd t 1 f1 2 f2
             r xadd s * f v
             r debug reload
-            assert_equal 1 [r keyspace.is_key_loaded x]
-            assert_equal 1 [r keyspace.is_key_loaded y]
-            assert_equal 1 [r keyspace.is_key_loaded z]
-            assert_equal 1 [r keyspace.is_key_loaded p]
-            assert_equal 1 [r keyspace.is_key_loaded t]
-            assert_equal 1 [r keyspace.is_key_loaded s]
+            assert_equal {1 x} [r keyspace.is_key_loaded x]
+            assert_equal {1 y} [r keyspace.is_key_loaded y]
+            assert_equal {1 z} [r keyspace.is_key_loaded z]
+            assert_equal {1 p} [r keyspace.is_key_loaded p]
+            assert_equal {1 t} [r keyspace.is_key_loaded t]
+            assert_equal {1 s} [r keyspace.is_key_loaded s]
         }
 	}
 }


### PR DESCRIPTION
PR follow the discussion on https://github.com/redis/redis/issues/7544

Added RedisModule_HoldString that either returns a shallow copy of the given String (by increasing the String ref count) or a new deep copy of String in case it's not possible to get a shallow copy.

Notice that I still wonder if passing the ctx in this case and add the String to its auto memory handling is the correct approach. Maybe we should just not allow passing a ctx in this case and say that HoldString keeps the String handling in the module writer hands and he needs to free it (no auto memory in this case).

Let me know what you think

