### PR TITLE
fix config set client-output-buffer-limit lost units

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -927,8 +927,8 @@ void configSetCommand(client *c) {
             int soft_seconds;
 
             class = getClientTypeByName(v[j]);
-            hard = strtoll(v[j+1],NULL,10);
-            soft = strtoll(v[j+2],NULL,10);
+            hard = memtoll(v[j+1],NULL);
+            soft = memtoll(v[j+2],NULL);
             soft_seconds = strtoll(v[j+3],NULL,10);
 
             server.client_obuf_limits[class].hard_limit_bytes = hard;


### PR DESCRIPTION
fix config set client-output-buffer-limit lost units, when the  parameter containing units.
For example:
>config set client-output-buffer-limit "slave 1024mb 256mb 60"
OK

but:
> config get client-output-buffer-limit
1) "client-output-buffer-limit"
2) "normal 0 0 0 slave 1024 256 60 pubsub 33554432 8388608 60"