### PR TITLE
__quicklistCompress may compress more node than required

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -315,7 +315,7 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
         if (forward == node || reverse == node)
             in_depth = 1;
 
-        if (forward == reverse)
+        if (forward == reverse || forward->next == reverse)
             return;
 
         forward = forward->next;
@@ -325,11 +325,9 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
     if (!in_depth)
         quicklistCompressNode(node);
 
-    if (depth > 2 && quicklist->len > (unsigned int)(quicklist->compress * 2)) {
-        /* At this point, forward and reverse are one node beyond depth */
-        quicklistCompressNode(forward);
-        quicklistCompressNode(reverse);
-    }
+    /* At this point, forward and reverse are one node beyond depth */
+    quicklistCompressNode(forward);
+    quicklistCompressNode(reverse);
 }
 
 #define quicklistCompress(_ql, _node)                                          \

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -315,10 +315,8 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
         if (forward == node || reverse == node)
             in_depth = 1;
 
-        /* To make quicklist->len no matter odd or even exit early.
-         * If quicklist->len == quicklist->compress * 2, the old code will
-         * not exit here, so the middle two nodes will be compressed
-         * again. */
+        /* We passed into compress depth of opposite side of the quicklist
+         * so there's no need to compress anything and we can exit. */
         if (forward == reverse || forward->next == reverse)
             return;
 


### PR DESCRIPTION
When a quicklist has quicklist->compress * 2 nodes, then call
__quicklistCompress, all nodes will be decompressed and the middle
two nodes will be recompressed again. This violates the fact that
quicklist->compress * 2 nodes are uncompressed. It's harmless
because when visit a node, we always try to uncompress node first.
This only happened when a quicklist has quicklist->compress * 2 + 1
nodes, then delete a node. For other scenarios like insert node and
iterate this will not happen.