### PR TITLE
Remove unnecessary determine statement in sdsrange

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -793,7 +793,7 @@ void sdsrange(sds s, ssize_t start, ssize_t end) {
             newlen = 0;
         } else if (end >= (ssize_t)len) {
             end = len-1;
-            newlen = (start > end) ? 0 : (end-start)+1;
+            newlen = (end-start)+1;
         }
     }
     if (start && newlen) memmove(s, s+start, newlen);


### PR DESCRIPTION
In `sdsrange`, after checking:
- `start, end` both converted to non-negative.
- `start` not in the right of `end`
- `start` does not overflow.

Now, if `end` overflows, just reset and take diff+1, no need to double-check whether `start` in the right of `end` 

![image](https://user-images.githubusercontent.com/24536920/119224373-b1c16d00-bb30-11eb-9a86-62e128024324.png)

