### PR TITLE
Introduce fast path to bypass expensive serveClientsBlockedOnKeyByModule call

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -577,8 +577,12 @@ void handleClientsBlockedOnKeys(void) {
                     serveClientsBlockedOnStreamKey(o,rl);
                 /* We want to serve clients blocked on module keys
                  * regardless of the object type: we don't know what the
-                 * module is trying to accomplish right now. */
-                serveClientsBlockedOnKeyByModule(rl);
+                 * module is trying to accomplish right now.
+                 *
+                 * Optimization: If no clients are in type BLOCKED_MODULE,
+                 * we can skip this loop. */
+                if (server.blocked_clients_by_type[BLOCKED_MODULE])
+                    serveClientsBlockedOnKeyByModule(rl);
             }
             server.fixed_time_expire--;
 

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -479,6 +479,10 @@ void serveClientsBlockedOnStreamKey(robj *o, readyList *rl) {
 void serveClientsBlockedOnKeyByModule(readyList *rl) {
     dictEntry *de;
 
+    /* Optimization: If no clients are in type BLOCKED_MODULE,
+     * we can skip this loop. */
+    if (!server.blocked_clients_by_type[BLOCKED_MODULE]) return;
+
     /* We serve clients in the same order they blocked for
      * this key, from the first blocked to the last. */
     de = dictFind(rl->db->blocking_keys,rl->key);
@@ -577,12 +581,8 @@ void handleClientsBlockedOnKeys(void) {
                     serveClientsBlockedOnStreamKey(o,rl);
                 /* We want to serve clients blocked on module keys
                  * regardless of the object type: we don't know what the
-                 * module is trying to accomplish right now.
-                 *
-                 * Optimization: If no clients are in type BLOCKED_MODULE,
-                 * we can skip this loop. */
-                if (server.blocked_clients_by_type[BLOCKED_MODULE])
-                    serveClientsBlockedOnKeyByModule(rl);
+                 * module is trying to accomplish right now. */
+                serveClientsBlockedOnKeyByModule(rl);
             }
             server.fixed_time_expire--;
 


### PR DESCRIPTION
This is a proposed fix for https://github.com/redis/redis/issues/8668. It is expected to significantly improve CPU utilization for BRPOP heavy workloads (e.g. sidekiq).

A performance regression was introduced in https://github.com/redis/redis/commit/215b72c0ba1f42d15dcfe6fa60abb414275296ba that affects `BRPOP` heavy workloads. This patch introduces a fast path that bypasses the expensive new code path if no clients are blocked by type `BLOCKED_MODULE`.

Since the issue affects Redis 6.0 as well, we'd love to be able to backport this to the 6.0 series. I checked, and `6.0` already includes `server.blocked_clients_by_type` -- so I expect a backport would be quite straight forward.

I profiled using the reproduce workload from https://github.com/redis/redis/issues/8668#issuecomment-804350847, and here are the results.

**Before (current `unstable`):**

![Screenshot 2021-03-24 at 14 53 24](https://user-images.githubusercontent.com/11158255/112322109-e8097a00-8cb0-11eb-814a-0761f0974953.png)

**After (`blocked-module-fast-path`):**

![Screenshot 2021-03-24 at 14 54 47](https://user-images.githubusercontent.com/11158255/112322145-f061b500-8cb0-11eb-9dae-293c05ef962a.png)
