### PR TITLE
Add tests for module publish message to pubsub.

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -35,4 +35,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/hash \
 --single unit/moduleapi/zset \
 --single unit/moduleapi/stream \
+--single unit/moduleapi/pubsub \
 "${@}"

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -37,7 +37,8 @@ TEST_MODULES = \
     defragtest.so \
     hash.so \
     zset.so \
-    stream.so
+    stream.so \
+    pubsub.so
 
 
 .PHONY: all

--- a/tests/modules/pubsub.c
+++ b/tests/modules/pubsub.c
@@ -1,0 +1,36 @@
+/*
+ * This module is used to test the pubsub API.
+ *
+ * Created by Harkrishn Patro.
+ * -----------------------------------------------------------------------------
+*/
+#define REDISMODULE_EXPERIMENTAL_API
+
+#include "redismodule.h"
+
+int Pubsub_Publish(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    RedisModuleString *channel = RedisModule_CreateString(ctx, "universe", 8);
+    RedisModuleString *message = RedisModule_CreateString(ctx, "42", 2);
+
+    int count = RedisModule_PublishMessage(ctx, channel, message);
+    RedisModule_FreeString(ctx, channel);
+    RedisModule_FreeString(ctx, message);
+    return RedisModule_ReplyWithLongLong(ctx, count);
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    if (RedisModule_Init(ctx, "pubsub", 1, REDISMODULE_APIVER_1)== REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"pubsub.publish",
+        Pubsub_Publish,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    return REDISMODULE_OK;
+}
+

--- a/tests/unit/moduleapi/pubsub.tcl
+++ b/tests/unit/moduleapi/pubsub.tcl
@@ -1,0 +1,65 @@
+#source tests/support/util.tcl
+
+set testmodule [file normalize tests/modules/pubsub.so]
+
+start_server {tags {"modules"}} {
+
+    proc __consume_subscribe_messages {client type channels} {
+        set numsub -1
+        set counts {}
+
+        for {set i [llength $channels]} {$i > 0} {incr i -1} {
+            set msg [$client read]
+            assert_equal $type [lindex $msg 0]
+
+            # when receiving subscribe messages the channels names
+            # are ordered. when receiving unsubscribe messages
+            # they are unordered
+            set idx [lsearch -exact $channels [lindex $msg 1]]
+            if {[string match "*unsubscribe" $type]} {
+                assert {$idx >= 0}
+            } else {
+                assert {$idx == 0}
+            }
+            set channels [lreplace $channels $idx $idx]
+
+            # aggregate the subscription count to return to the caller
+            lappend counts [lindex $msg 2]
+        }
+
+        # we should have received messages for channels
+        assert {[llength $channels] == 0}
+        return $counts
+    }
+
+    proc subscribe {client channels} {
+        $client subscribe {*}$channels
+        __consume_subscribe_messages $client subscribe $channels
+    }
+
+    proc unsubscribe {client {channels {}}} {
+        $client unsubscribe {*}$channels
+        __consume_subscribe_messages $client unsubscribe $channels
+    }
+
+    r module load $testmodule
+
+    test "Module can publish message to channel" {
+
+        set rd1 [redis_deferring_client]
+
+        # First a subscribe need to exist to verify
+        # a message is published
+        assert_equal {1} [subscribe $rd1 {universe}]
+
+        assert_equal 1 [r pubsub.publish]
+        assert_equal {message universe 42} [$rd1 read]
+
+        unsubscribe $rd1 {universe}
+
+        assert_equal 0 [r pubsub.publish]
+
+        # clean up clients
+        $rd1 close
+    }
+}


### PR DESCRIPTION
Will rebase with #8759 after it is merged to be able to reuse the pubsub methods across test files.