### PR TITLE
When tests exit normally, some processes may still be alive

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3054,7 +3054,7 @@ int listenToPort(int port, socketFds *sfd) {
         }
         if (sfd->fd[sfd->count] == ANET_ERR) {
             serverLog(LL_WARNING,
-                "Could not create server TCP listening socket %s:%d: %s",
+                "Warning: Could not create server TCP listening socket %s:%d: %s",
                 addr, port, server.neterr);
             if (errno == EADDRNOTAVAIL && optional)
                 continue;
@@ -3192,11 +3192,15 @@ void initServer(void) {
 
     /* Open the TCP listening socket for the user commands. */
     if (server.port != 0 &&
-        listenToPort(server.port,&server.ipfd) == C_ERR)
+        listenToPort(server.port,&server.ipfd) == C_ERR) {
+        serverLog(LL_WARNING, "Failed listening on port %u (TCP), aborting.", server.port);
         exit(1);
+    }
     if (server.tls_port != 0 &&
-        listenToPort(server.tls_port,&server.tlsfd) == C_ERR)
+        listenToPort(server.tls_port,&server.tlsfd) == C_ERR) {
+        serverLog(LL_WARNING, "Failed listening on port %u (TLS), aborting.", server.tls_port);
         exit(1);
+    }
 
     /* Open the listening Unix domain socket. */
     if (server.unixsocket != NULL) {

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -253,16 +253,18 @@ proc wait_server_started {config_file stdout pid} {
             break
         }
 
+        set res [exec cat $stdout]
+
         # Check if the instance is success. We have to check is first.
         # Instance may bind one interface success and other interface failed and
         # output "Could not create server TCP".
-        if {[regexp -- " PID: $pid" [exec cat $stdout]]} {
+        if {[regexp -- " PID: $pid" $res]} {
             break
         }
 
         # Check if the port is actually busy and the server failed
         # for this reason.
-        if {[regexp {Could not create server TCP} [exec cat $stdout]]} {
+        if {[regexp {Could not create server TCP} $res]} {
             set port_busy 1
             break
         }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -477,6 +477,7 @@ proc signal_idle_client fd {
         lappend ::idle_clients $fd
         set ::active_clients_task($fd) "SLEEPING, no more units to assign"
         if {[llength $::active_clients] == 0} {
+            force_kill_all_servers
             the_end
         }
     }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -477,7 +477,6 @@ proc signal_idle_client fd {
         lappend ::idle_clients $fd
         set ::active_clients_task($fd) "SLEEPING, no more units to assign"
         if {[llength $::active_clients] == 0} {
-            force_kill_all_servers
             the_end
         }
     }


### PR DESCRIPTION
In certain scenario start_server may think it failed to start a redis server
although it started successfully. in these cases, it'll not terminate it, and
it'll remain running when the test is over.

In start_server if config doesn't have bind (the minimal.conf in introspection.tcl),
it will try to bind ipv4 and ipv6. One may success while other fails. It will
output "Could not create server TCP listening socket".
wait_server_started uses this message to check whether instance started
successfully. So it will consider that it failed even though redis started successfully.

Additionally, in some cases it wasn't clear to users why the server exited,
since the warning message printed to the log, could in some cases be harmless,
and in some cases fatal.

This PR adds makes a clear distinction between a warning log message and
a fatal one, and changes the test suite to look for the fatal message.