### PR TITLE
Slave migration won't work when the  smallest slave has failed

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3358,7 +3358,7 @@ void clusterHandleSlaveMigration(int max_slaves) {
          * node ID. */
         if (okslaves == max_slaves) {
             for (j = 0; j < node->numslaves; j++) {
-                if (memcmp(node->slaves[j]->name,
+                if (!nodeFailed(node->slaves[j]) && memcmp(node->slaves[j]->name,
                            candidate->name,
                            CLUSTER_NAMELEN) < 0)
                 {


### PR DESCRIPTION
Consider the following scenario:

We have 3 masters A,B,C. A has three slaves 1,2,3. B has one slave 4. C has two slaves 5,6 (A,B,C,1,2,3,4,5,6 are all node IDs). After a while, the slave 1 fails. Then another master D joins in. D is an orphaned master. A and C have the max (two) working slaves and the slave 1 with the smallest node ID will be chosen to perform the slave migration. But the slave 1 has failed, so the migration won't work. In the above situation, the slave 2 should be chosen(a working slave and with the smallest node ID), am I right?