### PR TITLE
fix wrong comment for data_age time unit & typo

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3090,7 +3090,7 @@ void clusterFailoverReplaceYourMaster(void) {
 /* This function is called if we are a slave node and our master serving
  * a non-zero amount of hash slots is in FAIL state.
  *
- * The gaol of this function is:
+ * The goal of this function is:
  * 1) To check if we are able to perform a failover, is our data updated?
  * 2) Try to get elected by masters.
  * 3) Perform the failover informing all the other nodes.
@@ -3135,7 +3135,7 @@ void clusterHandleSlaveFailover(void) {
         return;
     }
 
-    /* Set data_age to the number of seconds we are disconnected from
+    /* Set data_age to the number of milliseconds we are disconnected from
      * the master. */
     if (server.repl_state == REPL_STATE_CONNECTED) {
         data_age = (mstime_t)(server.unixtime - server.master->lastinteraction)


### PR DESCRIPTION
this is a follow up pr for https://github.com/redis/redis/issues/7828, the time unit in data_age comment is wrong which may misleading the reader. Also fixing a typo in the top function comments.