### PR TITLE
fix Redis build failed on suse 11 sp4

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,6 +19,16 @@ OPTIMIZATION?=-O2
 DEPENDENCY_TARGETS=hiredis linenoise lua
 NODEPS:=clean distclean
 
+HAVE_PTHREAD_SETNAME_NP := "0"
+ifeq ($(uname_S),Linux)
+   HAVE_PTHREAD_SETNAME_NP := $(shell sh -c "grep 'pthread_setname_np' /usr/include/pthread.h | wc -l")
+endif
+
+ifeq "$(HAVE_PTHREAD_SETNAME_NP)" "1"
+   $(info "PTHREAD_SETNAME_NP enable")
+   FINAL_CFLAGS+=-DHAVE_PTHREAD_SETNAME_NP $(HAVE_PTHREAD_SETNAME_NP)
+endif
+
 # Default settings
 STD=-std=c11 -pedantic -DREDIS_STATIC=''
 ifneq (,$(findstring clang,$(CC)))

--- a/src/config.h
+++ b/src/config.h
@@ -220,7 +220,11 @@ void setproctitle(const char *fmt, ...);
 
 /* Define for redis_set_thread_title */
 #ifdef __linux__
+#ifdef HAVE_PTHREAD_SETNAME_NP
 #define redis_set_thread_title(name) pthread_setname_np(pthread_self(), name)
+#else
+#define redis_set_thread_title(name)
+#endif
 #else
 #if (defined __FreeBSD__ || defined __OpenBSD__)
 #include <pthread_np.h>


### PR DESCRIPTION
i build Redis on suse 11 sp4 and got error ：
```
networking.o: In function `IOThreadMain':
/data/redis/src/networking.c:3058: undefined reference to `pthread_setname_np'
bio.o: In function `bioProcessBackgroundJobs':
/data/redis/src/bio.c:165: undefined reference to `pthread_setname_np'
/data/redis/src/bio.c:159: undefined reference to `pthread_setname_np'
/data/redis/src/bio.c:162: undefined reference to `pthread_setname_np'
collect2: error: ld returned 1 exit status
make[1]: *** [redis-server] Error 1
make[1]: Leaving directory `/data/redis/src'
make: *** [all] Error 2
```
system info：

```
70461d7ac821:/data/redis # uname -a
Linux 70461d7ac821 3.10.0-862.el7.x86_64 #1 SMP Fri Apr 20 16:44:24 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
70461d7ac821:/data/redis # cat /etc/issue

Welcome to SUSE Linux Enterprise Server 11 SP4  (x86_64) - Kernel \r (\l).
```
 
and i found `pthread_setname_np`  does not exist in `libpthread-2.11.3.so`
```
70461d7ac821:/lib64 # ll | grep thread
-rwxr-xr-x 1 root root  135764 Apr 24  2015 libpthread-2.11.3.so
lrwxrwxrwx 1 root root      20 Dec 29  2017 libpthread.so.0 -> libpthread-2.11.3.so
-rwxr-xr-x 1 root root   36714 Apr 24  2015 libthread_db-1.0.so
lrwxrwxrwx 1 root root      19 Dec 29  2017 libthread_db.so.1 -> libthread_db-1.0.so
70461d7ac821:/lib64 # strings libpthread-2.11.3.so | grep pthread_setname_np
70461d7ac821:/lib64 # 
```

is libpthread too old ？

