### PR TITLE
Fix not updating backlog histlen when trimming repl backlog

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -220,7 +220,7 @@ void feedReplicationBufferWithObject(robj *o) {
 void incrementalTrimReplicationBacklog(size_t max_blocks) {
     serverAssert(server.repl_backlog != NULL);
 
-    size_t trimmed_blocks = 0, trimmed_bytes = 0;
+    size_t trimmed_blocks = 0;
     while (server.repl_backlog->histlen > server.repl_backlog_size &&
            trimmed_blocks < max_blocks)
     {
@@ -245,8 +245,8 @@ void incrementalTrimReplicationBacklog(size_t max_blocks) {
 
         /* Decr refcount and release the first block later. */
         fo->refcount--;
-        trimmed_bytes += fo->size;
         trimmed_blocks++;
+        server.repl_backlog->histlen -= fo->size;
 
         /* Go to use next replication buffer block node. */
         listNode *next = listNextNode(first);
@@ -267,7 +267,6 @@ void incrementalTrimReplicationBacklog(size_t max_blocks) {
         listDelNode(server.repl_buffer_blocks, first);
     }
 
-    server.repl_backlog->histlen -= trimmed_bytes;
     /* Set the offset of the first byte we have in the backlog. */
     server.repl_backlog->offset = server.master_repl_offset -
                               server.repl_backlog->histlen + 1;


### PR DESCRIPTION
Since the loop in incrementalTrimReplicationBacklog checks the size of histlen, we cannot afford to update it only when the loop exits, this may cause deleting much more replication blocks, and replication backlog may be less than setting size.

introduce in #9166 

thanks @sundb finding this bug.