### PR TITLE
Fix rdb_fsync_range if defined to sync_file_range.

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -112,7 +112,7 @@
 #endif
 
 #ifdef HAVE_SYNC_FILE_RANGE
-#define rdb_fsync_range(fd,off,size) sync_file_range(fd,off,size,SYNC_FILE_RANGE_WAIT_BEFORE|SYNC_FILE_RANGE_WRITE)
+#define rdb_fsync_range(fd,off,size) sync_file_range(fd,off,size,SYNC_FILE_RANGE_WAIT_BEFORE|SYNC_FILE_RANGE_WRITE|SYNC_FILE_RANGE_WAIT_AFTER)
 #else
 #define rdb_fsync_range(fd,off,size) fsync(fd)
 #endif


### PR DESCRIPTION
According to `Linux Programmer's Manual`([sync_file_range(2)](https://man7.org/linux/man-pages/man2/sync_file_range.2.html)):

SYNC_FILE_RANGE_WAIT_BEFORE | SYNC_FILE_RANGE_WRITE
	Ensures that all pages in the specified range which were dirty when
	sync_file_range() was called are placed under write-out.  This is
	a start-write-for-data-integrity operation.

SYNC_FILE_RANGE_WAIT_BEFORE | SYNC_FILE_RANGE_WRITE | SYNC_FILE_RANGE_WAIT_AFTER
	This is a write-for-data-integrity operation that will ensure that all
	pages in the specified range which were dirty when sync_file_range() was
	called are committed to disk.

We change `SYNC_FILE_RANGE_WAIT_BEFORE | SYNC_FILE_RANGE_WRITE` to
`SYNC_FILE_RANGE_WAIT_BEFORE | SYNC_FILE_RANGE_WRITE | SYNC_FILE_RANGE_WAIT_AFTER`
in this commit to ensure that data in the specified range are committed
to dist when we call sync_file_range().

Fixes #5199