### PR TITLE
Remove cron saving during BGSAVE test.

### DIFF
--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -1,4 +1,4 @@
-start_server {tags {"other"}} {
+start_server {overrides {save ""} tags {"other"}} {
     if {$::force_failure} {
         # This is used just for test suite development purposes.
         test {Failing test} {


### PR DESCRIPTION
This fixes a race where a bgsave can start during the test after we verified no bgsave is running.
Is this what happened here: https://github.com/redis/redis/runs/2144641244?check_suite_focus=true?