### PR TITLE
Redis-cli monitor and pubsub can be aborted with Ctrl+C, keeping the cli alive

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -212,6 +212,7 @@ static struct config {
     int interactive;
     int shutdown;
     int monitor_mode;
+    int monitor_skip;
     int pubsub_mode;
     int latency_mode;
     int latency_dist_mode;
@@ -1287,11 +1288,22 @@ static int cliReadReply(int output_raw_strings) {
     int output = 1;
 
     if (redisGetReply(context,&_reply) != REDIS_OK) {
+        if (config.monitor_skip) {
+            context->fd = 0;
+            redisFree(context);
+            context = NULL;
+            config.monitor_skip = 0;
+            config.monitor_mode = 0;
+            return cliConnect(1);
+        }
+
+
         if (config.shutdown) {
             redisFree(context);
             context = NULL;
             return REDIS_OK;
         }
+
         if (config.interactive) {
             /* Filter cases where we should reconnect */
             if (context->err == REDIS_ERR_IO &&
@@ -1362,6 +1374,7 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
     char *command = argv[0];
     size_t *argvlen;
     int j, output_raw;
+    int in = 0;
 
     if (!config.eval_ldb && /* In debugging mode, let's pass "help" to Redis. */
         (!strcasecmp(command,"help") || !strcasecmp(command,"?"))) {
@@ -1434,8 +1447,14 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
     while(repeat < 0 || repeat-- > 0) {
         redisAppendCommandArgv(context,argc,(const char**)argv,argvlen);
         while (config.monitor_mode) {
+            in = 1;
             if (cliReadReply(output_raw) != REDIS_OK) exit(1);
             fflush(stdout);
+        }
+
+        if (in == 1) {
+            zfree(argvlen);
+            return REDIS_OK;
         }
 
         if (config.pubsub_mode) {
@@ -8210,11 +8229,24 @@ static void intrinsicLatencyModeStop(int s) {
     force_cancel_loop = 1;
 }
 
+static void defaultSigIntHandler(int s) {
+    UNUSED(s);
+
+    if (config.monitor_mode) {
+        close(context->fd);
+        config.monitor_skip = 1;
+        return;
+    } else {
+        exit(1);
+    }
+}
+
 static void intrinsicLatencyMode(void) {
     long long test_end, run_time, max_latency = 0, runs = 0;
 
     run_time = (long long)config.intrinsic_latency_duration * 1000000;
     test_end = ustime() + run_time;
+
     signal(SIGINT, intrinsicLatencyModeStop);
 
     while(1) {
@@ -8449,6 +8481,7 @@ int main(int argc, char **argv) {
     if (argc == 0 && !config.eval) {
         /* Ignore SIGPIPE in interactive mode to force a reconnect */
         signal(SIGPIPE, SIG_IGN);
+        signal(SIGINT, defaultSigIntHandler);
 
         /* Note that in repl mode we don't abort on connection error.
          * A new attempt will be performed for every command send. */

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -213,7 +213,7 @@ static struct config {
     int shutdown;
     int monitor_mode;
     int pubsub_mode;
-    int blocking_state_aborted;
+    int blocking_state_aborted; /* used to abort monitor_mode and pubsub_mode. */
     int latency_mode;
     int latency_dist_mode;
     int latency_history;
@@ -8228,7 +8228,7 @@ static void sigIntHandler(int s) {
     if (config.monitor_mode || config.pubsub_mode) {
         close(context->fd);
         context->fd = REDIS_INVALID_FD;
-        config.blocking_state_aborted = 1; /* used to abort monitor_mode and pubsub_mode. */
+        config.blocking_state_aborted = 1;
     } else {
         exit(1);
     }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -213,7 +213,7 @@ static struct config {
     int shutdown;
     int monitor_mode;
     int pubsub_mode;
-    int block_state_aborted;
+    int blocking_state_aborted;
     int latency_mode;
     int latency_dist_mode;
     int latency_history;
@@ -1288,8 +1288,8 @@ static int cliReadReply(int output_raw_strings) {
     int output = 1;
 
     if (redisGetReply(context,&_reply) != REDIS_OK) {
-        if (config.block_state_aborted) {
-            config.block_state_aborted = 0;
+        if (config.blocking_state_aborted) {
+            config.blocking_state_aborted = 0;
             config.monitor_mode = 0;
             config.pubsub_mode = 0;
             return cliConnect(CC_FORCE);
@@ -8228,7 +8228,7 @@ static void sigIntHandler(int s) {
     if (config.monitor_mode || config.pubsub_mode) {
         close(context->fd);
         context->fd = REDIS_INVALID_FD;
-        config.block_state_aborted = 1;
+        config.blocking_state_aborted = 1; /* used to abort monitor_mode and pubsub_mode. */
     } else {
         exit(1);
     }
@@ -8298,7 +8298,7 @@ int main(int argc, char **argv) {
     config.shutdown = 0;
     config.monitor_mode = 0;
     config.pubsub_mode = 0;
-    config.block_state_aborted = 0;
+    config.blocking_state_aborted = 0;
     config.latency_mode = 0;
     config.latency_dist_mode = 0;
     config.latency_history = 0;


### PR DESCRIPTION
Copy from https://github.com/redis/redis/pull/3589 and do some improvement.
We can use `Ctrl+C` to exit monitor/pubsub modeand come back to redis-cli.