### PR TITLE
Use chi-square for random distributivity verification in test

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -686,21 +686,30 @@ proc string2printable s {
 # we can verify the random distribution sample confidence.
 # Based on the following wiki:
 # https://en.wikipedia.org/wiki/Chi-square_distribution
+#
+# param res    Random sample list
+# return       Value of Chi-Square Distribution
+#
+# x2_value: return of chi_square_value function
+# df: Degrees of freedom, Number of independent values minus 1
+#
+# By using x2_value and df to back check the cardinality table,
+# we can know the confidence of the random sample.
 proc chi_square_value {res} {
     unset -nocomplain mydict
     foreach key $res {
         dict incr mydict $key 1
     }
 
-    set chi_square_sum 0
+    set x2_value 0
     set p [expr [llength $res] / [dict size $mydict]]
     foreach key [dict keys $mydict] {
         set value [dict get $mydict $key]
 
         # Aggregate the chi-square value of each element
         set v [expr {pow($value - $p, 2) / $p}]
-        set chi_square_sum [expr {$chi_square_sum + $v}]
+        set x2_value [expr {$x2_value + $v}]
     }
 
-    return $chi_square_sum
+    return $x2_value
 }

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -682,36 +682,19 @@ proc string2printable s {
     return $res
 }
 
-# Two validation methods are used here to verify the reasonableness
-# of the random distribution.
-# 1) Check that probability of each element are between {min_prop} and {max_prop}.
-# 2) Check with Chi-Square Distribution. Based on the following wiki:
-#    https://en.wikipedia.org/wiki/Chi-square_distribution
-proc check_histogram_distribution {res min_prop max_prop chi_square_max_value} {
+# Check that probability of each element are between {min_prop} and {max_prop}.
+proc check_histogram_distribution {res min_prop max_prop} {
     unset -nocomplain mydict
     foreach key $res {
         dict incr mydict $key 1
     }
 
-    set check_prop_result true
-    set chi_square_value 0
-    set p [expr [llength $res] / [dict size $mydict]]
     foreach key [dict keys $mydict] {
         set value [dict get $mydict $key]
-
-        # Check probability of each element
         set probability [expr {double($value) / [llength $res]}]
         if {$probability < $min_prop || $probability > $max_prop} {
-            set check_prop_result false
+            return false
         }
-
-        # Aggregate the chi-square value of each element
-        set v [expr {pow($value - $p, 2) / $p}]
-        set chi_square_value [expr {$chi_square_value + $v}]
-    }
-
-    if {!$check_prop_result && $chi_square_value < $chi_square_max_value} {
-        return false
     }
 
     return true

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -682,20 +682,25 @@ proc string2printable s {
     return $res
 }
 
-# Check that probability of each element are between {min_prop} and {max_prop}.
-proc check_histogram_distribution {res min_prop max_prop} {
+# Calculation value of Chi-Square Distribution. By this value
+# we can verify the random distribution sample confidence.
+# Based on the following wiki:
+# https://en.wikipedia.org/wiki/Chi-square_distribution
+proc chi_square_value {res} {
     unset -nocomplain mydict
     foreach key $res {
         dict incr mydict $key 1
     }
 
+    set chi_square_sum 0
+    set p [expr [llength $res] / [dict size $mydict]]
     foreach key [dict keys $mydict] {
         set value [dict get $mydict $key]
-        set probability [expr {double($value) / [llength $res]}]
-        if {$probability < $min_prop || $probability > $max_prop} {
-            return false
-        }
+
+        # Aggregate the chi-square value of each element
+        set v [expr {pow($value - $p, 2) / $p}]
+        set chi_square_sum [expr {$chi_square_sum + $v}]
     }
 
-    return true
+    return $chi_square_sum
 }

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -106,7 +106,7 @@ start_server {tags {"hash"}} {
 
             # Test random uniform distribution
             set res [r hrandfield myhash -1000]
-            assert_equal [check_histogram_distribution $res 0.05 0.15] true
+            assert_equal [check_histogram_distribution $res 0.05 0.15 27.88] true
 
             # 2) Check that all the elements actually belong to the original hash.
             foreach {key val} $res {
@@ -199,7 +199,7 @@ start_server {tags {"hash"}} {
                     }
                 }
                 assert_equal $all_ele_return true
-                assert_equal [check_histogram_distribution $allkey 0.05 0.15] true
+                assert_equal [check_histogram_distribution $allkey 0.05 0.15 27.88] true
             }
         }
         r config set hash-max-ziplist-value $original_max_value

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -106,7 +106,7 @@ start_server {tags {"hash"}} {
 
             # Test random uniform distribution
             set res [r hrandfield myhash -1000]
-            assert_equal [check_histogram_distribution $res 0.05 0.15 27.88] true
+            assert_equal [check_histogram_distribution $res 0.05 0.15] true
 
             # 2) Check that all the elements actually belong to the original hash.
             foreach {key val} $res {
@@ -199,7 +199,7 @@ start_server {tags {"hash"}} {
                     }
                 }
                 assert_equal $all_ele_return true
-                assert_equal [check_histogram_distribution $allkey 0.05 0.15 27.88] true
+                assert_equal [check_histogram_distribution $allkey 0.05 0.15] true
             }
         }
         r config set hash-max-ziplist-value $original_max_value

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -107,7 +107,7 @@ start_server {tags {"hash"}} {
             # Test random uniform distribution
             # df = 9, 40 means 0.00001 probability
             set res [r hrandfield myhash -1000]
-            assert_morethan 40 [chi_square_value $res] 
+            assert_morethan 40 [chi_square_value $res]
 
             # 2) Check that all the elements actually belong to the original hash.
             foreach {key val} $res {

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -105,8 +105,15 @@ start_server {tags {"hash"}} {
             assert_equal [llength $res] 2002
 
             # Test random uniform distribution
-            set res [r hrandfield myhash -1000]
-            assert_equal [check_histogram_distribution $res 0.05 0.15] true
+            set iterations 2
+            while {$iterations != 0} {
+                incr iterations -1
+                set res [r hrandfield myhash -1000]
+                if {[check_histogram_distribution $res 0.05 0.15] == true} {
+                    break
+                }
+            }
+            assert {$iterations != 0}
 
             # 2) Check that all the elements actually belong to the original hash.
             foreach {key val} $res {
@@ -174,32 +181,39 @@ start_server {tags {"hash"}} {
 
                 # 2) Check that eventually all the elements are returned.
                 #    Use both WITHVALUES and without
-                unset -nocomplain auxset
-                unset -nocomplain allkey
-                set iterations [expr {1000 / $size}]
-                set all_ele_return false
-                while {$iterations != 0} {
-                    incr iterations -1
-                    if {[expr {$iterations % 2}] == 0} {
-                        set res [r hrandfield myhash $size withvalues]
-                        foreach {key value} $res {
-                            dict append auxset $key $value
-                            lappend allkey $key
+                set retry 2
+                while {$retry != 0} {
+                    incr retry -1
+                    unset -nocomplain auxset
+                    unset -nocomplain allkey
+                    set iterations [expr {1000 / $size}]
+                    set all_ele_return false
+                    while {$iterations != 0} {
+                        incr iterations -1
+                        if {[expr {$iterations % 2}] == 0} {
+                            set res [r hrandfield myhash $size withvalues]
+                            foreach {key value} $res {
+                                dict append auxset $key $value
+                                lappend allkey $key
+                            }
+                        } else {
+                            set res [r hrandfield myhash $size]
+                            foreach key $res {
+                                dict append auxset $key
+                                lappend allkey $key
+                            }
                         }
-                    } else {
-                        set res [r hrandfield myhash $size]
-                        foreach key $res {
-                            dict append auxset $key
-                            lappend allkey $key
+                        if {[lsort [dict keys $mydict]] eq
+                            [lsort [dict keys $auxset]]} {
+                            set all_ele_return true
                         }
                     }
-                    if {[lsort [dict keys $mydict]] eq
-                        [lsort [dict keys $auxset]]} {
-                        set all_ele_return true
+                    assert_equal $all_ele_return true
+                    if {[check_histogram_distribution $allkey 0.05 0.15] == true} {
+                        break
                     }
                 }
-                assert_equal $all_ele_return true
-                assert_equal [check_histogram_distribution $allkey 0.05 0.15] true
+                assert {$retry != 0}
             }
         }
         r config set hash-max-ziplist-value $original_max_value

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -200,13 +200,8 @@ start_server {tags {"hash"}} {
                     }
                 }
                 assert_equal $all_ele_return true
-                if {$size == 8} {
-                    # df = 7, 35 means 0.00001 probability
-                    assert_morethan 35 [chi_square_value $allkey]
-                } elseif {$size == 2} {
-                    # df = 1, 19 means 0.00001 probability
-                    assert_morethan 19 [chi_square_value $allkey]
-                }
+                # df = 9, 40 means 0.00001 probability
+                assert_morethan 40 [chi_square_value $allkey]
             }
         }
         r config set hash-max-ziplist-value $original_max_value

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -107,7 +107,7 @@ start_server {tags {"hash"}} {
             # Test random uniform distribution
             # df = 9, 40 means 0.00001 probability
             set res [r hrandfield myhash -1000]
-            assert_morethan 40 [chi_square_value $res]
+            assert_lessthan [chi_square_value $res] 40
 
             # 2) Check that all the elements actually belong to the original hash.
             foreach {key val} $res {
@@ -201,7 +201,7 @@ start_server {tags {"hash"}} {
                 }
                 assert_equal $all_ele_return true
                 # df = 9, 40 means 0.00001 probability
-                assert_morethan 40 [chi_square_value $allkey]
+                assert_lessthan [chi_square_value $allkey] 40
             }
         }
         r config set hash-max-ziplist-value $original_max_value

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -534,7 +534,7 @@ start_server {
 
             # Use negative count (PATH 1).
             set res [r srandmember myset -1000]
-            assert_equal [check_histogram_distribution $res 0.05 0.15 27.88] true
+            assert_equal [check_histogram_distribution $res 0.05 0.15] true
 
             # Use positive count (both PATH 3 and PATH 4).
             foreach size {8 2} {
@@ -547,7 +547,7 @@ start_server {
                         lappend allkey $ele
                     }
                 }
-                assert_equal [check_histogram_distribution $allkey 0.05 0.15 27.88] true
+                assert_equal [check_histogram_distribution $allkey 0.05 0.15] true
             }
         }
     }

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -534,7 +534,7 @@ start_server {
 
             # Use negative count (PATH 1).
             set res [r srandmember myset -1000]
-            assert_equal [check_histogram_distribution $res 0.05 0.15] true
+            assert_equal [check_histogram_distribution $res 0.05 0.15 27.88] true
 
             # Use positive count (both PATH 3 and PATH 4).
             foreach size {8 2} {
@@ -547,7 +547,7 @@ start_server {
                         lappend allkey $ele
                     }
                 }
-                assert_equal [check_histogram_distribution $allkey 0.05 0.15] true
+                assert_equal [check_histogram_distribution $allkey 0.05 0.15 27.88] true
             }
         }
     }

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -548,13 +548,8 @@ start_server {
                         lappend allkey $ele
                     }
                 }
-                if {$size == 8} {
-                    # df = 7, 35 means 0.00001 probability
-                    assert_morethan 35 [chi_square_value $allkey]
-                } elseif {$size == 2} {
-                    # df = 1, 19 means 0.00001 probability
-                    assert_morethan 19 [chi_square_value $allkey]
-                }
+                # df = 9, 40 means 0.00001 probability
+                assert_morethan 40 [chi_square_value $allkey]
             }
         }
     }

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -535,7 +535,7 @@ start_server {
             # Use negative count (PATH 1).
             # df = 9, 40 means 0.00001 probability
             set res [r srandmember myset -1000]
-            assert_morethan 40 [chi_square_value $res]
+            assert_lessthan [chi_square_value $res] 40
 
             # Use positive count (both PATH 3 and PATH 4).
             foreach size {8 2} {
@@ -549,7 +549,7 @@ start_server {
                     }
                 }
                 # df = 9, 40 means 0.00001 probability
-                assert_morethan 40 [chi_square_value $allkey]
+                assert_lessthan [chi_square_value $allkey] 40
             }
         }
     }

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1750,13 +1750,8 @@ start_server {tags {"zset"}} {
                     }
                 }
                 assert_equal $all_ele_return true
-                if {$size == 8} {
-                    # df = 7, 35 means 0.00001 probability
-                    assert_morethan 35 [chi_square_value $allkey]
-                } elseif {$size == 2} {
-                    # df = 1, 19 means 0.00001 probability
-                    assert_morethan 19 [chi_square_value $allkey]
-                }
+                # df = 9, 40 means 0.00001 probability
+                assert_morethan 40 [chi_square_value $allkey]
             }
         }
         r config set zset-max-ziplist-value $original_max_value

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1657,7 +1657,7 @@ start_server {tags {"zset"}} {
             # Test random uniform distribution
             # df = 9, 40 means 0.00001 probability
             set res [r zrandmember myzset -1000]
-            assert_morethan 40 [chi_square_value $res]
+            assert_lessthan [chi_square_value $res] 40
 
             # 2) Check that all the elements actually belong to the original zset.
             foreach {key val} $res {
@@ -1751,7 +1751,7 @@ start_server {tags {"zset"}} {
                 }
                 assert_equal $all_ele_return true
                 # df = 9, 40 means 0.00001 probability
-                assert_morethan 40 [chi_square_value $allkey]
+                assert_lessthan [chi_square_value $allkey] 40
             }
         }
         r config set zset-max-ziplist-value $original_max_value

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1656,7 +1656,7 @@ start_server {tags {"zset"}} {
 
             # Test random uniform distribution
             set res [r zrandmember myzset -1000]
-            assert_equal [check_histogram_distribution $res 0.05 0.15 27.88] true
+            assert_equal [check_histogram_distribution $res 0.05 0.15] true
 
             # 2) Check that all the elements actually belong to the original zset.
             foreach {key val} $res {
@@ -1749,7 +1749,7 @@ start_server {tags {"zset"}} {
                     }
                 }
                 assert_equal $all_ele_return true
-                assert_equal [check_histogram_distribution $allkey 0.05 0.15 27.88] true
+                assert_equal [check_histogram_distribution $allkey 0.05 0.15] true
             }
         }
         r config set zset-max-ziplist-value $original_max_value

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1655,15 +1655,9 @@ start_server {tags {"zset"}} {
             assert_equal [llength $res] 2002
 
             # Test random uniform distribution
-            set iterations 2
-            while {$iterations != 0} {
-                incr iterations -1
-                set res [r zrandmember myzset -1000]
-                if {[check_histogram_distribution $res 0.05 0.15] == true} {
-                    break
-                }
-            }
-            assert {$iterations != 0}
+            # df = 9, 40 means 0.00001 probability
+            set res [r zrandmember myzset -1000]
+            assert_morethan 40 [chi_square_value $res]
 
             # 2) Check that all the elements actually belong to the original zset.
             foreach {key val} $res {
@@ -1731,39 +1725,38 @@ start_server {tags {"zset"}} {
 
                 # 2) Check that eventually all the elements are returned.
                 #    Use both WITHSCORES and without
-                set retry 2
-                while {$retry != 0} {
-                    incr retry -1
-                    unset -nocomplain auxset
-                    unset -nocomplain allkey
-                    set iterations [expr {1000 / $size}]
-                    set all_ele_return false
-                    while {$iterations != 0} {
-                        incr iterations -1
-                        if {[expr {$iterations % 2}] == 0} {
-                            set res [r zrandmember myzset $size withscores]
-                            foreach {key value} $res {
-                                dict append auxset $key $value
-                                lappend allkey $key
-                            }
-                        } else {
-                            set res [r zrandmember myzset $size]
-                            foreach key $res {
-                                dict append auxset $key
-                                lappend allkey $key
-                            }
+                unset -nocomplain auxset
+                unset -nocomplain allkey
+                set iterations [expr {1000 / $size}]
+                set all_ele_return false
+                while {$iterations != 0} {
+                    incr iterations -1
+                    if {[expr {$iterations % 2}] == 0} {
+                        set res [r zrandmember myzset $size withscores]
+                        foreach {key value} $res {
+                            dict append auxset $key $value
+                            lappend allkey $key
                         }
-                        if {[lsort [dict keys $mydict]] eq
-                            [lsort [dict keys $auxset]]} {
-                            set all_ele_return true
+                    } else {
+                        set res [r zrandmember myzset $size]
+                        foreach key $res {
+                            dict append auxset $key
+                            lappend allkey $key
                         }
                     }
-                    assert_equal $all_ele_return true
-                    if {[check_histogram_distribution $allkey 0.05 0.15] == true} {
-                        break
+                    if {[lsort [dict keys $mydict]] eq
+                        [lsort [dict keys $auxset]]} {
+                        set all_ele_return true
                     }
                 }
-                assert {$retry != 0}
+                assert_equal $all_ele_return true
+                if {$size == 8} {
+                    # df = 7, 35 means 0.00001 probability
+                    assert_morethan 35 [chi_square_value $allkey]
+                } elseif {$size == 2} {
+                    # df = 1, 19 means 0.00001 probability
+                    assert_morethan 19 [chi_square_value $allkey]
+                }
             }
         }
         r config set zset-max-ziplist-value $original_max_value

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1656,7 +1656,7 @@ start_server {tags {"zset"}} {
 
             # Test random uniform distribution
             set res [r zrandmember myzset -1000]
-            assert_equal [check_histogram_distribution $res 0.05 0.15] true
+            assert_equal [check_histogram_distribution $res 0.05 0.15 27.88] true
 
             # 2) Check that all the elements actually belong to the original zset.
             foreach {key val} $res {
@@ -1749,7 +1749,7 @@ start_server {tags {"zset"}} {
                     }
                 }
                 assert_equal $all_ele_return true
-                assert_equal [check_histogram_distribution $allkey 0.05 0.15] true
+                assert_equal [check_histogram_distribution $allkey 0.05 0.15 27.88] true
             }
         }
         r config set zset-max-ziplist-value $original_max_value


### PR DESCRIPTION
**Problem**

Currently, when performing random distribution verification, we determine the probability of each element occurring in the sum, but the probability is only an estimate, these tests had rare sporadic failures, and we cannot verify what the probability of failure will be.

**Solution**

Using the chi-square distribution instead of the original random distribution validation makes the test more reasonable and easier to find problems.