### PR TITLE
fix valgrind warning created by recent pidfile fix

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5203,6 +5203,7 @@ void closeClildUnusedResourceAfterFork() {
 
     /* Clear server.pidfile, this is the parent pidfile which should not
      * be touched (or deleted) by the child (on exit / crash) */
+    zfree(server.pidfile);
     server.pidfile = NULL;
 }
 


### PR DESCRIPTION
This isn't a leak, just an warning due to unreachable
allocation on the fork child.
Problem created by 92a483bca