### PR TITLE
Added additional validation for cluster SETSLOT

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4652,6 +4652,10 @@ NULL
                     (char*)c->argv[4]->ptr);
                 return;
             }
+            if (nodeIsSlave(n)) {
+                addReplyError(c,"Target node is not a master");
+                return;
+            }
             server.cluster->migrating_slots_to[slot] = n;
         } else if (!strcasecmp(c->argv[3]->ptr,"importing") && c->argc == 5) {
             if (server.cluster->slots[slot] == myself) {
@@ -4662,6 +4666,10 @@ NULL
             if ((n = clusterLookupNode(c->argv[4]->ptr)) == NULL) {
                 addReplyErrorFormat(c,"I don't know about node %s",
                     (char*)c->argv[4]->ptr);
+                return;
+            }
+            if (nodeIsSlave(n)) {
+                addReplyError(c,"Target node is not a master");
                 return;
             }
             server.cluster->importing_slots_from[slot] = n;


### PR DESCRIPTION
Redis cluster SETSLOT <slot> [importing|migrating] <nodeid> is intended to migrate data from one primary to another. In this case these two nodes should agree that each other are primaries before continuing. This just adds another layer of validation so that end users get the error sooner that they may have copied the wrong node ID.

Follow up from https://github.com/redis/redis/pull/3450#issuecomment-892884390.

Note the other PR also had a FIX for SETSLOT <slot> node <nodeid> which you may call by default across the entire cluster to force acknowledging ownership of a slot, and someone might not know the state. 