### PR TITLE
Backport Lua 5.2.2 stack overflow fix.

### DIFF
--- a/deps/lua/src/ldo.c
+++ b/deps/lua/src/ldo.c
@@ -274,7 +274,7 @@ int luaD_precall (lua_State *L, StkId func, int nresults) {
     CallInfo *ci;
     StkId st, base;
     Proto *p = cl->p;
-    luaD_checkstack(L, p->maxstacksize);
+    luaD_checkstack(L, p->maxstacksize + p->numparams);
     func = restorestack(L, funcr);
     if (!p->is_vararg) {  /* no varargs? */
       base = func + 1;


### PR DESCRIPTION
This fixes the issue described in CVE-2014-5461. So far we cannot
confirm that the original issue has any real impact on Redis, but it is
included as an extra safety measure.