### PR TITLE
Enable configuring OpenSSL using the standard openssl.cnf

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -34,6 +34,7 @@
 
 #ifdef USE_OPENSSL
 
+#include <openssl/conf.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
@@ -136,6 +137,17 @@ static void initCryptoLocks(void) {
 #endif /* USE_CRYPTO_LOCKS */
 
 void tlsInit(void) {
+    /* Enable configuring OpenSSL using the standard openssl.cnf
+     * OPENSSL_config()/OPENSSL_init_crypto() should be the first 
+     * call to the OpenSSL* library.
+     *  - OPENSSL_config() should be used for OpenSSL versions < 1.1.0
+     *  - OPENSSL_init_crypto() should be used for OpenSSL versions >= 1.1.0
+     */
+    #if OPENSSL_VERSION_NUMBER < 0x10100000L
+    OPENSSL_config(NULL);
+    #else
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+    #endif
     ERR_load_crypto_strings();
     SSL_load_error_strings();
     SSL_library_init();


### PR DESCRIPTION
This rather simple PR will enable configuring and enabling very important OpenSSL features using the standard openssl.cnf file. 
One example of it are [Engines](https://github.com/openssl/openssl/blob/master/README-Engine.md) ( introduced in OpenSSL 0.9.6 ). 
More information of the current bultin engines of opensll for the following crypto devices:
- Microsoft CryptoAPI
- VIA Padlock
- nCipher CHIL


In addition, dynamic binding to external ENGINE implementations is now provided. An example of dynamic agent is [Intel® QAT OpenSSL* Engine](https://github.com/intel/QAT_Engine#using-the-openssl-configuration-file-to-loadinitialize-engines).
Given we're using `OPENSSL_config()` and  `OPENSSL_init_crypto()` we're compatible with versions >= 0.9.6. 