### PR TITLE
solve race in replication-2 test

### DIFF
--- a/tests/integration/replication-2.tcl
+++ b/tests/integration/replication-2.tcl
@@ -39,17 +39,15 @@ start_server {tags {"repl"}} {
         }
 
         test {No write if min-slaves-max-lag is > of the slave lag} {
-            r -1 deferred 1
             r config set min-slaves-to-write 1
             r config set min-slaves-max-lag 2
-            r -1 debug sleep 6
+            exec kill -SIGSTOP [srv -1 pid]
             assert {[r set foo 12345] eq {OK}}
-            after 4000
+            after 3000
             catch {r set foo 12345} err
-            assert {[r -1 read] eq {OK}}
-            r -1 deferred 0
             set err
         } {NOREPLICAS*}
+        exec kill -SIGCONT [srv -1 pid]
 
         test {min-slaves-to-write is ignored by slaves} {
             r config set min-slaves-to-write 1

--- a/tests/integration/replication-2.tcl
+++ b/tests/integration/replication-2.tcl
@@ -43,7 +43,7 @@ start_server {tags {"repl"}} {
             r config set min-slaves-max-lag 2
             exec kill -SIGSTOP [srv -1 pid]
             assert {[r set foo 12345] eq {OK}}
-            after 3000
+            after 4000
             catch {r set foo 12345} err
             set err
         } {NOREPLICAS*}


### PR DESCRIPTION
use SIGSTOP instead of DEBUG SLEEP, reduces the test
time by some 2 seconds and avoids failures on slow machines