### PR TITLE
Fix rdb checksum / crc64 on bigendian

### DIFF
--- a/src/crcspeed.c
+++ b/src/crcspeed.c
@@ -35,7 +35,8 @@ void crcspeed64little_init(crcfn64 crcfn, uint64_t table[8][256]) {
 
     /* generate CRCs for all single byte sequences */
     for (int n = 0; n < 256; n++) {
-        table[0][n] = crcfn(0, &n, 1);
+        unsigned char v = n;
+        table[0][n] = crcfn(0, &v, 1);
     }
 
     /* generate nested CRC table for future slice-by-8 lookup */


### PR DESCRIPTION
Turns out the RDB checksum in Redis 6.0 on bigendian is broken.
It always returned 0, so the RDB files are generated as if checksum is
disabled, and will be loaded ok on littleendian, and on bigendian.
But it'll not be able to load RDB files generated on littleendian or older versions.

Similarly DUMP and RESTORE will work on the same version (0==0),
but will be unable to exchange dump payloads with littleendian or old versions.