### PR TITLE
Add maxclients and cluster_connections to INFO CLIENTS

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4314,6 +4314,7 @@ sds genRedisInfoString(const char *section) {
         info = sdscatprintf(info,
             "# Clients\r\n"
             "connected_clients:%lu\r\n"
+            "cluster_connections:%lu\r\n"
             "maxclients:%u\r\n"
             "client_recent_max_input_buffer:%zu\r\n"
             "client_recent_max_output_buffer:%zu\r\n"
@@ -4321,6 +4322,7 @@ sds genRedisInfoString(const char *section) {
             "tracking_clients:%d\r\n"
             "clients_in_timeout_table:%llu\r\n",
             listLength(server.clients)-listLength(server.slaves),
+            getClusterConnectionsCount(),
             server.maxclients,
             maxin, maxout,
             server.blocked_clients,
@@ -4801,10 +4803,8 @@ sds genRedisInfoString(const char *section) {
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info,
         "# Cluster\r\n"
-        "cluster_enabled:%d\r\n"
-        "connected_clusters:%lu\r\n",
-        server.cluster_enabled,
-        getClusterConnectionsCount());
+        "cluster_enabled:%d\r\n",
+        server.cluster_enabled);
     }
 
     /* Key space */

--- a/src/server.c
+++ b/src/server.c
@@ -4314,12 +4314,14 @@ sds genRedisInfoString(const char *section) {
         info = sdscatprintf(info,
             "# Clients\r\n"
             "connected_clients:%lu\r\n"
+            "maxclients:%u\r\n"
             "client_recent_max_input_buffer:%zu\r\n"
             "client_recent_max_output_buffer:%zu\r\n"
             "blocked_clients:%d\r\n"
             "tracking_clients:%d\r\n"
             "clients_in_timeout_table:%llu\r\n",
             listLength(server.clients)-listLength(server.slaves),
+            server.maxclients,
             maxin, maxout,
             server.blocked_clients,
             server.tracking_clients,

--- a/src/server.c
+++ b/src/server.c
@@ -4801,8 +4801,10 @@ sds genRedisInfoString(const char *section) {
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info,
         "# Cluster\r\n"
-        "cluster_enabled:%d\r\n",
-        server.cluster_enabled);
+        "cluster_enabled:%d\r\n"
+        "connected_clusters:%lu\r\n",
+        server.cluster_enabled,
+        getClusterConnectionsCount());
     }
 
     /* Key space */


### PR DESCRIPTION
Few config settings are also reflected by the INFO command.
these are mainly ones that are important for either an instant view of
the server status (to compare a metric to it's limit config),
Important configurations that are necessary in the crash log (which
currently doesn't print the config),
And things that are important for monitoring solutions (such as
Prometheus), which rely on INFO to collect their data.

Add cluster_connections to INFO CLIENTS too,
This makes it possible to be combined together with connected_clients
and connected_slaves and be matched against maxclients