### PR TITLE
Expand the effective range of lpDecodeBacklen and modify the puzzling return value

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -366,8 +366,13 @@ uint64_t lpDecodeBacklen(unsigned char *p) {
         val |= (uint64_t)(p[0] & 127) << shift;
         if (!(p[0] & 128)) break;
         shift += 7;
+        if (shift > 28) {
+            shift -= 7;
+            /* Set val when the eighth bit of the fifth byte is 1. */
+            val |= (uint64_t)(p[0] & 128) << shift;
+            break;
+        }
         p--;
-        if (shift > 28) return UINT64_MAX;
     } while(1);
     return val;
 }


### PR DESCRIPTION
When the lengths of the entry in the listpack is decoded, theoretically, 7 bits in the first four bytes are valid, and 8 bits in the fifth byte are valid. But our current decoding method makes the fifth byte only 7bit valid. When the 8th bit of the five bytes is 1, lpDecodeBacklen returns UINT64_MAX directly.

Although the total length in the current listpack cannot exceed UINT32_MAX (lpInsert), but part of the code in the listpack is very independent and may be used as a library in other places. No one wants to get UINT64_MAX when inputting a 100000001...1(28).

Not only that, by modifying the code  we can easily double the effective length of the listpack (2^35-2^36).