### PR TITLE
Add hashtable-min-fill config to control ResizeHashTables

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1745,6 +1745,11 @@ hll-sparse-max-bytes 3000
 stream-node-max-bytes 4096
 stream-node-max-entries 100
 
+# If the percentage of used slots in the HashTable reaches "hashtable-min-fill", we
+# resize the HashTable to save memory (Default minimal hash table fill 10%), values
+# range from 1 to 50 (higher means more easier to trigger ResizeHashTables).
+hashtable-min-fill 10
+
 # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
 # order to help rehashing the main Redis hash table (the one mapping top-level
 # keys to values). The hash table implementation Redis uses (see dict.c)

--- a/src/config.c
+++ b/src/config.c
@@ -2491,6 +2491,7 @@ standardConfig configs[] = {
     createIntConfig("hz", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.config_hz, CONFIG_DEFAULT_HZ, INTEGER_CONFIG, NULL, updateHZ),
     createIntConfig("min-replicas-to-write", "min-slaves-to-write", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_to_write, 0, INTEGER_CONFIG, NULL, updateGoodSlaves),
     createIntConfig("min-replicas-max-lag", "min-slaves-max-lag", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_max_lag, 10, INTEGER_CONFIG, NULL, updateGoodSlaves),
+    createIntConfig("hashtable-min-fill", NULL, MODIFIABLE_CONFIG, 1, 50, server.hashtable_min_fill, 10, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),

--- a/src/server.c
+++ b/src/server.c
@@ -1555,10 +1555,10 @@ int htNeedsResize(dict *dict) {
     size = dictSlots(dict);
     used = dictSize(dict);
     return (size > DICT_HT_INITIAL_SIZE &&
-            (used*100/size < HASHTABLE_MIN_FILL));
+            (used*100/size < server.hashtable_min_fill));
 }
 
-/* If the percentage of used slots in the HT reaches HASHTABLE_MIN_FILL
+/* If the percentage of used slots in the HT reaches server.hashtable_min_fill
  * we resize the hash table to save memory */
 void tryResizeHashTables(int dbid) {
     if (htNeedsResize(server.db[dbid].dict))

--- a/src/server.h
+++ b/src/server.h
@@ -162,7 +162,6 @@ typedef long long ustime_t; /* microsecond time type. */
 extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 
 /* Hash table parameters */
-#define HASHTABLE_MIN_FILL        10      /* Minimal hash table fill 10% */
 #define HASHTABLE_MAX_LOAD_FACTOR 1.618   /* Maximum hash table load factor. */
 
 /* Command flags. Please check the command table defined in the server.c file
@@ -1176,6 +1175,7 @@ struct redisServer {
     rax *errors;                /* Errors table */
     redisAtomic unsigned int lruclock; /* Clock for LRU eviction */
     volatile sig_atomic_t shutdown_asap; /* SHUTDOWN needed ASAP */
+    int hashtable_min_fill;     /* Minimal hash table fill */
     int activerehashing;        /* Incremental rehash in serverCron() */
     int active_defrag_running;  /* Active defragmentation running (holds current scan aggressiveness) */
     char *pidfile;              /* PID file path */


### PR DESCRIPTION
This hashtable-min-fill config allows users to control the trigger timing of dictreSize more accurately, for specific reasons, refer to #8611 