### PR TITLE
redis-cli: some commands should bypass history file.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2083,15 +2083,17 @@ static int isDangerousCommand(int argc, char **argv) {
     if (!strcasecmp(argv[0],"auth")) {
         return 1;
     } else if (argc > 1 &&
-            !strcasecmp(argv[0],"acl") &&
-            !strcasecmp(argv[1],"setuser")) {
+        !strcasecmp(argv[0],"acl") &&
+        !strcasecmp(argv[1],"setuser"))
+    {
         return 1;
     } else if (argc > 2 &&
-            !strcasecmp(argv[0],"config") &&
-            !strcasecmp(argv[1],"set") && (
-                !strcasecmp(argv[2],"masterauth") ||
-                !strcasecmp(argv[2],"masteruser") ||
-                !strcasecmp(argv[2],"requirepass"))) {
+        !strcasecmp(argv[0],"config") &&
+        !strcasecmp(argv[1],"set") && (
+            !strcasecmp(argv[2],"masterauth") ||
+            !strcasecmp(argv[2],"masteruser") ||
+            !strcasecmp(argv[2],"requirepass")))
+    {
         return 1;
     /* HELLO [protover [AUTH username password] [SETNAME clientname]] */
     } else if (argc > 4 && !strcasecmp(argv[0],"hello")) {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2072,7 +2072,7 @@ void cliLoadPreferences(void) {
     sdsfree(rcfile);
 }
 
-/* We think some commands is dangerous and shoudn't be output in history file.
+/* We think some commands are dangerous and shoudn't be output in history file.
  * Currently these commands are inclued:
  * - AUTH
  * - ACL SETUSER
@@ -2114,8 +2114,7 @@ static int isDangerousCommand(int argc, char **argv) {
                 return 1;
             } else if (!strcasecmp(argv[j],"auth2") && moreargs >= 2) {
                 return 1;
-            } else if (strcasecmp(argv[j],"copy") &&
-                    strcasecmp(argv[j],"replace")) {
+            } else if (!strcasecmp(argv[j],"keys") && moreargs) {
                 return 0;
             }
         }
@@ -2179,7 +2178,6 @@ static void repl(void) {
                 }
             }
 
-            /* Won't save auth or acl setuser commands in history file */
             int dangerous = 0;
             if (argv && argc > 0) {
                 dangerous = isDangerousCommand(argc - skipargs, argv + skipargs);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2072,14 +2072,14 @@ void cliLoadPreferences(void) {
     sdsfree(rcfile);
 }
 
-/* We think some commands are dangerous and shoudn't be output in history file.
- * Currently these commands are inclued:
+/* Some commands can include sensitive information and shouldn't be put in the
+ * history file. Currently these commands are include:
  * - AUTH
  * - ACL SETUSER
  * - CONFIG SET masterauth/masteruser/requirepass
  * - HELLO with [AUTH username password]
  * - MIGRATE with [AUTH password] or [AUTH2 username password] */
-static int isDangerousCommand(int argc, char **argv) {
+static int isSensitiveCommand(int argc, char **argv) {
     if (!strcasecmp(argv[0],"auth")) {
         return 1;
     } else if (argc > 1 &&
@@ -2190,7 +2190,7 @@ static void repl(void) {
                 repeat = 1;
             }
 
-            if (!isDangerousCommand(argc - skipargs, argv + skipargs)) {
+            if (!isSensitiveCommand(argc - skipargs, argv + skipargs)) {
                 if (history) linenoiseHistoryAdd(line);
                 if (historyfile) linenoiseHistorySave(historyfile);
             }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2164,6 +2164,8 @@ static void repl(void) {
             if (argv == NULL) {
                 printf("Invalid argument(s)\n");
                 fflush(stdout);
+                if (history) linenoiseHistoryAdd(line);
+                if (historyfile) linenoiseHistorySave(historyfile);
                 linenoiseFree(line);
                 continue;
             } else if (argc == 0) {


### PR DESCRIPTION
Currently in redis-cli only AUTH and ACL SETUSER bypass history
file. We add CONFIG SET masterauth/masteruser/requirepass,
HELLO with AUTH, MIGRATE with AUTH or AUTH2 to bypass history
file too.

The drawback is HELLO and MIGRATE's code is a mess. Someday if
we change these commands, we have to change here too.