### PR TITLE
Removing unnecessary runtime tio_debug checks

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3245,7 +3245,7 @@ void processEventsWhileBlocked(void) {
  * Threaded I/O
  * ========================================================================== */
 
-int tio_debug = 0;
+#define IO_THREADS_DEBUG 0
 
 #define IO_THREADS_MAX_NUM 128
 #define IO_THREADS_OP_READ 0
@@ -3297,7 +3297,9 @@ void *IOThreadMain(void *myid) {
 
         serverAssert(getIOPendingCount(id) != 0);
 
-        if (tio_debug) printf("[%ld] %d to handle\n", id, (int)listLength(io_threads_list[id]));
+        #if IO_THREADS_DEBUG
+        printf("[%ld] %d to handle\n", id, (int)listLength(io_threads_list[id]));
+        #endif
 
         /* Process: note that the main thread will never touch our list
          * before we drop the pending count to 0. */
@@ -3317,7 +3319,9 @@ void *IOThreadMain(void *myid) {
         listEmpty(io_threads_list[id]);
         setIOPendingCount(id, 0);
 
-        if (tio_debug) printf("[%ld] Done\n", id);
+        #if IO_THREADS_DEBUG
+        printf("[%ld] Done\n", id);
+        #endif
     }
 }
 
@@ -3372,8 +3376,10 @@ void killIOThreads(void) {
 }
 
 void startThreadedIO(void) {
-    if (tio_debug) { printf("S"); fflush(stdout); }
-    if (tio_debug) printf("--- STARTING THREADED IO ---\n");
+    #if IO_THREADS_DEBUG
+    printf("S"); fflush(stdout);
+    printf("--- STARTING THREADED IO ---\n");
+    #endif
     serverAssert(server.io_threads_active == 0);
     for (int j = 1; j < server.io_threads_num; j++)
         pthread_mutex_unlock(&io_threads_mutex[j]);
@@ -3384,10 +3390,12 @@ void stopThreadedIO(void) {
     /* We may have still clients with pending reads when this function
      * is called: handle them before stopping the threads. */
     handleClientsWithPendingReadsUsingThreads();
-    if (tio_debug) { printf("E"); fflush(stdout); }
-    if (tio_debug) printf("--- STOPPING THREADED IO [R%d] [W%d] ---\n",
+    #if IO_THREADS_DEBUG
+    printf("E"); fflush(stdout);
+    printf("--- STOPPING THREADED IO [R%d] [W%d] ---\n",
         (int) listLength(server.clients_pending_read),
         (int) listLength(server.clients_pending_write));
+    #endif
     serverAssert(server.io_threads_active == 1);
     for (int j = 1; j < server.io_threads_num; j++)
         pthread_mutex_lock(&io_threads_mutex[j]);
@@ -3430,7 +3438,9 @@ int handleClientsWithPendingWritesUsingThreads(void) {
     /* Start threads if needed. */
     if (!server.io_threads_active) startThreadedIO();
 
-    if (tio_debug) printf("%d TOTAL WRITE pending clients\n", processed);
+    #if IO_THREADS_DEBUG
+    printf("%d TOTAL WRITE pending clients\n", processed);
+    #endif
 
     /* Distribute the clients across N different lists. */
     listIter li;
@@ -3476,7 +3486,9 @@ int handleClientsWithPendingWritesUsingThreads(void) {
             pending += getIOPendingCount(j);
         if (pending == 0) break;
     }
-    if (tio_debug) printf("I/O WRITE All threads finshed\n");
+    #if IO_THREADS_DEBUG
+    printf("I/O WRITE All threads finshed\n");
+    #endif
 
     /* Run the list of clients again to install the write handler where
      * needed. */
@@ -3529,7 +3541,9 @@ int handleClientsWithPendingReadsUsingThreads(void) {
     int processed = listLength(server.clients_pending_read);
     if (processed == 0) return 0;
 
-    if (tio_debug) printf("%d TOTAL READ pending clients\n", processed);
+    #if IO_THREADS_DEBUG
+    printf("%d TOTAL READ pending clients\n", processed);
+    #endif
 
     /* Distribute the clients across N different lists. */
     listIter li;
@@ -3566,7 +3580,9 @@ int handleClientsWithPendingReadsUsingThreads(void) {
             pending += getIOPendingCount(j);
         if (pending == 0) break;
     }
-    if (tio_debug) printf("I/O READ All threads finshed\n");
+    #if IO_THREADS_DEBUG
+    printf("I/O READ All threads finshed\n");
+    #endif
 
     /* Run the list of clients again to process the new buffers. */
     while(listLength(server.clients_pending_read)) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -3245,7 +3245,6 @@ void processEventsWhileBlocked(void) {
  * Threaded I/O
  * ========================================================================== */
 
-
 #define IO_THREADS_MAX_NUM 128
 #define IO_THREADS_OP_READ 0
 #define IO_THREADS_OP_WRITE 1
@@ -3296,7 +3295,6 @@ void *IOThreadMain(void *myid) {
 
         serverAssert(getIOPendingCount(id) != 0);
 
-
         /* Process: note that the main thread will never touch our list
          * before we drop the pending count to 0. */
         listIter li;
@@ -3314,7 +3312,6 @@ void *IOThreadMain(void *myid) {
         }
         listEmpty(io_threads_list[id]);
         setIOPendingCount(id, 0);
-
     }
 }
 
@@ -3421,7 +3418,6 @@ int handleClientsWithPendingWritesUsingThreads(void) {
     /* Start threads if needed. */
     if (!server.io_threads_active) startThreadedIO();
 
-
     /* Distribute the clients across N different lists. */
     listIter li;
     listNode *ln;
@@ -3517,7 +3513,6 @@ int handleClientsWithPendingReadsUsingThreads(void) {
     if (!server.io_threads_active || !server.io_threads_do_reads) return 0;
     int processed = listLength(server.clients_pending_read);
     if (processed == 0) return 0;
-
 
     /* Distribute the clients across N different lists. */
     listIter li;


### PR DESCRIPTION
This PR removes some unnecessary runtime debug checks from 2 years ago regarding io-threads.