### PR TITLE
Delete an unnecessary function declaration

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1951,7 +1951,6 @@ void trackingBroadcastInvalidationMessages(void);
 int checkPrefixCollisionsOrReply(client *c, robj **prefix, size_t numprefix);
 
 /* List data type */
-void listTypeTryConversion(robj *subject, robj *value);
 void listTypePush(robj *subject, robj *value, int where);
 robj *listTypePop(robj *subject, int where);
 unsigned long listTypeLength(const robj *subject);


### PR DESCRIPTION
Function listTypeTryConversion is so old that there is no function definition, so I think it’s a good idea to delete it