### PR TITLE
fix ZRANGESTORE - should return 0 when src points to an empty key

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3663,7 +3663,12 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
         lookupKeyWrite(c->db,key) :
         lookupKeyRead(c->db,key);
     if (zobj == NULL) {
-        addReply(c,shared.emptyarray);
+        if (store) {
+            handler->beginResultEmission(handler);
+            handler->finalizeResultEmission(handler, 0);
+        } else {
+            addReply(c, shared.emptyarray);
+        }
         goto cleanup;
     }
 
@@ -3683,7 +3688,7 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
         break;
 
     case ZRANGE_LEX:
-        genericZrangebylexCommand(handler, &lexrange, zobj, opt_withscores || store,
+         genericZrangebylexCommand(handler, &lexrange, zobj, opt_withscores || store,
             opt_offset, opt_limit, direction == ZRANGE_DIRECTION_REVERSE);
         break;
     }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3688,7 +3688,7 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
         break;
 
     case ZRANGE_LEX:
-         genericZrangebylexCommand(handler, &lexrange, zobj, opt_withscores || store,
+        genericZrangebylexCommand(handler, &lexrange, zobj, opt_withscores || store,
             opt_offset, opt_limit, direction == ZRANGE_DIRECTION_REVERSE);
         break;
     }

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1579,8 +1579,8 @@ start_server {tags {"zset"}} {
 
     test {ZRANGESTORE - src key wrong type} {
         r zadd z2{t} 1 a
-        r set foo bar
-        assert_error "*WRONGTYPE*" {r zrangestore z2{t} foo 0 -1}
+        r set foo{t} bar
+        assert_error "*WRONGTYPE*" {r zrangestore z2{t} foo{t} 0 -1}
         r zrange z2{t} 0 -1
     } {a}
 

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1571,6 +1571,12 @@ start_server {tags {"zset"}} {
         r zrange z1{t} 5 0 BYSCORE REV LIMIT 0 2 WITHSCORES
     } {d 4 c 3}
 
+    test {ZRANGESTORE - null src key} {
+        set res [r zrangestore z2{t} null 0 -1]
+        assert_equal $res 0
+        r exists z2{t}
+    } {0}
+
     test {ZRANGESTORE - empty range} {
         set res [r zrangestore z2{t} z1{t} 5 6]
         assert_equal $res 0

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1571,11 +1571,18 @@ start_server {tags {"zset"}} {
         r zrange z1{t} 5 0 BYSCORE REV LIMIT 0 2 WITHSCORES
     } {d 4 c 3}
 
-    test {ZRANGESTORE - null src key} {
-        set res [r zrangestore z2{t} null 0 -1]
+    test {ZRANGESTORE - src key missing} {
+        set res [r zrangestore z2{t} missing 0 -1]
         assert_equal $res 0
         r exists z2{t}
     } {0}
+
+    test {ZRANGESTORE - src key wrong type} {
+        r zadd z2{t} 1 a
+        r set foo bar
+        assert_error "*WRONGTYPE*" {r zrangestore z2{t} foo 0 -1}
+        r zrange z2{t} 0 -1
+    } {a}
 
     test {ZRANGESTORE - empty range} {
         set res [r zrangestore z2{t} z1{t} 5 6]

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1572,7 +1572,7 @@ start_server {tags {"zset"}} {
     } {d 4 c 3}
 
     test {ZRANGESTORE - src key missing} {
-        set res [r zrangestore z2{t} missing 0 -1]
+        set res [r zrangestore z2{t} missing{t} 0 -1]
         assert_equal $res 0
         r exists z2{t}
     } {0}


### PR DESCRIPTION
Using `ZRANGESTORE` and setting the `src` to an empty key will return an empty array and leave the `dest` key as-is:
```
ZADD dest 0 member
(integer) 1
ZRANGESTORE dest src 0 -1
(empty array)
ZCARD dest
(integer) 1
```

the expected result is:
```
ZADD dest 0 member
(integer) 1
ZRANGESTORE dest src 0 -1
(integer) 0
ZCARD dest
(integer) 0
```