### PR TITLE
dbUnshareStringValue should not call dbOverwrite.

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -362,6 +362,7 @@ robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o) {
         o = createRawStringObject(decoded->ptr, sdslen(decoded->ptr));
         decrRefCount(decoded);
         dictEntry *de = dictFind(db->dict, key->ptr);
+        serverAssertWithInfo(NULL,key,de != NULL);
         dictEntry auxentry = *de;
         if (server.maxmemory_policy & MAXMEMORY_FLAG_LFU) {
             robj *old = dictGetVal(de);


### PR DESCRIPTION
dbUnshareStringValue doesn't intend to replace the existing key with
a new one. So it should not call any module hooks, keyspace
notifications, and so on.

See https://github.com/redis/redis/pull/9406