### PR TITLE
Replica doesn't serve stale data if it never synced with master

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5425,7 +5425,7 @@ int processCommand(client *c) {
      * when slave-serve-stale-data is no and we are a slave with a broken
      * link with master. */
     if (server.masterhost && server.repl_state != REPL_STATE_CONNECTED &&
-        server.repl_serve_stale_data == 0 &&
+        (server.repl_serve_stale_data == 0 || replicationGetSlaveOffset() == 0) &&
         is_denystale_command)
     {
         rejectCommand(c, shared.masterdownerr);


### PR DESCRIPTION
Discussed in #3172 

If a replica never synced with master, so it may have different data history, i think this replica should not server stale data even if `replica-serve-stale-data` is enabled.

This commit breaks some old behaviors, before, for the following cases, replica can serve stale data, but now can't
- replica is empty
- replica is rebooted from AOF or old version RDB which doesn't have replication info.

But `replica-serve-stale-data` seems to aim the case that replicas disconnect with master at the runtime .

The commit breaks old behaviors, feel free to discuss

P.S.
After  #9398, calling `replicationGetSlaveOffset` on replicas never returns 0 if replicas ever synced with master.