### PR TITLE
Add ZMPOP/BZMPOP commands.

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -322,7 +322,7 @@ void serveClientsBlockedOnSortedSetKey(robj *o, readyList *rl) {
         int numclients = listLength(clients);
         int deleted = 0;
 
-        while(numclients--) {
+        while (numclients--) {
             listNode *clientnode = listFirst(clients);
             client *receiver = clientnode->value;
 
@@ -336,13 +336,13 @@ void serveClientsBlockedOnSortedSetKey(robj *o, readyList *rl) {
             long llen = zsetLength(o);
             long count = receiver->bpop.count;
             int where = receiver->bpop.blockpos.wherefrom;
-            int use_nested_array_with_key = (receiver->lastcmd &&
-                                             receiver->lastcmd->proc == bzmpopCommand)
-                                             ? 1 : 0;
+            int use_nested_array = (receiver->lastcmd &&
+                                    receiver->lastcmd->proc == bzmpopCommand)
+                                    ? 1 : 0;
 
             monotime replyTimer;
             elapsedStart(&replyTimer);
-            genericZpopCommand(receiver,&rl->key,1,where,1,count,use_nested_array_with_key,&deleted);
+            genericZpopCommand(receiver, &rl->key, 1, where, 1, count, use_nested_array, &deleted);
             updateStatsOnUnblock(receiver, 0, elapsedUs(replyTimer));
             unblockClient(receiver);
 
@@ -354,13 +354,13 @@ void serveClientsBlockedOnSortedSetKey(robj *o, readyList *rl) {
                                        server.zpopmaxCommand;
             argv[0] = createStringObject(cmd->name,strlen(cmd->name));
             argv[1] = rl->key;
+            incrRefCount(rl->key);
             if (count != 0) {
                 /* Replicate it as command with COUNT. */
                 robj *count_obj = createStringObjectFromLongLong((count > llen) ? llen : count);
                 argv[2] = count_obj;
                 argc++;
             }
-            incrRefCount(rl->key);
             propagate(cmd,receiver->db->id,
                       argv,argc,PROPAGATE_AOF|PROPAGATE_REPL);
             decrRefCount(argv[0]);

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -339,10 +339,11 @@ void serveClientsBlockedOnSortedSetKey(robj *o, readyList *rl) {
             int use_nested_array = (receiver->lastcmd &&
                                     receiver->lastcmd->proc == bzmpopCommand)
                                     ? 1 : 0;
+            int reply_nil_when_empty = use_nested_array;
 
             monotime replyTimer;
             elapsedStart(&replyTimer);
-            genericZpopCommand(receiver, &rl->key, 1, where, 1, count, use_nested_array, &deleted);
+            genericZpopCommand(receiver, &rl->key, 1, where, 1, count, use_nested_array, reply_nil_when_empty, &deleted);
             updateStatsOnUnblock(receiver, 0, elapsedUs(replyTimer));
             unblockClient(receiver);
 

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -285,8 +285,8 @@ void serveClientsBlockedOnListKey(robj *o, readyList *rl) {
             }
 
             robj *dstkey = receiver->bpop.target;
-            int wherefrom = receiver->bpop.listpos.wherefrom;
-            int whereto = receiver->bpop.listpos.whereto;
+            int wherefrom = receiver->bpop.blockpos.wherefrom;
+            int whereto = receiver->bpop.blockpos.whereto;
 
             /* Protect receiver->bpop.target, that will be
              * freed by the next unblockClient()
@@ -320,9 +320,9 @@ void serveClientsBlockedOnSortedSetKey(robj *o, readyList *rl) {
     if (de) {
         list *clients = dictGetVal(de);
         int numclients = listLength(clients);
-        unsigned long zcard = zsetLength(o);
+        int deleted = 0;
 
-        while(numclients-- && zcard) {
+        while(numclients--) {
             listNode *clientnode = listFirst(clients);
             client *receiver = clientnode->value;
 
@@ -333,28 +333,42 @@ void serveClientsBlockedOnSortedSetKey(robj *o, readyList *rl) {
                 continue;
             }
 
-            int where = (receiver->lastcmd &&
-                         receiver->lastcmd->proc == bzpopminCommand)
-                         ? ZSET_MIN : ZSET_MAX;
+            long llen = zsetLength(o);
+            long count = receiver->bpop.count;
+            int where = receiver->bpop.blockpos.wherefrom;
+            int use_nested_array_with_key = (receiver->lastcmd &&
+                                             receiver->lastcmd->proc == bzmpopCommand)
+                                             ? 1 : 0;
+
             monotime replyTimer;
             elapsedStart(&replyTimer);
-            genericZpopCommand(receiver,&rl->key,1,where,1,NULL);
+            genericZpopCommand(receiver,&rl->key,1,where,1,count,use_nested_array_with_key,&deleted);
             updateStatsOnUnblock(receiver, 0, elapsedUs(replyTimer));
             unblockClient(receiver);
-            zcard--;
 
             /* Replicate the command. */
-            robj *argv[2];
+            int argc = 2;
+            robj *argv[3];
             struct redisCommand *cmd = where == ZSET_MIN ?
                                        server.zpopminCommand :
                                        server.zpopmaxCommand;
             argv[0] = createStringObject(cmd->name,strlen(cmd->name));
             argv[1] = rl->key;
+            if (count != 0) {
+                /* Replicate it as command with COUNT. */
+                robj *count_obj = createStringObjectFromLongLong((count > llen) ? llen : count);
+                argv[2] = count_obj;
+                argc++;
+            }
             incrRefCount(rl->key);
             propagate(cmd,receiver->db->id,
-                      argv,2,PROPAGATE_AOF|PROPAGATE_REPL);
+                      argv,argc,PROPAGATE_AOF|PROPAGATE_REPL);
             decrRefCount(argv[0]);
             decrRefCount(argv[1]);
+            if (count != 0) decrRefCount(argv[2]);
+
+            /* The zset is empty and has been deleted. */
+            if (deleted) break;
         }
     }
 }
@@ -618,7 +632,7 @@ void handleClientsBlockedOnKeys(void) {
  *
  * 'count' for those commands that support the optional count argument.
  * Otherwise the value is 0. */
-void blockForKeys(client *c, int btype, robj **keys, int numkeys, long count, mstime_t timeout, robj *target, struct listPos *listpos, streamID *ids) {
+void blockForKeys(client *c, int btype, robj **keys, int numkeys, long count, mstime_t timeout, robj *target, struct blockPos *blockpos, streamID *ids) {
     dictEntry *de;
     list *l;
     int j;
@@ -627,7 +641,7 @@ void blockForKeys(client *c, int btype, robj **keys, int numkeys, long count, ms
     c->bpop.timeout = timeout;
     c->bpop.target = target;
 
-    if (listpos != NULL) c->bpop.listpos = *listpos;
+    if (blockpos != NULL) c->bpop.blockpos = *blockpos;
 
     if (target != NULL) incrRefCount(target);
 

--- a/src/db.c
+++ b/src/db.c
@@ -1699,7 +1699,6 @@ int blmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult
     return genericGetKeys(0, 2, 3, 1, argv, argc, result);
 }
 
-/* todo similar to [b]lmpopGetKeys, it can be shared after being renamed? */
 int zmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
     UNUSED(cmd);
     return genericGetKeys(0, 1, 2, 1, argv, argc, result);

--- a/src/db.c
+++ b/src/db.c
@@ -1699,6 +1699,17 @@ int blmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult
     return genericGetKeys(0, 2, 3, 1, argv, argc, result);
 }
 
+/* todo similar to [b]lmpopGetKeys, it can be shared after being renamed? */
+int zmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
+    UNUSED(cmd);
+    return genericGetKeys(0, 1, 2, 1, argv, argc, result);
+}
+
+int bzmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
+    UNUSED(cmd);
+    return genericGetKeys(0, 2, 3, 1, argv, argc, result);
+}
+
 /* Helper function to extract keys from the SORT command.
  *
  * SORT <sort-key> ... STORE <store-key> ...

--- a/src/server.c
+++ b/src/server.c
@@ -564,6 +564,10 @@ struct redisCommand redisCommandTable[] = {
      "write fast @sortedset",
      0,NULL,1,1,1,0,0,0},
 
+    {"zmpop", zmpopCommand,-4,
+     "write @sortedset",
+     0,zmpopGetKeys,0,0,0,0,0,0},
+
     {"bzpopmin",bzpopminCommand,-3,
      "write no-script fast @sortedset @blocking",
      0,NULL,1,-2,1,0,0,0},
@@ -571,6 +575,10 @@ struct redisCommand redisCommandTable[] = {
     {"bzpopmax",bzpopmaxCommand,-3,
      "write no-script fast @sortedset @blocking",
      0,NULL,1,-2,1,0,0,0},
+
+    {"bzmpop",bzmpopCommand,-5,
+     "write @sortedset @blocking",
+     0,bzmpopGetKeys,0,0,0,0,0,0},
 
     {"zrandmember",zrandmemberCommand,-2,
      "read-only random @sortedset",

--- a/src/server.c
+++ b/src/server.c
@@ -794,7 +794,10 @@ struct redisCommand redisCommandTable[] = {
 
     {"zmpop", zmpopCommand,-4,
      "write @sortedset",
-     0,zmpopGetKeys,0,0,0,0,0,0},
+     {{"write",
+       KSPEC_BS_INDEX,.bs.index={1},
+       KSPEC_FK_KEYNUM,.fk.keynum={0,1,1}}},
+     zmpopGetKeys},
 
     {"bzpopmin",bzpopminCommand,-3,
      "write no-script fast @sortedset @blocking",
@@ -810,7 +813,10 @@ struct redisCommand redisCommandTable[] = {
 
     {"bzmpop",bzmpopCommand,-5,
      "write @sortedset @blocking",
-     0,bzmpopGetKeys,0,0,0,0,0,0},
+     {{"write",
+       KSPEC_BS_INDEX,.bs.index={2},
+       KSPEC_FK_KEYNUM,.fk.keynum={0,1,1}}},
+     blmpopGetKeys},
 
     {"zrandmember",zrandmemberCommand,-2,
      "read-only random @sortedset",

--- a/src/server.h
+++ b/src/server.h
@@ -2240,7 +2240,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 long zsetRank(robj *zobj, sds ele, int reverse);
 int zsetDel(robj *zobj, sds ele);
 robj *zsetDup(robj *o);
-void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey, long count, int use_nested_array, int *deleted);
+void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey, long count, int use_nested_array, int reply_nil_when_empty, int *deleted);
 sds lpGetObject(unsigned char *sptr);
 int zslValueGteMin(double value, zrangespec *spec);
 int zslValueLteMax(double value, zrangespec *spec);

--- a/src/server.h
+++ b/src/server.h
@@ -802,12 +802,12 @@ typedef struct blockingState {
                              * operation such as BLPOP or XREAD. Or NULL. */
     robj *target;           /* The key that should receive the element,
                              * for BLMOVE. */
-    struct listPos {
+    struct blockPos {
         int wherefrom;      /* Where to pop from */
         int whereto;        /* Where to push to */
-    } listpos;              /* The positions in the src/dst lists
+    } blockpos;              /* The positions in the src/dst lists/zsets
                              * where we want to pop/push an element
-                             * for BLPOP, BRPOP and BLMOVE. */
+                             * for BLPOP, BRPOP, BLMOVE and BZMPOP. */
 
     /* BLOCK_STREAM */
     size_t xread_count;     /* XREAD COUNT option. */
@@ -2240,7 +2240,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 long zsetRank(robj *zobj, sds ele, int reverse);
 int zsetDel(robj *zobj, sds ele);
 robj *zsetDup(robj *o);
-void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey, robj *countarg);
+void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey, long count, int use_nested_array_with_key, int *deleted);
 sds lpGetObject(unsigned char *sptr);
 int zslValueGteMin(double value, zrangespec *spec);
 int zslValueLteMax(double value, zrangespec *spec);
@@ -2453,6 +2453,8 @@ int memoryGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult
 int lcsGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 int lmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 int blmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
+int zmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
+int bzmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 
 unsigned short crc16(const char *buf, int len);
 
@@ -2489,7 +2491,7 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
 void disconnectAllBlockedClients(void);
 void handleClientsBlockedOnKeys(void);
 void signalKeyAsReady(redisDb *db, robj *key, int type);
-void blockForKeys(client *c, int btype, robj **keys, int numkeys, long count, mstime_t timeout, robj *target, struct listPos *listpos, streamID *ids);
+void blockForKeys(client *c, int btype, robj **keys, int numkeys, long count, mstime_t timeout, robj *target, struct blockPos *blockpos, streamID *ids);
 void updateStatsOnUnblock(client *c, long blocked_us, long reply_us);
 
 /* timeout.c -- Blocked clients timeout and connections timeout. */
@@ -2647,8 +2649,10 @@ void zremrangebyscoreCommand(client *c);
 void zremrangebylexCommand(client *c);
 void zpopminCommand(client *c);
 void zpopmaxCommand(client *c);
+void zmpopCommand(client *c);
 void bzpopminCommand(client *c);
 void bzpopmaxCommand(client *c);
+void bzmpopCommand(client *c);
 void zrandmemberCommand(client *c);
 void multiCommand(client *c);
 void execCommand(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -2240,7 +2240,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 long zsetRank(robj *zobj, sds ele, int reverse);
 int zsetDel(robj *zobj, sds ele);
 robj *zsetDup(robj *o);
-void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey, long count, int use_nested_array_with_key, int *deleted);
+void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey, long count, int use_nested_array, int *deleted);
 sds lpGetObject(unsigned char *sptr);
 int zslValueGteMin(double value, zrangespec *spec);
 int zslValueLteMax(double value, zrangespec *spec);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1088,7 +1088,7 @@ void blockingPopGenericCommand(client *c, robj **keys, int numkeys, int where, i
     }
 
     /* If the keys do not exist we must block */
-    struct listPos pos = {where};
+    struct blockPos pos = {where};
     blockForKeys(c,BLOCKED_LIST,keys,numkeys,count,timeout,NULL,&pos,NULL);
 }
 
@@ -1113,7 +1113,7 @@ void blmoveGenericCommand(client *c, int wherefrom, int whereto, mstime_t timeou
             addReplyNull(c);
         } else {
             /* The list is empty and the client blocks. */
-            struct listPos pos = {wherefrom, whereto};
+            struct blockPos pos = {wherefrom, whereto};
             blockForKeys(c,BLOCKED_LIST,c->argv + 1,1,0,timeout,c->argv[2],&pos,NULL);
         }
     } else {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3768,7 +3768,7 @@ void zscanCommand(client *c) {
  * 'reply_nil_when_empty' when true we reply a NIL if we are not able to pop up any elements.
  * Like in ZMPOP/BZMPOP we reply with a structured nested array containing key name
  * and member + score pairs. In these commands, we reply with null when we have no result.
- * Otherwise we reply an empty array by default.
+ * Otherwise in ZPOPMIN/ZPOPMAX we reply an empty array by default.
  *
  * 'deleted' is an optional output argument to get an indication
  * if the key got deleted by this function.

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3857,6 +3857,15 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
         dbDelete(c->db,key);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"del",key,c->db->id);
     }
+
+    if (c->cmd->proc == zmpopCommand) {
+        /* Always replicate it as ZPOP[MIN|MAX] with COUNT option instead of ZMPOP. */
+        robj *count_obj = createStringObjectFromLongLong((count > llen) ? llen : count);
+        rewriteClientCommandVector(c, 3,
+                                   (where == ZSET_MAX) ? shared.zpopmax : shared.zpopmin,
+                                   key, count_obj);
+        decrRefCount(count_obj);
+    }
 }
 
 /* ZPOPMIN/ZPOPMAX key [<count>] */

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -333,7 +333,6 @@ tags {"aof external:skip"} {
             set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
             set client2 [redis [dict get $srv host] [dict get $srv port] 1 $::tls]
             wait_done_loading $client
-            wait_done_loading $client2
 
             # Pop all elements from mylist, should be blmpop delete mylist.
             $client lmpop 1 mylist left count 1
@@ -381,7 +380,6 @@ tags {"aof external:skip"} {
             set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
             set client2 [redis [dict get $srv host] [dict get $srv port] 1 $::tls]
             wait_done_loading $client
-            wait_done_loading $client2
 
             # Pop all elements from myzset, should be bzmpop delete myzset.
             $client zmpop 1 myzset min count 1

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -368,4 +368,52 @@ tags {"aof external:skip"} {
             assert_equal 2 [$client llen mylist3]
         }
     }
+
+    # Test that ZMPOP/BZMPOP work fine with AOF.
+    create_aof {
+        append_to_aof [formatCommand zadd myzset 1 one 2 two 3 three]
+        append_to_aof [formatCommand zadd myzset2 4 four 5 five 6 six]
+        append_to_aof [formatCommand zadd myzset3 1 one 2 two 3 three 4 four 5 five]
+    }
+
+    start_server_aof [list dir $server_path aof-load-truncated no] {
+        test "AOF+ZMPOP/BZMPOP: pop elements from the zset" {
+            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client2 [redis [dict get $srv host] [dict get $srv port] 1 $::tls]
+            wait_done_loading $client
+            wait_done_loading $client2
+
+            # Pop all elements from myzset, should be bzmpop delete myzset.
+            $client zmpop 1 myzset min count 1
+            $client bzmpop 0 1 myzset min count 10
+
+            # Pop all elements from myzset2, should be zmpop delete myzset2.
+            $client bzmpop 0 2 myzset myzset2 max count 10
+            $client zmpop 2 myzset myzset2 max count 2
+
+            # Blocking path, be blocked and then released.
+            $client2 bzmpop 0 2 myzset myzset2 min count 2
+            after 100
+            $client zadd myzset2 1 one 2 two 3 three
+
+            # Pop up the last element in myzset2
+            $client bzmpop 0 3 myzset myzset2 myzset3 min count 1
+
+            # Leave two elements in myzset3.
+            $client bzmpop 0 3 myzset myzset2 myzset3 max count 3
+        }
+    }
+
+    start_server_aof [list dir $server_path aof-load-truncated no] {
+        test "AOF+ZMPOP/BZMPOP: after pop elements from the zset" {
+            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            wait_done_loading $client
+
+            # myzset and myzset2 no longer exist.
+            assert_equal 0 [$client exists myzset myzset2]
+
+            # Length of myzset3 is two.
+            assert_equal 2 [$client zcard myzset3]
+        }
+    }
 }

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -738,7 +738,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         r rpush mylist2{t} a b c
 
         # Released on timeout.
-        assert_equal {} [$rd blmpop 0.01 1 mylist{t} left count 10]
+        assert_equal {} [r blmpop 0.01 1 mylist{t} left count 10]
         r set foo{t} bar ;# something else to propagate after, so we can make sure the above pop didn't.
 
         assert_replication_stream $repl {

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -6,7 +6,7 @@ start_server {
 } {
     source "tests/unit/type/list-common.tcl"
 
-    # A helper function for BPOP/BLMPOP with one input key.
+    # A helper function to execute either BPOP* or BLMPOP* with one input key in a differing way.
     proc bpop_command {rd pop key timeout} {
         if {$pop == "BLMPOP_LEFT"} {
             $rd blmpop $timeout 1 $key left count 1
@@ -17,7 +17,7 @@ start_server {
         }
     }
 
-    # A helper function for BPOP/BLMPOP with two input keys.
+    # A helper function to execute either BPOP* or BLMPOP* with two input keys in a differing way.
     proc bpop_command_two_key {rd pop key key2 timeout} {
         if {$pop == "BLMPOP_LEFT"} {
             $rd blmpop $timeout 2 $key $key2 left count 1
@@ -719,14 +719,14 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         set rd [redis_deferring_client]
         set repl [attach_to_replication_stream]
 
-        # BLMPOP without block.
+        # BLMPOP without being blocked.
         r lpush mylist{t} a b c
         r rpush mylist2{t} 1 2 3
         r blmpop 0 1 mylist{t} left count 1
         r blmpop 0 2 mylist{t} mylist2{t} right count 10
         r blmpop 0 2 mylist{t} mylist2{t} right count 10
 
-        # BLMPOP with block.
+        # BLMPOP that gets blocked.
         $rd blmpop 0 1 mylist{t} left count 1
         wait_for_blocked_client
         r lpush mylist{t} a
@@ -736,6 +736,11 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         $rd blmpop 0 2 mylist{t} mylist2{t} right count 10
         wait_for_blocked_client
         r rpush mylist2{t} a b c
+
+        # Released on timeout.
+        $rd blmpop 0.1 1 mylist{t} left count 10
+        after 150
+        r set foo{t} bar
 
         assert_replication_stream $repl {
             {select *}
@@ -750,6 +755,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             {lpop mylist{t} 3}
             {rpush mylist2{t} a b c}
             {rpop mylist2{t} 3}
+            {set foot{t} bar}
         }
     } {} {needs:repl}
 

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -738,11 +738,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         r rpush mylist2{t} a b c
 
         # Released on timeout.
-        $rd blmpop 0.01 1 mylist{t} left count 10
-        $rd flush
-        r ping ;# just to make sure redis got CPU time.
-        after 10
-        wait_for_blocked_clients_count 0
+        assert_equal {} [$rd blmpop 0.01 1 mylist{t} left count 10]
         r set foo{t} bar ;# something else to propagate after, so we can make sure the above pop didn't.
 
         assert_replication_stream $repl {

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -755,7 +755,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             {lpop mylist{t} 3}
             {rpush mylist2{t} a b c}
             {rpop mylist2{t} 3}
-            {set foot{t} bar}
+            {set foo{t} bar}
         }
     } {} {needs:repl}
 

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1981,11 +1981,7 @@ start_server {tags {"zset"}} {
         r zadd myzset2{t} 4 four 5 five 6 six
 
         # Released on timeout.
-        $rd bzmpop 0.01 1 myzset{t} max count 10
-        $rd flush
-        r ping ;# just to make sure redis got CPU time.
-        after 10
-        wait_for_blocked_clients_count 0
+        assert_equal {} [$rd bzmpop 0.01 1 myzset{t} max count 10]
         r set foo{t} bar ;# something else to propagate after, so we can make sure the above pop didn't.
 
         assert_replication_stream $repl {

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1981,7 +1981,7 @@ start_server {tags {"zset"}} {
         r zadd myzset2{t} 4 four 5 five 6 six
 
         # Released on timeout.
-        assert_equal {} [$rd bzmpop 0.01 1 myzset{t} max count 10]
+        assert_equal {} [r bzmpop 0.01 1 myzset{t} max count 10]
         r set foo{t} bar ;# something else to propagate after, so we can make sure the above pop didn't.
 
         assert_replication_stream $repl {


### PR DESCRIPTION
This is similar to the recent addition of LMPOP/BLMPOP (#9373), but zset.

Syntax for the new ZMPOP command:
`ZMPOP numkeys [<key> ...] MIN|MAX [COUNT count]`

Syntax for the new BZMPOP command:
`BZMPOP timeout numkeys [<key> ...] MIN|MAX [COUNT count]`

Some background:
- ZPOPMIN/ZPOPMAX take only one key, and can return multiple elements.
- BZPOPMIN/BZPOPMAX take multiple keys, but return only one element from just one key.
- ZMPOP/BZMPOP can take multiple keys, and can return multiple elements from just one key.

Note that ZMPOP/BZMPOP can take multiple keys, it eventually operates on just on key.
And it will propagate as ZPOPMIN or ZPOPMAX with the COUNT option.

As new commands, if we can not pop any elements, the response like:
- ZMPOP: Return a NIL in both RESP2 and RESP3, unlike ZPOPMIN/ZPOPMAX return emptyarray.
- BZMPOP: Return a NIL in both RESP2 and RESP3 when timeout is reached, like BZPOPMIN/BZPOPMAX.

For the normal response is nested arrays in RESP2 and RESP3:
```
ZMPOP/BZMPOP
1) keyname
2) 1) 1) member1
      2) score1
   2) 1) member2
      2) score2

In RESP2:
1) "myzset"
2) 1) 1) "three"
      2) "3"
   2) 1) "two"
      2) "2"

In RESP3:
1) "myzset"
2) 1) 1) "three"
      2) (double) 3
   2) 1) "two"
      2) (double) 2
```