### PR TITLE
Remove dead global variable 'lru_clock'

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -71,7 +71,6 @@ double R_Zero, R_PosInf, R_NegInf, R_Nan;
 
 /* Global vars */
 struct redisServer server; /* Server global state */
-volatile unsigned long lru_clock; /* Server global current LRU time. */
 
 /* Our command table.
  *


### PR DESCRIPTION
BTW

> volatile access does not establish inter-thread synchronization.

https://en.cppreference.com/w/c/atomic/memory_order