### PR TITLE
Fix script kill to work also on scripts that use pcall

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1453,6 +1453,7 @@ void luaMaskCountHook(lua_State *lua, lua_Debug *ar) {
     if (server.lua_timedout) processEventsWhileBlocked();
     if (server.lua_kill) {
         serverLog(LL_WARNING,"Lua script killed by user with SCRIPT KILL.");
+        lua_sethook(lua, luaMaskCountHook, LUA_MASKLINE, 0);
         lua_pushstring(lua,"Script killed by user with SCRIPT KILL...");
         lua_error(lua);
     }

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -1453,7 +1453,14 @@ void luaMaskCountHook(lua_State *lua, lua_Debug *ar) {
     if (server.lua_timedout) processEventsWhileBlocked();
     if (server.lua_kill) {
         serverLog(LL_WARNING,"Lua script killed by user with SCRIPT KILL.");
+
+        /*
+         * Set the hook to invoke all the time so the user
+         * will not be able to catch the error with pcall and invoke
+         * pcall again which will prevent the script from ever been killed
+         */
         lua_sethook(lua, luaMaskCountHook, LUA_MASKLINE, 0);
+
         lua_pushstring(lua,"Script killed by user with SCRIPT KILL...");
         lua_error(lua);
     }

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -616,12 +616,12 @@ start_server {tags {"scripting"}} {
         set rd [redis_deferring_client]
         r config set lua-time-limit 10
         $rd eval {local f = function() while 1 do redis.call('ping') end end while 1 do pcall(f) end} 0
-        after 200
-        catch {r ping} e
-        assert_match {BUSY*} $e
         r script kill
-        after 200 ; # Give some time to Lua to call the hook again...
-        assert_equal [r ping] "PONG"
+        wait_for_condition 50 100 {
+            [string match {PONG} [r ping]]
+        } else {
+            fail "Can't turn the instance into a replica"
+        }
     }
 
     test {Timedout script link is still usable after Lua returns} {


### PR DESCRIPTION
pcall function runs another LUA function in protected mode, this means that any error will be caught by this function and will not stop the LUA execution. The script kill mechanism uses error to stop the running script. Scripts that uses pcall can catch the error raise by the script kill mechanism, this will cause a script like this to be unkillable:
```
local f = function()
        while 1 do
                redis.call('ping')
        end
end
while 1 do
        pcall(f)
end
```
The fix is, when we want to kill the script, we set the hook function to be invoked after each line. This will promise that the execution will get another error before it is able to enter the pcall function again.