### PR TITLE
Throw error on conflicting BCAST tracking prefixes.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2706,7 +2706,7 @@ NULL
                     addReplyErrorFormat(c,
                     "Prefix '%s' overlaps with one of the existing prefixes "
                     "associated with this client or one of the other "
-                    "provided prefixes.", prefix[collision_idx]->ptr);
+                    "provided prefixes.", (char *)prefix[collision_idx]->ptr);
                     zfree(prefix);
                     return;
                 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -2701,12 +2701,7 @@ NULL
             }
 
             if (options & CLIENT_TRACKING_BCAST) {
-                int collision_idx = findPrefixCollisions(c,prefix,numprefix);
-                if (collision_idx != -1) {
-                    addReplyErrorFormat(c,
-                    "Prefix '%s' overlaps with one of the existing prefixes "
-                    "associated with this client or one of the other "
-                    "provided prefixes.", (char *)prefix[collision_idx]->ptr);
+                if (!checkPrefixCollisionsOrReply(c,prefix,numprefix)) {
                     zfree(prefix);
                     return;
                 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -2700,6 +2700,18 @@ NULL
                 return;
             }
 
+            if (options & CLIENT_TRACKING_BCAST) {
+                int collision_idx = findPrefixCollisions(c,prefix,numprefix);
+                if (collision_idx != -1) {
+                    addReplyErrorFormat(c,
+                    "Prefix '%s' overlaps with one of the existing prefixes "
+                    "associated with this client or one of the other "
+                    "provided prefixes.", prefix[collision_idx]->ptr);
+                    zfree(prefix);
+                    return;
+                }
+            }
+
             enableTracking(c,redir,options,prefix,numprefix);
         } else if (!strcasecmp(c->argv[2]->ptr,"off")) {
             disableTracking(c);

--- a/src/server.h
+++ b/src/server.h
@@ -1825,6 +1825,7 @@ uint64_t trackingGetTotalItems(void);
 uint64_t trackingGetTotalKeys(void);
 uint64_t trackingGetTotalPrefixes(void);
 void trackingBroadcastInvalidationMessages(void);
+int findPrefixCollisions(client *c, robj **prefix, size_t numprefix);
 
 /* List data type */
 void listTypeTryConversion(robj *subject, robj *value);

--- a/src/server.h
+++ b/src/server.h
@@ -1825,7 +1825,7 @@ uint64_t trackingGetTotalItems(void);
 uint64_t trackingGetTotalKeys(void);
 uint64_t trackingGetTotalPrefixes(void);
 void trackingBroadcastInvalidationMessages(void);
-int findPrefixCollisions(client *c, robj **prefix, size_t numprefix);
+int checkPrefixCollisionsOrReply(client *c, robj **prefix, size_t numprefix);
 
 /* List data type */
 void listTypeTryConversion(robj *subject, robj *value);

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -147,10 +147,12 @@ void enableBcastTrackingForPrefix(client *c, char *prefix, size_t plen) {
                 while(raxNext(&ri)) {
                     raxInsert(bcast_keys,sub_ri.key,sub_ri.key_len,NULL,NULL);
                 }
+                raxStop(&sub_ri);
                 removeClientFromBcastState(c,sub_bs,ri.key,ri.key_len);
                 raxRemove(c->client_tracking_prefixes,ri.key,ri.key_len,NULL);
             }
         }    
+        raxStop(&ri);
     }
 
     /* If this is the first client subscribing to such prefix, create

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -124,7 +124,8 @@ int checkPrefixCollisionsOrReply(client *c, robj **prefixes, size_t numprefix) {
                     addReplyErrorFormat(c,
                         "Prefix '%s' overlaps with an existing prefix '%s'. "
                         "Prefixes for a single client must not overlap.",
-                        prefixes[i]->ptr,(unsigned char *)collision);
+                        (unsigned char *)prefixes[i]->ptr,
+                        (unsigned char *)collision);
                     sdsfree(collision);
                     raxStop(&ri);
                     return 0;
@@ -140,7 +141,8 @@ int checkPrefixCollisionsOrReply(client *c, robj **prefixes, size_t numprefix) {
                 addReplyErrorFormat(c,
                     "Prefix '%s' overlaps with another provided prefix '%s'. "
                     "Prefixes for a single client must not overlap.",
-                    prefixes[i]->ptr,prefixes[j]->ptr);
+                    (unsigned char *)prefixes[i]->ptr,
+                    (unsigned char *)prefixes[j]->ptr);
                 return i;
             }
         }

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -134,6 +134,7 @@ void enableBcastTrackingForPrefix(client *c, char *prefix, size_t plen) {
 
             if (ri.key_len <= plen) {
                 /* Case 1 */
+                raxStop(&ri);
                 return;
             } else {
                 /* Case 2 */

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -117,8 +117,9 @@ int checkPrefixCollisionsOrReply(client *c, robj **prefixes, size_t numprefix) {
             raxStart(&ri,c->client_tracking_prefixes);
             raxSeek(&ri,"^",NULL,0);
             while(raxNext(&ri)) {
-                if(stringCheckPrefix(ri.key,ri.key_len,
-                        prefixes[i]->ptr,sdslen(prefixes[i]->ptr))) {
+                if (stringCheckPrefix(ri.key,ri.key_len,
+                    prefixes[i]->ptr,sdslen(prefixes[i]->ptr))) 
+                {
                     sds collision = sdsnewlen(ri.key,ri.key_len);
                     addReplyErrorFormat(c,
                         "Prefix '%s' overlaps with an existing prefix '%s'. "
@@ -134,7 +135,8 @@ int checkPrefixCollisionsOrReply(client *c, robj **prefixes, size_t numprefix) {
         /* Check input has no overlap with itself. */
         for (size_t j = i + 1; j < numprefix; j++) {
             if (stringCheckPrefix(prefixes[i]->ptr,sdslen(prefixes[i]->ptr),
-                    prefixes[j]->ptr,sdslen(prefixes[j]->ptr))) {
+                prefixes[j]->ptr,sdslen(prefixes[j]->ptr)))
+            {
                 addReplyErrorFormat(c,
                     "Prefix '%s' overlaps with another provided prefix '%s'. "
                     "Prefixes for a single client must not overlap.",

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -114,18 +114,19 @@ int findPrefixCollisions(client *c, robj **prefixes, size_t numprefix) {
         /* Check input list has no overlap with existing prefixes. */
         if (c->client_tracking_prefixes) {
             raxIterator ri;
-            raxStart(&ri, c->client_tracking_prefixes);
+            raxStart(&ri,c->client_tracking_prefixes);
             raxSeek(&ri,"^",NULL,0);
             while(raxNext(&ri)) {
                 if(stringCheckPrefix(ri.key,ri.key_len,
-                        prefixes[i]->ptr, sdslen(prefixes[i]->ptr))) {
+                        prefixes[i]->ptr,sdslen(prefixes[i]->ptr))) {
+                    raxStop(&ri);
                     return i;
                 }
             }
             raxStop(&ri);
         }
         /* Check input has no overlap with itself. */
-        for (size_t j = i+1; j < numprefix; j++) {
+        for (size_t j = i + 1; j < numprefix; j++) {
             if (stringCheckPrefix(prefixes[i]->ptr,sdslen(prefixes[i]->ptr),
                     prefixes[j]->ptr,sdslen(prefixes[j]->ptr))) {
                 return i;

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -308,7 +308,7 @@ start_server {tags {"tracking"}} {
         assert {$ping_reply eq {PONG}}
     }
 
-    test {BCAST with collisions throw errors} {
+    test {BCAST with prefix collisions throw errors} {
         set r [redis_client] 
         catch {$r CLIENT TRACKING ON BCAST PREFIX FOOBAR PREFIX FOO} output
         assert_match {ERR Prefix 'FOOBAR'*} $output
@@ -316,12 +316,12 @@ start_server {tags {"tracking"}} {
         catch {$r CLIENT TRACKING ON BCAST PREFIX FOOBAR PREFIX FOO} output
         assert_match {ERR Prefix 'FOOBAR'*} $output
 
-        $r CLIENT TRACKING ON BCAST PREFIX FOO
+        $r CLIENT TRACKING ON BCAST PREFIX FOO PREFIX BAR
         catch {$r CLIENT TRACKING ON BCAST PREFIX FO} output
         assert_match {ERR Prefix 'FO'*} $output
 
-        catch {$r CLIENT TRACKING ON BCAST PREFIX FOOB} output
-        assert_match {ERR Prefix 'FOOB'*} $output
+        catch {$r CLIENT TRACKING ON BCAST PREFIX BARB} output
+        assert_match {ERR Prefix 'BARB'*} $output
 
         $r CLIENT TRACKING OFF
     }

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -311,17 +311,17 @@ start_server {tags {"tracking"}} {
     test {BCAST with prefix collisions throw errors} {
         set r [redis_client] 
         catch {$r CLIENT TRACKING ON BCAST PREFIX FOOBAR PREFIX FOO} output
-        assert_match {ERR Prefix 'FOOBAR'*} $output
+        assert_match {ERR Prefix 'FOOBAR'*'FOO'*} $output
 
-        catch {$r CLIENT TRACKING ON BCAST PREFIX FOOBAR PREFIX FOO} output
-        assert_match {ERR Prefix 'FOOBAR'*} $output
+        catch {$r CLIENT TRACKING ON BCAST PREFIX FOO PREFIX FOOBAR} output
+        assert_match {ERR Prefix 'FOO'*'FOOBAR'*} $output
 
         $r CLIENT TRACKING ON BCAST PREFIX FOO PREFIX BAR
         catch {$r CLIENT TRACKING ON BCAST PREFIX FO} output
-        assert_match {ERR Prefix 'FO'*} $output
+        assert_match {ERR Prefix 'FO'*'FOO'*} $output
 
         catch {$r CLIENT TRACKING ON BCAST PREFIX BARB} output
-        assert_match {ERR Prefix 'BARB'*} $output
+        assert_match {ERR Prefix 'BARB'*'BAR'*} $output
 
         $r CLIENT TRACKING OFF
     }

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -306,7 +306,20 @@ start_server {tags {"tracking"}} {
         set ping_reply [$rd read]
         assert {$inv_msg eq {invalidate key1}}
         assert {$ping_reply eq {PONG}}
-    } 
+    }
+
+    test {BCAST with multiple prefixes de-duplicate and don't send duplicate invalidations} {
+        $rd HELLO 3
+        $rd read ; # Consume the HELLO reply
+        $rd CLIENT TRACKING on BCAST PREFIX FOOBARBAZ PREFIX FOO PREFIX FOOBAR PREFIX FOOBARBAZ
+        $rd read ; # Consume the TRACKING reply
+        $rd_sg SET FOO BAR
+        set inv_msg [$rd read]
+        $rd PING
+        set ping_reply [$rd read]
+        assert {$inv_msg eq {invalidate FOO}}
+        assert {$ping_reply eq {PONG}}
+    }
 
     test {Tracking gets notification on tracking table key eviction} {
         $rd_redirection HELLO 2


### PR DESCRIPTION
Handle BCAST deduplications. This is mostly a POC to evaluate whether or not we should do this or throw an error: https://github.com/redis/redis/pull/8135

I'm not sure if we need to do all the work to copy all the keys into the BCAST state, but it handles some edge cases where a new client had created the new bcast state.  