### PR TITLE
Fix div by 0 in redis-cli cluster creation

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2969,7 +2969,7 @@ static void clusterManagerOptimizeAntiAffinity(clusterManagerNodeArray *ipnodes,
                                                    ip_count,
                                                    &offenders,
                                                    &offending_len);
-        if (score == 0) break; // Optimal anti affinity reached
+        if (score == 0 || offending_len == 0) break; // Optimal anti affinity reached
         /* We'll try to randomly swap a slave's assigned master causing
          * an affinity problem with another random slave, to see if we
          * can improve the affinity. */


### PR DESCRIPTION
```
 redis-cli --cluster create 127.0.0.1:6379 127.0.0.1:6379 127.0.0.1:6379
 >>> Performing hash slots allocation on 3 nodes...
 Master[0] -> Slots 0 - 5460
 Master[1] -> Slots 5461 - 10922
 Master[2] -> Slots 10923 - 16383
 >>> Trying to optimize slaves allocation for anti-affinity
 Floating point exception (core dumped)
```