### PR TITLE
Fix querybuf test failure

### DIFF
--- a/tests/unit/querybuf.tcl
+++ b/tests/unit/querybuf.tcl
@@ -25,7 +25,7 @@ start_server {tags {"querybuf slow"}} {
         set rd [redis_deferring_client]
         $rd client setname test_client
         set orig_test_client_qbuf [client_query_buffer test_client]
-        assert {$orig_test_client_qbuf > 16384 && $orig_test_client_qbuf < 32768}
+        assert {$orig_test_client_qbuf >= 16384 && $orig_test_client_qbuf < 32768}
 
         # Check that the initial query buffer is not resized if it is idle for more than 2s
         wait_for_condition 1000 10 {


### PR DESCRIPTION
Fix test failure which introduced by #9003.
The following case will occur when querybuf expansion will allocate memory equal to (16*1024)k.
1) make use ```CFLAGS=-DNO_MALLOC_USABLE_SIZE```.
2) ```malloc``` will not allocate more under ```alpine```.