### PR TITLE
Remove update-jemalloc.sh, it's not needed anymore

### DIFF
--- a/deps/update-jemalloc.sh
+++ b/deps/update-jemalloc.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-VER=$1
-URL="http://www.canonware.com/download/jemalloc/jemalloc-${VER}.tar.bz2"
-echo "Downloading $URL"
-curl $URL > /tmp/jemalloc.tar.bz2
-tar xvjf /tmp/jemalloc.tar.bz2
-rm -rf jemalloc
-mv jemalloc-${VER} jemalloc
-echo "Use git status, add all files and commit changes."


### PR DESCRIPTION
We now use git subtree for deps/jemalloc, updating
jemalloc is detailed in deps/README.md

see #9623 