### PR TITLE
fix memory leak in example module hellocluster

### DIFF
--- a/src/modules/hellocluster.c
+++ b/src/modules/hellocluster.c
@@ -78,7 +78,7 @@ void PingReceiver(RedisModuleCtx *ctx, const char *sender_id, uint8_t type, cons
         type,REDISMODULE_NODE_ID_LEN,sender_id,(int)len, payload);
     RedisModule_SendClusterMessage(ctx,NULL,MSGTYPE_PONG,(unsigned char*)"Ohi!",4);
     RedisModuleCallReply *reply = RedisModule_Call(ctx, "INCR", "c", "pings_received");
-	RedisModule_FreeCallReply(reply);
+    RedisModule_FreeCallReply(reply);
 }
 
 /* Callback for message MSGTYPE_PONG. */

--- a/src/modules/hellocluster.c
+++ b/src/modules/hellocluster.c
@@ -77,7 +77,8 @@ void PingReceiver(RedisModuleCtx *ctx, const char *sender_id, uint8_t type, cons
     RedisModule_Log(ctx,"notice","PING (type %d) RECEIVED from %.*s: '%.*s'",
         type,REDISMODULE_NODE_ID_LEN,sender_id,(int)len, payload);
     RedisModule_SendClusterMessage(ctx,NULL,MSGTYPE_PONG,(unsigned char*)"Ohi!",4);
-    RedisModule_Call(ctx, "INCR", "c", "pings_received");
+    RedisModuleCallReply *reply = RedisModule_Call(ctx, "INCR", "c", "pings_received");
+	RedisModule_FreeCallReply(reply);
 }
 
 /* Callback for message MSGTYPE_PONG. */


### PR DESCRIPTION
Auto memory management is not enabled, so we need to manually free the call reply. See details in #9800 