### PR TITLE
Support tclsh 8.7

### DIFF
--- a/runtest
+++ b/runtest
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6"
+TCL_VERSIONS="8.5 8.6 8.7"
 TCLSH=""
 
 for VERSION in $TCL_VERSIONS; do

--- a/runtest-cluster
+++ b/runtest-cluster
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6"
+TCL_VERSIONS="8.5 8.6 8.7"
 TCLSH=""
 
 for VERSION in $TCL_VERSIONS; do

--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6"
+TCL_VERSIONS="8.5 8.6 8.7"
 TCLSH=""
 [ -z "$MAKE" ] && MAKE=make
 

--- a/runtest-sentinel
+++ b/runtest-sentinel
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6"
+TCL_VERSIONS="8.5 8.6 8.7"
 TCLSH=""
 
 for VERSION in $TCL_VERSIONS; do


### PR DESCRIPTION
[root@ycz redis-unstable]# echo 'puts $tcl_version;exit 0' | tclsh
8.7
[root@ycz redis-unstable]# make test-modules
cd src && make test-modules   
make[1]: Entering directory `/root/redis-unstable/src`   
You need tcl 8.5 or newer in order to run the Redis ModuleApi test   
make[1]: *** [test-modules] Error 1   
make[1]: Leaving directory `/root/redis-unstable/src`  
make: *** [test-modules] Error 2
