### PR TITLE
Add version support for redis-check-rdb

### DIFF
--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -352,6 +352,20 @@ err:
     return 1;
 }
 
+static sds checkRdbVersion(void) {
+    sds version;
+    version = sdscatprintf(sdsempty(), "%s", REDIS_VERSION);
+
+    /* Add git commit and working tree status when available */
+    if (strtoll(redisGitSHA1(),NULL,16)) {
+        version = sdscatprintf(version, " (git:%s", redisGitSHA1());
+        if (strtoll(redisGitDirty(),NULL,10))
+            version = sdscatprintf(version, "-dirty");
+        version = sdscat(version, ")");
+    }
+    return version;
+}
+
 /* RDB check main: called form server.c when Redis is executed with the
  * redis-check-rdb alias, on during RDB loading errors.
  *
@@ -370,6 +384,11 @@ int redis_check_rdb_main(int argc, char **argv, FILE *fp) {
     if (argc != 2 && fp == NULL) {
         fprintf(stderr, "Usage: %s <rdb-file-name>\n", argv[0]);
         exit(1);
+    } else if (!strcmp(argv[1],"-v") || !strcmp(argv[1], "--version")) {
+        sds version = checkRdbVersion();
+        printf("redis-check-rdb %s\n", version);
+        sdsfree(version);
+        exit(0);
     }
 
     gettimeofday(&tv, NULL);


### PR DESCRIPTION
I accidentally found that a low version of 'redis-check-rdb' would report an error when checking a high version of rdb file. The prompt message is that the rdb file of this version cannot be processed. When I went to check the 'redis-check-rdb' version, I found that it couldn't be checked. So add 'redis-check-rdb' version support.

[root@node src]# ./redis-check-rdb /root/dump.rdb 
[offset 0] Checking RDB file /root/dump.rdb
--- RDB ERROR DETECTED ---
[offset 9] Can't handle RDB format version 9