### PR TITLE
Fix null character in sdsrange()

### DIFF
--- a/deps/hiredis/sds.c
+++ b/deps/hiredis/sds.c
@@ -748,7 +748,7 @@ int hi_sdsrange(hisds s, ssize_t start, ssize_t end) {
         start = 0;
     }
     if (start && newlen) memmove(s, s+start, newlen);
-    s[newlen] = 0;
+    s[newlen] = '\0';
     hi_sdssetlen(s,newlen);
     return 0;
 }

--- a/src/sds.c
+++ b/src/sds.c
@@ -797,7 +797,7 @@ void sdsrange(sds s, ssize_t start, ssize_t end) {
         }
     }
     if (start && newlen) memmove(s, s+start, newlen);
-    s[newlen] = 0;
+    s[newlen] = '\0';
     sdssetlen(s,newlen);
 }
 


### PR DESCRIPTION
might be a bug when set null character at the end of a sds in `sdsrange`.