### PR TITLE
obuf based eviction tests run until eviction occurs

### DIFF
--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -22,7 +22,7 @@ start_server {tags {"maxmemory" "external:skip"}} {
         assert_equal [r dbsize] 50
     }
     
-    # Return true if the eviction occured (client or key) based on argument
+    # Return true if the eviction occurred (client or key) based on argument
     proc check_eviction_test {client_eviction} {
         set evicted_keys [s evicted_keys]
         set evicted_clients [s evicted_clients]


### PR DESCRIPTION
obuf based eviction tests run until eviction occurs instead of assuming a certain amount of writes will fill the obuf enough for eviction to occur. This handles the kernel buffering written data and emptying the obuf even though no one actualy reads from it.

The tests have a new timeout of 20sec: if the test doesn't pass after 20 sec it'll fail. Hopefully this enough for our slow CI targets.

This also eliminates the need to skip some tests in TLS.