### PR TITLE
Fix a confusing return value from debug command

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -764,13 +764,17 @@ NULL
         }
     } else if (!strcasecmp(c->argv[1]->ptr,"sleep") && c->argc == 3) {
         double dtime = strtod(c->argv[2]->ptr,NULL);
-        long long utime = dtime*1000000;
-        struct timespec tv;
+        if (dtime <= 0) {
+            addReplyError(c, "Wrong time. Please enter a valid number greater than zero");
+        } else {
+            long long utime = dtime*1000000;
+            struct timespec tv;
 
-        tv.tv_sec = utime / 1000000;
-        tv.tv_nsec = (utime % 1000000) * 1000;
-        nanosleep(&tv, NULL);
-        addReply(c,shared.ok);
+            tv.tv_sec = utime / 1000000;
+            tv.tv_nsec = (utime % 1000000) * 1000;
+            nanosleep(&tv, NULL);
+            addReply(c,shared.ok);
+        }
     } else if (!strcasecmp(c->argv[1]->ptr,"set-active-expire") &&
                c->argc == 3)
     {


### PR DESCRIPTION
This is a display error. If we execute "debug sleep redis" or "debug sleep -1024", we will get OK, which is what we don't want to see.  So I modified its behavior to give information when strtod fails to parse or parses out negative numbers and zeros.