### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,9 +452,9 @@ Other C files
 * `anet.c` is a library to use POSIX networking in a simpler way compared to the raw interface exposed by the kernel.
 * `dict.c` is an implementation of a non-blocking hash table which rehashes incrementally.
 * `scripting.c` implements Lua scripting. It is completely self-contained and isolated from the rest of the Redis implementation and is simple enough to understand if you are familiar with the Lua API.
-* `cluster.c` implements the Redis Cluster. Probably a good read only after being very familiar with the rest of the Redis code base. If you want to read `cluster.c` make sure to read the [Redis Cluster specification][3].
+* `cluster.c` implements the Redis Cluster. Probably a good read only after being very familiar with the rest of the Redis code base. If you want to read `cluster.c` make sure to read the [Redis Cluster specification][4].
 
-[3]: https://redis.io/topics/cluster-spec
+[4]: https://redis.io/topics/cluster-spec
 
 Anatomy of a Redis command
 ---


### PR DESCRIPTION
In the previous version, the link number to "Redis Cluster specification" is conflicted with "SECURITY.md" defined in line 231, causing github markdown viewer to mis-redirect the link to https://github.com/redis/redis/blob/unstable/SECURITY.md.
This commit fix the link confict issue.