### PR TITLE
Module API for getting user name of a client

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1839,8 +1839,8 @@ unsigned long long RM_GetClientId(RedisModuleCtx *ctx) {
 
 /* Return the ACL user name used by the client with the specified client ID.
  * Client ID can be obtained with RM_GetClientId() API. If the client does not
- * exists, NULL is returned. If the client isn't using an ACL user user, an
- * empty string is returned. */
+ * exist, NULL is returned. If the client isn't using an ACL user, an empty
+ * string is returned. */
 RedisModuleString *RM_GetClientUserNameById(RedisModuleCtx *ctx, uint64_t id) {
     client *client = lookupClientByID(id);
     if (client == NULL) return NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -1837,6 +1837,19 @@ unsigned long long RM_GetClientId(RedisModuleCtx *ctx) {
     return ctx->client->id;
 }
 
+
+/* Return the Name of the current client calling the currently active module
+ * command. If client authentication is NULL will return "default"
+ */
+RedisModuleString *RM_GetClientName(RedisModuleCtx *ctx) {
+    if (ctx->client == NULL) return NULL;
+    sds name = sdsnew(ctx->client->user ? ctx->client->user->name: "default");
+    robj *str = createObject(OBJ_STRING, name);
+    autoMemoryAdd(ctx,REDISMODULE_AM_STRING, str);
+    return str;
+}
+
+
 /* This is an helper for RM_GetClientInfoById() and other functions: given
  * a client, it populates the client info structure with the appropriate
  * fields depending on the version provided. If the version is not valid
@@ -9133,6 +9146,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(IsKeysPositionRequest);
     REGISTER_API(KeyAtPos);
     REGISTER_API(GetClientId);
+    REGISTER_API(GetClientName);
     REGISTER_API(GetContextFlags);
     REGISTER_API(AvoidReplicaTraffic);
     REGISTER_API(PoolAlloc);

--- a/src/module.c
+++ b/src/module.c
@@ -1849,7 +1849,7 @@ RedisModuleString *RM_GetClientUserNameById(RedisModuleCtx *ctx, uint64_t id) {
     }
     
     if (client->user == NULL) {
-        errno = ENOSUP;
+        errno = ENOTSUP;
         return NULL;
     }
 

--- a/src/module.c
+++ b/src/module.c
@@ -1839,12 +1839,15 @@ unsigned long long RM_GetClientId(RedisModuleCtx *ctx) {
 
 /* Return the ACL user name used by the client with the specified client ID.
  * Client ID can be obtained with RM_GetClientId() API. If the client does not
- * exist, NULL is returned. If the client isn't using an ACL user, NULL is
- * returned and errno is set to ENODEV */
+ * exist, NULL is returned and errno is set to ENOTDIR. If the client isn't 
+ * using an ACL user, NULL is returned and errno is set to ENODEV */
 RedisModuleString *RM_GetClientUserNameById(RedisModuleCtx *ctx, uint64_t id) {
     client *client = lookupClientByID(id);
-    if (client == NULL) return NULL;
-
+    if (client == NULL) {
+        errno = ENOTDIR;
+        return NULL;
+    }
+    
     if (client->user == NULL) {
         errno = ENODEV;
         return NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -1839,8 +1839,8 @@ unsigned long long RM_GetClientId(RedisModuleCtx *ctx) {
 
 /* Return the ACL user name used by the client with the specified client ID.
  * Client ID can be obtained with RM_GetClientId() API. If the client does not
- * exist, NULL is returned. If the client isn't using an ACL user, an empty
- * string is returned. */
+ * exist, NULL is returned. If the client isn't using an ACL user, NULL is
+ * returned and errno is set to ENODEV */
 RedisModuleString *RM_GetClientUserNameById(RedisModuleCtx *ctx, uint64_t id) {
     client *client = lookupClientByID(id);
     if (client == NULL) return NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -1839,17 +1839,17 @@ unsigned long long RM_GetClientId(RedisModuleCtx *ctx) {
 
 /* Return the ACL user name used by the client with the specified client ID.
  * Client ID can be obtained with RM_GetClientId() API. If the client does not
- * exist, NULL is returned and errno is set to ENOTDIR. If the client isn't 
- * using an ACL user, NULL is returned and errno is set to ENODEV */
+ * exist, NULL is returned and errno is set to ENOENT. If the client isn't 
+ * using an ACL user, NULL is returned and errno is set to ENOTSUP */
 RedisModuleString *RM_GetClientUserNameById(RedisModuleCtx *ctx, uint64_t id) {
     client *client = lookupClientByID(id);
     if (client == NULL) {
-        errno = ENOTDIR;
+        errno = ENOENT;
         return NULL;
     }
     
     if (client->user == NULL) {
-        errno = ENODEV;
+        errno = ENOSUP;
         return NULL;
     }
 

--- a/src/module.c
+++ b/src/module.c
@@ -1836,7 +1836,7 @@ unsigned long long RM_GetClientId(RedisModuleCtx *ctx) {
     if (ctx->client == NULL) return 0;
     return ctx->client->id;
 }
-================================================================================
+
 /* Return the ACL user name used by the client with the specified client ID.
  * Client ID can be obtained with RM_GetClientId() API. If the client does not
  * exists, NULL is returned. If the client isn't using an ACL user user, an

--- a/src/module.c
+++ b/src/module.c
@@ -1836,23 +1836,20 @@ unsigned long long RM_GetClientId(RedisModuleCtx *ctx) {
     if (ctx->client == NULL) return 0;
     return ctx->client->id;
 }
-
-
-/* Return name of client user with the specified ID (that was
- * previously obtained via the RedisModule_GetClientId() API). If the
- * client is not exists, NULL is returned. If client->user is NULL,
- * "default" is returned.
- */
+================================================================================
+/* Return the ACL user name used by the client with the specified client ID.
+ * Client ID can be obtained with RM_GetClientId() API. If the client does not
+ * exists, NULL is returned. If the client isn't using an ACL user user, an
+ * empty string is returned. */
 RedisModuleString *RM_GetClientUserNameById(RedisModuleCtx *ctx, uint64_t id) {
     client *client = lookupClientByID(id);
     if (client == NULL) return NULL;
 
-    sds name = sdsnew(client->user ? client->user->name: "default");
+    sds name = sdsnew(client->user ? client->user->name: "");
     robj *str = createObject(OBJ_STRING, name);
     autoMemoryAdd(ctx, REDISMODULE_AM_STRING, str);
     return str;
 }
-
 
 /* This is an helper for RM_GetClientInfoById() and other functions: given
  * a client, it populates the client info structure with the appropriate

--- a/src/module.c
+++ b/src/module.c
@@ -1845,7 +1845,12 @@ RedisModuleString *RM_GetClientUserNameById(RedisModuleCtx *ctx, uint64_t id) {
     client *client = lookupClientByID(id);
     if (client == NULL) return NULL;
 
-    sds name = sdsnew(client->user ? client->user->name: "");
+    if (client->user == NULL) {
+        errno = ENODEV;
+        return NULL;
+    }
+
+    sds name = sdsnew(client->user->name);
     robj *str = createObject(OBJ_STRING, name);
     autoMemoryAdd(ctx, REDISMODULE_AM_STRING, str);
     return str;

--- a/src/module.c
+++ b/src/module.c
@@ -1838,15 +1838,46 @@ unsigned long long RM_GetClientId(RedisModuleCtx *ctx) {
 }
 
 
-/* Return the Name of the current client calling the currently active module
- * command. If client authentication is NULL will return "default"
+/*
+ * Return name of RedisModuleUser. Get current client RedisModuleUser via the
+ * RM_GetClientUserById API. If user reference in RedisModuleUser is null,
+ * "default" is returned.
  */
-RedisModuleString *RM_GetClientName(RedisModuleCtx *ctx) {
-    if (ctx->client == NULL) return NULL;
-    sds name = sdsnew(ctx->client->user ? ctx->client->user->name: "default");
+RedisModuleString *RM_GetUserName(RedisModuleCtx *ctx, RedisModuleUser *user) {
+    if (user == NULL) return NULL;
+    sds name = sdsnew(user->user ? user->user->name: "default");
     robj *str = createObject(OBJ_STRING, name);
     autoMemoryAdd(ctx,REDISMODULE_AM_STRING, str);
     return str;
+}
+
+
+/* Return reference of RedisModuleUser with the specified ID (that was
+ * previously obtained via the RedisModule_GetClientId() API). RedisModuleUser
+ * contains fake user which copy current client user's name and flags. If the
+ * client is not exists, NULL is returned. If client->user is NULL, user name
+ * will set to "default".
+ *
+ * User created here are not listed by the ACL command. Free the user using the
+ * function RM_FreeModuleUser()
+ */
+RedisModuleUser *RM_GetClientUserById(uint64_t id) {
+    client *client = lookupClientByID(id);
+    if (client == NULL) return NULL;
+
+    RedisModuleUser *new_user = zmalloc(sizeof(RedisModuleUser));
+    new_user->user = ACLCreateUnlinkedUser();
+
+    /* Free the previous temporarily assigned name */
+    sdsfree(new_user->user->name);
+
+    if (client->user == NULL) {
+        new_user->user->name = sdsnew("default");
+    } else {
+        new_user->user->name = sdsnew(client->user->name);
+        new_user->user->flags = client->user->flags;
+    }
+    return new_user;
 }
 
 
@@ -9146,7 +9177,8 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(IsKeysPositionRequest);
     REGISTER_API(KeyAtPos);
     REGISTER_API(GetClientId);
-    REGISTER_API(GetClientName);
+    REGISTER_API(GetUserName);
+    REGISTER_API(GetClientUserById);
     REGISTER_API(GetContextFlags);
     REGISTER_API(AvoidReplicaTraffic);
     REGISTER_API(PoolAlloc);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -665,8 +665,7 @@ REDISMODULE_API long long (*RedisModule_StreamTrimByID)(RedisModuleKey *key, int
 REDISMODULE_API int (*RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_KeyAtPos)(RedisModuleCtx *ctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_GetClientId)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_GetUserName)(RedisModuleCtx *ctx, RedisModuleUser *user) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleUser * (*RedisModule_GetClientUserById)(uint64_t id) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString * (*RedisModule_GetClientUserNameById)(RedisModuleCtx *ctx, uint64_t id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetClientInfoById)(void *ci, uint64_t id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_PublishMessage)(RedisModuleCtx *ctx, RedisModuleString *channel, RedisModuleString *message) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetContextFlags)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -938,8 +937,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(IsKeysPositionRequest);
     REDISMODULE_GET_API(KeyAtPos);
     REDISMODULE_GET_API(GetClientId);
-    REDISMODULE_GET_API(GetClientUserById);
-    REDISMODULE_GET_API(GetUserName);
+    REDISMODULE_GET_API(GetClientUserNameById);
     REDISMODULE_GET_API(GetContextFlags);
     REDISMODULE_GET_API(AvoidReplicaTraffic);
     REDISMODULE_GET_API(PoolAlloc);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -665,7 +665,8 @@ REDISMODULE_API long long (*RedisModule_StreamTrimByID)(RedisModuleKey *key, int
 REDISMODULE_API int (*RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_KeyAtPos)(RedisModuleCtx *ctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_GetClientId)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString * (*RedisModule_GetClientName)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString * (*RedisModule_GetUserName)(RedisModuleCtx *ctx, RedisModuleUser *user) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleUser * (*RedisModule_GetClientUserById)(uint64_t id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetClientInfoById)(void *ci, uint64_t id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_PublishMessage)(RedisModuleCtx *ctx, RedisModuleString *channel, RedisModuleString *message) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetContextFlags)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -937,7 +938,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(IsKeysPositionRequest);
     REDISMODULE_GET_API(KeyAtPos);
     REDISMODULE_GET_API(GetClientId);
-    REDISMODULE_GET_API(GetClientName);
+    REDISMODULE_GET_API(GetClientUserById);
+    REDISMODULE_GET_API(GetUserName);
     REDISMODULE_GET_API(GetContextFlags);
     REDISMODULE_GET_API(AvoidReplicaTraffic);
     REDISMODULE_GET_API(PoolAlloc);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -665,6 +665,7 @@ REDISMODULE_API long long (*RedisModule_StreamTrimByID)(RedisModuleKey *key, int
 REDISMODULE_API int (*RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_KeyAtPos)(RedisModuleCtx *ctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_GetClientId)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString * (*RedisModule_GetClientName)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetClientInfoById)(void *ci, uint64_t id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_PublishMessage)(RedisModuleCtx *ctx, RedisModuleString *channel, RedisModuleString *message) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetContextFlags)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -936,6 +937,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(IsKeysPositionRequest);
     REDISMODULE_GET_API(KeyAtPos);
     REDISMODULE_GET_API(GetClientId);
+    REDISMODULE_GET_API(GetClientName);
     REDISMODULE_GET_API(GetContextFlags);
     REDISMODULE_GET_API(AvoidReplicaTraffic);
     REDISMODULE_GET_API(PoolAlloc);


### PR DESCRIPTION
I'am developing some pure memory service base on `redis-module`. It's very hard to get client user name in redis module. 

`ID` is always change when upper application(my service consumer) recreate connection or use connection pool. But client user name is almost never change in upper layer application.  Add  `client name` can help module developer to do some business logic by consumer identity