### PR TITLE
Cleanup usage of malloc_usable_size.

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -250,7 +250,7 @@ jobs:
     - name: make
       run: |
           apk add build-base
-          make REDIS_CFLAGS='-Werror' USE_JEMALLOC=no
+          make REDIS_CFLAGS='-Werror' USE_JEMALLOC=no CFLAGS=-DUSE_MALLOC_USABLE_SIZE
     - name: test
       run: |
         apk add tcl procps

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -48,6 +48,25 @@ jobs:
     - name: cluster tests
       run: ./runtest-cluster
 
+  test-ubuntu-no-malloc-usable-size:
+    runs-on: ubuntu-latest
+    if: github.repository == 'redis/redis'
+    timeout-minutes: 14400
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make MALLOC=libc CFLAGS=-DNO_MALLOC_USABLE_SIZE
+    - name: test
+      run: |
+        sudo apt-get install tcl8.6
+        ./runtest --accurate --verbose --dump-logs
+    - name: module api test
+      run: ./runtest-moduleapi --verbose
+    - name: sentinel tests
+      run: ./runtest-sentinel
+    - name: cluster tests
+      run: ./runtest-cluster
+
   test-ubuntu-32bit:
     runs-on: ubuntu-latest
     if: github.repository == 'redis/redis'
@@ -124,6 +143,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: make valgrind
+    - name: test
+      run: |
+        sudo apt-get update
+        sudo apt-get install tcl8.6 valgrind -y
+        ./runtest --valgrind --verbose --clients 1 --dump-logs
+    - name: module api test
+      run: ./runtest-moduleapi --valgrind --no-latency --verbose --clients 1
+
+  test-valgrind-no-malloc-usable-size:
+    runs-on: ubuntu-latest
+    if: github.repository == 'redis/redis'
+    timeout-minutes: 14400
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE"
     - name: test
       run: |
         sudo apt-get update

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -60,6 +60,11 @@ void zlibc_free(void *ptr) {
 #define ASSERT_NO_SIZE_OVERFLOW(sz) assert((sz) + PREFIX_SIZE > (sz))
 #endif
 
+/* When using the libc allocator, use a minimum allocation size to match the
+ * jemalloc behavior that doesn't return NULL in this case.
+ */
+#define MALLOC_MIN_SIZE(x) ((x) > 0 ? (x) : sizeof(long))
+
 /* Explicitly override malloc/free etc when using tcmalloc. */
 #if defined(USE_TCMALLOC)
 #define malloc(size) tc_malloc(size)
@@ -93,7 +98,7 @@ static void (*zmalloc_oom_handler)(size_t) = zmalloc_default_oom;
  * '*usable' is set to the usable size if non NULL. */
 void *ztrymalloc_usable(size_t size, size_t *usable) {
     ASSERT_NO_SIZE_OVERFLOW(size);
-    void *ptr = malloc(size+PREFIX_SIZE);
+    void *ptr = malloc(MALLOC_MIN_SIZE(size)+PREFIX_SIZE);
 
     if (!ptr) return NULL;
 #ifdef HAVE_MALLOC_SIZE
@@ -153,7 +158,7 @@ void zfree_no_tcache(void *ptr) {
  * '*usable' is set to the usable size if non NULL. */
 void *ztrycalloc_usable(size_t size, size_t *usable) {
     ASSERT_NO_SIZE_OVERFLOW(size);
-    void *ptr = calloc(1, size+PREFIX_SIZE);
+    void *ptr = calloc(1, MALLOC_MIN_SIZE(size)+PREFIX_SIZE);
     if (ptr == NULL) return NULL;
 
 #ifdef HAVE_MALLOC_SIZE
@@ -675,7 +680,7 @@ int zmalloc_test(int argc, char **argv) {
 
     UNUSED(argc);
     UNUSED(argv);
-    printf("Malloc prefix size: %zu\n", PREFIX_SIZE);
+    printf("Malloc prefix size: %d\n", (int) PREFIX_SIZE);
     printf("Initial used memory: %zu\n", zmalloc_used_memory());
     ptr = zmalloc(123);
     printf("Allocated 123 bytes; used: %zu\n", zmalloc_used_memory());

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -675,6 +675,7 @@ int zmalloc_test(int argc, char **argv) {
 
     UNUSED(argc);
     UNUSED(argv);
+    printf("Malloc prefix size: %zu\n", PREFIX_SIZE);
     printf("Initial used memory: %zu\n", zmalloc_used_memory());
     ptr = zmalloc(123);
     printf("Allocated 123 bytes; used: %zu\n", zmalloc_used_memory());

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -62,11 +62,18 @@
 #endif
 
 /* On native libc implementations, we should still do our best to provide a
- * HAVE_MALLOC_SIZE capability.
+ * HAVE_MALLOC_SIZE capability. This can be set explicitly as well:
+ *
+ * NO_MALLOC_USABLE_SIZE disables it on all platforms, even if they are
+ *      known to support it.
+ * USE_MALLOC_USABLE_SIZE forces use of malloc_usable_size() regardless
+ *      of platform.
  */
 #ifndef ZMALLOC_LIB
 #define ZMALLOC_LIB "libc"
-#if defined(__GLIBC__) || defined(__FreeBSD__)
+#if !defined(NO_MALLOC_USABLE_SIZE) && \
+    (defined(__GLIBC__) || defined(__FreeBSD__) || \
+     defined(USE_MALLOC_USABLE_SIZE))
 #include <malloc.h>
 #define HAVE_MALLOC_SIZE 1
 #define zmalloc_size(p) malloc_usable_size(p)


### PR DESCRIPTION
* Allow explicit control of HAVE_MALLOC_SIZE when using libc.
* zmalloc(0) should align with jemalloc and never return NULL, panic, or return something valgrind will consider a dangling pointer (and report false leaks).
* Move alpine-libc daily to use malloc_usable_size.
* Create an explicit no-malloc-usable-size daily with valgrind.