### PR TITLE
the param(dict type) name of dictDelete is wrong

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -434,7 +434,7 @@ static dictEntry *dictGenericDelete(dict *d, const void *key, int nofree) {
 
 /* Remove an element, returning DICT_OK on success or DICT_ERR if the
  * element was not found. */
-int dictDelete(dict *ht, const void *key) {
+int dictDelete(dict *d, const void *key) {
     return dictGenericDelete(ht,key,0) ? DICT_OK : DICT_ERR;
 }
 


### PR DESCRIPTION
int dictDelete(dict *ht, const void *key)=>int dictDelete(dict *d, const void *key)