### PR TITLE
Remove unused parameter container in quicklist

### DIFF
--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -38,8 +38,7 @@
 /* quicklistNode is a 32 byte struct describing a ziplist for a quicklist.
  * We use bit fields keep the quicklistNode at 32 bytes.
  * count: 16 bits, max 65536 (max zl bytes is 65k, so max count actually < 32k).
- * encoding: 2 bits, RAW=1, LZF=2.
- * container: 2 bits, NONE=1, ZIPLIST=2.
+ * encoding: 2 bits, ZIPLIST=1, LZF=2.
  * recompress: 1 bit, bool, true if node is temporary decompressed for usage.
  * attempted_compress: 1 bit, boolean, used for verifying during testing.
  * extra: 10 bits, free for future use; pads out the remainder of 32 bits */
@@ -49,8 +48,7 @@ typedef struct quicklistNode {
     unsigned char *zl;
     unsigned int sz;             /* ziplist size in bytes */
     unsigned int count : 16;     /* count of items in ziplist */
-    unsigned int encoding : 2;   /* RAW==1 or LZF==2 */
-    unsigned int container : 2;  /* NONE==1 or ZIPLIST==2 */
+    unsigned int encoding : 2;   /* ZIPLIST==1 or LZF==2 */
     unsigned int recompress : 1; /* was this node previous compressed? */
     unsigned int attempted_compress : 1; /* node can't compress; too small */
     unsigned int extra : 10; /* more bits to steal for future usage */
@@ -135,15 +133,11 @@ typedef struct quicklistEntry {
 #define QUICKLIST_TAIL -1
 
 /* quicklist node encodings */
-#define QUICKLIST_NODE_ENCODING_RAW 1
+#define QUICKLIST_NODE_ENCODING_ZIPLIST 1
 #define QUICKLIST_NODE_ENCODING_LZF 2
 
 /* quicklist compression disable */
 #define QUICKLIST_NOCOMPRESS 0
-
-/* quicklist container formats */
-#define QUICKLIST_NODE_CONTAINER_NONE 1
-#define QUICKLIST_NODE_CONTAINER_ZIPLIST 2
 
 #define quicklistNodeIsCompressed(node)                                        \
     ((node)->encoding == QUICKLIST_NODE_ENCODING_LZF)


### PR DESCRIPTION
* Remove container parameter
The container parameter is only set at initialization and is not used anywhere else.

* Change `QUICKLIST_NODE_ENCODING_RAW` to `QUICKLIST_NODE_ENCODING_ZIPLIST`
When encoding is `QUICKLIST_NODE_ENCODING_RAW`, the encoding of quicklist is actually ziplist.