### PR TITLE
redis-cli fixes MultipleSlotOwners should set the import flag of the source node before moving the slot

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5115,9 +5115,18 @@ static int clusterManagerFixMultipleSlotOwners(int slot, list *owners) {
         clusterManagerDelSlot(n, slot, 1);
         if (!clusterManagerSetSlot(n, owner, slot, "node", NULL)) return 0;
         if (count > 0) {
+            //the source node should set importing flag before moveslot
+            success = clusterManagerSetSlot(n, owner,slot,
+                                        "importing", NULL);
+            if (!success) break;
+
             int opts = CLUSTER_MANAGER_OPT_VERBOSE |
                        CLUSTER_MANAGER_OPT_COLD;
             success = clusterManagerMoveSlot(n, owner, slot, opts, NULL);
+            if (!success) break;
+
+            //close the improting flag
+            success = clusterManagerClearSlotStatus(n, slot);
             if (!success) break;
         }
     }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5125,7 +5125,6 @@ static int clusterManagerFixMultipleSlotOwners(int slot, list *owners) {
             success = clusterManagerMoveSlot(n, owner, slot, opts, NULL);
             if (!success) break;
 
-            //close the improting flag
             success = clusterManagerClearSlotStatus(n, slot);
             if (!success) break;
         }


### PR DESCRIPTION
When repairing MutipleSlotOwners, it need to set the import flag of the source node in the function “clusterManagerFixMultipleSlotOwners” before executing movelot, otherwise it will fail