### PR TITLE
t_set.c comment update for srandmemberWithCountCommand

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -694,7 +694,7 @@ void srandmemberWithCountCommand(client *c) {
      *
      * This is done because if the number of requested elements is just
      * a bit less than the number of elements in the set, the natural approach
-     * used into CASE 3 is highly inefficient. */
+     * used into CASE 4 is highly inefficient. */
     if (count*SRANDMEMBER_SUB_STRATEGY_MUL > size) {
         setTypeIterator *si;
 


### PR DESCRIPTION
Reference the correct "case", case 4, in the comment explaining the need
for case 3, when the number of request items is too close to the
cardinality of the set. Case 4 is indeed the "natural approach"
referenced earlier in that sentence.

---

PS: I want to take advantage of this PR for really thanking all the contributors for the quality of code throughout the codebase, it is extremely easy to read and comments, such as the one updated in this PR, make it really easy to browse through the implementation. Kudos!