### PR TITLE
[Sentinel] generalize error check for SENTINEL MONITOR rumtime config

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3710,17 +3710,7 @@ NULL
         ri = createSentinelRedisInstance(c->argv[2]->ptr,SRI_MASTER,
                 c->argv[3]->ptr,port,quorum,NULL);
         if (ri == NULL) {
-            switch(errno) {
-            case EBUSY:
-                addReplyError(c,"Duplicated master name");
-                break;
-            case EINVAL:
-                addReplyError(c,"Invalid port number");
-                break;
-            default:
-                addReplyError(c,"Unspecified error adding the instance");
-                break;
-            }
+            addReplyError(c,sentinelCheckCreateInstanceErrors(SRI_MASTER));
         } else {
             sentinelFlushConfig();
             sentinelEvent(LL_WARNING,"+monitor",ri,"%@ quorum %d",ri->quorum);


### PR DESCRIPTION
Since sentinelCheckCreateInstanceErrors function was introduced, we can use it to generalize the error check for create master instances in SENTINEL MONITOR command.