### PR TITLE
Use monotonic clock to check for Lua script timeout.

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1475,7 +1475,7 @@ int keyIsExpired(redisDb *db, robj *key) {
      * script execution, making propagation to slaves / AOF consistent.
      * See issue #1525 on Github for more information. */
     if (server.lua_caller) {
-        now = server.lua_time_start;
+        now = server.lua_time_snapshot;
     }
     /* If we are in the middle of a command execution, we still want to use
      * a reference time that does not change: in that case we just use the

--- a/src/server.h
+++ b/src/server.h
@@ -1570,7 +1570,8 @@ struct redisServer {
     dict *lua_scripts;         /* A dictionary of SHA1 -> Lua scripts */
     unsigned long long lua_scripts_mem;  /* Cached scripts' memory + oh */
     mstime_t lua_time_limit;  /* Script timeout in milliseconds */
-    mstime_t lua_time_start;  /* Start time of script, milliseconds time */
+    monotime lua_time_start;  /* monotonic timer to detect timed-out script */
+    mstime_t lua_time_snapshot; /* Snapshot of mstime when script is started */
     int lua_write_dirty;  /* True if a write command was called during the
                              execution of the current script. */
     int lua_random_dirty; /* True if a random command was called during the


### PR DESCRIPTION
We use EVAL extensively on a device without RTC and rely on NTP to keep the device time up. Sometimes the EVAL commands failes with error `BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE.` but we are certainly sure the script won't run longer than our configured timeout value. We have seen following output from Redis, reporting an unreasonable execution time, too: 

```
Lua slow script detected: still in execution after 140612837289 milliseconds. You can try killing the script using the SCRIPT KILL command.
```

By looking into Redis source code, we have found that Lua scripting relies on `mstime()` to check for script timeout, which is a wrapper of `gettimeofday`. `gettimeofday` is not a steady clock source and might jump forward or back. It should use a monotonic time source.