### PR TITLE
There is something wrong with the configuration prompt of sentinel. change not to no

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2039,12 +2039,12 @@ const char *sentinelHandleConfiguration(char **argv, int argc) {
     } else if (!strcasecmp(argv[0],"resolve-hostnames") && argc == 2) {
         /* resolve-hostnames <yes|no> */
         if ((sentinel.resolve_hostnames = yesnotoi(argv[1])) == -1) {
-            return "Please specify yes or not for the resolve-hostnames option.";
+            return "Please specify yes or no for the resolve-hostnames option.";
         }
     } else if (!strcasecmp(argv[0],"announce-hostnames") && argc == 2) {
         /* announce-hostnames <yes|no> */
         if ((sentinel.announce_hostnames = yesnotoi(argv[1])) == -1) {
-            return "Please specify yes or not for the announce-hostnames option.";
+            return "Please specify yes or no for the announce-hostnames option.";
         }
     } else {
         return "Unrecognized sentinel configuration statement.";


### PR DESCRIPTION
When configuring resolve_hostnames and announce_hostnames, if this configuration item is not needed, it should be configured as no instead of not. Configuration errors will cause problems