### PR TITLE
Reset db num and transaction state from redis-cli prompt after RESET …

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1486,7 +1486,12 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
                 config.in_multi = 0;
                 config.input_dbnum = config.dbnum = config.pre_multi_dbnum;
                 cliRefreshPrompt();
-            } 
+            } else if (!strcasecmp(command,"reset") && argc == 1 &&
+                                     config.last_cmd_type != REDIS_REPLY_ERROR) {
+                config.in_multi = 0;
+                config.dbnum = 0;
+                cliRefreshPrompt();
+            }
         }
         if (config.cluster_reissue_command){
             /* If we need to reissue the command, break to prevent a

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1490,6 +1490,8 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
                                      config.last_cmd_type != REDIS_REPLY_ERROR) {
                 config.in_multi = 0;
                 config.dbnum = 0;
+                config.input_dbnum = 0;
+                config.resp3 = 0;
                 cliRefreshPrompt();
             }
         }


### PR DESCRIPTION
Currently multi state and db num are not being reset after reset command:
Before the change:
 ```
$./src/redis-cli
127.0.0.1:6379> select 2
OK
127.0.0.1:6379[2]> multi
OK
127.0.0.1:6379[2](TX)> get x
QUEUED
127.0.0.1:6379[2](TX)> reset
RESET
127.0.0.1:6379[2](TX)> exec
(error) ERR EXEC without MULTI
127.0.0.1:6379[2]> 
```
After:
```
$./src/redis-cli
127.0.0.1:6379> select 2
OK
127.0.0.1:6379[2]> multi
OK
127.0.0.1:6379[2](TX)> get x
QUEUED
127.0.0.1:6379[2](TX)> reset
RESET
127.0.0.1:6379> 
```