### PR TITLE
Fix error reply of GEOSEARCHSTORE unsupported args

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -651,9 +651,9 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
 
     /* Trap options not compatible with STORE and STOREDIST. */
     if (storekey && (withdist || withhash || withcoords)) {
-        addReplyError(c,
-            "STORE option in GEORADIUS is not compatible with "
-            "WITHDIST, WITHHASH and WITHCOORDS options");
+        addReplyErrorFormat(c,
+            "%s is not compatible with WITHDIST, WITHHASH and WITHCOORD options",
+            flags & GEOSEARCHSTORE? "GEOSEARCHSTORE": "STORE option in GEORADIUS");
         return;
     }
 


### PR DESCRIPTION
When [WITHCOORD] [WITHDIST] [WITHHASH] are used, the error mentioned GEORADIUS command
Fixes issue #8864