### PR TITLE
Fix ACL category for SELECT, WAIT, ROLE, LASTSAVE, READONLY, READWRITE, ASKING

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -883,6 +883,40 @@ replica-priority 100
 #
 # Basically ACL rules are processed left-to-right.
 #
+# The following is a list of command categories and their meanings:
+# * keyspace - Writing or reading from keyspace, keys or their metadata but not
+#     a certain data type. Includes DEL, RESTORE, DUMP, RENAME, EXISTS, DBSIZE,
+#     KEYS, EXPIRE, TTL, FLUSHALL, etc. Commands that may modify the keyspace,
+#     key or metadata will also have `write` category. Commands that only read
+#     the keyspace, key or medatada will have the `read` category.
+# * read - Reading from keys (values or metadata). Note that commands that don't
+#     interact with keys, will not have either `read` or `write`.
+# * write - Writing to keys (values or metadata)
+# * admin - Administrative commands. Normal applications will never need to use
+#     these. Includes REPLICAOF, CONFIG, DEBUG, SAVE, MONITOR, ACL, SHUTDOWN, etc.
+# * dangerous - Potentially dangerous (each should be considered with care for
+#     various reasons). This includes FLUSHALL, MIGRATE, RESTORE, SORT, KEYS,
+#     CLIENT, DEBUG, INFO, CONFIG, SAVE, REPLICAOF, etc.
+# * connection - Commands affecting the connection or other connections.
+#     This includes AUTH, SELECT, COMMAND, CLIENT, ECHO, PING, etc.
+# * blocking - Potentially blocking the connection until released by aonther
+#   command.
+# * fast - Fast O(1) commands. May loop on the number of arguments, but not the
+#     number of elements in the key.
+# * slow - All commands that are not Fast.
+# * pubsub - PUBLISH / SUBSCRIBE related
+# * transaction - WATCH / MULTI / EXEC related commands.
+# * scripting - Scripting related.
+# * set - Data type: sets related.
+# * sortedset - Data type: zsets related.
+# * list - Data type: lists related.
+# * hash - Data type: hashes related.
+# * string - Data type: strings related.
+# * bitmap - Data type: bitmaps related.
+# * hyperloglog - Data type: hyperloglog related.
+# * geo - Data type: geo related.
+# * stream - Data type: streams related.
+#
 # For more information about ACL configuration please refer to
 # the Redis web site at https://redis.io/topics/acl
 

--- a/redis.conf
+++ b/redis.conf
@@ -884,11 +884,11 @@ replica-priority 100
 # Basically ACL rules are processed left-to-right.
 #
 # The following is a list of command categories and their meanings:
-# * keyspace - Writing or reading from keyspace, keys or their metadata but not
-#     a certain data type. Includes DEL, RESTORE, DUMP, RENAME, EXISTS, DBSIZE,
+# * keyspace - Writing or reading from keys, databases, or their metadata 
+#     in a type agnostic way. Includes DEL, RESTORE, DUMP, RENAME, EXISTS, DBSIZE,
 #     KEYS, EXPIRE, TTL, FLUSHALL, etc. Commands that may modify the keyspace,
 #     key or metadata will also have `write` category. Commands that only read
-#     the keyspace, key or medatada will have the `read` category.
+#     the keyspace, key or metadata will have the `read` category.
 # * read - Reading from keys (values or metadata). Note that commands that don't
 #     interact with keys, will not have either `read` or `write`.
 # * write - Writing to keys (values or metadata)

--- a/redis.conf
+++ b/redis.conf
@@ -900,7 +900,7 @@ replica-priority 100
 # * connection - Commands affecting the connection or other connections.
 #     This includes AUTH, SELECT, COMMAND, CLIENT, ECHO, PING, etc.
 # * blocking - Potentially blocking the connection until released by aonther
-#   command.
+#     command.
 # * fast - Fast O(1) commands. May loop on the number of arguments, but not the
 #     number of elements in the key.
 # * slow - All commands that are not Fast.

--- a/redis.conf
+++ b/redis.conf
@@ -899,7 +899,7 @@ replica-priority 100
 #     CLIENT, DEBUG, INFO, CONFIG, SAVE, REPLICAOF, etc.
 # * connection - Commands affecting the connection or other connections.
 #     This includes AUTH, SELECT, COMMAND, CLIENT, ECHO, PING, etc.
-# * blocking - Potentially blocking the connection until released by aonther
+# * blocking - Potentially blocking the connection until released by another
 #     command.
 # * fast - Fast O(1) commands. May loop on the number of arguments, but not the
 #     number of elements in the key.

--- a/src/acl.c
+++ b/src/acl.c
@@ -60,35 +60,28 @@ static unsigned long nextid = 0; /* Next command id that has not been assigned *
 struct ACLCategoryItem {
     const char *name;
     uint64_t flag;
-} ACLCommandCategories[] = {
-    {"keyspace", CMD_CATEGORY_KEYSPACE},   /* Writing or reading from keyspace, keys or their metadata but not a certain data type.
-                                            * Includes DEL, RESTORE, DUMP, RENAME, EXISTS, DBSIZE, KEYS, EXPIRE, TTL, FLUSHALL, etc.
-                                            * Commands that may modify the keyspace, key or metadata will also have `write` category.
-                                            * Commands that only read the keyspace, key or medatada will have the `read` category. */
-    {"read", CMD_CATEGORY_READ},           /* Reading from keys (values or metadata).
-                                            * Note that commands that don't interact with keys, will not have either `read` or `write`. */
-    {"write", CMD_CATEGORY_WRITE},         /* Writing to keys (values or metadata) */
-    {"set", CMD_CATEGORY_SET},             /* Data type: sets related. */
-    {"sortedset", CMD_CATEGORY_SORTEDSET}, /* Data type: zsets related. */
-    {"list", CMD_CATEGORY_LIST},           /* Data type: lists related. */
-    {"hash", CMD_CATEGORY_HASH},           /* Data type: hashes related. */
-    {"string", CMD_CATEGORY_STRING},       /* Data type: strings related. */
-    {"bitmap", CMD_CATEGORY_BITMAP},       /* Data type: bitmaps related. */
-    {"hyperloglog", CMD_CATEGORY_HYPERLOGLOG}, /* Data type: HLL related. */
-    {"geo", CMD_CATEGORY_GEO},             /* Data type: geo related. */
-    {"stream", CMD_CATEGORY_STREAM},       /* Data type: streams related. */
-    {"pubsub", CMD_CATEGORY_PUBSUB},       /* PUBLISH / SUBSCRIBE related */
-    {"admin", CMD_CATEGORY_ADMIN},         /* Administrative commands (Normal applications will never need to use these).
-                                            * Includes REPLICAOF, CONFIG, DEBUG, SAVE, MONITOR, ACL, SHUTDOWN, etc. */
-    {"fast", CMD_CATEGORY_FAST},           /* Fast O(1) commands. (May loop on the number of arguments, but not the number of elements in the key). */
-    {"slow", CMD_CATEGORY_SLOW},           /* All commands that are not Fast. */
-    {"blocking", CMD_CATEGORY_BLOCKING},   /* Potentially blocking the connectoin. */
-    {"dangerous", CMD_CATEGORY_DANGEROUS}, /* Potentially dangerous (each should be considered with care for various reasons).
-                                            * This includes FLUSHALL, MIGRATE, RESTORE, SORT, KEYS, CLIENT, DEBUG, INFO, CONFIG, SAVE, REPLICAOF, etc. */
-    {"connection", CMD_CATEGORY_CONNECTION}, /* Commands affecting the connection or other connections.
-                                              * This includes AUTH, SELECT, COMMAND, CLIENT, ECHO, PING, etc. */
-    {"transaction", CMD_CATEGORY_TRANSACTION}, /* WATCH / MULTI / EXEC related commands. */
-    {"scripting", CMD_CATEGORY_SCRIPTING}, /* Scripting related. */
+} ACLCommandCategories[] = { /* See redis.conf for details on each category. */
+    {"keyspace", CMD_CATEGORY_KEYSPACE},
+    {"read", CMD_CATEGORY_READ},
+    {"write", CMD_CATEGORY_WRITE},
+    {"set", CMD_CATEGORY_SET},
+    {"sortedset", CMD_CATEGORY_SORTEDSET},
+    {"list", CMD_CATEGORY_LIST},
+    {"hash", CMD_CATEGORY_HASH},
+    {"string", CMD_CATEGORY_STRING},
+    {"bitmap", CMD_CATEGORY_BITMAP},
+    {"hyperloglog", CMD_CATEGORY_HYPERLOGLOG},
+    {"geo", CMD_CATEGORY_GEO},
+    {"stream", CMD_CATEGORY_STREAM},
+    {"pubsub", CMD_CATEGORY_PUBSUB},
+    {"admin", CMD_CATEGORY_ADMIN},
+    {"fast", CMD_CATEGORY_FAST},
+    {"slow", CMD_CATEGORY_SLOW},
+    {"blocking", CMD_CATEGORY_BLOCKING},
+    {"dangerous", CMD_CATEGORY_DANGEROUS},
+    {"connection", CMD_CATEGORY_CONNECTION},
+    {"transaction", CMD_CATEGORY_TRANSACTION},
+    {"scripting", CMD_CATEGORY_SCRIPTING},
     {NULL,0} /* Terminator. */
 };
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -61,27 +61,34 @@ struct ACLCategoryItem {
     const char *name;
     uint64_t flag;
 } ACLCommandCategories[] = {
-    {"keyspace", CMD_CATEGORY_KEYSPACE},
-    {"read", CMD_CATEGORY_READ},
-    {"write", CMD_CATEGORY_WRITE},
-    {"set", CMD_CATEGORY_SET},
-    {"sortedset", CMD_CATEGORY_SORTEDSET},
-    {"list", CMD_CATEGORY_LIST},
-    {"hash", CMD_CATEGORY_HASH},
-    {"string", CMD_CATEGORY_STRING},
-    {"bitmap", CMD_CATEGORY_BITMAP},
-    {"hyperloglog", CMD_CATEGORY_HYPERLOGLOG},
-    {"geo", CMD_CATEGORY_GEO},
-    {"stream", CMD_CATEGORY_STREAM},
-    {"pubsub", CMD_CATEGORY_PUBSUB},
-    {"admin", CMD_CATEGORY_ADMIN},
-    {"fast", CMD_CATEGORY_FAST},
-    {"slow", CMD_CATEGORY_SLOW},
-    {"blocking", CMD_CATEGORY_BLOCKING},
-    {"dangerous", CMD_CATEGORY_DANGEROUS},
-    {"connection", CMD_CATEGORY_CONNECTION},
-    {"transaction", CMD_CATEGORY_TRANSACTION},
-    {"scripting", CMD_CATEGORY_SCRIPTING},
+    {"keyspace", CMD_CATEGORY_KEYSPACE},   /* Writing or reading from keyspace, keys or their metadata but not a certain data type.
+                                            * Includes DEL, RESTORE, DUMP, RENAME, EXIST, DBSIZE, KEYS, EXPIRE, TTL, FLUSHALL, etc.
+                                            * Commands that may modify the keyspace, key or metadata will also have `write` category.
+                                            * Commands that only read the keyspace, key or medatada will have the `read` category. */
+    {"read", CMD_CATEGORY_READ},           /* Reading from keys (values or metadata).
+                                            * Note that commands that don't interact with keys, will not have either `read` or `write`. */
+    {"write", CMD_CATEGORY_WRITE},         /* Writing to keys (values or metadata) */
+    {"set", CMD_CATEGORY_SET},             /* Data type: sets related. */
+    {"sortedset", CMD_CATEGORY_SORTEDSET}, /* Data type: zsets related. */
+    {"list", CMD_CATEGORY_LIST},           /* Data type: lists related. */
+    {"hash", CMD_CATEGORY_HASH},           /* Data type: hashes related. */
+    {"string", CMD_CATEGORY_STRING},       /* Data type: strings related. */
+    {"bitmap", CMD_CATEGORY_BITMAP},       /* Data type: bitmaps related. */
+    {"hyperloglog", CMD_CATEGORY_HYPERLOGLOG}, /* Data type: HLL related. */
+    {"geo", CMD_CATEGORY_GEO},             /* Data type: geo related. */
+    {"stream", CMD_CATEGORY_STREAM},       /* Data type: streams related. */
+    {"pubsub", CMD_CATEGORY_PUBSUB},       /* PUBLISH / SUBSCRIBE related */
+    {"admin", CMD_CATEGORY_ADMIN},         /* Administrative comands (Normal applications will never need to use these.
+                                            * Includes REPLICAOF, CONFIG, DEBUG, SAVE, MONITOR, ACL, SHUTDOWN, etc. */
+    {"fast", CMD_CATEGORY_FAST},           /* Fast O(1) commands. */
+    {"slow", CMD_CATEGORY_SLOW},           /* All commands that are not Fast. */
+    {"blocking", CMD_CATEGORY_BLOCKING},   /* Potentially blocking the connectoin. */
+    {"dangerous", CMD_CATEGORY_DANGEROUS}, /* Potentially dangerous (each should be considered with care for various reasons).
+                                            * This includes FLUSHALL, MIGRATE, RESTORE, SORT, KEYS, CLIENT, DEBUG, INFO, CONFIG, SAVE, REPLICAOF, etc. */
+    {"connection", CMD_CATEGORY_CONNECTION}, /* Commands affecting the connection or other connections.
+                                              * This includes AUTH, SELECT, COMMAND, CLIENT, ECHO, PING, etc. */
+    {"transaction", CMD_CATEGORY_TRANSACTION}, /* WATCH / MULTI / EXEC related commands. */
+    {"scripting", CMD_CATEGORY_SCRIPTING}, /* Scripting related. */
     {NULL,0} /* Terminator. */
 };
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -62,7 +62,7 @@ struct ACLCategoryItem {
     uint64_t flag;
 } ACLCommandCategories[] = {
     {"keyspace", CMD_CATEGORY_KEYSPACE},   /* Writing or reading from keyspace, keys or their metadata but not a certain data type.
-                                            * Includes DEL, RESTORE, DUMP, RENAME, EXIST, DBSIZE, KEYS, EXPIRE, TTL, FLUSHALL, etc.
+                                            * Includes DEL, RESTORE, DUMP, RENAME, EXISTS, DBSIZE, KEYS, EXPIRE, TTL, FLUSHALL, etc.
                                             * Commands that may modify the keyspace, key or metadata will also have `write` category.
                                             * Commands that only read the keyspace, key or medatada will have the `read` category. */
     {"read", CMD_CATEGORY_READ},           /* Reading from keys (values or metadata).
@@ -78,9 +78,9 @@ struct ACLCategoryItem {
     {"geo", CMD_CATEGORY_GEO},             /* Data type: geo related. */
     {"stream", CMD_CATEGORY_STREAM},       /* Data type: streams related. */
     {"pubsub", CMD_CATEGORY_PUBSUB},       /* PUBLISH / SUBSCRIBE related */
-    {"admin", CMD_CATEGORY_ADMIN},         /* Administrative comands (Normal applications will never need to use these.
+    {"admin", CMD_CATEGORY_ADMIN},         /* Administrative commands (Normal applications will never need to use these).
                                             * Includes REPLICAOF, CONFIG, DEBUG, SAVE, MONITOR, ACL, SHUTDOWN, etc. */
-    {"fast", CMD_CATEGORY_FAST},           /* Fast O(1) commands. */
+    {"fast", CMD_CATEGORY_FAST},           /* Fast O(1) commands. (May loop on the number of arguments, but not the number of elements in the key). */
     {"slow", CMD_CATEGORY_SLOW},           /* All commands that are not Fast. */
     {"blocking", CMD_CATEGORY_BLOCKING},   /* Potentially blocking the connectoin. */
     {"dangerous", CMD_CATEGORY_DANGEROUS}, /* Potentially dangerous (each should be considered with care for various reasons).

--- a/src/server.c
+++ b/src/server.c
@@ -173,6 +173,7 @@ struct redisServer server; /* Server global state */
  *
  * The following additional flags are only used in order to put commands
  * in a specific ACL category. Commands can have multiple ACL categories.
+ * Refer to acl.c for the exact meaning of each.
  *
  * @keyspace, @read, @write, @set, @sortedset, @list, @hash, @string, @bitmap,
  * @hyperloglog, @stream, @admin, @fast, @slow, @pubsub, @blocking, @dangerous,
@@ -793,7 +794,7 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,1,1,1,0,0,0},
 
     {"touch",touchCommand,-2,
-     "read-only fast @keyspace",
+     "write fast @keyspace",
      0,NULL,1,-1,1,0,0,0},
 
     {"pttl",pttlCommand,2,
@@ -821,7 +822,7 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,0,0,0,0,0,0},
 
     {"role",roleCommand,1,
-     "ok-loading ok-stale no-script fast @dangerous",
+     "ok-loading ok-stale no-script fast @admin @dangerous",
      0,NULL,0,0,0,0,0,0},
 
     {"debug",debugCommand,-2,

--- a/src/server.c
+++ b/src/server.c
@@ -794,7 +794,7 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,1,1,1,0,0,0},
 
     {"touch",touchCommand,-2,
-     "write fast @keyspace",
+     "read-only fast @keyspace",
      0,NULL,1,-1,1,0,0,0},
 
     {"pttl",pttlCommand,2,

--- a/src/server.c
+++ b/src/server.c
@@ -881,15 +881,15 @@ struct redisCommand redisCommandTable[] = {
      0,migrateGetKeys,0,0,0,0,0,0},
 
     {"asking",askingCommand,1,
-     "fast @keyspace",
+     "fast @connection",
      0,NULL,0,0,0,0,0,0},
 
     {"readonly",readonlyCommand,1,
-     "fast @keyspace",
+     "fast @connection",
      0,NULL,0,0,0,0,0,0},
 
     {"readwrite",readwriteCommand,1,
-     "fast @keyspace",
+     "fast @connection",
      0,NULL,0,0,0,0,0,0},
 
     {"dump",dumpCommand,2,

--- a/src/server.c
+++ b/src/server.c
@@ -652,7 +652,7 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,0,0,0,0,0,0},
 
     {"select",selectCommand,2,
-     "ok-loading fast ok-stale @keyspace",
+     "ok-loading fast ok-stale @connection",
      0,NULL,0,0,0,0,0,0},
 
     {"swapdb",swapdbCommand,3,
@@ -959,7 +959,7 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,1,1,1,0,0,0},
 
     {"wait",waitCommand,3,
-     "no-script @keyspace",
+     "no-script @connection",
      0,NULL,0,0,0,0,0,0},
 
     {"command",commandCommand,-1,

--- a/src/server.c
+++ b/src/server.c
@@ -173,7 +173,7 @@ struct redisServer server; /* Server global state */
  *
  * The following additional flags are only used in order to put commands
  * in a specific ACL category. Commands can have multiple ACL categories.
- * Refer to acl.c for the exact meaning of each.
+ * See redis.conf for the exact meaning of each.
  *
  * @keyspace, @read, @write, @set, @sortedset, @list, @hash, @string, @bitmap,
  * @hyperloglog, @stream, @admin, @fast, @slow, @pubsub, @blocking, @dangerous,


### PR DESCRIPTION
- SELECT and WAIT don't read or write from the keyspace (unlike DEL, EXISTS, EXPIRE, DBSIZE, KEYS, etc).
they're more similar to AUTH and HELLO (and maybe PING and COMMAND).
they only affect the current connection, not the server state, so they should be `@connection`, not `@keyspace`

- ROLE, like LASTSAVE is `@admin` (and `@dangerous` like INFO) 

- ASKING, READONLY, READWRITE are `@connection` too (not `@keyspace`)

- Additionally, i'm now documenting the exact meaning of each ACL category so it's clearer which commands belong where.