### PR TITLE
Oprdbsavelen

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -165,8 +165,8 @@ int rdbSaveLen(rio *rdb, uint64_t len) {
     size_t nwritten;
 
     if (len < (1<<6)) {
-        /* Save a 6 bit len */
-        buf[0] = (len&0xFF)|(RDB_6BITLEN<<6);
+        /* Save a 6 bit len, Currently RDB_6BITLEN is 0 ,no need to operate buf[0] with `|(RDB_6BITLEN<<6)`*/
+        buf[0] = len&0xFF;
         if (rdbWriteRaw(rdb,buf,1) == -1) return -1;
         nwritten = 1;
     } else if (len < (1<<14)) {

--- a/src/server.h
+++ b/src/server.h
@@ -1229,7 +1229,7 @@ struct redisMemOverhead {
  * order to implement additional functionalities, by storing and loading
  * metadata to the RDB file.
  *
- * Currently the only use is to select a DB at load time, useful in
+ * For example use to select a DB at load time, useful in
  * replication in order to make sure that chained slaves (slaves of slaves)
  * select the correct DB and are able to accept the stream coming from the
  * top-level master. */


### PR DESCRIPTION
Currently RDB_6BITLEN is 0 ,no need to operate buf[0], we can write in annote in case we change the value in futrue
