### PR TITLE
Replace dict's hash table with HAMT

### DIFF
--- a/deps/hiredis/async.h
+++ b/deps/hiredis/async.h
@@ -103,8 +103,8 @@ typedef struct redisAsyncContext {
     /* Subscription callbacks */
     struct {
         redisCallbackList invalid;
-        struct dict *channels;
-        struct dict *patterns;
+        struct hi_dict *channels;
+        struct hi_dict *patterns;
     } sub;
 
     /* Any configured RESP3 PUSH handler */

--- a/deps/hiredis/dict.h
+++ b/deps/hiredis/dict.h
@@ -42,85 +42,85 @@
 /* Unused arguments generate annoying warnings... */
 #define DICT_NOTUSED(V) ((void) V)
 
-typedef struct dictEntry {
+typedef struct hi_dictEntry {
     void *key;
     void *val;
-    struct dictEntry *next;
-} dictEntry;
+    struct hi_dictEntry *next;
+} hi_dictEntry;
 
-typedef struct dictType {
+typedef struct hi_dictType {
     unsigned int (*hashFunction)(const void *key);
     void *(*keyDup)(void *privdata, const void *key);
     void *(*valDup)(void *privdata, const void *obj);
     int (*keyCompare)(void *privdata, const void *key1, const void *key2);
     void (*keyDestructor)(void *privdata, void *key);
     void (*valDestructor)(void *privdata, void *obj);
-} dictType;
+} hi_dictType;
 
-typedef struct dict {
-    dictEntry **table;
-    dictType *type;
+typedef struct hi_dict {
+    hi_dictEntry **table;
+    hi_dictType *type;
     unsigned long size;
     unsigned long sizemask;
     unsigned long used;
     void *privdata;
-} dict;
+} hi_dict;
 
-typedef struct dictIterator {
-    dict *ht;
+typedef struct hi_dictIterator {
+    hi_dict *ht;
     int index;
-    dictEntry *entry, *nextEntry;
-} dictIterator;
+    hi_dictEntry *entry, *nextEntry;
+} hi_dictIterator;
 
 /* This is the initial size of every hash table */
 #define DICT_HT_INITIAL_SIZE     4
 
 /* ------------------------------- Macros ------------------------------------*/
-#define dictFreeEntryVal(ht, entry) \
+#define hi_dictFreeEntryVal(ht, entry) \
     if ((ht)->type->valDestructor) \
         (ht)->type->valDestructor((ht)->privdata, (entry)->val)
 
-#define dictSetHashVal(ht, entry, _val_) do { \
+#define hi_dictSetHashVal(ht, entry, _val_) do { \
     if ((ht)->type->valDup) \
         entry->val = (ht)->type->valDup((ht)->privdata, _val_); \
     else \
         entry->val = (_val_); \
 } while(0)
 
-#define dictFreeEntryKey(ht, entry) \
+#define hi_dictFreeEntryKey(ht, entry) \
     if ((ht)->type->keyDestructor) \
         (ht)->type->keyDestructor((ht)->privdata, (entry)->key)
 
-#define dictSetHashKey(ht, entry, _key_) do { \
+#define hi_dictSetHashKey(ht, entry, _key_) do { \
     if ((ht)->type->keyDup) \
         entry->key = (ht)->type->keyDup((ht)->privdata, _key_); \
     else \
         entry->key = (_key_); \
 } while(0)
 
-#define dictCompareHashKeys(ht, key1, key2) \
+#define hi_dictCompareHashKeys(ht, key1, key2) \
     (((ht)->type->keyCompare) ? \
         (ht)->type->keyCompare((ht)->privdata, key1, key2) : \
         (key1) == (key2))
 
-#define dictHashKey(ht, key) (ht)->type->hashFunction(key)
+#define hi_dictHashKey(ht, key) (ht)->type->hashFunction(key)
 
-#define dictGetEntryKey(he) ((he)->key)
-#define dictGetEntryVal(he) ((he)->val)
-#define dictSlots(ht) ((ht)->size)
-#define dictSize(ht) ((ht)->used)
+#define hi_dictGetEntryKey(he) ((he)->key)
+#define hi_dictGetEntryVal(he) ((he)->val)
+#define hi_dictSlots(ht) ((ht)->size)
+#define hi_dictSize(ht) ((ht)->used)
 
 /* API */
-static unsigned int dictGenHashFunction(const unsigned char *buf, int len);
-static dict *dictCreate(dictType *type, void *privDataPtr);
-static int dictExpand(dict *ht, unsigned long size);
-static int dictAdd(dict *ht, void *key, void *val);
-static int dictReplace(dict *ht, void *key, void *val);
-static int dictDelete(dict *ht, const void *key);
-static void dictRelease(dict *ht);
-static dictEntry * dictFind(dict *ht, const void *key);
-static dictIterator *dictGetIterator(dict *ht);
-static dictEntry *dictNext(dictIterator *iter);
-static void dictReleaseIterator(dictIterator *iter);
+static unsigned int hi_dictGenHashFunction(const unsigned char *buf, int len);
+static hi_dict *hi_dictCreate(hi_dictType *type, void *privDataPtr);
+static int hi_dictExpand(hi_dict *ht, unsigned long size);
+static int hi_dictAdd(hi_dict *ht, void *key, void *val);
+static int hi_dictReplace(hi_dict *ht, void *key, void *val);
+static int hi_dictDelete(hi_dict *ht, const void *key);
+static void hi_dictRelease(hi_dict *ht);
+static hi_dictEntry * hi_dictFind(hi_dict *ht, const void *key);
+static hi_dictIterator *hi_dictGetIterator(hi_dict *ht);
+static hi_dictEntry *hi_dictNext(hi_dictIterator *iter);
+static void hi_dictReleaseIterator(hi_dictIterator *iter);
 
 #endif /* __DICT_H */

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -130,29 +130,30 @@ robj *activeDefragStringOb(robj* ob, long *defragged) {
 /* Defrag helper for dictEntries to be used during dict iteration (called on
  * each step). Returns a stat of how many pointers were moved. */
 long dictIterDefragEntry(dictIterator *iter) {
+    UNUSED(iter);
     /* This function is a little bit dirty since it messes with the internals
      * of the dict and it's iterator, but the benefit is that it is very easy
      * to use, and require no other changes in the dict. */
     long defragged = 0;
-    /* Handle the next entry (if there is one), and update the pointer in the
-     * current entry. */
-    if (iter->nextEntry) {
-        dictEntry *newde = activeDefragAlloc(iter->nextEntry);
-        if (newde) {
-            defragged++;
-            iter->nextEntry = newde;
-            iter->entry->next = newde;
-        }
-    }
-    /* handle the case of the first entry in the hash bucket. */
-    if (iter->d->ht_table[iter->table][iter->index] == iter->entry) {
-        dictEntry *newde = activeDefragAlloc(iter->entry);
-        if (newde) {
-            iter->entry = newde;
-            iter->d->ht_table[iter->table][iter->index] = newde;
-            defragged++;
-        }
-    }
+    /* /\* Handle the next entry (if there is one), and update the pointer in the */
+    /*  * current entry. *\/ */
+    /* if (iter->nextEntry) { */
+    /*     dictEntry *newde = activeDefragAlloc(iter->nextEntry); */
+    /*     if (newde) { */
+    /*         defragged++; */
+    /*         iter->nextEntry = newde; */
+    /*         iter->entry->next = newde; */
+    /*     } */
+    /* } */
+    /* /\* handle the case of the first entry in the hash bucket. *\/ */
+    /* if (iter->d->ht_table[iter->table][iter->index] == iter->entry) { */
+    /*     dictEntry *newde = activeDefragAlloc(iter->entry); */
+    /*     if (newde) { */
+    /*         iter->entry = newde; */
+    /*         iter->d->ht_table[iter->table][iter->index] = newde; */
+    /*         defragged++; */
+    /*     } */
+    /* } */
     return defragged;
 }
 
@@ -160,18 +161,19 @@ long dictIterDefragEntry(dictIterator *iter) {
  * receives a pointer to the dict* and implicitly updates it when the dict
  * struct itself was moved. Returns a stat of how many pointers were moved. */
 long dictDefragTables(dict* d) {
-    dictEntry **newtable;
+    UNUSED(d);
+    /* dictEntry **newtable; */
     long defragged = 0;
-    /* handle the first hash table */
-    newtable = activeDefragAlloc(d->ht_table[0]);
-    if (newtable)
-        defragged++, d->ht_table[0] = newtable;
-    /* handle the second hash table */
-    if (d->ht_table[1]) {
-        newtable = activeDefragAlloc(d->ht_table[1]);
-        if (newtable)
-            defragged++, d->ht_table[1] = newtable;
-    }
+    /* /\* handle the first hash table *\/ */
+    /* newtable = activeDefragAlloc(d->ht_table[0]); */
+    /* if (newtable) */
+    /*     defragged++, d->ht_table[0] = newtable; */
+    /* /\* handle the second hash table *\/ */
+    /* if (d->ht_table[1]) { */
+    /*     newtable = activeDefragAlloc(d->ht_table[1]); */
+    /*     if (newtable) */
+    /*         defragged++, d->ht_table[1] = newtable; */
+    /* } */
     return defragged;
 }
 
@@ -897,12 +899,10 @@ void defragScanCallback(void *privdata, const dictEntry *de) {
  * used in order to defrag the dictEntry allocations. */
 void defragDictBucketCallback(void *privdata, dictEntry **bucketref) {
     UNUSED(privdata); /* NOTE: this function is also used by both activeDefragCycle and scanLaterHash, etc. don't use privdata */
-    while(*bucketref) {
-        dictEntry *de = *bucketref, *newde;
-        if ((newde = activeDefragAlloc(de))) {
-            *bucketref = newde;
-        }
-        bucketref = &(*bucketref)->next;
+    /* FIXME: *bucketref will be a dictNode array, not a single entry. */
+    dictEntry *de = *bucketref, *newde;
+    if ((newde = activeDefragAlloc(de))) {
+        *bucketref = newde;
     }
 }
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -1,11 +1,11 @@
 /* Hash Tables Implementation.
  *
- * This file implements in memory hash tables with insert/del/replace/find/
- * get-random-element operations. Hash tables will auto resize if needed
- * tables of power of two in size are used, collisions are handled by
- * chaining. See the source code for more information... :)
+ * This file implements in memory dictionaries with insert/del/replace/find/
+ * get-random-element operations. The dictionary is implemented as a Hash Array
+ * Mapped Trie (HAMT). See the source code for more information... :)
  *
  * Copyright (c) 2006-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2021, Viktor Söderqvist <viktor.soderqvist@est.tech>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,28 +42,91 @@
 #include <stdarg.h>
 #include <limits.h>
 #include <sys/time.h>
+#include <math.h>
 
 #include "dict.h"
 #include "zmalloc.h"
 #include "redisassert.h"
 
-/* Using dictEnableResize() / dictDisableResize() we make possible to
- * enable/disable resizing of the hash table as needed. This is very important
- * for Redis, as we use copy-on-write and don't want to move too much memory
- * around when there is a child performing saving operations.
+/* Our dict is implemented as a Hash Array Mapped Trie (HAMT). The hash (result
+ * of a hash function) of each key is stored in a a tree structure where each
+ * node has up to 32 children. With this large branching factor, the tree never
+ * becomes very deep (6-7 levels). The time complexity is O(log32 n), which is
+ * very close to constant.
  *
- * Note that even when dict_can_resize is set to 0, not all resizes are
- * prevented: a hash table is still allowed to grow if the ratio between
- * the number of elements and the buckets > dict_force_resize_ratio. */
-static int dict_can_resize = 1;
-static unsigned int dict_force_resize_ratio = 5;
+ * This is our HAMT structure:
+ *
+ * +--------------------+
+ * | dict               |
+ * |--------------------|   +--------------------+   +--------------------+
+ * | bitmaps | children---->| bitmaps | children---->| key     | value    |
+ * | size               |   | key     | value    |   | ...     | ...      |
+ * | dictType           |   | key     | value    |   +--------------------+
+ * | privdata           |   | key     | value    |
+ * +--------------------+   | key     | value    |   +--------------------+
+ *                          | bitmaps | children---->| key     | value    |
+ *                          | key     | value    |   | bitmaps | children--->..
+ *                          | ...     | ...      |   | value   | key      |
+ *                          +--------------------+   | ...     | ...      |
+ *                                                   +--------------------+
+ *
+ * In each level, 5 bits of the hash is used as an index into the children. A
+ * bitmap indicates which of the children exist (1) and which don't (0). Whether
+ * the child is a leaf or a subnode is indicated by a second bitmap, "leafmap".
+ *
+ * hash(key) = 0010 10010 01011 00101 01001 10110 11101
+ * (64 bits)   10101 11001 01001 01101 10111 11010
+ *                                           ^^^^^
+ *                                             26
+ *
+ * bitmap    = 00100101 00000010 00010100 01100001
+ * (level 0)        ^
+ *                  bit 26 is 1, so there is a child node or leaf
+ *
+ * leafmap   = 00000100 00000010 00010000 01100000
+ * (level 0)        ^
+ *                  bit 26 is 1, so the child is a key-value entry
+ *
+ * The children array is compact and its length is equal to the number of 1s in
+ * the bitmap. In the bitmap above, our bit is the 2nd 1-bit from the left, so
+ * we look at the 2nd child.
+ *
+ * children  = +--------------------+
+ *             | bitmaps | children |
+ *             | key     | value    | <-- The 2nd child is a key-value entry. If
+ *             | bitmaps | children |     the key matches our key, then it's our
+ *             | ...     | ...      |     key. Otherwise, the dict doesn't
+ *             +--------------------+     contain our key.
+ *
+ * If, instead, our child is a subnode, we use the next 5 bits from the hash to
+ * index into the next level of children.
+ *
+ * The HAMT is described in Phil Bagwell (2000). Ideal Hash Trees.
+ * https://infoscience.epfl.ch/record/64398/files/idealhashtrees.pdf
+ *
+ * Until 2021, the dictionary was implemented as a hash table with incremental
+ * rehashing using two hash tables while rehashing and resized in powers of two.
+ * Despite the incremental rehashing, allocating and freeing very large
+ * continuous memory is expensive. The memory usage was also higher than for the
+ * HAMT. */
+
+/*##########################################################################\
+|#/                                                                       \#|
+|#|    DEBUGGING notes (to be deleted)                                    |#|
+|#|                                                                       |#|
+
+cd src
+make OPTIMIZATION="-O0" REDIS_CFLAGS=-DREDIS_TEST -j5 noopt
+make BUILD_TLS=1 OPTIMIZATION="-O0" REDIS_CFLAGS=-DREDIS_TEST \
+     CFLAGS=-fsanitize=address \
+     "LDFLAGS=-static-libasan -fsanitize=address" -j5 noopt
+gdb --args ./redis-server test dict
+
+|#|                                                                       |#|
+|#\_______________________________________________________________________/#|
+\##########################################################################*/
 
 /* -------------------------- private prototypes ---------------------------- */
-
-static int _dictExpandIfNeeded(dict *d);
-static signed char _dictNextExp(unsigned long size);
-static long _dictKeyIndex(dict *d, const void *key, uint64_t hash, dictEntry **existing);
-static int _dictInit(dict *d, dictType *type);
 
 /* -------------------------- hash functions -------------------------------- */
 
@@ -91,170 +154,46 @@ uint64_t dictGenCaseHashFunction(const unsigned char *buf, int len) {
     return siphash_nocase(buf,len,dict_hash_function_seed);
 }
 
-/* ----------------------------- API implementation ------------------------- */
+/* ---------------- Macros and functions for bit manipulation --------------- */
 
-/* Reset a hash table already initialized with ht_init().
- * NOTE: This function should only be called by ht_destroy(). */
-static void _dictReset(dict *d, int htidx)
-{
-    d->ht_table[htidx] = NULL;
-    d->ht_size_exp[htidx] = -1;
-    d->ht_used[htidx] = 0;
+/* Using builtin popcount CPU instruction is ~4 times faster than the
+ * bit-twiddling emulation below. The builtin requires GCC >= 3.4.0 or a recent
+ * Clang. To utilize the CPU popcount instruction, compile with -msse4.2 or use
+ * #pragma GCC target ("sse4.2"). */
+#ifdef USE_BUILTIN_POPCOUNT
+# define dict_popcount(x)  __builtin_popcount((unsigned int)(x))
+#else
+/* Population count (the number of 1s in a binary number), parallel summing. */
+int dict_popcount(uint32_t x) {
+    x -= ((x >> 1) & 0x55555555);
+    x  = ((x >> 2) & 0x33333333) + (x & 0x33333333);
+    x  = ((x >> 4) & 0x0f0f0f0f) + (x & 0x0f0f0f0f);
+    x += (x >> 8);
+    return (x + (x >> 16)) & 0x3f;
 }
+#endif
+
+/* The 5 bits used at level N to index into the children. */
+#define bitindex_at_level(h, lvl) ((int)((h) >> (5 * (lvl))) & 0x1f)
+
+/* Check if bit 'bit' is set in 'bitmap' */
+#define bit_is_set(bitmap, bit) (((bitmap) >> (bit)) & 1)
+
+#define child_exists(node, bit) bit_is_set((node)->bitmap, bit)
+#define child_is_entry(node, bit) bit_is_set((node)->leafmap, bit)
+
+/* The index in the children array is the number of children before this one */
+#define child_index(node, bit) dict_popcount((node)->bitmap >> (bit) >> 1)
+
+/* ----------------------------- API implementation ------------------------- */
 
 /* Create a new hash table */
 dict *dictCreate(dictType *type)
 {
     dict *d = zmalloc(sizeof(*d));
-
-    _dictInit(d,type);
-    return d;
-}
-
-/* Initialize the hash table */
-int _dictInit(dict *d, dictType *type)
-{
-    _dictReset(d, 0);
-    _dictReset(d, 1);
     d->type = type;
-    d->rehashidx = -1;
-    d->pauserehash = 0;
-    return DICT_OK;
-}
-
-/* Resize the table to the minimal size that contains all the elements,
- * but with the invariant of a USED/BUCKETS ratio near to <= 1 */
-int dictResize(dict *d)
-{
-    unsigned long minimal;
-
-    if (!dict_can_resize || dictIsRehashing(d)) return DICT_ERR;
-    minimal = d->ht_used[0];
-    if (minimal < DICT_HT_INITIAL_SIZE)
-        minimal = DICT_HT_INITIAL_SIZE;
-    return dictExpand(d, minimal);
-}
-
-/* Expand or create the hash table,
- * when malloc_failed is non-NULL, it'll avoid panic if malloc fails (in which case it'll be set to 1).
- * Returns DICT_OK if expand was performed, and DICT_ERR if skipped. */
-int _dictExpand(dict *d, unsigned long size, int* malloc_failed)
-{
-    if (malloc_failed) *malloc_failed = 0;
-
-    /* the size is invalid if it is smaller than the number of
-     * elements already inside the hash table */
-    if (dictIsRehashing(d) || d->ht_used[0] > size)
-        return DICT_ERR;
-
-    /* the new hash table */
-    dictEntry **new_ht_table;
-    unsigned long new_ht_used;
-    signed char new_ht_size_exp = _dictNextExp(size);
-
-    /* Detect overflows */
-    size_t newsize = 1ul<<new_ht_size_exp;
-    if (newsize < size || newsize * sizeof(dictEntry*) < newsize)
-        return DICT_ERR;
-
-    /* Rehashing to the same table size is not useful. */
-    if (new_ht_size_exp == d->ht_size_exp[0]) return DICT_ERR;
-
-    /* Allocate the new hash table and initialize all pointers to NULL */
-    if (malloc_failed) {
-        new_ht_table = ztrycalloc(newsize*sizeof(dictEntry*));
-        *malloc_failed = new_ht_table == NULL;
-        if (*malloc_failed)
-            return DICT_ERR;
-    } else
-        new_ht_table = zcalloc(newsize*sizeof(dictEntry*));
-
-    new_ht_used = 0;
-
-    /* Is this the first initialization? If so it's not really a rehashing
-     * we just set the first hash table so that it can accept keys. */
-    if (d->ht_table[0] == NULL) {
-        d->ht_size_exp[0] = new_ht_size_exp;
-        d->ht_used[0] = new_ht_used;
-        d->ht_table[0] = new_ht_table;
-        return DICT_OK;
-    }
-
-    /* Prepare a second hash table for incremental rehashing */
-    d->ht_size_exp[1] = new_ht_size_exp;
-    d->ht_used[1] = new_ht_used;
-    d->ht_table[1] = new_ht_table;
-    d->rehashidx = 0;
-    return DICT_OK;
-}
-
-/* return DICT_ERR if expand was not performed */
-int dictExpand(dict *d, unsigned long size) {
-    return _dictExpand(d, size, NULL);
-}
-
-/* return DICT_ERR if expand failed due to memory allocation failure */
-int dictTryExpand(dict *d, unsigned long size) {
-    int malloc_failed;
-    _dictExpand(d, size, &malloc_failed);
-    return malloc_failed? DICT_ERR : DICT_OK;
-}
-
-/* Performs N steps of incremental rehashing. Returns 1 if there are still
- * keys to move from the old to the new hash table, otherwise 0 is returned.
- *
- * Note that a rehashing step consists in moving a bucket (that may have more
- * than one key as we use chaining) from the old to the new hash table, however
- * since part of the hash table may be composed of empty spaces, it is not
- * guaranteed that this function will rehash even a single bucket, since it
- * will visit at max N*10 empty buckets in total, otherwise the amount of
- * work it does would be unbound and the function may block for a long time. */
-int dictRehash(dict *d, int n) {
-    int empty_visits = n*10; /* Max number of empty buckets to visit. */
-    if (!dictIsRehashing(d)) return 0;
-
-    while(n-- && d->ht_used[0] != 0) {
-        dictEntry *de, *nextde;
-
-        /* Note that rehashidx can't overflow as we are sure there are more
-         * elements because ht[0].used != 0 */
-        assert(DICTHT_SIZE(d->ht_size_exp[0]) > (unsigned long)d->rehashidx);
-        while(d->ht_table[0][d->rehashidx] == NULL) {
-            d->rehashidx++;
-            if (--empty_visits == 0) return 1;
-        }
-        de = d->ht_table[0][d->rehashidx];
-        /* Move all the keys in this bucket from the old to the new hash HT */
-        while(de) {
-            uint64_t h;
-
-            nextde = de->next;
-            /* Get the index in the new hash table */
-            h = dictHashKey(d, de->key) & DICTHT_SIZE_MASK(d->ht_size_exp[1]);
-            de->next = d->ht_table[1][h];
-            d->ht_table[1][h] = de;
-            d->ht_used[0]--;
-            d->ht_used[1]++;
-            de = nextde;
-        }
-        d->ht_table[0][d->rehashidx] = NULL;
-        d->rehashidx++;
-    }
-
-    /* Check if we already rehashed the whole table... */
-    if (d->ht_used[0] == 0) {
-        zfree(d->ht_table[0]);
-        /* Copy the new ht onto the old one */
-        d->ht_table[0] = d->ht_table[1];
-        d->ht_used[0] = d->ht_used[1];
-        d->ht_size_exp[0] = d->ht_size_exp[1];
-        _dictReset(d, 1);
-        d->rehashidx = -1;
-        return 0;
-    }
-
-    /* More to rehash... */
-    return 1;
+    d->size = 0;
+    return d;
 }
 
 long long timeInMilliseconds(void) {
@@ -262,34 +201,6 @@ long long timeInMilliseconds(void) {
 
     gettimeofday(&tv,NULL);
     return (((long long)tv.tv_sec)*1000)+(tv.tv_usec/1000);
-}
-
-/* Rehash in ms+"delta" milliseconds. The value of "delta" is larger 
- * than 0, and is smaller than 1 in most cases. The exact upper bound 
- * depends on the running time of dictRehash(d,100).*/
-int dictRehashMilliseconds(dict *d, int ms) {
-    if (d->pauserehash > 0) return 0;
-
-    long long start = timeInMilliseconds();
-    int rehashes = 0;
-
-    while(dictRehash(d,100)) {
-        rehashes += 100;
-        if (timeInMilliseconds()-start > ms) break;
-    }
-    return rehashes;
-}
-
-/* This function performs just a step of rehashing, and only if hashing has
- * not been paused for our hash table. When we have iterators in the
- * middle of a rehashing we can't mess with the two hash tables otherwise
- * some element can be missed or duplicated.
- *
- * This function is called by common lookup or update operations in the
- * dictionary so that the hash table automatically migrates from H1 to H2
- * while it is actively used. */
-static void _dictRehashStep(dict *d) {
-    if (d->pauserehash == 0) dictRehash(d,1);
 }
 
 /* Add an element to the target hash table */
@@ -300,6 +211,20 @@ int dictAdd(dict *d, void *key, void *val)
     if (!entry) return DICT_ERR;
     dictSetVal(d, entry, val);
     return DICT_OK;
+}
+
+/* In-place converts an entry into a subnode. The old entry is copied and
+ * becomes the only child of the subnode. When using this function, don't forget
+ * to flag the node as a subnode in the parent's leafmap. */
+static void dictWrapEntryInSubnode(dict *d, union dictNode *node, int level) {
+    union dictNode *children = zmalloc(sizeof(union dictNode) * 1);
+    children[0].entry = node->entry; /* copy entry */
+    uint64_t hash = dictHashKey(d, node->entry.key);
+    int childbit = bitindex_at_level(hash, level);
+    /* Reinterpret the node as a subnode and add children. */
+    node->sub.children = children;
+    node->sub.bitmap = (1U << childbit);
+    node->sub.leafmap = (1U << childbit);
 }
 
 /* Low level add or find:
@@ -320,32 +245,107 @@ int dictAdd(dict *d, void *key, void *val)
  *
  * If key was added, the hash entry is returned to be manipulated by the caller.
  */
-dictEntry *dictAddRaw(dict *d, void *key, dictEntry **existing)
-{
-    long index;
-    dictEntry *entry;
-    int htidx;
+dictEntry *dictAddRaw(dict *d, void *key, dictEntry **existing) {
+    if (existing) *existing = NULL;
+    if (d->size == 0) {
+        dictSetKey(d, &d->root.entry, key);
+        d->size = 1;
+        return &d->root.entry;
+    }
+    if (d->size == 1) {
+        /* Root is an entry. */
+        if (dictCompareKeys(d, key, d->root.entry.key)) {
+            if (existing) *existing = &d->root.entry;
+            return NULL;
+        }
+        /* Convert the root to a subnode. */
+        dictWrapEntryInSubnode(d, &d->root, 0);
+    }
 
-    if (dictIsRehashing(d)) _dictRehashStep(d);
+    uint64_t hash = dictHashKey(d, key);
+    dictSubNode *node = &d->root.sub;
+    int level = 0;
+    for (;;) {
+        /* Use 5 bits of the hash as an index into one of 32 possible
+         * children. The child exists if the bit at childbit is set. */
+        int childbit = bitindex_at_level(hash, level);
+        int childindex = child_index(node, childbit);
+        if (!child_exists(node, childbit)) {
+            /* Let's make space for our entry here. */
+            int numchildren = dict_popcount(node->bitmap);
+            int numafter = numchildren - childindex;
+            node->children = zrealloc(node->children,
+                                      sizeof(union dictNode) * ++numchildren);
+            memmove(&node->children[childindex + 1],
+                    &node->children[childindex],
+                    sizeof(union dictNode) * numafter);
+            dictSetKey(d, &node->children[childindex].entry, key);
+            node->bitmap |= (1U << childbit);
+            node->leafmap |= (1U << childbit);
+            d->size++;
+            return &node->children[childindex].entry;
+        }
 
-    /* Get the index of the new element, or -1 if
-     * the element already exists. */
-    if ((index = _dictKeyIndex(d, key, dictHashKey(d,key), existing)) == -1)
-        return NULL;
+        if (child_is_entry(node, childbit)) {
+            dictEntry *entry = &node->children[childindex].entry;
+            if (dictCompareKeys(d, key, entry->key)) {
+                if (existing) *existing = entry;
+                return NULL;
+            }
 
-    /* Allocate the memory and store the new entry.
-     * Insert the element in top, with the assumption that in a database
-     * system it is more likely that recently added entries are accessed
-     * more frequently. */
-    htidx = dictIsRehashing(d) ? 1 : 0;
-    entry = zmalloc(sizeof(*entry));
-    entry->next = d->ht_table[htidx][index];
-    d->ht_table[htidx][index] = entry;
-    d->ht_used[htidx]++;
+            /* There's another entry at this position. We need to wrap it in
+             * a subnode and then add our entry in there. */
+            if ((level + 1) * 5 >= 64) {
+                /* Max depth reached; no more hash bits available. TODO: Use
+                 * secondary hash function or a duplicate list (a flat array on
+                 * the deepest level). */
+                assert(0);
+            }
 
-    /* Set the hash entry fields. */
-    dictSetKey(d, entry, key);
-    return entry;
+            /* Convert entry to subnode and clear its leaf flag. */
+            dictWrapEntryInSubnode(d, &node->children[childindex], level+1);
+            node->leafmap &= ~(1U << childbit);
+        }
+
+        /* The child is a subnode. Loop to add our new key inside it. */
+        node = &node->children[childindex].sub;
+        level++;
+    }
+}
+
+/* Returns a pointer to an entry or NULL if the key isn't found in the dict. */
+dictEntry *dictFind(dict *d, const void *key) {
+    if (d->size == 0) return NULL; /* dict is empty */
+    if (d->size == 1) {
+        /* Root is an entry. */
+        dictEntry *entry = &d->root.entry;
+        if (dictCompareKeys(d, key, entry->key))
+            return entry;
+        else
+            return NULL;
+    }
+    uint64_t hash = dictHashKey(d, key);
+    dictSubNode *node = &d->root.sub;
+    int level = 0;
+    for (;;) {
+        /* Use 5 bits of the hash as an index into one of 32 possible
+           children. The child exists if the bit at childbit is set. */
+        int childbit = bitindex_at_level(hash, level);
+        if (!child_exists(node, childbit))
+            return NULL;
+        int childindex = child_index(node, childbit);
+        if (child_is_entry(node, childbit)) {
+            dictEntry *entry = &node->children[childindex].entry;
+            if (dictCompareKeys(d, key, entry->key))
+                return entry;
+            else
+                return NULL;
+        } else {
+            /* It's a subnode */
+            node = &node->children[childindex].sub;
+            level++;
+        }
+    }
 }
 
 /* Add or Overwrite:
@@ -389,49 +389,112 @@ dictEntry *dictAddOrFind(dict *d, void *key) {
     return entry ? entry : existing;
 }
 
-/* Search and remove an element. This is a helper function for
- * dictDelete() and dictUnlink(), please check the top comment
- * of those functions. */
-static dictEntry *dictGenericDelete(dict *d, const void *key, int nofree) {
-    uint64_t h, idx;
-    dictEntry *he, *prevHe;
-    int table;
+/* Removes an entry from a subnode. Returns 1 if the key was found and 0
+ * otherwise. The 'deleted' entry is filled with the key and value from the
+ * deleted entry. This is a recursive helper for dictGenericDelete(). */
+static int dictDeleteFromNode(dict *d, dictSubNode *node, int level,
+                              uint64_t hash, const void *key,
+                              dictEntry *deleted) {
+    /* Use 5 bits of the hash as an index into one of 32 possible
+       children. The child exists if the bit at childbit is set. */
+    int childbit = bitindex_at_level(hash, level);
+    if (!child_exists(node, childbit))
+        return 0;
 
-    /* dict is empty */
-    if (dictSize(d) == 0) return NULL;
+    int childindex = child_index(node, childbit);
+    if (child_is_entry(node, childbit)) {
+        dictEntry *entry = &node->children[childindex].entry;
+        if (!dictCompareKeys(d, key, entry->key))
+            return 0;
 
-    if (dictIsRehashing(d)) _dictRehashStep(d);
-    h = dictHashKey(d, key);
+        /* It's a match. Copy to 'deleted' and remove child from node. */
+        *deleted = *entry;
 
-    for (table = 0; table <= 1; table++) {
-        idx = h & DICTHT_SIZE_MASK(d->ht_size_exp[table]);
-        he = d->ht_table[table][idx];
-        prevHe = NULL;
-        while(he) {
-            if (key==he->key || dictCompareKeys(d, key, he->key)) {
-                /* Unlink the element from the list */
-                if (prevHe)
-                    prevHe->next = he->next;
-                else
-                    d->ht_table[table][idx] = he->next;
-                if (!nofree) {
-                    dictFreeUnlinkedEntry(d, he);
-                }
-                d->ht_used[table]--;
-                return he;
-            }
-            prevHe = he;
-            he = he->next;
-        }
-        if (!dictIsRehashing(d)) break;
+        int numchildren = dict_popcount(node->bitmap);
+        numchildren--;
+        int numafter = numchildren - childindex;
+        memmove(&node->children[childindex],
+                &node->children[childindex + 1],
+                sizeof(union dictNode) * numafter);
+        node->children = zrealloc(node->children,
+                                  sizeof(union dictNode) * numchildren);
+        node->bitmap  &= ~(1U << childbit);
+        node->leafmap &= ~(1U << childbit);
+        return 1;
     }
-    return NULL; /* not found */
+
+    /* It's a subnode. Recursively delete from the subnode. */
+    if ((level + 1) * 5 >= 64) {
+        /* All hash bits used up. TODO: Use secondary hash function. */
+        assert(0);
+    }
+    dictSubNode *subnode = &node->children[childindex].sub;
+    if (!dictDeleteFromNode(d, subnode, level + 1, hash, key, deleted))
+        return 0; /* Not found in subtree. */
+
+    /* If we're here, it means we have removed an entry from the subnode. If the
+     * subnode has now only one child and it's an entry, we need to collapse the
+     * subnode.
+     *                                  ,--entry
+     * Before delete:  node---subnode--<
+     *                                  `--entry
+     *
+     * After removal:  node---subnode---entry
+     *
+     * After collapse: node---entry
+     */
+    if (dict_popcount(subnode->bitmap) == 1 &&
+        subnode->leafmap == subnode->bitmap) {
+        union dictNode *grandchildren = subnode->children;
+        node->children[childindex] = grandchildren[0]; /* copy */
+        node->leafmap |= (1U << childbit);
+        zfree(grandchildren);
+    }
+    return 1;
+}
+
+/* Search and remove an element. Returns 1 if the key was found and 0 otherwise.
+ * The 'deleted' entry is filled with the key and value from the deleted entry.
+ *
+ * This is an helper function for dictDelete() and dictUnlink(). Please check
+ * the top comment of those functions. */
+static int dictGenericDelete(dict *d, const void *key, dictEntry *deleted) {
+    if (d->size == 0) return 0;
+    if (d->size == 1) {
+        /* Root is an entry. */
+        if (dictCompareKeys(d, key, d->root.entry.key)) {
+            *deleted = d->root.entry;
+            d->size = 0;
+            return 1;
+        }
+        return 0;
+    }
+    uint64_t hash = dictHashKey(d, key);
+    int found = dictDeleteFromNode(d, &d->root.sub, 0, hash, key, deleted);
+    if (found) {
+        d->size--;
+        if (d->size == 1) {
+            /* Collapse into root. */
+            assert(d->root.sub.bitmap == d->root.sub.leafmap);
+            assert(dict_popcount(d->root.sub.bitmap) == 1);
+            union dictNode *grandchildren = d->root.sub.children;
+            d->root.entry = grandchildren[0].entry; /* copy */
+            zfree(grandchildren);
+        }
+    }
+    return found;
 }
 
 /* Remove an element, returning DICT_OK on success or DICT_ERR if the
  * element was not found. */
-int dictDelete(dict *ht, const void *key) {
-    return dictGenericDelete(ht,key,0) ? DICT_OK : DICT_ERR;
+int dictDelete(dict *d, const void *key) {
+    dictEntry entry;
+    if (dictGenericDelete(d, key, &entry)) {
+        dictFreeKey(d, &entry);
+        dictFreeVal(d, &entry);
+        return DICT_OK;
+    }
+    return DICT_ERR;
 }
 
 /* Remove an element from the table, but without actually releasing
@@ -456,7 +519,15 @@ int dictDelete(dict *ht, const void *key) {
  * dictFreeUnlinkedEntry(entry); // <- This does not need to lookup again.
  */
 dictEntry *dictUnlink(dict *d, const void *key) {
-    return dictGenericDelete(d,key,1);
+    dictEntry entry;
+    if (dictGenericDelete(d, key, &entry)) {
+        /* TODO: Rename dictGenericDelete() to dictUnlink() and refactor calls
+           to it to get rid of the silly dup_entry. */
+        dictEntry *dup_entry = zmalloc(sizeof(dictEntry));
+        *dup_entry = entry;
+        return dup_entry;
+    }
+    return NULL;
 }
 
 /* You need to call this function to really free the entry after a call
@@ -468,60 +539,36 @@ void dictFreeUnlinkedEntry(dict *d, dictEntry *he) {
     zfree(he);
 }
 
-/* Destroy an entire dictionary */
-int _dictClear(dict *d, int htidx, void(callback)(dict*)) {
-    unsigned long i;
-
-    /* Free all the elements */
-    for (i = 0; i < DICTHT_SIZE(d->ht_size_exp[htidx]) && d->ht_used[htidx] > 0; i++) {
-        dictEntry *he, *nextHe;
-
-        if (callback && (i & 65535) == 0) callback(d);
-
-        if ((he = d->ht_table[htidx][i]) == NULL) continue;
-        while(he) {
-            nextHe = he->next;
-            dictFreeKey(d, he);
-            dictFreeVal(d, he);
-            zfree(he);
-            d->ht_used[htidx]--;
-            he = nextHe;
+/* Deletes the contents of a subnode. Returns counter after incrementing it with
+ * the number of deleted elements. Calls progress indicator callback sometimes
+ * if provided. */
+int dictClearNode(dict *d, dictSubNode *node, long counter,
+                  void(callback)(dict *)) {
+    for (int childbit = 0; childbit < 32; childbit++) {
+        if (child_exists(node, childbit)) {
+            int childindex = child_index(node, childbit);
+            if (child_is_entry(node, childbit)) {
+                dictEntry *entry = &node->children[childindex].entry;
+                dictFreeKey(d, entry);
+                dictFreeVal(d, entry);
+                counter++;
+                if (callback && (counter & 65535) == 0)
+                    callback(d);
+            } else {
+                dictSubNode *subnode = &node->children[childindex].sub;
+                counter = dictClearNode(d, subnode, counter, callback);
+            }
         }
     }
-    /* Free the table and the allocated cache structure */
-    zfree(d->ht_table[htidx]);
-    /* Re-initialize the table */
-    _dictReset(d, htidx);
-    return DICT_OK; /* never fails */
+    zfree(node->children);
+    return counter;
 }
 
 /* Clear & Release the hash table */
 void dictRelease(dict *d)
 {
-    _dictClear(d,0,NULL);
-    _dictClear(d,1,NULL);
+    dictEmpty(d, NULL);
     zfree(d);
-}
-
-dictEntry *dictFind(dict *d, const void *key)
-{
-    dictEntry *he;
-    uint64_t h, idx, table;
-
-    if (dictSize(d) == 0) return NULL; /* dict is empty */
-    if (dictIsRehashing(d)) _dictRehashStep(d);
-    h = dictHashKey(d, key);
-    for (table = 0; table <= 1; table++) {
-        idx = h & DICTHT_SIZE_MASK(d->ht_size_exp[table]);
-        he = d->ht_table[table][idx];
-        while(he) {
-            if (key==he->key || dictCompareKeys(d, key, he->key))
-                return he;
-            he = he->next;
-        }
-        if (!dictIsRehashing(d)) return NULL;
-    }
-    return NULL;
 }
 
 void *dictFetchValue(dict *d, const void *key) {
@@ -531,105 +578,103 @@ void *dictFetchValue(dict *d, const void *key) {
     return he ? dictGetVal(he) : NULL;
 }
 
-/* A fingerprint is a 64 bit number that represents the state of the dictionary
- * at a given time, it's just a few dict properties xored together.
- * When an unsafe iterator is initialized, we get the dict fingerprint, and check
- * the fingerprint again when the iterator is released.
- * If the two fingerprints are different it means that the user of the iterator
- * performed forbidden operations against the dictionary while iterating. */
-long long dictFingerprint(dict *d) {
-    long long integers[6], hash = 0;
-    int j;
-
-    integers[0] = (long) d->ht_table[0];
-    integers[1] = d->ht_size_exp[0];
-    integers[2] = d->ht_used[0];
-    integers[3] = (long) d->ht_table[1];
-    integers[4] = d->ht_size_exp[1];
-    integers[5] = d->ht_used[1];
-
-    /* We hash N integers by summing every successive integer with the integer
-     * hashing of the previous sum. Basically:
-     *
-     * Result = hash(hash(hash(int1)+int2)+int3) ...
-     *
-     * This way the same set of integers in a different order will (likely) hash
-     * to a different number. */
-    for (j = 0; j < 6; j++) {
-        hash += integers[j];
-        /* For the hashing step we use Tomas Wang's 64 bit integer hash. */
-        hash = (~hash) + (hash << 21); // hash = (hash << 21) - hash - 1;
-        hash = hash ^ (hash >> 24);
-        hash = (hash + (hash << 3)) + (hash << 8); // hash * 265
-        hash = hash ^ (hash >> 14);
-        hash = (hash + (hash << 2)) + (hash << 4); // hash * 21
-        hash = hash ^ (hash >> 28);
-        hash = hash + (hash << 31);
-    }
-    return hash;
-}
-
 dictIterator *dictGetIterator(dict *d)
 {
     dictIterator *iter = zmalloc(sizeof(*iter));
-
-    iter->d = d;
-    iter->table = 0;
-    iter->index = -1;
-    iter->safe = 0;
-    iter->entry = NULL;
-    iter->nextEntry = NULL;
+    dictInitIterator(iter, d, 0);
     return iter;
 }
 
 dictIterator *dictGetSafeIterator(dict *d) {
-    dictIterator *i = dictGetIterator(d);
-
-    i->safe = 1;
-    return i;
+    return dictGetIterator(d);
 }
 
-dictEntry *dictNext(dictIterator *iter)
-{
+/* Forwards a cursor to the next index on the given level. The 5-bit group
+ * corresponding to the given level is incremented and all sublevels indexes are
+ * cleared. If the incremented 5-bit number overflows (i.e. if it reaches 32),
+ * it wraps to 0 and the outer level's 5-bit group is incremented and overflow
+ * on this level is handle the same way. If level 0 overflows, 0 is returned
+ * (meaning that the root level has been fully scanned and there is no more to
+ * scan).
+ *
+ * If the 5-bit groups were be stored in order of significance, this would be a
+ * simple increment, but they are stored in reverse order, i.e. the most
+ * significant 5-bit group is the least significant 5 bits in the cursor. */
+static inline uint64_t incrCursorAtLevel(uint64_t cursor, int level) {
+    for (; level >= 0; level--) {
+        int bits = (cursor >> (level * 5)) & 0x1f;
+        /* Clear this level and all more significant bits. */
+        cursor &= (1ULL << ((level) * 5)) - 1;
+        if (++bits < 32) {
+            assert((bits & ~0x1f) == 0);
+            cursor |= ((uint64_t)bits << (level * 5)); /* set bits this level */
+            break;
+        }
+        /* loop to increment the level above */
+    }
+    return cursor;
+}
+
+/* Recursive helper for dictNext(). */
+dictEntry *dictNextInNode(dictIterator *iter, dictSubNode *node, int level) {
+    union dictNode *children = node->children;
+    int childbit = bitindex_at_level(iter->cursor, level);
     while (1) {
-        if (iter->entry == NULL) {
-            if (iter->index == -1 && iter->table == 0) {
-                if (iter->safe)
-                    dictPauseRehashing(iter->d);
-                else
-                    iter->fingerprint = dictFingerprint(iter->d);
+        if (child_exists(node, childbit)) {
+            int childindex = child_index(node, childbit);
+            if (child_is_entry(node, childbit)) {
+                /* Set start position for next time. */
+                iter->cursor = incrCursorAtLevel(iter->cursor, level);
+                return &children[childindex].entry;
+            } else {
+                /* Find next recursively. */
+                assert(level < 13); /* FIXME */
+                dictSubNode *subnode = &children[childindex].sub;
+                dictEntry *found = dictNextInNode(iter, subnode, level + 1);
+                if (found) return found;
             }
-            iter->index++;
-            if (iter->index >= (long) DICTHT_SIZE(iter->d->ht_size_exp[iter->table])) {
-                if (dictIsRehashing(iter->d) && iter->table == 0) {
-                    iter->table++;
-                    iter->index = 0;
-                } else {
-                    break;
-                }
-            }
-            iter->entry = iter->d->ht_table[iter->table][iter->index];
-        } else {
-            iter->entry = iter->nextEntry;
         }
-        if (iter->entry) {
-            /* We need to save the 'next' here, the iterator user
-             * may delete the entry we are returning. */
-            iter->nextEntry = iter->entry->next;
-            return iter->entry;
-        }
+        /* No more entries within child. Clear this and all sublevel indices.
+         * (At level 0 the mask is 0, at level 1 it is 0x1f, and so on.) */
+        iter->cursor &= (1ULL << (5 * level)) - 1;
+
+        /* Skip to beginning of next child. */
+        if (++childbit == 32) break;
+        iter->cursor |= ((uint64_t)childbit << (5*level)); /* set bits */
     }
     return NULL;
 }
 
+/* Returns a pointer to the next entry. It's safe to add, delete and replace
+ * elements in the dict while iterating. However, the entry pointer returned by
+ * this function becomes invalid when adding or deleting any entries. */
+dictEntry *dictNext(dictIterator *iter) {
+    if (iter->d == NULL) return NULL;
+    dictEntry *entry = NULL;
+    switch (iter->d->size) {
+    case 0:
+        break;
+    case 1:
+        if (iter->cursor++ == 0)
+            entry = &iter->d->root.entry;
+        break;
+    default:
+        entry = dictNextInNode(iter, &iter->d->root.sub, 0);
+    }
+    if (entry == NULL) {
+        iter->d = NULL; /* Prevents it from restarting from 0. */
+        iter->cursor = 0;
+    }
+    return entry;
+}
+
+void dictInitIterator(dictIterator *iter, dict *d, uint64_t cursor) {
+    iter->d = d;
+    iter->cursor = cursor;
+}
+
 void dictReleaseIterator(dictIterator *iter)
 {
-    if (!(iter->index == -1 && iter->table == 0)) {
-        if (iter->safe)
-            dictResumeRehashing(iter->d);
-        else
-            assert(iter->fingerprint == dictFingerprint(iter->d));
-    }
     zfree(iter);
 }
 
@@ -637,42 +682,18 @@ void dictReleaseIterator(dictIterator *iter)
  * implement randomized algorithms */
 dictEntry *dictGetRandomKey(dict *d)
 {
-    dictEntry *he, *orighe;
-    unsigned long h;
-    int listlen, listele;
-
     if (dictSize(d) == 0) return NULL;
-    if (dictIsRehashing(d)) _dictRehashStep(d);
-    if (dictIsRehashing(d)) {
-        unsigned long s0 = DICTHT_SIZE(d->ht_size_exp[0]);
-        do {
-            /* We are sure there are no elements in indexes from 0
-             * to rehashidx-1 */
-            h = d->rehashidx + (randomULong() % (dictSlots(d) - d->rehashidx));
-            he = (h >= s0) ? d->ht_table[1][h - s0] : d->ht_table[0][h];
-        } while(he == NULL);
-    } else {
-        unsigned long m = DICTHT_SIZE_MASK(d->ht_size_exp[0]);
-        do {
-            h = randomULong() & m;
-            he = d->ht_table[0][h];
-        } while(he == NULL);
+    dictIterator iter;
+    uint64_t start = randomULong();
+    dictInitIterator(&iter, d, start);
+    dictEntry *entry = dictNext(&iter);
+    if (entry == NULL) {
+        /* wrap and start from the beginning */
+        dictInitIterator(&iter, d, 0);
+        entry = dictNext(&iter);
+        assert(entry != NULL);
     }
-
-    /* Now we found a non empty bucket, but it is a linked
-     * list and we need to get a random element from the list.
-     * The only sane way to do so is counting the elements and
-     * select a random index. */
-    listlen = 0;
-    orighe = he;
-    while(he) {
-        he = he->next;
-        listlen++;
-    }
-    listele = random() % listlen;
-    he = orighe;
-    while(listele--) he = he->next;
-    return he;
+    return entry;
 }
 
 /* This function samples the dictionary to return a few keys from random
@@ -698,72 +719,21 @@ dictEntry *dictGetRandomKey(dict *d)
  * statistics. However the function is much faster than dictGetRandomKey()
  * at producing N elements. */
 unsigned int dictGetSomeKeys(dict *d, dictEntry **des, unsigned int count) {
-    unsigned long j; /* internal hash table id, 0 or 1. */
-    unsigned long tables; /* 1 or 2 tables? */
-    unsigned long stored = 0, maxsizemask;
-    unsigned long maxsteps;
-
     if (dictSize(d) < count) count = dictSize(d);
-    maxsteps = count*10;
-
-    /* Try to do a rehashing work proportional to 'count'. */
-    for (j = 0; j < count; j++) {
-        if (dictIsRehashing(d))
-            _dictRehashStep(d);
-        else
-            break;
-    }
-
-    tables = dictIsRehashing(d) ? 2 : 1;
-    maxsizemask = DICTHT_SIZE_MASK(d->ht_size_exp[0]);
-    if (tables > 1 && maxsizemask < DICTHT_SIZE_MASK(d->ht_size_exp[1]))
-        maxsizemask = DICTHT_SIZE_MASK(d->ht_size_exp[1]);
-
-    /* Pick a random point inside the larger table. */
-    unsigned long i = randomULong() & maxsizemask;
-    unsigned long emptylen = 0; /* Continuous empty entries so far. */
-    while(stored < count && maxsteps--) {
-        for (j = 0; j < tables; j++) {
-            /* Invariant of the dict.c rehashing: up to the indexes already
-             * visited in ht[0] during the rehashing, there are no populated
-             * buckets, so we can skip ht[0] for indexes between 0 and idx-1. */
-            if (tables == 2 && j == 0 && i < (unsigned long) d->rehashidx) {
-                /* Moreover, if we are currently out of range in the second
-                 * table, there will be no elements in both tables up to
-                 * the current rehashing index, so we jump if possible.
-                 * (this happens when going from big to small table). */
-                if (i >= DICTHT_SIZE(d->ht_size_exp[1]))
-                    i = d->rehashidx;
-                else
-                    continue;
-            }
-            if (i >= DICTHT_SIZE(d->ht_size_exp[j])) continue; /* Out of range for this table. */
-            dictEntry *he = d->ht_table[j][i];
-
-            /* Count contiguous empty buckets, and jump to other
-             * locations if they reach 'count' (with a minimum of 5). */
-            if (he == NULL) {
-                emptylen++;
-                if (emptylen >= 5 && emptylen > count) {
-                    i = randomULong() & maxsizemask;
-                    emptylen = 0;
-                }
-            } else {
-                emptylen = 0;
-                while (he) {
-                    /* Collect all the elements of the buckets found non
-                     * empty while iterating. */
-                    *des = he;
-                    des++;
-                    he = he->next;
-                    stored++;
-                    if (stored == count) return stored;
-                }
-            }
+    dictIterator iter;
+    uint64_t start = randomULong();
+    dictInitIterator(&iter, d, start);
+    for (unsigned int i = 0; i < count; i++) {
+        dictEntry *entry = dictNext(&iter);
+        if (entry == NULL) {
+            /* wrap and start from the beginning */
+            dictInitIterator(&iter, d, 0);
+            entry = dictNext(&iter);
+            assert(entry != NULL);
         }
-        i = (i+1) & maxsizemask;
+        des[i] = entry;
     }
-    return stored;
+    return count;
 }
 
 /* This is like dictGetRandomKey() from the POV of the API, but will do more
@@ -790,18 +760,6 @@ dictEntry *dictGetFairRandomKey(dict *d) {
     return entries[idx];
 }
 
-/* Function to reverse bits. Algorithm from:
- * http://graphics.stanford.edu/~seander/bithacks.html#ReverseParallel */
-static unsigned long rev(unsigned long v) {
-    unsigned long s = CHAR_BIT * sizeof(v); // bit size; must be power of 2
-    unsigned long mask = ~0UL;
-    while ((s >>= 1) > 0) {
-        mask ^= (mask << s);
-        v = ((v >> s) & mask) | ((v << s) & ~mask);
-    }
-    return v;
-}
-
 /* dictScan() is used to iterate over the elements of a dictionary.
  *
  * Iterating works the following way:
@@ -821,70 +779,30 @@ static unsigned long rev(unsigned long v) {
  *
  * HOW IT WORKS.
  *
- * The iteration algorithm was designed by Pieter Noordhuis.
- * The main idea is to increment a cursor starting from the higher order
- * bits. That is, instead of incrementing the cursor normally, the bits
- * of the cursor are reversed, then the cursor is incremented, and finally
- * the bits are reversed again.
- *
- * This strategy is needed because the hash table may be resized between
- * iteration calls.
- *
- * dict.c hash tables are always power of two in size, and they
- * use chaining, so the position of an element in a given table is given
- * by computing the bitwise AND between Hash(key) and SIZE-1
- * (where SIZE-1 is always the mask that is equivalent to taking the rest
- *  of the division between the Hash of the key and SIZE).
- *
- * For example if the current hash table size is 16, the mask is
- * (in binary) 1111. The position of a key in the hash table will always be
- * the last four bits of the hash output, and so forth.
- *
- * WHAT HAPPENS IF THE TABLE CHANGES IN SIZE?
- *
- * If the hash table grows, elements can go anywhere in one multiple of
- * the old bucket: for example let's say we already iterated with
- * a 4 bit cursor 1100 (the mask is 1111 because hash table size = 16).
- *
- * If the hash table will be resized to 64 elements, then the new mask will
- * be 111111. The new buckets you obtain by substituting in ??1100
- * with either 0 or 1 can be targeted only by keys we already visited
- * when scanning the bucket 1100 in the smaller hash table.
- *
- * By iterating the higher bits first, because of the inverted counter, the
- * cursor does not need to restart if the table size gets bigger. It will
- * continue iterating using cursors without '1100' at the end, and also
- * without any other combination of the final 4 bits already explored.
- *
- * Similarly when the table size shrinks over time, for example going from
- * 16 to 8, if a combination of the lower three bits (the mask for size 8
- * is 111) were already completely explored, it would not be visited again
- * because we are sure we tried, for example, both 0111 and 1111 (all the
- * variations of the higher bit) so we don't need to test it again.
- *
- * WAIT... YOU HAVE *TWO* TABLES DURING REHASHING!
- *
- * Yes, this is true, but we always iterate the smaller table first, then
- * we test all the expansions of the current cursor into the larger
- * table. For example if the current cursor is 101 and we also have a
- * larger table of size 16, we also test (0)101 and (1)101 inside the larger
- * table. This reduces the problem back to having only one table, where
- * the larger one, if it exists, is just an expansion of the smaller one.
+ * The cursor is basically a path into the hash tree. The keys are iterated in
+ * the order of how they are stored in the hash tree, in depth first order. The
+ * 5 least significant bits of the cursor are used as an index into the first
+ * level of nodes. The next 5 bits are used an index into the next level and so
+ * forth.
  *
  * LIMITATIONS
  *
  * This iterator is completely stateless, and this is a huge advantage,
  * including no additional memory used.
  *
- * The disadvantages resulting from this design are:
+ * It also has the following nice properties:
  *
- * 1) It is possible we return elements more than once. However this is usually
- *    easy to deal with in the application level.
- * 2) The iterator must return multiple elements per call, as it needs to always
- *    return all the keys chained in a given bucket, and all the expansions, so
- *    we are sure we don't miss keys moving during rehashing.
- * 3) The reverse cursor is somewhat hard to understand at first, but this
- *    comment is supposed to help.
+ * 1) No duplicates. Each element is returned only once.
+ *
+ * 2) The iterator can usually return exactly the requested number of entries.
+ *    The exception is when there are multiple keys with exactly the same 64-bit
+ *    hash value. These are always returned together, since they correspond to
+ *    the same cursor value.
+ *
+ * The disadvantages resulting from this design is:
+ *
+ * 1) The cursor is somewhat hard to understand at first, but this comment is
+ *    supposed to help.
  */
 unsigned long dictScan(dict *d,
                        unsigned long v,
@@ -892,180 +810,29 @@ unsigned long dictScan(dict *d,
                        dictScanBucketFunction* bucketfn,
                        void *privdata)
 {
-    int htidx0, htidx1;
-    const dictEntry *de, *next;
-    unsigned long m0, m1;
-
-    if (dictSize(d) == 0) return 0;
-
-    /* This is needed in case the scan callback tries to do dictFind or alike. */
-    dictPauseRehashing(d);
-
-    if (!dictIsRehashing(d)) {
-        htidx0 = 0;
-        m0 = DICTHT_SIZE_MASK(d->ht_size_exp[htidx0]);
-
-        /* Emit entries at cursor */
-        if (bucketfn) bucketfn(privdata, &d->ht_table[htidx0][v & m0]);
-        de = d->ht_table[htidx0][v & m0];
-        while (de) {
-            next = de->next;
-            fn(privdata, de);
-            de = next;
-        }
-
-        /* Set unmasked bits so incrementing the reversed cursor
-         * operates on the masked bits */
-        v |= ~m0;
-
-        /* Increment the reverse cursor */
-        v = rev(v);
-        v++;
-        v = rev(v);
-
-    } else {
-        htidx0 = 0;
-        htidx1 = 1;
-
-        /* Make sure t0 is the smaller and t1 is the bigger table */
-        if (DICTHT_SIZE(d->ht_size_exp[htidx0]) > DICTHT_SIZE(d->ht_size_exp[htidx1])) {
-            htidx0 = 1;
-            htidx1 = 0;
-        }
-
-        m0 = DICTHT_SIZE_MASK(d->ht_size_exp[htidx0]);
-        m1 = DICTHT_SIZE_MASK(d->ht_size_exp[htidx1]);
-
-        /* Emit entries at cursor */
-        if (bucketfn) bucketfn(privdata, &d->ht_table[htidx0][v & m0]);
-        de = d->ht_table[htidx0][v & m0];
-        while (de) {
-            next = de->next;
-            fn(privdata, de);
-            de = next;
-        }
-
-        /* Iterate over indices in larger table that are the expansion
-         * of the index pointed to by the cursor in the smaller table */
-        do {
-            /* Emit entries at cursor */
-            if (bucketfn) bucketfn(privdata, &d->ht_table[htidx1][v & m1]);
-            de = d->ht_table[htidx1][v & m1];
-            while (de) {
-                next = de->next;
-                fn(privdata, de);
-                de = next;
-            }
-
-            /* Increment the reverse cursor not covered by the smaller mask.*/
-            v |= ~m1;
-            v = rev(v);
-            v++;
-            v = rev(v);
-
-            /* Continue while bits covered by mask difference is non-zero */
-        } while (v & (m0 ^ m1));
-    }
-
-    dictResumeRehashing(d);
-
-    return v;
-}
-
-/* ------------------------- private functions ------------------------------ */
-
-/* Because we may need to allocate huge memory chunk at once when dict
- * expands, we will check this allocation is allowed or not if the dict
- * type has expandAllowed member function. */
-static int dictTypeExpandAllowed(dict *d) {
-    if (d->type->expandAllowed == NULL) return 1;
-    return d->type->expandAllowed(
-                    DICTHT_SIZE(_dictNextExp(d->ht_used[0] + 1)) * sizeof(dictEntry*),
-                    (double)d->ht_used[0] / DICTHT_SIZE(d->ht_size_exp[0]));
-}
-
-/* Expand the hash table if needed */
-static int _dictExpandIfNeeded(dict *d)
-{
-    /* Incremental rehashing already in progress. Return. */
-    if (dictIsRehashing(d)) return DICT_OK;
-
-    /* If the hash table is empty expand it to the initial size. */
-    if (DICTHT_SIZE(d->ht_size_exp[0]) == 0) return dictExpand(d, DICT_HT_INITIAL_SIZE);
-
-    /* If we reached the 1:1 ratio, and we are allowed to resize the hash
-     * table (global setting) or we should avoid it but the ratio between
-     * elements/buckets is over the "safe" threshold, we resize doubling
-     * the number of buckets. */
-    if (d->ht_used[0] >= DICTHT_SIZE(d->ht_size_exp[0]) &&
-        (dict_can_resize ||
-         d->ht_used[0]/ DICTHT_SIZE(d->ht_size_exp[0]) > dict_force_resize_ratio) &&
-        dictTypeExpandAllowed(d))
-    {
-        return dictExpand(d, d->ht_used[0] + 1);
-    }
-    return DICT_OK;
-}
-
-/* TODO: clz optimization */
-/* Our hash table capability is a power of two */
-static signed char _dictNextExp(unsigned long size)
-{
-    unsigned char e = DICT_HT_INITIAL_EXP;
-
-    if (size >= LONG_MAX) return (8*sizeof(long)-1);
-    while(1) {
-        if (((unsigned long)1<<e) >= size)
-            return e;
-        e++;
-    }
-}
-
-/* Returns the index of a free slot that can be populated with
- * a hash entry for the given 'key'.
- * If the key already exists, -1 is returned
- * and the optional output parameter may be filled.
- *
- * Note that if we are in the process of rehashing the hash table, the
- * index is always returned in the context of the second (new) hash table. */
-static long _dictKeyIndex(dict *d, const void *key, uint64_t hash, dictEntry **existing)
-{
-    unsigned long idx, table;
-    dictEntry *he;
-    if (existing) *existing = NULL;
-
-    /* Expand the hash table if needed */
-    if (_dictExpandIfNeeded(d) == DICT_ERR)
-        return -1;
-    for (table = 0; table <= 1; table++) {
-        idx = hash & DICTHT_SIZE_MASK(d->ht_size_exp[table]);
-        /* Search if this slot does not already contain the given key */
-        he = d->ht_table[table][idx];
-        while(he) {
-            if (key==he->key || dictCompareKeys(d, key, he->key)) {
-                if (existing) *existing = he;
-                return -1;
-            }
-            he = he->next;
-        }
-        if (!dictIsRehashing(d)) break;
-    }
-    return idx;
+    (void)bucketfn;
+    dictIterator iter;
+    dictInitIterator(&iter, d, v);
+    unsigned long u = v;
+    do {
+        const dictEntry *de = dictNext(&iter);
+        if (de == NULL)
+            return 0;
+        fn(privdata, de);
+        u = iter.cursor;
+    } while (u == v);
+    return u;
 }
 
 void dictEmpty(dict *d, void(callback)(dict*)) {
-    _dictClear(d,0,callback);
-    _dictClear(d,1,callback);
-    d->rehashidx = -1;
-    d->pauserehash = 0;
-}
-
-void dictEnableResize(void) {
-    dict_can_resize = 1;
-}
-
-void dictDisableResize(void) {
-    dict_can_resize = 0;
+    if (d->size == 1) {
+        /* The root is an entry. */
+        dictFreeKey(d, &d->root.entry);
+        dictFreeVal(d, &d->root.entry);
+    } else if (d->size > 1) {
+        dictClearNode(d, &d->root.sub, 0, callback);
+    }
+    d->size = 0;
 }
 
 uint64_t dictGetHash(dict *d, const void *key) {
@@ -1078,102 +845,89 @@ uint64_t dictGetHash(dict *d, const void *key) {
  * no string / key comparison is performed.
  * return value is the reference to the dictEntry if found, or NULL if not found. */
 dictEntry **dictFindEntryRefByPtrAndHash(dict *d, const void *oldptr, uint64_t hash) {
-    dictEntry *he, **heref;
-    unsigned long idx, table;
-
+    (void)oldptr;
+    (void)hash;
     if (dictSize(d) == 0) return NULL; /* dict is empty */
-    for (table = 0; table <= 1; table++) {
-        idx = hash & DICTHT_SIZE_MASK(d->ht_size_exp[table]);
-        heref = &d->ht_table[table][idx];
-        he = *heref;
-        while(he) {
-            if (oldptr==he->key)
-                return heref;
-            heref = &he->next;
-            he = *heref;
-        }
-        if (!dictIsRehashing(d)) return NULL;
-    }
+    printf("FIXME dictFindEntryRefByPtrAndHash\n");
+    assert(0);
     return NULL;
+}
+
+/* Returns the estimated memory usage of the dict structure in bytes. This does
+ * NOT include additional memory allocated for keys and values.
+ *
+ * With large sizes, the root node will be close to full. So will the nodes
+ * close to the root. As a rough estimate we assume that half of the nodes, the
+ * ones far away from the root, are only half-full, thus roughly 1.5 * log32 N.
+ *
+ * (The estimate 1.28 * N given in Phil Bagwell (2000). Ideal Hash Trees,
+ * Section 3.5 "Space Used" refers to a HAMT with resizable root table.)
+ */
+size_t dictEstimateMem(dict *d) {
+    /* Rough estimate: N + 1.5 * log32(N) */
+    /* Log base conversion rule: log32(x) = log2(x) / log2(32) */
+    unsigned long numsubnodes = 1.5 * log2(d->size) / log2(32);
+    unsigned long numentries = d->size;
+    unsigned long numnodes = numentries + numsubnodes;
+    return sizeof(dict) + sizeof(union dictNode) * numnodes;
 }
 
 /* ------------------------------- Debugging ---------------------------------*/
 
-#define DICT_STATS_VECTLEN 50
-size_t _dictGetStatsHt(char *buf, size_t bufsize, dict *d, int htidx) {
-    unsigned long i, slots = 0, chainlen, maxchainlen = 0;
-    unsigned long totchainlen = 0;
-    unsigned long clvector[DICT_STATS_VECTLEN];
-    size_t l = 0;
-
-    if (d->ht_used[htidx] == 0) {
-        return snprintf(buf,bufsize,
-            "No stats available for empty dictionaries\n");
-    }
-
-    /* Compute stats. */
-    for (i = 0; i < DICT_STATS_VECTLEN; i++) clvector[i] = 0;
-    for (i = 0; i < DICTHT_SIZE(d->ht_size_exp[htidx]); i++) {
-        dictEntry *he;
-
-        if (d->ht_table[htidx][i] == NULL) {
-            clvector[0]++;
-            continue;
-        }
-        slots++;
-        /* For each hash entry on this slot... */
-        chainlen = 0;
-        he = d->ht_table[htidx][i];
-        while(he) {
-            chainlen++;
-            he = he->next;
-        }
-        clvector[(chainlen < DICT_STATS_VECTLEN) ? chainlen : (DICT_STATS_VECTLEN-1)]++;
-        if (chainlen > maxchainlen) maxchainlen = chainlen;
-        totchainlen += chainlen;
-    }
-
-    /* Generate human readable stats. */
-    l += snprintf(buf+l,bufsize-l,
-        "Hash table %d stats (%s):\n"
-        " table size: %lu\n"
-        " number of elements: %lu\n"
-        " different slots: %lu\n"
-        " max chain length: %lu\n"
-        " avg chain length (counted): %.02f\n"
-        " avg chain length (computed): %.02f\n"
-        " Chain length distribution:\n",
-        htidx, (htidx == 0) ? "main hash table" : "rehashing target",
-        DICTHT_SIZE(d->ht_size_exp[htidx]), d->ht_used[htidx], slots, maxchainlen,
-        (float)totchainlen/slots, (float)d->ht_used[htidx]/slots);
-
-    for (i = 0; i < DICT_STATS_VECTLEN-1; i++) {
-        if (clvector[i] == 0) continue;
-        if (l >= bufsize) break;
-        l += snprintf(buf+l,bufsize-l,
-            "   %s%ld: %ld (%.02f%%)\n",
-            (i == DICT_STATS_VECTLEN-1)?">= ":"",
-            i, clvector[i], ((float)clvector[i]/DICTHT_SIZE(d->ht_size_exp[htidx]))*100);
-    }
-
-    /* Unlike snprintf(), return the number of characters actually written. */
+/* Ideas for stats: Store the total number of subnodes in the dict. Then the
+ * total allocation size can be computed using dict size. */
+void dictGetStats(char *buf, size_t bufsize, dict *d) {
+    (void)d;
+    snprintf(buf, bufsize, "Stats for HAMT not implemented");
+    /* Make sure there is a NULL term at the end. */
     if (bufsize) buf[bufsize-1] = '\0';
-    return strlen(buf);
 }
 
-void dictGetStats(char *buf, size_t bufsize, dict *d) {
-    size_t l;
-    char *orig_buf = buf;
-    size_t orig_bufsize = bufsize;
-
-    l = _dictGetStatsHt(buf,bufsize,d,0);
-    buf += l;
-    bufsize -= l;
-    if (dictIsRehashing(d) && bufsize > 0) {
-        _dictGetStatsHt(buf,bufsize,d,1);
+/* Helper for dictDump(). */
+void dictDumpSub(dictSubNode *node, int level) {
+    for (int childbit = 0; childbit < 32; childbit++) {
+        if (!child_exists(node, childbit)) continue;
+        int childindex = child_index(node, childbit);
+        if (child_is_entry(node, childbit)) {
+            dictEntry *entry = &node->children[childindex].entry;
+            printf("%*s%02d \"%s\"\n", level*3, "", childbit, (char*)entry->key);
+        } else {
+            printf("%*s%02d\n", level*3, "", childbit);
+            dictDumpSub(&node->children[childindex].sub, level + 1);
+        }
     }
-    /* Make sure there is a NULL term at the end. */
-    if (orig_bufsize) orig_buf[orig_bufsize-1] = '\0';
+}
+
+/* Prints a dict as a tree with node indices. Keys must be strings. */
+void dictDump(dict *d) {
+    if (d->size == 0)
+        printf("00 (empty)\n");
+    else if (d->size == 1)
+        printf("00 \"%s\"\n", (char*)d->root.entry.key);
+    else
+        dictDumpSub(&d->root.sub, 0);
+}
+
+/* Prints a cursor as a path of 5-bit indices into the tree. */
+void dictDumpCursor(uint64_t c) {
+    printf("cursor:");
+    while (c) {
+        printf("/%d", (int)(c & 0x1f));
+        c = c >> 5;
+    }
+}
+
+/* Prints all keys on a single line using an iterator. Keys must be strings. */
+void dictPrintAll(dict *d) {
+    dictIterator iter;
+    dictInitIterator(&iter, d, 0);
+    printf("Dict keys:");
+    for (;;) {
+        dictEntry *e = dictNext(&iter);
+        if (e == NULL) break;
+        printf(" %s", (char*)e->key);
+    }
+    printf("\n");
 }
 
 /* ------------------------------- Benchmark ---------------------------------*/

--- a/src/dict.h
+++ b/src/dict.h
@@ -52,56 +52,54 @@ typedef struct dictEntry {
         int64_t s64;
         double d;
     } v;
-    struct dictEntry *next;
 } dictEntry;
 
 typedef struct dict dict;
 
 typedef struct dictType {
-    uint64_t (*hashFunction)(const void *key);
+    uint64_t (*hashFunction)(const void *key); /* TODO: add level? */
     void *(*keyDup)(dict *d, const void *key);
     void *(*valDup)(dict *d, const void *obj);
     int (*keyCompare)(dict *d, const void *key1, const void *key2);
     void (*keyDestructor)(dict *d, void *key);
     void (*valDestructor)(dict *d, void *obj);
-    int (*expandAllowed)(size_t moreMem, double usedRatio);
+    int (*expandAllowed)(size_t moreMem, double usedRatio); /* DELETEME */
 } dictType;
 
-#define DICTHT_SIZE(exp) ((exp) == -1 ? 0 : (unsigned long)1<<(exp))
-#define DICTHT_SIZE_MASK(exp) ((exp) == -1 ? 0 : (DICTHT_SIZE(exp))-1)
+/* The internal dict structure: a HAMT (see dict.c for details). */
+
+union dictNode; /* leaf or internal node */
+
+/* Internal node (same size as dictEntry) */
+typedef struct dictSubNode {
+    uint32_t bitmap;  /* exitence of potential child */
+    uint32_t leafmap; /* child is 1=leaf or 0=subnode */
+    union dictNode *children;
+} dictSubNode;
+
+/* The parent node contains a 'leafmap', which has a bit for each child to flag
+ * it as 1 = entry or 0 = subnode. */
+union dictNode {
+    dictEntry entry;
+    dictSubNode sub;
+};
 
 struct dict {
     dictType *type;
-
-    dictEntry **ht_table[2];
-    unsigned long ht_used[2];
-
-    long rehashidx; /* rehashing not in progress if rehashidx == -1 */
-
-    /* Keep small vars at end for optimal (minimal) struct padding */
-    int16_t pauserehash; /* If >0 rehashing is paused (<0 indicates coding error) */
-    signed char ht_size_exp[2]; /* exponent of size. (size = 1<<exp) */
+    unsigned long size; /* total num keys */
+    union dictNode root;
 };
 
-/* If safe is set to 1 this is a safe iterator, that means, you can call
- * dictAdd, dictFind, and other functions against the dictionary even while
- * iterating. Otherwise it is a non safe iterator, and only dictNext()
- * should be called while iterating. */
+/* It is safe to call dictAdd, dictFind, and other functions against the
+ * dictionary even while iterating. */
 typedef struct dictIterator {
     dict *d;
-    long index;
-    int table, safe;
-    dictEntry *entry, *nextEntry;
-    /* unsafe iterator fingerprint for misuse detection. */
-    long long fingerprint;
+    uint64_t cursor;
+    /* TODO: Add counter for elements with the exact same cursor (hash) */
 } dictIterator;
 
 typedef void (dictScanFunction)(void *privdata, const dictEntry *de);
 typedef void (dictScanBucketFunction)(void *privdata, dictEntry **bucketref);
-
-/* This is the initial size of every hash table */
-#define DICT_HT_INITIAL_EXP      2
-#define DICT_HT_INITIAL_SIZE     (1<<(DICT_HT_INITIAL_EXP))
 
 /* ------------------------------- Macros ------------------------------------*/
 #define dictFreeVal(d, entry) \
@@ -146,11 +144,11 @@ typedef void (dictScanBucketFunction)(void *privdata, dictEntry **bucketref);
 #define dictGetSignedIntegerVal(he) ((he)->v.s64)
 #define dictGetUnsignedIntegerVal(he) ((he)->v.u64)
 #define dictGetDoubleVal(he) ((he)->v.d)
-#define dictSlots(d) (DICTHT_SIZE((d)->ht_size_exp[0])+DICTHT_SIZE((d)->ht_size_exp[1]))
-#define dictSize(d) ((d)->ht_used[0]+(d)->ht_used[1])
-#define dictIsRehashing(d) ((d)->rehashidx != -1)
-#define dictPauseRehashing(d) (d)->pauserehash++
-#define dictResumeRehashing(d) (d)->pauserehash--
+#define dictSize(d) ((d)->size)
+#define dictIsRehashing(d) 0 /* DELETEME */
+#define dictPauseRehashing(d) 0 /* DELETEME */
+#define dictResumeRehashing(d) 0 /* DELETEME */
+#define dictIteratorCursor(it) ((it)->cursor)
 
 /* If our unsigned long type can store a 64 bit number, use a 64 bit PRNG. */
 #if ULONG_MAX >= 0xffffffffffffffff
@@ -161,8 +159,8 @@ typedef void (dictScanBucketFunction)(void *privdata, dictEntry **bucketref);
 
 /* API */
 dict *dictCreate(dictType *type);
-int dictExpand(dict *d, unsigned long size);
-int dictTryExpand(dict *d, unsigned long size);
+static inline int dictExpand(dict* d, unsigned long size);
+static inline int dictTryExpand(dict* d, unsigned long size);
 int dictAdd(dict *d, void *key, void *val);
 dictEntry *dictAddRaw(dict *d, void *key, dictEntry **existing);
 dictEntry *dictAddOrFind(dict *d, void *key);
@@ -173,9 +171,10 @@ void dictFreeUnlinkedEntry(dict *d, dictEntry *he);
 void dictRelease(dict *d);
 dictEntry * dictFind(dict *d, const void *key);
 void *dictFetchValue(dict *d, const void *key);
-int dictResize(dict *d);
+static inline int dictResize(dict *d);
 dictIterator *dictGetIterator(dict *d);
 dictIterator *dictGetSafeIterator(dict *d);
+void dictInitIterator(dictIterator *iter, dict *d, uint64_t cursor);
 dictEntry *dictNext(dictIterator *iter);
 void dictReleaseIterator(dictIterator *iter);
 dictEntry *dictGetRandomKey(dict *d);
@@ -185,18 +184,35 @@ void dictGetStats(char *buf, size_t bufsize, dict *d);
 uint64_t dictGenHashFunction(const void *key, int len);
 uint64_t dictGenCaseHashFunction(const unsigned char *buf, int len);
 void dictEmpty(dict *d, void(callback)(dict*));
-void dictEnableResize(void);
-void dictDisableResize(void);
-int dictRehash(dict *d, int n);
-int dictRehashMilliseconds(dict *d, int ms);
+#define dictEnableResize(d) ((void)0)
+#define dictDisableResize(d) ((void)0)
+#define dictRehash(d, n) 0
+#define dictRehashMilliseconds(d, ms) 0
 void dictSetHashFunctionSeed(uint8_t *seed);
 uint8_t *dictGetHashFunctionSeed(void);
 unsigned long dictScan(dict *d, unsigned long v, dictScanFunction *fn, dictScanBucketFunction *bucketfn, void *privdata);
 uint64_t dictGetHash(dict *d, const void *key);
 dictEntry **dictFindEntryRefByPtrAndHash(dict *d, const void *oldptr, uint64_t hash);
+size_t dictEstimateMem(dict *d);
 
 #ifdef REDIS_TEST
 int dictTest(int argc, char *argv[], int accurate);
 #endif
+
+/* inline functions (to be deleted) */
+static inline int dictExpand(dict* d, unsigned long size) {
+    (void)d;
+    (void)size;
+    return DICT_OK;
+}
+static inline int dictTryExpand(dict* d, unsigned long size) {
+    (void)d;
+    (void)size;
+    return DICT_OK;
+}
+static inline int dictResize(dict *d) {
+    (void)d;
+    return DICT_OK;
+}
 
 #endif /* __DICT_H */

--- a/src/expire.c
+++ b/src/expire.c
@@ -198,7 +198,7 @@ void activeExpireCycle(int type) {
          * we scanned. The percentage, stored in config_cycle_acceptable_stale
          * is not fixed, but depends on the Redis configured "expire effort". */
         do {
-            unsigned long num, slots;
+            unsigned long num;
             long long now, ttl_sum;
             int ttl_samples;
             iteration++;
@@ -208,14 +208,7 @@ void activeExpireCycle(int type) {
                 db->avg_ttl = 0;
                 break;
             }
-            slots = dictSlots(db->expires);
             now = mstime();
-
-            /* When there are less than 1% filled slots, sampling the key
-             * space is expensive, so stop here waiting for better times...
-             * The dictionary will be resized asap. */
-            if (slots > DICT_HT_INITIAL_SIZE &&
-                (num*100/slots < 1)) break;
 
             /* The main collection cycle. Sample random keys among keys
              * with an expire set, checking for expired ones. */
@@ -240,36 +233,28 @@ void activeExpireCycle(int type) {
             long max_buckets = num*20;
             long checked_buckets = 0;
 
+            dictIterator expires_iter;
+            dictInitIterator(&expires_iter, db->expires, db->expires_cursor);
             while (sampled < num && checked_buckets < max_buckets) {
-                for (int table = 0; table < 2; table++) {
-                    if (table == 1 && !dictIsRehashing(db->expires)) break;
 
-                    unsigned long idx = db->expires_cursor;
-                    idx &= DICTHT_SIZE_MASK(db->expires->ht_size_exp[table]);
-                    dictEntry *de = db->expires->ht_table[table][idx];
-                    long long ttl;
+                dictEntry *de = dictNext(&expires_iter);
+                if (de == NULL) break;
+                long long ttl;
 
-                    /* Scan the current bucket of the current table. */
-                    checked_buckets++;
-                    while(de) {
-                        /* Get the next entry now since this entry may get
-                         * deleted. */
-                        dictEntry *e = de;
-                        de = de->next;
+                /* Scan the current bucket of the current table. */
+                checked_buckets++;
 
-                        ttl = dictGetSignedIntegerVal(e)-now;
-                        if (activeExpireCycleTryExpire(db,e,now)) expired++;
-                        if (ttl > 0) {
-                            /* We want the average TTL of keys yet
-                             * not expired. */
-                            ttl_sum += ttl;
-                            ttl_samples++;
-                        }
-                        sampled++;
-                    }
+                ttl = dictGetSignedIntegerVal(de)-now;
+                if (activeExpireCycleTryExpire(db,de,now)) expired++;
+                if (ttl > 0) {
+                    /* We want the average TTL of keys yet
+                     * not expired. */
+                    ttl_sum += ttl;
+                    ttl_samples++;
                 }
-                db->expires_cursor++;
+                sampled++;
             }
+            db->expires_cursor = dictIteratorCursor(&expires_iter);
             total_expired += expired;
             total_sampled += sampled;
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1576,11 +1576,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             o = createSetObject();
             /* It's faster to expand the dict to the right size asap in order
              * to avoid rehashing */
-            if (len > DICT_HT_INITIAL_SIZE && dictTryExpand(o->ptr,len) != DICT_OK) {
-                rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)len);
-                decrRefCount(o);
-                return NULL;
-            }
+            /* if (len > DICT_HT_INITIAL_SIZE && dictTryExpand(o->ptr,len) != DICT_OK) { */
+            /*     rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)len); */
+            /*     decrRefCount(o); */
+            /*     return NULL; */
+            /* } */
         } else {
             o = createIntsetObject();
         }
@@ -1642,11 +1642,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
         o = createZsetObject();
         zs = o->ptr;
 
-        if (zsetlen > DICT_HT_INITIAL_SIZE && dictTryExpand(zs->dict,zsetlen) != DICT_OK) {
-            rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)zsetlen);
-            decrRefCount(o);
-            return NULL;
-        }
+        /* if (zsetlen > DICT_HT_INITIAL_SIZE && dictTryExpand(zs->dict,zsetlen) != DICT_OK) { */
+        /*     rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)zsetlen); */
+        /*     decrRefCount(o); */
+        /*     return NULL; */
+        /* } */
 
         /* Load every single element of the sorted set. */
         while(zsetlen--) {
@@ -1766,13 +1766,13 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             dupSearchDict = NULL;
         }
 
-        if (o->encoding == OBJ_ENCODING_HT && len > DICT_HT_INITIAL_SIZE) {
-            if (dictTryExpand(o->ptr,len) != DICT_OK) {
-                rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)len);
-                decrRefCount(o);
-                return NULL;
-            }
-        }
+        /* if (o->encoding == OBJ_ENCODING_HT && len > DICT_HT_INITIAL_SIZE) { */
+        /*     if (dictTryExpand(o->ptr,len) != DICT_OK) { */
+        /*         rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)len); */
+        /*         decrRefCount(o); */
+        /*         return NULL; */
+        /*     } */
+        /* } */
 
         /* Load remaining fields and values into the hash table */
         while (o->encoding == OBJ_ENCODING_HT && len > 0) {

--- a/src/server.c
+++ b/src/server.c
@@ -1545,21 +1545,14 @@ dictType replScriptCacheDictType = {
 };
 
 int htNeedsResize(dict *dict) {
-    long long size, used;
-
-    size = dictSlots(dict);
-    used = dictSize(dict);
-    return (size > DICT_HT_INITIAL_SIZE &&
-            (used*100/size < HASHTABLE_MIN_FILL));
+    UNUSED(dict);
+    return 0;
 }
 
 /* If the percentage of used slots in the HT reaches HASHTABLE_MIN_FILL
  * we resize the hash table to save memory */
 void tryResizeHashTables(int dbid) {
-    if (htNeedsResize(server.db[dbid].dict))
-        dictResize(server.db[dbid].dict);
-    if (htNeedsResize(server.db[dbid].expires))
-        dictResize(server.db[dbid].expires);
+    UNUSED(dbid);
 }
 
 /* Our hash table implementation performs rehashing incrementally while
@@ -1570,16 +1563,7 @@ void tryResizeHashTables(int dbid) {
  * The function returns 1 if some rehashing was performed, otherwise 0
  * is returned. */
 int incrementallyRehash(int dbid) {
-    /* Keys dictionary */
-    if (dictIsRehashing(server.db[dbid].dict)) {
-        dictRehashMilliseconds(server.db[dbid].dict,1);
-        return 1; /* already used our millisecond for this loop... */
-    }
-    /* Expires */
-    if (dictIsRehashing(server.db[dbid].expires)) {
-        dictRehashMilliseconds(server.db[dbid].expires,1);
-        return 1; /* already used our millisecond for this loop... */
-    }
+    UNUSED(dbid);
     return 0;
 }
 
@@ -2119,7 +2103,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
             for (j = 0; j < server.dbnum; j++) {
                 long long size, used, vkeys;
 
-                size = dictSlots(server.db[j].dict);
+                size =
                 used = dictSize(server.db[j].dict);
                 vkeys = dictSize(server.db[j].expires);
                 if (used || vkeys) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1155,7 +1155,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         while (size > count) {
             dictEntry *de;
             de = dictGetRandomKey(d);
-            dictUnlink(d,dictGetKey(de));
+            de = dictUnlink(d,dictGetKey(de));
             sdsfree(dictGetKey(de));
             sdsfree(dictGetVal(de));
             dictFreeUnlinkedEntry(d,de);

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -757,7 +757,7 @@ void srandmemberWithCountCommand(client *c) {
         while (size > count) {
             dictEntry *de;
             de = dictGetRandomKey(d);
-            dictUnlink(d,dictGetKey(de));
+            de = dictUnlink(d,dictGetKey(de));
             sdsfree(dictGetKey(de));
             dictFreeUnlinkedEntry(d,de);
             size--;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4125,7 +4125,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         while (size > count) {
             dictEntry *de;
             de = dictGetRandomKey(d);
-            dictUnlink(d,dictGetKey(de));
+            de = dictUnlink(d,dictGetKey(de));
             sdsfree(dictGetKey(de));
             dictFreeUnlinkedEntry(d,de);
             size--;


### PR DESCRIPTION
A drop-in replacement of the hash tables in dict, affecting the key space and all other uses of the dict. Fixes #8698.

Status: It's working-ish. The the dict tests are passing, but the Redis test suites are not passing. Most tests are passing ocationally but Redis seems to hang at various times until it's killed by the test runner. Debugging help is most welcome.

The dict in hiredis gets it's function names prefixed with `hi_` to avoid collisions. This needs to be done upstream in hiredis...

Performance comparison
-----------------------------

Comparison using `./redis-server test dict 10000000` (compiled using `make
CFLAGS=-DREDIS_TEST`) on my laptop (64-bit Linux, 32G RAM).

Classic dict:

    Inserting: 10000000 items in 4746 ms
    Linear access of existing elements: 10000000 items in 2474 ms
    Linear access of existing elements (2nd round): 10000000 items in 2459 ms
    Random access of existing elements: 10000000 items in 3726 ms
    Accessing random keys: 10000000 items in 1287 ms
    Accessing missing: 10000000 items in 2638 ms
    Removing and adding: 10000000 items in 4516 ms

HAMT:

    Inserting: 10000000 items in 3253 ms
    Linear access of existing elements: 10000000 items in 2793 ms
    Linear access of existing elements (2nd round): 10000000 items in 2805 ms
    Random access of existing elements: 10000000 items in 3676 ms
    Accessing random keys: 10000000 items in 1103 ms
    Accessing missing: 10000000 items in 2240 ms
    Removing and adding: 10000000 items in 6467 ms

Structure
---------

```
+--------------------+
| dict               |
|--------------------|   +--------------------+   +--------------------+
| bitmaps | children---->| bitmaps | children---->| key     | value    |
| size               |   | key     | value    |   | ...     | ...      |
| dictType           |   | key     | value    |   +--------------------+
| privdata           |   | key     | value    |
+--------------------+   | key     | value    |   +--------------------+
                         | bitmaps | children---->| key     | value    |
                         | key     | value    |   | bitmaps | children--->..
                         | ...     | ...      |   | value   | key      |
                         +--------------------+   | ...     | ...      |
                                                  +--------------------+
```

In each level, 5 bits of the hash is used as an index into the children. A
bitmap indicates which of the children exist (1) and which don't (0). Whether
the child is a leaf or a subnode is indicated by a second bitmap, "leafmap".

```
hash(key) = 0010 10010 01011 00101 01001 10110 11101
(64 bits)   10101 11001 01001 01101 10111 11010
                                          ^^^^^
                                            26

bitmap    = 00100101 00000010 00010100 01100001
(level 0)        ^
                 bit 26 is 1, so there is a child node or leaf

leafmap   = 00000100 00000010 00010000 01100000
(level 0)        ^
                 bit 26 is 1, so the child is a key-value entry
```

The children array is compact and its length is equal to the number of 1s in
the bitmap. In the bitmap above, our bit is the 2nd 1-bit from the left, so
we look at the 2nd child.

```
children  = +--------------------+
            | bitmaps | children |
            | key     | value    | <-- The 2nd child is a key-value entry. If
            | bitmaps | children |     the key matches our key, then it's our
            | ...     | ...      |     key. Otherwise, the dict doesn't
            +--------------------+     contain our key.
```

If, instead, our child is a subnode, we use the next 5 bits from the hash to
index into the next level of children.

The classic dict has this structure:

```
+------+
| dict |
|------|    +-------+     +-------+       +----------+
| ht[0]---->| slot ------>| key   |   ,-->| key      |
| ...  |    | NULL  |     | value |  /    | value    |
+------+    | slot  |     | next----'     | next=NULL|
            | ...   |     +-------+       +----------+
            +-------+
```

Memory comparison: The classic dict has an entry pointer for every slot and a
'next' pointer in every entry. The HAMT stores the entries within the nodes, so
the only overhead is the subnode pointers and the bitmaps for each subnode. The
number of subnodes is logarithmic to the number of keys.

Possible improvements
---------------------

To increase speed for large HAMTs, a possible optimization is to resize the root
table. This can be done incrementally and without rehashing the keys, so it's
much faster than resizing a regular hash table. It's explained in the paper.
It's not implemented (yet) and the performance comparision above is done without
this optimization.
