### PR TITLE
Add 'ist' to wordlist.

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -13,3 +13,4 @@ smove
 te
 tre
 cancelability
+ist


### PR DESCRIPTION
https://github.com/redis/redis/runs/3097034201
Spell check failed. We need to add ist to the wordlist