### PR TITLE
Fix error message for replica-serve-stale-data in redis.conf doc

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -518,8 +518,9 @@ dir ./
 #    still reply to client requests, possibly with out of date data, or the
 #    data set may just be empty if this is the first synchronization.
 #
-# 2) If replica-serve-stale-data is set to 'no' the replica will reply with
-#    an error "SYNC with master in progress" to all commands except:
+# 2) If replica-serve-stale-data is set to 'no' the replica will reply with error
+#    "MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'"
+#    to all commands except:
 #    INFO, REPLICAOF, AUTH, PING, SHUTDOWN, REPLCONF, ROLE, CONFIG, SUBSCRIBE,
 #    UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, PUBLISH, PUBSUB, COMMAND, POST,
 #    HOST and LATENCY.

--- a/redis.conf
+++ b/redis.conf
@@ -520,7 +520,7 @@ dir ./
 #
 # 2) If replica-serve-stale-data is set to 'no' the replica will reply with error
 #    "MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'"
-#    to all commands except:
+#    to all data access commands, excusing commands such as :
 #    INFO, REPLICAOF, AUTH, PING, SHUTDOWN, REPLCONF, ROLE, CONFIG, SUBSCRIBE,
 #    UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, PUBLISH, PUBSUB, COMMAND, POST,
 #    HOST and LATENCY.


### PR DESCRIPTION
Fixing wrong documentation for replica-serve-stale-data in redis.conf.
Error message didn't match with actual one returned.
Reported in https://github.com/redis/redis/issues/3131
