### PR TITLE
Archive external redis log in external tests

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -15,12 +15,18 @@ jobs:
     - name: Build
       run: make REDIS_CFLAGS=-Werror
     - name: Start redis-server
-      run: ./src/redis-server --daemonize yes
+      run: ./src/redis-server --daemonize yes --logfile external-redis.log
     - name: Run external test
       run: |
           ./runtest \
             --host 127.0.0.1 --port 6379 \
             --tags -slow
+    - name: Archive redis log
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-external-redis-log
+        path: external-redis.log
 
   test-external-cluster:
     runs-on: ubuntu-latest
@@ -30,7 +36,7 @@ jobs:
     - name: Build
       run: make REDIS_CFLAGS=-Werror
     - name: Start redis-server
-      run: ./src/redis-server --cluster-enabled yes --daemonize yes
+      run: ./src/redis-server --cluster-enabled yes --daemonize yes --logfile external-redis.log
     - name: Create a single node cluster
       run: ./src/redis-cli cluster addslots $(for slot in {0..16383}; do echo $slot; done); sleep 5
     - name: Run external test
@@ -39,4 +45,10 @@ jobs:
             --host 127.0.0.1 --port 6379 \
             --cluster-mode \
             --tags -slow
+    - name: Archive redis log
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-external-cluster-log
+        path: external-redis.log
 

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -152,11 +152,17 @@ proc test {name code {okpattern undefined} {tags {}}} {
     set details {}
     lappend details "$name in $::curfile"
 
-    # set a cur_test global to be logged into new servers that are spown
+    # set a cur_test global to be logged into new servers that are spawn
     # and log the test name in all existing servers
     set prev_test $::cur_test
     set ::cur_test "$name in $::curfile"
-    if {!$::external} {
+    if {$::external} {
+        catch {
+            set r [redis [srv 0 host] [srv 0 port] 0 $::tls]
+            $r debug log "### Starting test $::cur_test"
+            $r close
+        }
+    } else {
         foreach srv $::servers {
             set stdout [dict get $srv stdout]
             set fd [open $stdout "a+"]

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -699,14 +699,6 @@ proc generate_fuzzy_traffic_on_key {key duration} {
     return $sent
 }
 
-# write line to server log file
-proc write_log_line {srv_idx msg} {
-    set logfile [srv $srv_idx stdout]
-    set fd [open $logfile "a+"]
-    puts $fd "### $msg"
-    close $fd
-}
-
 proc string2printable s {
     set res {}
     set has_special_chars false


### PR DESCRIPTION
On test failure store the external redis server logs as CI artifacts so we can review them.

This was very helpful for me to debug external redis test failures.

The PR also includes writing the test name to the external-server's log file for easier debugging.