### PR TITLE
Dont performEvictions twice if an eviction is in progress

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2265,7 +2265,10 @@ static int updateMaxmemory(long long val, long long prev, char **err) {
         if ((unsigned long long)val < used) {
             serverLog(LL_WARNING,"WARNING: the new maxmemory value set via CONFIG SET (%llu) is smaller than the current memory usage (%zu). This will result in key eviction and/or the inability to accept new write commands depending on the maxmemory-policy.", server.maxmemory, used);
         }
-        performEvictions();
+
+        if (!evictionInProgress()) {
+            performEvictions();
+        }
     }
     return 1;
 }

--- a/src/evict.c
+++ b/src/evict.c
@@ -485,6 +485,11 @@ static unsigned long evictionTimeLimitUs() {
     return ULONG_MAX;   /* No limit to eviction time */
 }
 
+/* Return true if an eviction is currently already in progress. */
+int evictionInProgress() {
+    return isEvictionProcRunning;
+}
+
 /* Check that memory usage is within the current "maxmemory" limit.  If over
  * "maxmemory", attempt to free memory by evicting data (if it's safe to do so).
  *

--- a/src/server.c
+++ b/src/server.c
@@ -3800,7 +3800,7 @@ int processCommand(client *c) {
      * condition, to avoid mixing the propagation of scripts with the
      * propagation of DELs due to eviction. */
     if (server.maxmemory && !server.lua_timedout) {
-        int out_of_memory = (performEvictions() == EVICT_FAIL);
+        int out_of_memory = (evictionInProgress() || performEvictions() == EVICT_FAIL);
         /* performEvictions may flush slave output buffers. This may result
          * in a slave, that may be the active client, to be freed. */
         if (server.current_client == NULL) return C_ERR;

--- a/src/server.h
+++ b/src/server.h
@@ -2356,6 +2356,7 @@ unsigned long LFUDecrAndReturn(robj *o);
 #define EVICT_OK 0
 #define EVICT_RUNNING 1
 #define EVICT_FAIL 2
+int evictionInProgress();
 int performEvictions(void);
 
 


### PR DESCRIPTION
If a non-oom command or config command is executed while eviction is in progress, performEvictions will be executed twice.