### PR TITLE
Fix random probability check in ziplistRandomPairsUnique

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1608,7 +1608,7 @@ unsigned int ziplistRandomPairsUnique(unsigned char *zl, unsigned int count, zip
     while (picked < count && p) {
         double randomDouble = ((double)rand()) / RAND_MAX;
         double threshold = ((double)remaining) / (total_size - index);
-        if(randomDouble <= threshold) {
+        if (randomDouble <= threshold) {
             assert(ziplistGet(p, &key, &klen, &klval));
             ziplistSaveValue(key, klen, klval, &keys[picked]);
             p = ziplistNext(zl, p);

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1608,7 +1608,7 @@ unsigned int ziplistRandomPairsUnique(unsigned char *zl, unsigned int count, zip
     while (picked < count && p) {
         double randomDouble = ((double)rand()) / RAND_MAX;
         double threshold = ((double)remaining) / (total_size - index);
-        if(randomDouble <= threshold){
+        if(randomDouble <= threshold) {
             assert(ziplistGet(p, &key, &klen, &klval));
             ziplistSaveValue(key, klen, klval, &keys[picked]);
             p = ziplistNext(zl, p);

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1608,7 +1608,7 @@ unsigned int ziplistRandomPairsUnique(unsigned char *zl, unsigned int count, zip
     while (picked < count && p) {
         double randomDouble = ((double)rand()) / RAND_MAX;
         double threshold = ((double)remaining) / (total_size - index);
-        if(randomDouble < threshold){
+        if(randomDouble <= threshold){
             assert(ziplistGet(p, &key, &klen, &klval));
             ziplistSaveValue(key, klen, klval, &keys[picked]);
             p = ziplistNext(zl, p);


### PR DESCRIPTION
When `(remaining == (total_size - index))`, element will definitely be random to.
But when `rand() == RAND_MAX`, the element will miss, this will trigger assert 
in `serverAssert(ziplistRandomPairsUnique(zsetobj->ptr, count, keys, vals) == count)`.