### PR TITLE
Add a test verifying PUBSUB NUMPAT output

### DIFF
--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -158,6 +158,24 @@ start_server {tags {"pubsub network"}} {
         r pubsub numsub abc def
     } {abc 0 def 0}
 
+    test "NUMPATs returns the number of unique patterns" {
+        set rd1 [redis_deferring_client]
+        set rd2 [redis_deferring_client]
+
+        # Three unique patterns and one that overlaps
+        psubscribe $rd1 "foo*"
+        psubscribe $rd2 "foo*"
+        psubscribe $rd1 "bar*"
+        psubscribe $rd2 "baz*"
+
+        set patterns [r pubsub numpat]
+
+        # clean up clients
+        punsubscribe $rd1
+        punsubscribe $rd2
+        assert_equal 3 $patterns
+    }
+
     test "Mix SUBSCRIBE and PSUBSCRIBE" {
         set rd1 [redis_deferring_client]
         assert_equal {1} [subscribe $rd1 {foo.bar}]


### PR DESCRIPTION
Someone mentioned on https://github.com/redis/redis/pull/4721 that the guarantees for pub-sub pattern matching changed in v6.2, previously it was the total number of pattern subscriptions but it became the total number patterns in https://github.com/redis/redis/pull/8472. This change is just codifying that change and we will explicitly mention it in the release notes.