### PR TITLE
fix meaningless initialization in activeDefragCycle

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1144,7 +1144,6 @@ void activeDefragCycle(void) {
 
                 start_scan = now;
                 current_db = -1;
-                cursor = 0;
                 db = NULL;
                 server.active_defrag_running = 0;
 
@@ -1160,7 +1159,6 @@ void activeDefragCycle(void) {
             }
 
             db = &server.db[current_db];
-            cursor = 0;
         }
 
         do {


### PR DESCRIPTION
When a db finishes defrag and the time is not finished, it will pass the judgment of "if (!cursor)" to perform some initialization operations and the finishing work after defrag all db, among which (cursor=0) is not meaningful. So I think these codes should be deleted.