### PR TITLE
SMOVE only notify dstset when the addition is successful.

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -392,12 +392,12 @@ void smoveCommand(client *c) {
     }
 
     signalModifiedKey(c,c->db,c->argv[1]);
-    signalModifiedKey(c,c->db,c->argv[2]);
     server.dirty++;
 
     /* An extra key has changed when ele was successfully added to dstset */
     if (setTypeAdd(dstset,ele->ptr)) {
         server.dirty++;
+        signalModifiedKey(c,c->db,c->argv[2]);
         notifyKeyspaceEvent(NOTIFY_SET,"sadd",c->argv[2],c->db->id);
     }
     addReply(c,shared.cone);

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -828,6 +828,27 @@ start_server {
         lsort [r smembers set{t}]
     } {a b c}
 
+    test "SMOVE only notify dstset when the addition is successful" {
+        r del srcset{t}
+        r del dstset{t}
+
+        r sadd srcset{t} a b
+        r sadd dstset{t} a
+
+        r watch dstset{t}
+
+        r multi
+        r sadd dstset{t} c
+
+        set r2 [redis_client]
+        $r2 smove srcset{t} dstset{t} a
+
+        # The dstset is actually unchanged, multi should success
+        r exec
+        set res [r scard dstset{t}]
+        assert_equal $res 2
+    }
+
     tags {slow} {
         test {intsets implementation stress testing} {
             for {set j 0} {$j < 20} {incr j} {

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -847,7 +847,7 @@ start_server {
         r exec
         set res [r scard dstset{t}]
         assert_equal $res 2
-        r2 close
+        $r2 close
     }
 
     tags {slow} {

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -847,6 +847,7 @@ start_server {
         r exec
         set res [r scard dstset{t}]
         assert_equal $res 2
+        r2 close
     }
 
     tags {slow} {


### PR DESCRIPTION
In case dest key already contains the member, the dest key isn't modified, so the command shouldn't invalidate watch.
Fixes #9242