### PR TITLE
fix a redundant judgment in processCommand

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4065,8 +4065,7 @@ int processCommand(client *c) {
      * 2) The command has no key arguments. */
     if (server.cluster_enabled &&
         !(c->flags & CLIENT_MASTER) &&
-        !(c->flags & CLIENT_LUA &&
-          server.lua_caller->flags & CLIENT_MASTER) &&
+        !(server.lua_caller->flags & CLIENT_MASTER) &&
         !(!cmdHasMovableKeys(c->cmd) && c->cmd->firstkey == 0 &&
           c->cmd->proc != execCommand))
     {


### PR DESCRIPTION
processCommand will not be called by lua client, so this is actually a redundant judgment.

The initial commit record of this code is here：https://github.com/redis/redis/commit/2f4240b9d9e36b83fcd6bf2525484effabe69298

The modification in scripting.c is correct, but the judgment of REDIS_LUA_CLIENT in redis.c is redundant.