### PR TITLE
in dict struct , rehashidx's type is long, i think we should keep the…

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -510,7 +510,9 @@ void dictRelease(dict *d)
 dictEntry *dictFind(dict *d, const void *key)
 {
     dictEntry *he;
-    uint64_t h, idx, table;
+    uint64_t h;
+    long idx;
+    int table;
 
     if (dictSize(d) == 0) return NULL; /* dict is empty */
     if (dictIsRehashing(d)) _dictRehashStep(d);


### PR DESCRIPTION
… idx type same with it, because their range is same but -1.and table type i range 0 to 1 so it's type no need to be uint64_t.