### PR TITLE
Improve new time sensitive pexpireat propagation test

### DIFF
--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -434,7 +434,7 @@ start_server {tags {"expire"}} {
         r set foo1 bar ex 200
         r set foo1 bar px 100000
         r set foo1 bar exat [expr [clock seconds]+100]
-        r set foo1 bar pxat [expr [clock milliseconds]+10000]
+        r set foo1 bar pxat [expr [clock milliseconds]+100000]
         r setex foo1 100 bar
         r psetex foo1 100000 bar
         r set foo2 bar
@@ -450,7 +450,7 @@ start_server {tags {"expire"}} {
         r getex foo4 ex 200
         r getex foo4 px 200000
         r getex foo4 exat [expr [clock seconds]+100]
-        r getex foo4 pxat [expr [clock milliseconds]+10000]
+        r getex foo4 pxat [expr [clock milliseconds]+100000]
         # RESTORE commands
         r set foo5 bar
         set encoded [r dump foo5]


### PR DESCRIPTION
The test that was merged yesterday fails with valgrind and freebsd CI
that are too slow, and 10 seconds apparently passed between the time the
command was sent to redis and the time it was actually executed.

```
*** [err]: All TTL in commands are propagated as absolute timestamp in replication stream in tests/unit/expire.tcl
Expected 'del a' to match 'set foo1 bar PXAT *' (context: type source line 778 file /home/runner/work/redis/redis/tests/test_helper.tcl cmd {assert_match [lindex $patterns $j] [read_from_replication_stream $s]} proc ::assert_replication_stream level 1)
```