### PR TITLE
msetnx reply error

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -549,7 +549,8 @@ void msetGenericCommand(client *c, int nx) {
     int j;
 
     if ((c->argc % 2) == 0) {
-        addReplyError(c,"wrong number of arguments for MSET");
+        addReplyErrorFormat(c,"wrong number of arguments for '%s' command",
+                            c->cmd->name);
         return;
     }
 


### PR DESCRIPTION
When `msetnx` with wrong numer of arguments,
redis just gives  error msg `"wrong number of arguments for MSET"`.

the error msg should point to request command `msetnx`.
