### PR TITLE
Update redis.conf to recommend use of /run.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -112,7 +112,7 @@ tcp-backlog 511
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
 #
-# unixsocket /tmp/redis.sock
+# unixsocket /run/redis.sock
 # unixsocketperm 700
 
 # Close the connection after a client is idle for N seconds (0 to disable)
@@ -251,6 +251,9 @@ supervised no
 #
 # Creating a pid file is best effort: if Redis is not able to create it
 # nothing bad happens, the server will start and run normally.
+#
+# Note that on modern Linux systems "/run/redis.pid" is more conforming
+# and should be used instead.
 pidfile /var/run/redis_6379.pid
 
 # Specify the server verbosity level.


### PR DESCRIPTION
Fixes #8001 