### PR TITLE
Add --dump-logs to ci tests and daily tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     - name: test
       run: |
         sudo apt-get install tcl8.6 tclx
-        ./runtest --verbose --tags -slow
+        ./runtest --verbose --tags -slow --dump-logs
     - name: module api test
-      run: ./runtest-moduleapi --verbose
+      run: ./runtest-moduleapi --verbose --dump-logs
 
   test-sanitizer-address:
     runs-on: ubuntu-latest
@@ -28,9 +28,9 @@ jobs:
       - name: testprep
         run: sudo apt-get install tcl8.6 tclx -y
       - name: test
-        run: ./runtest --verbose --tags -slow
+        run: ./runtest --verbose --tags -slow --dump-logs
       - name: module api test
-        run: ./runtest-moduleapi --verbose
+        run: ./runtest-moduleapi --verbose --dump-logs
 
   build-debian-old:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -338,7 +338,7 @@ jobs:
         run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
-        run: ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}}
+        run: ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
       - name: sentinel tests
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
         run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
@@ -380,7 +380,7 @@ jobs:
         run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
-        run: ./runtest-moduleapi --verbose ${{github.event.inputs.test_args}}
+        run: ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
       - name: sentinel tests
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
         run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}


### PR DESCRIPTION
So that we can print server log on test failure.