### PR TITLE
Add missing stat_dump_payload_sanitizations++ when we call zipmapValidateIntegrity(deep=1).

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -706,7 +706,7 @@ int rdbLoadObjectType(rio *rdb) {
 
 /* This helper function serializes a consumer group Pending Entries List (PEL)
  * into the RDB file. The 'nacks' argument tells the function if also persist
- * the informations about the not acknowledged message, or if to persist
+ * the information about the not acknowledged message, or if to persist
  * just the IDs: this is useful because for the global consumer group PEL
  * we serialized the NACKs as well, but when serializing the local consumer
  * PELs we just add the ID, that will be resolved inside the global PEL to
@@ -1459,7 +1459,7 @@ void rdbRemoveTempFile(pid_t childpid, int from_signal) {
     char tmpfile[256];
     char pid[32];
 
-    /* Generate temp rdb file name using aync-signal safe functions. */
+    /* Generate temp rdb file name using async-signal safe functions. */
     int pid_len = ll2string(pid, sizeof(pid), childpid);
     strcpy(tmpfile, "temp-");
     strncpy(tmpfile+5, pid, pid_len);
@@ -1621,7 +1621,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key) {
             }
         }
     } else if (rdbtype == RDB_TYPE_ZSET_2 || rdbtype == RDB_TYPE_ZSET) {
-        /* Read list/set value. */
+        /* Read sorted set value. */
         uint64_t zsetlen;
         size_t maxelelen = 0;
         zset *zs;
@@ -1836,6 +1836,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key) {
             case RDB_TYPE_HASH_ZIPMAP:
                 /* Since we don't keep zipmaps anymore, the rdb loading for these
                  * is O(n) anyway, use `deep` validation. */
+                server.stat_dump_payload_sanitizations++;
                 if (!zipmapValidateIntegrity(encoded, encoded_len, 1)) {
                     rdbReportCorruptRDB("Zipmap integrity check failed.");
                     zfree(encoded);
@@ -2632,7 +2633,7 @@ eoferr:
  * to do the actual loading. Moreover the ETA displayed in the INFO
  * output is initialized and finalized.
  *
- * If you pass an 'rsi' structure initialied with RDB_SAVE_OPTION_INIT, the
+ * If you pass an 'rsi' structure initialized with RDB_SAVE_OPTION_INIT, the
  * loading code will fill the information fields in the structure. */
 int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     FILE *fp;
@@ -2907,7 +2908,7 @@ void bgsaveCommand(client *c) {
  * information inside the RDB file. Currently the structure explicitly
  * contains just the currently selected DB from the master stream, however
  * if the rdbSave*() family functions receive a NULL rsi structure also
- * the Replication ID/offset is not saved. The function popultes 'rsi'
+ * the Replication ID/offset is not saved. The function populates 'rsi'
  * that is normally stack-allocated in the caller, returns the populated
  * pointer if the instance has a valid master client, otherwise NULL
  * is returned, and the RDB saving will not persist any replication related

--- a/src/zipmap.c
+++ b/src/zipmap.c
@@ -399,7 +399,7 @@ int zipmapValidateIntegrity(unsigned char *zm, size_t size, int deep) {
     while(*p != ZIPMAP_END) {
         /* read the field name length encoding type */
         s = zipmapGetEncodedLengthSize(p);
-        /* make sure the entry length doesn't rech outside the edge of the zipmap */
+        /* make sure the entry length doesn't reach outside the edge of the zipmap */
         if (OUT_OF_RANGE(p+s))
             return 0;
 
@@ -408,13 +408,13 @@ int zipmapValidateIntegrity(unsigned char *zm, size_t size, int deep) {
         p += s; /* skip the encoded field size */
         p += l; /* skip the field */
 
-        /* make sure the entry doesn't rech outside the edge of the zipmap */
+        /* make sure the entry doesn't reach outside the edge of the zipmap */
         if (OUT_OF_RANGE(p))
             return 0;
 
         /* read the value length encoding type */
         s = zipmapGetEncodedLengthSize(p);
-        /* make sure the entry length doesn't rech outside the edge of the zipmap */
+        /* make sure the entry length doesn't reach outside the edge of the zipmap */
         if (OUT_OF_RANGE(p+s))
             return 0;
 
@@ -425,7 +425,7 @@ int zipmapValidateIntegrity(unsigned char *zm, size_t size, int deep) {
         p += l+e; /* skip the value and free space */
         count++;
 
-        /* make sure the entry doesn't rech outside the edge of the zipmap */
+        /* make sure the entry doesn't reach outside the edge of the zipmap */
         if (OUT_OF_RANGE(p))
             return 0;
     }


### PR DESCRIPTION
Maybe missing stat_dump_payload_sanitizations++ when we call zipmapValidateIntegrity(deep=1) ?
if not needed or i understand wrong. Feel free to close it
```
                /* Since we don't keep zipmaps anymore, the rdb loading for these
                 * is O(n) anyway, use `deep` validation. */
                server.stat_dump_payload_sanitizations++;  // chang diff
                if (!zipmapValidateIntegrity(encoded, encoded_len, 1)) {
                    rdbReportCorruptRDB("Zipmap integrity check failed.");
```

Also fix some typos while reading...