### PR TITLE
sinterstore: add missing keyspace del event when any source set not exists.

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -869,6 +869,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
             if (dstkey) {
                 if (dbDelete(c->db,dstkey)) {
                     signalModifiedKey(c,c->db,dstkey);
+                    notifyKeyspaceEvent(NOTIFY_GENERIC,"del",dstkey,c->db->id);
                     server.dirty++;
                 }
                 addReply(c,shared.czero);


### PR DESCRIPTION
This is the rebased PR for  https://github.com/redis/redis/pull/5585.
