### PR TITLE
Client eviction

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1841,6 +1841,25 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 #
 # client-query-buffer-limit 1gb
 
+# In some scenarios client connections can hog up memory leading to OOM
+# errors or data eviction. To avoid this we can cap the accumulated memory
+# used by all client connections (all pubsub and normal clients). Once we
+# reach that limit connections will be dropped by the server freeing up
+# memory. The server will attempt to drop the connections using the most 
+# memory first. We call this mechanism "client eviction".
+#
+# Client eviction is configured using the maxmemory-clients setting as follows:
+# 0 - client eviction is disabled (default)
+#
+# A positive memory value can be used for the client eviction threshold,
+# for example:
+# maxmemory-clients 1g
+#
+# A negative value (between -1 and -100) means the client eviction threshold
+# is set based on a percentage of the maxmemory setting. For example to set
+# client eviction at 5% of maxmemory:
+# maxmemory-clients -5
+
 # In the Redis protocol, bulk requests, that are, elements representing single
 # strings, are normally limited to 512 mb. However you can change this limit
 # here, but must be 1mb or greater

--- a/redis.conf
+++ b/redis.conf
@@ -1851,14 +1851,14 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 # Client eviction is configured using the maxmemory-clients setting as follows:
 # 0 - client eviction is disabled (default)
 #
-# A positive memory value can be used for the client eviction threshold,
+# A memory value can be used for the client eviction threshold,
 # for example:
 # maxmemory-clients 1g
 #
-# A negative value (between -1 and -100) means the client eviction threshold
-# is set based on a percentage of the maxmemory setting. For example to set
-# client eviction at 5% of maxmemory:
-# maxmemory-clients -5
+# A percentage value (between 1% and 100%) means the client eviction threshold
+# is based on a percentage of the maxmemory setting. For example to set client
+# eviction at 5% of maxmemory:
+# maxmemory-clients 5%
 
 # In the Redis protocol, bulk requests, that are, elements representing single
 # strings, are normally limited to 512 mb. However you can change this limit

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -138,30 +138,14 @@ void processUnblockedClients(void) {
          * the code is conceptually more correct this way. */
         if (!(c->flags & CLIENT_BLOCKED)) {
             /* If we have a queued command, execute it now. */
-            if (processPendingCommandsAndResetClient(c) == C_ERR) {
-                continue;
-            }
-
-            /* Free the client if it's no longer needed after processing the
-             * command to reclaim its memory */
-            if (c->flags & CLIENT_CLOSE_ASAP) {
-                serverLog(LL_WARNING, "@@@ freeing unblocked client early!");
-                freeClient(c);
-                continue;
-            }
-
-            /* Then process client if it has more data in it's buffer. */
-            if (c->querybuf && sdslen(c->querybuf) > 0) {
-                processInputBuffer(c);
-
-                /* Free the client if it's no longer needed after processing the
-                 * command to reclaim its memory */
-                if (c->flags & CLIENT_CLOSE_ASAP) {
-                    serverLog(LL_WARNING, "@@@ freeing unblocked client early!");
-                    freeClient(c);
+            if (processPendingCommandsAndResetClient(c) == C_OK) {
+                /* Now process client if it has more data in it's buffer. */
+                if (c->querybuf && sdslen(c->querybuf) > 0) {
+                    processInputBuffer(c);
                 }
             }
         }
+        beforeNextClient(c);
     }
 }
 

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -141,9 +141,25 @@ void processUnblockedClients(void) {
             if (processPendingCommandsAndResetClient(c) == C_ERR) {
                 continue;
             }
+
+            /* Free the client if it's no longer needed after processing the
+             * command to reclaim its memory */
+            if (c->flags & CLIENT_CLOSE_ASAP) {
+                serverLog(LL_WARNING, "@@@ freeing unblocked client early!");
+                freeClient(c);
+                continue;
+            }
+
             /* Then process client if it has more data in it's buffer. */
             if (c->querybuf && sdslen(c->querybuf) > 0) {
                 processInputBuffer(c);
+
+                /* Free the client if it's no longer needed after processing the
+                 * command to reclaim its memory */
+                if (c->flags & CLIENT_CLOSE_ASAP) {
+                    serverLog(LL_WARNING, "@@@ freeing unblocked client early!");
+                    freeClient(c);
+                }
             }
         }
     }

--- a/src/config.c
+++ b/src/config.c
@@ -198,6 +198,9 @@ typedef enum numericType {
     NUMERIC_TYPE_TIME_T,
 } numericType;
 
+#define NUM_CONF_FLAG_MEMORY (1<<0) /* Indicates if this value can be loaded as a memory value */
+#define NUM_CONF_FLAG_PERCENT (1<<1) /* Indicates if this value can be loaded as a percent (and stored as a negative int) */
+
 typedef struct numericConfigData {
     union {
         int *i;
@@ -211,7 +214,7 @@ typedef struct numericConfigData {
         off_t *ot;
         time_t *tt;
     } config; /* The pointer to the numeric config this value is stored in */
-    int is_memory; /* Indicates if this value can be loaded as a memory value */
+    unsigned int flags;
     numericType numeric_type; /* An enum indicating the type of this value */
     long long lower_bound; /* The lower bound of this numeric value */
     long long upper_bound; /* The upper bound of this numeric value */
@@ -2127,7 +2130,7 @@ static int numericBoundaryCheck(typeData data, long long ll, const char **err) {
 
 static int numericConfigSet(typeData data, sds value, int update, const char **err) {
     long long ll, prev = 0;
-    if (data.numeric.is_memory) {
+    if (data.numeric.flags & NUM_CONF_FLAG_MEMORY) {
         int memerr;
         ll = memtoull(value, &memerr);
         if (memerr) {
@@ -2180,18 +2183,15 @@ static void numericConfigRewrite(typeData data, const char *name, struct rewrite
 
     GET_NUMERIC_TYPE(value)
 
-    if (data.numeric.is_memory) {
+    if (data.numeric.flags & NUM_CONF_FLAG_MEMORY) {
         rewriteConfigBytesOption(state, name, value, data.numeric.default_value);
     } else {
         rewriteConfigNumericalOption(state, name, value, data.numeric.default_value);
     }
 }
 
-#define INTEGER_CONFIG 0
-#define MEMORY_CONFIG 1
-
-#define embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) { \
-    embedCommonConfig(name, alias, flags) \
+#define embedCommonNumericalConfig(name, alias, _flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) { \
+    embedCommonConfig(name, alias, _flags) \
     embedConfigInterface(numericConfigInit, numericConfigSet, numericConfigGet, numericConfigRewrite) \
     .data.numeric = { \
         .lower_bound = (lower), \
@@ -2199,73 +2199,73 @@ static void numericConfigRewrite(typeData data, const char *name, struct rewrite
         .default_value = (default), \
         .is_valid_fn = (is_valid), \
         .update_fn = (update), \
-        .is_memory = (memory),
+        .flags = (num_conf_flags),
 
-#define createIntConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
-    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
+#define createIntConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
+    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
         .numeric_type = NUMERIC_TYPE_INT, \
         .config.i = &(config_addr) \
     } \
 }
 
-#define createUIntConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
-    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
+#define createUIntConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
+    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
         .numeric_type = NUMERIC_TYPE_UINT, \
         .config.ui = &(config_addr) \
     } \
 }
 
-#define createLongConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
-    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
+#define createLongConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
+    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
         .numeric_type = NUMERIC_TYPE_LONG, \
         .config.l = &(config_addr) \
     } \
 }
 
-#define createULongConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
-    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
+#define createULongConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
+    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
         .numeric_type = NUMERIC_TYPE_ULONG, \
         .config.ul = &(config_addr) \
     } \
 }
 
-#define createLongLongConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
-    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
+#define createLongLongConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
+    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
         .numeric_type = NUMERIC_TYPE_LONG_LONG, \
         .config.ll = &(config_addr) \
     } \
 }
 
-#define createULongLongConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
-    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
+#define createULongLongConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
+    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
         .numeric_type = NUMERIC_TYPE_ULONG_LONG, \
         .config.ull = &(config_addr) \
     } \
 }
 
-#define createSizeTConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
-    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
+#define createSizeTConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
+    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
         .numeric_type = NUMERIC_TYPE_SIZE_T, \
         .config.st = &(config_addr) \
     } \
 }
 
-#define createSSizeTConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
-    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
+#define createSSizeTConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
+    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
         .numeric_type = NUMERIC_TYPE_SSIZE_T, \
         .config.sst = &(config_addr) \
     } \
 }
 
-#define createTimeTConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
-    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
+#define createTimeTConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
+    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
         .numeric_type = NUMERIC_TYPE_TIME_T, \
         .config.tt = &(config_addr) \
     } \
 }
 
-#define createOffTConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
-    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, memory, is_valid, update) \
+#define createOffTConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
+    embedCommonNumericalConfig(name, alias, flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) \
         .numeric_type = NUMERIC_TYPE_OFF_T, \
         .config.ot = &(config_addr) \
     } \
@@ -2588,59 +2588,59 @@ standardConfig configs[] = {
     createEnumConfig("sanitize-dump-payload", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, sanitize_dump_payload_enum, server.sanitize_dump_payload, SANITIZE_DUMP_NO, NULL, NULL),
 
     /* Integer configs */
-    createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */
-    createIntConfig("io-threads", NULL, DEBUG_CONFIG | IMMUTABLE_CONFIG, 1, 128, server.io_threads_num, 1, INTEGER_CONFIG, NULL, NULL), /* Single threaded by default */
-    createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_slave_validity_factor, 10, INTEGER_CONFIG, NULL, NULL), /* Slave max data age factor. */
-    createIntConfig("list-max-ziplist-size", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.list_max_ziplist_size, -2, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("tcp-keepalive", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tcpkeepalive, 300, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("cluster-migration-barrier", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_migration_barrier, 1, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("active-defrag-cycle-min", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_min, 1, INTEGER_CONFIG, NULL, NULL), /* Default: 1% CPU min (at lower threshold) */
-    createIntConfig("active-defrag-cycle-max", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_max, 25, INTEGER_CONFIG, NULL, NULL), /* Default: 25% CPU max (at upper threshold) */
-    createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, INTEGER_CONFIG, NULL, NULL), /* Default: don't defrag when fragmentation is below 10% */
-    createIntConfig("active-defrag-threshold-upper", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_upper, 100, INTEGER_CONFIG, NULL, NULL), /* Default: maximum defrag force at 100% fragmentation */
-    createIntConfig("lfu-log-factor", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_log_factor, 10, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("lfu-decay-time", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_decay_time, 1, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("replica-priority", "slave-priority", MODIFIABLE_CONFIG, 0, INT_MAX, server.slave_priority, 100, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("repl-diskless-sync-delay", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_diskless_sync_delay, 5, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("maxmemory-samples", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.maxmemory_samples, 5, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("maxmemory-eviction-tenacity", NULL, MODIFIABLE_CONFIG, 0, 100, server.maxmemory_eviction_tenacity, 10, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.maxidletime, 0, INTEGER_CONFIG, NULL, NULL), /* Default client timeout: infinite */
-    createIntConfig("replica-announce-port", "slave-announce-port", MODIFIABLE_CONFIG, 0, 65535, server.slave_announce_port, 0, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("tcp-backlog", NULL, IMMUTABLE_CONFIG, 0, INT_MAX, server.tcp_backlog, 511, INTEGER_CONFIG, NULL, NULL), /* TCP listen backlog. */
-    createIntConfig("cluster-announce-bus-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_bus_port, 0, INTEGER_CONFIG, NULL, NULL), /* Default: Use +10000 offset. */
-    createIntConfig("cluster-announce-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_port, 0, INTEGER_CONFIG, NULL, NULL), /* Use server.port */
-    createIntConfig("cluster-announce-tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_tls_port, 0, INTEGER_CONFIG, NULL, NULL), /* Use server.tls_port */
-    createIntConfig("repl-timeout", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.repl_timeout, 60, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("repl-ping-replica-period", "repl-ping-slave-period", MODIFIABLE_CONFIG, 1, INT_MAX, server.repl_ping_slave_period, 10, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("list-compress-depth", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 0, INT_MAX, server.list_compress_depth, 0, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("rdb-key-save-delay", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.rdb_key_save_delay, 0, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("key-load-delay", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.key_load_delay, 0, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("active-expire-effort", NULL, MODIFIABLE_CONFIG, 1, 10, server.active_expire_effort, 1, INTEGER_CONFIG, NULL, NULL), /* From 1 to 10. */
-    createIntConfig("hz", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.config_hz, CONFIG_DEFAULT_HZ, INTEGER_CONFIG, NULL, updateHZ),
-    createIntConfig("min-replicas-to-write", "min-slaves-to-write", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_to_write, 0, INTEGER_CONFIG, NULL, updateGoodSlaves),
-    createIntConfig("min-replicas-max-lag", "min-slaves-max-lag", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_max_lag, 10, INTEGER_CONFIG, NULL, updateGoodSlaves),
+    createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, 0, NULL, NULL),
+    createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, 0, NULL, updatePort), /* TCP port. */
+    createIntConfig("io-threads", NULL, DEBUG_CONFIG | IMMUTABLE_CONFIG, 1, 128, server.io_threads_num, 1, 0, NULL, NULL), /* Single threaded by default */
+    createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, 0, NULL, NULL),
+    createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_slave_validity_factor, 10, 0, NULL, NULL), /* Slave max data age factor. */
+    createIntConfig("list-max-ziplist-size", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.list_max_ziplist_size, -2, 0, NULL, NULL),
+    createIntConfig("tcp-keepalive", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tcpkeepalive, 300, 0, NULL, NULL),
+    createIntConfig("cluster-migration-barrier", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_migration_barrier, 1, 0, NULL, NULL),
+    createIntConfig("active-defrag-cycle-min", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_min, 1, 0, NULL, NULL), /* Default: 1% CPU min (at lower threshold) */
+    createIntConfig("active-defrag-cycle-max", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_max, 25, 0, NULL, NULL), /* Default: 25% CPU max (at upper threshold) */
+    createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, 0, NULL, NULL), /* Default: don't defrag when fragmentation is below 10% */
+    createIntConfig("active-defrag-threshold-upper", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_upper, 100, 0, NULL, NULL), /* Default: maximum defrag force at 100% fragmentation */
+    createIntConfig("lfu-log-factor", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_log_factor, 10, 0, NULL, NULL),
+    createIntConfig("lfu-decay-time", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_decay_time, 1, 0, NULL, NULL),
+    createIntConfig("replica-priority", "slave-priority", MODIFIABLE_CONFIG, 0, INT_MAX, server.slave_priority, 100, 0, NULL, NULL),
+    createIntConfig("repl-diskless-sync-delay", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_diskless_sync_delay, 5, 0, NULL, NULL),
+    createIntConfig("maxmemory-samples", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.maxmemory_samples, 5, 0, NULL, NULL),
+    createIntConfig("maxmemory-eviction-tenacity", NULL, MODIFIABLE_CONFIG, 0, 100, server.maxmemory_eviction_tenacity, 10, 0, NULL, NULL),
+    createIntConfig("timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.maxidletime, 0, 0, NULL, NULL), /* Default client timeout: infinite */
+    createIntConfig("replica-announce-port", "slave-announce-port", MODIFIABLE_CONFIG, 0, 65535, server.slave_announce_port, 0, 0, NULL, NULL),
+    createIntConfig("tcp-backlog", NULL, IMMUTABLE_CONFIG, 0, INT_MAX, server.tcp_backlog, 511, 0, NULL, NULL), /* TCP listen backlog. */
+    createIntConfig("cluster-announce-bus-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_bus_port, 0, 0, NULL, NULL), /* Default: Use +10000 offset. */
+    createIntConfig("cluster-announce-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_port, 0, 0, NULL, NULL), /* Use server.port */
+    createIntConfig("cluster-announce-tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_tls_port, 0, 0, NULL, NULL), /* Use server.tls_port */
+    createIntConfig("repl-timeout", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.repl_timeout, 60, 0, NULL, NULL),
+    createIntConfig("repl-ping-replica-period", "repl-ping-slave-period", MODIFIABLE_CONFIG, 1, INT_MAX, server.repl_ping_slave_period, 10, 0, NULL, NULL),
+    createIntConfig("list-compress-depth", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 0, INT_MAX, server.list_compress_depth, 0, 0, NULL, NULL),
+    createIntConfig("rdb-key-save-delay", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.rdb_key_save_delay, 0, 0, NULL, NULL),
+    createIntConfig("key-load-delay", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.key_load_delay, 0, 0, NULL, NULL),
+    createIntConfig("active-expire-effort", NULL, MODIFIABLE_CONFIG, 1, 10, server.active_expire_effort, 1, 0, NULL, NULL), /* From 1 to 10. */
+    createIntConfig("hz", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.config_hz, CONFIG_DEFAULT_HZ, 0, NULL, updateHZ),
+    createIntConfig("min-replicas-to-write", "min-slaves-to-write", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_to_write, 0, 0, NULL, updateGoodSlaves),
+    createIntConfig("min-replicas-max-lag", "min-slaves-max-lag", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_max_lag, 10, 0, NULL, updateGoodSlaves),
 
     /* Unsigned int configs */
-    createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),
+    createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, 0, NULL, updateMaxclients),
 
     /* Unsigned Long configs */
-    createULongConfig("active-defrag-max-scan-fields", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, server.active_defrag_max_scan_fields, 1000, INTEGER_CONFIG, NULL, NULL), /* Default: keys with more than 1000 fields will be processed separately */
-    createULongConfig("slowlog-max-len", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.slowlog_max_len, 128, INTEGER_CONFIG, NULL, NULL),
-    createULongConfig("acllog-max-len", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.acllog_max_len, 128, INTEGER_CONFIG, NULL, NULL),
+    createULongConfig("active-defrag-max-scan-fields", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, server.active_defrag_max_scan_fields, 1000, 0, NULL, NULL), /* Default: keys with more than 1000 fields will be processed separately */
+    createULongConfig("slowlog-max-len", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.slowlog_max_len, 128, 0, NULL, NULL),
+    createULongConfig("acllog-max-len", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.acllog_max_len, 128, 0, NULL, NULL),
 
     /* Long Long configs */
-    createLongLongConfig("lua-time-limit", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.lua_time_limit, 5000, INTEGER_CONFIG, NULL, NULL),/* milliseconds */
-    createLongLongConfig("cluster-node-timeout", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.cluster_node_timeout, 15000, INTEGER_CONFIG, NULL, NULL),
-    createLongLongConfig("slowlog-log-slower-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.slowlog_log_slower_than, 10000, INTEGER_CONFIG, NULL, NULL),
-    createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, INTEGER_CONFIG, NULL, NULL),
-    createLongLongConfig("proto-max-bulk-len", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.proto_max_bulk_len, 512ll*1024*1024, MEMORY_CONFIG, NULL, NULL), /* Bulk request max size */
-    createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
-    createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.cfg_repl_backlog_size, 1024*1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 1mb */
+    createLongLongConfig("lua-time-limit", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.lua_time_limit, 5000, 0, NULL, NULL),/* milliseconds */
+    createLongLongConfig("cluster-node-timeout", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.cluster_node_timeout, 15000, 0, NULL, NULL),
+    createLongLongConfig("slowlog-log-slower-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.slowlog_log_slower_than, 10000, 0, NULL, NULL),
+    createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, 0, NULL, NULL),
+    createLongLongConfig("proto-max-bulk-len", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.proto_max_bulk_len, 512ll*1024*1024, NUM_CONF_FLAG_MEMORY, NULL, NULL), /* Bulk request max size */
+    createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, 0, NULL, NULL),
+    createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.cfg_repl_backlog_size, 1024*1024, NUM_CONF_FLAG_MEMORY, NULL, updateReplBacklogSize), /* Default: 1mb */
 
     /* Unsigned Long Long configs */
-    createULongLongConfig("maxmemory", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory, 0, MEMORY_CONFIG, NULL, updateMaxmemory),
+    createULongLongConfig("maxmemory", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory, 0, NUM_CONF_FLAG_MEMORY, NULL, updateMaxmemory),
 
     /* Size_t configs */
     createSizeTConfig("hash-max-listpack-entries", "hash-max-ziplist-entries", MODIFIABLE_CONFIG, 0, LONG_MAX, server.hash_max_listpack_entries, 512, INTEGER_CONFIG, NULL, NULL),
@@ -2656,13 +2656,13 @@ standardConfig configs[] = {
     createSSizeTConfig("maxmemory-clients", NULL, MODIFIABLE_CONFIG, -100, SSIZE_MAX, server.maxmemory_clients, 0, MEMORY_CONFIG, NULL, NULL),
 
     /* Other configs */
-    createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60*60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */
-    createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64*1024*1024, MEMORY_CONFIG, NULL, NULL),
+    createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60*60, 0, NULL, NULL), /* Default: 1 hour */
+    createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64*1024*1024, NUM_CONF_FLAG_MEMORY, NULL, NULL),
 
 #ifdef USE_OPENSSL
-    createIntConfig("tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.tls_port, 0, INTEGER_CONFIG, NULL, updateTLSPort), /* TCP port. */
-    createIntConfig("tls-session-cache-size", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_size, 20*1024, INTEGER_CONFIG, NULL, updateTlsCfgInt),
-    createIntConfig("tls-session-cache-timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_timeout, 300, INTEGER_CONFIG, NULL, updateTlsCfgInt),
+    createIntConfig("tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.tls_port, 0, 0, NULL, updateTLSPort), /* TCP port. */
+    createIntConfig("tls-session-cache-size", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_size, 20*1024, 0, NULL, updateTlsCfgInt),
+    createIntConfig("tls-session-cache-timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_timeout, 300, 0, NULL, updateTlsCfgInt),
     createBoolConfig("tls-cluster", NULL, MODIFIABLE_CONFIG, server.tls_cluster, 0, NULL, updateTlsCfgBool),
     createBoolConfig("tls-replication", NULL, MODIFIABLE_CONFIG, server.tls_replication, 0, NULL, updateTlsCfgBool),
     createEnumConfig("tls-auth-clients", NULL, MODIFIABLE_CONFIG, tls_auth_clients_enum, server.tls_auth_clients, TLS_CLIENT_AUTH_YES, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -2653,7 +2653,7 @@ standardConfig configs[] = {
     createSizeTConfig("hll-sparse-max-bytes", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.hll_sparse_max_bytes, 3000, MEMORY_CONFIG, NULL, NULL),
     createSizeTConfig("tracking-table-max-keys", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.tracking_table_max_keys, 1000000, INTEGER_CONFIG, NULL, NULL), /* Default: 1 million keys max. */
     createSizeTConfig("client-query-buffer-limit", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.client_max_querybuf_len, 1024*1024*1024, MEMORY_CONFIG, NULL, NULL), /* Default: 1GB max query buffer. */
-    createSizeTConfig("maxmemory-clients", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory_clients, 0, MEMORY_CONFIG, NULL, NULL),
+    createSSizeTConfig("maxmemory-clients", NULL, MODIFIABLE_CONFIG, -100, SSIZE_MAX, server.maxmemory_clients, 0, MEMORY_CONFIG, NULL, NULL),
 
     /* Other configs */
     createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60*60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */

--- a/src/config.c
+++ b/src/config.c
@@ -2653,6 +2653,7 @@ standardConfig configs[] = {
     createSizeTConfig("hll-sparse-max-bytes", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.hll_sparse_max_bytes, 3000, MEMORY_CONFIG, NULL, NULL),
     createSizeTConfig("tracking-table-max-keys", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.tracking_table_max_keys, 1000000, INTEGER_CONFIG, NULL, NULL), /* Default: 1 million keys max. */
     createSizeTConfig("client-query-buffer-limit", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.client_max_querybuf_len, 1024*1024*1024, MEMORY_CONFIG, NULL, NULL), /* Default: 1GB max query buffer. */
+    createSizeTConfig("maxmemory-clients", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory_clients, 0, MEMORY_CONFIG, NULL, NULL),
 
     /* Other configs */
     createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60*60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */

--- a/src/config.c
+++ b/src/config.c
@@ -2234,6 +2234,9 @@ static void numericConfigRewrite(typeData data, const char *name, struct rewrite
     }
 }
 
+#define INTEGER_CONFIG 0
+#define MEMORY_CONFIG (NUM_CONF_MEMORY)
+
 #define embedCommonNumericalConfig(name, alias, _flags, lower, upper, config_addr, default, num_conf_flags, is_valid, update) { \
     embedCommonConfig(name, alias, _flags) \
     embedConfigInterface(numericConfigInit, numericConfigSet, numericConfigGet, numericConfigRewrite) \
@@ -2632,81 +2635,81 @@ standardConfig configs[] = {
     createEnumConfig("sanitize-dump-payload", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, sanitize_dump_payload_enum, server.sanitize_dump_payload, SANITIZE_DUMP_NO, NULL, NULL),
 
     /* Integer configs */
-    createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, 0, NULL, NULL),
-    createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, 0, NULL, updatePort), /* TCP port. */
-    createIntConfig("io-threads", NULL, DEBUG_CONFIG | IMMUTABLE_CONFIG, 1, 128, server.io_threads_num, 1, 0, NULL, NULL), /* Single threaded by default */
-    createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, 0, NULL, NULL),
-    createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_slave_validity_factor, 10, 0, NULL, NULL), /* Slave max data age factor. */
-    createIntConfig("list-max-ziplist-size", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.list_max_ziplist_size, -2, 0, NULL, NULL),
-    createIntConfig("tcp-keepalive", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tcpkeepalive, 300, 0, NULL, NULL),
-    createIntConfig("cluster-migration-barrier", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_migration_barrier, 1, 0, NULL, NULL),
-    createIntConfig("active-defrag-cycle-min", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_min, 1, 0, NULL, NULL), /* Default: 1% CPU min (at lower threshold) */
-    createIntConfig("active-defrag-cycle-max", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_max, 25, 0, NULL, NULL), /* Default: 25% CPU max (at upper threshold) */
-    createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, 0, NULL, NULL), /* Default: don't defrag when fragmentation is below 10% */
-    createIntConfig("active-defrag-threshold-upper", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_upper, 100, 0, NULL, NULL), /* Default: maximum defrag force at 100% fragmentation */
-    createIntConfig("lfu-log-factor", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_log_factor, 10, 0, NULL, NULL),
-    createIntConfig("lfu-decay-time", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_decay_time, 1, 0, NULL, NULL),
-    createIntConfig("replica-priority", "slave-priority", MODIFIABLE_CONFIG, 0, INT_MAX, server.slave_priority, 100, 0, NULL, NULL),
-    createIntConfig("repl-diskless-sync-delay", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_diskless_sync_delay, 5, 0, NULL, NULL),
-    createIntConfig("maxmemory-samples", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.maxmemory_samples, 5, 0, NULL, NULL),
-    createIntConfig("maxmemory-eviction-tenacity", NULL, MODIFIABLE_CONFIG, 0, 100, server.maxmemory_eviction_tenacity, 10, 0, NULL, NULL),
-    createIntConfig("timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.maxidletime, 0, 0, NULL, NULL), /* Default client timeout: infinite */
-    createIntConfig("replica-announce-port", "slave-announce-port", MODIFIABLE_CONFIG, 0, 65535, server.slave_announce_port, 0, 0, NULL, NULL),
-    createIntConfig("tcp-backlog", NULL, IMMUTABLE_CONFIG, 0, INT_MAX, server.tcp_backlog, 511, 0, NULL, NULL), /* TCP listen backlog. */
-    createIntConfig("cluster-announce-bus-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_bus_port, 0, 0, NULL, NULL), /* Default: Use +10000 offset. */
-    createIntConfig("cluster-announce-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_port, 0, 0, NULL, NULL), /* Use server.port */
-    createIntConfig("cluster-announce-tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_tls_port, 0, 0, NULL, NULL), /* Use server.tls_port */
-    createIntConfig("repl-timeout", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.repl_timeout, 60, 0, NULL, NULL),
-    createIntConfig("repl-ping-replica-period", "repl-ping-slave-period", MODIFIABLE_CONFIG, 1, INT_MAX, server.repl_ping_slave_period, 10, 0, NULL, NULL),
-    createIntConfig("list-compress-depth", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 0, INT_MAX, server.list_compress_depth, 0, 0, NULL, NULL),
-    createIntConfig("rdb-key-save-delay", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.rdb_key_save_delay, 0, 0, NULL, NULL),
-    createIntConfig("key-load-delay", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.key_load_delay, 0, 0, NULL, NULL),
-    createIntConfig("active-expire-effort", NULL, MODIFIABLE_CONFIG, 1, 10, server.active_expire_effort, 1, 0, NULL, NULL), /* From 1 to 10. */
-    createIntConfig("hz", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.config_hz, CONFIG_DEFAULT_HZ, 0, NULL, updateHZ),
-    createIntConfig("min-replicas-to-write", "min-slaves-to-write", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_to_write, 0, 0, NULL, updateGoodSlaves),
-    createIntConfig("min-replicas-max-lag", "min-slaves-max-lag", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_max_lag, 10, 0, NULL, updateGoodSlaves),
+    createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */
+    createIntConfig("io-threads", NULL, DEBUG_CONFIG | IMMUTABLE_CONFIG, 1, 128, server.io_threads_num, 1, INTEGER_CONFIG, NULL, NULL), /* Single threaded by default */
+    createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_slave_validity_factor, 10, INTEGER_CONFIG, NULL, NULL), /* Slave max data age factor. */
+    createIntConfig("list-max-ziplist-size", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.list_max_ziplist_size, -2, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("tcp-keepalive", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tcpkeepalive, 300, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("cluster-migration-barrier", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_migration_barrier, 1, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("active-defrag-cycle-min", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_min, 1, INTEGER_CONFIG, NULL, NULL), /* Default: 1% CPU min (at lower threshold) */
+    createIntConfig("active-defrag-cycle-max", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_max, 25, INTEGER_CONFIG, NULL, NULL), /* Default: 25% CPU max (at upper threshold) */
+    createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, INTEGER_CONFIG, NULL, NULL), /* Default: don't defrag when fragmentation is below 10% */
+    createIntConfig("active-defrag-threshold-upper", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_upper, 100, INTEGER_CONFIG, NULL, NULL), /* Default: maximum defrag force at 100% fragmentation */
+    createIntConfig("lfu-log-factor", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_log_factor, 10, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("lfu-decay-time", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_decay_time, 1, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("replica-priority", "slave-priority", MODIFIABLE_CONFIG, 0, INT_MAX, server.slave_priority, 100, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("repl-diskless-sync-delay", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_diskless_sync_delay, 5, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("maxmemory-samples", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.maxmemory_samples, 5, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("maxmemory-eviction-tenacity", NULL, MODIFIABLE_CONFIG, 0, 100, server.maxmemory_eviction_tenacity, 10, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.maxidletime, 0, INTEGER_CONFIG, NULL, NULL), /* Default client timeout: infinite */
+    createIntConfig("replica-announce-port", "slave-announce-port", MODIFIABLE_CONFIG, 0, 65535, server.slave_announce_port, 0, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("tcp-backlog", NULL, IMMUTABLE_CONFIG, 0, INT_MAX, server.tcp_backlog, 511, INTEGER_CONFIG, NULL, NULL), /* TCP listen backlog. */
+    createIntConfig("cluster-announce-bus-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_bus_port, 0, INTEGER_CONFIG, NULL, NULL), /* Default: Use +10000 offset. */
+    createIntConfig("cluster-announce-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_port, 0, INTEGER_CONFIG, NULL, NULL), /* Use server.port */
+    createIntConfig("cluster-announce-tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_tls_port, 0, INTEGER_CONFIG, NULL, NULL), /* Use server.tls_port */
+    createIntConfig("repl-timeout", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.repl_timeout, 60, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("repl-ping-replica-period", "repl-ping-slave-period", MODIFIABLE_CONFIG, 1, INT_MAX, server.repl_ping_slave_period, 10, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("list-compress-depth", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 0, INT_MAX, server.list_compress_depth, 0, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("rdb-key-save-delay", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.rdb_key_save_delay, 0, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("key-load-delay", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.key_load_delay, 0, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("active-expire-effort", NULL, MODIFIABLE_CONFIG, 1, 10, server.active_expire_effort, 1, INTEGER_CONFIG, NULL, NULL), /* From 1 to 10. */
+    createIntConfig("hz", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.config_hz, CONFIG_DEFAULT_HZ, INTEGER_CONFIG, NULL, updateHZ),
+    createIntConfig("min-replicas-to-write", "min-slaves-to-write", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_to_write, 0, INTEGER_CONFIG, NULL, updateGoodSlaves),
+    createIntConfig("min-replicas-max-lag", "min-slaves-max-lag", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_max_lag, 10, INTEGER_CONFIG, NULL, updateGoodSlaves),
 
     /* Unsigned int configs */
-    createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, 0, NULL, updateMaxclients),
+    createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),
 
     /* Unsigned Long configs */
-    createULongConfig("active-defrag-max-scan-fields", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, server.active_defrag_max_scan_fields, 1000, 0, NULL, NULL), /* Default: keys with more than 1000 fields will be processed separately */
-    createULongConfig("slowlog-max-len", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.slowlog_max_len, 128, 0, NULL, NULL),
-    createULongConfig("acllog-max-len", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.acllog_max_len, 128, 0, NULL, NULL),
+    createULongConfig("active-defrag-max-scan-fields", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, server.active_defrag_max_scan_fields, 1000, INTEGER_CONFIG, NULL, NULL), /* Default: keys with more than 1000 fields will be processed separately */
+    createULongConfig("slowlog-max-len", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.slowlog_max_len, 128, INTEGER_CONFIG, NULL, NULL),
+    createULongConfig("acllog-max-len", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.acllog_max_len, 128, INTEGER_CONFIG, NULL, NULL),
 
     /* Long Long configs */
-    createLongLongConfig("lua-time-limit", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.lua_time_limit, 5000, 0, NULL, NULL),/* milliseconds */
-    createLongLongConfig("cluster-node-timeout", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.cluster_node_timeout, 15000, 0, NULL, NULL),
-    createLongLongConfig("slowlog-log-slower-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.slowlog_log_slower_than, 10000, 0, NULL, NULL),
-    createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, 0, NULL, NULL),
-    createLongLongConfig("proto-max-bulk-len", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.proto_max_bulk_len, 512ll*1024*1024, NUM_CONF_MEMORY, NULL, NULL), /* Bulk request max size */
-    createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, 0, NULL, NULL),
-    createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.cfg_repl_backlog_size, 1024*1024, NUM_CONF_MEMORY, NULL, updateReplBacklogSize), /* Default: 1mb */
+    createLongLongConfig("lua-time-limit", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.lua_time_limit, 5000, INTEGER_CONFIG, NULL, NULL),/* milliseconds */
+    createLongLongConfig("cluster-node-timeout", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.cluster_node_timeout, 15000, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("slowlog-log-slower-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.slowlog_log_slower_than, 10000, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("proto-max-bulk-len", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.proto_max_bulk_len, 512ll*1024*1024, MEMORY_CONFIG, NULL, NULL), /* Bulk request max size */
+    createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.cfg_repl_backlog_size, 1024*1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 1mb */
 
     /* Unsigned Long Long configs */
-    createULongLongConfig("maxmemory", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory, 0, NUM_CONF_MEMORY, NULL, updateMaxmemory),
+    createULongLongConfig("maxmemory", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory, 0, MEMORY_CONFIG, NULL, updateMaxmemory),
 
     /* Size_t configs */
-    createSizeTConfig("hash-max-listpack-entries", "hash-max-ziplist-entries", MODIFIABLE_CONFIG, 0, LONG_MAX, server.hash_max_listpack_entries, 512, 0, NULL, NULL),
-    createSizeTConfig("set-max-intset-entries", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.set_max_intset_entries, 512, 0, NULL, NULL),
-    createSizeTConfig("zset-max-listpack-entries", "zset-max-ziplist-entries", MODIFIABLE_CONFIG, 0, LONG_MAX, server.zset_max_listpack_entries, 128, 0, NULL, NULL),
-    createSizeTConfig("active-defrag-ignore-bytes", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.active_defrag_ignore_bytes, 100<<20, NUM_CONF_MEMORY, NULL, NULL), /* Default: don't defrag if frag overhead is below 100mb */
-    createSizeTConfig("hash-max-listpack-value", "hash-max-ziplist-value", MODIFIABLE_CONFIG, 0, LONG_MAX, server.hash_max_listpack_value, 64, NUM_CONF_MEMORY, NULL, NULL),
-    createSizeTConfig("stream-node-max-bytes", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.stream_node_max_bytes, 4096, NUM_CONF_MEMORY, NULL, NULL),
-    createSizeTConfig("zset-max-listpack-value", "zset-max-ziplist-value", MODIFIABLE_CONFIG, 0, LONG_MAX, server.zset_max_listpack_value, 64, NUM_CONF_MEMORY, NULL, NULL),
-    createSizeTConfig("hll-sparse-max-bytes", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.hll_sparse_max_bytes, 3000, NUM_CONF_MEMORY, NULL, NULL),
-    createSizeTConfig("tracking-table-max-keys", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.tracking_table_max_keys, 1000000, 0, NULL, NULL), /* Default: 1 million keys max. */
-    createSizeTConfig("client-query-buffer-limit", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.client_max_querybuf_len, 1024*1024*1024, NUM_CONF_MEMORY, NULL, NULL), /* Default: 1GB max query buffer. */
+    createSizeTConfig("hash-max-listpack-entries", "hash-max-ziplist-entries", MODIFIABLE_CONFIG, 0, LONG_MAX, server.hash_max_listpack_entries, 512, INTEGER_CONFIG, NULL, NULL),
+    createSizeTConfig("set-max-intset-entries", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.set_max_intset_entries, 512, INTEGER_CONFIG, NULL, NULL),
+    createSizeTConfig("zset-max-listpack-entries", "zset-max-ziplist-entries", MODIFIABLE_CONFIG, 0, LONG_MAX, server.zset_max_listpack_entries, 128, INTEGER_CONFIG, NULL, NULL),
+    createSizeTConfig("active-defrag-ignore-bytes", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.active_defrag_ignore_bytes, 100<<20, MEMORY_CONFIG, NULL, NULL), /* Default: don't defrag if frag overhead is below 100mb */
+    createSizeTConfig("hash-max-listpack-value", "hash-max-ziplist-value", MODIFIABLE_CONFIG, 0, LONG_MAX, server.hash_max_listpack_value, 64, MEMORY_CONFIG, NULL, NULL),
+    createSizeTConfig("stream-node-max-bytes", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.stream_node_max_bytes, 4096, MEMORY_CONFIG, NULL, NULL),
+    createSizeTConfig("zset-max-listpack-value", "zset-max-ziplist-value", MODIFIABLE_CONFIG, 0, LONG_MAX, server.zset_max_listpack_value, 64, MEMORY_CONFIG, NULL, NULL),
+    createSizeTConfig("hll-sparse-max-bytes", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.hll_sparse_max_bytes, 3000, MEMORY_CONFIG, NULL, NULL),
+    createSizeTConfig("tracking-table-max-keys", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.tracking_table_max_keys, 1000000, INTEGER_CONFIG, NULL, NULL), /* Default: 1 million keys max. */
+    createSizeTConfig("client-query-buffer-limit", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.client_max_querybuf_len, 1024*1024*1024, MEMORY_CONFIG, NULL, NULL), /* Default: 1GB max query buffer. */
     createSSizeTConfig("maxmemory-clients", NULL, MODIFIABLE_CONFIG, -100, SSIZE_MAX, server.maxmemory_clients, 0, NUM_CONF_MEMORY | NUM_CONF_PERCENT, NULL, NULL),
 
     /* Other configs */
-    createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60*60, 0, NULL, NULL), /* Default: 1 hour */
-    createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64*1024*1024, NUM_CONF_MEMORY, NULL, NULL),
+    createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60*60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */
+    createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64*1024*1024, MEMORY_CONFIG, NULL, NULL),
 
 #ifdef USE_OPENSSL
-    createIntConfig("tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.tls_port, 0, 0, NULL, updateTLSPort), /* TCP port. */
-    createIntConfig("tls-session-cache-size", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_size, 20*1024, 0, NULL, updateTlsCfgInt),
-    createIntConfig("tls-session-cache-timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_timeout, 300, 0, NULL, updateTlsCfgInt),
+    createIntConfig("tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.tls_port, 0, INTEGER_CONFIG, NULL, updateTLSPort), /* TCP port. */
+    createIntConfig("tls-session-cache-size", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_size, 20*1024, INTEGER_CONFIG, NULL, updateTlsCfgInt),
+    createIntConfig("tls-session-cache-timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_timeout, 300, INTEGER_CONFIG, NULL, updateTlsCfgInt),
     createBoolConfig("tls-cluster", NULL, MODIFIABLE_CONFIG, server.tls_cluster, 0, NULL, updateTlsCfgBool),
     createBoolConfig("tls-replication", NULL, MODIFIABLE_CONFIG, server.tls_replication, 0, NULL, updateTlsCfgBool),
     createEnumConfig("tls-auth-clients", NULL, MODIFIABLE_CONFIG, tls_auth_clients_enum, server.tls_auth_clients, TLS_CLIENT_AUTH_YES, NULL, NULL),

--- a/src/debug.c
+++ b/src/debug.c
@@ -902,6 +902,7 @@ NULL
                 server.client_mem_usage_buckets[j].clients->len);
         }
         addReplyVerbatim(c,bucket_info,sdslen(bucket_info),"txt");
+        sdsfree(bucket_info);
 #ifdef USE_JEMALLOC
     } else if(!strcasecmp(c->argv[1]->ptr,"mallctl") && c->argc >= 3) {
         mallctl_int(c, c->argv+2, c->argc-2);

--- a/src/debug.c
+++ b/src/debug.c
@@ -885,8 +885,7 @@ NULL
             addReplyError(c, "CONFIG-REWRITE-FORCE-ALL failed");
         else
             addReply(c, shared.ok);
-    } else if(!strcasecmp(c->argv[1]->ptr,"client-eviction") && c->argc == 2)
-    {
+    } else if(!strcasecmp(c->argv[1]->ptr,"client-eviction") && c->argc == 2) {
         sds bucket_info = sdsempty();
         for (int j = 0; j < CLIENT_MEM_USAGE_BUCKETS; j++) {
             if (j == 0)

--- a/src/debug.c
+++ b/src/debug.c
@@ -469,6 +469,8 @@ void debugCommand(client *c) {
 "    Return the size of different Redis core C structures.",
 "ZIPLIST <key>",
 "    Show low level info about the ziplist encoding of <key>.",
+"CLIENT-EVICTION",
+"    Show low level client eviction pools info (maxmemory-clients).",
 NULL
         };
         addReplyHelp(c, help);
@@ -883,6 +885,23 @@ NULL
             addReplyError(c, "CONFIG-REWRITE-FORCE-ALL failed");
         else
             addReply(c, shared.ok);
+    } else if(!strcasecmp(c->argv[1]->ptr,"client-eviction") && c->argc == 2)
+    {
+        sds bucket_info = sdsempty();
+        for (int j = 0; j < CLIENT_MEM_USAGE_BUCKETS; j++) {
+            if (j == 0)
+                bucket_info = sdscatprintf(bucket_info, "bucket          0");
+            else
+                bucket_info = sdscatprintf(bucket_info, "bucket %10zu", (size_t)1<<(j-1+CLIENT_MEM_USAGE_BUCKET_MIN_LOG));
+            if (j == CLIENT_MEM_USAGE_BUCKETS-1)
+                bucket_info = sdscatprintf(bucket_info, "+            : ");
+            else
+                bucket_info = sdscatprintf(bucket_info, " - %10zu: ", ((size_t)1<<(j+CLIENT_MEM_USAGE_BUCKET_MIN_LOG))-1);
+            bucket_info = sdscatprintf(bucket_info, "tot-mem: %10zu, clients: %lu\n",
+                server.client_mem_usage_buckets[j].mem_usage_sum,
+                server.client_mem_usage_buckets[j].clients->len);
+        }
+        addReplyVerbatim(c,bucket_info,sdslen(bucket_info),"txt");
 #ifdef USE_JEMALLOC
     } else if(!strcasecmp(c->argv[1]->ptr,"mallctl") && c->argc >= 3) {
         mallctl_int(c, c->argv+2, c->argc-2);

--- a/src/multi.c
+++ b/src/multi.c
@@ -440,8 +440,7 @@ void unwatchCommand(client *c) {
 
 size_t multiStateMemOverhead(client *c) {
     size_t mem = c->mstate.argv_len_sums;
-    /* Add watched keys overhead */
-    /* TODO: this doesn't take into account the watched keys themselves, becuase they aren't managed per-client. Also handle this in mem overhead. */
+    /* Add watched keys overhead, Note: this doesn't take into account the watched keys themselves, because they aren't managed per-client. */
     mem += listLength(c->watched_keys) * (sizeof(listNode) + sizeof(watchedKey));
     return mem;
 }

--- a/src/multi.c
+++ b/src/multi.c
@@ -79,7 +79,7 @@ void queueMultiCommand(client *c) {
     c->mstate.count++;
     c->mstate.cmd_flags |= c->cmd->flags;
     c->mstate.cmd_inv_flags |= ~c->cmd->flags;
-    c->mstate.argv_len_sums += c->argv_len_sum;
+    c->mstate.argv_len_sums += c->argv_len_sum + sizeof(robj*)*c->argc;
 }
 
 void discardTransaction(client *c) {

--- a/src/multi.c
+++ b/src/multi.c
@@ -37,7 +37,7 @@ void initClientMultiState(client *c) {
     c->mstate.count = 0;
     c->mstate.cmd_flags = 0;
     c->mstate.cmd_inv_flags = 0;
-    c->mstate.argv_mem_sum = 0;
+    c->mstate.argv_len_sums = 0;
 }
 
 /* Release all the resources associated with MULTI/EXEC state */
@@ -439,7 +439,7 @@ void unwatchCommand(client *c) {
 }
 
 size_t multiStateMemOverhead(client *c) {
-    size_t mem = c->mstate.argv_mem_sum;
+    size_t mem = c->mstate.argv_len_sums;
     /* Add watched keys overhead */
     /* TODO: this doesn't take into account the watched keys themselves, becuase they aren't managed per-client. Also handle this in mem overhead. */
     mem += listLength(c->watched_keys) * (sizeof(listNode) + sizeof(watchedKey));

--- a/src/networking.c
+++ b/src/networking.c
@@ -3875,8 +3875,11 @@ int clientEvictionCheckLimit() {
     size_t maxmemory_clients_actual = SIZE_MAX;
 
     /* Handle percentage of maxmemory*/
-    if (server.maxmemory_clients < 0 && server.maxmemory > 0)
-        maxmemory_clients_actual = (size_t)((double)server.maxmemory * -(double)server.maxmemory_clients / 100);
+    if (server.maxmemory_clients < 0 && server.maxmemory > 0) {
+        unsigned long long maxmemory_clients_bytes = (unsigned long long)((double)server.maxmemory * -(double) server.maxmemory_clients / 100);
+        if (maxmemory_clients_bytes <= SIZE_MAX)
+            maxmemory_clients_actual = maxmemory_clients_bytes;
+    }
     else if (server.maxmemory_clients > 0)
         maxmemory_clients_actual = server.maxmemory_clients;
     else

--- a/src/networking.c
+++ b/src/networking.c
@@ -2332,7 +2332,7 @@ sds catClientInfoString(sds s, client *client) {
     if (client->flags & CLIENT_CLOSE_ASAP) *p++ = 'A';
     if (client->flags & CLIENT_UNIX_SOCKET) *p++ = 'U';
     if (client->flags & CLIENT_READONLY) *p++ = 'r';
-    if (client->flags & CLIENT_NO_EVICT) *p++ = 'p';
+    if (client->flags & CLIENT_NO_EVICT) *p++ = 'e';
     if (p == flags) *p++ = 'N';
     *p++ = '\0';
 
@@ -2584,7 +2584,7 @@ NULL
             addReplyErrorObject(c,shared.syntaxerr);
             return;
         }
-    } else if (!strcasecmp(c->argv[1]->ptr,"protect") && c->argc == 3) {
+    } else if (!strcasecmp(c->argv[1]->ptr,"no-evict") && c->argc == 3) {
         /* CLIENT PROTECT ON|OFF */
         if (!strcasecmp(c->argv[2]->ptr,"on")) {
             c->flags |= CLIENT_NO_EVICT;
@@ -3828,7 +3828,7 @@ int clientEvictionCheckLimit() {
     return 1;
 }
 
-void clientsEviction() {
+void evictClients() {
     /* Start eviction from topmost bucket (largest clients) */
     int curr_bucket = CLIENT_MEM_USAGE_BUCKETS-1;
     listIter bucket_iter;

--- a/src/networking.c
+++ b/src/networking.c
@@ -1484,7 +1484,7 @@ void freeClientAsync(client *c) {
  * return C_ERR in case client is no longer valid after call. */
 int beforeNextClient(client *c) {
     /* Skip the client processing if we're in an IO thread, in that case we'll perform
-       this operation later in the fan-in stage of the threading mechanism */
+       this operation later (this function is called again) in the fan-in stage of the threading mechanism */
     if (io_threads_op != IO_THREADS_OP_IDLE)
         return C_OK;
     /* Handle async frees */

--- a/src/networking.c
+++ b/src/networking.c
@@ -1817,7 +1817,7 @@ int processInlineBuffer(client *c) {
     if (argc) {
         if (c->argv) zfree(c->argv);
         c->argv = zmalloc(sizeof(robj*)*argc);
-        c->argv_len_sum = sizeof(robj*)*argc;
+        c->argv_len_sum = 0;
     }
 
     /* Create redis objects for all arguments. */
@@ -1916,7 +1916,7 @@ int processMultibulkBuffer(client *c) {
         /* Setup argv array on client structure */
         if (c->argv) zfree(c->argv);
         c->argv = zmalloc(sizeof(robj*)*c->multibulklen);
-        c->argv_len_sum = sizeof(robj*)*c->multibulklen;
+        c->argv_len_sum = 0;
     }
 
     serverAssertWithInfo(c,NULL,c->multibulklen > 0);
@@ -3219,7 +3219,7 @@ size_t getClientMemoryUsage(client *c, size_t *output_buffer_mem_usage) {
     /* For efficiency (less work keeping track of the argv memory), it doesn't include the used memory
      * i.e. unused sds space and internal fragmentation, just the string length. but this is enough to
      * spot problematic clients. */
-    mem += c->argv_len_sum;
+    mem += c->argv_len_sum + sizeof(robj*)*c->argc;
     mem += multiStateMemOverhead(c);
 
     /* Add memory overhead of pubsub channels and patterns. Note: this is just the overhead of the robj pointers

--- a/src/networking.c
+++ b/src/networking.c
@@ -3203,7 +3203,7 @@ void rewriteClientCommandArgument(client *c, int i, robj *newval) {
  * the caller wishes. The main usage of this function currently is
  * enforcing the client output length limits. */
 size_t getClientOutputBufferMemoryUsage(client *c) {
-    unsigned long list_item_size = sizeof(listNode) + sizeof(clientReplyBlock);
+    size_t list_item_size = sizeof(listNode) + sizeof(clientReplyBlock);
     return c->reply_bytes + (list_item_size*listLength(c->reply));
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1474,8 +1474,8 @@ void freeClientAsync(client *c) {
     pthread_mutex_unlock(&async_free_queue_mutex);
 }
 
-/* Perform procssing of the client before moving on to processing the next client
- * this is usefull for performing operations that affect the global state but can't
+/* Perform processing of the client before moving on to processing the next client
+ * this is useful for performing operations that affect the global state but can't
  * wait until we're done with all clients. In other words can't wait until beforeSleep()
  * return C_ERR in case client is no longer valid after call. */
 int beforeNextClient(client *c) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -1795,7 +1795,7 @@ int processInlineBuffer(client *c) {
     if (argc) {
         if (c->argv) zfree(c->argv);
         c->argv = zmalloc(sizeof(robj*)*argc);
-        c->argv_len_sum = 0;
+        c->argv_len_sum = sizeof(robj*)*argc;
     }
 
     /* Create redis objects for all arguments. */
@@ -1894,7 +1894,7 @@ int processMultibulkBuffer(client *c) {
         /* Setup argv array on client structure */
         if (c->argv) zfree(c->argv);
         c->argv = zmalloc(sizeof(robj*)*c->multibulklen);
-        c->argv_len_sum = 0;
+        c->argv_len_sum = sizeof(robj*)*c->multibulklen;
     }
 
     serverAssertWithInfo(c,NULL,c->multibulklen > 0);
@@ -2346,7 +2346,7 @@ sds catClientInfoString(sds s, client *client) {
     size_t obufmem, total_mem = getClientMemoryUsage(client, &obufmem);
 
     return sdscatfmt(s,
-        "id=%U addr=%s laddr=%s %s name=%s age=%I idle=%I flags=%s db=%i sub=%i psub=%i multi=%i qbuf=%U qbuf-free=%U argv-mem=%U obl=%U oll=%U omem=%U tot-mem=%U events=%s cmd=%s user=%s redir=%I resp=%i",
+        "id=%U addr=%s laddr=%s %s name=%s age=%I idle=%I flags=%s db=%i sub=%i psub=%i multi=%i qbuf=%U qbuf-free=%U argv-mem=%U multi-mem=%U obl=%U oll=%U omem=%U tot-mem=%U events=%s cmd=%s user=%s redir=%I resp=%i",
         (unsigned long long) client->id,
         getClientPeerId(client),
         getClientSockname(client),
@@ -2362,6 +2362,7 @@ sds catClientInfoString(sds s, client *client) {
         (unsigned long long) sdslen(client->querybuf),
         (unsigned long long) sdsavail(client->querybuf),
         (unsigned long long) client->argv_len_sum,
+        (unsigned long long) client->mstate.argv_mem_sum,
         (unsigned long long) client->bufpos,
         (unsigned long long) listLength(client->reply),
         (unsigned long long) obufmem, /* should not include client->buf since we want to see 0 for static clients. */
@@ -3197,11 +3198,12 @@ size_t getClientMemoryUsage(client *c, size_t *output_buffer_mem_usage) {
         *output_buffer_mem_usage = mem;
     mem += sdsZmallocSize(c->querybuf);
     mem += zmalloc_size(c);
-    mem += c->argv_len_sum;
     /* For efficiency (less work keeping track of the argv memory), it doesn't include the used memory
      * i.e. unused sds space and internal fragmentation, just the string length. but this is enough to
      * spot problematic clients. */
-    if (c->argv) mem += zmalloc_size(c->argv);
+    mem += c->argv_len_sum;
+    mem += multiStateMemOverhead(c);
+
     return mem;
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -3779,7 +3779,7 @@ void clientsEviction() {
     if (!clientEvictionCheckLimit())
         return;
 
-    raxStart(&ri,server.client_eviction_pull);
+    raxStart(&ri,server.client_eviction_pool);
     raxSeek(&ri,"$",NULL,0);
     while (raxPrev(&ri)) {
         client *best = ri.data;

--- a/src/networking.c
+++ b/src/networking.c
@@ -2317,6 +2317,7 @@ sds catClientInfoString(sds s, client *client) {
     if (client->flags & CLIENT_CLOSE_ASAP) *p++ = 'A';
     if (client->flags & CLIENT_UNIX_SOCKET) *p++ = 'U';
     if (client->flags & CLIENT_READONLY) *p++ = 'r';
+    if (client->flags & CLIENT_NO_EVICT) *p++ = 'p';
     if (p == flags) *p++ = 'N';
     *p++ = '\0';
 
@@ -2567,6 +2568,18 @@ NULL
         } else if (!strcasecmp(c->argv[2]->ptr,"skip")) {
             if (!(c->flags & CLIENT_REPLY_OFF))
                 c->flags |= CLIENT_REPLY_SKIP_NEXT;
+        } else {
+            addReplyErrorObject(c,shared.syntaxerr);
+            return;
+        }
+    } else if (!strcasecmp(c->argv[1]->ptr,"protect") && c->argc == 3) {
+        /* CLIENT PROTECT ON|OFF */
+        if (!strcasecmp(c->argv[2]->ptr,"on")) {
+            c->flags |= CLIENT_NO_EVICT;
+            addReply(c,shared.ok);
+        } else if (!strcasecmp(c->argv[2]->ptr,"off")) {
+            c->flags &= ~CLIENT_NO_EVICT;
+            addReply(c,shared.ok);
         } else {
             addReplyErrorObject(c,shared.syntaxerr);
             return;

--- a/src/networking.c
+++ b/src/networking.c
@@ -3872,7 +3872,7 @@ int handleClientsWithPendingReadsUsingThreads(void) {
 
 /* Returns the actual client eviction limit based on current configuration or
  * 0 if no limit. */
-size_t getClientEvictionLimit() {
+size_t getClientEvictionLimit(void) {
     size_t maxmemory_clients_actual = SIZE_MAX;
 
     /* Handle percentage of maxmemory*/
@@ -3894,7 +3894,7 @@ size_t getClientEvictionLimit() {
     return maxmemory_clients_actual;
 }
 
-void evictClients() {
+void evictClients(void) {
     /* Start eviction from topmost bucket (largest clients) */
     int curr_bucket = CLIENT_MEM_USAGE_BUCKETS-1;
     listIter bucket_iter;

--- a/src/networking.c
+++ b/src/networking.c
@@ -2045,6 +2045,11 @@ int processCommandAndResetClient(client *c) {
     if (processCommand(c) == C_OK) {
         commandProcessed(c);
     }
+
+    /* Update the client's memory to include output buffer growth following the
+     * processed command. */
+    updateClientMemUsage(c);
+
     if (server.current_client == NULL) deadclient = 1;
     /*
      * Restore the old client, this is needed because when a script
@@ -2146,7 +2151,9 @@ void processInputBuffer(client *c) {
         c->qb_pos = 0;
     }
 
-    // TODO: should this move into the loop above? Into processCommandAndResetClient? We do check the client_maxmemory per command but don't update the mem usage per command?!
+    /* Update client memory usage after processing the query buffer, this is
+     * important in case the query buffer is big and wasn't drained during
+     * the above loop (because of partially sent big commands). */
     updateClientMemUsage(c);
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1317,8 +1317,6 @@ void freeClient(client *c) {
         return;
     }
 
-    serverLog(LL_WARNING, "Freeing %s", c->name ? (char*)c->name->ptr : "");
-
     /* For connected clients, call the disconnection event of modules hooks. */
     if (c->conn) {
         moduleFireServerEvent(REDISMODULE_EVENT_CLIENT_CHANGE,
@@ -1464,7 +1462,6 @@ void freeClientAsync(client *c) {
      * are in the context of the main thread while the other threads are
      * idle. */
     if (c->flags & CLIENT_CLOSE_ASAP || c->flags & CLIENT_LUA) return;
-    serverLog(LL_WARNING, "Marking client %s to be freed", c->name ? (char*)c->name->ptr : "");
     c->flags |= CLIENT_CLOSE_ASAP;
     if (server.io_threads_num == 1) {
         /* no need to bother with locking if there's just one thread (the main thread) */
@@ -1489,7 +1486,6 @@ int beforeNextClient(client *c) {
     /* Handle async frees */
     /* TODO: check if we even need freeClientsInAsyncFreeQueue() anymore... */
     if (c->flags & CLIENT_CLOSE_ASAP) {
-        serverLog(LL_WARNING, "@@ freeing client %s scheduled for async freeing", c->name ? (char*)c->name->ptr : "");
         freeClient(c);
         return C_ERR;
     }
@@ -1502,8 +1498,6 @@ int freeClientsInAsyncFreeQueue(void) {
     int freed = 0;
     listIter li;
     listNode *ln;
-
-    serverLog(LL_WARNING, "Doing async client frees");
 
     listRewind(server.clients_to_close,&li);
     while ((ln = listNext(&li)) != NULL) {
@@ -3290,7 +3284,6 @@ int checkClientOutputBufferLimits(client *c) {
      * like normal clients. */
     if (class == CLIENT_TYPE_MASTER) class = CLIENT_TYPE_NORMAL;
 
-    serverLog(LL_WARNING, "checking obuf limit, used_mem %zu limit %llu", used_mem, server.client_obuf_limits[class].hard_limit_bytes);
     if (server.client_obuf_limits[class].hard_limit_bytes &&
         used_mem >= server.client_obuf_limits[class].hard_limit_bytes)
         hard = 1;
@@ -3858,8 +3851,6 @@ int handleClientsWithPendingReadsUsingThreads(void) {
 
 /* Returns true if client memory limit was reached */
 int clientEvictionCheckLimit() {
-    serverLog(LL_WARNING, "Used client mem: %zu", server.stat_clients_type_memory[CLIENT_TYPE_NORMAL] +
-                                                  server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB]);
     if (server.maxmemory_clients == 0 ||
         server.stat_clients_type_memory[CLIENT_TYPE_NORMAL] +
         server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB] < server.maxmemory_clients) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -3885,7 +3885,7 @@ int clientEvictionCheckLimit() {
     /* Don't allow a too small maxmemory-clients to avoid cases where we can't communicate
      * at all with the server because of bad configuration */
     if (maxmemory_clients_actual < 1024*128)
-        maxmemory_clients_actual = 1024*128; //TODO: Warn here??
+        maxmemory_clients_actual = 1024*128;
 
     if (server.stat_clients_type_memory[CLIENT_TYPE_NORMAL] +
         server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB] < maxmemory_clients_actual) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -2044,11 +2044,10 @@ int processCommandAndResetClient(client *c) {
     server.current_client = c;
     if (processCommand(c) == C_OK) {
         commandProcessed(c);
+        /* Update the client's memory to include output buffer growth following the
+         * processed command. */
+        updateClientMemUsage(c);
     }
-
-    /* Update the client's memory to include output buffer growth following the
-     * processed command. */
-    updateClientMemUsage(c);
 
     if (server.current_client == NULL) deadclient = 1;
     /*
@@ -2249,7 +2248,7 @@ void readQueryFromClient(connection *conn) {
      * in case to check if there is a full command to execute. */
      processInputBuffer(c);
 
-     /* If the client was marked to be closed the free it now so we reclaim
+     /* If the client was marked to be closed then free it now so we reclaim
       * client memory before handling any other clients. */
      if (c->flags & CLIENT_CLOSE_ASAP) {
          serverLog(LL_WARNING, "@@@ freeing client early!");

--- a/src/networking.c
+++ b/src/networking.c
@@ -3224,7 +3224,7 @@ size_t getClientMemoryUsage(client *c, size_t *output_buffer_mem_usage) {
     mem += dictSize(c->pubsub_channels) * sizeof(dictEntry) +
            dictSlots(c->pubsub_channels) * sizeof(dictEntry*);
 
-    /* Add memory overhaed of the tracking prefixes, this is an underestimation so we don't need to traverse the entire rax */
+    /* Add memory overhead of the tracking prefixes, this is an underestimation so we don't need to traverse the entire rax */
     if (c->client_tracking_prefixes)
         mem += c->client_tracking_prefixes->numnodes * (sizeof(raxNode) * sizeof(raxNode*));
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -3206,7 +3206,7 @@ size_t getClientMemoryUsage(client *c, size_t *output_buffer_mem_usage) {
     mem += multiStateMemOverhead(c);
 
     /* Add memory overhead of pubsub channels and patterns. Note: this is just the overhead of the robj pointers
-     * the strings themselves because they aren't stored per client */
+     * to the strings themselves because they aren't stored per client. */
     mem += listLength(c->pubsub_patterns) * sizeof(listNode);
     mem += dictSize(c->pubsub_channels) * sizeof(dictEntry) +
            dictSlots(c->pubsub_channels) * sizeof(dictEntry*);

--- a/src/networking.c
+++ b/src/networking.c
@@ -1488,7 +1488,10 @@ int beforeNextClient(client *c) {
     if (io_threads_op != IO_THREADS_OP_IDLE)
         return C_OK;
     /* Handle async frees */
-    /* TODO: check if we even need freeClientsInAsyncFreeQueue() anymore... */
+    /* Note: this doesn't make the server.clients_to_close list redundant because of
+     * cases where we want an async free of a client other than myself. For example
+     * in ACL modifications we disconnect clients authenticated to non-existent
+     * users (see ACL LOAD). */
     if (c->flags & CLIENT_CLOSE_ASAP) {
         freeClient(c);
         return C_ERR;

--- a/src/networking.c
+++ b/src/networking.c
@@ -2146,6 +2146,7 @@ void processInputBuffer(client *c) {
         c->qb_pos = 0;
     }
 
+    // TODO: should this move into the loop above? Into processCommandAndResetClient? We do check the client_maxmemory per command but don't update the mem usage per command?!
     updateClientMemUsage(c);
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -1180,7 +1180,7 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
 
     /* Computing the memory used by the clients would be O(N) if done
      * here online. We use our values computed incrementally by
-     * clientsCronTrackClientsMemUsage(). */
+     * updateClientMemUsage(). */
     mh->clients_slaves = server.stat_clients_type_memory[CLIENT_TYPE_SLAVE];
     mh->clients_normal = server.stat_clients_type_memory[CLIENT_TYPE_MASTER]+
                          server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB]+

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -304,6 +304,7 @@ int pubsubPublishMessage(robj *channel, robj *message) {
         while ((ln = listNext(&li)) != NULL) {
             client *c = ln->value;
             addReplyPubsubMessage(c,channel,message);
+            updateClientMemUsage(c);
             receivers++;
         }
     }
@@ -323,6 +324,7 @@ int pubsubPublishMessage(robj *channel, robj *message) {
             while ((ln = listNext(&li)) != NULL) {
                 client *c = listNodeValue(ln);
                 addReplyPubsubPatMessage(c,pattern,channel,message);
+                updateClientMemUsage(c);
                 receivers++;
             }
         }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1286,6 +1286,8 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
                        !strcasecmp(argv[1],"htstats")) ||
         (argc >= 2 && !strcasecmp(command,"debug") &&
                        !strcasecmp(argv[1],"htstats-key")) ||
+        (argc >= 2 && !strcasecmp(command,"debug") &&
+                       !strcasecmp(argv[1],"client-eviction")) ||
         (argc >= 2 && !strcasecmp(command,"memory") &&
                       (!strcasecmp(argv[1],"malloc-stats") ||
                        !strcasecmp(argv[1],"doctor"))) ||

--- a/src/replication.c
+++ b/src/replication.c
@@ -414,6 +414,7 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     while((ln = listNext(&li))) {
         client *monitor = ln->value;
         addReply(monitor,cmdobj);
+        updateClientMemUsage(c);
     }
     decrRefCount(cmdobj);
 }

--- a/src/server.c
+++ b/src/server.c
@@ -2879,6 +2879,9 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
      * visit processCommand() at all). */
     handleClientsBlockedOnKeys();
 
+    /* Disconnect some clients if they are consuming too much memory. */
+    clientsEviction();
+
     /* Before we are going to sleep, let the threads access the dataset by
      * releasing the GIL. Redis main thread will not touch anything at this
      * time. */

--- a/src/server.c
+++ b/src/server.c
@@ -2217,8 +2217,8 @@ int updateClientMemUsage(client *c) {
 
 /* Adds the client to the correct memory usage bucket. Each bucket contains
  * all clients with roughly the same amount of memory. This way we group
- * together clients consuming about the same amount of memory and can quicly free
- * them in case we reach maxmemory-clients (client eviction).
+ * together clients consuming about the same amount of memory and can quickly
+ * free them in case we reach maxmemory-clients (client eviction).
  * Note that in case of io-threads enabled we have to call this function only
  * after the fan-in phase (when no io-threads are working) because the bucket
  * lists are global. The io-threads themselves track per-client memory usage in

--- a/src/server.c
+++ b/src/server.c
@@ -2177,11 +2177,11 @@ void removeClientFromEvictionPool(client *c) {
     uint64_t score = htonu64(c->client_cron_last_memory_usage);
     memcpy(buf, &score, 8);
     memcpy(buf+8, &c->id, 8);
-    raxRemove(server.client_eviction_pull, (void*)&buf, 16, NULL);
+    raxRemove(server.client_eviction_pool, (void*)&buf, 16, NULL);
 
     raxIterator ri;
     if (c->client_cron_last_memory_usage == server.client_eviction_pull_min) {
-        raxStart(&ri,server.client_eviction_pull);
+        raxStart(&ri,server.client_eviction_pool);
         raxSeek(&ri,"^",NULL,0);
         if (raxNext(&ri))
             server.client_eviction_pull_min = ((client*)ri.data)->client_cron_last_memory_usage;
@@ -2189,7 +2189,7 @@ void removeClientFromEvictionPool(client *c) {
     }
 
     if (c->client_cron_last_memory_usage == server.client_eviction_pull_max) {
-        raxStart(&ri,server.client_eviction_pull);
+        raxStart(&ri,server.client_eviction_pool);
         raxSeek(&ri,"$",NULL,0);
         if (raxPrev(&ri))
             server.client_eviction_pull_max = ((client*)ri.data)->client_cron_last_memory_usage;
@@ -2202,7 +2202,7 @@ void removeClientFromEvictionPool(client *c) {
  * computation incrementally and track the (not instantaneous but updated
  * to the second) total memory used by clients using clientsCron() in
  * a more incremental way (depending on server.hz). */
-int clientsCronTrackClientsMemUsage(client *c) {
+int updateClientMemUsage(client *c) {
     size_t mem = 0;
     int type = getClientType(c);
     mem += getClientOutputBufferMemoryUsage(c);
@@ -2222,24 +2222,24 @@ int clientsCronTrackClientsMemUsage(client *c) {
     //TODO: skip non normal client types, and handle cases where client changes type
     //TODO: add some minimum under which clients don't bother to run the rax code below (in remove too)
     removeClientFromEvictionPool(c);
-    if (raxSize(server.client_eviction_pull) < CLIENT_EVICTION_POOL || mem > server.client_eviction_pull_min) {
+    if (raxSize(server.client_eviction_pool) < CLIENT_EVICTION_POOL || mem > server.client_eviction_pull_min) {
         char buf[16];
         uint64_t score = htonu64(mem);
         memcpy(buf, &score, 8);
         memcpy(buf+8, &c->id, 8);
-        raxInsert(server.client_eviction_pull, (void*)buf, 16, c, NULL);
+        raxInsert(server.client_eviction_pool, (void*)buf, 16, c, NULL);
         if (mem < server.client_eviction_pull_min)
             server.client_eviction_pull_min = mem;
         if (mem > server.client_eviction_pull_max)
             server.client_eviction_pull_max = mem;
 
         /* too many items? remove the smallest one */
-        if (raxSize(server.client_eviction_pull) > CLIENT_EVICTION_POOL) {
+        if (raxSize(server.client_eviction_pool) > CLIENT_EVICTION_POOL) {
             raxIterator ri;
-            raxStart(&ri,server.client_eviction_pull);
+            raxStart(&ri,server.client_eviction_pool);
             raxSeek(&ri,"^",NULL,0);
             if (raxNext(&ri))
-                raxRemove(server.client_eviction_pull, ri.key, ri.key_len, NULL);
+                raxRemove(server.client_eviction_pool, ri.key, ri.key_len, NULL);
             raxStop(&ri);
         }
 
@@ -2329,7 +2329,7 @@ void clientsCron(void) {
         if (clientsCronHandleTimeout(c,now)) continue;
         if (clientsCronResizeQueryBuffer(c)) continue;
         if (clientsCronTrackExpansiveClients(c, curr_peak_mem_usage_slot)) continue;
-        if (clientsCronTrackClientsMemUsage(c)) continue;
+        if (updateClientMemUsage(c)) continue;
         if (closeClientOnOutputBufferLimitReached(c, 0)) continue;
     }
 }

--- a/src/server.c
+++ b/src/server.c
@@ -5456,7 +5456,7 @@ sds genRedisInfoString(const char *section) {
             listIter *it = listGetIterator(server.client_mem_usage_buckets[j].clients, AL_START_HEAD);
             for (listNode *ln = listNext(it); ln; ln = listNext(it)) {
                 client *c = (client*)ln->value;
-                info = sdscatprintf(info, "client_mem: %lu\r\n", c->client_last_memory_usage);
+                info = sdscatprintf(info, "client_mem: %zu\r\n", c->client_last_memory_usage);
             }
             listReleaseIterator(it);
         }

--- a/src/server.c
+++ b/src/server.c
@@ -2180,8 +2180,11 @@ clientMemUsageBucket *getMemUsageBucket(size_t mem) {
     int size_in_bits = 8*(int)sizeof(mem);
     int clz = mem > 0 ? __builtin_clzl(mem) : size_in_bits;
     int bucket_idx = size_in_bits - clz;
-    if (bucket_idx >= CLIENT_MEM_USAGE_BUCKETS)
-        bucket_idx = CLIENT_MEM_USAGE_BUCKETS-1;
+    if (bucket_idx > CLIENT_MEM_USAGE_BUCKET_MAX_LOG)
+        bucket_idx = CLIENT_MEM_USAGE_BUCKET_MAX_LOG;
+    else if (bucket_idx < CLIENT_MEM_USAGE_BUCKET_MIN_LOG)
+        bucket_idx = CLIENT_MEM_USAGE_BUCKET_MIN_LOG;
+    bucket_idx -= CLIENT_MEM_USAGE_BUCKET_MIN_LOG;
     return &server.client_mem_usage_buckets[bucket_idx];
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -5453,17 +5453,6 @@ sds genRedisInfoString(const char *section) {
             server.blocked_clients,
             server.tracking_clients,
             (unsigned long long) raxSize(server.clients_timeout_table));
-        for (j = 0; j < CLIENT_MEM_USAGE_BUCKETS; j++) {
-            info = sdscatprintf(info, "clients_mem_bucket%02d: tot-mem: %zu, clients: %lu\r\n", j,
-                                server.client_mem_usage_buckets[j].mem_usage_sum,
-                                server.client_mem_usage_buckets[j].clients->len);
-            listIter *it = listGetIterator(server.client_mem_usage_buckets[j].clients, AL_START_HEAD);
-            for (listNode *ln = listNext(it); ln; ln = listNext(it)) {
-                client *c = (client*)ln->value;
-                info = sdscatprintf(info, "client_mem: %zu\r\n", c->client_last_memory_usage);
-            }
-            listReleaseIterator(it);
-        }
     }
 
     /* Memory */

--- a/src/server.c
+++ b/src/server.c
@@ -2211,6 +2211,8 @@ int updateClientMemUsage(client *c) {
     if (io_threads_op == IO_THREADS_OP_IDLE)
         updateClientMemUsageBucket(c); // do this only when no pending read flag and no write_handler flag - unify?!
 
+    serverLog(LL_WARNING, "Client: %s, mem usage: %zu", c->name ? (char*)c->name->ptr : "", mem);
+
     return 0;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -2207,7 +2207,7 @@ int updateClientMemUsage(client *c) {
     c->last_memory_usage = mem;
     c->last_memory_type = type;
 
-    /* Update client mem usage bucket only when we're no in the context of an IO thread */
+    /* Update client mem usage bucket only when we're not in the context of an IO thread */
     if (io_threads_op == IO_THREADS_OP_IDLE)
         updateClientMemUsageBucket(c); // do this only when no pending read flag and no write_handler flag - unify?!
 

--- a/src/server.c
+++ b/src/server.c
@@ -2189,9 +2189,10 @@ clientMemUsageBucket *getMemUsageBucket(size_t mem) {
 }
 
 /* This is called both on explicit clients when something changed their buffers,
- * so we can track clients' memory and enforce clients maxmemory in real time,
- * and also from the clientsCron so we have updated stats for non
- * CLIENT_TYPE_NORMAL/PUBSUB clients.
+ * so we can track clients' memory and enforce clients' maxmemory in real time,
+ * and also from the clientsCron. We call it from the cron so we have updated
+ * stats for non CLIENT_TYPE_NORMAL/PUBSUB clients and in case a configuration
+ * change requires us to evict a non-active client.
  */
 int updateClientMemUsage(client *c) {
     size_t mem = getClientMemoryUsage(c, NULL);

--- a/src/server.c
+++ b/src/server.c
@@ -4684,6 +4684,10 @@ int processCommand(client *c) {
      * before key eviction, after the last command was executed and consumed
      * some client output buffer memory. */
     evictClients();
+    if (server.current_client == NULL) {
+        /* If we evicted ourself then abort processing the command */
+        return C_ERR;
+    }
 
     /* Handle the maxmemory directive.
      *

--- a/src/server.c
+++ b/src/server.c
@@ -2183,20 +2183,12 @@ clientMemUsageBucket *getMemUsageBucket(size_t mem) {
  * and also from the clietsCron so we have updated stats for non
  * CLIENT_TYPE_NORMAL/PUBSUB clients.
  */
-#define EMA_ALPHA (0.1f)
 int updateClientMemUsage(client *c) {
     size_t mem = getClientMemoryUsage(c);
     int type = getClientType(c);
     int allow_eviction =
             (type == CLIENT_TYPE_NORMAL || type == CLIENT_TYPE_PUBSUB) &&
             !(c->flags & CLIENT_NO_EVICT);
-
-    /* Track last T secs of memory usage */
-    // TODO: consider changing this to a rolling avg (SMA) instead of an exponential moving average (EMA)
-    if (c->client_memory_usage_avg < 0)
-        c->client_memory_usage_avg = mem;
-    else
-        c->client_memory_usage_avg = (EMA_ALPHA * mem) + ((1.0f - EMA_ALPHA) * c->client_memory_usage_avg);
 
     /* Remove the old value of the memory used by the client from the old
      * category, and add it back. */

--- a/src/server.c
+++ b/src/server.c
@@ -2941,7 +2941,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     handleClientsBlockedOnKeys();
 
     /* Disconnect some clients if they are consuming too much memory. */
-    clientsEviction();
+    evictClients();
 
     /* Before we are going to sleep, let the threads access the dataset by
      * releasing the GIL. Redis main thread will not touch anything at this
@@ -4683,7 +4683,7 @@ int processCommand(client *c) {
     /* Disconnect some clients if total clients memory is too high. We do this
      * before key eviction, after the last command was executed and consumed
      * some client output buffer memory. */
-    clientsEviction();
+    evictClients();
 
     /* Handle the maxmemory directive.
      *

--- a/src/server.c
+++ b/src/server.c
@@ -2211,8 +2211,6 @@ int updateClientMemUsage(client *c) {
     if (io_threads_op == IO_THREADS_OP_IDLE)
         updateClientMemUsageBucket(c); // do this only when no pending read flag and no write_handler flag - unify?!
 
-    serverLog(LL_WARNING, "Client: %s, mem usage: %zu", c->name ? (char*)c->name->ptr : "", mem);
-
     return 0;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -984,8 +984,8 @@ typedef struct client {
     blockingState bpop;     /* blocking state */
     long long woff;         /* Last write global replication offset. */
     list *watched_keys;     /* Keys WATCHED for MULTI/EXEC CAS */
-    dict *pubsub_channels;  /* channels a client is interested in (SUBSCRIBE) */
-    list *pubsub_patterns;  /* patterns a client is interested in (SUBSCRIBE) */
+    dict *pubsub_channels;  /* channels a client is interested in (SUBSCRIBE) */ // TODO: add this to memory accounting
+    list *pubsub_patterns;  /* patterns a client is interested in (SUBSCRIBE) */ // TODO: add this to memory accounting
     sds peerid;             /* Cached peer ID. */
     sds sockname;           /* Cached connection target address. */
     listNode *client_list_node; /* list node in client list */
@@ -1006,7 +1006,7 @@ typedef struct client {
     uint64_t client_tracking_redirection;
     rax *client_tracking_prefixes; /* A dictionary of prefixes we are already
                                       subscribed to in BCAST mode, in the
-                                      context of client side caching. */
+                                      context of client side caching. */ // TODO: add this to memory accounting
     /* In updateClientMemUsage() we track the memory usage of
      * each client and add it to the sum of all the clients of a given type,
      * however we need to remember what was the old contribution of each

--- a/src/server.h
+++ b/src/server.h
@@ -1056,8 +1056,8 @@ typedef struct client {
      * however we need to remember what was the old contribution of each
      * client, and in which category the client was, in order to remove it
      * before adding it the new value. */
-    uint64_t client_last_memory_usage;
-    int      client_last_memory_type;
+    size_t client_last_memory_usage;
+    int client_last_memory_type;
 
     listNode *mem_usage_bucket_node;
     clientMemUsageBucket *mem_usage_bucket;
@@ -1422,7 +1422,7 @@ struct redisServer {
     size_t stat_aof_cow_bytes;      /* Copy on write bytes during AOF rewrite. */
     size_t stat_module_cow_bytes;   /* Copy on write bytes during module fork. */
     double stat_module_progress;   /* Module save progress. */
-    uint64_t stat_clients_type_memory[CLIENT_TYPE_COUNT];/* Mem usage by type */
+    size_t stat_clients_type_memory[CLIENT_TYPE_COUNT];/* Mem usage by type */
     long long stat_unexpected_error_replies; /* Number of unexpected (aof-loading, replica to master, etc.) error replies */
     long long stat_total_error_replies; /* Total number of issued error replies ( command + rejected errors ) */
     long long stat_dump_payload_sanitizations; /* Number deep dump payloads integrity validations. */

--- a/src/server.h
+++ b/src/server.h
@@ -988,6 +988,7 @@ typedef struct client {
     sds sockname;           /* Cached connection target address. */
     listNode *client_list_node; /* list node in client list */
     listNode *paused_list_node; /* list node within the pause list */
+    listNode *pending_read_list_node; /* list node in clients pending read list */
     RedisModuleUserChangedFunc auth_callback; /* Module callback to execute
                                                * when the authenticated user
                                                * changes. */

--- a/src/server.h
+++ b/src/server.h
@@ -1576,7 +1576,7 @@ struct redisServer {
     /* Limits */
     unsigned int maxclients;            /* Max number of simultaneous clients */
     unsigned long long maxmemory;   /* Max number of memory bytes to use */
-    size_t maxmemory_clients;       /* Memory limit for total client buffers */
+    ssize_t maxmemory_clients;       /* Memory limit for total client buffers */
     int maxmemory_policy;           /* Policy for key eviction */
     int maxmemory_samples;          /* Precision of random sampling */
     int maxmemory_eviction_tenacity;/* Aggressiveness of eviction processing */

--- a/src/server.h
+++ b/src/server.h
@@ -2095,7 +2095,7 @@ void rewriteClientCommandArgument(client *c, int i, robj *newval);
 void replaceClientCommandVector(client *c, int argc, robj **argv);
 void redactClientCommandArgument(client *c, int argc);
 size_t getClientOutputBufferMemoryUsage(client *c);
-size_t getClientMemoryUsage(client *c);
+size_t getClientMemoryUsage(client *c, size_t *output_buffer_mem_usage);
 int freeClientsInAsyncFreeQueue(void);
 int closeClientOnOutputBufferLimitReached(client *c, int async);
 int getClientType(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -125,13 +125,8 @@ typedef long long ustime_t; /* microsecond time type. */
 #define CONFIG_MIN_RESERVED_FDS 32
 #define CONFIG_DEFAULT_PROC_TITLE_TEMPLATE "{title} {listen-addr} {server-mode}"
 
-/* TODO:
- * We can optimize this by ignoring the first N bits in the memory size, for
- * example if we ignore the first 14 bits then we need 14 less buckets. This
- * means we assume there are no clients with less than 2^14 (16K) memory usage,
- * or at least we group them together with the up to 32K bucket.
- *
- * Even better, we can implement Yuval's 2 layer bucketing with pre-eviction
+/* TODO: Optimization:
+ * We can implement Yuval's 2 layer bucketing with pre-eviction
  * sort algorithm. From slack:
  *
  * I would decide on buckets sizes on M (the overall threashold) and have simple

--- a/src/server.h
+++ b/src/server.h
@@ -170,7 +170,7 @@ typedef long long ustime_t; /* microsecond time type. */
  * in general is based on leftmost bits of ((M/8)<<C)/m
  */
 #define CLIENT_MEM_USAGE_BUCKET_MIN_LOG 15 /* Bucket sizes start at 32KB */
-#define CLIENT_MEM_USAGE_BUCKET_MAX_LOG 33 /* Bucket sizes up to 8GB */
+#define CLIENT_MEM_USAGE_BUCKET_MAX_LOG 33 /* Bucket sizes above 4GB */
 #define CLIENT_MEM_USAGE_BUCKETS (1+CLIENT_MEM_USAGE_BUCKET_MAX_LOG-CLIENT_MEM_USAGE_BUCKET_MIN_LOG)
 
 #define ACTIVE_EXPIRE_CYCLE_SLOW 0

--- a/src/server.h
+++ b/src/server.h
@@ -1003,7 +1003,7 @@ typedef struct client {
     uint64_t client_tracking_redirection;
     rax *client_tracking_prefixes; /* A dictionary of prefixes we are already
                                       subscribed to in BCAST mode, in the
-                                      context of client side caching. */ // TODO: add this to memory accounting
+                                      context of client side caching. */
     /* In updateClientMemUsage() we track the memory usage of
      * each client and add it to the sum of all the clients of a given type,
      * however we need to remember what was the old contribution of each

--- a/src/server.h
+++ b/src/server.h
@@ -350,6 +350,8 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
                                            and AOF client */
 #define CLIENT_REPL_RDBONLY (1ULL<<42) /* This client is a replica that only wants
                                           RDB without replication buffer. */
+#define CLIENT_NO_EVICT (1ULL<<43) /* This client is protected against client
+                                      memory eviction. */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/src/server.h
+++ b/src/server.h
@@ -1001,6 +1001,9 @@ typedef struct client {
      * before adding it the new value. */
     uint64_t client_cron_last_memory_usage;
     int      client_cron_last_memory_type;
+
+    //uint32_t client_cron_memory_usage_avg_samples;
+    float client_cron_memory_usage_avg;
     /* Response buffer */
     int bufpos;
     size_t buf_usable_size; /* Usable size of buffer. */
@@ -2032,7 +2035,9 @@ void rewriteClientCommandVector(client *c, int argc, ...);
 void rewriteClientCommandArgument(client *c, int i, robj *newval);
 void replaceClientCommandVector(client *c, int argc, robj **argv);
 void redactClientCommandArgument(client *c, int argc);
-unsigned long getClientOutputBufferMemoryUsage(client *c);
+size_t getClientOutputBufferMemoryUsage(client *c);
+size_t getClientMemoryUsage(client *c);
+size_t getClientAverageMemory(client *c);
 int freeClientsInAsyncFreeQueue(void);
 int closeClientOnOutputBufferLimitReached(client *c, int async);
 int getClientType(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -994,7 +994,7 @@ typedef struct client {
     rax *client_tracking_prefixes; /* A dictionary of prefixes we are already
                                       subscribed to in BCAST mode, in the
                                       context of client side caching. */
-    /* In clientsCronTrackClientsMemUsage() we track the memory usage of
+    /* In updateClientMemUsage() we track the memory usage of
      * each client and add it to the sum of all the clients of a given type,
      * however we need to remember what was the old contribution of each
      * client, and in which category the client was, in order to remove it
@@ -1289,7 +1289,7 @@ struct redisServer {
     list *clients_pending_read;  /* Client has pending read socket buffers. */
     list *slaves, *monitors;    /* List of slaves and MONITORs */
     client *current_client;     /* Current client executing the command. */
-    rax *client_eviction_pull;  /* Radix tree holding the top memory hoggers. */
+    rax *client_eviction_pool;  /* Radix tree holding the top memory hoggers. */
     size_t client_eviction_pull_max;
     size_t client_eviction_pull_min;
     rax *clients_timeout_table; /* Radix tree for blocked clients timeouts. */

--- a/src/server.h
+++ b/src/server.h
@@ -1062,7 +1062,6 @@ typedef struct client {
     listNode *mem_usage_bucket_node;
     clientMemUsageBucket *mem_usage_bucket;
 
-    float client_memory_usage_avg;
     /* Response buffer */
     int bufpos;
     size_t buf_usable_size; /* Usable size of buffer. */
@@ -2097,7 +2096,6 @@ void replaceClientCommandVector(client *c, int argc, robj **argv);
 void redactClientCommandArgument(client *c, int argc);
 size_t getClientOutputBufferMemoryUsage(client *c);
 size_t getClientMemoryUsage(client *c);
-size_t getClientAverageMemory(client *c);
 int freeClientsInAsyncFreeQueue(void);
 int closeClientOnOutputBufferLimitReached(client *c, int async);
 int getClientType(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -281,6 +281,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_LUA_DEBUG_SYNC (1<<26)  /* EVAL debugging without fork() */
 #define CLIENT_MODULE (1<<27) /* Non connected client used by some module. */
 #define CLIENT_PROTECTED (1<<28) /* Client should not be freed for now. */
+/* #define CLIENT_... (1<<29) currently unused, feel free to use in the future */
 #define CLIENT_PENDING_COMMAND (1<<30) /* Indicates the client has a fully
                                         * parsed command ready for execution. */
 #define CLIENT_TRACKING (1ULL<<31) /* Client enabled keys tracking in order to

--- a/src/server.h
+++ b/src/server.h
@@ -2065,7 +2065,7 @@ int getClientTypeByName(char *name);
 char *getClientTypeName(int class);
 void flushSlavesOutputBuffers(void);
 void disconnectSlaves(void);
-void evictClients();
+void evictClients(void);
 int listenToPort(int port, socketFds *fds);
 void pauseClients(mstime_t duration, pause_type type);
 void unpauseClients(void);

--- a/src/server.h
+++ b/src/server.h
@@ -2062,7 +2062,7 @@ int getClientTypeByName(char *name);
 char *getClientTypeName(int class);
 void flushSlavesOutputBuffers(void);
 void disconnectSlaves(void);
-void clientsEviction();
+void evictClients();
 int listenToPort(int port, socketFds *fds);
 void pauseClients(mstime_t duration, pause_type type);
 void unpauseClients(void);

--- a/src/server.h
+++ b/src/server.h
@@ -805,6 +805,7 @@ typedef struct multiState {
     int cmd_inv_flags;      /* Same as cmd_flags, OR-ing the ~flags. so that it
                                is possible to know if all the commands have a
                                certain flag. */
+    size_t argv_mem_sum;    /* mem used by all commands arguments */
 } multiState;
 
 /* This structure holds the blocking operation state for a client.
@@ -2132,6 +2133,7 @@ void unwatchAllKeys(client *c);
 void initClientMultiState(client *c);
 void freeClientMultiState(client *c);
 void queueMultiCommand(client *c);
+size_t multiStateMemOverhead(client *c);
 void touchWatchedKey(redisDb *db, robj *key);
 int isWatchedKeyExpired(client *c);
 void touchAllWatchedKeysInDb(redisDb *emptied, redisDb *replaced_with);

--- a/src/server.h
+++ b/src/server.h
@@ -1054,13 +1054,13 @@ typedef struct client {
      * however we need to remember what was the old contribution of each
      * client, and in which category the client was, in order to remove it
      * before adding it the new value. */
-    uint64_t client_cron_last_memory_usage;
-    int      client_cron_last_memory_type;
+    uint64_t client_last_memory_usage;
+    int      client_last_memory_type;
 
     listNode *mem_usage_bucket_node;
     clientMemUsageBucket *mem_usage_bucket;
 
-    float client_cron_memory_usage_avg;
+    float client_memory_usage_avg;
     /* Response buffer */
     int bufpos;
     size_t buf_usable_size; /* Usable size of buffer. */

--- a/src/server.h
+++ b/src/server.h
@@ -1375,7 +1375,7 @@ struct redisServer {
     size_t stat_aof_cow_bytes;      /* Copy on write bytes during AOF rewrite. */
     size_t stat_module_cow_bytes;   /* Copy on write bytes during module fork. */
     double stat_module_progress;   /* Module save progress. */
-    size_t stat_clients_type_memory[CLIENT_TYPE_COUNT];/* Mem usage by type */
+    redisAtomic size_t stat_clients_type_memory[CLIENT_TYPE_COUNT];/* Mem usage by type */
     long long stat_unexpected_error_replies; /* Number of unexpected (aof-loading, replica to master, etc.) error replies */
     long long stat_total_error_replies; /* Total number of issued error replies ( command + rejected errors ) */
     long long stat_dump_payload_sanitizations; /* Number deep dump payloads integrity validations. */

--- a/src/server.h
+++ b/src/server.h
@@ -982,8 +982,8 @@ typedef struct client {
     blockingState bpop;     /* blocking state */
     long long woff;         /* Last write global replication offset. */
     list *watched_keys;     /* Keys WATCHED for MULTI/EXEC CAS */
-    dict *pubsub_channels;  /* channels a client is interested in (SUBSCRIBE) */ // TODO: add this to memory accounting
-    list *pubsub_patterns;  /* patterns a client is interested in (SUBSCRIBE) */ // TODO: add this to memory accounting
+    dict *pubsub_channels;  /* channels a client is interested in (SUBSCRIBE) */
+    list *pubsub_patterns;  /* patterns a client is interested in (SUBSCRIBE) */
     sds peerid;             /* Cached peer ID. */
     sds sockname;           /* Cached connection target address. */
     listNode *client_list_node; /* list node in client list */

--- a/src/server.h
+++ b/src/server.h
@@ -1553,6 +1553,7 @@ struct redisServer {
     /* Limits */
     unsigned int maxclients;            /* Max number of simultaneous clients */
     unsigned long long maxmemory;   /* Max number of memory bytes to use */
+    size_t maxmemory_clients;       /* Memory limit for total client buffers */
     int maxmemory_policy;           /* Policy for key eviction */
     int maxmemory_samples;          /* Precision of random sampling */
     int maxmemory_eviction_tenacity;/* Aggressiveness of eviction processing */
@@ -2034,6 +2035,7 @@ int getClientTypeByName(char *name);
 char *getClientTypeName(int class);
 void flushSlavesOutputBuffers(void);
 void disconnectSlaves(void);
+void clientsEviction();
 int listenToPort(int port, socketFds *fds);
 void pauseClients(mstime_t duration, pause_type type);
 void unpauseClients(void);
@@ -2048,6 +2050,7 @@ int handleClientsWithPendingWritesUsingThreads(void);
 int handleClientsWithPendingReadsUsingThreads(void);
 int stopThreadedIOIfNeeded(void);
 int clientHasPendingReplies(client *c);
+int updateClientMemUsage(client *c);
 void unlinkClient(client *c);
 int writeToClient(client *c, int handler_installed);
 void linkClient(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -1993,6 +1993,7 @@ void redisSetCpuAffinity(const char *cpulist);
 client *createClient(connection *conn);
 void freeClient(client *c);
 void freeClientAsync(client *c);
+int beforeNextClient(client *c);
 void resetClient(client *c);
 void freeClientOriginalArgv(client *c);
 void sendReplyToClient(connection *conn);

--- a/src/server.h
+++ b/src/server.h
@@ -174,7 +174,9 @@ typedef long long ustime_t; /* microsecond time type. */
  * always afraid to do something wrong with the bits ops.
  * in general is based on leftmost bits of ((M/8)<<C)/m
  */
-#define CLIENT_MEM_USAGE_BUCKETS 30 /* Bucket sizes up to 1GB */
+#define CLIENT_MEM_USAGE_BUCKET_MIN_LOG 15 /* Bucket sizes start at 32KB */
+#define CLIENT_MEM_USAGE_BUCKET_MAX_LOG 33 /* Bucket sizes up to 8GB */
+#define CLIENT_MEM_USAGE_BUCKETS (1+CLIENT_MEM_USAGE_BUCKET_MAX_LOG-CLIENT_MEM_USAGE_BUCKET_MIN_LOG)
 
 #define ACTIVE_EXPIRE_CYCLE_SLOW 0
 #define ACTIVE_EXPIRE_CYCLE_FAST 1

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -305,6 +305,7 @@ void sendTrackingMessage(client *c, char *keyname, size_t keylen, int proto) {
         addReplyArrayLen(c,1);
         addReplyBulkCBuffer(c,keyname,keylen);
     }
+    updateClientMemUsage(c);
 }
 
 /* This function is called when a key is modified in Redis and in the case

--- a/src/util.c
+++ b/src/util.c
@@ -204,7 +204,10 @@ unsigned long long memtoull(const char *p, int *err) {
 
     /* Search the first non digit character. */
     u = p;
-    if (*u == '-') u++;
+    if (*u == '-') {
+        if (err) *err = 1;
+        return 0;
+    }
     while(*u && isdigit(*u)) u++;
     if (*u == '\0' || !strcasecmp(u,"b")) {
         mul = 1;

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -13,7 +13,7 @@ proc randstring {min max {type binary}} {
     }
     while {$len} {
         set rr [format "%c" [expr {$minval+int(rand()*($maxval-$minval+1))}]]
-        if {![string is alnum $rr]} {continue}
+        if {$type eq {alpha} && ![string is alnum $rr]} {continue}
         append output $rr
         incr len -1
     }

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -4,7 +4,7 @@ proc randstring {min max {type binary}} {
     if {$type eq {binary}} {
         set minval 0
         set maxval 255
-    } elseif {$type eq {alpha}} {
+    } elseif {$type eq {alpha} || $type eq {simplealpha}} {
         set minval 48
         set maxval 122
     } elseif {$type eq {compr}} {
@@ -13,7 +13,8 @@ proc randstring {min max {type binary}} {
     }
     while {$len} {
         set rr [format "%c" [expr {$minval+int(rand()*($maxval-$minval+1))}]]
-        if {$type eq {alpha} && ![string is alnum $rr]} {continue}
+        if {$type eq {simplealpha} && ![string is alnum $rr]} {continue}
+        if {$type eq {alpha} && $rr eq 92} {continue} ;# avoid putting '\' char in the string, it can mess up TCL processing
         append output $rr
         incr len -1
     }

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -12,11 +12,9 @@ proc randstring {min max {type binary}} {
         set maxval 52
     }
     while {$len} {
-        set rr [expr {$minval+int(rand()*($maxval-$minval+1))}]
-        if {$type eq {alpha} && $rr eq 92} {
-            set rr 90; # avoid putting '\' char in the string, it can mess up TCL processing
-        }
-        append output [format "%c" $rr]
+        set rr [format "%c" [expr {$minval+int(rand()*($maxval-$minval+1))}]]
+        if {![string is alnum $rr]} {continue}
+        append output $rr
         incr len -1
     }
     return $output

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -82,6 +82,7 @@ set ::all_tests {
     unit/oom-score-adj
     unit/shutdown
     unit/networking
+    unit/client-eviction
 }
 # Index to the next test to run in the ::all_tests list.
 set ::next_test 0

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -1,0 +1,93 @@
+proc client_field {name f} {
+    set clients [split [r client list] "\r\n"]
+    set c [lsearch -inline $clients *name=$name*]
+    if {![regexp $f=(\[a-zA-Z0-9-\]+) $c - res]} {
+        throw no-client "no client named $name found"
+    }
+    return $res
+}
+
+start_server {} {
+    set maxmemory_clients 3000000
+    r config set maxmemory-clients $maxmemory_clients
+    
+    test "client evicted due to query buf" {
+        r flushdb
+        set rr [redis_client]
+        # Attempt a large multi-bulk command under eviction limit
+        $rr mset k v k2 [string repeat v 1000000]
+        assert_equal [$rr get k] v
+        # Attempt another command, now causing client eviction
+        catch { $rr mset k v k2 [string repeat v $maxmemory_clients] } e
+        assert_match {*connection reset by peer*} $e
+    }
+
+    test "client evicted due to output buf" {
+        r flushdb
+        r setrange k 200000 v
+        set rr [redis_deferring_client]
+        $rr client setname test_client
+        $rr flush
+        assert {[$rr read] == "OK"}
+        # Attempt a large response under eviction limit
+        $rr get k
+        $rr flush
+        assert {[string length [$rr read]] == 200001}
+        set mem [client_field test_client tot-mem]
+        assert {$mem < $maxmemory_clients}
+
+        # Fill output buff in loop without reading it and make sure 
+        # we're eventually disconnected, but before reaching maxmemory_clients
+        while true {
+            if { [catch {
+                set mem [client_field test_client tot-mem]
+                assert {$mem < $maxmemory_clients}
+                $rr get k
+                $rr flush
+               } e]} {
+                assert_match {no client named test_client found} $e
+                break
+            }
+        }
+    }
+}
+
+start_server {} {
+    set maxmemory_clients 20000000
+    set obuf_limit 6000000
+    r config set maxmemory-clients $maxmemory_clients
+    r config set client-output-buffer-limit "normal $obuf_limit 0 0"
+
+    test "avoid client eviction when client is freed by output buffer limit" {
+        r flushdb
+        r setrange k 200000 v
+        # Occupy client's query buff with half of maxmemory_clients
+        set rr1 [redis_client]
+        $rr1 client setname "qbuf-client"
+        set rr2 [redis_deferring_client]
+        set qbsize [expr {$maxmemory_clients - 5000000 }]
+        $rr1 write [join [list "*1\r\n\$$qbsize\r\n" [string repeat v $qbsize]] ""]
+        #$rr1 write [string repeat v [expr {100000 }]]
+        $rr1 flush
+        # Wait for qbuff to be as expected
+        wait_for_condition 200 10 {
+            [client_field qbuf-client qbuf] == $qbsize
+        } else {
+            fail "Failed to fill qbuf for test"
+        }
+        
+        # Now we know that ~15mb is being used by rr1, fill rr2's obuf until obuf limit, hopefully we won't trigger rr1 to disconnect
+        while true {
+            if { [catch {
+                $rr2 get k
+                $rr2 flush
+               } e]} {
+                assert_match {I/O error reading reply} $e
+                break
+            }
+        }
+        
+        # Validate rr1 is still connected
+        assert_match [client_field qbuf-client name] {qbuf-client}
+    }
+}

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -61,6 +61,7 @@ start_server {} {
     set maxmemory_clients [mb 10]
     set obuf_limit [mb 3]
     r config set maxmemory-clients $maxmemory_clients
+    r config set client-output-buffer-limit "normal $obuf_limit 0 0"
 
     test "avoid client eviction when client is freed by output buffer limit" {
         r flushdb
@@ -98,9 +99,9 @@ start_server {} {
         exec kill -SIGCONT $server_pid
         
         # Validate obuf-clients were disconnected (because of obuf limit)
-        catch {[client_field obuf-client1 name]} e
+        catch {client_field obuf-client1 name} e
         assert_match $e {no client named obuf-client1 found}
-        catch {[client_field obuf-client2 name]} e
+        catch {client_field obuf-client2 name} e
         assert_match $e {no client named obuf-client2 found}
         
         # Validate qbuf-client is still connected and wasn't evicted

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -1,5 +1,8 @@
 tags {"external:skip"} {
 
+# Get info about a redis client connection:
+# name - name of client we want to query
+# f - field name from "CLIENT LIST" we want to get
 proc client_field {name f} {
     set clients [split [string trim [r client list]] "\r\n"]
     set c [lsearch -inline $clients *name=$name*]
@@ -9,6 +12,8 @@ proc client_field {name f} {
     return $res
 }
 
+# Sum a value across all redis client connections:
+# f - the field name from "CLIENT LIST" we want to sum
 proc clients_sum {f} {
     set sum 0
     set clients [split [string trim [r client list]] "\r\n"]

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -1,3 +1,5 @@
+tags {"external:skip"} {
+
 proc client_field {name f} {
     set clients [split [string trim [r client list]] "\r\n"]
     set c [lsearch -inline $clients *name=$name*]
@@ -254,7 +256,7 @@ start_server {} {
     }
 }
 
-start_server {tags {"external:skip"}} {
+start_server {} {
     test "evict clients only until below limit" {
         set client_count 10
         set client_mem [mb 1]
@@ -300,7 +302,7 @@ start_server {tags {"external:skip"}} {
     }
 }
 
-start_server {tags {"external:skip"}} {
+start_server {} {
     test "evict clients in right order (large to small)" {
         # Note that each size step needs to be at least x2 larger than previous step 
         # because of how the client-eviction size bucktting works
@@ -357,5 +359,7 @@ start_server {tags {"external:skip"}} {
             }
         }
     }
+}
+
 }
 

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -109,7 +109,7 @@ start_server {} {
                 $rr get k
                 $rr flush
                } e]} {
-                assert_match {no client named test_client found} $e
+                assert_match {no client named test_client found*} $e
                 break
             }
         }
@@ -192,9 +192,9 @@ start_server {} {
         
         # Validate obuf-clients were disconnected (because of obuf limit)
         catch {client_field obuf-client1 name} e
-        assert_match $e {no client named obuf-client1 found}
+        assert_match {no client named obuf-client1 found*} $e
         catch {client_field obuf-client2 name} e
-        assert_match $e {no client named obuf-client2 found}
+        assert_match {no client named obuf-client2 found*} $e
         
         # Validate qbuf-client is still connected and wasn't evicted
         assert_match [client_field qbuf-client name] {qbuf-client}

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -120,6 +120,43 @@ start_server {} {
         r config set maxmemory-clients $maxmemory_clients
     }
     
+    test "client evicted due to tracking redirection" {
+        r flushdb
+        # Use slow hz to avoid clientsCron from updating memory usage frequently since 
+        # we're testing the update logic when writing tracking redirection output
+        set backup_hz [lindex [r config get hz] 1]
+        r config set hz 1
+
+        set rr [redis_client]
+        set redirected_c [redis_client] 
+        $redirected_c client setname redirected_client
+        set redir_id [$redirected_c client id]
+        $redirected_c SUBSCRIBE __redis__:invalidate
+        $rr client tracking on redirect $redir_id bcast
+        # Use a big key name to fill the redirected tracking client's buffer quickly
+        set key_length [expr 1024*10]
+        set long_key [string repeat k $key_length]
+        # Use a script so we won't need to pass the long key name when dirtying it in the loop
+        set script_sha [$rr script load "redis.call('incr', '$long_key')"]
+        # Read and write to same (long) key until redirected_client's buffers cause it to be evicted
+        set t [clock milliseconds]
+        catch {
+            while true {
+                set mem [client_field redirected_client tot-mem]
+                assert {$mem < $maxmemory_clients}
+                $rr evalsha $script_sha 0
+            }
+        } e
+        assert_match {no client named redirected_client found*} $e
+        
+        # Make sure eviction happened in less than 1sec, this means, statistically eviction
+        # wasn't caused by clientCron accounting
+        set t [expr [clock milliseconds] - $t]
+        assert {$t < 1000}
+
+        r config set hz $backup_hz
+    }
+
     test "client evicted due to client tracking prefixes" {
         r flushdb
         set rr [redis_client]

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -218,6 +218,7 @@ start_server {} {
 
         r config set hz $backup_hz
         $rr close
+        $redirected_c close
     }
 
     test "client evicted due to client tracking prefixes" {

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -66,7 +66,7 @@ start_server {} {
         r config set maxmemory $maxmemory
         # Set client eviction threshold to 7% of maxmemory        
         set maxmemory_clients_p 7
-        r config set maxmemory-clients -$maxmemory_clients_p
+        r config set maxmemory-clients $maxmemory_clients_p%
         r flushdb
         
         set maxmemory_clients_actual [expr $maxmemory * $maxmemory_clients_p / 100]

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -254,7 +254,7 @@ start_server {} {
     }
 }
 
-start_server {} {
+start_server {tags {"external:skip"}} {
     test "evict clients only until below limit" {
         set client_count 10
         set client_mem [mb 1]
@@ -300,7 +300,7 @@ start_server {} {
     }
 }
 
-start_server {} {
+start_server {tags {"external:skip"}} {
     test "evict clients in right order (large to small)" {
         # Note that each size step needs to be at least x2 larger than previous step 
         # because of how the client-eviction size bucktting works
@@ -308,6 +308,7 @@ start_server {} {
         set clients_per_size 3
         r client setname control
         r client no-evict on
+        r config set maxmemory-clients 0
         
         # Run over all sizes and create some clients using up that size
         set total_client_mem 0

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -21,7 +21,7 @@ proc client_exists {name} {
 
 proc gen_client {} {
     set rr [redis_client]
-    set name "tst_[randstring 4 4 alpha]"
+    set name "tst_[randstring 4 4 simplealpha]"
     $rr client setname $name
     assert {[client_exists $name]}
     return [list $rr $name]

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -27,7 +27,7 @@ proc clients_sum {f} {
 }
 
 proc write_err_exception {e} {
-    return [regexp {(.*connection reset by peer.*|.*broken pipe.*)} $e]
+    return [regexp {(.*connection reset by peer.*|.*broken pipe.*|error writing .*: protocol wrong type for socket)} $e]
 }
 
 proc mb {v} {

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -7,7 +7,7 @@ proc client_field {name f} {
     set clients [split [string trim [r client list]] "\r\n"]
     set c [lsearch -inline $clients *name=$name*]
     if {![regexp $f=(\[a-zA-Z0-9-\]+) $c - res]} {
-        throw no-client "no client named $name found with field $f"
+        error "no client named $name found with field $f"
     }
     return $res
 }
@@ -19,7 +19,7 @@ proc clients_sum {f} {
     set clients [split [string trim [r client list]] "\r\n"]
     foreach c $clients {
         if {![regexp $f=(\[a-zA-Z0-9-\]+) $c - res]} {
-            throw no-field "field $f not found in $c"
+            error "field $f not found in $c"
         }
         incr sum $res
     }

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -123,7 +123,7 @@ start_server {tags {"maxmemory"}} {
                 $rr flush
             }
 
-            for {set j 0} {$j < 35} {incr j} {
+            for {set j 0} {$j < 40} {incr j} {
                 catch {r publish bla [string repeat x 100000]} err
             }
 

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -22,7 +22,7 @@ start_server {tags {"maxmemory"}} {
         for {set j 0} {$j < 50} {incr j} {
             r setrange $j 100000 x
         }
-        assert {[r dbsize] == 50}
+        assert_equal [r dbsize] 50
     }
     
     proc verify_test {client_eviction} {
@@ -30,10 +30,21 @@ start_server {tags {"maxmemory"}} {
         set evicted_clients [s evicted_clients]
         set dbsize [r dbsize]
         
+        if $::verbose {
+            puts "evicted keys: $evicted_keys"
+            puts "evicted clients: $evicted_clients"
+            puts "dbsize: $dbsize"
+        }
+        
         if $client_eviction {
-            assert {$evicted_clients > 0 && $evicted_keys == 0 && $dbsize == 50}
+            assert_morethan $evicted_clients 0
+            assert_equal $evicted_keys 0
+            assert_equal $dbsize 50
         } else {
             assert {$evicted_clients == 0 && $evicted_keys > 0 && $dbsize < 50}
+            assert_equal $evicted_clients 0
+            assert_morethan $evicted_keys 0
+            assert_lessthan $dbsize 50
         }
     }
 
@@ -92,7 +103,6 @@ start_server {tags {"maxmemory"}} {
                         $rr flush
                     }
                 }]} {
-                    puts "removing...."
                     lremove clients $rr
                 }
             }

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -12,10 +12,6 @@ start_server {tags {"maxmemory"}} {
         } else {
             r config set maxmemory-clients 0
         }
-        # If maxmemory-clients changed we need to wait for clients cron to update all the clients accordingly
-        if {$prev_maxmemory_clients != [r config get maxmemory-clients]} {
-            after 1500
-        }
 
         r config resetstat
         # fill 5mb using 50 keys of 100kb
@@ -35,7 +31,7 @@ start_server {tags {"maxmemory"}} {
             puts "evicted clients: $evicted_clients"
             puts "dbsize: $dbsize"
         }
-        
+
         if $client_eviction {
             assert_morethan $evicted_clients 0
             assert_equal $evicted_keys 0

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -91,8 +91,8 @@ start_server {tags {"maxmemory"}} {
 
             foreach rr $clients {
                 if {[catch {
-                    $rr write "*200\r\n"
-                    for {set j 0} {$j < 199} {incr j} {
+                    $rr write "*250\r\n"
+                    for {set j 0} {$j < 249} {incr j} {
                         $rr write "\$1000\r\n"
                         $rr write [string repeat x 1000]
                         $rr write "\r\n"

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -30,7 +30,6 @@ start_server {tags {"maxmemory"}} {
         set evicted_clients [s evicted_clients]
         set dbsize [r dbsize]
         
-        puts "evicted clients: $evicted_clients, evicted keys: $evicted_keys, dbsize: $dbsize"
         if $client_eviction {
             assert {$evicted_clients > 0 && $evicted_keys == 0 && $dbsize == 50}
         } else {
@@ -98,7 +97,7 @@ start_server {tags {"maxmemory"}} {
                 }
             }
 
-            verify_test $client_evictionco
+            verify_test $client_eviction
         }
         foreach rr $clients {
             $rr close

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -11,6 +11,8 @@ start_server {tags {"maxmemory"}} {
         }
     }
 
+    r config set maxmemory-clients 3mb
+
     set clients {}
     test "eviction due to output buffers of many MGET clients" {
         refill

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -11,6 +11,7 @@ start_server {tags {"maxmemory"}} {
         }
     }
 
+    # TODO: we might want to change the tests so we run them first with no maxmemory-cliets and verify we get key eviction, and then re-run them and see clients disconnect and there's no eviction
     r config set maxmemory-clients 3mb
 
     set clients {}
@@ -79,7 +80,7 @@ start_server {tags {"maxmemory"}} {
     set clients {}
     test "eviction due to output buffers of pubsub" {
         refill
-        for {set j 0} {$j < 30} {incr j} {
+        for {set j 0} {$j < 10} {incr j} {
             set rr [redis_deferring_client]
             lappend clients $rr
         }
@@ -88,7 +89,7 @@ start_server {tags {"maxmemory"}} {
             $rr subscribe bla
         }
 
-        for {set j 0} {$j < 50} {incr j} {
+        for {set j 0} {$j < 35} {incr j} {
             catch {r publish bla [string repeat x 100000]} err
         }
 

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -54,7 +54,7 @@ start_server {tags {"maxmemory"}} {
                 lappend clients $rr
             }
 
-            # Freez the server so output buffers will be filled in one event loop when we un-freez after sending mgets
+            # Freeze the server so output buffers will be filled in one event loop when we un-freeze after sending mgets
             exec kill -SIGSTOP $server_pid
             for {set j 0} {$j < 5} {incr j} {
                 foreach rr $clients {
@@ -62,7 +62,7 @@ start_server {tags {"maxmemory"}} {
                     $rr flush
                 }
             }
-            # Unfreez server
+            # Unfreeze server
             exec kill -SIGCONT $server_pid
             
 

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -1,5 +1,5 @@
 start_server {tags {"maxmemory" "external:skip"}} {
-    r config set maxmemory 10mb
+    r config set maxmemory 11mb
     r config set maxmemory-policy allkeys-lru
     set server_pid [s process_id]
 

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -1,4 +1,4 @@
-start_server {tags {"maxmemory"}} {
+start_server {tags {"maxmemory" "external:skip"}} {
     r config set maxmemory 10mb
     r config set maxmemory-policy allkeys-lru
     set server_pid [s process_id]

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -37,7 +37,6 @@ start_server {tags {"maxmemory" "external:skip"}} {
             assert_equal $evicted_keys 0
             assert_equal $dbsize 50
         } else {
-            assert {$evicted_clients == 0 && $evicted_keys > 0 && $dbsize < 50}
             assert_equal $evicted_clients 0
             assert_morethan $evicted_keys 0
             assert_lessthan $dbsize 50


### PR DESCRIPTION
### Description
A mechanism for disconnecting clients when the sum of all connected clients is above a configured limit. This prevents eviction or OOM caused by accumulated used memory between all clients. It's a complimentary mechanism to the `client-output-buffer-limit` mechanism which takes into account not only a single client and not only output buffers but rather all memory used by all clients.

#### Design
The general design is as following:
* We track memory usage of each client, taking into account all memory used by the client (query buffer, output buffer, parsed arguments, etc...). This is kept up to date after reading from the socket, after processing commands and after writing to the socket.
* Based on the used memory we sort all clients into buckets. Each bucket contains all clients using up up to x2 memory of the clients in the bucket below it. For example up to 1m clients, up to 2m clients, up to 4m clients, ...
* Before processing a command and before sleep we check if we're over the configured limit. If we are we start disconnecting clients from larger buckets downwards until we're under the limit.

#### Config
`maxmemory-clients` max memory all clients are allowed to consume, above this threshold we disconnect clients.
This config can either be set to 0 (meaning no limit), a size in bytes (possibly with MB/GB suffix),
or as a percentage of `maxmemory` by using the `%` suffix (e.g. setting it to `10%` would mean 10% of `maxmemory`).

#### Important code changes
* During the development I encountered yet more situations where our io-threads access global vars. And needed to fix them. I also had to handle keeps the clients sorted into the memory buckets (which are global) while their memory usage changes in the io-thread. To achieve this I decided to simplify how we check if we're in an io-thread and make it much more explicit. I removed the `CLIENT_PENDING_READ` flag used for checking if the client is in an io-thread (it wasn't used for anything else) and just used the global `io_threads_op` variable the same way to check during writes.
* I optimized the cleanup of the client from the `clients_pending_read` list on client freeing. We now store a pointer in the `client` struct to this list so we don't need to search in it (`pending_read_list_node`).
* Added `evicted_clients` stat to `INFO` command.
* Added `CLIENT NO-EVICT ON|OFF` sub command to exclude a specific client from the client eviction mechanism. Added corrosponding 'e' flag in the client info string.
* Added `multi-mem` field in the client info string to show how much memory is used up by buffered multi commands.
* Client `tot-mem` now accounts for buffered multi-commands, pubsub patterns and channels (partially), tracking prefixes (partially).
* CLIENT_CLOSE_ASAP flag is now handled in a new `beforeNextClient()` function so clients will be disconnected between processing different clients and not only before sleep. This new function can be used in the future for work we want to do outside the command processing loop but don't want to wait for all clients to be processed before we get to it. Specifically I wanted to handle output-buffer-limit related closing before we process client eviction in case the two race with each other.
* Added a `DEBUG CLIENT-EVICTION` command to print out info about the client eviction buckets.
* Each client now holds a pointer to the client eviction memory usage bucket it belongs to and listNode to itself in that bucket for quick removal.
* Global `io_threads_op` variable now can contain a `IO_THREADS_OP_IDLE` value indicating no io-threading is currently being executed.
* In order to track memory used by each clients in real-time we can't rely on updating these stats in `clientsCron()` alone anymore. So now I call `updateClientMemUsage()` (used to be `clientsCronTrackClientsMemUsage()`) after command processing, after writing data to pubsub clients, after writing the output buffer and after reading from the socket (and maybe other places too). The function is written to be fast.
* Clients are evicted if needed (with appropriate log line) in `beforeSleep()` and before processing a command (before performing oom-checks and key-eviction).
* All clients memory usage buckets are grouped as follows:
  * All clients using less than 64k.
  * 64K..128K
  * 128K..256K
  * ...
  * 2G..4G
  * All clients using 4g and up.
* Added client-eviction.tcl with a bunch of tests for the new mechanism.
* Extended maxmemory.tcl to test the interaction between maxmemory and maxmemory-clients settings.
* Added an option to flag a numeric configuration variable as a "percent", this means that if we encounter a '%' after the number in the config file (or config set command) we consider it as valid. Such a number is store internally as a negative value. This way an integer value can be interpreted as either a percent (negative) or absolute value (positive). This is useful for example if some numeric configuration can optionally be set to a percentage of something else.

----------------------
Origianl PR description:

See #7676

### Description
We track how much memory each client uses. The value is updated after each `processInputBuffer` and after writing to the socket. When the sum of all clients exceeds configuration we disconnect the fat clients. This is checked after each command.

This is more or less done given the current state of my discussions with @oranagra.
We need a larger forum to review this solution and decide if it's good enough. 
### Important/Open issues:
1. @oranagra and I thought it **won't** be right to evict clients based on some rolling avg of memory usage, rather to look at the current state. This is because we evict clients until we're back under some threshold and looking at **past** memory usage while aiming to go below some **current** memory usage might cause unexpected results. Originally we thought some past avg will be needed to avoid disconnecting a bursting client which uses up a lot of memory for a short time, but in reality such a client might eventually also be disconnected and it might not be what we want if not disconnecting it will cause all other clients to disconnect as well. There's no one right solution here, but I think adding a past based rolling avg just complicates things and makes them less predictable and tougher to tune for the user.
2. How does this relate to the already existing single client COB threshold. Do we still need it? Or is it redundant and should be deprecated. From the user's point of view it's easier to simply define a threshold for `maxmemory-clients` which is also enforced on the individual client level (and also includes the query buffer size) and there might be no real reason to configure the `client-output-buffer-limit`. Also need to consider how this relates to replication client limits, currently `maxmemory-clients` ignores these clients.
3. Soft vs hard thresholds: the old `client-output-buffer-limit` had a timer based soft threshold. What is it really good for? Isn't this just over complicating things? If not perhaps we want something like this for `maxmemory-clients` as well? I have a feeling this is an overkill and can probably be deprecated.
4. One difference between the `client-output-buffer-limit` implementation and this is that here we check and evict clients only before processing a command and before sleep but not during the command processing. We might want to change this and add the code checking the limit and evicting clients inside `_addReplyProtoToList` where `asyncCloseClientOnOutputBufferLimitReached` is called. I think this won't affect performance that much. If we're thinking this is the future replacement for `client-output-buffer-limit` then we need to do this.
5. Should client no-evict flag also guard against client-output-buffer-limit protection?

TODO:
- [x] remove client loop in info command: https://github.com/redis/redis/pull/8687#discussion_r619832078
- [x] remove big todo comment in server.h: https://github.com/redis/redis/pull/8687#discussion_r619833195
- [x] Account `MULTI` command buffer size as clients used memory.
- [x] There's the issue of accounting watched keys: they are kind of per-client but not really because in reality there's a list of clients per watched key. How do we handle this? Do we add **another** mechanism for limiting memory used by watched keys?

### Tests to be added:
- [x] Decrease maxmemory-clients in runtime causes client eviction.
- [x] Only the required number of clients are evicted to achieve maxmemory-clients
- [x] First larger clients are evicted and then smaller ones.
- [x] Client eviction works on both large query, large args and large output buffers, and large multi buffers and watched keys list.
