### PR TITLE
Fix failing basics moduleapi test on 32bit CI

### DIFF
--- a/tests/modules/basics.c
+++ b/tests/modules/basics.c
@@ -333,6 +333,9 @@ int TestCtxFlags(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     flags = RedisModule_GetContextFlags(ctx);
     if (!(flags & REDISMODULE_CTX_FLAGS_AOF)) FAIL("AOF Flag not set after config set");
 
+    /* Disable RDB saving and test the flag. */
+    RedisModule_Call(ctx, "config", "ccc", "set", "save", "");
+    flags = RedisModule_GetContextFlags(ctx);
     if (flags & REDISMODULE_CTX_FLAGS_RDB) FAIL("RDB Flag was set");
     /* Enable RDB to test RDB flags */
     RedisModule_Call(ctx, "config", "ccc", "set", "save", "900 1");
@@ -344,8 +347,12 @@ int TestCtxFlags(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (flags & REDISMODULE_CTX_FLAGS_READONLY) FAIL("Read-only flag was set");
     if (flags & REDISMODULE_CTX_FLAGS_CLUSTER) FAIL("Cluster flag was set");
 
+    /* Disable maxmemory and test the flag. (it is implicitly set in 32bit builds. */
+    RedisModule_Call(ctx, "config", "ccc", "set", "maxmemory", "0");
+    flags = RedisModule_GetContextFlags(ctx);
     if (flags & REDISMODULE_CTX_FLAGS_MAXMEMORY) FAIL("Maxmemory flag was set");
 
+    /* Enable maxmemory and test the flag. */
     RedisModule_Call(ctx, "config", "ccc", "set", "maxmemory", "100000000");
     flags = RedisModule_GetContextFlags(ctx);
     if (!(flags & REDISMODULE_CTX_FLAGS_MAXMEMORY))

--- a/tests/unit/moduleapi/basics.tcl
+++ b/tests/unit/moduleapi/basics.tcl
@@ -1,8 +1,7 @@
 set testmodule [file normalize tests/modules/basics.so]
 
 
-# TEST.CTXFLAGS requires RDB to be disabled, so override save file
-start_server {tags {"modules"} overrides {save ""}} {
+start_server {tags {"modules"}} {
     r module load $testmodule
 
     test {test module api basics} {


### PR DESCRIPTION
it failed because on 32bit builds, the maxmemory config is enabled implicitly (by redis).