### PR TITLE
FLUSHDB will not be replicated nor put into the AOF when db was already empty.

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -657,6 +657,10 @@ void flushdbCommand(client *c) {
 
     if (getFlushCommandFlags(c,&flags) == C_ERR) return;
     server.dirty += emptyDb(c->db->id,flags,NULL);
+    /* Without that extra dirty++, when db was already empty, FLUSHDB will
+     * not be replicated nor put into the AOF. */
+    server.dirty++;
+
     addReply(c,shared.ok);
 #if defined(USE_JEMALLOC)
     /* jemalloc 5 doesn't release pages back to the OS when there's no traffic.


### PR DESCRIPTION
these days can be module hooks. i.e. in case of FLUSHDB on an empty db, the hooks are only called in the master.

```c
/* Flushes the whole server data set. */
void flushAllDataAndResetRDB(int flags) {
    /* Without that extra dirty++, when db was already empty, FLUSHALL will
     * not be replicated nor put into the AOF. */
    server.dirty++;
}
```