### PR TITLE
Use __common__ attribute in redismodule.h for Clang C builds

### DIFF
--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -506,7 +506,7 @@ typedef long long mstime_t;
 #endif
 
 #ifndef REDISMODULE_ATTR_COMMON
-#    if defined(__GNUC__) && !defined(__clang__)
+#    if defined(__GNUC__) && !(defined(__clang__) && defined(__cplusplus))
 #        define REDISMODULE_ATTR_COMMON __attribute__((__common__))
 #    else
 #        define REDISMODULE_ATTR_COMMON


### PR DESCRIPTION
Starting from version 11, Clang enables -fno-common by default : https://releases.llvm.org/11.0.0/tools/clang/docs/ReleaseNotes.html#modified-compiler-flags

 So, "\_\_common\_\_" attribute can be used for Clang C builds.
As Clang C++ does not allow this attribute, I added a check to enable attribute only for Clang C builds. 