### PR TITLE
Add const to char/void pointers

### DIFF
--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -119,7 +119,7 @@
 
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
 #define LINENOISE_MAX_LINE 4096
-static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
+static const char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
 static linenoiseCompletionCallback *completionCallback = NULL;
 static linenoiseHintsCallback *hintsCallback = NULL;
 static linenoiseFreeHintsCallback *freeHintsCallback = NULL;

--- a/src/acl.c
+++ b/src/acl.c
@@ -161,7 +161,7 @@ sds ACLHashPassword(unsigned char *cleartext, size_t len) {
     SHA256_CTX ctx;
     unsigned char hash[SHA256_BLOCK_SIZE];
     char hex[HASH_PASSWORD_LEN];
-    char *cset = "0123456789abcdef";
+    const char *cset = "0123456789abcdef";
 
     sha256_init(&ctx);
     sha256_update(&ctx,(unsigned char*)cleartext,len);
@@ -2160,7 +2160,7 @@ void aclCommand(client *c) {
             addReplyLongLong(c,le->count);
 
             addReplyBulkCString(c,"reason");
-            char *reasonstr;
+            const char *reasonstr;
             switch(le->reason) {
             case ACL_DENIED_CMD: reasonstr="command"; break;
             case ACL_DENIED_KEY: reasonstr="key"; break;
@@ -2171,7 +2171,7 @@ void aclCommand(client *c) {
             addReplyBulkCString(c,reasonstr);
 
             addReplyBulkCString(c,"context");
-            char *ctxstr;
+            const char *ctxstr;
             switch(le->context) {
             case ACL_LOG_CTX_TOPLEVEL: ctxstr="toplevel"; break;
             case ACL_LOG_CTX_MULTI: ctxstr="multi"; break;

--- a/src/ae_epoll.c
+++ b/src/ae_epoll.c
@@ -134,6 +134,6 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
     return numevents;
 }
 
-static char *aeApiName(void) {
+static const char *aeApiName(void) {
     return "epoll";
 }

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -412,7 +412,7 @@ void printBits(unsigned char *p, unsigned long count) {
  * is multiplied by 'bits'. This is useful for the BITFIELD command. */
 int getBitOffsetFromArgument(client *c, robj *o, uint64_t *offset, int hash, int bits) {
     long long loffset;
-    char *err = "bit offset is not an integer or out of range";
+    const char *err = "bit offset is not an integer or out of range";
     char *p = o->ptr;
     size_t plen = sdslen(p);
     int usehash = 0;
@@ -448,7 +448,7 @@ int getBitOffsetFromArgument(client *c, robj *o, uint64_t *offset, int hash, int
  * On error C_ERR is returned and an error is sent to the client. */
 int getBitfieldTypeFromArgument(client *c, robj *o, int *sign, int *bits) {
     char *p = o->ptr;
-    char *err = "Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is.";
+    const char *err = "Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is.";
     long long llbits;
 
     if (p[0] == 'i') {
@@ -526,7 +526,7 @@ unsigned char *getObjectReadOnlyString(robj *o, long *len, char *llbuf) {
 /* SETBIT key offset bitvalue */
 void setbitCommand(client *c) {
     robj *o;
-    char *err = "bit is not an integer or out of range";
+    const char *err = "bit is not an integer or out of range";
     uint64_t bitoffset;
     ssize_t byte, bit;
     int byteval, bitval;

--- a/src/childinfo.c
+++ b/src/childinfo.c
@@ -67,7 +67,7 @@ void closeChildInfoPipe(void) {
 }
 
 /* Send save data to parent. */
-void sendChildInfoGeneric(childInfoType info_type, size_t keys, double progress, char *pname) {
+void sendChildInfoGeneric(childInfoType info_type, size_t keys, double progress, const char *pname) {
     if (server.child_info_pipe[1] == -1) return;
 
     static monotime cow_updated = 0;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3076,7 +3076,7 @@ int clusterGetSlaveRank(void) {
  *
  * The function is guaranteed to be called only if 'myself' is a slave. */
 void clusterLogCantFailover(int reason) {
-    char *msg;
+    const char *msg;
     static time_t lastlog_time = 0;
     mstime_t nolog_fail_time = server.cluster_node_timeout + 5000;
 
@@ -4184,7 +4184,7 @@ void clusterSetMaster(clusterNode *n) {
 
 struct redisNodeFlags {
     uint16_t flag;
-    char *name;
+    const char *name;
 };
 
 static struct redisNodeFlags redisNodeFlagsTable[] = {
@@ -4745,7 +4745,7 @@ NULL
         addReplySds(c,reply);
     } else if (!strcasecmp(c->argv[1]->ptr,"info") && c->argc == 2) {
         /* CLUSTER INFO */
-        char *statestr[] = {"ok","fail","needhelp"};
+        const char *statestr[] = {"ok","fail","needhelp"};
         int slots_assigned = 0, slots_ok = 0, slots_pfail = 0, slots_fail = 0;
         uint64_t myepoch;
         int j;

--- a/src/config.c
+++ b/src/config.c
@@ -1048,7 +1048,7 @@ void configGetCommand(client *c) {
     if (stringmatch(pattern,"slaveof",1) ||
         stringmatch(pattern,"replicaof",1))
     {
-        char *optname = stringmatch(pattern,"slaveof",1) ?
+        const char *optname = stringmatch(pattern,"slaveof",1) ?
                         "slaveof" : "replicaof";
         char buf[256];
 
@@ -1411,7 +1411,7 @@ void rewriteConfigNumericalOption(struct rewriteConfigState *state, const char *
 }
 
 /* Rewrite an octal option. */
-void rewriteConfigOctalOption(struct rewriteConfigState *state, char *option, int value, int defvalue) {
+void rewriteConfigOctalOption(struct rewriteConfigState *state, const char *option, int value, int defvalue) {
     int force = value != defvalue;
     sds line = sdscatprintf(sdsempty(),"%s %o",option,value);
 
@@ -1502,7 +1502,7 @@ void rewriteConfigDirOption(struct rewriteConfigState *state) {
 }
 
 /* Rewrite the slaveof option. */
-void rewriteConfigSlaveofOption(struct rewriteConfigState *state, char *option) {
+void rewriteConfigSlaveofOption(struct rewriteConfigState *state, const char *option) {
     sds line;
 
     /* If this is a master, we want all the slaveof config options
@@ -1520,7 +1520,7 @@ void rewriteConfigSlaveofOption(struct rewriteConfigState *state, char *option) 
 /* Rewrite the notify-keyspace-events option. */
 void rewriteConfigNotifykeyspaceeventsOption(struct rewriteConfigState *state) {
     int force = server.notify_keyspace_events != 0;
-    char *option = "notify-keyspace-events";
+    const char *option = "notify-keyspace-events";
     sds line, flags;
 
     flags = keyspaceEventsFlagsToString(server.notify_keyspace_events);
@@ -1534,7 +1534,7 @@ void rewriteConfigNotifykeyspaceeventsOption(struct rewriteConfigState *state) {
 /* Rewrite the client-output-buffer-limit option. */
 void rewriteConfigClientoutputbufferlimitOption(struct rewriteConfigState *state) {
     int j;
-    char *option = "client-output-buffer-limit";
+    const char *option = "client-output-buffer-limit";
 
     for (j = 0; j < CLIENT_TYPE_OBUF_COUNT; j++) {
         int force = (server.client_obuf_limits[j].hard_limit_bytes !=
@@ -1551,7 +1551,7 @@ void rewriteConfigClientoutputbufferlimitOption(struct rewriteConfigState *state
         rewriteConfigFormatMemory(soft,sizeof(soft),
                 server.client_obuf_limits[j].soft_limit_bytes);
 
-        char *typename = getClientTypeName(j);
+        const char *typename = getClientTypeName(j);
         if (!strcmp(typename,"slave")) typename = "replica";
         line = sdscatprintf(sdsempty(),"%s %s %s %s %ld",
                 option, typename, hard, soft,
@@ -1564,7 +1564,7 @@ void rewriteConfigClientoutputbufferlimitOption(struct rewriteConfigState *state
 void rewriteConfigOOMScoreAdjValuesOption(struct rewriteConfigState *state) {
     int force = 0;
     int j;
-    char *option = "oom-score-adj-values";
+    const char *option = "oom-score-adj-values";
     sds line;
 
     line = sdsnew(option);
@@ -1584,7 +1584,7 @@ void rewriteConfigOOMScoreAdjValuesOption(struct rewriteConfigState *state) {
 void rewriteConfigBindOption(struct rewriteConfigState *state) {
     int force = 1;
     sds line, addresses;
-    char *option = "bind";
+    const char *option = "bind";
     int is_default = 0;
 
     /* Compare server.bindaddr with CONFIG_DEFAULT_BINDADDR */

--- a/src/db.c
+++ b/src/db.c
@@ -982,7 +982,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long cursor) {
         /* Filter an element if it isn't the type we want. */
         if (!filter && o == NULL && typename){
             robj* typecheck = lookupKeyReadWithFlags(c->db, kobj, LOOKUP_NOTOUCH);
-            char* type = getObjectTypeName(typecheck);
+            const char* type = getObjectTypeName(typecheck);
             if (strcasecmp((char*) typename, type)) filter = 1;
         }
 
@@ -1043,8 +1043,8 @@ void lastsaveCommand(client *c) {
     addReplyLongLong(c,server.lastsave);
 }
 
-char* getObjectTypeName(robj *o) {
-    char* type;
+const char* getObjectTypeName(robj *o) {
+    const char* type;
     if (o == NULL) {
         type = "none";
     } else {
@@ -1737,7 +1737,7 @@ int sortGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *
      * next. However there are options with 1 or 2 arguments, so we
      * provide a list here in order to skip the right number of args. */
     struct {
-        char *name;
+        const char *name;
         int skip;
     } skiplist[] = {
         {"limit", 2},

--- a/src/debug.c
+++ b/src/debug.c
@@ -76,9 +76,10 @@ void logStackTrace(void *eip, int uplevel);
  * "add" digests relative to unordered elements.
  *
  * So digest(a,b,c,d) will be the same of digest(b,a,c,d) */
-void xorDigest(unsigned char *digest, void *ptr, size_t len) {
+void xorDigest(unsigned char *digest, const void *ptr, size_t len) {
     SHA1_CTX ctx;
-    unsigned char hash[20], *s = ptr;
+    unsigned char hash[20];
+    const unsigned char *s = ptr;
     int j;
 
     SHA1Init(&ctx);
@@ -562,7 +563,7 @@ NULL
     } else if (!strcasecmp(c->argv[1]->ptr,"object") && c->argc == 3) {
         dictEntry *de;
         robj *val;
-        char *strenc;
+        const char *strenc;
 
         if ((de = dictFind(c->db->dict,c->argv[2]->ptr)) == NULL) {
             addReplyErrorObject(c,shared.nokeyerr);
@@ -1554,7 +1555,7 @@ void closeDirectLogFiledes(int fd) {
 void logStackTrace(void *eip, int uplevel) {
     void *trace[100];
     int trace_size = 0, fd = openDirectLogFiledes();
-    char *msg;
+    const char *msg;
     uplevel++; /* skip this function */
 
     if (fd == -1) return; /* If we can't log there is anything to do. */
@@ -1899,7 +1900,7 @@ void bugReportEnd(int killViaSignal, int sig) {
 
 /* ==================== Logging functions for debugging ===================== */
 
-void serverLogHexDump(int level, char *descr, void *value, size_t len) {
+void serverLogHexDump(int level, const char *descr, void *value, size_t len) {
     char buf[65], *b;
     unsigned char *v = value;
     char charset[] = "0123456789abcdef";

--- a/src/geo.c
+++ b/src/geo.c
@@ -868,7 +868,7 @@ void geosearchstoreCommand(client *c) {
  * Returns an array with an 11 characters geohash representation of the
  * position of the specified elements. */
 void geohashCommand(client *c) {
-    char *geoalphabet= "0123456789bcdefghjkmnpqrstuvwxyz";
+    const char *geoalphabet= "0123456789bcdefghjkmnpqrstuvwxyz";
     int j;
 
     /* Look up the requested zset */

--- a/src/help.h
+++ b/src/help.h
@@ -3,7 +3,7 @@
 #ifndef __REDIS_HELP_H
 #define __REDIS_HELP_H
 
-static char *commandGroups[] = {
+static const char *commandGroups[] = {
     "generic",
     "string",
     "list",
@@ -22,11 +22,11 @@ static char *commandGroups[] = {
 };
 
 struct commandHelp {
-  char *name;
-  char *params;
-  char *summary;
+  const char *name;
+  const char *params;
+  const char *summary;
   int group;
-  char *since;
+  const char *since;
 } commandHelp[] = {
     { "ACL CAT",
     "[categoryname]",

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -205,7 +205,7 @@ struct hllhdr {
 #define HLL_RAW 255 /* Only used internally, never exposed. */
 #define HLL_MAX_ENCODING 1
 
-static char *invalid_hll_err = "-INVALIDOBJ Corrupted HLL object detected";
+static const char *invalid_hll_err = "-INVALIDOBJ Corrupted HLL object detected";
 
 /* =========================== Low level bit macros ========================= */
 
@@ -1564,7 +1564,7 @@ void pfdebugCommand(client *c) {
     }
     /* PFDEBUG ENCODING <key> */
     else if (!strcasecmp(cmd,"encoding")) {
-        char *encodingstr[2] = {"dense","sparse"};
+        const char *encodingstr[2] = {"dense","sparse"};
         if (c->argc != 3) goto arityerr;
 
         addReplyStatus(c,encodingstr[hdr->encoding]);

--- a/src/latency.c
+++ b/src/latency.c
@@ -290,7 +290,7 @@ sds createLatencyReport(void) {
 
         /* Fork */
         if (!strcasecmp(event,"fork")) {
-            char *fork_quality;
+            const char *fork_quality;
             if (server.stat_fork_rate < 10) {
                 fork_quality = "terrible";
                 advise_better_vm = 1;

--- a/src/lolwut6.c
+++ b/src/lolwut6.c
@@ -49,7 +49,7 @@ static sds renderCanvas(lwCanvas *canvas) {
     for (int y = 0; y < canvas->height; y++) {
         for (int x = 0; x < canvas->width; x++) {
             int color = lwGetPixel(canvas,x,y);
-            char *ce; /* Color escape sequence. */
+            const char *ce; /* Color escape sequence. */
 
             /* Note that we set both the foreground and background color.
              * This way we are able to get a more consistent result among

--- a/src/memtest.c
+++ b/src/memtest.c
@@ -60,7 +60,7 @@ static struct winsize ws;
 size_t progress_printed; /* Printed chars in screen-wide progress bar. */
 size_t progress_full; /* How many chars to write to fill the progress bar. */
 
-void memtest_progress_start(char *title, int pass) {
+void memtest_progress_start(const char *title, int pass) {
     int j;
 
     printf("\x1b[H\x1b[2J");    /* Cursor home, clear screen. */

--- a/src/module.c
+++ b/src/module.c
@@ -2667,12 +2667,12 @@ int RM_StringSet(RedisModuleKey *key, RedisModuleString *str) {
  * so a RM_StringTruncate() call should be used if there is to enlarge
  * the string, and later call StringDMA() again to get the pointer.
  */
-char *RM_StringDMA(RedisModuleKey *key, size_t *len, int mode) {
+const char *RM_StringDMA(RedisModuleKey *key, size_t *len, int mode) {
     /* We need to return *some* pointer for empty keys, we just return
      * a string literal pointer, that is the advantage to be mapped into
      * a read only memory page, so the module will segfault if a write
      * attempt is performed. */
-    char *emptystring = "<dma-empty-string>";
+    const char *emptystring = "<dma-empty-string>";
     if (key->value == NULL) {
         *len = 0;
         return emptystring;
@@ -8908,7 +8908,7 @@ int moduleUnload(sds name) {
 
     /* Unload the dynamic library. */
     if (dlclose(module->handle) == -1) {
-        char *error = dlerror();
+        const char *error = dlerror();
         if (error == NULL) error = "Unknown error";
         serverLog(LL_WARNING,"Error when trying to close the %s module: %s",
             module->name, error);
@@ -9051,7 +9051,7 @@ NULL
         if (moduleUnload(c->argv[2]->ptr) == C_OK)
             addReply(c,shared.ok);
         else {
-            char *errmsg;
+            const char *errmsg;
             switch(errno) {
             case ENOENT:
                 errmsg = "no such module with that name";

--- a/src/multi.c
+++ b/src/multi.c
@@ -214,7 +214,7 @@ void execCommand(client *c) {
         int acl_errpos;
         int acl_retval = ACLCheckAllPerm(c,&acl_errpos);
         if (acl_retval != ACL_OK) {
-            char *reason;
+            const char *reason;
             switch (acl_retval) {
             case ACL_DENIED_CMD:
                 reason = "no permission to execute the command or subcommand";
@@ -267,7 +267,7 @@ void execCommand(client *c) {
          * rest was not. We need to make sure to at least terminate the
          * backlog with the final EXEC. */
         if (server.repl_backlog && was_master && !is_master) {
-            char *execcmd = "*1\r\n$4\r\nEXEC\r\n";
+            const char *execcmd = "*1\r\n$4\r\nEXEC\r\n";
             feedReplicationBacklog(execcmd,strlen(execcmd));
         }
         afterPropagateExec();

--- a/src/networking.c
+++ b/src/networking.c
@@ -435,7 +435,7 @@ void afterErrorReply(client *c, const char *s, size_t len) {
      * they are rare and may hint at errors in a script or a bug in Redis. */
     int ctype = getClientType(c);
     if (ctype == CLIENT_TYPE_MASTER || ctype == CLIENT_TYPE_SLAVE || c->id == CLIENT_ID_AOF) {
-        char *to, *from;
+        const char *to, *from;
 
         if (c->id == CLIENT_ID_AOF) {
             to = "AOF-loading-client";
@@ -449,7 +449,7 @@ void afterErrorReply(client *c, const char *s, size_t len) {
         }
 
         if (len > 4096) len = 4096;
-        char *cmdname = c->lastcmd ? c->lastcmd->name : "<unknown>";
+        const char *cmdname = c->lastcmd ? c->lastcmd->name : "<unknown>";
         serverLog(LL_WARNING,"== CRITICAL == This %s is sending an error "
                              "to its %s: '%.*s' after processing the command "
                              "'%s'", from, to, (int)len, s, cmdname);
@@ -1021,7 +1021,7 @@ void clientAcceptHandler(connection *conn) {
         connPeerToString(conn, cip, sizeof(cip)-1, NULL);
 
         if (strcmp(cip,"127.0.0.1") && strcmp(cip,"::1")) {
-            char *err =
+            const char *err =
                 "-DENIED Redis is running in protected mode because protected "
                 "mode is enabled and no password is set for the default user. "
                 "In this mode connections are only accepted from the loopback interface. "
@@ -1079,7 +1079,7 @@ static void acceptCommonHandler(connection *conn, int flags, char *ip) {
     if (listLength(server.clients) + getClusterConnectionsCount()
         >= server.maxclients)
     {
-        char *err;
+        const char *err;
         if (server.cluster_enabled)
             err = "-ERR max number of clients + cluster "
                   "connections reached\r\n";
@@ -3182,7 +3182,7 @@ int getClientTypeByName(char *name) {
     else return -1;
 }
 
-char *getClientTypeName(int class) {
+const char *getClientTypeName(int class) {
     switch(class) {
     case CLIENT_TYPE_NORMAL: return "normal";
     case CLIENT_TYPE_SLAVE:  return "slave";

--- a/src/notify.c
+++ b/src/notify.c
@@ -93,13 +93,13 @@ sds keyspaceEventsFlagsToString(int flags) {
 
 /* The API provided to the rest of the Redis core is a simple function:
  *
- * notifyKeyspaceEvent(int type, char *event, robj *key, int dbid);
+ * notifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
  *
  * 'type' is the notification class we define in `server.h`.
  * 'event' is a C string representing the event name.
  * 'key' is a Redis object representing the key name.
  * 'dbid' is the database ID where the key lives.  */
-void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
+void notifyKeyspaceEvent(int type, const char *event, robj *key, int dbid) {
     sds chan;
     robj *chanobj, *eventobj;
     int len = -1;

--- a/src/object.c
+++ b/src/object.c
@@ -930,7 +930,7 @@ int getIntFromObjectOrReply(client *c, robj *o, int *target, const char *msg) {
     return C_OK;
 }
 
-char *strEncoding(int encoding) {
+const char *strEncoding(int encoding) {
     switch(encoding) {
     case OBJ_ENCODING_RAW: return "raw";
     case OBJ_ENCODING_INT: return "int";

--- a/src/rax.c
+++ b/src/rax.c
@@ -1846,7 +1846,7 @@ void raxRecursiveShow(int level, int lpad, raxNode *n) {
     }
     raxNode **cp = raxNodeFirstChildPtr(n);
     for (int i = 0; i < numchildren; i++) {
-        char *branch = " `-(%c) ";
+        const char *branch = " `-(%c) ";
         if (numchildren > 1) {
             printf("\n");
             for (int j = 0; j < lpad; j++) putchar(' ');

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -158,7 +158,7 @@ ssize_t rdbSaveSingleModuleAux(rio *rdb, int when, moduleType *mt);
 robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename);
 robj *rdbLoadStringObject(rio *rdb);
 ssize_t rdbSaveStringObject(rio *rdb, robj *obj);
-ssize_t rdbSaveRawString(rio *rdb, unsigned char *s, size_t len);
+ssize_t rdbSaveRawString(rio *rdb, unsigned const char *s, size_t len);
 void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr);
 int rdbSaveBinaryDoubleValue(rio *rdb, double val);
 int rdbLoadBinaryDoubleValue(rio *rdb, double *val);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -272,7 +272,7 @@ static redisContext *getRedisContext(const char *ip, int port,
         ctx = redisConnectUnix(hostsocket);
     if (ctx == NULL || ctx->err) {
         fprintf(stderr,"Could not connect to Redis at ");
-        char *err = (ctx != NULL ? ctx->errstr : "");
+        const char *err = (ctx != NULL ? ctx->errstr : "");
         if (hostsocket == NULL)
             fprintf(stderr,"%s:%d: %s\n",ip,port,err);
         else
@@ -345,7 +345,7 @@ static redisConfig *getRedisConfig(const char *ip, int port,
         }
         if (reply->type != REDIS_REPLY_ARRAY || reply->elements < 2) goto fail;
         sub_reply = reply->element[1];
-        char *value = sub_reply->str;
+        const char *value = sub_reply->str;
         if (!value) value = "";
         switch (i) {
         case 0: cfg->save = sdsnew(value); break;
@@ -666,7 +666,7 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
  *    for arguments randomization.
  *
  * Even when cloning another client, prefix commands are applied if needed.*/
-static client createClient(char *cmd, size_t len, client from, int thread_id) {
+static client createClient(const char *cmd, size_t len, client from, int thread_id) {
     int j;
     int is_cluster_client = (config.cluster_mode && thread_id >= 0);
     client c = zmalloc(sizeof(struct _client));
@@ -974,7 +974,7 @@ static void startBenchmarkThreads() {
         pthread_join(config.threads[i]->thread, NULL);
 }
 
-static void benchmark(char *title, char *cmd, int len) {
+static void benchmark(const char *title, const char *cmd, int len) {
     client c;
 
     config.title = title;
@@ -1663,7 +1663,7 @@ int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData
 
 /* Return true if the named test was selected using the -t command line
  * switch, or if all the tests are selected (no -t passed by user). */
-int test_is_selected(char *name) {
+int test_is_selected(const char *name) {
     char buf[256];
     int l = strlen(name);
 
@@ -1677,7 +1677,8 @@ int test_is_selected(char *name) {
 
 int main(int argc, char **argv) {
     int i;
-    char *data, *cmd, *tag;
+    char *data, *cmd;
+    const char *tag;
     int len;
 
     client c;
@@ -1916,7 +1917,7 @@ int main(int argc, char **argv) {
         }
 
         if (test_is_selected("zadd")) {
-            char *score = "0";
+            const char *score = "0";
             if (config.randomkeys) score = "__rand_int__";
             len = redisFormatCommand(&cmd,
                 "ZADD myzset%s %s element:__rand_int__",tag,score);

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -63,7 +63,7 @@ struct {
 #define RDB_CHECK_DOING_READ_AUX 7
 #define RDB_CHECK_DOING_READ_MODULE_AUX 8
 
-char *rdb_check_doing_string[] = {
+const char *rdb_check_doing_string[] = {
     "start",
     "read-type",
     "read-expire",
@@ -75,7 +75,7 @@ char *rdb_check_doing_string[] = {
     "read-module-aux"
 };
 
-char *rdb_type_string[] = {
+const char *rdb_type_string[] = {
     "string",
     "list-linked",
     "set-hashtable",

--- a/src/redisassert.h
+++ b/src/redisassert.h
@@ -43,7 +43,7 @@
 #define assert(_e) (likely((_e))?(void)0 : (_serverAssert(#_e,__FILE__,__LINE__),redis_unreachable()))
 #define panic(...) _serverPanic(__FILE__,__LINE__,__VA_ARGS__),redis_unreachable()
 
-void _serverAssert(char *estr, char *file, int line);
+void _serverAssert(const char *estr, const char *file, int line);
 void _serverPanic(const char *file, int line, const char *msg, ...);
 
 #endif

--- a/src/replication.c
+++ b/src/replication.c
@@ -2061,7 +2061,7 @@ char *sendCommandArgv(connection *conn, int argc, char **argv, size_t *argv_lens
 #define PSYNC_NOT_SUPPORTED 4
 #define PSYNC_TRY_LATER 5
 int slaveTryPartialResynchronization(connection *conn, int read_reply) {
-    char *psync_replid;
+    const char *psync_replid;
     char psync_offset[32];
     sds reply;
 
@@ -2291,7 +2291,7 @@ void syncWithMaster(connection *conn) {
     if (server.repl_state == REPL_STATE_SEND_HANDSHAKE) {
         /* AUTH with the master if required. */
         if (server.masterauth) {
-            char *args[3] = {"AUTH",NULL,NULL};
+            const char *args[3] = {"AUTH",NULL,NULL};
             size_t lens[3] = {4,0,0};
             int argc = 1;
             if (server.masteruser) {
@@ -2835,7 +2835,7 @@ void roleCommand(client *c) {
         }
         setDeferredArrayLen(c,mbcount,slaves);
     } else {
-        char *slavestate = NULL;
+        const char *slavestate = NULL;
 
         addReplyArrayLen(c,5);
         addReplyBulkCBuffer(c,"slave",5);

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -101,7 +101,7 @@ struct ldbState {
 void sha1hex(char *digest, char *script, size_t len) {
     SHA1_CTX ctx;
     unsigned char hash[20];
-    char *cset = "0123456789abcdef";
+    const char *cset = "0123456789abcdef";
     int j;
 
     SHA1Init(&ctx);
@@ -375,7 +375,7 @@ static void redisProtocolToLuaType_Double(void *ctx, double d, const char *proto
  * with a single "err" field set to the error string. Note that this
  * table is never a valid reply by proper commands, since the returned
  * tables are otherwise always indexed by integers, never by strings. */
-void luaPushError(lua_State *lua, char *error) {
+void luaPushError(lua_State *lua, const char *error) {
     lua_Debug dbg;
 
     /* If debugging is active and in step mode, log errors resulting from
@@ -632,7 +632,7 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
      * To make this function reentrant is futile and makes it slower, but
      * we should at least detect such a misuse, and abort. */
     if (inuse) {
-        char *recursion_warning =
+        const char *recursion_warning =
             "luaRedisGenericCommand() recursive call detected. "
             "Are you doing funny stuff with Lua debug hooks?";
         serverLog(LL_WARNING,"%s",recursion_warning);
@@ -1005,7 +1005,7 @@ int luaRedisSha1hexCommand(lua_State *lua) {
  * return redis.error_reply("ERR Some Error")
  * return redis.status_reply("ERR Some Error")
  */
-int luaRedisReturnSingleFieldTable(lua_State *lua, char *field) {
+int luaRedisReturnSingleFieldTable(lua_State *lua, const char *field) {
     if (lua_gettop(lua) != 1 || lua_type(lua,-1) != LUA_TSTRING) {
         luaPushError(lua, "wrong number or type of arguments");
         return 1;
@@ -1208,7 +1208,7 @@ void luaRemoveUnsupportedFunctions(lua_State *lua) {
  * It should be the last to be called in the scripting engine initialization
  * sequence, because it may interact with creation of globals. */
 void scriptingEnableGlobalsProtection(lua_State *lua) {
-    char *s[32];
+    const char *s[32];
     sds code = sdsempty();
     int j = 0;
 
@@ -1383,7 +1383,7 @@ void scriptingInit(int setup) {
     /* Add a helper function that we use to sort the multi bulk output of non
      * deterministic commands, when containing 'false' elements. */
     {
-        char *compare_func =    "function __redis__compare_helper(a,b)\n"
+        const char *compare_func =    "function __redis__compare_helper(a,b)\n"
                                 "  if a == false then a = '' end\n"
                                 "  if b == false then b = '' end\n"
                                 "  return a<b\n"
@@ -1397,7 +1397,7 @@ void scriptingInit(int setup) {
      * information about the caller, that's what makes sense from the point
      * of view of the user debugging a script. */
     {
-        char *errh_func =       "local dbg = debug\n"
+        const char *errh_func = "local dbg = debug\n"
                                 "function __redis__err__handler(err)\n"
                                 "  local i = dbg.getinfo(2,'nSl')\n"
                                 "  if i and i.what == 'C' then\n"
@@ -1451,7 +1451,7 @@ void scriptingReset(int async) {
 
 /* Set an array of Redis String Objects as a Lua array (table) stored into a
  * global variable. */
-void luaSetGlobalArray(lua_State *lua, char *var, robj **elev, int elec) {
+void luaSetGlobalArray(lua_State *lua, const char *var, robj **elev, int elec) {
     int j;
 
     lua_newtable(lua);
@@ -2198,7 +2198,7 @@ void evalGenericCommandWithDebugging(client *c, int evalsha) {
 
 /* Return a pointer to ldb.src source code line, considering line to be
  * one-based, and returning a special string for out of range lines. */
-char *ldbGetSourceLine(int line) {
+const char *ldbGetSourceLine(int line) {
     int idx = line-1;
     if (idx < 0 || idx >= ldb.lines) return "<out of range source code line>";
     return ldb.src[idx];
@@ -2291,8 +2291,8 @@ protoerr:
 
 /* Log the specified line in the Lua debugger output. */
 void ldbLogSourceLine(int lnum) {
-    char *line = ldbGetSourceLine(lnum);
-    char *prefix;
+    const char *line = ldbGetSourceLine(lnum);
+    const char *prefix;
     int bp = ldbIsBreakpoint(lnum);
     int current = ldb.currentline == lnum;
 
@@ -2398,7 +2398,7 @@ sds ldbCatStackValueRec(sds s, lua_State *lua, int idx, int level) {
     case LUA_TLIGHTUSERDATA:
         {
         const void *p = lua_topointer(lua,idx);
-        char *typename = "unknown";
+        const char *typename = "unknown";
         if (t == LUA_TFUNCTION) typename = "function";
         else if (t == LUA_TUSERDATA) typename = "userdata";
         else if (t == LUA_TTHREAD) typename = "thread";
@@ -2422,7 +2422,7 @@ sds ldbCatStackValue(sds s, lua_State *lua, int idx) {
 /* Produce a debugger log entry representing the value of the Lua object
  * currently on the top of the stack. The element is not popped nor modified.
  * Check ldbCatStackValue() for the actual implementation. */
-void ldbLogStackValue(lua_State *lua, char *prefix) {
+void ldbLogStackValue(lua_State *lua, const char *prefix) {
     sds s = sdsnew(prefix);
     s = ldbCatStackValue(s,lua,-1);
     ldbLogWithMaxLen(s);
@@ -2911,7 +2911,7 @@ void luaLdbLineHook(lua_State *lua, lua_Debug *ar) {
     }
 
     if (ldb.step || bp) {
-        char *reason = "step over";
+        const char *reason = "step over";
         if (bp) reason = ldb.luabp ? "redis.breakpoint() called" :
                                      "break point";
         else if (timeout) reason = "timeout reached, infinite loop?";

--- a/src/sds.c
+++ b/src/sds.c
@@ -1208,7 +1208,7 @@ sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen) {
 
 /* Join an array of C strings using the specified separator (also a C string).
  * Returns the result as an sds string. */
-sds sdsjoin(char **argv, int argc, char *sep) {
+sds sdsjoin(char **argv, int argc, const char *sep) {
     sds join = sdsempty();
     int j;
 

--- a/src/sds.h
+++ b/src/sds.h
@@ -251,7 +251,7 @@ sds sdsfromlonglong(long long value);
 sds sdscatrepr(sds s, const char *p, size_t len);
 sds *sdssplitargs(const char *line, int *argc);
 sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen);
-sds sdsjoin(char **argv, int argc, char *sep);
+sds sdsjoin(char **argv, int argc, const char *sep);
 sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
 
 /* Callback for sdstemplate. The function gets called by sdstemplate

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -392,7 +392,7 @@ int yesnotoi(char *s);
 void instanceLinkConnectionError(const redisAsyncContext *c);
 const char *sentinelRedisInstanceTypeStr(sentinelRedisInstance *ri);
 void sentinelAbortFailover(sentinelRedisInstance *ri);
-void sentinelEvent(int level, char *type, sentinelRedisInstance *ri, const char *fmt, ...);
+void sentinelEvent(int level, const char *type, sentinelRedisInstance *ri, const char *fmt, ...);
 sentinelRedisInstance *sentinelSelectSlave(sentinelRedisInstance *master);
 void sentinelScheduleScriptExecution(char *path, ...);
 void sentinelStartFailover(sentinelRedisInstance *master);
@@ -691,7 +691,7 @@ sds announceSentinelAddrAndPort(const sentinelAddr *a) {
  *
  *  Any other specifier after "%@" is processed by printf itself.
  */
-void sentinelEvent(int level, char *type, sentinelRedisInstance *ri,
+void sentinelEvent(int level, const char *type, sentinelRedisInstance *ri,
                    const char *fmt, ...) {
     va_list ap;
     char msg[LOG_MAX_LEN];
@@ -1024,7 +1024,7 @@ void sentinelPendingScriptsCommand(client *c) {
  *
  * from/to fields are respectively master -> promoted slave addresses for
  * "start" and "end". */
-void sentinelCallClientReconfScript(sentinelRedisInstance *master, int role, char *state, sentinelAddr *from, sentinelAddr *to) {
+void sentinelCallClientReconfScript(sentinelRedisInstance *master, int role, const char *state, sentinelAddr *from, sentinelAddr *to) {
     char fromport[32], toport[32];
 
     if (master->client_reconfig_script == NULL) return;
@@ -1737,7 +1737,7 @@ void sentinelPropagateDownAfterPeriod(sentinelRedisInstance *master) {
  * we check the one of the master), and map the command that we should send
  * to the set of renamed commands. However, if the command was not renamed,
  * we just return "command" itself. */
-char *sentinelInstanceMapCommand(sentinelRedisInstance *ri, char *command) {
+const char *sentinelInstanceMapCommand(sentinelRedisInstance *ri, const char *command) {
     sds sc = sdsnew(command);
     if (ri->master) ri = ri->master;
     char *retval = dictFetchValue(ri->renamed_commands, sc);
@@ -2371,7 +2371,7 @@ void sentinelSendAuthIfNeeded(sentinelRedisInstance *ri, redisAsyncContext *c) {
  *
  * This makes it possible to list all the sentinel instances connected
  * to a Redis server with CLIENT LIST, grepping for a specific name format. */
-void sentinelSetClientName(sentinelRedisInstance *ri, redisAsyncContext *c, char *type) {
+void sentinelSetClientName(sentinelRedisInstance *ri, redisAsyncContext *c, const char *type) {
     char name[64];
 
     snprintf(name,sizeof(name),"sentinel-%.8s-%s",sentinel.myid,type);
@@ -4158,7 +4158,7 @@ void sentinelInfoCommand(client *c) {
         di = dictGetIterator(sentinel.masters);
         while((de = dictNext(di)) != NULL) {
             sentinelRedisInstance *ri = dictGetVal(de);
-            char *status = "ok";
+            const char *status = "ok";
 
             if (ri->flags & SRI_O_DOWN) status = "odown";
             else if (ri->flags & SRI_S_DOWN) status = "sdown";

--- a/src/server.c
+++ b/src/server.c
@@ -3376,7 +3376,7 @@ void InitServerLast() {
 /* Parse the flags string description 'strflags' and set them to the
  * command 'c'. If the flags are all valid C_OK is returned, otherwise
  * C_ERR is returned (yet the recognized flags are set in the command). */
-int populateCommandTableParseFlags(struct redisCommand *c, char *strflags) {
+int populateCommandTableParseFlags(struct redisCommand *c, const char *strflags) {
     int argc;
     sds *argv;
 
@@ -3765,7 +3765,7 @@ void call(client *c, int flags) {
      * unless instructed by the caller not to log. (happens when processing
      * a MULTI-EXEC from inside an AOF). */
     if (flags & CMD_CALL_SLOWLOG) {
-        char *latency_event = (real_cmd->flags & CMD_FAST) ?
+        const char *latency_event = (real_cmd->flags & CMD_FAST) ?
                                "fast-command" : "command";
         latencyAddSampleIfNeeded(latency_event,duration/1000);
     }
@@ -4466,7 +4466,7 @@ void timeCommand(client *c) {
 }
 
 /* Helper function for addReplyCommand() to output flags. */
-int addReplyCommandFlag(client *c, struct redisCommand *cmd, int f, char *reply) {
+int addReplyCommandFlag(client *c, struct redisCommand *cmd, int f, const char *reply) {
     if (cmd->flags & f) {
         addReplyStatus(c, reply);
         return 1;
@@ -4648,8 +4648,8 @@ sds genRedisInfoString(const char *section) {
     if (allsections || defsections || !strcasecmp(section,"server")) {
         static int call_uname = 1;
         static struct utsname name;
-        char *mode;
-        char *supervised;
+        const char *mode;
+        const char *supervised;
 
         if (server.cluster_enabled) mode = "cluster";
         else if (server.sentinel_mode) mode = "sentinel";
@@ -5181,7 +5181,7 @@ sds genRedisInfoString(const char *section) {
             listRewind(server.slaves,&li);
             while((ln = listNext(&li))) {
                 client *slave = listNodeValue(ln);
-                char *state = NULL;
+                const char *state = NULL;
                 char ip[NET_IP_STR_LEN], *slaveip = slave->slave_addr;
                 int port;
                 long lag = 0;
@@ -5354,7 +5354,7 @@ sds genRedisInfoString(const char *section) {
 }
 
 void infoCommand(client *c) {
-    char *section = c->argc == 2 ? c->argv[1]->ptr : "default";
+    const char *section = c->argc == 2 ? c->argv[1]->ptr : "default";
 
     if (c->argc > 2) {
         addReplyErrorObject(c,shared.syntaxerr);
@@ -5626,7 +5626,7 @@ void usage(void) {
 void redisAsciiArt(void) {
 #include "asciilogo.h"
     char *buf = zmalloc(1024*16);
-    char *mode;
+    const char *mode;
 
     if (server.cluster_enabled) mode = "cluster";
     else if (server.sentinel_mode) mode = "sentinel";
@@ -5759,7 +5759,7 @@ int changeListenPort(int port, socketFds *sfd, aeFileProc *accept_handler) {
 }
 
 static void sigShutdownHandler(int sig) {
-    char *msg;
+    const char *msg;
 
     switch (sig) {
     case SIGINT:
@@ -5923,11 +5923,11 @@ int redisFork(int purpose) {
     return childpid;
 }
 
-void sendChildCowInfo(childInfoType info_type, char *pname) {
+void sendChildCowInfo(childInfoType info_type, const char *pname) {
     sendChildInfoGeneric(info_type, 0, -1, pname);
 }
 
-void sendChildInfo(childInfoType info_type, size_t keys, char *pname) {
+void sendChildInfo(childInfoType info_type, size_t keys, const char *pname) {
     sendChildInfoGeneric(info_type, keys, -1, pname);
 }
 
@@ -6123,7 +6123,7 @@ int validateProcTitleTemplate(const char *template) {
     return ok;
 }
 
-int redisSetProcTitle(char *title) {
+int redisSetProcTitle(const char *title) {
 #ifdef USE_SETPROCTITLE
     if (!title) title = server.exec_argv[0];
     sds proc_title = expandProcTitleTemplate(server.proc_title_template, title);

--- a/src/server.h
+++ b/src/server.h
@@ -729,7 +729,7 @@ typedef struct redisObject {
 /* The a string name for an object's type as listed above
  * Native types are checked against the OBJ_STRING, OBJ_LIST, OBJ_* defines,
  * and Module types have their registered name returned. */
-char *getObjectTypeName(robj*);
+const char *getObjectTypeName(robj*);
 
 /* Macro used to initialize a Redis object allocated on the stack.
  * Note that this macro is taken near the structure definition to make sure
@@ -1698,10 +1698,10 @@ typedef struct {
 typedef void redisCommandProc(client *c);
 typedef int redisGetKeysProc(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 struct redisCommand {
-    char *name;
+    const char *name;
     redisCommandProc *proc;
     int arity;
-    char *sflags;   /* Flags as string representation, one char per flag. */
+    const char *sflags;   /* Flags as string representation, one char per flag. */
     uint64_t flags; /* The actual flags, obtained from the 'sflags' field. */
     /* Use a function to determine keys arguments in a command line.
      * Used for Redis Cluster redirect. */
@@ -1853,7 +1853,7 @@ void getRandomBytes(unsigned char *p, size_t len);
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
 void exitFromChild(int retcode);
 long long redisPopcount(void *s, long count);
-int redisSetProcTitle(char *title);
+int redisSetProcTitle(const char *title);
 int validateProcTitleTemplate(const char *template);
 int redisCommunicateSystemd(const char *sd_notify_msg);
 void redisSetCpuAffinity(const char *cpulist);
@@ -1926,7 +1926,7 @@ int freeClientsInAsyncFreeQueue(void);
 int closeClientOnOutputBufferLimitReached(client *c, int async);
 int getClientType(client *c);
 int getClientTypeByName(char *name);
-char *getClientTypeName(int class);
+const char *getClientTypeName(int class);
 void flushSlavesOutputBuffers(void);
 void disconnectSlaves(void);
 int listenToPort(int port, socketFds *fds);
@@ -2056,7 +2056,7 @@ int getLongLongFromObject(robj *o, long long *target);
 int getLongDoubleFromObject(robj *o, long double *target);
 int getLongDoubleFromObjectOrReply(client *c, robj *o, long double *target, const char *msg);
 int getIntFromObjectOrReply(client *c, robj *o, int *target, const char *msg);
-char *strEncoding(int encoding);
+const char *strEncoding(int encoding);
 int compareStringObjects(robj *a, robj *b);
 int collateStringObjects(robj *a, robj *b);
 int equalStringObjects(robj *a, robj *b);
@@ -2145,9 +2145,9 @@ void restartAOFAfterSYNC();
 /* Child info */
 void openChildInfoPipe(void);
 void closeChildInfoPipe(void);
-void sendChildInfoGeneric(childInfoType info_type, size_t keys, double progress, char *pname);
-void sendChildCowInfo(childInfoType info_type, char *pname);
-void sendChildInfo(childInfoType info_type, size_t keys, char *pname);
+void sendChildInfoGeneric(childInfoType info_type, size_t keys, double progress, const char *pname);
+void sendChildCowInfo(childInfoType info_type, const char *pname);
+void sendChildInfo(childInfoType info_type, size_t keys, const char *pname);
 void receiveChildInfo(void);
 
 /* Fork helpers */
@@ -2364,7 +2364,7 @@ int pubsubPublishMessage(robj *channel, robj *message);
 void addReplyPubsubMessage(client *c, robj *channel, robj *msg);
 
 /* Keyspace events notification */
-void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid);
+void notifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
 int keyspaceEventsStringToFlags(char *classes);
 sds keyspaceEventsFlagsToString(int flags);
 
@@ -2785,11 +2785,11 @@ sds genModulesInfoString(sds info);
 void enableWatchdog(int period);
 void disableWatchdog(void);
 void watchdogScheduleSignal(int period);
-void serverLogHexDump(int level, char *descr, void *value, size_t len);
+void serverLogHexDump(int level, const char *descr, void *value, size_t len);
 int memtest_preserving_test(unsigned long *m, size_t bytes, int passes);
 void mixDigest(unsigned char *digest, void *ptr, size_t len);
-void xorDigest(unsigned char *digest, void *ptr, size_t len);
-int populateCommandTableParseFlags(struct redisCommand *c, char *strflags);
+void xorDigest(unsigned char *digest, const void *ptr, size_t len);
+int populateCommandTableParseFlags(struct redisCommand *c, const char *strflags);
 void debugDelay(int usec);
 void killIOThreads(void);
 void killThreads(void);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -245,7 +245,7 @@ void pushGenericCommand(client *c, int where, int xx) {
 
     addReplyLongLong(c, listTypeLength(lobj));
 
-    char *event = (where == LIST_HEAD) ? "lpush" : "rpush";
+    const char *event = (where == LIST_HEAD) ? "lpush" : "rpush";
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_LIST,event,c->argv[1],c->db->id);
 }
@@ -421,7 +421,7 @@ void addListRangeReply(client *c, robj *o, long start, long end, int reverse) {
 
 /* A housekeeping helper for list elements popping tasks. */
 void listElementsRemoved(client *c, robj *key, int where, robj *o, long count) {
-    char *event = (where == LIST_HEAD) ? "lpop" : "rpop";
+    const char *event = (where == LIST_HEAD) ? "lpop" : "rpop";
 
     notifyKeyspaceEvent(NOTIFY_LIST, event, key, c->db->id);
     if (listTypeLength(o) == 0) {
@@ -867,7 +867,7 @@ int serveClientBlockedOnList(client *receiver, robj *key, robj *dstkey, redisDb 
         addReplyBulk(receiver,value);
 
         /* Notify event. */
-        char *event = (wherefrom == LIST_HEAD) ? "lpop" : "rpop";
+        const char *event = (wherefrom == LIST_HEAD) ? "lpop" : "rpop";
         notifyKeyspaceEvent(NOTIFY_LIST,event,key,receiver->db->id);
     } else {
         /* BLMOVE */

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1707,7 +1707,7 @@ void zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, ziplistEntry *
 
 /* This generic command implements both ZADD and ZINCRBY. */
 void zaddGenericCommand(client *c, int flags) {
-    static char *nanerr = "resulting score is not a number (NaN)";
+    static const char *nanerr = "resulting score is not a number (NaN)";
     robj *key = c->argv[1];
     robj *zobj;
     sds ele;
@@ -1885,7 +1885,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     zrangespec range;
     zlexrangespec lexrange;
     long start, end, llen;
-    char *notify_type = NULL;
+    const char *notify_type = NULL;
 
     /* Step 1: Parse the range. */
     if (rangetype == ZRANGE_RANK) {
@@ -3887,7 +3887,7 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
         server.dirty++;
 
         if (result_count == 0) { /* Do this only for the first iteration. */
-            char *events[2] = {"zpopmin","zpopmax"};
+            const char *events[2] = {"zpopmin","zpopmax"};
             notifyKeyspaceEvent(NOTIFY_ZSET,events[where],key,c->db->id);
             signalModifiedKey(c,c->db,key);
         }

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -152,7 +152,7 @@ int checkPrefixCollisionsOrReply(client *c, robj **prefixes, size_t numprefix) {
 
 /* Set the client 'c' to track the prefix 'prefix'. If the client 'c' is
  * already registered for the specified prefix, no operation is performed. */
-void enableBcastTrackingForPrefix(client *c, char *prefix, size_t plen) {
+void enableBcastTrackingForPrefix(client *c, const char *prefix, size_t plen) {
     bcastState *bs = raxFind(PrefixTable,(unsigned char*)prefix,plen);
     /* If this is the first client subscribing to such prefix, create
      * the prefix in the table. */

--- a/src/util.c
+++ b/src/util.c
@@ -713,7 +713,7 @@ void getRandomBytes(unsigned char *p, size_t len) {
  * having run_id == A, and you reconnect and it has run_id == B, you can be
  * sure that it is either a different instance or it was restarted. */
 void getRandomHexChars(char *p, size_t len) {
-    char *charset = "0123456789abcdef";
+    const char *charset = "0123456789abcdef";
     size_t j;
 
     getRandomBytes((unsigned char*)p,len);


### PR DESCRIPTION
Throughout the codebase, many pointers are declared with "char" instead of the proper type, "const char". This PR resolves this by replacing "char*" to "const char*" at many locations. These locations were discovered by compiling with the warning flag `-Wdiscarded-qualifiers` enabled, and resolving many (but not all) of the warnings.