### PR TITLE
config memory limits: handle values larger than (signed) LLONG_MAX

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -743,7 +743,7 @@ void loadServerConfig(char *filename, char config_from_stdin, char *options) {
 
 #define config_set_memory_field(_name,_var) \
     } else if (!strcasecmp(c->argv[2]->ptr,_name)) { \
-        ll = memtuoll(o->ptr,&err); \
+        ll = memtoull(o->ptr,&err); \
         if (err || ll < 0) goto badfmt; \
         _var = ll;
 

--- a/src/config.c
+++ b/src/config.c
@@ -2099,37 +2099,33 @@ static int numericBoundaryCheck(typeData data, long long ll, const char **err) {
     return 1;
 }
 
-#define CONFIGSETCOMMON(data, ll, prev, err) \
-    if (!numericBoundaryCheck(data, ll, err)){ \
-        return 0; \
-    } \
-    if (data.numeric.is_valid_fn && !data.numeric.is_valid_fn(ll, err)){ \
-        return 0; \
-    } \
-    GET_NUMERIC_TYPE(prev) \
-    SET_NUMERIC_TYPE(ll) \
-    if (update && data.numeric.update_fn && !data.numeric.update_fn(ll, prev, err)) { \
-        SET_NUMERIC_TYPE(prev) \
-        return 0; \
-    }
 
 static int numericConfigSet(typeData data, sds value, int update, const char **err) {
+    long long ll, prev = 0;
     if (data.numeric.is_memory) {
-        unsigned long long ll, prev = 0;
         int memerr;
         ll = memtoull(value, &memerr);
         if (memerr) {
             *err = "argument must be a memory value";
             return 0;
         }
-        CONFIGSETCOMMON(data, ll, prev, err);
     } else {
-        long long ll, prev = 0;
         if (!string2ll(value, sdslen(value), &ll)) {
             *err = "argument couldn't be parsed into an integer" ;
             return 0;
         }
-        CONFIGSETCOMMON(data, ll, prev, err);
+    }
+    if (!numericBoundaryCheck(data, ll, err)){
+        return 0;
+    }
+    if (data.numeric.is_valid_fn && !data.numeric.is_valid_fn(ll, err)){
+        return 0;
+    }
+    GET_NUMERIC_TYPE(prev)
+    SET_NUMERIC_TYPE(ll)
+    if (update && data.numeric.update_fn && !data.numeric.update_fn(ll, prev, err)) {
+        SET_NUMERIC_TYPE(prev)
+        return 0;
     }
     return 1;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -854,8 +854,6 @@ void configSetCommand(client *c) {
          * whole configuration string or accept it all, even if a single
          * error in a single client class is present. */
         for (j = 0; j < vlen; j++) {
-            unsigned long long val;
-
             if ((j % 4) == 0) {
                 int class = getClientTypeByName(v[j]);
                 if (class == -1 || class == CLIENT_TYPE_MASTER)
@@ -866,7 +864,7 @@ void configSetCommand(client *c) {
                 if (l < 0 || *endptr != '\0')
                     break;
             } else {
-                val = memtoull(v[j], &err);
+                memtoull(v[j], &err);
                 if (err)
                     break;
             }

--- a/src/config.c
+++ b/src/config.c
@@ -862,7 +862,7 @@ void configSetCommand(client *c) {
                     break;
             } else if ((j % 4) == 3) {
                 char *endptr;
-                long l = strtoll(v[j],endptr,10);
+                long l = strtoll(v[j],&endptr,10);
                 if (val < 0 || *endptr != '\0')
                     break;
             } else {

--- a/src/config.c
+++ b/src/config.c
@@ -863,7 +863,7 @@ void configSetCommand(client *c) {
             } else if ((j % 4) == 3) {
                 char *endptr;
                 long l = strtoll(v[j],&endptr,10);
-                if (val < 0 || *endptr != '\0')
+                if (l < 0 || *endptr != '\0')
                     break;
             } else {
                 val = memtoull(v[j], &err);

--- a/src/config.c
+++ b/src/config.c
@@ -2099,37 +2099,32 @@ static int numericBoundaryCheck(typeData data, long long ll, const char **err) {
     return 1;
 }
 
-#define CONFIGSETCOMMON(data, ll, prev, err) \
-    if (!numericBoundaryCheck(data, ll, err)){ \
-        return 0; \
-    } \
-    if (data.numeric.is_valid_fn && !data.numeric.is_valid_fn(ll, err)){ \
-        return 0; \
-    } \
-    GET_NUMERIC_TYPE(prev) \
-    SET_NUMERIC_TYPE(ll) \
-    if (update && data.numeric.update_fn && !data.numeric.update_fn(ll, prev, err)) { \
-        SET_NUMERIC_TYPE(prev) \
-        return 0; \
-    }
-
 static int numericConfigSet(typeData data, sds value, int update, const char **err) {
+    long long ll, prev = 0;
     if (data.numeric.is_memory) {
-        unsigned long long ll, prev = 0;
         int memerr;
         ll = memtoull(value, &memerr);
         if (memerr) {
             *err = "argument must be a memory value";
             return 0;
         }
-        CONFIGSETCOMMON(data, ll, prev, err);
     } else {
-        long long ll, prev = 0;
         if (!string2ll(value, sdslen(value), &ll)) {
             *err = "argument couldn't be parsed into an integer" ;
             return 0;
         }
-        CONFIGSETCOMMON(data, ll, prev, err);
+    }
+    if (!numericBoundaryCheck(data, ll, err)){
+        return 0;
+    }
+    if (data.numeric.is_valid_fn && !data.numeric.is_valid_fn(ll, err)){
+        return 0;
+    }
+    GET_NUMERIC_TYPE(prev)
+    SET_NUMERIC_TYPE(ll)
+    if (update && data.numeric.update_fn && !data.numeric.update_fn(ll, prev, err)) {
+        SET_NUMERIC_TYPE(prev)
+        return 0;
     }
     return 1;
 }
@@ -2141,7 +2136,7 @@ static void numericConfigGet(client *c, typeData data) {
         
         GET_NUMERIC_TYPE(value)
 
-        ull2string(buf, sizeof(buf), value, 0);
+        ull2string(buf, sizeof(buf), value);
         addReplyBulkCString(c, buf);
     } else{
         long long value = 0;

--- a/src/config.c
+++ b/src/config.c
@@ -744,7 +744,7 @@ void loadServerConfig(char *filename, char config_from_stdin, char *options) {
 #define config_set_memory_field(_name,_var) \
     } else if (!strcasecmp(c->argv[2]->ptr,_name)) { \
         ll = memtoull(o->ptr,&err); \
-        if (err || ll < 0) goto badfmt; \
+        if (err) goto badfmt; \
         _var = ll;
 
 #define config_set_special_field(_name) \
@@ -2104,7 +2104,7 @@ static int numericConfigSet(typeData data, sds value, int update, const char **e
         unsigned long long ll, prev = 0;
         int memerr;
         ll = memtoull(value, &memerr);
-        if (memerr || ll < 0) {
+        if (memerr) {
             *err = "argument must be a memory value";
             return 0;
         }

--- a/src/config.c
+++ b/src/config.c
@@ -2109,7 +2109,7 @@ static int numericConfigSet(typeData data, sds value, int update, const char **e
             return 0;
         }
     } else {
-        if (!string2ull(value, sdslen(value),&ll)) {
+        if (!string2ull(value,&ll)) {
             *err = "argument couldn't be parsed into an integer" ;
             return 0;
         }

--- a/src/config.c
+++ b/src/config.c
@@ -2103,7 +2103,7 @@ static int numericConfigSet(typeData data, sds value, int update, const char **e
     long long ll, prev = 0;
     if (data.numeric.is_memory) {
         int memerr;
-        ll = memtoull(value, &memerr);
+        ll = memtoll(value, &memerr);
         if (memerr || ll < 0) {
             *err = "argument must be a memory value";
             return 0;

--- a/src/config.c
+++ b/src/config.c
@@ -2138,7 +2138,7 @@ static void numericConfigGet(client *c, typeData data) {
         
         GET_NUMERIC_TYPE(value)
 
-        ull2string(buf, sizeof(buf), value, 0);
+        ull2string(buf, sizeof(buf), value);
         addReplyBulkCString(c, buf);
     } else{
         long long value = 0;

--- a/src/config.c
+++ b/src/config.c
@@ -2100,7 +2100,7 @@ static int numericBoundaryCheck(typeData data, long long ll, const char **err) {
 }
 
 static int numericConfigSet(typeData data, sds value, int update, const char **err) {
-    long long ll, prev = 0;
+    unsigned long long ll, prev = 0;
     if (data.numeric.is_memory) {
         int memerr;
         ll = memtoll(value, &memerr);
@@ -2109,7 +2109,7 @@ static int numericConfigSet(typeData data, sds value, int update, const char **e
             return 0;
         }
     } else {
-        if (!string2ll(value, sdslen(value),&ll)) {
+        if (!string2ull(value, sdslen(value),&ll)) {
             *err = "argument couldn't be parsed into an integer" ;
             return 0;
         }
@@ -2133,11 +2133,11 @@ static int numericConfigSet(typeData data, sds value, int update, const char **e
 
 static void numericConfigGet(client *c, typeData data) {
     char buf[128];
-    long long value = 0;
+    unsigned long long value = 0;
 
     GET_NUMERIC_TYPE(value)
 
-    ll2string(buf, sizeof(buf), value);
+    ull2string(buf, sizeof(buf), value);
     addReplyBulkCString(c, buf);
 }
 
@@ -2330,7 +2330,7 @@ static int updateReplBacklogSize(long long val, long long prev, const char **err
     return 1;
 }
 
-static int updateMaxmemory(long long val, long long prev, const char **err) {
+static int updateMaxmemory(unsigned long long val, unsigned long long prev, const char **err) {
     UNUSED(prev);
     UNUSED(err);
     if (val) {

--- a/src/config.c
+++ b/src/config.c
@@ -869,7 +869,7 @@ void configSetCommand(client *c) {
                     break;
             }
         }
-        if (j <= vlen) {
+        if (j < vlen) {
             sdsfreesplitres(v,vlen);
             goto badfmt;
         }

--- a/src/config.c
+++ b/src/config.c
@@ -2103,7 +2103,7 @@ static int numericConfigSet(typeData data, sds value, int update, const char **e
     unsigned long long ll, prev = 0;
     if (data.numeric.is_memory) {
         int memerr;
-        ll = memtoll(value, &memerr);
+        ll = memtuoll(value, &memerr);
         if (memerr || ll < 0) {
             *err = "argument must be a memory value";
             return 0;

--- a/src/config.c
+++ b/src/config.c
@@ -2115,14 +2115,15 @@ static int numericConfigSet(typeData data, sds value, int update, const char **e
             return 0;
         }
     }
-    if (!numericBoundaryCheck(data, ll, err)){
+    if (!numericBoundaryCheck(data, ll, err))
         return 0;
-    }
-    if (data.numeric.is_valid_fn && !data.numeric.is_valid_fn(ll, err)){
+
+    if (data.numeric.is_valid_fn && !data.numeric.is_valid_fn(ll, err))
         return 0;
-    }
+
     GET_NUMERIC_TYPE(prev)
     SET_NUMERIC_TYPE(ll)
+
     if (update && data.numeric.update_fn && !data.numeric.update_fn(ll, prev, err)) {
         SET_NUMERIC_TYPE(prev)
         return 0;

--- a/src/config.c
+++ b/src/config.c
@@ -558,8 +558,8 @@ void loadServerConfigFromString(char *config) {
                 "an invalid one, or 'master' which has no buffer limits.";
                 goto loaderr;
             }
-            hard = memtoll(argv[2],NULL);
-            soft = memtoll(argv[3],NULL);
+            hard = memtuoll(argv[2],NULL);
+            soft = memtuoll(argv[3],NULL);
             soft_seconds = atoi(argv[4]);
             if (soft_seconds < 0) {
                 err = "Negative number of seconds in soft limit is invalid";
@@ -743,7 +743,7 @@ void loadServerConfig(char *filename, char config_from_stdin, char *options) {
 
 #define config_set_memory_field(_name,_var) \
     } else if (!strcasecmp(c->argv[2]->ptr,_name)) { \
-        ll = memtoll(o->ptr,&err); \
+        ll = memtuoll(o->ptr,&err); \
         if (err || ll < 0) goto badfmt; \
         _var = ll;
 

--- a/src/config.c
+++ b/src/config.c
@@ -2352,7 +2352,7 @@ static int updateReplBacklogSize(long long val, long long prev, const char **err
     return 1;
 }
 
-static int updateMaxmemory(unsigned long long val, unsigned long long prev, const char **err) {
+static int updateMaxmemory(long long val, long long prev, const char **err) {
     UNUSED(prev);
     UNUSED(err);
     if (val) {

--- a/src/config.c
+++ b/src/config.c
@@ -2103,7 +2103,7 @@ static int numericConfigSet(typeData data, sds value, int update, const char **e
     unsigned long long ll, prev = 0;
     if (data.numeric.is_memory) {
         int memerr;
-        ll = memtuoll(value, &memerr);
+        ll = memtoull(value, &memerr);
         if (memerr || ll < 0) {
             *err = "argument must be a memory value";
             return 0;

--- a/src/config.c
+++ b/src/config.c
@@ -2099,32 +2099,37 @@ static int numericBoundaryCheck(typeData data, long long ll, const char **err) {
     return 1;
 }
 
+#define CONFIGSETCOMMON(data, ll, prev, err) \
+    if (!numericBoundaryCheck(data, ll, err)){ \
+        return 0; \
+    } \
+    if (data.numeric.is_valid_fn && !data.numeric.is_valid_fn(ll, err)){ \
+        return 0; \
+    } \
+    GET_NUMERIC_TYPE(prev) \
+    SET_NUMERIC_TYPE(ll) \
+    if (update && data.numeric.update_fn && !data.numeric.update_fn(ll, prev, err)) { \
+        SET_NUMERIC_TYPE(prev) \
+        return 0; \
+    }
+
 static int numericConfigSet(typeData data, sds value, int update, const char **err) {
-    long long ll, prev = 0;
     if (data.numeric.is_memory) {
+        unsigned long long ll, prev = 0;
         int memerr;
         ll = memtoull(value, &memerr);
         if (memerr) {
             *err = "argument must be a memory value";
             return 0;
         }
+        CONFIGSETCOMMON(data, ll, prev, err);
     } else {
+        long long ll, prev = 0;
         if (!string2ll(value, sdslen(value), &ll)) {
             *err = "argument couldn't be parsed into an integer" ;
             return 0;
         }
-    }
-    if (!numericBoundaryCheck(data, ll, err)){
-        return 0;
-    }
-    if (data.numeric.is_valid_fn && !data.numeric.is_valid_fn(ll, err)){
-        return 0;
-    }
-    GET_NUMERIC_TYPE(prev)
-    SET_NUMERIC_TYPE(ll)
-    if (update && data.numeric.update_fn && !data.numeric.update_fn(ll, prev, err)) {
-        SET_NUMERIC_TYPE(prev)
-        return 0;
+        CONFIGSETCOMMON(data, ll, prev, err);
     }
     return 1;
 }
@@ -2136,7 +2141,7 @@ static void numericConfigGet(client *c, typeData data) {
         
         GET_NUMERIC_TYPE(value)
 
-        ull2string(buf, sizeof(buf), value);
+        ull2string(buf, sizeof(buf), value, 0);
         addReplyBulkCString(c, buf);
     } else{
         long long value = 0;

--- a/src/config.c
+++ b/src/config.c
@@ -2103,7 +2103,7 @@ static int numericConfigSet(typeData data, sds value, int update, const char **e
     long long ll, prev = 0;
     if (data.numeric.is_memory) {
         int memerr;
-        ll = memtoll(value, &memerr);
+        ll = memtoull(value, &memerr);
         if (memerr || ll < 0) {
             *err = "argument must be a memory value";
             return 0;

--- a/src/util.c
+++ b/src/util.c
@@ -352,7 +352,7 @@ int ull2string(char *dst, size_t dstlen, unsigned long long value) {
         "8081828384858687888990919293949596979899";
 
     /* Check length. */
-    uint32_t const length = digits10(value);
+    uint32_t const length = digits10(value) + negative;
     if (length >= dstlen) return 0;
 
     /* Null term. */

--- a/src/util.c
+++ b/src/util.c
@@ -336,14 +336,14 @@ int ll2string(char *dst, size_t dstlen, long long svalue) {
     }
 
     /* Converts the unsigned long long value to string*/
-    uint32_t const length = ull2string(dst, dstlen, value, negative);
+    uint32_t const length = ull2string(dst, dstlen + negative, value);
 
     /* Add sign. */
     if (negative) dst[0] = '-';
     return length;
 }
 
-int ull2string(char *dst, size_t dstlen, unsigned long long value, int negative) {
+int ull2string(char *dst, size_t dstlen, unsigned long long value) {
     static const char digits[201] =
         "0001020304050607080910111213141516171819"
         "2021222324252627282930313233343536373839"

--- a/src/util.c
+++ b/src/util.c
@@ -335,7 +335,7 @@ int ll2string(char *dst, size_t dstlen, long long svalue) {
         negative = 0;
     }
 
-    /* Converts the unsigned long long calue to string*/
+    /* Converts the unsigned long long value to string*/
     uint32_t const length = ull2string(dst, dstlen, value, negative);
 
     /* Add sign. */

--- a/src/util.c
+++ b/src/util.c
@@ -308,17 +308,10 @@ uint32_t sdigits10(int64_t v) {
 
 /* Convert a long long into a string. Returns the number of
  * characters needed to represent the number.
- * If the buffer is not big enough to store the string, 0 is returned.
- *
- * Based on the following article (that apparently does not provide a
- * novel approach but only publicizes an already used technique):
- *
- * https://www.facebook.com/notes/facebook-engineering/three-optimization-tips-for-c/10151361643253920
- *
- * Modified in order to handle signed integers since the original code was
- * designed for unsigned integers. */
-int ll2string(char *dst, size_t dstlen, long long svalue) {
+ * If the buffer is not big enough to store the string, 0 is returned. */
+ int ll2string(char *dst, size_t dstlen, long long svalue) {
     unsigned long long value;
+    int negative = 0;
 
     /* The ull2string function with 64bit unsigned integers for simplicity, so
      * we convert the number here and remember if it is negative. */
@@ -328,17 +321,30 @@ int ll2string(char *dst, size_t dstlen, long long svalue) {
         } else {
             value = ((unsigned long long) LLONG_MAX)+1;
         }
+        if (dstlen < 2)
+            return 0;
+        negative = 1;
         dst[0] = '-';
+        dst++;
+        dstlen--;
     } else {
         value = svalue;
-        dst[0] = ' '; // This will be overwritten in ullstring
     }
 
     /* Converts the unsigned long long value to string*/
-    uint32_t const length = ull2string(dst, dstlen, value);
-    return length;
+    int length = ull2string(dst, dstlen, value);
+    if (length == 0) return 0;
+    return length + negative;
 }
 
+/* Convert a unsigned long long into a string. Returns the number of
+ * characters needed to represent the number.
+ * If the buffer is not big enough to store the string, 0 is returned.
+ *
+ * Based on the following article (that apparently does not provide a
+ * novel approach but only publicizes an already used technique):
+ *
+ * https://www.facebook.com/notes/facebook-engineering/three-optimization-tips-for-c/10151361643253920 */
 int ull2string(char *dst, size_t dstlen, unsigned long long value) {
     static const char digits[201] =
         "0001020304050607080910111213141516171819"
@@ -349,9 +355,6 @@ int ull2string(char *dst, size_t dstlen, unsigned long long value) {
 
     /* Check length. */
     uint32_t length = digits10(value);
-    if (dst[0] == '-'){
-        length = length + 1;
-    }
     if (length >= dstlen) return 0;
 
     /* Null term. */

--- a/src/util.c
+++ b/src/util.c
@@ -192,7 +192,7 @@ int stringmatchlen_fuzz_test(void) {
  * On parsing error, if *err is not NULL, it's set to 1, otherwise it's
  * set to 0. On error the function return value is 0, regardless of the
  * fact 'err' is NULL or not. */
-long long memtoll(const char *p, int *err) {
+long long memtoull(const char *p, int *err) {
     const char *u;
     char buf[128];
     long mul; /* unit multiplier */
@@ -252,7 +252,7 @@ long long memtoll(const char *p, int *err) {
  * On parsing error, if *err is not NULL, it's set to 1, otherwise it's
  * set to 0. On error the function return value is 0, regardless of the
  * fact 'err' is NULL or not. */
-unsigned long long memtoull(const char *p, int *err) {
+unsigned long long memtoll(const char *p, int *err) {
     const char *u;
     char buf[128];
     long mul; /* unit multiplier */

--- a/src/util.c
+++ b/src/util.c
@@ -244,6 +244,66 @@ long long memtoll(const char *p, int *err) {
     return val*mul;
 }
 
+/* Similar to memtoll but this is for unsigned long long
+ * Convert a string representing an amount of memory into the number of
+ * bytes, so for instance memtoll("1Gb") will return 1073741824 that is
+ * (1024*1024*1024).
+ *
+ * On parsing error, if *err is not NULL, it's set to 1, otherwise it's
+ * set to 0. On error the function return value is 0, regardless of the
+ * fact 'err' is NULL or not. */
+long long memtoll(const char *p, int *err) {
+    const char *u;
+    char buf[128];
+    long mul; /* unit multiplier */
+    unsigned long long val;
+    unsigned int digits;
+
+    if (err) *err = 0;
+
+    /* Search the first non digit character. */
+    u = p;
+    if (*u == '-') u++;
+    while(*u && isdigit(*u)) u++;
+    if (*u == '\0' || !strcasecmp(u,"b")) {
+        mul = 1;
+    } else if (!strcasecmp(u,"k")) {
+        mul = 1000;
+    } else if (!strcasecmp(u,"kb")) {
+        mul = 1024;
+    } else if (!strcasecmp(u,"m")) {
+        mul = 1000*1000;
+    } else if (!strcasecmp(u,"mb")) {
+        mul = 1024*1024;
+    } else if (!strcasecmp(u,"g")) {
+        mul = 1000L*1000*1000;
+    } else if (!strcasecmp(u,"gb")) {
+        mul = 1024L*1024*1024;
+    } else {
+        if (err) *err = 1;
+        return 0;
+    }
+
+    /* Copy the digits into a buffer, we'll use strtoll() to convert
+     * the digit (without the unit) into a number. */
+    digits = u-p;
+    if (digits >= sizeof(buf)) {
+        if (err) *err = 1;
+        return 0;
+    }
+    memcpy(buf,p,digits);
+    buf[digits] = '\0';
+
+    char *endptr;
+    errno = 0;
+    val = strtoull(buf,&endptr,10);
+    if ((val == 0 && errno == EINVAL) || *endptr != '\0') {
+        if (err) *err = 1;
+        return 0;
+    }
+    return val*mul;
+}
+
 /* Search a memory buffer for any set of bytes, like strpbrk().
  * Returns pointer to first found char or NULL.
  */

--- a/src/util.c
+++ b/src/util.c
@@ -444,8 +444,7 @@ int ull2string(char *dst, size_t dstlen, unsigned long long value) {
 
     /* Null term. */
     uint32_t next = length - 1;
-    dst[next] = '\0';
-    next--;
+    dst[next + 1] = '\0';
     while (value >= 100) {
         int const i = (value % 100) * 2;
         value /= 100;

--- a/src/util.c
+++ b/src/util.c
@@ -309,7 +309,7 @@ uint32_t sdigits10(int64_t v) {
 /* Convert a long long into a string. Returns the number of
  * characters needed to represent the number.
  * If the buffer is not big enough to store the string, 0 is returned. */
- int ll2string(char *dst, size_t dstlen, long long svalue) {
+int ll2string(char *dst, size_t dstlen, long long svalue) {
     unsigned long long value;
     int negative = 0;
 

--- a/src/util.c
+++ b/src/util.c
@@ -336,14 +336,14 @@ int ll2string(char *dst, size_t dstlen, long long svalue) {
     }
 
     /* Converts the unsigned long long value to string*/
-    uint32_t const length = ull2string(dst, dstlen + negative, value);
+    uint32_t const length = ull2string(dst, dstlen, value, negative);
 
     /* Add sign. */
     if (negative) dst[0] = '-';
     return length;
 }
 
-int ull2string(char *dst, size_t dstlen, unsigned long long value) {
+int ull2string(char *dst, size_t dstlen, unsigned long long value, int negative) {
     static const char digits[201] =
         "0001020304050607080910111213141516171819"
         "2021222324252627282930313233343536373839"

--- a/src/util.c
+++ b/src/util.c
@@ -318,7 +318,6 @@ uint32_t sdigits10(int64_t v) {
  * Modified in order to handle signed integers since the original code was
  * designed for unsigned integers. */
 int ll2string(char *dst, size_t dstlen, long long svalue) {
-    int negative;
     unsigned long long value;
 
     /* The ull2string function with 64bit unsigned integers for simplicity, so
@@ -329,21 +328,18 @@ int ll2string(char *dst, size_t dstlen, long long svalue) {
         } else {
             value = ((unsigned long long) LLONG_MAX)+1;
         }
-        negative = 1;
+        dst[0] = '-';
     } else {
         value = svalue;
-        negative = 0;
+        dst[0] = ' '; // This will be overwritten in ullstring
     }
 
     /* Converts the unsigned long long value to string*/
-    uint32_t const length = ull2string(dst, dstlen, value, negative);
-
-    /* Add sign. */
-    if (negative) dst[0] = '-';
+    uint32_t const length = ull2string(dst, dstlen, value);
     return length;
 }
 
-int ull2string(char *dst, size_t dstlen, unsigned long long value, int negative) {
+int ull2string(char *dst, size_t dstlen, unsigned long long value) {
     static const char digits[201] =
         "0001020304050607080910111213141516171819"
         "2021222324252627282930313233343536373839"
@@ -352,7 +348,10 @@ int ull2string(char *dst, size_t dstlen, unsigned long long value, int negative)
         "8081828384858687888990919293949596979899";
 
     /* Check length. */
-    uint32_t const length = digits10(value) + negative;
+    uint32_t length = digits10(value);
+    if (dst[0] == '-'){
+        length = length + 1;
+    }
     if (length >= dstlen) return 0;
 
     /* Null term. */

--- a/src/util.c
+++ b/src/util.c
@@ -252,7 +252,7 @@ long long memtoll(const char *p, int *err) {
  * On parsing error, if *err is not NULL, it's set to 1, otherwise it's
  * set to 0. On error the function return value is 0, regardless of the
  * fact 'err' is NULL or not. */
-long long memtoll(const char *p, int *err) {
+unsigned long long memtoull(const char *p, int *err) {
     const char *u;
     char buf[128];
     long mul; /* unit multiplier */

--- a/src/util.c
+++ b/src/util.c
@@ -192,7 +192,7 @@ int stringmatchlen_fuzz_test(void) {
  * On parsing error, if *err is not NULL, it's set to 1, otherwise it's
  * set to 0. On error the function return value is 0, regardless of the
  * fact 'err' is NULL or not. */
-long long memtoull(const char *p, int *err) {
+long long memtoll(const char *p, int *err) {
     const char *u;
     char buf[128];
     long mul; /* unit multiplier */
@@ -252,7 +252,7 @@ long long memtoull(const char *p, int *err) {
  * On parsing error, if *err is not NULL, it's set to 1, otherwise it's
  * set to 0. On error the function return value is 0, regardless of the
  * fact 'err' is NULL or not. */
-unsigned long long memtoll(const char *p, int *err) {
+unsigned long long memtoull(const char *p, int *err) {
     const char *u;
     char buf[128];
     long mul; /* unit multiplier */
@@ -427,6 +427,42 @@ int ll2string(char *dst, size_t dstlen, long long svalue) {
 
     /* Add sign. */
     if (negative) dst[0] = '-';
+    return length;
+}
+
+int ull2string(char *dst, size_t dstlen, unsigned long long value) {
+    static const char digits[201] =
+        "0001020304050607080910111213141516171819"
+        "2021222324252627282930313233343536373839"
+        "4041424344454647484950515253545556575859"
+        "6061626364656667686970717273747576777879"
+        "8081828384858687888990919293949596979899";
+
+    /* Check length. */
+    uint32_t const length = digits10(value);
+    if (length >= dstlen) return 0;
+
+    /* Null term. */
+    uint32_t next = length - 1;
+    dst[next] = '\0';
+    next--;
+    while (value >= 100) {
+        int const i = (value % 100) * 2;
+        value /= 100;
+        dst[next] = digits[i + 1];
+        dst[next - 1] = digits[i];
+        next -= 2;
+    }
+
+    /* Handle last 1-2 digits. */
+    if (value < 10) {
+        dst[next] = '0' + (uint32_t) value;
+    } else {
+        int i = (uint32_t) value * 2;
+        dst[next] = digits[i + 1];
+        dst[next - 1] = digits[i];
+    }
+
     return length;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -352,7 +352,7 @@ int ull2string(char *dst, size_t dstlen, unsigned long long value) {
         "8081828384858687888990919293949596979899";
 
     /* Check length. */
-    uint32_t const length = digits10(value) + negative;
+    uint32_t const length = digits10(value);
     if (length >= dstlen) return 0;
 
     /* Null term. */

--- a/src/util.h
+++ b/src/util.h
@@ -48,14 +48,13 @@ typedef enum {
 int stringmatchlen(const char *p, int plen, const char *s, int slen, int nocase);
 int stringmatch(const char *p, const char *s, int nocase);
 int stringmatchlen_fuzz_test(void);
-long long memtoll(const char *p, int *err);
 unsigned long long memtoull(const char *p, int *err);
 const char *mempbrk(const char *s, size_t len, const char *chars, size_t charslen);
 char *memmapchars(char *s, size_t len, const char *from, const char *to, size_t setlen);
 uint32_t digits10(uint64_t v);
 uint32_t sdigits10(int64_t v);
 int ll2string(char *s, size_t len, long long value);
-int ull2string(char *s, size_t len, unsigned long long value);
+int ull2string(char *s, size_t len, unsigned long long value, int negative);
 int string2ll(const char *s, size_t slen, long long *value);
 int string2ull(const char *s, unsigned long long *value);
 int string2l(const char *s, size_t slen, long *value);

--- a/src/util.h
+++ b/src/util.h
@@ -49,11 +49,13 @@ int stringmatchlen(const char *p, int plen, const char *s, int slen, int nocase)
 int stringmatch(const char *p, const char *s, int nocase);
 int stringmatchlen_fuzz_test(void);
 long long memtoll(const char *p, int *err);
+unsigned long long memtoull(const char *p, int *err);
 const char *mempbrk(const char *s, size_t len, const char *chars, size_t charslen);
 char *memmapchars(char *s, size_t len, const char *from, const char *to, size_t setlen);
 uint32_t digits10(uint64_t v);
 uint32_t sdigits10(int64_t v);
 int ll2string(char *s, size_t len, long long value);
+int ull2string(char *s, size_t len, unsigned long long value);
 int string2ll(const char *s, size_t slen, long long *value);
 int string2ull(const char *s, unsigned long long *value);
 int string2l(const char *s, size_t slen, long *value);

--- a/src/util.h
+++ b/src/util.h
@@ -54,7 +54,7 @@ char *memmapchars(char *s, size_t len, const char *from, const char *to, size_t 
 uint32_t digits10(uint64_t v);
 uint32_t sdigits10(int64_t v);
 int ll2string(char *s, size_t len, long long value);
-int ull2string(char *s, size_t len, unsigned long long value);
+int ull2string(char *s, size_t len, unsigned long long value, int negative);
 int string2ll(const char *s, size_t slen, long long *value);
 int string2ull(const char *s, unsigned long long *value);
 int string2l(const char *s, size_t slen, long *value);

--- a/src/util.h
+++ b/src/util.h
@@ -54,7 +54,7 @@ char *memmapchars(char *s, size_t len, const char *from, const char *to, size_t 
 uint32_t digits10(uint64_t v);
 uint32_t sdigits10(int64_t v);
 int ll2string(char *s, size_t len, long long value);
-int ull2string(char *s, size_t len, unsigned long long value, int negative);
+int ull2string(char *s, size_t len, unsigned long long value);
 int string2ll(const char *s, size_t slen, long long *value);
 int string2ull(const char *s, unsigned long long *value);
 int string2l(const char *s, size_t slen, long *value);


### PR DESCRIPTION
This PR is for https://github.com/redis/redis/issues/9071.

This aims to solve the issue in CONFIG SET maxmemory can only set maxmemory to up to 9223372036854775807 (2^63) while the maxmemory should be ULLONG. Added a memtoull function to convert a string representing an amount of memory into the number of bytes (similar to memtoll but for ull). Also added ull2string to convert a ULLong to string (Similar to ll2string).