### PR TITLE
Change typo for port range

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -509,8 +509,7 @@ void clusterInit(void) {
         serverLog(LL_WARNING, "Redis port number too high. "
                    "Cluster communication port is 10,000 port "
                    "numbers higher than your Redis port. "
-                   "Your Redis port number must be "
-                   "lower than 55535.");
+                   "Your Redis port number must be 55535 or less.");
         exit(1);
     }
     if (listenToPort(port+CLUSTER_PORT_INCR,


### PR DESCRIPTION
lower than 55535 doesn't include 55535, but 55535 is ok for this condition.
so 55535 or less is better message for error 