### PR TITLE
Unsigned int should use %u in string format.

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -936,8 +936,8 @@ void _serverAssertPrintClientInfo(const client *c) {
 }
 
 void serverLogObjectDebugInfo(const robj *o) {
-    serverLog(LL_WARNING,"Object type: %d", o->type);
-    serverLog(LL_WARNING,"Object encoding: %d", o->encoding);
+    serverLog(LL_WARNING,"Object type: %u", o->type);
+    serverLog(LL_WARNING,"Object encoding: %u", o->encoding);
     serverLog(LL_WARNING,"Object refcount: %d", o->refcount);
 #if UNSAFE_CRASH_REPORT
     /* This code is now disabled. o->ptr may be unreliable to print. in some


### PR DESCRIPTION
This commit did not fix any bugs. I think using it will be more standardized...
```
typedef struct redisObject {
    unsigned type:4;
    unsigned encoding:4;
```