### PR TITLE
Use exitFromChild to exit from child process in linuxMadvFreeForkBugCheck

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5499,7 +5499,7 @@ int linuxMadvFreeForkBugCheck(void) {
 
         if (write(pipefd[1], &bug_found, sizeof(bug_found)) < 0)
             serverLog(LL_WARNING, "Failed to write to parent: %s", strerror(errno));
-        exit(0);
+        exitFromChild(0);
     } else {
         /* Read the result from the child. */
         ret = read(pipefd[0], &bug_found, sizeof(bug_found));


### PR DESCRIPTION
Use exitFromChild to exit from child process in linuxMadvFreeForkBugCheck. This ensures that _exit is called instead of exit when exiting from the child process. This also makes the code consistent to other places in code where we exit from child process. 