### PR TITLE
Fix connGetSocketError usage

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -251,8 +251,9 @@ static void connSocketEventHandler(struct aeEventLoop *el, int fd, void *clientD
     if (conn->state == CONN_STATE_CONNECTING &&
             (mask & AE_WRITABLE) && conn->conn_handler) {
 
-        if (connGetSocketError(conn)) {
-            conn->last_errno = errno;
+        int conn_error = connGetSocketError(conn);
+        if (conn_error) {
+            conn->last_errno = conn_error;
             conn->state = CONN_STATE_ERROR;
         } else {
             conn->state = CONN_STATE_CONNECTED;

--- a/src/tls.c
+++ b/src/tls.c
@@ -464,8 +464,9 @@ static void tlsHandleEvent(tls_connection *conn, int mask) {
 
     switch (conn->c.state) {
         case CONN_STATE_CONNECTING:
-            if (connGetSocketError((connection *) conn)) {
-                conn->c.last_errno = errno;
+            int conn_error = connGetSocketError((connection *) conn);
+            if (conn_error) {
+                conn->c.last_errno = conn_error;
                 conn->c.state = CONN_STATE_ERROR;
             } else {
                 if (!(conn->flags & TLS_CONN_FLAG_FD_SET)) {


### PR DESCRIPTION
Method *connGetSocketError* is designed to return error status of the socket. 

When the *getsockopt* method in *connGetSocketError* is invoked successfully, and the socket does have error, *errno* won't be updated. Assigning *errno* to connection error here is misleading. As *connectGetSocketError* can get socket error number by *getsockopt* and return it, we should record the returned value instead. 