### PR TITLE
verbose debug print in test to debug rare CI failure.

### DIFF
--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -126,7 +126,11 @@ start_server {tags {"maxmemory" "external:skip"}} {
             }
 
             for {set j 0} {$j < 40} {incr j} {
-                catch {r publish bla [string repeat x 100000]} err
+                if {[catch {r publish bla [string repeat x 100000]} err]} {
+                    if $::verbose {
+                        puts "Error publishing: $err"
+                    }
+                }
             }
 
             verify_test $client_eviction


### PR DESCRIPTION
See https://github.com/redis/redis/runs/3726678420?check_suite_focus=true
```
*** [err]: eviction due to output buffers of pubsub, client eviction: false in tests/unit/maxmemory.tcl
Expected '0' to be more than '0' (context: type source line 41 file /__w/redis/redis/tests/unit/maxmemory.tcl cmd {assert_moret
```
For some reason the maxmemory pubsub obuf publish tests which should fill the output buffer and cause key eviction fails sometimes with TLS turned on. Added debug print to verify `publish` commands aren't failing.