### PR TITLE
redis-cli cluster import support source and target that need auth

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1818,8 +1818,6 @@ static void usage(void) {
 "                     (if both are used, this argument takes precedence).\n"
 "  --user <username>  Used to send ACL style 'AUTH username pass'. Needs -a.\n"
 "  --pass <password>  Alias of -a for consistency with the new --user option.\n"
-"  --from-user <username>  Source node auth user name where we import keys from.\n"
-"  --from-pass <password>  Source node auth password where we import keys from.\n"
 "  --askpass          Force user to input password with mask from STDIN.\n"
 "                     If this argument is used, '-a' and " REDIS_CLI_AUTH_ENV "\n"
 "                     environment variable will be ignored.\n"
@@ -2439,7 +2437,7 @@ clusterManagerCommandDef clusterManagerCommands[] = {
     {"set-timeout", clusterManagerCommandSetTimeout, 2,
      "host:port milliseconds", NULL},
     {"import", clusterManagerCommandImport, 1, "host:port",
-     "from <arg>,copy,replace"},
+     "from <arg>,from-user <arg>,from-pass <arg>,from-askpass,copy,replace"},
     {"backup", clusterManagerCommandBackup, 2,  "host:port backup_directory",
      NULL},
     {"help", clusterManagerCommandHelp, 0, NULL, NULL}

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6412,7 +6412,7 @@ static int clusterManagerCommandImport(int argc, char **argv) {
                 src_port, src_ctx->errstr);
         goto cleanup;
     }
-    //Auth for the source node. 
+    // Auth for the source node. 
     char *from_user = config.cluster_manager_command.from_user;
     char *from_pass = config.cluster_manager_command.from_pass;
     if (cliAuth(src_ctx, from_user, from_pass) == REDIS_ERR) {


### PR DESCRIPTION
This commit fixes https://github.com/redis/redis/issues/6489 by providing two different flags --cluster-from-user, --cluster-from-pass and --cluster-askpass for source node authentication. Also for cluster node authentication, using existing --user and --pass flag.

Example:
./redis-cli --cluster import 127.0.0.1:7000 --cluster-from 127.0.0.1:6379 --pass 1234 --user default --cluster-from-user default --cluster-from-pass 123456 

./redis-cli --cluster import 127.0.0.1:7000 --cluster-from 127.0.0.1:6379 --askpass --cluster-from-user default --cluster-from-askpass 
