### PR TITLE
Expands lazyfree's effort estimate to include string

### DIFF
--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -89,7 +89,7 @@ size_t lazyfreeGetFreedObjectsCount(void) {
 size_t lazyfreeGetFreeEffort(robj *key, robj *obj) {
     if (obj->type == OBJ_STRING) {
         return sdslen(obj->ptr);
-    } if (obj->type == OBJ_LIST) {
+    } else if (obj->type == OBJ_LIST) {
         quicklist *ql = obj->ptr;
         return ql->len;
     } else if (obj->type == OBJ_SET && obj->encoding == OBJ_ENCODING_HT) {

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -87,7 +87,9 @@ size_t lazyfreeGetFreedObjectsCount(void) {
  * For lists the function returns the number of elements in the quicklist
  * representing the list. */
 size_t lazyfreeGetFreeEffort(robj *key, robj *obj) {
-    if (obj->type == OBJ_LIST) {
+    if (obj->type == OBJ_STRING) {
+        return sdslen(obj->ptr);
+    } if (obj->type == OBJ_LIST) {
         quicklist *ql = obj->ptr;
         return ql->len;
     } else if (obj->type == OBJ_SET && obj->encoding == OBJ_ENCODING_HT) {


### PR DESCRIPTION
When free large string, the time to free memory is much longer than the command processing time.
In the example in #8336 , when free a 512M string, the time consumed is almost 8000 microseconds, after modification it becomes 30 microseconds.