### PR TITLE
Add comments on 'slave.repldboff' when use diskless replication

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1186,6 +1186,8 @@ void rdbPipeReadHandler(struct aeEventLoop *eventLoop, int fd, void *clientData,
                 /* An error and still in connected state, is equivalent to EAGAIN */
                 slave->repldboff = 0;
             } else {
+                /* Note: when use diskless replication, 'repldboff' is the offset
+                 * of 'rdb_pipe_buff' sent rather than the offset of entire RDB. */
                 slave->repldboff = nwritten;
                 server.stat_net_output_bytes += nwritten;
             }


### PR DESCRIPTION
I found the meaning of `slave.repldboff` is different from disk-backed replication when use diskless replication. 
It's easy to misunderstand for `slave->repldboff = nwritten;`, at first glance, I think it's an error,  I think we should add comments on it.