### PR TITLE
Support RDMA as tranport layer protocol by rsocket

### DIFF
--- a/RDMA.md
+++ b/RDMA.md
@@ -1,0 +1,67 @@
+RDMA Support
+============
+
+Getting Started
+---------------
+
+### Building
+
+To build with RDMA support you'll need RDMA development libraries (e.g.
+librdmacm-dev and libibverbs-dev on Debian/Ubuntu).
+
+Run `make BUILD_RDMA=yes`.
+
+### Running manually
+
+To manually run a Redis server with RDMA mode:
+
+    ./src/redis-server --rdma-port 6379  --rdma-bind 192.168.122.100 \
+        --protected-mode no
+
+To connect to this Redis server with `redis-cli`:
+
+    ./src/redis-cli -h 192.168.122.100 --rdma
+
+Note that the network card (192.168.122.100 of this example) should support
+RDMA. It's also possible to have both RDMA and TCP available, and there is no
+conflict of TCP(6379) and RDMA(6379), Ex:
+
+    ./src/redis-server --bind 127.0.0.1 --port 6379 \
+                       --rdma-port 6379 --rdma-bind 192.168.122.100 \
+                       --protected-mode no
+
+### rdma-core
+Upgrading rdma-core is suggested, clone source code from:
+
+    https://github.com/linux-rdma/rdma-core
+
+Follow README.md of rdma-core and compile/install it. Or run redis with
+environment variable like this:
+
+    LD_LIBRARY_PATH=/root/path/of/rdma-core/build/lib:$LD_LIBRARY_PATH \
+        ./src/redis-server --rdma-port 6379  --rdma-bind 192.168.122.100 \
+        --protected-mode no
+
+
+
+Connections
+-----------
+
+RDMA IO mechanism also goes through a connection abstraction layer that hides
+read/write event handling from the caller.
+
+Because RDMA is a message-oriented protocol, TCP is a stream-oriented protocol,
+to implement the stream-like operations(Ex, read/write) needs additional works
+in RDMA scenario. Luckly, rdma-core has already supported a stream like protocol
+named "rsocket", redis could uses rsocket/rclose/rsend/rrecv/rpoll API directly
+by linking librdmacm.so(no other dependency).
+
+Note that rdma-core should be upgraded.
+
+
+To-Do List
+----------
+
+- [ ] support sentinel mode to bind RDMA.
+- [ ] more abstraction work should be implemented.
+- [ ] auto-test suite is not implemented currently.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ libssl-dev on Debian/Ubuntu) and run:
 
     % make BUILD_TLS=yes
 
+To build with RDMA support(currently only supported on Linux), you'll need
+librdmacm&libibverbs development libraries (e.g. librdmacm-dev
+&libibverbs-dev on Debian/Ubuntu) and run:
+
+    % make BUILD_RDMA=yes
+
 To build with systemd support, you'll need systemd development libraries (such 
 as libsystemd-dev on Debian/Ubuntu or systemd-devel on CentOS) and run:
 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -46,6 +46,10 @@ ifeq ($(BUILD_TLS),yes)
     HIREDIS_MAKE_FLAGS = USE_SSL=1
 endif
 
+ifeq ($(BUILD_RDMA),yes)
+    HIREDIS_MAKE_FLAGS += USE_RDMA=yes
+endif
+
 hiredis: .make-prerequisites
 	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)
 	cd hiredis && $(MAKE) static $(HIREDIS_MAKE_FLAGS)

--- a/deps/hiredis/Makefile
+++ b/deps/hiredis/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2010-2011 Pieter Noordhuis <pcnoordhuis at gmail dot com>
 # This file is released under the BSD license, see the COPYING file
 
-OBJ=alloc.o net.o hiredis.o sds.o async.o read.o sockcompat.o
+OBJ=alloc.o net.o hiredis.o sds.o async.o read.o sockcompat.o rdma.o
 SSL_OBJ=ssl.o
 EXAMPLES=hiredis-example hiredis-example-libevent hiredis-example-libev hiredis-example-glib hiredis-example-push
 ifeq ($(USE_SSL),1)
@@ -78,6 +78,11 @@ endif
 
 ifeq ($(uname_S),Linux)
   SSL_LDFLAGS=-lssl -lcrypto
+  ifeq ($(BUILD_RDMA),yes)
+  EXAMPLES+=hiredis-example-rdma
+  CFLAGS+=-DUSE_RDMA
+  REAL_LDFLAGS+= -lrdmacm -libverbs
+  endif
 else
   OPENSSL_PREFIX?=/usr/local/opt/openssl
   CFLAGS+=-I$(OPENSSL_PREFIX)/include
@@ -118,6 +123,7 @@ read.o: read.c fmacros.h alloc.h read.h sds.h win32.h
 sds.o: sds.c sds.h sdsalloc.h alloc.h
 sockcompat.o: sockcompat.c sockcompat.h
 ssl.o: ssl.c hiredis.h read.h sds.h alloc.h async.h win32.h async_private.h
+rdma.o: rdma.c hiredis.h read.h sds.h alloc.h async.h async_private.h fmacros.h
 test.o: test.c fmacros.h hiredis.h read.h sds.h alloc.h net.h sockcompat.h win32.h
 
 $(DYLIBNAME): $(OBJ)

--- a/deps/hiredis/hiredis.c
+++ b/deps/hiredis/hiredis.c
@@ -43,6 +43,7 @@
 #include "sds.h"
 #include "async.h"
 #include "win32.h"
+#include "rdma.h"
 
 extern int redisContextUpdateConnectTimeout(redisContext *c, const struct timeval *timeout);
 extern int redisContextUpdateCommandTimeout(redisContext *c, const struct timeval *timeout);
@@ -713,7 +714,11 @@ static redisContext *redisContextInit(void) {
 void redisFree(redisContext *c) {
     if (c == NULL)
         return;
-    redisNetClose(c);
+
+    if (c->funcs->close) {
+        c->funcs->close(c);
+    } else
+        redisNetClose(c);
 
     hi_sdsfree(c->obuf);
     redisReaderFree(c->reader);
@@ -824,6 +829,13 @@ redisContext *redisConnectWithOptions(const redisOptions *options) {
     } else if (options->type == REDIS_CONN_USERFD) {
         c->fd = options->endpoint.fd;
         c->flags |= REDIS_CONNECTED;
+    } else if (options->type == REDIS_CONN_RDMA) {
+        if (redisContextConnectBindRdma(c, options->endpoint.tcp.ip,
+                                        options->endpoint.tcp.port,
+                                        options->connect_timeout,
+                                        options->endpoint.tcp.source_addr)) {
+            return c;
+        }
     } else {
         // Unknown type - FIXME - FREE
         return NULL;
@@ -901,6 +913,19 @@ redisContext *redisConnectFd(redisFD fd) {
     redisOptions options = {0};
     options.type = REDIS_CONN_USERFD;
     options.endpoint.fd = fd;
+    return redisConnectWithOptions(&options);
+}
+
+redisContext *redisConnectRdma(const char *ip, int port) {
+    redisOptions options = {0};
+    REDIS_OPTIONS_SET_RDMA(&options, ip, port);
+    return redisConnectWithOptions(&options);
+}
+
+redisContext *redisConnectRdmaTimeout(const char *ip, int port, const struct timeval tv) {
+    redisOptions options = {0};
+    REDIS_OPTIONS_SET_RDMA(&options, ip, port);
+    options.connect_timeout = &tv;
     return redisConnectWithOptions(&options);
 }
 

--- a/deps/hiredis/hiredis.h
+++ b/deps/hiredis/hiredis.h
@@ -135,7 +135,8 @@ void redisFreeSdsCommand(hisds cmd);
 enum redisConnectionType {
     REDIS_CONN_TCP,
     REDIS_CONN_UNIX,
-    REDIS_CONN_USERFD
+    REDIS_CONN_USERFD,
+    REDIS_CONN_RDMA
 };
 
 struct redisSsl;
@@ -217,11 +218,17 @@ typedef struct {
     (opts)->type = REDIS_CONN_UNIX;        \
     (opts)->endpoint.unix_socket = path;
 
+#define REDIS_OPTIONS_SET_RDMA(opts, ip_, port_) \
+    (opts)->type = REDIS_CONN_RDMA; \
+    (opts)->endpoint.tcp.ip = ip_; \
+    (opts)->endpoint.tcp.port = port_;
+
 #define REDIS_OPTIONS_SET_PRIVDATA(opts, data, dtor) \
     (opts)->privdata = data;                         \
     (opts)->free_privdata = dtor;                    \
 
 typedef struct redisContextFuncs {
+    void (*close)(struct redisContext *);
     void (*free_privctx)(void *);
     void (*async_read)(struct redisAsyncContext *);
     void (*async_write)(struct redisAsyncContext *);
@@ -283,6 +290,8 @@ redisContext *redisConnectUnix(const char *path);
 redisContext *redisConnectUnixWithTimeout(const char *path, const struct timeval tv);
 redisContext *redisConnectUnixNonBlock(const char *path);
 redisContext *redisConnectFd(redisFD fd);
+redisContext *redisConnectRdma(const char *ip, int port);
+redisContext *redisConnectRdmaTimeout(const char *ip, int port, const struct timeval tv);
 
 /**
  * Reconnect the given context using the saved information.

--- a/deps/hiredis/net.c
+++ b/deps/hiredis/net.c
@@ -215,7 +215,7 @@ int redisSetTcpNoDelay(redisContext *c) {
 
 #define __MAX_MSEC (((LONG_MAX) - 999) / 1000)
 
-static int redisContextTimeoutMsec(redisContext *c, long *result)
+int redisContextTimeoutMsec(redisContext *c, long *result)
 {
     const struct timeval *timeout = c->connect_timeout;
     long msec = -1;

--- a/deps/hiredis/rdma.c
+++ b/deps/hiredis/rdma.c
@@ -1,0 +1,340 @@
+/* ==========================================================================
+ * rdma.c - Support RDMA protocol for transport layer. Instead of IB verbs
+ *          low-level API, Use rsocket which is implemented by rdma-core to
+ *          make this module easy to implement/maintain.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2021  zhenwei pi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ==========================================================================
+ */
+
+#include "fmacros.h"
+
+#include "async.h"
+#include "async_private.h"
+#include "hiredis.h"
+#include "rdma.h"
+#include <errno.h>
+
+#define UNUSED(x) (void)(x)
+
+void __redisSetError(redisContext *c, int type, const char *str);
+
+#ifdef USE_RDMA
+#ifdef __linux__    /* currently RDMA is only supported on Linux */
+#define __USE_MISC
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <poll.h>
+#include <rdma/rsocket.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <sys/types.h>
+
+/* TODO: defined in net.c, should declear it as public function */
+int redisContextTimeoutMsec(redisContext *c, long *result);
+int redisContextUpdateConnectTimeout(redisContext *c, const struct timeval *timeout);
+
+ssize_t redisRdmaRead(redisContext *c, char *buf, size_t bufcap) {
+    ssize_t nread = rrecv(c->fd, buf, bufcap, 0);
+
+    if (nread == -1) {
+        if ((errno == EWOULDBLOCK && !(c->flags & REDIS_BLOCK)) || (errno == EINTR)) {
+            return 0;
+        } else {
+            __redisSetError(c, REDIS_ERR_IO, "RDMA: recv failed");
+            return REDIS_ERR;
+        }
+    } else if (nread == 0) {
+        __redisSetError(c, REDIS_ERR_EOF, "RDMA: Server closed the connection");
+        return REDIS_ERR;
+    }
+
+    return nread;
+}
+
+ssize_t redisRdmaWrite(redisContext *c) {
+    ssize_t nwritten = rsend(c->fd, c->obuf, hi_sdslen(c->obuf), 0);
+
+    if (nwritten < 0) {
+        if ((errno == EWOULDBLOCK && !(c->flags & REDIS_BLOCK)) || (errno == EINTR)) {
+             return 0;
+        } else {
+            __redisSetError(c, REDIS_ERR_IO, NULL);
+            return REDIS_ERR;
+        }
+    }
+
+    return nwritten;
+}
+
+void redisRdmaAsyncRead(redisAsyncContext *ac) {
+    redisContext *c = &(ac->c);
+
+    if (redisBufferRead(c) == REDIS_ERR) {
+        __redisAsyncDisconnect(ac);
+    } else {
+        /* Always re-schedule reads */
+        _EL_ADD_READ(ac);
+        redisProcessCallbacks(ac);
+    }
+}
+
+void redisRdmaAsyncWrite(redisAsyncContext *ac) {
+    redisContext *c = &(ac->c);
+    int done = 0;
+
+    if (redisBufferWrite(c,&done) == REDIS_ERR) {
+        __redisAsyncDisconnect(ac);
+    } else {
+        /* Continue writing when not done, stop writing otherwise */
+        if (!done)
+            _EL_ADD_WRITE(ac);
+        else
+            _EL_DEL_WRITE(ac);
+
+        /* Always schedule reads after writes */
+        _EL_ADD_READ(ac);
+    }
+}
+
+static void redisRdmaClose(redisContext *c) {
+    if (c && c->fd != REDIS_INVALID_FD) {
+        rclose(c->fd);
+        c->fd = REDIS_INVALID_FD;
+    }
+}
+
+static void redisRdmaFree(void *privctx) {
+    UNUSED(privctx);
+}
+
+redisContextFuncs redisContextRdmaFuncs = {
+    .close = redisRdmaClose,
+    .free_privctx = redisRdmaFree,
+    .async_read = redisRdmaAsyncRead,
+    .async_write = redisRdmaAsyncWrite,
+    .read = redisRdmaRead,
+    .write = redisRdmaWrite,
+};
+
+static int rsocketSetBlock(redisContext *c, int fd, int block) {
+    int flags;
+
+    if ((flags = rfcntl(fd, F_GETFL)) == -1) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: rfcntl failed");
+        return REDIS_ERR;
+    }
+
+    if (block)
+        flags &= ~O_NONBLOCK;
+    else
+        flags |= O_NONBLOCK;
+
+    if (rfcntl(fd, F_SETFL, flags) == -1) {
+        __redisSetError(c, REDIS_ERR_OTHER, "RDMA: rfcntl failed");
+        return REDIS_ERR;
+    }
+
+    return REDIS_OK;
+}
+
+static int redisRdmaWait(int fd, int events, long long timeoutms) {
+    struct pollfd pfd = {0};
+    int retval;
+
+    pfd.fd = fd;
+    pfd.events = events;
+
+    retval = rpoll(&pfd, 1, timeoutms);
+    if (retval < 0) {
+        return REDIS_ERR;
+    }
+
+    return pfd.revents;
+}
+
+static int _redisContextConnectBindRdma(redisContext *c, const char *addr,
+                                       int port, const struct timeval *timeout,
+                                       const char *source_addr) {
+    struct addrinfo hints, *servinfo = NULL, *cliinfo = NULL, *psrv, *pcli;
+    char buf[128];
+    char _port[6];
+    long timeoutms = -1;
+    int blocking = (c->flags & REDIS_BLOCK);
+    int ret;
+
+    c->connection_type = REDIS_CONN_RDMA;
+    c->funcs = &redisContextRdmaFuncs;
+    c->tcp.port = port;
+    c->fd = REDIS_INVALID_FD;
+
+    if (c->tcp.host != addr) {
+        hi_free(c->tcp.host);
+
+        c->tcp.host = hi_strdup(addr);
+        if (c->tcp.host == NULL) {
+            __redisSetError(c, REDIS_ERR_OOM, "RDMA: Out of memory");
+            return REDIS_ERR;
+        }
+    }
+
+    if (source_addr == NULL) {
+        hi_free(c->tcp.source_addr);
+        c->tcp.source_addr = NULL;
+    } else if (c->tcp.source_addr != source_addr) {
+        hi_free(c->tcp.source_addr);
+        c->tcp.source_addr = hi_strdup(source_addr);
+    }
+
+    if (timeout) {
+        if (redisContextUpdateConnectTimeout(c, timeout) == REDIS_ERR) {
+            __redisSetError(c, REDIS_ERR_OOM, "RDMA: Out of memory");
+            return REDIS_ERR;
+        }
+    } else {
+        hi_free(c->connect_timeout);
+        c->connect_timeout = NULL;
+    }
+
+    if (redisContextTimeoutMsec(c, &timeoutms) != REDIS_OK) {
+        __redisSetError(c, REDIS_ERR_IO, "RDMA: Invalid timeout specified");
+        return REDIS_ERR;
+    } else if (timeoutms == -1) {
+        timeoutms = INT_MAX;
+    }
+
+    /* getaddrinfo for server side */
+    snprintf(_port, 6, "%d", port);
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    if ((ret = getaddrinfo(c->tcp.host, _port, &hints, &servinfo)) != 0) {
+        hints.ai_family = AF_INET6;
+        if ((ret = getaddrinfo(addr, _port, &hints, &servinfo)) != 0) {
+            __redisSetError(c, REDIS_ERR_OTHER, gai_strerror(ret));
+            goto err;
+        }
+    }
+
+    /* getaddrinfo for client side */
+    if (c->tcp.source_addr) {
+        memset(&hints, 0, sizeof(hints));
+        hints.ai_family = AF_INET;
+        hints.ai_socktype = SOCK_STREAM;
+        if (getaddrinfo(c->tcp.source_addr, NULL, &hints, &cliinfo) != 0) {
+            hints.ai_family = AF_INET6;
+            if (getaddrinfo(c->tcp.source_addr, NULL, &hints, &servinfo) != 0) {
+                __redisSetError(c, REDIS_ERR_OTHER, gai_strerror(ret));
+                goto err;
+            }
+        }
+    }
+
+    for (psrv = servinfo; psrv != NULL; psrv = psrv->ai_next) {
+        c->fd = rsocket(psrv->ai_family, psrv->ai_socktype, psrv->ai_protocol);
+        if (c->fd == REDIS_INVALID_FD) {
+            continue;
+        }
+
+        for (pcli = cliinfo; pcli != NULL; pcli = pcli->ai_next) {
+            if (rbind(c->fd, pcli->ai_addr, pcli->ai_addrlen) != -1) {
+                break;
+            }
+        }
+
+        if (rsocketSetBlock(c, c->fd, 0) != REDIS_OK) {
+            goto err;
+        }
+
+        hi_free(c->saddr);
+        c->addrlen = psrv->ai_addrlen;
+        c->saddr = hi_malloc(psrv->ai_addrlen);
+        memcpy(c->saddr, psrv->ai_addr, psrv->ai_addrlen);
+        ret = rconnect(c->fd, psrv->ai_addr, psrv->ai_addrlen);
+        if (ret == -1) {
+            if (errno != EINPROGRESS) {
+                snprintf(buf, sizeof(buf), "RDMA: rconnect failed: %s", strerror(errno));
+                __redisSetError(c, REDIS_ERR_OTHER, buf);
+	        goto err;
+            }
+
+            if (redisRdmaWait(c->fd, POLLOUT, timeoutms) == REDIS_ERR) {
+	        goto err;
+            }
+        }
+
+        if (blocking && rsocketSetBlock(c, c->fd, 1) != REDIS_OK) {
+            goto err;
+        }
+
+        break;
+    }
+
+    c->flags |= REDIS_CONNECTED;
+    ret = REDIS_OK;
+    goto out;
+
+err:
+    ret = REDIS_ERR;
+    if (c->fd != REDIS_INVALID_FD) {
+        rclose(c->fd);
+        c->fd = REDIS_INVALID_FD;
+    }
+
+out:
+    if(servinfo) {
+        freeaddrinfo(servinfo);
+    }
+
+    if(cliinfo) {
+        freeaddrinfo(cliinfo);
+    }
+
+    return ret;
+}
+
+int redisContextConnectBindRdma(redisContext *c, const char *addr, int port,
+                                const struct timeval *timeout,
+                                const char *source_addr) {
+    return _redisContextConnectBindRdma(c, addr, port, timeout, source_addr);
+}
+#else    /* __linux__ */
+
+"BUILD ERROR: RDMA is only supported on linux"
+
+#endif   /* __linux__ */
+#else    /* USE_RDMA */
+
+int redisContextConnectBindRdma(redisContext *c, const char *addr, int port,
+                                const struct timeval *timeout,
+                                const char *source_addr) {
+    UNUSED(c);
+    UNUSED(addr);
+    UNUSED(port);
+    UNUSED(timeout);
+    UNUSED(source_addr);
+    __redisSetError(c, REDIS_ERR_PROTOCOL, "RDMA: disabled, please rebuild with BUILD_RDMA");
+    return -EPROTONOSUPPORT;
+}
+
+#endif

--- a/deps/hiredis/rdma.h
+++ b/deps/hiredis/rdma.h
@@ -1,0 +1,39 @@
+/* rdma.h - Support RDMA protocol for transport layer.
+ * --------------------------------------------------------------------------
+ * Copyright (c) 2021 zhenwei pi
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __RDMA_H
+#define __RDMA_H
+
+#include "hiredis.h"
+
+int redisContextConnectBindRdma(redisContext *c, const char *addr, int port, const struct timeval *timeout, const char *source_addr);
+
+#endif

--- a/redis.conf
+++ b/redis.conf
@@ -2008,3 +2008,11 @@ jemalloc-bg-thread yes
 # to suppress
 #
 # ignore-warnings ARM64-COW-BUG
+
+# It is possible to use RDMA as transport layer, bind addresses and port config
+# are as same as TCP. Note that there is no conflict of TCP port and RDMA port,
+# for example, both TCP and RDMA could use the same port at the same time.
+rdma-bind 192.168.122.1
+rdma-port 6379
+rdma-bind-source-addr 192.168.122.1
+rdma-replication yes

--- a/src/Makefile
+++ b/src/Makefile
@@ -252,6 +252,17 @@ endif
 	FINAL_LIBS += ../deps/hiredis/libhiredis_ssl.a $(LIBSSL_LIBS) $(LIBCRYPTO_LIBS)
 endif
 
+ifeq ($(BUILD_RDMA),yes)
+	FINAL_CFLAGS+=-DUSE_RDMA
+	RDMA_PKGCONFIG := $(shell $(PKG_CONFIG) --exists librdmacm libibverbs && echo $$?)
+ifeq ($(RDMA_PKGCONFIG),0)
+	RDMA_LIBS=$(shell $(PKG_CONFIG) --libs librdmacm libibverbs)
+else
+	RDMA_LIBS=-lrdmacm -libverbs
+endif
+	FINAL_LIBS += $(RDMA_LIBS)
+endif
+
 ifndef V
     define MAKE_INSTALL
         @printf '    %b %b\n' $(LINKCOLOR)INSTALL$(ENDCOLOR) $(BINCOLOR)$(1)$(ENDCOLOR) 1>&2
@@ -282,7 +293,7 @@ endif
 
 REDIS_SERVER_NAME=redis-server$(PROG_SUFFIX)
 REDIS_SENTINEL_NAME=redis-sentinel$(PROG_SUFFIX)
-REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crcspeed.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o redis-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o tracking.o connection.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o
+REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o scripting.o bio.o rio.o rand.o memtest.o crcspeed.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o redis-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o tracking.o connection.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o rdma.o
 REDIS_CLI_NAME=redis-cli$(PROG_SUFFIX)
 REDIS_CLI_OBJ=anet.o adlist.o dict.o redis-cli.o zmalloc.o release.o ae.o redisassert.o crcspeed.o crc64.o siphash.o crc16.o monotonic.o cli_common.o mt19937-64.o
 REDIS_BENCHMARK_NAME=redis-benchmark$(PROG_SUFFIX)
@@ -310,6 +321,9 @@ persist-settings: distclean
 	echo OPT=$(OPT) >> .make-settings
 	echo MALLOC=$(MALLOC) >> .make-settings
 	echo BUILD_TLS=$(BUILD_TLS) >> .make-settings
+	echo BUILD_RDMA=$(BUILD_RDMA) >> .make-settings
+	echo RDMA_PKGCONFIG=$(RDMA_PKGCONFIG) >> .make-settings
+	echo RDMA_LIBS=$(RDMA_LIBS) >> .make-settings
 	echo USE_SYSTEMD=$(USE_SYSTEMD) >> .make-settings
 	echo CFLAGS=$(CFLAGS) >> .make-settings
 	echo LDFLAGS=$(LDFLAGS) >> .make-settings

--- a/src/ae.c
+++ b/src/ae.c
@@ -49,16 +49,20 @@
 
 /* Include the best multiplexing layer supported by this system.
  * The following should be ordered by performances, descending. */
-#ifdef HAVE_EVPORT
-#include "ae_evport.c"
+#ifdef USE_RDMA
+#include "ae_rpoll.c"
 #else
-    #ifdef HAVE_EPOLL
-    #include "ae_epoll.c"
+    #ifdef HAVE_EVPORT
+    #include "ae_evport.c"
     #else
-        #ifdef HAVE_KQUEUE
-        #include "ae_kqueue.c"
+        #ifdef HAVE_EPOLL
+        #include "ae_epoll.c"
         #else
-        #include "ae_select.c"
+            #ifdef HAVE_KQUEUE
+            #include "ae_kqueue.c"
+            #else
+            #include "ae_select.c"
+            #endif
         #endif
     #endif
 #endif

--- a/src/ae_rpoll.c
+++ b/src/ae_rpoll.c
@@ -1,0 +1,200 @@
+/* RSOCKET(7)-implemented by rdma-core, based ae.c module
+ *
+ * Support RDMA protocol for transport layer. Instead of IB verbs
+ * low-level API, Use rsocket which is implemented by rdma-core to
+ * make this module easy to implement/maintain.
+ *
+ * Copyright (C) 2021 zhenwei pi
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <sys/time.h>
+#include <rdma/rsocket.h>
+
+typedef struct aeApiState {
+    struct pollfd *pfds;
+    struct pollfd *polling;
+    int nfds;
+} aeApiState;
+
+static int aeApiCreate(aeEventLoop *eventLoop) {
+    aeApiState *state;
+    struct pollfd *pfd;
+    int i;
+
+    state = zmalloc(sizeof(aeApiState));
+    state->nfds = eventLoop->setsize;
+    state->pfds = zmalloc(sizeof(struct pollfd) * eventLoop->setsize);
+    state->polling = zmalloc(sizeof(struct pollfd) * eventLoop->setsize);
+
+    for (i = 0; i < eventLoop->setsize; i++) {
+        pfd = state->pfds + i;
+        pfd->fd = -1;
+        pfd->events = 0;
+    }
+
+    eventLoop->apidata = state;
+    return 0;
+}
+
+static int aeApiResize(aeEventLoop *eventLoop, int setsize) {
+    aeApiState *state = eventLoop->apidata;
+    struct pollfd *pfd;
+    int i;
+
+    state->pfds = zrealloc(state->pfds, sizeof(struct pollfd) * setsize);
+    state->polling = zrealloc(state->polling, sizeof(struct pollfd) * setsize);
+
+    /* mark the new pollfd(s) fd as -1 */
+    if (setsize > state->nfds) {
+        for (i = state->nfds; i < setsize; i++) {
+            pfd = state->pfds + i;
+            pfd->fd = -1;
+            pfd->events = 0;
+        }
+    }
+
+    state->nfds = setsize;
+
+    return 0;
+}
+
+static void aeApiFree(aeEventLoop *eventLoop) {
+    aeApiState *state = eventLoop->apidata;
+
+    zfree(state->pfds);
+    zfree(state->polling);
+    zfree(state);
+}
+
+static int aeApiAddEvent(aeEventLoop *eventLoop, int fd, int mask) {
+    aeApiState *state = eventLoop->apidata;
+    struct pollfd *pfd;
+
+    if (fd >= state->nfds) {
+        return -1;
+    }
+
+    pfd = state->pfds + fd;
+    pfd->fd = fd;
+    pfd->revents = 0;
+    if (mask & AE_READABLE) {
+        pfd->events |= POLLIN;
+    }
+
+    if (mask & AE_WRITABLE) {
+        pfd->events |= POLLOUT;
+    }
+
+    pfd->events |= (POLLERR | POLLHUP);
+
+    return 0;
+}
+
+static void aeApiDelEvent(aeEventLoop *eventLoop, int fd, int mask) {
+    aeApiState *state = eventLoop->apidata;
+    struct pollfd *pfd;
+
+    if (fd >= state->nfds) {
+        return;
+    }
+
+    pfd = state->pfds + fd;
+    pfd->fd = fd;
+    pfd->revents = 0;
+    if (mask & AE_READABLE) {
+        pfd->events &= ~POLLIN;
+    }
+
+    if (mask & AE_WRITABLE) {
+        pfd->events &= ~POLLOUT;
+    }
+
+    /* no POLLIN/POLLOUT event should poll, set fd as invalid */
+    if (!(pfd->events & (POLLIN | POLLOUT))) {
+        pfd->fd = -1;
+    }
+}
+
+static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
+    aeApiState *state = eventLoop->apidata;
+    struct pollfd *pfd, *polling;
+    aeFiredEvent *fired;
+    int nevents, timeoutms, nfds = 0;
+    int i, fires, mask;
+
+    for (i = 0; i < state->nfds; i++) {
+        pfd = state->pfds + i;
+        if (pfd->fd < 0 || !pfd->events) {
+            continue;
+        }
+
+        polling = state->polling + nfds;
+        *polling = *pfd;
+        nfds++;
+    }
+
+    timeoutms = tvp ? (tvp->tv_sec * 1000 + (tvp->tv_usec + 999) / 1000) : -1;
+    nevents = rpoll(state->polling, nfds, timeoutms);
+    if (nevents == -1) {
+        if ( errno == EINTR) {
+            return 0;
+        }
+
+        panic("aeApiPoll: Fatal error rpoll: %s", strerror(errno));
+    }
+
+    for (fires = 0, i = 0; i < nfds; i++) {
+        polling = state->polling + i;
+
+        if (!polling->revents) {
+            continue;
+        }
+
+        mask = 0;
+        if (polling->revents & POLLIN)
+            mask |= AE_READABLE;
+        if (polling->revents & POLLOUT)
+            mask |= AE_WRITABLE;
+        if (polling->revents & POLLERR)
+            mask |= AE_WRITABLE | AE_READABLE;
+        if (polling->revents & POLLHUP)
+            mask |= AE_WRITABLE | AE_READABLE;
+
+        fired = eventLoop->fired + fires;
+        fired->fd = polling->fd;
+        fired->mask = mask;
+        fires++;
+    }
+
+    return nevents;
+}
+
+static char *aeApiName(void) {
+    return "rpoll";
+}

--- a/src/anet.h
+++ b/src/anet.h
@@ -61,6 +61,7 @@ int anetTcp6Server(char *err, int port, char *bindaddr, int backlog);
 int anetUnixServer(char *err, char *path, mode_t perm, int backlog);
 int anetTcpAccept(char *err, int serversock, char *ip, size_t ip_len, int *port);
 int anetUnixAccept(char *err, int serversock);
+int rdmaAccept(char *err, int serversock, char *ip, size_t ip_len, int *port);
 int anetNonBlock(char *err, int fd);
 int anetBlock(char *err, int fd);
 int anetCloexec(int fd);

--- a/src/connection.h
+++ b/src/connection.h
@@ -50,6 +50,7 @@ typedef enum {
 
 #define CONN_TYPE_SOCKET            1
 #define CONN_TYPE_TLS               2
+#define CONN_TYPE_RDMA              3
 
 typedef void (*ConnectionCallbackFunc)(struct connection *conn);
 
@@ -208,6 +209,9 @@ connection *connCreateAcceptedSocket(int fd);
 
 connection *connCreateTLS();
 connection *connCreateAcceptedTLS(int fd, int require_auth);
+
+connection *connCreateRdma();
+connection *connCreateAcceptedRdma(int fd);
 
 void connSetPrivateData(connection *conn, void *data);
 void *connGetPrivateData(connection *conn);

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -1,0 +1,694 @@
+/* ==========================================================================
+ * rdma.c - Support RDMA protocol for transport layer. Instead of IB verbs
+ *          low-level API, Use rsocket which is implemented by rdma-core to
+ *          make this module easy to implement/maintain.
+ * --------------------------------------------------------------------------
+ * Copyright (C) 2021  zhenwei pi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ==========================================================================
+ */
+
+#include "server.h"
+#include "connection.h"
+#include "connhelpers.h"
+
+static void serverNetError(char *err, const char *fmt, ...) {
+    va_list ap;
+
+    if (!err) return;
+    va_start(ap, fmt);
+    vsnprintf(err, ANET_ERR_LEN, fmt, ap);
+    va_end(ap);
+}
+
+#ifdef USE_RDMA
+#ifdef __linux__    /* currently RDMA is only supported on Linux */
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <rdma/rsocket.h>
+#include <sys/types.h>
+#include <fcntl.h>
+
+void closeSocketListeners(socketFds *sfd);
+
+static int rsocketSetBlock(int fd, int block) {
+    int flags;
+
+    if ((flags = rfcntl(fd, F_GETFL)) == -1) {
+        serverLog(LL_WARNING, "RDMA: rfcntl F_GETFL failed");
+        return ANET_ERR;
+    }
+
+    if (block)
+        flags &= ~O_NONBLOCK;
+    else
+        flags |= O_NONBLOCK;
+
+    if (rfcntl(fd, F_SETFL, flags) == -1) {
+        serverLog(LL_WARNING, "RDMA: rfcntl F_SETFL failed");
+        return ANET_ERR;
+    }
+
+    return ANET_OK;
+}
+
+int rsocketGetSocketError(connection *conn) {
+    int sockerr = 0;
+    socklen_t errlen = sizeof(sockerr);
+
+    if (rgetsockopt(conn->fd, SOL_SOCKET, SO_ERROR, &sockerr, &errlen) == -1) {
+        sockerr = errno;
+    }
+
+    return sockerr;
+}
+
+static void connRdmaEventHandler(struct aeEventLoop *el, int fd, void *clientData, int mask)
+{
+    UNUSED(el);
+    UNUSED(fd);
+    connection *conn = clientData;
+
+    if (conn->state == CONN_STATE_CONNECTING &&
+            (mask & AE_WRITABLE) && conn->conn_handler) {
+
+        int conn_error = rsocketGetSocketError(conn);
+        if (conn_error) {
+            conn->last_errno = conn_error;
+            conn->state = CONN_STATE_ERROR;
+        } else {
+            conn->state = CONN_STATE_CONNECTED;
+        }
+
+        if (!conn->write_handler) {
+            aeDeleteFileEvent(server.el, conn->fd, AE_WRITABLE);
+        }
+
+        if (!callHandler(conn, conn->conn_handler)) {
+            return;
+        }
+
+        conn->conn_handler = NULL;
+    }
+
+    int invert = conn->flags & CONN_FLAG_WRITE_BARRIER;
+    int call_write = (mask & AE_WRITABLE) && conn->write_handler;
+    int call_read = (mask & AE_READABLE) && conn->read_handler;
+
+    if (!invert && call_read) {
+        if (!callHandler(conn, conn->read_handler)) {
+            return;
+	}
+    }
+
+    if (call_write) {
+        if (!callHandler(conn, conn->write_handler)) {
+           return;
+        }
+    }
+
+    if (invert && call_read) {
+        if (!callHandler(conn, conn->read_handler)) {
+            return;
+        }
+    }
+}
+
+static void connRdmaClose(connection *conn) {
+    if (conn->fd != -1) {
+        aeDeleteFileEvent(server.el,conn->fd, AE_READABLE | AE_WRITABLE);
+        rclose(conn->fd);
+        conn->fd = -1;
+    }
+
+    if (connHasRefs(conn)) {
+        conn->flags |= CONN_FLAG_CLOSE_SCHEDULED;
+        return;
+    }
+
+    zfree(conn);
+}
+
+static int connRdmaWrite(connection *conn, const void *data, size_t data_len) {
+    int ret = rsend(conn->fd, data, data_len, 0);
+
+    if (ret < 0 && errno != EAGAIN) {
+        conn->last_errno = errno;
+
+        if (conn->state == CONN_STATE_CONNECTED) {
+            conn->state = CONN_STATE_ERROR;
+        }
+    }
+
+    return ret;
+}
+
+static int connRdmaRead(connection *conn, void *buf, size_t buf_len) {
+    int ret = rrecv(conn->fd, buf, buf_len, 0);
+
+    if (!ret) {
+        conn->state = CONN_STATE_CLOSED;
+    } else if (ret < 0 && errno != EAGAIN) {
+        conn->last_errno = errno;
+
+        if (conn->state == CONN_STATE_CONNECTED) {
+            conn->state = CONN_STATE_ERROR;
+        }
+    }
+
+    return ret;
+}
+
+static int connRdmaAccept(connection *conn, ConnectionCallbackFunc accept_handler) {
+    int ret = C_OK;
+
+    if (conn->state != CONN_STATE_ACCEPTING) {
+        return C_ERR;
+    }
+
+    conn->state = CONN_STATE_CONNECTED;
+    connIncrRefs(conn);
+
+    if (!callHandler(conn, accept_handler)) {
+        ret = C_ERR;
+    }
+    connDecrRefs(conn);
+
+    return ret;
+}
+
+static int connRdmaSetWriteHandler(connection *conn, ConnectionCallbackFunc func, int barrier) {
+    if (func == conn->write_handler) {
+        return C_OK;
+    }
+
+    conn->write_handler = func;
+    if (barrier)
+        conn->flags |= CONN_FLAG_WRITE_BARRIER;
+    else
+        conn->flags &= ~CONN_FLAG_WRITE_BARRIER;
+
+    if (!conn->write_handler) {
+        aeDeleteFileEvent(server.el, conn->fd, AE_WRITABLE);
+    } else {
+        if (aeCreateFileEvent(server.el, conn->fd, AE_WRITABLE,
+                    conn->type->ae_handler, conn) == AE_ERR) {
+            return C_ERR;
+        }
+    }
+
+    return C_OK;
+}
+
+static int connRdmaSetReadHandler(connection *conn, ConnectionCallbackFunc func) {
+    if (func == conn->read_handler) {
+        return C_OK;
+    }
+
+    conn->read_handler = func;
+    if (!conn->read_handler) {
+        aeDeleteFileEvent(server.el, conn->fd, AE_READABLE);
+    } else {
+        if (aeCreateFileEvent(server.el,conn->fd, AE_READABLE,
+                              conn->type->ae_handler, conn) == AE_ERR) {
+            return C_ERR;
+        }
+    }
+
+    return C_OK;
+}
+
+static const char *connRdmaGetLastError(connection *conn) {
+    return strerror(conn->last_errno);
+}
+
+static int _connRdmaConnect(connection *conn, const char *addr, int port, const char *src_addr) {
+    struct addrinfo hints, *servinfo = NULL, *cliinfo = NULL, *psrv, *pcli;
+    char _port[6];
+    int ret;
+
+    /* getaddrinfo for server side */
+    snprintf(_port, 6, "%d", port);
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    if ((ret = getaddrinfo(addr, _port, &hints, &servinfo)) != 0) {
+        hints.ai_family = AF_INET6;
+        if ((ret = getaddrinfo(addr, _port, &hints, &servinfo)) != 0) {
+            serverLog(LL_WARNING, "RDMA: try to connect %s:%s, getaddrinfo failed, %s",
+                      addr, _port, gai_strerror(ret));
+            goto err;
+        }
+    }
+
+    /* getaddrinfo for client side */
+    if (src_addr) {
+        memset(&hints, 0, sizeof(hints));
+        hints.ai_family = AF_INET;
+        hints.ai_socktype = SOCK_STREAM;
+        if (getaddrinfo(src_addr, NULL, &hints, &cliinfo) != 0) {
+            hints.ai_family = AF_INET6;
+            if (getaddrinfo(src_addr, NULL, &hints, &servinfo) != 0) {
+                serverLog(LL_WARNING, "RDMA: try to bind %s, getaddrinfo failed, %s",
+                          src_addr, gai_strerror(ret));
+                goto err;
+            }
+        }
+    }
+
+    for (psrv = servinfo; psrv != NULL; psrv = psrv->ai_next) {
+        conn->fd = rsocket(psrv->ai_family, psrv->ai_socktype, psrv->ai_protocol);
+        if (conn->fd == -1) {
+            continue;
+        }
+
+        for (pcli = cliinfo; pcli != NULL; pcli = pcli->ai_next) {
+            if (rbind(conn->fd, pcli->ai_addr, pcli->ai_addrlen) != -1) {
+                break;
+            }
+        }
+
+        if (rsocketSetBlock(conn->fd, 0) != ANET_OK) {
+            goto err;
+        }
+
+        ret = rconnect(conn->fd, psrv->ai_addr, psrv->ai_addrlen);
+        if (ret == -1) {
+            if (errno != EINPROGRESS) {
+                serverLog(LL_WARNING, "RDMA: connect failed, %s", strerror(errno));
+	        goto err;
+            }
+        }
+
+        break;
+    }
+
+    ret = ANET_OK;
+    goto out;
+
+err:
+    ret = ANET_ERR;
+    if (conn->fd != -1) {
+        rclose(conn->fd);
+        conn->fd = -1;
+    }
+
+out:
+    if(servinfo) {
+        freeaddrinfo(servinfo);
+    }
+
+    if(cliinfo) {
+        freeaddrinfo(cliinfo);
+    }
+
+    return ret;
+}
+
+static int connRdmaWait(int fd, int events, long long timeoutms) {
+    struct pollfd pfd = {0};
+    int retval;
+
+    pfd.fd = fd;
+    pfd.events = events;
+
+    retval = rpoll(&pfd, 1, timeoutms);
+    if (retval < 0) {
+        return C_ERR;
+    }
+
+    return pfd.revents;
+}
+
+static int connRdmaConnect(connection *conn, const char *addr, int port, const char *src_addr, ConnectionCallbackFunc connect_handler) {
+    if (_connRdmaConnect(conn, addr, port, src_addr) != ANET_OK) {
+        return C_ERR;
+    }
+
+    conn->state = CONN_STATE_CONNECTING;
+    conn->conn_handler = connect_handler;
+    aeCreateFileEvent(server.el, conn->fd, AE_WRITABLE, conn->type->ae_handler, conn);
+
+    return C_OK;
+}
+
+static int connRdmaBlockingConnect(connection *conn, const char *addr, int port, long long timeout) {
+    if (_connRdmaConnect(conn, addr, port, NULL) != ANET_OK) {
+        return C_ERR;
+    }
+
+    if (connRdmaWait(conn->fd, POLLOUT, timeout) == C_ERR) {
+        conn->state = CONN_STATE_ERROR;
+        conn->last_errno = ETIMEDOUT;
+    }
+
+    conn->state = CONN_STATE_CONNECTED;
+    return C_OK;
+}
+
+static ssize_t connRdmaSyncWrite(connection *conn, char *ptr, ssize_t size, long long timeout) {
+    ssize_t nwritten, towrite = size;
+    long long startms = mstime(), elapsedms, waitms;
+
+    while(1) {
+        nwritten = rsend(conn->fd, ptr, towrite, 0);
+        if (nwritten == -1) {
+            if (errno != EAGAIN) {
+                return -1;
+            }
+        } else {
+            ptr += nwritten;
+            towrite -= nwritten;
+            if (towrite == 0) {
+                break;
+            }
+        }
+
+        elapsedms = mstime() - startms;
+        waitms = timeout - elapsedms;
+        if (connRdmaWait(conn->fd, POLLOUT, waitms) == C_ERR) {
+            return -1;
+        }
+
+        if (elapsedms >= timeout) {
+            errno = ETIMEDOUT;
+            return -1;
+        }
+    }
+
+    return size;
+}
+
+static ssize_t connRdmaSyncRead(connection *conn, char *ptr, ssize_t size, long long timeout) {
+    ssize_t nwritten, toread = size;
+    long long startms = mstime(), elapsedms, waitms;
+
+    while(1) {
+        nwritten = rrecv(conn->fd, ptr, toread, 0);
+        if (nwritten == -1) {
+            if (errno != EAGAIN) {
+                return -1;
+            }
+        } else {
+            ptr += nwritten;
+            toread -= nwritten;
+            if (toread == 0) {
+                break;
+            }
+        }
+
+        elapsedms = mstime() - startms;
+        waitms = timeout - elapsedms;
+        if (connRdmaWait(conn->fd, POLLIN, waitms) == C_ERR) {
+            return -1;
+        }
+
+        if (elapsedms >= timeout) {
+            errno = ETIMEDOUT;
+            return -1;
+        }
+    }
+
+    return size;
+}
+
+static ssize_t connRdmaSyncReadLine(connection *conn, char *ptr, ssize_t size, long long timeout) {
+    ssize_t nread = 0;
+    char c;
+
+    size--;
+    while(size) {
+        if (connRdmaSyncRead(conn, &c, 1, timeout) == -1) {
+            return -1;
+        }
+
+        if (c == '\n') {
+            *ptr = '\0';
+            if (nread && *(ptr - 1) == '\r') {
+                *(ptr-1) = '\0';
+            }
+
+            return nread;
+        } else {
+            *ptr++ = c;
+            *ptr = '\0';
+            nread++;
+        }
+
+        size--;
+    }
+
+    return nread;
+}
+
+static int connRdmaGetType(connection *conn) {
+    UNUSED(conn);
+
+    return CONN_TYPE_RDMA;
+}
+
+ConnectionType CT_RDMA = {
+    .ae_handler = connRdmaEventHandler,
+    .accept = connRdmaAccept,
+    .set_read_handler = connRdmaSetReadHandler,
+    .set_write_handler = connRdmaSetWriteHandler,
+    .get_last_error = connRdmaGetLastError,
+    .read = connRdmaRead,
+    .write = connRdmaWrite,
+    .close = connRdmaClose,
+    .connect = connRdmaConnect,
+    .blocking_connect = connRdmaBlockingConnect,
+    .sync_read = connRdmaSyncRead,
+    .sync_write = connRdmaSyncWrite,
+    .sync_readline = connRdmaSyncReadLine,
+    .get_type = connRdmaGetType
+};
+
+static int rdmaServer(char *err, int port, char *bindaddr, int af)
+{
+    int fd = -1, retval, val;
+    char _port[6];  /* strlen("65535") */
+    struct addrinfo hints, *servinfo, *p;
+
+    snprintf(_port,6,"%d",port);
+    memset(&hints,0,sizeof(hints));
+    hints.ai_family = af;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+    if (bindaddr && !strcmp("*", bindaddr))
+        bindaddr = NULL;
+
+    if (af == AF_INET6 && bindaddr && !strcmp("::*", bindaddr)) {
+        bindaddr = NULL;
+    }
+
+    if ((retval = getaddrinfo(bindaddr, _port, &hints, &servinfo)) != 0) {
+        serverNetError(err, "RDMA: getaddrinfo %s", gai_strerror(retval));
+        return ANET_ERR;
+    } else if (!servinfo) {
+        serverNetError(err, "RDMA: get empty addr info");
+        return ANET_ERR;
+    }
+
+    for (p = servinfo; p != NULL; p = p->ai_next) {
+        fd = rsocket(p->ai_family, p->ai_socktype, p->ai_protocol);
+        if (fd < 0) {
+            continue;
+        }
+
+        val = 1;
+        retval = rsetsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof val);
+        if (retval < 0) {
+            goto error;
+        }
+
+        retval = rbind(fd, p->ai_addr, p->ai_addrlen);
+        if (retval < 0) {
+            goto error;
+        }
+
+        retval = rlisten(fd, 16);
+        if (retval < 0) {
+            goto error;
+        }
+
+        goto end;
+    }
+
+error:
+    if (fd >= 0) {
+        rclose(fd);
+        fd = -1;
+    }
+
+end:
+    freeaddrinfo(servinfo);
+    return fd;
+}
+
+
+int listenToRdma(int port, socketFds *sfd) {
+    int j, fd;
+    char **bindaddr = server.rdma_bindaddr;
+    int bindaddr_count = server.rdma_bindaddr_count;
+    char *default_bindaddr[2] = {"*", "-::*"};
+
+    if (ibv_fork_init()) {
+        serverLog(LL_WARNING, "RDMA: FATAL error, ibv_fork_init failed");
+        return ANET_ERR;
+    }
+
+    /* Force binding of 0.0.0.0 if no bind address is specified. */
+    if (server.bindaddr_count == 0) {
+        bindaddr_count = 2;
+        bindaddr = default_bindaddr;
+    }
+
+    for (j = 0; j < bindaddr_count; j++) {
+        char* addr = bindaddr[j];
+        int optional = *addr == '-';
+
+        if (optional)
+            addr++;
+
+        if (strchr(addr,':')) {
+            fd = rdmaServer(server.neterr, port, addr, AF_INET6);
+        } else {
+            fd = rdmaServer(server.neterr, port, addr, AF_INET);
+        }
+
+        if (fd == ANET_ERR) {
+            int net_errno = errno;
+            serverLog(LL_WARNING, "RDMA: Could not create server for %s:%d: %s",
+                      addr, port, server.neterr);
+
+            if (net_errno == EADDRNOTAVAIL && optional)
+                continue;
+
+            if (net_errno == ENOPROTOOPT || net_errno == EPROTONOSUPPORT ||
+                    net_errno == ESOCKTNOSUPPORT || net_errno == EPFNOSUPPORT ||
+                    net_errno == EAFNOSUPPORT)
+                continue;
+
+            closeSocketListeners(sfd);
+            return C_ERR;
+        }
+
+        rsocketSetBlock(fd, 0);
+        anetCloexec(fd);
+        sfd->fd[sfd->count] = fd;
+        sfd->count++;
+    }
+
+    return C_OK;
+}
+
+int rdmaAccept(char *err, int s, char *ip, size_t ip_len, int *port) {
+    struct sockaddr sa;
+    struct sockaddr_in *sin;
+    socklen_t addrlen = sizeof(struct sockaddr);
+    int fd;
+
+    fd = raccept(s, &sa, &addrlen);
+    if (fd < 0) {
+        serverNetError(err, "RDMA: raccept failed, %s", gai_strerror(errno));
+        return C_ERR;
+    }
+
+    if (sa.sa_family != AF_INET) {
+        serverNetError(err, "RDMA: only support AF_INET");
+        rclose(fd);
+        fd = -1;
+        return C_ERR;
+    }
+
+    sin = (struct sockaddr_in *)&sa;
+    if (ip) {
+        inet_ntop(AF_INET, (void*)&(sin->sin_addr), ip, ip_len);
+    }
+
+    if (port) {
+        *port = ntohs(sin->sin_port);
+    }
+
+    return fd;
+}
+
+connection *connCreateRdma() {
+    connection *c = zcalloc(sizeof(connection));
+
+    c->type = &CT_RDMA;
+    c->fd = -1;
+
+    return c;
+}
+
+connection *connCreateAcceptedRdma(int fd) {
+    connection *c = connCreateRdma();
+
+    c->fd = fd;
+    c->state = CONN_STATE_ACCEPTING;
+
+    return c;
+}
+#else    /* __linux__ */
+
+"BUILD ERROR: RDMA is only supported on linux"
+
+#endif   /* __linux__ */
+#else    /* USE_RDMA */
+int listenToRdma(int port, socketFds *sfd) {
+    UNUSED(port);
+    UNUSED(sfd);
+    serverNetError(server.neterr, "RDMA: disabled, need rebuild with BUILD_RDMA=yes");
+
+    return C_ERR;
+}
+
+int rdmaAccept(char *err, int s, char *ip, size_t ip_len, int *port) {
+    UNUSED(err);
+    UNUSED(s);
+    UNUSED(ip);
+    UNUSED(ip_len);
+    UNUSED(port);
+
+    serverNetError(server.neterr, "RDMA: disabled, need rebuild with BUILD_RDMA=yes");
+    errno = EOPNOTSUPP;
+
+    return C_ERR;
+}
+
+connection *connCreateRdma() {
+    serverNetError(server.neterr, "RDMA: disabled, need rebuild with BUILD_RDMA=yes");
+    errno = EOPNOTSUPP;
+
+    return NULL;
+}
+
+connection *connCreateAcceptedRdma(int fd) {
+    UNUSED(fd);
+    serverNetError(server.neterr, "RDMA: disabled, need rebuild with BUILD_RDMA=yes");
+    errno = EOPNOTSUPP;
+
+    return NULL;
+}
+
+#endif

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -83,6 +83,7 @@ static struct config {
     const char *hostip;
     int hostport;
     const char *hostsocket;
+    int rdma;
     int tls;
     struct cliSSLconfig sslconfig;
     int numclients;
@@ -691,7 +692,10 @@ static client createClient(char *cmd, size_t len, client from, int thread_id) {
             port = node->port;
             c->cluster_node = node;
         }
-        c->context = redisConnectNonBlock(ip,port);
+        if (config.rdma)
+            c->context = redisConnectRdma(ip,port);
+        else
+            c->context = redisConnectNonBlock(ip,port);
     } else {
         c->context = redisConnectUnixNonBlock(config.hostsocket);
     }
@@ -1531,6 +1535,10 @@ int parseOptions(int argc, const char **argv) {
             config.sslconfig.ciphersuites = strdup(argv[++i]);
         #endif
         #endif
+        #ifdef USE_RDMA
+        } else if (!strcmp(argv[i],"--rdma")) {
+            config.rdma = 1;
+        #endif
         } else {
             /* Assume the user meant to provide an option when the arg starts
              * with a dash. We're done otherwise and should use the remainder
@@ -1595,6 +1603,9 @@ usage:
 "                    See the ciphers(1ssl) manpage for more information about the syntax of this string,\n"
 "                    and specifically for TLSv1.3 ciphersuites.\n"
 #endif
+#endif
+#ifdef USE_RDMA
+" --rdma             Use RDMA as transport protocol.\n"
 #endif
 " --help             Output this help and exit.\n"
 " --version          Output version and exit.\n\n"
@@ -1704,6 +1715,7 @@ int main(int argc, const char **argv) {
     config.hostip = "127.0.0.1";
     config.hostport = 6379;
     config.hostsocket = NULL;
+    config.rdma = 0;
     config.tests = NULL;
     config.dbnum = 0;
     config.auth = NULL;

--- a/src/server.h
+++ b/src/server.h
@@ -1673,6 +1673,13 @@ struct redisServer {
                                 * failover then any replica can be used. */
     int target_replica_port; /* Failover target port */
     int failover_state; /* Failover state */
+    /* RDMA config */
+    char *rdma_bindaddr[CONFIG_BINDADDR_MAX]; /* Addresses RDMA should bind to */
+    int rdma_bindaddr_count; /* Number of addresses in server.rdma_bindaddr[] */
+    char *rdma_bind_source_addr; /* Source address to bind on for outgoing connections */
+    int rdma_port; /* RDMA listening port */
+    socketFds rdmafd; /* RDMA file descriptors */
+    int rdma_replication; /* RDMA replication */
 };
 
 #define MAX_KEYS_BUFFER 256
@@ -1868,6 +1875,7 @@ void processInputBuffer(client *c);
 void acceptTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void acceptTLSHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void acceptUnixHandler(aeEventLoop *el, int fd, void *privdata, int mask);
+void acceptRdmaHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void readQueryFromClient(connection *conn);
 void addReplyNull(client *c);
 void addReplyNullArray(client *c);
@@ -1922,6 +1930,7 @@ char *getClientTypeName(int class);
 void flushSlavesOutputBuffers(void);
 void disconnectSlaves(void);
 int listenToPort(int port, socketFds *fds);
+int listenToRdma(int port, socketFds *fds);
 void pauseClients(mstime_t duration, pause_type type);
 void unpauseClients(void);
 int areClientsPaused(void);


### PR DESCRIPTION
In the production environment, RDMA gets popular and common for a
networking card. So support RDMA as transport layer protocol to
improve performance and cost reduction.

Note that this feature is ONLY implemented/tested on Linux.

Actually, this is the v2 implementation. The v1 uses low level IB
verbs API directly, the code and discuss ses PR:
    https://github.com/redis/redis/pull/9161

Instead of low level API, the v2 use rsocket which is implemented
by rdma-core to simplify the work in Redis.

The test result is quite exciting:
CPU: Intel(R) Xeon(R) Platinum 8260.
NIC: Mellanox ConnectX-5.
Config of redis: appendonly no, port 6379, rdma-port 6379, appendonly no,
                 server_cpulist 12, bgsave_cpulist 16.
For RDMA: ./redis-benchmark -h HOST -c 30 -n 10000000 -r 1000000000 \
          --threads 8 -d 512 -t ping,set,get,lrange_100 --rdma
For TCP: ./redis-benchmark -h HOST -c 30 -n 10000000 -r 1000000000 \
          --threads 8 -d 512 -t ping,set,get,lrange_100

====== PING_INLINE ======
    TCP: QPS: 159017   AVG LAT: 0.183
v1 RDMA: QPS: 523944   AVG LAT: 0.054
v2 RDMA: QPS: 492683   AVG LAT: 0.052

====== PING_MBULK ======
    TCP: QPS: 162256   AVG LAT: 0.179
v1 RDMA: QPS: 509839   AVG LAT: 0.056
v2 RDMA: QPS: 532226   AVG LAT: 0.048

====== SET ======
    TCP: QPS: 154700   AVG LAT: 0.187
v1 RDMA: QPS: 492368   AVG LAT: 0.058
v2 RDMA: QPS: 295534   AVG LAT: 0.095

====== GET ======
    TCP: QPS: 159022   AVG LAT: 0.182
v1 RDMA: QPS: 525099   AVG LAT: 0.054
v1 RDMA: QPS: 411488   AVG LAT: 0.065

====== LPUSH (needed to benchmark LRANGE) ======
    TCP: QPS: 142537   AVG LAT: 0.207
v1 RDMA: QPS: 395038   AVG LAT: 0.073
v2 RDMA: QPS: 353232   AVG LAT: 0.079

====== LRANGE_100 (first 100 elements) ======
    TCP: QPS:  36171   AVG LAT: 0.657
v1 RDMA: QPS:  55266   AVG LAT: 0.412
v2 RDMA: QPS:  52228   AVG LAT: 0.468

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>