### PR TITLE
Fixed Tracking test “The other connection is able to get invalidations”

### DIFF
--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -16,9 +16,10 @@ start_server {tags {"tracking"}} {
 
     test {The other connection is able to get invalidations} {
         r SET a 1
+        r SET b 1
         r GET a
-        r INCR a
-        r INCR b ; # This key should not be notified, since it wasn't fetched.
+        r INCR b ; # This key should not be notified, since it wasn't fetched. 
+        r INCR a 
         set keys [lindex [$rd1 read] 2]
         assert {[llength $keys] == 1}
         assert {[lindex $keys 0] eq {a}}


### PR DESCRIPTION
PROBLEM:

[$rd1 read] reads invalidation messages one by one, so it's never going to see the second invalidation message produced after INCR b, whether or not it exists. Adding another read will block incase no invalidation message is produced.

FIX:

We switch the order of "INCR a" and "INCR b" - now "INCR b" comes first. We still only read the first invalidation message produces. If an invalidation message is wrongly produces for b - then it will be produced before that of a, since "INCR b" comes before "INCR a".