### PR TITLE
fix typo in redis.conf. Interfece changed to interface

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -60,7 +60,7 @@
 # the "bind" configuration directive, followed by one or more IP addresses.
 # Each address can be prefixed by "-", which means that redis will not fail to
 # start if the address is not available. Being not available only refers to
-# addresses that does not correspond to any network interfece. Addresses that
+# addresses that does not correspond to any network interface. Addresses that
 # are already in use will always fail, and unsupported protocols will always BE
 # silently skipped.
 #


### PR DESCRIPTION
## What?
Slight type in redis.conf file where interfece  is changed to interface.