### PR TITLE
Adds pub/sub channel patterns to ACL

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -803,6 +803,19 @@ acllog-max-len 128
 #
 # requirepass foobared
 
+# New users are initialized with restrictive permissions by default, via the
+# equivalent of this ACL rule 'off nokeys -@all'. Stsrting with Redis 6.2 it is
+# possible to manage access via ACL for Pub/Sub channels as well. To ensure
+# backwards compatability, new users are granted the 'allchannels' permission
+# by default.
+#
+# Future compatability note: it is very likely that in a future version of Redis
+# the directive's default of 'allchannels' will be changed to 'nochannels' in
+# order to provide better out-of-the-box Pub/Sub security. Therefore, it is
+# recommended that you explicitly define Pub/Sub permissions for all user rather
+# then rely on the implicit defaults.
+acl-pubsub-default allchannels
+
 # Command renaming (DEPRECATED).
 #
 # ------------------------------------------------------------------------

--- a/redis.conf
+++ b/redis.conf
@@ -810,7 +810,7 @@ acllog-max-len 128
 # by default.
 #
 # Future compatability note: it is very likely that in a future version of Redis
-# the directive's default of 'allchannels' will be changed to 'nochannels' in
+# the directive's default of 'allchannels' will be changed to 'resetchannels' in
 # order to provide better out-of-the-box Pub/Sub security. Therefore, it is
 # recommended that you explicitly define Pub/Sub permissions for all user rather
 # then rely on the implicit defaults.

--- a/redis.conf
+++ b/redis.conf
@@ -821,7 +821,7 @@ acllog-max-len 128
 # requirepass foobared
 
 # New users are initialized with restrictive permissions by default, via the
-# equivalent of this ACL rule 'off -@all'. Stsrting with Redis 6.2, it is
+# equivalent of this ACL rule 'off -@all'. Starting with Redis 6.2, it is
 # possible to manage access via ACL for Pub/Sub channels as well. To ensure
 # backwards compatability, new users are granted the 'allchannels' permission
 # by default.

--- a/redis.conf
+++ b/redis.conf
@@ -821,7 +821,7 @@ acllog-max-len 128
 # requirepass foobared
 
 # New users are initialized with restrictive permissions by default, via the
-# equivalent of this ACL rule 'off nokeys -@all'. Stsrting with Redis 6.2 it is
+# equivalent of this ACL rule 'off -@all'. Stsrting with Redis 6.2, it is
 # possible to manage access via ACL for Pub/Sub channels as well. To ensure
 # backwards compatability, new users are granted the 'allchannels' permission
 # by default.

--- a/redis.conf
+++ b/redis.conf
@@ -747,6 +747,11 @@ replica-priority 100
 #               It is possible to specify multiple patterns.
 #  allkeys      Alias for ~*
 #  resetkeys    Flush the list of allowed keys patterns.
+#  &<pattern>   Add a glob-style pattern of Pub/Sub channels that can be
+#               accessed by the user. It is possible to specify multiple channel
+#               patterns.
+#  allchannels  Alias for &*
+#  resetchannels            Flush the list of allowed channel patterns.
 #  ><password>  Add this password to the list of valid password for the user.
 #               For example >mypass will add "mypass" to the list.
 #               This directive clears the "nopass" flag (see later).
@@ -821,17 +826,25 @@ acllog-max-len 128
 # requirepass foobared
 
 # New users are initialized with restrictive permissions by default, via the
-# equivalent of this ACL rule 'off -@all'. Starting with Redis 6.2, it is
-# possible to manage access via ACL for Pub/Sub channels as well. To ensure
-# backwards compatibility, new users are granted the 'allchannels' permission
-# by default.
+# equivalent of this ACL rule 'off resetkeys -@all'. Starting with Redis 6.2, it
+# is possible to manage access to Pub/Sub channels with ACL rules as well. The
+# default Pub/Sub channels permission if new users is controlled by the 
+# acl-pubsub-default configuration directive, which accepts one of these values:
+#
+# allchannels: grants access to all Pub/Sub channels
+# resetchannels: revokes access to all Pub/Sub channels
+#
+# To ensure backward compatibility while upgrading Redis 6.0, acl-pubsub-default
+# defaults to the 'allchannels' permission.
 #
 # Future compatibility note: it is very likely that in a future version of Redis
 # the directive's default of 'allchannels' will be changed to 'resetchannels' in
 # order to provide better out-of-the-box Pub/Sub security. Therefore, it is
-# recommended that you explicitly define Pub/Sub permissions for all user rather
-# then rely on the implicit defaults.
-acl-pubsub-default allchannels
+# recommended that you explicitly define Pub/Sub permissions for all users
+# rather then rely on implicit default values. Once you've set explicit
+# Pub/Sub for all exisitn users, you should uncomment the following line.
+#
+# acl-pubsub-default resetchannels
 
 # Command renaming (DEPRECATED).
 #

--- a/redis.conf
+++ b/redis.conf
@@ -823,10 +823,10 @@ acllog-max-len 128
 # New users are initialized with restrictive permissions by default, via the
 # equivalent of this ACL rule 'off -@all'. Starting with Redis 6.2, it is
 # possible to manage access via ACL for Pub/Sub channels as well. To ensure
-# backwards compatability, new users are granted the 'allchannels' permission
+# backwards compatibility, new users are granted the 'allchannels' permission
 # by default.
 #
-# Future compatability note: it is very likely that in a future version of Redis
+# Future compatibility note: it is very likely that in a future version of Redis
 # the directive's default of 'allchannels' will be changed to 'resetchannels' in
 # order to provide better out-of-the-box Pub/Sub security. Therefore, it is
 # recommended that you explicitly define Pub/Sub permissions for all user rather

--- a/src/acl.c
+++ b/src/acl.c
@@ -242,7 +242,7 @@ user *ACLCreateUser(const char *name, size_t namelen) {
     if (raxFind(Users,(unsigned char*)name,namelen) != raxNotFound) return NULL;
     user *u = zmalloc(sizeof(*u));
     u->name = sdsnewlen(name,namelen);
-    u->flags = USER_FLAG_DISABLED;
+    u->flags = USER_FLAG_DISABLED | server.acl_pubusub_default;
     u->allowed_subcommands = NULL;
     u->passwords = listCreate();
     u->patterns = listCreate();

--- a/src/acl.c
+++ b/src/acl.c
@@ -1240,6 +1240,8 @@ int ACLCheckPubsubPerm(client *c, int idx, int count, int literal, int *idxptr) 
      * arguments. */
     if (!(c->user->flags & USER_FLAG_ALLCHANNELS)) {
         for (int j = idx; j < idx+count; j++) {
+            sds channel = c->argv[j]->ptr;
+            size_t clen = sdslen(channel);
             listIter li;
             listNode *ln;
             listRewind(u->channels,&li);
@@ -1249,9 +1251,9 @@ int ACLCheckPubsubPerm(client *c, int idx, int count, int literal, int *idxptr) 
             while((ln = listNext(&li))) {
                 sds pattern = listNodeValue(ln);
                 size_t plen = sdslen(pattern);
-                if ((literal && !sdscmp(pattern,c->argv[j]->ptr)) || 
-                    (!literal && stringmatchlen(pattern,plen,c->argv[j]->ptr,
-                                                sdslen(c->argv[j]->ptr),0)))
+                
+                if ((literal && !sdscmp(pattern,channel)) || 
+                    (!literal && stringmatchlen(pattern,plen,channel,clen,0)))
                 {
                     match = 1;
                     break;

--- a/src/acl.c
+++ b/src/acl.c
@@ -1254,6 +1254,9 @@ int ACLCheckCommandPerm(client *c, int *keyidxptr) {
     return ACL_OK;
 }
 
+/* Check if the provided channel is whitelisted by the given allowed channels
+ * list. Glob-style pattern matching is employed, unless the literal flag is
+ * set. Returns ACL_OK if access is granted or ACL_DENIED_CHANNEL otherwise. */
 int ACLCheckPubsubChannelPerm(sds channel, list *allowed, int literal) {
     listIter li;
     listNode *ln;

--- a/src/acl.c
+++ b/src/acl.c
@@ -1221,8 +1221,8 @@ int ACLCheckCommandPerm(client *c, int *keyidxptr) {
 }
 
 /* Check if the pub/sub channels of the command, that's ready to be executed in
- * the client 'c' and already referenced by c->cmd, can be executed by this
- * client according to the ACLs channels associated to the client user c->user.
+ * the client 'c', can be executed by this client according to the ACLs channels
+ * associated to the client user c->user.
  * 
  * idx and count are the index and count of channel arguments from the
  * command. The literal argument controls whether the user's ACL channels are 
@@ -1703,9 +1703,9 @@ void addACLLogEntry(client *c, int reason, int argpos, sds username) {
 
     switch(reason) {
     case ACL_DENIED_CMD: le->object = sdsnew(c->cmd->name); break;
-    case ACL_DENIED_KEY: le->object = sdsnew(c->argv[argpos]->ptr); break;
-    case ACL_DENIED_CHANNEL: le->object = sdsnew(c->argv[argpos]->ptr); break;
-    case ACL_DENIED_AUTH: le->object = sdsnew(c->argv[0]->ptr); break;
+    case ACL_DENIED_KEY: le->object = sdsdup(c->argv[argpos]->ptr); break;
+    case ACL_DENIED_CHANNEL: le->object = sdsdup(c->argv[argpos]->ptr); break;
+    case ACL_DENIED_AUTH: le->object = sdsdup(c->argv[0]->ptr); break;
     default: le->object = sdsempty();
     }
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -610,9 +610,10 @@ sds ACLDescribeUser(user *u) {
 
     /* Flags. */
     for (int j = 0; ACLUserFlags[j].flag; j++) {
-        /* Skip the allcommands and allkeys flags because they'll be emitted
-         * later as ~* and +@all. */
+        /* Skip the allcommands, allkeys and allchannels flags because they'll
+         * be emitted later as +@all, ~* and &*. */
         if (ACLUserFlags[j].flag == USER_FLAG_ALLKEYS ||
+            ACLUserFlags[j].flag == USER_FLAG_ALLCHANNELS ||
             ACLUserFlags[j].flag == USER_FLAG_ALLCOMMANDS) continue;
         if (u->flags & ACLUserFlags[j].flag) {
             res = sdscat(res,ACLUserFlags[j].name);

--- a/src/config.c
+++ b/src/config.c
@@ -104,6 +104,13 @@ configEnum tls_auth_clients_enum[] = {
     {"optional", TLS_CLIENT_AUTH_OPTIONAL},
     {NULL, 0}
 };
+
+configEnum acl_pubsub_default_enum[] = {
+    {"allchannels", USER_FLAG_ALLCHANNELS},
+    {"resetchannels", 0},
+    {NULL, 0}
+};
+
 /* Output buffer limits presets. */
 clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT] = {
     {0, 0, 0}, /* normal */
@@ -2338,6 +2345,7 @@ standardConfig configs[] = {
     createEnumConfig("loglevel", NULL, MODIFIABLE_CONFIG, loglevel_enum, server.verbosity, LL_NOTICE, NULL, NULL),
     createEnumConfig("maxmemory-policy", NULL, MODIFIABLE_CONFIG, maxmemory_policy_enum, server.maxmemory_policy, MAXMEMORY_NO_EVICTION, NULL, NULL),
     createEnumConfig("appendfsync", NULL, MODIFIABLE_CONFIG, aof_fsync_enum, server.aof_fsync, AOF_FSYNC_EVERYSEC, NULL, NULL),
+    createEnumConfig("acl-pubsub-default", NULL, MODIFIABLE_CONFIG, acl_pubsub_default_enum, server.acl_pubusub_default, USER_FLAG_ALLCHANNELS, NULL, NULL),
 
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),

--- a/src/multi.c
+++ b/src/multi.c
@@ -192,18 +192,34 @@ void execCommand(client *c) {
             must_propagate = 1;
         }
 
-        int acl_keypos;
-        int acl_retval = ACLCheckCommandPerm(c,&acl_keypos);
+        /* ACL permissions are also checked at the time of execution in case
+         * they were changed after the commands were ququed. */
+        int acl_errpos;
+        int acl_retval = ACLCheckCommandPerm(c,&acl_errpos);
+        if (acl_retval == ACL_OK && c->cmd->proc == publishCommand)
+            acl_retval = ACLCheckPubsubPerm(c,1,1,0,&acl_errpos);
         if (acl_retval != ACL_OK) {
-            addACLLogEntry(c,acl_retval,acl_keypos,NULL);
+            char *reason;
+            switch (acl_retval) {
+            case ACL_DENIED_CMD:
+                reason = "no permission to execute the command or subcommand";
+                break;
+            case ACL_DENIED_KEY:
+                reason = "no permission to touch the specified keys";
+                break;
+            case ACL_DENIED_CHANNEL:
+                reason = "no permission to publish to the specified channel";
+                break;
+            default:
+                reason = "no permission";
+                break;
+            }
+            addACLLogEntry(c,acl_retval,acl_errpos,NULL);
             addReplyErrorFormat(c,
                 "-NOPERM ACLs rules changed between the moment the "
                 "transaction was accumulated and the EXEC call. "
                 "This command is no longer allowed for the "
-                "following reason: %s",
-                (acl_retval == ACL_DENIED_CMD) ?
-                "no permission to execute the command or subcommand" :
-                "no permission to touch the specified keys");
+                "following reason: %s", reason);
         } else {
             call(c,server.loading ? CMD_CALL_NONE : CMD_CALL_FULL);
         }

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -354,14 +354,14 @@ int pubsubPublishMessage(robj *channel, robj *message) {
 }
 
 /* This wraps handling ACL channel permissions for the given client. */
-int pubsubCheckACLPermissions(client *c, int idx, int count, int literal) {
+int pubsubCheckACLPermissionsOrReply(client *c, int idx, int count, int literal) {
     /* Check if the user can run the command according to the current
      * ACLs. */
     int acl_chanpos;
     int acl_retval = ACLCheckPubsubPerm(c,idx,count,literal,&acl_chanpos);
     if (acl_retval == ACL_DENIED_CHANNEL) {
         addACLLogEntry(c,acl_retval,acl_chanpos,NULL);
-        rejectCommandFormat(c,
+        addReplyError(c,
             "-NOPERM this user has no permissions to access "
             "one of the channels used as arguments");
     }
@@ -374,7 +374,7 @@ int pubsubCheckACLPermissions(client *c, int idx, int count, int literal) {
 
 /* SUBSCRIBE channel [channel ...] */
 void subscribeCommand(client *c) {
-    if (pubsubCheckACLPermissions(c, 1, c->argc-1, 0) != ACL_OK) return;
+    if (pubsubCheckACLPermissionsOrReply(c, 1, c->argc-1, 0) != ACL_OK) return;
     for (int j = 1; j < c->argc; j++)
         pubsubSubscribeChannel(c,c->argv[j]);
     c->flags |= CLIENT_PUBSUB;
@@ -395,7 +395,7 @@ void unsubscribeCommand(client *c) {
 
 /* PSUBSCRIBE pattern [pattern ...] */
 void psubscribeCommand(client *c) {
-    if (pubsubCheckACLPermissions(c, 1, c->argc-1, 1) != ACL_OK) return;
+    if (pubsubCheckACLPermissionsOrReply(c, 1, c->argc-1, 1) != ACL_OK) return;
     for (int j = 1; j < c->argc; j++)
         pubsubSubscribePattern(c,c->argv[j]);
     c->flags |= CLIENT_PUBSUB;
@@ -416,7 +416,7 @@ void punsubscribeCommand(client *c) {
 
 /* PUBLISH <channel> <message> */
 void publishCommand(client *c) {
-    if (pubsubCheckACLPermissions(c, 1, 1, 0) != ACL_OK) return;
+    if (pubsubCheckACLPermissionsOrReply(c, 1, 1, 0) != ACL_OK) return;
     int receivers = pubsubPublishMessage(c->argv[1],c->argv[2]);
     if (server.cluster_enabled)
         clusterPropagatePublish(c->argv[1],c->argv[2]);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -374,7 +374,7 @@ int pubsubCheckACLPermissions(client *c, int idx, int count, int literal) {
 
 /* SUBSCRIBE channel [channel ...] */
 void subscribeCommand(client *c) {
-    if (pubsubCheckACLPermissions(c, 1, c->argc, 0) != ACL_OK) return;
+    if (pubsubCheckACLPermissions(c, 1, c->argc-1, 0) != ACL_OK) return;
     for (int j = 1; j < c->argc; j++)
         pubsubSubscribeChannel(c,c->argv[j]);
     c->flags |= CLIENT_PUBSUB;
@@ -395,7 +395,7 @@ void unsubscribeCommand(client *c) {
 
 /* PSUBSCRIBE pattern [pattern ...] */
 void psubscribeCommand(client *c) {
-    if (pubsubCheckACLPermissions(c, 1, c->argc, 1) != ACL_OK) return;
+    if (pubsubCheckACLPermissions(c, 1, c->argc-1, 1) != ACL_OK) return;
     for (int j = 1; j < c->argc; j++)
         pubsubSubscribePattern(c,c->argv[j]);
     c->flags |= CLIENT_PUBSUB;

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -374,7 +374,7 @@ int pubsubCheckACLPermissionsOrReply(client *c, int idx, int count, int literal)
 
 /* SUBSCRIBE channel [channel ...] */
 void subscribeCommand(client *c) {
-    if (pubsubCheckACLPermissionsOrReply(c, 1, c->argc-1, 0) != ACL_OK) return;
+    if (pubsubCheckACLPermissionsOrReply(c,1,c->argc-1,0) != ACL_OK) return;
     for (int j = 1; j < c->argc; j++)
         pubsubSubscribeChannel(c,c->argv[j]);
     c->flags |= CLIENT_PUBSUB;
@@ -395,7 +395,7 @@ void unsubscribeCommand(client *c) {
 
 /* PSUBSCRIBE pattern [pattern ...] */
 void psubscribeCommand(client *c) {
-    if (pubsubCheckACLPermissionsOrReply(c, 1, c->argc-1, 1) != ACL_OK) return;
+    if (pubsubCheckACLPermissionsOrReply(c,1,c->argc-1,1) != ACL_OK) return;
     for (int j = 1; j < c->argc; j++)
         pubsubSubscribePattern(c,c->argv[j]);
     c->flags |= CLIENT_PUBSUB;
@@ -416,7 +416,7 @@ void punsubscribeCommand(client *c) {
 
 /* PUBLISH <channel> <message> */
 void publishCommand(client *c) {
-    if (pubsubCheckACLPermissionsOrReply(c, 1, 1, 0) != ACL_OK) return;
+    if (pubsubCheckACLPermissionsOrReply(c,1,1,0) != ACL_OK) return;
     int receivers = pubsubPublishMessage(c->argv[1],c->argv[2]);
     if (server.cluster_enabled)
         clusterPropagatePublish(c->argv[1],c->argv[2]);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1428,9 +1428,16 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
             /* Unset our default PUSH handler so this works in RESP2/RESP3 */
             redisSetPushCallback(context, NULL);
 
-            while (1) {
+            while (config.pubsub_mode) {
                 if (cliReadReply(output_raw) != REDIS_OK) exit(1);
+                if (config.last_cmd_type == REDIS_REPLY_ERROR) {
+                    if (config.push_output) {
+                        redisSetPushCallback(context, cliPushHandler);
+                    }
+                    config.pubsub_mode = 0;
+                }
             }
+            continue;
         }
 
         if (config.slave_mode) {

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -625,7 +625,7 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
         case ACL_DENIED_AUTH:
             luaPushError(lua, "The user executing the script can't publish "
                               "to the channel mentioned in the command");
-                
+            break;
         default:
             luaPushError(lua, "The user executing the script is lacking the "
                               "permissions for the command");

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -606,17 +606,31 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
     }
 
     /* Check the ACLs. */
-    int acl_keypos;
-    int acl_retval = ACLCheckCommandPerm(c,&acl_keypos);
+    int acl_errpos;
+    int acl_retval = ACLCheckCommandPerm(c,&acl_errpos);
+    if (acl_retval == ACL_OK && c->cmd->proc == publishCommand)
+        acl_retval = ACLCheckPubsubPerm(c,1,1,0,&acl_errpos);
     if (acl_retval != ACL_OK) {
-        addACLLogEntry(c,acl_retval,acl_keypos,NULL);
-        if (acl_retval == ACL_DENIED_CMD)
+        addACLLogEntry(c,acl_retval,acl_errpos,NULL);
+        switch (acl_retval) {
+        case ACL_DENIED_CMD:
             luaPushError(lua, "The user executing the script can't run this "
                               "command or subcommand");
-        else
+            break;
+        case ACL_DENIED_KEY:
             luaPushError(lua, "The user executing the script can't access "
                               "at least one of the keys mentioned in the "
                               "command arguments");
+            break;
+        case ACL_DENIED_AUTH:
+            luaPushError(lua, "The user executing the script can't publish "
+                              "to the channel mentioned in the command");
+                
+        default:
+            luaPushError(lua, "The user executing the script is lacking the "
+                              "permissions for the command");
+            break;
+        }
         goto cleanup;
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -4898,7 +4898,7 @@ void monitorCommand(client *c) {
         /**
          * A client that has CLIENT_DENY_BLOCKING flag on
          * expects a reply per command and so can't execute MONITOR. */
-        addReplyError(c, "MONITOR is not allowed for DENY BLOCKING client");
+        addReplyError(c, "MONITOR isn't allowed for DENY BLOCKING client");
         return;
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -1477,11 +1477,12 @@ struct redisServer {
     long long latency_monitor_threshold;
     dict *latency_events;
     /* ACLs */
-    char *acl_filename;     /* ACL Users file. NULL if not configured. */
+    char *acl_filename;           /* ACL Users file. NULL if not configured. */
     unsigned long acllog_max_len; /* Maximum length of the ACL LOG list. */
-    sds requirepass;        /* Remember the cleartext password set with the
-                               old "requirepass" directive for backward
-                               compatibility with Redis <= 5. */
+    sds requirepass;              /* Remember the cleartext password set with
+                                     the old "requirepass" directive for
+                                     backward compatibility with Redis <= 5. */
+    int acl_pubusub_default;      /* Default ACL pub/sub channels flag */
     /* Assert & bug reporting */
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
     /* System hardware info */

--- a/src/server.h
+++ b/src/server.h
@@ -761,6 +761,8 @@ typedef struct readyList {
                                            no AUTH is needed, and every
                                            connection is immediately
                                            authenticated. */
+#define USER_FLAG_ALLCHANNELS (1<<5)    /* The user can mention any Pub/Sub
+                                           channel. */
 typedef struct {
     sds name;       /* The username as an SDS string. */
     uint64_t flags; /* See USER_FLAG_* */
@@ -784,6 +786,10 @@ typedef struct {
     list *patterns;  /* A list of allowed key patterns. If this field is NULL
                         the user cannot mention any key in a command, unless
                         the flag ALLKEYS is set in the user. */
+    list *channels;  /* A list of allowed Pub/Sub channel patterns. If this
+                        field is NULL the user cannot mention any channel in a
+                        `PUBLISH` or [P][UNSUSBSCRIBE] command, unless the flag
+                        ALLCHANNELS is set in the user. */
 } user;
 
 /* With multiplexing we need to take per-client state.
@@ -1937,17 +1943,19 @@ void sendChildCOWInfo(int ptype, char *pname);
 extern rax *Users;
 extern user *DefaultUser;
 void ACLInit(void);
-/* Return values for ACLCheckCommandPerm(). */
+/* Return values for ACLCheckCommandPerm() and ACLCheckPubsubPerm(). */
 #define ACL_OK 0
 #define ACL_DENIED_CMD 1
 #define ACL_DENIED_KEY 2
 #define ACL_DENIED_AUTH 3 /* Only used for ACL LOG entries. */
+#define ACL_DENIED_CHANNEL 4 /* Only used for pub/sub commands */
 int ACLCheckUserCredentials(robj *username, robj *password);
 int ACLAuthenticateUser(client *c, robj *username, robj *password);
 unsigned long ACLGetCommandID(const char *cmdname);
 void ACLClearCommandID(void);
 user *ACLGetUserByName(const char *name, size_t namelen);
 int ACLCheckCommandPerm(client *c, int *keyidxptr);
+int ACLCheckPubsubPerm(client *c, int idx, int count, int literal, int *idxptr);
 int ACLSetUser(user *u, const char *op, ssize_t oplen);
 sds ACLDefaultUserFirstPassword(void);
 uint64_t ACLGetCommandCategoryFlagByName(const char *name);
@@ -2071,6 +2079,7 @@ struct redisMemOverhead *getMemoryOverheadData(void);
 void freeMemoryOverheadData(struct redisMemOverhead *mh);
 void checkChildrenDone(void);
 int setOOMScoreAdj(int process_class);
+void rejectCommandFormat(client *c, const char *fmt, ...);
 
 #define RESTART_SERVER_NONE 0
 #define RESTART_SERVER_GRACEFULLY (1<<0)     /* Do proper shutdown. */

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -63,7 +63,7 @@ start_server {tags {"modules"}} {
             r do_rm_call monitor
         } e
         set e
-    } {*MONITOR is not allow*}
+    } {*ERR*DENY BLOCKING*}
 
     test {subscribe disallow inside RM_Call} {
         set e {}
@@ -71,5 +71,5 @@ start_server {tags {"modules"}} {
             r do_rm_call subscribe x
         } e
         set e
-    } {*subscribe is not allow*}
+    } {*ERR*DENY BLOCKING*}
 }


### PR DESCRIPTION
Fixes #7923.

This PR appropriates the special `&` symbol (because `@` and `*` are taken), followed by a literal value or pattern for describing the Pub/Sub patterns that an ACL user can interact with. It is similar to the existing key patterns mechanism in function (additive) and implementation (copy-pasta). It also adds the `allchannels` and `resetchannels` ACL keywords, naturally.

The default user is given `allchannels` permissions, whereas new users get whatever is defined by the 'acl-pubsub-default' configuration directive. For backward compatibility in 6.2, the default of this directive is `allchannels` but this is likely to be changed to `resetchannels` in the next major version for stronger default security settings.

Unless `allchannels` is set for the user, channel access  permissions are checked as follows :
* Calls to both `PUBLISH` and `SUBSCRIBE` will fail unless a pattern matching the argumentative channel name(s) exists for the user.
* Calls to `PSUBSCRIBE` will fail unless the pattern(s) provided as an argument literally exist(s) in the user's list.
* Such failures are logged to the ACL log.

Runtime changes to channel permissions for a user with existing subscribing clients cause said clients to disconnect unless the new permissions permit the connections to continue. Note, however, that `PSUBSCRIBE`rs' patterns are matched literally, so given the change `bar:*` -> `b*`, pattern subscribers to `bar:*` **will be disconnected**.

Notes/questions:
* `UNSUBSCRIBE`, `PUNSUBSCRIBE`  and `PUBSUB` remain unprotected due to lack of reasons for touching them.

To do:
* [ ] Decide whether to add/use `nochannels` and `nokeys` as aliases/instead
