### PR TITLE
Make tracking invalidation messages always after command's reply

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -301,6 +301,7 @@ void serveClientsBlockedOnListKey(robj *o, readyList *rl) {
                                      &deleted);
             updateStatsOnUnblock(receiver, 0, elapsedUs(replyTimer));
             unblockClient(receiver);
+            afterCommand(receiver);
 
             if (dstkey) decrRefCount(dstkey);
 
@@ -341,6 +342,7 @@ void serveClientsBlockedOnSortedSetKey(robj *o, readyList *rl) {
             genericZpopCommand(receiver,&rl->key,1,where,1,NULL);
             updateStatsOnUnblock(receiver, 0, elapsedUs(replyTimer));
             unblockClient(receiver);
+            afterCommand(receiver);
             zcard--;
 
             /* Replicate the command. */
@@ -458,6 +460,7 @@ void serveClientsBlockedOnStreamKey(robj *o, readyList *rl) {
                  * valid, so we must do the setup above before
                  * this call. */
                 unblockClient(receiver);
+                afterCommand(receiver);
             }
         }
     }
@@ -508,6 +511,7 @@ void serveClientsBlockedOnKeyByModule(readyList *rl) {
             updateStatsOnUnblock(receiver, 0, elapsedUs(replyTimer));
 
             moduleUnblockClient(receiver);
+            afterCommand(receiver);
         }
     }
 }

--- a/src/db.c
+++ b/src/db.c
@@ -556,7 +556,7 @@ long long dbTotalServerKeyCount() {
  * a context of a client. */
 void signalModifiedKey(client *c, redisDb *db, robj *key) {
     touchWatchedKey(db,key);
-    trackingInvalidateKey(c,key);
+    trackingInvalidateKey(c,key,1);
 }
 
 void signalFlushedDb(int dbid, int async) {

--- a/src/server.c
+++ b/src/server.c
@@ -2933,8 +2933,9 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
      * our clients. */
     updateFailoverStatus();
 
-    /* We can't have pending invalidation messages to clients participating
-     * to the client side caching protocol in general mode */
+    /* Since we rely on current_client to send scheduled invalidation messages
+     * we have to flush them after each command, so when we get here, the list
+     * must be empty. */
     serverAssert(listLength(server.tracking_pending_keys) == 0);
 
     /* Send the invalidation messages to clients participating to the

--- a/src/server.c
+++ b/src/server.c
@@ -4546,12 +4546,12 @@ void afterCommand(client *c) {
     UNUSED(c);
     /* Flush pending invalidation messages only when we are not in nested call.
      * So the messages are not interleaved with transaction response. */
-    if (!server.fixed_time_expire) trackingHandlePendingKeyInvalidations();
+    if (!inNestedCall()) trackingHandlePendingKeyInvalidations();
 }
 
-/* This means we are in a nested call of a call*/
+/* This means we are in a nested call of a call */
 int inNestedCall(void) {
-    return !server.fixed_time_expire;
+    return server.fixed_time_expire;
 }
 
 /* Returns 1 for commands that may have key names in their arguments, but the legacy range

--- a/src/server.h
+++ b/src/server.h
@@ -1568,6 +1568,7 @@ struct redisServer {
     /* Client side caching. */
     unsigned int tracking_clients;  /* # of clients with tracking enabled.*/
     size_t tracking_table_max_keys; /* Max number of keys in tracking table. */
+    list *tracking_pending_keys; /* tracking invalidation keys pending to flush */
     /* Sort parameters - qsort_r() is only available under BSD so we
      * have to take this state global, in order to pass it to sortCompare() */
     int sort_desc;
@@ -1971,7 +1972,9 @@ void addReplyStatusFormat(client *c, const char *fmt, ...);
 void enableTracking(client *c, uint64_t redirect_to, uint64_t options, robj **prefix, size_t numprefix);
 void disableTracking(client *c);
 void trackingRememberKeys(client *c);
-void trackingInvalidateKey(client *c, robj *keyobj);
+void trackingInvalidateKey(client *c, robj *keyobj, int bcast);
+void trackingScheduleKey(uint64_t client_id, robj *keyobj);
+void trackingHandlePendingKeys(void);
 void trackingInvalidateKeysOnFlush(int async);
 void freeTrackingRadixTree(rax *rt);
 void freeTrackingRadixTreeAsync(rax *rt);
@@ -2282,6 +2285,7 @@ void preventCommandAOF(client *c);
 void preventCommandReplication(client *c);
 void slowlogPushCurrentCommand(client *c, struct redisCommand *cmd, ustime_t duration);
 int prepareForShutdown(int flags);
+void afterCommand(client *c);
 #ifdef __GNUC__
 void _serverLog(int level, const char *fmt, ...)
     __attribute__((format(printf, 2, 3)));

--- a/src/server.h
+++ b/src/server.h
@@ -1312,6 +1312,7 @@ struct redisServer {
 
     rax *clients_timeout_table; /* Radix tree for blocked clients timeouts. */
     long fixed_time_expire;     /* If > 0, expire keys against server.mstime. */
+    int in_nested_call;         /* If > 0, in a nested call of a call */
     rax *clients_index;         /* Active clients dictionary by client ID. */
     pause_type client_pause_type;      /* True if clients are currently paused */
     list *paused_clients;       /* List of pause clients */

--- a/src/server.h
+++ b/src/server.h
@@ -2107,8 +2107,8 @@ void enableTracking(client *c, uint64_t redirect_to, uint64_t options, robj **pr
 void disableTracking(client *c);
 void trackingRememberKeys(client *c);
 void trackingInvalidateKey(client *c, robj *keyobj, int bcast);
-void trackingScheduleKey(uint64_t client_id, robj *keyobj);
-void trackingHandlePendingKeys(void);
+void trackingScheduleKeyInvalidation(uint64_t client_id, robj *keyobj);
+void trackingHandlePendingKeyInvalidations(void);
 void trackingInvalidateKeysOnFlush(int async);
 void freeTrackingRadixTree(rax *rt);
 void freeTrackingRadixTreeAsync(rax *rt);
@@ -2433,6 +2433,7 @@ void preventCommandReplication(client *c);
 void slowlogPushCurrentCommand(client *c, struct redisCommand *cmd, ustime_t duration);
 int prepareForShutdown(int flags);
 void afterCommand(client *c);
+int inNestedCall(void);
 #ifdef __GNUC__
 void _serverLog(int level, const char *fmt, ...)
     __attribute__((format(printf, 2, 3)));

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -415,6 +415,8 @@ void trackingHandlePendingKeyInvalidations() {
     listRewind(server.tracking_pending_keys,&li);
     while ((ln = listNext(&li)) != NULL) {
         robj *key = listNodeValue(ln);
+        /* current_client maybe freed, so we need to send invalidation
+         * message only when current_client is still alive */
         if (server.current_client != NULL)
             sendTrackingMessage(server.current_client,(char *)key->ptr,sdslen(key->ptr),0);
         decrRefCount(key);

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -393,8 +393,15 @@ void trackingInvalidateKey(client *c, robj *keyobj, int bcast) {
             continue;
         }
 
-        /* We need to use id as client may be freed */
-        trackingScheduleKeyInvalidation(id,keyobj);
+        /* If target is current client, we need schedule key invalidation.
+         * As the invalidation messages may be interleaved with command
+         * response and should after command response */
+        if (target == server.current_client){
+            /* We need to use id as client may be freed */
+            trackingScheduleKeyInvalidation(id,keyobj);
+        } else {
+            sendTrackingMessage(target,(char *)keyobj->ptr,sdslen(keyobj->ptr),0);
+        }
     }
     raxStop(&ri);
 


### PR DESCRIPTION
Tracking invalidation messages were sometimes sent in inconsistent order, before the command's reply rather than after.
In addition to that, they were sometimes embedded inside other commands responses, like MULTI-EXEC and MGET.
Fix https://github.com/redis/redis/issues/8206 and https://github.com/redis/redis/issues/8935