### PR TITLE
Avoid allocating query buf in advance and after a big arg

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -643,7 +643,7 @@ struct client *createAOFClient(void) {
     c->id = CLIENT_ID_AOF; /* So modules can identify it's the AOF client. */
     c->conn = NULL;
     c->name = NULL;
-    c->querybuf = sdsempty();
+    c->querybuf = NULL;
     c->querybuf_peak = 0;
     c->argc = 0;
     c->argv = NULL;

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -136,10 +136,7 @@ void processUnblockedClients(void) {
             if (processPendingCommandsAndResetClient(c) == C_ERR) {
                 continue;
             }
-            /* Then process client if it has more data in it's buffer. */
-            if (c->querybuf && sdslen(c->querybuf) > 0) {
-                processInputBuffer(c);
-            }
+            processInputBuffer(c);
         }
     }
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -2904,7 +2904,8 @@ void replicationCacheMaster(client *c) {
      * we want to discard the non processed query buffers and non processed
      * offsets, including pending transactions, already populated arguments,
      * pending outputs to the master. */
-    sdsclear(server.master->querybuf);
+    if (server.master->querybuf != NULL)
+        sdsclear(server.master->querybuf);
     sdsclear(server.master->pending_querybuf);
     server.master->read_reploff = server.master->reploff;
     if (c->flags & CLIENT_MULTI) discardTransaction(c);

--- a/src/sds.c
+++ b/src/sds.c
@@ -351,6 +351,7 @@ sds sdsRemoveFreeSpace(sds s) {
  * 4) The implicit null term.
  */
 size_t sdsAllocSize(sds s) {
+    if (s == NULL) return 0;
     size_t alloc = sdsalloc(s);
     return sdsHdrSize(s[-1])+alloc+1;
 }

--- a/src/server.h
+++ b/src/server.h
@@ -1902,8 +1902,6 @@ size_t sdsZmallocSize(sds s);
 size_t getStringObjectSdsUsedMemory(robj *o);
 void freeClientReplyValue(void *o);
 void *dupClientReplyValue(void *o);
-void getClientsMaxBuffers(unsigned long *longest_output_list,
-                          unsigned long *biggest_input_buffer);
 char *getClientPeerId(client *client);
 char *getClientSockName(client *client);
 sds catClientInfoString(sds s, client *client);

--- a/tests/unit/querybuf.tcl
+++ b/tests/unit/querybuf.tcl
@@ -34,10 +34,15 @@ start_server {tags {"querybuf slow"}} {
             fail "query buffer was resized"
         }
 
+        puts [client_query_buffer test_client]
+
         # Fill query buffer to more than 32k
         $rd set bigstring v ;# create bigstring in advance to avoid adding extra memory
         $rd set bigstring [string repeat A 32768] nx
+        $rd flush
 
+        puts [client_query_buffer test_client]
+        
         # Wait for query buffer to be resized to 0.
         wait_for_condition 1000 10 {
             [client_query_buffer test_client] == 0


### PR DESCRIPTION
After handling a bigarg there's no point performing a query buff pre allocation. Lets leave the qbuf allocation logic to one place only: `readQueryFromClient()`. We might want to keep the code as is, but in so lets just alloc an empty sds after handling the bigarg.

- [ ] Still need to fix querybuf shrink test accordingly

