### PR TITLE
Wait for `asyn_loading` to stop in `short read` test

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -688,8 +688,11 @@ test {diskless loading short read} {
                     }
                     $master exec
                 }
+
                 # wait for loading to stop (fail)
+                # After a loading successfully, next loop will enter `async_loading`
                 wait_for_condition 1000 1 {
+                    [s -1 async_loading] eq 0 &&
                     [s -1 loading] eq 0
                 } else {
                     fail "Replica didn't disconnect"

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -114,8 +114,11 @@ tags "modules" {
                             }
                             $master exec
                         }
+
                         # wait for loading to stop (fail)
+                        # After a loading successfully, next loop will enter `async_loading`
                         wait_for_condition 1000 1 {
+                            [s -1 async_loading] eq 0 &&
                             [s -1 loading] eq 0
                         } else {
                             fail "Replica didn't disconnect"


### PR DESCRIPTION
In #9323, when `repl-diskless-load` is enabled and set to `swapdb`,
if the master replication ID hasn't changed, we can load data-set
asynchronously, and serving read commands during the full resync.

In `diskless loading short read` test, after a loading successfully,
we will wait for the loading to stop and continue the for loop.

After the introduction of `async_loading`, we also need to check it.
Otherwise the next loop will start too soon, may trigger a timing issue.