### PR TITLE
Fix typos, and consistent function argument names in quicklist

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -192,7 +192,7 @@ REDIS_STATIC int __quicklistCompressNode(quicklistNode *node) {
     if (((lzf->sz = lzf_compress(node->zl, node->sz, lzf->compressed,
                                  node->sz)) == 0) ||
         lzf->sz + MIN_COMPRESS_IMPROVE >= node->sz) {
-        /* lzf_compress aborts/rejects compression if value not compressable. */
+        /* lzf_compress aborts/rejects compression if value not compressible. */
         zfree(lzf);
         return 0;
     }
@@ -240,7 +240,7 @@ REDIS_STATIC int __quicklistDecompressNode(quicklistNode *node) {
         }                                                                      \
     } while (0)
 
-/* Force node to not be immediately re-compresable */
+/* Force node to not be immediately re-compressible */
 #define quicklistDecompressNodeForUse(_node)                                   \
     do {                                                                       \
         if ((_node) && (_node)->encoding == QUICKLIST_NODE_ENCODING_LZF) {     \
@@ -668,7 +668,7 @@ void quicklistDelEntry(quicklistIter *iter, quicklistEntry *entry) {
      * doesn't move again because:
      *   - [1, 2, 3] => delete offset 1 => [1, 3]: next element still offset 1
      *   - [1, 2, 3] => delete offset 0 => [2, 3]: next element still offset 0
-     *  if we deleted the last element at offet N and now
+     *  if we deleted the last element at offset N and now
      *  length of this ziplist is N-1, the next call into
      *  quicklistNext() will jump to the next node. */
 }
@@ -1138,7 +1138,7 @@ int quicklistNext(quicklistIter *iter, quicklistEntry *entry) {
     entry->node = iter->current;
 
     if (!iter->current) {
-        D("Returning because current node is NULL")
+        D("Returning because current node is NULL");
         return 0;
     }
 
@@ -1438,7 +1438,7 @@ void quicklistPush(quicklist *quicklist, void *value, const size_t sz,
  * Returns 0 on failure (reached the maximum supported number of bookmarks).
  * NOTE: use short simple names, so that string compare on find is quick.
  * NOTE: bookmark creation may re-allocate the quicklist, so the input pointer
-         may change and it's the caller responsibilty to update the reference.
+         may change and it's the caller responsibility to update the reference.
  */
 int quicklistBookmarkCreate(quicklist **ql_ref, const char *name, quicklistNode *node) {
     quicklist *ql = *ql_ref;

--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -100,7 +100,7 @@ typedef struct quicklistBookmark {
  * 'compress' is: 0 if compression disabled, otherwise it's the number
  *                of quicklistNodes to leave uncompressed at ends of quicklist.
  * 'fill' is the user-requested (or default) fill factor.
- * 'bookmakrs are an optional feature that is used by realloc this struct,
+ * 'bookmarks are an optional feature that is used by realloc this struct,
  *      so that they don't consume memory when not used. */
 typedef struct quicklist {
     quicklistNode *head;
@@ -164,9 +164,9 @@ quicklist *quicklistAppendValuesFromZiplist(quicklist *quicklist,
                                             unsigned char *zl);
 quicklist *quicklistCreateFromZiplist(int fill, int compress,
                                       unsigned char *zl);
-void quicklistInsertAfter(quicklist *quicklist, quicklistEntry *node,
+void quicklistInsertAfter(quicklist *quicklist, quicklistEntry *entry,
                           void *value, const size_t sz);
-void quicklistInsertBefore(quicklist *quicklist, quicklistEntry *node,
+void quicklistInsertBefore(quicklist *quicklist, quicklistEntry *entry,
                            void *value, const size_t sz);
 void quicklistDelEntry(quicklistIter *iter, quicklistEntry *entry);
 int quicklistReplaceAtIndex(quicklist *quicklist, long index, void *data,
@@ -175,7 +175,7 @@ int quicklistDelRange(quicklist *quicklist, const long start, const long stop);
 quicklistIter *quicklistGetIterator(const quicklist *quicklist, int direction);
 quicklistIter *quicklistGetIteratorAtIdx(const quicklist *quicklist,
                                          int direction, const long long idx);
-int quicklistNext(quicklistIter *iter, quicklistEntry *node);
+int quicklistNext(quicklistIter *iter, quicklistEntry *entry);
 void quicklistReleaseIterator(quicklistIter *iter);
 quicklist *quicklistDup(quicklist *orig);
 int quicklistIndex(const quicklist *quicklist, const long long index,


### PR DESCRIPTION
1. `quicklistEntry *node`, This may cause some confusion. In the code, we usually use `quicklistNode *node` and `quicklistEntry *entry`
2. fix some typos
3. D missing a `;`  (btw, shoud we delete all the D?)

did not fix any bugs or something . Feel free to close if unneeded