### PR TITLE
Stack allocate dict iterators in sentinel

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -566,24 +566,30 @@ long long dictFingerprint(dict *d) {
     return hash;
 }
 
-dictIterator *dictGetIterator(dict *d)
-{
-    dictIterator *iter = zmalloc(sizeof(*iter));
-
+void dictInitIterator(dictIterator *iter, dict *d) {
     iter->d = d;
     iter->table = 0;
     iter->index = -1;
     iter->safe = 0;
     iter->entry = NULL;
     iter->nextEntry = NULL;
+}
+
+void dictInitSafeIterator(dictIterator *iter, dict *d) {
+    dictInitIterator(iter, d);
+    iter->safe = 1;
+}
+
+dictIterator *dictGetIterator(dict *d) {
+    dictIterator *iter = zmalloc(sizeof(*iter));
+    dictInitIterator(iter,d);
     return iter;
 }
 
 dictIterator *dictGetSafeIterator(dict *d) {
-    dictIterator *i = dictGetIterator(d);
-
-    i->safe = 1;
-    return i;
+    dictIterator *iter = zmalloc(sizeof(*iter));
+    dictInitSafeIterator(iter,d);
+    return iter;
 }
 
 dictEntry *dictNext(dictIterator *iter)

--- a/src/dict.h
+++ b/src/dict.h
@@ -173,6 +173,8 @@ void dictRelease(dict *d);
 dictEntry * dictFind(dict *d, const void *key);
 void *dictFetchValue(dict *d, const void *key);
 int dictResize(dict *d);
+void dictInitIterator(dictIterator *iter, dict *d);
+void dictInitSafeIterator(dictIterator *iter, dict *d);
 dictIterator *dictGetIterator(dict *d);
 dictIterator *dictGetSafeIterator(dict *d);
 dictEntry *dictNext(dictIterator *iter);


### PR DESCRIPTION
This PR adds initiation functions for the dict type to enable stack allocated safe- and regular dict iterators.
It also updates sentinel.c to use stack allocated iterators.

This would give less fragmented memory, be theoretically faster, reduce code a bit,
and simplify failure paths since explicit deallocation of iterators is not needed.

This is also how the `listIter` is used, so it will give consistency between list and dict iterators.

This PR only treats sentinel to get some feedback of the idea.