### PR TITLE
Avoid excessive malloc and free in copyCommand robj creation

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -202,7 +202,7 @@ robj *listTypeDup(robj *o) {
 
     switch (o->encoding) {
         case OBJ_ENCODING_QUICKLIST:
-            lobj = createObject(OBJ_LIST, o->ptr);
+            lobj = createObject(OBJ_LIST, quicklistDup(o->ptr));
             lobj->encoding = OBJ_ENCODING_QUICKLIST;
             break;
         default:

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -202,14 +202,13 @@ robj *listTypeDup(robj *o) {
 
     switch (o->encoding) {
         case OBJ_ENCODING_QUICKLIST:
-            lobj = createQuicklistObject();
+            lobj = createObject(OBJ_LIST, o->ptr);
+            lobj->encoding = OBJ_ENCODING_QUICKLIST;
             break;
         default:
             serverPanic("Wrong encoding.");
             break;
     }
-    zfree(lobj->ptr);
-    lobj->ptr = quicklistDup(o->ptr);
     return lobj;
 }
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1566,30 +1566,19 @@ robj *zsetDup(robj *o) {
     serverAssert(o->type == OBJ_ZSET);
 
     /* Create a new sorted set object that have the same encoding as the original object's encoding */
-    switch (o->encoding) {
-        case OBJ_ENCODING_ZIPLIST:
-            zobj = createZsetZiplistObject();
-            break;
-        case OBJ_ENCODING_SKIPLIST:
-            zobj = createZsetObject();
-            zs = o->ptr;
-            new_zs = zobj->ptr;
-            dictExpand(new_zs->dict,dictSize(zs->dict));
-            break;
-        default:
-            serverPanic("Wrong encoding.");
-            break;
-    }
-    if (zobj->encoding == OBJ_ENCODING_ZIPLIST) {
+    if (o->encoding == OBJ_ENCODING_ZIPLIST) {
+        zobj = createZsetZiplistObject();
         unsigned char *zl = o->ptr;
         size_t sz = ziplistBlobLen(zl);
         unsigned char *new_zl = zmalloc(sz);
         memcpy(new_zl, zl, sz);
         zfree(zobj->ptr);
         zobj->ptr = new_zl;
-    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+    } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
+        zobj = createZsetObject();
         zs = o->ptr;
         new_zs = zobj->ptr;
+        dictExpand(new_zs->dict,dictSize(zs->dict));
         zskiplist *zsl = zs->zsl;
         zskiplistNode *ln;
         sds ele;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1567,13 +1567,12 @@ robj *zsetDup(robj *o) {
 
     /* Create a new sorted set object that have the same encoding as the original object's encoding */
     if (o->encoding == OBJ_ENCODING_ZIPLIST) {
-        zobj = createZsetZiplistObject();
         unsigned char *zl = o->ptr;
         size_t sz = ziplistBlobLen(zl);
         unsigned char *new_zl = zmalloc(sz);
         memcpy(new_zl, zl, sz);
-        zfree(zobj->ptr);
-        zobj->ptr = new_zl;
+        zobj = createObject(OBJ_ZSET, new_zl);
+        zobj->encoding = OBJ_ENCODING_ZIPLIST;
     } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
         zobj = createZsetObject();
         zs = o->ptr;


### PR DESCRIPTION
1. Avoid multiple conditional judgments
2. Avoid free robj->ptr