### PR TITLE
Fix a small error due to the unreleased lock before program exit.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3515,6 +3515,7 @@ void initThreadedIO(void) {
         pthread_mutex_lock(&io_threads_mutex[i]); /* Thread will be stopped. */
         if (pthread_create(&tid,NULL,IOThreadMain,(void*)(long)i) != 0) {
             serverLog(LL_WARNING,"Fatal: Can't initialize IO thread.");
+            pthread_mutex_unlock(&io_threads_mutex[i]);
             exit(1);
         }
         io_threads[i] = tid;


### PR DESCRIPTION
Fix a small error due to the unreleased lock io_threads_mutex before program exit.

It is a small, harmless error since the program exits and all of the program resources will be cleaned up by some common OS. However, other OS systems (e.g., embedded systems) do not automatically free some resources at the exit. It is a good manner for resource management. Adding the unlock statement adds symmetry, so the code looks better. Also, the debugger would not warn this case : )