### PR TITLE
Fix oom-score-adj test on older distros.

### DIFF
--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -16,8 +16,8 @@ if {$system_name eq {linux}} {
 
         proc get_child_pid {} {
             set pid [srv 0 pid]
-            set fd [open "|ps --ppid $pid -o pid -h" "r"]
-            set child_pid [string trim [read $fd]]
+            set fd [open "|ps --ppid $pid -o pid" "r"]
+            set child_pid [string trim [lindex [split [read $fd] \n] 1]]
             close $fd
 
             return $child_pid


### PR DESCRIPTION
Don't assume `ps` handles `-h` to display output without headers and
manually trim headers line from output.