### PR TITLE
Add the READONLY command as a prefix to redis-benchmark

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -667,6 +667,13 @@ proc resume_process pid {
     exec kill -SIGCONT $pid
 }
 
+# Get the command stats for a given index
+proc cmdistat {index cmd} {
+    if {[regexp "\r\ncmdstat_$cmd:(.*?)\r\n" [R $index info commandstats] _ value]} {
+        set _ $value
+    }
+}
+
 proc cmdrstat {cmd r} {
     if {[regexp "\r\ncmdstat_$cmd:(.*?)\r\n" [$r info commandstats] _ value]} {
         set _ $value

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -103,6 +103,7 @@ set ::all_tests {
     unit/cluster/slot-ownership
     unit/cluster/links
     unit/cluster/cluster-response-tls
+    unit/cluster/redis-benchmark
 }
 # Index to the next test to run in the ::all_tests list.
 set ::next_test 0

--- a/tests/unit/cluster/redis-benchmark.tcl
+++ b/tests/unit/cluster/redis-benchmark.tcl
@@ -1,0 +1,55 @@
+source tests/support/benchmark.tcl
+
+proc run_benchmark {cmd} {
+    if {[catch { exec {*}$cmd } error]} {
+        set first_line [lindex [split $error "\n"] 0]
+        puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
+        fail "redis-benchmark non zero code. first line: $first_line"
+    }
+}
+
+proc cmd_count {cmd_stats} {
+    if {[regexp {^calls=([0-9]+?),(.*?)$} $cmd_stats _ value]} {
+        set _ $value
+    }
+}
+
+start_cluster 2 2 {tags {external:skip cluster}} {
+
+    set seed_host [srv 0 host]
+    set seed_port [srv 0 port]
+
+    test {Readonly parameter sends requests to primaries and replicas} {
+        set cmd [redisbenchmark $seed_host $seed_port "--cluster --readonly -n 120 -t get,set"]
+        run_benchmark $cmd
+
+        set total_get_cmds 0
+        set total_set_cmds 0
+
+        for { set i 0}  {$i < 4} {incr i} {
+            set get_cmd_stats [cmdistat $i get]
+            assert_match "*,failed_calls=0" $get_cmd_stats
+
+            set num_get_cmds [cmd_count $get_cmd_stats]
+            set total_get_cmds [expr $total_get_cmds + $num_get_cmds]
+
+            # Since redis-benchmark doesn't nessecarily send an equal number of commands to each
+            # node in the cluster we need to assert on a range here
+            assert {$num_get_cmds > 0}
+
+            set set_cmd_stats [cmdistat $i set]
+            assert_match "*,failed_calls=0" $set_cmd_stats
+
+            set num_set_cmds [cmd_count $set_cmd_stats]
+            assert {$num_set_cmds > 0}
+
+            if {[getInfoProperty [R $i info replication] role] == "master"} {
+                set total_set_cmds [expr $total_set_cmds + $num_set_cmds]
+            }
+        }
+
+        assert {$total_get_cmds == 120}
+        assert {$total_set_cmds == 120}
+    }
+
+}


### PR DESCRIPTION
Adds support for the READONLY command to redis-benchmark through the `--readonly` command line argument. 

When the `--readonly` flag is set the READONLY command is sent as a prefix by the client before any other commands are sent to redis. This enables benchmarking read workloads where replicas handle part of the load.

Additionally, I've updated the cluster discover method `fetchClusterConfiguration` to add replicas to the list of `clusterNodes` if the readonly flag has been set. This ensures that commands get sent to the replicas as well as the primaries. Commands will only be sent to replicas if the command is a read command.