### PR TITLE
support NOMKSTREAM option in xadd command

### DIFF
--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -105,6 +105,7 @@ start_server {
     test {XADD with NOMKSTREAM option} {
         r DEL mystream
         assert_equal "" [r XADD mystream NOMKSTREAM * item 1 value a]
+        assert_equal 0 [r EXISTS mystream]
         r XADD mystream * item 1 value a
         r XADD mystream NOMKSTREAM * item 2 value b
         assert_equal 2 [r XLEN mystream]

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -102,6 +102,17 @@ start_server {
         }
     }
 
+    test {XADD with NOMKSTREAM option} {
+        r DEL mystream
+        assert_equal "" [r XADD mystream NOMKSTREAM * item 1 value a]
+        r XADD mystream * item 1 value a
+        r XADD mystream NOMKSTREAM * item 2 value b
+        assert_equal 2 [r XLEN mystream]
+        set items [r XRANGE mystream - +]
+        assert_equal [lindex $items 0 1] {item 1 value a}
+        assert_equal [lindex $items 1 1] {item 2 value b}
+    }
+
     test {XADD mass insertion and XLEN} {
         r DEL mystream
         r multi


### PR DESCRIPTION
This PR introduces a NOMKSTREAM option for xadd command, this would be useful for some use cases when we do not want to create new stream by default:

`XADD key [MAXLEN [~|=] <count>] <ID or *> <NOMKSTREAM> [field value] [field value]`

Fixes: https://github.com/redis/redis/issues/6204