### PR TITLE
Improve handling of optional command arguments in cli hints

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -755,11 +755,16 @@ static char *hintsCallback(const char *buf, int *color, int *bold) {
         sds hint = sdsnew(entry->org->params);
 
         /* Remove arguments from the returned hint to show only the
-            * ones the user did not yet type. */
+         * ones the user did not yet type. */
         int toremove = argc-matchlen;
+        /* Nesting depth of optional arguments - treat as a single unit. */
+        int optdepth = 0;
         while(toremove > 0 && sdslen(hint)) {
-            if (hint[0] == '[') break;
-            if (hint[0] == ' ') toremove--;
+            if (hint[0] == '[') optdepth++;
+            if (optdepth) {
+                if (hint[0] == ']') optdepth--; 
+            }
+            if (!optdepth && hint[0] == ' ') toremove--;
             sdsrange(hint,1,-1);
         }
 


### PR DESCRIPTION
This implements a rudimentary improvement (I hope!) to the handling of optional command arguments in the CLI's hints (issue #8084 ). It treats the entire optional argument block as a single word, and removes it from the hint as a unit. The current behavior simply stops hinting when an optional argument is reached.

This is not really "the right thing to do". Optional arguments often include multiple words. This doesn't handle repeated args or nested optional args. The only question is whether this is incrementally better than what we already have.

Solving the problem correctly is much more complicated.