### PR TITLE
Correct error message of runtest-cluster and runtest-moduleapi

### DIFF
--- a/runtest-cluster
+++ b/runtest-cluster
@@ -8,7 +8,7 @@ done
 
 if [ -z $TCLSH ]
 then
-    echo "You need tcl 8.5 or newer in order to run the Redis Sentinel test"
+    echo "You need tcl 8.5 or newer in order to run the Redis Cluster test"
     exit 1
 fi
 $TCLSH tests/cluster/run.tcl $*

--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -8,7 +8,7 @@ done
 
 if [ -z $TCLSH ]
 then
-    echo "You need tcl 8.5 or newer in order to run the Redis test"
+    echo "You need tcl 8.5 or newer in order to run the Redis ModuleApi test"
     exit 1
 fi
 


### PR DESCRIPTION
Improve the output of runtest-cluster and runtest-moduleapi, make it more exactly.