### PR TITLE
Bugfix: Make modules blocked on keys unblock on commands like LPUSH

### DIFF
--- a/tests/unit/moduleapi/blockonkeys.tcl
+++ b/tests/unit/moduleapi/blockonkeys.tcl
@@ -196,9 +196,9 @@ start_server {tags {"modules"}} {
         } else {
             fail "Client is not blocked"
         }
-        r lpush k 42
-        assert_equal {42} [$rd read]
-    $rd close
+        r lpush k 42 squirrel banana
+        assert_equal {banana squirrel 42} [$rd read]
+        $rd close
     }
 
     test {Module client unblocks BLPOP} {
@@ -213,6 +213,6 @@ start_server {tags {"modules"}} {
         }
         r blockonkeys.lpush k 42
         assert_equal {k 42} [$rd read]
-    $rd close
+        $rd close
     }
 }

--- a/tests/unit/moduleapi/blockonkeys.tcl
+++ b/tests/unit/moduleapi/blockonkeys.tcl
@@ -185,4 +185,32 @@ start_server {tags {"modules"}} {
         r fsl.push k 34
         assert_equal {34} [$rd read]
     }
+
+    test {Module client blocked on keys woken up by LPUSH} {
+        r del k
+        set rd [redis_deferring_client]
+        $rd blockonkeys.popall k
+        # wait until client is actually blocked
+        wait_for_condition 50 100 {
+            [s 0 blocked_clients] eq {1}
+        } else {
+            fail "Client is not blocked"
+        }
+        r lpush k 42
+        assert_equal {42} [$rd read]
+    }
+
+    test {Module client unblocks BLPOP} {
+        r del k
+        set rd [redis_deferring_client]
+        $rd blpop k 3
+        # wait until client is actually blocked
+        wait_for_condition 50 100 {
+            [s 0 blocked_clients] eq {1}
+        } else {
+            fail "Client is not blocked"
+        }
+        r blockonkeys.lpush k 42
+        assert_equal {k 42} [$rd read]
+    }
 }

--- a/tests/unit/moduleapi/blockonkeys.tcl
+++ b/tests/unit/moduleapi/blockonkeys.tcl
@@ -198,6 +198,7 @@ start_server {tags {"modules"}} {
         }
         r lpush k 42
         assert_equal {42} [$rd read]
+    $rd close
     }
 
     test {Module client unblocks BLPOP} {
@@ -212,5 +213,6 @@ start_server {tags {"modules"}} {
         }
         r blockonkeys.lpush k 42
         assert_equal {k 42} [$rd read]
+    $rd close
     }
 }


### PR DESCRIPTION
This makes it possible to implement blocking list and zset commands
using the modules API.

It is already supposed to work like this according to the Modules API
reference in the documentation for RedisModule_BlockClientOnKeys():

> If you block on a key of a type that has blocking operations
> associated, like a list, a sorted set, a stream, and so forth,
> the client may be unblocked once the relevant key is targeted
> by an operation that normally unblocks the native blocking
> operations for that type.

This commit also includes a test case for the reverse: A module
unblocks a client blocked on BLPOP by inserting elements using
RedisModule_ListPush(). This already works, but it was untested.