### PR TITLE
Remove duplicate zero-port sentinels.

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1212,7 +1212,7 @@ int sentinelUpdateSentinelAddressInAllMasters(sentinelRedisInstance *ri) {
         if (match->link->pc != NULL)
             instanceLinkCloseConnection(match->link,match->link->pc);
 
-	/*Remove any sentinel with port number set to 0 */
+        /* Remove any sentinel with port number set to 0 */
         if (match->addr->port == 0)
             dictDelete(master->sentinels,match->name);
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1212,7 +1212,7 @@ int sentinelUpdateSentinelAddressInAllMasters(sentinelRedisInstance *ri) {
         if (match->link->pc != NULL)
             instanceLinkCloseConnection(match->link,match->link->pc);
 
-		/*Remove any sentinel with port number set to 0 */
+	/*Remove any sentinel with port number set to 0 */
         if (match->addr->port == 0)
             dictDelete(master->sentinels,match->name);
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1202,7 +1202,6 @@ int sentinelUpdateSentinelAddressInAllMasters(sentinelRedisInstance *ri) {
         sentinelRedisInstance *master = dictGetVal(de), *match;
         match = getSentinelRedisInstanceByAddrAndRunID(master->sentinels,
                                                        NULL,0,ri->runid);
-
         /* If there is no match, this master does not know about this
          * Sentinel, try with the next one. */
         if (match == NULL) continue;
@@ -1214,9 +1213,8 @@ int sentinelUpdateSentinelAddressInAllMasters(sentinelRedisInstance *ri) {
             instanceLinkCloseConnection(match->link,match->link->pc);
 
 		/*Remove any sentinel with port number set to 0 */
-        if (match->addr->port == 0) {
+        if (match->addr->port == 0)
             dictDelete(master->sentinels,match->name);
-        }
 
         if (match == ri) continue; /* Address already updated for it. */
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1202,6 +1202,7 @@ int sentinelUpdateSentinelAddressInAllMasters(sentinelRedisInstance *ri) {
         sentinelRedisInstance *master = dictGetVal(de), *match;
         match = getSentinelRedisInstanceByAddrAndRunID(master->sentinels,
                                                        NULL,0,ri->runid);
+
         /* If there is no match, this master does not know about this
          * Sentinel, try with the next one. */
         if (match == NULL) continue;
@@ -1211,6 +1212,11 @@ int sentinelUpdateSentinelAddressInAllMasters(sentinelRedisInstance *ri) {
             instanceLinkCloseConnection(match->link,match->link->cc);
         if (match->link->pc != NULL)
             instanceLinkCloseConnection(match->link,match->link->pc);
+
+		/*Remove any sentinel with port number set to 0 */
+        if (match->addr->port == 0) {
+            dictDelete(master->sentinels,match->name);
+        }
 
         if (match == ri) continue; /* Address already updated for it. */
 

--- a/tests/sentinel/tests/11-port-0.tcl
+++ b/tests/sentinel/tests/11-port-0.tcl
@@ -1,0 +1,33 @@
+source "../tests/includes/init-tests.tcl"
+
+test "Start/Stop sentinel on same port with a different runID should not change the total number of sentinels" {
+        set sentinel_id [expr $::instances_count-1]
+        #Kill sentinel instance
+        kill_instance sentinel $sentinel_id
+
+        #Delete line with myid in sentinels configuration file
+        set orgfilename [file join "sentinel_$sentinel_id" "sentinel.conf"]
+        set tmpfilename "sentinel.conf_tmp"
+        set dirname "sentinel_$sentinel_id"
+
+        delete_lines_with_pattern $orgfilename $tmpfilename "myid"
+
+        #Get count of total sentinels
+        set a [S 0 SENTINEL  master mymaster]
+        set original_count [lindex $a 33] #num-other-sentinels at index 33
+
+        #Restart sentinel with the modified config file
+        set pid [exec_instance "sentinel" $dirname $orgfilename]
+        lappend ::pids $pid
+
+        after 5000
+
+        #Get new count of total sentinel
+        set b [S 0 SENTINEL master mymaster]
+        set curr_count [lindex $b 33]
+
+        #If the count is not the same then fail the test
+        if {$original_count != $curr_count} {
+                fail "Sentinel count is incorrect, original count being $original_count and current count is $curr_count"
+        }
+}

--- a/tests/sentinel/tests/11-port-0.tcl
+++ b/tests/sentinel/tests/11-port-0.tcl
@@ -5,7 +5,7 @@ test "Start/Stop sentinel on same port with a different runID should not change 
         #Kill sentinel instance
         kill_instance sentinel $sentinel_id
 
-        #Delete line with myid in sentinels configuration file
+        #Delete line with myid in sentinels config file
         set orgfilename [file join "sentinel_$sentinel_id" "sentinel.conf"]
         set tmpfilename "sentinel.conf_tmp"
         set dirname "sentinel_$sentinel_id"

--- a/tests/sentinel/tests/11-port-0.tcl
+++ b/tests/sentinel/tests/11-port-0.tcl
@@ -14,7 +14,7 @@ test "Start/Stop sentinel on same port with a different runID should not change 
 
         #Get count of total sentinels
         set a [S 0 SENTINEL  master mymaster]
-        set original_count [lindex $a 33] #num-other-sentinels at index 33
+        set original_count [lindex $a 33]
 
         #Restart sentinel with the modified config file
         set pid [exec_instance "sentinel" $dirname $orgfilename]

--- a/tests/sentinel/tests/11-port-0.tcl
+++ b/tests/sentinel/tests/11-port-0.tcl
@@ -2,31 +2,31 @@ source "../tests/includes/init-tests.tcl"
 
 test "Start/Stop sentinel on same port with a different runID should not change the total number of sentinels" {
         set sentinel_id [expr $::instances_count-1]
-        #Kill sentinel instance
+        # Kill sentinel instance
         kill_instance sentinel $sentinel_id
 
-        #Delete line with myid in sentinels config file
+        # Delete line with myid in sentinels config file
         set orgfilename [file join "sentinel_$sentinel_id" "sentinel.conf"]
         set tmpfilename "sentinel.conf_tmp"
         set dirname "sentinel_$sentinel_id"
 
         delete_lines_with_pattern $orgfilename $tmpfilename "myid"
 
-        #Get count of total sentinels
+        # Get count of total sentinels
         set a [S 0 SENTINEL  master mymaster]
         set original_count [lindex $a 33]
 
-        #Restart sentinel with the modified config file
+        # Restart sentinel with the modified config file
         set pid [exec_instance "sentinel" $dirname $orgfilename]
         lappend ::pids $pid
 
         after 5000
 
-        #Get new count of total sentinel
+        # Get new count of total sentinel
         set b [S 0 SENTINEL master mymaster]
         set curr_count [lindex $b 33]
 
-        #If the count is not the same then fail the test
+        # If the count is not the same then fail the test
         if {$original_count != $curr_count} {
                 fail "Sentinel count is incorrect, original count being $original_count and current count is $curr_count"
         }

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -865,3 +865,16 @@ proc config_set {param value {options {}}} {
         }
     }
 }
+
+proc delete_lines_with_pattern {filename tmpfilename pattern} {
+    set fh_in [open $filename r]
+    set fh_out [open $tmpfilename w]
+    while {[gets $fh_in line] != -1} {
+        if {![regexp $pattern $line]} {
+            puts $fh_out $line
+        }
+    }
+    close $fh_in
+    close $fh_out
+    file rename -force $tmpfilename $filename
+}


### PR DESCRIPTION
There is a bug that is mentioned in issue 8786 https://github.com/redis/redis/issues/8786. 

The issue is that when a sentinel with the same address and IP is turned on with a different runid, its port is set to 0 but it is still present in the dictionary master->sentinels which contain all the sentinels for a master. This causes a problem when we do INFO SENTINEL because it takes the size of the dictionary of sentinels. This might also cause a problem for failover if enough sentinels have their port set to 0 since the number of voters in failover is also determined by the size of the dictionary of sentinels.

We suggest that we should remove the sentinels with the port set to zero from the dictionary of sentinels.