### PR TITLE
Print the number of abnormal line in AOF

### DIFF
--- a/src/redis-check-aof.c
+++ b/src/redis-check-aof.c
@@ -39,12 +39,14 @@
 
 static char error[1044];
 static off_t epos;
+static long long line = 1;
 
 int consumeNewline(char *buf) {
     if (strncmp(buf,"\r\n",2) != 0) {
         ERROR("Expected \\r\\n, got: %02x%02x",buf[0],buf[1]);
         return 0;
     }
+    line += 1;
     return 1;
 }
 
@@ -201,8 +203,8 @@ int redis_check_aof_main(int argc, char **argv) {
 
     off_t pos = process(fp);
     off_t diff = size-pos;
-    printf("AOF analyzed: size=%lld, ok_up_to=%lld, diff=%lld\n",
-        (long long) size, (long long) pos, (long long) diff);
+    printf("AOF analyzed: size=%lld, ok_up_to=%lld, ok_up_to_line=%lld, diff=%lld\n",
+        (long long) size, (long long) pos, line, (long long) diff);
     if (diff > 0) {
         if (fix) {
             char buf[2];

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -158,6 +158,18 @@ tags {"aof"} {
         assert_match "*not valid*" $result
     }
 
+    test "Short read: Utility should show the abnormal line num in AOF" {
+        create_aof {
+            append_to_aof [formatCommand set foo hello]
+            append_to_aof "!!!"
+        }
+
+        catch {
+            exec src/redis-check-aof $aof_path
+        } result
+        assert_match "*ok_up_to_line=8*" $result
+    }
+
     test "Short read: Utility should be able to fix the AOF" {
         set result [exec src/redis-check-aof --fix $aof_path << "y\n"]
         assert_match "*Successfully truncated AOF*" $result


### PR DESCRIPTION
The redis-check-aof tool can quickly help detect and repair AOF abnormalities, but in some cases, we need to analyze the context of the abnormal position of the AOF, so we need to split the AOF by byte, but If it can directly print the abnormal line number in the AOF file, can we troubleshoot faster?

This PR allows redis-check-aof to support printing the line number of the abnormal location.