### PR TITLE
Add modules API for streams

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -31,4 +31,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/getkeys \
 --single unit/moduleapi/test_lazyfree \
 --single unit/moduleapi/defrag \
+--single unit/moduleapi/stream \
 "${@}"

--- a/src/module.c
+++ b/src/module.c
@@ -3354,13 +3354,13 @@ int RM_StreamIteratorStop(RedisModuleKey *key) {
  *   don't care.
  *
  * Returns REDISMODULE_OK and sets `*id` and `*numfields` if an entry was found.
- * If there are no more entries, REDISMODULE_EOF is returned. On failure,
- * REDISMODULE_ERR is returned and `errno` is set as follows:
+ * On failure, REDISMODULE_ERR is returned and `errno` is set as follows:
  *
  * - EINVAL if called with a NULL key
  * - ENOTSUP if the key refers to a value of a type other than stream or if the
  *   key is empty
  * - EBADF if no stream iterator is associated with the key
+ * - ENOENT if there are no more entries in the range of the iterator
  *
  * Use RedisModule_StreamIteratorNextField() to retrieve the fields and values.
  * See the example at RedisModule_StreamIteratorStart().
@@ -3396,7 +3396,7 @@ int RM_StreamIteratorNextID(RedisModuleKey *key, RedisModuleStreamID *id, long *
             id->seq = 0;
         }
         if (numfields) *numfields = 0;
-        return REDISMODULE_EOF;
+        return REDISMODULE_ERR;
     }
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -3145,6 +3145,7 @@ int RM_StreamAdd(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisM
         /* Current last ID is greater than or equal to 'use_id' */
         return REDISMODULE_ERR;
     }
+    signalKeyAsReady(key->db, key->key, OBJ_STREAM);
 
     if (id != NULL) {
         id->ms = added_id.ms;

--- a/src/module.c
+++ b/src/module.c
@@ -3097,8 +3097,6 @@ int RM_HashGet(RedisModuleKey *key, int flags, ...) {
  * - `flags`: A bit field of
  *   - `REDISMODULE_STREAM_AUTOID`: Assign a stream ID automatically, like `*`
  *     in the XADD command.
- *   - `REDISMODULE_STREAM_NOMKSTREAM`: Don't create the stream if it doesn't
- *     exist.
  * - `id`: If the `AUTOID` flag is set, this is where the assigned ID is
  *   returned. Can be NULL if `AUTOID` is set, if you don't care to receive the
  *   ID. If `AUTOID` is not set, this is the requested ID.
@@ -3108,20 +3106,16 @@ int RM_HashGet(RedisModuleKey *key, int flags, ...) {
  *
  * Returns REDISMODULE_OK if an entry has been added. Returns REDISMODULE_ERR if
  * the key is not opened for writing, if the key has a type other than stream,
- * if the key doesn't exist in case the flag `NOMKSTREAM` is set, if unknown
- * flags are given or when attempting to create an entry with an id which is not
- * allowed.
+ * if unknown flags are given or when attempting to create an entry with an id
+ * which is not allowed.
  */
 int RM_StreamAdd(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisModuleString **argv, long numfields) {
     /* Validate args */
-    if (flags & ~(REDISMODULE_STREAM_AUTOID |
-                  REDISMODULE_STREAM_NOMKSTREAM))
+    if (flags & ~(REDISMODULE_STREAM_AUTOID))
         return REDISMODULE_ERR; /* unknown flags */
     if (!(key->mode & REDISMODULE_WRITE))
         return REDISMODULE_ERR;
     if (key->value && key->value->type != OBJ_STREAM)
-        return REDISMODULE_ERR;
-    if (key->value == NULL && (flags & REDISMODULE_STREAM_NOMKSTREAM))
         return REDISMODULE_ERR;
     if (!(flags & REDISMODULE_STREAM_AUTOID) &&
         (id == NULL || (id->ms == 0 && id->seq == 0)))

--- a/src/module.c
+++ b/src/module.c
@@ -3321,13 +3321,13 @@ int RM_StreamIteratorStop(RedisModuleKey *key) {
  *   don't care.
  *
  * Returns REDISMODULE_OK and sets `*id` and `*numfields` if an entry was found.
- * On failure, REDISMODULE_ERR is returned and `errno` is set as follows:
+ * If there are no more entries, REDISMODULE_EOF is returned. On failure,
+ * REDISMODULE_ERR is returned and `errno` is set as follows:
  *
  * - EINVAL if called with a NULL key
  * - ENOTSUP if the key refers to a value of a type other than stream or if the
  *   key is empty
  * - EBADF if no stream iterator is associated with the key
- * - ENOENT if there are no more entries in the range of the iterator
  *
  * Use RedisModule_StreamIteratorNextField() to retrieve the fields and values.
  * See the example at RedisModule_StreamIteratorStart().
@@ -3360,7 +3360,7 @@ int RM_StreamIteratorNextID(RedisModuleKey *key, RedisModuleStreamID *id, long *
             id->seq = 0;
         }
         if (numfields) *numfields = 0;
-        return REDISMODULE_ERR;
+        return REDISMODULE_EOF;
     }
 }
 
@@ -3385,8 +3385,8 @@ int RM_StreamIteratorNextID(RedisModuleKey *key, RedisModuleStreamID *id, long *
  *
  * See the example at RedisModule_StreamIteratorStart().
  *
- * Known issues: No error is returned if called more times than the number of
- * fields.
+ * Known issues: No error nor EOF is returned if called more times than the
+ * number of fields.
  */
 int RM_StreamIteratorNextField(RedisModuleKey *key, RedisModuleString **field_ptr, RedisModuleString **value_ptr) {
     if (!key) {

--- a/src/module.c
+++ b/src/module.c
@@ -2174,7 +2174,7 @@ static void moduleCloseKey(RedisModuleKey *key) {
     int signal = SHOULD_SIGNAL_MODIFIED_KEYS(key->ctx);
     if ((key->mode & REDISMODULE_WRITE) && signal)
         signalModifiedKey(key->ctx->client,key->db,key->key);
-    /* TODO: if (key->iter) RM_KeyIteratorStop(kp); */
+    if (key->iter) zfree(key->iter);
     RM_ZsetRangeStop(key);
     if (key && key->value && key->value->type == OBJ_STREAM &&
         key->u.stream.signalready) {
@@ -3268,7 +3268,7 @@ int RM_StreamDelete(RedisModuleKey *key, RedisModuleStreamID *id) {
  *
  * The stream IDs are retrieved using RedisModule_StreamIteratorNextID() and
  * for each stream ID, the fields and values are retrieved using
- * RedisModule_StreamIteratorNextField(). The iterator must be freed by calling
+ * RedisModule_StreamIteratorNextField(). The iterator is freed by calling
  * RedisModule_StreamIteratorStop().
  *
  * Example (error handling omitted):

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -11,10 +11,6 @@
 #define REDISMODULE_OK 0
 #define REDISMODULE_ERR 1
 
-/* EOF returned by iterator functions when there are no more elements. EOF is an
- * implementation defined negative number (normally -1). */
-#define REDISMODULE_EOF EOF
-
 /* API versions. */
 #define REDISMODULE_APIVER_1 1
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -78,10 +78,9 @@ typedef struct RedisModuleStreamID {
 /* Stream API flags. */
 #define REDISMODULE_STREAM_NONE 0
 #define REDISMODULE_STREAM_AUTOID (1<<0)
-#define REDISMODULE_STREAM_NOMKSTREAM (1<<1)
-#define REDISMODULE_STREAM_EXCLUSIVE (1<<2)
-#define REDISMODULE_STREAM_REVERSE (1<<3)
-#define REDISMODULE_STREAM_APPROX (1<<4)
+#define REDISMODULE_STREAM_EXCLUSIVE (1<<1)
+#define REDISMODULE_STREAM_REVERSE (1<<2)
+#define REDISMODULE_STREAM_APPROX (1<<3)
 
 /* Context Flags: Info about the current context returned by
  * RM_GetContextFlags(). */

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -69,6 +69,15 @@
 #define REDISMODULE_HASH_CFIELDS    (1<<2)
 #define REDISMODULE_HASH_EXISTS     (1<<3)
 
+/* StreamID type. */
+typedef struct RedisModuleStreamID {
+    uint64_t ms;
+    uint64_t seq;
+} RedisModuleStreamID;
+
+/* Stream API flags. */
+#define REDISMODULE_STREAM_NONE 0
+
 /* Context Flags: Info about the current context returned by
  * RM_GetContextFlags(). */
 
@@ -629,6 +638,8 @@ REDISMODULE_API int (*RedisModule_ZsetRangePrev)(RedisModuleKey *key) REDISMODUL
 REDISMODULE_API int (*RedisModule_ZsetRangeEndReached)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_HashSet)(RedisModuleKey *key, int flags, ...) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_HashGet)(RedisModuleKey *key, int flags, ...) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StreamParseID)(RedisModuleString *id_str, RedisModuleStreamID *id_parsed) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString * (*RedisModule_StreamFormatID)(RedisModuleCtx *ctx, RedisModuleStreamID *id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_KeyAtPos)(RedisModuleCtx *ctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_GetClientId)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -887,6 +898,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ZsetRangeEndReached);
     REDISMODULE_GET_API(HashSet);
     REDISMODULE_GET_API(HashGet);
+    REDISMODULE_GET_API(StreamParseID);
+    REDISMODULE_GET_API(StreamFormatID);
     REDISMODULE_GET_API(IsKeysPositionRequest);
     REDISMODULE_GET_API(KeyAtPos);
     REDISMODULE_GET_API(GetClientId);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -655,6 +655,7 @@ REDISMODULE_API int (*RedisModule_StreamIteratorStart)(RedisModuleKey *key, int 
 REDISMODULE_API int (*RedisModule_StreamIteratorStop)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StreamIteratorNextID)(RedisModuleKey *key, RedisModuleStreamID *id, long *numfields) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StreamIteratorNextField)(RedisModuleKey *key, RedisModuleString **field_ptr, RedisModuleString **value_ptr) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StreamIteratorDelete)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API long long (*RedisModule_StreamTrimByLength)(RedisModuleKey *key, int flags, long long length) REDISMODULE_ATTR;
 REDISMODULE_API long long (*RedisModule_StreamTrimByID)(RedisModuleKey *key, int flags, RedisModuleStreamID *id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -923,6 +924,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(StreamIteratorStop);
     REDISMODULE_GET_API(StreamIteratorNextID);
     REDISMODULE_GET_API(StreamIteratorNextField);
+    REDISMODULE_GET_API(StreamIteratorDelete);
     REDISMODULE_GET_API(StreamTrimByLength);
     REDISMODULE_GET_API(StreamTrimByID);
     REDISMODULE_GET_API(IsKeysPositionRequest);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -87,6 +87,7 @@ typedef struct RedisModuleStreamID {
 #define REDISMODULE_STREAM_NOMKSTREAM (1<<1)
 #define REDISMODULE_STREAM_EXCLUSIVE (1<<2)
 #define REDISMODULE_STREAM_REVERSE (1<<3)
+#define REDISMODULE_STREAM_APPROX (1<<4)
 
 /* Context Flags: Info about the current context returned by
  * RM_GetContextFlags(). */
@@ -654,6 +655,8 @@ REDISMODULE_API int (*RedisModule_StreamAdd)(RedisModuleKey *key, int flags, Red
 REDISMODULE_API int (*RedisModule_StreamIteratorStart)(RedisModuleKey *key, int flags, RedisModuleStreamID *minid, RedisModuleStreamID *maxid) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StreamIteratorStop)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StreamIteratorNext)(RedisModuleKey *key, long maxnumfields, RedisModuleStreamID *id, RedisModuleString **fieldsvalues, long *numfields) REDISMODULE_ATTR;
+REDISMODULE_API long long (*RedisModule_StreamTrimByLength)(RedisModuleKey *key, int flags, long long length) REDISMODULE_ATTR;
+REDISMODULE_API long long (*RedisModule_StreamTrimByID)(RedisModuleKey *key, int flags, RedisModuleStreamID *id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_KeyAtPos)(RedisModuleCtx *ctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_GetClientId)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -918,6 +921,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(StreamIteratorStart);
     REDISMODULE_GET_API(StreamIteratorStop);
     REDISMODULE_GET_API(StreamIteratorNext);
+    REDISMODULE_GET_API(StreamTrimByLength);
+    REDISMODULE_GET_API(StreamTrimByID);
     REDISMODULE_GET_API(IsKeysPositionRequest);
     REDISMODULE_GET_API(KeyAtPos);
     REDISMODULE_GET_API(GetClientId);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -648,7 +648,8 @@ REDISMODULE_API int (*RedisModule_HashGet)(RedisModuleKey *key, int flags, ...) 
 REDISMODULE_API int (*RedisModule_StreamAdd)(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisModuleString **argv, int64_t numfields) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StreamIteratorStart)(RedisModuleKey *key, int flags, RedisModuleStreamID *startid, RedisModuleStreamID *endid) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StreamIteratorStop)(RedisModuleKey *key) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StreamIteratorNext)(RedisModuleKey *key, long maxnumfields, RedisModuleStreamID *id, RedisModuleString **fieldsvalues, long *numfields) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StreamIteratorNextID)(RedisModuleKey *key, RedisModuleStreamID *id, long *numfields) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StreamIteratorNextField)(RedisModuleKey *key, RedisModuleString **field_ptr, RedisModuleString **value_ptr) REDISMODULE_ATTR;
 REDISMODULE_API long long (*RedisModule_StreamTrimByLength)(RedisModuleKey *key, int flags, long long length) REDISMODULE_ATTR;
 REDISMODULE_API long long (*RedisModule_StreamTrimByID)(RedisModuleKey *key, int flags, RedisModuleStreamID *id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -914,7 +915,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(StreamAdd);
     REDISMODULE_GET_API(StreamIteratorStart);
     REDISMODULE_GET_API(StreamIteratorStop);
-    REDISMODULE_GET_API(StreamIteratorNext);
+    REDISMODULE_GET_API(StreamIteratorNextID);
+    REDISMODULE_GET_API(StreamIteratorNextField);
     REDISMODULE_GET_API(StreamTrimByLength);
     REDISMODULE_GET_API(StreamTrimByID);
     REDISMODULE_GET_API(IsKeysPositionRequest);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -75,12 +75,13 @@ typedef struct RedisModuleStreamID {
     uint64_t seq;
 } RedisModuleStreamID;
 
-/* Stream API flags. */
-#define REDISMODULE_STREAM_NONE 0
-#define REDISMODULE_STREAM_AUTOID (1<<0)
-#define REDISMODULE_STREAM_EXCLUSIVE (1<<1)
-#define REDISMODULE_STREAM_REVERSE (1<<2)
-#define REDISMODULE_STREAM_APPROX (1<<3)
+/* StreamAdd() flags. */
+#define REDISMODULE_STREAM_ADD_AUTOID (1<<0)
+/* StreamIteratorStart() flags. */
+#define REDISMODULE_STREAM_ITERATOR_EXCLUSIVE (1<<0)
+#define REDISMODULE_STREAM_ITERATOR_REVERSE (1<<1)
+/* StreamIteratorTrim*() flags. */
+#define REDISMODULE_STREAM_TRIM_APPROX (1<<0)
 
 /* Context Flags: Info about the current context returned by
  * RM_GetContextFlags(). */

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -77,6 +77,8 @@ typedef struct RedisModuleStreamID {
 
 /* Stream API flags. */
 #define REDISMODULE_STREAM_NONE 0
+#define REDISMODULE_STREAM_AUTOID (1<<0)
+#define REDISMODULE_STREAM_NOMKSTREAM (1<<1)
 
 /* Context Flags: Info about the current context returned by
  * RM_GetContextFlags(). */
@@ -640,6 +642,7 @@ REDISMODULE_API int (*RedisModule_HashSet)(RedisModuleKey *key, int flags, ...) 
 REDISMODULE_API int (*RedisModule_HashGet)(RedisModuleKey *key, int flags, ...) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StreamParseID)(RedisModuleString *id_str, RedisModuleStreamID *id_parsed) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_StreamFormatID)(RedisModuleCtx *ctx, RedisModuleStreamID *id) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StreamAdd)(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisModuleString **argv, int64_t numfields) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_KeyAtPos)(RedisModuleCtx *ctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_GetClientId)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -900,6 +903,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(HashGet);
     REDISMODULE_GET_API(StreamParseID);
     REDISMODULE_GET_API(StreamFormatID);
+    REDISMODULE_GET_API(StreamAdd);
     REDISMODULE_GET_API(IsKeysPositionRequest);
     REDISMODULE_GET_API(KeyAtPos);
     REDISMODULE_GET_API(GetClientId);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -645,6 +645,7 @@ REDISMODULE_API int (*RedisModule_ZsetRangeEndReached)(RedisModuleKey *key) REDI
 REDISMODULE_API int (*RedisModule_HashSet)(RedisModuleKey *key, int flags, ...) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_HashGet)(RedisModuleKey *key, int flags, ...) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StreamAdd)(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisModuleString **argv, int64_t numfields) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StreamDelete)(RedisModuleKey *key, RedisModuleStreamID *id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StreamIteratorStart)(RedisModuleKey *key, int flags, RedisModuleStreamID *startid, RedisModuleStreamID *endid) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StreamIteratorStop)(RedisModuleKey *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StreamIteratorNextID)(RedisModuleKey *key, RedisModuleStreamID *id, long *numfields) REDISMODULE_ATTR;
@@ -912,6 +913,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(HashSet);
     REDISMODULE_GET_API(HashGet);
     REDISMODULE_GET_API(StreamAdd);
+    REDISMODULE_GET_API(StreamDelete);
     REDISMODULE_GET_API(StreamIteratorStart);
     REDISMODULE_GET_API(StreamIteratorStop);
     REDISMODULE_GET_API(StreamIteratorNextID);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -75,10 +75,18 @@ typedef struct RedisModuleStreamID {
     uint64_t seq;
 } RedisModuleStreamID;
 
+/* StreamID MIN and MAX to be used like "-" and "+". */
+#define REDISMODULE_STREAMID_MIN \
+    ((struct RedisModuleStreamID){0, 0})
+#define REDISMODULE_STREAMID_MAX \
+    ((struct RedisModuleStreamID){UINT64_MAX, UINT64_MAX})
+
 /* Stream API flags. */
 #define REDISMODULE_STREAM_NONE 0
 #define REDISMODULE_STREAM_AUTOID (1<<0)
 #define REDISMODULE_STREAM_NOMKSTREAM (1<<1)
+#define REDISMODULE_STREAM_EXCLUSIVE (1<<2)
+#define REDISMODULE_STREAM_REVERSE (1<<3)
 
 /* Context Flags: Info about the current context returned by
  * RM_GetContextFlags(). */
@@ -643,6 +651,9 @@ REDISMODULE_API int (*RedisModule_HashGet)(RedisModuleKey *key, int flags, ...) 
 REDISMODULE_API int (*RedisModule_StreamParseID)(RedisModuleString *id_str, RedisModuleStreamID *id_parsed) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_StreamFormatID)(RedisModuleCtx *ctx, RedisModuleStreamID *id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StreamAdd)(RedisModuleKey *key, int flags, RedisModuleStreamID *id, RedisModuleString **argv, int64_t numfields) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StreamIteratorStart)(RedisModuleKey *key, int flags, RedisModuleStreamID *minid, RedisModuleStreamID *maxid) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StreamIteratorStop)(RedisModuleKey *key) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StreamIteratorNext)(RedisModuleKey *key, long maxnumfields, RedisModuleStreamID *id, RedisModuleString **fieldsvalues, long *numfields) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_KeyAtPos)(RedisModuleCtx *ctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_GetClientId)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -904,6 +915,9 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(StreamParseID);
     REDISMODULE_GET_API(StreamFormatID);
     REDISMODULE_GET_API(StreamAdd);
+    REDISMODULE_GET_API(StreamIteratorStart);
+    REDISMODULE_GET_API(StreamIteratorStop);
+    REDISMODULE_GET_API(StreamIteratorNext);
     REDISMODULE_GET_API(IsKeysPositionRequest);
     REDISMODULE_GET_API(KeyAtPos);
     REDISMODULE_GET_API(GetClientId);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -11,6 +11,10 @@
 #define REDISMODULE_OK 0
 #define REDISMODULE_ERR 1
 
+/* EOF returned by iterator functions when there are no more elements. EOF is an
+ * implementation defined negative number (normally -1). */
+#define REDISMODULE_EOF EOF
+
 /* API versions. */
 #define REDISMODULE_APIVER_1 1
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -121,5 +121,7 @@ int streamDecrID(streamID *id);
 void streamPropagateConsumerCreation(client *c, robj *key, robj *groupname, sds consumername);
 robj *streamDup(robj *o);
 int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep);
+int streamParseID(robj *o, streamID *id);
+robj *createObjectFromStreamID(streamID *id);
 
 #endif

--- a/src/stream.h
+++ b/src/stream.h
@@ -124,6 +124,7 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep);
 int streamParseID(const robj *o, streamID *id);
 robj *createObjectFromStreamID(streamID *id);
 int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_id, streamID *use_id);
+int streamDeleteItem(stream *s, streamID *id);
 int64_t streamTrimByLength(stream *s, long long maxlen, int approx);
 int64_t streamTrimByID(stream *s, streamID minid, int approx);
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -121,7 +121,7 @@ int streamDecrID(streamID *id);
 void streamPropagateConsumerCreation(client *c, robj *key, robj *groupname, sds consumername);
 robj *streamDup(robj *o);
 int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep);
-int streamParseID(robj *o, streamID *id);
+int streamParseID(const robj *o, streamID *id);
 robj *createObjectFromStreamID(streamID *id);
 int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_id, streamID *use_id);
 int64_t streamTrimByLength(stream *s, long long maxlen, int approx);

--- a/src/stream.h
+++ b/src/stream.h
@@ -123,5 +123,6 @@ robj *streamDup(robj *o);
 int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep);
 int streamParseID(robj *o, streamID *id);
 robj *createObjectFromStreamID(streamID *id);
+int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_id, streamID *use_id);
 
 #endif

--- a/src/stream.h
+++ b/src/stream.h
@@ -124,5 +124,7 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep);
 int streamParseID(robj *o, streamID *id);
 robj *createObjectFromStreamID(streamID *id);
 int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_id, streamID *use_id);
+int64_t streamTrimByLength(stream *s, long long maxlen, int approx);
+int64_t streamTrimByID(stream *s, streamID minid, int approx);
 
 #endif

--- a/src/stream.h
+++ b/src/stream.h
@@ -108,6 +108,7 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
 void streamIteratorStart(streamIterator *si, stream *s, streamID *start, streamID *end, int rev);
 int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields);
 void streamIteratorGetField(streamIterator *si, unsigned char **fieldptr, unsigned char **valueptr, int64_t *fieldlen, int64_t *valuelen);
+void streamIteratorRemoveEntry(streamIterator *si, streamID *current);
 void streamIteratorStop(streamIterator *si);
 streamCG *streamLookupCG(stream *s, sds groupname);
 streamConsumer *streamLookupConsumer(streamCG *cg, sds name, int flags, int *created);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1661,6 +1661,11 @@ invalid:
     return C_ERR;
 }
 
+/* Wrapper for streamGenericParseIDOrReply() used by module API. */
+int streamParseID(robj *o, streamID *id) {
+    return streamGenericParseIDOrReply(NULL, o, id, 0, 0);
+}
+
 /* Wrapper for streamGenericParseIDOrReply() with 'strict' argument set to
  * 0, to be used when - and + are acceptable IDs. */
 int streamParseIDOrReply(client *c, robj *o, streamID *id, uint64_t missing_seq) {

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -818,6 +818,28 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
     return deleted;
 }
 
+/* Trims a stream by length. Returns the number of deleted items. */
+int64_t streamTrimByLength(stream *s, long long maxlen, int approx) {
+    streamAddTrimArgs args = {
+        .trim_strategy = TRIM_STRATEGY_MAXLEN,
+        .approx_trim = approx,
+        .limit = approx ? 100 * server.stream_node_max_entries : 0,
+        .maxlen = maxlen
+    };
+    return streamTrim(s, &args);
+}
+
+/* Trims a stream by minimum ID. Returns the number of deleted items. */
+int64_t streamTrimByID(stream *s, streamID minid, int approx) {
+    streamAddTrimArgs args = {
+        .trim_strategy = TRIM_STRATEGY_MINID,
+        .approx_trim = approx,
+        .limit = approx ? 100 * server.stream_node_max_entries : 0,
+        .minid = minid
+    };
+    return streamTrim(s, &args);
+}
+
 /* Parse the arguements of XADD/XTRIM.
  *
  * See streamAddTrimArgs for more details about the arguments handled.

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1647,7 +1647,7 @@ robj *streamTypeLookupWriteOrCreate(client *c, robj *key, int no_create) {
  * treated as an invalid ID.
  *
  * If 'c' is set to NULL, no reply is sent to the client. */
-int streamGenericParseIDOrReply(client *c, robj *o, streamID *id, uint64_t missing_seq, int strict) {
+int streamGenericParseIDOrReply(client *c, const robj *o, streamID *id, uint64_t missing_seq, int strict) {
     char buf[128];
     if (sdslen(o->ptr) > sizeof(buf)-1) goto invalid;
     memcpy(buf,o->ptr,sdslen(o->ptr)+1);
@@ -1684,7 +1684,7 @@ invalid:
 }
 
 /* Wrapper for streamGenericParseIDOrReply() used by module API. */
-int streamParseID(robj *o, streamID *id) {
+int streamParseID(const robj *o, streamID *id) {
     return streamGenericParseIDOrReply(NULL, o, id, 0, 0);
 }
 

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -27,7 +27,8 @@ TEST_MODULES = \
     getkeys.so \
     test_lazyfree.so \
     timer.so \
-    defragtest.so
+    defragtest.so \
+    stream.so
 
 
 .PHONY: all

--- a/tests/modules/stream.c
+++ b/tests/modules/stream.c
@@ -1,0 +1,78 @@
+#include "redismodule.h"
+
+#include <string.h>
+#include <assert.h>
+#include <unistd.h>
+
+/* Command which adds a stream entry with automatic ID, like XADD *.
+ *
+ * Syntax: STREAM.ADD key field1 value1 [ field2 value2 ... ]
+ *
+ * The response is the ID of the added stream entry or an error message.
+ */
+int stream_add(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 2 || argc % 2 != 0) {
+        RedisModule_WrongArity(ctx);
+        return REDISMODULE_OK;
+    }
+
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+    RedisModuleStreamID id;
+    if (RedisModule_StreamAdd(key, REDISMODULE_STREAM_AUTOID, &id,
+                              &argv[2], (argc-2)/2) == REDISMODULE_OK) {
+        RedisModuleString *id_str = RedisModule_StreamFormatID(ctx, &id);
+        RedisModule_ReplyWithString(ctx, id_str);
+        RedisModule_FreeString(ctx, id_str);
+    } else {
+        RedisModule_ReplyWithError(ctx, "ERR StreamAdd failed");
+    }
+    RedisModule_CloseKey(key);
+    /* RedisModule_SignalKeyAsReady(ctx, argv[1]); */
+    return REDISMODULE_OK;
+}
+
+/* Command which adds a stream entry N times.
+ *
+ * Syntax: STREAM.ADD key N field1 value1 [ field2 value2 ... ]
+ *
+ * Returns the number of successfully added entries.
+ */
+int stream_addn(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 3 || argc % 2 == 0) {
+        RedisModule_WrongArity(ctx);
+        return REDISMODULE_OK;
+    }
+
+    long long n, i;
+    if (RedisModule_StringToLongLong(argv[2], &n) == REDISMODULE_ERR) {
+        RedisModule_ReplyWithError(ctx, "N must be a number");
+        return REDISMODULE_OK;
+    }
+
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+    for (i = 0; i < n; i++) {
+        if (RedisModule_StreamAdd(key, REDISMODULE_STREAM_AUTOID, NULL,
+                                  &argv[3], (argc-3)/2) == REDISMODULE_ERR)
+            break;
+    }
+    RedisModule_ReplyWithLongLong(ctx, i);
+    RedisModule_CloseKey(key);
+    /* if (i > 0) RedisModule_SignalKeyAsReady(ctx, argv[1]); */
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    if (RedisModule_Init(ctx, "stream", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "stream.add", stream_add, "",
+                                  1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "stream.addn", stream_addn, "",
+                                  1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    return REDISMODULE_OK;
+}

--- a/tests/modules/stream.c
+++ b/tests/modules/stream.c
@@ -19,7 +19,7 @@ int stream_add(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
     RedisModuleStreamID id;
-    if (RedisModule_StreamAdd(key, REDISMODULE_STREAM_AUTOID, &id,
+    if (RedisModule_StreamAdd(key, REDISMODULE_STREAM_ADD_AUTOID, &id,
                               &argv[2], (argc-2)/2) == REDISMODULE_OK) {
         RedisModuleString *id_str = RedisModule_CreateStringFromStreamID(ctx, &id);
         RedisModule_ReplyWithString(ctx, id_str);
@@ -28,7 +28,6 @@ int stream_add(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         RedisModule_ReplyWithError(ctx, "ERR StreamAdd failed");
     }
     RedisModule_CloseKey(key);
-    /* RedisModule_SignalKeyAsReady(ctx, argv[1]); */
     return REDISMODULE_OK;
 }
 
@@ -52,13 +51,12 @@ int stream_addn(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
     for (i = 0; i < n; i++) {
-        if (RedisModule_StreamAdd(key, REDISMODULE_STREAM_AUTOID, NULL,
+        if (RedisModule_StreamAdd(key, REDISMODULE_STREAM_ADD_AUTOID, NULL,
                                   &argv[3], (argc-3)/2) == REDISMODULE_ERR)
             break;
     }
     RedisModule_ReplyWithLongLong(ctx, i);
     RedisModule_CloseKey(key);
-    /* if (i > 0) RedisModule_SignalKeyAsReady(ctx, argv[1]); */
     return REDISMODULE_OK;
 }
 
@@ -104,7 +102,7 @@ int stream_range(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         RedisModuleStreamID tmp = startid;
         startid = endid;
         endid = tmp;
-        flags |= REDISMODULE_STREAM_REVERSE;
+        flags |= REDISMODULE_STREAM_ITERATOR_REVERSE;
     }
 
     /* Open key and start iterator. */
@@ -178,7 +176,7 @@ int stream_trim(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     int flags;
     arg = RedisModule_StringPtrLen(argv[3], &arg_len);
     if (arg_len == 1 && arg[0] == '~') {
-        flags = REDISMODULE_STREAM_APPROX;
+        flags = REDISMODULE_STREAM_TRIM_APPROX;
     } else if (arg_len == 1 && arg[0] == '=') {
         flags = 0;
     } else {

--- a/tests/modules/stream.c
+++ b/tests/modules/stream.c
@@ -62,6 +62,23 @@ int stream_addn(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return REDISMODULE_OK;
 }
 
+/* STREAM.DELETE key stream-id */
+int stream_delete(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    RedisModuleStreamID id;
+    if (RedisModule_StringToStreamID(argv[2], &id) != REDISMODULE_OK) {
+        return RedisModule_ReplyWithError(ctx, "Invalid stream ID");
+    }
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+    if (RedisModule_StreamDelete(key, &id) == REDISMODULE_OK) {
+        RedisModule_ReplyWithSimpleString(ctx, "OK");
+    } else {
+        RedisModule_ReplyWithError(ctx, "ERR StreamDelete failed");
+    }
+    RedisModule_CloseKey(key);
+    return REDISMODULE_OK;
+}
+
 /* STREAM.RANGE key start-id end-id
  *
  * Returns an array of stream items. Each item is an array on the form
@@ -198,6 +215,9 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                                   1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
     if (RedisModule_CreateCommand(ctx, "stream.addn", stream_addn, "",
+                                  1, 1, 1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx, "stream.delete", stream_delete, "",
                                   1, 1, 1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
     if (RedisModule_CreateCommand(ctx, "stream.range", stream_range, "",

--- a/tests/modules/stream.c
+++ b/tests/modules/stream.c
@@ -103,19 +103,20 @@ int stream_range(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     /* Return array. */
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
     RedisModule_AutoMemory(ctx);
-    RedisModuleString *fields_and_values[200];
     RedisModuleStreamID id;
     long numfields;
     long len = 0;
-    while (RedisModule_StreamIteratorNext(key, 100, &id,
-                                          fields_and_values,
-                                          &numfields) == REDISMODULE_OK) {
+    while (RedisModule_StreamIteratorNextID(key, &id,
+                                            &numfields) == REDISMODULE_OK) {
         RedisModule_ReplyWithArray(ctx, 2);
         RedisModuleString *id_str = RedisModule_CreateStringFromStreamID(ctx, &id);
         RedisModule_ReplyWithString(ctx, id_str);
         RedisModule_ReplyWithArray(ctx, numfields * 2);
-        for (long i = 0; i < numfields * 2; i++) {
-            RedisModule_ReplyWithString(ctx, fields_and_values[i]);
+        for (long i = 0; i < numfields; i++) {
+            RedisModuleString *field, *value;
+            RedisModule_StreamIteratorNextField(key, &field, &value);
+            RedisModule_ReplyWithString(ctx, field);
+            RedisModule_ReplyWithString(ctx, value);
         }
         len++;
     }

--- a/tests/unit/moduleapi/stream.tcl
+++ b/tests/unit/moduleapi/stream.tcl
@@ -27,4 +27,27 @@ start_server {tags {"modules"}} {
         set result [r stream.addn mystream $n field value]
         assert_equal $result $n
     }
+
+    test {Module stream iterator} {
+        r del mystream
+        set streamid1 [r xadd mystream * item 1 value a]
+        set streamid2 [r xadd mystream * item 2 value b]
+        # range result
+        set result1 [r stream.range mystream "-" "+"]
+        set expect1 [r xrange mystream "-" "+"]
+        assert_equal $result1 $expect1
+        # reverse range
+        set result_rev [r stream.range mystream "+" "-"]
+        set expect_rev [r xrevrange mystream "+" "-"]
+        assert_equal $result_rev $expect_rev
+
+        # only one item: range with startid = endid
+        set result2 [r stream.range mystream "-" $streamid1]
+        assert_equal $result2 "{$streamid1 {item 1 value a}}"
+        assert_equal $result2 [list [list $streamid1 {item 1 value a}]]
+        # only one item: range with startid = endid
+        set result3 [r stream.range mystream $streamid2 $streamid2]
+        assert_equal $result3 "{$streamid2 {item 2 value b}}"
+        assert_equal $result3 [list [list $streamid2 {item 2 value b}]]
+    }
 }

--- a/tests/unit/moduleapi/stream.tcl
+++ b/tests/unit/moduleapi/stream.tcl
@@ -84,6 +84,21 @@ start_server {tags {"modules"}} {
         assert_equal $result3 [list [list $streamid2 {item 2 value b}]]
     }
 
+    test {Module stream iterator delete} {
+        r del mystream
+        set id1 [r xadd mystream * normal item]
+        set id2 [r xadd mystream * selfdestruct yes]
+        set id3 [r xadd mystream * another item]
+        # stream.range deletes the "selfdestruct" item after returning it
+        assert_equal \
+            "{$id1 {normal item}} {$id2 {selfdestruct yes}} {$id3 {another item}}" \
+            [r stream.range mystream - +]
+        # now, the "selfdestruct" item is gone
+        assert_equal \
+            "{$id1 {normal item}} {$id3 {another item}}" \
+            [r stream.range mystream - +]
+    }
+
     test {Module stream trim by length} {
         r del mystream
         # exact maxlen

--- a/tests/unit/moduleapi/stream.tcl
+++ b/tests/unit/moduleapi/stream.tcl
@@ -1,0 +1,30 @@
+set testmodule [file normalize tests/modules/stream.so]
+
+start_server {tags {"modules"}} {
+    r module load $testmodule
+
+    test {Module stream add} {
+        r del mystream
+        # add to empty key
+        set streamid1 [r stream.add mystream item 1 value a]
+        # add to existing stream
+        set streamid2 [r stream.add mystream item 2 value b]
+        # check result
+        assert { [string match "*-*" $streamid1] }
+        set items [r XRANGE mystream - +]
+        assert_equal $items \
+            "{$streamid1 {item 1 value a}} {$streamid2 {item 2 value b}}"
+        # check error condition
+        r del mystream
+        r set mystream mystring
+        catch {r stream.add mystream item 1 value a} e
+        assert_equal $e "ERR StreamAdd failed"
+    }
+
+    test {Module stream add benchmark (1M stream add)} {
+        set n 1000000
+        r del mystream
+        set result [r stream.addn mystream $n field value]
+        assert_equal $result $n
+    }
+}


### PR DESCRIPTION
APIs added for these stream operations: add, delete, iterate and
trim (by ID or maxlength). The functions are prefixed by RM_Stream.

The type RedisModuleStreamID is added and functions for converting
from and to RedisModuleString.

Whenever the stream functions return REDISMODULE_ERR, errno is set to
provide additional error information.

Refactoring: The zset iterator fields in the RedisModuleKey struct
are wrapped in a union, to allow the same space to be used for type-
specific info for streams and allow future use for other key types.

Fixes #5760.
