### PR TITLE
Fix redundancy incrRefCount in lmoveGenericCommand

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -729,10 +729,6 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
         if (checkType(c,dobj,OBJ_LIST)) return;
         value = listTypePop(sobj,wherefrom);
         serverAssert(value); /* assertion for valgrind (avoid NPD) */
-        /* We saved touched key, and protect it, since lmoveHandlePush
-         * may change the client command argument vector (it does not
-         * currently). */
-        incrRefCount(touchedkey);
         lmoveHandlePush(c,c->argv[2],dobj,value,whereto);
 
         /* listTypePop returns an object with its refcount incremented */
@@ -749,7 +745,6 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
                                 touchedkey,c->db->id);
         }
         signalModifiedKey(c,c->db,touchedkey);
-        decrRefCount(touchedkey);
         server.dirty++;
         if (c->cmd->proc == blmoveCommand) {
             rewriteClientCommandVector(c,5,shared.lmove,


### PR DESCRIPTION
incrRefCount(touchedkey) because rpoplpushHandlePush may change the client command argument vector, rpoplpushHandlePush has been modify to lmoveHandlePush, lmoveHandlePush does not change the client command argument vector.

related to [Fix for bug 561 and other related problems](https://github.com/redis/redis/commit/c1c9d551da6dd534c8dae051a3a7e64bf7db6bfb)