### PR TITLE
Sentinel: don't log auth-pass value for better security.

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -4333,7 +4333,7 @@ void sentinelSetCommand(client *c) {
         int numargs = j-old_j+1;
         switch(numargs) {
         case 2:
-            sentinelEvent(LL_WARNING,"+set",ri,"%@ %s %s",(char*)c->argv[old_j]->ptr, 
+            sentinelEvent(LL_WARNING,"+set",ri,"%@ %s %s",(char*)c->argv[old_j]->ptr,
                                                           redacted ? "******" : (char*)c->argv[old_j+1]->ptr);
             break;
         case 3:

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -4334,7 +4334,7 @@ void sentinelSetCommand(client *c) {
         switch(numargs) {
         case 2:
             sentinelEvent(LL_WARNING,"+set",ri,"%@ %s %s",(char*)c->argv[old_j]->ptr, 
-                                                          redacted ? "******" : (char*)c->argv[old_j+1]->ptr);                                                        
+                                                          redacted ? "******" : (char*)c->argv[old_j+1]->ptr);
             break;
         case 3:
             sentinelEvent(LL_WARNING,"+set",ri,"%@ %s %s %s",(char*)c->argv[old_j]->ptr,

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -4330,8 +4330,14 @@ void sentinelSetCommand(client *c) {
         int numargs = j-old_j+1;
         switch(numargs) {
         case 2:
-            sentinelEvent(LL_WARNING,"+set",ri,"%@ %s %s",(char*)c->argv[old_j]->ptr,
+            if (!strcasecmp(option,"auth-pass")) {
+                sentinelEvent(LL_WARNING,"+set",ri,"%@ %s %s",(char*)c->argv[old_j]->ptr,
+                                                          "******");
+            } else {
+                sentinelEvent(LL_WARNING,"+set",ri,"%@ %s %s",(char*)c->argv[old_j]->ptr,
                                                           (char*)c->argv[old_j+1]->ptr);
+            }
+            
             break;
         case 3:
             sentinelEvent(LL_WARNING,"+set",ri,"%@ %s %s %s",(char*)c->argv[old_j]->ptr,


### PR DESCRIPTION
Before this fix, processing a `sentinel auth-pass` command would dump the new password in the log which does not follow best practices of redacting secrets.

Related to #9605