### PR TITLE
In sdscatfmt when call sdsMakeRoomFor, it required more space

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -642,7 +642,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
     /* To avoid continuous reallocations, let's start with a buffer that
      * can hold at least two times the format string itself. It's not the
      * best heuristic but seems to work in practice. */
-    s = sdsMakeRoomFor(s, initlen + strlen(fmt)*2);
+    s = sdsMakeRoomFor(s, strlen(fmt)*2);
     va_start(ap,fmt);
     f = fmt;    /* Next format specifier byte to process. */
     i = initlen; /* Position of the next byte to write to dest str. */


### PR DESCRIPTION
In sdscatfmt when call sdsMakeRoomFor, it required more space than needed.
If the initlen is very big, it will allocate a lot of memory than needed.