### PR TITLE
WIP: Fix abnormal compression due to out-of-control recompress

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -959,9 +959,8 @@ int rewriteListObject(rio *r, robj *key, robj *o) {
     if (o->encoding == OBJ_ENCODING_QUICKLIST) {
         quicklist *list = o->ptr;
         quicklistIter *li = quicklistGetIterator(list, AL_START_HEAD);
-        quicklistEntry entry;
 
-        while (quicklistNext(li,&entry)) {
+        while (quicklistNext(li)) {
             if (count == 0) {
                 int cmd_items = (items > AOF_REWRITE_ITEMS_PER_CMD) ?
                     AOF_REWRITE_ITEMS_PER_CMD : items;
@@ -974,13 +973,13 @@ int rewriteListObject(rio *r, robj *key, robj *o) {
                 }
             }
 
-            if (entry.value) {
-                if (!rioWriteBulkString(r,(char*)entry.value,entry.sz)) {
+            if (li->value) {
+                if (!rioWriteBulkString(r,(char*)li->value,li->sz)) {
                     quicklistReleaseIterator(li);
                     return 0;
                 }
             } else {
-                if (!rioWriteBulkLongLong(r,entry.longval)) {
+                if (!rioWriteBulkLongLong(r,li->longval)) {
                     quicklistReleaseIterator(li);
                     return 0;
                 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -147,9 +147,8 @@ void xorObjectDigest(redisDb *db, robj *keyobj, unsigned char *digest, robj *o) 
         mixStringObjectDigest(digest,o);
     } else if (o->type == OBJ_LIST) {
         listTypeIterator *li = listTypeInitIterator(o,0,LIST_TAIL);
-        listTypeEntry entry;
-        while(listTypeNext(li,&entry)) {
-            robj *eleobj = listTypeGet(&entry);
+        while(listTypeNext(li)) {
+            robj *eleobj = listTypeGet(li);
             mixStringObjectDigest(digest,eleobj);
             decrRefCount(eleobj);
         }

--- a/src/module.c
+++ b/src/module.c
@@ -187,7 +187,6 @@ struct RedisModuleKey {
     union {
         struct {
             /* List, use only if value->type == OBJ_LIST */
-            listTypeEntry entry;   /* Current entry in iteration. */
             long index;            /* Current 0-based index in iteration. */
         } list;
         struct {
@@ -3240,7 +3239,7 @@ int moduleListIteratorSeek(RedisModuleKey *key, long index, int mode) {
         /* No existing iterator. Create one. */
         key->iter = listTypeInitIterator(key->value, index, LIST_TAIL);
         serverAssert(key->iter != NULL);
-        serverAssert(listTypeNext(key->iter, &key->u.list.entry));
+        serverAssert(listTypeNext(key->iter));
         key->u.list.index = index;
         return 1;
     }
@@ -3256,7 +3255,7 @@ int moduleListIteratorSeek(RedisModuleKey *key, long index, int mode) {
     unsigned char dir = key->u.list.index < index ? LIST_TAIL : LIST_HEAD;
     listTypeSetIteratorDirection(key->iter, dir);
     while (key->u.list.index != index) {
-        serverAssert(listTypeNext(key->iter, &key->u.list.entry));
+        serverAssert(listTypeNext(key->iter));
         key->u.list.index += dir == LIST_HEAD ? -1 : 1;
     }
     return 1;
@@ -3352,7 +3351,7 @@ RedisModuleString *RM_ListPop(RedisModuleKey *key, int where) {
  */
 RedisModuleString *RM_ListGet(RedisModuleKey *key, long index) {
     if (moduleListIteratorSeek(key, index, REDISMODULE_READ)) {
-        robj *elem = listTypeGet(&key->u.list.entry);
+        robj *elem = listTypeGet(key->iter);
         robj *decoded = getDecodedObject(elem);
         decrRefCount(elem);
         autoMemoryAdd(key->ctx, REDISMODULE_AM_STRING, decoded);
@@ -3383,7 +3382,7 @@ int RM_ListSet(RedisModuleKey *key, long index, RedisModuleString *value) {
         return REDISMODULE_ERR;
     }
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
-        listTypeReplace(&key->u.list.entry, value);
+        listTypeReplace(key->iter, value);
         /* A note in quicklist.c forbids use of iterator after insert, so
          * probably also after replace. */
         listTypeReleaseIterator(key->iter);
@@ -3430,7 +3429,7 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
     }
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         int where = index < 0 ? LIST_TAIL : LIST_HEAD;
-        listTypeInsert(&key->u.list.entry, value, where);
+        listTypeInsert(key->iter, value, where);
         /* A note in quicklist.c forbids use of iterator after insert. */
         listTypeReleaseIterator(key->iter);
         key->iter = NULL;
@@ -3453,7 +3452,7 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
  */
 int RM_ListDelete(RedisModuleKey *key, long index) {
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
-        listTypeDelete(key->iter, &key->u.list.entry);
+        listTypeDelete(key->iter);
         moduleDelKeyIfEmpty(key);
         return REDISMODULE_OK;
     } else {

--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -114,22 +114,15 @@ typedef struct quicklist {
 } quicklist;
 
 typedef struct quicklistIter {
-    const quicklist *quicklist;
+    quicklist *quicklist;
     quicklistNode *current;
     unsigned char *zi;
     long offset; /* offset in current listpack */
     int direction;
-} quicklistIter;
-
-typedef struct quicklistEntry {
-    const quicklist *quicklist;
-    quicklistNode *node;
-    unsigned char *zi;
     unsigned char *value;
     long long longval;
     size_t sz;
-    int offset;
-} quicklistEntry;
+} quicklistIter;
 
 #define QUICKLIST_HEAD 0
 #define QUICKLIST_TAIL -1
@@ -163,25 +156,18 @@ void quicklistPush(quicklist *quicklist, void *value, const size_t sz,
                    int where);
 void quicklistAppendListpack(quicklist *quicklist, unsigned char *zl);
 void quicklistAppendPlainNode(quicklist *quicklist, unsigned char *data, size_t sz);
-void quicklistInsertAfter(quicklist *quicklist, quicklistEntry *entry,
-                          void *value, const size_t sz);
-void quicklistInsertBefore(quicklist *quicklist, quicklistEntry *entry,
-                           void *value, const size_t sz);
-void quicklistDelEntry(quicklistIter *iter, quicklistEntry *entry);
-void quicklistReplaceEntry(quicklist *quicklist, quicklistEntry *entry,
-                           void *data, size_t sz);
-int quicklistReplaceAtIndex(quicklist *quicklist, long index, void *data,
-                            const size_t sz);
+void quicklistInsertAfter(quicklistIter *entry, void *value, const size_t sz);
+void quicklistInsertBefore(quicklistIter *entry, void *value, const size_t sz);
+void quicklistDelEntry(quicklistIter *iter);
+void quicklistReplaceEntry(quicklistIter *iter, void *data, size_t sz);
+int quicklistReplaceAtIndex(quicklist *quicklist, long index, void *data, const size_t sz);
 int quicklistDelRange(quicklist *quicklist, const long start, const long stop);
-quicklistIter *quicklistGetIterator(const quicklist *quicklist, int direction);
-quicklistIter *quicklistGetIteratorAtIdx(const quicklist *quicklist,
-                                         int direction, const long long idx);
-int quicklistNext(quicklistIter *iter, quicklistEntry *entry);
+quicklistIter *quicklistGetIterator(quicklist *quicklist, int direction);
+quicklistIter *quicklistGetIteratorAtIdx(quicklist *quicklist, int direction, const long long idx);
+int quicklistNext(quicklistIter *iter);
 void quicklistSetDirection(quicklistIter *iter, int direction);
 void quicklistReleaseIterator(quicklistIter *iter);
 quicklist *quicklistDup(quicklist *orig);
-int quicklistIndex(const quicklist *quicklist, const long long index,
-                   quicklistEntry *entry);
 void quicklistRotate(quicklist *quicklist);
 int quicklistPopCustom(quicklist *quicklist, int where, unsigned char **data,
                        size_t *sz, long long *sval,
@@ -189,7 +175,7 @@ int quicklistPopCustom(quicklist *quicklist, int where, unsigned char **data,
 int quicklistPop(quicklist *quicklist, int where, unsigned char **data,
                  size_t *sz, long long *slong);
 unsigned long quicklistCount(const quicklist *ql);
-int quicklistCompare(quicklistEntry *entry, unsigned char *p2, const size_t p2_len);
+int quicklistCompare(quicklistIter *entry, unsigned char *p2, const size_t p2_len);
 size_t quicklistGetLzf(const quicklistNode *node, void **data);
 void quicklistRepr(unsigned char *ql, int full);
 

--- a/src/server.h
+++ b/src/server.h
@@ -1946,12 +1946,6 @@ typedef struct {
     quicklistIter *iter;
 } listTypeIterator;
 
-/* Structure for an entry while iterating over a list. */
-typedef struct {
-    listTypeIterator *li;
-    quicklistEntry entry; /* Entry in quicklist */
-} listTypeEntry;
-
 /* Structure to hold set iteration abstraction. */
 typedef struct {
     robj *subject;
@@ -2202,12 +2196,12 @@ unsigned long listTypeLength(const robj *subject);
 listTypeIterator *listTypeInitIterator(robj *subject, long index, unsigned char direction);
 void listTypeReleaseIterator(listTypeIterator *li);
 void listTypeSetIteratorDirection(listTypeIterator *li, unsigned char direction);
-int listTypeNext(listTypeIterator *li, listTypeEntry *entry);
-robj *listTypeGet(listTypeEntry *entry);
-void listTypeInsert(listTypeEntry *entry, robj *value, int where);
-void listTypeReplace(listTypeEntry *entry, robj *value);
-int listTypeEqual(listTypeEntry *entry, robj *o);
-void listTypeDelete(listTypeIterator *iter, listTypeEntry *entry);
+int listTypeNext(listTypeIterator *li);
+robj *listTypeGet(listTypeIterator *li);
+void listTypeInsert(listTypeIterator *li, robj *value, int where);
+void listTypeReplace(listTypeIterator *li, robj *value);
+int listTypeEqual(listTypeIterator *li, robj *o);
+void listTypeDelete(listTypeIterator *li);
 robj *listTypeDup(robj *o);
 int listTypeDelRange(robj *o, long start, long stop);
 void unblockClientWaitingData(client *c);

--- a/src/sort.c
+++ b/src/sort.c
@@ -359,13 +359,12 @@ void sortCommandGeneric(client *c, int readonly) {
          * way, just getting the required range, as an optimization. */
         if (end >= start) {
             listTypeIterator *li;
-            listTypeEntry entry;
             li = listTypeInitIterator(sortval,
                     desc ? (long)(listTypeLength(sortval) - start - 1) : start,
                     desc ? LIST_HEAD : LIST_TAIL);
 
-            while(j < vectorlen && listTypeNext(li,&entry)) {
-                vector[j].obj = listTypeGet(&entry);
+            while(j < vectorlen && listTypeNext(li)) {
+                vector[j].obj = listTypeGet(li);
                 vector[j].u.score = 0;
                 vector[j].u.cmpobj = NULL;
                 j++;
@@ -377,9 +376,8 @@ void sortCommandGeneric(client *c, int readonly) {
         }
     } else if (sortval->type == OBJ_LIST) {
         listTypeIterator *li = listTypeInitIterator(sortval,0,LIST_TAIL);
-        listTypeEntry entry;
-        while(listTypeNext(li,&entry)) {
-            vector[j].obj = listTypeGet(&entry);
+        while(listTypeNext(li)) {
+            vector[j].obj = listTypeGet(li);
             vector[j].u.score = 0;
             vector[j].u.cmpobj = NULL;
             j++;

--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -1,3 +1,39 @@
+proc generate_cmd_on_list_key {key} {
+    set op [randomInt 7]
+    set small_signed_count [expr 5-[randomInt 10]]
+    if {[randomInt 2] == 0} {
+        set ele [randomInt 1000]
+    } else {
+        set ele [string repeat x [randomInt 10000]][randomInt 1000]
+    }
+    switch $op {
+        0 {return "lpush $key $ele"}
+        1 {return "rpush $key $ele"}
+        2 {return "lpop $key"}
+        3 {return "rpop $key"}
+        4 {
+            return "lset $key $small_signed_count $ele"
+        }
+        5 {
+            set otherele [randomInt 1000]
+            if {[randomInt 2] == 0} {
+                set where before
+            } else {
+                set where after
+            }
+            return "linsert $key $where $otherele $ele"
+        }
+        6 {
+            set otherele ""
+            catch {
+                set index [randomInt [r llen $key]]
+                set otherele [r lindex $key $index]
+            }
+            return "lrem $key 1 $otherele"
+        }
+    }
+}
+
 start_server {
     tags {"list ziplist"}
     overrides {
@@ -38,7 +74,24 @@ start_server {
         r rpush key [string repeat e 5000]
         r linsert key before f 1
         r rpush key g
-   }
+        r ping
+    }
+
+    test {Crash due to wrongly recompress after lrem} {
+        r del key
+        config_set list-compress-depth 2
+        r lpush key a
+        r lpush key [string repeat a 5000]
+        r lpush key [string repeat b 5000]
+        r lpush key [string repeat c 5000]
+        r rpush key [string repeat x 10000]"969"
+        r rpush key b
+        r lrem key 1 a
+        r rpop key 
+        r lrem key 1 [string repeat x 10000]"969"
+        r rpush key crash
+        r ping
+    }
 
 foreach comp {2 1 0} {
     set cycles 1000
@@ -47,39 +100,42 @@ foreach comp {2 1 0} {
     
     test "Stress tester for #3343-alike bugs comp: $comp" {
         r del key
+        set sent {}
+        set print_commands false
         for {set j 0} {$j < $cycles} {incr j} {
-            set op [randomInt 7]
-            set small_signed_count [expr 5-[randomInt 10]]
-            if {[randomInt 2] == 0} {
-                set ele [randomInt 1000]
-            } else {
-                set ele [string repeat x [randomInt 10000]][randomInt 1000]
-            }
-            switch $op {
-                0 {r lpush key $ele}
-                1 {r rpush key $ele}
-                2 {r lpop key}
-                3 {r rpop key}
-                4 {
-                    catch {r lset key $small_signed_count $ele}
-                }
-                5 {
-                    set otherele [randomInt 1000]
-                    if {[randomInt 2] == 0} {
-                        set where before
-                    } else {
-                        set where after
-                    }
-                    r linsert key $where $otherele $ele
-                }
-                6 {
-                    set index [randomInt [r llen key]]
-                    set otherele [r lindex key $index]
-                    r lrem key 1 $otherele
+            if {[catch {
+                set cmd [generate_cmd_on_list_key key]
+                lappend sent $cmd
+
+                # execute the command, we expect commands to fail on syntax errors
+                r {*}$cmd
+            }]} {
+                if {[count_log_message 0 "crashed by signal"] != 0 || [count_log_message 0 "ASSERTION FAILED"] != 0} {
+                    puts "Server crashed"
+                    set print_commands true
+                    break
                 }
             }
         }
-    }
+
+        # check valgrind and asan report for invalid reads after execute
+        # command so that we have a report that is easier to reproduce
+        set valgrind_errors [find_valgrind_errors [srv 0 stderr] false]
+        set asan_errors [sanitizer_errors_from_file [srv 0 stderr]]
+        if {$valgrind_errors != "" || $asan_errors != ""} {
+            puts "valgrind or asan found an issue"
+            set print_commands true
+        }
+
+        if {$print_commands} {
+            puts "violating commands:"
+            foreach cmd $sent {
+                puts $cmd
+            }
+        }
+
+        r ping
+    } {PONG} {external:skip}
 } ;# foreach comp
 
     tags {slow} {


### PR DESCRIPTION
This pr is following #9779 .

## Describe of feature
Now when we turn on the `list-compress-depth` configuration, the list will compress the ziplist between `[list-compress-depth, -list-compress-depth]`.
When we need to use the compressed data, we will first decompress it, then use it, and finally compress it again.
It's controlled by `quicklistNode->recompress`, which is designed to avoid the need to re-traverse the entire quicklist for compression after each decompression, we only need to recompress the quicklsitNode being used.
In order to ensure the correctness of recompressing, we should normally let quicklistDecompressNodeForUse and quicklistCompress appear in pairs, otherwise, it may lead to the head and tail being compressed or the middle ziplist not being compressed correctly, which is exactly the problem this pr needs to solve.

## Solution
1. Reset `quicklistIter` after insert and replace.
    The compression will be updated correctly in quicklistInsertAfter,
    quicklistInsertBefore, quicklistReplaceAtIndex, so we can safely reset the quicklistIter to avoid it being used again
2. `quicklistIndex` will return an iterator that can be used to recompress the current node after use.
    
## Test
1. In the `Stress Tester for #3343-Similar Errors` test, when the server crashes or when `valgrind` or `asan` error is detected, print violating commands.
2. Add a crash test due to wrongly recompressing after `lrem`.
3. Remove `insert before with 0 elements` and `insert after with 0 elements`, 
    Now we forbid any operation on an NULL quicklistIter.
# TODO
- [ ] benchmark
- [ ] more test