### PR TITLE
Add tests for RESP3 responce of ZINTER and ZRANGE

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2751,6 +2751,9 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
         unsigned long length = dstzset->zsl->length;
         zskiplist *zsl = dstzset->zsl;
         zskiplistNode *zn = zsl->header->level[0].forward;
+        /* In case of WITHSCORES, respond with a single array in RESP2, and
+         * nested arrays in RESP3. We can't use a map response type since the
+         * client library needs to know to respect the order. */
         if (withscores && c->resp == 2)
             addReplyArrayLen(c, length*2);
         else
@@ -2868,6 +2871,9 @@ static void zrangeResultEmitLongLongToClient(zrange_result_handler *handler,
 static void zrangeResultFinalizeClient(zrange_result_handler *handler,
     size_t result_count)
 {
+    /* In case of WITHSCORES, respond with a single array in RESP2, and
+     * nested arrays in RESP3. We can't use a map response type since the
+     * client library needs to know to respect the order. */
     if (handler->withscores && (handler->client->resp == 2)) {
         result_count *= 2;
     }

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -244,6 +244,7 @@ proc ::redis::redis_read_reply {id fd} {
         _ {redis_read_null $fd}
         : -
         + {redis_read_line $fd}
+        , {expr {double([redis_read_line $fd])}}
         - {return -code error [redis_read_line $fd]}
         $ {redis_bulk_read $fd}
         > -

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -713,6 +713,12 @@ start_server {tags {"zset"}} {
             assert_equal {b 3 c 5} [r zinter 2 zseta zsetb withscores]
         }
 
+        test "ZINTER RESP3 - $encoding" {
+            r hello 3
+            assert_equal {{b 3.0} {c 5.0}} [r zinter 2 zseta zsetb withscores]
+        }
+        r hello 2
+
         test "ZINTERSTORE with weights - $encoding" {
             assert_equal 2 [r zinterstore zsetc 2 zseta zsetb weights 2 3]
             assert_equal {b 7 c 12} [r zrange zsetc 0 -1 withscores]
@@ -1480,6 +1486,12 @@ start_server {tags {"zset"}} {
         assert_equal $res 4
         r zrange z2 0 -1 withscores
     } {a 1 b 2 c 3 d 4}
+
+    test {ZRANGESTORE RESP3} {
+        r hello 3
+        r zrange z2 0 -1 withscores
+    } {{a 1.0} {b 2.0} {c 3.0} {d 4.0}}
+    r hello 2
 
     test {ZRANGESTORE range} {
         set res [r zrangestore z2 z1 1 2]


### PR DESCRIPTION
It was confusing as to why these don't return a map type.
the reason is that order matters, so we need to make sure the client
library knows to respect it.
Added comments in the implementation and tests to cover it.