### PR TITLE
Monitor support filter command

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -141,7 +141,7 @@ client *createClient(connection *conn) {
     c->argv_len_sum = 0;
     c->original_argc = 0;
     c->original_argv = NULL;
-    c->cmd = c->lastcmd = NULL;
+    c->cmd = c->lastcmd = c->monitor_cmd = NULL;
     c->multibulklen = 0;
     c->bulklen = -1;
     c->sentlen = 0;

--- a/src/replication.c
+++ b/src/replication.c
@@ -410,7 +410,9 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     listRewind(monitors,&li);
     while((ln = listNext(&li))) {
         client *monitor = ln->value;
-        addReply(monitor,cmdobj);
+        if (monitor->monitor_cmd == NULL || monitor->monitor_cmd == c->cmd) {
+            addReply(monitor,cmdobj);
+        }
     }
     decrRefCount(cmdobj);
 }

--- a/src/server.h
+++ b/src/server.h
@@ -875,6 +875,7 @@ typedef struct client {
     robj **original_argv;   /* Arguments of original command if arguments were rewritten. */
     size_t argv_len_sum;    /* Sum of lengths of objects in argv list. */
     struct redisCommand *cmd, *lastcmd;  /* Last command executed. */
+    struct redisCommand *monitor_cmd; /* Monitor filter command. */
     user *user;             /* User associated with this connection. If the
                                user is set to NULL the connection can do
                                anything (admin). */


### PR DESCRIPTION
In some cases, we need to capture specific operation logs. When AOF is on, we can scan the AOF, and if AOF is off, we can use the monitor command. But the monitor will return lots of replies when the ops is high. The usual practice is to filter data on the client side, of course, we can also use other tools for data analysis, but undoubtedly we need to transmit a large amount of redundant data through the network. So consider whether it would be better if redis can support filtering command when it feed to it's monitors.

