### PR TITLE
Fix bug in sdscatfmt when % is the last format char

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -682,6 +682,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
         switch(*f) {
         case '%':
             next = *(f+1);
+            if (next == '\0') break;
             f++;
             switch(next) {
             case 's':


### PR DESCRIPTION
For the sdscatfmt function in sds.c, when the parameter fmt ended up with '%',
the behavior is undefined. This commit fix this bug.

lucky we don't have any format string that ends with % and we don't take user input
to use it as format string, so this doesn't fix any real bug....

This replaces #2698 which had indentation issues that i was unable to fix