### PR TITLE
Do not watch keys for dirty client

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -446,7 +446,7 @@ void watchCommand(client *c) {
         addReplyError(c,"WATCH inside MULTI is not allowed");
         return;
     }
-    /* No point in watching if the client is already dirty.*/
+    /* No point in watching if the client is already dirty. */
     if (c->flags & CLIENT_DIRTY_CAS) {
         addReply(c,shared.ok);
         return;

--- a/src/multi.c
+++ b/src/multi.c
@@ -430,6 +430,8 @@ void touchAllWatchedKeysInDb(redisDb *emptied, redisDb *replaced_with) {
             while((ln = listNext(&li))) {
                 client *c = listNodeValue(ln);
                 c->flags |= CLIENT_DIRTY_CAS;
+                /* As the client is marked as dirty, there is no point in getting here
+                 * again for others keys (or keep the memory overhead till EXEC). */
                 unwatchAllKeys(c);
             }
         }

--- a/src/multi.c
+++ b/src/multi.c
@@ -397,7 +397,9 @@ void touchWatchedKey(redisDb *db, robj *key) {
         client *c = listNodeValue(ln);
 
         c->flags |= CLIENT_DIRTY_CAS;
-        /* As the client is marked as dirty, there is no point in watching other key events. */
+        /* As the client is marked as dirty, there is no point in getting here
+         * again in case that key (or others) are modified again (or keep the
+         * memory overhead till EXEC). */
         unwatchAllKeys(c);
     }
 }

--- a/src/multi.c
+++ b/src/multi.c
@@ -388,7 +388,7 @@ void touchWatchedKey(redisDb *db, robj *key) {
 
     /* Mark all the clients watching this key as CLIENT_DIRTY_CAS */
     /* Check if we are already watching for this key */
-    while ((clients = dictFetchValue(db->watched_keys, key)) && listLength(clients) != 0) {
+    while ((clients = dictFetchValue(db->watched_keys, key))) {
         client *c = listNodeValue(listFirst(clients));
         c->flags |= CLIENT_DIRTY_CAS;
         /* As the client is marked as dirty, there is no point in watching other key events. */


### PR DESCRIPTION
Currently, the watching clients are marked as dirty when a watched key is touched, but we continue watching the keys for no reason. Then, when the same key is touched again, we iterate again on the watching clients list and mark all clients as dirty again. Only when the exec/unwatch command is issued will the client be removed from the key->watching_clients list. The same applies when a dirty client calls the WATCH command. The key will be added to be watched by the client even if it has no effect.

In the field, no performance degradation was observed as a result of the current implementation;  it is merely a cleanup with possible memory and performance gains in some situations.
