### PR TITLE
Remove dead code in defrag.c (ziplist encoded list)

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -843,9 +843,6 @@ long defragKey(redisDb *db, dictEntry *de) {
     } else if (ob->type == OBJ_LIST) {
         if (ob->encoding == OBJ_ENCODING_QUICKLIST) {
             defragged += defragQuicklist(db, de);
-        } else if (ob->encoding == OBJ_ENCODING_ZIPLIST) {
-            if ((newzl = activeDefragAlloc(ob->ptr)))
-                defragged++, ob->ptr = newzl;
         } else {
             serverPanic("Unknown list encoding");
         }


### PR DESCRIPTION
This seems to be a very obvious oversight. The OBJ_ENCODING_SKIPLIST was judged when defrag OBJ_LIST. But OBJ_ENCODING_SKIPLIST is no longer the encoding method of List. So I think this code should be deleted.