### PR TITLE
Cluster migration test cleanup.

### DIFF
--- a/tests/cluster/tests/includes/utils.tcl
+++ b/tests/cluster/tests/includes/utils.tcl
@@ -4,14 +4,15 @@ proc fix_cluster {addr} {
     set code [catch {
         exec ../../../src/redis-cli {*}[rediscli_tls_config "../../../tests"] --cluster fix $addr << yes
     } result]
-    if {$code != 0 && $::verbose} {
+    if {$code != 0} {
         puts $result
     }
     assert {$code == 0}
     assert_cluster_state ok
-    wait_for_condition 1000 10 {
-        [catch {exec ../../../src/redis-cli {*}[rediscli_tls_config "../../../tests"] --cluster check $addr} _] == 0
+    wait_for_condition 100 100 {
+        [catch {exec ../../../src/redis-cli {*}[rediscli_tls_config "../../../tests"] --cluster check $addr} result] == 0
     } else {
+        puts $result
         fail "Cluster could not settle with configuration"
     }
 }


### PR DESCRIPTION
* Dump more output on error (always, cluster tests currently have no
verbose flag).
* Slow down redis-cli check iteration.