### PR TITLE
Fix TLS build on macOS arm64 systems

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -115,8 +115,13 @@ else
 ifeq ($(uname_S),Darwin)
 	# Darwin
 	FINAL_LIBS+= -ldl
+ifeq ($(uname_M),arm64)
+	OPENSSL_CFLAGS=-I/opt/homebrew/opt/openssl/include
+	OPENSSL_LDFLAGS=-L/opt/homebrew/opt/openssl/lib
+else
 	OPENSSL_CFLAGS=-I/usr/local/opt/openssl/include
 	OPENSSL_LDFLAGS=-L/usr/local/opt/openssl/lib
+endif
 else
 ifeq ($(uname_S),AIX)
         # AIX

--- a/src/Makefile
+++ b/src/Makefile
@@ -115,10 +115,15 @@ else
 ifeq ($(uname_S),Darwin)
 	# Darwin
 	FINAL_LIBS+= -ldl
+	# Homebrew's OpenSSL is not linked to /usr/local to avoid
+	# conflicts with the system's LibreSSL installation so it
+	# must be referenced explicitly during build.
 ifeq ($(uname_M),arm64)
+	# Homebrew arm64 uses /opt/homebrew as HOMEBREW_PREFIX
 	OPENSSL_CFLAGS=-I/opt/homebrew/opt/openssl/include
 	OPENSSL_LDFLAGS=-L/opt/homebrew/opt/openssl/lib
 else
+	# Homebrew x86/ppc uses /usr/local as HOMEBREW_PREFIX
 	OPENSSL_CFLAGS=-I/usr/local/opt/openssl/include
 	OPENSSL_LDFLAGS=-L/usr/local/opt/openssl/lib
 endif


### PR DESCRIPTION
Homebrew for darwin-arm64 uses `/opt/homebrew` instead of `/usr/local` as the prefix, so that it can co-exist with x86_64 using Rosetta 2.

This patch detects the arm64 environment and chooses the proper Homebrew prefix.

Tested using both arm64 and x86_64 builds on a M1 Mac running macOS 11.1 and Xcode 12.3 with dual Hombrew installations.