### PR TITLE
[Sentinel] sentinelFlushConfig avoid close to overwrite original errno

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2314,8 +2314,8 @@ void sentinelFlushConfig(void) {
     return;
 
 werr:
-    if (fd != -1) close(fd);
     serverLog(LL_WARNING,"WARNING: Sentinel was not able to save the new configuration on disk!!!: %s", strerror(errno));
+    if (fd != -1) close(fd);
 }
 
 /* ====================== hiredis connection handling ======================= */


### PR DESCRIPTION
In sentinelFlushConfig function, we should call close after logging the error in order to avoid it overwrite the original errno.