### PR TITLE
Prevent integer overflow in RM_PoolAlloc

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -472,6 +472,7 @@ void poolAllocRelease(RedisModuleCtx *ctx) {
  * The function returns NULL if `bytes` is 0. */
 void *RM_PoolAlloc(RedisModuleCtx *ctx, size_t bytes) {
     if (bytes == 0) return NULL;
+    if (bytes > SIZE_MAX - sizeof(RedisModulePoolAllocBlock)) return NULL;
     RedisModulePoolAllocBlock *b = ctx->pa_head;
     size_t left = b ? b->size - b->used : 0;
 


### PR DESCRIPTION
If we invoke the module API `RM_PoolAlloc` with a large size, e.g., `RM_PoolAlloc(ctx, SIZE_MAX)`, the memory allocation will be under-sized: `b = zmalloc(sizeof(*b) + blocksize);`.

This PR explicitly checks and return NULL pointer for this case. As this is part of the module APIs, I think it is not a severe issue. Still, better make the API robust against such cases.