### PR TITLE
invalid aeTimer when returning AE_NOMORE

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -5453,7 +5453,12 @@ int moduleTimerHandler(struct aeEventLoop *eventLoop, long long id, void *client
 
     /* Reschedule the next timer or cancel it. */
     if (next_period <= 0) next_period = 1;
-    return (raxSize(Timers) > 0) ? next_period : AE_NOMORE;
+    if (raxSize(Timers) > 0) {
+        return next_period;
+    } else {
+        aeTimer = -1;
+        return AE_NOMORE;
+    }
 }
 
 /* Create a new timer that will fire after `period` milliseconds, and will call


### PR DESCRIPTION
In `module.c`, when `moduleTimerHandler` returning `AE_NOMORE`, `aeTimer` become invalid. Next time when `RM_CreateTimer` is called, we know we must create a new aeTimer directly.