### PR TITLE
Use fchmod to update command history file.

### DIFF
--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -103,6 +103,7 @@
  *
  */
 
+#define _BSD_SOURCE     /* For fchmod() */
 #include <termios.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -1194,7 +1195,7 @@ int linenoiseHistorySave(const char *filename) {
     fp = fopen(filename,"w");
     umask(old_umask);
     if (fp == NULL) return -1;
-    chmod(filename,S_IRUSR|S_IWUSR);
+    fchmod(fileno(fp),S_IRUSR|S_IWUSR);
     for (j = 0; j < history_len; j++)
         fprintf(fp,"%s\n",history[j]);
     fclose(fp);


### PR DESCRIPTION
This is considered a safer approach as it prevents a race condition that
could lead to chmod executed on a different file.

Not a major risk, but CodeQL alerted this so it makes sense to fix.