### PR TITLE
Don't use accurate option with ASAN unit tests

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -346,7 +346,7 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'cluster')
         run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
       - name: unittest
-        run: ./src/redis-server test all --accurate
+        run: ./src/redis-server test all
 
   test-sanitizer-undefined:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Don't use accurate option with ASAN unit tests to prevent extreme slow down.

Stress tests and benchmarks in ziplist.c and listpack.c with "accurate" flag causes extreme slow down in the address sanitizer. 

Found here : https://github.com/redis/redis/runs/4232082551?check_suite_focus=true
Introduced by : https://github.com/redis/redis/pull/9792

