### PR TITLE
Fix space included in links in modules API doc

### DIFF
--- a/src/modules/gendoc.rb
+++ b/src/modules/gendoc.rb
@@ -23,8 +23,8 @@ def markdown(s)
             # Add backquotes around macro and var names containing underscores.
             l = l.gsub(/(?<![`A-z\*])[A-Za-z]+_[A-Za-z0-9_]+/){|x| "`#{x}`"}
             # Link URLs preceded by space or newline (not already linked)
-            l = l.gsub(/((?:^| )https?:\/\/[A-Za-z0-9_\/\.\-]+[A-Za-z0-9\/])/,
-                       '[\1](\1)')
+            l = l.gsub(/(^| )(https?:\/\/[A-Za-z0-9_\/\.\-]+[A-Za-z0-9\/])/,
+                       '\1[\2](\2)')
             # Replace double-dash with unicode ndash
             l = l.gsub(/ -- /, ' – ')
         end


### PR DESCRIPTION
See these comments:

* https://github.com/redis/redis/pull/8442/files#r615932389
* https://github.com/redis/redis-doc/pull/1556#pullrequestreview-638983937

It's a minor glitch in the appearance. The links still work so there is no hurry.