### PR TITLE
longer timeout in replication test

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -864,7 +864,7 @@ test {Kill rdb child process if its dumping RDB is not useful} {
                 # Slave2 disconnect with master
                 $slave2 slaveof no one
                 # Should kill child
-                wait_for_condition 20 10 {
+                wait_for_condition 100 10 {
                     [s 0 rdb_bgsave_in_progress] eq 0
                 } else {
                     fail "can't kill rdb child"


### PR DESCRIPTION
the test normally passes. but we saw one failure in a valgrind run in github actions:
https://github.com/redis/redis/runs/2605801289?check_suite_focus=true
```
*** [err]: Kill rdb child process if its dumping RDB is not useful in tests/integration/replication.tcl
can't kill rdb child
```