### PR TITLE
Wrong usage sdscatprintf in redis-cli.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2913,8 +2913,12 @@ static int clusterManagerGetAntiAffinityScore(clusterManagerNodeArray *ipnodes,
             else types = sdsempty();
             /* Master type 'm' is always set as the first character of the
              * types string. */
-            if (!node->replicate) types = sdscatprintf(types, "m%s", types);
-            else types = sdscat(types, "s");
+            if (node->replicate) types = sdscat(types, "s");
+            else {
+                sds s = sdscatsds(sdsnew("m"), types);
+                sdsfree(types);
+                types = s;
+            }
             dictReplace(related, key, types);
         }
         /* Now it's trivial to check, for each related group having the


### PR DESCRIPTION
The result of `sdscatprintf` is doubled when using argument twice.