### PR TITLE
set module eviction context flag only in masters

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -2077,7 +2077,7 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
         flags |= REDISMODULE_CTX_FLAGS_LOADING;
 
     /* Maxmemory and eviction policy */
-    if (server.maxmemory > 0) {
+    if (server.maxmemory > 0 && (!server.masterhost || !server.repl_slave_ignore_maxmemory)) {
         flags |= REDISMODULE_CTX_FLAGS_MAXMEMORY;
 
         if (server.maxmemory_policy != MAXMEMORY_NO_EVICTION)


### PR DESCRIPTION
I'm not certain this is right, so let's discuss it.
The question is if REDISMODULE_CTX_FLAGS_EVICT and REDISMODULE_CTX_FLAGS_MAXMEMORY should be set when the module is run inside a replica that doesn't do eviction.

one may argue that the database is under eviction (the master does eviction and sends DELs to the replica).
but on the other hand, we don't really know the master's configuration.

in my eyes, the current instance doesn't do eviction, and that's all that matters.