### PR TITLE
presize hashtable to avoid rehashing in hashTypeConvertZiplist()

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -470,6 +470,9 @@ void hashTypeConvertZiplist(robj *o, int enc) {
         hi = hashTypeInitIterator(o);
         dict = dictCreate(&hashDictType, NULL);
 
+        /* Presize the dict to avoid rehashing */
+        dictExpand(dict,hashTypeLength(o));
+
         while (hashTypeNext(hi) != C_ERR) {
             sds key, value;
 


### PR DESCRIPTION
Hi guys,

In `hashTypeConvertZiplist` from t_hash.c, when try to convert a hashtype from encoding `ziplist` to`hash` , redis just creates an empty dict and do the `dictAdd` one by one. 

As `hash_max_ziplist_entries` is set default to 512, this could lead to some unwanted rehashing process(4->8, 8->16, 16->32, 32->64, 64->128, 128->256, 256->512). 

And I also found that in `t_set.c` and `t_zset.c` they all do the presize to avoid rehashing. So I think do the hash table presize in `t_hash.c` should be fine.   

The only problem might be the time complexity of `ziplistLen`. As `hash_max_ziplist_entries` is set default to be 512, I think less time would be consumed than rehashing process.


