### PR TITLE
Rewritten commands are logged as their original command

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3467,8 +3467,13 @@ void call(client *c, int flags) {
         char *latency_event = (c->cmd->flags & CMD_FAST) ?
                               "fast-command" : "command";
         latencyAddSampleIfNeeded(latency_event,duration/1000);
-        slowlogPushEntryIfNeeded(c,c->argv,c->argc,duration);
+        /* If command argument vector was rewritten, use the original
+         * arguments. */
+        robj **argv = c->original_argv ? c->original_argv : c->argv;
+        int argc = c->original_argv ? c->original_argc : c->argc;
+        slowlogPushEntryIfNeeded(c,argv,argc,duration);
     }
+    freeClientOriginalArgv(c);
 
     if (flags & CMD_CALL_STATS) {
         /* use the real command that was executed (cmd and lastamc) may be

--- a/src/server.h
+++ b/src/server.h
@@ -808,6 +808,8 @@ typedef struct client {
     size_t querybuf_peak;   /* Recent (100ms or more) peak of querybuf size. */
     int argc;               /* Num of arguments of current command. */
     robj **argv;            /* Arguments of current command. */
+    int original_argc;      /* Num of arguments of original command if arguments were rewritten. */
+    robj **original_argv;   /* Arguments of original command if arguments were rewritten. */
     size_t argv_len_sum;    /* Sum of lengths of objects in argv list. */
     struct redisCommand *cmd, *lastcmd;  /* Last command executed. */
     user *user;             /* User associated with this connection. If the
@@ -1668,6 +1670,7 @@ void closeTimedoutClients(void);
 void freeClient(client *c);
 void freeClientAsync(client *c);
 void resetClient(client *c);
+void freeClientOriginalArgv(client *c);
 void sendReplyToClient(connection *conn);
 void *addReplyDeferredLen(client *c);
 void setDeferredArrayLen(client *c, void *node, long length);

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -71,7 +71,7 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         r set A 0
         r slowlog reset
         
-        # INCRBYFLOAT is replicated is SET
+        # INCRBYFLOAT is replicated as SET
         r INCRBYFLOAT A 1.0
         assert_equal {INCRBYFLOAT A 1.0} [lindex [lindex [r slowlog get] 0] 3]
     }

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -41,6 +41,16 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         assert_equal {foobar} [lindex $e 5]
     }
 
+    test {SLOWLOG - Rewritten commands are logged as their original command} {
+        r sadd set a b c d e
+        r config set slowlog-log-slower-than 0
+        r slowlog reset
+        # spop is replicated as DEL when all the members are removed
+        r spop set 10
+
+        lindex [lindex [r slowlog get] 0] 3
+    } {spop set 10}
+
     test {SLOWLOG - commands with too many arguments are trimmed} {
         r config set slowlog-log-slower-than 0
         r slowlog reset

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -66,6 +66,14 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         # GETSET is replicated as SET
         r getset a 5
         assert_equal {getset a 5} [lindex [lindex [r slowlog get] 0] 3]
+
+        # INCRBYFLOAT calls rewrite multiple times, so it's a special case
+        r set A 0
+        r slowlog reset
+        
+        # INCRBYFLOAT is replicated is SET
+        r INCRBYFLOAT A 1.0
+        assert_equal {INCRBYFLOAT A 1.0} [lindex [lindex [r slowlog get] 0] 3]
     }
 
     test {SLOWLOG - commands with too many arguments are trimmed} {


### PR DESCRIPTION
Slowlog emits whatever is on the client argv, which can be rewritten for replication. Note: They are rewritten even when there is no replica, so this occurs on standalone redis instances as well. 