### PR TITLE
Small doc fix for stream module API

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3398,8 +3398,8 @@ int RM_StreamDelete(RedisModuleKey *key, RedisModuleStreamID *id) {
  *             //
  *             // ... Do stuff ...
  *             //
- *             RedisModule_Free(field);
- *             RedisModule_Free(value);
+ *             RedisModule_FreeString(ctx, field);
+ *             RedisModule_FreeString(ctx, value);
  *         }
  *     }
  *     RedisModule_StreamIteratorStop(key);


### PR DESCRIPTION
In a code example, using RedisModule_FreeString instead of
RedisModule_Free makes it behave correctly regardless of whether
automatic memory is used or not.