### PR TITLE
clean up non conf server warning for sentinel mode

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6302,7 +6302,7 @@ int main(int argc, char **argv) {
             (int)getpid());
 
     if (argc == 1) {
-        serverLog(LL_WARNING, "Warning: no config file specified, using the default config. In order to specify a config file use %s /path/to/%s.conf", argv[0], server.sentinel_mode ? "sentinel" : "redis");
+        serverLog(LL_WARNING, "Warning: no config file specified, using the default config. In order to specify a config file use %s /path/to/redis.conf", argv[0]);
     } else {
         serverLog(LL_WARNING, "Configuration loaded");
     }


### PR DESCRIPTION
In Sentinel mode no config file is not allowed, so there is not necessary to keep no config file warning for sentinel anymore. Also this lline will not be executed since empty config file check for sentinel will happen earlier than that.