### PR TITLE
Modules: Add TLSAuth module.

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -230,6 +230,7 @@ int connSockName(connection *conn, char *ip, size_t ip_len, int *port);
 const char *connGetInfo(connection *conn, char *buf, size_t buf_len);
 
 /* Helpers for tls special considerations */
+sds connTLSGetClientCert(connection *conn);
 int tlsHasPendingData();
 int tlsProcessPendingData();
 

--- a/src/module.c
+++ b/src/module.c
@@ -5678,6 +5678,26 @@ int RM_DeauthenticateAndCloseClient(RedisModuleCtx *ctx, uint64_t client_id) {
     return REDISMODULE_OK;
 }
 
+/* Return the X.509 client-side certificate used by the client to authenticate
+ * this connection.
+ *
+ * The returned string is a X.509 PEM (base64 encoded) string. If the connection
+ * is not TLS, or if no client-side certificate was used, a NULL is returned.
+ */
+
+RedisModuleString *RM_GetClientCertificate(RedisModuleCtx *ctx, uint64_t client_id) {
+    client *c = lookupClientByID(client_id);
+    if (c == NULL) return NULL;
+
+    sds cert = connTLSGetClientCert(c->conn);
+    if (!cert) return NULL;
+
+    RedisModuleString *s = createObject(OBJ_STRING, cert);
+    if (ctx != NULL) autoMemoryAdd(ctx, REDISMODULE_AM_STRING, s);
+
+    return s;
+}
+
 /* --------------------------------------------------------------------------
  * Modules Dictionary API
  *
@@ -8054,4 +8074,5 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(DeauthenticateAndCloseClient);
     REGISTER_API(AuthenticateClientWithACLUser);
     REGISTER_API(AuthenticateClientWithUser);
+    REGISTER_API(GetClientCertificate);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -5689,7 +5689,6 @@ int RM_DeauthenticateAndCloseClient(RedisModuleCtx *ctx, uint64_t client_id) {
  * The returned string is a X.509 PEM (base64 encoded) string. If the connection
  * is not TLS, or if no client-side certificate was used, a NULL is returned.
  */
-
 RedisModuleString *RM_GetClientCertificate(RedisModuleCtx *ctx, uint64_t client_id) {
     client *c = lookupClientByID(client_id);
     if (c == NULL) return NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -5614,6 +5614,11 @@ static int authenticateClientWithUser(RedisModuleCtx *ctx, user *user, RedisModu
         return REDISMODULE_ERR;
     }
 
+    /* Avoid settings which are meaningless and will be lost */
+    if (!ctx->client || (ctx->client->flags & CLIENT_MODULE)) {
+        return REDISMODULE_ERR;
+    }
+
     moduleNotifyUserChanged(ctx->client);
 
     ctx->client->user = user;

--- a/src/module.c
+++ b/src/module.c
@@ -7245,6 +7245,7 @@ void moduleFireServerEvent(uint64_t eid, int subid, void *data) {
      * cheap if there are no registered modules. */
     if (listLength(RedisModule_EventListeners) == 0) return;
 
+    int real_client_used = 0;
     listIter li;
     listNode *ln;
     listRewind(RedisModule_EventListeners,&li);
@@ -7254,7 +7255,15 @@ void moduleFireServerEvent(uint64_t eid, int subid, void *data) {
             RedisModuleCtx ctx = REDISMODULE_CTX_INIT;
             ctx.module = el->module;
 
-            if (ModulesInHooks == 0) {
+            if (eid == REDISMODULE_EVENT_CLIENT_CHANGE) {
+                /* In the case of client changes, we're pushing the real client
+                 * so the event handler can mutate it if needed. For example,
+                 * to change its authentication state in a way that does not
+                 * depend on specific commands executed later.
+                 */
+                ctx.client = (client *) data;
+                real_client_used = 1;
+            } else if (ModulesInHooks == 0) {
                 ctx.client = moduleFreeContextReusedClient;
             } else {
                 ctx.client = createClient(NULL);
@@ -7305,7 +7314,7 @@ void moduleFireServerEvent(uint64_t eid, int subid, void *data) {
             el->module->in_hook--;
             ModulesInHooks--;
 
-            if (ModulesInHooks != 0) freeClient(ctx.client);
+            if (ModulesInHooks != 0 && !real_client_used) freeClient(ctx.client);
             moduleFreeContext(&ctx);
         }
     }

--- a/src/modules/examples/Makefile
+++ b/src/modules/examples/Makefile
@@ -1,67 +1,49 @@
 
-# find the OS
-uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
-
-# Compile flags for linux / osx
-ifeq ($(uname_S),Linux)
-	SHOBJ_CFLAGS ?= -W -Wall -fno-common -g -ggdb -std=c99 -O2
-	SHOBJ_LDFLAGS ?= -shared
-else
-	SHOBJ_CFLAGS ?= -W -Wall -dynamic -fno-common -g -ggdb -std=c99 -O2
-	SHOBJ_LDFLAGS ?= -bundle -undefined dynamic_lookup
-endif
-
-.SUFFIXES: .c .so .xo .o
+include ../module.mk
 
 all: helloworld.so hellotype.so helloblock.so testmodule.so hellocluster.so hellotimer.so hellodict.so hellohook.so helloacl.so
 
-.c.xo:
-	$(CC) -I. $(CFLAGS) $(SHOBJ_CFLAGS) -fPIC -c $< -o $@
-
-helloworld.xo: ../redismodule.h
+helloworld.xo: $(REDISMODULE_H)
 
 helloworld.so: helloworld.xo
 	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
-hellotype.xo: ../redismodule.h
+hellotype.xo: $(REDISMODULE_H)
 
 hellotype.so: hellotype.xo
 	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
-helloblock.xo: ../redismodule.h
+helloblock.xo: $(REDISMODULE_H)
 
 helloblock.so: helloblock.xo
 	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lpthread -lc
 
-hellocluster.xo: ../redismodule.h
+hellocluster.xo: $(REDISMODULE_H)
 
 hellocluster.so: hellocluster.xo
 	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
-hellotimer.xo: ../redismodule.h
+hellotimer.xo: $(REDISMODULE_H)
 
 hellotimer.so: hellotimer.xo
 	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
-hellodict.xo: ../redismodule.h
+hellodict.xo: $(REDISMODULE_H)
 
 hellodict.so: hellodict.xo
 	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
-hellohook.xo: ../redismodule.h
+hellohook.xo: $(REDISMODULE_H)
 
 hellohook.so: hellohook.xo
 	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
-helloacl.xo: ../redismodule.h
+helloacl.xo: $(REDISMODULE_H)
 
 helloacl.so: helloacl.xo
 	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
-testmodule.xo: ../redismodule.h
+testmodule.xo: $(REDISMODULE_H)
 
 testmodule.so: testmodule.xo
 	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
-
-clean:
-	rm -rf *.xo *.so

--- a/src/modules/examples/helloacl.c
+++ b/src/modules/examples/helloacl.c
@@ -32,7 +32,7 @@
  */
 
 #define REDISMODULE_EXPERIMENTAL_API
-#include "../redismodule.h"
+#include "redismodule.h"
 #include <pthread.h>
 #include <unistd.h>
 

--- a/src/modules/examples/helloblock.c
+++ b/src/modules/examples/helloblock.c
@@ -32,7 +32,7 @@
  */
 
 #define REDISMODULE_EXPERIMENTAL_API
-#include "../redismodule.h"
+#include "redismodule.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>

--- a/src/modules/examples/hellocluster.c
+++ b/src/modules/examples/hellocluster.c
@@ -31,7 +31,7 @@
  */
 
 #define REDISMODULE_EXPERIMENTAL_API
-#include "../redismodule.h"
+#include "redismodule.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/src/modules/examples/hellodict.c
+++ b/src/modules/examples/hellodict.c
@@ -34,7 +34,7 @@
  */
 
 #define REDISMODULE_EXPERIMENTAL_API
-#include "../redismodule.h"
+#include "redismodule.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/src/modules/examples/hellohook.c
+++ b/src/modules/examples/hellohook.c
@@ -31,7 +31,7 @@
  */
 
 #define REDISMODULE_EXPERIMENTAL_API
-#include "../redismodule.h"
+#include "redismodule.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/src/modules/examples/hellohook.c
+++ b/src/modules/examples/hellohook.c
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
+#include <inttypes.h>
 
 /* Client state change callback. */
 void clientChangeCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub, void *data)
@@ -44,7 +45,7 @@ void clientChangeCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub,
     REDISMODULE_NOT_USED(e);
 
     RedisModuleClientInfo *ci = data;
-    printf("Client %s event for client #%llu %s:%d\n",
+    printf("Client %s event for client #%"PRIu64" %s:%d\n",
         (sub == REDISMODULE_SUBEVENT_CLIENT_CHANGE_CONNECTED) ?
             "connection" : "disconnection",
         ci->id,ci->addr,ci->port);

--- a/src/modules/examples/hellotimer.c
+++ b/src/modules/examples/hellotimer.c
@@ -31,7 +31,7 @@
  */
 
 #define REDISMODULE_EXPERIMENTAL_API
-#include "../redismodule.h"
+#include "redismodule.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/src/modules/examples/hellotype.c
+++ b/src/modules/examples/hellotype.c
@@ -35,7 +35,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../redismodule.h"
+#include "redismodule.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/src/modules/examples/helloworld.c
+++ b/src/modules/examples/helloworld.c
@@ -34,7 +34,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../redismodule.h"
+#include "redismodule.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/src/modules/examples/testmodule.c
+++ b/src/modules/examples/testmodule.c
@@ -220,7 +220,7 @@ int TestNotifications(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     } else {
         rep = RedisModule_CallReplyStringPtr(r, &sz);
         if (sz != 1 || *rep != '1') {
-            FAIL("Got reply '%.*s'. expected '1'", sz, rep);
+            FAIL("Got reply '%.*s'. expected '1'", (int) sz, rep);
         }
     }
     /* For l we expect nothing since we didn't subscribe to list events */
@@ -235,7 +235,7 @@ int TestNotifications(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     } else {
         rep = RedisModule_CallReplyStringPtr(r, &sz);
         if (sz != 1 || *rep != '2') {
-            FAIL("Got reply '%.*s'. expected '2'", sz, rep);
+            FAIL("Got reply '%.*s'. expected '2'", (int) sz, rep);
         }
     }
 

--- a/src/modules/examples/testmodule.c
+++ b/src/modules/examples/testmodule.c
@@ -31,7 +31,7 @@
  */
 
 #define REDISMODULE_EXPERIMENTAL_API
-#include "../redismodule.h"
+#include "redismodule.h"
 #include <string.h>
 
 /* --------------------------------- Helpers -------------------------------- */

--- a/src/modules/module.mk
+++ b/src/modules/module.mk
@@ -1,0 +1,25 @@
+
+# find the OS
+uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+
+# Compile flags for linux / osx
+ifeq ($(uname_S),Linux)
+	SHOBJ_CFLAGS ?= -W -Wall -fno-common -g -ggdb -std=c99 -O2
+	SHOBJ_LDFLAGS ?= -shared
+else
+	SHOBJ_CFLAGS ?= -W -Wall -dynamic -fno-common -g -ggdb -std=c99 -O2
+	SHOBJ_LDFLAGS ?= -bundle -undefined dynamic_lookup
+endif
+
+CFLAGS = -I../..
+REDISMODULE_H = ../../redismodule.h
+
+.SUFFIXES: .c .so .xo .o
+
+all:
+
+.c.xo:
+	$(CC) $(CFLAGS) $(SHOBJ_CFLAGS) -fPIC -c $< -o $@
+
+clean:
+	rm -rf *.xo *.so

--- a/src/modules/tlsauth/Makefile
+++ b/src/modules/tlsauth/Makefile
@@ -1,0 +1,9 @@
+
+include ../module.mk
+
+all: tlsauth.so
+
+tlsauth.xo: $(REDISMODULE_H)
+
+tlsauth.so: tlsauth.xo
+	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc

--- a/src/modules/tlsauth/README.md
+++ b/src/modules/tlsauth/README.md
@@ -1,0 +1,89 @@
+# TLSAuth module
+
+This modules integrates TLS client side certificates with the ACL subsystem,
+making it possible to automatically grant users their ACL permissions based on
+the client-side certificate used to authenticate.
+
+## Getting started
+
+To get started quickly and see how it works, follow these steps:
+
+1. Run `./utils/gen-test-certs.sh` to have server certs generated.
+
+2. Create user certificates for Alice and Bob. We will use the commonName (CN)
+   attribute to store the user identity, and a "Redis Test" organization and
+   "Users" organizatinalUnit.
+
+        openssl req \
+                 -new -sha256 \
+                 -newkey rsa:2048 -nodes -keyout tests/tls/alice.key \
+                 -subj '/O=Redis Test/OU=Users/CN=alice' | \
+                     openssl x509 \
+                         -req -sha256 -CA tests/tls/ca.crt \
+                         -CAkey tests/tls/ca.key \
+                         -CAserial tests/tls/ca.txt \
+                         -CAcreateserial \
+                         -days 365 \
+                         -out tests/tls/alice.crt
+
+        openssl req \
+                 -new -sha256 \
+                 -newkey rsa:2048 -nodes -keyout tests/tls/bob.key \
+                 -subj '/O=Redis Test/OU=Users/CN=bob' | \
+                     openssl x509 \
+                         -req -sha256 -CA tests/tls/ca.crt \
+                         -CAkey tests/tls/ca.key \
+                         -CAserial tests/tls/ca.txt \
+                         -CAcreateserial \
+                         -days 365 \
+                         -out tests/tls/bob.crt
+
+3. Create a Redis configuration with two ACL users and TLS enabled:
+
+         tls-ca-cert-file "tests/tls/ca.crt"
+         tls-cert-file "tests/tls/redis.crt"
+         tls-key-file "tests/tls/redis.key"
+         tls-auth-clients yes
+         tls-port 6379
+         port 0
+         user alice on #93dbc7782132ec0d34e8543805a5f85401044c0e04b6c69d4544cac7d29eb029 ~* +@all
+         user bob on #2a31d2ffaa7fe4e35b7fe6c990c02489ebee5a18cf388c3236910c59212e11b3 ~* +@all
+         loadmodule src/modules/tlsauth/tlsauth.so attr-user=commonName attr-check=O:"Redis Test" attr-check=OU:Users
+
+4. Start Redis, connect using redis-cli with the different certificates and
+   observe user identity assigned depending on certificate used:
+
+         redis-cli --tls --cacert tests/tls/ca.crt --cert tests/tls/alice.crt --key tests/tls/alice.key acl whoami
+         "alice"
+
+         redis-cli --tls --cacert tests/tls/ca.crt --cert tests/tls/bob.crt --key tests/tls/bob.key acl whoami
+         "bob"
+
+## How it works
+
+The TLSAuth module monitors all incoming connections and inspects the
+client-side certificate that was in use.
+
+First, it performs a series of checks on the Subject Distinguished Name to
+confirm the certificate should be used to extract user information. These checks
+are configured by the `attr-check` arguments, which take the form of
+`<attribute-name>:<expected-value>`.
+
+In the example above, we specify two checks:
+
+1. The `O (organization)` attribute should match `Redis Test`.
+2. The `OU (organizationalUnit)` attribute should match `Users`.
+
+By default, no checks are performed.
+
+If all checks are successful, the user identity is extracted from the attribute
+specified in the `attr-user` attribute. By default, the `CN (commonName)`
+attribute is used.
+
+Once the identity of the user has been established, the user is authenticated to
+Redis as if an explicit `AUTH` command was issued. For this to succeed, the
+following conditions must be met:
+
+1. The user needs to be defined as an ACL user.
+2. The user must not be disabled.
+

--- a/src/modules/tlsauth/README.md
+++ b/src/modules/tlsauth/README.md
@@ -48,42 +48,71 @@ To get started quickly and see how it works, follow these steps:
          port 0
          user alice on #93dbc7782132ec0d34e8543805a5f85401044c0e04b6c69d4544cac7d29eb029 ~* +@all
          user bob on #2a31d2ffaa7fe4e35b7fe6c990c02489ebee5a18cf388c3236910c59212e11b3 ~* +@all
-         loadmodule src/modules/tlsauth/tlsauth.so attr-user=commonName attr-check=O:"Redis Test" attr-check=OU:Users
+         loadmodule src/modules/tlsauth/tlsauth.so USER-ATTRIBUTE commonName REQUIRED-ATTRIBUTE O "Redis Test" REQUIRED-ATTRIBUTE OU Users
 
 4. Start Redis, connect using redis-cli with the different certificates and
    observe user identity assigned depending on certificate used:
 
-         redis-cli --tls --cacert tests/tls/ca.crt --cert tests/tls/alice.crt --key tests/tls/alice.key acl whoami
-         "alice"
+         redis-cli --tls \
+            --cacert tests/tls/ca.crt \
+            --cert tests/tls/alice.crt \
+            --key tests/tls/alice.key \
+            acl whoami
 
-         redis-cli --tls --cacert tests/tls/ca.crt --cert tests/tls/bob.crt --key tests/tls/bob.key acl whoami
-         "bob"
+         redis-cli --tls \
+            --cacert tests/tls/ca.crt \
+            --cert tests/tls/bob.crt \
+            --key tests/tls/bob.key \
+         acl whoami
 
 ## How it works
 
-The TLSAuth module monitors all incoming connections and inspects the
-client-side certificate that was in use.
+The TLSAuth module uses information encoded in the client side certificate to
+authenticate users without requiring explicit `AUTH` commands.
 
-First, it performs a series of checks on the Subject Distinguished Name to
-confirm the certificate should be used to extract user information. These checks
-are configured by the `attr-check` arguments, which take the form of
-`<attribute-name>:<expected-value>`.
+A user will be authenticated using the client-side certificate when all of
+the following conditions are met:
 
-In the example above, we specify two checks:
+1. User has established a TLS connection and used a client-side certificate.
+2. The client-side certificate is valid and has been signed by a trusted
+   certificate authority (per `tls-ca-cert-file` configuration).
+3. The certificate Subject Distinguished Name (DN) contains a user identity
+   attribute, as specified by USER-ATTRIBUTE (default is `CN` or `commonName`).
+4. If REQUIRED-ATTRIBUTE configuration keywords are used, the specified
+   attributes and values must be part of the DN.
+
+In the example above, we specify two required attributes:
 
 1. The `O (organization)` attribute should match `Redis Test`.
 2. The `OU (organizationalUnit)` attribute should match `Users`.
 
-By default, no checks are performed.
+If no required attributes are specified, any certificate is accepted (as long
+as it is valid and signed by a trusted certificate authority).
 
-If all checks are successful, the user identity is extracted from the attribute
-specified in the `attr-user` attribute. By default, the `CN (commonName)`
-attribute is used.
+The user identity is extracted from the attribute specified as USER-ATTRIBUTE.
+By default, the `CN (commonName)` attribute is used.
 
-Once the identity of the user has been established, the user is authenticated to
-Redis as if an explicit `AUTH` command was issued. For this to succeed, the
-following conditions must be met:
+The extracted user ID must match an existing ACL user. If the ID corresponds
+to a non-existing or disabled user, authentication will fail and the connection
+will fall back to the normal authentication flow.
 
-1. The user needs to be defined as an ACL user.
-2. The user must not be disabled.
+## Configuration
 
+Configuration is provided as extra arguments to the `MODULE LOAD` command or
+`loadmodule` configuration directive.
+
+### USER-ATTRIBUTE `attribute name`
+
+Optional; Default: `CN` or `commonName`.
+
+Specifies the name of the Subject Distinguished Name (DN) attribute that holds
+the user identity. The attribute name can be specified in short form (e.g.
+`cn`) or long form (e.g. `commonName`).
+
+### REQUIRED-ATTRIBUTE `attribute name` `attribute value`
+
+Optional; Maye be listed multiple times; Default: None
+
+Specifies an attribute (name and value) that must be part of the Subject
+Distinguished Name (DN). If the DN does not contain the attribute, or
+holds a different value, the certificate is not considered for authentication.

--- a/src/modules/tlsauth/tlsauth.c
+++ b/src/modules/tlsauth/tlsauth.c
@@ -1,0 +1,231 @@
+/* TLS Authentication module -- Handle automatic user authentication
+ * based on TLS client side certificate attributes.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * Copyright (c) 2020, Redis Labs
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* To see this module in action, follow these steps:
+ *
+ */
+
+#define REDISMODULE_EXPERIMENTAL_API
+#include <string.h>
+#include <sys/types.h>
+
+#include <openssl/x509.h>
+#include <openssl/bio.h>
+#include <openssl/pem.h>
+
+#include "redismodule.h"
+
+struct AttrCheck {
+    int nid;
+    const char *req_value;
+    struct AttrCheck *next;
+};
+
+static int configUserAttr = NID_commonName;
+static struct AttrCheck *configAttrChecks = NULL;
+
+static struct AttrCheck *parseAttrCheck(RedisModuleCtx *ctx, char *attr_check_str)
+{
+    char *delim = strchr(attr_check_str, ':');
+    if (!delim) {
+        RedisModule_Log(ctx, "warn",
+                "Invalid attr-check: expected 'attribute:value' format: %s", attr_check_str);
+        return NULL;
+    }
+
+    *delim = '\0';
+    int nid = OBJ_txt2nid(attr_check_str);
+    if (nid == NID_undef) {
+        RedisModule_Log(ctx, "warn",
+                "Invalid attr-check attribute: %s", attr_check_str);
+        return NULL;
+    }
+
+    struct AttrCheck *check = RedisModule_Alloc(sizeof(struct AttrCheck));
+    check->nid = nid;
+    check->req_value = RedisModule_Strdup(delim + 1);
+    check->next = NULL;
+
+    return check;
+}
+
+static int parseConfigArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+{
+    const char kw_attr_user[] = "attr-user";
+    const char kw_attr_check[] = "attr-check";
+    int error = 0;
+    int i;
+
+    for (i = 0; i < argc; i++) {
+        size_t len;
+        const char *str = RedisModule_StringPtrLen(argv[i], &len);
+
+        const char *delim = memchr(str, '=', len);
+        if (!delim) {
+            RedisModule_Log(ctx, "warn",
+                    "Invalid argument: %.*s", (int) len, str);
+            return REDISMODULE_ERR;
+        }
+
+        /* Set up keyword, value lengths and a null-terminated value */
+        size_t kw_len = delim - str;
+        size_t val_len = len - (kw_len + 1);
+        char *val = RedisModule_Alloc(val_len + 1);
+        memcpy(val, delim + 1, val_len);
+        val[val_len] = '\0';
+
+
+        if (kw_len == strlen(kw_attr_user) && !memcmp(str, kw_attr_user, kw_len)) {
+            int nid = OBJ_txt2nid(val);
+            if (nid == NID_undef) {
+                RedisModule_Log(ctx, "warn",
+                        "Invalid attribute name: %s", val);
+                error = 1;
+            } else {
+                configUserAttr = nid;
+            }
+        } else if (kw_len == strlen(kw_attr_check) && !memcmp(str, kw_attr_check, kw_len)) {
+            struct AttrCheck *check = parseAttrCheck(ctx, val);
+            if (!check) {
+                error = 1;
+            } else {
+                check->next = configAttrChecks;
+                configAttrChecks = check;
+            }
+        } else {
+            RedisModule_Log(ctx, "warn",
+                    "Unknown configuration argument: %.*s", (int) kw_len, str);
+            error = 1;
+        }
+
+        RedisModule_Free(val);
+        if (error) return 0;
+    }
+
+    return 1;
+}
+
+static X509 *decodeCertificate(RedisModuleString *cert_str)
+{
+    size_t len;
+    const char *str = RedisModule_StringPtrLen(cert_str, &len);
+
+    BIO *bio = BIO_new(BIO_s_mem());
+    BIO_write(bio, str, len);
+
+    X509 *cert = PEM_read_bio_X509(bio, NULL, NULL, NULL);
+    return cert;
+}
+
+static int checkCertificate(X509 *cert)
+{
+    int loc;
+    X509_NAME *subj = X509_get_subject_name(cert);
+    X509_NAME_ENTRY *entry;
+    struct AttrCheck *check = configAttrChecks;
+
+    while (check != NULL) {
+        /* Find entry */
+        if ((loc = X509_NAME_get_index_by_NID(subj, check->nid, -1)) < 0)
+            return 0;
+
+        /* Compare */
+        if (!(entry = X509_NAME_get_entry(subj, loc)))
+            return 0;
+
+        const char *val = (const char *) ASN1_STRING_get0_data(X509_NAME_ENTRY_get_data(entry));
+        if (strcmp(val, check->req_value)) return 0;
+
+        /* Next */
+        check = check->next;
+    }
+
+    return 1;
+}
+
+const char *getAttribute(X509 *cert, int nid)
+{
+    X509_NAME_ENTRY *entry;
+    X509_NAME *subj = X509_get_subject_name(cert);
+    int loc;
+
+    if ((loc = X509_NAME_get_index_by_NID(subj, nid, -1)) < 0)
+        return NULL;
+
+    if (!(entry = X509_NAME_get_entry(subj, loc)))
+        return NULL;
+
+    return (const char *) ASN1_STRING_get0_data(X509_NAME_ENTRY_get_data(entry));
+}
+
+static void handleClientConnection(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data)
+{
+    if (eid.id == REDISMODULE_EVENT_CLIENT_CHANGE &&
+            subevent == REDISMODULE_SUBEVENT_CLIENT_CHANGE_CONNECTED) {
+        RedisModuleClientInfo *ci = (RedisModuleClientInfo *) data;
+        RedisModuleString *cert_str = RedisModule_GetClientCertificate(ctx, ci->id);
+        if (cert_str != NULL) {
+            X509 *cert = decodeCertificate(cert_str);
+            const char *user;
+
+            if (cert && checkCertificate(cert) &&
+                    (user = getAttribute(cert, configUserAttr)) != NULL) {
+
+                    if (RedisModule_AuthenticateClientWithACLUser(ctx, user, strlen(user),
+                                NULL, NULL, NULL) == REDISMODULE_ERR) {
+                        RedisModule_Log(ctx, "verbose",
+                                "Failed to authorize user %s", user);
+                    } else {
+                        RedisModule_Log(ctx, "debug", "Authorized user %s", user);
+                    }
+            }
+
+            RedisModule_FreeString(ctx, cert_str);
+        }
+    }
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (RedisModule_Init(ctx, "tlsauth", 1, REDISMODULE_APIVER_1)
+            == REDISMODULE_ERR) return REDISMODULE_ERR;
+
+    if (!parseConfigArgs(ctx, argv, argc))
+        return REDISMODULE_ERR;
+
+    if (RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ClientChange,
+        handleClientConnection) == REDISMODULE_ERR) {
+            return REDISMODULE_ERR;
+    }
+
+    return REDISMODULE_OK;
+}

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -706,6 +706,7 @@ REDISMODULE_API int (*RedisModule_SetModuleUserACL)(RedisModuleUser *user, const
 REDISMODULE_API int (*RedisModule_AuthenticateClientWithACLUser)(RedisModuleCtx *ctx, const char *name, size_t len, RedisModuleUserChangedFunc callback, void *privdata, uint64_t *client_id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_AuthenticateClientWithUser)(RedisModuleCtx *ctx, RedisModuleUser *user, RedisModuleUserChangedFunc callback, void *privdata, uint64_t *client_id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_DeauthenticateAndCloseClient)(RedisModuleCtx *ctx, uint64_t client_id) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString * (*RedisModule_GetClientCertificate)(RedisModuleCtx *ctx, uint64_t id) REDISMODULE_ATTR;
 #endif
 
 #define RedisModule_IsAOFClient(id) ((id) == CLIENT_ID_AOF)
@@ -947,6 +948,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(DeauthenticateAndCloseClient);
     REDISMODULE_GET_API(AuthenticateClientWithACLUser);
     REDISMODULE_GET_API(AuthenticateClientWithUser);
+    REDISMODULE_GET_API(GetClientCertificate);
 #endif
 
     if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;

--- a/src/tls.c
+++ b/src/tls.c
@@ -37,6 +37,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#include <openssl/pem.h>
 
 #define REDIS_TLS_PROTO_TLSv1       (1<<0)
 #define REDIS_TLS_PROTO_TLSv1_1     (1<<1)
@@ -865,6 +866,27 @@ int tlsProcessPendingData() {
     return processed;
 }
 
+sds connTLSGetClientCert(connection *conn_) {
+    tls_connection *conn = (tls_connection *) conn_;
+    if (conn_->type->get_type(conn_) != CONN_TYPE_TLS || !conn->ssl) return NULL;
+
+    X509 *cert = SSL_get_peer_certificate(conn->ssl);
+    if (!cert) return NULL;
+
+    BIO *bio = BIO_new(BIO_s_mem());
+    if (bio == NULL || !PEM_write_bio_X509(bio, cert)) {
+        if (bio != NULL) BIO_free(bio);
+        return NULL;
+    }
+
+    const char *bio_ptr;
+    long long bio_len = BIO_get_mem_data(bio, &bio_ptr);
+    sds cert_pem = sdsnewlen(bio_ptr, bio_len);
+    BIO_free(bio);
+
+    return cert_pem;
+}
+
 #else   /* USE_OPENSSL */
 
 void tlsInit(void) {
@@ -892,6 +914,11 @@ int tlsHasPendingData() {
 
 int tlsProcessPendingData() {
     return 0;
+}
+
+sds connTLSGetClientCert(connection *conn_) {
+    (void) conn_;
+    return NULL;
 }
 
 #endif

--- a/src/tls.c
+++ b/src/tls.c
@@ -825,7 +825,7 @@ exit:
 }
 
 static int connTLSGetType(connection *conn_) {
-    (void) conn_;
+    UNUSED(conn_);
 
     return CONN_TYPE_TLS;
 }
@@ -917,7 +917,7 @@ int tlsProcessPendingData() {
 }
 
 sds connTLSGetClientCert(connection *conn_) {
-    (void) conn_;
+    UNUSED(conn_);
     return NULL;
 }
 

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -195,6 +195,23 @@ int test_setlfu(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     return REDISMODULE_OK;
 }
 
+int test_getclientcert(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+{
+    (void) argv;
+    (void) argc;
+
+    RedisModuleString *cert = RedisModule_GetClientCertificate(ctx,
+            RedisModule_GetClientId(ctx));
+    if (!cert) {
+        RedisModule_ReplyWithNull(ctx);
+    } else {
+        RedisModule_ReplyWithString(ctx, cert);
+        RedisModule_FreeString(ctx, cert);
+    }
+
+    return REDISMODULE_OK;
+}
+
 int test_clientinfo(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 {
     (void) argv;
@@ -258,6 +275,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_CreateCommand(ctx,"test.getlfu", test_getlfu,"",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
     if (RedisModule_CreateCommand(ctx,"test.clientinfo", test_clientinfo,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx,"test.getclientcert", test_getclientcert,"",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     return REDISMODULE_OK;

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -86,4 +86,14 @@ start_server {tags {"modules"}} {
         set info [r test.clientinfo]
         assert { [dict get $info flags] == "${ssl_flag}::tracking::" }
     }
+
+    test {test module getclientcert api} {
+        set cert [r test.getclientcert]
+
+        if {$::tls} {
+            assert {$cert != ""}
+        } else {
+            assert {$cert == ""}
+        }
+    }
 }


### PR DESCRIPTION
This introduces a new `tlsauth` module that makes it possible to use TLS client-side certificates together with ACL configuration. Being a module, it makes it possible to easily extend the naive configuration provided to match more complex real-world needs.

This also introduces a change to the modules source tree: current modules which are essentially examples with no real-world use are moved to an `examples/` directory, and the `modules/` main directory is reserved to usable modules. In the future we may consider adding additional modules that have real-world value but don't necessarily have to be part of core Redis.

Resolves #6899.