### PR TITLE
Improve ziplistRandomPairs code logic

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1601,8 +1601,8 @@ void ziplistRandomPairs(unsigned char *zl, unsigned int count, ziplistEntry *key
     qsort(picks, count, sizeof(rand_pick), uintCompare);
 
     /* fetch the elements form the ziplist into a output array respecting the original order. */
-    unsigned int zipindex = 0, pickindex = 0;
-    p = ziplistIndex(zl, 0);
+    unsigned int zipindex = picks[0].index, pickindex = 0;
+    p = ziplistIndex(zl, zipindex);
     while (ziplistGet(p, &key, &klen, &klval) && pickindex < count) {
         p = ziplistNext(zl, p);
         assert(ziplistGet(p, &value, &vlen, &vlval));


### PR DESCRIPTION
After sorting, each item in picks is sorted according
to its index.

In the original code logic, we traverse from the first
element of ziplist until `zipindex == picks[pickindex].index`.

We may be able to start directly in `picks[0].index`,
this will bring performance improvements.

Signed-off-by: ZheNing Hu <adlternative@gmail.com>