### PR TITLE
Benchmark qps control

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -630,8 +630,7 @@ static void readHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
 
 /* control the QPS of the thread of current client 
 */
-static int controlQps(void *privdata) {
-    client c = privdata;
+static int controlQps(client c) {
     int thread_id = c->thread_id == -1 ? 0 : c->thread_id;
     if (config.paused[thread_id]) {
         /* this thread has been paused, delete event and add it to paused clients list */
@@ -692,7 +691,7 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
         if (config.cluster_mode && c->staglen > 0) setClusterKeyHashTag(c);
         atomicGet(config.slots_last_update, c->slots_last_update);
         c->start = ustime();
-        if (config.qps && controlQps((void *) c)) return;
+        if (config.qps && controlQps(c)) return;
         c->latency = -1;
     }
     const ssize_t buflen = sdslen(c->obuf);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -684,6 +684,8 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
         int requests_issued = 0;
         atomicGetIncr(config.requests_issued, requests_issued, config.pipeline);
         if (requests_issued >= config.requests) {
+            atomicDecr(config.requests_issued, config.pipeline);
+            freeClient(c);
             return;
         }
 

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1071,7 +1071,7 @@ static void initQpsControl() {
         qps_per_thread = 1;
     }
     for (int i = 0; i < num_threads; ++i) {
-        config.paused_clients[i] = zmalloc(sizeof(list));
+        config.paused_clients[i] = listCreate();
         config.last_resume_time[i] = -1;
         config.control_granularity[i] = qps_per_thread;
         config.resume_interval[i] = USECOND;

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1062,8 +1062,8 @@ static void initQpsControl() {
     int qps_per_thread = config.qps / num_threads;
     config.paused_clients = zmalloc(num_threads * sizeof(list *));
     config.last_resume_time = zmalloc(num_threads * sizeof(long long));
-    config.count = zmalloc(num_threads * sizeof(int));
-    config.paused = zmalloc(num_threads * sizeof(bool));
+    config.count = zcalloc(num_threads * sizeof(int));
+    config.paused = zcalloc(num_threads * sizeof(bool));
     config.control_granularity = zmalloc(num_threads * sizeof(int));
     config.resume_interval = zmalloc(num_threads * sizeof(long long));
     if (qps_per_thread/config.pipeline <= 0) {
@@ -1089,6 +1089,8 @@ static void finishQpsControl() {
     if (config.last_resume_time) zfree(config.last_resume_time);
     if (config.count) zfree(config.count);
     if (config.paused) zfree(config.count);
+    if (config.control_granularity) zfree(config.control_granularity);
+    if (config.resume_interval) zfree(config.resume_interval);
 }
 
 static void benchmark(const char *title, char *cmd, int len) {

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -654,8 +654,9 @@ static int controlQps(client c) {
             aeCreateTimeEvent(CLIENT_GET_EVENTLOOP(c), (config.resume_interval[thread_id]-time_elapsed)/1000, resumeClients, c, NULL);
             
             if (config.resume_interval[thread_id] - time_elapsed >= 10000 && config.control_granularity[thread_id] >= 2*config.pipeline) {
-                config.resume_interval[thread_id] /= 2;
-                config.control_granularity[thread_id] /= 2;
+                int new_granularity = config.control_granularity[thread_id] / 2;
+                config.resume_interval[thread_id] = config.resume_interval[thread_id] * new_granularity / config.control_granularity[thread_id];
+                config.control_granularity[thread_id] = new_granularity;
             }
             return 1;
         }


### PR DESCRIPTION
-  implement throughput control in redis-benchmark using producer/consumer model  
    * use `--qps` arg to control throughput
- change the latency computation logic to make it closer to the real scene (from user's perspective)