### PR TITLE
redis-cli: Sleep for a while in each cliConnect when we got connect error in cluster mode.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -869,13 +869,14 @@ static int cliConnect(int flags) {
             if (!(flags & CC_QUIET)) {
                 fprintf(stderr,"Could not connect to Redis at ");
                 if (config.hostsocket == NULL ||
-                    (config.cluster_mode && config.cluster_reissue_command)) {
+                    (config.cluster_mode && config.cluster_reissue_command))
+                {
                     fprintf(stderr, "%s:%d: %s\n",
                         config.hostip,config.hostport,context->errstr);
-                }
-                else
+                } else {
                     fprintf(stderr,"%s: %s\n",
                         config.hostsocket,context->errstr);
+                }
             }
             redisFree(context);
             context = NULL;
@@ -2006,23 +2007,21 @@ static int issueCommandRepeat(int argc, char **argv, long repeat) {
             /* If we still cannot send the command print error.
              * We'll try to reconnect the next time. */
             if (cliSendCommand(argc,argv,repeat) != REDIS_OK) {
-                goto error;
+                cliPrintContextError();
+                return REDIS_ERR;
             }
         }
 
         /* Issue the command again if we got redirected in cluster mode */
         if (config.cluster_mode && config.cluster_reissue_command) {
             /* If cliConnect fails, sleep for a while and try again. */
-            if (cliConnect(CC_FORCE) != REDIS_OK) sleep(1);
+            if (cliConnect(CC_FORCE) != REDIS_OK)
+                sleep(1);
         } else {
             break;
         }
     }
     return REDIS_OK;
-
-error:
-    cliPrintContextError();
-    return REDIS_ERR;
 }
 
 static int issueCommand(int argc, char **argv) {


### PR DESCRIPTION
reference: https://github.com/redis/redis/pull/8870
Inspired by @https://github.com/huangzhw/redis/commit/f7e5ecd588b4a4eab2a376f3cadf195e46a9ee4f . So i check the code again and found another infinite loop.... (my fault, did not double check last time) and thank @huangzhw 

Except for the error message, if we close the target server, it will stuck `while (1)` . Also a infinite loop.

Also ping @oranagra . Take a look for me again  :) ... Thanks

before:
![image](https://user-images.githubusercontent.com/22811481/116525619-49091b00-a90b-11eb-8dff-1f1b4261b298.png)

after:
![image](https://user-images.githubusercontent.com/22811481/116525629-4c040b80-a90b-11eb-8352-2b7334d05fa1.png)

