### PR TITLE
Fix incorrect shared ping length.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2599,7 +2599,7 @@ void createSharedObjects(void) {
     shared.justid = createStringObject("JUSTID",6);
     shared.lastid = createStringObject("LASTID",6);
     shared.default_username = createStringObject("default",7);
-    shared.ping = createStringObject("ping",7);
+    shared.ping = createStringObject("ping",4);
     shared.setid = createStringObject("SETID",5);
     shared.keepttl = createStringObject("KEEPTTL",7);
     shared.load = createStringObject("LOAD",4);


### PR DESCRIPTION
This was caught thanks to server log files:

```
tests/tmp/server.78365.113/stdout:81105:S 15 Feb 2021 16:22:04.743 # == CRITICAL == This replica is sending an error to its master: 'unknown command `ping`, with args beginning with: ' after processing the command '<unknown>'
```