### PR TITLE
Free value if dup succeed but listAddNodeTail failed.

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -272,6 +272,11 @@ list *listDup(list *orig)
         } else
             value = node->value;
         if (listAddNodeTail(copy, value) == NULL) {
+            /* Free value if dup succeed but listAddNodeTail failed. */
+            if (copy->free) {
+                copy->free(value);
+            }
+
             listRelease(copy);
             return NULL;
         }

--- a/src/adlist.c
+++ b/src/adlist.c
@@ -269,13 +269,13 @@ list *listDup(list *orig)
                 listRelease(copy);
                 return NULL;
             }
-        } else
+        } else {
             value = node->value;
+        }
+        
         if (listAddNodeTail(copy, value) == NULL) {
             /* Free value if dup succeed but listAddNodeTail failed. */
-            if (copy->free) {
-                copy->free(value);
-            }
+            if (copy->free) copy->free(value);
 
             listRelease(copy);
             return NULL;


### PR DESCRIPTION
I think there may be a leak if dup succeed but listAddNodeTail zmalloc failed.
Better call copy->free if it exist?