### PR TITLE
replication: introduce REPLCONF buf-only to listen only modification without whole RDB

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7003,8 +7003,8 @@ static ssize_t readConn(redisContext *c, char *buf, size_t len)
 
 /* Sends SYNC and reads the number of bytes in the payload. Used both by
  * slaveMode() and getRDB().
- * returns ULLONG_MAX and fill out_eof in case an EOF marker is used.
- * otherwise, return bulk length of rdb. */
+ * returns ULLONG_MAX and fills out_eof in case an EOF marker is used.
+ * otherwise, returns bulk length of rdb. */
 unsigned long long sendSync(redisContext *c, char *out_eof) {
     /* To start we need to send the SYNC command and return the payload.
      * The hiredis client lib does not understand this part of the protocol
@@ -7123,11 +7123,11 @@ static void getRDB(clusterManagerNode *node) {
     static char eofmark[RDB_EOF_MARK_SIZE];
     static char lastbytes[RDB_EOF_MARK_SIZE];
     static int usemark = 0;
+    eofmark[0] = 0; /* none $EOF by default */
     unsigned long long payload = sendSync(s, eofmark);
     char buf[4096];
 
-    if (payload == 0) {
-        payload = ULLONG_MAX;
+    if (eofmark[0]) {
         memset(lastbytes,0,RDB_EOF_MARK_SIZE);
         usemark = 1;
         fprintf(stderr,"SYNC sent to master, writing bytes of bulk transfer "

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6989,6 +6989,10 @@ void sendRdbOnly(void) {
     sendReplconf("rdb-only", "1");
 }
 
+void sendBufOnly(void) {
+    sendReplconf("buf-only", "1");
+}
+
 /* Read raw bytes through a redisContext. The read operation is not greedy
  * and may not fill the buffer entirely.
  */
@@ -8321,6 +8325,7 @@ int main(int argc, char **argv) {
     if (config.slave_mode) {
         if (cliConnect(0) == REDIS_ERR) exit(1);
         sendCapa();
+        sendBufOnly();
         slaveMode();
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -2614,9 +2614,7 @@ void syncWithMaster(connection *conn) {
          * slave listening port correctly. */
         {
             int port;
-            if (server.repl_bufonly)
-                port = 0;
-            else if (server.slave_announce_port)
+            if (server.slave_announce_port)
                 port = server.slave_announce_port;
             else if (server.tls_replication && server.tls_port)
                 port = server.tls_port;
@@ -2645,7 +2643,7 @@ void syncWithMaster(connection *conn) {
          *
          * The master will ignore capabilities it does not understand. */
         err = sendCommand(conn,"REPLCONF",
-                "capa","eof","capa","psync2","buf-only",server.repl_bufonly ? "1" : "0",NULL);
+                "capa","eof","capa","psync2",NULL);
         if (err) goto write_error;
 
         server.repl_state = REPL_STATE_RECEIVE_AUTH_REPLY;
@@ -3093,16 +3091,12 @@ void replicaofCommand(client *c) {
                                  "master\r\n"));
             return;
         }
-
-        /* REPLICAOF HOST PORT [BUF-ONLY] */
-        server.repl_bufonly = c->argc == 4 && !strcasecmp(c->argv[3]->ptr,"buf-only");
-
         /* There was no previous master or the user specified a different one,
          * we can continue. */
         replicationSetMaster(c->argv[1]->ptr, port);
         sds client = catClientInfoString(sdsempty(),c);
-        serverLog(LL_NOTICE,"REPLICAOF %s:%d buf-only=%d enabled (user request from '%s')",
-            server.masterhost, server.masterport, server.repl_bufonly, client);
+        serverLog(LL_NOTICE,"REPLICAOF %s:%d enabled (user request from '%s')",
+            server.masterhost, server.masterport, client);
         sdsfree(client);
     }
     addReply(c,shared.ok);

--- a/src/replication.c
+++ b/src/replication.c
@@ -3347,6 +3347,8 @@ void refreshGoodSlavesCount(void) {
     listRewind(server.slaves,&li);
     while((ln = listNext(&li))) {
         client *slave = ln->value;
+        if (slave->flags & CLIENT_REPL_BUFONLY)
+            continue;
         time_t lag = server.unixtime - slave->repl_ack_time;
 
         if (slave->replstate == SLAVE_STATE_ONLINE &&

--- a/src/server.c
+++ b/src/server.c
@@ -1646,10 +1646,10 @@ struct redisCommand redisCommandTable[] = {
        KSPEC_BS_INDEX,.bs.index={1},
        KSPEC_FK_RANGE,.fk.range={0,1,0}}}},
 
-    {"slaveof",replicaofCommand,-3,
+    {"slaveof",replicaofCommand,3,
      "admin no-script ok-stale"},
 
-    {"replicaof",replicaofCommand,-3,
+    {"replicaof",replicaofCommand,3,
      "admin no-script ok-stale"},
 
     {"role",roleCommand,1,
@@ -3732,7 +3732,6 @@ void initServerConfig(void) {
     server.repl_syncio_timeout = CONFIG_REPL_SYNCIO_TIMEOUT;
     server.repl_down_since = 0; /* Never connected, repl is down since EVER. */
     server.master_repl_offset = 0;
-    server.repl_bufonly = 0;
 
     /* Replication partial resync backlog */
     server.repl_backlog = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -1646,10 +1646,10 @@ struct redisCommand redisCommandTable[] = {
        KSPEC_BS_INDEX,.bs.index={1},
        KSPEC_FK_RANGE,.fk.range={0,1,0}}}},
 
-    {"slaveof",replicaofCommand,3,
+    {"slaveof",replicaofCommand,-3,
      "admin no-script ok-stale"},
 
-    {"replicaof",replicaofCommand,3,
+    {"replicaof",replicaofCommand,-3,
      "admin no-script ok-stale"},
 
     {"role",roleCommand,1,
@@ -3650,6 +3650,9 @@ void createSharedObjects(void) {
      * string in string comparisons for the ZRANGEBYLEX command. */
     shared.minstring = sdsnew("minstring");
     shared.maxstring = sdsnew("maxstring");
+
+    /* Shared RDB bulk response for BUF-ONLY salves. Created when needed. */
+    shared.bufonlybulk = NULL;
 }
 
 void initServerConfig(void) {
@@ -3729,6 +3732,7 @@ void initServerConfig(void) {
     server.repl_syncio_timeout = CONFIG_REPL_SYNCIO_TIMEOUT;
     server.repl_down_since = 0; /* Never connected, repl is down since EVER. */
     server.master_repl_offset = 0;
+    server.repl_bufonly = 0;
 
     /* Replication partial resync backlog */
     server.repl_backlog = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -3650,9 +3650,6 @@ void createSharedObjects(void) {
      * string in string comparisons for the ZRANGEBYLEX command. */
     shared.minstring = sdsnew("minstring");
     shared.maxstring = sdsnew("maxstring");
-
-    /* Shared RDB bulk response for BUF-ONLY salves. Created when needed. */
-    shared.bufonlybulk = NULL;
 }
 
 void initServerConfig(void) {

--- a/src/server.h
+++ b/src/server.h
@@ -307,6 +307,9 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
                                           RDB without replication buffer. */
 #define CLIENT_NO_EVICT (1ULL<<43) /* This client is protected against client
                                       memory eviction. */
+#define CLIENT_REPL_BUFONLY (1ULL<<44) /* This client is a replica that only wants
+                                           replication buffer without RDB. */
+#define CLIENT_REPL_RDBBUF (CLIENT_REPL_RDBONLY|CLIENT_REPL_BUFONLY)
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */
@@ -1137,6 +1140,7 @@ struct sharedObjectsStruct {
     *mbulkhdr[OBJ_SHARED_BULKHDR_LEN], /* "*<value>\r\n" */
     *bulkhdr[OBJ_SHARED_BULKHDR_LEN];  /* "$<value>\r\n" */
     sds minstring, maxstring;
+    sds bufonlybulk;
 };
 
 /* ZSETs use a specialized version of Skiplists */
@@ -1623,6 +1627,7 @@ struct redisServer {
     int repl_slave_ignore_maxmemory;    /* If true slaves do not evict. */
     time_t repl_down_since; /* Unix time at which link with master went down */
     int repl_disable_tcp_nodelay;   /* Disable TCP_NODELAY after SYNC? */
+    int repl_bufonly;              /* Set if last REPLICAOF command has extra BUF-ONLY option */
     int slave_priority;             /* Reported in INFO and used by Sentinel. */
     int replica_announced;          /* If true, replica is announced by Sentinel */
     int slave_announce_port;        /* Give the master this listening port. */

--- a/src/server.h
+++ b/src/server.h
@@ -1140,7 +1140,6 @@ struct sharedObjectsStruct {
     *mbulkhdr[OBJ_SHARED_BULKHDR_LEN], /* "*<value>\r\n" */
     *bulkhdr[OBJ_SHARED_BULKHDR_LEN];  /* "$<value>\r\n" */
     sds minstring, maxstring;
-    sds bufonlybulk;
 };
 
 /* ZSETs use a specialized version of Skiplists */

--- a/src/server.h
+++ b/src/server.h
@@ -1627,7 +1627,6 @@ struct redisServer {
     int repl_slave_ignore_maxmemory;    /* If true slaves do not evict. */
     time_t repl_down_since; /* Unix time at which link with master went down */
     int repl_disable_tcp_nodelay;   /* Disable TCP_NODELAY after SYNC? */
-    int repl_bufonly;              /* Set if last REPLICAOF command has extra BUF-ONLY option */
     int slave_priority;             /* Reported in INFO and used by Sentinel. */
     int replica_announced;          /* If true, replica is announced by Sentinel */
     int slave_announce_port;        /* Give the master this listening port. */


### PR DESCRIPTION
As what we want usually, master will send back a big rdb if PSYNC
turns out to be a full resynchronization. This really helps if
replica wants the whole same dataset as master. In some another
uncommon situation, however, replica only needs stream of commands
that change dataset, such as redis-cli --replica. This contributes
master performance drops caused by BGSAVE.

By sending REPLCONF BUF-ONLY 1 to master before PSYNC, An empty
RDB is received if partial resynchronization failed, and
master is forkless and diskless. More redis-cli clients replicate
master, more this option helps.

Although REPLCONF and PSYNC are internal commands, some end user
could talk replication handshake protocol whith master on a clean
connection to get a modification command stream. This using case
should drop master performance as little as possible, and BUF-ONLY
option helps much.  From the view point of master, those clients are
not real replica at all.
