### PR TITLE
Return -1 when connTLSWrite fails to write due to socket being closed

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -759,7 +759,7 @@ static int connTLSWrite(connection *conn_, const void *data, size_t data_len) {
             if (ssl_err == SSL_ERROR_ZERO_RETURN ||
                     ((ssl_err == SSL_ERROR_SYSCALL && !errno))) {
                 conn->c.state = CONN_STATE_CLOSED;
-                return 0;
+                return -1;
             } else {
                 conn->c.state = CONN_STATE_ERROR;
                 return -1;


### PR DESCRIPTION
This change ensures that if the connTLSWrite fails to write when the socket is closed,
it returns -1. This would ensure that the client is closed in writeClient function. This also makes the function more compliant with the POSIX write function.