### PR TITLE
Make full use of aofrwblock's buf

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -165,9 +165,10 @@ void aofRewriteBufferAppend(unsigned char *s, unsigned long len) {
 
         if (len) { /* First block to allocate, or need another block. */
             int numblocks;
+            size_t usable_size;
 
-            block = zmalloc(sizeof(*block));
-            block->free = zmalloc_usable_size(block)-offsetof(aofrwblock,buf);
+            block = zmalloc_usable(sizeof(*block), &usable_size);
+            block->free = usable_size-offsetof(aofrwblock,buf);
             block->used = 0;
             block->pos = 0;
             listAddNodeTail(server.aof_rewrite_buf_blocks,block);

--- a/src/evict.c
+++ b/src/evict.c
@@ -342,7 +342,7 @@ size_t freeMemoryGetNotCountedMemory(void) {
         }
     }
     if (server.aof_state != AOF_OFF) {
-        overhead += sdsAllocSize(server.aof_buf)+aofRewriteBufferSize();
+        overhead += sdsAllocSize(server.aof_buf)+aofRewriteBufferMemoryUsage();
     }
     return overhead;
 }

--- a/src/object.c
+++ b/src/object.c
@@ -1011,7 +1011,7 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
     mem = 0;
     if (server.aof_state != AOF_OFF) {
         mem += sdsZmallocSize(server.aof_buf);
-        mem += aofRewriteBufferSize();
+        mem += aofRewriteBufferMemoryUsage();
     }
     mh->aof_buffer = mem;
     mem_total+=mem;

--- a/src/server.h
+++ b/src/server.h
@@ -2077,6 +2077,7 @@ int startAppendOnly(void);
 void backgroundRewriteDoneHandler(int exitcode, int bysignal);
 void aofRewriteBufferReset(void);
 unsigned long aofRewriteBufferSize(void);
+unsigned long aofRewriteBufferMemoryUsage(void);
 ssize_t aofReadDiffFromParent(void);
 void killAppendOnlyChild(void);
 void restartAOFAfterSYNC();


### PR DESCRIPTION
1. AOF_RW_BUF_BLOCK_SIZE is 10M, if we use [jemalloc](http://jemalloc.net/jemalloc.3.html#size_classes), we will get 12M actually when we alloc aofrwblock, but we only use 10M, there is 20% waste of memory.

2. If we want to get aof rewrite buffer memory usage, we should also count all other fields(except 'buf') of aofrwblock and the last block's free size. Before, there may be 20% deviation with its real memory usage.