### PR TITLE
Fix compliation on arm64 Mac with jemalloc

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -54,6 +54,10 @@ typedef ucontext_t sigcontext_t;
 #endif
 #endif
 
+#if defined(__APPLE__) && defined(__arm64__) && defined(USE_JEMALLOC)
+#include <mach/mach.h>
+#endif
+
 /* Globals */
 static int bug_report_start = 0; /* True if bug report header was already logged. */
 static pthread_mutex_t bug_report_start_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/src/debug.c
+++ b/src/debug.c
@@ -54,7 +54,7 @@ typedef ucontext_t sigcontext_t;
 #endif
 #endif
 
-#if defined(__APPLE__) && defined(__arm64__) && defined(USE_JEMALLOC)
+#if defined(__APPLE__) && defined(__arm64__)
 #include <mach/mach.h>
 #endif
 


### PR DESCRIPTION
The `arm_thread_state64_get_pc` used later in the file is defined in mach kernel headers. Apparently they get included if you use the system malloc but not if you use jemalloc. This patch guarantees their inclusion and successful compilation.