### PR TITLE
GEOSEARCH bybox bug fixes and new fuzzy tester

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -223,7 +223,7 @@ int geoAppendIfWithinShape(geoArray *ga, GeoShape *shape, double score, sds memb
         if (!geohashGetDistanceIfInRadiusWGS84(shape->xy[0], shape->xy[1], xy[0], xy[1],
                                                shape->t.radius*shape->conversion, &distance)) return C_ERR;
     } else if (shape->type == RECTANGLE_TYPE) {
-        if (!geohashGetDistanceIfInTrapezoid(shape->bounds, shape->xy[0], shape->xy[1],
+        if (!geohashGetDistanceIfInPolygon(shape->polygon, shape->bounds, shape->xy[0], shape->xy[1],
                                              xy[0], xy[1], &distance)) return C_ERR;
     }
 

--- a/src/geo.c
+++ b/src/geo.c
@@ -174,10 +174,10 @@ int extractDistanceOrReply(client *c, robj **argv,
  * that should be in the form: <number> <number> <unit>, and return C_OK or C_ERR means success or failure
  * *conversions is populated with the coefficient to use in order to convert meters to the unit.*/
 int extractBoxOrReply(client *c, robj **argv, double *conversion,
-                         double *height, double *width) {
+                         double *width, double *height) {
     double h, w;
-    if ((getDoubleFromObjectOrReply(c, argv[0], &h, "need numeric width") != C_OK) ||
-        (getDoubleFromObjectOrReply(c, argv[1], &w, "need numeric height") != C_OK)) {
+    if ((getDoubleFromObjectOrReply(c, argv[0], &w, "need numeric width") != C_OK) ||
+        (getDoubleFromObjectOrReply(c, argv[1], &h, "need numeric height") != C_OK)) {
         return C_ERR;
     }
 

--- a/src/geo.c
+++ b/src/geo.c
@@ -176,8 +176,8 @@ int extractDistanceOrReply(client *c, robj **argv,
 int extractBoxOrReply(client *c, robj **argv, double *conversion,
                          double *height, double *width) {
     double h, w;
-    if ((getDoubleFromObjectOrReply(c, argv[0], &h, "need numeric height") != C_OK) ||
-        (getDoubleFromObjectOrReply(c, argv[1], &w, "need numeric width") != C_OK)) {
+    if ((getDoubleFromObjectOrReply(c, argv[0], &h, "need numeric width") != C_OK) ||
+        (getDoubleFromObjectOrReply(c, argv[1], &w, "need numeric height") != C_OK)) {
         return C_ERR;
     }
 
@@ -634,8 +634,8 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
                        flags & GEOSEARCH &&
                        !byradius)
             {
-                if (extractBoxOrReply(c, c->argv+base_args+i+1, &shape.conversion, &shape.t.r.height,
-                        &shape.t.r.width) != C_OK) return;
+                if (extractBoxOrReply(c, c->argv+base_args+i+1, &shape.conversion, &shape.t.r.width,
+                        &shape.t.r.height) != C_OK) return;
                 shape.type = RECTANGLE_TYPE;
                 bybox = 1;
                 i += 3;

--- a/src/geo.c
+++ b/src/geo.c
@@ -223,7 +223,7 @@ int geoAppendIfWithinShape(geoArray *ga, GeoShape *shape, double score, sds memb
         if (!geohashGetDistanceIfInRadiusWGS84(shape->xy[0], shape->xy[1], xy[0], xy[1],
                                                shape->t.radius*shape->conversion, &distance)) return C_ERR;
     } else if (shape->type == RECTANGLE_TYPE) {
-        if (!geohashGetDistanceIfInRectangle(shape->bounds, shape->xy[0], shape->xy[1],
+        if (!geohashGetDistanceIfInTrapezoid(shape->bounds, shape->xy[0], shape->xy[1],
                                              xy[0], xy[1], &distance)) return C_ERR;
     }
 

--- a/src/geohash.h
+++ b/src/geohash.h
@@ -96,8 +96,8 @@ typedef struct {
     int type; /* search type */
     double xy[2]; /* search center point, xy[0]: lon, xy[1]: lat */
     double conversion; /* km: 1000 */
-    double bounds[8]; /* bounds[0] - bounds[7] are the 4 coordinates of the trapezoid
-                       * see geohash_helper.c geohashBoundingBox */
+    double bounds[12]; /* bounds[0]-bounds[11] are 6 coordinates in the search
+                       * area, see geohash_helper.c geohashBoundingBox */
     union {
         /* CIRCULAR_TYPE */
         double radius;

--- a/src/geohash.h
+++ b/src/geohash.h
@@ -96,8 +96,10 @@ typedef struct {
     int type; /* search type */
     double xy[2]; /* search center point, xy[0]: lon, xy[1]: lat */
     double conversion; /* km: 1000 */
-    double bounds[12]; /* bounds[0]-bounds[11] are 6 coordinates in the search
-                       * area, see geohash_helper.c geohashBoundingBox */
+    double bounds[4]; /* bounds[0]: min_lon, bounds[1]: min_lat, bounds[2]: max_lon, bounds[3]: max_lat */
+    double polygon[12]; /* polygon are 6 coordinates (see geohash_helper.c geohashBoundingBoxAndPolygon)
+                         * in the search area, the latitude and longitude coordinates are arranged in
+                         * order, with longitude first. */
     union {
         /* CIRCULAR_TYPE */
         double radius;

--- a/src/geohash.h
+++ b/src/geohash.h
@@ -96,8 +96,8 @@ typedef struct {
     int type; /* search type */
     double xy[2]; /* search center point, xy[0]: lon, xy[1]: lat */
     double conversion; /* km: 1000 */
-    double bounds[4]; /* bounds[0]: min_lon, bounds[1]: min_lat
-                       * bounds[2]: max_lon, bounds[3]: max_lat */
+    double bounds[8]; /* bounds[0] - bounds[7] are the 4 coordinates of the trapezoid
+                       * see geohash_helper.c geohashBoundingBox */
     union {
         /* CIRCULAR_TYPE */
         double radius;

--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -275,7 +275,7 @@ int is_double_eq(double a, double b) {
  *
  * ray-crossing Algorithm refer: http://erich.realtimerendering.com/ptinpoly/
  */
-int geohashGetDistanceIfInRectangle(double *bounds, double x1, double y1,
+int geohashGetDistanceIfInTrapezoid(double *bounds, double x1, double y1,
                                     double x2, double y2, double *distance) {
     /* Use max_lon max_lat min_lat min_lat to quickly exclude some points */
     int southern_hemisphere = y1 < 0 ? 1 : 0;

--- a/src/geohash_helper.h
+++ b/src/geohash_helper.h
@@ -60,7 +60,7 @@ int geohashGetDistanceIfInRadius(double x1, double y1,
 int geohashGetDistanceIfInRadiusWGS84(double x1, double y1, double x2,
                                       double y2, double radius,
                                       double *distance);
-int geohashGetDistanceIfInRectangle(double *bounds, double x1, double y1,
+int geohashGetDistanceIfInTrapezoid(double *bounds, double x1, double y1,
                                     double x2, double y2, double *distance);
 
 #endif /* GEOHASH_HELPER_HPP_ */

--- a/src/geohash_helper.h
+++ b/src/geohash_helper.h
@@ -49,7 +49,7 @@ typedef struct {
 
 int GeoHashBitsComparator(const GeoHashBits *a, const GeoHashBits *b);
 uint8_t geohashEstimateStepsByRadius(double range_meters, double lat);
-int geohashBoundingBox(GeoShape *shape, double *bounds);
+int geohashBoundingBoxAndPolygon(GeoShape *shape);
 GeoHashRadius geohashCalculateAreasByShapeWGS84(GeoShape *shape);
 GeoHashFix52Bits geohashAlign52Bits(const GeoHashBits hash);
 double geohashGetDistance(double lon1d, double lat1d,
@@ -60,7 +60,7 @@ int geohashGetDistanceIfInRadius(double x1, double y1,
 int geohashGetDistanceIfInRadiusWGS84(double x1, double y1, double x2,
                                       double y2, double radius,
                                       double *distance);
-int geohashGetDistanceIfInTrapezoid(double *bounds, double x1, double y1,
+int geohashGetDistanceIfInPolygon(double *polygon, double *bounds, double x1, double y1,
                                     double x2, double y2, double *distance);
 
 #endif /* GEOHASH_HELPER_HPP_ */

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -1,6 +1,7 @@
 # Helper functions to simulate search-in-radius in the Tcl side in order to
 # verify the Redis implementation with a fuzzy test.
-proc geo_degrad deg {expr {$deg*atan(1)*8/360}}
+proc geo_degrad deg {expr {$deg*(atan(1)*8/360)}}
+proc geo_raddeg deg {expr {$deg/(atan(1)*8/360)}}
 
 proc geo_distance {lon1d lat1d lon2d lat2d} {
     set lon1r [geo_degrad $lon1d]
@@ -40,6 +41,31 @@ proc compare_lists {List1 List2} {
       }
    }
    return $DiffList
+}
+
+# If a point in circular
+proc pointInCircular {radius_km lon lat search_lon search_lat} {
+    set radius_m [expr {$radius_km*1000}]
+    set distance [geo_distance $lon $lat $search_lon $search_lat]
+    if {$distance < $radius_m} {
+        return true
+    }
+    return false
+}
+
+# If a point in box
+proc pointInBox {width_km height_km lon lat search_lon search_lat fixed_degree} {
+    set width_m [expr {$width_km*1000/2}]
+    set height_m [expr {$height_km*1000/2}]
+    set long_delta [geo_raddeg [expr {$width_m/6372797.560856/cos([geo_degrad $search_lat])}]]
+    set lat_delta [geo_raddeg [expr {$height_m/6372797.560856}]]
+    if {$lon < [expr {$search_lon-$long_delta-$fixed_degree}] ||
+        $lon > [expr {$search_lon+$long_delta+$fixed_degree}] ||
+        $lat < [expr {$search_lat-$lat_delta-$fixed_degree}] ||
+        $lat > [expr {$search_lat+$lat_delta+$fixed_degree}]} {
+        return false
+    }
+    return true
 }
 
 # The following list represents sets of random seed, search position
@@ -229,12 +255,12 @@ start_server {tags {"geo"}} {
         r geoadd Sicily 12.75 36.50 "test2"
         r geoadd Sicily 13.00 36.50 "test3"
         # box height=2km width=400km
-        set ret1 [r geosearch Sicily fromlonlat 15 37 bybox 2 400 km]
+        set ret1 [r geosearch Sicily fromlonlat 15 37 bybox 400 2 km]
         assert_equal $ret1 {test1}
 
         # Add a western Hemisphere point
         r geoadd Sicily -1 37.00 "test3"
-        set ret2 [r geosearch Sicily fromlonlat 15 37 bybox 2 3000 km asc]
+        set ret2 [r geosearch Sicily fromlonlat 15 37 bybox 3000 2 km asc]
         assert_equal $ret2 {test1 test3}
     }
 
@@ -360,12 +386,14 @@ start_server {tags {"geo"}} {
         assert {[lindex $res 0] eq "Catania"}
     }
 
-    test {GEOADD + GEORANGE randomized test} {
+    foreach {type} {byradius bybox} {
+    test "GEOSEARCH fuzzy test - $type" {
         set attempt 30
         while {[incr attempt -1]} {
             set rv [lindex $regression_vectors $rv_idx]
             incr rv_idx
 
+            set radius_km 0; set width_km 0; set height_km 0
             unset -nocomplain debuginfo
             set srand_seed [clock milliseconds]
             if {$rv ne {}} {set srand_seed [lindex $rv 0]}
@@ -374,34 +402,56 @@ start_server {tags {"geo"}} {
             r del mypoints
 
             if {[randomInt 10] == 0} {
+                if {$type == "byradius"} {
+                    set radius_km [expr {[randomInt 5000]+10}]
+                } elseif {$type == "bybox"} {
+                    set width_km [expr {[randomInt 5000]+10}]
+                    set height_km [expr {[randomInt 5000]+10}]
+                }
                 # From time to time use very big radiuses
-                set radius_km [expr {[randomInt 50000]+10}]
             } else {
                 # Normally use a few - ~200km radiuses to stress
                 # test the code the most in edge cases.
-                set radius_km [expr {[randomInt 200]+10}]
+                if {$type == "byradius"} {
+                    set radius_km [expr {[randomInt 200]+10}]
+                } elseif {$type == "bybox"} {
+                    set width_km [expr {[randomInt 200]+10}]
+                    set height_km [expr {[randomInt 200]+10}]
+                }
             }
-            if {$rv ne {}} {set radius_km [lindex $rv 1]}
-            set radius_m [expr {$radius_km*1000}]
+            if {$rv ne {}} {
+                set radius_km [lindex $rv 1]
+                set width_km [lindex $rv 1]
+                set height_km [lindex $rv 1]
+            }
             geo_random_point search_lon search_lat
             if {$rv ne {}} {
                 set search_lon [lindex $rv 2]
                 set search_lat [lindex $rv 3]
             }
-            lappend debuginfo "Search area: $search_lon,$search_lat $radius_km km"
+            lappend debuginfo "Search area: $search_lon,$search_lat $radius_km $width_km $height_km km"
             set tcl_result {}
             set argv {}
             for {set j 0} {$j < 20000} {incr j} {
                 geo_random_point lon lat
                 lappend argv $lon $lat "place:$j"
-                set distance [geo_distance $lon $lat $search_lon $search_lat]
-                if {$distance < $radius_m} {
-                    lappend tcl_result "place:$j"
+                if {$type == "byradius"} {
+                    if {[pointInCircular $radius_km $lon $lat $search_lon $search_lat]} {
+                        lappend tcl_result "place:$j"
+                    }
+                } elseif {$type == "bybox"} {
+                    if {[pointInBox $width_km $height_km $lon $lat $search_lon $search_lat 0]} {
+                        lappend tcl_result "place:$j"
+                    }
                 }
-                lappend debuginfo "place:$j $lon $lat [expr {$distance/1000}] km"
+                lappend debuginfo "place:$j $lon $lat"
             }
             r geoadd mypoints {*}$argv
-            set res [lsort [r georadius mypoints $search_lon $search_lat $radius_km km]]
+            if {$type == "byradius"} {
+                set res [lsort [r geosearch mypoints fromlonlat $search_lon $search_lat byradius $radius_km km]]
+            } elseif {$type == "bybox"} {
+                set res [lsort [r geosearch mypoints fromlonlat $search_lon $search_lat bybox $width_km $height_km km]]
+            }
             set res2 [lsort $tcl_result]
             set test_result OK
 
@@ -409,18 +459,27 @@ start_server {tags {"geo"}} {
                 set rounding_errors 0
                 set diff [compare_lists $res $res2]
                 foreach place $diff {
+                    lassign [lindex [r geopos mypoints $place] 0] lon lat
                     set mydist [geo_distance $lon $lat $search_lon $search_lat]
                     set mydist [expr $mydist/1000]
-                    if {($mydist / $radius_km) > 0.999} {
-                        incr rounding_errors
-                        continue
-                    }
-                    if {$mydist < $radius_m} {
-                        # This is a false positive for redis since given the 
-                        # same points the higher precision calculation provided 
-                        # by TCL shows the point within range
-                        incr rounding_errors
-                        continue
+                    if {$type == "byradius"} {
+                        if {($mydist / $radius_km) > 0.999} {
+                            incr rounding_errors
+                            continue
+                        }
+                        if {$mydist < [expr {$radius_km*1000}]} {
+                            # This is a false positive for redis since given the
+                            # same points the higher precision calculation provided
+                            # by TCL shows the point within range
+                            incr rounding_errors
+                            continue
+                        }
+                    } elseif {$type == "bybox"} {
+                        # we add fixed 0.01 degree because higher precision calculation
+                        if {[pointInBox $width_km $height_km $lon $lat $search_lon $search_lat 0.01]} {
+                            incr rounding_errors
+                            continue
+                        }
                     }
                 }
 
@@ -447,7 +506,6 @@ start_server {tags {"geo"}} {
                     set mydist [geo_distance $lon $lat $search_lon $search_lat]
                     set mydist [expr $mydist/1000]
                     puts "$place -> [r geopos mypoints $place] $mydist $where"
-                    if {($mydist / $radius_km) > 0.999} {incr rounding_errors}
                 }
                 set test_result FAIL
             }
@@ -456,4 +514,5 @@ start_server {tags {"geo"}} {
         }
         set test_result
     } {OK}
+    }
 }

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -1,7 +1,7 @@
 # Helper functions to simulate search-in-radius in the Tcl side in order to
 # verify the Redis implementation with a fuzzy test.
 proc geo_degrad deg {expr {$deg*(atan(1)*8/360)}}
-proc geo_raddeg deg {expr {$deg/(atan(1)*8/360)}}
+proc geo_raddeg rad {expr {$rad/(atan(1)*8/360)}}
 
 proc geo_distance {lon1d lat1d lon2d lat2d} {
     set lon1r [geo_degrad $lon1d]

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -43,8 +43,10 @@ proc compare_lists {List1 List2} {
    return $DiffList
 }
 
-# If a point in circular
-proc pointInCircular {radius_km lon lat search_lon search_lat} {
+# return true If a point in circle.
+# search_lon and search_lat define the center of the circle,
+# and lon, lat define the point being searched.
+proc pointInCircle {radius_km lon lat search_lon search_lat} {
     set radius_m [expr {$radius_km*1000}]
     set distance [geo_distance $lon $lat $search_lon $search_lat]
     if {$distance < $radius_m} {
@@ -501,7 +503,7 @@ start_server {tags {"geo"}} {
                 geo_random_point lon lat
                 lappend argv $lon $lat "place:$j"
                 if {$type == "byradius"} {
-                    if {[pointInCircular $radius_km $lon $lat $search_lon $search_lat]} {
+                    if {[pointInCircle $radius_km $lon $lat $search_lon $search_lat]} {
                         lappend tcl_result "place:$j"
                     }
                 } elseif {$type == "bybox"} {
@@ -581,7 +583,7 @@ start_server {tags {"geo"}} {
     } {OK}
     }
 
-    test {GEOSEARCH fuzzy test} {
+    test {GEOSEARCH box edges fuzzy test} {
         if {$::accurate} { set attempt 300 } else { set attempt 30 }
         while {[incr attempt -1]} {
             unset -nocomplain debuginfo
@@ -628,7 +630,7 @@ start_server {tags {"geo"}} {
 
             set res2 [lsort $tcl_result]
 
-            # move the box by two meter to put the coordinate slightly inside the box.
+            # make the box larger by two meter in each direction to put the coordinate slightly inside the box.
             set height_new [expr {$height_m+4}]
             set width_new [expr {$width_m+4}]
             set res [lsort [r geosearch mypoints fromlonlat $search_lon $search_lat bybox $width_new $height_new m]]
@@ -638,7 +640,7 @@ start_server {tags {"geo"}} {
                 fail "place should be found, debuginfo: $debuginfo, height_new: $height_new width_new: $width_new"
             }
 
-            # move the box by two meter to put the coordinate slightly outside the box.
+            # make the box smaller by two meter in each direction to put the coordinate slightly outside the box.
             set height_new [expr {$height_m-4}]
             set width_new [expr {$width_m-4}]
             set res [r geosearch mypoints fromlonlat $search_lon $search_lat bybox $width_new $height_new m]


### PR DESCRIPTION
[Edit]

- Fix GEOSEARCH bybox width and height mismatch
- Fix errors of GEOSEARCH bybox search due to projection of the box to a
  trapezoid (when the meter box is converted to long / lat it's no longer a box).
- Add GEOSEARCH bybox testing to the existing "GEOADD + GEORANGE randomized test"
- Add new fuzzy test to stress test the bybox corners and edges
- Add some tests for edge cases of the bybox algorithm


---

This PR add fuzzy test for `GEOSEARCH` command and fix the wrong order of widht and height parameters. As shown in the [document](https://redis.io/commands/geosearch), width is before height.
