### PR TITLE
Let CONFIG GET * show both replicaof and its alias

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1045,13 +1045,10 @@ void configGetCommand(client *c) {
         addReplyBulkCString(c,buf);
         matches++;
     }
-    if (stringmatch(pattern,"slaveof",1) ||
-        stringmatch(pattern,"replicaof",1))
-    {
-        char *optname = stringmatch(pattern,"slaveof",1) ?
-                        "slaveof" : "replicaof";
+    for (int i = 0; i < 2; i++) {
+        char *optname = i == 0 ? "replicaof" : "slaveof";
+        if (!stringmatch(pattern, optname, 1)) continue;
         char buf[256];
-
         addReplyBulkCString(c,optname);
         if (server.masterhost)
             snprintf(buf,sizeof(buf),"%s %d",

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -149,6 +149,7 @@ start_server {tags {"introspection"}} {
             io-threads
             logfile
             unixsocketperm
+            replicaof
             slaveof
             requirepass
             server_cpulist


### PR DESCRIPTION
For other configs, we show both the main config name and its alias if both match the pattern. This one is handled separately.

Fixes #9376