### PR TITLE
Modules: fix RM_GetCommandKeys API.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -7943,13 +7943,13 @@ int RM_ModuleTypeReplaceValue(RedisModuleKey *key, moduleType *mt, void *new_val
  * get automatically freed even when auto-memory is used. The caller
  * must explicitly call RM_Free() to free it.
  */
-int *RM_GetCommandKeys(RedisModuleCtx *ctx, const char *cmdname, RedisModuleString **argv, int argc, int *num_keys) {
+int *RM_GetCommandKeys(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *num_keys) {
     UNUSED(ctx);
     struct redisCommand *cmd;
     int *res = NULL;
 
     /* Find command */
-    if ((cmd = lookupCommandByCString(cmdname)) == NULL) {
+    if ((cmd = lookupCommand(argv[0]->ptr)) == NULL) {
         errno = ENOENT;
         return NULL;
     }

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -728,7 +728,7 @@ REDISMODULE_API int (*RedisModule_AuthenticateClientWithACLUser)(RedisModuleCtx 
 REDISMODULE_API int (*RedisModule_AuthenticateClientWithUser)(RedisModuleCtx *ctx, RedisModuleUser *user, RedisModuleUserChangedFunc callback, void *privdata, uint64_t *client_id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_DeauthenticateAndCloseClient)(RedisModuleCtx *ctx, uint64_t client_id) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_GetClientCertificate)(RedisModuleCtx *ctx, uint64_t id) REDISMODULE_ATTR;
-REDISMODULE_API int *(*RedisModule_GetCommandKeys)(RedisModuleCtx *ctx, const char *cmdname, RedisModuleString **argv, int argc, int *num_keys) REDISMODULE_ATTR;
+REDISMODULE_API int *(*RedisModule_GetCommandKeys)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *num_keys) REDISMODULE_ATTR;
 #endif
 
 #define RedisModule_IsAOFClient(id) ((id) == CLIENT_ID_AOF)

--- a/tests/modules/getkeys.c
+++ b/tests/modules/getkeys.c
@@ -69,11 +69,8 @@ int getkeys_introspect(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         return REDISMODULE_OK;
     }
 
-    size_t cmd_len;
-    const char *cmd = RedisModule_StringPtrLen(argv[1], &cmd_len);
-
     int num_keys;
-    int *keyidx = RedisModule_GetCommandKeys(ctx, cmd, &argv[1], argc - 1, &num_keys);
+    int *keyidx = RedisModule_GetCommandKeys(ctx, &argv[1], argc - 1, &num_keys);
 
     if (!keyidx) {
         if (!errno)


### PR DESCRIPTION
This cleans up and simplifies the API by passing the command name as the
first argument. Previously the command name was specified explicitly,
but was still included in the argv.