### PR TITLE
Add stdlib.h for RedisModule_Assert

### DIFF
--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -4,6 +4,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 /* ---------------- Defines common between core and modules --------------- */
 


### PR DESCRIPTION
I think `redismodule.h` needs to include necessary header files for `RedisModule_Assert`, such as stdlib.h where `exit` is located, otherwise a compilation warning or error will be generated（If the module itself does not include this header file）.


on linux:
```
note: include ‘<stdlib.h>’ or provide a declaration of ‘exit’
 #define RedisModule_Assert(_e) ((_e)?(void)0 : (RedisModule__Assert(#_e,__FILE__,__LINE__),exit(1)))
```

on macos:
```
error: implicitly declaring library function 'exit' with type 'void (int) __attribute__((noreturn))' [-Werror,-Wimplicit-function-declaration]
```