### PR TITLE
decrby LLONG_MIN caused nagation overflow.

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -637,6 +637,11 @@ void decrbyCommand(client *c) {
     long long incr;
 
     if (getLongLongFromObjectOrReply(c, c->argv[2], &incr, NULL) != C_OK) return;
+    /* Overflow check: negating LLONG_MIN will cause an overflow */
+    if (incr == LLONG_MIN) {
+        addReplyError(c, "decrement would overflow");
+        return;
+    }
     incrDecrCommand(c,-incr);
 }
 

--- a/tests/unit/type/incr.tcl
+++ b/tests/unit/type/incr.tcl
@@ -42,6 +42,12 @@ start_server {tags {"incr"}} {
         format $err
     } {ERR*}
 
+    test {DECRBY negation overflow} {
+        r set x 0
+        catch {r decrby x -9223372036854775808} err
+        format $err
+    } {ERR*}
+
     test {INCR fails against a key holding a list} {
         r rpush mylist 1
         catch {r incr mylist} err


### PR DESCRIPTION
See #725

Note that this breaks compatibility because in the past doing:
`DECRBY x -9223372036854775808` 
would succeed (and create an invalid result) and now this returns an error.