### PR TITLE
Clean redis-benchmark Throughput output.

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1649,6 +1649,7 @@ int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData
     const float instantaneous_rps = (float)(requests_finished-previous_requests_finished)/instantaneous_dt;
     config.previous_tick = current_tick;
     atomicSet(config.previous_requests_finished,requests_finished);
+    printf("%*s\r", config.last_printed_bytes, " "); /* ensure there is a clean line */
     int printed_bytes = printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)\r", config.title, instantaneous_rps, rps, hdr_mean(config.current_sec_latency_histogram)/1000.0f, hdr_mean(config.latency_histogram)/1000.0f);
     if (printed_bytes > config.last_printed_bytes){
        config.last_printed_bytes = printed_bytes;


### PR DESCRIPTION
The `showThroughput` output may display wrong:
```
PING_INLINE: rps=78000.0 (overall: 75001.1) avg_msec=0.845 (overall: 0.649)))
```

Other info or error output also have this problem. But fix will change a lot of lines.