### PR TITLE
fix explanation of sha256

### DIFF
--- a/src/sha256.h
+++ b/src/sha256.h
@@ -3,7 +3,7 @@
 * Author:     Brad Conte (brad AT bradconte.com)
 * Copyright:
 * Disclaimer: This code is presented "as is" without any guarantees.
-* Details:    Defines the API for the corresponding SHA1 implementation.
+* Details:    Defines the API for the corresponding SHA256 implementation.
 *********************************************************************/
 
 #ifndef SHA256_H


### PR DESCRIPTION
The explanation of sha256.h is `Defines the API for the corresponding SHA1 implementation.`. But actually this file `Defines the API for the corresponding SHA256 implementation.`

So I fixed this.