### PR TITLE
redis-benchmark: improved help and warnings

### DIFF
--- a/tests/integration/redis-benchmark.tcl
+++ b/tests/integration/redis-benchmark.tcl
@@ -13,7 +13,7 @@ start_server {tags {"benchmark network external:skip"}} {
         test {benchmark: set,get} {
             r config resetstat
             r flushall
-            set cmd [redisbenchmark $master_host $master_port "-c 5 -n 10 -e -t set,get"]
+            set cmd [redisbenchmark $master_host $master_port "-c 5 -n 10 -t set,get"]
             if {[catch { exec {*}$cmd } error]} {
                 set first_line [lindex [split $error "\n"] 0]
                 puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
@@ -27,7 +27,7 @@ start_server {tags {"benchmark network external:skip"}} {
 
         test {benchmark: full test suite} {
             r config resetstat
-            set cmd [redisbenchmark $master_host $master_port "-c 10 -n 100 -e"]
+            set cmd [redisbenchmark $master_host $master_port "-c 10 -n 100"]
             if {[catch { exec {*}$cmd } error]} {
                 set first_line [lindex [split $error "\n"] 0]
                 puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
@@ -57,7 +57,7 @@ start_server {tags {"benchmark network external:skip"}} {
         test {benchmark: multi-thread set,get} {
             r config resetstat
             r flushall
-            set cmd [redisbenchmark $master_host $master_port "--threads 10 -c 5 -n 10 -e -t set,get"]
+            set cmd [redisbenchmark $master_host $master_port "--threads 10 -c 5 -n 10 -t set,get"]
             if {[catch { exec {*}$cmd } error]} {
                 set first_line [lindex [split $error "\n"] 0]
                 puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
@@ -75,7 +75,7 @@ start_server {tags {"benchmark network external:skip"}} {
         test {benchmark: pipelined full set,get} {
             r config resetstat
             r flushall
-            set cmd [redisbenchmark $master_host $master_port "-P 5 -c 10 -n 10010 -e -t set,get"]
+            set cmd [redisbenchmark $master_host $master_port "-P 5 -c 10 -n 10010 -t set,get"]
             if {[catch { exec {*}$cmd } error]} {
                 set first_line [lindex [split $error "\n"] 0]
                 puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
@@ -93,7 +93,7 @@ start_server {tags {"benchmark network external:skip"}} {
         test {benchmark: arbitrary command} {
             r config resetstat
             r flushall
-            set cmd [redisbenchmark $master_host $master_port "-c 5 -n 150 -e INCRBYFLOAT mykey 10.0"]
+            set cmd [redisbenchmark $master_host $master_port "-c 5 -n 150 INCRBYFLOAT mykey 10.0"]
             if {[catch { exec {*}$cmd } error]} {
                 set first_line [lindex [split $error "\n"] 0]
                 puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]


### PR DESCRIPTION
A few pitfalls I discovered while testing the slot-to-key PR and some more fixes while I'm at it. Commit message below.

----

1. The output of --help:

  * On the Usage line, just write [OPTIONS] [COMMAND ARGS...] instead listing
    only a few arbitrary options and no command.
  * For --cluster, describe that if the command is supplied on the command line,
    the key must contain "{tag}". Otherwise, the command will not be sent to the
    right cluster node.
  * For -r, add a note that if -r is omitted, all commands in a benchmark will
    use the same key. Also align the description.
  * For -t, describe that -t is ignored if a command is supplied on the command
    line.

2. Print a warning if -t is present when a specific command is supplied.

3. Print all warnings and errors to stderr.

4. Remove -e from calls in redis-benchmark test suite.