### PR TITLE
config rewrite enhancement, in case of line longer than 1024

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1010,17 +1010,32 @@ struct rewriteConfigState *rewriteConfigReadOldFile(char *path) {
     FILE *fp = fopen(path,"r");
     if (fp == NULL && errno != ENOENT) return NULL;
 
-    char buf[CONFIG_MAX_LINE+1];
+    struct redis_stat sb;
+    if (fp && redis_fstat(fileno(fp),&sb) == -1) return NULL;
+
     int linenum = -1;
     struct rewriteConfigState *state = rewriteConfigCreateState();
 
-    if (fp == NULL) return state;
+    if (fp == NULL || sb.st_size == 0) return state;
 
-    /* Read the old file line by line, populate the state. */
-    while(fgets(buf,CONFIG_MAX_LINE+1,fp) != NULL) {
+    /* Load the file content */
+    sds config = sdsnewlen(SDS_NOINIT,sb.st_size);
+    if (fread(config,1,sb.st_size,fp) == 0) {
+        sdsfree(config);
+        rewriteConfigReleaseState(state);
+        fclose(fp);
+        return NULL;
+    }
+
+    int i, totlines;
+    sds *lines = sdssplitlen(config,sdslen(config),"\n",1,&totlines);
+
+    /* Read the old content line by line, populate the state. */
+    for (i = 0; i < totlines; i++) {
         int argc;
         sds *argv;
-        sds line = sdstrim(sdsnew(buf),"\r\n\t ");
+        sds line = sdstrim(lines[i],"\r\n\t ");
+        lines[i] = NULL;
 
         linenum++; /* Zero based, so we init at -1 */
 
@@ -1076,6 +1091,8 @@ struct rewriteConfigState *rewriteConfigReadOldFile(char *path) {
         sdsfreesplitres(argv,argc);
     }
     fclose(fp);
+    sdsfreesplitres(lines,totlines);
+    sdsfree(config);
     return state;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -592,9 +592,10 @@ loaderr:
  * Both filename and options can be NULL, in such a case are considered
  * empty. This way loadServerConfig can be used to just load a file or
  * just load a string. */
+#define CONFIG_READ_LEN 1024
 void loadServerConfig(char *filename, char config_from_stdin, char *options) {
     sds config = sdsempty();
-    char buf[CONFIG_MAX_LINE+1];
+    char buf[CONFIG_READ_LEN+1];
     FILE *fp;
     glob_t globbuf;
 
@@ -626,7 +627,7 @@ void loadServerConfig(char *filename, char config_from_stdin, char *options) {
                                   globbuf.gl_pathv[i], strerror(errno));
                         exit(1);
                     }
-                    while(fgets(buf,CONFIG_MAX_LINE+1,fp) != NULL)
+                    while(fgets(buf,CONFIG_READ_LEN+1,fp) != NULL)
                         config = sdscat(config,buf);
                     fclose(fp);
                 }
@@ -642,7 +643,7 @@ void loadServerConfig(char *filename, char config_from_stdin, char *options) {
                           filename, strerror(errno));
                 exit(1);
             }
-            while(fgets(buf,CONFIG_MAX_LINE+1,fp) != NULL)
+            while(fgets(buf,CONFIG_READ_LEN+1,fp) != NULL)
                 config = sdscat(config,buf);
             fclose(fp);
         }
@@ -652,7 +653,7 @@ void loadServerConfig(char *filename, char config_from_stdin, char *options) {
     if (config_from_stdin) {
         serverLog(LL_WARNING,"Reading config from stdin");
         fp = stdin;
-        while(fgets(buf,CONFIG_MAX_LINE+1,fp) != NULL)
+        while(fgets(buf,CONFIG_READ_LEN+1,fp) != NULL)
             config = sdscat(config,buf);
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -103,7 +103,6 @@ typedef long long ustime_t; /* microsecond time type. */
 #define CONFIG_MIN_HZ            1
 #define CONFIG_MAX_HZ            500
 #define MAX_CLIENTS_PER_CLOCK_TICK 200          /* HZ is adapted based on that. */
-#define CONFIG_MAX_LINE    1024
 #define CRON_DBS_PER_CALL 16
 #define NET_MAX_WRITES_PER_EVENT (1024*64)
 #define PROTO_SHARED_SELECT_CMDS 10


### PR DESCRIPTION
When rewrite the config file, we need read the old config file first, and the CONFIG_MAX_LEN is 1024, so if some lines are longer than, it will generate a wrong config file, and redis cannot reboot from the new config file.