### PR TITLE
Fix compatibility with OpenSSL 1.1.0.

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -146,6 +146,8 @@ void tlsInit(void) {
      */
     #if OPENSSL_VERSION_NUMBER < 0x10100000L
     OPENSSL_config(NULL);
+    #elif OPENSSL_VERSION_NUMBER < 0x10101000L
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
     #else
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG|OPENSSL_INIT_ATFORK, NULL);
     #endif


### PR DESCRIPTION
Found this while building on Debian Stretch and confirmed the problem is solved. I believe OpenSSL 1.1.0 is less popular, older systems use <1.1.0 and newer systems tend to use 1.1.1 for TLSv3 support.