### PR TITLE
Remove race condition and consistency issues with client pause threaded IO

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -98,6 +98,9 @@ void processUnblockedClients(void) {
     client *c;
 
     while (listLength(server.unblocked_clients)) {
+        /* If clients are paused we yield for now, since
+         * we don't want to process any commands later. */
+        if (clientsArePaused()) return;
         ln = listFirst(server.unblocked_clients);
         serverAssert(ln != NULL);
         c = ln->value;
@@ -109,7 +112,6 @@ void processUnblockedClients(void) {
          * client is not blocked before to proceed, but things may change and
          * the code is conceptually more correct this way. */
         if (!(c->flags & CLIENT_BLOCKED)) {
-            if (clientsArePaused()) return;
             /* If we have a queued command, execute it now. */
             if (processPendingCommandsAndResetClient(c) == C_ERR) {
                 continue;

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -109,6 +109,12 @@ void processUnblockedClients(void) {
          * client is not blocked before to proceed, but things may change and
          * the code is conceptually more correct this way. */
         if (!(c->flags & CLIENT_BLOCKED)) {
+            if (clientsArePaused()) return;
+            /* If we have a queued command, execute it now. */
+            if (processPendingCommandsAndResetClient(c) == C_ERR) {
+                continue;
+            }
+            /* Then process client if it has more data in it's buffer. */
             if (c->querybuf && sdslen(c->querybuf) > 0) {
                 processInputBuffer(c);
             }

--- a/src/networking.c
+++ b/src/networking.c
@@ -1911,7 +1911,9 @@ void processInputBuffer(client *c) {
     /* Keep processing while there is something in the input buffer */
     while(c->qb_pos < sdslen(c->querybuf)) {
         /* Return if clients are paused. */
-        if (!(c->flags & CLIENT_SLAVE) && clientsArePaused()) break;
+        if (!(c->flags & CLIENT_SLAVE) && 
+            !(c->flags & CLIENT_PENDING_READ) && 
+            clientsArePaused()) break;
 
         /* Immediately abort if the client is in the middle of something. */
         if (c->flags & CLIENT_BLOCKED) break;
@@ -3269,6 +3271,7 @@ int handleClientsWithPendingWritesUsingThreads(void) {
 int postponeClientRead(client *c) {
     if (server.io_threads_active &&
         server.io_threads_do_reads &&
+        !clientsArePaused() &&
         !ProcessingEventsWhileBlocked &&
         !(c->flags & (CLIENT_MASTER|CLIENT_SLAVE|CLIENT_PENDING_READ)))
     {

--- a/src/server.h
+++ b/src/server.h
@@ -2020,6 +2020,7 @@ size_t freeMemoryGetNotCountedMemory();
 int freeMemoryIfNeeded(void);
 int freeMemoryIfNeededAndSafe(void);
 int processCommand(client *c);
+int processPendingCommandsAndResetClient(client *c);
 void setupSignalHandlers(void);
 struct redisCommand *lookupCommand(sds name);
 struct redisCommand *lookupCommandByCString(const char *s);


### PR DESCRIPTION
clientsArePaused isn't thread safe because it has a side effect of attempting to unpause, which may cause multiple threads concurrently updating the unblocked_clients global list. This change resolves this issue by no longer postponing client for threaded reads when clients are paused and then skipping the check for client paused for threaded reads, incase one is postponed and then clients are paused. (I don't think this is strictly possible, but being defensive seems better here)