### PR TITLE
slowlog get command supports passing in -1 to get all logs.

### DIFF
--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -143,8 +143,9 @@ void slowlogCommand(client *c) {
     if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
         const char *help[] = {
 "GET [<count>]",
-"    Return top <count> entries from the slowlog (default: 10). Entries are",
-"    made of:",
+"    Return top <count> entries from the slowlog (default: 10).",
+"    It is also allowed to pass in -1 to get all slow logs.",
+"    Entries are made of:",
 "    id, timestamp, time in microseconds, arguments array, client IP and port,",
 "    client name",
 "LEN",
@@ -168,9 +169,18 @@ NULL
         listNode *ln;
         slowlogEntry *se;
 
-        if (c->argc == 3 &&
-            getLongFromObjectOrReply(c,c->argv[2],&count,NULL) != C_OK)
-            return;
+        if (c->argc == 3) {
+            /* Consume count arg. */
+            if (getRangeLongFromObjectOrReply(c, c->argv[2], -1,
+                    LONG_MAX, &count, "count should be greater than or equal to -1") != C_OK)
+                return;
+
+            if (count == -1) {
+                /* We treat -1 as a special value, which means to get all slow logs.
+                 * Simply set count to the length of server.slowlog.*/
+                count = listLength(server.slowlog);
+            }
+        }
 
         listRewind(server.slowlog,&li);
         totentries = addReplyDeferredLen(c);

--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -143,8 +143,7 @@ void slowlogCommand(client *c) {
     if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
         const char *help[] = {
 "GET [<count>]",
-"    Return top <count> entries from the slowlog (default: 10).",
-"    It is also allowed to pass in -1 to get all slow logs.",
+"    Return top <count> entries from the slowlog (default: 10, -1 mean all).",
 "    Entries are made of:",
 "    id, timestamp, time in microseconds, arguments array, client IP and port,",
 "    client name",

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -174,4 +174,25 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         r debug sleep 0.2
         assert_equal [r slowlog len] 0
     }
+
+    test {SLOWLOG - count must be >= -1} {
+       assert_error "ERR count should be greater than or equal to -1" {r slowlog get -2}
+       assert_error "ERR count should be greater than or equal to -1" {r slowlog get -222}
+    }
+
+    test {SLOWLOG - get all slow logs} {
+        r config set slowlog-log-slower-than 0
+        r config set slowlog-max-len 3
+        r slowlog reset
+
+        r set key test
+        r sadd set a b c
+        r incr num
+        r lpush list a
+
+        assert_equal [r slowlog len] 3
+        assert_equal 0 [llength [r slowlog get 0]]
+        assert_equal 1 [llength [r slowlog get 1]]
+        assert_equal 3 [llength [r slowlog get -1]]
+    }
 }


### PR DESCRIPTION
New:
Based on the results of the comments, this commit introduced `slowlog get -1` to get all slow logs.
```
127.0.0.1:6379> slowlog len
(integer) 0
127.0.0.1:6379> slowlog get -1
(empty array)
127.0.0.1:6379> slowlog get -2
(error) ERR count should be greater than or equal to -1
127.0.0.1:6379> config set slowlog-log-slower-than 0
OK
127.0.0.1:6379> set a 1
OK
127.0.0.1:6379> slowlog get -1
1) 1) (integer) 1
   2) (integer) 1622739251
   3) (integer) 12
   4) 1) "set"
      2) "a"
      3) "1"
   5) "127.0.0.1:55892"
   6) ""
2) 1) (integer) 0
   2) (integer) 1622739247
   3) (integer) 6
   4) 1) "config"
      2) "set"
      3) "slowlog-log-slower-than"
      4) "0"
   5) "127.0.0.1:55892"
   6) ""
127.0.0.1:6379> slowlog help
 1) SLOWLOG <subcommand> [<arg> [value] [opt] ...]. Subcommands are:
 2) GET [<count>]
 3)     Return top <count> entries from the slowlog (default: 10).
 4)     It is also allowed to pass in -1 to get all slow logs.
 5)     Entries are made of:
 6)     id, timestamp, time in microseconds, arguments array, client IP and port,
 7)     client name
 8) LEN
 9)     Return the length of the slowlog.
10) RESET
11)     Reset the slowlog.
12) HELP
13)     Prints this help.
127.0.0.1:6379>
```
@oranagra Take a look for me when you have time. Check the code style and the help txt. Make sure i do it right. Thanks!
Need to be updated on the redis-doc?


--------- old comment ----------
Before: (When typing a negative count, it will traverse the whole slowlog list. When the slowlog list is huge. May cause serious consequences if the user type a wrong count.)
```
127.0.0.1:6379> slowlog reset
OK
127.0.0.1:6379> slowlog get -1
1) 1) (integer) 13
   2) (integer) 1622525509
   3) (integer) 25
   4) 1) "slowlog"
      2) "reset"
   5) "127.0.0.1:49392"
   6) ""
127.0.0.1:6379>
127.0.0.1:6379> slowlog get 0
(empty array)
127.0.0.1:6379>
```

After: (So i added a check. I could not help myself...)
```
127.0.0.1:6379> slowlog get -1
(error) ERR value is out of range, must be positive
127.0.0.1:6379> slowlog get 0  (0 is ok)
(empty array)
```
