### PR TITLE
Release 6.0.8

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -168,3 +168,21 @@ jobs:
         ./runtest-cluster --tls
         ./runtest-cluster
 
+  test-macos-latest:
+    runs-on: macos-latest
+    if: github.repository == 'redis/redis'
+    timeout-minutes: 14400
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make
+    - name: test
+      run: |
+        ./runtest --accurate --verbose
+    - name: module api test
+      run: ./runtest-moduleapi --verbose
+    - name: sentinel tests
+      run: ./runtest-sentinel
+    - name: cluster tests
+      run: ./runtest-cluster
+

--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -12,6 +12,154 @@ SECURITY: There are security fixes in the release.
 --------------------------------------------------------------------------------
 
 ================================================================================
+Redis 6.0.8     Released Wed Sep 09 23:34:17 IDT 2020
+================================================================================
+
+Upgrade urgency HIGH: Anyone who's using Redis 6.0.7 with Sentinel or
+CONFIG REWRITE command is affected and should upgrade ASAP, see #7760.
+
+Bug fixes:
+
+* CONFIG REWRITE after setting oom-score-adj-values either via CONFIG SET or
+  loading it from a config file, will generate a corrupt config file that will
+  cause Redis to fail to start
+* Fix issue with redis-cli --pipe on MacOS
+* Fix RESP3 response for HKEYS/HVALS on non-existing key
+* Various small bug fixes
+
+New features / Changes:
+
+* Remove THP warning when set to madvise
+* Allow EXEC with read commands on readonly replica in cluster
+* Add masters/replicas options to redis-cli --cluster call command
+
+Module API:
+
+* Add RedisModule_ThreadSafeContextTryLock
+
+Full list of commits:
+
+Oran Agra in commit cdabf696a:
+ Fix RESP3 response for HKEYS/HVALS on non-existing key
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+Oran Agra in commit ec633c716:
+ Fix leak in new blockedclient module API test
+ 1 file changed, 3 insertions(+)
+
+Yossi Gottlieb in commit 6bac07c5c:
+ Tests: fix oom-score-adj false positives. (#7772)
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+杨博东 in commit 6043dc614:
+ Tests: Add aclfile load and save tests (#7765)
+ 2 files changed, 41 insertions(+)
+
+Roi Lipman in commit c0b5f9bf0:
+ RM_ThreadSafeContextTryLock a non-blocking method for acquiring GIL (#7738)
+ 7 files changed, 122 insertions(+), 1 deletion(-)
+
+Yossi Gottlieb in commit 5780a1599:
+ Tests: validate CONFIG REWRITE for all params. (#7764)
+ 6 files changed, 43 insertions(+), 6 deletions(-)
+
+Oran Agra in commit e3c14b25d:
+ Change THP warning to use madvise rather than never (#7771)
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Itamar Haber in commit 28929917b:
+ Documents RM_Call's fmt (#5448)
+ 1 file changed, 25 insertions(+)
+
+Jan-Erik Rediger in commit 9146402c2:
+ Check that THP is not set to always (madvise is ok) (#4001)
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Yossi Gottlieb in commit d05089429:
+ Tests: clean up stale .cli files. (#7768)
+ 1 file changed, 2 insertions(+)
+
+Eran Liberty in commit 8861c1bae:
+ Allow exec with read commands on readonly replica in cluster (#7766)
+ 3 files changed, 59 insertions(+), 3 deletions(-)
+
+Yossi Gottlieb in commit 2cf2ff2f6:
+ Fix CONFIG REWRITE of oom-score-adj-values. (#7761)
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+Oran Agra in commit 1386c80f7:
+ handle cur_test for nested tests
+ 1 file changed, 3 insertions(+)
+
+Oran Agra in commit c7d4945f0:
+ Add daily CI for MacOS (#7759)
+ 1 file changed, 18 insertions(+)
+
+bodong.ybd in commit 32548264c:
+ Tests: Some fixes for macOS
+ 3 files changed, 26 insertions(+), 11 deletions(-)
+
+Oran Agra in commit 1e17f9812:
+ Fix cluster consistency-check test (#7754)
+ 1 file changed, 55 insertions(+), 29 deletions(-)
+
+Yossi Gottlieb in commit f4ecdf86a:
+ Tests: fix unmonitored servers. (#7756)
+ 1 file changed, 5 insertions(+)
+
+Oran Agra in commit 9f020050d:
+ fix broken cluster/sentinel tests by recent commit (#7752)
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Oran Agra in commit fdbabb496:
+ Improve valgrind support for cluster tests (#7725)
+ 3 files changed, 83 insertions(+), 23 deletions(-)
+
+Oran Agra in commit 35a6a0bbc:
+ test infra - add durable mode to work around test suite crashing
+ 3 files changed, 35 insertions(+), 3 deletions(-)
+
+Oran Agra in commit e3136b13f:
+ test infra - wait_done_loading
+ 2 files changed, 16 insertions(+), 36 deletions(-)
+
+Oran Agra in commit 83c75dbd9:
+ test infra - flushall between tests in external mode
+ 1 file changed, 1 insertion(+)
+
+Oran Agra in commit 265f5d3cf:
+ test infra - improve test skipping ability
+ 3 files changed, 91 insertions(+), 36 deletions(-)
+
+Oran Agra in commit fcd3a9908:
+ test infra - reduce disk space usage
+ 3 files changed, 33 insertions(+), 11 deletions(-)
+
+Oran Agra in commit b6ea4699f:
+ test infra - write test name to logfile
+ 3 files changed, 35 insertions(+)
+
+Yossi Gottlieb in commit 4a4b07fc6:
+ redis-cli: fix writeConn() buffer handling. (#7749)
+ 1 file changed, 37 insertions(+), 6 deletions(-)
+
+Oran Agra in commit f2d08de2e:
+ Print server startup messages after daemonization (#7743)
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+Thandayuthapani in commit 77541d555:
+ Add masters/replicas options to redis-cli --cluster call command (#6491)
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+Oran Agra in commit 91d13a854:
+ fix README about BUILD_WITH_SYSTEMD usage (#7739)
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Yossi Gottlieb in commit 88d03d965:
+ Fix double-make issue with make && make install. (#7734)
+ 1 file changed, 2 insertions(+)
+
+================================================================================
 Redis 6.0.7     Released Fri Aug 28 11:05:09 IDT 2020
 ================================================================================
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ libssl-dev on Debian/Ubuntu) and run:
 To build with systemd support, you'll need systemd development libraries (such 
 as libsystemd-dev on Debian/Ubuntu or systemd-devel on CentOS) and run:
 
-    % make BUILD_WITH_SYSTEMD=yes USE_SYSTEMD=yes
+    % make USE_SYSTEMD=yes
 
 You can run a 32 bit Redis binary using:
 

--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -26,4 +26,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/datatype \
 --single unit/moduleapi/auth \
 --single unit/moduleapi/keyspace_events \
+--single unit/moduleapi/blockedclient \
 "${@}"

--- a/src/Makefile
+++ b/src/Makefile
@@ -255,6 +255,8 @@ persist-settings: distclean
 	echo WARN=$(WARN) >> .make-settings
 	echo OPT=$(OPT) >> .make-settings
 	echo MALLOC=$(MALLOC) >> .make-settings
+	echo BUILD_TLS=$(BUILD_TLS) >> .make-settings
+	echo USE_SYSTEMD=$(USE_SYSTEMD) >> .make-settings
 	echo CFLAGS=$(CFLAGS) >> .make-settings
 	echo LDFLAGS=$(LDFLAGS) >> .make-settings
 	echo REDIS_CFLAGS=$(REDIS_CFLAGS) >> .make-settings

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5765,8 +5765,10 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
     /* Handle the read-only client case reading from a slave: if this
      * node is a slave and the request is about an hash slot our master
      * is serving, we can reply without redirection. */
+    int is_readonly_command = (c->cmd->flags & CMD_READONLY) ||
+                              (c->cmd->proc == execCommand && !(c->mstate.cmd_inv_flags & CMD_READONLY));
     if (c->flags & CLIENT_READONLY &&
-        (cmd->flags & CMD_READONLY || cmd->proc == evalCommand ||
+        (is_readonly_command || cmd->proc == evalCommand ||
          cmd->proc == evalShaCommand) &&
         nodeIsSlave(myself) &&
         myself->slaveof == n)

--- a/src/config.c
+++ b/src/config.c
@@ -1422,7 +1422,8 @@ void rewriteConfigOOMScoreAdjValuesOption(struct rewriteConfigState *state) {
     char *option = "oom-score-adj-values";
     sds line;
 
-    line = sdsempty();
+    line = sdsnew(option);
+    line = sdscatlen(line, " ", 1);
     for (j = 0; j < CONFIG_OOM_COUNT; j++) {
         if (server.oom_score_adj_values[j] != configOOMScoreAdjValuesDefaults[j])
             force = 1;

--- a/src/config.c
+++ b/src/config.c
@@ -1055,6 +1055,8 @@ struct rewriteConfigState {
     sds *lines;           /* Current lines as an array of sds strings */
     int has_tail;         /* True if we already added directives that were
                              not present in the original config file. */
+    int force_all;        /* True if we want all keywords to be force
+                             written. Currently only used for testing. */
 };
 
 /* Append the new line to the current configuration state. */
@@ -1101,6 +1103,7 @@ struct rewriteConfigState *rewriteConfigReadOldFile(char *path) {
     state->numlines = 0;
     state->lines = NULL;
     state->has_tail = 0;
+    state->force_all = 0;
     if (fp == NULL) return state;
 
     /* Read the old file line by line, populate the state. */
@@ -1179,7 +1182,7 @@ void rewriteConfigRewriteLine(struct rewriteConfigState *state, const char *opti
 
     rewriteConfigMarkAsProcessed(state,option);
 
-    if (!l && !force) {
+    if (!l && !force && !state->force_all) {
         /* Option not used previously, and we are not forced to use it. */
         sdsfree(line);
         sdsfree(o);
@@ -1603,15 +1606,18 @@ cleanup:
  *
  * Configuration parameters that are at their default value, unless already
  * explicitly included in the old configuration file, are not rewritten.
+ * The force_all flag overrides this behavior and forces everything to be
+ * written. This is currently only used for testing purposes.
  *
  * On error -1 is returned and errno is set accordingly, otherwise 0. */
-int rewriteConfig(char *path) {
+int rewriteConfig(char *path, int force_all) {
     struct rewriteConfigState *state;
     sds newcontent;
     int retval;
 
     /* Step 1: read the old config into our rewrite state. */
     if ((state = rewriteConfigReadOldFile(path)) == NULL) return -1;
+    if (force_all) state->force_all = 1;
 
     /* Step 2: rewrite every single option, replacing or appending it inside
      * the rewrite state. */
@@ -2405,7 +2411,7 @@ NULL
             addReplyError(c,"The server is running without a config file");
             return;
         }
-        if (rewriteConfig(server.configfile) == -1) {
+        if (rewriteConfig(server.configfile, 0) == -1) {
             serverLog(LL_WARNING,"CONFIG REWRITE failed: %s", strerror(errno));
             addReplyErrorFormat(c,"Rewriting config file: %s", strerror(errno));
         } else {

--- a/src/debug.c
+++ b/src/debug.c
@@ -397,6 +397,7 @@ void debugCommand(client *c) {
 "STRUCTSIZE -- Return the size of different Redis core C structures.",
 "ZIPLIST <key> -- Show low level info about the ziplist encoding.",
 "STRINGMATCH-TEST -- Run a fuzz tester against the stringmatchlen() function.",
+"CONFIG-REWRITE-FORCE-ALL -- Like CONFIG REWRITE but writes all configuration options, including keywords not listed in original configuration file or default values.",
 #ifdef USE_JEMALLOC
 "MALLCTL <key> [<val>] -- Get or set a malloc tunning integer.",
 "MALLCTL-STR <key> [<val>] -- Get or set a malloc tunning string.",
@@ -794,6 +795,12 @@ NULL
     {
         stringmatchlen_fuzz_test();
         addReplyStatus(c,"Apparently Redis did not crash: test passed");
+    } else if (!strcasecmp(c->argv[1]->ptr,"config-rewrite-force-all") && c->argc == 2)
+    {
+        if (rewriteConfig(server.configfile, 1) == -1)
+            addReplyError(c, "CONFIG-REWRITE-FORCE-ALL failed");
+        else
+            addReply(c, shared.ok);
 #ifdef USE_JEMALLOC
     } else if(!strcasecmp(c->argv[1]->ptr,"mallctl") && c->argc >= 3) {
         mallctl_int(c, c->argv+2, c->argc-2);

--- a/src/help.h
+++ b/src/help.h
@@ -974,7 +974,7 @@ struct commandHelp {
     8,
     "1.0.0" },
     { "SET",
-    "key value [EX seconds|PX milliseconds] [NX|XX] [KEEPTTL]",
+    "key value [EX seconds|PX milliseconds|KEEPTTL] [NX|XX]",
     "Set the string value of a key",
     1,
     "1.0.0" },

--- a/src/latency.c
+++ b/src/latency.c
@@ -71,7 +71,7 @@ int THPIsEnabled(void) {
         return 0;
     }
     fclose(fp);
-    return (strstr(buf,"[never]") == NULL) ? 1 : 0;
+    return (strstr(buf,"[always]") != NULL) ? 1 : 0;
 }
 #endif
 

--- a/src/module.c
+++ b/src/module.c
@@ -3303,6 +3303,23 @@ fmterr:
 }
 
 /* Exported API to call any Redis command from modules.
+ *
+ * * **cmdname**: The Redis command to call.
+ * * **fmt**: A format specifier string for the command's arguments. Each
+ *   of the arguments should be specified by a valid type specification:
+ *   b    The argument is a buffer and is immediately followed by another
+ *        argument that is the buffer's length.
+ *   c    The argument is a pointer to a plain C string (null-terminated).
+ *   l    The argument is long long integer.
+ *   s    The argument is a RedisModuleString.
+ *   v    The argument(s) is a vector of RedisModuleString.
+ *
+ *   The format specifier can also include modifiers:
+ *   !    Sends the Redis command and its arguments to replicas and AOF.
+ *   A    Suppress AOF propagation, send only to replicas (requires `!`).
+ *   R    Suppress replicas propagation, send only to AOF (requires `!`).
+ * * **...**: The actual arguments to the Redis command.
+ *
  * On success a RedisModuleCallReply object is returned, otherwise
  * NULL is returned and errno is set to the following values:
  *
@@ -3313,6 +3330,14 @@ fmterr:
  * EROFS:  operation in Cluster instance when a write command is sent
  *         in a readonly state.
  * ENETDOWN: operation in Cluster instance when cluster is down.
+ *
+ * Example code fragment:
+ * 
+ *      reply = RedisModule_Call(ctx,"INCRBY","sc",argv[1],"10");
+ *      if (RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_INTEGER) {
+ *        long long myval = RedisModule_CallReplyInteger(reply);
+ *        // Do something with myval.
+ *      }
  *
  * This API is documented here: https://redis.io/topics/modules-intro
  */

--- a/src/module.c
+++ b/src/module.c
@@ -4906,6 +4906,23 @@ void RM_ThreadSafeContextLock(RedisModuleCtx *ctx) {
     moduleAcquireGIL();
 }
 
+/* Similar to RM_ThreadSafeContextLock but this function
+ * would not block if the server lock is already acquired.
+ *
+ * If successful (lock acquired) REDISMODULE_OK is returned,
+ * otherwise REDISMODULE_ERR is returned and errno is set
+ * accordingly. */
+int RM_ThreadSafeContextTryLock(RedisModuleCtx *ctx) {
+    UNUSED(ctx);
+
+    int res = moduleTryAcquireGIL();
+    if(res != 0) {
+        errno = res;
+        return REDISMODULE_ERR;
+    }
+    return REDISMODULE_OK;
+}
+
 /* Release the server lock after a thread safe API call was executed. */
 void RM_ThreadSafeContextUnlock(RedisModuleCtx *ctx) {
     UNUSED(ctx);
@@ -4914,6 +4931,10 @@ void RM_ThreadSafeContextUnlock(RedisModuleCtx *ctx) {
 
 void moduleAcquireGIL(void) {
     pthread_mutex_lock(&moduleGIL);
+}
+
+int moduleTryAcquireGIL(void) {
+    return pthread_mutex_trylock(&moduleGIL);
 }
 
 void moduleReleaseGIL(void) {
@@ -7929,6 +7950,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(GetThreadSafeContext);
     REGISTER_API(FreeThreadSafeContext);
     REGISTER_API(ThreadSafeContextLock);
+    REGISTER_API(ThreadSafeContextTryLock);
     REGISTER_API(ThreadSafeContextUnlock);
     REGISTER_API(DigestAddStringBuffer);
     REGISTER_API(DigestAddLongLong);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6822,21 +6822,52 @@ static ssize_t writeConn(redisContext *c, const char *buf, size_t buf_len)
 {
     int done = 0;
 
+    /* Append data to buffer which is *usually* expected to be empty
+     * but we don't assume that, and write.
+     */
     c->obuf = sdscatlen(c->obuf, buf, buf_len);
     if (redisBufferWrite(c, &done) == REDIS_ERR) {
-        sdsrange(c->obuf, 0, -(buf_len+1));
         if (!(c->flags & REDIS_BLOCK))
             errno = EAGAIN;
+
+        /* On error, we assume nothing was written and we roll back the
+         * buffer to its original state.
+         */
+        if (sdslen(c->obuf) > buf_len)
+            sdsrange(c->obuf, 0, -(buf_len+1));
+        else
+            sdsclear(c->obuf);
+
         return -1;
     }
 
-    size_t left = sdslen(c->obuf);
-    sdsclear(c->obuf);
-    if (!done) {
-        return buf_len - left;
+    /* If we're done, free up everything. We may have written more than
+     * buf_len (if c->obuf was not initially empty) but we don't have to
+     * tell.
+     */
+    if (done) {
+        sdsclear(c->obuf);
+        return buf_len;
     }
 
-    return buf_len;
+    /* Write was successful but we have some leftovers which we should
+     * remove from the buffer.
+     *
+     * Do we still have data that was there prior to our buf? If so,
+     * restore buffer to it's original state and report no new data was
+     * writen.
+     */
+    if (sdslen(c->obuf) > buf_len) {
+        sdsrange(c->obuf, 0, -(buf_len+1));
+        return 0;
+    }
+
+    /* At this point we're sure no prior data is left. We flush the buffer
+     * and report how much we've written.
+     */
+    size_t left = sdslen(c->obuf);
+    sdsclear(c->obuf);
+    return buf_len - left;
 }
 
 /* Read raw bytes through a redisContext. The read operation is not greedy

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -666,6 +666,7 @@ REDISMODULE_API int (*RedisModule_AbortBlock)(RedisModuleBlockedClient *bc) REDI
 REDISMODULE_API RedisModuleCtx * (*RedisModule_GetThreadSafeContext)(RedisModuleBlockedClient *bc) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_FreeThreadSafeContext)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ThreadSafeContextLock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ThreadSafeContextTryLock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ThreadSafeContextUnlock)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SubscribeToKeyspaceEvents)(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_NotifyKeyspaceEvent)(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) REDISMODULE_ATTR;
@@ -899,6 +900,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(GetThreadSafeContext);
     REDISMODULE_GET_API(FreeThreadSafeContext);
     REDISMODULE_GET_API(ThreadSafeContextLock);
+    REDISMODULE_GET_API(ThreadSafeContextTryLock);
     REDISMODULE_GET_API(ThreadSafeContextUnlock);
     REDISMODULE_GET_API(BlockClient);
     REDISMODULE_GET_API(UnblockClient);

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1954,7 +1954,7 @@ void sentinelFlushConfig(void) {
     int rewrite_status;
 
     server.hz = CONFIG_DEFAULT_HZ;
-    rewrite_status = rewriteConfig(server.configfile);
+    rewrite_status = rewriteConfig(server.configfile, 0);
     server.hz = saved_hz;
 
     if (rewrite_status == -1) goto werr;

--- a/src/server.c
+++ b/src/server.c
@@ -2488,7 +2488,7 @@ int restartServer(int flags, mstime_t delay) {
     /* Config rewriting. */
     if (flags & RESTART_SERVER_CONFIG_REWRITE &&
         server.configfile &&
-        rewriteConfig(server.configfile) == -1)
+        rewriteConfig(server.configfile, 0) == -1)
     {
         serverLog(LL_WARNING,"Can't restart: configuration rewrite process "
                              "failed");

--- a/src/server.c
+++ b/src/server.c
@@ -4728,7 +4728,7 @@ void linuxMemoryWarnings(void) {
         serverLog(LL_WARNING,"WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.");
     }
     if (THPIsEnabled()) {
-        serverLog(LL_WARNING,"WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.");
+        serverLog(LL_WARNING,"WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo madvise > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled (set to 'madvise' or 'never').");
     }
 }
 #endif /* __linux__ */

--- a/src/server.c
+++ b/src/server.c
@@ -5234,6 +5234,10 @@ int main(int argc, char **argv) {
         sdsfree(options);
     }
 
+    server.supervised = redisIsSupervised(server.supervised_mode);
+    int background = server.daemonize && !server.supervised;
+    if (background) daemonize();
+
     serverLog(LL_WARNING, "oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo");
     serverLog(LL_WARNING,
         "Redis version=%s, bits=%d, commit=%s, modified=%d, pid=%d, just started",
@@ -5249,11 +5253,7 @@ int main(int argc, char **argv) {
         serverLog(LL_WARNING, "Configuration loaded");
     }
 
-    server.supervised = redisIsSupervised(server.supervised_mode);
-    int background = server.daemonize && !server.supervised;
-    if (background) daemonize();
     readOOMScoreAdj();
-
     initServer();
     if (background || server.pidfile) createPidFile();
     redisSetProcTitle(argv[0]);

--- a/src/server.h
+++ b/src/server.h
@@ -1595,6 +1595,7 @@ void moduleBlockedClientTimedOut(client *c);
 void moduleBlockedClientPipeReadable(aeEventLoop *el, int fd, void *privdata, int mask);
 size_t moduleCount(void);
 void moduleAcquireGIL(void);
+int moduleTryAcquireGIL(void);
 void moduleReleaseGIL(void);
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
 void moduleCallCommandFilters(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -2089,7 +2089,7 @@ void appendServerSaveParams(time_t seconds, int changes);
 void resetServerSaveParams(void);
 struct rewriteConfigState; /* Forward declaration to export API. */
 void rewriteConfigRewriteLine(struct rewriteConfigState *state, const char *option, sds line, int force);
-int rewriteConfig(char *path);
+int rewriteConfig(char *path, int force_all);
 void initConfigValues();
 
 /* db.c -- Keyspace access API */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -772,7 +772,9 @@ void genericHgetallCommand(client *c, int flags) {
     hashTypeIterator *hi;
     int length, count = 0;
 
-    if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.emptymap[c->resp]))
+    robj *emptyResp = (flags & OBJ_HASH_KEY && flags & OBJ_HASH_VALUE) ?
+        shared.emptymap[c->resp] : shared.emptyarray;
+    if ((o = lookupKeyReadOrReply(c,c->argv[1],emptyResp))
         == NULL || checkType(c,o,OBJ_HASH)) return;
 
     /* We return a map if the user requested keys and values, like in the

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define REDIS_VERSION "6.0.7"
+#define REDIS_VERSION "6.0.8"

--- a/tests/assets/user.acl
+++ b/tests/assets/user.acl
@@ -1,0 +1,2 @@
+user alice on allcommands allkeys >alice
+user bob on -@all +@set +acl ~set* >bob

--- a/tests/cluster/tests/14-consistency-check.tcl
+++ b/tests/cluster/tests/14-consistency-check.tcl
@@ -39,53 +39,79 @@ proc cluster_write_keys_with_expire {id ttl} {
     $cluster close
 }
 
+# make sure that replica who restarts from persistence will load keys
+# that have already expired, critical for correct execution of commands
+# that arrive from the master
 proc test_slave_load_expired_keys {aof} {
     test "Slave expired keys is loaded when restarted: appendonly=$aof" {
         set master_id [find_non_empty_master]
         set replica_id [get_one_of_my_replica $master_id]
 
-        set master_dbsize [R $master_id dbsize]
-        set slave_dbsize [R $replica_id dbsize]
-        assert_equal $master_dbsize $slave_dbsize
+        set master_dbsize_0 [R $master_id dbsize]
+        set replica_dbsize_0 [R $replica_id dbsize]
+        assert_equal $master_dbsize_0 $replica_dbsize_0
 
-        set data_ttl 5
-        cluster_write_keys_with_expire $master_id $data_ttl
-        after 100
-        set replica_dbsize_1 [R $replica_id dbsize]
-        assert {$replica_dbsize_1  > $slave_dbsize}
-
+        # config the replica persistency and rewrite the config file to survive restart
+        # note that this needs to be done before populating the volatile keys since
+        # that triggers and AOFRW, and we rather the AOF file to have SETEX commands
+        # rather than an RDB with volatile keys
         R $replica_id config set appendonly $aof
         R $replica_id config rewrite
 
-        set start_time [clock seconds]
-        set end_time [expr $start_time+$data_ttl+2]
-        R $replica_id save
-        set replica_dbsize_2 [R $replica_id dbsize]
-        assert {$replica_dbsize_2  > $slave_dbsize}
+        # fill with 100 keys with 3 second TTL
+        set data_ttl 3
+        cluster_write_keys_with_expire $master_id $data_ttl
+
+        # wait for replica to be in sync with master
+        wait_for_condition 500 10 {
+            [R $replica_id dbsize] eq [R $master_id dbsize]
+        } else {
+            fail "replica didn't sync"
+        }
+        
+        set replica_dbsize_1 [R $replica_id dbsize]
+        assert {$replica_dbsize_1 > $replica_dbsize_0}
+
+        # make replica create persistence file
+        if {$aof == "yes"} {
+            # we need to wait for the initial AOFRW to be done, otherwise
+            # kill_instance (which now uses SIGTERM will fail ("Writing initial AOF, can't exit")
+            wait_for_condition 100 10 {
+                [RI $replica_id aof_rewrite_in_progress] eq 0
+            } else {
+                fail "keys didn't expire"
+            }
+        } else {
+            R $replica_id save
+        }
+
+        # kill the replica (would stay down until re-started)
         kill_instance redis $replica_id
 
-        set master_port [get_instance_attrib redis $master_id port]
-        exec ../../../src/redis-cli \
-            -h 127.0.0.1 -p $master_port \
-            {*}[rediscli_tls_config "../../../tests"] \
-            debug sleep [expr $data_ttl+3] > /dev/null &
+        # Make sure the master doesn't do active expire (sending DELs to the replica)
+        R $master_id DEBUG SET-ACTIVE-EXPIRE 0
 
-        while {[clock seconds] <= $end_time} {
-            #wait for $data_ttl seconds
-        }
+        # wait for all the keys to get logically expired
+        after [expr $data_ttl*1000]
+
+        # start the replica again (loading an RDB or AOF file)
         restart_instance redis $replica_id
 
-        wait_for_condition 200 50 {
-            [R $replica_id ping] eq {PONG}
-        } else {
-            fail "replica #$replica_id not started"
-        }
-
+        # make sure the keys are still there
         set replica_dbsize_3 [R $replica_id dbsize]
-        assert {$replica_dbsize_3  > $slave_dbsize}
+        assert {$replica_dbsize_3 > $replica_dbsize_0}
+        
+        # restore settings
+        R $master_id DEBUG SET-ACTIVE-EXPIRE 1
+
+        # wait for the master to expire all keys and replica to get the DELs
+        wait_for_condition 500 10 {
+            [R $replica_id dbsize] eq $master_dbsize_0
+        } else {
+            fail "keys didn't expire"
+        }
     }
 }
 
 test_slave_load_expired_keys no
-after 5000
 test_slave_load_expired_keys yes

--- a/tests/cluster/tests/16-transactions-on-replica.tcl
+++ b/tests/cluster/tests/16-transactions-on-replica.tcl
@@ -1,0 +1,48 @@
+# Check basic transactions on a replica.
+
+source "../tests/includes/init-tests.tcl"
+
+test "Create a primary with a replica" {
+    create_cluster 1 1
+}
+
+test "Cluster should start ok" {
+    assert_cluster_state ok
+}
+
+set primary [Rn 0]
+set replica [Rn 1]
+
+test "Cant read from replica without READONLY" {
+    $primary SET a 1
+    catch {$replica GET a} err
+    assert {[string range $err 0 4] eq {MOVED}}
+}
+
+test "Can read from replica after READONLY" {
+    $replica READONLY
+    assert {[$replica GET a] eq {1}}
+}
+
+test "Can preform HSET primary and HGET from replica" {
+    $primary HSET h a 1
+    $primary HSET h b 2
+    $primary HSET h c 3
+    assert {[$replica HGET h a] eq {1}}
+    assert {[$replica HGET h b] eq {2}}
+    assert {[$replica HGET h c] eq {3}}
+}
+
+test "Can MULTI-EXEC transaction of HGET operations from replica" {
+    $replica MULTI
+    assert {[$replica HGET h a] eq {QUEUED}}
+    assert {[$replica HGET h b] eq {QUEUED}}
+    assert {[$replica HGET h c] eq {QUEUED}}
+    assert {[$replica EXEC] eq {1 2 3}}
+}
+
+test "MULTI-EXEC with write operations is MOVED" {
+    $replica MULTI
+    catch {$replica HSET h b 4} err
+    assert {[string range $err 0 4] eq {MOVED}}
+}

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -422,10 +422,16 @@ proc S {n args} {
     [dict get $s link] {*}$args
 }
 
+# Returns a Redis instance by index.
+# Example:
+#     [Rn 0] info
+proc Rn {n} {
+    return [dict get [lindex $::redis_instances $n] link]
+}
+
 # Like R but to chat with Redis instances.
 proc R {n args} {
-    set r [lindex $::redis_instances $n]
-    [dict get $r link] {*}$args
+    [Rn $n] {*}$args
 }
 
 proc get_info_field {info field} {

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -52,7 +52,7 @@ proc exec_instance {type dirname cfgfile} {
     if {$::valgrind} {
         set pid [exec valgrind --track-origins=yes --suppressions=../../../src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full ../../../src/${prgname} $cfgfile 2>> $errfile &]
     } else {
-        set pid [exec ../../../src/${prgname} $cfgfile &]
+        set pid [exec ../../../src/${prgname} $cfgfile 2>> $errfile &]
     }
     return $pid
 }

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -52,15 +52,9 @@ tags {"aof"} {
             assert_equal 1 [is_alive $srv]
         }
 
-        set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
-
-        wait_for_condition 50 100 {
-            [catch {$client ping} e] == 0
-        } else {
-            fail "Loading DB is taking too much time."
-        }
-
         test "Truncated AOF loaded: we expect foo to be equal to 5" {
+            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            wait_done_loading $client
             assert {[$client get foo] eq "5"}
         }
 
@@ -75,15 +69,9 @@ tags {"aof"} {
             assert_equal 1 [is_alive $srv]
         }
 
-        set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
-
-        wait_for_condition 50 100 {
-            [catch {$client ping} e] == 0
-        } else {
-            fail "Loading DB is taking too much time."
-        }
-
         test "Truncated AOF loaded: we expect foo to be equal to 6 now" {
+            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            wait_done_loading $client
             assert {[$client get foo] eq "6"}
         }
     }
@@ -183,11 +171,7 @@ tags {"aof"} {
 
         test "Fixed AOF: Keyspace should contain values that were parseable" {
             set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
-            wait_for_condition 50 100 {
-                [catch {$client ping} e] == 0
-            } else {
-                fail "Loading DB is taking too much time."
-            }
+            wait_done_loading $client
             assert_equal "hello" [$client get foo]
             assert_equal "" [$client get bar]
         }
@@ -207,11 +191,7 @@ tags {"aof"} {
 
         test "AOF+SPOP: Set should have 1 member" {
             set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
-            wait_for_condition 50 100 {
-                [catch {$client ping} e] == 0
-            } else {
-                fail "Loading DB is taking too much time."
-            }
+            wait_done_loading $client
             assert_equal 1 [$client scard set]
         }
     }
@@ -231,11 +211,7 @@ tags {"aof"} {
 
         test "AOF+SPOP: Set should have 1 member" {
             set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
-            wait_for_condition 50 100 {
-                [catch {$client ping} e] == 0
-            } else {
-                fail "Loading DB is taking too much time."
-            }
+            wait_done_loading $client
             assert_equal 1 [$client scard set]
         }
     }
@@ -254,11 +230,7 @@ tags {"aof"} {
 
         test "AOF+EXPIRE: List should be empty" {
             set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
-            wait_for_condition 50 100 {
-                [catch {$client ping} e] == 0
-            } else {
-                fail "Loading DB is taking too much time."
-            }
+            wait_done_loading $client
             assert_equal 0 [$client llen list]
         }
     }

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -25,7 +25,7 @@ start_server [list overrides [list "dir" $server_path "dbfilename" "encodings.rd
 
 set server_path [tmpdir "server.rdb-startup-test"]
 
-start_server [list overrides [list "dir" $server_path]] {
+start_server [list overrides [list "dir" $server_path] keep_persistence true] {
     test {Server started empty with non-existing RDB file} {
         r debug digest
     } {0000000000000000000000000000000000000000}
@@ -33,13 +33,13 @@ start_server [list overrides [list "dir" $server_path]] {
     r save
 }
 
-start_server [list overrides [list "dir" $server_path]] {
+start_server [list overrides [list "dir" $server_path] keep_persistence true] {
     test {Server started empty with empty RDB file} {
         r debug digest
     } {0000000000000000000000000000000000000000}
 }
 
-start_server [list overrides [list "dir" $server_path]] {
+start_server [list overrides [list "dir" $server_path] keep_persistence true] {
     test {Test RDB stream encoding} {
         for {set j 0} {$j < 1000} {incr j} {
             if {rand() < 0.9} {
@@ -64,7 +64,7 @@ set defaults {}
 proc start_server_and_kill_it {overrides code} {
     upvar defaults defaults srv srv server_path server_path
     set config [concat $defaults $overrides]
-    set srv [start_server [list overrides $config]]
+    set srv [start_server [list overrides $config keep_persistence true]]
     uplevel 1 $code
     kill_server $srv
 }

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -182,6 +182,7 @@ start_server {tags {"cli"}} {
         set tmpfile [write_tmpfile "from file"]
         assert_equal "OK" [run_cli_with_input_file $tmpfile set key]
         assert_equal "from file" [r get key]
+        file delete $tmpfile
     }
 
     test_nontty_cli "Status reply" {
@@ -215,6 +216,7 @@ start_server {tags {"cli"}} {
         set tmpfile [write_tmpfile "from file"]
         assert_equal "OK" [run_cli_with_input_file $tmpfile set key]
         assert_equal "from file" [r get key]
+        file delete $tmpfile
     }
 
     proc test_redis_cli_rdb_dump {} {

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -23,7 +23,9 @@ TEST_MODULES = \
     scan.so \
     datatype.so \
     auth.so \
-    keyspace_events.so
+    keyspace_events.so \
+    blockedclient.so
+
 
 .PHONY: all
 

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -46,6 +46,9 @@ void *worker(void *arg) {
     // Unblock client
     RedisModule_UnblockClient(bc, NULL);
 
+    // Free the Redis module context
+    RedisModule_FreeThreadSafeContext(ctx);
+
     return NULL;
 }
 

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -1,0 +1,82 @@
+#define REDISMODULE_EXPERIMENTAL_API
+#include "redismodule.h"
+#include <assert.h>
+#include <stdio.h>
+#include <pthread.h>
+
+#define UNUSED(V) ((void) V)
+
+void *sub_worker(void *arg) {
+    // Get Redis module context
+    RedisModuleCtx *ctx = (RedisModuleCtx *)arg;
+
+    // Try acquiring GIL
+    int res = RedisModule_ThreadSafeContextTryLock(ctx);
+
+    // GIL is already taken by the calling thread expecting to fail.
+    assert(res != REDISMODULE_OK);
+
+    return NULL;
+}
+
+void *worker(void *arg) {
+    // Retrieve blocked client
+    RedisModuleBlockedClient *bc = (RedisModuleBlockedClient *)arg;
+
+    // Get Redis module context
+    RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(bc);
+
+    // Acquire GIL
+    RedisModule_ThreadSafeContextLock(ctx);
+
+    // Create another thread which will try to acquire the GIL
+    pthread_t tid;
+    int res = pthread_create(&tid, NULL, sub_worker, ctx);
+    assert(res == 0);
+
+    // Wait for thread
+    pthread_join(tid, NULL);
+
+    // Release GIL
+    RedisModule_ThreadSafeContextUnlock(ctx);
+
+    // Reply to client
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+
+    // Unblock client
+    RedisModule_UnblockClient(bc, NULL);
+
+    return NULL;
+}
+
+int acquire_gil(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+{
+    UNUSED(argv);
+    UNUSED(argc);
+
+    /* This command handler tries to acquire the GIL twice
+     * once in the worker thread using "RedisModule_ThreadSafeContextLock"
+     * second in the sub-worker thread
+     * using "RedisModule_ThreadSafeContextTryLock"
+     * as the GIL is already locked. */
+    RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
+
+    pthread_t tid;
+    int res = pthread_create(&tid, NULL, worker, bc);
+    assert(res == 0);
+
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx, "blockedclient", 1, REDISMODULE_APIVER_1)== REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "acquire_gil", acquire_gil, "", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    return REDISMODULE_OK;
+}

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -383,6 +383,11 @@ proc start_server {options {code undefined}} {
                 dict set config port $port
             }
             create_server_config_file $config_file $config
+
+            # Truncate log so wait_server_started will not be looking at
+            # output of the failed server.
+            close [open $stdout "w"]
+
             continue; # Try again
         }
 

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -13,21 +13,9 @@ proc start_server_error {config_file error} {
 }
 
 proc check_valgrind_errors stderr {
-    set fd [open $stderr]
-    set buf [read $fd]
-    close $fd
-
-    # look for stack trace and other errors, or the absense of a leak free summary
-    if {[regexp -- { at 0x} $buf] ||
-        [regexp -- {Warning} $buf] ||
-        [regexp -- {Invalid} $buf] ||
-        [regexp -- {Mismatched} $buf] ||
-        [regexp -- {uninitialized} $buf] ||
-        [regexp -- {has a fishy} $buf] ||
-        [regexp -- {overlap} $buf] ||
-        (![regexp -- {definitely lost: 0 bytes} $buf] &&
-         ![regexp -- {no leaks are possible} $buf])} {
-        send_data_packet $::test_server_fd err "Valgrind error: $buf\n"
+    set res [find_valgrind_errors $stderr]
+    if {$res != ""} {
+        send_data_packet $::test_server_fd err "Valgrind error: $res\n"
     }
 }
 

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -296,6 +296,7 @@ proc start_server {options {code undefined}} {
             # append the server to the stack
             lappend ::servers $srv
         }
+        r flushall
         uplevel 1 $code
         set ::tags [lrange $::tags 0 end-[llength $tags]]
         return

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -301,6 +301,13 @@ proc start_server {options {code undefined}} {
     set stdout [format "%s/%s" [dict get $config "dir"] "stdout"]
     set stderr [format "%s/%s" [dict get $config "dir"] "stderr"]
 
+    # if we're inside a test, write the test name to the server log file
+    if {[info exists ::cur_test]} {
+        set fd [open $stdout "a+"]
+        puts $fd "### Starting server for test $::cur_test"
+        close $fd
+    }
+
     # We need a loop here to retry with different ports.
     set server_started 0
     while {$server_started == 0} {
@@ -442,6 +449,13 @@ proc restart_server {level wait_ready} {
     set stdout [dict get $srv "stdout"]
     set stderr [dict get $srv "stderr"]
     set config_file [dict get $srv "config_file"]
+
+    # if we're inside a test, write the test name to the server log file
+    if {[info exists ::cur_test]} {
+        set fd [open $stdout "a+"]
+        puts $fd "### Restarting server for test $::cur_test"
+        close $fd
+    }
 
     set prev_ready_count [exec grep -i "Ready to accept" | wc -l < $stdout]
 

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -4,6 +4,7 @@ set ::num_failed 0
 set ::num_skipped 0
 set ::num_aborted 0
 set ::tests_failed {}
+set ::cur_test ""
 
 proc fail {msg} {
     error "assertion:$msg"
@@ -136,6 +137,7 @@ proc test {name code {okpattern undefined} {options undefined}} {
 
     # set a cur_test global to be logged into new servers that are spown
     # and log the test name in all existing servers
+    set prev_test $::cur_test
     set ::cur_test "$name in $::curfile"
     if {!$::external} {
         foreach srv $::servers {
@@ -190,4 +192,5 @@ proc test {name code {okpattern undefined} {options undefined}} {
             send_data_packet $::test_server_fd err "Detected a memory leak in test '$name': $output"
         }
     }
+    set ::cur_test $prev_test
 }

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -190,5 +190,4 @@ proc test {name code {okpattern undefined} {options undefined}} {
             send_data_packet $::test_server_fd err "Detected a memory leak in test '$name': $output"
         }
     }
-    unset ::cur_test
 }

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -149,9 +149,13 @@ proc test {name code {okpattern undefined} {options undefined}} {
     send_data_packet $::test_server_fd testing $name
 
     if {[catch {set retval [uplevel 1 $code]} error]} {
-        if {[string match "assertion:*" $error]} {
+        set assertion [string match "assertion:*" $error]
+        if {$assertion || $::durable} {
             set msg [string range $error 10 end]
             lappend details $msg
+            if {!$assertion} {
+                lappend details $::errorInfo
+            }
             lappend ::tests_failed $details
 
             incr ::num_failed

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -143,6 +143,18 @@ proc test {name code {okpattern undefined}} {
     set details {}
     lappend details "$name in $::curfile"
 
+    # set a cur_test global to be logged into new servers that are spown
+    # and log the test name in all existing servers
+    set ::cur_test "$name in $::curfile"
+    if {!$::external} {
+        foreach srv $::servers {
+            set stdout [dict get $srv stdout]
+            set fd [open $stdout "a+"]
+            puts $fd "### Starting test $::cur_test"
+            close $fd
+        }
+    }
+
     send_data_packet $::test_server_fd testing $name
 
     if {[catch {set retval [uplevel 1 $code]} error]} {
@@ -183,4 +195,5 @@ proc test {name code {okpattern undefined}} {
             send_data_packet $::test_server_fd err "Detected a memory leak in test '$name': $output"
         }
     }
+    unset ::cur_test
 }

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -99,16 +99,7 @@ proc wait_for_condition {maxtries delay e _else_ elsescript} {
     }
 }
 
-proc test {name code {okpattern undefined}} {
-    # abort if tagged with a tag to deny
-    foreach tag $::denytags {
-        if {[lsearch $::tags $tag] >= 0} {
-            incr ::num_aborted
-            send_data_packet $::test_server_fd ignore $name
-            return
-        }
-    }
-
+proc test {name code {okpattern undefined} {options undefined}} {
     # abort if test name in skiptests
     if {[lsearch $::skiptests $name] >= 0} {
         incr ::num_skipped

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -494,3 +494,28 @@ proc start_bg_complex_data {host port db ops} {
 proc stop_bg_complex_data {handle} {
     catch {exec /bin/kill -9 $handle}
 }
+
+proc populate {num prefix size} {
+    set rd [redis_deferring_client]
+    for {set j 0} {$j < $num} {incr j} {
+        $rd set $prefix$j [string repeat A $size]
+    }
+    for {set j 0} {$j < $num} {incr j} {
+        $rd read
+    }
+    $rd close
+}
+
+proc get_child_pid {idx} {
+    set pid [srv $idx pid]
+    if {[string match {*Darwin*} [exec uname -a]]} {
+        set fd [open "|pgrep -P $pid" "r"]
+        set child_pid [string trim [lindex [split [read $fd] \n] 0]]
+    } else {
+        set fd [open "|ps --ppid $pid -o pid" "r"]
+        set child_pid [string trim [lindex [split [read $fd] \n] 1]]
+    }
+    close $fd
+
+    return $child_pid
+}

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -99,6 +99,14 @@ proc wait_for_ofs_sync {r1 r2} {
     }
 }
 
+proc wait_done_loading r {
+    wait_for_condition 50 100 {
+        [catch {$r ping} e] == 0
+    } else {
+        fail "Loading DB is taking too much time."
+    }
+}
+
 # count current log lines in server's stdout
 proc count_log_lines {srv_idx} {
     set _ [exec wc -l < [srv $srv_idx stdout]]

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -138,6 +138,14 @@ proc wait_for_log_messages {srv_idx patterns from_line maxtries delay} {
     }
 }
 
+# write line to server log file
+proc write_log_line {srv_idx msg} {
+    set logfile [srv $srv_idx stdout]
+    set fd [open $logfile "a+"]
+    puts $fd "### $msg"
+    close $fd
+}
+
 # Random integer between 0 and max (excluded).
 proc randomInt {max} {
     expr {int(rand()*$max)}

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -79,6 +79,7 @@ set ::baseport 21111; # initial port for spawned redis servers
 set ::portcount 8000; # we don't wanna use more than 10000 to avoid collision with cluster bus ports
 set ::traceleaks 0
 set ::valgrind 0
+set ::durable 0
 set ::tls 0
 set ::stack_logging 0
 set ::verbose 0
@@ -521,6 +522,7 @@ proc send_data_packet {fd status data} {
 proc print_help_screen {} {
     puts [join {
         "--valgrind         Run the test over valgrind."
+        "--durable          suppress test crashes and keep running"
         "--stack-logging    Enable OSX leaks/malloc stack logging."
         "--accurate         Run slow randomized tests for more iterations."
         "--quiet            Don't show individual tests."
@@ -633,6 +635,8 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     } elseif {$opt eq {--clients}} {
         set ::numclients $arg
         incr j
+    } elseif {$opt eq {--durable}} {
+        set ::durable 1
     } elseif {$opt eq {--dont-clean}} {
         set ::dont_clean 1
     } elseif {$opt eq {--wait-server}} {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -85,6 +85,7 @@ set ::verbose 0
 set ::quiet 0
 set ::denytags {}
 set ::skiptests {}
+set ::skipunits {}
 set ::allowtags {}
 set ::only_tests {}
 set ::single_tests {}
@@ -423,6 +424,12 @@ proc lpop {listVar {count 1}} {
     set ele
 }
 
+proc lremove {listVar value} {
+    upvar 1 $listVar var
+    set idx [lsearch -exact $var $value]
+    set var [lreplace $var $idx $idx]
+}
+
 # A new client is idle. Remove it from the list of active clients and
 # if there are still test units to run, launch them.
 proc signal_idle_client fd {
@@ -521,11 +528,13 @@ proc print_help_screen {} {
         "--list-tests       List all the available test units."
         "--only <test>      Just execute the specified test by test name. this option can be repeated."
         "--skip-till <unit> Skip all units until (and including) the specified one."
+        "--skipunit <unit>  Skip one unit."
         "--clients <num>    Number of test clients (default 16)."
         "--timeout <sec>    Test timeout in seconds (default 10 min)."
         "--force-failure    Force the execution of a test that always fails."
         "--config <k> <v>   Extra config file argument."
         "--skipfile <file>  Name of a file containing test names that should be skipped (one per line)."
+        "--skiptest <name>  Name of a file containing test names that should be skipped (one per line)."
         "--dont-clean       Don't delete redis log files after the run."
         "--stop             Blocks once the first test fails."
         "--loop             Execute the specified set of tests forever."
@@ -563,6 +572,9 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         set file_data [read $fp]
         close $fp
         set ::skiptests [split $file_data "\n"]
+    } elseif {$opt eq {--skiptest}} {
+        lappend ::skiptests $arg
+        incr j
     } elseif {$opt eq {--valgrind}} {
         set ::valgrind 1
     } elseif {$opt eq {--stack-logging}} {
@@ -601,6 +613,9 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     } elseif {$opt eq {--only}} {
         lappend ::only_tests $arg
         incr j
+    } elseif {$opt eq {--skipunit}} {
+        lappend ::skipunits $arg
+        incr j
     } elseif {$opt eq {--skip-till}} {
         set ::skip_till $arg
         incr j
@@ -638,13 +653,23 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     }
 }
 
-# If --skil-till option was given, we populate the list of single tests
+set filtered_tests {}
+
+# Set the filtered tests to be the short list (single_tests) if exists.
+# Otherwise, we start filtering all_tests
+if {[llength $::single_tests] > 0} {
+    set filtered_tests $::single_tests
+} else {
+    set filtered_tests $::all_tests
+}
+
+# If --skip-till option was given, we populate the list of single tests
 # to run with everything *after* the specified unit.
 if {$::skip_till != ""} {
     set skipping 1
     foreach t $::all_tests {
-        if {$skipping == 0} {
-            lappend ::single_tests $t
+        if {$skipping == 1} {
+            lremove filtered_tests $t
         }
         if {$t == $::skip_till} {
             set skipping 0
@@ -656,10 +681,20 @@ if {$::skip_till != ""} {
     }
 }
 
+# If --skipunits option was given, we populate the list of single tests
+# to run with everything *not* in the skipunits list.
+if {[llength $::skipunits] > 0} {
+    foreach t $::all_tests {
+        if {[lsearch $::skipunits $t] != -1} {
+            lremove filtered_tests $t
+        }
+    }
+}
+
 # Override the list of tests with the specific tests we want to run
-# in case there was some filter, that is --single or --skip-till options.
-if {[llength $::single_tests] > 0} {
-    set ::all_tests $::single_tests
+# in case there was some filter, that is --single, -skipunit or --skip-till options.
+if {[llength $filtered_tests] < [llength $::all_tests]} {
+    set ::all_tests $filtered_tests
 }
 
 proc attach_to_replication_stream {} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -134,4 +134,28 @@ start_server {tags {"introspection"}} {
 
         }
     }
+
+    # Do a force-all config rewrite and make sure we're able to parse
+    # it.
+    test {CONFIG REWRITE sanity} {
+        # Capture state of config before
+        set configs {}
+        foreach {k v} [r config get *] {
+            dict set configs $k $v
+        }
+
+        # Rewrite entire configuration, restart and confirm the
+        # server is able to parse it and start.
+        assert_equal [r debug config-rewrite-force-all] "OK"
+        restart_server 0 0
+        assert_equal [r ping] "PONG"
+
+        # Verify no changes were introduced
+        dict for {k v} $configs {
+            assert_equal $v [lindex [r config get $k] 1]
+        }
+    }
+
+    # Config file at this point is at a wierd state, and includes all
+    # known keywords. Might be a good idea to avoid adding tests here.
 }

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -1,0 +1,11 @@
+# source tests/support/util.tcl
+
+set testmodule [file normalize tests/modules/blockedclient.so]
+
+start_server {tags {"modules"}} {
+    r module load $testmodule
+
+    test {Locked GIL acquisition} {
+        assert_match "OK" [r acquire_gil]
+    }
+}

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -12,7 +12,7 @@ tags "modules" {
 
     test {modules global are lost without aux} {
         set server_path [tmpdir "server.module-testrdb"]
-        start_server [list overrides [list loadmodule "$testmodule" "dir" $server_path]] {
+        start_server [list overrides [list loadmodule "$testmodule" "dir" $server_path] keep_persistence true] {
             r testrdb.set.before global1
             assert_equal "global1" [r testrdb.get.before]
         }
@@ -23,7 +23,7 @@ tags "modules" {
 
     test {modules are able to persist globals before and after} {
         set server_path [tmpdir "server.module-testrdb"]
-        start_server [list overrides [list loadmodule "$testmodule 2" "dir" $server_path]] {
+        start_server [list overrides [list loadmodule "$testmodule 2" "dir" $server_path] keep_persistence true] {
             r testrdb.set.before global1
             r testrdb.set.after global2
             assert_equal "global1" [r testrdb.get.before]
@@ -38,7 +38,7 @@ tags "modules" {
 
     test {modules are able to persist globals just after} {
         set server_path [tmpdir "server.module-testrdb"]
-        start_server [list overrides [list loadmodule "$testmodule 1" "dir" $server_path]] {
+        start_server [list overrides [list loadmodule "$testmodule 1" "dir" $server_path] keep_persistence true] {
             r testrdb.set.after global2
             assert_equal "global2" [r testrdb.get.after]
         }

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -35,7 +35,7 @@ if {$system_name eq {linux}} {
 
             # Check child process
             r set key-a value-a
-            r config set rdb-key-save-delay 100000
+            r config set rdb-key-save-delay 1000000
             r bgsave
 
             set child_pid [get_child_pid 0]

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -14,15 +14,6 @@ if {$system_name eq {linux}} {
             return $val
         }
 
-        proc get_child_pid {} {
-            set pid [srv 0 pid]
-            set fd [open "|ps --ppid $pid -o pid" "r"]
-            set child_pid [string trim [lindex [split [read $fd] \n] 1]]
-            close $fd
-
-            return $child_pid
-        }
-
         test {CONFIG SET oom-score-adj works as expected} {
             set base [get_oom_score_adj]
 
@@ -47,7 +38,7 @@ if {$system_name eq {linux}} {
             r config set rdb-key-save-delay 100000
             r bgsave
 
-            set child_pid [get_child_pid]
+            set child_pid [get_child_pid 0]
             assert {[get_oom_score_adj $child_pid] == [expr $base + 30]}
         }
 


### PR DESCRIPTION
Upgrade urgency HIGH: Anyone who's using Redis 6.0.7 with Sentinel or
CONFIG REWRITE command is affected and should upgrade ASAP, see #7760.

Bug fixes:

* CONFIG REWRITE after setting oom-score-adj-values either via CONFIG SET or
  loading it from a config file, will generate a corrupt config file that will
  cause Redis to fail to start
* Fix issue with redis-cli --pipe on MacOS
* Fix RESP3 response for HKEYS/HVALS on non-existing key
* Various small bug fixes

New features / Changes:

* Remove THP warning when set to madvise
* Allow EXEC with read commands on readonly replica in cluster
* Add masters/replicas options to redis-cli --cluster call command

Module API:

* Add RedisModule_ThreadSafeContextTryLock