### PR TITLE
Add some additional signal info to the crash log

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1725,7 +1725,7 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     bugReportStart();
     serverLog(LL_WARNING,
         "Redis %s crashed by signal: %d, si_code: %d", REDIS_VERSION, sig, info->si_code);
-    if (sig == SIGSEGV || sig == SIGBUS || sig == SIGFPE) {
+    if (sig == SIGSEGV || sig == SIGBUS) {
         serverLog(LL_WARNING,
         "Accessing address: %p", (void*)info->si_addr);
     }

--- a/src/debug.c
+++ b/src/debug.c
@@ -1724,10 +1724,13 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
 
     bugReportStart();
     serverLog(LL_WARNING,
-        "Redis %s crashed by signal: %d", REDIS_VERSION, sig);
-    if (sig == SIGSEGV || sig == SIGBUS) {
+        "Redis %s crashed by signal: %d, si_code: %d", REDIS_VERSION, sig, info->si_code);
+    if (sig == SIGSEGV || sig == SIGBUS || sig == SIGFPE) {
         serverLog(LL_WARNING,
         "Accessing address: %p", (void*)info->si_addr);
+    }
+    if (info->si_pid != -1) {
+        serverLog(LL_WARNING, "Killed by PID: %d, UID: %d", info->si_pid, info->si_uid);
     }
 
 #ifdef HAVE_BACKTRACE


### PR DESCRIPTION
1. si_code can be very useful info some day.
2. a clear indication that redis was killed by an external user