### PR TITLE
Fix wrong format specifiers of 'sdscatfmt' for the INFO command

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4080,7 +4080,7 @@ sds genRedisInfoString(const char *section) {
             "lru_clock:%u\r\n"
             "executable:%s\r\n"
             "config_file:%s\r\n"
-            "io_threads_active:%d\r\n",
+            "io_threads_active:%i\r\n",
             REDIS_VERSION,
             redisGitSHA1(),
             strtol(redisGitDirty(),NULL,10) > 0,


### PR DESCRIPTION
`%d` is format specifiers of printf instead of sdscatfmt, for signed int, it should be `%i`, so we couldn't see right info of `io_threads_active` when execute INFO server command.

before
`io_threads_active:d`
after
`io_threads_active`:1