### PR TITLE
Tests: fix oom-score-adj false positives.

### DIFF
--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -35,7 +35,7 @@ if {$system_name eq {linux}} {
 
             # Check child process
             r set key-a value-a
-            r config set rdb-key-save-delay 100000
+            r config set rdb-key-save-delay 1000000
             r bgsave
 
             set child_pid [get_child_pid 0]


### PR DESCRIPTION
The key save delay is too short and on certain systems the child process
is gone before we have a chance to inspect it.