### PR TITLE
fix deprecation of _BSD_SOURCE feature test macro

### DIFF
--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -103,7 +103,7 @@
  *
  */
 
-#define _BSD_SOURCE     /* For fchmod() */
+#define _DEFAULT_SOURCE /* For fchmod() */
 #include <termios.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -104,6 +104,7 @@
  */
 
 #define _DEFAULT_SOURCE /* For fchmod() */
+#define _BSD_SOURCE     /* For fchmod() */
 #include <termios.h>
 #include <unistd.h>
 #include <stdlib.h>


### PR DESCRIPTION
caused a build warning in linenoise since glibc 2.20:
```
MAKE linenoise
cd linenoise && make
make[3]: Entering directory '/home/yoav/redis/deps/linenoise'
cc  -Wall -Os -g  -c linenoise.c
In file included from /usr/include/termios.h:25,
                 from linenoise.c:107:
/usr/include/features.h:187:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
  187 | # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
      |   ^~~~~~~
make[3]: Leaving directory '/home/yoav/redis/deps/linenoise'
MAKE lua
```