### PR TITLE
handle redis error when redis unixsocket does not exist.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -106,8 +106,8 @@ tcp-backlog 511
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
 #
-# unixsocket /tmp/redis.sock
-# unixsocketperm 700
+ unixsocket /var/run/redis/redis.sock
+ unixsocketperm 700
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout 0

--- a/src/server.c
+++ b/src/server.c
@@ -55,6 +55,7 @@
 #include <sys/utsname.h>
 #include <locale.h>
 #include <sys/socket.h>
+#include <string.h>
 
 /* Our shared "common" objects */
 
@@ -1814,6 +1815,26 @@ void resetServerStats(void) {
     server.aof_delayed_fsync = 0;
 }
 
+void checkUnixSocketDirectory(char* unix_socket_path)
+{
+    char directory[100] = "/";
+    char path[100] = "";
+    strcpy(path,unix_socket_path);
+	/* Extract the first token. */
+	char * token = strtok(path, "/");
+	/* loop through the string to extract all other tokens. */
+    while( token != NULL ) {
+		if(strchr(token, '.') == NULL)
+		{
+			strcat(directory,token);
+			/* check directory existance and if it does not exist, create it.*/
+            mkdir(directory,2777);
+            strcat(directory,"/");
+        }
+	token = strtok(NULL, "/");
+    }
+}
+
 void initServer(void) {
     int j;
 
@@ -1856,6 +1877,9 @@ void initServer(void) {
     if (server.port != 0 &&
         listenToPort(server.port,server.ipfd,&server.ipfd_count) == C_ERR)
         exit(1);
+
+    /* Check redis unixsocket path existance. */
+    checkUnixSocketDirectory(server.unixsocket);
 
     /* Open the listening Unix domain socket. */
     if (server.unixsocket != NULL) {


### PR DESCRIPTION
when we want to run redis server on system,it is possible that system does not have any directory for /var/run/redis
for this reason we add some code to check if we do not have this directory, created this directory with given permission, rerecursively