### PR TITLE
Add currdb command to get current db value.

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -698,6 +698,15 @@ void selectCommand(client *c) {
     }
 }
 
+void currdbCommand(client *c) {
+
+    if (server.cluster_enabled) {
+        addReplyLongLong(c, 0);
+    } else {
+        addReplyLongLong(c, c->db->id);
+    }
+}
+
 void randomkeyCommand(client *c) {
     robj *key;
 

--- a/src/server.c
+++ b/src/server.c
@@ -1052,7 +1052,11 @@ struct redisCommand redisCommandTable[] = {
 
     {"reset",resetCommand,-1,
      "no-script ok-stale ok-loading fast @connection",
-     0,NULL,0,0,0,0,0,0}
+     0,NULL,0,0,0,0,0,0},
+
+    {"currdb",currdbCommand,-1,
+      "ok-stale ok-loading fast @connection",
+      0,NULL,0,0,0,0,0,0},
 };
 
 /*============================ Utility functions ============================ */

--- a/src/server.h
+++ b/src/server.h
@@ -2359,6 +2359,7 @@ void incrbyCommand(client *c);
 void decrbyCommand(client *c);
 void incrbyfloatCommand(client *c);
 void selectCommand(client *c);
+void currdbCommand(client *c);
 void swapdbCommand(client *c);
 void randomkeyCommand(client *c);
 void keysCommand(client *c);

--- a/tests/unit/commands.tcl
+++ b/tests/unit/commands.tcl
@@ -1,0 +1,9 @@
+start_server {tags {"currdb"}} {
+    test "CURRDB" {
+        assert_equal "0" r CURRDB
+        r SELECT 1
+        assert_equal "1" r CURRDB
+        r SELECT 2
+        assert_equal "2" r CURRDB
+    }
+}


### PR DESCRIPTION
Currently during cli connect of Redis CLI, if it fails to SELECT a database (due to ACL permissions), the user lands onto database 0. However the Redis CLI prompt states otherwise which is confusing to the end user. For e.g.

```
$ ./redis-cli
127.0.0.1:6379> acl setuser mydefault on nopass +@all -select +select|5
OK
127.0.0.1:6379> acl list
1) "user default on nopass ~* &* +@all"
2) "user mydefault on nopass &* +@all -select +select|5"
127.0.0.1:6379>
$ ./redis-cli --user mydefault --pass a -n 1
Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
127.0.0.1:6379[1]> client list
id=8 addr=127.0.0.1:61906 laddr=127.0.0.1:6379 fd=8 name= age=10 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=45024 argv-mem=10 obl=0 oll=0 omem=0 tot-mem=62490 events=r cmd=client user=mydefault redir=-1
127.0.0.1:6379[1]>
```

As we can see in the above scenario, the current client is pointing to 0 db index instead of 1.

After the proposed changes, redis-cli warns about the failure of selection of database as well as displays the current database index the client is pointing to.

```
$ ./redis-cli
127.0.0.1:6379> acl setuser mydefault on nopass +@all -select +select|5
OK
127.0.0.1:6379> acl list
1) "user default on nopass ~* &* +@all"
2) "user mydefault on nopass &* +@all -select +select|5"
$ ./redis-cli --user mydefault --pass a -n 1
Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
Warning: SELECT failed
127.0.0.1:6379> client list
id=10 addr=127.0.0.1:62661 laddr=127.0.0.1:6379 fd=8 name= age=5 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=45024 argv-mem=10 obl=0 oll=0 omem=0 tot-mem=62490 events=r cmd=client user=mydefault redir=-1
127.0.0.1:6379> CURRDB
(integer) 0
127.0.0.1:6379> SELECT 1
(error) NOPERM this user has no permissions to run the 'select' command or its subcommand
127.0.0.1:6379> SELECT 5
OK
127.0.0.1:6379[5]> CURRDB
(integer) 5
```
