### PR TITLE
Simplify parameters

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -154,7 +154,7 @@ void execCommandAbort(client *c, sds error) {
      * already, and didn't send any of the queued commands, now we'll just send
      * EXEC so it is clear that the transaction is over. */
     if (listLength(server.monitors) && !server.loading)
-        replicationFeedMonitors(c,server.monitors,c->db->id,c->argv,c->argc);
+        replicationFeedMonitors(c, c->db->id, c->argv, c->argc);
 }
 
 void execCommand(client *c) {
@@ -289,7 +289,7 @@ handle_monitor:
      * Instead EXEC is flagged as CMD_SKIP_MONITOR in the command
      * table, and we do it here with correct ordering. */
     if (listLength(server.monitors) && !server.loading)
-        replicationFeedMonitors(c,server.monitors,c->db->id,c->argv,c->argc);
+        replicationFeedMonitors(c, c->db->id, c->argv, c->argc);
 }
 
 /* ===================== WATCH (CAS alike for MULTI/EXEC) ===================

--- a/src/networking.c
+++ b/src/networking.c
@@ -1925,8 +1925,7 @@ void commandProcessed(client *c) {
     if (c->flags & CLIENT_MASTER) {
         long long applied = c->reploff - prev_offset;
         if (applied) {
-            replicationFeedSlavesFromMasterStream(server.slaves,
-                    c->pending_querybuf, applied);
+            replicationFeedSlavesFromMasterStream(c->pending_querybuf, applied);
             sdsrange(c->pending_querybuf,applied,-1);
         }
     }

--- a/src/server.c
+++ b/src/server.c
@@ -2324,7 +2324,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
         argv[0] = createStringObject("REPLCONF",8);
         argv[1] = createStringObject("GETACK",6);
         argv[2] = createStringObject("*",1); /* Not used argument. */
-        replicationFeedSlaves(server.slaves, server.slaveseldb, argv, 3);
+        replicationFeedSlaves(server.slaveseldb, argv, 3);
         decrRefCount(argv[0]);
         decrRefCount(argv[1]);
         decrRefCount(argv[2]);
@@ -3377,7 +3377,7 @@ void propagate(struct redisCommand *cmd, int dbid, robj **argv, int argc,
     if (server.aof_state != AOF_OFF && flags & PROPAGATE_AOF)
         feedAppendOnlyFile(cmd,dbid,argv,argc);
     if (flags & PROPAGATE_REPL)
-        replicationFeedSlaves(server.slaves,dbid,argv,argc);
+        replicationFeedSlaves(dbid,argv,argc);
 }
 
 /* Used inside commands to schedule the propagation of additional commands
@@ -3484,7 +3484,7 @@ void call(client *c, int flags) {
         !server.loading &&
         !(c->cmd->flags & (CMD_SKIP_MONITOR|CMD_ADMIN)))
     {
-        replicationFeedMonitors(c,server.monitors,c->db->id,c->argv,c->argc);
+        replicationFeedMonitors(c,c->db->id,c->argv,c->argc);
     }
 
     /* Initialization: clear the flags that must be set by the command on

--- a/src/server.h
+++ b/src/server.h
@@ -1923,9 +1923,9 @@ ssize_t syncRead(int fd, char *ptr, ssize_t size, long long timeout);
 ssize_t syncReadLine(int fd, char *ptr, ssize_t size, long long timeout);
 
 /* Replication */
-void replicationFeedSlaves(list *slaves, int dictid, robj **argv, int argc);
-void replicationFeedSlavesFromMasterStream(list *slaves, char *buf, size_t buflen);
-void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv, int argc);
+void replicationFeedSlaves(int dictid, robj **argv, int argc);
+void replicationFeedSlavesFromMasterStream(char *buf, size_t buflen);
+void replicationFeedMonitors(client *c, int dictid, robj **argv, int argc);
 void updateSlavesWaitingBgsave(int bgsaveerr, int type);
 void replicationCron(void);
 void replicationStartPendingFork(void);


### PR DESCRIPTION
> I agree that it's unnecessary, since it's a global, but I think this commit just obfuscates the git commit history. Do you think the change actually improves the code readability?

@madolson  Old PR https://github.com/redis/redis/pull/8192 was unexpected closed by me, I made some changes and submitted another. I think the list of slaves and monitors is part of the function and should not be exposed. After removing these parameters, the whole function will be more concise.