### PR TITLE
Fix race in new lazyfree test

### DIFF
--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -38,6 +38,13 @@ start_server {tags {"lazyfree"}} {
     }
 
     test "lazy free a stream with all types of metadata" {
+        # make the previous test is really done before doing RESETSTAT
+        wait_for_condition 5 100 {
+            [s lazyfree_pending_objects] == 0
+        } else {
+            fail "lazyfree isn't done"
+        }
+
         r config resetstat
         r config set stream-node-max-entries 5
         for {set j 0} {$j < 1000} {incr j} {


### PR DESCRIPTION
I recently saw this failure:
[err]: lazy free a stream with all types of metadata in tests/unit/lazyfree.tcl
Expected '2' to be equal to '1' (context: type eval line 23 cmd {assert_equal [s lazyfreed_objects] 1} proc ::test)

The only explanation for such a thing is that the async flushdb wasn't
done before we did the resetstat