### PR TITLE
Sentinel master reboot fix

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -339,3 +339,11 @@ SENTINEL resolve-hostnames no
 # to retain the hostnames when announced, enable announce-hostnames below.
 #
 SENTINEL announce-hostnames no
+
+# If master reboot in very short time, Sentinel will receive "reboot" flag information.
+# When master_reboot_down_after_period set 0, Sentinel will not failover until the 
+# process of master loading data finish
+# If master_reboot_down_after_period is not equal 0, Sentinel will failover after 
+# master_reboot_down_after_period millisecond pass.
+
+SENTINEL master-reboot-down-after-period mymaster 0

--- a/sentinel.conf
+++ b/sentinel.conf
@@ -340,10 +340,12 @@ SENTINEL resolve-hostnames no
 #
 SENTINEL announce-hostnames no
 
-# If master reboot in very short time, Sentinel will receive "reboot" flag information.
-# When master_reboot_down_after_period set 0, Sentinel will not failover until the 
-# process of master loading data finish
-# If master_reboot_down_after_period is not equal 0, Sentinel will failover after 
-# master_reboot_down_after_period millisecond pass.
+# When master_reboot_down_after_period is set to 0, Sentinel does not fail over
+# when receiving a -LOADING response from a master. This was the only supported
+# behavior before version 7.0.
+#
+# Otherwise, Sentinel will use this value as the time (in ms) it is willing to
+# accept a -LOADING response after a master has been rebooted, before failing
+# over.
 
 SENTINEL master-reboot-down-after-period mymaster 0

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1818,8 +1818,6 @@ void loadSentinelConfigFromQueue(void) {
         server.sentinel_config->monitor_cfg,
         server.sentinel_config->post_monitor_cfg
     };
-
-
     /* loading from pre monitor config queue first to avoid dependency issues
      * loading from monitor config queue
      * loading from the post monitor config queue */
@@ -2010,7 +2008,6 @@ const char *sentinelHandleConfiguration(char **argv, int argc) {
         ri->master_reboot_down_after_period = atoi(argv[2]);
         if (ri->master_reboot_down_after_period < 0)
             return "negative time parameter.";
-        serverLog(LL_WARNING,"Sentinel are initialing, master-reboot-down-after-period is %lld", ri->master_reboot_down_after_period);        
     } else {
         return "Unrecognized sentinel configuration statement.";
     }

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -76,7 +76,7 @@ typedef struct sentinelAddr {
 #define SRI_RECONF_DONE (1<<10)     /* Slave synchronized with new master. */
 #define SRI_FORCE_FAILOVER (1<<11)  /* Force failover with master up. */
 #define SRI_SCRIPT_KILL_SENT (1<<12) /* SCRIPT KILL already sent on -BUSY */
-#define SRI_MASTER_REBOOT  (1<<13)   /* Master was detected as rebooting*/
+#define SRI_MASTER_REBOOT  (1<<13)   /* Master was detected as rebooting */
 
 /* Note: times are in milliseconds. */
 #define SENTINEL_PING_PERIOD 1000
@@ -1298,7 +1298,7 @@ sentinelRedisInstance *createSentinelRedisInstance(char *name, int flags, char *
     ri->s_down_since_time = 0;
     ri->o_down_since_time = 0;
     ri->down_after_period = master ? master->down_after_period : sentinel_default_down_after;
-    ri->master_reboot_down_after_period = 0;                     
+    ri->master_reboot_down_after_period = 0;
     ri->master_link_down_time = 0;
     ri->auth_pass = NULL;
     ri->auth_user = NULL;
@@ -2150,7 +2150,6 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
             master->name, (unsigned long long) master->leader_epoch);
         rewriteConfigRewriteLine(state,"sentinel leader-epoch",line,1);
         /* rewriteConfigMarkAsProcessed is handled after the loop */
-        
 
         /* sentinel known-slave */
         di2 = dictGetIterator(master->slaves);
@@ -2777,7 +2776,7 @@ void sentinelPingReplyCallback(redisAsyncContext *c, void *reply, void *privdata
         {
             link->last_avail_time = mstime();
             link->act_ping_time = 0; /* Flag the pong as received. */
-            
+
             if (ri->flags & SRI_MASTER_REBOOT && strncmp(r->str,"PONG",4) == 0)
                 ri->flags &= ~SRI_MASTER_REBOOT;
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -76,7 +76,7 @@ typedef struct sentinelAddr {
 #define SRI_RECONF_DONE (1<<10)     /* Slave synchronized with new master. */
 #define SRI_FORCE_FAILOVER (1<<11)  /* Force failover with master up. */
 #define SRI_SCRIPT_KILL_SENT (1<<12) /* SCRIPT KILL already sent on -BUSY */
-#define SRI_MASTER_REBOOT  (1<<13)   /* this flag set thinks that master is rebooted in very shot time*/
+#define SRI_MASTER_REBOOT  (1<<13)   /* Master was detected as rebooting*/
 
 /* Note: times are in milliseconds. */
 #define SENTINEL_PING_PERIOD 1000
@@ -1316,7 +1316,7 @@ sentinelRedisInstance *createSentinelRedisInstance(char *name, int flags, char *
     ri->o_down_since_time = 0;
     ri->down_after_period = master ? master->down_after_period :
                             sentinel_default_down_after;
-    if(ri->flags & SRI_SLAVE){
+    if (ri->flags & SRI_SLAVE) {
         ri->master_reboot_down_after_period = master ? master->master_reboot_down_after_period :SENTINEL_PING_PERIOD*10;
     }                        
     ri->master_link_down_time = 0;
@@ -2507,7 +2507,7 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
                 if (strncmp(ri->runid,l+7,40) != 0) {
                     sentinelEvent(LL_NOTICE,"+reboot",ri,"%@");
 
-                    if(ri->flags & SRI_MASTER) {
+                    if (ri->flags & SRI_MASTER) {
                         ri->flags |= SRI_MASTER_REBOOT;
                         ri->master_reboot_since_time = mstime();
                     }

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -76,7 +76,7 @@ typedef struct sentinelAddr {
 #define SRI_RECONF_DONE (1<<10)     /* Slave synchronized with new master. */
 #define SRI_FORCE_FAILOVER (1<<11)  /* Force failover with master up. */
 #define SRI_SCRIPT_KILL_SENT (1<<12) /* SCRIPT KILL already sent on -BUSY */
-#define SRI_MASTER_REBOOT  (1<<13)
+#define SRI_MASTER_REBOOT  (1<<13)   /* this flag set thinks that master is rebooted in very shot time*/
 
 /* Note: times are in milliseconds. */
 #define SENTINEL_PING_PERIOD 1000

--- a/tests/sentinel/tests/12-a-test.tcl
+++ b/tests/sentinel/tests/12-a-test.tcl
@@ -1,0 +1,112 @@
+# Check the basic monitoring and failover capabilities.
+#source "../tests/includes/start-init-tests.tcl"
+source "../tests/includes/init-tests.tcl"
+
+
+if {$::simulate_error} {
+    test "This test will fail" {
+        fail "Simulated error"
+    }
+}
+
+
+# Restart an instance previously killed by kill_instance
+proc restart_instance_local {type id} {
+
+    puts "run restart locally"
+
+    set dirname "${type}_${id}"
+    set cfgfile [file join $dirname $type.conf]
+    set port [get_instance_attrib $type $id port]
+
+    # Execute the instance with its old setup and append the new pid
+    # file for cleanup.
+    set pid [exec_instance $type $dirname $cfgfile]
+    set_instance_attrib $type $id pid $pid
+    lappend ::pids $pid
+
+    # Check that the instance is running
+    if {[server_is_up 127.0.0.1 $port 100] == 0} {
+        set logfile [file join $dirname log.txt]
+        puts [exec tail $logfile]
+        abort_sentinel_test "Problems starting $type #$id: ping timeout, maybe server start failed, check $logfile"
+    }
+
+    # Connect with it with a fresh link
+    set link [redis 127.0.0.1 $port 0 $::tls]
+    $link reconnect 1
+    set_instance_attrib $type $id link $link
+
+    # Make sure the instance is not loading the dataset when this
+    # function returns.
+    # while 1 {
+    #    catch {[$link ping]} retval
+    #    if {[string match {*LOADING*} $retval]} {
+    #        after 100
+    #        continue
+    #    } else {
+    #        break
+    #    }
+    # }
+   
+}
+
+
+test "Before failover output all ids" {
+   puts ""
+   puts "current master id is $master_id"
+   set new_port [RPort $master_id]
+   puts "current port is $new_port"
+}
+
+test "Restart master test" {
+    set old_port [RPort $master_id]
+    set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
+    assert {[lindex $addr 1] == $old_port}
+
+    puts "populate 10000 keys"
+    R $master_id debug populate 10000
+    R $master_id bgsave
+    R $master_id config set key-load-delay 10000
+    R $master_id config set loading-process-events-interval-bytes 1024
+    R $master_id config rewrite
+
+    set size_b [R $master_id dbsize]
+    puts "now dbsize is $size_b"
+    
+    foreach_sentinel_id id {
+        S $id SENTINEL SET mymaster master-reboot-down-after-period 5000
+        S $id sentinel debug ping-period 500
+        S $id sentinel debug ask-period 500 
+    }
+
+    kill_instance redis $master_id
+    set previous_master_id $master_id
+   
+    restart_instance_local redis $master_id
+    
+    foreach_sentinel_id id {        
+        wait_for_condition 1000 100 {
+            [lindex [S $id SENTINEL GET-MASTER-ADDR-BY-NAME mymaster] 1] != $old_port
+        } else {
+            fail "At least one Sentinel did not receive failover info"
+        }
+    }
+    after 20000   
+    puts "current port AAA ---------------------------------------"
+    set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
+    set master_id [get_instance_id_by_port redis [lindex $addr 1]]
+    puts "previous_master_id = $previous_master_id"
+
+}
+
+test "New master [join $addr {:}] role matches" {
+    assert {[RI $master_id role] eq {master}}
+}
+
+test "after failover output all ids" {
+   puts ""
+   puts "current master id is $master_id"
+   set new_port [RPort $master_id]
+   puts "current port is $new_port"
+}

--- a/tests/sentinel/tests/12-master-reboot.tcl
+++ b/tests/sentinel/tests/12-master-reboot.tcl
@@ -1,5 +1,4 @@
 # Check the basic monitoring and failover capabilities.
-#source "../tests/includes/start-init-tests.tcl"
 source "../tests/includes/init-tests.tcl"
 
 
@@ -10,11 +9,8 @@ if {$::simulate_error} {
 }
 
 
-# Restart an instance previously killed by kill_instance
-proc restart_instance_local {type id} {
-
-    puts "run restart locally"
-
+# Reboot an instance previously in very short time but do not check if it is loading
+proc reboot_instance {type id} {
     set dirname "${type}_${id}"
     set cfgfile [file join $dirname $type.conf]
     set port [get_instance_attrib $type $id port]
@@ -36,44 +32,20 @@ proc restart_instance_local {type id} {
     set link [redis 127.0.0.1 $port 0 $::tls]
     $link reconnect 1
     set_instance_attrib $type $id link $link
-
-    # Make sure the instance is not loading the dataset when this
-    # function returns.
-    # while 1 {
-    #    catch {[$link ping]} retval
-    #    if {[string match {*LOADING*} $retval]} {
-    #        after 100
-    #        continue
-    #    } else {
-    #        break
-    #    }
-    # }
-   
 }
 
 
-test "Before failover output all ids" {
-   puts ""
-   puts "current master id is $master_id"
-   set new_port [RPort $master_id]
-   puts "current port is $new_port"
-}
-
-test "Restart master test" {
+test "Master reboot in very short time" {
     set old_port [RPort $master_id]
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
-
-    puts "populate 10000 keys"
+    
     R $master_id debug populate 10000
     R $master_id bgsave
-    R $master_id config set key-load-delay 10000
+    R $master_id config set key-load-delay 1500
     R $master_id config set loading-process-events-interval-bytes 1024
     R $master_id config rewrite
 
-    set size_b [R $master_id dbsize]
-    puts "now dbsize is $size_b"
-    
     foreach_sentinel_id id {
         S $id SENTINEL SET mymaster master-reboot-down-after-period 5000
         S $id sentinel debug ping-period 500
@@ -81,9 +53,7 @@ test "Restart master test" {
     }
 
     kill_instance redis $master_id
-    set previous_master_id $master_id
-   
-    restart_instance_local redis $master_id
+    reboot_instance redis $master_id
     
     foreach_sentinel_id id {        
         wait_for_condition 1000 100 {
@@ -92,21 +62,42 @@ test "Restart master test" {
             fail "At least one Sentinel did not receive failover info"
         }
     }
-    after 20000   
-    puts "current port AAA ---------------------------------------"
+
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     set master_id [get_instance_id_by_port redis [lindex $addr 1]]
-    puts "previous_master_id = $previous_master_id"
 
+    # Make sure the instance load all the dataset
+    while 1 {
+        catch {[$link ping]} retval
+        if {[string match {*LOADING*} $retval]} {
+            after 100
+            continue
+        } else {
+            break
+        }
+    }
 }
 
 test "New master [join $addr {:}] role matches" {
     assert {[RI $master_id role] eq {master}}
 }
 
-test "after failover output all ids" {
-   puts ""
-   puts "current master id is $master_id"
-   set new_port [RPort $master_id]
-   puts "current port is $new_port"
+test "All the other slaves now point to the new master" {
+    foreach_redis_id id {
+        if {$id != $master_id && $id != 0} {
+            wait_for_condition 1000 50 {
+                [RI $id master_port] == [lindex $addr 1]
+            } else {
+                fail "Redis ID $id not configured to replicate with new master"
+            }
+        }
+    }
+}
+
+test "The old master eventually gets reconfigured as a slave" {
+    wait_for_condition 1000 50 {
+        [RI 0 master_port] == [lindex $addr 1]
+    } else {
+        fail "Old master not reconfigured as slave of new master"
+    }
 }


### PR DESCRIPTION
Background Information:

We have two issues https://github.com/redis/redis/issues/1297 and https://github.com/redis/redis/issues/4561
They mentioned that Sentinel does not trigger failover in case of master node reboot in very shot time.
This PR is to fix this problem for sentinel.

Sentinel send PING request to master, replicas and other sentinels according to the "down-after-milliseconds" parameters in
sentinel.conf or its own config file.

If down-after-milliseconds is greater than 1000, Sentinel will send PING every second.
If down-after-milliseconds is less than 1000, Sentinel will send PING according to the down-after-milliseconds value

For example:

// Sentinel send PING request every 1 second
Sentinel down-after-milliseconds mymaster 60000

// Sentinel send PING request every 600 milliseconds
Sentinel down-after-milliseconds mymaster 600

Solution:

If master reboot in very short time, Sentinel will receive one "reboot" information.
At this time, add SRI_MASTER_REBOOT to this Sentinel instance and record the master reboot time in master_reboot_since_time variable.

If Sentinel receives "Loading" reply with SRI_MASTER_REBOOT flag from master for 10 * PING time,
Sentinel think master is subjectively down, and ready to vote and failover process.

This solution could grantee if master is reboot in very short time, failover could finish in 10 seconds.