### PR TITLE
Add GET parameter to SET command

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -44,9 +44,9 @@ static int checkStringLength(client *c, long long size) {
 
 /* The setGenericCommand() function implements the SET operation with different
  * options and variants. This function is called in order to implement the
- * following commands: SET, SETEX, PSETEX, SETNX.
+ * following commands: SET, SETEX, PSETEX, SETNX, GETSET.
  *
- * 'flags' changes the behavior of the command (NX or XX, see below).
+ * 'flags' changes the behavior of the command (NX, XX or GET, see below).
  *
  * 'expire' represents an expire to set in form of a Redis object as passed
  * by the user. It is interpreted according to the specified 'unit'.
@@ -64,6 +64,7 @@ static int checkStringLength(client *c, long long size) {
 #define OBJ_SET_EX (1<<2)          /* Set if time in seconds is given */
 #define OBJ_SET_PX (1<<3)          /* Set if time in ms in given */
 #define OBJ_SET_KEEPTTL (1<<4)     /* Set and keep the ttl */
+#define OBJ_SET_GET (1<<5)         /* Set if want to get key before set */
 
 void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire, int unit, robj *ok_reply, robj *abort_reply) {
     long long milliseconds = 0; /* initialized to avoid any harmness warning */
@@ -84,16 +85,23 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
         addReply(c, abort_reply ? abort_reply : shared.null[c->resp]);
         return;
     }
+
+    if (flags & OBJ_SET_GET) {
+       getGenericCommand(c);
+    }
+
     genericSetKey(c,c->db,key,val,flags & OBJ_SET_KEEPTTL,1);
     server.dirty++;
     if (expire) setExpire(c,c->db,key,mstime()+milliseconds);
     notifyKeyspaceEvent(NOTIFY_STRING,"set",key,c->db->id);
     if (expire) notifyKeyspaceEvent(NOTIFY_GENERIC,
         "expire",key,c->db->id);
-    addReply(c, ok_reply ? ok_reply : shared.ok);
+    if (!(flags & OBJ_SET_GET)) {
+        addReply(c, ok_reply ? ok_reply : shared.ok);
+    }
 }
 
-/* SET key value [NX] [XX] [KEEPTTL] [EX <seconds>] [PX <milliseconds>] */
+/* SET key value [NX] [XX] [KEEPTTL] [GET] [EX <seconds>] [PX <milliseconds>] */
 void setCommand(client *c) {
     int j;
     robj *expire = NULL;
@@ -106,7 +114,7 @@ void setCommand(client *c) {
 
         if ((a[0] == 'n' || a[0] == 'N') &&
             (a[1] == 'x' || a[1] == 'X') && a[2] == '\0' &&
-            !(flags & OBJ_SET_XX))
+            !(flags & OBJ_SET_XX) && !(flags & OBJ_SET_GET))
         {
             flags |= OBJ_SET_NX;
         } else if ((a[0] == 'x' || a[0] == 'X') &&
@@ -114,6 +122,11 @@ void setCommand(client *c) {
                    !(flags & OBJ_SET_NX))
         {
             flags |= OBJ_SET_XX;
+        } else if ((a[0] == 'g' || a[0] == 'G') &&
+                   (a[1] == 'e' || a[1] == 'E') &&
+                   (a[2] == 't' || a[2] == 'T') && a[3] == '\0' &&
+                   !(flags & OBJ_SET_NX)) {
+            flags |= OBJ_SET_GET;
         } else if (!strcasecmp(c->argv[j]->ptr,"KEEPTTL") &&
                    !(flags & OBJ_SET_EX) && !(flags & OBJ_SET_PX))
         {

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -394,6 +394,27 @@ start_server {tags {"string"}} {
         list $v1 $v2 [r get foo]
     } {{} OK 2}
 
+    test {Extended SET GET option} {
+        r del foo
+        r set foo bar
+        set old_value [r set foo bar2 GET]
+        set new_value [r get foo]
+        list $old_value $new_value
+    } {bar bar2}
+
+    test {Extended SET GET option with no previous value} {
+        r del foo
+        set old_value [r set foo bar GET]
+        set new_value [r get foo]
+        list $old_value $new_value
+    } {{} bar}
+
+    test {Extended SET GET with NX option should result in syntax err} {
+      catch {r set foo bar NX GET} err1
+      catch {r set foo bar NX GET} err2
+      list $err1 $err2
+    } {*syntax err* *syntax err*}
+
     test {Extended SET EX option} {
         r del foo
         r set foo bar ex 10


### PR DESCRIPTION
Closes #2349

Add optional GET parameter to SET command in order to set a new value to
a key and retrieve the old key value. With this change we can deprecate
`GETSET` command and use only the SET command with the GET parameter.

@oranagra 