### PR TITLE
Tests: fix issues with defrag tests

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -133,7 +133,8 @@ proc execute_test_file name {
 # as argument, and an associated name.
 # It will run the specified code and signal it to the test server when
 # finished.
-proc execute_test_code {name code} {
+proc execute_test_code {name filename code} {
+    set ::curfile $filename
     eval $code
     send_data_packet $::test_server_fd done "$name"
 }
@@ -238,7 +239,7 @@ proc run_solo {name code} {
         eval $code
         return
     }
-    send_data_packet $::test_server_fd run_solo [list $name $code]
+    send_data_packet $::test_server_fd run_solo [list $name $::curfile $code]
 }
 
 proc cleanup {} {
@@ -507,8 +508,8 @@ proc test_client_main server_port {
         if {$cmd eq {run}} {
             execute_test_file $data
         } elseif {$cmd eq {run_code}} {
-            foreach {name code} $data break
-            execute_test_code $name $code
+            foreach {name filename code} $data break
+            execute_test_code $name $filename $code
         } else {
             error "Unknown test client command: $cmd"
         }

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -395,7 +395,7 @@ start_server {tags {"defrag"} overrides {appendonly yes auto-aof-rewrite-percent
             # if the current slab is lower in utilization the defragger would have ended up in stagnation,
             # keept running and not move any allocation.
             # this test is more consistent on a fresh server with no history
-            start_server {tags {"defrag"}} {
+            start_server {tags {"defrag"} overrides {save ""}} {
                 r flushdb
                 r config resetstat
                 r config set hz 100


### PR DESCRIPTION
This solves consistent defrag test failures on Ubuntu 20.04 arm64 (Pine64 A64+ board) as well as a minor issue where solo tests were not reported with their correct file name.