### PR TITLE
Remove acl subcommand validation if fully added command exists.

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -814,8 +814,6 @@ void ACLAddAllowedSubcommand(user *u, unsigned long id, const char *sub) {
  *         invalid (contains non allowed characters).
  * ENOENT: The command name or command category provided with + or - is not
  *         known.
- * EBUSY:  The subcommand you want to add is about a command that is currently
- *         fully added.
  * EEXIST: You are adding a key pattern after "*" was already added. This is
  *         almost surely an error on the user side.
  * EISDIR: You are adding a channel pattern after "*" was already added. This is
@@ -976,22 +974,10 @@ int ACLSetUser(user *u, const char *op, ssize_t oplen) {
                 return C_ERR;
             }
 
-            /* The command should not be set right now in the command
-             * bitmap, because adding a subcommand of a fully added
-             * command is probably an error on the user side. */
             unsigned long id = ACLGetCommandID(copy);
-            if (ACLGetUserCommandBit(u,id) == 1) {
-                zfree(copy);
-                errno = EBUSY;
-                return C_ERR;
-            }
-
             /* Add the subcommand to the list of valid ones. */
             ACLAddAllowedSubcommand(u,id,sub);
 
-            /* We have to clear the command bit so that we force the
-             * subcommand check. */
-            ACLSetUserCommandBit(u,id,0);
             zfree(copy);
         }
     } else if (op[0] == '-' && op[1] != '@') {
@@ -1030,10 +1016,6 @@ const char *ACLSetUserStringError(void) {
         errmsg = "Unknown command or category name in ACL";
     else if (errno == EINVAL)
         errmsg = "Syntax error";
-    else if (errno == EBUSY)
-        errmsg = "Adding a subcommand of a command already fully "
-                 "added is not allowed. Remove the command to start. "
-                 "Example: -DEBUG +DEBUG|DIGEST";
     else if (errno == EEXIST)
         errmsg = "Adding a pattern after the * pattern (or the "
                  "'allkeys' flag) is not valid and does not have any "

--- a/src/acl.c
+++ b/src/acl.c
@@ -975,8 +975,10 @@ int ACLSetUser(user *u, const char *op, ssize_t oplen) {
             }
 
             unsigned long id = ACLGetCommandID(copy);
-            /* Add the subcommand to the list of valid ones. */
-            ACLAddAllowedSubcommand(u,id,sub);
+            /* Add the subcommand to the list of valid ones, if  the command is not set. */
+            if (ACLGetUserCommandBit(u,id) == 0) {
+                ACLAddAllowedSubcommand(u,id,sub);
+            }
 
             zfree(copy);
         }

--- a/src/acl.c
+++ b/src/acl.c
@@ -975,7 +975,7 @@ int ACLSetUser(user *u, const char *op, ssize_t oplen) {
             }
 
             unsigned long id = ACLGetCommandID(copy);
-            /* Add the subcommand to the list of valid ones, if  the command is not set. */
+            /* Add the subcommand to the list of valid ones, if the command is not set. */
             if (ACLGetUserCommandBit(u,id) == 0) {
                 ACLAddAllowedSubcommand(u,id,sub);
             }

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -218,14 +218,14 @@ start_server {tags {"acl"}} {
     } {*NOPERM*}
 
     test {ACLs set can include subcommands, if already full command exists} {
-        r ACL setuser bob +pfcount|hll
+        r ACL setuser bob +memory|doctor
         set cmdstr [dict get [r ACL getuser bob] commands]
-        assert_equal {-@all +pfcount|hll} $cmdstr
+        assert_equal {-@all +memory|doctor} $cmdstr
 
-        # Validate the commands have got engulfed to +pfcount.
-        r ACL setuser bob +pfcount
+        # Validate the commands have got engulfed to +memory.
+        r ACL setuser bob +memory
         set cmdstr [dict get [r ACL getuser bob] commands]
-        assert_equal {-@all +pfcount} $cmdstr
+        assert_equal {-@all +memory} $cmdstr
 
         # Appending to the existing access string of bob.
         r ACL setuser bob +@all +client|id
@@ -233,7 +233,7 @@ start_server {tags {"acl"}} {
         set cmdstr [dict get [r ACL getuser bob] commands]
         assert_equal {+@all} $cmdstr
         r CLIENT ID; # Should not fail
-        r PFCOUNT hll; # Should not fail
+        r MEMORY DOCTOR; # Should not fail
     }
 
     # Note that the order of the generated ACL rules is not stable in Redis

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -217,6 +217,20 @@ start_server {tags {"acl"}} {
         set e
     } {*NOPERM*}
 
+    test {ACLs set can include subcommands, if already full command exists} {
+            r ACL setuser bob +pfcount +pfcount|hll
+            # Validate the commands have got engulfed to +pfcount.
+            set cmdstr [dict get [r ACL getuser bob] commands]
+            assert_match {-@all +pfcount} $cmdstr
+            # Appending to the existing access string of bob.
+            r ACL setuser bob +@all +client|id
+            # Validate the new commands have got engulfed to +@all.
+            set cmdstr [dict get [r ACL getuser bob] commands]
+            assert_match {+@all} $cmdstr
+            r CLIENT ID; # Should not fail
+            r PFCOUNT hll # Should not fail
+        }
+
     # Note that the order of the generated ACL rules is not stable in Redis
     # so we need to match the different parts and not as a whole string.
     test {ACL GETUSER is able to translate back command permissions} {

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -218,18 +218,23 @@ start_server {tags {"acl"}} {
     } {*NOPERM*}
 
     test {ACLs set can include subcommands, if already full command exists} {
-            r ACL setuser bob +pfcount +pfcount|hll
-            # Validate the commands have got engulfed to +pfcount.
-            set cmdstr [dict get [r ACL getuser bob] commands]
-            assert_match {-@all +pfcount} $cmdstr
-            # Appending to the existing access string of bob.
-            r ACL setuser bob +@all +client|id
-            # Validate the new commands have got engulfed to +@all.
-            set cmdstr [dict get [r ACL getuser bob] commands]
-            assert_match {+@all} $cmdstr
-            r CLIENT ID; # Should not fail
-            r PFCOUNT hll # Should not fail
-        }
+        r ACL setuser bob +pfcount|hll
+        set cmdstr [dict get [r ACL getuser bob] commands]
+        assert_equal {-@all +pfcount|hll} $cmdstr
+
+        # Validate the commands have got engulfed to +pfcount.
+        r ACL setuser bob +pfcount
+        set cmdstr [dict get [r ACL getuser bob] commands]
+        assert_equal {-@all +pfcount} $cmdstr
+
+        # Appending to the existing access string of bob.
+        r ACL setuser bob +@all +client|id
+        # Validate the new commands has got engulfed to +@all.
+        set cmdstr [dict get [r ACL getuser bob] commands]
+        assert_equal {+@all} $cmdstr
+        r CLIENT ID; # Should not fail
+        r PFCOUNT hll; # Should not fail
+    }
 
     # Note that the order of the generated ACL rules is not stable in Redis
     # so we need to match the different parts and not as a whole string.


### PR DESCRIPTION
Currently there is a validation to disallow subcommand addition to a fully added command. This is to avoid if a customer has wrongly added it. Due to this there is a breaking change across versions, due to the addition of PFDEBUG into hyperloglog category.

```
// Redis 6.0.5
127.0.0.1:6379> acl setuser user1 +@hyperloglog +pfdebug|test
OK
```
```
// Redis 6.2
127.0.0.1:6379> acl setuser user1 +@hyperloglog +pfdebug|test
(error) ERR Error in ACL SETUSER modifier '+pfdebug|test': Adding a subcommand of a command already fully added is not allowed. Remove the command to start. Example: -DEBUG +DEBUG|DIGEST
```

However, we can ignore the subcommand instead of throwing the error. 

Current behaviour:
```
127.0.0.1:6380> ACL SETUSER newuser +PFCOUNT +PFCOUNT|DEBUG
(error) ERR Error in ACL SETUSER modifier '+PFCOUNT|DEBUG': Adding a subcommand of a command already fully added is not allowed. Remove the command to start. Example: -DEBUG +DEBUG|DIGEST
```

Proposed changes:
```
127.0.0.1:6379> ACL SETUSER newuser +PFCOUNT +PFCOUNT|DEBUG
OK
127.0.0.1:6379> ACL LIST
1) "user default on nopass ~* &* +@all"
2) "user newuser off &* -@all +pfcount"
```