### PR TITLE
cleanup: move list pop logic to single function

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1786,6 +1786,7 @@ void listTypeDelete(listTypeIterator *iter, listTypeEntry *entry);
 void listTypeConvert(robj *subject, int enc);
 void unblockClientWaitingData(client *c);
 void popGenericCommand(client *c, int where);
+void listElementsRemoved(client *c, robj *key, int where, robj *o);
 
 /* MULTI/EXEC/WATCH... */
 void unwatchAllKeys(client *c);


### PR DESCRIPTION
BLPOP when there are elements in the list works in the same way as LPOP
does. Due to this they also does the same repeatitive action and logic
for the same is written at two different places. This is a bad code
practice as the one needs the context to change the BLPOP list pop code
as well when the LPOP code gets changed.

Separated the generic logic from LPOP to a function that is being used
by the BLPOP code as well.