### PR TITLE
Fix multiple COUNT in LMPOP/BLMPOP/ZMPOP/BZMPOP

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1198,6 +1198,7 @@ void lmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
     long j;
     long numkeys = 0;      /* Number of keys. */
     int where = 0;         /* HEAD for LEFT, TAIL for RIGHT. */
+    int count_is_set = 0;  /* Determine whether the count variant is set. */
     long count = 1;        /* Reply will consist of up to count elements, depending on the list's length. */
 
     /* Parse the numkeys. */
@@ -1219,11 +1220,13 @@ void lmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
         char *opt = c->argv[j]->ptr;
         int moreargs = (c->argc - 1) - j;
 
-        if (!strcasecmp(opt, "COUNT") && moreargs) {
+        if (count_is_set == 0 && !strcasecmp(opt, "COUNT") && moreargs) {
             j++;
             if (getRangeLongFromObjectOrReply(c, c->argv[j], 1, LONG_MAX,
                                               &count,"count should be greater than 0") != C_OK)
                 return;
+
+            count_is_set = 1;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);
             return;

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1198,8 +1198,7 @@ void lmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
     long j;
     long numkeys = 0;      /* Number of keys. */
     int where = 0;         /* HEAD for LEFT, TAIL for RIGHT. */
-    int count_is_set = 0;  /* Determine whether the count variant is set. */
-    long count = 1;        /* Reply will consist of up to count elements, depending on the list's length. */
+    long count = 0;        /* Reply will consist of up to count elements, depending on the list's length. */
 
     /* Parse the numkeys. */
     if (getRangeLongFromObjectOrReply(c, c->argv[numkeys_idx], 1, LONG_MAX,
@@ -1220,18 +1219,18 @@ void lmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
         char *opt = c->argv[j]->ptr;
         int moreargs = (c->argc - 1) - j;
 
-        if (count_is_set == 0 && !strcasecmp(opt, "COUNT") && moreargs) {
+        if (count == 0 && !strcasecmp(opt, "COUNT") && moreargs) {
             j++;
             if (getRangeLongFromObjectOrReply(c, c->argv[j], 1, LONG_MAX,
                                               &count,"count should be greater than 0") != C_OK)
                 return;
-
-            count_is_set = 1;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);
             return;
         }
     }
+
+    if (count == 0) count = 1;
 
     if (is_block) {
         /* BLOCK. We will handle CLIENT_DENY_BLOCKING flag in blockingPopGenericCommand. */

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4287,8 +4287,7 @@ void zmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
     long j;
     long numkeys = 0;      /* Number of keys. */
     int where = 0;         /* ZSET_MIN or ZSET_MAX. */
-    int count_is_set = 0;  /* Determine whether the count variant is set. */
-    long count = 1;        /* Reply will consist of up to count elements, depending on the zset's length. */
+    long count = 0;        /* Reply will consist of up to count elements, depending on the zset's length. */
 
     /* Parse the numkeys. */
     if (getRangeLongFromObjectOrReply(c, c->argv[numkeys_idx], 1, LONG_MAX,
@@ -4315,18 +4314,18 @@ void zmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
         char *opt = c->argv[j]->ptr;
         int moreargs = (c->argc - 1) - j;
 
-        if (count_is_set == 0 && !strcasecmp(opt, "COUNT") && moreargs) {
+        if (count == 0 && !strcasecmp(opt, "COUNT") && moreargs) {
             j++;
             if (getRangeLongFromObjectOrReply(c, c->argv[j], 1, LONG_MAX,
                                               &count,"count should be greater than 0") != C_OK)
                 return;
-
-            count_is_set = 1;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);
             return;
         }
     }
+
+    if (count == 0) count = 1;
 
     if (is_block) {
         /* BLOCK. We will handle CLIENT_DENY_BLOCKING flag in blockingGenericZpopCommand. */

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4287,6 +4287,7 @@ void zmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
     long j;
     long numkeys = 0;      /* Number of keys. */
     int where = 0;         /* ZSET_MIN or ZSET_MAX. */
+    int count_is_set = 0;  /* Determine whether the count variant is set. */
     long count = 1;        /* Reply will consist of up to count elements, depending on the zset's length. */
 
     /* Parse the numkeys. */
@@ -4314,11 +4315,13 @@ void zmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
         char *opt = c->argv[j]->ptr;
         int moreargs = (c->argc - 1) - j;
 
-        if (!strcasecmp(opt, "COUNT") && moreargs) {
+        if (count_is_set == 0 && !strcasecmp(opt, "COUNT") && moreargs) {
             j++;
             if (getRangeLongFromObjectOrReply(c, c->argv[j], 1, LONG_MAX,
                                               &count,"count should be greater than 0") != C_OK)
                 return;
+
+            count_is_set = 1;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);
             return;

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1076,6 +1076,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         assert_error "ERR syntax error*" {r lmpop 1 mylist{t} LEFT bar_arg}
         assert_error "ERR syntax error*" {r lmpop 1 mylist{t} RIGHT LEFT}
         assert_error "ERR syntax error*" {r lmpop 1 mylist{t} COUNT}
+        assert_error "ERR syntax error*" {r lmpop 1 mylist{t} LEFT COUNT 1 COUNT 2}
         assert_error "ERR syntax error*" {r lmpop 2 mylist{t} mylist2{t} bad_arg}
 
         assert_error "ERR count*" {r lmpop 1 mylist{t} LEFT COUNT 0}

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1137,6 +1137,7 @@ start_server {tags {"zset"}} {
         assert_error "ERR syntax error*" {r zmpop 1 myzset{t} MIN bar_arg}
         assert_error "ERR syntax error*" {r zmpop 1 myzset{t} MAX MIN}
         assert_error "ERR syntax error*" {r zmpop 1 myzset{t} COUNT}
+        assert_error "ERR synatx error*" {r zmpop 1 myzset{t} MAX COUNT 1 COUNT 2}
         assert_error "ERR syntax error*" {r zmpop 2 myzset{t} myzset2{t} bad_arg}
 
         assert_error "ERR count*" {r zmpop 1 myzset{t} MIN COUNT 0}
@@ -1922,6 +1923,7 @@ start_server {tags {"zset"}} {
         assert_error "ERR syntax error*" {r bzmpop 1 1 myzset{t} MIN bar_arg}
         assert_error "ERR syntax error*" {r bzmpop 1 1 myzset{t} MAX MIN}
         assert_error "ERR syntax error*" {r bzmpop 1 1 myzset{t} COUNT}
+        assert_error "ERR syntax error*" {r bzmpop 1 1 myzset{t} MIN COUNT 1 COUNT 2}
         assert_error "ERR syntax error*" {r bzmpop 1 2 myzset{t} myzset2{t} bad_arg}
 
         assert_error "ERR count*" {r bzmpop 1 1 myzset{t} MIN COUNT 0}

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1137,7 +1137,7 @@ start_server {tags {"zset"}} {
         assert_error "ERR syntax error*" {r zmpop 1 myzset{t} MIN bar_arg}
         assert_error "ERR syntax error*" {r zmpop 1 myzset{t} MAX MIN}
         assert_error "ERR syntax error*" {r zmpop 1 myzset{t} COUNT}
-        assert_error "ERR synatx error*" {r zmpop 1 myzset{t} MAX COUNT 1 COUNT 2}
+        assert_error "ERR syntax error*" {r zmpop 1 myzset{t} MAX COUNT 1 COUNT 2}
         assert_error "ERR syntax error*" {r zmpop 2 myzset{t} myzset2{t} bad_arg}
 
         assert_error "ERR count*" {r zmpop 1 myzset{t} MIN COUNT 0}


### PR DESCRIPTION
The previous code did not check whether COUNT is set.
So we can use `lmpop 2 key1 key2 left count 1 count 2`.

This situation can occur in LMPOP/BLMPOP/ZMPOP/BZMPOP commands.
LMPOP/BLMPOP introduced in #9373, ZMPOP/BZMPOP introduced in #9484.

before:
```
127.0.0.1:6379> lmpop 2 key1 key2 left count 1
(nil)
127.0.0.1:6379> lmpop 2 key1 key2 left count 1 count 2
(nil)
127.0.0.1:6379> lmpop 2 key1 key2 left count 1 count 2 count 3
(nil)

127.0.0.1:6379> zmpop 2 key1 key2 min count 1
(nil)
127.0.0.1:6379> zmpop 2 key1 key2 min count 1 count 2
(nil)
127.0.0.1:6379> zmpop 2 key1 key2 min count 1 count 2 count 3
(nil)
```

after:
```
127.0.0.1:6379> lmpop 2 key1 key2 left count 1 count 2 count 3
(error) ERR syntax error
127.0.0.1:6379> zmpop 2 key1 key2 min count 2 count 2 count 3
(error) ERR syntax error
```