### PR TITLE
redis-cli --rdb: fix broken fsync/ftruncate for stdout

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7226,7 +7226,7 @@ static void getRDB(clusterManagerNode *node) {
             payload, filename);
     }
 
-    int write_to_stdout = !strcmp(filename,"-") || !strcmp(filename,"/dev/stdout");
+    int write_to_stdout = !strcmp(filename,"-");
     /* Write to file. */
     if (write_to_stdout) {
         fd = STDOUT_FILENO;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1928,7 +1928,7 @@ static void usage(void) {
 "                     Default time interval is 1 sec. Change it using -i.\n"
 "  --lru-test <keys>  Simulate a cache workload with an 80-20 distribution.\n"
 "  --replica          Simulate a replica showing commands received from the master.\n"
-"  --rdb <filename>   Transfer an RDB dump from remote server to local file.
+"  --rdb <filename>   Transfer an RDB dump from remote server to local file.\n"
 "                     Use filename of \"-\" to write to stdout.\n"
 "  --pipe             Transfer raw Redis protocol from stdin to server.\n"
 "  --pipe-timeout <n> In --pipe mode, abort with error if after sending all data.\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1928,7 +1928,8 @@ static void usage(void) {
 "                     Default time interval is 1 sec. Change it using -i.\n"
 "  --lru-test <keys>  Simulate a cache workload with an 80-20 distribution.\n"
 "  --replica          Simulate a replica showing commands received from the master.\n"
-"  --rdb <filename>   Transfer an RDB dump from remote server to local file.\n"
+"  --rdb <filename>   Transfer an RDB dump from remote server to local file.
+"                     Use filename of \"-\" to write to stdout.\n"
 "  --pipe             Transfer raw Redis protocol from stdin to server.\n"
 "  --pipe-timeout <n> In --pipe mode, abort with error if after sending all data.\n"
 "                     no reply is received within <n> seconds.\n"


### PR DESCRIPTION
In 6.2 I got errors. I used redis-cli --rdb /dev/stdout or even redis-cli --rdb -, but now process fails, because it can't make fsync to stdout.
I've found "-" arg for stdout, so I've improved this code and now it will skip ftruncate and fsync for stdout file


example of failed redis-cli

```redis-cli --rdb - > /dev/null
SYNC sent to master, writing bytes of bulk transfer until EOF marker to '-'
ftruncate failed: Invalid argument.
Transfer finished with success after 178 bytes
Fail to fsync '-': Invalid argument
```

```
redis-cli --rdb /dev/stdout > /dev/null
SYNC sent to master, writing bytes of bulk transfer until EOF marker to '/dev/stdout'
ftruncate failed: Invalid argument.
Transfer finished with success after 178 bytes
Fail to fsync '/dev/stdout': Invalid argument
```

and exit code of this == 1