### PR TITLE
Removes call to resetSaveParams when command...

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5160,7 +5160,6 @@ int main(int argc, char **argv) {
                 "Sentinel needs config file on disk to save state.  Exiting...");
             exit(1);
         }
-        resetServerSaveParams();
         loadServerConfig(configfile,options);
         sdsfree(options);
     }


### PR DESCRIPTION
...line arguments are passed to redis-server

Fixes #4567

(best issue number ever)