### PR TITLE
Fix crash unlinking a stream with groups rax and no groups

### DIFF
--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -109,7 +109,7 @@ size_t lazyfreeGetFreeEffort(robj *key, robj *obj) {
         /* Every consumer group is an allocation and so are the entries in its
          * PEL. We use size of the first group's PEL as an estimate for all
          * others. */
-        if (s->cgroups) {
+        if (s->cgroups && raxSize(s->cgroups)) {
             raxIterator ri;
             streamCG *cg;
             raxStart(&ri,s->cgroups);


### PR DESCRIPTION
When estimating the effort for unlink, we try to compute the effort of
the first group and extrapolate.
If there's a groups rax that's empty, there'a an assertion.

reproduce:
```
xadd s * a b
xgroup create s bla $
xgroup destroy s bla
unlink s
```

it'll hit this assertion in lazyfree.c:
```c
            raxStart(&ri,s->cgroups);
            raxSeek(&ri,"^",NULL,0);
            /* There must be at least one group so the following should always
             * work. */
            serverAssert(raxNext(&ri));
```