### PR TITLE
Sentinel Mode: do not add "save" config during config rewrite

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1335,6 +1335,12 @@ void rewriteConfigSaveOption(struct rewriteConfigState *state) {
     int j;
     sds line;
 
+    /* In Sentinel mode we don't need to rewrite the save parameters */
+    if (server.sentinel_mode) {
+        rewriteConfigMarkAsProcessed(state,"save");
+        return;
+    }
+
     /* Note that if there are no save parameters at all, all the current
      * config line with "save" will be detected as orphaned and deleted,
      * resulting into no RDB persistence as expected. */


### PR DESCRIPTION
In current sentinel code, if we do sentinel flushconfig, some redundant configuration for RDB save will be added in sentinel conf, for example:
requirepass 1234
sentinel myid 4cc73269c70ebf64cc8fb18a1a37898044c30463
sentinel deny-scripts-reconfig yes
#Generated by CONFIG REWRITE
protected-mode no
port 26379
save 3600 1
save 300 100
save 60 10000

Although this configuration has no effect in Sentinel mode, it may make user confused and make sentinel configuration not clean enough.
