### PR TITLE
Use loaderr label to handle error.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -487,10 +487,9 @@ void loadServerConfigFromString(char *config) {
             }
         } else if (!strcasecmp(argv[0],"dir") && argc == 2) {
             if (chdir(argv[1]) == -1) {
-                serverLog(LL_WARNING,"Can't chdir to '%s': %s",
-                    argv[1], strerror(errno));
-                exit(1);
-            }
+                err = sdscatprintf(sdsempty(), "Can't chdir to '%s': %s",
+                                   argv[1], strerror(errno));
+                goto loaderr;
         } else if (!strcasecmp(argv[0],"logfile") && argc == 2) {
             FILE *logfp;
 

--- a/src/config.c
+++ b/src/config.c
@@ -490,6 +490,7 @@ void loadServerConfigFromString(char *config) {
                 err = sdscatprintf(sdsempty(), "Can't chdir to '%s': %s",
                                    argv[1], strerror(errno));
                 goto loaderr;
+            }
         } else if (!strcasecmp(argv[0],"logfile") && argc == 2) {
             FILE *logfp;
 


### PR DESCRIPTION
So that we can easily see the lines of the config.
Also unified with other error handling.

Before:
```
11634:C 19 Jun 2021 22:00:34.824 # Can't chdir to '/ppp': No such file or directory
```

After:
```
*** FATAL CONFIG FILE ERROR (Redis 255.255.255) ***
Reading the configuration file, at line 394
>>> 'dir /ppp'
Can't chdir to '/ppp': No such file or directory
```

Also a minor cleanup :)