### PR TITLE
Fix head and tail check with negative offset in _quicklistInsert

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -2020,6 +2020,7 @@ int quicklistTest(int argc, char *argv[], int accurate) {
             quicklistIndex(ql, -1, &entry);
             quicklistInsertBefore(ql, &entry, "abc", 3);
             ql_verify(ql, 2, 3, 2, 1);
+            zfree(value);
             quicklistRelease(ql);
         }
 
@@ -2035,6 +2036,7 @@ int quicklistTest(int argc, char *argv[], int accurate) {
             quicklistIndex(ql, -2, &entry);
             quicklistInsertAfter(ql, &entry, "abc", 3);
             ql_verify(ql, 2, 3, 1, 2);
+            zfree(value);
             quicklistRelease(ql);
         }
 


### PR DESCRIPTION
When the current node is full, if the passed offset is -1 or the length of the node, it will cause the pre or next node to fail to determine full, and eventually, the current node will be split and split invalid(nothing to split), and eventually insert into the current node, resulting in the length of the node exceeding the maximum value set by fill.
This problem does not create any bug, because the existing code does not iterate from tail to head, and the offset never has a negative value when insert.
