### PR TITLE
Skip Active-defrag edge case test until we fix it.

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -389,6 +389,9 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
             r del biglist1 ;# coverage for quicklistBookmarksClear
         } {1}
 
+        # Temporarily skip the active defrag edge case since it constantly fails on 32bit bit builds
+        # since upgrading to jemalloc 5.2.1 (#9623). We need to resolve this and re-enabled.
+        if {false} {
         test "Active defrag edge case" {
             # there was an edge case in defrag where all the slabs of a certain bin are exact the same
             # % utilization, with the exception of the current slab from which new allocations are made
@@ -490,6 +493,7 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
                 assert {$digest eq $newdigest}
                 r save ;# saving an rdb iterates over all the data / pointers
             }
+        }
         }
     }
 }


### PR DESCRIPTION
Test started failing consistently in 32bit builds after upgrading to jemalloc 5.2.1 (#9623).