### PR TITLE
In XADD take deleted items into consideration when switch to new node

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -513,6 +513,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
             lp = NULL;
         } else if (server.stream_node_max_entries) {
             unsigned char *lp_ele = lpFirst(lp);
+            /* Count both live entries and deleted ones. */
             int64_t count = lpGetInteger(lp_ele) + lpGetInteger(lpNext(lp,lp_ele));
             if (count >= server.stream_node_max_entries) {
                 /* Shrink extra pre-allocated memory */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -512,7 +512,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
         {
             lp = NULL;
         } else if (server.stream_node_max_entries) {
-            int64_t count = lpGetInteger(lpFirst(lp));
+            unsigned char *lp_ele = lpFirst(lp);
+            int64_t count = lpGetInteger(lp_ele) + lpGetInteger(lpNext(lp,lp_ele));
             if (count >= server.stream_node_max_entries) {
                 /* Shrink extra pre-allocated memory */
                 lp = lpShrinkToFit(lp);


### PR DESCRIPTION
If we set stream-node-max-bytes = 0, then we insert entry then delete,
do this many times, the last stream node will be very big.