### PR TITLE
Modules: In RM_HashSet, add COUNT_ALL flag and set errno

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -32,6 +32,7 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/getkeys \
 --single unit/moduleapi/test_lazyfree \
 --single unit/moduleapi/defrag \
+--single unit/moduleapi/hash \
 --single unit/moduleapi/zset \
 --single unit/moduleapi/stream \
 "${@}"

--- a/src/module.c
+++ b/src/module.c
@@ -3008,9 +3008,9 @@ int RM_ZsetRangePrev(RedisModuleKey *key) {
  *   were just created and the COUNT_ALL flag was unset, or if changes were held
  *   back due to the NX and XX flags.
  *
- * NOTICE: The return value semantics of this function is very different between
- * Redis 6.2 and older versions. Modules that use it should determine the Redis
- * version and handle it accordingly.
+ * NOTICE: The return value semantics of this function are very different
+ * between Redis 6.2 and older versions. Modules that use it should determine
+ * the Redis version and handle it accordingly.
  */
 int RM_HashSet(RedisModuleKey *key, int flags, ...) {
     va_list ap;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -68,7 +68,7 @@
 #define REDISMODULE_HASH_XX         (1<<1)
 #define REDISMODULE_HASH_CFIELDS    (1<<2)
 #define REDISMODULE_HASH_EXISTS     (1<<3)
-#define REDISMODULE_HASH_COUNT_INSERTS (1<<4)
+#define REDISMODULE_HASH_COUNT_ALL  (1<<4)
 
 /* StreamID type. */
 typedef struct RedisModuleStreamID {

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -68,6 +68,7 @@
 #define REDISMODULE_HASH_XX         (1<<1)
 #define REDISMODULE_HASH_CFIELDS    (1<<2)
 #define REDISMODULE_HASH_EXISTS     (1<<3)
+#define REDISMODULE_HASH_COUNT_INSERTS (1<<4)
 
 /* StreamID type. */
 typedef struct RedisModuleStreamID {

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -35,6 +35,7 @@ TEST_MODULES = \
     test_lazyfree.so \
     timer.so \
     defragtest.so \
+    hash.so \
     zset.so \
     stream.so
 

--- a/tests/modules/hash.c
+++ b/tests/modules/hash.c
@@ -15,7 +15,7 @@ static RedisModuleString *value_or_delete(RedisModuleString *s) {
 /* HASH.SET key flags field1 value1 [field2 value2 ..]
  *
  * Sets 1-4 fields. Returns the same as RedisModule_HashSet().
- * Flags is a string of "nxi" where n = NX, x = XX, i = count inserts.
+ * Flags is a string of "nxa" where n = NX, x = XX, a = COUNT_ALL.
  * To delete a field, use the value ":delete:".
  */
 int hash_set(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -32,11 +32,11 @@ int hash_set(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         switch (flags_str[i]) {
         case 'n': flags |= REDISMODULE_HASH_NX; break;
         case 'x': flags |= REDISMODULE_HASH_XX; break;
-        case 'i': flags |= REDISMODULE_HASH_COUNT_INSERTS; break;
+        case 'a': flags |= REDISMODULE_HASH_COUNT_ALL; break;
         }
     }
 
-    /* This is why varargs sucks... */
+    /* Test some varargs. (In real-world, use a loop and set one at a time.) */
     int result;
     errno = 0;
     if (argc == 5) {

--- a/tests/modules/hash.c
+++ b/tests/modules/hash.c
@@ -66,16 +66,11 @@ int hash_set(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
 
     /* Check errno */
-    if (errno == ENOTSUP) {
-        RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
-    } else if (flags & REDISMODULE_HASH_COUNT_INSERTS) {
-        int numfields = (argc - 3) / 2;
-        if (result != numfields) {
-            if (flags & REDISMODULE_HASH_NX)
-                RedisModule_Assert(errno == EEXIST);
-            if (flags & REDISMODULE_HASH_XX)
-                RedisModule_Assert(errno == ENOENT);
-        }
+    if (result == 0) {
+        if (errno == ENOTSUP)
+            return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+        else
+            RedisModule_Assert(errno == ENOENT);
     }
 
     return RedisModule_ReplyWithLongLong(ctx, result);

--- a/tests/modules/hash.c
+++ b/tests/modules/hash.c
@@ -1,0 +1,95 @@
+#include "redismodule.h"
+#include <strings.h>
+#include <errno.h>
+#include <stdlib.h>
+
+/* If a string is ":deleted:", the special value for deleted hash fields is
+ * returned; otherwise the input string is returned. */
+static RedisModuleString *value_or_delete(RedisModuleString *s) {
+    if (!strcasecmp(RedisModule_StringPtrLen(s, NULL), ":delete:"))
+        return REDISMODULE_HASH_DELETE;
+    else
+        return s;
+}
+
+/* HASH.SET key flags field1 value1 [field2 value2 ..]
+ *
+ * Sets 1-4 fields. Returns the same as RedisModule_HashSet().
+ * Flags is a string of "nxi" where n = NX, x = XX, i = count inserts.
+ * To delete a field, use the value ":delete:".
+ */
+int hash_set(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 5 || argc % 2 == 0 || argc > 11)
+        return RedisModule_WrongArity(ctx);
+
+    RedisModule_AutoMemory(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
+
+    size_t flags_len;
+    const char *flags_str = RedisModule_StringPtrLen(argv[2], &flags_len);
+    int flags = REDISMODULE_HASH_NONE;
+    for (size_t i = 0; i < flags_len; i++) {
+        switch (flags_str[i]) {
+        case 'n': flags |= REDISMODULE_HASH_NX; break;
+        case 'x': flags |= REDISMODULE_HASH_XX; break;
+        case 'i': flags |= REDISMODULE_HASH_COUNT_INSERTS; break;
+        }
+    }
+
+    /* This is why varargs sucks... */
+    int result;
+    errno = 0;
+    if (argc == 5) {
+        result = RedisModule_HashSet(key, flags,
+                                     argv[3], value_or_delete(argv[4]),
+                                     NULL);
+    } else if (argc == 7) {
+        result = RedisModule_HashSet(key, flags,
+                                     argv[3], value_or_delete(argv[4]),
+                                     argv[5], value_or_delete(argv[6]),
+                                     NULL);
+    } else if (argc == 9) {
+        result = RedisModule_HashSet(key, flags,
+                                     argv[3], value_or_delete(argv[4]),
+                                     argv[5], value_or_delete(argv[6]),
+                                     argv[7], value_or_delete(argv[8]),
+                                     NULL);
+    } else if (argc == 11) {
+        result = RedisModule_HashSet(key, flags,
+                                     argv[3], value_or_delete(argv[4]),
+                                     argv[5], value_or_delete(argv[6]),
+                                     argv[7], value_or_delete(argv[8]),
+                                     argv[9], value_or_delete(argv[10]),
+                                     NULL);
+    } else {
+        return RedisModule_ReplyWithError(ctx, "ERR too many fields");
+    }
+
+    /* Check errno */
+    if (errno == ENOTSUP) {
+        RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+    } else if (flags & REDISMODULE_HASH_COUNT_INSERTS) {
+        int numfields = (argc - 3) / 2;
+        if (result != numfields) {
+            if (flags & REDISMODULE_HASH_NX)
+                RedisModule_Assert(errno == EEXIST);
+            if (flags & REDISMODULE_HASH_XX)
+                RedisModule_Assert(errno == ENOENT);
+        }
+    }
+
+    return RedisModule_ReplyWithLongLong(ctx, result);
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    if (RedisModule_Init(ctx, "hash", 1, REDISMODULE_APIVER_1) ==
+        REDISMODULE_OK &&
+        RedisModule_CreateCommand(ctx, "hash.set", hash_set, "",
+                                  1, 1, 1) == REDISMODULE_OK) {
+        return REDISMODULE_OK;
+    } else {
+        return REDISMODULE_ERR;
+    }
+}

--- a/tests/unit/moduleapi/hash.tcl
+++ b/tests/unit/moduleapi/hash.tcl
@@ -4,12 +4,18 @@ start_server {tags {"modules"}} {
     r module load $testmodule
 
     test {Module hash set} {
+        r set k mystring
+        assert_error "WRONGTYPE*" {r hash.set k "" hello world}
         r del k
+        # "" = count updates and deletes of existing fields only
         assert_equal 0 [r hash.set k "" squirrel yes]
-        assert_equal 2 [r hash.set k "i" banana no sushi whynot]
+        # "a" = COUNT_ALL = count inserted, modified and deleted fields
+        assert_equal 2 [r hash.set k "a" banana no sushi whynot]
+        # "n" = NX = only add fields not already existing in the hash
+        # "x" = XX = only replace the value for existing fields
         assert_equal 0 [r hash.set k "n" squirrel hoho what nothing]
-        assert_equal 1 [r hash.set k "ni" squirrel hoho something nice]
-        assert_equal 0 [r hash.set k "xi" new stuff not inserted]
+        assert_equal 1 [r hash.set k "na" squirrel hoho something nice]
+        assert_equal 0 [r hash.set k "xa" new stuff not inserted]
         assert_equal 1 [r hash.set k "x" squirrel ofcourse]
         assert_equal 1 [r hash.set k "" sushi :delete: none :delete:]
         r hgetall k

--- a/tests/unit/moduleapi/hash.tcl
+++ b/tests/unit/moduleapi/hash.tcl
@@ -1,0 +1,17 @@
+set testmodule [file normalize tests/modules/hash.so]
+
+start_server {tags {"modules"}} {
+    r module load $testmodule
+
+    test {Module hash set} {
+        r del k
+        assert_equal 0 [r hash.set k "" squirrel yes]
+        assert_equal 2 [r hash.set k "i" banana no sushi whynot]
+        assert_equal 0 [r hash.set k "n" squirrel hoho what nothing]
+        assert_equal 1 [r hash.set k "ni" squirrel hoho something nice]
+        assert_equal 0 [r hash.set k "xi" new stuff not inserted]
+        assert_equal 1 [r hash.set k "x" squirrel ofcourse]
+        assert_equal 1 [r hash.set k "" sushi :delete: none :delete:]
+        r hgetall k
+    } {squirrel ofcourse banana no what nothing something nice}
+}


### PR DESCRIPTION
The added flag affects the return value of RM_HashSet() to include
the number of inserted fields, in addition to updated and deleted
fields.

Errno is set on errors, tests are added and documentation updated.

Fixes #6914.