### PR TITLE
GETEX, GETDEL and SET PXAT/EXAT

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -598,11 +598,8 @@ void feedAppendOnlyFile(struct redisCommand *cmd, int dictid, robj **argv, int a
         buf = catAppendOnlyExpireAtCommand(buf,cmd,argv[1],argv[2]);
     } else if (cmd->proc == setCommand && argc > 3) {
         robj *pxarg = NULL;
-        /* When SET is used with EX/PX argument we propagate them with PX millisecond argument. This is
-         * done so that replication will still use relative time as specified.
-         *
-         * We rely on the index being 3 for PX. Since this is propagated from SET.
-         * */
+        /* When SET is used with EX/PX argument setGenericCommand propagates them with PX millisecond argument.
+         * So since the command arguments are re-written there, we can rely here on the index of PX being 3. */
         if (!strcasecmp(argv[3]->ptr, "px")) {
             pxarg = argv[4];
         }

--- a/src/aof.c
+++ b/src/aof.c
@@ -581,8 +581,6 @@ sds catAppendOnlyExpireAtCommand(sds buf, struct redisCommand *cmd, robj *key, r
 
 void feedAppendOnlyFile(struct redisCommand *cmd, int dictid, robj **argv, int argc) {
     sds buf = sdsempty();
-    robj *tmpargv[3];
-
     /* The DB this command was targeting is not the same as the last command
      * we appended. To issue a SELECT command is needed. */
     if (dictid != server.aof_selected_db) {
@@ -598,35 +596,6 @@ void feedAppendOnlyFile(struct redisCommand *cmd, int dictid, robj **argv, int a
         cmd->proc == expireatCommand) {
         /* Translate EXPIRE/PEXPIRE/EXPIREAT into PEXPIREAT */
         buf = catAppendOnlyExpireAtCommand(buf,cmd,argv[1],argv[2]);
-    } else if (cmd->proc == setexCommand || cmd->proc == psetexCommand) {
-        /* Translate SETEX/PSETEX to SET and PEXPIREAT */
-        tmpargv[0] = createStringObject("SET",3);
-        tmpargv[1] = argv[1];
-        tmpargv[2] = argv[3];
-        buf = catAppendOnlyGenericCommand(buf,3,tmpargv);
-        decrRefCount(tmpargv[0]);
-        buf = catAppendOnlyExpireAtCommand(buf,cmd,argv[1],argv[2]);
-    } else if (cmd->proc == setCommand && argc > 3) {
-        int i;
-        robj *exarg = NULL, *pxarg = NULL;
-        for (i = 3; i < argc; i ++) {
-            if (!strcasecmp(argv[i]->ptr, "ex")) exarg = argv[i+1];
-            if (!strcasecmp(argv[i]->ptr, "px")) pxarg = argv[i+1];
-        }
-        serverAssert(!(exarg && pxarg));
-
-        if (exarg || pxarg) {
-            /* Translate SET [EX seconds][PX milliseconds] to SET and PEXPIREAT */
-            buf = catAppendOnlyGenericCommand(buf,3,argv);
-            if (exarg)
-                buf = catAppendOnlyExpireAtCommand(buf,server.expireCommand,argv[1],
-                                                   exarg);
-            if (pxarg)
-                buf = catAppendOnlyExpireAtCommand(buf,server.pexpireCommand,argv[1],
-                                                   pxarg);
-        } else {
-            buf = catAppendOnlyGenericCommand(buf,argc,argv);
-        }
     } else {
         /* All the other commands don't need translation or need the
          * same translation already operated in the command vector

--- a/src/server.c
+++ b/src/server.c
@@ -201,8 +201,8 @@ struct redisCommand redisCommandTable[] = {
      "read-only fast @string",
      0,NULL,1,1,1,0,0,0},
 
-    {"getex",getexCommand,-3,
-     "write use-memory @string",
+    {"getex",getexCommand,-2,
+     "write fast @string",
      0,NULL,1,1,1,0,0,0},
 
     /* Note that we can't flag set as fast, since it may perform an
@@ -2537,9 +2537,11 @@ void createSharedObjects(void) {
     shared.left = createStringObject("left",4);
     shared.right = createStringObject("right",5);
     shared.pexpireat = createStringObject("PEXPIREAT",9);
+    shared.pexpire = createStringObject("PEXPIRE",7);
     shared.persist = createStringObject("PERSIST",7);
     shared.set = createStringObject("SET",3);
     shared.pxat = createStringObject("PXAT", 4);
+    shared.px = createStringObject("PX",2);
     for (j = 0; j < OBJ_SHARED_INTEGERS; j++) {
         shared.integers[j] =
             makeObjectShared(createObject(OBJ_STRING,(void*)(long)j));

--- a/src/server.c
+++ b/src/server.c
@@ -201,6 +201,10 @@ struct redisCommand redisCommandTable[] = {
      "read-only fast @string",
      0,NULL,1,1,1,0,0,0},
 
+    {"getex",getexCommand,-3,
+     "write use-memory @string",
+     0,NULL,1,1,1,0,0,0},
+
     /* Note that we can't flag set as fast, since it may perform an
      * implicit DEL of a large key. */
     {"set",setCommand,-3,
@@ -2532,6 +2536,10 @@ void createSharedObjects(void) {
     /* Used in the LMOVE/BLMOVE commands */
     shared.left = createStringObject("left",4);
     shared.right = createStringObject("right",5);
+    shared.pexpireat = createStringObject("PEXPIREAT",9);
+    shared.persist = createStringObject("PERSIST",7);
+    shared.set = createStringObject("SET",3);
+    shared.pxat = createStringObject("PXAT", 4);
     for (j = 0; j < OBJ_SHARED_INTEGERS; j++) {
         shared.integers[j] =
             makeObjectShared(createObject(OBJ_STRING,(void*)(long)j));

--- a/src/server.c
+++ b/src/server.c
@@ -205,6 +205,10 @@ struct redisCommand redisCommandTable[] = {
      "write fast @string",
      0,NULL,1,1,1,0,0,0},
 
+    {"getdel",getdelCommand,2,
+     "write fast @string",
+     0,NULL,1,1,1,0,0,0},
+
     /* Note that we can't flag set as fast, since it may perform an
      * implicit DEL of a large key. */
     {"set",setCommand,-3,

--- a/src/server.h
+++ b/src/server.h
@@ -951,7 +951,8 @@ struct sharedObjectsStruct {
     *busykeyerr, *oomerr, *plus, *messagebulk, *pmessagebulk, *subscribebulk,
     *unsubscribebulk, *psubscribebulk, *punsubscribebulk, *del, *unlink,
     *rpop, *lpop, *lpush, *rpoplpush, *lmove, *blmove, *zpopmin, *zpopmax,
-    *emptyscan, *multi, *exec, *left, *right, *persist, *set, *pexpireat, *pxat,
+    *emptyscan, *multi, *exec, *left, *right, *persist, *set, *pexpireat,
+    *pexpire, *pxat, *px,
     *select[PROTO_SHARED_SELECT_CMDS],
     *integers[OBJ_SHARED_INTEGERS],
     *mbulkhdr[OBJ_SHARED_BULKHDR_LEN], /* "*<value>\r\n" */

--- a/src/server.h
+++ b/src/server.h
@@ -2407,6 +2407,7 @@ void setexCommand(client *c);
 void psetexCommand(client *c);
 void getCommand(client *c);
 void getexCommand(client *c);
+void getdelCommand(client *c);
 void delCommand(client *c);
 void unlinkCommand(client *c);
 void existsCommand(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -951,7 +951,7 @@ struct sharedObjectsStruct {
     *busykeyerr, *oomerr, *plus, *messagebulk, *pmessagebulk, *subscribebulk,
     *unsubscribebulk, *psubscribebulk, *punsubscribebulk, *del, *unlink,
     *rpop, *lpop, *lpush, *rpoplpush, *lmove, *blmove, *zpopmin, *zpopmax,
-    *emptyscan, *multi, *exec, *left, *right,
+    *emptyscan, *multi, *exec, *left, *right, *persist, *set, *pexpireat, *pxat,
     *select[PROTO_SHARED_SELECT_CMDS],
     *integers[OBJ_SHARED_INTEGERS],
     *mbulkhdr[OBJ_SHARED_BULKHDR_LEN], /* "*<value>\r\n" */
@@ -2405,6 +2405,7 @@ void setnxCommand(client *c);
 void setexCommand(client *c);
 void psetexCommand(client *c);
 void getCommand(client *c);
+void getexCommand(client *c);
 void delCommand(client *c);
 void unlinkCommand(client *c);
 void existsCommand(client *c);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -109,8 +109,7 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
         } else {
             setExpire(c,c->db,key,milliseconds);
         }
-        notifyKeyspaceEvent(NOTIFY_GENERIC,
-                            "expire", key, c->db->id);
+        notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);
 
         /* Propagate as SET Key Value PXAT millisecond-timestamp if there is EXAT/PXAT or
          * propagate as SET Key Value PX millisecond if there is EX/PX flag.
@@ -303,81 +302,6 @@ int getGenericCommand(client *c) {
     return C_OK;
 }
 
-int getexGenericCommand(client *c, int flags, robj *expire, int unit) {
-    robj *o;
-
-    if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp])) == NULL)
-        return C_OK;
-
-    if (checkType(c,o,OBJ_STRING)) {
-        return C_ERR;
-    }
-
-    long long milliseconds = 0;
-
-    /* Validate the expiration time value first */
-    if (expire) {
-        if (getLongLongFromObjectOrReply(c, expire, &milliseconds, NULL) != C_OK)
-            return C_ERR;
-        if (milliseconds <= 0) {
-            addReplyErrorFormat(c,"invalid expire time in %s",c->cmd->name);
-            return C_ERR;
-        }
-        if (unit == UNIT_SECONDS) milliseconds *= 1000;
-    }
-
-    /* We need to do this before we expire the key or delete it */
-    addReplyBulk(c,o);
-
-    /* When PXAT/EXAT absolute timestamp is specified, there can be a chance that timestamp
-     * has already elapsed so delete the key in that case. */
-    if ((flags & OBJ_PXAT) || (flags & OBJ_EXAT)) {
-        if (checkAlreadyExpired(milliseconds)) {
-            flags = OBJ_DEL;
-        }
-    }
-
-    /* This command is never propagated as is. It is either propagated as PEXPIRE[AT], DEL, or PERSIST.
-     * This why it doesn't need special handling in feedAppendOnlyFile to convert relative expire time to absolute one. */
-    if (flags & OBJ_DEL) {
-        int deleted = server.lazyfree_lazy_user_del ? dbAsyncDelete(c->db, c->argv[1]) :
-                      dbSyncDelete(c->db, c->argv[1]);
-        serverAssert(deleted);
-
-        rewriteClientCommandVector(c, 2, shared.del, c->argv[1]);
-        signalModifiedKey(c, c->db, c->argv[1]);
-        notifyKeyspaceEvent(NOTIFY_GENERIC,
-                            "del", c->argv[1], c->db->id);
-        server.dirty++;
-    } else if (expire) {
-        robj *exp = shared.pexpireat;
-        if ((flags & OBJ_PX) || (flags & OBJ_EX)) {
-            setExpire(c,c->db,c->argv[1],milliseconds + mstime());
-            exp = shared.pexpire;
-        } else {
-            setExpire(c,c->db,c->argv[1],milliseconds);
-        }
-
-        robj* millisecondObj = createStringObjectFromLongLong(milliseconds);
-        rewriteClientCommandVector(c,3,exp,c->argv[1],millisecondObj);
-        decrRefCount(millisecondObj);
-        signalModifiedKey(c, c->db, c->argv[1]);
-        notifyKeyspaceEvent(NOTIFY_GENERIC,
-                            "expire", c->argv[1], c->db->id);
-        server.dirty++;
-    } else if (flags & OBJ_PERSIST) {
-        if (removeExpire(c->db, c->argv[1])) {
-            signalModifiedKey(c, c->db, c->argv[1]);
-            rewriteClientCommandVector(c, 2, shared.persist, c->argv[1]);
-            notifyKeyspaceEvent(NOTIFY_GENERIC,
-                                "persist", c->argv[1], c->db->id);
-            server.dirty++;
-        }
-    }
-
-    return C_OK;
-}
-
 void getCommand(client *c) {
     getGenericCommand(c);
 }
@@ -413,7 +337,73 @@ void getexCommand(client *c) {
         return;
     }
 
-    getexGenericCommand(c,flags,expire,unit);
+    robj *o;
+
+    if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp])) == NULL)
+        return;
+
+    if (checkType(c,o,OBJ_STRING)) {
+        return;
+    }
+
+    long long milliseconds = 0;
+
+    /* Validate the expiration time value first */
+    if (expire) {
+        if (getLongLongFromObjectOrReply(c, expire, &milliseconds, NULL) != C_OK)
+            return;
+        if (milliseconds <= 0) {
+            addReplyErrorFormat(c,"invalid expire time in %s",c->cmd->name);
+            return;
+        }
+        if (unit == UNIT_SECONDS) milliseconds *= 1000;
+    }
+
+    /* We need to do this before we expire the key or delete it */
+    addReplyBulk(c,o);
+
+    /* When PXAT/EXAT absolute timestamp is specified, there can be a chance that timestamp
+     * has already elapsed so delete the key in that case. */
+    if ((flags & OBJ_PXAT) || (flags & OBJ_EXAT)) {
+        if (checkAlreadyExpired(milliseconds)) {
+            flags = OBJ_DEL;
+        }
+    }
+
+    /* This command is never propagated as is. It is either propagated as PEXPIRE[AT], DEL, or PERSIST.
+     * This why it doesn't need special handling in feedAppendOnlyFile to convert relative expire time to absolute one. */
+    if (flags & OBJ_DEL) {
+        int deleted = server.lazyfree_lazy_user_del ? dbAsyncDelete(c->db, c->argv[1]) :
+                      dbSyncDelete(c->db, c->argv[1]);
+        serverAssert(deleted);
+
+        rewriteClientCommandVector(c, 2, shared.del, c->argv[1]);
+        signalModifiedKey(c, c->db, c->argv[1]);
+        notifyKeyspaceEvent(NOTIFY_GENERIC,"del",c->argv[1],c->db->id);
+        server.dirty++;
+    } else if (expire) {
+        robj *exp = shared.pexpireat;
+        if ((flags & OBJ_PX) || (flags & OBJ_EX)) {
+            setExpire(c,c->db,c->argv[1],milliseconds + mstime());
+            exp = shared.pexpire;
+        } else {
+            setExpire(c,c->db,c->argv[1],milliseconds);
+        }
+
+        robj* millisecondObj = createStringObjectFromLongLong(milliseconds);
+        rewriteClientCommandVector(c,3,exp,c->argv[1],millisecondObj);
+        decrRefCount(millisecondObj);
+        signalModifiedKey(c, c->db, c->argv[1]);
+        notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",c->argv[1],c->db->id);
+        server.dirty++;
+    } else if (flags & OBJ_PERSIST) {
+        if (removeExpire(c->db, c->argv[1])) {
+            signalModifiedKey(c, c->db, c->argv[1]);
+            rewriteClientCommandVector(c, 2, shared.persist, c->argv[1]);
+            notifyKeyspaceEvent(NOTIFY_GENERIC,"persist",c->argv[1],c->db->id);
+            server.dirty++;
+        }
+    }
 }
 
 void getsetCommand(client *c) {

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -394,8 +394,9 @@ void getdelCommand(client *c) {
     int deleted = server.lazyfree_lazy_user_del ? dbAsyncDelete(c->db, c->argv[1]) :
                   dbSyncDelete(c->db, c->argv[1]);
     if (deleted) {
-        /* Propagate as DEL command */
-        rewriteClientCommandVector(c, 2, shared.del, c->argv[1]);
+        /* Propagate as DEL/UNLINK command */
+        robj *aux = server.lazyfree_lazy_user_del ? shared.unlink : shared.del;
+        rewriteClientCommandVector(c,2,aux,c->argv[1]);
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
         server.dirty++;

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -272,4 +272,15 @@ tags {"aof"} {
             }
         }
     }
+
+    start_server {overrides {appendonly {yes} appendfilename {appendonly.aof}}} {
+        test {GETEX should not append to AOF} {
+            set aof [file join [lindex [r config get dir] 1] appendonly.aof]
+            r set foo bar
+            set before [file size $aof]
+            r getex foo
+            set after [file size $aof]
+            assert_equal $before $after
+        }
+    }
 }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -209,7 +209,7 @@ start_server {tags {"expire"}} {
         set e
     } {*not an integer*}
 
-    test {EXPIRE and SET EX/PX option, TTL should not be reset after loadaof} {
+    test {EXPIRE and SET/GETEX EX/PX/EXAT/PXAT option, TTL should not be reset after loadaof} {
         # This test makes sure that expire times are propagated as absolute
         # times to the AOF file and not as relative time, so that when the AOF
         # is reloaded the TTLs are not being shifted forward to the future.
@@ -224,6 +224,17 @@ start_server {tags {"expire"}} {
         r pexpire foo4 100000
         r setex foo5 100 bar
         r psetex foo6 100000 bar
+        r set foo7 bar EXAT [expr [clock seconds] + 100]
+        r set foo8 bar PXAT [expr [clock milliseconds] + 100000]
+        r set foo9 bar
+        r getex foo9 EX 100
+        r set foo10 bar
+        r getex foo10 PX 100000
+        r set foo11 bar
+        r getex foo11 EXAT [expr [clock seconds] + 100]
+        r set foo12 bar
+        r getex foo12 PXAT [expr [clock milliseconds] + 100000]
+
         after 2000
         r debug loadaof
         assert_range [r ttl foo1] 90 98
@@ -232,6 +243,12 @@ start_server {tags {"expire"}} {
         assert_range [r ttl foo4] 90 98
         assert_range [r ttl foo5] 90 98
         assert_range [r ttl foo6] 90 98
+        assert_range [r ttl foo7] 90 98
+        assert_range [r ttl foo8] 90 98
+        assert_range [r ttl foo9] 90 98
+        assert_range [r ttl foo10] 90 98
+        assert_range [r ttl foo11] 90 98
+        assert_range [r ttl foo12] 90 98
     }
 
     test {EXPIRE relative and absolute propagation to replicas} {
@@ -248,8 +265,10 @@ start_server {tags {"expire"}} {
         # https://github.com/redis/redis/pull/5171#issuecomment-409553266
 
         set repl [attach_to_replication_stream]
-        r set foo1 bar ex 100
+        r set foo1 bar ex 200
         r set foo1 bar px 100000
+        r set foo1 bar exat [expr [clock seconds]+100]
+        r set foo1 bar pxat [expr [clock milliseconds]+10000]
         r setex foo1 100 bar
         r psetex foo1 100000 bar
         r set foo2 bar
@@ -259,12 +278,19 @@ start_server {tags {"expire"}} {
         r expireat foo3 [expr [clock seconds]+100]
         r pexpireat foo3 [expr [clock seconds]*1000+100000]
         r expireat foo3 [expr [clock seconds]-100]
+        r set foo4 bar
+        r getex foo4 ex 200
+        r getex foo4 px 200000
+        r getex foo4 exat [expr [clock seconds]+100]
+        r getex foo4 pxat [expr [clock milliseconds]+10000]
         assert_replication_stream $repl {
             {select *}
-            {set foo1 bar ex 100}
-            {set foo1 bar px 100000}
-            {setex foo1 100 bar}
-            {psetex foo1 100000 bar}
+            {set foo1 bar PX 200000}
+            {set foo1 bar PX 100000}
+            {set foo1 bar PXAT *}
+            {set foo1 bar PXAT *}
+            {set foo1 bar PX 100000}
+            {set foo1 bar PX 100000}
             {set foo2 bar}
             {expire foo2 100}
             {pexpire foo2 100000}
@@ -272,6 +298,11 @@ start_server {tags {"expire"}} {
             {expireat foo3 *}
             {pexpireat foo3 *}
             {del foo3}
+            {set foo4 bar}
+            {pexpire foo4 200000}
+            {pexpire foo4 200000}
+            {pexpireat foo4 *}
+            {pexpireat foo4 *}
         }
     }
 
@@ -296,5 +327,30 @@ start_server {tags {"expire"}} {
         r debug loadaof
         set ttl [r ttl foo]
         assert {$ttl <= 98 && $ttl > 90}
+    }
+
+    test {GETEX use of PERSIST option should remove TTL} {
+       r set foo bar EX 100
+       r getex foo PERSIST
+       r ttl foo
+    } {-1}
+
+    test {GETEX use of PERSIST option should remove TTL after loadaof} {
+       r set foo bar EX 100
+       r getex foo PERSIST
+       after 2000
+       r debug loadaof
+       r ttl foo
+    } {-1}
+
+    test {GETEX use of PERSIST option propagate as PERSIST command to replica} {
+       set repl [attach_to_replication_stream]
+       r set foo bar EX 100
+       r getex foo PERSIST
+       assert_replication_stream $repl {
+           {select *}
+           {set foo bar PX 100000}
+           {persist foo}
+        }
     }
 }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -343,14 +343,17 @@ start_server {tags {"expire"}} {
        r ttl foo
     } {-1}
 
-    test {GETEX use of PERSIST option propagate as PERSIST command to replica} {
+    test {GETEX propagate as to replica as PERSIST, DEL, or nothing} {
        set repl [attach_to_replication_stream]
        r set foo bar EX 100
        r getex foo PERSIST
+       r getex foo
+       r getex foo exat [expr [clock seconds]-100]
        assert_replication_stream $repl {
            {select *}
            {set foo bar PX 100000}
            {persist foo}
+           {del foo}
         }
     }
 }

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -163,14 +163,6 @@ start_server {tags {"string"}} {
         assert_equal bar [r getdel foo ]
         assert_equal {} [r getdel foo ]
     }
-    test {GETDEL should delete after loadaof} {
-        r config set appendonly yes
-        r set foo bar EX 100
-        r getdel foo
-        after 2000
-        r debug loadaof
-        r getex foo
-    } {}
 
     test {GETDEL propagate as DEL command to replica} {
         set repl [attach_to_replication_stream]

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -130,13 +130,6 @@ start_server {tags {"string"}} {
         assert_range [r pttl foo] 5000 10000
     }
 
-    test "GETEX DEL option" {
-        r del foo
-        r set foo bar
-        assert_equal bar [r getex foo del]
-        assert_equal {} [r getex foo del]
-    }
-
     test "GETEX PERSIST option" {
         r del foo
         r set foo bar ex 10
@@ -164,19 +157,25 @@ start_server {tags {"string"}} {
          set ex
      } {*wrong number of arguments*}
 
-    test {GETEX use of DEL option should delete after loadaof} {
+    test "GETDEL command" {
+        r del foo
+        r set foo bar
+        assert_equal bar [r getdel foo ]
+        assert_equal {} [r getdel foo ]
+    }
+    test {GETDEL should delete after loadaof} {
         r config set appendonly yes
         r set foo bar EX 100
-        r getex foo DEL
+        r getdel foo
         after 2000
         r debug loadaof
         r getex foo
     } {}
 
-    test {GETEX use of DEL option propagate as DEL command to replica} {
+    test {GETDEL propagate as DEL command to replica} {
         set repl [attach_to_replication_stream]
         r set foo bar
-        r getex foo DEL
+        r getdel foo
         assert_replication_stream $repl {
             {select *}
             {set foo bar}

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -106,32 +106,28 @@ start_server {tags {"string"}} {
         r del foo
         r set foo bar
         r getex foo ex 10
-        set ttl [r ttl foo]
-        assert {$ttl <= 10 && $ttl > 5}
+        assert_range [r ttl foo] 5 10
     }
 
     test "GETEX PX option" {
         r del foo
         r set foo bar
         r getex foo px 10000
-        set pttl [r pttl foo]
-        assert {$pttl <= 10000 && $pttl > 5000}
+        assert_range [r pttl foo] 5000 10000
     }
 
     test "GETEX EXAT option" {
         r del foo
         r set foo bar
         r getex foo exat [expr [clock seconds] + 10]
-        set ttl [r ttl foo]
-        assert {$ttl <= 10 && $ttl > 5}
+        assert_range [r ttl foo] 5 10
     }
 
     test "GETEX PXAT option" {
         r del foo
         r set foo bar
         r getex foo pxat [expr [clock milliseconds] + 10000]
-        set pttl [r pttl foo]
-        assert {$pttl <= 10000 && $pttl > 5000}
+        assert_range [r pttl foo] 5000 10000
     }
 
     test "GETEX DEL option" {
@@ -144,30 +140,27 @@ start_server {tags {"string"}} {
     test "GETEX PERSIST option" {
         r del foo
         r set foo bar ex 10
-        set ttl [r ttl foo]
-        assert {$ttl <= 10 && $ttl > 5}
+        assert_range [r ttl foo] 5 10
         r getex foo persist
         assert_equal -1 [r ttl foo]
     }
 
-    test "GETEX KEEPTTL option" {
+    test "GETEX no option" {
         r del foo
-        r set foo bar ex 10
-        set ttl [r ttl foo]
-        assert {$ttl <= 10 && $ttl > 5}
-        r getex foo keepttl
-        assert {$ttl <= 10 && $ttl > 5}
+        r set foo bar
+        r getex foo
+        assert_equal bar [r getex foo]
     }
 
     test "GETEX syntax errors" {
         set ex {}
-        catch {r getex foo non-existant-option} ex
+        catch {r getex foo non-existent-option} ex
         set ex
     } {*syntax*}
 
-    test "GETEX no optional argument" {
+    test "GETEX no arguments" {
          set ex {}
-         catch {r getex foo} ex
+         catch {r getex} ex
          set ex
      } {*wrong number of arguments*}
 
@@ -509,15 +502,13 @@ start_server {tags {"string"}} {
     test "Extended SET EXAT option" {
         r del foo
         r set foo bar exat [expr [clock seconds] + 10]
-        set ttl [r ttl foo]
-        assert {$ttl <= 10 && $ttl > 5}
+        assert_range [r ttl foo] 5 10
     }
 
     test "Extended SET PXAT option" {
         r del foo
         r set foo bar pxat [expr [clock milliseconds] + 10000]
-        set ttl [r ttl foo]
-        assert {$ttl <= 10 && $ttl > 5}
+        assert_range [r ttl foo] 5 10
     }
     test {Extended SET using multiple options at once} {
         r set foo val

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -102,6 +102,75 @@ start_server {tags {"string"}} {
         assert_equal 20 [r get x]
     }
 
+    test "GETEX EX option" {
+        r del foo
+        r set foo bar
+        r getex foo ex 10
+        set ttl [r ttl foo]
+        assert {$ttl <= 10 && $ttl > 5}
+    }
+
+    test "GETEX PX option" {
+        r del foo
+        r set foo bar
+        r getex foo px 10000
+        set pttl [r pttl foo]
+        assert {$pttl <= 10000 && $pttl > 5000}
+    }
+
+    test "GETEX EXAT option" {
+        r del foo
+        r set foo bar
+        r getex foo exat [expr [clock seconds] + 10]
+        set ttl [r ttl foo]
+        assert {$ttl <= 10 && $ttl > 5}
+    }
+
+    test "GETEX PXAT option" {
+        r del foo
+        r set foo bar
+        r getex foo pxat [expr [clock milliseconds] + 10000]
+        set pttl [r pttl foo]
+        assert {$pttl <= 10000 && $pttl > 5000}
+    }
+
+    test "GETEX DEL option" {
+        r del foo
+        r set foo bar
+        assert_equal bar [r getex foo del]
+        assert_equal {} [r getex foo del]
+    }
+
+    test "GETEX PERSIST option" {
+        r del foo
+        r set foo bar ex 10
+        set ttl [r ttl foo]
+        assert {$ttl <= 10 && $ttl > 5}
+        r getex foo persist
+        assert_equal -1 [r ttl foo]
+    }
+
+    test "GETEX KEEPTTL option" {
+        r del foo
+        r set foo bar ex 10
+        set ttl [r ttl foo]
+        assert {$ttl <= 10 && $ttl > 5}
+        r getex foo keepttl
+        assert {$ttl <= 10 && $ttl > 5}
+    }
+
+    test "GETEX syntax errors" {
+        set ex {}
+        catch {r getex foo non-existant-option} ex
+        set ex
+    } {*syntax*}
+
+    test "GETEX no optional argument" {
+         set ex {}
+         catch {r getex foo} ex
+         set ex
+     } {*wrong number of arguments*}
+
     test {MGET} {
         r flushdb
         r set foo BAR
@@ -437,6 +506,19 @@ start_server {tags {"string"}} {
         assert {$ttl <= 10 && $ttl > 5}
     }
 
+    test "Extended SET EXAT option" {
+        r del foo
+        r set foo bar exat [expr [clock seconds] + 10]
+        set ttl [r ttl foo]
+        assert {$ttl <= 10 && $ttl > 5}
+    }
+
+    test "Extended SET PXAT option" {
+        r del foo
+        r set foo bar pxat [expr [clock milliseconds] + 10000]
+        set ttl [r ttl foo]
+        assert {$ttl <= 10 && $ttl > 5}
+    }
     test {Extended SET using multiple options at once} {
         r set foo val
         assert {[r set foo bar xx px 10000] eq {OK}}


### PR DESCRIPTION
This commit introduces two new command and two options for an existing command

```
GETEX <key> [PERSIST][EX seconds][PX milliseconds] [EXAT seconds-timestamp][PXAT milliseconds-timestamp]
```
The getexCommand() function implements extended options and variants of the GET command. Unlike GET command this command is not read-only. Only one of the options can be used at a given time.

1. PERSIST removes any TTL associated with the key.
2. EX Set expiry TTL in seconds.
3. PX Set expiry TTL in milliseconds.
4. EXAT Same like EX instead of specifying the number of seconds representing the TTL (time to live), it takes an absolute Unix timestamp
5. PXAT Same like PX instead of specifying the number of milliseconds representing the TTL (time to live), it takes an absolute Unix timestamp

Command would return either the bulk string, error or nil.

```
GETDEL <key>
```
Would delete the key after getting.

```
SET key value [NX] [XX] [KEEPTTL] [GET] [EX <seconds>] [PX <milliseconds>] [EXAT <seconds-timestamp>][PXAT <milliseconds-timestamp>]
```

Two new options added here are EXAT and PXAT

Key implementation notes

- `SET` with `PX/EX/EXAT/PXAT` is always translated to `PXAT` in `AOF`. When relative time is specified (`PX/EX`), replication will always use `PX`.
- `setexCommand` and `psetexCommand` would no longer need translation in `feedAppendOnlyFile` as they are modified to invoke `setGenericCommand ` with appropriate flags which will take care of correct AOF translation.
- `GETEX` without any optional argument behaves like `GET`.
- `GETEX` command is never propagated, It is either propagated as `PEXPIRE[AT], or PERSIST`.
- `GETDEL` command is propagated as `DEL`
- Combined the validation for `SET` and `GETEX` arguments. 
- Test cases to validate AOF/Replication propagation

Issue - https://github.com/redis/redis/issues/2762