### PR TITLE
Add REDIS_CFLAGS='-Werror' to CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: make
-        run: make SANITIZER=address
+        run: make SANITIZER=address REDIS_CFLAGS='-Werror'
       - name: testprep
         run: sudo apt-get install tcl8.6 tclx -y
       - name: test

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -84,7 +84,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make MALLOC=libc
+      run: make MALLOC=libc REDIS_CFLAGS='-Werror'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -117,7 +117,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make MALLOC=libc CFLAGS=-DNO_MALLOC_USABLE_SIZE
+      run: make MALLOC=libc CFLAGS=-DNO_MALLOC_USABLE_SIZE REDIS_CFLAGS='-Werror'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -190,7 +190,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        make BUILD_TLS=yes
+        make BUILD_TLS=yes REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         sudo apt-get install tcl8.6 tclx tcl-tls
@@ -234,7 +234,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        make
+        make REDIS_CFLAGS='-Werror'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -294,7 +294,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE"
+      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE" REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         sudo apt-get update
@@ -328,7 +328,7 @@ jobs:
           repository: ${{ env.GITHUB_REPOSITORY }}
           ref: ${{ env.GITHUB_HEAD_REF }}
       - name: make
-        run: make SANITIZER=address REDIS_CFLAGS='-DREDIS_TEST'
+        run: make SANITIZER=address REDIS_CFLAGS='-DREDIS_TEST -Werror'
       - name: testprep
         run: |
           sudo apt-get update
@@ -370,7 +370,7 @@ jobs:
           repository: ${{ env.GITHUB_REPOSITORY }}
           ref: ${{ env.GITHUB_HEAD_REF }}
       - name: make
-        run: make SANITIZER=undefined REDIS_CFLAGS='-DREDIS_TEST'
+        run: make SANITIZER=undefined REDIS_CFLAGS='-DREDIS_TEST -Werror'
       - name: testprep
         run: |
           sudo apt-get update
@@ -410,7 +410,7 @@ jobs:
     - name: make
       run: |
         yum -y install gcc make
-        make
+        make REDIS_CFLAGS='-Werror'
     - name: testprep
       run: yum -y install which tcl tclx
     - name: test
@@ -447,7 +447,7 @@ jobs:
       run: |
         yum -y install centos-release-scl epel-release
         yum -y install devtoolset-7 openssl-devel openssl
-        scl enable devtoolset-7 "make BUILD_TLS=yes"
+        scl enable devtoolset-7 "make BUILD_TLS=yes REDIS_CFLAGS='-Werror'"
     - name: testprep
       run: |
         yum -y install tcl tcltls tclx
@@ -490,7 +490,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make
+      run: make REDIS_CFLAGS='-Werror'
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
       run: ./runtest --accurate --verbose --no-latency --dump-logs ${{github.event.inputs.test_args}}

--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -13,7 +13,7 @@ then
     exit 1
 fi
 
-$MAKE -C tests/modules && \
+$MAKE -C tests/modules CFLAGS='-Werror' && \
 $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/commandfilter \
 --single unit/moduleapi/basics \

--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -13,7 +13,7 @@ then
     exit 1
 fi
 
-$MAKE -C tests/modules CFLAGS='-Werror' && \
+$MAKE -C tests/modules && \
 $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/commandfilter \
 --single unit/moduleapi/basics \

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -542,7 +542,7 @@ void clusterUpdateMyselfIp(void) {
             * duplicating the string. This way later we can check if
             * the address really changed. */
             prev_ip = zstrdup(prev_ip);
-            strncpy(myself->ip,server.cluster_announce_ip,NET_IP_STR_LEN);
+            strncpy(myself->ip,server.cluster_announce_ip,NET_IP_STR_LEN-1);
             myself->ip[NET_IP_STR_LEN-1] = '\0';
         } else {
             myself->ip[0] = '\0'; /* Force autodetection. */
@@ -2538,7 +2538,7 @@ void clusterBuildMessageHdr(clusterMsg *hdr, int type) {
      * first byte is zero, they'll do auto discovery. */
     memset(hdr->myip,0,NET_IP_STR_LEN);
     if (server.cluster_announce_ip) {
-        strncpy(hdr->myip,server.cluster_announce_ip,NET_IP_STR_LEN);
+        strncpy(hdr->myip,server.cluster_announce_ip,NET_IP_STR_LEN-1);
         hdr->myip[NET_IP_STR_LEN-1] = '\0';
     }
 


### PR DESCRIPTION
Update CI so that warnings cause build failures.

Also fix a warning in `test-sanitizer-address`:
```
In function ‘strncpy’,
   inlined from ‘clusterUpdateMyselfIp’ at cluster.c:545:13:

/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10:
error: ‘__builtin_strncpy’ specified bound 46 equals destination size [-Werror=stringop-truncation]

  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

![image](https://user-images.githubusercontent.com/22811481/142894958-345a8e98-290b-4392-ae3e-d89669329e77.png)
