### PR TITLE
XAUTOCLAIM: JUSTID should prevent incrementing delivery_count

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3120,7 +3120,9 @@ void xautoclaimCommand(client *c) {
 
         /* Update the consumer and idle time. */
         nack->delivery_time = now;
-        nack->delivery_count++;
+        /* Increment the delivery attempts counter unless JUSTID option provided */
+        if (!justid)
+            nack->delivery_count++;
 
         if (nack->consumer != consumer) {
             /* Add the entry in the new consumer local PEL. */


### PR DESCRIPTION
To align with XCLAIM and the XAUTOCLAIM docs