### PR TITLE
Add module data-type support for COPY.

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1163,7 +1163,12 @@ void copyCommand(client *c) {
                     addReplyError(c, "not supported for this module key");
                     return;
                 }
-                newobj = createModuleObject(mt, mt->copy(key, newkey, mv->value));
+                void *newval = mt->copy(key, newkey, mv->value);
+                if (!newval) {
+                    addReplyError(c, "module key failed to copy");
+                    return;
+                }
+                newobj = createModuleObject(mt, newval);
             }; break;
         default: {
             addReplyError(c, "unknown type object");

--- a/src/db.c
+++ b/src/db.c
@@ -1156,24 +1156,13 @@ void copyCommand(client *c) {
         case OBJ_ZSET: newobj = zsetDup(o); break;
         case OBJ_HASH: newobj = hashTypeDup(o); break;
         case OBJ_STREAM: newobj = streamDup(o); break;
-        case OBJ_MODULE: {
-                moduleValue *mv = o->ptr;
-                moduleType *mt = mv->type;
-                if (!mt->copy) {
-                    addReplyError(c, "not supported for this module key");
-                    return;
-                }
-                void *newval = mt->copy(key, newkey, mv->value);
-                if (!newval) {
-                    addReplyError(c, "module key failed to copy");
-                    return;
-                }
-                newobj = createModuleObject(mt, newval);
-            }; break;
-        default: {
+        case OBJ_MODULE:
+            newobj = moduleTypeDupOrReply(c, key, newkey, o);
+            if (!newobj) return;
+            break;
+        default:
             addReplyError(c, "unknown type object");
             return;
-        };
     }
 
     if (delete) {

--- a/src/db.c
+++ b/src/db.c
@@ -1156,9 +1156,15 @@ void copyCommand(client *c) {
         case OBJ_ZSET: newobj = zsetDup(o); break;
         case OBJ_HASH: newobj = hashTypeDup(o); break;
         case OBJ_STREAM: newobj = streamDup(o); break;
-        case OBJ_MODULE:
-            addReplyError(c, "Copying module type object is not supported");
-            return;
+        case OBJ_MODULE: {
+                moduleValue *mv = o->ptr;
+                moduleType *mt = mv->type;
+                if (!mt->copy) {
+                    addReplyError(c, "not supported for this module key");
+                    return;
+                }
+                newobj = createModuleObject(mt, mt->copy(key, newkey, mv->value));
+            }; break;
         default: {
             addReplyError(c, "unknown type object");
             return;

--- a/src/module.c
+++ b/src/module.c
@@ -3636,6 +3636,24 @@ void moduleTypeNameByID(char *name, uint64_t moduleid) {
     }
 }
 
+/* Create a copy of a module type value using the copy callback. If failed
+ * or not supported, produce an error reply and return NULL.
+ */
+robj *moduleTypeDupOrReply(client *c, robj *fromkey, robj *tokey, robj *value) {
+    moduleValue *mv = value->ptr;
+    moduleType *mt = mv->type;
+    if (!mt->copy) {
+        addReplyError(c, "not supported for this module key");
+        return NULL;
+    }
+    void *newval = mt->copy(fromkey, tokey, mv->value);
+    if (!newval) {
+        addReplyError(c, "module key failed to copy");
+        return NULL;
+    }
+    return createModuleObject(mt, newval);
+}
+
 /* Register a new data type exported by the module. The parameters are the
  * following. Please for in depth documentation check the modules API
  * documentation, especially https://redis.io/topics/modules-native-types.

--- a/src/module.c
+++ b/src/module.c
@@ -3699,7 +3699,7 @@ void moduleTypeNameByID(char *name, uint64_t moduleid) {
  *   The module is expected to perform a deep copy of the specified value and return it.
  *   In addition, hints about the names of the source and destination keys is provided.
  *   Note: if the target key exists and is being overwritten, the copy callback will be
- *         called first, followed by a free callback to the value that is being replaced.
+ *   called first, followed by a free callback to the value that is being replaced.
  * 
  * Note: the module name "AAAAAAAAA" is reserved and produces an error, it
  * happens to be pretty lame as well.

--- a/src/module.c
+++ b/src/module.c
@@ -3698,6 +3698,7 @@ void moduleTypeNameByID(char *name, uint64_t moduleid) {
  * * **copy**: A callback function pointer that is used to make a copy of the specified key.
  *   The module is expected to perform a deep copy of the specified value and return it.
  *   In addition, hints about the names of the source and destination keys is provided.
+ *   A NULL return value is considered an error and the copy operation fails.
  *   Note: if the target key exists and is being overwritten, the copy callback will be
  *   called first, followed by a free callback to the value that is being replaced.
  * 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -494,6 +494,7 @@ typedef void (*RedisModuleTypeDigestFunc)(RedisModuleDigest *digest, void *value
 typedef void (*RedisModuleTypeFreeFunc)(void *value);
 typedef size_t (*RedisModuleTypeFreeEffortFunc)(RedisModuleString *key, const void *value);
 typedef void (*RedisModuleTypeUnlinkFunc)(RedisModuleString *key, const void *value);
+typedef void *(*RedisModuleTypeCopyFunc)(RedisModuleString *fromkey, RedisModuleString *tokey, const void *value);
 typedef void (*RedisModuleClusterMessageReceiver)(RedisModuleCtx *ctx, const char *sender_id, uint8_t type, const unsigned char *payload, uint32_t len);
 typedef void (*RedisModuleTimerProc)(RedisModuleCtx *ctx, void *data);
 typedef void (*RedisModuleCommandFilterFunc) (RedisModuleCommandFilterCtx *filter);
@@ -516,6 +517,7 @@ typedef struct RedisModuleTypeMethods {
     int aux_save_triggers;
     RedisModuleTypeFreeEffortFunc free_effort;
     RedisModuleTypeUnlinkFunc unlink;
+    RedisModuleTypeCopyFunc copy;
 } RedisModuleTypeMethods;
 
 #define REDISMODULE_GET_API(name) \

--- a/src/server.h
+++ b/src/server.h
@@ -523,6 +523,7 @@ typedef size_t (*moduleTypeMemUsageFunc)(const void *value);
 typedef void (*moduleTypeFreeFunc)(void *value);
 typedef size_t (*moduleTypeFreeEffortFunc)(struct redisObject *key, const void *value);
 typedef void (*moduleTypeUnlinkFunc)(struct redisObject *key, void *value);
+typedef void *(*moduleTypeCopyFunc)(struct redisObject *fromkey, struct redisObject *tokey, const void *value);
 
 /* This callback type is called by moduleNotifyUserChanged() every time
  * a user authenticated via the module API is associated with a different
@@ -544,6 +545,7 @@ typedef struct RedisModuleType {
     moduleTypeFreeFunc free;
     moduleTypeFreeEffortFunc free_effort;
     moduleTypeUnlinkFunc unlink;
+    moduleTypeCopyFunc copy;
     moduleTypeAuxLoadFunc aux_load;
     moduleTypeAuxSaveFunc aux_save;
     int aux_save_triggers;

--- a/src/server.h
+++ b/src/server.h
@@ -1666,6 +1666,7 @@ void moduleUnblockClient(client *c);
 int moduleClientIsBlockedOnKeys(client *c);
 void moduleNotifyUserChanged(client *c);
 void moduleNotifyKeyUnlink(robj *key, robj *val);
+robj *moduleTypeDupOrReply(client *c, robj *fromkey, robj *tokey, robj *value);
 
 /* Utils */
 long long ustime(void);

--- a/tests/modules/datatype.c
+++ b/tests/modules/datatype.c
@@ -43,6 +43,11 @@ static void datatype_free(void *value) {
 
 static void *datatype_copy(RedisModuleString *fromkey, RedisModuleString *tokey, const void *value) {
     const DataType *old = value;
+
+    /* Answers to ultimate questions cannot be copied! */
+    if (old->intval == 42)
+        return NULL;
+
     DataType *new = (DataType *) RedisModule_Alloc(sizeof(DataType));
 
     new->intval = old->intval;

--- a/tests/modules/datatype.c
+++ b/tests/modules/datatype.c
@@ -41,6 +41,27 @@ static void datatype_free(void *value) {
     }
 }
 
+static void *datatype_copy(RedisModuleString *fromkey, RedisModuleString *tokey, const void *value) {
+    const DataType *old = value;
+    DataType *new = (DataType *) RedisModule_Alloc(sizeof(DataType));
+
+    new->intval = old->intval;
+    new->strval = RedisModule_CreateStringFromString(NULL, old->strval);
+
+    /* Breaking the rules here! We return a copy that also includes traces
+     * of fromkey/tokey to confirm we get what we expect.
+     */
+    size_t len;
+    const char *str = RedisModule_StringPtrLen(fromkey, &len);
+    RedisModule_StringAppendBuffer(NULL, new->strval, "/", 1);
+    RedisModule_StringAppendBuffer(NULL, new->strval, str, len);
+    RedisModule_StringAppendBuffer(NULL, new->strval, "/", 1);
+    str = RedisModule_StringPtrLen(tokey, &len);
+    RedisModule_StringAppendBuffer(NULL, new->strval, str, len);
+
+    return new;
+}
+
 static int datatype_set(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 4) {
         RedisModule_WrongArity(ctx);
@@ -97,9 +118,13 @@ static int datatype_get(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     DataType *dt = RedisModule_ModuleTypeGetValue(key);
     RedisModule_CloseKey(key);
 
-    RedisModule_ReplyWithArray(ctx, 2);
-    RedisModule_ReplyWithLongLong(ctx, dt->intval);
-    RedisModule_ReplyWithString(ctx, dt->strval);
+    if (!dt) {
+        RedisModule_ReplyWithNullArray(ctx);
+    } else {
+        RedisModule_ReplyWithArray(ctx, 2);
+        RedisModule_ReplyWithLongLong(ctx, dt->intval);
+        RedisModule_ReplyWithString(ctx, dt->strval);
+    }
     return REDISMODULE_OK;
 }
 
@@ -161,6 +186,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         .rdb_load = datatype_load,
         .rdb_save = datatype_save,
         .free = datatype_free,
+        .copy = datatype_copy
     };
 
     datatype = RedisModule_CreateDataType(ctx, "test___dt", 1, &datatype_methods);

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -41,4 +41,13 @@ start_server {tags {"modules"}} {
         catch {r datatype.swap key-a key-b} e
         set e
     } {*ERR*}
+
+    test {DataType: Copy command works for modules} {
+        # Our module's data type copy function copies the int value as-is
+        # but appends /<from-key>/<to-key> to the string value so we can
+        # track passed arguments.
+        r datatype.set sourcekey 1234 AAA
+        r copy sourcekey targetkey
+        r datatype.get targetkey
+    } {1234 AAA/sourcekey/targetkey}
 }

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -43,6 +43,11 @@ start_server {tags {"modules"}} {
     } {*ERR*}
 
     test {DataType: Copy command works for modules} {
+        # Test failed copies
+        r datatype.set answer-to-universe 42 AAA
+        catch {r copy answer-to-universe answer2} e
+        assert_match {*module key failed to copy*} $e
+
         # Our module's data type copy function copies the int value as-is
         # but appends /<from-key>/<to-key> to the string value so we can
         # track passed arguments.


### PR DESCRIPTION
This adds a copy callback for module data types, in order to make
modules compatible with the new COPY command.

The callback is optional and COPY will fail for keys with data types
that do not implement it.