### PR TITLE
Skip new redis-cli ASK test in TLS mode

### DIFF
--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -234,6 +234,7 @@ start_server {tags {"cli"}} {
         assert_equal "foo\nbar" [run_cli lrange list 0 -1]
     }
 
+if {!$::tls} { ;# fake_redis_node doesn't support TLS
     test_nontty_cli "ASK redirect test" {
         # Set up two fake Redis nodes.
         set tclsh [info nameofexecutable]
@@ -250,6 +251,7 @@ start_server {tags {"cli"}} {
         # Run the cli
         assert_equal "OK" [run_cli_host_port_db "127.0.0.1" $port1 0 -c SET foo bar]
     }
+}
 
     test_nontty_cli "Quoted input arguments" {
         r set "\x00\x00" "value"


### PR DESCRIPTION
new test added in #8930 which is not compatible with TLS mode and fails the daily CI