### PR TITLE
Fix memory leak when doing lazy free of the tracking table

### DIFF
--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -39,12 +39,11 @@ void lazyfreeFreeSlotsMap(void *args[]) {
     atomicIncr(lazyfreed_objects,len);
 }
 
-/* Release the rax mapping Redis Cluster keys to slots in the
- * lazyfree thread. */
+/* Release the key tracking table. */
 void lazyFreeTrackingTable(void *args[]) {
     rax *rt = args[0];
     size_t len = rt->numele;
-    raxFree(rt);
+    freeTrackingRadixTree(rt);
     atomicDecr(lazyfree_objects,len);
     atomicIncr(lazyfreed_objects,len);
 }

--- a/src/server.h
+++ b/src/server.h
@@ -1911,6 +1911,7 @@ void disableTracking(client *c);
 void trackingRememberKeys(client *c);
 void trackingInvalidateKey(client *c, robj *keyobj);
 void trackingInvalidateKeysOnFlush(int async);
+void freeTrackingRadixTree(rax *rt);
 void freeTrackingRadixTreeAsync(rax *rt);
 void trackingLimitUsedSlots(void);
 uint64_t trackingGetTotalItems(void);

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -395,6 +395,17 @@ start_server {tags {"tracking network"}} {
         assert {[lindex msg 2] eq {} }
     }
 
+    test {Test ASYNC flushall} {
+        clean_all
+        r CLIENT TRACKING on REDIRECT $redir_id
+        r GET key1
+        r GET key2
+        assert_equal [s 0 tracking_total_keys] 2
+        $rd_sg FLUSHALL ASYNC
+        assert_equal [s 0 tracking_total_keys] 0
+        assert_equal [lindex [$rd_redirection read] 2] {}
+    }
+
     # Keys are defined to be evicted 100 at a time by default.
     # If after eviction the number of keys still surpasses the limit
     # defined in tracking-table-max-keys, we increases eviction 


### PR DESCRIPTION
The tracking table is a radix tree that maps key->rax. The current implementation doesn't free the interior radix trees, just the top level one. This can result in a lot of leaked memory. We talked about adding a test to cover this case back when we added all the tracking tests, but now we have it.