### PR TITLE
Fix some typos in the code of basic data structures

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -546,7 +546,7 @@ robj *hashTypeDup(robj *o) {
     return hobj;
 }
 
-/* callback for to check the ziplist doesn't have duplicate recoreds */
+/* callback for to check the ziplist doesn't have duplicate records */
 static int _hashZiplistEntryValidation(unsigned char *p, void *userdata) {
     struct {
         long count;

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -562,7 +562,7 @@ void ltrimCommand(client *c) {
  *
  * If COUNT is given, instead of returning the single element, a list of
  * all the matching elements up to "num-matches" are returned. COUNT can
- * be combiled with RANK in order to returning only the element starting
+ * be combined with RANK in order to returning only the element starting
  * from the Nth. If COUNT is zero, all the matching elements are returned.
  *
  * MAXLEN tells the command to scan a max of len elements. If zero (the

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1376,7 +1376,7 @@ void streamPropagateXCLAIM(client *c, robj *key, streamCG *group, robj *groupnam
     decrRefCount(argv[13]);
 }
 
-/* We need this when we want to propoagate the new last-id of a consumer group
+/* We need this when we want to propagate the new last-id of a consumer group
  * that was consumed by XREADGROUP with the NOACK option: in that case we can't
  * propagate the last ID just using the XCLAIM LASTID option, so we emit
  *

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -836,7 +836,7 @@ void stralgoLCS(client *c) {
      * it backward, but the length is already known, we store it into idx. */
     uint32_t idx = LCS(alen,blen);
     sds result = NULL;        /* Resulting LCS string. */
-    void *arraylenptr = NULL; /* Deffered length of the array for IDX. */
+    void *arraylenptr = NULL; /* Deferred length of the array for IDX. */
     uint32_t arange_start = alen, /* alen signals that values are not set. */
              arange_end = 0,
              brange_start = 0,


### PR DESCRIPTION
Found some typos when reading the source code of basic data structures.