### PR TITLE
Fix daily failures due to macos-latest change.

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -399,7 +399,7 @@ jobs:
       run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
   test-freebsd:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     if: github.repository == 'redis/redis' && !contains(github.event.inputs.skipjobs, 'freebsd')
     timeout-minutes: 14400
     steps:

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -11,8 +11,9 @@ else	# Linux, others
 endif
 
 # Needed to satisfy __stack_chk_fail_local on Linux with -m32, due to gcc
-# -fstack-protector by default. Breaks on FreeBSD so we exclude it.
-ifneq ($(uname_S),FreeBSD)
+# -fstack-protector by default. Breaks on FreeBSD and macOS 11 so needs
+# to be Linux specific.
+ifeq ($(uname_S),Linux)
     LIBS = -lc
 endif
 


### PR DESCRIPTION
* Fix test modules linking on macOS 11.x.
* Use macOS 10.x for FreeBSD VM as VirtualBox is not yet supported on
  11.