### PR TITLE
remove unused latency variable

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -102,7 +102,6 @@ static struct config {
     int showerrors;
     long long start;
     long long totlatency;
-    long long *latency;
     const char *title;
     list *clients;
     int quiet;


### PR DESCRIPTION
After [#7600](https://github.com/redis/redis/pull/7600) it is no longer used.