### PR TITLE
In quicklistDelRange delete range wrong

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -1000,7 +1000,7 @@ int quicklistDelRange(quicklist *quicklist, const long start,
              * can just delete the entire node without ziplist math. */
             delete_entire_node = 1;
             del = node->count;
-        } else if (entry.offset >= 0 && extent >= node->count) {
+        } else if (entry.offset >= 0 && extent >= node->count - entry.offset) {
             /* If deleting more nodes after this one, calculate delete based
              * on size of current node. */
             del = node->count - entry.offset;


### PR DESCRIPTION
In quicklistDelRange when delete entry from entry.offset to node tail, extent only need gte node->count - entry.offset, not node->count.
```
        } else if (entry.offset >= 0 && extent >= node->count) {
            /* If deleting more nodes after this one, calculate delete based
             * on size of current node. */
            del = node->count - entry.offset;
```

For now, this code path nerver happen, because when use this function the first `entry.offset` is always <= 0.
But if we write a command like `lremrange key begin end` and use this function, errors will occur.