### PR TITLE
Fix RESP3 response for HKEYS/HVALS on non-existing key

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -766,7 +766,9 @@ void genericHgetallCommand(client *c, int flags) {
     hashTypeIterator *hi;
     int length, count = 0;
 
-    if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.emptymap[c->resp]))
+    robj *emptyResp = (flags & OBJ_HASH_KEY && flags & OBJ_HASH_VALUE) ?
+        shared.emptymap[c->resp] : shared.emptyarray;
+    if ((o = lookupKeyReadOrReply(c,c->argv[1],emptyResp))
         == NULL || checkType(c,o,OBJ_HASH)) return;
 
     /* We return a map if the user requested keys and values, like in the


### PR DESCRIPTION
Fixes #7776