### PR TITLE
FIX: CONFIG REWRITE is wrong when INCLUDE is used

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -32,6 +32,11 @@
 # If instead you are interested in using includes to override configuration
 # options, it is better to use include as the last line.
 #
+# When configurations needs to be restored to it's original status written
+# before "include" line with "config set" command, "config rewrite" should be 
+# used before any "config set" restoration commands, or the configurations
+# won't be restored.
+#
 # include /path/to/local.conf
 # include /path/to/other.conf
 

--- a/src/config.c
+++ b/src/config.c
@@ -1385,7 +1385,7 @@ void rewriteConfigSaveOption(struct rewriteConfigState *state) {
      * defaults from being used.
      */
     if (!server.saveparamslen) {
-        rewriteConfigRewriteLine(state,"save",sdsnew("save \"\""),0);
+        rewriteConfigRewriteLine(state,"save",sdsnew("save \"\""),1);
     } else {
         for (j = 0; j < server.saveparamslen; j++) {
             line = sdscatprintf(sdsempty(),"save %ld %d",

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -190,6 +190,14 @@ start_server {tags {"introspection"}} {
         r config rewrite
         restart_server 0 true false
         assert_equal [r config get save] {save {}}
+
+        start_server {config "minimal.conf"} {
+            assert_equal [r config get save] {save {3600 1 300 100 60 10000}}
+            r config set save ""
+            r config rewrite
+            restart_server 0 true false
+            assert_equal [r config get save] {save {}}
+        }
     }
 
     # Config file at this point is at a wierd state, and includes all


### PR DESCRIPTION
fix #8572

If a command (not only the "save") is in the included file, the command is also in the redis.conf and the included file is behind the command,
when set the command again with "config set", issue the "config rewrite" and restart the server,
the new command option doesn't work.
