### PR TITLE
Remove argument count limit, dynamically grow argv.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1958,7 +1958,7 @@ int processMultibulkBuffer(client *c) {
             /* Check if we have space in argv, grow if needed */
             if (c->argc >= c->argv_len) {
                 c->argv_len = min(c->argv_len*2, c->argc+c->multibulklen);
-                c->argv  = zrealloc(c->argv, sizeof(robj*)*c->argv_len);
+                c->argv = zrealloc(c->argv, sizeof(robj*)*c->argv_len);
             }
 
             /* Optimization: if the buffer contains JUST our bulk element

--- a/src/networking.c
+++ b/src/networking.c
@@ -1957,7 +1957,7 @@ int processMultibulkBuffer(client *c) {
         } else {
             /* Check if we have space in argv, grow if needed */
             if (c->argc >= c->argv_len) {
-                c->argv_len = min(c->argv_len*2, c->argc+c->multibulklen);
+                c->argv_len = min(c->argv_len < INT_MAX/2 ? c->argv_len*2 : INT_MAX, c->argc+c->multibulklen);
                 c->argv = zrealloc(c->argv, sizeof(robj*)*c->argv_len);
             }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1957,7 +1957,7 @@ int processMultibulkBuffer(client *c) {
         } else {
             /* Check if we have space in argv, grow if needed */
             if (c->argc >= c->argv_len) {
-                c->argv_len *= 2;
+                c->argv_len = min(c->argv_len*2, c->argc+c->multibulklen);
                 c->argv  = zrealloc(c->argv, sizeof(robj*)*c->argv_len);
             }
 

--- a/src/server.h
+++ b/src/server.h
@@ -927,6 +927,7 @@ typedef struct client {
     size_t querybuf_peak;   /* Recent (100ms or more) peak of querybuf size. */
     int argc;               /* Num of arguments of current command. */
     robj **argv;            /* Arguments of current command. */
+    int argv_len;           /* Size of argv array (may be more than argc) */
     int original_argc;      /* Num of arguments of original command if arguments were rewritten. */
     robj **original_argv;   /* Arguments of original command if arguments were rewritten. */
     size_t argv_len_sum;    /* Sum of lengths of objects in argv list. */

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -15,7 +15,7 @@ start_server {tags {"protocol network"}} {
 
     test "Out of range multibulk length" {
         reconnect
-        r write "*20000000\r\n"
+        r write "*3000000000\r\n"
         r flush
         assert_error "*invalid multibulk length*" {r read}
     }
@@ -195,6 +195,14 @@ start_server {tags {"protocol network"}} {
         r hello 3
         r debug protocol verbatim
     } "This is a verbatim\nstring" {needs:debug resp3}
+
+    test "test large number of args" {
+        r flushdb
+        set args [split [string trim [string repeat "k v " 10000]]]
+        lappend args k2 v2
+        r mset {*}$args
+        assert_equal [r get k2] v2
+    }
 
 }
 

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -199,9 +199,9 @@ start_server {tags {"protocol network"}} {
     test "test large number of args" {
         r flushdb
         set args [split [string trim [string repeat "k v " 10000]]]
-        lappend args k2 v2
+        lappend args "{k}2" v2
         r mset {*}$args
-        assert_equal [r get k2] v2
+        assert_equal [r get "{k}2"] v2
     }
 
 }


### PR DESCRIPTION
Remove hard coded multi-bulk limit (was 1,048,576), new limit is INT_MAX.
When client sends an m-bulk that's higher than 1024, we initially only allocate
the argv array for 1024 arguments, and gradually grow that allocation as arguments
are received.

See #9023