### PR TITLE
Included in redis.conf explicit explanation of tls-protocol defaults

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -196,9 +196,12 @@ tcp-keepalive 300
 #
 # tls-cluster yes
 
-# Explicitly specify TLS versions to support. Allowed values are case insensitive
-# and include "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" (OpenSSL >= 1.1.1) or
-# any combination. To enable only TLSv1.2 and TLSv1.3, use:
+# By default, only TLSv1.2 and TLSv1.3 are enabled and it is highly recommended
+# that older formally deprecated versions are kept disabled to reduce the attack surface.
+# You can explicitly specify TLS versions to support.
+# Allowed values are case insensitive and include "TLSv1", "TLSv1.1", "TLSv1.2",
+# "TLSv1.3" (OpenSSL >= 1.1.1) or any combination.
+# To enable only TLSv1.2 and TLSv1.3, use:
 #
 # tls-protocols "TLSv1.2 TLSv1.3"
 


### PR DESCRIPTION
This small PR has by main goal to explicitly state the default TLS protocols supported and raise awareness to why TLS 1.0 and TLS 1.1 (formally [deprecated](https://tools.ietf.org/id/draft-ietf-tls-oldversions-deprecate-02.html)) should not be used.