### PR TITLE
Reset average ttl when empty databases

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -416,6 +416,9 @@ long long emptyDbGeneric(redisDb *dbarray, int dbnum, int flags, void(callback)(
             dictEmpty(dbarray[j].dict,callback);
             dictEmpty(dbarray[j].expires,callback);
         }
+        /* Because we will start a new database, reset average ttl. */
+        dbarray[j].avg_ttl = 0;
+        dbarray[j].expires_cursor = 0;
     }
 
     /* Post-flush actions */


### PR DESCRIPTION
If master changes into replica role, it still keep old average ttl.