### PR TITLE
Added timeout to redisConnect in redis-cli.c

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -867,10 +867,11 @@ static int cliConnect(int flags) {
             redisFree(context);
         }
 
+        struct timeval timeout = { 1, 500000 }; // 1.5 seconds
         if (config.hostsocket == NULL) {
-            context = redisConnect(config.hostip,config.hostport);
+            context = redisConnectWithTimeout(config.hostip,config.hostport,timeout);
         } else {
-            context = redisConnectUnix(config.hostsocket);
+            context = redisConnectUnixWithTimeout(config.hostsocket,timeout);
         }
 
         if (!context->err && config.tls) {


### PR DESCRIPTION
When redis-cli trying to connect with the Redis server for the very first time and if it finds the server isn't reachable which is running behind NAT, the commands gets blocked for 2 to 3 mins. This creates unnecessary delay when redis-cli is being used in shell script. Updated the redisConnect to redisConnectWithTimeout function and introduced a constant timeout of 1.5 seconds.