### PR TITLE
Sentinel: fix info_refresh time before sentinel get first response

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3343,7 +3343,8 @@ void addReplySentinelRedisInstance(client *c, sentinelRedisInstance *ri) {
     /* Masters and Slaves */
     if (ri->flags & (SRI_MASTER|SRI_SLAVE)) {
         addReplyBulkCString(c,"info-refresh");
-        addReplyBulkLongLong(c,mstime() - ri->info_refresh);
+        addReplyBulkLongLong(c,
+            ri->info_refresh ? (mstime() - ri->info_refresh) : 0);
         fields++;
 
         addReplyBulkCString(c,"role-reported");
@@ -3820,7 +3821,8 @@ NULL
             addReplyBulkCBuffer(c,ri->name,strlen(ri->name));
             addReplyArrayLen(c,dictSize(ri->slaves) + 1); /* +1 for self */
             addReplyArrayLen(c,2);
-            addReplyLongLong(c, now - ri->info_refresh);
+            addReplyLongLong(c,
+                ri->info_refresh ? (now - ri->info_refresh) : 0);
             if (ri->info)
                 addReplyBulkCBuffer(c,ri->info,sdslen(ri->info));
             else
@@ -3832,7 +3834,8 @@ NULL
             while ((sde = dictNext(sdi)) != NULL) {
                 sentinelRedisInstance *sri = dictGetVal(sde);
                 addReplyArrayLen(c,2);
-                addReplyLongLong(c, now - sri->info_refresh);
+                addReplyLongLong(c,
+                    ri->info_refresh ? (now - sri->info_refresh) : 0);
                 if (sri->info)
                     addReplyBulkCBuffer(c,sri->info,sdslen(sri->info));
                 else


### PR DESCRIPTION
Before this commit, when sentinel doesn't sucessfully get response from monitored master/replicas the info-refresh field will show current unix timestamps in milliseconds, which does not have valid meaning IMHO.. Similarly to `last-ping-sent` field, if sentinel has not get response for info command, we should reply value as 0 to indicate the reply has never been received.

```
127.0.0.1:26379> sentinel masters
****************
   25) "info-refresh"
   26) "1614269775017"
```