### PR TITLE
Update redis conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -148,7 +148,7 @@ tcp-keepalive 300
 # server to connected clients, masters or cluster peers.  These files should be
 # PEM formatted.
 #
-# tls-cert-file redis.crt 
+# tls-cert-file redis.crt
 # tls-key-file redis.key
 #
 # If the key file is encrypted using a passphrase, it can be included here
@@ -860,8 +860,8 @@ replica-priority 100
 # ACL LOG
 #
 # The ACL Log tracks failed commands and authentication events associated
-# with ACLs. The ACL Log is useful to troubleshoot failed commands blocked 
-# by ACLs. The ACL Log is stored in memory. You can reclaim memory with 
+# with ACLs. The ACL Log is useful to troubleshoot failed commands blocked
+# by ACLs. The ACL Log is stored in memory. You can reclaim memory with
 # ACL LOG RESET. Define the maximum entry length of the ACL Log below.
 acllog-max-len 128
 
@@ -891,7 +891,7 @@ acllog-max-len 128
 # New users are initialized with restrictive permissions by default, via the
 # equivalent of this ACL rule 'off resetkeys -@all'. Starting with Redis 6.2, it
 # is possible to manage access to Pub/Sub channels with ACL rules as well. The
-# default Pub/Sub channels permission if new users is controlled by the 
+# default Pub/Sub channels permission if new users is controlled by the
 # acl-pubsub-default configuration directive, which accepts one of these values:
 #
 # allchannels: grants access to all Pub/Sub channels
@@ -1021,7 +1021,7 @@ acllog-max-len 128
 
 # Eviction processing is designed to function well with the default setting.
 # If there is an unusually large amount of write traffic, this value may need to
-# be increased.  Decreasing this value may reduce latency at the risk of 
+# be increased.  Decreasing this value may reduce latency at the risk of
 # eviction processing effectiveness
 #   0 = minimum latency, 10 = default, 100 = process without regard to latency
 #
@@ -1474,18 +1474,18 @@ lua-time-limit 5000
 # cluster-replica-no-failover no
 
 # This option, when set to yes, allows nodes to serve read traffic while the
-# the cluster is in a down state, as long as it believes it owns the slots. 
+# the cluster is in a down state, as long as it believes it owns the slots.
 #
-# This is useful for two cases.  The first case is for when an application 
+# This is useful for two cases.  The first case is for when an application
 # doesn't require consistency of data during node failures or network partitions.
 # One example of this is a cache, where as long as the node has the data it
-# should be able to serve it. 
+# should be able to serve it.
 #
-# The second use case is for configurations that don't meet the recommended  
-# three shards but want to enable cluster mode and scale later. A 
+# The second use case is for configurations that don't meet the recommended
+# three shards but want to enable cluster mode and scale later. A
 # master outage in a 1 or 2 shard configuration causes a read/write outage to the
 # entire cluster without this option set, with it set there is only a write outage.
-# Without a quorum of masters, slot ownership will not change automatically. 
+# Without a quorum of masters, slot ownership will not change automatically.
 #
 # cluster-allow-reads-when-down no
 

--- a/redis.conf
+++ b/redis.conf
@@ -883,7 +883,7 @@ acllog-max-len 128
 # AUTH <password> as usually, or more explicitly with AUTH default <password>
 # if they follow the new protocol: both will work.
 #
-# The requirepass is not compatable with aclfile option and the ACL LOAD
+# The requirepass is not compatible with aclfile option and the ACL LOAD
 # command, these will cause requirepass to be ignored.
 #
 # requirepass foobared


### PR DESCRIPTION
This PR updates the redis.conf by:

1. Removing trailing white space
2. Fixing a typo in `compatable`.