### PR TITLE
fix different reply on `SENTINEL SIMULATE-FAILURE HELP` command

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3860,6 +3860,7 @@ NULL
                 addReplyArrayLen(c,2);
                 addReplyBulkCString(c,"crash-after-election");
                 addReplyBulkCString(c,"crash-after-promotion");
+                return;
             } else {
                 addReplyError(c,"Unknown failure simulation specified");
                 return;


### PR DESCRIPTION
`SENTINEL SIMULATE-FAILURE HELP` reply with different format
```
127.0.0.1:26379> SENTINEL SIMULATE-FAILURE help
1) "crash-after-election"
2) "crash-after-promotion"
127.0.0.1:26379> SENTINEL SIMULATE-FAILURE help
OK
```
