### PR TITLE
Add range check for server port in redis-cli/benchmark

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1446,6 +1446,10 @@ int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"-p")) {
             if (lastarg) goto invalid;
             config.conn_info.hostport = atoi(argv[++i]);
+            if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {
+                fprintf(stderr, "Invalid server port.\n");
+                exit(1);
+            }
         } else if (!strcmp(argv[i],"-s")) {
             if (lastarg) goto invalid;
             config.hostsocket = strdup(argv[++i]);
@@ -1459,6 +1463,10 @@ int parseOptions(int argc, char **argv) {
             config.conn_info.user = sdsnew(argv[++i]);
         } else if (!strcmp(argv[i],"-u") && !lastarg) {
             parseRedisUri(argv[++i],"redis-benchmark",&config.conn_info,&config.tls);
+            if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {
+                fprintf(stderr, "Invalid server port.\n");
+                exit(1);
+            }
             config.input_dbnumstr = sdsfromlonglong(config.conn_info.input_dbnum);
         } else if (!strcmp(argv[i],"-3")) {
             config.resp3 = 1;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1961,6 +1961,10 @@ static int parseOptions(int argc, char **argv) {
             config.stdin_tag_name = argv[++i];
         } else if (!strcmp(argv[i],"-p") && !lastarg) {
             config.conn_info.hostport = atoi(argv[++i]);
+            if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {
+                fprintf(stderr, "Invalid server port.\n");
+                exit(1);
+            }
         } else if (!strcmp(argv[i],"-s") && !lastarg) {
             config.hostsocket = argv[++i];
         } else if (!strcmp(argv[i],"-r") && !lastarg) {
@@ -1982,6 +1986,10 @@ static int parseOptions(int argc, char **argv) {
             config.conn_info.user = sdsnew(argv[++i]);
         } else if (!strcmp(argv[i],"-u") && !lastarg) {
             parseRedisUri(argv[++i],"redis-cli",&config.conn_info,&config.tls);
+            if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {
+                fprintf(stderr, "Invalid server port.\n");
+                exit(1);
+            }
         } else if (!strcmp(argv[i],"--raw")) {
             config.output = OUTPUT_RAW;
         } else if (!strcmp(argv[i],"--no-raw")) {


### PR DESCRIPTION
Validating inputs ahead of time, to give the end user a slightly more useful error.

before:
```
[root@binblog redis]# src/redis-benchmark -p 888888
Could not connect to Redis at 127.0.0.1:888888: Connection refused
WARNING: Could not fetch server CONFIG
^C
[root@binblog redis]# src/redis-cli -p 688888
Could not connect to Redis at 127.0.0.1:688888: Connection refused
not connected>

[root@binblog redis]# src/redis-benchmark -u redis://127.0.0.1:80000/10
Could not connect to Redis at 127.0.0.1:80000: Connection refused
WARNING: Could not fetch server CONFIG
^C
[root@binblog redis]# src/redis-cli -u redis://127.0.0.1:80000/10
Could not connect to Redis at 127.0.0.1:80000: Connection refused
not connected>
```

after:
```
[root@binblog redis]# src/redis-benchmark -p -100
Invalid server port.
[root@binblog redis]# src/redis-cli -p 688888
Invalid server port.

[root@binblog redis]# src/redis-cli -u redis://127.0.0.1:80000/10
Invalid server port.
[root@binblog redis]# src/redis-benchmark -u redis://127.0.0.1:80000/10
Invalid server port.
```

see https://github.com/redis/redis/pull/5545