### PR TITLE
Add a --no-latency tests flag.

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -200,7 +200,7 @@ jobs:
       run: make
     - name: test
       run: |
-        ./runtest --accurate --verbose
+        ./runtest --accurate --verbose --no-latency
     - name: module api test
       run: ./runtest-moduleapi --verbose
     - name: sentinel tests

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -575,7 +575,7 @@ start_server {tags {"repl"}} {
     $master config set rdbcompression no
     # If running on Linux, we also measure utime/stime to detect possible I/O handling issues
     set os [catch {exec unamee}]
-    set measure_time [expr {$os == "Linux" && !$::no_latency} ? 1 : 0]
+    set measure_time [expr {$os == "Linux"} ? 1 : 0]
     foreach all_drop {no slow fast all} {
         test "diskless $all_drop replicas drop during rdb pipe" {
             set replicas {}
@@ -655,11 +655,11 @@ start_server {tags {"repl"}} {
                             puts "master utime: $master_utime"
                             puts "master stime: $master_stime"
                         }
-                        if {$all_drop == "all" || $all_drop == "slow"} {
+                        if {!$::no_latency && ($all_drop == "all" || $all_drop == "slow")} {
                             assert {$master_utime < 70}
                             assert {$master_stime < 70}
                         }
-                        if {$all_drop == "none" || $all_drop == "fast"} {
+                        if {!$::no_latency && ($all_drop == "none" || $all_drop == "fast")} {
                             assert {$master_utime < 15}
                             assert {$master_stime < 15}
                         }

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -575,7 +575,7 @@ start_server {tags {"repl"}} {
     $master config set rdbcompression no
     # If running on Linux, we also measure utime/stime to detect possible I/O handling issues
     set os [catch {exec unamee}]
-    set measure_time [expr {$os == "Linux"} ? 1 : 0]
+    set measure_time [expr {$os == "Linux" && !$::no_latency} ? 1 : 0]
     foreach all_drop {no slow fast all} {
         test "diskless $all_drop replicas drop during rdb pipe" {
             set replicas {}

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -88,6 +88,7 @@ set ::quiet 0
 set ::denytags {}
 set ::skiptests {}
 set ::skipunits {}
+set ::no_latency 0
 set ::allowtags {}
 set ::only_tests {}
 set ::single_tests {}
@@ -540,6 +541,7 @@ proc print_help_screen {} {
         "--skipfile <file>  Name of a file containing test names that should be skipped (one per line)."
         "--skiptest <name>  Name of a file containing test names that should be skipped (one per line)."
         "--dont-clean       Don't delete redis log files after the run."
+        "--no-latency       Skip latency measurements and validation by some tests."
         "--stop             Blocks once the first test fails."
         "--loop             Execute the specified set of tests forever."
         "--wait-server      Wait after server is started (so that you can attach a debugger)."
@@ -641,6 +643,8 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         set ::durable 1
     } elseif {$opt eq {--dont-clean}} {
         set ::dont_clean 1
+    } elseif {$opt eq {--no-latency}} {
+        set ::no_latency 1
     } elseif {$opt eq {--wait-server}} {
         set ::wait_server 1
     } elseif {$opt eq {--stop}} {

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -32,8 +32,8 @@ start_server {tags {"latency-monitor"}} {
             assert {$eventname eq "command"}
             if {!$::no_latency} {
                 assert {$max >= 450 & $max <= 650}
+                assert {$time == $last_time}
             }
-            assert {$time == $last_time}
             break
         }
     }

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -17,7 +17,9 @@ start_server {tags {"latency-monitor"}} {
         set max 450
         foreach event [r latency history command] {
             lassign $event time latency
-            assert {$latency >= $min && $latency <= $max}
+            if {!$::no_latency} {
+                assert {$latency >= $min && $latency <= $max}
+            }
             incr min 100
             incr max 100
             set last_time $time ; # Used in the next test
@@ -28,7 +30,9 @@ start_server {tags {"latency-monitor"}} {
         foreach event [r latency latest] {
             lassign $event eventname time latency max
             assert {$eventname eq "command"}
-            assert {$max >= 450 & $max <= 650}
+            if {!$::no_latency} {
+                assert {$max >= 450 & $max <= 650}
+            }
             assert {$time == $last_time}
             break
         }

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -105,7 +105,9 @@ start_server {tags {"defrag"} overrides {appendonly yes auto-aof-rewrite-percent
                 assert {$frag < 1.1}
                 # due to high fragmentation, 100hz, and active-defrag-cycle-max set to 75,
                 # we expect max latency to be not much higher than 7.5ms but due to rare slowness threshold is set higher
-                assert {$max_latency <= 30}
+                if {!$::no_latency} {
+                    assert {$max_latency <= 30}
+                }
             }
             # verify the data isn't corrupted or changed
             set newdigest [r debug digest]
@@ -148,7 +150,9 @@ start_server {tags {"defrag"} overrides {appendonly yes auto-aof-rewrite-percent
                 assert {$frag < 1.4}
                 # since the AOF contains simple (fast) SET commands (and the cron during loading runs every 1000 commands),
                 # it'll still not block the loading for long periods of time.
-                assert {$max_latency <= 30}
+                if {!$::no_latency} {
+                    assert {$max_latency <= 30}
+                }
             }
         }
         r config set appendonly no
@@ -273,7 +277,9 @@ start_server {tags {"defrag"} overrides {appendonly yes auto-aof-rewrite-percent
                 assert {$frag < 1.1}
                 # due to high fragmentation, 100hz, and active-defrag-cycle-max set to 75,
                 # we expect max latency to be not much higher than 7.5ms but due to rare slowness threshold is set higher
-                assert {$max_latency <= 30}
+                if {!$::no_latency} {
+                    assert {$max_latency <= 30}
+                }
             }
             # verify the data isn't corrupted or changed
             set newdigest [r debug digest]
@@ -368,7 +374,9 @@ start_server {tags {"defrag"} overrides {appendonly yes auto-aof-rewrite-percent
                 assert {$frag < 1.1}
                 # due to high fragmentation, 100hz, and active-defrag-cycle-max set to 75,
                 # we expect max latency to be not much higher than 7.5ms but due to rare slowness threshold is set higher
-                assert {$max_latency <= 30}
+                if {!$::no_latency} {
+                    assert {$max_latency <= 30}
+                }
 
                 # in extreme cases of stagnation, we see over 20m misses before the tests aborts with "defrag didn't stop",
                 # in normal cases we only see 100k misses out of 500k elements


### PR DESCRIPTION
Useful for running tests on systems which may be way slower than usual.