### PR TITLE
Throw and handle errors related to event loop failures

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -650,6 +650,14 @@ static void clusterConnAcceptHandler(connection *conn) {
         return;
     }
 
+    /* Register read handler */
+    if (connSetReadHandler(conn, clusterReadHandler) != C_OK) {
+        serverLog(LL_VERBOSE,
+                "Error registering read handler on cluster connection: %s", connGetLastError(conn));
+        connClose(conn);
+        return;
+    }
+
     /* Create a link object we use to handle the connection.
      * It gets passed to the readable handler when data is available.
      * Initially the link->node pointer is set to NULL as we don't know
@@ -658,9 +666,6 @@ static void clusterConnAcceptHandler(connection *conn) {
     link = createClusterLink(NULL);
     link->conn = conn;
     connSetPrivateData(conn, link);
-
-    /* Register read handler */
-    connSetReadHandler(conn, clusterReadHandler);
 }
 
 #define MAX_CLUSTER_ACCEPTS_PER_CALL 1000

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2242,7 +2242,9 @@ void clusterWriteHandler(connection *conn) {
     sdsrange(link->sndbuf,nwritten,-1);
     if (sdslen(link->sndbuf) == 0) {
         if (connSetWriteHandler(link->conn, NULL) == C_ERR) {
-            serverPanic("Unrecoverable setting write handler for cluster link.");
+            serverPanic("Error setting write handler for cluster link: %s",
+                connGetLastError(conn));
+            handleLinkIOError(link);
         }
     }
         

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2242,9 +2242,10 @@ void clusterWriteHandler(connection *conn) {
     sdsrange(link->sndbuf,nwritten,-1);
     if (sdslen(link->sndbuf) == 0) {
         if (connSetWriteHandler(link->conn, NULL) == C_ERR) {
-            serverPanic("Error setting write handler for cluster link: %s",
+            serverLog(LL_WARNING, "Error setting write handler for cluster link: %s",
                 connGetLastError(conn));
             handleLinkIOError(link);
+            return;
         }
     }
         

--- a/src/connection.c
+++ b/src/connection.c
@@ -250,7 +250,7 @@ static int connSocketSetReadHandler(connection *conn, ConnectionCallbackFunc fun
         aeDeleteFileEvent(server.el,conn->fd,AE_READABLE);
     else
         if (aeCreateFileEvent(server.el,conn->fd,
-                    AE_READABLE,conn->type->ae_handler,conn) == AE_ERR)
+                    AE_READABLE, conn->type->ae_handler, conn) == AE_ERR)
         {
             conn->last_errno = errno;
             return C_ERR;

--- a/src/module.c
+++ b/src/module.c
@@ -3392,7 +3392,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
 
     /* Create the client and dispatch the command. */
     va_start(ap, fmt);
-    c = createClient(NULL);
+    c = createClient();
     c->user = NULL; /* Root user. */
     argv = moduleCreateArgvFromUserFormat(cmdname,fmt,&argc,&flags,ap);
     replicate = flags & REDISMODULE_ARGV_REPLICATE;
@@ -4564,7 +4564,7 @@ RedisModuleBlockedClient *moduleBlockClient(RedisModuleCtx *ctx, RedisModuleCmdF
     bc->disconnect_callback = NULL; /* Set by RM_SetDisconnectCallback() */
     bc->free_privdata = free_privdata;
     bc->privdata = privdata;
-    bc->reply_client = createClient(NULL);
+    bc->reply_client = createClient();
     bc->reply_client->flags |= CLIENT_MODULE;
     bc->dbid = c->db->id;
     bc->blocked_on_keys = keys != NULL;
@@ -4991,7 +4991,7 @@ RedisModuleCtx *RM_GetThreadSafeContext(RedisModuleBlockedClient *bc) {
      * access it safely from another thread, so we create a fake client here
      * in order to keep things like the currently selected database and similar
      * things. */
-    ctx->client = createClient(NULL);
+    ctx->client = createClient();
     if (bc) {
         selectDb(ctx->client,bc->dbid);
         if (bc->client) ctx->client->id = bc->client->id;
@@ -5010,7 +5010,7 @@ RedisModuleCtx *RM_GetDetachedThreadSafeContext(RedisModuleCtx *ctx) {
     memcpy(new_ctx,&empty,sizeof(empty));
     new_ctx->module = ctx->module;
     new_ctx->flags |= REDISMODULE_CTX_THREAD_SAFE;
-    new_ctx->client = createClient(NULL);
+    new_ctx->client = createClient();
     return new_ctx;
 }
 
@@ -7486,7 +7486,7 @@ void moduleFireServerEvent(uint64_t eid, int subid, void *data) {
             } else if (ModulesInHooks == 0) {
                 ctx.client = moduleFreeContextReusedClient;
             } else {
-                ctx.client = createClient(NULL);
+                ctx.client = createClient();
                 ctx.client->flags |= CLIENT_MODULE;
                 ctx.client->user = NULL; /* Root user. */
             }
@@ -7633,7 +7633,7 @@ void moduleRegisterCoreAPI(void);
  * For example, selectDb() in createClient() requires that server.db has
  * been initialized, see #7323. */
 void moduleInitModulesSystemLast(void) {
-    moduleFreeContextReusedClient = createClient(NULL);
+    moduleFreeContextReusedClient = createClient();
     moduleFreeContextReusedClient->flags |= CLIENT_MODULE;
     moduleFreeContextReusedClient->user = NULL; /* root user. */
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -1021,7 +1021,7 @@ static void acceptCommonHandler(connection *conn, int flags, char *ip) {
             connGetLastError(conn),
             connGetInfo(conn, conninfo, sizeof(conninfo)));
         connClose(conn); /* May be already closed, just ignore errors */
-        zfree(c);
+        freeClient(c);
         return;
     }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -128,6 +128,7 @@ int prepareClientForReading(client *c, connection *conn) {
  * connection object. */
 client *createClient() {
     client *c = zmalloc(sizeof(client));
+    c->conn = NULL;
 
     selectDb(c,0);
     uint64_t client_id;

--- a/src/networking.c
+++ b/src/networking.c
@@ -115,11 +115,14 @@ client *createClient(connection *conn) {
      * in the context of a client. When commands are executed in other
      * contexts (for instance a Lua script) we need a non connected client. */
     if (conn) {
+        if (connSetReadHandler(conn, readQueryFromClient) != C_OK) {
+            zfree(c);
+            return NULL;
+        }
         connNonBlock(conn);
         connEnableTcpNoDelay(conn);
         if (server.tcpkeepalive)
             connKeepAlive(conn,server.tcpkeepalive);
-        connSetReadHandler(conn, readQueryFromClient);
         connSetPrivateData(conn, c);
     }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -3414,7 +3414,7 @@ int handleClientsWithPendingWritesUsingThreads(void) {
         /* Install the write handler if there are pending writes in some
          * of the clients. */
         if (clientHasPendingReplies(c) &&
-                connSetWriteHandler(c->conn, sendReplyToClient) == AE_ERR)
+                connSetWriteHandler(c->conn, sendReplyToClient) == C_ERR)
         {
             freeClientAsync(c);
         }

--- a/src/networking.c
+++ b/src/networking.c
@@ -107,11 +107,9 @@ static void clientSetDefaultAuth(client *c) {
                        !(c->user->flags & USER_FLAG_DISABLED);
 }
 
+/* Initialize a client with a connection and prepare it for reading
+ * incoming queries. */
 int prepareClientForReading(client *c, connection *conn) {
-    /* passing NULL as conn it is possible to create a non connected client.
-     * This is useful since all the commands needs to be executed
-     * in the context of a client. When commands are executed in other
-     * contexts (for instance a Lua script) we need a non connected client. */
     if (connSetReadHandler(conn, readQueryFromClient) != C_OK) {
         return C_ERR;
     }
@@ -125,6 +123,9 @@ int prepareClientForReading(client *c, connection *conn) {
     return C_OK;
 }
 
+/* Creates a disconnected client that is fully initialized. To bring this
+ * client fully online, you need to call prepareClientForReading with a 
+ * connection object. */
 client *createClient() {
     client *c = zmalloc(sizeof(client));
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -1795,7 +1795,7 @@ void readSyncBulkPayload(connection *conn) {
     if (prepareClientForReading(server.master,server.repl_transfer_s) == C_ERR) {
         serverLog(LL_WARNING,"Failed registering read handler for master client: %s",
             connGetLastError(server.repl_transfer_s));
-        zfree(server.master);
+        freeClient(server.master);
         server.master = NULL;
         cancelReplicationHandshake(1);
         return;

--- a/src/replication.c
+++ b/src/replication.c
@@ -1368,8 +1368,10 @@ void replicationEmptyDbCallback(void *privdata) {
  * at server.master, starting from the specified file descriptor. */
 void replicationCreateMasterClient(connection *conn, int dbid) {
     server.master = createClient(conn);
-    if (conn)
-        connSetReadHandler(server.master->conn, readQueryFromClient);
+    /* CreateClient should never fail here, since we've already
+     * been using the connection on the eventloop OR no connection
+     * was passed in. */
+    serverAssert(server.master);
 
     /**
      * Important note:

--- a/src/replication.c
+++ b/src/replication.c
@@ -1795,6 +1795,8 @@ void readSyncBulkPayload(connection *conn) {
     if (prepareClientForReading(server.master,server.repl_transfer_s) == C_ERR) {
         serverLog(LL_WARNING,"Failed registering replication client for reading.");
         cancelReplicationHandshake(1);
+        zfree(server.master);
+        server.master = NULL;
         return;
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -1793,10 +1793,11 @@ void readSyncBulkPayload(connection *conn) {
     /* Final setup of the connected slave <- master link */
     replicationCreateMasterClient(rsi.repl_stream_db);
     if (prepareClientForReading(server.master,server.repl_transfer_s) == C_ERR) {
-        serverLog(LL_WARNING,"Failed registering replication client for reading.");
-        cancelReplicationHandshake(1);
+        serverLog(LL_WARNING,"Failed registering read handler for master client: %s",
+            connGetLastError(server.repl_transfer_s));
         zfree(server.master);
         server.master = NULL;
+        cancelReplicationHandshake(1);
         return;
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -2148,7 +2148,8 @@ void syncWithMaster(connection *conn) {
         /* Delete the writable event so that the readable event remains
          * registered and we can wait for the PONG reply. */
         if (connSetReadHandler(conn, syncWithMaster) == C_ERR) {
-            serverLog(LL_NOTICE,"Failed to register read handler for reading from master.");
+            serverLog(LL_NOTICE,"Failed to register read handler for reading "
+                "from master: %s.", connGetLastError(conn));
             goto error;
         }
         connSetWriteHandler(conn, NULL);

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1268,7 +1268,7 @@ void scriptingInit(int setup) {
      * Note: there is no need to create it again when this function is called
      * by scriptingReset(). */
     if (server.lua_client == NULL) {
-        server.lua_client = createClient(NULL);
+        server.lua_client = createClient();
         server.lua_client->flags |= CLIENT_LUA;
 
         /* We do not want to allow blocking commands inside Lua */

--- a/src/server.h
+++ b/src/server.h
@@ -1720,7 +1720,8 @@ int redisCommunicateSystemd(const char *sd_notify_msg);
 void redisSetCpuAffinity(const char *cpulist);
 
 /* networking.c -- Networking and Client related operations */
-client *createClient(connection *conn);
+client *createClient();
+int prepareClientForReading(client *c, connection *conn);
 void closeTimedoutClients(void);
 void freeClient(client *c);
 void freeClientAsync(client *c);

--- a/src/tls.c
+++ b/src/tls.c
@@ -555,9 +555,9 @@ static void tlsHandleEvent(tls_connection *conn, int mask) {
                     if (!handleSSLReturnCode(conn, ret, &want)) {
                         if (registerSSLEvent(conn, want) == C_OK) {
                             /* Avoid hitting UpdateSSLEvent, which knows nothing
-                            * of what SSL_connect() wants and instead looks at our
-                            * R/W handlers.
-                            */
+                             * of what SSL_connect() wants and instead looks at our
+                             * R/W handlers.
+                             */
                             return;
                         }
                     }

--- a/src/tls.c
+++ b/src/tls.c
@@ -589,9 +589,9 @@ static void tlsHandleEvent(tls_connection *conn, int mask) {
                 if (!handleSSLReturnCode(conn, ret, &want)) {
                     if (registerSSLEvent(conn, want) == C_OK) {
                         /* Avoid hitting UpdateSSLEvent, which knows nothing
-                        * of what SSL_connect() wants and instead looks at our
-                        * R/W handlers.
-                        */
+                         * of what SSL_connect() wants and instead looks at our
+                         * R/W handlers.
+                         */
                         return;
                     }
                 }

--- a/src/tls.c
+++ b/src/tls.c
@@ -477,8 +477,8 @@ int registerSSLEvent(tls_connection *conn, WantIOType want) {
         case WANT_READ:
             if (mask & AE_WRITABLE) aeDeleteFileEvent(server.el, conn->c.fd, AE_WRITABLE);
             if (!(mask & AE_READABLE)) {
-                if (aeCreateFileEvent(server.el,conn->c.fd,AE_READABLE,
-                        tlsEventHandler,conn) == AE_ERR) 
+                if (aeCreateFileEvent(server.el,conn->c.fd, AE_READABLE,
+                    tlsEventHandler,conn) == AE_ERR) 
                 {
                     c.conn->err = errno;
                     return C_ERR;
@@ -489,7 +489,7 @@ int registerSSLEvent(tls_connection *conn, WantIOType want) {
             if (mask & AE_READABLE) aeDeleteFileEvent(server.el, conn->c.fd, AE_READABLE);
             if (!(mask & AE_WRITABLE)) {
                 if (aeCreateFileEvent(server.el, conn->c.fd, AE_WRITABLE,
-                        tlsEventHandler,conn) == AE_ERR) 
+                    tlsEventHandler,conn) == AE_ERR) 
                 {
                     c.conn->err = errno;
                     return C_ERR;
@@ -553,14 +553,15 @@ static void tlsHandleEvent(tls_connection *conn, int mask) {
                 if (ret <= 0) {
                     WantIOType want = 0;
                     if (!handleSSLReturnCode(conn, ret, &want)) {
-                        /* We're in an event handler, this can't fail */
-                        serverAssert(registerSSLEvent(conn, want) == C_OK);
+                        /* We have to error out if this fails */
+                        if (registerSSLEvent(conn, want) == C_OK) {
 
-                        /* Avoid hitting UpdateSSLEvent, which knows nothing
-                         * of what SSL_connect() wants and instead looks at our
-                         * R/W handlers.
-                         */
-                        return;
+                            /* Avoid hitting UpdateSSLEvent, which knows nothing
+                            * of what SSL_connect() wants and instead looks at our
+                            * R/W handlers.
+                            */
+                            return;
+                        }
                     }
 
                     /* If not handled, it's an error */
@@ -578,14 +579,14 @@ static void tlsHandleEvent(tls_connection *conn, int mask) {
             if (ret <= 0) {
                 WantIOType want = 0;
                 if (!handleSSLReturnCode(conn, ret, &want)) {
-                    /* We're in an event handler, this can't fail */
-                    serverAssert(registerSSLEvent(conn, want) == C_OK);
-
-                    /* Avoid hitting UpdateSSLEvent, which knows nothing
-                     * of what SSL_connect() wants and instead looks at our
-                     * R/W handlers.
-                     */
-                    return;
+                    /* We have to error out if this fails */
+                    if (registerSSLEvent(conn, want) == C_OK) {
+                        /* Avoid hitting UpdateSSLEvent, which knows nothing
+                        * of what SSL_connect() wants and instead looks at our
+                        * R/W handlers.
+                        */
+                        return;
+                    }
                 }
 
                 /* If not handled, it's an error */
@@ -656,8 +657,12 @@ static void tlsHandleEvent(tls_connection *conn, int mask) {
             break;
     }
 
-    /* Failure to update the SSL Event is not trivially recoverable here. */
-    serverAssert(updateSSLEvent(conn) == C_OK);
+    /* If we fail update the event handler, we fail out */
+    if (updateSSLEvent(conn) == C_ERR) {
+        conn->c.state = CONN_STATE_ERROR;
+        if (!callHandler((connection *) conn, conn->c.conn_handler)) return;
+        conn->c.conn_handler = NULL;
+    }
 }
 
 static void tlsEventHandler(struct aeEventLoop *el, int fd, void *clientData, int mask) {
@@ -744,7 +749,7 @@ static int connTLSWrite(connection *conn_, const void *data, size_t data_len) {
         WantIOType want = 0;
         if (!(ssl_err = handleSSLReturnCode(conn, ret, &want))) {
             if (want == WANT_READ) conn->flags |= TLS_CONN_FLAG_WRITE_WANT_READ;
-            if (updateSSLEvent(conn) == C_ERR) return -;1
+            if (updateSSLEvent(conn) == C_ERR) return -1;
             errno = EAGAIN;
             return -1;
         } else {
@@ -774,7 +779,7 @@ static int connTLSRead(connection *conn_, void *buf, size_t buf_len) {
         WantIOType want = 0;
         if (!(ssl_err = handleSSLReturnCode(conn, ret, &want))) {
             if (want == WANT_WRITE) conn->flags |= TLS_CONN_FLAG_READ_WANT_WRITE;
-            if (updateSSLEvent(conn) == C_ERR) return -;1
+            if (updateSSLEvent(conn) == C_ERR) return -1;
 
             errno = EAGAIN;
             return -1;
@@ -806,14 +811,12 @@ int connTLSSetWriteHandler(connection *conn, ConnectionCallbackFunc func, int ba
         conn->flags |= CONN_FLAG_WRITE_BARRIER;
     else
         conn->flags &= ~CONN_FLAG_WRITE_BARRIER;
-    if (updateSSLEvent((tls_connection *) conn) == C_ERR) return C_ERR;
-    return C_OK;
+    return updateSSLEvent((tls_connection *) conn);
 }
 
 int connTLSSetReadHandler(connection *conn, ConnectionCallbackFunc func) {
     conn->read_handler = func;
-    if (updateSSLEvent((tls_connection *) conn) == C_ERR) return C_ERR;
-    return C_OK;
+    return updateSSLEvent((tls_connection *) conn);
 }
 
 static void setBlockingTimeout(tls_connection *conn, long long timeout) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -553,9 +553,7 @@ static void tlsHandleEvent(tls_connection *conn, int mask) {
                 if (ret <= 0) {
                     WantIOType want = 0;
                     if (!handleSSLReturnCode(conn, ret, &want)) {
-                        /* We have to error out if this fails */
                         if (registerSSLEvent(conn, want) == C_OK) {
-
                             /* Avoid hitting UpdateSSLEvent, which knows nothing
                             * of what SSL_connect() wants and instead looks at our
                             * R/W handlers.
@@ -579,7 +577,6 @@ static void tlsHandleEvent(tls_connection *conn, int mask) {
             if (ret <= 0) {
                 WantIOType want = 0;
                 if (!handleSSLReturnCode(conn, ret, &want)) {
-                    /* We have to error out if this fails */
                     if (registerSSLEvent(conn, want) == C_OK) {
                         /* Avoid hitting UpdateSSLEvent, which knows nothing
                         * of what SSL_connect() wants and instead looks at our
@@ -657,7 +654,6 @@ static void tlsHandleEvent(tls_connection *conn, int mask) {
             break;
     }
 
-    /* If we fail update the event handler, we fail out */
     if (updateSSLEvent(conn) == C_ERR) {
         conn->c.state = CONN_STATE_ERROR;
         if (!callHandler((connection *) conn, conn->c.conn_handler)) return;

--- a/src/tls.c
+++ b/src/tls.c
@@ -480,7 +480,7 @@ int registerSSLEvent(tls_connection *conn, WantIOType want) {
                 if (aeCreateFileEvent(server.el,conn->c.fd, AE_READABLE,
                     tlsEventHandler,conn) == AE_ERR) 
                 {
-                    c.conn->err = errno;
+                    conn->c.last_errno = errno;
                     return C_ERR;
                 }
             } 
@@ -491,7 +491,7 @@ int registerSSLEvent(tls_connection *conn, WantIOType want) {
                 if (aeCreateFileEvent(server.el, conn->c.fd, AE_WRITABLE,
                     tlsEventHandler,conn) == AE_ERR) 
                 {
-                    c.conn->err = errno;
+                    conn->c.last_errno = errno;
                     return C_ERR;
                 }
             }


### PR DESCRIPTION
This mostly aims to fix a specific issue, which is an outbound connection might be outside of the eventloop size, so it get's created but not registered. 

The rest of the changes are mostly just being defensive and trying to properly return errors when they can be.