### PR TITLE
reset resize_db and current_db when exceed server db number

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -186,12 +186,13 @@ void activeExpireCycle(int type) {
         /* Expired and checked in a single loop. */
         unsigned long expired, sampled;
 
-        redisDb *db = server.db+(current_db % server.dbnum);
+        redisDb *db = server.db+current_db;
 
         /* Increment the DB now so we are sure if we run out of time
          * in the current DB we'll restart from the next. This allows to
          * distribute the time evenly across DBs. */
         current_db++;
+        current_db %= server.dbnum;
 
         /* Continue to expire if at the end of the cycle there are still
          * a big percentage of keys to expire, compared to the number of keys

--- a/src/server.c
+++ b/src/server.c
@@ -2867,8 +2867,9 @@ void databasesCron(void) {
 
         /* Resize */
         for (j = 0; j < dbs_per_call; j++) {
-            tryResizeHashTables(resize_db % server.dbnum);
+            tryResizeHashTables(resize_db);
             resize_db++;
+            resize_db %= server.dbnum;
         }
 
         /* Rehash */


### PR DESCRIPTION
Currently, `current_db` and `resize_db` are both `unsigned int`. When updating in each loop, the value for them may overflow `unsigned int`. We need to reset `current_db` and `resize_db` when needed.