### PR TITLE
master client should ignore proto_max_bulk_len in bitops

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -429,8 +429,7 @@ int getBitOffsetFromArgument(client *c, robj *o, uint64_t *offset, int hash, int
     if (usehash) loffset *= bits;
 
     /* Limit offset to server.proto_max_bulk_len (512MB in bytes by default) */
-    if (!(c->flags & CLIENT_MASTER) &&
-        ((loffset < 0) || (loffset >> 3) >= server.proto_max_bulk_len))
+    if (loffset < 0 || (!(c->flags & CLIENT_MASTER) && (loffset >> 3) >= server.proto_max_bulk_len))
     {
         addReplyError(c,err);
         return C_ERR;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -429,7 +429,8 @@ int getBitOffsetFromArgument(client *c, robj *o, uint64_t *offset, int hash, int
     if (usehash) loffset *= bits;
 
     /* Limit offset to server.proto_max_bulk_len (512MB in bytes by default) */
-    if ((loffset < 0) || (loffset >> 3) >= server.proto_max_bulk_len)
+    if (!(c->flags & CLIENT_MASTER) &&
+        ((loffset < 0) || (loffset >> 3) >= server.proto_max_bulk_len))
     {
         addReplyError(c,err);
         return C_ERR;


### PR DESCRIPTION
Supplement to #8096 , in case config inconsistency between master and replicas.