### PR TITLE
Optimize quicklistIndex to seek from the nearest end

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -1244,17 +1244,17 @@ int quicklistIndex(const quicklist *quicklist, const long long idx,
     initEntry(entry);
     entry->quicklist = quicklist;
 
-    if (!forward) {
-        index = (-idx) - 1;
-        n = quicklist->tail;
-    } else {
-        index = idx;
-        n = quicklist->head;
-    }
-
+    index = forward ? idx : (-idx) - 1;
     if (index >= quicklist->count)
         return 0;
 
+    /* Change direction if the other way is shorter. */
+    if (index > (quicklist->count - 1) / 2) {
+        forward = !forward;
+        index = quicklist->count - 1 - index;
+    }
+
+    n = forward ? quicklist->head : quicklist->tail;
     while (likely(n)) {
         if ((accum + n->count) > index) {
             break;

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -405,7 +405,7 @@ void addListRangeReply(client *c, robj *o, long start, long end, int reverse) {
 
         while(rangelen--) {
             listTypeEntry entry;
-            listTypeNext(iter, &entry);
+            serverAssert(listTypeNext(iter, &entry)); /* fail on corrupt data */
             quicklistEntry *qe = &entry.entry;
             if (qe->value) {
                 addReplyBulkCBuffer(c,qe->value,qe->sz);

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -82,7 +82,7 @@ test {corrupt payload: valid zipped hash header, dup records} {
 test {corrupt payload: quicklist big ziplist prev len} {
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
         r config set sanitize-dump-payload no
-        r restore key 0 "\x0E\x01\x13\x13\x00\x00\x00\x0E\x00\x00\x00\x02\x00\x00\x02\x61\x00\x0E\x02\x62\x00\xFF\x09\x00\x49\x97\x30\xB2\x0D\xA1\xED\xAA"
+        r restore key 0 "\x0e\x01\x1b\x1b\x00\x00\x00\x16\x00\x00\x00\x04\x00\x00\x02\x61\x00\x04\x02\x62\x00\x04\x02\x63\x00\x19\x02\x64\x00\xff\x09\x00\xec\x42\xe9\xf5\xd6\x19\x9e\xbd"
         catch {r lindex key -2}
         assert_equal [count_log_message 0 "crashed by signal"] 0
         assert_equal [count_log_message 0 "ASSERTION FAILED"] 1
@@ -107,7 +107,7 @@ test {corrupt payload: quicklist ziplist wrong count} {
         # we'll be able to push, but iterating on the list will assert
         r lpush key header
         r rpush key footer
-        catch { [r lrange key -1 -1] }
+        catch { [r lrange key 0 -1] }
         assert_equal [count_log_message 0 "crashed by signal"] 0
         assert_equal [count_log_message 0 "ASSERTION FAILED"] 1
     }


### PR DESCRIPTION
Until now, giving a negative index seeks from the end of a list and a
positive seeks from the beginning. This change makes it seek from the
nearest end, regardless of the sign of the given index.

quicklistIndex is used by all list commands which operate by index.

LINDEX key 999999 in a list if 1M elements is greately optimized by
this change. Latency is cut by 75%.

LINDEX key -1000000 in a list of 1M elements, likewise.

LRANGE key -1 -1 is affected by this, since LRANGE converts the indices
to positive numbers before seeking.

The tests for corrupt dumps are updated to make sure the corrupt data
is seeked in the same direction as before.