### PR TITLE
Iterate backwards on zdiff/zinter/zunion to optimize for zslInsert

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1965,17 +1965,20 @@ void zuiInitIterator(zsetopsrc *op) {
             serverPanic("Unknown set encoding");
         }
     } else if (op->type == OBJ_ZSET) {
+        /* Sorted sets are traversed in reverse order to optimize for
+         * the insertion of the elements in a new list as in
+         * ZDIFF/ZINTER/ZUNION */
         iterzset *it = &op->iter.zset;
         if (op->encoding == OBJ_ENCODING_ZIPLIST) {
             it->zl.zl = op->subject->ptr;
-            it->zl.eptr = ziplistIndex(it->zl.zl,0);
+            it->zl.eptr = ziplistIndex(it->zl.zl,-2);
             if (it->zl.eptr != NULL) {
                 it->zl.sptr = ziplistNext(it->zl.zl,it->zl.eptr);
                 serverAssert(it->zl.sptr != NULL);
             }
         } else if (op->encoding == OBJ_ENCODING_SKIPLIST) {
             it->sl.zs = op->subject->ptr;
-            it->sl.node = it->sl.zs->zsl->header->level[0].forward;
+            it->sl.node = it->sl.zs->zsl->tail;
         } else {
             serverPanic("Unknown sorted set encoding");
         }
@@ -2083,7 +2086,7 @@ int zuiNext(zsetopsrc *op, zsetopval *val) {
             val->score = zzlGetScore(it->zl.sptr);
 
             /* Move to next element. */
-            zzlNext(it->zl.zl,&it->zl.eptr,&it->zl.sptr);
+            zzlPrev(it->zl.zl,&it->zl.eptr,&it->zl.sptr);
         } else if (op->encoding == OBJ_ENCODING_SKIPLIST) {
             if (it->sl.node == NULL)
                 return 0;
@@ -2091,7 +2094,7 @@ int zuiNext(zsetopsrc *op, zsetopval *val) {
             val->score = it->sl.node->score;
 
             /* Move to next element. */
-            it->sl.node = it->sl.node->level[0].forward;
+            it->sl.node = it->sl.node->backward;
         } else {
             serverPanic("Unknown sorted set encoding");
         }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2085,7 +2085,7 @@ int zuiNext(zsetopsrc *op, zsetopval *val) {
             serverAssert(ziplistGet(it->zl.eptr,&val->estr,&val->elen,&val->ell));
             val->score = zzlGetScore(it->zl.sptr);
 
-            /* Move to next element. */
+            /* Move to next element (going backwards, see zuiInitIterator). */
             zzlPrev(it->zl.zl,&it->zl.eptr,&it->zl.sptr);
         } else if (op->encoding == OBJ_ENCODING_SKIPLIST) {
             if (it->sl.node == NULL)
@@ -2093,7 +2093,7 @@ int zuiNext(zsetopsrc *op, zsetopval *val) {
             val->ele = it->sl.node->ele;
             val->score = it->sl.node->score;
 
-            /* Move to next element. */
+            /* Move to next element. (going backwards, see zuiInitIterator) */
             it->sl.node = it->sl.node->backward;
         } else {
             serverPanic("Unknown sorted set encoding");


### PR DESCRIPTION
In the iterator for these functions, we'll traverse the sorted sets
in a reversed way so that largest elements come first. We prefer
this order because it's optimized for insertion in a skiplist, which
is the destination of the elements being iterated in these functions.

I didn't modify the iteration code for sets (since it isn't ordered anyway),
and I also kept the function names (didn't rename to "reverse" or something),
just added a comment to zuiInitIterator. I feel like this should be further
documented, but I wasn't sure where to put further explanations.

I just noticed that the "ui" in "zuiInitIterator" is probably "union" and "inter".
Maybe we should rename all "zui" functions to "zuid"?