### PR TITLE
Fix sentinel FD leak test, checking the wrong OS name

### DIFF
--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -37,11 +37,8 @@ test "(init) Sentinels can start monitoring a master" {
         S $id SENTINEL SET mymaster down-after-milliseconds 2000
         S $id SENTINEL SET mymaster failover-timeout 20000
         S $id SENTINEL SET mymaster parallel-syncs 10
-        # The bash script for detecting fd leaks in sentinel should only be registered and run on Linux.
-        if {[string match {*Linux*} [exec uname -a]]} {
-            S $id SENTINEL SET mymaster notification-script ../../tests/includes/notify.sh
-            S $id SENTINEL SET mymaster client-reconfig-script ../../tests/includes/notify.sh
-        }
+        S $id SENTINEL SET mymaster notification-script ../../tests/includes/notify.sh
+        S $id SENTINEL SET mymaster client-reconfig-script ../../tests/includes/notify.sh
     }
 }
 

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -37,8 +37,11 @@ test "(init) Sentinels can start monitoring a master" {
         S $id SENTINEL SET mymaster down-after-milliseconds 2000
         S $id SENTINEL SET mymaster failover-timeout 20000
         S $id SENTINEL SET mymaster parallel-syncs 10
-        S $id SENTINEL SET mymaster notification-script ../../tests/includes/notify.sh
-        S $id SENTINEL SET mymaster client-reconfig-script ../../tests/includes/notify.sh
+        # The bash script for detecting fd leaks in sentinel should only be registered and run on Linux.
+        if {[string match {*Linux*} [exec uname -a]]} {
+            S $id SENTINEL SET mymaster notification-script ../../tests/includes/notify.sh
+            S $id SENTINEL SET mymaster client-reconfig-script ../../tests/includes/notify.sh
+        }
     }
 }
 

--- a/tests/sentinel/tests/includes/notify.sh
+++ b/tests/sentinel/tests/includes/notify.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-OS=`uname -s`	
-if [ ${OS} != "Linux" ]	
-then	
-    exit 0	
+OS=`uname -s`
+if [ ${OS} != "Linux" ]
+then
+    exit 0
 fi
 
 # fd 3 is meant to catch the actual access to /proc/pid/fd, 

--- a/tests/sentinel/tests/includes/notify.sh
+++ b/tests/sentinel/tests/includes/notify.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-OS=`uname -s`
-if [ ${OS} == "Linux" ]
-then
-    exit 0
-fi
-
 # fd 3 is meant to catch the actual access to /proc/pid/fd, 
 # in case there's an fd leak by the sentinel,
 # it can take 3, but then the access to /proc will take another fd, and we'll catch that.

--- a/tests/sentinel/tests/includes/notify.sh
+++ b/tests/sentinel/tests/includes/notify.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+OS=`uname -s`	
+if [ ${OS} != "Linux" ]	
+then	
+    exit 0	
+fi
+
 # fd 3 is meant to catch the actual access to /proc/pid/fd, 
 # in case there's an fd leak by the sentinel,
 # it can take 3, but then the access to /proc will take another fd, and we'll catch that.


### PR DESCRIPTION
Move the logic of detecting OS from bash script to TCL script.