### PR TITLE
add missing module unload description in comments

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -8590,7 +8590,10 @@ int moduleLoad(const char *path, void **module_argv, int module_argc) {
  * to the following values depending on the type of error:
  *
  * * ENONET: No such module having the specified name.
- * * EBUSY: The module exports a new data type and can only be reloaded. */
+ * * EBUSY: The module exports a new data type and can only be reloaded. 
+ * * EPERM: The module exports APIs which are used by other module. 
+ * * EAGAIN: The module has blocked clients. 
+ * * ECANCELED: Unload module error.  */
 int moduleUnload(sds name) {
     struct RedisModule *module = dictFetchValue(modules,name);
 


### PR DESCRIPTION
the moduleUnload function is not up-to-date. this commit adds the additional error in comment