### PR TITLE
Fix stream sanitization for non-int first value

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3603,12 +3603,12 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep) {
         p = next; if (!lpValidateNext(lp, &next, size)) return 0;
 
         /* entry id */
-        p = next; if (!lpValidateNext(lp, &next, size)) return 0;
         lpGetIntegerIfValid(p, &valid_record);
         if (!valid_record) return 0;
         p = next; if (!lpValidateNext(lp, &next, size)) return 0;
         lpGetIntegerIfValid(p, &valid_record);
         if (!valid_record) return 0;
+        p = next; if (!lpValidateNext(lp, &next, size)) return 0;
 
         if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) {
             /* num-of-fields */

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -45,7 +45,7 @@ start_server [list overrides [list "dir" $server_path] keep_persistence true] {
     test {Test RDB stream encoding} {
         for {set j 0} {$j < 1000} {incr j} {
             if {rand() < 0.9} {
-                r xadd stream * foo $j
+                r xadd stream * foo abc
             } else {
                 r xadd stream * bar $j
             }


### PR DESCRIPTION
This was recently broken in #9321 when we validated stream IDs to be
integers but did that after to the stepping next record instead of before.