### PR TITLE
Connection leak in external tests.

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -378,7 +378,11 @@ proc run_external_server_test {code overrides} {
         r config set $param $val
     }
 
-    lpop ::servers
+    set srv [lpop ::servers]
+    
+    if {[dict exists $srv "client"]} {
+        [dict get $srv "client"] close
+    }
 }
 
 proc start_server {options {code undefined}} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -19,8 +19,9 @@ start_server {tags {"introspection"}} {
         assert_match {*OK*} [$rd read]
         r set foo bar
         r get foo
-        list [$rd read] [$rd read]
-    } {*"set" "foo"*"get" "foo"*}
+        assert_match {*"set" "foo"*"get" "foo"*} [list [$rd read] [$rd read]]
+        $rd close
+    } 
 
     test {MONITOR can log commands issued by the scripting engine} {
         set rd [redis_deferring_client]
@@ -29,6 +30,7 @@ start_server {tags {"introspection"}} {
         r eval {redis.call('set',KEYS[1],ARGV[1])} 1 foo bar
         assert_match {*eval*} [$rd read]
         assert_match {*lua*"set"*"foo"*"bar"*} [$rd read]
+        $rd close
     }
 
     test {MONITOR supports redacting command arguments} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -19,9 +19,10 @@ start_server {tags {"introspection"}} {
         assert_match {*OK*} [$rd read]
         r set foo bar
         r get foo
-        assert_match {*"set" "foo"*"get" "foo"*} [list [$rd read] [$rd read]]
+        set res [list [$rd read] [$rd read]]
         $rd close
-    } 
+        set _ $res
+    } {*"set" "foo"*"get" "foo"*}
 
     test {MONITOR can log commands issued by the scripting engine} {
         set rd [redis_deferring_client]

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -272,6 +272,7 @@ start_server {tags {"other"}} {
 
         $rd reset
         assert_equal [$rd read] "RESET"
+        $rd close
 
         assert_no_match {*flags=O*} [r client list]
     } {} {needs:reset}

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -236,5 +236,6 @@ start_server {tags {"regression"}} {
         $rd read
         $rd rpush nolist a
         $rd read
+        $rd close
     }
 }

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -174,6 +174,8 @@ start_server {tags {"pubsub network"}} {
         punsubscribe $rd1
         punsubscribe $rd2
         assert_equal 3 $patterns
+        $rd1 close
+        $rd2 close
     }
 
     test "Mix SUBSCRIBE and PSUBSCRIBE" {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -637,6 +637,7 @@ start_server {tags {"scripting"}} {
         r script kill
         after 200 ; # Give some time to Lua to call the hook again...
         assert_equal [r ping] "PONG"
+        $rd close
     }
 
     test {Timedout read-only scripts can be killed by SCRIPT KILL even when use pcall} {

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -990,10 +990,11 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         $watching_client read
         r lpush srclist{t} element
         $watching_client exec
-        assert_equal [$watching_client read] {}
+        set res [$watching_client read]
         $blocked_client close
         $watching_client close
-    }
+        set _ $res
+    } {}
 
     test "BRPOPLPUSH does not affect WATCH while still blocked" {
         set blocked_client [redis_deferring_client]
@@ -1011,10 +1012,11 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         $watching_client exec
         # Blocked BLPOPLPUSH may create problems, unblock it.
         r lpush srclist{t} element
-        assert_equal [$watching_client read] {somevalue}
+        set res [$watching_client read]
         $blocked_client close
         $watching_client close
-    }
+        set _ $res
+    } {somevalue}
 
     test {BRPOPLPUSH timeout} {
       set rd [redis_deferring_client]
@@ -1022,9 +1024,10 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
       $rd brpoplpush foo_list{t} bar_list{t} 1
       wait_for_blocked_clients_count 1
       wait_for_blocked_clients_count 0 500 10
-      assert_equal [$rd read] {}
+      set res [$rd read]
       $rd close
-    }
+      set _ $res
+    } {}
 
 foreach {pop} {BLPOP BLMPOP_LEFT} {
     test "$pop when new key is moved into place" {
@@ -1035,9 +1038,10 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         wait_for_blocked_client
         r lpush bob{t} abc def hij
         r rename bob{t} foo{t}
-        assert_equal [$rd read] {foo{t} hij}
+        set res [$rd read]
         $rd close
-    }
+        set _ $res
+    } {foo{t} hij}
 
     test "$pop when result key is created by SORT..STORE" {
         set rd [redis_deferring_client]
@@ -1051,9 +1055,10 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         wait_for_blocked_client
         r lpush notfoo{t} hello hola aguacate konichiwa zanzibar
         r sort notfoo{t} ALPHA store foo{t}
-        assert_equal [$rd read] {foo{t} aguacate}
+        set res [$rd read]
         $rd close
-    }
+        set _ $res
+    } {foo{t} aguacate}
 }
 
     foreach {pop} {BLPOP BRPOP BLMPOP_LEFT BLMPOP_RIGHT} {

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -582,6 +582,7 @@ start_server {
             assert_equal {blist c} [$rd read]
 
             assert_equal 1 [r llen blist]
+            $rd close
         }
 
         test "$pop: multiple existing lists - $type" {
@@ -610,6 +611,7 @@ start_server {
             assert_equal {blist2{t} f} [$rd read]
             assert_equal 1 [r llen blist1{t}]
             assert_equal 1 [r llen blist2{t}]
+            $rd close
         }
 
         test "$pop: second list has an entry - $type" {
@@ -627,6 +629,7 @@ start_server {
             assert_equal {blist2{t} f} [$rd read]
             assert_equal 0 [r llen blist1{t}]
             assert_equal 1 [r llen blist2{t}]
+            $rd close
         }
     }
 
@@ -642,6 +645,7 @@ start_server {
 
             assert_equal d [r lpop target{t}]
             assert_equal "a b $large c" [r lrange blist{t} 0 -1]
+            $rd close
         }
 
         foreach wherefrom {left right} {
@@ -669,6 +673,7 @@ start_server {
                     } else {
                         assert_equal $poppedelement [r lpop target{t}]
                     }
+                    $rd close
                 }
             }
         }
@@ -690,6 +695,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         r del list
         r lpush list b
         assert_equal {list b} [$rd read]
+        $rd close
     }
 
     test "$pop, LPUSH + DEL + SET should not awake blocked client" {
@@ -708,6 +714,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         r del list
         r lpush list b
         assert_equal {list b} [$rd read]
+        $rd close
     }
 }
 
@@ -730,6 +737,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         assert_equal [$rd read] {list1{t} a}
         $rd blpop list1{t} list2{t} list2{t} list1{t} 0
         assert_equal [$rd read] {list2{t} b}
+        $rd close
     }
 
 foreach {pop} {BLPOP BLMPOP_LEFT} {
@@ -747,6 +755,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         r lpush list c
         r exec
         assert_equal {list c} [$rd read]
+        $rd close
     }
 
     test "$pop with variadic LPUSH" {
@@ -760,6 +769,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         if {$::valgrind} {after 100}
         assert_equal {blist bar} [$rd read]
         assert_equal foo [lindex [r lrange blist 0 -1] 0]
+        $rd close
     }
 }
 
@@ -772,6 +782,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         r rpush blist{t} foo
         assert_equal foo [$rd read]
         assert_equal {foo bar} [r lrange target{t} 0 -1]
+        $rd close
     }
 
     foreach wherefrom {left right} {
@@ -789,6 +800,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
                 } else {
                     assert_equal {foo bar} [r lrange target{t} 0 -1]
                 }
+                $rd close
             }
         }
     }
@@ -806,6 +818,8 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
                 assert_equal foo [$rd read]
                 assert_equal {target{t} foo} [$rd2 read]
                 assert_equal 0 [r exists target{t}]
+                $rd close
+                $rd2 close
             }
         }
     }
@@ -816,6 +830,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         r set blist{t} nolist
         $rd brpoplpush blist{t} target{t} 1
         assert_error "WRONGTYPE*" {$rd read}
+        $rd close
     }
 
     test "BRPOPLPUSH with wrong destination type" {
@@ -825,6 +840,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         r lpush blist{t} foo
         $rd brpoplpush blist{t} target{t} 1
         assert_error "WRONGTYPE*" {$rd read}
+        $rd close
 
         set rd [redis_deferring_client]
         r del blist{t} target{t}
@@ -834,6 +850,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         r rpush blist{t} foo
         assert_error "WRONGTYPE*" {$rd read}
         assert_equal {foo} [r lrange blist{t} 0 -1]
+        $rd close
     }
 
     test "BRPOPLPUSH maintains order of elements after failure" {
@@ -843,6 +860,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         $rd brpoplpush blist{t} target{t} 0
         r rpush blist{t} a b c
         assert_error "WRONGTYPE*" {$rd read}
+        $rd close
         r lrange blist{t} 0 -1
     } {a b c}
 
@@ -858,6 +876,8 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         assert_error "WRONGTYPE*" {$rd1 read}
         assert_equal {foo} [$rd2 read]
         assert_equal {foo} [r lrange target2{t} 0 -1]
+        $rd1 close
+        $rd2 close
     }
 
     test "BLMPOP with multiple blocked clients" {
@@ -884,6 +904,10 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
 
         r lpush blist2{t} 1 2 3
         assert_equal {blist2{t} 1} [$rd4 read]
+        $rd1 close
+        $rd2 close
+        $rd3 close
+        $rd4 close
     }
 
     test "Linked LMOVEs" {
@@ -901,6 +925,8 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
       assert_equal {} [r lrange list1{t} 0 -1]
       assert_equal {} [r lrange list2{t} 0 -1]
       assert_equal {foo} [r lrange list3{t} 0 -1]
+      $rd1 close
+      $rd2 close
     }
 
     test "Circular BRPOPLPUSH" {
@@ -917,6 +943,8 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
 
       assert_equal {foo} [r lrange list1{t} 0 -1]
       assert_equal {} [r lrange list2{t} 0 -1]
+      $rd1 close
+      $rd2 close
     }
 
     test "Self-referential BRPOPLPUSH" {
@@ -930,6 +958,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
       r rpush blist{t} foo
 
       assert_equal {foo} [r lrange blist{t} 0 -1]
+      $rd close
     }
 
     test "BRPOPLPUSH inside a transaction" {
@@ -961,8 +990,10 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         $watching_client read
         r lpush srclist{t} element
         $watching_client exec
-        $watching_client read
-    } {}
+        assert_equal [$watching_client read] {}
+        $blocked_client close
+        $watching_client close
+    }
 
     test "BRPOPLPUSH does not affect WATCH while still blocked" {
         set blocked_client [redis_deferring_client]
@@ -980,8 +1011,10 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         $watching_client exec
         # Blocked BLPOPLPUSH may create problems, unblock it.
         r lpush srclist{t} element
-        $watching_client read
-    } {somevalue}
+        assert_equal [$watching_client read] {somevalue}
+        $blocked_client close
+        $watching_client close
+    }
 
     test {BRPOPLPUSH timeout} {
       set rd [redis_deferring_client]
@@ -989,8 +1022,9 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
       $rd brpoplpush foo_list{t} bar_list{t} 1
       wait_for_blocked_clients_count 1
       wait_for_blocked_clients_count 0 500 10
-      $rd read
-    } {}
+      assert_equal [$rd read] {}
+      $rd close
+    }
 
 foreach {pop} {BLPOP BLMPOP_LEFT} {
     test "$pop when new key is moved into place" {
@@ -1001,8 +1035,9 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         wait_for_blocked_client
         r lpush bob{t} abc def hij
         r rename bob{t} foo{t}
-        $rd read
-    } {foo{t} hij}
+        assert_equal [$rd read] {foo{t} hij}
+        $rd close
+    }
 
     test "$pop when result key is created by SORT..STORE" {
         set rd [redis_deferring_client]
@@ -1016,8 +1051,9 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         wait_for_blocked_client
         r lpush notfoo{t} hello hola aguacate konichiwa zanzibar
         r sort notfoo{t} ALPHA store foo{t}
-        $rd read
-    } {foo{t} aguacate}
+        assert_equal [$rd read] {foo{t} aguacate}
+        $rd close
+    }
 }
 
     foreach {pop} {BLPOP BRPOP BLMPOP_LEFT BLMPOP_RIGHT} {
@@ -1029,12 +1065,14 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             r rpush blist1 foo
             assert_equal {blist1 foo} [$rd read]
             assert_equal 0 [r exists blist1]
+            $rd close
         }
 
         test "$pop: with negative timeout" {
             set rd [redis_deferring_client]
             bpop_command $rd $pop blist1 -1
             assert_error "ERR*is negative*" {$rd read}
+            $rd close
         }
 
         test "$pop: with non-integer timeout" {
@@ -1044,6 +1082,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             r rpush blist1 foo
             assert_equal {blist1 foo} [$rd read]
             assert_equal 0 [r exists blist1]
+            $rd close
         }
 
         test "$pop: with zero timeout should block indefinitely" {
@@ -1055,6 +1094,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             after 1000
             r rpush blist1 foo
             assert_equal {blist1 foo} [$rd read]
+            $rd close
         }
 
         test "$pop: second argument is not a list" {
@@ -1064,6 +1104,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             bpop_command_two_key $rd $pop blist1{t} blist2{t} 1
             $rd $pop blist1{t} blist2{t} 1
             assert_error "WRONGTYPE*" {$rd read}
+            $rd close
         }
 
         test "$pop: timeout" {
@@ -1072,6 +1113,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             bpop_command_two_key $rd $pop blist1{t} blist2{t} 1
             wait_for_blocked_client
             assert_equal {} [$rd read]
+            $rd close
         }
 
         test "$pop: arguments are empty" {
@@ -1091,6 +1133,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             assert_equal {blist2{t} foo} [$rd read]
             assert_equal 0 [r exists blist1{t}]
             assert_equal 0 [r exists blist2{t}]
+            $rd close
         }
     }
 
@@ -1133,6 +1176,8 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         # Released on timeout.
         assert_equal {} [r blmpop 0.01 1 mylist{t} left count 10]
         r set foo{t} bar ;# something else to propagate after, so we can make sure the above pop didn't.
+
+        $rd close
 
         assert_replication_stream $repl {
             {select *}
@@ -1749,7 +1794,8 @@ foreach {pop} {BLPOP BLMPOP_RIGHT} {
         wait_for_blocked_client
         r lpush l foo
         assert_equal {l foo} [$rd read]
-    } {}
+        $rd close
+    }
 }
 
     test {List ziplist of various encodings} {

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -202,6 +202,7 @@ start_server {
         $rd XREADGROUP GROUP mygroup Alice BLOCK 10 STREAMS mystream ">"
         after 20
         assert {[$rd read] == {}} ;# before the fix, client didn't even block, but was served synchronously with {mystream {}}
+        $rd close
     }
 
     test {XGROUP DESTROY should unblock XREADGROUP with -NOGROUP} {
@@ -211,6 +212,7 @@ start_server {
         $rd XREADGROUP GROUP mygroup Alice BLOCK 100 STREAMS mystream ">"
         r XGROUP DESTROY mystream mygroup
         assert_error "*NOGROUP*" {$rd read}
+        $rd close
     }
 
     test {RENAME can unblock XREADGROUP with data} {
@@ -222,6 +224,7 @@ start_server {
         r XADD mystream2{t} 100 f1 v1
         r RENAME mystream2{t} mystream{t}
         assert_equal "{mystream{t} {{100-0 {f1 v1}}}}" [$rd read] ;# mystream2{t} had mygroup before RENAME
+        $rd close
     }
 
     test {RENAME can unblock XREADGROUP with -NOGROUP} {
@@ -232,6 +235,7 @@ start_server {
         r XADD mystream2{t} 100 f1 v1
         r RENAME mystream2{t} mystream{t}
         assert_error "*NOGROUP*" {$rd read} ;# mystream2{t} didn't have mygroup before RENAME
+        $rd close
     }
 
     test {XCLAIM can claim PEL items from another consumer} {
@@ -566,6 +570,7 @@ start_server {
             assert_equal [lindex $consumer_info 1] "Alice" ;# consumer name
             set consumer_info [lindex $reply 1]
             assert_equal [lindex $consumer_info 1] "Bob" ;# consumer name
+            $rd close
         }
 
         test {Consumer without PEL is present in AOF after AOFRW} {
@@ -593,6 +598,7 @@ start_server {
             assert_equal [lindex $consumer_info 1] "Alice"
             set consumer_info [lindex $reply 1]
             assert_equal [lindex $consumer_info 1] "Charlie"
+            $rd close
         }
     }
 

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -291,6 +291,7 @@ start_server {
         set res [$rd read]
         assert {[lindex $res 0 0] eq {s2{t}}}
         assert {[lindex $res 0 1 0 1] eq {new abcd1234}}
+        $rd close
     }
 
     test {Blocking XREAD waiting old data} {
@@ -300,6 +301,7 @@ start_server {
         set res [$rd read]
         assert {[lindex $res 0 0] eq {s2{t}}}
         assert {[lindex $res 0 1 0 1] eq {old abcd1234}}
+        $rd close
     }
 
     test {Blocking XREAD will not reply with an empty array} {
@@ -311,6 +313,7 @@ start_server {
         $rd XREAD BLOCK 10 STREAMS s1 666
         after 20
         assert {[$rd read] == {}} ;# before the fix, client didn't even block, but was served synchronously with {s1 {}}
+        $rd close
     }
 
     test "XREAD: XADD + DEL should not awake client" {
@@ -325,6 +328,7 @@ start_server {
         set res [$rd read]
         assert {[lindex $res 0 0] eq {s1}}
         assert {[lindex $res 0 1 0 1] eq {new abcd1234}}
+        $rd close
     }
 
     test "XREAD: XADD + DEL + LPUSH should not awake client" {
@@ -341,6 +345,7 @@ start_server {
         set res [$rd read]
         assert {[lindex $res 0 0] eq {s1}}
         assert {[lindex $res 0 1 0 1] eq {new abcd1234}}
+        $rd close
     }
 
     test {XREAD with same stream name multiple times should work} {
@@ -351,6 +356,7 @@ start_server {
         set res [$rd read]
         assert {[lindex $res 0 0] eq {s2}}
         assert {[lindex $res 0 1 0 1] eq {new abcd1234}}
+        $rd close
     }
 
     test {XREAD + multiple XADD inside transaction} {
@@ -366,6 +372,7 @@ start_server {
         assert {[lindex $res 0 0] eq {s2}}
         assert {[lindex $res 0 1 0 1] eq {field one}}
         assert {[lindex $res 0 1 1 1] eq {field two}}
+        $rd close
     }
 
     test {XDEL basic test} {
@@ -470,6 +477,7 @@ start_server {
         r XADD x 2-1 f v
         set res [$rd read]
         assert {[lindex $res 0 1 0] == {2-1 {f v}}}
+        $rd close
     }
 
     test {XADD streamID edge} {


### PR DESCRIPTION
Two issues:
1. In many tests we simply forgot to close the connections we created, which doesn't matter for normal tests where the server is killed, but creates a leak on external server tests.
2. When calling `start_server` on external test we create a fresh connection instead of really starting a new server, but never clean it at the end.

What happened in the past is that when running a complete test suite against an external server we wound up having hundreds of connections to that server. For any test that assumes a limited number of connections or iterates over the connection list this can potentially create a problem and a gap between external and normal test cases. Specifically this used to cause issues when running the "query buffer resized correctly when not idle" test, which, on certain platform used to fail because the `clientsCron` took too long.