### PR TITLE
Fix integer overflow in _sdsMakeRoomFor (CVE-2021-41099)

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -239,7 +239,7 @@ void sdsclear(sds s) {
 sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
     void *sh, *newsh;
     size_t avail = sdsavail(s);
-    size_t len, newlen, alloclen;
+    size_t len, newlen, reqlen;
     char type, oldtype = s[-1] & SDS_TYPE_MASK;
     int hdrlen;
     size_t usable;
@@ -249,7 +249,7 @@ sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
 
     len = sdslen(s);
     sh = (char*)s-sdsHdrSize(oldtype);
-    alloclen = newlen = (len+addlen);
+    reqlen = newlen = (len+addlen);
     assert(newlen > len);   /* Catch size_t overflow */
     if (greedy == 1) {
         if (newlen < SDS_MAX_PREALLOC)
@@ -266,7 +266,7 @@ sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
     if (type == SDS_TYPE_5) type = SDS_TYPE_8;
 
     hdrlen = sdsHdrSize(type);
-    assert(hdrlen + newlen + 1 > alloclen);  /* Catch size_t overflow */
+    assert(hdrlen + newlen + 1 > reqlen);  /* Catch size_t overflow */
     if (oldtype==type) {
         newsh = s_realloc_usable(sh, hdrlen+newlen+1, &usable);
         if (newsh == NULL) return NULL;

--- a/src/sds.c
+++ b/src/sds.c
@@ -239,7 +239,7 @@ void sdsclear(sds s) {
 sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
     void *sh, *newsh;
     size_t avail = sdsavail(s);
-    size_t len, newlen;
+    size_t len, newlen, alloclen;
     char type, oldtype = s[-1] & SDS_TYPE_MASK;
     int hdrlen;
     size_t usable;
@@ -249,15 +249,13 @@ sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
 
     len = sdslen(s);
     sh = (char*)s-sdsHdrSize(oldtype);
-    newlen = (len+addlen);
+    alloclen = newlen = (len+addlen);
     assert(newlen > len);   /* Catch size_t overflow */
     if (greedy == 1) {
         if (newlen < SDS_MAX_PREALLOC)
             newlen *= 2;
-        else {
-            assert (newlen + SDS_MAX_PREALLOC > newlen);  /* Catch size_t overflow */
+        else
             newlen += SDS_MAX_PREALLOC;
-        }
     }
 
     type = sdsReqType(newlen);
@@ -268,7 +266,7 @@ sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
     if (type == SDS_TYPE_5) type = SDS_TYPE_8;
 
     hdrlen = sdsHdrSize(type);
-    assert(hdrlen + newlen + 1 > newlen);  /* Catch size_t overflow */
+    assert(hdrlen + newlen + 1 > alloclen);  /* Catch size_t overflow */
     if (oldtype==type) {
         newsh = s_realloc_usable(sh, hdrlen+newlen+1, &usable);
         if (newsh == NULL) return NULL;

--- a/src/sds.c
+++ b/src/sds.c
@@ -254,8 +254,10 @@ sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
     if (greedy == 1) {
         if (newlen < SDS_MAX_PREALLOC)
             newlen *= 2;
-        else
+        else {
+            assert (newlen + SDS_MAX_PREALLOC > newlen);  /* Catch size_t overflow */
             newlen += SDS_MAX_PREALLOC;
+        }
     }
 
     type = sdsReqType(newlen);
@@ -266,7 +268,7 @@ sds _sdsMakeRoomFor(sds s, size_t addlen, int greedy) {
     if (type == SDS_TYPE_5) type = SDS_TYPE_8;
 
     hdrlen = sdsHdrSize(type);
-    assert(hdrlen + newlen + 1 > len);  /* Catch size_t overflow */
+    assert(hdrlen + newlen + 1 > newlen);  /* Catch size_t overflow */
     if (oldtype==type) {
         newsh = s_realloc_usable(sh, hdrlen+newlen+1, &usable);
         if (newsh == NULL) return NULL;


### PR DESCRIPTION
An integer overflow bug in the underlying string library can be used to corrupt the heap and potentially result with denial of service or remote code execution.

The vulnerability involves changing the default proto-max-bulk-len configuration parameter to a very large value and constructing specially crafted network payloads or commands.