### PR TITLE
Simplify function latencyResetEvent.

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -291,7 +291,7 @@ int hashTypeDelete(robj *o, sds field) {
             }
         }
     } else if (o->encoding == OBJ_ENCODING_HT) {
-        if (dictDelete((dict*)o->ptr, field) == C_OK) {
+        if (dictDelete((dict*)o->ptr, field) == DICT_OK) {
             deleted = 1;
 
             /* Always check if the dictionary needs a resize after a delete. */


### PR DESCRIPTION
In old way, we traverse the whole dict and reset the event.
Because the dict is small now, the cost is low.
At the same time the old code is a bit complicated.
Simplifies the code and improves readability.