### PR TITLE
Improve bind and protected-mode config handling.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -536,6 +536,10 @@ void clusterInit(void) {
                    "Your Redis port number must be 55535 or less.");
         exit(1);
     }
+    if (!server.bindaddr_count) {
+        serverLog(LL_WARNING, "No bind address is configured, but it is required for the Cluster bus.");
+        exit(1);
+    }
     if (listenToPort(port+CLUSTER_PORT_INCR, &server.cfd) == C_ERR) {
         exit(1);
     }

--- a/src/config.c
+++ b/src/config.c
@@ -743,7 +743,7 @@ void configSetCommand(client *c) {
         int vlen;
         sds *v = sdssplitlen(o->ptr,sdslen(o->ptr)," ",1,&vlen);
 
-        if (vlen < 1 || vlen > CONFIG_BINDADDR_MAX) {
+        if (vlen > CONFIG_BINDADDR_MAX) {
             addReplyError(c, "Too many bind addresses specified.");
             sdsfreesplitres(v, vlen);
             return;

--- a/src/networking.c
+++ b/src/networking.c
@@ -992,7 +992,6 @@ void clientAcceptHandler(connection *conn) {
      * requests from non loopback interfaces. Instead we try to explain the
      * user what to do to fix it if needed. */
     if (server.protected_mode &&
-        server.bindaddr_count == 0 &&
         DefaultUser->flags & USER_FLAG_NOPASS &&
         !(c->flags & CLIENT_UNIX_SOCKET))
     {

--- a/src/server.c
+++ b/src/server.c
@@ -2647,6 +2647,7 @@ void createSharedObjects(void) {
 
 void initServerConfig(void) {
     int j;
+    char *default_bindaddr[CONFIG_DEFAULT_BINDADDR_COUNT] = CONFIG_DEFAULT_BINDADDR;
 
     updateCachedTime(1);
     getRandomHexChars(server.runid,CONFIG_RUN_ID_SIZE);
@@ -2661,7 +2662,9 @@ void initServerConfig(void) {
     server.configfile = NULL;
     server.executable = NULL;
     server.arch_bits = (sizeof(long) == 8) ? 64 : 32;
-    server.bindaddr_count = 0;
+    server.bindaddr_count = CONFIG_DEFAULT_BINDADDR_COUNT;
+    for (j = 0; j < CONFIG_DEFAULT_BINDADDR_COUNT; j++)
+        server.bindaddr[j] = zstrdup(default_bindaddr[j]);
     server.unixsocketperm = CONFIG_DEFAULT_UNIX_SOCKET_PERM;
     server.ipfd.count = 0;
     server.tlsfd.count = 0;
@@ -3053,16 +3056,11 @@ int createSocketAcceptHandler(socketFds *sfd, aeFileProc *accept_handler) {
 int listenToPort(int port, socketFds *sfd) {
     int j;
     char **bindaddr = server.bindaddr;
-    int bindaddr_count = server.bindaddr_count;
-    char *default_bindaddr[2] = {"*", "-::*"};
 
-    /* Force binding of 0.0.0.0 if no bind address is specified. */
-    if (server.bindaddr_count == 0) {
-        bindaddr_count = 2;
-        bindaddr = default_bindaddr;
-    }
+    /* If we have no bind address, we don't listen on a TCP socket */
+    if (server.bindaddr_count == 0) return C_OK;
 
-    for (j = 0; j < bindaddr_count; j++) {
+    for (j = 0; j < server.bindaddr_count; j++) {
         char* addr = bindaddr[j];
         int optional = *addr == '-';
         if (optional) addr++;

--- a/src/server.h
+++ b/src/server.h
@@ -111,6 +111,8 @@ typedef long long ustime_t; /* microsecond time type. */
 #define CONFIG_DEFAULT_CLUSTER_CONFIG_FILE "nodes.conf"
 #define CONFIG_DEFAULT_UNIX_SOCKET_PERM 0
 #define CONFIG_DEFAULT_LOGFILE ""
+#define CONFIG_DEFAULT_BINDADDR_COUNT 2
+#define CONFIG_DEFAULT_BINDADDR { "*", "-::*" }
 #define NET_HOST_STR_LEN 256 /* Longest valid hostname */
 #define NET_IP_STR_LEN 46 /* INET6_ADDRSTRLEN is 46, but we need to be sure */
 #define NET_ADDR_STR_LEN (NET_IP_STR_LEN+32) /* Must be enough for ip:port */

--- a/tests/support/cli.tcl
+++ b/tests/support/cli.tcl
@@ -11,9 +11,26 @@ proc rediscli_tls_config {testsdir} {
     }
 }
 
+# Returns command line for executing redis-cli
 proc rediscli {host port {opts {}}} {
     set cmd [list src/redis-cli -h $host -p $port]
     lappend cmd {*}[rediscli_tls_config "tests"]
     lappend cmd {*}$opts
     return $cmd
+}
+
+# Returns command line for executing redis-cli with a unix socket address
+proc rediscli_unixsocket {unixsocket {opts {}}} {
+    return [list src/redis-cli -s $unixsocket {*}$opts]
+}
+
+# Run redis-cli with specified args on the server of specified level.
+# Returns output broken down into individual lines.
+proc rediscli_exec {level args} {
+    set cmd [rediscli_unixsocket [srv $level unixsocket] $args]
+    set fd [open "|$cmd" "r"]
+    set ret [lrange [split [read $fd] "\n"] 0 end-1]
+    close $fd
+
+    return $ret
 }

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -626,7 +626,7 @@ proc start_server {options {code undefined}} {
     }
 }
 
-proc restart_server {level wait_ready rotate_logs} {
+proc restart_server {level wait_ready rotate_logs {reconnect 1}} {
     set srv [lindex $::servers end+$level]
     kill_server $srv
 
@@ -668,5 +668,7 @@ proc restart_server {level wait_ready rotate_logs} {
             after 10
         }
     }
-    reconnect $level
+    if {$reconnect} {
+        reconnect $level
+    }
 }


### PR DESCRIPTION
TL;DR This commit involves one new feature and two breaking changes:

* Feature: specifying an empty `bind` address prevents Redis from listening on a TCP port. Previously, such configuration was not accepted so this is not a breaking change.
* Breaking change: `CONFIG GET bind` will always return an explicit configuration value. In the past, if the default settings were used (listening on all IPv4 and IPv6 addresses), the value was empty.
* Breaking change: Modifying the `bind` parameter to a non-default value will no longer implicitly disabled `protected-mode`.

The `protected-mode` behavior is changed because it is no longer possible to differentiate between the default bind settings and user-provided settings that have an identical value (`* -::*`).

Before this commit, the `bind` configuration parameter was anomalous:

* If not specified, it would be treated as `* -::*`: The server must succeed
  binding on `0.0.0.0`, and will also attempt `::*` but can silently fail.
* If not specified, `CONFIG GET bind` would return an empty value.
* Specifying `bind ""` in the configuration file would fail, because the empty
  string could not be mapped to an address family.
* Specifying `CONFIG SET bind ""` would fail with an erroneous "Too many bind
  addresses specified" error.

This commits fixes these issues and introduces a more consistent behavior which
is also backwards compatible:

* The default value is maintained if not explicitly specified in the
  configuration file.
* Using `CONFIG GET bind` will always return with the actual value applied. If
  no value was specified in the configuration file, the default `* -::*` will be
  returned.
* Explicitly specifying `CONFIG SET bind ""` or `bind ""` in the configuration
  file will result with no binding on a TCP IPv4/IPv6 address. This
  configuration is illegal for cluster mode, where a cluster bus is required.