### PR TITLE
Fix timing issue in unit/pause test

### DIFF
--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -73,8 +73,8 @@ start_server {tags {"pause network"}} {
         $rd MULTI
         assert_equal [$rd read] "OK"
         $rd SET FOO BAR
-        r client PAUSE 100000000 WRITE
         assert_equal [$rd read] "QUEUED"
+        r client PAUSE 100000000 WRITE
         $rd EXEC
         wait_for_blocked_clients_count 1 50 100
         r client unpause 


### PR DESCRIPTION
Change the order of these statements form
```
        $rd SET FOO BAR
        r client PAUSE 100000000 WRITE
        assert_equal [$rd read] "QUEUED"
```
to
``` 
        $rd SET FOO BAR
        assert_equal [$rd read] "QUEUED"
        r client PAUSE 100000000 WRITE
```
This ensures `r client PAUSE 100000000 WRITE` is  executed after `$rd SET FOO BAR`.