### PR TITLE
rdbSaveLzfStringObject function only called by rdbSaveRawString.in rd…

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -362,8 +362,6 @@ ssize_t rdbSaveLzfStringObject(rio *rdb, unsigned char *s, size_t len) {
     size_t comprlen, outlen;
     void *out;
 
-    /* We require at least four bytes compression for this to be worth it */
-    if (len <= 4) return 0;
     outlen = len-4;
     if ((out = zmalloc(outlen+1)) == NULL) return 0;
     comprlen = lzf_compress(s, len, out, outlen);


### PR DESCRIPTION
rdbSaveLzfStringObject function only called by rdbSaveRawString.in rdbSaveRawString has the condition len > 20, so Judgment length < 4 is no need;
![image](https://user-images.githubusercontent.com/60819151/143872234-ed3e2144-4261-4d53-84c1-fc571a618570.png)
