### PR TITLE
Fix flaky test case for absolute TTL replication

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -570,7 +570,7 @@ void pexpireatCommand(client *c) {
     expireGenericCommand(c,0,UNIT_MILLISECONDS);
 }
 
-/* Implements TTL, PTTL and EXPIRETIME */
+/* Implements TTL, PTTL, EXPIRETIME and PEXPIRETIME */
 void ttlGenericCommand(client *c, int output_ms, int output_abs) {
     long long expire, ttl = -1;
 

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -221,8 +221,9 @@ start_server {tags {"expire"}} {
         r set e c
         r set s c
         r set foo b
-        lsort [r keys *]
-    } {a e foo s t}
+        assert_equal [lsort [r keys *]] {a e foo s t}
+        r del a ; # Do not leak volatile keys to other tests
+    }
 
     test {EXPIRE with empty string as TTL should report an error} {
         r set foo bar
@@ -433,6 +434,7 @@ start_server {tags {"expire"}} {
         #    stream, which is as absolute timestamps.
         # See: https://github.com/redis/redis/issues/8433
 
+        r flushall ; # Clean up keyspace to avoid interference by keys from other tests
         set repl [attach_to_replication_stream]
         # SET commands
         r set foo1 bar ex 200


### PR DESCRIPTION
Fix flaky test case reported here: https://github.com/redis/redis/pull/8474/#issuecomment-855346434

The root cause is that one test (`5 keys in, 5 keys out`) is leaking a volatile key that can expire while another later test(`All TTL in commands are propagated as absolute timestamp in replication stream`) is running. Such leaked expiration injects an unexpected `DEL` command into the replication command during the later test, causing it to fail.

The fixes are two fold:
1. Plug the leak in the first test.
2. Add FLUSHALL to the later test, to avoid future interference from other tests.

