### PR TITLE
Count zmalloc size of aof buf into overhead

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -342,7 +342,7 @@ size_t freeMemoryGetNotCountedMemory(void) {
         }
     }
     if (server.aof_state != AOF_OFF) {
-        overhead += sdsalloc(server.aof_buf)+aofRewriteBufferSize();
+        overhead += sdsAllocSize(server.aof_buf)+aofRewriteBufferSize();
     }
     return overhead;
 }


### PR DESCRIPTION
In #5453 we use sds allocated size to get aof buf occupation size, but actually we need to use zmalloc size of it. I find @oranagra have fixed another one in #7864