### PR TITLE
Fix memory leak due to missing freeCallback in blockonbackground module test

### DIFF
--- a/tests/modules/blockonbackground.c
+++ b/tests/modules/blockonbackground.c
@@ -31,6 +31,11 @@ void HelloBlock_FreeData(RedisModuleCtx *ctx, void *privdata) {
     RedisModule_Free(privdata);
 }
 
+/* Private data freeing callback for BLOCK.BLOCK command. */
+void HelloBlock_FreeStringData(RedisModuleCtx *ctx, void *privdata) {
+    RedisModule_FreeString(ctx, (RedisModuleString*)privdata);
+}
+
 /* The thread entry point that actually executes the blocking part
  * of the command BLOCK.DEBUG. */
 void *BlockDebug_ThreadMain(void *arg) {
@@ -225,7 +230,7 @@ int Block_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
      * callback and differentiate the different code flows above.
      */
     blocked_client = RedisModule_BlockClient(ctx, Block_RedisCommand,
-            timeout > 0 ? Block_RedisCommand : NULL, NULL, timeout);
+            timeout > 0 ? Block_RedisCommand : NULL, HelloBlock_FreeStringData, timeout);
     return REDISMODULE_OK;
 }
 


### PR DESCRIPTION
Before #9497, before redis-server was shut down, we did not manually shut down all the clients, which would have prevented valgrind from detecting a memory leak in the client's argc.

This was exposed by the following test failure: https://github.com/redis/redis/runs/3593238549?check_suite_focus=true