### PR TITLE
XADD and XTRIM, Trim by MINID, and new LIMIT argument

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -841,7 +841,7 @@ static int streamParseAddOrTrimArgsOrReply(client *c, streamAddTrimArgs *args, i
             break;
         } else if (!strcasecmp(opt,"maxlen") && moreargs) {
             if (args->trim_strategy != TRIM_STRATEGY_NONE) {
-                addReplyError(c,"Cannot trim by both MAXLEN and MINID");
+                addReplyError(c,"syntax error, MAXLEN and MINID options at the same time are not compatible");
                 return -1;
             }
             args->approx_trim = 0;
@@ -865,7 +865,7 @@ static int streamParseAddOrTrimArgsOrReply(client *c, streamAddTrimArgs *args, i
             args->trim_strategy_arg_idx = i;
         } else if (!strcasecmp(opt,"minid") && moreargs) {
             if (args->trim_strategy != TRIM_STRATEGY_NONE) {
-                addReplyError(c,"Cannot trim by both MAXLEN and MINID");
+                addReplyError(c,"syntax error, MAXLEN and MINID options at the same time are not compatible");
                 return -1;
             }
             args->approx_trim = 0;
@@ -915,12 +915,12 @@ static int streamParseAddOrTrimArgsOrReply(client *c, streamAddTrimArgs *args, i
     }
 
     if (args->limit && args->trim_strategy == TRIM_STRATEGY_NONE) {
-        addReplyError(c,"LIMIT without trim options");
+        addReplyError(c,"syntax error, LIMIT cannot be used without specifying a trimming strategy");
         return -1;
     }
 
     if (!xadd && args->trim_strategy == TRIM_STRATEGY_NONE) {
-        addReplyError(c,"XTRIM called without an option to trim the stream");
+        addReplyErrorObject(c,"syntax error, XTRIM must be called with a trimming strategy");
         return -1;
     }
 
@@ -934,7 +934,7 @@ static int streamParseAddOrTrimArgsOrReply(client *c, streamAddTrimArgs *args, i
         if (limit_given) {
             if (!args->approx_trim) {
                 /* LIMIT was provided without ~ */
-                addReplyError(c,"LIMIT without ~ option is illegal");
+                addReplyError(c,"syntax error, LIMIT cannot be used without the special ~ option");
                 return -1;
             }
         } else {

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -920,7 +920,7 @@ static int streamParseAddOrTrimArgsOrReply(client *c, streamAddTrimArgs *args, i
     }
 
     if (!xadd && args->trim_strategy == TRIM_STRATEGY_NONE) {
-        addReplyErrorObject(c,"syntax error, XTRIM must be called with a trimming strategy");
+        addReplyError(c,"syntax error, XTRIM must be called with a trimming strategy");
         return -1;
     }
 

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -494,6 +494,37 @@ start_server {
         assert {[r xlen mystream] == 62}
         r config set stream-node-max-entries 100
     }
+
+    test {XTRIM with ~ is limited} {
+        r del mystream
+        r config set stream-node-max-entries 1
+        for {set j 0} {$j < 102} {incr j} {
+            r XADD mystream * xitem v
+        }
+        r XTRIM mystream MAXLEN ~ 1
+        assert {[r xlen mystream] == 2}
+        r config set stream-node-max-entries 100
+    }
+
+    test {XTRIM without ~ is not limited} {
+        r del mystream
+        r config set stream-node-max-entries 1
+        for {set j 0} {$j < 102} {incr j} {
+            r XADD mystream * xitem v
+        }
+        r XTRIM mystream MAXLEN 1
+        assert {[r xlen mystream] == 1}
+        r config set stream-node-max-entries 100
+    }
+
+    test {XTRIM without ~ and with LIMIT} {
+        r del mystream
+        r config set stream-node-max-entries 1
+        for {set j 0} {$j < 102} {incr j} {
+            r XADD mystream * xitem v
+        }
+        assert_error ERR* {r XTRIM mystream MAXLEN 1 LIMIT 30}
+    }
 }
 
 start_server {tags {"stream"} overrides {appendonly yes}} {

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -543,11 +543,11 @@ start_server {tags {"stream"} overrides {appendonly yes}} {
 }
 
 start_server {tags {"stream"} overrides {appendonly yes stream-node-max-entries 10}} {
-    test {XADD with ~ MAXLEN and MAXNODES can propagate correctly} {
+    test {XADD with ~ MAXLEN and LIMIT can propagate correctly} {
         for {set j 0} {$j < 100} {incr j} {
             r XADD mystream * xitem v
         }
-        r XADD mystream MAXLEN ~ 55 MAXNODES 3 * xitem v
+        r XADD mystream MAXLEN ~ 55 LIMIT 30 * xitem v
         assert {[r xlen mystream] == 71}
         r config set stream-node-max-entries 1
         r debug loadaof
@@ -557,11 +557,11 @@ start_server {tags {"stream"} overrides {appendonly yes stream-node-max-entries 
 }
 
 start_server {tags {"stream"} overrides {appendonly yes stream-node-max-entries 10}} {
-    test {XADD with MAXLEN and MAXNODES can propagate correctly} {
+    test {XADD with MAXLEN and LIMIT can propagate correctly} {
         for {set j 0} {$j < 100} {incr j} {
             r XADD mystream * xitem v
         }
-        r XADD mystream MAXLEN 55 MAXNODES 3 * xitem v
+        r XADD mystream MAXLEN 55 LIMIT 30 * xitem v
         assert {[r xlen mystream] == 71}
         r config set stream-node-max-entries 1
         r debug loadaof
@@ -588,12 +588,12 @@ start_server {tags {"stream"} overrides {appendonly yes}} {
 }
 
 start_server {tags {"stream"} overrides {appendonly yes stream-node-max-entries 10}} {
-    test {XADD with ~ MINID and MAXNODES can propagate correctly} {
+    test {XADD with ~ MINID and LIMIT can propagate correctly} {
         for {set j 0} {$j < 100} {incr j} {
             set id [expr {$j+1}]
             r XADD mystream $id xitem v
         }
-        r XADD mystream MINID ~ 55 MAXNODES 3 * xitem v
+        r XADD mystream MINID ~ 55 LIMIT 30 * xitem v
         assert {[r xlen mystream] == 71}
         r config set stream-node-max-entries 1
         r debug loadaof
@@ -603,12 +603,12 @@ start_server {tags {"stream"} overrides {appendonly yes stream-node-max-entries 
 }
 
 start_server {tags {"stream"} overrides {appendonly yes stream-node-max-entries 10}} {
-    test {XADD with MINID and MAXNODES can propagate correctly} {
+    test {XADD with MINID and LIMIT can propagate correctly} {
         for {set j 0} {$j < 100} {incr j} {
             set id [expr {$j+1}]
             r XADD mystream $id xitem v
         }
-        r XADD mystream MINID 55 MAXNODES 3 * xitem v
+        r XADD mystream MINID 55 LIMIT 30 * xitem v
         assert {[r xlen mystream] == 71}
         r config set stream-node-max-entries 1
         r debug loadaof


### PR DESCRIPTION
Fix #6640 #4450 #5951

This PR adds an additional trimming strategy to XADD and XTRIM named MINID (complements the existing MAXLEN).
It also adds a new LIMIT argument that allows incremental trimming by repeated calls (rather than all at once).

This provides the ability to trim all records older than a certain ID (which makes it possible for the user to trim by age too).
Example:
`XTRIM mystream MINID ~ 1608540753 ` will trim entries with id < 1608540753, but might not trim all (because of the `~` modifier)

The purpose is to ease the use of streams. many users use streams as logs and the common case is wanting a log of the last X seconds rather than a log that contains maximum X entries (new MINID vs existing MAXLEN)

The new LIMIT modifier is only supported when the trim strategy uses `~`. i.e. when the user asked for exact trimming, it all happens in one go (no possibility for incremental trimming).
However, when `~` is provided, we trim full rax nodes, up to the limit number of records.
The default limit is `100*stream_node_max_entries` (used when LIMIT is not provided).
I.e. this is a **behavior change** (even if the existing MAXLEN strategy is used).
An explicit limit of 0 means unlimited (but note that it's not the default).

Other changes:
1. Refactor arg parsing code for XADD and XTRIM to use common code.