### PR TITLE
RedisModuleEvent_LoadingProgress always at 100% progress

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -7263,7 +7263,7 @@ void processModuleLoadingProgressEvent(int is_aof) {
         int progress = -1;
         if (server.loading_total_bytes)
             progress = (server.loading_total_bytes<<10) / server.loading_total_bytes;
-        RedisModuleFlushInfoV1 fi = {REDISMODULE_LOADING_PROGRESS_VERSION,
+        RedisModuleLoadingProgressV1 fi = {REDISMODULE_LOADING_PROGRESS_VERSION,
                                      server.hz,
                                      progress};
         moduleFireServerEvent(REDISMODULE_EVENT_LOADING_PROGRESS,

--- a/src/module.c
+++ b/src/module.c
@@ -7262,7 +7262,7 @@ void processModuleLoadingProgressEvent(int is_aof) {
         /* Fire the loading progress modules end event. */
         int progress = -1;
         if (server.loading_total_bytes)
-            progress = (server.loading_total_bytes<<10) / server.loading_total_bytes;
+            progress = (server.loading_loaded_bytes<<10) / server.loading_total_bytes;
         RedisModuleLoadingProgressV1 fi = {REDISMODULE_LOADING_PROGRESS_VERSION,
                                      server.hz,
                                      progress};


### PR DESCRIPTION
In `module.c/processModuleLoadingProgressEvent`, there is two bugs.
`fi` should be `RedisModuleLoadingProgressV1`, not `RedisModuleFlushInfoV1`.
```
RedisModuleFlushInfoV1 fi = {REDISMODULE_LOADING_PROGRESS_VERSION,
                                     server.hz,
                                     progress};
```

When calculating `progress`, we should use `server.loading_loaded_bytes`. Otherwise, `progress` will always be 1024.

```
if (server.loading_total_bytes)
      progress = (server.loading_total_bytes<<10) / server.loading_total_bytes;
```