### PR TITLE
Fix C11 detection in the makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,7 @@ OPT=$(OPTIMIZATION)
 
 # Detect if the compiler supports C11 _Atomic
 C11_ATOMIC := $(shell sh -c 'echo "\#include <stdatomic.h>" > foo.c; \
-	$(CC) -std=c11 -c foo.c -o foo.o &> /dev/null; \
+	$(CC) -std=c11 -c foo.c -o foo.o > /dev/null 2>&1; \
 	if [ -f foo.o ]; then echo "yes"; rm foo.o; fi; rm foo.c')
 ifeq ($(C11_ATOMIC),yes)
 	STD+=-std=c11


### PR DESCRIPTION
445a4b6 introudced a makefile script that detects if the toolchain
supports c11, and it looked that it was passing on MacOS and fails on
Ubuntu, looks like Ubuntu's Dash was spawning a background process,
deleted foo.c before gcc tried to compile it.