### PR TITLE
Include sizeof(struct stream) in objectComputeSize

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -880,7 +880,7 @@ size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
         }
     } else if (o->type == OBJ_STREAM) {
         stream *s = o->ptr;
-        asize = sizeof(*o);
+        asize = sizeof(*o)+sizeof(*s);
         asize += streamRadixTreeMemoryUsage(s->rax);
 
         /* Now we have to add the listpacks. The last listpack is often non


### PR DESCRIPTION
Affects MEMORY USAGE