### PR TITLE
Add range check for master port in REPLICAOF.

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2777,7 +2777,8 @@ void replicaofCommand(client *c) {
             return;
         }
 
-        if ((getLongFromObjectOrReply(c, c->argv[2], &port, NULL) != C_OK))
+        if (getRangeLongFromObjectOrReply(c, c->argv[2], 0, 65535, &port,
+                                          "Invalid master port") != C_OK)
             return;
 
         /* Check if we are already attached to the specified master */


### PR DESCRIPTION
So that we can avoid commands that are obviously wrong.

Also unified with loadServerConfigFromString
because we also checked the range.

Minor cleanup...

Before:
```
127.0.0.1:6379> replicaof 127.0.0.1 65536
OK
127.0.0.1:6379> replicaof 127.0.0.1 -1111
OK
```

After:
```
127.0.0.1:6379> replicaof 127.0.0.1 -1
(error) ERR Invalid master port
127.0.0.1:6379> replicaof 127.0.0.1 -111
(error) ERR Invalid master port
127.0.0.1:6379> replicaof 127.0.0.1 65536
(error) ERR Invalid master port
```

loadServerConfigFromString:
```c
        } else if ((!strcasecmp(argv[0],"slaveof") ||
                    !strcasecmp(argv[0],"replicaof")) && argc == 3) {
            slaveof_linenum = linenum;
            sdsfree(server.masterhost);
            if (!strcasecmp(argv[1], "no") && !strcasecmp(argv[2], "one")) {
                server.masterhost = NULL;
                continue;
            }
            server.masterhost = sdsnew(argv[1]);
            char *ptr;
            server.masterport = strtol(argv[2], &ptr, 10);
            if (server.masterport < 0 || server.masterport > 65535 || *ptr != '\0') {
                err = "Invalid master port"; goto loaderr;
            }
            server.repl_state = REPL_STATE_CONNECT;
```
