### PR TITLE
Add missing slave option in client list help.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2469,7 +2469,7 @@ void clientCommand(client *c) {
 "      Skip killing current connection (default: yes).",
 "LIST [options ...]",
 "    Return information about client connections. Options:",
-"    * TYPE (NORMAL|MASTER|REPLICA|PUBSUB)",
+"    * TYPE (NORMAL|MASTER|SLAVE|REPLICA|PUBSUB)",
 "      Return clients of specified type.",
 "UNPAUSE",
 "    Stop the current client pause, resuming traffic.",

--- a/src/networking.c
+++ b/src/networking.c
@@ -2474,7 +2474,7 @@ void clientCommand(client *c) {
 "UNPAUSE",
 "    Stop the current client pause, resuming traffic.",
 "PAUSE <timeout> [WRITE|ALL]",
-"    Suspend all, or just write, clients for <timout> milliseconds.",
+"    Suspend all, or just write, clients for <timeout> milliseconds.",
 "REPLY (ON|OFF|SKIP)",
 "    Control the replies sent to the current connection.",
 "SETNAME <name>",


### PR DESCRIPTION
Also fix type: timout -> timeout in help message

Also update redis-doc: https://github.com/redis/redis-doc/pull/1580

![image](https://user-images.githubusercontent.com/22811481/120102195-67696d00-c17c-11eb-9b81-f8fb7ec2af06.png)

