### PR TITLE
fix broken cluster/sentinel tests by recent commit

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -52,7 +52,7 @@ proc exec_instance {type dirname cfgfile} {
     if {$::valgrind} {
         set pid [exec valgrind --track-origins=yes --suppressions=../../../src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full ../../../src/${prgname} $cfgfile 2>> $errfile &]
     } else {
-        set pid [exec ../../../src/${prgname} $cfgfile &]
+        set pid [exec ../../../src/${prgname} $cfgfile 2>> $errfile &]
     }
     return $pid
 }


### PR DESCRIPTION
2b998de46 added a file for stderr to keep valgrind log but i forgot to
add a similar thing when valgrind isn't being used.
the result is that `glob */err.txt` fails.