### PR TITLE
Support glob pattern matching for config include files

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -36,19 +36,13 @@
 # be included in alphabetical order.
 # Note that if an include path contains a wildcards but no files match it when
 # the server is started, the include statement will be ignored and no error will
-# be emitted.
+# be emitted.  It is safe, therefore, to include wildcard files from empty
+# directories.
 #
 # include /path/to/local.conf
 # include /path/to/other.conf
+# include /path/to/fragments/*.conf
 #
-# By default, include config fragments from /etc/redis/conf.d/*-pre.conf, at
-# this point. Per the note above, the directives included in the following
-# configuration files will be overwritten by runtime configuration changes,
-# via "CONFIG REWRITE" or Redis Sentienl.
-include /etc/redis/conf.d/*-pre.conf
-
-# Note: the bottom of this file includes files from /etc/redis/conf.d/*-post.conf
-# in the "FINAL INCLUDES" section.
 
 ################################## MODULES #####################################
 
@@ -2064,12 +2058,3 @@ jemalloc-bg-thread yes
 # to suppress
 #
 # ignore-warnings ARM64-COW-BUG
-
-################################# FINAL INCLUDES  ##############################
-# Very lastly, include config fragments from /etc/redis/conf.d/*-post.conf.
-# The directives included in the following configuration files will overwrite
-# configuration changes made at runtime by the "CONFIG REWRITE" command or
-# by Redis Sentinel.  Use wisely!
-#
-# See the "INCLUDES" section, above, for additional information.
-include /etc/redis/conf.d/*-post.conf

--- a/redis.conf
+++ b/redis.conf
@@ -32,8 +32,23 @@
 # If instead you are interested in using includes to override configuration
 # options, it is better to use include as the last line.
 #
+# Included paths may contain wildcards. All files matching the wildcards will
+# be included in alphabetical order.
+# Note that if an include path contains a wildcards but no files match it when
+# the server is started, the include statement will be ignored and no error will
+# be emitted.
+#
 # include /path/to/local.conf
 # include /path/to/other.conf
+#
+# By default, include config fragments from /etc/redis/conf.d/*-pre.conf, at
+# this point. Per the note above, the directives included in the following
+# configuration files will be overwritten by runtime configuration changes,
+# via "CONFIG REWRITE" or Redis Sentienl.
+include /etc/redis/conf.d/*-pre.conf
+
+# Note: the bottom of this file includes files from /etc/redis/conf.d/*-post.conf
+# in the "FINAL INCLUDES" section.
 
 ################################## MODULES #####################################
 
@@ -2049,3 +2064,12 @@ jemalloc-bg-thread yes
 # to suppress
 #
 # ignore-warnings ARM64-COW-BUG
+
+################################# FINAL INCLUDES  ##############################
+# Very lastly, include config fragments from /etc/redis/conf.d/*-post.conf.
+# The directives included in the following configuration files will overwrite
+# configuration changes made at runtime by the "CONFIG REWRITE" command or
+# by Redis Sentinel.  Use wisely!
+#
+# See the "INCLUDES" section, above, for additional information.
+include /etc/redis/conf.d/*-post.conf

--- a/src/config.c
+++ b/src/config.c
@@ -652,13 +652,11 @@ void loadServerConfig(char *filename, char config_from_stdin, char *options) {
     glob_t globbuf;
 
     /* Load the file content */
-    if (filename)
-    {
+    if (filename) {
         globbuf.gl_offs = 0;
         glob(filename, GLOB_DOOFFS, NULL, &globbuf);
 
-        for (size_t i=0; i<globbuf.gl_pathc; i++)
-        {
+        for (size_t i = 0; i < globbuf.gl_pathc; i++) {
             if ((fp = fopen(globbuf.gl_pathv[i],"r")) == NULL) {
                 serverLog(LL_WARNING,
                         "Fatal error, can't open config file '%s': %s",

--- a/src/config.c
+++ b/src/config.c
@@ -669,7 +669,7 @@ void loadServerConfig(char *filename, char config_from_stdin, char *options) {
          *                       config file, as if the current entry was never encountered.
          *                       This will allow for empty conf.d directories to be included. */
 
-        if (strchr(filename, '*')) {
+        if (strchr(filename, '*') || strchr(filename, '?') || strchr(filename, '[')) {
             /* A wildcard character detected in filename, so let us use glob */
             if (glob(filename, 0, NULL, &globbuf) == 0) {
 


### PR DESCRIPTION
As described in issue #6351 (as well as https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=988947) this is a very minor patch to loadServerConfig to include individual files or wildcard files.  This will allow us to continue with the debian packaging bug.  Once that's done redis will be able to use an "include conf.d/*.conf" statement in the default configuration file which will facilitate customization across upgrades/downgrades.

The change itself is trivial:  instead of opening an individual file, the glob call creates a vector of files to open, and each file is opened in turn, and its content is added to the configuration. 