### PR TITLE
Fix units in log message of copy-on-write

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5533,7 +5533,7 @@ void sendChildCOWInfo(int ptype, int on_exit, char *pname) {
     if (private_dirty) {
         serverLog(on_exit ? LL_NOTICE : LL_VERBOSE,
             "%s: %zu MB of memory used by copy-on-write",
-            pname, private_dirty);
+            pname, private_dirty/(1024*1024));
     }
 
     sendChildInfo(ptype, on_exit, private_dirty);


### PR DESCRIPTION
ref [https://github.com/redis/redis/commit/ea930a352ca748c0fa49a1b2ee894ea92bc83b0e](https://github.com/redis/redis/commit/ea930a352ca748c0fa49a1b2ee894ea92bc83b0e)

output:
```shell
30450:C 13 Jan 2021 14:27:44.072 * RDB: 1052672 MB of memory used by copy-on-write
```

Feels like it was deleted by mistake.