### PR TITLE
Update CI so that warnings fail the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: make
-      # build with TLS just for compilatoin coverage
-      run: make BUILD_TLS=yes
+      # Fail build if there are warnings
+      # build with TLS just for compilation coverage
+      run: make REDIS_CFLAGS='-Werror' BUILD_TLS=yes
     - name: test
       run: |
         sudo apt-get install tcl8.5
@@ -30,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: make
-      run: make
+      run: make REDIS_CFLAGS='-Werror'
 
   build-32bit:
     runs-on: ubuntu-latest
@@ -39,14 +40,14 @@ jobs:
     - name: make
       run: |
         sudo apt-get update && sudo apt-get install libc6-dev-i386
-        make 32bit
+        make REDIS_CFLAGS='-Werror' 32bit
 
   build-libc-malloc:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: make
-      run: make MALLOC=libc
+      run: make REDIS_CFLAGS='-Werror' MALLOC=libc
 
   build-centos7-jemalloc:
     runs-on: ubuntu-latest
@@ -56,7 +57,7 @@ jobs:
     - name: make
       run: |
         yum -y install gcc make
-        make
+        make REDIS_CFLAGS='-Werror'
 
   build-centos6-jemalloc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: make
-      run: make
+      run: make REDIS_CFLAGS='-Werror'
 
   build-macos-latest:
     runs-on: macos-latest

--- a/src/lzf_d.c
+++ b/src/lzf_d.c
@@ -52,7 +52,7 @@
 #endif
 #endif
 
-#if defined(__GNUC__) && __GNUC__ >= 5
+#if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #endif


### PR DESCRIPTION
Hopefully we never see a new git commit that is, "fixing warnings".

Jemalloc on centos 6 and old ubuntu are excluded since they already have warnings that appear to be bugs, and not real issues. There is also a 32 bit warning that was fixed by Oran in another PR: https://github.com/redis/redis/pull/7926