### PR TITLE
Make threads killable

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -168,10 +168,7 @@ void *bioProcessBackgroundJobs(void *arg) {
 
     redisSetCpuAffinity(server.bio_cpulist);
 
-    /* Make the thread killable at any time, so that bioKillThreads()
-     * can work reliably. */
-    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+    makeThreadKillable();
 
     pthread_mutex_lock(&bio_mutex[type]);
     /* Block SIGALRM so we are sure that only the main thread will

--- a/src/networking.c
+++ b/src/networking.c
@@ -2966,6 +2966,7 @@ void *IOThreadMain(void *myid) {
     snprintf(thdname, sizeof(thdname), "io_thd_%ld", id);
     redis_set_thread_title(thdname);
     redisSetCpuAffinity(server.server_cpulist);
+    makeThreadKillable();
 
     while(1) {
         /* Wait for start */

--- a/src/server.c
+++ b/src/server.c
@@ -2870,12 +2870,21 @@ void resetServerStats(void) {
     server.blocked_last_cron = 0;
 }
 
+/* Make the thread killable at any time, so that kill threads functions
+ * can work reliably (default cancelability type is PTHREAD_CANCEL_DEFERRED).
+ * Needed for pthread_cancel used by the fast memory test used by the crash report. */
+void makeThreadKillable(void) {
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+}
+
 void initServer(void) {
     int j;
 
     signal(SIGHUP, SIG_IGN);
     signal(SIGPIPE, SIG_IGN);
     setupSignalHandlers();
+    makeThreadKillable();
 
     if (server.syslog_enabled) {
         openlog(server.syslog_ident, LOG_PID | LOG_NDELAY | LOG_NOWAIT,

--- a/src/server.h
+++ b/src/server.h
@@ -2492,6 +2492,7 @@ int populateCommandTableParseFlags(struct redisCommand *c, char *strflags);
 void debugDelay(int usec);
 void killIOThreads(void);
 void killThreads(void);
+void makeThreadKillable(void);
 
 /* TLS stuff */
 void tlsInit(void);


### PR DESCRIPTION
When killThreads() is triggered, we should make sure that all others thread are killable and the cancellation requests should not be deferred.

The first commit can be cherry picked to elder version.