### PR TITLE
Improve dbid range check for SELECT, MOVE, COPY

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1018,8 +1018,7 @@ void renamenxCommand(client *c) {
 void moveCommand(client *c) {
     robj *o;
     redisDb *src, *dst;
-    int srcid;
-    int dbid;
+    int srcid, dbid;
     long long expire;
 
     if (server.cluster_enabled) {
@@ -1081,8 +1080,7 @@ void moveCommand(client *c) {
 void copyCommand(client *c) {
     robj *o;
     redisDb *src, *dst;
-    int srcid;
-    int dbid;
+    int srcid, dbid;
     long long expire;
     int j, replace = 0, delete = 0;
 

--- a/src/db.c
+++ b/src/db.c
@@ -607,7 +607,7 @@ void selectCommand(client *c) {
         addReplyError(c,"SELECT is not allowed in cluster mode");
         return;
     }
-    if (selectDb(c,id) == C_ERR) {
+    if (id < INT_MIN || id > INT_MAX || selectDb(c,id) == C_ERR) {
         addReplyError(c,"DB index is out of range");
     } else {
         addReply(c,shared.ok);

--- a/src/db.c
+++ b/src/db.c
@@ -1034,8 +1034,7 @@ void moveCommand(client *c) {
     if (getIntFromObjectOrReply(c, c->argv[2], &dbid, NULL) != C_OK)
         return;
 
-    if (selectDb(c,dbid) == C_ERR)
-    {
+    if (selectDb(c,dbid) == C_ERR) {
         addReplyError(c,"DB index is out of range");
         return;
     }
@@ -1102,8 +1101,7 @@ void copyCommand(client *c) {
             if (getIntFromObjectOrReply(c, c->argv[j+1], &dbid, NULL) != C_OK)
                 return;
 
-            if (selectDb(c, dbid) == C_ERR)
-            {
+            if (selectDb(c, dbid) == C_ERR) {
                 addReplyError(c,"DB index is out of range");
                 return;
             }

--- a/src/object.c
+++ b/src/object.c
@@ -747,6 +747,16 @@ int getPositiveLongFromObjectOrReply(client *c, robj *o, long *target, const cha
     return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, msg);
 }
 
+int getIntFromObjectOrReply(client *c, robj *o, int *target, const char *msg) {
+    long value;
+
+    if (getRangeLongFromObjectOrReply(c, o, INT_MIN, INT_MAX, &value, msg) != C_OK)
+        return C_ERR;
+
+    *target = value;
+    return C_OK;
+}
+
 char *strEncoding(int encoding) {
     switch(encoding) {
     case OBJ_ENCODING_RAW: return "raw";

--- a/src/server.h
+++ b/src/server.h
@@ -1865,6 +1865,7 @@ int getDoubleFromObject(const robj *o, double *target);
 int getLongLongFromObject(robj *o, long long *target);
 int getLongDoubleFromObject(robj *o, long double *target);
 int getLongDoubleFromObjectOrReply(client *c, robj *o, long double *target, const char *msg);
+int getIntFromObjectOrReply(client *c, robj *o, int *target, const char *msg);
 char *strEncoding(int encoding);
 int compareStringObjects(robj *a, robj *b);
 int collateStringObjects(robj *a, robj *b);

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -217,7 +217,7 @@ start_server {tags {"keyspace"}} {
         r set mykey foobar
         catch {r copy mykey mynewkey DB notanumber} e
         set e
-    } {*ERR*invalid DB index}
+    } {ERR value is not an integer or out of range}
 
     test {COPY can copy key expire metadata as well} {
         r set mykey foobar ex 100
@@ -398,7 +398,7 @@ start_server {tags {"keyspace"}} {
         r set mykey hello
         catch {r move mykey notanumber} e
         set e
-    } {*ERR*index out of range}
+    } {ERR value is not an integer or out of range}
 
     test {MOVE can move key expire metadata as well} {
         r select 10


### PR DESCRIPTION
SELECT used to read the index into a `long` variable, and then pass it to a function
that takes an `int`, possibly causing an overflow before the range check.

Now all these commands use better and cleaner range check, and that also results in
a slight change of the error response in case of an invalid database index.

SELECT:
in the past it would have returned either `-ERR invalid DB index` (if not a number),
or `-ERR DB index is out of range` (if not between 1..16 or alike).
now it'll return either `-ERR value is out of range` (if not a number), or
`-ERR value is out of range, value must between -2147483648 and 2147483647`
(if not in the range for an int), or `-ERR DB index is out of range`
(if not between 0..16 or alike)


MOVE:
in the past it would only fail with `-ERR index out of range` no matter the reason.
now return the same errors as the new ones for SELECT mentioned above.
(i.e. unlike for SELECT even for a value like 17 we changed the error message)

COPY:
doesn't really matter how it behaved in the past (new command), new behavior is
like the above two.
