### PR TITLE
Fix in activeDefragSdsListAndDict update de->v.val not ln->value

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -367,7 +367,7 @@ long activeDefragSdsListAndDict(list *l, dict *d, int dict_val_type) {
         } else if (dict_val_type == DEFRAG_SDS_DICT_VAL_VOID_PTR) {
             void *newptr, *ptr = dictGetVal(de);
             if ((newptr = activeDefragAlloc(ptr)))
-                ln->value = newptr, defragged++;
+                de->v.val = newptr, defragged++;
         }
         defragged += dictIterDefragEntry(di);
     }


### PR DESCRIPTION
In activeDefragSdsListAndDict when `dict_val_type` is `DEFRAG_SDS_DICT_VAL_VOID_PTR`, it should update `de->v.val` not `ln->value`.
Because this code path will never be executed, so this bug never happened.