### PR TITLE
Clear the ownership when the slot no longer belongs to the sender

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1675,7 +1675,14 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                                      CLUSTER_TODO_UPDATE_STATE|
                                      CLUSTER_TODO_FSYNC_CONFIG);
             }
-        }
+        } else {
+            if(server.cluster->slots[j] == sender){
+                clusterDelSlot(j);
+                clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG|
+                                     CLUSTER_TODO_UPDATE_STATE|
+                                     CLUSTER_TODO_FSYNC_CONFIG);
+            }
+        }	 
     }
 
     /* After updating the slots configuration, don't do any actual change


### PR DESCRIPTION
For safety, if the slot no longer belongs to the sender, clear the ownership.