### PR TITLE
tests: add details when test fails on malformed info

### DIFF
--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -109,7 +109,9 @@ start_server {tags {"cli"}} {
     test_interactive_cli "INFO response should be printed raw" {
         set lines [split [run_command $fd info] "\n"]
         foreach line $lines {
-            assert [regexp {^$|^#|^[^#:]+:} $line]
+            if {![regexp {^$|^#|^[^#:]+:} $line]} {
+                fail "Malformed info line: $line"
+            }
         }
     }
 


### PR DESCRIPTION
we recently seen this in [CI](https://github.com/redis/redis/runs/2723627060?check_suite_focus=true):
```
*** [err]: Interactive CLI: INFO response should be printed raw in tests/integration/redis-cli.tcl
Expected 0 (context: type eval line 4 cmd {assert [regexp {^$|^#|^[^#:]+:} $line]} proc ::test)
```
if / when it'll happen again, we'll get more details.