### PR TITLE
Don't write to clients with CLIENT_CLOSE_ASAP flag

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1418,9 +1418,9 @@ int handleClientsWithPendingWrites(void) {
         c->flags &= ~CLIENT_PENDING_WRITE;
         listDelNode(server.clients_pending_write,ln);
 
-        /* If a client is protected, don't do anything,
+        /* If a client is protected or at risk of closing, don't do anything
          * that may trigger write error or recreate handler. */
-        if (c->flags & CLIENT_PROTECTED) continue;
+        if (c->flags & (CLIENT_PROTECTED|CLIENT_CLOSE_ASAP)) continue;
 
         /* Try to write buffers to the client socket. */
         if (writeToClient(c,0) == C_ERR) continue;


### PR DESCRIPTION
This PR resolves an issue observed on RedisGraph in which prematurely closing clients that are awaiting replies from Redis can cause a server crash on a broken pipe.

I can consistently reproduce this issue locally, but the code to do so is unfortunately non-trivial. The reproduction steps include instantiating several clients, issuing RedisGraph commands which return data, then disconnecting the clients without waiting for responses.

This causes a crash with the stack trace:
```
Thread 1 "redis-server" received signal SIGPIPE, Broken pipe.
0x00007ffff76252c7 in __libc_write (fd=16, buf=0x555555a74bc8, nbytes=140) at ../sysdeps/unix/sysv/linux/write.c:27
27      ../sysdeps/unix/sysv/linux/write.c: No such file or directory.

#0  0x00007ffff76252c7 in __libc_write (fd=16, buf=0x555555a74bc8, nbytes=140) at ../sysdeps/unix/sysv/linux/write.c:27
#1  0x000055555564dfef in connSocketWrite (conn=0x555555a1ec50, data=0x555555a74bc8, data_len=140) at connection.c:168
#2  0x00005555555a2af7 in connWrite (conn=0x555555a1ec50, data=0x555555a74bc8, data_len=140) at connection.h:140
#3  0x00005555555a630f in writeToClient (c=0x555555a74970, handler_installed=0) at networking.c:1311
#4  0x00005555555a6780 in handleClientsWithPendingWrites () at networking.c:1426
#5  0x00005555555ab64c in handleClientsWithPendingWritesUsingThreads () at networking.c:3063
#6  0x0000555555590ef5 in beforeSleep (eventLoop=0x555555928230) at server.c:2202
#7  0x000055555558a42a in aeProcessEvents (eventLoop=0x555555928230, flags=27) at ae.c:443
#8  0x000055555558a748 in aeMain (eventLoop=0x555555928230) at ae.c:539
#9  0x00005555555996fe in main (argc=2, argv=0x7fffffffd2a8) at server.c:5325
```

This issue is reproduce on unstable and 6.0.6, this PR resolves it on both.
