### PR TITLE
Added module-acquire-GIL LATENCY tracking

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2973,7 +2973,15 @@ void afterSleep(struct aeEventLoop *eventLoop) {
 
     /* Acquire the modules GIL so that their threads won't touch anything. */
     if (!ProcessingEventsWhileBlocked) {
-        if (moduleCount()) moduleAcquireGIL();
+        if (moduleCount()) {
+            mstime_t latency;
+            latencyStartMonitor(latency);
+
+            moduleAcquireGIL();
+
+            latencyEndMonitor(latency);
+            latencyAddSampleIfNeeded("module-acquire-GIL",latency);
+        }
     }
 }
 


### PR DESCRIPTION
The new value indicates how long Redis wait to acquire the GIL after sleep. This can help identify problems where a module performs some background operation for a long time (with the GIL held) and blocks the Redis main thread.
This will be now reflected in the LATENCY command.