### PR TITLE
Set TCP keepalive on inbound clusterbus connections

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1935,6 +1935,15 @@ int clusterProcessPacket(clusterLink *link) {
          * of the message type. */
         if (!sender && type == CLUSTERMSG_TYPE_MEET)
             clusterProcessGossipSection(hdr,link);
+	    
+	if (sender && type == CLUSTERMSG_TYPE_PING && link->node == NULL){
+            link->node = sender;
+            if(sender->link_from) {
+                sender->link_from->node = NULL;
+                freeClusterLink(sender->link_from);
+            }
+            sender->link_from = link;
+        }
 
         /* Anyway reply with a PONG */
         clusterSendPing(link,CLUSTERMSG_TYPE_PONG);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1936,15 +1936,6 @@ int clusterProcessPacket(clusterLink *link) {
          * of the message type. */
         if (!sender && type == CLUSTERMSG_TYPE_MEET)
             clusterProcessGossipSection(hdr,link);
-	    
-        if (sender && type == CLUSTERMSG_TYPE_PING && link->node == NULL) {
-            link->node = sender;
-            if (sender->link_from) {
-                sender->link_from->node = NULL;
-                freeClusterLink(sender->link_from);
-            }
-            sender->link_from = link;
-        }
 
         /* Anyway reply with a PONG */
         clusterSendPing(link,CLUSTERMSG_TYPE_PONG);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -736,7 +736,6 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
         connEnableTcpNoDelay(conn);
-	connKeepAlive(conn,server.cluster_node_timeout * 2); 
 
         /* Use non-blocking I/O for cluster messages. */
         serverLog(LL_VERBOSE,"Accepting cluster node connection from %s:%d", cip, cport);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1936,9 +1936,9 @@ int clusterProcessPacket(clusterLink *link) {
         if (!sender && type == CLUSTERMSG_TYPE_MEET)
             clusterProcessGossipSection(hdr,link);
 	    
-	if (sender && type == CLUSTERMSG_TYPE_PING && link->node == NULL){
+        if (sender && type == CLUSTERMSG_TYPE_PING && link->node == NULL) {
             link->node = sender;
-            if(sender->link_from) {
+            if (sender->link_from) {
                 sender->link_from->node = NULL;
                 freeClusterLink(sender->link_from);
             }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -736,7 +736,7 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
         connEnableTcpNoDelay(conn);
-	connKeepAlive(conn,server.cluster_node_timeout * 2);
+        connKeepAlive(conn,server.cluster_node_timeout * 2);
 
         /* Use non-blocking I/O for cluster messages. */
         serverLog(LL_VERBOSE,"Accepting cluster node connection from %s:%d", cip, cport);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -736,6 +736,7 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
         connEnableTcpNoDelay(conn);
+	connKeepAlive(conn,server.cluster_node_timeout * 2);
 
         /* Use non-blocking I/O for cluster messages. */
         serverLog(LL_VERBOSE,"Accepting cluster node connection from %s:%d", cip, cport);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -736,7 +736,7 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
         connEnableTcpNoDelay(conn);
-	connKeepAlive(conn,server.cluster_node_timeout * CLUSTER_LINK_FREE_MULT); 
+	connKeepAlive(conn,server.cluster_node_timeout * 2); 
 
         /* Use non-blocking I/O for cluster messages. */
         serverLog(LL_VERBOSE,"Accepting cluster node connection from %s:%d", cip, cport);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -736,6 +736,7 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
         connEnableTcpNoDelay(conn);
+	connKeepAlive(conn,server.cluster_node_timeout * CLUSTER_LINK_FREE_MULT); 
 
         /* Use non-blocking I/O for cluster messages. */
         serverLog(LL_VERBOSE,"Accepting cluster node connection from %s:%d", cip, cport);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -138,6 +138,7 @@ typedef struct clusterNode {
                                    if the main clients port is for TLS. */
     int cport;                  /* Latest known cluster port of this node. */
     clusterLink *link;          /* TCP/IP link with this node */
+    clusterLink *link_from;
     list *fail_reports;         /* List of nodes signaling this as failing */
 } clusterNode;
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -18,6 +18,7 @@
 #define CLUSTER_MF_TIMEOUT 5000 /* Milliseconds to do a manual failover. */
 #define CLUSTER_MF_PAUSE_MULT 2 /* Master pause manual failover mult. */
 #define CLUSTER_SLAVE_MIGRATION_DELAY 5000 /* Delay for slave migration. */
+#define CLUSTER_LINK_FREE_MULT 2 /* fee the inbound link from other nodes. */
 
 /* Redirection errors returned by getNodeByQuery(). */
 #define CLUSTER_REDIR_NONE 0          /* Node can serve the request. */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -138,7 +138,8 @@ typedef struct clusterNode {
                                    if the main clients port is for TLS. */
     int cport;                  /* Latest known cluster port of this node. */
     clusterLink *link;          /* TCP/IP link with this node */
-    clusterLink *link_from;
+    clusterLink *link;          /* TCP/IP link with this node  - outbound connection*/
+    clusterLink *link_from;  /*TCP/IP link with this node - inbound connection*/
     list *fail_reports;         /* List of nodes signaling this as failing */
 } clusterNode;
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -18,7 +18,6 @@
 #define CLUSTER_MF_TIMEOUT 5000 /* Milliseconds to do a manual failover. */
 #define CLUSTER_MF_PAUSE_MULT 2 /* Master pause manual failover mult. */
 #define CLUSTER_SLAVE_MIGRATION_DELAY 5000 /* Delay for slave migration. */
-#define CLUSTER_LINK_FREE_MULT 2 /* free the inbound link from other nodes. */
 
 /* Redirection errors returned by getNodeByQuery(). */
 #define CLUSTER_REDIR_NONE 0          /* Node can serve the request. */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -137,8 +137,7 @@ typedef struct clusterNode {
     int pport;                  /* Latest known clients plaintext port. Only used
                                    if the main clients port is for TLS. */
     int cport;                  /* Latest known cluster port of this node. */
-    clusterLink *link;          /* TCP/IP link with this node  - outbound connection*/
-    clusterLink *link_from;  /*TCP/IP link with this node - inbound connection*/
+    clusterLink *link;          /* TCP/IP link with this node */
     list *fail_reports;         /* List of nodes signaling this as failing */
 } clusterNode;
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -137,7 +137,6 @@ typedef struct clusterNode {
     int pport;                  /* Latest known clients plaintext port. Only used
                                    if the main clients port is for TLS. */
     int cport;                  /* Latest known cluster port of this node. */
-    clusterLink *link;          /* TCP/IP link with this node */
     clusterLink *link;          /* TCP/IP link with this node  - outbound connection*/
     clusterLink *link_from;  /*TCP/IP link with this node - inbound connection*/
     list *fail_reports;         /* List of nodes signaling this as failing */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -18,7 +18,7 @@
 #define CLUSTER_MF_TIMEOUT 5000 /* Milliseconds to do a manual failover. */
 #define CLUSTER_MF_PAUSE_MULT 2 /* Master pause manual failover mult. */
 #define CLUSTER_SLAVE_MIGRATION_DELAY 5000 /* Delay for slave migration. */
-#define CLUSTER_LINK_FREE_MULT 2 /* fee the inbound link from other nodes. */
+#define CLUSTER_LINK_FREE_MULT 2 /* free the inbound link from other nodes. */
 
 /* Redirection errors returned by getNodeByQuery(). */
 #define CLUSTER_REDIR_NONE 0          /* Node can serve the request. */


### PR DESCRIPTION
Addresses the issue where an inbound link is disconnected but is never detected since the packet was dropped. This can cause a memory leak as the connection will not be detected through any other mechanism. 

For example, A and B are two nodes in a cluster.

When A is partitioned away, B will free the "struct clusterLink" which is used for send ping to A. But the corresponding "struct clusterLink" in A won't be freed.

When partition heals, B uses a new clusterLink to send ping to A and A will create another new corresponding clusterLink. The older "struct clusterLink" above is still in the memory.
