### PR TITLE
fix: call CLIENT INFO from redis module will crash the server

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -427,7 +427,7 @@ int connGetState(connection *conn) {
  * For sockets, we always return "fd=<fdnum>" to maintain compatibility.
  */
 const char *connGetInfo(connection *conn, char *buf, size_t buf_len) {
-    snprintf(buf, buf_len-1, "fd=%i", conn->fd);
+    snprintf(buf, buf_len-1, "fd=%i", conn == NULL ? -1 : conn->fd);
     return buf;
 }
 

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -106,4 +106,8 @@ start_server {tags {"modules"}} {
         r test.log_tsctx "info" "Test message"
         verify_log_message 0 "*<misc> Test message*" 0
     }
+
+    test {test RM_Call CLIENT INFO} {
+        assert_match "*fd=-1*" [r test.call_generic client info]
+    }
 }


### PR DESCRIPTION
HI, Mr.Big @oranagra 

In #8508 , I wanna get client username by `redis-module` api. But it's not release. So I need to find a way....
Here's what i think... Firstly call `client info`, Secondly parse the `reply` string.  Of course this approach 
does not work. Because when the `RM_CALL` is invoked. It will create a faker client.

The point is client connection is NULL, so server will crash in `connGetInfo `

My solution is set the `fd` to an illegal value(-1) to avoid crashing.  What do you think about 😄
