### PR TITLE
Fixes `CLUSTER COUNTKEYSINSLOT`

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -561,7 +561,7 @@ struct redisCommand clusterSubcommands[] = {
     {"count-failure-reports",clusterCommand,3,
      "admin ok-stale random"},
 
-    {"countkeysinslots",clusterCommand,3,
+    {"countkeysinslot",clusterCommand,3,
      "ok-stale random"},
 
     {"delslots",clusterCommand,-3,

--- a/tests/cluster/tests/00-base.tcl
+++ b/tests/cluster/tests/00-base.tcl
@@ -54,6 +54,11 @@ test "Nodes should report cluster_state is ok now" {
     assert_cluster_state ok
 }
 
+test "Sanity for CLUSTER COUNTKEYSINSLOT" {
+    set reply [R 0 CLUSTER COUNTKEYSINSLOT 0]
+    assert {$reply eq 0}
+}
+
 test "It is possible to write and read from the cluster" {
     cluster_write_test 0
 }


### PR DESCRIPTION
Introduced via typo in #9504. Reported by @sazzad16.

Also adds a sanity test for coverage.

Additional seemingly uncovered `CLUSTER` subcommands: `BUMPEPOCH`, `COUNT-FAILURE-REPORTS`, `FORGET`, `FLUSHSLOTS`, `KEYSLOT`, `SAVECONFIG`