### PR TITLE
redis-cli prompt: fix db number and transaction state inconsistencies after reconnect

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -821,6 +821,7 @@ static int cliConnect(int flags) {
             redisFree(context);
             config.dbnum = 0;
             config.in_multi = 0;
+            cliRefreshPrompt();
         }
 
         if (config.hostsocket == NULL) {
@@ -2067,7 +2068,6 @@ static void repl(void) {
 
     cliRefreshPrompt();
     while((line = linenoise(context ? config.prompt : "not connected> ")) != NULL) {
-        cliRefreshPrompt();
         if (line[0] != '\0') {
             long repeat = 1;
             int skipargs = 0;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -819,6 +819,8 @@ static int cliConnect(int flags) {
     if (context == NULL || flags & CC_FORCE) {
         if (context != NULL) {
             redisFree(context);
+            config.dbnum = 0;
+            config.in_multi = 0;
         }
 
         if (config.hostsocket == NULL) {
@@ -2065,6 +2067,7 @@ static void repl(void) {
 
     cliRefreshPrompt();
     while((line = linenoise(context ? config.prompt : "not connected> ")) != NULL) {
+        cliRefreshPrompt();
         if (line[0] != '\0') {
             long repeat = 1;
             int skipargs = 0;


### PR DESCRIPTION
Before this commit, when redis-cli interactive mode perform a reconnect, the dbnum and transaction state hasn't been reset. This will cause incoonsistencies after the reconnect is successful. Examples:

127.0.0.1:6379> select 10
OK
127.0.0.1:6379[10]> set foo bar
OK

//Disconnect happens:

127.0.0.1:6379[10]> set foo bar
Could not connect to Redis at 127.0.0.1:6379: Connection refused
not connected> set foo bar
OK
127.0.0.1:6379[10]> 