### PR TITLE
Add LMPOP/BLMPOP commands.

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -65,7 +65,7 @@
 #include "latency.h"
 #include "monotonic.h"
 
-void serveClientBlockedOnList(client *receiver, robj *o, robj *key, robj *dstkey, redisDb *db, int *deleted, int wherefrom, int whereto);
+void serveClientBlockedOnList(client *receiver, robj *o, robj *key, robj *dstkey, redisDb *db, int wherefrom, int whereto, int *deleted);
 int getListPositionFromObjectOrReply(client *c, robj *arg, int *position);
 
 /* This structure represents the blocked key information that we store
@@ -292,8 +292,8 @@ void serveClientsBlockedOnListKey(robj *o, readyList *rl) {
             elapsedStart(&replyTimer);
             serveClientBlockedOnList(receiver, o,
                                      rl->key, dstkey, rl->db,
-                                     &deleted,
-                                     wherefrom, whereto);
+                                     wherefrom, whereto,
+                                     &deleted);
             updateStatsOnUnblock(receiver, 0, elapsedUs(replyTimer));
             unblockClient(receiver);
 

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -294,8 +294,8 @@ void serveClientsBlockedOnListKey(robj *o, readyList *rl) {
              * This is the reason why i added a `del = 0` in blocking way before.
              * Avoid calling listTypeLength after deleting the key (or delete the key in caller)
              * */
-            //if (listTypeLength(o) == 0) {
-            if (!isListType(o) || listTypeLength(o) == 0) {
+            if (listTypeLength(o) == 0) {
+            // if (!isListType(o) || listTypeLength(o) == 0) {
                 /* The list is empty, we can't pop any elements, break the loop. */
                 break;
             }

--- a/src/db.c
+++ b/src/db.c
@@ -1717,6 +1717,11 @@ int evalGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *
     return genericGetKeys(0, 2, 3, 1, argv, argc, result);
 }
 
+int lmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
+    UNUSED(cmd);
+    return genericGetKeys(0, 1, 2, 1, argv, argc, result);
+}
+
 /* Helper function to extract keys from the SORT command.
  *
  * SORT <sort-key> ... STORE <store-key> ...

--- a/src/db.c
+++ b/src/db.c
@@ -1722,6 +1722,11 @@ int lmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult 
     return genericGetKeys(0, 1, 2, 1, argv, argc, result);
 }
 
+int blmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
+    UNUSED(cmd);
+    return genericGetKeys(0, 2, 3, 1, argv, argc, result);
+}
+
 /* Helper function to extract keys from the SORT command.
  *
  * SORT <sort-key> ... STORE <store-key> ...

--- a/src/module.c
+++ b/src/module.c
@@ -5504,7 +5504,7 @@ RedisModuleBlockedClient *moduleBlockClient(RedisModuleCtx *ctx, RedisModuleCmdF
             "Blocking module command called from transaction");
     } else {
         if (keys) {
-            blockForKeys(c,BLOCKED_MODULE,keys,numkeys,timeout,NULL,NULL,NULL);
+            blockForKeys(c,BLOCKED_MODULE,keys,numkeys,0,timeout,NULL,NULL,NULL);
         } else {
             blockClient(c,BLOCKED_MODULE);
         }

--- a/src/server.c
+++ b/src/server.c
@@ -316,9 +316,9 @@ struct redisCommand redisCommandTable[] = {
      "write fast @list",
      0,NULL,1,1,1,0,0,0},
 
-    {"lmpop",lmpopCommand,-3,
-     "write @list @blocking",
-     0,NULL,0,0,1,0,0,0},
+    {"lmpop",lmpopCommand,-4,
+     "write @list",
+     0,lmpopGetKeys,0,0,0,0,0,0},
 
     {"brpop",brpopCommand,-3,
      "write no-script @list @blocking",
@@ -335,6 +335,10 @@ struct redisCommand redisCommandTable[] = {
     {"blpop",blpopCommand,-3,
      "write no-script @list @blocking",
      0,NULL,1,-2,1,0,0,0},
+
+    {"blmpop",blmpopCommand,-5,
+     "write @list @blocking",
+     0,lmpopGetKeys,0,0,0,0,0,0},
 
     {"llen",llenCommand,2,
      "read-only fast @list",

--- a/src/server.c
+++ b/src/server.c
@@ -338,7 +338,7 @@ struct redisCommand redisCommandTable[] = {
 
     {"blmpop",blmpopCommand,-5,
      "write @list @blocking",
-     0,lmpopGetKeys,0,0,0,0,0,0},
+     0,blmpopGetKeys,0,0,0,0,0,0},
 
     {"llen",llenCommand,2,
      "read-only fast @list",

--- a/src/server.c
+++ b/src/server.c
@@ -316,6 +316,10 @@ struct redisCommand redisCommandTable[] = {
      "write fast @list",
      0,NULL,1,1,1,0,0,0},
 
+    {"lmpop",lmpopCommand,-3,
+     "write @list @blocking",
+     0,NULL,0,0,1,0,0,0},
+
     {"brpop",brpopCommand,-3,
      "write no-script @list @blocking",
      0,NULL,1,-2,1,0,0,0},

--- a/src/server.h
+++ b/src/server.h
@@ -1979,7 +1979,6 @@ void trackingBroadcastInvalidationMessages(void);
 int checkPrefixCollisionsOrReply(client *c, robj **prefix, size_t numprefix);
 
 /* List data type */
-int isListType(robj *subject);
 void listTypePush(robj *subject, robj *value, int where);
 robj *listTypePop(robj *subject, int where);
 unsigned long listTypeLength(const robj *subject);

--- a/src/server.h
+++ b/src/server.h
@@ -2461,6 +2461,7 @@ int xreadGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult 
 int memoryGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 int lcsGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 int lmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
+int blmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 
 unsigned short crc16(const char *buf, int len);
 

--- a/src/server.h
+++ b/src/server.h
@@ -793,7 +793,7 @@ typedef struct multiState {
  * The fields used depend on client->btype. */
 typedef struct blockingState {
     /* Generic fields. */
-    long count;             /* BPOP count option, set to 0 if the cmd do not support. */
+    long count;             /* Elements to pop if count was specified (BLMPOP), 0 otherwise. */
     mstime_t timeout;       /* Blocking operation timeout. If UNIX current time
                              * is > timeout then the operation timed out. */
 
@@ -1979,6 +1979,7 @@ void trackingBroadcastInvalidationMessages(void);
 int checkPrefixCollisionsOrReply(client *c, robj **prefix, size_t numprefix);
 
 /* List data type */
+int isListType(robj *subject);
 void listTypePush(robj *subject, robj *value, int where);
 robj *listTypePop(robj *subject, int where);
 unsigned long listTypeLength(const robj *subject);
@@ -1994,7 +1995,7 @@ robj *listTypeDup(robj *o);
 int listTypeDelRange(robj *o, long start, long stop);
 void unblockClientWaitingData(client *c);
 void popGenericCommand(client *c, int where);
-void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, int del);
+void listElementsRemoved(client *c, robj *key, int where, robj *o, long count);
 
 /* MULTI/EXEC/WATCH... */
 void unwatchAllKeys(client *c);
@@ -2460,6 +2461,7 @@ int georadiusGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysRes
 int xreadGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 int memoryGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 int lcsGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
+int lmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 
 unsigned short crc16(const char *buf, int len);
 
@@ -2662,6 +2664,7 @@ void execCommand(client *c);
 void discardCommand(client *c);
 void blpopCommand(client *c);
 void brpopCommand(client *c);
+void blmpopCommand(client *c);
 void brpoplpushCommand(client *c);
 void blmoveCommand(client *c);
 void appendCommand(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -1995,7 +1995,7 @@ robj *listTypeDup(robj *o);
 int listTypeDelRange(robj *o, long start, long stop);
 void unblockClientWaitingData(client *c);
 void popGenericCommand(client *c, int where);
-void listElementsRemoved(client *c, robj *key, int where, robj *o, long count);
+void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, int *deleted);
 
 /* MULTI/EXEC/WATCH... */
 void unwatchAllKeys(client *c);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -560,6 +560,7 @@ void mpopGenericCommand(client *c, robj **keys, int numkeys, int where, long cou
         rewriteClientCommandVector(c, 3,
                                    (where == LIST_HEAD) ? shared.lpop : shared.rpop,
                                    key, count_obj);
+        decrRefCount(count_obj);
         return;
     }
 

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -392,7 +392,8 @@ void lsetCommand(client *c) {
  * And also actually pop out from the list by calling listElementsRemoved.
  * We maintain the server.dirty and notifications there.
  *
- * The 'deleted' is an optional argument to get an indication if the key got deleted. */
+ * 'deleted' is an optional output argument to get an indication
+ * if the key got deleted by this function. */
 void listPopRangeAndReplyWithKey(client *c, robj *o, robj *key, int where, long count, int *deleted) {
     long llen = listTypeLength(o);
     long rangelen = (count > llen) ? llen : count;
@@ -458,7 +459,8 @@ void addListRangeReply(client *c, robj *o, long start, long end, int reverse) {
 
 /* A housekeeping helper for list elements popping tasks.
  *
- * The 'deleted' is an optional argument to get an indication if the key got deleted. */
+ * 'deleted' is an optional output argument to get an indication
+ * if the key got deleted by this function. */
 void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, int *deleted) {
     char *event = (where == LIST_HEAD) ? "lpop" : "rpop";
 
@@ -919,15 +921,16 @@ void rpoplpushCommand(client *c) {
  * 3) Propagate the resulting BRPOP, BLPOP, BLMPOP and additional xPUSH if any into
  *    the AOF and replication channel.
  *
- * The 'deleted' is an optional argument to get an indication if the key got deleted.
- *
  * The argument 'wherefrom' is LIST_TAIL or LIST_HEAD, and indicates if the
  * 'value' element was popped from the head (BLPOP) or tail (BRPOP) so that
  * we can propagate the command properly.
  *
  * The argument 'whereto' is LIST_TAIL or LIST_HEAD, and indicates if the
  * 'value' element is to be pushed to the head or tail so that we can
- * propagate the command properly. */
+ * propagate the command properly.
+ *
+ * 'deleted' is an optional output argument to get an indication
+ * if the key got deleted by this function. */
 void serveClientBlockedOnList(client *receiver, robj *o, robj *key, robj *dstkey, redisDb *db, int wherefrom, int whereto, int *deleted)
 {
     robj *argv[5];

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -74,14 +74,6 @@ robj *listTypePop(robj *subject, int where) {
     return value;
 }
 
-/* Return 1 if the subject is a LIST, 0 if not */
-int isListType(robj *subject) {
-    if (subject->encoding == OBJ_ENCODING_QUICKLIST) {
-        return 1;
-    }
-    return 0;
-}
-
 unsigned long listTypeLength(const robj *subject) {
     if (subject->encoding == OBJ_ENCODING_QUICKLIST) {
         return quicklistCount(subject->ptr);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -956,6 +956,7 @@ void serveClientBlockedOnList(client *receiver, robj *o, robj *key, robj *dstkey
 
             argv[2] = createStringObjectFromLongLong((count > llen) ? llen : count);
             propagate(cmd, db->id, argv, 3, PROPAGATE_AOF|PROPAGATE_REPL);
+            decrRefCount(argv[2]);
 
             /* Pop a range of elements in a nested arrays way. */
             listPopRangeAndReplyWithKey(receiver, o, key, wherefrom, count, deleted);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2152,7 +2152,7 @@ void xreadCommand(client *c) {
             goto cleanup;
         }
         blockForKeys(c, BLOCKED_STREAM, c->argv+streams_arg, streams_count,
-                     timeout, NULL, NULL, ids);
+                     0, timeout, NULL, NULL, ids);
         /* If no COUNT is given and we block, set a relatively small count:
          * in case the ID provided is too low, we do not want the server to
          * block just to serve this client a huge stream of messages. */

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3967,7 +3967,7 @@ void blockingGenericZpopCommand(client *c, int where) {
     }
 
     /* If the keys do not exist we must block */
-    blockForKeys(c,BLOCKED_ZSET,c->argv + 1,c->argc - 2,timeout,NULL,NULL,NULL);
+    blockForKeys(c,BLOCKED_ZSET,c->argv + 1,c->argc - 2,0,timeout,NULL,NULL,NULL);
 }
 
 // BZPOPMIN key [key ...] timeout

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -321,6 +321,7 @@ tags {"aof external:skip"} {
         }
     }
 
+    # Test that LMPOP/BLMPOP work fine with AOF.
     create_aof {
         append_to_aof [formatCommand lpush mylist a b c]
         append_to_aof [formatCommand rpush mylist2 1 2 3]
@@ -328,7 +329,7 @@ tags {"aof external:skip"} {
     }
 
     start_server_aof [list dir $server_path aof-load-truncated no] {
-        test "AOF+LMPOP: pop elements from the list" {
+        test "AOF+LMPOP/BLMPOP: pop elements from the list" {
             set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
             wait_done_loading $client
 
@@ -347,7 +348,7 @@ tags {"aof external:skip"} {
     }
 
     start_server_aof [list dir $server_path aof-load-truncated no] {
-        test "AOF+LMPOP: after pop elements from the list" {
+        test "AOF+LMPOP/BLMPOP: after pop elements from the list" {
             set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
             wait_done_loading $client
 

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -334,15 +334,15 @@ tags {"aof external:skip"} {
 
             # Pop all elements from mylist.
             $client lmpop 1 mylist left count 1
-            $client lmpop 1 mylist left count 10 block 0
+            $client blmpop 1 mylist left count 10 0
 
             # Pop all elements from mylist2.
             $client lmpop 2 mylist mylist2 right count 2
-            $client lmpop 2 mylist mylist2 right count 10 block 0
+            $client blmpop 2 mylist mylist2 right count 10 0
 
             # Leave two elements in mylist3.
-            $client lmpop 3 mylist mylist2 mylist3 left count 1 block 0
-            $client lmpop 3 mylist mylist2 mylist3 right count 2 block 0
+            $client blmpop 3 mylist mylist2 mylist3 left count 1 0
+            $client blmpop 3 mylist mylist2 mylist3 right count 2 0
         }
     }
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -12,74 +12,7 @@ source tests/support/test.tcl
 source tests/support/util.tcl
 
 set ::all_tests {
-    unit/printver
-    unit/dump
-    unit/auth
-    unit/protocol
-    unit/keyspace
-    unit/scan
-    unit/info
-    unit/type/string
-    unit/type/incr
     unit/type/list
-    unit/type/list-2
-    unit/type/list-3
-    unit/type/set
-    unit/type/zset
-    unit/type/hash
-    unit/type/stream
-    unit/type/stream-cgroups
-    unit/sort
-    unit/expire
-    unit/other
-    unit/multi
-    unit/quit
-    unit/aofrw
-    unit/acl
-    unit/latency-monitor
-    integration/block-repl
-    integration/replication
-    integration/replication-2
-    integration/replication-3
-    integration/replication-4
-    integration/replication-psync
-    integration/aof
-    integration/rdb
-    integration/corrupt-dump
-    integration/corrupt-dump-fuzzer
-    integration/convert-zipmap-hash-on-load
-    integration/convert-ziplist-hash-on-load
-    integration/logging
-    integration/psync2
-    integration/psync2-reg
-    integration/psync2-pingoff
-    integration/failover
-    integration/redis-cli
-    integration/redis-benchmark
-    integration/dismiss-mem
-    unit/pubsub
-    unit/slowlog
-    unit/scripting
-    unit/maxmemory
-    unit/introspection
-    unit/introspection-2
-    unit/limits
-    unit/obuf-limits
-    unit/bitops
-    unit/bitfield
-    unit/geo
-    unit/memefficiency
-    unit/hyperloglog
-    unit/lazyfree
-    unit/wait
-    unit/pause
-    unit/querybuf
-    unit/pendingquerybuf
-    unit/tls
-    unit/tracking
-    unit/oom-score-adj
-    unit/shutdown
-    unit/networking
 }
 # Index to the next test to run in the ::all_tests list.
 set ::next_test 0

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -12,7 +12,7 @@ source tests/support/test.tcl
 source tests/support/util.tcl
 
 set ::all_tests {
-unit/printver
+    unit/printver
     unit/dump
     unit/auth
     unit/protocol

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -12,7 +12,74 @@ source tests/support/test.tcl
 source tests/support/util.tcl
 
 set ::all_tests {
+unit/printver
+    unit/dump
+    unit/auth
+    unit/protocol
+    unit/keyspace
+    unit/scan
+    unit/info
+    unit/type/string
+    unit/type/incr
     unit/type/list
+    unit/type/list-2
+    unit/type/list-3
+    unit/type/set
+    unit/type/zset
+    unit/type/hash
+    unit/type/stream
+    unit/type/stream-cgroups
+    unit/sort
+    unit/expire
+    unit/other
+    unit/multi
+    unit/quit
+    unit/aofrw
+    unit/acl
+    unit/latency-monitor
+    integration/block-repl
+    integration/replication
+    integration/replication-2
+    integration/replication-3
+    integration/replication-4
+    integration/replication-psync
+    integration/aof
+    integration/rdb
+    integration/corrupt-dump
+    integration/corrupt-dump-fuzzer
+    integration/convert-zipmap-hash-on-load
+    integration/convert-ziplist-hash-on-load
+    integration/logging
+    integration/psync2
+    integration/psync2-reg
+    integration/psync2-pingoff
+    integration/failover
+    integration/redis-cli
+    integration/redis-benchmark
+    integration/dismiss-mem
+    unit/pubsub
+    unit/slowlog
+    unit/scripting
+    unit/maxmemory
+    unit/introspection
+    unit/introspection-2
+    unit/limits
+    unit/obuf-limits
+    unit/bitops
+    unit/bitfield
+    unit/geo
+    unit/memefficiency
+    unit/hyperloglog
+    unit/lazyfree
+    unit/wait
+    unit/pause
+    unit/querybuf
+    unit/pendingquerybuf
+    unit/tls
+    unit/tracking
+    unit/oom-score-adj
+    unit/shutdown
+    unit/networking
 }
 # Index to the next test to run in the ::all_tests list.
 set ::next_test 0

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -551,7 +551,7 @@ start_server {
         assert_equal {list {f e d c b}} [$rd read]
     }
 
-    test "BLPOP with same key multiple times should work" {
+    test "BLPOP with same key multiple times should work (issue #801)" {
         set rd [redis_deferring_client]
         r del list1{t} list2{t}
 
@@ -1459,7 +1459,7 @@ start_server {
             catch {[r client unblock $myid]} e
             assert_equal $e {invalid command name "0"}
 
-            # finally, see the this client and list are still functionals
+            # finally, see the this client and list are still functional
             bpop_command $rd $pop l 0
             wait_for_blocked_client
             r lpush l foo

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -6,16 +6,12 @@ start_server {
 } {
     source "tests/unit/type/list-common.tcl"
 
-    proc create_list {key entries} {
-        r del $key
-        foreach entry $entries { r rpush $key $entry }
-        assert_encoding quicklist $key
-    }
-
     # A helper function for BPOP/BLMPOP with one input key.
     proc bpop_command {rd pop key timeout} {
-        if {$pop == "BLMPOP"} {
+        if {$pop == "BLMPOP_LEFT"} {
             $rd blmpop 1 $key left count 1 $timeout
+        } elseif {$pop == "BLMPOP_RIGHT"} {
+            $rd blmpop 1 $key right count 1 $timeout
         } else {
             $rd $pop $key $timeout
         }
@@ -23,181 +19,14 @@ start_server {
 
     # A helper function for BPOP/BLMPOP with two input keys.
     proc bpop_command_two_key {rd pop key key2 timeout} {
-        if {$pop == "BLMPOP"} {
+        if {$pop == "BLMPOP_LEFT"} {
             $rd blmpop 2 $key $key2 left count 1 $timeout
+        } elseif {$pop == "BLMPOP_RIGHT"} {
+            $rd blmpop 2 $key $key2 right count 1 $timeout
         } else {
             $rd $pop $key $key2 $timeout
         }
     }
-
-    test {LMPOP with illegal argument} {
-        assert_error "ERR wrong number of arguments*" {r lmpop}
-        assert_error "ERR wrong number of arguments*" {r lmpop 1}
-        assert_error "ERR wrong number of arguments*" {r lmpop 1 mylist{t}}
-
-        assert_error "ERR numkeys*" {r lmpop 0 mylist{t} LEFT}
-        assert_error "ERR numkeys*" {r lmpop a mylist{t} LEFT}
-        assert_error "ERR numkeys*" {r lmpop -1 mylist{t} RIGHT}
-
-        assert_error "ERR syntax error*" {r lmpop 1 mylist{t} bad_where}
-        assert_error "ERR syntax error*" {r lmpop 1 mylist{t} LEFT bar_arg}
-        assert_error "ERR syntax error*" {r lmpop 1 mylist{t} RIGHT LEFT}
-        assert_error "ERR syntax error*" {r lmpop 1 mylist{t} COUNT}
-        assert_error "ERR syntax error*" {r lmpop 2 mylist{t} mylist2{t} bad_arg}
-
-        assert_error "ERR count*" {r lmpop 1 mylist{t} LEFT COUNT 0}
-        assert_error "ERR count*" {r lmpop 1 mylist{t} RIGHT COUNT a}
-        assert_error "ERR count*" {r lmpop 1 mylist{t} LEFT COUNT -1}
-        assert_error "ERR count*" {r lmpop 2 mylist{t} mylist2{t} RIGHT COUNT -1}
-
-        #assert_error "ERR timeout*" {r lmpop 1 mylist{t} LEFT COUNT 1 BLOCK a}
-        #assert_error "ERR timeout*" {r lmpop 1 mylist{t} RIGHT COUNT 1 BLOCK -1}
-        #assert_error "ERR timeout*" {r lmpop 2 mylist{t} mylist2{t} RIGHT COUNT 1 BLOCK -1}
-    }
-
-    test {LMPOP against empty list} {
-        assert_equal {} [r lmpop 1 non-existing-list{t} left count 1]
-        assert_equal {} [r lmpop 1 non-existing-list{t} left count 10]
-
-        assert_equal {} [r lmpop 2 non-existing-list{t} non-existing-list2{t} right count 1]
-        assert_equal {} [r lmpop 2 non-existing-list{t} non-existing-list2{t} right count 10]
-    }
-
-    test {LMPOP single input key} {
-        create_list mylist "a b c d e f"
-
-        assert_equal {mylist a} [r lmpop 1 mylist left count 1]
-        assert_equal {mylist f} [r lmpop 1 mylist right count 1]
-        assert_equal 4 [r llen mylist]
-
-        # Same key multiple times.
-        assert_equal {mylist {b c}} [r lmpop 2 mylist mylist left count 2]
-        assert_equal {mylist {e d}} [r lmpop 2 mylist mylist right count 2]
-        assert_equal 0 [r exists mylist]
-    }
-
-    test {LMPOP single existing list} {
-        # First one exists, second one does not exist.
-        create_list mylist{t} "a b c d e"
-        r del mylist2{t}
-        assert_equal {mylist{t} a} [r lmpop 2 mylist{t} mylist2{t} left count 1]
-        assert_equal 4 [r llen mylist{t}]
-        assert_equal {mylist{t} {e d c b}} [r lmpop 2 mylist{t} mylist2{t} right count 10]
-        assert_equal {} [r lmpop 2 mylist{t} mylist2{t} right count 1]
-
-        # First one does not exist, second one exists.
-        r del mylist{t}
-        create_list mylist2{t} "1 2 3 4 5"
-        assert_equal {mylist2{t} 5} [r lmpop 2 mylist{t} mylist2{t} right count 1]
-        assert_equal 4 [r llen mylist2{t}]
-        assert_equal {mylist2{t} {1 2 3 4}} [r lmpop 2 mylist{t} mylist2{t} left count 10]
-
-        assert_equal 0 [r exists mylist{t} mylist2{t}]
-    }
-
-    test {LMPOP multiple existing lists} {
-        create_list mylist{t} "a b c d e"
-        create_list mylist2{t} "1 2 3 4 5"
-
-        # Pop up from the first key.
-        assert_equal {mylist{t} {a b}} [r lmpop 2 mylist{t} mylist2{t} left count 2]
-        assert_equal 3 [r llen mylist{t}]
-        assert_equal {mylist{t} {e d c}} [r lmpop 2 mylist{t} mylist2{t} right count 3]
-        assert_equal 0 [r exists mylist{t}]
-
-        # Pop up from the second key.
-        assert_equal {mylist2{t} {1 2 3}} [r lmpop 2 mylist{t} mylist2{t} left count 3]
-        assert_equal 2 [r llen mylist2{t}]
-        assert_equal {mylist2{t} {5 4}} [r lmpop 2 mylist{t} mylist2{t} right count 2]
-        assert_equal 0 [r exists mylist{t}]
-
-        # Pop up all elements.
-        create_list mylist{t} "a b c"
-        create_list mylist2{t} "1 2 3"
-        assert_equal {mylist{t} {a b c}} [r lmpop 2 mylist{t} mylist2{t} left count 10]
-        assert_equal 0 [r llen mylist{t}]
-        assert_equal {mylist2{t} {3 2 1}} [r lmpop 2 mylist{t} mylist2{t} right count 10]
-        assert_equal 0 [r llen mylist2{t}]
-        assert_equal 0 [r exists mylist{t} mylist2{t}]
-    }
-
-    test {LMPOP propagate as pop with count command to replica} {
-        set repl [attach_to_replication_stream]
-
-        # left/right propagate as lpop/rpop with count
-        r lpush mylist{t} a b c
-
-        # Pop elements from one list.
-        r lmpop 1 mylist{t} left count 1
-        r lmpop 1 mylist{t} right count 1
-
-        # Now the list have only one element
-        r lmpop 2 mylist{t} mylist2{t} left count 10
-
-        # No elements so we don't propagate.
-        r lmpop 2 mylist{t} mylist2{t} left count 10
-
-        # Pop elements from the second list.
-        r rpush mylist2{t} 1 2 3
-        r lmpop 2 mylist{t} mylist2{t} left count 2
-        r lmpop 2 mylist{t} mylist2{t} right count 1
-
-        # Pop all elements.
-        r rpush mylist{t} a b c
-        r rpush mylist2{t} 1 2 3
-        r lmpop 2 mylist{t} mylist2{t} left count 10
-        r lmpop 2 mylist{t} mylist2{t} right count 10
-
-        assert_replication_stream $repl {
-            {select *}
-            {lpush mylist{t} a b c}
-            {lpop mylist{t} 1}
-            {rpop mylist{t} 1}
-            {lpop mylist{t} 1}
-            {rpush mylist2{t} 1 2 3}
-            {lpop mylist2{t} 2}
-            {rpop mylist2{t} 1}
-            {rpush mylist{t} a b c}
-            {rpush mylist2{t} 1 2 3}
-            {lpop mylist{t} 3}
-            {rpop mylist2{t} 3}
-        }
-    } {} {needs:repl}
-
-    test {BLMPOP propagate as pop with count command to replica} {
-        set rd [redis_deferring_client]
-        set repl [attach_to_replication_stream]
-
-        # BLMPOP without block.
-        r lpush mylist{t} a b c
-        r rpush mylist2{t} 1 2 3
-        r blmpop 1 mylist{t} left count 1 0
-        r blmpop 2 mylist{t} mylist2{t} right count 10 0
-        r blmpop 2 mylist{t} mylist2{t} right count 10 0
-
-        # BLMPOP with block.
-        $rd blmpop 1 mylist{t} left count 1 0
-        r lpush mylist{t} a
-        $rd blmpop 2 mylist{t} mylist2{t} left count 5 0
-        r lpush mylist{t} a b c
-        $rd blmpop 2 mylist{t} mylist2{t} right count 10 0
-        r rpush mylist2{t} a b c
-
-        assert_replication_stream $repl {
-            {select *}
-            {lpush mylist{t} a b c}
-            {rpush mylist2{t} 1 2 3}
-            {lpop mylist{t} 1}
-            {rpop mylist{t} 2}
-            {rpop mylist2{t} 3}
-            {lpush mylist{t} a}
-            {lpop mylist{t} 1}
-            {lpush mylist{t} a b c}
-            {lpop mylist{t} 3}
-            {rpush mylist2{t} a b c}
-            {rpop mylist2{t} 3}
-        }
-    } {} {needs:repl}
 
     test {LPOS basic usage} {
         r DEL mylist
@@ -304,10 +133,6 @@ start_server {
         assert_equal $largevalue(linkedlist) [r rpop mylist2]
         assert_equal c [r lpop mylist2]
     }
-
-    test {R/LPOP against empty list} {
-        r lpop non-existing-list
-    } {}
     
     test {R/LPOP with the optional count argument} {
         assert_equal 7 [r lpush listcount aa bb cc dd ee ff gg]
@@ -333,113 +158,84 @@ start_server {
         assert_equal 0 [r llen mylist2]
     }
 
+    proc create_list {key entries} {
+        r del $key
+        foreach entry $entries { r rpush $key $entry }
+        assert_encoding quicklist $key
+    }
+
     foreach {type large} [array get largevalue] {
-        test "BLPOP, BRPOP: single existing list - $type" {
+    foreach {pop} {BLPOP BLMPOP_LEFT} {
+        test "$pop: single existing list - $type" {
             set rd [redis_deferring_client]
             create_list blist "a b $large c d"
 
-            $rd blpop blist 1
+            bpop_command $rd $pop blist 1
             assert_equal {blist a} [$rd read]
-            $rd brpop blist 1
+            if {$pop == "BLPOP"} {
+                bpop_command $rd BRPOP blist 1
+            } else {
+                bpop_command $rd BLMPOP_RIGHT blist 1
+            }
             assert_equal {blist d} [$rd read]
 
-            $rd blpop blist 1
+            bpop_command $rd $pop blist 1
             assert_equal {blist b} [$rd read]
-            $rd brpop blist 1
+            if {$pop == "BLPOP"} {
+                bpop_command $rd BRPOP blist 1
+            } else {
+                bpop_command $rd BLMPOP_RIGHT blist 1
+            }
             assert_equal {blist c} [$rd read]
+
+            assert_equal 1 [r llen blist]
         }
 
-        test "BLMPOP: single existing list - $type" {
-            set rd [redis_deferring_client]
-            create_list blist{t} "a b c $large d e f"
-
-            $rd blmpop 1 blist{t} left count 1 1
-            assert_equal {blist{t} a} [$rd read]
-            $rd blmpop 1 blist{t} left count 2 1
-            assert_equal {blist{t} {b c}} [$rd read]
-
-            $rd blmpop 1 blist{t} right count 2 1
-            assert_equal {blist{t} {f e}} [$rd read]
-            $rd blmpop 1 blist{t} right count 1 1
-            assert_equal {blist{t} d} [$rd read]
-
-            assert_equal 1 [r llen blist{t}]
-        }
-
-        test "BLPOP, BRPOP: multiple existing lists - $type" {
+        test "$pop: multiple existing lists - $type" {
             set rd [redis_deferring_client]
             create_list blist1{t} "a $large c"
             create_list blist2{t} "d $large f"
 
-            $rd blpop blist1{t} blist2{t} 1
+            bpop_command_two_key $rd $pop blist1{t} blist2{t} 1
             assert_equal {blist1{t} a} [$rd read]
-            $rd brpop blist1{t} blist2{t} 1
+            if {$pop == "BLPOP"} {
+                bpop_command_two_key $rd BRPOP blist1{t} blist2{t} 1
+            } else {
+                bpop_command_two_key $rd BLMPOP_RIGHT blist1{t} blist2{t} 1
+            }
             assert_equal {blist1{t} c} [$rd read]
             assert_equal 1 [r llen blist1{t}]
             assert_equal 3 [r llen blist2{t}]
 
-            $rd blpop blist2{t} blist1{t} 1
+            bpop_command_two_key $rd $pop blist2{t} blist1{t} 1
             assert_equal {blist2{t} d} [$rd read]
-            $rd brpop blist2{t} blist1{t} 1
+            if {$pop == "BLPOP"} {
+                bpop_command_two_key $rd BRPOP blist2{t} blist1{t} 1
+            } else {
+                bpop_command_two_key $rd BLMPOP_RIGHT blist2{t} blist1{t} 1
+            }
             assert_equal {blist2{t} f} [$rd read]
             assert_equal 1 [r llen blist1{t}]
             assert_equal 1 [r llen blist2{t}]
         }
 
-        test "BLMPOP: multiple existing lists - $type" {
-            set rd [redis_deferring_client]
-            create_list blist1{t} "a b c $large e f g"
-            create_list blist2{t} "1 2 3 $large 4 5 6"
-
-            # BLMPOP: Pop up from the first key.
-            $rd blmpop 2 blist1{t} blist2{t} left count 1 1
-            assert_equal {blist1{t} a} [$rd read]
-            $rd blmpop 2 blist1{t} blist2{t} right count 2 1
-            assert_equal {blist1{t} {g f}} [$rd read]
-            assert_equal 4 [r llen blist1{t}]
-            assert_equal 7 [r llen blist2{t}]
-
-            # BLMPOP: Pop up from the second key.
-            $rd blmpop 2 blist2{t} blist1{t} left count 2 1
-            assert_equal {blist2{t} {1 2}} [$rd read]
-            $rd blmpop 2 blist2{t} blist1{t} right count 1 1
-            assert_equal {blist2{t} 6} [$rd read]
-            assert_equal 4 [r llen blist1{t}]
-            assert_equal 4 [r llen blist2{t}]
-
-            # BLMPOP: Pop up all elements.
-            $rd blmpop 2 blist1{t} blist2{t} left count 10 1
-            $rd read
-            $rd blmpop 2 blist1{t} blist2{t} right count 10 1
-            $rd read
-            assert_equal 0 [r exists blist1{t} blist2{t}]
-        }
-
-        test "BLPOP, BRPOP: second list has an entry - $type" {
+        test "$pop: second list has an entry - $type" {
             set rd [redis_deferring_client]
             r del blist1{t}
             create_list blist2{t} "d $large f"
 
-            $rd blpop blist1{t} blist2{t} 1
+            bpop_command_two_key $rd $pop blist1{t} blist2{t} 1
             assert_equal {blist2{t} d} [$rd read]
-            $rd brpop blist1{t} blist2{t} 1
+            if {$pop == "BLPOP"} {
+                bpop_command_two_key $rd BRPOP blist1{t} blist2{t} 1
+            } else {
+                bpop_command_two_key $rd BLMPOP_RIGHT blist1{t} blist2{t} 1
+            }
             assert_equal {blist2{t} f} [$rd read]
             assert_equal 0 [r llen blist1{t}]
             assert_equal 1 [r llen blist2{t}]
         }
-
-        test "BLMPOP: second list has an entry - $type" {
-            set rd [redis_deferring_client]
-            r del blist1{t}
-            create_list blist2{t} "d $large f"
-
-            $rd blmpop 2 blist1{t} blist2{t} left count 1 1
-            assert_equal {blist2{t} d} [$rd read]
-            $rd blmpop 2 blist1{t} blist2{t} right count 1 1
-            assert_equal {blist2{t} f} [$rd read]
-            assert_equal 0 [r llen blist1{t}]
-            assert_equal 1 [r llen blist2{t}]
-        }
+    }
 
         test "BRPOPLPUSH - $type" {
             r del target{t}
@@ -485,11 +281,12 @@ start_server {
         }
     }
 
-    test "BLPOP, LPUSH + DEL should not awake blocked client" {
+foreach {pop} {BLPOP BLMPOP_LEFT} {
+    test "$pop, LPUSH + DEL should not awake blocked client" {
         set rd [redis_deferring_client]
         r del list
 
-        $rd blpop list 0
+        bpop_command $rd $pop list 0
         after 100 ;# Make sure rd is blocked before MULTI
 
         r multi
@@ -498,30 +295,14 @@ start_server {
         r exec
         r del list
         r lpush list b
-        $rd read
-    } {list b}
-
-    test "BLMPOP, LPUSH + DEL should not awake blocked client" {
-        set rd [redis_deferring_client]
-        r del list
-
-        $rd blmpop 1 list left count 10 0
-        after 100 ;# Make sure rd is blocked before MULTI
-
-        r multi
-        r lpush list a
-        r del list
-        r exec
-        r del list
-        r lpush list b c d e f
-        assert_equal {list {f e d c b}} [$rd read]
+        assert_equal {list b} [$rd read]
     }
 
-    test "BLPOP, LPUSH + DEL + SET should not awake blocked client" {
+    test "$pop, LPUSH + DEL + SET should not awake blocked client" {
         set rd [redis_deferring_client]
         r del list
 
-        $rd blpop list 0
+        bpop_command $rd $pop list 0
         after 100 ;# Make sure rd is blocked before MULTI
 
         r multi
@@ -531,25 +312,9 @@ start_server {
         r exec
         r del list
         r lpush list b
-        $rd read
-    } {list b}
-
-    test "BLMPOP, LPUSH + DEL + SET should not awake blocked client" {
-        set rd [redis_deferring_client]
-        r del list
-
-        $rd blmpop 1 list right count 10 0
-        after 100 ;# Make sure rd is blocked before MULTI
-
-        r multi
-        r rpush list a
-        r del list
-        r set list foo
-        r exec
-        r del list
-        r rpush list b c d e f
-        assert_equal {list {f e d c b}} [$rd read]
+        assert_equal {list b} [$rd read]
     }
+}
 
     test "BLPOP with same key multiple times should work (issue #801)" {
         set rd [redis_deferring_client]
@@ -572,64 +337,34 @@ start_server {
         assert_equal [$rd read] {list2{t} b}
     }
 
-    test "BLMPOP with same key multiple times should work" {
-        set rd [redis_deferring_client]
-        r del list1{t} list2{t}
-
-        # Data arriving after the BLMPOP - left count 1
-        $rd blmpop 4 list1{t} list2{t} list2{t} list1{t} left count 1 0
-        r lpush list1{t} a
-        assert_equal [$rd read] {list1{t} a}
-
-        # Data arriving after the BLMPOP - right count 10
-        $rd blmpop 4 list1{t} list2{t} list2{t} list1{t} right count 10 0
-        r lpush list2{t} a b c d e
-        assert_equal [$rd read] {list2{t} {a b c d e}}
-
-        # Data already there.
-        r lpush list1{t} a
-        r lpush list2{t} a b c d e
-        $rd blmpop 4 list1{t} list2{t} list2{t} list1{t} right count 1 0
-        assert_equal [$rd read] {list1{t} a}
-        $rd blmpop 4 list1{t} list2{t} list2{t} list1{t} left count 10 0
-        assert_equal [$rd read] {list2{t} {e d c b a}}
-    }
-
-    test "MULTI/EXEC is isolated from the point of view of BLPOP" {
+foreach {pop} {BLPOP BLMPOP_LEFT} {
+    test "MULTI/EXEC is isolated from the point of view of $pop" {
         set rd [redis_deferring_client]
         r del list
-        $rd blpop list 0
+
+        bpop_command $rd $pop list 0
+        after 100 ;# Make sure rd is blocked before MULTI
+
         r multi
         r lpush list a
         r lpush list b
         r lpush list c
         r exec
-        $rd read
-    } {list c}
+        assert_equal {list c} [$rd read]
+    }
 
-    test "MULTI/EXEC is isolated from the point of view of BLMPOP" {
-        set rd [redis_deferring_client]
-        r del list
-        $rd blmpop 1 list left count 2 0
-        r multi
-        r rpush list a
-        r rpush list b
-        r rpush list c
-        r exec
-        $rd read
-    } {list {a b}}
-
-    test "BLPOP with variadic LPUSH" {
+    test "$pop with variadic LPUSH" {
         set rd [redis_deferring_client]
         r del blist
         if {$::valgrind} {after 100}
-        $rd blpop blist 0
+        bpop_command $rd $pop blist 0
         if {$::valgrind} {after 100}
         assert_equal 2 [r lpush blist foo bar]
         if {$::valgrind} {after 100}
         assert_equal {blist bar} [$rd read]
         assert_equal foo [lindex [r lrange blist 0 -1] 0]
     }
+}
 
     test "BRPOPLPUSH with zero timeout should block indefinitely" {
         set rd [redis_deferring_client]
@@ -852,16 +587,18 @@ start_server {
       $rd read
     } {}
 
-    test "BLPOP when new key is moved into place" {
+foreach {pop} {BLPOP BLMPOP_LEFT} {
+    test "$pop when new key is moved into place" {
         set rd [redis_deferring_client]
+        r del foo{t}
 
-        $rd blpop foo{t} 5
+        bpop_command $rd $pop foo{t} 0
         r lpush bob{t} abc def hij
         r rename bob{t} foo{t}
         $rd read
     } {foo{t} hij}
 
-    test "BLPOP when result key is created by SORT..STORE" {
+    test "$pop when result key is created by SORT..STORE" {
         set rd [redis_deferring_client]
 
         # zero out list from previous test without explicit delete
@@ -869,35 +606,14 @@ start_server {
         r lpop foo{t}
         r lpop foo{t}
 
-        $rd blpop foo{t} 5
+        bpop_command $rd $pop foo{t} 5
         r lpush notfoo{t} hello hola aguacate konichiwa zanzibar
         r sort notfoo{t} ALPHA store foo{t}
         $rd read
     } {foo{t} aguacate}
+}
 
-    test "BLMPOP when new key is moved into place" {
-        set rd [redis_deferring_client]
-        r del blist{t} blist2{t}
-
-        $rd blmpop 1 blist{t} left count 1 0
-        r lpush blist2{t} aaa bbb ccc
-        r rename blist2{t} blist{t}
-        assert_equal {blist{t} ccc} [$rd read]
-    }
-
-    test "BLMPOP when result key is created by SORT..STORE" {
-        set rd [redis_deferring_client]
-
-        # zero out list from previous test without explicit delete
-        r lpop blist{t} 10
-
-        $rd blmpop 1 blist{t} left count 10 0
-        r lpush blist2{t} hello hola aguacate konichiwa zanzibar
-        r sort blist2{t} ALPHA store blist{t}
-        assert_equal {blist{t} {aguacate hello hola konichiwa zanzibar}} [$rd read]
-    }
-
-    foreach {pop} {BLPOP BRPOP BLMPOP} {
+    foreach {pop} {BLPOP BRPOP BLMPOP_LEFT BLMPOP_RIGHT} {
         test "$pop: with single empty list argument" {
             set rd [redis_deferring_client]
             r del blist1
@@ -966,29 +682,54 @@ start_server {
         }
     }
 
-    test {BLPOP inside a transaction} {
+foreach {pop} {BLPOP BLMPOP_LEFT} {
+    test {$pop inside a transaction} {
         r del xlist
         r lpush xlist foo
         r lpush xlist bar
         r multi
-        r blpop xlist 0
-        r blpop xlist 0
-        r blpop xlist 0
+
+        bpop_command r $pop xlist 0
+        bpop_command r $pop xlist 0
+        bpop_command r $pop xlist 0
         r exec
     } {{xlist bar} {xlist foo} {}}
+}
 
-    test {BLMPOP inside a transaction} {
-        create_list blist{t} "a b c d e"
-        create_list blist2{t} "1 2 3 4 5"
+    test {BLMPOP propagate as pop with count command to replica} {
+        set rd [redis_deferring_client]
+        set repl [attach_to_replication_stream]
 
-        r multi
-        r blmpop 1 blist{t} left count 1 0
-        r blmpop 2 blist{t} blist2{t} left count 10 0
-        r blmpop 2 blist{t} blist2{t} right count 10 0
+        # BLMPOP without block.
+        r lpush mylist{t} a b c
+        r rpush mylist2{t} 1 2 3
+        r blmpop 1 mylist{t} left count 1 0
+        r blmpop 2 mylist{t} mylist2{t} right count 10 0
+        r blmpop 2 mylist{t} mylist2{t} right count 10 0
 
-        set res [r exec]
-        assert_equal $res {{blist{t} a} {blist{t} {b c d e}} {blist2{t} {5 4 3 2 1}}}
-    }
+        # BLMPOP with block.
+        $rd blmpop 1 mylist{t} left count 1 0
+        r lpush mylist{t} a
+        $rd blmpop 2 mylist{t} mylist2{t} left count 5 0
+        r lpush mylist{t} a b c
+        $rd blmpop 2 mylist{t} mylist2{t} right count 10 0
+        r rpush mylist2{t} a b c
+
+        assert_replication_stream $repl {
+            {select *}
+            {lpush mylist{t} a b c}
+            {rpush mylist2{t} 1 2 3}
+            {lpop mylist{t} 1}
+            {rpop mylist{t} 2}
+            {rpop mylist2{t} 3}
+            {lpush mylist{t} a}
+            {lpop mylist{t} 1}
+            {lpush mylist{t} a b c}
+            {lpop mylist{t} 3}
+            {rpush mylist2{t} a b c}
+            {rpop mylist2{t} 3}
+        }
+    } {} {needs:repl}
 
     test {LPUSHX, RPUSHX - generic} {
         r del xlist
@@ -1242,31 +983,35 @@ start_server {
             assert_equal 1 [r lpop mylist]
             assert_equal 0 [r llen mylist]
 
-            # pop on empty list
-            assert_equal {} [r lpop mylist]
-            assert_equal {} [r rpop mylist]
-
             create_list mylist "$large 1 2"
             assert_equal "mylist $large" [r lmpop 1 mylist left count 1]
-            assert_equal {mylist {2 1}} [r lmpop 1 mylist right count 2]
-            assert_equal {} [r lmpop 1 mylist right count 2]
+            assert_equal {mylist {2 1}} [r lmpop 2 mylist mylist right count 2]
         }
     }
 
-    test {LPOP/RPOP against non list value} {
-        r set notalist foo
-        assert_error WRONGTYPE* {r lpop notalist}
-        assert_error WRONGTYPE* {r rpop notalist}
+    test {LPOP/RPOP/LMPOP against empty list} {
+        r del non-existing-list{t} non-existing-list2{t}
+
+        assert_equal {} [r lpop non-existing-list{t}]
+        assert_equal {} [r rpop non-existing-list2{t}]
+
+        assert_equal {} [r lmpop 1 non-existing-list{t} left count 1]
+        assert_equal {} [r lmpop 1 non-existing-list{t} left count 10]
+        assert_equal {} [r lmpop 2 non-existing-list{t} non-existing-list2{t} right count 1]
+        assert_equal {} [r lmpop 2 non-existing-list{t} non-existing-list2{t} right count 10]
     }
 
-    test {LMPOP against non list value} {
-        r del mylist2{t}
-        r set mylist{t} nolist
-        assert_error "WRONGTYPE*" {r lmpop 2 mylist{t} mylist2{t} left count 1}
+    test {LPOP/RPOP/LMPOP against non list value} {
+        r set notalist{t} foo
+        assert_error WRONGTYPE* {r lpop notalist{t}}
+        assert_error WRONGTYPE* {r rpop notalist{t}}
 
-        r del mylist{t}
-        r set mylist2{t} nolist
-        assert_error "WRONGTYPE*" {r lmpop 2 mylist{t} mylist2{t} right count 10}
+        r del notalist2{t}
+        assert_error "WRONGTYPE*" {r lmpop 2 notalist{t} notalist2{t} left count 1}
+
+        r del notalist{t}
+        r set notalist2{t} nolist
+        assert_error "WRONGTYPE*" {r lmpop 2 notalist{t} notalist2{t} right count 10}
     }
 
     foreach {type num} {quicklist 250 quicklist 500} {
@@ -1286,6 +1031,121 @@ start_server {
             assert_equal $sum1 $sum2
         }
     }
+
+    test {LMPOP with illegal argument} {
+        assert_error "ERR wrong number of arguments*" {r lmpop}
+        assert_error "ERR wrong number of arguments*" {r lmpop 1}
+        assert_error "ERR wrong number of arguments*" {r lmpop 1 mylist{t}}
+
+        assert_error "ERR numkeys*" {r lmpop 0 mylist{t} LEFT}
+        assert_error "ERR numkeys*" {r lmpop a mylist{t} LEFT}
+        assert_error "ERR numkeys*" {r lmpop -1 mylist{t} RIGHT}
+
+        assert_error "ERR syntax error*" {r lmpop 1 mylist{t} bad_where}
+        assert_error "ERR syntax error*" {r lmpop 1 mylist{t} LEFT bar_arg}
+        assert_error "ERR syntax error*" {r lmpop 1 mylist{t} RIGHT LEFT}
+        assert_error "ERR syntax error*" {r lmpop 1 mylist{t} COUNT}
+        assert_error "ERR syntax error*" {r lmpop 2 mylist{t} mylist2{t} bad_arg}
+
+        assert_error "ERR count*" {r lmpop 1 mylist{t} LEFT COUNT 0}
+        assert_error "ERR count*" {r lmpop 1 mylist{t} RIGHT COUNT a}
+        assert_error "ERR count*" {r lmpop 1 mylist{t} LEFT COUNT -1}
+        assert_error "ERR count*" {r lmpop 2 mylist{t} mylist2{t} RIGHT COUNT -1}
+    }
+
+    test {LMPOP single existing list} {
+        # Same key multiple times.
+        create_list mylist{t} "a b c d e f"
+        assert_equal {mylist{t} {a b}} [r lmpop 2 mylist{t} mylist{t} left count 2]
+        assert_equal {mylist{t} {f e}} [r lmpop 2 mylist{t} mylist{t} right count 2]
+        assert_equal 2 [r llen mylist{t}]
+
+        # First one exists, second one does not exist.
+        create_list mylist{t} "a b c d e"
+        r del mylist2{t}
+        assert_equal {mylist{t} a} [r lmpop 2 mylist{t} mylist2{t} left count 1]
+        assert_equal 4 [r llen mylist{t}]
+        assert_equal {mylist{t} {e d c b}} [r lmpop 2 mylist{t} mylist2{t} right count 10]
+        assert_equal {} [r lmpop 2 mylist{t} mylist2{t} right count 1]
+
+        # First one does not exist, second one exists.
+        r del mylist{t}
+        create_list mylist2{t} "1 2 3 4 5"
+        assert_equal {mylist2{t} 5} [r lmpop 2 mylist{t} mylist2{t} right count 1]
+        assert_equal 4 [r llen mylist2{t}]
+        assert_equal {mylist2{t} {1 2 3 4}} [r lmpop 2 mylist{t} mylist2{t} left count 10]
+
+        assert_equal 0 [r exists mylist{t} mylist2{t}]
+    }
+
+    test {LMPOP multiple existing lists} {
+        create_list mylist{t} "a b c d e"
+        create_list mylist2{t} "1 2 3 4 5"
+
+        # Pop up from the first key.
+        assert_equal {mylist{t} {a b}} [r lmpop 2 mylist{t} mylist2{t} left count 2]
+        assert_equal 3 [r llen mylist{t}]
+        assert_equal {mylist{t} {e d c}} [r lmpop 2 mylist{t} mylist2{t} right count 3]
+        assert_equal 0 [r exists mylist{t}]
+
+        # Pop up from the second key.
+        assert_equal {mylist2{t} {1 2 3}} [r lmpop 2 mylist{t} mylist2{t} left count 3]
+        assert_equal 2 [r llen mylist2{t}]
+        assert_equal {mylist2{t} {5 4}} [r lmpop 2 mylist{t} mylist2{t} right count 2]
+        assert_equal 0 [r exists mylist{t}]
+
+        # Pop up all elements.
+        create_list mylist{t} "a b c"
+        create_list mylist2{t} "1 2 3"
+        assert_equal {mylist{t} {a b c}} [r lmpop 2 mylist{t} mylist2{t} left count 10]
+        assert_equal 0 [r llen mylist{t}]
+        assert_equal {mylist2{t} {3 2 1}} [r lmpop 2 mylist{t} mylist2{t} right count 10]
+        assert_equal 0 [r llen mylist2{t}]
+        assert_equal 0 [r exists mylist{t} mylist2{t}]
+    }
+
+    test {LMPOP propagate as pop with count command to replica} {
+        set repl [attach_to_replication_stream]
+
+        # left/right propagate as lpop/rpop with count
+        r lpush mylist{t} a b c
+
+        # Pop elements from one list.
+        r lmpop 1 mylist{t} left count 1
+        r lmpop 1 mylist{t} right count 1
+
+        # Now the list have only one element
+        r lmpop 2 mylist{t} mylist2{t} left count 10
+
+        # No elements so we don't propagate.
+        r lmpop 2 mylist{t} mylist2{t} left count 10
+
+        # Pop elements from the second list.
+        r rpush mylist2{t} 1 2 3
+        r lmpop 2 mylist{t} mylist2{t} left count 2
+        r lmpop 2 mylist{t} mylist2{t} right count 1
+
+        # Pop all elements.
+        r rpush mylist{t} a b c
+        r rpush mylist2{t} 1 2 3
+        r lmpop 2 mylist{t} mylist2{t} left count 10
+        r lmpop 2 mylist{t} mylist2{t} right count 10
+
+        assert_replication_stream $repl {
+            {select *}
+            {lpush mylist{t} a b c}
+            {lpop mylist{t} 1}
+            {rpop mylist{t} 1}
+            {lpop mylist{t} 1}
+            {rpush mylist2{t} 1 2 3}
+            {lpop mylist2{t} 2}
+            {rpop mylist2{t} 1}
+            {rpush mylist{t} a b c}
+            {rpush mylist2{t} 1 2 3}
+            {lpop mylist{t} 3}
+            {rpop mylist2{t} 3}
+        }
+    } {} {needs:repl}
 
     foreach {type large} [array get largevalue] {
         test "LRANGE basics - $type" {
@@ -1424,48 +1284,48 @@ start_server {
         r ping
     } {PONG}
 
-    foreach {pop} {BLPOP BRPOP BLMPOP} {
-        test "client unblock tests" {
-            r del l
-            set rd [redis_deferring_client]
-            $rd client id
-            set id [$rd read]
+foreach {pop} {BLPOP BLMPOP_RIGHT} {
+    test "client unblock tests" {
+        r del l
+        set rd [redis_deferring_client]
+        $rd client id
+        set id [$rd read]
 
-            # test default args
-            bpop_command $rd $pop l 0
-            wait_for_blocked_client
-            r client unblock $id
-            assert_equal {} [$rd read]
+        # test default args
+        bpop_command $rd $pop l 0
+        wait_for_blocked_client
+        r client unblock $id
+        assert_equal {} [$rd read]
 
-            # test with timeout
-            bpop_command $rd $pop l 0
-            wait_for_blocked_client
-            r client unblock $id TIMEOUT
-            assert_equal {} [$rd read]
+        # test with timeout
+        bpop_command $rd $pop l 0
+        wait_for_blocked_client
+        r client unblock $id TIMEOUT
+        assert_equal {} [$rd read]
 
-            # test with error
-            bpop_command $rd $pop l 0
-            wait_for_blocked_client
-            r client unblock $id ERROR
-            catch {[$rd read]} e
-            assert_equal $e "UNBLOCKED client unblocked via CLIENT UNBLOCK"
+        # test with error
+        bpop_command $rd $pop l 0
+        wait_for_blocked_client
+        r client unblock $id ERROR
+        catch {[$rd read]} e
+        assert_equal $e "UNBLOCKED client unblocked via CLIENT UNBLOCK"
 
-            # test with invalid client id
-            catch {[r client unblock asd]} e
-            assert_equal $e "ERR value is not an integer or out of range"
+        # test with invalid client id
+        catch {[r client unblock asd]} e
+        assert_equal $e "ERR value is not an integer or out of range"
 
-            # test with non blocked client
-            set myid [r client id]
-            catch {[r client unblock $myid]} e
-            assert_equal $e {invalid command name "0"}
+        # test with non blocked client
+        set myid [r client id]
+        catch {[r client unblock $myid]} e
+        assert_equal $e {invalid command name "0"}
 
-            # finally, see the this client and list are still functional
-            bpop_command $rd $pop l 0
-            wait_for_blocked_client
-            r lpush l foo
-            assert_equal {l foo} [$rd read]
-        } {}
-    }
+        # finally, see the this client and list are still functional
+        bpop_command $rd $pop l 0
+        wait_for_blocked_client
+        r lpush l foo
+        assert_equal {l foo} [$rd read]
+    } {}
+}
 
     test {List ziplist of various encodings} {
         r del k


### PR DESCRIPTION
We want to add COUNT option for BLPOP.
But we can't do it without breaking compatibility due to the command arguments syntax.
So this commit introduce two new commands.

Syntax for the new LMPOP command:
`LMPOP numkeys [<key> ...] LEFT|RIGHT [COUNT count]`

Syntax for the new BLMPOP command:
`BLMPOP timeout numkeys [<key> ...] LEFT|RIGHT [COUNT count]`

Some background:
- LPOP takes one key, and can return multiple elements.
- BLPOP takes multiple keys, but returns one element from just one key.
- LMPOP can take multiple keys and return multiple elements from just one key.

Note that LMPOP/BLMPOP  can take multiple keys, it eventually operates on just one key.
And it will propagate as LPOP or RPOP with the COUNT option.

As a new command, it still return NIL if we can't pop any elements.
For the normal response is nested arrays in RESP2 and RESP3, like:
```
LMPOP/BLMPOP 
1) keyname
2) 1) element1
   2) element2
```
I.e. unlike BLPOP that returns a key name and one element so it uses a flat array,
and LPOP that returns multiple elements with no key name, and again uses a flat array,
this one has to return a nested array, and it does for for both RESP2 and RESP3 (like SCAN does)

Some discuss can see: #766 #8824