### PR TITLE
Fix crashes when list-compress-depth is used.

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -383,7 +383,6 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
     if (!in_depth)
         quicklistCompressNode(node);
 
-
     /* At this point, forward and reverse are one node beyond depth */
     quicklistCompressNode(forward);
     quicklistCompressNode(reverse);

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -199,6 +199,7 @@ REDIS_STATIC int __quicklistCompressNode(quicklistNode *node) {
     node->attempted_compress = 1;
 #endif
 
+    node->recompress = 0;
     /* Don't bother compressing small values */
     if (node->sz < MIN_COMPRESS_BYTES)
         return 0;
@@ -217,7 +218,6 @@ REDIS_STATIC int __quicklistCompressNode(quicklistNode *node) {
     zfree(node->entry);
     node->entry = (unsigned char *)lzf;
     node->encoding = QUICKLIST_NODE_ENCODING_LZF;
-    node->recompress = 0;
     return 1;
 }
 

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -385,10 +385,8 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
 
 
     /* At this point, forward and reverse are one node beyond depth */
-    if (forward != quicklist->head)
-        quicklistCompressNode(forward);
-    if (reverse != quicklist->tail)
-        quicklistCompressNode(reverse);
+    quicklistCompressNode(forward);
+    quicklistCompressNode(reverse);
 }
 
 #define quicklistCompress(_ql, _node)                                          \
@@ -1642,6 +1640,10 @@ int quicklistPop(quicklist *quicklist, int where, unsigned char **data,
 /* Wrapper to allow argument-based switching between HEAD/TAIL pop */
 void quicklistPush(quicklist *quicklist, void *value, const size_t sz,
                    int where) {
+    if(quicklist->head)
+        assert(quicklist->head->encoding != QUICKLIST_NODE_ENCODING_LZF);
+    if(quicklist->tail)
+        assert(quicklist->tail->encoding != QUICKLIST_NODE_ENCODING_LZF);
     if (where == QUICKLIST_HEAD) {
         quicklistPushHead(quicklist, value, sz);
     } else if (where == QUICKLIST_TAIL) {

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -318,8 +318,8 @@ void quicklistRepr(unsigned char *ql, int full) {
  * If compress depth is larger than the entire list, we return immediately. */
 REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
                                       quicklistNode *node) {
-    # The head and tail should never be compressed (we should not attempt to recompress them)
-    # This needs to be an assertion in the future
+    /* The head and tail should never be compressed (we should not attempt to recompress them)
+     * This needs to be an assertion in the future */
     if (quicklist->head) quicklist->head->recompress = 0;
     if (quicklist->tail) quicklist->tail->recompress = 0;
 
@@ -1575,7 +1575,7 @@ int quicklistPopCustom(quicklist *quicklist, int where, unsigned char **data,
         return 0;
     }
 
-    # The head and tail should never be compressed
+    /* The head and tail should never be compressed */
     assert(node->encoding != QUICKLIST_NODE_ENCODING_LZF);
 
     if (unlikely(QL_NODE_IS_PLAIN(node))) {
@@ -1641,10 +1641,10 @@ int quicklistPop(quicklist *quicklist, int where, unsigned char **data,
 /* Wrapper to allow argument-based switching between HEAD/TAIL pop */
 void quicklistPush(quicklist *quicklist, void *value, const size_t sz,
                    int where) {
-    # The head and tail should never be compressed (we don't attempt to decompress them)
-    if(quicklist->head)
+    /* The head and tail should never be compressed (we don't attempt to decompress them) */
+    if (quicklist->head)
         assert(quicklist->head->encoding != QUICKLIST_NODE_ENCODING_LZF);
-    if(quicklist->tail)
+    if (quicklist->tail)
         assert(quicklist->tail->encoding != QUICKLIST_NODE_ENCODING_LZF);
 
     if (where == QUICKLIST_HEAD) {

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -404,9 +404,8 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
 /* If we previously used quicklistDecompressNodeForUse(), just recompress. */
 #define quicklistRecompressOnly(_ql, _node)                                    \
     do {                                                                       \
-        if ((_node)->recompress) {                                             \
+        if ((_node)->recompress)                                               \
             quicklistCompressNode((_node));                                    \
-        }                                                                      \
     } while (0)
 
 /* Insert 'new_node' after 'old_node' if 'after' is 1.
@@ -1580,6 +1579,8 @@ int quicklistPopCustom(quicklist *quicklist, int where, unsigned char **data,
         return 0;
     }
 
+    assert(node->encoding != QUICKLIST_NODE_ENCODING_LZF);
+
     if (unlikely(QL_NODE_IS_PLAIN(node))) {
         if (data)
             *data = saver(node->entry, node->sz);
@@ -1588,8 +1589,6 @@ int quicklistPopCustom(quicklist *quicklist, int where, unsigned char **data,
         quicklistDelIndex(quicklist, node, NULL);
         return 1;
     }
-
-    assert(node->encoding != QUICKLIST_NODE_ENCODING_LZF);
 
     p = ziplistIndex(node->entry, pos);
     if (ziplistGet(p, &vstr, &vlen, &vlong)) {

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -374,6 +374,7 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
     if (!in_depth)
         quicklistCompressNode(node);
 
+
     /* At this point, forward and reverse are one node beyond depth */
     quicklistCompressNode(forward);
     quicklistCompressNode(reverse);
@@ -381,17 +382,20 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
 
 #define quicklistCompress(_ql, _node)                                          \
     do {                                                                       \
-        if ((_node)->recompress)                                               \
+        if ((_node)->recompress) {                                             \
+            assert(_node != _ql->head && _node != _ql->tail);                  \
             quicklistCompressNode((_node));                                    \
-        else                                                                   \
+        } else                                                                 \
             __quicklistCompress((_ql), (_node));                               \
     } while (0)
 
 /* If we previously used quicklistDecompressNodeForUse(), just recompress. */
 #define quicklistRecompressOnly(_ql, _node)                                    \
     do {                                                                       \
-        if ((_node)->recompress)                                               \
+        if ((_node)->recompress) {                                             \
+            assert(_node != _ql->head && _node != _ql->tail);                  \
             quicklistCompressNode((_node));                                    \
+        }                                                                      \
     } while (0)
 
 /* Insert 'new_node' after 'old_node' if 'after' is 1.

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -323,8 +323,6 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
 
     if (forward) forward->recompress = 0;
     if (reverse) reverse->recompress = 0;
-    quicklistDecompressNode(forward);
-    quicklistDecompressNode(reverse);
 
     /* If length is less than our compress depth (from both sides),
      * we can't compress anything. */

--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -26,6 +26,39 @@ start_server {
         r ping ; # It's enough if the server is still alive
     } {PONG}
 
+    test {Stress tester for #3343-alike bugs with compression} {
+        r del key
+        config_set list-compress-depth 2
+        for {set j 0} {$j < 10000} {incr j} {
+            set op [randomInt 6]
+            set small_signed_count [expr 5-[randomInt 10]]
+            if {[randomInt 2] == 0} {
+                set ele [randomInt 1000]
+            } else {
+                set ele [string repeat x [randomInt 10000]][randomInt 1000]
+            }
+            switch $op {
+                0 {r lpush key $ele}
+                1 {r rpush key $ele}
+                2 {r lpop key}
+                3 {r rpop key}
+                4 {
+                    catch {r lset key $small_signed_count $ele}
+                }
+                5 {
+                    set otherele [randomInt 1000]
+                    if {[randomInt 2] == 0} {
+                        set where before
+                    } else {
+                        set where after
+                    }
+                    r linsert key $where $otherele $ele
+                }
+            }
+        }
+    }
+
+
     test {Stress tester for #3343-alike bugs} {
         r del key
         for {set j 0} {$j < 10000} {incr j} {

--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -26,38 +26,19 @@ start_server {
         r ping ; # It's enough if the server is still alive
     } {PONG}
 
-    test {Stress tester for #3343-alike bugs with compression} {
+   test { check compression with recompress } {
         r del key
-        config_set list-compress-depth 2
-        for {set j 0} {$j < 10000} {incr j} {
-            set op [randomInt 6]
-            set small_signed_count [expr 5-[randomInt 10]]
-            if {[randomInt 2] == 0} {
-                set ele [randomInt 1000]
-            } else {
-                set ele [string repeat x [randomInt 10000]][randomInt 1000]
-            }
-            switch $op {
-                0 {r lpush key $ele}
-                1 {r rpush key $ele}
-                2 {r lpop key}
-                3 {r rpop key}
-                4 {
-                    catch {r lset key $small_signed_count $ele}
-                }
-                5 {
-                    set otherele [randomInt 1000]
-                    if {[randomInt 2] == 0} {
-                        set where before
-                    } else {
-                        set where after
-                    }
-                    r linsert key $where $otherele $ele
-                }
-            }
-        }
-    }
-
+        config_set list-compress-depth 1
+        config_set list-max-ziplist-size 16
+        r rpush key a
+        r rpush key [string repeat b 50000]
+        r rpush key c
+        r lset key 1 d
+        r rpop key
+        r rpush key [string repeat e 5000]
+        r linsert key before f 1
+        r rpush key g
+   }
 
     test {Stress tester for #3343-alike bugs} {
         r del key

--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -40,42 +40,42 @@ start_server {
         r rpush key g
    }
 
-    set cycles 1000
-    if {$::accurate} { set cycles 10000 }
-    foreach comp {2 1 0} {
+   set cycles 1000
+   if {$::accurate} { set cycles 10000 }
+   foreach comp {2 1 0} {
         config_set list-compress-depth $comp
         test "Stress tester for #3343-alike bugs comp: $comp" {
             r del key
             for {set j 0} {$j < $cycles} {incr j} {
-            set op [randomInt 7]
-            set small_signed_count [expr 5-[randomInt 10]]
-            if {[randomInt 2] == 0} {
-                set ele [randomInt 1000]
-            } else {
-                set ele [string repeat x [randomInt 10000]][randomInt 1000]
-            }
-            switch $op {
-                0 {r lpush key $ele}
-                1 {r rpush key $ele}
-                2 {r lpop key}
-                3 {r rpop key}
-                4 {
-                    catch {r lset key $small_signed_count $ele}
+                set op [randomInt 7]
+                set small_signed_count [expr 5-[randomInt 10]]
+                if {[randomInt 2] == 0} {
+                    set ele [randomInt 1000]
+                } else {
+                    set ele [string repeat x [randomInt 10000]][randomInt 1000]
                 }
-                5 {
-                    set otherele [randomInt 1000]
-                    if {[randomInt 2] == 0} {
-                        set where before
-                    } else {
-                        set where after
+                switch $op {
+                    0 {r lpush key $ele}
+                    1 {r rpush key $ele}
+                    2 {r lpop key}
+                    3 {r rpop key}
+                    4 {
+                        catch {r lset key $small_signed_count $ele}
                     }
-                    r linsert key $where $otherele $ele
-                }
-                6 {
-                    set index [randomInt [r llen key]]
-                    set otherele [r lindex key $index]
-                    r lrem key 1 $otherele
-                }
+                    5 {
+                        set otherele [randomInt 1000]
+                        if {[randomInt 2] == 0} {
+                            set where before
+                        } else {
+                            set where after
+                        }
+                        r linsert key $where $otherele $ele
+                    }
+                    6 {
+                        set index [randomInt [r llen key]]
+                        set otherele [r lindex key $index]
+                        r lrem key 1 $otherele
+                    }
                 }
             }
         }

--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -26,7 +26,7 @@ start_server {
         r ping ; # It's enough if the server is still alive
     } {PONG}
 
-   test {Check compression with recompress} {
+    test {Check compression with recompress} {
         r del key
         config_set list-compress-depth 1
         config_set list-max-ziplist-size 16
@@ -42,44 +42,44 @@ start_server {
 
    set cycles 1000
    if {$::accurate} { set cycles 10000 }
-   foreach comp {2 1 0} {
-        config_set list-compress-depth $comp
-        test "Stress tester for #3343-alike bugs comp: $comp" {
-            r del key
-            for {set j 0} {$j < $cycles} {incr j} {
-                set op [randomInt 7]
-                set small_signed_count [expr 5-[randomInt 10]]
-                if {[randomInt 2] == 0} {
-                    set ele [randomInt 1000]
-                } else {
-                    set ele [string repeat x [randomInt 10000]][randomInt 1000]
+foreach comp {2 1 0} {
+   config_set list-compress-depth $comp
+   test "Stress tester for #3343-alike bugs comp: $comp" {
+        r del key
+        for {set j 0} {$j < $cycles} {incr j} {
+            set op [randomInt 7]
+            set small_signed_count [expr 5-[randomInt 10]]
+            if {[randomInt 2] == 0} {
+                set ele [randomInt 1000]
+            } else {
+                set ele [string repeat x [randomInt 10000]][randomInt 1000]
+            }
+            switch $op {
+                0 {r lpush key $ele}
+                1 {r rpush key $ele}
+                2 {r lpop key}
+                3 {r rpop key}
+                4 {
+                    catch {r lset key $small_signed_count $ele}
                 }
-                switch $op {
-                    0 {r lpush key $ele}
-                    1 {r rpush key $ele}
-                    2 {r lpop key}
-                    3 {r rpop key}
-                    4 {
-                        catch {r lset key $small_signed_count $ele}
+                5 {
+                    set otherele [randomInt 1000]
+                    if {[randomInt 2] == 0} {
+                        set where before
+                    } else {
+                        set where after
                     }
-                    5 {
-                        set otherele [randomInt 1000]
-                        if {[randomInt 2] == 0} {
-                            set where before
-                        } else {
-                            set where after
-                        }
-                        r linsert key $where $otherele $ele
-                    }
-                    6 {
-                        set index [randomInt [r llen key]]
-                        set otherele [r lindex key $index]
-                        r lrem key 1 $otherele
-                    }
+                    r linsert key $where $otherele $ele
+                }
+                6 {
+                    set index [randomInt [r llen key]]
+                    set otherele [r lindex key $index]
+                    r lrem key 1 $otherele
                 }
             }
         }
     }
+}
 
     tags {slow} {
         test {ziplist implementation: value encoding and backlink} {

--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -72,7 +72,7 @@ start_server {
                         r linsert key $where $otherele $ele
                     }
                     6 {
-                        set index [randomInt  [r llen key]]
+                        set index [randomInt [r llen key]]
                         set otherele [r lindex key $index]
                         r lrem key 1 $otherele
                     }

--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -40,11 +40,12 @@ start_server {
         r rpush key g
    }
 
-   set cycles 1000
-   if {$::accurate} { set cycles 10000 }
 foreach comp {2 1 0} {
-   config_set list-compress-depth $comp
-   test "Stress tester for #3343-alike bugs comp: $comp" {
+    set cycles 1000
+    if {$::accurate} { set cycles 10000 }
+    config_set list-compress-depth $comp
+    
+    test "Stress tester for #3343-alike bugs comp: $comp" {
         r del key
         for {set j 0} {$j < $cycles} {incr j} {
             set op [randomInt 7]
@@ -79,7 +80,7 @@ foreach comp {2 1 0} {
             }
         }
     }
-}
+} ;# foreach comp
 
     tags {slow} {
         test {ziplist implementation: value encoding and backlink} {

--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -26,7 +26,7 @@ start_server {
         r ping ; # It's enough if the server is still alive
     } {PONG}
 
-   test { check compression with recompress } {
+   test {Check compression with recompress} {
         r del key
         config_set list-compress-depth 1
         config_set list-max-ziplist-size 16
@@ -44,7 +44,7 @@ start_server {
     if {$::accurate} { set cycles 10000 }
     foreach comp {2 1 0} {
         config_set list-compress-depth $comp
-        test {Stress tester for #3343-alike bugs comp: $comp} {
+        test "Stress tester for #3343-alike bugs comp: $comp" {
             r del key
                 for {set j 0} {$j < $cycles} {incr j} {
                 set op [randomInt 7]
@@ -71,7 +71,11 @@ start_server {
                         }
                         r linsert key $where $otherele $ele
                     }
-                    6 {r lrem key 1 $ele}
+                    6 {
+                        set index [randomInt  [r llen key]]
+                        set otherele [r lindex key $index]
+                        r lrem key 1 $otherele
+                    }
                 }
             }
         }

--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -46,36 +46,36 @@ start_server {
         config_set list-compress-depth $comp
         test "Stress tester for #3343-alike bugs comp: $comp" {
             r del key
-                for {set j 0} {$j < $cycles} {incr j} {
-                set op [randomInt 7]
-                set small_signed_count [expr 5-[randomInt 10]]
-                if {[randomInt 2] == 0} {
-                    set ele [randomInt 1000]
-                } else {
-                    set ele [string repeat x [randomInt 10000]][randomInt 1000]
+            for {set j 0} {$j < $cycles} {incr j} {
+            set op [randomInt 7]
+            set small_signed_count [expr 5-[randomInt 10]]
+            if {[randomInt 2] == 0} {
+                set ele [randomInt 1000]
+            } else {
+                set ele [string repeat x [randomInt 10000]][randomInt 1000]
+            }
+            switch $op {
+                0 {r lpush key $ele}
+                1 {r rpush key $ele}
+                2 {r lpop key}
+                3 {r rpop key}
+                4 {
+                    catch {r lset key $small_signed_count $ele}
                 }
-                switch $op {
-                    0 {r lpush key $ele}
-                    1 {r rpush key $ele}
-                    2 {r lpop key}
-                    3 {r rpop key}
-                    4 {
-                        catch {r lset key $small_signed_count $ele}
+                5 {
+                    set otherele [randomInt 1000]
+                    if {[randomInt 2] == 0} {
+                        set where before
+                    } else {
+                        set where after
                     }
-                    5 {
-                        set otherele [randomInt 1000]
-                        if {[randomInt 2] == 0} {
-                            set where before
-                        } else {
-                            set where after
-                        }
-                        r linsert key $where $otherele $ele
-                    }
-                    6 {
-                        set index [randomInt [r llen key]]
-                        set otherele [r lindex key $index]
-                        r lrem key 1 $otherele
-                    }
+                    r linsert key $where $otherele $ele
+                }
+                6 {
+                    set index [randomInt [r llen key]]
+                    set otherele [r lindex key $index]
+                    r lrem key 1 $otherele
+                }
                 }
             }
         }

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -123,7 +123,8 @@ start_server [list overrides [list save ""] ] {
         assert_equal [string repeat d 500] [r lindex list6 0]
     } {} {needs:debug}
 
-   r config set list-compress-depth 0
+# revert config for external mode tests.
+    r config set list-compress-depth 0
 }
 
 # check functionality of plain nodes using low packed-threshold

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -122,6 +122,8 @@ start_server [list overrides [list save ""] ] {
         r LSET list6 0 [string repeat d 500]
         assert_equal [string repeat d 500] [r lindex list6 0]
     } {} {needs:debug}
+
+   r config set list-compress-depth 0
 }
 
 # check functionality of plain nodes using low packed-threshold

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -123,7 +123,7 @@ start_server [list overrides [list save ""] ] {
         assert_equal [string repeat d 500] [r lindex list6 0]
     } {} {needs:debug}
 
-# revert config for external mode tests.
+    # revert config for external mode tests.
     r config set list-compress-depth 0
 }
 


### PR DESCRIPTION
Recently we started using list-compress-depth in tests (was completely untested till now).
Turns this triggered test failures with the external mode, since the tests left the setting enabled and then it was used in other tests (specifically the fuzzer named "Stress tester for #3343-alike bugs").

This PR fixes the issue of the `recompress` flag being left set by mistake, which caused the code to later to compress the head or tail nodes (which should never be compressed)

The solution is to reset the recompress flag when it should have been (when it was decided not to compress).

Additionally we're adding some assertions and improve the tests so in order to catch other similar bugs.