### PR TITLE
in cluster mode, there is a risk of double free memory

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -910,9 +910,10 @@ typedef struct rdbSaveInfo {
     int repl_id_is_set;  /* True if repl_id field is set. */
     char repl_id[CONFIG_RUN_ID_SIZE+1];     /* Replication ID. */
     long long repl_offset;                  /* Replication offset. */
+    int repl_load;       /* Distinguish wether load rdb for replicate */
 } rdbSaveInfo;
 
-#define RDB_SAVE_INFO_INIT {-1,0,"000000000000000000000000000000",-1}
+#define RDB_SAVE_INFO_INIT {-1,0,"000000000000000000000000000000",-1, 0}
 
 struct malloc_stats {
     size_t zmalloc_used;


### PR DESCRIPTION
We are tencent cloud redis team, we found that there was a risk of double free memory in redis clustere mode, cause redis server crash.