### PR TITLE
Fix failing valgrind installation in github actions

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -109,6 +109,7 @@ jobs:
       run: make valgrind
     - name: test
       run: |
+        sudo apt-get update
         sudo apt-get install tcl8.5 valgrind -y
         ./runtest --valgrind --verbose --clients 1
     - name: module api test


### PR DESCRIPTION
These tests started failing every day on http 404 (not being able to
install valgrind)