### PR TITLE
Fix misleading comment

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2773,7 +2773,7 @@ void replicaofCommand(client *c) {
         if ((getLongFromObjectOrReply(c, c->argv[2], &port, NULL) != C_OK))
             return;
 
-        /* Check if we are already attached to the specified slave */
+        /* Check if we are already attached to the specified master */
         if (server.masterhost && !strcasecmp(server.masterhost,c->argv[1]->ptr)
             && server.masterport == port) {
             serverLog(LL_NOTICE,"REPLICAOF would result into synchronization "


### PR DESCRIPTION
REPLICAOF actually specifies which master to attach.