### PR TITLE
Slot-to-keys using dict entry metadata

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -38,8 +38,7 @@
 /* Database backup. */
 struct dbBackup {
     redisDb *dbarray;
-    rax *slots_to_keys;
-    uint64_t slots_keys_count[CLUSTER_SLOTS];
+    clusterSlotsToKeysData slots_to_keys;
 };
 
 /*-----------------------------------------------------------------------------
@@ -184,11 +183,11 @@ robj *lookupKeyWriteOrReply(client *c, robj *key, robj *reply) {
  * The program is aborted if the key already exists. */
 void dbAdd(redisDb *db, robj *key, robj *val) {
     sds copy = sdsdup(key->ptr);
-    int retval = dictAdd(db->dict, copy, val);
-
-    serverAssertWithInfo(NULL,key,retval == DICT_OK);
+    dictEntry *de = dictAddRaw(db->dict, copy, NULL);
+    serverAssertWithInfo(NULL, key, de != NULL);
+    dictSetVal(db->dict, de, val);
     signalKeyAsReady(db, key, val->type);
-    if (server.cluster_enabled) slotToKeyAdd(key->ptr);
+    if (server.cluster_enabled) slotToKeyAddEntry(de);
 }
 
 /* This is a special version of dbAdd() that is used only when loading
@@ -203,9 +202,10 @@ void dbAdd(redisDb *db, robj *key, robj *val) {
  * ownership of the SDS string, otherwise 0 is returned, and is up to the
  * caller to free the SDS string. */
 int dbAddRDBLoad(redisDb *db, sds key, robj *val) {
-    int retval = dictAdd(db->dict, key, val);
-    if (retval != DICT_OK) return 0;
-    if (server.cluster_enabled) slotToKeyAdd(key);
+    dictEntry *de = dictAddRaw(db->dict, key, NULL);
+    if (de == NULL) return 0;
+    dictSetVal(db->dict, de, val);
+    if (server.cluster_enabled) slotToKeyAddEntry(de);
     return 1;
 }
 
@@ -313,8 +313,8 @@ int dbSyncDelete(redisDb *db, robj *key) {
         robj *val = dictGetVal(de);
         /* Tells the module that the key has been unlinked from the database. */
         moduleNotifyKeyUnlink(key,val,db->id);
+        if (server.cluster_enabled) slotToKeyDelEntry(de);
         dictFreeUnlinkedEntry(db->dict,de);
-        if (server.cluster_enabled) slotToKeyDel(key->ptr);
         return 1;
     } else {
         return 0;
@@ -441,7 +441,7 @@ long long emptyDb(int dbnum, int flags, void(callback)(dict*)) {
     /* Flush slots to keys map if enable cluster, we can flush entire
      * slots to keys map whatever dbnum because only support one DB
      * in cluster mode. */
-    if (server.cluster_enabled) slotToKeyFlush(async);
+    if (server.cluster_enabled) slotToKeyFlush();
 
     if (dbnum == -1) flushSlaveKeysWithExpireList();
 
@@ -469,12 +469,8 @@ dbBackup *backupDb(void) {
 
     /* Backup cluster slots to keys map if enable cluster. */
     if (server.cluster_enabled) {
-        backup->slots_to_keys = server.cluster->slots_to_keys;
-        memcpy(backup->slots_keys_count, server.cluster->slots_keys_count,
-            sizeof(server.cluster->slots_keys_count));
-        server.cluster->slots_to_keys = raxNew();
-        memset(server.cluster->slots_keys_count, 0,
-            sizeof(server.cluster->slots_keys_count));
+        slotToKeyCopyToBackup(&backup->slots_to_keys);
+        slotToKeyFlush();
     }
 
     moduleFireServerEvent(REDISMODULE_EVENT_REPL_BACKUP,
@@ -495,9 +491,6 @@ void discardDbBackup(dbBackup *backup, int flags, void(callback)(dict*)) {
         dictRelease(backup->dbarray[i].dict);
         dictRelease(backup->dbarray[i].expires);
     }
-
-    /* Release slots to keys map backup if enable cluster. */
-    if (server.cluster_enabled) freeSlotsToKeysMap(backup->slots_to_keys, async);
 
     /* Release backup. */
     zfree(backup->dbarray);
@@ -523,13 +516,7 @@ void restoreDbBackup(dbBackup *backup) {
     }
 
     /* Restore slots to keys map backup if enable cluster. */
-    if (server.cluster_enabled) {
-        serverAssert(server.cluster->slots_to_keys->numele == 0);
-        raxFree(server.cluster->slots_to_keys);
-        server.cluster->slots_to_keys = backup->slots_to_keys;
-        memcpy(server.cluster->slots_keys_count, backup->slots_keys_count,
-                sizeof(server.cluster->slots_keys_count));
-    }
+    if (server.cluster_enabled) slotToKeyRestoreBackup(&backup->slots_to_keys);
 
     /* Release backup. */
     zfree(backup->dbarray);
@@ -1912,103 +1899,4 @@ int xreadGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult 
     for (i = streams_pos+1; i < argc-num; i++) keys[i-streams_pos-1] = i;
     result->numkeys = num;
     return num;
-}
-
-/* Slot to Key API. This is used by Redis Cluster in order to obtain in
- * a fast way a key that belongs to a specified hash slot. This is useful
- * while rehashing the cluster and in other conditions when we need to
- * understand if we have keys for a given hash slot. */
-void slotToKeyUpdateKey(sds key, int add) {
-    size_t keylen = sdslen(key);
-    unsigned int hashslot = keyHashSlot(key,keylen);
-    unsigned char buf[64];
-    unsigned char *indexed = buf;
-
-    server.cluster->slots_keys_count[hashslot] += add ? 1 : -1;
-    if (keylen+2 > 64) indexed = zmalloc(keylen+2);
-    indexed[0] = (hashslot >> 8) & 0xff;
-    indexed[1] = hashslot & 0xff;
-    memcpy(indexed+2,key,keylen);
-    if (add) {
-        raxInsert(server.cluster->slots_to_keys,indexed,keylen+2,NULL,NULL);
-    } else {
-        raxRemove(server.cluster->slots_to_keys,indexed,keylen+2,NULL);
-    }
-    if (indexed != buf) zfree(indexed);
-}
-
-void slotToKeyAdd(sds key) {
-    slotToKeyUpdateKey(key,1);
-}
-
-void slotToKeyDel(sds key) {
-    slotToKeyUpdateKey(key,0);
-}
-
-/* Release the radix tree mapping Redis Cluster keys to slots. If 'async'
- * is true, we release it asynchronously. */
-void freeSlotsToKeysMap(rax *rt, int async) {
-    if (async) {
-        freeSlotsToKeysMapAsync(rt);
-    } else {
-        raxFree(rt);
-    }
-}
-
-/* Empty the slots-keys map of Redis CLuster by creating a new empty one and
- * freeing the old one. */
-void slotToKeyFlush(int async) {
-    rax *old = server.cluster->slots_to_keys;
-
-    server.cluster->slots_to_keys = raxNew();
-    memset(server.cluster->slots_keys_count,0,
-           sizeof(server.cluster->slots_keys_count));
-    freeSlotsToKeysMap(old, async);
-}
-
-/* Populate the specified array of objects with keys in the specified slot.
- * New objects are returned to represent keys, it's up to the caller to
- * decrement the reference count to release the keys names. */
-unsigned int getKeysInSlot(unsigned int hashslot, robj **keys, unsigned int count) {
-    raxIterator iter;
-    int j = 0;
-    unsigned char indexed[2];
-
-    indexed[0] = (hashslot >> 8) & 0xff;
-    indexed[1] = hashslot & 0xff;
-    raxStart(&iter,server.cluster->slots_to_keys);
-    raxSeek(&iter,">=",indexed,2);
-    while(count-- && raxNext(&iter)) {
-        if (iter.key[0] != indexed[0] || iter.key[1] != indexed[1]) break;
-        keys[j++] = createStringObject((char*)iter.key+2,iter.key_len-2);
-    }
-    raxStop(&iter);
-    return j;
-}
-
-/* Remove all the keys in the specified hash slot.
- * The number of removed items is returned. */
-unsigned int delKeysInSlot(unsigned int hashslot) {
-    raxIterator iter;
-    int j = 0;
-    unsigned char indexed[2];
-
-    indexed[0] = (hashslot >> 8) & 0xff;
-    indexed[1] = hashslot & 0xff;
-    raxStart(&iter,server.cluster->slots_to_keys);
-    while(server.cluster->slots_keys_count[hashslot]) {
-        raxSeek(&iter,">=",indexed,2);
-        raxNext(&iter);
-
-        robj *key = createStringObject((char*)iter.key+2,iter.key_len-2);
-        dbDelete(&server.db[0],key);
-        decrRefCount(key);
-        j++;
-    }
-    raxStop(&iter);
-    return j;
-}
-
-unsigned int countKeysInSlot(unsigned int hashslot) {
-    return server.cluster->slots_keys_count[hashslot];
 }

--- a/src/dict.c
+++ b/src/dict.c
@@ -910,7 +910,7 @@ unsigned long dictScan(dict *d,
         m0 = DICTHT_SIZE_MASK(d->ht_size_exp[htidx0]);
 
         /* Emit entries at cursor */
-        if (bucketfn) bucketfn(privdata, &d->ht_table[htidx0][v & m0]);
+        if (bucketfn) bucketfn(d, &d->ht_table[htidx0][v & m0]);
         de = d->ht_table[htidx0][v & m0];
         while (de) {
             next = de->next;
@@ -941,7 +941,7 @@ unsigned long dictScan(dict *d,
         m1 = DICTHT_SIZE_MASK(d->ht_size_exp[htidx1]);
 
         /* Emit entries at cursor */
-        if (bucketfn) bucketfn(privdata, &d->ht_table[htidx0][v & m0]);
+        if (bucketfn) bucketfn(d, &d->ht_table[htidx0][v & m0]);
         de = d->ht_table[htidx0][v & m0];
         while (de) {
             next = de->next;
@@ -953,7 +953,7 @@ unsigned long dictScan(dict *d,
          * of the index pointed to by the cursor in the smaller table */
         do {
             /* Emit entries at cursor */
-            if (bucketfn) bucketfn(privdata, &d->ht_table[htidx1][v & m1]);
+            if (bucketfn) bucketfn(d, &d->ht_table[htidx1][v & m1]);
             de = d->ht_table[htidx1][v & m1];
             while (de) {
                 next = de->next;

--- a/src/dict.c
+++ b/src/dict.c
@@ -338,7 +338,11 @@ dictEntry *dictAddRaw(dict *d, void *key, dictEntry **existing)
      * system it is more likely that recently added entries are accessed
      * more frequently. */
     htidx = dictIsRehashing(d) ? 1 : 0;
-    entry = zmalloc(sizeof(*entry));
+    size_t metasize = dictMetadataSize(d);
+    entry = zmalloc(sizeof(*entry) + metasize);
+    if (metasize > 0) {
+        memset(dictMetadata(entry), 0, metasize);
+    }
     entry->next = d->ht_table[htidx][index];
     d->ht_table[htidx][index] = entry;
     d->ht_used[htidx]++;

--- a/src/dict.h
+++ b/src/dict.h
@@ -53,6 +53,7 @@ typedef struct dictEntry {
         double d;
     } v;
     struct dictEntry *next;
+    void *metadata[];
 } dictEntry;
 
 typedef struct dict dict;
@@ -65,6 +66,9 @@ typedef struct dictType {
     void (*keyDestructor)(dict *d, void *key);
     void (*valDestructor)(dict *d, void *obj);
     int (*expandAllowed)(size_t moreMem, double usedRatio);
+    /* Allow a dictEntry to carry extra caller-defined metadata.  The
+     * extra memory is initialized to 0 when a dictEntry is allocated. */
+    size_t (*dictEntryMetadataBytes)(dict *d);
 } dictType;
 
 #define DICTHT_SIZE(exp) ((exp) == -1 ? 0 : (unsigned long)1<<(exp))
@@ -139,6 +143,10 @@ typedef void (dictScanBucketFunction)(void *privdata, dictEntry **bucketref);
     (((d)->type->keyCompare) ? \
         (d)->type->keyCompare((d), key1, key2) : \
         (key1) == (key2))
+
+#define dictMetadata(entry) (&(entry)->metadata)
+#define dictMetadataSize(d) ((d)->type->dictEntryMetadataBytes \
+                             ? (d)->type->dictEntryMetadataBytes(d) : 0)
 
 #define dictHashKey(d, key) (d)->type->hashFunction(key)
 #define dictGetKey(he) ((he)->key)

--- a/src/dict.h
+++ b/src/dict.h
@@ -52,8 +52,10 @@ typedef struct dictEntry {
         int64_t s64;
         double d;
     } v;
-    struct dictEntry *next;
-    void *metadata[];
+    struct dictEntry *next;     /* Next entry in the same hash bucket. */
+    void *metadata[];           /* An arbitrary number of bytes (starting at a
+                                 * pointer-aligned address) of size as returned
+                                 * by dictType's dictEntryMetadataBytes(). */
 } dictEntry;
 
 typedef struct dict dict;
@@ -101,7 +103,7 @@ typedef struct dictIterator {
 } dictIterator;
 
 typedef void (dictScanFunction)(void *privdata, const dictEntry *de);
-typedef void (dictScanBucketFunction)(void *privdata, dictEntry **bucketref);
+typedef void (dictScanBucketFunction)(dict *d, dictEntry **bucketref);
 
 /* This is the initial size of every hash table */
 #define DICT_HT_INITIAL_EXP      2

--- a/src/server.c
+++ b/src/server.c
@@ -1384,6 +1384,14 @@ int dictExpandAllowed(size_t moreMem, double usedRatio) {
     }
 }
 
+/* Returns the size of the DB dict entry metadata in bytes. In cluster mode, the
+ * metadata is used for constructing a doubly linked list of the dict entries
+ * belonging to the same cluster slot. */
+size_t dictEntryMetadataSize(dict *d) {
+    UNUSED(d);
+    return server.cluster_enabled ? sizeof(void*) * 2 : 0;
+}
+
 /* Generic hash table type where keys are Redis Objects, Values
  * dummy pointers. */
 dictType objectKeyPointerValueDictType = {

--- a/src/server.c
+++ b/src/server.c
@@ -1386,10 +1386,10 @@ int dictExpandAllowed(size_t moreMem, double usedRatio) {
 
 /* Returns the size of the DB dict entry metadata in bytes. In cluster mode, the
  * metadata is used for constructing a doubly linked list of the dict entries
- * belonging to the same cluster slot. */
+ * belonging to the same cluster slot. See the Slot to Key API in cluster.c. */
 size_t dictEntryMetadataSize(dict *d) {
     UNUSED(d);
-    return server.cluster_enabled ? sizeof(void*) * 2 : 0;
+    return server.cluster_enabled ? sizeof(clusterDictEntryMetadata) : 0;
 }
 
 /* Generic hash table type where keys are Redis Objects, Values
@@ -1445,7 +1445,8 @@ dictType dbDictType = {
     dictSdsKeyCompare,          /* key compare */
     dictSdsDestructor,          /* key destructor */
     dictObjectDestructor,       /* val destructor */
-    dictExpandAllowed           /* allow to expand */
+    dictExpandAllowed,          /* allow to expand */
+    dictEntryMetadataSize       /* size of entry metadata in bytes */
 };
 
 /* server.lua_scripts sha (as sds string) -> scripts (as robj) cache. */

--- a/src/server.h
+++ b/src/server.h
@@ -2426,22 +2426,14 @@ void discardDbBackup(dbBackup *backup, int flags, void(callback)(dict*));
 int selectDb(client *c, int id);
 void signalModifiedKey(client *c, redisDb *db, robj *key);
 void signalFlushedDb(int dbid, int async);
-unsigned int getKeysInSlot(unsigned int hashslot, robj **keys, unsigned int count);
-unsigned int countKeysInSlot(unsigned int hashslot);
-unsigned int delKeysInSlot(unsigned int hashslot);
 void scanGenericCommand(client *c, robj *o, unsigned long cursor);
 int parseScanCursorOrReply(client *c, robj *o, unsigned long *cursor);
-void slotToKeyAdd(sds key);
-void slotToKeyDel(sds key);
 int dbAsyncDelete(redisDb *db, robj *key);
 void emptyDbAsync(redisDb *db);
-void slotToKeyFlush(int async);
 size_t lazyfreeGetPendingObjectsCount(void);
 size_t lazyfreeGetFreedObjectsCount(void);
 void lazyfreeResetStats(void);
 void freeObjAsync(robj *key, robj *obj, int dbid);
-void freeSlotsToKeysMapAsync(rax *rt);
-void freeSlotsToKeysMap(rax *rt, int async);
 
 
 /* API to get key arguments from commands */


### PR DESCRIPTION
This PR replaces the radix tree used for the mapping from cluster slot to keys.

In cluster mode, there is a mapping from cluster slot to the keys in the slot. Until now, this was stored in a radix tree, duplicating the keys. This PR replaces the parallel structure with a new structure which has the following design:

* In each dictEntry (hashtable bucket) in the main DB dict, memory for two extra pointers is allocated.
* The entries with keys belonging to the same cluster slot form a linked list using these pointers.
* For each of the 16384 cluster slots, there is a pointer to the beginning of each of these lists.

This new structure saves up to 20% memory and reduces the latency for adding and deleting keys by up to 50% (for keys of length 16 and very small values). This is at the cost of a latency regression of 5-10% for accessing and updating existing keys. For details, see the benchmark results posted in comments below in this PR.

Another side effect of this change is that now this data structure gets implicitly defragged when defrag.c reallocates the dictEntries, so this solves a problem in which earlier versions may have been unable to resolve fragmentation issues when redis was used in cluster mode. 

This work is based on #8210 which prepares for allocating extra memory in the dict entries.

Additionally, the slot-to-keys API is moved to cluster.c and cluster.h (from server.h and db.c).