### PR TITLE
Handle error on redis, when redis socket directory does not exist.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -112,8 +112,8 @@ tcp-backlog 511
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
 #
-# unixsocket /run/redis.sock
-# unixsocketperm 700
+ unixsocket /var/run/redis/redis.sock
+ unixsocketperm 700
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout 0
@@ -148,7 +148,7 @@ tcp-keepalive 300
 # server to connected clients, masters or cluster peers.  These files should be
 # PEM formatted.
 #
-# tls-cert-file redis.crt 
+# tls-cert-file redis.crt
 # tls-key-file redis.key
 
 # Configure a DH parameters file to enable Diffie-Hellman (DH) key exchange:
@@ -261,7 +261,7 @@ daemonize no
 #
 # Note that on modern Linux systems "/run/redis.pid" is more conforming
 # and should be used instead.
-pidfile /var/run/redis_6379.pid
+pidfile /var/run/redis/redis_6379.pid
 
 # Specify the server verbosity level.
 # This can be one of:
@@ -792,8 +792,8 @@ replica-priority 100
 # ACL LOG
 #
 # The ACL Log tracks failed commands and authentication events associated
-# with ACLs. The ACL Log is useful to troubleshoot failed commands blocked 
-# by ACLs. The ACL Log is stored in memory. You can reclaim memory with 
+# with ACLs. The ACL Log is useful to troubleshoot failed commands blocked
+# by ACLs. The ACL Log is stored in memory. You can reclaim memory with
 # ACL LOG RESET. Define the maximum entry length of the ACL Log below.
 acllog-max-len 128
 
@@ -932,7 +932,7 @@ acllog-max-len 128
 
 # Eviction processing is designed to function well with the default setting.
 # If there is an unusually large amount of write traffic, this value may need to
-# be increased.  Decreasing this value may reduce latency at the risk of 
+# be increased.  Decreasing this value may reduce latency at the risk of
 # eviction processing effectiveness
 #   0 = minimum latency, 10 = default, 100 = process without regard to latency
 #
@@ -1378,18 +1378,18 @@ lua-time-limit 5000
 # cluster-replica-no-failover no
 
 # This option, when set to yes, allows nodes to serve read traffic while the
-# the cluster is in a down state, as long as it believes it owns the slots. 
+# the cluster is in a down state, as long as it believes it owns the slots.
 #
-# This is useful for two cases.  The first case is for when an application 
+# This is useful for two cases.  The first case is for when an application
 # doesn't require consistency of data during node failures or network partitions.
 # One example of this is a cache, where as long as the node has the data it
-# should be able to serve it. 
+# should be able to serve it.
 #
-# The second use case is for configurations that don't meet the recommended  
-# three shards but want to enable cluster mode and scale later. A 
+# The second use case is for configurations that don't meet the recommended
+# three shards but want to enable cluster mode and scale later. A
 # master outage in a 1 or 2 shard configuration causes a read/write outage to the
 # entire cluster without this option set, with it set there is only a write outage.
-# Without a quorum of masters, slot ownership will not change automatically. 
+# Without a quorum of masters, slot ownership will not change automatically.
 #
 # cluster-allow-reads-when-down no
 

--- a/src/server.c
+++ b/src/server.c
@@ -2917,6 +2917,26 @@ void makeThreadKillable(void) {
     pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 }
 
+void checkUnixSocketDirectory(char* unix_socket_path)
+{
+    char directory[100] = "/";
+    char path[100] = "";
+    strcpy(path,unix_socket_path);
+	/* Extract the first token. */
+	char * token = strtok(path, "/");
+	/* loop through the string to extract all other tokens. */
+    while( token != NULL ) {
+		if(strchr(token, '.') == NULL)
+		{
+			strcat(directory,token);
+			/* check directory existance and if it does not exist, create it.*/
+            mkdir(directory,2777);
+            strcat(directory,"/");
+        }
+	token = strtok(NULL, "/");
+    }
+}
+
 void initServer(void) {
     int j;
 
@@ -2981,6 +3001,9 @@ void initServer(void) {
     if (server.tls_port != 0 &&
         listenToPort(server.tls_port,server.tlsfd,&server.tlsfd_count) == C_ERR)
         exit(1);
+
+    /* Check redis unixsocket path existance. */
+    checkUnixSocketDirectory(server.unixsocket);
 
     /* Open the listening Unix domain socket. */
     if (server.unixsocket != NULL) {
@@ -5222,7 +5245,7 @@ void loadDataFromDisk(void) {
 void redisOutOfMemoryHandler(size_t allocation_size) {
     serverLog(LL_WARNING,"Out Of Memory allocating %zu bytes!",
         allocation_size);
-    serverPanic("Redis aborting for OUT OF MEMORY. Allocating %zu bytes!", 
+    serverPanic("Redis aborting for OUT OF MEMORY. Allocating %zu bytes!",
         allocation_size);
 }
 


### PR DESCRIPTION
when we want to run redis server on system,it is possible that system does not have any directory for /var/run/redis
for this reason we add some code to check if we do not have this directory, created this directory with given permission, rerecursively