### PR TITLE
Add documentation for `firstkey`, `lastkey` and `keystep` parameters of `RedisModule_CreateCommand`

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -878,11 +878,14 @@ int64_t commandFlagsFromString(char *s) {
  *                        though it's not a write command.  
  *
  * The last three parameters specify which arguments of the new command are
- * Redis keys.
+ * Redis keys. See https://redis.io/commands/command for more info
  *
  * * 'firstkey': One-based index of the first argument that's a key.
+ *               Position 0 is always the command name itself.
  *               0 for commands with no keys.
  * * 'lastkey':  One-based index of the last argument that's a key.
+ *               Negative numbers refer to counting backwards from the last
+ *               argument (-1 means the last argument provided)
  *               0 for commands with no keys.
  * * 'keystep':  Step between first and last key indexes.
  *               0 for commands with no keys.

--- a/src/module.c
+++ b/src/module.c
@@ -878,7 +878,7 @@ int64_t commandFlagsFromString(char *s) {
  *                        though it's not a write command.  
  *
  * The last three parameters specify which arguments of the new command are
- * Redis keys. See https://redis.io/commands/command for more info
+ * Redis keys. See https://redis.io/commands/command for more information.
  *
  * * 'firstkey': One-based index of the first argument that's a key.
  *               Position 0 is always the command name itself.

--- a/src/module.c
+++ b/src/module.c
@@ -818,7 +818,7 @@ int64_t commandFlagsFromString(char *s) {
 }
 
 /* Register a new command in the Redis server, that will be handled by
- * calling the function pointer 'func' using the RedisModule calling
+ * calling the function pointer 'cmdfunc' using the RedisModule calling
  * convention. The function returns REDISMODULE_ERR if the specified command
  * name is already busy or a set of invalid flags were passed, otherwise
  * REDISMODULE_OK is returned and the new command is registered.
@@ -876,6 +876,18 @@ int64_t commandFlagsFromString(char *s) {
  *                     to authenticate a client. 
  * * **"may-replicate"**: This command may generate replication traffic, even
  *                        though it's not a write command.  
+ *
+ * The last three parameters specify which arguments of the new command are
+ * Redis keys.
+ *
+ * * 'firstkey': One-based index of the first argument that's a key.
+ *               0 for commands with no keys.
+ * * 'lastkey':  One-based index of the last argument that's a key.
+ *               0 for commands with no keys.
+ * * 'keystep':  Step between first and last key indexes.
+ *               0 for commands with no keys.
+ *
+ * This information is used by ACL, Cluster and the 'COMMAND' command.
  */
 int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) {
     int64_t flags = strflags ? commandFlagsFromString((char*)strflags) : 0;


### PR DESCRIPTION
These parameters of `RedisModule_CreateCommand` were previously undocumented but they are needed for ACL to check permission on keys and also by Redis Cluster to figure our how to route the command.

Previously submitted to redis-doc: https://github.com/redis/redis-doc/pull/1562