### PR TITLE
Start redis after network is online

### DIFF
--- a/utils/systemd-redis_server.service
+++ b/utils/systemd-redis_server.service
@@ -20,6 +20,8 @@ Description=Redis data structure server
 Documentation=https://redis.io/documentation
 #Before=your_application.service another_example_application.service
 #AssertPathExists=/var/lib/redis
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/usr/local/bin/redis-server --supervised systemd --daemonize no


### PR DESCRIPTION
The two lines allow systemd to start redis.service after the network is online. With this it could not bind to IP address other than 127.0.0.1 during initial boot up process.