### PR TITLE
Add check for the MADV_FREE/fork arm64 Linux kernel bug

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1976,3 +1976,10 @@ jemalloc-bg-thread yes
 #
 # Set bgsave child process to cpu affinity 1,10,11
 # bgsave_cpulist 1,10-11
+
+# In some cases redis will emit warnings and even refuse to start if it detects
+# that the system is in bad state, it is possible to suppress these warnings
+# by setting the following config which takes a space delimited list of warnings
+# to suppress
+#
+# ignore-warnings ARM64-COW-BUG

--- a/src/config.c
+++ b/src/config.c
@@ -2424,6 +2424,7 @@ standardConfig configs[] = {
     createStringConfig("bio_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.bio_cpulist, NULL, NULL, NULL),
     createStringConfig("aof_rewrite_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.aof_rewrite_cpulist, NULL, NULL, NULL),
     createStringConfig("bgsave_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.bgsave_cpulist, NULL, NULL, NULL),
+    createStringConfig("ignore-warnings", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.ignore_warnings, "", NULL, NULL),
 
     /* SDS Configs */
     createSDSConfig("masterauth", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.masterauth, NULL, NULL, NULL),

--- a/src/server.c
+++ b/src/server.c
@@ -5097,7 +5097,7 @@ void linuxMemoryWarnings(void) {
     }
 }
 
-#ifdef __arm__
+#ifdef __arm64__
 
 /* Get size in kilobytes of the Shared_Dirty pages of the specified pid for the
  * memory map corresponding to the provided address, or -1 on error. */
@@ -5196,7 +5196,7 @@ int linuxMadvFreeForkBugCheck(void) {
 
     return bug_found;
 }
-#endif /* __arm__ */
+#endif /* __arm64__ */
 #endif /* __linux__ */
 
 void createPidFile(void) {
@@ -5773,7 +5773,7 @@ int main(int argc, char **argv) {
         serverLog(LL_WARNING,"Server initialized");
     #ifdef __linux__
         linuxMemoryWarnings();
-    #if defined (__arm__)
+    #if defined (__arm64__)
         if (linuxMadvFreeForkBugCheck()) {
             serverLog(LL_WARNING,"WARNING Your kernel has a bug that could lead to data corruption during background save. Please upgrade to the latest stable kernel.");
             if (!CheckIgnoreWarning("ARM64-COW-BUG")) {
@@ -5781,7 +5781,7 @@ int main(int argc, char **argv) {
                 exit(1);
             }
         }
-    #endif /* __arm__ */
+    #endif /* __arm64__ */
     #endif /* __linux__ */
         moduleInitModulesSystemLast();
         moduleLoadFromQueue();

--- a/src/server.c
+++ b/src/server.c
@@ -5776,8 +5776,10 @@ int main(int argc, char **argv) {
     #if defined (__arm__)
         if (linuxMadvFreeForkBugCheck()) {
             serverLog(LL_WARNING,"WARNING Your kernel has a bug that could lead to data corruption during background save. Please upgrade to the latest stable kernel.");
-            if (!CheckIgnoreWarning("ARM64-COW-BUG"))
+            if (!CheckIgnoreWarning("ARM64-COW-BUG")) {
+                serverLog(LL_WARNING,"Reids will now exit to prevent data corruption. note that it is possible to suppress this warning by setting the follwoing config: ignore-warnings ARM64-COW-BUG");
                 exit(1);
+            }
         }
     #endif /* __arm__ */
     #endif /* __linux__ */

--- a/src/server.c
+++ b/src/server.c
@@ -5058,7 +5058,7 @@ void monitorCommand(client *c) {
 
 /* =================================== Main! ================================ */
 
-int CheckIgnoreWarning(const char *warning) {
+int checkIgnoreWarning(const char *warning) {
     int argc, j;
     sds *argv = sdssplitargs(server.ignore_warnings, &argc);
     if (argv == NULL)
@@ -5782,7 +5782,7 @@ int main(int argc, char **argv) {
     #if defined (__arm64__)
         if (linuxMadvFreeForkBugCheck()) {
             serverLog(LL_WARNING,"WARNING Your kernel has a bug that could lead to data corruption during background save. Please upgrade to the latest stable kernel.");
-            if (!CheckIgnoreWarning("ARM64-COW-BUG")) {
+            if (!checkIgnoreWarning("ARM64-COW-BUG")) {
                 serverLog(LL_WARNING,"Redis will now exit to prevent data corruption. Note that it is possible to suppress this warning by setting the following config: ignore-warnings ARM64-COW-BUG");
                 exit(1);
             }

--- a/src/server.c
+++ b/src/server.c
@@ -5101,16 +5101,13 @@ void linuxMemoryWarnings(void) {
 
 /* Get size in kilobytes of the Shared_Dirty pages of the calling process for the
  * memory map corresponding to the provided address, or -1 on error. */
-static int smapsGetSharedDirty(pid_t pid, unsigned long addr) {
+static int smapsGetSharedDirty(unsigned long addr) {
     int ret, in_mapping = 0, val = -1;
     unsigned long from, to;
     char buf[64];
     FILE *f;
 
-    ret = snprintf(buf, sizeof(buf), "/proc/%d/smaps", pid);
-    serverAssert((unsigned int)ret < sizeof(buf));
-
-    f = fopen(buf, "r");
+    f = fopen("/proc/self/smaps", "r");
     serverAssert(f);
 
     while (1) {
@@ -5170,7 +5167,7 @@ int linuxMadvFreeForkBugCheck(void) {
     if (!pid) {
         /* Child: check if the page is marked as dirty, expecing 4 (kB).
          * A value of 0 means the kernel is affected by the bug. */
-        if (!smapsGetSharedDirty(getpid(), (unsigned long)p))
+        if (!smapsGetSharedDirty((unsigned long)q))
             bug_found = 1;
 
         ret = write(pipefd[1], &bug_found, 1);

--- a/src/server.h
+++ b/src/server.h
@@ -1137,6 +1137,7 @@ struct redisServer {
     int in_eval;                /* Are we inside EVAL? */
     int in_exec;                /* Are we inside EXEC? */
     int propagate_in_transaction;  /* Make sure we don't propagate nested MULTI/EXEC */
+    char *ignore_warnings;      /* Config: warnings that should be ignored. */
     /* Modules */
     dict *moduleapi;            /* Exported core APIs dictionary for modules. */
     dict *sharedapi;            /* Like moduleapi but containing the APIs that


### PR DESCRIPTION
Older arm64 Linux kernels have a bug that could lead to data corruption during
background save under the following scenario:

1) jemalloc uses MADV_FREE on a page,
2) jemalloc reuses and writes the page,
3) Redis forks the background save process, and
4) Linux performs page reclamation.

Under these conditions, Linux will reclaim the page wrongfully and the
background save process will read zeros when it tries to read the page.

The bug has been fixed in Linux with commit:
ff1712f953e27f0b0718762ec17d0adb15c9fd0b ("arm64: pgtable: Ensure dirty bit is
preserved across pte_wrprotect()")