### PR TITLE
Replace all usage of ziplist with listpack for quicklist

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1727,7 +1727,7 @@ hash-max-ziplist-value 64
 # per list node.
 # The highest performing option is usually -2 (8 Kb size) or -1 (4 Kb size),
 # but if your use case is unique, adjust the settings as necessary.
-list-max-ziplist-size -2
+list-max-listpack-size -2
 
 # Lists may also be compressed.
 # Compress depth is the number of quicklist ziplist nodes from *each* side of

--- a/src/config.c
+++ b/src/config.c
@@ -2479,7 +2479,7 @@ standardConfig configs[] = {
     createIntConfig("io-threads", NULL, IMMUTABLE_CONFIG, 1, 128, server.io_threads_num, 1, INTEGER_CONFIG, NULL, NULL), /* Single threaded by default */
     createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_slave_validity_factor, 10, INTEGER_CONFIG, NULL, NULL), /* Slave max data age factor. */
-    createIntConfig("list-max-ziplist-size", NULL, MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.list_max_ziplist_size, -2, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("list-max-listpack-size", "list-max-ziplist-size", MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.list_max_listpack_size, -2, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("tcp-keepalive", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tcpkeepalive, 300, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-migration-barrier", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_migration_barrier, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("active-defrag-cycle-min", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cycle_min, 1, INTEGER_CONFIG, NULL, NULL), /* Default: 1% CPU min (at lower threshold) */

--- a/src/debug.c
+++ b/src/debug.c
@@ -585,8 +585,8 @@ NULL
             used = snprintf(nextra, remaining, " ql_avg_node:%.2f", avg);
             nextra += used;
             remaining -= used;
-            /* Add quicklist fill level / max ziplist size */
-            used = snprintf(nextra, remaining, " ql_ziplist_max:%d", ql->fill);
+            /* Add quicklist fill level / max listpack size */
+            used = snprintf(nextra, remaining, " ql_listpack_max:%d", ql->fill);
             nextra += used;
             remaining -= used;
             /* Add isCompressed? */

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -417,8 +417,8 @@ long activeDefragQuickListNode(quicklist *ql, quicklistNode **node_ref) {
         *node_ref = node = newnode;
         defragged++;
     }
-    if ((newzl = activeDefragAlloc(node->zl)))
-        defragged++, node->zl = newzl;
+    if ((newzl = activeDefragAlloc(node->l)))
+        defragged++, node->l = newzl;
     return defragged;
 }
 

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -45,21 +45,50 @@
 #define LP_AFTER 1
 #define LP_REPLACE 2
 
+/* Each entry in the listpack is either a string or an integer. */
+typedef struct {
+    /* When string is used, it is provided with the length (slen). */
+    unsigned char *sval;
+    unsigned int slen;
+    /* When integer is used, 'sval' is NULL, and lval holds the value. */
+    int64_t lval;
+} lpEntry;
+
 unsigned char *lpNew(size_t capacity);
+unsigned char *lpEmpty();
 void lpFree(unsigned char *lp);
 unsigned char* lpShrinkToFit(unsigned char *lp);
-unsigned char *lpInsert(unsigned char *lp, unsigned char *ele, uint32_t size, unsigned char *p, int where, unsigned char **newp);
-unsigned char *lpAppend(unsigned char *lp, unsigned char *ele, uint32_t size);
+int lpEncodeGetType(unsigned char *s, uint32_t slen, unsigned char *intenc, uint64_t *enclen);
+unsigned char *lpInsert(unsigned char *lp, unsigned char *s, uint32_t slen, unsigned char *p, int where, unsigned char **newp);
+unsigned char *lpInsertBefore(unsigned char *lp, unsigned char *s, uint32_t slen, unsigned char *p);
+unsigned char *lpInsertAfter(unsigned char *lp, unsigned char *s, uint32_t slen, unsigned char *p);
+unsigned char *lpPushHead(unsigned char *lp, unsigned char *s, uint32_t slen);
+unsigned char *lpPushTail(unsigned char *lp, unsigned char *s, uint32_t slen);
+unsigned char *lpReplace(unsigned char *lp, unsigned char *s, uint32_t slen, unsigned char *p);
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp);
 uint32_t lpLength(unsigned char *lp);
 unsigned char *lpGet(unsigned char *p, int64_t *count, unsigned char *intbuf);
+unsigned char *lpFind(unsigned char *lp, unsigned char *s, unsigned int slen, unsigned char *p, unsigned int skip);
 unsigned char *lpFirst(unsigned char *lp);
 unsigned char *lpLast(unsigned char *lp);
 unsigned char *lpNext(unsigned char *lp, unsigned char *p);
 unsigned char *lpPrev(unsigned char *lp, unsigned char *p);
 uint32_t lpBytes(unsigned char *lp);
 unsigned char *lpSeek(unsigned char *lp, long index);
-int lpValidateIntegrity(unsigned char *lp, size_t size, int deep);
+void lpRepr(unsigned char *lp);
+typedef int (*listpackValidateEntryCB)(unsigned char *p, void *userdata);
+int lpValidateIntegrity(unsigned char *lp, size_t size, int deep,
+                        listpackValidateEntryCB entry_cb, void *cb_userdata);
 int lpValidateNext(unsigned char *lp, unsigned char **pp, size_t lpbytes);
+unsigned char *lpMerge(unsigned char **first, unsigned char **second);
+unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned int num);
+unsigned int lpCompare(unsigned char *p, unsigned char *s, unsigned int slen);
+void lpRandomPair(unsigned char *lp, unsigned long total_count, lpEntry *key, lpEntry *val);
+void lpRandomPairs(unsigned char *lp, unsigned int count, lpEntry *keys, lpEntry *vals);
+unsigned int lpRandomPairsUnique(unsigned char *lp, unsigned int count, lpEntry *keys, lpEntry *vals);
+
+#ifdef REDIS_TEST
+int listpackTest(int argc, char *argv[], int accurate);
+#endif
 
 #endif

--- a/src/module.c
+++ b/src/module.c
@@ -543,8 +543,8 @@ int moduleCreateEmptyKey(RedisModuleKey *key, int type) {
 
     switch(type) {
     case REDISMODULE_KEYTYPE_LIST:
-        obj = createQuicklistObject();
-        quicklistSetOptions(obj->ptr, server.list_max_ziplist_size,
+        obj = createQuicklistObject(&quicklistContainerTypeListpack);
+        quicklistSetOptions(obj->ptr, server.list_max_listpack_size,
                             server.list_compress_depth);
         break;
     case REDISMODULE_KEYTYPE_ZSET:

--- a/src/object.c
+++ b/src/object.c
@@ -211,8 +211,8 @@ robj *dupStringObject(const robj *o) {
     }
 }
 
-robj *createQuicklistObject(void) {
-    quicklist *l = quicklistCreate();
+robj *createQuicklistObject(quicklistContainerType *type) {
+    quicklist *l = quicklistCreate(type);
     robj *o = createObject(OBJ_LIST,l);
     o->encoding = OBJ_ENCODING_QUICKLIST;
     return o;
@@ -813,7 +813,7 @@ size_t objectComputeSize(robj *o, size_t sample_size) {
             quicklistNode *node = ql->head;
             asize = sizeof(*o)+sizeof(quicklist);
             do {
-                elesize += sizeof(quicklistNode)+ziplistBlobLen(node->zl);
+                elesize += sizeof(quicklistNode)+node->sz;
                 samples++;
             } while ((node = node->next) && samples < sample_size);
             asize += (double)elesize/samples*ql->len;

--- a/src/server.c
+++ b/src/server.c
@@ -6133,7 +6133,7 @@ struct redisTest {
     {"zmalloc", zmalloc_test},
     {"sds", sdsTest},
     {"dict", dictTest},
-    {"listpack", listpackTest}
+    {"listpack", listpackTest},
 };
 redisTestProc *getTestProcByName(const char *name) {
     int numtests = sizeof(redisTests)/sizeof(struct redisTest);

--- a/src/server.c
+++ b/src/server.c
@@ -6132,7 +6132,8 @@ struct redisTest {
     {"crc64", crc64Test},
     {"zmalloc", zmalloc_test},
     {"sds", sdsTest},
-    {"dict", dictTest}
+    {"dict", dictTest},
+    {"listpack", listpackTest}
 };
 redisTestProc *getTestProcByName(const char *name) {
     int numtests = sizeof(redisTests)/sizeof(struct redisTest);

--- a/src/server.h
+++ b/src/server.h
@@ -661,7 +661,7 @@ typedef struct RedisModuleDigest {
 #define OBJ_ENCODING_INTSET 6  /* Encoded as intset */
 #define OBJ_ENCODING_SKIPLIST 7  /* Encoded as skiplist */
 #define OBJ_ENCODING_EMBSTR 8  /* Embedded sds string encoding */
-#define OBJ_ENCODING_QUICKLIST 9 /* Encoded as linked list of ziplists */
+#define OBJ_ENCODING_QUICKLIST 9 /* Encoded as linked list of listpacks */
 #define OBJ_ENCODING_STREAM 10 /* Encoded as a radix tree of listpacks */
 
 #define LRU_BITS 24
@@ -1525,7 +1525,7 @@ struct redisServer {
     size_t stream_node_max_bytes;
     long long stream_node_max_entries;
     /* List parameters */
-    int list_max_ziplist_size;
+    int list_max_listpack_size;
     int list_compress_depth;
     /* time cache */
     redisAtomic time_t unixtime; /* Unix time sampled every cron cycle. */
@@ -1978,7 +1978,7 @@ size_t stringObjectLen(robj *o);
 robj *createStringObjectFromLongLong(long long value);
 robj *createStringObjectFromLongLongForValue(long long value);
 robj *createStringObjectFromLongDouble(long double value, int humanfriendly);
-robj *createQuicklistObject(void);
+robj *createQuicklistObject(quicklistContainerType *type);
 robj *createZiplistObject(void);
 robj *createSetObject(void);
 robj *createIntsetObject(void);

--- a/src/sort.c
+++ b/src/sort.c
@@ -289,7 +289,7 @@ void sortCommand(client *c) {
     if (sortval)
         incrRefCount(sortval);
     else
-        sortval = createQuicklistObject();
+        sortval = createQuicklistObject(&quicklistContainerTypeListpack);
 
 
     /* When sorting a set with no sort specified, we must sort the output
@@ -538,7 +538,7 @@ void sortCommand(client *c) {
             }
         }
     } else {
-        robj *sobj = createQuicklistObject();
+        robj *sobj = createQuicklistObject(&quicklistContainerTypeListpack);
 
         /* STORE option specified, set the sorting result as a List object */
         for (j = start; j <= end; j++) {

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -241,12 +241,12 @@ robj *streamDup(robj *o) {
     return sobj;
 }
 
-/* This is just a wrapper for lpAppend() to directly use a 64 bit integer
+/* This is just a wrapper for lpPushTail() to directly use a 64 bit integer
  * instead of a string. */
 unsigned char *lpAppendInteger(unsigned char *lp, int64_t value) {
     char buf[LONG_STR_SIZE];
     int slen = ll2string(buf,sizeof(buf),value);
-    return lpAppend(lp,(unsigned char*)buf,slen);
+    return lpPushTail(lp,(unsigned char*)buf,slen);
 }
 
 /* This is just a wrapper for lpReplace() to directly use a 64 bit integer
@@ -545,7 +545,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
         lp = lpAppendInteger(lp,numfields);
         for (int64_t i = 0; i < numfields; i++) {
             sds field = argv[i*2]->ptr;
-            lp = lpAppend(lp,(unsigned char*)field,sdslen(field));
+            lp = lpPushTail(lp,(unsigned char*)field,sdslen(field));
         }
         lp = lpAppendInteger(lp,0); /* Master entry zero terminator. */
         raxInsert(s->rax,(unsigned char*)&rax_key,sizeof(rax_key),lp,NULL);
@@ -618,8 +618,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
     for (int64_t i = 0; i < numfields; i++) {
         sds field = argv[i*2]->ptr, value = argv[i*2+1]->ptr;
         if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS))
-            lp = lpAppend(lp,(unsigned char*)field,sdslen(field));
-        lp = lpAppend(lp,(unsigned char*)value,sdslen(value));
+            lp = lpPushTail(lp,(unsigned char*)field,sdslen(field));
+        lp = lpPushTail(lp,(unsigned char*)value,sdslen(value));
     }
     /* Compute and store the lp-count field. */
     int64_t lp_count = numfields;
@@ -3556,7 +3556,7 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep) {
 
     /* Since we don't want to run validation of all records twice, we'll
      * run the listpack validation of just the header and do the rest here. */
-    if (!lpValidateIntegrity(lp, size, 0))
+    if (!lpValidateIntegrity(lp, size, 0, NULL, NULL))
         return 0;
 
     /* In non-deep mode we just validated the listpack header (encoded size) */

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -30,7 +30,7 @@ proc generate_collections {suffix elements} {
 
 # generate keys with various types and encodings
 proc generate_types {} {
-    r config set list-max-ziplist-size 5
+    r config set list-max-listpack-size 5
     r config set hash-max-ziplist-entries 5
     r config set zset-max-ziplist-entries 5
     r config set stream-node-max-entries 5

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -169,7 +169,7 @@ start_server {tags {"defrag"} overrides {appendonly yes auto-aof-rewrite-percent
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 2mb
             r config set maxmemory 0
-            r config set list-max-ziplist-size 5 ;# list of 10k items will have 2000 quicklist nodes
+            r config set list-max-listpack-size 5 ;# list of 10k items will have 2000 quicklist nodes
             r config set stream-node-max-entries 5
             r hmset hash h1 v1 h2 v2 h3 v3
             r lpush list a b c d
@@ -298,7 +298,7 @@ start_server {tags {"defrag"} overrides {appendonly yes auto-aof-rewrite-percent
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 2mb
             r config set maxmemory 0
-            r config set list-max-ziplist-size 5 ;# list of 500k items will have 100k quicklist nodes
+            r config set list-max-listpack-size 5 ;# list of 500k items will have 100k quicklist nodes
 
             # create big keys with 10k items
             set rd [redis_deferring_client]

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -1,7 +1,7 @@
 start_server {
     tags {"sort"}
     overrides {
-        "list-max-ziplist-size" 32
+        "list-max-listpack-size" 32
         "set-max-intset-entries" 32
     }
 } {

--- a/tests/unit/type/list-2.tcl
+++ b/tests/unit/type/list-2.tcl
@@ -1,7 +1,7 @@
 start_server {
     tags {"list"}
     overrides {
-        "list-max-ziplist-size" 4
+        "list-max-listpack-size" 4
     }
 } {
     source "tests/unit/type/list-common.tcl"

--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -1,7 +1,7 @@
 start_server {
-    tags {list ziplist}
+    tags {list listpack}
     overrides {
-        "list-max-ziplist-size" 16
+        "list-max-listpack-size" 16
     }
 } {
     test {Explicit regression for a list bug} {
@@ -58,7 +58,7 @@ start_server {
     }
 
     tags {slow} {
-        test {ziplist implementation: value encoding and backlink} {
+        test {listpack implementation: value encoding and backlink} {
             if {$::accurate} {set iterations 100} else {set iterations 10}
             for {set j 0} {$j < $iterations} {incr j} {
                 r del l
@@ -95,7 +95,7 @@ start_server {
             }
         }
 
-        test {ziplist implementation: encoding stress testing} {
+        test {listpack implementation: encoding stress testing} {
             for {set j 0} {$j < 200} {incr j} {
                 r del l
                 set l {}

--- a/tests/unit/type/list-common.tcl
+++ b/tests/unit/type/list-common.tcl
@@ -1,5 +1,5 @@
-# We need a value larger than list-max-ziplist-value to make sure
+# We need a value larger than list-max-listpack-size to make sure
 # the list has the right encoding when it is swapped in again.
 array set largevalue {}
-set largevalue(ziplist) "hello"
+set largevalue(listpack) "hello"
 set largevalue(linkedlist) [string repeat "hello" 4]

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -9,7 +9,7 @@ proc wait_for_blocked_client {} {
 start_server {
     tags {"list"}
     overrides {
-        "list-max-ziplist-size" 5
+        "list-max-listpack-size" 5
     }
 } {
     source "tests/unit/type/list-common.tcl"
@@ -64,32 +64,32 @@ start_server {
         assert {[r LPOS mylist b COUNT 10 RANK 5] eq {}}
     }
 
-    test {LPUSH, RPUSH, LLENGTH, LINDEX, LPOP - ziplist} {
+    test {LPUSH, RPUSH, LLENGTH, LINDEX, LPOP - listpack} {
         # first lpush then rpush
-        assert_equal 1 [r lpush myziplist1 aa]
-        assert_equal 2 [r rpush myziplist1 bb]
-        assert_equal 3 [r rpush myziplist1 cc]
-        assert_equal 3 [r llen myziplist1]
-        assert_equal aa [r lindex myziplist1 0]
-        assert_equal bb [r lindex myziplist1 1]
-        assert_equal cc [r lindex myziplist1 2]
-        assert_equal {} [r lindex myziplist2 3]
-        assert_equal cc [r rpop myziplist1]
-        assert_equal aa [r lpop myziplist1]
-        assert_encoding quicklist myziplist1
+        assert_equal 1 [r lpush mylistpack1 aa]
+        assert_equal 2 [r rpush mylistpack1 bb]
+        assert_equal 3 [r rpush mylistpack1 cc]
+        assert_equal 3 [r llen mylistpack1]
+        assert_equal aa [r lindex mylistpack1 0]
+        assert_equal bb [r lindex mylistpack1 1]
+        assert_equal cc [r lindex mylistpack1 2]
+        assert_equal {} [r lindex mylistpack2 3]
+        assert_equal cc [r rpop mylistpack1]
+        assert_equal aa [r lpop mylistpack1]
+        assert_encoding quicklist mylistpack1
 
         # first rpush then lpush
-        assert_equal 1 [r rpush myziplist2 a]
-        assert_equal 2 [r lpush myziplist2 b]
-        assert_equal 3 [r lpush myziplist2 c]
-        assert_equal 3 [r llen myziplist2]
-        assert_equal c [r lindex myziplist2 0]
-        assert_equal b [r lindex myziplist2 1]
-        assert_equal a [r lindex myziplist2 2]
-        assert_equal {} [r lindex myziplist2 3]
-        assert_equal a [r rpop myziplist2]
-        assert_equal c [r lpop myziplist2]
-        assert_encoding quicklist myziplist2
+        assert_equal 1 [r rpush mylistpack2 a]
+        assert_equal 2 [r lpush mylistpack2 b]
+        assert_equal 3 [r lpush mylistpack2 c]
+        assert_equal 3 [r llen mylistpack2]
+        assert_equal c [r lindex mylistpack2 0]
+        assert_equal b [r lindex mylistpack2 1]
+        assert_equal a [r lindex mylistpack2 2]
+        assert_equal {} [r lindex mylistpack2 3]
+        assert_equal a [r rpop mylistpack2]
+        assert_equal c [r lpop mylistpack2]
+        assert_encoding quicklist mylistpack2
     }
 
     test {LPUSH, RPUSH, LLENGTH, LINDEX, LPOP - regular list} {
@@ -1107,17 +1107,19 @@ start_server {
         assert_equal {l foo} [$rd read]
     } {}
 
-    test {List ziplist of various encodings} {
+    test {List listpack of various encodings} {
         r del k
-        r lpush k 127 ;# ZIP_INT_8B
-        r lpush k 32767 ;# ZIP_INT_16B
-        r lpush k 2147483647 ;# ZIP_INT_32B
-        r lpush k 9223372036854775808 ;# ZIP_INT_64B
-        r lpush k 0 ;# ZIP_INT_IMM_MIN
-        r lpush k 12 ;# ZIP_INT_IMM_MAX
-        r lpush k [string repeat x 31] ;# ZIP_STR_06B
-        r lpush k [string repeat x 8191] ;# ZIP_STR_14B
-        r lpush k [string repeat x 65535] ;# ZIP_STR_32B
+        r lpush k 127 ;# LP_ENCODING_7BIT_UINT
+        r lpush k 4095 ;# LP_ENCODING_13BIT_INT
+        r lpush k 32767 ;# LP_ENCODING_16BIT_INT
+        r lpush k 8388607 ;# LP_ENCODING_24BIT_INT
+        r lpush k 2147483647 ;# LP_ENCODING_32BIT_INT
+        r lpush k 9223372036854775807 ;# LP_ENCODING_64BIT_INT
+        r lpush k 0
+        r lpush k 12
+        r lpush k [string repeat x 31] ;# LP_ENCODING_6BIT_STR
+        r lpush k [string repeat x 4095] ;# LP_ENCODING_12BIT_STR
+        r lpush k [string repeat x 65535] ;# LP_ENCODING_32BIT_STR
         set k [r lrange k 0 -1]
         set dump [r dump k]
 
@@ -1127,20 +1129,20 @@ start_server {
 
         # try some forward and backward searches to make sure all encodings
         # can be traversed
-        assert_equal [r lindex kk 5] {9223372036854775808}
-        assert_equal [r lindex kk -5] {0}
+        assert_equal [r lindex kk 5] {9223372036854775807}
+        assert_equal [r lindex kk -7] {0}
         assert_equal [r lpos kk foo rank 1] {}
         assert_equal [r lpos kk foo rank -1] {}
 
         # make sure the values are right
         assert_equal $k $kk
         assert_equal [lpop k] [string repeat x 65535]
-        assert_equal [lpop k] [string repeat x 8191]
+        assert_equal [lpop k] [string repeat x 4095]
         assert_equal [lpop k] [string repeat x 31]
         set _ $k
-    } {12 0 9223372036854775808 2147483647 32767 127}
+    } {12 0 9223372036854775807 2147483647 8388607 32767 4095 127}
 
-    test {List ziplist of various encodings - sanitize dump} {
+    test {List listpack of various encodings - sanitize dump} {
         r config set sanitize-dump-payload yes
         r restore kk 0 $dump replace
         set k [r lrange k 0 -1]
@@ -1149,9 +1151,9 @@ start_server {
         # make sure the values are right
         assert_equal $k $kk
         assert_equal [lpop k] [string repeat x 65535]
-        assert_equal [lpop k] [string repeat x 8191]
+        assert_equal [lpop k] [string repeat x 4095]
         assert_equal [lpop k] [string repeat x 31]
         set _ $k
-    } {12 0 9223372036854775808 2147483647 32767 127}
+    } {12 0 9223372036854775807 2147483647 8388607 32767 4095 127}
 
 }


### PR DESCRIPTION
Implement #8702

## Description of the feature
1) Add multi-container support to quicklist
    quicklsit only supports ziplist container, when replacing it with listpack container, it needs to replace a lot of code, if 
    we need to add new container type in the future, you still need to do the same thing.
    And quicklist can support multiple container easy at the same time, just add the new QuicklistContainerType.

2) Convert ziplist to listpack at runtime when the quicklsit node is accessed.
    If convert ziplist to listpack is done in rdb loading, it may slow down rdb loading.

2) Add some methods to the listpack to make it easier to support quicklist migration.
3) Add unit tests to listpack, and fix some bugs.

## Fix bugs
1) #8773  Fix lost of quicklistNodeUpdateSz.
2) Fix wrongly cal count in lpValidateIntegrity.