### PR TITLE
Add RM_ReplyWithBigNumber module API

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -43,4 +43,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/cluster \
 --single unit/moduleapi/aclcheck \
 --single unit/moduleapi/subcommands \
+--single unit/moduleapi/reply \
 "${@}"

--- a/src/module.c
+++ b/src/module.c
@@ -2231,7 +2231,7 @@ int RM_ReplyWithNull(RedisModuleCtx *ctx) {
  * Visit https://github.com/antirez/RESP3/blob/master/spec.md for more info about RESP3.
  *
  * In RESP3, this is boolean type
- * In RESP2, it's a string response of "1" and "0" for true and false respectively
+ * In RESP2, it's a string response of "1" and "0" for true and false respectively.
  *
  * The function always returns REDISMODULE_OK. */
 int RM_ReplyWithBool(RedisModuleCtx *ctx, int b) {
@@ -2291,7 +2291,7 @@ int RM_ReplyWithDouble(RedisModuleCtx *ctx, double d) {
  * Visit https://github.com/antirez/RESP3/blob/master/spec.md for more info about RESP3.
  *
  * In RESP3, this is a string of length `len` that is tagged as a BigNumber, 
- * however, it's up to the caller to ensure that it's a valid BigNumber
+ * however, it's up to the caller to ensure that it's a valid BigNumber.
  * In RESP2, this is just a plain bulk string response.
  * 
  * The function always returns REDISMODULE_OK. */
@@ -6472,7 +6472,7 @@ void moduleHandleBlockedClients(void) {
 
     pthread_mutex_lock(&moduleUnblockedClientsMutex);
     /* Here we unblock all the pending clients blocked in modules operations
-     * so we can read every pending "awake byte" in the pipe. */
+     e so we can read every pending "awake byte" in the pipe. */
     char buf[1];
     while (read(server.module_blocked_pipe[0],buf,1) == 1);
     while (listLength(moduleUnblockedClients)) {

--- a/src/module.c
+++ b/src/module.c
@@ -2277,6 +2277,14 @@ int RM_ReplyWithDouble(RedisModuleCtx *ctx, double d) {
     return REDISMODULE_OK;
 }
 
+/* Send a BigNumber reply */
+int RM_ReplyWithBigNumber(RedisModuleCtx *ctx, const char* bignum, size_t len) {
+    client *c = moduleGetReplyClient(ctx);
+    if (c == NULL) return REDISMODULE_OK;
+    addReplyBigNum(c, bignum, len);
+    return REDISMODULE_OK;
+}
+
 /* Send a string reply obtained converting the long double 'ld' into a bulk
  * string. This function is basically equivalent to converting a long double
  * into a string into a C buffer, and then calling the function
@@ -10341,6 +10349,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ReplyWithBool);
     REGISTER_API(ReplyWithCallReply);
     REGISTER_API(ReplyWithDouble);
+    REGISTER_API(ReplyWithBigNumber);
     REGISTER_API(ReplyWithLongDouble);
     REGISTER_API(GetSelectedDb);
     REGISTER_API(SelectDb);

--- a/src/module.c
+++ b/src/module.c
@@ -2276,6 +2276,7 @@ int RM_ReplyWithDouble(RedisModuleCtx *ctx, double d) {
     addReplyDouble(c,d);
     return REDISMODULE_OK;
 }
+
 /* Send a string as a BigNumber reply.  
  * It does not appear that any verification is done on this string to ensure
  * it is a valid BigNumber.  should it?

--- a/src/module.c
+++ b/src/module.c
@@ -2231,7 +2231,7 @@ int RM_ReplyWithNull(RedisModuleCtx *ctx) {
  * Visit https://github.com/antirez/RESP3/blob/master/spec.md for more info about RESP3.
  *
  * In RESP3, this is boolean type
- * In RESP2, its a string response of "1" and "0" for true and false respectively
+ * In RESP2, it's a string response of "1" and "0" for true and false respectively
  *
  * The function always returns REDISMODULE_OK. */
 int RM_ReplyWithBool(RedisModuleCtx *ctx, int b) {
@@ -2290,8 +2290,8 @@ int RM_ReplyWithDouble(RedisModuleCtx *ctx, double d) {
 /* Reply with a RESP3 BigNumber type.
  * Visit https://github.com/antirez/RESP3/blob/master/spec.md for more info about RESP3.
  *
- * In RESP3, this is a string of length lenthat is tagged as a BigNumber, 
- * however, its up to the caller to ensure that its a valid BigNumber
+ * In RESP3, this is a string of length `len` that is tagged as a BigNumber, 
+ * however, it's up to the caller to ensure that it's a valid BigNumber
  * In RESP2, this is just a plain bulk string response.
  * 
  * The function always returns REDISMODULE_OK. */

--- a/src/module.c
+++ b/src/module.c
@@ -2227,7 +2227,11 @@ int RM_ReplyWithNull(RedisModuleCtx *ctx) {
     return REDISMODULE_OK;
 }
 
-/* Reply to the client with a boolean value.
+/* Reply with a RESP3 Boolean type.
+ * Visit https://github.com/antirez/RESP3/blob/master/spec.md for more info about RESP3.
+ *
+ * In RESP3, this is boolean type
+ * In RESP2, its a string response of "1" and "0" for true and false respectively
  *
  * The function always returns REDISMODULE_OK. */
 int RM_ReplyWithBool(RedisModuleCtx *ctx, int b) {
@@ -2277,9 +2281,12 @@ int RM_ReplyWithDouble(RedisModuleCtx *ctx, double d) {
     return REDISMODULE_OK;
 }
 
-/* Send a string as a BigNumber reply.  
- * It does not appear that any verification is done on this string to ensure
- * it is a valid BigNumber.  should it?
+/* Reply with a RESP3 BigNumber type.
+ * Visit https://github.com/antirez/RESP3/blob/master/spec.md for more info about RESP3.
+ *
+ * In RESP3, this is a string of length lenthat is tagged as a BigNumber, 
+ * however, its up to the caller to ensure that its a valid BigNumber
+ * In RESP2, this is just a plain bulk string response.
  * 
  * The function always returns REDISMODULE_OK. */
 int RM_ReplyWithBigNumber(RedisModuleCtx *ctx, const char *bignum, size_t len) {

--- a/src/module.c
+++ b/src/module.c
@@ -2276,8 +2276,11 @@ int RM_ReplyWithDouble(RedisModuleCtx *ctx, double d) {
     addReplyDouble(c,d);
     return REDISMODULE_OK;
 }
-
-/* Send a BigNumber reply */
+/* Send a string as a BigNumber reply.  
+ * It does not appear that any verification is done on this string to ensure
+ * it is a valid BigNumber.  should it?
+ * 
+ * The function always returns REDISMODULE_OK. */
 int RM_ReplyWithBigNumber(RedisModuleCtx *ctx, const char *bignum, size_t len) {
     client *c = moduleGetReplyClient(ctx);
     if (c == NULL) return REDISMODULE_OK;

--- a/src/module.c
+++ b/src/module.c
@@ -2276,7 +2276,7 @@ int RM_ReplyWithCallReply(RedisModuleCtx *ctx, RedisModuleCallReply *reply) {
  * a string into a C buffer, and then calling the function
  * RedisModule_ReplyWithStringBuffer() with the buffer and length.
  *
- * In RESP3 the string is tagged as a double, while in RESP2 its just a plain string 
+ * In RESP3 the string is tagged as a double, while in RESP2 it's just a plain string 
  * that the user will have to parse.
  *
  * The function always returns REDISMODULE_OK. */

--- a/src/module.c
+++ b/src/module.c
@@ -2268,10 +2268,16 @@ int RM_ReplyWithCallReply(RedisModuleCtx *ctx, RedisModuleCallReply *reply) {
     return REDISMODULE_OK;
 }
 
-/* Send a string reply obtained converting the double 'd' into a bulk string.
+/* Reply with a RESP3 Double type.
+ * Visit https://github.com/antirez/RESP3/blob/master/spec.md for more info about RESP3.
+ *
+ * Send a string reply obtained converting the double 'd' into a bulk string.
  * This function is basically equivalent to converting a double into
  * a string into a C buffer, and then calling the function
  * RedisModule_ReplyWithStringBuffer() with the buffer and length.
+ *
+ * In RESP3 the string is tagged as a double, while in RESP2 its just a plain string 
+ * that the user will have to parse.
  *
  * The function always returns REDISMODULE_OK. */
 int RM_ReplyWithDouble(RedisModuleCtx *ctx, double d) {

--- a/src/module.c
+++ b/src/module.c
@@ -2278,7 +2278,7 @@ int RM_ReplyWithDouble(RedisModuleCtx *ctx, double d) {
 }
 
 /* Send a BigNumber reply */
-int RM_ReplyWithBigNumber(RedisModuleCtx *ctx, const char* bignum, size_t len) {
+int RM_ReplyWithBigNumber(RedisModuleCtx *ctx, const char *bignum, size_t len) {
     client *c = moduleGetReplyClient(ctx);
     if (c == NULL) return REDISMODULE_OK;
     addReplyBigNum(c, bignum, len);

--- a/src/module.c
+++ b/src/module.c
@@ -2293,7 +2293,7 @@ int RM_ReplyWithDouble(RedisModuleCtx *ctx, double d) {
  * In RESP3, this is a string of length `len` that is tagged as a BigNumber, 
  * however, it's up to the caller to ensure that it's a valid BigNumber.
  * In RESP2, this is just a plain bulk string response.
- * 
+ *
  * The function always returns REDISMODULE_OK. */
 int RM_ReplyWithBigNumber(RedisModuleCtx *ctx, const char *bignum, size_t len) {
     client *c = moduleGetReplyClient(ctx);
@@ -6472,7 +6472,7 @@ void moduleHandleBlockedClients(void) {
 
     pthread_mutex_lock(&moduleUnblockedClientsMutex);
     /* Here we unblock all the pending clients blocked in modules operations
-     e so we can read every pending "awake byte" in the pipe. */
+     * so we can read every pending "awake byte" in the pipe. */
     char buf[1];
     while (read(server.module_blocked_pipe[0],buf,1) == 1);
     while (listLength(moduleUnblockedClients)) {

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -667,8 +667,9 @@ REDISMODULE_API int (*RedisModule_ReplyWithVerbatimString)(RedisModuleCtx *ctx, 
 REDISMODULE_API int (*RedisModule_ReplyWithVerbatimStringType)(RedisModuleCtx *ctx, const char *buf, size_t len, const char *ext) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithNull)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithBool)(RedisModuleCtx *ctx, int b) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithDouble)(RedisModuleCtx *ctx, double d) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithLongDouble)(RedisModuleCtx *ctx, long double d) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithDouble)(RedisModuleCtx *ctx, double d) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithBigNumber)(RedisModuleCtx *ctx, const char* bignum, size_t len) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithCallReply)(RedisModuleCtx *ctx, RedisModuleCallReply *reply) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StringToLongLong)(const RedisModuleString *str, long long *ll) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StringToDouble)(const RedisModuleString *str, double *d) REDISMODULE_ATTR;
@@ -953,6 +954,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ReplyWithBool);
     REDISMODULE_GET_API(ReplyWithCallReply);
     REDISMODULE_GET_API(ReplyWithDouble);
+    REDISMODULE_GET_API(ReplyWithBigNumber);
     REDISMODULE_GET_API(ReplyWithLongDouble);
     REDISMODULE_GET_API(GetSelectedDb);
     REDISMODULE_GET_API(SelectDb);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -669,7 +669,7 @@ REDISMODULE_API int (*RedisModule_ReplyWithNull)(RedisModuleCtx *ctx) REDISMODUL
 REDISMODULE_API int (*RedisModule_ReplyWithBool)(RedisModuleCtx *ctx, int b) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithLongDouble)(RedisModuleCtx *ctx, long double d) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithDouble)(RedisModuleCtx *ctx, double d) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithBigNumber)(RedisModuleCtx *ctx, const char* bignum, size_t len) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithBigNumber)(RedisModuleCtx *ctx, const char *bignum, size_t len) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithCallReply)(RedisModuleCtx *ctx, RedisModuleCallReply *reply) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StringToLongLong)(const RedisModuleString *str, long long *ll) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StringToDouble)(const RedisModuleString *str, double *d) REDISMODULE_ATTR;

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -51,7 +51,8 @@ TEST_MODULES = \
     stream.so \
     aclcheck.so \
     list.so \
-    subcommands.so
+    subcommands.so \
+    reply.so
 
 
 .PHONY: all

--- a/tests/modules/reply.c
+++ b/tests/modules/reply.c
@@ -50,7 +50,7 @@ int rw_longdouble(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 int rw_bignumber(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 1) return RedisModule_WrongArity(ctx);
 
-     return RedisModule_ReplyWithBigNumber(ctx, "12345678901234567890");
+    return RedisModule_ReplyWithBigNumber(ctx, "12345678901234567890");
 }
 
 int rw_array(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {

--- a/tests/modules/reply.c
+++ b/tests/modules/reply.c
@@ -115,9 +115,9 @@ int rw_attribute(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     for (int i = 0; i < integer; ++i) {
         RedisModule_ReplyWithLongLong(ctx, i);
+        RedisModule_ReplyWithDouble(ctx, i * 1.5);
     }
 
-    RedisModule_ReplyWithSimpleString(ctx, "OK");
     return REDISMODULE_OK;
 }
 

--- a/tests/modules/reply.c
+++ b/tests/modules/reply.c
@@ -118,6 +118,8 @@ int rw_attribute(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         RedisModule_ReplyWithDouble(ctx, i * 1.5);
     }
 
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+
     return REDISMODULE_OK;
 }
 

--- a/tests/modules/reply.c
+++ b/tests/modules/reply.c
@@ -47,6 +47,12 @@ int rw_longdouble(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithLongDouble(ctx, longdbl);
 }
 
+int rw_bignumber(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 1) return RedisModule_WrongArity(ctx);
+
+     return RedisModule_ReplyWithBigNumber(ctx, "12345678901234567890");
+}
+
 int rw_array(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 2) return RedisModule_WrongArity(ctx);
 
@@ -150,6 +156,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_CreateCommand(ctx,"rw.string",rw_string,"",0,0,0) != REDISMODULE_OK)
         return REDISMODULE_ERR;
     if (RedisModule_CreateCommand(ctx,"rw.cstring",rw_cstring,"",0,0,0) != REDISMODULE_OK)
+        return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx,"rw.bignumber",rw_bignumber,"",0,0,0) != REDISMODULE_OK)
         return REDISMODULE_ERR;
     if (RedisModule_CreateCommand(ctx,"rw.int",rw_int,"",0,0,0) != REDISMODULE_OK)
         return REDISMODULE_ERR;

--- a/tests/modules/reply.c
+++ b/tests/modules/reply.c
@@ -48,9 +48,12 @@ int rw_longdouble(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 }
 
 int rw_bignumber(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    if (argc != 1) return RedisModule_WrongArity(ctx);
+    if (argc != 2) return RedisModule_WrongArity(ctx);
 
-    return RedisModule_ReplyWithBigNumber(ctx, "12345678901234567890");
+    size_t bignum_len;
+    const char *bignum_str = RedisModule_StringPtrLen(argv[1], &bignum_len);
+
+    return RedisModule_ReplyWithBigNumber(ctx, bignum_str, bignum_len);
 }
 
 int rw_array(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -142,9 +145,12 @@ int rw_error(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 }
 
 int rw_verbatim(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    if (argc != 1) return RedisModule_WrongArity(ctx);
+    if (argc != 2) return RedisModule_WrongArity(ctx);
 
-    return RedisModule_ReplyWithVerbatimString(ctx, argv[1]);
+    size_t verbatim_len;
+    const char *verbatim_str = RedisModule_StringPtrLen(argv[1], &verbatim_len);
+
+    return RedisModule_ReplyWithVerbatimString(ctx, verbatim_str, verbatim_len);
 }
 
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {

--- a/tests/modules/reply.c
+++ b/tests/modules/reply.c
@@ -119,7 +119,6 @@ int rw_attribute(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
 
     RedisModule_ReplyWithSimpleString(ctx, "OK");
-
     return REDISMODULE_OK;
 }
 

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -281,7 +281,11 @@ proc ::redis::redis_read_reply {id fd} {
             ~ -
             * {return [redis_multi_bulk_read $id $fd]}
             % {return [redis_read_map $id $fd]}
-            | {return [redis_read_map $id $fd]}
+            | {
+                # ignore attributes for now (nowhere to store them)
+                redis_read_map $id $fd
+                continue
+            }
             default {
                 if {$type eq {}} {
                     catch {close $fd}

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -281,11 +281,7 @@ proc ::redis::redis_read_reply {id fd} {
             ~ -
             * {return [redis_multi_bulk_read $id $fd]}
             % {return [redis_read_map $id $fd]}
-            | {
-                # ignore attributes for now (nowhere to store them)
-                redis_read_map $id $fd
-                continue
-            }
+            | {return [redis_read_map $id $fd]}
             default {
                 if {$type eq {}} {
                     catch {close $fd}

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -1,11 +1,9 @@
-
-
 set testmodule [file normalize tests/modules/reply.so]
 
 start_server {tags {"modules"}} {
     r module load $testmodule
     
-#   test all with hello 2/3
+    #   test all with hello 2/3
     for {set proto 2} {$proto <= 3} {incr proto} {
         r hello $proto
 

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -62,6 +62,9 @@ start_server {tags {"modules"}} {
             } else {
                 set res [r rw.attribute 3]
                 assert_equal [dict create 0 0.0 1 1.5 2 3.0] $res
+		r readraw 1
+		assert_equal [r read] {+OK}
+		r readraw 0
             }
         }
 

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -17,6 +17,11 @@ start_server {tags {"modules"}} {
             assert_equal "A simple string" $string
         }
 
+        test {RM_ReplyWithBigNumber: an string reply} {
+            set bignumber [r rw.bignumber "123456778901234567890"
+            asset_equal "123456778901234567890" $bignumber
+        }
+
         test {RM_ReplyWithInt: an integer reply} {
             assert_equal 42 [r rw.int 42]
         }

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -45,7 +45,7 @@ start_server {tags {"modules"}} {
         test {RM_ReplyWithMap: an map reply} {
             set res [r rw.map 3]
             if {$proto == 2} {
-                assert_equal {0 0.0 1 1.5 2 3.0} $res
+                assert_equal {0 0 1 1.5 2 3} $res
             } else {
                 assert_equal [dict create 0 0.0 1 1.5 2 3.0] $res
             }
@@ -56,14 +56,13 @@ start_server {tags {"modules"}} {
         }
 
         test {RM_ReplyWithAttribute: an set reply} {
-            set res [r rw.attribute 3]
             if {$proto == 2} {
-                catch {r rw.error} e
+                catch {[r rw.attribute 3]} e
                 assert_match "Attributes aren't supported by RESP 2" $e
             } else {
+                set res [r rw.attribute 3]
                 assert_equal [dict create 0 0.0 1 1.5 2 3.0] $res
             }
-            assert_equal "OK" $res
         }
 
         test {RM_ReplyWithBool: a boolean reply} {

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -60,16 +60,16 @@ start_server {tags {"modules"}} {
                 catch {[r rw.attribute 3]} e
                 assert_match "Attributes aren't supported by RESP 2" $e
             } else {
-		r readraw 1
+                r readraw 1
                 set res [r rw.attribute 3]
-		assert_equal [r read] {:0}
-		assert_equal [r read] {,0}
-		assert_equal [r read] {:1}
-		assert_equal [r read] {,1.5}
-		assert_equal [r read] {:2}
-		assert_equal [r read] {,3}
-		assert_equal [r read] {+OK}
-		r readraw 0
+                assert_equal [r read] {:0}
+                assert_equal [r read] {,0}
+                assert_equal [r read] {:1}
+                assert_equal [r read] {,1.5}
+                assert_equal [r read] {:2}
+                assert_equal [r read] {,3}
+                assert_equal [r read] {+OK}
+                r readraw 0
             }
         }
 

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -60,9 +60,14 @@ start_server {tags {"modules"}} {
                 catch {[r rw.attribute 3]} e
                 assert_match "Attributes aren't supported by RESP 2" $e
             } else {
-                set res [r rw.attribute 3]
-                assert_equal [dict create 0 0.0 1 1.5 2 3.0] $res
 		r readraw 1
+                set res [r rw.attribute 3]
+		assert_equal [r read] {:0}
+		assert_equal [r read] {,0}
+		assert_equal [r read] {:1}
+		assert_equal [r read] {,1.5}
+		assert_equal [r read] {:2}
+		assert_equal [r read] {,3}
 		assert_equal [r read] {+OK}
 		r readraw 0
             }

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -1,11 +1,12 @@
-set testmodule [file normalize tests/modules/reply.so]
 
-# test all with hello 2/3
+
+set testmodule [file normalize tests/modules/reply.so]
 
 start_server {tags {"modules"}} {
     r module load $testmodule
     
-    for {proto=2; proto<=3; incr proto} {
+#   test all with hello 2/3
+    for {set proto 2} {$proto <= 3} {incr proto} {
         r hello $proto
 
         test {RM_ReplyWithString: an string reply} {
@@ -18,8 +19,7 @@ start_server {tags {"modules"}} {
         }
 
         test {RM_ReplyWithBigNumber: an string reply} {
-            set bignumber [r rw.bignumber "123456778901234567890"]
-            asset_equal "123456778901234567890" $bignumber
+            assert_equal "123456778901234567890" [r rw.bignumber "123456778901234567890"]
         }
 
         test {RM_ReplyWithInt: an integer reply} {
@@ -42,29 +42,29 @@ start_server {tags {"modules"}} {
             assert_equal {0 1 2 3 4} [r rw.array 5]
         }
 
-        test {RM_ReplyWithMap: an map reply} {
-            set res [r rw.map 3]
-            if {$proto == 2} {
-                assert_equal {0 0.0 1 1.5 2 3.0} $res
-            } else {
-                assert_equal [dict create 0 0.0 1 1.5 2 3.0] $res
-            }
-        }
+#        test {RM_ReplyWithMap: an map reply} {
+#            set res [r rw.map 3]
+#            if {$proto == 2} {
+#                assert_equal {0 0.0 1 1.5 2 3.0} $res
+#            } else {
+#                assert_equal [dict create 0 0.0 1 1.5 2 3.0] $res
+#            }
+#        }
 
         test {RM_ReplyWithSet: an set reply} {
             assert_equal {0 1 2} [r rw.set 3]
         }
 
-        test {RM_ReplyWithAttribute: an set reply} {
-            set res [r rw.attribute 3]
-            if {$proto == 2} {
-                catch {r rw.error} e
-                assert_match "Attributes aren't supported by RESP 2" $e
-            } else {
-                assert_equal [dict create 0 0.0 1 1.5 2 3.0] $res
-            }
-            assert_equal "OK" $res
-        }
+#        test {RM_ReplyWithAttribute: an set reply} {
+#            set res [r rw.attribute 3]
+#            if {$proto == 2} {
+#                catch {r rw.error} e
+#                assert_match "Attributes aren't supported by RESP 2" $e
+#            } else {
+#                assert_equal [dict create 0 0.0 1 1.5 2 3.0] $res
+#            }
+#            assert_equal "OK" $res
+#        }
 
         test {RM_ReplyWithBool: a boolean reply} {
             assert_equal {0 1} [r rw.bool]

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -18,7 +18,7 @@ start_server {tags {"modules"}} {
         }
 
         test {RM_ReplyWithBigNumber: an string reply} {
-            set bignumber [r rw.bignumber "123456778901234567890"
+            set bignumber [r rw.bignumber "123456778901234567890"]
             asset_equal "123456778901234567890" $bignumber
         }
 

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -42,29 +42,29 @@ start_server {tags {"modules"}} {
             assert_equal {0 1 2 3 4} [r rw.array 5]
         }
 
-#        test {RM_ReplyWithMap: an map reply} {
-#            set res [r rw.map 3]
-#            if {$proto == 2} {
-#                assert_equal {0 0.0 1 1.5 2 3.0} $res
-#            } else {
-#                assert_equal [dict create 0 0.0 1 1.5 2 3.0] $res
-#            }
-#        }
+        test {RM_ReplyWithMap: an map reply} {
+            set res [r rw.map 3]
+            if {$proto == 2} {
+                assert_equal {0 0.0 1 1.5 2 3.0} $res
+            } else {
+                assert_equal [dict create 0 0.0 1 1.5 2 3.0] $res
+            }
+        }
 
         test {RM_ReplyWithSet: an set reply} {
             assert_equal {0 1 2} [r rw.set 3]
         }
 
-#        test {RM_ReplyWithAttribute: an set reply} {
-#            set res [r rw.attribute 3]
-#            if {$proto == 2} {
-#                catch {r rw.error} e
-#                assert_match "Attributes aren't supported by RESP 2" $e
-#            } else {
-#                assert_equal [dict create 0 0.0 1 1.5 2 3.0] $res
-#            }
-#            assert_equal "OK" $res
-#        }
+        test {RM_ReplyWithAttribute: an set reply} {
+            set res [r rw.attribute 3]
+            if {$proto == 2} {
+                catch {r rw.error} e
+                assert_match "Attributes aren't supported by RESP 2" $e
+            } else {
+                assert_equal [dict create 0 0.0 1 1.5 2 3.0] $res
+            }
+            assert_equal "OK" $res
+        }
 
         test {RM_ReplyWithBool: a boolean reply} {
             assert_equal {0 1} [r rw.bool]


### PR DESCRIPTION
Let modules use additional type of RESP3 response (unused by redis so far)

Also fix tests that where introduced in #8521 but didn't actually run.
