### PR TITLE
XADD - skip rewrite the id arg if it was given and is valid.

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1841,9 +1841,11 @@ void xaddCommand(client *c) {
 
     /* Let's rewrite the ID argument with the one actually generated for
      * AOF/replication propagation. */
-    robj *idarg = createObjectFromStreamID(&id);
-    rewriteClientCommandArgument(c,idpos,idarg);
-    decrRefCount(idarg);
+    if (!parsed_args.id_given) {
+        robj *idarg = createObjectFromStreamID(&id);
+        rewriteClientCommandArgument(c, idpos, idarg);
+        decrRefCount(idarg);
+    }
 
     /* We need to signal to blocked clients that there is new data on this
      * stream. */


### PR DESCRIPTION
When calling `XADD` with a predefined id (instead of `*`) there's no need to run the code which replaces the supplied id with itself. Only when we pass a wildcard id we need to do this. For apps which always supply their own id this is a slight optimization.