### PR TITLE
Improve code doc of allowed_firstargs following #9504

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -896,21 +896,17 @@ typedef struct {
      * understand if the command can be executed. */
     uint64_t allowed_commands[USER_COMMAND_BITS_COUNT/64];
 
-    /* NOTE: allowed_firstargs is a transformation of the old mechanism for allowing
-     * subcommands (now, subcommands are actually commands, with their own
-     * ACL ID)
-     * We had to keep allowed_firstargs (previously called allowed_subcommands)
-     * in order to support the widespread abuse of ACL rules to block a command
-     * with a specific argv[1] (which is not a subcommand at all).
+    /* allowed_firstargs is used by ACL rules to block access to a command unless a
+     * specific argv[1] is given (or argv[2] in case it is applied on a sub-command).
      * For example, a user can use the rule "-select +select|0" to block all
      * SELECT commands, except "SELECT 0".
-     * It can also be applied for subcommands: "+config -config|set +config|set|loglevel"
+     * And for a sub-command: "+config -config|set +config|set|loglevel"
      *
-     * This array points, for each command ID (corresponding to the command
-     * bit set in allowed_commands), to an array of SDS strings, terminated by
-     * a NULL pointer, with all the first-args that are allowed for
-     * this command. When no first-arg matching is used, the field is just
-     * set to NULL to avoid allocating USER_COMMAND_BITS_COUNT pointers. */
+     * For each command ID (corresponding to the command bit set in allowed_commands),
+     * This array points to an array of SDS strings, terminated by a NULL pointer,
+     * with all the first-args that are allowed for this command. When no first-arg
+     * matching is used, the field is just set to NULL to avoid allocating
+     * USER_COMMAND_BITS_COUNT pointers. */
     sds **allowed_firstargs;
     list *passwords; /* A list of SDS valid passwords for this user. */
     list *patterns;  /* A list of allowed key patterns. If this field is NULL


### PR DESCRIPTION
Improve code doc for allowed_firstargs (used to be allowed_commands before #9504.
I don't think the text in the code needs to refer to the history (it's not there just for backwards compatibility).
instead it should just describe what it does.
ref https://github.com/redis/redis/pull/9504#discussion_r728327508