### PR TITLE
add repobeats image to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img src="https://repobeats.axiom.co/api/embed/f917a77cbbdeee19b87fa1f2f932895d1df18b47.svg" />
+
 This README is just a fast *quick start* document. You can find more detailed documentation at [redis.io](https://redis.io).
 
 What is Redis?


### PR DESCRIPTION
We added some small swag to the repository README.md

This tries to fetch from repobeats.axiom.co and the svg is generated on the fly :) (but there is a stale cache)

Light Mode:
<img width="922" alt="Screenshot 2021-11-05 at 14 26 13" src="https://user-images.githubusercontent.com/117837/140517492-7b99a0da-c923-4f73-b53d-402e434c6977.png">


Dark mode:
<img width="991" alt="Screenshot 2021-11-05 at 14 25 34" src="https://user-images.githubusercontent.com/117837/140517509-bf211234-1564-4f1c-aa75-e2b58189794d.png">


We are also using Redis to make this happen :) 
