### PR TITLE
masterport is not allowed to be set to 0.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -517,10 +517,10 @@ void loadServerConfigFromString(char *config) {
                 server.masterhost = NULL;
                 continue;
             }
+
             server.masterhost = sdsnew(argv[1]);
-            char *ptr;
-            server.masterport = strtol(argv[2], &ptr, 10);
-            if (server.masterport < 0 || server.masterport > 65535 || *ptr != '\0') {
+            server.masterport = atoi(argv[2]);
+            if (server.masterport < 1 || server.masterport > 65535) {
                 err = "Invalid master port"; goto loaderr;
             }
             server.repl_state = REPL_STATE_CONNECT;


### PR DESCRIPTION
Since we can not start a redis server on port 0.
See https://github.com/redis/redis/blob/unstable/src/server.c#L3192

Also masterport is an int. It seems better to use atoi.
It's more intuitive and reduces the code. (Minor cleanup)

ref link: https://github.com/redis/redis/pull/7842