### PR TITLE
Do not install a file event to send data to rewrite child when parent stop sending diff to child in aof rewrite.

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -163,7 +163,7 @@ void aofRewriteBufferAppend(unsigned char *s, unsigned long len) {
     /* Install a file event to send data to the rewrite child if there is
      * not one already. */
     if (!server.aof_stop_sending_diff &&
-            aeGetFileEvents(server.el,server.aof_pipe_write_data_to_child) == 0)
+        aeGetFileEvents(server.el,server.aof_pipe_write_data_to_child) == 0)
     {
         aeCreateFileEvent(server.el, server.aof_pipe_write_data_to_child,
             AE_WRITABLE, aofChildWriteDiffData, NULL);

--- a/src/aof.c
+++ b/src/aof.c
@@ -162,7 +162,8 @@ void aofRewriteBufferAppend(unsigned char *s, unsigned long len) {
 
     /* Install a file event to send data to the rewrite child if there is
      * not one already. */
-    if (aeGetFileEvents(server.el,server.aof_pipe_write_data_to_child) == 0) {
+    if (!server.aof_stop_sending_diff &&
+            aeGetFileEvents(server.el,server.aof_pipe_write_data_to_child) == 0) {
         aeCreateFileEvent(server.el, server.aof_pipe_write_data_to_child,
             AE_WRITABLE, aofChildWriteDiffData, NULL);
     }

--- a/src/aof.c
+++ b/src/aof.c
@@ -163,7 +163,8 @@ void aofRewriteBufferAppend(unsigned char *s, unsigned long len) {
     /* Install a file event to send data to the rewrite child if there is
      * not one already. */
     if (!server.aof_stop_sending_diff &&
-            aeGetFileEvents(server.el,server.aof_pipe_write_data_to_child) == 0) {
+            aeGetFileEvents(server.el,server.aof_pipe_write_data_to_child) == 0)
+    {
         aeCreateFileEvent(server.el, server.aof_pipe_write_data_to_child,
             AE_WRITABLE, aofChildWriteDiffData, NULL);
     }


### PR DESCRIPTION
Do not install a file event to send data to rewrite child when parent
stop sending diff to child in aof rewrite.

In aof rewrite, when parent stop sending data to child, if there is
new rewrite data, aofChildWriteDiffData write event will be installed.
Then this event is issued and deletes the file event without do anyting.
This will happen over and over again until aof rewrite finish.