### PR TITLE
[WIP] add idle rax (with benchmarks)

### DIFF
--- a/src/stream.h
+++ b/src/stream.h
@@ -58,6 +58,7 @@ typedef struct streamCG {
                                as processed. The key of the radix tree is the
                                ID as a 64 bit big endian number, while the
                                associated value is a streamNACK structure.*/
+    rax *idle_pel;
     rax *consumers;         /* A radix tree representing the consumers by name
                                and their associated representation in the form
                                of streamConsumer structures. */
@@ -76,6 +77,7 @@ typedef struct streamConsumer {
                                    the same streamNACK structure referenced
                                    in the "pel" of the consumer group structure
                                    itself, so the value is shared. */
+    rax *idle_pel;
 } streamConsumer;
 
 /* Pending (yet not acknowledged) message in a consumer group. */


### PR DESCRIPTION
As discussed with @guybe7 in https://github.com/redis/redis/pull/7973

This is a test of adding a new rax for consumer groups and consumers that stores a PEL indexed on the entries delivery_time.  This will allow for a more efficient and easier to use implementation of XAUTOCLAIM.

This test adds 1,000,000 entries to a stream where each entry just has a single field/value of the strings "field" and "value" via

`redis.xadd(["mystream",'*','field','value'])`

they are then all consumed by a single consumer using `xreadgroup` 

I ran the benchmark a couple times on each `unstable` and `idle-pel` branch and the numbers are stable.  I used `/proc/<pid>/status` to measure memory usage.


Before Running Benchmark

```
VmPeak:    53672 kB
VmSize:    53672 kB
VmHWM:     10104 kB
VmRSS:     10104 kB
RssAnon:         6480 kB
RssFile:         3624 kB
VmData:    43452 kB
VmPTE:        88 kB
```

UNSTABLE RESULTS

```
VmPeak:   146856 kB
VmSize:   146856 kB
VmHWM:    102152 kB
VmRSS:    102152 kB
RssAnon:           98080 kB
RssFile:            4072 kB
VmData:   136636 kB
VmPTE:       272 kB
```


IDLE-PEL RESULTS

```
VmPeak:   226728 kB
VmSize:   226728 kB
VmHWM:    155016 kB
VmRSS:    155016 kB
RssAnon:          151024 kB
RssFile:            3992 kB
VmData:   216508 kB
VmPTE:       376 kB
```


If this idea is considered viable then there is still more work to do on the PR to get it ready to be merged but I think the changes were enough to generate a valid benchmark.