### PR TITLE
Optimize performance of clusterGenNodesDescription for large clusters

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4218,7 +4218,7 @@ sds clusterGenNodeDescription(clusterNode *node) {
  * in the slots_info struct on the node. This is used to improve the efficiency
  * of clusterGenNodesDescription() because it removes looping of the slot space
  * for generating the slot info for each node individually. */
-void genNodesSlotsInfo(int filter) {
+void clusterGenNodesSlotsInfo(int filter) {
     clusterNode *n = NULL;
     int start = -1;
 
@@ -4242,6 +4242,7 @@ void genNodesSlotsInfo(int filter) {
                     n->slots_info = sdscatfmt(n->slots_info," %i-%i",start,i-1);
                 }
             }
+            if (i == CLUSTER_SLOTS) break;
             n = server.cluster->slots[i];
             start = i;
         }
@@ -4266,7 +4267,7 @@ sds clusterGenNodesDescription(int filter) {
     dictEntry *de;
 
     /* Generate all nodes slots info firstly. */
-    genNodesSlotsInfo(filter);
+    clusterGenNodesSlotsInfo(filter);
 
     di = dictGetSafeIterator(server.cluster->nodes);
     while((de = dictNext(di)) != NULL) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4214,11 +4214,11 @@ sds clusterGenNodeDescription(clusterNode *node) {
     return ci;
 }
 
-/* Gnerate all nodes slots topology info. Generating one node slots info is
+/* Generate all nodes slots topology info. Generating one node slots info is
  * costly in clusterGenNodeDescription(), if there are many nodes in cluster,
- * it will cost much time and block server to generate all nodes description,
- * so we can gnerate all firstly and complexity of this function is similar
- * to generate one node slots info in clusterGenNodeDescription(). */
+ * it will cost much time and block server to separately generate every node
+ * slots info. We have all slots topology of cluster, so we can generate all
+ * nodes slots info by only iterating slots topology once. */
 void genNodesSlotsInfo(void) {
     clusterNode *n = NULL;
     int start = -1;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4219,7 +4219,7 @@ sds clusterGenNodeDescription(clusterNode *node) {
  * it will cost much time and block server to generate all nodes description,
  * so we can gnerate all firstly and complexity of this function is similar
  * to generate one node slots info in clusterGenNodeDescription(). */
-void GenNodesSlotsInfo(void) {
+void genNodesSlotsInfo(void) {
     clusterNode *n = NULL;
     int start = -1;
 
@@ -4247,7 +4247,7 @@ void GenNodesSlotsInfo(void) {
     }
 }
 
-void ReleaseNodesSlotsInfo(void) {
+void releaseNodesSlotsInfo(void) {
     dictIterator *di;
     dictEntry *de;
 
@@ -4280,7 +4280,7 @@ sds clusterGenNodesDescription(int filter) {
     dictEntry *de;
 
     /* Gnerate all nodes slots info firstly. */
-    GenNodesSlotsInfo();
+    genNodesSlotsInfo();
 
     di = dictGetSafeIterator(server.cluster->nodes);
     while((de = dictNext(di)) != NULL) {
@@ -4294,7 +4294,7 @@ sds clusterGenNodesDescription(int filter) {
     }
     dictReleaseIterator(di);
 
-    ReleaseNodesSlotsInfo();
+    releaseNodesSlotsInfo();
     return ci;
 }
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -118,6 +118,7 @@ typedef struct clusterNode {
     int flags;      /* CLUSTER_NODE_... */
     uint64_t configEpoch; /* Last configEpoch observed for this node */
     unsigned char slots[CLUSTER_SLOTS/8]; /* slots handled by this node */
+    sds slots_info; /* Slots info represented by string. */
     int numslots;   /* Number of slots handled by this node */
     int numslaves;  /* Number of slave nodes, if this is a master */
     struct clusterNode **slaves; /* pointers to slave nodes */

--- a/tests/cluster/tests/18-cluster-nodes-slots.tcl
+++ b/tests/cluster/tests/18-cluster-nodes-slots.tcl
@@ -1,0 +1,62 @@
+# Optimize CLUSTER NODES command by generating all nodes slot topology firstly
+
+source "../tests/includes/init-tests.tcl"
+
+proc cluster_allocate_with_continuous_slots {n} {
+    set slot 16383
+    set avg [expr ($slot+1) / $n]
+    while {$slot >= 0} {
+        set node [expr $slot/$avg >= $n ? $n-1 : $slot/$avg]
+        lappend slots_$node $slot
+        incr slot -1
+    }
+    for {set j 0} {$j < $n} {incr j} {
+        R $j cluster addslots {*}[set slots_${j}]
+    }
+}
+
+proc cluster_create_with_continuous_slots {masters slaves} {
+    cluster_allocate_with_continuous_slots $masters
+    if {$slaves} {
+        cluster_allocate_slaves $masters $slaves
+    }
+    assert_cluster_state ok
+}
+
+test "Create a 2 nodes cluster" {
+    cluster_create_with_continuous_slots 2 2
+}
+
+test "Cluster should start ok" {
+    assert_cluster_state ok
+}
+
+set master1 [Rn 0]
+set master2 [Rn 1]
+
+test "Continuous slots distribution" {
+    assert_match "* 0-8191*" [$master1 CLUSTER NODES]
+    assert_match "* 8192-16383*" [$master2 CLUSTER NODES]
+
+    $master1 CLUSTER DELSLOTS 4096
+    assert_match "* 0-4095 4097-8191*" [$master1 CLUSTER NODES]
+
+    $master2 CLUSTER DELSLOTS 12288
+    assert_match "* 8192-12287 12289-16383*" [$master2 CLUSTER NODES]
+}
+
+test "Discontinuous slots distribution" {
+    # Remove middle slots
+    $master1 CLUSTER DELSLOTS 4092 4094
+    assert_match "* 0-4091 4093 4095 4097-8191*" [$master1 CLUSTER NODES]
+    $master2 CLUSTER DELSLOTS 12284 12286
+    assert_match "* 8192-12283 12285 12287 12289-16383*" [$master2 CLUSTER NODES]
+
+    # Remove head slots
+    $master1 CLUSTER DELSLOTS 0 2
+    assert_match "* 1 3-4091 4093 4095 4097-8191*" [$master1 CLUSTER NODES]
+
+    # Remove tail slots
+    $master2 CLUSTER DELSLOTS 16380 16382 16383
+    assert_match "* 8192-12283 12285 12287 12289-16379 16381*" [$master2 CLUSTER NODES]
+}


### PR DESCRIPTION
Fix #8145

Generating one node slots info is costly in clusterGenNodeDescription(), if there are many nodes in cluster, it will cost much time and block server to separately  generate every node description. We already had all slots topology of cluster, so we can generate all nodes slots info by only iterating slots topology once, that can reduce complexity to get clusterGenNodesDescription for big redis cluster.

Otherwise, replace `sdscatprintf` with `sdsfmt` in clusterGenNodeDescription, since `sdsfmt` has better performance.