### PR TITLE
Don't send unnecessary PING to replicas

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2572,6 +2572,7 @@ void initServerConfig(void) {
     server.repl_syncio_timeout = CONFIG_REPL_SYNCIO_TIMEOUT;
     server.repl_down_since = 0; /* Never connected, repl is down since EVER. */
     server.master_repl_offset = 0;
+    server.last_feed_slaves = 0;
 
     /* Replication partial resync backlog */
     server.repl_backlog = NULL;

--- a/src/server.h
+++ b/src/server.h
@@ -1384,6 +1384,7 @@ struct redisServer {
     int repl_diskless_load;         /* Slave parse RDB directly from the socket.
                                      * see REPL_DISKLESS_LOAD_* enum */
     int repl_diskless_sync_delay;   /* Delay to start a diskless repl BGSAVE. */
+    time_t last_feed_slaves;        /* Last time of feeding slaves. */
     /* Replication (slave) */
     char *masteruser;               /* AUTH with this user and masterauth with master */
     sds masterauth;                 /* AUTH with this password with master */


### PR DESCRIPTION
In replicationCron, mater sends PING according to ping_slave_period,
The reason why master sends PING is to update interaction time in slaves,
so master needn't send PING to slaves if already sent other synchronization
stream in the past repl_ping_slave_period time.