### PR TITLE
hrandfield and zrandmember with count should return emptyarray when key does not exist.

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -989,7 +989,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     int uniq = 1;
     robj *hash;
 
-    if ((hash = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp]))
+    if ((hash = lookupKeyReadOrReply(c,c->argv[1],shared.emptyarray))
         == NULL || checkType(c,hash,OBJ_HASH)) return;
     size = hashTypeLength(hash);
 
@@ -1178,7 +1178,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     }
 }
 
-/* HRANDFIELD [<count> WITHVALUES] */
+/* HRANDFIELD key [count [WITHVALUES]] */
 void hrandfieldCommand(client *c) {
     long l;
     int withvalues = 0;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1178,7 +1178,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     }
 }
 
-/* HRANDFIELD key [count [WITHVALUES]] */
+/* HRANDFIELD key [<count> [WITHVALUES]] */
 void hrandfieldCommand(client *c) {
     long l;
     int withvalues = 0;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4188,7 +4188,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     zuiClearIterator(&src);
 }
 
-/* ZRANDMEMBER key [count [WITHSCORES]] */
+/* ZRANDMEMBER key [<count> [WITHSCORES]] */
 void zrandmemberCommand(client *c) {
     long l;
     int withscores = 0;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4000,7 +4000,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     int uniq = 1;
     robj *zsetobj;
 
-    if ((zsetobj = lookupKeyReadOrReply(c, c->argv[1], shared.null[c->resp]))
+    if ((zsetobj = lookupKeyReadOrReply(c, c->argv[1], shared.emptyarray))
         == NULL || checkType(c, zsetobj, OBJ_ZSET)) return;
     size = zsetLength(zsetobj);
 
@@ -4188,7 +4188,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     zuiClearIterator(&src);
 }
 
-/* ZRANDMEMBER [<count> WITHSCORES] */
+/* ZRANDMEMBER key [count [WITHSCORES]] */
 void zrandmemberCommand(client *c) {
     long l;
     int withscores = 0;

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -72,6 +72,7 @@ start_server {tags {"hash"}} {
         r hrandfield nonexisting_key 100
     } {}
 
+    # Make sure we can distinguish between an empty array and a null response
     r readraw 1
 
     test "HRANDFIELD count of 0 is handled correctly - emptyarray" {

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -72,6 +72,18 @@ start_server {tags {"hash"}} {
         r hrandfield nonexisting_key 100
     } {}
 
+    r readraw 1
+
+    test "HRANDFIELD count of 0 is handled correctly - emptyarray" {
+        r hrandfield myhash 0
+    } {*0}
+
+    test "HRANDFIELD with <count> against non existing key - emptyarray" {
+        r hrandfield nonexisting_key 100
+    } {*0}
+
+    r readraw 0
+
     foreach {type contents} "
         hashtable {{a 1} {b 2} {c 3} {d 4} {e 5} {6 f} {7 g} {8 h} {9 i} {[randstring 70 90 alpha] 10}}
         ziplist {{a 1} {b 2} {c 3} {d 4} {e 5} {6 f} {7 g} {8 h} {9 i} {10 j}} " {

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -582,9 +582,25 @@ start_server {
         assert {[lsort $union] eq [lsort $content]}
     }
 
+    test "SRANDMEMBER count of 0 is handled correctly" {
+        r srandmember myset 0
+    } {}
+
     test "SRANDMEMBER with <count> against non existing key" {
         r srandmember nonexisting_key 100
     } {}
+
+    r readraw 1
+
+    test "SRANDMEMBER count of 0 is handled correctly - emptyarray" {
+        r srandmember myset 0
+    } {*0}
+
+    test "SRANDMEMBER with <count> against non existing key - emptyarray" {
+        r srandmember nonexisting_key 100
+    } {*0}
+
+    r readraw 0
 
     foreach {type contents} {
         hashtable {

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -590,6 +590,7 @@ start_server {
         r srandmember nonexisting_key 100
     } {}
 
+    # Make sure we can distinguish between an empty array and a null response
     r readraw 1
 
     test "SRANDMEMBER count of 0 is handled correctly - emptyarray" {

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1717,6 +1717,7 @@ start_server {tags {"zset"}} {
         r zrandmember nonexisting_key 100
     } {}
 
+    # Make sure we can distinguish between an empty array and a null response
     r readraw 1
 
     test "ZRANDMEMBER count of 0 is handled correctly - emptyarray" {

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1717,6 +1717,18 @@ start_server {tags {"zset"}} {
         r zrandmember nonexisting_key 100
     } {}
 
+    r readraw 1
+
+    test "ZRANDMEMBER count of 0 is handled correctly - emptyarray" {
+        r zrandmember myzset 0
+    } {*0}
+
+    test "ZRANDMEMBER with <count> against non existing key - emptyarray" {
+        r zrandmember nonexisting_key 100
+    } {*0}
+
+    r readraw 0
+
     foreach {type contents} "
         skiplist {1 a 2 b 3 c 4 d 5 e 6 f 7 g 7 h 9 i 10 [randstring 70 90 alpha]}
         ziplist {1 a 2 b 3 c 4 d 5 e 6 f 7 g 7 h 9 i 10 j} " {


### PR DESCRIPTION
we treat non-existing key as an empty hash or zset

Before:
```
127.0.0.1:6379> hrandfield a 1
(nil)
127.0.0.1:6379> zrandmember a 1
(nil)
```

After:
```
127.0.0.1:6379> hrandfield a 1
(empty array)
127.0.0.1:6379> zrandmember a 1
(empty array)
```

also can check https://redis.io/commands/hrandfield
```
Exactly count fields, or an empty array if the hash is empty (non-existing key), are always returned.
```

Also add test to check emptyarray.