### PR TITLE
GEOSEARCHSTORE err string WITHCOORD to WITHCOORDS

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -652,7 +652,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
     /* Trap options not compatible with STORE and STOREDIST. */
     if (storekey && (withdist || withhash || withcoords)) {
         addReplyErrorFormat(c,
-            "%s is not compatible with WITHDIST, WITHHASH and WITHCOORD options",
+            "%s is not compatible with WITHDIST, WITHHASH and WITHCOORDS options",
             flags & GEOSEARCHSTORE? "GEOSEARCHSTORE": "STORE option in GEORADIUS");
         return;
     }


### PR DESCRIPTION
I changed WITHCOORDS to WITHCOORD when improving the err string. I'm changing back to WITHCOORDS so the original error is the same as it was before.