### PR TITLE
Solve sentinel test issue in TLS due to recent tests change.

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -499,6 +499,14 @@ proc RI {n field} {
     get_info_field [R $n info] $field
 }
 
+proc RPort {n} {
+    if {$::tls} {
+        return [lindex [R $n config get tls-port] 1]
+    } else {
+        return [lindex [R $n config get port] 1]
+    }
+}
+
 # Iterate over IDs of sentinel or redis instances.
 proc foreach_instance_id {instances idvar code} {
     upvar 1 $idvar id

--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -9,7 +9,7 @@ if {$::simulate_error} {
 }
 
 test "Basic failover works if the master is down" {
-    set old_port [RI $master_id tcp_port]
+    set old_port [RPort $master_id]
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
     kill_instance redis $master_id
@@ -53,7 +53,7 @@ test "ODOWN is not possible without N (quorum) Sentinels reports" {
     foreach_sentinel_id id {
         S $id SENTINEL SET mymaster quorum [expr $sentinels+1]
     }
-    set old_port [RI $master_id tcp_port]
+    set old_port [RPort $master_id]
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
     kill_instance redis $master_id

--- a/tests/sentinel/tests/01-conf-update.tcl
+++ b/tests/sentinel/tests/01-conf-update.tcl
@@ -3,7 +3,7 @@
 source "../tests/includes/init-tests.tcl"
 
 test "We can failover with Sentinel 1 crashed" {
-    set old_port [RI $master_id tcp_port]
+    set old_port [RPort $master_id]
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
 

--- a/tests/sentinel/tests/02-slaves-reconf.tcl
+++ b/tests/sentinel/tests/02-slaves-reconf.tcl
@@ -10,7 +10,7 @@ source "../tests/includes/init-tests.tcl"
 proc 02_test_slaves_replication {} {
     uplevel 1 {
         test "Check that slaves replicate from current master" {
-            set master_port [RI $master_id tcp_port]
+            set master_port [RPort $master_id]
             foreach_redis_id id {
                 if {$id == $master_id} continue
                 if {[instance_is_killed redis $id]} continue
@@ -28,7 +28,7 @@ proc 02_test_slaves_replication {} {
 proc 02_crash_and_failover {} {
     uplevel 1 {
         test "Crash the master and force a failover" {
-            set old_port [RI $master_id tcp_port]
+            set old_port [RPort $master_id]
             set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
             assert {[lindex $addr 1] == $old_port}
             kill_instance redis $master_id

--- a/tests/sentinel/tests/05-manual.tcl
+++ b/tests/sentinel/tests/05-manual.tcl
@@ -3,7 +3,7 @@
 source "../tests/includes/init-tests.tcl"
 
 test "Manual failover works" {
-    set old_port [RI $master_id tcp_port]
+    set old_port [RPort $master_id]
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
     catch {S 0 SENTINEL FAILOVER mymaster} reply


### PR DESCRIPTION
5629dbe7155f2534cd44404743003dc37c444b2a added a change that configures
the tcp (plaintext) port alongside the tls port, this causes the INFO
command for tcp_port to return that instead of the tls port when running
in tls, and that broke the sentinel tests that query it.

the fix is to add a method that gets the right port from CONFIG instead
of relying on the tcp_port info field.