### PR TITLE
[sentinel] add additional arg num check for sentinel set command

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3767,7 +3767,7 @@ NULL
             addReplySds(c,e);
         }
     } else if (!strcasecmp(c->argv[1]->ptr,"set")) {
-        if (c->argc < 3) goto numargserr;
+        if (c->argc <= 3) goto numargserr;
         sentinelSetCommand(c);
     } else if (!strcasecmp(c->argv[1]->ptr,"config")) {
         if (c->argc < 3) goto numargserr;


### PR DESCRIPTION
before this commit, sentinel set command will accept args like `sentinel set <master-name>`, which is not a valid option since sentinel set will need at least one valid config. but sentinel will still accept it. eg.
`
127.0.0.1:26379> sentinel set foo

OK
`
In this commit, we can do this invalid arg check for sentinel set command.
