### PR TITLE
Fix double-make issue with make && make install.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -255,6 +255,8 @@ persist-settings: distclean
 	echo WARN=$(WARN) >> .make-settings
 	echo OPT=$(OPT) >> .make-settings
 	echo MALLOC=$(MALLOC) >> .make-settings
+	echo BUILD_TLS=$(BUILD_TLS) >> .make-settings
+	echo USE_SYSTEMD=$(USE_SYSTEMD) >> .make-settings
 	echo CFLAGS=$(CFLAGS) >> .make-settings
 	echo LDFLAGS=$(LDFLAGS) >> .make-settings
 	echo REDIS_CFLAGS=$(REDIS_CFLAGS) >> .make-settings


### PR DESCRIPTION
All user-supplied variables that affect the build should be explicitly
persisted.

Fixes #7254