### PR TITLE
Allow stopped redis processes to be killed

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -186,6 +186,8 @@ proc is_alive pid {
 
 proc stop_instance pid {
     catch {exec kill $pid}
+    # Node might have been stopped in the test
+    catch {exec kill -SIGCONT $pid}
     if {$::valgrind} {
         set max_wait 60000
     } else {

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -72,6 +72,8 @@ proc kill_server config {
     # kill server and wait for the process to be totally exited
     send_data_packet $::test_server_fd server-killing $pid
     catch {exec kill $pid}
+    # Node might have been stopped in the test
+    catch {exec kill -SIGCONT $pid}
     if {$::valgrind} {
         set max_wait 60000
     } else {


### PR DESCRIPTION
If a test fails while a node is stopped, we intercept the signal but since it's stopped it never exits until the timeout kills it. This just executes a continue signal to all nodes to cover that case, so tests exit more quickly.