### PR TITLE
hiredis: improve calloc() overflow fix.

### DIFF
--- a/deps/hiredis/alloc.c
+++ b/deps/hiredis/alloc.c
@@ -68,6 +68,10 @@ void *hi_malloc(size_t size) {
 }
 
 void *hi_calloc(size_t nmemb, size_t size) {
+    /* Overflow check as the user can specify any arbitrary allocator */
+    if (SIZE_MAX / size < nmemb)
+        return NULL;
+
     return hiredisAllocFns.callocFn(nmemb, size);
 }
 

--- a/deps/hiredis/alloc.h
+++ b/deps/hiredis/alloc.h
@@ -32,6 +32,7 @@
 #define HIREDIS_ALLOC_H
 
 #include <stddef.h> /* for size_t */
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,6 +60,10 @@ static inline void *hi_malloc(size_t size) {
 }
 
 static inline void *hi_calloc(size_t nmemb, size_t size) {
+    /* Overflow check as the user can specify any arbitrary allocator */
+    if (SIZE_MAX / size < nmemb)
+        return NULL;
+
     return hiredisAllocFns.callocFn(nmemb, size);
 }
 

--- a/deps/hiredis/hiredis.c
+++ b/deps/hiredis/hiredis.c
@@ -174,7 +174,6 @@ static void *createArrayObject(const redisReadTask *task, size_t elements) {
         return NULL;
 
     if (elements > 0) {
-        if (SIZE_MAX / sizeof(redisReply*) < elements) return NULL;  /* Don't overflow */
         r->element = hi_calloc(elements,sizeof(redisReply*));
         if (r->element == NULL) {
             freeReplyObject(r);


### PR DESCRIPTION
Cherry pick a more complete fix to 0215324a6 that also doesn't leak
memory from latest hiredis.