### PR TITLE
Avoid passing GeoHashRadius by value

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -355,20 +355,20 @@ int membersOfGeoHashBox(robj *zobj, GeoHashBits hash, geoArray *ga, GeoShape *sh
 }
 
 /* Search all eight neighbors + self geohash box */
-int membersOfAllNeighbors(robj *zobj, GeoHashRadius n, GeoShape *shape, geoArray *ga, unsigned long limit) {
+int membersOfAllNeighbors(robj *zobj, const GeoHashRadius *n, GeoShape *shape, geoArray *ga, unsigned long limit) {
     GeoHashBits neighbors[9];
     unsigned int i, count = 0, last_processed = 0;
     int debugmsg = 0;
 
-    neighbors[0] = n.hash;
-    neighbors[1] = n.neighbors.north;
-    neighbors[2] = n.neighbors.south;
-    neighbors[3] = n.neighbors.east;
-    neighbors[4] = n.neighbors.west;
-    neighbors[5] = n.neighbors.north_east;
-    neighbors[6] = n.neighbors.north_west;
-    neighbors[7] = n.neighbors.south_east;
-    neighbors[8] = n.neighbors.south_west;
+    neighbors[0] = n->hash;
+    neighbors[1] = n->neighbors.north;
+    neighbors[2] = n->neighbors.south;
+    neighbors[3] = n->neighbors.east;
+    neighbors[4] = n->neighbors.west;
+    neighbors[5] = n->neighbors.north_east;
+    neighbors[6] = n->neighbors.north_west;
+    neighbors[7] = n->neighbors.south_east;
+    neighbors[8] = n->neighbors.south_west;
 
     /* For each neighbor (*and* our own hashbox), get all the matching
      * members and add them to the potential result list. */
@@ -687,7 +687,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
 
     /* Search the zset for all matching points */
     geoArray *ga = geoArrayCreate();
-    membersOfAllNeighbors(zobj, georadius, &shape, ga, any ? count : 0);
+    membersOfAllNeighbors(zobj, &georadius, &shape, ga, any ? count : 0);
 
     /* If no matching results, the user gets an empty reply. */
     if (ga->used == 0 && storekey == NULL) {


### PR DESCRIPTION
This parameter of type GeoHashRadius is 192 bytes - passing a `const` pointer instead.