### PR TITLE
Reject PING with MASTERDOWN when replica-serve-stale-data=no

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -520,8 +520,8 @@ dir ./
 #
 # 2) If replica-serve-stale-data is set to 'no' the replica will reply with error
 #    "MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'"
-#    to all data access commands, excluding commands such as :
-#    INFO, REPLICAOF, AUTH, PING, SHUTDOWN, REPLCONF, ROLE, CONFIG, SUBSCRIBE,
+#    to all data access commands, excluding commands such as:
+#    INFO, REPLICAOF, AUTH, SHUTDOWN, REPLCONF, ROLE, CONFIG, SUBSCRIBE,
 #    UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, PUBLISH, PUBSUB, COMMAND, POST,
 #    HOST and LATENCY.
 #

--- a/src/server.c
+++ b/src/server.c
@@ -1530,11 +1530,12 @@ struct redisCommand redisCommandTable[] = {
     {"auth",authCommand,-2,
      "no-auth no-script ok-loading ok-stale fast sentinel @connection"},
 
-    /* We don't allow PING during loading since in Redis PING is used as
-     * failure detection, and a loading server is considered to be
-     * not available. */
+    /* PING is used for Redis failure detection and availability check.
+     * So we return LOADING in case there's a synchronous replication in progress,
+     * MASTERDOWN when replica-serve-stale-data=no and link with MASTER is down,
+     * BUSY when blocked by a script, etc. */
     {"ping",pingCommand,-1,
-     "ok-stale fast sentinel @connection"},
+     "fast sentinel @connection"},
 
     {"sentinel",NULL,-2,
      "admin only-sentinel",
@@ -5423,8 +5424,8 @@ int processCommand(client *c) {
         return C_OK;
     }
 
-    /* Only allow commands with flag "t", such as INFO, SLAVEOF and so on,
-     * when slave-serve-stale-data is no and we are a slave with a broken
+    /* Only allow commands with flag "t", such as INFO, REPLICAOF and so on,
+     * when replica-serve-stale-data is no and we are a replica with a broken
      * link with master. */
     if (server.masterhost && server.repl_state != REPL_STATE_CONNECTED &&
         server.repl_serve_stale_data == 0 &&


### PR DESCRIPTION
As discussed here https://github.com/redis/redis/issues/3172#issuecomment-962593315
Currently PING returns different status when server is not serving data, for example when `LOADING` or `BUSY`.
But same is not true for `MASTERDOWN`
This PR makes PING reply with `MASTERDOWN` when replica-serve-stale-data=no and link is MASTER is down.