### PR TITLE
Fix some wrong server.dirty increments

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -604,6 +604,10 @@ void flushAllDataAndResetRDB(int flags) {
         rdbSave(server.rdb_filename,rsiptr);
         server.dirty = saved_dirty;
     }
+
+    /* Without that extra dirty++, when db was already empty, FLUSHALL will
+     * not be replicated nor put into the AOF. */
+    server.dirty++;
 #if defined(USE_JEMALLOC)
     /* jemalloc 5 doesn't release pages back to the OS when there's no traffic.
      * for large databases, flushdb blocks for long anyway, so a bit more won't

--- a/src/db.c
+++ b/src/db.c
@@ -604,7 +604,6 @@ void flushAllDataAndResetRDB(int flags) {
         rdbSave(server.rdb_filename,rsiptr);
         server.dirty = saved_dirty;
     }
-    server.dirty++;
 #if defined(USE_JEMALLOC)
     /* jemalloc 5 doesn't release pages back to the OS when there's no traffic.
      * for large databases, flushdb blocks for long anyway, so a bit more won't

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1189,6 +1189,7 @@ void pfaddCommand(client *c) {
          * is guaranteed to return bytes initialized to zero. */
         o = createHLLObject();
         dbAdd(c->db,c->argv[1],o);
+        updated++;
     } else {
         if (isHLLObjectOrReply(c,o) != C_OK) return;
         o = dbUnshareStringValue(c->db,c->argv[1],o);

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1189,7 +1189,6 @@ void pfaddCommand(client *c) {
          * is guaranteed to return bytes initialized to zero. */
         o = createHLLObject();
         dbAdd(c->db,c->argv[1],o);
-        updated++;
     } else {
         if (isHLLObjectOrReply(c,o) != C_OK) return;
         o = dbUnshareStringValue(c->db,c->argv[1],o);
@@ -1211,7 +1210,7 @@ void pfaddCommand(client *c) {
     if (updated) {
         signalModifiedKey(c,c->db,c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_STRING,"pfadd",c->argv[1],c->db->id);
-        server.dirty++;
+        server.dirty += updated;
         HLL_INVALIDATE_CACHE(hdr);
     }
     addReply(c, updated ? shared.cone : shared.czero);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -581,8 +581,10 @@ void hsetCommand(client *c) {
     if ((o = hashTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
     hashTypeTryConversion(o,c->argv,2,c->argc-1);
 
-    for (i = 2; i < c->argc; i += 2)
+    for (i = 2; i < c->argc; i += 2) {
         created += !hashTypeSet(o,c->argv[i]->ptr,c->argv[i+1]->ptr,HASH_SET_COPY);
+        server.dirty++;
+    }
 
     /* HMSET (deprecated) and HSET return value is different. */
     char *cmdname = c->argv[0]->ptr;
@@ -595,7 +597,6 @@ void hsetCommand(client *c) {
     }
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
-    server.dirty += created;
 }
 
 void hincrbyCommand(client *c) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -595,7 +595,7 @@ void hsetCommand(client *c) {
     }
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
-    server.dirty++;
+    server.dirty += created;
 }
 
 void hincrbyCommand(client *c) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -581,10 +581,8 @@ void hsetCommand(client *c) {
     if ((o = hashTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
     hashTypeTryConversion(o,c->argv,2,c->argc-1);
 
-    for (i = 2; i < c->argc; i += 2) {
+    for (i = 2; i < c->argc; i += 2)
         created += !hashTypeSet(o,c->argv[i]->ptr,c->argv[i+1]->ptr,HASH_SET_COPY);
-        server.dirty++;
-    }
 
     /* HMSET (deprecated) and HSET return value is different. */
     char *cmdname = c->argv[0]->ptr;
@@ -597,6 +595,7 @@ void hsetCommand(client *c) {
     }
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH,"hset",c->argv[1],c->db->id);
+    server.dirty += (c->argc - 2)/2;
 }
 
 void hincrbyCommand(client *c) {

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -508,7 +508,7 @@ void ltrimCommand(client *c) {
         notifyKeyspaceEvent(NOTIFY_GENERIC,"del",c->argv[1],c->db->id);
     }
     signalModifiedKey(c,c->db,c->argv[1]);
-    server.dirty++;
+    server.dirty += (ltrim + rtrim);
     addReply(c,shared.ok);
 }
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -497,7 +497,6 @@ void spopWithCountCommand(client *c) {
         /* Propagate this command as a DEL operation */
         rewriteClientCommandVector(c,2,shared.del,c->argv[1]);
         signalModifiedKey(c,c->db,c->argv[1]);
-        server.dirty++;
         return;
     }
 
@@ -599,7 +598,6 @@ void spopWithCountCommand(client *c) {
     decrRefCount(propargv[0]);
     preventCommandPropagation(c);
     signalModifiedKey(c,c->db,c->argv[1]);
-    server.dirty++;
 }
 
 void spopCommand(client *c) {

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -481,7 +481,7 @@ void spopWithCountCommand(client *c) {
 
     /* Generate an SPOP keyspace notification */
     notifyKeyspaceEvent(NOTIFY_SET,"spop",c->argv[1],c->db->id);
-    server.dirty += count;
+    server.dirty += (count >= size) ? size : count;
 
     /* CASE 1:
      * The number of requested elements is greater than or equal to


### PR DESCRIPTION
1. Fix wrong server.drity increment in spopWithCountCommand. If the count of spop is larger than the size of set, server.dirty should only increase the count of set, not the count.
2. Fix wrong server.dirty increment in hsetCommand, pfaddCommand, ltrimCommand.