### PR TITLE
[sentinel] add tilt mode since in sentinel info

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3923,11 +3923,13 @@ void sentinelInfoCommand(client *c) {
             "# Sentinel\r\n"
             "sentinel_masters:%lu\r\n"
             "sentinel_tilt:%d\r\n"
+            "sentinel_tilt_since_seconds:%jd\r\n"
             "sentinel_running_scripts:%d\r\n"
             "sentinel_scripts_queue_length:%ld\r\n"
             "sentinel_simulate_failure_flags:%lu\r\n",
             dictSize(sentinel.masters),
             sentinel.tilt,
+            sentinel.tilt ? (intmax_t)((mstime()-sentinel.tilt_start_time)/1000) : -1,
             sentinel.running_scripts,
             listLength(sentinel.scripts_queue),
             sentinel.simfailure_flags);


### PR DESCRIPTION
In sentinel tilt mode, IMO it will be a good idea to add tilt_mode_since in info command to show how long tilt mode has been lasted, since tilt mode can last for 30 seconds.