### PR TITLE
Improve redis-cli non-binary safe string handling.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7369,10 +7369,10 @@ static void pipeMode(void) {
 static redisReply *sendScan(unsigned long long *it) {
     redisReply *reply;
 
-    if (config.pattern) {
+    if (config.pattern)
         reply = redisCommand(context, "SCAN %llu MATCH %b",
-                             *it, config.pattern, sdslen(config.pattern));
-    } else
+            *it, config.pattern, sdslen(config.pattern));
+    else
         reply = redisCommand(context,"SCAN %llu",*it);
 
     /* Handle any error conditions */

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7960,8 +7960,16 @@ static void scanMode(void) {
             unsigned int j;
 
             cur = strtoull(reply->element[0]->str,NULL,10);
-            for (j = 0; j < reply->element[1]->elements; j++)
-                printf("%s\n", reply->element[1]->element[j]->str);
+            for (j = 0; j < reply->element[1]->elements; j++) {
+                if (config.output == OUTPUT_STANDARD) {
+                    sds out = sdscatrepr(sdsempty(), reply->element[1]->element[j]->str,
+                                         reply->element[1]->element[j]->len);
+                    printf("%s\n", out);
+                    sdsfree(out);
+                } else {
+                    printf("%s\n", reply->element[1]->element[j]->str);
+                }
+            }
         }
         freeReplyObject(reply);
     } while(cur != 0);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1576,10 +1576,10 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--scan")) {
             config.scan_mode = 1;
         } else if (!strcmp(argv[i],"--pattern") && !lastarg) {
-            if (config.pattern) sdsfree(config.pattern);
+            sdsfree(config.pattern);
             config.pattern = sdsnew(argv[++i]);
         } else if (!strcmp(argv[i],"--quoted-pattern") && !lastarg) {
-            if (config.pattern) sdsfree(config.pattern);
+            sdsfree(config.pattern);
             config.pattern = unquoteCString(argv[++i]);
             if (!config.pattern) {
                 fprintf(stderr,"Invalid quoted string specified for --quoted-pattern.\n");

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1576,10 +1576,10 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--scan")) {
             config.scan_mode = 1;
         } else if (!strcmp(argv[i],"--pattern") && !lastarg) {
-            if (config.pattern) sds_free(config.pattern);
+            if (config.pattern) sdsfree(config.pattern);
             config.pattern = sdsnew(argv[++i]);
         } else if (!strcmp(argv[i],"--quoted-pattern") && !lastarg) {
-            if (config.pattern) sds_free(config.pattern);
+            if (config.pattern) sdsfree(config.pattern);
             config.pattern = unquoteCString(argv[++i]);
             if (!config.pattern) {
                 fprintf(stderr,"Invalid quoted string specified for --quoted-pattern.\n");
@@ -1905,7 +1905,7 @@ static void usage(void) {
 "  --pattern <pat>    Keys pattern when using the --scan, --bigkeys or --hotkeys\n"
 "                     options (default: *).\n"
 "  --quoted-pattern <pat> Same as --pattern, but the specified string can be\n"
-"                         quoted, in order to pass a non binary-safe string.\n"
+"                         quoted, in order to pass an otherwise non binary-safe string.\n"
 "  --intrinsic-latency <sec> Run a test to measure intrinsic system latency.\n"
 "                     The test will run for the specified amount of seconds.\n"
 "  --eval <file>      Send an EVAL command using the Lua script at <file>.\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -768,16 +768,17 @@ static void freeHintsCallback(void *ptr) {
 static sds unquoteCString(char *str) {
     int count;
     sds *unquoted = sdssplitargs(str, &count);
+    sds res = NULL;
 
     if (unquoted && count == 1) {
-        sds res = unquoted[0];
-        sds_free(unquoted);
-        return res;
+        res = unquoted[0];
+        unquoted[0] = NULL;
     }
 
     if (unquoted)
         sdsfreesplitres(unquoted, count);
-    return NULL;
+
+    return res;
 }
 
 /* Send AUTH command to the server */
@@ -1931,6 +1932,7 @@ static void usage(void) {
 "  redis-cli get mypasswd\n"
 "  redis-cli -r 100 lpush mylist x\n"
 "  redis-cli -r 100 -i 1 info | grep used_memory_human:\n"
+"  redis-cli --quoted-input set '\"null-\\x00-separated\"' value\n"
 "  redis-cli --eval myscript.lua key1 key2 , arg1 arg2 arg3\n"
 "  redis-cli --scan --pattern '*:12345*'\n"
 "\n"

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -280,7 +280,7 @@ start_server {tags {"cli"}} {
         assert_equal {key:2} [run_cli --scan --pattern "*:2"]
 
         # pattern matching with a quoted string
-        assert_equal {key:2} [run_cli --scan --quoted-input --pattern {"*:\x32"}]
+        assert_equal {key:2} [run_cli --scan --quoted-pattern {"*:\x32"}]
     }
 
     test "Connecting as a replica" {

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -207,6 +207,28 @@ start_server {tags {"cli"}} {
         assert_equal "foo\nbar" [run_cli lrange list 0 -1]
     }
 
+    test_nontty_cli "Quoted input arguments" {
+        r set "\x00\x00" "value"
+        assert_equal "value" [run_cli --quoted-input get {"\x00\x00"}]
+    }
+
+    test_nontty_cli "No accidental unquoting of input arguments" {
+        run_cli --quoted-input set {"\x41\x41"} quoted-val
+        run_cli set {"\x41\x41"} unquoted-val
+
+        assert_equal "quoted-val" [r get AA]
+        assert_equal "unquoted-val" [r get {"\x41\x41"}]
+    }
+
+    test_nontty_cli "Invalid quoted input arguments" {
+        catch {run_cli --quoted-input set {"Unterminated}} err
+        assert_match {*exited abnormally*} $err
+
+        # A single arg that unquotes to two arguments is also not expected
+        catch {run_cli --quoted-input set {"arg1" "arg2"}} err
+        assert_match {*exited abnormally*} $err
+    }
+
     test_nontty_cli "Read last argument from pipe" {
         assert_equal "OK" [run_cli_with_input_pipe "echo foo" set key]
         assert_equal "foo\n" [r get key]
@@ -245,6 +267,20 @@ start_server {tags {"cli"}} {
         assert_match "OK" [r config set repl-diskless-sync yes]
         assert_match "OK" [r config set repl-diskless-sync-delay 0]
         test_redis_cli_rdb_dump
+    }
+
+    test "Scan mode" {
+        r flushdb
+        r debug populate 1000 key 1
+
+        # basic use
+        assert_equal 1000 [llength [split [run_cli --scan]]]
+
+        # pattern
+        assert_equal {key:2} [run_cli --scan --pattern "*:2"]
+
+        # pattern matching with a quoted string
+        assert_equal {key:2} [run_cli --scan --quoted-input --pattern {"*:\x32"}]
     }
 
     test "Connecting as a replica" {

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -271,7 +271,7 @@ start_server {tags {"cli"}} {
 
     test "Scan mode" {
         r flushdb
-        r debug populate 1000 key 1
+        populate 1000 key: 1
 
         # basic use
         assert_equal 1000 [llength [split [run_cli --scan]]]


### PR DESCRIPTION
* The `redis-cli --scan` output should honor output mode (set explicitly or implicitly), and quote key names when not in raw mode.
  * Technically this is a breaking change, but it should be very minor since raw mode is by default on for non-tty output.
  * It should only affect  TTY output (human users) or non-tty output if `--no-raw` is specified.

* Added `--quoted-input` option to treat all arguments as potentially quoted strings.
* Added `--quoted-pattern` option to accept a potentially quoted pattern.

Unquoting is applied to potentially quoted input only if single or double quotes are used. 

Fixes #8561, #8563