### PR TITLE
Fix misleading module test

### DIFF
--- a/tests/modules/blockonkeys.c
+++ b/tests/modules/blockonkeys.c
@@ -65,6 +65,7 @@ int get_fsl(RedisModuleCtx *ctx, RedisModuleString *keyname, int mode, int creat
         RedisModule_CloseKey(key);
         if (reply_on_failure)
             RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+        RedisModule_Call(ctx, "INCR", "c", "fsl_wrong_type");
         return 0;
     }
 

--- a/tests/unit/moduleapi/blockonkeys.tcl
+++ b/tests/unit/moduleapi/blockonkeys.tcl
@@ -168,7 +168,7 @@ start_server {tags {"modules"}} {
         assert_error "*unblocked*" {$rd read}
     }
 
-    test {Module client blocked on keys does not wake up on wrong type} {
+    test {Module client re-blocked on keys after woke up on wrong type} {
         r del k
         set rd [redis_deferring_client]
         $rd fsl.bpop k 0
@@ -184,6 +184,7 @@ start_server {tags {"modules"}} {
         r del k
         r fsl.push k 34
         assert_equal {34} [$rd read]
+        assert_equal {1} [r get fsl_wrong_type] ;# first lpush caused one wrong-type wake-up
     }
 
     test {Module client blocked on keys woken up by LPUSH} {


### PR DESCRIPTION
the test was misleading because the module would actually woke up on a wrong type and re-blocked, while the test name suggests the module doesn't not wake up at all on a wrong type..

i changed the name of the test + added verification that indeed the module wakes up and gets re-blocked after it understand it's the wrong type