### PR TITLE
Add sentinel debug option command

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -92,8 +92,6 @@ static int sentinel_script_max_runtime = 60000;  /* 60 seconds max exec time. */
 static int sentinel_script_retry_delay = 30000;  /* 30 seconds between retries. */
 static int sentinel_default_failover_timeout = 60*3*1000;
 
-
-
 #define SENTINEL_HELLO_CHANNEL "__sentinel__:hello"
 #define SENTINEL_DEFAULT_SLAVE_PRIORITY 100
 #define SENTINEL_DEFAULT_PARALLEL_SYNCS 1
@@ -130,7 +128,6 @@ static int sentinel_default_failover_timeout = 60*3*1000;
 #define SENTINEL_SCRIPT_MAX_QUEUE 256
 #define SENTINEL_SCRIPT_MAX_RUNNING 16
 #define SENTINEL_SCRIPT_MAX_RETRY 10
-
 
 /* SENTINEL SIMULATE-FAILURE command flags. */
 #define SENTINEL_SIMFAILURE_NONE 0
@@ -2107,7 +2104,6 @@ const char *sentinelHandleConfiguration(char **argv, int argc) {
         return "Unrecognized sentinel configuration statement.";
     }
     return NULL;
-    /*#define SENTINEL_DEFAUT_DOWN_AFTER 30000*/
 }
 
 /* Implements CONFIG REWRITE for "sentinel" option.

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3489,6 +3489,60 @@ void addReplySentinelRedisInstance(client *c, sentinelRedisInstance *ri) {
     setDeferredMapLen(c,mbl,fields);
 }
 
+void addReplySentinelConfig(client *c) {
+   
+    void *mbl;
+    int fields = 0;
+
+    mbl = addReplyDeferredLen(c);
+
+    addReplyBulkCString(c,"SENTINEL_INFO_PERIOD");
+    addReplyBulkLongLong(c,sentinel_info_period);
+    fields++;
+
+    addReplyBulkCString(c,"SENTINEL_PING_PERIOD");
+    addReplyBulkLongLong(c,sentinel_ping_period);
+    fields++;
+
+    addReplyBulkCString(c,"SENTINEL_ASK_PERIOD");
+    addReplyBulkLongLong(c,sentinel_ask_period);
+    fields++;
+
+    addReplyBulkCString(c,"SENTINEL_PUBLISH_PERIOD");
+    addReplyBulkLongLong(c,sentinel_publish_period);
+    fields++;
+
+    addReplyBulkCString(c,"SENTINEL_TILT_TRIGGER");
+    addReplyBulkLongLong(c,sentinel_tilt_trigger);
+    fields++;
+
+    addReplyBulkCString(c,"SENTINEL_TILT_PERIOD");
+    addReplyBulkLongLong(c,sentinel_tilt_period);
+    fields++;
+
+    addReplyBulkCString(c,"SENTINEL_SLAVE_RECONF_TIMEOUT");
+    addReplyBulkLongLong(c,sentinel_slave_reconf_timeout);
+    fields++;
+
+    addReplyBulkCString(c,"SENTINEL_MIN_LINK_RECONNECT_PERIOD");
+    addReplyBulkLongLong(c,sentinel_min_link_reconnect_period);
+    fields++;
+
+    addReplyBulkCString(c,"SENTINEL_ELECTION_TIMEOUT");
+    addReplyBulkLongLong(c,sentinel_election_timeout);
+    fields++;
+
+    addReplyBulkCString(c,"SENTINEL_SCRIPT_MAX_RUNTIME");
+    addReplyBulkLongLong(c,sentinel_script_max_runtime);
+    fields++;
+
+    addReplyBulkCString(c,"SENTINEL_SCRIPT_RETRY_DELAY");
+    addReplyBulkLongLong(c,sentinel_script_retry_delay);
+    fields++;
+
+    setDeferredMapLen(c,mbl,fields);
+}
+
 /* Output a number of instances contained inside a dictionary as
  * Redis protocol. */
 void addReplyDictOfRedisInstances(client *c, dict *instances) {
@@ -3562,6 +3616,8 @@ void sentinelCommand(client *c) {
 "    Set a global Sentinel configuration parameter.",
 "CONFIG GET <param>",
 "    Get global Sentinel configuration parameter.",
+"DEBUG",
+"    Show a list of configurable time parameters and their values (milliseconds).",
 "GET-MASTER-ADDR-BY-NAME <master-name>",
 "    Return the ip and port number of the master with that name.",
 "FAILOVER <master-name>",
@@ -3913,7 +3969,11 @@ NULL
             }
         }
         addReply(c,shared.ok);
-    } else {
+    } else if (!strcasecmp(c->argv[1]->ptr,"debug")) {
+        if (c->argc != 2) goto numargserr;
+        addReplySentinelConfig(c);
+    } 
+    else {
         addReplySubcommandSyntaxError(c);
     }
     return;

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3475,7 +3475,6 @@ void sentinelSetDebugConfigParameters(client *c){
                 goto badfmt;
             }
             sentinel_ping_period = ll;
-            sentinel_tilt_period = sentinel_ping_period * 30;
            
         } else if (!strcasecmp(option,"ask-period") && moreargs > 0) {
             /* ask-period <milliseconds> */
@@ -3512,6 +3511,15 @@ void sentinelSetDebugConfigParameters(client *c){
                 goto badfmt;
             }
             sentinel_tilt_trigger = ll;
+           
+        } else if (!strcasecmp(option,"tilt_period") && moreargs > 0) {
+            /* tilt-period <milliseconds> */
+            robj *o = c->argv[++j];
+            if (getLongLongFromObject(o,&ll) == C_ERR || ll <= 0) {
+                badarg = j;
+                goto badfmt;
+            }
+            sentinel_tilt_period = ll;
            
         } else if (!strcasecmp(option,"slave_reconf_timeout") && moreargs > 0) {
             /* slave_reconf_timeout <milliseconds> */

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -83,7 +83,7 @@ typedef struct sentinelAddr {
 static mstime_t sentinel_info_period = 10000;
 static mstime_t sentinel_ping_period = SENTINEL_PING_PERIOD;
 static mstime_t sentinel_ask_period = 1000;
-static mstime_t sentinel_publish_period = 1000;
+static mstime_t sentinel_publish_period = 2000;
 static mstime_t sentinel_default_down_after = 30000;
 static mstime_t sentinel_tilt_trigger = 2000;
 static mstime_t sentinel_tilt_period = SENTINEL_PING_PERIOD * 30;
@@ -2008,7 +2008,7 @@ const char *sentinelHandleConfiguration(char **argv, int argc) {
             return "Same command renamed multiple times with rename-command.";
         }
     } else if (!strcasecmp(argv[0],"announce-ip") && argc == 2) {
-        /* announce-ip <ip-address> */  
+        /* announce-ip <ip-address> */
         if (strlen(argv[1]))
             sentinel.announce_ip = sdsnew(argv[1]);
     } else if (!strcasecmp(argv[0],"announce-port") && argc == 2) {
@@ -2038,8 +2038,7 @@ const char *sentinelHandleConfiguration(char **argv, int argc) {
         if ((sentinel.announce_hostnames = yesnotoi(argv[1])) == -1) {
             return "Please specify yes or no for the announce-hostnames option.";
         }
-    } 
-    else {
+    } else {
         return "Unrecognized sentinel configuration statement.";
     }
     return NULL;
@@ -3494,8 +3493,8 @@ void sentinelSetDebugConfigParameters(client *c){
             }
             sentinel_publish_period = ll;
            
-        }else if (!strcasecmp(option,"default_down_after") && moreargs > 0) {
-            /* sentinel_default_down_after <milliseconds> */
+        }else if (!strcasecmp(option,"default-down-after") && moreargs > 0) {
+            /* default-down-after <milliseconds> */
             robj *o = c->argv[++j];
             if (getLongLongFromObject(o,&ll) == C_ERR || ll <= 0) {
                 badarg = j;
@@ -3503,8 +3502,8 @@ void sentinelSetDebugConfigParameters(client *c){
             }
             sentinel_default_down_after = ll;
            
-        } else if (!strcasecmp(option,"tilt_trigger") && moreargs > 0) {
-            /* tilt_trigger <milliseconds> */
+        } else if (!strcasecmp(option,"tilt-trigger") && moreargs > 0) {
+            /* tilt-trigger <milliseconds> */
             robj *o = c->argv[++j];
             if (getLongLongFromObject(o,&ll) == C_ERR || ll <= 0) {
                 badarg = j;
@@ -3512,7 +3511,7 @@ void sentinelSetDebugConfigParameters(client *c){
             }
             sentinel_tilt_trigger = ll;
            
-        } else if (!strcasecmp(option,"tilt_period") && moreargs > 0) {
+        } else if (!strcasecmp(option,"tilt-period") && moreargs > 0) {
             /* tilt-period <milliseconds> */
             robj *o = c->argv[++j];
             if (getLongLongFromObject(o,&ll) == C_ERR || ll <= 0) {
@@ -3521,8 +3520,8 @@ void sentinelSetDebugConfigParameters(client *c){
             }
             sentinel_tilt_period = ll;
            
-        } else if (!strcasecmp(option,"slave_reconf_timeout") && moreargs > 0) {
-            /* slave_reconf_timeout <milliseconds> */
+        } else if (!strcasecmp(option,"slave-reconf-timeout") && moreargs > 0) {
+            /* slave-reconf-timeout <milliseconds> */
             robj *o = c->argv[++j];
             if (getLongLongFromObject(o,&ll) == C_ERR || ll <= 0) {
                 badarg = j;
@@ -3530,8 +3529,8 @@ void sentinelSetDebugConfigParameters(client *c){
             }
             sentinel_slave_reconf_timeout = ll;
            
-        } else if (!strcasecmp(option,"min_link_reconnect_period") && moreargs > 0) {
-            /* min_link_reconnect_period <milliseconds> */
+        } else if (!strcasecmp(option,"min-link-reconnect-period") && moreargs > 0) {
+            /* min-link-reconnect-period <milliseconds> */
             robj *o = c->argv[++j];
             if (getLongLongFromObject(o,&ll) == C_ERR || ll <= 0) {
                 badarg = j;
@@ -3539,8 +3538,8 @@ void sentinelSetDebugConfigParameters(client *c){
             }
             sentinel_min_link_reconnect_period = ll;
            
-        } else if (!strcasecmp(option,"default_failover_timeout") && moreargs > 0) {
-            /* default_failover_timeout <milliseconds> */
+        } else if (!strcasecmp(option,"default-failover-timeout") && moreargs > 0) {
+            /* default-failover-timeout <milliseconds> */
             robj *o = c->argv[++j];
             if (getLongLongFromObject(o,&ll) == C_ERR || ll <= 0) {
                 badarg = j;
@@ -3548,8 +3547,8 @@ void sentinelSetDebugConfigParameters(client *c){
             }
             sentinel_default_failover_timeout = ll;
            
-        } else if (!strcasecmp(option,"election_timeout") && moreargs > 0) {
-            /* election_timeout <milliseconds> */
+        } else if (!strcasecmp(option,"election-timeout") && moreargs > 0) {
+            /* election-timeout <milliseconds> */
             robj *o = c->argv[++j];
             if (getLongLongFromObject(o,&ll) == C_ERR || ll <= 0) {
                 badarg = j;
@@ -3557,8 +3556,8 @@ void sentinelSetDebugConfigParameters(client *c){
             }
             sentinel_election_timeout = ll;
            
-        } else if (!strcasecmp(option,"script_max_runtime") && moreargs > 0) {
-            /* script_max_runtime <milliseconds> */
+        } else if (!strcasecmp(option,"script-max-runtime") && moreargs > 0) {
+            /* script-max-runtime <milliseconds> */
             robj *o = c->argv[++j];
             if (getLongLongFromObject(o,&ll) == C_ERR || ll <= 0) {
                 badarg = j;
@@ -3566,8 +3565,8 @@ void sentinelSetDebugConfigParameters(client *c){
             }
             sentinel_script_max_runtime = ll;
            
-        } else if (!strcasecmp(option,"script_retry_delay") && moreargs > 0) {
-            /* script_retry_delay <milliseconds> */
+        } else if (!strcasecmp(option,"script-retry-delay") && moreargs > 0) {
+            /* script-retry-delay <milliseconds> */
             robj *o = c->argv[++j];
             if (getLongLongFromObject(o,&ll) == C_ERR || ll <= 0) {
                 badarg = j;
@@ -3600,55 +3599,55 @@ void addReplySentinelDebugInfo(client *c) {
 
     mbl = addReplyDeferredLen(c);
 
-    addReplyBulkCString(c,"SENTINEL_INFO_PERIOD");
+    addReplyBulkCString(c,"INFO-PERIOD");
     addReplyBulkLongLong(c,sentinel_info_period);
     fields++;
 
-    addReplyBulkCString(c,"SENTINEL_PING_PERIOD");
+    addReplyBulkCString(c,"PING-PERIOD");
     addReplyBulkLongLong(c,sentinel_ping_period);
     fields++;
 
-    addReplyBulkCString(c,"SENTINEL_ASK_PERIOD");
+    addReplyBulkCString(c,"ASK-PERIOD");
     addReplyBulkLongLong(c,sentinel_ask_period);
     fields++;
 
-    addReplyBulkCString(c,"SENTINEL_PUBLISH_PERIOD");
+    addReplyBulkCString(c,"PUBLISH-PERIOD");
     addReplyBulkLongLong(c,sentinel_publish_period);
     fields++;
 
-    addReplyBulkCString(c,"SENTINEL_DEFAULT_DOWN_AFTER");
+    addReplyBulkCString(c,"DEFAULT-DOWN-AFTER");
     addReplyBulkLongLong(c,sentinel_default_down_after);
     fields++;
 
-    addReplyBulkCString(c,"SENTINEL_DEFAULT_FAILOVER_TIMEOUT");
+    addReplyBulkCString(c,"DEFAULT-FAILOVER-TIMEOUT");
     addReplyBulkLongLong(c,sentinel_default_failover_timeout);
     fields++;
     
-    addReplyBulkCString(c,"SENTINEL_TILT_TRIGGER");
+    addReplyBulkCString(c,"TILT-TRIGGER");
     addReplyBulkLongLong(c,sentinel_tilt_trigger);
     fields++;
 
-    addReplyBulkCString(c,"SENTINEL_TILT_PERIOD");
+    addReplyBulkCString(c,"TILT-PERIOD");
     addReplyBulkLongLong(c,sentinel_tilt_period);
     fields++;
 
-    addReplyBulkCString(c,"SENTINEL_SLAVE_RECONF_TIMEOUT");
+    addReplyBulkCString(c,"SLAVE-RECONF-TIMEOUT");
     addReplyBulkLongLong(c,sentinel_slave_reconf_timeout);
     fields++;
 
-    addReplyBulkCString(c,"SENTINEL_MIN_LINK_RECONNECT_PERIOD");
+    addReplyBulkCString(c,"MIN-LINK-RECONNECT-PERIOD");
     addReplyBulkLongLong(c,sentinel_min_link_reconnect_period);
     fields++;
 
-    addReplyBulkCString(c,"SENTINEL_ELECTION_TIMEOUT");
+    addReplyBulkCString(c,"ELECTION-TIMEOUT");
     addReplyBulkLongLong(c,sentinel_election_timeout);
     fields++;
 
-    addReplyBulkCString(c,"SENTINEL_SCRIPT_MAX_RUNTIME");
+    addReplyBulkCString(c,"SCRIPT-MAX-RUNTIME");
     addReplyBulkLongLong(c,sentinel_script_max_runtime);
     fields++;
 
-    addReplyBulkCString(c,"SENTINEL_SCRIPT_RETRY_DELAY");
+    addReplyBulkCString(c,"SCRIPT-RETRY-DELAY");
     addReplyBulkLongLong(c,sentinel_script_retry_delay);
     fields++;
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -78,13 +78,15 @@ typedef struct sentinelAddr {
 #define SRI_SCRIPT_KILL_SENT (1<<12) /* SCRIPT KILL already sent on -BUSY */
 
 /* Note: times are in milliseconds. */
+#define SENTINEL_PING_PERIOD 1000
+
 static mstime_t sentinel_info_period = 10000;
-static mstime_t sentinel_ping_period = 1000;
+static mstime_t sentinel_ping_period = SENTINEL_PING_PERIOD;
 static mstime_t sentinel_ask_period = 1000;
 static mstime_t sentinel_publish_period = 1000;
 static mstime_t sentinel_default_down_after = 30000;
 static mstime_t sentinel_tilt_trigger = 2000;
-static mstime_t sentinel_tilt_period = 1000 * 30;
+static mstime_t sentinel_tilt_period = SENTINEL_PING_PERIOD * 30;
 static mstime_t sentinel_slave_reconf_timeout = 10000;
 static mstime_t sentinel_min_link_reconnect_period = 15000;
 static mstime_t sentinel_election_timeout = 10000;
@@ -3473,6 +3475,7 @@ void sentinelSetDebugConfigParameters(client *c){
                 goto badfmt;
             }
             sentinel_ping_period = ll;
+            sentinel_tilt_period = sentinel_ping_period * 30;
            
         } else if (!strcasecmp(option,"ask-period") && moreargs > 0) {
             /* ask-period <milliseconds> */
@@ -3509,15 +3512,6 @@ void sentinelSetDebugConfigParameters(client *c){
                 goto badfmt;
             }
             sentinel_tilt_trigger = ll;
-           
-        } else if (!strcasecmp(option,"tilt_period") && moreargs > 0) {
-            /* tilt-period <milliseconds> */
-            robj *o = c->argv[++j];
-            if (getLongLongFromObject(o,&ll) == C_ERR || ll <= 0) {
-                badarg = j;
-                goto badfmt;
-            }
-            sentinel_tilt_period = ll;
            
         } else if (!strcasecmp(option,"slave_reconf_timeout") && moreargs > 0) {
             /* slave_reconf_timeout <milliseconds> */

--- a/tests/sentinel/tests/includes/sentinel.conf
+++ b/tests/sentinel/tests/includes/sentinel.conf
@@ -6,17 +6,4 @@ sentinel parallel-syncs setmaster 2
 sentinel failover-timeout setmaster 240000
 # monitoring set
 sentinel monitor setmaster 10.0.0.1 30000 2
-sentinel info-period 5000
-sentinel ping-period 500
-sentinel ask-period 500
-sentinel publish-period 1000
-sentinel default_down_after 15000
-sentinel tilt_trigger 1000
-sentinel tilt_period 15000
-sentinel slave_reconf_timeout 5000
-sentinel min_link_reconnect_period 7500
-sentinel default_failover_timeout 90000
-sentinel election_timeout 5000
-sentinel script_max_runtime 30000
-sentinel script_retry_delay 15000
 

--- a/tests/sentinel/tests/includes/sentinel.conf
+++ b/tests/sentinel/tests/includes/sentinel.conf
@@ -6,6 +6,17 @@ sentinel parallel-syncs setmaster 2
 sentinel failover-timeout setmaster 240000
 # monitoring set
 sentinel monitor setmaster 10.0.0.1 30000 2
-
-
+sentinel info-period 5000
+sentinel ping-period 500
+sentinel ask-period 500
+sentinel publish-period 1000
+sentinel default_down_after 15000
+sentinel tilt_trigger 1000
+sentinel tilt_period 15000
+sentinel slave_reconf_timeout 5000
+sentinel min_link_reconnect_period 7500
+sentinel default_failover_timeout 90000
+sentinel election_timeout 5000
+sentinel script_max_runtime 30000
+sentinel script_retry_delay 15000
 


### PR DESCRIPTION
For test purpose, we could change some parameters by SENTINEL DEBUG command
 It is mentioned in the following 2 PR:
#8891 and #8710

The command format has 2 options:
1. SENTINEL DEBUG: display our current configurable parameters value
![Capture](https://user-images.githubusercontent.com/51993843/128195464-78c1254a-1682-4fe7-aea9-bde7ea65a3d8.JPG)

2. SENTINEL DEBUG [<option> <value>...]: update our current configurable parameters values (one or more)
for example: sentinel debug info-period 6000

These configurable parameters as following: 
SENTINEL_INFO_PERIOD 
SENTINEL_PING_PERIOD 
SENTINEL_ASK_PERIOD 
SENTINEL_PUBLISH_PERIOD 
SENTINEL_DEFAULT_DOWN_AFTER 
SENTINEL_TILT_TRIGGER 
SENTINEL_TILT_PERIOD
SENTINEL_SLAVE_RECONF_TIMEOUT 
SENTINEL_MIN_LINK_RECONNECT_PERIOD 
SENTINEL_ELECTION_TIMEOUT 
SENTINEL_SCRIPT_MAX_RUNTIME
SENTINEL_SCRIPT_RETRY_DELAY
SENTINEL_DEFAULT_FAILOVER_TIMEOUT 