### PR TITLE
Fix cluster diskless load swapdb test

### DIFF
--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -57,6 +57,11 @@ proc CI {n field} {
     get_info_field [R $n cluster info] $field
 }
 
+# Return the value of the specified INFO field.
+proc s {n field} {
+    get_info_field [R $n info] $field
+}
+
 # Assuming nodes are reest, this function performs slots allocation.
 # Only the first 'n' nodes are used.
 proc cluster_allocate_slots {n} {

--- a/tests/cluster/tests/17-diskless-load-swapdb.tcl
+++ b/tests/cluster/tests/17-diskless-load-swapdb.tcl
@@ -22,6 +22,8 @@ test "Right to restore backups when fail to diskless load " {
 
     $replica READONLY
     $replica config set repl-diskless-load swapdb
+    $replica config set appendonly no
+    $replica config set save ""
     $replica config rewrite
     $master config set repl-backlog-size 1024
     $master config set repl-diskless-sync yes
@@ -38,7 +40,8 @@ test "Right to restore backups when fail to diskless load " {
     assert_equal {1} [$replica get $slot0_key]
     assert_equal $slot0_key [$replica CLUSTER GETKEYSINSLOT 0 1]
 
-    # Kill the replica
+    # Save an RDB and kill the replica
+    $replica save
     kill_instance redis $replica_id
 
     # Delete the key from master
@@ -60,13 +63,12 @@ test "Right to restore backups when fail to diskless load " {
     restart_instance redis $replica_id
     $replica READONLY
 
-    # Start full sync
+    # Start full sync, wait till after db is flushed (backed up)
     wait_for_condition 500 10 {
-        [string match "*sync*" [$replica role]]
+        [s $replica_id loading] eq 1
     } else {
         fail "Fail to full sync"
     }
-    after 100
 
     # Kill master, abort full sync
     kill_instance redis $master_id


### PR DESCRIPTION
The test was trying to wait for the replica to start loading the rdb
from the master before it kills the master, but it was actually waiting
for ROLE to be in "sync" mode, which corresponds to REPL_STATE_TRANSFER
that starts before the actual loading starts.
now instead it waits for the loading flag to be set.

Besides, the test was dependent on the previous configuration of the
servers, relying on the fact the replica is configured to persist
(either RDB of AOF), now it is set explicitly.