### PR TITLE
Test can fail if flushdb triggers a bgsave

### DIFF
--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -39,8 +39,8 @@ start_server {tags {"other"}} {
     }
 
     test {BGSAVE} {
-        waitForBgsave r
         r flushdb
+        waitForBgsave r
         r save
         r set x 10
         r bgsave


### PR DESCRIPTION
Flush db and *then* wait for the bgsave to complete.