### PR TITLE
Fix EINTR test failures.

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -171,7 +171,7 @@ static int connSocketWrite(connection *conn, const void *data, size_t data_len) 
         /* Don't overwrite the state of a connection that is not already
          * connected, not to mess with handler callbacks.
          */
-        if (conn->state == CONN_STATE_CONNECTED)
+        if (errno != EINTR && conn->state == CONN_STATE_CONNECTED)
             conn->state = CONN_STATE_ERROR;
     }
 
@@ -188,7 +188,7 @@ static int connSocketRead(connection *conn, void *buf, size_t buf_len) {
         /* Don't overwrite the state of a connection that is not already
          * connected, not to mess with handler callbacks.
          */
-        if (conn->state == CONN_STATE_CONNECTED)
+        if (errno != EINTR && conn->state == CONN_STATE_CONNECTED)
             conn->state = CONN_STATE_ERROR;
     }
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -152,9 +152,6 @@ static inline int connWrite(connection *conn, const void *data, size_t data_len)
  */
 static inline int connRead(connection *conn, void *buf, size_t buf_len) {
     int ret = conn->type->read(conn, buf, buf_len);
-    if (ret == -1 && conn->last_errno == EINTR) {
-        conn->state = CONN_STATE_CONNECTED;
-    }
     return ret;
 }
 


### PR DESCRIPTION
An alternative fix for #9749:

* Clean up `EINTR` handling so `EINTR` will not change connection state to begin with.
* On TLS, catch `EINTR` and return it as-is before going through OpenSSL error handling (which seems to not distinguish it from `EAGAIN`).