### PR TITLE
Use addReplyErrorObject with shared.noscripterr

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1544,7 +1544,7 @@ void evalGenericCommand(client *c, int evalsha) {
          * return an error. */
         if (evalsha) {
             lua_pop(lua,1); /* remove the error handler from the stack. */
-            addReply(c, shared.noscripterr);
+            addReplyErrorObject(c, shared.noscripterr);
             return;
         }
         if (luaCreateFunction(c,lua,c->argv[1]) == NULL) {
@@ -1695,7 +1695,7 @@ void evalShaCommand(client *c) {
          * not the right length. So we return an error ASAP, this way
          * evalGenericCommand() can be implemented without string length
          * sanity check */
-        addReply(c, shared.noscripterr);
+        addReplyErrorObject(c, shared.noscripterr);
         return;
     }
     if (!(c->flags & CLIENT_LUA_DEBUG))

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -62,6 +62,19 @@ start_server {tags {"info"}} {
             assert_equal [s total_error_replies] 2
         }
 
+        test {errorstats: failed call NOSCRIPT error} {
+            r config resetstat
+            assert_equal [s total_error_replies] 0
+            assert_match {} [errorstat NOSCRIPT]
+            catch {r evalsha NotValidShaSUM 0} e
+            assert_match {NOSCRIPT*} $e
+            assert_match {*count=1*} [errorstat NOSCRIPT]
+            assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat evalsha]
+            assert_equal [s total_error_replies] 1
+            r config resetstat
+            assert_match {} [errorstat NOSCRIPT]
+        }
+
         test {errorstats: failed call NOGROUP error} {
             r config resetstat
             assert_match {} [errorstat NOGROUP]


### PR DESCRIPTION
Use addReplyErrorObject instead of addReply to reply shared.noscripterr, and add test for it.