### PR TITLE
Fix lastkey index of mset/msetnx

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -641,11 +641,11 @@ struct redisCommand redisCommandTable[] = {
 
     {"mset",msetCommand,-3,
      "write use-memory @string",
-     0,NULL,1,-1,2,0,0,0},
+     0,NULL,1,-2,2,0,0,0},
 
     {"msetnx",msetnxCommand,-3,
      "write use-memory @string",
-     0,NULL,1,-1,2,0,0,0},
+     0,NULL,1,-2,2,0,0,0},
 
     {"randomkey",randomkeyCommand,1,
      "read-only random @keyspace",


### PR DESCRIPTION
Comparing with BLPOP/BRPOP, It is unreasonable that the lastkey index is -1 for MSET/MSETNX.
And it does not conform to the meaning of variable name "lastkey" which may make coders confused.