### PR TITLE
Fix timing error oom-score-adj test

### DIFF
--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -39,7 +39,18 @@ if {$system_name eq {linux}} {
             r bgsave
 
             set child_pid [get_child_pid 0]
-            assert_equal [get_oom_score_adj $child_pid] [expr $base + 30]
+            set iterations 10
+            while {$iterations != 0} {
+                incr iterations -1
+                set oom_score_adj [get_oom_score_adj $child_pid]
+                if {$oom_score_adj == [expr $base + 30]} {
+                    break
+                }
+
+                after 10
+            }
+
+            assert_equal $oom_score_adj [expr $base + 30]
         }
 
         # Failed oom-score-adj tests can only run unprivileged

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -39,18 +39,12 @@ if {$system_name eq {linux}} {
             r bgsave
 
             set child_pid [get_child_pid 0]
-            set iterations 10
-            while {$iterations != 0} {
-                incr iterations -1
-                set oom_score_adj [get_oom_score_adj $child_pid]
-                if {$oom_score_adj == [expr $base + 30]} {
-                    break
-                }
-
-                after 10
+            # Wait until background child process to setOOMScoreAdj success.
+            wait_for_condition 10 10 {
+                [get_oom_score_adj $child_pid] == [expr $base + 30]
+            } else {
+                fail "Set oom-score-adj of background child process not ok"
             }
-
-            assert_equal $oom_score_adj [expr $base + 30]
         }
 
         # Failed oom-score-adj tests can only run unprivileged

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -43,7 +43,7 @@ if {$system_name eq {linux}} {
             wait_for_condition 10 10 {
                 [get_oom_score_adj $child_pid] == [expr $base + 30]
             } else {
-                fail "Set oom-score-adj of background child process not ok"
+                fail "Set oom-score-adj of background child process is not ok"
             }
         }
 

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -40,7 +40,7 @@ if {$system_name eq {linux}} {
 
             set child_pid [get_child_pid 0]
             # Wait until background child process to setOOMScoreAdj success.
-            wait_for_condition 10 10 {
+            wait_for_condition 100 10 {
                 [get_oom_score_adj $child_pid] == [expr $base + 30]
             } else {
                 fail "Set oom-score-adj of background child process is not ok"


### PR DESCRIPTION
I typed some logs and found that the background save process may not have finished executing setOOMScoreAdj after executing the get_oom_score_adj method, resulting in the obtained oom_score_adj being 15.
Increased the number of attempts to get_oom_score_adj, ran for half an hour without fail.

![get_child_oom_score_adj](https://user-images.githubusercontent.com/965798/108452040-c462a680-72a2-11eb-8272-502d6ab4dd24.png)
