### PR TITLE
Fix COMMAND GETKEYS on LCS

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1861,31 +1861,6 @@ int georadiusGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysRes
     return num;
 }
 
-/* LCS ... [KEYS <key1> <key2>] ... */
-int lcsGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
-    int i;
-    int *keys = getKeysPrepareResult(result, 2);
-    UNUSED(cmd);
-
-    /* We need to parse the options of the command in order to check for the
-     * "KEYS" argument before the "STRINGS" argument. */
-    for (i = 1; i < argc; i++) {
-        char *arg = argv[i]->ptr;
-        int moreargs = (argc-1) - i;
-
-        if (!strcasecmp(arg, "strings")) {
-            break;
-        } else if (!strcasecmp(arg, "keys") && moreargs >= 2) {
-            keys[0] = i+1;
-            keys[1] = i+2;
-            result->numkeys = 2;
-            return result->numkeys;
-        }
-    }
-    result->numkeys = 0;
-    return result->numkeys;
-}
-
 /* XREAD [BLOCK <milliseconds>] [COUNT <count>] [GROUP <groupname> <ttl>]
  *       STREAMS key_1 key_2 ... key_N ID_1 ID_2 ... ID_N */
 int xreadGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {

--- a/src/server.c
+++ b/src/server.c
@@ -2023,8 +2023,7 @@ struct redisCommand redisCommandTable[] = {
      "read-only @string",
       {{"read",
         KSPEC_BS_INDEX,.bs.index={1},
-        KSPEC_FK_RANGE,.fk.range={1,1,0}}},
-     lcsGetKeys},
+        KSPEC_FK_RANGE,.fk.range={1,1,0}}}},
 
     {"quit",quitCommand,-1,
      "no-auth no-script ok-stale ok-loading fast @connection"},

--- a/src/server.h
+++ b/src/server.h
@@ -2691,7 +2691,6 @@ int sortGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *
 int migrateGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 int georadiusGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 int xreadGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
-int lcsGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 int lmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 int blmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 int zmpopGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -97,6 +97,10 @@ start_server {tags {"introspection"}} {
         assert_equal {} [r command getkeys eval "return 1" 0]
     }
 
+    test {COMMAND GETKEYS LCS} {
+        assert_equal {key1 key2} [r command getkeys lcs key1 key2]
+    }
+
     test "COMMAND LIST FILTERBY ACLCAT" {
         set reply [r command list filterby aclcat hyperloglog]
         assert_equal [lsort $reply] {pfadd pfcount pfdebug pfmerge pfselftest}


### PR DESCRIPTION
Remove `lcsGetKeys` to clean up the remaining `Stralgo` after #9733.

Before:
```sh
$ command getkeys lcs keys a b
1) "a"
2) "b"

$ command getkeys lcs a b
(error) ERR Invalid arguments specified for command
```

After:
```
$ command getkeys lcs keys a b
1) "keys"
2) "a"

$ command getkeys lcs a b
1) "a"
2) "b"
```