### PR TITLE
Reduce the number of null judgments in rax.c

### DIFF
--- a/src/rax.c
+++ b/src/rax.c
@@ -534,23 +534,19 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             memcpy(parentlink,&h,sizeof(h));
         }
 
-        int res;
         /* Update the existing key if there is already one. */
         if (h->iskey) {
             if (old) *old = raxGetData(h);
             if (overwrite) raxSetData(h,data);
             errno = 0;
-            res = 0;    /* Element already exists. */
+            return 0; /* Element already exists. */
         }
 
-        /* A new element, note raxSetData() will set h->iskey. */
-        if (!h->iskey) {
-            raxSetData(h,data);
-            rax->numele++;
-            res = 1;    /* Element inserted. */
-        }
-
-        return res;
+        /* Otherwise set the node as a key. Note that raxSetData()
+         * will set h->iskey. */
+        raxSetData(h,data);
+        rax->numele++;
+        return 1; /* Element inserted. */
     }
 
     /* If the node we stopped at is a compressed node, we need to


### PR DESCRIPTION
This modification comes from my doubts while reading the code of rax.c. 

When we have found the raxNode corresponding to the key, we need to judge whether raxGetData is based on overwrite and h->iskey. First judgment `(!h->iskey || (h->isnull && overwrite))` tells us that we should realloc. 

The next judgment is actually like this `h->iskey && (!h->isnull || !overwrite)`, This tells us that we should modify a raxnode that `h->iskey == 1`.

Next is the more confusing place, why do we need raxSetData() and numele++? The reason is that the execution here actually contains `!h->iskey`, but this is usually difficult to see at a glance. 

So I modified the judgment here to make it easier to understand. This may save an hour for someone.