### PR TITLE
Fix spelling of sanitization includes redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -429,13 +429,13 @@ rdbcompression yes
 # tell the loading code to skip the check.
 rdbchecksum yes
 
-# Enables or disables full sanitation checks for ziplist and listpack etc when
+# Enables or disables full sanitization checks for ziplist and listpack etc when
 # loading an RDB or RESTORE payload. This reduces the chances of a assertion or
 # crash later on while processing commands.
 # Options:
-#   no         - Never perform full sanitation
-#   yes        - Always perform full sanitation
-#   clients    - Perform full sanitation only for user connections.
+#   no         - Never perform full sanitization
+#   yes        - Always perform full sanitization
+#   clients    - Perform full sanitization only for user connections.
 #                Excludes: RDB files, RESTORE commands received from the master
 #                connection, and client connections which have the
 #                skip-sanitize-payload ACL flag.
@@ -816,7 +816,7 @@ replica-priority 100
 #  off          Disable the user: it's no longer possible to authenticate
 #               with this user, however the already authenticated connections
 #               will still work.
-#  skip-sanitize-payload    RESTORE dump-payload sanitation is skipped.
+#  skip-sanitize-payload    RESTORE dump-payload sanitization is skipped.
 #  sanitize-payload         RESTORE dump-payload is sanitized (default).
 #  +<command>   Allow the execution of that command.
 #               May be used with `|` for allowing subcommands (e.g "+config|get")


### PR DESCRIPTION
Just a minor typo I noticed while working on ACL V2, sanitation vs sanitization. 