### PR TITLE
Benchmark should exit when redisConnect* fail.

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -278,7 +278,9 @@ static redisContext *getRedisContext(const char *ip, int port,
             fprintf(stderr,"%s:%d: %s\n",ip,port,err);
         else
             fprintf(stderr,"%s: %s\n",hostsocket,err);
-        goto cleanup;
+        freeReplyObject(reply);
+        redisFree(ctx);
+        exit(1);
     }
     if (config.tls==1) {
         const char *err = NULL;

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -278,9 +278,7 @@ static redisContext *getRedisContext(const char *ip, int port,
             fprintf(stderr,"%s:%d: %s\n",ip,port,err);
         else
             fprintf(stderr,"%s: %s\n",hostsocket,err);
-        freeReplyObject(reply);
-        redisFree(ctx);
-        exit(1);
+        goto exit;
     }
     if (config.tls==1) {
         const char *err = NULL;
@@ -301,9 +299,7 @@ static redisContext *getRedisContext(const char *ip, int port,
                 fprintf(stderr, "Node %s:%d replied with error:\n%s\n", ip, port, reply->str);
             else
                 fprintf(stderr, "Node %s replied with error:\n%s\n", hostsocket, reply->str);
-            freeReplyObject(reply);
-            redisFree(ctx);
-            exit(1);
+            goto exit;
         }
         freeReplyObject(reply);
         return ctx;
@@ -317,6 +313,11 @@ cleanup:
     freeReplyObject(reply);
     redisFree(ctx);
     return NULL;
+
+exit:
+    freeReplyObject(reply);
+    redisFree(ctx);
+    exit(1);
 }
 
 


### PR DESCRIPTION
ref: redis-benchmark: Error/Warning handling updates. https://github.com/redis/redis/pull/8869

Benchmark should exit when redisConnect* fail. Otherwise it will get stuck in the benchmark and does not do anything. 
(PS even the redisConnect recover later ( like restart the server))

Before( i think connect error also should exit):
```
[root@binblog redis]# src/redis-benchmark
Could not connect to Redis at 127.0.0.1:6379: Connection refused
WARN: could not fetch server CONFIG
^C
```

After:
```
[root@binblog redis]# src/redis-benchmark
Could not connect to Redis at 127.0.0.1:6379: Connection refused
[root@binblog redis]#
```