### PR TITLE
exec fails when grep exists with status other than 0 

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -342,7 +342,7 @@ ssize_t aofWrite(int fd, const char *buf, size_t len) {
 /* Write the append only file buffer on disk.
  *
  * Since we are required to write the AOF before replying to the client,
- * and the only way the client socket can get a write is entering when the
+ * and the only way the client socket can get a write is entering when
  * the event loop, we accumulate all the AOF writes in a memory
  * buffer and write it on disk using this function just before entering
  * the event loop again.

--- a/tests/unit/moduleapi/fork.tcl
+++ b/tests/unit/moduleapi/fork.tcl
@@ -1,7 +1,9 @@
 set testmodule [file normalize tests/modules/fork.so]
 
 proc count_log_message {pattern} {
-    set result [exec grep -c $pattern < [srv 0 stdout]]
+    catch {
+        exec grep -c $pattern < [srv 0 stdout]
+    } result
 }
 
 start_server {tags {"modules"}} {

--- a/tests/unit/moduleapi/fork.tcl
+++ b/tests/unit/moduleapi/fork.tcl
@@ -1,9 +1,11 @@
 set testmodule [file normalize tests/modules/fork.so]
 
 proc count_log_message {pattern} {
-    catch {
-        exec grep -c $pattern < [srv 0 stdout]
-    } result
+    set status [catch {exec grep -c $pattern < [srv 0 stdout]} result]
+    if {$status == 1} {
+        set result 0
+    }
+    return $result
 }
 
 start_server {tags {"modules"}} {


### PR DESCRIPTION
This will exit abnormally when the exec search fails, so the exception needs to be caught here to prevent the test from exiting abnormally.