### PR TITLE
More efficient self-XCLAIM

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2500,15 +2500,16 @@ void xclaimCommand(client *c) {
                 mstime_t this_idle = now - nack->delivery_time;
                 if (this_idle < minidle) continue;
             }
-            /* Remove the entry from the old consumer.
-             * Note that nack->consumer is NULL if we created the
-             * NACK above because of the FORCE option. */
-            if (nack->consumer)
-                raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
-            /* Update the consumer and idle time. */
             if (consumer == NULL)
                 consumer = streamLookupConsumer(group,c->argv[3]->ptr,SLC_NONE,NULL);
-            nack->consumer = consumer;
+            if (nack->consumer != consumer) {
+                /* Remove the entry from the old consumer.
+                 * Note that nack->consumer is NULL if we created the
+                 * NACK above because of the FORCE option. */
+                if (nack->consumer)
+                    raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
+                nack->consumer = consumer;
+            }
             nack->delivery_time = deliverytime;
             /* Set the delivery attempts counter if given, otherwise
              * autoincrement unless JUSTID option provided */
@@ -2517,8 +2518,10 @@ void xclaimCommand(client *c) {
             } else if (!justid) {
                 nack->delivery_count++;
             }
-            /* Add the entry in the new consumer local PEL. */
-            raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
+            if (nack->consumer != consumer) {
+                /* Add the entry in the new consumer local PEL. */
+                raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
+            }
             /* Send the reply for this entry. */
             if (justid) {
                 addReplyStreamID(c,&id);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2508,7 +2508,6 @@ void xclaimCommand(client *c) {
                  * NACK above because of the FORCE option. */
                 if (nack->consumer)
                     raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
-                nack->consumer = consumer;
             }
             nack->delivery_time = deliverytime;
             /* Set the delivery attempts counter if given, otherwise
@@ -2521,6 +2520,7 @@ void xclaimCommand(client *c) {
             if (nack->consumer != consumer) {
                 /* Add the entry in the new consumer local PEL. */
                 raxInsert(consumer->pel,buf,sizeof(buf),nack,NULL);
+                nack->consumer = consumer;
             }
             /* Send the reply for this entry. */
             if (justid) {

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -294,6 +294,26 @@ start_server {
         assert {[lindex $reply 0 3] == 2}
     }
 
+    test {XCLAIM same consumer} {
+        # Add 3 items into the stream, and create a consumer group
+        r del mystream
+        set id1 [r XADD mystream * a 1]
+        set id2 [r XADD mystream * b 2]
+        set id3 [r XADD mystream * c 3]
+        r XGROUP CREATE mystream mygroup 0
+
+        set reply [
+            r XREADGROUP GROUP mygroup client1 count 1 STREAMS mystream >
+        ]
+        assert {[llength [lindex $reply 0 1 0 1]] == 2}
+        assert {[lindex $reply 0 1 0 1] eq {a 1}}
+        r debug sleep 0.2
+        set reply [
+            r XCLAIM mystream mygroup client1 10 $id1
+        ]
+        assert {[llength $reply] == 1}
+    }
+
     test {XINFO FULL output} {
         r del x
         r XADD x 100 a 1

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -219,18 +219,9 @@ start_server {
         assert {[llength [lindex $reply 0 1 0 1]] == 2}
         assert {[lindex $reply 0 1 0 1] eq {a 1}}
 
-        set reply [
-            r XPENDING mystream mygroup - + 10
-        ]
-        assert {[llength $reply] == 1}
-        set reply [
-            r XPENDING mystream mygroup - + 10 client1
-        ]
-        assert {[llength $reply] == 1}
-        set reply [
-            r XPENDING mystream mygroup - + 10 client2
-        ]
-        assert {[llength $reply] == 0}
+        assert {[llength [r XPENDING mystream mygroup - + 10]] == 1}
+        assert {[llength [r XPENDING mystream mygroup - + 10 client1]] == 1}
+        assert {[llength [r XPENDING mystream mygroup - + 10 client2]] == 0}
 
         r debug sleep 0.2
         set reply [
@@ -239,18 +230,9 @@ start_server {
         assert {[llength [lindex $reply 0 1]] == 2}
         assert {[lindex $reply 0 1] eq {a 1}}
 
-        set reply [
-            r XPENDING mystream mygroup - + 10
-        ]
-        assert {[llength $reply] == 1}
-        set reply [
-            r XPENDING mystream mygroup - + 10 client1
-        ]
-        assert {[llength $reply] == 0}
-        set reply [
-            r XPENDING mystream mygroup - + 10 client2
-        ]
-        assert {[llength $reply] == 1}
+        assert {[llength [r XPENDING mystream mygroup - + 10]] == 1}
+        assert {[llength [r XPENDING mystream mygroup - + 10 client1]] == 0}
+        assert {[llength [r XPENDING mystream mygroup - + 10 client2]] == 1}
 
         # Client 1 reads another 2 items from stream
         r XREADGROUP GROUP mygroup client1 count 2 STREAMS mystream >
@@ -335,10 +317,13 @@ start_server {
         assert {[llength [lindex $reply 0 1 0 1]] == 2}
         assert {[lindex $reply 0 1 0 1] eq {a 1}}
         r debug sleep 0.2
+        assert {[llength [r XCLAIM mystream mygroup client1 10 $id1]] == 1}
+
         set reply [
-            r XCLAIM mystream mygroup client1 10 $id1
+            r XPENDING mystream mygroup - + 10
         ]
         assert {[llength $reply] == 1}
+        assert {[lindex $reply 0 1] eq {client1}}
     }
 
     test {XINFO FULL output} {

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -218,12 +218,39 @@ start_server {
         ]
         assert {[llength [lindex $reply 0 1 0 1]] == 2}
         assert {[lindex $reply 0 1 0 1] eq {a 1}}
+
+        set reply [
+            r XPENDING mystream mygroup - + 10
+        ]
+        assert {[llength $reply] == 1}
+        set reply [
+            r XPENDING mystream mygroup - + 10 client1
+        ]
+        assert {[llength $reply] == 1}
+        set reply [
+            r XPENDING mystream mygroup - + 10 client2
+        ]
+        assert {[llength $reply] == 0}
+
         r debug sleep 0.2
         set reply [
             r XCLAIM mystream mygroup client2 10 $id1
         ]
         assert {[llength [lindex $reply 0 1]] == 2}
         assert {[lindex $reply 0 1] eq {a 1}}
+
+        set reply [
+            r XPENDING mystream mygroup - + 10
+        ]
+        assert {[llength $reply] == 1}
+        set reply [
+            r XPENDING mystream mygroup - + 10 client1
+        ]
+        assert {[llength $reply] == 0}
+        set reply [
+            r XPENDING mystream mygroup - + 10 client2
+        ]
+        assert {[llength $reply] == 1}
 
         # Client 1 reads another 2 items from stream
         r XREADGROUP GROUP mygroup client1 count 2 STREAMS mystream >

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -219,6 +219,7 @@ start_server {
         assert {[llength [lindex $reply 0 1 0 1]] == 2}
         assert {[lindex $reply 0 1 0 1] eq {a 1}}
 
+        # make sure the entry is present in both the gorup, and the right consumer
         assert {[llength [r XPENDING mystream mygroup - + 10]] == 1}
         assert {[llength [r XPENDING mystream mygroup - + 10 client1]] == 1}
         assert {[llength [r XPENDING mystream mygroup - + 10 client2]] == 0}
@@ -230,6 +231,7 @@ start_server {
         assert {[llength [lindex $reply 0 1]] == 2}
         assert {[lindex $reply 0 1] eq {a 1}}
 
+        # make sure the entry is present in both the gorup, and the right consumer
         assert {[llength [r XPENDING mystream mygroup - + 10]] == 1}
         assert {[llength [r XPENDING mystream mygroup - + 10 client1]] == 0}
         assert {[llength [r XPENDING mystream mygroup - + 10 client2]] == 1}
@@ -311,17 +313,15 @@ start_server {
         set id3 [r XADD mystream * c 3]
         r XGROUP CREATE mystream mygroup 0
 
-        set reply [
-            r XREADGROUP GROUP mygroup client1 count 1 STREAMS mystream >
-        ]
+        set reply [r XREADGROUP GROUP mygroup client1 count 1 STREAMS mystream >]
         assert {[llength [lindex $reply 0 1 0 1]] == 2}
         assert {[lindex $reply 0 1 0 1] eq {a 1}}
         r debug sleep 0.2
+        # re-claim with the same consumer that already has it
         assert {[llength [r XCLAIM mystream mygroup client1 10 $id1]] == 1}
 
-        set reply [
-            r XPENDING mystream mygroup - + 10
-        ]
+        # make sure the entry is still in the PEL
+        set reply [r XPENDING mystream mygroup - + 10]
         assert {[llength $reply] == 1}
         assert {[lindex $reply 0 1] eq {client1}}
     }


### PR DESCRIPTION
No need to remove-and-insert if it's the same rax (same consumer)