### PR TITLE
Fix error message for the DEBUG ZIPLIST command

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -588,7 +588,7 @@ NULL
                 == NULL) return;
 
         if (o->encoding != OBJ_ENCODING_ZIPLIST) {
-            addReplyError(c,"Not an sds encoded string.");
+            addReplyError(c,"Not a ziplist encoded object.");
         } else {
             ziplistRepr(o->ptr);
             addReplyStatus(c,"Ziplist structure printed on stdout");


### PR DESCRIPTION
DEBUG ZIPLIST <key> currently returns the following error string if the
key is not a ziplist: "ERR Not an sds encoded string.". This looks like
an accidental copy/paste error from the error returned in the else if
branch above where this string is returned if the key is not an sds
string. The command was added in
ac61f9062583d67dd43f7d698824464d1e30d84b and looking at the commit,
nothing indicates that it is not an accidental typo.

The error string now returns a correct error: "Not a ziplist encoded
object", which accurately describes the error.

---

It doesn't look like like there are any tests for the `DEBUG SDSLEN` command, so I didn't add any here, but I'd be happy to add some if that was deemed necessary (which I kinda doubt given it's a debug command, but maybe?)