### PR TITLE
Fix EINTR test in TLS mode

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -152,7 +152,7 @@ static inline int connWrite(connection *conn, const void *data, size_t data_len)
  */
 static inline int connRead(connection *conn, void *buf, size_t buf_len) {
     int ret = conn->type->read(conn, buf, buf_len);
-    if (ret == -1 && conn->last_errno == EINTR) {
+    if (ret == -1 && (conn->last_errno == EINTR || conn->last_errno == EAGAIN)) {
         conn->state = CONN_STATE_CONNECTED;
     }
     return ret;
@@ -210,7 +210,7 @@ static inline int connGetType(connection *conn) {
 }
 
 static inline int connLastErrorRetryable(connection *conn) {
-    return conn->last_errno == EINTR;
+    return conn->last_errno == EINTR || conn->last_errno == EAGAIN;
 }
 
 connection *connCreateSocket();

--- a/src/tls.c
+++ b/src/tls.c
@@ -756,7 +756,7 @@ static int connTLSWrite(connection *conn_, const void *data, size_t data_len) {
         if (!(ssl_err = handleSSLReturnCode(conn, ret, &want))) {
             if (want == WANT_READ) conn->flags |= TLS_CONN_FLAG_WRITE_WANT_READ;
             updateSSLEvent(conn);
-            errno = EAGAIN;
+            conn->c.last_errno = errno = EAGAIN;
             return -1;
         } else {
             if (ssl_err == SSL_ERROR_ZERO_RETURN ||
@@ -787,7 +787,7 @@ static int connTLSRead(connection *conn_, void *buf, size_t buf_len) {
             if (want == WANT_WRITE) conn->flags |= TLS_CONN_FLAG_READ_WANT_WRITE;
             updateSSLEvent(conn);
 
-            errno = EAGAIN;
+            conn->c.last_errno = errno = EAGAIN;
             return -1;
         } else {
             if (ssl_err == SSL_ERROR_ZERO_RETURN ||


### PR DESCRIPTION
Test introduced in #9629 fails in TLS mode.
```
*** [err]: replica can handle EINTR if use diskless load in tests/integration/replication.tcl
Expected !1 (context: type eval line 28 cmd {assert ![log_file_matches [srv -1 stdout] "*Reconnecting to MASTER*"]            } proc ::start_server)
```