### PR TITLE
Tests: add a way to read raw RESP protocol reponses

### DIFF
--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -34,13 +34,14 @@ array set ::redis::fd {}
 array set ::redis::addr {}
 array set ::redis::blocking {}
 array set ::redis::deferred {}
+array set ::redis::readraw {}
 array set ::redis::reconnect {}
 array set ::redis::tls {}
 array set ::redis::callback {}
 array set ::redis::state {} ;# State in non-blocking reply reading
 array set ::redis::statestack {} ;# Stack of states, for nested mbulks
 
-proc redis {{server 127.0.0.1} {port 6379} {defer 0} {tls 0} {tlsoptions {}}} {
+proc redis {{server 127.0.0.1} {port 6379} {defer 0} {tls 0} {tlsoptions {}} {readraw 0}} {
     if {$tls} {
         package require tls
         ::tls::init \
@@ -58,6 +59,7 @@ proc redis {{server 127.0.0.1} {port 6379} {defer 0} {tls 0} {tlsoptions {}}} {
     set ::redis::addr($id) [list $server $port]
     set ::redis::blocking($id) 1
     set ::redis::deferred($id) $defer
+    set ::redis::readraw($id) $readraw
     set ::redis::reconnect($id) 0
     set ::redis::tls($id) $tls
     ::redis::redis_reset_state $id
@@ -158,6 +160,7 @@ proc ::redis::__method__close {id fd} {
     catch {unset ::redis::addr($id)}
     catch {unset ::redis::blocking($id)}
     catch {unset ::redis::deferred($id)}
+    catch {unset ::redis::readraw($id)}
     catch {unset ::redis::reconnect($id)}
     catch {unset ::redis::tls($id)}
     catch {unset ::redis::state($id)}
@@ -172,6 +175,10 @@ proc ::redis::__method__channel {id fd} {
 
 proc ::redis::__method__deferred {id fd val} {
     set ::redis::deferred($id) $val
+}
+
+proc ::redis::__method__readraw {id fd val} {
+    set ::redis::readraw($id) $val
 }
 
 proc ::redis::redis_write {fd buf} {
@@ -241,6 +248,10 @@ proc ::redis::redis_read_null fd {
 }
 
 proc ::redis::redis_read_reply {id fd} {
+    if {$::redis::readraw($id)} {
+        return [redis_read_line $fd]
+    }
+
     set type [read $fd 1]
     switch -exact -- $type {
         _ {redis_read_null $fd}

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -102,6 +102,40 @@ start_server {tags {"protocol network"}} {
         } {*Protocol error*}
     }
     unset c
+
+    # recover the broken connection
+    reconnect
+    r ping
+
+    # raw RESP response tests
+    r readraw 1
+
+    test "raw protocol response" {
+        r srandmember nonexisting_key
+    } {*-1}
+
+    r deferred 1
+
+    test "raw protocol response - deferred" {
+        r srandmember nonexisting_key
+        r read
+    } {*-1}
+
+    test "raw protocol response - multiline" {
+        r sadd ss a
+        assert_equal [r read] {:1}
+        r srandmember ss 100
+        assert_equal [r read] {*1}
+        assert_equal [r read] {$1}
+        assert_equal [r read] {a}
+    }
+
+    # restore connection settings
+    r readraw 0
+    r deferred 0
+
+    # check the connection still works
+    assert_equal [r ping] {PONG}
 }
 
 start_server {tags {"regression"}} {


### PR DESCRIPTION
This makes it possible to distinguish between null response and an empty
array (currently the tests infra translates both to an empty string/list)