### PR TITLE
Fix race condition in psync2-pingoff test

### DIFF
--- a/tests/integration/psync2-pingoff.tcl
+++ b/tests/integration/psync2-pingoff.tcl
@@ -53,25 +53,16 @@ start_server {} {
     }
 
     test "Make the old master a replica of the new one and check conditions" {
-        # There is a chance the master will send an additional PING to the
-        # replica between the two calls to INFO. So there is a chance the
-        # master will have an incremented offset due to PING and the slave
-        # won't have it yet. Change the period to prevent further PINGs.
-        set original_period_value [lindex [r CONFIG GET repl-ping-replica-period] 1]
-        $R(1) CONFIG SET repl-ping-replica-period 10
+        # We set the new master's ping period to a high value, so that there's
+        # no chance for a race condition of sending a PING in between the two
+        # INFO calls in the assert for master_repl_offset match below.
+        $R(1) CONFIG SET repl-ping-replica-period 1000
 
         assert_equal [status $R(1) sync_full] 0
         $R(0) REPLICAOF $R_host(1) $R_port(1)
 
-        # We wait for sync_full to increment and assumes that the master did
-        # the fork. In fact there are cases that the master will increment
-        # the sync_full counter (after replica asks for sync), but will see
-        # that there is already a fork running and will delay the fork creation.
-        # In this case, the INCR will be executed before the fork happens and it
-        # will not be in the command stream so we wait for the link to become up.
         wait_for_condition 50 1000 {
-            [status $R(0) master_link_status] == "up" &&
-            [status $R(1) sync_full] == 1
+            [status $R(0) master_link_status] == "up"
         } else {
             fail "The new master was not able to sync"
         }
@@ -85,9 +76,6 @@ start_server {} {
             fail "replica didn't get incr"
         }
         assert_equal [status $R(0) master_repl_offset] [status $R(1) master_repl_offset]
-
-        # Restore the original configuration
-        $R(1) CONFIG SET repl-ping-replica-period $original_period_value
     }
 }}
 


### PR DESCRIPTION
Test failed on freebsd: https://github.com/redis/redis/runs/4028903962?check_suite_focus=true
```
*** [err]: Make the old master a replica of the new one and check conditions in tests/integration/psync2-pingoff.tcl
Expected '162' to be equal to '176' (context: type eval line 18 cmd {assert_equal [status $R(0) master_repl_offset] [status $R(1) master_repl_offset]} proc ::test)
```
Some observations made with @oranagra:
There are two possible race conditions in the test.

1. The code waits for sync_full to increment, and assumes that means the
master did the fork. But in fact there are cases the master will increment
that sync_full counter (after replica asks for sync), but will see that
there's already a fork running and will delay the fork creation.

In this case the INCR will be executed before the fork happens, so it'll
not be in the command stream. Solve that by waiting for `master_link_status: up`
on the replica before the INCR.

2. The repl-ping-replica-period is still high (1 second), so there's a chance the
master will send an additional PING between the two calls to INFO (the line that
fails is the one that samples INFO from both servers). So there's a chance one of
them will have an incremented offset due to PING and the other won't have it yet.

In theory we can wait for the repl_offset to match, but then we risk facing a
situation where that race will hide an offset mis-match. so instead, i think we
should just change repl-ping-replica-period to prevent further pings from being pushed.