### PR TITLE
Add RESET command.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2252,7 +2252,7 @@ void resetCommand(client *c) {
     listNode *ln;
 
     /* MONITOR clients are also marked with CLIENT_SLAVE, we need to
-     * distinguish the two.
+     * distinguish between the two.
      */
     if (c->flags & CLIENT_MONITOR) {
         ln = listSearchKey(server.monitors,c);

--- a/src/server.c
+++ b/src/server.c
@@ -1036,7 +1036,11 @@ struct redisCommand redisCommandTable[] = {
 
     {"stralgo",stralgoCommand,-2,
      "read-only @string",
-     0,lcsGetKeys,0,0,0,0,0,0}
+     0,lcsGetKeys,0,0,0,0,0,0},
+
+    {"reset",resetCommand,-1,
+     "no-script ok-stale fast @connection",
+     0,NULL,0,0,0,0,0,0}
 };
 
 /*============================ Utility functions ============================ */
@@ -3759,7 +3763,8 @@ int processCommand(client *c) {
          * set. */
         if (c->flags & CLIENT_MULTI &&
             c->cmd->proc != execCommand &&
-            c->cmd->proc != discardCommand) {
+            c->cmd->proc != discardCommand &&
+            c->cmd->proc != resetCommand) {
             reject_cmd_on_oom = 1;
         }
 
@@ -3825,7 +3830,8 @@ int processCommand(client *c) {
         c->cmd->proc != subscribeCommand &&
         c->cmd->proc != unsubscribeCommand &&
         c->cmd->proc != psubscribeCommand &&
-        c->cmd->proc != punsubscribeCommand) {
+        c->cmd->proc != punsubscribeCommand &&
+        c->cmd->proc != resetCommand) {
         rejectCommandFormat(c,
             "Can't execute '%s': only (P)SUBSCRIBE / "
             "(P)UNSUBSCRIBE / PING / QUIT are allowed in this context",
@@ -3879,7 +3885,8 @@ int processCommand(client *c) {
     /* Exec the command */
     if (c->flags & CLIENT_MULTI &&
         c->cmd->proc != execCommand && c->cmd->proc != discardCommand &&
-        c->cmd->proc != multiCommand && c->cmd->proc != watchCommand)
+        c->cmd->proc != multiCommand && c->cmd->proc != watchCommand &&
+        c->cmd->proc != resetCommand)
     {
         queueMultiCommand(c);
         addReply(c,shared.queued);

--- a/src/server.c
+++ b/src/server.c
@@ -3834,7 +3834,7 @@ int processCommand(client *c) {
         c->cmd->proc != resetCommand) {
         rejectCommandFormat(c,
             "Can't execute '%s': only (P)SUBSCRIBE / "
-            "(P)UNSUBSCRIBE / PING / QUIT are allowed in this context",
+            "(P)UNSUBSCRIBE / PING / QUIT / RESET are allowed in this context",
             c->cmd->name);
         return C_OK;
     }

--- a/src/server.c
+++ b/src/server.c
@@ -1039,7 +1039,7 @@ struct redisCommand redisCommandTable[] = {
      0,lcsGetKeys,0,0,0,0,0,0},
 
     {"reset",resetCommand,-1,
-     "no-script ok-stale fast @connection",
+     "no-script ok-stale ok-loading fast @connection",
      0,NULL,0,0,0,0,0,0}
 };
 

--- a/src/server.h
+++ b/src/server.h
@@ -2491,6 +2491,7 @@ void xtrimCommand(client *c);
 void lolwutCommand(client *c);
 void aclCommand(client *c);
 void stralgoCommand(client *c);
+void resetCommand(client *c);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -249,4 +249,55 @@ start_server {tags {"other"}} {
         waitForBgsave r
         r save
     } {OK}
+
+    test {RESET clears client state} {
+        r client setname test-client
+        r client tracking on
+
+        assert_equal [r reset] "RESET"
+        set client [r client list]
+        assert_match {*name= *} $client
+        assert_match {*flags=N *} $client
+    }
+
+    test {RESET clears MONITOR state} {
+        set rd [redis_deferring_client]
+        $rd monitor
+        assert_equal [$rd read] "OK"
+
+        $rd reset
+
+        # skip reset ouptut
+        $rd read
+        assert_equal [$rd read] "RESET"
+
+        assert_no_match {*flags=O*} [r client list]
+    }
+
+    test {RESET clears and discards MULTI state} {
+        r multi
+        r set key-a a
+
+        r reset
+        catch {r exec} err
+        assert_match {*EXEC without MULTI*} $err
+    }
+
+    test {RESET clears Pub/Sub state} {
+        r subscribe channel-1
+        r reset
+
+        # confirm we're not subscribed by executing another command
+        r set key val
+    }
+
+    test {RESET clears authenticated state} {
+        r acl setuser user1 on >secret +@all
+        r auth user1 secret
+        assert_equal [r acl whoami] user1
+
+        r reset
+
+        assert_equal [r acl whoami] default
+    }
 }


### PR DESCRIPTION
Perform full reset of all client connection states, is if the client was
disconnected and re-connected. This affects:

* `MULTI` state
* Watched keys
* `MONITOR` mode
* Pub/Sub subscription
* ACL/Authenticated state
* Client tracking state
* Cluster read-only/asking state
* RESP version
* Selected database
* `CLIENT REPLY` state

The response is +RESET to make it easily distinguishable from other
responses.

Resolves #5571 