### PR TITLE
Add hostname support in Sentinel.

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -321,3 +321,21 @@ sentinel deny-scripts-reconfig yes
 # is possible to just rename a command to itself:
 #
 # SENTINEL rename-command mymaster CONFIG CONFIG
+
+# HOSTNAMES SUPPORT
+#
+# Normally Sentinel uses only IP addresses and requires SENTINEL MONITOR
+# to specify an IP address. Also, it requires the Redis replica-announce-ip
+# keyword to specify only IP addressess.
+#
+# You may enable hostnames support by enabling resolve-hostnames. Note
+# that you must make sure your DNS is configured properly and that DNS
+# resolution does not introduce very long delays.
+#
+SENTINEL resolve-hostnames no
+
+# When resolve-hostnames is enabled, Sentinel still uses IP addresses
+# when exposing instances to users, configuration files, etc. If you want
+# to retain the hostnames when announced, enable announce-hostnames below.
+#
+SENTINEL announce-hostnames no

--- a/sentinel.conf
+++ b/sentinel.conf
@@ -326,7 +326,7 @@ sentinel deny-scripts-reconfig yes
 #
 # Normally Sentinel uses only IP addresses and requires SENTINEL MONITOR
 # to specify an IP address. Also, it requires the Redis replica-announce-ip
-# keyword to specify only IP addressess.
+# keyword to specify only IP addresses.
 #
 # You may enable hostnames support by enabling resolve-hostnames. Note
 # that you must make sure your DNS is configured properly and that DNS

--- a/src/anet.c
+++ b/src/anet.c
@@ -241,12 +241,8 @@ int anetGenericResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len,
     return ANET_OK;
 }
 
-int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len) {
-    return anetGenericResolve(err,host,ipbuf,ipbuf_len,ANET_NONE);
-}
-
-int anetResolveIP(char *err, char *host, char *ipbuf, size_t ipbuf_len) {
-    return anetGenericResolve(err,host,ipbuf,ipbuf_len,ANET_IP_ONLY);
+int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len, int flags) {
+    return anetGenericResolve(err,host,ipbuf,ipbuf_len,flags);
 }
 
 static int anetSetReuseAddr(char *err, int fd) {

--- a/src/anet.c
+++ b/src/anet.c
@@ -207,14 +207,13 @@ int anetRecvTimeout(char *err, int fd, long long ms) {
     return ANET_OK;
 }
 
-/* anetGenericResolve() is called by anetResolve() and anetResolveIP() to
- * do the actual work. It resolves the hostname "host" and set the string
- * representation of the IP address into the buffer pointed by "ipbuf".
+/* Resolve the hostname "host" and set the string representation of the
+ * IP address into the buffer pointed by "ipbuf".
  *
  * If flags is set to ANET_IP_ONLY the function only resolves hostnames
  * that are actually already IPv4 or IPv6 addresses. This turns the function
  * into a validating / normalizing function. */
-int anetGenericResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len,
+int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len,
                        int flags)
 {
     struct addrinfo hints, *info;
@@ -239,10 +238,6 @@ int anetGenericResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len,
 
     freeaddrinfo(info);
     return ANET_OK;
-}
-
-int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len, int flags) {
-    return anetGenericResolve(err,host,ipbuf,ipbuf_len,flags);
 }
 
 static int anetSetReuseAddr(char *err, int fd) {

--- a/src/anet.h
+++ b/src/anet.h
@@ -60,8 +60,7 @@ int anetTcpNonBlockBestEffortBindConnect(char *err, const char *addr, int port, 
 int anetUnixConnect(char *err, const char *path);
 int anetUnixNonBlockConnect(char *err, const char *path);
 int anetRead(int fd, char *buf, int count);
-int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len);
-int anetResolveIP(char *err, char *host, char *ipbuf, size_t ipbuf_len);
+int anetResolve(char *err, char *host, char *ipbuf, size_t ipbuf_len, int flags);
 int anetTcpServer(char *err, int port, char *bindaddr, int backlog);
 int anetTcp6Server(char *err, int port, char *bindaddr, int backlog);
 int anetUnixServer(char *err, char *path, mode_t perm, int backlog);

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1126,7 +1126,7 @@ int sentinelTryConnectionSharing(sentinelRedisInstance *ri) {
     return C_ERR;
 }
 
-/* Drop all connections to other sentinels. Returns then number of connections
+/* Drop all connections to other sentinels. Returns the number of connections
  * dropped.*/
 int sentinelDropConnections(void) {
     dictIterator *di;
@@ -1387,10 +1387,10 @@ sentinelRedisInstance *sentinelRedisInstanceLookupSlave(
 
     serverAssert(ri->flags & SRI_MASTER);
 
-    /* Make sure the address specified is an IP, as in the case of
-     * slave-announce-ip <hostname> it could also be a name.
+    /* We need to handle a slave_addr that is potentially a hostname.
+     * If that is the case, depending on configuration we either resolve
+     * it and use the IP addres or fail.
      */
-
     addr = createSentinelAddr(slave_addr, port);
     if (!addr) return NULL;
 
@@ -1461,11 +1461,6 @@ sentinelRedisInstance *getSentinelRedisInstanceByAddrAndRunID(dict *instances, c
         if (!ri_addr) return NULL;
     }
     di = dictGetIterator(instances);
-    if (addr != NULL) {
-        /* Resolve addr, we use the IP as a key even if a hostname is used */
-        ri_addr = createSentinelAddr(addr, port);
-        if (!ri_addr) return NULL;
-    }
     while((de = dictNext(di)) != NULL) {
         sentinelRedisInstance *ri = dictGetVal(de);
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1455,6 +1455,11 @@ sentinelRedisInstance *getSentinelRedisInstanceByAddrAndRunID(dict *instances, c
     sentinelAddr *ri_addr = NULL;
 
     serverAssert(addr || runid);   /* User must pass at least one search param. */
+    if (addr != NULL) {
+        /* Resolve addr, we use the IP as a key even if a hostname is used */
+        ri_addr = createSentinelAddr(addr, port);
+        if (!ri_addr) return NULL;
+    }
     di = dictGetIterator(instances);
     if (addr != NULL) {
         /* Resolve addr, we use the IP as a key even if a hostname is used */
@@ -4874,4 +4879,3 @@ void sentinelTimer(void) {
      * election because of split brain voting). */
     server.hz = CONFIG_DEFAULT_HZ + rand() % CONFIG_DEFAULT_HZ;
 }
-

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -27,6 +27,7 @@ set ::redis_instances {}
 set ::sentinel_base_port 20000
 set ::redis_base_port 30000
 set ::redis_port_count 1024
+set ::host "127.0.0.1"
 set ::pids {} ; # We kill everything at exit
 set ::dirs {} ; # We remove all the temp dirs at exit
 set ::run_matching {} ; # If non empty, only tests matching pattern are run.
@@ -119,18 +120,18 @@ proc spawn_instance {type base_port count {conf {}}} {
         }
 
         # Check availability finally
-        if {[server_is_up 127.0.0.1 $port 100] == 0} {
+        if {[server_is_up $::host $port 100] == 0} {
             set logfile [file join $dirname log.txt]
             puts [exec tail $logfile]
             abort_sentinel_test "Problems starting $type #$j: ping timeout, maybe server start failed, check $logfile"
         }
 
         # Push the instance into the right list
-        set link [redis 127.0.0.1 $port 0 $::tls]
+        set link [redis $::host $port 0 $::tls]
         $link reconnect 1
         lappend ::${type}_instances [list \
             pid $pid \
-            host 127.0.0.1 \
+            host $::host \
             port $port \
             link $link \
         ]
@@ -232,6 +233,9 @@ proc parse_options {} {
             set ::simulate_error 1
         } elseif {$opt eq {--valgrind}} {
             set ::valgrind 1
+        } elseif {$opt eq {--host}} {
+            incr j
+            set ::host ${val}
         } elseif {$opt eq {--tls}} {
             package require tls 1.6
             ::tls::init \
@@ -246,6 +250,7 @@ proc parse_options {} {
             puts "--fail                  Simulate a test failure."
             puts "--valgrind              Run with valgrind."
             puts "--tls                   Run tests in TLS mode."
+            puts "--host <host>           Use hostname instead of 127.0.0.1."
             puts "--help                  Shows this help."
             exit 0
         } else {

--- a/tests/sentinel/tests/08-hostname-conf.tcl
+++ b/tests/sentinel/tests/08-hostname-conf.tcl
@@ -1,0 +1,62 @@
+proc set_redis_announce_ip {addr} {
+    foreach_redis_id id {
+        R $id config set replica-announce-ip $addr
+    }
+}
+
+proc set_sentinel_config {keyword value} {
+    foreach_sentinel_id id {
+        S $id sentinel config set $keyword $value
+    }
+}
+
+proc set_all_instances_hostname {hostname} {
+    foreach_sentinel_id id {
+        set_instance_attrib sentinel $id host $hostname
+    }
+    foreach_redis_id id {
+        set_instance_attrib redis $id host $hostname
+    }
+}
+
+test "(pre-init) Configure instances and sentinel for hostname use" {
+    set ::host "localhost"
+    restart_killed_instances
+    set_all_instances_hostname $::host
+    set_redis_announce_ip $::host
+    set_sentinel_config resolve-hostnames yes
+    set_sentinel_config announce-hostnames yes
+}
+
+source "../tests/includes/init-tests.tcl"
+
+proc verify_hostname_announced {hostname} {
+    foreach_sentinel_id id {
+        # Master is reported with its hostname
+        assert_equal [lindex [S $id SENTINEL GET-MASTER-ADDR-BY-NAME mymaster] 0] $hostname
+
+        # Replicas are reported with their hostnames
+        foreach replica [S $id SENTINEL REPLICAS mymaster] {
+            assert_equal [dict get $replica ip] $hostname
+        }
+    }
+}
+
+test "Sentinel announces hostnames" {
+    # Check initial state
+    verify_hostname_announced $::host
+
+    # Disable announce-hostnames and confirm IPs are used
+    set_sentinel_config announce-hostnames no
+    verify_hostname_announced "127.0.0.1"
+}
+
+# We need to revert any special configuration because all tests currently
+# share the same instances.
+test "(post-cleanup) Configure instances and sentinel for IPs" {
+    set ::host "127.0.0.1"
+    set_all_instances_hostname $::host
+    set_redis_announce_ip $::host
+    set_sentinel_config resolve-hostnames no
+    set_sentinel_config announce-hostnames no
+}

--- a/tests/sentinel/tests/09-acl-support.tcl
+++ b/tests/sentinel/tests/09-acl-support.tcl
@@ -1,0 +1,50 @@
+
+source "../tests/includes/init-tests.tcl"
+
+set ::user "testuser"
+set ::password "secret"
+
+proc setup_acl {} {
+    foreach_sentinel_id id {
+        assert_equal {OK} [S $id ACL SETUSER $::user >$::password +@all on]
+        assert_equal {OK} [S $id ACL SETUSER default off]
+
+        S $id CLIENT KILL USER default SKIPME no
+        assert_equal {OK} [S $id AUTH $::user $::password]
+    }
+}
+
+proc teardown_acl {} {
+    foreach_sentinel_id id {
+        assert_equal {OK} [S $id ACL SETUSER default on]
+        assert_equal {1} [S $id ACL DELUSER $::user]
+
+        S $id SENTINEL CONFIG SET sentinel-user ""
+        S $id SENTINEL CONFIG SET sentinel-pass ""
+    }
+}
+
+test "(post-init) Set up ACL configuration" {
+    setup_acl
+    assert_equal $::user [S 1 ACL WHOAMI]
+}
+
+test "SENTINEL CONFIG SET handles on-the-fly credentials reconfiguration" {
+    # Make sure we're starting with a broken state...
+    after 5000
+    catch {S 1 SENTINEL CKQUORUM mymaster} err
+    assert_match {*NOQUORUM*} $err
+
+    foreach_sentinel_id id {
+        assert_equal {OK} [S $id SENTINEL CONFIG SET sentinel-user $::user]
+        assert_equal {OK} [S $id SENTINEL CONFIG SET sentinel-pass $::password]
+    }
+
+    after 5000
+    assert_match {*OK*} [S 1 SENTINEL CKQUORUM mymaster]
+}
+
+test "(post-cleanup) Tear down ACL configuration" {
+    teardown_acl
+}
+

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -1,6 +1,6 @@
 # Initialization tests -- most units will start including this.
 
-test "(init) Restart killed instances" {
+proc restart_killed_instances {} {
     foreach type {redis sentinel} {
         foreach_${type}_id id {
             if {[get_instance_attrib $type $id pid] == -1} {
@@ -10,6 +10,10 @@ test "(init) Restart killed instances" {
             }
         }
     }
+}
+
+test "(init) Restart killed instances" {
+    restart_killed_instances
 }
 
 test "(init) Remove old master entry from sentinels" {


### PR DESCRIPTION
This is both a bugfix and an enhancement.

Internally, Sentinel relies entirely on IP addressess to identify
instances. When configured with a new master, it also requires users to
specify and IP and not hostname.

However, replicas may use the replica-announce-ip configuration to
announce a hostname. When that happens, Sentinel fails to match the
announced hostname with the expected IP and considers that a different
instance, trigerring reconfiguration, etc.

Another use case is where TLS is used and clients are expected to match
the hostname to connect to with the certificate's SAN attribute. To
properly implement this configuration, it is necessary for Sentinel to
redirect clients to a hostname rather than an IP address.

The new 'resolve-hostnames' configuration parameter determines if
Sentinel is willing to accept hostnames. It is set by default to no,
which maintains backwards compatibility and avoids unexpected DNS
resolution delays on systems with DNS configuration issues.

Internally, Sentinel contineus to identify instances by their resolved
IP address and will also report the IP by default. The new
'announce-hostnames' parameter determines if Sentinel should prefer to
announce a hostname, when available, rather than an IP address. This
applies to addresses returned to clients, as well as their
representation in the configuration file, REPLICAOF configuration
commands, etc.

This commit also introduces SENTINEL CONFIG GET and SENTINEL CONFIG SET
which can be used to introspect or configure global Sentinel
configuration that was previously was only possible by directly
accessing the configuration file and possibly restarting the instance.

Fixes #7758, #7393, #2118, #7928

Co-authored-by: myl1024 <myl92916@qq.com>