### PR TITLE
[SENTINEL] reset sentinel-user/pass to NULL when user config with empty string

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3161,13 +3161,13 @@ void sentinelConfigSetCommand(client *c) {
         sentinel.announce_port = numval;
     } else if (!strcasecmp(o->ptr, "sentinel-user")) {
         sdsfree(sentinel.sentinel_auth_user);
-        sentinel.sentinel_auth_user = strcmp(val->ptr,"") ? 
-            sdsnew(val->ptr) : NULL;
+        sentinel.sentinel_auth_user = sdslen(val->ptr) == 0 ?
+            sdsdup(val->ptr) : NULL;
         drop_conns = 1;
     } else if (!strcasecmp(o->ptr, "sentinel-pass")) {
         sdsfree(sentinel.sentinel_auth_pass);
-        sentinel.sentinel_auth_pass = strcmp(val->ptr,"") ? 
-            sdsnew(val->ptr) : NULL;
+        sentinel.sentinel_auth_pass = sdslen(val->ptr) == 0 ?
+            sdsdup(val->ptr) : NULL;
         drop_conns = 1;
     } else {
         addReplyErrorFormat(c, "Invalid argument '%s' to SENTINEL CONFIG SET",

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3161,11 +3161,13 @@ void sentinelConfigSetCommand(client *c) {
         sentinel.announce_port = numval;
     } else if (!strcasecmp(o->ptr, "sentinel-user")) {
         sdsfree(sentinel.sentinel_auth_user);
-        sentinel.sentinel_auth_user = sdsnew(val->ptr);
+        sentinel.sentinel_auth_user = strcmp(val->ptr,"") ? 
+            sdsnew(val->ptr) : NULL;
         drop_conns = 1;
     } else if (!strcasecmp(o->ptr, "sentinel-pass")) {
         sdsfree(sentinel.sentinel_auth_pass);
-        sentinel.sentinel_auth_pass = sdsnew(val->ptr);
+        sentinel.sentinel_auth_pass = strcmp(val->ptr,"") ? 
+            sdsnew(val->ptr) : NULL;
         drop_conns = 1;
     } else {
         addReplyErrorFormat(c, "Invalid argument '%s' to SENTINEL CONFIG SET",


### PR DESCRIPTION
Before this commit, when user set sentinel-user/pass to empty string using SENTINEL CONFIG SET command, sentinel will consider "" as a vaild sernanme/password and dump into config file, therefore, the following error happens when start server again using same config file:

```
*** FATAL CONFIG FILE ERROR (Redis 255.255.255) ***
Reading the configuration file, at line 24
>>> 'sentinel sentinel-user'
Unrecognized sentinel configuration statement.
```

In this commit, when user calling set sentinel-user/pass and pass into an empty string, we set sentinel.sentinel_auth_user/pass to NULL to avoid the above rewite issue.
