### PR TITLE
relax obuf-limit test, which fails on freebsd ci

### DIFF
--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -67,7 +67,7 @@ start_server {tags {"obuf-limits"}} {
                 if {$time_elapsed >= 10} break
             }
         }
-        assert {$omem >= 100000 && $time_elapsed < 6}
+        assert {$omem >= 100000 && $time_elapsed < 9}
         $rd1 close
     }
 


### PR DESCRIPTION
This test failed twice in the recent days in the freebsd CI.
The test sets a softlimit timeout of 3 seconds, waits 10 seconds for redis to disconnect the client, but fails the test if it took more than 6 seconds (changing to 9)

```
*** [err]: Client output buffer soft limit is enforced if time is overreached in tests/unit/obuf-limits.tcl
Expected 102520 >= 100000 && 6 < 6 (context: type eval line 23 cmd {assert {$omem >= 100000 && $time_elapsed < 6}} proc ::test)
```