### PR TITLE
Fix the wrong detection of sync_file_range system call

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -36,6 +36,7 @@
 
 #ifdef __linux__
 #include <features.h>
+#include <fcntl.h>
 #endif
 
 /* Define redis_fstat to fstat or fstat64() */


### PR DESCRIPTION
If we want to check `defined(SYNC_FILE_RANGE_WAIT_BEFORE)`, we should include fcntl.h.
otherwise, SYNC_FILE_RANGE_WAIT_BEFORE is not defined, and there is alway not `sync_file_range` system call.
Introduced by #8532 (released in 6.0.12 and 6.2.1)