### PR TITLE
optimze the judgment logic of use_pattern in scanGenericCommand()

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -832,7 +832,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long cursor) {
 
             /* The pattern always matches if it is exactly "*", so it is
              * equivalent to disabling it. */
-            use_pattern = !(pat[0] == '*' && patlen == 1);
+            use_pattern = !(patlen == 1 && pat[0] == '*');
 
             i += 2;
         } else if (!strcasecmp(c->argv[i]->ptr, "type") && o == NULL && j >= 2) {


### PR DESCRIPTION
in `scan 0 match ""` case,  pat is empty sds(patlen is 0), I don't think should access the first character directly in this case(even though the first character is ' \0 '), for the  code readability, I switch the two positions of judgment logic. 