### PR TITLE
Fixes for systems with 64-bit time

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -473,7 +473,7 @@ NULL
     } else if (!strcasecmp(c->argv[1]->ptr,"segfault")) {
         *((char*)-1) = 'x';
     } else if (!strcasecmp(c->argv[1]->ptr,"panic")) {
-        serverPanic("DEBUG PANIC called at Unix time %ld", time(NULL));
+        serverPanic("DEBUG PANIC called at Unix time %lld", (long long)time(NULL));
     } else if (!strcasecmp(c->argv[1]->ptr,"restart") ||
                !strcasecmp(c->argv[1]->ptr,"crash-and-recover"))
     {

--- a/src/networking.c
+++ b/src/networking.c
@@ -3008,7 +3008,7 @@ void securityWarningCommand(client *c) {
     static time_t logged_time;
     time_t now = time(NULL);
 
-    if (labs(now-logged_time) > 60) {
+    if (llabs(now-logged_time) > 60) {
         serverLog(LL_WARNING,"Possible SECURITY ATTACK detected. It looks like somebody is sending POST or Host: commands to Redis. This is likely due to an attacker attempting to use Cross Protocol Scripting to compromise your Redis instance. Connection aborted.");
         logged_time = now;
     }


### PR DESCRIPTION
Some operating systems (e.g., NetBSD and OpenBSD) have switched to using a 64-bit integer for `time_t` on all platforms. This results in currently harmless compiler warnings due to potential truncation. The two unintrusive commits fix these minor portability concerns.