### PR TITLE
Add select to the category @Read

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -652,7 +652,7 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,0,0,0,0,0,0},
 
     {"select",selectCommand,2,
-     "ok-loading fast ok-stale @keyspace",
+     "read-only ok-loading fast ok-stale @keyspace",
      0,NULL,0,0,0,0,0,0},
 
     {"swapdb",swapdbCommand,3,


### PR DESCRIPTION
Without the permission of select for @Read, I can only read the data of db0, not other db. @Read should be able to read all DB permissions, so add read-only for select.



