### PR TITLE
tests: fix exec fails when grep exists with status other than 0

### DIFF
--- a/tests/unit/moduleapi/fork.tcl
+++ b/tests/unit/moduleapi/fork.tcl
@@ -1,7 +1,11 @@
 set testmodule [file normalize tests/modules/fork.so]
 
 proc count_log_message {pattern} {
-    set result [exec grep -c $pattern < [srv 0 stdout]]
+    set status [catch {exec grep -c $pattern < [srv 0 stdout]} result]
+    if {$status == 1} {
+        set result 0
+    }
+    return $result
 }
 
 start_server {tags {"modules"}} {


### PR DESCRIPTION
This will exit abnormally when the exec search fails, so you need to catch the exception here to prevent the test from exiting abnormally, and return a valid value to the caller.

If we have another tcl statement as follows: exec grep "hello world" < hello.txt
but there is no "hello world" in the hello.txt file

We will get the following output：
`
child process exited abnormally
    while executing
"exec grep "hello" < hello.txt"
`