### PR TITLE
fix wrong comment in cluster.h

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -40,7 +40,7 @@ typedef struct clusterLink {
     sds sndbuf;                 /* Packet send buffer */
     char *rcvbuf;               /* Packet reception buffer */
     size_t rcvbuf_len;          /* Used size of rcvbuf */
-    size_t rcvbuf_alloc;        /* Used size of rcvbuf */
+    size_t rcvbuf_alloc;        /* Allocated size of rcvbuf */
     struct clusterNode *node;   /* Node related to this link if any, or NULL */
 } clusterLink;
 


### PR DESCRIPTION
a small comment nit was found when i was reading https://github.com/redis/redis/pull/7958 .