### PR TITLE
Initialise RedisModuleDigest with zeroes

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -249,7 +249,7 @@ void xorObjectDigest(redisDb *db, robj *keyobj, unsigned char *digest, robj *o) 
         }
         streamIteratorStop(&si);
     } else if (o->type == OBJ_MODULE) {
-        RedisModuleDigest md;
+        RedisModuleDigest md = {{0},{0}};
         moduleValue *mv = o->ptr;
         moduleType *mt = mv->type;
         moduleInitDigestContext(md);


### PR DESCRIPTION
In case the module's digest function doesn't modify
'md' it'll contain garbage and result in wrong
DEBUG DIGEST