### PR TITLE
change streamAppendItem to use raxEOF instead of raxNext

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -458,8 +458,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
     size_t lp_bytes = 0;        /* Total bytes in the tail listpack. */
     unsigned char *lp = NULL;   /* Tail listpack pointer. */
 
-    /* Get a reference to the tail node listpack. */
-    if (raxNext(&ri)) {
+    if (!raxEOF(&ri)) {
+        /* Get a reference to the tail node listpack. */
         lp = ri.data;
         lp_bytes = lpBytes(lp);
     }


### PR DESCRIPTION
In this judgment, we have used `raxSeek` to move raxIterator to the end, and the use of `raxNext` here does not actually make any sense. 
It only uses the judgment of `ri.flags` to detect whether the `raxSeek` is successful. 

`raxSeek` fails when the flag contains `RAX_ITER_EOF`. So we can replace `raxNext` as the judgment of flags. 