### PR TITLE
Unified MULTI, LUA, and RM_Call with respect to blocking commands

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -671,7 +671,18 @@ struct client *createAOFClient(void) {
     c->argv = NULL;
     c->argv_len_sum = 0;
     c->bufpos = 0;
-    c->flags = 0;
+
+    /*
+     * The AOF client should never be blocked (unlikle master
+     * replication connection).
+     * This is because blocking the AOF client might cause
+     * deadlock (because potentially no one will unblock it).
+     * Also, if the AOF client will be blocked just for
+     * background processing there is a chance that the
+     * command execution order will be violated.
+     */
+    c->flags = CLIENT_DENY_BLOCKING;
+
     c->btype = BLOCKED_NONE;
     /* We set the fake client as a slave waiting for the synchronization
      * so that Redis will not try to send replies to this client. */

--- a/src/aof.c
+++ b/src/aof.c
@@ -673,7 +673,7 @@ struct client *createAOFClient(void) {
     c->bufpos = 0;
 
     /*
-     * The AOF client should never be blocked (unlikle master
+     * The AOF client should never be blocked (unlike master
      * replication connection).
      * This is because blocking the AOF client might cause
      * deadlock (because potentially no one will unblock it).

--- a/src/module.c
+++ b/src/module.c
@@ -3465,6 +3465,8 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
     }
     call(c,call_flags);
 
+    serverAssert((c->flags & CLIENT_BLOCKED) == 0);
+
     /* Convert the result of the Redis command into a module reply. */
     sds proto = sdsnewlen(c->buf,c->bufpos);
     c->bufpos = 0;

--- a/src/module.c
+++ b/src/module.c
@@ -1947,6 +1947,8 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
              flags |= REDISMODULE_CTX_FLAGS_LUA;
             if (ctx->client->flags & CLIENT_MULTI)
              flags |= REDISMODULE_CTX_FLAGS_MULTI;
+            if (ctx->client->flags & CLIENT_DENY_BLOCKING)
+             flags |= REDISMODULE_CTX_FLAGS_DENY_BLOCKING;
             /* Module command received from MASTER, is replicated. */
             if (ctx->client->flags & CLIENT_MASTER)
              flags |= REDISMODULE_CTX_FLAGS_REPLICATED;
@@ -3392,6 +3394,9 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
 
     /* Setup our fake client for command execution. */
     c->flags |= CLIENT_MODULE;
+
+    /* We do not want to allow block, the module do not expect it */
+    c->flags |= CLIENT_DENY_BLOCKING;
     c->db = ctx->client->db;
     c->argv = argv;
     c->argc = argc;

--- a/src/multi.c
+++ b/src/multi.c
@@ -83,7 +83,7 @@ void queueMultiCommand(client *c) {
 void discardTransaction(client *c) {
     freeClientMultiState(c);
     initClientMultiState(c);
-    c->flags &= ~(CLIENT_MULTI|CLIENT_DIRTY_CAS|CLIENT_DIRTY_EXEC);
+    c->flags &= ~(CLIENT_DENY_BLOCKING|CLIENT_MULTI|CLIENT_DIRTY_CAS|CLIENT_DIRTY_EXEC);
     unwatchAllKeys(c);
 }
 
@@ -100,6 +100,9 @@ void multiCommand(client *c) {
         return;
     }
     c->flags |= CLIENT_MULTI;
+
+    /* we do not want to allow blocking commands inside multi */
+    c->flags |= CLIENT_DENY_BLOCKING;
     addReply(c,shared.ok);
 }
 

--- a/src/multi.c
+++ b/src/multi.c
@@ -209,6 +209,7 @@ void execCommand(client *c) {
                 "no permission to touch the specified keys");
         } else {
             call(c,server.loading ? CMD_CALL_NONE : CMD_CALL_FULL);
+            serverAssert((c->flags & CLIENT_BLOCKED) == 0);
         }
 
         /* Commands may alter argc/argv, restore mstate. */

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -362,7 +362,7 @@ void subscribeCommand(client *c) {
 
     if ((c->flags & CLIENT_DENY_BLOCKING) && !(c->flags & CLIENT_MULTI)) {
         /**
-         * A Client that has CLIENT_DENY_BLOCKING flag on
+         * A client that has CLIENT_DENY_BLOCKING flag on
          * expect a reply per command and so can not execute subscribe.
          *
          * Notice that we have a special treatment for multi because of

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -360,6 +360,18 @@ int pubsubPublishMessage(robj *channel, robj *message) {
 void subscribeCommand(client *c) {
     int j;
 
+    if ((c->flags & CLIENT_DENY_BLOCKING) && !(c->flags & CLIENT_MULTI)) {
+        /**
+         * A Client that has CLIENT_DENY_BLOCKING flag on
+         * expect a reply per command and so can not execute subscribe.
+         *
+         * Notice that we have a special treatment for multi because of
+         * backword compatibility
+         */
+        addReplyError(c, "subscribe is not allow on DENY BLOCKING client");
+        return;
+    }
+
     for (j = 1; j < c->argc; j++)
         pubsubSubscribeChannel(c,c->argv[j]);
     c->flags |= CLIENT_PUBSUB;

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -394,7 +394,7 @@ void psubscribeCommand(client *c) {
 
     if ((c->flags & CLIENT_DENY_BLOCKING) && !(c->flags & CLIENT_MULTI)) {
         /**
-         * A Client that has CLIENT_DENY_BLOCKING flag on
+         * A client that has CLIENT_DENY_BLOCKING flag on
          * expect a reply per command and so can not execute subscribe.
          *
          * Notice that we have a special treatment for multi because of

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -392,6 +392,18 @@ void unsubscribeCommand(client *c) {
 void psubscribeCommand(client *c) {
     int j;
 
+    if ((c->flags & CLIENT_DENY_BLOCKING) && !(c->flags & CLIENT_MULTI)) {
+        /**
+         * A Client that has CLIENT_DENY_BLOCKING flag on
+         * expect a reply per command and so can not execute subscribe.
+         *
+         * Notice that we have a special treatment for multi because of
+         * backword compatibility
+         */
+        addReplyError(c, "psubscribe is not allow on DENY BLOCKING client");
+        return;
+    }
+
     for (j = 1; j < c->argc; j++)
         pubsubSubscribePattern(c,c->argv[j]);
     c->flags |= CLIENT_PUBSUB;

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -400,7 +400,7 @@ void psubscribeCommand(client *c) {
          * Notice that we have a special treatment for multi because of
          * backword compatibility
          */
-        addReplyError(c, "psubscribe is not allow on DENY BLOCKING client");
+        addReplyError(c, "PSUBSCRIBE is not allowed for DENY BLOCKING client");
         return;
     }
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -116,7 +116,7 @@
 #define REDISMODULE_CTX_FLAGS_MULTI_DIRTY (1<<19)
 /* Redis is currently running inside background child process. */
 #define REDISMODULE_CTX_FLAGS_IS_CHILD (1<<20)
-/* The current client do not allow blocking, either called from
+/* The current client does not allow blocking, either called from
  * within multi, lua, or from another module using RM_Call */
 #define REDISMODULE_CTX_FLAGS_DENY_BLOCKING (1<<21)
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -116,11 +116,14 @@
 #define REDISMODULE_CTX_FLAGS_MULTI_DIRTY (1<<19)
 /* Redis is currently running inside background child process. */
 #define REDISMODULE_CTX_FLAGS_IS_CHILD (1<<20)
+/* The current client do not allow blocking, either called from
+ * within multi, lua, or from another module using RM_Call */
+#define REDISMODULE_CTX_FLAGS_DENY_BLOCKING (1<<21)
 
 /* Next context flag, must be updated when adding new flags above!
 This flag should not be used directly by the module.
  * Use RedisModule_GetContextFlagsAll instead. */
-#define _REDISMODULE_CTX_FLAGS_NEXT (1<<21)
+#define _REDISMODULE_CTX_FLAGS_NEXT (1<<22)
 
 /* Keyspace changes notification classes. Every class is associated with a
  * character for configuration purposes.

--- a/src/replication.c
+++ b/src/replication.c
@@ -1372,7 +1372,21 @@ void replicationCreateMasterClient(connection *conn, int dbid) {
     server.master = createClient(conn);
     if (conn)
         connSetReadHandler(server.master->conn, readQueryFromClient);
+
+    /**
+     * Notice!!!
+     * The CLIENT_DENY_BLOCKING flag is not, and should not, be set here.
+     * On command like BLPOP, it makes no sense to block the master connection
+     * And such blocking attempt will probably cause deadlock and break the
+     * replication. We consider such a thing as a bug because command like blpop
+     * should never be sent on the replication link.
+     * A possible use-case for blocking the replication link is if a module wants
+     * to pass the execution to a background thread and unblock after the
+     * execution is done. This is the reason why we allow blocking the replication
+     * connection.
+     */
     server.master->flags |= CLIENT_MASTER;
+
     server.master->authenticated = 1;
     server.master->reploff = server.master_initial_offset;
     server.master->read_reploff = server.master->reploff;

--- a/src/replication.c
+++ b/src/replication.c
@@ -1374,17 +1374,16 @@ void replicationCreateMasterClient(connection *conn, int dbid) {
         connSetReadHandler(server.master->conn, readQueryFromClient);
 
     /**
-     * Notice!!!
+     * Important note:
      * The CLIENT_DENY_BLOCKING flag is not, and should not, be set here.
-     * On command like BLPOP, it makes no sense to block the master connection
-     * And such blocking attempt will probably cause deadlock and break the
-     * replication. We consider such a thing as a bug because command like blpop
-     * should never be sent on the replication link.
+     * For commands like BLPOP, it makes no sense to block the master
+     * connection, and such blocking attempt will probably cause deadlock and
+     * break the replication. We consider such a thing as a bug because
+     * commands as BLPOP should never be sent on the replication link.
      * A possible use-case for blocking the replication link is if a module wants
      * to pass the execution to a background thread and unblock after the
      * execution is done. This is the reason why we allow blocking the replication
-     * connection.
-     */
+     * connection. */
     server.master->flags |= CLIENT_MASTER;
 
     server.master->authenticated = 1;

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -724,6 +724,7 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
             call_flags |= CMD_CALL_PROPAGATE_REPL;
     }
     call(c,call_flags);
+    serverAssert((c->flags & CLIENT_BLOCKED) == 0);
 
     /* Convert the result of the Redis command into a suitable Lua type.
      * The first thing we need is to create a single string from the client

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1255,6 +1255,9 @@ void scriptingInit(int setup) {
     if (server.lua_client == NULL) {
         server.lua_client = createClient(NULL);
         server.lua_client->flags |= CLIENT_LUA;
+
+        /* We do not want to allow blocking commands inside lua */
+        server.lua_client->flags |= CLIENT_DENY_BLOCKING;
     }
 
     /* Lua beginners often don't use "local", this is likely to introduce

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1257,7 +1257,7 @@ void scriptingInit(int setup) {
         server.lua_client = createClient(NULL);
         server.lua_client->flags |= CLIENT_LUA;
 
-        /* We do not want to allow blocking commands inside lua */
+        /* We do not want to allow blocking commands inside Lua */
         server.lua_client->flags |= CLIENT_DENY_BLOCKING;
     }
 
@@ -2721,4 +2721,3 @@ void luaLdbLineHook(lua_State *lua, lua_Debug *ar) {
         server.lua_time_start = mstime();
     }
 }
-

--- a/src/server.c
+++ b/src/server.c
@@ -4861,7 +4861,7 @@ void monitorCommand(client *c) {
         /**
          * A client that has CLIENT_DENY_BLOCKING flag on
          * expects a reply per command and so can't execute MONITOR. */
-        addReplyError(c, "monitor is not allow on DENY BLOCKING client");
+        addReplyError(c, "MONITOR is not allowed for DENY BLOCKING client");
         return;
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -4857,13 +4857,10 @@ void infoCommand(client *c) {
 }
 
 void monitorCommand(client *c) {
-    if ((c->flags & CLIENT_DENY_BLOCKING) && !(c->flags & CLIENT_MULTI)) {
+    if (c->flags & CLIENT_DENY_BLOCKING) {
         /**
          * A Client that has CLIENT_DENY_BLOCKING flag on
          * expect a reply per command and so can not execute monitor.
-         *
-         * Notice that we have a special treatment for multi because of
-         * backword compatibility
          */
         addReplyError(c, "monitor is not allow on DENY BLOCKING client");
         return;

--- a/src/server.c
+++ b/src/server.c
@@ -4859,9 +4859,8 @@ void infoCommand(client *c) {
 void monitorCommand(client *c) {
     if (c->flags & CLIENT_DENY_BLOCKING) {
         /**
-         * A Client that has CLIENT_DENY_BLOCKING flag on
-         * expect a reply per command and so can not execute monitor.
-         */
+         * A client that has CLIENT_DENY_BLOCKING flag on
+         * expects a reply per command and so can't execute MONITOR. */
         addReplyError(c, "monitor is not allow on DENY BLOCKING client");
         return;
     }

--- a/src/server.c
+++ b/src/server.c
@@ -295,19 +295,19 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,1,1,1,0,0,0},
 
     {"brpop",brpopCommand,-3,
-     "write no-script @list @blocking",
+     "write @list @blocking",
      0,NULL,1,-2,1,0,0,0},
 
     {"brpoplpush",brpoplpushCommand,4,
-     "write use-memory no-script @list @blocking",
+     "write use-memory @list @blocking",
      0,NULL,1,2,1,0,0,0},
 
     {"blmove",blmoveCommand,6,
-     "write use-memory no-script @list @blocking",
+     "write use-memory @list @blocking",
      0,NULL,1,2,1,0,0,0},
 
     {"blpop",blpopCommand,-3,
-     "write no-script @list @blocking",
+     "write @list @blocking",
      0,NULL,1,-2,1,0,0,0},
 
     {"llen",llenCommand,2,
@@ -515,11 +515,11 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,1,1,1,0,0,0},
 
     {"bzpopmin",bzpopminCommand,-3,
-     "write no-script fast @sortedset @blocking",
+     "write fast @sortedset @blocking",
      0,NULL,1,-2,1,0,0,0},
 
     {"bzpopmax",bzpopmaxCommand,-3,
-     "write no-script fast @sortedset @blocking",
+     "write fast @sortedset @blocking",
      0,NULL,1,-2,1,0,0,0},
 
     {"hset",hsetCommand,-4,

--- a/src/server.h
+++ b/src/server.h
@@ -268,7 +268,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_CLOSE_AFTER_COMMAND (1ULL<<40) /* Close after executing commands
                                                * and writing entire reply. */
 #define CLIENT_DENY_BLOCKING (1ULL<<41) /* Indicate that the client should not be blocked.
-                                           currently, turned on inside MULTI, LUA, RM_Call,
+                                           currently, turned on inside MULTI, Lua, RM_Call,
                                            and AOF client */
 
 /* Client block type (btype field in client structure)

--- a/src/server.h
+++ b/src/server.h
@@ -267,6 +267,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_PROTOCOL_ERROR (1ULL<<39) /* Protocol error chatting with it. */
 #define CLIENT_CLOSE_AFTER_COMMAND (1ULL<<40) /* Close after executing commands
                                                * and writing entire reply. */
+#define CLIENT_DENY_BLOCKING (1ULL<<41) /* Indicate that the client should not be blocked */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/src/server.h
+++ b/src/server.h
@@ -267,7 +267,9 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_PROTOCOL_ERROR (1ULL<<39) /* Protocol error chatting with it. */
 #define CLIENT_CLOSE_AFTER_COMMAND (1ULL<<40) /* Close after executing commands
                                                * and writing entire reply. */
-#define CLIENT_DENY_BLOCKING (1ULL<<41) /* Indicate that the client should not be blocked */
+#define CLIENT_DENY_BLOCKING (1ULL<<41) /* Indicate that the client should not be blocked.
+                                           currently, turned on inside MULTI, LUA, RM_Call,
+                                           and AOF client */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -887,9 +887,9 @@ void blockingPopGenericCommand(client *c, int where) {
         }
     }
 
-    /* If we are inside a MULTI/EXEC and the list is empty the only thing
+    /* If we are not allowed to block the client, the only thing
      * we can do is treating it as a timeout (even with timeout 0). */
-    if (c->flags & CLIENT_MULTI) {
+    if (c->flags & CLIENT_DENY_BLOCKING) {
         addReplyNullArray(c);
         return;
     }
@@ -912,8 +912,8 @@ void blmoveGenericCommand(client *c, int wherefrom, int whereto, mstime_t timeou
     if (checkType(c,key,OBJ_LIST)) return;
 
     if (key == NULL) {
-        if (c->flags & CLIENT_MULTI) {
-            /* Blocking against an empty list in a multi state
+        if (c->flags & CLIENT_DENY_BLOCKING) {
+            /* Blocking against an empty list when blocking is not allowed
              * returns immediately. */
             addReplyNull(c);
         } else {

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1416,11 +1416,6 @@ void xreadCommand(client *c) {
         int moreargs = c->argc-i-1;
         char *o = c->argv[i]->ptr;
         if (!strcasecmp(o,"BLOCK") && moreargs) {
-            if (c->flags & CLIENT_LUA) {
-                /* There is no sense to use BLOCK option within LUA */
-                addReplyErrorFormat(c, "%s command is not allowed with BLOCK option from scripts", (char *)c->argv[0]->ptr);
-                return;
-            }
             i++;
             if (getTimeoutFromObjectOrReply(c,c->argv[i],&timeout,
                 UNIT_MILLISECONDS) != C_OK) return;
@@ -1628,9 +1623,9 @@ void xreadCommand(client *c) {
 
     /* Block if needed. */
     if (timeout != -1) {
-        /* If we are inside a MULTI/EXEC and the list is empty the only thing
+        /* If we are not allowed to block the client, the only thing
          * we can do is treating it as a timeout (even with timeout 0). */
-        if (c->flags & CLIENT_MULTI) {
+        if (c->flags & CLIENT_DENY_BLOCKING) {
             addReplyNullArray(c);
             goto cleanup;
         }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1416,6 +1416,15 @@ void xreadCommand(client *c) {
         int moreargs = c->argc-i-1;
         char *o = c->argv[i]->ptr;
         if (!strcasecmp(o,"BLOCK") && moreargs) {
+            if (c->flags & CLIENT_LUA) {
+                /*
+                 * Although the CLIENT_DENY_BLOCKING flag should protect from blocking the client
+                 * on LUA/MULTI/RM_Call we want a special treatment for lua to keep backword compatibility.
+                 * There is no sense to use BLOCK option within LUA
+                 */
+                addReplyErrorFormat(c, "%s command is not allowed with BLOCK option from scripts", (char *)c->argv[0]->ptr);
+                return;
+            }
             i++;
             if (getTimeoutFromObjectOrReply(c,c->argv[i],&timeout,
                 UNIT_MILLISECONDS) != C_OK) return;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1419,7 +1419,7 @@ void xreadCommand(client *c) {
             if (c->flags & CLIENT_LUA) {
                 /*
                  * Although the CLIENT_DENY_BLOCKING flag should protect from blocking the client
-                 * on LUA/MULTI/RM_Call we want a special treatment for lua to keep backword compatibility.
+                 * on Lua/MULTI/RM_Call we want special treatment for Lua to keep backword compatibility.
                  * There is no sense to use BLOCK option within LUA
                  */
                 addReplyErrorFormat(c, "%s command is not allowed with BLOCK option from scripts", (char *)c->argv[0]->ptr);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1420,8 +1420,7 @@ void xreadCommand(client *c) {
                 /*
                  * Although the CLIENT_DENY_BLOCKING flag should protect from blocking the client
                  * on Lua/MULTI/RM_Call we want special treatment for Lua to keep backword compatibility.
-                 * There is no sense to use BLOCK option within LUA
-                 */
+                 * There is no sense to use BLOCK option within Lua. */
                 addReplyErrorFormat(c, "%s command is not allowed with BLOCK option from scripts", (char *)c->argv[0]->ptr);
                 return;
             }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3356,9 +3356,9 @@ void blockingGenericZpopCommand(client *c, int where) {
         }
     }
 
-    /* If we are inside a MULTI/EXEC and the zset is empty the only thing
+    /* If we are not allowed to block the client and the zset is empty the only thing
      * we can do is treating it as a timeout (even with timeout 0). */
-    if (c->flags & CLIENT_MULTI) {
+    if (c->flags & CLIENT_DENY_BLOCKING) {
         addReplyNullArray(c);
         return;
     }

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -14,4 +14,17 @@ start_server {tags {"modules"}} {
     	r acquire_gil
     	assert_equal {{Blocked client is not supported inside multi}} [r exec]
     }
+
+    test {Locked GIL acquisition from RM_Call} {
+    	assert_equal {Blocked client is not allowed} [r do_rm_call acquire_gil]
+    }
+
+    test {Blocking command are not block the client on RM_Call} {
+    	assert {[r do_rm_call blpop empty_list 10] eq {}}
+        assert {[r do_rm_call brpop empty_list 10] eq {}}
+        assert {[r do_rm_call brpoplpush empty_list1 empty_list2 10] eq {}}
+        assert {[r do_rm_call blmove empty_list1 empty_list2 LEFT LEFT 10] eq {}}
+        assert {[r do_rm_call bzpopmin empty_zset 10] eq {}}
+        assert {[r do_rm_call bzpopmax empty_zset 10] eq {}}
+    }
 }

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -63,7 +63,7 @@ start_server {tags {"modules"}} {
             r do_rm_call monitor
         } e
         set e
-    } {*monitor is not allow*}
+    } {*MONITOR is not allow*}
 
     test {subscribe disallow inside RM_Call} {
         set e {}

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -509,14 +509,14 @@ start_server {tags {"multi"}} {
         r xgroup create s g $ MKSTREAM
 
         set m [r multi]
-        r blpop empty_list 10
-        r brpop empty_list 10
-        r brpoplpush empty_list1 empty_list2 10
-        r blmove empty_list1 empty_list2 LEFT LEFT 10
-        r bzpopmin empty_zset 10
-        r bzpopmax empty_zset 10
-        r xread BLOCK 10 STREAMS s $
-        r xreadgroup group g c BLOCK 10 STREAMS s >
+        r blpop empty_list 0
+        r brpop empty_list 0
+        r brpoplpush empty_list1 empty_list2 0
+        r blmove empty_list1 empty_list2 LEFT LEFT 0
+        r bzpopmin empty_zset 0
+        r bzpopmax empty_zset 0
+        r xread BLOCK 0 STREAMS s $
+        r xreadgroup group g c BLOCK 0 STREAMS s >
         set res [r exec]
 
         list $m $res


### PR DESCRIPTION
Blocking command should not be used with MULTI, LUA, and RM_Call. This is because, the caller, who executes the command in this context, expects a reply.

Today, LUA and MULTI have a special (and different) treatment to blocking commands:
* LUA   - Most commands are marked with no-script flag which are checked when executing and command from LUA, commands that are not marked (like XREAD) verify that their blocking mode is not used inside LUA (by checking the CLIENT_LUA client flag).
* MULTI - Command that is going to block, first verify that the client is not inside multi (by checking the CLIENT_MULTI client flag). If the client is inside multi, they return a result which is a match to the empty key with no timeout (for example blpop inside MULTI will act as lpop)

For modules that perform RM_Call with blocking command, the returned results type is REDISMODULE_REPLY_UNKNOWN and the caller can not really know what happened.

Disadvantages of the current state are:
* No unified approach, LUA, MULTI, and RM_Call, each has a different treatment
* Module can not safely execute blocking command (and get reply or error). Though It is true that modules are not like LUA or MULTI and should be smarter not to execute blocking commands on RM_Call, sometimes you want to execute a command base on client input (for example if you create a module that provides a new scripting language like javascript or python).
* While modules (on modules command) can check for REDISMODULE_CTX_FLAGS_LUA or REDISMODULE_CTX_FLAGS_MULTI to know not to block the client, there is no way to check if the command came from another module using RM_Call. So there is no way for a module to know not to block another module RM_Call execution.

The PR suggests a way to unified the treatment for blocking clients by introducing a new CLIENT_DENY_BLOCKING client flag. On LUA, MULTI, and RM_Call the new flag turned on to signify that the client should not be blocked. A blocking command
verifies that the flag is turned off before blocking. If a blocking command sees that the CLIENT_DENY_BLOCKING flag is on, it's not blocking and return results which are matches to empty key with no timeout (as MULTI does today).

The new flag is checked on the following commands:
* List blocking commands: BLPOP, BRPOP, BRPOPLPUSH, BLMOVE, 
* Zset blocking commands: BZPOPMIN, BZPOPMAX
* Stream blocking commands: XREAD, XREADGROUP
* SUBSCRIBE, PSUBSCRIBE
* MONITOR

In addition, the new flag is turned on inside the AOF client, we do not want to block the AOF client to prevent deadlocks and commands ordering issues (and there is also an existing assert in the code that verifies it).

To keep backward compatibility on LUA, all the no-script flags on existing commands were kept untouched. In addition, a LUA special treatment on `XREAD` and `XREADGROUP` was kept.

To keep backward compatibility on MULTI (which today allows SUBSCRIBE, and PSUBSCRIBE). We added a special treatment on those commands to allow executing them on MULTI.

The only backward compatibility issue that this PR introduces is that now MONITOR is not allowed inside MULTI.

Tests were added to verify blocking commands are not blocking the client on LUA, MULTI, or RM_Call. Tests were added to verify the module can check for CLIENT_DENY_BLOCKING flag.

Related issues:
* https://github.com/redis/redis/issues/7991
* https://github.com/redis/redis/issues/7992 - the next step from here is async RM_Call which does not turn on the new flag and allows the command to block it.

@oranagra @yossigo @guybe7 @itamarhaber let me know what you think. 