### PR TITLE
Fix rare test failures due to repl-ping-replica-period

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -717,6 +717,7 @@ if {[llength $filtered_tests] < [llength $::all_tests]} {
 }
 
 proc attach_to_replication_stream {} {
+    r config set repl-ping-replica-period 3600
     if {$::tls} {
         set s [::tls::socket [srv 0 "host"] [srv 0 "port"]]
     } else {
@@ -774,6 +775,7 @@ proc assert_replication_stream {s patterns} {
 
 proc close_replication_stream {s} {
     close $s
+    r config set repl-ping-replica-period 10
 }
 
 # With the parallel test running multiple Redis instances at the same time

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -39,7 +39,7 @@ if {$system_name eq {linux}} {
             r bgsave
 
             set child_pid [get_child_pid 0]
-            assert {[get_oom_score_adj $child_pid] == [expr $base + 30]}
+            assert_equal [get_oom_score_adj $child_pid] [expr $base + 30]
         }
 
         # Failed oom-score-adj tests can only run unprivileged


### PR DESCRIPTION
some tests use attach_to_replication_stream to watch what's propagated
to replicas, but in some cases the periodic ping may slip in and fail
the test.
we disable that ping by setting the period to once an hour (tests should
not run for that long).

other change is so that the next time this oom-score-adj test fails,
we'll see the value (assert_equals prints it)