### PR TITLE
cluster gossip fix: discard messages from previous myself before role switch checking

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2037,8 +2037,10 @@ int clusterProcessPacket(clusterLink *link) {
             }
         }
 
-        /* Check for role switch: slave -> master or master -> slave. */
-        if (sender) {
+        /* Check for role switch: slave -> master or master -> slave. 
+         * Discard the message in case it was sent from previous myself.
+         */
+        if (sender && sender != myself) {
             if (!memcmp(hdr->slaveof,CLUSTER_NODE_NULL_NAME,
                 sizeof(hdr->slaveof)))
             {


### PR DESCRIPTION
# Issue
There is a scenario when redis cluster was running in containers with overlay network, the IP would be changed after restarting the container, and even the IP would switch between containers when multiple containers were restarted.
In this case, if the several masters from a cluster restarted and their IP addresses were mixed up. The master was supposed to switch into a replica after failover, but there is a possibility that it would become a master without slots.
For an illustration:
1. There were 2 master nodes A and B that got down, A previous IP was 1.1.1.1 and B's 2.2.2.2
2. After A's replica failover, and then restart A to live. At this moment, its IP turned to 2.2.2.2, which was previously belonged to B.
3. After restarting, A was supposed to be a replica, and it happens that it weirdly became a master without slots.

# Cause
After node A restarting, before it detected the configuration changed, it would by chance send itself a PING by misleading the address. And if the PING received after its role switched, it would wrongly change the role info of itself eventually. 
![image](https://user-images.githubusercontent.com/180805/129529864-2a746c2d-6e7d-4744-a29f-aa1614dcba16.png)
1. Before the timeline T1 point, node A sent a PING to itself since it regarded it as B.
2. At the T1, node A detected the configuration changed and switch into a replica.
3. At the T2, node A received the PING package and it would change the sender's(actually itself) role due to the empty in the  `slaveof` item.

# Fix
In the ping/pong/meet handling flow, just discard the message if the sender is `myself` before `Check for role switch`. 
