### PR TITLE
Log enhancement: print client info when client exit

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2166,7 +2166,11 @@ void readQueryFromClient(connection *conn) {
             return;
         }
     } else if (nread == 0) {
-        serverLog(LL_VERBOSE, "Client closed connection");
+        if (server.verbosity <= LL_VERBOSE) {
+            sds info = catClientInfoString(sdsempty(), c);
+            serverLog(LL_VERBOSE, "Client closed connection %s", info);
+            sdsfree(info);
+        }
         freeClientAsync(c);
         return;
     } else if (c->flags & CLIENT_MASTER) {


### PR DESCRIPTION
before:
```
73601:M 08 Jun 2021 11:34:55.327 - Client closed connection
```

after (we can get client ip:port which is useful when debugging):
```
72808:M 08 Jun 2021 11:31:31.851 - Accepted 127.0.0.1:56263
72808:M 08 Jun 2021 11:31:33.444 - Client closed connection id=4 addr=127.0.0.1:56263 laddr=127.0.0.1:6379 fd=8 name= age=2 idle=2 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=33274 argv-mem=0 obl=0 oll=0 omem=0 tot-mem=50704 events=r cmd=command user=default redir=-1
```