### PR TITLE
make server.loading flag atomic

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1120,7 +1120,7 @@ struct redisServer {
     long long events_processed_while_blocked; /* processEventsWhileBlocked() */
 
     /* RDB / AOF loading information */
-    int loading;                /* We are loading data from disk if true */
+    _Atomic int loading;        /* We are loading data from disk if true */
     off_t loading_total_bytes;
     off_t loading_loaded_bytes;
     time_t loading_start_time;


### PR DESCRIPTION
Reported a potential data race on `server.loading` in  #7777 .

This is a potential fix by making the flag atomic.