### PR TITLE
Cluster redirect vs EXECABORT responses

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -285,6 +285,7 @@ typedef struct {
 /* ---------------------- API exported outside cluster.c -------------------- */
 clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, int argc, int *hashslot, int *ask);
 int clusterRedirectBlockedClientIfNeeded(client *c);
+sds clusterRedirectError(clusterNode *n, int hashslot, int error_code);
 void clusterRedirectClient(client *c, clusterNode *n, int hashslot, int error_code);
 unsigned long getClusterConnectionsCount(void);
 


### PR DESCRIPTION
When EXEC is rejected we must sent -EXECABORT so that the client knows
that the connection is no longer in multi-state, this is done by
execCommandAbort which also makes sure to send EXEC to the monitors.

In cluster mode when a command needs to be redirected it must be
responded with -MOVED or -ASK -CROSSSLOT etc.

The -EXECABORT mechanism has a way to reflect the secondary error inside
the error text, but i'm not sure if that's sufficient.