### PR TITLE
Improve objectComputeSize() with allocator fragmentaiton.

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -813,12 +813,12 @@ size_t objectComputeSize(robj *o, size_t sample_size) {
             quicklistNode *node = ql->head;
             asize = sizeof(*o)+sizeof(quicklist);
             do {
-                elesize += sizeof(quicklistNode) + zmalloc_size(node->zl);
+                elesize += sizeof(quicklistNode)+zmalloc_size(node->zl);
                 samples++;
             } while ((node = node->next) && samples < sample_size);
             asize += (double)elesize/samples*ql->len;
         } else if (o->encoding == OBJ_ENCODING_ZIPLIST) {
-            asize = sizeof(*o)+ zmalloc_size(o->ptr);
+            asize = sizeof(*o)+zmalloc_size(o->ptr);
         } else {
             serverPanic("Unknown list encoding");
         }
@@ -835,13 +835,13 @@ size_t objectComputeSize(robj *o, size_t sample_size) {
             dictReleaseIterator(di);
             if (samples) asize += (double)elesize/samples*dictSize(d);
         } else if (o->encoding == OBJ_ENCODING_INTSET) {
-            asize = sizeof(*o) + zmalloc_size(o->ptr);
+            asize = sizeof(*o)+zmalloc_size(o->ptr);
         } else {
             serverPanic("Unknown set encoding");
         }
     } else if (o->type == OBJ_ZSET) {
         if (o->encoding == OBJ_ENCODING_ZIPLIST) {
-            asize = sizeof(*o)+ zmalloc_size(o->ptr);
+            asize = sizeof(*o)+zmalloc_size(o->ptr);
         } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
             d = ((zset*)o->ptr)->dict;
             zskiplist *zsl = ((zset*)o->ptr)->zsl;
@@ -851,7 +851,7 @@ size_t objectComputeSize(robj *o, size_t sample_size) {
                     zmalloc_size(zsl->header);
             while(znode != NULL && samples < sample_size) {
                 elesize += sdsZmallocSize(znode->ele);
-                elesize += sizeof(struct dictEntry) + zmalloc_size(znode);
+                elesize += sizeof(struct dictEntry)+zmalloc_size(znode);
                 samples++;
                 znode = znode->level[0].forward;
             }
@@ -861,7 +861,7 @@ size_t objectComputeSize(robj *o, size_t sample_size) {
         }
     } else if (o->type == OBJ_HASH) {
         if (o->encoding == OBJ_ENCODING_ZIPLIST) {
-            asize = sizeof(*o)+ zmalloc_size(o->ptr);
+            asize = sizeof(*o)+zmalloc_size(o->ptr);
         } else if (o->encoding == OBJ_ENCODING_HT) {
             d = o->ptr;
             di = dictGetIterator(d);


### PR DESCRIPTION
Hi guys, 

I found that when I use MEMORY USAGE command for a key, the result is not same compared to the result of INFO MEMORY.

For example,  I run `set a b` in an empty redis(with **jemalloc allocator**) and check `used_memory` with INFO MEMORY. The used memory increment is `88` bytes:
- 32 for creating a dictEntry table in dictht;
- 24 for a dictEntry;
- 8 for key sds;
- 24 for the value obj (embstr) ;

When I run `MEMORY USAGE a`, I'd like to see a result like `56`(while the left `32`  is actually the db hashtable consumption), but actually get `51`, which is computed by `objectComputeSize`.

So I use `zmalloc_size` to get the the allocated size of ziplist, intset and EMBSTR string. And other sds size is already fixed using sdsZmallocSize. For stream, I am not familiar with the structure now. So there is no modificaiton.

I saw the related problem discussed in #6263 and #6198.

This PR improve MEMORY USAGE command to include internal fragmentation overheads of:
1. EMBSTR encoded strings
2. ziplist encoded zsets and hashes
3. List type nodes