### PR TITLE
When test CONFIG bind with non valid address, some server may configure search domain. 

### DIFF
--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -25,7 +25,7 @@ test {CONFIG SET port number} {
 test {CONFIG SET bind address} {
     start_server {} {
         # non-valid address
-        catch {r CONFIG SET bind "some.wrong.bind.address."} e
+        catch {r CONFIG SET bind "999.999.999.999"} e
         assert_match {*Failed to bind to specified addresses*} $e
 
         # make sure server still bound to the previous address

--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -25,7 +25,7 @@ test {CONFIG SET port number} {
 test {CONFIG SET bind address} {
     start_server {} {
         # non-valid address
-        catch {r CONFIG SET bind "some.wrong.bind.address"} e
+        catch {r CONFIG SET bind "some.wrong.bind.address."} e
         assert_match {*Failed to bind to specified addresses*} $e
 
         # make sure server still bound to the previous address


### PR DESCRIPTION
Fix part of https://github.com/redis/redis/issues/8871 and  https://github.com/redis/redis/issues/8828

When test CONFIG bind with non valid address, some server
configure search domain. So whatever addresses will bind success.
Using an invalid ip will always fail.