### PR TITLE
Fix some issues with modules and MULTI/EXEC 

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -113,30 +113,30 @@ void discardCommand(client *c) {
     addReply(c,shared.ok);
 }
 
-void beforePropagateMultiOrExec(int multi) {
-    if (multi) {
-        /* Propagating MULTI */
-        serverAssert(!server.propagate_in_transaction);
-        server.propagate_in_transaction = 1;
-    } else {
-        /* Propagating EXEC */
-        serverAssert(server.propagate_in_transaction == 1);
-        server.propagate_in_transaction = 0;
-    }
+void beforePropagateMulti() {
+    /* Propagating MULTI */
+    serverAssert(!server.propagate_in_transaction);
+    server.propagate_in_transaction = 1;
+}
+
+void afterPropagateExec() {
+    /* Propagating EXEC */
+    serverAssert(server.propagate_in_transaction == 1);
+    server.propagate_in_transaction = 0;
 }
 
 /* Send a MULTI command to all the slaves and AOF file. Check the execCommand
  * implementation for more information. */
 void execCommandPropagateMulti(int dbid) {
-    beforePropagateMultiOrExec(1);
+    beforePropagateMulti();
     propagate(server.multiCommand,dbid,&shared.multi,1,
               PROPAGATE_AOF|PROPAGATE_REPL);
 }
 
 void execCommandPropagateExec(int dbid) {
-    beforePropagateMultiOrExec(0);
     propagate(server.execCommand,dbid,&shared.exec,1,
               PROPAGATE_AOF|PROPAGATE_REPL);
+    afterPropagateExec();
 }
 
 /* Aborts a transaction, with a specific error message.
@@ -254,7 +254,6 @@ void execCommand(client *c) {
     if (server.propagate_in_transaction) {
         int is_master = server.masterhost == NULL;
         server.dirty++;
-        beforePropagateMultiOrExec(0);
         /* If inside the MULTI/EXEC block this instance was suddenly
          * switched from master to slave (using the SLAVEOF command), the
          * initial MULTI was propagated into the replication backlog, but the
@@ -264,6 +263,7 @@ void execCommand(client *c) {
             char *execcmd = "*1\r\n$4\r\nEXEC\r\n";
             feedReplicationBacklog(execcmd,strlen(execcmd));
         }
+        afterPropagateExec();
     }
 
     server.in_exec = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -3158,6 +3158,7 @@ void initServer(void) {
     server.clients_pending_write = listCreate();
     server.clients_pending_read = listCreate();
     server.clients_timeout_table = raxNew();
+    server.replication_allowed = 1;
     server.slaveseldb = -1; /* Force to emit the first SELECT command. */
     server.unblocked_clients = listCreate();
     server.ready_keys = listCreate();
@@ -3553,6 +3554,9 @@ struct redisCommand *lookupCommandOrOriginal(sds name) {
 void propagate(struct redisCommand *cmd, int dbid, robj **argv, int argc,
                int flags)
 {
+    if (!server.replication_allowed)
+        return;
+
     /* Propagate a MULTI request once we encounter the first command which
      * is a write command.
      * This way we'll deliver the MULTI/..../EXEC block as a whole and

--- a/src/server.c
+++ b/src/server.c
@@ -3502,6 +3502,7 @@ void redisOpArrayFree(redisOpArray *oa) {
         zfree(op->argv);
     }
     zfree(oa->ops);
+    oa->ops = NULL;
 }
 
 /* ====================== Commands lookup and execution ===================== */

--- a/src/server.h
+++ b/src/server.h
@@ -1400,6 +1400,7 @@ struct redisServer {
     int child_info_nread;           /* Num of bytes of the last read from pipe */
     /* Propagation of commands in AOF / replication */
     redisOpArray also_propagate;    /* Additional command to propagate. */
+    int replication_allowed;        /* Are we allowed to replicate? */
     /* Logging */
     char *logfile;                  /* Path of log file */
     int syslog_enabled;             /* Is syslog enabled? */

--- a/src/server.h
+++ b/src/server.h
@@ -1932,7 +1932,8 @@ void flagTransaction(client *c);
 void execCommandAbort(client *c, sds error);
 void execCommandPropagateMulti(int dbid);
 void execCommandPropagateExec(int dbid);
-void beforePropagateMultiOrExec(int multi);
+void beforePropagateMulti();
+void afterPropagateExec();
 
 /* Redis object implementation */
 void decrRefCount(robj *o);

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -42,6 +42,58 @@ tags "modules" {
                     close_replication_stream $repl
                 }
 
+                test {module propagates nested ctx case1} {
+                    set repl [attach_to_replication_stream]
+
+                    $master del timer-mixed-start
+                    $master del timer-mixed-end
+                    $master propagate-test.timer-mixed
+
+                    wait_for_condition 5000 10 {
+                        [$replica get timer-mixed-end] eq "1"
+                    } else {
+                        fail "The two counters don't match the expected value."
+                    }
+
+                    # Note the 'after-call' and 'timer-mixed-start' propagation below is out of order (known limitation)
+                    assert_replication_stream $repl {
+                        {select *}
+                        {multi}
+                        {incrby timer-mixed-start 1}
+                        {incrby timer-mixed-end 1}
+                        {exec}
+                    }
+                    close_replication_stream $repl
+                }
+
+                test {module propagates nested ctx case2} {
+                    set repl [attach_to_replication_stream]
+
+                    $master del timer-mixed-start
+                    $master del timer-mixed-end
+                    $master propagate-test.timer-mixed-repl
+
+                    wait_for_condition 5000 10 {
+                        [$replica get timer-mixed-end] eq "1"
+                    } else {
+                        fail "The two counters don't match the expected value."
+                    }
+
+                    # Note the 'after-call' and 'timer-mixed-start' propagation below is out of order (known limitation)
+                    assert_replication_stream $repl {
+                        {select *}
+                        {multi}
+                        {incr using-call}
+                        {incr after-call}
+                        {incr counter-1}
+                        {incr counter-2}
+                        {incrby timer-mixed-start 1}
+                        {incrby timer-mixed-end 1}
+                        {exec}
+                    }
+                    close_replication_stream $repl
+                }
+
                 test {module propagates from thread} {
                     set repl [attach_to_replication_stream]
 

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -45,22 +45,21 @@ tags "modules" {
                 test {module propagates nested ctx case1} {
                     set repl [attach_to_replication_stream]
 
-                    $master del timer-mixed-start
-                    $master del timer-mixed-end
-                    $master propagate-test.timer-mixed
+                    $master del timer-nested-start
+                    $master del timer-nested-end
+                    $master propagate-test.timer-nested
 
                     wait_for_condition 5000 10 {
-                        [$replica get timer-mixed-end] eq "1"
+                        [$replica get timer-nested-end] eq "1"
                     } else {
                         fail "The two counters don't match the expected value."
                     }
 
-                    # Note the 'after-call' and 'timer-mixed-start' propagation below is out of order (known limitation)
                     assert_replication_stream $repl {
                         {select *}
                         {multi}
-                        {incrby timer-mixed-start 1}
-                        {incrby timer-mixed-end 1}
+                        {incrby timer-nested-start 1}
+                        {incrby timer-nested-end 1}
                         {exec}
                     }
                     close_replication_stream $repl
@@ -69,26 +68,28 @@ tags "modules" {
                 test {module propagates nested ctx case2} {
                     set repl [attach_to_replication_stream]
 
-                    $master del timer-mixed-start
-                    $master del timer-mixed-end
-                    $master propagate-test.timer-mixed-repl
+                    $master del timer-nested-start
+                    $master del timer-nested-end
+                    $master propagate-test.timer-nested-repl
 
                     wait_for_condition 5000 10 {
-                        [$replica get timer-mixed-end] eq "1"
+                        [$replica get timer-nested-end] eq "1"
                     } else {
                         fail "The two counters don't match the expected value."
                     }
 
-                    # Note the 'after-call' and 'timer-mixed-start' propagation below is out of order (known limitation)
+                    # Note the 'after-call' and 'timer-nested-start' propagation below is out of order (known limitation)
                     assert_replication_stream $repl {
                         {select *}
                         {multi}
                         {incr using-call}
-                        {incr after-call}
                         {incr counter-1}
                         {incr counter-2}
-                        {incrby timer-mixed-start 1}
-                        {incrby timer-mixed-end 1}
+                        {incr after-call}
+                        {incr counter-3}
+                        {incr counter-4}
+                        {incrby timer-nested-start 1}
+                        {incrby timer-nested-end 1}
                         {exec}
                     }
                     close_replication_stream $repl


### PR DESCRIPTION
NOTE: If anyone relied on the buggy behavior before this commit (specifically "Bug 2") this may seem like a breaking change, which it technically is because it changes user-facing behavior but it is in fact something that needed to be fixed.

Bug 1:
When a module ctx is freed moduleHandlePropagationAfterCommandCallback
is called and handles propagation. We want to prevent it from propagating
commands that were not replicated by the same context. Example:
1. module1.foo does: RM_Replicate(cmd1); RM_Call(cmd2); RM_Replicate(cmd3)
2. RM_Replicate(cmd1) propagates MULTI and adds cmd1 to also_propagagte
3. RM_Call(cmd2) create a new ctx, calls call() and destroys the ctx.
4. moduleHandlePropagationAfterCommandCallback is called, calling
   alsoPropagates EXEC (Note: EXEC is still not written to socket),
   setting server.in_trnsaction = 0
5. RM_Replicate(cmd3) is called, propagating yet another MULTI (now
   we have nested MULTI calls, which is no good) and then cmd3

We must prevent RM_Call(cmd2) from resetting server.in_transaction.
REDISMODULE_CTX_MULTI_EMITTED was revived for that purpose.

Bug 2:
Fix issues with nested RM_Call where some have '!' and some don't.
Example:
1. module1.foo does RM_Call of module2.bar without replication (i.e. no '!')
2. module2.bar internally calls RM_Call of INCR with '!'
3. at the end of module1.foo we call RM_ReplicateVerbatim

We want the replica/AOF to see only module1.foo and not the INCR from module2.bar

Introduced a global replication_allowed flag inside RM_Call to determine
whether we need to replicate or not (even if '!' was specified)

Other changes:
Split beforePropagateMultiOrExec to beforePropagateMulti afterPropagateExec
just for better readability