### PR TITLE
redis-cli clusterManagerCommandCreate calculate interleaved_len wrong

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5760,7 +5760,7 @@ assign_replicas:
             if (found) slave = found;
             else if (firstNodeIdx >= 0) {
                 slave = interleaved[firstNodeIdx];
-                interleaved_len -= (interleaved - (interleaved + firstNodeIdx));
+                interleaved_len -= (firstNodeIdx + 1);
                 interleaved += (firstNodeIdx + 1);
             }
             if (slave != NULL) {


### PR DESCRIPTION
redis-cli clusterManagerCommandCreate calculate interleaved_len wrong
which make interleaved_len bigger and may access array out of range.