### PR TITLE
fix: lookupKey on SETNX and SETXX only once

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -777,7 +777,7 @@ void bitopCommand(client *c) {
     /* Store the computed value into the target key */
     if (maxlen) {
         o = createObject(OBJ_STRING,res);
-        setKey(c,c->db,targetkey,o);
+        setKey(c,c->db,targetkey,o,SETKEY_SIGNAL);
         notifyKeyspaceEvent(NOTIFY_STRING,"set",targetkey,c->db->id);
         decrRefCount(o);
         server.dirty++;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -777,7 +777,7 @@ void bitopCommand(client *c) {
     /* Store the computed value into the target key */
     if (maxlen) {
         o = createObject(OBJ_STRING,res);
-        setKey(c,c->db,targetkey,o,SETKEY_SIGNAL);
+        setKey(c,c->db,targetkey,o,0);
         notifyKeyspaceEvent(NOTIFY_STRING,"set",targetkey,c->db->id);
         decrRefCount(o);
         server.dirty++;

--- a/src/db.c
+++ b/src/db.c
@@ -254,16 +254,16 @@ void setKey(client *c, redisDb *db, robj *key, robj *val, int flags) {
     if (flags & SETKEY_ALREADY_EXIST)
         keyfound = 1;
     else if (!(flags & SETKEY_DOESNT_EXIST))
-        keyfound = (lookupKeyWrite(db, key) != NULL);
+        keyfound = (lookupKeyWrite(db,key) != NULL);
 
     if (!keyfound) {
-        dbAdd(db, key, val);
+        dbAdd(db,key,val);
     } else {
-        dbOverwrite(db, key, val);
+        dbOverwrite(db,key,val);
     }
     incrRefCount(val);
-    if (!(flags & SETKEY_KEEPTTL)) removeExpire(db, key);
-    if (flags & SETKEY_SIGNAL) signalModifiedKey(c, db, key);
+    if (!(flags & SETKEY_KEEPTTL)) removeExpire(db,key);
+    if (flags & SETKEY_SIGNAL) signalModifiedKey(c,db,key);
 }
 
 /* Return a random key, in form of a Redis object.

--- a/src/db.c
+++ b/src/db.c
@@ -259,6 +259,8 @@ void genericSetKeyLookup(client *c, redisDb *db, robj *key, robj *val,int keeptt
     if (!keepttl) removeExpire(db,key);
     if (signal) signalModifiedKey(c,db,key);
 }
+
+/* Wrapper for genericSetKeyLookup. */
 void genericSetKey(client *c, redisDb *db, robj *key, robj *val,int keepttl,
                          int signal) {
     genericSetKeyLookup(c, db, key, val, keepttl, signal, lookupKeyWrite(db,key));

--- a/src/db.c
+++ b/src/db.c
@@ -263,7 +263,7 @@ void setKey(client *c, redisDb *db, robj *key, robj *val, int flags) {
     }
     incrRefCount(val);
     if (!(flags & SETKEY_KEEPTTL)) removeExpire(db,key);
-    if (flags & SETKEY_SIGNAL) signalModifiedKey(c,db,key);
+    if (!(flags & SETKEY_NO_SIGNAL)) signalModifiedKey(c,db,key);
 }
 
 /* Return a random key, in form of a Redis object.

--- a/src/db.c
+++ b/src/db.c
@@ -249,8 +249,8 @@ void dbOverwrite(redisDb *db, robj *key, robj *val) {
  * The client 'c' argument may be set to NULL if the operation is performed
  * in a context where there is no clear client performing the operation. */
 void genericSetKeyLookup(client *c, redisDb *db, robj *key, robj *val,int keepttl,
-                         int signal, int keyLooked, int keyFound) {
-    if ((!keyLooked || !keyFound) && lookupKeyWrite(db,key) == NULL) {
+                         int signal, robj* keyFound) {
+    if (keyFound == NULL) {
         dbAdd(db,key,val);
     } else {
         dbOverwrite(db,key,val);
@@ -261,7 +261,7 @@ void genericSetKeyLookup(client *c, redisDb *db, robj *key, robj *val,int keeptt
 }
 void genericSetKey(client *c, redisDb *db, robj *key, robj *val,int keepttl,
                          int signal) {
-    genericSetKeyLookup(c, db, key, val, keepttl, signal, 0, 0);
+    genericSetKeyLookup(c, db, key, val, keepttl, signal, lookupKeyWrite(db,key));
 }
 
 /* Common case for genericSetKey() where the TTL is not retained. */

--- a/src/db.c
+++ b/src/db.c
@@ -243,7 +243,9 @@ void dbOverwrite(redisDb *db, robj *key, robj *val) {
  * 1) The ref count of the value object is incremented.
  * 2) clients WATCHing for the destination key notified.
  * 3) The expire time of the key is reset (the key is made persistent),
- *    unless 'keepttl' is true.
+ *    unless 'SETKEY_KEEPTTL' is enabled in flags.
+ * 4) The key lookup can take place outside this interface outcome will be
+ *    delivered with 'SETKEY_ALREADY_EXIST' or 'SETKEY_DOESNT_EXIST'
  *
  * All the new keys in the database should be created via this interface.
  * The client 'c' argument may be set to NULL if the operation is performed

--- a/src/geo.c
+++ b/src/geo.c
@@ -820,7 +820,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
 
         if (returned_items) {
             zsetConvertToListpackIfNeeded(zobj,maxelelen,totelelen);
-            setKey(c,c->db,storekey,zobj);
+            setKey(c,c->db,storekey,zobj,SETKEY_SIGNAL);
             decrRefCount(zobj);
             notifyKeyspaceEvent(NOTIFY_ZSET,flags & GEOSEARCH ? "geosearchstore" : "georadiusstore",storekey,
                                 c->db->id);

--- a/src/geo.c
+++ b/src/geo.c
@@ -820,7 +820,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
 
         if (returned_items) {
             zsetConvertToListpackIfNeeded(zobj,maxelelen,totelelen);
-            setKey(c,c->db,storekey,zobj,SETKEY_SIGNAL);
+            setKey(c,c->db,storekey,zobj,0);
             decrRefCount(zobj);
             notifyKeyspaceEvent(NOTIFY_ZSET,flags & GEOSEARCH ? "geosearchstore" : "georadiusstore",storekey,
                                 c->db->id);

--- a/src/module.c
+++ b/src/module.c
@@ -2971,7 +2971,7 @@ int RM_GetToDbIdFromOptCtx(RedisModuleKeyOptCtx *ctx) {
 int RM_StringSet(RedisModuleKey *key, RedisModuleString *str) {
     if (!(key->mode & REDISMODULE_WRITE) || key->iter) return REDISMODULE_ERR;
     RM_DeleteKey(key);
-    genericSetKey(key->ctx->client,key->db,key->key,str,0,0);
+    setKey(key->ctx->client,key->db,key->key,str,0);
     key->value = str;
     return REDISMODULE_OK;
 }
@@ -3051,7 +3051,7 @@ int RM_StringTruncate(RedisModuleKey *key, size_t newlen) {
     if (key->value == NULL) {
         /* Empty key: create it with the new size. */
         robj *o = createObject(OBJ_STRING,sdsnewlen(NULL, newlen));
-        genericSetKey(key->ctx->client,key->db,key->key,o,0,0);
+        setKey(key->ctx->client,key->db,key->key,o,0);
         key->value = o;
         decrRefCount(o);
     } else {
@@ -5328,7 +5328,7 @@ int RM_ModuleTypeSetValue(RedisModuleKey *key, moduleType *mt, void *value) {
     if (!(key->mode & REDISMODULE_WRITE) || key->iter) return REDISMODULE_ERR;
     RM_DeleteKey(key);
     robj *o = createModuleObject(mt,value);
-    genericSetKey(key->ctx->client,key->db,key->key,o,0,0);
+    setKey(key->ctx->client,key->db,key->key,o,0);
     decrRefCount(o);
     key->value = o;
     return REDISMODULE_OK;

--- a/src/module.c
+++ b/src/module.c
@@ -5328,7 +5328,7 @@ int RM_ModuleTypeSetValue(RedisModuleKey *key, moduleType *mt, void *value) {
     if (!(key->mode & REDISMODULE_WRITE) || key->iter) return REDISMODULE_ERR;
     RM_DeleteKey(key);
     robj *o = createModuleObject(mt,value);
-    setKey(key->ctx->client,key->db,key->key,o,0);
+    setKey(key->ctx->client,key->db,key->key,o,SETKEY_NO_SIGNAL);
     decrRefCount(o);
     key->value = o;
     return REDISMODULE_OK;

--- a/src/module.c
+++ b/src/module.c
@@ -2971,7 +2971,7 @@ int RM_GetToDbIdFromOptCtx(RedisModuleKeyOptCtx *ctx) {
 int RM_StringSet(RedisModuleKey *key, RedisModuleString *str) {
     if (!(key->mode & REDISMODULE_WRITE) || key->iter) return REDISMODULE_ERR;
     RM_DeleteKey(key);
-    setKey(key->ctx->client,key->db,key->key,str,0);
+    setKey(key->ctx->client,key->db,key->key,str,SETKEY_NO_SIGNAL);
     key->value = str;
     return REDISMODULE_OK;
 }
@@ -3051,7 +3051,7 @@ int RM_StringTruncate(RedisModuleKey *key, size_t newlen) {
     if (key->value == NULL) {
         /* Empty key: create it with the new size. */
         robj *o = createObject(OBJ_STRING,sdsnewlen(NULL, newlen));
-        setKey(key->ctx->client,key->db,key->key,o,0);
+        setKey(key->ctx->client,key->db,key->key,o,SETKEY_NO_SIGNAL);
         key->value = o;
         decrRefCount(o);
     } else {

--- a/src/server.h
+++ b/src/server.h
@@ -2564,7 +2564,7 @@ void dbAdd(redisDb *db, robj *key, robj *val);
 int dbAddRDBLoad(redisDb *db, sds key, robj *val);
 void dbOverwrite(redisDb *db, robj *key, robj *val);
 #define SETKEY_KEEPTTL 1
-#define SETKEY_SIGNAL 2
+#define SETKEY_NO_SIGNAL 2
 #define SETKEY_ALREADY_EXIST 4
 #define SETKEY_DOESNT_EXIST 8
 void setKey(client *c, redisDb *db, robj *key, robj *val, int flags);

--- a/src/server.h
+++ b/src/server.h
@@ -2563,6 +2563,7 @@ int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle,
 void dbAdd(redisDb *db, robj *key, robj *val);
 int dbAddRDBLoad(redisDb *db, sds key, robj *val);
 void dbOverwrite(redisDb *db, robj *key, robj *val);
+
 #define SETKEY_KEEPTTL 1
 #define SETKEY_NO_SIGNAL 2
 #define SETKEY_ALREADY_EXIST 4

--- a/src/server.h
+++ b/src/server.h
@@ -2563,9 +2563,11 @@ int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle,
 void dbAdd(redisDb *db, robj *key, robj *val);
 int dbAddRDBLoad(redisDb *db, sds key, robj *val);
 void dbOverwrite(redisDb *db, robj *key, robj *val);
-void genericSetKey(client *c, redisDb *db, robj *key, robj *val, int keepttl, int signal);
-void genericSetKeyLookup(client *c, redisDb *db, robj *key, robj *val, int keepttl, int signal, robj* keyFound);
-void setKey(client *c, redisDb *db, robj *key, robj *val);
+#define SETKEY_KEEPTTL 1
+#define SETKEY_SIGNAL 2
+#define SETKEY_ALREADY_EXIST 4
+#define SETKEY_DOESNT_EXIST 8
+void setKey(client *c, redisDb *db, robj *key, robj *val, int flags);
 robj *dbRandomKey(redisDb *db);
 int dbSyncDelete(redisDb *db, robj *key);
 int dbDelete(redisDb *db, robj *key);

--- a/src/server.h
+++ b/src/server.h
@@ -2564,7 +2564,7 @@ void dbAdd(redisDb *db, robj *key, robj *val);
 int dbAddRDBLoad(redisDb *db, sds key, robj *val);
 void dbOverwrite(redisDb *db, robj *key, robj *val);
 void genericSetKey(client *c, redisDb *db, robj *key, robj *val, int keepttl, int signal);
-void genericSetKeyLookup(client *c, redisDb *db, robj *key, robj *val, int keepttl, int signal, int keyLooked, int keyFound);
+void genericSetKeyLookup(client *c, redisDb *db, robj *key, robj *val, int keepttl, int signal, robj* keyFound);
 void setKey(client *c, redisDb *db, robj *key, robj *val);
 robj *dbRandomKey(redisDb *db);
 int dbSyncDelete(redisDb *db, robj *key);

--- a/src/server.h
+++ b/src/server.h
@@ -2564,6 +2564,7 @@ void dbAdd(redisDb *db, robj *key, robj *val);
 int dbAddRDBLoad(redisDb *db, sds key, robj *val);
 void dbOverwrite(redisDb *db, robj *key, robj *val);
 void genericSetKey(client *c, redisDb *db, robj *key, robj *val, int keepttl, int signal);
+void genericSetKeyLookup(client *c, redisDb *db, robj *key, robj *val, int keepttl, int signal, int keyLooked, int keyFound);
 void setKey(client *c, redisDb *db, robj *key, robj *val);
 robj *dbRandomKey(redisDb *db);
 int dbSyncDelete(redisDb *db, robj *key);

--- a/src/sort.c
+++ b/src/sort.c
@@ -570,7 +570,7 @@ void sortCommandGeneric(client *c, int readonly) {
             }
         }
         if (outputlen) {
-            setKey(c,c->db,storekey,sobj,SETKEY_SIGNAL);
+            setKey(c,c->db,storekey,sobj,0);
             notifyKeyspaceEvent(NOTIFY_LIST,"sortstore",storekey,
                                 c->db->id);
             server.dirty += outputlen;

--- a/src/sort.c
+++ b/src/sort.c
@@ -570,7 +570,7 @@ void sortCommandGeneric(client *c, int readonly) {
             }
         }
         if (outputlen) {
-            setKey(c,c->db,storekey,sobj);
+            setKey(c,c->db,storekey,sobj,SETKEY_SIGNAL);
             notifyKeyspaceEvent(NOTIFY_LIST,"sortstore",storekey,
                                 c->db->id);
             server.dirty += outputlen;

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -987,7 +987,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
         /* Store the resulting set into the target, if the intersection
          * is not an empty set. */
         if (setTypeSize(dstset) > 0) {
-            setKey(c,c->db,dstkey,dstset);
+            setKey(c,c->db,dstkey,dstset, SETKEY_SIGNAL);
             addReplyLongLong(c,setTypeSize(dstset));
             notifyKeyspaceEvent(NOTIFY_SET,"sinterstore",
                 dstkey,c->db->id);
@@ -1195,7 +1195,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
         /* If we have a target key where to store the resulting set
          * create this key with the result set inside */
         if (setTypeSize(dstset) > 0) {
-            setKey(c,c->db,dstkey,dstset);
+            setKey(c,c->db,dstkey,dstset, SETKEY_SIGNAL);
             addReplyLongLong(c,setTypeSize(dstset));
             notifyKeyspaceEvent(NOTIFY_SET,
                 op == SET_OP_UNION ? "sunionstore" : "sdiffstore",

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -987,7 +987,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
         /* Store the resulting set into the target, if the intersection
          * is not an empty set. */
         if (setTypeSize(dstset) > 0) {
-            setKey(c,c->db,dstkey,dstset, SETKEY_SIGNAL);
+            setKey(c,c->db,dstkey,dstset,SETKEY_SIGNAL);
             addReplyLongLong(c,setTypeSize(dstset));
             notifyKeyspaceEvent(NOTIFY_SET,"sinterstore",
                 dstkey,c->db->id);
@@ -1195,7 +1195,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
         /* If we have a target key where to store the resulting set
          * create this key with the result set inside */
         if (setTypeSize(dstset) > 0) {
-            setKey(c,c->db,dstkey,dstset, SETKEY_SIGNAL);
+            setKey(c,c->db,dstkey,dstset,SETKEY_SIGNAL);
             addReplyLongLong(c,setTypeSize(dstset));
             notifyKeyspaceEvent(NOTIFY_SET,
                 op == SET_OP_UNION ? "sunionstore" : "sdiffstore",

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -987,7 +987,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
         /* Store the resulting set into the target, if the intersection
          * is not an empty set. */
         if (setTypeSize(dstset) > 0) {
-            setKey(c,c->db,dstkey,dstset,SETKEY_SIGNAL);
+            setKey(c,c->db,dstkey,dstset,0);
             addReplyLongLong(c,setTypeSize(dstset));
             notifyKeyspaceEvent(NOTIFY_SET,"sinterstore",
                 dstkey,c->db->id);
@@ -1195,7 +1195,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
         /* If we have a target key where to store the resulting set
          * create this key with the result set inside */
         if (setTypeSize(dstset) > 0) {
-            setKey(c,c->db,dstkey,dstset,SETKEY_SIGNAL);
+            setKey(c,c->db,dstkey,dstset,0);
             addReplyLongLong(c,setTypeSize(dstset));
             notifyKeyspaceEvent(NOTIFY_SET,
                 op == SET_OP_UNION ? "sunionstore" : "sdiffstore",

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -103,7 +103,7 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
     setkey_flags = found ? setkey_flags | SETKEY_ALREADY_EXIST : setkey_flags | SETKEY_DOESNT_EXIST;
     setkey_flags |= SETKEY_SIGNAL;
 
-    setKey(c,c->db,key, val, setkey_flags);
+    setKey(c,c->db,key,val,setkey_flags);
     server.dirty++;
     notifyKeyspaceEvent(NOTIFY_STRING,"set",key,c->db->id);
 
@@ -427,7 +427,7 @@ void getdelCommand(client *c) {
 void getsetCommand(client *c) {
     if (getGenericCommand(c) == C_ERR) return;
     c->argv[2] = tryObjectEncoding(c->argv[2]);
-    setKey(c,c->db,c->argv[1],c->argv[2], SETKEY_SIGNAL);
+    setKey(c,c->db,c->argv[1],c->argv[2],SETKEY_SIGNAL);
     notifyKeyspaceEvent(NOTIFY_STRING,"set",c->argv[1],c->db->id);
     server.dirty++;
 
@@ -576,7 +576,7 @@ void msetGenericCommand(client *c, int nx) {
 
     for (j = 1; j < c->argc; j += 2) {
         c->argv[j+1] = tryObjectEncoding(c->argv[j+1]);
-        setKey(c,c->db,c->argv[j],c->argv[j+1], SETKEY_SIGNAL);
+        setKey(c,c->db,c->argv[j],c->argv[j+1],SETKEY_SIGNAL);
         notifyKeyspaceEvent(NOTIFY_STRING,"set",c->argv[j],c->db->id);
     }
     server.dirty += (c->argc-1)/2;

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -100,7 +100,7 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
     }
 
     setkey_flags = (flags & OBJ_KEEPTTL) ? setkey_flags | SETKEY_KEEPTTL : setkey_flags;
-    setkey_flags = found ? setkey_flags | SETKEY_ALREADY_EXIST : setkey_flags | SETKEY_DOESNT_EXIST;
+    setkey_flags |= found ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST;
     setkey_flags |= SETKEY_SIGNAL;
 
     setKey(c,c->db,key,val,setkey_flags);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -99,9 +99,8 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
         return;
     }
 
-    setkey_flags = (flags & OBJ_KEEPTTL) ? setkey_flags | SETKEY_KEEPTTL : setkey_flags;
+    setkey_flags |= (flags & OBJ_KEEPTTL) ? SETKEY_KEEPTTL : 0;
     setkey_flags |= found ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST;
-    setkey_flags |= SETKEY_SIGNAL;
 
     setKey(c,c->db,key,val,setkey_flags);
     server.dirty++;
@@ -427,7 +426,7 @@ void getdelCommand(client *c) {
 void getsetCommand(client *c) {
     if (getGenericCommand(c) == C_ERR) return;
     c->argv[2] = tryObjectEncoding(c->argv[2]);
-    setKey(c,c->db,c->argv[1],c->argv[2],SETKEY_SIGNAL);
+    setKey(c,c->db,c->argv[1],c->argv[2],0);
     notifyKeyspaceEvent(NOTIFY_STRING,"set",c->argv[1],c->db->id);
     server.dirty++;
 
@@ -576,7 +575,7 @@ void msetGenericCommand(client *c, int nx) {
 
     for (j = 1; j < c->argc; j += 2) {
         c->argv[j+1] = tryObjectEncoding(c->argv[j+1]);
-        setKey(c,c->db,c->argv[j],c->argv[j+1],SETKEY_SIGNAL);
+        setKey(c,c->db,c->argv[j],c->argv[j+1],0);
         notifyKeyspaceEvent(NOTIFY_STRING,"set",c->argv[j],c->db->id);
     }
     server.dirty += (c->argc-1)/2;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2762,7 +2762,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
     if (dstkey) {
         if (dstzset->zsl->length) {
             zsetConvertToListpackIfNeeded(dstobj, maxelelen, totelelen);
-            setKey(c, c->db, dstkey, dstobj, SETKEY_SIGNAL);
+            setKey(c, c->db, dstkey, dstobj, 0);
             addReplyLongLong(c, zsetLength(dstobj));
             notifyKeyspaceEvent(NOTIFY_ZSET,
                                 (op == SET_OP_UNION) ? "zunionstore" :
@@ -2955,7 +2955,7 @@ static void zrangeResultEmitLongLongForStore(zrange_result_handler *handler,
 static void zrangeResultFinalizeStore(zrange_result_handler *handler, size_t result_count)
 {
     if (result_count) {
-        setKey(handler->client, handler->client->db, handler->dstkey, handler->dstobj, SETKEY_SIGNAL);
+        setKey(handler->client, handler->client->db, handler->dstkey, handler->dstobj, 0);
         addReplyLongLong(handler->client, result_count);
         notifyKeyspaceEvent(NOTIFY_ZSET, "zrangestore", handler->dstkey, handler->client->db->id);
         server.dirty++;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2762,7 +2762,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
     if (dstkey) {
         if (dstzset->zsl->length) {
             zsetConvertToListpackIfNeeded(dstobj, maxelelen, totelelen);
-            setKey(c, c->db, dstkey, dstobj);
+            setKey(c, c->db, dstkey, dstobj, SETKEY_SIGNAL);
             addReplyLongLong(c, zsetLength(dstobj));
             notifyKeyspaceEvent(NOTIFY_ZSET,
                                 (op == SET_OP_UNION) ? "zunionstore" :
@@ -2955,7 +2955,7 @@ static void zrangeResultEmitLongLongForStore(zrange_result_handler *handler,
 static void zrangeResultFinalizeStore(zrange_result_handler *handler, size_t result_count)
 {
     if (result_count) {
-        setKey(handler->client, handler->client->db, handler->dstkey, handler->dstobj);
+        setKey(handler->client, handler->client->db, handler->dstkey, handler->dstobj, SETKEY_SIGNAL);
         addReplyLongLong(handler->client, result_count);
         notifyKeyspaceEvent(NOTIFY_ZSET, "zrangestore", handler->dstkey, handler->client->db->id);
         server.dirty++;


### PR DESCRIPTION
When using SETNX and SETXX we could end up doing key lookup twice.
This presents a small inefficiency price.
Also once we have statistics of write hit and miss they'll be wrong (recording the same key hit twice) 