### PR TITLE
Fix last COW INFO report, Skip test on non-linux platforms

### DIFF
--- a/src/childinfo.c
+++ b/src/childinfo.c
@@ -127,21 +127,9 @@ void receiveChildInfo(void) {
     int process_type;
     int on_exit;
     size_t cow_size;
-    if (readChildInfo(&process_type, &on_exit, &cow_size)) {
-        updateChildInfo(process_type, on_exit, cow_size);
-    }
-}
 
-/* Receive last COW data from child. */
-void receiveLastChildInfo(void) {
-    if (server.child_info_pipe[0] == -1) return;
-
-    /* Drain the pipe and update child info */
-    int process_type;
-    int on_exit;
-    size_t cow_size;
-
-    while (readChildInfo(&process_type, &on_exit, &cow_size) > 0) {
+    /* Drain the pipe and update child info so that we get the final message. */
+    while (readChildInfo(&process_type, &on_exit, &cow_size)) {
         updateChildInfo(process_type, on_exit, cow_size);
     }
 }

--- a/src/server.h
+++ b/src/server.h
@@ -2013,7 +2013,6 @@ void openChildInfoPipe(void);
 void closeChildInfoPipe(void);
 void sendChildInfo(int process_type, int on_exit, size_t cow_size);
 void receiveChildInfo(void);
-void receiveLastChildInfo(void);
 
 /* Fork helpers */
 int redisFork(int type);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -580,15 +580,18 @@ size_t zmalloc_get_smap_bytes_by_field(char *field, long pid) {
 size_t zmalloc_get_smap_bytes_by_field(char *field, long pid) {
 #if defined(__APPLE__)
     struct proc_regioninfo pri;
-    if (proc_pidinfo(pid, PROC_PIDREGIONINFO, 0, &pri, PROC_PIDREGIONINFO_SIZE) ==
-	PROC_PIDREGIONINFO_SIZE) {
-	if (!strcmp(field, "Private_Dirty:")) {
-            return (size_t)pri.pri_pages_dirtied * 4096;
-	} else if (!strcmp(field, "Rss:")) {
-            return (size_t)pri.pri_pages_resident * 4096;
-	} else if (!strcmp(field, "AnonHugePages:")) {
+    if (pid == -1) pid = getpid();
+    if (proc_pidinfo(pid, PROC_PIDREGIONINFO, 0, &pri,
+                     PROC_PIDREGIONINFO_SIZE) == PROC_PIDREGIONINFO_SIZE)
+    {
+        int pagesize = getpagesize();
+        if (!strcmp(field, "Private_Dirty:")) {
+            return (size_t)pri.pri_pages_dirtied * pagesize;
+        } else if (!strcmp(field, "Rss:")) {
+            return (size_t)pri.pri_pages_resident * pagesize;
+        } else if (!strcmp(field, "AnonHugePages:")) {
             return 0;
-	}
+        }
     }
     return 0;
 #endif


### PR DESCRIPTION
- the last COW report wasn't always read from the pipe
  (receiveLastChildInfo wasn't used)
- but in fact, there's no reason we won't always try to drain that pipe
  so i'm unifying receiveLastChildInfo with receiveChildInfo
- adjust threshold of the COW test when run in accurate mode
- add some prints in case this test fails again
- fix indentation, page size, and PID! in MacOS proc info

p.s. it seems that pri_pages_dirtied is always 0