### PR TITLE
Hide empty replicas from CLUSTER SLOTS responses

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4383,6 +4383,24 @@ int getSlotOrReply(client *c, robj *o) {
     return (int) slot;
 }
 
+/* Returns an indication if the replica node is fully available
+* and should be listed in CLUSTER SLOTS response.
+* Returns 1 for available nodes, 0 for nodes that have 
+* not finished their initial sync, in failed state, or are 
+* otherwise considered not available to serve read commands. */
+static int isReplicaAvailable(clusterNode *node) {
+    if (nodeFailed(node)) {
+        return 0;
+    }
+    long long repl_offset = node->repl_offset;
+    if (node->flags & CLUSTER_NODE_MYSELF) {
+        /* Nodes do not update their own information
+        * in the cluster node list. */
+        repl_offset = replicationGetSlaveOffset();
+    }
+    return (repl_offset != 0);
+}
+
 void addNodeReplyForClusterSlot(client *c, clusterNode *node, int start_slot, int end_slot) {
     int i, nested_elements = 3; /* slots (2) + master addr (1) */
     void *nested_replylen = addReplyDeferredLen(c);
@@ -4400,7 +4418,7 @@ void addNodeReplyForClusterSlot(client *c, clusterNode *node, int start_slot, in
     for (i = 0; i < node->numslaves; i++) {
         /* This loop is copy/pasted from clusterGenNodeDescription()
          * with modifications for per-slot node aggregation. */
-        if (nodeFailed(node->slaves[i])) continue;
+        if (!isReplicaAvailable(node->slaves[i])) continue;
         addReplyArrayLen(c, 3);
         addReplyBulkCString(c, node->slaves[i]->ip);
         /* Report slave's non-TLS port to non-TLS client in TLS cluster */

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4395,7 +4395,7 @@ static int isReplicaAvailable(clusterNode *node) {
     long long repl_offset = node->repl_offset;
     if (node->flags & CLUSTER_NODE_MYSELF) {
         /* Nodes do not update their own information
-        * in the cluster node list. */
+         * in the cluster node list. */
         repl_offset = replicationGetSlaveOffset();
     }
     return (repl_offset != 0);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4384,10 +4384,10 @@ int getSlotOrReply(client *c, robj *o) {
 }
 
 /* Returns an indication if the replica node is fully available
-* and should be listed in CLUSTER SLOTS response.
-* Returns 1 for available nodes, 0 for nodes that have 
-* not finished their initial sync, in failed state, or are 
-* otherwise considered not available to serve read commands. */
+ * and should be listed in CLUSTER SLOTS response.
+ * Returns 1 for available nodes, 0 for nodes that have 
+ * not finished their initial sync, in failed state, or are 
+ * otherwise considered not available to serve read commands. */
 static int isReplicaAvailable(clusterNode *node) {
     if (nodeFailed(node)) {
         return 0;

--- a/tests/cluster/tests/22-replica-in-sync.tcl
+++ b/tests/cluster/tests/22-replica-in-sync.tcl
@@ -1,0 +1,56 @@
+source "../tests/includes/init-tests.tcl"
+
+test "Create a 1 node cluster" {
+    create_cluster 1 0
+}
+
+test "Cluster is up" {
+    assert_cluster_state ok
+}
+
+test "Cluster is writable" {
+    cluster_write_test 0
+}
+
+set numkeys 10000000000
+set numops 100000
+array set content {}
+set master_id 0
+
+proc is_in_slots {id slots} {
+    set found_position [string first $id $slots]
+    set result [expr {$found_position != -1}]
+    return $result
+}
+
+test "Fill up with keys" {
+    for {set j 0} {$j < $numops} {incr j} {
+        set listid [randomInt $numkeys]
+        set key "key:$listid"
+        set ele [randomValue]
+        R 0 rpush $key $ele
+        lappend content($key) $ele
+    }
+}
+
+test "Add new node as replica" {
+    set replica_id [cluster_find_available_slave 1]
+    set master_myself [get_myself $master_id]
+    R $replica_id clusteradmin replicate [dict get $master_myself id]
+}
+
+test "Check keys exist in the new replica" {
+    R 1 readonly
+    while (1) {
+        set slots [R 0 cluster slots]
+        set replica_myself [get_myself $replica_id]
+        set replica [dict get $replica_myself id]
+        if ([is_in_slots $replica $slots]) {
+            foreach {key value} [array get content] {
+                set is_exist [R 1 exists $key]
+                assert {$is_exist}
+            }
+            break
+        }
+    }
+}

--- a/tests/cluster/tests/22-replica-in-sync.tcl
+++ b/tests/cluster/tests/22-replica-in-sync.tcl
@@ -12,8 +12,9 @@ test "Cluster is writable" {
     cluster_write_test 0
 }
 
-proc is_in_slots {id slots} {
-    set found_position [string first $id $slots]
+proc is_in_slots {master_id replica} {
+    set slots [R $master_id cluster slots]
+    set found_position [string first $replica $slots]
     set result [expr {$found_position != -1}]
     return $result
 }
@@ -35,20 +36,19 @@ test "Add new node as replica" {
     set master_myself [get_myself $master_id]
     set replica_myself [get_myself $replica_id]
     set replica [dict get $replica_myself id]
-    R $replica_id clusteradmin replicate [dict get $master_myself id]
+    R $replica_id cluster replicate [dict get $master_myself id]
 }
 
 test "Check digest and replica state" {
     R 1 readonly
-    while (1) {
-        set slots [R $master_id cluster slots]
-        if ([is_in_slots $replica $slots]) {
-            set master_digest [R $master_id debug digest]
-            set replica_digest [R $replica_id debug digest]
-            set info_repl [R $master_id info replication]
-            assert {$master_digest eq $replica_digest}
-            assert {[is_replica_online $info_repl]}
-            break
-        }
+    wait_for_condition 100 50 {
+        [is_in_slots $master_id $replica]
+    } else {
+        fail "New replica didn't appear in the slots"
     }
+    set master_digest [R $master_id debug digest]
+    set replica_digest [R $replica_id debug digest]
+    set info_repl [R $master_id info replication]
+    assert {$master_digest eq $replica_digest}
+    assert {[is_replica_online $info_repl]}
 }

--- a/tests/cluster/tests/22-replica-in-sync.tcl
+++ b/tests/cluster/tests/22-replica-in-sync.tcl
@@ -28,7 +28,7 @@ proc is_replica_online {info_repl} {
 set master_id 0
 
 test "Fill up" {
-    R $master_id debug populate 1000000 key 100
+    R $master_id debug populate 10000000 key 100
 }
 
 test "Add new node as replica" {
@@ -41,14 +41,63 @@ test "Add new node as replica" {
 
 test "Check digest and replica state" {
     R 1 readonly
-    wait_for_condition 100 50 {
+    wait_for_condition 1000 50 {
         [is_in_slots $master_id $replica]
     } else {
         fail "New replica didn't appear in the slots"
     }
-    set master_digest [R $master_id debug digest]
+    wait_for_condition 1000 50 {
+        [is_replica_online [R $master_id info replication]]
+    } else {
+        fail "Replica is down for too long"
+    }
     set replica_digest [R $replica_id debug digest]
-    set info_repl [R $master_id info replication]
-    assert {$master_digest eq $replica_digest}
-    assert {[is_replica_online $info_repl]}
+    assert {$replica_digest ne 0}
+}
+
+test "Replica in loading state is hidden" {
+    # Kill replica client for master and load new data to the primary
+    R $master_id multi
+    R $master_id config set repl-backlog-size 100
+    R $master_id client kill type replica
+    set num 10000
+    set value [string repeat A 1024]
+    for {set j 0} {$j < $num} {incr j} {
+        set key "{0}"
+        append key $j
+        R $master_id set key $value
+    }
+    R $master_id exec
+
+    # Check that replica started loading
+    wait_for_condition 1000 50 {
+        [s $replica_id loading] eq 1
+    } else {
+        fail "Replica didn't enter loading state"
+    }
+    # Check that replica is not in cluster slots
+    assert {![is_in_slots $master_id $replica]}
+
+    # Wait for sync to finish
+    wait_for_condition 1000 50 {
+        [s $replica_id loading] eq 0
+    } else {
+        fail "Replica is in loading state for too long"
+    }
+
+    # Check replica is back to cluster slots
+    wait_for_condition 1000 50 {
+        [is_in_slots $master_id $replica] 
+    } else {
+        fail "Replica is not back to slots"
+    }
+}
+
+test "Check disconnected replica not hidden from slots" {
+    # Disconnect replica from primary
+    R $master_id client kill type replica
+    # Check master to have no replicas
+    assert {[s $master_id connected_slaves] == 0}
+    # Check that replica is still in the cluster slots
+    assert {[is_in_slots $master_id $replica]}
 }


### PR DESCRIPTION
Hide empty replicas - Cluster bus delay broadcast new replica address until replica is in sync with primary · Issue #8208 · redis/redis (https://github.com/redis/redis/issues/8208): One possible solution for this without changing cluster bus is to hide empty replicas from CLUSTER SLOTS command. Empty means having a reported replication offset of zero. This relies on the replication offset reported by nodes in cluster PING/PONG messages.

Hiding empty replicas from CLUSTER SLOTS (while still showing them in CLUSTER NODES) is similar to the current hiding of failed nodes. From a data-path POV, an empty replica is not very useful.