### PR TITLE
redis-cli: Do not use hostsocket when we got redirected in cluster mode

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -844,7 +844,9 @@ static int cliConnect(int flags) {
             cliRefreshPrompt();
         }
 
-        if (config.hostsocket == NULL) {
+        /* Do not use hostsocket when we got redirected in cluster mode */
+        if (config.hostsocket == NULL ||
+            (config.cluster_mode && config.cluster_reissue_command)) {
             context = redisConnect(config.hostip,config.hostport);
         } else {
             context = redisConnectUnix(config.hostsocket);


### PR DESCRIPTION
when i test in cluster, i found: when redis-cli connecting through redis.sock, it will stuck into a dead loop

Follow the steps below:
- set up unixsocket in conf
- set up six node：src/redis-cli --cluster create 127.0.0.1:6379 127.0.0.1:6380 127.0.0.1:6381 127.0.0.1:6382 127.0.0.1:6383 127.0.0.1:6384 --cluster-replicas 1
- src/redis-cli -s /var/run/redis/redis.sock get name   .  it got an MOVED error
- src/redis-cli -c -s /var/run/redis/redis.sock get name   .  it won't stop, stuck into a dead loop

redis-cli call `cliConnect` when we got redirected in cluster mode. And in `cliConnect `it will always call `context = redisConnectUnix(config.hostsocket);` Always use hostsocket so it ran into a dead loop

Some pictures I debugged:
![image](https://user-images.githubusercontent.com/22811481/116115411-f3efbe00-a6ec-11eb-842e-8843143a1d6a.png)
![image](https://user-images.githubusercontent.com/22811481/116115434-f9e59f00-a6ec-11eb-88f5-bb2acbc1e478.png)


