### PR TITLE
Fix obtain the AOF file length error when load AOF

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1771,21 +1771,13 @@ void aofRemoveTempFile(pid_t childpid) {
 void aofUpdateCurrentSize(void) {
     struct redis_stat sb;
     mstime_t latency;
-    int aof_fd = server.aof_fd;
 
     latencyStartMonitor(latency);
-    if (aof_fd == -1) {
-        /* Don't care if this fails: aof_fd will be -1 and redis_fstat handle that. */
-        aof_fd = open(server.aof_filename,O_RDONLY|O_NONBLOCK);
-    } 
-    if (redis_fstat(aof_fd,&sb) == -1) {
+    if (redis_stat(server.aof_filename,&sb) == -1) {
         serverLog(LL_WARNING,"Unable to obtain the AOF file length. stat: %s",
             strerror(errno));
     } else {
         server.aof_current_size = sb.st_size;
-    }
-    if (server.aof_fd == -1 && aof_fd != -1) {
-        close(aof_fd);
     }
     latencyEndMonitor(latency);
     latencyAddSampleIfNeeded("aof-fstat",latency);

--- a/src/aof.c
+++ b/src/aof.c
@@ -1771,13 +1771,21 @@ void aofRemoveTempFile(pid_t childpid) {
 void aofUpdateCurrentSize(void) {
     struct redis_stat sb;
     mstime_t latency;
+    int aof_fd = server.aof_fd;
 
     latencyStartMonitor(latency);
-    if (redis_fstat(server.aof_fd,&sb) == -1) {
+    if (aof_fd == -1) {
+        /* Don't care if this fails: aof_fd will be -1 and redis_fstat handle that. */
+        aof_fd = open(server.aof_filename,O_RDONLY|O_NONBLOCK);
+    } 
+    if (redis_fstat(aof_fd,&sb) == -1) {
         serverLog(LL_WARNING,"Unable to obtain the AOF file length. stat: %s",
             strerror(errno));
     } else {
         server.aof_current_size = sb.st_size;
+    }
+    if (server.aof_fd == -1 && aof_fd != -1) {
+        close(aof_fd);
     }
     latencyEndMonitor(latency);
     latencyAddSampleIfNeeded("aof-fstat",latency);


### PR DESCRIPTION
When redis executes `loadDataFromDisk` after startup, since `server.aof_fd` is still -1 at this time,`aofUpdateCurrentSize` will not be able to get the loaded AOF size and will report the following error. I think in this case we can try to use `open` to get the real size.

57831:M 16 Sep 2021 09:37:25.907 # Server initialized
57831:M 16 Sep 2021 09:37:25.907 # **Unable to obtain the AOF file length. stat: Bad file descriptor**
57831:M 16 Sep 2021 09:37:25.907 * DB loaded from append only file: 0.000 seconds
57831:M 16 Sep 2021 09:37:25.907 * Ready to accept connections