### PR TITLE
temporarily disable sentinel test FD leak print

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -431,9 +431,9 @@ proc run_tests {} {
 proc end_tests {} {
     set sentinel_fd_leaks_file "sentinel_fd_leaks"
     if { [file exists $sentinel_fd_leaks_file] } {
-        puts [colorstr red "WARNING: sentinel test(s) failed, there are leaked fds in sentinel:"] 
-        puts [exec cat $sentinel_fd_leaks_file]
         # temporarily disabling this error from failing the tests until leaks are fixed.
+        #puts [colorstr red "WARNING: sentinel test(s) failed, there are leaked fds in sentinel:"] 
+        #puts [exec cat $sentinel_fd_leaks_file]
         #exit 1
     }
 


### PR DESCRIPTION
Temporarily disabling this print until #8383 is solved and merged.
I rather these error message not show up for now when people run the tests.