### PR TITLE
modify the comment of "ZSKIPLIST_MAXLEVEL"

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -386,7 +386,7 @@ typedef enum {
 /* Anti-warning macro... */
 #define UNUSED(V) ((void) V)
 
-#define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
+#define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^32 elements */
 #define ZSKIPLIST_P 0.25      /* Skiplist P = 1/4 */
 
 /* Append only defines */


### PR DESCRIPTION
modify the comment of "ZSKIPLIST_MAXLEVEL",  " 2^64 elements" maybe modif to "2^32 elements" .

<!-- 
#define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
-->