### PR TITLE
New Cluster Command: CLUSTER DELSLOTSRANGE and CLUSTER ADDSLOTSRANGE

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4416,7 +4416,8 @@ int getSlotStatus(client *c, unsigned char *slots, int del, int start_slot, int 
         if (del && server.cluster->slots[slot] == NULL) {
             addReplyErrorFormat(c,"Slot %d is already unassigned", slot);
             return C_ERR;
-        } else if (!del && server.cluster->slots[slot]) {
+        } 
+        if (!del && server.cluster->slots[slot]) {
             addReplyErrorFormat(c,"Slot %d is already busy", slot);
             return C_ERR;
         }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4419,7 +4419,7 @@ int getSlotStatus(client *c, unsigned char *slots, int del, int start_slot, int 
         } 
         if (!del && server.cluster->slots[slot]) {
             addReplyErrorFormat(c,"Slot %d is already busy", slot);
-            return C_ERR;
+            return C_ERR; 
         }
         if (slots[slot]++ == 1) {
             addReplyErrorFormat(c,"Slot %d specified multiple times",(int)slot);


### PR DESCRIPTION
Now, in the cluster mode. By using command CLUSTER DELSLOTS slot [slot ...] and command CLUSTER ADDSLOTS slot [slot ...]
user can only assign or forget discrete slot for a cluster node instead of a slot range.

Foe example, if user want to assign 1--5000 slot to a cluster node, user has only 2 choices:
option 1: run command CLUSTER ADDSLOTS 1 2 3 .... 4999 5000
option 2: assign these slot by bash shell command
redis-cli -h 127.0.0.1 -p 6379 cluster addslots {0...5000}

I would like to add 2 new commands:

CLUSTER DELSLOTSRANGE startslot endslot [startslot endslot...]
CLUSTER ADDSLOTSRANGE startslot endslot [startslot endslot...]

Thus, if I would like to assign 1 -- 5000 slot to current cluster node, user only need to run command:

cluster addslotsrange 1 5000