### PR TITLE
Fix test CONFIG SET bind-source-addr fail because of firewall.

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -458,6 +458,9 @@ proc start_server {options {code undefined}} {
         close $fd
     }
 
+    set host $::host
+    if {[dict exists $config bind]} { set host [dict get $config bind] }
+
     # We need a loop here to retry with different ports.
     set server_started 0
     while {$server_started == 0} {
@@ -494,7 +497,7 @@ proc start_server {options {code undefined}} {
 
         if {$::valgrind} {set retrynum 1000} else {set retrynum 100}
         if {$code ne "undefined"} {
-            set serverisup [server_is_up $::host $port $retrynum]
+            set serverisup [server_is_up $host $port $retrynum]
         } else {
             set serverisup 1
         }
@@ -514,8 +517,6 @@ proc start_server {options {code undefined}} {
 
     # setup properties to be able to initialize a client object
     set port_param [expr $::tls ? {"tls-port"} : {"port"}]
-    set host $::host
-    if {[dict exists $config bind]} { set host [dict get $config bind] }
     if {[dict exists $config $port_param]} { set port [dict get $config $port_param] }
 
     # setup config dict

--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -39,14 +39,14 @@ test {CONFIG SET bind address} {
 
 test {CONFIG SET bind-source-addr} {
     if {[exec uname] == {Linux}} {
-        start_server {} {
-            start_server {} {
+        start_server [list overrides [list bind "127.0.0.2"] ] {
+            start_server [list overrides [list bind "127.0.0.2"] ] {
                 set replica [srv 0 client]
                 set master [srv -1 client]
 
                 $master config set protected-mode no
 
-                $replica config set bind-source-addr 127.0.0.2
+                $replica config set bind-source-addr 127.0.0.1
                 $replica replicaof [srv -1 host] [srv -1 port]
 
                 wait_for_condition 50 100 {
@@ -55,7 +55,7 @@ test {CONFIG SET bind-source-addr} {
                     fail "Replication not started."
                 }
 
-                assert_match {*ip=127.0.0.2*} [s -1 slave0]
+                assert_match {*ip=127.0.0.1*} [s -1 slave0]
             }
         }
     }


### PR DESCRIPTION
At some machine, firewall is configured accept any packets from
127.0.0.1 but reject any packets from other 127.0.0.*. So
bind-source-addr test using source addr 127.0.0.2 will fail.
So in the test, we start server bind 127.0.0.2 and bind source addr
127.0.0.1 .

Also fix in test start_server, when provide bind config, server_is_up may take
wrong host.
