### PR TITLE
Improve SSL cleanup handling.

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -870,6 +870,7 @@ void sentinelRunPendingScripts(void) {
             sj->pid = 0;
         } else if (pid == 0) {
             /* Child */
+            tlsCleanup();
             execve(sj->argv[0],sj->argv,environ);
             /* If we are here an error occurred. */
             _exit(2); /* Don't retry execution. */

--- a/src/server.h
+++ b/src/server.h
@@ -2715,6 +2715,7 @@ void makeThreadKillable(void);
 
 /* TLS stuff */
 void tlsInit(void);
+void tlsCleanup(void);
 int tlsConfigure(redisTLSContextConfig *ctx_config);
 
 #define redisDebug(fmt, ...) \

--- a/src/tls.c
+++ b/src/tls.c
@@ -147,7 +147,7 @@ void tlsInit(void) {
     #if OPENSSL_VERSION_NUMBER < 0x10100000L
     OPENSSL_config(NULL);
     #else
-    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG|OPENSSL_INIT_ATFORK, NULL);
     #endif
     ERR_load_crypto_strings();
     SSL_load_error_strings();
@@ -162,6 +162,21 @@ void tlsInit(void) {
     }
 
     pending_list = listCreate();
+}
+
+void tlsCleanup(void) {
+    if (redis_tls_ctx) {
+        SSL_CTX_free(redis_tls_ctx);
+        redis_tls_ctx = NULL;
+    }
+    if (redis_tls_client_ctx) {
+        SSL_CTX_free(redis_tls_client_ctx);
+        redis_tls_client_ctx = NULL;
+    }
+
+    #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    OPENSSL_cleanup();
+    #endif
 }
 
 /* Create a *base* SSL_CTX using the SSL configuration provided. The base context
@@ -946,6 +961,9 @@ sds connTLSGetPeerCert(connection *conn_) {
 #else   /* USE_OPENSSL */
 
 void tlsInit(void) {
+}
+
+void tlsCleanup(void) {
 }
 
 int tlsConfigure(redisTLSContextConfig *ctx_config) {


### PR DESCRIPTION
This solves the problem of /dev/random and /dev/urandom open file
descriptors leaking to childs with some versions of OpenSSL.