### PR TITLE
[Fix]Memory leak in cluster

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1936,6 +1936,15 @@ int clusterProcessPacket(clusterLink *link) {
         if (!sender && type == CLUSTERMSG_TYPE_MEET)
             clusterProcessGossipSection(hdr,link);
 
+	if (sender && type == CLUSTERMSG_TYPE_PING && link->node == NULL){
+            link->node = sender;
+            if(sender->link_from) {
+                sender->link_from->node = NULL;
+                freeClusterLink(sender->link_from);
+            }
+            sender->link_from = link;
+        }
+
         /* Anyway reply with a PONG */
         clusterSendPing(link,CLUSTERMSG_TYPE_PONG);
     }


### PR DESCRIPTION
For example, A and B are two nodes in a cluster.

When A is partitioned away, B will free the "struct clusterLink" which is used for send ping to A. But the corresponding "struct clusterLink" in A won't be freed.
 
When partition heals, B uses a new clusterLink to send ping to A and A will create another new corresponding clusterLink. The older "struct clusterLink" above is still in the memory.