### PR TITLE
Make full use of replication backlog memory

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -635,6 +635,9 @@ repl-disable-tcp-nodelay no
 # The bigger the replication backlog, the longer the replica can endure the
 # disconnect and later be able to perform a partial resynchronization.
 #
+# Moreover, actual size may be bigger than the setting because allocators
+# have size allocation strategy for decreasing fragmentation.
+#
 # The backlog is only allocated if there is at least one replica connected.
 #
 # repl-backlog-size 1mb

--- a/redis.conf
+++ b/redis.conf
@@ -635,9 +635,6 @@ repl-disable-tcp-nodelay no
 # The bigger the replication backlog, the longer the replica can endure the
 # disconnect and later be able to perform a partial resynchronization.
 #
-# Moreover, actual size may be bigger than the setting because allocators
-# have size allocation strategy for decreasing fragmentation.
-#
 # The backlog is only allocated if there is at least one replica connected.
 #
 # repl-backlog-size 1mb

--- a/src/config.c
+++ b/src/config.c
@@ -2242,10 +2242,10 @@ static int updateJemallocBgThread(int val, int prev, const char **err) {
 }
 
 static int updateReplBacklogSize(long long val, long long prev, const char **err) {
-    /* resizeReplicationBacklog sets server.repl_backlog_size, and relies on
+    /* resizeReplicationBacklog sets server.cfg_repl_backlog_size, and relies on
      * being able to tell when the size changes, so restore prev before calling it. */
     UNUSED(err);
-    server.repl_backlog_size = prev;
+    server.cfg_repl_backlog_size = prev;
     resizeReplicationBacklog(val);
     return 1;
 }
@@ -2523,7 +2523,7 @@ standardConfig configs[] = {
     createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("proto-max-bulk-len", NULL, MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.proto_max_bulk_len, 512ll*1024*1024, MEMORY_CONFIG, NULL, NULL), /* Bulk request max size */
     createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
-    createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.repl_backlog_size, 1024*1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 1mb */
+    createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.cfg_repl_backlog_size, 1024*1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 1mb */
 
     /* Unsigned Long Long configs */
     createULongLongConfig("maxmemory", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory, 0, MEMORY_CONFIG, NULL, updateMaxmemory),

--- a/src/replication.c
+++ b/src/replication.c
@@ -109,7 +109,8 @@ int bg_unlink(const char *filename) {
 
 void createReplicationBacklog(void) {
     serverAssert(server.repl_backlog == NULL);
-    server.repl_backlog = zmalloc(server.repl_backlog_size);
+    server.repl_backlog = zmalloc_usable(server.repl_backlog_size,
+                               (size_t*)&server.repl_backlog_size);
     server.repl_backlog_histlen = 0;
     server.repl_backlog_idx = 0;
 
@@ -138,7 +139,8 @@ void resizeReplicationBacklog(long long newsize) {
          * worse often we need to alloc additional space before freeing the
          * old buffer. */
         zfree(server.repl_backlog);
-        server.repl_backlog = zmalloc(server.repl_backlog_size);
+        server.repl_backlog = zmalloc_usable(server.repl_backlog_size,
+                                   (size_t*)&server.repl_backlog_size);
         server.repl_backlog_histlen = 0;
         server.repl_backlog_idx = 0;
         /* Next byte we have is... the next since the buffer is empty. */

--- a/src/server.h
+++ b/src/server.h
@@ -1433,6 +1433,7 @@ struct redisServer {
     int repl_ping_slave_period;     /* Master pings the slave every N seconds */
     char *repl_backlog;             /* Replication backlog for partial syncs */
     long long repl_backlog_size;    /* Backlog circular buffer size */
+    long long cfg_repl_backlog_size;/* Backlog circular buffer size in config */
     long long repl_backlog_histlen; /* Backlog actual data length */
     long long repl_backlog_idx;     /* Backlog circular buffer current offset,
                                        that is the next byte will'll write to.*/


### PR DESCRIPTION
According[ jemalloc size classes](http://jemalloc.net/jemalloc.3.html#size_classes), we may allocate much more memory than our setting of  `repl_backlog_size`, but we don't make full use of it. For example, we actually have 112MB for replication backlog if we set `repl_backlog_size` to 100MB, but we only use 100MB, there is 12% waste fo memory.