### PR TITLE
Remove redundancy barrier mechanism in ae.c

### DIFF
--- a/src/ae.h
+++ b/src/ae.h
@@ -41,11 +41,6 @@
 #define AE_NONE 0       /* No events registered. */
 #define AE_READABLE 1   /* Fire when descriptor is readable. */
 #define AE_WRITABLE 2   /* Fire when descriptor is writable. */
-#define AE_BARRIER 4    /* With WRITABLE, never fire the event if the
-                           READABLE event already fired in the same event
-                           loop iteration. Useful when you want to persist
-                           things to disk before sending replies, and want
-                           to do that in a group fashion. */
 
 #define AE_FILE_EVENTS (1<<0)
 #define AE_TIME_EVENTS (1<<1)


### PR DESCRIPTION
In #6236 barrier mechanism has been moved to connection.c.
Also remove `AE_BARRIER` which is no longer in use.