### PR TITLE
Include internal sds fragmentation in MEMORY reporting

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1626,7 +1626,7 @@ int clientsCronTrackClientsMemUsage(client *c) {
     size_t mem = 0;
     int type = getClientType(c);
     mem += getClientOutputBufferMemoryUsage(c);
-    mem += sdsAllocSize(c->querybuf);
+    mem += sdsZmallocSize(c->querybuf);
     mem += sizeof(client);
     /* Now that we have the memory used by the client, remove the old
      * value from the old category, and add it back. */


### PR DESCRIPTION
The MEMORY command is used for debugging memory usage, so it should include internal
fragmentation, same as used_memory

This PR is a portion of https://github.com/redis/redis/pull/5159