### PR TITLE
WAIT command supports replicas number is 'majority' and 'all'

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -3184,8 +3184,16 @@ void waitCommand(client *c) {
     }
 
     /* Argument parsing. */
-    if (getLongFromObjectOrReply(c,c->argv[1],&numreplicas,NULL) != C_OK)
+    if (!strcasecmp(c->argv[1]->ptr,"majority")) {
+        numreplicas = listLength(server.slaves)/2 + 1;
+    } else if (!strcasecmp(c->argv[1]->ptr,"all")) {
+        numreplicas = listLength(server.slaves);
+    } else if (getPositiveLongFromObjectOrReply(c,c->argv[1],&numreplicas,
+        "replicas number should be a number, 'majority', or 'all'") != C_OK)
+    {
         return;
+    }
+
     if (getTimeoutFromObjectOrReply(c,c->argv[2],&timeout,UNIT_MILLISECONDS)
         != C_OK) return;
 

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -19,6 +19,18 @@ start_server {} {
         }
     }
 
+    test {WAIT replicas number should be a number, 'majority', 'all'} {
+        assert {[$master wait 1 5000] == 1}
+        assert {[$master wait majority 5000] == 1}
+        assert {[$master wait all 5000] == 1}
+
+        set err "*replicas*number*majority*all*"
+        catch {[$master wait -1 5000]} e
+        assert_match $err $e
+        catch {[$master wait less 5000]} e
+        assert_match $err $e
+    }
+
     test {WAIT should acknowledge 1 additional copy of the data} {
         $master set foo 0
         $master incr foo


### PR DESCRIPTION
In WAIT command, we need to set replicas number, i think it is convenient to support 'majority' and 'all' because developers needn't adjust this parameter for different redis cluster.

I got inspiration from [Mogodb write concern](https://docs.mongodb.com/manual/reference/write-concern/)