### PR TITLE
Sentinel: Fix Config Dependency and Rewrite Sequence issue

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -624,8 +624,7 @@ void loadServerConfigFromString(char *config) {
                     err = "sentinel directive while not in sentinel mode";
                     goto loaderr;
                 }
-                err = sentinelHandleConfiguration(argv+1,argc-1);
-                if (err) goto loaderr;
+                queueSentinelConfig(argv+1,argc-1,linenum,lines[i]);
             }
         } else {
             err = "Bad directive or wrong number of arguments"; goto loaderr;

--- a/src/config.c
+++ b/src/config.c
@@ -1220,7 +1220,7 @@ struct rewriteConfigState *rewriteConfigReadOldFile(char *path) {
             sdsfree(argv[0]);
             argv[0] = alt;
         }
-        /* If this is sentinel config, we use sentinel <sentinel-config> as option 
+        /* If this is sentinel config, we use sentinel "sentinel <config>" as option 
             to avoid messing up the sequence. */
         if (server.sentinel_mode && argc > 1 && !strcasecmp(argv[0],"sentinel")) {
             sds sentinelOption = sdsempty();

--- a/src/config.c
+++ b/src/config.c
@@ -1221,7 +1221,7 @@ struct rewriteConfigState *rewriteConfigReadOldFile(char *path) {
             argv[0] = alt;
         }
         /* If this is sentinel config, we use sentinel <sentinel-config> as option 
-            avoid messing up the sequence. */
+            to avoid messing up the sequence. */
         if (server.sentinel_mode && argc > 1 && !strcasecmp(argv[0],"sentinel")) {
             sds sentinelOption = sdsempty();
             sentinelOption = sdscatfmt(sentinelOption,"%S %S",argv[0],argv[1]);

--- a/src/config.c
+++ b/src/config.c
@@ -1221,7 +1221,16 @@ struct rewriteConfigState *rewriteConfigReadOldFile(char *path) {
             sdsfree(argv[0]);
             argv[0] = alt;
         }
-        rewriteConfigAddLineNumberToOption(state,argv[0],linenum);
+        /* If this is sentinel config, we use sentinel <sentinel-config> as option 
+            avoid messing up the sequence. */
+        if (server.sentinel_mode && argc > 1 && !strcasecmp(argv[0],"sentinel")) {
+            sds sentinelOption = sdsempty();
+            sentinelOption = sdscatfmt(sentinelOption,"%S %S",argv[0],argv[1]);
+            rewriteConfigAddLineNumberToOption(state,sentinelOption,linenum);
+            sdsfree(sentinelOption);
+        } else {
+            rewriteConfigAddLineNumberToOption(state,argv[0],linenum);
+        }
         sdsfreesplitres(argv,argc);
     }
     fclose(fp);

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1998,10 +1998,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             master->name, master_addr->ip, master_addr->port,
             master->quorum);
         rewriteConfigRewriteLine(state,"sentinel monitor",line,1);
-        /* NOTE: in case if there is no monitored masters and previously has
-         "sentinel monitor" config, a line rewriteConfigMarkAsProcessed should
-         be put at the end of this function to mark it as processed.
-        */
+        /* rewriteConfigMarkAsProcessed is handled after the loop */
 
         /* sentinel down-after-milliseconds */
         if (master->down_after_period != SENTINEL_DEFAULT_DOWN_AFTER) {
@@ -2009,11 +2006,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel down-after-milliseconds %s %ld",
                 master->name, (long) master->down_after_period);
             rewriteConfigRewriteLine(state,"sentinel down-after-milliseconds",line,1);
-            /* NOTE: in case if there is no monitored masters or master's down_after_period
-             is all set to default, but previously has "sentinel down-after-milliseconds" config, 
-             a line rewriteConfigMarkAsProcessed should be put at the end of this function to mark
-             it as processed.
-            */
+            /* rewriteConfigMarkAsProcessed is handled after the loop */
         }
 
         /* sentinel failover-timeout */
@@ -2022,11 +2015,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel failover-timeout %s %ld",
                 master->name, (long) master->failover_timeout);
             rewriteConfigRewriteLine(state,"sentinel failover-timeout",line,1);
-            /* NOTE: in case if there is no monitored masters or master's failover_timeout
-             is all set to default, but previously has "sentinel failover-timeout" config, 
-             a line rewriteConfigMarkAsProcessed should be put at the end of this function
-             to mark it as processed.
-            */
+            /* rewriteConfigMarkAsProcessed is handled after the loop */
 
         }
 
@@ -2036,11 +2025,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel parallel-syncs %s %d",
                 master->name, master->parallel_syncs);
             rewriteConfigRewriteLine(state,"sentinel parallel-syncs",line,1);
-            /* NOTE: in case if there is no monitored masters or master's parallel_syncs
-             is all set to default, but previously has "sentinel parallel-syncs" config, 
-             a line rewriteConfigMarkAsProcessed should be put at the end of this function
-             to mark it as processed.
-            */
+            /* rewriteConfigMarkAsProcessed is handled after the loop */
         }
 
         /* sentinel notification-script */
@@ -2049,11 +2034,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel notification-script %s %s",
                 master->name, master->notification_script);
             rewriteConfigRewriteLine(state,"sentinel notification-script",line,1);
-            /* NOTE: in case if there is no monitored masters or master's notification_script
-             has not been set, but previously has "sentinel notification-script" config, 
-             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
-             to mark it as processed.
-            */
+            /* rewriteConfigMarkAsProcessed is handled after the loop */
         }
 
         /* sentinel client-reconfig-script */
@@ -2062,11 +2043,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel client-reconfig-script %s %s",
                 master->name, master->client_reconfig_script);
             rewriteConfigRewriteLine(state,"sentinel client-reconfig-script",line,1);
-            /* NOTE: in case if there is no monitored masters or master's client_reconfig_script
-             has not been set, but previously has "sentinel client-reconfig-script" config, 
-             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
-             to mark it as processed.
-            */
+            /* rewriteConfigMarkAsProcessed is handled after the loop */
         }
 
         /* sentinel auth-pass & auth-user */
@@ -2075,11 +2052,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel auth-pass %s %s",
                 master->name, master->auth_pass);
             rewriteConfigRewriteLine(state,"sentinel auth-pass",line,1);
-            /* NOTE: in case if there is no monitored masters or master's auth_pass
-             has not been set, but previously has "sentinel auth-pass" config, 
-             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
-             to mark it as processed.
-            */
+            /* rewriteConfigMarkAsProcessed is handled after the loop */
         }
 
         if (master->auth_user) {
@@ -2087,11 +2060,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel auth-user %s %s",
                 master->name, master->auth_user);
             rewriteConfigRewriteLine(state,"sentinel auth-user",line,1);
-            /* NOTE: in case if there is no monitored masters or master's auth_user
-             has not been set, but previously has "sentinel auth-user" config, 
-             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
-             to mark it as processed.
-            */
+            /* rewriteConfigMarkAsProcessed is handled after the loop */
         }
 
         /* sentinel config-epoch */
@@ -2099,11 +2068,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             "sentinel config-epoch %s %llu",
             master->name, (unsigned long long) master->config_epoch);
         rewriteConfigRewriteLine(state,"sentinel config-epoch",line,1);
-        /* NOTE: in case if there is no monitored masters and previously has 
-         "sentinel config-epoch" config for certain masters, a line 
-         rewriteConfigMarkAsProcessed should be put at the end of this function to 
-         mark it as processed.
-        */
+        /* rewriteConfigMarkAsProcessed is handled after the loop */
 
 
         /* sentinel leader-epoch */
@@ -2111,11 +2076,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             "sentinel leader-epoch %s %llu",
             master->name, (unsigned long long) master->leader_epoch);
         rewriteConfigRewriteLine(state,"sentinel leader-epoch",line,1);
-        /* NOTE: in case if there is no monitored masters and previously has 
-         "sentinel leader-epoch" config for certain masters, a line 
-         rewriteConfigMarkAsProcessed should be put at the end of this function to 
-         mark it as processed.
-        */
+        /* rewriteConfigMarkAsProcessed is handled after the loop */
 
         /* sentinel known-slave */
         di2 = dictGetIterator(master->slaves);
@@ -2136,11 +2097,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel known-replica %s %s %d",
                 master->name, slave_addr->ip, slave_addr->port);
             rewriteConfigRewriteLine(state,"sentinel known-replica",line,1);
-            /* NOTE: in case if there is no monitored masters or all master has no known slaves, 
-             but previously has "sentinel known-replica" config, 
-             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
-             to mark it as processed.
-            */
+            /* rewriteConfigMarkAsProcessed is handled after the loop */
         }
         dictReleaseIterator(di2);
 
@@ -2153,11 +2110,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel known-sentinel %s %s %d %s",
                 master->name, ri->addr->ip, ri->addr->port, ri->runid);
             rewriteConfigRewriteLine(state,"sentinel known-sentinel",line,1);
-            /* NOTE: in case if there is no monitored masters or all master has no known sentinels, 
-             but previously has "sentinel known-sentinel" config, 
-             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
-             to mark it as processed.
-            */
+            /* rewriteConfigMarkAsProcessed is handled after the loop */
         }
         dictReleaseIterator(di2);
 
@@ -2170,11 +2123,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel rename-command %s %s %s",
                 master->name, oldname, newname);
             rewriteConfigRewriteLine(state,"sentinel rename-command",line,1);
-            /* NOTE: in case if there is no monitored masters or all master has no renamed_commands, 
-             but previously has "sentinel rename-command" config, 
-             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
-             to mark it as processed.
-            */
+            /* rewriteConfigMarkAsProcessed is handled after the loop */
         }
         dictReleaseIterator(di2);
     }
@@ -2220,7 +2169,11 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
 
     dictReleaseIterator(di);
 
-    /* mark rewrite as done for the optional configs */
+    /* NOTE: the purpose here is in case due to the state change, the config rewrite 
+     does not handle the configs, however, previously the config was set in the config file, 
+     rewriteConfigMarkAsProcessed should be put here to mark it as processed in order to 
+     delete the old config entry.
+    */
     rewriteConfigMarkAsProcessed(state,"sentinel monitor");
     rewriteConfigMarkAsProcessed(state,"sentinel down-after-milliseconds");
     rewriteConfigMarkAsProcessed(state,"sentinel failover-timeout");

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1717,7 +1717,7 @@ void loadSentinelConfigFromQueue(void) {
     int linenum = 0;
     sds line = NULL;
 
-    /* loading from moonitor config queue to avoid dependency issues */
+    /* loading from monitor config queue first to avoid dependency issues */
     listRewind(server.sentinel_config->monitor_cfg,&li);
     while((ln = listNext(&li))) {
         struct sentinelLoadQueueEntry *entry = ln->value;
@@ -1746,6 +1746,7 @@ void loadSentinelConfigFromQueue(void) {
     listRelease(server.sentinel_config->monitor_cfg);
     listRelease(server.sentinel_config->aux_cfg);
     zfree(server.sentinel_config);
+    server.sentinel_config = NULL;
     return;
 
 loaderr:
@@ -2087,6 +2088,26 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
 
 
     dictReleaseIterator(di);
+
+    /* mark rewrite as done for the optional configs */
+    rewriteConfigMarkAsProcessed(state,"sentinel monitor");
+    rewriteConfigMarkAsProcessed(state,"sentinel down-after-milliseconds");
+    rewriteConfigMarkAsProcessed(state,"sentinel failover-timeout");
+    rewriteConfigMarkAsProcessed(state,"sentinel parallel-syncs");
+    rewriteConfigMarkAsProcessed(state,"sentinel notification-script");
+    rewriteConfigMarkAsProcessed(state,"sentinel client-reconfig-script");
+    rewriteConfigMarkAsProcessed(state,"sentinel auth-pass");
+    rewriteConfigMarkAsProcessed(state,"sentinel auth-user");
+    rewriteConfigMarkAsProcessed(state,"sentinel config-epoch");
+    rewriteConfigMarkAsProcessed(state,"sentinel leader-epoch");
+    rewriteConfigMarkAsProcessed(state,"sentinel known-replica");
+    rewriteConfigMarkAsProcessed(state,"sentinel known-sentinel");
+    rewriteConfigMarkAsProcessed(state,"sentinel rename-command");
+    rewriteConfigMarkAsProcessed(state,"sentinel announce-ip");
+    rewriteConfigMarkAsProcessed(state,"sentinel announce-port");
+    rewriteConfigMarkAsProcessed(state,"sentinel sentinel-user");
+    rewriteConfigMarkAsProcessed(state,"sentinel sentinel-pass");
+    
 }
 
 /* This function uses the config rewriting Redis engine in order to persist

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1705,7 +1705,6 @@ void freeSentinelConfig() {
     listRelease(server.sentinel_config->post_monitor_cfg);
     zfree(server.sentinel_config);
     server.sentinel_config = NULL;
-    
 }
 
 /* Search config name in pre monitor config name array, return 1 if found,
@@ -1727,7 +1726,7 @@ void freeSentinelLoadQueueEntry(void *item) {
 
 /* This function is used for queuing sentinel configuration, the main
  * purpose of this function is to delay parsing the sentinel config option
- * in order to avoid the dependency issue from the config. */
+ * in order to avoid the order dependent issue from the config. */
 void queueSentinelConfig(sds *argv, int argc, int linenum, sds line) {
     int i;
     struct sentinelLoadQueueEntry *entry;
@@ -2145,7 +2144,6 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
         rewriteConfigRewriteLine(state,"sentinel sentinel-pass",line,1);
     }
 
-
     dictReleaseIterator(di);
 
     /* mark rewrite as done for the optional configs */
@@ -2165,8 +2163,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
     rewriteConfigMarkAsProcessed(state,"sentinel announce-ip");
     rewriteConfigMarkAsProcessed(state,"sentinel announce-port");
     rewriteConfigMarkAsProcessed(state,"sentinel sentinel-user");
-    rewriteConfigMarkAsProcessed(state,"sentinel sentinel-pass");
-    
+    rewriteConfigMarkAsProcessed(state,"sentinel sentinel-pass");  
 }
 
 /* This function uses the config rewriting Redis engine in order to persist

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1758,7 +1758,7 @@ void queueSentinelConfig(sds *argv, int argc, int linenum, sds line) {
 /* This function is used for loading the sentinel configuration from
  * pre_monitor_cfg, monitor_cfg and post_monitor_cfg list */
 void loadSentinelConfigFromQueue(void) {
-    char *err = NULL;
+    const char *err = NULL;
     listIter li;
     listNode *ln;
     int linenum = 0;

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1830,12 +1830,12 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
 
     /* sentinel unique ID. */
     line = sdscatprintf(sdsempty(), "sentinel myid %s", sentinel.myid);
-    rewriteConfigRewriteLine(state,"sentinel",line,1);
+    rewriteConfigRewriteLine(state,"sentinel myid",line,1);
 
     /* sentinel deny-scripts-reconfig. */
     line = sdscatprintf(sdsempty(), "sentinel deny-scripts-reconfig %s",
         sentinel.deny_scripts_reconfig ? "yes" : "no");
-    rewriteConfigRewriteLine(state,"sentinel",line,
+    rewriteConfigRewriteLine(state,"sentinel deny-scripts-reconfig",line,
         sentinel.deny_scripts_reconfig != SENTINEL_DEFAULT_DENY_SCRIPTS_RECONFIG);
 
     /* For every master emit a "sentinel monitor" config entry. */
@@ -1850,14 +1850,14 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
         line = sdscatprintf(sdsempty(),"sentinel monitor %s %s %d %d",
             master->name, master_addr->ip, master_addr->port,
             master->quorum);
-        rewriteConfigRewriteLine(state,"sentinel",line,1);
+        rewriteConfigRewriteLine(state,"sentinel monitor",line,1);
 
         /* sentinel down-after-milliseconds */
         if (master->down_after_period != SENTINEL_DEFAULT_DOWN_AFTER) {
             line = sdscatprintf(sdsempty(),
                 "sentinel down-after-milliseconds %s %ld",
                 master->name, (long) master->down_after_period);
-            rewriteConfigRewriteLine(state,"sentinel",line,1);
+            rewriteConfigRewriteLine(state,"sentinel down-after-milliseconds",line,1);
         }
 
         /* sentinel failover-timeout */
@@ -1865,7 +1865,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             line = sdscatprintf(sdsempty(),
                 "sentinel failover-timeout %s %ld",
                 master->name, (long) master->failover_timeout);
-            rewriteConfigRewriteLine(state,"sentinel",line,1);
+            rewriteConfigRewriteLine(state,"sentinel failover-timeout",line,1);
         }
 
         /* sentinel parallel-syncs */
@@ -1873,7 +1873,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             line = sdscatprintf(sdsempty(),
                 "sentinel parallel-syncs %s %d",
                 master->name, master->parallel_syncs);
-            rewriteConfigRewriteLine(state,"sentinel",line,1);
+            rewriteConfigRewriteLine(state,"sentinel parallel-syncs",line,1);
         }
 
         /* sentinel notification-script */
@@ -1881,7 +1881,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             line = sdscatprintf(sdsempty(),
                 "sentinel notification-script %s %s",
                 master->name, master->notification_script);
-            rewriteConfigRewriteLine(state,"sentinel",line,1);
+            rewriteConfigRewriteLine(state,"sentinel notification-script",line,1);
         }
 
         /* sentinel client-reconfig-script */
@@ -1889,7 +1889,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             line = sdscatprintf(sdsempty(),
                 "sentinel client-reconfig-script %s %s",
                 master->name, master->client_reconfig_script);
-            rewriteConfigRewriteLine(state,"sentinel",line,1);
+            rewriteConfigRewriteLine(state,"sentinel client-reconfig-script",line,1);
         }
 
         /* sentinel auth-pass & auth-user */
@@ -1897,27 +1897,27 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             line = sdscatprintf(sdsempty(),
                 "sentinel auth-pass %s %s",
                 master->name, master->auth_pass);
-            rewriteConfigRewriteLine(state,"sentinel",line,1);
+            rewriteConfigRewriteLine(state,"sentinel auth-pass",line,1);
         }
 
         if (master->auth_user) {
             line = sdscatprintf(sdsempty(),
                 "sentinel auth-user %s %s",
                 master->name, master->auth_user);
-            rewriteConfigRewriteLine(state,"sentinel",line,1);
+            rewriteConfigRewriteLine(state,"sentinel auth-user",line,1);
         }
 
         /* sentinel config-epoch */
         line = sdscatprintf(sdsempty(),
             "sentinel config-epoch %s %llu",
             master->name, (unsigned long long) master->config_epoch);
-        rewriteConfigRewriteLine(state,"sentinel",line,1);
+        rewriteConfigRewriteLine(state,"sentinel config-epoch",line,1);
 
         /* sentinel leader-epoch */
         line = sdscatprintf(sdsempty(),
             "sentinel leader-epoch %s %llu",
             master->name, (unsigned long long) master->leader_epoch);
-        rewriteConfigRewriteLine(state,"sentinel",line,1);
+        rewriteConfigRewriteLine(state,"sentinel leader-epoch",line,1);
 
         /* sentinel known-slave */
         di2 = dictGetIterator(master->slaves);
@@ -1937,7 +1937,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             line = sdscatprintf(sdsempty(),
                 "sentinel known-replica %s %s %d",
                 master->name, slave_addr->ip, slave_addr->port);
-            rewriteConfigRewriteLine(state,"sentinel",line,1);
+            rewriteConfigRewriteLine(state,"sentinel known-replica",line,1);
         }
         dictReleaseIterator(di2);
 
@@ -1949,7 +1949,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             line = sdscatprintf(sdsempty(),
                 "sentinel known-sentinel %s %s %d %s",
                 master->name, ri->addr->ip, ri->addr->port, ri->runid);
-            rewriteConfigRewriteLine(state,"sentinel",line,1);
+            rewriteConfigRewriteLine(state,"sentinel known-sentinel",line,1);
         }
         dictReleaseIterator(di2);
 
@@ -1961,7 +1961,7 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             line = sdscatprintf(sdsempty(),
                 "sentinel rename-command %s %s %s",
                 master->name, oldname, newname);
-            rewriteConfigRewriteLine(state,"sentinel",line,1);
+            rewriteConfigRewriteLine(state,"sentinel rename-command",line,1);
         }
         dictReleaseIterator(di2);
     }
@@ -1969,32 +1969,32 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
     /* sentinel current-epoch is a global state valid for all the masters. */
     line = sdscatprintf(sdsempty(),
         "sentinel current-epoch %llu", (unsigned long long) sentinel.current_epoch);
-    rewriteConfigRewriteLine(state,"sentinel",line,1);
+    rewriteConfigRewriteLine(state,"sentinel current-epoch",line,1);
 
     /* sentinel announce-ip. */
     if (sentinel.announce_ip) {
         line = sdsnew("sentinel announce-ip ");
         line = sdscatrepr(line, sentinel.announce_ip, sdslen(sentinel.announce_ip));
-        rewriteConfigRewriteLine(state,"sentinel",line,1);
+        rewriteConfigRewriteLine(state,"sentinel announce-ip",line,1);
     }
 
     /* sentinel announce-port. */
     if (sentinel.announce_port) {
         line = sdscatprintf(sdsempty(),"sentinel announce-port %d",
                             sentinel.announce_port);
-        rewriteConfigRewriteLine(state,"sentinel",line,1);
+        rewriteConfigRewriteLine(state,"sentinel announce-port",line,1);
     }
 
     /* sentinel sentinel-user. */
     if (sentinel.sentinel_auth_user) {
         line = sdscatprintf(sdsempty(), "sentinel sentinel-user %s", sentinel.sentinel_auth_user);
-        rewriteConfigRewriteLine(state,"sentinel",line,1);
+        rewriteConfigRewriteLine(state,"sentinel sentinel-user",line,1);
     }
 
     /* sentinel sentinel-pass. */
     if (sentinel.sentinel_auth_pass) {
         line = sdscatprintf(sdsempty(), "sentinel sentinel-pass %s", sentinel.sentinel_auth_pass);
-        rewriteConfigRewriteLine(state,"sentinel",line,1);
+        rewriteConfigRewriteLine(state,"sentinel sentinel-pass",line,1);
     }
 
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1998,6 +1998,10 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             master->name, master_addr->ip, master_addr->port,
             master->quorum);
         rewriteConfigRewriteLine(state,"sentinel monitor",line,1);
+        /* NOTE: in case if there is no monitored masters and previously has
+         "sentinel monitor" config, a line rewriteConfigMarkAsProcessed should
+         be put at the end of this function to mark it as processed.
+        */
 
         /* sentinel down-after-milliseconds */
         if (master->down_after_period != SENTINEL_DEFAULT_DOWN_AFTER) {
@@ -2005,6 +2009,11 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel down-after-milliseconds %s %ld",
                 master->name, (long) master->down_after_period);
             rewriteConfigRewriteLine(state,"sentinel down-after-milliseconds",line,1);
+            /* NOTE: in case if there is no monitored masters or master's down_after_period
+             is all set to default, but previously has "sentinel down-after-milliseconds" config, 
+             a line rewriteConfigMarkAsProcessed should be put at the end of this function to mark
+             it as processed.
+            */
         }
 
         /* sentinel failover-timeout */
@@ -2013,6 +2022,12 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel failover-timeout %s %ld",
                 master->name, (long) master->failover_timeout);
             rewriteConfigRewriteLine(state,"sentinel failover-timeout",line,1);
+            /* NOTE: in case if there is no monitored masters or master's failover_timeout
+             is all set to default, but previously has "sentinel failover-timeout" config, 
+             a line rewriteConfigMarkAsProcessed should be put at the end of this function
+             to mark it as processed.
+            */
+
         }
 
         /* sentinel parallel-syncs */
@@ -2021,6 +2036,11 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel parallel-syncs %s %d",
                 master->name, master->parallel_syncs);
             rewriteConfigRewriteLine(state,"sentinel parallel-syncs",line,1);
+            /* NOTE: in case if there is no monitored masters or master's parallel_syncs
+             is all set to default, but previously has "sentinel parallel-syncs" config, 
+             a line rewriteConfigMarkAsProcessed should be put at the end of this function
+             to mark it as processed.
+            */
         }
 
         /* sentinel notification-script */
@@ -2029,6 +2049,11 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel notification-script %s %s",
                 master->name, master->notification_script);
             rewriteConfigRewriteLine(state,"sentinel notification-script",line,1);
+            /* NOTE: in case if there is no monitored masters or master's notification_script
+             has not been set, but previously has "sentinel notification-script" config, 
+             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
+             to mark it as processed.
+            */
         }
 
         /* sentinel client-reconfig-script */
@@ -2037,6 +2062,11 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel client-reconfig-script %s %s",
                 master->name, master->client_reconfig_script);
             rewriteConfigRewriteLine(state,"sentinel client-reconfig-script",line,1);
+            /* NOTE: in case if there is no monitored masters or master's client_reconfig_script
+             has not been set, but previously has "sentinel client-reconfig-script" config, 
+             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
+             to mark it as processed.
+            */
         }
 
         /* sentinel auth-pass & auth-user */
@@ -2045,6 +2075,11 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel auth-pass %s %s",
                 master->name, master->auth_pass);
             rewriteConfigRewriteLine(state,"sentinel auth-pass",line,1);
+            /* NOTE: in case if there is no monitored masters or master's auth_pass
+             has not been set, but previously has "sentinel auth-pass" config, 
+             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
+             to mark it as processed.
+            */
         }
 
         if (master->auth_user) {
@@ -2052,6 +2087,11 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel auth-user %s %s",
                 master->name, master->auth_user);
             rewriteConfigRewriteLine(state,"sentinel auth-user",line,1);
+            /* NOTE: in case if there is no monitored masters or master's auth_user
+             has not been set, but previously has "sentinel auth-user" config, 
+             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
+             to mark it as processed.
+            */
         }
 
         /* sentinel config-epoch */
@@ -2059,12 +2099,23 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             "sentinel config-epoch %s %llu",
             master->name, (unsigned long long) master->config_epoch);
         rewriteConfigRewriteLine(state,"sentinel config-epoch",line,1);
+        /* NOTE: in case if there is no monitored masters and previously has 
+         "sentinel config-epoch" config for certain masters, a line 
+         rewriteConfigMarkAsProcessed should be put at the end of this function to 
+         mark it as processed.
+        */
+
 
         /* sentinel leader-epoch */
         line = sdscatprintf(sdsempty(),
             "sentinel leader-epoch %s %llu",
             master->name, (unsigned long long) master->leader_epoch);
         rewriteConfigRewriteLine(state,"sentinel leader-epoch",line,1);
+        /* NOTE: in case if there is no monitored masters and previously has 
+         "sentinel leader-epoch" config for certain masters, a line 
+         rewriteConfigMarkAsProcessed should be put at the end of this function to 
+         mark it as processed.
+        */
 
         /* sentinel known-slave */
         di2 = dictGetIterator(master->slaves);
@@ -2085,6 +2136,11 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel known-replica %s %s %d",
                 master->name, slave_addr->ip, slave_addr->port);
             rewriteConfigRewriteLine(state,"sentinel known-replica",line,1);
+            /* NOTE: in case if there is no monitored masters or all master has no known slaves, 
+             but previously has "sentinel known-replica" config, 
+             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
+             to mark it as processed.
+            */
         }
         dictReleaseIterator(di2);
 
@@ -2097,6 +2153,11 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel known-sentinel %s %s %d %s",
                 master->name, ri->addr->ip, ri->addr->port, ri->runid);
             rewriteConfigRewriteLine(state,"sentinel known-sentinel",line,1);
+            /* NOTE: in case if there is no monitored masters or all master has no known sentinels, 
+             but previously has "sentinel known-sentinel" config, 
+             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
+             to mark it as processed.
+            */
         }
         dictReleaseIterator(di2);
 
@@ -2109,6 +2170,11 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
                 "sentinel rename-command %s %s %s",
                 master->name, oldname, newname);
             rewriteConfigRewriteLine(state,"sentinel rename-command",line,1);
+            /* NOTE: in case if there is no monitored masters or all master has no renamed_commands, 
+             but previously has "sentinel rename-command" config, 
+             a line rewriteConfigMarkAsProcessed should be put at the end of this function 
+             to mark it as processed.
+            */
         }
         dictReleaseIterator(di2);
     }
@@ -2123,6 +2189,8 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
         line = sdsnew("sentinel announce-ip ");
         line = sdscatrepr(line, sentinel.announce_ip, sdslen(sentinel.announce_ip));
         rewriteConfigRewriteLine(state,"sentinel announce-ip",line,1);
+    } else {
+        rewriteConfigMarkAsProcessed(state,"sentinel announce-ip");
     }
 
     /* sentinel announce-port. */
@@ -2130,18 +2198,24 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
         line = sdscatprintf(sdsempty(),"sentinel announce-port %d",
                             sentinel.announce_port);
         rewriteConfigRewriteLine(state,"sentinel announce-port",line,1);
+    } else {
+        rewriteConfigMarkAsProcessed(state,"sentinel announce-port");
     }
 
     /* sentinel sentinel-user. */
     if (sentinel.sentinel_auth_user) {
         line = sdscatprintf(sdsempty(), "sentinel sentinel-user %s", sentinel.sentinel_auth_user);
         rewriteConfigRewriteLine(state,"sentinel sentinel-user",line,1);
+    } else {
+        rewriteConfigMarkAsProcessed(state,"sentinel sentinel-user");
     }
 
     /* sentinel sentinel-pass. */
     if (sentinel.sentinel_auth_pass) {
         line = sdscatprintf(sdsempty(), "sentinel sentinel-pass %s", sentinel.sentinel_auth_pass);
         rewriteConfigRewriteLine(state,"sentinel sentinel-pass",line,1);
+    } else {
+        rewriteConfigMarkAsProcessed(state,"sentinel sentinel-pass");  
     }
 
     dictReleaseIterator(di);
@@ -2160,10 +2234,6 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
     rewriteConfigMarkAsProcessed(state,"sentinel known-replica");
     rewriteConfigMarkAsProcessed(state,"sentinel known-sentinel");
     rewriteConfigMarkAsProcessed(state,"sentinel rename-command");
-    rewriteConfigMarkAsProcessed(state,"sentinel announce-ip");
-    rewriteConfigMarkAsProcessed(state,"sentinel announce-port");
-    rewriteConfigMarkAsProcessed(state,"sentinel sentinel-user");
-    rewriteConfigMarkAsProcessed(state,"sentinel sentinel-pass");  
 }
 
 /* This function uses the config rewriting Redis engine in order to persist

--- a/src/server.c
+++ b/src/server.c
@@ -5851,6 +5851,7 @@ int main(int argc, char **argv) {
             exit(1);
         }
         loadServerConfig(server.configfile, config_from_stdin, options);
+        if (server.sentinel_mode) loadSentinelConfigFromQueue();
         sdsfree(options);
     }
 
@@ -5921,7 +5922,6 @@ int main(int argc, char **argv) {
             }
         }
     } else {
-        loadSentinelConfigFromQueue();
         ACLLoadUsersAtStartup();
         InitServerLast();
         sentinelIsRunning();

--- a/src/server.c
+++ b/src/server.c
@@ -5913,6 +5913,7 @@ int main(int argc, char **argv) {
             }
         }
     } else {
+        loadSentinelConfigFromQueue();
         ACLLoadUsersAtStartup();
         InitServerLast();
         sentinelIsRunning();

--- a/src/server.h
+++ b/src/server.h
@@ -950,8 +950,9 @@ struct sentinelLoadQueueEntry {
 };
 
 struct sentinelConfig {
+    list *pre_monitor_cfg;
     list *monitor_cfg;
-    list *aux_cfg;
+    list *post_monitor_cfg;
 };
 
 struct sharedObjectsStruct {

--- a/src/server.h
+++ b/src/server.h
@@ -942,6 +942,18 @@ struct moduleLoadQueueEntry {
     robj **argv;
 };
 
+struct sentinelLoadQueueEntry {
+    int argc;
+    sds *argv;
+    int linenum;
+    sds line;
+};
+
+struct sentinelConfig {
+    list *monitor_cfg;
+    list *aux_cfg;
+};
+
 struct sharedObjectsStruct {
     robj *crlf, *ok, *err, *emptybulk, *czero, *cone, *pong, *space,
     *colon, *queued, *null[4], *nullarray[4], *emptymap[4], *emptyset[4],
@@ -1555,6 +1567,8 @@ struct redisServer {
     char *bio_cpulist; /* cpu affinity list of bio thread. */
     char *aof_rewrite_cpulist; /* cpu affinity list of aof rewrite process. */
     char *bgsave_cpulist; /* cpu affinity list of bgsave process. */
+    /* Sentinel config */
+    struct sentinelConfig *sentinel_config; /* sentinel config to load at startup time. */
 };
 
 typedef struct pubsubPattern {
@@ -2332,6 +2346,8 @@ void initSentinelConfig(void);
 void initSentinel(void);
 void sentinelTimer(void);
 char *sentinelHandleConfiguration(char **argv, int argc);
+void queueSentinelConfig(sds *argv, int argc, int linenum, sds line);
+void loadSentinelConfigFromQueue(void);
 void sentinelIsRunning(void);
 
 /* redis-check-rdb & aof */

--- a/src/server.h
+++ b/src/server.h
@@ -2251,6 +2251,7 @@ void appendServerSaveParams(time_t seconds, int changes);
 void resetServerSaveParams(void);
 struct rewriteConfigState; /* Forward declaration to export API. */
 void rewriteConfigRewriteLine(struct rewriteConfigState *state, const char *option, sds line, int force);
+void rewriteConfigMarkAsProcessed(struct rewriteConfigState *state, const char *option);
 int rewriteConfig(char *path, int force_all);
 void initConfigValues();
 

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -59,10 +59,9 @@ proc exec_instance {type dirname cfgfile} {
 }
 
 # Spawn a redis or sentinel instance, depending on 'type'.
-proc spawn_instance {type base_port count {conf {}}} {
+proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
     for {set j 0} {$j < $count} {incr j} {
         set port [find_available_port $base_port $::redis_port_count]
-
         # Create a directory for this instance.
         set dirname "${type}_${j}"
         lappend ::dirs $dirname
@@ -71,7 +70,13 @@ proc spawn_instance {type base_port count {conf {}}} {
 
         # Write the instance config file.
         set cfgfile [file join $dirname $type.conf]
-        set cfg [open $cfgfile w]
+        if {$base_conf_file ne ""} {
+            file copy -- $base_conf_file $cfgfile
+            set cfg [open $cfgfile a+]
+        } else {
+            set cfg [open $cfgfile w]
+        }
+
         if {$::tls} {
             puts $cfg "tls-port $port"
             puts $cfg "tls-replication yes"

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -10,7 +10,7 @@ set ::tlsdir "../../tls"
 
 proc main {} {
     parse_options
-    spawn_instance sentinel $::sentinel_base_port $::instances_count [list "sentinel deny-scripts-reconfig no"]
+    spawn_instance sentinel $::sentinel_base_port $::instances_count [list "sentinel deny-scripts-reconfig no"] "../tests/includes/sentinel.conf"
     spawn_instance redis $::redis_base_port $::instances_count
     run_tests
     cleanup

--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -1,5 +1,5 @@
 # Check the basic monitoring and failover capabilities.
-
+source "../tests/includes/start-init-tests.tcl"
 source "../tests/includes/init-tests.tcl"
 
 if {$::simulate_error} {

--- a/tests/sentinel/tests/includes/sentinel.conf
+++ b/tests/sentinel/tests/includes/sentinel.conf
@@ -1,0 +1,11 @@
+# assume master is down after being unresponsive for 20s
+sentinel down-after-milliseconds setmaster 20000
+# reconfigure one slave at a time
+sentinel parallel-syncs setmaster 2
+# wait for 4m before assuming failover went wrong
+sentinel failover-timeout setmaster 240000
+# monitoring set
+sentinel monitor setmaster 10.0.0.1 30000 2
+
+
+

--- a/tests/sentinel/tests/includes/start-init-tests.tcl
+++ b/tests/sentinel/tests/includes/start-init-tests.tcl
@@ -1,0 +1,18 @@
+test "(start-init) Flush config and compare rewrite config file lines" {
+    foreach_sentinel_id id {
+        assert_match "OK" [S $id SENTINEL FLUSHCONFIG]
+        set file1 ../tests/includes/sentinel.conf
+        set file2 [file join "sentinel_${id}" "sentinel.conf"] 
+        set fh1 [open $file1 r]
+        set fh2 [open $file2 r]
+        while {[gets $fh1 line1]} {
+            if {[gets $fh2 line2]} {
+                assert [string equal $line1 $line2]
+            } else {
+                fail "sentinel config file rewrite sequence changed"
+            }
+        }
+        close $fh1
+        close $fh2  
+    }
+}


### PR DESCRIPTION
This PR fixes https://github.com/redis/redis/issues/5388 . This is a well known and an annoying issue in Sentinel mode, and has left for 2 years hasn't been fixed. 
**Cause of this issue:**
Currently, Redis rewrite process works well in server mode, however in sentinel mode, the sentinel config has variant semantics for different configurations, in example configuration https://github.com/redis/redis/blob/unstable/sentinel.conf, we put comments on these. However the rewrite process only treat the sentinel config as a single option. During rewrite process, it will mess up with the lines and comments.
**Approaches:**
In order to solve this issue, we need to differentiate different subconfig options in sentinel separately, for example, `sentinel monitor <master-name> <ip> <redis-port> <quorum>
`
we can treat it as `sentinel monitor` option, instead of the `sentinel` option.

This PR also fixes the dependency issue when putting configurations in sentinel.conf. For example before this commit, 
we must put `sentinel monitor <master-name> <ip> <redis-port> <quorum>` before `sentinel auth-pass <master-name> <password>` for a single master, otherwise the server cannot start and will return error. This commit fixes this issue, as long as the monitoring master was configured, no matter the sequence is, the sentinel can start and run properly.
