### PR TITLE
[lua] Use all characters to calculate string hash

### DIFF
--- a/deps/lua/src/lstring.c
+++ b/deps/lua/src/lstring.c
@@ -75,7 +75,7 @@ static TString *newlstr (lua_State *L, const char *str, size_t l,
 TString *luaS_newlstr (lua_State *L, const char *str, size_t l) {
   GCObject *o;
   unsigned int h = cast(unsigned int, l);  /* seed */
-  size_t step = (l>>5)+1;  /* if string is too long, don't hash all its chars */
+  size_t step = 1;
   size_t l1;
   for (l1=l; l1>=step; l1-=step)  /* compute hash */
     h = h ^ ((h<<5)+(h>>2)+cast(unsigned char, str[l1-1]));


### PR DESCRIPTION
For a lot of long strings which have same prefix which extends beyond
hashing limit, there will be many hash collisions which result in
performance degradation using commands like KEYS

Addresses https://github.com/redis/redis/issues/8077