### PR TITLE
Also remove CLUSTER_NODE_NOFAILOVER flag when a slave turns into a ma…

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1642,6 +1642,7 @@ void clusterSetNodeAsMaster(clusterNode *n) {
         if (n != myself) n->flags |= CLUSTER_NODE_MIGRATE_TO;
     }
     n->flags &= ~CLUSTER_NODE_SLAVE;
+    n->flags &= ~CLUSTER_NODE_NOFAILOVER;
     n->flags |= CLUSTER_NODE_MASTER;
     n->slaveof = NULL;
 


### PR DESCRIPTION
…ster.

For example, the `RESET` command calls `clusterSetNodeAsMaster` function, so when we reset a node the flag will not be deleted. Then this node which may act as a fresh slave to rejoin the cluster will not try to failover its master by default.