### PR TITLE
Fix  timing issue in replication buffer test

### DIFF
--- a/tests/integration/replication-buffer.tcl
+++ b/tests/integration/replication-buffer.tcl
@@ -96,6 +96,14 @@ start_server {} {
     $master config set save ""
     $master config set repl-backlog-size 16384
     $master config set client-output-buffer-limit "replica 0 0 0"
+
+    # Executing 'debug digest' on master which has many keys costs much time
+    # (especially in valgrind), this causes that replica1 and replica2 disconnect
+    # with master.
+    $master config set repl-timeout 1000
+    $replica1 config set repl-timeout 1000
+    $replica2 config set repl-timeout 1000
+
     $replica1 replicaof $master_host $master_port
     wait_for_sync $replica1
 


### PR DESCRIPTION
Introduced in #9166

In daily CI https://github.com/redis/redis/runs/4028904569?check_suite_focus=true, I found this log.
I think executing 'debug digest' on master which has many keys costs much time (especially in valgrind), default `repl-timeout` is 60s, and i notice last test spent more than 80 seconds, so i think  this causes that replica1 and replica2 disconnect with master.
```
101967:S 28 Oct 2021 01:42:58.406 # MASTER timeout: no data nor PING received...
101967:S 28 Oct 2021 01:42:58.407 # Connection with master lost.
101967:S 28 Oct 2021 01:42:58.407 * Caching the disconnected master state.
101967:S 28 Oct 2021 01:42:58.408 * Reconnecting to MASTER 127.0.0.1:21291
101967:S 28 Oct 2021 01:42:58.408 * MASTER <-> REPLICA sync started
101967:S 28 Oct 2021 01:42:58.409 * Non blocking connect for SYNC fired the event.
101967:S 28 Oct 2021 01:43:01.429 - DB 9: 10000 keys (0 volatile) in 16384 slots HT.
### Starting test Replication backlog memory will become smaller if disconnecting with replica in tests/integration/replication-buffer.tcl
```