### PR TITLE
Update debug log to include human readable packet type

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1786,8 +1786,8 @@ int clusterProcessPacket(clusterLink *link) {
 
     if (type < CLUSTERMSG_TYPE_COUNT)
         server.cluster->stats_bus_messages_received[type]++;
-    serverLog(LL_DEBUG,"--- Processing packet of type %d, %lu bytes",
-        type, (unsigned long) totlen);
+    serverLog(LL_DEBUG,"--- Processing packet of type %s, %lu bytes",
+        clusterGetMessageTypeString(type), (unsigned long) totlen);
 
     /* Perform sanity checks */
     if (totlen < 16) return 1; /* At least signature, version, totlen, count. */


### PR DESCRIPTION
Minor nitpick to print the human readable name for a packet while debugging cluster packets.