### PR TITLE
Add debian:oldoldstable build target for CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ jobs:
     - name: make
       run: make REDIS_CFLAGS='-Werror'
 
+  build-debian-old:
+    runs-on: ubuntu-latest
+    container: debian:oldoldstable
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: |
+        apt-get update && apt-get install -y build-essential
+        make REDIS_CFLAGS='-Werror'
+
   build-macos-latest:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,6 @@ jobs:
     - name: module api test
       run: ./runtest-moduleapi --verbose
 
-  build-ubuntu-old:
-    runs-on: ubuntu-16.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: make
-      run: make REDIS_CFLAGS='-Werror'
-
   build-debian-old:
     runs-on: ubuntu-latest
     container: debian:oldoldstable


### PR DESCRIPTION
Making sure Redis builds properly on older compiler is important given the wide range of systems it is built for. So far Ubuntu 16.04 has been used for this purpose, but as it's getting phased out we'll move to `oldoldstable` Debian as an "old system" precursor.
