### PR TITLE
Attempt to fix a valgrind test failure due to timing

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -413,7 +413,7 @@ test {slave fails full sync and diskless load swapdb recovers it} {
             $slave slaveof $master_host $master_port
 
             # wait for the slave to start reading the rdb
-            wait_for_condition 50 100 {
+            wait_for_condition 100 100 {
                 [s -1 loading] eq 1
             } else {
                 fail "Replica didn't get into loading mode"


### PR DESCRIPTION
in the past few days i've seen two failures in the valgrind daily test.
https://github.com/redis/redis/runs/3921123821?check_suite_focus=true
```
*** [err]: slave fails full sync and diskless load swapdb recovers it in tests/integration/replication.tcl
Replica didn't get into loading mode
```
can't reproduce it, but i'm hoping it's just too slow (to start loading within 5 seconds)