### PR TITLE
In sdssplitargs when in single quotes "\" should be escaped too.

### DIFF
--- a/deps/hiredis/sds.c
+++ b/deps/hiredis/sds.c
@@ -990,9 +990,9 @@ hisds *hi_sdssplitargs(const char *line, int *argc) {
                         current = hi_sdscatlen(current,p,1);
                     }
                 } else if (insq) {
-                    if (*p == '\\' && *(p+1) == '\'') {
+                    if (*p == '\\' && (*(p+1) == '\'' || *(p+1) == '\\')) {
                         p++;
-                        current = hi_sdscatlen(current,"'",1);
+                        current = hi_sdscatlen(current,p,1);
                     } else if (*p == '\'') {
                         /* closing quote must be followed by a space or
                          * nothing at all. */

--- a/src/sds.c
+++ b/src/sds.c
@@ -1046,9 +1046,9 @@ sds *sdssplitargs(const char *line, int *argc) {
                         current = sdscatlen(current,p,1);
                     }
                 } else if (insq) {
-                    if (*p == '\\' && *(p+1) == '\'') {
+                    if (*p == '\\' && (*(p+1) == '\'' || *(p+1) == '\\')) {
                         p++;
-                        current = sdscatlen(current,"'",1);
+                        current = sdscatlen(current,p,1);
                     } else if (*p == '\'') {
                         /* closing quote must be followed by a space or
                          * nothing at all. */

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -150,7 +150,7 @@ start_server {tags {"cli"}} {
         assert_equal "OK" [run_command $fd "set key\"\" bar"]
         assert_equal "bar" [r get key]
 
-        # backslash should also be quoted in singe quotes
+        # backslash should also be quoted in single quotes
         # We need four \ to represent one backslash as \ also needs to
         # be quoted in double quotes.
         assert_equal "OK" [run_command $fd "set key '\\\\\\' bar\\\\'"]

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -149,6 +149,12 @@ start_server {tags {"cli"}} {
         # quotes after the argument are weird, but should be allowed
         assert_equal "OK" [run_command $fd "set key\"\" bar"]
         assert_equal "bar" [r get key]
+
+        # backslash should also be quoted in singe quotes
+        # We need four \ to represent one backslash as \ also needs to
+        # be quoted in double quotes.
+        assert_equal "OK" [run_command $fd "set key '\\\\\\' bar\\\\'"]
+        assert_equal "\\' bar\\" [r get key]
     }
 
     test_tty_cli "Status reply" {


### PR DESCRIPTION
Fix https://github.com/redis/redis/issues/8672
In sdssplitargs single quotes are raw mode. But `'` should be escaped by `\`. 
So I think `\` is a special character and should be escaped too.
For now, we can't input an arg ends with '\':
```
127.0.0.1:6380> set a '\\'
Invalid argument(s)
127.0.0.1:6380> set a '\'
Invalid argument(s)
```

I fix this by
```
if (*p == '\\' && (*(p+1) == '\'' || *(p+1) == '\\')) {
        p++; 
        current = sdscatlen(current,p,1); 
```

So `\\` will be `\` and `\'` will be `'`.

But this will produce problem:
```
127.0.0.1:6380> set a '\c'
OK
127.0.0.1:6380> get a
"\\c"
127.0.0.1:6380> set b '\\c'
OK
127.0.0.1:6380> get b
"\\c"
```

`\\` and `\` will be considered same.
I think if we encounter a single `\`, we should ignore it.
However this is incompatible with the past.
But if we enter two `\\` it is also incompatible with the past.
Or this is always input by human, the fix is all right.
So I think whether should we fix it ?