### PR TITLE
[Sentinel] more specific config errors for duplicate known-replica and known-sentinel

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1643,14 +1643,23 @@ char *sentinelInstanceMapCommand(sentinelRedisInstance *ri, char *command) {
 
 /* ============================ Config handling ============================= */
 
-/* generalise handling create instance error. role == 0 for master, role == 1 for
-   slave, role == 2 for sentinel */
+/* Generalise handling create instance error. Use SRI_MASTER, SRI_SLAVE or
+ * SRI_SENTINEL as a role value. */
 char *sentinelCheckCreateInstanceErrors(int role) {
     switch(errno) {
     case EBUSY:
-        if (role == 0) return "Duplicated master name.";
-        else if (role == 1) return "duplicated hostname and port for replica.";
-        else return "duplicated runid for sentinel.";
+        switch (role) {
+        case SRI_MASTER:
+            return "Duplicate master name.";
+        case SRI_SLAVE:
+            return "Duplicate hostname and port for replica.";
+        case SRI_SENTINEL:
+            return "Duplicate runid for sentinel.";
+        default:
+            serverAssert(0);
+            break;
+        }
+        break;
     case ENOENT:
         return "Can't resolve instance hostname.";
     case EINVAL:
@@ -1671,7 +1680,7 @@ char *sentinelHandleConfiguration(char **argv, int argc) {
         if (createSentinelRedisInstance(argv[1],SRI_MASTER,argv[2],
                                         atoi(argv[3]),quorum,NULL) == NULL)
         {
-            return sentinelCheckCreateInstanceErrors(0);
+            return sentinelCheckCreateInstanceErrors(SRI_MASTER);
         }
     } else if (!strcasecmp(argv[0],"down-after-milliseconds") && argc == 3) {
         /* down-after-milliseconds <name> <milliseconds> */
@@ -1753,7 +1762,7 @@ char *sentinelHandleConfiguration(char **argv, int argc) {
         if ((slave = createSentinelRedisInstance(NULL,SRI_SLAVE,argv[2],
                     atoi(argv[3]), ri->quorum, ri)) == NULL)
         {
-            return sentinelCheckCreateInstanceErrors(1);
+            return sentinelCheckCreateInstanceErrors(SRI_SLAVE);
         }
     } else if (!strcasecmp(argv[0],"known-sentinel") &&
                (argc == 4 || argc == 5)) {
@@ -1766,7 +1775,7 @@ char *sentinelHandleConfiguration(char **argv, int argc) {
             if ((si = createSentinelRedisInstance(argv[4],SRI_SENTINEL,argv[2],
                         atoi(argv[3]), ri->quorum, ri)) == NULL)
             {
-                return sentinelCheckCreateInstanceErrors(2);
+                return sentinelCheckCreateInstanceErrors(SRI_SENTINEL);
             }
             si->runid = sdsnew(argv[4]);
             sentinelTryConnectionSharing(si);


### PR DESCRIPTION
This is a follow up PR from https://github.com/redis/redis/issues/8313

Before this commit, like the linked issue, the config error `Wrong hostname or port for replica.` may bring some confusion to users if they configed duplicate known-replica or known-sentinel entry.. This commit providing a more specific error case when duplicate to avoid this confusion.