### PR TITLE
[WIP] WATCH command can delete expired keys

### DIFF
--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -147,6 +147,18 @@ start_server {tags {"multi"}} {
         r debug set-active-expire 1
     } {OK} {needs:debug}
 
+    test {WATCH stale keys should not fail EXEC} {
+        r del x
+        r debug set-active-expire 0
+        r set x foo px 1
+        after 2
+        r watch x
+        r multi
+        r ping
+        assert_equal {PONG} [r exec]
+        r debug set-active-expire 1
+    } {OK} {needs:debug}
+
     test {After successful EXEC key is no longer watched} {
         r set x 30
         r watch x


### PR DESCRIPTION
After a discussion in #9068 and #9194, we reached an agreement
that we should handle all scenarios about expire, not only the real
expired deletion but also the logic expired time.

This PR aims to fix the issue below:
Time 1: we have a key "foo" is expired but not deleted.
Time 2: we WATCH the key "foo".
Time 3: execute EXEC and we find "foo" is expired and discard the
transaction, but it's not right, cause key "foo" is expired before
WATCH.

To fix it, the WATCH command now calls expireIfNeeded() to delete
the expired keys, and considering stale data would not be deleted if
clients are paused, WATCH command is now with may-replicate flag.

Notes: expireIfNeeded() cannot work in replicas, but WATCH expired keys
in replicas is rare case, we can fix it in future.

@redis/core-team @zuiderkwast please check.