### PR TITLE
Add hostname variables

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -132,6 +132,7 @@ typedef struct clusterNode {
     mstime_t repl_offset_time;  /* Unix time we received offset for this node */
     mstime_t orphaned_time;     /* Starting time of orphaned master condition */
     long long repl_offset;      /* Last known repl offset for this node. */
+    char* hostname;
     char ip[NET_IP_STR_LEN];  /* Latest known IP address of this node */
     int port;                   /* Latest known clients port (TLS or plain). */
     int pport;                  /* Latest known clients plaintext port. Only used
@@ -195,6 +196,8 @@ typedef struct clusterState {
     long long stats_bus_messages_received[CLUSTERMSG_TYPE_COUNT];
     long long stats_pfail_nodes;    /* Number of nodes in PFAIL status,
                                        excluding nodes without address. */
+    int resolve_hostnames;       /* Support use of hostnames, assuming DNS is well configured. */
+    int announce_hostnames;      /* Announce hostnames instead of IPs when we have them. */
 } clusterState;
 
 /* Redis cluster messages header */


### PR DESCRIPTION
This PR is to add the hostname feature for clusters as mentioned in https://github.com/redis/redis/issues/8948. This feature is similar to the hostname feature implemented in sentinel.c. This is a work in progress, any comments/suggestions are welcome.