### PR TITLE
Make CONFIG GET OOM-score-adj-values case insensitive.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1072,7 +1072,7 @@ void configGetCommand(client *c) {
         matches++;
     }
 
-    if (stringmatch(pattern,"oom-score-adj-values",0)) {
+    if (stringmatch(pattern,"oom-score-adj-values",1)) {
         sds buf = sdsempty();
         int j;
 


### PR DESCRIPTION
May be overlook in this one.

```
127.0.0.1:6379> config get oom-score-adj-values
1) "oom-score-adj-values"
2) "0 200 800"
127.0.0.1:6379> config get OOM-score-adj-values
(empty array)
127.0.0.1:6379> config set OOM-score-adj-values "0 200 888"
OK
127.0.0.1:6379> config get oom-score-adj-values
1) "oom-score-adj-values"
2) "0 200 888"
127.0.0.1:6379> config get OOM-score-adj-values
(empty array)

# after
127.0.0.1:6379> config get OOM-score-adj-values
1) "oom-score-adj-values"
2) "0 200 800"
127.0.0.1:6379>
```

BTW...   i want to remove all the if .. and change it to else if. So that we can avoid `stringmatch`
```c
    if (stringmatch(pattern,"dir",1)) {
        char buf[1024];

        if (getcwd(buf,sizeof(buf)) == NULL)
            buf[0] = '\0';

        addReplyBulkCString(c,"dir");
        addReplyBulkCString(c,buf);
        matches++;
    }
    if (stringmatch(pattern,"save",1)) {
```