### PR TITLE
fix redis-benchmark to ignore unsupported configs

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -361,9 +361,10 @@ fail:
     if (hostsocket == NULL) fprintf(stderr, "%s:%d\n", ip, port);
     else fprintf(stderr, "%s\n", hostsocket);
     int abort_test = 0;
-    if (!strncmp(reply->str,"NOAUTH",5) ||
-        !strncmp(reply->str,"WRONGPASS",9) ||
-        !strncmp(reply->str,"NOPERM",5))
+    if (reply->type == REDIS_REPLY_ERROR &&
+        (!strncmp(reply->str,"NOAUTH",5) ||
+         !strncmp(reply->str,"WRONGPASS",9) ||
+         !strncmp(reply->str,"NOPERM",5)))
         abort_test = 1;
     freeReplyObject(reply);
     redisFree(c);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -361,7 +361,7 @@ fail:
     if (hostsocket == NULL) fprintf(stderr, "%s:%d\n", ip, port);
     else fprintf(stderr, "%s\n", hostsocket);
     int abort_test = 0;
-    if (reply->type == REDIS_REPLY_ERROR &&
+    if (reply && reply->type == REDIS_REPLY_ERROR &&
         (!strncmp(reply->str,"NOAUTH",5) ||
          !strncmp(reply->str,"WRONGPASS",9) ||
          !strncmp(reply->str,"NOPERM",5)))


### PR DESCRIPTION
Redis Enterprise supports the CONFIG GET command, but it replies with am
empty array since the save and appendonly configs are not supported.
before this fix redis-benchmark would segfault for trying to access the
error string on an array type reply.
see #8869