### PR TITLE
Fix loading of save params from config file.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -353,6 +353,7 @@ void loadServerConfigFromString(char *config) {
     int linenum = 0, totlines, i;
     int slaveof_linenum = 0;
     sds *lines;
+    int save_loaded = 0;
 
     lines = sdssplitlen(config,strlen(config),"\n",1,&totlines);
 
@@ -425,6 +426,14 @@ void loadServerConfigFromString(char *config) {
                 err = "Invalid socket file permissions"; goto loaderr;
             }
         } else if (!strcasecmp(argv[0],"save")) {
+            /* We don't reset save params before loading, because if they're not part
+             * of the file the defaults should be used.
+             */
+            if (!save_loaded) {
+                save_loaded = 1;
+                resetServerSaveParams();
+            }
+
             if (argc == 3) {
                 int seconds = atoi(argv[1]);
                 int changes = atoi(argv[2]);

--- a/tests/assets/minimal.conf
+++ b/tests/assets/minimal.conf
@@ -1,0 +1,5 @@
+# Minimal configuration for testing.
+always-show-logo yes
+daemonize no
+pidfile /var/run/redis.pid
+loglevel verbose

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -58,6 +58,19 @@ start_server {tags {"introspection"}} {
         }
     }
 
+    test {CONFIG save params special case handled properly} {
+        # No "save" keyword - defaults should apply
+        start_server {config "minimal.conf"} {
+            assert_match [r config get save] {save {3600 1 300 100 60 10000}}
+        }
+
+        # First "save" keyword overrides defaults
+        start_server {config "minimal.conf" overrides {save {100 100}}} {
+            # Defaults
+            assert_match [r config get save] {save {100 100}}
+        }
+    }
+
     test {CONFIG sanity} {
         # Do CONFIG GET, CONFIG SET and then CONFIG GET again
         # Skip immutable configs, one with no get, and other complicated configs


### PR DESCRIPTION
Save parameters should either be default or whatever specified in the
config file. This fixes an issue introduced in #7092 which causes
configuration file settings to be applied on top of the defaults.