### PR TITLE
Minor refactoring for rioConnRead and adding errno

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1756,10 +1756,10 @@ void readSyncBulkPayload(connection *conn) {
 
         if (rdbLoadRio(&rdb,RDBFLAGS_REPLICATION,&rsi) != C_OK) {
             /* RDB loading failed. */
-            stopLoading(0);
             serverLog(LL_WARNING,
-                "Failed trying to load the MASTER synchronization DB "
-                "from socket: %s", strerror(errno));
+                      "Failed trying to load the MASTER synchronization DB "
+                      "from socket: %s", strerror(errno));
+            stopLoading(0);
             cancelReplicationHandshake(1);
             rioFreeConn(&rdb, NULL);
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -1759,7 +1759,7 @@ void readSyncBulkPayload(connection *conn) {
             stopLoading(0);
             serverLog(LL_WARNING,
                 "Failed trying to load the MASTER synchronization DB "
-                "from socket");
+                "from socket: %s", strerror(errno));
             cancelReplicationHandshake(1);
             rioFreeConn(&rdb, NULL);
 

--- a/src/rio.c
+++ b/src/rio.c
@@ -204,7 +204,8 @@ static size_t rioConnRead(rio *r, void *buf, size_t len) {
         size_t toread = needs < PROTO_IOBUF_LEN ? PROTO_IOBUF_LEN: needs;
         if (toread > sdsavail(r->io.conn.buf)) toread = sdsavail(r->io.conn.buf);
         if (r->io.conn.read_limit != 0 &&
-            r->io.conn.read_so_far + buffered + toread > r->io.conn.read_limit) {
+            r->io.conn.read_so_far + buffered + toread > r->io.conn.read_limit)
+        {
             toread = r->io.conn.read_limit - r->io.conn.read_so_far - buffered;
         }
         int retval = connRead(r->io.conn.conn,

--- a/src/rio.c
+++ b/src/rio.c
@@ -187,6 +187,14 @@ static size_t rioConnRead(rio *r, void *buf, size_t len) {
         r->io.conn.pos = 0;
     }
 
+    /* Make sure the caller didn't request to read past the limit.
+     * If they didn't we'll buffer till the limit, if they did, we'll
+     * return an error. */
+    if (r->io.conn.read_limit != 0 && r->io.conn.read_limit < r->io.conn.read_so_far + len) {
+        errno = EOVERFLOW;
+        return 0;
+    }
+
     /* If we don't already have all the data in the sds, read more */
     while (len > sdslen(r->io.conn.buf) - r->io.conn.pos) {
         size_t buffered = sdslen(r->io.conn.buf) - r->io.conn.pos;
@@ -196,17 +204,8 @@ static size_t rioConnRead(rio *r, void *buf, size_t len) {
         size_t toread = needs < PROTO_IOBUF_LEN ? PROTO_IOBUF_LEN: needs;
         if (toread > sdsavail(r->io.conn.buf)) toread = sdsavail(r->io.conn.buf);
         if (r->io.conn.read_limit != 0 &&
-            r->io.conn.read_so_far + buffered + toread > r->io.conn.read_limit)
-        {
-            /* Make sure the caller didn't request to read past the limit.
-             * If they didn't we'll buffer till the limit, if they did, we'll
-             * return an error. */
-            if (r->io.conn.read_limit >= r->io.conn.read_so_far + len)
-                toread = r->io.conn.read_limit - r->io.conn.read_so_far - buffered;
-            else {
-                errno = EOVERFLOW;
-                return 0;
-            }
+            r->io.conn.read_so_far + buffered + toread > r->io.conn.read_limit) {
+            toread = r->io.conn.read_limit - r->io.conn.read_so_far - buffered;
         }
         int retval = connRead(r->io.conn.conn,
                           (char*)r->io.conn.buf + sdslen(r->io.conn.buf),


### PR DESCRIPTION
Redis 6.0 contained a bug when the master uses disk-based replication (repl-diskless-sync is no) and the replica is disk-less (repl-diskless-load is set to non-default value).
The bug could cause the rdb loading code in the replica to buffer too much data from the socket and fail the replication.

Due to https://github.com/redis/redis/commit/da840e9851bab8d1674e245a812b2105be111208 the error condition does not depend on the while loop where we read from socket. This change cleans up the code and extracts the condition outside the loop. 
The change adds errno to "Failed trying to load the MASTER synchronization DB" error message in readSyncBulkPayload() to make debugging of the similar problems easier in the future.