### PR TITLE
[WIP] Add io_uring support to redis

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -179,7 +179,7 @@ ifeq ($(uname_S),Haiku)
 else
 	# All the other OSes (notably Linux)
 	FINAL_LDFLAGS+= -rdynamic
-	FINAL_LIBS+=-ldl -pthread -lrt
+	FINAL_LIBS+=-ldl -pthread -lrt -luring
 endif
 endif
 endif

--- a/src/ae.c
+++ b/src/ae.c
@@ -535,3 +535,9 @@ void aeSetBeforeSleepProc(aeEventLoop *eventLoop, aeBeforeSleepProc *beforesleep
 void aeSetAfterSleepProc(aeEventLoop *eventLoop, aeBeforeSleepProc *aftersleep) {
     eventLoop->aftersleep = aftersleep;
 }
+
+void aeRegisterFile(aeEventLoop *eventLoop, int fd) {
+#if defined(HAVE_IO_URING)
+    aeApiRegisterFile(eventLoop, fd);
+#endif
+}

--- a/src/ae.c
+++ b/src/ae.c
@@ -453,6 +453,12 @@ int aeProcessEvents(aeEventLoop *eventLoop, int flags)
 
             /* Fire the writable event. */
             if (fe->mask & mask & AE_WRITABLE) {
+#if defined(HAVE_IO_URING)
+                    if (!(mask & AE_POLLABLE)) {
+                        connection *conn = fe->clientData;
+                        conn->cqe_res = eventLoop->fired[j].res;
+                    }
+#endif
                 if (!fired || fe->wfileProc != fe->rfileProc) {
                     fe->wfileProc(eventLoop,fd,fe->clientData,mask);
                     fired++;

--- a/src/ae.c
+++ b/src/ae.c
@@ -52,13 +52,17 @@
 #ifdef HAVE_EVPORT
 #include "ae_evport.c"
 #else
-    #ifdef HAVE_EPOLL
-    #include "ae_epoll.c"
+    #ifdef HAVE_IO_URING
+    #include "ae_iouring.c"
     #else
-        #ifdef HAVE_KQUEUE
-        #include "ae_kqueue.c"
+        #ifdef HAVE_EPOLL
+        #include "ae_epoll.c"
         #else
-        #include "ae_select.c"
+            #ifdef HAVE_KQUEUE
+            #include "ae_kqueue.c"
+            #else
+            #include "ae_select.c"
+            #endif
         #endif
     #endif
 #endif

--- a/src/ae.c
+++ b/src/ae.c
@@ -69,7 +69,7 @@
 #endif
 
 
-aeEventLoop *aeCreateEventLoop(int setsize) {
+aeEventLoop *aeCreateEventLoop(int setsize, int extflags) {
     aeEventLoop *eventLoop;
     int i;
 
@@ -87,6 +87,7 @@ aeEventLoop *aeCreateEventLoop(int setsize) {
     eventLoop->beforesleep = NULL;
     eventLoop->aftersleep = NULL;
     eventLoop->flags = 0;
+    eventLoop->extflags = extflags;
     if (aeApiCreate(eventLoop) == -1) goto err;
     /* Events with mask == AE_NONE are not set. So let's initialize the
      * vector with it. */

--- a/src/ae.h
+++ b/src/ae.h
@@ -136,5 +136,6 @@ void aeSetAfterSleepProc(aeEventLoop *eventLoop, aeBeforeSleepProc *aftersleep);
 int aeGetSetSize(aeEventLoop *eventLoop);
 int aeResizeSetSize(aeEventLoop *eventLoop, int setsize);
 void aeSetDontWait(aeEventLoop *eventLoop, int noWait);
+void aeRegisterFile(aeEventLoop *eventLoop, int fd);
 
 #endif

--- a/src/ae.h
+++ b/src/ae.h
@@ -111,10 +111,11 @@ typedef struct aeEventLoop {
     aeBeforeSleepProc *beforesleep;
     aeBeforeSleepProc *aftersleep;
     int flags;
+    int extflags;
 } aeEventLoop;
 
 /* Prototypes */
-aeEventLoop *aeCreateEventLoop(int setsize);
+aeEventLoop *aeCreateEventLoop(int setsize, int extflags);
 void aeDeleteEventLoop(aeEventLoop *eventLoop);
 void aeStop(aeEventLoop *eventLoop);
 int aeCreateFileEvent(aeEventLoop *eventLoop, int fd, int mask,

--- a/src/ae.h
+++ b/src/ae.h
@@ -46,6 +46,7 @@
                            loop iteration. Useful when you want to persist
                            things to disk before sending replies, and want
                            to do that in a group fashion. */
+#define AE_POLLABLE 8   /* Especially for io_uring */
 
 #define AE_FILE_EVENTS (1<<0)
 #define AE_TIME_EVENTS (1<<1)
@@ -61,6 +62,7 @@
 #define AE_NOTUSED(V) ((void) V)
 
 struct aeEventLoop;
+struct iovec;
 
 /* Types and data structures */
 typedef void aeFileProc(struct aeEventLoop *eventLoop, int fd, void *clientData, int mask);
@@ -93,6 +95,7 @@ typedef struct aeTimeEvent {
 typedef struct aeFiredEvent {
     int fd;
     int mask;
+    int res;
 } aeFiredEvent;
 
 /* State of an event based program */
@@ -116,6 +119,8 @@ void aeDeleteEventLoop(aeEventLoop *eventLoop);
 void aeStop(aeEventLoop *eventLoop);
 int aeCreateFileEvent(aeEventLoop *eventLoop, int fd, int mask,
         aeFileProc *proc, void *clientData);
+int aeCreateFileEventWithBuf(aeEventLoop *eventLoop, int fd, int mask,
+                             aeFileProc *proc, void *clientData, struct iovec *iovecs);
 void aeDeleteFileEvent(aeEventLoop *eventLoop, int fd, int mask);
 int aeGetFileEvents(aeEventLoop *eventLoop, int fd);
 long long aeCreateTimeEvent(aeEventLoop *eventLoop, long long milliseconds,

--- a/src/ae_iouring.c
+++ b/src/ae_iouring.c
@@ -1,0 +1,172 @@
+/* Linux epoll(2) based ae.c module
+ *
+ * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <sys/epoll.h> //used for define EPOLLIN and EPOLLOUT
+#include "liburing.h"
+
+#define BACKLOG 4096
+#define MAX_ENTRIES 16384 /* entries should be configured by users */
+
+typedef struct uring_event {
+    int fd;
+    int type;
+} uring_event;
+
+typedef struct aeApiState {
+    int urfd;
+    struct io_uring *ring;
+    struct uring_event *events;
+} aeApiState;
+
+static int aeApiCreate(aeEventLoop *eventLoop) {
+    aeApiState *state = zmalloc(sizeof(aeApiState));
+    if (!state) return -1;
+    
+    state->events = zmalloc(sizeof(struct epoll_event)*eventLoop->setsize);
+    if (!state->events) {
+        zfree(state);
+        return -1;
+    }
+    
+    state->ring = zmalloc(sizeof(struct io_uring));
+    if (!state->ring) {
+        zfree(state->events);
+        zfree(state);
+        return -1;
+    }
+    
+    state->urfd = io_uring_queue_init(MAX_ENTRIES, state->ring, 0);
+    if (state->urfd == -1) {
+        zfree(state->ring);
+        zfree(state->events);
+        zfree(state);
+        return -1;
+    }
+    eventLoop->apidata = state;
+    return 0;
+}
+
+static int aeApiResize(aeEventLoop *eventLoop, int setsize) {
+    (void)eventLoop;
+    if (setsize >= FD_SETSIZE) return -1;
+    return 0;
+}
+
+static void aeApiFree(aeEventLoop *eventLoop) {
+    aeApiState *state = eventLoop->apidata;
+
+    close(state->urfd);
+    zfree(state->events);
+    zfree(state->ring);
+    zfree(state);
+}
+
+static int aeApiAddEvent(aeEventLoop *eventLoop, int fd, int mask) {
+    aeApiState *state = eventLoop->apidata;
+
+    struct io_uring_sqe *sqe = io_uring_get_sqe(state->ring);
+    if (!sqe) return -1;
+    
+    int poll_mask = 0;
+    /* io_uring only support onshot epoll */
+    if (mask == AE_READABLE) poll_mask |= EPOLLIN;
+    if (mask == AE_WRITABLE) poll_mask |= EPOLLOUT;
+    io_uring_prep_poll_add(sqe, fd, poll_mask);
+    
+    uring_event *ev = &state->events[fd];
+    ev->fd = fd;
+    ev->type = mask;
+    io_uring_sqe_set_data(sqe, (void *)ev);
+    io_uring_submit(state->ring);
+    
+    return 0;
+}
+
+static void aeApiDelEvent(aeEventLoop *eventLoop, int fd, int delmask) {
+    (void)delmask;
+    aeApiState *state = eventLoop->apidata;
+
+    struct io_uring_sqe *sqe = io_uring_get_sqe(state->ring);
+    if (!sqe) exit(1);
+    
+    uring_event *ev = &state->events[fd];
+    io_uring_prep_poll_remove(sqe, (void *)ev);
+    io_uring_submit(state->ring);
+}
+
+static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
+    aeApiState *state = eventLoop->apidata;
+    int retval, numevents = 0;
+
+    /* TODO: handle timeout */
+    (void)tvp;
+    
+    struct io_uring_cqe *cqe;
+    retval = io_uring_wait_cqe(state->ring, &cqe);
+    if (retval < 0) {
+        return numevents;
+    }
+    
+    struct io_uring_cqe *cqes[BACKLOG];
+    int cqe_count = io_uring_peek_batch_cqe(state->ring, cqes, sizeof(cqes) / sizeof(cqes[0]));
+    
+    /* go through all the cqe's */
+    for (int i = 0; i < cqe_count; ++i) {
+        int mask = 0;
+        struct io_uring_cqe *cqe = cqes[i];
+        uring_event *ev = io_uring_cqe_get_data(cqe);
+        if (!ev) {
+            io_uring_cqe_seen(state->ring, cqe);
+            continue;
+        }
+    
+        if (cqe->res < 0) {
+            io_uring_cqe_seen(state->ring, cqe);
+            continue;
+        }
+        
+        if (cqe->res & EPOLLIN) mask |= AE_READABLE;
+        if (cqe->res & EPOLLOUT) mask |= AE_WRITABLE;
+        if (cqe->res & EPOLLERR) mask |= AE_WRITABLE|AE_READABLE;
+        if (cqe->res & EPOLLHUP) mask |= AE_WRITABLE|AE_READABLE;
+        eventLoop->fired[numevents].fd = ev->fd;
+        eventLoop->fired[numevents].mask = mask;
+        
+        io_uring_cqe_seen(state->ring, cqe);
+        numevents++;
+    }
+
+    return numevents;
+}
+
+static char *aeApiName(void) {
+    return "io_uring";
+}

--- a/src/ae_iouring.c
+++ b/src/ae_iouring.c
@@ -34,6 +34,7 @@
 
 #define BACKLOG 8192
 #define MAX_ENTRIES 16384 /* entries should be configured by users */
+#define ENABLE_SQPOLL 1
 
 static int register_files = 1;
 
@@ -67,6 +68,8 @@ static int aeApiCreate(aeEventLoop *eventLoop) {
     
     struct io_uring_params params;
     memset(&params, 0, sizeof(params));
+    if (eventLoop->extflags & ENABLE_SQPOLL)
+        params.flags |= IORING_SETUP_SQPOLL;
     state->urfd = io_uring_queue_init_params(MAX_ENTRIES, state->ring, &params);
     if (state->urfd == -1) {
         zfree(state->ring);

--- a/src/ae_iouring.c
+++ b/src/ae_iouring.c
@@ -128,7 +128,7 @@ static int aeApiAddEvent(aeEventLoop *eventLoop, int fd, int mask,
         unsigned int poll_mask = 0;
         if (mask == AE_READABLE) poll_mask |= EPOLLIN;
         if (mask == AE_WRITABLE) poll_mask |= EPOLLOUT;
-        io_uring_prep_poll_add(sqe, fd, EPOLLIN);
+        io_uring_prep_poll_add(sqe, fd, poll_mask);
     } else {
         if (mask & AE_READABLE)
             io_uring_prep_readv(sqe, fd, iovecs, 1, 0);

--- a/src/ae_iouring.c
+++ b/src/ae_iouring.c
@@ -124,6 +124,7 @@ static int aeApiAddEvent(aeEventLoop *eventLoop, int fd, int mask,
     ev->type = mask;
     if (!iovecs)
         ev->type |= AE_POLLABLE;
+
     io_uring_sqe_set_data(sqe, (void *)ev);
     io_uring_submit(state->ring);
     

--- a/src/config.c
+++ b/src/config.c
@@ -313,6 +313,10 @@ void resetServerSaveParams(void) {
     server.saveparamslen = 0;
 }
 
+void setServerSqpoll() {
+    server.sqpoll = 1;
+}
+
 void queueLoadModule(sds path, sds *argv, int argc) {
     int i;
     struct moduleLoadQueueEntry *loadmod;
@@ -639,6 +643,8 @@ void loadServerConfigFromString(char *config) {
                 }
                 queueSentinelConfig(argv+1,argc-1,linenum,lines[i]);
             }
+        } else if (!strcasecmp(argv[0], "sqpoll")) {
+            setServerSqpoll();
         } else {
             err = "Bad directive or wrong number of arguments"; goto loaderr;
         }

--- a/src/config.h
+++ b/src/config.h
@@ -79,6 +79,11 @@
 #define HAVE_EPOLL 1
 #endif
 
+/* Test for io uring API */
+#ifdef __linux__
+#define HAVE_IO_URING 1
+#endif
+
 /* Test for accept4() */
 #ifdef __linux__
 #define HAVE_ACCEPT4 1

--- a/src/connection.h
+++ b/src/connection.h
@@ -28,6 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "sds.h"
 #ifndef __REDIS_CONNECTION_H
 #define __REDIS_CONNECTION_H
 
@@ -80,6 +81,7 @@ struct connection {
     ConnectionCallbackFunc conn_handler;
     ConnectionCallbackFunc write_handler;
     ConnectionCallbackFunc read_handler;
+    int cqe_res;
     int fd;
 };
 
@@ -141,7 +143,7 @@ static inline int connWrite(connection *conn, const void *data, size_t data_len)
 }
 
 /* Read from the connection, behaves the same as read(2).
- * 
+ *
  * Like read(2), a short read is possible.  A return value of 0 will indicate the
  * connection was closed, and -1 will indicate an error.
  *

--- a/src/networking.c
+++ b/src/networking.c
@@ -1168,6 +1168,7 @@ void acceptTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
         serverLog(LL_VERBOSE,"Accepted %s:%d", cip, cport);
+        aeRegisterFile(el, cfd);
         acceptCommonHandler(connCreateAcceptedSocket(cfd),0,cip);
     }
 }
@@ -1195,6 +1196,7 @@ void acceptTLSHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
         serverLog(LL_VERBOSE,"Accepted %s:%d", cip, cport);
+        aeRegisterFile(el, cfd);
         acceptCommonHandler(connCreateAcceptedTLS(cfd, server.tls_auth_clients),0,cip);
     }
 }
@@ -1221,6 +1223,7 @@ void acceptUnixHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
         serverLog(LL_VERBOSE,"Accepted connection to %s", server.unixsocket);
+        aeRegisterFile(el, cfd);
         acceptCommonHandler(connCreateAcceptedSocket(cfd),CLIENT_UNIX_SOCKET,NULL);
     }
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -1142,6 +1142,13 @@ void acceptTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             if (errno != EWOULDBLOCK)
                 serverLog(LL_WARNING,
                     "Accepting client connection: %s", server.neterr);
+
+#ifdef HAVE_IO_URING
+            if (aeCreateFileEvent(el, fd, AE_READABLE, acceptTcpHandler, NULL) == AE_ERR) {
+                serverPanic("Unrecoverable error creating server.ipfd file event.");
+            }
+#endif
+
             return;
         }
         serverLog(LL_VERBOSE,"Accepted %s:%d", cip, cport);
@@ -1162,6 +1169,13 @@ void acceptTLSHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             if (errno != EWOULDBLOCK)
                 serverLog(LL_WARNING,
                     "Accepting client connection: %s", server.neterr);
+
+#ifdef HAVE_IO_URING
+            if (aeCreateFileEvent(el, fd, AE_READABLE, acceptTcpHandler, NULL) == AE_ERR) {
+                serverPanic("Unrecoverable error creating server.ipfd file event.");
+            }
+#endif
+
             return;
         }
         serverLog(LL_VERBOSE,"Accepted %s:%d", cip, cport);
@@ -1181,6 +1195,13 @@ void acceptUnixHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             if (errno != EWOULDBLOCK)
                 serverLog(LL_WARNING,
                     "Accepting client connection: %s", server.neterr);
+
+#ifdef HAVE_IO_URING
+            if (aeCreateFileEvent(el, fd, AE_READABLE, acceptTcpHandler, NULL) == AE_ERR) {
+                serverPanic("Unrecoverable error creating server.ipfd file event.");
+            }
+#endif
+
             return;
         }
         serverLog(LL_VERBOSE,"Accepted connection to %s", server.unixsocket);
@@ -2225,6 +2246,14 @@ void readQueryFromClient(connection *conn) {
     /* There is more data in the client input buffer, continue parsing it
      * in case to check if there is a full command to execute. */
      processInputBuffer(c);
+
+     if (c->flags & CLIENT_CLOSE_AFTER_REPLY) return;
+
+#ifdef HAVE_IO_URING
+     if (aeCreateFileEvent(server.el, conn->fd, AE_READABLE, conn->type->ae_handler, conn) == AE_ERR) {
+         serverPanic("Unrecoverable error creating conn.fd file event.");
+     }
+#endif
 }
 
 /* A Redis "Address String" is a colon separated ip:port pair.

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -710,6 +710,7 @@ static client createClient(char *cmd, size_t len, client from, int thread_id) {
             exit(1);
         }
     }
+    aeRegisterFile(config.el, c->context->fd);
     c->thread_id = thread_id;
     /* Suppress hiredis cleanup of unused buffers for max speed. */
     c->context->reader->maxbuf = 0;

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1020,7 +1020,7 @@ static benchmarkThread *createBenchmarkThread(int index) {
     benchmarkThread *thread = zmalloc(sizeof(*thread));
     if (thread == NULL) return NULL;
     thread->index = index;
-    thread->el = aeCreateEventLoop(1024*10);
+    thread->el = aeCreateEventLoop(1024*10, 0);
     aeCreateTimeEvent(thread->el,1,showThroughput,(void *)thread,NULL);
     return thread;
 }
@@ -1709,7 +1709,7 @@ int main(int argc, char **argv) {
     config.numclients = 50;
     config.requests = 100000;
     config.liveclients = 0;
-    config.el = aeCreateEventLoop(1024*10);
+    config.el = aeCreateEventLoop(1024*10, 0);
     aeCreateTimeEvent(config.el,1,showThroughput,NULL,NULL);
     config.keepalive = 1;
     config.datasize = 3;

--- a/src/server.c
+++ b/src/server.c
@@ -3035,6 +3035,7 @@ int createSocketAcceptHandler(socketFds *sfd, aeFileProc *accept_handler) {
     int j;
 
     for (j = 0; j < sfd->count; j++) {
+        aeRegisterFile(server.el, sfd->fd[j]);
         if (aeCreateFileEvent(server.el, sfd->fd[j], AE_READABLE, accept_handler,NULL) == AE_ERR) {
             /* Rollback */
             for (j = j-1; j >= 0; j--) aeDeleteFileEvent(server.el, sfd->fd[j], AE_READABLE);
@@ -3341,6 +3342,7 @@ void initServer(void) {
 
     /* Register a readable event for the pipe used to awake the event loop
      * when a blocked client in a module needs attention. */
+    aeRegisterFile(server.el, server.module_blocked_pipe[0]);
     if (aeCreateFileEvent(server.el, server.module_blocked_pipe[0], AE_READABLE,
         moduleBlockedClientPipeReadable,NULL) == AE_ERR) {
             serverPanic(

--- a/src/server.c
+++ b/src/server.c
@@ -1688,7 +1688,7 @@ int clientsCronResizeQueryBuffer(client *c) {
 
     /* Only resize the query buffer if the buffer is actually wasting at least a
      * few kbytes */
-    if (sdsavail(c->querybuf) > 1024*4) {
+    if (sdsavail(c->querybuf) > 1024*4 && !c->submitted_query) {
         /* There are two conditions to resize the query buffer: */
         if (idletime > 2) {
             /* 1) Query is idle for a long time. */

--- a/src/server.h
+++ b/src/server.h
@@ -908,6 +908,9 @@ typedef struct client {
     redisDb *db;            /* Pointer to currently SELECTed DB. */
     robj *name;             /* As set by CLIENT SETNAME. */
     sds querybuf;           /* Buffer we use to accumulate client queries. */
+    struct iovec riov;
+    int submitted_query;
+    size_t qblen;
     size_t qb_pos;          /* The position we have read in querybuf. */
     sds pending_querybuf;   /* If this client is flagged as master, this buffer
                                represents the yet not applied portion of the
@@ -1876,6 +1879,9 @@ void acceptTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void acceptTLSHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void acceptUnixHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void readQueryFromClient(connection *conn);
+#if defined(HAVE_IO_URING)
+void readDoneFromClient(connection *conn);
+#endif
 void addReplyNull(client *c);
 void addReplyNullArray(client *c);
 void addReplyBool(client *c, int b);

--- a/src/server.h
+++ b/src/server.h
@@ -1675,6 +1675,7 @@ struct redisServer {
     char *bio_cpulist; /* cpu affinity list of bio thread. */
     char *aof_rewrite_cpulist; /* cpu affinity list of aof rewrite process. */
     char *bgsave_cpulist; /* cpu affinity list of bgsave process. */
+    int sqpoll;
     /* Sentinel config */
     struct sentinelConfig *sentinel_config; /* sentinel config to load at startup time. */
     /* Coordinate failover info */

--- a/src/server.h
+++ b/src/server.h
@@ -909,6 +909,7 @@ typedef struct client {
     robj *name;             /* As set by CLIENT SETNAME. */
     sds querybuf;           /* Buffer we use to accumulate client queries. */
     struct iovec riov;
+    struct iovec wiov;
     int submitted_query;
     size_t qblen;
     size_t qb_pos;          /* The position we have read in querybuf. */
@@ -933,6 +934,7 @@ typedef struct client {
     unsigned long long reply_bytes; /* Tot bytes of objects in reply list. */
     size_t sentlen;         /* Amount of bytes already sent in the current
                                buffer or object being sent. */
+    size_t totwritten;
     time_t ctime;           /* Client creation time. */
     long duration;          /* Current command duration. Used for measuring latency of blocking/non-blocking cmds */
     time_t lastinteraction; /* Time of the last interaction, used for timeout */
@@ -1881,6 +1883,7 @@ void acceptUnixHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void readQueryFromClient(connection *conn);
 #if defined(HAVE_IO_URING)
 void readDoneFromClient(connection *conn);
+void writeDoneToClient(connection *conn);
 #endif
 void addReplyNull(client *c);
 void addReplyNullArray(client *c);


### PR DESCRIPTION
`io_uring` is a powerful new asynchronous I/O API for Linux by Jens Axboe from Facebook. And it has been added to Linux kernel since 5.1 version. For more details about `io_uring`, we can see [Lord of the io_uring](https://unixism.net/loti/#).

This work is a **POC**(Proof of Concept) cooperated by *Alibaba team of Anolis community* and *Uniontech Software Technology Co., Ltd*. We have experimentally added io_uring support to redis and gotten good performance improvement in testes.  If this work can be approved by the community, we will proceed.

**Test Environment**

- *System*: [Anolis 8.4](https://mirrors.openanolis.cn/anolis/8.4/) [An OS benchmarked to Centos 8]
- *Kernel*: Linux 4.19 + [patch of io_uring](https://codeup.openanolis.cn/codeup/storage/liburing/tree/master/)
- *Kernel Configuration*: use default setting of CPU mitigations, no disable mitigations. But in this CPU, some vulnerabilities is not affected. For more details:
```bash
# cat /sys/devices/system/cpu/vulnerabilities/meltdown 
Not affected
# cat /sys/devices/system/cpu/vulnerabilities/tsx_async_abort
Not affected
# cat /sys/devices/system/cpu/vulnerabilities/spectre_v2
Mitigation: Full AMD retpoline, IBPB: conditional, STIBP: disabled, RSB filling
```
- *Server Model*: Hygon C86 7280
- *CPU*: Hygon C86 7285 32-core Processor * 2
```bash
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
CPU(s):              128
On-line CPU(s) list: 0-127
Thread(s) per core:  2
Core(s) per socket:  32
Socket(s):           2
NUMA node(s):        8
Vendor ID:           HygonGenuine
CPU family:          24
Model:               1
Model name:          Hygon C86 7285 32-core Processor
Stepping:            1
CPU MHz:             2486.209
CPU max MHz:         2000.0000              
CPU min MHz:         1200.0000
BogoMIPS:            4000.20
Virtualization:      AMD-V
L1d cache:           32K          L1i cache:           64K
L2 cache:            512K         L3 cache:            8192K
NUMA node0 CPU(s):   0-7,64-71        NUMA node1 CPU(s):   8-15,72-79
NUMA node2 CPU(s):   16-23,80-87      NUMA node3 CPU(s):   24-31,88-95
NUMA node4 CPU(s):   32-39,96-103     NUMA node5 CPU(s):   40-47,104-111
NUMA node6 CPU(s):   48-55,112-119    NUMA node7 CPU(s):   56-63,120-127
Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid amd_dcm aperfmperf pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb hw_pstate sme ssbd sev ibpb vmmcall fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 xsaves clzero irperf xsaveerptr arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif overflow_recov succor smca
```

**Test Data**

Please see the table below to get the data of performance improvement. And we also published it in [Anolis Chinese Web](https://openanolis.cn/sig/high-perf-storage/doc/218937424285597744).

RPS(request per second) | PING_INLINE | PING_BULK | SET | GET | INCR | LPUSH | RPUSH | LPOP | RPOP | SADD | HSET | SPOP | LPUSH(needed to benchmark LRANGE) | LRANGE_100 | LRANGE_300 | LRANGE_500 | LRANGE_600 | MSET (10 keys)
-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-
*redis_origin*|55493.90|55224.21|55540.44|55549.07|55652.95|56640.22|56493.03|56379.64|56280.96|55788.94|56218.62|55697.90|56774.31|33953.20|15290.75|12066.89|9730.44|57729.39
*redis_add_uring + close_sqpoll*|73336.37|72344.24|72844.88|73514.27|73542.93|72688.68|73133.63|73871.06|72998.56|72183.41|72502.65|73361.65|72535.25|43849.07|18304.73|13540.14|10733.82|61616.95
*redis_add_uring + open_sqpoll*|86625.09|84141.09|86079.27|84939.39|85744.91|84075.30|85814.08|85478.12|85657.51|85462.05|85095.52|84509.42|84403.15|51821.53|18953.36|14276.23|11673.47|83557.55
*improvement of close_sqpoll*|32.15%|31.00%|31.16%|32.34%|32.15%|28.33%|29.46%|31.02%|29.70%|29.39%|28.97%|31.71%|27.76%|29.15%|19.71%|12.21%|10.31%|6.73%
*improvement of open_sqpoll*|56.10%|52.36%|54.98%|52.91%|54.07%|48.44%|51.90%|51.61%|52.20%|53.19%|51.37%|51.73%|48.66%|52.63%|23.95%|18.31%|19.97%|44.74%

**Test Command**

*Test Tool*: redis-benchmark
We ran the benchmark and the redis-server on the same server. And both redis-server and redis-benchmark are bound fixed CPU cores.
```shell
## didn't open SQ polling
taskset -c 24-28 redis-server
taskset -c 30 redis-benchmark -c 500 -n 10000000 -q

## open SQ polling
taskset -c 24-28 redis-server --sqpoll
# query pid of sq, and bind it to cpu
ps -ef|grep io_uring-sq  
taskset -pc 29 {sq_pid}
taskset -c 30 redis-benchmark -c 500 -n 10000000 -q
```
```
Notes:
    The sq process and the redis-server process should be bound to the CPU 
cores of the same numa node if the compute uses numa(non-uniform memory access).
```

Looking forward to your comments, best wishes to you.
Related-Issue: #9441 