### PR TITLE
Fix typo in comment of defrag and modify log information

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1064,7 +1064,8 @@ void computeDefragCycles() {
      /* We allow increasing the aggressiveness during a scan, but don't
       * reduce it. */
     if (!server.active_defrag_running ||
-        cpu_pct > server.active_defrag_running) {
+        cpu_pct > server.active_defrag_running)
+    {
         server.active_defrag_running = cpu_pct;
         serverLog(LL_VERBOSE,
             "Starting active defrag, frag=%.0f%%, frag_bytes=%zu, cpu=%d%%",
@@ -1137,8 +1138,10 @@ void activeDefragCycle(void) {
                 long long now = ustime();
                 size_t frag_bytes;
                 float frag_pct = getAllocatorFragmentation(&frag_bytes);
+                /* reallocated, misses and scanned respectively represent the hits, misses
+                 * and scanned keys of the db keys actually executed in a defrag. */
                 serverLog(LL_VERBOSE,
-                    "Active defrag done in %dms, hits=%d, misses=%d, scanned=%d, frag=%.0f%%, frag_bytes=%zu",
+                    "Active defrag done in %dms, reallocated=%d, misses=%d, scanned=%d, frag=%.0f%%, frag_bytes=%zu",
                     (int)((now - start_time)/1000), (int)(server.stat_active_defrag_hits - start_hit), 
                     (int)(server.stat_active_defrag_misses - start_miss),
                     (int)(server.stat_active_defrag_scanned - start_scan), frag_pct, frag_bytes);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -380,7 +380,7 @@ long activeDefragSdsListAndDict(list *l, dict *d, int dict_val_type) {
 
 /* Utility function that replaces an old key pointer in the dictionary with a
  * new pointer. Additionally, we try to defrag the dictEntry in that dict.
- * Oldkey mey be a dead pointer and should not be accessed (we get a
+ * Oldkey may be a dead pointer and should not be accessed (we get a
  * pre-calculated hash value). Newkey may be null if the key pointer wasn't
  * moved. Return value is the the dictEntry if found, or NULL if not found.
  * NOTE: this is very ugly code, but it let's us avoid the complication of
@@ -1064,8 +1064,7 @@ void computeDefragCycles() {
      /* We allow increasing the aggressiveness during a scan, but don't
       * reduce it. */
     if (!server.active_defrag_running ||
-        cpu_pct > server.active_defrag_running)
-    {
+        cpu_pct > server.active_defrag_running) {
         server.active_defrag_running = cpu_pct;
         serverLog(LL_VERBOSE,
             "Starting active defrag, frag=%.0f%%, frag_bytes=%zu, cpu=%d%%",
@@ -1080,7 +1079,7 @@ void activeDefragCycle(void) {
     static int current_db = -1;
     static unsigned long cursor = 0;
     static redisDb *db = NULL;
-    static long long start_scan, start_stat;
+    static long long start_time, start_hit, start_miss, start_scan;
     unsigned int iterations = 0;
     unsigned long long prev_defragged = server.stat_active_defrag_hits;
     unsigned long long prev_scanned = server.stat_active_defrag_scanned;
@@ -1139,10 +1138,12 @@ void activeDefragCycle(void) {
                 size_t frag_bytes;
                 float frag_pct = getAllocatorFragmentation(&frag_bytes);
                 serverLog(LL_VERBOSE,
-                    "Active defrag done in %dms, reallocated=%d, frag=%.0f%%, frag_bytes=%zu",
-                    (int)((now - start_scan)/1000), (int)(server.stat_active_defrag_hits - start_stat), frag_pct, frag_bytes);
+                    "Active defrag done in %dms, hits=%d, misses=%d, scanned=%d, frag=%.0f%%, frag_bytes=%zu",
+                    (int)((now - start_time)/1000), (int)(server.stat_active_defrag_hits - start_hit), 
+                    (int)(server.stat_active_defrag_misses - start_miss),
+                    (int)(server.stat_active_defrag_scanned - start_scan), frag_pct, frag_bytes);
 
-                start_scan = now;
+                start_time = now;
                 current_db = -1;
                 cursor = 0;
                 db = NULL;
@@ -1152,11 +1153,12 @@ void activeDefragCycle(void) {
                 if (server.active_defrag_running != 0 && ustime() < endtime)
                     continue;
                 break;
-            }
-            else if (current_db==0) {
+            } else if (current_db==0) {
                 /* Start a scan from the first database. */
-                start_scan = ustime();
-                start_stat = server.stat_active_defrag_hits;
+                start_time = ustime();
+                start_hit = server.stat_active_defrag_hits;
+                start_miss = server.stat_active_defrag_misses;
+                start_scan = server.stat_active_defrag_scanned;
             }
 
             db = &server.db[current_db];
@@ -1172,7 +1174,7 @@ void activeDefragCycle(void) {
 
             cursor = dictScan(db->dict, cursor, defragScanCallback, defragDictBucketCallback, db);
 
-            /* Once in 16 scan iterations, 512 pointer reallocations. or 64 keys
+            /* Once in 16 scan iterations, 512 pointer reallocations or 64 keys
              * (if we have a lot of pointers in one hash bucket or rehasing),
              * check if we reached the time limit.
              * But regardless, don't start a new db in this loop, this is because after

--- a/src/server.h
+++ b/src/server.h
@@ -1346,7 +1346,7 @@ struct redisServer {
     int tcpkeepalive;               /* Set SO_KEEPALIVE if non-zero. */
     int active_expire_enabled;      /* Can be disabled for testing purposes. */
     int active_expire_effort;       /* From 1 (default) to 10, active effort. */
-    int active_defrag_enabled;
+    int active_defrag_enabled;      /* Can be disabled for incremental defragmentation. */
     int sanitize_dump_payload;      /* Enables deep sanitization for ziplist and listpack in RDB and RESTORE. */
     int skip_checksum_validation;   /* Disables checksum validateion for RDB and RESTORE payload. */
     int jemalloc_bg_thread;         /* Enable jemalloc background thread */


### PR DESCRIPTION
I think these simple operations can make the code look better than before!

I mainly did three things:
1. Fix typo in comment.
2. Modify non-conventional parentheses.
3. Make the information printed by log more useful. Because usually only getting the information of hits is not enough, the information of misses and scanned is also very important.