### PR TITLE
startLoading and stopLoading should be called in pairs.

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -856,8 +856,6 @@ int loadAppendOnlyFile(char *filename) {
         /* Command lookup */
         cmd = lookupCommand(argv[0]->ptr);
         if (!cmd) {
-            if (fakeClient) freeFakeClient(fakeClient); /* avoid valgrind warning */
-            fclose(fp);
             serverLog(LL_WARNING,
                 "Unknown command '%s' reading the append only file",
                 (char*)argv[0]->ptr);
@@ -918,7 +916,6 @@ readerr: /* Read error. If feof(fp) is true, fall through to unexpected EOF. */
         if (fakeClient) freeFakeClient(fakeClient); /* avoid valgrind warning */
         fclose(fp);
         serverLog(LL_WARNING,"Unrecoverable error reading the append only file: %s", strerror(errno));
-        stopLoading(0);
         exit(1);
     }
 
@@ -950,14 +947,12 @@ uxeof: /* Unexpected AOF end of file. */
     if (fakeClient) freeFakeClient(fakeClient); /* avoid valgrind warning */
     fclose(fp);
     serverLog(LL_WARNING,"Unexpected end of file reading the append only file. You can: 1) Make a backup of your AOF file, then use ./redis-check-aof --fix <filename>. 2) Alternatively you can set the 'aof-load-truncated' configuration option to yes and restart the server.");
-    stopLoading(0);
     exit(1);
 
 fmterr: /* Format error. */
     if (fakeClient) freeFakeClient(fakeClient); /* avoid valgrind warning */
     fclose(fp);
     serverLog(LL_WARNING,"Bad file format reading the append only file: make a backup of your AOF file, then use ./redis-check-aof --fix <filename>");
-    stopLoading(0);
     exit(1);
 }
 

--- a/src/aof.c
+++ b/src/aof.c
@@ -856,6 +856,8 @@ int loadAppendOnlyFile(char *filename) {
         /* Command lookup */
         cmd = lookupCommand(argv[0]->ptr);
         if (!cmd) {
+            if (fakeClient) freeFakeClient(fakeClient); /* avoid valgrind warning */
+            fclose(fp);
             serverLog(LL_WARNING,
                 "Unknown command '%s' reading the append only file",
                 (char*)argv[0]->ptr);
@@ -916,6 +918,7 @@ readerr: /* Read error. If feof(fp) is true, fall through to unexpected EOF. */
         if (fakeClient) freeFakeClient(fakeClient); /* avoid valgrind warning */
         fclose(fp);
         serverLog(LL_WARNING,"Unrecoverable error reading the append only file: %s", strerror(errno));
+        stopLoading(0);
         exit(1);
     }
 
@@ -947,12 +950,14 @@ uxeof: /* Unexpected AOF end of file. */
     if (fakeClient) freeFakeClient(fakeClient); /* avoid valgrind warning */
     fclose(fp);
     serverLog(LL_WARNING,"Unexpected end of file reading the append only file. You can: 1) Make a backup of your AOF file, then use ./redis-check-aof --fix <filename>. 2) Alternatively you can set the 'aof-load-truncated' configuration option to yes and restart the server.");
+    stopLoading(0);
     exit(1);
 
 fmterr: /* Format error. */
     if (fakeClient) freeFakeClient(fakeClient); /* avoid valgrind warning */
     fclose(fp);
     serverLog(LL_WARNING,"Bad file format reading the append only file: make a backup of your AOF file, then use ./redis-check-aof --fix <filename>");
+    stopLoading(0);
     exit(1);
 }
 

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -192,6 +192,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     int closefile = (fp == NULL);
     if (fp == NULL && (fp = fopen(rdbfilename,"r")) == NULL) return 1;
 
+    startLoadingFile(fp, rdbfilename, RDBFLAGS_NONE);
     rioInitWithFile(&rdb,fp);
     rdbstate.rio = &rdb;
     rdb.update_cksum = rdbLoadProgressCallback;
@@ -208,7 +209,6 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     }
 
     expiretime = -1;
-    startLoadingFile(fp, rdbfilename, RDBFLAGS_NONE);
     while(1) {
         robj *key, *val;
 


### PR DESCRIPTION
Change the order of start startLoadingFile call in redis-check-rdb

redis_check_rdb in some scenarios only stopLoading is called because
startLoadingFile is called too late.

-----------------------------------------------------------------------------
Old description:

loadAppendOnlyFile when load failed, only startLoading is called.
redis_check_rdb in some scenarios only stopLoading is called.
And we will miss some module server event.

There are many `exit(1)` `stopLoading` missed. I'm not sure whether we should add it all.