### PR TITLE
Add monitor client type

### DIFF
--- a/src/help.h
+++ b/src/help.h
@@ -189,7 +189,7 @@ struct commandHelp {
     8,
     "2.4.0" },
     { "CLIENT LIST",
-    "[TYPE normal|master|replica|pubsub] [ID client-id [client-id ...]]",
+    "[TYPE normal|master|replica|pubsub|monitor] [ID client-id [client-id ...]]",
     "Get the list of client connections",
     8,
     "2.4.0" },

--- a/src/server.c
+++ b/src/server.c
@@ -5375,9 +5375,9 @@ void monitorCommand(client *c) {
     }
 
     /* ignore MONITOR if already slave or in monitor mode */
-    if (c->flags & CLIENT_SLAVE) return;
+    if (c->flags & (CLIENT_SLAVE|CLIENT_MONITOR)) return;
 
-    c->flags |= (CLIENT_SLAVE|CLIENT_MONITOR);
+    c->flags |= CLIENT_MONITOR;
     listAddNodeTail(server.monitors,c);
     addReply(c,shared.ok);
 }

--- a/src/server.h
+++ b/src/server.h
@@ -301,7 +301,8 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_TYPE_SLAVE 1  /* Slaves. */
 #define CLIENT_TYPE_PUBSUB 2 /* Clients subscribed to PubSub channels. */
 #define CLIENT_TYPE_MASTER 3 /* Master. */
-#define CLIENT_TYPE_COUNT 4  /* Total number of client types. */
+#define CLIENT_TYPE_MONITOR 4 /* Monitor. */
+#define CLIENT_TYPE_COUNT 5  /* Total number of client types. */
 #define CLIENT_TYPE_OBUF_COUNT 3 /* Number of clients to expose to output
                                     buffer configuration. Just the first
                                     three: normal, slave, pubsub. */


### PR DESCRIPTION
## Changes

- `client list` supports `monitor` parameters
- Monitor cmd and `CLIENT_TYPE_SLAVE` decoupling

## Questions

- The purpose of the `CLIENT_TYPE_SLAVE` introduced in the Monitor is to avoid repeated execution of the Monitor?
- Why does the monitor not return an error message when the client type is slave and monitor?