### PR TITLE
Fix issue where fork process deletes the parent pidfile

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1808,7 +1808,7 @@ void bugReportEnd(int killViaSignal, int sig) {
 );
 
     /* free(messages); Don't call free() with possibly corrupted memory. */
-    if (server.daemonize && server.supervised == 0) unlink(server.pidfile);
+    if (server.daemonize && server.supervised == 0 && server.pidfile) unlink(server.pidfile);
 
     if (!killViaSignal) {
         if (server.use_exit_on_panic)

--- a/src/server.c
+++ b/src/server.c
@@ -5200,6 +5200,10 @@ void closeClildUnusedResourceAfterFork() {
     closeListeningSockets(0);
     if (server.cluster_enabled && server.cluster_config_file_lock_fd != -1)
         close(server.cluster_config_file_lock_fd);  /* don't care if this fails */
+
+    /* Clear server.pidfile, this is the parent pidfile which should not
+     * be touched (or deleted) by the child (on exit / crash) */
+    server.pidfile = NULL;
 }
 
 /* purpose is one of CHILD_TYPE_ types */
@@ -5212,11 +5216,6 @@ int redisFork(int purpose) {
         setOOMScoreAdj(CONFIG_OOM_BGCHILD);
         setupChildSignalHandlers();
         closeClildUnusedResourceAfterFork();
-
-        /* reset the pidfile, this is the parent pidfile which should not
-         * be touched by the child
-         */
-        server.pidfile = NULL;
     } else {
         /* Parent */
         server.stat_total_forks++;

--- a/src/server.c
+++ b/src/server.c
@@ -5212,6 +5212,11 @@ int redisFork(int purpose) {
         setOOMScoreAdj(CONFIG_OOM_BGCHILD);
         setupChildSignalHandlers();
         closeClildUnusedResourceAfterFork();
+
+        /* reset the pidfile, this is the parent pidfile which should not
+         * be touched by the child
+         */
+        server.pidfile = NULL;
     } else {
         /* Parent */
         server.stat_total_forks++;


### PR DESCRIPTION
Turns out that when the fork child crashes, the crash log was deleting
the pidfile from the disk (although the parent is still running.

Now we set the pidfile of the fork process to NULL so the fork process
will never deletes it.