### PR TITLE
Getset fix

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -71,7 +71,7 @@ static int checkStringLength(client *c, long long size) {
 
 void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire, int unit, robj *ok_reply, robj *abort_reply) {
     long long milliseconds = 0; /* initialized to avoid any harmness warning */
-
+    
     if (expire) {
         if (getLongLongFromObjectOrReply(c, expire, &milliseconds, NULL) != C_OK)
             return;
@@ -90,7 +90,7 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
     }
 
     if (flags & OBJ_SET_GET) {
-        getGenericCommand(c);
+        if (getGenericCommand(c) == C_ERR) return;
     }
 
     genericSetKey(c,c->db,key,val,flags & OBJ_SET_KEEPTTL,1);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -71,7 +71,7 @@ static int checkStringLength(client *c, long long size) {
 
 void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire, int unit, robj *ok_reply, robj *abort_reply) {
     long long milliseconds = 0; /* initialized to avoid any harmness warning */
-    
+
     if (expire) {
         if (getLongLongFromObjectOrReply(c, expire, &milliseconds, NULL) != C_OK)
             return;

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -415,7 +415,7 @@ start_server {tags {"string"}} {
       list $err1 $err2
     } {*syntax err* *syntax err*}
 
-    test {Extended SET GET with incorrect type should result in syntax err} {
+    test {Extended SET GET with incorrect type should result in wrong type error} {
       r del foo
       r rpush foo waffle
       catch {r set foo bar GET} err1

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -415,6 +415,14 @@ start_server {tags {"string"}} {
       list $err1 $err2
     } {*syntax err* *syntax err*}
 
+    test {Extended SET GET with incorrect type should result in syntax err} {
+      r del foo
+      r rpush foo waffle
+      catch {r set foo bar GET} err1
+      assert_equal "waffle" [r rpop foo]
+      set err1
+    } {*WRONGTYPE*}
+
     test {Extended SET EX option} {
         r del foo
         r set foo bar ex 10


### PR DESCRIPTION
SET with GET will throw an error but still overwrite the value on error. So checking the error code. 

Resolves https://github.com/redis/redis/issues/8116

Side note, I think there is a static code checker that will make sure we are checking return codes, might be worth looking at. (Or we could use rust)