### PR TITLE
fix make warnings

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2551,9 +2551,6 @@ static void readOOMScoreAdj(void) {
  * depending on current role.
  */
 int setOOMScoreAdj(int process_class) {
-    int fd;
-    int val;
-    char buf[64];
 
     if (!server.oom_score_adj) return C_OK;
     if (process_class == -1)
@@ -2562,6 +2559,10 @@ int setOOMScoreAdj(int process_class) {
     serverAssert(process_class >= 0 && process_class < CONFIG_OOM_COUNT);
 
 #ifdef HAVE_PROC_OOM_SCORE_ADJ
+    int fd;
+    int val;
+    char buf[64];
+
     val = server.oom_score_adj_base + server.oom_score_adj_values[process_class];
     if (val > 1000) val = 1000;
     if (val < -1000) val = -1000;


### PR DESCRIPTION
The following warnings were generated when I do make to build binary today..

server.c:2556:10: warning: unused variable 'buf' [-Wunused-variable]
    char buf[64];
         ^
server.c:2555:9: warning: unused variable 'val' [-Wunused-variable]
    int val;
        ^
server.c:2554:9: warning: unused variable 'fd' [-Wunused-variable]
    int fd;
        ^
3 warnings generated.

This PR fixes these warnings ...