### PR TITLE
Fix race condition in cluster test 22-replica-in-sync

### DIFF
--- a/tests/cluster/tests/22-replica-in-sync.tcl
+++ b/tests/cluster/tests/22-replica-in-sync.tcl
@@ -109,21 +109,23 @@ test "Replica in loading state is hidden" {
 }
 
 test "Check disconnected replica not hidden from slots" {
-    # Disconnect replica from primary by stopping it
-    # Stop AOF so that an initial AOFRW won't prevent the instance from terminating
-    R $replica_id config set appendonly no
-    kill_instance redis $replica_id
+    # We want to disconnect the replica, but keep it alive so it can still gossip
 
-    # Wait for master to have no replicas
-    wait_for_condition 100 50 {
-        [s $master_id connected_slaves] == 0
-    } else {
-        fail "replica didn't disconnect"
-    }
+    # Make sure that the replica will not be able to re-connect to the master
+    R $master_id config set requirepass asdf
+
+    # Disconnect replica from primary
+    R $master_id client kill type replica
+
+    # Check master to have no replicas
+    assert {[s $master_id connected_slaves] == 0}
 
     # Check that replica is still in the cluster slots
     assert {[is_in_slots $master_id $replica]}
 
-    # Restart the stopped replica
-    restart_instance redis $replica_id
+    # undo config
+    R $master_id config set requirepass ""
+
+    # Stop AOF so that an initial AOFRW won't prevent the instance from terminating
+    R $replica_id config set appendonly no
 }

--- a/tests/cluster/tests/22-replica-in-sync.tcl
+++ b/tests/cluster/tests/22-replica-in-sync.tcl
@@ -135,7 +135,7 @@ test "Check disconnected replica not hidden from slots" {
     wait_for_condition 50 100 {
         $initial_pong != [get_last_pong_time $master_id $replica_cid]
     } else {
-        fail "Primary never recieved gossip from replica"
+        fail "Primary never received gossip from replica"
     }
 
     # Check that replica is still in the cluster slots


### PR DESCRIPTION
there was a chance that by the time the assertion is executed,
the replica already manages to reconnect.

now we make sure the replica is unable to re-connect to the master.

additionally, we wait for some gossip from the disconnected replica,
to see that it doesn't mess things up.

unrelated: fix a typo when trying to exhaust the backlog, one that
didn't have any harmful implications