### PR TITLE
Fix wrongly use of flag for RedisModule_OpenKey()

### DIFF
--- a/src/modules/hellotype.c
+++ b/src/modules/hellotype.c
@@ -104,8 +104,7 @@ int HelloTypeInsert_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, 
     RedisModule_AutoMemory(ctx); /* Use automatic memory management. */
 
     if (argc != 3) return RedisModule_WrongArity(ctx);
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
     int type = RedisModule_KeyType(key);
     if (type != REDISMODULE_KEYTYPE_EMPTY &&
         RedisModule_ModuleTypeGetType(key) != HelloType)
@@ -141,8 +140,7 @@ int HelloTypeRange_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, i
     RedisModule_AutoMemory(ctx); /* Use automatic memory management. */
 
     if (argc != 4) return RedisModule_WrongArity(ctx);
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
     int type = RedisModule_KeyType(key);
     if (type != REDISMODULE_KEYTYPE_EMPTY &&
         RedisModule_ModuleTypeGetType(key) != HelloType)
@@ -177,8 +175,7 @@ int HelloTypeLen_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int
     RedisModule_AutoMemory(ctx); /* Use automatic memory management. */
 
     if (argc != 2) return RedisModule_WrongArity(ctx);
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
     int type = RedisModule_KeyType(key);
     if (type != REDISMODULE_KEYTYPE_EMPTY &&
         RedisModule_ModuleTypeGetType(key) != HelloType)
@@ -235,8 +232,7 @@ void HelloBlock_FreeData(RedisModuleCtx *ctx, void *privdata) {
 int HelloTypeBRange_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 5) return RedisModule_WrongArity(ctx);
     RedisModule_AutoMemory(ctx); /* Use automatic memory management. */
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
     int type = RedisModule_KeyType(key);
     if (type != REDISMODULE_KEYTYPE_EMPTY &&
         RedisModule_ModuleTypeGetType(key) != HelloType)

--- a/src/modules/helloworld.c
+++ b/src/modules/helloworld.c
@@ -62,8 +62,7 @@ int HelloPushNative_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, 
 {
     if (argc != 3) return RedisModule_WrongArity(ctx);
 
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
 
     RedisModule_ListPush(key,REDISMODULE_LIST_TAIL,argv[2]);
     size_t newlen = RedisModule_ValueLength(key);
@@ -134,10 +133,8 @@ int HelloListSumLen_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, 
 int HelloListSplice_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 4) return RedisModule_WrongArity(ctx);
 
-    RedisModuleKey *srckey = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
-    RedisModuleKey *dstkey = RedisModule_OpenKey(ctx,argv[2],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *srckey = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
+    RedisModuleKey *dstkey = RedisModule_OpenKey(ctx,argv[2],REDISMODULE_WRITE);
 
     /* Src and dst key must be empty or lists. */
     if ((RedisModule_KeyType(srckey) != REDISMODULE_KEYTYPE_LIST &&
@@ -181,10 +178,8 @@ int HelloListSpliceAuto_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **ar
 
     RedisModule_AutoMemory(ctx);
 
-    RedisModuleKey *srckey = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
-    RedisModuleKey *dstkey = RedisModule_OpenKey(ctx,argv[2],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *srckey = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
+    RedisModuleKey *dstkey = RedisModule_OpenKey(ctx,argv[2],REDISMODULE_WRITE);
 
     /* Src and dst key must be empty or lists. */
     if ((RedisModule_KeyType(srckey) != REDISMODULE_KEYTYPE_LIST &&
@@ -279,8 +274,7 @@ int HelloRepl2_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     if (argc != 2) return RedisModule_WrongArity(ctx);
 
     RedisModule_AutoMemory(ctx); /* Use automatic memory management. */
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
 
     if (RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_LIST)
         return RedisModule_ReplyWithError(ctx,REDISMODULE_ERRORMSG_WRONGTYPE);
@@ -314,8 +308,7 @@ int HelloRepl2_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 int HelloToggleCase_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 2) return RedisModule_WrongArity(ctx);
 
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
 
     int keytype = RedisModule_KeyType(key);
     if (keytype != REDISMODULE_KEYTYPE_STRING &&
@@ -356,8 +349,7 @@ int HelloMoreExpire_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, 
     if (RedisModule_StringToLongLong(argv[2],&addms) != REDISMODULE_OK)
         return RedisModule_ReplyWithError(ctx,"ERR invalid expire time");
 
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
     expire = RedisModule_GetExpire(key);
     if (expire != REDISMODULE_NO_EXPIRE) {
         expire += addms;
@@ -382,8 +374,7 @@ int HelloZsumRange_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, i
         return RedisModule_ReplyWithError(ctx,"ERR invalid range");
     }
 
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
     if (RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_ZSET) {
         return RedisModule_ReplyWithError(ctx,REDISMODULE_ERRORMSG_WRONGTYPE);
     }
@@ -432,8 +423,7 @@ int HelloLexRange_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
     if (argc != 6) return RedisModule_WrongArity(ctx);
 
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
     if (RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_ZSET) {
         return RedisModule_ReplyWithError(ctx,REDISMODULE_ERRORMSG_WRONGTYPE);
     }
@@ -469,8 +459,7 @@ int HelloHCopy_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     RedisModule_AutoMemory(ctx); /* Use automatic memory management. */
 
     if (argc != 4) return RedisModule_WrongArity(ctx);
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
     int type = RedisModule_KeyType(key);
     if (type != REDISMODULE_KEYTYPE_HASH &&
         type != REDISMODULE_KEYTYPE_EMPTY)

--- a/src/modules/testmodule.c
+++ b/src/modules/testmodule.c
@@ -131,7 +131,7 @@ int TestUnlink(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
 
-    RedisModuleKey *k = RedisModule_OpenKey(ctx, RedisModule_CreateStringPrintf(ctx, "unlinked"), REDISMODULE_WRITE | REDISMODULE_READ);
+    RedisModuleKey *k = RedisModule_OpenKey(ctx, RedisModule_CreateStringPrintf(ctx, "unlinked"), REDISMODULE_WRITE);
     if (!k) return failTest(ctx, "Could not create key");
 
     if (REDISMODULE_ERR == RedisModule_StringSet(k, RedisModule_CreateStringPrintf(ctx, "Foobar"))) {

--- a/tests/modules/commandfilter.c
+++ b/tests/modules/commandfilter.c
@@ -52,7 +52,7 @@ int CommandFilter_LogCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
         RedisModule_StringAppendBuffer(ctx, s, arg, arglen);
     }
 
-    RedisModuleKey *log = RedisModule_OpenKey(ctx, log_key_name, REDISMODULE_WRITE|REDISMODULE_READ);
+    RedisModuleKey *log = RedisModule_OpenKey(ctx, log_key_name, REDISMODULE_WRITE);
     RedisModule_ListPush(log, REDISMODULE_LIST_HEAD, s);
     RedisModule_CloseKey(log);
     RedisModule_FreeString(ctx, s);

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -95,8 +95,7 @@ static int fragCreateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     if (argc != 5)
         return RedisModule_WrongArity(ctx);
 
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-                                              REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
     int type = RedisModule_KeyType(key);
     if (type != REDISMODULE_KEYTYPE_EMPTY)
     {

--- a/tests/modules/stream.c
+++ b/tests/modules/stream.c
@@ -111,7 +111,7 @@ int stream_range(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
 
     /* Open key and start iterator. */
-    int openflags = REDISMODULE_READ | REDISMODULE_WRITE;
+    int openflags = REDISMODULE_WRITE;
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], openflags);
     if (RedisModule_StreamIteratorStart(key, flags,
                                         &startid, &endid) != REDISMODULE_OK) {

--- a/tests/modules/test_lazyfree.c
+++ b/tests/modules/test_lazyfree.c
@@ -62,8 +62,7 @@ int LazyFreeLinkInsert_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **arg
     RedisModule_AutoMemory(ctx); /* Use automatic memory management. */
 
     if (argc != 3) return RedisModule_WrongArity(ctx);
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
     int type = RedisModule_KeyType(key);
     if (type != REDISMODULE_KEYTYPE_EMPTY &&
         RedisModule_ModuleTypeGetType(key) != LazyFreeLinkType)
@@ -97,8 +96,7 @@ int LazyFreeLinkLen_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, 
     RedisModule_AutoMemory(ctx); /* Use automatic memory management. */
 
     if (argc != 2) return RedisModule_WrongArity(ctx);
-    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],
-        REDISMODULE_READ|REDISMODULE_WRITE);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
     int type = RedisModule_KeyType(key);
     if (type != REDISMODULE_KEYTYPE_EMPTY &&
         RedisModule_ModuleTypeGetType(key) != LazyFreeLinkType)

--- a/tests/modules/zset.c
+++ b/tests/modules/zset.c
@@ -8,7 +8,7 @@
 int zset_rem(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 3) return RedisModule_WrongArity(ctx);
     RedisModule_AutoMemory(ctx);
-    int keymode = REDISMODULE_READ | REDISMODULE_WRITE;
+    int keymode = REDISMODULE_WRITE;
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], keymode);
     int deleted;
     if (RedisModule_ZsetRem(key, argv[2], &deleted) == REDISMODULE_OK)


### PR DESCRIPTION
This change does not fix any bugs, as RedisModule_OpenKey determines REDISMODULE_WRITE first, but the way it is written may result in the order of RM_OpenKey never being changed again, which may result in existing RedisModules not being backwards compatible.
And I've seen some redis modules that use the same writing style.