### PR TITLE
Fix sentinel FD leak test, not printing the list of leaks

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -422,7 +422,7 @@ proc end_tests {} {
     set sentinel_fd_leaks_file "sentinel_fd_leaks"
     if { [file exists $sentinel_fd_leaks_file] } {
         puts [colorstr red "WARNING: sentinel test(s) failed, there are leaked fds in sentinel:"] 
-        exec cat $sentinel_fd_leaks_file
+        puts [exec cat $sentinel_fd_leaks_file]
         exit 1
     }
 


### PR DESCRIPTION
It turns out that the `exec` only executes the `cat` command without printing the file content on stdout, thus we have to always wrap the `exec cat $file` into a `puts` to get outputs printed on stdout in TCL.