### PR TITLE
Fix two minor bugs (MIGRATE key args and getKeysUsingCommandTable)

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1627,7 +1627,6 @@ int getKeysUsingCommandTable(struct redisCommand *cmd,robj **argv, int argc, get
              * return no keys and expect the command implementation to report
              * an arity or syntax error. */
             if (cmd->flags & CMD_MODULE || cmd->arity < 0) {
-                getKeysFreeResult(result);
                 result->numkeys = 0;
                 return 0;
             } else {

--- a/src/server.c
+++ b/src/server.c
@@ -891,7 +891,7 @@ struct redisCommand redisCommandTable[] = {
 
     {"migrate",migrateCommand,-6,
      "write random @keyspace @dangerous",
-     0,migrateGetKeys,0,0,0,0,0,0},
+     0,migrateGetKeys,3,3,1,0,0,0},
 
     {"asking",askingCommand,1,
      "fast @connection",


### PR DESCRIPTION
1. MIGRATE has a potnetial key arg in argv[3]. It should be reflected in the command table.
2. getKeysUsingCommandTable should never free getKeysResult, it is always freed by the caller.
   The reason we never encountered this double-free bug is that almost always getKeysResult
   uses the static buffer and doesn't allocate a new one.