### PR TITLE
Process hello command even if the default user has no permissions.

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1180,9 +1180,9 @@ int ACLCheckCommandPerm(client *c, int *keyidxptr) {
     /* If there is no associated user, the connection can run anything. */
     if (u == NULL) return ACL_OK;
 
-    /* Check if the user can execute this command. */
-    if (!(u->flags & USER_FLAG_ALLCOMMANDS) &&
-        c->cmd->proc != authCommand)
+    /* Check if the user can execute this command or if the command
+     * doesn't need to be authenticated (hello, auth). */
+    if (!(u->flags & USER_FLAG_ALLCOMMANDS) && !(c->cmd->flags & CMD_NO_AUTH))
     {
         /* If the bit is not set we have to check further, in case the
          * command is allowed just with that specific subcommand. */

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -409,6 +409,14 @@ start_server {tags {"acl"}} {
         set e
     } {*NOAUTH*}
 
+    test {When default user has no command permission, hello command still works for other users} {
+        r ACL setuser secure-user >supass on +@all
+        r ACL setuser default -@all
+        r HELLO 2 AUTH secure-user supass
+        r ACL setuser default nopass +@all
+        r AUTH default ""
+    }
+
     test {ACL HELP should not have unexpected options} {
         catch {r ACL help xxx} e
         assert_match "*Unknown subcommand or wrong number of arguments*" $e


### PR DESCRIPTION
hello and auth command both have special flag `no-auth` which allows them to processed even if the client is not authenticated. During process command, REDIS should let hello command irrespective of the status of default user in the server.