### PR TITLE
memory used by Lua is allocated and freed by zrealloc()/zfree()

### DIFF
--- a/deps/lua/src/lauxlib.c
+++ b/deps/lua/src/lauxlib.c
@@ -650,3 +650,9 @@ LUALIB_API lua_State *luaL_newstate (void) {
   return L;
 }
 
+LUALIB_API lua_State *luaL_newstate_with_alloc (lua_Alloc f) {
+  lua_State *L = lua_newstate(f, NULL);
+  if (L) lua_atpanic(L, &panic);
+  return L;
+}
+

--- a/deps/lua/src/lauxlib.h
+++ b/deps/lua/src/lauxlib.h
@@ -80,6 +80,7 @@ LUALIB_API int (luaL_loadbuffer) (lua_State *L, const char *buff, size_t sz,
 LUALIB_API int (luaL_loadstring) (lua_State *L, const char *s);
 
 LUALIB_API lua_State *(luaL_newstate) (void);
+LUALIB_API lua_State *(luaL_newstate_with_alloc) (lua_Alloc f);
 
 
 LUALIB_API const char *(luaL_gsub) (lua_State *L, const char *s, const char *p,

--- a/deps/lua/src/lua.h
+++ b/deps/lua/src/lua.h
@@ -284,7 +284,8 @@ LUA_API void lua_setallocf (lua_State *L, lua_Alloc f, void *ud);
 ** compatibility macros and functions
 */
 
-#define lua_open()	luaL_newstate()
+#define lua_open()             luaL_newstate()
+#define lua_open_with_alloc(f) luaL_newstate_with_alloc(f)
 
 #define lua_getregistry(L)	lua_pushvalue(L, LUA_REGISTRYINDEX)
 

--- a/src/object.c
+++ b/src/object.c
@@ -1012,6 +1012,10 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
             sdsZmallocSize(listNodeValue(listFirst(server.repl_scriptcache_fifo))));
     }
     mh->lua_caches = mem;
+
+    /* LUA memory is currently part of zmalloc_used, so we must accumulate it to
+     * mem_total in order to be able to calculate correct "used memory dataset" */
+    mem += (size_t)lua_gc(server.lua,LUA_GCCOUNT,0)*1024;
     mem_total+=mem;
 
     for (j = 0; j < server.dbnum; j++) {

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1077,6 +1077,17 @@ void scriptingEnableGlobalsProtection(lua_State *lua) {
     sdsfree(code);
 }
 
+static void *l_alloc (void *ud, void *ptr, size_t osize, size_t nsize) {
+  (void)ud;
+  (void)osize;
+  if (nsize == 0) {
+    zfree(ptr);
+    return NULL;
+  }
+  else
+    return zrealloc(ptr, nsize);
+}
+
 /* Initialize the scripting environment.
  *
  * This function is called the first time at server startup with
@@ -1088,7 +1099,7 @@ void scriptingEnableGlobalsProtection(lua_State *lua) {
  *
  * However it is simpler to just call scriptingReset() that does just that. */
 void scriptingInit(int setup) {
-    lua_State *lua = lua_open();
+    lua_State *lua = lua_open_with_alloc(l_alloc);
 
     if (setup) {
         server.lua_client = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -1852,11 +1852,7 @@ void cronUpdateMemoryStats() {
         /* in case the allocator isn't providing these stats, fake them so that
          * fragmentation info still shows some (inaccurate metrics) */
         if (!server.cron_malloc_stats.allocator_resident) {
-            /* LUA memory isn't part of zmalloc_used, but it is part of the process RSS,
-             * so we must deduct it in order to be able to calculate correct
-             * "allocator fragmentation" ratio */
-            size_t lua_memory = lua_gc(server.lua,LUA_GCCOUNT,0)*1024LL;
-            server.cron_malloc_stats.allocator_resident = server.cron_malloc_stats.process_rss - lua_memory;
+            server.cron_malloc_stats.allocator_resident = server.cron_malloc_stats.process_rss;
         }
         if (!server.cron_malloc_stats.allocator_active)
             server.cron_malloc_stats.allocator_active = server.cron_malloc_stats.allocator_resident;


### PR DESCRIPTION
We are tencent cloud redis team, recently some redis Instance takes up a lot of memory,  but user data takes up very little，we found that most of the memory was consumed by Lua. 

Currently Lua memory control does not pass through Redis’s zrealloc()\zfree(), Redis total memory cannot be effectively controlled when user maliciously uses Lua(maxmemory does not work), This will bring disaster to cloud vendors.

We want to allocate Lua’s memory through zmalloc as well, it helps to control the total memory consume of the Redis, In addition, Redis uses Jemalloc to better control the memory fragmentation rate

---

We loaded an RDB file with a little bit of user data, but a lot of Lua scripts:
![截屏2020-09-18 下午4 21 20](https://user-images.githubusercontent.com/11421972/93574481-0bcec900-f9cb-11ea-8ed9-689fc445e74e.png)

---

After Lua's memory control is pass zrealloc()\zfree(),  load the same RDB file,  the total memory consume is reduced(due to the use of Jemalloc, the memory fragmentation rate is reduced)

![截屏2020-09-18 下午4 27 15](https://user-images.githubusercontent.com/11421972/93575113-cf4f9d00-f9cb-11ea-87eb-038d21c02061.png)


