### PR TITLE
fix module cluster API RM_GetClusterNodeInfo() to correctly populate master id

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -6168,7 +6168,7 @@ int RM_GetClusterNodeInfo(RedisModuleCtx *ctx, const char *id, char *ip, char *m
         /* If the information is not available, the function will set the
          * field to zero bytes, so that when the field can't be populated the
          * function kinda remains predictable. */
-        if (node->flags & CLUSTER_NODE_MASTER && node->slaveof)
+        if (node->flags & CLUSTER_NODE_SLAVE && node->slaveof)
             memcpy(master_id,node->slaveof->name,REDISMODULE_NODE_ID_LEN);
         else
             memset(master_id,0,REDISMODULE_NODE_ID_LEN);


### PR DESCRIPTION
**Describe the bug**
In a module loaded to each node running in cluster mode (e.g., 3 primaries, 3 replicas),
RedisModule_GetClusterNodeInfo() does not return the `master_id` field for a replica node.

**To reproduce**

Create a module with the following function, load it to each node in a cluster with at least one replica and call the following function (e.g., in some dummy function for the module).

```
void get_cluster_info(RedisModuleCtx *ctx)
{
    char ip[REDISMODULE_NODE_ID_LEN];
    char master_id[REDISMODULE_NODE_ID_LEN];
    int port;
    int flags;

    size_t count, j;
    char **ids = RedisModule_GetClusterNodesList(NULL, &count);

    for (j = 0; j < count; j++) {
        RedisModule_Log(NULL, "notice", "Node %.*s", REDISMODULE_NODE_ID_LEN, ids[j]);
        RedisModule_GetClusterNodeInfo(NULL, ids[j], ip, master_id, &port, &flags);
        RedisModule_Log(NULL, "notice", "info %.*s, %.*s, %d, %d", REDISMODULE_NODE_ID_LEN, ip, REDISMODULE_NODE_ID_LEN, master_id, port, flags);
    }

    RedisModule_FreeClusterNodesList(ids);
}
```

**Expected behavior**

For replica nodes, the `master_id` field would be populated.

**Additional information**

The condition to decide whether to populate the master id (https://github.com/redis/redis/blob/f61c37cec900ba391541f20f7655aad44a26bafc/src/module.c#L6171) is performing the wrong bitwise operation (i.e., checking whether it is a master rather than a replica).