### PR TITLE
Fix XTRIM or XADD with LIMIT may delete more entries than Count.

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -708,6 +708,10 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         unsigned char *lp = ri.data, *p = lpFirst(lp);
         int64_t entries = lpGetInteger(p);
 
+        /* Check if we exceeded the amount of work we could do */
+        if (limit && (deleted + entries) > limit)
+            break;
+
         /* Check if we can remove the whole node. */
         int remove_node;
         streamID master_id = {0}; /* For MINID */
@@ -726,9 +730,6 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         }
 
         if (remove_node) {
-            /* Check if we exceeded the amount of work we could do */
-            if (limit && (deleted + entries) > limit)
-                break;
             lpFree(lp);
             raxRemove(s->rax,ri.key,ri.key_len,NULL);
             raxSeek(&ri,">=",ri.key,ri.key_len);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -702,10 +702,6 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
 
     int64_t deleted = 0;
     while (raxNext(&ri)) {
-        /* Check if we exceeded the amount of work we could do */
-        if (limit && deleted >= limit)
-            break;
-
         if (trim_strategy == TRIM_STRATEGY_MAXLEN && s->length <= maxlen)
             break;
 
@@ -730,6 +726,9 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         }
 
         if (remove_node) {
+            /* Check if we exceeded the amount of work we could do */
+            if (limit && (deleted + entries) > limit)
+                break;
             lpFree(lp);
             raxRemove(s->rax,ri.key,ri.key_len,NULL);
             raxSeek(&ri,">=",ri.key,ri.key_len);

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -542,6 +542,7 @@ start_server {
             r XADD mystream * xitem v
         }
         assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 1] == 0}
+        assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 2] == 2}
     }
 }
 

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -205,7 +205,7 @@ start_server {
             r XADD yourstream * xitem v
         }
         r XADD yourstream MAXLEN ~ 0 limit 1 * xitem v
-        assert {[r XLEN yourstream] >= 3}
+        assert {[r XLEN yourstream] == 4}
     }
 
     test {XRANGE COUNT works as expected} {
@@ -541,7 +541,7 @@ start_server {
         for {set j 0} {$j < 3} {incr j} {
             r XADD mystream * xitem v
         }
-        assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 1] <= 1}
+        assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 1] == 0}
     }
 }
 

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -199,6 +199,15 @@ start_server {
         assert {[r EXISTS otherstream] == 0}
     }
 
+    test {XADD with LIMIT delete entries no more than limit} {
+        r del yourstream
+        for {set j 0} {$j < 3} {incr j} {
+            r XADD yourstream * xitem v
+        }
+        r XADD yourstream MAXLEN ~ 0 limit 1 * xitem v
+        assert {[r XLEN yourstream] >= 3}
+    }
+
     test {XRANGE COUNT works as expected} {
         assert {[llength [r xrange mystream - + COUNT 10]] == 10}
     }
@@ -524,6 +533,15 @@ start_server {
             r XADD mystream * xitem v
         }
         assert_error ERR* {r XTRIM mystream MAXLEN 1 LIMIT 30}
+    }
+
+    test {XTRIM with LIMIT delete entries no more than limit} {
+        r del mystream
+        r config set stream-node-max-entries 2
+        for {set j 0} {$j < 3} {incr j} {
+            r XADD mystream * xitem v
+        }
+        assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 1] <= 1}
     }
 }
 


### PR DESCRIPTION
The decision to stop trimming due to LIMIT in XADD and XTRIM was after the limit was reached.
i.e. the code was deleting **at least** that count of records (from the LIMIT argument's perspective, not the MAXLEN),
instead of **up to** that count of records.
see #9046