### PR TITLE
On 32 bit platform, the bit position of GETBIT/SETBIT/BITFIELD/BITCOUNT,BITPOS may overflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -6,7 +6,7 @@ on:
       # any PR to a release branch.
       - '[0-9].[0-9]'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 9 * * *'
   workflow_dispatch:
     inputs:
       skipjobs:
@@ -33,7 +33,7 @@ jobs:
 
   test-ubuntu-jemalloc:
     runs-on: ubuntu-latest
-    if: github.repository == 'redis/redis'
+    if: github.repository == 'huangzhw/redis'
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -67,7 +67,7 @@ jobs:
 
   test-ubuntu-libc-malloc:
     runs-on: ubuntu-latest
-    if: github.repository == 'redis/redis'
+    if: github.repository == 'huangzhw/redis'
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -98,7 +98,7 @@ jobs:
 
   test-ubuntu-no-malloc-usable-size:
     runs-on: ubuntu-latest
-    if: github.repository == 'redis/redis'
+    if: github.repository == 'huangzhw/redis'
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -129,7 +129,7 @@ jobs:
 
   test-ubuntu-32bit:
     runs-on: ubuntu-latest
-    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, '32bit')
+    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, '32bit')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -166,7 +166,7 @@ jobs:
 
   test-ubuntu-tls:
     runs-on: ubuntu-latest
-    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'tls')
+    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'tls')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -208,7 +208,7 @@ jobs:
 
   test-ubuntu-io-threads:
     runs-on: ubuntu-latest
-    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'iothreads')
+    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'iothreads')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -234,7 +234,7 @@ jobs:
 
   test-valgrind:
     runs-on: ubuntu-latest
-    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'valgrind')
+    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'valgrind')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -265,7 +265,7 @@ jobs:
 
   test-valgrind-no-malloc-usable-size:
     runs-on: ubuntu-latest
-    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'valgrind')
+    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'valgrind')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -292,7 +292,7 @@ jobs:
 
   test-centos7-jemalloc:
     runs-on: ubuntu-latest
-    if: github.repository == 'redis/redis'
+    if: github.repository == 'huangzhw/redis'
     container: centos:7
     timeout-minutes: 14400
     steps:
@@ -326,7 +326,7 @@ jobs:
 
   test-centos7-tls:
     runs-on: ubuntu-latest
-    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'tls')
+    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'tls')
     container: centos:7
     timeout-minutes: 14400
     steps:
@@ -371,7 +371,7 @@ jobs:
 
   test-macos-latest:
     runs-on: macos-latest
-    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'macos')
+    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'macos')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -399,7 +399,7 @@ jobs:
 
   test-freebsd:
     runs-on: macos-latest
-    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'freebsd')
+    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'freebsd')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -426,7 +426,7 @@ jobs:
 
   test-alpine-jemalloc:
     runs-on: ubuntu-latest
-    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'alpine')
+    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'alpine')
     container: alpine:latest
     steps:
     - name: prep
@@ -458,7 +458,7 @@ jobs:
 
   test-alpine-libc-malloc:
     runs-on: ubuntu-latest
-    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'alpine')
+    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'alpine')
     container: alpine:latest
     steps:
     - name: prep

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,32 +1,6 @@
 name: Daily
 
-on:
-  pull_request:
-    branches:
-      # any PR to a release branch.
-      - '[0-9].[0-9]'
-  schedule:
-    - cron: '0 9 * * *'
-  workflow_dispatch:
-    inputs:
-      skipjobs:
-        description: 'jobs to skip (delete the ones you wanna keep)'
-        default: 'valgrind,tls,freebsd,macos,alpine,32bit'
-      skiptests:
-        description: 'tests to skip (delete the ones you wanna keep)'
-        default: 'redis,modules,sentinel,cluster'
-      test_args:
-        description: 'extra test arguments'
-        default: ''
-      cluster_test_args:
-        description: 'extra cluster / sentinel test arguments'
-        default: ''
-      use_repo:
-        description: 'repo owner and name'
-        default: 'redis/redis'
-      use_git_ref:
-        description: 'git branch or sha to use'
-        default: 'unstable'
+on: [pull_request, push]
 
 
 jobs:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,6 +1,32 @@
 name: Daily
 
-on: [pull_request, push]
+on:
+  pull_request:
+    branches:
+      # any PR to a release branch.
+      - '[0-9].[0-9]'
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+    inputs:
+      skipjobs:
+        description: 'jobs to skip (delete the ones you wanna keep)'
+        default: 'valgrind,tls,freebsd,macos,alpine,32bit'
+      skiptests:
+        description: 'tests to skip (delete the ones you wanna keep)'
+        default: 'redis,modules,sentinel,cluster'
+      test_args:
+        description: 'extra test arguments'
+        default: ''
+      cluster_test_args:
+        description: 'extra cluster / sentinel test arguments'
+        default: ''
+      use_repo:
+        description: 'repo owner and name'
+        default: 'redis/redis'
+      use_git_ref:
+        description: 'git branch or sha to use'
+        default: 'unstable'
 
 
 jobs:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -6,7 +6,7 @@ on:
       # any PR to a release branch.
       - '[0-9].[0-9]'
   schedule:
-    - cron: '0 9 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       skipjobs:
@@ -33,7 +33,7 @@ jobs:
 
   test-ubuntu-jemalloc:
     runs-on: ubuntu-latest
-    if: github.repository == 'huangzhw/redis'
+    if: github.repository == 'redis/redis'
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -67,7 +67,7 @@ jobs:
 
   test-ubuntu-libc-malloc:
     runs-on: ubuntu-latest
-    if: github.repository == 'huangzhw/redis'
+    if: github.repository == 'redis/redis'
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -98,7 +98,7 @@ jobs:
 
   test-ubuntu-no-malloc-usable-size:
     runs-on: ubuntu-latest
-    if: github.repository == 'huangzhw/redis'
+    if: github.repository == 'redis/redis'
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -129,7 +129,7 @@ jobs:
 
   test-ubuntu-32bit:
     runs-on: ubuntu-latest
-    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, '32bit')
+    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, '32bit')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -166,7 +166,7 @@ jobs:
 
   test-ubuntu-tls:
     runs-on: ubuntu-latest
-    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'tls')
+    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'tls')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -208,7 +208,7 @@ jobs:
 
   test-ubuntu-io-threads:
     runs-on: ubuntu-latest
-    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'iothreads')
+    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'iothreads')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -234,7 +234,7 @@ jobs:
 
   test-valgrind:
     runs-on: ubuntu-latest
-    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'valgrind')
+    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'valgrind')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -265,7 +265,7 @@ jobs:
 
   test-valgrind-no-malloc-usable-size:
     runs-on: ubuntu-latest
-    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'valgrind')
+    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'valgrind')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -292,7 +292,7 @@ jobs:
 
   test-centos7-jemalloc:
     runs-on: ubuntu-latest
-    if: github.repository == 'huangzhw/redis'
+    if: github.repository == 'redis/redis'
     container: centos:7
     timeout-minutes: 14400
     steps:
@@ -326,7 +326,7 @@ jobs:
 
   test-centos7-tls:
     runs-on: ubuntu-latest
-    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'tls')
+    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'tls')
     container: centos:7
     timeout-minutes: 14400
     steps:
@@ -371,7 +371,7 @@ jobs:
 
   test-macos-latest:
     runs-on: macos-latest
-    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'macos')
+    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'macos')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -399,7 +399,7 @@ jobs:
 
   test-freebsd:
     runs-on: macos-latest
-    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'freebsd')
+    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'freebsd')
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -426,7 +426,7 @@ jobs:
 
   test-alpine-jemalloc:
     runs-on: ubuntu-latest
-    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'alpine')
+    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'alpine')
     container: alpine:latest
     steps:
     - name: prep
@@ -458,7 +458,7 @@ jobs:
 
   test-alpine-libc-malloc:
     runs-on: ubuntu-latest
-    if: github.repository == 'huangzhw/redis' && !contains(github.event.inputs.skipjobs, 'alpine')
+    if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'alpine')
     container: alpine:latest
     steps:
     - name: prep

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -254,7 +254,7 @@ jobs:
         sudo apt-get install tcl8.6 tclx valgrind -y
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
-      run: ./runtest --valgrind --verbose --clients 1 --dump-logs ${{github.event.inputs.test_args}}
+      run: ./runtest --valgrind --verbose --clients 1 --tags -large-memory --dump-logs ${{github.event.inputs.test_args}}
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
       run: ./runtest-moduleapi --valgrind --no-latency --verbose --clients 1 ${{github.event.inputs.test_args}}
@@ -285,7 +285,7 @@ jobs:
         sudo apt-get install tcl8.6 tclx valgrind -y
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
-      run: ./runtest --valgrind --verbose --clients 1 --dump-logs ${{github.event.inputs.test_args}}
+      run: ./runtest --valgrind --verbose --clients 1 --tags -large-memory --dump-logs ${{github.event.inputs.test_args}}
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
       run: ./runtest-moduleapi --valgrind --no-latency --verbose --clients 1 ${{github.event.inputs.test_args}}
@@ -419,7 +419,7 @@ jobs:
         prepare: pkg install -y bash gmake lang/tcl86 lang/tclx
         run: >
           gmake || exit 1 ;
-          if echo "${{github.event.inputs.skiptests}}" | grep -vq redis ; then ./runtest --accurate --verbose --no-latency --dump-logs ${{github.event.inputs.test_args}} || exit 1 ; fi ;
+          if echo "${{github.event.inputs.skiptests}}" | grep -vq redis ; then ./runtest --accurate --verbose --no-latency --tags -large-memory --dump-logs ${{github.event.inputs.test_args}} || exit 1 ; fi ;
           if echo "${{github.event.inputs.skiptests}}" | grep -vq modules ; then MAKE=gmake ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}} || exit 1 ; fi ;
           if echo "${{github.event.inputs.skiptests}}" | grep -vq sentinel ; then ./runtest-sentinel ${{github.event.inputs.cluster_test_args}} || exit 1 ; fi ;
           if echo "${{github.event.inputs.skiptests}}" | grep -vq cluster ; then ./runtest-cluster ${{github.event.inputs.cluster_test_args}} || exit 1 ; fi ;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1128,9 +1128,9 @@ void bitfieldGeneric(client *c, int flags) {
              * object boundaries. */
             memset(buf,0,9);
             int i;
-            size_t byte = thisop->offset >> 3;
+            uint64_t byte = thisop->offset >> 3;
             for (i = 0; i < 9; i++) {
-                if (src == NULL || i+byte >= (size_t)strlen) break;
+                if (src == NULL || i+byte >= (uint64_t)strlen) break;
                 buf[i] = src[i+byte];
             }
 

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -477,7 +477,7 @@ int getBitfieldTypeFromArgument(client *c, robj *o, int *sign, int *bits) {
  * so that the 'maxbit' bit can be addressed. The object is finally
  * returned. Otherwise if the key holds a wrong type NULL is returned and
  * an error is sent to the client. */
-robj *lookupStringForBitCommand(client *c, size_t maxbit) {
+robj *lookupStringForBitCommand(client *c, uint64_t maxbit) {
     size_t byte = maxbit >> 3;
     robj *o = lookupKeyWrite(c->db,c->argv[1]);
     if (checkType(c,o,OBJ_STRING)) return NULL;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -410,7 +410,7 @@ void printBits(unsigned char *p, unsigned long count) {
  * If the 'hash' argument is true, and 'bits is positive, then the command
  * will also parse bit offsets prefixed by "#". In such a case the offset
  * is multiplied by 'bits'. This is useful for the BITFIELD command. */
-int getBitOffsetFromArgument(client *c, robj *o, size_t *offset, int hash, int bits) {
+int getBitOffsetFromArgument(client *c, robj *o, uint64_t *offset, int hash, int bits) {
     long long loffset;
     char *err = "bit offset is not an integer or out of range";
     char *p = o->ptr;
@@ -435,7 +435,7 @@ int getBitOffsetFromArgument(client *c, robj *o, size_t *offset, int hash, int b
         return C_ERR;
     }
 
-    *offset = (size_t)loffset;
+    *offset = loffset;
     return C_OK;
 }
 
@@ -527,7 +527,7 @@ unsigned char *getObjectReadOnlyString(robj *o, long *len, char *llbuf) {
 void setbitCommand(client *c) {
     robj *o;
     char *err = "bit is not an integer or out of range";
-    size_t bitoffset;
+    uint64_t bitoffset;
     ssize_t byte, bit;
     int byteval, bitval;
     long on;
@@ -566,7 +566,7 @@ void setbitCommand(client *c) {
 void getbitCommand(client *c) {
     robj *o;
     char llbuf[32];
-    size_t bitoffset;
+    uint64_t bitoffset;
     size_t byte, bit;
     size_t bitval = 0;
 
@@ -933,12 +933,12 @@ struct bitfieldOp {
  * GET subcommand is allowed, other subcommands will return an error. */
 void bitfieldGeneric(client *c, int flags) {
     robj *o;
-    size_t bitoffset;
+    uint64_t bitoffset;
     int j, numops = 0, changes = 0;
     struct bitfieldOp *ops = NULL; /* Array of ops to execute at end. */
     int owtype = BFOVERFLOW_WRAP; /* Overflow type. */
     int readonly = 1;
-    size_t highest_write_offset = 0;
+    uint64_t highest_write_offset = 0;
 
     for (j = 2; j < c->argc; j++) {
         int remargs = c->argc-j-1; /* Remaining args other than current. */

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -37,8 +37,8 @@
 /* Count number of bits set in the binary array pointed by 's' and long
  * 'count' bytes. The implementation of this function is required to
  * work with an input string length up to 512 MB or more (server.proto_max_bulk_len) */
-size_t redisPopcount(void *s, long count) {
-    size_t bits = 0;
+long long redisPopcount(void *s, long count) {
+    long long bits = 0;
     unsigned char *p = s;
     uint32_t *p4;
     static const unsigned char bitsinbyte[256] = {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,1,2,2,3,2,3,3,4,2,3,3,4,3,4,4,5,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,2,3,3,4,3,4,4,5,3,4,4,5,4,5,5,6,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,3,4,4,5,4,5,5,6,4,5,5,6,5,6,6,7,4,5,5,6,5,6,6,7,5,6,6,7,6,7,7,8};
@@ -98,11 +98,11 @@ size_t redisPopcount(void *s, long count) {
  * no zero bit is found, it returns count*8 assuming the string is zero
  * padded on the right. However if 'bit' is 1 it is possible that there is
  * not a single set bit in the bitmap. In this special case -1 is returned. */
-long redisBitpos(void *s, unsigned long count, int bit) {
+long long redisBitpos(void *s, unsigned long count, int bit) {
     unsigned long *l;
     unsigned char *c;
     unsigned long skipval, word = 0, one;
-    long pos = 0; /* Position of bit, to return to the caller. */
+    long long pos = 0; /* Position of bit, to return to the caller. */
     unsigned long j;
     int found;
 
@@ -888,7 +888,7 @@ void bitposCommand(client *c) {
         addReplyLongLong(c, -1);
     } else {
         long bytes = end-start+1;
-        long pos = redisBitpos(p+start,bytes,bit);
+        long long pos = redisBitpos(p+start,bytes,bit);
 
         /* If we are looking for clear bits, and the user specified an exact
          * range with start-end, we can't consider the right of the range as

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -897,11 +897,11 @@ void bitposCommand(client *c) {
          * So if redisBitpos() returns the first bit outside the range,
          * we return -1 to the caller, to mean, in the specified range there
          * is not a single "0" bit. */
-        if (end_given && bit == 0 && pos == bytes*8) {
+        if (end_given && bit == 0 && pos == (long long)bytes<<3) {
             addReplyLongLong(c,-1);
             return;
         }
-        if (pos != -1) pos += start*8; /* Adjust for the bytes we skipped. */
+        if (pos != -1) pos += (long long)start<<3; /* Adjust for the bytes we skipped. */
         addReplyLongLong(c,pos);
     }
 }

--- a/src/server.h
+++ b/src/server.h
@@ -1845,7 +1845,7 @@ void getRandomHexChars(char *p, size_t len);
 void getRandomBytes(unsigned char *p, size_t len);
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
 void exitFromChild(int retcode);
-size_t redisPopcount(void *s, long count);
+long long redisPopcount(void *s, long count);
 int redisSetProcTitle(char *title);
 int validateProcTitleTemplate(const char *template);
 int redisCommunicateSystemd(const char *sd_notify_msg);

--- a/tests/unit/bitops.tcl
+++ b/tests/unit/bitops.tcl
@@ -355,17 +355,23 @@ start_server {tags {"bitops"}} {
         set oldval [lindex [r config get proto-max-bulk-len] 1]
         r config set proto-max-bulk-len $bytes
         r setbit mykey $bitpos 1
-        set len [r strlen mykey]
-        set bit [r getbit mykey $bitpos]
-        set fields [r bitfield mykey get u8 $bitpos set u8 $bitpos 255 get i8 $bitpos]
-        set pos1 [r bitpos mykey 1]
-        set pos2 [r bitpos mykey 1 [expr $bytes - 1]]
+        assert_equal $bytes [r strlen mykey]
+        assert_equal 1 [r getbit mykey $bitpos]
+        assert_equal [list 128 128 -1] [r bitfield mykey get u8 $bitpos set u8 $bitpos 255 get i8 $bitpos]
+        assert_equal $bitpos [r bitpos mykey 1]
+        assert_equal $bitpos [r bitpos mykey 1 [expr $bytes - 1]]
+        if {$::accurate} {
+            # set all bits to 1
+            set mega [expr (1 << 23)]
+            set part [string repeat "\xFF" $mega]
+            for {set i 0} {$i < 64} {incr i} {
+                r setrange mykey [expr $i * $mega] $part
+            }
+            r setrange mykey [expr $bytes - 1] "\xFF"
+            assert_equal [expr $bitpos + 8] [r bitcount mykey]
+            assert_equal -1 [r bitpos mykey 0 0 [expr $bytes - 1]]
+        }
         r config set proto-max-bulk-len $oldval
-        assert_equal $bytes $len
-        assert_equal 1 $bit
-        assert_equal [list 128 128 -1] $fields
-        assert_equal $bitpos $pos1
-        assert_equal $bitpos $pos2
         r del mykey
     } {1} {large-memory}
 }

--- a/tests/unit/bitops.tcl
+++ b/tests/unit/bitops.tcl
@@ -358,12 +358,14 @@ start_server {tags {"bitops"}} {
         set len [r strlen mykey]
         set bit [r getbit mykey $bitpos]
         set fields [r bitfield mykey get u8 $bitpos set u8 $bitpos 255 get i8 $bitpos]
-        set pos [r bitpos mykey 1]
+        set pos1 [r bitpos mykey 1]
+        set pos2 [r bitpos mykey 1 [expr $bytes - 1]]
         r config set proto-max-bulk-len $oldval
         assert_equal $bytes $len
         assert_equal 1 $bit
         assert_equal [list 128 128 -1] $fields
-        assert_equal $bitpos $pos
+        assert_equal $bitpos $pos1
+        assert_equal $bitpos $pos2
         r del mykey
     } {1} {large-memory}
 }

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -348,17 +348,6 @@ start_server {tags {"string"}} {
         assert_equal 0 [r getbit mykey 10000]
     }
 
-    test "GETBIT pos larger than UINT_MAX" {
-        r del mykey
-        r setbit mykey [expr (1 << 32) - 1] 1
-        set oldval [lindex [r config get proto-max-bulk-len] 1]
-        r config set proto-max-bulk-len [expr (1 << 29) + 1]
-        r append mykey "\xFF"
-        set res [r getbit mykey [expr (1 << 32)]]
-        r config set proto-max-bulk-len $oldval
-        assert_equal 1 $res
-    }
-
     test "SETRANGE against non-existing key" {
         r del mykey
         assert_equal 3 [r setrange mykey 0 foo]

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -348,6 +348,17 @@ start_server {tags {"string"}} {
         assert_equal 0 [r getbit mykey 10000]
     }
 
+    test "GETBIT pos larger than UINT_MAX" {
+        r del mykey
+        r setbit mykey [expr (1 << 32) - 1] 1
+        set oldval [lindex [r config get proto-max-bulk-len] 1]
+        r config set proto-max-bulk-len [expr (1 << 29) + 1]
+        r append mykey "\xFF"
+        set res [r getbit mykey [expr (1 << 32)]]
+        r config set proto-max-bulk-len $oldval
+        assert_equal 1 $res
+    }
+
     test "SETRANGE against non-existing key" {
         r del mykey
         assert_equal 3 [r setrange mykey 0 foo]


### PR DESCRIPTION
GETBIT, SETBIT may access wrong address because of wrap.
BITCOUNT and BITPOS may return wrapped results.
BITFIELD may access the wrong address but also allocate insufficient memory and segfault (see CVE-2021-32761).

This commit uses `uint64_t` or `long long` instead of `size_t`.
related https://github.com/redis/redis/pull/8096

At 32bit platform:
> setbit bit 4294967295 1
(integer) 0
> config set proto-max-bulk-len 536870913
OK
> append bit "\xFF"
(integer) 536870913
> getbit bit 4294967296
(integer) 0

When the bit index is larger than 4294967295, size_t can't hold bit index. In the past,  `proto-max-bulk-len` is limit to 536870912, so there is no problem.

After this commit, bit position is stored in `uint64_t` or `long long`. So when `proto-max-bulk-len > 536870912`, 32bit platforms can still be correct.

For 64bit platform, this problem still exists. The major reason is bit pos 8 times of byte pos. When proto-max-bulk-len is very larger, bit pos may overflow.
But at 64bit platform, we don't have so long string. So this bug may never happen.

Additionally this commit add a test cost `512MB` memory which is tag as `large-memory`. Make freebsd ci and valgrind ci ignore this test.