### PR TITLE
Assert that clusterAddNode can't fail

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -963,6 +963,7 @@ void freeClusterNode(clusterNode *n) {
 /* Add a node to the nodes hash table */
 void clusterAddNode(clusterNode *node) {
     int retval;
+
     retval = dictAdd(server.cluster->nodes,
             sdsnewlen(node->name,CLUSTER_NAMELEN), node);
     serverAssert(retval == DICT_OK);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -962,11 +962,13 @@ void freeClusterNode(clusterNode *n) {
 
 /* Add a node to the nodes hash table */
 int clusterAddNode(clusterNode *node) {
-    int retval;
+    sds nodename = sdsnewlen(node->name,CLUSTER_NAMELEN);
+    if (dictAdd(server.cluster->nodes, nodename, node) == C_ERR) {
+        sdsfree(nodename);
+        return C_ERR;
+    }
 
-    retval = dictAdd(server.cluster->nodes,
-            sdsnewlen(node->name,CLUSTER_NAMELEN), node);
-    return (retval == DICT_OK) ? C_OK : C_ERR;
+    return C_OK;
 }
 
 /* Remove a node from the cluster. The function performs the high level

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -47,7 +47,7 @@
 clusterNode *myself = NULL;
 
 clusterNode *createClusterNode(char *nodename, int flags);
-int clusterAddNode(clusterNode *node);
+void clusterAddNode(clusterNode *node);
 void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void clusterReadHandler(connection *conn);
 void clusterSendPing(clusterLink *link, int type);
@@ -961,14 +961,11 @@ void freeClusterNode(clusterNode *n) {
 }
 
 /* Add a node to the nodes hash table */
-int clusterAddNode(clusterNode *node) {
-    sds nodename = sdsnewlen(node->name,CLUSTER_NAMELEN);
-    if (dictAdd(server.cluster->nodes, nodename, node) == DICT_ERR) {
-        sdsfree(nodename);
-        return C_ERR;
-    }
-
-    return C_OK;
+void clusterAddNode(clusterNode *node) {
+    int retval;
+    retval = dictAdd(server.cluster->nodes,
+            sdsnewlen(node->name,CLUSTER_NAMELEN), node);
+    serverAssert(retval == DICT_OK);
 }
 
 /* Remove a node from the cluster. The function performs the high level

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -963,7 +963,7 @@ void freeClusterNode(clusterNode *n) {
 /* Add a node to the nodes hash table */
 int clusterAddNode(clusterNode *node) {
     sds nodename = sdsnewlen(node->name,CLUSTER_NAMELEN);
-    if (dictAdd(server.cluster->nodes, nodename, node) == C_ERR) {
+    if (dictAdd(server.cluster->nodes, nodename, node) == DICT_ERR) {
         sdsfree(nodename);
         return C_ERR;
     }


### PR DESCRIPTION
I'm not sure this change is necessary since the clusterAddNode return value is unused anywhere.