### PR TITLE
Add a precheck before the actual call to fcntl

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -69,6 +69,11 @@ int anetSetBlock(char *err, int fd, int non_block) {
         return ANET_ERR;
     }
 
+    /* Check if this flag has been set or unset. */
+    if (!!(flags & O_NONBLOCK) == !!non_block) {
+        return ANET_OK;
+    }
+
     if (non_block)
         flags |= O_NONBLOCK;
     else

--- a/src/anet.c
+++ b/src/anet.c
@@ -71,9 +71,8 @@ int anetSetBlock(char *err, int fd, int non_block) {
 
     /* Check if this flag has been set or unset, if so, 
      * then there is no need to call fcntl to set/unset it again. */
-    if (!!(flags & O_NONBLOCK) == !!non_block) {
+    if (!!(flags & O_NONBLOCK) == !!non_block)
         return ANET_OK;
-    }
 
     if (non_block)
         flags |= O_NONBLOCK;

--- a/src/anet.c
+++ b/src/anet.c
@@ -69,7 +69,8 @@ int anetSetBlock(char *err, int fd, int non_block) {
         return ANET_ERR;
     }
 
-    /* Check if this flag has been set or unset. */
+    /* Check if this flag has been set or unset, if so, 
+     * then there is no need to call fcntl to set/unset it again. */
     if (!!(flags & O_NONBLOCK) == !!non_block) {
         return ANET_OK;
     }


### PR DESCRIPTION
Avoid redundant calls to `fcntl` with `O_NONBLOCK` flag set/unset if this flag has been already set/unset.