### PR TITLE
[module] using predefined REDISMODULE_NO_EXPIRE in RM_GetExpire

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -2157,7 +2157,8 @@ int RM_UnlinkKey(RedisModuleKey *key) {
  * REDISMODULE_NO_EXPIRE is returned. */
 mstime_t RM_GetExpire(RedisModuleKey *key) {
     mstime_t expire = getExpire(key->db,key->key);
-    if (expire == -1 || key->value == NULL) return -1;
+    if (expire == -1 || key->value == NULL) 
+        return REDISMODULE_NO_EXPIRE;
     expire -= mstime();
     return expire >= 0 ? expire : 0;
 }


### PR DESCRIPTION
the REDISMODULE_NO_EXPIRE was predefined in redismodule.h ... we should using this rather than hardcoded -1 in order to avoid future problem if we decided to change its value.