### PR TITLE
Fix timing issue in replication test

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -624,6 +624,9 @@ start_server {tags {"repl external:skip"}} {
                     # using the log file since the replica only responds to INFO once in 2mb
                     wait_for_log_messages -1 {"*Loading DB in memory*"} $loglines 800 10
 
+                    # Count loglines as early as possible to prevent the log from shifting backward.
+                    set loglines [count_log_lines -2]
+
                     if {$measure_time} {
                         set master_statfile "/proc/$master_pid/stat"
                         set master_start_metrics [get_cpu_metrics $master_statfile]
@@ -638,7 +641,6 @@ start_server {tags {"repl external:skip"}} {
                     $master incr $all_drop
 
                     # disconnect replicas depending on the current test
-                    set loglines [count_log_lines -2]
                     if {$all_drop == "all" || $all_drop == "fast"} {
                         exec kill [srv 0 pid]
                         set replicas_alive [lreplace $replicas_alive 1 1]

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -614,7 +614,7 @@ start_server {tags {"repl external:skip"}} {
                     # start replication
                     # it's enough for just one replica to be slow, and have it's write handler enabled
                     # so that the whole rdb generation process is bound to that
-                    set loglines [count_log_lines -1]
+                    set loglines [count_log_lines -2]
                     [lindex $replicas 0] config set repl-diskless-load swapdb
                     [lindex $replicas 0] config set key-load-delay 100 ;# 20k keys and 100 microseconds sleep means at least 2 seconds
                     [lindex $replicas 0] replicaof $master_host $master_port
@@ -622,10 +622,7 @@ start_server {tags {"repl external:skip"}} {
 
                     # wait for the replicas to start reading the rdb
                     # using the log file since the replica only responds to INFO once in 2mb
-                    wait_for_log_messages -1 {"*Loading DB in memory*"} $loglines 800 10
-
-                    # Count loglines as early as possible to prevent the log from shifting backward.
-                    set loglines [count_log_lines -2]
+                    wait_for_log_messages -1 {"*Loading DB in memory*"} 0 800 10
 
                     if {$measure_time} {
                         set master_statfile "/proc/$master_pid/stat"


### PR DESCRIPTION
```
https://github.com/redis/redis/runs/4028904426?check_suite_focus=true
*** [err]: diskless no replicas drop during rdb pipe in tests/integration/replication.tcl
log message of '"*Diskless rdb transfer, done reading from pipe, 2 replicas still up*"' not found in ./tests/tmp/server.6124.69/stdout after line: 52 till line: 52
```
Some observations made with @oranagra:

```
content of ./tests/tmp/server.6124.69/stdout from line: 52:
17992:M 28 Oct 2021 00:11:45.137 * Streamed RDB transfer with replica 127.0.0.1:24146 succeeded (socket). Waiting for REPLCONF ACK from slave to enable streaming

49 17992:M 28 Oct 2021 00:11:45.129 # Diskless rdb transfer, done reading from pipe, 2 replicas still up.
50 17992:M 28 Oct 2021 00:11:45.137 * Background RDB transfer terminated with success
51 17992:M 28 Oct 2021 00:11:45.137 * Streamed RDB transfer with replica 127.0.0.1:24147 succeeded (socket). Waiting for REPLCONF ACK from slave to enable streaming
52 17992:M 28 Oct 2021 00:11:45.137 * Streamed RDB transfer with replica 127.0.0.1:24146 succeeded (socket). Waiting for REPLCONF ACK from slave to enable streaming
```

Look at the logs, we can see `Diskless rdb transfer, done reading from pipe, 2 replicas still up`
was printed in line 49. But the test was looking for it from line 52.

So it looks like sampling `set loglines [count_log_lines -2]` was
executed too late, and the replication managed to complete before that.

Change:
1. when we search the master log file, we start to search from before we sent the REPLICAOF command,
  to prevent a race in which the replication completed before we sampled the log line count.
2. we don't need to sample the replica loglines sine it's a fresh resplica that's just been started, so the message we're looking for is the
  first occurrence in the log, we can start search from 0.

![image](https://user-images.githubusercontent.com/22811481/139792811-a87982a3-44b2-4dce-9c9b-5c2c9a502bb6.png)
