### PR TITLE
Tracking: disabling call BCAST mode again when BCAST already enabled

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2641,6 +2641,14 @@ NULL
                 return;
             }
 
+            if (options & CLIENT_TRACKING_BCAST && c->flags & CLIENT_TRACKING_BCAST) {
+                addReplyError(c,
+                "BCAST mode already enabled, you cannot enable BCAST again "
+                "before disabling tracking for this client.");
+                zfree(prefix);
+                return;
+            }
+
             enableTracking(c,redir,options,prefix,numprefix);
         } else if (!strcasecmp(c->argv[2]->ptr,"off")) {
             disableTracking(c);

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -81,11 +81,9 @@ start_server {tags {"tracking"}} {
         assert {$keys eq {a:1 a:2 b:1 b:2}}
     }
 
-    test {Adding prefixes to BCAST mode works} {
-        r CLIENT TRACKING on BCAST REDIRECT $redir_id PREFIX c:
-        r INCR c:1234
-        set keys [lsort [lindex [$rd_redirection read] 2]]
-        assert {$keys eq {c:1234}}
+    test {Cannot call BCAST mode again when BCAST already enabled} {
+        catch {r CLIENT TRACKING on BCAST REDIRECT $redir_id PREFIX c:} e
+        assert_match {ERR BCAST*} $e
     }
 
     test {Tracking NOLOOP mode in standard mode works} {


### PR DESCRIPTION
This PR fixes https://github.com/redis/redis/issues/8003 . The cause of this issue is if we did not specify any prefixes, "" will be used as the default prefix since an empty string is a prefix for all other string. However if we call the CLIENT TRACKING ON BCAST with prefixes again both "" and other prefixes will be registered in the prefixes radix tree for bcast tracking, this will cause same client receive duplicate invalidation messages.

 For a side note regarding my comment if user specifying one prefix is a subset  of another in the same call: https://github.com/redis/redis/issues/8003#issuecomment-721314648 . There are two ways we handle this:
1. Do a brute force check for each prefixes.
2. Provide the Radix tree API for checking if a key's path has other keys.

The first one has O(n^2) performance and we are trying to avoid, the second is optimal but we may not doing it for now since it need to change the lower level Radix tree code for providing this API,  maybe we can do this later, but for now since we don't want to bring much complexity, we can just simply solving the original issue now first..