### PR TITLE
Delete dbExists() which is redundant.

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -254,12 +254,6 @@ void setKey(client *c, redisDb *db, robj *key, robj *val) {
     genericSetKey(c,db,key,val,0,1);
 }
 
-/* Return true if the specified key exists in the specified database.
- * LRU/LFU info is not updated in any way. */
-int dbExists(redisDb *db, robj *key) {
-    return dictFind(db->dict,key->ptr) != NULL;
-}
-
 /* Return a random key, in form of a Redis object.
  * If there are no keys, NULL is returned.
  *

--- a/src/server.h
+++ b/src/server.h
@@ -2161,7 +2161,6 @@ int dbAddRDBLoad(redisDb *db, sds key, robj *val);
 void dbOverwrite(redisDb *db, robj *key, robj *val);
 void genericSetKey(client *c, redisDb *db, robj *key, robj *val, int keepttl, int signal);
 void setKey(client *c, redisDb *db, robj *key, robj *val);
-int dbExists(redisDb *db, robj *key);
 robj *dbRandomKey(redisDb *db);
 int dbSyncDelete(redisDb *db, robj *key);
 int dbDelete(redisDb *db, robj *key);


### PR DESCRIPTION
#5021 fixed exists command on replica, but it did not delete dbExists(), which is never used after that.