### PR TITLE
support sentinel myid subcommand

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3050,6 +3050,7 @@ void sentinelCommand(client *c) {
 "MASTER <master-name> -- Show the state and info of the specified master.",
 "REPLICAS <master-name> -- Show a list of replicas for this master and their state.",
 "SENTINELS <master-name> -- Show a list of Sentinel instances for this master and their state.",
+"MYID -- Show Current Sentinel Id",
 "IS-MASTER-DOWN-BY-ADDR <ip> <port> <current-epoch> <runid> -- Check if the master specified by ip:port is down from current Sentinel's point of view.",
 "GET-MASTER-ADDR-BY-NAME <master-name> -- Return the ip and port number of the master with that name.",
 "RESET <pattern> -- Reset masters for specific master name matching this pattern.",
@@ -3097,6 +3098,9 @@ NULL
         if ((ri = sentinelGetMasterByNameOrReplyError(c,c->argv[2])) == NULL)
             return;
         addReplyDictOfRedisInstances(c,ri->sentinels);
+    } else if (!strcasecmp(c->argv[1]->ptr,"myid") && c->argc == 2) {
+        /* SENTINEL MYID */
+        addReplyBulkCBuffer(c,sentinel.myid,CONFIG_RUN_ID_SIZE);
     } else if (!strcasecmp(c->argv[1]->ptr,"is-master-down-by-addr")) {
         /* SENTINEL IS-MASTER-DOWN-BY-ADDR <ip> <port> <current-epoch> <runid>
          *


### PR DESCRIPTION
This commit provides a fast way to get current sentinel id. Similar to Cluster myid subcommand. Currently there is no good way to get current sentinel id, other than jumping to the top of sentinel run log file when sentinel starts.  Getting sentinel id would be helpful when analysing sentinel behaviour in logs, such as:

1958:X 15 Apr 19:36:46.426 # +try-failover master redisroute144200262587 10.133.0.56 6379
1958:X 15 Apr 19:36:46.430 # +vote-for-leader b7b5e68f89e1593427afde670b7c1ff5bc1fbe8f 14
1958:X 15 Apr 19:36:46.440 # 24f3ea9e48876738c8ed52a3f2fe5f0f9d9fdd81 voted for b7b5e68f89e1593427afde670b7c1ff5bc1fbe8f 14