### PR TITLE
fuzz tester, try to print hung command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       run: make REDIS_CFLAGS='-Werror' BUILD_TLS=yes
     - name: test
       run: |
-        sudo apt-get install tcl8.6
+        sudo apt-get install tcl8.6 tclx
         ./runtest --verbose
     - name: module api test
       run: ./runtest-moduleapi --verbose

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -20,7 +20,7 @@ jobs:
       run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
     - name: test
       run: |
-        sudo apt-get install tcl8.6
+        sudo apt-get install tcl8.6 tclx
         ./runtest --accurate --verbose --dump-logs
     - name: module api test
       run: ./runtest-moduleapi --verbose
@@ -41,7 +41,7 @@ jobs:
       run: make MALLOC=libc
     - name: test
       run: |
-        sudo apt-get install tcl8.6
+        sudo apt-get install tcl8.6 tclx
         ./runtest --accurate --verbose --dump-logs
     - name: module api test
       run: ./runtest-moduleapi --verbose
@@ -60,7 +60,7 @@ jobs:
       run: make MALLOC=libc CFLAGS=-DNO_MALLOC_USABLE_SIZE
     - name: test
       run: |
-        sudo apt-get install tcl8.6
+        sudo apt-get install tcl8.6 tclx
         ./runtest --accurate --verbose --dump-logs
     - name: module api test
       run: ./runtest-moduleapi --verbose
@@ -81,7 +81,7 @@ jobs:
         make 32bit REDIS_CFLAGS='-Werror -DREDIS_TEST'
     - name: test
       run: |
-        sudo apt-get install tcl8.6
+        sudo apt-get install tcl8.6 tclx
         ./runtest --accurate --verbose --dump-logs
     - name: module api test
       run: |
@@ -105,7 +105,7 @@ jobs:
         make BUILD_TLS=yes
     - name: test
       run: |
-        sudo apt-get install tcl8.6 tcl-tls
+        sudo apt-get install tcl8.6 tclx tcl-tls
         ./utils/gen-test-certs.sh
         ./runtest --accurate --verbose --tls --dump-logs
         ./runtest --accurate --verbose --dump-logs
@@ -133,7 +133,7 @@ jobs:
         make
     - name: test
       run: |
-        sudo apt-get install tcl8.6 tcl-tls
+        sudo apt-get install tcl8.6 tclx tcl-tls
         ./runtest --config io-threads 4 --config io-threads-do-reads yes --accurate --verbose --tags network --dump-logs
     - name: cluster tests
       run: |
@@ -150,7 +150,7 @@ jobs:
     - name: test
       run: |
         sudo apt-get update
-        sudo apt-get install tcl8.6 valgrind -y
+        sudo apt-get install tcl8.6 tclx valgrind -y
         ./runtest --valgrind --verbose --clients 1 --dump-logs
     - name: module api test
       run: ./runtest-moduleapi --valgrind --no-latency --verbose --clients 1
@@ -170,7 +170,7 @@ jobs:
     - name: test
       run: |
         sudo apt-get update
-        sudo apt-get install tcl8.6 valgrind -y
+        sudo apt-get install tcl8.6 tclx valgrind -y
         ./runtest --valgrind --verbose --clients 1 --dump-logs
     - name: module api test
       run: ./runtest-moduleapi --valgrind --no-latency --verbose --clients 1
@@ -188,7 +188,7 @@ jobs:
         make
     - name: test
       run: |
-        yum -y install which tcl
+        yum -y install which tcl tclx
         ./runtest --accurate --verbose --dump-logs
     - name: module api test
       run: ./runtest-moduleapi --verbose
@@ -211,7 +211,7 @@ jobs:
         scl enable devtoolset-7 "make BUILD_TLS=yes"
     - name: test
       run: |
-        yum -y install tcl tcltls
+        yum -y install tcl tcltls tclx
         ./utils/gen-test-certs.sh
         ./runtest --accurate --verbose --tls --dump-logs
         ./runtest --accurate --verbose --dump-logs
@@ -257,7 +257,7 @@ jobs:
       with:
         usesh: true
         sync: rsync
-        prepare: pkg install -y bash gmake lang/tcl86
+        prepare: pkg install -y bash gmake lang/tcl86 lang/tclx
         run: >
           gmake &&
           ./runtest --accurate --verbose --no-latency --dump-logs &&
@@ -277,7 +277,7 @@ jobs:
           make REDIS_CFLAGS='-Werror'
     - name: test
       run: |
-        apk add tcl procps
+        apk add tcl procps tclx
         ./runtest --accurate --verbose --dump-logs
     - name: module api test
       run: ./runtest-moduleapi --verbose
@@ -298,7 +298,7 @@ jobs:
           make REDIS_CFLAGS='-Werror' USE_JEMALLOC=no CFLAGS=-DUSE_MALLOC_USABLE_SIZE
     - name: test
       run: |
-        apk add tcl procps
+        apk add tcl procps tclx
         ./runtest --accurate --verbose --dump-logs
     - name: module api test
       run: ./runtest-moduleapi --verbose

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -2,6 +2,15 @@
 
 tags {"dump" "corruption"} {
 
+# catch sigterm so that in case one of the random command hangs the test,
+# usually due to redis not putting a response in the output buffers,
+# we'll know which command it was
+if { ! [ catch {
+    package require Tclx
+} err ] } {
+    signal error SIGTERM
+}
+
 proc generate_collections {suffix elements} {
     set rd [redis_deferring_client]
     for {set j 0} {$j < $elements} {incr j} {

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -641,6 +641,12 @@ proc generate_fuzzy_traffic_on_key {key duration} {
             r {*}$cmd
         } err ] } {
             incr succeeded
+        } else {
+            set err [format "%s" $err] ;# convert to string for pattern matching
+            if {[string match "*SIGTERM*" $err]} {
+                puts "command caused test to hang? $cmd"
+                exit 1
+            }
         }
     }
 


### PR DESCRIPTION
I saw one case where the tests timed out in the fuzz tester:
```
Testing integration/corrupt-dump-fuzzer
=== () Starting server 127.0.0.1:21418 ok
[TIMEOUT]: clients state report follows.
```
i assume it sent some random erroneous command that caused redis to
forget responding, which caused the test to hung.
hopefully, next time it'll happen, we'll know which command it is.