### PR TITLE
Fix for benchmark output cannot ensure clean line

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1648,7 +1648,10 @@ int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData
     const float instantaneous_rps = (float)(requests_finished-previous_requests_finished)/instantaneous_dt;
     config.previous_tick = current_tick;
     atomicSet(config.previous_requests_finished,requests_finished);
-    config.last_printed_bytes = printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)\r", config.title, instantaneous_rps, rps, hdr_mean(config.current_sec_latency_histogram)/1000.0f, hdr_mean(config.latency_histogram)/1000.0f);
+    int printed_bytes = printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)\r", config.title, instantaneous_rps, rps, hdr_mean(config.current_sec_latency_histogram)/1000.0f, hdr_mean(config.latency_histogram)/1000.0f);
+    if (printed_bytes > config.last_printed_bytes){
+       config.last_printed_bytes = printed_bytes;
+    }
     hdr_reset(config.current_sec_latency_histogram);
     fflush(stdout);
     return 250; /* every 250ms */


### PR DESCRIPTION
when run benchmark with multi threads(easy to reproduce), the output message cannot erase the longger output at the tail.

```
# ./redis-benchmark -q --threads 3
PING_INLINE: 132802.12 requests per second, p50=0.343 msec                   
PING_MBULK: 132802.12 requests per second, p50=0.335 msec                    
SET: 132978.73 requests per second, p50=0.351 msec               358)
GET: 132978.73 requests per second, p50=0.343 msec                 3)
INCR: 132978.73 requests per second, p50=0.343 msec               348)
LPUSH: 99700.90 requests per second, p50=0.367 msec                 )))
RPUSH: 132978.73 requests per second, p50=0.351 msec              .351)
LPOP: 99700.90 requests per second, p50=0.367 msec               .369)
RPOP: 132978.73 requests per second, p50=0.359 msec                    
SADD: 132978.73 requests per second, p50=0.351 msec                56)
HSET: 99700.90 requests per second, p50=0.359 msec                  1)
SPOP: 132978.73 requests per second, p50=0.343 msec                43)
ZADD: 132802.12 requests per second, p50=0.359 msec               365)
ZPOPMIN: 132978.73 requests per second, p50=0.343 msec              .359)
```
