### PR TITLE
Allow to override OPENSSL_PREFIX

### DIFF
--- a/deps/hiredis/Makefile
+++ b/deps/hiredis/Makefile
@@ -77,7 +77,12 @@ ifeq ($(USE_SSL),1)
 endif
 
 ifeq ($(uname_S),Linux)
-  SSL_LDFLAGS=-lssl -lcrypto
+  ifdef OPENSSL_PREFIX
+    CFLAGS+=-I$(OPENSSL_PREFIX)/include
+    SSL_LDFLAGS+=-L$(OPENSSL_PREFIX)/lib -lssl -lcrypto
+  else
+    SSL_LDFLAGS=-lssl -lcrypto
+  endif
 else
   OPENSSL_PREFIX?=/usr/local/opt/openssl
   CFLAGS+=-I$(OPENSSL_PREFIX)/include

--- a/src/Makefile
+++ b/src/Makefile
@@ -121,15 +121,11 @@ ifeq ($(uname_S),Darwin)
 	# must be referenced explicitly during build.
 ifeq ($(uname_M),arm64)
 	# Homebrew arm64 uses /opt/homebrew as HOMEBREW_PREFIX
-	OPENSSL_PREFIX=/opt/homebrew/opt/openssl
+	OPENSSL_PREFIX?=/opt/homebrew/opt/openssl
 else
 	# Homebrew x86/ppc uses /usr/local as HOMEBREW_PREFIX
-	OPENSSL_PREFIX=/usr/local/opt/openssl
+	OPENSSL_PREFIX?=/usr/local/opt/openssl
 endif
-OPENSSL_CFLAGS=-I$(OPENSSL_PREFIX)/include
-OPENSSL_LDFLAGS=-L$(OPENSSL_PREFIX)/lib
-# Also export OPENSSL_PREFIX so it ends up in deps sub-Makefiles
-export OPENSSL_PREFIX
 else
 ifeq ($(uname_S),AIX)
         # AIX
@@ -190,6 +186,14 @@ endif
 endif
 endif
 endif
+
+ifdef OPENSSL_PREFIX
+	OPENSSL_CFLAGS=-I$(OPENSSL_PREFIX)/include
+	OPENSSL_LDFLAGS=-L$(OPENSSL_PREFIX)/lib
+	# Also export OPENSSL_PREFIX so it ends up in deps sub-Makefiles
+	export OPENSSL_PREFIX
+endif
+
 # Include paths to dependencies
 FINAL_CFLAGS+= -I../deps/hiredis -I../deps/linenoise -I../deps/lua/src -I../deps/hdr_histogram
 


### PR DESCRIPTION
While the original issue was on Linux, this should work for other
platforms as well.

Fixes #9565