### PR TITLE
Allow setting blocked client private data for background processing

### DIFF
--- a/src/modules/helloblock.c
+++ b/src/modules/helloblock.c
@@ -199,6 +199,127 @@ int HelloKeys_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     return REDISMODULE_OK;
 }
 
+/* Example of background processing */
+struct BackgroundProcessingRequest {
+    int input;
+    int success;
+    int result;
+    int timeout;
+    pthread_t tid;
+    RedisModuleBlockedClient *blocked_client;
+};
+typedef struct BackgroundProcessingRequest BackgroundProcessingRequest;
+static int success_count = 0;
+static int requests_count = 0;
+
+/* Reply callback for blocking command HELLO.BACK.PROCESS */
+int BackgroundProcess_Reply(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    BackgroundProcessingRequest *req = RedisModule_GetBlockedClientPrivateData(ctx);
+    if (req == NULL) {
+        return RedisModule_ReplyWithSimpleString(ctx,"Blocked client data is NULL");
+    }
+    return RedisModule_ReplyWithLongLong(ctx,req->result);
+}
+
+/* Timeout callback for blocking command HELLO.BACK.PROCESS */
+int BackgroundProcess_Timeout(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    return RedisModule_ReplyWithSimpleString(ctx,"Request timed out");
+}
+
+/* Private data freeing callback for HELLO.BACK.PROCESS command. */
+void BackgroundProcess_FreeData(RedisModuleCtx *ctx, void *privdata) {
+    REDISMODULE_NOT_USED(ctx);
+
+    /* Parameter privdata is a pointer to a BackgroundProcessingRequest struct.
+     * It will be freed in both cases: the background processing is completed
+     * and the client is unblocked; and in case when background processing was
+     * not completed and the client timed out */
+    BackgroundProcessingRequest *req = (BackgroundProcessingRequest*)privdata;
+    if (req == NULL) {
+        RedisModule_Log(ctx,"error","BackgroundProcess_FreeData: request is NULL");
+    }
+
+    if (req->success) success_count++;
+    requests_count++;
+
+    /* It is tempting to call pthread_join(req->tid) here,
+     * but this would potentially block the main thread. */
+
+    RedisModule_Free(privdata);
+}
+
+/* The thread entry point that actually executes the blocking part
+ * of the command HELLO.BACK.PROCESS. 
+ * For demo purposes: the background processing succeeds if an input
+ * number is odd; it fails if the number is even.
+ * In case of "failed background processing", the thread will block
+ * for time exceeding timeout, which will result in the timed out client.
+ */
+void *BackgroundProcess_ThreadMain(void *arg) {
+    BackgroundProcessingRequest* req = (BackgroundProcessingRequest*)arg;
+
+    req->result = req->input * 2;
+    req->success = req->input % 2 ? 1 : 0;
+
+    if (req->success == 0) {
+        sleep(req->timeout+1);
+    }
+
+    RedisModule_UnblockClientKeepPrivData(req->blocked_client);
+    return NULL;
+}
+
+/* HELLO.BACK.PROCESS <input> - Background procesing produces result
+ * equal input*2. It succeeds if the input is an odd number and fails
+ * if the input is an even number. In case of failed background processing,
+ * the client will be blocked for a few seconds and it will timeout. */
+int BackgroundProcess_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 2) return RedisModule_WrongArity(ctx);
+    long long input;
+
+    if (RedisModule_StringToLongLong(argv[1],&input) != REDISMODULE_OK) {
+        return RedisModule_ReplyWithError(ctx,"ERR invalid input");
+    }
+
+    BackgroundProcessingRequest *req = RedisModule_Alloc(sizeof(BackgroundProcessingRequest));
+    req->input = input;
+    req->success = 0;
+    req->result = 0;
+    req->timeout = 1;
+    req->tid = 0;
+
+    req->blocked_client = RedisModule_BlockClient(ctx,
+        BackgroundProcess_Reply,
+        BackgroundProcess_Timeout,
+        BackgroundProcess_FreeData,
+        req->timeout);
+
+    RedisModule_SetBlockedClientPrivData(ctx,req);
+
+    if (pthread_create(&req->tid,NULL,BackgroundProcess_ThreadMain,req) != 0) {
+        RedisModule_AbortBlock(req->blocked_client);
+        RedisModule_Free(req);
+        return RedisModule_ReplyWithError(ctx,"-ERR Can't start thread");
+    }
+    return REDISMODULE_OK;
+}
+
+/* HELLO.BLOCK.STATS - Retrieve background processing stats */
+int BackgroundProcessStats_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    char msg[256];
+    snprintf(msg, sizeof(msg), "Background processing requests count: %d; success count: %d",
+        requests_count, success_count);
+
+    return RedisModule_ReplyWithSimpleString(ctx,msg);
+}
+
 /* This function must be present on each Redis module. It is used in order to
  * register the commands into the Redis server. */
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -213,6 +334,12 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
     if (RedisModule_CreateCommand(ctx,"hello.keys",
         HelloKeys_RedisCommand,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx,"hello.back.process",
+        BackgroundProcess_RedisCommand,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx,"hello.back.stats",
+        BackgroundProcessStats_RedisCommand,"",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     return REDISMODULE_OK;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -781,6 +781,8 @@ REDISMODULE_API int (*RedisModule_GetTypeMethodVersion)() REDISMODULE_ATTR;
 #define REDISMODULE_EXPERIMENTAL_API_VERSION 3
 REDISMODULE_API RedisModuleBlockedClient * (*RedisModule_BlockClient)(RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback, RedisModuleCmdFunc timeout_callback, void (*free_privdata)(RedisModuleCtx*,void*), long long timeout_ms) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_UnblockClient)(RedisModuleBlockedClient *bc, void *privdata) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_UnblockClientKeepPrivData)(RedisModuleBlockedClient *bc) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SetBlockedClientPrivData)(RedisModuleCtx *ctx, void *privdata) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsBlockedReplyRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsBlockedTimeoutRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void * (*RedisModule_GetBlockedClientPrivateData)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -1059,6 +1061,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ThreadSafeContextUnlock);
     REDISMODULE_GET_API(BlockClient);
     REDISMODULE_GET_API(UnblockClient);
+    REDISMODULE_GET_API(UnblockClientKeepPrivData);
+    REDISMODULE_GET_API(SetBlockedClientPrivData);
     REDISMODULE_GET_API(IsBlockedReplyRequest);
     REDISMODULE_GET_API(IsBlockedTimeoutRequest);
     REDISMODULE_GET_API(GetBlockedClientPrivateData);


### PR DESCRIPTION
I am working with Redis Modules API to implement authorization module. There is a missing functionality.
Here is a short description.

1. I need to block a client to allow analyzing auth credentials in background. When a client is blocked, I allocate a “request” object for background processing on a working thread.

2. The client can be unblocked in two ways:
   - Calling RedisModule_UnblockClient(bc, req) on a working thread
   - Timeout of client’s blocking

3. When authorization request is completed on the working thread, I can pass information about allocated “request” object in the RedisModule_UnblockClient. Thus, when a “FreeData” callback is called, the pointer to the “request” object is passed as a parameter and I can de-allocate it.

4. There is no way to pass this information from the callback handling timeout. It means “FreeData” callback will not get this information and “request” object is not de-allocated.

In this case I need to associate a “private data” pointer with a blocked client, so it will be available in “FreeData” callback independently of the way the client was unblocked.

There are two new Module API functions:
-	RedisModule_SetBlockedClientPrivData
-	RedisModule_UnblockClientKeepPrivData

Function RedisModule_SetBlockedClientPrivData allows setting a “private data” pointer in internal module structures. This pointer will be processed by FreeData callback even if a client’s block timed out.

Function RedisModule_UnblockClientKeepPrivData allows unblocking a client without changing a pointer to “private data” set using RedisModule_SetBlockedClientPrivData. 

New example in helloblock.c module shows usage of these functions.

