### PR TITLE
Adds command introspection to Sentinel

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -466,7 +466,8 @@ struct redisCommand sentinelcmds[] = {
     {"shutdown",shutdownCommand,-1,"admin",0,NULL,0,0,0,0,0},
     {"auth",authCommand,-2,"no-auth fast @connection",0,NULL,0,0,0,0,0},
     {"hello",helloCommand,-2,"no-auth fast @connection",0,NULL,0,0,0,0,0},
-    {"acl",aclCommand,-2,"admin",0,NULL,0,0,0,0,0,0}
+    {"acl",aclCommand,-2,"admin",0,NULL,0,0,0,0,0,0},
+    {"command",commandCommand,-1, "random @connection", 0,NULL,0,0,0,0,0,0}
 };
 
 /* This function overwrites a few normal Redis config default with Sentinel


### PR DESCRIPTION
This one-liner provides the below and brings Sentinel en par with the core server's introspectability abilities. Furthermore, given #7888, one needs the ability to actually review the commands (and their respective categories) for administrative purposes.

```
127.0.0.1:26379> COMMAND
 1) 1) "command"
    2) (integer) -1
    3) 1) random
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @slow
       2) @connection
 2) 1) "shutdown"
    2) (integer) -1
    3) 1) admin
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @admin
       2) @slow
       3) @dangerous
 3) 1) "role"
    2) (integer) 1
    3) 1) readonly
       2) fast
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @read
       2) @fast
       3) @dangerous
 4) 1) "psubscribe"
    2) (integer) -2
    3) 1) pubsub
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @pubsub
       2) @slow
 5) 1) "subscribe"
    2) (integer) -2
    3) 1) pubsub
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @pubsub
       2) @slow
 6) 1) "sentinel"
    2) (integer) -2
    3) 1) admin
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @admin
       2) @slow
       3) @dangerous
 7) 1) "auth"
    2) (integer) -2
    3) 1) fast
       2) no_auth
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @fast
       2) @connection
 8) 1) "info"
    2) (integer) -1
    3) 1) random
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @slow
       2) @dangerous
 9) 1) "publish"
    2) (integer) 3
    3) 1) pubsub
       2) fast
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @pubsub
       2) @fast
10) 1) "punsubscribe"
    2) (integer) -1
    3) 1) pubsub
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @pubsub
       2) @slow
11) 1) "acl"
    2) (integer) -2
    3) 1) admin
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @admin
       2) @slow
       3) @dangerous
12) 1) "unsubscribe"
    2) (integer) -1
    3) 1) pubsub
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @pubsub
       2) @slow
13) 1) "ping"
    2) (integer) 1
    3) 1) fast
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @fast
       2) @connection
14) 1) "hello"
    2) (integer) -2
    3) 1) fast
       2) no_auth
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @fast
       2) @connection
15) 1) "client"
    2) (integer) -2
    3) 1) admin
       2) random
    4) (integer) 0
    5) (integer) 0
    6) (integer) 0
    7) 1) @admin
       2) @slow
       3) @dangerous
       4) @connection
```