### PR TITLE
Fix diskless load handling on broken EOF marker

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1963,11 +1963,25 @@ void readSyncBulkPayload(connection *conn) {
         connRecvTimeout(conn, server.repl_timeout*1000);
         startLoading(server.repl_transfer_size, RDBFLAGS_REPLICATION, asyncLoading);
 
+        int replicationFailed = 0;
         if (rdbLoadRio(&rdb,RDBFLAGS_REPLICATION,&rsi,dbarray) != C_OK) {
             /* RDB loading failed. */
             serverLog(LL_WARNING,
                       "Failed trying to load the MASTER synchronization DB "
                       "from socket: %s", strerror(errno));
+            replicationFailed = 1;
+        }
+        else if (usemark) {
+            /* Verify the end mark is correct. */
+            if (!rioRead(&rdb, buf, CONFIG_RUN_ID_SIZE) ||
+                memcmp(buf, eofmark, CONFIG_RUN_ID_SIZE) != 0)
+            {
+                serverLog(LL_WARNING, "Replication stream EOF marker is broken");
+                replicationFailed = 1;
+            }
+        }
+
+        if (replicationFailed) {
             stopLoading(0);
             cancelReplicationHandshake(1);
             rioFreeConn(&rdb, NULL);
@@ -2012,19 +2026,6 @@ void readSyncBulkPayload(connection *conn) {
 
         /* Inform about db change, as replication was diskless and didn't cause a save. */
         server.dirty++;
-
-        /* Verify the end mark is correct. */
-        if (usemark) {
-            if (!rioRead(&rdb,buf,CONFIG_RUN_ID_SIZE) ||
-                memcmp(buf,eofmark,CONFIG_RUN_ID_SIZE) != 0)
-            {
-                stopLoading(0);
-                serverLog(LL_WARNING,"Replication stream EOF marker is broken");
-                cancelReplicationHandshake(1);
-                rioFreeConn(&rdb, NULL);
-                return;
-            }
-        }
 
         stopLoading(1);
 


### PR DESCRIPTION
As noted by @oranagra here: https://github.com/redis/redis/pull/9323#discussion_r744605630
During diskless replication, the check for broken EOF mark is misplaced and should be earlier.
Now we do not swap db, we do proper cleanup and correctly raise module events on this kind of failure.

This issue existed prior to #9323, but before, the side effect was not restoring backup and not raising the correct module events on this failure.