### PR TITLE
tracking memory for set proc title

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -146,6 +146,7 @@
 #if ((defined __linux && defined(__GLIBC__)) || defined __APPLE__)
 #define USE_SETPROCTITLE
 #define INIT_SETPROCTITLE_REPLACEMENT
+#define PROC_ZMALLOC 
 void spt_init(int argc, char *argv[]);
 void setproctitle(const char *fmt, ...);
 #endif


### PR DESCRIPTION
this is a minor change for setproctitle implementation. For the alloc/dealloc call the memory should be tracked using zmalloc library, but currently the untracked memory is very small through.