### PR TITLE
Delay to discard cached master when full synchronization

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1732,10 +1732,10 @@ void readSyncBulkPayload(connection *conn) {
         diskless_load_backup = disklessLoadMakeBackup();
     }
 
-    /* Replica starts to appply data from new master, we must discard the cached
+    /* Replica starts to apply data from new master, we must discard the cached
      * master structure. And before this, make sure there is no master client,
      * since replica's data would be changed and cached master is exactly wrong
-     * once creating master client. */
+     * once the master client is created. */
     serverAssert(server.master == NULL);
     replicationDiscardCachedMaster();
 
@@ -2637,7 +2637,7 @@ void replicationSetMaster(char *ip, int port) {
 
     /* Here we don't disconnect with replicas, since they may hopefully be able
      * to partially resync with us. We will disconnect with replicas and force
-     * them resync with us when changing replid on partially resync with new
+     * them to resync with us when changing replid on partially resync with new
      * master, or finishing transferring RDB and preparing loading DB on full
      * sync with new master. */
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -1733,9 +1733,7 @@ void readSyncBulkPayload(connection *conn) {
     }
 
     /* Replica starts to apply data from new master, we must discard the cached
-     * master structure. And before this, make sure there is no master client,
-     * since replica's data would be changed and cached master is exactly wrong
-     * once the master client is created. */
+     * master structure. */
     serverAssert(server.master == NULL);
     replicationDiscardCachedMaster();
 

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -927,20 +927,21 @@ test {Kill rdb child process if its dumping RDB is not useful} {
     }
 } {} {external:skip}
 
-test {delay to discard cache master when full sync} {
-    start_server {tags {"repl"}} {
-        set master1 [srv 0 client]
-        set master1_host [srv 0 host]
-        set master1_port [srv 0 port]
-        $master1 set a b
+start_server {tags {"repl external:skip"}} {
+    set master1_host [srv 0 host]
+    set master1_port [srv 0 port]
+    r set a b
+
+    start_server {} {
+        set master2 [srv 0 client]
+        set master2_host [srv 0 host]
+        set master2_port [srv 0 port]
+        # Take 10s for dumping RDB
+        $master2 debug populate 10 master2 10
+        $master2 config set rdb-key-save-delay 1000000
 
         start_server {} {
-            set master2 [srv 0 client]
-            set master2_host [srv 0 host]
-            set master2_port [srv 0 port]
-            # Take 10s for dumping RDB
-            $master2 debug populate 10 master2 10
-            $master2 config set rdb-key-save-delay 1000000
+            set sub_replica [srv 0 client]
 
             start_server {} {
                 # Full sync with master1
@@ -948,24 +949,38 @@ test {delay to discard cache master when full sync} {
                 wait_for_sync r
                 assert_equal "b" [r get a]
 
-                # Full sync with master2, and then kill master2
+                # Let sub replicas sync with me
+                $sub_replica slaveof [srv 0 host] [srv 0 port]
+                wait_for_sync $sub_replica
+                assert_equal "b" [$sub_replica get a]
+
+                # Full sync with master2, and then kill master2 before finishing dumping RDB
                 r slaveof $master2_host $master2_port
                 wait_for_condition 50 100 {
-                    ([s -1 rdb_bgsave_in_progress] == 1) &&
-                    ([string match "*wait_bgsave*" [s -1 slave0]])
+                    ([s -2 rdb_bgsave_in_progress] == 1) &&
+                    ([string match "*wait_bgsave*" [s -2 slave0]])
                 } else {
                     fail "full sync didn't start"
                 }
                 catch {$master2 shutdown nosave}
 
-                # Partial sync with master1
-                r slaveof $master1_host $master1_port
-                wait_for_condition 50 100 {
-                    [log_file_matches [srv 0 stdout] "*Successful partial resynchronization*"]
-                } else {
-                    fail "slave cant't be allowed to start partial resynchronization"
+                test {Don't disconnect with replicas before loading transferred RDB when full sync} {
+                    assert ![log_file_matches [srv -1 stdout] "*Connection with master lost*"]
+                    # The replication id is not changed in entire replication chain
+                    assert_equal [s master_replid] [s -3 master_replid]
+                    assert_equal [s master_replid] [s -1 master_replid]
+                }
+
+                test {Discard cache master before loading transferred RDB when full sync} {
+                    # Partial sync with master1
+                    r slaveof $master1_host $master1_port
+                    wait_for_condition 50 100 {
+                        [log_file_matches [srv 0 stdout] "*Successful partial resynchronization*"]
+                    } else {
+                        fail "slave cant't be allowed to start partial resynchronization"
+                    }
                 }
             }
         }
     }
-} {} {external:skip}
+}

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -986,6 +986,9 @@ start_server {tags {"repl external:skip"}} {
                     assert_equal [s master_replid] [s -3 master_replid]
                     assert_equal [s master_replid] [s -1 master_replid]
                     assert ![log_file_matches [srv -1 stdout] "*Connection with master lost*"]
+                    # Sub replica just has one full sync, no partial resync.
+                    assert_equal 1 [s sync_full]
+                    assert_equal 0 [s sync_partial_ok]
                 }
             }
         }


### PR DESCRIPTION
Currently, once replica need to start full synchronization with master, it will discard cached master whatever full synchronization is failed or not. I think the cached master still is valid if failing to full synchronization, since replica's data is not changed during waiting data snapshot from master. Now we discard cached master only when transferring RDB is finished  and start to change data space, this make replica could start partial resynchronization with another new master if new master is failed during full synchronization.