### PR TITLE
Fix CLIENT KILL kill all clients with id 0

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2741,10 +2741,11 @@ NULL
                 int moreargs = c->argc > i+1;
 
                 if (!strcasecmp(c->argv[i]->ptr,"id") && moreargs) {
-                    long long tmp;
+                    long tmp;
 
-                    if (getLongLongFromObjectOrReply(c,c->argv[i+1],&tmp,NULL)
-                        != C_OK) return;
+                    if (getRangeLongFromObjectOrReply(c, c->argv[i+1], 1, LONG_MAX, &tmp,
+                                                      "client-id should be greater than 0") != C_OK)
+                        return;
                     id = tmp;
                 } else if (!strcasecmp(c->argv[i]->ptr,"type") && moreargs) {
                     type = getClientTypeByName(c->argv[i+1]->ptr);
@@ -2772,6 +2773,11 @@ NULL
                         skipme = 0;
                     } else {
                         addReplyErrorObject(c,shared.syntaxerr);
+                        return;
+                    }
+
+                    if (c->argc == 4) {
+                        addReplyError(c, "The skipme parameter cannot be used alone");
                         return;
                     }
                 } else {

--- a/src/networking.c
+++ b/src/networking.c
@@ -2775,11 +2775,6 @@ NULL
                         addReplyErrorObject(c,shared.syntaxerr);
                         return;
                     }
-
-                    if (c->argc == 4) {
-                        addReplyError(c, "The skipme parameter cannot be used alone");
-                        return;
-                    }
                 } else {
                     addReplyErrorObject(c,shared.syntaxerr);
                     return;

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -13,6 +13,23 @@ start_server {tags {"introspection"}} {
         r client info
     } {*addr=*:* fd=* age=* idle=* flags=N db=* sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client*}
 
+    test {CLIENT KILL with illegal arguments} {
+        assert_error "ERR wrong number*" {r client kill}
+        assert_error "ERR syntax error*" {r client kill id 10 wrong_arg}
+
+        assert_error "ERR*greater than 0*" {r client kill id str}
+        assert_error "ERR*greater than 0*" {r client kill id -1}
+        assert_error "ERR*greater than 0*" {r client kill id 0}
+
+        assert_error "ERR Unknown client type*" {r client kill type wrong_type}
+
+        assert_error "ERR No such user*" {r client kill user wrong_user}
+
+        assert_error "ERR syntax error*" {r client kill skipme yes_or_no}
+        assert_error "ERR*skipme*" {r client kill skipme yes}
+        assert_error "ERR*skipme*" {r client kill skipme no}
+    }
+
     test {MONITOR can log executed commands} {
         set rd [redis_deferring_client]
         $rd monitor

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -33,6 +33,7 @@ start_server {tags {"introspection"}} {
         set rd1 [redis_deferring_client]
         set rd2 [redis_deferring_client]
         set connected_clients [s connected_clients]
+        assert {$connected_clients >= 3}
         set res [r client kill skipme yes]
         assert {$res == $connected_clients - 1}
 
@@ -40,6 +41,7 @@ start_server {tags {"introspection"}} {
         set rd3 [redis_deferring_client]
         set rd4 [redis_deferring_client]
         set connected_clients [s connected_clients]
+        assert {$connected_clients == 3}
         set res [r client kill skipme no]
         assert_equal $res $connected_clients
 


### PR DESCRIPTION
CLIENT KILL with ID argument should only kill the client
with the provided ID. In old code, CLIENT KILL with id 0
will kill all the connected clients.

This commit adds an input check to avoid this situation.
Adds some tests to ensure that the behavior is as expected.

Refresh #3235