### PR TITLE
enable module blocked client to carry through resp version

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -6570,7 +6570,10 @@ RedisModuleCtx *RM_GetThreadSafeContext(RedisModuleBlockedClient *bc) {
     ctx->client = createClient(NULL);
     if (bc) {
         selectDb(ctx->client,bc->dbid);
-        if (bc->client) ctx->client->id = bc->client->id;
+        if (bc->client) {
+            ctx->client->id = bc->client->id;
+            ctx->client->resp = bc->client->resp;
+        }
     }
     return ctx;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -6097,6 +6097,8 @@ RedisModuleBlockedClient *moduleBlockClient(RedisModuleCtx *ctx, RedisModuleCmdF
     bc->free_privdata = free_privdata;
     bc->privdata = privdata;
     bc->reply_client = createClient(NULL);
+    if (bc->client)
+        bc->reply_client->resp = bc->client->resp;
     bc->reply_client->flags |= CLIENT_MODULE;
     bc->dbid = c->db->id;
     bc->blocked_on_keys = keys != NULL;

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -188,6 +188,20 @@ int do_rm_call(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
     return REDISMODULE_OK;
 }
 
+int do_fake_bg_true(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+
+    RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
+    RedisModuleCtx *bctx = RedisModule_GetThreadSafeContext(bc);
+
+    RedisModule_ReplyWithBool(bctx, 1);
+
+    RedisModule_FreeThreadSafeContext(bctx);
+    RedisModule_UnblockClient(bc, NULL);
+
+    return REDISMODULE_OK;
+}
 
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
@@ -203,6 +217,9 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx, "do_bg_rm_call", do_bg_rm_call, "", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "do_fake_bg_true", do_fake_bg_true, "", 0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     return REDISMODULE_OK;

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -191,7 +191,7 @@ int do_rm_call(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
 /* simulate a blocked client replying to a thread safe context without creating a thread */
 int do_fake_bg_true(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     UNUSED(argv);
-r    UNUSED(argc);
+    UNUSED(argc);
 
     RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
     RedisModuleCtx *bctx = RedisModule_GetThreadSafeContext(bc);

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -188,9 +188,10 @@ int do_rm_call(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
     return REDISMODULE_OK;
 }
 
+/* simulate a blocked client replying to a thread safe context without creating a thread */
 int do_fake_bg_true(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     UNUSED(argv);
-    UNUSED(argc);
+r    UNUSED(argc);
 
     RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
     RedisModuleCtx *bctx = RedisModule_GetThreadSafeContext(bc);

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -78,6 +78,20 @@ start_server {tags {"modules"}} {
         r do_bg_rm_call hgetall hash
     } {foo bar}
 
+    test {RESP version carries through to blocked client} {
+        for {set client_proto 2} {$client_proto <= 3} {incr client_proto} {
+            r hello $client_proto
+            r readraw 1
+            set ret [r do_fake_bg_true]
+            if {$client_proto == 2} {
+                assert_equal $ret {:1}
+            } else {
+                assert_equal $ret "#t"
+            }
+            r readraw 0
+        }
+    }
+
     test {blocked client reaches client output buffer limit} {
         r hset hash big [string repeat x 50000]
         r hset hash bada [string repeat x 50000]


### PR DESCRIPTION
currently when we create a blocked client and a thread safe context for it, the new context's client doesn't carry through the original's resp version.

this copies it through to the new client