### PR TITLE
Add support for client pause WRITE

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -110,13 +110,12 @@ void processUnblockedClients(void) {
          * client is not blocked before to proceed, but things may change and
          * the code is conceptually more correct this way. */
         if (!(c->flags & CLIENT_BLOCKED)) {
-            serverLog(LL_WARNING, "??");
-            /* If we have a queued command, execute it now */
+            /* If we have a queued command, execute it now. */
             if (c->flags & CLIENT_PENDING_COMMAND) {
-                serverLog(LL_WARNING, "GOGO");
+                c->flags &= ~CLIENT_PENDING_COMMAND;
                 if (processCommandAndResetClient(c) == C_ERR) continue;
-            }
-            /* Otherwise, try to process more input from the buffer */
+            } 
+            /* Then process client if it has more data in it's buffer. */
             if (c->querybuf && sdslen(c->querybuf) > 0) {
                 processInputBuffer(c);
             }

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -91,6 +91,7 @@ void blockClient(client *c, int btype) {
     addClientToTimeoutTable(c);
     if (btype == BLOCKED_PAUSE) {
         listAddNodeTail(server.paused_clients, c);
+        c->paused_list_node = listLast(server.paused_clients);
     }
 }
 
@@ -166,6 +167,7 @@ void unblockClient(client *c) {
     } else if (c->btype == BLOCKED_PAUSE) {
         /* Mark this client to execute its command */
         c->flags |= CLIENT_PENDING_COMMAND;
+        listDelNode(server.paused_clients,c->paused_list_node);
     } else {
         serverPanic("Unknown btype in unblockClient().");
     }

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -168,6 +168,7 @@ void unblockClient(client *c) {
         /* Mark this client to execute its command */
         c->flags |= CLIENT_PENDING_COMMAND;
         listDelNode(server.paused_clients,c->paused_list_node);
+        c->paused_list_node = NULL;
     } else {
         serverPanic("Unknown btype in unblockClient().");
     }

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -89,6 +89,9 @@ void blockClient(client *c, int btype) {
     server.blocked_clients++;
     server.blocked_clients_by_type[btype]++;
     addClientToTimeoutTable(c);
+    if (btype == BLOCKED_PAUSE) {
+        listAddNodeTail(server.paused_clients, c);
+    }
 }
 
 /* This function is called in the beforeSleep() function of the event loop

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2164,7 +2164,7 @@ int clusterProcessPacket(clusterLink *link) {
         resetManualFailover();
         server.cluster->mf_end = now + CLUSTER_MF_TIMEOUT;
         server.cluster->mf_slave = sender;
-        pauseClients(now+(CLUSTER_MF_TIMEOUT*CLUSTER_MF_PAUSE_MULT));
+        pauseClients(now+(CLUSTER_MF_TIMEOUT*CLUSTER_MF_PAUSE_MULT), CLIENT_PAUSE_RO);
         serverLog(LL_WARNING,"Manual failover requested by replica %.40s.",
             sender->name);
         /* We need to send a ping message to the replica, as it would carry
@@ -3422,8 +3422,7 @@ void clusterHandleSlaveMigration(int max_slaves) {
  * startup or to abort a manual failover in progress. */
 void resetManualFailover(void) {
     if (server.cluster->mf_end && clientsArePaused()) {
-        server.clients_pause_end_time = 0;
-        clientsArePaused(); /* Just use the side effect of the function. */
+        unpauseClients(1);
     }
     server.cluster->mf_end = 0; /* No manual failover in progress. */
     server.cluster->mf_can_start = 0;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3421,8 +3421,8 @@ void clusterHandleSlaveMigration(int max_slaves) {
  * The function can be used both to initialize the manual failover state at
  * startup or to abort a manual failover in progress. */
 void resetManualFailover(void) {
-    if (server.cluster->mf_end && clientsArePaused()) {
-        unpauseClients(1);
+    if (server.cluster->mf_end) {
+        checkClientPauseTimeoutAndReturnIfPaused();
     }
     server.cluster->mf_end = 0; /* No manual failover in progress. */
     server.cluster->mf_can_start = 0;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2164,7 +2164,7 @@ int clusterProcessPacket(clusterLink *link) {
         resetManualFailover();
         server.cluster->mf_end = now + CLUSTER_MF_TIMEOUT;
         server.cluster->mf_slave = sender;
-        pauseClients(now+(CLUSTER_MF_TIMEOUT*CLUSTER_MF_PAUSE_MULT), CLIENT_PAUSE_RO);
+        pauseClients(now+(CLUSTER_MF_TIMEOUT*CLUSTER_MF_PAUSE_MULT),CLIENT_PAUSE_WRITE);
         serverLog(LL_WARNING,"Manual failover requested by replica %.40s.",
             sender->name);
         /* We need to send a ping message to the replica, as it would carry

--- a/src/db.c
+++ b/src/db.c
@@ -1520,6 +1520,12 @@ int expireIfNeeded(redisDb *db, robj *key) {
      * we think the key is expired at this time. */
     if (server.masterhost != NULL) return 1;
 
+    /* If clients are paused, we keep the current dataset constant,
+     * but return to the client what we believe is the wrong state. Typically,
+     * at the end of the pause we will properly expire the key OR we will
+     * have failed over and the new primary will sent us the expirey. */
+    if (clientsArePaused()) return 1;
+
     /* Delete the key */
     server.stat_expiredkeys++;
     propagateExpire(db,key,server.lazyfree_lazy_expire);
@@ -1529,6 +1535,10 @@ int expireIfNeeded(redisDb *db, robj *key) {
                                                dbSyncDelete(db,key);
     if (retval) signalModifiedKey(NULL,db,key);
     return retval;
+}
+
+int expireKey(robj *key) {
+    
 }
 
 /* -----------------------------------------------------------------------------

--- a/src/db.c
+++ b/src/db.c
@@ -1521,9 +1521,9 @@ int expireIfNeeded(redisDb *db, robj *key) {
     if (server.masterhost != NULL) return 1;
 
     /* If clients are paused, we keep the current dataset constant,
-     * but return to the client what we believe is the wrong state. Typically,
+     * but return to the client what we believe is the right state. Typically,
      * at the end of the pause we will properly expire the key OR we will
-     * have failed over and the new primary will sent us the expirey. */
+     * have failed over and the new primary will send us the expire. */
     if (checkClientPauseTimeoutAndReturnIfPaused()) return 1;
 
     /* Delete the key */

--- a/src/db.c
+++ b/src/db.c
@@ -1537,10 +1537,6 @@ int expireIfNeeded(redisDb *db, robj *key) {
     return retval;
 }
 
-int expireKey(robj *key) {
-    
-}
-
 /* -----------------------------------------------------------------------------
  * API to get key arguments from commands
  * ---------------------------------------------------------------------------*/

--- a/src/db.c
+++ b/src/db.c
@@ -1524,7 +1524,7 @@ int expireIfNeeded(redisDb *db, robj *key) {
      * but return to the client what we believe is the wrong state. Typically,
      * at the end of the pause we will properly expire the key OR we will
      * have failed over and the new primary will sent us the expirey. */
-    if (clientsArePaused()) return 1;
+    if (checkClientPauseTimeoutAndReturnIfPaused()) return 1;
 
     /* Delete the key */
     server.stat_expiredkeys++;

--- a/src/evict.c
+++ b/src/evict.c
@@ -462,7 +462,7 @@ static int isSafeToPerformEvictions(void) {
     /* When clients are paused the dataset should be static not just from the
      * POV of clients not being able to write, but also from the POV of
      * expires and evictions of keys not being performed. */
-    if (clientsArePaused()) return 0;
+    if (checkClientPauseTimeoutAndReturnIfPaused()) return 0;
 
     return 1;
 }

--- a/src/expire.c
+++ b/src/expire.c
@@ -148,7 +148,7 @@ void activeExpireCycle(int type) {
     /* When clients are paused the dataset should be static not just from the
      * POV of clients not being able to write, but also from the POV of
      * expires and evictions of keys not being performed. */
-    if (clientsArePaused()) return;
+    if (checkClientPauseTimeoutAndReturnIfPaused()) return;
 
     if (type == ACTIVE_EXPIRE_CYCLE_FAST) {
         /* Don't start a fast cycle if the previous cycle did not exit

--- a/src/module.c
+++ b/src/module.c
@@ -2045,7 +2045,7 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
  * periodically in timer callbacks or other periodic callbacks.
  */
 int RM_AvoidReplicaTraffic() {
-    return !checkClientPauseTimeoutAndReturnIfPaused();
+    return checkClientPauseTimeoutAndReturnIfPaused();
 }
 
 /* Change the currently selected DB. Returns an error if the id

--- a/src/module.c
+++ b/src/module.c
@@ -747,7 +747,7 @@ int64_t commandFlagsFromString(char *s) {
         else if (!strcasecmp(t,"no-slowlog")) flags |= CMD_SKIP_SLOWLOG;
         else if (!strcasecmp(t,"fast")) flags |= CMD_FAST;
         else if (!strcasecmp(t,"no-auth")) flags |= CMD_NO_AUTH;
-        else if (!strcasecmp(t,"can-replicate")) flags |= CMD_CAN_REPLICATE;
+        else if (!strcasecmp(t,"may-replicate")) flags |= CMD_MAY_REPLICATE;
         else if (!strcasecmp(t,"getkeys-api")) flags |= CMD_MODULE_GETKEYS;
         else if (!strcasecmp(t,"no-cluster")) flags |= CMD_MODULE_NO_CLUSTER;
         else break;
@@ -814,7 +814,7 @@ int64_t commandFlagsFromString(char *s) {
  * * **"no-auth"**:    This command can be run by an un-authenticated client.
  *                     Normally this is used by a command that is used
  *                     to authenticate a client. 
- * * **"can-replicate"**: This command may generate replication traffic, even
+ * * **"may-replicate"**: This command may generate replication traffic, even
  *                        though it's not a write command.  
  */
 int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) {
@@ -2045,7 +2045,7 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
  * periodically in timer callbacks or other periodic callbacks.
  */
 int RM_AvoidReplicaTraffic() {
-    return !(clientsArePaused() == CLIENT_PAUSE_OFF);
+    return !checkClientPauseTimeoutAndReturnIfPaused();
 }
 
 /* Change the currently selected DB. Returns an error if the id

--- a/src/module.c
+++ b/src/module.c
@@ -747,6 +747,7 @@ int64_t commandFlagsFromString(char *s) {
         else if (!strcasecmp(t,"no-slowlog")) flags |= CMD_SKIP_SLOWLOG;
         else if (!strcasecmp(t,"fast")) flags |= CMD_FAST;
         else if (!strcasecmp(t,"no-auth")) flags |= CMD_NO_AUTH;
+        else if (!strcasecmp(t,"can-replicate")) flags |= CMD_CAN_REPLICATE;
         else if (!strcasecmp(t,"getkeys-api")) flags |= CMD_MODULE_GETKEYS;
         else if (!strcasecmp(t,"no-cluster")) flags |= CMD_MODULE_NO_CLUSTER;
         else break;
@@ -813,6 +814,8 @@ int64_t commandFlagsFromString(char *s) {
  * * **"no-auth"**:    This command can be run by an un-authenticated client.
  *                     Normally this is used by a command that is used
  *                     to authenticate a client. 
+ * * **"can-replicate"**: This command may generate replication traffic, even
+ *                        though it's not a write command.  
  */
 int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) {
     int64_t flags = strflags ? commandFlagsFromString((char*)strflags) : 0;
@@ -2042,7 +2045,7 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
  * periodically in timer callbacks or other periodic callbacks.
  */
 int RM_AvoidReplicaTraffic() {
-    return clientsArePaused();
+    return !(clientsArePaused() == CLIENT_PAUSE_OFF);
 }
 
 /* Change the currently selected DB. Returns an error if the id

--- a/src/networking.c
+++ b/src/networking.c
@@ -1960,7 +1960,7 @@ void commandProcessed(client *c) {
      * still be able to access the client argv and argc field.
      * The client will be reset in unblockClientFromModule(). */
     if (!(c->flags & CLIENT_BLOCKED) ||
-        c->btype != BLOCKED_MODULE || c->btype != BLOCKED_PAUSE)
+        (c->btype != BLOCKED_MODULE && c->btype != BLOCKED_PAUSE))
     {
         resetClient(c);
     }

--- a/src/networking.c
+++ b/src/networking.c
@@ -3295,7 +3295,9 @@ void unpauseClients(int force) {
 /* Return non-zero if clients are currently paused. As a side effect the
  * function checks if the pause time was reached and clear it. */
 int clientsArePaused(void) {
-    unpauseClients(0);
+    if (server.client_pause_flags != CLIENT_PAUSE_OFF) {
+        unpauseClients(0);
+    }
     return server.client_pause_flags;
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -178,6 +178,7 @@ client *createClient(connection *conn) {
     c->peerid = NULL;
     c->sockname = NULL;
     c->client_list_node = NULL;
+    c->paused_list_node = NULL;
     c->client_tracking_redirection = 0;
     c->client_tracking_prefixes = NULL;
     c->client_cron_last_memory_usage = 0;

--- a/src/networking.c
+++ b/src/networking.c
@@ -3245,6 +3245,8 @@ void pauseClients(mstime_t end, int type) {
         current_end = &server.client_pause_ro_end_time;
     } else if (type == CLIENT_PAUSE_ALL) {
         current_end = &server.client_pause_end_time;
+    } else {
+        serverPanic("Pause called with invalid type.");
     }
 
     if (!(server.client_pause_flags & type) || end > *current_end) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -3270,30 +3270,23 @@ void unpauseClients(int force) {
         && server.client_pause_end_time < server.mstime))
     {
         server.client_pause_flags &= ~CLIENT_PAUSE_ALL;
-        serverLog(LL_WARNING, "unpausing all");
     }
 
     if (force || (server.client_pause_flags & CLIENT_PAUSE_RO
         && server.client_pause_ro_end_time < server.mstime))
     {
         server.client_pause_flags &= ~CLIENT_PAUSE_RO;
-        serverLog(LL_WARNING, "unpausing ro %lld %lld",server.client_pause_ro_end_time, server.mstime);
     }
 
     /* Nothing was unblocked */
     if (initial_flags == server.client_pause_flags) return;
-    serverLog(LL_WARNING, "UNPAUSING");
 
     /* Put all the clients in the unblocked clients queue in order to
      * force the re-processing of the input buffer if any. */
-    listRewind(server.clients,&li);
+    listRewind(server.paused_clients,&li);
     while ((ln = listNext(&li)) != NULL) {
         c = listNodeValue(ln);
-
-        /* Replicas are never blocked */
-        if (c->flags & CLIENT_BLOCKED && c->btype == BLOCKED_PAUSE) {
-            unblockClient(c);
-        }
+        unblockClient(c);
     }
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -2680,11 +2680,11 @@ NULL
         if (c->argc == 4) {
             if (!strcasecmp(c->argv[3]->ptr,"write")) {
                 type = CLIENT_PAUSE_WRITE;
-            if (!strcasecmp(c->argv[3]->ptr,"all")) {
+            } else if (!strcasecmp(c->argv[3]->ptr,"all")) {
                 type = CLIENT_PAUSE_ALL;
             } else {
                 addReplyError(c,
-                    "CLIENT PAUSE option must be WRITE or ALL");  
+                    "CLIENT PAUSE mode must be WRITE or ALL");  
                 return;       
             }
         }

--- a/src/replication.c
+++ b/src/replication.c
@@ -3237,7 +3237,7 @@ void replicationCron(void) {
         int manual_failover_in_progress =
             server.cluster_enabled &&
             server.cluster->mf_end &&
-            clientsArePaused();
+            checkClientPauseTimeoutAndReturnIfPaused();
 
         if (!manual_failover_in_progress) {
             ping_argv[0] = createStringObject("PING",4);

--- a/src/server.c
+++ b/src/server.c
@@ -164,9 +164,11 @@ struct redisServer server; /* Server global state */
  *              us time. Note that commands that may trigger a DEL as a side
  *              effect (like SET) are not fast commands.
  * 
- * can-replicate: Command may produce replication traffic but has it's own
+ * may-replicate: Command may produce replication traffic but has it's own
  *                explicit checks to make sure it's not called on a replcia.
- *                This is only used for client pause to allow non-write commands.
+ *                Examples include PUBLISH, which replicates pubsub messages,
+ *                and EVAL, which may execute write commands which are replicated 
+ *                or may just execute read commands.
  *
  * The following additional flags are only used in order to put commands
  * in a specific ACL category. Commands can have multiple ACL categories.
@@ -822,7 +824,7 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,0,0,0,0,0,0},
 
     {"publish",publishCommand,3,
-     "pub-sub ok-loading ok-stale fast can-replicate",
+     "pub-sub ok-loading ok-stale fast may-replicate",
      0,NULL,0,0,0,0,0,0},
 
     {"pubsub",pubsubCommand,-2,
@@ -888,11 +890,11 @@ struct redisCommand redisCommandTable[] = {
     /* EVAL can modify the dataset, however it is not flagged as a write
      * command since we do the check while running commands from Lua. */
     {"eval",evalCommand,-3,
-     "no-script can-replicate @scripting",
+     "no-script may-replicate @scripting",
      0,evalGetKeys,0,0,0,0,0,0},
 
     {"evalsha",evalShaCommand,-3,
-     "no-script can-replicate @scripting",
+     "no-script may-replicate @scripting",
      0,evalGetKeys,0,0,0,0,0,0},
 
     {"slowlog",slowlogCommand,-2,
@@ -900,7 +902,7 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,0,0,0,0,0,0},
 
     {"script",scriptCommand,-2,
-     "no-script can-replicate @scripting",
+     "no-script may-replicate @scripting",
      0,NULL,0,0,0,0,0,0},
 
     {"time",timeCommand,1,
@@ -981,7 +983,7 @@ struct redisCommand redisCommandTable[] = {
      * we claim that the representation, even if accessible, is an internal
      * affair, and the command is semantically read only. */
     {"pfcount",pfcountCommand,-2,
-     "read-only can-replicate @hyperloglog",
+     "read-only may-replicate @hyperloglog",
      0,NULL,1,-1,1,0,0,0},
 
     {"pfmerge",pfmergeCommand,-2,
@@ -2167,8 +2169,8 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
             flushAppendOnlyFile(0);
     }
 
-    /* Clear the paused clients flag if needed. */
-    unpauseClients(0);
+    /* Clear the paused clients state if needed. */
+    checkClientPauseTimeoutAndReturnIfPaused();
 
     /* Replication cron function -- used to reconnect to master,
      * detect transfer failures, start background RDB transfers and so forth. */
@@ -2370,7 +2372,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
      * We also don't send the ACKs while clients are paused, since it can
      * increment the replication backlog, they'll be sent after the pause
      * if we are still the master. */
-    if (server.get_ack_from_slaves && !clientsArePaused()) {
+    if (server.get_ack_from_slaves && !checkClientPauseTimeoutAndReturnIfPaused()) {
         robj *argv[3];
 
         argv[0] = createStringObject("REPLCONF",8);
@@ -3048,7 +3050,7 @@ void initServer(void) {
     server.ready_keys = listCreate();
     server.clients_waiting_acks = listCreate();
     server.get_ack_from_slaves = 0;
-    server.client_pause_flags = 0;
+    server.client_pause_type = 0;
     server.paused_clients = listCreate();
     server.events_processed_while_blocked = 0;
     server.system_memory_size = zmalloc_get_memory_size();
@@ -3123,6 +3125,7 @@ void initServer(void) {
     server.in_eval = 0;
     server.in_exec = 0;
     server.propagate_in_transaction = 0;
+    server.client_pause_in_transaction = 0;
     server.child_pid = -1;
     server.child_type = CHILD_TYPE_NONE;
     server.rdb_child_type = RDB_CHILD_TYPE_NONE;
@@ -3289,8 +3292,8 @@ int populateCommandTableParseFlags(struct redisCommand *c, char *strflags) {
             c->flags |= CMD_FAST | CMD_CATEGORY_FAST;
         } else if (!strcasecmp(flag,"no-auth")) {
             c->flags |= CMD_NO_AUTH;
-        } else if (!strcasecmp(flag,"can-replicate")) {
-            c->flags |= CMD_CAN_REPLICATE;
+        } else if (!strcasecmp(flag,"may-replicate")) {
+            c->flags |= CMD_MAY_REPLICATE;
         } else {
             /* Parse ACL categories here if the flag name starts with @. */
             uint64_t catflag;
@@ -3442,16 +3445,6 @@ struct redisCommand *lookupCommandOrOriginal(sds name) {
 void propagate(struct redisCommand *cmd, int dbid, robj **argv, int argc,
                int flags)
 {
-    /* This should be unreachable while clients are paused, but modules or
-     * a multi-exec with client pause + write can reach here, so log a warning
-     * instead of a serverAssert() to record the misuse. */
-    if (!clientsArePaused()) {
-        serverLog(LL_WARNING, "Command '%s' propagated to replicas " 
-            "during client pause, when the dataset should be constant. "
-            "Propagating data during client pause can result in data "
-            "loss when performing failovers.", cmd->name);
-    }
-
     /* Propagate a MULTI request once we encounter the first command which
      * is a write command.
      * This way we'll deliver the MULTI/..../EXEC block as a whole and
@@ -3459,6 +3452,10 @@ void propagate(struct redisCommand *cmd, int dbid, robj **argv, int argc,
      * and atomicity guarantees. */
     if (server.in_exec && !server.propagate_in_transaction)
         execCommandPropagateMulti(dbid);
+    /* This needs to be unreachable since data should be fixed during client
+     * pause, otherwise data may be lossed if a failover is happening. */
+    serverLog(LL_WARNING, "%s %d %d", cmd->name, areClientsPaused(), server.client_pause_in_transaction);
+    serverAssert(!(areClientsPaused() && !server.client_pause_in_transaction));
 
     if (server.aof_state != AOF_OFF && flags & PROPAGATE_AOF)
         feedAppendOnlyFile(cmd,dbid,argv,argc);
@@ -3498,7 +3495,7 @@ void alsoPropagate(struct redisCommand *cmd, int dbid, robj **argv, int argc,
  * Redis command implementation in order to to force the propagation of a
  * specific command execution into AOF / Replication. */
 void forceCommandPropagation(client *c, int flags) {
-    serverAssert(c->cmd->flags & (CMD_WRITE | CMD_CAN_REPLICATE));
+    serverAssert(c->cmd->flags & (CMD_WRITE | CMD_MAY_REPLICATE));
     if (flags & PROPAGATE_REPL) c->flags |= CLIENT_FORCE_REPL;
     if (flags & PROPAGATE_AOF) c->flags |= CLIENT_FORCE_AOF;
 }
@@ -3723,6 +3720,12 @@ void call(client *c, int flags) {
     }
     server.also_propagate = prev_also_propagate;
 
+    /* Client pause takes effect after a transaction has finished. This needs
+     * to be located after everything is propagated. */
+    if (!server.in_exec && server.client_pause_in_transaction) {
+        server.client_pause_in_transaction = 0;
+    }
+
     /* If the client has keys tracking enabled for client side caching,
      * make sure to remember the keys it fetched via this command. */
     if (c->cmd->flags & CMD_READONLY) {
@@ -3836,8 +3839,8 @@ int processCommand(client *c) {
                                (c->cmd->proc == execCommand && (c->mstate.cmd_inv_flags & CMD_STALE));
     int is_denyloading_command = !(c->cmd->flags & CMD_LOADING) ||
                                  (c->cmd->proc == execCommand && (c->mstate.cmd_inv_flags & CMD_LOADING));
-    int is_can_replicate_command = (c->cmd->flags & (CMD_WRITE | CMD_CAN_REPLICATE)) ||
-                                   (c->cmd->proc == execCommand && (c->mstate.cmd_flags & (CMD_WRITE | CMD_CAN_REPLICATE)));
+    int is_may_replicate_command = (c->cmd->flags & (CMD_WRITE | CMD_MAY_REPLICATE)) ||
+                                   (c->cmd->proc == execCommand && (c->mstate.cmd_flags & (CMD_WRITE | CMD_MAY_REPLICATE)));
 
     /* Check if the user is authenticated. This check is skipped in case
      * the default user is flagged as "nopass" and is active. */
@@ -4039,8 +4042,8 @@ int processCommand(client *c) {
     /* If the server is paused, block the client until
      * the pause has ended. Replicas are never paused. */
     if (!(c->flags & CLIENT_SLAVE) && 
-        ((server.client_pause_flags & CLIENT_PAUSE_ALL) ||
-        (server.client_pause_flags & CLIENT_PAUSE_WRITE && is_can_replicate_command)))
+        ((server.client_pause_type & CLIENT_PAUSE_ALL) ||
+        (server.client_pause_type & CLIENT_PAUSE_WRITE && is_may_replicate_command)))
     {
         c->bpop.timeout = 0;
         blockClient(c,BLOCKED_PAUSE);
@@ -4301,7 +4304,7 @@ void addReplyCommand(client *c, struct redisCommand *cmd) {
         flagcount += addReplyCommandFlag(c,cmd,CMD_ASKING, "asking");
         flagcount += addReplyCommandFlag(c,cmd,CMD_FAST, "fast");
         flagcount += addReplyCommandFlag(c,cmd,CMD_NO_AUTH, "no_auth");
-        flagcount += addReplyCommandFlag(c,cmd,CMD_CAN_REPLICATE, "fast");
+        flagcount += addReplyCommandFlag(c,cmd,CMD_MAY_REPLICATE, "may_replicate");
         if (cmdHasMovableKeys(cmd)) {
             addReplyStatus(c, "movablekeys");
             flagcount += 1;

--- a/src/server.c
+++ b/src/server.c
@@ -3445,7 +3445,7 @@ void propagate(struct redisCommand *cmd, int dbid, robj **argv, int argc,
     /* Clients must be paused when propagating, but you can cause diverge
      * with a multi-exec. */
     if (!clientsArePaused()) {
-        serverLog(LL_WARNING, "Commands '%s' propagated to replicas " 
+        serverLog(LL_WARNING, "Command '%s' propagated to replicas " 
             "during client pause, when the dataset should be constant. "
             "Propagating data during client pause can result in data "
             "loss when performing failovers.", cmd->name);
@@ -3497,6 +3497,7 @@ void alsoPropagate(struct redisCommand *cmd, int dbid, robj **argv, int argc,
  * Redis command implementation in order to to force the propagation of a
  * specific command execution into AOF / Replication. */
 void forceCommandPropagation(client *c, int flags) {
+    serverAssert(c->cmd->flags & (CMD_WRITE | CMD_CAN_REPLICATE));
     if (flags & PROPAGATE_REPL) c->flags |= CLIENT_FORCE_REPL;
     if (flags & PROPAGATE_AOF) c->flags |= CLIENT_FORCE_AOF;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -4017,7 +4017,7 @@ int processCommand(client *c) {
      * the pause has ended. Replicas are never paused. */
     if (!(c->flags & CLIENT_SLAVE) && 
         ((server.client_pause_flags & CLIENT_PAUSE_ALL) ||
-        (server.client_pause_flags & CLIENT_PAUSE_RO && !is_write_command)))
+        (server.client_pause_flags & CLIENT_PAUSE_RO && is_write_command)))
     {
         c->bpop.timeout = 0;
         blockClient(c,BLOCKED_PAUSE);

--- a/src/server.h
+++ b/src/server.h
@@ -281,7 +281,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define BLOCKED_MODULE 3  /* Blocked by a loadable module. */
 #define BLOCKED_STREAM 4  /* XREAD. */
 #define BLOCKED_ZSET 5    /* BZPOP et al. */
-#define BLOCKED_PAUSE 6
+#define BLOCKED_PAUSE 6   /* Blocked by CLIENT PAUSE */
 #define BLOCKED_NUM 7     /* Number of blocked states. */
 
 /* Client request types */

--- a/src/server.h
+++ b/src/server.h
@@ -440,7 +440,7 @@ typedef enum {
 
 /* Client pause types */
 #define CLIENT_PAUSE_OFF 0
-#define CLIENT_PAUSE_RO (1<<0)
+#define CLIENT_PAUSE_WRITE (1<<0)
 #define CLIENT_PAUSE_ALL (1<<1)
 
 /* RDB active child save type. */
@@ -1182,7 +1182,7 @@ struct redisServer {
     int client_pause_flags;     /* True if clients are currently paused */
     list *paused_clients;       /* List of pause clients */
     mstime_t client_pause_end_time;    /* Time when we undo clients_paused */
-    mstime_t client_pause_ro_end_time; /* Time when we undo RO clients_paused */
+    mstime_t client_pause_write_end_time; /* Time when we undo RO clients_paused */
     char neterr[ANET_ERR_LEN];   /* Error buffer for anet.c */
     dict *migrate_cached_sockets;/* MIGRATE cached sockets */
     redisAtomic uint64_t next_client_id; /* Next client unique ID. Incremental. */

--- a/src/server.h
+++ b/src/server.h
@@ -436,11 +436,13 @@ typedef enum {
 #define PROPAGATE_AOF 1
 #define PROPAGATE_REPL 2
 
-/* Client pause types, larger types must also include
- * smaller types. */
-enum {
-    CLIENT_PAUSE_OFF = 0, CLIENT_PAUSE_WRITE, CLIENT_PAUSE_ALL
-};
+/* Client pause types, larger types are more restrictive
+ * pause types than smaller pause types. */
+typedef enum {
+    CLIENT_PAUSE_OFF = 0, /* Pause no commands */
+    CLIENT_PAUSE_WRITE,   /* Pause write commands */
+    CLIENT_PAUSE_ALL      /* Pause all commands */
+} pause_type;
 
 /* RDB active child save type. */
 #define RDB_CHILD_TYPE_NONE 0
@@ -1179,7 +1181,7 @@ struct redisServer {
     rax *clients_timeout_table; /* Radix tree for blocked clients timeouts. */
     long fixed_time_expire;     /* If > 0, expire keys against server.mstime. */
     rax *clients_index;         /* Active clients dictionary by client ID. */
-    int client_pause_type;      /* True if clients are currently paused */
+    pause_type client_pause_type;      /* True if clients are currently paused */
     list *paused_clients;       /* List of pause clients */
     mstime_t client_pause_end_time;    /* Time when we undo clients_paused */
     char neterr[ANET_ERR_LEN];   /* Error buffer for anet.c */
@@ -1803,7 +1805,7 @@ char *getClientTypeName(int class);
 void flushSlavesOutputBuffers(void);
 void disconnectSlaves(void);
 int listenToPort(int port, int *fds, int *count);
-void pauseClients(mstime_t duration, int type);
+void pauseClients(mstime_t duration, pause_type type);
 void unpauseClients(void);
 int areClientsPaused(void);
 int checkClientPauseTimeoutAndReturnIfPaused(void);

--- a/src/server.h
+++ b/src/server.h
@@ -1178,6 +1178,7 @@ struct redisServer {
     long fixed_time_expire;     /* If > 0, expire keys against server.mstime. */
     rax *clients_index;         /* Active clients dictionary by client ID. */
     int client_pause_flags;     /* True if clients are currently paused */
+    list *paused_clients;       /* List of pause clients */
     mstime_t client_pause_end_time;    /* Time when we undo clients_paused */
     mstime_t client_pause_ro_end_time; /* Time when we undo RO clients_paused */
     char neterr[ANET_ERR_LEN];   /* Error buffer for anet.c */

--- a/src/server.h
+++ b/src/server.h
@@ -181,33 +181,34 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CMD_ASKING (1ULL<<13)          /* "cluster-asking" flag */
 #define CMD_FAST (1ULL<<14)            /* "fast" flag */
 #define CMD_NO_AUTH (1ULL<<15)         /* "no-auth" flag */
+#define CMD_CAN_REPLICATE (1ULL<<16)   /* "can-replicate" flag */
 
 /* Command flags used by the module system. */
-#define CMD_MODULE_GETKEYS (1ULL<<16)  /* Use the modules getkeys interface. */
-#define CMD_MODULE_NO_CLUSTER (1ULL<<17) /* Deny on Redis Cluster. */
+#define CMD_MODULE_GETKEYS (1ULL<<17)  /* Use the modules getkeys interface. */
+#define CMD_MODULE_NO_CLUSTER (1ULL<<18) /* Deny on Redis Cluster. */
 
 /* Command flags that describe ACLs categories. */
-#define CMD_CATEGORY_KEYSPACE (1ULL<<18)
-#define CMD_CATEGORY_READ (1ULL<<19)
-#define CMD_CATEGORY_WRITE (1ULL<<20)
-#define CMD_CATEGORY_SET (1ULL<<21)
-#define CMD_CATEGORY_SORTEDSET (1ULL<<22)
-#define CMD_CATEGORY_LIST (1ULL<<23)
-#define CMD_CATEGORY_HASH (1ULL<<24)
-#define CMD_CATEGORY_STRING (1ULL<<25)
-#define CMD_CATEGORY_BITMAP (1ULL<<26)
-#define CMD_CATEGORY_HYPERLOGLOG (1ULL<<27)
-#define CMD_CATEGORY_GEO (1ULL<<28)
-#define CMD_CATEGORY_STREAM (1ULL<<29)
-#define CMD_CATEGORY_PUBSUB (1ULL<<30)
-#define CMD_CATEGORY_ADMIN (1ULL<<31)
-#define CMD_CATEGORY_FAST (1ULL<<32)
-#define CMD_CATEGORY_SLOW (1ULL<<33)
-#define CMD_CATEGORY_BLOCKING (1ULL<<34)
-#define CMD_CATEGORY_DANGEROUS (1ULL<<35)
-#define CMD_CATEGORY_CONNECTION (1ULL<<36)
-#define CMD_CATEGORY_TRANSACTION (1ULL<<37)
-#define CMD_CATEGORY_SCRIPTING (1ULL<<38)
+#define CMD_CATEGORY_KEYSPACE (1ULL<<19)
+#define CMD_CATEGORY_READ (1ULL<<20)
+#define CMD_CATEGORY_WRITE (1ULL<<21)
+#define CMD_CATEGORY_SET (1ULL<<22)
+#define CMD_CATEGORY_SORTEDSET (1ULL<<23)
+#define CMD_CATEGORY_LIST (1ULL<<24)
+#define CMD_CATEGORY_HASH (1ULL<<25)
+#define CMD_CATEGORY_STRING (1ULL<<26)
+#define CMD_CATEGORY_BITMAP (1ULL<<27)
+#define CMD_CATEGORY_HYPERLOGLOG (1ULL<<28)
+#define CMD_CATEGORY_GEO (1ULL<<29)
+#define CMD_CATEGORY_STREAM (1ULL<<30)
+#define CMD_CATEGORY_PUBSUB (1ULL<<31)
+#define CMD_CATEGORY_ADMIN (1ULL<<32)
+#define CMD_CATEGORY_FAST (1ULL<<33)
+#define CMD_CATEGORY_SLOW (1ULL<<34)
+#define CMD_CATEGORY_BLOCKING (1ULL<<35)
+#define CMD_CATEGORY_DANGEROUS (1ULL<<36)
+#define CMD_CATEGORY_CONNECTION (1ULL<<37)
+#define CMD_CATEGORY_TRANSACTION (1ULL<<38)
+#define CMD_CATEGORY_SCRIPTING (1ULL<<39)
 
 /* AOF states */
 #define AOF_OFF 0             /* AOF is off */
@@ -899,6 +900,7 @@ typedef struct client {
     sds peerid;             /* Cached peer ID. */
     sds sockname;           /* Cached connection target address. */
     listNode *client_list_node; /* list node in client list */
+    listNode *paused_list_node; /* list node within the pause list */
     RedisModuleUserChangedFunc auth_callback; /* Module callback to execute
                                                * when the authenticated user
                                                * changes. */

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -1,0 +1,18 @@
+start_server {tags {"pause"}} {
+    proc verify_command_blocked {rd id} {   
+        r unblock client $id
+        assert_match "-UNBLOCKED client unblocked via CLIENT UNBLOCK" [$rd read]
+    }
+
+    test "Test various write commands are blocked by client pause" {
+        r client PAUSE 100000000 READONLY
+        set rd [redis_deferring_client]
+        $rd client id
+        set id [$rd read]
+        [$rd id]
+
+        # Test basic write commands
+        $rd SET FOO BAR
+        verify_command_blocked $rd $id
+    }
+}

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -7,6 +7,7 @@ start_server {tags {"pause"}} {
         $rd INFO
         assert_equal [s 0 blocked_clients] 0
         r client unpause
+        $rd close
     }
 
     test "Test write commands are paused by RO" {
@@ -22,6 +23,7 @@ start_server {tags {"pause"}} {
 
         r client unpause
         assert_match "OK" [$rd read]
+        $rd close
     }
 
     test "Test special commands are paused by RO" {
@@ -60,6 +62,9 @@ start_server {tags {"pause"}} {
         assert_match "1" [$rd read]
         assert_match "0" [$rd2 read]
         assert_match "*" [$rd3 read]
+        $rd close
+        $rd2 close
+        $rd3 close
     }
 
     test "Test read/admin mutli-execs are not blocked by pause RO" {
@@ -76,6 +81,7 @@ start_server {tags {"pause"}} {
         assert_equal [s 0 blocked_clients] 0
         r client unpause 
         assert_match "PONG BAR" [$rd read]
+        $rd close
     }
 
     test "Test write mutli-execs are blocked by pause RO" {
@@ -93,6 +99,7 @@ start_server {tags {"pause"}} {
         }
         r client unpause 
         assert_match "OK" [$rd read]
+        $rd close
     }
 
     test "Test scripts are blocked by pause RO" {
@@ -107,6 +114,7 @@ start_server {tags {"pause"}} {
         }
         r client unpause 
         assert_match "1" [$rd read]
+        $rd close
     }
 
     test "Test multiple clients can be queued up and unblocked" {
@@ -124,6 +132,7 @@ start_server {tags {"pause"}} {
         r client unpause
         foreach client $clients {
             assert_match "OK" [$client read]
+            $client close
         }
     }
 
@@ -143,7 +152,7 @@ start_server {tags {"pause"}} {
         r exec
 
         wait_for_condition 10 100 {
-            [r get foo] eq [r get bar]
+            [r get foo] == {} && [r get bar] == {}
         } else {
             fail "Keys were never logically expired"
         }
@@ -183,6 +192,7 @@ start_server {tags {"pause"}} {
 
         r client unpause 
         assert_match "OK" [$rd read]
+        $rd close
     }
 
     # Make sure we unpause at the end

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -1,14 +1,16 @@
 start_server {tags {"pause"}} {
     test "Test read commands are not blocked by client pause" {
-        r client PAUSE 100000000 READONLY
+        r client PAUSE 100000000 WRITE
         set rd [redis_deferring_client]
         $rd GET FOO
+        $rd PING
+        $rd INFO
         assert_equal [s 0 blocked_clients] 0
         r client unpause
     }
 
     test "Test write commands are paused by RO" {
-        r client PAUSE 100000000 READONLY
+        r client PAUSE 100000000 WRITE
 
         set rd [redis_deferring_client]
         $rd SET FOO BAR
@@ -24,7 +26,7 @@ start_server {tags {"pause"}} {
 
     test "Test special commands are paused by RO" {
         r PFADD pause-hll test
-        r client PAUSE 100000000 READONLY
+        r client PAUSE 100000000 WRITE
 
         # Test that pfcount, which can replicate, is also blocked
         set rd [redis_deferring_client]
@@ -39,7 +41,7 @@ start_server {tags {"pause"}} {
     }
 
     test "Test mutli-execs are blocked by pause RO" {
-        r client PAUSE 100000000 READONLY
+        r client PAUSE 100000000 WRITE
         set rd [redis_deferring_client]
         $rd MULTI
         assert_equal [$rd read] "OK"
@@ -53,6 +55,45 @@ start_server {tags {"pause"}} {
         }
         r client unpause 
         assert_match "PONG" [$rd read]
+    }
+
+    test "Test scripts are blocked by pause RO" {
+        r client PAUSE 100000000 WRITE
+        set rd [redis_deferring_client]
+        $rd EVAL "return 1" 0
+        
+        wait_for_condition 50 100 {
+            [s 0 blocked_clients] eq {1}
+        } else {
+            fail "Clients are not blocked"
+        }
+        r client unpause 
+        assert_match "1" [$rd read]
+    }
+
+    test "Test multiple clients can be queued up and unblocked" {
+        r client PAUSE 100000000 WRITE
+        set clients [list [redis_deferring_client] [redis_deferring_client] [redis_deferring_client]]
+        foreach client $clients {
+            $client SET FOO BAR
+        }
+        
+        wait_for_condition 50 100 {
+            [s 0 blocked_clients] eq {3}
+        } else {
+            fail "Clients are not blocked"
+        }
+        r client unpause
+        foreach client $clients {
+            assert_match "OK" [$client read]
+        }
+    }
+
+    test "Test clients with syntax errors will get responses immediately" {
+        r client PAUSE 100000000 WRITE
+        catch {r set FOO} err
+        assert_match "ERR wrong number of arguments for *" $err
+        r client unpause
     }
 
     # Make sure we unpause at the end

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -1,18 +1,60 @@
 start_server {tags {"pause"}} {
-    proc verify_command_blocked {rd id} {   
-        r unblock client $id
-        assert_match "-UNBLOCKED client unblocked via CLIENT UNBLOCK" [$rd read]
-    }
-
-    test "Test various write commands are blocked by client pause" {
+    test "Test read commands are not blocked by client pause" {
         r client PAUSE 100000000 READONLY
         set rd [redis_deferring_client]
-        $rd client id
-        set id [$rd read]
-        [$rd id]
-
-        # Test basic write commands
-        $rd SET FOO BAR
-        verify_command_blocked $rd $id
+        $rd GET FOO
+        assert_equal [s 0 blocked_clients] 0
+        r client unpause
     }
+
+    test "Test write commands are paused by RO" {
+        r client PAUSE 100000000 READONLY
+
+        set rd [redis_deferring_client]
+        $rd SET FOO BAR
+        wait_for_condition 50 100 {
+            [s 0 blocked_clients] eq {1}
+        } else {
+            fail "Clients are not blocked"
+        }
+
+        r client unpause
+        assert_match "OK" [$rd read]
+    }
+
+    test "Test special commands are paused by RO" {
+        r PFADD pause-hll test
+        r client PAUSE 100000000 READONLY
+
+        # Test that pfcount, which can replicate, is also blocked
+        set rd [redis_deferring_client]
+        $rd PFCOUNT pause-hll
+        wait_for_condition 50 100 {
+            [s 0 blocked_clients] eq {1}
+        } else {
+            fail "Clients are not blocked"
+        }
+        r client unpause 
+        assert_match "1" [$rd read]
+    }
+
+    test "Test mutli-execs are blocked by pause RO" {
+        r client PAUSE 100000000 READONLY
+        set rd [redis_deferring_client]
+        $rd MULTI
+        assert_equal [$rd read] "OK"
+        $rd PING
+        assert_equal [$rd read] "QUEUED"
+        $rd EXEC
+        wait_for_condition 50 100 {
+            [s 0 blocked_clients] eq {1}
+        } else {
+            fail "Clients are not blocked"
+        }
+        r client unpause 
+        assert_match "PONG" [$rd read]
+    }
+
+    # Make sure we unpause at the end
+    r client unpause
 }

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -42,4 +42,14 @@ start_server {} {
         $master incr foo
         assert {[$master wait 1 3000] == 0}
     }
+
+    test {WAIT implicitly blocks on client pause since ACKs aren't sent} {
+        $master multi
+        $master incr foo
+        $master client pause 10000 write
+        $master exec
+        assert {[$master wait 1 1000] == 0}
+        $master client unpause
+        assert {[$master wait 1 1000] == 1}
+    }
 }}


### PR DESCRIPTION
Readonly implementation for: https://github.com/redis/redis/pull/6784

Main Changes:
This introduces a new optional mode argument for CLIENT PAUSE, WRITE, which blocked all clients when they attempt execute a write command. There is also now a companion command, CLIENT UNPAUSE, which can be used to undo a client pause. This is targeted for failover use cases, where you use ```CLIENT PAUSE <timeout> WRITE``` to stop all traffic on the master until the replica is caught up. You can then multi-exec the ```CLIENT UNPAUSE``` + ```REPLICAOF <newip> <newport>``` to transactionally failover without two master situations.

Behavior changes:
* Commands will now throw basic errors (basically wrong node, wrong number of arguments) instead of just hanging.
* Redis will no longer spin on the event loop during pause, but it will be doing useful work of parsing commands. (Although they might be ditched later)

Other minor changes:
* new may-replicate flag in the command table. The flag essentially indicates that the command should be allowed on replicas (it's not marked with write) but shouldn't be allowed during client pause. 
* new flag to COMMAND command: "may_replicate"
*  Client pause will strongly enforce the guarantee that replication offset does not change while it's happening, fixed two places this can occur
* * REPLCONF GETACK to replicas for WAIT command
* * lazy expire