### PR TITLE
add resize-hashtables-enabled config to control tryResizeHashTables in serverCron()

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1745,6 +1745,21 @@ hll-sparse-max-bytes 3000
 stream-node-max-bytes 4096
 stream-node-max-entries 100
 
+# enable resize the main Redis hash table (the one mapping top-level keys to
+# values) when dictSlots much larger than dictSize for free memroy.
+#
+# If unsure:
+# use "resize-hashtables-enabled yes" if you don't have such hard requirements
+# but want to save as much memory as possible.
+#
+# use "resize-hashtables-enabled no" if the number of keys change trend is the
+# same per day and frequently triggered dictResize/dictExpand operation, it will
+# keep the main Redis hash table at the state that can hold the most keys per day
+# to avoid create hashtables affect performance(Redis may block too long on allocate
+# large blocks of memory) and frequent rehashing operation cost CPU time.
+
+resize-hashtables-enabled yes
+
 # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
 # order to help rehashing the main Redis hash table (the one mapping top-level
 # keys to values). The hash table implementation Redis uses (see dict.c)

--- a/src/config.c
+++ b/src/config.c
@@ -2392,6 +2392,7 @@ standardConfig configs[] = {
     createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, server.protected_mode, 1, NULL, NULL),
     createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, server.rdb_compression, 1, NULL, NULL),
     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, server.rdb_del_sync_files, 0, NULL, NULL),
+    createBoolConfig("resize-hashtables-enabled", NULL, MODIFIABLE_CONFIG, server.resize_hashtables_enabled, 1, NULL, NULL),
     createBoolConfig("activerehashing", NULL, MODIFIABLE_CONFIG, server.activerehashing, 1, NULL, NULL),
     createBoolConfig("stop-writes-on-bgsave-error", NULL, MODIFIABLE_CONFIG, server.stop_writes_on_bgsave_err, 1, NULL, NULL),
     createBoolConfig("set-proc-title", NULL, IMMUTABLE_CONFIG, server.set_proc_title, 1, NULL, NULL), /* Should setproctitle be used? */

--- a/src/server.c
+++ b/src/server.c
@@ -1883,9 +1883,11 @@ void databasesCron(void) {
         if (dbs_per_call > server.dbnum) dbs_per_call = server.dbnum;
 
         /* Resize */
-        for (j = 0; j < dbs_per_call; j++) {
-            tryResizeHashTables(resize_db % server.dbnum);
-            resize_db++;
+        if (server.resize_hashtables_enabled) {
+            for (j = 0; j < dbs_per_call; j++) {
+                tryResizeHashTables(resize_db % server.dbnum);
+                resize_db++;
+            }
         }
 
         /* Rehash */

--- a/src/server.h
+++ b/src/server.h
@@ -1176,6 +1176,7 @@ struct redisServer {
     rax *errors;                /* Errors table */
     redisAtomic unsigned int lruclock; /* Clock for LRU eviction */
     volatile sig_atomic_t shutdown_asap; /* SHUTDOWN needed ASAP */
+    int resize_hashtables_enabled; /* Control ResizeHashTables in serverCron() */
     int activerehashing;        /* Incremental rehash in serverCron() */
     int active_defrag_running;  /* Active defragmentation running (holds current scan aggressiveness) */
     char *pidfile;              /* PID file path */


### PR DESCRIPTION
recently we discovered a redis-cluster(128 shared) that often reported slow log for simple commands, such as unlink/setex, the key/value are not big, we were confusion that such a simple command cost tens or even hundreds of milliseconds.

after we looked at the monitoring, we found some interesting things:
1. the number of keys in the  redis-cluster fluctuates greatly throughout the day(single node can reach up to 40 million keys a day, but the lowest was just 2.6 million), and the number of keys change trend is the same per day.
2. we found that the memory of the node would shake violently at certain times of the day(we don't have big Key delete or write).
3. the time points slowlog reported each day were very similar.

The number of keys change trend in the following figure:

<img width="947" alt="Snipaste_2021-03-06_22-18-26" src="https://user-images.githubusercontent.com/11421972/110210904-e8430080-7ece-11eb-9999-2553ada766f9.png">

We realized that it might have something to do with creating Hashtable at the begin of the Rehash, our redis-cluster node may need to allocate and free large chunks of memory, It could be up to 512MB for new hashtable(40 million keys require a table of size 2^26 to store, 2^26 * sizeof(dictEntry*) = 512MB), so we add some log in the code to record the allocate/free memory consumption time:

ZCalloc log:
<img width="1808" alt="zcalloc_source" src="https://user-images.githubusercontent.com/11421972/110211226-8edbd100-7ed0-11eb-9091-6c932147a1d3.png">

ZFree log:
<img width="1797" alt="zfree_source" src="https://user-images.githubusercontent.com/11421972/110211228-900cfe00-7ed0-11eb-9a67-dd6389f2e235.png">


then we watched for a few days, and sure enough, the slowlog was caused by allocate/free memory:
Setex slowlog:
<img width="1672" alt="setex_slowlog" src="https://user-images.githubusercontent.com/11421972/110211300-fbef6680-7ed0-11eb-89c9-833f81a024c1.png">

Unlink slowlog:
<img width="1679" alt="unlink_slowlog" src="https://user-images.githubusercontent.com/11421972/110211326-0ad61900-7ed1-11eb-87ec-c906ccb06925.png">


The detailed time consumption of these days is shown in the following figure:

ZCalloc time cost:
<img width="1635" alt="zcalloc_cost" src="https://user-images.githubusercontent.com/11421972/110211410-7ae49f00-7ed1-11eb-8c3a-2f1a2df03cdf.png">

ZFree time cost:
<img width="1610" alt="zfree_cost" src="https://user-images.githubusercontent.com/11421972/110211455-a4052f80-7ed1-11eb-8ed4-fbb3c792956c.png">

So I think for this type of instance(the number of keys change trend is the same per day), do we provide the ability to prevent ResizeHashTables(it lead to dictResize/dictExpand again and again every day, cost CPU time and may block too long on allocate/free large blocks of memory)? maybe users don't care about a little extra memory for Hashtables, but performance is what they really care about.







