### PR TITLE
The save configuration item is not allowed to set changes to 0.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -478,7 +478,7 @@ void loadServerConfigFromString(char *config) {
             if (argc == 3) {
                 int seconds = atoi(argv[1]);
                 int changes = atoi(argv[2]);
-                if (seconds < 1 || changes < 0) {
+                if (seconds < 1 || changes < 1) {
                     err = "Invalid save parameters"; goto loaderr;
                 }
                 appendServerSaveParams(seconds,changes);

--- a/src/config.c
+++ b/src/config.c
@@ -802,7 +802,7 @@ void configSetCommand(client *c) {
 
         /* Perform sanity check before setting the new config:
          * - Even number of args
-         * - Seconds >= 1, changes >= 0 */
+         * - Seconds >= 1, changes >= 1 */
         if (vlen & 1) {
             sdsfreesplitres(v,vlen);
             goto badfmt;
@@ -814,7 +814,7 @@ void configSetCommand(client *c) {
             val = strtoll(v[j], &eptr, 10);
             if (eptr[0] != '\0' ||
                 ((j & 1) == 0 && val < 1) ||
-                ((j & 1) == 1 && val < 0)) {
+                ((j & 1) == 1 && val < 1)) {
                 sdsfreesplitres(v,vlen);
                 goto badfmt;
             }


### PR DESCRIPTION
If we set changes to 0, bgsave will be performed every few seconds.
Because changes is actually 0, this makes no sense.
(Although no one would do it... Minor cleanup)

Before:
```
27478:M 19 Jun 2021 20:45:36.097 * 0 changes in 1 seconds. Saving...
27478:M 19 Jun 2021 20:45:36.097 * Background saving started by pid 27489
27489:C 19 Jun 2021 20:45:36.107 * DB saved on disk
27489:C 19 Jun 2021 20:45:36.108 * RDB: 0 MB of memory used by copy-on-write
27478:M 19 Jun 2021 20:45:36.197 * Background saving terminated with success

27478:M 19 Jun 2021 20:45:38.001 * 0 changes in 1 seconds. Saving...
27478:M 19 Jun 2021 20:45:38.001 * Background saving started by pid 27492
27492:C 19 Jun 2021 20:45:38.009 * DB saved on disk
27492:C 19 Jun 2021 20:45:38.009 * RDB: 0 MB of memory used by copy-on-write
27478:M 19 Jun 2021 20:45:38.101 * Background saving terminated with success
```


After:
```
*** FATAL CONFIG FILE ERROR (Redis 255.255.255) ***
Reading the configuration file, at line 391
>>> 'save 1 0'
Invalid save parameters
```