### PR TITLE
Fix BITOP deletes destination key if operands are empty strings

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -657,7 +657,7 @@ void bitopCommand(client *c) {
     }
 
     /* Compute the bit operation, if at least one string is not empty. */
-    if (maxlen || nullobjs < numkeys) {
+    if (nullobjs < numkeys) {
         res = (unsigned char*) sdsnewlen(NULL,maxlen);
         unsigned char output, byte;
         unsigned long i;
@@ -766,7 +766,7 @@ void bitopCommand(client *c) {
     zfree(objects);
 
     /* Store the computed value into the target key */
-    if (maxlen || nullobjs < numkeys) {
+    if (nullobjs < numkeys) {
         o = createObject(OBJ_STRING,res);
         setKey(c,c->db,targetkey,o);
         notifyKeyspaceEvent(NOTIFY_STRING,"set",targetkey,c->db->id);

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -593,7 +593,7 @@ void getbitCommand(client *c) {
 void bitopCommand(client *c) {
     char *opname = c->argv[1]->ptr;
     robj *o, *targetkey = c->argv[2];
-    unsigned long op, j, numkeys;
+    unsigned long op, j, numkeys, nullobjs = 0;
     robj **objects;      /* Array of source objects. */
     unsigned char **src; /* Array of source strings pointers. */
     unsigned long *len, maxlen = 0; /* Array of length of src strings,
@@ -634,6 +634,7 @@ void bitopCommand(client *c) {
             src[j] = NULL;
             len[j] = 0;
             minlen = 0;
+            nullobjs++;
             continue;
         }
         /* Return an error if one of the keys is not a string. */
@@ -656,7 +657,7 @@ void bitopCommand(client *c) {
     }
 
     /* Compute the bit operation, if at least one string is not empty. */
-    if (maxlen) {
+    if (maxlen || nullobjs < numkeys) {
         res = (unsigned char*) sdsnewlen(NULL,maxlen);
         unsigned char output, byte;
         unsigned long i;
@@ -765,7 +766,7 @@ void bitopCommand(client *c) {
     zfree(objects);
 
     /* Store the computed value into the target key */
-    if (maxlen) {
+    if (maxlen || nullobjs < numkeys) {
         o = createObject(OBJ_STRING,res);
         setKey(c,c->db,targetkey,o);
         notifyKeyspaceEvent(NOTIFY_STRING,"set",targetkey,c->db->id);

--- a/tests/unit/bitops.tcl
+++ b/tests/unit/bitops.tcl
@@ -214,6 +214,15 @@ start_server {tags {"bitops"}} {
         r bitop or x a b
     } {32}
 
+    test {BITOP with input all empty string or nil} {
+        assert_equal [r bitop and dest c d] 0
+        assert_equal [r exists dest] 0
+        r set c ""
+        assert_equal [r bitop and dest c d] 0
+        assert_equal [r exists dest] 1
+        assert_equal [r get dest] ""
+    }
+
     test {BITPOS bit=0 with empty key returns 0} {
         r del str
         r bitpos str 0


### PR DESCRIPTION
Fix https://github.com/redis/redis/issues/6967

When BITOP input keys are not all nil but only empty strings, 
the result should be empty string not delete the key.