### PR TITLE
Replace raxIteratorAddChars with raxStackPop to improve performance

### DIFF
--- a/src/rax.c
+++ b/src/rax.c
@@ -1633,8 +1633,11 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
                 if (nodechar > keychar) {
                     if (!raxIteratorNextStep(it,0)) return 0;
                 } else {
-                    if (!raxIteratorAddChars(it,it->node->data,it->node->size))
-                        return 0;
+                    it->node = raxStackPop(&it->stack);
+                    if (it->key_len == 0) {
+                        it->flags |= RAX_ITER_EOF;
+                        return 1;
+                    }
                     if (!raxIteratorNextStep(it,1)) return 0;
                 }
             }
@@ -1647,8 +1650,11 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
                     if (!raxSeekGreatest(it)) return 0;
                     it->data = raxGetData(it->node);
                 } else {
-                    if (!raxIteratorAddChars(it,it->node->data,it->node->size))
-                        return 0;
+                    it->node = raxStackPop(&it->stack);
+                    if (it->key_len == 0) {
+                        it->flags |= RAX_ITER_EOF;
+                        return 1;
+                    }
                     if (!raxIteratorPrevStep(it,1)) return 0;
                 }
             }


### PR DESCRIPTION
It takes a little time to clarify this problem, but it does make our code more efficient.

First, before judging lt and gt, we executed `(i != len && it->node->iscompr)`, that is to say, satisfies `it->node->iscompr ==1 and noup == 1`when executing `raxIteratorNextStep` and `raxIteratorPrevStep`.

Let's take `raxIteratorNextStep` as an example: when `it->node->iscompr == 1 and noup == 1` conditions are met, `raxIteratorDelChars` will be executed and will not enter the loop of line 1381, which means that in fact ` raxIteratorAddChars` is a completely redundant operation, and it needs to be executed once more `raxIteratorDelChars`.

If we execute `raxStackPop` directly before `raxIteratorNextStep`, this situation can be avoided, but it brings the problem of line1459 line out of bounds, only need to judge the special case that it->key_len is equal to zero.

This approach can reduce the number of operations of `raxIteratorAddChars` and `raxIteratorDelChars` when executing `raxSeek` in most cases. This is obviously a place to improve performance, especially when the key is large.