### PR TITLE
Use the extra bits in the flags for len/alloc.

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -118,12 +118,11 @@ sds sdsnewlen(const void *init, size_t initlen) {
     else if (!init)
         memset(sh, 0, hdrlen+initlen+1);
     s = (char*)sh+hdrlen;
-    fp = ((unsigned char*)s)-1;
     usable = usable-hdrlen-1;
     if (usable > sdsTypeMaxSize(type))
         usable = sdsTypeMaxSize(type);
 
-    *fp = type;
+    sdssettype(s, type);
     sdssetlen(s,initlen);
     sdssetalloc(s, usable);
 
@@ -229,7 +228,7 @@ sds sdsMakeRoomFor(sds s, size_t addlen) {
         memcpy((char*)newsh+hdrlen, s, len+1);
         s_free(sh);
         s = (char*)newsh+hdrlen;
-        s[-1] = type;
+        sdssettype(s, type);
         sdssetlen(s, len);
     }
     usable = usable-hdrlen-1;
@@ -275,7 +274,7 @@ sds sdsRemoveFreeSpace(sds s) {
         memcpy((char*)newsh+hdrlen, s, len+1);
         s_free(sh);
         s = (char*)newsh+hdrlen;
-        s[-1] = type;
+        sdssettype(s, type);
         sdssetlen(s, len);
     }
     sdssetalloc(s, len);

--- a/src/sds.h
+++ b/src/sds.h
@@ -236,6 +236,12 @@ static inline void sdssetallocextrabit(sds s, size_t value) {
     }
 }
 
+static inline void sdssettype(sds s, char type) {
+    unsigned char *fp = ((unsigned char*)s)-1;
+    *fp &= type;
+    *fp |= type;
+}
+
 static inline void sdssetlen(sds s, size_t newlen) {
     unsigned char flags = s[-1];
     switch(flags&SDS_TYPE_MASK) {

--- a/src/sds.h
+++ b/src/sds.h
@@ -83,11 +83,11 @@ struct __attribute__ ((__packed__)) sdshdr64 {
 #define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = (void*)((s)-(sizeof(struct sdshdr##T)));
 #define SDS_HDR(T,s) ((struct sdshdr##T *)((s)-(sizeof(struct sdshdr##T))))
 #define SDS_TYPE_5_LEN(f) ((f)>>SDS_TYPE_BITS)
-#define SDS_LSB_4_5_MASK (4ll << 4) // 56x0_0011_4x0
-#define SDS_LSB_6_7_MASK (4ll << 6) // 56x0_1100_4x0
-#define SDS_LSB_8_9_MASK (4ll << 8) // 52x0_0011_8x0
-#define SDS_LSB_16_17_MASK (4ll << 16) // 40x0_0011_16x0
-#define SDS_LSB_32_33_MASK (4ll << 32) // 24x0_0011_32x0
+#define SDS_LSB_4_5_MASK (3ll << 4) // 56x0_0011_4x0
+#define SDS_LSB_6_7_MASK (3ll << 6) // 56x0_1100_4x0
+#define SDS_LSB_8_9_MASK (3ll << 8) // 52x0_0011_8x0
+#define SDS_LSB_16_17_MASK (3ll << 16) // 40x0_0011_16x0
+#define SDS_LSB_32_33_MASK (3ll << 32) // 24x0_0011_32x0
 
 // Returns the low extra bit masked by SDS_FLAGS_0_1_MSB_MASK
 static inline size_t sdslenextra(const sds s) {


### PR DESCRIPTION
Implementation notes:

1. For sds(len/setlen/etc) methods, we technically do not need to mask the for the extra bits whenever we
we want to shift the given value because the caller of all of these functions should have guaranteed that
the given `size_t` does not exceed what the current SDS_TYPE_* can handle.

2. I think this is all that needs to be done. There might be edge cases where code is accessing the values directly?

Edit: Getting connection refused error for tests. Is that me? :V

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>