### PR TITLE
Optimize zrangeGenericCommand to make it readable

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3004,7 +3004,8 @@ void genericZrangebyrankCommand(zrange_result_handler *handler,
             serverAssertWithInfo(c,zobj,eptr != NULL && sptr != NULL);
             serverAssertWithInfo(c,zobj,ziplistGet(eptr,&vstr,&vlen,&vlong));
 
-            if (handler->withscores || handler->store) /* don't bother to extract the score if it's gonna be ignored. */
+            /* don't bother to extract the score if it's gonna be ignored. */
+            if (handler->withscores || handler->store)
                 score = zzlGetScore(sptr);
 
             if (vstr == NULL) {
@@ -3400,7 +3401,8 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
 
         while (eptr && limit--) {
             double score = 0;
-            if (handler->withscores || handler->store) /* don't bother to extract the score if it's gonna be ignored. */
+            /* don't bother to extract the score if it's gonna be ignored. */
+            if (handler->withscores || handler->store)
                 score = zzlGetScore(sptr);
 
             /* Abort when the node is no longer in range. */

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2810,7 +2810,7 @@ typedef void (*zrangeResultEmitCBufferFunction)(
 typedef void (*zrangeResultEmitLongLongFunction)(
     zrange_result_handler *c, long long ll, double score);
 
-void zrangeGenericCommand (zrange_result_handler *handler, int argc_start,
+void zrangeGenericCommand(zrange_result_handler *handler, int argc_start,
                            zrange_type rangetype, zrange_direction direction);
 
 /* Interface struct for ZRANGE/ZRANGESTORE generic implementation.


### PR DESCRIPTION
1. zrange_result_handler add store variable, simplifies the use of zrangeGenericCommand method。
2. Delete the withscores parameter of the genericZrangebyrankCommand, genericZrangebyscoreCommand, and genericZrangebylexCommand methods to avoid confusion withscores and store.
3. Remove the space after zrangeGenericCommand  function.
