### PR TITLE
improve error handing in anetFDToString to avoid returning successfully with garbage.

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -541,12 +541,12 @@ int anetFdToString(int fd, char *ip, size_t ip_len, int *port, int fd_to_str_typ
     struct sockaddr_storage sa;
     socklen_t salen = sizeof(sa);
 
+    if (ip_len == 0) goto error;
     if (fd_to_str_type == FD_TO_PEER_NAME) {
         if (getpeername(fd, (struct sockaddr *)&sa, &salen) == -1) goto error;
     } else {
         if (getsockname(fd, (struct sockaddr *)&sa, &salen) == -1) goto error;
     }
-    if (ip_len == 0) goto error;
 
     if (sa.ss_family == AF_INET) {
         struct sockaddr_in *s = (struct sockaddr_in *)&sa;

--- a/src/anet.c
+++ b/src/anet.c
@@ -564,7 +564,7 @@ int anetFdToString(int fd, char *ip, size_t ip_len, int *port, int fd_to_str_typ
     } else if (sa.ss_family == AF_UNIX) {
         if (ip) {
             int res = snprintf(ip, ip_len, "/unixsocket");
-            if (res < 0 || res >= ip_len) goto error;
+            if (res < 0 || (unsigned int) res >= ip_len) goto error;
         }
         if (port) *port = 0;
     } else {

--- a/src/anet.c
+++ b/src/anet.c
@@ -562,9 +562,8 @@ int anetFdToString(int fd, char *ip, size_t ip_len, int *port, int fd_to_str_typ
         }
         if (port) *port = ntohs(s->sin6_port);
     } else if (sa.ss_family == AF_UNIX) {
-        char sus[] = "/unixsocket";
-        if (ip_len < sizeof(sus)) goto error;
-        if (ip) snprintf(ip, ip_len, sus);
+        if (ip_len < sizeof("/unixsocket")) goto error;
+        if (ip) snprintf(ip, ip_len, "/unixsocket");
         if (port) *port = 0;
     } else {
         goto error;

--- a/src/anet.c
+++ b/src/anet.c
@@ -562,8 +562,10 @@ int anetFdToString(int fd, char *ip, size_t ip_len, int *port, int fd_to_str_typ
         }
         if (port) *port = ntohs(s->sin6_port);
     } else if (sa.ss_family == AF_UNIX) {
-        if (ip_len < sizeof("/unixsocket")) goto error;
-        if (ip) snprintf(ip, ip_len, "/unixsocket");
+        if (ip) {
+            int res = snprintf(ip, ip_len, "/unixsocket");
+            if (res < 0 || res >= ip_len) goto error;
+        }
         if (port) *port = 0;
     } else {
         goto error;


### PR DESCRIPTION
Check for errors in inet_ntop and snprintf rather than ignore them and return success (with garbage output).
The check for `ip_len == 0` seems like dead code, removed.

----------

Old title and subject:
Move ip_len validation up in anetFDToString func
Avoid expensive socket operation when not necessary. If `ip` is of size `0` then `goto error` immediately instead of attempting to get peer or sock name against the file descriptor. Changing the order of this validation should be safe and have no side effects.