### PR TITLE
Revert cluster slot migration tests.

### DIFF
--- a/tests/cluster/tests/20-half-migrated-slot.tcl
+++ b/tests/cluster/tests/20-half-migrated-slot.tcl
@@ -4,6 +4,11 @@
 # 3. migration inited, but not finished
 # 4. migration is half finished on "migrating" node
 # 5. migration is half finished on "importing" node
+
+# TODO: Test is currently disabled until it is stabilized (fixing the test
+# itself or real issues in Redis).
+
+if {false} {
 source "../tests/includes/init-tests.tcl"
 source "../tests/includes/utils.tcl"
 
@@ -90,3 +95,4 @@ test "Half-finish importing" {
 }
 
 config_set_all_nodes cluster-allow-replica-migration yes
+}

--- a/tests/cluster/tests/21-many-slot-migration.tcl
+++ b/tests/cluster/tests/21-many-slot-migration.tcl
@@ -1,11 +1,12 @@
 # Tests for many simlutaneous migrations.
 
+# TODO: Test is currently disabled until it is stabilized (fixing the test
+# itself or real issues in Redis).
+
+if {false} {
+
 source "../tests/includes/init-tests.tcl"
 source "../tests/includes/utils.tcl"
-
-# TODO: This test currently runs without replicas, as failovers (which may
-# happen on lower-end CI platforms) are still not handled properly by the
-# cluster during slot migration (related to #6339).
 
 test "Create a 10 nodes cluster" {
     create_cluster 10 0
@@ -56,3 +57,4 @@ test "Keys are accessible" {
 }
 
 config_set_all_nodes cluster-allow-replica-migration yes
+}

--- a/tests/cluster/tests/21-many-slot-migration.tcl
+++ b/tests/cluster/tests/21-many-slot-migration.tcl
@@ -8,6 +8,10 @@ if {false} {
 source "../tests/includes/init-tests.tcl"
 source "../tests/includes/utils.tcl"
 
+# TODO: This test currently runs without replicas, as failovers (which may
+# happen on lower-end CI platforms) are still not handled properly by the
+# cluster during slot migration (related to #6339).
+
 test "Create a 10 nodes cluster" {
     create_cluster 10 0
     config_set_all_nodes cluster-allow-replica-migration no


### PR DESCRIPTION
Reverts #8649 and subsequent attempts to stabilize the test.