### PR TITLE
Fix module doc - missing function due to blank line

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -8435,7 +8435,6 @@ int moduleUnregisterFilters(RedisModule *module) {
  * If multiple filters are registered (by the same or different modules), they
  * are executed in the order of registration.
  */
-
 RedisModuleCommandFilter *RM_RegisterCommandFilter(RedisModuleCtx *ctx, RedisModuleCommandFilterFunc callback, int flags) {
     RedisModuleCommandFilter *filter = zmalloc(sizeof(*filter));
     filter->module = ctx->module;


### PR DESCRIPTION
The extra line in module.c before RM_RegisterCommandFilter caused the https://github.com/redis/redis/blob/unstable/src/modules/gendoc.rb file to skip the documentation for the function. We can see that in https://redis.io/topics/modules-api-ref#section-module-command-filter-api there is no mention of RedisModule_RegisterCommandFilter. Removing the line allows gendoc to add the documentation of RedisModule_RegisterCommandFilter. The sample output from gendoc is shown below

![image](https://user-images.githubusercontent.com/51993843/142477451-2cb0dcb9-1171-42e9-97e7-eac6118c1c9c.png)
