### PR TITLE
Fix LPOS command when RANK is greater than matches

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -492,6 +492,7 @@ void *addReplyDeferredLen(client *c) {
 
 /* Populate the length object and try gluing it to the next chunk. */
 void setDeferredAggregateLen(client *c, void *node, long length, char prefix) {
+    serverAssert(length >= 0);
     listNode *ln = (listNode*)node;
     clientReplyBlock *next;
     char lenstr[128];

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -571,13 +571,14 @@ void lposCommand(client *c) {
     li = listTypeInitIterator(o,direction == LIST_HEAD ? -1 : 0,direction);
     listTypeEntry entry;
     long llen = listTypeLength(o);
-    long index = 0, matches = 0, matchindex = -1;
+    long index = 0, matches = 0, matchindex = -1, arraylen = 0;
     while (listTypeNext(li,&entry) && (maxlen == 0 || index < maxlen)) {
         if (listTypeEqual(&entry,ele)) {
             matches++;
             matchindex = (direction == LIST_TAIL) ? index : llen - index - 1;
             if (matches >= rank) {
                 if (arraylenptr) {
+                    arraylen++;
                     addReplyLongLong(c,matchindex);
                     if (count && matches-rank+1 >= count) break;
                 } else {
@@ -593,7 +594,7 @@ void lposCommand(client *c) {
     /* Reply to the client. Note that arraylenptr is not NULL only if
      * the COUNT option was selected. */
     if (arraylenptr != NULL) {
-        setDeferredArrayLen(c,arraylenptr,matches-rank+1);
+        setDeferredArrayLen(c,arraylenptr,arraylen);
     } else {
         if (matchindex != -1)
             addReplyLongLong(c,matchindex);

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -50,6 +50,12 @@ start_server {
         assert {[r LPOS mylist c COUNT 0 MAXLEN 7 RANK 2] == {6}}
     }
 
+    test {LPOS when RANK is greater than matches} {
+        r DEL mylist
+        r LPUSH l a
+        assert {[r LPOS mylist b COUNT 10 RANK 5] eq {}}
+    }
+
     test {LPUSH, RPUSH, LLENGTH, LINDEX, LPOP - ziplist} {
         # first lpush then rpush
         assert_equal 1 [r lpush myziplist1 aa]


### PR DESCRIPTION
For example,
before the fix we get:
```
telnet localhost 6379
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
LPUSH l a
:1
LPOS l b RANK 5 COUNT 10
*-4
```

and after the fix we get:
```
telnet localhost 6379
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
LPUSH l a
:1
LPOS l b RANK 5 COUNT 10
*0
```