### PR TITLE
Fixed excessive categories being displayed from acls

### DIFF
--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -135,6 +135,20 @@ start_server {tags {"acl"}} {
         assert_match {*+acl*} $cmdstr
     }
 
+    # A regression test make sure that as long as there is a simple
+    # category defining the commands, that it will be used as is.
+    test {ACL GETUSER provides reasonable results} {
+        # Test for future commands where allowed
+        r ACL setuser additive reset +@all -@write
+        set cmdstr [dict get [r ACL getuser additive] commands]
+        assert_match {+@all -@write} $cmdstr
+
+        # Test for future commands are disallowed
+        r ACL setuser subtractive reset -@all +@read
+        set cmdstr [dict get [r ACL getuser subtractive] commands]
+        assert_match {-@all +@read} $cmdstr
+    }
+
     test {ACL #5998 regression: memory leaks adding / removing subcommands} {
         r AUTH default ""
         r ACL setuser newuser reset -debug +debug|a +debug|b +debug|c


### PR DESCRIPTION
When there are multiple categories that fix the criteria of "more than half of the commands are in this group, either by inclusion or exclusion," we include all of them. This can result in overlapping categories that require a lot of re-adding or re-removing. For example:

"-@all +@read" -> "-@all +@read +@set +@sortedset +@hash +@bitmap +@geo -sdiffstore -hmset -setbit -hsetnx -zremrangebyscore -zpopmax -spop -sort -zpopmin -hset -georadiusbymember -zremrangebylex -geoadd -sunionstore -bitfield -bzpopmin -sadd -zadd -hdel -zunionstore -bitop -zinterstore -bzpopmax -hincrby -sinterstore -zremrangebyrank -zrem -smove -zincrby -srem -hincrbyfloat -georadius"

Since the set, sortedset, hash, bitmap, and geo categories have a majority of read commands, they all get included, but then need all their write to be removed. 

We still might not build the "optimal" string, but we should only build shorter strings after this change. 