### PR TITLE
Cleanup typos, incorrect comments, and fixed small memory leak in redis-cli

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -520,7 +520,7 @@ dir ./
 #
 # 2) If replica-serve-stale-data is set to 'no' the replica will reply with error
 #    "MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'"
-#    to all data access commands, excusing commands such as :
+#    to all data access commands, excluding commands such as :
 #    INFO, REPLICAOF, AUTH, PING, SHUTDOWN, REPLCONF, ROLE, CONFIG, SUBSCRIBE,
 #    UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, PUBLISH, PUBSUB, COMMAND, POST,
 #    HOST and LATENCY.

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -137,7 +137,6 @@
 
 int rdbSaveType(rio *rdb, unsigned char type);
 int rdbLoadType(rio *rdb);
-int rdbSaveTime(rio *rdb, time_t t);
 time_t rdbLoadTime(rio *rdb);
 int rdbSaveLen(rio *rdb, uint64_t len);
 int rdbSaveMillisecondTime(rio *rdb, long long t);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -68,7 +68,7 @@
 #define MAX_THREADS 500
 #define CLUSTER_SLOTS 16384
 #define CONFIG_LATENCY_HISTOGRAM_MIN_VALUE 10L          /* >= 10 usecs */
-#define CONFIG_LATENCY_HISTOGRAM_MAX_VALUE 3000000L          /* <= 30 secs(us precision) */
+#define CONFIG_LATENCY_HISTOGRAM_MAX_VALUE 3000000L          /* <= 3 secs(us precision) */
 #define CONFIG_LATENCY_HISTOGRAM_INSTANT_MAX_VALUE 3000000L   /* <= 3 secs(us precision) */
 #define SHOW_THROUGHPUT_INTERVAL 250  /* 250ms */
 
@@ -1859,6 +1859,7 @@ int main(int argc, char **argv) {
         } while(config.loop);
         sdsfreesplitres(sds_args, argc);
 
+        sdsfree(title);
         if (config.redis_config != NULL) freeRedisConfig(config.redis_config);
         return 0;
     }

--- a/src/replication.c
+++ b/src/replication.c
@@ -2394,7 +2394,7 @@ void syncWithMaster(connection *conn) {
     if (server.repl_state == REPL_STATE_RECEIVE_IP_REPLY) {
         err = receiveSynchronousResponse(conn);
         /* Ignore the error if any, not all the Redis versions support
-         * REPLCONF listening-port. */
+         * REPLCONF ip-address. */
         if (err[0] == '-') {
             serverLog(LL_NOTICE,"(Non critical) Master does not understand "
                                 "REPLCONF ip-address: %s", err);

--- a/src/server.h
+++ b/src/server.h
@@ -2819,7 +2819,6 @@ void zrevrankCommand(client *c);
 void hsetCommand(client *c);
 void hsetnxCommand(client *c);
 void hgetCommand(client *c);
-void hmsetCommand(client *c);
 void hmgetCommand(client *c);
 void hdelCommand(client *c);
 void hlenCommand(client *c);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3097,7 +3097,7 @@ void zrangeCommand(client *c) {
     zrangeGenericCommand(&handler, 1, 0, ZRANGE_AUTO, ZRANGE_DIRECTION_AUTO);
 }
 
-/* ZREVRANGE <key> <min> <max> [WITHSCORES] */
+/* ZREVRANGE <key> <start> <stop> [WITHSCORES] */
 void zrevrangeCommand(client *c) {
     zrange_result_handler handler;
     zrangeResultHandlerInit(&handler, c, ZRANGE_CONSUMER_TYPE_CLIENT);
@@ -3225,7 +3225,7 @@ void zrangebyscoreCommand(client *c) {
     zrangeGenericCommand(&handler, 1, 0, ZRANGE_SCORE, ZRANGE_DIRECTION_FORWARD);
 }
 
-/* ZREVRANGEBYSCORE <key> <min> <max> [WITHSCORES] [LIMIT offset count] */
+/* ZREVRANGEBYSCORE <key> <max> <min> [WITHSCORES] [LIMIT offset count] */
 void zrevrangebyscoreCommand(client *c) {
     zrange_result_handler handler;
     zrangeResultHandlerInit(&handler, c, ZRANGE_CONSUMER_TYPE_CLIENT);
@@ -3506,7 +3506,7 @@ void zrangebylexCommand(client *c) {
     zrangeGenericCommand(&handler, 1, 0, ZRANGE_LEX, ZRANGE_DIRECTION_FORWARD);
 }
 
-/* ZREVRANGEBYLEX <key> <min> <max> [LIMIT offset count] */
+/* ZREVRANGEBYLEX <key> <max> <min> [LIMIT offset count] */
 void zrevrangebylexCommand(client *c) {
     zrange_result_handler handler;
     zrangeResultHandlerInit(&handler, c, ZRANGE_CONSUMER_TYPE_CLIENT);


### PR DESCRIPTION
  minor code cleanup

  1. Remove forward declarations from header files to functions that do not exist:
  hmsetCommand and rdbSaveTime.

  2. Minor phrasing fixes in #9519

  3. Add missing sdsfree(title) and fix typo in redis-benchmark.

  4. Modify some error comments in some zset commands.

  5. Fix copy-paste bug comment in syncWithMaster about `ip-address`.