### PR TITLE
Adds MUL AGGREGATE to ZUNION/ZINTER/ZUNIONSTORE/ZINTERSTORE

### DIFF
--- a/src/commands/zinter.json
+++ b/src/commands/zinter.json
@@ -70,6 +70,11 @@
                         "name": "max",
                         "type": "pure-token",
                         "token": "MAX"
+                    },
+                    {
+                        "name": "mul",
+                        "type": "pure-token",
+                        "token": "MUL"
                     }
                 ]
             },

--- a/src/commands/zinterstore.json
+++ b/src/commands/zinterstore.json
@@ -93,6 +93,11 @@
                         "name": "max",
                         "type": "pure-token",
                         "token": "MAX"
+                    },
+                    {
+                        "name": "mul",
+                        "type": "pure-token",
+                        "token": "MUL"
                     }
                 ]
             }

--- a/src/commands/zunion.json
+++ b/src/commands/zunion.json
@@ -70,6 +70,11 @@
                         "name": "max",
                         "type": "pure-token",
                         "token": "MAX"
+                    },
+                    {
+                        "name": "mul",
+                        "type": "pure-token",
+                        "token": "MUL"
                     }
                 ]
             },

--- a/src/commands/zunionstore.json
+++ b/src/commands/zunionstore.json
@@ -93,6 +93,11 @@
                         "name": "max",
                         "type": "pure-token",
                         "token": "MAX"
+                    },
+                    {
+                        "name": "mul",
+                        "type": "pure-token",
+                        "token": "MUL"
                     }
                 ]
             }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1014,7 +1014,7 @@ void sinterCommand(client *c) {
 void sinterCardCommand(client *c) {
     long j;
     long numkeys = 0; /* Number of keys. */
-    long limit = 0;   /* 0 means not limit. */
+    long limit = -1;  /* 0 means not limit. */
 
     if (getRangeLongFromObjectOrReply(c, c->argv[1], 1, LONG_MAX,
                                       &numkeys, "numkeys should be greater than 0") != C_OK)
@@ -1028,7 +1028,7 @@ void sinterCardCommand(client *c) {
         char *opt = c->argv[j]->ptr;
         int moreargs = (c->argc - 1) - j;
 
-        if (!strcasecmp(opt, "LIMIT") && moreargs) {
+        if (limit == -1 && !strcasecmp(opt, "LIMIT") && moreargs) {
             j++;
             if (getPositiveLongFromObjectOrReply(c, c->argv[j], &limit,
                                                  "LIMIT can't be negative") != C_OK)
@@ -1039,6 +1039,7 @@ void sinterCardCommand(client *c) {
         }
     }
 
+    if (limit == -1) limit = 0;
     sinterGenericCommand(c, c->argv+2, numkeys, NULL, 1, limit);
 }
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2293,9 +2293,11 @@ static int zuiCompareByRevCardinality(const void *s1, const void *s2) {
     return zuiCompareByCardinality(s1, s2) * -1;
 }
 
+#define REDIS_AGGR_NONE 0
 #define REDIS_AGGR_SUM 1
 #define REDIS_AGGR_MIN 2
 #define REDIS_AGGR_MAX 3
+#define REDIS_AGGR_MUL 4
 #define zunionInterDictValue(_e) (dictGetVal(_e) == NULL ? 1.0 : *(double*)dictGetVal(_e))
 
 inline static void zunionInterAggregate(double *target, double val, int aggregate) {
@@ -2309,6 +2311,12 @@ inline static void zunionInterAggregate(double *target, double val, int aggregat
         *target = val < *target ? val : *target;
     } else if (aggregate == REDIS_AGGR_MAX) {
         *target = val > *target ? val : *target;
+    } else if (aggregate == REDIS_AGGR_MUL) {
+        *target = *target * val;
+        /* The result of multiplying two doubles is NaN when one variable
+         * is 0 and the other is +inf or -inf. When these numbers are multiplied,
+         * we maintain the convention of the result being 0.0. */
+        if (isnan(*target)) *target = 0.0;
     } else {
         /* safety net */
         serverPanic("Unknown ZUNION/INTER aggregate type");
@@ -2520,7 +2528,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
                                    int cardinality_only) {
     int i, j;
     long setnum;
-    int aggregate = REDIS_AGGR_SUM;
+    int aggregate = REDIS_AGGR_NONE;
     zsetopsrc *src;
     zsetopval zval;
     sds tmp;
@@ -2530,7 +2538,8 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
     zskiplistNode *znode;
     int withscores = 0;
     unsigned long cardinality = 0;
-    long limit = 0; /* Stop searching after reaching the limit. 0 means unlimited. */
+    long limit = -1; /* Stop searching after reaching the limit. 0 means unlimited. */
+    int has_weights = 0;
 
     /* expect setnum input keys to be given */
     if ((getLongFromObjectOrReply(c, c->argv[numkeysIndex], &setnum, NULL) != C_OK))
@@ -2576,7 +2585,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
 
         while (remaining) {
             if (op != SET_OP_DIFF && !cardinality_only &&
-                remaining >= (setnum + 1) &&
+                !has_weights && remaining >= (setnum + 1) &&
                 !strcasecmp(c->argv[j]->ptr,"weights"))
             {
                 j++; remaining--;
@@ -2588,8 +2597,9 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
                         return;
                     }
                 }
+                has_weights = 1;
             } else if (op != SET_OP_DIFF && !cardinality_only &&
-                       remaining >= 2 &&
+                       aggregate == REDIS_AGGR_NONE && remaining >= 2 &&
                        !strcasecmp(c->argv[j]->ptr,"aggregate"))
             {
                 j++; remaining--;
@@ -2599,19 +2609,21 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
                     aggregate = REDIS_AGGR_MIN;
                 } else if (!strcasecmp(c->argv[j]->ptr,"max")) {
                     aggregate = REDIS_AGGR_MAX;
+                } else if (!strcasecmp(c->argv[j]->ptr, "mul")) {
+                    aggregate = REDIS_AGGR_MUL;
                 } else {
                     zfree(src);
                     addReplyErrorObject(c,shared.syntaxerr);
                     return;
                 }
                 j++; remaining--;
-            } else if (remaining >= 1 &&
+            } else if (!withscores && remaining >= 1 &&
                        !dstkey && !cardinality_only &&
                        !strcasecmp(c->argv[j]->ptr,"withscores"))
             {
                 j++; remaining--;
                 withscores = 1;
-            } else if (cardinality_only && remaining >= 2 &&
+            } else if (limit == -1 && cardinality_only && remaining >= 2 &&
                        !strcasecmp(c->argv[j]->ptr, "limit"))
             {
                 j++; remaining--;
@@ -2629,6 +2641,10 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
             }
         }
     }
+
+    /* Use defaults if not overridden by arguments. */
+    if (aggregate == REDIS_AGGR_NONE) aggregate = REDIS_AGGR_SUM;
+    if (limit == -1) limit = 0;
 
     if (op != SET_OP_DIFF) {
         /* sort sets from the smallest to largest, this will improve our
@@ -2800,12 +2816,12 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
     zfree(src);
 }
 
-/* ZUNIONSTORE destination numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX] */
+/* ZUNIONSTORE destination numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX|MUL] */
 void zunionstoreCommand(client *c) {
     zunionInterDiffGenericCommand(c, c->argv[1], 2, SET_OP_UNION, 0);
 }
 
-/* ZINTERSTORE destination numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX] */
+/* ZINTERSTORE destination numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX|MUL] */
 void zinterstoreCommand(client *c) {
     zunionInterDiffGenericCommand(c, c->argv[1], 2, SET_OP_INTER, 0);
 }
@@ -2815,12 +2831,12 @@ void zdiffstoreCommand(client *c) {
     zunionInterDiffGenericCommand(c, c->argv[1], 2, SET_OP_DIFF, 0);
 }
 
-/* ZUNION numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX] [WITHSCORES] */
+/* ZUNION numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX|MUL] [WITHSCORES] */
 void zunionCommand(client *c) {
     zunionInterDiffGenericCommand(c, NULL, 1, SET_OP_UNION, 0);
 }
 
-/* ZINTER numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX] [WITHSCORES] */
+/* ZINTER numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX|MUL] [WITHSCORES] */
 void zinterCommand(client *c) {
     zunionInterDiffGenericCommand(c, NULL, 1, SET_OP_INTER, 0);
 }

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -156,6 +156,7 @@ start_server {
         assert_error "ERR syntax error*" {r sintercard 1 myset{t} myset2{t}}
         assert_error "ERR syntax error*" {r sintercard 1 myset{t} bar_arg}
         assert_error "ERR syntax error*" {r sintercard 1 myset{t} LIMIT}
+        assert_error "ERR syntax error*" {r sintercard 1 myset{t} LIMIT 0 LIMIT 1}
 
         assert_error "ERR LIMIT*" {r sintercard 1 myset{t} LIMIT -1}
         assert_error "ERR LIMIT*" {r sintercard 1 myset{t} LIMIT a}


### PR DESCRIPTION
Introduce MUL AGGREGATE to zset inter/union. It allow weighting
one set with another.

Syntax of commands involved (AGGREGATE MUL option):
`ZUNION numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX|MUL] [WITHSCORES]`
`ZINTER numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX|MUL] [WITHSCORES]`
`ZUNIONSTORE destination numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX|MUL]`
`ZINTERSTORE destination numkeys key [key ...] [WEIGHTS weight] [AGGREGATE SUM|MIN|MAX|MUL]`

This PR also fixes the problem of passing in multiple identical
parameters and adds some tests to cover it.

refresh PR #4348 and closes #172