### PR TITLE
Slowlog Get: Set reply array length at beginning

### DIFF
--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -158,9 +158,8 @@ NULL
     } else if ((c->argc == 2 || c->argc == 3) &&
                !strcasecmp(c->argv[1]->ptr,"get"))
     {
-        long count = 10, sent = 0;
+        long count = 10;
         listIter li;
-        void *totentries;
         listNode *ln;
         slowlogEntry *se;
 
@@ -168,8 +167,12 @@ NULL
             getLongFromObjectOrReply(c,c->argv[2],&count,NULL) != C_OK)
             return;
 
+        if (count < 0) count = 0;
+        if ((size_t)count > listLength(server.slowlog)) 
+            count = listLength(server.slowlog);
+
         listRewind(server.slowlog,&li);
-        totentries = addReplyDeferredLen(c);
+        addReplyArrayLen(c,count);
         while(count-- && (ln = listNext(&li))) {
             int j;
 
@@ -183,9 +186,7 @@ NULL
                 addReplyBulk(c,se->argv[j]);
             addReplyBulkCBuffer(c,se->peerid,sdslen(se->peerid));
             addReplyBulkCBuffer(c,se->cname,sdslen(se->cname));
-            sent++;
         }
-        setDeferredArrayLen(c,totentries,sent);
     } else {
         addReplySubcommandSyntaxError(c);
     }


### PR DESCRIPTION
In current implementation, slowlog get command use setDeferredArrayLen to set reply length at the end. However, we should know the length of the reply after we parse the user flag.   By setting array length at beginning will avoid the redundant potentical call for malloc and memcpy operation when we use setDeferredArrayLen to set the array actual length.