### PR TITLE
tune lazyfree test timeout

### DIFF
--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -39,7 +39,7 @@ start_server {tags {"lazyfree"}} {
 
     test "lazy free a stream with all types of metadata" {
         # make the previous test is really done before doing RESETSTAT
-        wait_for_condition 5 100 {
+        wait_for_condition 50 100 {
             [s lazyfree_pending_objects] == 0
         } else {
             fail "lazyfree isn't done"
@@ -61,7 +61,7 @@ start_server {tags {"lazyfree"}} {
         r unlink stream
 
         # make sure it was lazy freed
-        wait_for_condition 5 100 {
+        wait_for_condition 50 100 {
             [s lazyfree_pending_objects] == 0
         } else {
             fail "lazyfree isn't done"
@@ -77,7 +77,7 @@ start_server {tags {"lazyfree"}} {
         r unlink s
 
         # make sure it was not lazy freed
-        wait_for_condition 5 100 {
+        wait_for_condition 50 100 {
             [s lazyfree_pending_objects] == 0
         } else {
             fail "lazyfree isn't done"


### PR DESCRIPTION
i've seen this CI failure a couple of times on MacOS:
```
*** [err]: lazy free a stream with all types of metadata in tests/unit/lazyfree.tcl
lazyfree isn't done
```
only reason i can think of is that 500ms is sometimes not enough on slow systems.