### PR TITLE
XCLAIM: Skip if dst and src consumers are the same

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2393,14 +2393,17 @@ void xclaimCommand(client *c) {
                 mstime_t this_idle = now - nack->delivery_time;
                 if (this_idle < minidle) continue;
             }
+            if (consumer == NULL)
+                consumer = streamLookupConsumer(group,c->argv[3]->ptr,SLC_NONE,NULL);
+            /* Nothing to do if current and claiming consumers are the same */
+            if (nack->consumer == consumer)
+                continue;
             /* Remove the entry from the old consumer.
              * Note that nack->consumer is NULL if we created the
              * NACK above because of the FORCE option. */
             if (nack->consumer)
                 raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
             /* Update the consumer and idle time. */
-            if (consumer == NULL)
-                consumer = streamLookupConsumer(group,c->argv[3]->ptr,SLC_NONE,NULL);
             nack->consumer = consumer;
             nack->delivery_time = deliverytime;
             /* Set the delivery attempts counter if given, otherwise

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -251,6 +251,26 @@ start_server {
         assert_equal "" [lindex $reply 0]
     }
 
+    test {XCLAIM same consumer} {
+        # Add 3 items into the stream, and create a consumer group
+        r del mystream
+        set id1 [r XADD mystream * a 1]
+        set id2 [r XADD mystream * b 2]
+        set id3 [r XADD mystream * c 3]
+        r XGROUP CREATE mystream mygroup 0
+
+        set reply [
+            r XREADGROUP GROUP mygroup client1 count 1 STREAMS mystream >
+        ]
+        assert {[llength [lindex $reply 0 1 0 1]] == 2}
+        assert {[lindex $reply 0 1 0 1] eq {a 1}}
+        r debug sleep 0.2
+        set reply [
+            r XCLAIM mystream mygroup client1 10 $id1
+        ]
+        assert {[llength $reply] == 0}
+    }
+
     test {XCLAIM without JUSTID increments delivery count} {
         # Add 3 items into the stream, and create a consumer group
         r del mystream


### PR DESCRIPTION
Do not claim the entry if claiming consumer is identical
to the consumer that already has the entry in its PEL
(It affects delivery_count for no reason as the entry
stays with the same consumer)