### PR TITLE
cleanup around loadAppendOnlyFile

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -759,10 +759,11 @@ int loadAppendOnlyFile(char *filename) {
     long loops = 0;
     off_t valid_up_to = 0; /* Offset of latest well-formed command loaded. */
     off_t valid_before_multi = 0; /* Offset before MULTI command loaded. */
+    int ret;
 
     if (fp == NULL) {
         serverLog(LL_WARNING,"Fatal error: can't open the append log file for reading: %s",strerror(errno));
-        exit(1);
+        return AOF_OPEN_ERR;
     }
 
     /* Handle a zero-length AOF file as a special case. An empty AOF file
@@ -773,7 +774,7 @@ int loadAppendOnlyFile(char *filename) {
         server.aof_current_size = 0;
         server.aof_fsync_offset = server.aof_current_size;
         fclose(fp);
-        return C_ERR;
+        return AOF_EMPTY;
     }
 
     /* Temporarily disable AOF, to prevent EXEC from feeding a MULTI
@@ -874,7 +875,9 @@ int loadAppendOnlyFile(char *filename) {
             serverLog(LL_WARNING,
                 "Unknown command '%s' reading the append only file",
                 (char*)argv[0]->ptr);
-            exit(1);
+            freeFakeClientArgv(fakeClient);
+            ret = AOF_FAILED;
+            goto cleanup;
         }
 
         if (cmd == server.multiCommand) valid_before_multi = valid_up_to;
@@ -917,21 +920,18 @@ int loadAppendOnlyFile(char *filename) {
     }
 
 loaded_ok: /* DB loaded, cleanup and return C_OK to the caller. */
-    fclose(fp);
-    freeFakeClient(fakeClient);
     server.aof_state = old_aof_state;
-    stopLoading(1);
     aofUpdateCurrentSize();
     server.aof_rewrite_base_size = server.aof_current_size;
     server.aof_fsync_offset = server.aof_current_size;
-    return C_OK;
+    ret = AOF_OK;
+    goto cleanup;
 
 readerr: /* Read error. If feof(fp) is true, fall through to unexpected EOF. */
     if (!feof(fp)) {
-        if (fakeClient) freeFakeClient(fakeClient); /* avoid valgrind warning */
-        fclose(fp);
         serverLog(LL_WARNING,"Unrecoverable error reading the append only file: %s", strerror(errno));
-        exit(1);
+        ret = AOF_FAILED;
+        goto cleanup;
     }
 
 uxeof: /* Unexpected AOF end of file. */
@@ -959,16 +959,20 @@ uxeof: /* Unexpected AOF end of file. */
             }
         }
     }
-    if (fakeClient) freeFakeClient(fakeClient); /* avoid valgrind warning */
-    fclose(fp);
     serverLog(LL_WARNING,"Unexpected end of file reading the append only file. You can: 1) Make a backup of your AOF file, then use ./redis-check-aof --fix <filename>. 2) Alternatively you can set the 'aof-load-truncated' configuration option to yes and restart the server.");
-    exit(1);
+    ret = AOF_FAILED;
+    goto cleanup;
 
 fmterr: /* Format error. */
+    serverLog(LL_WARNING,"Bad file format reading the append only file: make a backup of your AOF file, then use ./redis-check-aof --fix <filename>");
+    ret = AOF_FAILED;
+    /* fall through to cleanup. */
+
+cleanup:
     if (fakeClient) freeFakeClient(fakeClient); /* avoid valgrind warning */
     fclose(fp);
-    serverLog(LL_WARNING,"Bad file format reading the append only file: make a backup of your AOF file, then use ./redis-check-aof --fix <filename>");
-    exit(1);
+    stopLoading(ret == AOF_OK);
+    return ret;
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/debug.c
+++ b/src/debug.c
@@ -551,11 +551,9 @@ NULL
         emptyDb(-1,EMPTYDB_NO_FLAGS,NULL);
         protectClient(c);
         int ret = loadAppendOnlyFile(server.aof_filename);
+        if (ret != AOF_OK && ret != AOF_EMPTY)
+            exit(1);
         unprotectClient(c);
-        if (ret != C_OK) {
-            addReplyErrorObject(c,shared.err);
-            return;
-        }
         server.dirty = 0; /* Prevent AOF / replication */
         serverLog(LL_WARNING,"Append Only File loaded by DEBUG LOADAOF");
         addReply(c,shared.ok);

--- a/src/server.c
+++ b/src/server.c
@@ -5915,9 +5915,9 @@ int checkForSentinelMode(int argc, char **argv) {
 void loadDataFromDisk(void) {
     long long start = ustime();
     if (server.aof_state == AOF_ON) {
-        /* It's not an failure if the file is empty or doesn't exist (later we will create it) */
+        /* It's not a failure if the file is empty or doesn't exist (later we will create it) */
         int ret = loadAppendOnlyFile(server.aof_filename);
-        if (ret == AOF_FAILED)
+        if (ret == AOF_FAILED || ret == AOF_OPEN_ERR)
             exit(1);
         if (ret == AOF_OK)
             serverLog(LL_NOTICE,"DB loaded from append only file: %.3f seconds",(float)(ustime()-start)/1000000);

--- a/src/server.h
+++ b/src/server.h
@@ -222,6 +222,12 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define AOF_ON 1              /* AOF is on */
 #define AOF_WAIT_REWRITE 2    /* AOF waits rewrite to start appending */
 
+/* AOF return values for loadAppendOnlyFile() */
+#define AOF_OK 0
+#define AOF_EMPTY 1
+#define AOF_OPEN_ERR 2
+#define AOF_FAILED 3
+
 /* Client flags */
 #define CLIENT_SLAVE (1<<0)   /* This client is a replica */
 #define CLIENT_MASTER (1<<1)  /* This client is a master */

--- a/src/server.h
+++ b/src/server.h
@@ -224,9 +224,10 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 
 /* AOF return values for loadAppendOnlyFile() */
 #define AOF_OK 0
-#define AOF_EMPTY 1
-#define AOF_OPEN_ERR 2
-#define AOF_FAILED 3
+#define AOF_NOT_EXIST 1
+#define AOF_EMPTY 2
+#define AOF_OPEN_ERR 3
+#define AOF_FAILED 4
 
 /* Client flags */
 #define CLIENT_SLAVE (1<<0)   /* This client is a replica */

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -295,4 +295,29 @@ tags {"aof"} {
             assert_equal $before $after
         }
     }
+
+    ## Test that the server exits when the AOF contains a unknown command
+    create_aof {
+        append_to_aof [formatCommand set foo hello]
+        append_to_aof [formatCommand bla foo hello]
+        append_to_aof [formatCommand set foo hello]
+    }
+
+    start_server_aof [list dir $server_path aof-load-truncated yes] {
+        test "Unknown command: Server should have logged an error" {
+            set pattern "*Unknown command 'bla' reading the append only file*"
+            set retry 10
+            while {$retry} {
+                set result [exec tail -1 < [dict get $srv stdout]]
+                if {[string match $pattern $result]} {
+                    break
+                }
+                incr retry -1
+                after 1000
+            }
+            if {$retry == 0} {
+                error "assertion:expected error not found on config file"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Today when we load the AOF on startup, the loadAppendOnlyFile checks if
the file is openning for reading.
This check is redundent (dead code) as we open the AOF file for writing at initServer,
and the file will always be existing for the loadAppendOnlyFile.

In this commit:
- remove all the exit(1) from loadAppendOnlyFile, as it is the caller
  responsibility to decide what to do in case of failure.
- move the opening of the AOF file for writing, to be after we loading it.
- avoid return -ERR in DEBUG LOADAOF, when the AOF is existing but empty