### PR TITLE
fix default user password config when loading from acl file

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1291,7 +1291,12 @@ sds ACLLoadFromFile(const char *filename) {
     user *old_default_user = DefaultUser;
     Users = raxNew();
     ACLInitDefaultUser();
-
+    /* Set password for default user. */
+    if (server.requirepass) {
+        sds aclop = sdscatprintf(sdsempty(),">%s",server.requirepass);
+        ACLSetUser(DefaultUser,aclop,sdslen(aclop));
+        sdsfree(aclop);
+    }
     /* Load each line of the file. */
     for (int i = 0; i < totlines; i++) {
         sds *argv;


### PR DESCRIPTION
Before this commit, when configuring redis using acl file, the requirepass of default user will be ignored, for example:

in redis.conf file if we configure:
aclfile /etc/redis/users.acl
requirepass foobar

when server starts the default user password was set to empty, this was not expected behaviour:

127.0.0.1:6379> acl list
1) "user default on nopass ~* +@all"
2) "user frank on #2d9c75273d72b32df726fb545c8a4edc719f0a95a6fd993950b10c474ad9c927 ~cached:* -@all +acl"

This commit make sure the requirepass will take effect when acl file was used, so after the changes, default user password wil l be set if requirepass was configured.