### PR TITLE
Turn PERSIST command into variadic.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -808,9 +808,9 @@ struct redisCommand redisCommandTable[] = {
      "read-only fast random @keyspace",
      0,NULL,1,1,1,0,0,0},
 
-    {"persist",persistCommand,2,
+    {"persist",persistCommand,-2,
      "write fast @keyspace",
-     0,NULL,1,1,1,0,0,0},
+     0,NULL,1,-1,1,0,0,0},
 
     {"slaveof",replicaofCommand,3,
      "admin no-script ok-stale",

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -72,13 +72,13 @@ start_server {tags {"expire"}} {
         list [r persist foo] [r persist nokeyatall]
     } {0 0}
 
-    test {PERSIST against multi keys} {
-        r set x foo
-        r expire x 50
-        r set y foo
-        r expire y 100
-        r set a foo
-        list [r ttl x] [r ttl y] [r persist x y a b] [r ttl x] [r ttl y] [r ttl a] [r ttl b]
+    test {PERSIST against multiple keys} {
+        r set x{t} foo
+        r expire x{t} 50
+        r set y{t} foo
+        r expire y{t} 100
+        r set a{t} foo
+        list [r ttl x{t}] [r ttl y{t}] [r persist x{t} y{t} a{t} b{t}] [r ttl x{t}] [r ttl y{t}] [r ttl a{t}] [r ttl b{t}]
     } {50 100 2 -1 -1 -1 -2}
 
     test {EXPIRE precision is now the millisecond} {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -72,6 +72,15 @@ start_server {tags {"expire"}} {
         list [r persist foo] [r persist nokeyatall]
     } {0 0}
 
+    test {PERSIST against multi keys} {
+        r set x foo
+        r expire x 50
+        r set y foo
+        r expire y 100
+        r set a foo
+        list [r ttl x] [r ttl y] [r persist x y a b] [r ttl x] [r ttl y] [r ttl a] [r ttl b]
+    } {50 100 2 -1 -1 -1 -2}
+
     test {EXPIRE precision is now the millisecond} {
         # This test is very likely to do a false positive if the
         # server is under pressure, so if it does not work give it a few more


### PR DESCRIPTION
As I know all commands which can be turned into variadic compatibly were done but `PERSIST`.
In fact variadic `PERSIST` uses less code. So I think it's reasonable to turn it into variadic.