### PR TITLE
Moved RMAPI_FUNC_SUPPORTED location such that it will be visible to modules

### DIFF
--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1020,13 +1020,13 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
 
 #define RedisModule_Assert(_e) ((_e)?(void)0 : (RedisModule__Assert(#_e,__FILE__,__LINE__),exit(1)))
 
+#define RMAPI_FUNC_SUPPORTED(func) (func != NULL)
+
 #else
 
 /* Things only defined for the modules core, not exported to modules
  * including this file. */
 #define RedisModuleString robj
-
-#define RMAPI_FUNC_SUPPORTED(func) (func != NULL)
 
 #endif /* REDISMODULE_CORE */
 #endif /* REDISMODULE_H */

--- a/tests/modules/fork.c
+++ b/tests/modules/fork.c
@@ -28,6 +28,12 @@ int fork_create(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         RedisModule_WrongArity(ctx);
         return REDISMODULE_OK;
     }
+
+    if(!RMAPI_FUNC_SUPPORTED(RedisModule_Fork)){
+        RedisModule_ReplyWithError(ctx, "Fork api is not supported in the current redis version");
+        return REDISMODULE_OK;
+    }
+
     RedisModule_StringToLongLong(argv[1], &code_to_exit_with);
     exitted_with_code = -1;
     child_pid = RedisModule_Fork(done_handler, (void*)0xdeadbeef);


### PR DESCRIPTION
The RMAPI_FUNC_SUPPORTED was defined in the wrong place on redismodule.h
and was not visible to modules.