### PR TITLE
Update getTimeZone to long

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -749,7 +749,7 @@ sds getAbsolutePath(char *filename) {
  * Gets the proper timezone in a more portable fashion
  * i.e timezone variables are linux specific.
  */
-unsigned long getTimeZone(void) {
+long getTimeZone(void) {
 #if defined(__linux__) || defined(__sun)
     return timezone;
 #else
@@ -758,7 +758,7 @@ unsigned long getTimeZone(void) {
 
     gettimeofday(&tv, &tz);
 
-    return tz.tz_minuteswest * 60UL;
+    return tz.tz_minuteswest * 60L;
 #endif
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -60,7 +60,7 @@ int string2d(const char *s, size_t slen, double *dp);
 int d2string(char *buf, size_t len, double value);
 int ld2string(char *buf, size_t len, long double value, ld2string_mode mode);
 sds getAbsolutePath(char *filename);
-unsigned long getTimeZone(void);
+long getTimeZone(void);
 int pathIsBaseName(char *path);
 
 #ifdef REDIS_TEST


### PR DESCRIPTION
getTimeZone with unsigned long can be negative so changing it to signed long. 

Fixes https://github.com/redis/redis/issues/8237