### PR TITLE
Fix compile warning when define REDIS_TEST

### DIFF
--- a/src/crc64.c
+++ b/src/crc64.c
@@ -134,7 +134,7 @@ int crc64Test(int argc, char *argv[]) {
     printf("[calcula]: e9c6d914c4b8d9ca == %016" PRIx64 "\n",
            (uint64_t)_crc64(0, "123456789", 9));
     printf("[64speed]: e9c6d914c4b8d9ca == %016" PRIx64 "\n",
-           (uint64_t)crc64(0, "123456789", 9));
+           (uint64_t)crc64(0, (unsigned char*)"123456789", 9));
     char li[] = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed "
                 "do eiusmod tempor incididunt ut labore et dolore magna "
                 "aliqua. Ut enim ad minim veniam, quis nostrud exercitation "
@@ -146,7 +146,7 @@ int crc64Test(int argc, char *argv[]) {
     printf("[calcula]: c7794709e69683b3 == %016" PRIx64 "\n",
            (uint64_t)_crc64(0, li, sizeof(li)));
     printf("[64speed]: c7794709e69683b3 == %016" PRIx64 "\n",
-           (uint64_t)crc64(0, li, sizeof(li)));
+           (uint64_t)crc64(0, (unsigned char*)li, sizeof(li)));
     return 0;
 }
 

--- a/src/intset.c
+++ b/src/intset.c
@@ -358,12 +358,6 @@ static long long usec(void) {
     return (((long long)tv.tv_sec)*1000000)+tv.tv_usec;
 }
 
-#define intsetAssert(_e) ((_e)?(void)0:(_assert(#_e,__FILE__,__LINE__),exit(1)))
-static void _assert(char *estr, char *file, int line) {
-    printf("\n\n=== ASSERTION FAILED ===\n");
-    printf("==> %s:%d '%s' is not true\n",file,line,estr);
-}
-
 static intset *createSet(int bits, int size) {
     uint64_t mask = (1<<bits)-1;
     uint64_t value;
@@ -386,13 +380,13 @@ static void checkConsistency(intset *is) {
 
         if (encoding == INTSET_ENC_INT16) {
             int16_t *i16 = (int16_t*)is->contents;
-            intsetAssert(i16[i] < i16[i+1]);
+            assert(i16[i] < i16[i+1]);
         } else if (encoding == INTSET_ENC_INT32) {
             int32_t *i32 = (int32_t*)is->contents;
-            intsetAssert(i32[i] < i32[i+1]);
+            assert(i32[i] < i32[i+1]);
         } else {
             int64_t *i64 = (int64_t*)is->contents;
-            intsetAssert(i64[i] < i64[i+1]);
+            assert(i64[i] < i64[i+1]);
         }
     }
 }
@@ -408,27 +402,27 @@ int intsetTest(int argc, char **argv) {
     UNUSED(argv);
 
     printf("Value encodings: "); {
-        intsetAssert(_intsetValueEncoding(-32768) == INTSET_ENC_INT16);
-        intsetAssert(_intsetValueEncoding(+32767) == INTSET_ENC_INT16);
-        intsetAssert(_intsetValueEncoding(-32769) == INTSET_ENC_INT32);
-        intsetAssert(_intsetValueEncoding(+32768) == INTSET_ENC_INT32);
-        intsetAssert(_intsetValueEncoding(-2147483648) == INTSET_ENC_INT32);
-        intsetAssert(_intsetValueEncoding(+2147483647) == INTSET_ENC_INT32);
-        intsetAssert(_intsetValueEncoding(-2147483649) == INTSET_ENC_INT64);
-        intsetAssert(_intsetValueEncoding(+2147483648) == INTSET_ENC_INT64);
-        intsetAssert(_intsetValueEncoding(-9223372036854775808ull) ==
+        assert(_intsetValueEncoding(-32768) == INTSET_ENC_INT16);
+        assert(_intsetValueEncoding(+32767) == INTSET_ENC_INT16);
+        assert(_intsetValueEncoding(-32769) == INTSET_ENC_INT32);
+        assert(_intsetValueEncoding(+32768) == INTSET_ENC_INT32);
+        assert(_intsetValueEncoding(-2147483648) == INTSET_ENC_INT32);
+        assert(_intsetValueEncoding(+2147483647) == INTSET_ENC_INT32);
+        assert(_intsetValueEncoding(-2147483649) == INTSET_ENC_INT64);
+        assert(_intsetValueEncoding(+2147483648) == INTSET_ENC_INT64);
+        assert(_intsetValueEncoding(-9223372036854775808ull) ==
                     INTSET_ENC_INT64);
-        intsetAssert(_intsetValueEncoding(+9223372036854775807ull) ==
+        assert(_intsetValueEncoding(+9223372036854775807ull) ==
                     INTSET_ENC_INT64);
         ok();
     }
 
     printf("Basic adding: "); {
         is = intsetNew();
-        is = intsetAdd(is,5,&success); intsetAssert(success);
-        is = intsetAdd(is,6,&success); intsetAssert(success);
-        is = intsetAdd(is,4,&success); intsetAssert(success);
-        is = intsetAdd(is,4,&success); intsetAssert(!success);
+        is = intsetAdd(is,5,&success); assert(success);
+        is = intsetAdd(is,6,&success); assert(success);
+        is = intsetAdd(is,4,&success); assert(success);
+        is = intsetAdd(is,4,&success); assert(!success);
         ok();
     }
 
@@ -439,7 +433,7 @@ int intsetTest(int argc, char **argv) {
             is = intsetAdd(is,rand()%0x800,&success);
             if (success) inserts++;
         }
-        intsetAssert(intrev32ifbe(is->length) == inserts);
+        assert(intrev32ifbe(is->length) == inserts);
         checkConsistency(is);
         ok();
     }
@@ -447,20 +441,20 @@ int intsetTest(int argc, char **argv) {
     printf("Upgrade from int16 to int32: "); {
         is = intsetNew();
         is = intsetAdd(is,32,NULL);
-        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
+        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
         is = intsetAdd(is,65535,NULL);
-        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
-        intsetAssert(intsetFind(is,32));
-        intsetAssert(intsetFind(is,65535));
+        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
+        assert(intsetFind(is,32));
+        assert(intsetFind(is,65535));
         checkConsistency(is);
 
         is = intsetNew();
         is = intsetAdd(is,32,NULL);
-        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
+        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
         is = intsetAdd(is,-65535,NULL);
-        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
-        intsetAssert(intsetFind(is,32));
-        intsetAssert(intsetFind(is,-65535));
+        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
+        assert(intsetFind(is,32));
+        assert(intsetFind(is,-65535));
         checkConsistency(is);
         ok();
     }
@@ -468,20 +462,20 @@ int intsetTest(int argc, char **argv) {
     printf("Upgrade from int16 to int64: "); {
         is = intsetNew();
         is = intsetAdd(is,32,NULL);
-        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
+        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
         is = intsetAdd(is,4294967295,NULL);
-        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
-        intsetAssert(intsetFind(is,32));
-        intsetAssert(intsetFind(is,4294967295));
+        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
+        assert(intsetFind(is,32));
+        assert(intsetFind(is,4294967295));
         checkConsistency(is);
 
         is = intsetNew();
         is = intsetAdd(is,32,NULL);
-        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
+        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
         is = intsetAdd(is,-4294967295,NULL);
-        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
-        intsetAssert(intsetFind(is,32));
-        intsetAssert(intsetFind(is,-4294967295));
+        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
+        assert(intsetFind(is,32));
+        assert(intsetFind(is,-4294967295));
         checkConsistency(is);
         ok();
     }
@@ -489,20 +483,20 @@ int intsetTest(int argc, char **argv) {
     printf("Upgrade from int32 to int64: "); {
         is = intsetNew();
         is = intsetAdd(is,65535,NULL);
-        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
+        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
         is = intsetAdd(is,4294967295,NULL);
-        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
-        intsetAssert(intsetFind(is,65535));
-        intsetAssert(intsetFind(is,4294967295));
+        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
+        assert(intsetFind(is,65535));
+        assert(intsetFind(is,4294967295));
         checkConsistency(is);
 
         is = intsetNew();
         is = intsetAdd(is,65535,NULL);
-        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
+        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
         is = intsetAdd(is,-4294967295,NULL);
-        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
-        intsetAssert(intsetFind(is,65535));
-        intsetAssert(intsetFind(is,-4294967295));
+        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
+        assert(intsetFind(is,65535));
+        assert(intsetFind(is,-4294967295));
         checkConsistency(is);
         ok();
     }
@@ -526,11 +520,11 @@ int intsetTest(int argc, char **argv) {
         for (i = 0; i < 0xffff; i++) {
             v1 = rand() % 0xfff;
             is = intsetAdd(is,v1,NULL);
-            intsetAssert(intsetFind(is,v1));
+            assert(intsetFind(is,v1));
 
             v2 = rand() % 0xfff;
             is = intsetRemove(is,v2,NULL);
-            intsetAssert(!intsetFind(is,v2));
+            assert(!intsetFind(is,v2));
         }
         checkConsistency(is);
         ok();

--- a/src/intset.c
+++ b/src/intset.c
@@ -358,7 +358,7 @@ static long long usec(void) {
     return (((long long)tv.tv_sec)*1000000)+tv.tv_usec;
 }
 
-#define assert(_e) ((_e)?(void)0:(_assert(#_e,__FILE__,__LINE__),exit(1)))
+#define intsetAssert(_e) ((_e)?(void)0:(_assert(#_e,__FILE__,__LINE__),exit(1)))
 static void _assert(char *estr, char *file, int line) {
     printf("\n\n=== ASSERTION FAILED ===\n");
     printf("==> %s:%d '%s' is not true\n",file,line,estr);
@@ -386,13 +386,13 @@ static void checkConsistency(intset *is) {
 
         if (encoding == INTSET_ENC_INT16) {
             int16_t *i16 = (int16_t*)is->contents;
-            assert(i16[i] < i16[i+1]);
+            intsetAssert(i16[i] < i16[i+1]);
         } else if (encoding == INTSET_ENC_INT32) {
             int32_t *i32 = (int32_t*)is->contents;
-            assert(i32[i] < i32[i+1]);
+            intsetAssert(i32[i] < i32[i+1]);
         } else {
             int64_t *i64 = (int64_t*)is->contents;
-            assert(i64[i] < i64[i+1]);
+            intsetAssert(i64[i] < i64[i+1]);
         }
     }
 }
@@ -408,27 +408,27 @@ int intsetTest(int argc, char **argv) {
     UNUSED(argv);
 
     printf("Value encodings: "); {
-        assert(_intsetValueEncoding(-32768) == INTSET_ENC_INT16);
-        assert(_intsetValueEncoding(+32767) == INTSET_ENC_INT16);
-        assert(_intsetValueEncoding(-32769) == INTSET_ENC_INT32);
-        assert(_intsetValueEncoding(+32768) == INTSET_ENC_INT32);
-        assert(_intsetValueEncoding(-2147483648) == INTSET_ENC_INT32);
-        assert(_intsetValueEncoding(+2147483647) == INTSET_ENC_INT32);
-        assert(_intsetValueEncoding(-2147483649) == INTSET_ENC_INT64);
-        assert(_intsetValueEncoding(+2147483648) == INTSET_ENC_INT64);
-        assert(_intsetValueEncoding(-9223372036854775808ull) ==
+        intsetAssert(_intsetValueEncoding(-32768) == INTSET_ENC_INT16);
+        intsetAssert(_intsetValueEncoding(+32767) == INTSET_ENC_INT16);
+        intsetAssert(_intsetValueEncoding(-32769) == INTSET_ENC_INT32);
+        intsetAssert(_intsetValueEncoding(+32768) == INTSET_ENC_INT32);
+        intsetAssert(_intsetValueEncoding(-2147483648) == INTSET_ENC_INT32);
+        intsetAssert(_intsetValueEncoding(+2147483647) == INTSET_ENC_INT32);
+        intsetAssert(_intsetValueEncoding(-2147483649) == INTSET_ENC_INT64);
+        intsetAssert(_intsetValueEncoding(+2147483648) == INTSET_ENC_INT64);
+        intsetAssert(_intsetValueEncoding(-9223372036854775808ull) ==
                     INTSET_ENC_INT64);
-        assert(_intsetValueEncoding(+9223372036854775807ull) ==
+        intsetAssert(_intsetValueEncoding(+9223372036854775807ull) ==
                     INTSET_ENC_INT64);
         ok();
     }
 
     printf("Basic adding: "); {
         is = intsetNew();
-        is = intsetAdd(is,5,&success); assert(success);
-        is = intsetAdd(is,6,&success); assert(success);
-        is = intsetAdd(is,4,&success); assert(success);
-        is = intsetAdd(is,4,&success); assert(!success);
+        is = intsetAdd(is,5,&success); intsetAssert(success);
+        is = intsetAdd(is,6,&success); intsetAssert(success);
+        is = intsetAdd(is,4,&success); intsetAssert(success);
+        is = intsetAdd(is,4,&success); intsetAssert(!success);
         ok();
     }
 
@@ -439,7 +439,7 @@ int intsetTest(int argc, char **argv) {
             is = intsetAdd(is,rand()%0x800,&success);
             if (success) inserts++;
         }
-        assert(intrev32ifbe(is->length) == inserts);
+        intsetAssert(intrev32ifbe(is->length) == inserts);
         checkConsistency(is);
         ok();
     }
@@ -447,20 +447,20 @@ int intsetTest(int argc, char **argv) {
     printf("Upgrade from int16 to int32: "); {
         is = intsetNew();
         is = intsetAdd(is,32,NULL);
-        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
+        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
         is = intsetAdd(is,65535,NULL);
-        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
-        assert(intsetFind(is,32));
-        assert(intsetFind(is,65535));
+        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
+        intsetAssert(intsetFind(is,32));
+        intsetAssert(intsetFind(is,65535));
         checkConsistency(is);
 
         is = intsetNew();
         is = intsetAdd(is,32,NULL);
-        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
+        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
         is = intsetAdd(is,-65535,NULL);
-        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
-        assert(intsetFind(is,32));
-        assert(intsetFind(is,-65535));
+        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
+        intsetAssert(intsetFind(is,32));
+        intsetAssert(intsetFind(is,-65535));
         checkConsistency(is);
         ok();
     }
@@ -468,20 +468,20 @@ int intsetTest(int argc, char **argv) {
     printf("Upgrade from int16 to int64: "); {
         is = intsetNew();
         is = intsetAdd(is,32,NULL);
-        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
+        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
         is = intsetAdd(is,4294967295,NULL);
-        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
-        assert(intsetFind(is,32));
-        assert(intsetFind(is,4294967295));
+        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
+        intsetAssert(intsetFind(is,32));
+        intsetAssert(intsetFind(is,4294967295));
         checkConsistency(is);
 
         is = intsetNew();
         is = intsetAdd(is,32,NULL);
-        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
+        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT16);
         is = intsetAdd(is,-4294967295,NULL);
-        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
-        assert(intsetFind(is,32));
-        assert(intsetFind(is,-4294967295));
+        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
+        intsetAssert(intsetFind(is,32));
+        intsetAssert(intsetFind(is,-4294967295));
         checkConsistency(is);
         ok();
     }
@@ -489,20 +489,20 @@ int intsetTest(int argc, char **argv) {
     printf("Upgrade from int32 to int64: "); {
         is = intsetNew();
         is = intsetAdd(is,65535,NULL);
-        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
+        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
         is = intsetAdd(is,4294967295,NULL);
-        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
-        assert(intsetFind(is,65535));
-        assert(intsetFind(is,4294967295));
+        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
+        intsetAssert(intsetFind(is,65535));
+        intsetAssert(intsetFind(is,4294967295));
         checkConsistency(is);
 
         is = intsetNew();
         is = intsetAdd(is,65535,NULL);
-        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
+        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT32);
         is = intsetAdd(is,-4294967295,NULL);
-        assert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
-        assert(intsetFind(is,65535));
-        assert(intsetFind(is,-4294967295));
+        intsetAssert(intrev32ifbe(is->encoding) == INTSET_ENC_INT64);
+        intsetAssert(intsetFind(is,65535));
+        intsetAssert(intsetFind(is,-4294967295));
         checkConsistency(is);
         ok();
     }
@@ -526,11 +526,11 @@ int intsetTest(int argc, char **argv) {
         for (i = 0; i < 0xffff; i++) {
             v1 = rand() % 0xfff;
             is = intsetAdd(is,v1,NULL);
-            assert(intsetFind(is,v1));
+            intsetAssert(intsetFind(is,v1));
 
             v2 = rand() % 0xfff;
             is = intsetRemove(is,v2,NULL);
-            assert(!intsetFind(is,v2));
+            intsetAssert(!intsetFind(is,v2));
         }
         checkConsistency(is);
         ok();

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -1508,15 +1508,6 @@ void quicklistBookmarksClear(quicklist *ql) {
 #include <stdint.h>
 #include <sys/time.h>
 
-#define quicklistAssert(_e)                                                             \
-    do {                                                                       \
-        if (!(_e)) {                                                           \
-            printf("\n\n=== ASSERTION FAILED ===\n");                          \
-            printf("==> %s:%d '%s' is not true\n", __FILE__, __LINE__, #_e);   \
-            err++;                                                             \
-        }                                                                      \
-    } while (0)
-
 #define yell(str, ...) printf("ERROR! " str "\n\n", __VA_ARGS__)
 
 #define OK printf("\tOK\n")
@@ -1858,8 +1849,8 @@ int quicklistTest(int argc, char *argv[]) {
             long long lv;
             ql_info(ql);
             quicklistPop(ql, QUICKLIST_HEAD, &data, &sz, &lv);
-            quicklistAssert(data != NULL);
-            quicklistAssert(sz == 32);
+            assert(data != NULL);
+            assert(sz == 32);
             if (strcmp(populate, (char *)data))
                 ERR("Pop'd value (%.*s) didn't equal original value (%s)", sz,
                     data, populate);
@@ -1876,8 +1867,8 @@ int quicklistTest(int argc, char *argv[]) {
             long long lv;
             ql_info(ql);
             quicklistPop(ql, QUICKLIST_HEAD, &data, &sz, &lv);
-            quicklistAssert(data == NULL);
-            quicklistAssert(lv == 55513);
+            assert(data == NULL);
+            assert(lv == 55513);
             ql_verify(ql, 0, 0, 0, 0);
             quicklistRelease(ql);
         }
@@ -1892,9 +1883,9 @@ int quicklistTest(int argc, char *argv[]) {
                 unsigned int sz;
                 long long lv;
                 int ret = quicklistPop(ql, QUICKLIST_HEAD, &data, &sz, &lv);
-                quicklistAssert(ret == 1);
-                quicklistAssert(data != NULL);
-                quicklistAssert(sz == 32);
+                assert(ret == 1);
+                assert(data != NULL);
+                assert(sz == 32);
                 if (strcmp(genstr("hello", 499 - i), (char *)data))
                     ERR("Pop'd value (%.*s) didn't equal original value (%s)",
                         sz, data, genstr("hello", 499 - i));
@@ -1914,16 +1905,16 @@ int quicklistTest(int argc, char *argv[]) {
                 long long lv;
                 int ret = quicklistPop(ql, QUICKLIST_HEAD, &data, &sz, &lv);
                 if (i < 500) {
-                    quicklistAssert(ret == 1);
-                    quicklistAssert(data != NULL);
-                    quicklistAssert(sz == 32);
+                    assert(ret == 1);
+                    assert(data != NULL);
+                    assert(sz == 32);
                     if (strcmp(genstr("hello", 499 - i), (char *)data))
                         ERR("Pop'd value (%.*s) didn't equal original value "
                             "(%s)",
                             sz, data, genstr("hello", 499 - i));
                     zfree(data);
                 } else {
-                    quicklistAssert(ret == 0);
+                    assert(ret == 0);
                 }
             }
             ql_verify(ql, 0, 0, 0, 0);
@@ -2741,23 +2732,23 @@ int quicklistTest(int argc, char *argv[]) {
         quicklistPushTail(ql, "3", 1);
         quicklistPushTail(ql, "4", 1);
         quicklistPushTail(ql, "5", 1);
-        quicklistAssert(ql->len==5);
+        assert(ql->len==5);
         /* add two bookmarks, one pointing to the node before the last. */
-        quicklistAssert(quicklistBookmarkCreate(&ql, "_dummy", ql->head->next));
-        quicklistAssert(quicklistBookmarkCreate(&ql, "_test", ql->tail->prev));
+        assert(quicklistBookmarkCreate(&ql, "_dummy", ql->head->next));
+        assert(quicklistBookmarkCreate(&ql, "_test", ql->tail->prev));
         /* test that the bookmark returns the right node, delete it and see that the bookmark points to the last node */
-        quicklistAssert(quicklistBookmarkFind(ql, "_test") == ql->tail->prev);
-        quicklistAssert(quicklistDelRange(ql, -2, 1));
-        quicklistAssert(quicklistBookmarkFind(ql, "_test") == ql->tail);
+        assert(quicklistBookmarkFind(ql, "_test") == ql->tail->prev);
+        assert(quicklistDelRange(ql, -2, 1));
+        assert(quicklistBookmarkFind(ql, "_test") == ql->tail);
         /* delete the last node, and see that the bookmark was deleted. */
-        quicklistAssert(quicklistDelRange(ql, -1, 1));
-        quicklistAssert(quicklistBookmarkFind(ql, "_test") == NULL);
+        assert(quicklistDelRange(ql, -1, 1));
+        assert(quicklistBookmarkFind(ql, "_test") == NULL);
         /* test that other bookmarks aren't affected */
-        quicklistAssert(quicklistBookmarkFind(ql, "_dummy") == ql->head->next);
-        quicklistAssert(quicklistBookmarkFind(ql, "_missing") == NULL);
-        quicklistAssert(ql->len==3);
+        assert(quicklistBookmarkFind(ql, "_dummy") == ql->head->next);
+        assert(quicklistBookmarkFind(ql, "_missing") == NULL);
+        assert(ql->len==3);
         quicklistBookmarksClear(ql); /* for coverage */
-        quicklistAssert(quicklistBookmarkFind(ql, "_dummy") == NULL);
+        assert(quicklistBookmarkFind(ql, "_dummy") == NULL);
         quicklistRelease(ql);
     }
 
@@ -2766,19 +2757,19 @@ int quicklistTest(int argc, char *argv[]) {
         quicklist *ql = quicklistNew(1, 0);
         quicklistPushHead(ql, "1", 1);
         for (i=0; i<QL_MAX_BM; i++)
-            quicklistAssert(quicklistBookmarkCreate(&ql, genstr("",i), ql->head));
+            assert(quicklistBookmarkCreate(&ql, genstr("",i), ql->head));
         /* when all bookmarks are used, creation fails */
-        quicklistAssert(!quicklistBookmarkCreate(&ql, "_test", ql->head));
+        assert(!quicklistBookmarkCreate(&ql, "_test", ql->head));
         /* delete one and see that we can now create another */
-        quicklistAssert(quicklistBookmarkDelete(ql, "0"));
-        quicklistAssert(quicklistBookmarkCreate(&ql, "_test", ql->head));
+        assert(quicklistBookmarkDelete(ql, "0"));
+        assert(quicklistBookmarkCreate(&ql, "_test", ql->head));
         /* delete one and see that the rest survive */
-        quicklistAssert(quicklistBookmarkDelete(ql, "_test"));
+        assert(quicklistBookmarkDelete(ql, "_test"));
         for (i=1; i<QL_MAX_BM; i++)
-            quicklistAssert(quicklistBookmarkFind(ql, genstr("",i)) == ql->head);
+            assert(quicklistBookmarkFind(ql, genstr("",i)) == ql->head);
         /* make sure the deleted ones are indeed gone */
-        quicklistAssert(!quicklistBookmarkFind(ql, "0"));
-        quicklistAssert(!quicklistBookmarkFind(ql, "_test"));
+        assert(!quicklistBookmarkFind(ql, "0"));
+        assert(!quicklistBookmarkFind(ql, "_test"));
         quicklistRelease(ql);
     }
 

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -66,7 +66,7 @@ static const size_t optimization_level[] = {4096, 8192, 16384, 32768, 65536};
 #else
 #define D(...)                                                                 \
     do {                                                                       \
-        printf("%s:%s:%d:\t", __FILE__, __FUNCTION__, __LINE__);               \
+        printf("%s:%s:%d:\t", __FILE__, __func__, __LINE__);               \
         printf(__VA_ARGS__);                                                   \
         printf("\n");                                                          \
     } while (0)
@@ -1508,7 +1508,7 @@ void quicklistBookmarksClear(quicklist *ql) {
 #include <stdint.h>
 #include <sys/time.h>
 
-#define assert(_e)                                                             \
+#define quicklistAssert(_e)                                                             \
     do {                                                                       \
         if (!(_e)) {                                                           \
             printf("\n\n=== ASSERTION FAILED ===\n");                          \
@@ -1529,7 +1529,7 @@ void quicklistBookmarksClear(quicklist *ql) {
 
 #define ERR(x, ...)                                                            \
     do {                                                                       \
-        printf("%s:%s:%d:\t", __FILE__, __FUNCTION__, __LINE__);               \
+        printf("%s:%s:%d:\t", __FILE__, __func__, __LINE__);               \
         printf("ERROR! " x "\n", __VA_ARGS__);                                 \
         err++;                                                                 \
     } while (0)
@@ -1614,7 +1614,7 @@ static int _ql_verify(quicklist *ql, uint32_t len, uint32_t count,
 
     ql_info(ql);
     if (len != ql->len) {
-        yell("quicklist length wrong: expected %d, got %u", len, ql->len);
+        yell("quicklist length wrong: expected %d, got %lu", len, ql->len);
         errors++;
     }
 
@@ -1670,7 +1670,7 @@ static int _ql_verify(quicklist *ql, uint32_t len, uint32_t count,
                 if (node->encoding != QUICKLIST_NODE_ENCODING_RAW) {
                     yell("Incorrect compression: node %d is "
                          "compressed at depth %d ((%u, %u); total "
-                         "nodes: %u; size: %u; recompress: %d)",
+                         "nodes: %lu; size: %u; recompress: %d)",
                          at, ql->compress, low_raw, high_raw, ql->len, node->sz,
                          node->recompress);
                     errors++;
@@ -1680,7 +1680,7 @@ static int _ql_verify(quicklist *ql, uint32_t len, uint32_t count,
                     !node->attempted_compress) {
                     yell("Incorrect non-compression: node %d is NOT "
                          "compressed at depth %d ((%u, %u); total "
-                         "nodes: %u; size: %u; recompress: %d; attempted: %d)",
+                         "nodes: %lu; size: %u; recompress: %d; attempted: %d)",
                          at, ql->compress, low_raw, high_raw, ql->len, node->sz,
                          node->recompress, node->attempted_compress);
                     errors++;
@@ -1858,8 +1858,8 @@ int quicklistTest(int argc, char *argv[]) {
             long long lv;
             ql_info(ql);
             quicklistPop(ql, QUICKLIST_HEAD, &data, &sz, &lv);
-            assert(data != NULL);
-            assert(sz == 32);
+            quicklistAssert(data != NULL);
+            quicklistAssert(sz == 32);
             if (strcmp(populate, (char *)data))
                 ERR("Pop'd value (%.*s) didn't equal original value (%s)", sz,
                     data, populate);
@@ -1876,8 +1876,8 @@ int quicklistTest(int argc, char *argv[]) {
             long long lv;
             ql_info(ql);
             quicklistPop(ql, QUICKLIST_HEAD, &data, &sz, &lv);
-            assert(data == NULL);
-            assert(lv == 55513);
+            quicklistAssert(data == NULL);
+            quicklistAssert(lv == 55513);
             ql_verify(ql, 0, 0, 0, 0);
             quicklistRelease(ql);
         }
@@ -1892,9 +1892,9 @@ int quicklistTest(int argc, char *argv[]) {
                 unsigned int sz;
                 long long lv;
                 int ret = quicklistPop(ql, QUICKLIST_HEAD, &data, &sz, &lv);
-                assert(ret == 1);
-                assert(data != NULL);
-                assert(sz == 32);
+                quicklistAssert(ret == 1);
+                quicklistAssert(data != NULL);
+                quicklistAssert(sz == 32);
                 if (strcmp(genstr("hello", 499 - i), (char *)data))
                     ERR("Pop'd value (%.*s) didn't equal original value (%s)",
                         sz, data, genstr("hello", 499 - i));
@@ -1914,16 +1914,16 @@ int quicklistTest(int argc, char *argv[]) {
                 long long lv;
                 int ret = quicklistPop(ql, QUICKLIST_HEAD, &data, &sz, &lv);
                 if (i < 500) {
-                    assert(ret == 1);
-                    assert(data != NULL);
-                    assert(sz == 32);
+                    quicklistAssert(ret == 1);
+                    quicklistAssert(data != NULL);
+                    quicklistAssert(sz == 32);
                     if (strcmp(genstr("hello", 499 - i), (char *)data))
                         ERR("Pop'd value (%.*s) didn't equal original value "
                             "(%s)",
                             sz, data, genstr("hello", 499 - i));
                     zfree(data);
                 } else {
-                    assert(ret == 0);
+                    quicklistAssert(ret == 0);
                 }
             }
             ql_verify(ql, 0, 0, 0, 0);
@@ -2706,7 +2706,7 @@ int quicklistTest(int argc, char *argv[]) {
                             if (node->encoding != QUICKLIST_NODE_ENCODING_RAW) {
                                 ERR("Incorrect compression: node %d is "
                                     "compressed at depth %d ((%u, %u); total "
-                                    "nodes: %u; size: %u)",
+                                    "nodes: %lu; size: %u)",
                                     at, depth, low_raw, high_raw, ql->len,
                                     node->sz);
                             }
@@ -2714,7 +2714,7 @@ int quicklistTest(int argc, char *argv[]) {
                             if (node->encoding != QUICKLIST_NODE_ENCODING_LZF) {
                                 ERR("Incorrect non-compression: node %d is NOT "
                                     "compressed at depth %d ((%u, %u); total "
-                                    "nodes: %u; size: %u; attempted: %d)",
+                                    "nodes: %lu; size: %u; attempted: %d)",
                                     at, depth, low_raw, high_raw, ql->len,
                                     node->sz, node->attempted_compress);
                             }
@@ -2741,23 +2741,23 @@ int quicklistTest(int argc, char *argv[]) {
         quicklistPushTail(ql, "3", 1);
         quicklistPushTail(ql, "4", 1);
         quicklistPushTail(ql, "5", 1);
-        assert(ql->len==5);
+        quicklistAssert(ql->len==5);
         /* add two bookmarks, one pointing to the node before the last. */
-        assert(quicklistBookmarkCreate(&ql, "_dummy", ql->head->next));
-        assert(quicklistBookmarkCreate(&ql, "_test", ql->tail->prev));
+        quicklistAssert(quicklistBookmarkCreate(&ql, "_dummy", ql->head->next));
+        quicklistAssert(quicklistBookmarkCreate(&ql, "_test", ql->tail->prev));
         /* test that the bookmark returns the right node, delete it and see that the bookmark points to the last node */
-        assert(quicklistBookmarkFind(ql, "_test") == ql->tail->prev);
-        assert(quicklistDelRange(ql, -2, 1));
-        assert(quicklistBookmarkFind(ql, "_test") == ql->tail);
+        quicklistAssert(quicklistBookmarkFind(ql, "_test") == ql->tail->prev);
+        quicklistAssert(quicklistDelRange(ql, -2, 1));
+        quicklistAssert(quicklistBookmarkFind(ql, "_test") == ql->tail);
         /* delete the last node, and see that the bookmark was deleted. */
-        assert(quicklistDelRange(ql, -1, 1));
-        assert(quicklistBookmarkFind(ql, "_test") == NULL);
+        quicklistAssert(quicklistDelRange(ql, -1, 1));
+        quicklistAssert(quicklistBookmarkFind(ql, "_test") == NULL);
         /* test that other bookmarks aren't affected */
-        assert(quicklistBookmarkFind(ql, "_dummy") == ql->head->next);
-        assert(quicklistBookmarkFind(ql, "_missing") == NULL);
-        assert(ql->len==3);
+        quicklistAssert(quicklistBookmarkFind(ql, "_dummy") == ql->head->next);
+        quicklistAssert(quicklistBookmarkFind(ql, "_missing") == NULL);
+        quicklistAssert(ql->len==3);
         quicklistBookmarksClear(ql); /* for coverage */
-        assert(quicklistBookmarkFind(ql, "_dummy") == NULL);
+        quicklistAssert(quicklistBookmarkFind(ql, "_dummy") == NULL);
         quicklistRelease(ql);
     }
 
@@ -2766,19 +2766,19 @@ int quicklistTest(int argc, char *argv[]) {
         quicklist *ql = quicklistNew(1, 0);
         quicklistPushHead(ql, "1", 1);
         for (i=0; i<QL_MAX_BM; i++)
-            assert(quicklistBookmarkCreate(&ql, genstr("",i), ql->head));
+            quicklistAssert(quicklistBookmarkCreate(&ql, genstr("",i), ql->head));
         /* when all bookmarks are used, creation fails */
-        assert(!quicklistBookmarkCreate(&ql, "_test", ql->head));
+        quicklistAssert(!quicklistBookmarkCreate(&ql, "_test", ql->head));
         /* delete one and see that we can now create another */
-        assert(quicklistBookmarkDelete(ql, "0"));
-        assert(quicklistBookmarkCreate(&ql, "_test", ql->head));
+        quicklistAssert(quicklistBookmarkDelete(ql, "0"));
+        quicklistAssert(quicklistBookmarkCreate(&ql, "_test", ql->head));
         /* delete one and see that the rest survive */
-        assert(quicklistBookmarkDelete(ql, "_test"));
+        quicklistAssert(quicklistBookmarkDelete(ql, "_test"));
         for (i=1; i<QL_MAX_BM; i++)
-            assert(quicklistBookmarkFind(ql, genstr("",i)) == ql->head);
+            quicklistAssert(quicklistBookmarkFind(ql, genstr("",i)) == ql->head);
         /* make sure the deleted ones are indeed gone */
-        assert(!quicklistBookmarkFind(ql, "0"));
-        assert(!quicklistBookmarkFind(ql, "_test"));
+        quicklistAssert(!quicklistBookmarkFind(ql, "0"));
+        quicklistAssert(!quicklistBookmarkFind(ql, "_test"));
         quicklistRelease(ql);
     }
 

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -66,7 +66,7 @@ static const size_t optimization_level[] = {4096, 8192, 16384, 32768, 65536};
 #else
 #define D(...)                                                                 \
     do {                                                                       \
-        printf("%s:%s:%d:\t", __FILE__, __func__, __LINE__);               \
+        printf("%s:%s:%d:\t", __FILE__, __func__, __LINE__);                   \
         printf(__VA_ARGS__);                                                   \
         printf("\n");                                                          \
     } while (0)
@@ -1520,7 +1520,7 @@ void quicklistBookmarksClear(quicklist *ql) {
 
 #define ERR(x, ...)                                                            \
     do {                                                                       \
-        printf("%s:%s:%d:\t", __FILE__, __func__, __LINE__);               \
+        printf("%s:%s:%d:\t", __FILE__, __func__, __LINE__);                   \
         printf("ERROR! " x "\n", __VA_ARGS__);                                 \
         err++;                                                                 \
     } while (0)

--- a/src/rax.c
+++ b/src/rax.c
@@ -61,7 +61,7 @@ void raxDebugShowNode(const char *msg, raxNode *n);
 #ifdef RAX_DEBUG_MSG
 #define debugf(...)                                                            \
     if (raxDebugMsg) {                                                         \
-        printf("%s:%s:%d:\t", __FILE__, __func__, __LINE__);               \
+        printf("%s:%s:%d:\t", __FILE__, __func__, __LINE__);                   \
         printf(__VA_ARGS__);                                                   \
         fflush(stdout);                                                        \
     }

--- a/src/rax.c
+++ b/src/rax.c
@@ -61,7 +61,7 @@ void raxDebugShowNode(const char *msg, raxNode *n);
 #ifdef RAX_DEBUG_MSG
 #define debugf(...)                                                            \
     if (raxDebugMsg) {                                                         \
-        printf("%s:%s:%d:\t", __FILE__, __FUNCTION__, __LINE__);               \
+        printf("%s:%s:%d:\t", __FILE__, __func__, __LINE__);               \
         printf(__VA_ARGS__);                                                   \
         fflush(stdout);                                                        \
     }

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1713,7 +1713,7 @@ int ziplistTest(int argc, char **argv) {
         if (p == NULL) {
             printf("No entry\n");
         } else {
-            printf("ERROR: Out of range index should return NULL, returned offset: %ld\n", p-zl);
+            printf("ERROR: Out of range index should return NULL, returned offset: %ld\n", (long)(p-zl));
             return 1;
         }
         printf("\n");
@@ -1763,7 +1763,7 @@ int ziplistTest(int argc, char **argv) {
         if (p == NULL) {
             printf("No entry\n");
         } else {
-            printf("ERROR: Out of range index should return NULL, returned offset: %ld\n", p-zl);
+            printf("ERROR: Out of range index should return NULL, returned offset: %ld\n", (long)(p-zl));
             return 1;
         }
         printf("\n");


### PR DESCRIPTION
1. Change `__FUNCTION__` to `__func__`
2. Fix printf format.
3. Replace the assert in quicklist and intset with the assert of redisAssert.