### PR TITLE
Use next_db++ make sure we can start from db0.

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -605,7 +605,7 @@ int performEvictions(void) {
              * each DB, so we use the static 'next_db' variable to
              * incrementally visit all DBs. */
             for (i = 0; i < server.dbnum; i++) {
-                j = (++next_db) % server.dbnum;
+                j = (next_db++) % server.dbnum;
                 db = server.db+j;
                 dict = (server.maxmemory_policy == MAXMEMORY_ALLKEYS_RANDOM) ?
                         db->dict : db->expires;


### PR DESCRIPTION
In old way, we use ++next_db in performEvictions,
so the db search will start with db1 at the first time,
and back to db0 at the end.

This commit will make sure we can start from db0.
It’s not actually a bug, it might be more uniform.