### PR TITLE
comment typo: form -> from

### DIFF
--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1033,7 +1033,7 @@ uint64_t hllCount(struct hllhdr *hdr, int *invalid) {
         serverPanic("Unknown HyperLogLog encoding in hllCount()");
     }
 
-    /* Estimate cardinality form register histogram. See:
+    /* Estimate cardinality from register histogram. See:
      * "New cardinality estimation algorithms for HyperLogLog sketches"
      * Otmar Ertl, arXiv:1702.01284 */
     double z = m * hllTau((m-reghisto[HLL_Q+1])/(double)m);


### PR DESCRIPTION
I was just reading this lovely HyperLogLog implementation and noticed a small typo in a comment.

Keep up the great work. Redis is awesome!