### PR TITLE
Adds user parsing to redis-cli URIs

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -411,7 +411,7 @@ static void parseRedisUri(const char *uri) {
     /* Extract user info. */
     if ((userinfo = strchr(curr,'@'))) {
         if ((username = strchr(curr, ':')) && username < userinfo) {
-            /* If provided, username is ignored. */
+            config.user = percentDecode(curr, username - curr);
             curr = username + 1;
         }
 


### PR DESCRIPTION
Until v6's ACL, users weren't generally supported and specifically ignored when parsing the URI. This fixes this behavior.

Ref: #8047