### PR TITLE
Simplify a redundant condition in computeDefragCycles

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1063,9 +1063,7 @@ void computeDefragCycles() {
             server.active_defrag_cycle_max);
      /* We allow increasing the aggressiveness during a scan, but don't
       * reduce it. */
-    if (!server.active_defrag_running ||
-        cpu_pct > server.active_defrag_running)
-    {
+    if (cpu_pct > server.active_defrag_running) {
         server.active_defrag_running = cpu_pct;
         serverLog(LL_VERBOSE,
             "Starting active defrag, frag=%.0f%%, frag_bytes=%zu, cpu=%d%%",


### PR DESCRIPTION
The statement cpu_pct = LIMIT ensures that the minimum cpu_pct is server.active_defrag_cycle_min. And it is meaningless for server.active_defrag_cycle_min to be zero. In other words, as long as the (!server.active_defrag_running) condition is met, (cpu_pct> server.active_defrag_running) must be met, so we can delete the first condition.