### PR TITLE
Simplify the method of obtaining the absolute path

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -185,6 +185,11 @@ sds sdsnew(const char *init) {
     return sdsnewlen(init, initlen);
 }
 
+/* Create a new sds string starting from the last char 'ch' in C string. */
+sds sdsrchr(const sds s, const char ch) {
+    return sdsnew(strrchr(s, ch));
+}
+
 /* Duplicate an sds string. */
 sds sdsdup(const sds s) {
     return sdsnewlen(s, sdslen(s));

--- a/src/sds.h
+++ b/src/sds.h
@@ -216,6 +216,7 @@ static inline void sdssetalloc(sds s, size_t newlen) {
 }
 
 sds sdsnewlen(const void *init, size_t initlen);
+sds sdsrchr(const sds s, const char ch);
 sds sdstrynewlen(const void *init, size_t initlen);
 sds sdsnew(const char *init);
 sds sdsempty(void);

--- a/src/util.c
+++ b/src/util.c
@@ -721,54 +721,35 @@ void getRandomHexChars(char *p, size_t len) {
 }
 
 /* Given the filename, return the absolute path as an SDS string, or NULL
- * if it fails for some reason. Note that "filename" may be an absolute path
- * already, this will be detected and handled correctly.
- *
- * The function does not try to normalize everything, but only the obvious
- * case of one or more "../" appearing at the start of "filename"
- * relative path. */
+ * if it fails for some reason. */
 sds getAbsolutePath(char *filename) {
     char cwd[1024];
-    sds abspath;
-    sds relpath = sdsnew(filename);
+    sds abspath, relname;
 
-    relpath = sdstrim(relpath," \r\n\t");
-    if (relpath[0] == '/') return relpath; /* Path is already absolute. */
-
-    /* If path is relative, join cwd and relative path. */
+    /* Get absolute path. */
     if (getcwd(cwd,sizeof(cwd)) == NULL) {
-        sdsfree(relpath);
         return NULL;
     }
     abspath = sdsnew(cwd);
-    if (sdslen(abspath) && abspath[sdslen(abspath)-1] != '/')
+    if (sdslen(abspath) && abspath[sdslen(abspath)-1] != '/') {
         abspath = sdscat(abspath,"/");
-
-    /* At this point we have the current path always ending with "/", and
-     * the trimmed relative path. Try to normalize the obvious case of
-     * trailing ../ elements at the start of the path.
-     *
-     * For every "../" we find in the filename, we remove it and also remove
-     * the last element of the cwd, unless the current cwd is "/". */
-    while (sdslen(relpath) >= 3 &&
-           relpath[0] == '.' && relpath[1] == '.' && relpath[2] == '/')
-    {
-        sdsrange(relpath,3,-1);
-        if (sdslen(abspath) > 1) {
-            char *p = abspath + sdslen(abspath)-2;
-            int trimlen = 1;
-
-            while(*p != '/') {
-                p--;
-                trimlen++;
-            }
-            sdsrange(abspath,0,-(trimlen+1));
-        }
     }
 
-    /* Finally glue the two parts together. */
-    abspath = sdscatsds(abspath,relpath);
+    /* Get exec file name. */
+    sds relpath = sdstrim(sdsnew(filename)," \r\n\t");
+    relname = sdsrchr(relpath,'/');
+    if (sdslen(relname) == 0) {
+        sdsfree(relname);
+        relname = sdsdup(relpath);
+    }
+    if (sdslen(relname) > 1 && relname[0] == '/') {
+        sdsrange(relname,1,-1);
+    }
     sdsfree(relpath);
+
+    /* Finally glue the two parts together. */
+    abspath = sdscatsds(abspath, relname);
+    sdsfree(relname);
     return abspath;
 }
 


### PR DESCRIPTION
There are some problems with the current method of obtaining the absolute path:

- `./redis-server`: translate into `/home/redis/src/./redis-server`
- `/home/redis/src/../src/redis-server`: translate into `/home/redis/src/../src/redis-server`

As written in the original function comment: `The function does not try to normalize everything`, so I made some adjustments.