### PR TITLE
Check `CLIENT_DIRTY_CAS` flag before process transaction.

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -98,9 +98,6 @@ void multiCommand(client *c) {
     if (c->flags & CLIENT_MULTI) {
         addReplyError(c,"MULTI calls can not be nested");
         return;
-    } else if (c->flags & CLIENT_DIRTY_CAS) {
-        addReplyError(c,"Watched keys modified. MULTI EXEC will fail.");
-        return;
     }
     c->flags |= CLIENT_MULTI;
 


### PR DESCRIPTION
Do not queue command in an already aborted MULTI state.
We can detect an error (watched key).
So in queueMultiCommand, we also can return early.
Like we deal with `CLIENT_DIRTY_EXEC`.


**For example**:
```
127.0.0.1:6379> watch a
OK
127.0.0.1:6379> get a
"1"
127.0.0.1:6379> get a           # client2 modify the key
"2"
127.0.0.1:6379> multi
OK
127.0.0.1:6379(TX)> get a    # we can not queue the command (save memory or cpu)
QUEUED
127.0.0.1:6379(TX)> exec
(nil)
```

CLIENT_DIRTY_EXEC ref: https://github.com/redis/redis/pull/7370
