### PR TITLE
Fix out of range confusing error messages (XAUTOCLAIM, RPOP count)

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -727,7 +727,11 @@ int getRangeLongFromObjectOrReply(client *c, robj *o, long min, long max, long *
 }
 
 int getPositiveLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg) {
-    return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, msg);
+    if (msg) {
+        return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, msg);
+    } else {
+        return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, "Must be positive");
+    }
 }
 
 int getIntFromObjectOrReply(client *c, robj *o, int *target, const char *msg) {

--- a/src/object.c
+++ b/src/object.c
@@ -730,7 +730,7 @@ int getPositiveLongFromObjectOrReply(client *c, robj *o, long *target, const cha
     if (msg) {
         return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, msg);
     } else {
-        return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, "Must be positive");
+        return getRangeLongFromObjectOrReply(c, o, 0, LONG_MAX, target, "value is out of range, must be positive");
     }
 }
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3051,12 +3051,8 @@ void xautoclaimCommand(client *c) {
         int moreargs = (c->argc-1) - j; /* Number of additional arguments. */
         char *opt = c->argv[j]->ptr;
         if (!strcasecmp(opt,"COUNT") && moreargs) {
-            if (getPositiveLongFromObjectOrReply(c,c->argv[j+1],&count,NULL) != C_OK)
+            if (getRangeLongFromObjectOrReply(c,c->argv[j+1],1,LONG_MAX,&count,"COUNT must be > 0") != C_OK)
                 return;
-            if (count == 0) {
-                addReplyError(c,"COUNT must be > 0");
-                return;
-            }
             j++;
         } else if (!strcasecmp(opt,"JUSTID")) {
             justid = 1;

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -132,7 +132,7 @@ start_server {
         assert_equal {aa bb} [r rpop listcount 2]
         assert_equal {cc} [r rpop listcount 1]
         assert_equal {dd} [r rpop listcount 123]
-        assert_error "ERR Must be positive" {r lpop forbarqaz -123}
+        assert_error "*ERR*range*" {r lpop forbarqaz -123}
     }
 
     test {Variadic RPUSH/LPUSH} {

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -132,7 +132,7 @@ start_server {
         assert_equal {aa bb} [r rpop listcount 2]
         assert_equal {cc} [r rpop listcount 1]
         assert_equal {dd} [r rpop listcount 123]
-        assert_error "*ERR*range*" {r lpop forbarqaz -123}
+        assert_error "ERR Must be positive" {r lpop forbarqaz -123}
     }
 
     test {Variadic RPUSH/LPUSH} {

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -462,6 +462,10 @@ start_server {
         assert_equal [lindex $reply 1 0 1] {e 5}
     }
 
+    test {XAUTOCLAIM COUNT must be > 0} {
+       assert_error "ERR COUNT must be > 0" {r XAUTOCLAIM key group consumer 1 1 COUNT 0}
+    }
+
     test {XINFO FULL output} {
         r del x
         r XADD x 100 a 1


### PR DESCRIPTION
Actually, we don not need `ERR value is out of range, value must between 0 and 9223372036854775807`, this will cause user to continue using `COUNT = 0`, but will get `COUNT must be> 0`.

![image](https://user-images.githubusercontent.com/13137470/113650898-9656eb80-96c3-11eb-8c8b-3effd161a6a6.png)

Fix out of range error messages to be clearer (avoid mentioning 9223372036854775807)
* Fix XAUTOCLAIM COUNT option confusing error msg
* Fix other (RPOP and alike) error message