### PR TITLE
In flushAppendOnlyFile update server.aof_last_fsync only when arrange a background fsync

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -529,9 +529,9 @@ try_fsync:
                 server.unixtime > server.aof_last_fsync)) {
         if (!sync_in_progress) {
             aof_background_fsync(server.aof_fd);
+            server.aof_last_fsync = server.unixtime;
             server.aof_fsync_offset = server.aof_current_size;
         }
-        server.aof_last_fsync = server.unixtime;
     }
 }
 


### PR DESCRIPTION
When appendfsync is everysec and fsync is in progress, server.aof_last_fsync will be updated, but no fsync is done. If fsync is done within 1 second, flushAppendOnlyFile has to wait next second before start a new fsync. This commit will make fsync ASAP.