### PR TITLE
warning: comparison between signed and unsigned integer in 32bit build

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -768,10 +768,10 @@ unsigned char *lpSeek(unsigned char *lp, long index) {
     if (numele != LP_HDR_NUMELE_UNKNOWN) {
         if (index < 0) index = (long)numele+index;
         if (index < 0) return NULL; /* Index still < 0 means out of range. */
-        if (index >= numele) return NULL; /* Out of range the other side. */
+        if ((long)index >= numele) return NULL; /* Out of range the other side. */
         /* We want to scan right-to-left if the element we are looking for
          * is past the half of the listpack. */
-        if (index > numele/2) {
+        if ((long)index > numele/2) {
             forward = 0;
             /* Right to left scanning always expects a negative index. Convert
              * our index to negative form. */


### PR DESCRIPTION
`numele` can't be more than 65k, and we already know `index` is non-negative from an earlier check