### PR TITLE
Change server.io_threads_active to server.io_threads_active_num, gives the thread io more opportunities to be used.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3547,7 +3547,7 @@ void killIOThreads(void) {
 
 /* This function automatically adjusts the number of io threads based
  * on the number of pending write requests from the client. */
-void adjustingActiveThreadedIO(void) {
+void adjustActiveThreadedIO(void) {
     /* Return ASAP if IO threads are disabled (single threaded mode). */
     if (server.io_threads_num == 1) return;
 
@@ -3584,7 +3584,7 @@ int handleClientsWithPendingWritesUsingThreads(void) {
     if (processed == 0) return 0; /* Return ASAP if there are no clients. */
 
     /* Automatic adjustment of active IO threads based on pending writes. */
-    adjustingActiveThreadedIO();
+    adjustActiveThreadedIO();
 
     /* If only need one active IO thread serve，use synchronous code. */
     if (server.io_threads_active_num == 1) {

--- a/src/server.c
+++ b/src/server.c
@@ -2262,8 +2262,8 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
         migrateCloseTimedoutSockets();
     }
 
-    /* Stop the I/O threads if we don't have enough pending work. */
-    stopThreadedIOIfNeeded();
+    /* Adjust the number of active I/O threads based on pending work. */
+    adjustingActiveThreadedIO();
 
     /* Resize tracking keys table if needed. This is also done at every
      * command execution, but we want to be sure that if the last command
@@ -4723,7 +4723,7 @@ sds genRedisInfoString(const char *section) {
             "lru_clock:%u\r\n"
             "executable:%s\r\n"
             "config_file:%s\r\n"
-            "io_threads_active:%i\r\n",
+            "io_threads_active_num:%i\r\n",
             REDIS_VERSION,
             redisGitSHA1(),
             strtol(redisGitDirty(),NULL,10) > 0,
@@ -4750,7 +4750,7 @@ sds genRedisInfoString(const char *section) {
             lruclock,
             server.executable ? server.executable : "",
             server.configfile ? server.configfile : "",
-            server.io_threads_active);
+            server.io_threads_active_num);
     }
 
     /* Clients */

--- a/src/server.c
+++ b/src/server.c
@@ -2263,7 +2263,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     }
 
     /* Adjust the number of active I/O threads based on pending work. */
-    adjustingActiveThreadedIO();
+    adjustActiveThreadedIO();
 
     /* Resize tracking keys table if needed. This is also done at every
      * command execution, but we want to be sure that if the last command

--- a/src/server.h
+++ b/src/server.h
@@ -1945,7 +1945,7 @@ void blockingOperationEnds();
 int handleClientsWithPendingWrites(void);
 int handleClientsWithPendingWritesUsingThreads(void);
 int handleClientsWithPendingReadsUsingThreads(void);
-void adjustingActiveThreadedIO(void);
+void adjustActiveThreadedIO(void);
 int clientHasPendingReplies(client *c);
 void unlinkClient(client *c);
 int writeToClient(client *c, int handler_installed);

--- a/src/server.h
+++ b/src/server.h
@@ -1289,9 +1289,9 @@ struct redisServer {
     dict *migrate_cached_sockets;/* MIGRATE cached sockets */
     redisAtomic uint64_t next_client_id; /* Next client unique ID. Incremental. */
     int protected_mode;         /* Don't accept external connections. */
-    int io_threads_num;         /* Number of IO threads to use. */
+    int io_threads_num;         /* Max number of IO threads to use. */
     int io_threads_do_reads;    /* Read and parse from IO threads? */
-    int io_threads_active;      /* Is IO threads currently active? */
+    int io_threads_active_num;      /* Number of IO threads currently active. */
     long long events_processed_while_blocked; /* processEventsWhileBlocked() */
 
     /* RDB / AOF loading information */
@@ -1945,7 +1945,7 @@ void blockingOperationEnds();
 int handleClientsWithPendingWrites(void);
 int handleClientsWithPendingWritesUsingThreads(void);
 int handleClientsWithPendingReadsUsingThreads(void);
-int stopThreadedIOIfNeeded(void);
+void adjustingActiveThreadedIO(void);
 int clientHasPendingReplies(client *c);
 void unlinkClient(client *c);
 int writeToClient(client *c, int handler_installed);


### PR DESCRIPTION
 When configured to use multithreading, users expect to use them more to make the redis server as soon as possible to response client. for example use the redis.conf like this : 

`io-threads 6
io-threads-do-reads yes`

when there are only 10 client requests, current redis server will not use multi-threading, which is of course not a problem, but I think it is probably better to use some of the configured threads to handle client requests in a reasonable way. on the other hand, server.io_threads_active_num can provide more useful information about thread usage than server.io_threads_active.