### PR TITLE
Remove temporary aof and rdb files in a background thread

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1703,10 +1703,10 @@ void aofRemoveTempFile(pid_t childpid) {
     char tmpfile[256];
 
     snprintf(tmpfile,256,"temp-rewriteaof-bg-%d.aof", (int) childpid);
-    unlink(tmpfile);
+    bg_unlink(tmpfile);
 
     snprintf(tmpfile,256,"temp-rewriteaof-%d.aof", (int) childpid);
-    unlink(tmpfile);
+    bg_unlink(tmpfile);
 }
 
 /* Update the server.aof_current_size field explicitly using stat(2)

--- a/src/replication.c
+++ b/src/replication.c
@@ -2444,7 +2444,7 @@ void replicationAbortSyncTransfer(void) {
     undoConnectWithMaster();
     if (server.repl_transfer_fd!=-1) {
         close(server.repl_transfer_fd);
-        unlink(server.repl_transfer_tmpfile);
+        bg_unlink(server.repl_transfer_tmpfile);
         zfree(server.repl_transfer_tmpfile);
         server.repl_transfer_tmpfile = NULL;
         server.repl_transfer_fd = -1;


### PR DESCRIPTION
If we fail or stop to rewrite aof, we need to remove temporary aof. We also remove temporary rdb when replicas abort to receive rdb. But currently we delete them in main thread, to avoid unnecessary latency, we should use bg_unlink to remove them in a background thread.

Btw, we have already used this way to removed child process temporary rdb.