### PR TITLE
[WIP] replication: handling PINGs as out-of-band data

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -225,8 +225,13 @@ void replicationFeedSlaves(list *slaves, int dictid, robj **argv, int argc, int 
      * the stream of data we receive from our master instead, in order to
      * propagate *identical* replication stream. In this way this slave can
      * advertise the same replication ID as the master (since it shares the
-     * master replication history and has the same backlog and offsets). */
-    if (server.masterhost != NULL) return;
+     * master replication history and has the same backlog and offsets).
+     *
+     * Unless it is out of replication, it means these data would not affect
+     * backlog and offsets. Because the replica do not proxy PINGs received
+     * from master to sub-replicas to keep alive, so replica need send PINGs
+     * in replicationCron by itself to keep alive. */
+    if (server.masterhost != NULL && !out_of_repl) return;
 
     /* If there aren't slaves, and there is no backlog buffer to populate,
      * we can return ASAP. */

--- a/src/server.h
+++ b/src/server.h
@@ -340,8 +340,9 @@ typedef enum {
 
 /* Slave capabilities. */
 #define SLAVE_CAPA_NONE 0
-#define SLAVE_CAPA_EOF (1<<0)    /* Can parse the RDB EOF streaming format. */
-#define SLAVE_CAPA_PSYNC2 (1<<1) /* Supports PSYNC2 protocol. */
+#define SLAVE_CAPA_EOF (1<<0)      /* Can parse the RDB EOF streaming format. */
+#define SLAVE_CAPA_PSYNC2 (1<<1)   /* Supports PSYNC2 protocol. */
+#define SLAVE_CAPA_PING_OOB (1<<2) /* Supports handle PING out-of-band. */
 
 /* Synchronous read timeout - slave side */
 #define CONFIG_REPL_SYNCIO_TIMEOUT 5

--- a/src/server.h
+++ b/src/server.h
@@ -183,6 +183,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CMD_FAST (1ULL<<14)            /* "fast" flag */
 #define CMD_NO_AUTH (1ULL<<15)         /* "no-auth" flag */
 #define CMD_MAY_REPLICATE (1ULL<<16)   /* "may-replicate" flag */
+#define CMD_OUT_OF_REPL (1ULL<<17)     /* "out-of-replication" flag */
 
 /* Command flags used by the module system. */
 #define CMD_MODULE_GETKEYS (1ULL<<17)  /* Use the modules getkeys interface. */
@@ -1983,7 +1984,7 @@ ssize_t syncRead(int fd, char *ptr, ssize_t size, long long timeout);
 ssize_t syncReadLine(int fd, char *ptr, ssize_t size, long long timeout);
 
 /* Replication */
-void replicationFeedSlaves(list *slaves, int dictid, robj **argv, int argc);
+void replicationFeedSlaves(list *slaves, int dictid, robj **argv, int argc, int out_of_repl);
 void replicationFeedSlavesFromMasterStream(list *slaves, char *buf, size_t buflen);
 void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv, int argc);
 void updateSlavesWaitingBgsave(int bgsaveerr, int type);


### PR DESCRIPTION
This feature tries to handle PINGs as out-of-band data in replication stream. The main idea and implementation is simple:

1. master just propagate PINGs to replica client's reply buffer, but do not feed replication backlog, then the replication offset would not be affected.

2. when replica receive PINGs, just execute it to keep alive, but do not increase the master client's `reploff`, then the replica can have the same offset with master. And do not proxy the PINGs to it's sub-replicas, just remove PINGs from replication stream.

3. now replica do not proxy PINGs, so it should send PINGs to sub-replicas by itself.

4. master accept replica only when it support this feature, or the replication offset will be wrong, so replica need send `replconf capa ping-out-of-band` to master.