### PR TITLE
Fix server won't start on alpine/libmusl without IPv6.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3053,14 +3053,15 @@ int listenToPort(int port, socketFds *sfd) {
             sfd->fd[sfd->count] = anetTcpServer(server.neterr,port,addr,server.tcp_backlog);
         }
         if (sfd->fd[sfd->count] == ANET_ERR) {
+            int net_errno = errno;
             serverLog(LL_WARNING,
                 "Could not create server TCP listening socket %s:%d: %s",
                 addr, port, server.neterr);
-            if (errno == EADDRNOTAVAIL && optional)
+            if (net_errno == EADDRNOTAVAIL && optional)
                 continue;
-            if (errno == ENOPROTOOPT     || errno == EPROTONOSUPPORT ||
-                errno == ESOCKTNOSUPPORT || errno == EPFNOSUPPORT ||
-                errno == EAFNOSUPPORT)
+            if (net_errno == ENOPROTOOPT     || net_errno == EPROTONOSUPPORT ||
+                net_errno == ESOCKTNOSUPPORT || net_errno == EPFNOSUPPORT ||
+                net_errno == EAFNOSUPPORT)
                 continue;
 
             /* Rollback successful listens before exiting */


### PR DESCRIPTION
`listenToPort` attempts to gracefully handle and ignore certain errors but does not store `errno` prior to logging, which in turn calls several libc functions that may overwrite `errno`.

This has been discovered due to libmusl strftime() always returning with `errno` set to `EINVAL`, which resulted with docker-library/redis#273.