### PR TITLE
Skip unnecessary check for pong received

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3630,7 +3630,6 @@ void clusterCron(void) {
             now - node->link->ctime >
             server.cluster_node_timeout && /* was not already reconnected */
             node->ping_sent && /* we already sent a ping */
-            node->pong_received < node->ping_sent && /* still waiting pong */
             /* and we are waiting for the pong more than timeout/2 */
             ping_delay > server.cluster_node_timeout/2 &&
             /* and in such interval we are not seeing any traffic at all. */


### PR DESCRIPTION
An active ping is indicated by node->ping_sent being non-zero. When a pong is received, node->ping_sent is reset to zero, so it is redundant to check both node->ping_sent and pong_received. 

This resolves an issue when a dropped ping may prevent failure detection if the pong time was updated for some other reason. 

Closes #8057