### PR TITLE
Better error handling for updateClientOutputBufferLimit.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -384,38 +384,60 @@ static int updateOOMScoreAdjValues(sds *args, const char **err, int apply) {
     return C_OK;
 }
 
-/* Parse an array of sds strings, validate and populate server.client_obuf_limits
- * if valid. Used in CONFIG SET and configuration file parsing.
- * args: <class> <hard limit> <soft limit> <soft seconds> */
-static int updateClientOutputBufferLimit(sds *args, const char **err, int apply) {
-    int class = getClientTypeByName(args[0]);
+/* Parse an array of `arg_len` sds strings, validate and populate
+ * server.client_obuf_limits if valid.
+ * Used in CONFIG SET and configuration file parsing. */
+static int updateClientOutputBufferLimit(sds *args, int arg_len, const char **err) {
+    int j;
+    int class;
     unsigned long long hard, soft;
     int hard_err, soft_err;
     int soft_seconds;
     char *soft_seconds_eptr;
+    unsigned long long values[arg_len];
 
-    if (class == -1 || class == CLIENT_TYPE_MASTER) {
-        if (err) *err = "Invalid client class specified in buffer limit configuration.";
+    /* We need a multiple of 4: <class> <hard> <soft> <soft_seconds> */
+    if (arg_len % 4) {
+        if (err) *err = "Wrong number of arguments in "
+                        "buffer limit configuration.";
         return C_ERR;
     }
 
-    hard = memtoull(args[1], &hard_err);
-    soft = memtoull(args[2], &soft_err);
-    soft_seconds = strtoll(args[3], &soft_seconds_eptr, 10);
-    if (hard_err || soft_err ||
-        soft_seconds < 0 || *soft_seconds_eptr != '\0')
-    {
-        if (err) *err = "Error in hard, soft or soft_seconds setting in buffer limit configuration.";
-        return C_ERR;
+    /* Sanity check of single arguments, so that we either refuse the
+     * whole configuration string or accept it all, even if a single
+     * error in a single client class is present. */
+    for (j = 0; j < arg_len; j += 4) {
+        class = getClientTypeByName(args[j]);
+        if (class == -1 || class == CLIENT_TYPE_MASTER) {
+            if (err) *err = "Invalid client class specified in "
+                            "buffer limit configuration.";
+            return C_ERR;
+        }
+
+        hard = memtoull(args[j+1], &hard_err);
+        soft = memtoull(args[j+2], &soft_err);
+        soft_seconds = strtoll(args[j+3], &soft_seconds_eptr, 10);
+        if (hard_err || soft_err ||
+            soft_seconds < 0 || *soft_seconds_eptr != '\0')
+        {
+            if (err) *err = "Error in hard, soft or soft_seconds setting in "
+                            "buffer limit configuration.";
+            return C_ERR;
+        }
+
+        values[j] = class;
+        values[j+1] = hard;
+        values[j+2] = soft;
+        values[j+3] = soft_seconds;
     }
 
-    /* When dealing with CONFIG SET, we want to apply only when all is correct. */
-    if (!apply)
-        return C_OK;
-
-    server.client_obuf_limits[class].hard_limit_bytes = hard;
-    server.client_obuf_limits[class].soft_limit_bytes = soft;
-    server.client_obuf_limits[class].soft_limit_seconds = soft_seconds;
+    /* Finally set the new config. */
+    for (j = 0; j < arg_len; j += 4) {
+        class = values[j];
+        server.client_obuf_limits[class].hard_limit_bytes = values[j+1];
+        server.client_obuf_limits[class].soft_limit_bytes = values[j+2];
+        server.client_obuf_limits[class].soft_limit_seconds = values[j+3];
+    }
 
     return C_OK;
 }
@@ -586,7 +608,7 @@ void loadServerConfigFromString(char *config) {
         } else if (!strcasecmp(argv[0],"client-output-buffer-limit") &&
                    argc == 5)
         {
-            if (updateClientOutputBufferLimit(&argv[1], &err, 1) == C_ERR) goto loaderr;
+            if (updateClientOutputBufferLimit(&argv[1], 4, &err) == C_ERR) goto loaderr;
         } else if (!strcasecmp(argv[0],"oom-score-adj-values") && argc == 1 + CONFIG_OOM_COUNT) {
             if (updateOOMScoreAdjValues(&argv[1], &err, 0) == C_ERR) goto loaderr;
         } else if (!strcasecmp(argv[0],"notify-keyspace-events") && argc == 2) {
@@ -859,32 +881,14 @@ void configSetCommand(client *c) {
             return;
         }
     } config_set_special_field("client-output-buffer-limit") {
-        int vlen, j;
+        int vlen;
         sds *v = sdssplitlen(o->ptr,sdslen(o->ptr)," ",1,&vlen);
 
-        /* We need a multiple of 4: <class> <hard> <soft> <soft_seconds> */
-        if (vlen % 4) {
-            sdsfreesplitres(v,vlen);
+        if (updateClientOutputBufferLimit(&v[0], vlen, &errstr) == C_ERR) {
+            sdsfreesplitres(v, vlen);
             goto badfmt;
         }
 
-        /* Sanity check of single arguments, so that we either refuse the
-         * whole configuration string or accept it all, even if a single
-         * error in a single client class is present. */
-        for (j = 0; j < vlen; j += 4) {
-            if (updateClientOutputBufferLimit(&v[j], &errstr, 0) == C_ERR) {
-                sdsfreesplitres(v, vlen);
-                goto badfmt;
-            }
-        }
-        /* Finally set the new config */
-        for (j = 0; j < vlen; j += 4) {
-            if (updateClientOutputBufferLimit(&v[j], &errstr, 1) == C_ERR) {
-                /* Never reached. */
-                sdsfreesplitres(v, vlen);
-                goto badfmt;
-            }
-        }
         sdsfreesplitres(v,vlen);
     } config_set_special_field("oom-score-adj-values") {
         int vlen;

--- a/src/config.c
+++ b/src/config.c
@@ -406,7 +406,7 @@ static int updateClientOutputBufferLimit(sds *args, const char **err, int apply)
     if (hard_err || soft_err ||
         soft_seconds < 0 || *soft_seconds_eptr != '\0')
     {
-        if (err) *err = "hard, soft or soft_seconds value error.";
+        if (err) *err = "Error in hard, soft or soft_seconds setting in buffer limit configuration.";
         return C_ERR;
     }
 

--- a/src/config.c
+++ b/src/config.c
@@ -882,7 +882,7 @@ void configSetCommand(client *c) {
         int vlen;
         sds *v = sdssplitlen(o->ptr,sdslen(o->ptr)," ",1,&vlen);
 
-        if (updateClientOutputBufferLimit(&v[0], vlen, &errstr) == C_ERR) {
+        if (updateClientOutputBufferLimit(v, vlen, &errstr) == C_ERR) {
             sdsfreesplitres(v, vlen);
             goto badfmt;
         }

--- a/src/config.c
+++ b/src/config.c
@@ -395,8 +395,7 @@ static int updateClientOutputBufferLimit(sds *args, const char **err, int apply)
     char *soft_seconds_eptr;
 
     if (class == -1 || class == CLIENT_TYPE_MASTER) {
-        if (err) *err = "Unrecognized client limit class: the user specified "
-                        "an invalid one, or 'master' which has no buffer limits.";
+        if (err) *err = "Invalid client class specified in buffer limit configuration.";
         return C_ERR;
     }
 


### PR DESCRIPTION
Refresh https://github.com/redis/redis/pull/3465
This one follow #9313 and goes deeper (validation of config file parsing)

Move the check/update logic to a new updateClientOutputBufferLimit
function. So that it can be used in CONFIG SET and config file parsing.

--------------------------------------------
Add some changes before and after

Before:
```
If we set an error value(256fffmb) in redis.conf
client-output-buffer-limit replica 256fffmb 64mb 60

We can start a server and we will get this
127.0.0.1:6379> config get client-output-buffer-limit
1) "client-output-buffer-limit"
2) "normal 0 0 0 slave 0 67108864 60 pubsub 33554432 8388608 60"

If we set an error value(fff60) in redis.conf
client-output-buffer-limit replica 256mb 64mb fff60

We will get this
127.0.0.1:6379> config get client-output-buffer-limit
1) "client-output-buffer-limit"
2) "normal 0 0 0 slave 268435456 67108864 0 pubsub 33554432 8388608 60"
```

After:
```
If we set an error value in redis.conf
like: client-output-buffer-limit areplica 256mb 64mb 60f
*** FATAL CONFIG FILE ERROR (Redis 255.255.255) ***
Reading the configuration file, at line 1835
>>> 'client-output-buffer-limit areplica 256mb 64mb 60f'
Invalid client class specified in buffer limit configuration.

like: client-output-buffer-limit replica 256fmb 64mb 60f
*** FATAL CONFIG FILE ERROR (Redis 255.255.255) ***
Reading the configuration file, at line 1835
>>> 'client-output-buffer-limit replica 256fmb 64mb 60f'
Error in hard, soft or soft_seconds setting in buffer limit configuration.

like: client-output-buffer-limit replica 256mb 64mb 60f
*** FATAL CONFIG FILE ERROR (Redis 255.255.255) ***
Reading the configuration file, at line 1835
>>> 'client-output-buffer-limit replica 256mb 64mb 60f'
Error in hard, soft or soft_seconds setting in buffer limit configuration.
```