### PR TITLE
Enable specifying the prefered ciphers(TLS <= v1.2) / ciphersuites(TLS v1.3) for redis-cli/redis-benchmark

### DIFF
--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -78,6 +78,14 @@ int cliSecureConnection(redisContext *c, cliSSLconfig config, const char **err) 
             *err = "Invalid private key";
             goto error;
         }
+        if (config.ciphers && !SSL_CTX_set_cipher_list(ssl_ctx, config.ciphers)) {
+            *err = "Error while configuring ciphers";
+            goto error;
+        }
+        if (config.ciphersuites && !SSL_CTX_set_ciphersuites(ssl_ctx, config.ciphersuites)) {
+            *err = "Error while setting cypher suites";
+            goto error;
+        }
     }
 
     SSL *ssl = SSL_new(ssl_ctx);

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -53,7 +53,6 @@ int cliSecureConnection(redisContext *c, cliSSLconfig config, const char **err) 
             *err = "Failed to create SSL_CTX";
             goto error;
         }
-
         SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
         SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER, NULL);
 
@@ -82,10 +81,12 @@ int cliSecureConnection(redisContext *c, cliSSLconfig config, const char **err) 
             *err = "Error while configuring ciphers";
             goto error;
         }
+#ifdef TLS1_3_VERSION
         if (config.ciphersuites && !SSL_CTX_set_ciphersuites(ssl_ctx, config.ciphersuites)) {
             *err = "Error while setting cypher suites";
             goto error;
         }
+#endif
     }
 
     SSL *ssl = SSL_new(ssl_ctx);

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -14,6 +14,10 @@ typedef struct cliSSLconfig {
     char *cert;
     /* Private key file to authenticate with, or NULL */
     char *key;
+    /* Prefered cipher list, or NULL (applies only to <= TLSv1.2) */
+    char* ciphers;
+    /* Prefered ciphersuites list, or NULL (applies only to TLSv1.3) */
+    char* ciphersuites;
 } cliSSLconfig;
 
 /* Wrapper around redisSecureConnection to avoid hiredis_ssl dependencies if

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1520,6 +1520,12 @@ int parseOptions(int argc, const char **argv) {
         } else if (!strcmp(argv[i],"--key")) {
             if (lastarg) goto invalid;
             config.sslconfig.key = strdup(argv[++i]);
+        } else if (!strcmp(argv[i],"--tls-ciphers")) {
+            if (lastarg) goto invalid;
+            config.sslconfig.ciphers = strdup(argv[++i]);
+        } else if (!strcmp(argv[i],"--tls-ciphersuites")) {
+            if (lastarg) goto invalid;
+            config.sslconfig.ciphersuites = strdup(argv[++i]);
         #endif
         } else {
             /* Assume the user meant to provide an option when the arg starts
@@ -1577,6 +1583,15 @@ usage:
 "                    system-wide trusted root certs configuration will apply.\n"
 " --cert <file>      Client certificate to authenticate with.\n"
 " --key <file>       Private key file to authenticate with.\n"
+" --tls-ciphers <list> Sets the list of prefered ciphers (TLSv1.2 and below)\n"
+"                    in order of preference from highest to lowest separated by colon (\":\").\n"
+"                    See the ciphers(1ssl) manpage for more information about the syntax of this string.\n"
+"                    If none is specified, the default system-wide settings are used.\n"
+" --tls-ciphersuites <list> Sets the list of prefered ciphersuites (TLSv1.3)\n"
+"                    in order of preference from highest to lowest separated by colon (\":\").\n"
+"                    See the ciphers(1ssl) manpage for more information about the syntax of this string,\n"
+"                    and specifically for TLSv1.3 ciphersuites.\n"
+"                    If none is specified, the default system-wide settings are used.\n"
 #endif
 " --help             Output this help and exit.\n"
 " --version          Output version and exit.\n\n"

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1523,9 +1523,11 @@ int parseOptions(int argc, const char **argv) {
         } else if (!strcmp(argv[i],"--tls-ciphers")) {
             if (lastarg) goto invalid;
             config.sslconfig.ciphers = strdup(argv[++i]);
+        #ifdef TLS1_3_VERSION
         } else if (!strcmp(argv[i],"--tls-ciphersuites")) {
             if (lastarg) goto invalid;
             config.sslconfig.ciphersuites = strdup(argv[++i]);
+        #endif
         #endif
         } else {
             /* Assume the user meant to provide an option when the arg starts

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1586,12 +1586,10 @@ usage:
 " --tls-ciphers <list> Sets the list of prefered ciphers (TLSv1.2 and below)\n"
 "                    in order of preference from highest to lowest separated by colon (\":\").\n"
 "                    See the ciphers(1ssl) manpage for more information about the syntax of this string.\n"
-"                    If none is specified, the default system-wide settings are used.\n"
 " --tls-ciphersuites <list> Sets the list of prefered ciphersuites (TLSv1.3)\n"
 "                    in order of preference from highest to lowest separated by colon (\":\").\n"
 "                    See the ciphers(1ssl) manpage for more information about the syntax of this string,\n"
 "                    and specifically for TLSv1.3 ciphersuites.\n"
-"                    If none is specified, the default system-wide settings are used.\n"
 #endif
 " --help             Output this help and exit.\n"
 " --version          Output version and exit.\n\n"

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1588,10 +1588,12 @@ usage:
 " --tls-ciphers <list> Sets the list of prefered ciphers (TLSv1.2 and below)\n"
 "                    in order of preference from highest to lowest separated by colon (\":\").\n"
 "                    See the ciphers(1ssl) manpage for more information about the syntax of this string.\n"
+#ifdef TLS1_3_VERSION
 " --tls-ciphersuites <list> Sets the list of prefered ciphersuites (TLSv1.3)\n"
 "                    in order of preference from highest to lowest separated by colon (\":\").\n"
 "                    See the ciphers(1ssl) manpage for more information about the syntax of this string,\n"
 "                    and specifically for TLSv1.3 ciphersuites.\n"
+#endif
 #endif
 " --help             Output this help and exit.\n"
 " --version          Output version and exit.\n\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1769,13 +1769,15 @@ static void usage(void) {
 "                     system-wide trusted root certs configuration will apply.\n"
 "  --cert <file>      Client certificate to authenticate with.\n"
 "  --key <file>       Private key file to authenticate with.\n"
-" --tls-ciphers <list> Sets the list of prefered ciphers (TLSv1.2 and below)\n"
+"  --tls-ciphers <list> Sets the list of prefered ciphers (TLSv1.2 and below)\n"
 "                     in order of preference from highest to lowest separated by colon (\":\").\n"
 "                     See the ciphers(1ssl) manpage for more information about the syntax of this string.\n"
-" --tls-ciphersuites <list> Sets the list of prefered ciphersuites (TLSv1.3)\n"
+#ifdef TLS1_3_VERSION
+"  --tls-ciphersuites <list> Sets the list of prefered ciphersuites (TLSv1.3)\n"
 "                     in order of preference from highest to lowest separated by colon (\":\").\n"
 "                     See the ciphers(1ssl) manpage for more information about the syntax of this string,\n"
 "                     and specifically for TLSv1.3 ciphersuites.\n"
+#endif
 #endif
 "  --raw              Use raw formatting for replies (default when STDOUT is\n"
 "                     not a tty).\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1770,12 +1770,10 @@ static void usage(void) {
 " --tls-ciphers <list> Sets the list of prefered ciphers (TLSv1.2 and below)\n"
 "                     in order of preference from highest to lowest separated by colon (\":\").\n"
 "                     See the ciphers(1ssl) manpage for more information about the syntax of this string.\n"
-"                     If none is specified, the default system-wide settings are used.\n"
 " --tls-ciphersuites <list> Sets the list of prefered ciphersuites (TLSv1.3)\n"
 "                     in order of preference from highest to lowest separated by colon (\":\").\n"
 "                     See the ciphers(1ssl) manpage for more information about the syntax of this string,\n"
 "                     and specifically for TLSv1.3 ciphersuites.\n"
-"                     If none is specified, the default system-wide settings are used.\n"
 #endif
 "  --raw              Use raw formatting for replies (default when STDOUT is\n"
 "                     not a tty).\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1641,6 +1641,10 @@ static int parseOptions(int argc, char **argv) {
             config.sslconfig.cert = argv[++i];
         } else if (!strcmp(argv[i],"--key") && !lastarg) {
             config.sslconfig.key = argv[++i];
+        } else if (!strcmp(argv[i],"--tls-ciphers") && !lastarg) {
+            config.sslconfig.ciphers = argv[++i];
+        } else if (!strcmp(argv[i],"--tls-ciphersuites") && !lastarg) {
+            config.sslconfig.ciphersuites = argv[++i];
 #endif
         } else if (!strcmp(argv[i],"-v") || !strcmp(argv[i], "--version")) {
             sds version = cliVersion();
@@ -1763,6 +1767,15 @@ static void usage(void) {
 "                     system-wide trusted root certs configuration will apply.\n"
 "  --cert <file>      Client certificate to authenticate with.\n"
 "  --key <file>       Private key file to authenticate with.\n"
+" --tls-ciphers <list> Sets the list of prefered ciphers (TLSv1.2 and below)\n"
+"                     in order of preference from highest to lowest separated by colon (\":\").\n"
+"                     See the ciphers(1ssl) manpage for more information about the syntax of this string.\n"
+"                     If none is specified, the default system-wide settings are used.\n"
+" --tls-ciphersuites <list> Sets the list of prefered ciphersuites (TLSv1.3)\n"
+"                     in order of preference from highest to lowest separated by colon (\":\").\n"
+"                     See the ciphers(1ssl) manpage for more information about the syntax of this string,\n"
+"                     and specifically for TLSv1.3 ciphersuites.\n"
+"                     If none is specified, the default system-wide settings are used.\n"
 #endif
 "  --raw              Use raw formatting for replies (default when STDOUT is\n"
 "                     not a tty).\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1643,8 +1643,10 @@ static int parseOptions(int argc, char **argv) {
             config.sslconfig.key = argv[++i];
         } else if (!strcmp(argv[i],"--tls-ciphers") && !lastarg) {
             config.sslconfig.ciphers = argv[++i];
+        #ifdef TLS1_3_VERSION
         } else if (!strcmp(argv[i],"--tls-ciphersuites") && !lastarg) {
             config.sslconfig.ciphersuites = argv[++i];
+        #endif
 #endif
         } else if (!strcmp(argv[i],"-v") || !strcmp(argv[i], "--version")) {
             sds version = cliVersion();

--- a/tests/integration/redis-benchmark.tcl
+++ b/tests/integration/redis-benchmark.tcl
@@ -143,15 +143,25 @@ start_server {tags {"benchmark"}} {
             test {benchmark: specific tls-ciphersuites} {
                 r flushall
                 r config resetstat
+                set ciphersuites_supported 1
                 set cmd [redisbenchmark $master_host $master_port "-r 50 -t set -n 1000 --tls-ciphersuites \"TLS_AES_128_GCM_SHA256\""]
                 if {[catch { exec {*}$cmd } error]} {
                     set first_line [lindex [split $error "\n"] 0]
-                    puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
-                    fail "redis-benchmark non zero code. first line: $first_line"
+                    if {[string match "*Invalid option*" $first_line]} {
+                        set ciphersuites_supported 0
+                        if {$::verbose} {
+                            puts "Skipping test, TLSv1.3 not supported."
+                        }
+                    } else {
+                        puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
+                        fail "redis-benchmark non zero code. first line: $first_line"
+                    }
                 }
-                assert_match  {*calls=1000,*} [cmdstat set]
-                # assert one of the non benchmarked commands is not present
-                assert_match  {} [cmdstat get]
+                if {$ciphersuites_supported} {
+                    assert_match  {*calls=1000,*} [cmdstat set]
+                    # assert one of the non benchmarked commands is not present
+                    assert_match  {} [cmdstat get]
+                }
             }
         }
     }

--- a/tests/integration/redis-benchmark.tcl
+++ b/tests/integration/redis-benchmark.tcl
@@ -123,5 +123,36 @@ start_server {tags {"benchmark"}} {
             # ensure the keyspace has the desired size
             assert_match  {50} [scan [regexp -inline {keys\=([\d]*)} [r info keyspace]] keys=%d]
         }
+
+        # tls specific tests
+        if {$::tls} {
+            test {benchmark: specific tls-ciphers} {
+                r flushall
+                r config resetstat
+                set cmd [redisbenchmark $master_host $master_port "-r 50 -t set -n 1000 --tls-ciphers \"DEFAULT:-AES128-SHA256\""]
+                if {[catch { exec {*}$cmd } error]} {
+                    set first_line [lindex [split $error "\n"] 0]
+                    puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
+                    fail "redis-benchmark non zero code. first line: $first_line"
+                }
+                assert_match  {*calls=1000,*} [cmdstat set]
+                # assert one of the non benchmarked commands is not present
+                assert_match  {} [cmdstat get]
+            }
+
+            test {benchmark: specific tls-ciphersuites} {
+                r flushall
+                r config resetstat
+                set cmd [redisbenchmark $master_host $master_port "-r 50 -t set -n 1000 --tls-ciphersuites \"TLS_AES_128_GCM_SHA256\""]
+                if {[catch { exec {*}$cmd } error]} {
+                    set first_line [lindex [split $error "\n"] 0]
+                    puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
+                    fail "redis-benchmark non zero code. first line: $first_line"
+                }
+                assert_match  {*calls=1000,*} [cmdstat set]
+                # assert one of the non benchmarked commands is not present
+                assert_match  {} [cmdstat get]
+            }
+        }
     }
 }


### PR DESCRIPTION
The following PR enables specifying the prefered ciphers list (TLS <=v1.2) or prefered ciphersuites (TLS v1.3)  to connect to redis-server. ( Added tests for both variations )
Here is a sample usage:

TLS <= v1.2
```
redis-benchmark  --cacert <...> --tls --tls-ciphers "DEFAULT:-AES128-SHA256" 
```

TLS v1.3
```
redis-benchmark  --cacert <...> --tls --tls-ciphersuites "TLS_AES_128_GCM_SHA256" 
```