### PR TITLE
Fix SENTINEL subcommands's arity

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3943,7 +3943,6 @@ NULL
             addReplyErrorSds(c,e);
         }
     } else if (!strcasecmp(c->argv[1]->ptr,"set")) {
-        if (c->argc <= 3) goto numargserr;
         sentinelSetCommand(c);
     } else if (!strcasecmp(c->argv[1]->ptr,"config")) {
         if (c->argc < 3) goto numargserr;

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3726,9 +3726,9 @@ void sentinelCommand(client *c) {
 "    Reset masters for specific master name matching this pattern.",
 "SENTINELS <master-name>",
 "    Show a list of Sentinel instances for this master and their state.",
-"SET <master-name> <option> <value>",
+"SET <master-name> <option> <value> [<option> <value> ...]",
 "    Set configuration parameters for certain masters.",
-"SIMULATE-FAILURE (CRASH-AFTER-ELECTION|CRASH-AFTER-PROMOTION|HELP)",
+"SIMULATE-FAILURE [CRASH-AFTER-ELECTION] [CRASH-AFTER-PROMOTION] [HELP]",
 "    Simulate a Sentinel crash.",
 NULL
         };

--- a/src/server.c
+++ b/src/server.c
@@ -693,10 +693,10 @@ struct redisCommand sentinelSubcommands[] = {
     {"sentinels",sentinelCommand,3,
      "admin only-sentinel"},
 
-    {"set",sentinelCommand,-3,
+    {"set",sentinelCommand,-5,
      "admin only-sentinel"},
 
-    {"simulate-failure",sentinelCommand,3,
+    {"simulate-failure",sentinelCommand,-3,
      "admin only-sentinel"},
 
     {"help",sentinelCommand,2,


### PR DESCRIPTION
For `SENTINEL SET`, we can use in these ways:
1. SENTINEL SET mymaster quorum 3
2. SENTINEL SET mymaster quorum 5 parallel-syncs 1

For `SENTINEL SIMULATE-FAILURE`, although it is only used for testing:
1. SENTINEL SIMULATE-FAILURE CRASH-AFTER-ELECTION
2. SENTINEL SIMULATE-FAILURE CRASH-AFTER-ELECTION CRASH-AFTER-PROMOTION

see https://github.com/redis/redis/pull/9504#pullrequestreview-824123777