### PR TITLE
Expose Redis main thread cpu time, and scrape system time via INFO command. 

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -56,6 +56,7 @@
 #include <sys/utsname.h>
 #include <locale.h>
 #include <sys/socket.h>
+#include <sys/resource.h>
 
 /* Our shared "common" objects */
 
@@ -4269,7 +4270,6 @@ sds genRedisInfoString(const char *section) {
     sds info = sdsempty();
     time_t uptime = server.unixtime-server.stat_starttime;
     int j;
-    struct rusage self_ru, c_ru;
     int allsections = 0, defsections = 0, everything = 0, modules = 0;
     int sections = 0;
 
@@ -4279,9 +4279,6 @@ sds genRedisInfoString(const char *section) {
     everything = strcasecmp(section,"everything") == 0;
     modules = strcasecmp(section,"modules") == 0;
     if (everything) allsections = 1;
-
-    getrusage(RUSAGE_SELF, &self_ru);
-    getrusage(RUSAGE_CHILDREN, &c_ru);
 
     /* Server */
     if (allsections || defsections || !strcasecmp(section,"server")) {
@@ -4328,6 +4325,7 @@ sds genRedisInfoString(const char *section) {
             "process_supervised:%s\r\n"
             "run_id:%s\r\n"
             "tcp_port:%i\r\n"
+            "server_time_usec:%I\r\n"
             "uptime_in_seconds:%I\r\n"
             "uptime_in_days:%I\r\n"
             "hz:%i\r\n"
@@ -4354,6 +4352,7 @@ sds genRedisInfoString(const char *section) {
             supervised,
             server.runid,
             server.port ? server.port : server.tls_port,
+            (int64_t)server.ustime,
             (int64_t)uptime,
             (int64_t)(uptime/(3600*24)),
             server.hz,
@@ -4839,6 +4838,10 @@ sds genRedisInfoString(const char *section) {
     /* CPU */
     if (allsections || defsections || !strcasecmp(section,"cpu")) {
         if (sections++) info = sdscat(info,"\r\n");
+
+        struct rusage self_ru, c_ru;
+        getrusage(RUSAGE_SELF, &self_ru);
+        getrusage(RUSAGE_CHILDREN, &c_ru);
         info = sdscatprintf(info,
         "# CPU\r\n"
         "used_cpu_sys:%ld.%06ld\r\n"
@@ -4849,6 +4852,15 @@ sds genRedisInfoString(const char *section) {
         (long)self_ru.ru_utime.tv_sec, (long)self_ru.ru_utime.tv_usec,
         (long)c_ru.ru_stime.tv_sec, (long)c_ru.ru_stime.tv_usec,
         (long)c_ru.ru_utime.tv_sec, (long)c_ru.ru_utime.tv_usec);
+#ifdef RUSAGE_THREAD
+        struct rusage m_ru;
+        getrusage(RUSAGE_THREAD, &m_ru);
+        info = sdscatprintf(info,
+            "used_cpu_sys_main_thread:%ld.%06ld\r\n"
+            "used_cpu_user_main_thread:%ld.%06ld\r\n",
+            (long)m_ru.ru_stime.tv_sec, (long)m_ru.ru_stime.tv_usec,
+            (long)m_ru.ru_utime.tv_sec, (long)m_ru.ru_utime.tv_usec);
+#endif  /* RUSAGE_THREAD */
     }
 
     /* Modules */


### PR DESCRIPTION
The following PR exposes the main thread CPU info via info modules ( linux specific only ) (`used_cpu_sys_main_thread` and `used_cpu_user_main_thread`). This is important for:
- distinguish between main thread and io-threads cpu time total cpu time consumed ( check what is the first bottleneck on the used config )
- distinguish between main thread and modules threads total cpu time consumed

Apart from it, this PR also exposes the `server_time_in_microseconds` within the Server section so that we can properly differentiate consecutive collection and calculate for example the CPU% and or / cpu time vs wall time, etc... 

Note: given that I was already touching the CPU time collection code I've moved it to be called within the cpu section ( no need to measure cpu time if we're not outputting it ). 

Here is a sample output of the proposed #CPU section on a 1 and 4 io-threads config ( while running a simple benchmark ):

### 1 io-thread (default) 
We should see a small difference between main thread / all threads cpu time. Not very usefull for this simple scenario

```
$ redis-cli info cpu
# CPU
used_cpu_sys:15.972181
used_cpu_user:2.316606
used_cpu_sys_children:0.000000
used_cpu_user_children:0.000000
used_cpu_sys_main_thread:15.972034
used_cpu_user_main_thread:2.316585
```

### 4 io-threads 
We should see a large difference between main thread / all threads cpu time, and be able to properly identify the main/bg threads cpu usage.

```
$ redis-cli info cpu
# CPU
used_cpu_sys:18.644760
used_cpu_user:20.648113
used_cpu_sys_children:0.000000
used_cpu_user_children:0.000000
used_cpu_sys_main_thread:6.978166
used_cpu_user_main_thread:2.860689
```

-----------------------------------------------

## Regarding server time

Sample #SERVER section output:

```
$ redis-cli info server
# Server
# Server
redis_version:255.255.255
redis_git_sha1:c44a11c6
redis_git_dirty:0
redis_build_id:f6545694f8309272
redis_mode:standalone
os:Linux 5.4.0-56-generic x86_64
arch_bits:64
multiplexing_api:epoll
atomicvar_api:c11-builtin
gcc_version:9.3.0
process_id:310328
process_supervised:no
run_id:d25738d6a821c41f0cf1036078b8728c0c0eaaa8
tcp_port:6379
server_time_usec:1607863602885086
uptime_in_seconds:7
uptime_in_days:0
hz:10
configured_hz:10
lru_clock:14028082
executable:/home/filipe/redislabs/redis/./src/redis-server
config_file:
io_threads_active:0
```