### PR TITLE
Support RDMA as tranport layer protocol

### DIFF
--- a/RDMA.md
+++ b/RDMA.md
@@ -1,0 +1,113 @@
+RDMA Support
+============
+
+Getting Started
+---------------
+
+### Building
+
+To build with RDMA support you'll need RDMA development libraries (e.g.
+librdmacm-dev and libibverbs-dev on Debian/Ubuntu).
+
+Run `make BUILD_RDMA=yes`.
+
+### Running manually
+
+To manually run a Redis server with RDMA mode:
+
+    ./src/redis-server --rdma-port 6379  --bind 192.168.122.100 \
+        --protected-mode no
+
+To connect to this Redis server with `redis-cli`:
+
+    ./src/redis-cli -h 192.168.122.100 --rdma
+
+Note that the network card (192.168.122.100 of this example) should support
+RDMA. It's also possible to have both RDMA and TCP available, and there is no
+conflict of TCP(6379) and RDMA(6379), Ex:
+
+    ./src/redis-server --rdma-port 6379 --port 6379  --bind 192.168.122.100 \
+        --protected-mode no
+
+Connections
+-----------
+
+All socket operations now go through a connection abstraction layer that hides
+I/O and read/write event handling from the caller.
+
+Because RDMA is a message-oriented protocol, TCP is a stream-oriented protocol,
+to implement the stream-like operations(Ex, read/write) needs additional works
+in RDMA scenario.
+
+In redis, separate control-plane(to exchange control message) and data-plane(to
+transfer the real payload for redis).
+
+#### Protocol
+For control message, use a 32 bytes message which defines a structure:
+```
+typedef struct RedisRdmaCmd {
+    uint8_t magic;
+    uint8_t version;
+    uint8_t opcode;
+    uint8_t rsvd[13];
+    uint64_t addr;
+    uint32_t length;
+    uint32_t key;
+} RedisRdmaCmd;
+```
+
+magic: should be 'R'
+version: 1
+opcode: define as following enum RedisRdmaOpcode
+rsvd: reserved
+addr: local address of a buffer which is used to receive remote streaming data,
+      aka 'RX buffer address'
+length: length of the 'RX buffer'
+key: the RDMA remote key of 'RX buffer'
+
+
+```
+typedef enum RedisRdmaOpcode {
+    RegisterLocalAddr,
+} RedisRdmaOpcode;
+```
+
+RegisterLocalAddr: tell the 'RX buffer' information to the remote side, and the
+                  remote side uses this as 'TX buffer'
+
+
+The workflow of this protocol:
+```
+client                     server
+      ----RDMA connect---->
+                           handle connection, create RDMA resources
+      <---Establish RDMA---
+      <-Register RX buffer-
+setup TX buffer
+      -Register RX buffer->
+                           setup TX buffer
+      ---send commands---->
+      <--send response-----
+
+          .......
+
+RX buffer is full
+      -Register RX buffer->
+                           setup TX buffer
+      <-continue response--
+```
+
+
+#### Event handling
+There is no POLLOUT event of RDMA comp channel:
+   1, if TX is not full, it's always writable.
+   2, if TX is full, should wait a 'RegisterLocalAddr' message to refresh
+      'TX buffer'.
+   3, run a timer of a RDMA connection to kick write handler periodically
+
+To-Do List
+----------
+
+- [ ] rdma-cluster is to be implemented
+- [ ] POLLOUT event emulation for hiredis
+- [ ] auto-test suite is not implemented currently

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ libssl-dev on Debian/Ubuntu) and run:
 
     % make BUILD_TLS=yes
 
+To build with RDMA support(currently only supported on Linux), you'll need
+librdmacm&libibverbs development libraries (e.g. librdmacm-dev
+&libibverbs-dev on Debian/Ubuntu) and run:
+
+    % make BUILD_RDMA=yes
+
 To build with systemd support, you'll need systemd development libraries (such 
 as libsystemd-dev on Debian/Ubuntu or systemd-devel on CentOS) and run:
 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -46,6 +46,10 @@ ifeq ($(BUILD_TLS),yes)
     HIREDIS_MAKE_FLAGS = USE_SSL=1
 endif
 
+ifeq ($(BUILD_RDMA),yes)
+    HIREDIS_MAKE_FLAGS += USE_RDMA=yes
+endif
+
 hiredis: .make-prerequisites
 	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)
 	cd hiredis && $(MAKE) static $(HIREDIS_MAKE_FLAGS)

--- a/deps/hiredis/Makefile
+++ b/deps/hiredis/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2010-2011 Pieter Noordhuis <pcnoordhuis at gmail dot com>
 # This file is released under the BSD license, see the COPYING file
 
-OBJ=alloc.o net.o hiredis.o sds.o async.o read.o sockcompat.o
+OBJ=alloc.o net.o hiredis.o sds.o async.o read.o sockcompat.o rdma.o
 SSL_OBJ=ssl.o
 EXAMPLES=hiredis-example hiredis-example-libevent hiredis-example-libev hiredis-example-glib hiredis-example-push
 ifeq ($(USE_SSL),1)
@@ -78,6 +78,11 @@ endif
 
 ifeq ($(uname_S),Linux)
   SSL_LDFLAGS=-lssl -lcrypto
+  ifeq ($(BUILD_RDMA),yes)
+  EXAMPLES+=hiredis-example-rdma
+  CFLAGS+=-DUSE_RDMA
+  REAL_LDFLAGS+= -lrdmacm -libverbs
+  endif
 else
   OPENSSL_PREFIX?=/usr/local/opt/openssl
   CFLAGS+=-I$(OPENSSL_PREFIX)/include
@@ -118,6 +123,7 @@ read.o: read.c fmacros.h alloc.h read.h sds.h win32.h
 sds.o: sds.c sds.h sdsalloc.h alloc.h
 sockcompat.o: sockcompat.c sockcompat.h
 ssl.o: ssl.c hiredis.h read.h sds.h alloc.h async.h win32.h async_private.h
+rdma.o: rdma.c hiredis.h read.h sds.h alloc.h async.h async_private.h fmacros.h
 test.o: test.c fmacros.h hiredis.h read.h sds.h alloc.h net.h sockcompat.h win32.h
 
 $(DYLIBNAME): $(OBJ)

--- a/deps/hiredis/hiredis.c
+++ b/deps/hiredis/hiredis.c
@@ -43,6 +43,7 @@
 #include "sds.h"
 #include "async.h"
 #include "win32.h"
+#include "rdma.h"
 
 extern int redisContextUpdateConnectTimeout(redisContext *c, const struct timeval *timeout);
 extern int redisContextUpdateCommandTimeout(redisContext *c, const struct timeval *timeout);
@@ -713,7 +714,11 @@ static redisContext *redisContextInit(void) {
 void redisFree(redisContext *c) {
     if (c == NULL)
         return;
-    redisNetClose(c);
+
+    if (c->funcs->close) {
+        c->funcs->close(c);
+    } else
+        redisNetClose(c);
 
     hi_sdsfree(c->obuf);
     redisReaderFree(c->reader);
@@ -824,6 +829,11 @@ redisContext *redisConnectWithOptions(const redisOptions *options) {
     } else if (options->type == REDIS_CONN_USERFD) {
         c->fd = options->endpoint.fd;
         c->flags |= REDIS_CONNECTED;
+    } else if (options->type == REDIS_CONN_RDMA) {
+        if (redisContextConnectRdma(c, options->endpoint.tcp.ip, options->endpoint.tcp.port,
+                                    options->connect_timeout)) {
+            return c; /* error should be already saved in c */
+        }
     } else {
         // Unknown type - FIXME - FREE
         return NULL;
@@ -901,6 +911,19 @@ redisContext *redisConnectFd(redisFD fd) {
     redisOptions options = {0};
     options.type = REDIS_CONN_USERFD;
     options.endpoint.fd = fd;
+    return redisConnectWithOptions(&options);
+}
+
+redisContext *redisConnectRdma(const char *ip, int port) {
+    redisOptions options = {0};
+    REDIS_OPTIONS_SET_RDMA(&options, ip, port);
+    return redisConnectWithOptions(&options);
+}
+
+redisContext *redisConnectRdmaTimeout(const char *ip, int port, const struct timeval tv) {
+    redisOptions options = {0};
+    REDIS_OPTIONS_SET_RDMA(&options, ip, port);
+    options.connect_timeout = &tv;
     return redisConnectWithOptions(&options);
 }
 

--- a/deps/hiredis/rdma.c
+++ b/deps/hiredis/rdma.c
@@ -1,0 +1,950 @@
+/* ==========================================================================
+ * rdma.c - support RDMA protocol for transport layer.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2021  zhenwei pi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ==========================================================================
+ */
+
+#include "fmacros.h"
+
+#include "async.h"
+#include "async_private.h"
+#include "hiredis.h"
+#include "rdma.h"
+#include <errno.h>
+
+#define UNUSED(x) (void)(x)
+
+void __redisSetError(redisContext *c, int type, const char *str);
+
+#ifdef USE_RDMA
+#ifdef __linux__    /* currently RDMA is only supported on Linux */
+#define __USE_MISC
+#include <arpa/inet.h>
+#include <assert.h>
+#include <endian.h>
+#include <limits.h>
+#include <netdb.h>
+#include <poll.h>
+#include <rdma/rdma_cma.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+
+typedef enum RedisRdmaOpcode {
+    RegisterLocalAddr,
+} RedisRdmaOpcode;
+
+typedef struct RedisRdmaCmd {
+    uint8_t magic;
+    uint8_t version;
+    uint8_t opcode;
+    uint8_t rsvd[13];
+    uint64_t addr;
+    uint32_t length;
+    uint32_t key;
+} RedisRdmaCmd;
+
+#define MIN(a, b) (a) < (b) ? a : b
+#define REDIS_MAX_SGE 1024
+#define REDIS_RDMA_DEFAULT_RX_LEN  (1024*1024)
+#define REDID_RDMA_CMD_MAGIC 'R'
+
+typedef struct RdmaContext {
+    struct rdma_cm_id *cm_id;
+    struct rdma_event_channel *cm_channel;
+    struct ibv_comp_channel *comp_channel;
+    struct ibv_cq *cq;
+    struct ibv_pd *pd;
+
+    /* TX */
+    char *tx_addr;
+    uint32_t tx_length;
+    uint32_t tx_offset;
+    uint32_t tx_key;
+    char *send_buf;
+    uint32_t send_length;
+    uint32_t send_ops;
+    struct ibv_mr *send_mr;
+
+    /* RX */
+    uint32_t rx_offset;
+    char *recv_buf;
+    unsigned int recv_length;
+    unsigned int recv_offset;
+    struct ibv_mr *recv_mr;
+
+    /* CMD 0 ~ REDIS_MAX_SGE for recv buffer
+     * REDIS_MAX_SGE ~ 2 * REDIS_MAX_SGE -1 for send buffer */
+    RedisRdmaCmd *cmd_buf;
+    struct ibv_mr *cmd_mr;
+} RdmaContext;
+
+int redisContextTimeoutMsec(redisContext *c, long *result);
+int redisContextUpdateConnectTimeout(redisContext *c, const struct timeval *timeout);
+int redisSetFdBlocking(redisContext *c, redisFD fd, int blocking);
+
+static inline long redisNowMs(void) {
+    struct timeval tv;
+
+    if (gettimeofday(&tv, NULL) < 0)
+            return -1;
+
+    return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+}
+
+
+static int rdmaPostRecv(RdmaContext *ctx, struct rdma_cm_id *cm_id, RedisRdmaCmd *cmd) {
+    struct ibv_sge sge;
+    size_t length = sizeof(RedisRdmaCmd);
+    struct ibv_recv_wr recv_wr, *bad_wr;
+
+
+    sge.addr = (uint64_t)cmd;
+    sge.length = length;
+    sge.lkey = ctx->cmd_mr->lkey;
+
+    recv_wr.wr_id = (uint64_t)cmd;
+    recv_wr.sg_list = &sge;
+    recv_wr.num_sge = 1;
+    recv_wr.next = NULL;
+
+    if (ibv_post_recv(cm_id->qp, &recv_wr, &bad_wr)) {
+        return REDIS_ERR;
+    }
+
+    return REDIS_OK;
+}
+
+static void rdmaDestroyIoBuf(RdmaContext *ctx)
+{
+    if (ctx->recv_mr) {
+        ibv_dereg_mr(ctx->recv_mr);
+        ctx->recv_mr = NULL;
+    }
+
+    hi_free(ctx->recv_buf);
+    ctx->recv_buf = NULL;
+
+    if (ctx->send_mr) {
+        ibv_dereg_mr(ctx->send_mr);
+        ctx->send_mr = NULL;
+    }
+
+    hi_free(ctx->send_buf);
+    ctx->send_buf = NULL;
+
+    if (ctx->cmd_mr) {
+        ibv_dereg_mr(ctx->cmd_mr);
+        ctx->cmd_mr = NULL;
+    }
+
+    hi_free(ctx->cmd_buf);
+    ctx->cmd_buf = NULL;
+}
+
+static int rdmaSetupIoBuf(redisContext *c, RdmaContext *ctx, struct rdma_cm_id *cm_id) {
+    int access = IBV_ACCESS_LOCAL_WRITE;
+    size_t length = sizeof(RedisRdmaCmd) * REDIS_MAX_SGE * 2;
+    RedisRdmaCmd *cmd;
+    int i;
+
+    /* setup CMD buf & MR */
+    ctx->cmd_buf = hi_calloc(length, 1);
+    ctx->cmd_mr = ibv_reg_mr(ctx->pd, ctx->cmd_buf, length, access);
+    if (!ctx->cmd_mr) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: reg recv mr failed");
+	goto destroy_iobuf;
+    }
+
+    for (i = 0; i < REDIS_MAX_SGE; i++) {
+        cmd = ctx->cmd_buf + i;
+
+        if (rdmaPostRecv(ctx, cm_id, cmd) == REDIS_ERR) {
+            __redisSetError(c, REDIS_ERR_OTHER, "RDMA: post recv failed");
+            goto destroy_iobuf;
+        }
+    }
+
+    /* setup recv buf & MR */
+    access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
+    length = REDIS_RDMA_DEFAULT_RX_LEN;
+    ctx->recv_buf = hi_calloc(length, 1);
+    ctx->recv_length = length;
+    ctx->recv_mr = ibv_reg_mr(ctx->pd, ctx->recv_buf, length, access);
+    if (!ctx->recv_mr) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: reg send mr failed");
+	goto destroy_iobuf;
+    }
+
+    return REDIS_OK;
+
+destroy_iobuf:
+    rdmaDestroyIoBuf(ctx);
+    return REDIS_ERR;
+}
+
+static int rdmaAdjustSendbuf(redisContext *c, RdmaContext *ctx, unsigned int length) {
+    int access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
+
+    if (length == ctx->send_length) {
+        return REDIS_OK;
+    }
+
+    /* try to free old MR & buffer */
+    if (ctx->send_length) {
+        ibv_dereg_mr(ctx->send_mr);
+        hi_free(ctx->send_buf);
+        ctx->send_length = 0;
+    }
+
+    /* create a new buffer & MR */
+    ctx->send_buf = hi_calloc(length, 1);
+    ctx->send_length = length;
+    ctx->send_mr = ibv_reg_mr(ctx->pd, ctx->send_buf, length, access);
+    if (!ctx->send_mr) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: reg send buf mr failed");
+        hi_free(ctx->send_buf);
+        ctx->send_buf = NULL;
+        ctx->send_length = 0;
+        return REDIS_ERR;
+    }
+
+    return REDIS_OK;
+}
+
+
+static int rdmaSendCommand(RdmaContext *ctx, struct rdma_cm_id *cm_id, RedisRdmaCmd *cmd) {
+    struct ibv_send_wr send_wr, *bad_wr;
+    struct ibv_sge sge;
+    RedisRdmaCmd *_cmd;
+    int i;
+    int ret;
+
+    /* find an unused cmd buffer */
+    for (i = REDIS_MAX_SGE; i < 2 * REDIS_MAX_SGE; i++) {
+        _cmd = ctx->cmd_buf + i;
+        if (!_cmd->magic) {
+            break;
+        }
+    }
+
+    assert(i < 2 * REDIS_MAX_SGE);
+
+    _cmd->addr = htobe64(cmd->addr);
+    _cmd->length = htonl(cmd->length);
+    _cmd->key = htonl(cmd->key);
+    _cmd->opcode = cmd->opcode;
+    _cmd->magic = REDID_RDMA_CMD_MAGIC;
+
+    sge.addr = (uint64_t)_cmd;
+    sge.length = sizeof(RedisRdmaCmd);
+    sge.lkey = ctx->cmd_mr->lkey;
+
+    send_wr.sg_list = &sge;
+    send_wr.num_sge = 1;
+    send_wr.wr_id = (uint64_t)_cmd;
+    send_wr.opcode = IBV_WR_SEND;
+    send_wr.send_flags = IBV_SEND_SIGNALED;
+    send_wr.next = NULL;
+    ret = ibv_post_send(cm_id->qp, &send_wr, &bad_wr);
+    if (ret) {
+        return REDIS_ERR;
+    }
+
+    return REDIS_OK;
+}
+
+static int connRdmaRegisterRx(RdmaContext *ctx, struct rdma_cm_id *cm_id) {
+    RedisRdmaCmd cmd;
+
+    cmd.addr = (uint64_t)ctx->recv_buf;
+    cmd.length = ctx->recv_length;
+    cmd.key = ctx->recv_mr->rkey;
+    cmd.opcode = RegisterLocalAddr;
+
+    ctx->rx_offset = 0;
+    ctx->recv_offset = 0;
+
+    return rdmaSendCommand(ctx, cm_id, &cmd);
+}
+
+static int connRdmaHandleRecv(redisContext *c, RdmaContext *ctx, struct rdma_cm_id *cm_id, RedisRdmaCmd *cmd, uint32_t byte_len) {
+    RedisRdmaCmd _cmd;
+
+    if (byte_len != sizeof(RedisRdmaCmd)) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: FATAL error, recv corrupted cmd");
+        return REDIS_ERR;
+    }
+
+    _cmd.addr = be64toh(cmd->addr);
+    _cmd.length = ntohl(cmd->length);
+    _cmd.key = ntohl(cmd->key);
+    _cmd.opcode = cmd->opcode;
+
+    switch (_cmd.opcode) {
+    case RegisterLocalAddr:
+        ctx->tx_addr = (char *)_cmd.addr;
+        ctx->tx_length = _cmd.length;
+        ctx->tx_key = _cmd.key;
+        ctx->tx_offset = 0;
+        rdmaAdjustSendbuf(c, ctx, ctx->tx_length);
+        break;
+
+    default:
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: FATAL error, unknown cmd");
+        return REDIS_ERR;
+    }
+
+    return rdmaPostRecv(ctx, cm_id, cmd);
+}
+
+static int connRdmaHandleRecvImm(RdmaContext *ctx, struct rdma_cm_id *cm_id, RedisRdmaCmd *cmd, uint32_t byte_len) {
+    assert(byte_len + ctx->rx_offset <= ctx->recv_length);
+    ctx->rx_offset += byte_len;
+
+    return rdmaPostRecv(ctx, cm_id, cmd);
+}
+
+static int connRdmaHandleSend(RedisRdmaCmd *cmd) {
+    /* mark this cmd has already sent */
+    cmd->magic = 0;
+
+    return REDIS_OK;
+}
+
+static int connRdmaHandleWrite(RdmaContext *ctx, uint32_t byte_len) {
+    UNUSED(ctx);
+    UNUSED(byte_len);
+
+    return REDIS_OK;
+}
+
+static int connRdmaHandleCq(redisContext *c) {
+    RdmaContext *ctx = (RdmaContext *)c->privctx;
+    struct rdma_cm_id *cm_id = ctx->cm_id;
+    struct ibv_cq *ev_cq = NULL;
+    void *ev_ctx = NULL;
+    struct ibv_wc wc = {0};
+    RedisRdmaCmd *cmd;
+    int ret;
+
+    if (ibv_get_cq_event(ctx->comp_channel, &ev_cq, &ev_ctx) < 0) {
+        if (errno != EAGAIN) {
+            __redisSetError(c, REDIS_ERR_OTHER, "RDMA: get cq event failed");
+            return REDIS_ERR;
+        }
+    } else if (ibv_req_notify_cq(ev_cq, 0)) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: notify cq failed");
+        return REDIS_ERR;
+    }
+
+pollcq:
+    ret = ibv_poll_cq(ctx->cq, 1, &wc);
+    if (ret < 0) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: poll cq failed");
+        return REDIS_ERR;
+    } else if (ret == 0) {
+        return REDIS_OK;
+    }
+
+    ibv_ack_cq_events(ctx->cq, 1);
+
+    if (wc.status != IBV_WC_SUCCESS) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: send/recv failed");
+        return REDIS_ERR;
+    }
+
+    switch (wc.opcode) {
+    case IBV_WC_RECV:
+        cmd = (RedisRdmaCmd *)wc.wr_id;
+        if (connRdmaHandleRecv(c, ctx, cm_id, cmd, wc.byte_len) == REDIS_ERR) {
+            return REDIS_ERR;
+        }
+
+        break;
+
+    case IBV_WC_RECV_RDMA_WITH_IMM:
+        cmd = (RedisRdmaCmd *)wc.wr_id;
+        if (connRdmaHandleRecvImm(ctx, cm_id, cmd, wc.byte_len) == REDIS_ERR) {
+            return REDIS_ERR;
+        }
+
+        break;
+    case IBV_WC_RDMA_WRITE:
+        if (connRdmaHandleWrite(ctx, wc.byte_len) == REDIS_ERR) {
+            return REDIS_ERR;
+        }
+
+        break;
+    case IBV_WC_SEND:
+        cmd = (RedisRdmaCmd *)wc.wr_id;
+        if (connRdmaHandleSend(cmd) == REDIS_ERR) {
+            return REDIS_ERR;
+        }
+
+        break;
+    default:
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: unexpected opcode");
+        return REDIS_ERR;
+    }
+
+    goto pollcq;
+
+    return REDIS_OK;
+}
+
+#define __MAX_MSEC (((LONG_MAX) - 999) / 1000)
+
+static int redisCommandTimeoutMsec(redisContext *c, long *result)
+{
+    const struct timeval *timeout = c->command_timeout;
+    long msec = INT_MAX;
+
+    /* Only use timeout when not NULL. */
+    if (timeout != NULL) {
+        if (timeout->tv_usec > 1000000 || timeout->tv_sec > __MAX_MSEC) {
+            *result = msec;
+            return REDIS_ERR;
+        }
+
+        msec = (timeout->tv_sec * 1000) + ((timeout->tv_usec + 999) / 1000);
+
+        if (msec < 0 || msec > INT_MAX) {
+            msec = INT_MAX;
+        }
+    }
+
+    *result = msec;
+    return REDIS_OK;
+}
+
+static ssize_t redisRdmaRead(redisContext *c, char *buf, size_t bufcap) {
+    RdmaContext *ctx = (RdmaContext *)c->privctx;
+    struct rdma_cm_id *cm_id = ctx->cm_id;
+    struct pollfd pfd;
+    long timed = -1;
+    long start = redisNowMs();
+    uint32_t toread, remained;
+
+    if (redisCommandTimeoutMsec(c, &timed)) {
+        return REDIS_ERR;
+    }
+
+copy:
+    if (ctx->recv_offset < ctx->rx_offset) {
+        remained = ctx->rx_offset - ctx->recv_offset;
+        toread = MIN(remained, bufcap);
+
+        memcpy(buf, ctx->recv_buf + ctx->recv_offset, toread);
+        ctx->recv_offset += toread;
+
+        if (ctx->recv_offset == ctx->recv_length) {
+            connRdmaRegisterRx(ctx, cm_id);
+        }
+
+        return toread;
+    }
+
+pollcq:
+    /* try to poll a CQ firstly */
+    if (connRdmaHandleCq(c) == REDIS_ERR) {
+        return REDIS_ERR;
+    }
+
+    if (ctx->recv_offset < ctx->rx_offset) {
+        goto copy;
+    }
+
+    pfd.fd = ctx->comp_channel->fd;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    if (poll(&pfd, 1, 1000) < 0) {
+        return REDIS_ERR;
+    }
+
+    if ((redisNowMs() - start) < timed) {
+        goto pollcq;
+    }
+
+    __redisSetError(c, REDIS_ERR_TIMEOUT, "RDMA: read timeout");
+    return REDIS_ERR;
+}
+
+
+static size_t connRdmaSend(RdmaContext *ctx, struct rdma_cm_id *cm_id, const void *data, size_t data_len) {
+    struct ibv_send_wr send_wr, *bad_wr;
+    struct ibv_sge sge;
+    uint32_t off = ctx->tx_offset;
+    char *addr = ctx->send_buf + off;
+    char *remote_addr = ctx->tx_addr + off;
+    int ret;
+
+    assert(data_len <= ctx->tx_length);
+    memcpy(addr, data, data_len);
+
+    sge.addr = (uint64_t)addr;
+    sge.lkey = ctx->send_mr->lkey;
+    sge.length = data_len;
+
+    send_wr.sg_list = &sge;
+    send_wr.num_sge = 1;
+    send_wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+    send_wr.send_flags = (++ctx->send_ops % REDIS_MAX_SGE) ? 0 : IBV_SEND_SIGNALED;
+    send_wr.imm_data = htonl(0);
+    send_wr.wr.rdma.remote_addr = (uint64_t)remote_addr;
+    send_wr.wr.rdma.rkey = ctx->tx_key;
+    send_wr.next = NULL;
+    ret = ibv_post_send(cm_id->qp, &send_wr, &bad_wr);
+    if (ret) {
+        return REDIS_ERR;
+    }
+
+    ctx->tx_offset += data_len;
+
+    return data_len;
+}
+
+static ssize_t redisRdmaWrite(redisContext *c) {
+    RdmaContext *ctx = (RdmaContext *)c->privctx;
+    struct rdma_cm_id *cm_id = ctx->cm_id;
+    size_t data_len = hi_sdslen(c->obuf);
+    struct pollfd pfd;
+    long timed = -1;
+    long start = redisNowMs();
+    uint32_t towrite, wrote = 0;
+    size_t ret;
+
+    if (redisCommandTimeoutMsec(c, &timed)) {
+        return REDIS_ERR;
+    }
+
+    /* try to pollcq to */
+    goto pollcq;
+
+waitcq:
+    pfd.fd = ctx->comp_channel->fd;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    if (poll(&pfd, 1, 1) < 0) {
+        return REDIS_ERR;
+    }
+
+pollcq:
+    if (connRdmaHandleCq(c) == REDIS_ERR) {
+        return REDIS_ERR;
+    }
+
+    assert(ctx->tx_offset <= ctx->tx_length);
+    if (ctx->tx_offset == ctx->tx_length) {
+        /* wait a new TX buffer */
+	goto waitcq;
+    }
+
+    towrite = MIN(ctx->tx_length - ctx->tx_offset, data_len - wrote);
+    ret = connRdmaSend(ctx, cm_id, c->obuf + wrote, towrite);
+    if (ret == (size_t)REDIS_ERR) {
+        return REDIS_ERR;
+    }
+
+    wrote += ret;
+    if (wrote == data_len) {
+        return data_len;
+    }
+
+    if ((redisNowMs() - start) < timed) {
+        goto waitcq;
+    }
+
+    __redisSetError(c, REDIS_ERR_TIMEOUT, "RDMA: write timeout");
+
+    return REDIS_ERR;
+}
+
+/* RDMA has no POLLOUT event supported, so it could't work well with hiredis async mechanism */
+void redisRdmaAsyncRead(redisAsyncContext *ac) {
+    UNUSED(ac);
+    assert("hiredis async mechanism can't work with RDMA" == NULL);
+}
+
+void redisRdmaAsyncWrite(redisAsyncContext *ac) {
+    UNUSED(ac);
+    assert("hiredis async mechanism can't work with RDMA" == NULL);
+}
+
+static void redisRdmaClose(redisContext *c) {
+    RdmaContext *ctx = (RdmaContext *)c->privctx;
+    struct rdma_cm_id *cm_id = ctx->cm_id;
+
+    connRdmaHandleCq(c);
+    rdma_disconnect(cm_id);
+    ibv_destroy_cq(ctx->cq);
+    rdmaDestroyIoBuf(ctx);
+    ibv_destroy_qp(cm_id->qp);
+    ibv_destroy_comp_channel(ctx->comp_channel);
+    ibv_dealloc_pd(ctx->pd);
+    rdma_destroy_id(cm_id);
+
+    rdma_destroy_event_channel(ctx->cm_channel);
+}
+
+static void redisRdmaFree(void *privctx) {
+    if (!privctx)
+        return;
+
+    hi_free(privctx);
+}
+
+redisContextFuncs redisContextRdmaFuncs = {
+    .close = redisRdmaClose,
+    .free_privctx = redisRdmaFree,
+    .async_read = redisRdmaAsyncRead,
+    .async_write = redisRdmaAsyncWrite,
+    .read = redisRdmaRead,
+    .write = redisRdmaWrite,
+};
+
+
+static int redisRdmaConnect(redisContext *c, struct rdma_cm_id *cm_id) {
+    RdmaContext *ctx = (RdmaContext *)c->privctx;
+    struct ibv_comp_channel *comp_channel = NULL;
+    struct ibv_cq *cq = NULL;
+    struct ibv_pd *pd = NULL;
+    struct ibv_qp_init_attr init_attr = {0};
+    struct rdma_conn_param conn_param = {0};
+
+    pd = ibv_alloc_pd(cm_id->verbs);
+    if (!pd) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: alloc pd failed");
+        goto error;
+    }
+
+    comp_channel = ibv_create_comp_channel(cm_id->verbs);
+    if (!comp_channel) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: alloc pd failed");
+        goto error;
+    }
+
+    if (redisSetFdBlocking(c, comp_channel->fd, 0) != REDIS_OK) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: set recv comp channel fd non-block failed");
+        goto error;
+    }
+
+    cq = ibv_create_cq(cm_id->verbs, REDIS_MAX_SGE * 2, ctx, comp_channel, 0);
+    if (!cq) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: create send cq failed");
+        goto error;
+    }
+
+    if (ibv_req_notify_cq(cq, 0)) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: notify send cq failed");
+        goto error;
+    }
+
+    /* create qp with attr */
+    init_attr.cap.max_send_wr = REDIS_MAX_SGE;
+    init_attr.cap.max_recv_wr = REDIS_MAX_SGE; 
+    init_attr.cap.max_send_sge = 1; 
+    init_attr.cap.max_recv_sge = 1; 
+    init_attr.qp_type = IBV_QPT_RC;
+    init_attr.send_cq = cq;
+    init_attr.recv_cq = cq;
+    if (rdma_create_qp(cm_id, pd, &init_attr)) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: create qp failed");
+        goto error;
+    }
+
+    ctx->cm_id = cm_id;
+    ctx->comp_channel = comp_channel;
+    ctx->cq = cq;
+    ctx->pd = pd;
+
+    if (rdmaSetupIoBuf(c, ctx, cm_id) != REDIS_OK)
+        goto free_qp;
+
+    /* rdma connect with param */
+    conn_param.responder_resources = 1;
+    conn_param.initiator_depth = 1;
+    conn_param.retry_count = 7;
+    conn_param.rnr_retry_count = 7;
+    if (rdma_connect(cm_id, &conn_param)) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: connect failed");
+        goto destroy_iobuf;
+    }
+
+    return REDIS_OK;
+
+destroy_iobuf:
+    rdmaDestroyIoBuf(ctx);
+free_qp:
+    ibv_destroy_qp(cm_id->qp);
+error:
+    if (cq)
+        ibv_destroy_cq(cq);
+    if (pd)
+        ibv_dealloc_pd(pd);
+    if (comp_channel)
+        ibv_destroy_comp_channel(comp_channel);
+
+    return REDIS_ERR;
+}
+
+static int redisRdmaEstablished(redisContext *c, struct rdma_cm_id *cm_id) {
+    RdmaContext *ctx = (RdmaContext *)c->privctx;
+
+    /* it's time to tell redis we have already connected */
+    c->flags |= REDIS_CONNECTED;
+    c->funcs = &redisContextRdmaFuncs;
+    c->fd = ctx->comp_channel->fd;
+
+    return connRdmaRegisterRx(ctx, cm_id);
+}
+
+static int redisRdmaCM(redisContext *c, int timeout) {
+    RdmaContext *ctx = (RdmaContext *)c->privctx;
+    struct rdma_cm_event *event;
+    char errorstr[128];
+    int ret = REDIS_ERR;
+
+    while (rdma_get_cm_event(ctx->cm_channel, &event) == 0) {
+        switch (event->event) {
+        case RDMA_CM_EVENT_ADDR_RESOLVED:
+            if (timeout < 0 || timeout > 100)
+                timeout = 100; /* at most 100ms to resolve route */
+            ret = rdma_resolve_route(event->id, timeout);
+            if (ret) {
+                __redisSetError(c, REDIS_ERR_OTHER, "RDMA: route resolve failed");
+            }
+            break;
+        case RDMA_CM_EVENT_ROUTE_RESOLVED:
+            ret = redisRdmaConnect(c, event->id);
+            break;
+        case RDMA_CM_EVENT_ESTABLISHED:
+            ret = redisRdmaEstablished(c, event->id);
+            break;
+        case RDMA_CM_EVENT_TIMEWAIT_EXIT:
+            ret = REDIS_ERR;
+            __redisSetError(c, REDIS_ERR_TIMEOUT, "RDMA: connect timeout");
+            break;
+        case RDMA_CM_EVENT_ADDR_ERROR:
+        case RDMA_CM_EVENT_ROUTE_ERROR:
+        case RDMA_CM_EVENT_CONNECT_ERROR:
+        case RDMA_CM_EVENT_UNREACHABLE:
+        case RDMA_CM_EVENT_REJECTED:
+        case RDMA_CM_EVENT_DISCONNECTED:
+        case RDMA_CM_EVENT_ADDR_CHANGE:
+        default:
+            snprintf(errorstr, sizeof(errorstr), "RDMA: connect failed - %s", rdma_event_str(event->event));
+            __redisSetError(c, REDIS_ERR_OTHER, errorstr);
+            ret = REDIS_ERR;
+            break;
+        }
+
+        rdma_ack_cm_event(event);
+    }
+
+    return ret;
+}
+
+static int redisRdmaWaitConn(redisContext *c, long timeout) {
+    int timed;
+    struct pollfd pfd;
+    long now = redisNowMs();
+    long start = now;
+    RdmaContext *ctx = (RdmaContext *)c->privctx;
+
+    while (now - start < timeout) {
+        timed = (int)(timeout - (now - start));
+
+        pfd.fd = ctx->cm_channel->fd;
+        pfd.events = POLLIN;
+        pfd.revents = 0;
+        if (poll(&pfd, 1, timed) < 0) {
+            return REDIS_ERR;
+        }
+
+        if (redisRdmaCM(c, timed) == REDIS_ERR) {
+            return REDIS_ERR;
+        }
+
+        if (c->flags & REDIS_CONNECTED) {
+            return REDIS_OK;
+        }
+
+        now = redisNowMs();
+    }
+
+    return REDIS_ERR;
+}
+
+int redisContextConnectRdma(redisContext *c, const char *addr, int port,
+                            const struct timeval *timeout) {
+    int ret;
+    char _port[6];  /* strlen("65535"); */
+    struct addrinfo hints, *servinfo, *p;
+    long timeout_msec = -1;
+    struct rdma_event_channel *cm_channel = NULL;
+    struct rdma_cm_id *cm_id = NULL;
+    RdmaContext *ctx = NULL;
+    struct sockaddr_storage saddr;
+    long start = redisNowMs(), timed;
+
+    servinfo = NULL;
+    c->connection_type = REDIS_CONN_RDMA;
+    c->tcp.port = port;
+
+    if (c->tcp.host != addr) {
+        hi_free(c->tcp.host);
+
+        c->tcp.host = hi_strdup(addr);
+        if (c->tcp.host == NULL) {
+            __redisSetError(c, REDIS_ERR_OOM, "RDMA: Out of memory");
+            return REDIS_ERR;
+        }
+    }
+
+    if (timeout) {
+        if (redisContextUpdateConnectTimeout(c, timeout) == REDIS_ERR) {
+            __redisSetError(c, REDIS_ERR_OOM, "RDMA: Out of memory");
+            return REDIS_ERR;
+        }
+    } else {
+        hi_free(c->connect_timeout);
+        c->connect_timeout = NULL;
+    }
+
+    if (redisContextTimeoutMsec(c, &timeout_msec) != REDIS_OK) {
+        __redisSetError(c, REDIS_ERR_IO, "RDMA: Invalid timeout specified");
+        return REDIS_ERR;
+    } else if (timeout_msec == -1) {
+        timeout_msec = INT_MAX;
+    }
+
+    snprintf(_port, 6, "%d", port);
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    if ((ret = getaddrinfo(c->tcp.host, _port, &hints, &servinfo)) != 0) {
+         hints.ai_family = AF_INET6;
+         if ((ret = getaddrinfo(addr, _port, &hints, &servinfo)) != 0) {
+            __redisSetError(c, REDIS_ERR_OTHER, gai_strerror(ret));
+            return REDIS_ERR;
+        }
+    }
+
+    ctx = hi_calloc(sizeof(RdmaContext), 1);
+    if (!ctx) {
+        __redisSetError(c, REDIS_ERR_OOM, "Out of memory");
+        goto error;
+    }
+
+    c->privctx = ctx;
+
+   cm_channel = rdma_create_event_channel();
+    if (!cm_channel) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: create event channel failed");
+        goto error;
+    }
+
+    ctx->cm_channel = cm_channel;
+
+    if (rdma_create_id(cm_channel, &cm_id, (void *)ctx, RDMA_PS_TCP)) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: create id failed");
+        return REDIS_ERR;
+    }
+    ctx->cm_id = cm_id;
+
+    if ((redisSetFdBlocking(c, cm_channel->fd, 0) != REDIS_OK)) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: set cm channel fd non-block failed");
+        goto free_rdma;
+    }
+
+    for (p = servinfo; p != NULL; p = p->ai_next) {
+        if (p->ai_family == PF_INET) {
+                memcpy(&saddr, p->ai_addr, sizeof(struct sockaddr_in));
+                ((struct sockaddr_in *)&saddr)->sin_port = htons(port);
+        } else if (p->ai_family == PF_INET6) {
+                memcpy(&saddr, p->ai_addr, sizeof(struct sockaddr_in6));
+                ((struct sockaddr_in6 *)&saddr)->sin6_port = htons(port);
+        } else {
+            __redisSetError(c, REDIS_ERR_PROTOCOL, "RDMA: unsupported family");
+            goto free_rdma;
+        }
+
+        /* resolve addr as most 100ms */
+        if (rdma_resolve_addr(cm_id, NULL, (struct sockaddr *)&saddr, 100)) {
+            continue;
+        }
+
+        timed = timeout_msec - (redisNowMs() - start);
+        if ((redisRdmaWaitConn(c, timed) == REDIS_OK) && (c->flags & REDIS_CONNECTED)) {
+            ret = REDIS_OK;
+            goto end;
+        }
+    }
+
+    if ((!c->err) && (p == NULL)) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: resolve failed");
+    }
+
+free_rdma:
+    if (cm_id) {
+        rdma_destroy_id(cm_id);
+    }
+    if (cm_channel) {
+        rdma_destroy_event_channel(cm_channel);
+    }
+
+error:
+    ret = REDIS_ERR;
+    if (ctx) {
+        hi_free(ctx);
+    }
+
+end:
+    if(servinfo) {
+        freeaddrinfo(servinfo);
+    }
+
+    return ret;
+}
+
+#else    /* __linux__ */
+
+"BUILD ERROR: RDMA is only supported on linux"
+
+#endif   /* __linux__ */
+#else    /* USE_RDMA */
+
+int redisContextConnectRdma(redisContext *c, const char *addr, int port,
+                            const struct timeval *timeout) {
+    UNUSED(c);
+    UNUSED(addr);
+    UNUSED(port);
+    UNUSED(timeout);
+    __redisSetError(c, REDIS_ERR_PROTOCOL, "RDMA: disabled, please rebuild with BUILD_RDMA");
+    return -EPROTONOSUPPORT;
+}
+
+#endif

--- a/deps/hiredis/rdma.h
+++ b/deps/hiredis/rdma.h
@@ -1,0 +1,39 @@
+/* Extracted from anet.c to work properly with Hiredis error reporting.
+ *
+ * Copyright (c) 2021 zhenwei pi
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __RDMA_H
+#define __RDMA_H
+
+#include "hiredis.h"
+
+int redisContextConnectRdma(redisContext *c, const char *addr, int port, const struct timeval *timeout);
+
+#endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -252,6 +252,17 @@ endif
 	FINAL_LIBS += ../deps/hiredis/libhiredis_ssl.a $(LIBSSL_LIBS) $(LIBCRYPTO_LIBS)
 endif
 
+ifeq ($(BUILD_RDMA),yes)
+	FINAL_CFLAGS+=-DUSE_RDMA
+	RDMA_PKGCONFIG := $(shell $(PKG_CONFIG) --exists librdmacm libibverbs && echo $$?)
+ifeq ($(RDMA_PKGCONFIG),0)
+	RDMA_LIBS=$(shell $(PKG_CONFIG) --libs librdmacm libibverbs)
+else
+	RDMA_LIBS=-lrdmacm -libverbs
+endif
+	FINAL_LIBS += $(RDMA_LIBS)
+endif
+
 ifndef V
     define MAKE_INSTALL
         @printf '    %b %b\n' $(LINKCOLOR)INSTALL$(ENDCOLOR) $(BINCOLOR)$(1)$(ENDCOLOR) 1>&2
@@ -282,7 +293,7 @@ endif
 
 REDIS_SERVER_NAME=redis-server$(PROG_SUFFIX)
 REDIS_SENTINEL_NAME=redis-sentinel$(PROG_SUFFIX)
-REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crcspeed.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o redis-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o tracking.o connection.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o
+REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crcspeed.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o redis-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o tracking.o connection.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o rdma.o
 REDIS_CLI_NAME=redis-cli$(PROG_SUFFIX)
 REDIS_CLI_OBJ=anet.o adlist.o dict.o redis-cli.o zmalloc.o release.o ae.o redisassert.o crcspeed.o crc64.o siphash.o crc16.o monotonic.o cli_common.o mt19937-64.o
 REDIS_BENCHMARK_NAME=redis-benchmark$(PROG_SUFFIX)
@@ -310,6 +321,9 @@ persist-settings: distclean
 	echo OPT=$(OPT) >> .make-settings
 	echo MALLOC=$(MALLOC) >> .make-settings
 	echo BUILD_TLS=$(BUILD_TLS) >> .make-settings
+	echo BUILD_RDMA=$(BUILD_RDMA) >> .make-settings
+	echo RDMA_PKGCONFIG=$(RDMA_PKGCONFIG) >> .make-settings
+	echo RDMA_LIBS=$(RDMA_LIBS) >> .make-settings
 	echo USE_SYSTEMD=$(USE_SYSTEMD) >> .make-settings
 	echo CFLAGS=$(CFLAGS) >> .make-settings
 	echo LDFLAGS=$(LDFLAGS) >> .make-settings

--- a/src/anet.h
+++ b/src/anet.h
@@ -61,6 +61,7 @@ int anetTcp6Server(char *err, int port, char *bindaddr, int backlog);
 int anetUnixServer(char *err, char *path, mode_t perm, int backlog);
 int anetTcpAccept(char *err, int serversock, char *ip, size_t ip_len, int *port);
 int anetUnixAccept(char *err, int serversock);
+int rdmaAccept(char *err, int serversock, char *ip, size_t ip_len, int *port, void **priv);
 int anetNonBlock(char *err, int fd);
 int anetBlock(char *err, int fd);
 int anetCloexec(int fd);

--- a/src/config.c
+++ b/src/config.c
@@ -2646,6 +2646,10 @@ standardConfig configs[] = {
     createStringConfig("tls-ciphers", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ciphers, NULL, NULL, updateTlsCfg),
     createStringConfig("tls-ciphersuites", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ciphersuites, NULL, NULL, updateTlsCfg),
 #endif
+#ifdef USE_RDMA
+    createIntConfig("rdma-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.rdma_port, 0, INTEGER_CONFIG, NULL, NULL), /* RDMA port. */
+    createBoolConfig("rdma-replication", NULL, MODIFIABLE_CONFIG, server.rdma_replication, 0, NULL, NULL),
+#endif
 
     /* NULL Terminator */
     {NULL}

--- a/src/connection.h
+++ b/src/connection.h
@@ -50,6 +50,7 @@ typedef enum {
 
 #define CONN_TYPE_SOCKET            1
 #define CONN_TYPE_TLS               2
+#define CONN_TYPE_RDMA              3
 
 typedef void (*ConnectionCallbackFunc)(struct connection *conn);
 
@@ -208,6 +209,9 @@ connection *connCreateAcceptedSocket(int fd);
 
 connection *connCreateTLS();
 connection *connCreateAcceptedTLS(int fd, int require_auth);
+
+connection *connCreateRdma();
+connection *connCreateAcceptedRdma(int fd, void *priv);
 
 void connSetPrivateData(connection *conn, void *data);
 void *connGetPrivateData(connection *conn);

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -1,0 +1,1483 @@
+/* ==========================================================================
+ * rdma.c - support RDMA protocol for transport layer.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2021  zhenwei pi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ==========================================================================
+ */
+
+#include "server.h"
+#include "connection.h"
+#include "connhelpers.h"
+
+static void serverNetError(char *err, const char *fmt, ...) {
+    va_list ap;
+
+    if (!err) return;
+    va_start(ap, fmt);
+    vsnprintf(err, ANET_ERR_LEN, fmt, ap);
+    va_end(ap);
+}
+
+#ifdef USE_RDMA
+#ifdef __linux__    /* currently RDMA is only supported on Linux */
+#include <assert.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <rdma/rdma_cma.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+
+typedef enum RedisRdmaOpcode {
+    RegisterLocalAddr,
+} RedisRdmaOpcode;
+
+typedef struct RedisRdmaCmd {
+    uint8_t magic;
+    uint8_t version;
+    uint8_t opcode;
+    uint8_t rsvd[13];
+    uint64_t addr;
+    uint32_t length;
+    uint32_t key;
+} RedisRdmaCmd;
+
+#define MIN(a, b) (a) < (b) ? a : b
+#define REDIS_MAX_SGE 1024
+#define REDIS_RDMA_DEFAULT_RX_LEN  (1024*1024)
+#define REDID_RDMA_CMD_MAGIC 'R'
+#define REDIS_SYNCIO_RES 10
+
+typedef struct rdma_connection {
+    connection c;
+    struct rdma_cm_id *cm_id;
+    int last_errno;
+} rdma_connection;
+
+typedef struct RdmaContext {
+    connection *conn;
+    char *ip;
+    int port;
+    struct ibv_pd *pd;
+    struct rdma_event_channel *cm_channel;
+    struct ibv_comp_channel *comp_channel;
+    struct ibv_cq *cq;
+    long long timeEvent;
+
+    /* TX */
+    char *tx_addr;
+    uint32_t tx_length;
+    uint32_t tx_offset;
+    uint32_t tx_key;
+    char *send_buf;
+    uint32_t send_length;
+    uint32_t send_offset;
+    uint32_t send_ops;
+    struct ibv_mr *send_mr;
+
+    /* RX */
+    uint32_t rx_offset;
+    char *recv_buf;
+    unsigned int recv_length;
+    unsigned int recv_offset;
+    struct ibv_mr *recv_mr;
+
+    /* CMD 0 ~ REDIS_MAX_SGE for recv buffer
+     * REDIS_MAX_SGE ~ 2 * REDIS_MAX_SGE -1 for send buffer */
+    RedisRdmaCmd *cmd_buf;
+    struct ibv_mr *cmd_mr;
+} RdmaContext;
+
+static struct rdma_event_channel *listen_channel;
+static struct rdma_cm_id *listen_cmids[CONFIG_BINDADDR_MAX];
+
+static int rdmaPostRecv(RdmaContext *ctx, struct rdma_cm_id *cm_id, RedisRdmaCmd *cmd) {
+    struct ibv_sge sge;
+    size_t length = sizeof(RedisRdmaCmd);
+    struct ibv_recv_wr recv_wr, *bad_wr;
+    int ret;
+
+    sge.addr = (uint64_t)cmd;
+    sge.length = length;
+    sge.lkey = ctx->cmd_mr->lkey;
+
+    recv_wr.wr_id = (uint64_t)cmd;
+    recv_wr.sg_list = &sge;
+    recv_wr.num_sge = 1;
+    recv_wr.next = NULL;
+
+    ret = ibv_post_recv(cm_id->qp, &recv_wr, &bad_wr);
+    if (ret && (ret != EAGAIN)) {
+        serverLog(LL_WARNING, "RDMA: post recv failed: %d", ret);
+        return C_ERR;
+    }
+
+    return C_OK;
+}
+
+static void rdmaDestroyIoBuf(RdmaContext *ctx)
+{
+    if (ctx->recv_mr) {
+        ibv_dereg_mr(ctx->recv_mr);
+        ctx->recv_mr = NULL;
+    }
+
+    zfree(ctx->recv_buf);
+    ctx->recv_buf = NULL;
+
+    if (ctx->send_mr) {
+        ibv_dereg_mr(ctx->send_mr);
+        ctx->send_mr = NULL;
+    }
+
+    zfree(ctx->send_buf);
+    ctx->send_buf = NULL;
+
+    if (ctx->cmd_mr) {
+        ibv_dereg_mr(ctx->cmd_mr);
+        ctx->cmd_mr = NULL;
+    }
+
+    zfree(ctx->cmd_buf);
+    ctx->cmd_buf = NULL;
+}
+
+static int rdmaSetupIoBuf(RdmaContext *ctx, struct rdma_cm_id *cm_id)
+{
+    int access = IBV_ACCESS_LOCAL_WRITE;
+    size_t length = sizeof(RedisRdmaCmd) * REDIS_MAX_SGE * 2;
+    RedisRdmaCmd *cmd;
+    int i;
+
+    /* setup CMD buf & MR */
+    ctx->cmd_buf = zcalloc(length);
+    ctx->cmd_mr = ibv_reg_mr(ctx->pd, ctx->cmd_buf, length, access);
+    if (!ctx->cmd_mr) {
+        serverLog(LL_WARNING, "RDMA: reg mr for CMD failed");
+	goto destroy_iobuf;
+    }
+
+    for (i = 0; i < REDIS_MAX_SGE; i++) {
+        cmd = ctx->cmd_buf + i;
+
+        if (rdmaPostRecv(ctx, cm_id, cmd) == C_ERR) {
+            serverLog(LL_WARNING, "RDMA: post recv failed");
+            goto destroy_iobuf;
+        }
+    }
+
+    /* setup recv buf & MR */
+    access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
+    length = REDIS_RDMA_DEFAULT_RX_LEN;
+    ctx->recv_buf = zcalloc(length);
+    ctx->recv_length = length;
+    ctx->recv_mr = ibv_reg_mr(ctx->pd, ctx->recv_buf, length, access);
+    if (!ctx->recv_mr) {
+        serverLog(LL_WARNING, "RDMA: reg mr for recv buffer failed");
+	goto destroy_iobuf;
+    }
+
+    return C_OK;
+
+destroy_iobuf:
+    rdmaDestroyIoBuf(ctx);
+    return C_ERR;
+}
+
+static int rdmaAdjustSendbuf(RdmaContext *ctx, unsigned int length) {
+    int access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
+
+    if (length == ctx->send_length) {
+        return C_OK;
+    }
+
+    /* try to free old MR & buffer */
+    if (ctx->send_length) {
+        ibv_dereg_mr(ctx->send_mr);
+        zfree(ctx->send_buf);
+        ctx->send_length = 0;
+    }
+
+    /* create a new buffer & MR */
+    ctx->send_buf = zcalloc(length);
+    ctx->send_length = length;
+    ctx->send_mr = ibv_reg_mr(ctx->pd, ctx->send_buf, length, access);
+    if (!ctx->send_mr) {
+        serverNetError(server.neterr, "RDMA: reg send mr failed");
+        serverLog(LL_WARNING, "RDMA: FATAL error, recv corrupted cmd");
+        zfree(ctx->send_buf);
+        ctx->send_buf = NULL;
+        ctx->send_length = 0;
+        return C_ERR;
+    }
+
+    return C_OK;
+}
+
+static int rdmaSendCommand(RdmaContext *ctx, struct rdma_cm_id *cm_id, RedisRdmaCmd *cmd) {
+    struct ibv_send_wr send_wr, *bad_wr;
+    struct ibv_sge sge;
+    RedisRdmaCmd *_cmd;
+    int i, ret;
+
+    /* find an unused cmd buffer */
+    for (i = REDIS_MAX_SGE; i < 2 * REDIS_MAX_SGE; i++) {
+        _cmd = ctx->cmd_buf + i;
+        if (!_cmd->magic) {
+            break;
+        }
+    }
+
+    assert(i < 2 * REDIS_MAX_SGE);
+
+    _cmd->addr = htonu64(cmd->addr);
+    _cmd->length = htonl(cmd->length);
+    _cmd->key = htonl(cmd->key);
+    _cmd->opcode = cmd->opcode;
+    _cmd->magic = REDID_RDMA_CMD_MAGIC;
+
+    sge.addr = (uint64_t)_cmd;
+    sge.length = sizeof(RedisRdmaCmd);
+    sge.lkey = ctx->cmd_mr->lkey;
+
+    send_wr.sg_list = &sge;
+    send_wr.num_sge = 1;
+    send_wr.wr_id = (uint64_t)_cmd;
+    send_wr.opcode = IBV_WR_SEND;
+    send_wr.send_flags = IBV_SEND_SIGNALED;
+    send_wr.next = NULL;
+    ret = ibv_post_send(cm_id->qp, &send_wr, &bad_wr);
+    if (ret) {
+        serverLog(LL_WARNING, "RDMA: post send failed: %d", ret);
+        return C_ERR;
+    }
+
+    return C_OK;
+}
+
+static int connRdmaRegisterRx(RdmaContext *ctx, struct rdma_cm_id *cm_id) {
+    RedisRdmaCmd cmd;
+
+    cmd.addr = (uint64_t)ctx->recv_buf;
+    cmd.length = ctx->recv_length;
+    cmd.key = ctx->recv_mr->rkey;
+    cmd.opcode = RegisterLocalAddr;
+
+    ctx->rx_offset = 0;
+    ctx->recv_offset = 0;
+
+    return rdmaSendCommand(ctx, cm_id, &cmd);
+}
+
+static int rdmaHandleEstablished(struct rdma_cm_event *ev)
+{
+    struct rdma_cm_id *cm_id = ev->id;
+    RdmaContext *ctx = cm_id->context;
+
+    connRdmaRegisterRx(ctx, cm_id);
+
+    return C_OK;
+}
+
+static int rdmaHandleDisconnect(struct rdma_cm_event *ev)
+{
+    struct rdma_cm_id *cm_id = ev->id;
+    RdmaContext *ctx = cm_id->context;
+    connection *conn = ctx->conn;
+
+    conn->state = CONN_STATE_CLOSED;
+
+    /* kick connection read/write handler to avoid resource leak */
+    if (conn->read_handler) {
+        callHandler(conn, conn->read_handler);
+    } else if (conn->write_handler) {
+        callHandler(conn, conn->write_handler);
+    }
+
+    return C_OK;
+}
+
+static int connRdmaHandleRecv(RdmaContext *ctx, struct rdma_cm_id *cm_id, RedisRdmaCmd *cmd, uint32_t byte_len) {
+    RedisRdmaCmd _cmd;
+
+    if (unlikely(byte_len != sizeof(RedisRdmaCmd))) {
+        serverLog(LL_WARNING, "RDMA: FATAL error, recv corrupted cmd");
+        return C_ERR;
+    }
+
+    _cmd.addr = ntohu64(cmd->addr);
+    _cmd.length = ntohl(cmd->length);
+    _cmd.key = ntohl(cmd->key);
+    _cmd.opcode = cmd->opcode;
+
+    switch (_cmd.opcode) {
+    case RegisterLocalAddr:
+        ctx->tx_addr = (char *)_cmd.addr;
+        ctx->tx_length = _cmd.length;
+        ctx->tx_key = _cmd.key;
+        ctx->tx_offset = 0;
+        rdmaAdjustSendbuf(ctx, ctx->tx_length);
+
+        break;
+
+    default:
+        serverLog(LL_WARNING, "RDMA: FATAL error, unknown cmd");
+        return C_ERR;
+    }
+
+    return rdmaPostRecv(ctx, cm_id, cmd);
+}
+
+static int connRdmaHandleSend(RedisRdmaCmd *cmd) {
+    /* mark this cmd has already sent */
+    cmd->magic = 0;
+
+    return C_OK;
+}
+
+static int connRdmaHandleRecvImm(RdmaContext *ctx, struct rdma_cm_id *cm_id, RedisRdmaCmd *cmd, uint32_t byte_len) {
+    assert(byte_len + ctx->rx_offset <= ctx->recv_length);
+
+    ctx->rx_offset += byte_len;
+
+    return rdmaPostRecv(ctx, cm_id, cmd);
+}
+
+static int connRdmaHandleWrite(RdmaContext *ctx, uint32_t byte_len) {
+    UNUSED(ctx);
+    UNUSED(byte_len);
+
+    return C_OK;
+}
+
+
+static int connRdmaHandleCq(rdma_connection *rdma_conn) {
+    struct rdma_cm_id *cm_id = rdma_conn->cm_id;
+    RdmaContext *ctx = cm_id->context;
+    struct ibv_cq *ev_cq = NULL;
+    void *ev_ctx = NULL;
+    struct ibv_wc wc = {0};
+    RedisRdmaCmd *cmd;
+    int ret;
+
+    if (ibv_get_cq_event(ctx->comp_channel, &ev_cq, &ev_ctx) < 0) {
+        if (errno != EAGAIN) {
+            serverLog(LL_WARNING, "RDMA: get CQ event error");
+            return C_ERR;
+        }
+    } else if (ibv_req_notify_cq(ev_cq, 0)) {
+        serverLog(LL_WARNING, "RDMA: notify CQ error");
+        return C_ERR;
+    }
+
+pollcq:
+    ret = ibv_poll_cq(ctx->cq, 1, &wc);
+    if (ret < 0) {
+        serverLog(LL_WARNING, "RDMA: poll recv CQ error");
+        return C_ERR;
+    } else if (ret == 0) {
+        return C_OK;
+    }
+
+    ibv_ack_cq_events(ctx->cq, 1);
+
+    if (wc.status != IBV_WC_SUCCESS) {
+        serverLog(LL_WARNING, "RDMA: CQ handle error status 0x%x", wc.status);
+        return C_ERR;
+    }
+
+    switch (wc.opcode) {
+    case IBV_WC_RECV:
+        cmd = (RedisRdmaCmd *)wc.wr_id;
+        if (connRdmaHandleRecv(ctx, cm_id, cmd, wc.byte_len) == C_ERR) {
+            return C_ERR;
+        }
+        break;
+
+    case IBV_WC_RECV_RDMA_WITH_IMM:
+        cmd = (RedisRdmaCmd *)wc.wr_id;
+        if (connRdmaHandleRecvImm(ctx, cm_id, cmd, wc.byte_len) == C_ERR) {
+            rdma_conn->c.state = CONN_STATE_ERROR;
+            return C_ERR;
+        }
+
+        break;
+    case IBV_WC_RDMA_WRITE:
+        if (connRdmaHandleWrite(ctx, wc.byte_len) == C_ERR) {
+            return C_ERR;
+        }
+
+        break;
+
+    case IBV_WC_SEND:
+        cmd = (RedisRdmaCmd *)wc.wr_id;
+        if (connRdmaHandleSend(cmd) == C_ERR) {
+            return C_ERR;
+        }
+
+        break;
+
+    default:
+        serverLog(LL_WARNING, "RDMA: unexpected opcode 0x[%x]", wc.opcode);
+        return C_ERR;
+    }
+
+    goto pollcq;
+}
+
+static int connRdmaAccept(connection *conn, ConnectionCallbackFunc accept_handler) {
+    int ret = C_OK;
+
+    if (conn->state != CONN_STATE_ACCEPTING)
+        return C_ERR;
+
+    conn->state = CONN_STATE_CONNECTED;
+
+    connIncrRefs(conn);
+    if (!callHandler(conn, accept_handler))
+        ret = C_ERR;
+    connDecrRefs(conn);
+
+    return ret;
+}
+
+static void connRdmaEventHandler(struct aeEventLoop *el, int fd, void *clientData, int mask) {
+    rdma_connection *rdma_conn = (rdma_connection *)clientData;
+    connection *conn = &rdma_conn->c;
+    struct rdma_cm_id *cm_id = rdma_conn->cm_id;
+    RdmaContext *ctx = cm_id->context;
+    int ret = 0;
+
+    UNUSED(el);
+    UNUSED(fd);
+    UNUSED(mask);
+
+    ret = connRdmaHandleCq(rdma_conn);
+    if (ret == C_ERR) {
+        conn->state = CONN_STATE_ERROR;
+        return;
+    }
+
+    /* uplayer should read all */
+    while (ctx->recv_offset < ctx->rx_offset) {
+        if (conn->read_handler && (callHandler(conn, conn->read_handler) == C_ERR)) {
+            return;
+        }
+    }
+
+    /* recv buf is full, register a new RX buffer */
+    if (ctx->recv_offset == ctx->recv_length) {
+        connRdmaRegisterRx(ctx, cm_id);
+    }
+
+    /* RDMA comp channel has no POLLOUT event, try to send remaining buffer */
+    if (conn->write_handler) {
+        callHandler(conn, conn->write_handler);
+    }
+}
+
+int connRdmaCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
+    connection *conn = (connection *)clientData;
+
+    UNUSED(eventLoop);
+    UNUSED(id);
+    if (conn->state != CONN_STATE_CONNECTED) {
+        return REDIS_SYNCIO_RES;
+    }
+
+    connRdmaEventHandler(NULL, -1, conn, 0);
+
+    return REDIS_SYNCIO_RES;
+}
+
+static int connRdmaSetRwHandler(connection *conn) {
+    rdma_connection *rdma_conn = (rdma_connection *)conn;
+    struct rdma_cm_id *cm_id = rdma_conn->cm_id;
+    RdmaContext *ctx = cm_id->context;
+
+    /* save conn into RdmaContext */
+    ctx->conn = conn;
+
+    /* IB channel only has POLLIN event */
+    if (conn->read_handler || conn->write_handler) {
+        if (aeCreateFileEvent(server.el, conn->fd, AE_READABLE, conn->type->ae_handler, conn) == AE_ERR) {
+            return C_ERR;
+        }
+
+        if (ctx->timeEvent == -1) {
+            ctx->timeEvent = aeCreateTimeEvent(server.el, REDIS_SYNCIO_RES, connRdmaCron, conn, NULL);
+            if (ctx->timeEvent == AE_ERR) {
+                return C_ERR;
+            }
+        }
+    } else {
+        aeDeleteFileEvent(server.el, conn->fd, AE_READABLE);
+        if (ctx->timeEvent > 0) {
+            aeDeleteTimeEvent(server.el, ctx->timeEvent);
+            ctx->timeEvent = -1;
+        }
+    }
+
+    return C_OK;
+}
+
+static int connRdmaSetWriteHandler(connection *conn, ConnectionCallbackFunc func, int barrier) {
+
+    conn->write_handler = func;
+    if (barrier) {
+        conn->flags |= CONN_FLAG_WRITE_BARRIER;
+    } else {
+        conn->flags &= ~CONN_FLAG_WRITE_BARRIER;
+    }
+
+    return connRdmaSetRwHandler(conn);
+}
+
+static int connRdmaSetReadHandler(connection *conn, ConnectionCallbackFunc func) {
+    conn->read_handler = func;
+
+    return connRdmaSetRwHandler(conn);
+}
+
+static const char *connRdmaGetLastError(connection *conn) {
+    return strerror(conn->last_errno);
+}
+
+static inline void rdmaConnectFailed(rdma_connection *rdma_conn) {
+    connection *conn = &rdma_conn->c;
+
+    conn->state = CONN_STATE_ERROR;
+    conn->last_errno = ENETUNREACH;
+}
+
+static int rdmaCreateResource(RdmaContext *ctx, struct rdma_cm_id *cm_id)
+{
+    int ret = C_OK;
+    struct ibv_qp_init_attr init_attr;
+    struct ibv_comp_channel *comp_channel = NULL;
+    struct ibv_cq *cq = NULL;
+    struct ibv_pd *pd = NULL;
+
+    pd = ibv_alloc_pd(cm_id->verbs);
+    if (!pd) {
+        serverLog(LL_WARNING, "RDMA: ibv alloc pd failed");
+        return C_ERR;
+    }
+
+    ctx->pd = pd;
+
+    comp_channel = ibv_create_comp_channel(cm_id->verbs);
+    if (!comp_channel) {
+        serverLog(LL_WARNING, "RDMA: ibv create comp channel failed");
+        return C_ERR;
+    }
+
+    ctx->comp_channel = comp_channel;
+
+    cq = ibv_create_cq(cm_id->verbs, REDIS_MAX_SGE * 2, NULL, comp_channel, 0);
+    if (!cq) {
+        serverLog(LL_WARNING, "RDMA: ibv create cq failed");
+        return C_ERR;
+    }
+
+    ctx->cq = cq;
+    ibv_req_notify_cq(cq, 0);
+
+    memset(&init_attr, 0, sizeof(init_attr));
+    init_attr.cap.max_send_wr = REDIS_MAX_SGE;
+    init_attr.cap.max_recv_wr = REDIS_MAX_SGE;
+    init_attr.cap.max_send_sge = 1;
+    init_attr.cap.max_recv_sge = 1;
+    init_attr.qp_type = IBV_QPT_RC;
+    init_attr.send_cq = cq;
+    init_attr.recv_cq = cq;
+    ret = rdma_create_qp(cm_id, pd, &init_attr);
+    if (ret) {
+        serverLog(LL_WARNING, "RDMA: create qp failed");
+        return C_ERR;
+    }
+
+    if (rdmaSetupIoBuf(ctx, cm_id)) {
+        return C_ERR;
+    }
+
+    return C_OK;
+}
+
+static void rdmaReleaseResource(RdmaContext *ctx) {
+    rdmaDestroyIoBuf(ctx);
+
+    if (ctx->cq) {
+        ibv_destroy_cq(ctx->cq);
+    }
+
+    if (ctx->comp_channel) {
+        ibv_destroy_comp_channel(ctx->comp_channel);
+    }
+
+    if (ctx->pd) {
+        ibv_dealloc_pd(ctx->pd);
+    }
+}
+
+static int rdmaConnect(RdmaContext *ctx, struct rdma_cm_id *cm_id) {
+    struct rdma_conn_param conn_param = {0};
+
+    if (rdmaCreateResource(ctx, cm_id) == C_ERR) {
+        return C_ERR;
+    }
+
+    /* rdma connect with param */
+    conn_param.responder_resources = 1;
+    conn_param.initiator_depth = 1;
+    conn_param.retry_count = 7;
+    conn_param.rnr_retry_count = 7;
+    if (rdma_connect(cm_id, &conn_param)) {
+        return C_ERR;
+    }
+
+    anetNonBlock(NULL, ctx->comp_channel->fd);
+    anetCloexec(ctx->comp_channel->fd);
+
+    return C_OK;
+}
+
+static void rdmaCMeventHandler(struct aeEventLoop *el, int fd, void *clientData, int mask) {
+    rdma_connection *rdma_conn = (rdma_connection *)clientData;
+    connection *conn = &rdma_conn->c;
+    struct rdma_cm_id *cm_id = rdma_conn->cm_id;
+    RdmaContext *ctx = cm_id->context;
+    struct rdma_event_channel *cm_channel = ctx->cm_channel;
+    struct rdma_cm_event *ev;
+    enum rdma_cm_event_type ev_type;
+    int ret = C_OK;
+
+    UNUSED(el);
+    UNUSED(fd);
+    UNUSED(mask);
+
+    ret = rdma_get_cm_event(cm_channel, &ev);
+    if (ret) {
+        if (errno != EAGAIN) {
+            serverLog(LL_WARNING, "RDMA: client channel rdma_get_cm_event failed, %s", strerror(errno));
+        }
+        return;
+    }
+
+    ev_type = ev->event;
+    switch (ev_type) {
+        case RDMA_CM_EVENT_ADDR_RESOLVED:
+            /* resolve route at most 100ms */
+            if (rdma_resolve_route(ev->id, 100)) {
+                rdmaConnectFailed(rdma_conn);
+            }
+            break;
+
+        case RDMA_CM_EVENT_ROUTE_RESOLVED:
+            if (rdmaConnect(ctx, ev->id) == C_ERR) {
+                rdmaConnectFailed(rdma_conn);
+            }
+            break;
+
+        case RDMA_CM_EVENT_ESTABLISHED:
+            rdmaHandleEstablished(ev);
+            conn->state = CONN_STATE_CONNECTED;
+            conn->fd = ctx->comp_channel->fd;
+            if (conn->conn_handler) {
+                callHandler(conn, conn->conn_handler);
+            }
+            break;
+
+        case RDMA_CM_EVENT_UNREACHABLE:
+        case RDMA_CM_EVENT_ROUTE_ERROR:
+        case RDMA_CM_EVENT_ADDR_ERROR:
+        case RDMA_CM_EVENT_REJECTED:
+            rdmaConnectFailed(rdma_conn);
+            break;
+
+        case RDMA_CM_EVENT_CONNECT_ERROR:
+        case RDMA_CM_EVENT_TIMEWAIT_EXIT:
+        case RDMA_CM_EVENT_CONNECT_REQUEST:
+        case RDMA_CM_EVENT_ADDR_CHANGE:
+        case RDMA_CM_EVENT_DISCONNECTED:
+            rdmaHandleDisconnect(ev);
+            break;
+
+        case RDMA_CM_EVENT_MULTICAST_JOIN:
+        case RDMA_CM_EVENT_MULTICAST_ERROR:
+        case RDMA_CM_EVENT_DEVICE_REMOVAL:
+        case RDMA_CM_EVENT_CONNECT_RESPONSE:
+        default:
+            serverLog(LL_NOTICE, "RDMA: client channel ignore event: %s", rdma_event_str(ev_type));
+    }
+
+    if (rdma_ack_cm_event(ev)) {
+        serverLog(LL_NOTICE, "RDMA: ack cm event failed\n");
+    }
+
+    /* connection error or closed by remote peer */
+    if (conn->state == CONN_STATE_ERROR) {
+        callHandler(conn, conn->conn_handler);
+    }
+}
+
+/* free resource during connection close */
+static int rdmaResolveAddr(rdma_connection *rdma_conn, const char *addr, int port, const char *src_addr) {
+    struct addrinfo hints, *servinfo = NULL, *p = NULL;
+    struct rdma_event_channel *cm_channel = NULL;
+    struct rdma_cm_id *cm_id = NULL;
+    RdmaContext *ctx = NULL;
+    struct sockaddr_storage saddr;
+    char _port[6];  /* strlen("65535") */
+    int availableAddrs = 0;
+    int ret = C_ERR;
+
+    UNUSED(src_addr);
+    ctx = zcalloc(sizeof(RdmaContext));
+    if (!ctx) {
+        serverLog(LL_WARNING, "RDMA: Out of memory");
+        goto out;
+    }
+
+    ctx->timeEvent = -1;
+    cm_channel = rdma_create_event_channel();
+    if (!cm_channel) {
+        serverLog(LL_WARNING, "RDMA: create event channel failed");
+        goto out;
+    }
+    ctx->cm_channel = cm_channel;
+
+    if (rdma_create_id(cm_channel, &cm_id, (void *)ctx, RDMA_PS_TCP)) {
+        serverLog(LL_WARNING, "RDMA: create id failed");
+        goto out;
+    }
+    rdma_conn->cm_id = cm_id;
+
+    if (anetNonBlock(NULL, cm_channel->fd) != C_OK) {
+        serverLog(LL_WARNING, "RDMA: set cm channel fd non-block failed");
+        goto out;
+    }
+
+    snprintf(_port, 6, "%d", port);
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    if (getaddrinfo(addr, _port, &hints, &servinfo)) {
+         hints.ai_family = AF_INET6;
+         if (getaddrinfo(addr, _port, &hints, &servinfo)) {
+             serverLog(LL_WARNING, "RDMA: bad server addr info");
+             goto out;
+        }
+    }
+
+    for (p = servinfo; p != NULL; p = p->ai_next) {
+        if (p->ai_family == PF_INET) {
+                memcpy(&saddr, p->ai_addr, sizeof(struct sockaddr_in));
+                ((struct sockaddr_in *)&saddr)->sin_port = htons(port);
+        } else if (p->ai_family == PF_INET6) {
+                memcpy(&saddr, p->ai_addr, sizeof(struct sockaddr_in6));
+                ((struct sockaddr_in6 *)&saddr)->sin6_port = htons(port);
+        } else {
+            serverLog(LL_WARNING, "RDMA: Unsupported family");
+            goto out;
+        }
+
+        /* resolve addr at most 100ms */
+        if (rdma_resolve_addr(cm_id, NULL, (struct sockaddr *)&saddr, 100)) {
+            continue;
+        }
+        availableAddrs++;
+    }
+
+    if (!availableAddrs) {
+        serverLog(LL_WARNING, "RDMA: server addr not available");
+        goto out;
+    }
+
+    ret = C_OK;
+
+out:
+    if(servinfo) {
+        freeaddrinfo(servinfo);
+    }
+
+    return ret;
+}
+
+static int connRdmaWait(connection *conn, long start, long timeout) {
+    rdma_connection *rdma_conn = (rdma_connection *)conn;
+    long long remaining = timeout, wait, elapsed = 0;
+
+    remaining = timeout - elapsed;
+    wait = (remaining < REDIS_SYNCIO_RES) ? remaining : REDIS_SYNCIO_RES;
+    aeWait(conn->fd, AE_READABLE, wait);
+    elapsed = mstime() - start;
+    if (elapsed >= timeout) {
+        errno = ETIMEDOUT;
+        return C_ERR;
+    }
+
+    if (connRdmaHandleCq(rdma_conn) == C_ERR) {
+        conn->state = CONN_STATE_ERROR;
+        return C_ERR;
+    }
+
+    return C_OK;
+}
+
+static int connRdmaConnect(connection *conn, const char *addr, int port, const char *src_addr, ConnectionCallbackFunc connect_handler) {
+    rdma_connection *rdma_conn = (rdma_connection *)conn;
+    struct rdma_cm_id *cm_id;
+    RdmaContext *ctx;
+
+    if (rdmaResolveAddr(rdma_conn, addr, port, src_addr) == C_ERR) {
+        return C_ERR;
+    }
+
+    cm_id = rdma_conn->cm_id;
+    ctx = cm_id->context;
+    if (aeCreateFileEvent(server.el, ctx->cm_channel->fd, AE_READABLE, rdmaCMeventHandler, conn) == AE_ERR) {
+        return C_ERR;
+    }
+
+    conn->conn_handler = connect_handler;
+
+    return C_OK;
+}
+
+static int connRdmaBlockingConnect(connection *conn, const char *addr, int port, long long timeout) {
+    rdma_connection *rdma_conn = (rdma_connection *)conn;
+    struct rdma_cm_id *cm_id;
+    RdmaContext *ctx;
+    long long start = mstime();
+
+    if (rdmaResolveAddr(rdma_conn, addr, port, NULL) == C_ERR) {
+        return C_ERR;
+    }
+
+    cm_id = rdma_conn->cm_id;
+    ctx = cm_id->context;
+    if (aeCreateFileEvent(server.el, ctx->cm_channel->fd, AE_READABLE, rdmaCMeventHandler, conn) == AE_ERR) {
+        return C_ERR;
+    }
+
+    do {
+        if (connRdmaWait(conn, start, timeout) == C_ERR) {
+            return C_ERR ;
+        }
+    } while (conn->state != CONN_STATE_CONNECTED);
+
+    return C_OK;
+}
+
+static void connRdmaClose(connection *conn) {
+    rdma_connection *rdma_conn = (rdma_connection *)conn;
+    struct rdma_cm_id *cm_id = rdma_conn->cm_id;
+    RdmaContext *ctx;
+
+    if (conn->fd != -1) {
+        aeDeleteFileEvent(server.el, conn->fd, AE_READABLE);
+        conn->fd = -1;
+    }
+
+    if (!cm_id) {
+        return;
+    }
+
+    ctx = cm_id->context;
+    if (ctx->timeEvent > 0) {
+        aeDeleteTimeEvent(server.el, ctx->timeEvent);
+    }
+
+    rdma_disconnect(cm_id);
+
+    /* poll all CQ before close */
+    connRdmaHandleCq(rdma_conn);
+    rdmaReleaseResource(ctx);
+    if (cm_id->qp) {
+        ibv_destroy_qp(cm_id->qp);
+    }
+
+    rdma_destroy_id(cm_id);
+    if (ctx->cm_channel) {
+        aeDeleteFileEvent(server.el, ctx->cm_channel->fd, AE_READABLE);
+        rdma_destroy_event_channel(ctx->cm_channel);
+    }
+
+    rdma_conn->cm_id = NULL;
+    zfree(ctx);
+    zfree(conn);
+}
+
+static size_t connRdmaSend(connection *conn, const void *data, size_t data_len) {
+    rdma_connection *rdma_conn = (rdma_connection *)conn;
+    struct rdma_cm_id *cm_id = rdma_conn->cm_id;
+    RdmaContext *ctx = cm_id->context;
+    struct ibv_send_wr send_wr, *bad_wr;
+    struct ibv_sge sge;
+    uint32_t off = ctx->tx_offset;
+    char *addr = ctx->send_buf + off;
+    char *remote_addr = ctx->tx_addr + ctx->tx_offset;
+    int ret;
+
+    memcpy(addr, data, data_len);
+
+    sge.addr = (uint64_t)addr;
+    sge.lkey = ctx->send_mr->lkey;
+    sge.length = data_len;
+
+    send_wr.sg_list = &sge;
+    send_wr.num_sge = 1;
+    send_wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+    send_wr.send_flags = (++ctx->send_ops % (REDIS_MAX_SGE / 2)) ? 0 : IBV_SEND_SIGNALED;
+    send_wr.imm_data = htonl(0);
+    send_wr.wr.rdma.remote_addr = (uint64_t)remote_addr;
+    send_wr.wr.rdma.rkey = ctx->tx_key;
+    send_wr.wr_id = 0;
+    send_wr.next = NULL;
+    ret = ibv_post_send(cm_id->qp, &send_wr, &bad_wr);
+    if (ret) {
+        serverLog(LL_WARNING, "RDMA: post send failed: %d", ret);
+        conn->state = CONN_STATE_ERROR;
+        return C_ERR;
+    }
+
+    ctx->tx_offset += data_len;
+
+    return data_len;
+}
+
+static int connRdmaWrite(connection *conn, const void *data, size_t data_len) {
+    rdma_connection *rdma_conn = (rdma_connection *)conn;
+    struct rdma_cm_id *cm_id = rdma_conn->cm_id;
+    RdmaContext *ctx = cm_id->context;
+    uint32_t towrite;
+
+    if (conn->state == CONN_STATE_ERROR || conn->state == CONN_STATE_CLOSED) {
+        return C_ERR;
+    }
+
+    assert(ctx->tx_offset <= ctx->tx_length);
+    towrite = MIN(ctx->tx_length - ctx->tx_offset, data_len);
+    if (!towrite) {
+        return 0;
+    }
+
+    return connRdmaSend(conn, data, towrite);
+}
+
+static inline uint32_t rdmaRead(RdmaContext *ctx, void *buf, size_t buf_len) {
+    uint32_t toread;
+
+    toread = MIN(ctx->rx_offset - ctx->recv_offset, buf_len);
+
+    assert(ctx->recv_offset + toread <= ctx->recv_length);
+    memcpy(buf, ctx->recv_buf + ctx->recv_offset, toread);
+
+    ctx->recv_offset += toread;
+
+    return toread;
+}
+
+static int connRdmaRead(connection *conn, void *buf, size_t buf_len) {
+    rdma_connection *rdma_conn = (rdma_connection *)conn;
+    struct rdma_cm_id *cm_id = rdma_conn->cm_id;
+    RdmaContext *ctx = cm_id->context;
+
+    if (conn->state == CONN_STATE_ERROR || conn->state == CONN_STATE_CLOSED) {
+        return C_ERR;
+    }
+
+    assert(ctx->recv_offset < ctx->rx_offset);
+
+    return rdmaRead(ctx, buf, buf_len);
+}
+
+static ssize_t connRdmaSyncWrite(connection *conn, char *ptr, ssize_t size, long long timeout) {
+    rdma_connection *rdma_conn = (rdma_connection *)conn;
+    struct rdma_cm_id *cm_id = rdma_conn->cm_id;
+    RdmaContext *ctx = cm_id->context;
+    ssize_t nwritten = 0;
+    long long start = mstime();
+    uint32_t towrite;
+
+    if (conn->state == CONN_STATE_ERROR || conn->state == CONN_STATE_CLOSED) {
+        return C_ERR;
+    }
+
+    assert(ctx->tx_offset <= ctx->tx_length);
+    if (ctx->tx_offset < ctx->tx_length) {
+        /* TX buffer is available */
+        goto copy;
+    }
+
+wait:
+    if (connRdmaWait(conn, start, timeout) == C_ERR) {
+        return C_ERR;
+    }
+
+    if (unlikely(!ctx->send_mr)) {
+        goto wait;
+    }
+
+copy:
+    towrite = MIN(ctx->tx_length - ctx->tx_offset, size - nwritten);
+    if (connRdmaSend(conn, ptr, towrite) == (size_t)C_ERR) {
+        return C_ERR;
+    } else {
+        ptr += towrite;
+        nwritten += towrite;
+    }
+
+    if (nwritten < size) {
+        goto wait;
+    }
+
+    return size;
+}
+
+static ssize_t connRdmaSyncRead(connection *conn, char *ptr, ssize_t size, long long timeout) {
+    rdma_connection *rdma_conn = (rdma_connection *)conn;
+    struct rdma_cm_id *cm_id = rdma_conn->cm_id;
+    RdmaContext *ctx = cm_id->context;
+    ssize_t nread = 0;
+    long long start = mstime();
+    uint32_t toread;
+
+    if (conn->state == CONN_STATE_ERROR || conn->state == CONN_STATE_CLOSED) {
+        return C_ERR;
+    }
+
+    assert(ctx->recv_offset <= ctx->rx_offset);
+    if (ctx->recv_offset < ctx->rx_offset) {
+        goto copy;
+    }
+
+wait:
+    if (connRdmaWait(conn, start, timeout) == C_ERR) {
+        return C_ERR;
+    }
+
+copy:
+    toread = rdmaRead(ctx, ptr, size - nread);
+    ptr += toread;
+    nread += toread;
+    if (nread < size) {
+        goto wait;
+    }
+
+    return size;
+}
+
+static ssize_t connRdmaSyncReadLine(connection *conn, char *ptr, ssize_t size, long long timeout) {
+    rdma_connection *rdma_conn = (rdma_connection *)conn;
+    struct rdma_cm_id *cm_id = rdma_conn->cm_id;
+    RdmaContext *ctx = cm_id->context;
+    ssize_t nread = 0;
+    long long start = mstime();
+    uint32_t toread;
+    char *c;
+    char nl = 0;
+
+    if (conn->state == CONN_STATE_ERROR || conn->state == CONN_STATE_CLOSED) {
+        return C_ERR;
+    }
+
+    assert(ctx->recv_offset <= ctx->rx_offset);
+    if (ctx->recv_offset < ctx->rx_offset) {
+        goto copy;
+    }
+
+wait:
+    if (connRdmaWait(conn, start, timeout) == C_ERR) {
+        return C_ERR;
+    }
+
+copy:
+    for (toread = 0; toread <= ctx->rx_offset - ctx->recv_offset; toread++) {
+        c = ctx->recv_buf + ctx->recv_offset + toread;
+        if (*c == '\n') {
+            *c = '\0';
+            if (toread && *(c - 1) == '\r') {
+                *(c - 1) = '\0';
+            }
+            nl = 1;
+            break;
+        }
+    }
+
+    toread = rdmaRead(ctx, ptr, MIN(toread + nl, size - nread));
+    ptr += toread;
+    nread += toread;
+    if (nl) {
+        return nread;
+    }
+
+    if (nread < size) {
+        goto wait;
+    }
+
+    return size;
+}
+
+static int connRdmaGetType(connection *conn) {
+    UNUSED(conn);
+
+    return CONN_TYPE_RDMA;
+}
+
+ConnectionType CT_RDMA = {
+    .ae_handler = connRdmaEventHandler,
+    .accept = connRdmaAccept,
+    .set_read_handler = connRdmaSetReadHandler,
+    .set_write_handler = connRdmaSetWriteHandler,
+    .get_last_error = connRdmaGetLastError,
+    .read = connRdmaRead,
+    .write = connRdmaWrite,
+    .close = connRdmaClose,
+    .connect = connRdmaConnect,
+    .blocking_connect = connRdmaBlockingConnect,
+    .sync_read = connRdmaSyncRead,
+    .sync_write = connRdmaSyncWrite,
+    .sync_readline = connRdmaSyncReadLine,
+    .get_type = connRdmaGetType
+};
+
+static int rdmaServer(char *err, int port, char *bindaddr, int af, int index)
+{
+    int s = ANET_OK, rv, afonly = 1;
+    char _port[6];  /* strlen("65535") */
+    struct addrinfo hints, *servinfo, *p;
+    struct sockaddr_storage sock_addr;
+    struct rdma_cm_id *listen_cmid;
+
+    if (ibv_fork_init()) {
+        serverLog(LL_WARNING, "RDMA: FATAL error, recv corrupted cmd");
+        return ANET_ERR;
+    }
+
+    snprintf(_port,6,"%d",port);
+    memset(&hints,0,sizeof(hints));
+    hints.ai_family = af;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;    /* No effect if bindaddr != NULL */
+    if (bindaddr && !strcmp("*", bindaddr))
+        bindaddr = NULL;
+
+    if (af == AF_INET6 && bindaddr && !strcmp("::*", bindaddr))
+        bindaddr = NULL;
+
+    if ((rv = getaddrinfo(bindaddr, _port, &hints, &servinfo)) != 0) {
+        serverNetError(err, "RDMA: %s", gai_strerror(rv));
+        return ANET_ERR;
+    } else if (!servinfo) {
+        serverNetError(err, "RDMA: get addr info failed");
+        s = ANET_ERR;
+        goto end;
+    }
+
+    for (p = servinfo; p != NULL; p = p->ai_next) {
+        memset(&sock_addr, 0, sizeof(sock_addr));
+        if (p->ai_family == AF_INET6) {
+            memcpy(&sock_addr, p->ai_addr, sizeof(struct sockaddr_in6));
+            ((struct sockaddr_in6 *) &sock_addr)->sin6_family = AF_INET6;
+            ((struct sockaddr_in6 *) &sock_addr)->sin6_port = htons(port);
+        } else {
+            memcpy(&sock_addr, p->ai_addr, sizeof(struct sockaddr_in));
+            ((struct sockaddr_in *) &sock_addr)->sin_family = AF_INET;
+            ((struct sockaddr_in *) &sock_addr)->sin_port = htons(port);
+        }
+
+        if (rdma_create_id(listen_channel, &listen_cmid, NULL, RDMA_PS_TCP)) {
+            serverNetError(err, "RDMA: create listen cm id error");
+            return ANET_ERR;
+        }
+
+        rdma_set_option(listen_cmid, RDMA_OPTION_ID, RDMA_OPTION_ID_AFONLY,
+                        &afonly, sizeof(afonly));
+
+        if (rdma_bind_addr(listen_cmid, (struct sockaddr *)&sock_addr)) {
+            serverNetError(err, "RDMA: bind addr error");
+            goto error;
+        }
+
+        if (rdma_listen(listen_cmid, 0)) {
+            serverNetError(err, "RDMA: listen addr error");
+            goto error;
+        }
+
+        listen_cmids[index] = listen_cmid;
+        goto end;
+    }
+
+error:
+    if (listen_cmid)
+        rdma_destroy_id(listen_cmid);
+    s = ANET_ERR;
+
+end:
+    freeaddrinfo(servinfo);
+    return s;
+}
+
+int listenToRdma(int port, socketFds *sfd) {
+    int j, index = 0, ret;
+    char **bindaddr = server.bindaddr;
+    int bindaddr_count = server.bindaddr_count;
+    char *default_bindaddr[2] = {"*", "-::*"};
+
+    assert(server.proto_max_bulk_len <= 512ll * 1024 * 1024);
+
+    /* Force binding of 0.0.0.0 if no bind address is specified. */
+    if (server.bindaddr_count == 0) {
+        bindaddr_count = 2;
+        bindaddr = default_bindaddr;
+    }
+
+    listen_channel = rdma_create_event_channel();
+    if (!listen_channel) {
+        serverLog(LL_WARNING, "RDMA: Could not create event channel");
+        return C_ERR;
+    }
+
+    for (j = 0; j < bindaddr_count; j++) {
+        char* addr = bindaddr[j];
+        int optional = *addr == '-';
+
+        if (optional)
+            addr++;
+        if (strchr(addr,':')) {
+            /* Bind IPv6 address. */
+            ret = rdmaServer(server.neterr, port, addr, AF_INET6, index);
+        } else {
+            /* Bind IPv4 address. */
+            ret = rdmaServer(server.neterr, port, addr, AF_INET, index);
+        }
+
+        if (ret == ANET_ERR) {
+            int net_errno = errno;
+            serverLog(LL_WARNING, "RDMA: Could not create server for %s:%d: %s",
+                      addr, port, server.neterr);
+
+            if (net_errno == EADDRNOTAVAIL && optional)
+                continue;
+
+            if (net_errno == ENOPROTOOPT || net_errno == EPROTONOSUPPORT ||
+                    net_errno == ESOCKTNOSUPPORT || net_errno == EPFNOSUPPORT ||
+                    net_errno == EAFNOSUPPORT)
+                continue;
+
+            return C_ERR;
+        }
+
+        index++;
+    }
+
+    sfd->fd[sfd->count] = listen_channel->fd;
+    anetNonBlock(NULL, sfd->fd[sfd->count]);
+    anetCloexec(sfd->fd[sfd->count]);
+    sfd->count++;
+
+    return C_OK;
+}
+
+static int rdmaHandleConnect(char *err, struct rdma_cm_event *ev, char *ip, size_t ip_len, int *port)
+{
+    int ret = C_OK;
+    struct rdma_cm_id *cm_id = ev->id;
+    struct sockaddr_storage caddr;
+    RdmaContext *ctx = NULL;
+    struct rdma_conn_param conn_param = {
+            .responder_resources = 1,
+            .initiator_depth = 1,
+            .retry_count = 5,
+    };
+
+    memcpy(&caddr, &cm_id->route.addr.dst_addr, sizeof(caddr));
+    if (caddr.ss_family == AF_INET) {
+        struct sockaddr_in *s = (struct sockaddr_in *)&caddr;
+        if (ip)
+            inet_ntop(AF_INET, (void*)&(s->sin_addr), ip, ip_len);
+        if (port)
+            *port = ntohs(s->sin_port);
+    } else {
+        struct sockaddr_in6 *s = (struct sockaddr_in6 *)&caddr;
+        if (ip)
+            inet_ntop(AF_INET6, (void*)&(s->sin6_addr), ip, ip_len);
+        if (port)
+            *port = ntohs(s->sin6_port);
+    }
+
+    ctx = zcalloc(sizeof(RdmaContext));
+    ctx->timeEvent = -1;
+    ctx->ip = zstrdup(ip);
+    ctx->port = *port;
+    cm_id->context = ctx;
+    if (rdmaCreateResource(ctx, cm_id) == C_ERR) {
+        goto reject;
+    }
+
+    ret = rdma_accept(cm_id, &conn_param);
+    if (ret) {
+        serverNetError(err, "RDMA: accept failed");
+        goto free_rdma;
+    }
+
+    return C_OK;
+
+free_rdma:
+    rdmaReleaseResource(ctx);
+reject:
+    /* reject connect request if hitting error */
+    rdma_reject(cm_id, NULL, 0);
+
+    return C_ERR;
+}
+
+/*
+ * rdmaAccept, actually it works as cm-event handler for listen cm_id.
+ * accept a connection logic works in two steps:
+ * 1, handle RDMA_CM_EVENT_CONNECT_REQUEST and return CM fd on success
+ * 2, handle RDMA_CM_EVENT_ESTABLISHED and return C_OK on success
+ */
+int rdmaAccept(char *err, int s, char *ip, size_t ip_len, int *port, void **priv) {
+    struct rdma_cm_event *ev;
+    enum rdma_cm_event_type ev_type;
+    int ret = C_OK;
+    UNUSED(s);
+
+    ret = rdma_get_cm_event(listen_channel, &ev);
+    if (ret) {
+        if (errno != EAGAIN) {
+            serverLog(LL_WARNING, "RDMA: listen channel rdma_get_cm_event failed, %s", strerror(errno));
+            return ANET_ERR;
+        }
+        return ANET_OK;
+    }
+
+    ev_type = ev->event;
+    switch (ev_type) {
+        case RDMA_CM_EVENT_CONNECT_REQUEST:
+            ret = rdmaHandleConnect(err, ev, ip, ip_len, port);
+            if (ret == C_OK) {
+                RdmaContext *ctx = (RdmaContext *)ev->id->context;
+                *priv = ev->id;
+                ret = ctx->comp_channel->fd;
+            }
+            break;
+
+        case RDMA_CM_EVENT_ESTABLISHED:
+            ret = rdmaHandleEstablished(ev);
+            break;
+
+        case RDMA_CM_EVENT_UNREACHABLE:
+        case RDMA_CM_EVENT_ADDR_ERROR:
+        case RDMA_CM_EVENT_ROUTE_ERROR:
+        case RDMA_CM_EVENT_CONNECT_ERROR:
+        case RDMA_CM_EVENT_REJECTED:
+        case RDMA_CM_EVENT_ADDR_CHANGE:
+        case RDMA_CM_EVENT_DISCONNECTED:
+        case RDMA_CM_EVENT_TIMEWAIT_EXIT:
+            rdmaHandleDisconnect(ev);
+            ret = C_OK;
+            break;
+
+        case RDMA_CM_EVENT_MULTICAST_JOIN:
+        case RDMA_CM_EVENT_MULTICAST_ERROR:
+        case RDMA_CM_EVENT_DEVICE_REMOVAL:
+        case RDMA_CM_EVENT_ADDR_RESOLVED:
+        case RDMA_CM_EVENT_ROUTE_RESOLVED:
+        case RDMA_CM_EVENT_CONNECT_RESPONSE:
+        default:
+            serverLog(LL_NOTICE, "RDMA: listen channel ignore event: %s", rdma_event_str(ev_type));
+            break;
+    }
+
+    if (rdma_ack_cm_event(ev)) {
+        serverLog(LL_WARNING, "ack cm event failed\n");
+        return ANET_ERR;
+    }
+
+    return ret;
+}
+
+connection *connCreateRdma() {
+    rdma_connection *rdma_conn = zcalloc(sizeof(rdma_connection));
+    rdma_conn->c.type = &CT_RDMA;
+    rdma_conn->c.fd = -1;
+
+    return (connection *)rdma_conn;
+}
+
+connection *connCreateAcceptedRdma(int fd, void *priv) {
+    rdma_connection *rdma_conn = (rdma_connection *)connCreateRdma();
+    rdma_conn->c.fd = fd;
+    rdma_conn->c.state = CONN_STATE_ACCEPTING;
+    rdma_conn->cm_id = priv;
+
+    return (connection *)rdma_conn;
+}
+#else    /* __linux__ */
+
+"BUILD ERROR: RDMA is only supported on linux"
+
+#endif   /* __linux__ */
+#else    /* USE_RDMA */
+int listenToRdma(int port, socketFds *sfd) {
+    UNUSED(port);
+    UNUSED(sfd);
+    serverNetError(server.neterr, "RDMA: disabled, need rebuild with BUILD_RDMA=yes");
+
+    return C_ERR;
+}
+
+int rdmaAccept(char *err, int s, char *ip, size_t ip_len, int *port, void **priv) {
+    UNUSED(err);
+    UNUSED(s);
+    UNUSED(ip);
+    UNUSED(ip_len);
+    UNUSED(port);
+    UNUSED(priv);
+
+    serverNetError(server.neterr, "RDMA: disabled, need rebuild with BUILD_RDMA=yes");
+    errno = EOPNOTSUPP;
+
+    return C_ERR;
+}
+
+connection *connCreateRdma() {
+    serverNetError(server.neterr, "RDMA: disabled, need rebuild with BUILD_RDMA=yes");
+    errno = EOPNOTSUPP;
+
+    return NULL;
+}
+
+connection *connCreateAcceptedRdma(int fd, void *priv) {
+    UNUSED(fd);
+    UNUSED(priv);
+    serverNetError(server.neterr, "RDMA: disabled, need rebuild with BUILD_RDMA=yes");
+    errno = EOPNOTSUPP;
+
+    return NULL;
+}
+
+#endif

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -83,6 +83,7 @@ static struct config {
     const char *hostip;
     int hostport;
     const char *hostsocket;
+    int rdma;
     int tls;
     struct cliSSLconfig sslconfig;
     int numclients;
@@ -417,7 +418,11 @@ static void resetClient(client c) {
     aeEventLoop *el = CLIENT_GET_EVENTLOOP(c);
     aeDeleteFileEvent(el,c->context->fd,AE_WRITABLE);
     aeDeleteFileEvent(el,c->context->fd,AE_READABLE);
-    aeCreateFileEvent(el,c->context->fd,AE_WRITABLE,writeHandler,c);
+    if (config.rdma) {
+        writeHandler(el,c->context->fd,c,0);
+    } else {
+        aeCreateFileEvent(el,c->context->fd,AE_WRITABLE,writeHandler,c);
+    }
     c->written = 0;
     c->pending = config.pipeline;
 }
@@ -691,7 +696,10 @@ static client createClient(char *cmd, size_t len, client from, int thread_id) {
             port = node->port;
             c->cluster_node = node;
         }
-        c->context = redisConnectNonBlock(ip,port);
+        if (config.rdma)
+            c->context = redisConnectRdma(ip,port);
+        else
+            c->context = redisConnectNonBlock(ip,port);
     } else {
         c->context = redisConnectUnixNonBlock(config.hostsocket);
     }
@@ -835,8 +843,13 @@ static client createClient(char *cmd, size_t len, client from, int thread_id) {
         benchmarkThread *thread = config.threads[thread_id];
         el = thread->el;
     }
-    if (config.idlemode == 0)
-        aeCreateFileEvent(el,c->context->fd,AE_WRITABLE,writeHandler,c);
+    if (config.idlemode == 0) {
+        if (config.rdma) {
+            writeHandler(el,c->context->fd,c,0);
+        } else {
+            aeCreateFileEvent(el,c->context->fd,AE_WRITABLE,writeHandler,c);
+        }
+    }
     listAddNodeTail(config.clients,c);
     atomicIncr(config.liveclients, 1);
     atomicGet(config.slots_last_update, c->slots_last_update);
@@ -1531,6 +1544,10 @@ int parseOptions(int argc, const char **argv) {
             config.sslconfig.ciphersuites = strdup(argv[++i]);
         #endif
         #endif
+        #ifdef USE_RDMA
+        } else if (!strcmp(argv[i],"--rdma")) {
+            config.rdma = 1;
+        #endif
         } else {
             /* Assume the user meant to provide an option when the arg starts
              * with a dash. We're done otherwise and should use the remainder
@@ -1595,6 +1612,9 @@ usage:
 "                    See the ciphers(1ssl) manpage for more information about the syntax of this string,\n"
 "                    and specifically for TLSv1.3 ciphersuites.\n"
 #endif
+#endif
+#ifdef USE_RDMA
+" --rdma             Use RDMA as transport protocol.\n"
 #endif
 " --help             Output this help and exit.\n"
 " --version          Output version and exit.\n\n"
@@ -1704,6 +1724,7 @@ int main(int argc, const char **argv) {
     config.hostip = "127.0.0.1";
     config.hostport = 6379;
     config.hostsocket = NULL;
+    config.rdma = 0;
     config.tests = NULL;
     config.dbnum = 0;
     config.auth = NULL;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -205,6 +205,7 @@ static struct config {
     char *hostsocket;
     int tls;
     cliSSLconfig sslconfig;
+    int rdma;
     long repeat;
     long interval;
     int dbnum; /* db num currently selected */
@@ -871,15 +872,17 @@ static int cliConnect(int flags) {
             cliRefreshPrompt();
         }
 
-        /* Do not use hostsocket when we got redirected in cluster mode */
-        if (config.hostsocket == NULL ||
+        if (config.rdma) {
+            context = redisConnectRdma(config.hostip,config.hostport);
+        } else if (config.hostsocket == NULL ||
             (config.cluster_mode && config.cluster_reissue_command)) {
+            /* Do not use hostsocket when we got redirected in cluster mode */
             context = redisConnect(config.hostip,config.hostport);
         } else {
             context = redisConnectUnix(config.hostsocket);
         }
 
-        if (!context->err && config.tls) {
+        if (!context->err && config.tls && !config.rdma) {
             const char *err = NULL;
             if (cliSecureConnection(context, config.sslconfig, &err) == REDIS_ERR && err) {
                 fprintf(stderr, "Could not negotiate a TLS connection: %s\n", err);
@@ -1772,6 +1775,10 @@ static int parseOptions(int argc, char **argv) {
             config.sslconfig.ciphersuites = argv[++i];
         #endif
 #endif
+#ifdef USE_RDMA
+        } else if (!strcmp(argv[i],"--rdma")) {
+            config.rdma = 1;
+#endif
         } else if (!strcmp(argv[i],"-v") || !strcmp(argv[i], "--version")) {
             sds version = cliVersion();
             printf("redis-cli %s\n", version);
@@ -1904,6 +1911,9 @@ static void usage(void) {
 "                     See the ciphers(1ssl) manpage for more information about the syntax of this string,\n"
 "                     and specifically for TLSv1.3 ciphersuites.\n"
 #endif
+#endif
+#ifdef USE_RDMA
+"  --rdma             Establish a RDMA connection.\n"
 #endif
 "  --raw              Use raw formatting for replies (default when STDOUT is\n"
 "                     not a tty).\n"

--- a/src/server.c
+++ b/src/server.c
@@ -3212,8 +3212,14 @@ void initServer(void) {
         anetCloexec(server.sofd);
     }
 
+    if (server.rdma_port != 0 &&
+        listenToRdma(server.rdma_port, &server.rdmafd) == C_ERR) {
+        serverLog(LL_WARNING, "Failed listening on port %u (RDMA): %s, aborting.", server.rdma_port, server.neterr);
+        exit(1);
+    }
+
     /* Abort if there are no listening sockets at all. */
-    if (server.ipfd.count == 0 && server.tlsfd.count == 0 && server.sofd < 0) {
+    if (server.ipfd.count == 0 && server.tlsfd.count == 0 && server.sofd < 0 && server.rdmafd.count == 0) {
         serverLog(LL_WARNING, "Configured to not listen anywhere, exiting.");
         exit(1);
     }
@@ -3300,6 +3306,9 @@ void initServer(void) {
     }
     if (server.sofd > 0 && aeCreateFileEvent(server.el,server.sofd,AE_READABLE,
         acceptUnixHandler,NULL) == AE_ERR) serverPanic("Unrecoverable error creating server.sofd file event.");
+    if (createSocketAcceptHandler(&server.rdmafd, acceptRdmaHandler) != C_OK) {
+        serverPanic("Unrecoverable error creating RDMA socket accept handler.");
+    }
 
 
     /* Register a readable event for the pipe used to awake the event loop

--- a/src/server.h
+++ b/src/server.h
@@ -1673,6 +1673,10 @@ struct redisServer {
                                 * failover then any replica can be used. */
     int target_replica_port; /* Failover target port */
     int failover_state; /* Failover state */
+    /* RDMA */
+    int rdma_port;              /* RDMA listening port */
+    socketFds rdmafd;           /* RDMA CM file descriptors */
+    int rdma_replication;       /* RDMA replication */
 };
 
 #define MAX_KEYS_BUFFER 256
@@ -1867,6 +1871,7 @@ void processInputBuffer(client *c);
 void acceptTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void acceptTLSHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void acceptUnixHandler(aeEventLoop *el, int fd, void *privdata, int mask);
+void acceptRdmaHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void readQueryFromClient(connection *conn);
 void addReplyNull(client *c);
 void addReplyNullArray(client *c);
@@ -1921,6 +1926,7 @@ char *getClientTypeName(int class);
 void flushSlavesOutputBuffers(void);
 void disconnectSlaves(void);
 int listenToPort(int port, socketFds *fds);
+int listenToRdma(int port, socketFds *fds);
 void pauseClients(mstime_t duration, pause_type type);
 void unpauseClients(void);
 int areClientsPaused(void);


### PR DESCRIPTION
In the production environment, RDMA gets popular and common for a
networking card. So support RDMA as transport layer protocol to
improve performance and cost reduction.

Note that this feature is ONLY implemented/tested on Linux.

Several steps of the full job:
1, support RDMA for the connection from client & server. This is the
   most import part, and luckly it's implemented in this patch.
   Add a new config "rdma-port" for the server side to listen on
   a RDMA port. Both redis-cli and redis-benchmark work fine with a
   new argument '--rdma'. "REPLICAOF" command launches a RDMA client
   if "rdma-replication" is enabled, and it works fine.

2, To support RDMA cluster mode.

3, To implement async read/write for client side. Because RDMA does
   NOT support POLLOUT event, it's a little difficult to implement
   the async IO mechanism for hiredis.

The test result is quite exciting:
CPU: Intel(R) Xeon(R) Platinum 8260.
NIC: Mellanox ConnectX-5.
Config of redis: appendonly no, port 6379, rdma-port 6379, appendonly no,
                 server_cpulist 12, bgsave_cpulist 16.
For RDMA: ./redis-benchmark -h HOST -c 30 -n 10000000 -r 1000000000 \
          --threads 8 -d 512 -t ping,set,get,lrange_100 --rdma
For TCP: ./redis-benchmark -h HOST -c 30 -n 10000000 -r 1000000000 \
          --threads 8 -d 512 -t ping,set,get,lrange_100

====== PING_INLINE ======
 TCP: QPS: 159017   AVG LAT: 0.183
RDMA: QPS: 523944   AVG LAT: 0.054

====== PING_MBULK ======
 TCP: QPS: 162256   AVG LAT: 0.179
RDMA: QPS: 509839   AVG LAT: 0.056

====== SET ======
 TCP: QPS: 154700   AVG LAT: 0.187
RDMA: QPS: 492368   AVG LAT: 0.058

====== GET ======
 TCP: QPS: 159022   AVG LAT: 0.182
RDMA: QPS: 525099   AVG LAT: 0.054

====== LPUSH (needed to benchmark LRANGE) ======
 TCP: QPS: 142537   AVG LAT: 0.207
RDMA: QPS: 395038   AVG LAT: 0.073

====== LRANGE_100 (first 100 elements) ======
 TCP: QPS:  36171   AVG LAT: 0.657
RDMA: QPS:  55266   AVG LAT: 0.412

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>