### PR TITLE
Fix some minor bugs in redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6811,7 +6811,8 @@ static int clusterManagerCommandHelp(int argc, char **argv) {
             }
         }
     }
-    fprintf(stderr, "\nFor check, fix, reshard, del-node, set-timeout you "
+    fprintf(stderr, "\nFor check, fix, reshard, del-node, set-timeout, "
+                    "info, rebalance, call, import, backup you "
                     "can specify the host and port of any working node in "
                     "the cluster.\n");
 

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -4989,7 +4989,7 @@ static int clusterManagerFixOpenSlot(int slot) {
                                       "in node %s:%d!\n", slot, n->ip,
                                       n->port);
                 char *sep = (listLength(importing) == 0 ? "" : ",");
-                importing_str = sdscatfmt(importing_str, "%s%S:%u",
+                importing_str = sdscatfmt(importing_str, "%s%s:%u",
                                           sep, n->ip, n->port);
                 listAddNodeTail(importing, n);
             }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5027,11 +5027,6 @@ static int clusterManagerFixOpenSlot(int slot) {
         /* Since CLUSTER ADDSLOTS succeeded, we also update the slot
          * info into the node struct, in order to keep it synced */
         owner->slots[slot] = 1;
-        /* Make sure this information will propagate. Not strictly needed
-         * since there is no past owner, so all the other nodes will accept
-         * whatever epoch this node will claim the slot with. */
-        success = clusterManagerBumpEpoch(owner);
-        if (!success) goto cleanup;
         /* Remove the owner from the list of migrating/importing
          * nodes. */
         clusterManagerRemoveNodeFromList(migrating, owner);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3424,7 +3424,7 @@ static int clusterManagerAddSlots(clusterManagerNode *node, char**err)
             argv_idx++;
         }
     }
-    if (!argv_idx) {
+    if (argv_idx == 2) {
         success = 0;
         goto cleanup;
     }


### PR DESCRIPTION
This PR include 3 bugs, 1 cleanup and 1 output fix in separate commits.

* `clusterManagerAddSlots` check `argv_idx` error, `argv_idx` >= 2 is always `true`. 
* `node->ip` may be an sds or a c string. Using `%s` to format is always right, `%S` may be wrong.
*  In `clusterManagerFixOpenSlot` `clusterManagerBumpEpoch` call is redundant, because it is already called in `clusterManagerSetSlotOwner`.
* `clusterManagerLoadInfoFromNode` remove unused param `opts`.
* cluster help add more commands in help messages.
