### PR TITLE
Fixed leaked client for "start_server" when running in --loop

### DIFF
--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -84,7 +84,7 @@ proc ::redis::__dispatch__raw__ {id method argv} {
     set fd $::redis::fd($id)
 
     # Reconnect the link if needed.
-    if {$fd eq {}} {
+    if {$fd eq {} && $method ne {close}} {
         lassign $::redis::addr($id) host port
         if {$::redis::tls($id)} {
             set ::redis::fd($id) [::tls::socket $host $port]

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -33,6 +33,11 @@ proc kill_server config {
     # nothing to kill when running against external server
     if {$::external} return
 
+    # Close client connection if exists
+    if {[dict exists $config "client"]} {
+        [dict get $config "client"] close
+    }
+
     # nevermind if its already dead
     if {![is_alive $config]} {
         # Check valgrind errors if needed
@@ -629,6 +634,8 @@ proc start_server {options {code undefined}} {
 proc restart_server {level wait_ready rotate_logs {reconnect 1}} {
     set srv [lindex $::servers end+$level]
     kill_server $srv
+    # Remove the default client from the server
+    dict unset srv "client"
 
     set pid [dict get $srv "pid"]
     set stdout [dict get $srv "stdout"]


### PR DESCRIPTION
To recreate the issue see: https://gist.github.com/yoav-steinberg/e6d48ff1a2958da5338368c309b53e2f
The fix:
* On `kill_server` make sure we close the default `"client"` connection.
* Don't reconnect when trying to execute the client's `close` command.
* On `restart_server` make sure to remove the (closed) default `"client"` after killing the old server.