### PR TITLE
Don't write oom score adj to proc unless we're managing it.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2387,6 +2387,7 @@ static sds getConfigClientOutputBufferLimitOption(typeData data) {
 static int setConfigOOMScoreAdjValuesOption(typeData data, sds *argv, int argc, const char **err) {
     int i;
     int values[CONFIG_OOM_COUNT];
+    int change = 0;
     UNUSED(data);
 
     if (argc != CONFIG_OOM_COUNT) {
@@ -2419,10 +2420,13 @@ static int setConfigOOMScoreAdjValuesOption(typeData data, sds *argv, int argc, 
     }
 
     for (i = 0; i < CONFIG_OOM_COUNT; i++) {
-        server.oom_score_adj_values[i] = values[i];
+        if (server.oom_score_adj_values[i] != values[i]) {
+            server.oom_score_adj_values[i] = values[i];
+            change = 1;
+        }
     }
 
-    return 1;
+    return change ? 1 : 2;
 }
 
 static sds getConfigOOMScoreAdjValuesOption(typeData data) {

--- a/src/server.h
+++ b/src/server.h
@@ -1664,7 +1664,6 @@ struct redisServer {
     int lfu_log_factor;             /* LFU logarithmic counter factor. */
     int lfu_decay_time;             /* LFU counter decay factor. */
     long long proto_max_bulk_len;   /* Protocol bulk length maximum size. */
-    int oom_score_adj_base;         /* Base oom_score_adj value, as observed on startup */
     int oom_score_adj_values[CONFIG_OOM_COUNT];   /* Linux oom_score_adj configuration */
     int oom_score_adj;                            /* If true, oom_score_adj is managed */
     int disable_thp;                              /* If true, disable THP by syscall */

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -98,5 +98,29 @@ if {$system_name eq {linux}} {
             
             assert_equal [get_oom_score_adj] $other_val2
         }
+
+        test {CONFIG SET oom score restored on disable} {
+            r config set oom-score-adj no
+            set_oom_score_adj 22
+            assert_equal [get_oom_score_adj] 22
+
+            r config set oom-score-adj-values "9 9 9" oom-score-adj yes
+            assert_equal [get_oom_score_adj] [expr 9+22]
+
+            r config set oom-score-adj no
+            assert_equal [get_oom_score_adj] 22
+        }
+
+        test {CONFIG SET oom score relative and absolute} {
+            set custom_oom 9
+            r config set oom-score-adj no
+            set base_oom [get_oom_score_adj]
+
+            r config set oom-score-adj-values "$custom_oom $custom_oom $custom_oom" oom-score-adj relative
+            assert_equal [get_oom_score_adj] [expr $base_oom+$custom_oom]
+
+            r config set oom-score-adj absolute
+            assert_equal [get_oom_score_adj] $custom_oom
+        }
     }
 }


### PR DESCRIPTION
When disabling redis oom-score-adj managment we restore the base value read before enabling oom-score-adj management.

This fixes an issue introduced in #9748 where updating `oom-score-adj-values` while `oom-score-adj` was set to `no` would write the base oom score adj value read on startup to `/proc`. This is a bug since while `oom-score-adj` is disabled we should never write to proc and let external processes manage it.

Added appropriate test.