### PR TITLE
Replicas discard slave keys with expire when loading AOF and changed into master

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1378,7 +1378,7 @@ void setExpire(client *c, redisDb *db, robj *key, long long when) {
     dictSetSignedIntegerVal(de,when);
 
     int writable_slave = server.masterhost && server.repl_slave_ro == 0;
-    if (c && writable_slave && !(c->flags & CLIENT_MASTER))
+    if (!server.loading && c && writable_slave && !(c->flags & CLIENT_MASTER))
         rememberSlaveKeyWithExpire(db,key);
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -2564,6 +2564,10 @@ void replicationUnsetMaster(void) {
     /* Update oom_score_adj */
     setOOMScoreAdj(-1);
 
+    /* There is no need to keep slaves keys with expire when redis is changed
+     * into master role. */
+    flushSlaveKeysWithExpireList();
+
     /* Once we turn from slave to master, we consider the starting time without
      * slaves (that is used to count the replication backlog time to live) as
      * starting from now. Otherwise the backlog will be freed after a


### PR DESCRIPTION
Before this commit,  redis replicas will add all keys  with expire into `slaveKeysWithExpire` when replicas load AOF and set `replicas-read-only no`. After loading AOF and starting, this memory will be freed when it finishes resync with master, but may lead redis freezing because we release `slaveKeysWithExpire` in blocking way.
Moreover, redis still keeps `slaveKeysWithExpire` but doesn't use if it changed into master.

In this PR, replicas discard slave keys with expire when loading AOF and changed into master.

Found this problems by https://github.com/redis/redis/issues/8345, also can fix it.