### PR TITLE
Sentinel tls memory leak

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2348,7 +2348,10 @@ static int instanceLinkNegotiateTLS(redisAsyncContext *context) {
     SSL *ssl = SSL_new(redis_tls_client_ctx ? redis_tls_client_ctx : redis_tls_ctx);
     if (!ssl) return C_ERR;
 
-    if (redisInitiateSSL(&context->c, ssl) == REDIS_ERR) return C_ERR;
+    if (redisInitiateSSL(&context->c, ssl) == REDIS_ERR) {
+        SSL_free(ssl);
+        return C_ERR;
+    }
 #endif
     return C_OK;
 }


### PR DESCRIPTION
This PR fixes the bug mentioned in issue https://github.com/redis/redis/issues/9725. There was a memory leak when tls is used in Sentinels. 
The memory leak is noticed when some of the replicas are offline. Here is the log of a Sentinel from Valgrind when 1 Master and 5 Replicas were used and 4 replicas are offline. 

![image](https://user-images.githubusercontent.com/51993843/140806023-32fda31a-e8a8-4f4a-a764-24046c1cc134.png)

Next is the Log after applying the code change

![image](https://user-images.githubusercontent.com/51993843/140806123-2862623b-c48c-4c5b-9d6e-a918aeb5311b.png)

