### PR TITLE
rebuild replication backlog index when master restart

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -7611,17 +7611,8 @@ void loadDataFromDisk(void) {
                     serverAssert(server.repl_backlog);
                     server.repl_backlog->offset = server.master_repl_offset -
                               server.repl_backlog->histlen + 1;
+                    rebaseReplicationBuffer(rsi.repl_offset);
                     server.repl_no_slaves_since = time(NULL);
-
-                    /* Rebase replication buffer blocks' offset since the previous
-                     * setting offset starts from 0. */
-                    listIter li;
-                    listNode *ln;
-                    listRewind(server.repl_buffer_blocks, &li);
-                    while ((ln = listNext(&li))) {
-                        replBufBlock *o = listNodeValue(ln);
-                        o->repl_offset += rsi.repl_offset;
-                    }
                 }
             }
         } else if (errno != ENOENT) {

--- a/src/server.h
+++ b/src/server.h
@@ -2326,6 +2326,7 @@ void replicationCacheMasterUsingMyself(void);
 void feedReplicationBacklog(void *ptr, size_t len);
 void incrementalTrimReplicationBacklog(size_t blocks);
 int canFeedReplicaReplBuffer(client *replica);
+void rebaseReplicationBuffer(long long base_repl_offset);
 void showLatestBacklog(void);
 void rdbPipeReadHandler(struct aeEventLoop *eventLoop, int fd, void *clientData, int mask);
 void rdbPipeWriteHandlerConnRemoved(struct connection *conn);


### PR DESCRIPTION
After PR #9166 , replication backlog is not a real block of memory, just contains a reference points to replication buffer's block and the blocks index (to accelerate search offset when partial sync), so we need update both replication buffer's block's offset and replication backlog blocks index's offset when master restart from RDB, since the `server.master_repl_offset` is changed.
The implications of this bug was just a slow search, but not a replication failure.