### PR TITLE
introduce dynamic client reply buffer size - save memory on idle clients

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -958,6 +958,13 @@ NULL
     {
         server.pause_cron = atoi(c->argv[2]->ptr);
         addReply(c,shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr,"replybuffer-peak-reset-time") && c->argc == 3 ) {
+        if (!strcasecmp(c->argv[2]->ptr, "never")) {
+            server.reply_buffer_peak_reset_frequency = -1;
+        } else {
+            server.reply_buffer_peak_reset_frequency = atoi(c->argv[2]->ptr);
+        }
+        addReply(c, shared.ok);
     } else {
         addReplySubcommandSyntaxError(c);
         return;

--- a/src/debug.c
+++ b/src/debug.c
@@ -963,9 +963,9 @@ NULL
         addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"replybuffer-peak-reset-time") && c->argc == 3 ) {
         if (!strcasecmp(c->argv[2]->ptr, "never")) {
-            server.reply_buffer_peak_reset_frequency = -1;
+            server.reply_buffer_peak_reset_time = -1;
         } else {
-            server.reply_buffer_peak_reset_frequency = atoi(c->argv[2]->ptr);
+            server.reply_buffer_peak_reset_time = atoi(c->argv[2]->ptr);
         }
         addReply(c, shared.ok);
     } else {

--- a/src/debug.c
+++ b/src/debug.c
@@ -482,6 +482,9 @@ void debugCommand(client *c) {
 "    Show low level client eviction pools info (maxmemory-clients).",
 "PAUSE-CRON <0|1>",
 "    Stop periodic cron job processing.",
+"REPLYBUFFER-PEAK-RESET-TIME <NEVER|time>",
+"    Sets the time (in milliseconds) to wait between client reply buffer peak resets.",
+"    In case NEVER is configured the last observed peak will never be reset",
 NULL
         };
         addReplyHelp(c, help);

--- a/src/debug.c
+++ b/src/debug.c
@@ -965,7 +965,8 @@ NULL
         if (!strcasecmp(c->argv[2]->ptr, "never")) {
             server.reply_buffer_peak_reset_time = -1;
         } else {
-            server.reply_buffer_peak_reset_time = atoi(c->argv[2]->ptr);
+            if (getLongFromObjectOrReply(c, c->argv[2], &server.reply_buffer_peak_reset_time, NULL) != C_OK)
+                return;
         }
         addReply(c, shared.ok);
     } else {

--- a/src/debug.c
+++ b/src/debug.c
@@ -482,9 +482,10 @@ void debugCommand(client *c) {
 "    Show low level client eviction pools info (maxmemory-clients).",
 "PAUSE-CRON <0|1>",
 "    Stop periodic cron job processing.",
-"REPLYBUFFER-PEAK-RESET-TIME <NEVER|time>",
+"REPLYBUFFER-PEAK-RESET-TIME <NEVER||RESET|time>",
 "    Sets the time (in milliseconds) to wait between client reply buffer peak resets.",
-"    In case NEVER is configured the last observed peak will never be reset",
+"    In case NEVER is provided the last observed peak will never be reset",
+"    In case RESET is provided the peak reset time will be restored to the default value",
 NULL
         };
         addReplyHelp(c, help);
@@ -964,6 +965,8 @@ NULL
     } else if (!strcasecmp(c->argv[1]->ptr,"replybuffer-peak-reset-time") && c->argc == 3 ) {
         if (!strcasecmp(c->argv[2]->ptr, "never")) {
             server.reply_buffer_peak_reset_time = -1;
+        } else if(!strcasecmp(c->argv[2]->ptr, "reset")) {
+            server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
         } else {
             if (getLongFromObjectOrReply(c, c->argv[2], &server.reply_buffer_peak_reset_time, NULL) != C_OK)
                 return;

--- a/src/networking.c
+++ b/src/networking.c
@@ -316,6 +316,9 @@ size_t _addReplyToBuffer(client *c, const char *s, size_t len) {
     size_t reply_len = len > available ? available : len;
     memcpy(c->buf+c->bufpos,s,reply_len);
     c->bufpos+=reply_len;
+    /* We update the buffer peak after appending the reply to the buffer */
+    if(c->buf_peak < (size_t)c->bufpos)
+        c->buf_peak = (size_t)c->bufpos;
     return reply_len;
 }
 
@@ -1734,8 +1737,6 @@ int _writeToClient(client *c, ssize_t *nwritten) {
         /* If the buffer was sent, set bufpos to zero to continue with
          * the remainder of the reply. */
         if ((int)c->sentlen == c->bufpos) {
-            if(c->buf_peak < (size_t)c->bufpos)
-                c->buf_peak = (size_t)c->bufpos;
             c->bufpos = 0;
             c->sentlen = 0;
         }

--- a/src/networking.c
+++ b/src/networking.c
@@ -142,7 +142,7 @@ client *createClient(connection *conn) {
     c->bufpos = 0;
     c->buf_usable_size = zmalloc_usable_size(c->buf);
     c->buf_peak = c->buf_usable_size;
-    c->buf_peak_last_reset_time = 0UL;
+    c->buf_peak_last_reset_time = server.unixtime;
     c->ref_repl_buf_node = NULL;
     c->ref_block_pos = 0;
     c->qb_pos = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -711,7 +711,7 @@ int clientsCronResizeQueryBuffer(client *c) {
  * the logic is:
  * in case the last observed peak size of the buffer equals the buffer size - we double the size
  * in case the last observed peak size of the buffer is less than half the buffer size - we shrink by half.
- * The buffer peak will be reset back to zero every 5 seconds
+ * The buffer peak will be reset back to the buffer possition every 5 seconds
  * The function always returns 0 as it never terminates the client. */
 int clientsCronResizeOutputBuffer(client *c) {
 
@@ -720,11 +720,13 @@ int clientsCronResizeOutputBuffer(client *c) {
     const size_t buffer_target_expend_size = c->buf_usable_size*2;
 
     if (buffer_target_shrink_size >= PROTO_REPLY_MIN_BYTES &&
-        c->buf_peak < buffer_target_shrink_size ) {
+        c->buf_peak < buffer_target_shrink_size )
+    {
         new_buffer_size = buffer_target_shrink_size;
         server.stat_reply_buffer_shrinks++;
-    } else if(buffer_target_expend_size <= PROTO_REPLY_CHUNK_BYTES &&
-            c->buf_peak == c->buf_usable_size) {
+    } else if (buffer_target_expend_size <= PROTO_REPLY_CHUNK_BYTES &&
+        c->buf_peak == c->buf_usable_size)
+    {
         new_buffer_size = buffer_target_expend_size;
         server.stat_reply_buffer_expends++;
     }

--- a/src/server.c
+++ b/src/server.c
@@ -733,7 +733,7 @@ int clientsCronResizeOutputBuffer(client *c) {
      * it will start to shrink.
      */
     if(server.unixtime - c->buf_peak_last_reset_time >= 5) {
-        c->buf_peak = 0UL;
+        c->buf_peak = c->bufpos;
         c->buf_peak_last_reset_time = server.unixtime;
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -743,8 +743,7 @@ int clientsCronResizeOutputBuffer(client *c) {
          */
         if(c->bufpos == 0) {
             zfree(c->buf);
-            c->buf = zmalloc(new_buffer_size);
-            c->buf_usable_size = zmalloc_usable_size(c->buf);
+            c->buf = zmalloc_usable(new_buffer_size, c->buf_usable_size);
         } else {
             c->buf = zrealloc_usable(c->buf,new_buffer_size,&c->buf_usable_size);
         }

--- a/src/server.c
+++ b/src/server.c
@@ -718,7 +718,7 @@ int clientsCronResizeOutputBuffer(client *c, mstime_t now_ms) {
     size_t new_buffer_size = 0;
     char *oldbuf = NULL;
     const size_t buffer_target_shrink_size = c->buf_usable_size/2;
-    const size_t buffer_target_expend_size = c->buf_usable_size*2;
+    const size_t buffer_target_expand_size = c->buf_usable_size*2;
 
     if (buffer_target_shrink_size >= PROTO_REPLY_MIN_BYTES &&
         c->buf_peak < buffer_target_shrink_size )

--- a/src/server.c
+++ b/src/server.c
@@ -711,7 +711,7 @@ int clientsCronResizeQueryBuffer(client *c) {
  * the logic is:
  * in case the last observed peak size of the buffer equals the buffer size - we double the size
  * in case the last observed peak size of the buffer is less than half the buffer size - we shrink by half.
- * The buffer peak will be reset back to the buffer possition every 5 seconds
+ * The buffer peak will be reset back to the buffer position every 5 seconds
  * The function always returns 0 as it never terminates the client. */
 int clientsCronResizeOutputBuffer(client *c) {
 

--- a/src/server.c
+++ b/src/server.c
@@ -735,7 +735,9 @@ int clientsCronResizeOutputBuffer(client *c) {
     /* reset the peak value each 5 seconds. in case the client will be idle
      * it will start to shrink.
      */
-    if (server.unixtime - c->buf_peak_last_reset_time >= 5) {
+    if (server.reply_buffer_peak_reset_frequency >=0 &&
+        server.unixtime - c->buf_peak_last_reset_time >= server.reply_buffer_peak_reset_frequency)
+    {
         c->buf_peak = c->bufpos;
         c->buf_peak_last_reset_time = server.unixtime;
     }
@@ -2397,6 +2399,7 @@ void initServer(void) {
     server.blocking_op_nesting = 0;
     server.thp_enabled = 0;
     server.cluster_drop_packet_filter = -1;
+    server.reply_buffer_peak_reset_frequency = 5;
     resetReplicationBuffer();
 
     if ((server.tls_port || server.tls_replication || server.tls_cluster)

--- a/src/server.c
+++ b/src/server.c
@@ -5539,7 +5539,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             server.stat_io_reads_processed,
             server.stat_io_writes_processed,
             server.stat_reply_buffer_shrinks,
-            server.stat_reply_buffer_expends);
+            server.stat_reply_buffer_expands);
     }
 
     /* Replication */

--- a/src/server.c
+++ b/src/server.c
@@ -734,16 +734,16 @@ int clientsCronResizeOutputBuffer(client *c) {
     /* reset the peak value each 5 seconds. in case the client will be idle
      * it will start to shrink.
      */
-    if(server.unixtime - c->buf_peak_last_reset_time >= 5) {
+    if (server.unixtime - c->buf_peak_last_reset_time >= 5) {
         c->buf_peak = c->bufpos;
         c->buf_peak_last_reset_time = server.unixtime;
     }
 
-    if(new_buffer_size) {
+    if (new_buffer_size) {
         /* In case the buffer position in 0 we can just delete and realloc the buffer with the new size
          * no memmove is needed.
          */
-        if(c->bufpos == 0) {
+        if (c->bufpos == 0) {
             zfree(c->buf);
             c->buf = zmalloc_usable(new_buffer_size, &c->buf_usable_size);
         } else {

--- a/src/server.c
+++ b/src/server.c
@@ -2399,7 +2399,7 @@ void initServer(void) {
     server.blocking_op_nesting = 0;
     server.thp_enabled = 0;
     server.cluster_drop_packet_filter = -1;
-    server.reply_buffer_peak_reset_time = 5000;
+    server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
     resetReplicationBuffer();
 
     if ((server.tls_port || server.tls_replication || server.tls_cluster)

--- a/src/server.c
+++ b/src/server.c
@@ -722,7 +722,7 @@ int clientsCronResizeOutputBuffer(client *c) {
     if (buffer_target_shrink_size >= PROTO_REPLY_MIN_BYTES &&
         c->buf_peak < buffer_target_shrink_size )
     {
-        new_buffer_size = c->buf_peak+1;
+        new_buffer_size = max(PROTO_REPLY_MIN_BYTES,c->buf_peak+1);
         server.stat_reply_buffer_shrinks++;
     } else if (buffer_target_expend_size <= PROTO_REPLY_CHUNK_BYTES &&
         c->buf_peak == c->buf_usable_size)

--- a/src/server.c
+++ b/src/server.c
@@ -736,7 +736,7 @@ int clientsCronResizeOutputBuffer(client *c, mstime_t now_ms) {
      * it will start to shrink.
      */
     if (server.reply_buffer_peak_reset_time >=0 &&
-            now_ms - c->buf_peak_last_reset_time >= server.reply_buffer_peak_reset_time)
+        now_ms - c->buf_peak_last_reset_time >= server.reply_buffer_peak_reset_time)
     {
         c->buf_peak = c->bufpos;
         c->buf_peak_last_reset_time = now_ms;

--- a/src/server.c
+++ b/src/server.c
@@ -735,8 +735,8 @@ int clientsCronResizeOutputBuffer(client *c) {
     /* reset the peak value each 5 seconds. in case the client will be idle
      * it will start to shrink.
      */
-    if (server.reply_buffer_peak_reset_frequency >=0 &&
-        server.unixtime - c->buf_peak_last_reset_time >= server.reply_buffer_peak_reset_frequency)
+    if (server.reply_buffer_peak_reset_time >=0 &&
+        server.unixtime - c->buf_peak_last_reset_time >= server.reply_buffer_peak_reset_time)
     {
         c->buf_peak = c->bufpos;
         c->buf_peak_last_reset_time = server.unixtime;
@@ -2399,7 +2399,7 @@ void initServer(void) {
     server.blocking_op_nesting = 0;
     server.thp_enabled = 0;
     server.cluster_drop_packet_filter = -1;
-    server.reply_buffer_peak_reset_frequency = 5;
+    server.reply_buffer_peak_reset_time = 5;
     resetReplicationBuffer();
 
     if ((server.tls_port || server.tls_replication || server.tls_cluster)

--- a/src/server.c
+++ b/src/server.c
@@ -728,8 +728,8 @@ int clientsCronResizeOutputBuffer(client *c, mstime_t now_ms) {
     } else if (buffer_target_expand_size < PROTO_REPLY_CHUNK_BYTES*2 &&
         c->buf_peak == c->buf_usable_size)
     {
-        new_buffer_size = min(PROTO_REPLY_CHUNK_BYTES,buffer_target_expend_size);
-        server.stat_reply_buffer_expends++;
+        new_buffer_size = min(PROTO_REPLY_CHUNK_BYTES,buffer_target_expand_size);
+        server.stat_reply_buffer_expands++;
     }
 
     /* reset the peak value each server.reply_buffer_peak_reset_time seconds. in case the client will be idle

--- a/src/server.c
+++ b/src/server.c
@@ -2338,7 +2338,7 @@ void resetServerStats(void) {
     server.stat_dump_payload_sanitizations = 0;
     server.aof_delayed_fsync = 0;
     server.stat_reply_buffer_shrinks = 0;
-    server.stat_reply_buffer_expends = 0;
+    server.stat_reply_buffer_expands = 0;
     lazyfreeResetStats();
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -738,7 +738,7 @@ int clientsCronResizeOutputBuffer(client *c) {
     }
 
     if(new_buffer_size) {
-        /* In case the buffer possition in 0 we can just delete and realloc the buffer with the new size
+        /* In case the buffer position in 0 we can just delete and realloc the buffer with the new size
          * no memmove is needed.
          */
         if(c->bufpos == 0) {

--- a/src/server.c
+++ b/src/server.c
@@ -725,7 +725,7 @@ int clientsCronResizeOutputBuffer(client *c, mstime_t now_ms) {
     {
         new_buffer_size = max(PROTO_REPLY_MIN_BYTES,c->buf_peak+1);
         server.stat_reply_buffer_shrinks++;
-    } else if (buffer_target_expend_size < PROTO_REPLY_CHUNK_BYTES*2 &&
+    } else if (buffer_target_expand_size < PROTO_REPLY_CHUNK_BYTES*2 &&
         c->buf_peak == c->buf_usable_size)
     {
         new_buffer_size = min(PROTO_REPLY_CHUNK_BYTES,buffer_target_expend_size);

--- a/src/server.c
+++ b/src/server.c
@@ -732,14 +732,14 @@ int clientsCronResizeOutputBuffer(client *c) {
         server.stat_reply_buffer_expends++;
     }
 
-    /* reset the peak value each 5 seconds. in case the client will be idle
+    /* reset the peak value each server.reply_buffer_peak_reset_time seconds. in case the client will be idle
      * it will start to shrink.
      */
     if (server.reply_buffer_peak_reset_time >=0 &&
-        server.unixtime - c->buf_peak_last_reset_time >= server.reply_buffer_peak_reset_time)
+        server.mstime - c->buf_peak_last_reset_time >= server.reply_buffer_peak_reset_time)
     {
         c->buf_peak = c->bufpos;
-        c->buf_peak_last_reset_time = server.unixtime;
+        c->buf_peak_last_reset_time = server.mstime;
     }
 
     if (new_buffer_size) {
@@ -2399,7 +2399,7 @@ void initServer(void) {
     server.blocking_op_nesting = 0;
     server.thp_enabled = 0;
     server.cluster_drop_packet_filter = -1;
-    server.reply_buffer_peak_reset_time = 5;
+    server.reply_buffer_peak_reset_time = 5000;
     resetReplicationBuffer();
 
     if ((server.tls_port || server.tls_replication || server.tls_cluster)

--- a/src/server.c
+++ b/src/server.c
@@ -5494,7 +5494,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "io_threaded_reads_processed:%lld\r\n"
             "io_threaded_writes_processed:%lld\r\n"
             "reply_buffer_shrinks:%lld\r\n"
-            "reply_buffer_expends:%lld\r\n",
+            "reply_buffer_expands:%lld\r\n",
             server.stat_numconnections,
             server.stat_numcommands,
             getInstantaneousMetric(STATS_METRIC_COMMAND),

--- a/src/server.c
+++ b/src/server.c
@@ -5493,7 +5493,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "total_writes_processed:%lld\r\n"
             "io_threaded_reads_processed:%lld\r\n"
             "io_threaded_writes_processed:%lld\r\n"
-            "reply_buffer_shrink:%lld\r\n"
+            "reply_buffer_shrinks:%lld\r\n"
             "reply_buffer_expends:%lld\r\n",
             server.stat_numconnections,
             server.stat_numcommands,

--- a/src/server.c
+++ b/src/server.c
@@ -706,7 +706,7 @@ int clientsCronResizeQueryBuffer(client *c) {
     return 0;
 }
 
-/* The client output buffer can be adjusted to better fit the memory requierments.
+/* The client output buffer can be adjusted to better fit the memory requirements.
  *
  * the logic is:
  * in case the last observed peak size of the buffer equals the buffer size - we double the size

--- a/src/server.c
+++ b/src/server.c
@@ -2336,6 +2336,8 @@ void resetServerStats(void) {
     server.stat_total_error_replies = 0;
     server.stat_dump_payload_sanitizations = 0;
     server.aof_delayed_fsync = 0;
+    server.stat_reply_buffer_shrinks = 0;
+    server.stat_reply_buffer_expends = 0;
     lazyfreeResetStats();
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -745,7 +745,7 @@ int clientsCronResizeOutputBuffer(client *c) {
          */
         if(c->bufpos == 0) {
             zfree(c->buf);
-            c->buf = zmalloc_usable(new_buffer_size, c->buf_usable_size);
+            c->buf = zmalloc_usable(new_buffer_size, &c->buf_usable_size);
         } else {
             c->buf = zrealloc_usable(c->buf,new_buffer_size,&c->buf_usable_size);
         }

--- a/src/server.c
+++ b/src/server.c
@@ -722,7 +722,7 @@ int clientsCronResizeOutputBuffer(client *c) {
     if (buffer_target_shrink_size >= PROTO_REPLY_MIN_BYTES &&
         c->buf_peak < buffer_target_shrink_size )
     {
-        new_buffer_size = buffer_target_shrink_size;
+        new_buffer_size = c->buf_peak+1;
         server.stat_reply_buffer_shrinks++;
     } else if (buffer_target_expend_size <= PROTO_REPLY_CHUNK_BYTES &&
         c->buf_peak == c->buf_usable_size)

--- a/src/server.c
+++ b/src/server.c
@@ -724,10 +724,10 @@ int clientsCronResizeOutputBuffer(client *c) {
     {
         new_buffer_size = max(PROTO_REPLY_MIN_BYTES,c->buf_peak+1);
         server.stat_reply_buffer_shrinks++;
-    } else if (buffer_target_expend_size <= PROTO_REPLY_CHUNK_BYTES &&
+    } else if (buffer_target_expend_size < PROTO_REPLY_CHUNK_BYTES*2 &&
         c->buf_peak == c->buf_usable_size)
     {
-        new_buffer_size = buffer_target_expend_size;
+        new_buffer_size = min(PROTO_REPLY_CHUNK_BYTES,buffer_target_expend_size);
         server.stat_reply_buffer_expends++;
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -716,6 +716,7 @@ int clientsCronResizeQueryBuffer(client *c) {
 int clientsCronResizeOutputBuffer(client *c) {
 
     size_t new_buffer_size = 0;
+    char *oldbuf = NULL;
     const size_t buffer_target_shrink_size = c->buf_usable_size/2;
     const size_t buffer_target_expend_size = c->buf_usable_size*2;
 
@@ -740,15 +741,10 @@ int clientsCronResizeOutputBuffer(client *c) {
     }
 
     if (new_buffer_size) {
-        /* In case the buffer position in 0 we can just delete and realloc the buffer with the new size
-         * no memmove is needed.
-         */
-        if (c->bufpos == 0) {
-            zfree(c->buf);
-            c->buf = zmalloc_usable(new_buffer_size, &c->buf_usable_size);
-        } else {
-            c->buf = zrealloc_usable(c->buf,new_buffer_size,&c->buf_usable_size);
-        }
+        oldbuf = c->buf;
+        c->buf = zmalloc_usable(new_buffer_size, &c->buf_usable_size);
+        memcpy(c->buf,oldbuf,c->bufpos);
+        zfree(oldbuf);
     }
     return 0;
 }

--- a/src/server.h
+++ b/src/server.h
@@ -169,6 +169,8 @@ typedef long long ustime_t; /* microsecond time type. */
 
 #define LIMIT_PENDING_QUERYBUF (4*1024*1024) /* 4mb */
 
+#define REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME 5000 /* 5 seconds */
+
 /* When configuring the server eventloop, we setup it so that the total number
  * of file descriptors we can handle are server.maxclients + RESERVED_FDS +
  * a few more to stay safe. Since RESERVED_FDS defaults to 32, we add 96

--- a/src/server.h
+++ b/src/server.h
@@ -1587,7 +1587,7 @@ struct redisServer {
         int idx;
     } inst_metric[STATS_METRIC_COUNT];
     long long stat_reply_buffer_shrinks; /* Total number of output buffer shrinks */
-    long long stat_reply_buffer_expends; /* Total number of output buffer expends */
+    long long stat_reply_buffer_expands; /* Total number of output buffer expands */
 
     /* Configuration */
     int verbosity;                  /* Loglevel in redis.conf */

--- a/src/server.h
+++ b/src/server.h
@@ -1169,7 +1169,7 @@ typedef struct client {
 
     /* Response buffer */
     size_t buf_peak; /* Peak used size of buffer in last 5 sec interval. */
-    time_t buf_peak_last_reset_time; /* keeps the last time the buffer peak value was reset */
+    mstime_t buf_peak_last_reset_time; /* keeps the last time the buffer peak value was reset */
     int bufpos;
     size_t buf_usable_size; /* Usable size of buffer. */
     char *buf;
@@ -1896,7 +1896,7 @@ struct redisServer {
     int failover_state; /* Failover state */
     int cluster_allow_pubsubshard_when_down; /* Is pubsubshard allowed when the cluster
                                                 is down, doesn't affect pubsub global. */
-    int reply_buffer_peak_reset_time; /* The amount of time to wait between reply buffer peak resets */
+    long reply_buffer_peak_reset_time; /* The amount of time (in milliseconds) to wait between reply buffer peak resets */
 };
 
 #define MAX_KEYS_BUFFER 256

--- a/src/server.h
+++ b/src/server.h
@@ -1896,6 +1896,7 @@ struct redisServer {
     int failover_state; /* Failover state */
     int cluster_allow_pubsubshard_when_down; /* Is pubsubshard allowed when the cluster
                                                 is down, doesn't affect pubsub global. */
+    int reply_buffer_peak_reset_frequency; /* The amount of time to wait between reply buffer peak resets */
 };
 
 #define MAX_KEYS_BUFFER 256

--- a/src/server.h
+++ b/src/server.h
@@ -1584,7 +1584,7 @@ struct redisServer {
         long long samples[STATS_METRIC_SAMPLES];
         int idx;
     } inst_metric[STATS_METRIC_COUNT];
-    long long stat_reply_buffer_shrinks; /* Total number of buffer output buffer shrinks */
+    long long stat_reply_buffer_shrinks; /* Total number of output buffer shrinks */
     long long stat_reply_buffer_expends; /* Total number of output buffer expends */
 
     /* Configuration */

--- a/src/server.h
+++ b/src/server.h
@@ -1896,7 +1896,7 @@ struct redisServer {
     int failover_state; /* Failover state */
     int cluster_allow_pubsubshard_when_down; /* Is pubsubshard allowed when the cluster
                                                 is down, doesn't affect pubsub global. */
-    int reply_buffer_peak_reset_frequency; /* The amount of time to wait between reply buffer peak resets */
+    int reply_buffer_peak_reset_time; /* The amount of time to wait between reply buffer peak resets */
 };
 
 #define MAX_KEYS_BUFFER 256

--- a/src/server.h
+++ b/src/server.h
@@ -1168,7 +1168,7 @@ typedef struct client {
                                   * i.e. the next offset to send. */
 
     /* Response buffer */
-    size_t buf_peak; /* Usable size of buffer. */
+    size_t buf_peak; /* Peak used size of buffer in last 5 sec interval. */
     time_t buf_peak_last_reset_time; /* keeps the last time the buffer peak value was reset */
     int bufpos;
     size_t buf_usable_size; /* Usable size of buffer. */

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -93,6 +93,7 @@ set ::all_tests {
     unit/cluster
     unit/client-eviction
     unit/violations
+    unit/replybufsize
 }
 # Index to the next test to run in the ::all_tests list.
 set ::next_test 0

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -500,6 +500,10 @@ start_server {} {
                 }
             }
         }
+        
+        # Restore the peak reset time to default
+        r debug replybuffer-peak-reset-time reset
+        
         foreach rr $rrs {$rr close}
     } {} {needs:debug}
 }

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -441,7 +441,7 @@ start_server {} {
     }
 }
 
-start_server {} {
+start_server {overrides {enable-debug-command {local}}} {
     test "evict clients in right order (large to small)" {
         # Note that each size step needs to be at least x2 larger than previous step 
         # because of how the client-eviction size bucktting works

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -441,7 +441,7 @@ start_server {} {
     }
 }
 
-start_server {overrides {enable-debug-command {local}}} {
+start_server {} {
     test "evict clients in right order (large to small)" {
         # Note that each size step needs to be at least x2 larger than previous step 
         # because of how the client-eviction size bucktting works

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -501,7 +501,7 @@ start_server {} {
             }
         }
         foreach rr $rrs {$rr close}
-    }
+    } {} {needs:debug}
 }
 
 }

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -7,7 +7,7 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT LIST} {
         r client list
-    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=2*}
+    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=2*}
 
     test {CLIENT LIST with IDs} {
         set myid [r client id]
@@ -17,7 +17,7 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT INFO} {
         r client info
-    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=2*}
+    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=2*}
 
     test {CLIENT KILL with illegal arguments} {
         assert_error "ERR wrong number of arguments for 'client|kill' command" {r client kill}

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -7,7 +7,7 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT LIST} {
         r client list
-    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=2*}
+    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=2*}
 
     test {CLIENT LIST with IDs} {
         set myid [r client id]
@@ -17,7 +17,7 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT INFO} {
         r client info
-    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=2*}
+    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=2*}
 
     test {CLIENT KILL with illegal arguments} {
         assert_error "ERR wrong number of arguments for 'client|kill' command" {r client kill}

--- a/tests/unit/replybufsize.tcl
+++ b/tests/unit/replybufsize.tcl
@@ -37,6 +37,9 @@ start_server {tags {"replybufsize"}} {
             set rbs [get_reply_buffer_size test_client]
             fail "reply buffer of busy client is $rbs after 1 seconds"
         }
+   
+        # Restore the peak reset time to default
+        r debug replybuffer-peak-reset-time reset
         
         $tc close
     } {0} {needs:debug}

--- a/tests/unit/replybufsize.tcl
+++ b/tests/unit/replybufsize.tcl
@@ -5,51 +5,35 @@ proc get_reply_buffer_size {cname} {
     if {![regexp rbs=(\[a-zA-Z0-9-\]+) $c - rbufsize]} {
         error "field rbus not found in $c"
     }
+    puts $c
     return $rbufsize
 }
 
 start_server {tags {"replybufsize"}} {
     
-    test {idle client buffer maximum shrink to 1kib} {
-        variable rbs 0
+    test {verify reply buffer limits} {
         
         # Create a simple idle test client
         variable tc [redis_client]
         $tc client setname test_client
         
         # make sure the client is idle for 5 seconds to make it shrink the reply buffer
-        after 5000 {set rbs [get_reply_buffer_size test_client]} 
-        vwait rbs
-        
-        assert_equal $rbs 1024
-        
-        $tc close
-    }
-    
-    test {busy client buffer maximum enlarge to 16kib} {
-        variable rbs 0
-       
-        r set bigval [string repeat x 16384]
-        
-        # Create a simple test client
-        variable tc [redis_client]
-        $tc client setname test_client
-        
-        # make sure the client is idle for 5 seconds to make it shrink the reply buffer
-        after 5000 {set rbs [get_reply_buffer_size test_client]} 
-        vwait rbs
-        
-        assert_equal $rbs 1024
-        variable client_bussy 1
-       
-        after 5000 {set client_bussy 0}
-       
-        while { $client_bussy == 1 } {
-            $tc get bigval
-            after 100 {set rbs [get_reply_buffer_size test_client]}
-            vwait rbs
+        wait_for_condition 5 1000 {
+            [get_reply_buffer_size test_client] >= 1024 && [get_reply_buffer_size test_client] < 2046
+        } else {
+            set rbs [get_reply_buffer_size test_client]
+            fail "reply buffer of idle client is $rbs after 5 seconds"
         }
-        assert_equal $rbs 16384     
+        
+        r set bigval [string repeat x 32768]
+        
+        wait_for_condition 50 100 {
+            [$tc get bigval ; get_reply_buffer_size test_client] >= 16384 && [get_reply_buffer_size test_client] < 32768
+        } else {
+            set rbs [get_reply_buffer_size test_client]
+            fail "reply buffer of busy client is $rbs after 5 seconds"
+        }
+        
         $tc close
     }
 }

--- a/tests/unit/replybufsize.tcl
+++ b/tests/unit/replybufsize.tcl
@@ -8,7 +8,7 @@ proc get_reply_buffer_size {cname} {
     return $rbufsize
 }
 
-start_server {tags {"replybufsize"} overrides {enable-debug-command {local}}} {
+start_server {tags {"replybufsize"}} {
     
     test {verify reply buffer limits} {
         # In order to reduce test time we can set the peak reset time very low

--- a/tests/unit/replybufsize.tcl
+++ b/tests/unit/replybufsize.tcl
@@ -1,0 +1,56 @@
+proc get_reply_buffer_size {cname} {
+
+    set clients [split [string trim [r client list]] "\r\n"]
+    set c [lsearch -inline $clients *name=$cname*]
+    if {![regexp rbs=(\[a-zA-Z0-9-\]+) $c - rbufsize]} {
+        error "field rbus not found in $c"
+    }
+    return $rbufsize
+}
+
+start_server {tags {"replybufsize"}} {
+    
+    test {idle client buffer maximum shrink to 1kib} {
+        variable rbs 0
+        
+        # Create a simple idle test client
+        variable tc [redis_client]
+        $tc client setname test_client
+        
+        # make sure the client is idle for 5 seconds to make it shrink the reply buffer
+        after 5000 {set rbs [get_reply_buffer_size test_client]} 
+        vwait rbs
+        
+        assert_equal $rbs 1024
+        
+        $tc close
+    }
+    
+    test {busy client buffer maximum enlarge to 16kib} {
+        variable rbs 0
+       
+        r set bigval [string repeat x 16384]
+        
+        # Create a simple test client
+        variable tc [redis_client]
+        $tc client setname test_client
+        
+        # make sure the client is idle for 5 seconds to make it shrink the reply buffer
+        after 5000 {set rbs [get_reply_buffer_size test_client]} 
+        vwait rbs
+        
+        assert_equal $rbs 1024
+        variable client_bussy 1
+       
+        after 5000 {set client_bussy 0}
+       
+        while { $client_bussy == 1 } {
+            $tc get bigval
+            after 100 {set rbs [get_reply_buffer_size test_client]}
+            vwait rbs
+        }
+        assert_equal $rbs 16384     
+        $tc close
+    }
+}
+    

--- a/tests/unit/replybufsize.tcl
+++ b/tests/unit/replybufsize.tcl
@@ -11,36 +11,34 @@ proc get_reply_buffer_size {cname} {
 start_server {tags {"replybufsize"}} {
     
     test {verify reply buffer limits} {
-        if {$::accurate} {
-            # In order to reduce test time we can set the peak reset time very low
-            r debug replybuffer-peak-reset-time 0
-            
-            # Create a simple idle test client
-            variable tc [redis_client]
-            $tc client setname test_client
-            
-            # make sure the client is idle for 5 seconds to make it shrink the reply buffer
-            wait_for_condition 10 100 {
-                [get_reply_buffer_size test_client] >= 1024 && [get_reply_buffer_size test_client] < 2046
-            } else {
-                set rbs [get_reply_buffer_size test_client]
-                fail "reply buffer of idle client is $rbs after 1 seconds"
-            }
-            
-            r set bigval [string repeat x 32768]
-            
-            # In order to reduce test time we can set the peak reset time very low
-            r debug replybuffer-peak-reset-time never
-            
-            wait_for_condition 10 100 {
-                [$tc get bigval ; get_reply_buffer_size test_client] >= 16384 && [get_reply_buffer_size test_client] < 32768
-            } else {
-                set rbs [get_reply_buffer_size test_client]
-                fail "reply buffer of busy client is $rbs after 1 seconds"
-            }
-            
-            $tc close
-        } 
-    }
+        # In order to reduce test time we can set the peak reset time very low
+        r debug replybuffer-peak-reset-time 0
+        
+        # Create a simple idle test client
+        variable tc [redis_client]
+        $tc client setname test_client
+        
+        # make sure the client is idle for 5 seconds to make it shrink the reply buffer
+        wait_for_condition 10 100 {
+            [get_reply_buffer_size test_client] >= 1024 && [get_reply_buffer_size test_client] < 2046
+        } else {
+            set rbs [get_reply_buffer_size test_client]
+            fail "reply buffer of idle client is $rbs after 1 seconds"
+        }
+        
+        r set bigval [string repeat x 32768]
+        
+        # In order to reduce test time we can set the peak reset time very low
+        r debug replybuffer-peak-reset-time never
+        
+        wait_for_condition 10 100 {
+            [$tc get bigval ; get_reply_buffer_size test_client] >= 16384 && [get_reply_buffer_size test_client] < 32768
+        } else {
+            set rbs [get_reply_buffer_size test_client]
+            fail "reply buffer of busy client is $rbs after 1 seconds"
+        }
+        
+        $tc close
+    } {} {needs:debug}
 }
     

--- a/tests/unit/replybufsize.tcl
+++ b/tests/unit/replybufsize.tcl
@@ -12,29 +12,30 @@ proc get_reply_buffer_size {cname} {
 start_server {tags {"replybufsize"}} {
     
     test {verify reply buffer limits} {
-        
-        # Create a simple idle test client
-        variable tc [redis_client]
-        $tc client setname test_client
-        
-        # make sure the client is idle for 5 seconds to make it shrink the reply buffer
-        wait_for_condition 5 1000 {
-            [get_reply_buffer_size test_client] >= 1024 && [get_reply_buffer_size test_client] < 2046
-        } else {
-            set rbs [get_reply_buffer_size test_client]
-            fail "reply buffer of idle client is $rbs after 5 seconds"
-        }
-        
-        r set bigval [string repeat x 32768]
-        
-        wait_for_condition 50 100 {
-            [$tc get bigval ; get_reply_buffer_size test_client] >= 16384 && [get_reply_buffer_size test_client] < 32768
-        } else {
-            set rbs [get_reply_buffer_size test_client]
-            fail "reply buffer of busy client is $rbs after 5 seconds"
-        }
-        
-        $tc close
+        if {$::accurate} {
+            # Create a simple idle test client
+            variable tc [redis_client]
+            $tc client setname test_client
+            
+            # make sure the client is idle for 5 seconds to make it shrink the reply buffer
+            wait_for_condition 5 1000 {
+                [get_reply_buffer_size test_client] >= 1024 && [get_reply_buffer_size test_client] < 2046
+            } else {
+                set rbs [get_reply_buffer_size test_client]
+                fail "reply buffer of idle client is $rbs after 5 seconds"
+            }
+            
+            r set bigval [string repeat x 32768]
+            
+            wait_for_condition 50 100 {
+                [$tc get bigval ; get_reply_buffer_size test_client] >= 16384 && [get_reply_buffer_size test_client] < 32768
+            } else {
+                set rbs [get_reply_buffer_size test_client]
+                fail "reply buffer of busy client is $rbs after 5 seconds"
+            }
+            
+            $tc close
+        } 
     }
 }
     

--- a/tests/unit/replybufsize.tcl
+++ b/tests/unit/replybufsize.tcl
@@ -5,7 +5,6 @@ proc get_reply_buffer_size {cname} {
     if {![regexp rbs=(\[a-zA-Z0-9-\]+) $c - rbufsize]} {
         error "field rbus not found in $c"
     }
-    puts $c
     return $rbufsize
 }
 
@@ -13,25 +12,31 @@ start_server {tags {"replybufsize"}} {
     
     test {verify reply buffer limits} {
         if {$::accurate} {
+            # In order to reduce test time we can set the peak reset time very low
+            r debug replybuffer-peak-reset-time 0
+            
             # Create a simple idle test client
             variable tc [redis_client]
             $tc client setname test_client
             
             # make sure the client is idle for 5 seconds to make it shrink the reply buffer
-            wait_for_condition 6 1000 {
+            wait_for_condition 10 100 {
                 [get_reply_buffer_size test_client] >= 1024 && [get_reply_buffer_size test_client] < 2046
             } else {
                 set rbs [get_reply_buffer_size test_client]
-                fail "reply buffer of idle client is $rbs after 5 seconds"
+                fail "reply buffer of idle client is $rbs after 1 seconds"
             }
             
             r set bigval [string repeat x 32768]
             
-            wait_for_condition 50 100 {
+            # In order to reduce test time we can set the peak reset time very low
+            r debug replybuffer-peak-reset-time never
+            
+            wait_for_condition 10 100 {
                 [$tc get bigval ; get_reply_buffer_size test_client] >= 16384 && [get_reply_buffer_size test_client] < 32768
             } else {
                 set rbs [get_reply_buffer_size test_client]
-                fail "reply buffer of busy client is $rbs after 5 seconds"
+                fail "reply buffer of busy client is $rbs after 1 seconds"
             }
             
             $tc close

--- a/tests/unit/replybufsize.tcl
+++ b/tests/unit/replybufsize.tcl
@@ -18,7 +18,7 @@ start_server {tags {"replybufsize"}} {
             $tc client setname test_client
             
             # make sure the client is idle for 5 seconds to make it shrink the reply buffer
-            wait_for_condition 5 1000 {
+            wait_for_condition 6 1000 {
                 [get_reply_buffer_size test_client] >= 1024 && [get_reply_buffer_size test_client] < 2046
             } else {
                 set rbs [get_reply_buffer_size test_client]

--- a/tests/unit/replybufsize.tcl
+++ b/tests/unit/replybufsize.tcl
@@ -12,7 +12,7 @@ start_server {tags {"replybufsize"} overrides {enable-debug-command {local}}} {
     
     test {verify reply buffer limits} {
         # In order to reduce test time we can set the peak reset time very low
-        r debug replybuffer-peak-reset-time 0
+        r debug replybuffer-peak-reset-time 100
         
         # Create a simple idle test client
         variable tc [redis_client]

--- a/tests/unit/replybufsize.tcl
+++ b/tests/unit/replybufsize.tcl
@@ -8,7 +8,7 @@ proc get_reply_buffer_size {cname} {
     return $rbufsize
 }
 
-start_server {tags {"replybufsize"}} {
+start_server {tags {"replybufsize"} overrides {enable-debug-command {local}}} {
     
     test {verify reply buffer limits} {
         # In order to reduce test time we can set the peak reset time very low
@@ -17,8 +17,8 @@ start_server {tags {"replybufsize"}} {
         # Create a simple idle test client
         variable tc [redis_client]
         $tc client setname test_client
-        
-        # make sure the client is idle for 5 seconds to make it shrink the reply buffer
+         
+        # make sure the client is idle for 1 seconds to make it shrink the reply buffer
         wait_for_condition 10 100 {
             [get_reply_buffer_size test_client] >= 1024 && [get_reply_buffer_size test_client] < 2046
         } else {
@@ -39,6 +39,6 @@ start_server {tags {"replybufsize"}} {
         }
         
         $tc close
-    } {} {needs:debug}
+    } {0} {needs:debug}
 }
     


### PR DESCRIPTION
Current implementation simple idle client which serves no traffic still
use ~17Kb of memory. this is mainly due to a fixed size reply buffer
currently set to 16kb here: https://github.com/redis/redis/blob/unstable/src/server.h#L157

We have encountered some cases in which the server operates in a low memory environments.
In such cases a user who wishes to create large connection pools to support potential burst period, 
will exhaust a large amount of memory  to maintain connected Idle clients.
Some users may choose to "sacrifice" performance in order to save memory.

This commit introduce a dynamic mechanism to shrink and expend the client reply buffer based on periodic observed peak.
the algorithm works as follows:
1. each time a client reply buffer has been fully written, the last recorded peak is updated: 
new peak = MAX( last peak, current written size)
2. during clients cron we check for each client if the last observed peak was:
     a. matching the current buffer size - in which case we expend (resize) the buffer size by 100%
     b. less than half the buffer size - in which case we shrink the buffer size by 50%
3. In any case we will **not** resize the buffer in case:
    a. the current buffer peak is less then the current buffer usable size and higher than 1/2 the current buffer usable size
    b. the value of (current buffer usable size/2) is less than 1Kib
    c. the value of  (current buffer usable size*2) is larger than 16Kib
4. the peak value is reset to the current buffer position once every **5** seconds. we maintain a new field in the client structure (buf_peak_last_reset_time) which is used to keep track of how long it passed since the last buffer peak reset.

### **Interface changes:**
**CIENT LIST** - now contains 2 new extra fields:
rbs= < the current size in bytes of the client reply buffer >
rbp=< the current value in bytes of the last observed buffer peak position >

**INFO STATS** - now contains 2 new statistics:
reply_buffer_shrinks = < total number of buffer shrinks performed >
reply_buffer_expends = < total number of buffer expends performed >

### **Results:**
The main concern in this case was the potential performance degradation as a result of buffer dereferencing.
In order to verify the change we have performed multiple benchmarking tests.
all tests performed on:

m5.2xlarge instance
3 io-threads (main+2 threads)
468750 keys with 4K values
15 c5n.2xlarge client machines running single threaded redis-benchmark.
each redis benchmark running 50 clients with only get requests and run for 900 seconds 

comparing the  results of the static vs dynamic case:
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/ranshid/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/ranshid/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{font-weight:700;}
-->

</head>

<body link="#0563C1" vlink="#954F72">



  | DYNAMIC | STATIC
-- | -- | --
TPS | 164353 | 164667
P90 Latency(ms) | 6.1 | 6.1



</body>

</html>
 
Also looking into **cache-misses** stats using perf verified the TLB and L1 cache misses was increased ~1%.

`sudo perf stat -a -g --pid 'pidof redis-servert' -e cache-misses -- sleep 60`

Static Buf:
> 3,313,413,581      cache-misses

Dynamic Buffer:
> 3,351,794,484      cache-misses

![cache-misses-fg](https://user-images.githubusercontent.com/88133677/147092458-3459be1b-1a6b-44da-b3e1-3f551a8dcc0d.PNG)

