### PR TITLE
AOF: call redis_fsync inside flushAppendOnlyFile when force flush

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3954,7 +3954,6 @@ int prepareForShutdown(int flags) {
         /* Append only file: flush buffers and fsync() the AOF at exit */
         serverLog(LL_NOTICE,"Calling fsync() on the AOF file.");
         flushAppendOnlyFile(1);
-        redis_fsync(server.aof_fd);
     }
 
     /* Create a new RDB file before exiting. */


### PR DESCRIPTION
Avoid creating an useless bio fsync when aof_fsync is everysec.