### PR TITLE
Don't support Gopher if enable io threads to read queries

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1538,10 +1538,11 @@ notify-keyspace-events ""
 #
 # So use the 'requirepass' option to protect your instance.
 #
+# Note that Ghopher is not currently supported when 'io-threads-do-reads'
+# is enabled.
+#
 # To enable Gopher support, uncomment the following line and set the option
-# from no (the default) to yes. What's more, you must set 'io-threads-do-reads'
-# to no (the default) to avoid data race in Gopher handler, otherwise,
-# Redis will not support Gopher.
+# from no (the default) to yes.
 #
 # gopher-enabled no
 
@@ -1881,4 +1882,3 @@ jemalloc-bg-thread yes
 #
 # Set bgsave child process to cpu affinity 1,10,11
 # bgsave_cpulist 1,10-11
-

--- a/redis.conf
+++ b/redis.conf
@@ -1538,7 +1538,7 @@ notify-keyspace-events ""
 #
 # So use the 'requirepass' option to protect your instance.
 #
-# Note that Ghopher is not currently supported when 'io-threads-do-reads'
+# Note that Gopher is not currently supported when 'io-threads-do-reads'
 # is enabled.
 #
 # To enable Gopher support, uncomment the following line and set the option

--- a/redis.conf
+++ b/redis.conf
@@ -1538,8 +1538,10 @@ notify-keyspace-events ""
 #
 # So use the 'requirepass' option to protect your instance.
 #
-# To enable Gopher support uncomment the following line and set
-# the option from no (the default) to yes.
+# To enable Gopher support, uncomment the following line and set the option
+# from no (the default) to yes. What's more, you must set 'io-threads-do-reads'
+# to no (the default) to avoid data race in Gopher handler, otherwise,
+# Redis will not support Gopher.
 #
 # gopher-enabled no
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1919,8 +1919,9 @@ void processInputBuffer(client *c) {
         if (c->reqtype == PROTO_REQ_INLINE) {
             if (processInlineBuffer(c) != C_OK) break;
             /* If the Gopher mode and we got zero or one argument, process
-             * the request in Gopher mode. */
-            if (server.gopher_enabled &&
+             * the request in Gopher mode. To avoid data race, Redis won't
+             * support Gopher if enable io threads to read queries. */
+            if (server.gopher_enabled && !server.io_threads_do_reads &&
                 ((c->argc == 1 && ((char*)(c->argv[0]->ptr))[0] == '/') ||
                   c->argc == 0))
             {


### PR DESCRIPTION
Fix #7779 
If you enable Gopher, you also must disable 'io-threads-do-reads' to avoid data race in Gopher handler, otherwise, Redis will 
not support Gopher.