### PR TITLE
fix access to uninitialized var in checkClientPauseTimeoutAndReturnIfPaused

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3332,6 +3332,8 @@ int areClientsPaused(void) {
  * if it has. Also returns true if clients are now paused and false 
  * otherwise. */
 int checkClientPauseTimeoutAndReturnIfPaused(void) {
+    if (!areClientsPaused())
+        return 0;
     if (server.client_pause_end_time < server.mstime) {
         unpauseClients();
     }


### PR DESCRIPTION
i noticed server.client_pause_end_time is uninitialized, or actually 0, at
startup, which means this method would think the timerout was reached
and go look for paused clients.

maybe there's a cleaner fix by setting it to 0, and then checking for a special
0 value, but i suppose an early exit in that function when we're not in pause,
avoiding access to that var is just as good.

This causes no harm since unpauseClients will not find any paused clients.