### PR TITLE
XTRIM call streamParseAddOrTrimArgsOrReply use wrong arg xadd.

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3233,7 +3233,7 @@ void xtrimCommand(client *c) {
 
     /* Argument parsing. */
     streamAddTrimArgs parsed_args;
-    if (streamParseAddOrTrimArgsOrReply(c, &parsed_args, 1) < 0)
+    if (streamParseAddOrTrimArgsOrReply(c, &parsed_args, 0) < 0)
         return; /* streamParseAddOrTrimArgsOrReply already replied. */
 
     /* If the key does not exist, we are ok returning zero, that is, the


### PR DESCRIPTION
`xtrimCommand` call `streamParseAddOrTrimArgsOrReply ` should use `xadd==0`.
Wrong behavior:
```
127.0.0.1:6383> xtrim key maxlen ~ 3 nomkstream *
(integer) 0
```

When the syntax is valid, it does not cause any bugs because the params of XADD is superset of XTRIM.
Just XTRIM will not respond with error on invalid syntax. The syntax of XADD will also be accpeted by XTRIM.