### PR TITLE
Removed time sensitive checks from block on background tests during leak checks

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -130,7 +130,7 @@ jobs:
         sudo apt-get install tcl8.6 valgrind -y
         ./runtest --valgrind --verbose --clients 1 --dump-logs
     - name: module api test
-      run: ./runtest-moduleapi --valgrind --verbose --clients 1
+      run: ./runtest-moduleapi --valgrind --no-latency --verbose --clients 1
 
   test-centos7-jemalloc:
     runs-on: ubuntu-latest

--- a/src/module.c
+++ b/src/module.c
@@ -5122,6 +5122,7 @@ RedisModuleBlockedClient *moduleBlockClient(RedisModuleCtx *ctx, RedisModuleCmdF
     bc->dbid = c->db->id;
     bc->blocked_on_keys = keys != NULL;
     bc->unblocked = 0;
+    bc->background_timer = 0;
     bc->background_duration = 0;
     c->bpop.timeout = timeout;
 

--- a/tests/modules/blockonbackground.c
+++ b/tests/modules/blockonbackground.c
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <time.h>
-#include "assert.h"
 
 #define UNUSED(x) (void)(x)
 
@@ -22,7 +21,7 @@ int HelloBlock_Timeout(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     UNUSED(argv);
     UNUSED(argc);
     RedisModuleBlockedClient *bc = RedisModule_GetBlockedClientHandle(ctx);
-    assert(RedisModule_BlockedClientMeasureTimeEnd(bc)==REDISMODULE_OK);
+    RedisModule_BlockedClientMeasureTimeEnd(bc);
     return RedisModule_ReplyWithSimpleString(ctx,"Request timedout");
 }
 
@@ -40,7 +39,7 @@ void *BlockDebug_ThreadMain(void *arg) {
     long long delay = (unsigned long)targ[1];
     long long enable_time_track = (unsigned long)targ[2];
     if (enable_time_track)
-        assert(RedisModule_BlockedClientMeasureTimeStart(bc)==REDISMODULE_OK);
+        RedisModule_BlockedClientMeasureTimeStart(bc);
     RedisModule_Free(targ);
 
     struct timespec ts;
@@ -50,7 +49,7 @@ void *BlockDebug_ThreadMain(void *arg) {
     int *r = RedisModule_Alloc(sizeof(int));
     *r = rand();
     if (enable_time_track)
-        assert(RedisModule_BlockedClientMeasureTimeEnd(bc)==REDISMODULE_OK);
+        RedisModule_BlockedClientMeasureTimeEnd(bc);
     RedisModule_UnblockClient(bc,r);
     return NULL;
 }
@@ -61,7 +60,7 @@ void *DoubleBlock_ThreadMain(void *arg) {
     void **targ = arg;
     RedisModuleBlockedClient *bc = targ[0];
     long long delay = (unsigned long)targ[1];
-    assert(RedisModule_BlockedClientMeasureTimeStart(bc)==REDISMODULE_OK);
+    RedisModule_BlockedClientMeasureTimeStart(bc);
     RedisModule_Free(targ);
     struct timespec ts;
     ts.tv_sec = delay / 1000;
@@ -73,7 +72,7 @@ void *DoubleBlock_ThreadMain(void *arg) {
     /* call again RedisModule_BlockedClientMeasureTimeStart() and
      * RedisModule_BlockedClientMeasureTimeEnd and ensure that the
      * total execution time is 2x the delay. */
-    assert(RedisModule_BlockedClientMeasureTimeStart(bc)==REDISMODULE_OK);
+    RedisModule_BlockedClientMeasureTimeStart(bc);
     nanosleep(&ts, NULL);
     RedisModule_BlockedClientMeasureTimeEnd(bc);
 

--- a/tests/unit/moduleapi/blockonbackground.tcl
+++ b/tests/unit/moduleapi/blockonbackground.tcl
@@ -8,12 +8,18 @@ start_server {tags {"modules"}} {
     test { blocked clients time tracking - check blocked command that uses RedisModule_BlockedClientMeasureTimeStart() is tracking background time} {
         r slowlog reset
         r config set slowlog-log-slower-than 200000
-        assert_equal [r slowlog len] 0
+        if {!$::no_latency} {
+            assert_equal [r slowlog len] 0
+        }
         r block.debug 0 10000
-        assert_equal [r slowlog len] 0
+        if {!$::no_latency} {
+            assert_equal [r slowlog len] 0
+        }
         r config resetstat
         r block.debug 200 10000
-        assert_equal [r slowlog len] 1
+        if {!$::no_latency} {
+            assert_equal [r slowlog len] 1
+        }
 
         set cmdstatline [cmdrstat block.debug r]
 
@@ -25,12 +31,18 @@ start_server {tags {"modules"}} {
     test { blocked clients time tracking - check blocked command that uses RedisModule_BlockedClientMeasureTimeStart() is tracking background time even in timeout } {
         r slowlog reset
         r config set slowlog-log-slower-than 200000
-        assert_equal [r slowlog len] 0
+        if {!$::no_latency} {
+            assert_equal [r slowlog len] 0
+        }
         r block.debug 0 20000
-        assert_equal [r slowlog len] 0
+        if {!$::no_latency} {
+            assert_equal [r slowlog len] 0
+        }
         r config resetstat
         r block.debug 20000 500
-        assert_equal [r slowlog len] 1
+        if {!$::no_latency} {
+            assert_equal [r slowlog len] 1
+        }
 
         set cmdstatline [cmdrstat block.debug r]
 
@@ -42,13 +54,18 @@ start_server {tags {"modules"}} {
     test { blocked clients time tracking - check blocked command with multiple calls RedisModule_BlockedClientMeasureTimeStart()  is tracking the total background time } {
         r slowlog reset
         r config set slowlog-log-slower-than 200000
-        assert_equal [r slowlog len] 0
+        if {!$::no_latency} {
+            assert_equal [r slowlog len] 0
+        }
         r block.double_debug 0
-        assert_equal [r slowlog len] 0
+        if {!$::no_latency} {
+            assert_equal [r slowlog len] 0
+        }
         r config resetstat
         r block.double_debug 100
-        assert_equal [r slowlog len] 1
-
+        if {!$::no_latency} {
+            assert_equal [r slowlog len] 1
+        }
         set cmdstatline [cmdrstat block.double_debug r]
 
         regexp "calls=1,usec=(.*?),usec_per_call=(.*?),rejected_calls=0,failed_calls=0" $cmdstatline usec usec_per_call
@@ -59,9 +76,13 @@ start_server {tags {"modules"}} {
     test { blocked clients time tracking - check blocked command without calling RedisModule_BlockedClientMeasureTimeStart() is not reporting background time } {
         r slowlog reset
         r config set slowlog-log-slower-than 200000
-        assert_equal [r slowlog len] 0
+        if {!$::no_latency} {
+            assert_equal [r slowlog len] 0
+        }
         r block.debug_no_track 200 1000
         # ensure slowlog is still empty
-        assert_equal [r slowlog len] 0
+        if {!$::no_latency} {
+            assert_equal [r slowlog len] 0
+        }
     }
 }


### PR DESCRIPTION
The following PR removes time sensitive checks from block on background tests during leak checks.
It also an uninitialized variable on RedisModuleBlockedClient() when calling RM_BlockedClientMeasureTimeEnd() without RM_BlockedClientMeasureTimeStart()