### PR TITLE
Direct redis-cli repl prints to stderr, because --rdb can print to stdout. fflush stdout after responses 

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1342,6 +1342,7 @@ static int cliReadReply(int output_raw_strings) {
     if (output) {
         out = cliFormatReply(reply, config.output, output_raw_strings);
         fwrite(out,sdslen(out),1,stdout);
+        fflush(stdout);
         sdsfree(out);
     }
     freeReplyObject(reply);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7061,7 +7061,7 @@ static void latencyDistMode(void) {
 #define RDB_EOF_MARK_SIZE 40
 
 void sendReplconf(const char* arg1, const char* arg2) {
-    printf("sending REPLCONF %s %s\n", arg1, arg2);
+    fprintf(stderr, "sending REPLCONF %s %s\n", arg1, arg2);
     redisReply *reply = redisCommand(context, "REPLCONF %s %s", arg1, arg2);
 
     /* Handle any error conditions */
@@ -7121,7 +7121,7 @@ unsigned long long sendSync(redisContext *c, char *out_eof) {
     }
     *p = '\0';
     if (buf[0] == '-') {
-        printf("SYNC with master failed: %s\n", buf);
+        fprintf(stderr, "SYNC with master failed: %s\n", buf);
         exit(1);
     }
     if (strncmp(buf+1,"EOF:",4) == 0 && strlen(buf+5) >= RDB_EOF_MARK_SIZE) {

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -312,11 +312,10 @@ start_server {tags {"cli"}} {
             fail "redis-cli --replica didn't read commands"
         }
 
+        fconfigure $fd -blocking true
         r client kill type slave
-        #catch { read_cli $fd } err
-        #assert_match {*exited abnormally*} $err
-
-        close_cli $fd
+        catch { close_cli $fd } err
+        assert_match {*Server closed the connection*} $err
     }
 
     test "Connecting as a replica" {


### PR DESCRIPTION
1. redis-cli can output --rdb data to stdout
   but redis-cli also write some messages to stdout which will mess up the rdb.

2. Make redis-cli flush stdout when printing a reply
  This was needed in order to fix a hung in redis-cli test that uses
  --replica.
   Note that printf does flush when there's a newline, but fwrite does not.

3. fix the redis-cli --replica test which used to pass previously
   because it didn't really care what it read, and because redis-cli
   used printf to print these other things to stdout.

4. improve redis-cli --replica test to run with both diskless and disk-based.