### PR TITLE
Stabilized and imporve maxmemory test suit

### DIFF
--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -176,7 +176,7 @@ proc test_slave_buffers {test_name cmd_count payload_len limit_memory pipeline} 
             wait_for_condition 50 100 {
                 [regexp {lag=([0-9]+)} [status $master slave0] - lag] && $lag != 0
             } else {
-                fail "master has not receive ack from slave."
+                fail "Master has not receive ack from slave."
             }
 
             # measure used memory after the slave connected and set maxmemory

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -168,6 +168,11 @@ proc test_slave_buffers {test_name cmd_count payload_len limit_memory pipeline} 
 
             $slave slaveof $master_host $master_port
             wait_for_sync $slave
+
+            # put the slave to sleep
+            set rd_slave [redis_deferring_client]
+            exec kill -SIGSTOP $slave_pid
+
             wait_for_condition 50 100 {
                 [regexp {lag=([0-9]+)} [status $master slave0] - lag] && $lag != 0
             } else {
@@ -185,9 +190,7 @@ proc test_slave_buffers {test_name cmd_count payload_len limit_memory pipeline} 
                 $master config set maxmemory $limit
             }
 
-            # put the slave to sleep
-            set rd_slave [redis_deferring_client]
-            exec kill -SIGSTOP $slave_pid
+            
 
             # send some 10mb worth of commands that don't increase the memory usage
             if {$pipeline == 1} {

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -173,7 +173,7 @@ proc test_slave_buffers {test_name cmd_count payload_len limit_memory pipeline} 
             set rd_slave [redis_deferring_client]
             exec kill -SIGSTOP $slave_pid
 
-            # wait util master receive ask from slave, avoid
+            # wait util master receive ack from slave, avoid
             # slave's querybuf to affect used_memory of master.
             wait_for_condition 50 100 {
                 [regexp {lag=([0-9]+)} [status $master slave0] - lag] && $lag != 0

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -190,8 +190,6 @@ proc test_slave_buffers {test_name cmd_count payload_len limit_memory pipeline} 
                 $master config set maxmemory $limit
             }
 
-            
-
             # send some 10mb worth of commands that don't increase the memory usage
             if {$pipeline == 1} {
                 set rd_master [redis_deferring_client -1]


### PR DESCRIPTION
Fix ci error ```replica buffer don't induce eviction in tests/unit/maxmemory.tcl```

1) Stop slave before getting memory information.
2) Wait util master received ack from slave after stop slave.
    Since the memory calculation for eviction does not include the slave's querybuf,
    if the ack message from salve is not handled in advance, it may cause the slave's querybuf 
    to grow in memory and lead to eviction in subsequent tests.
3) Disable slowlog of master to avoid memory growth.