### PR TITLE
Cleanup: createAOFClient uses createClient to avoid overlooked mismatches

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1184,7 +1184,7 @@ void freeClientOriginalArgv(client *c) {
     c->original_argc = 0;
 }
 
-static void freeClientArgv(client *c) {
+void freeClientArgv(client *c) {
     int j;
     for (j = 0; j < c->argc; j++)
         decrRefCount(c->argv[j]);


### PR DESCRIPTION
AOF fake client creation (createAOFClient) was doing similar work as createClient, with some minor differences, most of which unintended, this was dangerous and meant that many changes to createClient should have always been reflected to aof.c
This cleanup changes createAOFClient to call createClient with NULL, like we do in module.c and elsewhere.

##### Original description:
I noticed that when fake AOF client is created in `createAOFClient()`, not all the internal attributes in the client struct are properly initialized as compared to `createClient()` in `networking.c`. This can be potentially dangerous in terms of client usage later on when un-initialized variables get accessed. This commit fixes this issue. 

I haven't checked if all the fields in `client` struct are properly initialized in the regular `createClient()` routine, but I have a feeling it is better maintained and less likely to have missed out on some fields. I am open to also making this similar change in that routine as I think it can help simplify the code by not needing to explicitly setting a lot of fields to NULL or 0. 