### PR TITLE
fix short timeout in replication short read tests

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -55,7 +55,7 @@ jobs:
       run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
-      run: ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}}
+      run: ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: sentinel tests
       if: true && !contains(github.event.inputs.skiptests, 'sentinel')
       run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
@@ -88,7 +88,7 @@ jobs:
       run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
-      run: ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}}
+      run: ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: sentinel tests
       if: true && !contains(github.event.inputs.skiptests, 'sentinel')
       run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
@@ -119,7 +119,7 @@ jobs:
       run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
-      run: ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}}
+      run: ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: sentinel tests
       if: true && !contains(github.event.inputs.skiptests, 'sentinel')
       run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
@@ -154,7 +154,7 @@ jobs:
       if: true && !contains(github.event.inputs.skiptests, 'modules')
       run: |
         make -C tests/modules 32bit # the script below doesn't have an argument, we must build manually ahead of time
-        ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}}
+        ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: sentinel tests
       if: true && !contains(github.event.inputs.skiptests, 'sentinel')
       run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
@@ -193,8 +193,8 @@ jobs:
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
       run: |
-        ./runtest-moduleapi --verbose --tls ${{github.event.inputs.test_args}}
-        ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}}
+        ./runtest-moduleapi --verbose --tls --dump-logs ${{github.event.inputs.test_args}}
+        ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: sentinel tests
       if: true && !contains(github.event.inputs.skiptests, 'sentinel')
       run: |
@@ -316,7 +316,7 @@ jobs:
       run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
-      run: ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}}
+      run: ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: sentinel tests
       if: true && !contains(github.event.inputs.skiptests, 'sentinel')
       run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
@@ -356,8 +356,8 @@ jobs:
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
       run: |
-        ./runtest-moduleapi --verbose --tls ${{github.event.inputs.test_args}}
-        ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}}
+        ./runtest-moduleapi --verbose --tls --dump-logs ${{github.event.inputs.test_args}}
+        ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: sentinel tests
       if: true && !contains(github.event.inputs.skiptests, 'sentinel')
       run: |
@@ -390,7 +390,7 @@ jobs:
       run: ./runtest --accurate --verbose --no-latency --dump-logs ${{github.event.inputs.test_args}}
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
-      run: ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}}
+      run: ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: sentinel tests
       if: true && !contains(github.event.inputs.skiptests, 'sentinel')
       run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
@@ -421,7 +421,7 @@ jobs:
         run: >
           gmake || exit 1 ;
           if echo "${{github.event.inputs.skiptests}}" | grep -vq redis ; then ./runtest --accurate --verbose --no-latency --dump-logs ${{github.event.inputs.test_args}} || exit 1 ; fi ;
-          if echo "${{github.event.inputs.skiptests}}" | grep -vq modules ; then MAKE=gmake ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}} || exit 1 ; fi ;
+          if echo "${{github.event.inputs.skiptests}}" | grep -vq modules ; then MAKE=gmake ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}} || exit 1 ; fi ;
           if echo "${{github.event.inputs.skiptests}}" | grep -vq sentinel ; then ./runtest-sentinel ${{github.event.inputs.cluster_test_args}} || exit 1 ; fi ;
           if echo "${{github.event.inputs.skiptests}}" | grep -vq cluster ; then ./runtest-cluster ${{github.event.inputs.cluster_test_args}} || exit 1 ; fi ;
 
@@ -450,7 +450,7 @@ jobs:
       run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
-      run: ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}}
+      run: ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: sentinel tests
       if: true && !contains(github.event.inputs.skiptests, 'sentinel')
       run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
@@ -483,7 +483,7 @@ jobs:
       run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
-      run: ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}}
+      run: ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
     - name: sentinel tests
       if: true && !contains(github.event.inputs.skiptests, 'sentinel')
       run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -257,7 +257,7 @@ jobs:
       run: ./runtest --valgrind --verbose --clients 1 --dump-logs ${{github.event.inputs.test_args}}
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
-      run: ./runtest-moduleapi --valgrind --no-latency --verbose --clients 1 ${{github.event.inputs.test_args}}
+      run: ./runtest-moduleapi --valgrind --no-latency --verbose --clients 1 --dump-logs ${{github.event.inputs.test_args}}
     - name: unittest
       run: |
         valgrind --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.txt ./src/redis-server test all
@@ -288,7 +288,7 @@ jobs:
       run: ./runtest --valgrind --verbose --clients 1 --dump-logs ${{github.event.inputs.test_args}}
     - name: module api test
       if: true && !contains(github.event.inputs.skiptests, 'modules')
-      run: ./runtest-moduleapi --valgrind --no-latency --verbose --clients 1 ${{github.event.inputs.test_args}}
+      run: ./runtest-moduleapi --valgrind --no-latency --verbose --clients 1 --dump-logs ${{github.event.inputs.test_args}}
 
   test-centos7-jemalloc:
     runs-on: ubuntu-latest

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -672,7 +672,7 @@ test {diskless loading short read} {
                 # kill the replica connection on the master
                 set killed [$master client kill type replica]
 
-                set res [wait_for_log_messages -1 {"*Internal error in RDB*" "*Finished with success*" "*Successful partial resynchronization*"} $loglines 1000 1]
+                set res [wait_for_log_messages -1 {"*Internal error in RDB*" "*Finished with success*" "*Successful partial resynchronization*"} $loglines 500 10]
                 if {$::verbose} { puts $res }
                 set log_text [lindex $res 0]
                 set loglines [lindex $res 1]

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -98,7 +98,7 @@ tags "modules" {
                         # kill the replica connection on the master
                         set killed [$master client kill type replica]
 
-                        set res [wait_for_log_messages -1 {"*Internal error in RDB*" "*Finished with success*" "*Successful partial resynchronization*"} $loglines 1000 1]
+                        set res [wait_for_log_messages -1 {"*Internal error in RDB*" "*Finished with success*" "*Successful partial resynchronization*"} $loglines 500 10]
                         if {$::verbose} { puts $res }
                         set log_text [lindex $res 0]
                         set loglines [lindex $res 1]


### PR DESCRIPTION
In both tests, "diskless loading short read" and "diskless loading short read with module",
the timeout of waiting for the replica to respond to a short read and log it, is too short.

The test fails to find one of the results of the replication in the replica log:
```
[wait_for_log_messages -1 {"*Internal error in RDB*" "*Finished with success*" "*Successful partial resynchronization*"} $loglines 500 10]
```

Log from Replica:
```
15757:S 08 Nov 2021 00:46:22.139 * MASTER <-> REPLICA sync: Loading DB in memory
15757:S 08 Nov 2021 00:46:22.140 * Loading RDB produced by version 255.255.255
15757:S 08 Nov 2021 00:46:22.140 * RDB age 0 seconds
15757:S 08 Nov 2021 00:46:22.141 * RDB memory usage when created 69.97 Mb
15757:S 08 Nov 2021 00:46:22.863 # Short read or OOM loading DB. Unrecoverable error, aborting now.
15757:S 08 Nov 2021 00:46:22.863 # Internal error in RDB reading offset 0, function at rdb.c:2952 -> Unexpected EOF reading RDB file. Failure loading rdb format from socket, assuming connection error, resuming operation.
15757:S 08 Nov 2021 00:46:22.864 # Failed trying to load the MASTER synchronization DB from socket: Success
15757:S 08 Nov 2021 00:46:22.864 * Reconnecting to MASTER 127.0.0.1:21216 after failure
15757:S 08 Nov 2021 00:46:22.864 * MASTER <-> REPLICA sync started
15757:S 08 Nov 2021 00:46:22.865 * MASTER <-> REPLICA sync: Discarding temporary DB in background
15757:S 08 Nov 2021 00:46:22.866 * Non blocking connect for SYNC fired the event.
15757:S 08 Nov 2021 00:46:22.868 * Master replied to PING, replication can continue...
15757:S 08 Nov 2021 00:46:22.870 * Trying a partial resynchronization (request 694d7ebd1f0f1b04a2fe50d4c072696025a4d9d5:1).
15757:S 08 Nov 2021 00:46:22.879 * Full resync from master: 5361195be938e956f5d6455dee7b6935902c4aa0:0
15757:S 08 Nov 2021 00:46:22.957 * MASTER <-> REPLICA sync: receiving streamed RDB from master with EOF to parser
15757:S 08 Nov 2021 00:46:22.958 * MASTER <-> REPLICA sync: Loading DB in memory
15757:S 08 Nov 2021 00:46:22.959 * Loading RDB produced by version 255.255.255
15757:S 08 Nov 2021 00:46:22.959 * RDB age 0 seconds
15757:S 08 Nov 2021 00:46:22.959 * RDB memory usage when created 69.97 Mb
15757:signal-handler (1636332391) Received shutdown signal during loading, exiting now.
```
We can see that at the first iteration, it took 720 [ms] from where the replica started loading DB in memory (00:46:22.139) till it fails on short read and log the failure (00:46:22.863).
But on the next iteration, we can see that the replica starts to load the DB in memory (00:46:22.958) but since we have a timeout of 1000 [ms] the test terminate the replica.

Also, add --dump-logs in runtest-moduleapi for valgrind runs.