### PR TITLE
Adds test for gopher prtocol support.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1698,9 +1698,6 @@ notify-keyspace-events ""
 #
 # So use the 'requirepass' option to protect your instance.
 #
-# Note that Gopher is not currently supported when 'io-threads-do-reads'
-# is enabled.
-#
 # To enable Gopher support, uncomment the following line and set the option
 # from no (the default) to yes.
 #

--- a/src/server.c
+++ b/src/server.c
@@ -3962,6 +3962,12 @@ int processCommand(client *c) {
         serverAssert(!server.in_eval);
     }
 
+    if (c->flags & CLIENT_GOPHER) {
+        processGopherRequest(c);
+        c->flags |= CLIENT_CLOSE_AFTER_REPLY;
+        return C_OK;
+    }
+
     moduleCallCommandFilters(c);
 
     /* The QUIT command is handled separately. Normal command procs will

--- a/src/server.h
+++ b/src/server.h
@@ -279,6 +279,8 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
                                            and AOF client */
 #define CLIENT_REPL_RDBONLY (1ULL<<42) /* This client is a replica that only wants
                                           RDB without replication buffer. */
+#define CLIENT_GOPHER (1ULL<<43) /* This client expects its request to be
+                                    replied in the gopher protocol */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -144,6 +144,10 @@ proc ::redis::__method__read {id fd} {
     ::redis::redis_read_reply $id $fd
 }
 
+proc ::redis::__method__read_all {id fd} {
+    ::redis::redis_read_all $id $fd
+}
+
 proc ::redis::__method__write {id fd buf} {
     ::redis::redis_write $fd $buf
 }
@@ -238,6 +242,10 @@ proc ::redis::redis_read_line fd {
 proc ::redis::redis_read_null fd {
     gets $fd
     return {}
+}
+
+proc ::redis::redis_read_all {id fd} {
+    return [read $fd]
 }
 
 proc ::redis::redis_read_reply {id fd} {

--- a/tests/unit/gopher.tcl
+++ b/tests/unit/gopher.tcl
@@ -1,0 +1,36 @@
+start_server {tags {"gopher protocol"}} {
+   r set "/" rootval
+   r set "/subkey" subkeyval 
+   assert_equal [r config set gopher-enabled yes] OK
+
+
+    test "Get root explicit" {
+        reconnect
+        r write "/\r\n"
+        r flush
+        r read_all
+    } {rootval}
+
+    test "Get root implicit" {
+        reconnect
+        r write "\r\n"
+        r flush
+        r read_all
+    } {rootval}
+
+    test "Get subkey" {
+        reconnect
+        r write "/subkey\r\n"
+        r flush
+        r read_all
+    } {subkeyval}
+
+    test "Get invalid key" {
+        reconnect
+        r write "/invalidkey\r\n"
+        r flush
+        assert_match "iError:*" [r read_all]
+    }
+}
+
+


### PR DESCRIPTION
This also makes gopher work with io-threads-do-reads enabled as an alternative fix for #7779.