### PR TITLE
ACL : mentioning requirepass and aclfile not compatable in redis conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -798,6 +798,9 @@ acllog-max-len 128
 # AUTH <password> as usually, or more explicitly with AUTH default <password>
 # if they follow the new protocol: both will work.
 #
+# The requirepass is not compatable with aclfile option and the ACL LOAD
+# command, these will cause requirepass to be ignored.
+#
 # requirepass foobared
 
 # Command renaming (DEPRECATED).


### PR DESCRIPTION
as discussed in https://github.com/redis/redis/pull/7873, we need to mention two configs requirepass and aclfile are not compatable in order to avoid the confusion for users. 