### PR TITLE
Improve errno reporting on fork and fopen rdbLoad failures

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3110,7 +3110,6 @@ int rdbSaveToSlavesSockets(rdbSaveInfo *rsi) {
         exitFromChild((retval == C_OK) ? 0 : 1);
     } else {
         /* Parent */
-        close(safe_to_exit_pipe);
         if (childpid == -1) {
             serverLog(LL_WARNING,"Can't save in background: fork: %s",
                 strerror(errno));
@@ -3141,6 +3140,7 @@ int rdbSaveToSlavesSockets(rdbSaveInfo *rsi) {
                 serverPanic("Unrecoverable error creating server.rdb_pipe_read file event.");
             }
         }
+        close(safe_to_exit_pipe);
         return (childpid == -1) ? C_ERR : C_OK;
     }
     return C_OK; /* Unreached. */

--- a/src/replication.c
+++ b/src/replication.c
@@ -1859,7 +1859,7 @@ void readSyncBulkPayload(connection *conn) {
         if (rdbLoad(server.rdb_filename,&rsi,RDBFLAGS_REPLICATION) != C_OK) {
             serverLog(LL_WARNING,
                 "Failed trying to load the MASTER synchronization "
-                "DB from disk");
+                "DB from disk: %s", strerror(errno));
             cancelReplicationHandshake(1);
             if (server.rdb_del_sync_files && allPersistenceDisabled()) {
                 serverLog(LL_NOTICE,"Removing the RDB file obtained from "

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -2164,7 +2164,7 @@ int ldbStartSession(client *c) {
     if (ldb.forked) {
         pid_t cp = redisFork(CHILD_TYPE_LDB);
         if (cp == -1) {
-            addReplyError(c,"Fork() failed: can't run EVAL in debugging mode.");
+            addReplyErrorFormat(c,"Fork() failed: can't run EVAL in debugging mode: %s", strerror(errno));
             return 0;
         } else if (cp == 0) {
             /* Child. Let's ignore important signals handled by the parent. */


### PR DESCRIPTION
I moved a bunch of stats in redisFork to be executed only on successful
fork, since they seem wrong to be done when it failed.
I guess when fork fails it does that immediately, no latency spike.