### PR TITLE
Cleanup: remove duplicated code from sentinel

### DIFF
--- a/src/latency.c
+++ b/src/latency.c
@@ -137,7 +137,7 @@ void latencyAddSample(const char *event, mstime_t latency) {
         return;
     }
 
-    ts->samples[ts->idx].time = time(NULL);
+    ts->samples[ts->idx].time = now;
     ts->samples[ts->idx].latency = latency;
 
     ts->idx++;


### PR DESCRIPTION
Cleanup: remove duplicated code from sentinel/lazyfree, and remove
an extra time call in latency.

I found in `loadSentinelConfigFromQueue`, load config from three items in queue are the same.
In lazyfree.c, `lazyfreeFreeSlotsMap` and `lazyFreeTrackingTable` are the same.
We can reduce duplicated code.

In `latencyAddSample` second call `time(NULL)` is unnecessary.