### PR TITLE
Fix the timing of read and write events under kqueue

### DIFF
--- a/src/ae_kqueue.c
+++ b/src/ae_kqueue.c
@@ -44,7 +44,7 @@ typedef struct aeApiState {
 } aeApiState;
 
 #define EVENT_MASK_MALLOC_SIZE(sz) (((sz) + 3) / 4)
-#define EVENT_MASK_OFFSET(fd) (6 - (fd) % 4 * 2)
+#define EVENT_MASK_OFFSET(fd) ((fd) % 4 * 2)
 #define EVENT_MASK_ENCODE(fd, mask) (((mask) & 0x3) << EVENT_MASK_OFFSET(fd))
 
 static inline int getEventMask(const char *eventsMask, int fd) {

--- a/src/ae_kqueue.c
+++ b/src/ae_kqueue.c
@@ -36,7 +36,11 @@
 typedef struct aeApiState {
     int kqfd;
     struct kevent *events;
-    char *eventsMask; /* events mask for merge read and write event. */
+
+    /* Events mask for merge read and write event.
+     * To reduce memory consumption, we use 2 bits to store the mask
+     * of an event, so that 1 byte will store the mask of 4 events. */
+    char *eventsMask; 
 } aeApiState;
 
 static int aeApiCreate(aeEventLoop *eventLoop) {
@@ -55,7 +59,7 @@ static int aeApiCreate(aeEventLoop *eventLoop) {
         return -1;
     }
     anetCloexec(state->kqfd);
-    state->eventsMask = zmalloc(eventLoop->setsize);
+    state->eventsMask = zmalloc((eventLoop->setsize+3)/4);
     eventLoop->apidata = state;
     return 0;
 }
@@ -64,7 +68,7 @@ static int aeApiResize(aeEventLoop *eventLoop, int setsize) {
     aeApiState *state = eventLoop->apidata;
 
     state->events = zrealloc(state->events, sizeof(struct kevent)*setsize);
-    state->eventsMask = zrealloc(state->eventsMask, setsize);
+    state->eventsMask = zrealloc(state->eventsMask, (setsize+3)/4);
     return 0;
 }
 
@@ -106,6 +110,9 @@ static void aeApiDelEvent(aeEventLoop *eventLoop, int fd, int mask) {
     }
 }
 
+#define EVENT_MASK_OFFSET(fd) (6 - (fd) % 4 * 2)
+#define EVENT_MASK_ENCODE(fd, mask) (((mask) & 0x3) << EVENT_MASK_OFFSET(fd))
+#define EVENT_MASK_DECODE(fd, mask) (((mask) >> EVENT_MASK_OFFSET(fd)) & 0x3);
 static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
     aeApiState *state = eventLoop->apidata;
     int retval, numevents = 0;
@@ -133,9 +140,12 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
          * the same fd events later. */
         for (j = 0; j < retval; j++) {
             struct kevent *e = state->events+j;
+            int fd = e->ident;
+            int mask = 0; 
 
-            if (e->filter == EVFILT_READ) state->eventsMask[e->ident] |= AE_READABLE;
-            else if (e->filter == EVFILT_WRITE) state->eventsMask[e->ident] |= AE_WRITABLE;
+            if (e->filter == EVFILT_READ) mask = AE_READABLE;
+            else if (e->filter == EVFILT_WRITE) mask = AE_WRITABLE;
+            state->eventsMask[fd/4] |= EVENT_MASK_ENCODE(fd, mask);
         }
 
         /* Re-traversal to merge read and write events, and set the fd's mask to
@@ -143,12 +153,13 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
         numevents = 0;
         for (j = 0; j < retval; j++) {
             struct kevent *e = state->events+j;
-            int mask = state->eventsMask[e->ident];
+            int fd = e->ident;
+            int mask = EVENT_MASK_DECODE(fd, state->eventsMask[fd/4]);
 
             if (mask) {
-                eventLoop->fired[numevents].fd = e->ident;
+                eventLoop->fired[numevents].fd = fd;
                 eventLoop->fired[numevents].mask = mask;
-                state->eventsMask[e->ident] = 0;
+                state->eventsMask[fd/4] &= ~EVENT_MASK_ENCODE(fd, AE_READABLE|AE_WRITABLE);
                 numevents++;
             }
         }

--- a/src/ae_kqueue.c
+++ b/src/ae_kqueue.c
@@ -86,7 +86,7 @@ static int aeApiResize(aeEventLoop *eventLoop, int setsize) {
 
     state->events = zrealloc(state->events, sizeof(struct kevent)*setsize);
     state->eventsMask = zrealloc(state->eventsMask, EVENT_MASK_MALLOC_SIZE(setsize));
-    memset(state->eventsMask, 0, EVENT_MASK_MALLOC_SIZE(eventLoop->setsize));
+    memset(state->eventsMask, 0, EVENT_MASK_MALLOC_SIZE(setsize));
     return 0;
 }
 

--- a/src/ae_kqueue.c
+++ b/src/ae_kqueue.c
@@ -133,7 +133,7 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
             if (e->filter == EVFILT_READ) mask |= AE_READABLE;
             if (e->filter == EVFILT_WRITE) mask |= AE_WRITABLE;
 
-            /* Normally we execute the write event first and then the read event.
+            /* Normally we execute the read event first and then the write event.
              * When the barrier is set, we will do it reverse.
              * 
              * However, under kqueue, read and write events would be separate


### PR DESCRIPTION
Normally we execute the read event first and then the write event. When the barrier is set, we will do it reverse.
However, under `kqueue`, if an `fd` has both read and write events, reading the event using `kevent` will generate two events, which will result in uncontrolled read and write timing.
This also means that the guarantees of AOF `appendfsync` = `always` are not met on MacOS without this fix.

The main change to this pr is to cache the events already obtained when reading them, so that if the same `fd` occurs again, only the mask in the cache is updated, rather than a new event is generated.

This was exposed by the following test failure on MacOS:
```
*** [err]: AOF fsync always barrier issue in tests/integration/aof.tcl
Expected 544 != 544 (context: type eval line 26 cmd {assert {$size1 != $size2}} proc ::test)
```