### PR TITLE
add force option to 'create-cluster create' script call

### DIFF
--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -38,7 +38,11 @@ then
         PORT=$((PORT+1))
         HOSTS="$HOSTS $CLUSTER_HOST:$PORT"
     done
-    $BIN_PATH/redis-cli --cluster create $HOSTS --cluster-replicas $REPLICAS
+    OPT_ARG=""
+    if [ "$2" == "-f" ]; then
+        OPT_ARG="--cluster-yes"
+    fi
+    $BIN_PATH/redis-cli --cluster create $HOSTS --cluster-replicas $REPLICAS $OPT_ARG
     exit 0
 fi
 
@@ -104,7 +108,7 @@ fi
 
 echo "Usage: $0 [start|create|stop|watch|tail|clean|call]"
 echo "start       -- Launch Redis Cluster instances."
-echo "create      -- Create a cluster using redis-cli --cluster create."
+echo "create [-f] -- Create a cluster using redis-cli --cluster create."
 echo "stop        -- Stop Redis Cluster instances."
 echo "watch       -- Show CLUSTER NODES output (first 30 lines) of first node."
 echo "tail <id>   -- Run tail -f of instance at base port + ID."


### PR DESCRIPTION
This is a followup on my PR #5879 for Redis 6.0. 
With Redis 6.0 redis-cli has an option to force cluster creation (without interaction) via the '--cluster-yes' option. Unfortunately there is still no '--force' option for the 'create-cluster create' script command.
Therefore I created this pull request to add a simple '-f' option to the script command. A more versatile approach would be to generically pass-thorough command-line options to redis-cli, but I wanted to keep the pull request small (to begin with).