### PR TITLE
sort Command lookupKeyRead and lookupKeyWrite are used on the opposite

### DIFF
--- a/src/sort.c
+++ b/src/sort.c
@@ -270,7 +270,7 @@ void sortCommand(client *c) {
     }
 
     /* Lookup the key to sort. It must be of the right types */
-    if (storekey)
+    if (!storekey)
         sortval = lookupKeyRead(c->db,c->argv[1]);
     else
         sortval = lookupKeyWrite(c->db,c->argv[1]);


### PR DESCRIPTION
When storekey is not null, it is a write command.