### PR TITLE
Fixing import of sys/errno

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -31,7 +31,7 @@
 #ifndef __REDIS_CONNECTION_H
 #define __REDIS_CONNECTION_H
 
-#include <sys/errno.h>
+#include <errno.h>
 
 #define CONN_INFO_LEN   32
 


### PR DESCRIPTION
There is a warning when compiling on the alphine platform

```
# https://github.com/redis/redis/runs/4111889932?check_suite_focus=true#step:5:494
/usr/include/sys/errno.h:1:2: error: #warning redirecting incorrect #include <sys/errno.h> to <errno.h> [-Werror=cpp]
    1 | #warning redirecting incorrect #include <sys/errno.h> to <errno.h>
```

Introduced in https://github.com/redis/redis/pull/9629

