### PR TITLE
Tests: Some fixes for macOS

### DIFF
--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -4,6 +4,7 @@ set ::num_failed 0
 set ::num_skipped 0
 set ::num_aborted 0
 set ::tests_failed {}
+set ::cur_test ""
 
 proc fail {msg} {
     error "assertion:$msg"
@@ -136,6 +137,7 @@ proc test {name code {okpattern undefined} {options undefined}} {
 
     # set a cur_test global to be logged into new servers that are spown
     # and log the test name in all existing servers
+    set prev_test $::cur_test
     set ::cur_test "$name in $::curfile"
     if {!$::external} {
         foreach srv $::servers {
@@ -190,4 +192,5 @@ proc test {name code {okpattern undefined} {options undefined}} {
             send_data_packet $::test_server_fd err "Detected a memory leak in test '$name': $output"
         }
     }
+    set ::cur_test $prev_test
 }

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -190,5 +190,4 @@ proc test {name code {okpattern undefined} {options undefined}} {
             send_data_packet $::test_server_fd err "Detected a memory leak in test '$name': $output"
         }
     }
-    unset ::cur_test
 }

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -508,8 +508,13 @@ proc populate {num prefix size} {
 
 proc get_child_pid {idx} {
     set pid [srv $idx pid]
-    set fd [open "|ps --ppid $pid -o pid" "r"]
-    set child_pid [string trim [lindex [split [read $fd] \n] 1]]
+    if {[string match {*Darwin*} [exec uname -a]]} {
+        set fd [open "|pgrep -P $pid" "r"]
+        set child_pid [string trim [lindex [split [read $fd] \n] 0]]
+    } else {
+        set fd [open "|ps --ppid $pid -o pid" "r"]
+        set child_pid [string trim [lindex [split [read $fd] \n] 1]]
+    }
     close $fd
 
     return $child_pid


### PR DESCRIPTION
### 1) cur_test: when restart_server, "no such variable" error occurs 
```
➜  redis git:(unstable) ✗ ./runtest --single integration/rdb    
Cleanup: may take some time... OK
Starting test server at port 11111
[ready]: 67092
Testing integration/rdb
[ready]: 67093
[ready]: 67091
[ready]: 67094
[ready]: 67095
[ready]: 67097
[ready]: 67099
[ready]: 67104
[ready]: 67096
[ready]: 67100
[ready]: 67098
[ready]: 67105
[ready]: 67106
[ok]: RDB encoding loading test
[ok]: Check for memory leaks (pid 67109)
[ok]: Server started empty with non-existing RDB file
[ready]: 67101
[ready]: 67102
[ready]: 67103
[ok]: Check for memory leaks (pid 67133)
[ok]: Server started empty with empty RDB file
[ok]: Check for memory leaks (pid 67153)
[ok]: Test RDB stream encoding
[ok]: Check for memory leaks (pid 67173)
[ok]: Server should not start if RDB file can't be open
[ok]: Server should not start if RDB is corrupted
[ok]: Test FLUSHALL aborts bgsave
[ok]: bgsave resets the change counter
[ok]: Check for memory leaks (pid 67207)
[ok]: Check for memory leaks (pid 67231)
[ok]: Check for memory leaks (pid 67282)
[ok]: client freed during loading
[exception]: Executing test client: can't unset "::cur_test": no such variable.
can't unset "::cur_test": no such variable
    while executing
"unset ::cur_test"
    (procedure "test" line 92)
    invoked from within
"test {client freed during loading} {
    start_server [list overrides [list key-load-delay 10 rdbcompression no]] {
        # create a big rdb that wi..."
    (file "tests/integration/rdb.tcl" line 151)
    invoked from within
"source $path"
    (procedure "execute_test_file" line 4)
    invoked from within
"execute_test_file $data"
    (procedure "test_client_main" line 10)
    invoked from within
"test_client_main $::test_server_port "
Killing still running Redis server 67193
Killing still running Redis server 67200
```

#### The calling process is as follows：
```
test {client freed during loading}
      SET ::cur_test
      restart_server
        kill_server
          test "Check for memory leaks (pid $pid)"
          SET ::cur_test
          UNSET ::cur_test
      UNSET ::cur_test // This global variable has been unset, so "no such variable" error occurs 
```
#### fixd way:
I think unset can be cancelled, because every test will actively set at the beginning of the run.

@oranagra Do you have any suggestions?


### 2) ps --ppid
`ps --ppid` not available on macOS platform, can be replaced with `pgrep -P pid`.