### PR TITLE
Fix range issues in default value of LIMIT argument to XADD and XTRIM

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2544,7 +2544,7 @@ standardConfig configs[] = {
     createLongLongConfig("slowlog-log-slower-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.slowlog_log_slower_than, 10000, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("proto-max-bulk-len", NULL, MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.proto_max_bulk_len, 512ll*1024*1024, MEMORY_CONFIG, NULL, NULL), /* Bulk request max size */
-    createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.cfg_repl_backlog_size, 1024*1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 1mb */
 
     /* Unsigned Long Long configs */

--- a/src/config.c
+++ b/src/config.c
@@ -2544,7 +2544,7 @@ standardConfig configs[] = {
     createLongLongConfig("slowlog-log-slower-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.slowlog_log_slower_than, 10000, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("proto-max-bulk-len", NULL, MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.proto_max_bulk_len, 512ll*1024*1024, MEMORY_CONFIG, NULL, NULL), /* Bulk request max size */
-    createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX/100, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.cfg_repl_backlog_size, 1024*1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 1mb */
 
     /* Unsigned Long Long configs */

--- a/src/config.c
+++ b/src/config.c
@@ -2544,7 +2544,7 @@ standardConfig configs[] = {
     createLongLongConfig("slowlog-log-slower-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.slowlog_log_slower_than, 10000, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("proto-max-bulk-len", NULL, MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.proto_max_bulk_len, 512ll*1024*1024, MEMORY_CONFIG, NULL, NULL), /* Bulk request max size */
-    createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX/100, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.cfg_repl_backlog_size, 1024*1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 1mb */
 
     /* Unsigned Long Long configs */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -986,7 +986,7 @@ static int streamParseAddOrTrimArgsOrReply(client *c, streamAddTrimArgs *args, i
             if (args->approx_trim) {
                 /* In order to prevent from trimming to do too much work and cause
                  * latency spikes we limit the amount of work it can do */
-                args->limit = 100 * server.stream_node_max_entries;
+                args->limit = 100 * server.stream_node_max_entries; /* Maximum 100 rax nodes. */
             } else {
                 /* No LIMIT for exact trimming */
                 args->limit = 0;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -986,7 +986,7 @@ static int streamParseAddOrTrimArgsOrReply(client *c, streamAddTrimArgs *args, i
             if (args->approx_trim) {
                 /* In order to prevent from trimming to do too much work and cause
                  * latency spikes we limit the amount of work it can do */
-                args->limit = 100 * server.stream_node_max_entries; /* Maximum 100 rax nodes. */
+                args->limit = 100 * server.stream_node_max_entries;
             } else {
                 /* No LIMIT for exact trimming */
                 args->limit = 0;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -982,7 +982,6 @@ static int streamParseAddOrTrimArgsOrReply(client *c, streamAddTrimArgs *args, i
             }
         } else {
             /* User didn't provide LIMIT, we must set it. */
-
             if (args->approx_trim) {
                 /* In order to prevent from trimming to do too much work and 
                  * cause latency spikes we limit the amount of work it can do.
@@ -990,7 +989,7 @@ static int streamParseAddOrTrimArgsOrReply(client *c, streamAddTrimArgs *args, i
                  * stream_node_max_entries is 0 or too big (could cause overflow)
                  */
                 args->limit = 100 * server.stream_node_max_entries; /* Maximum 100 rax nodes. */
-                if (args->limit < 1) args->limit = 1;
+                if (args->limit <= 0) args->limit = 10000;
                 if (args->limit > 1000000) args->limit = 1000000;
             } else {
                 /* No LIMIT for exact trimming */


### PR DESCRIPTION
This seems to be an unimportant bug that was accidentally generated. If the user does not specify limit in streamParseAddOrTrimArgsOrReply, the initial value of `args->limit` is `100 * server.stream_node_max_entries`, which may lead to out of bounds, and then the default function of limit in xadd becomes invalid (this failure occurs in streamTrim).

Additionally, provide sane default for `args->limit` in case `stream_node_max_entries` is set to 0.

Of course, such a large value is generally not set, but this is a value that allows users to set and does cause problems.

And the comment looks wrong.

Maybe we need some notes to explain why the boundary is set to `LLONG_MAX/100` in the configuration initialization
