### PR TITLE
Remove check leading to duplicate branches

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1284,9 +1284,9 @@ int zsetScore(robj *zobj, sds member, double *score) {
  *            assume 0 as previous score.
  * ZADD_NX:   Perform the operation only if the element does not exist.
  * ZADD_XX:   Perform the operation only if the element already exist.
- * ZADD_GT:   Perform the operation on existing elements only if the new score is 
+ * ZADD_GT:   Perform the operation on existing elements only if the new score is
  *            greater than the current score.
- * ZADD_LT:   Perform the operation on existing elements only if the new score is 
+ * ZADD_LT:   Perform the operation on existing elements only if the new score is
  *            less than the current score.
  *
  * When ZADD_INCR is used, the new score of the element is stored in
@@ -1355,11 +1355,11 @@ int zsetAdd(robj *zobj, double score, sds ele, int *flags, double *newscore) {
             }
 
             /* Remove and re-insert when score changed. */
-            if (score != curscore &&  
+            if (score != curscore &&
                 /* LT? Only update if score is less than current. */
                 (!lt || score < curscore) &&
                 /* GT? Only update if score is greater than current. */
-                (!gt || score > curscore)) 
+                (!gt || score > curscore))
             {
                 zobj->ptr = zzlDelete(zobj->ptr,eptr);
                 zobj->ptr = zzlInsert(zobj->ptr,ele,score);
@@ -1405,11 +1405,11 @@ int zsetAdd(robj *zobj, double score, sds ele, int *flags, double *newscore) {
             }
 
             /* Remove and re-insert when score changes. */
-            if (score != curscore &&  
+            if (score != curscore &&
                 /* LT? Only update if score is less than current. */
                 (!lt || score < curscore) &&
                 /* GT? Only update if score is greater than current. */
-                (!gt || score > curscore)) 
+                (!gt || score > curscore))
             {
                 znode = zslUpdateScore(zs->zsl,curscore,ele,score);
                 /* Note that we did not removed the original element from
@@ -1712,7 +1712,7 @@ void zaddGenericCommand(client *c, int flags) {
             "XX and NX options at the same time are not compatible");
         return;
     }
-    
+
     if ((gt && nx) || (lt && nx) || (gt && lt)) {
         addReplyError(c,
             "GT, LT, and/or NX options at the same time are not compatible");
@@ -3174,8 +3174,7 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
             }
 
             rangelen++;
-            handler->emitResultFromCBuffer(handler, ln->ele, sdslen(ln->ele),
-              ((withscores) ? ln->score : ln->score));
+            handler->emitResultFromCBuffer(handler, ln->ele, sdslen(ln->ele), ln->score);
 
             /* Move to next node */
             if (reverse) {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3073,8 +3073,8 @@ void zrevrangeCommand(client *c) {
 
 /* This command implements ZRANGEBYSCORE, ZREVRANGEBYSCORE. */
 void genericZrangebyscoreCommand(zrange_result_handler *handler,
-    zrangespec *range, robj *zobj, int withscores, long offset,
-    long limit, int reverse) {
+    zrangespec *range, robj *zobj, long offset, long limit, 
+    int reverse) {
 
     client *c = handler->client;
     unsigned long rangelen = 0;
@@ -3625,8 +3625,8 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
         break;
 
     case ZRANGE_SCORE:
-        genericZrangebyscoreCommand(handler, &range, zobj, opt_withscores || store,
-            opt_offset, opt_limit, direction == ZRANGE_DIRECTION_REVERSE);
+        genericZrangebyscoreCommand(handler, &range, zobj, opt_offset,
+            opt_limit, direction == ZRANGE_DIRECTION_REVERSE);
         break;
 
     case ZRANGE_LEX:

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1284,9 +1284,9 @@ int zsetScore(robj *zobj, sds member, double *score) {
  *            assume 0 as previous score.
  * ZADD_NX:   Perform the operation only if the element does not exist.
  * ZADD_XX:   Perform the operation only if the element already exist.
- * ZADD_GT:   Perform the operation on existing elements only if the new score is
+ * ZADD_GT:   Perform the operation on existing elements only if the new score is 
  *            greater than the current score.
- * ZADD_LT:   Perform the operation on existing elements only if the new score is
+ * ZADD_LT:   Perform the operation on existing elements only if the new score is 
  *            less than the current score.
  *
  * When ZADD_INCR is used, the new score of the element is stored in
@@ -1355,11 +1355,11 @@ int zsetAdd(robj *zobj, double score, sds ele, int *flags, double *newscore) {
             }
 
             /* Remove and re-insert when score changed. */
-            if (score != curscore &&
+            if (score != curscore &&  
                 /* LT? Only update if score is less than current. */
                 (!lt || score < curscore) &&
                 /* GT? Only update if score is greater than current. */
-                (!gt || score > curscore))
+                (!gt || score > curscore)) 
             {
                 zobj->ptr = zzlDelete(zobj->ptr,eptr);
                 zobj->ptr = zzlInsert(zobj->ptr,ele,score);
@@ -1405,11 +1405,11 @@ int zsetAdd(robj *zobj, double score, sds ele, int *flags, double *newscore) {
             }
 
             /* Remove and re-insert when score changes. */
-            if (score != curscore &&
+            if (score != curscore &&  
                 /* LT? Only update if score is less than current. */
                 (!lt || score < curscore) &&
                 /* GT? Only update if score is greater than current. */
-                (!gt || score > curscore))
+                (!gt || score > curscore)) 
             {
                 znode = zslUpdateScore(zs->zsl,curscore,ele,score);
                 /* Note that we did not removed the original element from
@@ -1712,7 +1712,7 @@ void zaddGenericCommand(client *c, int flags) {
             "XX and NX options at the same time are not compatible");
         return;
     }
-
+    
     if ((gt && nx) || (lt && nx) || (gt && lt)) {
         addReplyError(c,
             "GT, LT, and/or NX options at the same time are not compatible");


### PR DESCRIPTION
I noticed in `src/t_zset.c` that a ternary conditional evaluated to the same result in either case. The condition also has no side-effects. This pull request removes the ternary conditional, to improve readability.

This also meant that the `withscores` parameter was unused. So I removed it from the function so that the compiler wouldn't emit a warning.