### PR TITLE
Feature: add filter into MONITOR

### DIFF
--- a/src/help.h
+++ b/src/help.h
@@ -749,7 +749,7 @@ struct commandHelp {
     9,
     "4.0.0" },
     { "MONITOR",
-    "-",
+    "[SIZE threshold] [LIMIT maxnum]",
     "Listen for all requests received by the server in real time",
     9,
     "1.0.0" },

--- a/src/networking.c
+++ b/src/networking.c
@@ -185,6 +185,8 @@ client *createClient(connection *conn) {
     c->auth_callback = NULL;
     c->auth_callback_privdata = NULL;
     c->auth_module = NULL;
+    c->monitor_size_threshold = 0;
+    c->monitor_num_threadhold = 0;
     listSetFreeMethod(c->pubsub_patterns,decrRefCountVoid);
     listSetMatchMethod(c->pubsub_patterns,listMatchObjects);
     if (conn) linkClient(c);

--- a/src/replication.c
+++ b/src/replication.c
@@ -373,6 +373,7 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     listNode *ln;
     listIter li;
     int j;
+    size_t subcommandlen = 0;
     sds cmdrepr = sdsnew("+");
     robj *cmdobj;
     struct timeval tv;
@@ -394,6 +395,10 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
             cmdrepr = sdscatrepr(cmdrepr,(char*)argv[j]->ptr,
                         sdslen(argv[j]->ptr));
         }
+
+        if (j != 0)
+            subcommandlen += sdslen(argv[j]->ptr);
+
         if (j != argc-1)
             cmdrepr = sdscatlen(cmdrepr," ",1);
     }
@@ -403,7 +408,16 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     listRewind(monitors,&li);
     while((ln = listNext(&li))) {
         client *monitor = ln->value;
-        addReply(monitor,cmdobj);
+
+        if (subcommandlen >= monitor->monitor_size_threshold) {
+            addReply(monitor,cmdobj);
+            monitor->monitor_num++;
+        }
+
+        if (monitor->monitor_num_threadhold > 0 &&
+            monitor->monitor_num >= monitor->monitor_num_threadhold) {
+                monitor->flags |= CLIENT_CLOSE_AFTER_REPLY;
+         }
     }
     decrRefCount(cmdobj);
 }
@@ -1848,7 +1862,7 @@ char* sendCommandRaw(connection *conn, sds cmd) {
     return NULL;
 }
 
-/* Compose a multi-bulk command and send it to the connection.
+/* Compose a multi-bulk command and send it to the connection. 
  * Used to send AUTH and REPLCONF commands to the master before starting the
  * replication.
  *
@@ -1887,7 +1901,7 @@ char *sendCommand(connection *conn, ...) {
     return NULL;
 }
 
-/* Compose a multi-bulk command and send it to the connection. 
+/* Compose a multi-bulk command and send it to the connection.
  * Used to send AUTH and REPLCONF commands to the master before starting the
  * replication.
  *

--- a/src/server.c
+++ b/src/server.c
@@ -753,7 +753,7 @@ struct redisCommand redisCommandTable[] = {
      "ok-loading ok-stale random @dangerous",
      0,NULL,0,0,0,0,0,0},
 
-    {"monitor",monitorCommand,1,
+    {"monitor",monitorCommand,-1,
      "admin no-script ok-loading ok-stale",
      0,NULL,0,0,0,0,0,0},
 
@@ -4967,7 +4967,10 @@ void infoCommand(client *c) {
     sdsfree(info);
 }
 
+/* MONITOR [SIZE threshold] [LIMIT maxnum]*/
 void monitorCommand(client *c) {
+    int i;
+
     if (c->flags & CLIENT_DENY_BLOCKING) {
         /**
          * A client that has CLIENT_DENY_BLOCKING flag on
@@ -4979,9 +4982,37 @@ void monitorCommand(client *c) {
     /* ignore MONITOR if already slave or in monitor mode */
     if (c->flags & CLIENT_SLAVE) return;
 
+    /* the argument number must be odd*/
+    if (!(c->argc&1)) goto fmterr;
+
+    for (i = 1; i < c->argc; i++) {
+        int threshold;
+
+        if (!strcasecmp(c->argv[i]->ptr,"SIZE")) {
+            /* get the threshold */
+            if (getIntFromObjectOrReply(c,c->argv[i+1],&threshold,NULL) != C_OK ||
+                threshold < 0)
+                goto fmterr;
+
+            c->monitor_size_threshold = threshold;
+        } else if (!strcasecmp(c->argv[i]->ptr,"LIMIT")) {
+            /* get the threshold */
+            if (getIntFromObjectOrReply(c,c->argv[i+1],&threshold,NULL) != C_OK ||
+                threshold < 0)
+                goto fmterr;
+
+            c->monitor_num_threadhold = threshold;
+        }
+    }
+
     c->flags |= (CLIENT_SLAVE|CLIENT_MONITOR);
     listAddNodeTail(server.monitors,c);
     addReply(c,shared.ok);
+    return;
+
+fmterr:
+    addReply(c,shared.syntaxerr);
+    return;
 }
 
 /* =================================== Main! ================================ */

--- a/src/server.h
+++ b/src/server.h
@@ -920,6 +920,9 @@ typedef struct client {
     /* Response buffer */
     int bufpos;
     char buf[PROTO_REPLY_CHUNK_BYTES];
+    size_t monitor_size_threshold;
+    size_t monitor_num_threadhold;
+    size_t monitor_num;
 } client;
 
 struct saveparam {


### PR DESCRIPTION
The command `MONITOR` is usually used for debugging but it is hard to capture specified commands.  I add some filter into `MONITOR` which can be used to list size limited  and count limited commands.