### PR TITLE
Mem efficiency, make full use of client struct memory for reply buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,8 +304,8 @@ struct client {
     redisDb *db;
     int flags;
     list *reply;
-    char buf[PROTO_REPLY_CHUNK_BYTES];
     // ... many other fields ...
+    char buf[PROTO_REPLY_CHUNK_BYTES];
 }
 ```
 The client structure defines a *connected client*:

--- a/src/aof.c
+++ b/src/aof.c
@@ -700,6 +700,7 @@ struct client *createAOFClient(void) {
     c->original_argv = NULL;
     c->argv_len_sum = 0;
     c->bufpos = 0;
+    c->buf_usable_size = zmalloc_usable_size(c)-offsetof(client,buf);
 
     /*
      * The AOF client should never be blocked (unlike master

--- a/src/networking.c
+++ b/src/networking.c
@@ -280,7 +280,7 @@ int prepareClientToWrite(client *c) {
  * -------------------------------------------------------------------------- */
 
 /* Attempts to add the reply to the static buffer in the client struct.
- * Returns the lengh of data that is added to the reply buffer. */
+ * Returns the length of data that is added to the reply buffer. */
 size_t _addReplyToBuffer(client *c, const char *s, size_t len) {
     size_t available = c->buf_usable_size - c->bufpos;
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -959,7 +959,7 @@ void copyClientOutputBuffer(client *dst, client *src) {
     dst->sentlen = 0;
     dst->reply = listDup(src->reply);
     dst->reply_bytes = src->reply_bytes;
-    if ((long)dst->buf_usable_size == src->bufpos) {
+    if ((long)dst->buf_usable_size >= src->bufpos) {
         memcpy(dst->buf,src->buf,src->bufpos);
         dst->bufpos = src->bufpos;
     } else {

--- a/src/networking.c
+++ b/src/networking.c
@@ -284,8 +284,6 @@ int prepareClientToWrite(client *c) {
 size_t _addReplyToBuffer(client *c, const char *s, size_t len) {
     size_t available = c->buf_usable_size - c->bufpos;
 
-    if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return len;
-
     /* If there already are entries in the reply list, we cannot
      * add anything more to the static buffer. */
     if (listLength(c->reply) > 0) return 0;
@@ -299,8 +297,6 @@ size_t _addReplyToBuffer(client *c, const char *s, size_t len) {
 /* Adds the reply to the reply linked list.
  * Note: some edits to this function need to be relayed to AddReplyFromClient. */
 void _addReplyProtoToList(client *c, const char *s, size_t len) {
-    if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return;
-
     listNode *ln = listLast(c->reply);
     clientReplyBlock *tail = ln? listNodeValue(ln): NULL;
 
@@ -336,6 +332,8 @@ void _addReplyProtoToList(client *c, const char *s, size_t len) {
 }
 
 void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
+    if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return;
+
     size_t reply_len = _addReplyToBuffer(c,s,len);
     if (len > reply_len) _addReplyProtoToList(c,s+reply_len,len-reply_len);
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -318,10 +318,11 @@ void _addReplyProtoToList(client *c, const char *s, size_t len) {
     if (len) {
         /* Create a new node, make sure it is allocated to at
          * least PROTO_REPLY_CHUNK_BYTES */
+        size_t usable_size;
         size_t size = len < PROTO_REPLY_CHUNK_BYTES? PROTO_REPLY_CHUNK_BYTES: len;
-        tail = zmalloc(size + sizeof(clientReplyBlock));
+        tail = zmalloc_usable(size + sizeof(clientReplyBlock), &usable_size);
         /* take over the allocation's internal fragmentation */
-        tail->size = zmalloc_usable_size(tail) - sizeof(clientReplyBlock);
+        tail->size = usable_size - sizeof(clientReplyBlock);
         tail->used = len;
         memcpy(tail->buf, s, len);
         listAddNodeTail(c->reply, tail);

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -748,7 +748,7 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
     /* Convert the result of the Redis command into a suitable Lua type.
      * The first thing we need is to create a single string from the client
      * output buffers. */
-    if (listLength(c->reply) == 0 && c->bufpos < PROTO_REPLY_CHUNK_BYTES) {
+    if (listLength(c->reply) == 0 && c->bufpos < (long)c->buf_usable_size) {
         /* This is a fast path for the common case of a reply inside the
          * client static buffer. Don't create an SDS string but just use
          * the client buffer directly. */

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -748,7 +748,7 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
     /* Convert the result of the Redis command into a suitable Lua type.
      * The first thing we need is to create a single string from the client
      * output buffers. */
-    if (listLength(c->reply) == 0 && c->bufpos < (long)c->buf_usable_size) {
+    if (listLength(c->reply) == 0 && (size_t)c->bufpos < c->buf_usable_size) {
         /* This is a fast path for the common case of a reply inside the
          * client static buffer. Don't create an SDS string but just use
          * the client buffer directly. */

--- a/src/server.h
+++ b/src/server.h
@@ -949,7 +949,7 @@ typedef struct client {
     size_t buf_usable_size; /* Usable size of buffer. */
     /* Note that 'buf' must be the last field of client struct, because memory
      * allocator may give us more memory than our apply for reducing fragments,
-     * but we want to make full use of this memory, i.e. we will access the
+     * but we want to make full use of given memory, i.e. we may access the
      * memory after 'buf'. To avoid make others fields corrupt, 'buf' must be
      * the last one. */
     char buf[PROTO_REPLY_CHUNK_BYTES];

--- a/src/server.h
+++ b/src/server.h
@@ -946,6 +946,12 @@ typedef struct client {
     int      client_cron_last_memory_type;
     /* Response buffer */
     int bufpos;
+    size_t buf_usable_size; /* Usable size of buffer. */
+    /* Note that 'buf' must be the last field of client struct, because memory
+     * allocator may give us more memory than our apply for reducing fragments,
+     * but we want to make full use of this memory, i.e. we will access the
+     * memory after 'buf'. To avoid make others fields corrupt, 'buf' must be
+     * the last one. */
     char buf[PROTO_REPLY_CHUNK_BYTES];
 } client;
 


### PR DESCRIPTION
When we allocate a client struct with 16k reply buffer, the allocator we may give us 20K,
This commit makes use of that extra space.
Additionally, it tries to store whatever it can from the reply into the static 'buf' before
allocating a new node for the reply list.

Suggested by @oranagra in https://github.com/redis/redis/pull/8966#pullrequestreview-662844775

Similar changes (can all be mentioned in the release notes together): #8975, #8966