### PR TITLE
Fix coredump after Client Unpause command when threaded I/O is enabled

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3718,7 +3718,8 @@ int handleClientsWithPendingReadsUsingThreads(void) {
         c->flags &= ~CLIENT_PENDING_READ;
         listDelNode(server.clients_pending_read,ln);
 
-        if ((c->flags & CLIENT_BLOCKED) || processPendingCommandsAndResetClient(c) == C_ERR) {
+        serverAssert(!(c->flags & CLIENT_BLOCKED));
+        if (processPendingCommandsAndResetClient(c) == C_ERR) {
             /* If the client is no longer valid, we avoid
              * processing the client later. So we just go
              * to the next. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -3654,7 +3654,7 @@ int postponeClientRead(client *c) {
     if (server.io_threads_active &&
         server.io_threads_do_reads &&
         !ProcessingEventsWhileBlocked &&
-        !(c->flags & (CLIENT_MASTER|CLIENT_SLAVE|CLIENT_PENDING_READ)))
+        !(c->flags & (CLIENT_MASTER|CLIENT_SLAVE|CLIENT_PENDING_READ|CLIENT_BLOCKED))) 
     {
         c->flags |= CLIENT_PENDING_READ;
         listAddNodeHead(server.clients_pending_read,c);

--- a/src/networking.c
+++ b/src/networking.c
@@ -3718,7 +3718,7 @@ int handleClientsWithPendingReadsUsingThreads(void) {
         c->flags &= ~CLIENT_PENDING_READ;
         listDelNode(server.clients_pending_read,ln);
 
-        if (processPendingCommandsAndResetClient(c) == C_ERR) {
+        if ((c->flags & CLIENT_BLOCKED) || processPendingCommandsAndResetClient(c) == C_ERR) {
             /* If the client is no longer valid, we avoid
              * processing the client later. So we just go
              * to the next. */


### PR DESCRIPTION
Fix coredump after `Client Unpause` command when threaded I/O is also enabled for the reading + parsing side and  clients are sending pipelining requests.

enable threaded I/O in redis.conf:
```
io-threads 4
io-threads-do-reads yes
```
start redis-benchmark sending pipelining requests:
```
redis-benchmark -t set -P 1000 -c 10 -r 100000000 -n 100000000
```
send `client pause` and `client unpause`:
```
127.0.0.1:6379> client pause 100000 write
OK
127.0.0.1:6379> client unpause
Could not connect to Redis at 127.0.0.1:6379: Connection refused
```
Backtrace:
```
0   redis-server                        0x000000010e9e7b79 unblockClient + 329
1   redis-server                        0x000000010e974e23 clientCommand + 3459
2   redis-server                        0x000000010e95e2eb call + 267
3   redis-server                        0x000000010e95f27e processCommand + 2398
4   redis-server                        0x000000010e976e39 processInputBuffer + 393
5   redis-server                        0x000000010ea1be48 connSocketEventHandler + 280
6   redis-server                        0x000000010e954e24 aeProcessEvents + 788
7   redis-server                        0x000000010e95507d aeMain + 29
8   redis-server                        0x000000010e96379d main + 1885
9   libdyld.dylib                       0x00007fff599af015 start + 1
```

Since a same client was pushed into block_list repeatedly,  when we send `Client unpause`, unblockClient will call the btype-specific function to cleanup the state repeatedly which result in coredump at `serverPanic("Unknown btype in unblockClient().")`





