### PR TITLE
Improve redis-cli help

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -656,7 +656,7 @@ static void cliOutputHelp(int argc, char **argv) {
         help = entry->org;
         if (group == -1) {
             /* Compare all arguments */
-            if (argc == entry->argc) {
+            if (argc <= entry->argc) {
                 for (j = 0; j < argc; j++) {
                     if (strcasecmp(argv[j],entry->argv[j]) != 0) break;
                 }


### PR DESCRIPTION
Improve redis-cli help. When help command, we only match command
prefix args not all args. So when we help commands with subcommands,
all subcommands will be output.

Before this:
```
127.0.0.1:6380> help config


```

After this:
```
127.0.0.1:6380> help config

  CONFIG GET parameter
  summary: Get the value of a configuration parameter
  since: 2.0.0
  group: server

  CONFIG RESETSTAT -
  summary: Reset the stats returned by INFO
  since: 2.0.0
  group: server

  CONFIG REWRITE -
  summary: Rewrite the configuration file with the in memory configuration
  since: 2.8.0
  group: server

  CONFIG SET parameter value
  summary: Set a configuration parameter to the given value
  since: 2.0.0
  group: server
```