### PR TITLE
Replace deprecated REDISMODULE_POSTPONED_ARRAY_LEN in module tests and examples

### DIFF
--- a/src/modules/helloblock.c
+++ b/src/modules/helloblock.c
@@ -142,7 +142,7 @@ void *HelloKeys_ThreadMain(void *arg) {
     long long cursor = 0;
     size_t replylen = 0;
 
-    RedisModule_ReplyWithArray(ctx,REDISMODULE_POSTPONED_ARRAY_LEN);
+    RedisModule_ReplyWithArray(ctx,REDISMODULE_POSTPONED_LEN);
     do {
         RedisModule_ThreadSafeContextLock(ctx);
         RedisModuleCallReply *reply = RedisModule_Call(ctx,

--- a/src/modules/hellodict.c
+++ b/src/modules/hellodict.c
@@ -89,7 +89,7 @@ int cmd_KEYRANGE(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     char *key;
     size_t keylen;
     long long replylen = 0; /* Keep track of the emitted array len. */
-    RedisModule_ReplyWithArray(ctx,REDISMODULE_POSTPONED_ARRAY_LEN);
+    RedisModule_ReplyWithArray(ctx,REDISMODULE_POSTPONED_LEN);
     while((key = RedisModule_DictNextC(iter,&keylen,NULL)) != NULL) {
         if (replylen >= count) break;
         if (RedisModule_DictCompare(iter,"<=",argv[2]) == REDISMODULE_ERR)

--- a/src/modules/hellotype.c
+++ b/src/modules/hellotype.c
@@ -161,7 +161,7 @@ int HelloTypeRange_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, i
 
     struct HelloTypeObject *hto = RedisModule_ModuleTypeGetValue(key);
     struct HelloTypeNode *node = hto ? hto->head : NULL;
-    RedisModule_ReplyWithArray(ctx,REDISMODULE_POSTPONED_ARRAY_LEN);
+    RedisModule_ReplyWithArray(ctx,REDISMODULE_POSTPONED_LEN);
     long long arraylen = 0;
     while(node && count--) {
         RedisModule_ReplyWithLongLong(ctx,node->value);

--- a/src/modules/helloworld.c
+++ b/src/modules/helloworld.c
@@ -443,7 +443,7 @@ int HelloLexRange_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, in
     }
 
     int arraylen = 0;
-    RedisModule_ReplyWithArray(ctx,REDISMODULE_POSTPONED_ARRAY_LEN);
+    RedisModule_ReplyWithArray(ctx,REDISMODULE_POSTPONED_LEN);
     while(!RedisModule_ZsetRangeEndReached(key)) {
         double score;
         RedisModuleString *ele = RedisModule_ZsetRangeCurrentElement(key,&score);

--- a/tests/modules/getkeys.c
+++ b/tests/modules/getkeys.c
@@ -30,7 +30,7 @@ int getkeys_command(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     }
 
     /* Handle real command invocation */
-    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
     for (i = 0; i < argc; i++) {
         size_t len;
         const char *str = RedisModule_StringPtrLen(argv[i], &len);

--- a/tests/modules/scan.c
+++ b/tests/modules/scan.c
@@ -36,7 +36,7 @@ int scan_strings(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         .nkeys = 0,
     };
 
-    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
 
     RedisModuleScanCursor* cursor = RedisModule_ScanCursorCreate();
     while(RedisModule_Scan(ctx, cursor, scan_strings_callback, &pd));

--- a/tests/modules/stream.c
+++ b/tests/modules/stream.c
@@ -132,7 +132,7 @@ int stream_range(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     assert(errno == ENOENT);
 
     /* Return array. */
-    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
     RedisModule_AutoMemory(ctx);
     RedisModuleStreamID id;
     long numfields;


### PR DESCRIPTION
REDISMODULE_POSTPONED_ARRAY_LEN is deprecated, use REDISMODULE_POSTPONED_LEN instead