### PR TITLE
Modules: add defrag API support.

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -29,4 +29,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/blockedclient \
 --single unit/moduleapi/getkeys \
 --single unit/moduleapi/test_lazyfree \
+--single unit/moduleapi/defrag \
 "${@}"

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -800,12 +800,10 @@ long defragStream(redisDb *db, dictEntry *kde) {
 long defragModule(redisDb *db, dictEntry *kde) {
     robj *obj = dictGetVal(kde);
     serverAssert(obj->type == OBJ_MODULE);
+    long defragged = 0;
 
-    long defragged = moduleDefragValue(dictGetKey(kde), obj);
-    if (defragged == -1) {
+    if (!moduleDefragValue(dictGetKey(kde), obj, &defragged))
         defragLater(db, kde);
-        return 0;
-    }
 
     return defragged;
 }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -794,6 +794,22 @@ long defragStream(redisDb *db, dictEntry *kde) {
     return defragged;
 }
 
+/* Defrag a module key. This is either done immediately or scheduled
+ * for later. Returns then number of pointers defragged.
+ */
+long defragModule(redisDb *db, dictEntry *kde) {
+    robj *obj = dictGetVal(kde);
+    serverAssert(obj->type == OBJ_MODULE);
+
+    long defragged = moduleDefragValue(dictGetKey(kde), obj);
+    if (defragged == -1) {
+        defragLater(db, kde);
+        return 0;
+    }
+
+    return defragged;
+}
+
 /* for each key we scan in the main dict, this function will attempt to defrag
  * all the various pointers it has. Returns a stat of how many pointers were
  * moved. */
@@ -865,8 +881,7 @@ long defragKey(redisDb *db, dictEntry *de) {
     } else if (ob->type == OBJ_STREAM) {
         defragged += defragStream(db, de);
     } else if (ob->type == OBJ_MODULE) {
-        /* Currently defragmenting modules private data types
-         * is not supported. */
+        defragged += defragModule(db, de);
     } else {
         serverPanic("Unknown object type");
     }
@@ -928,6 +943,7 @@ long defragOtherGlobals() {
      * that remain static for a long time */
     defragged += activeDefragSdsDict(server.lua_scripts, DEFRAG_SDS_DICT_VAL_IS_STROB);
     defragged += activeDefragSdsListAndDict(server.repl_scriptcache_fifo, server.repl_scriptcache_dict, DEFRAG_SDS_DICT_NO_VAL);
+    defragged += moduleDefragGlobals();
     return defragged;
 }
 
@@ -946,6 +962,8 @@ int defragLaterItem(dictEntry *de, unsigned long *cursor, long long endtime) {
             server.stat_active_defrag_hits += scanLaterHash(ob, cursor);
         } else if (ob->type == OBJ_STREAM) {
             return scanLaterStraemListpacks(ob, cursor, endtime, &server.stat_active_defrag_hits);
+        } else if (ob->type == OBJ_MODULE) {
+            return moduleLateDefrag(dictGetKey(de), ob, cursor, endtime, &server.stat_active_defrag_hits);
         } else {
             *cursor = 0; /* object type may have changed since we schedule it for later */
         }
@@ -1182,6 +1200,17 @@ void activeDefragCycle(void) {
 
 void activeDefragCycle(void) {
     /* Not implemented yet. */
+}
+
+void *activeDefragAlloc(void *ptr) {
+    UNUSED(ptr);
+    return NULL;
+}
+
+robj *activeDefragStringOb(robj *ob, long *defragged) {
+    UNUSED(ob);
+    UNUSED(defragged);
+    return NULL;
 }
 
 #endif

--- a/src/module.c
+++ b/src/module.c
@@ -8263,8 +8263,11 @@ void *RM_DefragAlloc(RedisModuleDefragCtx *ctx, void *ptr) {
  * See RM_DefragAlloc() for more information on how the defragmentation process
  * works.
  *
- * NOTE: Currently retained strings (which have multiple references) do not get
- * defragmented.
+ * NOTE: It is only possible to defrag strings that have a single reference.
+ * Typically this means strings retained with RM_RetainString or RM_HoldString
+ * may not be defragmentable. One exception is command argvs which, if retained
+ * by the module, will end up with a single reference (because the reference
+ * on the Redis side is dropped as soon as the command callback returns).
  */
 RedisModuleString *RM_DefragRedisModuleString(RedisModuleDefragCtx *ctx, RedisModuleString *str) {
     return activeDefragStringOb(str, &ctx->defragged);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -225,6 +225,7 @@ typedef struct RedisModuleEvent {
 } RedisModuleEvent;
 
 struct RedisModuleCtx;
+struct RedisModuleDefragCtx;
 typedef void (*RedisModuleEventCallback)(struct RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data);
 
 static const RedisModuleEvent
@@ -479,6 +480,7 @@ typedef struct RedisModuleCommandFilter RedisModuleCommandFilter;
 typedef struct RedisModuleInfoCtx RedisModuleInfoCtx;
 typedef struct RedisModuleServerInfoData RedisModuleServerInfoData;
 typedef struct RedisModuleScanCursor RedisModuleScanCursor;
+typedef struct RedisModuleDefragCtx RedisModuleDefragCtx;
 typedef struct RedisModuleUser RedisModuleUser;
 
 typedef int (*RedisModuleCmdFunc)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
@@ -494,6 +496,7 @@ typedef void (*RedisModuleTypeDigestFunc)(RedisModuleDigest *digest, void *value
 typedef void (*RedisModuleTypeFreeFunc)(void *value);
 typedef size_t (*RedisModuleTypeFreeEffortFunc)(RedisModuleString *key, const void *value);
 typedef void (*RedisModuleTypeUnlinkFunc)(RedisModuleString *key, const void *value);
+typedef int (*RedisModuleTypeDefragFunc)(RedisModuleDefragCtx *ctx, RedisModuleString *key, void **value);
 typedef void (*RedisModuleClusterMessageReceiver)(RedisModuleCtx *ctx, const char *sender_id, uint8_t type, const unsigned char *payload, uint32_t len);
 typedef void (*RedisModuleTimerProc)(RedisModuleCtx *ctx, void *data);
 typedef void (*RedisModuleCommandFilterFunc) (RedisModuleCommandFilterCtx *filter);
@@ -502,6 +505,7 @@ typedef void (*RedisModuleInfoFunc)(RedisModuleInfoCtx *ctx, int for_crash_repor
 typedef void (*RedisModuleScanCB)(RedisModuleCtx *ctx, RedisModuleString *keyname, RedisModuleKey *key, void *privdata);
 typedef void (*RedisModuleScanKeyCB)(RedisModuleKey *key, RedisModuleString *field, RedisModuleString *value, void *privdata);
 typedef void (*RedisModuleUserChangedFunc) (uint64_t client_id, void *privdata);
+typedef int (*RedisModuleDefragFunc)(RedisModuleDefragCtx *ctx);
 
 typedef struct RedisModuleTypeMethods {
     uint64_t version;
@@ -516,6 +520,7 @@ typedef struct RedisModuleTypeMethods {
     int aux_save_triggers;
     RedisModuleTypeFreeEffortFunc free_effort;
     RedisModuleTypeUnlinkFunc unlink;
+    RedisModuleTypeDefragFunc defrag;
 } RedisModuleTypeMethods;
 
 #define REDISMODULE_GET_API(name) \
@@ -774,6 +779,12 @@ REDISMODULE_API int (*RedisModule_AuthenticateClientWithUser)(RedisModuleCtx *ct
 REDISMODULE_API int (*RedisModule_DeauthenticateAndCloseClient)(RedisModuleCtx *ctx, uint64_t client_id) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_GetClientCertificate)(RedisModuleCtx *ctx, uint64_t id) REDISMODULE_ATTR;
 REDISMODULE_API int *(*RedisModule_GetCommandKeys)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *num_keys) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_RegisterDefragFunc)(RedisModuleCtx *ctx, RedisModuleDefragFunc func) REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_DefragAlloc)(RedisModuleDefragCtx *ctx, void *ptr) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_DefragRedisModuleString)(RedisModuleDefragCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DefragShouldStop)(RedisModuleDefragCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DefragCursorSet)(RedisModuleDefragCtx *ctx, unsigned long cursor) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_DefragCursorGet)(RedisModuleDefragCtx *ctx, unsigned long *cursor) REDISMODULE_ATTR;
 #endif
 
 #define RedisModule_IsAOFClient(id) ((id) == CLIENT_ID_AOF)
@@ -1023,6 +1034,12 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(AuthenticateClientWithUser);
     REDISMODULE_GET_API(GetClientCertificate);
     REDISMODULE_GET_API(GetCommandKeys);
+    REDISMODULE_GET_API(RegisterDefragFunc);
+    REDISMODULE_GET_API(DefragAlloc);
+    REDISMODULE_GET_API(DefragRedisModuleString);
+    REDISMODULE_GET_API(DefragShouldStop);
+    REDISMODULE_GET_API(DefragCursorSet);
+    REDISMODULE_GET_API(DefragCursorGet);
 #endif
 
     if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;

--- a/src/server.h
+++ b/src/server.h
@@ -1697,7 +1697,7 @@ void moduleUnblockClient(client *c);
 int moduleClientIsBlockedOnKeys(client *c);
 void moduleNotifyUserChanged(client *c);
 void moduleNotifyKeyUnlink(robj *key, robj *val);
-long moduleDefragValue(robj *key, robj *obj);
+int moduleDefragValue(robj *key, robj *obj, long *defragged);
 int moduleLateDefrag(robj *key, robj *value, unsigned long *cursor, long long endtime, long long *defragged);
 long moduleDefragGlobals(void);
 

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -28,6 +28,7 @@ TEST_MODULES = \
     getkeys.so \
     test_lazyfree.so \
     timer.so \
+    defragtest.so
 
 
 .PHONY: all

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -179,7 +179,8 @@ int FragDefrag(RedisModuleDefragCtx *ctx, RedisModuleString *key, void **value) 
         }
 
         if ((o->maxstep && ++steps > o->maxstep) ||
-            ((i % 64 == 0) && RedisModule_DefragShouldStop(ctx))) {
+            ((i % 64 == 0) && RedisModule_DefragShouldStop(ctx)))
+        {
             RedisModule_DefragCursorSet(ctx, i);
             last_set_cursor = i;
             return 1;

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -1,0 +1,233 @@
+/* A module that implements defrag callback mechanisms.
+ */
+
+#define REDISMODULE_EXPERIMENTAL_API
+#include "redismodule.h"
+
+static RedisModuleType *FragType;
+
+struct FragObject {
+    unsigned long len;
+    void **values;
+    int maxstep;
+};
+
+/* Make sure we get the expected cursor */
+unsigned long int last_set_cursor = 0;
+
+unsigned long int datatype_attempts = 0;
+unsigned long int datatype_defragged = 0;
+unsigned long int datatype_resumes = 0;
+unsigned long int datatype_wrong_cursor = 0;
+unsigned long int global_attempts = 0;
+unsigned long int global_defragged = 0;
+
+int global_strings_len = 0;
+RedisModuleString **global_strings = NULL;
+
+static void createGlobalStrings(RedisModuleCtx *ctx, int count)
+{
+    global_strings_len = count;
+    global_strings = RedisModule_Alloc(sizeof(RedisModuleString *) * count);
+
+    for (int i = 0; i < count; i++) {
+        global_strings[i] = RedisModule_CreateStringFromLongLong(ctx, i);
+    }
+}
+
+static int defragGlobalStrings(RedisModuleDefragCtx *ctx)
+{
+    for (int i = 0; i < global_strings_len; i++) {
+        RedisModuleString *new = RedisModule_DefragRedisModuleString(ctx, global_strings[i]);
+        global_attempts++;
+        if (new != NULL) {
+            global_strings[i] = new;
+            global_defragged++;
+        }
+    }
+
+    return 0;
+}
+
+static void FragInfo(RedisModuleInfoCtx *ctx, int for_crash_report) {
+    REDISMODULE_NOT_USED(for_crash_report);
+
+    RedisModule_InfoAddSection(ctx, "stats");
+    RedisModule_InfoAddFieldLongLong(ctx, "datatype_attempts", datatype_attempts);
+    RedisModule_InfoAddFieldLongLong(ctx, "datatype_defragged", datatype_defragged);
+    RedisModule_InfoAddFieldLongLong(ctx, "datatype_resumes", datatype_resumes);
+    RedisModule_InfoAddFieldLongLong(ctx, "datatype_wrong_cursor", datatype_wrong_cursor);
+    RedisModule_InfoAddFieldLongLong(ctx, "global_attempts", global_attempts);
+    RedisModule_InfoAddFieldLongLong(ctx, "global_defragged", global_defragged);
+}
+
+struct FragObject *createFragObject(unsigned long len, unsigned long size, int maxstep) {
+    struct FragObject *o = RedisModule_Alloc(sizeof(*o));
+    o->len = len;
+    o->values = RedisModule_Alloc(sizeof(RedisModuleString*) * len);
+    o->maxstep = maxstep;
+
+    for (unsigned long i = 0; i < len; i++) {
+        o->values[i] = RedisModule_Calloc(1, size);
+    }
+
+    return o;
+}
+
+/* FRAG.RESETSTATS */
+static int fragResetStatsCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    datatype_attempts = 0;
+    datatype_defragged = 0;
+    datatype_resumes = 0;
+    datatype_wrong_cursor = 0;
+    global_attempts = 0;
+    global_defragged = 0;
+
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+/* FRAG.CREATE key len size maxstep */
+static int fragCreateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 5)
+        return RedisModule_WrongArity(ctx);
+
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
+                                              REDISMODULE_READ|REDISMODULE_WRITE);
+    int type = RedisModule_KeyType(key);
+    if (type != REDISMODULE_KEYTYPE_EMPTY)
+    {
+        return RedisModule_ReplyWithError(ctx, "ERR key exists");
+    }
+
+    long long len;
+    if ((RedisModule_StringToLongLong(argv[2], &len) != REDISMODULE_OK)) {
+        return RedisModule_ReplyWithError(ctx, "ERR invalid len");
+    }
+
+    long long size;
+    if ((RedisModule_StringToLongLong(argv[3], &size) != REDISMODULE_OK)) {
+        return RedisModule_ReplyWithError(ctx, "ERR invalid size");
+    }
+
+    long long maxstep;
+    if ((RedisModule_StringToLongLong(argv[4], &maxstep) != REDISMODULE_OK)) {
+        return RedisModule_ReplyWithError(ctx, "ERR invalid maxstep");
+    }
+
+    struct FragObject *o = createFragObject(len, size, maxstep);
+    RedisModule_ModuleTypeSetValue(key, FragType, o);
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    RedisModule_CloseKey(key);
+
+    return REDISMODULE_OK;
+}
+
+void FragFree(void *value) {
+    struct FragObject *o = value;
+
+    for (unsigned long i = 0; i < o->len; i++)
+        RedisModule_Free(o->values[i]);
+    RedisModule_Free(o->values);
+    RedisModule_Free(o);
+}
+
+size_t FragFreeEffort(RedisModuleString *key, const void *value) {
+    REDISMODULE_NOT_USED(key);
+
+    const struct FragObject *o = value;
+    return o->len;
+}
+
+int FragDefrag(RedisModuleDefragCtx *ctx, RedisModuleString *key, void **value) {
+    REDISMODULE_NOT_USED(key);
+    unsigned long i = 0;
+    int steps = 0;
+
+    /* Attempt to get cursor, validate it's what we're exepcting */
+    if (RedisModule_DefragCursorGet(ctx, &i) == REDISMODULE_OK) {
+        if (i > 0) datatype_resumes++;
+
+        /* Validate we're expecting this cursor */
+        if (i != last_set_cursor) datatype_wrong_cursor++;
+    } else {
+        if (last_set_cursor != 0) datatype_wrong_cursor++;
+    }
+
+    /* Attempt to defrag the object itself */
+    datatype_attempts++;
+    struct FragObject *o = RedisModule_DefragAlloc(ctx, *value);
+    if (o == NULL) {
+        /* Not defragged */
+        o = *value;
+    } else {
+        /* Defragged */
+        *value = o;
+        datatype_defragged++;
+    }
+
+    /* Deep defrag now */
+    for (; i < o->len; i++) {
+        datatype_attempts++;
+        void *new = RedisModule_DefragAlloc(ctx, o->values[i]);
+        if (new) {
+            o->values[i] = new;
+            datatype_defragged++;
+        }
+
+        if ((o->maxstep && ++steps > o->maxstep) ||
+            ((i % 64 == 0) && RedisModule_DefragShouldStop(ctx))) {
+            RedisModule_DefragCursorSet(ctx, i);
+            last_set_cursor = i;
+            return 1;
+        }
+    }
+
+    last_set_cursor = 0;
+    return 0;
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx, "defragtest", 1, REDISMODULE_APIVER_1)
+        == REDISMODULE_ERR) return REDISMODULE_ERR;
+
+    if (RedisModule_GetTypeMethodVersion() < REDISMODULE_TYPE_METHOD_VERSION) {
+        return REDISMODULE_ERR;
+    }
+
+    long long glen;
+    if (argc != 1 || RedisModule_StringToLongLong(argv[0], &glen) == REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
+    }
+
+    createGlobalStrings(ctx, glen);
+
+    RedisModuleTypeMethods tm = {
+            .version = REDISMODULE_TYPE_METHOD_VERSION,
+            .free = FragFree,
+            .free_effort = FragFreeEffort,
+            .defrag = FragDefrag
+    };
+
+    FragType = RedisModule_CreateDataType(ctx, "frag_type", 0, &tm);
+    if (FragType == NULL) return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "frag.create",
+                                  fragCreateCommand, "write deny-oom", 1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "frag.resetstats",
+                                  fragResetStatsCommand, "write deny-oom", 1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    RedisModule_RegisterInfoFunc(ctx, FragInfo);
+    RedisModule_RegisterDefragFunc(ctx, defragGlobalStrings);
+
+    return REDISMODULE_OK;
+}

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -46,11 +46,15 @@ proc warnings_from_file {filename} {
     join $result "\n"
 }
 
-# Return value for INFO property
-proc status {r property} {
-    if {[regexp "\r\n$property:(.*?)\r\n" [{*}$r info] _ value]} {
+proc getInfoProperty {infostr property} {
+    if {[regexp "\r\n$property:(.*?)\r\n" $infostr _ value]} {
         set _ $value
     }
+}
+
+# Return value for INFO property
+proc status {r property} {
+    set _ [getInfoProperty [{*}$r info] $property]
 }
 
 proc waitForBgsave r {

--- a/tests/unit/moduleapi/defrag.tcl
+++ b/tests/unit/moduleapi/defrag.tcl
@@ -1,0 +1,43 @@
+set testmodule [file normalize tests/modules/defragtest.so]
+
+start_server {tags {"modules"} overrides {{save ""}}} {
+    r module load $testmodule 10000
+    r config set hz 100
+
+    test {Module defrag: simple key defrag works} {
+        r frag.create key1 1 1000 0
+
+        r config set active-defrag-ignore-bytes 1
+        r config set active-defrag-threshold-lower 0
+        r config set active-defrag-cycle-min 99
+        r config set activedefrag yes
+
+        after 2000
+        set info [r info defragtest_stats]
+        assert {[getInfoProperty $info defragtest_datatype_attempts] > 0}
+        assert_equal 0 [getInfoProperty $info defragtest_datatype_resumes]
+    }
+
+    test {Module defrag: late defrag with cursor works} {
+        r flushdb
+        r frag.resetstats
+
+        # key can only be defragged in no less than 10 iterations
+        # due to maxstep
+        r frag.create key2 10000 100 1000
+
+        after 2000
+        set info [r info defragtest_stats]
+        assert {[getInfoProperty $info defragtest_datatype_resumes] > 10}
+        assert_equal 0 [getInfoProperty $info defragtest_datatype_wrong_cursor]
+    }
+
+    test {Module defrag: global defrag works} {
+        r flushdb
+        r frag.resetstats
+
+        after 2000
+        set info [r info defragtest_stats]
+        assert {[getInfoProperty $info defragtest_global_attempts] > 0}
+    }
+}


### PR DESCRIPTION
Add a new set of defrag functions that take a defrag context and allow
defragmenting memory blocks and RedisModuleStrings.

Modules can register a defrag callback which will be invoked when the
defrag process handles globals.

Modules with custom data types can also register a datatype-specific
defrag callback which is invoked for keys that require defragmentation.
The callback and associated functions support both one-step and
multi-step options, depending on the complexity of the key as exposed by
the free_effort callback.