### PR TITLE
Add INFO stat eviction_exceeded_time

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -680,6 +680,7 @@ int performEvictions(void) {
                         aeCreateTimeEvent(server.el, 0,
                                 evictionTimeProc, NULL, NULL);
                     }
+                    server.stat_evicted_time_cap_reached_count++;
                     break;
                 }
             }

--- a/src/evict.c
+++ b/src/evict.c
@@ -680,7 +680,7 @@ int performEvictions(void) {
                         aeCreateTimeEvent(server.el, 0,
                                 evictionTimeProc, NULL, NULL);
                     }
-                    server.stat_evicted_time_cap_reached_count++;
+                    server.stat_eviction_time_limit_exceeded_count++;
                     break;
                 }
             }

--- a/src/evict.c
+++ b/src/evict.c
@@ -680,7 +680,6 @@ int performEvictions(void) {
                         aeCreateTimeEvent(server.el, 0,
                                 evictionTimeProc, NULL, NULL);
                     }
-                    server.stat_evicted_time_cap_reached_count++;
                     break;
                 }
             }

--- a/src/evict.c
+++ b/src/evict.c
@@ -716,9 +716,11 @@ update_metrics:
     if (result == EVICT_RUNNING || result == EVICT_FAIL) {
         if (server.stat_last_eviction_exceeded_time == 0)
             elapsedStart(&server.stat_last_eviction_exceeded_time);
-    } else if (server.stat_last_eviction_exceeded_time != 0) {
-        server.stat_total_eviction_exceeded_time += elapsedUs(server.stat_last_eviction_exceeded_time);
-        server.stat_last_eviction_exceeded_time = 0;
+    } else if (result == EVICT_OK) {
+        if (server.stat_last_eviction_exceeded_time != 0) {
+            server.stat_total_eviction_exceeded_time += elapsedUs(server.stat_last_eviction_exceeded_time);
+            server.stat_last_eviction_exceeded_time = 0;
+        }
     }
     return result;
 }

--- a/src/evict.c
+++ b/src/evict.c
@@ -510,8 +510,8 @@ static unsigned long evictionTimeLimitUs() {
  *   EVICT_FAIL     - memory is over the limit, and there's nothing to evict
  * */
 int performEvictions(void) {
-    /* we don't go to update_metrics on purpose because it's as if we don't
-     * call this function */
+    /* Note, we don't goto update_metrics here because this check skips eviction
+     * as if it wasn't triggered. it's a fake EVICT_OK. */
     if (!isSafeToPerformEvictions()) return EVICT_OK;
 
     int keys_freed = 0;
@@ -717,7 +717,7 @@ update_metrics:
         if (server.stat_last_eviction_exceeded_time == 0)
             elapsedStart(&server.stat_last_eviction_exceeded_time);
     } else if (server.stat_last_eviction_exceeded_time != 0) {
-        server.stat_total_eviction_exceeded_time += elapsedUs(server.stat_last_eviction_exceeded_time) / 1000;
+        server.stat_total_eviction_exceeded_time += elapsedUs(server.stat_last_eviction_exceeded_time);
         server.stat_last_eviction_exceeded_time = 0;
     }
     return result;

--- a/src/evict.c
+++ b/src/evict.c
@@ -680,7 +680,7 @@ int performEvictions(void) {
                         aeCreateTimeEvent(server.el, 0,
                                 evictionTimeProc, NULL, NULL);
                     }
-                    server.stat_eviction_time_limit_exceeded_count++;
+                    server.stat_evicted_time_cap_reached_count++;
                     break;
                 }
             }

--- a/src/server.c
+++ b/src/server.c
@@ -4973,8 +4973,8 @@ sds genRedisInfoString(const char *section) {
     if (allsections || defsections || !strcasecmp(section,"stats")) {
         long long stat_total_reads_processed, stat_total_writes_processed;
         long long stat_net_input_bytes, stat_net_output_bytes;
-        unsigned long long current_eviction_exceeded_time = server.stat_last_eviction_exceeded_time ?
-            (unsigned long long) elapsedUs(server.stat_last_eviction_exceeded_time) : 0;
+        long long current_eviction_exceeded_time = server.stat_last_eviction_exceeded_time ?
+            (long long) elapsedUs(server.stat_last_eviction_exceeded_time) / 1000 : 0;
         atomicGet(server.stat_total_reads_processed, stat_total_reads_processed);
         atomicGet(server.stat_total_writes_processed, stat_total_writes_processed);
         atomicGet(server.stat_net_input_bytes, stat_net_input_bytes);
@@ -4999,8 +4999,8 @@ sds genRedisInfoString(const char *section) {
             "expired_time_cap_reached_count:%lld\r\n"
             "expire_cycle_cpu_milliseconds:%lld\r\n"
             "evicted_keys:%lld\r\n"
-            "total_eviction_exceeded_time:%llu\r\n"
-            "current_eviction_exceeded_time:%llu\r\n"
+            "total_eviction_exceeded_time:%lld\r\n"
+            "current_eviction_exceeded_time:%lld\r\n"
             "keyspace_hits:%lld\r\n"
             "keyspace_misses:%lld\r\n"
             "pubsub_channels:%ld\r\n"
@@ -5039,7 +5039,7 @@ sds genRedisInfoString(const char *section) {
             server.stat_expired_time_cap_reached_count,
             server.stat_expire_cycle_time_used/1000,
             server.stat_evictedkeys,
-            (unsigned long long) server.stat_total_eviction_exceeded_time + current_eviction_exceeded_time,
+            server.stat_total_eviction_exceeded_time + current_eviction_exceeded_time,
             current_eviction_exceeded_time,
             server.stat_keyspace_hits,
             server.stat_keyspace_misses,

--- a/src/server.c
+++ b/src/server.c
@@ -3083,7 +3083,7 @@ void resetServerStats(void) {
     server.stat_expired_time_cap_reached_count = 0;
     server.stat_expire_cycle_time_used = 0;
     server.stat_evictedkeys = 0;
-    server.stat_eviction_exceeded_time = 0;
+    server.stat_total_eviction_exceeded_time = 0;
     server.stat_last_eviction_exceeded_time = 0;
     server.stat_keyspace_misses = 0;
     server.stat_keyspace_hits = 0;
@@ -4973,8 +4973,8 @@ sds genRedisInfoString(const char *section) {
     if (allsections || defsections || !strcasecmp(section,"stats")) {
         long long stat_total_reads_processed, stat_total_writes_processed;
         long long stat_net_input_bytes, stat_net_output_bytes;
-        long long current_eviction_exceeded_time = server.stat_last_eviction_exceeded_time ?
-            server.ustime - server.stat_last_eviction_exceeded_time : 0;
+        unsigned long long current_eviction_exceeded_time = server.stat_last_eviction_exceeded_time ?
+            (unsigned long long) elapsedUs(server.stat_last_eviction_exceeded_time) : 0;
         atomicGet(server.stat_total_reads_processed, stat_total_reads_processed);
         atomicGet(server.stat_total_writes_processed, stat_total_writes_processed);
         atomicGet(server.stat_net_input_bytes, stat_net_input_bytes);
@@ -4999,8 +4999,8 @@ sds genRedisInfoString(const char *section) {
             "expired_time_cap_reached_count:%lld\r\n"
             "expire_cycle_cpu_milliseconds:%lld\r\n"
             "evicted_keys:%lld\r\n"
-            "eviction_exceeded_time:%lld\r\n"
-            "current_eviction_exceeded_time:%lld\r\n"
+            "total_eviction_exceeded_time:%llu\r\n"
+            "current_eviction_exceeded_time:%llu\r\n"
             "keyspace_hits:%lld\r\n"
             "keyspace_misses:%lld\r\n"
             "pubsub_channels:%ld\r\n"
@@ -5039,7 +5039,7 @@ sds genRedisInfoString(const char *section) {
             server.stat_expired_time_cap_reached_count,
             server.stat_expire_cycle_time_used/1000,
             server.stat_evictedkeys,
-            server.stat_eviction_exceeded_time + current_eviction_exceeded_time,
+            (unsigned long long) server.stat_total_eviction_exceeded_time + current_eviction_exceeded_time,
             current_eviction_exceeded_time,
             server.stat_keyspace_hits,
             server.stat_keyspace_misses,

--- a/src/server.c
+++ b/src/server.c
@@ -3083,7 +3083,7 @@ void resetServerStats(void) {
     server.stat_expired_time_cap_reached_count = 0;
     server.stat_expire_cycle_time_used = 0;
     server.stat_evictedkeys = 0;
-    server.stat_evicted_time_cap_reached_count = 0;
+    server.stat_eviction_time_limit_exceeded_count = 0;
     server.stat_keyspace_misses = 0;
     server.stat_keyspace_hits = 0;
     server.stat_active_defrag_hits = 0;
@@ -4996,7 +4996,7 @@ sds genRedisInfoString(const char *section) {
             "expired_time_cap_reached_count:%lld\r\n"
             "expire_cycle_cpu_milliseconds:%lld\r\n"
             "evicted_keys:%lld\r\n"
-            "evicted_time_cap_reached_count:%lld\r\n"
+            "eviction_time_limit_exceeded_count:%lld\r\n"
             "keyspace_hits:%lld\r\n"
             "keyspace_misses:%lld\r\n"
             "pubsub_channels:%ld\r\n"
@@ -5035,7 +5035,7 @@ sds genRedisInfoString(const char *section) {
             server.stat_expired_time_cap_reached_count,
             server.stat_expire_cycle_time_used/1000,
             server.stat_evictedkeys,
-            server.stat_evicted_time_cap_reached_count,
+            server.stat_eviction_time_limit_exceeded_count,
             server.stat_keyspace_hits,
             server.stat_keyspace_misses,
             dictSize(server.pubsub_channels),

--- a/src/server.c
+++ b/src/server.c
@@ -3083,6 +3083,7 @@ void resetServerStats(void) {
     server.stat_expired_time_cap_reached_count = 0;
     server.stat_expire_cycle_time_used = 0;
     server.stat_evictedkeys = 0;
+    server.stat_evicted_time_cap_reached_count = 0;
     server.stat_keyspace_misses = 0;
     server.stat_keyspace_hits = 0;
     server.stat_active_defrag_hits = 0;
@@ -4995,6 +4996,7 @@ sds genRedisInfoString(const char *section) {
             "expired_time_cap_reached_count:%lld\r\n"
             "expire_cycle_cpu_milliseconds:%lld\r\n"
             "evicted_keys:%lld\r\n"
+            "evicted_time_cap_reached_count:%lld\r\n"
             "keyspace_hits:%lld\r\n"
             "keyspace_misses:%lld\r\n"
             "pubsub_channels:%ld\r\n"
@@ -5033,6 +5035,7 @@ sds genRedisInfoString(const char *section) {
             server.stat_expired_time_cap_reached_count,
             server.stat_expire_cycle_time_used/1000,
             server.stat_evictedkeys,
+            server.stat_evicted_time_cap_reached_count,
             server.stat_keyspace_hits,
             server.stat_keyspace_misses,
             dictSize(server.pubsub_channels),

--- a/src/server.c
+++ b/src/server.c
@@ -3083,7 +3083,7 @@ void resetServerStats(void) {
     server.stat_expired_time_cap_reached_count = 0;
     server.stat_expire_cycle_time_used = 0;
     server.stat_evictedkeys = 0;
-    server.stat_eviction_time_limit_exceeded_count = 0;
+    server.stat_evicted_time_cap_reached_count = 0;
     server.stat_keyspace_misses = 0;
     server.stat_keyspace_hits = 0;
     server.stat_active_defrag_hits = 0;
@@ -4996,7 +4996,7 @@ sds genRedisInfoString(const char *section) {
             "expired_time_cap_reached_count:%lld\r\n"
             "expire_cycle_cpu_milliseconds:%lld\r\n"
             "evicted_keys:%lld\r\n"
-            "eviction_time_limit_exceeded_count:%lld\r\n"
+            "evicted_time_cap_reached_count:%lld\r\n"
             "keyspace_hits:%lld\r\n"
             "keyspace_misses:%lld\r\n"
             "pubsub_channels:%ld\r\n"
@@ -5035,7 +5035,7 @@ sds genRedisInfoString(const char *section) {
             server.stat_expired_time_cap_reached_count,
             server.stat_expire_cycle_time_used/1000,
             server.stat_evictedkeys,
-            server.stat_eviction_time_limit_exceeded_count,
+            server.stat_evicted_time_cap_reached_count,
             server.stat_keyspace_hits,
             server.stat_keyspace_misses,
             dictSize(server.pubsub_channels),

--- a/src/server.c
+++ b/src/server.c
@@ -3083,6 +3083,8 @@ void resetServerStats(void) {
     server.stat_expired_time_cap_reached_count = 0;
     server.stat_expire_cycle_time_used = 0;
     server.stat_evictedkeys = 0;
+    server.stat_eviction_exceeded_time = 0;
+    server.stat_last_eviction_exceeded_time = 0;
     server.stat_keyspace_misses = 0;
     server.stat_keyspace_hits = 0;
     server.stat_active_defrag_hits = 0;
@@ -4971,6 +4973,8 @@ sds genRedisInfoString(const char *section) {
     if (allsections || defsections || !strcasecmp(section,"stats")) {
         long long stat_total_reads_processed, stat_total_writes_processed;
         long long stat_net_input_bytes, stat_net_output_bytes;
+        long long current_eviction_exceeded_time = server.stat_last_eviction_exceeded_time ?
+            server.ustime - server.stat_last_eviction_exceeded_time : 0;
         atomicGet(server.stat_total_reads_processed, stat_total_reads_processed);
         atomicGet(server.stat_total_writes_processed, stat_total_writes_processed);
         atomicGet(server.stat_net_input_bytes, stat_net_input_bytes);
@@ -4995,6 +4999,8 @@ sds genRedisInfoString(const char *section) {
             "expired_time_cap_reached_count:%lld\r\n"
             "expire_cycle_cpu_milliseconds:%lld\r\n"
             "evicted_keys:%lld\r\n"
+            "eviction_exceeded_time:%lld\r\n"
+            "current_eviction_exceeded_time:%lld\r\n"
             "keyspace_hits:%lld\r\n"
             "keyspace_misses:%lld\r\n"
             "pubsub_channels:%ld\r\n"
@@ -5033,6 +5039,8 @@ sds genRedisInfoString(const char *section) {
             server.stat_expired_time_cap_reached_count,
             server.stat_expire_cycle_time_used/1000,
             server.stat_evictedkeys,
+            server.stat_eviction_exceeded_time + current_eviction_exceeded_time,
+            current_eviction_exceeded_time,
             server.stat_keyspace_hits,
             server.stat_keyspace_misses,
             dictSize(server.pubsub_channels),

--- a/src/server.c
+++ b/src/server.c
@@ -3083,7 +3083,6 @@ void resetServerStats(void) {
     server.stat_expired_time_cap_reached_count = 0;
     server.stat_expire_cycle_time_used = 0;
     server.stat_evictedkeys = 0;
-    server.stat_evicted_time_cap_reached_count = 0;
     server.stat_keyspace_misses = 0;
     server.stat_keyspace_hits = 0;
     server.stat_active_defrag_hits = 0;
@@ -4996,7 +4995,6 @@ sds genRedisInfoString(const char *section) {
             "expired_time_cap_reached_count:%lld\r\n"
             "expire_cycle_cpu_milliseconds:%lld\r\n"
             "evicted_keys:%lld\r\n"
-            "evicted_time_cap_reached_count:%lld\r\n"
             "keyspace_hits:%lld\r\n"
             "keyspace_misses:%lld\r\n"
             "pubsub_channels:%ld\r\n"
@@ -5035,7 +5033,6 @@ sds genRedisInfoString(const char *section) {
             server.stat_expired_time_cap_reached_count,
             server.stat_expire_cycle_time_used/1000,
             server.stat_evictedkeys,
-            server.stat_evicted_time_cap_reached_count,
             server.stat_keyspace_hits,
             server.stat_keyspace_misses,
             dictSize(server.pubsub_channels),

--- a/src/server.c
+++ b/src/server.c
@@ -4974,7 +4974,7 @@ sds genRedisInfoString(const char *section) {
         long long stat_total_reads_processed, stat_total_writes_processed;
         long long stat_net_input_bytes, stat_net_output_bytes;
         long long current_eviction_exceeded_time = server.stat_last_eviction_exceeded_time ?
-            (long long) elapsedUs(server.stat_last_eviction_exceeded_time) / 1000 : 0;
+            (long long) elapsedUs(server.stat_last_eviction_exceeded_time): 0;
         atomicGet(server.stat_total_reads_processed, stat_total_reads_processed);
         atomicGet(server.stat_total_writes_processed, stat_total_writes_processed);
         atomicGet(server.stat_net_input_bytes, stat_net_input_bytes);
@@ -5039,8 +5039,8 @@ sds genRedisInfoString(const char *section) {
             server.stat_expired_time_cap_reached_count,
             server.stat_expire_cycle_time_used/1000,
             server.stat_evictedkeys,
-            server.stat_total_eviction_exceeded_time + current_eviction_exceeded_time,
-            current_eviction_exceeded_time,
+            (server.stat_total_eviction_exceeded_time + current_eviction_exceeded_time) / 1000,
+            current_eviction_exceeded_time / 1000,
             server.stat_keyspace_hits,
             server.stat_keyspace_misses,
             dictSize(server.pubsub_channels),

--- a/src/server.h
+++ b/src/server.h
@@ -1312,8 +1312,8 @@ struct redisServer {
     long long stat_expired_time_cap_reached_count; /* Early expire cycle stops.*/
     long long stat_expire_cycle_time_used; /* Cumulative microseconds used. */
     long long stat_evictedkeys;     /* Number of evicted keys (maxmemory) */
-    monotime stat_total_eviction_exceeded_time;  /* Total time over the memory limit */
-    monotime stat_last_eviction_exceeded_time;  /* Timestamp of current eviction start */
+    long long stat_total_eviction_exceeded_time;  /* Total time over the memory limit, unit ms */
+    monotime stat_last_eviction_exceeded_time;  /* Timestamp of current eviction start, unit us */
     long long stat_keyspace_hits;   /* Number of successful lookups of keys */
     long long stat_keyspace_misses; /* Number of failed lookups of keys */
     long long stat_active_defrag_hits;      /* number of allocations moved */

--- a/src/server.h
+++ b/src/server.h
@@ -1312,6 +1312,8 @@ struct redisServer {
     long long stat_expired_time_cap_reached_count; /* Early expire cycle stops.*/
     long long stat_expire_cycle_time_used; /* Cumulative microseconds used. */
     long long stat_evictedkeys;     /* Number of evicted keys (maxmemory) */
+    long long stat_eviction_exceeded_time;  /* Total time over the memory limit */
+    long long stat_last_eviction_exceeded_time; /* Timestamp of current eviction start */
     long long stat_keyspace_hits;   /* Number of successful lookups of keys */
     long long stat_keyspace_misses; /* Number of failed lookups of keys */
     long long stat_active_defrag_hits;      /* number of allocations moved */

--- a/src/server.h
+++ b/src/server.h
@@ -1312,6 +1312,7 @@ struct redisServer {
     long long stat_expired_time_cap_reached_count; /* Early expire cycle stops.*/
     long long stat_expire_cycle_time_used; /* Cumulative microseconds used. */
     long long stat_evictedkeys;     /* Number of evicted keys (maxmemory) */
+    long long stat_evicted_time_cap_reached_count; /* Early evict cylce stops.*/
     long long stat_keyspace_hits;   /* Number of successful lookups of keys */
     long long stat_keyspace_misses; /* Number of failed lookups of keys */
     long long stat_active_defrag_hits;      /* number of allocations moved */

--- a/src/server.h
+++ b/src/server.h
@@ -1312,7 +1312,6 @@ struct redisServer {
     long long stat_expired_time_cap_reached_count; /* Early expire cycle stops.*/
     long long stat_expire_cycle_time_used; /* Cumulative microseconds used. */
     long long stat_evictedkeys;     /* Number of evicted keys (maxmemory) */
-    long long stat_evicted_time_cap_reached_count; /* Early evict cylce stops.*/
     long long stat_keyspace_hits;   /* Number of successful lookups of keys */
     long long stat_keyspace_misses; /* Number of failed lookups of keys */
     long long stat_active_defrag_hits;      /* number of allocations moved */

--- a/src/server.h
+++ b/src/server.h
@@ -1312,7 +1312,7 @@ struct redisServer {
     long long stat_expired_time_cap_reached_count; /* Early expire cycle stops.*/
     long long stat_expire_cycle_time_used; /* Cumulative microseconds used. */
     long long stat_evictedkeys;     /* Number of evicted keys (maxmemory) */
-    long long stat_total_eviction_exceeded_time;  /* Total time over the memory limit, unit ms */
+    long long stat_total_eviction_exceeded_time;  /* Total time over the memory limit, unit us */
     monotime stat_last_eviction_exceeded_time;  /* Timestamp of current eviction start, unit us */
     long long stat_keyspace_hits;   /* Number of successful lookups of keys */
     long long stat_keyspace_misses; /* Number of failed lookups of keys */

--- a/src/server.h
+++ b/src/server.h
@@ -1312,7 +1312,7 @@ struct redisServer {
     long long stat_expired_time_cap_reached_count; /* Early expire cycle stops.*/
     long long stat_expire_cycle_time_used; /* Cumulative microseconds used. */
     long long stat_evictedkeys;     /* Number of evicted keys (maxmemory) */
-    long long stat_evicted_time_cap_reached_count; /* Early evict cylce stops.*/
+    long long stat_eviction_time_limit_exceeded_count; /* Early evict cycle stops.*/
     long long stat_keyspace_hits;   /* Number of successful lookups of keys */
     long long stat_keyspace_misses; /* Number of failed lookups of keys */
     long long stat_active_defrag_hits;      /* number of allocations moved */

--- a/src/server.h
+++ b/src/server.h
@@ -1312,7 +1312,7 @@ struct redisServer {
     long long stat_expired_time_cap_reached_count; /* Early expire cycle stops.*/
     long long stat_expire_cycle_time_used; /* Cumulative microseconds used. */
     long long stat_evictedkeys;     /* Number of evicted keys (maxmemory) */
-    long long stat_eviction_time_limit_exceeded_count; /* Early evict cycle stops.*/
+    long long stat_evicted_time_cap_reached_count; /* Early evict cylce stops.*/
     long long stat_keyspace_hits;   /* Number of successful lookups of keys */
     long long stat_keyspace_misses; /* Number of failed lookups of keys */
     long long stat_active_defrag_hits;      /* number of allocations moved */

--- a/src/server.h
+++ b/src/server.h
@@ -1312,8 +1312,8 @@ struct redisServer {
     long long stat_expired_time_cap_reached_count; /* Early expire cycle stops.*/
     long long stat_expire_cycle_time_used; /* Cumulative microseconds used. */
     long long stat_evictedkeys;     /* Number of evicted keys (maxmemory) */
-    long long stat_eviction_exceeded_time;  /* Total time over the memory limit */
-    long long stat_last_eviction_exceeded_time; /* Timestamp of current eviction start */
+    monotime stat_total_eviction_exceeded_time;  /* Total time over the memory limit */
+    monotime stat_last_eviction_exceeded_time;  /* Timestamp of current eviction start */
     long long stat_keyspace_hits;   /* Number of successful lookups of keys */
     long long stat_keyspace_misses; /* Number of failed lookups of keys */
     long long stat_active_defrag_hits;      /* number of allocations moved */


### PR DESCRIPTION
Add two INFO metrics:
```
total_eviction_exceeded_time:69734
current_eviction_exceeded_time:10230
```
`current_eviction_exceeded_time` if greater than 0, means how much time current used memory is greater than `maxmemory`. And we are still over the maxmemory. If used memory is below `maxmemory`, this metric is reset to 0.
`total_eviction_exceeded_time` means total time used memory is greater than `maxmemory` since server startup. 
The units of these two metrics are ms.