### PR TITLE
Fix overflow of rdbWriteRaw return value

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -94,7 +94,7 @@ void rdbReportError(int corruption_error, int linenum, char *reason, ...) {
     exit(1);
 }
 
-static int rdbWriteRaw(rio *rdb, void *p, size_t len) {
+static ssize_t rdbWriteRaw(rio *rdb, void *p, size_t len) {
     if (rdb && rioWrite(rdb,p,len) == 0)
         return -1;
     return len;


### PR DESCRIPTION
Fixes #8299 

Just change the rdbWriteRaw return value type from `int` to `ssize_t`.

This function is called about 20 places. Most of caller's input parameter `len` is in the range of int, so this change will just act on the function `rdbSaveLzfBlob` and function `rdbSaveRawString` when a string(>2GB) need to be written to rdb.