### PR TITLE
Allow setting privdata for blocked client in module

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -5385,8 +5385,8 @@ int moduleTryServeClientBlockedOnKey(client *c, robj *key) {
  * use RM_BlockedClientMeasureTimeStart() and RM_BlockedClientMeasureTimeEnd() one,
  * or multiple times within the blocking command background work.
  */
-RedisModuleBlockedClient *RM_BlockClient(RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback, RedisModuleCmdFunc timeout_callback, void (*free_privdata)(RedisModuleCtx*,void*), long long timeout_ms) {
-    return moduleBlockClient(ctx,reply_callback,timeout_callback,free_privdata,timeout_ms, NULL,0,NULL);
+RedisModuleBlockedClient *RM_BlockClient(RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback, RedisModuleCmdFunc timeout_callback, void (*free_privdata)(RedisModuleCtx*,void*), long long timeout_ms, void *privdata) {
+    return moduleBlockClient(ctx,reply_callback,timeout_callback,free_privdata,timeout_ms, NULL,0, privdata);
 }
 
 /* This call is similar to RedisModule_BlockClient(), however in this case we

--- a/src/modules/helloacl.c
+++ b/src/modules/helloacl.c
@@ -140,7 +140,7 @@ int AuthAsyncCommand_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     if (argc != 2) return RedisModule_WrongArity(ctx);
 
     pthread_t tid;
-    RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, HelloACL_Reply, HelloACL_Timeout, HelloACL_FreeData, TIMEOUT_TIME);
+    RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, HelloACL_Reply, HelloACL_Timeout, HelloACL_FreeData, TIMEOUT_TIME, NULL);
     
 
     void **targs = RedisModule_Alloc(sizeof(void*)*2);

--- a/src/modules/helloblock.c
+++ b/src/modules/helloblock.c
@@ -108,7 +108,7 @@ int HelloBlock_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     }
 
     pthread_t tid;
-    RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx,HelloBlock_Reply,HelloBlock_Timeout,HelloBlock_FreeData,timeout);
+    RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx,HelloBlock_Reply,HelloBlock_Timeout,HelloBlock_FreeData,timeout,NULL);
 
     /* Here we set a disconnection handler, however since this module will
      * block in sleep() in a thread, there is not much we can do in the
@@ -187,7 +187,7 @@ int HelloKeys_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     /* Note that when blocking the client we do not set any callback: no
      * timeout is possible since we passed '0', nor we need a reply callback
      * because we'll use the thread safe context to accumulate a reply. */
-    RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx,NULL,NULL,NULL,0);
+    RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx,NULL,NULL,NULL,0,NULL);
 
     /* Now that we setup a blocking client, we need to pass the control
      * to the thread. However we need to pass arguments to the thread:

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -779,7 +779,7 @@ REDISMODULE_API int (*RedisModule_GetTypeMethodVersion)() REDISMODULE_ATTR;
 /* Experimental APIs */
 #ifdef REDISMODULE_EXPERIMENTAL_API
 #define REDISMODULE_EXPERIMENTAL_API_VERSION 3
-REDISMODULE_API RedisModuleBlockedClient * (*RedisModule_BlockClient)(RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback, RedisModuleCmdFunc timeout_callback, void (*free_privdata)(RedisModuleCtx*,void*), long long timeout_ms) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleBlockedClient * (*RedisModule_BlockClient)(RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback, RedisModuleCmdFunc timeout_callback, void (*free_privdata)(RedisModuleCtx*,void*), long long timeout_ms, void *privdata) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_UnblockClient)(RedisModuleBlockedClient *bc, void *privdata) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsBlockedReplyRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsBlockedTimeoutRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;


### PR DESCRIPTION
I am working with Redis Modules API to implement authorization module. There is a missing functionality.
Here is a short description.

1. I need to block a client to allow analyzing auth credentials in background. When a client is blocked, I allocate a “request” object for background processing on a working thread.

2. The client can be unblocked in two ways:
        - Calling RedisModule_UnblockClient(bc, req) on a working thread
        - Timeout of client’s blocking

3. When authorization request is completed on the working thread, I can pass information about allocated “request” object in the RedisModule_UnblockClient. Thus, when a “FreeData” callback is called, the pointer to the “request” object is passed as a parameter and I can de-allocate it.

4. There is no way to pass this information from the callback handling timeout. It means “FreeData” callback will not get this information and “request” object is not de-allocated.

In this case I need to associate “privdata” pointer with a blocked client, so it will be available in “FreeData” callback independently of the way the client was unblocked.
