### PR TITLE
Add test to prove that active expiry isn't executed during a script timed out

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2852,7 +2852,10 @@ void clientsCron(void) {
  * rehashing. */
 void databasesCron(void) {
     /* Expire keys by random sampling. Not required for slaves
-     * as master will synthesize DELs for us. */
+     * as master will synthesize DELs for us. 
+     * Note: this code is completely unreachable during busy Lua script
+     * or data loading. So active expiry can't happen for those cases.
+     */
     if (server.active_expire_enabled) {
         if (iAmMaster()) {
             activeExpireCycle(ACTIVE_EXPIRE_CYCLE_SLOW);
@@ -3393,7 +3396,9 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     if (server.cluster_enabled) clusterBeforeSleep();
 
     /* Run a fast expire cycle (the called function will return
-     * ASAP if a fast cycle is not needed). */
+     * ASAP if a fast cycle is not needed).
+     * Note: this code is unreachable during busy Lua script or data loading.
+     */
     if (server.active_expire_enabled && server.masterhost == NULL)
         activeExpireCycle(ACTIVE_EXPIRE_CYCLE_FAST);
 

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -140,6 +140,25 @@ start_server {tags {"scripting"}} {
         } {*execution time*}
     }
 
+    test {EVAL - Active expiry can't happen during long script} {
+        r config set lua-time-limit 10
+        r flushall
+        r psetex key 20 value
+        r eval {
+            for i = 0, 5 do
+                redis.call("psetex", "tempKey", 10, "1")
+                while true do
+                    local ttl = redis.call("pttl", "tempKey")
+                    if ttl == 0 then
+                        break;
+                    end
+                end
+            end
+            redis.call("del", "tempKey")
+            return redis.call("info", "keyspace")
+        } 0
+    } {*keys=1,expires=1*}
+
     test {EVAL - Scripts can't run blpop command} {
         set e {}
         catch {r eval {return redis.pcall('blpop','x',0)} 0} e


### PR DESCRIPTION
Add comments and tests to make it clear that active expiry would never happen during loading and busy scripts.
For eviction there are explicit checks, and for active expiry there aren't since the code is unreachable.

----------

_old description:
We currently don't allow eviction when loading data, or a long running Lua script has timed out (see https://github.com/redis/redis/blob/unstable/src/evict.c#L475). Active expiry should also behave the same way to ensure that data is kept consistent for those 2 scenarios._ 