### PR TITLE
Send RDB by a separate thread when full synchronization

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -88,15 +88,10 @@ void lazyfreeFreeObjectFromBioThread(robj *o);
 void lazyfreeFreeDatabaseFromBioThread(dict *ht1, dict *ht2);
 void lazyfreeFreeSlotsMapFromBioThread(rax *rt);
 
-/* Make sure we have enough stack to perform all the things we do in the
- * main thread. */
-#define REDIS_THREAD_STACK_SIZE (1024*1024*4)
-
 /* Initialize the background system, spawning the thread. */
 void bioInit(void) {
     pthread_attr_t attr;
     pthread_t thread;
-    size_t stacksize;
     int j;
 
     /* Initialization of state vars and objects */
@@ -108,12 +103,7 @@ void bioInit(void) {
         bio_pending[j] = 0;
     }
 
-    /* Set the stack size as by default it may be small in some system */
-    pthread_attr_init(&attr);
-    pthread_attr_getstacksize(&attr,&stacksize);
-    if (!stacksize) stacksize = 1; /* The world is full of Solaris Fixes */
-    while (stacksize < REDIS_THREAD_STACK_SIZE) stacksize *= 2;
-    pthread_attr_setstacksize(&attr, stacksize);
+    setPthreadAttrStacksize(&attr);
 
     /* Ready to spawn our threads. We use the single argument the thread
      * function accepts in order to pass the job ID the thread is
@@ -145,7 +135,6 @@ void bioCreateBackgroundJob(int type, void *arg1, void *arg2, void *arg3) {
 void *bioProcessBackgroundJobs(void *arg) {
     struct bio_job *job;
     unsigned long type = (unsigned long) arg;
-    sigset_t sigset;
 
     /* Check that the type is within the right interval. */
     if (type >= BIO_NUM_OPS) {
@@ -173,9 +162,7 @@ void *bioProcessBackgroundJobs(void *arg) {
     pthread_mutex_lock(&bio_mutex[type]);
     /* Block SIGALRM so we are sure that only the main thread will
      * receive the watchdog signal. */
-    sigemptyset(&sigset);
-    sigaddset(&sigset, SIGALRM);
-    if (pthread_sigmask(SIG_BLOCK, &sigset, NULL))
+    if (blockThreadSigalrm())
         serverLog(LL_WARNING,
             "Warning: can't mask SIGALRM in bio.c thread: %s", strerror(errno));
 

--- a/src/config.c
+++ b/src/config.c
@@ -2334,6 +2334,7 @@ standardConfig configs[] = {
     createStringConfig("bio_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.bio_cpulist, NULL, NULL, NULL),
     createStringConfig("aof_rewrite_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.aof_rewrite_cpulist, NULL, NULL, NULL),
     createStringConfig("bgsave_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.bgsave_cpulist, NULL, NULL, NULL),
+    createStringConfig("send_rdb_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.send_rdb_cpulist, NULL, NULL, NULL),
 
     /* Enum Configs */
     createEnumConfig("supervised", NULL, IMMUTABLE_CONFIG, supervised_mode_enum, server.supervised_mode, SUPERVISED_NONE, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -2295,6 +2295,7 @@ standardConfig configs[] = {
     createBoolConfig("crash-memcheck-enabled", NULL, MODIFIABLE_CONFIG, server.memcheck_enabled, 1, NULL, NULL),
     createBoolConfig("use-exit-on-panic", NULL, MODIFIABLE_CONFIG, server.use_exit_on_panic, 0, NULL, NULL),
     createBoolConfig("oom-score-adj", NULL, MODIFIABLE_CONFIG, server.oom_score_adj, 0, NULL, updateOOMScoreAdj),
+    createBoolConfig("send-rdb-by-thread", NULL, MODIFIABLE_CONFIG, server.send_rdb_by_thread, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),
@@ -2353,6 +2354,7 @@ standardConfig configs[] = {
     createIntConfig("hz", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.config_hz, CONFIG_DEFAULT_HZ, INTEGER_CONFIG, NULL, updateHZ),
     createIntConfig("min-replicas-to-write", "min-slaves-to-write", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_to_write, 0, INTEGER_CONFIG, NULL, updateGoodSlaves),
     createIntConfig("min-replicas-max-lag", "min-slaves-max-lag", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_max_lag, 10, INTEGER_CONFIG, NULL, updateGoodSlaves),
+    createIntConfig("rdb-bulk-send-delay", NULL, IMMUTABLE_CONFIG, INT_MIN, INT_MAX, server.rdb_bulk_send_delay, 0, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),

--- a/src/config.h
+++ b/src/config.h
@@ -138,6 +138,12 @@ void setproctitle(const char *fmt, ...);
 /* Byte ordering detection */
 #include <sys/types.h> /* This will likely define BYTE_ORDER */
 
+/* Define redis_sendfile. */
+#if defined(__linux__) || (defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_5))
+#define HAVE_SENDFILE 1
+#endif
+ssize_t redis_sendfile(int out_fd, int in_fd, off_t offset, size_t count);
+
 #ifndef BYTE_ORDER
 #if (BSD >= 199103)
 # include <machine/endian.h>

--- a/src/replication.c
+++ b/src/replication.c
@@ -1113,7 +1113,7 @@ void *sendRDBToSlaveThread(void *arg) {
         (unsigned long long)slave->id & 0xFFFF);
     thdname[sizeof(thdname) - 1] = '\0';
     redis_set_thread_title(thdname);
-    redisSetCpuAffinity(server.server_cpulist);
+    redisSetCpuAffinity(server.send_rdb_cpulist);
 
     /* Block SIGALRM for sending RDB thread, so it will not receive the
      * watchdog signal, since thera are many blocking I/O operations. */

--- a/src/server.c
+++ b/src/server.c
@@ -2485,7 +2485,8 @@ void initServerConfig(void) {
     server.repl_syncio_timeout = CONFIG_REPL_SYNCIO_TIMEOUT;
     server.repl_down_since = 0; /* Never connected, repl is down since EVER. */
     server.master_repl_offset = 0;
-    server.send_rdb_by_thread = 0;
+    server.send_rdb_max_threads = 0;
+    server.send_rdb_active_threads = 0;
 
     /* Replication partial resync backlog */
     server.repl_backlog = NULL;
@@ -4280,7 +4281,8 @@ sds genRedisInfoString(const char *section) {
             "lru_clock:%u\r\n"
             "executable:%s\r\n"
             "config_file:%s\r\n"
-            "io_threads_active:%i\r\n",
+            "io_threads_active:%i\r\n"
+            "send_rdb_active_threads:%i\r\n",
             REDIS_VERSION,
             redisGitSHA1(),
             strtol(redisGitDirty(),NULL,10) > 0,
@@ -4305,7 +4307,8 @@ sds genRedisInfoString(const char *section) {
             lruclock,
             server.executable ? server.executable : "",
             server.configfile ? server.configfile : "",
-            server.io_threads_active);
+            server.io_threads_active,
+            server.send_rdb_active_threads);
     }
 
     /* Clients */

--- a/src/server.h
+++ b/src/server.h
@@ -878,7 +878,7 @@ typedef struct client {
     /* Response buffer */
     int bufpos;
     char buf[PROTO_REPLY_CHUNK_BYTES];
-    pthread_t send_db_thread; /* The thread of Sending RDB to replica. */
+    pthread_t send_db_thread; /* The thread of sending RDB to replica. */
     redisAtomic int thread_send_db_state; /* State of sending RDB. */
 } client;
 
@@ -1333,7 +1333,8 @@ struct redisServer {
     int repl_diskless_load;         /* Slave parse RDB directly from the socket.
                                      * see REPL_DISKLESS_LOAD_* enum */
     int repl_diskless_sync_delay;   /* Delay to start a diskless repl BGSAVE. */
-    int send_rdb_by_thread;         /* Send RDB file by thread when full disk-based sync. */
+    int send_rdb_max_threads;       /* Max thread number used for sending RDB. */
+    int send_rdb_active_threads;    /* Active thread number used for sending RDB. */
     int rdb_bulk_send_delay;        /* Delay in microseconds between bulks while
                                      * send the RDB file. (for testings). negative
                                      * value means fractions of microsecons (on average). */

--- a/src/server.h
+++ b/src/server.h
@@ -1497,6 +1497,7 @@ struct redisServer {
     char *bio_cpulist; /* cpu affinity list of bio thread. */
     char *aof_rewrite_cpulist; /* cpu affinity list of aof rewrite process. */
     char *bgsave_cpulist; /* cpu affinity list of bgsave process. */
+    char *send_rdb_cpulist; /* cpu affinity list of send rdb threads. */
 };
 
 typedef struct pubsubPattern {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -103,6 +103,7 @@ start_server {tags {"introspection"}} {
             bio_cpulist
             aof_rewrite_cpulist
             bgsave_cpulist
+            send_rdb_cpulist
         }
 
         if {!$::tls} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -93,6 +93,7 @@ start_server {tags {"introspection"}} {
             port
             tls-port
             io-threads
+            rdb-bulk-send-delay
             logfile
             unixsocketperm
             slaveof


### PR DESCRIPTION
As we know, master has heavy load when sends RDB file to replicas in disk-based mode during full synchronization, and more replicas more heavier. What's more, I find master has much heavy load if replicas come from the same machine, i think, the local back network has high speed and event loops are constantly triggered on master. So during full synchronization in disk-based mode, master has low ability to handle clients's requests.

I implement a way to send RDB file by a separate thread, and one thread is used for one replica, the thread handles the job of sending RDB to replica. In my implementation, actually, the thread just is like `sendBulkToSlave` function. Create a thread when master needs to send RDB and release it when finishes sending RDB. I don't find latency to create and join threads though it  is not beautiful to create threads when we need rather than creating them when server starts. But I think this way is much easy.

I also implement blocking `redis_sendfile` to send RDB file on Linux and macOS, it can exactly reduce CPU usage and may lessen RDB transfer time if on high speed network.