### PR TITLE
WATCH no longer ignores keys which have expired for MULTI/EXEC.

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -64,7 +64,7 @@ int activeExpireCycleTryExpire(redisDb *db, dictEntry *de, long long now) {
             dbSyncDelete(db,keyobj);
         notifyKeyspaceEvent(NOTIFY_EXPIRED,
             "expired",keyobj,db->id);
-        trackingInvalidateKey(NULL,keyobj);
+        signalModifiedKey(NULL, db, keyobj);
         decrRefCount(keyobj);
         server.stat_expiredkeys++;
         return 1;

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -221,7 +221,7 @@ start_server {tags {"multi"}} {
         r exec
     } {}
 
-    test {WATCH will not consider touched expired keys} {
+    test {WATCH will consider touched expired keys} {
         r del x
         r set x foo
         r expire x 1
@@ -230,7 +230,7 @@ start_server {tags {"multi"}} {
         r multi
         r ping
         r exec
-    } {PONG}
+    } {}
 
     test {DISCARD should clear the WATCH dirty flag on the client} {
         r watch x


### PR DESCRIPTION
WATCH no longer ignores keys which have expired for MULTI/EXEC. expire.c now calls signalModifiedKey() to invalidate watch as well. This fixes #7918 and Issue 9 in #6860 