### PR TITLE
Fail Exec command in case a watched key is expired

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -355,7 +355,7 @@ int isWatchedKeyExpired(client *c) {
     watchedKey *wk;
     if (listLength(c->watched_keys) == 0) return 0;
     listRewind(c->watched_keys,&li);
-    while((ln = listNext(&li))) {
+    while ((ln = listNext(&li))) {
         wk = listNodeValue(ln);
         if (keyIsExpired(wk->db, wk->key)) return 1;
     }

--- a/src/multi.c
+++ b/src/multi.c
@@ -168,6 +168,11 @@ void execCommand(client *c) {
         return;
     }
 
+    /* EXEC with expired watched key is disallowed*/
+    if (isWatchedKeyExpired(c)) {
+        c->flags |= (CLIENT_DIRTY_CAS);
+    }
+
     /* Check if we need to abort the EXEC because:
      * 1) Some WATCHed key was touched.
      * 2) There was a previous error while queueing commands.
@@ -340,6 +345,22 @@ void unwatchAllKeys(client *c) {
         decrRefCount(wk->key);
         zfree(wk);
     }
+}
+
+/* iterates over the watched_keys list and
+ * look for an expired key . */
+int isWatchedKeyExpired(client *c) {
+    listIter li;
+    listNode *ln;
+    watchedKey *wk;
+    if (listLength(c->watched_keys) == 0) return 0;
+    listRewind(c->watched_keys,&li);
+    while((ln = listNext(&li))) {
+        wk = listNodeValue(ln);
+        if (keyIsExpired(wk->db, wk->key)) return 1;
+    }
+
+    return 0;
 }
 
 /* "Touch" a key, so that if this key is being WATCHed by some client the

--- a/src/server.c
+++ b/src/server.c
@@ -1930,6 +1930,12 @@ void databasesCron(void) {
  * such info only when calling this function from serverCron() but not when
  * calling it from call(). */
 void updateCachedTime(int update_daylight_info) {
+    /* In case we have nested calls we want to
+     * update only on the first call*/
+    if (server.fixed_time_expire == 1) {
+        return;
+    }
+
     server.ustime = ustime();
     server.mstime = server.ustime / 1000;
     time_t unixtime = server.mstime / 1000;
@@ -3716,7 +3722,9 @@ void call(client *c, int flags) {
     /* Call the command. */
     dirty = server.dirty;
     prev_err_count = server.stat_total_error_replies;
+
     updateCachedTime(0);
+
     elapsedStart(&call_timer);
     c->cmd->proc(c);
     const long duration = elapsedUs(call_timer);

--- a/src/server.h
+++ b/src/server.h
@@ -1980,6 +1980,7 @@ void initClientMultiState(client *c);
 void freeClientMultiState(client *c);
 void queueMultiCommand(client *c);
 void touchWatchedKey(redisDb *db, robj *key);
+int isWatchedKeyExpired(client *c);
 void touchAllWatchedKeysInDb(redisDb *emptied, redisDb *replaced_with);
 void discardTransaction(client *c);
 void flagTransaction(client *c);
@@ -2354,6 +2355,7 @@ void initConfigValues();
 /* db.c -- Keyspace access API */
 int removeExpire(redisDb *db, robj *key);
 void propagateExpire(redisDb *db, robj *key, int lazy);
+int keyIsExpired(redisDb *db, robj *key);
 int expireIfNeeded(redisDb *db, robj *key);
 long long getExpire(redisDb *db, robj *key);
 void setExpire(client *c, redisDb *db, robj *key, long long when);

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -131,6 +131,22 @@ start_server {tags {"multi"}} {
         r exec
     } {} {cluster:skip}
 
+    test {EXEC fail on lazy expired WATCHed key} {
+        r flushall
+        r debug set-active-expire 0
+
+        r del key
+        r set key 1 px 2
+        r watch key
+
+        after 100
+
+        r multi
+        r incr key
+        r exec
+        r debug set-active-expire 1
+    } {}
+
     test {After successful EXEC key is no longer watched} {
         r set x 30
         r watch x

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -145,7 +145,7 @@ start_server {tags {"multi"}} {
         r incr key
         assert_equal [r exec] {}
         r debug set-active-expire 1
-    } {OK}
+    } {OK} {needs:debug}
 
     test {After successful EXEC key is no longer watched} {
         r set x 30

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -143,9 +143,9 @@ start_server {tags {"multi"}} {
 
         r multi
         r incr key
-        r exec
+        assert_equal [r exec] {}
         r debug set-active-expire 1
-    } {}
+    } {OK}
 
     test {After successful EXEC key is no longer watched} {
         r set x 30


### PR DESCRIPTION
There are two issues fixed in this Pr: 
1) fixing issue #9068, we want to fail the EXEC command in case there is a watched key that's logically expired but not yet deleted by active expire or lazy expire.

2) we saw that currently cache time is update in every call, this time is being also being use for the isKeyExpired comparison, we in case of a nested call, we want to update the cache time only in the first call (execCommand)