### PR TITLE
Avoid server crash on redisProtocolToLuaType failing lua_checkstack

### DIFF
--- a/src/call_reply.c
+++ b/src/call_reply.c
@@ -71,73 +71,84 @@ static void callReplySetSharedData(CallReply *rep, int type, const char *proto, 
     rep->flags |= extra_flags;
 }
 
-static void callReplyNull(void *ctx, const char *proto, size_t proto_len) {
+static int callReplyNull(void *ctx, const char *proto, size_t proto_len) {
     CallReply *rep = ctx;
     callReplySetSharedData(rep, REDISMODULE_REPLY_NULL, proto, proto_len, REPLY_FLAG_RESP3);
+    return C_OK;
 }
 
-static void callReplyNullBulkString(void *ctx, const char *proto, size_t proto_len) {
+static int callReplyNullBulkString(void *ctx, const char *proto, size_t proto_len) {
     CallReply *rep = ctx;
     callReplySetSharedData(rep, REDISMODULE_REPLY_NULL, proto, proto_len, 0);
+    return C_OK;
 }
 
-static void callReplyNullArray(void *ctx, const char *proto, size_t proto_len) {
+static int callReplyNullArray(void *ctx, const char *proto, size_t proto_len) {
     CallReply *rep = ctx;
     callReplySetSharedData(rep, REDISMODULE_REPLY_NULL, proto, proto_len, 0);
+    return C_OK;
 }
 
-static void callReplyBulkString(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len) {
+static int callReplyBulkString(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len) {
     CallReply *rep = ctx;
     callReplySetSharedData(rep, REDISMODULE_REPLY_STRING, proto, proto_len, 0);
     rep->len = len;
     rep->val.str = str;
+    return C_OK;
 }
 
-static void callReplyError(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len) {
+static int callReplyError(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len) {
     CallReply *rep = ctx;
     callReplySetSharedData(rep, REDISMODULE_REPLY_ERROR, proto, proto_len, 0);
     rep->len = len;
     rep->val.str = str;
+    return C_OK;
 }
 
-static void callReplySimpleStr(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len) {
+static int callReplySimpleStr(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len) {
     CallReply *rep = ctx;
     callReplySetSharedData(rep, REDISMODULE_REPLY_STRING, proto, proto_len, 0);
     rep->len = len;
     rep->val.str = str;
+    return C_OK;
 }
 
-static void callReplyLong(void *ctx, long long val, const char *proto, size_t proto_len) {
+static int callReplyLong(void *ctx, long long val, const char *proto, size_t proto_len) {
     CallReply *rep = ctx;
     callReplySetSharedData(rep, REDISMODULE_REPLY_INTEGER, proto, proto_len, 0);
     rep->val.ll = val;
+    return C_OK;
 }
 
-static void callReplyDouble(void *ctx, double val, const char *proto, size_t proto_len) {
+static int callReplyDouble(void *ctx, double val, const char *proto, size_t proto_len) {
     CallReply *rep = ctx;
     callReplySetSharedData(rep, REDISMODULE_REPLY_DOUBLE, proto, proto_len, REPLY_FLAG_RESP3);
     rep->val.d = val;
+    return C_OK;
 }
 
-static void callReplyVerbatimString(void *ctx, const char *format, const char *str, size_t len, const char *proto, size_t proto_len) {
+static int callReplyVerbatimString(void *ctx, const char *format, const char *str, size_t len, const char *proto, size_t proto_len) {
     CallReply *rep = ctx;
     callReplySetSharedData(rep, REDISMODULE_REPLY_VERBATIM_STRING, proto, proto_len, REPLY_FLAG_RESP3);
     rep->len = len;
     rep->val.verbatim_str.str = str;
     rep->val.verbatim_str.format = format;
+    return C_OK;
 }
 
-static void callReplyBigNumber(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len) {
+static int callReplyBigNumber(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len) {
     CallReply *rep = ctx;
     callReplySetSharedData(rep, REDISMODULE_REPLY_BIG_NUMBER, proto, proto_len, REPLY_FLAG_RESP3);
     rep->len = len;
     rep->val.str = str;
+    return C_OK;
 }
 
-static void callReplyBool(void *ctx, int val, const char *proto, size_t proto_len) {
+static int callReplyBool(void *ctx, int val, const char *proto, size_t proto_len) {
     CallReply *rep = ctx;
     callReplySetSharedData(rep, REDISMODULE_REPLY_BOOL, proto, proto_len, REPLY_FLAG_RESP3);
     rep->val.ll = val;
+    return C_OK;
 }
 
 static void callReplyParseCollection(ReplyParser *parser, CallReply *rep, size_t len, const char *proto, size_t elements_per_entry) {
@@ -158,7 +169,7 @@ static void callReplyParseCollection(ReplyParser *parser, CallReply *rep, size_t
     rep->proto_len = parser->curr_location - proto;
 }
 
-static void callReplyAttribute(ReplyParser *parser, void *ctx, size_t len, const char *proto) {
+static int callReplyAttribute(ReplyParser *parser, void *ctx, size_t len, const char *proto) {
     CallReply *rep = ctx;
     rep->attribute = zcalloc(sizeof(CallReply));
 
@@ -176,31 +187,36 @@ static void callReplyAttribute(ReplyParser *parser, void *ctx, size_t len, const
     rep->proto = proto;
     rep->proto_len = parser->curr_location - proto;
     rep->flags |= REPLY_FLAG_RESP3;
+    return C_OK;
 }
 
-static void callReplyArray(ReplyParser *parser, void *ctx, size_t len, const char *proto) {
+static int callReplyArray(ReplyParser *parser, void *ctx, size_t len, const char *proto) {
     CallReply *rep = ctx;
     rep->type = REDISMODULE_REPLY_ARRAY;
     callReplyParseCollection(parser, rep, len, proto, 1);
+    return C_OK;
 }
 
-static void callReplySet(ReplyParser *parser, void *ctx, size_t len, const char *proto) {
+static int callReplySet(ReplyParser *parser, void *ctx, size_t len, const char *proto) {
     CallReply *rep = ctx;
     rep->type = REDISMODULE_REPLY_SET;
     callReplyParseCollection(parser, rep, len, proto, 1);
     rep->flags |= REPLY_FLAG_RESP3;
+    return C_OK;
 }
 
-static void callReplyMap(ReplyParser *parser, void *ctx, size_t len, const char *proto) {
+static int callReplyMap(ReplyParser *parser, void *ctx, size_t len, const char *proto) {
     CallReply *rep = ctx;
     rep->type = REDISMODULE_REPLY_MAP;
     callReplyParseCollection(parser, rep, len, proto, 2);
     rep->flags |= REPLY_FLAG_RESP3;
+    return C_OK;
 }
 
-static void callReplyParseError(void *ctx) {
+static int callReplyParseError(void *ctx) {
     CallReply *rep = ctx;
     rep->type = REDISMODULE_REPLY_UNKNOWN;
+    return C_OK;
 }
 
 /* Recursively free the current call reply and its sub-replies. */

--- a/src/resp_parser.c
+++ b/src/resp_parser.c
@@ -66,31 +66,27 @@ static int parseBulk(ReplyParser *parser, void *p_ctx) {
 
     string2ll(proto+1,p-proto-1,&bulklen);
     if (bulklen == -1) {
-        parser->callbacks.null_bulk_string_callback(p_ctx, proto, parser->curr_location - proto);
+        return parser->callbacks.null_bulk_string_callback(p_ctx, proto, parser->curr_location - proto);
     } else {
         const char *str = parser->curr_location;
         parser->curr_location += bulklen;
         parser->curr_location += 2; /* for \r\n */
-        parser->callbacks.bulk_string_callback(p_ctx, str, bulklen, proto, parser->curr_location - proto);
+        return parser->callbacks.bulk_string_callback(p_ctx, str, bulklen, proto, parser->curr_location - proto);
     }
-
-    return C_OK;
 }
 
 static int parseSimpleString(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
     char *p = strchr(proto+1,'\r');
     parser->curr_location = p + 2; /* for \r\n */
-    parser->callbacks.simple_str_callback(p_ctx, proto+1, p-proto-1, proto, parser->curr_location - proto);
-    return C_OK;
+    return parser->callbacks.simple_str_callback(p_ctx, proto+1, p-proto-1, proto, parser->curr_location - proto);
 }
 
 static int parseError(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
     char *p = strchr(proto+1,'\r');
     parser->curr_location = p + 2; // for \r\n
-    parser->callbacks.error_callback(p_ctx, proto+1, p-proto-1, proto, parser->curr_location - proto);
-    return C_OK;
+    return parser->callbacks.error_callback(p_ctx, proto+1, p-proto-1, proto, parser->curr_location - proto);
 }
 
 static int parseLong(ReplyParser *parser, void *p_ctx) {
@@ -99,8 +95,7 @@ static int parseLong(ReplyParser *parser, void *p_ctx) {
     parser->curr_location = p + 2; /* for \r\n */
     long long val;
     string2ll(proto+1,p-proto-1,&val);
-    parser->callbacks.long_callback(p_ctx, val, proto, parser->curr_location - proto);
-    return C_OK;
+    return parser->callbacks.long_callback(p_ctx, val, proto, parser->curr_location - proto);
 }
 
 static int parseAttributes(ReplyParser *parser, void *p_ctx) {
@@ -110,8 +105,7 @@ static int parseAttributes(ReplyParser *parser, void *p_ctx) {
     string2ll(proto+1,p-proto-1,&len);
     p += 2;
     parser->curr_location = p;
-    parser->callbacks.attribute_callback(parser, p_ctx, len, proto);
-    return C_OK;
+    return parser->callbacks.attribute_callback(parser, p_ctx, len, proto);
 }
 
 static int parseVerbatimString(ReplyParser *parser, void *p_ctx) {
@@ -123,24 +117,21 @@ static int parseVerbatimString(ReplyParser *parser, void *p_ctx) {
     const char *format = parser->curr_location;
     parser->curr_location += bulklen;
     parser->curr_location += 2; /* for \r\n */
-    parser->callbacks.verbatim_string_callback(p_ctx, format, format + 4, bulklen - 4, proto, parser->curr_location - proto);
-    return C_OK;
+    return parser->callbacks.verbatim_string_callback(p_ctx, format, format + 4, bulklen - 4, proto, parser->curr_location - proto);
 }
 
 static int parseBigNumber(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
     char *p = strchr(proto+1,'\r');
     parser->curr_location = p + 2; /* for \r\n */
-    parser->callbacks.big_number_callback(p_ctx, proto+1, p-proto-1, proto, parser->curr_location - proto);
-    return C_OK;
+    return parser->callbacks.big_number_callback(p_ctx, proto+1, p-proto-1, proto, parser->curr_location - proto);
 }
 
 static int parseNull(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
     char *p = strchr(proto+1,'\r');
     parser->curr_location = p + 2; /* for \r\n */
-    parser->callbacks.null_callback(p_ctx, proto, parser->curr_location - proto);
-    return C_OK;
+    return parser->callbacks.null_callback(p_ctx, proto, parser->curr_location - proto);
 }
 
 static int parseDouble(ReplyParser *parser, void *p_ctx) {
@@ -157,16 +148,14 @@ static int parseDouble(ReplyParser *parser, void *p_ctx) {
     } else {
         d = 0;
     }
-    parser->callbacks.double_callback(p_ctx, d, proto, parser->curr_location - proto);
-    return C_OK;
+    return parser->callbacks.double_callback(p_ctx, d, proto, parser->curr_location - proto);
 }
 
 static int parseBool(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
     char *p = strchr(proto+1,'\r');
     parser->curr_location = p + 2; /* for \r\n */
-    parser->callbacks.bool_callback(p_ctx, proto[1] == 't', proto, parser->curr_location - proto);
-    return C_OK;
+    return parser->callbacks.bool_callback(p_ctx, proto[1] == 't', proto, parser->curr_location - proto);
 }
 
 static int parseArray(ReplyParser *parser, void *p_ctx) {
@@ -177,11 +166,10 @@ static int parseArray(ReplyParser *parser, void *p_ctx) {
     p += 2;
     parser->curr_location = p;
     if (len == -1) {
-        parser->callbacks.null_array_callback(p_ctx, proto, parser->curr_location - proto);
+        return parser->callbacks.null_array_callback(p_ctx, proto, parser->curr_location - proto);
     } else {
-        parser->callbacks.array_callback(parser, p_ctx, len, proto);
+        return parser->callbacks.array_callback(parser, p_ctx, len, proto);
     }
-    return C_OK;
 }
 
 static int parseSet(ReplyParser *parser, void *p_ctx) {
@@ -191,8 +179,7 @@ static int parseSet(ReplyParser *parser, void *p_ctx) {
     string2ll(proto+1,p-proto-1,&len);
     p += 2;
     parser->curr_location = p;
-    parser->callbacks.set_callback(parser, p_ctx, len, proto);
-    return C_OK;
+    return parser->callbacks.set_callback(parser, p_ctx, len, proto);
 }
 
 static int parseMap(ReplyParser *parser, void *p_ctx) {
@@ -202,8 +189,7 @@ static int parseMap(ReplyParser *parser, void *p_ctx) {
     string2ll(proto+1,p-proto-1,&len);
     p += 2;
     parser->curr_location = p;
-    parser->callbacks.map_callback(parser, p_ctx, len, proto);
-    return C_OK;
+    return parser->callbacks.map_callback(parser, p_ctx, len, proto);
 }
 
 /* Parse a reply pointed to by parser->curr_location. */

--- a/src/resp_parser.h
+++ b/src/resp_parser.h
@@ -34,53 +34,58 @@
 
 typedef struct ReplyParser ReplyParser;
 
+/*
+ * All call back functions registered with ReplyParserCallbacks should return
+ * C_OK on success. C_ERR or other appropriate error code should be returned
+ * on failure.
+ */
 typedef struct ReplyParserCallbacks {
     /* Called when the parser reaches an empty mbulk ('*-1') */
-    void (*null_array_callback)(void *ctx, const char *proto, size_t proto_len);
+    int (*null_array_callback)(void *ctx, const char *proto, size_t proto_len);
 
     /* Called when the parser reaches an empty bulk ('$-1') (bulk len is -1) */
-    void (*null_bulk_string_callback)(void *ctx, const char *proto, size_t proto_len);
+    int (*null_bulk_string_callback)(void *ctx, const char *proto, size_t proto_len);
 
     /* Called when the parser reaches a bulk ('$'), which is passed as 'str' along with its length 'len' */
-    void (*bulk_string_callback)(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len);
+    int (*bulk_string_callback)(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len);
 
     /* Called when the parser reaches an error ('-'), which is passed as 'str' along with its length 'len' */
-    void (*error_callback)(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len);
+    int (*error_callback)(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len);
 
     /* Called when the parser reaches a simple string ('+'), which is passed as 'str' along with its length 'len' */
-    void (*simple_str_callback)(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len);
+    int (*simple_str_callback)(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len);
 
     /* Called when the parser reaches a long long value (':'), which is passed as an argument 'val' */
-    void (*long_callback)(void *ctx, long long val, const char *proto, size_t proto_len);
+    int (*long_callback)(void *ctx, long long val, const char *proto, size_t proto_len);
 
     /* Called when the parser reaches an array ('*'). The array length is passed as an argument 'len' */
-    void (*array_callback)(struct ReplyParser *parser, void *ctx, size_t len, const char *proto);
+    int (*array_callback)(struct ReplyParser *parser, void *ctx, size_t len, const char *proto);
 
     /* Called when the parser reaches a set ('~'). The set length is passed as an argument 'len' */
-    void (*set_callback)(struct ReplyParser *parser, void *ctx, size_t len, const char *proto);
+    int (*set_callback)(struct ReplyParser *parser, void *ctx, size_t len, const char *proto);
 
     /* Called when the parser reaches a map ('%'). The map length is passed as an argument 'len' */
-    void (*map_callback)(struct ReplyParser *parser, void *ctx, size_t len, const char *proto);
+    int (*map_callback)(struct ReplyParser *parser, void *ctx, size_t len, const char *proto);
 
     /* Called when the parser reaches a bool ('#'), which is passed as an argument 'val' */
-    void (*bool_callback)(void *ctx, int val, const char *proto, size_t proto_len);
+    int (*bool_callback)(void *ctx, int val, const char *proto, size_t proto_len);
 
     /* Called when the parser reaches a double (','), which is passed as an argument 'val' */
-    void (*double_callback)(void *ctx, double val, const char *proto, size_t proto_len);
+    int (*double_callback)(void *ctx, double val, const char *proto, size_t proto_len);
 
     /* Called when the parser reaches a big number (','), which is passed as 'str' along with its length 'len' */
-    void (*big_number_callback)(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len);
+    int (*big_number_callback)(void *ctx, const char *str, size_t len, const char *proto, size_t proto_len);
 
     /* Called when the parser reaches a string, which is passed as 'str' along with its 'format' and length 'len' */
-    void (*verbatim_string_callback)(void *ctx, const char *format, const char *str, size_t len, const char *proto, size_t proto_len);
+    int (*verbatim_string_callback)(void *ctx, const char *format, const char *str, size_t len, const char *proto, size_t proto_len);
 
     /* Called when the parser reaches an attribute ('|'). The attribute length is passed as an argument 'len' */
-    void (*attribute_callback)(struct ReplyParser *parser, void *ctx, size_t len, const char *proto);
+    int (*attribute_callback)(struct ReplyParser *parser, void *ctx, size_t len, const char *proto);
 
     /* Called when the parser reaches a null ('_') */
-    void (*null_callback)(void *ctx, const char *proto, size_t proto_len);
+    int (*null_callback)(void *ctx, const char *proto, size_t proto_len);
 
-    void (*error)(void *ctx);
+    int (*error)(void *ctx);
 } ReplyParserCallbacks;
 
 struct ReplyParser {


### PR DESCRIPTION
redisProtocolToLuaType was changed to assert upon failing lua_checkstack
as part of CVE-2021-32626 to avoid heap overflow vulnerability. The server
crash is not a good experience for users of redis server and can be painful.
This patch gracefully bails out and avoids server crash in redisProtocolToLuaType
upon failing lua_checkstack.