### PR TITLE
fix redis-cli --memkeys-samples 0

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1574,6 +1574,7 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--memkeys-samples")) {
             config.memkeys = 1;
             config.memkeys_samples = atoi(argv[++i]);
+	    if (!config.memkeys_samples) config.memkeys_samples = LLONG_MAX;
         } else if (!strcmp(argv[i],"--hotkeys")) {
             config.hotkeys = 1;
         } else if (!strcmp(argv[i],"--eval") && !lastarg) {


### PR DESCRIPTION
when providing 0 to memkeys samples via `redis-cli --memkeys-samples` option, it is converted to use the default sampling. [Conversion happens here](https://github.com/redis/redis/blob/unstable/src/redis-cli.c#L7524)

The suggested fix is to convert 0 to LLONG_MAX during the parseOption phase.
