### PR TITLE
Change return value type for ZPOPMAX/MIN in RESP3

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3825,9 +3825,10 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
     /* We emit the key only for the blocking variant. */
     if (emitkey) addReplyBulk(c,key);
 
-    /* Respond with a single array in RESP2 and nested arrays in RESP3.
-     * Even in RESP3, use a single array when blocking or when no 'count' argument.  */
-    int use_nested_array = (c->resp > 2 && emitkey == 0 && countarg != NULL);
+    /* Respond with a single (flat) array in RESP2 or if countarg is not
+     * provided (returning a single element). In RESP3, when countarg is
+     * provided, use nested array.  */
+    int use_nested_array = c->resp > 2 && countarg != NULL;
 
     /* Remove the element. */
     do {

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -963,6 +963,39 @@ start_server {tags {"zset"}} {
             assert_equal 1 [r zcard z2{t}]
         }
 
+        test "Basic ZPOP - $encoding RESP3" {
+            r hello 3
+            r del z1 z2 z3 foo
+            create_zset z1 {0 a 1 b 2 c 3 d}
+            assert_equal {a 0.0} [r zpopmin z1]
+            assert_equal {d 3.0} [r zpopmax z1]
+        }
+        r hello 2
+
+        test "ZPOP with count - $encoding RESP3" {
+            r hello 3
+            r del z1 z2 z3 foo
+            create_zset z1 {0 a 1 b 2 c 3 d}
+            assert_equal {{a 0.0} {b 1.0}} [r zpopmin z1 2]
+            assert_equal {{d 3.0} {c 2.0}} [r zpopmax z1 2]
+        }
+        r hello 2
+
+        test "BZPOP - $encoding RESP3" {
+            r hello 3
+            set rd [redis_deferring_client]
+            create_zset zset {0 a 1 b 2 c}
+
+            $rd bzpopmin zset 5
+            assert_equal {zset a 0} [$rd read]
+            $rd bzpopmin zset 5
+            assert_equal {zset b 1} [$rd read]
+            $rd bzpopmax zset 5
+            assert_equal {zset c 2} [$rd read]
+            assert_equal 0 [r exists zset]
+        }
+        r hello 2
+
         r config set zset-max-ziplist-entries $original_max_entries
         r config set zset-max-ziplist-value $original_max_value
     }

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -965,21 +965,21 @@ start_server {tags {"zset"}} {
 
         test "Basic ZPOP - $encoding RESP3" {
             r hello 3
-            r del z1 z2 z3 foo
+            r del z1
             create_zset z1 {0 a 1 b 2 c 3 d}
             assert_equal {a 0.0} [r zpopmin z1]
             assert_equal {d 3.0} [r zpopmax z1]
+            r hello 2
         }
-        r hello 2
 
         test "ZPOP with count - $encoding RESP3" {
             r hello 3
-            r del z1 z2 z3 foo
+            r del z1
             create_zset z1 {0 a 1 b 2 c 3 d}
             assert_equal {{a 0.0} {b 1.0}} [r zpopmin z1 2]
             assert_equal {{d 3.0} {c 2.0}} [r zpopmax z1 2]
+            r hello 2
         }
-        r hello 2
 
         test "BZPOP - $encoding RESP3" {
             r hello 3
@@ -993,8 +993,8 @@ start_server {tags {"zset"}} {
             $rd bzpopmax zset 5
             assert_equal {zset c 2} [$rd read]
             assert_equal 0 [r exists zset]
+            r hello 2
         }
-        r hello 2
 
         r config set zset-max-ziplist-entries $original_max_entries
         r config set zset-max-ziplist-value $original_max_value


### PR DESCRIPTION
When using RESP3, ZPOPMAX/ZPOPMIN should return nested arrays for consistency
with other commands (e.g. ZRANGE).

We do that only when COUNT argument is present (similarly to how LPOP behaves).
for reasoning see https://github.com/redis/redis/issues/8824#issuecomment-855427955

This is a breaking change only when RESP3 is used, and COUNT argument is present!