### PR TITLE
Santize dump payload: fix invalid listpack entry start with EOF

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1303,7 +1303,7 @@ int lpValidateIntegrity(unsigned char *lp, size_t size, int deep,
     uint32_t count = 0;
     uint32_t numele = lpGetNumElements(lp);
     unsigned char *p = lp + LP_HDR_SIZE;
-    while(p && p != (lp + size - 1)) {
+    while(p && p[0] != LP_EOF) {
         unsigned char *prev = p;
 
         /* Validate this entry and move to the next entry in advance
@@ -1317,6 +1317,10 @@ int lpValidateIntegrity(unsigned char *lp, size_t size, int deep,
 
         count++;
     }
+
+    /* Make sure 'p' really does point to the end of the listpack. */
+    if (p != lp + size - 1)
+        return 0;
 
     /* Check that the count in the header is correct */
     if (numele != LP_HDR_NUMELE_UNKNOWN && numele != count)

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1303,7 +1303,7 @@ int lpValidateIntegrity(unsigned char *lp, size_t size, int deep,
     uint32_t count = 0;
     uint32_t numele = lpGetNumElements(lp);
     unsigned char *p = lp + LP_HDR_SIZE;
-    while(p && p[0] != LP_EOF) {
+    while(p && p != (lp + size - 1)) {
         unsigned char *prev = p;
 
         /* Validate this entry and move to the next entry in advance

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -118,6 +118,15 @@ test {corrupt payload: quicklist encoded_len is 0} {
     }
 }
 
+test {corrupt payload: quicklist listpack entry start with EOF} {
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        r config set sanitize-dump-payload yes
+        catch { r restore _list 0 "\x12\x01\x02\x0b\x0b\x00\x00\x00\x01\x00\x81\x61\x02\xff\xff\x0a\x00\x7e\xd8\xde\x5b\x0d\xd7\x70\xb8" replace } err
+        assert_match "*Bad data format*" $err
+        r ping
+    }
+}
+
 test {corrupt payload: #3080 - ziplist} {
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
         # shallow sanitization is enough for restore to safely reject the payload with wrong size


### PR DESCRIPTION
When an invalid listpack entry starts with EOF, we will skip it when we verify it in the loop.
Following are the steps to reproduce it before modifying:

```sh
config set sanitize-dump-payload yes
restore _list 0 "\x12\x01\x02\x0b\x0b\x00\x00\x00\x01\x00\x81\x61\x02\xff\xff\x0a\x00\x7e\xd8\xde\x5b\x0d\xd7\x70\xb8"
rpush _list a
lrange _list 0 -1
```