### PR TITLE
Fix copy-paste typo in t_list.c comment

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -954,7 +954,7 @@ void blpopCommand(client *c) {
     blockingPopGenericCommand(c,LIST_HEAD);
 }
 
-/* BLPOP <key> [<key> ...] <timeout> */
+/* BRPOP <key> [<key> ...] <timeout> */
 void brpopCommand(client *c) {
     blockingPopGenericCommand(c,LIST_TAIL);
 }


### PR DESCRIPTION
Fix "BLPOP" to "BRPOP" in `brpopCommand` comments.