### PR TITLE
Fix issue with trailing backslash single quoting.

### DIFF
--- a/deps/hiredis/sds.c
+++ b/deps/hiredis/sds.c
@@ -990,7 +990,7 @@ hisds *hi_sdssplitargs(const char *line, int *argc) {
                         current = hi_sdscatlen(current,p,1);
                     }
                 } else if (insq) {
-                    if (*p == '\\' && *(p+1) == '\'') {
+                    if (*p == '\\' && *(p+1) == '\'' && *(p+2)) {
                         p++;
                         current = hi_sdscatlen(current,"'",1);
                     } else if (*p == '\'') {

--- a/src/sds.c
+++ b/src/sds.c
@@ -1046,7 +1046,7 @@ sds *sdssplitargs(const char *line, int *argc) {
                         current = sdscatlen(current,p,1);
                     }
                 } else if (insq) {
-                    if (*p == '\\' && *(p+1) == '\'') {
+                    if (*p == '\\' && *(p+1) == '\'' && *(p+2)) {
                         p++;
                         current = sdscatlen(current,"'",1);
                     } else if (*p == '\'') {

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -149,6 +149,10 @@ start_server {tags {"cli"}} {
         # quotes after the argument are weird, but should be allowed
         assert_equal "OK" [run_command $fd "set key\"\" bar"]
         assert_equal "bar" [r get key]
+
+        # single quote with a backslash trailing character
+        assert_equal "OK" [run_command $fd "set key '\\'bar\\'\\'"]
+        assert_equal "'bar'\\" [r get key]
     }
 
     test_tty_cli "Status reply" {


### PR DESCRIPTION
This makes 'quoted-string\' a valid string that ends with a backslash
character rather than return an error.

This is somewhat inconsistent as one would expect backslash to be a
special character that needs to be quoted by itself, but doing this more
conventional fix will introduce a backwards compatibility breakage we'd
like to avoid.