### PR TITLE
GEOADD - add [CH] [NX|XX] options

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -439,11 +439,12 @@ void geoaddCommand(client *c) {
     }
 
     int elements = (c->argc - 2) / 3;
-    int argc = 2+elements*2; /* ZADD key score ele ... */
+    int argc = 3+elements*2; /* ZADD key CH score ele ... */
     robj **argv = zcalloc(argc*sizeof(robj*));
     argv[0] = createRawStringObject("zadd",4);
     argv[1] = c->argv[1]; /* key */
     incrRefCount(argv[1]);
+    argv[2] = createRawStringObject("ch",2);
 
     /* Create the argument vector to call ZADD in order to add all
      * the score,value pairs to the requested zset, where score is actually
@@ -465,8 +466,8 @@ void geoaddCommand(client *c) {
         GeoHashFix52Bits bits = geohashAlign52Bits(hash);
         robj *score = createObject(OBJ_STRING, sdsfromlonglong(bits));
         robj *val = c->argv[2 + i * 3 + 2];
-        argv[2+i*2] = score;
-        argv[3+i*2] = val;
+        argv[3+i*2] = score;
+        argv[4+i*2] = val;
         incrRefCount(val);
     }
 

--- a/src/geo.c
+++ b/src/geo.c
@@ -435,7 +435,7 @@ void geoaddCommand(client *c) {
 
     /* Parse options. At the end 'longidx' is set to the argument position
      * of the longitude of the first element. */
-    while(longidx < c->argc) {
+    while (longidx < c->argc) {
         char *opt = c->argv[longidx]->ptr;
         if (!strcasecmp(opt,"nx")) nx = 1;
         else if (!strcasecmp(opt,"xx")) xx = 1;
@@ -455,9 +455,7 @@ void geoaddCommand(client *c) {
     int argc = longidx+elements*2; /* ZADD key [CH] [NX|XX] score ele ... */
     robj **argv = zcalloc(argc*sizeof(robj*));
     argv[0] = createRawStringObject("zadd",4);
-    argv[1] = c->argv[1]; /* key */
-    incrRefCount(argv[1]);
-    for (i = 2; i < longidx; i++) {
+    for (i = 1; i < longidx; i++) {
         argv[i] = c->argv[i];
         incrRefCount(argv[i]);
     }

--- a/src/geo.c
+++ b/src/geo.c
@@ -430,7 +430,7 @@ static int sort_gp_desc(const void *a, const void *b) {
 
 /* GEOADD key [CH] [NX|XX] long lat name [long2 lat2 name2 ... longN latN nameN] */
 void geoaddCommand(client *c) {
-    int xx = 0, nx = 0, ch = 0, longidx = 2;
+    int xx = 0, nx = 0, longidx = 2;
     int i;
 
     /* Parse options. At the end 'longidx' is set to the argument position
@@ -438,8 +438,8 @@ void geoaddCommand(client *c) {
     while(longidx < c->argc) {
         char *opt = c->argv[longidx]->ptr;
         if (!strcasecmp(opt,"nx")) nx = 1;
-        else if (!strcasecmp(opt,"xx")) xx = 1
-        else if (!strcasecmp(opt,"ch")) ch = 1;
+        else if (!strcasecmp(opt,"xx")) xx = 1;
+        else if (!strcasecmp(opt,"ch")) {}
         else break;
         longidx++;
     }
@@ -457,10 +457,9 @@ void geoaddCommand(client *c) {
     argv[0] = createRawStringObject("zadd",4);
     argv[1] = c->argv[1]; /* key */
     incrRefCount(argv[1]);
-    int options = longidx - 2;
-    for (i = 0; i < options; i++) {
-        argv[2+i] = c->argv[2+i];
-        incrRefCount(argv[2+i]);
+    for (i = 2; i < longidx; i++) {
+        argv[i] = c->argv[i];
+        incrRefCount(argv[i]);
     }
 
     /* Create the argument vector to call ZADD in order to add all

--- a/src/help.h
+++ b/src/help.h
@@ -444,7 +444,7 @@ struct commandHelp {
     9,
     "1.0.0" },
     { "GEOADD",
-    "key [CH] [NX|XX] longitude latitude member [longitude latitude member ...]",
+    "key longitude latitude member [longitude latitude member ...]",
     "Add one or more geospatial items in the geospatial index represented using a sorted set",
     13,
     "3.2.0" },

--- a/src/help.h
+++ b/src/help.h
@@ -444,7 +444,7 @@ struct commandHelp {
     9,
     "1.0.0" },
     { "GEOADD",
-    "key longitude latitude member [longitude latitude member ...]",
+    "key [CH] [NX|XX] longitude latitude member [longitude latitude member ...]",
     "Add one or more geospatial items in the geospatial index represented using a sorted set",
     13,
     "3.2.0" },

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -74,6 +74,28 @@ start_server {tags {"geo"}} {
         r geoadd nyc -73.9454966 40.747533 "lic market"
     } {0}
 
+    test {GEOADD update with CH option} {
+        assert_equal 1 [r geoadd nyc CH 40.747533 -73.9454966 "lic market"]
+        lassign [lindex [r geopos nyc "lic market"] 0] x1 y1
+        assert {abs($x1) - 40.747 < 0.001}
+        assert {abs($y1) - 73.945 < 0.001}
+    } {}
+
+    test {GEOADD update with CH NX option} {
+        r geoadd nyc CH NX -73.9454966 40.747533 "lic market"
+    } {0}
+
+    test {GEOADD update with CH XX option} {
+        r geoadd nyc CH XX -73.9454966 40.747533 "lic market"
+    } {1}
+
+    test {GEOADD update with invalid option} {
+        catch {
+            r geoadd nyc ch xx lt nx gt -73.9454966 40.747533 "lic market"
+        } err
+        set err
+    } {ERR*}
+
     test {GEOADD invalid coordinates} {
         catch {
             r geoadd nyc -73.9454966 40.747533 "lic market" \
@@ -400,8 +422,4 @@ start_server {tags {"geo"}} {
         }
         set test_result
     } {OK}
-
-    test {GEOADD update with diff longitude and latitude} {
-        r geoadd nyc -73.9454966 30.747533 "lic market"
-    } {1}
 }

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -400,4 +400,8 @@ start_server {tags {"geo"}} {
         }
         set test_result
     } {OK}
+
+    test {GEOADD update with diff longitude and latitude} {
+        r geoadd nyc -73.9454966 30.747533 "lic market"
+    } {1}
 }

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -81,6 +81,20 @@ start_server {tags {"geo"}} {
         assert {abs($y1) - 73.945 < 0.001}
     } {}
 
+    test {GEOADD update with NX option} {
+        assert_equal 0 [r geoadd nyc NX -73.9454966 40.747533 "lic market"]
+        lassign [lindex [r geopos nyc "lic market"] 0] x1 y1
+        assert {abs($x1) - 40.747 < 0.001}
+        assert {abs($y1) - 73.945 < 0.001}
+    } {}
+
+    test {GEOADD update with XX option} {
+        assert_equal 0 [r geoadd nyc XX -83.9454966 40.747533 "lic market"]
+        lassign [lindex [r geopos nyc "lic market"] 0] x1 y1
+        assert {abs($x1) - 83.945 < 0.001}
+        assert {abs($y1) - 40.747 < 0.001}
+    } {}
+
     test {GEOADD update with CH NX option} {
         r geoadd nyc CH NX -73.9454966 40.747533 "lic market"
     } {0}
@@ -89,12 +103,19 @@ start_server {tags {"geo"}} {
         r geoadd nyc CH XX -73.9454966 40.747533 "lic market"
     } {1}
 
-    test {GEOADD update with invalid option} {
+    test {GEOADD update with XX NX option will return syntax error} {
         catch {
-            r geoadd nyc ch xx lt nx gt -73.9454966 40.747533 "lic market"
+            r geoadd nyc xx nx -73.9454966 40.747533 "lic market"
         } err
         set err
-    } {ERR*}
+    } {ERR*syntax*}
+
+    test {GEOADD update with invalid option} {
+        catch {
+            r geoadd nyc ch xx foo -73.9454966 40.747533 "lic market"
+        } err
+        set err
+    } {ERR*syntax*}
 
     test {GEOADD invalid coordinates} {
         catch {


### PR DESCRIPTION
geoadd same member with diff longitude or latitude return updated members.

e.g:
geoadd test 1.0 2.0 same will return 1
geoadd test 1.0 3.0 same will return 0

The actual value has been updated，because the score is update。