### PR TITLE
Fix ouput buffer limit test

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -332,9 +332,8 @@ void _addReplyProtoToList(client *c, const char *s, size_t len) {
         memcpy(tail->buf, s, len);
         listAddNodeTail(c->reply, tail);
         c->reply_bytes += tail->size;
-
-        asyncCloseClientOnOutputBufferLimitReached(c);
     }
+    asyncCloseClientOnOutputBufferLimitReached(c);
 }
 
 /* -----------------------------------------------------------------------------
@@ -615,9 +614,8 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
         memcpy(buf->buf, s, length);
         listNodeValue(ln) = buf;
         c->reply_bytes += buf->size;
-
-        asyncCloseClientOnOutputBufferLimitReached(c);
     }
+    asyncCloseClientOnOutputBufferLimitReached(c);
 }
 
 /* Populate the length object and try gluing it to the next chunk. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -332,8 +332,9 @@ void _addReplyProtoToList(client *c, const char *s, size_t len) {
         memcpy(tail->buf, s, len);
         listAddNodeTail(c->reply, tail);
         c->reply_bytes += tail->size;
+
+        asyncCloseClientOnOutputBufferLimitReached(c);
     }
-    asyncCloseClientOnOutputBufferLimitReached(c);
 }
 
 /* -----------------------------------------------------------------------------
@@ -614,8 +615,9 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
         memcpy(buf->buf, s, length);
         listNodeValue(ln) = buf;
         c->reply_bytes += buf->size;
+
+        asyncCloseClientOnOutputBufferLimitReached(c);
     }
-    asyncCloseClientOnOutputBufferLimitReached(c);
 }
 
 /* Populate the length object and try gluing it to the next chunk. */

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -31,7 +31,10 @@ start_server {tags {"obuf-limits"}} {
         set start_time 0
         set time_elapsed 0
         while 1 {
-            r publish foo bar
+            if {$start_time != 0} {
+                after 10
+            }
+            r publish foo [string repeat "x" 1000]
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]
             if {![regexp {omem=([0-9]+)} $c - omem]} break
@@ -57,7 +60,10 @@ start_server {tags {"obuf-limits"}} {
         set start_time 0
         set time_elapsed 0
         while 1 {
-            r publish foo bar
+            if {$start_time != 0} {
+                after 10
+            }
+            r publish foo [string repeat "x" 1000]
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]
             if {![regexp {omem=([0-9]+)} $c - omem]} break

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -9,7 +9,7 @@ start_server {tags {"obuf-limits"}} {
 
         set omem 0
         while 1 {
-            r publish foo bar
+            r publish foo [string repeat x 1000]
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]
             if {![regexp {omem=([0-9]+)} $c - omem]} break
@@ -31,7 +31,7 @@ start_server {tags {"obuf-limits"}} {
         set start_time 0
         set time_elapsed 0
         while 1 {
-            r publish foo bar
+            r publish foo [string repeat x 1000]
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]
             if {![regexp {omem=([0-9]+)} $c - omem]} break
@@ -57,7 +57,7 @@ start_server {tags {"obuf-limits"}} {
         set start_time 0
         set time_elapsed 0
         while 1 {
-            r publish foo bar
+            r publish foo [string repeat x 1000]
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]
             if {![regexp {omem=([0-9]+)} $c - omem]} break

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -32,6 +32,7 @@ start_server {tags {"obuf-limits"}} {
         set time_elapsed 0
         while 1 {
             if {$start_time != 0} {
+                # Slow down loop when omen has reached the limit.
                 after 10
             }
             r publish foo [string repeat "x" 1000]
@@ -61,6 +62,7 @@ start_server {tags {"obuf-limits"}} {
         set time_elapsed 0
         while 1 {
             if {$start_time != 0} {
+                # Slow down loop when omen has reached the limit.
                 after 10
             }
             r publish foo [string repeat "x" 1000]

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -31,12 +31,7 @@ start_server {tags {"obuf-limits"}} {
         set start_time 0
         set time_elapsed 0
         while 1 {
-            if {$start_time == 0} {
-                r publish foo [string repeat x 1000]
-            } else {
-                # Slow down loop when omen reach limit.
-                r publish foo bar
-            }
+            r publish foo bar
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]
             if {![regexp {omem=([0-9]+)} $c - omem]} break
@@ -62,12 +57,7 @@ start_server {tags {"obuf-limits"}} {
         set start_time 0
         set time_elapsed 0
         while 1 {
-            if {$start_time == 0} {
-                r publish foo [string repeat x 1000]
-            } else {
-                # Slow down loop when omen reach limit.
-                r publish foo bar
-            }
+            r publish foo bar
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]
             if {![regexp {omem=([0-9]+)} $c - omem]} break

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -9,7 +9,7 @@ start_server {tags {"obuf-limits"}} {
 
         set omem 0
         while 1 {
-            r publish foo [string repeat x 1000]
+            r publish foo bar
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]
             if {![regexp {omem=([0-9]+)} $c - omem]} break
@@ -31,7 +31,7 @@ start_server {tags {"obuf-limits"}} {
         set start_time 0
         set time_elapsed 0
         while 1 {
-            r publish foo [string repeat x 1000]
+            r publish foo bar
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]
             if {![regexp {omem=([0-9]+)} $c - omem]} break

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -31,7 +31,12 @@ start_server {tags {"obuf-limits"}} {
         set start_time 0
         set time_elapsed 0
         while 1 {
-            r publish foo bar
+            if {$start_time == 0} {
+                r publish foo [string repeat x 1000]
+            } else {
+                # Slow down loop when omen reach limit.
+                r publish foo bar
+            }
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]
             if {![regexp {omem=([0-9]+)} $c - omem]} break
@@ -57,7 +62,12 @@ start_server {tags {"obuf-limits"}} {
         set start_time 0
         set time_elapsed 0
         while 1 {
-            r publish foo [string repeat x 1000]
+            if {$start_time == 0} {
+                r publish foo [string repeat x 1000]
+            } else {
+                # Slow down loop when omen reach limit.
+                r publish foo bar
+            }
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]
             if {![regexp {omem=([0-9]+)} $c - omem]} break


### PR DESCRIPTION
## Problem

Since the tail size of c->reply is PROTO_REPLY_CHUNK_BYTES(16 * 1024bytes), but in the test only publish foo bar each time (subscribe foo will receive message foo bar, only 10 more bytes), when the soft limit is triggered for the first time, it will take almost 16 * 1024 / 10 times to publish foo bar, which may cause the soft_limit_seconds to be triggered for a very long time in a slow environment.

## Solution

Increase the length of the publish data to fill the time needed for c->reply.

## Other
The duration of the soft_limit_seconds trigger may be twice as long as the soft_limit_seconds, I'm not sure if this is a bug, because it only occurs in slow environments.

This is a "regression" from the change in #8699