### PR TITLE
Fix: server will crash if rdbload or rdbsave method is not provided in module

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -4344,9 +4344,9 @@ robj *moduleTypeDupOrReply(client *c, robj *fromkey, robj *tokey, robj *value) {
  *             .defrag = myType_DefragCallback
  *         }
  *
- * * **rdb_load**: A callback function pointer that loads data from RDB files.
- * * **rdb_save**: A callback function pointer that saves data to RDB files.
- * * **aof_rewrite**: A callback function pointer that rewrites data as commands.
+ * * **rdb_load**: A callback function pointer that loads data from RDB files. (mandatory)
+ * * **rdb_save**: A callback function pointer that saves data to RDB files. (mandatory)
+ * * **aof_rewrite**: A callback function pointer that rewrites data as commands. (mandatory)
  * * **digest**: A callback function pointer that is used for `DEBUG DIGEST`.
  * * **free**: A callback function pointer that can free a type value.
  * * **aux_save**: A callback function pointer that saves out of keyspace data to RDB files.
@@ -4386,13 +4386,12 @@ robj *moduleTypeDupOrReply(client *c, robj *fromkey, robj *tokey, robj *value) {
  * Note: the module name "AAAAAAAAA" is reserved and produces an error, it
  * happens to be pretty lame as well.
  *
- * If there is already a module registering a type with the same name, or if
- * the module name or encver is invalid, or if module type register without
- * persistence functions, NULL is returned.
- * Otherwise the new type is registered into Redis, and a reference of type
- * RedisModuleType is returned. the caller of the function should store this
- * reference into a global variable to make future use of it in the modules
- * type API, since a single module may register multiple types.
+ * If there is already a module registering a type with the same name, the name
+ * or encver are invalid, or a mandatory callback is missing, NULL is returned.
+ * Otherwise the new type is registered into Redis, and a reference of
+ * type RedisModuleType is returned: the caller of the function should store
+ * this reference into a global variable to make future use of it in the
+ * modules type API, since a single module may register multiple types.
  * Example code fragment:
  *
  *      static RedisModuleType *BalancedTreeType;
@@ -4436,7 +4435,7 @@ moduleType *RM_CreateDataType(RedisModuleCtx *ctx, const char *name, int encver,
         return NULL;
     }
 
-    /* Function aux_load and aux_save can't one is defined and the other is not */
+    /* Function aux_load and aux_save must be either both defined or undefined. */
     if ((tms->version >= 2) && ((tms->v2.aux_load != NULL) != (tms->v2.aux_save != NULL))) {
         return NULL;
     }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1034,6 +1034,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key) {
         RedisModuleIO io;
         moduleValue *mv = o->ptr;
         moduleType *mt = mv->type;
+        if (mt->rdb_save == NULL) return -1;
 
         /* Write the "module" identifier as prefix, so that we'll be able
          * to call the right module during loading. */
@@ -2196,7 +2197,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key) {
         io.ver = (rdbtype == RDB_TYPE_MODULE) ? 1 : 2;
         /* Call the rdb_load method of the module providing the 10 bit
          * encoding version in the lower 10 bits of the module ID. */
-        void *ptr = mt->rdb_load(&io,moduleid&1023);
+        void *ptr = mt->rdb_load == NULL ? NULL : mt->rdb_load(&io,moduleid&1023);
         if (io.ctx) {
             moduleFreeContext(io.ctx);
             zfree(io.ctx);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1034,7 +1034,6 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key) {
         RedisModuleIO io;
         moduleValue *mv = o->ptr;
         moduleType *mt = mv->type;
-        if (mt->rdb_save == NULL) return -1;
 
         /* Write the "module" identifier as prefix, so that we'll be able
          * to call the right module during loading. */
@@ -2197,7 +2196,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key) {
         io.ver = (rdbtype == RDB_TYPE_MODULE) ? 1 : 2;
         /* Call the rdb_load method of the module providing the 10 bit
          * encoding version in the lower 10 bits of the module ID. */
-        void *ptr = mt->rdb_load == NULL ? NULL : mt->rdb_load(&io,moduleid&1023);
+        void *ptr = mt->rdb_load(&io,moduleid&1023);
         if (io.ctx) {
             moduleFreeContext(io.ctx);
             zfree(io.ctx);

--- a/tests/modules/datatype.c
+++ b/tests/modules/datatype.c
@@ -32,6 +32,10 @@ static void datatype_save(RedisModuleIO *io, void *value) {
     RedisModule_SaveString(io, dt->strval);
 }
 
+static void datatype_rewrite(RedisModuleIO *aof, RedisModuleString *key, void *value) {
+    /*  do-nothing callback. */
+}
+
 static void datatype_free(void *value) {
     if (value) {
         DataType *dt = (DataType *) value;
@@ -190,6 +194,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         .version = REDISMODULE_TYPE_METHOD_VERSION,
         .rdb_load = datatype_load,
         .rdb_save = datatype_save,
+        .aof_rewrite = datatype_rewrite,
         .free = datatype_free,
         .copy = datatype_copy
     };

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -25,6 +25,20 @@ unsigned long int global_defragged = 0;
 int global_strings_len = 0;
 RedisModuleString **global_strings = NULL;
 
+static void *fragtype_load(RedisModuleIO *io, int encver) {
+    /*  do-nothing callback. */
+    return NULL;
+}
+
+static void fragtype_save(RedisModuleIO *io, void *value) {
+    /*  do-nothing callback. */
+}
+
+static void fragtype_rewrite(RedisModuleIO *aof, RedisModuleString *key, void *value) {
+    /*  do-nothing callback. */
+}
+
+
 static void createGlobalStrings(RedisModuleCtx *ctx, int count)
 {
     global_strings_len = count;
@@ -211,6 +225,9 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     RedisModuleTypeMethods tm = {
             .version = REDISMODULE_TYPE_METHOD_VERSION,
+            .rdb_load = fragtype_load,
+            .rdb_save = fragtype_save,
+            .aof_rewrite = fragtype_rewrite,
             .free = FragFree,
             .free_effort = FragFreeEffort,
             .defrag = FragDefrag

--- a/tests/modules/testrdb.c
+++ b/tests/modules/testrdb.c
@@ -79,6 +79,11 @@ void testrdb_type_save(RedisModuleIO *rdb, void *value) {
     RedisModule_SaveLongDouble(rdb, 0.333333333333333333L);
 }
 
+
+void testrdb_type_aof_rewrite(RedisModuleIO *aof, RedisModuleString *key, void *value) {
+    /*  do-nothing callback. */
+}
+
 void testrdb_aux_save(RedisModuleIO *rdb, int when) {
     if (conf_aux_count==1) assert(when == REDISMODULE_AUX_AFTER_RDB);
     if (conf_aux_count==0) assert(0);
@@ -240,7 +245,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
             .version = 1,
             .rdb_load = testrdb_type_load,
             .rdb_save = testrdb_type_save,
-            .aof_rewrite = NULL,
+            .aof_rewrite = testrdb_type_aof_rewrite,
             .digest = NULL,
             .free = testrdb_type_free,
         };
@@ -253,7 +258,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
             .version = REDISMODULE_TYPE_METHOD_VERSION,
             .rdb_load = testrdb_type_load,
             .rdb_save = testrdb_type_save,
-            .aof_rewrite = NULL,
+            .aof_rewrite = testrdb_type_aof_rewrite,
             .digest = NULL,
             .free = testrdb_type_free,
             .aux_load = testrdb_aux_load,


### PR DESCRIPTION
Hi: 

I have implement some native data types in redis-module for helping my module retrieve data easier.  And I don't need to backoff data. Thus I simply set ` moduleTypeLoadFunc rdb_load; moduleTypeSaveFunc rdb_save` to null. Everything is ok . But I forget to close AUTO RDBDUMP in redis.conf.  


Then after 60 seconds, Server crash because rdb auto save. 

With this fix, module data type registration will fail if the load or save callbacks are not defined, or the optional aux load and save callbacks are not either both defined or both missing.