### PR TITLE
redis-benchmark bad check for NOAUTH and NOPERM

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -362,9 +362,9 @@ fail:
     else fprintf(stderr, "%s\n", hostsocket);
     int abort_test = 0;
     if (reply && reply->type == REDIS_REPLY_ERROR &&
-        (!strncmp(reply->str,"NOAUTH",5) ||
+        (!strncmp(reply->str,"NOAUTH",6) ||
          !strncmp(reply->str,"WRONGPASS",9) ||
-         !strncmp(reply->str,"NOPERM",5)))
+         !strncmp(reply->str,"NOPERM",6)))
         abort_test = 1;
     freeReplyObject(reply);
     redisFree(c);
@@ -530,21 +530,21 @@ static void readHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
                             * before requesting the new configuration. */
                             fetch_slots = 1;
                             do_wait = 1;
-                            printf("Error from server %s:%d: %s.\n",
-                                   c->cluster_node->ip,
-                                   c->cluster_node->port,
-                                   r->str);
+                            fprintf(stderr, "Error from server %s:%d: %s.\n",
+                                    c->cluster_node->ip,
+                                    c->cluster_node->port,
+                                    r->str);
                         }
                         if (do_wait) sleep(1);
                         if (fetch_slots && !fetchClusterSlotsConfiguration(c))
                             exit(1);
                     } else {
                         if (c->cluster_node) {
-                            printf("Error from server %s:%d: %s\n",
-                                c->cluster_node->ip,
-                                c->cluster_node->port,
-                                r->str);
-                        } else printf("Error from server: %s\n", r->str);
+                            fprintf(stderr, "Error from server %s:%d: %s\n",
+                                 c->cluster_node->ip,
+                                 c->cluster_node->port,
+                                 r->str);
+                        } else fprintf(stderr, "Error from server: %s\n", r->str);
                         exit(1);
                     }
                 }


### PR DESCRIPTION
also, print errors to stderr rather than stdout