### PR TITLE
Add more attempts to a timing sensitive test

### DIFF
--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -76,7 +76,7 @@ start_server {tags {"expire"}} {
         # This test is very likely to do a false positive if the
         # server is under pressure, so if it does not work give it a few more
         # chances.
-        for {set j 0} {$j < 3} {incr j} {
+        for {set j 0} {$j < 10} {incr j} {
             r del x
             r setex x 1 somevalue
             after 900
@@ -84,6 +84,9 @@ start_server {tags {"expire"}} {
             after 1100
             set b [r get x]
             if {$a eq {somevalue} && $b eq {}} break
+        }
+        if {$::verbose} {
+            puts "millisecond expire test attempts: $j"
         }
         list $a $b
     } {somevalue {}}


### PR DESCRIPTION
failed on MacOS
```
*** [err]: EXPIRE precision is now the millisecond in tests/unit/expire.tcl
Expected 'somevalue {}' to equal or match '{} {}'
```
https://github.com/redis/redis/runs/2329125455?check_suite_focus=true