### PR TITLE
Fix missing separator in module info line (usedby and using lists)

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -8832,9 +8832,9 @@ sds genModulesInfoStringRenderModulesList(list *l) {
     while((ln = listNext(&li))) {
         RedisModule *module = ln->value;
         output = sdscat(output,module->name);
-        output = sdscat(output,"|");
+        if (ln != listLast(l))
+            output = sdscat(output,"|");
     }
-    output = sdstrim(output,"|");
     output = sdscat(output,"]");
     return output;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -8832,6 +8832,7 @@ sds genModulesInfoStringRenderModulesList(list *l) {
     while((ln = listNext(&li))) {
         RedisModule *module = ln->value;
         output = sdscat(output,module->name);
+        output = sdscat(output,"|");
     }
     output = sdstrim(output,"|");
     output = sdscat(output,"]");


### PR DESCRIPTION
genModulesInfoStringRenderModulesList lack `|`.