### PR TITLE
Fix timing issue in psync2 test.

### DIFF
--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -125,7 +125,7 @@ start_server {} {
 
                 # Need to prepare that lookup.
                 set r_master_id $R_id_from_port($r_master_port)
-                set r $root_master($r_master_id)
+                set r $r_master_id
             }
         }
 

--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -109,6 +109,7 @@ start_server {} {
     while {([clock seconds]-$start_time) < $duration} {
         test "PSYNC2: --- CYCLE $cycle ---" {}
         incr cycle
+
         # Create a random replication layout.
         # Start with switching master (this simulates a failover).
 

--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -109,6 +109,19 @@ start_server {} {
     while {([clock seconds]-$start_time) < $duration} {
         test "PSYNC2: --- CYCLE $cycle ---" {}
         incr cycle
+        # Create a random replication layout.
+        # Start with switching master (this simulates a failover).
+
+        # 1) Select the new master.
+        set master_id [randomInt 5]
+        set used [list $master_id]
+        test "PSYNC2: \[NEW LAYOUT\] Set #$master_id as master" {
+            $R($master_id) slaveof no one
+            $R($master_id) config set repl-ping-replica-period 1 ;# increase the chance that random ping will cause issues
+            if {$counter_value == 0} {
+                $R($master_id) set x $counter_value
+            }
+        }
 
         # Build a lookup with the root master of each replica (head of the chain).
         array set root_master {}
@@ -126,20 +139,6 @@ start_server {} {
                 # Need to prepare that lookup.
                 set r_master_id $R_id_from_port($r_master_port)
                 set r $r_master_id
-            }
-        }
-
-        # Create a random replication layout.
-        # Start with switching master (this simulates a failover).
-
-        # 1) Select the new master.
-        set master_id [randomInt 5]
-        set used [list $master_id]
-        test "PSYNC2: \[NEW LAYOUT\] Set #$master_id as master" {
-            $R($master_id) slaveof no one
-            $R($master_id) config set repl-ping-replica-period 1 ;# increase the chance that random ping will cause issues
-            if {$counter_value == 0} {
-                $R($master_id) set x $counter_value
             }
         }
 

--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -145,6 +145,8 @@ start_server {} {
 
         # Wait for the newly detached master-replica chain (new master and existing replicas that were
         # already connected to it, to get updated on the new replication id.
+        # This is needed to avoid a race that can result in a full sync when a replica that already
+        # got an updated repl id, tries to psync from one that's not yet aware of it.
         wait_for_condition 50 1000 {
             ([status $R(0) master_replid] == [status $R($root_master(0)) master_replid]) &&
             ([status $R(1) master_replid] == [status $R($root_master(1)) master_replid]) &&

--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -143,7 +143,7 @@ start_server {} {
             }
         }
 
-        # For the newly detached master-replica chain (new master and existing replicas that were
+        # Wait for the newly detached master-replica chain (new master and existing replicas that were
         # already connected to it, to get updated on the new replication id.
         wait_for_condition 50 1000 {
             ([status $R(0) master_replid] == [status $R($root_master(0)) master_replid]) &&

--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -100,7 +100,7 @@ start_server {} {
         set R($j) [srv [expr 0-$j] client]
         set R_host($j) [srv [expr 0-$j] host]
         set R_port($j) [srv [expr 0-$j] port]
-        set R_id_from_port($R_port($j)) $j; # Find id according to port
+        set R_id_from_port($R_port($j)) $j ;# To get a replica index by port
         set R_log($j) [srv [expr 0-$j] stdout]
         if {$debug_msg} {puts "Log file: [srv [expr 0-$j] stdout]"}
     }
@@ -128,16 +128,12 @@ start_server {} {
         array set root_master {}
         for {set j 0} {$j < 5} {incr j} {
             set r $j
-
             while {1} {
                 set r_master_port [status $R($r) master_port]
-
                 if {$r_master_port == ""} {
                     set root_master($j) $r
                     break
                 }
-
-                # Need to prepare that lookup.
                 set r_master_id $R_id_from_port($r_master_port)
                 set r $r_master_id
             }
@@ -155,7 +151,7 @@ start_server {} {
             ([status $R(4) master_replid] == [status $R($root_master(4)) master_replid])
         } else {
             show_cluster_status
-            fail "Replica does not inherit the new replid."
+            fail "Replica did not inherit the new replid."
         }
 
         # 2) Attach all the slaves to a random instance

--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -119,7 +119,7 @@ start_server {} {
                 set r_master_port [status $R($r) master_port]
 
                 if {$r_master_port == ""} {
-                    set root_master($r) $r
+                    set root_master($j) $r
                     break
                 }
 


### PR DESCRIPTION
*** [err]: PSYNC2: total sum of full synchronizations is exactly 4 intests/integration/psync2.tcl
Expected 5 == 4 (context: type eval line 8 cmd {assert {$sum == 4}} proc::test)

Sometime the test got an unexpected full sync since a replica switch to master,
before the new master change propagated the new replid to all replicas,
a replica attempted to sync with it using a wrong replid and triggered a full resync.

Consider this scenario:
1 slaveof 4 full resync
0 slaveof 4 full resync
2 slaveof 0 full resync
3 slaveof 1 full resync

1 slaveof no one, replid changed
3 reconnect 1, did a partial resyn and got the new replid

Before 2 inherits the new replid.
3 slaveof 2
3 try to do a partial resyn with 2.
But their replication ids are inconsistent, so a full resync happens.

CI: https://github.com/redis/redis/runs/2779092193?check_suite_focus=true