### PR TITLE
correct OBJECT ENCODING response for stream type

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -740,6 +740,7 @@ char *strEncoding(int encoding) {
     case OBJ_ENCODING_INTSET: return "intset";
     case OBJ_ENCODING_SKIPLIST: return "skiplist";
     case OBJ_ENCODING_EMBSTR: return "embstr";
+    case OBJ_ENCODING_STREAM: return "stream";
     default: return "unknown";
     }
 }


### PR DESCRIPTION
This commit makes stream object returning "stream" as encoding type in OBJECT ENCODING subcommand and DEBUG OBJECT command.

Before:
127.0.0.1:6379> object encoding tt
"unknown"

After:
127.0.0.1:6379> object encoding tt
"stream"