### PR TITLE
Fix make warning in hellohook,c and testmodule.c

### DIFF
--- a/src/modules/hellohook.c
+++ b/src/modules/hellohook.c
@@ -44,7 +44,7 @@ void clientChangeCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub,
     REDISMODULE_NOT_USED(e);
 
     RedisModuleClientInfo *ci = data;
-    printf("Client %s event for client #%llu %s:%d\n",
+    printf("Client %s event for client #%lu %s:%d\n",
         (sub == REDISMODULE_SUBEVENT_CLIENT_CHANGE_CONNECTED) ?
             "connection" : "disconnection",
         ci->id,ci->addr,ci->port);

--- a/src/modules/hellohook.c
+++ b/src/modules/hellohook.c
@@ -44,10 +44,10 @@ void clientChangeCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub,
     REDISMODULE_NOT_USED(e);
 
     RedisModuleClientInfo *ci = data;
-    printf("Client %s event for client #%lu %s:%d\n",
+    printf("Client %s event for client #%llu %s:%d\n",
         (sub == REDISMODULE_SUBEVENT_CLIENT_CHANGE_CONNECTED) ?
             "connection" : "disconnection",
-        ci->id,ci->addr,ci->port);
+        (unsigned long long)ci->id,ci->addr,ci->port);
 }
 
 void flushdbCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub, void *data)

--- a/src/modules/testmodule.c
+++ b/src/modules/testmodule.c
@@ -220,7 +220,7 @@ int TestNotifications(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     } else {
         rep = RedisModule_CallReplyStringPtr(r, &sz);
         if (sz != 1 || *rep != '1') {
-            FAIL("Got reply '%.*s'. expected '1'", sz, rep);
+            FAIL("Got reply '%.*s'. expected '1'", (int)sz, rep);
         }
     }
     /* For l we expect nothing since we didn't subscribe to list events */
@@ -235,7 +235,7 @@ int TestNotifications(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     } else {
         rep = RedisModule_CallReplyStringPtr(r, &sz);
         if (sz != 1 || *rep != '2') {
-            FAIL("Got reply '%.*s'. expected '2'", sz, rep);
+            FAIL("Got reply '%.*s'. expected '2'", (int)sz, rep);
         }
     }
 


### PR DESCRIPTION
Compiling module generates some compiler warnings.

```
testmodule.c: In function ‘TestNotifications’:
testmodule.c:176:41: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 4 has type ‘size_t {aka long unsigned int}’ [-Wformat=]
         RedisModule_Log(ctx, "warning", "Failed NOTIFY Test. Reason: " #msg, ##__VA_ARGS__); \
                                         ^
testmodule.c:223:13: note: in expansion of macro ‘FAIL’
             FAIL("Got reply '%.*s'. expected '1'", sz, rep);
             ^~~~
testmodule.c:176:41: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 4 has type ‘size_t {aka long unsigned int}’ [-Wformat=]
         RedisModule_Log(ctx, "warning", "Failed NOTIFY Test. Reason: " #msg, ##__VA_ARGS__); \
                                         ^
testmodule.c:238:13: note: in expansion of macro ‘FAIL’
             FAIL("Got reply '%.*s'. expected '2'", sz, rep);
             ^~~~
ld -o testmodule.so testmodule.xo -shared  -lc
cc -I.  -W -Wall -fno-common -g -ggdb -std=c99 -O2 -fPIC -c hellocluster.c -o hellocluster.xo
ld -o hellocluster.so hellocluster.xo -shared  -lc
cc -I.  -W -Wall -fno-common -g -ggdb -std=c99 -O2 -fPIC -c hellotimer.c -o hellotimer.xo
ld -o hellotimer.so hellotimer.xo -shared  -lc
cc -I.  -W -Wall -fno-common -g -ggdb -std=c99 -O2 -fPIC -c hellodict.c -o hellodict.xo
ld -o hellodict.so hellodict.xo -shared  -lc
cc -I.  -W -Wall -fno-common -g -ggdb -std=c99 -O2 -fPIC -c hellohook.c -o hellohook.xo
hellohook.c: In function ‘clientChangeCallback’:
hellohook.c:47:44: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 3 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
     printf("Client %s event for client #%llu %s:%d\n",
                                         ~~~^
                                         %lu
hellohook.c:50:9:
         ci->id,ci->addr,ci->port);
         ~~~~~~
```