### PR TITLE
[Redis-benchmark] Use IPs in the reply of CLUSTER NODES command

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1182,8 +1182,8 @@ static int fetchClusterConfiguration() {
         }
         if (myself) {
             node = firstNode;
-            if (node->ip == NULL && ip != NULL) {
-                node->ip = ip;
+            if (ip != NULL && strcmp(node->ip, ip) != 0) {
+                node->ip = sdsnew(ip);
                 node->port = port;
             }
         } else {


### PR DESCRIPTION
If we only has one node in cluster or before https://github.com/redis/redis/commit/8fdc857a9f83e59b3062d051dc0155dd53c89ea7, we don't know myself ip, so we should use config.hostip for myself.

But now, more than one node in cluster,  if we use `-h` with virtual IP or DNS, benchmark doesn't show node real ip and port of myself even though it could get right IP and port by CLUSTER NODES command.

We must use `sdsnew(ip)` to update `node->ip` if it is different from config.hostip, because we will free `ip` when leave this function. 
Here will free `node->ip` https://github.com/redis/redis/blob/unstable/src/redis-benchmark.c#L1084-L1088