### PR TITLE
Let the write command have consistent behavior when a slot is unstable.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5758,7 +5758,7 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
     if (importing_slot &&
         (c->flags & CLIENT_ASKING || cmd->flags & CMD_ASKING))
     {
-        if (multiple_keys && missing_keys) {
+        if (missing_keys) {
             if (error_code) *error_code = CLUSTER_REDIR_UNSTABLE;
             return NULL;
         } else {


### PR DESCRIPTION
Let the write command with multiple keys and the write command with single key have consistent behavior when a slot is unstable.

Now the two are different. For example, we are migrating slot 12706 from node A to node B and we know the key k1 belongs to the slot 12706. When a client executes "set k1 a" on node B with ASKING flag and node B doesn't have k1, the client can execute the command successfully. But when the client executes "mset k1 a a{k1} aa" in the same situation, it will receive "TRYGAGIN".

This commit fix this, let the client receive the same "TRYAGAIN".