### PR TITLE
Remove the range judgment of dbid in copyCommand

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1098,7 +1098,6 @@ void copyCommand(client *c) {
             replace = 1;
         } else if (!strcasecmp(c->argv[j]->ptr, "db") && additional >= 1) {
             if (getLongLongFromObject(c->argv[j+1], &dbid) == C_ERR ||
-                dbid < INT_MIN || dbid > INT_MAX ||
                 selectDb(c, dbid) == C_ERR)
             {
                 addReplyError(c,"invalid DB index");


### PR DESCRIPTION
The range of dbid has already been determined in selectDb.

```c
int selectDb(client *c, int id) {
    if (id < 0 || id >= server.dbnum)
        return C_ERR;
    c->db = &server.db[id];
    return C_OK;
}

```