### PR TITLE
Reduce the frequency of memory allocation in raxIteratorAddChars and raxStackPush

### DIFF
--- a/src/rax.c
+++ b/src/rax.c
@@ -119,7 +119,7 @@ static inline int raxStackPush(raxStack *ts, void *ptr) {
             }
             ts->stack = newalloc;
         }
-        ts->maxitems = rax_malloc_size(ts->stack)%sizeof(void*);
+        ts->maxitems = rax_malloc_usable_size(ts->stack)/sizeof(void*);
     }
     ts->stack[ts->items] = ptr;
     ts->items++;
@@ -1281,7 +1281,7 @@ int raxIteratorAddChars(raxIterator *it, unsigned char *s, size_t len) {
             return 0;
         }
         if (old == NULL) memcpy(it->key,it->key_static_string,it->key_len);
-        it->key_max = rax_malloc_size(it->key);
+        it->key_max = rax_malloc_usable_size(it->key);
     }
     /* Use memmove since there could be an overlap between 's' and
      * it->key when we use the current key in order to re-seek. */

--- a/src/rax.c
+++ b/src/rax.c
@@ -119,7 +119,7 @@ static inline int raxStackPush(raxStack *ts, void *ptr) {
             }
             ts->stack = newalloc;
         }
-        ts->maxitems *= 2;
+        ts->maxitems = rax_malloc_size(ts->stack)%sizeof(void*);
     }
     ts->stack[ts->items] = ptr;
     ts->items++;
@@ -1281,7 +1281,7 @@ int raxIteratorAddChars(raxIterator *it, unsigned char *s, size_t len) {
             return 0;
         }
         if (old == NULL) memcpy(it->key,it->key_static_string,it->key_len);
-        it->key_max = new_max;
+        it->key_max = rax_malloc_size(it->key);
     }
     /* Use memmove since there could be an overlap between 's' and
      * it->key when we use the current key in order to re-seek. */

--- a/src/rax_malloc.h
+++ b/src/rax_malloc.h
@@ -41,5 +41,5 @@
 #define rax_malloc zmalloc
 #define rax_realloc zrealloc
 #define rax_free zfree
-#define rax_malloc_size zmalloc_size
+#define rax_malloc_usable_size zmalloc_usable_size
 #endif

--- a/src/rax_malloc.h
+++ b/src/rax_malloc.h
@@ -41,4 +41,5 @@
 #define rax_malloc zmalloc
 #define rax_realloc zrealloc
 #define rax_free zfree
+#define rax_malloc_size zmalloc_size
 #endif


### PR DESCRIPTION
raxIteratorAddChars and raxStackPush are functions that are called very frequently. The use of malloc_size can reduce the probability of memory allocation without any effort.