### PR TITLE
Add --large-memory flag for REDIS_TEST to enable tests that consume more than 100mb

### DIFF
--- a/src/crc64.c
+++ b/src/crc64.c
@@ -127,10 +127,10 @@ uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l) {
 #include <stdio.h>
 
 #define UNUSED(x) (void)(x)
-int crc64Test(int argc, char *argv[], int accurate) {
+int crc64Test(int argc, char *argv[], int flags) {
     UNUSED(argc);
     UNUSED(argv);
-    UNUSED(accurate);
+    UNUSED(flags);
     crc64_init();
     printf("[calcula]: e9c6d914c4b8d9ca == %016" PRIx64 "\n",
            (uint64_t)_crc64(0, "123456789", 9));

--- a/src/crc64.h
+++ b/src/crc64.h
@@ -7,7 +7,7 @@ void crc64_init(void);
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
 
 #ifdef REDIS_TEST
-int crc64Test(int argc, char *argv[], int accurate);
+int crc64Test(int argc, char *argv[], int flags);
 #endif
 
 #endif

--- a/src/dict.c
+++ b/src/dict.c
@@ -1183,6 +1183,7 @@ void dictGetStats(char *buf, size_t bufsize, dict *d) {
 /* ------------------------------- Benchmark ---------------------------------*/
 
 #ifdef REDIS_TEST
+#include "testhelp.h"
 
 #define UNUSED(V) ((void) V)
 
@@ -1235,11 +1236,12 @@ dictType BenchmarkDictType = {
 } while(0)
 
 /* ./redis-server test dict [<count> | --accurate] */
-int dictTest(int argc, char **argv, int accurate) {
+int dictTest(int argc, char **argv, int flags) {
     long j;
     long long start, elapsed;
     dict *dict = dictCreate(&BenchmarkDictType);
     long count = 0;
+    int accurate = (flags & REDIS_TEST_ACCURATE);
 
     if (argc == 4) {
         if (accurate) {

--- a/src/dict.h
+++ b/src/dict.h
@@ -206,7 +206,7 @@ uint64_t dictGetHash(dict *d, const void *key);
 dictEntry **dictFindEntryRefByPtrAndHash(dict *d, const void *oldptr, uint64_t hash);
 
 #ifdef REDIS_TEST
-int dictTest(int argc, char *argv[], int accurate);
+int dictTest(int argc, char *argv[], int flags);
 #endif
 
 #endif /* __DICT_H */

--- a/src/endianconv.c
+++ b/src/endianconv.c
@@ -105,12 +105,12 @@ uint64_t intrev64(uint64_t v) {
 #include <stdio.h>
 
 #define UNUSED(x) (void)(x)
-int endianconvTest(int argc, char *argv[], int accurate) {
+int endianconvTest(int argc, char *argv[], int flags) {
     char buf[32];
 
     UNUSED(argc);
     UNUSED(argv);
-    UNUSED(accurate);
+    UNUSED(flags);
 
     sprintf(buf,"ciaoroma");
     memrev16(buf);

--- a/src/endianconv.h
+++ b/src/endianconv.h
@@ -72,7 +72,7 @@ uint64_t intrev64(uint64_t v);
 #endif
 
 #ifdef REDIS_TEST
-int endianconvTest(int argc, char *argv[], int accurate);
+int endianconvTest(int argc, char *argv[], int flags);
 #endif
 
 #endif

--- a/src/intset.c
+++ b/src/intset.c
@@ -393,7 +393,7 @@ static void checkConsistency(intset *is) {
 }
 
 #define UNUSED(x) (void)(x)
-int intsetTest(int argc, char **argv, int accurate) {
+int intsetTest(int argc, char **argv, int flags) {
     uint8_t success;
     int i;
     intset *is;
@@ -401,7 +401,7 @@ int intsetTest(int argc, char **argv, int accurate) {
 
     UNUSED(argc);
     UNUSED(argv);
-    UNUSED(accurate);
+    UNUSED(flags);
 
     printf("Value encodings: "); {
         assert(_intsetValueEncoding(-32768) == INTSET_ENC_INT16);

--- a/src/intset.h
+++ b/src/intset.h
@@ -49,7 +49,7 @@ size_t intsetBlobLen(intset *is);
 int intsetValidateIntegrity(const unsigned char *is, size_t size, int deep);
 
 #ifdef REDIS_TEST
-int intsetTest(int argc, char *argv[], int accurate);
+int intsetTest(int argc, char *argv[], int flags);
 #endif
 
 #endif // __INTSET_H

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1375,6 +1375,7 @@ unsigned int lpRandomPairsUnique(unsigned char *lp, unsigned int count, listpack
 #include <sys/time.h>
 #include "adlist.h"
 #include "sds.h"
+#include "testhelp.h"
 
 #define UNUSED(x) (void)(x)
 #define TEST(name) printf("test — %s\n", name);
@@ -1499,15 +1500,15 @@ static int lpValidation(unsigned char *p, unsigned int head_count, void *userdat
     return ret;
 }
 
-int listpackTest(int argc, char *argv[], int accurate) {
+int listpackTest(int argc, char *argv[], int flags) {
     UNUSED(argc);
     UNUSED(argv);
-    UNUSED(accurate);
 
     int i;
     unsigned char *lp, *p, *vstr;
     int64_t vlen;
     unsigned char intbuf[LP_INTBUF_SIZE];
+    int accurate = (flags & REDIS_TEST_ACCURATE);
 
     TEST("Create int list") {
         lp = createIntList();

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -90,7 +90,7 @@ unsigned int lpRandomPairsUnique(unsigned char *lp, unsigned int count, listpack
 int lpSafeToAdd(unsigned char* lp, size_t add);
 
 #ifdef REDIS_TEST
-int listpackTest(int argc, char *argv[], int accurate);
+int listpackTest(int argc, char *argv[], int flags);
 #endif
 
 #endif

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -1720,6 +1720,7 @@ void quicklistBookmarksClear(quicklist *ql) {
 #ifdef REDIS_TEST
 #include <stdint.h>
 #include <sys/time.h>
+#include "testhelp.h"
 
 #define yell(str, ...) printf("ERROR! " str "\n\n", __VA_ARGS__)
 
@@ -1902,11 +1903,11 @@ static char *genstr(char *prefix, int i) {
 }
 
 /* main test, but callable from other files */
-int quicklistTest(int argc, char *argv[], int accurate) {
+int quicklistTest(int argc, char *argv[], int flags) {
     UNUSED(argc);
     UNUSED(argv);
-    UNUSED(accurate);
 
+    int accurate = (flags & REDIS_TEST_ACCURATE);
     unsigned int err = 0;
     int optimize_start =
         -(int)(sizeof(optimization_level) / sizeof(*optimization_level));

--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -205,7 +205,7 @@ void quicklistBookmarksClear(quicklist *ql);
 int quicklistisSetPackedThreshold(size_t sz);
 
 #ifdef REDIS_TEST
-int quicklistTest(int argc, char *argv[], int accurate);
+int quicklistTest(int argc, char *argv[], int flags);
 #endif
 
 /* Directions for iterators */

--- a/src/sds.c
+++ b/src/sds.c
@@ -1314,10 +1314,10 @@ static sds sdsTestTemplateCallback(sds varname, void *arg) {
     else return NULL;
 }
 
-int sdsTest(int argc, char **argv, int accurate) {
+int sdsTest(int argc, char **argv, int flags) {
     UNUSED(argc);
     UNUSED(argv);
-    UNUSED(accurate);
+    UNUSED(flags);
 
     {
         sds x = sdsnew("foo"), y;
@@ -1559,7 +1559,6 @@ int sdsTest(int argc, char **argv, int accurate) {
         test_cond("sdsrezie() crop alloc", sdsalloc(x) == 4);
         sdsfree(x);
     }
-    test_report();
     return 0;
 }
 #endif

--- a/src/sds.h
+++ b/src/sds.h
@@ -280,7 +280,7 @@ void *sds_realloc(void *ptr, size_t size);
 void sds_free(void *ptr);
 
 #ifdef REDIS_TEST
-int sdsTest(int argc, char *argv[], int accurate);
+int sdsTest(int argc, char *argv[], int flags);
 #endif
 
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -7807,7 +7807,15 @@ int iAmMaster(void) {
 }
 
 #ifdef REDIS_TEST
-typedef int redisTestProc(int argc, char **argv, int accurate);
+#include "testhelp.h"
+
+int __failed_tests = 0;
+int __test_num = 0;
+
+/* The flags are the following:
+* --accurate:     Runs tests with more iterations.
+* --large-memory: Enables tests that consume more than 100mb. */
+typedef int redisTestProc(int argc, char **argv, int flags);
 struct redisTest {
     char *name;
     redisTestProc *proc;
@@ -7844,17 +7852,17 @@ int main(int argc, char **argv) {
 
 #ifdef REDIS_TEST
     if (argc >= 3 && !strcasecmp(argv[1], "test")) {
-        int accurate = 0;
+        int flags = 0;
         for (j = 3; j < argc; j++) {
-            if (!strcasecmp(argv[j], "--accurate")) {
-                accurate = 1;
-            }
+            char *arg = argv[j];
+            if (!strcasecmp(arg, "--accurate")) flags |= REDIS_TEST_ACCURATE;
+            else if (!strcasecmp(arg, "--large-memory")) flags |= REDIS_TEST_LARGE_MEMORY;
         }
 
         if (!strcasecmp(argv[2], "all")) {
             int numtests = sizeof(redisTests)/sizeof(struct redisTest);
             for (j = 0; j < numtests; j++) {
-                redisTests[j].failed = (redisTests[j].proc(argc,argv,accurate) != 0);
+                redisTests[j].failed = (redisTests[j].proc(argc,argv,flags) != 0);
             }
 
             /* Report tests result */
@@ -7875,7 +7883,7 @@ int main(int argc, char **argv) {
         } else {
             redisTestProc *proc = getTestProcByName(argv[2]);
             if (!proc) return -1; /* test not found */
-            return proc(argc,argv,accurate);
+            return proc(argc,argv,flags);
         }
 
         return 0;

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -201,7 +201,7 @@ void SHA1Final(unsigned char digest[20], SHA1_CTX* context)
 #define BUFSIZE 4096
 
 #define UNUSED(x) (void)(x)
-int sha1Test(int argc, char **argv, int accurate)
+int sha1Test(int argc, char **argv, int flags)
 {
     SHA1_CTX ctx;
     unsigned char hash[20], buf[BUFSIZE];
@@ -209,7 +209,7 @@ int sha1Test(int argc, char **argv, int accurate)
 
     UNUSED(argc);
     UNUSED(argv);
-    UNUSED(accurate);
+    UNUSED(flags);
 
     for(i=0;i<BUFSIZE;i++)
         buf[i] = i;

--- a/src/sha1.h
+++ b/src/sha1.h
@@ -19,6 +19,6 @@ void SHA1Update(SHA1_CTX* context, const unsigned char* data, uint32_t len);
 void SHA1Final(unsigned char digest[20], SHA1_CTX* context);
 
 #ifdef REDIS_TEST
-int sha1Test(int argc, char **argv, int accurate);
+int sha1Test(int argc, char **argv, int flags);
 #endif
 #endif

--- a/src/testhelp.h
+++ b/src/testhelp.h
@@ -39,8 +39,12 @@
 #ifndef __TESTHELP_H
 #define __TESTHELP_H
 
-int __failed_tests = 0;
-int __test_num = 0;
+#define REDIS_TEST_ACCURATE     (1<<0)
+#define REDIS_TEST_LARGE_MEMORY (1<<1)
+
+extern int __failed_tests;
+extern int __test_num;
+
 #define test_cond(descr,_c) do { \
     __test_num++; printf("%d - %s: ", __test_num, descr); \
     if(_c) printf("PASSED\n"); else {printf("FAILED\n"); __failed_tests++;} \

--- a/src/util.c
+++ b/src/util.c
@@ -959,10 +959,10 @@ static void test_ll2string(void) {
 }
 
 #define UNUSED(x) (void)(x)
-int utilTest(int argc, char **argv, int accurate) {
+int utilTest(int argc, char **argv, int flags) {
     UNUSED(argc);
     UNUSED(argv);
-    UNUSED(accurate);
+    UNUSED(flags);
 
     test_string2ll();
     test_string2l();

--- a/src/util.h
+++ b/src/util.h
@@ -67,7 +67,7 @@ long getTimeZone(void);
 int pathIsBaseName(char *path);
 
 #ifdef REDIS_TEST
-int utilTest(int argc, char **argv, int accurate);
+int utilTest(int argc, char **argv, int flags);
 #endif
 
 #endif

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1688,6 +1688,7 @@ unsigned int ziplistRandomPairsUnique(unsigned char *zl, unsigned int count, zip
 #include <sys/time.h>
 #include "adlist.h"
 #include "sds.h"
+#include "testhelp.h"
 
 #define debug(f, ...) { if (DEBUG) printf(f, __VA_ARGS__); }
 
@@ -1842,8 +1843,9 @@ static size_t strEntryBytesLarge(size_t slen) {
     return slen + zipStorePrevEntryLength(NULL, ZIP_BIG_PREVLEN) + zipStoreEntryEncoding(NULL, 0, slen);
 }
 
-/* ./redis-server test ziplist <randomseed> --accurate */
-int ziplistTest(int argc, char **argv, int accurate) {
+/* ./redis-server test ziplist <randomseed> */
+int ziplistTest(int argc, char **argv, int flags) {
+    int accurate = (flags & REDIS_TEST_ACCURATE);
     unsigned char *zl, *p;
     unsigned char *entry;
     unsigned int elen;

--- a/src/ziplist.h
+++ b/src/ziplist.h
@@ -68,7 +68,7 @@ unsigned int ziplistRandomPairsUnique(unsigned char *zl, unsigned int count, zip
 int ziplistSafeToAdd(unsigned char* zl, size_t add);
 
 #ifdef REDIS_TEST
-int ziplistTest(int argc, char *argv[], int accurate);
+int ziplistTest(int argc, char *argv[], int flags);
 #endif
 
 #endif /* _ZIPLIST_H */

--- a/src/zipmap.c
+++ b/src/zipmap.c
@@ -476,12 +476,12 @@ static void zipmapRepr(unsigned char *p) {
 }
 
 #define UNUSED(x) (void)(x)
-int zipmapTest(int argc, char *argv[], int accurate) {
+int zipmapTest(int argc, char *argv[], int flags) {
     unsigned char *zm;
 
     UNUSED(argc);
     UNUSED(argv);
-    UNUSED(accurate);
+    UNUSED(flags);
 
     zm = zipmapNew();
 

--- a/src/zipmap.h
+++ b/src/zipmap.h
@@ -48,7 +48,7 @@ void zipmapRepr(unsigned char *p);
 int zipmapValidateIntegrity(unsigned char *zm, size_t size, int deep);
 
 #ifdef REDIS_TEST
-int zipmapTest(int argc, char *argv[], int accurate);
+int zipmapTest(int argc, char *argv[], int flags);
 #endif
 
 #endif

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -712,12 +712,12 @@ size_t zmalloc_get_memory_size(void) {
 
 #ifdef REDIS_TEST
 #define UNUSED(x) ((void)(x))
-int zmalloc_test(int argc, char **argv, int accurate) {
+int zmalloc_test(int argc, char **argv, int flags) {
     void *ptr;
 
     UNUSED(argc);
     UNUSED(argv);
-    UNUSED(accurate);
+    UNUSED(flags);
     printf("Malloc prefix size: %d\n", (int) PREFIX_SIZE);
     printf("Initial used memory: %zu\n", zmalloc_used_memory());
     ptr = zmalloc(123);

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -136,7 +136,7 @@ size_t zmalloc_usable_size(void *ptr);
 #endif
 
 #ifdef REDIS_TEST
-int zmalloc_test(int argc, char **argv, int accurate);
+int zmalloc_test(int argc, char **argv, int flags);
 #endif
 
 #endif /* __ZMALLOC_H */


### PR DESCRIPTION
This pr is for #9776.
Added the `--large-memory` flag to `REDIS_TEST`, and integrated the old `--accurate` flag into `testhelp.h`.