### PR TITLE
Fix recent test failures

### DIFF
--- a/tests/modules/blockonkeys.c
+++ b/tests/modules/blockonkeys.c
@@ -66,7 +66,8 @@ int get_fsl(RedisModuleCtx *ctx, RedisModuleString *keyname, int mode, int creat
         RedisModule_CloseKey(key);
         if (reply_on_failure)
             RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
-        RedisModule_Call(ctx, "INCR", "c", "fsl_wrong_type");
+        RedisModuleCallReply *reply = RedisModule_Call(ctx, "INCR", "c", "fsl_wrong_type");
+        RedisModule_FreeCallReply(reply);
         return 0;
     }
 

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -12,7 +12,7 @@ start_server {tags {"dump"}} {
         r del foo
         r restore foo 5000 $encoded
         set ttl [r pttl foo]
-        assert {$ttl >= 3000 && $ttl <= 5000}
+        assert_range $ttl 3000 5000
         r get foo
     } {bar}
 
@@ -22,7 +22,7 @@ start_server {tags {"dump"}} {
         r del foo
         r restore foo 2569591501 $encoded
         set ttl [r pttl foo]
-        assert {$ttl >= (2569591501-3000) && $ttl <= 2569591501}
+        assert_range $ttl (2569591501-3000) 2569591501
         r get foo
     } {bar}
     
@@ -33,7 +33,7 @@ start_server {tags {"dump"}} {
         set now [clock milliseconds]
         r restore foo [expr $now+3000] $encoded absttl
         set ttl [r pttl foo]
-        assert {$ttl >= 2900 && $ttl <= 3100}
+        assert_range $ttl 2000 3100
         r get foo
     } {bar}
 


### PR DESCRIPTION
1. Valgrind leak in a recent change in a module api test
2. Increase treshold of a RESTORE TTL test
3. Change assertions to use assert_range which prints the values