### PR TITLE
redis-cli: Fix integer overflow in intrinsic-latency

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -8142,7 +8142,7 @@ static void intrinsicLatencyModeStop(int s) {
 static void intrinsicLatencyMode(void) {
     long long test_end, run_time, max_latency = 0, runs = 0;
 
-    run_time = config.intrinsic_latency_duration*1000000;
+    run_time = (long long)config.intrinsic_latency_duration * 1000000;
     test_end = ustime() + run_time;
     signal(SIGINT, intrinsicLatencyModeStop);
 


### PR DESCRIPTION
There is a ploblem when using --intrinsic-latency. If we type a number greater than 2147, there is a int overflow ploblem. The run_time become a negative number...

2147483647 / 1000000 = 2147.483647
```
// intrinsic_latency_duration is a int
static struct config {
    int intrinsic_latency_duration; 
}
```

![image](https://user-images.githubusercontent.com/22811481/117031266-fc6e7700-ad32-11eb-99ad-f812c4c3aa0c.png)
