### PR TITLE
Fix diskless replication failure when has non-rdb child process

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -826,18 +826,16 @@ void syncCommand(client *c) {
 
     /* CASE 3: There is no BGSAVE is progress. */
     } else {
-        if (server.repl_diskless_sync && (c->slave_capa & SLAVE_CAPA_EOF)) {
+        if (server.repl_diskless_sync && (c->slave_capa & SLAVE_CAPA_EOF) &&
+            server.repl_diskless_sync_delay)
+        {
             /* Diskless replication RDB child is created inside
              * replicationCron() since we want to delay its start a
              * few seconds to wait for more slaves to arrive. */
-            if (server.repl_diskless_sync_delay)
-                serverLog(LL_NOTICE,"Delay next BGSAVE for diskless SYNC");
-            else
-                startBgsaveForReplication(c->slave_capa);
+            serverLog(LL_NOTICE,"Delay next BGSAVE for diskless SYNC");
         } else {
-            /* Target is disk (or the slave is not capable of supporting
-             * diskless replication) and we don't have a BGSAVE in progress,
-             * let's start one. */
+            /* We don't have a BGSAVE in progress, let's start one. Diskless
+             * or disk-based mode is determined by replica's capacity. */
             if (!hasActiveChildProcess()) {
                 startBgsaveForReplication(c->slave_capa);
             } else {


### PR DESCRIPTION
If we enable diskless replication, set `repl-diskless-sync-delay` to 0, and master has non-rdb child process such as rewrite aof child, master will start to a new BGSAVE but fails immediately when replicas ask for full synchronization, and master always fails to start a new BGSAVE and disconnects with replicas until non-rdb child process exists.

master log
```
18570:M 20 Nov 2020 21:00:08.968 - Accepted 127.0.0.1:60409
18570:M 20 Nov 2020 21:00:08.968 * Replica 127.0.0.1:21111 asks for synchronization
18570:M 20 Nov 2020 21:00:08.968 * Full resync requested by replica 127.0.0.1:21111
18570:M 20 Nov 2020 21:00:08.968 * Starting BGSAVE for SYNC with target: replicas sockets
18570:M 20 Nov 2020 21:00:08.968 # BGSAVE for replication failed
```
replica log
```
18803:S 20 Nov 2020 21:00:59.270 * MASTER <-> REPLICA sync started
18803:S 20 Nov 2020 21:00:59.270 * Non blocking connect for SYNC fired the event.
18803:S 20 Nov 2020 21:00:59.270 * Master replied to PING, replication can continue...
18803:S 20 Nov 2020 21:00:59.270 * Partial resynchronization not possible (no cached master)
18803:S 20 Nov 2020 21:00:59.270 * Master does not support PSYNC or is in error state (reply: -ERR BGSAVE failed, replication can't continue)
18803:S 20 Nov 2020 21:00:59.271 * Retrying with SYNC...
18803:S 20 Nov 2020 21:00:59.271 # I/O error reading bulk count from MASTER: Connection reset by peer
18803:S 20 Nov 2020 21:00:59.271 * Reconnecting to MASTER 127.0.0.1:21112 after failure
```
