### PR TITLE
[ACL] Edit auth failed message include user disabled case

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1981,7 +1981,7 @@ void authCommand(client *c) {
     if (ACLAuthenticateUser(c,username,password) == C_OK) {
         addReply(c,shared.ok);
     } else {
-        addReplyError(c,"-WRONGPASS invalid username-password pair");
+        addReplyError(c,"-WRONGPASS invalid username-password pair or user is disabled.");
     }
 
     /* Free the "default" string object we created for the two

--- a/src/networking.c
+++ b/src/networking.c
@@ -2523,7 +2523,7 @@ void helloCommand(client *c) {
         const char *opt = c->argv[j]->ptr;
         if (!strcasecmp(opt,"AUTH") && moreargs >= 2) {
             if (ACLAuthenticateUser(c, c->argv[j+1], c->argv[j+2]) == C_ERR) {
-                addReplyError(c,"-WRONGPASS invalid username-password pair");
+                addReplyError(c,"-WRONGPASS invalid username-password pair or user is disabled.");
                 return;
             }
             j += 2;


### PR DESCRIPTION
this is a follow up pr for https://github.com/redis/redis/pull/6773, the auth failed message should incude the case if user has been disabled, which is different than normal wrong user-pass. Therefore i think showing this information to user is necessary.