### PR TITLE
Tune expire test threshold.

### DIFF
--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -95,7 +95,7 @@ start_server {tags {"expire"}} {
         # This test is very likely to do a false positive if the
         # server is under pressure, so if it does not work give it a few more
         # chances.
-        for {set j 0} {$j < 30} {incr j} {
+        for {set j 0} {$j < 50} {incr j} {
             r del x
             r del y
             r del z


### PR DESCRIPTION
I have seen this CI failure twice on MacOS:

```
# https://github.com/redis/redis/runs/4195718065?check_suite_focus=true#step:5:1328
sub-second expire test attempts: 30
*** [err]: PEXPIRE/PSETEX/PEXPIREAT can set sub-second expires in tests/unit/expire.tcl
Expected 'somevalue {} somevalue {} somevalue {}' to equal or match '{} {} {} {} somevalue {}'
```

I did some loop test in my own daily CI, the results show that is
not particularly stable. Change the threshold from 30 to 50.

see: https://github.com/redis/redis/pull/7791#issuecomment-950800838 for more details