### PR TITLE
Fix memory info on FreeBSD.

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -414,7 +414,7 @@ size_t zmalloc_get_rss(void) {
 
     if (sysctl(mib, 4, &info, &infolen, NULL, 0) == 0)
 #if defined(__FreeBSD__)
-        return (size_t)info.ki_rssize;
+        return (size_t)info.ki_rssize * getpagesize();
 #else
         return (size_t)info.kp_vm_rssize;
 #endif

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -416,7 +416,7 @@ size_t zmalloc_get_rss(void) {
 #if defined(__FreeBSD__)
         return (size_t)info.ki_rssize * getpagesize();
 #else
-        return (size_t)info.kp_vm_rssize;
+        return (size_t)info.kp_vm_rssize * getpagesize();
 #endif
 
     return 0L;
@@ -436,7 +436,7 @@ size_t zmalloc_get_rss(void) {
     mib[4] = sizeof(info);
     mib[5] = 1;
     if (sysctl(mib, 4, &info, &infolen, NULL, 0) == 0)
-        return (size_t)info.p_vm_rssize;
+        return (size_t)info.p_vm_rssize * getpagesize();
 
     return 0L;
 }


### PR DESCRIPTION
The obtained process_rss was incorrect (the OS reports pages, not
bytes), resulting with many other fields getting corrupted.