### PR TITLE
Fix: don't assume char is unsigned.

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -61,7 +61,7 @@ static unsigned int dict_force_resize_ratio = 5;
 /* -------------------------- private prototypes ---------------------------- */
 
 static int _dictExpandIfNeeded(dict *d);
-static char _dictNextExp(unsigned long size);
+static signed char _dictNextExp(unsigned long size);
 static long _dictKeyIndex(dict *d, const void *key, uint64_t hash, dictEntry **existing);
 static int _dictInit(dict *d, dictType *type);
 
@@ -150,7 +150,7 @@ int _dictExpand(dict *d, unsigned long size, int* malloc_failed)
     /* the new hash table */
     dictEntry **new_ht_table;
     unsigned long new_ht_used;
-    char new_ht_size_exp = _dictNextExp(size);
+    signed char new_ht_size_exp = _dictNextExp(size);
 
     /* Detect overflows */
     size_t newsize = 1ul<<new_ht_size_exp;
@@ -1009,7 +1009,7 @@ static int _dictExpandIfNeeded(dict *d)
 
 /* TODO: clz optimization */
 /* Our hash table capability is a power of two */
-static char _dictNextExp(unsigned long size)
+static signed char _dictNextExp(unsigned long size)
 {
     unsigned char e = DICT_HT_INITIAL_EXP;
 

--- a/src/dict.h
+++ b/src/dict.h
@@ -80,7 +80,7 @@ struct dict {
 
     /* Keep small vars at end for optimal (minimal) struct padding */
     int16_t pauserehash; /* If >0 rehashing is paused (<0 indicates coding error) */
-    char ht_size_exp[2]; /* exponent of size. (size = 1<<exp) */
+    signed char ht_size_exp[2]; /* exponent of size. (size = 1<<exp) */
 };
 
 /* If safe is set to 1 this is a safe iterator, that means, you can call


### PR DESCRIPTION
On systems that have unsigned char by default (s390x, arm), redis-server
could crash as soon as it populates the command table.

Ideally, we should also have a nightly test for this config (using `-funsigned-char`) however:
* The current daily workflow is pretty complex as it is, a bit hard to justify another bulk of copy&paste only for that. Have some ideas on how to clean it up regardless.
* We should consider a way to run daily on an ARM system, which would also provide coverage for this.