### PR TITLE
Avoid argv memcpy when queuing a multi command.

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -790,6 +790,7 @@ typedef struct dbBackup dbBackup;
 /* Client MULTI/EXEC state */
 typedef struct multiCmd {
     robj **argv;
+    int argv_len;
     int argc;
     struct redisCommand *cmd;
 } multiCmd;


### PR DESCRIPTION
When queuing a multi command we duplicated the argv (meaning an alloc and a memcpy). This isn't needed since we can use the previously allocated argv and just reset the client objects argv to NULL. This should saves some memory and is a minor optimization in heavy MULTI/EXEC traffic, especially if there are lots of arguments.