### PR TITLE
fix compilation with uClibc-ng

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -65,7 +65,7 @@
 /* Test for backtrace() */
 #if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || \
     defined(__FreeBSD__) || ((defined(__OpenBSD__) || defined(__NetBSD__)) && defined(USE_BACKTRACE))\
- || defined(__DragonFly__)
+ || defined(__DragonFly__) || (defined(__UCLIBC__) && defined(__UCLIBC_HAS_BACKTRACE__))
 #define HAVE_BACKTRACE 1
 #endif
 


### PR DESCRIPTION
backtrace can be compile time disabled.