### PR TITLE
tests: prevent name clash in variables leading to wrong test name

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -127,11 +127,11 @@ set ::numclients 16
 # a "run" command from the server, with a filename as data.
 # It will run the specified test source file and signal it to the
 # test server when finished.
-proc execute_test_file name {
-    set path "tests/$name.tcl"
+proc execute_test_file testname {
+    set path "tests/$testname.tcl"
     set ::curfile $path
     source $path
-    send_data_packet $::test_server_fd done "$name"
+    send_data_packet $::test_server_fd done "$testname"
 }
 
 # This function is called by one of the test clients when it receives
@@ -139,10 +139,10 @@ proc execute_test_file name {
 # as argument, and an associated name.
 # It will run the specified code and signal it to the test server when
 # finished.
-proc execute_test_code {name filename code} {
+proc execute_test_code {testname filename code} {
     set ::curfile $filename
     eval $code
-    send_data_packet $::test_server_fd done "$name"
+    send_data_packet $::test_server_fd done "$testname"
 }
 
 # Setup a list to hold a stack of server configs. When calls to start_server

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -127,11 +127,11 @@ set ::numclients 16
 # a "run" command from the server, with a filename as data.
 # It will run the specified test source file and signal it to the
 # test server when finished.
-proc execute_test_file testname {
-    set path "tests/$testname.tcl"
+proc execute_test_file __testname {
+    set path "tests/$__testname.tcl"
     set ::curfile $path
     source $path
-    send_data_packet $::test_server_fd done "$testname"
+    send_data_packet $::test_server_fd done "$__testname"
 }
 
 # This function is called by one of the test clients when it receives
@@ -139,10 +139,10 @@ proc execute_test_file testname {
 # as argument, and an associated name.
 # It will run the specified code and signal it to the test server when
 # finished.
-proc execute_test_code {testname filename code} {
+proc execute_test_code {__testname filename code} {
     set ::curfile $filename
     eval $code
-    send_data_packet $::test_server_fd done "$testname"
+    send_data_packet $::test_server_fd done "$__testname"
 }
 
 # Setup a list to hold a stack of server configs. When calls to start_server


### PR DESCRIPTION
running the "geo" unit would have shown that it completed a unit named
"north". this was because the variable `$name` was overwritten.
This commit isn't perfect, but it slightly reduces the chance for
variable name clash.

```
$ ./runtest --single unit/geo
.......
Testing unit/geo
.......
[1/1 done]: north (15 seconds)
```