### PR TITLE
Add  GEOSEARCH/GEOSEARCHSTORE command

### DIFF
--- a/src/geohash.h
+++ b/src/geohash.h
@@ -90,6 +90,25 @@ typedef struct {
     GeoHashBits south_west;
 } GeoHashNeighbors;
 
+#define CIRCULAR_TYPE 1
+#define RECTANGLE_TYPE 2
+typedef struct {
+    int type; /* search type */
+    double xy[2]; /* search center point, xy[0]: lon, xy[1]: lat */
+    double conversion; /* km: 1000 */
+    double bounds[4]; /* bounds[0]: min_lon, bounds[1]: min_lat
+                       * bounds[2]: max_lon, bounds[3]: max_lat */
+    union {
+        /* CIRCULAR_TYPE */
+        double radius;
+        /* RECTANGLE_TYPE */
+        struct {
+            double height;
+            double width;
+        } r;
+    } t;
+} GeoShape;
+
 /*
  * 0:success
  * -1:failed

--- a/src/geohash_helper.h
+++ b/src/geohash_helper.h
@@ -49,14 +49,8 @@ typedef struct {
 
 int GeoHashBitsComparator(const GeoHashBits *a, const GeoHashBits *b);
 uint8_t geohashEstimateStepsByRadius(double range_meters, double lat);
-int geohashBoundingBox(double longitude, double latitude, double radius_meters,
-                        double *bounds);
-GeoHashRadius geohashGetAreasByRadius(double longitude,
-                                      double latitude, double radius_meters);
-GeoHashRadius geohashGetAreasByRadiusWGS84(double longitude, double latitude,
-                                           double radius_meters);
-GeoHashRadius geohashGetAreasByRadiusMercator(double longitude, double latitude,
-                                              double radius_meters);
+int geohashBoundingBox(GeoShape *shape, double *bounds);
+GeoHashRadius geohashCalculateAreasByShapeWGS84(GeoShape *shape);
 GeoHashFix52Bits geohashAlign52Bits(const GeoHashBits hash);
 double geohashGetDistance(double lon1d, double lat1d,
                           double lon2d, double lat2d);
@@ -66,5 +60,7 @@ int geohashGetDistanceIfInRadius(double x1, double y1,
 int geohashGetDistanceIfInRadiusWGS84(double x1, double y1, double x2,
                                       double y2, double radius,
                                       double *distance);
+int geohashGetDistanceIfInRectangle(double *bounds, double x1, double y1,
+                                    double x2, double y2, double *distance);
 
 #endif /* GEOHASH_HELPER_HPP_ */

--- a/src/server.c
+++ b/src/server.c
@@ -919,7 +919,7 @@ struct redisCommand redisCommandTable[] = {
 
     /* GEORADIUS has store options that may write. */
     {"georadius",georadiusCommand,-6,
-     "write @geo",
+     "write use-memory @geo",
      0,georadiusGetKeys,1,1,1,0,0,0},
 
     {"georadius_ro",georadiusroCommand,-6,
@@ -927,7 +927,7 @@ struct redisCommand redisCommandTable[] = {
      0,georadiusGetKeys,1,1,1,0,0,0},
 
     {"georadiusbymember",georadiusbymemberCommand,-5,
-     "write @geo",
+     "write use-memory @geo",
      0,georadiusGetKeys,1,1,1,0,0,0},
 
     {"georadiusbymember_ro",georadiusbymemberroCommand,-5,
@@ -945,6 +945,14 @@ struct redisCommand redisCommandTable[] = {
     {"geodist",geodistCommand,-4,
      "read-only @geo",
      0,NULL,1,1,1,0,0,0},
+
+    {"geosearch",geosearchCommand,-7,
+     "read-only @geo",
+      0,NULL,1,1,1,0,0,0},
+
+    {"geosearchstore",geosearchstoreCommand,-8,
+     "write use-memory @geo",
+      0,NULL,1,2,1,0,0,0},
 
     {"pfselftest",pfselftestCommand,1,
      "admin @hyperloglog",

--- a/src/server.h
+++ b/src/server.h
@@ -2498,6 +2498,8 @@ void geoaddCommand(client *c);
 void geohashCommand(client *c);
 void geoposCommand(client *c);
 void geodistCommand(client *c);
+void geosearchCommand(client *c);
+void geosearchstoreCommand(client *c);
 void pfselftestCommand(client *c);
 void pfaddCommand(client *c);
 void pfcountCommand(client *c);

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -94,9 +94,42 @@ start_server {tags {"geo"}} {
         r georadius nyc -73.9798091 40.7598464 3 km asc
     } {{central park n/q/r} 4545 {union square}}
 
+    test {GEOSEARCH simple (sorted)} {
+        r geosearch nyc fromloc -73.9798091 40.7598464 bybox 6 6 km asc
+    } {{central park n/q/r} 4545 {union square} {lic market}}
+
+    test {GEOSEARCH FROMLOC and FROMMEMBER cannot exist at the same time} {
+        catch {r geosearch nyc fromloc -73.9798091 40.7598464 frommember xxx bybox 6 6 km asc} e
+        set e
+    } {ERR*syntax*}
+
+    test {GEOSEARCH FROMLOC and FROMMEMBER one must exist} {
+        catch {r geosearch nyc bybox 3 3 km asc desc withhash withdist withcoord} e
+        set e
+    } {ERR*exactly one of FROMMEMBER or FROMLOC*}
+
+    test {GEOSEARCH BYRADIUS and BYBOX cannot exist at the same time} {
+        catch {r geosearch nyc fromloc -73.9798091 40.7598464 byradius 3 km bybox 3 3 km asc} e
+        set e
+    } {ERR*syntax*}
+
+    test {GEOSEARCH BYRADIUS and BYBOX one must exist} {
+        catch {r geosearch nyc fromloc -73.9798091 40.7598464 asc desc withhash withdist withcoord} e
+        set e
+    } {ERR*exactly one of BYRADIUS and BYBOX*}
+
+    test {GEOSEARCH with STOREDIST option} {
+        catch {r geosearch nyc fromloc -73.9798091 40.7598464 bybox 6 6 km asc storedist} e
+        set e
+    } {ERR*syntax*}
+
     test {GEORADIUS withdist (sorted)} {
         r georadius nyc -73.9798091 40.7598464 3 km withdist asc
     } {{{central park n/q/r} 0.7750} {4545 2.3651} {{union square} 2.7697}}
+
+    test {GEOSEARCH withdist (sorted)} {
+        r geosearch nyc fromloc -73.9798091 40.7598464 bybox 6 6 km withdist asc
+    } {{{central park n/q/r} 0.7750} {4545 2.3651} {{union square} 2.7697} {{lic market} 3.1991}}
 
     test {GEORADIUS with COUNT} {
         r georadius nyc -73.9798091 40.7598464 10 km COUNT 3
@@ -119,6 +152,35 @@ start_server {tags {"geo"}} {
     test {GEORADIUSBYMEMBER simple (sorted)} {
         r georadiusbymember nyc "wtc one" 7 km
     } {{wtc one} {union square} {central park n/q/r} 4545 {lic market}}
+
+    test {GEOSEARCH FROMMEMBER simple (sorted)} {
+        r geosearch nyc frommember "wtc one" bybox 14 14 km
+    } {{wtc one} {union square} {central park n/q/r} 4545 {lic market} q4}
+
+    test {GEOSEARCH vs GEORADIUS} {
+        r del Sicily
+        r geoadd Sicily 13.361389 38.115556 "Palermo" 15.087269 37.502669 "Catania"
+        r geoadd Sicily 12.758489 38.788135 "edge1"   17.241510 38.788135 "eage2"
+        set ret1 [r georadius Sicily 15 37 200 km asc]
+        assert_equal $ret1 {Catania Palermo}
+        set ret2 [r geosearch Sicily fromloc 15 37 bybox 400 400 km asc]
+        assert_equal $ret2 {Catania Palermo eage2 edge1}
+    }
+
+    test {GEOSEARCH non square, long and narrow} {
+        r del Sicily
+        r geoadd Sicily 12.75 37.00 "test1"
+        r geoadd Sicily 12.75 36.50 "test2"
+        r geoadd Sicily 13.00 36.50 "test3"
+        # box height=2km width=400km
+        set ret1 [r geosearch Sicily fromloc 15 37 bybox 2 400 km]
+        assert_equal $ret1 {test1}
+
+        # Add a western Hemisphere point
+        r geoadd Sicily -1 37.00 "test3"
+        set ret2 [r geosearch Sicily fromloc 15 37 bybox 2 3000 km asc]
+        assert_equal $ret2 {test1 test3}
+    }
 
     test {GEORADIUSBYMEMBER withdist (sorted)} {
         r georadiusbymember nyc "wtc one" 7 km withdist
@@ -178,6 +240,11 @@ start_server {tags {"geo"}} {
         set e
     } {*ERR*syntax*}
 
+    test {GEOSEARCHSTORE STORE option: syntax error} {
+        catch {r geosearchstore abc points fromloc 13.361389 38.115556 byradius 50 km store abc} e
+        set e
+    } {*ERR*syntax*}
+
     test {GEORANGE STORE option: incompatible options} {
         r del points
         r geoadd points 13.361389 38.115556 "Palermo" \
@@ -198,11 +265,24 @@ start_server {tags {"geo"}} {
         assert_equal [r zrange points 0 -1] [r zrange points2 0 -1]
     }
 
+    test {GEOSEARCHSTORE STORE option: plain usage} {
+        r geosearchstore points2 points fromloc 13.361389 38.115556 byradius 500 km
+        assert_equal [r zrange points 0 -1] [r zrange points2 0 -1]
+    }
+
     test {GEORANGE STOREDIST option: plain usage} {
         r del points
         r geoadd points 13.361389 38.115556 "Palermo" \
                         15.087269 37.502669 "Catania"
         r georadius points 13.361389 38.115556 500 km storedist points2
+        set res [r zrange points2 0 -1 withscores]
+        assert {[lindex $res 1] < 1}
+        assert {[lindex $res 3] > 166}
+        assert {[lindex $res 3] < 167}
+    }
+
+    test {GEOSEARCHSTORE STOREDIST option: plain usage} {
+        r geosearchstore points2 points fromloc 13.361389 38.115556 byradius 500 km storedist
         set res [r zrange points2 0 -1 withscores]
         assert {[lindex $res 1] < 1}
         assert {[lindex $res 3] > 166}


### PR DESCRIPTION
refer: #4417

Syntax:
```
GEOSEARCH key [FROMMEMBER member] [FROMLOC long lat] [BYRADIUS radius
unit] [BYBOX width height unit] [WITHCORD] [WITHDIST] [WITHASH] [COUNT
count] [ASC|DESC]

GEOSEARCHSTORE dest_key src_key [FROMMEMBER member] [FROMLOC long lat]
[BYRADIUS radius unit] [BYBOX width height unit] [WITHCORD] [WITHDIST]
[WITHASH] [COUNT count] [ASC|DESC] [STOREDIST]

```

- Add two types of CIRCULAR_TYPE and RECTANGLE_TYPE to achieve different
searches
- Judge whether the point is within the rectangle, refer to:
geohashGetDistanceIfInRectangle