### PR TITLE
fix a compilation error around madvise when make with jemalloc on MacOS

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -539,7 +539,7 @@ void dismissObject(robj *o, size_t size_hint) {
 
     /* Currently we use zmadvise_dontneed only when we use jemalloc.
      * so we avoid these pointless loops when they're not going to do anything. */
-#if defined(USE_JEMALLOC)
+#if defined(USE_JEMALLOC) && defined(__linux__)
     if (o->refcount != 1) return;
     switch(o->type) {
         case OBJ_STRING: dismissStringObject(o); break;

--- a/src/object.c
+++ b/src/object.c
@@ -537,7 +537,7 @@ void dismissObject(robj *o, size_t size_hint) {
     /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled. */
     if (server.thp_enabled) return;
 
-    /* Currently we use zmadvise_dontneed only when we use jemalloc.
+    /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
      * so we avoid these pointless loops when they're not going to do anything. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
     if (o->refcount != 1) return;

--- a/src/server.c
+++ b/src/server.c
@@ -5987,7 +5987,7 @@ void dismissMemoryInChild(void) {
     /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled. */
     if (server.thp_enabled) return;
 
-    /* Currently we use zmadvise_dontneed only when we use jemalloc.
+    /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
      * so we avoid these pointless loops when they're not going to do anything. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
 

--- a/src/server.c
+++ b/src/server.c
@@ -5989,7 +5989,7 @@ void dismissMemoryInChild(void) {
 
     /* Currently we use zmadvise_dontneed only when we use jemalloc.
      * so we avoid these pointless loops when they're not going to do anything. */
-#if defined(USE_JEMALLOC)
+#if defined(USE_JEMALLOC) && defined(__linux__)
 
     /* Dismiss replication backlog. */
     if (server.repl_backlog != NULL) {

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -346,7 +346,7 @@ void zmalloc_set_oom_handler(void (*oom_handler)(size_t)) {
  * We do that in a fork child process to avoid CoW when the parent modifies
  * these shared pages. */
 void zmadvise_dontneed(void *ptr) {
-#if defined(USE_JEMALLOC)
+#if defined(USE_JEMALLOC) && defined(__linux__)
     static size_t page_size = 0;
     if (page_size == 0) page_size = sysconf(_SC_PAGESIZE);
     size_t page_size_mask = page_size - 1;


### PR DESCRIPTION
in #8974 @ShooterIT introduced `madvise(MADV_DONTNEED)` to help release memory to reduce COW.
But the requires header file `<sys/mman.h>`  is only included for linux system. 

So when I tried to make with jemalloc in my APPLE machine, I got compilation errors like 
```
zmalloc.c:363:9: error: implicit declaration of function 'madvise' is invalid in C99
      [-Werror,-Wimplicit-function-declaration]
        madvise((void *)aligned_ptr, real_size&~page_size_mask, MADV_DONTNEED);
        ^
zmalloc.c:363:65: error: use of undeclared identifier 'MADV_DONTNEED'
        madvise((void *)aligned_ptr, real_size&~page_size_mask, MADV_DONTNEED);
```

I added a condition to avoid this error. So this would only work for linux system. 
