### PR TITLE
Fix memory leak in moduleDefragGlobals

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -9205,6 +9205,7 @@ long moduleDefragGlobals(void) {
         module->defrag_cb(&defrag_ctx);
         defragged += defrag_ctx.defragged;
     }
+    dictReleaseIterator(di);
 
     return defragged;
 }


### PR DESCRIPTION
Forget to call ```dictReleaseIterator```.