### PR TITLE
stop increasing level when level has reached ZSKIPLIST_MAXLEVEL

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -121,7 +121,7 @@ void zslFree(zskiplist *zsl) {
  * levels are less likely to be returned. */
 int zslRandomLevel(void) {
     int level = 1;
-    while ((random()&0xFFFF) < (ZSKIPLIST_P * 0xFFFF))
+    while (level < ZSKIPLIST_MAXLEVEL && (random()&0xFFFF) < (ZSKIPLIST_P * 0xFFFF))
         level += 1;
     return (level<ZSKIPLIST_MAXLEVEL) ? level : ZSKIPLIST_MAXLEVEL;
 }


### PR DESCRIPTION
When level has reached ZSKIPLIST_MAXLEVEL in zslRandomLevel ,the increasing should stop and return ZSKIPLIST_MAXLEVEL.