### PR TITLE
Fix the failures in fd leaks test

### DIFF
--- a/tests/sentinel/tests/helpers/check_leaked_fds.tcl
+++ b/tests/sentinel/tests/helpers/check_leaked_fds.tcl
@@ -24,7 +24,6 @@ proc get_parent_pid {_pid} {
 # Linux only
 set os [exec uname]
 if {$os != "Linux"} {
-    puts "Only Linux is supported."
     exit 0
 }
 

--- a/tests/sentinel/tests/helpers/check_leaked_fds.tcl
+++ b/tests/sentinel/tests/helpers/check_leaked_fds.tcl
@@ -21,12 +21,6 @@ proc get_parent_pid {_pid} {
     error "failed to get parent pid"
 }
 
-# Linux only
-set os [exec uname]
-if {$os != "Linux"} {
-    exit 0
-}
-
 if {![info exists env(LEAKED_FDS_FILE)]} {
     puts "Missing LEAKED_FDS_FILE environment variable."
     exit 0

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -36,12 +36,14 @@ test "(init) Sentinels can start monitoring a master" {
               [get_instance_attrib redis $master_id host] \
               [get_instance_attrib redis $master_id port] $quorum
     }
+    set os [exec uname]
     foreach_sentinel_id id {
         assert {[S $id sentinel master mymaster] ne {}}
         S $id SENTINEL SET mymaster down-after-milliseconds 2000
         S $id SENTINEL SET mymaster failover-timeout 20000
         S $id SENTINEL SET mymaster parallel-syncs 10
-        if {$::leaked_fds_file != ""} {
+        # Linux is the only supported platform for now.
+        if {$::leaked_fds_file != "" && $os == "Linux"} {
             S $id SENTINEL SET mymaster notification-script ../../tests/helpers/check_leaked_fds.tcl
             S $id SENTINEL SET mymaster client-reconfig-script ../../tests/helpers/check_leaked_fds.tcl
         }


### PR DESCRIPTION
Disable printing needless outputs on non-Linux platform, otherwise, it goes like this:
![image](https://user-images.githubusercontent.com/7496278/107325359-97fd9c00-6ae4-11eb-83a1-23f604f0b924.png)
