### PR TITLE
Tests: fix spawning of unmonitored servers

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -383,6 +383,11 @@ proc start_server {options {code undefined}} {
                 dict set config port $port
             }
             create_server_config_file $config_file $config
+
+            # Truncate log so wait_server_started will not be looking at
+            # output of the failed server.
+            close [open $stdout "w"]
+
             continue; # Try again
         }
 


### PR DESCRIPTION
There is an inherent race condition in port allocation for spawned
servers. If a server fails to start because a port is taken, a new port
is allocated. This fixes a problem where the logs are not truncated and
as a result a large number of unmonitored servers are started.