### PR TITLE
add missing raxStop calls in aof stream rewrite

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1355,6 +1355,9 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
                     if (rioWriteStreamEmptyConsumer(r,key,(char*)ri.key,
                                                     ri.key_len,consumer) == 0)
                     {
+                        raxStop(&ri_cons);
+                        raxStop(&ri);
+                        streamIteratorStop(&si);
                         return 0;
                     }
                     continue;


### PR DESCRIPTION
in aof stream object rewrite, an error handling case missing raxStop call. just a small nit in the code.