### PR TITLE
release slaveKeysWithExpire dict when unset master

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -461,7 +461,7 @@ size_t getSlaveKeyWithExpireCount(void) {
  * inconsistencies. This is just a best-effort thing we do. */
 void flushSlaveKeysWithExpireList(void) {
     if (slaveKeysWithExpire) {
-        dictRelease(slaveKeysWithExpire);
+        freeSlaveKeysWithExpireDictAsync(slaveKeysWithExpire);
         slaveKeysWithExpire = NULL;
     }
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -2873,6 +2873,9 @@ void replicationUnsetMaster(void) {
     disconnectSlaves();
     server.repl_state = REPL_STATE_NONE;
 
+    /* Release slaveKeysWithExpire dict, since master doesn't need it. */
+    flushSlaveKeysWithExpireList();
+
     /* We need to make sure the new master will start the replication stream
      * with a SELECT statement. This is forced after a full resync, but
      * with PSYNC version 2, there is no need for full resync after a

--- a/src/server.h
+++ b/src/server.h
@@ -2675,6 +2675,7 @@ size_t lazyfreeGetFreedObjectsCount(void);
 void lazyfreeResetStats(void);
 void freeObjAsync(robj *key, robj *obj, int dbid);
 void freeReplicationBacklogRefMemAsync(list *blocks, rax *index);
+void freeSlaveKeysWithExpireDictAsync(dict *slaveKeysWithExpire);
 
 /* API to get key arguments from commands */
 int *getKeysPrepareResult(getKeysResult *result, int numkeys);


### PR DESCRIPTION
When change a replica to master, we need release the `slaveKeysWithExpire` dict to free memory no longer used.

And now we use an async way to release the `slaveKeysWithExpire`, include `emptyDb` and `replicationUnsetMaster`.