### PR TITLE
Modules: Replicate lazy-expire even if replication is not allowed

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1453,7 +1453,12 @@ void propagateExpire(redisDb *db, robj *key, int lazy) {
     incrRefCount(argv[0]);
     incrRefCount(argv[1]);
 
+    /* If the master decided to axire a key we must propagate it to
+     * replicas no matter what... */
+    int prev_replication_allowed = server.replication_allowed;
+    server.replication_allowed = 1;
     propagate(server.delCommand,db->id,argv,2,PROPAGATE_AOF|PROPAGATE_REPL);
+    server.replication_allowed = prev_replication_allowed;
 
     decrRefCount(argv[0]);
     decrRefCount(argv[1]);

--- a/src/db.c
+++ b/src/db.c
@@ -1453,8 +1453,8 @@ void propagateExpire(redisDb *db, robj *key, int lazy) {
     incrRefCount(argv[0]);
     incrRefCount(argv[1]);
 
-    /* If the master decided to axire a key we must propagate it to
-     * replicas no matter what... */
+    /* If the master decided to expire a key we must propagate it to replicas no matter what..
+     * Even if module executed a command without asking for propagation. */
     int prev_replication_allowed = server.replication_allowed;
     server.replication_allowed = 1;
     propagate(server.delCommand,db->id,argv,2,PROPAGATE_AOF|PROPAGATE_REPL);

--- a/tests/modules/propagate.c
+++ b/tests/modules/propagate.c
@@ -197,7 +197,7 @@ int propagateTestIncr(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     REDISMODULE_NOT_USED(argc);
     RedisModuleCallReply *reply;
 
-    /* This test mixes multiple propagation systems. */
+    /* This test propagates the module command, not the INCR it executes. */
     reply = RedisModule_Call(ctx, "INCR", "s", argv[1]);
     RedisModule_ReplyWithCallReply(ctx,reply);
     RedisModule_FreeCallReply(reply);

--- a/tests/modules/propagate.c
+++ b/tests/modules/propagate.c
@@ -192,6 +192,19 @@ int propagateTestNestedCommand(RedisModuleCtx *ctx, RedisModuleString **argv, in
     return REDISMODULE_OK;
 }
 
+int propagateTestIncr(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+{
+    REDISMODULE_NOT_USED(argc);
+    RedisModuleCallReply *reply;
+
+    /* This test mixes multiple propagation systems. */
+    reply = RedisModule_Call(ctx, "INCR", "s", argv[1]);
+    RedisModule_ReplyWithCallReply(ctx,reply);
+    RedisModule_FreeCallReply(reply);
+    RedisModule_ReplicateVerbatim(ctx);
+    return REDISMODULE_OK;
+}
+
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
@@ -231,6 +244,11 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     if (RedisModule_CreateCommand(ctx,"propagate-test.nested",
                 propagateTestNestedCommand,
+                "",1,1,1) == REDISMODULE_ERR)
+            return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"propagate-test.incr",
+                propagateTestIncr,
                 "",1,1,1) == REDISMODULE_ERR)
             return REDISMODULE_ERR;
 

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -217,9 +217,9 @@ tags "modules" {
                 test {module RM_Call of expired key propagation} {
                     $master debug set-active-expire 0
 
-                    $master set k1 900 ex 1
+                    $master set k1 900 px 100
                     wait_for_ofs_sync $master $replica
-                    after 1100
+                    after 110
 
                     set repl [attach_to_replication_stream]
                     $master propagate-test.incr k1

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -225,7 +225,6 @@ tags "modules" {
                     $master propagate-test.incr k1
                     wait_for_ofs_sync $master $replica
 
-                    # Note the 'after-call' propagation below is out of order (known limitation)
                     assert_replication_stream $repl {
                         {select *}
                         {del k1}

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -217,7 +217,7 @@ tags "modules" {
                 test {module RM_Call of expired key propagation} {
                     $master debug set-active-expire 0
 
-                    $master setex k1 1 900
+                    $master set k1 900 ex 1
                     wait_for_ofs_sync $master $replica
                     after 1100
 
@@ -234,7 +234,9 @@ tags "modules" {
                     close_replication_stream $repl
 
                     assert_equal [$master get k1] 1
+                    assert_equal [$master ttl k1] -1
                     assert_equal [$replica get k1] 1
+                    assert_equal [$replica ttl k1] -1
                 }
 
                 assert_equal [s -1 unexpected_error_replies] 0


### PR DESCRIPTION
Before this commit using RM_Call without "!" could cause the master
to lazy-expire a key (delete it) but without replicating to replicas.
This could cause the replica's memory usage to gradually grow and
could also cause consistency issues if the master and replica have
a clock diff.
This bug was introduced in https://github.com/redis/redis/pull/8617

Added a test which demonstrates that scenario.

