### PR TITLE
When marking FAIL, 'myself' should have slots.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1270,8 +1270,8 @@ void markNodeAsFailingIfNeeded(clusterNode *node) {
     if (nodeFailed(node)) return; /* Already FAILing. */
 
     failures = clusterNodeFailureReportsCount(node);
-    /* Also count myself as a voter if I'm a master. */
-    if (nodeIsMaster(myself)) failures++;
+    /* Also count myself as a voter if I'm a master having at least one slot. */
+    if (nodeIsMaster(myself) && myself->numslots) failures++;
     if (failures < needed_quorum) return; /* No weak agreement from masters. */
 
     serverLog(LL_NOTICE,

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3336,7 +3336,7 @@ void clusterHandleSlaveMigration(int max_slaves) {
          * node ID. */
         if (okslaves == max_slaves) {
             for (j = 0; j < node->numslaves; j++) {
-                if (memcmp(node->slaves[j]->name,
+                if (!nodeFailed(node->slaves[j]) && memcmp(node->slaves[j]->name,
                            candidate->name,
                            CLUSTER_NAMELEN) < 0)
                 {


### PR DESCRIPTION
When flagging a node as FAIL, we also count 'myself' as a voter if 'myself'  is a master and HAS AT LEAST ONE SLOT.