### PR TITLE
Tests: fix new defrag test to be skipped when not supported

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -63,7 +63,7 @@ start_server {tags {"defrag"} overrides {appendonly yes auto-aof-rewrite-percent
             r config set maxmemory 110mb ;# prevent further eviction (not to fail the digest test)
             set digest [r debug digest]
             catch {r config set activedefrag yes} e
-            if {![string match {DISABLED*} $e]} {
+            if {[r config get activedefrag] eq "activedefrag yes"} {
                 # Wait for the active defrag to start working (decision once a
                 # second).
                 wait_for_condition 50 100 {
@@ -236,7 +236,7 @@ start_server {tags {"defrag"} overrides {appendonly yes auto-aof-rewrite-percent
 
             set digest [r debug digest]
             catch {r config set activedefrag yes} e
-            if {![string match {DISABLED*} $e]} {
+            if {[r config get activedefrag] eq "activedefrag yes"} {
                 # wait for the active defrag to start working (decision once a second)
                 wait_for_condition 50 100 {
                     [s active_defrag_running] ne 0
@@ -332,7 +332,7 @@ start_server {tags {"defrag"} overrides {appendonly yes auto-aof-rewrite-percent
 
             set digest [r debug digest]
             catch {r config set activedefrag yes} e
-            if {![string match {DISABLED*} $e]} {
+            if {[r config get activedefrag] eq "activedefrag yes"} {
                 # wait for the active defrag to start working (decision once a second)
                 wait_for_condition 50 100 {
                     [s active_defrag_running] ne 0
@@ -452,7 +452,7 @@ start_server {tags {"defrag"} overrides {appendonly yes auto-aof-rewrite-percent
 
                 set digest [r debug digest]
                 catch {r config set activedefrag yes} e
-                if {![string match {DISABLED*} $e]} {
+                if {[r config get activedefrag] eq "activedefrag yes"} {
                     # wait for the active defrag to start working (decision once a second)
                     wait_for_condition 50 100 {
                         [s active_defrag_running] ne 0

--- a/tests/unit/moduleapi/defrag.tcl
+++ b/tests/unit/moduleapi/defrag.tcl
@@ -3,41 +3,44 @@ set testmodule [file normalize tests/modules/defragtest.so]
 start_server {tags {"modules"} overrides {{save ""}}} {
     r module load $testmodule 10000
     r config set hz 100
+    r config set active-defrag-ignore-bytes 1
+    r config set active-defrag-threshold-lower 0
+    r config set active-defrag-cycle-min 99
 
-    test {Module defrag: simple key defrag works} {
-        r frag.create key1 1 1000 0
+    # try to enable active defrag, it will fail if redis was compiled without it
+    catch {r config set activedefrag yes} e
+    if {[r config get activedefrag] eq "activedefrag yes"} {
 
-        r config set active-defrag-ignore-bytes 1
-        r config set active-defrag-threshold-lower 0
-        r config set active-defrag-cycle-min 99
-        r config set activedefrag yes
+        test {Module defrag: simple key defrag works} {
+            r frag.create key1 1 1000 0
 
-        after 2000
-        set info [r info defragtest_stats]
-        assert {[getInfoProperty $info defragtest_datatype_attempts] > 0}
-        assert_equal 0 [getInfoProperty $info defragtest_datatype_resumes]
-    }
+            after 2000
+            set info [r info defragtest_stats]
+            assert {[getInfoProperty $info defragtest_datatype_attempts] > 0}
+            assert_equal 0 [getInfoProperty $info defragtest_datatype_resumes]
+        }
 
-    test {Module defrag: late defrag with cursor works} {
-        r flushdb
-        r frag.resetstats
+        test {Module defrag: late defrag with cursor works} {
+            r flushdb
+            r frag.resetstats
 
-        # key can only be defragged in no less than 10 iterations
-        # due to maxstep
-        r frag.create key2 10000 100 1000
+            # key can only be defragged in no less than 10 iterations
+            # due to maxstep
+            r frag.create key2 10000 100 1000
 
-        after 2000
-        set info [r info defragtest_stats]
-        assert {[getInfoProperty $info defragtest_datatype_resumes] > 10}
-        assert_equal 0 [getInfoProperty $info defragtest_datatype_wrong_cursor]
-    }
+            after 2000
+            set info [r info defragtest_stats]
+            assert {[getInfoProperty $info defragtest_datatype_resumes] > 10}
+            assert_equal 0 [getInfoProperty $info defragtest_datatype_wrong_cursor]
+        }
 
-    test {Module defrag: global defrag works} {
-        r flushdb
-        r frag.resetstats
+        test {Module defrag: global defrag works} {
+            r flushdb
+            r frag.resetstats
 
-        after 2000
-        set info [r info defragtest_stats]
-        assert {[getInfoProperty $info defragtest_global_attempts] > 0}
+            after 2000
+            set info [r info defragtest_stats]
+            assert {[getInfoProperty $info defragtest_global_attempts] > 0}
+        }
     }
 }


### PR DESCRIPTION
Additionally the older defrag tests are using an obsolete way to check
if the defragger is suuported (the error no longer contains "DISABLED").
this doesn't usually makes a difference since these tests are completely
skipped if the allocator is not jemalloc, but that would fail if the
allocator is a jemalloc that doesn't support defrag.