### PR TITLE
Fix outdated protected-mode documentation in sentinel.conf

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -1,20 +1,9 @@
 # Example sentinel.conf
 
-# *** IMPORTANT ***
-#
-# By default Sentinel will not be reachable from interfaces different than
-# localhost, either use the 'bind' directive to bind to a list of network
-# interfaces, or disable protected mode with "protected-mode no" by
-# adding it to this configuration file.
-#
-# Before doing that MAKE SURE the instance is protected from the outside
-# world via firewalling or other means.
-#
-# For example you may use one of the following:
-#
-# bind 127.0.0.1 192.168.1.1
-#
-# protected-mode no
+# By default protected mode is disabled in sentinel mode. Sentinel is reachable
+# from interfaces different than localhost. Make sure the sentinel instance is
+# protected from the outside world via firewalling or other means.
+protected-mode no
 
 # port <sentinel-port>
 # The port that this sentinel instance will run on


### PR DESCRIPTION
In 666b343, we modified the default value of protected-mode
from yes to no.

However, this change is not mentioned in sentinel.conf.
Looking at the sentinel.conf alone, it is easy to make
people think that in sentinel mode, we hava truned on
the protected-mode.