### PR TITLE
Check cluster_enabled in readwriteCommand just like readonlyCommand.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5709,6 +5709,10 @@ void readonlyCommand(client *c) {
 
 /* The READWRITE command just clears the READONLY command state. */
 void readwriteCommand(client *c) {
+    if (server.cluster_enabled == 0) {
+        addReplyError(c,"This instance has cluster support disabled");
+        return;
+    }
     c->flags &= ~CLIENT_READONLY;
     addReply(c,shared.ok);
 }


### PR DESCRIPTION
It seems that readwrite can only be used in cluster mode. So i add a check just like readonly command. Just a cleanup that consistent check

rewrite doc: https://redis.io/commands/readwrite

```c
/* The READONLY command is used by clients to enter the read-only mode.
 * In this mode slaves will not redirect clients as long as clients access
 * with read-only commands to keys that are served by the slave's master. */
void readonlyCommand(client *c) {
    if (server.cluster_enabled == 0) {
        addReplyError(c,"This instance has cluster support disabled");
        return;
    }
    c->flags |= CLIENT_READONLY;
    addReply(c,shared.ok);
}

/* The READWRITE command just clears the READONLY command state. */
void readwriteCommand(client *c) {
    +if (server.cluster_enabled == 0) {
    +   addReplyError(c,"This instance has cluster support disabled");
    +    return;
    +}
    c->flags &= ~CLIENT_READONLY;
    addReply(c,shared.ok);
}
```