### PR TITLE
add hrandmember command

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -587,6 +587,10 @@ struct redisCommand redisCommandTable[] = {
      "read-only fast @hash",
      0,NULL,1,1,1,0,0,0},
 
+    {"hrandmember",hrandmemberCommand,-2,
+     "read-only random @hash",
+     0,NULL,1,1,1,0,0,0},
+
     {"hscan",hscanCommand,-3,
      "read-only random @hash",
      0,NULL,1,1,1,0,0,0},

--- a/src/server.h
+++ b/src/server.h
@@ -2514,6 +2514,7 @@ void hvalsCommand(client *c);
 void hgetallCommand(client *c);
 void hexistsCommand(client *c);
 void hscanCommand(client *c);
+void hrandmemberCommand(client *c);
 void configCommand(client *c);
 void hincrbyCommand(client *c);
 void hincrbyfloatCommand(client *c);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -925,8 +925,8 @@ void hscanCommand(client *c) {
 
 #define HRANDMEMBER_SUB_STRATEGY_MUL 3
 
-void hrandmemberWithCountCommand(client *c, long entryCount) {
-    unsigned long hashSize;
+void hrandmemberWithCountCommand(client *c, long l) {
+    unsigned long entryCount, hashSize;
     hashTypeIterator *hi;
     robj *hash;
     dict *d;
@@ -938,6 +938,7 @@ void hrandmemberWithCountCommand(client *c, long entryCount) {
         == NULL || checkType(c,hash,OBJ_HASH)) return;
 
     hashSize = hashTypeLength(hash);
+    entryCount = (unsigned long) l;
     if(entryCount > hashSize)
         entryCount = hashSize;
     addReplyMapLen(c, entryCount);

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -18,6 +18,140 @@ start_server {tags {"hash"}} {
         assert_encoding ziplist smallhash
     }
 
+    proc create_hash {key entries} {
+        r del $key
+        foreach entry $entries { r hset $key $entry 1 }
+    }
+
+    foreach {type contents} "ziplist {1 2 3} hashtable {a b c[randstring 70 90 alpha]}" {
+
+        test "HRANDMEMBER - $type" {
+            create_hash myhash $contents;
+            assert_encoding $type myhash
+            unset -nocomplain myhash
+            array set myhash {}
+            for {set i 0} {$i < 100} {incr i} {
+                lassign [r hrandmember myhash] key val
+                set myhash($key) $val
+            }
+            assert_equal [lsort $contents] [lsort [array names myhash]]
+        }
+    }
+
+
+    test "HRANDMEMBER with <count> against non existing key" {
+        r hrandmember nonexisting_key 100
+    } {}
+
+    foreach {type contents} "
+        hashtable {
+            1 5 10 50 125 50000 33959417 4775547 65434162
+            12098459 427716 483706 2726473884 72615637475
+            MARY PATRICIA LINDA BARBARA ELIZABETH JENNIFER MARIA
+            SUSAN MARGARET DOROTHY LISA NANCY KAREN BETTY HELEN
+            SANDRA DONNA CAROL RUTH SHARON MICHELLE LAURA SARAH
+            KIMBERLY DEBORAH JESSICA SHIRLEY CYNTHIA ANGELA MELISSA
+            BRENDA AMY ANNA REBECCA VIRGINIA c[randstring 70 90 alpha]
+        }
+        ziplist {
+            0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
+            20 21 22 23 24 25 26 27 28 2d9
+            30 31 32 33 34 35 36 37 38 39
+            40 41 42 43 44 45 46 47 48 49
+        }
+    " {
+        test "HRANDMEMBER with <count> - $type" {
+            create_hash myhash $contents
+            unset -nocomplain myhash
+            foreach ele [r hkeys myhash] {
+                dict append myhash $ele 1
+            }
+            assert_equal [lsort $contents] [lsort [dict keys $myhash]]
+
+            # Make sure that a count of 0 is handled correctly.
+            assert_equal [r hrandmember myhash 0] {}
+
+            # We'll stress different parts of the code, see the implementation
+            # of HRANDMEMBER for more information, but basically there are
+            # four different code paths.
+            #
+            # PATH 1: Use negative count.
+            #
+            # 1) Check that it returns repeated elements.
+            set res [r hrandmember myhash 100]
+            # assert_equal [llength $res] 200
+            # If not asked, decide not to implement this feature.
+
+            # 2) Check that all the elements actually belong to the
+            # original set.
+            foreach {key val} $res {
+                assert {[dict exists $myhash $key]}
+            }
+
+            # 3) Check that eventually all the elements are returned.
+            unset -nocomplain auxset
+            set iterations 1000
+            while {$iterations != 0} {
+                incr iterations -1
+                set res [r hrandmember myhash -10]
+                foreach {key val} $res {
+                    dict append auxset $key $val
+                }
+                if {[lsort [dict keys $myhash]] eq
+                    [lsort [dict keys $auxset]]} {
+                    break;
+                }
+            }
+            assert {$iterations != 0}
+
+            # PATH 2: positive count (unique behavior) with requested size
+            # equal or greater than set size.
+            foreach size {50 100} {
+                set res [r hrandmember myhash $size]
+                assert_equal [dict size $res] 50
+                assert_equal [lsort [dict keys $res]] [lsort [dict keys $myhash]]
+            }
+
+            # PATH 3: Ask almost as elements as there are in the set.
+            # In this case the implementation will duplicate the original
+            # set and will remove random elements up to the requested size.
+            #
+            # PATH 4: Ask a number of elements definitely smaller than
+            # the set size.
+            #
+            # We can test both the code paths just changing the size but
+            # using the same code.
+
+            foreach size {45 5} {
+                set res [r hrandmember myhash $size]
+                assert_equal [dict size $res] $size
+
+                # 1) Check that all the elements actually belong to the
+                # original set.
+                foreach ele [dict keys $res] {
+                    assert {[dict exists $myhash $ele]}
+                }
+
+                # 2) Check that eventually all the elements are returned.
+                unset -nocomplain auxset
+                set iterations 1000
+                while {$iterations != 0} {
+                    incr iterations -1
+                    set res [r hrandmember myhash -10]
+                    foreach {key value} $res {
+                        dict append auxset $key $value
+                    }
+                    if {[lsort [dict keys $myhash]] eq
+                        [lsort [dict keys $auxset]]} {
+                        break;
+                    }
+                }
+                assert {$iterations != 0}
+            }
+        }
+    }
+
+
     test {HSET/HLEN - Big hash creation} {
         array set bighash {}
         for {set i 0} {$i < 1024} {incr i} {

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -73,38 +73,9 @@ start_server {tags {"hash"}} {
 
             # We'll stress different parts of the code, see the implementation
             # of HRANDMEMBER for more information, but basically there are
-            # four different code paths.
-            #
-            # PATH 1: Use negative count.
-            #
-            # 1) Check that it returns repeated elements.
-            set res [r hrandmember myhash 100]
-            # assert_equal [llength $res] 200
-            # If not asked, decide not to implement this feature.
+            # three different code paths.
 
-            # 2) Check that all the elements actually belong to the
-            # original set.
-            foreach {key val} $res {
-                assert {[dict exists $myhash $key]}
-            }
-
-            # 3) Check that eventually all the elements are returned.
-            unset -nocomplain auxset
-            set iterations 1000
-            while {$iterations != 0} {
-                incr iterations -1
-                set res [r hrandmember myhash -10]
-                foreach {key val} $res {
-                    dict append auxset $key $val
-                }
-                if {[lsort [dict keys $myhash]] eq
-                    [lsort [dict keys $auxset]]} {
-                    break;
-                }
-            }
-            assert {$iterations != 0}
-
-            # PATH 2: positive count (unique behavior) with requested size
+            # PATH 1: positive count (unique behavior) with requested size
             # equal or greater than set size.
             foreach size {50 100} {
                 set res [r hrandmember myhash $size]
@@ -112,11 +83,11 @@ start_server {tags {"hash"}} {
                 assert_equal [lsort [dict keys $res]] [lsort [dict keys $myhash]]
             }
 
-            # PATH 3: Ask almost as elements as there are in the set.
+            # PATH 2: Ask almost as elements as there are in the set.
             # In this case the implementation will duplicate the original
             # set and will remove random elements up to the requested size.
             #
-            # PATH 4: Ask a number of elements definitely smaller than
+            # PATH 3: Ask a number of elements definitely smaller than
             # the set size.
             #
             # We can test both the code paths just changing the size but
@@ -137,7 +108,7 @@ start_server {tags {"hash"}} {
                 set iterations 1000
                 while {$iterations != 0} {
                     incr iterations -1
-                    set res [r hrandmember myhash -10]
+                    set res [r hrandmember myhash 10]
                     foreach {key value} $res {
                         dict append auxset $key $value
                     }


### PR DESCRIPTION
Last week, I met the same problem as [this question posted on stackoverflow](https://stackoverflow.com/questions/17211639/get-random-any-value-from-redis-hash) . It seems that it's a common feature which is needed since a long time ago.

I know the code may looks like a shit, but as a user of redis, I hope the feature will be added before long.

And the new command `hrandmember` for now doesn't behave like `srandmember` when it comes to negative count, as you may concern