### PR TITLE
Unpause clients after manual failover ends instead of the timed offset

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3498,8 +3498,10 @@ void clusterHandleSlaveMigration(int max_slaves) {
  * The function can be used both to initialize the manual failover state at
  * startup or to abort a manual failover in progress. */
 void resetManualFailover(void) {
-    if (server.cluster->mf_end) {
-        checkClientPauseTimeoutAndReturnIfPaused();
+    if (server.cluster->mf_slave) {
+        /* We were a master failing over, so we paused clients. Regardless
+         * of the outcome we unpause now to allow traffic again. */
+        unpauseClients();
     }
     server.cluster->mf_end = 0; /* No manual failover in progress. */
     server.cluster->mf_can_start = 0;


### PR DESCRIPTION
Closes https://github.com/redis/redis/issues/9618. The basic idea is that when cluster failover is initiated manually, the master pauses itself for 10 seconds regardless of outcome. This now unpauses the master as soon as reset is called, either on success or failover, so commands can resume.

Note that the conditional was changed since mf_end is used by both primary and replica, while mf_slave is only used by the primary.  

Cluster test run: https://github.com/redis/redis/runs/3992088669. There are already tests for manual failover (and they run ~8 seconds faster now!)