### PR TITLE
solve valgrind warning for SaveStringBuffer to RDB

### DIFF
--- a/src/lzf_c.c
+++ b/src/lzf_c.c
@@ -104,7 +104,7 @@ lzf_compress (const void *const in_data, unsigned int in_len,
               )
 {
 #if !LZF_STATE_ARG
-  LZF_STATE htab;
+  LZF_STATE htab = {0};
 #endif
   const u8 *ip = (const u8 *)in_data;
         u8 *op = (u8 *)out_data;


### PR DESCRIPTION
Fix #4284 `Conditional jump or move depends on uninitialised value(s)`