### PR TITLE
Allow master to replicate command longer than replica's query buffer limit

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2196,7 +2196,7 @@ void readQueryFromClient(connection *conn) {
     c->lastinteraction = server.unixtime;
     if (c->flags & CLIENT_MASTER) c->read_reploff += nread;
     atomicIncr(server.stat_net_input_bytes, nread);
-    if (sdslen(c->querybuf) > server.client_max_querybuf_len) {
+    if (!(c->flags & CLIENT_MASTER) && sdslen(c->querybuf) > server.client_max_querybuf_len) {
         sds ci = catClientInfoString(sdsempty(),c), bytes = sdsempty();
 
         bytes = sdscatrepr(bytes,c->querybuf,64);


### PR DESCRIPTION
Currently if the replica is configured with a smaller `client-query-buffer-limit` value than the master, the master will be unable to replicate commands longer than this limit to the replica, which makes the replica disconnect from the master. When the replica tries to re-connect, if the master's replication backlog buffer is able to accomodate the command, the master will accept the PSYNC from the replica and send the command down to replica again, but the replica will be unable to apply the command again and disconnect - and get into a bad re-sync loop. 

This commit exempts the replication client on the replica from this limit to fix this replication problem. 