### PR TITLE
redis-cli add control on raw format line delimiter

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1242,7 +1242,7 @@ static sds cliFormatReply(redisReply *reply, int mode, int verbatim) {
         out = cliFormatReplyTTY(reply, "");
     } else if (mode == OUTPUT_RAW) {
         out = cliFormatReplyRaw(reply);
-        out = sdscatlen(out, config.raw_delim, sdslen(config.raw_delim));
+        out = sdscatsds(out, config.raw_delim);
     } else if (mode == OUTPUT_CSV) {
         out = cliFormatReplyCSV(reply);
         out = sdscatlen(out, "\n", 1);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1236,7 +1236,6 @@ static sds cliFormatReply(redisReply *reply, int mode, int verbatim) {
         out = cliFormatReplyTTY(reply, "");
     } else if (mode == OUTPUT_RAW) {
         out = cliFormatReplyRaw(reply);
-        out = sdscatlen(out, "\n", 1);
     } else if (mode == OUTPUT_CSV) {
         out = cliFormatReplyCSV(reply);
         out = sdscatlen(out, "\n", 1);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1816,8 +1816,8 @@ static void usage(void) {
 "  -n <db>            Database number.\n"
 "  -3                 Start session in RESP3 protocol mode.\n"
 "  -x                 Read last argument from STDIN.\n"
-"  -d <delimiter>     Multi-bulk delimiter in for raw formatting (default: \\n).\n"
-"  -D <delimiter>     Raw response new-line delimiter in for raw formatting (default: \\n).\n"
+"  -d <delimiter>     Delimiter between response bulks for raw formatting (default: \\n).\n"
+"  -D <delimiter>     Delimiter between responses for raw formatting (default: \\n).\n"
 "  -c                 Enable cluster mode (follow -ASK and -MOVED redirections).\n"
 #ifdef USE_OPENSSL
 "  --tls              Establish a secure TLS connection.\n"


### PR DESCRIPTION
Hi
This PR handles raw formatting unwanted addition line drop from redis-cli. This cuases the retrived raw data to become unusable as it has additional line drop symbol. Causes issue https://github.com/RedisAI/RedisAI/issues/458