### PR TITLE
Optimize return type of listAddNodeHead, listAddNodeTail, listInsertNode

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -85,7 +85,7 @@ void listRelease(list *list)
  *
  * On error, NULL is returned and no operation is performed (i.e. the
  * list remains unaltered).
- * On success the 'list' pointer you pass to the function is returned. */
+ * On success the node pointer which added is returned. */
 listNode *listAddNodeHead(list *list, void *value)
 {
     listNode *node;
@@ -111,7 +111,7 @@ listNode *listAddNodeHead(list *list, void *value)
  *
  * On error, NULL is returned and no operation is performed (i.e. the
  * list remains unaltered).
- * On success the 'list' pointer you pass to the function is returned. */
+ * On success the node pointer which added is returned. */
 listNode *listAddNodeTail(list *list, void *value)
 {
     listNode *node;

--- a/src/adlist.c
+++ b/src/adlist.c
@@ -86,7 +86,7 @@ void listRelease(list *list)
  * On error, NULL is returned and no operation is performed (i.e. the
  * list remains unaltered).
  * On success the 'list' pointer you pass to the function is returned. */
-list *listAddNodeHead(list *list, void *value)
+listNode *listAddNodeHead(list *list, void *value)
 {
     listNode *node;
 
@@ -103,7 +103,7 @@ list *listAddNodeHead(list *list, void *value)
         list->head = node;
     }
     list->len++;
-    return list;
+    return node;
 }
 
 /* Add a new node to the list, to tail, containing the specified 'value'
@@ -112,7 +112,7 @@ list *listAddNodeHead(list *list, void *value)
  * On error, NULL is returned and no operation is performed (i.e. the
  * list remains unaltered).
  * On success the 'list' pointer you pass to the function is returned. */
-list *listAddNodeTail(list *list, void *value)
+listNode *listAddNodeTail(list *list, void *value)
 {
     listNode *node;
 
@@ -129,10 +129,10 @@ list *listAddNodeTail(list *list, void *value)
         list->tail = node;
     }
     list->len++;
-    return list;
+    return node;
 }
 
-list *listInsertNode(list *list, listNode *old_node, void *value, int after) {
+listNode *listInsertNode(list *list, listNode *old_node, void *value, int after) {
     listNode *node;
 
     if ((node = zmalloc(sizeof(*node))) == NULL)
@@ -158,7 +158,7 @@ list *listInsertNode(list *list, listNode *old_node, void *value, int after) {
         node->next->prev = node;
     }
     list->len++;
-    return list;
+    return node;
 }
 
 /* Remove the specified node from the specified list.

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -73,9 +73,9 @@ typedef struct list {
 list *listCreate(void);
 void listRelease(list *list);
 void listEmpty(list *list);
-list *listAddNodeHead(list *list, void *value);
-list *listAddNodeTail(list *list, void *value);
-list *listInsertNode(list *list, listNode *old_node, void *value, int after);
+listNode *listAddNodeHead(list *list, void *value);
+listNode *listAddNodeTail(list *list, void *value);
+listNode *listInsertNode(list *list, listNode *old_node, void *value, int after);
 void listDelNode(list *list, listNode *node);
 listIter *listGetIterator(list *list, int direction);
 listNode *listNext(listIter *iter);

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -90,8 +90,7 @@ void blockClient(client *c, int btype) {
     server.blocked_clients_by_type[btype]++;
     addClientToTimeoutTable(c);
     if (btype == BLOCKED_PAUSE) {
-        listAddNodeTail(server.paused_clients, c);
-        c->paused_list_node = listLast(server.paused_clients);
+        c->paused_list_node = listAddNodeTail(server.paused_clients, c);
         /* Mark this client to execute its command */
         c->flags |= CLIENT_PENDING_COMMAND;
     }
@@ -620,8 +619,7 @@ void blockForKeys(client *c, int btype, robj **keys, int numkeys, mstime_t timeo
         } else {
             l = dictGetVal(de);
         }
-        listAddNodeTail(l,c);
-        bki->listnode = listLast(l);
+        bki->listnode = listAddNodeTail(l,c);
     }
     blockClient(c,btype);
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -88,11 +88,10 @@ int listMatchObjects(void *a, void *b) {
 /* This function links the client to the global linked list of clients.
  * unlinkClient() does the opposite, among other things. */
 void linkClient(client *c) {
-    listAddNodeTail(server.clients,c);
     /* Note that we remember the linked list node where the client is stored,
      * this way removing the client in unlinkClient() will not require
      * a linear scan, but just a constant time operation. */
-    c->client_list_node = listLast(server.clients);
+    c->client_list_node = listAddNodeTail(server.clients,c);
     uint64_t id = htonu64(c->id);
     raxInsert(server.clients_index,(unsigned char*)&id,sizeof(id),c,NULL);
 }
@@ -556,8 +555,7 @@ void *addReplyDeferredLen(client *c) {
      * event loop setDeferredAggregateLen() will be called. */
     if (prepareClientToWrite(c) != C_OK) return NULL;
     trimReplyUnusedTailSpace(c);
-    listAddNodeTail(c->reply,NULL); /* NULL is our placeholder. */
-    return listLast(c->reply);
+    return listAddNodeTail(c->reply,NULL); /* NULL is our placeholder. */
 }
 
 void setDeferredReply(client *c, void *node, const char *s, size_t length) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -615,8 +615,7 @@ static void tlsHandleEvent(tls_connection *conn, int mask) {
             if ((mask & AE_READABLE)) {
                 if (SSL_pending(conn->ssl) > 0) {
                     if (!conn->pending_list_node) {
-                        listAddNodeTail(pending_list, conn);
-                        conn->pending_list_node = listLast(pending_list);
+                        conn->pending_list_node = listAddNodeTail(pending_list, conn);
                     }
                 } else if (conn->pending_list_node) {
                     listDelNode(pending_list, conn->pending_list_node);


### PR DESCRIPTION
This is just optimization and does not fix any bugs or performance improvements.

* The return type of listAddNodeHead, listAddNodeTail, listInsertNode is `list*`, but in these three methods, the memory address of the list does not change, so the return value is meaningless.
* Return `listNode*` should make more sense. The code often call listAddNodeTail, then call listLast to get the node of current added.
