### PR TITLE
Adds consumer group constraints to stream trimming

### DIFF
--- a/src/stream.h
+++ b/src/stream.h
@@ -17,7 +17,11 @@ typedef struct stream {
     rax *rax;               /* The radix tree holding the stream. */
     uint64_t length;        /* Number of elements inside this stream. */
     streamID last_id;       /* Zero if there are yet no items. */
+    streamID pels_min_id;   /* Same, holds the minimal ID from all PELs. */
+    streamID lasts_min_id;  /* Same same, but for all CGs' last delivered ID. */
     rax *cgroups;           /* Consumer groups dictionary: name -> streamCG */
+    rax *cgpels;            /* A reference count dict of minimal PEL IDs. */
+    rax *cglasts;           /* A reference count dict of last delivered IDs. */
 } stream;
 
 /* We define an iterator to iterate stream items in an abstract way, without

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -482,22 +482,22 @@ start_server {
         r XDEL x 103
 
         set reply [r XINFO STREAM x FULL]
-        assert_equal [llength $reply] 12
+        assert_equal [llength $reply] 16
         assert_equal [lindex $reply 1] 4 ;# stream length
-        assert_equal [lindex $reply 9] "{100-0 {a 1}} {101-0 {b 1}} {102-0 {c 1}} {104-0 {f 1}}" ;# entries
-        assert_equal [lindex $reply 11 0 1] "g1" ;# first group name
-        assert_equal [lindex $reply 11 0 7 0 0] "100-0" ;# first entry in group's PEL
-        assert_equal [lindex $reply 11 0 9 0 1] "Alice" ;# first consumer
-        assert_equal [lindex $reply 11 0 9 0 7 0 0] "100-0" ;# first entry in first consumer's PEL
-        assert_equal [lindex $reply 11 1 1] "g2" ;# second group name
-        assert_equal [lindex $reply 11 1 9 0 1] "Charlie" ;# first consumer
-        assert_equal [lindex $reply 11 1 9 0 7 0 0] "100-0" ;# first entry in first consumer's PEL
-        assert_equal [lindex $reply 11 1 9 0 7 1 0] "101-0" ;# second entry in first consumer's PEL
+        assert_equal [lindex $reply 13] "{100-0 {a 1}} {101-0 {b 1}} {102-0 {c 1}} {104-0 {f 1}}" ;# entries
+        assert_equal [lindex $reply 15 0 1] "g1" ;# first group name
+        assert_equal [lindex $reply 15 0 7 0 0] "100-0" ;# first entry in group's PEL
+        assert_equal [lindex $reply 15 0 9 0 1] "Alice" ;# first consumer
+        assert_equal [lindex $reply 15 0 9 0 7 0 0] "100-0" ;# first entry in first consumer's PEL
+        assert_equal [lindex $reply 15 1 1] "g2" ;# second group name
+        assert_equal [lindex $reply 15 1 9 0 1] "Charlie" ;# first consumer
+        assert_equal [lindex $reply 15 1 9 0 7 0 0] "100-0" ;# first entry in first consumer's PEL
+        assert_equal [lindex $reply 15 1 9 0 7 1 0] "101-0" ;# second entry in first consumer's PEL
 
         set reply [r XINFO STREAM x FULL COUNT 1]
-        assert_equal [llength $reply] 12
+        assert_equal [llength $reply] 16
         assert_equal [lindex $reply 1] 4
-        assert_equal [lindex $reply 9] "{100-0 {a 1}}"
+        assert_equal [lindex $reply 13] "{100-0 {a 1}}"
     }
 
     test {XGROUP CREATECONSUMER: create consumer if does not exist} {


### PR DESCRIPTION
## Overview

By design, trimming stream entries "always succeeds." However, in the context of Consumer Groups (CG), this type of maintenance becomes more delicate due to the presumably common need to preserve internal integrity.

This proposal is for adding opt-in constraints to the trim operation. These constraints prevent excessive trimming of entries that have weren't delivered and/or acknowledged by the CGs. Now that Redis supports the `MINID ... COUNT` arguments for trim operations, this becomes possible to implement.

## Implementation

Note: this is a WIP - currently it only implements the basics in order to validate the feature's importance/feasability.

### API

The proposed optional modifier `RESPECT <type>` extends the `MAXLEN` and `MINID` trimming policies. It applies both to `XTRIM` as well as `XADD`.

The `type` can be one of the following:

* `NONE` - is the default and means no constraints (current behavior)
* `PENDING` - is equivalent to using `MINID` with the minimal global PEL entry ID, and prevents trimming of entries that are pending
* `FUTURE` - is equivalent to using `MINID` with the incremented minimal last-delivered ID of all CGs. It prevents trimming of yet-to-be-delivered entries.
* `ALL` - means the minimal ID from `PENDING` and `FUTURE`

When the constraint is applied (excluding the `NONE` type), it takes precedence over the policy's threshold.

### Design

To support efficient lookups of minimal PEL/last-delivered IDs, we add two stream-level IDs and reference-counting raxes (a.k.a refrax). The first pair tracks the minimal PEL ID from all CGs and all PEL IDs. The second pair tracks the minimal last-delivered ID from all CGs. These provide an O(1) time lookup for their respective minimal IDs, at the expense of memory and O(logN) complexities in `XREADGROUP ... >` and `XACK`.

## Alternatives

A comparable workflow can be implemented with a Lua script (for atomicity) that calls `XINFO`, and then executes before `XADD/XTRIM` operation with the `MINID` implied by the constraints. However, there are several disadvantages with using a script, including human-introduced implementation bugs; lack of out-of-the-box solution; and performance, specifically in the context of `XADD` (volume-wise) and an O(n) scan of the CGs.

## TODO

- [ ] (reserved for future use)
- [ ] Get feedback regarding the feature's neccesity/exisiting issues refs
- [ ] Achieve nomenclature concensus
- [ ] Verify implementation sanity
- [x] See if we can skip allocations for reference counters by using the refrax's pointer
- [ ] Justify costs with benchmarks
- [ ] Implement the API
- [ ] Implement persistence/replication
- [ ] Testing
- [ ] Documentation