### PR TITLE
redis-cli.c: Improve warning message when using '--pass' option.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1777,7 +1777,7 @@ static int parseOptions(int argc, char **argv) {
     }
 
     if (!config.no_auth_warning && config.auth != NULL) {
-        fputs("Warning: Using a password with '-a' or '-u' option on the command"
+        fputs("Warning: Using a password with '-a' or '-u' or '--pass' option on the command"
               " line interface may not be safe.\n", stderr);
     }
 


### PR DESCRIPTION
Sometime i use `--pass` to connect the redis just for test. And i add it in the warning message.

--pass <password>  Alias of -a for consistency with the new --user option.

before:
```
[root@binblog redis]# src/redis-cli --pass 123456
Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
127.0.0.1:6379>
```

after:
```
[root@binblog redis]# src/redis-cli --pass 123456
Warning: Using a password with '-a' or '-u' or '--pass' option on the command line interface may not be safe.
127.0.0.1:6379>
```