### PR TITLE
[BUGFIX]Add some missed error statistics

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -164,7 +164,8 @@ robj *lookupKeyWriteWithFlags(redisDb *db, robj *key, int flags) {
 robj *lookupKeyWrite(redisDb *db, robj *key) {
     return lookupKeyWriteWithFlags(db, key, LOOKUP_NONE);
 }
-static void SentReplyOnKeyMiss(client *c, robj *reply){
+
+void SentReplyOnKeyMiss(client *c, robj *reply){
     serverAssert(sdsEncodedObject(reply));
     sds rep = reply->ptr;
     if (sdslen(rep) > 1 && rep[0] == '-'){
@@ -173,6 +174,7 @@ static void SentReplyOnKeyMiss(client *c, robj *reply){
         addReply(c,reply);
     }
 }
+
 robj *lookupKeyReadOrReply(client *c, robj *key, robj *reply) {
     robj *o = lookupKeyRead(c->db, key);
     if (!o) SentReplyOnKeyMiss(c, reply);

--- a/src/db.c
+++ b/src/db.c
@@ -164,7 +164,6 @@ robj *lookupKeyWriteWithFlags(redisDb *db, robj *key, int flags) {
 robj *lookupKeyWrite(redisDb *db, robj *key) {
     return lookupKeyWriteWithFlags(db, key, LOOKUP_NONE);
 }
-
 void SentReplyOnKeyMiss(client *c, robj *reply){
     serverAssert(sdsEncodedObject(reply));
     sds rep = reply->ptr;

--- a/src/db.c
+++ b/src/db.c
@@ -174,7 +174,6 @@ void SentReplyOnKeyMiss(client *c, robj *reply){
         addReply(c,reply);
     }
 }
-
 robj *lookupKeyReadOrReply(client *c, robj *key, robj *reply) {
     robj *o = lookupKeyRead(c->db, key);
     if (!o) SentReplyOnKeyMiss(c, reply);

--- a/src/multi.c
+++ b/src/multi.c
@@ -174,9 +174,13 @@ void execCommand(client *c) {
      * A failed EXEC in the first case returns a multi bulk nil object
      * (technically it is not an error but a special behavior), while
      * in the second an EXECABORT error is returned. */
-    if (c->flags & (CLIENT_DIRTY_CAS|CLIENT_DIRTY_EXEC)) {
-        addReply(c, c->flags & CLIENT_DIRTY_EXEC ? shared.execaborterr :
-                                                   shared.nullarray[c->resp]);
+    if (c->flags & (CLIENT_DIRTY_CAS | CLIENT_DIRTY_EXEC)) {
+        if (c->flags & CLIENT_DIRTY_EXEC) {
+            addReplyErrorObject(c, shared.execaborterr);
+        } else {
+            addReply(c, shared.nullarray[c->resp]);
+        }
+
         discardTransaction(c);
         return;
     }

--- a/src/object.c
+++ b/src/object.c
@@ -1223,10 +1223,10 @@ robj *objectCommandLookup(client *c, robj *key) {
     return lookupKeyReadWithFlags(c->db,key,LOOKUP_NOTOUCH|LOOKUP_NONOTIFY);
 }
 
+extern void SentReplyOnKeyMiss();
 robj *objectCommandLookupOrReply(client *c, robj *key, robj *reply) {
     robj *o = objectCommandLookup(c,key);
-
-    if (!o) addReply(c, reply);
+    if (!o) SentReplyOnKeyMiss(c, reply);
     return o;
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -1223,7 +1223,6 @@ robj *objectCommandLookup(client *c, robj *key) {
     return lookupKeyReadWithFlags(c->db,key,LOOKUP_NOTOUCH|LOOKUP_NONOTIFY);
 }
 
-extern void SentReplyOnKeyMiss();
 robj *objectCommandLookupOrReply(client *c, robj *key, robj *reply) {
     robj *o = objectCommandLookup(c,key);
     if (!o) SentReplyOnKeyMiss(c, reply);

--- a/src/server.h
+++ b/src/server.h
@@ -2377,6 +2377,7 @@ robj *lookupKeyReadWithFlags(redisDb *db, robj *key, int flags);
 robj *lookupKeyWriteWithFlags(redisDb *db, robj *key, int flags);
 robj *objectCommandLookup(client *c, robj *key);
 robj *objectCommandLookupOrReply(client *c, robj *key, robj *reply);
+void SentReplyOnKeyMiss(client *c, robj *reply);
 int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle,
                        long long lru_clock, int lru_multiplier);
 #define LOOKUP_NONE 0

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -110,11 +110,12 @@ start_server {tags {"info" "external:skip"}} {
             catch {r exec} e
             assert_match {EXECABORT*} $e
             assert_match {*count=1*} [errorstat ERR]
-            assert_equal [s total_error_replies] 1
+            assert_match {*count=1*} [errorstat EXECABORT]
+            assert_equal [s total_error_replies] 2
             assert_match {*calls=0,*,rejected_calls=1,failed_calls=0} [cmdstat set]
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=0} [cmdstat multi]
-            assert_match {*calls=1,*,rejected_calls=0,failed_calls=0} [cmdstat exec]
-            assert_equal [s total_error_replies] 1
+            assert_match {*calls=1,*,rejected_calls=0,failed_calls=1} [cmdstat exec]
+            assert_equal [s total_error_replies] 2
             r config resetstat
             assert_match {} [errorstat ERR]
         }


### PR DESCRIPTION
The newest Redis provides a very comprehensive of error statistics. But some errors counting  is still missed.
This PR helps count errors for some behaviors which  add error replies with shared object. 

Before: 
(In this case, the client got the replied error message as no-key-error, but the errorstats does not count.)
```
➜  ~ redis-cli
127.0.0.1:6379> info errorstats
# Errorstats
127.0.0.1:6379> debug ziplist a
(error) ERR no such key
127.0.0.1:6379> info errorstats
# Errorstats
```

After
```
➜  ~ redis-cli
127.0.0.1:6379> info errorstats
# Errorstats
127.0.0.1:6379> debug ziplist a
(error) ERR no such key
127.0.0.1:6379> info errorstats
# Errorstats
errorstat_ERR:count=1
```
