### PR TITLE
solve test timing issues in replication tests

### DIFF
--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -161,10 +161,10 @@ start_server {} {
 }
 
 test {client freed during loading} {
-    start_server [list overrides [list key-load-delay 10 rdbcompression no]] {
+    start_server [list overrides [list key-load-delay 50 rdbcompression no]] {
         # create a big rdb that will take long to load. it is important
         # for keys to be big since the server processes events only once in 2mb.
-        # 100mb of rdb, 100k keys will load in more than 1 second
+        # 100mb of rdb, 100k keys will load in more than 5 seconds
         r debug populate 100000 key 1000
 
         restart_server 0 false false
@@ -172,9 +172,9 @@ test {client freed during loading} {
         # make sure it's still loading
         assert_equal [s loading] 1
 
-        # connect and disconnect 10 clients
+        # connect and disconnect 5 clients
         set clients {}
-        for {set j 0} {$j < 10} {incr j} {
+        for {set j 0} {$j < 5} {incr j} {
             lappend clients [redis_deferring_client]
         }
         foreach rd $clients {

--- a/tests/integration/replication-3.tcl
+++ b/tests/integration/replication-3.tcl
@@ -118,7 +118,7 @@ start_server {tags {"repl external:skip"}} {
             # correctly the RDB file: such file will contain "lua" AUX
             # sections with scripts already in the memory of the master.
 
-            wait_for_condition 500 100 {
+            wait_for_condition 1000 100 {
                 [s -1 master_link_status] eq {up}
             } else {
                 fail "Replication not started."

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -397,7 +397,7 @@ test {slave fails full sync and diskless load swapdb recovers it} {
             # Put different data sets on the master and slave
             # we need to put large keys on the master since the slave replies to info only once in 2mb
             $slave debug populate 2000 slave 10
-            $master debug populate 200 master 100000
+            $master debug populate 800 master 100000
             $master config set rdbcompression no
 
             # Set master and slave to use diskless replication
@@ -406,7 +406,7 @@ test {slave fails full sync and diskless load swapdb recovers it} {
             $slave config set repl-diskless-load swapdb
 
             # Set master with a slow rdb generation, so that we can easily disconnect it mid sync
-            # 10ms per key, with 200 keys is 2 seconds
+            # 10ms per key, with 800 keys is 8 seconds
             $master config set rdb-key-save-delay 10000
 
             # Start the replication process...


### PR DESCRIPTION
# replication-3.tcl
had a test timeout failure with valgrind on daily CI:
```
*** [err]: SLAVE can reload "lua" AUX RDB fields of duplicated scripts in tests/integration/replication-3.tcl
Replication not started.
```
replication took more than 70 seconds.
https://github.com/redis/redis/runs/2854037905?check_suite_focus=true

on my machine it takes only about 30, but i can see how 50 seconds isn't enough.

# replication.tcl
loading was over too quickly in freebsd daily CI:
```
*** [err]: slave fails full sync and diskless load swapdb recovers it in tests/integration/replication.tcl
Expected '0' to be equal to '1' (context: type eval line 44 cmd {assert_equal [s -1 loading] 1} proc ::start_server)
```

# rdb.tcl
loading was over too quickly.
increase the time loading takes, and decrease the amount of work we try to achieve in that time.