### PR TITLE
fixed mem leak on rdb load error

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2785,7 +2785,10 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi, redisDb *dbarray) {
              * An AUX field is composed of two strings: key and value. */
             robj *auxkey, *auxval;
             if ((auxkey = rdbLoadStringObject(rdb)) == NULL) goto eoferr;
-            if ((auxval = rdbLoadStringObject(rdb)) == NULL) goto eoferr;
+            if ((auxval = rdbLoadStringObject(rdb)) == NULL) {
+                decrRefCount(auxkey);
+                goto eoferr;
+            }
 
             if (((char*)auxkey->ptr)[0] == '%') {
                 /* All the fields with a name staring with '%' are considered


### PR DESCRIPTION
A rare case of short read that can happen when breaking the master-replica
connection on diskless load mode.

Found by Valgrind:

==32418== 523 (320 direct, 203 indirect) bytes in 20 blocks are definitely lost in loss record 1,564 of 1,685
==32418==    at 0x4C32FB5: malloc (vg_replace_malloc.c:380)
==32418==    by 0x159C73: ztrymalloc_usable (zmalloc.c:101)
==32418==    by 0x159CD6: zmalloc (zmalloc.c:119)
==32418==    by 0x16E986: createObject (object.c:42)
==32418==    by 0x16EC69: tryCreateRawStringObject (object.c:130)
==32418==    by 0x1820DB: rdbGenericLoadStringObject (rdb.c:549)
==32418==    by 0x1821B6: rdbLoadStringObject (rdb.c:563)
==32418==    by 0x188268: rdbLoadRio (rdb.c:2517)
==32418==    by 0x17C4D4: readSyncBulkPayload (replication.c:1755)
==32418==    by 0x222626: callHandler (connhelpers.h:79)
==32418==    by 0x222CB2: connSocketEventHandler (connection.c:295)
==32418==    by 0x145409: aeProcessEvents (ae.c:427)
==32418==