### PR TITLE
Make Cluster-bus port configurable with new cluster-port config

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1450,11 +1450,8 @@ lua-time-limit 5000
 #
 # cluster-node-timeout 15000
 
-# Cluster port incr is the offset from command port to cluster bus port. 
-# Cluster port = command port + cluster port incr.
-# User could define the difference from them. 
-#
-# cluster-port-incr 10000
+# Cluster port 
+# cluster-port 0
 
 # A replica of a failing master will avoid to start a failover if its data
 # looks too old.

--- a/redis.conf
+++ b/redis.conf
@@ -1450,6 +1450,10 @@ lua-time-limit 5000
 #
 # cluster-node-timeout 15000
 
+# The default cluster bus port parameter is 0. If this parameter is not set in the config file
+# then  cluster bus port = command port+ 10000; Otherwise in the cluster uou need  explicitly 
+# mention it in the command "cluster meet":  for example:  cluster meet ip port cluster-port
+#
 # Cluster port 
 # cluster-port 0
 

--- a/redis.conf
+++ b/redis.conf
@@ -1450,11 +1450,9 @@ lua-time-limit 5000
 #
 # cluster-node-timeout 15000
 
-# The default cluster bus port parameter is 0. If this parameter is not set in the config file
-# then  cluster bus port = command port+ 10000; Otherwise in the cluster uou need  explicitly 
-# mention it in the command "cluster meet":  for example:  cluster meet ip port cluster-port
-#
-# Cluster port 
+# The cluster port is the port that the cluster bus will listen for inbound connections on. When set 
+# to the default value, 0, it will be bound to the command port + 10000. Setting this value requires 
+# you to you to specify the cluster bus port when executing cluster meet.
 # cluster-port 0
 
 # A replica of a failing master will avoid to start a failover if its data

--- a/redis.conf
+++ b/redis.conf
@@ -1452,7 +1452,7 @@ lua-time-limit 5000
 
 # Cluster port incr is the offset from command port to cluster bus port. 
 # Cluster port = command port + cluster port incr.
-# User could define the differnce from them. 
+# User could define the difference from them. 
 #
 # cluster-port-incr 10000
 

--- a/redis.conf
+++ b/redis.conf
@@ -1450,6 +1450,12 @@ lua-time-limit 5000
 #
 # cluster-node-timeout 15000
 
+# Cluster port incr is the offset from command port to cluster bus port. 
+# Cluster port = command port + cluster port incr.
+# User could define the differnce from them. 
+#
+# cluster-port-incr 10000
+
 # A replica of a failing master will avoid to start a failover if its data
 # looks too old.
 #

--- a/redis.conf
+++ b/redis.conf
@@ -1452,7 +1452,7 @@ lua-time-limit 5000
 
 # The cluster port is the port that the cluster bus will listen for inbound connections on. When set 
 # to the default value, 0, it will be bound to the command port + 10000. Setting this value requires 
-# you to you to specify the cluster bus port when executing cluster meet.
+# you to specify the cluster bus port when executing cluster meet.
 # cluster-port 0
 
 # A replica of a failing master will avoid to start a failover if its data

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -559,7 +559,6 @@ void clusterInit(void) {
             createClusterNode(NULL,CLUSTER_NODE_MYSELF|CLUSTER_NODE_MASTER);
         serverLog(LL_NOTICE,"No cluster configuration found, I'm %.40s",
             myself->name);
-        serverLog(LL_NOTICE,"I will create a config file");
         clusterAddNode(myself);
         saveconf = 1;
     }
@@ -567,12 +566,6 @@ void clusterInit(void) {
 
     /* We need a listening TCP port for our cluster messaging needs. */
     server.cfd.count = 0;
-
-   
-    
-    serverLog(LL_WARNING, "-------------------------------");
-    serverLog(LL_WARNING, "cluster port is %d", server.cluster_port);
-    serverLog(LL_WARNING, "-------------------------------");
 
     /* Port sanity check II
      * The other handshake port check is triggered too late to stop
@@ -1428,11 +1421,6 @@ int clusterStartHandshake(char *ip, int port, int cport) {
     clusterNode *n;
     char norm_ip[NET_IP_STR_LEN];
     struct sockaddr_storage sa;
-
-    serverLog(LL_NOTICE,"---------------------------");
-    serverLog(LL_NOTICE,"The handshake ip is %s", ip);
-    serverLog(LL_NOTICE,"The handshake port is %d", port);
-    serverLog(LL_NOTICE,"The handshake cport is %d", cport);
 
     /* IP sanity check */
     if (inet_pton(AF_INET,ip,
@@ -4573,7 +4561,7 @@ NULL
         };
         addReplyHelp(c, help);
     } else if (!strcasecmp(c->argv[1]->ptr,"meet") && (c->argc == 4 || c->argc == 5)) {
-        /* CLUSTER MEET <ip> <port> [cport ] */
+        /* CLUSTER MEET <ip> <port> [cport] */
         long long port, cport;
 
         if (getLongLongFromObject(c->argv[3], &port) != C_OK) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -582,8 +582,8 @@ void clusterInit(void) {
         serverLog(LL_WARNING, "No bind address is configured, but it is required for the Cluster bus.");
         exit(1);
     }
-    if ((server.cluster_port && (listenToPort(server.cluster_port, &server.cfd) == C_ERR)) ||
-        listenToPort(port+CLUSTER_PORT_INCR, &server.cfd) == C_ERR ) {
+    int cport = server.cluster_port ? server.cluster_port : port + CLUSTER_PORT_INCR;
+    if (listenToPort(cport, &server.cfd) == C_ERR ) {
         exit(1);
     }
     
@@ -4572,7 +4572,7 @@ NULL
 
         if (c->argc == 5) {
             if (getLongLongFromObject(c->argv[4], &cport) != C_OK) {
-                addReplyErrorFormat(c,"Invalid TCP bus port or cluster port specified: %s",
+                addReplyErrorFormat(c,"Invalid TCP bus port specified: %s",
                                     (char*)c->argv[4]->ptr);
                 return;
             }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4572,8 +4572,8 @@ void clusterCommand(client *c) {
 NULL
         };
         addReplyHelp(c, help);
-    } else if (!strcasecmp(c->argv[1]->ptr,"meet") && (c->argc == 4 || c->argc == 5 || c->argc == 6)) {
-        /* CLUSTER MEET <ip> <port> [cport] [cluster-port]*/
+    } else if (!strcasecmp(c->argv[1]->ptr,"meet") && (c->argc == 4 || c->argc == 5)) {
+        /* CLUSTER MEET <ip> <port> [cport ] */
         long long port, cport;
 
         if (getLongLongFromObject(c->argv[3], &port) != C_OK) {
@@ -4584,14 +4584,8 @@ NULL
 
         if (c->argc == 5) {
             if (getLongLongFromObject(c->argv[4], &cport) != C_OK) {
-                addReplyErrorFormat(c,"Invalid TCP bus port specified: %s",
+                addReplyErrorFormat(c,"Invalid TCP bus port or cluster port specified: %s",
                                     (char*)c->argv[4]->ptr);
-                return;
-            }
-        } else if (c->argc == 6) {
-            if (getLongLongFromObject(c->argv[5], &cport) != C_OK) {
-                addReplyErrorFormat(c,"Invalid TCP bus port specified: %s",
-                                    (char*)c->argv[5]->ptr);
                 return;
             }
         } else {

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -9,6 +9,7 @@
 #define CLUSTER_OK 0          /* Everything looks ok */
 #define CLUSTER_FAIL 1        /* The cluster can't work */
 #define CLUSTER_NAMELEN 40    /* sha1 hex length */
+#define CLUSTER_PORT_INCR 10000  /* Cluster port = baseport + PORT_INCR*/
 
 /* The following defines are amount of time, sometimes expressed as
  * multiplicators of the node timeout value (when ending with MULT). */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -6,10 +6,10 @@
  *----------------------------------------------------------------------------*/
 
 #define CLUSTER_SLOTS 16384
-#define CLUSTER_OK 0          /* Everything looks ok */
-#define CLUSTER_FAIL 1        /* The cluster can't work */
-#define CLUSTER_NAMELEN 40    /* sha1 hex length */
-#define CLUSTER_PORT_INCR 10000  /* Cluster port = baseport + PORT_INCR*/
+#define CLUSTER_OK 0            /* Everything looks ok */
+#define CLUSTER_FAIL 1          /* The cluster can't work */
+#define CLUSTER_NAMELEN 40      /* sha1 hex length */
+#define CLUSTER_PORT_INCR 10000 /* Cluster port = baseport + PORT_INCR */
 
 /* The following defines are amount of time, sometimes expressed as
  * multiplicators of the node timeout value (when ending with MULT). */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -9,7 +9,6 @@
 #define CLUSTER_OK 0          /* Everything looks ok */
 #define CLUSTER_FAIL 1        /* The cluster can't work */
 #define CLUSTER_NAMELEN 40    /* sha1 hex length */
-#define CLUSTER_PORT_INCR 10000 /* Cluster port = baseport + PORT_INCR */
 
 /* The following defines are amount of time, sometimes expressed as
  * multiplicators of the node timeout value (when ending with MULT). */

--- a/src/config.c
+++ b/src/config.c
@@ -2645,6 +2645,7 @@ standardConfig configs[] = {
     createIntConfig("timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.maxidletime, 0, INTEGER_CONFIG, NULL, NULL), /* Default client timeout: infinite */
     createIntConfig("replica-announce-port", "slave-announce-port", MODIFIABLE_CONFIG, 0, 65535, server.slave_announce_port, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("tcp-backlog", NULL, IMMUTABLE_CONFIG, 0, INT_MAX, server.tcp_backlog, 511, INTEGER_CONFIG, NULL, NULL), /* TCP listen backlog. */
+    createIntConfig("cluster-port-incr", NULL, IMMUTABLE_CONFIG, 1, 10000, server.cluster_port_incr, 10000, INTEGER_CONFIG, NULL, NULL),    
     createIntConfig("cluster-announce-bus-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_bus_port, 0, INTEGER_CONFIG, NULL, NULL), /* Default: Use +10000 offset. */
     createIntConfig("cluster-announce-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_port, 0, INTEGER_CONFIG, NULL, NULL), /* Use server.port */
     createIntConfig("cluster-announce-tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_tls_port, 0, INTEGER_CONFIG, NULL, NULL), /* Use server.tls_port */

--- a/src/config.c
+++ b/src/config.c
@@ -2645,7 +2645,7 @@ standardConfig configs[] = {
     createIntConfig("timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.maxidletime, 0, INTEGER_CONFIG, NULL, NULL), /* Default client timeout: infinite */
     createIntConfig("replica-announce-port", "slave-announce-port", MODIFIABLE_CONFIG, 0, 65535, server.slave_announce_port, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("tcp-backlog", NULL, IMMUTABLE_CONFIG, 0, INT_MAX, server.tcp_backlog, 511, INTEGER_CONFIG, NULL, NULL), /* TCP listen backlog. */
-    createIntConfig("cluster-port-incr", NULL, IMMUTABLE_CONFIG, 1, 10000, server.cluster_port_incr, 10000, INTEGER_CONFIG, NULL, NULL),    
+    createIntConfig("cluster-port", NULL, IMMUTABLE_CONFIG, 0, 65535, server.cluster_port, 0, INTEGER_CONFIG, NULL, NULL),    
     createIntConfig("cluster-announce-bus-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_bus_port, 0, INTEGER_CONFIG, NULL, NULL), /* Default: Use +10000 offset. */
     createIntConfig("cluster-announce-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_port, 0, INTEGER_CONFIG, NULL, NULL), /* Use server.port */
     createIntConfig("cluster-announce-tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_tls_port, 0, INTEGER_CONFIG, NULL, NULL), /* Use server.tls_port */

--- a/src/server.h
+++ b/src/server.h
@@ -1631,6 +1631,7 @@ struct redisServer {
                                    xor of NOTIFY_... flags. */
     /* Cluster */
     int cluster_enabled;      /* Is cluster enabled? */
+    int cluster_port_incr;    /* Cluster port = baseport + cluster_port_incr */
     mstime_t cluster_node_timeout; /* Cluster node timeout. */
     char *cluster_configfile; /* Cluster auto-generated config file name. */
     struct clusterState *cluster;  /* State of the cluster */

--- a/src/server.h
+++ b/src/server.h
@@ -1631,7 +1631,7 @@ struct redisServer {
                                    xor of NOTIFY_... flags. */
     /* Cluster */
     int cluster_enabled;      /* Is cluster enabled? */
-    int cluster_port;   
+    int cluster_port;         /* Set the cluster port for a node. */
     mstime_t cluster_node_timeout; /* Cluster node timeout. */
     char *cluster_configfile; /* Cluster auto-generated config file name. */
     struct clusterState *cluster;  /* State of the cluster */

--- a/src/server.h
+++ b/src/server.h
@@ -1631,7 +1631,7 @@ struct redisServer {
                                    xor of NOTIFY_... flags. */
     /* Cluster */
     int cluster_enabled;      /* Is cluster enabled? */
-    int cluster_port_incr;    /* Cluster port = baseport + cluster_port_incr */
+    int cluster_port;   
     mstime_t cluster_node_timeout; /* Cluster node timeout. */
     char *cluster_configfile; /* Cluster auto-generated config file name. */
     struct clusterState *cluster;  /* State of the cluster */

--- a/tests/cluster/run.tcl
+++ b/tests/cluster/run.tcl
@@ -15,7 +15,6 @@ proc main {} {
     spawn_instance redis $::redis_base_port $::instances_count {
         "cluster-enabled yes"
         "appendonly yes"
-        "cluster-port-incr 100"
     }
     run_tests
     cleanup

--- a/tests/cluster/run.tcl
+++ b/tests/cluster/run.tcl
@@ -15,6 +15,7 @@ proc main {} {
     spawn_instance redis $::redis_base_port $::instances_count {
         "cluster-enabled yes"
         "appendonly yes"
+        "cluster-port-incr 100"
     }
     run_tests
     cleanup

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -158,6 +158,7 @@ start_server {tags {"introspection"}} {
             bgsave_cpulist
             set-proc-title
             cluster-config-file
+            cluster-port
         }
 
         if {!$::tls} {


### PR DESCRIPTION
Background: 
Currently, for a cluster node, cluster bus port = command port+ 10000, which is a fixed value.

We would like to make the value flexible, thus user could have more choice for the offset between command port
and cluster bus port.

The parameter "cluster-port" can be added in redis.conf, the value could be from 1 to 65535.

Example for 4 node config files in a clsuter:

**node1:** 

port 6381
cluster-enabled yes
cluster-config-file nodes1-6381.conf
cluster-node-timeout 15000
cluster-port 10000

**node2:**

port 6382
cluster-enabled yes
cluster-config-file nodes2-6382.conf
cluster-node-timeout 15000
cluster-port 10001

**node3:**

port 6383
cluster-enabled yes
cluster-config-file nodes3-6383.conf
cluster-node-timeout 15000
cluster-port 20000

**node4:**

port 6384
cluster-enabled yes
cluster-config-file nodes4-6384.conf
cluster-node-timeout 15000

the result:

![image](https://user-images.githubusercontent.com/51993843/134528277-530c02c4-25a1-4678-8f96-532a4418e3d9.png)




