### PR TITLE
Improve testsuite print of log file

### DIFF
--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -165,6 +165,8 @@ proc test {name code {okpattern undefined} {options undefined}} {
     if {[catch {set retval [uplevel 1 $code]} error]} {
         set assertion [string match "assertion:*" $error]
         if {$assertion || $::durable} {
+            # durable prevents the whole tcl test from exiting on an exception.
+            # an assertion is handled gracefully anyway.
             set msg [string range $error 10 end]
             lappend details $msg
             if {!$assertion} {

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -31,7 +31,7 @@ proc zlistAlikeSort {a b} {
 
 # Return all log lines starting with the first line that contains a warning.
 # Generally, this will be an assertion error with a stack trace.
-proc warnings_from_file {filename} {
+proc crashlog_from_file {filename} {
     set lines [split [exec cat $filename] "\n"]
     set matched 0
     set logall 0


### PR DESCRIPTION
1. the `dump_logs` option would have printed only logs of servers that were
   spawn before the test proc started, and not ones that the test proc
   started inside it.
2. when a server proc catches an exception it should normally forward the
   exception upwards, specifically when it's an assertion that should be
   caught by a test proc above. however, in `durable` mode, we caught all
   exceptions printed them to stdout and let the code continue,
   this was wrong to do for assertions, which should have still been
   propagated to the test function.
3. don't bother to search for crash log to print if we printed the the
   entire log anyway
4. if no crash log was found, no need to print anything (i.e. the fact it
   wasn't found)
5. rename warnings_from_file to crashlog_from_file