### PR TITLE
Fix quicklistDelRange dead code, delete range wrong

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -2239,6 +2239,17 @@ int quicklistTest(int argc, char *argv[]) {
             quicklistRelease(ql);
         }
 
+        TEST("delete less than fill but across nodes") {
+            quicklist *ql = quicklistNew(-2, options[_i]);
+            quicklistSetFill(ql, 32);
+            for (int i = 0; i < 500; i++)
+                quicklistPushTail(ql, genstr("hello", i + 1), 32);
+            ql_verify(ql, 16, 500, 32, 20);
+            quicklistDelRange(ql, 60, 10);
+            ql_verify(ql, 16, 490, 32, 20);
+            quicklistRelease(ql);
+        }
+
         TEST("delete negative 1 from 500 list") {
             quicklist *ql = quicklistNew(-2, options[_i]);
             quicklistSetFill(ql, 32);

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -1000,7 +1000,7 @@ int quicklistDelRange(quicklist *quicklist, const long start,
              * can just delete the entire node without ziplist math. */
             delete_entire_node = 1;
             del = node->count;
-        } else if (entry.offset >= 0 && extent >= node->count) {
+        } else if (entry.offset >= 0 && extent + entry.offset >= node->count) {
             /* If deleting more nodes after this one, calculate delete based
              * on size of current node. */
             del = node->count - entry.offset;


### PR DESCRIPTION
In quicklistDelRange when delete entry from entry.offset to node tail, extent only need gte node->count - entry.offset, not node->count.
```
        } else if (entry.offset >= 0 && extent >= node->count) {
            /* If deleting more nodes after this one, calculate delete based
             * on size of current node. */
            del = node->count - entry.offset;
```

For now, this code path nerver happen, because when use this function the first `entry.offset` is always <= 0.
But if we write a command like `lremrange key begin end` and use this function, errors will occur.
Because extent >= node->count - entry.offset will report comparison between signed and unsigned integer expressions error, we  
use extent + entry.offset >= node->count instead.