### PR TITLE
attempt to fix tracking test issue with external tests due to lazy free

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -113,6 +113,14 @@ proc wait_done_loading r {
     }
 }
 
+proc wait_lazyfree_done r {
+    wait_for_condition 50 100 {
+        [status $r lazyfree_pending_objects] == 0
+    } else {
+        fail "lazyfree isn't done"
+    }
+}
+
 # count current log lines in server's stdout
 proc count_log_lines {srv_idx} {
     set _ [string trim [exec wc -l < [srv $srv_idx stdout]]]

--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -20,11 +20,7 @@ start_server {tags {"lazyfree"}} {
 
     test "FLUSHDB ASYNC can reclaim memory in background" {
         # make the previous test is really done before sampling used_memory
-        wait_for_condition 50 100 {
-            [s lazyfree_pending_objects] == 0
-        } else {
-            fail "lazyfree isn't done"
-        }
+        wait_lazyfree_done r
 
         set orig_mem [s used_memory]
         set args {}

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -424,6 +424,10 @@ start_server {tags {"tracking network"}} {
         r CLIENT TRACKING off
         r HELLO 3
         r CLIENT TRACKING on
+
+        # make the previous test is really done before sampling used_memory
+        wait_lazyfree_done r
+
         set used [s used_memory]
         set limit [expr {$used+100*1024}]
         set old_policy [lindex [r config get maxmemory-policy] 1]


### PR DESCRIPTION
external tests started failing recently for unclear reason:
```
*** [err]: Tracking invalidation message of eviction keys should be before response in tests/unit/tracking.tcl
Expected '0' to be equal to 'invalidate volatile-key' (context: type eval line 21 cmd {assert_equal $res {invalidate volatile-key}} proc ::test)
```

I suspect the issue is that the used_memory sample is taken while a lazy free is still being processed.
see discussion in #9422