### PR TITLE
Fix undefined behavior in sdsll2str

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -553,7 +553,16 @@ int sdsll2str(char *s, long long value) {
 
     /* Generate the string representation, this method produces
      * a reversed string. */
-    v = (value < 0) ? -value : value;
+    if (value < 0) {
+        if (value != LLONG_MIN) {
+            v = -value;
+        } else {
+            v = ((unsigned long long) LLONG_MAX)+1;
+        }
+    } else {
+        v = value;
+    }
+
     p = s;
     do {
         *p++ = '0'+(v%10);


### PR DESCRIPTION
# Reproduct
Change Makefile:
```
gcov:
	$(MAKE) REDIS_CFLAGS="-DREDIS_TEST -fprofile-arcs -ftest-coverage -DCOVERAGE_TEST" REDIS_LDFLAGS="-fprofile-arcs -ftest-coverage"
```
run: 
```
make gcov
redis-server test sds
```

At https://github.com/redis/redis/commit/c951c3ee5a12110f1c0c1270c45ab663c04e0f77里, ll2string was fixed with the same problem, but not modified to sds.
