### PR TITLE
Fix redis-check-rdb rdb_type_string initialization error

### DIFF
--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -91,7 +91,7 @@ char *rdb_type_string[] = {
     "hash-ziplist",
     "quicklist",
     "stream",
-    "hash-listpack"
+    "hash-listpack",
     "zset-listpack"
 };
 


### PR DESCRIPTION

redis-check-rdb.c:95:5: warning: suspicious concatenation of string literals in an array initialization; did you mean to separate the elements with a comma? [-Wstring-concatenation]
    "zset-listpack"
    ^
redis-check-rdb.c:94:5: note: place parentheses around the string literal to silence warning
    "hash-listpack"
