### PR TITLE
WIP Add filename to aof and rdb logs

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1451,7 +1451,7 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
         return C_ERR;
     }
 
-    serverLog(LL_NOTICE,"DB saved on disk");
+    serverLog(LL_NOTICE,"DB %s saved on disk.". filename);
     server.dirty = 0;
     server.lastsave = time(NULL);
     server.lastbgsave_status = C_OK;
@@ -1459,7 +1459,7 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
     return C_OK;
 
 werr:
-    serverLog(LL_WARNING,"Write error saving DB on disk: %s", strerror(errno));
+    serverLog(LL_WARNING,"Write error saving DB %s on disk: %s", filename, strerror(errno));
     if (fp) fclose(fp);
     unlink(tmpfile);
     stopSaving(0);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3130,7 +3130,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
         if (server.rdb_checksum && !server.skip_checksum_validation) {
             memrev64ifbe(&cksum);
             if (cksum == 0) {
-                serverLog(LL_WARNING,"RDB file was saved with checksum disabled: no check performed.");
+                serverLog(LL_WARNING,"RDB file %s was saved with checksum disabled: no check performed.", server.rdb_filename);
             } else if (cksum != expected) {
                 serverLog(LL_WARNING,"Wrong RDB checksum expected: (%llx) but "
                     "got (%llx). Aborting now.",
@@ -3144,12 +3144,12 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
 
     if (empty_keys_skipped) {
         serverLog(LL_WARNING,
-            "Done loading RDB, keys loaded: %lld, keys expired: %lld, empty keys skipped: %lld.",
-                server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired, empty_keys_skipped);
+            "Done loading RDB %s, keys loaded: %lld, keys expired: %lld, empty keys skipped: %lld.",
+                server.rdb_filename, server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired, empty_keys_skipped);
     } else {
         serverLog(LL_NOTICE,
-            "Done loading RDB, keys loaded: %lld, keys expired: %lld.",
-                server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired);
+            "Done loading RDB %s, keys loaded: %lld, keys expired: %lld.",
+                server.rdb_filename, server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired);
     }
     return C_OK;
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1451,7 +1451,7 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
         return C_ERR;
     }
 
-    serverLog(LL_NOTICE,"DB %s saved on disk.", filename);
+    serverLog(LL_NOTICE,"DB file %s saved on disk.", filename);
     server.dirty = 0;
     server.lastsave = time(NULL);
     server.lastbgsave_status = C_OK;
@@ -1459,7 +1459,7 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
     return C_OK;
 
 werr:
-    serverLog(LL_WARNING,"Write error saving DB %s on disk: %s", filename, strerror(errno));
+    serverLog(LL_WARNING,"Write error saving DB file %s on disk: %s", filename, strerror(errno));
     if (fp) fclose(fp);
     unlink(tmpfile);
     stopSaving(0);
@@ -1489,7 +1489,7 @@ int rdbSaveBackground(int req, char *filename, rdbSaveInfo *rsi) {
         /* Parent */
         if (childpid == -1) {
             server.lastbgsave_status = C_ERR;
-            serverLog(LL_WARNING,"Can't save %s in background: fork: %s",
+            serverLog(LL_WARNING,"Can't save file %s in background: fork: %s",
                 filename,
                 strerror(errno));
             return C_ERR;
@@ -3144,11 +3144,11 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
 
     if (empty_keys_skipped) {
         serverLog(LL_WARNING,
-            "Done loading RDB %s, keys loaded: %lld, keys expired: %lld, empty keys skipped: %lld.",
+            "Done loading RDB file %s, keys loaded: %lld, keys expired: %lld, empty keys skipped: %lld.",
                 server.rdb_filename, server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired, empty_keys_skipped);
     } else {
         serverLog(LL_NOTICE,
-            "Done loading RDB %s, keys loaded: %lld, keys expired: %lld.",
+            "Done loading RDB file %s, keys loaded: %lld, keys expired: %lld.",
                 server.rdb_filename, server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired);
     }
     return C_OK;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1489,7 +1489,8 @@ int rdbSaveBackground(int req, char *filename, rdbSaveInfo *rsi) {
         /* Parent */
         if (childpid == -1) {
             server.lastbgsave_status = C_ERR;
-            serverLog(LL_WARNING,"Can't save in background: fork: %s",
+            serverLog(LL_WARNING,"Can't save %s in background: fork: %s",
+                filename,
                 strerror(errno));
             return C_ERR;
         }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1451,7 +1451,7 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
         return C_ERR;
     }
 
-    serverLog(LL_NOTICE,"DB %s saved on disk.". filename);
+    serverLog(LL_NOTICE,"DB %s saved on disk.", filename);
     server.dirty = 0;
     server.lastsave = time(NULL);
     server.lastbgsave_status = C_OK;

--- a/src/server.c
+++ b/src/server.c
@@ -6227,7 +6227,7 @@ void loadDataFromDisk(void) {
             rdb_flags |= RDBFLAGS_FEED_REPL;
         }
         if (rdbLoad(server.rdb_filename,&rsi,rdb_flags) == C_OK) {
-            serverLog(LL_NOTICE,"DB %s loaded from disk: %.3f seconds",
+            serverLog(LL_NOTICE,"DB loaded from RDB file %s disk: %.3f seconds",
                 server.rdb_filename,
                 (float)(ustime()-start)/1000000);
 
@@ -6263,7 +6263,7 @@ void loadDataFromDisk(void) {
                 }
             }
         } else if (errno != ENOENT) {
-            serverLog(LL_WARNING,"Fatal error loading the DB %s: %s. Exiting.", server.rdb_filename, strerror(errno));
+            serverLog(LL_WARNING,"Fatal error loading the DB file %s: %s. Exiting.", server.rdb_filename, strerror(errno));
             exit(1);
         }
 

--- a/src/server.c
+++ b/src/server.c
@@ -6227,7 +6227,7 @@ void loadDataFromDisk(void) {
             rdb_flags |= RDBFLAGS_FEED_REPL;
         }
         if (rdbLoad(server.rdb_filename,&rsi,rdb_flags) == C_OK) {
-            serverLog(LL_NOTICE,"DB loaded from disk %s: %.3f seconds",
+            serverLog(LL_NOTICE,"DB %s loaded from disk: %.3f seconds",
                 server.rdb_filename,
                 (float)(ustime()-start)/1000000);
 

--- a/src/server.c
+++ b/src/server.c
@@ -6227,7 +6227,8 @@ void loadDataFromDisk(void) {
             rdb_flags |= RDBFLAGS_FEED_REPL;
         }
         if (rdbLoad(server.rdb_filename,&rsi,rdb_flags) == C_OK) {
-            serverLog(LL_NOTICE,"DB loaded from disk: %.3f seconds",
+            serverLog(LL_NOTICE,"DB loaded from disk %s: %.3f seconds",
+                server.rdb_filename,
                 (float)(ustime()-start)/1000000);
 
             /* Restore the replication ID / offset from the RDB file. */
@@ -6262,7 +6263,7 @@ void loadDataFromDisk(void) {
                 }
             }
         } else if (errno != ENOENT) {
-            serverLog(LL_WARNING,"Fatal error loading the DB: %s. Exiting.",strerror(errno));
+            serverLog(LL_WARNING,"Fatal error loading the DB %s: %s. Exiting.", server.rdb_filename, strerror(errno));
             exit(1);
         }
 


### PR DESCRIPTION
Wait for https://github.com/redis/redis/pull/9788

This PR adds the filenames of the rdb and aof files to the logs in the following cases:

1. If no aof file the disk, and config file has appendonly yes
![image](https://user-images.githubusercontent.com/51993843/140405921-6bb27770-1481-4157-9550-1c2eb5eedf7f.png)

2. When redis server startup, and loading data from rdb file
![image](https://user-images.githubusercontent.com/51993843/140406157-ee87b376-ee2f-4c20-85e0-85ec7af8ca1f.png)

3. When redis server startup, and loading data from aof file
![image](https://user-images.githubusercontent.com/51993843/140406278-3ad71b86-7371-4927-ba44-20990ea06696.png)
