### PR TITLE
Fix running single test 14-consistency-check.tcl

### DIFF
--- a/tests/cluster/tests/14-consistency-check.tcl
+++ b/tests/cluster/tests/14-consistency-check.tcl
@@ -1,4 +1,5 @@
 source "../tests/includes/init-tests.tcl"
+source "../../../tests/support/cli.tcl"
 
 test "Create a 5 nodes cluster" {
     create_cluster 5 5


### PR DESCRIPTION
#7578 fixed test 14-consistency-check.tcl by adding TLS support.
But it did not consider running the single test. More precisely,
before this PR, it failed when running `./runtest-cluster --single 14`.