### PR TITLE
Fix errors with sentinel leaked fds test.

### DIFF
--- a/tests/sentinel/tests/helpers/check_leaked_fds.tcl
+++ b/tests/sentinel/tests/helpers/check_leaked_fds.tcl
@@ -21,6 +21,16 @@ proc get_parent_pid {_pid} {
     error "failed to get parent pid"
 }
 
+# Read symlink to get info about the specified fd of the specified process.
+# The result can be the file name or an arbitrary string that identifies it.
+# When not able to read, an empty string is returned.
+proc get_fdlink {_pid fd} {
+    if { [catch {set fdlink [file readlink "/proc/$_pid/fd/$fd"]} err] } {
+        return ""
+    }
+    return $fdlink
+}
+
 # Linux only
 set os [exec uname]
 if {$os != "Linux"} {
@@ -46,17 +56,16 @@ foreach fd [glob -tails -directory "/proc/self/fd" *] {
         continue
     }
 
-    # Read symlink to get info about the file descriptor. This can be a real
-    # file name or an arbitrary string that identifies the fd.
-    if { [catch {set fdlink [file readlink "/proc/self/fd/$fd"]} err] } {
+    set fdlink [get_fdlink "self" $fd]
+    if {$fdlink == ""} {
         continue
     }
 
-    # See if grandparent process has the same fd and info and skip if it does.
-    if { ! [catch {set gp_fdlink [file readlink "/proc/$grandparent_pid/fd/$fd"]} err] } {
-        if {$gp_fdlink == $fdlink} {
-            continue
-        }
+    # We ignore fds that existed in the grandparent, or fds that don't exist
+    # in our parent (Sentinel process).
+    if {[get_fdlink $grandparent_pid $fd] == $fdlink ||
+	[get_fdlink $parent_pid $fd] != $fdlink} {
+        continue
     }
 
     lappend leaked_fds [list $fd $fdlink]

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -41,7 +41,7 @@ test "(init) Sentinels can start monitoring a master" {
         S $id SENTINEL SET mymaster down-after-milliseconds 2000
         S $id SENTINEL SET mymaster failover-timeout 20000
         S $id SENTINEL SET mymaster parallel-syncs 10
-        if {$::leaked_fds_file != ""} {
+        if {$::leaked_fds_file != "" && [exec uname] == "Linux"} {
             S $id SENTINEL SET mymaster notification-script ../../tests/helpers/check_leaked_fds.tcl
             S $id SENTINEL SET mymaster client-reconfig-script ../../tests/helpers/check_leaked_fds.tcl
         }


### PR DESCRIPTION
* Don't run test script on non-Linux.
* Verify that reported fds do indeed exist also in parent, to avoid
  false negatives on some systems (namely CentOS).

Co-authored-by: Andy Pan <panjf2000@gmail.com>