### PR TITLE
Avoid assertions when testing arm64 cow bug.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5279,11 +5279,11 @@ int linuxMadvFreeForkBugCheck(void) {
     } else if (!pid) {
         /* Child: check if the page is marked as dirty, page_size in kb.
          * A value of 0 means the kernel is affected by the bug. */
-        ret = smapsGetSharedDirty((unsigned long) q));
+        ret = smapsGetSharedDirty((unsigned long) q);
         if (!ret)
             bug_found = 1;
         else if (ret == -1)     /* Failed to read */
-            bug_found -1;
+            bug_found = -1;
 
         if (write(pipefd[1], &bug_found, sizeof(bug_found)) < 0)
             serverLog(LL_WARNING, "Failed to write to parent: %s", strerror(errno));

--- a/src/server.c
+++ b/src/server.c
@@ -5902,13 +5902,12 @@ int main(int argc, char **argv) {
     checkTcpBacklogSettings();
 
     if (!server.sentinel_mode) {
-        int ret;
-
         /* Things not needed when running in Sentinel mode. */
         serverLog(LL_WARNING,"Server initialized");
     #ifdef __linux__
         linuxMemoryWarnings();
     #if defined (__arm64__)
+        int ret;
         if ((ret = linuxMadvFreeForkBugCheck())) {
             if (ret == 1)
                 serverLog(LL_WARNING,"WARNING Your kernel has a bug that could lead to data corruption during background save."


### PR DESCRIPTION
At least in one case the arm64 cow kernel bug test triggers an assert, which is a problem because it cannot be ignored like cases where the bug is found.

On older systems (Linux <4.5) madvise fails because MADV_FREE is not supported. We treat these failures as an indication the system is not affected.

Fixes #8351, #8406