### PR TITLE
Backport (6.0): Introduce fast path to bypass expensive serveClientsBlockedOnKeyByModule call

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -425,6 +425,10 @@ void serveClientsBlockedOnStreamKey(robj *o, readyList *rl) {
 void serveClientsBlockedOnKeyByModule(readyList *rl) {
     dictEntry *de;
 
+    /* Optimization: If no clients are in type BLOCKED_MODULE,
+     * we can skip this loop. */
+    if (!server.blocked_clients_by_type[BLOCKED_MODULE]) return;
+
     /* We serve clients in the same order they blocked for
      * this key, from the first blocked to the last. */
     de = dictFind(rl->db->blocking_keys,rl->key);


### PR DESCRIPTION
This is a backport of #8689 to the 6.0 branch, see https://github.com/redis/redis/issues/8668 for the original report.

Having this change in 6.0 would help us, as it would clear the upgrade path. We are currently unable to upgrade to 6.0 due to being at the limit of our single-threaded CPU utilization.

That said, if this change is deemed too risky to backport in redis core, we should be able to a workaround. We can consider applying it as a custom patch on our end if needed.