### PR TITLE
Use stack buffer instead of dynamic allocation when save/load rdb

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -358,20 +358,25 @@ writeerr:
 }
 
 ssize_t rdbSaveLzfStringObject(rio *rdb, unsigned char *s, size_t len) {
+    unsigned char buf[RDB_LZF_BUF_SIZE+1];
     size_t comprlen, outlen;
     void *out;
 
     /* We require at least four bytes compression for this to be worth it */
     if (len <= 4) return 0;
     outlen = len-4;
-    if ((out = zmalloc(outlen+1)) == NULL) return 0;
+    if (outlen <= RDB_LZF_BUF_SIZE) {
+        out = buf;
+    } else {
+        if ((out = zmalloc(outlen+1)) == NULL) return 0;
+    }
     comprlen = lzf_compress(s, len, out, outlen);
     if (comprlen == 0) {
-        zfree(out);
+        if (outlen > RDB_LZF_BUF_SIZE) zfree(out);
         return 0;
     }
     ssize_t nwritten = rdbSaveLzfBlob(rdb, out, comprlen, len);
-    zfree(out);
+    if (outlen > RDB_LZF_BUF_SIZE) zfree(out);
     return nwritten;
 }
 
@@ -379,6 +384,7 @@ ssize_t rdbSaveLzfStringObject(rio *rdb, unsigned char *s, size_t len) {
  * changes according to 'flags'. For more info check the
  * rdbGenericLoadStringObject() function. */
 void *rdbLoadLzfStringObject(rio *rdb, int flags, size_t *lenptr) {
+    unsigned char buf[RDB_LZF_BUF_SIZE+1];
     int plain = flags & RDB_LOAD_PLAIN;
     int sds = flags & RDB_LOAD_SDS;
     uint64_t len, clen;
@@ -387,9 +393,13 @@ void *rdbLoadLzfStringObject(rio *rdb, int flags, size_t *lenptr) {
 
     if ((clen = rdbLoadLen(rdb,NULL)) == RDB_LENERR) return NULL;
     if ((len = rdbLoadLen(rdb,NULL)) == RDB_LENERR) return NULL;
-    if ((c = ztrymalloc(clen)) == NULL) {
-        serverLog(server.loading? LL_WARNING: LL_VERBOSE, "rdbLoadLzfStringObject failed allocating %llu bytes", (unsigned long long)clen);
-        goto err;
+    if (clen <= RDB_LZF_BUF_SIZE) {
+        c = buf;
+    } else {
+        if ((c = ztrymalloc(clen)) == NULL) {
+            serverLog(server.loading? LL_WARNING: LL_VERBOSE, "rdbLoadLzfStringObject failed allocating %llu bytes", (unsigned long long)clen);
+            goto err;
+        }
     }
 
     /* Allocate our target according to the uncompressed size. */
@@ -411,7 +421,7 @@ void *rdbLoadLzfStringObject(rio *rdb, int flags, size_t *lenptr) {
         rdbReportCorruptRDB("Invalid LZF compressed string");
         goto err;
     }
-    zfree(c);
+    if (clen > RDB_LZF_BUF_SIZE) zfree(c);
 
     if (plain || sds) {
         return val;
@@ -419,7 +429,7 @@ void *rdbLoadLzfStringObject(rio *rdb, int flags, size_t *lenptr) {
         return createObject(OBJ_STRING,val);
     }
 err:
-    zfree(c);
+    if (clen > RDB_LZF_BUF_SIZE) zfree(c);
     if (plain)
         zfree(val);
     else

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -69,6 +69,10 @@
 #define RDB_ENC_INT32 2       /* 32 bit signed integer */
 #define RDB_ENC_LZF 3         /* string compressed with FASTLZ */
 
+/* We use stack buffer instead of dynamic allocation if required size
+ * is less than this value. */
+#define RDB_LZF_BUF_SIZE (16*1024)
+
 /* Map object types to RDB object types. Macros starting with OBJ_ are for
  * memory storage and may change. Instead RDB types must be fixed because
  * we store them on disk. */


### PR DESCRIPTION
I find we still use some dynamic memory allocations in save or load RDB, for lzf compressed buffer, we always allocate when needed. I think we can use stack buffer to reduce dynamic allocation if the needed space is not big.

As we know, the maximum consumption in saving/loading RDB is `lzf compress/uncompress`, in fact, i don't find this commit makes RDB loading/saving use less time, but in some scene, after this commit, redis bgsave child process uses less COW memory.

In my test, redis load a rdb(4.7GB) that may have some different size key/value, and then use benchmark `redis-benchmark -t set -d 4096 -r 1000000 -n 1000000000` to continue writing redis.
Before
```
29336:M 20 Apr 2021 17:57:43.067 * 10000 changes in 60 seconds. Saving...
29336:M 20 Apr 2021 17:57:43.227 * Background saving started by pid 100425
100425:C 20 Apr 2021 18:00:15.781 * DB saved on disk
100425:C 20 Apr 2021 18:00:15.957 * RDB: 5874 MB of memory used by copy-on-write
29336:M 20 Apr 2021 18:00:16.599 * Background saving terminated with success
```
Now
```
49808:M 20 Apr 2021 17:34:30.009 * 10000 changes in 60 seconds. Saving...
49808:M 20 Apr 2021 17:34:30.164 * Background saving started by pid 47585
47585:C 20 Apr 2021 17:37:00.153 * DB saved on disk
47585:C 20 Apr 2021 17:37:00.333 * RDB: 4947 MB of memory used by copy-on-write
```

For loading RDB, this commit doesn't decrease time, i am not sure we should do that, but it should be good to reduce memory dynamic allocation.