### PR TITLE
Tests: avoid short reads on redis-cli output.

### DIFF
--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -31,13 +31,18 @@ start_server {tags {"cli"}} {
     }
 
     proc read_cli {fd} {
-        set buf [read $fd]
-        while {[string length $buf] == 0} {
-            # wait some time and try again
-            after 10
+        set ret {}
+        set empty_reads 0
+        while {$empty_reads < 5 || [string index $ret end] != "\n"} {
             set buf [read $fd]
+            if {[string length $buf] == 0} {
+                after 10
+                incr empty_reads
+            } else {
+                append ret $buf
+            }
         }
-        set _ $buf
+        return $ret
     }
 
     proc write_cli {fd buf} {

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -33,13 +33,14 @@ start_server {tags {"cli"}} {
     proc read_cli {fd} {
         set ret {}
         set empty_reads 0
-        while {$empty_reads < 5 || [string index $ret end] != "\n"} {
+        while {$empty_reads < 5} {
             set buf [read $fd]
             if {[string length $buf] == 0} {
                 after 10
                 incr empty_reads
             } else {
                 append ret $buf
+                set empty_reads 0
             }
         }
         return $ret

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -31,7 +31,13 @@ start_server {tags {"cli"}} {
     }
 
     proc read_cli {fd} {
-        set ret {}
+        set ret [read $fd]
+        while {[string length $ret] == 0} {
+            after 10
+            set ret [read $fd]
+        }
+
+        # We may have a short read, try to read some more.
         set empty_reads 0
         while {$empty_reads < 5} {
             set buf [read $fd]


### PR DESCRIPTION
In some cases large replies on slow systems may only be partially read
by the test suite, resulting with parsing errors.

This fix is still timing sensitive but should greatly reduce the chances
of this happening.