### PR TITLE
optimization src/adlist.c:listJoin()

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -360,15 +360,16 @@ void listRotateHeadToTail(list *list) {
 /* Add all the elements of the list 'o' at the end of the
  * list 'l'. The list 'other' remains empty but otherwise valid. */
 void listJoin(list *l, list *o) {
-    if (o->head)
-        o->head->prev = l->tail;
+    if (o->len == 0) return;
+
+    o->head->prev = l->tail;
 
     if (l->tail)
         l->tail->next = o->head;
     else
         l->head = o->head;
 
-    if (o->tail) l->tail = o->tail;
+    l->tail = o->tail;
     l->len += o->len;
 
     /* Setup other as an empty list. */


### PR DESCRIPTION
In listJoin(), if list 'o' is empty, we can return without run the following code.