### PR TITLE
Fix data race in bugReportStart

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -55,7 +55,8 @@ typedef ucontext_t sigcontext_t;
 #endif
 
 /* Globals */
-static _Atomic int bug_report_start = 0; /* True if bug report header was already logged. */
+static int bug_report_start = 0; /* True if bug report header was already logged. */
+static pthread_mutex_t bug_report_start_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* Forward declarations */
 void bugReportStart(void);
@@ -919,11 +920,13 @@ void _serverPanic(const char *file, int line, const char *msg, ...) {
 }
 
 void bugReportStart(void) {
+    pthread_mutex_lock(&bug_report_start_mutex);
     if (bug_report_start == 0) {
         serverLogRaw(LL_WARNING|LL_RAW,
         "\n\n=== REDIS BUG REPORT START: Cut & paste starting from here ===\n");
         bug_report_start = 1;
     }
+    pthread_mutex_unlock(&bug_report_start_mutex);
 }
 
 #ifdef HAVE_BACKTRACE


### PR DESCRIPTION
There is a data race #7391 I think we don't solve it currently.
If two threads get `bug_report_start` simultaneously, both of them will execute the following instructions if `bug_report_start == 0`, because read and write of `bug_report_start` is not atomic. 
```
 if (bug_report_start == 0) {
    serverLogRaw(LL_WARNING|LL_RAW,
        "\n\n=== REDIS BUG REPORT START: Cut & paste starting from here ===\n");
    bug_report_start = 1;
}
```
we can use CAS of `_Atomic` to implement it efficiently https://en.cppreference.com/w/c/atomic/atomic_compare_exchange. But I think we should not introduce complicated operations with atomic variables, and this data race only will happen when more than one threads panic simultaneously. So i use `pthread_mutex_t ` easily to fix it.