### PR TITLE
change CI to run sentinel and cluster tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,19 @@ on: [push, pull_request]
 
 jobs:
 
+  test-ubuntu-latest-cluster:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      # Fail build if there are warnings
+      # build with TLS just for compilation coverage
+      run: make REDIS_CFLAGS='-Werror' BUILD_TLS=yes
+    - name: cluster tests
+      run: |
+        sudo apt-get install tcl8.6 tclx
+        ./runtest-cluster
+
   test-ubuntu-latest:
     runs-on: ubuntu-latest
     steps:
@@ -20,8 +33,6 @@ jobs:
       run: ./runtest-moduleapi --verbose --dump-logs
     - name: sentinel tests
       run: ./runtest-sentinel
-    - name: cluster tests
-      run: ./runtest-cluster
 
   test-sanitizer-address:
     runs-on: ubuntu-latest
@@ -37,8 +48,6 @@ jobs:
         run: ./runtest-moduleapi --verbose --dump-logs
       - name: sentinel tests
         run: ./runtest-sentinel
-      - name: cluster tests
-        run: ./runtest-cluster
 
   build-debian-old:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
         ./runtest --verbose --tags -slow --dump-logs
     - name: module api test
       run: ./runtest-moduleapi --verbose --dump-logs
+    - name: sentinel tests
+      run: ./runtest-sentinel
+    - name: cluster tests
+      run: ./runtest-cluster
 
   test-sanitizer-address:
     runs-on: ubuntu-latest
@@ -31,6 +35,10 @@ jobs:
         run: ./runtest --verbose --tags -slow --dump-logs
       - name: module api test
         run: ./runtest-moduleapi --verbose --dump-logs
+      - name: sentinel tests
+        run: ./runtest-sentinel
+      - name: cluster tests
+        run: ./runtest-cluster
 
   build-debian-old:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It is benefit to add sentinel and cluster test in CI part, we could avoid some running error in Daily schedule. 
There is no too much CI time added.

![image](https://user-images.githubusercontent.com/51993843/144093516-2f21016a-c4d3-477f-8248-2b4f8c59e6ce.png)


For sentinel part, it takes 3 mins to test.
For cluster part, it takes less than 9 mins.