### PR TITLE
Initialize manual failover replica target

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -632,6 +632,7 @@ void clusterInit(void) {
     deriveAnnouncedPorts(&myself->port, &myself->pport, &myself->cport);
 
     server.cluster->mf_end = 0;
+    server.cluster->mf_slave = NULL;
     resetManualFailover();
     clusterUpdateMyselfFlags();
     clusterUpdateMyselfIp();


### PR DESCRIPTION
We started depending on a value that wasn't properly initialized in cluster init, so adding that. This just causes a Valgrind warning but should other wise be correct since static initialization would have set it to 0 (NULL) anyways.

https://github.com/redis/redis/actions/runs/1483081713
https://github.com/redis/redis/actions/runs/1483085335