### PR TITLE
Increasing block on background timeout time to avoid nightly test failure

### DIFF
--- a/tests/unit/moduleapi/blockonbackground.tcl
+++ b/tests/unit/moduleapi/blockonbackground.tcl
@@ -29,14 +29,14 @@ start_server {tags {"modules"}} {
         r block.debug 0 20000
         assert_equal [r slowlog len] 0
         r config resetstat
-        r block.debug 20000 200
+        r block.debug 20000 500
         assert_equal [r slowlog len] 1
 
         set cmdstatline [cmdrstat block.debug r]
 
         regexp "calls=1,usec=(.*?),usec_per_call=(.*?),rejected_calls=0,failed_calls=0" $cmdstatline usec usec_per_call
-        assert {$usec >= 100000}
-        assert {$usec_per_call >= 100000}
+        assert {$usec >= 250000}
+        assert {$usec_per_call >= 250000}
     }
 
     test { blocked clients time tracking - check blocked command with multiple calls RedisModule_BlockedClientMeasureTimeStart()  is tracking the total background time } {


### PR DESCRIPTION
We think it's possible that on the module's blocking timeout time tracking test, the timeout is happening prior we issue the RedisModule_BlockedClientMeasureTimeStart(bc) on the background thread. If that is the case one possible solution is to increase the timeout. Increasing to 200ms to 500ms to see if nightly stops failing.