### PR TITLE
Make redis-cli grep friendly in pubsub mode.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1435,6 +1435,7 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
 
             while (config.pubsub_mode) {
                 if (cliReadReply(output_raw) != REDIS_OK) exit(1);
+                fflush(stdout); /* Make it grep friendly */
                 if (config.last_cmd_type == REDIS_REPLY_ERROR) {
                     if (config.push_output) {
                         redisSetPushCallback(context, cliPushHandler);


### PR DESCRIPTION
redis-cli is grep friendly for all commands but SUBSCRIBE/PSUBSCRIBE. It is unable to process output from these commands line by line piped to another program because of output buffering. To overcome this situation I propose to flush stdout each time when it is written with reply from these commands the same way as it is already done for all other commands.