### PR TITLE
redis-cli --bigkeys / memkeys, report detailed error on dbsize failure

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7417,8 +7417,14 @@ static int getDbSize(void) {
 
     reply = redisCommand(context, "DBSIZE");
 
-    if(reply == NULL || reply->type != REDIS_REPLY_INTEGER) {
-        fprintf(stderr, "Couldn't determine DBSIZE!\n");
+    if (reply == NULL) {
+        fprintf(stderr, "\nI/O error\n");
+        exit(1);
+    } else if (reply->type == REDIS_REPLY_ERROR) {
+        fprintf(stderr, "Couldn't determine DBSIZE: %s\n", reply->str);
+        exit(1);
+    } else if (reply->type != REDIS_REPLY_INTEGER) {
+        fprintf(stderr, "Non INTEGER response from DBSIZE!\n");
         exit(1);
     }
 


### PR DESCRIPTION
About https://github.com/redis/redis/issues/8736
I checked other places, `DBSIZE` is only needed to update.