### PR TITLE
Fix XAUTOCLAIM response to return the next available id as the cursor

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3149,6 +3149,9 @@ void xautoclaimCommand(client *c) {
         server.dirty++;
     }
 
+    /* We need to return the next entry as a cursor for the next XAUTOCLAIM call */
+    raxNext(&ri);
+
     streamID endid;
     if (raxEOF(&ri)) {
         endid.ms = endid.seq = 0;

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -373,7 +373,7 @@ start_server {
         after 200
         set reply [r XAUTOCLAIM mystream mygroup consumer2 10 - COUNT 1]
         assert_equal [llength $reply] 2
-        assert_equal [lindex $reply 0] $id1
+        assert_equal [lindex $reply 0] "0-0"
         assert_equal [llength [lindex $reply 1]] 1
         assert_equal [llength [lindex $reply 1 0]] 2
         assert_equal [llength [lindex $reply 1 0 1]] 2
@@ -392,7 +392,7 @@ start_server {
         set reply [r XAUTOCLAIM mystream mygroup consumer2 10 - COUNT 2]
         # id1 is self-claimed here but not id2 ('count' was set to 2)
         assert_equal [llength $reply] 2
-        assert_equal [lindex $reply 0] $id2
+        assert_equal [lindex $reply 0] $id3
         assert_equal [llength [lindex $reply 1]] 2
         assert_equal [llength [lindex $reply 1 0]] 2
         assert_equal [llength [lindex $reply 1 0 1]] 2
@@ -438,22 +438,22 @@ start_server {
         set reply [r XAUTOCLAIM mystream mygroup consumer2 10 - COUNT 2]
         assert_equal [llength $reply] 2
         set cursor [lindex $reply 0]
-        assert_equal $cursor $id2
+        assert_equal $cursor $id3
         assert_equal [llength [lindex $reply 1]] 2
         assert_equal [llength [lindex $reply 1 0 1]] 2
         assert_equal [lindex $reply 1 0 1] {a 1}
 
         # Claim 2 more entries
-        set reply [r XAUTOCLAIM mystream mygroup consumer2 10 ($cursor COUNT 2]
+        set reply [r XAUTOCLAIM mystream mygroup consumer2 10 $cursor COUNT 2]
         assert_equal [llength $reply] 2
         set cursor [lindex $reply 0]
-        assert_equal $cursor $id4
+        assert_equal $cursor $id5
         assert_equal [llength [lindex $reply 1]] 2
         assert_equal [llength [lindex $reply 1 0 1]] 2
         assert_equal [lindex $reply 1 0 1] {c 3}
 
         # Claim last entry
-        set reply [r XAUTOCLAIM mystream mygroup consumer2 10 ($cursor COUNT 2]
+        set reply [r XAUTOCLAIM mystream mygroup consumer2 10 $cursor COUNT 1]
         assert_equal [llength $reply] 2
         set cursor [lindex $reply 0]
         assert_equal $cursor {0-0}


### PR DESCRIPTION
This command used to return the last scanned entry id as the cursor, instead of the next one to be scanned.
so in the next call, the user could / should have sent `(cursor` and not just `cursor` if he wanted to avoid scanning the same record twice.

scanning the record twice would look odd if someone is checking what exactly was scanned, but it also has a side effect of incrementing the delivery count twice.
since documentation was correct, and didn't mention using `(`, so we hope won't cause anyone to miss a record.