### PR TITLE
Attempt to fix sporadic test failures due to wait_for_log_messages

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -128,6 +128,8 @@ proc wait_for_log_messages {srv_idx patterns from_line maxtries delay} {
     set next_line [expr $from_line + 1] ;# searching form the line after
     set stdout [srv $srv_idx stdout]
     while {$retry} {
+        # re-read the last line (unless it's before to our first), last time we read it, it might have been incomplete
+        set next_line [expr $next_line - 1 > $from_line + 1 ? $next_line - 1 : $from_line + 1]
         set result [exec tail -n +$next_line < $stdout]
         set result [split $result "\n"]
         foreach line $result {


### PR DESCRIPTION
The tests sometimes fail to find a log message.
Recently i added a print that shows the log files that are searched
and it shows that the message was in deed there.
The only reason i can't think of for this seach to fail, is we we
happened to read an incomplete line, which didn't match our pattern and
then on the next iteration we would continue reading from the line after
it.

The fix is to always re-evaluation the previous line.