### PR TITLE
Some redis-cli cluster subcommands output wrong address error messages.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -87,6 +87,9 @@
     "[ERR] Invalid arguments: you need to pass either a valid " \
     "address (ie. 120.0.0.1:7000) or space separated IP " \
     "and port (ie. 120.0.0.1 7000)\n"
+#define CLUSTER_MANAGER_INVALID_HOST_ARG_NEW \
+    "[ERR] Invalid arguments: you need to pass a valid " \
+    "address (ie. 120.0.0.1:7000)\n"
 #define CLUSTER_MANAGER_MODE() (config.cluster_manager_command.name != NULL)
 #define CLUSTER_MANAGER_MASTERS_COUNT(nodes, replicas) (nodes/(replicas + 1))
 #define CLUSTER_MANAGER_COMMAND(n,...) \
@@ -5889,11 +5892,12 @@ cleanup:
 }
 
 static int clusterManagerCommandAddNode(int argc, char **argv) {
+    UNUSED(argc);
     int success = 1;
     redisReply *reply = NULL;
     char *ref_ip = NULL, *ip = NULL;
     int ref_port = 0, port = 0;
-    if (!getClusterHostFromCmdArgs(argc - 1, argv + 1, &ref_ip, &ref_port))
+    if (!getClusterHostFromCmdArgs(1, argv + 1, &ref_ip, &ref_port))
         goto invalid_args;
     if (!getClusterHostFromCmdArgs(1, argv, &ip, &port))
         goto invalid_args;
@@ -5981,7 +5985,7 @@ cleanup:
     if (reply) freeReplyObject(reply);
     return success;
 invalid_args:
-    fprintf(stderr, CLUSTER_MANAGER_INVALID_HOST_ARG);
+    fprintf(stderr, CLUSTER_MANAGER_INVALID_HOST_ARG_NEW);
     return 0;
 }
 
@@ -6048,7 +6052,7 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
     if (r) freeReplyObject(r);
     return success;
 invalid_args:
-    fprintf(stderr, CLUSTER_MANAGER_INVALID_HOST_ARG);
+    fprintf(stderr, CLUSTER_MANAGER_INVALID_HOST_ARG_NEW);
     return 0;
 }
 
@@ -6513,7 +6517,7 @@ reply_err:;
                           ok_count, err_count);
     return 1;
 invalid_args:
-    fprintf(stderr, CLUSTER_MANAGER_INVALID_HOST_ARG);
+    fprintf(stderr, CLUSTER_MANAGER_INVALID_HOST_ARG_NEW);
     return 0;
 }
 
@@ -6712,7 +6716,7 @@ static int clusterManagerCommandCall(int argc, char **argv) {
     zfree(argvlen);
     return 1;
 invalid_args:
-    fprintf(stderr, CLUSTER_MANAGER_INVALID_HOST_ARG);
+    fprintf(stderr, CLUSTER_MANAGER_INVALID_HOST_ARG_NEW);
     return 0;
 }
 
@@ -6776,7 +6780,7 @@ cleanup:
     } else clusterManagerLogOk("[ERR] Failed to back cluster!\n");
     return success;
 invalid_args:
-    fprintf(stderr, CLUSTER_MANAGER_INVALID_HOST_ARG);
+    fprintf(stderr, CLUSTER_MANAGER_INVALID_HOST_ARG_NEW);
     return 0;
 }
 

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -85,11 +85,11 @@
 
 #define CLUSTER_MANAGER_INVALID_HOST_ARG \
     "[ERR] Invalid arguments: you need to pass either a valid " \
-    "address (ie. 120.0.0.1:7000) or space separated IP " \
-    "and port (ie. 120.0.0.1 7000)\n"
+    "address (e.g. 120.0.0.1:7000) or space separated IP " \
+    "and port (e.g. 120.0.0.1 7000)\n"
 #define CLUSTER_MANAGER_INVALID_HOST_ARG_NEW \
     "[ERR] Invalid arguments: you need to pass a valid " \
-    "address (ie. 120.0.0.1:7000)\n"
+    "address (e.g. 120.0.0.1:7000)\n"
 #define CLUSTER_MANAGER_MODE() (config.cluster_manager_command.name != NULL)
 #define CLUSTER_MANAGER_MASTERS_COUNT(nodes, replicas) (nodes/(replicas + 1))
 #define CLUSTER_MANAGER_COMMAND(n,...) \


### PR DESCRIPTION
Fix https://github.com/redis/redis/issues/8953

add-node/del-node/call/timeout/backup cluster commands only accept
address like host:port. The old prompt implied 120.0.0.1 7000 is also
acceptable.