### PR TITLE
cluster process publish message only when know that node.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2149,6 +2149,8 @@ int clusterProcessPacket(clusterLink *link) {
                 hdr->sender, hdr->data.fail.about.nodename);
         }
     } else if (type == CLUSTERMSG_TYPE_PUBLISH) {
+        if (!sender) return 1;  /* We don't know that node. */
+
         robj *channel, *message;
         uint32_t channel_len, message_len;
 


### PR DESCRIPTION
As document said: all other packets will be discarded by the receiving node if the sending node is not considered part of the cluster.

But the publish messages don't do this check.

