### PR TITLE
Handle cross-compiling when configuring jemalloc.

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -86,9 +86,13 @@ lua: .make-prerequisites
 JEMALLOC_CFLAGS= -std=gnu99 -Wall -pipe -g3 -O3 -funroll-loops $(CFLAGS)
 JEMALLOC_LDFLAGS= $(LDFLAGS)
 
+ifneq ($(DEB_HOST_GNU_TYPE),)
+JEMALLOC_CONFIGURE_OPTS += --host=$(DEB_HOST_GNU_TYPE)
+endif
+
 jemalloc: .make-prerequisites
 	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)
-	cd jemalloc && ./configure --with-version=5.2.1-0-g0 --with-lg-quantum=3 --with-jemalloc-prefix=je_ CFLAGS="$(JEMALLOC_CFLAGS)" LDFLAGS="$(JEMALLOC_LDFLAGS)"
+	cd jemalloc && ./configure --with-version=5.2.1-0-g0 --with-lg-quantum=3 --with-jemalloc-prefix=je_ CFLAGS="$(JEMALLOC_CFLAGS)" LDFLAGS="$(JEMALLOC_LDFLAGS)" $(JEMALLOC_CONFIGURE_OPTS)
 	cd jemalloc && $(MAKE) CFLAGS="$(JEMALLOC_CFLAGS)" LDFLAGS="$(JEMALLOC_LDFLAGS)" lib/libjemalloc.a
 
 .PHONY: jemalloc


### PR DESCRIPTION
This issue has come up in the cross-compilation setup in the redis-debian repository, and addressed by a [patch](https://github.com/redis/redis-debian/blob/master/debian/patches/jemalloc_crosscompile.diff).

This patch would be broken by the recent jemalloc upgrade, so it's a good opportunity to apply it here.