### PR TITLE
support comment cmd in redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2169,6 +2169,14 @@ static int isSensitiveCommand(int argc, char **argv) {
     return 0;
 }
 
+int isCommentCmd(const char* cmd) {
+    if (cmd == NULL) {
+        return 0;
+    }
+
+    return cmd[0] == '#';
+}
+
 static void repl(void) {
     sds historyfile = NULL;
     int history = 0;
@@ -2217,6 +2225,10 @@ static void repl(void) {
                 sdsfreesplitres(argv,argc);
                 linenoiseFree(line);
                 continue;
+            }
+
+            if (isCommentCmd(argv[0])) {
+              continue;
             }
 
             /* check if we have a repeat command option and


### PR DESCRIPTION
Support comment command in redis-cli, command start with `#` will be considered as comment.