### PR TITLE
remove superfluous else block

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -756,8 +756,6 @@ void sdsrange(sds s, ssize_t start, ssize_t end) {
             end = len-1;
             newlen = (start > end) ? 0 : (end-start)+1;
         }
-    } else {
-        start = 0;
     }
     if (start && newlen) memmove(s, s+start, newlen);
     s[newlen] = 0;


### PR DESCRIPTION
The else block would be executed when `newlen == 0` and in the case memmove won't be called, so there's no need to set `start`.