### PR TITLE
sds.c: Fix potential overflow in sdsll2str.

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -489,7 +489,17 @@ int sdsll2str(char *s, long long value) {
 
     /* Generate the string representation, this method produces
      * a reversed string. */
-    v = (value < 0) ? -value : value;
+    if (value < 0) {
+        /* Since v is unsigned, if value==LLONG_MIN, -LLONG_MIN will overflow. */
+        if (value != LLONG_MIN) {
+            v = -value;
+        } else {
+            v = ((unsigned long long)LLONG_MAX) + 1;
+        }
+    } else {
+        v = value;
+    }
+
     p = s;
     do {
         *p++ = '0'+(v%10);


### PR DESCRIPTION
i saw a ref issue: https://github.com/redis/redis/issues/4110

I did some tests, the test code:
```
    sds max_s = sdsfromlonglong(LLONG_MAX);
    printf("LLONG_MAX: %lld\n", LLONG_MAX);
    printf("LLONG_MAX to sds: %s\n", max_s);

    sds min_s = sdsfromlonglong(LLONG_MIN);
    printf("LLONG_MIN: %lld\n", LLONG_MIN);
    printf("LLONG_MIN to sds: %s\n", min_s);

    unsigned long long v;
    v = -LLONG_MIN;
    printf("-LLONG_MIN %llu\n", v);
```

output: The output is fine
```
LLONG_MAX: 9223372036854775807
LLONG_MAX to sds: 9223372036854775807
LLONG_MIN: -9223372036854775808
LLONG_MIN to sds: -9223372036854775808
-LLONG_MIN 9223372036854775808
```

But there will be a warning when compiling. So i think better have this fixed?
```
warning: integer overflow in expression ‘-9223372036854775808’ of type ‘long long int’ results in ‘-9223372036854775808’ [-Woverflow]

unsigned long long v;
v = -LLONG_MIN 
```

Maybe. I realize it's not very needed or necessary... Feel free to close it and the ref issue