### PR TITLE
Fix some type problems that may cause overflow

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -372,7 +372,7 @@ robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o) {
  * The dbnum can be -1 if all the DBs should be emptied, or the specified
  * DB index if we want to empty only a single database.
  * The function returns the number of keys removed from the database(s). */
-long long emptyDbStructure(redisDb *dbarray, int dbnum, int async,
+unsigned long long emptyDbStructure(redisDb *dbarray, int dbnum, int async,
                            void(callback)(void*))
 {
     long long removed = 0;
@@ -413,16 +413,16 @@ long long emptyDbStructure(redisDb *dbarray, int dbnum, int async,
  * and the function to return ASAP.
  *
  * On success the function returns the number of keys removed from the
- * database(s). Otherwise -1 is returned in the specific case the
+ * database(s). Otherwise 0 is returned in the specific case the
  * DB number is out of range, and errno is set to EINVAL. */
-long long emptyDb(int dbnum, int flags, void(callback)(void*)) {
+unsigned long long emptyDb(int dbnum, int flags, void(callback)(void*)) {
     int async = (flags & EMPTYDB_ASYNC);
     RedisModuleFlushInfoV1 fi = {REDISMODULE_FLUSHINFO_VERSION,!async,dbnum};
-    long long removed = 0;
+    unsigned long long removed = 0;
 
     if (dbnum < -1 || dbnum >= server.dbnum) {
         errno = EINVAL;
-        return -1;
+        return 0;
     }
 
     /* Fire the flushdb modules event. */
@@ -547,8 +547,8 @@ int selectDb(client *c, int id) {
     return C_OK;
 }
 
-long long dbTotalServerKeyCount() {
-    long long total = 0;
+unsigned long long dbTotalServerKeyCount() {
+    unsigned long long total = 0;
     int j;
     for (j = 0; j < server.dbnum; j++) {
         total += dictSize(server.db[j].dict);

--- a/src/db.c
+++ b/src/db.c
@@ -375,7 +375,7 @@ robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o) {
 unsigned long long emptyDbStructure(redisDb *dbarray, int dbnum, int async,
                            void(callback)(void*))
 {
-    long long removed = 0;
+    unsigned long long removed = 0;
     int startdb, enddb;
 
     if (dbnum == -1) {

--- a/src/dict.c
+++ b/src/dict.c
@@ -702,7 +702,7 @@ unsigned int dictGetSomeKeys(dict *d, dictEntry **des, unsigned int count) {
     unsigned long maxsteps;
 
     if (dictSize(d) < count) count = dictSize(d);
-    maxsteps = count*10;
+    maxsteps = (unsigned long)count*10;
 
     /* Try to do a rehashing work proportional to 'count'. */
     for (j = 0; j < count; j++) {

--- a/src/evict.c
+++ b/src/evict.c
@@ -564,7 +564,7 @@ int performEvictions(void) {
                         no_evict_key = 0;
                     }
                 }
-                if (!no_evict_key) break; /* No keys to evict. */
+                if (no_evict_key) break; /* No keys to evict. */
 
                 /* Go backward from best to worst element to evict. */
                 for (k = EVPOOL_SIZE-1; k >= 0; k--) {

--- a/src/evict.c
+++ b/src/evict.c
@@ -550,7 +550,7 @@ int performEvictions(void) {
             struct evictionPoolEntry *pool = EvictionPoolLRU;
 
             while(bestkey == NULL) {
-                unsigned long total_keys = 0, keys;
+                int no_evict_key = 1;
 
                 /* We don't want to make local-db choices when expiring keys,
                  * so to start populate the eviction pool sampling keys from
@@ -559,12 +559,12 @@ int performEvictions(void) {
                     db = server.db+i;
                     dict = (server.maxmemory_policy & MAXMEMORY_FLAG_ALLKEYS) ?
                             db->dict : db->expires;
-                    if ((keys = dictSize(dict)) != 0) {
+                    if (dictSize(dict) != 0) {
                         evictionPoolPopulate(i, dict, db->dict, pool);
-                        total_keys += keys;
+                        no_evict_key = 0;
                     }
                 }
-                if (!total_keys) break; /* No keys to evict. */
+                if (!no_evict_key) break; /* No keys to evict. */
 
                 /* Go backward from best to worst element to evict. */
                 for (k = EVPOOL_SIZE-1; k >= 0; k--) {

--- a/src/evict.c
+++ b/src/evict.c
@@ -512,7 +512,7 @@ static unsigned long evictionTimeLimitUs() {
 int performEvictions(void) {
     if (!isSafeToPerformEvictions()) return EVICT_OK;
 
-    long keys_freed = 0;
+    unsigned long keys_freed = 0;
     size_t mem_reported, mem_tofree;
     long long mem_freed; /* May be negative */
     mstime_t latency, eviction_latency;

--- a/src/evict.c
+++ b/src/evict.c
@@ -512,7 +512,7 @@ static unsigned long evictionTimeLimitUs() {
 int performEvictions(void) {
     if (!isSafeToPerformEvictions()) return EVICT_OK;
 
-    int keys_freed = 0;
+    long keys_freed = 0;
     size_t mem_reported, mem_tofree;
     long long mem_freed; /* May be negative */
     mstime_t latency, eviction_latency;

--- a/src/evict.c
+++ b/src/evict.c
@@ -226,7 +226,7 @@ void evictionPoolPopulate(int dbid, dict *sampledict, dict *keydict, struct evic
          * because allocating and deallocating this object is costly
          * (according to the profiler, not my fantasy. Remember:
          * premature optimization bla bla bla. */
-        int klen = sdslen(key);
+        size_t klen = sdslen(key);
         if (klen > EVPOOL_CACHED_SDS_SIZE) {
             pool[k].key = sdsdup(key);
         } else {

--- a/src/object.c
+++ b/src/object.c
@@ -1043,7 +1043,7 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
 
     for (j = 0; j < server.dbnum; j++) {
         redisDb *db = server.db+j;
-        long long keyscount = dictSize(db->dict);
+        unsigned long keyscount = dictSize(db->dict);
         if (keyscount==0) continue;
 
         mh->total_keys += keyscount;
@@ -1074,7 +1074,7 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
     if (zmalloc_used > mh->startup_allocated)
         net_usage = zmalloc_used - mh->startup_allocated;
     mh->dataset_perc = (float)mh->dataset*100/net_usage;
-    mh->bytes_per_key = mh->total_keys ? ((long long)net_usage / mh->total_keys) : 0;
+    mh->bytes_per_key = mh->total_keys ? (net_usage / mh->total_keys) : 0;
 
     return mh;
 }

--- a/src/object.c
+++ b/src/object.c
@@ -1074,7 +1074,7 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
     if (zmalloc_used > mh->startup_allocated)
         net_usage = zmalloc_used - mh->startup_allocated;
     mh->dataset_perc = (float)mh->dataset*100/net_usage;
-    mh->bytes_per_key = mh->total_keys ? (net_usage / mh->total_keys) : 0;
+    mh->bytes_per_key = mh->total_keys ? ((long long)net_usage / mh->total_keys) : 0;
 
     return mh;
 }

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -255,7 +255,7 @@ static uint64_t dictSdsHash(const void *key) {
 static int dictSdsKeyCompare(void *privdata, const void *key1,
         const void *key2)
 {
-    int l1,l2;
+    size_t l1,l2;
     DICT_NOTUSED(privdata);
 
     l1 = sdslen((sds)key1);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -452,7 +452,7 @@ static uint64_t dictSdsHash(const void *key) {
 static int dictSdsKeyCompare(void *privdata, const void *key1,
         const void *key2)
 {
-    int l1,l2;
+    size_t l1,l2;
     DICT_NOTUSED(privdata);
 
     l1 = sdslen((sds)key1);

--- a/src/server.c
+++ b/src/server.c
@@ -1212,7 +1212,7 @@ void dictListDestructor(void *privdata, void *val)
 int dictSdsKeyCompare(void *privdata, const void *key1,
         const void *key2)
 {
-    int l1,l2;
+    size_t l1,l2;
     DICT_NOTUSED(privdata);
 
     l1 = sdslen((sds)key1);

--- a/src/server.c
+++ b/src/server.c
@@ -1500,7 +1500,7 @@ dictType replScriptCacheDictType = {
 };
 
 int htNeedsResize(dict *dict) {
-    long long size, used;
+    unsigned long size, used;
 
     size = dictSlots(dict);
     used = dictSize(dict);
@@ -2029,13 +2029,13 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     if (server.verbosity <= LL_VERBOSE) {
         run_with_period(5000) {
             for (j = 0; j < server.dbnum; j++) {
-                long long size, used, vkeys;
+                unsigned long size, used, vkeys;
 
                 size = dictSlots(server.db[j].dict);
                 used = dictSize(server.db[j].dict);
                 vkeys = dictSize(server.db[j].expires);
                 if (used || vkeys) {
-                    serverLog(LL_VERBOSE,"DB %d: %lld keys (%lld volatile) in %lld slots HT.",j,used,vkeys,size);
+                    serverLog(LL_VERBOSE,"DB %d: %lu keys (%lu volatile) in %lu slots HT.",j,used,vkeys,size);
                 }
             }
         }
@@ -4930,13 +4930,13 @@ sds genRedisInfoString(const char *section) {
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info, "# Keyspace\r\n");
         for (j = 0; j < server.dbnum; j++) {
-            long long keys, vkeys;
+            unsigned long keys, vkeys;
 
             keys = dictSize(server.db[j].dict);
             vkeys = dictSize(server.db[j].expires);
             if (keys || vkeys) {
                 info = sdscatprintf(info,
-                    "db%d:keys=%lld,expires=%lld,avg_ttl=%lld\r\n",
+                    "db%d:keys=%lu,expires=%lu,avg_ttl=%lld\r\n",
                     j, keys, vkeys, server.db[j].avg_ttl);
             }
         }

--- a/src/server.h
+++ b/src/server.h
@@ -1017,7 +1017,7 @@ struct redisMemOverhead {
     size_t lua_caches;
     size_t overhead_total;
     size_t dataset;
-    size_t total_keys;
+    long long total_keys;
     size_t bytes_per_key;
     float dataset_perc;
     float peak_perc;

--- a/src/server.h
+++ b/src/server.h
@@ -1017,7 +1017,7 @@ struct redisMemOverhead {
     size_t lua_caches;
     size_t overhead_total;
     size_t dataset;
-    long long total_keys;
+    unsigned long long total_keys;
     size_t bytes_per_key;
     float dataset_perc;
     float peak_perc;

--- a/src/server.h
+++ b/src/server.h
@@ -2249,10 +2249,10 @@ robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o);
 
 #define EMPTYDB_NO_FLAGS 0      /* No flags. */
 #define EMPTYDB_ASYNC (1<<0)    /* Reclaim memory in another thread. */
-long long emptyDb(int dbnum, int flags, void(callback)(void*));
-long long emptyDbStructure(redisDb *dbarray, int dbnum, int async, void(callback)(void*));
+unsigned long long emptyDb(int dbnum, int flags, void(callback)(void*));
+unsigned long long emptyDbStructure(redisDb *dbarray, int dbnum, int async, void(callback)(void*));
 void flushAllDataAndResetRDB(int flags);
-long long dbTotalServerKeyCount();
+unsigned long long dbTotalServerKeyCount();
 dbBackup *backupDb(void);
 void restoreDbBackup(dbBackup *buckup);
 void discardDbBackup(dbBackup *buckup, int flags, void(callback)(void*));

--- a/src/sort.c
+++ b/src/sort.c
@@ -194,7 +194,8 @@ void sortCommand(client *c) {
     unsigned int outputlen = 0;
     int desc = 0, alpha = 0;
     long limit_start = 0, limit_count = -1, start, end;
-    int j, dontsort = 0, vectorlen;
+    long vectorlen;
+    int j, dontsort = 0;
     int getop = 0; /* GET operation counter */
     int int_conversion_error = 0;
     int syntax_error = 0;

--- a/src/sort.c
+++ b/src/sort.c
@@ -194,8 +194,8 @@ void sortCommand(client *c) {
     unsigned int outputlen = 0;
     int desc = 0, alpha = 0;
     long limit_start = 0, limit_count = -1, start, end;
-    long vectorlen;
-    int j, dontsort = 0;
+    long j, vectorlen;
+    int dontsort = 0;
     int getop = 0; /* GET operation counter */
     int int_conversion_error = 0;
     int syntax_error = 0;
@@ -408,7 +408,7 @@ void sortCommand(client *c) {
         zskiplist *zsl = zs->zsl;
         zskiplistNode *ln;
         sds sdsele;
-        int rangelen = vectorlen;
+        long rangelen = vectorlen;
 
         /* Check if starting point is trivial, before doing log(N) lookup. */
         if (desc) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -858,8 +858,7 @@ static void addHashIteratorCursorToReply(client *c, hashTypeIterator *hi, int wh
 void genericHgetallCommand(client *c, int flags) {
     robj *o;
     hashTypeIterator *hi;
-    long length;
-    long long count = 0;
+    unsigned long length, count = 0;
 
     robj *emptyResp = (flags & OBJ_HASH_KEY && flags & OBJ_HASH_VALUE) ?
         shared.emptymap[c->resp] : shared.emptyarray;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -858,7 +858,8 @@ static void addHashIteratorCursorToReply(client *c, hashTypeIterator *hi, int wh
 void genericHgetallCommand(client *c, int flags) {
     robj *o;
     hashTypeIterator *hi;
-    int length, count = 0;
+    long length;
+    long long count = 0;
 
     robj *emptyResp = (flags & OBJ_HASH_KEY && flags & OBJ_HASH_VALUE) ?
         shared.emptymap[c->resp] : shared.emptyarray;

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1007,7 +1007,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
      *
      * We compute what is the best bet with the current input here. */
     if (op == SET_OP_DIFF && sets[0]) {
-        long long algo_one_work = 0, algo_two_work = 0;
+        unsigned long long algo_one_work = 0, algo_two_work = 0;
 
         for (j = 0; j < setnum; j++) {
             if (sets[j] == NULL) continue;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2445,8 +2445,8 @@ static int zsetChooseDiffAlgorithm(zsetopsrc *src, long setnum) {
      * result set.
      *
      * We compute what is the best bet with the current input here. */
-    long long algo_one_work = 0;
-    long long algo_two_work = 0;
+    unsigned long long algo_one_work = 0;
+    unsigned long long algo_two_work = 0;
 
     for (j = 0; j < setnum; j++) {
         /* If any other set is equal to the first set, there is nothing to be


### PR DESCRIPTION
This fixes six issues:

1. Change key variable type to unsigned long
Because the maximum number of redis keys is greater than 2^32, so if the type is long or int, it will overflow.

2. Change sum of keys variable type to unsigned long long.
If it is the sum of N(>2) keys, using unsigned long to store it may cause an overflow.

3. Optimize performEvictions funcion, there is no need to calculate the sum of all keys(the original code may also overflow).

4. Fix dictGetRandomKey function implicit conversion overflow
If `count == server.maxmemory_samples` and server.maxmemory_samples is INT_MAX, `count*10` will overflow.

5. Change return type of emptyDb to unsigned long long
Return -1 in emptyDb is not used anywhere, and we can determine the error by `error == EINVAL`, so change it to 0.
And if -1 is returned, `server.dirty += emptyDb()` will result in server.dirty--, which obviously shouldn't happen.

6. Change variable type of sdslen to size_t.