### PR TITLE
Fixed cluster test where node was waiting to disable AOF

### DIFF
--- a/tests/cluster/tests/05-slave-selection.tcl
+++ b/tests/cluster/tests/05-slave-selection.tcl
@@ -64,7 +64,7 @@ test "Write data while slave #10 is paused and can't receive it" {
     assert {[R 10 read] eq {OK OK}}
 
     # Kill the master so that a reconnection will not be possible.
-    kill_instance redis 0
+    kill_instance redis 0 1
 }
 
 test "Wait for instance #5 (and not #10) to turn into a master" {

--- a/tests/cluster/tests/06-slave-stop-cond.tcl
+++ b/tests/cluster/tests/06-slave-stop-cond.tcl
@@ -56,7 +56,7 @@ test "Break master-slave link and prevent further reconnections" {
     assert {[R 5 read] eq {OK OK}}
 
     # Kill the master so that a reconnection will not be possible.
-    kill_instance redis 0
+    kill_instance redis 0 1
 }
 
 test "Slave #5 is reachable and alive" {

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -589,7 +589,7 @@ proc get_instance_id_by_port {type port} {
 # we kill at cleanup.
 #
 # The instance can be restarted with restart-instance.
-proc kill_instance {type id} {
+proc kill_instance {type id {is_paused 0}} {
     set pid [get_instance_attrib $type $id pid]
     set port [get_instance_attrib $type $id port]
 
@@ -597,8 +597,10 @@ proc kill_instance {type id} {
         error "You tried to kill $type $id twice."
     }
 
-    # stop appendonly so that the instance won't refuse to go down
-    R $id config set appendonly no
+    if { !($is_paused) } {
+        # stop appendonly so that the instance won't refuse to go down
+        R $id config set appendonly no
+    }
 
     stop_instance $pid
     set_instance_attrib $type $id pid -1


### PR DESCRIPTION
Two tests were getting delayed since there were waiting for the command to disable AOF to go through while it was being killed. However, the node was paused since the next part of the test relied on the node being unreachable from the replica, so the waiting to execute the AOF command broke the test timing.

https://github.com/redis/redis/actions/runs/1403850622