### PR TITLE
fix memory leak in processInlineBuffer

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1734,6 +1734,7 @@ int processInlineBuffer(client *c) {
      * However the is an exception: masters may send us just a newline
      * to keep the connection active. */
     if (querylen != 0 && c->flags & CLIENT_MASTER) {
+        sdsfreesplitres(argv,argc);
         serverLog(LL_WARNING,"WARNING: Receiving inline protocol from master, master stream corruption? Closing the master connection and discarding the cached master.");
         setProtocolError("Master using the inline protocol. Desync?",c);
         return C_ERR;


### PR DESCRIPTION
 a potential memory leaking was found in processInlineBuffer, valgrind message:

==10359== 32 (16 direct, 16 indirect) bytes in 1 blocks are definitely lost in loss record 401 of 669
==10359==    at 0x4C31D2F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==10359==    by 0x14FEF2: zrealloc (zmalloc.c:158)
==10359==    by 0x14FA4A: sdssplitargs (sds.c:1049)
==10359==    by 0x15A831: processInlineBuffer (networking.c:1578)
==10359==    by 0x15B71A: processInputBuffer (networking.c:1908)
==10359==    by 0x15BC39: readQueryFromClient (networking.c:2026)
==10359==    by 0x203464: callHandler (connhelpers.h:79)
==10359==    by 0x203B0D: connSocketEventHandler (connection.c:296)
==10359==    by 0x13DC8E: aeProcessEvents (ae.c:479)
==10359==    by 0x13DEBC: aeMain (ae.c:539)
==10359==    by 0x14D009: main (server.c:5349)

code base: 6.0.9
