### PR TITLE
fix new cluster tests issues

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -584,6 +584,8 @@ void clusterInit(void) {
     }
     int cport = server.cluster_port ? server.cluster_port : port + CLUSTER_PORT_INCR;
     if (listenToPort(cport, &server.cfd) == C_ERR ) {
+        /* Note: the following log text is matched by the test suite. */
+        serverLog(LL_WARNING, "Failed listening on port %u (cluster), aborting.", cport);
         exit(1);
     }
     

--- a/src/server.c
+++ b/src/server.c
@@ -3706,11 +3706,13 @@ void initServer(void) {
     /* Open the TCP listening socket for the user commands. */
     if (server.port != 0 &&
         listenToPort(server.port,&server.ipfd) == C_ERR) {
+        /* Note: the following log text is matched by the test suite. */
         serverLog(LL_WARNING, "Failed listening on port %u (TCP), aborting.", server.port);
         exit(1);
     }
     if (server.tls_port != 0 &&
         listenToPort(server.tls_port,&server.tlsfd) == C_ERR) {
+        /* Note: the following log text is matched by the test suite. */
         serverLog(LL_WARNING, "Failed listening on port %u (TLS), aborting.", server.tls_port);
         exit(1);
     }

--- a/tests/unit/cluster.tcl
+++ b/tests/unit/cluster.tcl
@@ -21,10 +21,14 @@ proc csi {args} {
 # make sure the test infra won't use SELECT
 set ::singledb 1
 
+# cluster creation is complicated with TLS, and the current tests don't really need that coverage
+tags {tls:skip external:skip cluster} {
+
 # start three servers
-start_server {overrides {cluster-enabled yes cluster-node-timeout 1} tags {"external:skip cluster"}} {
-start_server {overrides {cluster-enabled yes cluster-node-timeout 1} tags {"external:skip cluster"}} {
-start_server {overrides {cluster-enabled yes cluster-node-timeout 1} tags {"external:skip cluster"}} {
+set base_conf [list cluster-enabled yes cluster-node-timeout 1]
+start_server [list overrides $base_conf] {
+start_server [list overrides $base_conf] {
+start_server [list overrides $base_conf] {
 
     set node1 [srv 0 client]
     set node2 [srv -1 client]
@@ -149,3 +153,5 @@ start_server {overrides {cluster-enabled yes cluster-node-timeout 1} tags {"exte
 }
 }
 }
+
+} ;# tags

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -24,20 +24,21 @@ set testmodule_nokey [file normalize tests/modules/blockonbackground.so]
 # make sure the test infra won't use SELECT
 set ::singledb 1
 
+# cluster creation is complicated with TLS, and the current tests don't really need that coverage
+tags {tls:skip external:skip cluster modules} {
+
 # start three servers
-start_server {overrides {cluster-enabled yes cluster-node-timeout 1} tags {"external:skip cluster modules"}} {
-start_server {overrides {cluster-enabled yes cluster-node-timeout 1} tags {"external:skip cluster modules"}} {
-start_server {overrides {cluster-enabled yes cluster-node-timeout 1} tags {"external:skip cluster modules"}} {
+set base_conf [list cluster-enabled yes cluster-node-timeout 1 loadmodule $testmodule]
+start_server [list overrides $base_conf] {
+start_server [list overrides $base_conf] {
+start_server [list overrides $base_conf] {
 
     set node1 [srv 0 client]
     set node2 [srv -1 client]
     set node3 [srv -2 client]
     set node3_pid [srv -2 pid]
 
-    $node1 module load $testmodule
-    $node2 module load $testmodule
-    $node3 module load $testmodule
-
+    # the "overrides" mechanism can only support one "loadmodule" directive
     $node1 module load $testmodule_nokey
     $node2 module load $testmodule_nokey
     $node3 module load $testmodule_nokey
@@ -200,3 +201,5 @@ start_server {overrides {cluster-enabled yes cluster-node-timeout 1} tags {"exte
 }
 }
 }
+
+} ;# tags


### PR DESCRIPTION
Following #9483 the daily CI exposed a few problems.

* The cluster creation code (uses redis-cli) is complicated to test with TLS enabled.
  for now i'm just skipping them since the tests we run there don't really need that kind of coverage
* cluster port binding failures
  note that `find_available_port` already looks for a free cluster port
  but the code in `wait_server_started` couldn't detect the failure of binding
  (the text it greps for wasn't found in the log)

https://github.com/redis/redis/runs/3945811252?check_suite_focus=true