### PR TITLE
Fixed hset error since it's shared with hmset

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -532,7 +532,7 @@ void hsetCommand(client *c) {
     robj *o;
 
     if ((c->argc % 2) == 1) {
-        addReplyError(c,"wrong number of arguments for HMSET");
+        addReplyErrorFormat(c,"wrong number of arguments for '%s' command",c->cmd->name);
         return;
     }
 


### PR DESCRIPTION
hmset and hset use the same code path, but we print the wrong error out when using hset. 