### PR TITLE
Modify some error logs printing level.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -352,7 +352,7 @@ static int updateOOMScoreAdjValues(sds *args, const char **err, int apply) {
 
     if (values[CONFIG_OOM_REPLICA] < values[CONFIG_OOM_MASTER] ||
         values[CONFIG_OOM_BGCHILD] < values[CONFIG_OOM_REPLICA]) {
-            serverLog(LOG_WARNING,
+            serverLog(LL_WARNING,
                     "The oom-score-adj-values configuration may not work for non-privileged processes! "
                     "Please consult the documentation.");
     }

--- a/src/replication.c
+++ b/src/replication.c
@@ -1106,7 +1106,7 @@ void sendBulkToSlave(connection *conn) {
     if (slave->replpreamble) {
         nwritten = connWrite(conn,slave->replpreamble,sdslen(slave->replpreamble));
         if (nwritten == -1) {
-            serverLog(LL_VERBOSE,
+            serverLog(LL_WARNING,
                 "Write error sending RDB preamble to replica: %s",
                 connGetLastError(conn));
             freeClient(slave);

--- a/src/server.c
+++ b/src/server.c
@@ -2879,7 +2879,7 @@ int setOOMScoreAdj(int process_class) {
 
     fd = open("/proc/self/oom_score_adj", O_WRONLY);
     if (fd < 0 || write(fd, buf, strlen(buf)) < 0) {
-        serverLog(LOG_WARNING, "Unable to write oom_score_adj: %s", strerror(errno));
+        serverLog(LL_WARNING, "Unable to write oom_score_adj: %s", strerror(errno));
         if (fd != -1) close(fd);
         return C_ERR;
     }


### PR DESCRIPTION
1. In sendBulkToSlave, we used LL_VERBOSE in the past, changed to
LL_WARNING. (all the other places that do freeClient(slave) use LL_WARNING)
2. The old style LOG_WARNING, chang it to LL_WARNING. Introduced in an
old pr (#1690).