### PR TITLE
Add Swapdb Module Event

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1157,6 +1157,8 @@ void swapdbCommand(client *c) {
         addReplyError(c,"DB index is out of range");
         return;
     } else {
+        RedisModuleSwapDbInfo si = {REDISMODULE_SWAPDBINFO_VERSION,id1,id2};
+        moduleFireServerEvent(REDISMODULE_EVENT_SWAPDB,0,&si);
         server.dirty++;
         addReply(c,shared.ok);
     }

--- a/src/module.c
+++ b/src/module.c
@@ -7179,6 +7179,20 @@ void ModuleForkDoneHandler(int exitcode, int bysignal) {
  *              int32_t progress;  // Approximate progress between 0 and 1024,
  *                                    or -1 if unknown.
  *
+ *      RedisModuleEvent_SwapDB
+ *
+ *          This event is called when a swap db command has been successfully 
+ *          Executed. 
+ *          For this event call currently there is no subevents available.
+ *
+ *          The data pointer can be casted to a RedisModuleSwapDbInfo
+ *          structure with the following fields:
+ *
+ *             int32_t dbnum_first;    // Swap Db first dbnum 
+ *             int32_t dbnum_second;   // Swap Db second dbnum 
+ *
+ *
+ *
  * The function returns REDISMODULE_OK if the module was successfully subscribed
  * for the specified event. If the API is called from a wrong context then
  * REDISMODULE_ERR is returned. */
@@ -7282,6 +7296,8 @@ void moduleFireServerEvent(uint64_t eid, int subid, void *data) {
             } else if (eid == REDISMODULE_EVENT_LOADING_PROGRESS) {
                 moduledata = data;
             } else if (eid == REDISMODULE_EVENT_CRON_LOOP) {
+                moduledata = data;
+            } else if (eid == REDISMODULE_EVENT_SWAPDB) {
                 moduledata = data;
             }
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -190,6 +190,7 @@ typedef uint64_t RedisModuleTimerID;
 #define REDISMODULE_EVENT_CRON_LOOP 8
 #define REDISMODULE_EVENT_MODULE_CHANGE 9
 #define REDISMODULE_EVENT_LOADING_PROGRESS 10
+#define REDISMODULE_EVENT_SWAPDB 11
 
 typedef struct RedisModuleEvent {
     uint64_t id;        /* REDISMODULE_EVENT_... defines. */
@@ -242,6 +243,10 @@ static const RedisModuleEvent
     },
     RedisModuleEvent_LoadingProgress = {
         REDISMODULE_EVENT_LOADING_PROGRESS,
+        1
+    },
+    RedisModuleEvent_SwapDB = {
+        REDISMODULE_EVENT_SWAPDB,
         1
     };
 
@@ -373,6 +378,17 @@ typedef struct RedisModuleLoadingProgressInfo {
 } RedisModuleLoadingProgressV1;
 
 #define RedisModuleLoadingProgress RedisModuleLoadingProgressV1
+
+#define REDISMODULE_SWAPDBINFO_VERSION 1
+typedef struct RedisModuleSwapDbInfo {
+    uint64_t version;       /* Not used since this structure is never passed
+                               from the module to the core right now. Here
+                               for future compatibility. */
+    int32_t dbnum_first;    /* Swap Db first dbnum */
+    int32_t dbnum_second;   /* Swap Db second dbnum */
+} RedisModuleSwapDbInfoV1;
+
+#define RedisModuleSwapDbInfo RedisModuleSwapDbInfoV1
 
 /* ------------------------- End of common defines ------------------------ */
 

--- a/tests/modules/hooks.c
+++ b/tests/modules/hooks.c
@@ -253,6 +253,16 @@ void moduleChangeCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub,
     LogStringEvent(ctx, keyname, ei->module_name);
 }
 
+void swapDbCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub, void *data)
+{
+    REDISMODULE_NOT_USED(e);
+    REDISMODULE_NOT_USED(sub);
+
+    RedisModuleSwapDbInfo *ei = data;
+    LogNumericEvent(ctx, "swapdb-first", ei->dbnum_first);
+    LogNumericEvent(ctx, "swapdb-second", ei->dbnum_second);
+}
+
 /* This function must be present on each Redis module. It is used in order to
  * register the commands into the Redis server. */
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -289,6 +299,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         RedisModuleEvent_CronLoop, cronLoopCallback);
     RedisModule_SubscribeToServerEvent(ctx,
         RedisModuleEvent_ModuleChange, moduleChangeCallback);
+    RedisModule_SubscribeToServerEvent(ctx,
+        RedisModuleEvent_SwapDB, swapDbCallback);
 
     event_log = RedisModule_CreateDict(ctx);
 

--- a/tests/unit/moduleapi/hooks.tcl
+++ b/tests/unit/moduleapi/hooks.tcl
@@ -147,6 +147,12 @@ tags "modules" {
             set replica_stdout [srv 0 stdout]
         }
 
+        test {Test swapdb hooks} {
+            r swapdb 0 10
+            assert_equal [r hooks.event_last swapdb-first] 0
+            assert_equal [r hooks.event_last swapdb-second] 10
+
+        }
 
         # look into the log file of the server that just exited
         test {Test shutdown hook} {


### PR DESCRIPTION
This PR adds SwapDb module event, currently there is no notification mechanism for letting user know a swapdb has been called, this PR provides mechanism for adding swapdb as a new module event type.