### PR TITLE
Avoid notification if lrem remove nothing

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -641,11 +641,11 @@ void lremCommand(client *c) {
     if (removed) {
         signalModifiedKey(c,c->db,c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_LIST,"lrem",c->argv[1],c->db->id);
-    }
 
-    if (listTypeLength(subject) == 0) {
-        dbDelete(c->db,c->argv[1]);
-        notifyKeyspaceEvent(NOTIFY_GENERIC,"del",c->argv[1],c->db->id);
+        if (listTypeLength(subject) == 0) {
+            dbDelete(c->db,c->argv[1]);
+            notifyKeyspaceEvent(NOTIFY_GENERIC,"del",c->argv[1],c->db->id);
+        }
     }
 
     addReplyLongLong(c,removed);


### PR DESCRIPTION
If lrem has not deleted any elements, there is no need to determine if the list is empty and send a del notification