### PR TITLE
Remove dead code from lpStringToInt64()

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -183,9 +183,6 @@ int lpStringToInt64(const char *s, unsigned long slen, int64_t *value) {
     if (p[0] >= '1' && p[0] <= '9') {
         v = p[0]-'0';
         p++; plen++;
-    } else if (p[0] == '0' && slen == 1) {
-        *value = 0;
-        return 1;
     } else {
         return 0;
     }


### PR DESCRIPTION
When ```s == "0"```, the following two conditional judgements are repeated.
```
else if (p[0] == '0' && slen == 1)
```
```
/* Special case: first and only digit is 0. */
    if (slen == 1 && p[0] == '0') {
        if (value != NULL) *value = 0;
        return 1;
    }
```