### PR TITLE
A new AOF persistence mechanism 

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1302,9 +1302,12 @@ disable-thp yes
 
 appendonly no
 
-# The name of the append only file (default: "appendonly.aof")
-
+# The name of the BASE append only file (default: "appendonly.aof")
 appendfilename "appendonly.aof"
+# The name of the PING append only file (default: "appendonly.ping")
+aof-ping-filename "appendonly.ping"
+# The name of the PONG append only file (default: "appendonly.pong")
+aof-pong-filename "appendonly.pong"
 
 # The fsync() call tells the Operating System to actually write data on disk
 # instead of waiting for more data in the output buffer. Some OS will really flush

--- a/src/aof.c
+++ b/src/aof.c
@@ -1591,7 +1591,7 @@ void aofRemoveTempFile(pid_t childpid) {
  * a restart, normally the size is updated just adding the write length
  * to the current length, that is much faster. */
 void aofUpdateCurrentSize() {
-    off_t size, base_size, pong_size = 0, ping_size = 0;
+    off_t base_size, pong_size = 0, ping_size = 0;
     mstime_t latency;
 
     if (server.aof_current_type == AOF_TYPE_NONE) {
@@ -1601,18 +1601,13 @@ void aofUpdateCurrentSize() {
     latencyStartMonitor(latency)
 
     if (server.aof_current_type == AOF_TYPE_PONG) {
-        size = aofGetTypeSize(AOF_TYPE_PONG);
-        pong_size = size > 0 ? size : 0;
-
-        size = aofGetTypeSize(AOF_TYPE_PING);
-        ping_size = size > 0 ? size : 0;
+        pong_size = aofGetTypeSize(AOF_TYPE_PONG);
+        pong_size = aofGetTypeSize(AOF_TYPE_PING);
     } else if (server.aof_current_type == AOF_TYPE_PING ) {
-        size = aofGetTypeSize(AOF_TYPE_PING);
-        ping_size = size > 0 ? size : 0;
+        ping_size = aofGetTypeSize(AOF_TYPE_PING);
     }
 
-    size = aofGetTypeSize(AOF_TYPE_BASE);
-    base_size = size > 0 ? size : 0;
+    base_size = aofGetTypeSize(AOF_TYPE_BASE);
 
     server.aof_current_size = base_size + ping_size + pong_size;
     server.aof_working_size = server.aof_current_type == AOF_TYPE_PONG ? 

--- a/src/config.c
+++ b/src/config.c
@@ -2345,6 +2345,79 @@ static int isValidAOFfilename(char *val, const char **err) {
         *err = "appendfilename can't be a path, just a filename";
         return 0;
     }
+
+    char *temp_filename = aofGetFileNameByType(AOF_TYPE_TEMP);
+    if (temp_filename && !memcmp(val, temp_filename, strlen(val))) {
+        *err = "appendfilename can't be equal to TEMP filename";
+        return 0;
+    }
+
+    char *ping_filename = aofGetFileNameByType(AOF_TYPE_PING);
+    if (ping_filename && !memcmp(val, ping_filename, strlen(val))) {
+        *err = "appendfilename can't be equal to PING filename";
+        return 0;
+    }
+
+    char *pong_filename = aofGetFileNameByType(AOF_TYPE_PONG);
+    if (ping_filename && !memcmp(val, pong_filename, strlen(val))) {
+        *err = "appendfilename can't be equal to PONG filename";
+        return 0;
+    }
+
+    return 1;
+}
+
+static int isValidPingAOFfilename(char *val, const char **err) {
+    if (!pathIsBaseName(val)) {
+        *err = "aof-ping-filename can't be a path, just a filename";
+        return 0;
+    }
+
+    char *temp_filename = aofGetFileNameByType(AOF_TYPE_TEMP);
+    if (temp_filename && !memcmp(val, temp_filename, strlen(val))) {
+        *err = "aof-ping-filename can't be equal to TEMP filename";
+        return 0;
+    }
+
+    char *base_filename = aofGetFileNameByType(AOF_TYPE_BASE);
+    if (base_filename && !memcmp(val, base_filename, strlen(val))) {
+        *err = "aof-ping-filename can't be equal to BASE filename";
+        return 0;
+    }
+
+    char *pong_filename = aofGetFileNameByType(AOF_TYPE_PONG);
+    if (pong_filename && !memcmp(val, pong_filename, strlen(val))) {
+        *err = "aof-ping-filename can't be equal to PONG filename";
+        return 0;
+    }
+
+    return 1;
+}
+
+static int isValidPongAOFfilename(char *val, const char **err) {
+    if (!pathIsBaseName(val)) {
+        *err = "aof-pong-filename can't be a path, just a filename";
+        return 0;
+    }
+
+    char *temp_filename = aofGetFileNameByType(AOF_TYPE_TEMP);
+    if (temp_filename && !memcmp(val, temp_filename, strlen(val))) {
+        *err = "aof-pong-filename can't be equal to TEMP filename";
+        return 0;
+    }
+
+    char *ping_filename = aofGetFileNameByType(AOF_TYPE_PING);
+    if (ping_filename && !memcmp(val, ping_filename, strlen(val))) {
+        *err = "aof-pong-filename can't be equal to PING filename";
+        return 0;
+    }
+
+    char *base_filename = aofGetFileNameByType(AOF_TYPE_BASE);
+    if (base_filename && !memcmp(val, base_filename, strlen(val))) {
+        *err = "aof-pong-filename can't be equal to BASE filename";
+        return 0;
+    }
+
     return 1;
 }
 
@@ -2609,6 +2682,8 @@ standardConfig configs[] = {
     createStringConfig("syslog-ident", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.syslog_ident, "redis", NULL, NULL),
     createStringConfig("dbfilename", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.rdb_filename, "dump.rdb", isValidDBfilename, NULL),
     createStringConfig("appendfilename", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.aof_filename, "appendonly.aof", isValidAOFfilename, NULL),
+    createStringConfig("aof-ping-filename", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.aof_ping_filename, "appendonly.ping", isValidPingAOFfilename, NULL),
+    createStringConfig("aof-pong-filename", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.aof_pong_filename, "appendonly.pong", isValidPongAOFfilename, NULL),
     createStringConfig("server_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.server_cpulist, NULL, NULL, NULL),
     createStringConfig("bio_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.bio_cpulist, NULL, NULL, NULL),
     createStringConfig("aof_rewrite_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.aof_rewrite_cpulist, NULL, NULL, NULL),

--- a/src/evict.c
+++ b/src/evict.c
@@ -342,7 +342,7 @@ size_t freeMemoryGetNotCountedMemory(void) {
         }
     }
     if (server.aof_state != AOF_OFF) {
-        overhead += sdsAllocSize(server.aof_buf)+aofRewriteBufferMemoryUsage();
+        overhead += sdsAllocSize(server.aof_buf);
     }
     return overhead;
 }

--- a/src/object.c
+++ b/src/object.c
@@ -1191,7 +1191,6 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
     mem = 0;
     if (server.aof_state != AOF_OFF) {
         mem += sdsZmallocSize(server.aof_buf);
-        mem += aofRewriteBufferMemoryUsage();
     }
     mh->aof_buffer = mem;
     mem_total+=mem;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1215,7 +1215,6 @@ int rdbSaveRio(rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi) {
     dictEntry *de;
     char magic[10];
     uint64_t cksum;
-    size_t processed = 0;
     int j;
     long key_count = 0;
     long long info_updated_time = 0;
@@ -1262,16 +1261,6 @@ int rdbSaveRio(rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi) {
              * mechanism a hint about an estimated size of the object we stored. */
             size_t dump_size = rdb->processed_bytes - rdb_bytes_before_key;
             if (server.in_fork_child) dismissObject(o, dump_size);
-
-            /* When this RDB is produced as part of an AOF rewrite, move
-             * accumulated diff from parent to child while rewriting in
-             * order to have a smaller final write. */
-            if (rdbflags & RDBFLAGS_AOF_PREAMBLE &&
-                rdb->processed_bytes > processed+AOF_READ_DIFF_INTERVAL_BYTES)
-            {
-                processed = rdb->processed_bytes;
-                aofReadDiffFromParent();
-            }
 
             /* Update child info every 1 second (approximately).
              * in order to avoid calling mstime() on each iteration, we will

--- a/tests/integration/aof-race.tcl
+++ b/tests/integration/aof-race.tcl
@@ -1,6 +1,6 @@
-set defaults { appendonly {yes} appendfilename {appendonly.aof} aof-use-rdb-preamble {no} }
+set defaults { appendonly {yes} aof-ping-filename {appendonly.ping} aof-use-rdb-preamble {no} }
 set server_path [tmpdir server.aof]
-set aof_path "$server_path/appendonly.aof"
+set aof_path "$server_path/appendonly.ping"
 
 proc start_server_aof {overrides code} {
     upvar defaults defaults srv srv server_path server_path

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -1,6 +1,6 @@
-set defaults { appendonly {yes} appendfilename {appendonly.aof} }
+set defaults { appendonly {yes} aof-ping-filename {appendonly.ping} }
 set server_path [tmpdir server.aof]
-set aof_path "$server_path/appendonly.aof"
+set aof_path "$server_path/appendonly.ping"
 
 proc append_to_aof {str} {
     upvar fp fp
@@ -247,14 +247,14 @@ tags {"aof external:skip"} {
         }
     }
 
-    start_server {overrides {appendonly {yes} appendfilename {appendonly.aof}}} {
+    start_server {overrides {appendonly {yes} aof-ping-filename {appendonly.ping}}} {
         test {Redis should not try to convert DEL into EXPIREAT for EXPIRE -1} {
             r set x 10
             r expire x -1
         }
     }
 
-    start_server {overrides {appendonly {yes} appendfilename {appendonly.aof} appendfsync always}} {
+    start_server {overrides {appendonly {yes} aof-ping-filename {appendonly.ping} appendfsync always}} {
         test {AOF fsync always barrier issue} {
             set rd [redis_deferring_client]
             # Set a sleep when aof is flushed, so that we have a chance to look
@@ -272,7 +272,7 @@ tags {"aof external:skip"} {
                 r del x
                 r setrange x [expr {int(rand()*5000000)+10000000}] x
                 r debug aof-flush-sleep 500000
-                set aof [file join [lindex [r config get dir] 1] appendonly.aof]
+                set aof [file join [lindex [r config get dir] 1] appendonly.ping]
                 set size1 [file size $aof]
                 $rd get x
                 after [expr {int(rand()*30)}]
@@ -285,9 +285,9 @@ tags {"aof external:skip"} {
         }
     }
 
-    start_server {overrides {appendonly {yes} appendfilename {appendonly.aof}}} {
+    start_server {overrides {appendonly {yes} aof-ping-filename {appendonly.ping}}} {
         test {GETEX should not append to AOF} {
-            set aof [file join [lindex [r config get dir] 1] appendonly.aof]
+            set aof [file join [lindex [r config get dir] 1] appendonly.ping]
             r set foo bar
             set before [file size $aof]
             r getex foo

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -24,9 +24,13 @@ proc clean_persistence config {
     # files right away, since they can accumulate and take up a lot of space
     set config [dict get $config "config"]
     set rdb [format "%s/%s" [dict get $config "dir"] "dump.rdb"]
-    set aof [format "%s/%s" [dict get $config "dir"] "appendonly.aof"]
+    set aof_base [format "%s/%s" [dict get $config "dir"] "appendonly.aof"]
+    set aof_ping [format "%s/%s" [dict get $config "dir"] "appendonly.ping"]
+    set aof_pong [format "%s/%s" [dict get $config "dir"] "appendonly.pong"]
     catch {exec rm -rf $rdb}
-    catch {exec rm -rf $aof}
+    catch {exec rm -rf $aof_base}
+    catch {exec rm -rf $aof_ping}
+    catch {exec rm -rf $aof_pong}
 }
 
 proc kill_server config {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -284,14 +284,14 @@ start_server {tags {"expire"}} {
     } {-2}
 
     # Start a new server with empty data and AOF file.
-    start_server {overrides {appendonly {yes} appendfilename {appendonly.aof} appendfsync always} tags {external:skip}} {
+    start_server {overrides {appendonly {yes} aof-ping-filename {appendonly.ping} appendfsync always} tags {external:skip}} {
         test {All time-to-live(TTL) in commands are propagated as absolute timestamp in milliseconds in AOF} {
             # This test makes sure that expire times are propagated as absolute
             # times to the AOF file and not as relative time, so that when the AOF
             # is reloaded the TTLs are not being shifted forward to the future.
             # We want the time to logically pass when the server is restarted!
 
-            set aof [file join [lindex [r config get dir] 1] [lindex [r config get appendfilename] 1]]
+            set aof [file join [lindex [r config get dir] 1] [lindex [r config get aof-ping-filename] 1]]
 
             # Apply each TTL-related command to a unique key
             # SET commands

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -143,6 +143,8 @@ start_server {tags {"introspection"}} {
             pidfile
             syslog-ident
             appendfilename
+            aof-ping-filename
+            aof-pong-filename
             supervised
             syslog-facility
             databases


### PR DESCRIPTION
Hi, I implemented a new AOF persistence mechanism (currently it is still in the draft stage). Its main purpose is to remove the AOF rewrite buffer, which can save memory overhead during rewrite and shorten the time consumption of rewrite.

I call it the `ping-pong model` for the time being. The reason why I call it the `ping-pong model` is because it is similar to the `ping-pong buffer`. When one buffer is full, I can continue to write another buffer, and then exchange the two buffer without interrupting the entire processing flow.

I divide AOF into four types (BASE, PING, PONG, TEMP). The AOF generated after rewrite is called BASE type AOF (configured by `appendfilename` configuration item), which is similar to the rdb file and represents a certain one Snapshot of redis data at the moment. That is, the AOF of the BASE type will not write incremental commands.

Next is the PING type AOF (configured by the configuration item `aof-ping-filename` configuration item), which is basically the same as the current AOF concept, mainly used to store the incremental commands written, when the AOF persistence function is turned on at the time, the executed commands will be written into this type AOF one by one.

When bgrewriteaof is triggered, a new AOF will be generated at this time, which is a PONG type AOF, which will continue to store the user's incremental commands. At the same time, the original PING type AOF will no longer write any data.

When the child process completes the rewrite task (`temp-rewriteaof-bg.aof` is generated), in the backgroundRewriteDoneHandler, I will rename the `temp-rewriteaof-bg.aof` file to a new BASE type AOF, and at the same time, I will rename the PONG type AOF to  PING type. At this time, BASE AOF and PING AOF together constitute the current full amount of data. It can be seen that in the entire rewrite process, no rewrite buffer is used, and no data is exchanged between the parent process and the child process.

![image](https://user-images.githubusercontent.com/13696140/134442429-1dde94a0-ae49-42a6-97a8-7a939425e293.png)


The above is the success of rewrite. If the rewrite fails, we will eventually have three AOF files at the same time, namely BASE, PING and PONG, which together constitute the current full amount of data. This means that these AOF files need to be loaded in turn when redis restarts. Even worse, if bgrewrite occurs again at this time, we can no longer generate PONG2, PONG3 and other files without limitation, otherwise we will not know which files we need and their order.

Therefore, for the small probability event of rewrite failure, we will generate a new AOF file, which we temporarily call `temp.aof`. The next incremental command will be "simultaneously" double written to PONG type AOF and `temp.aof`. If this rewrite is successful, rename `temp.aof` to  PING type AOF, and both the original PING and PONG type AOFs can be deleted. If this rewrite still fails, just delete `temp.aof`, the original BASE/PING/PONG still constitute the complete data.


![image](https://user-images.githubusercontent.com/13696140/134441895-e2c4bcef-38f3-42e7-8624-f415c923d110.png)


Currently, this solution seems to have many problems (although the tests have already been run). For example, how to ensure the atomicity of multiple file renames. Since we did not record any meta informations for AOF files, we must use double writing and multiple renames to limit the number of AOF files. In fact, in our internal practice, we designed a meta file for the AOF file(s) to record the information (including the file name and sequence, etc.), so that we do not need to rename the newly generated AOF file. But this scheme is obviously inappropriate in the community, because once relying on the meta file, it means that it is no longer compatible with the previous redis version.

So, this is my current thinking, I don’t know if I have expressed it clearly. I think this idea is okay, but we still have some problems to solve (such as the atomic problem of multi-file modification, etc.).  @redis/core-team  Do you have any better suggestions?

TODO:  
- [x] Remove rewrite buf overhead，use ping-pong write models
- [x] Remove the pipe and data exchange between the child process and the parent
- [ ] The atomicity of multi-file modification
- [x] More accurate size statistics for multiple AOFs
- [ ] Separately add some test cases for multi aof, such as double writing
- [ ] Add or modify the corresponding code comment