### PR TITLE
Add make test-cluster option

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -392,6 +392,9 @@ test-modules: $(REDIS_SERVER_NAME)
 test-sentinel: $(REDIS_SENTINEL_NAME) $(REDIS_CLI_NAME)
 	@(cd ..; ./runtest-sentinel)
 
+test-cluster: $(REDIS_SERVER_NAME) $(REDIS_CLI_NAME)
+        @(cd ..; ./runtest-cluster)
+
 check: test
 
 lcov:

--- a/src/Makefile
+++ b/src/Makefile
@@ -393,7 +393,7 @@ test-sentinel: $(REDIS_SENTINEL_NAME) $(REDIS_CLI_NAME)
 	@(cd ..; ./runtest-sentinel)
 
 test-cluster: $(REDIS_SERVER_NAME) $(REDIS_CLI_NAME)
-        @(cd ..; ./runtest-cluster)
+	@(cd ..; ./runtest-cluster)
 
 check: test
 


### PR DESCRIPTION
Then can run 'make test-cluster' like 'make test-sentinel'.