### PR TITLE
Added Errorstats info section to enable keeping track of the different errors that occur within Redis; Added failed_calls to commandstats

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2560,6 +2560,7 @@ NULL
     } else if (!strcasecmp(c->argv[1]->ptr,"resetstat") && c->argc == 2) {
         resetServerStats();
         resetCommandTableStats();
+        resetErrorTableStats();
         addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"rewrite") && c->argc == 2) {
         if (server.configfile == NULL) {

--- a/src/module.c
+++ b/src/module.c
@@ -1368,18 +1368,6 @@ int RM_ReplyWithLongLong(RedisModuleCtx *ctx, long long ll) {
     return REDISMODULE_OK;
 }
 
-/* Reply with an error or simple string (status message). Used to implement
- * ReplyWithSimpleString() and ReplyWithError().
- * The function always returns REDISMODULE_OK. */
-int replyWithStatus(RedisModuleCtx *ctx, const char *msg, char *prefix) {
-    client *c = moduleGetReplyClient(ctx);
-    if (c == NULL) return REDISMODULE_OK;
-    addReplyProto(c,prefix,strlen(prefix));
-    addReplyProto(c,msg,strlen(msg));
-    addReplyProto(c,"\r\n",2);
-    return REDISMODULE_OK;
-}
-
 /* Reply with the error 'err'.
  *
  * Note that 'err' must contain all the error, including
@@ -1395,7 +1383,10 @@ int replyWithStatus(RedisModuleCtx *ctx, const char *msg, char *prefix) {
  * The function always returns REDISMODULE_OK.
  */
 int RM_ReplyWithError(RedisModuleCtx *ctx, const char *err) {
-    return replyWithStatus(ctx,err,"-");
+    client *c = moduleGetReplyClient(ctx);
+    if (c == NULL) return REDISMODULE_OK;
+    addReplyErrorFormat(c,"-%s",err);
+    return REDISMODULE_OK;
 }
 
 /* Reply with a simple string (+... \r\n in RESP protocol). This replies
@@ -1404,7 +1395,12 @@ int RM_ReplyWithError(RedisModuleCtx *ctx, const char *err) {
  *
  * The function always returns REDISMODULE_OK. */
 int RM_ReplyWithSimpleString(RedisModuleCtx *ctx, const char *msg) {
-    return replyWithStatus(ctx,msg,"+");
+    client *c = moduleGetReplyClient(ctx);
+    if (c == NULL) return REDISMODULE_OK;
+    addReplyProto(c,"+",1);
+    addReplyProto(c,msg,strlen(msg));
+    addReplyProto(c,"\r\n",2);
+    return REDISMODULE_OK;
 }
 
 /* Reply with an array type of 'len' elements. However 'len' other calls

--- a/src/networking.c
+++ b/src/networking.c
@@ -411,15 +411,15 @@ void afterErrorReply(client *c, const char *s, size_t len) {
      * If the string already starts with "-..." then the error prefix
      * is provided by the caller ( we limit the search to 32 chars). Otherwise we use "-ERR". */
     if (s[0] != '-') {
-        incrementError("ERR", 3);
+        incrementErrorCount("ERR", 3);
     } else {
         char* spaceloc = memchr(s, ' ', len < 32 ? len : 32);
         if (spaceloc) {
             const size_t errEndPos = (size_t)(spaceloc - s);
-            incrementError(s+1, errEndPos-1);
+            incrementErrorCount(s+1, errEndPos-1);
         } else {
             /* Fallback to ERR if we can't retrieve the error prefix */
-            incrementError("ERR", 3);
+            incrementErrorCount("ERR", 3);
         }
     }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -413,7 +413,7 @@ void afterErrorReply(client *c, const char *s, size_t len) {
     if (s[0] != '-') {
         incrementErrorCount("ERR", 3);
     } else {
-        char* spaceloc = memchr(s, ' ', len < 32 ? len : 32);
+        char *spaceloc = memchr(s, ' ', len < 32 ? len : 32);
         if (spaceloc) {
             const size_t errEndPos = (size_t)(spaceloc - s);
             incrementErrorCount(s+1, errEndPos-1);

--- a/src/networking.c
+++ b/src/networking.c
@@ -425,8 +425,8 @@ void afterErrorReply(client *c, const char *s, size_t len) {
         if (spaceloc) {
             const size_t errEndPos = (size_t)(spaceloc - s);
             incrementError(s+1, errEndPos-1);
-        /* Fallback to ERR if we can retrieve the error prefix */
         } else {
+            /* Fallback to ERR if we can retrieve the error prefix */
             incrementError("ERR", 3);
         }
     }

--- a/src/networking.c
+++ b/src/networking.c
@@ -405,16 +405,8 @@ void addReplyErrorLength(client *c, const char *s, size_t len) {
 
 /* Do some actions after an error reply was sent (Log if needed, updates stats, etc.) */
 void afterErrorReply(client *c, const char *s, size_t len) {
-    /* Update per command error stats.
-     * If the command was rejected no need to flag it
-     * as a failed count also. */
-    if (c->cmd) {
-        if (c->cmd->flags & CMD_ERR_REJECTED) {
-            c->cmd->rejected_calls++;
-        } else {
-            c->cmd->failed_calls++;
-        }
-    }
+    /* Increment the global error counter */
+    server.stat_total_error_replies++;
     /* Increment the error stats
      * If the string already starts with "-..." then the error prefix
      * is provided by the caller ( we limit the search to 32 chars). Otherwise we use "-ERR". */
@@ -425,7 +417,7 @@ void afterErrorReply(client *c, const char *s, size_t len) {
         if (spaceloc) {
             const size_t errEndPos = (size_t)(spaceloc - s);
             incrementError(s+1, errEndPos-1);
-        /* Fallback to ERR if we can retrieve the error prefix */
+        /* Fallback to ERR if we can't retrieve the error prefix */
         } else {
             incrementError("ERR", 3);
         }

--- a/src/server.c
+++ b/src/server.c
@@ -3986,7 +3986,7 @@ int processCommand(client *c) {
 
 /* ====================== Error lookup and execution ===================== */
 
-void incrementErrorCount(const char* fullerr, size_t namelen) {
+void incrementErrorCount(const char *fullerr, size_t namelen) {
     struct redisError *error = raxFind(server.errors,(unsigned char*)fullerr,namelen);
     if (error == raxNotFound) {
         error = zmalloc(sizeof(*error));

--- a/src/server.c
+++ b/src/server.c
@@ -4714,6 +4714,7 @@ sds genRedisInfoString(const char *section) {
             "tracking_total_items:%lld\r\n"
             "tracking_total_prefixes:%lld\r\n"
             "unexpected_error_replies:%lld\r\n"
+            "total_error_replies:%lld\r\n"
             "dump_payload_sanitizations:%lld\r\n"
             "total_reads_processed:%lld\r\n"
             "total_writes_processed:%lld\r\n"
@@ -4751,6 +4752,7 @@ sds genRedisInfoString(const char *section) {
             (unsigned long long) trackingGetTotalItems(),
             (unsigned long long) trackingGetTotalPrefixes(),
             server.stat_unexpected_error_replies,
+            server.stat_total_error_replies,
             server.stat_dump_payload_sanitizations,
             stat_total_reads_processed,
             stat_total_writes_processed,

--- a/src/server.c
+++ b/src/server.c
@@ -3529,7 +3529,7 @@ void call(client *c, int flags) {
      * We leverage a static variable (prev_err_count) to retain
      * the counter across nested function calls and avoid logging
      * the same error twice. */
-    if ((server.stat_total_error_replies - prev_err_count)>0) {
+    if ((server.stat_total_error_replies - prev_err_count) > 0) {
         real_cmd->failed_calls++;
     }
 
@@ -3986,14 +3986,14 @@ int processCommand(client *c) {
 
 /* ====================== Error lookup and execution ===================== */
 
-void incrementError(const char* fullerr, size_t namelen) {
+void incrementErrorCount(const char* fullerr, size_t namelen) {
     struct redisError *error = raxFind(server.errors,(unsigned char*)fullerr,namelen);
     if (error == raxNotFound) {
         error = zmalloc(sizeof(*error));
         error->count = 0;
         raxInsert(server.errors,(unsigned char*)fullerr,namelen,error,NULL);
     }
-    if (error) error->count++;
+    error->count++;
 }
 
 /*================================== Shutdown =============================== */
@@ -4941,7 +4941,7 @@ sds genRedisInfoString(const char *section) {
         di = dictGetSafeIterator(server.commands);
         while((de = dictNext(di)) != NULL) {
             c = (struct redisCommand *) dictGetVal(de);
-            if (!c->calls && !c->failed_calls &&!c->rejected_calls) 
+            if (!c->calls && !c->failed_calls && !c->rejected_calls)
                 continue;
             info = sdscatprintf(info,
                 "cmdstat_%s:calls=%lld,usec=%lld,usec_per_call=%.2f"
@@ -4962,7 +4962,6 @@ sds genRedisInfoString(const char *section) {
         struct redisError *e;
         while(raxNext(&ri)) {
             e = (struct redisError *) ri.data;
-            if (!e->count) continue;
             info = sdscatprintf(info,
                 "errorstat_%.*s:count=%lld\r\n",
                 (int)ri.key_len, ri.key, e->count);

--- a/src/server.c
+++ b/src/server.c
@@ -3525,7 +3525,10 @@ void call(client *c, int flags) {
     dirty = server.dirty-dirty;
     if (dirty < 0) dirty = 0;
 
-    /* Update failed command calls if required */
+    /* Update failed command calls if required.
+     * We leverage a static variable (prev_err_count) to retain
+     * the counter across nested function calls and avoid logging
+     * the same error twice. */
     if ((server.stat_total_error_replies - prev_err_count)>0) {
         real_cmd->failed_calls++;
     }

--- a/src/server.c
+++ b/src/server.c
@@ -3827,6 +3827,7 @@ int processCommand(client *c) {
                 flagTransaction(c);
             }
             clusterRedirectClient(c,n,hashslot,error_code);
+            c->cmd->rejected_calls++;
             return C_OK;
         }
     }

--- a/src/server.h
+++ b/src/server.h
@@ -2140,7 +2140,7 @@ void populateCommandTable(void);
 void resetCommandTableStats(void);
 void resetErrorTableStats(void);
 void adjustOpenFilesLimit(void);
-void incrementError(const char* fullerr, size_t namelen);
+void incrementErrorCount(const char* fullerr, size_t namelen);
 void closeListeningSockets(int unlink_unix_socket);
 void updateCachedTime(int update_daylight_info);
 void resetServerStats(void);

--- a/src/server.h
+++ b/src/server.h
@@ -209,9 +209,6 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CMD_CATEGORY_TRANSACTION (1ULL<<37)
 #define CMD_CATEGORY_SCRIPTING (1ULL<<38)
 
-/* Command flag used by the error statss. */
-#define CMD_ERR_REJECTED (1ULL<<39)
-
 /* AOF states */
 #define AOF_OFF 0             /* AOF is off */
 #define AOF_ON 1              /* AOF is on */
@@ -1236,6 +1233,7 @@ struct redisServer {
     size_t stat_module_cow_bytes;   /* Copy on write bytes during module fork. */
     uint64_t stat_clients_type_memory[CLIENT_TYPE_COUNT];/* Mem usage by type */
     long long stat_unexpected_error_replies; /* Number of unexpected (aof-loading, replica to master, etc.) error replies */
+    long long stat_total_error_replies; /* Total number of issued error replies ( command + rejected errors ) */
     long long stat_dump_payload_sanitizations; /* Number deep dump payloads integrity validations. */
     long long stat_io_reads_processed; /* Number of read events processed by IO / Main threads */
     long long stat_io_writes_processed; /* Number of write events processed by IO / Main threads */

--- a/src/server.h
+++ b/src/server.h
@@ -2140,7 +2140,7 @@ void populateCommandTable(void);
 void resetCommandTableStats(void);
 void resetErrorTableStats(void);
 void adjustOpenFilesLimit(void);
-void incrementErrorCount(const char* fullerr, size_t namelen);
+void incrementErrorCount(const char *fullerr, size_t namelen);
 void closeListeningSockets(int unlink_unix_socket);
 void updateCachedTime(int update_daylight_info);
 void resetServerStats(void);

--- a/tests/cluster/tests/18-info.tcl
+++ b/tests/cluster/tests/18-info.tcl
@@ -3,7 +3,7 @@
 source "../tests/includes/init-tests.tcl"
 
 test "Create a primary with a replica" {
-    create_cluster 2 2
+    create_cluster 2 0
 }
 
 test "Cluster should start ok" {
@@ -12,8 +12,6 @@ test "Cluster should start ok" {
 
 set primary1 [Rn 0]
 set primary2 [Rn 1]
-set replica1 [Rn 2]
-set replica2 [Rn 3]
 
 proc cmdstat {instace cmd} {
     return [cmdrstat $cmd $instace]
@@ -28,19 +26,11 @@ test "errorstats: rejected call due to MOVED Redirection" {
     $primary2 config resetstat
     assert_match {} [errorstat $primary1 MOVED]
     assert_match {} [errorstat $primary2 MOVED]
-    # we know that one of the commands will have a MOVED reply
-    catch {$primary1 set a b} replyP1
-    catch {$primary2 set a b} replyP2
-    if { [string range $replyP1 0 4] eq {MOVED} } {
-        assert_match {*count=1*} [errorstat $primary1 MOVED]
-        assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat $primary1 set]
-        assert_match {OK} $replyP2
-        assert_match {} [errorstat $primary2 MOVED]
-    }
-    if { [string range $replyP2 0 4] eq {MOVED} } {
-        assert_match {*count=1*} [errorstat $primary2 MOVED]
-        assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat $primary2 set]
-        assert_match {OK} $replyP1
-        assert_match {} [errorstat $primary1 MOVED]
-    }
+    # we know that the primary 2 will have a MOVED reply
+    catch {$primary1 set key{0x0000} b} replyP1
+    catch {$primary2 set key{0x0000} b} replyP2
+    assert_match {OK} $replyP1
+    assert_match {} [errorstat $primary1 MOVED]
+    assert_match {*count=1*} [errorstat $primary2 MOVED]
+    assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat $primary2 set]
 }

--- a/tests/cluster/tests/18-info.tcl
+++ b/tests/cluster/tests/18-info.tcl
@@ -1,0 +1,46 @@
+# Check cluster info stats
+
+source "../tests/includes/init-tests.tcl"
+
+test "Create a primary with a replica" {
+    create_cluster 2 2
+}
+
+test "Cluster should start ok" {
+    assert_cluster_state ok
+}
+
+set primary1 [Rn 0]
+set primary2 [Rn 1]
+set replica1 [Rn 2]
+set replica2 [Rn 3]
+
+proc cmdstat {instace cmd} {
+    return [cmdrstat $cmd $instace]
+}
+
+proc errorstat {instace cmd} {
+    return [errorrstat $cmd $instace]
+}
+
+test "errorstats: rejected call due to MOVED Redirection" {
+    $primary1 config resetstat
+    $primary2 config resetstat
+    assert_match {} [errorstat $primary1 MOVED]
+    assert_match {} [errorstat $primary2 MOVED]
+    # we know that one of the commands will have a MOVED reply
+    catch {$primary1 set a b} replyP1
+    catch {$primary2 set a b} replyP2
+    if { [string range $replyP1 0 4] eq {MOVED} } {
+        assert_match {*count=1*} [errorstat $primary1 MOVED]
+        assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat $primary1 set]
+        assert_match {OK} $replyP2
+        assert_match {} [errorstat $primary2 MOVED]
+    }
+    if { [string range $replyP2 0 4] eq {MOVED} } {
+        assert_match {*count=1*} [errorstat $primary2 MOVED]
+        assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat $primary2 set]
+        assert_match {OK} $replyP1
+        assert_match {} [errorstat $primary1 MOVED]
+    }
+}

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -561,6 +561,12 @@ proc cmdrstat {cmd r} {
     }
 }
 
+proc errorrstat {cmd r} {
+    if {[regexp "\r\nerrorstat_$cmd:(.*?)\r\n" [$r info errorstats] _ value]} {
+        set _ $value
+    }
+}
+
 proc generate_fuzzy_traffic_on_key {key duration} {
     # Commands per type, blocking commands removed
     # TODO: extract these from help.h or elsewhere, and improve to include other types

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -555,12 +555,6 @@ proc get_child_pid {idx} {
     return $child_pid
 }
 
-proc statsrstat {key r} {
-    if {[regexp "\r\n$key:(.*?)\r\n" [$r info stats] _ value]} {
-        set _ $value
-    }
-}
-
 proc cmdrstat {cmd r} {
     if {[regexp "\r\ncmdstat_$cmd:(.*?)\r\n" [$r info commandstats] _ value]} {
         set _ $value

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -555,6 +555,12 @@ proc get_child_pid {idx} {
     return $child_pid
 }
 
+proc statsrstat {key r} {
+    if {[regexp "\r\n$key:(.*?)\r\n" [$r info stats] _ value]} {
+        set _ $value
+    }
+}
+
 proc cmdrstat {cmd r} {
     if {[regexp "\r\ncmdstat_$cmd:(.*?)\r\n" [$r info commandstats] _ value]} {
         set _ $value

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -18,6 +18,7 @@ set ::all_tests {
     unit/protocol
     unit/keyspace
     unit/scan
+    unit/info
     unit/type/string
     unit/type/incr
     unit/type/list

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -82,6 +82,22 @@ start_server {tags {"info"}} {
             assert_match {} [errorstat ERR]
         }
 
+        test {errorstats: rejected call within MULTI/EXEC} {
+            r config resetstat
+            assert_match {} [errorstat ERR]
+            r multi
+            catch {r set} e
+            assert_match {ERR wrong number of arguments*} $e
+            catch {r exec} e
+            assert_match {EXECABORT*} $e
+            assert_match {*count=1*} [errorstat ERR]
+            assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat set]
+            assert_match {*calls=1,*,rejected_calls=0,failed_calls=0} [cmdstat multi]
+            assert_match {*calls=1,*,rejected_calls=0,failed_calls=0} [cmdstat exec]
+            r config resetstat
+            assert_match {} [errorstat ERR]
+        }
+
         test {errorstats: rejected call due to wrong arity} {
             r config resetstat
             assert_match {} [errorstat ERR]

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -33,6 +33,16 @@ start_server {tags {"info"}} {
             assert_match {} [errorstat NOGROUP]
         }
 
+        test {errorstats: rejected call unknown command} {
+            r config resetstat
+            assert_match {} [errorstat ERR]
+            catch {r asdf} e
+            assert_match {ERR unknown*} $e
+            assert_match {*count=1*} [errorstat ERR]
+            r config resetstat
+            assert_match {} [errorstat ERR]
+        }
+
         test {errorstats: rejected call due to wrong arity} {
             r config resetstat
             assert_match {} [errorstat ERR]

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -1,0 +1,74 @@
+proc cmdstat {cmd} {
+    return [cmdrstat $cmd r]
+}
+
+proc errorstat {cmd} {
+    return [errorrstat $cmd r]
+}
+
+start_server {tags {"info"}} {
+    start_server {} {
+
+        test {errorstats: failed call authentication error} {
+            r config resetstat
+            assert_match {} [errorstat ERR]
+            catch {r auth k} e
+            assert_match {ERR AUTH*} $e
+            assert_match {*count=1*} [errorstat ERR]
+            assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat auth]
+            r config resetstat
+            assert_match {} [errorstat ERR]
+        }
+
+        test {errorstats: failed call NOGROUP error} {
+            r config resetstat
+            assert_match {} [errorstat NOGROUP]
+            r del mystream
+            r XADD mystream * f v
+            catch {r XGROUP CREATECONSUMER mystream mygroup consumer} e
+            assert_match {NOGROUP*} $e
+            assert_match {*count=1*} [errorstat NOGROUP]
+            assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat xgroup]
+            r config resetstat
+            assert_match {} [errorstat NOGROUP]
+        }
+
+        test {errorstats: rejected call due to wrong arity} {
+            r config resetstat
+            assert_match {} [errorstat ERR]
+            catch {r set k} e
+            assert_match {ERR wrong number of arguments*} $e
+            assert_match {*count=1*} [errorstat ERR]
+            assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat set]
+            # ensure that after a rejected command, valid ones are counted properly
+            r set k1 v1
+            r set k2 v2
+            assert_match {calls=2,*,rejected_calls=1,failed_calls=0} [cmdstat set]
+        }
+
+        test {errorstats: rejected call by OOM error} {
+            r config resetstat
+            assert_match {} [errorstat OOM]
+            r config set maxmemory 1
+            catch {r set a b} e
+            assert_match {OOM*} $e
+            assert_match {*count=1*} [errorstat OOM]
+            assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat set]
+            r config resetstat
+            assert_match {} [errorstat OOM]
+        }
+
+        test {errorstats: rejected call by authorization error} {
+            r config resetstat
+            assert_match {} [errorstat NOPERM]
+            r ACL SETUSER alice on >p1pp0 ~cached:* +get +info +config
+            r auth alice p1pp0
+            catch {r set a b} e
+            assert_match {NOPERM*} $e
+            assert_match {*count=1*} [errorstat NOPERM]
+            assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat set]
+            r config resetstat
+            assert_match {} [errorstat NOPERM]
+        }
+    }
+}

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -45,8 +45,7 @@ start_server {tags {"info"}} {
         test {errorstats: failed call within LUA} {
             r config resetstat
             assert_match {} [errorstat ERR]
-            catch {r eval {return redis.pcall('XGROUP', 'CREATECONSUMER', 's1', 'mygroup', 'consumer')} 0} e
-            assert_match {ERR The XGROUP subcommand requires the key to exist*} $e
+            catch {r eval {redis.pcall('XGROUP', 'CREATECONSUMER', 's1', 'mygroup', 'consumer') return } 0} e
             assert_match {*count=1*} [errorstat ERR]
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat xgroup]
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=0} [cmdstat eval]

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -6,22 +6,18 @@ proc errorstat {cmd} {
     return [errorrstat $cmd r]
 }
 
-proc serverstat {cmd} {
-    return [statsrstat $cmd r]
-}
-
 start_server {tags {"info"}} {
     start_server {} {
 
         test {errorstats: failed call authentication error} {
             r config resetstat
             assert_match {} [errorstat ERR]
-            assert_match {0} [serverstat total_error_replies]
+            assert_equal [s total_error_replies] 0
             catch {r auth k} e
             assert_match {ERR AUTH*} $e
             assert_match {*count=1*} [errorstat ERR]
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat auth]
-            assert_match {1} [serverstat total_error_replies]
+            assert_equal [s total_error_replies] 1
             r config resetstat
             assert_match {} [errorstat ERR]
         }
@@ -29,7 +25,7 @@ start_server {tags {"info"}} {
         test {errorstats: failed call within MULTI/EXEC} {
             r config resetstat
             assert_match {} [errorstat ERR]
-            assert_match {0} [serverstat total_error_replies]
+            assert_equal [s total_error_replies] 0
             r multi
             r set a b
             r auth a
@@ -39,32 +35,31 @@ start_server {tags {"info"}} {
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=0} [cmdstat set]
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat auth]
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=0} [cmdstat exec]
-            assert_match {1} [serverstat total_error_replies]
-            r config resetstat
-            assert_match {} [errorstat ERR]
+            assert_equal [s total_error_replies] 1
 
             # MULTI/EXEC command errors should still be pinpointed to him
             catch {r exec} e
             assert_match {ERR EXEC without MULTI} $e
-            assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat exec]
-            assert_match {*count=1*} [errorstat ERR]
+            assert_match {*calls=2,*,rejected_calls=0,failed_calls=1} [cmdstat exec]
+            assert_match {*count=2*} [errorstat ERR]
+            assert_equal [s total_error_replies] 2
         }
 
         test {errorstats: failed call within LUA} {
             r config resetstat
             assert_match {} [errorstat ERR]
+            assert_equal [s total_error_replies] 0
             catch {r eval {redis.pcall('XGROUP', 'CREATECONSUMER', 's1', 'mygroup', 'consumer') return } 0} e
             assert_match {*count=1*} [errorstat ERR]
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat xgroup]
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=0} [cmdstat eval]
-            r config resetstat
-            assert_match {} [errorstat ERR]
 
             # EVAL command errors should still be pinpointed to him
             catch {r eval a} e
             assert_match {ERR wrong*} $e
-            assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat eval]
-            assert_match {*count=1*} [errorstat ERR]
+            assert_match {*calls=1,*,rejected_calls=1,failed_calls=0} [cmdstat eval]
+            assert_match {*count=2*} [errorstat ERR]
+            assert_equal [s total_error_replies] 2
         }
 
         test {errorstats: failed call NOGROUP error} {
@@ -82,18 +77,19 @@ start_server {tags {"info"}} {
 
         test {errorstats: rejected call unknown command} {
             r config resetstat
-            assert_match {0} [serverstat total_error_replies]
+            assert_equal [s total_error_replies] 0
             assert_match {} [errorstat ERR]
             catch {r asdf} e
             assert_match {ERR unknown*} $e
             assert_match {*count=1*} [errorstat ERR]
-            assert_match {1} [serverstat total_error_replies]
+            assert_equal [s total_error_replies] 1
             r config resetstat
             assert_match {} [errorstat ERR]
         }
 
         test {errorstats: rejected call within MULTI/EXEC} {
             r config resetstat
+            assert_equal [s total_error_replies] 0
             assert_match {} [errorstat ERR]
             r multi
             catch {r set} e
@@ -101,15 +97,18 @@ start_server {tags {"info"}} {
             catch {r exec} e
             assert_match {EXECABORT*} $e
             assert_match {*count=1*} [errorstat ERR]
+            assert_equal [s total_error_replies] 1
             assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat set]
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=0} [cmdstat multi]
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=0} [cmdstat exec]
+            assert_equal [s total_error_replies] 1
             r config resetstat
             assert_match {} [errorstat ERR]
         }
 
         test {errorstats: rejected call due to wrong arity} {
             r config resetstat
+            assert_equal [s total_error_replies] 0
             assert_match {} [errorstat ERR]
             catch {r set k} e
             assert_match {ERR wrong number of arguments*} $e
@@ -119,22 +118,26 @@ start_server {tags {"info"}} {
             r set k1 v1
             r set k2 v2
             assert_match {calls=2,*,rejected_calls=1,failed_calls=0} [cmdstat set]
+            assert_equal [s total_error_replies] 1
         }
 
         test {errorstats: rejected call by OOM error} {
             r config resetstat
+            assert_equal [s total_error_replies] 0
             assert_match {} [errorstat OOM]
             r config set maxmemory 1
             catch {r set a b} e
             assert_match {OOM*} $e
             assert_match {*count=1*} [errorstat OOM]
             assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat set]
+            assert_equal [s total_error_replies] 1
             r config resetstat
             assert_match {} [errorstat OOM]
         }
 
         test {errorstats: rejected call by authorization error} {
             r config resetstat
+            assert_equal [s total_error_replies] 0
             assert_match {} [errorstat NOPERM]
             r ACL SETUSER alice on >p1pp0 ~cached:* +get +info +config
             r auth alice p1pp0
@@ -142,6 +145,7 @@ start_server {tags {"info"}} {
             assert_match {NOPERM*} $e
             assert_match {*count=1*} [errorstat NOPERM]
             assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat set]
+            assert_equal [s total_error_replies] 1
             r config resetstat
             assert_match {} [errorstat NOPERM]
         }


### PR DESCRIPTION
this PR pushes forward the observability on overall error statistics and command statistics within redis-server:

- It extends `INFO COMMANDSTATS` to have
  - failed_calls in - so we can keep track of errors that happen from the command itself, broken by command.
  - rejected_calls - so we can keep track of errors that were triggered outside the commmand processing per se ( example of wrong arity, oom, etc... )
Sample ( notice rejected_calls ):
  ```
  127.0.0.1:6379> set k 
  (error) ERR wrong number of arguments for 'set' command
  127.0.0.1:6379> info commandstats
  # Commandstats
  cmdstat_set:calls=0,usec=0,usec_per_call=0.00,rejected_calls=1,failed_calls=0
  cmdstat_info:calls=8,usec=1077,usec_per_call=134.62,rejected_calls=0,failed_calls=0
  ```

- Adds a new section to INFO, named `ERRORSTATS` that enables keeping track of the different errors that occur within redis ( within processCommand and call ) based uppong the reply Error Prefix ( The first word after the "-", up to the first space ). 
  
  Sample:
  ```
  127.0.0.1:6379> auth a
  (error) ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?
  127.0.0.1:6379> set k
  (error) ERR wrong number of arguments for 'set' command
  127.0.0.1:6379> ACL SETUSER alice on >p1pp0 ~cached:* +get +info
  OK
  127.0.0.1:6379> auth alice p1pp0
  OK
  127.0.0.1:6379> set a b
  (error) NOPERM this user has no permissions to run the 'set' command or its subcommand
  127.0.0.1:6379> info errorstats
  # Errorstats
  errorstat_ERR:count=2
  errorstat_NOPERM:count=1
  ```


- This PR also fixes RM_ReplyWithError so that it can be correctly identified as an error reply.

---
To test the added features:
```
tclsh tests/test_helper.tcl --verbose --single unit/info
tclsh tests/cluster/run.tcl --single tests/18-info.tcl
```

The added tests are divided as follow:
- **failed** call authentication error
- **failed** call NOGROUP error
- **rejected** call due to wrong arity
- **rejected** call by OOM error
- **rejected** call by authorization error
- **rejected** call rejected due to MOVED Redirection