### PR TITLE
Handle binary safe string for REQUIREPASS and MASTERAUTH directives

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -511,8 +511,15 @@ void loadServerConfigFromString(char *config) {
                 err = "Invalid master port"; goto loaderr;
             }
             server.repl_state = REPL_STATE_CONNECT;
+        } else if (!strcasecmp(argv[0],"masterauth") && argc == 2) {
+            if (sdslen(argv[1]) > CONFIG_AUTHPASS_MAX_LEN) {
+                err = "Masterauth is longer than CONFIG_AUTHPASS_MAX_LEN";
+                goto loaderr;
+            }
+            sdsfree(server.masterauth);
+            server.masterauth = sdsdup(argv[1]);
         } else if (!strcasecmp(argv[0],"requirepass") && argc == 2) {
-            if (strlen(argv[1]) > CONFIG_AUTHPASS_MAX_LEN) {
+            if (sdslen(argv[1]) > CONFIG_AUTHPASS_MAX_LEN) {
                 err = "Password is longer than CONFIG_AUTHPASS_MAX_LEN";
                 goto loaderr;
             }
@@ -524,10 +531,10 @@ void loadServerConfigFromString(char *config) {
             sdsfree(server.requirepass);
             server.requirepass = NULL;
             if (sdslen(argv[1])) {
-                sds aclop = sdscatprintf(sdsempty(),">%s",argv[1]);
+                sds aclop = sdscatlen(sdsnew(">"), argv[1], sdslen(argv[1]));
                 ACLSetUser(DefaultUser,aclop,sdslen(aclop));
                 sdsfree(aclop);
-                server.requirepass = sdsnew(argv[1]);
+                server.requirepass = sdsdup(argv[1]);
             } else {
                 ACLSetUser(DefaultUser,"nopass",-1);
             }
@@ -751,10 +758,10 @@ void configSetCommand(client *c) {
         sdsfree(server.requirepass);
         server.requirepass = NULL;
         if (sdslen(o->ptr)) {
-            sds aclop = sdscatprintf(sdsempty(),">%s",(char*)o->ptr);
+            sds aclop = sdscatlen(sdsnew(">"), o->ptr, sdslen(o->ptr));
             ACLSetUser(DefaultUser,aclop,sdslen(aclop));
             sdsfree(aclop);
-            server.requirepass = sdsnew(o->ptr);
+            server.requirepass = sdsdup(o->ptr);
         } else {
             ACLSetUser(DefaultUser,"nopass",-1);
         }
@@ -1043,6 +1050,16 @@ void configGetCommand(client *c) {
         sds password = server.requirepass;
         if (password) {
             addReplyBulkCBuffer(c,password,sdslen(password));
+        } else {
+            addReplyBulkCString(c,"");
+        }
+        matches++;
+    }
+    if (stringmatch(pattern,"masterauth",1)) {
+        addReplyBulkCString(c,"masterauth");
+        sds masterauth = server.masterauth;
+        if (masterauth) {
+            addReplyBulkCBuffer(c,masterauth,sdslen(masterauth));
         } else {
             addReplyBulkCString(c,"");
         }
@@ -1545,6 +1562,26 @@ void rewriteConfigRequirepassOption(struct rewriteConfigState *state, char *opti
     rewriteConfigRewriteLine(state,option,line,force);
 }
 
+/* Rewrite the masterauth option. */
+void rewriteConfigMasterauthOption(struct rewriteConfigState *state, char *option) {
+    int force = 1;
+    sds line;
+    sds masterauth = server.masterauth;
+
+    /* If there is no masterauth set, we don't want the masterauth option
+     * to be present in the configuration at all. */
+    if (masterauth == NULL) {
+        rewriteConfigMarkAsProcessed(state,option);
+        return;
+    }
+
+    line = sdsnew(option);
+    line = sdscatlen(line, " ", 1);
+    line = sdscatsds(line, masterauth);
+
+    rewriteConfigRewriteLine(state,option,line,force);
+}
+
 /* Glue together the configuration lines in the current configuration
  * rewrite state into a single string, stripping multiple empty lines. */
 sds rewriteConfigGetContentFromState(struct rewriteConfigState *state) {
@@ -1702,6 +1739,7 @@ int rewriteConfig(char *path, int force_all) {
     rewriteConfigDirOption(state);
     rewriteConfigSlaveofOption(state,"replicaof");
     rewriteConfigRequirepassOption(state,"requirepass");
+    rewriteConfigMasterauthOption(state,"masterauth");
     rewriteConfigBytesOption(state,"client-query-buffer-limit",server.client_max_querybuf_len,PROTO_MAX_QUERYBUF_LEN);
     rewriteConfigStringOption(state,"cluster-config-file",server.cluster_configfile,CONFIG_DEFAULT_CLUSTER_CONFIG_FILE);
     rewriteConfigNotifykeyspaceeventsOption(state);
@@ -2349,7 +2387,6 @@ standardConfig configs[] = {
     createStringConfig("pidfile", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.pidfile, NULL, NULL, NULL),
     createStringConfig("replica-announce-ip", "slave-announce-ip", MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.slave_announce_ip, NULL, NULL, NULL),
     createStringConfig("masteruser", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.masteruser, NULL, NULL, NULL),
-    createStringConfig("masterauth", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.masterauth, NULL, NULL, NULL),
     createStringConfig("cluster-announce-ip", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_ip, NULL, NULL, NULL),
     createStringConfig("syslog-ident", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.syslog_ident, "redis", NULL, NULL),
     createStringConfig("dbfilename", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.rdb_filename, "dump.rdb", isValidDBfilename, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -166,6 +166,15 @@ typedef struct stringConfigData {
                                   be stored as a NULL value. */
 } stringConfigData;
 
+typedef struct sdsConfigData {
+    sds *config; /* Pointer to the server config this value is stored in. */
+    const char *default_value; /* Default value of the config on rewrite. */
+    int (*is_valid_fn)(sds val, char **err); /* Optional function to check validity of new value (generic doc above) */
+    int (*update_fn)(sds val, sds prev, char **err); /* Optional function to apply new value at runtime (generic doc above) */
+    int convert_empty_to_null; /* Boolean indicating if empty SDS strings should
+                                  be stored as a NULL value. */
+} sdsConfigData;
+
 typedef struct enumConfigData {
     int *config; /* The pointer to the server config this value is stored in */
     configEnum *enum_value; /* The underlying enum type this data represents */
@@ -212,6 +221,7 @@ typedef struct numericConfigData {
 typedef union typeData {
     boolConfigData yesno;
     stringConfigData string;
+    sdsConfigData sds;
     enumConfigData enumd;
     numericConfigData numeric;
 } typeData;
@@ -511,13 +521,6 @@ void loadServerConfigFromString(char *config) {
                 err = "Invalid master port"; goto loaderr;
             }
             server.repl_state = REPL_STATE_CONNECT;
-        } else if (!strcasecmp(argv[0],"masterauth") && argc == 2) {
-            if (sdslen(argv[1]) > CONFIG_AUTHPASS_MAX_LEN) {
-                err = "Masterauth is longer than CONFIG_AUTHPASS_MAX_LEN";
-                goto loaderr;
-            }
-            sdsfree(server.masterauth);
-            server.masterauth = sdsdup(argv[1]);
         } else if (!strcasecmp(argv[0],"requirepass") && argc == 2) {
             if (sdslen(argv[1]) > CONFIG_AUTHPASS_MAX_LEN) {
                 err = "Password is longer than CONFIG_AUTHPASS_MAX_LEN";
@@ -1055,16 +1058,6 @@ void configGetCommand(client *c) {
         }
         matches++;
     }
-    if (stringmatch(pattern,"masterauth",1)) {
-        addReplyBulkCString(c,"masterauth");
-        sds masterauth = server.masterauth;
-        if (masterauth) {
-            addReplyBulkCBuffer(c,masterauth,sdslen(masterauth));
-        } else {
-            addReplyBulkCString(c,"");
-        }
-        matches++;
-    }
 
     if (stringmatch(pattern,"oom-score-adj-values",0)) {
         sds buf = sdsempty();
@@ -1347,6 +1340,28 @@ void rewriteConfigStringOption(struct rewriteConfigState *state, const char *opt
     rewriteConfigRewriteLine(state,option,line,force);
 }
 
+/* Rewrite a SDS string option. */
+void rewriteConfigSdsOption(struct rewriteConfigState *state, const char *option, sds value, const sds defvalue) {
+    int force = 1;
+    sds line;
+
+    /* If there is no value set, we don't want the SDS option
+     * to be present in the configuration at all. */
+    if (value == NULL) {
+        rewriteConfigMarkAsProcessed(state, option);
+        return;
+    }
+
+    /* Set force to zero if the value is set to its default. */
+    if (defvalue && sdscmp(value, defvalue) == 0) force = 0;
+
+    line = sdsnew(option);
+    line = sdscatlen(line, " ", 1);
+    line = sdscatrepr(line, value, sdslen(value));
+
+    rewriteConfigRewriteLine(state, option, line, force);
+}
+
 /* Rewrite a numerical (long long range) option. */
 void rewriteConfigNumericalOption(struct rewriteConfigState *state, const char *option, long long value, long long defvalue) {
     int force = value != defvalue;
@@ -1562,26 +1577,6 @@ void rewriteConfigRequirepassOption(struct rewriteConfigState *state, char *opti
     rewriteConfigRewriteLine(state,option,line,force);
 }
 
-/* Rewrite the masterauth option. */
-void rewriteConfigMasterauthOption(struct rewriteConfigState *state, char *option) {
-    int force = 1;
-    sds line;
-    sds masterauth = server.masterauth;
-
-    /* If there is no masterauth set, we don't want the masterauth option
-     * to be present in the configuration at all. */
-    if (masterauth == NULL) {
-        rewriteConfigMarkAsProcessed(state,option);
-        return;
-    }
-
-    line = sdsnew(option);
-    line = sdscatlen(line, " ", 1);
-    line = sdscatsds(line, masterauth);
-
-    rewriteConfigRewriteLine(state,option,line,force);
-}
-
 /* Glue together the configuration lines in the current configuration
  * rewrite state into a single string, stripping multiple empty lines. */
 sds rewriteConfigGetContentFromState(struct rewriteConfigState *state) {
@@ -1739,7 +1734,6 @@ int rewriteConfig(char *path, int force_all) {
     rewriteConfigDirOption(state);
     rewriteConfigSlaveofOption(state,"replicaof");
     rewriteConfigRequirepassOption(state,"requirepass");
-    rewriteConfigMasterauthOption(state,"masterauth");
     rewriteConfigBytesOption(state,"client-query-buffer-limit",server.client_max_querybuf_len,PROTO_MAX_QUERYBUF_LEN);
     rewriteConfigStringOption(state,"cluster-config-file",server.cluster_configfile,CONFIG_DEFAULT_CLUSTER_CONFIG_FILE);
     rewriteConfigNotifykeyspaceeventsOption(state);
@@ -1840,22 +1834,14 @@ static void boolConfigRewrite(typeData data, const char *name, struct rewriteCon
 
 /* String Configs */
 static void stringConfigInit(typeData data) {
-    if (data.string.convert_empty_to_null) {
-        *data.string.config = data.string.default_value ? zstrdup(data.string.default_value) : NULL;
-    } else {
-        *data.string.config = zstrdup(data.string.default_value);
-    }
+    *data.string.config = (data.string.convert_empty_to_null && !data.string.default_value) ? NULL : zstrdup(data.string.default_value);
 }
 
 static int stringConfigSet(typeData data, sds value, int update, char **err) {
     if (data.string.is_valid_fn && !data.string.is_valid_fn(value, err))
         return 0;
     char *prev = *data.string.config;
-    if (data.string.convert_empty_to_null) {
-        *data.string.config = value[0] ? zstrdup(value) : NULL;
-    } else {
-        *data.string.config = zstrdup(value);
-    }
+    *data.string.config = (data.string.convert_empty_to_null && !value[0]) ? NULL : zstrdup(value);
     if (update && data.string.update_fn && !data.string.update_fn(*data.string.config, prev, err)) {
         zfree(*data.string.config);
         *data.string.config = prev;
@@ -1873,6 +1859,38 @@ static void stringConfigRewrite(typeData data, const char *name, struct rewriteC
     rewriteConfigStringOption(state, name,*(data.string.config), data.string.default_value);
 }
 
+/* SDS Configs */
+static void sdsConfigInit(typeData data) {
+    *data.sds.config = (data.sds.convert_empty_to_null && !data.sds.default_value) ? NULL: sdsnew(data.sds.default_value);
+}
+
+static int sdsConfigSet(typeData data, sds value, int update, char **err) {
+    if (data.sds.is_valid_fn && !data.sds.is_valid_fn(value, err))
+        return 0;
+    sds prev = *data.sds.config;
+    *data.sds.config = (data.sds.convert_empty_to_null && (sdslen(value) == 0)) ? NULL : sdsdup(value);
+    if (update && data.sds.update_fn && !data.sds.update_fn(*data.sds.config, prev, err)) {
+        sdsfree(*data.sds.config);
+        *data.sds.config = prev;
+        return 0;
+    }
+    sdsfree(prev);
+    return 1;
+}
+
+static void sdsConfigGet(client *c, typeData data) {
+    if (*data.sds.config) {
+        addReplyBulkSds(c, sdsdup(*data.sds.config));
+    } else {
+        addReplyBulkCString(c, "");
+    }
+}
+
+static void sdsConfigRewrite(typeData data, const char *name, struct rewriteConfigState *state) {
+    rewriteConfigSdsOption(state, name, *(data.sds.config), data.sds.default_value ? sdsnew(data.sds.default_value) : NULL);
+}
+
+
 #define ALLOW_EMPTY_STRING 0
 #define EMPTY_STRING_IS_NULL 1
 
@@ -1880,6 +1898,18 @@ static void stringConfigRewrite(typeData data, const char *name, struct rewriteC
     embedCommonConfig(name, alias, modifiable) \
     embedConfigInterface(stringConfigInit, stringConfigSet, stringConfigGet, stringConfigRewrite) \
     .data.string = { \
+        .config = &(config_addr), \
+        .default_value = (default), \
+        .is_valid_fn = (is_valid), \
+        .update_fn = (update), \
+        .convert_empty_to_null = (empty_to_null), \
+    } \
+}
+
+#define createSDSConfig(name, alias, modifiable, empty_to_null, config_addr, default, is_valid, update) { \
+    embedCommonConfig(name, alias, modifiable) \
+    embedConfigInterface(sdsConfigInit, sdsConfigSet, sdsConfigGet, sdsConfigRewrite) \
+    .data.sds = { \
         .config = &(config_addr), \
         .default_value = (default), \
         .is_valid_fn = (is_valid), \
@@ -2395,6 +2425,9 @@ standardConfig configs[] = {
     createStringConfig("bio_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.bio_cpulist, NULL, NULL, NULL),
     createStringConfig("aof_rewrite_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.aof_rewrite_cpulist, NULL, NULL, NULL),
     createStringConfig("bgsave_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.bgsave_cpulist, NULL, NULL, NULL),
+
+    /* SDS Configs */
+    createSDSConfig("masterauth", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.masterauth, NULL, NULL, NULL),
 
     /* Enum Configs */
     createEnumConfig("supervised", NULL, IMMUTABLE_CONFIG, supervised_mode_enum, server.supervised_mode, SUPERVISED_NONE, NULL, NULL),

--- a/src/replication.c
+++ b/src/replication.c
@@ -1835,6 +1835,7 @@ error:
  */
 #define SYNC_CMD_READ (1<<0)
 #define SYNC_CMD_WRITE (1<<1)
+#define SYNC_CMD_WRITE_SDS (1<<2)
 #define SYNC_CMD_FULL (SYNC_CMD_READ|SYNC_CMD_WRITE)
 char *sendSynchronousCommand(int flags, connection *conn, ...) {
 
@@ -1852,8 +1853,13 @@ char *sendSynchronousCommand(int flags, connection *conn, ...) {
         while(1) {
             arg = va_arg(ap, char*);
             if (arg == NULL) break;
-
-            cmdargs = sdscatprintf(cmdargs,"$%zu\r\n%s\r\n",strlen(arg),arg);
+            if (flags & SYNC_CMD_WRITE_SDS) {
+                cmdargs = sdscatprintf(cmdargs,"$%zu\r\n", sdslen((sds)arg));
+                cmdargs = sdscatsds(cmdargs, (sds)arg);
+                cmdargs = sdscat(cmdargs, "\r\n");
+            } else {
+                cmdargs = sdscatprintf(cmdargs,"$%zu\r\n%s\r\n",strlen(arg),arg);
+            }
             argslen++;
         }
 
@@ -2167,13 +2173,20 @@ void syncWithMaster(connection *conn) {
     /* AUTH with the master if required. */
     if (server.repl_state == REPL_STATE_SEND_AUTH) {
         if (server.masteruser && server.masterauth) {
-            err = sendSynchronousCommand(SYNC_CMD_WRITE,conn,"AUTH",
-                                         server.masteruser,server.masterauth,NULL);
+            sds masteruser = sdsnew(server.masteruser);
+            sds auth = sdsnew("AUTH");
+            err = sendSynchronousCommand(SYNC_CMD_WRITE | SYNC_CMD_WRITE_SDS, conn, auth,
+                                         masteruser, server.masterauth, NULL);
+            sdsfree(masteruser);
+            sdsfree(auth);
             if (err) goto write_error;
             server.repl_state = REPL_STATE_RECEIVE_AUTH;
             return;
         } else if (server.masterauth) {
-            err = sendSynchronousCommand(SYNC_CMD_WRITE,conn,"AUTH",server.masterauth,NULL);
+            sds auth = sdsnew("AUTH");
+            err = sendSynchronousCommand(SYNC_CMD_WRITE | SYNC_CMD_WRITE_SDS, conn, auth,
+                    server.masterauth, NULL);
+            sdsfree(auth);
             if (err) goto write_error;
             server.repl_state = REPL_STATE_RECEIVE_AUTH;
             return;

--- a/src/replication.c
+++ b/src/replication.c
@@ -2172,20 +2172,17 @@ void syncWithMaster(connection *conn) {
 
     /* AUTH with the master if required. */
     if (server.repl_state == REPL_STATE_SEND_AUTH) {
-        if (server.masteruser && server.masterauth) {
-            sds masteruser = sdsnew(server.masteruser);
+        if (server.masterauth) {
             sds auth = sdsnew("AUTH");
-            err = sendSynchronousCommand(SYNC_CMD_WRITE | SYNC_CMD_WRITE_SDS, conn, auth,
-                                         masteruser, server.masterauth, NULL);
-            sdsfree(masteruser);
-            sdsfree(auth);
-            if (err) goto write_error;
-            server.repl_state = REPL_STATE_RECEIVE_AUTH;
-            return;
-        } else if (server.masterauth) {
-            sds auth = sdsnew("AUTH");
-            err = sendSynchronousCommand(SYNC_CMD_WRITE | SYNC_CMD_WRITE_SDS, conn, auth,
-                    server.masterauth, NULL);
+            if (server.masteruser) {
+                sds masteruser = sdsnew(server.masteruser);
+                err = sendSynchronousCommand(SYNC_CMD_WRITE | SYNC_CMD_WRITE_SDS, conn, auth,
+                                             masteruser, server.masterauth, NULL);
+                sdsfree(masteruser);
+            } else {
+                err = sendSynchronousCommand(SYNC_CMD_WRITE | SYNC_CMD_WRITE_SDS, conn, auth,
+                                             server.masterauth, NULL);
+            }
             sdsfree(auth);
             if (err) goto write_error;
             server.repl_state = REPL_STATE_RECEIVE_AUTH;

--- a/src/server.h
+++ b/src/server.h
@@ -1386,7 +1386,7 @@ struct redisServer {
     int repl_diskless_sync_delay;   /* Delay to start a diskless repl BGSAVE. */
     /* Replication (slave) */
     char *masteruser;               /* AUTH with this user and masterauth with master */
-    char *masterauth;               /* AUTH with this password with master */
+    sds masterauth;                 /* AUTH with this password with master */
     char *masterhost;               /* Hostname of master */
     int masterport;                 /* Port of master */
     int repl_timeout;               /* Timeout after N seconds of master idle */

--- a/tests/unit/auth.tcl
+++ b/tests/unit/auth.tcl
@@ -25,3 +25,43 @@ start_server {tags {"auth"} overrides {requirepass foobar}} {
         r incr foo
     } {101}
 }
+
+start_server {tags {"auth_binary_password"}} {
+    test {AUTH fails when binary password is wrong} {
+        r config set requirepass "abc\x00def"
+        catch {r auth abc} err
+        set _ $err
+    } {WRONGPASS*}
+
+    test {AUTH succeeds when binary password is correct} {
+        r config set requirepass "abc\x00def"
+        r auth "abc\x00def"
+    } {OK}
+
+    start_server {tags {"masterauth"}} {
+        set master [srv -1 client]
+        set master_host [srv -1 host]
+        set master_port [srv -1 port]
+        set slave [srv 0 client]
+
+        test {MASTERAUTH test with binary password} {
+            $master config set requirepass "abc\x00def"
+
+            # Configure the replica with masterauth
+            $slave slaveof $master_host $master_port
+            $slave config set masterauth "abc"
+
+            # sleep for 3 seconds and verify replica is not in sync with master
+            $slave debug sleep 3
+            assert_equal {down} [s 0 master_link_status]
+            
+            # Test replica with the correct masterauth
+            $slave config set masterauth "abc\x00def"
+            wait_for_condition 50 100 {
+                [s 0 master_link_status] eq {up}
+            } else {
+                fail "Can't turn the instance into a replica"
+            }
+        }
+    }
+}

--- a/tests/unit/auth.tcl
+++ b/tests/unit/auth.tcl
@@ -48,11 +48,12 @@ start_server {tags {"auth_binary_password"}} {
             $master config set requirepass "abc\x00def"
 
             # Configure the replica with masterauth
+            set loglines [count_log_lines 0]
             $slave slaveof $master_host $master_port
             $slave config set masterauth "abc"
 
-            # sleep for 3 seconds and verify replica is not in sync with master
-            $slave debug sleep 3
+            # Verify replica is not able to sync with master
+            wait_for_log_messages 0 {"*Unable to AUTH to MASTER*"} $loglines 1000 10
             assert_equal {down} [s 0 master_link_status]
             
             # Test replica with the correct masterauth


### PR DESCRIPTION
Previously neither server.requirepass or server.masterauth handles binary safe SDS strings. This leads to inconsistencies in client experience around password authentication. This CR makes REQUIREPASS and MASTERAUTH directives handle binary safe strings and added generic SDS argument support in config.c. 

i.e. On master

```
config set requirepass "ab\x00cd"
OK
AUTH ab
OK
AUTH "ab\x00cd"
(error) WRONGPASS invalid username-password pair
```

After the fix.

```
config set requirepass "ab\x00cd"
OK
AUTH ab
(error) WRONGPASS invalid username-password pair
AUTH "ab\x00cd"
OK
```

Same goes for MASTERAUTH.

See original related PR https://github.com/redis/redis/pull/7236