### PR TITLE
generalize config file check for sentinel

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -548,14 +548,12 @@ void initSentinel(void) {
     server.sentinel_config = NULL;
 }
 
-/* This function gets called when the server is in Sentinel mode, started,
- * loaded the configuration, and is ready for normal operations. */
-void sentinelIsRunning(void) {
-    int j;
-
+/* This function is for checking whether sentinel config file has been set,
+ * also checking whether we have write permissions. */
+void sentinelCheckConfigFile(void) {
     if (server.configfile == NULL) {
         serverLog(LL_WARNING,
-            "Sentinel started without a config file. Exiting...");
+            "Sentinel needs config file on disk to save state. Exiting...");
         exit(1);
     } else if (access(server.configfile,W_OK) == -1) {
         serverLog(LL_WARNING,
@@ -563,6 +561,12 @@ void sentinelIsRunning(void) {
             server.configfile,strerror(errno));
         exit(1);
     }
+}
+
+/* This function gets called when the server is in Sentinel mode, started,
+ * loaded the configuration, and is ready for normal operations. */
+void sentinelIsRunning(void) {
+    int j;
 
     /* If this Sentinel has yet no ID set in the configuration file, we
      * pick a random one and persist the config on disk. From now on this

--- a/src/server.c
+++ b/src/server.c
@@ -6245,7 +6245,6 @@ int main(int argc, char **argv) {
             server.exec_argv[1] = zstrdup(server.configfile);
             j = 2; // Skip this arg when parsing options
         }
-
         while(j < argc) {
             /* Either first or last argument - Should we read config from stdin? */
             if (argv[j][0] == '-' && argv[j][1] == '\0' && (j == 1 || j == argc-1)) {
@@ -6268,16 +6267,11 @@ int main(int argc, char **argv) {
             j++;
         }
 
-        if (server.sentinel_mode && ! server.configfile) {
-            serverLog(LL_WARNING,
-                "Sentinel needs config file on disk to save state.  Exiting...");
-            exit(1);
-        }
         loadServerConfig(server.configfile, config_from_stdin, options);
         if (server.sentinel_mode) loadSentinelConfigFromQueue();
         sdsfree(options);
     }
-
+    if (server.sentinel_mode) sentinelCheckConfigFile();
     server.supervised = redisIsSupervised(server.supervised_mode);
     int background = server.daemonize && !server.supervised;
     if (background) daemonize();

--- a/src/server.h
+++ b/src/server.h
@@ -2402,6 +2402,7 @@ const char *sentinelHandleConfiguration(char **argv, int argc);
 void queueSentinelConfig(sds *argv, int argc, int linenum, sds line);
 void loadSentinelConfigFromQueue(void);
 void sentinelIsRunning(void);
+void sentinelCheckConfigFile(void);
 
 /* redis-check-rdb & aof */
 int redis_check_rdb(char *rdbfilename, FILE *fp);


### PR DESCRIPTION
Before this commit, the sentinel config check when server start is not consistant when we configring different number of args when start, if we start with argc >=2, such as ./redis-server --sentinel (without config file provided). the config check or sentinel will appen in this block, before server initiaization happens:
https://github.com/redis/redis/blob/e138698e54e97bfaababf56507026bf92dd4deb4/src/server.c#L6271
However for argc == 1 case, eg. ./redis-sentinel the check will happen in https://github.com/redis/redis/blob/91f4f41665c4e9e0ad248ce0b528644de28d0acd/src/sentinel.c#L557
which cause unnecessary start server and exit after all init work is done:

```Hwware-MacBook-Pro:src hwware$ ./redis-sentinel
15518:X 30 Mar 2021 16:46:28.085 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
15518:X 30 Mar 2021 16:46:28.085 # Redis version=255.255.255, bits=64, commit=1ccfd6a1, modified=0, pid=15518, just started
15518:X 30 Mar 2021 16:46:28.085 # Warning: no config file specified, using the default config. In order to specify a config file use ./redis-sentinel /path/to/sentinel.conf
15518:X 30 Mar 2021 16:46:28.086 * Increased maximum number of open files to 10032 (it was originally set to 256).
15518:X 30 Mar 2021 16:46:28.086 * monotonic clock: POSIX clock_gettime
                _._                                                  
           _.-``__ ''-._                                             
      _.-``    `.  `_.  ''-._           Redis 255.255.255 (1ccfd6a1/0) 64 bit
  .-`` .-```.  ```\/    _.,_ ''-._                                   
 (    '      ,       .-`  | `,    )     Running in sentinel mode
 |`-._`-...-` __...-.``-._|'` _.-'|     Port: 26379
 |    `-._   `._    /     _.-'    |     PID: 15518
  `-._    `-._  `-./  _.-'    _.-'                                   
 |`-._`-._    `-.__.-'    _.-'_.-'|                                  
 |    `-._`-._        _.-'_.-'    |           http://redis.io        
  `-._    `-._`-.__.-'_.-'    _.-'                                   
 |`-._`-._    `-.__.-'    _.-'_.-'|                                  
 |    `-._`-._        _.-'_.-'    |                                  
  `-._    `-._`-.__.-'_.-'    _.-'                                   
      `-._    `-.__.-'    _.-'                                       
          `-._        _.-'                                           
              `-.__.-'                                               

15518:X 30 Mar 2021 16:46:28.090 # Sentinel started without a config file. Exiting...
```

This commit provides a generalize way to check sentinel config early for all cases. After parsing config file path configured.
