### PR TITLE
Fix client pause timeout after failover

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3320,16 +3320,14 @@ void flushSlavesOutputBuffers(void) {
  * failover procedure implemented by CLUSTER FAILOVER.
  *
  * The function always succeed, even if there is already a pause in progress.
- * In such a case, the duration is set to the maximum and new end time and the
- * type is set to the more restrictive type of pause. */
+ * In such a case, the duration is set to the new time and the new type is
+ * set to the more restrictive type of pause. */
 void pauseClients(mstime_t end, pause_type type) {
     if (type > server.client_pause_type) {
         server.client_pause_type = type;
     }
 
-    if (end > server.client_pause_end_time) {
-        server.client_pause_end_time = end;
-    }
+    server.client_pause_end_time = end;
 
     /* We allow write commands that were queued
      * up before and after to execute. We need

--- a/tests/integration/pause.tcl
+++ b/tests/integration/pause.tcl
@@ -1,0 +1,44 @@
+start_server {tags {"pause external:skip"}} {
+start_server {} {
+    set node_0 [srv 0 client]
+    set node_0_host [srv 0 host]
+    set node_0_port [srv 0 port]
+    set node_0_pid [srv 0 pid]
+
+    set node_1 [srv -1 client]
+    set node_1_host [srv -1 host]
+    set node_1_port [srv -1 port]
+    set node_1_pid [srv -1 pid]
+
+    proc assert_digests_match {n1 n2} {
+        assert_equal [$n1 debug digest] [$n2 debug digest]
+    }
+
+    test {pause client after failover until timeout} {
+        $node_1 replicaof $node_0_host $node_0_port
+        wait_for_sync $node_1
+
+        # Wait for failover to end
+        $node_0 failover to $node_1_host $node_1_port
+        wait_for_condition 50 100 {
+            [s 0 master_failover_state] == "no-failover"
+        } else {
+            fail "Failover from node_0 to node_1 did not finish"
+        }
+        $node_1 failover to $node_0_host $node_0_port
+        wait_for_condition 50 100 {
+            [s -1 master_failover_state] == "no-failover"
+        } else {
+            fail "Failover from node_1 to node_0 did not finish"
+        }
+
+        # Write commands are paused after failover until timeout
+        $node_0 client pause 500 write
+        set rd [redis_deferring_client 0]
+        $rd set a 1
+        wait_for_blocked_clients_count 0 10 100
+        assert_match [$rd read] "OK"
+        $rd close
+    }
+}
+}

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -54,6 +54,7 @@ set ::all_tests {
     integration/psync2-reg
     integration/psync2-pingoff
     integration/failover
+    integration/pause
     integration/redis-cli
     integration/redis-benchmark
     integration/dismiss-mem


### PR DESCRIPTION
Hello, I feel the `FAILOVER` and `CLIENT PAUSE/UNPAUSE` may conflict in some scenarios, here are some of my thoughts, please correct me～

# Problem

- **Topo**: master(A) and replica(B)
- **Way**: 
    1. A: FAILOVER TO B_IP B_PORT (B is new master)
    2. B: FAILOVER TO A_IP A_PORT(A is new master)
    3. A: CLIENT PAUSE 1000 WRITE(**A will block all write commands until timeout, but it didn't end until the timeout was reached**)
- **Another way**:
     1. A: CLIENT PAUSE 1000000 WRITE (blocking for 1000s)
     2. A: CLIENT UNPAUSE
     3.  A: CLIENT PAUSE 1000 WRITE(**A will block all write commands until timeout, but it didn't end until the timeout was reached, it may block for about 1000s**)

- **Try fix**:
```c
void pauseClients(mstime_t end, pause_type type) {
    if (type > server.client_pause_type) {
        server.client_pause_type = type;
    }

    // Old
    if (end > server.client_pause_end_time) {
        server.client_pause_end_time = end;
    }

    // New
    server.client_pause_end_time = end;

    ...
}
```

# Thinking

Both `FAILOVER` and `CLIENT PAUSE/UNPAUSE` use `pauseClients` and `unpauseClients` functions to implement block client logic:

- FAILOVER
    - start: set `server.client_pause_end_time` to `LLONG_MAX` by `pauseClients` function, but we use `server.failover_end_time` to stop failover (try keep pauseClient simple?)
    - stop: clean failover meta data, but `server.client_pause_end_time` always a maximum
- CLINET PAUSE/UNPAUSE
    - pause: can't update `server.client_pause_end_time` after failover
    - unpause: not reset `server.client_pause_end_time` to zero

Another question is, why should we limit the value of `server.client_pause_end_time` to a larger value?

English is not my native language; please excuse typing errors.

Hope to get a reply~