### PR TITLE
re-fix config rewrite for empty save directive

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1385,7 +1385,7 @@ void rewriteConfigSaveOption(struct rewriteConfigState *state) {
      * defaults from being used.
      */
     if (!server.saveparamslen) {
-        rewriteConfigRewriteLine(state,"save",sdsnew("save \"\""),0);
+        rewriteConfigRewriteLine(state,"save",sdsnew("save \"\""),1);
     } else {
         for (j = 0; j < server.saveparamslen; j++) {
             line = sdscatprintf(sdsempty(),"save %ld %d",

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -190,6 +190,14 @@ start_server {tags {"introspection"}} {
         r config rewrite
         restart_server 0 true false
         assert_equal [r config get save] {save {}}
+
+        start_server {config "minimal.conf"} {
+            assert_equal [r config get save] {save {3600 1 300 100 60 10000}}
+            r config set save ""
+            r config rewrite
+            restart_server 0 true false
+            assert_equal [r config get save] {save {}}
+        }
     }
 
     # Config file at this point is at a wierd state, and includes all


### PR DESCRIPTION
fix #8572
the bug was also discussed in #8716, and was solved in #8719, but incompletely :

when the server is started, and the save option is default, if you issue the " config set save "" "
to change the save option, and then issue the “config rewrite” command, the save option change
( from the default to " save "" " ) won't be stored.

the bug maybe has no connection with "include" command.