### PR TITLE
Add INFO total_active_defrag_time and current_active_defrag_time

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1143,10 +1143,8 @@ void activeDefragCycle(void) {
                 server.active_defrag_running = 0;
 
                 computeDefragCycles(); /* if another scan is needed, start it right away */
-                if (server.active_defrag_running != 0) {
-                    if (ustime() < endtime) continue;
-                    else quit = 1;
-                }
+                if (server.active_defrag_running != 0 && ustime() < endtime)
+                    continue;
                 break;
             }
             else if (current_db==0) {
@@ -1191,12 +1189,12 @@ void activeDefragCycle(void) {
     latencyAddSampleIfNeeded("active-defrag-cycle",latency);
 
 update_metrics:
-    if (quit == 1) {
-        if (server.stat_last_active_defrag_exceeded_time == 0)
-            elapsedStart(&server.stat_last_active_defrag_exceeded_time);
-    } else if (server.stat_last_active_defrag_exceeded_time != 0) {
-        server.stat_total_active_defrag_exceeded_time += elapsedUs(server.stat_last_active_defrag_exceeded_time);
-        server.stat_last_active_defrag_exceeded_time = 0;
+    if (server.active_defrag_running > 0) {
+        if (server.stat_last_defrag_exceeded_time == 0)
+            elapsedStart(&server.stat_last_defrag_exceeded_time);
+    } else if (server.stat_last_defrag_exceeded_time != 0) {
+        server.stat_total_defrag_exceeded_time += elapsedUs(server.stat_last_defrag_exceeded_time);
+        server.stat_last_defrag_exceeded_time = 0;
     }
 }
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1190,11 +1190,11 @@ void activeDefragCycle(void) {
 
 update_metrics:
     if (server.active_defrag_running > 0) {
-        if (server.stat_last_defrag_exceeded_time == 0)
-            elapsedStart(&server.stat_last_defrag_exceeded_time);
-    } else if (server.stat_last_defrag_exceeded_time != 0) {
-        server.stat_total_defrag_exceeded_time += elapsedUs(server.stat_last_defrag_exceeded_time);
-        server.stat_last_defrag_exceeded_time = 0;
+        if (server.stat_last_active_defrag_time == 0)
+            elapsedStart(&server.stat_last_active_defrag_time);
+    } else if (server.stat_last_active_defrag_time != 0) {
+        server.stat_total_active_defrag_time += elapsedUs(server.stat_last_active_defrag_time);
+        server.stat_last_active_defrag_time = 0;
     }
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -3113,6 +3113,8 @@ void resetServerStats(void) {
     server.stat_active_defrag_key_hits = 0;
     server.stat_active_defrag_key_misses = 0;
     server.stat_active_defrag_scanned = 0;
+    server.stat_total_active_defrag_exceeded_time = 0;
+    server.stat_last_active_defrag_exceeded_time = 0;
     server.stat_fork_time = 0;
     server.stat_fork_rate = 0;
     server.stat_total_forks = 0;
@@ -5004,6 +5006,8 @@ sds genRedisInfoString(const char *section) {
         long long stat_net_input_bytes, stat_net_output_bytes;
         long long current_eviction_exceeded_time = server.stat_last_eviction_exceeded_time ?
             (long long) elapsedUs(server.stat_last_eviction_exceeded_time): 0;
+        long long current_active_defrag_exceeded_time = server.stat_last_active_defrag_exceeded_time ?
+            (long long) elapsedUs(server.stat_last_active_defrag_exceeded_time): 0;
         atomicGet(server.stat_total_reads_processed, stat_total_reads_processed);
         atomicGet(server.stat_total_writes_processed, stat_total_writes_processed);
         atomicGet(server.stat_net_input_bytes, stat_net_input_bytes);
@@ -5042,6 +5046,8 @@ sds genRedisInfoString(const char *section) {
             "active_defrag_misses:%lld\r\n"
             "active_defrag_key_hits:%lld\r\n"
             "active_defrag_key_misses:%lld\r\n"
+            "total_active_defrag_exceeded_time:%lld\r\n"
+            "current_active_defrag_exceeded_time:%lld\r\n"
             "tracking_total_keys:%lld\r\n"
             "tracking_total_items:%lld\r\n"
             "tracking_total_prefixes:%lld\r\n"
@@ -5082,6 +5088,8 @@ sds genRedisInfoString(const char *section) {
             server.stat_active_defrag_misses,
             server.stat_active_defrag_key_hits,
             server.stat_active_defrag_key_misses,
+            (server.stat_total_active_defrag_exceeded_time + current_active_defrag_exceeded_time) / 1000,
+            current_active_defrag_exceeded_time / 1000,
             (unsigned long long) trackingGetTotalKeys(),
             (unsigned long long) trackingGetTotalItems(),
             (unsigned long long) trackingGetTotalPrefixes(),

--- a/src/server.c
+++ b/src/server.c
@@ -3113,8 +3113,8 @@ void resetServerStats(void) {
     server.stat_active_defrag_key_hits = 0;
     server.stat_active_defrag_key_misses = 0;
     server.stat_active_defrag_scanned = 0;
-    server.stat_total_active_defrag_exceeded_time = 0;
-    server.stat_last_active_defrag_exceeded_time = 0;
+    server.stat_total_defrag_exceeded_time = 0;
+    server.stat_last_defrag_exceeded_time = 0;
     server.stat_fork_time = 0;
     server.stat_fork_rate = 0;
     server.stat_total_forks = 0;
@@ -5006,8 +5006,8 @@ sds genRedisInfoString(const char *section) {
         long long stat_net_input_bytes, stat_net_output_bytes;
         long long current_eviction_exceeded_time = server.stat_last_eviction_exceeded_time ?
             (long long) elapsedUs(server.stat_last_eviction_exceeded_time): 0;
-        long long current_active_defrag_exceeded_time = server.stat_last_active_defrag_exceeded_time ?
-            (long long) elapsedUs(server.stat_last_active_defrag_exceeded_time): 0;
+        long long current_defrag_exceeded_time = server.stat_last_defrag_exceeded_time ?
+            (long long) elapsedUs(server.stat_last_defrag_exceeded_time): 0;
         atomicGet(server.stat_total_reads_processed, stat_total_reads_processed);
         atomicGet(server.stat_total_writes_processed, stat_total_writes_processed);
         atomicGet(server.stat_net_input_bytes, stat_net_input_bytes);
@@ -5046,8 +5046,8 @@ sds genRedisInfoString(const char *section) {
             "active_defrag_misses:%lld\r\n"
             "active_defrag_key_hits:%lld\r\n"
             "active_defrag_key_misses:%lld\r\n"
-            "total_active_defrag_exceeded_time:%lld\r\n"
-            "current_active_defrag_exceeded_time:%lld\r\n"
+            "total_defrag_exceeded_time:%lld\r\n"
+            "current_defrag_exceeded_time:%lld\r\n"
             "tracking_total_keys:%lld\r\n"
             "tracking_total_items:%lld\r\n"
             "tracking_total_prefixes:%lld\r\n"
@@ -5088,8 +5088,8 @@ sds genRedisInfoString(const char *section) {
             server.stat_active_defrag_misses,
             server.stat_active_defrag_key_hits,
             server.stat_active_defrag_key_misses,
-            (server.stat_total_active_defrag_exceeded_time + current_active_defrag_exceeded_time) / 1000,
-            current_active_defrag_exceeded_time / 1000,
+            (server.stat_total_defrag_exceeded_time + current_defrag_exceeded_time) / 1000,
+            current_defrag_exceeded_time / 1000,
             (unsigned long long) trackingGetTotalKeys(),
             (unsigned long long) trackingGetTotalItems(),
             (unsigned long long) trackingGetTotalPrefixes(),

--- a/src/server.c
+++ b/src/server.c
@@ -3113,8 +3113,8 @@ void resetServerStats(void) {
     server.stat_active_defrag_key_hits = 0;
     server.stat_active_defrag_key_misses = 0;
     server.stat_active_defrag_scanned = 0;
-    server.stat_total_defrag_exceeded_time = 0;
-    server.stat_last_defrag_exceeded_time = 0;
+    server.stat_total_active_defrag_time = 0;
+    server.stat_last_active_defrag_time = 0;
     server.stat_fork_time = 0;
     server.stat_fork_rate = 0;
     server.stat_total_forks = 0;
@@ -5006,8 +5006,8 @@ sds genRedisInfoString(const char *section) {
         long long stat_net_input_bytes, stat_net_output_bytes;
         long long current_eviction_exceeded_time = server.stat_last_eviction_exceeded_time ?
             (long long) elapsedUs(server.stat_last_eviction_exceeded_time): 0;
-        long long current_defrag_exceeded_time = server.stat_last_defrag_exceeded_time ?
-            (long long) elapsedUs(server.stat_last_defrag_exceeded_time): 0;
+        long long current_active_defrag_time = server.stat_last_active_defrag_time ?
+            (long long) elapsedUs(server.stat_last_active_defrag_time): 0;
         atomicGet(server.stat_total_reads_processed, stat_total_reads_processed);
         atomicGet(server.stat_total_writes_processed, stat_total_writes_processed);
         atomicGet(server.stat_net_input_bytes, stat_net_input_bytes);
@@ -5046,8 +5046,8 @@ sds genRedisInfoString(const char *section) {
             "active_defrag_misses:%lld\r\n"
             "active_defrag_key_hits:%lld\r\n"
             "active_defrag_key_misses:%lld\r\n"
-            "total_defrag_exceeded_time:%lld\r\n"
-            "current_defrag_exceeded_time:%lld\r\n"
+            "total_active_defrag_time:%lld\r\n"
+            "current_active_defrag_time:%lld\r\n"
             "tracking_total_keys:%lld\r\n"
             "tracking_total_items:%lld\r\n"
             "tracking_total_prefixes:%lld\r\n"
@@ -5088,8 +5088,8 @@ sds genRedisInfoString(const char *section) {
             server.stat_active_defrag_misses,
             server.stat_active_defrag_key_hits,
             server.stat_active_defrag_key_misses,
-            (server.stat_total_defrag_exceeded_time + current_defrag_exceeded_time) / 1000,
-            current_defrag_exceeded_time / 1000,
+            (server.stat_total_active_defrag_time + current_active_defrag_time) / 1000,
+            current_active_defrag_time / 1000,
             (unsigned long long) trackingGetTotalKeys(),
             (unsigned long long) trackingGetTotalItems(),
             (unsigned long long) trackingGetTotalPrefixes(),

--- a/src/server.h
+++ b/src/server.h
@@ -1324,6 +1324,8 @@ struct redisServer {
     long long stat_active_defrag_key_hits;  /* number of keys with moved allocations */
     long long stat_active_defrag_key_misses;/* number of keys scanned and not moved */
     long long stat_active_defrag_scanned;   /* number of dictEntries scanned */
+    long long stat_total_active_defrag_exceeded_time; /* Total time memory fragmentation over the limit, unit us */
+    monotime stat_last_active_defrag_exceeded_time; /* Timestamp of current active defrag start */
     size_t stat_peak_memory;        /* Max used memory record */
     long long stat_fork_time;       /* Time needed to perform latest fork() */
     double stat_fork_rate;          /* Fork rate in GB/sec. */

--- a/src/server.h
+++ b/src/server.h
@@ -1324,8 +1324,8 @@ struct redisServer {
     long long stat_active_defrag_key_hits;  /* number of keys with moved allocations */
     long long stat_active_defrag_key_misses;/* number of keys scanned and not moved */
     long long stat_active_defrag_scanned;   /* number of dictEntries scanned */
-    long long stat_total_defrag_exceeded_time; /* Total time memory fragmentation over the limit, unit us */
-    monotime stat_last_defrag_exceeded_time; /* Timestamp of current active defrag start */
+    long long stat_total_active_defrag_time; /* Total time memory fragmentation over the limit, unit us */
+    monotime stat_last_active_defrag_time; /* Timestamp of current active defrag start */
     size_t stat_peak_memory;        /* Max used memory record */
     long long stat_fork_time;       /* Time needed to perform latest fork() */
     double stat_fork_rate;          /* Fork rate in GB/sec. */

--- a/src/server.h
+++ b/src/server.h
@@ -1324,8 +1324,8 @@ struct redisServer {
     long long stat_active_defrag_key_hits;  /* number of keys with moved allocations */
     long long stat_active_defrag_key_misses;/* number of keys scanned and not moved */
     long long stat_active_defrag_scanned;   /* number of dictEntries scanned */
-    long long stat_total_active_defrag_exceeded_time; /* Total time memory fragmentation over the limit, unit us */
-    monotime stat_last_active_defrag_exceeded_time; /* Timestamp of current active defrag start */
+    long long stat_total_defrag_exceeded_time; /* Total time memory fragmentation over the limit, unit us */
+    monotime stat_last_defrag_exceeded_time; /* Timestamp of current active defrag start */
     size_t stat_peak_memory;        /* Max used memory record */
     long long stat_fork_time;       /* Time needed to perform latest fork() */
     double stat_fork_rate;          /* Fork rate in GB/sec. */


### PR DESCRIPTION
Add two INFO metrics:
```
total_active_defrag_time:12345
current_active_defrag_time:456
```
`current_active_defrag_time` if greater than 0, means how much time has
passed since active defrag started running. If active defrag stops, this metric is reset to 0.
`total_active_defrag_time` means total time the fragmentation
was over the defrag threshold since the server started.

This is a followup PR for #9031