### PR TITLE
Improve stability in some blocking command tests

### DIFF
--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -815,6 +815,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
                 set rd2 [redis_deferring_client]
                 r del blist{t} target{t}
                 $rd2 blpop target{t} 0
+                wait_for_blocked_clients_count 1
                 $rd blmove blist{t} target{t} $wherefrom $whereto 0
                 wait_for_blocked_clients_count 2
                 r rpush blist{t} foo
@@ -891,8 +892,11 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         r del blist{t} blist2{t}
 
         $rd1 blmpop 0 2 blist{t} blist2{t} left count 1
+        wait_for_blocked_clients_count 1
         $rd2 blmpop 0 2 blist{t} blist2{t} right count 10
+        wait_for_blocked_clients_count 2
         $rd3 blmpop 0 2 blist{t} blist2{t} left count 10
+        wait_for_blocked_clients_count 3
         $rd4 blmpop 0 2 blist{t} blist2{t} right count 1
         wait_for_blocked_clients_count 4
 
@@ -920,6 +924,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
       r del list1{t} list2{t} list3{t}
 
       $rd1 blmove list1{t} list2{t} right left 0
+      wait_for_blocked_clients_count 1
       $rd2 blmove list2{t} list3{t} left right 0
       wait_for_blocked_clients_count 2
 
@@ -939,6 +944,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
       r del list1{t} list2{t}
 
       $rd1 brpoplpush list1{t} list2{t} 0
+      wait_for_blocked_clients_count 1
       $rd2 brpoplpush list2{t} list1{t} 0
       wait_for_blocked_clients_count 2
 

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1978,8 +1978,11 @@ start_server {tags {"zset"}} {
         r del myzset{t} myzset2{t}
 
         $rd1 bzmpop 0 2 myzset{t} myzset2{t} min count 1
+        wait_for_blocked_clients_count 1
         $rd2 bzmpop 0 2 myzset{t} myzset2{t} max count 10
+        wait_for_blocked_clients_count 2
         $rd3 bzmpop 0 2 myzset{t} myzset2{t} min count 10
+        wait_for_blocked_clients_count 3
         $rd4 bzmpop 0 2 myzset{t} myzset2{t} max count 1
         wait_for_blocked_clients_count 4
 


### PR DESCRIPTION
In order to test the situation where multiple clients are
blocked, we set up multiple clients to execute some blocking
commands. These tests depend on the order of command processing.

Those tests are based on the wrong assumption that the command
send first will be executed by the server first, which is obviously
wrong in some network delyas.

This commit ensures orderly execution of commands by waiting
and judging the number of blocked clients each time.

Fix #9850