### PR TITLE
Modify updateMaxmemory execution logic

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2279,8 +2279,8 @@ static int updateMaxmemory(long long val, long long prev, const char **err) {
         size_t used = zmalloc_used_memory()-freeMemoryGetNotCountedMemory();
         if ((unsigned long long)val < used) {
             serverLog(LL_WARNING,"WARNING: the new maxmemory value set via CONFIG SET (%llu) is smaller than the current memory usage (%zu). This will result in key eviction and/or the inability to accept new write commands depending on the maxmemory-policy.", server.maxmemory, used);
+            performEvictions();
         }
-        performEvictions();
     }
     return 1;
 }


### PR DESCRIPTION
When we modify the Maxmemory value to be less than the total amount of memory used, performEvictions need to be executed, but it is not necessary to do this when increasing Maxmemory.

It is also written in the comments of performEvictions："It's possible for Redis to suddenly be significantly over the "maxmemory" setting.  This can happen if there is a large allocation (like a hash table resize) or even if the "maxmemory" setting is manually adjusted. "