### PR TITLE
Remove tmp rdb file in background thread

### DIFF
--- a/src/rdb.h
+++ b/src/rdb.h
@@ -141,7 +141,7 @@ int rdbLoadObjectType(rio *rdb);
 int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags);
 int rdbSaveBackground(char *filename, rdbSaveInfo *rsi);
 int rdbSaveToSlavesSockets(rdbSaveInfo *rsi);
-void rdbRemoveTempFile(pid_t childpid, int force);
+void rdbRemoveTempFile(pid_t childpid, int from_signal);
 int rdbSave(char *filename, rdbSaveInfo *rsi);
 ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key);
 size_t rdbSavedObjectLen(robj *o, robj *key);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -141,7 +141,7 @@ int rdbLoadObjectType(rio *rdb);
 int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags);
 int rdbSaveBackground(char *filename, rdbSaveInfo *rsi);
 int rdbSaveToSlavesSockets(rdbSaveInfo *rsi);
-void rdbRemoveTempFile(pid_t childpid);
+void rdbRemoveTempFile(pid_t childpid, int force);
 int rdbSave(char *filename, rdbSaveInfo *rsi);
 ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key);
 size_t rdbSavedObjectLen(robj *o, robj *key);

--- a/src/server.c
+++ b/src/server.c
@@ -4919,7 +4919,7 @@ static void sigShutdownHandler(int sig) {
      * on disk. */
     if (server.shutdown_asap && sig == SIGINT) {
         serverLogFromHandler(LL_WARNING, "You insist... exiting now.");
-        rdbRemoveTempFile(getpid());
+        rdbRemoveTempFile(getpid(), 1);
         exit(1); /* Exit with an error since this was not a clean shutdown. */
     } else if (server.loading) {
         serverLogFromHandler(LL_WARNING, "Received shutdown signal during loading, exiting now.");

--- a/src/server.c
+++ b/src/server.c
@@ -3872,6 +3872,10 @@ int prepareForShutdown(int flags) {
        overwrite the synchronous saving did by SHUTDOWN. */
     if (server.rdb_child_pid != -1) {
         serverLog(LL_WARNING,"There is a child saving an .rdb. Killing it!");
+        /* Note that, in killRDBChild, we call rdbRemoveTempFile that will
+         * do close fd(in order to unlink file actully) in background thread.
+         * The temp rdb file fd may won't be closed when redis exits quickly,
+         * but OS will close this fd when process exits. */
         killRDBChild();
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -1874,6 +1874,7 @@ int writeCommandsDeniedByDiskError(void);
 /* RDB persistence */
 #include "rdb.h"
 void killRDBChild(void);
+int bg_unlink(const char *filename);
 
 /* AOF persistence */
 void flushAppendOnlyFile(int force);

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -69,6 +69,7 @@ set ::all_tests {
     unit/tls
     unit/tracking
     unit/oom-score-adj
+    unit/shutdown
 }
 # Index to the next test to run in the ::all_tests list.
 set ::next_test 0

--- a/tests/unit/shutdown.tcl
+++ b/tests/unit/shutdown.tcl
@@ -1,0 +1,49 @@
+start_server {tags {"shutdown"}} {
+    test {Temp rdb will be deleted if we use bg_unlink when shutdown} {
+        for {set i 0} {$i < 20} {incr i} {
+            r set $i $i
+        }
+        # It will cost 2s(20 * 100ms) to dump rdb
+        r config set rdb-key-save-delay 100000
+
+        # Child is dumping rdb
+        r bgsave
+        after 100
+        set dir [lindex [r config get dir] 1]
+        set child_pid [get_child_pid 0]
+        set temp_rdb [file join [lindex [r config get dir] 1] temp-${child_pid}.rdb]
+        # Temp rdb must be existed
+        assert {[file exists $temp_rdb]}
+
+        catch {r shutdown nosave}
+        # Make sure the server was killed
+        catch {set rd [redis_deferring_client]} e
+        assert_match {*connection refused*} $e
+
+        # Temp rdb file must be deleted
+        assert {![file exists $temp_rdb]}
+    }
+}
+
+start_server {tags {"shutdown"}} {
+    test {Temp rdb will be deleted in signal handle} {
+        for {set i 0} {$i < 20} {incr i} {
+            r set $i $i
+        }
+        # It will cost 2s(20 * 100ms) to dump rdb
+        r config set rdb-key-save-delay 100000
+        
+        set pid [s process_id]
+        set temp_rdb [file join [lindex [r config get dir] 1] temp-${pid}.rdb]
+
+        exec kill -SIGINT $pid
+        after 100
+        # Temp rdb must be existed
+        assert {[file exists $temp_rdb]}
+
+        # Temp rdb file must be deleted
+        exec kill -SIGINT $pid
+        after 100
+        assert {![file exists $temp_rdb]}
+    }
+}


### PR DESCRIPTION
Remove tmp rdb file in background thread to avoid unnecessary time cost. Maybe removing tmp aof file is similar.