### PR TITLE
Run create-cluster not from its dir

### DIFF
--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 # Settings
-BIN_PATH="../../src/"
+BIN_PATH="$SCRIPT_DIR/../../src/"
 CLUSTER_HOST=127.0.0.1
 PORT=30000
 TIMEOUT=2000


### PR DESCRIPTION
This fix makes it possible to run `create-cluster` from any dir, not only from the dir of the script.