### PR TITLE
Add checks for overflow in redis-check-aof and loadAppendOnlyFile

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -753,6 +753,7 @@ int loadAppendOnlyFile(char *filename) {
         if (buf[1] == '\0') goto readerr;
         argc = atoi(buf+1);
         if (argc < 1) goto fmterr;
+        if ((size_t)argc > SIZE_MAX / sizeof(robj*)) goto fmterr;
 
         /* Load the next command in the AOF as our fake client
          * argv. */

--- a/src/redis-check-aof.c
+++ b/src/redis-check-aof.c
@@ -82,6 +82,11 @@ int readString(FILE *fp, char** target) {
         return 0;
     }
 
+    if (len < 0 || len > LONG_MAX - 2) {
+        ERROR("Expected to read string of %ld bytes, which is not in the suitable range",len);
+        return 0;
+    }
+
     /* Increase length to also consume \r\n */
     len += 2;
     *target = (char*)zmalloc(len);


### PR DESCRIPTION
In the file redis-check-aof.c, we have the following [code](https://github.com/redis/redis/blob/761d7d27711edfbf737def41ff28f5b325fb16c8/src/redis-check-aof.c#L78):
```
int readString(FILE *fp, char** target) {
    long len;
    *target = NULL;
    if (!readLong(fp,'$',&len)) {
        return 0;
    }

    /* Increase length to also consume \r\n */
    len += 2;
    *target = (char*)zmalloc(len);
    if (!readBytes(fp,*target,len)) {
        return 0;
    }
    ...
}
```

The variable `len` is read from the file. It could be a large value (e.g., `LONG_MAX`) such that `len += 2` may result in integer overflow. Moreover, since signed overflow is undefined behavior in C, it should be avoided anyway.