### PR TITLE
send failover packets in order to resolve voting conflicts

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -158,6 +158,8 @@ typedef struct clusterState {
     int failover_auth_count;    /* Number of votes received so far. */
     int failover_auth_sent;     /* True if we already asked for votes. */
     int failover_auth_rank;     /* This slave rank for current auth request. */
+    int failed_master_rank;     /* This slave rank for auth request in failed master list. */
+    long long rank_failover_timeout; /* maximum time to vote by ordered failover*/
     uint64_t failover_auth_epoch; /* Epoch of the current election. */
     int cant_failover_reason;   /* Why a slave is currently not able to
                                    failover. See the CANT_FAILOVER_* macros. */


### PR DESCRIPTION
On Tencent Cloud, when multiple master nodes fail simultaneously,
the cluster cannot recover within the default effective time (160 seconds)
on the nodes. We tested 128 shards, 63 nodes failed simultaneously.
Among 900 tests, the cluster recovered for only three times.
The main reason is that the vote is without ranking among multiple slave
nodes, which case too many conflicts. Therefore, Tencent Cloud introduced
into ranking based on the master node name. If the ranking is stucked, a
round of maximum voting time will be 500*(failed nodes). After this optimization,
900 tests were all successful.