### PR TITLE
corrupt-dump-fuzzer test, avoid creating junk keys

### DIFF
--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -99,6 +99,7 @@ foreach sanitize_dump {no yes} {
             r debug set-skip-checksum-validation 1
             set start_time [clock seconds]
             generate_types
+            set dbsize [r dbsize]
             r save
             set cycle 0
             set stat_terminated_in_restore 0
@@ -142,6 +143,12 @@ foreach sanitize_dump {no yes} {
                         set sent [generate_fuzzy_traffic_on_key "_$k" 1] ;# traffic for 1 second
                         incr stat_traffic_commands_sent [llength $sent]
                         r del "_$k" ;# in case the server terminated, here's where we'll detect it.
+                        if {$dbsize != [r dbsize]} {
+                            puts "unexpected keys"
+                            puts "keys: [r keys *]"
+                            puts $sent
+                            exit 1
+                        }
                     } err ] } {
                         # if the server terminated update stats and restart it
                         set report_and_restart true

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -623,6 +623,7 @@ proc generate_fuzzy_traffic_on_key {key duration} {
         set arity [lindex $cmd_info 1]
         set arity [expr $arity < 0 ? - $arity: $arity]
         set firstkey [lindex $cmd_info 3]
+        set lastkey [lindex $cmd_info 4]
         set i 1
         if {$cmd == "XINFO"} {
             lappend cmd "STREAM"
@@ -652,7 +653,7 @@ proc generate_fuzzy_traffic_on_key {key duration} {
             incr i 4
         }
         for {} {$i < $arity} {incr i} {
-            if {$i == $firstkey} {
+            if {$i == $firstkey || $i == $lastkey} {
                 lappend cmd $key
             } else {
                 lappend cmd [randomValue]


### PR DESCRIPTION
The execution of the RPOPLPUSH command by the fuzzer created junk keys,
that were later being selected by RANDOMKEY and modified.
This also meant that lists were statistically tested more than other
files.

Fix the fuzzer not to pass junk key names to RPOPLPUSH, and add a check
that detects that new keys are not added by the fuzzer to detect future
similar issues.