### PR TITLE
Fix description of the save conf directive

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -326,29 +326,25 @@ databases 16
 always-show-logo no
 
 ################################ SNAPSHOTTING  ################################
-#
-# Save the DB on disk:
-#
-#   save <seconds> <changes>
-#
-#   Will save the DB if both the given number of seconds and the given
-#   number of write operations against the DB occurred.
-#
-#   In the example below the behavior will be to save:
-#   after 900 sec (15 min) if at least 1 key changed
-#   after 300 sec (5 min) if at least 10 keys changed
-#   after 60 sec if at least 10000 keys changed
-#
-#   Note: you can disable saving completely by commenting out all "save" lines.
-#
-#   It is also possible to remove all the previously configured save
-#   points by adding a save directive with a single empty string argument
-#   like in the following example:
-#
-#   save ""
 
-save 900 1
-save 300 10
+# Save the DB to disk.
+#
+# save <seconds> <changes>
+#
+# Redis will save the DB if both the given number of seconds and the given
+# number of write operations against the DB occurred.
+#
+# Snapshotting can be completely disabled with a single empty string argument
+# as in following example:
+#
+# save ""
+#
+# Unless specified otherwise, by default Redis will save the DB:
+# after 3600 seconds (an hour) if at least 1 key changed
+# after 300 seconds (5 minutes) if at least 10 keys changed
+# after 60 seconds if at least 10000 keys changed
+save 3600 1
+save 300 100
 save 60 10000
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled

--- a/redis.conf
+++ b/redis.conf
@@ -340,12 +340,15 @@ always-show-logo no
 # save ""
 #
 # Unless specified otherwise, by default Redis will save the DB:
-# after 3600 seconds (an hour) if at least 1 key changed
-# after 300 seconds (5 minutes) if at least 10 keys changed
-# after 60 seconds if at least 10000 keys changed
-save 3600 1
-save 300 100
-save 60 10000
+#   * After 3600 seconds (an hour) if at least 1 key changed
+#   * After 300 seconds (5 minutes) if at least 10 keys changed
+#   * After 60 seconds if at least 10000 keys changed
+#
+# You can set these explicitly by uncommenting the three following lines.
+#
+# save 3600 1
+# save 300 100
+# save 60 10000
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.


### PR DESCRIPTION
The line that said:

> Note: you can disable saving completely by commenting out all "save" lines

was incorrect.

Also, note that the `save` values used in the default redis.conf file are different than the server's defaults, so this PR also addresses this and introduces a potential behavior change for some users.

Fixes #8318 