### PR TITLE
Implement redisAtomic to replace _Atomic C11 builtin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,22 @@ jobs:
     - name: make
       run: make MALLOC=libc
 
+  build-centos7-jemalloc:
+    runs-on: ubuntu-latest
+    container: centos:7
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: |
+        yum -y install gcc make
+        make
+
+  build-centos6-jemalloc:
+    runs-on: ubuntu-latest
+    container: centos:6
+    steps:
+    - uses: actions/checkout@v1
+    - name: make
+      run: |
+        yum -y install gcc make
+        make

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -123,12 +123,33 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: |
-        yum -y install centos-release-scl
-        yum -y install devtoolset-7
-        scl enable devtoolset-7 "make"
+        yum -y install gcc make
+        make
     - name: test
       run: |
-        yum -y install tcl
+        yum -y install which tcl
+        ./runtest --accurate --verbose
+    - name: module api test
+      run: ./runtest-moduleapi --verbose
+    - name: sentinel tests
+      run: ./runtest-sentinel
+    - name: cluster tests
+      run: ./runtest-cluster
+
+  test-centos6-jemalloc:
+    runs-on: ubuntu-latest
+    if: github.repository == 'redis/redis'
+    container: centos:6
+    timeout-minutes: 14400
+    steps:
+    - uses: actions/checkout@v1
+    - name: make
+      run: |
+        yum -y install gcc make
+        make
+    - name: test
+      run: |
+        yum -y install which tcl util-linux-ng
         ./runtest --accurate --verbose
     - name: module api test
       run: ./runtest-moduleapi --verbose

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ DEPENDENCY_TARGETS=hiredis linenoise lua hdr_histogram
 NODEPS:=clean distclean
 
 # Default settings
-STD=-std=c99 -pedantic -DREDIS_STATIC=''
+STD=-pedantic -DREDIS_STATIC=''
 ifneq (,$(findstring clang,$(CC)))
 ifneq (,$(findstring FreeBSD,$(uname_S)))
   STD+=-Wno-c11-extensions
@@ -28,6 +28,16 @@ endif
 endif
 WARN=-Wall -W -Wno-missing-field-initializers
 OPT=$(OPTIMIZATION)
+
+# Detect if the compiler supports C11 _Atomic
+C11_ATOMIC := $(shell sh -c 'echo "\#include <stdatomic.h>" > foo.c; \
+	$(CC) -std=c11 -c foo.c -o foo.o &> /dev/null; \
+	if [ -f foo.o ]; then echo "yes"; rm foo.o; fi; rm foo.c')
+ifeq ($(C11_ATOMIC),yes)
+	STD+=-std=c11
+else
+	STD+=-std=c99
+endif
 
 PREFIX?=/usr/local
 INSTALL_BIN=$(PREFIX)/bin

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ DEPENDENCY_TARGETS=hiredis linenoise lua hdr_histogram
 NODEPS:=clean distclean
 
 # Default settings
-STD=-std=c11 -pedantic -DREDIS_STATIC=''
+STD=-std=c99 -pedantic -DREDIS_STATIC=''
 ifneq (,$(findstring clang,$(CC)))
 ifneq (,$(findstring FreeBSD,$(uname_S)))
   STD+=-Wno-c11-extensions
@@ -367,7 +367,7 @@ valgrind:
 	$(MAKE) OPTIMIZATION="-O0" MALLOC="libc"
 
 helgrind:
-	$(MAKE) OPTIMIZATION="-O0" MALLOC="libc" CFLAGS="-D__ATOMIC_VAR_FORCE_SYNC_MACROS"
+	$(MAKE) OPTIMIZATION="-O0" MALLOC="libc" CFLAGS="-D__ATOMIC_VAR_FORCE_SYNC_MACROS" REDIS_CFLAGS="-I/usr/local/include" REDIS_LDFLAGS="-L/usr/local/lib"
 
 src/help.h:
 	@../utils/generate-command-help.rb > help.h

--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -50,6 +50,7 @@
  */
 
 #include <pthread.h>
+#include "config.h"
 
 #ifndef __ATOMIC_VAR_H
 #define __ATOMIC_VAR_H

--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -83,11 +83,9 @@
  * install Valgrind in the default path configuration. */
 #ifdef __ATOMIC_VAR_FORCE_SYNC_MACROS
 #include <valgrind/helgrind.h>
-#define REDIS_ANNOTATE_HAPPENS_BEFORE(v) ANNOTATE_HAPPENS_BEFORE(v)
-#define REDIS_ANNOTATE_HAPPENS_AFTER(v)  ANNOTATE_HAPPENS_AFTER(v)
 #else
-#define REDIS_ANNOTATE_HAPPENS_BEFORE(v) ((void) v)
-#define REDIS_ANNOTATE_HAPPENS_AFTER(v)  ((void) v)
+#define ANNOTATE_HAPPENS_BEFORE(v) ((void) v)
+#define ANNOTATE_HAPPENS_AFTER(v)  ((void) v)
 #endif
 
 #if !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && (__STDC_VERSION__ >= 201112L) && \
@@ -152,10 +150,10 @@
 /* Actually the builtin issues a full memory barrier by default. */
 #define atomicGetWithSync(var,dstvar) { \
     dstvar = __sync_sub_and_fetch(&var,0,__sync_synchronize); \
-    REDIS_ANNOTATE_HAPPENS_AFTER(&var); \
+    ANNOTATE_HAPPENS_AFTER(&var); \
 } while(0)
 #define atomicSetWithSync(var,value) do { \
-    REDIS_ANNOTATE_HAPPENS_BEFORE(&var);  \
+    ANNOTATE_HAPPENS_BEFORE(&var);  \
     while(!__sync_bool_compare_and_swap(&var,var,value,__sync_synchronize)); \
 } while(0)
 #define REDIS_ATOMIC_API "sync-builtin"

--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -81,8 +81,8 @@
 #define ANNOTATE_HAPPENS_AFTER(v)  ((void) v)
 #endif
 
-#if !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && (__STDC_VERSION__ >= 201112L) && \
-    !defined(__STDC_NO_ATOMIC__)
+#if !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && defined(__STDC_VERSION__) && \
+    (__STDC_VERSION__ >= 201112L) && !defined(__STDC_NO_ATOMICS__)
 /* Use '_Atomic' keyword if the compiler supports. */
 #undef  redisAtomic
 #define redisAtomic _Atomic

--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -62,13 +62,61 @@
 #ifndef __ATOMIC_VAR_H
 #define __ATOMIC_VAR_H
 
+/* Define redisAtomic for atomic variable. */
+#define redisAtomic
+
 /* To test Redis with Helgrind (a Valgrind tool) it is useful to define
  * the following macro, so that __sync macros are used: those can be detected
  * by Helgrind (even if they are less efficient) so that no false positive
  * is reported. */
 // #define __ATOMIC_VAR_FORCE_SYNC_MACROS
 
-#if !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && defined(__ATOMIC_RELAXED) && !defined(__sun) && (!defined(__clang__) || !defined(__APPLE__) || __apple_build_version__ > 4210057)
+/* There will be many false positives if we test Redis with Helgrind, since
+ * Helgrind can't understand we have imposed ordering on the program, so
+ * we use macros in helgrind.h to tell Helgrind inter-thread happens-before
+ * relationship explicitly for avoiding false positives.
+ *
+ * For more details, please see: valgrind/helgrind.h and
+ * https://www.valgrind.org/docs/manual/hg-manual.html#hg-manual.effective-use
+ *
+ * These macros take effect only when 'make helgrind', and you must first
+ * install Valgrind in the default path configuration. */
+#ifdef __ATOMIC_VAR_FORCE_SYNC_MACROS
+#include <valgrind/helgrind.h>
+#define REDIS_ANNOTATE_HAPPENS_BEFORE(v) ANNOTATE_HAPPENS_BEFORE(v)
+#define REDIS_ANNOTATE_HAPPENS_AFTER(v)  ANNOTATE_HAPPENS_AFTER(v)
+#else
+#define REDIS_ANNOTATE_HAPPENS_BEFORE(v) ((void) v)
+#define REDIS_ANNOTATE_HAPPENS_AFTER(v)  ((void) v)
+#endif
+
+#if !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && (__STDC_VERSION__ >= 201112L) && \
+    !defined(__STDC_NO_ATOMIC__)
+/* Use '_Atomic' keyword if the compiler supports. */
+#undef  redisAtomic
+#define redisAtomic _Atomic
+/* Implementation using _Atomic in C11. */
+
+#include <stdatomic.h>
+#define atomicIncr(var,count) atomic_fetch_add_explicit(&var,(count),memory_order_relaxed)
+#define atomicGetIncr(var,oldvalue_var,count) do { \
+    oldvalue_var = atomic_fetch_add_explicit(&var,(count),memory_order_relaxed); \
+} while(0)
+#define atomicDecr(var,count) atomic_fetch_sub_explicit(&var,(count),memory_order_relaxed)
+#define atomicGet(var,dstvar) do { \
+    dstvar = atomic_load_explicit(&var,memory_order_relaxed); \
+} while(0)
+#define atomicSet(var,value) atomic_store_explicit(&var,value,memory_order_relaxed)
+#define atomicGetWithSync(var,dstvar) do { \
+    dstvar = atomic_load_explicit(&var,memory_order_seq_cst); \
+} while(0)
+#define atomicSetWithSync(var,value) \
+    atomic_store_explicit(&var,value,memory_order_seq_cst)
+#define REDIS_ATOMIC_API "c11-builtin"
+
+#elif !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && !defined(__sun) && \
+    (!defined(__clang__) || !defined(__APPLE__) || __apple_build_version__ > 4210057) && \
+    defined(__ATOMIC_RELAXED) && defined(__ATOMIC_SEQ_CST)
 /* Implementation using __atomic macros. */
 
 #define atomicIncr(var,count) __atomic_add_fetch(&var,(count),__ATOMIC_RELAXED)
@@ -80,6 +128,11 @@
     dstvar = __atomic_load_n(&var,__ATOMIC_RELAXED); \
 } while(0)
 #define atomicSet(var,value) __atomic_store_n(&var,value,__ATOMIC_RELAXED)
+#define atomicGetWithSync(var,dstvar) do { \
+    dstvar = __atomic_load_n(&var,__ATOMIC_SEQ_CST); \
+} while(0)
+#define atomicSetWithSync(var,value) \
+    __atomic_store_n(&var,value,__ATOMIC_SEQ_CST)
 #define REDIS_ATOMIC_API "atomic-builtin"
 
 #elif defined(HAVE_ATOMIC)
@@ -95,6 +148,15 @@
 } while(0)
 #define atomicSet(var,value) do { \
     while(!__sync_bool_compare_and_swap(&var,var,value)); \
+} while(0)
+/* Actually the builtin issues a full memory barrier by default. */
+#define atomicGetWithSync(var,dstvar) { \
+    dstvar = __sync_sub_and_fetch(&var,0,__sync_synchronize); \
+    REDIS_ANNOTATE_HAPPENS_AFTER(&var); \
+} while(0)
+#define atomicSetWithSync(var,value) do { \
+    REDIS_ANNOTATE_HAPPENS_BEFORE(&var);  \
+    while(!__sync_bool_compare_and_swap(&var,var,value,__sync_synchronize)); \
 } while(0)
 #define REDIS_ATOMIC_API "sync-builtin"
 
@@ -127,6 +189,8 @@
     var = value; \
     pthread_mutex_unlock(&var ## _mutex); \
 } while(0)
+#define atomicGetWithSync(var,dstvar) atomicGet(var,dstvar)
+#define atomicSetWithSync(var,value) atomicSet(var,value)
 #define REDIS_ATOMIC_API "pthread-mutex"
 
 #endif

--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -1,5 +1,5 @@
-/* This file implements atomic counters using __atomic or __sync macros if
- * available, otherwise synchronizing different threads using a mutex.
+/* This file implements atomic counters using c11 _Atomic, __atomic or __sync
+ * macros if available, otherwise we will throw an error when compile.
  *
  * The exported interface is composed of three macros:
  *
@@ -8,16 +8,8 @@
  * atomicDecr(var,count) -- Decrement the atomic counter
  * atomicGet(var,dstvar) -- Fetch the atomic counter value
  * atomicSet(var,value)  -- Set the atomic counter value
- *
- * The variable 'var' should also have a declared mutex with the same
- * name and the "_mutex" postfix, for instance:
- *
- *  long myvar;
- *  pthread_mutex_t myvar_mutex;
- *  atomicSet(myvar,12345);
- *
- * If atomic primitives are available (tested in config.h) the mutex
- * is not used.
+ * atomicGetWithSync(var,value)  -- 'atomicGet' with inter-thread synchronization
+ * atomicSetWithSync(var,value)  -- 'atomicSet' with inter-thread synchronization
  *
  * Never use return value from the macros, instead use the AtomicGetIncr()
  * if you need to get the current value and increment it atomically, like
@@ -159,37 +151,7 @@
 #define REDIS_ATOMIC_API "sync-builtin"
 
 #else
-/* Implementation using pthread mutex. */
-
-#define atomicIncr(var,count) do { \
-    pthread_mutex_lock(&var ## _mutex); \
-    var += (count); \
-    pthread_mutex_unlock(&var ## _mutex); \
-} while(0)
-#define atomicGetIncr(var,oldvalue_var,count) do { \
-    pthread_mutex_lock(&var ## _mutex); \
-    oldvalue_var = var; \
-    var += (count); \
-    pthread_mutex_unlock(&var ## _mutex); \
-} while(0)
-#define atomicDecr(var,count) do { \
-    pthread_mutex_lock(&var ## _mutex); \
-    var -= (count); \
-    pthread_mutex_unlock(&var ## _mutex); \
-} while(0)
-#define atomicGet(var,dstvar) do { \
-    pthread_mutex_lock(&var ## _mutex); \
-    dstvar = var; \
-    pthread_mutex_unlock(&var ## _mutex); \
-} while(0)
-#define atomicSet(var,value) do { \
-    pthread_mutex_lock(&var ## _mutex); \
-    var = value; \
-    pthread_mutex_unlock(&var ## _mutex); \
-} while(0)
-#define atomicGetWithSync(var,dstvar) atomicGet(var,dstvar)
-#define atomicSetWithSync(var,value) atomicSet(var,value)
-#define REDIS_ATOMIC_API "pthread-mutex"
+#error "Unable to determine atomic operations for your platform"
 
 #endif
 #endif /* __ATOMIC_VAR_H */

--- a/src/evict.c
+++ b/src/evict.c
@@ -78,7 +78,7 @@ unsigned int getLRUClock(void) {
 unsigned int LRU_CLOCK(void) {
     unsigned int lruclock;
     if (1000/server.hz <= LRU_CLOCK_RESOLUTION) {
-        lruclock = server.lruclock;
+        atomicGet(server.lruclock,lruclock);
     } else {
         lruclock = getLRUClock();
     }

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -4,7 +4,6 @@
 #include "cluster.h"
 
 static redisAtomic size_t lazyfree_objects = 0;
-pthread_mutex_t lazyfree_objects_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* Return the number of currently pending objects to free. */
 size_t lazyfreeGetPendingObjectsCount(void) {

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -3,7 +3,7 @@
 #include "atomicvar.h"
 #include "cluster.h"
 
-static size_t lazyfree_objects = 0;
+static redisAtomic size_t lazyfree_objects = 0;
 pthread_mutex_t lazyfree_objects_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* Return the number of currently pending objects to free. */

--- a/src/module.c
+++ b/src/module.c
@@ -357,11 +357,6 @@ unsigned long long ModulesInHooks = 0; /* Total number of modules in hooks
 
 /* Data structures related to the redis module users */
 
-/* This callback type is called by moduleNotifyUserChanged() every time
- * a user authenticated via the module API is associated with a different
- * user or gets disconnected. */
-typedef void (*RedisModuleUserChangedFunc) (uint64_t client_id, void *privdata);
-
 /* This is the object returned by RM_CreateModuleUser(). The module API is
  * able to create users, set ACLs to such users, and later authenticate
  * clients using such newly created users. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -103,7 +103,8 @@ client *createClient(connection *conn) {
     }
 
     selectDb(c,0);
-    uint64_t client_id = ++server.next_client_id;
+    uint64_t client_id;
+    atomicGetIncr(server.next_client_id, client_id, 1);
     c->id = client_id;
     c->resp = 2;
     c->conn = conn;
@@ -1314,7 +1315,7 @@ client *lookupClientByID(uint64_t id) {
  * thread safe. */
 int writeToClient(client *c, int handler_installed) {
     /* Update total number of writes on server */
-    server.stat_total_writes_processed++;
+    atomicIncr(server.stat_total_writes_processed, 1);
 
     ssize_t nwritten = 0, totwritten = 0;
     size_t objlen;
@@ -1376,7 +1377,7 @@ int writeToClient(client *c, int handler_installed) {
              zmalloc_used_memory() < server.maxmemory) &&
             !(c->flags & CLIENT_SLAVE)) break;
     }
-    server.stat_net_output_bytes += totwritten;
+    atomicIncr(server.stat_net_output_bytes, totwritten);
     if (nwritten == -1) {
         if (connGetState(c->conn) == CONN_STATE_CONNECTED) {
             nwritten = 0;
@@ -1933,7 +1934,7 @@ void readQueryFromClient(connection *conn) {
     if (postponeClientRead(c)) return;
 
     /* Update total number of reads on server */
-    server.stat_total_reads_processed++;
+    atomicIncr(server.stat_total_reads_processed, 1);
 
     readlen = PROTO_IOBUF_LEN;
     /* If this is a multi bulk request, and we are processing a bulk reply
@@ -1979,7 +1980,7 @@ void readQueryFromClient(connection *conn) {
     sdsIncrLen(c->querybuf,nread);
     c->lastinteraction = server.unixtime;
     if (c->flags & CLIENT_MASTER) c->read_reploff += nread;
-    server.stat_net_input_bytes += nread;
+    atomicIncr(server.stat_net_input_bytes, nread);
     if (sdslen(c->querybuf) > server.client_max_querybuf_len) {
         sds ci = catClientInfoString(sdsempty(),c), bytes = sdsempty();
 
@@ -2936,9 +2937,26 @@ int tio_debug = 0;
 #define IO_THREADS_OP_READ 0
 #define IO_THREADS_OP_WRITE 1
 
+typedef struct IOPending_t {
+    redisAtomic unsigned long var;
+    /* Mutexes used to protect atomic variables when atomic builtins are
+     * not available. */
+    pthread_mutex_t var_mutex;
+} IOPending_t;
+
+static inline unsigned long getIOPendingCount(IOPending_t *pending) {
+    unsigned long count = 0;
+    atomicGetWithSync(pending->var, count);
+    return count;
+}
+
+static inline void setIOPendingCount(IOPending_t *pending, unsigned long count) {
+    atomicSetWithSync(pending->var, count);
+}
+
 pthread_t io_threads[IO_THREADS_MAX_NUM];
 pthread_mutex_t io_threads_mutex[IO_THREADS_MAX_NUM];
-_Atomic unsigned long io_threads_pending[IO_THREADS_MAX_NUM];
+IOPending_t io_threads_pending[IO_THREADS_MAX_NUM];
 int io_threads_op;      /* IO_THREADS_OP_WRITE or IO_THREADS_OP_READ. */
 
 /* This is the list of clients each thread will serve when threaded I/O is
@@ -2959,17 +2977,17 @@ void *IOThreadMain(void *myid) {
     while(1) {
         /* Wait for start */
         for (int j = 0; j < 1000000; j++) {
-            if (io_threads_pending[id] != 0) break;
+            if (getIOPendingCount(&io_threads_pending[id]) != 0) break;
         }
 
         /* Give the main thread a chance to stop this thread. */
-        if (io_threads_pending[id] == 0) {
+        if (getIOPendingCount(&io_threads_pending[id]) == 0) {
             pthread_mutex_lock(&io_threads_mutex[id]);
             pthread_mutex_unlock(&io_threads_mutex[id]);
             continue;
         }
 
-        serverAssert(io_threads_pending[id] != 0);
+        serverAssert(getIOPendingCount(&io_threads_pending[id]) != 0);
 
         if (tio_debug) printf("[%ld] %d to handle\n", id, (int)listLength(io_threads_list[id]));
 
@@ -2989,7 +3007,7 @@ void *IOThreadMain(void *myid) {
             }
         }
         listEmpty(io_threads_list[id]);
-        io_threads_pending[id] = 0;
+        setIOPendingCount(&io_threads_pending[id], 0);
 
         if (tio_debug) printf("[%ld] Done\n", id);
     }
@@ -3018,7 +3036,8 @@ void initThreadedIO(void) {
         /* Things we do only for the additional threads. */
         pthread_t tid;
         pthread_mutex_init(&io_threads_mutex[i],NULL);
-        io_threads_pending[i] = 0;
+        pthread_mutex_init(&io_threads_pending[i].var_mutex, NULL);
+        setIOPendingCount(&io_threads_pending[i], 0);
         pthread_mutex_lock(&io_threads_mutex[i]); /* Thread will be stopped. */
         if (pthread_create(&tid,NULL,IOThreadMain,(void*)(long)i) != 0) {
             serverLog(LL_WARNING,"Fatal: Can't initialize IO thread.");
@@ -3107,7 +3126,7 @@ int handleClientsWithPendingWritesUsingThreads(void) {
     io_threads_op = IO_THREADS_OP_WRITE;
     for (int j = 1; j < server.io_threads_num; j++) {
         int count = listLength(io_threads_list[j]);
-        io_threads_pending[j] = count;
+        setIOPendingCount(&io_threads_pending[j], count);
     }
 
     /* Also use the main thread to process a slice of clients. */
@@ -3122,7 +3141,7 @@ int handleClientsWithPendingWritesUsingThreads(void) {
     while(1) {
         unsigned long pending = 0;
         for (int j = 1; j < server.io_threads_num; j++)
-            pending += io_threads_pending[j];
+            pending += getIOPendingCount(&io_threads_pending[j]);
         if (pending == 0) break;
     }
     if (tio_debug) printf("I/O WRITE All threads finshed\n");
@@ -3197,7 +3216,7 @@ int handleClientsWithPendingReadsUsingThreads(void) {
     io_threads_op = IO_THREADS_OP_READ;
     for (int j = 1; j < server.io_threads_num; j++) {
         int count = listLength(io_threads_list[j]);
-        io_threads_pending[j] = count;
+        setIOPendingCount(&io_threads_pending[j], count);
     }
 
     /* Also use the main thread to process a slice of clients. */
@@ -3212,7 +3231,7 @@ int handleClientsWithPendingReadsUsingThreads(void) {
     while(1) {
         unsigned long pending = 0;
         for (int j = 1; j < server.io_threads_num; j++)
-            pending += io_threads_pending[j];
+            pending += getIOPendingCount(&io_threads_pending[j]);
         if (pending == 0) break;
     }
     if (tio_debug) printf("I/O READ All threads finshed\n");

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -76,11 +76,11 @@ static struct config {
     int hostport;
     const char *hostsocket;
     int numclients;
-    int liveclients;
+    redisAtomic int liveclients;
     int requests;
-    int requests_issued;
-    int requests_finished;
-    int previous_requests_finished;
+    redisAtomic int requests_issued;
+    redisAtomic int requests_finished;
+    redisAtomic int previous_requests_finished;
     int last_printed_bytes;
     long long previous_tick;
     int keysize;
@@ -113,9 +113,9 @@ static struct config {
     struct redisConfig *redis_config;
     struct hdr_histogram* latency_histogram;
     struct hdr_histogram* current_sec_latency_histogram;
-    int is_fetching_slots;
-    int is_updating_slots;
-    int slots_last_update;
+    redisAtomic int is_fetching_slots;
+    redisAtomic int is_updating_slots;
+    redisAtomic int slots_last_update;
     int enable_tracking;
     /* Thread mutexes to be used as fallbacks by atomicvar.h */
     pthread_mutex_t requests_issued_mutex;

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -117,14 +117,8 @@ static struct config {
     redisAtomic int is_updating_slots;
     redisAtomic int slots_last_update;
     int enable_tracking;
-    /* Thread mutexes to be used as fallbacks by atomicvar.h */
-    pthread_mutex_t requests_issued_mutex;
-    pthread_mutex_t requests_finished_mutex;
     pthread_mutex_t liveclients_mutex;
-    pthread_mutex_t is_fetching_slots_mutex;
     pthread_mutex_t is_updating_slots_mutex;
-    pthread_mutex_t updating_slots_mutex;
-    pthread_mutex_t slots_last_update_mutex;
 } config;
 
 typedef struct _client {
@@ -1669,13 +1663,8 @@ int main(int argc, const char **argv) {
             fprintf(stderr, "WARN: could not fetch server CONFIG\n");
     }
     if (config.num_threads > 0) {
-        pthread_mutex_init(&(config.requests_issued_mutex), NULL);
-        pthread_mutex_init(&(config.requests_finished_mutex), NULL);
         pthread_mutex_init(&(config.liveclients_mutex), NULL);
-        pthread_mutex_init(&(config.is_fetching_slots_mutex), NULL);
         pthread_mutex_init(&(config.is_updating_slots_mutex), NULL);
-        pthread_mutex_init(&(config.updating_slots_mutex), NULL);
-        pthread_mutex_init(&(config.slots_last_update_mutex), NULL);
     }
 
     if (config.keepalive == 0) {

--- a/src/server.c
+++ b/src/server.c
@@ -1764,7 +1764,8 @@ void databasesCron(void) {
 void updateCachedTime(int update_daylight_info) {
     server.ustime = ustime();
     server.mstime = server.ustime / 1000;
-    server.unixtime = server.mstime / 1000;
+    time_t unixtime = server.mstime / 1000;
+    atomicSet(server.unixtime, unixtime);
 
     /* To get information about daylight saving time, we need to call
      * localtime_r and cache the result. However calling localtime_r in this
@@ -1913,11 +1914,15 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     }
 
     run_with_period(100) {
+        long long stat_net_input_bytes, stat_net_output_bytes;
+        atomicGet(server.stat_net_input_bytes, stat_net_input_bytes);
+        atomicGet(server.stat_net_output_bytes, stat_net_output_bytes);
+
         trackInstantaneousMetric(STATS_METRIC_COMMAND,server.stat_numcommands);
         trackInstantaneousMetric(STATS_METRIC_NET_INPUT,
-                server.stat_net_input_bytes);
+                stat_net_input_bytes);
         trackInstantaneousMetric(STATS_METRIC_NET_OUTPUT,
-                server.stat_net_output_bytes);
+                stat_net_output_bytes);
     }
 
     /* We have just LRU_BITS bits per object for LRU information.
@@ -1931,7 +1936,8 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
      *
      * Note that you can change the resolution altering the
      * LRU_CLOCK_RESOLUTION define. */
-    server.lruclock = getLRUClock();
+    unsigned int lruclock = getLRUClock();
+    atomicSet(server.lruclock,lruclock);
 
     cronUpdateMemoryStats();
 
@@ -2395,6 +2401,14 @@ void createSharedObjects(void) {
 void initServerConfig(void) {
     int j;
 
+    pthread_mutex_init(&server.unixtime_mutex, NULL);
+    pthread_mutex_init(&server.lruclock_mutex, NULL);
+    pthread_mutex_init(&server.next_client_id_mutex, NULL);
+    pthread_mutex_init(&server.stat_total_writes_processed_mutex, NULL);
+    pthread_mutex_init(&server.stat_total_reads_processed_mutex, NULL);
+    pthread_mutex_init(&server.stat_net_output_bytes_mutex, NULL);
+    pthread_mutex_init(&server.stat_net_input_bytes_mutex, NULL);
+
     updateCachedTime(1);
     getRandomHexChars(server.runid,CONFIG_RUN_ID_SIZE);
     server.runid[CONFIG_RUN_ID_SIZE] = '\0';
@@ -2443,7 +2457,8 @@ void initServerConfig(void) {
     server.next_client_id = 1; /* Client IDs, start from 1 .*/
     server.loading_process_events_interval_bytes = (1024*1024*2);
 
-    server.lruclock = getLRUClock();
+    unsigned int lruclock = getLRUClock();
+    atomicSet(server.lruclock,lruclock);
     resetServerSaveParams();
 
     appendServerSaveParams(60*60,1);  /* save after 1 hour and 1 change */
@@ -2846,9 +2861,9 @@ void resetServerStats(void) {
     server.stat_sync_partial_ok = 0;
     server.stat_sync_partial_err = 0;
     server.stat_io_reads_processed = 0;
-    server.stat_total_reads_processed = 0;
+    atomicSet(server.stat_total_reads_processed, 0);
     server.stat_io_writes_processed = 0;
-    server.stat_total_writes_processed = 0;
+    atomicSet(server.stat_total_writes_processed, 0);
     for (j = 0; j < STATS_METRIC_COUNT; j++) {
         server.inst_metric[j].idx = 0;
         server.inst_metric[j].last_sample_time = mstime();
@@ -2856,8 +2871,8 @@ void resetServerStats(void) {
         memset(server.inst_metric[j].samples,0,
             sizeof(server.inst_metric[j].samples));
     }
-    server.stat_net_input_bytes = 0;
-    server.stat_net_output_bytes = 0;
+    atomicSet(server.stat_net_input_bytes, 0);
+    atomicSet(server.stat_net_output_bytes, 0);
     server.stat_unexpected_error_replies = 0;
     server.aof_delayed_fsync = 0;
     server.blocked_last_cron = 0;
@@ -4185,6 +4200,8 @@ sds genRedisInfoString(const char *section) {
             call_uname = 0;
         }
 
+        unsigned int lruclock;
+        atomicGet(server.lruclock,lruclock);
         info = sdscatfmt(info,
             "# Server\r\n"
             "redis_version:%s\r\n"
@@ -4229,7 +4246,7 @@ sds genRedisInfoString(const char *section) {
             (int64_t)(uptime/(3600*24)),
             server.hz,
             server.config_hz,
-            server.lruclock,
+            lruclock,
             server.executable ? server.executable : "",
             server.configfile ? server.configfile : "",
             server.io_threads_active);
@@ -4471,6 +4488,13 @@ sds genRedisInfoString(const char *section) {
 
     /* Stats */
     if (allsections || defsections || !strcasecmp(section,"stats")) {
+        long long stat_total_reads_processed, stat_total_writes_processed;
+        long long stat_net_input_bytes, stat_net_output_bytes;
+        atomicGet(server.stat_total_reads_processed, stat_total_reads_processed);
+        atomicGet(server.stat_total_writes_processed, stat_total_writes_processed);
+        atomicGet(server.stat_net_input_bytes, stat_net_input_bytes);
+        atomicGet(server.stat_net_output_bytes, stat_net_output_bytes);
+
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info,
             "# Stats\r\n"
@@ -4512,8 +4536,8 @@ sds genRedisInfoString(const char *section) {
             server.stat_numconnections,
             server.stat_numcommands,
             getInstantaneousMetric(STATS_METRIC_COMMAND),
-            server.stat_net_input_bytes,
-            server.stat_net_output_bytes,
+            stat_net_input_bytes,
+            stat_net_output_bytes,
             (float)getInstantaneousMetric(STATS_METRIC_NET_INPUT)/1024,
             (float)getInstantaneousMetric(STATS_METRIC_NET_OUTPUT)/1024,
             server.stat_rejected_conn,
@@ -4540,8 +4564,8 @@ sds genRedisInfoString(const char *section) {
             (unsigned long long) trackingGetTotalItems(),
             (unsigned long long) trackingGetTotalPrefixes(),
             server.stat_unexpected_error_replies,
-            server.stat_total_reads_processed,
-            server.stat_total_writes_processed,
+            stat_total_reads_processed,
+            stat_total_writes_processed,
             server.stat_io_reads_processed,
             server.stat_io_writes_processed);
     }

--- a/src/server.c
+++ b/src/server.c
@@ -2401,14 +2401,6 @@ void createSharedObjects(void) {
 void initServerConfig(void) {
     int j;
 
-    pthread_mutex_init(&server.unixtime_mutex, NULL);
-    pthread_mutex_init(&server.lruclock_mutex, NULL);
-    pthread_mutex_init(&server.next_client_id_mutex, NULL);
-    pthread_mutex_init(&server.stat_total_writes_processed_mutex, NULL);
-    pthread_mutex_init(&server.stat_total_reads_processed_mutex, NULL);
-    pthread_mutex_init(&server.stat_net_output_bytes_mutex, NULL);
-    pthread_mutex_init(&server.stat_net_input_bytes_mutex, NULL);
-
     updateCachedTime(1);
     getRandomHexChars(server.runid,CONFIG_RUN_ID_SIZE);
     server.runid[CONFIG_RUN_ID_SIZE] = '\0';

--- a/src/server.h
+++ b/src/server.h
@@ -512,8 +512,10 @@ typedef void (*moduleTypeDigestFunc)(struct RedisModuleDigest *digest, void *val
 typedef size_t (*moduleTypeMemUsageFunc)(const void *value);
 typedef void (*moduleTypeFreeFunc)(void *value);
 
-/* A callback that is called when the client authentication changes. This
- * needs to be exposed since you can't cast a function pointer to (void *) */
+/* This callback type is called by moduleNotifyUserChanged() every time
+ * a user authenticated via the module API is associated with a different
+ * user or gets disconnected. This needs to be exposed since you can't cast
+ * a function pointer to (void *). */
 typedef void (*RedisModuleUserChangedFunc) (uint64_t client_id, void *privdata);
 
 

--- a/src/server.h
+++ b/src/server.h
@@ -1474,15 +1474,6 @@ struct redisServer {
     char *bio_cpulist; /* cpu affinity list of bio thread. */
     char *aof_rewrite_cpulist; /* cpu affinity list of aof rewrite process. */
     char *bgsave_cpulist; /* cpu affinity list of bgsave process. */
-    /* Mutexes used to protect atomic variables when atomic builtins are
-     * not available. */
-    pthread_mutex_t unixtime_mutex;
-    pthread_mutex_t lruclock_mutex;
-    pthread_mutex_t next_client_id_mutex;
-    pthread_mutex_t stat_total_writes_processed_mutex;
-    pthread_mutex_t stat_total_reads_processed_mutex;
-    pthread_mutex_t stat_net_output_bytes_mutex;
-    pthread_mutex_t stat_net_input_bytes_mutex;
 };
 
 typedef struct pubsubPattern {

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -75,7 +75,6 @@ void zlibc_free(void *ptr) {
 #define update_zmalloc_stat_free(__n) atomicDecr(used_memory,(__n))
 
 static redisAtomic size_t used_memory = 0;
-pthread_mutex_t used_memory_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static void zmalloc_default_oom(size_t size) {
     fprintf(stderr, "zmalloc: Out of memory trying to allocate %zu bytes\n",

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -74,7 +74,7 @@ void zlibc_free(void *ptr) {
 #define update_zmalloc_stat_alloc(__n) atomicIncr(used_memory,(__n))
 #define update_zmalloc_stat_free(__n) atomicDecr(used_memory,(__n))
 
-static size_t used_memory = 0;
+static redisAtomic size_t used_memory = 0;
 pthread_mutex_t used_memory_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static void zmalloc_default_oom(size_t size) {


### PR DESCRIPTION
Try to solve #7509 

Firstly, I try to explain how `_Atomic` can guarantee our program execute safely. The default behavior of `_Atomic` operations provides for sequentially consistent ordering. For threaded IO in redis, we use inter-thread synchronization of `io_threads_pending[i]`, so other IO threads could see the updated values of `io_threads_list`  instead of history values when `io_threads_pending[i]` is fired.

Currently we  implement atomic that only supports `memory_order_relaxed` for redis in `atomicvar.h`, so I implement operations with sequentially-consistent ordering, just like  the default behavior of `_Atomic`.

> More details for memory_order, we can see https://en.cppreference.com/w/c/atomic/memory_order

Currently, atomic variables we used in Redis are as follow
```
server.unixtime
server.lruclock
server.next_client_id
server.stat_total_writes_processed
server.stat_total_reads_processed
server.stat_net_output_bytes
server.stat_net_input_bytes
server.client_max_querybuf_len
```

For `server.unixtime`, `server.lruclock`, `server.next_client_id`, Salvatore started using atomic variable from commits
https://github.com/redis/redis/commit/ece658713b659513e2c43a9498da286cafec17dd https://github.com/redis/redis/commit/1f598fc2bb6975417751486405303d98246bb7bc
I just restored these operations back

For `stat_total_writes_processed`, `stat_total_reads_processed`, `stat_net_output_bytes`,`stat_net_input_bytes`, we still 
 use redis atomic implemented before，that means we use `memory_order_relaxed` access operations for them, it is ok because there is no happen-before relationship.

For `client_max_querybuf_len`, I don't find we write and read it simultaneously in redis, there is no data race, so i think it is safe to read in IO threads.

Other work i did is that we can test Redis with Helgrind, Now there still are 3 errors in helgrind report when we run redis with a module, as flow. I think there is no risk. For 1, it means redis still holds 4 locks(io_threads_mutex) when redis exits. For 2, 3, that is because we may acquire two mutex `moduleGIL` and `io_threads_mutex` but they are unrelated actully.
```
1 Thread #1: Exiting thread still holds 4 locks

2 Thread #1: lock order "0x77DB48 before 0x767D00" violated
Address 0x767d00 is 0 bytes inside data symbol "moduleGIL"

3 Thread #1: lock order "0x767D00 before 0x77DB48" violated
Address 0x77db48 is 40 bytes inside data symbol "io_threads_mutex"
```