### PR TITLE
Removes admin acl category from CLIENT TRACKINGINFO

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -510,7 +510,7 @@ struct redisCommand clientSubcommands[] = {
      "no-script ok-loading ok-stale @connection"},
 
     {"trackinginfo",clientCommand,2,
-     "admin no-script ok-loading ok-stale @connection"},
+     "no-script ok-loading ok-stale @connection"},
 
     {"no-evict",clientCommand,3,
      "admin no-script ok-loading ok-stale @connection"},


### PR DESCRIPTION
I think I missed this one in my review, but it shouldn't be admin as it applies only to the current connection.

TODO:
- [x] when we merge this, update the summary in #9504 for the release notes.