### PR TITLE
Make readQueryFromClient more aggressive when reading big arg again (Followup for #9003)

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2145,7 +2145,7 @@ void readQueryFromClient(connection *conn) {
 
         /* Note that the 'remaining' variable may be zero in some edge case,
          * for example once we resume a blocked client after CLIENT PAUSE. */
-        readlen = remaining;
+        if (remaining > 0) readlen = remaining;
     }
 
     qblen = sdslen(c->querybuf);

--- a/src/networking.c
+++ b/src/networking.c
@@ -2145,7 +2145,7 @@ void readQueryFromClient(connection *conn) {
 
         /* Note that the 'remaining' variable may be zero in some edge case,
          * for example once we resume a blocked client after CLIENT PAUSE. */
-        if (remaining > 0 && (size_t)remaining < readlen) readlen = remaining;
+        readlen = remaining;
     }
 
     qblen = sdslen(c->querybuf);


### PR DESCRIPTION
@oranagra @yoav-steinberg 
Due to the change in #9003, a long-standing bug was raised under ```valgrind```.
This bug can cause the master-slave sync to take a very long time, causing the ```pendingquerybuf.tcl``` test to fail.
This problem does not only occur in master-slave sync, it is triggered when the big arg is greater than 32k.
step:
```sh
dd if=/dev/zero of=bigfile bs=1M count=32
./src/redis-cli -x hset a a < bigfile
```

1) Make room for querybuf in processMultibulkBuffer, now the alloc of querybuf will be more than 32k.
https://github.com/redis/redis/blob/b586d5b567f78b27569f4ef11e5839f22d82e865/src/networking.c#L2159
2) If this happens to trigger the ```clientsCronResizeQueryBuffer```,  querybuf will be resized to 0.
3) Finally, in readQueryFromClient, we expand the querybuf non-greedily, from 0 to 32k.
    Old code, make room for querybuf is greedy, so it only needs 11 times to expand to 32M(16k*(2^11)), but now we need 2048(32*1024/16) times to reach it, due to the slow allocation under valgrind tha exposed the problem.

The fix for the excessive shrinking of the query buf to 0, will be handled in #5013 (that other change on it's own can fix failing test too), but the fix in this PR will also fix the failing test.

The fix in this PR will make the reading in `readQueryFromClient` more aggressive when working on a big arg (so that it is in par with the same code in `processMultibulkBuffer` (i.e. the two calls to `sdsMakeRoomForNonGreedy` should both use the bulk size).
In the current code (before this fix) the one in readQueryFromClient always has `readlen = PROTO_IOBUF_LEN`