### PR TITLE
fix broken PEXPIREAT test

### DIFF
--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -92,7 +92,7 @@ start_server {tags {"expire"}} {
         # This test is very likely to do a false positive if the
         # server is under pressure, so if it does not work give it a few more
         # chances.
-        for {set j 0} {$j < 3} {incr j} {
+        for {set j 0} {$j < 30} {incr j} {
             r del x y z
             r psetex x 100 somevalue
             after 80
@@ -108,18 +108,22 @@ start_server {tags {"expire"}} {
             set d [r get x]
 
             r set x somevalue
-            r pexpireat x [expr ([clock seconds]*1000)+100]
-            after 80
+            set now [r time]
+            r pexpireat x [expr ([lindex $now 0]*1000)+([lindex $now 1]/1000)+200]
+            after 20
             set e [r get x]
-            after 120
+            after 220
             set f [r get x]
 
             if {$a eq {somevalue} && $b eq {} &&
                 $c eq {somevalue} && $d eq {} &&
                 $e eq {somevalue} && $f eq {}} break
         }
-        list $a $b
-    } {somevalue {}}
+        if {$::verbose} {
+            puts "sub-second expire test attempts: $j"
+        }
+        list $a $b $c $d $e $f
+    } {somevalue {} somevalue {} somevalue {}}
 
     test {TTL returns time to live in seconds} {
         r del x


### PR DESCRIPTION
This test was nearly always failing on MacOS github actions.
This is because of bugs in the test that caused it to nearly always run
all 3 attempts and just look at the last one as the pass/fail creteria.

i.e. the test was nearly always running all 3 attempts and still sometimes
succeed. this is because the break condition was different than the test
completion condition.

The reason the test succeeded is because the break condition tested the
results of all 3 tests (PSETEX/PEXPIRE/PEXPIREAT), but the success check
at the end was only testing the result of PSETEX.

The reason the PEXPIREAT test nearly always failed is because it was
getting the current time wrong: getting the current second and loosing
the sub-section time, so the only chance for it to succeed is if it run
right when a certain second started.

Because i now get the time from redis, adding another round trip, i
added another 100ms to the PEXPIRE test to make it less fragile, and
also added many more attempts.

Adding many more attempts before failure to account for slow platforms,
github actions and valgrind