### PR TITLE
Fix a harmless bug when using monitor in redis-cli with wrong reply

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1347,6 +1347,9 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
             do {
                 if (cliReadReply(output_raw) != REDIS_OK) exit(1);
                 fflush(stdout);
+
+                if (config.last_cmd_type == REDIS_REPLY_ERROR)
+                    config.monitor_mode = 0;
             } while(config.monitor_mode);
             zfree(argvlen);
             return REDIS_OK;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1348,6 +1348,7 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
                 if (cliReadReply(output_raw) != REDIS_OK) exit(1);
                 fflush(stdout);
 
+                /* This happens when the MONITOR command returns an error. */
                 if (config.last_cmd_type == REDIS_REPLY_ERROR)
                     config.monitor_mode = 0;
             } while(config.monitor_mode);


### PR DESCRIPTION
When we use monitor in redis-cli but encounter an error reply,
we will get stuck until we press Ctrl-C to quit.

This is a harmless bug. It might be useful if we add parameters
to monitor in the future, suck as monitoring only selected db.

before:
```
127.0.0.1:6379> monitor wrong
(error) ERR wrong number of arguments for 'monitor' command or subcommand
^C(9.98s)
127.0.0.1:6379>
```

after:
```
127.0.0.1:6379> monitor wrong
(error) ERR wrong number of arguments for 'monitor' command or subcommand
127.0.0.1:6379>
```