### PR TITLE
fix new networking tests to work when the test suite is used in tls mode

### DIFF
--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -1,20 +1,22 @@
 test {CONFIG SET port number} {
     start_server {} {
+        if {$::tls} { set port_cfg tls-port} else { set port_cfg port }
+
         # available port
         set avail_port [find_available_port $::baseport $::portcount]
-        set rd [redis [srv 0 host] [srv 0 port] 0 0]
-        $rd CONFIG SET port $avail_port
+        set rd [redis [srv 0 host] [srv 0 port] 0 $::tls]
+        $rd CONFIG SET $port_cfg $avail_port
         $rd close
-        set rd [redis [srv 0 host] $avail_port 0 0]
+        set rd [redis [srv 0 host] $avail_port 0 $::tls]
         $rd PING
 
         # already inuse port
-        catch {$rd CONFIG SET port $::test_server_port} e
+        catch {$rd CONFIG SET $port_cfg $::test_server_port} e
         assert_match {*Unable to listen on this port*} $e
         $rd close
 
         # make sure server still listening on the previous port
-        set rd [redis [srv 0 host] $avail_port 0 0]
+        set rd [redis [srv 0 host] $avail_port 0 $::tls]
         $rd PING
         $rd close
     }
@@ -27,7 +29,7 @@ test {CONFIG SET bind address} {
         assert_match {*Failed to bind to specified addresses*} $e
 
         # make sure server still bound to the previous address
-        set rd [redis [srv 0 host] [srv 0 port] 0 0]
+        set rd [redis [srv 0 host] [srv 0 port] 0 $::tls]
         $rd PING
         $rd close
     }


### PR DESCRIPTION
the tests were unable to connect to the server since the attempted to use normal tcp