### PR TITLE
Add child current processed keys to persistence info

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1608,7 +1608,7 @@ int rewriteAppendOnlyFile(char *filename) {
         /* Update COW info */
         long long now = mstime();
         if (now - cow_updated_time >= 1000) {
-            sendChildInfo(CHILD_INFO_TYPE_CURRENT_INFO, 0, "AOF rewrite");
+            sendChildInfo(CHILD_INFO_TYPE_CURRENT_INFO, dbTotalServerKeyCount(), "AOF rewrite");
             cow_updated_time = now;
         }
     }
@@ -1742,7 +1742,7 @@ int rewriteAppendOnlyFileBackground(void) {
         redisSetCpuAffinity(server.aof_rewrite_cpulist);
         snprintf(tmpfile,256,"temp-rewriteaof-bg-%d.aof", (int) getpid());
         if (rewriteAppendOnlyFile(tmpfile) == C_OK) {
-            sendChildInfo(CHILD_INFO_TYPE_AOF_COW_SIZE, 0, "AOF rewrite");
+            sendChildCowInfo(CHILD_INFO_TYPE_AOF_COW_SIZE, "AOF rewrite");
             exitFromChild(0);
         } else {
             exitFromChild(1);

--- a/src/aof.c
+++ b/src/aof.c
@@ -1594,7 +1594,7 @@ int rewriteAppendOnlyFile(char *filename) {
     size_t bytes_to_write = sdslen(server.aof_child_diff);
     const char *buf = server.aof_child_diff;
     long long cow_updated_time = mstime();
-
+    long long key_count = dbTotalServerKeyCount();
     while (bytes_to_write) {
         /* We write the AOF buffer in chunk of 8MB so that we can check the time in between them */
         size_t chunk_size = bytes_to_write < (8<<20) ? bytes_to_write : (8<<20);
@@ -1608,7 +1608,7 @@ int rewriteAppendOnlyFile(char *filename) {
         /* Update COW info */
         long long now = mstime();
         if (now - cow_updated_time >= 1000) {
-            sendChildInfo(CHILD_INFO_TYPE_CURRENT_INFO, dbTotalServerKeyCount(), "AOF rewrite");
+            sendChildInfo(CHILD_INFO_TYPE_CURRENT_INFO, key_count, "AOF rewrite");
             cow_updated_time = now;
         }
     }

--- a/src/aof.c
+++ b/src/aof.c
@@ -1491,7 +1491,7 @@ int rewriteAppendOnlyFileRio(rio *aof) {
                 key_count = 0;
                 long long now = mstime();
                 if (now - cow_updated_time >= 1000) {
-                    sendChildCOWInfo(CHILD_TYPE_AOF, 0, "AOF rewrite");
+                    sendChildCOWInfo(CHILD_INFO_TYPE_CURRENT_COW_SIZE, "AOF rewrite");
                     cow_updated_time = now;
                 }
             }
@@ -1610,7 +1610,7 @@ int rewriteAppendOnlyFile(char *filename) {
         /* Update COW info */
         long long now = mstime();
         if (now - cow_updated_time >= 1000) {
-            sendChildCOWInfo(CHILD_TYPE_AOF, 0, "AOF rewrite");
+            sendChildCOWInfo(CHILD_INFO_TYPE_CURRENT_COW_SIZE, "AOF rewrite");
             cow_updated_time = now;
         }
     }
@@ -1744,7 +1744,7 @@ int rewriteAppendOnlyFileBackground(void) {
         redisSetCpuAffinity(server.aof_rewrite_cpulist);
         snprintf(tmpfile,256,"temp-rewriteaof-bg-%d.aof", (int) getpid());
         if (rewriteAppendOnlyFile(tmpfile) == C_OK) {
-            sendChildCOWInfo(CHILD_TYPE_AOF, 1, "AOF rewrite");
+            sendChildCOWInfo(CHILD_INFO_TYPE_AOF_COW_SIZE, "AOF rewrite");
             exitFromChild(0);
         } else {
             exitFromChild(1);

--- a/src/childinfo.c
+++ b/src/childinfo.c
@@ -31,9 +31,8 @@
 #include <unistd.h>
 
 typedef struct {
-    int process_type;           /* AOF or RDB child? */
-    int on_exit;                /* COW size of active or exited child */
-    size_t cow_size;            /* Copy on write size. */
+    int information_type;            /* Type of information */
+    size_t info;               /* Information about the process. */
 } child_info_data;
 
 /* Open a child-parent channel used in order to move information about the
@@ -64,11 +63,11 @@ void closeChildInfoPipe(void) {
     }
 }
 
-/* Send COW data to parent. */
-void sendChildInfo(int process_type, int on_exit, size_t cow_size) {
+/* Send save data to parent. */
+void sendChildInfo(int information_type, size_t info) {
     if (server.child_info_pipe[1] == -1) return;
 
-    child_info_data buffer = {.process_type = process_type, .on_exit = on_exit, .cow_size = cow_size};
+    child_info_data buffer = {.information_type = information_type, .info = info};
     ssize_t wlen = sizeof(buffer);
 
     if (write(server.child_info_pipe[1],&buffer,wlen) != wlen) {
@@ -76,27 +75,26 @@ void sendChildInfo(int process_type, int on_exit, size_t cow_size) {
     }
 }
 
-/* Update COW data. */
-void updateChildInfo(int process_type, int on_exit, size_t cow_size) {
-    if (!on_exit) {
-        server.stat_current_cow_bytes = cow_size;
-        return;
-    }
-
-    if (process_type == CHILD_TYPE_RDB) {
-        server.stat_rdb_cow_bytes = cow_size;
-    } else if (process_type == CHILD_TYPE_AOF) {
-        server.stat_aof_cow_bytes = cow_size;
-    } else if (process_type == CHILD_TYPE_MODULE) {
-        server.stat_module_cow_bytes = cow_size;
+/* Update Child info. */
+void updateChildInfo(int information_type, size_t info) {
+    if (information_type == CHILD_INFO_TYPE_CURRENT_COW_SIZE) {
+        server.stat_current_cow_bytes = info;
+    } else if (information_type == CHILD_INFO_TYPE_CURRENT_KEYS_PROCESSED) {
+        server.stat_current_processed_keys = info;
+    } else if (information_type == CHILD_INFO_TYPE_AOF_COW_SIZE) {
+        server.stat_aof_cow_bytes = info;
+    } else if (information_type == CHILD_INFO_TYPE_RDB_COW_SIZE) {
+        server.stat_rdb_cow_bytes = info;
+    } else if (information_type == CHILD_INFO_TYPE_MODULE_COW_SIZE) {
+        server.stat_module_cow_bytes = info;
     }
 }
 
-/* Read COW info data from the pipe.
+/* Read child info data from the pipe.
  * if complete data read into the buffer, process type, copy-on-write type and copy-on-write size
- * are stored into *process_type, *on_exit and *cow_size respectively and returns 1.
+ * are stored into *information_type, and *info respectively and returns 1.
  * otherwise, the partial data is left in the buffer, waiting for the next read, and returns 0. */
-int readChildInfo(int *process_type, int *on_exit, size_t *cow_size) {
+int readChildInfo(int *information_type, size_t *info) {
     /* We are using here a static buffer in combination with the server.child_info_nread to handle short reads */
     static child_info_data buffer;
     ssize_t wlen = sizeof(buffer);
@@ -111,25 +109,23 @@ int readChildInfo(int *process_type, int *on_exit, size_t *cow_size) {
 
     /* We have complete child info */
     if (server.child_info_nread == wlen) {
-        *process_type = buffer.process_type;
-        *on_exit = buffer.on_exit;
-        *cow_size = buffer.cow_size;
+        *information_type = buffer.information_type;
+        *info = buffer.info;
         return 1;
     } else {
         return 0;
     }
 }
 
-/* Receive COW data from child. */
+/* Receive info data from child. */
 void receiveChildInfo(void) {
     if (server.child_info_pipe[0] == -1) return;
 
-    int process_type;
-    int on_exit;
-    size_t cow_size;
+    int information_type;
+    size_t info;
 
     /* Drain the pipe and update child info so that we get the final message. */
-    while (readChildInfo(&process_type, &on_exit, &cow_size)) {
-        updateChildInfo(process_type, on_exit, cow_size);
+    while (readChildInfo(&information_type, &info)) {
+        updateChildInfo(information_type, info);
     }
 }

--- a/src/childinfo.c
+++ b/src/childinfo.c
@@ -63,7 +63,7 @@ void updateChildInfo(child_info_data *data) {
     if (data->information_type == CHILD_INFO_TYPE_CURRENT_INFO) {
         server.stat_current_cow_bytes = data->cow;
         server.stat_current_save_keys_processed = data->keys;
-        if (data->progress != -1) server.stat_module_save_progress = data->progress;
+        if (data->progress != -1) server.stat_module_progress = data->progress;
     } else if (data->information_type == CHILD_INFO_TYPE_AOF_COW_SIZE) {
         server.stat_aof_cow_bytes = data->cow;
     } else if (data->information_type == CHILD_INFO_TYPE_RDB_COW_SIZE) {

--- a/src/childinfo.c
+++ b/src/childinfo.c
@@ -101,7 +101,7 @@ int readChildInfo(child_info_data *buffer) {
 void receiveChildInfo(void) {
     if (server.child_info_pipe[0] == -1) return;
 
-    child_info_data data = {0};
+    static child_info_data data;
 
     /* Drain the pipe and update child info so that we get the final message. */
     while (readChildInfo(&data)) {

--- a/src/childinfo.c
+++ b/src/childinfo.c
@@ -61,8 +61,9 @@ void closeChildInfoPipe(void) {
 /* Update Child info. */
 void updateChildInfo(child_info_data *data) {
     if (data->information_type == CHILD_INFO_TYPE_CURRENT_INFO) {
-        if (data->cow) server.stat_current_cow_bytes = data->cow;
-        if (data->keys) server.stat_current_save_keys_processed = data->keys;
+        server.stat_current_cow_bytes = data->cow;
+        server.stat_current_save_keys_processed = data->keys;
+        if (data->progress != -1) server.stat_module_save_progress = data->progress;
     } else if (data->information_type == CHILD_INFO_TYPE_AOF_COW_SIZE) {
         server.stat_aof_cow_bytes = data->cow;
     } else if (data->information_type == CHILD_INFO_TYPE_RDB_COW_SIZE) {

--- a/src/module.c
+++ b/src/module.c
@@ -7097,15 +7097,15 @@ int RM_Fork(RedisModuleForkDoneHandler cb, void *user_data) {
 
 /* The module is advised to call this function from the fork child once in a while,
  * so that it can report COW memory to the parent which will be reported in INFO */
-void RM_SendChildCOWInfo(void) {
-    sendChildInfo(CHILD_INFO_TYPE_CURRENT_INFO, 0, "Module fork");
+void RM_ForkChildHeartbeat(double progress) {
+    sendChildInfoGeneric(CHILD_INFO_TYPE_CURRENT_INFO, 0, progress, "Module fork");
 }
 
 /* Call from the child process when you want to terminate it.
  * retcode will be provided to the done handler executed on the parent process.
  */
 int RM_ExitFromChild(int retcode) {
-    sendChildInfo(CHILD_INFO_TYPE_MODULE_COW_SIZE, 0, "Module fork");
+    sendChildCowInfo(CHILD_INFO_TYPE_MODULE_COW_SIZE, "Module fork");
     exitFromChild(retcode);
     return REDISMODULE_OK;
 }
@@ -8616,7 +8616,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(CommandFilterArgReplace);
     REGISTER_API(CommandFilterArgDelete);
     REGISTER_API(Fork);
-    REGISTER_API(SendChildCOWInfo);
+    REGISTER_API(ForkChildHeartbeat);
     REGISTER_API(ExitFromChild);
     REGISTER_API(KillForkChild);
     REGISTER_API(RegisterInfoFunc);

--- a/src/module.c
+++ b/src/module.c
@@ -7096,7 +7096,9 @@ int RM_Fork(RedisModuleForkDoneHandler cb, void *user_data) {
 }
 
 /* The module is advised to call this function from the fork child once in a while,
- * so that it can report COW memory to the parent which will be reported in INFO */
+ * so that it can report progress and COW memory to the parent which will be
+ * reported in INFO.
+ * The `progress` argument should between 0 and 1, or -1 when not available. */
 void RM_ForkChildHeartbeat(double progress) {
     sendChildInfoGeneric(CHILD_INFO_TYPE_CURRENT_INFO, 0, progress, "Module fork");
 }

--- a/src/module.c
+++ b/src/module.c
@@ -7099,7 +7099,7 @@ int RM_Fork(RedisModuleForkDoneHandler cb, void *user_data) {
  * so that it can report progress and COW memory to the parent which will be
  * reported in INFO.
  * The `progress` argument should between 0 and 1, or -1 when not available. */
-void RM_ForkChildHeartbeat(double progress) {
+void RM_SendChildHeartbeat(double progress) {
     sendChildInfoGeneric(CHILD_INFO_TYPE_CURRENT_INFO, 0, progress, "Module fork");
 }
 
@@ -8618,7 +8618,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(CommandFilterArgReplace);
     REGISTER_API(CommandFilterArgDelete);
     REGISTER_API(Fork);
-    REGISTER_API(ForkChildHeartbeat);
+    REGISTER_API(SendChildHeartbeat);
     REGISTER_API(ExitFromChild);
     REGISTER_API(KillForkChild);
     REGISTER_API(RegisterInfoFunc);

--- a/src/module.c
+++ b/src/module.c
@@ -7098,14 +7098,14 @@ int RM_Fork(RedisModuleForkDoneHandler cb, void *user_data) {
 /* The module is advised to call this function from the fork child once in a while,
  * so that it can report COW memory to the parent which will be reported in INFO */
 void RM_SendChildCOWInfo(void) {
-    sendChildCOWInfo(CHILD_INFO_TYPE_CURRENT_COW_SIZE, "Module fork");
+    sendChildInfo(CHILD_INFO_TYPE_CURRENT_INFO, 0, "Module fork");
 }
 
 /* Call from the child process when you want to terminate it.
  * retcode will be provided to the done handler executed on the parent process.
  */
 int RM_ExitFromChild(int retcode) {
-    sendChildCOWInfo(CHILD_INFO_TYPE_MODULE_COW_SIZE, "Module fork");
+    sendChildInfo(CHILD_INFO_TYPE_MODULE_COW_SIZE, 0, "Module fork");
     exitFromChild(retcode);
     return REDISMODULE_OK;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -7098,14 +7098,14 @@ int RM_Fork(RedisModuleForkDoneHandler cb, void *user_data) {
 /* The module is advised to call this function from the fork child once in a while,
  * so that it can report COW memory to the parent which will be reported in INFO */
 void RM_SendChildCOWInfo(void) {
-    sendChildCOWInfo(CHILD_TYPE_MODULE, 0, "Module fork");
+    sendChildCOWInfo(CHILD_INFO_TYPE_CURRENT_COW_SIZE, "Module fork");
 }
 
 /* Call from the child process when you want to terminate it.
  * retcode will be provided to the done handler executed on the parent process.
  */
 int RM_ExitFromChild(int retcode) {
-    sendChildCOWInfo(CHILD_TYPE_MODULE, 1, "Module fork");
+    sendChildCOWInfo(CHILD_INFO_TYPE_MODULE_COW_SIZE, "Module fork");
     exitFromChild(retcode);
     return REDISMODULE_OK;
 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1223,7 +1223,8 @@ int rdbSaveRio(rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi) {
     size_t processed = 0;
     int j;
     long key_count = 0;
-    long long cow_updated_time = 0;
+    long long info_updated_time = 0;
+    char *pname = (rdbflags & RDBFLAGS_AOF_PREAMBLE) ? "AOF rewrite" :  "RDB";
 
     if (server.rdb_checksum)
         rdb->update_cksum = rioGenericUpdateChecksum;
@@ -1270,22 +1271,17 @@ int rdbSaveRio(rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi) {
                 aofReadDiffFromParent();
             }
 
-            /* Update COW info every 1 second (approximately).
+            /* Update child info every 1 second (approximately).
              * in order to avoid calling mstime() on each iteration, we will
              * check the diff every 1024 keys */
-            if ((key_count & 1023) == 0) {
-                key_count = 0;
+            if ((key_count++ % 1024) == 0) {
                 long long now = mstime();
-                if (now - cow_updated_time >= 1000) {
-                    if (rdbflags & RDBFLAGS_AOF_PREAMBLE) {
-                        sendChildCOWInfo(CHILD_TYPE_AOF, 0, "AOF rewrite");
-                    } else {
-                        sendChildCOWInfo(CHILD_TYPE_RDB, 0, "RDB");
-                    }
-                    cow_updated_time = now;
+                if (now - info_updated_time >= 1000) {
+                    sendChildInfo(CHILD_INFO_TYPE_CURRENT_KEYS_PROCESSED, key_count);
+                    sendChildCOWInfo(CHILD_INFO_TYPE_CURRENT_COW_SIZE, pname);
+                    info_updated_time = now;
                 }
             }
-            key_count++;
         }
         dictReleaseIterator(di);
         di = NULL; /* So that we don't release it again on error. */
@@ -1438,7 +1434,7 @@ int rdbSaveBackground(char *filename, rdbSaveInfo *rsi) {
         redisSetCpuAffinity(server.bgsave_cpulist);
         retval = rdbSave(filename,rsi);
         if (retval == C_OK) {
-            sendChildCOWInfo(CHILD_TYPE_RDB, 1, "RDB");
+            sendChildCOWInfo(CHILD_INFO_TYPE_RDB_COW_SIZE, "RDB");
         }
         exitFromChild((retval == C_OK) ? 0 : 1);
     } else {
@@ -1450,6 +1446,7 @@ int rdbSaveBackground(char *filename, rdbSaveInfo *rsi) {
             return C_ERR;
         }
         serverLog(LL_NOTICE,"Background saving started by pid %ld",(long) childpid);
+        server.stat_keys_on_bgsave_start = dbTotalServerKeyCount();
         server.rdb_save_time_start = time(NULL);
         server.rdb_child_type = RDB_CHILD_TYPE_DISK;
         return C_OK;
@@ -2805,7 +2802,7 @@ int rdbSaveToSlavesSockets(rdbSaveInfo *rsi) {
             retval = C_ERR;
 
         if (retval == C_OK) {
-            sendChildCOWInfo(CHILD_TYPE_RDB, 1, "RDB");
+            sendChildCOWInfo(CHILD_INFO_TYPE_RDB_COW_SIZE, "RDB");
         }
 
         rioFreeFd(&rdb);
@@ -2845,6 +2842,7 @@ int rdbSaveToSlavesSockets(rdbSaveInfo *rsi) {
                 (long) childpid);
             server.rdb_save_time_start = time(NULL);
             server.rdb_child_type = RDB_CHILD_TYPE_SOCKET;
+            server.stat_keys_on_bgsave_start = dbTotalServerKeyCount();
             close(rdb_pipe_write); /* close write in parent so that it can detect the close on the child. */
             if (aeCreateFileEvent(server.el, server.rdb_pipe_read, AE_READABLE, rdbPipeReadHandler,NULL) == AE_ERR) {
                 serverPanic("Unrecoverable error creating server.rdb_pipe_read file event.");

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1433,7 +1433,7 @@ int rdbSaveBackground(char *filename, rdbSaveInfo *rsi) {
         redisSetCpuAffinity(server.bgsave_cpulist);
         retval = rdbSave(filename,rsi);
         if (retval == C_OK) {
-            sendChildInfo(CHILD_INFO_TYPE_RDB_COW_SIZE, 0, "RDB");
+            sendChildCowInfo(CHILD_INFO_TYPE_RDB_COW_SIZE, "RDB");
         }
         exitFromChild((retval == C_OK) ? 0 : 1);
     } else {
@@ -2800,7 +2800,7 @@ int rdbSaveToSlavesSockets(rdbSaveInfo *rsi) {
             retval = C_ERR;
 
         if (retval == C_OK) {
-            sendChildInfo(CHILD_INFO_TYPE_RDB_COW_SIZE, 0, "RDB");
+            sendChildCowInfo(CHILD_INFO_TYPE_RDB_COW_SIZE, "RDB");
         }
 
         rioFreeFd(&rdb);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -778,7 +778,7 @@ REDISMODULE_API int (*RedisModule_CommandFilterArgInsert)(RedisModuleCommandFilt
 REDISMODULE_API int (*RedisModule_CommandFilterArgReplace)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CommandFilterArgDelete)(RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_Fork)(RedisModuleForkDoneHandler cb, void *user_data) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ForkChildHeartbeat)(double progress) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SendChildHeartbeat)(double progress) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExitFromChild)(int retcode) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_KillForkChild)(int child_pid) REDISMODULE_ATTR;
 REDISMODULE_API float (*RedisModule_GetUsedMemoryRatio)() REDISMODULE_ATTR;
@@ -1034,7 +1034,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(CommandFilterArgReplace);
     REDISMODULE_GET_API(CommandFilterArgDelete);
     REDISMODULE_GET_API(Fork);
-    REDISMODULE_GET_API(ForkChildHeartbeat);
+    REDISMODULE_GET_API(SendChildHeartbeat);
     REDISMODULE_GET_API(ExitFromChild);
     REDISMODULE_GET_API(KillForkChild);
     REDISMODULE_GET_API(GetUsedMemoryRatio);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -778,7 +778,7 @@ REDISMODULE_API int (*RedisModule_CommandFilterArgInsert)(RedisModuleCommandFilt
 REDISMODULE_API int (*RedisModule_CommandFilterArgReplace)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CommandFilterArgDelete)(RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_Fork)(RedisModuleForkDoneHandler cb, void *user_data) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SendChildCOWInfo)(void) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_ForkChildHeartbeat)(void) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExitFromChild)(int retcode) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_KillForkChild)(int child_pid) REDISMODULE_ATTR;
 REDISMODULE_API float (*RedisModule_GetUsedMemoryRatio)() REDISMODULE_ATTR;
@@ -1034,7 +1034,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(CommandFilterArgReplace);
     REDISMODULE_GET_API(CommandFilterArgDelete);
     REDISMODULE_GET_API(Fork);
-    REDISMODULE_GET_API(SendChildCOWInfo);
+    REDISMODULE_GET_API(ForkChildHeartbeat);
     REDISMODULE_GET_API(ExitFromChild);
     REDISMODULE_GET_API(KillForkChild);
     REDISMODULE_GET_API(GetUsedMemoryRatio);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -778,7 +778,7 @@ REDISMODULE_API int (*RedisModule_CommandFilterArgInsert)(RedisModuleCommandFilt
 REDISMODULE_API int (*RedisModule_CommandFilterArgReplace)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CommandFilterArgDelete)(RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_Fork)(RedisModuleForkDoneHandler cb, void *user_data) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ForkChildHeartbeat)(void) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_ForkChildHeartbeat)(double progress) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExitFromChild)(int retcode) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_KillForkChild)(int child_pid) REDISMODULE_ATTR;
 REDISMODULE_API float (*RedisModule_GetUsedMemoryRatio)() REDISMODULE_ATTR;

--- a/src/server.c
+++ b/src/server.c
@@ -5593,28 +5593,6 @@ int redisFork(int purpose) {
     return childpid;
 }
 
-/* Send save data to parent. */
-void sendChildInfoGeneric(childInfoType info_type, size_t keys, double progress, char *pname) {
-    if (server.child_info_pipe[1] == -1) return;
-
-    child_info_data data = {.information_type=info_type,
-                            .keys=keys,
-                            .cow=zmalloc_get_private_dirty(-1),
-                            .progress=progress};
-
-    if (data.cow) {
-        serverLog((info_type == CHILD_INFO_TYPE_CURRENT_INFO) ? LL_VERBOSE : LL_NOTICE,
-            "%s: %zu MB of memory used by copy-on-write",
-            pname, data.cow/(1024*1024));
-    }
-
-    ssize_t wlen = sizeof(data);
-
-    if (write(server.child_info_pipe[1], &data, wlen) != wlen) {
-        /* Nothing to do on error, this will be detected by the other side. */
-    }
-}
-
 void sendChildCowInfo(childInfoType info_type, char *pname) {
     sendChildInfoGeneric(info_type, 0, -1, pname);
 }

--- a/src/server.c
+++ b/src/server.c
@@ -4694,7 +4694,7 @@ sds genRedisInfoString(const char *section) {
             "# Persistence\r\n"
             "loading:%d\r\n"
             "current_cow_size:%zu\r\n"
-            "current_fork_perc:%.2f\r\n"
+            "current_fork_perc:%.2f%%\r\n"
             "current_save_keys_processed:%zu\r\n"
             "current_save_keys_total:%zu\r\n"
             "rdb_changes_since_last_save:%lld\r\n"

--- a/src/server.c
+++ b/src/server.c
@@ -5595,8 +5595,11 @@ void sendChildInfo(childInfoType info_type, size_t keys, char *pname) {
             pname, data.cow/(1024*1024));
     }
 
-    write(server.child_info_pipe[1], &data, sizeof(data));
-    /* Nothing to do on write error, this will be detected by the other side. */
+    ssize_t wlen = sizeof(data);
+
+    if (write(server.child_info_pipe[1], &data, wlen) != wlen) {
+        /* Nothing to do on error, this will be detected by the other side. */
+    }
 }
 
 void memtest(size_t megabytes, int passes);

--- a/src/server.c
+++ b/src/server.c
@@ -4685,7 +4685,7 @@ sds genRedisInfoString(const char *section) {
         if (sections++) info = sdscat(info,"\r\n");
         double fork_perc = 0;
         if (server.stat_module_progress) {
-            fork_perc = server.stat_module_progress;
+            fork_perc = server.stat_module_progress * 100;
         } else if (server.stat_current_save_keys_total) {
             fork_perc = ((double)server.stat_current_save_keys_processed / server.stat_current_save_keys_total) * 100;
         }
@@ -4694,7 +4694,7 @@ sds genRedisInfoString(const char *section) {
             "# Persistence\r\n"
             "loading:%d\r\n"
             "current_cow_size:%zu\r\n"
-            "current_fork_perc:%f\r\n"
+            "current_fork_perc:%.2f\r\n"
             "current_save_keys_processed:%zu\r\n"
             "current_save_keys_total:%zu\r\n"
             "rdb_changes_since_last_save:%lld\r\n"

--- a/src/server.h
+++ b/src/server.h
@@ -1130,8 +1130,7 @@ struct clusterState;
 #define CHILD_TYPE_MODULE 4
 
 typedef enum childInfoType {
-    CHILD_INFO_TYPE_CURRENT_KEYS_PROCESSED,
-    CHILD_INFO_TYPE_CURRENT_COW_SIZE,
+    CHILD_INFO_TYPE_CURRENT_INFO,
     CHILD_INFO_TYPE_AOF_COW_SIZE,
     CHILD_INFO_TYPE_RDB_COW_SIZE,
     CHILD_INFO_TYPE_MODULE_COW_SIZE
@@ -1265,8 +1264,8 @@ struct redisServer {
     redisAtomic long long stat_net_input_bytes; /* Bytes read from network. */
     redisAtomic long long stat_net_output_bytes; /* Bytes written to network. */
     size_t stat_current_cow_bytes;  /* Copy on write bytes while child is active. */
-    size_t stat_current_processed_keys;  /* Processed keys while child is active. */
-    size_t stat_keys_on_bgsave_start;  /* Number of keys when child started. */
+    size_t stat_current_save_keys_processed;  /* Processed keys while child is active. */
+    size_t stat_current_save_keys_total;  /* Number of keys when child started. */
     size_t stat_rdb_cow_bytes;      /* Copy on write bytes during RDB saving. */
     size_t stat_aof_cow_bytes;      /* Copy on write bytes during AOF rewrite. */
     size_t stat_module_cow_bytes;   /* Copy on write bytes during module fork. */
@@ -1686,6 +1685,12 @@ typedef struct {
     dictEntry *de;
 } hashTypeIterator;
 
+typedef struct {
+    size_t keys;
+    size_t cow;
+    childInfoType information_type; /* Type of information */
+} child_info_data;
+
 #include "stream.h"  /* Stream data type header file. */
 
 #define OBJ_HASH_KEY 1
@@ -2042,7 +2047,7 @@ void restartAOFAfterSYNC();
 /* Child info */
 void openChildInfoPipe(void);
 void closeChildInfoPipe(void);
-void sendChildInfo(int information_type, size_t cow_size);
+void sendChildInfo(childInfoType info_type, size_t keys, char *pname);
 void receiveChildInfo(void);
 
 /* Fork helpers */
@@ -2050,7 +2055,6 @@ int redisFork(int type);
 int hasActiveChildProcess();
 void resetChildState();
 int isMutuallyExclusiveChildType(int type);
-void sendChildCOWInfo(int ptype, char *pname);
 
 /* acl.c -- Authentication related prototypes. */
 extern rax *Users;

--- a/src/server.h
+++ b/src/server.h
@@ -1269,6 +1269,7 @@ struct redisServer {
     size_t stat_rdb_cow_bytes;      /* Copy on write bytes during RDB saving. */
     size_t stat_aof_cow_bytes;      /* Copy on write bytes during AOF rewrite. */
     size_t stat_module_cow_bytes;   /* Copy on write bytes during module fork. */
+    double stat_module_save_progress;   /* Module save progress. */
     uint64_t stat_clients_type_memory[CLIENT_TYPE_COUNT];/* Mem usage by type */
     long long stat_unexpected_error_replies; /* Number of unexpected (aof-loading, replica to master, etc.) error replies */
     long long stat_total_error_replies; /* Total number of issued error replies ( command + rejected errors ) */
@@ -1688,6 +1689,7 @@ typedef struct {
 typedef struct {
     size_t keys;
     size_t cow;
+    double progress;
     childInfoType information_type; /* Type of information */
 } child_info_data;
 
@@ -2047,6 +2049,8 @@ void restartAOFAfterSYNC();
 /* Child info */
 void openChildInfoPipe(void);
 void closeChildInfoPipe(void);
+void sendChildInfoGeneric(childInfoType info_type, size_t keys, double progress, char *pname);
+void sendChildCowInfo(childInfoType info_type, char *pname);
 void sendChildInfo(childInfoType info_type, size_t keys, char *pname);
 void receiveChildInfo(void);
 

--- a/src/server.h
+++ b/src/server.h
@@ -1129,6 +1129,14 @@ struct clusterState;
 #define CHILD_TYPE_LDB 3
 #define CHILD_TYPE_MODULE 4
 
+typedef enum childInfoType {
+    CHILD_INFO_TYPE_CURRENT_KEYS_PROCESSED,
+    CHILD_INFO_TYPE_CURRENT_COW_SIZE,
+    CHILD_INFO_TYPE_AOF_COW_SIZE,
+    CHILD_INFO_TYPE_RDB_COW_SIZE,
+    CHILD_INFO_TYPE_MODULE_COW_SIZE
+} childInfoType;
+
 struct redisServer {
     /* General */
     pid_t pid;                  /* Main process pid. */
@@ -1257,6 +1265,8 @@ struct redisServer {
     redisAtomic long long stat_net_input_bytes; /* Bytes read from network. */
     redisAtomic long long stat_net_output_bytes; /* Bytes written to network. */
     size_t stat_current_cow_bytes;  /* Copy on write bytes while child is active. */
+    size_t stat_current_processed_keys;  /* Processed keys while child is active. */
+    size_t stat_keys_on_bgsave_start;  /* Number of keys when child started. */
     size_t stat_rdb_cow_bytes;      /* Copy on write bytes during RDB saving. */
     size_t stat_aof_cow_bytes;      /* Copy on write bytes during AOF rewrite. */
     size_t stat_module_cow_bytes;   /* Copy on write bytes during module fork. */
@@ -2032,7 +2042,7 @@ void restartAOFAfterSYNC();
 /* Child info */
 void openChildInfoPipe(void);
 void closeChildInfoPipe(void);
-void sendChildInfo(int process_type, int on_exit, size_t cow_size);
+void sendChildInfo(int information_type, size_t cow_size);
 void receiveChildInfo(void);
 
 /* Fork helpers */
@@ -2040,7 +2050,7 @@ int redisFork(int type);
 int hasActiveChildProcess();
 void resetChildState();
 int isMutuallyExclusiveChildType(int type);
-void sendChildCOWInfo(int ptype, int on_exit, char *pname);
+void sendChildCOWInfo(int ptype, char *pname);
 
 /* acl.c -- Authentication related prototypes. */
 extern rax *Users;

--- a/src/server.h
+++ b/src/server.h
@@ -1686,13 +1686,6 @@ typedef struct {
     dictEntry *de;
 } hashTypeIterator;
 
-typedef struct {
-    size_t keys;
-    size_t cow;
-    double progress;
-    childInfoType information_type; /* Type of information */
-} child_info_data;
-
 #include "stream.h"  /* Stream data type header file. */
 
 #define OBJ_HASH_KEY 1

--- a/src/server.h
+++ b/src/server.h
@@ -1269,7 +1269,7 @@ struct redisServer {
     size_t stat_rdb_cow_bytes;      /* Copy on write bytes during RDB saving. */
     size_t stat_aof_cow_bytes;      /* Copy on write bytes during AOF rewrite. */
     size_t stat_module_cow_bytes;   /* Copy on write bytes during module fork. */
-    double stat_module_save_progress;   /* Module save progress. */
+    double stat_module_progress;   /* Module save progress. */
     uint64_t stat_clients_type_memory[CLIENT_TYPE_COUNT];/* Mem usage by type */
     long long stat_unexpected_error_replies; /* Number of unexpected (aof-loading, replica to master, etc.) error replies */
     long long stat_total_error_replies; /* Total number of issued error replies ( command + rejected errors ) */

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -263,7 +263,9 @@ start_server {overrides {save ""}} {
             # wait to see that current_cow_size value updated (as long as the child is in progress)
             wait_for_condition 80 100 {
                 [s rdb_bgsave_in_progress] == 0 ||
-                [s current_cow_size] >= $cow_size + $size && [s current_save_keys_processed] > $keys_processed
+                [s current_cow_size] >= $cow_size + $size && 
+                [s current_save_keys_processed] > $keys_processed &&
+                [s current_fork_perc] > 0
             } else {
                 if {$::verbose} {
                     puts "COW info on fail: [s current_cow_size]"


### PR DESCRIPTION
Extend send data from child processes back to the parent to also send the current status of the BGSave (number of keys processed).
This will allow us to see the progress of the save process.