### PR TITLE
TLS: relax verification on CONFIG SET.

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -85,12 +85,19 @@ jobs:
         sudo apt-get install tcl8.5 tcl-tls
         ./utils/gen-test-certs.sh
         ./runtest --accurate --verbose --tls
+        ./runtest --accurate --verbose
     - name: module api test
-      run: ./runtest-moduleapi --verbose --tls
+      run: |
+        ./runtest-moduleapi --verbose --tls
+        ./runtest-moduleapi --verbose
     - name: sentinel tests
-      run: ./runtest-sentinel --tls
+      run: |
+        ./runtest-sentinel --tls
+        ./runtest-sentinel
     - name: cluster tests
-      run: ./runtest-cluster --tls
+      run: |
+        ./runtest-cluster --tls
+        ./runtest-cluster
 
   test-valgrind:
     runs-on: ubuntu-latest
@@ -147,10 +154,17 @@ jobs:
         yum -y install tcl tcltls
         ./utils/gen-test-certs.sh
         ./runtest --accurate --verbose --tls
+        ./runtest --accurate --verbose
     - name: module api test
-      run: ./runtest-moduleapi --verbose --tls
+      run: |
+        ./runtest-moduleapi --verbose --tls
+        ./runtest-moduleapi --verbose
     - name: sentinel tests
-      run: ./runtest-sentinel --tls
+      run: |
+        ./runtest-sentinel --tls
+        ./runtest-sentinel
     - name: cluster tests
-      run: ./runtest-cluster --tls
+      run: |
+        ./runtest-cluster --tls
+        ./runtest-cluster
 

--- a/src/config.c
+++ b/src/config.c
@@ -2205,7 +2205,10 @@ static int updateTlsCfg(char *val, char *prev, char **err) {
     UNUSED(val);
     UNUSED(prev);
     UNUSED(err);
-    if (tlsConfigure(&server.tls_ctx_config) == C_ERR) {
+
+    /* If TLS is enabled, try to configure OpenSSL. */
+    if ((server.tls_port || server.tls_replication || server.tls_cluster)
+            && tlsConfigure(&server.tls_ctx_config) == C_ERR) {
         *err = "Unable to update TLS configuration. Check server logs.";
         return 0;
     }


### PR DESCRIPTION
Avoid re-configuring (and validating) SSL/TLS configuration on `CONFIG
SET` when TLS is not actively enabled for incoming connections, cluster
bus or replication.

This fixes failures when tests run without `--tls` on binaries that were
built with TLS support.

An additional benefit is that it's now possible to perform a multi-step
configuration process while TLS is disabled. The new configuration will
be verified and applied only when TLS is effectively enabled.