### PR TITLE
Add hash-seed config parameter.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2100,6 +2100,14 @@ static int updateProcTitleTemplate(const char **err) {
     return 1;
 }
 
+static int isValidHashSeed(sds val, const char **err) {
+    if (val && sdslen(val) != DICT_HASH_SEED_SIZE) {
+        *err = "Invalid hash-seed length";
+        return 0;
+    }
+    return 1;
+}
+
 static int updateHZ(const char **err) {
     UNUSED(err);
     /* Hz is more a hint from the user, so we accept values out of range
@@ -2591,6 +2599,7 @@ standardConfig configs[] = {
     /* SDS Configs */
     createSDSConfig("masterauth", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.masterauth, NULL, NULL, NULL),
     createSDSConfig("requirepass", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.requirepass, NULL, NULL, updateRequirePass),
+    createSDSConfig("hash-seed", NULL, IMMUTABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.hash_seed, NULL, isValidHashSeed, NULL),
 
     /* Enum Configs */
     createEnumConfig("supervised", NULL, IMMUTABLE_CONFIG, supervised_mode_enum, server.supervised_mode, SUPERVISED_NONE, NULL, NULL),

--- a/src/dict.c
+++ b/src/dict.c
@@ -67,14 +67,10 @@ static int _dictInit(dict *d, dictType *type);
 
 /* -------------------------- hash functions -------------------------------- */
 
-static uint8_t dict_hash_function_seed[16];
+static uint8_t dict_hash_function_seed[DICT_HASH_SEED_SIZE];
 
 void dictSetHashFunctionSeed(uint8_t *seed) {
     memcpy(dict_hash_function_seed,seed,sizeof(dict_hash_function_seed));
-}
-
-uint8_t *dictGetHashFunctionSeed(void) {
-    return dict_hash_function_seed;
 }
 
 /* The default hashing function uses SipHash implementation
@@ -89,6 +85,14 @@ uint64_t dictGenHashFunction(const void *key, int len) {
 
 uint64_t dictGenCaseHashFunction(const unsigned char *buf, int len) {
     return siphash_nocase(buf,len,dict_hash_function_seed);
+}
+
+uint64_t dictHashFunction(const void *key, int len, const uint8_t *seed) {
+    return siphash(key,len,seed);
+}
+
+uint64_t dictCaseHashFunction(const unsigned char *buf, int len, const uint8_t *seed) {
+    return siphash_nocase(buf,len,seed);
 }
 
 /* ----------------------------- API implementation ------------------------- */

--- a/src/dict.h
+++ b/src/dict.h
@@ -169,6 +169,9 @@ typedef void (dictScanBucketFunction)(dict *d, dictEntry **bucketref);
 #define randomULong() random()
 #endif
 
+/* SipHash seed size */
+#define DICT_HASH_SEED_SIZE 16
+
 /* API */
 dict *dictCreate(dictType *type);
 int dictExpand(dict *d, unsigned long size);
@@ -194,13 +197,14 @@ unsigned int dictGetSomeKeys(dict *d, dictEntry **des, unsigned int count);
 void dictGetStats(char *buf, size_t bufsize, dict *d);
 uint64_t dictGenHashFunction(const void *key, int len);
 uint64_t dictGenCaseHashFunction(const unsigned char *buf, int len);
+uint64_t dictHashFunction(const void *key, int len, const uint8_t *seed);
+uint64_t dictCaseHashFunction(const unsigned char *buf, int len, const uint8_t *seed);
 void dictEmpty(dict *d, void(callback)(dict*));
 void dictEnableResize(void);
 void dictDisableResize(void);
 int dictRehash(dict *d, int n);
 int dictRehashMilliseconds(dict *d, int ms);
 void dictSetHashFunctionSeed(uint8_t *seed);
-uint8_t *dictGetHashFunctionSeed(void);
 unsigned long dictScan(dict *d, unsigned long v, dictScanFunction *fn, dictScanBucketFunction *bucketfn, void *privdata);
 uint64_t dictGetHash(dict *d, const void *key);
 dictEntry **dictFindEntryRefByPtrAndHash(dict *d, const void *oldptr, uint64_t hash);

--- a/src/module.c
+++ b/src/module.c
@@ -9494,17 +9494,8 @@ size_t moduleGetMemUsage(robj *key, robj *val, size_t sample_size, int dbid) {
 /* server.moduleapi dictionary type. Only uses plain C strings since
  * this gets queries from modules. */
 
-uint64_t dictCStringKeyHash(const void *key) {
-    return dictGenHashFunction((unsigned char*)key, strlen((char*)key));
-}
-
-int dictCStringKeyCompare(dict *d, const void *key1, const void *key2) {
-    UNUSED(d);
-    return strcmp(key1,key2) == 0;
-}
-
 dictType moduleAPIDictType = {
-    dictCStringKeyHash,        /* hash function */
+    dictPresetSeedCStringKeyHash,  /* hash function */
     NULL,                      /* key dup */
     NULL,                      /* val dup */
     dictCStringKeyCompare,     /* key compare */

--- a/src/server.h
+++ b/src/server.h
@@ -2549,7 +2549,6 @@ void dismissSds(sds s);
 void dismissMemory(void* ptr, size_t size_hint);
 void dismissMemoryInChild(void);
 
-
 #define RESTART_SERVER_NONE 0
 #define RESTART_SERVER_GRACEFULLY (1<<0)     /* Do proper shutdown. */
 #define RESTART_SERVER_CONFIG_REWRITE (1<<1) /* CONFIG REWRITE before restart.*/

--- a/src/server.h
+++ b/src/server.h
@@ -1337,6 +1337,7 @@ struct redisServer {
     dict *orig_commands;        /* Command table before command renaming. */
     aeEventLoop *el;
     rax *errors;                /* Errors table */
+    sds hash_seed;              /* Seed for dict hash function */
     redisAtomic unsigned int lruclock; /* Clock for LRU eviction */
     volatile sig_atomic_t shutdown_asap; /* SHUTDOWN needed ASAP */
     int activerehashing;        /* Incremental rehash in serverCron() */
@@ -2548,6 +2549,7 @@ void dismissSds(sds s);
 void dismissMemory(void* ptr, size_t size_hint);
 void dismissMemoryInChild(void);
 
+
 #define RESTART_SERVER_NONE 0
 #define RESTART_SERVER_GRACEFULLY (1<<0)     /* Do proper shutdown. */
 #define RESTART_SERVER_CONFIG_REWRITE (1<<1) /* CONFIG REWRITE before restart.*/
@@ -2777,6 +2779,8 @@ int dictSdsKeyCompare(dict *d, const void *key1, const void *key2);
 int dictSdsKeyCaseCompare(dict *d, const void *key1, const void *key2);
 void dictSdsDestructor(dict *d, void *val);
 void *dictSdsDup(dict *d, const void *key);
+int dictCStringKeyCompare(dict *d, const void *key1, const void *key2);
+uint64_t dictPresetSeedCStringKeyHash(const void *key);
 
 /* Git SHA1 */
 char *redisGitSHA1(void);

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -201,6 +201,7 @@ start_server {tags {"introspection"}} {
             cluster-port
             oom-score-adj
             oom-score-adj-values
+            hash-seed
         }
 
         if {!$::tls} {

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -374,3 +374,20 @@ start_server {tags {"other external:skip"}} {
     }
 }
 
+test {hash-seed configuration works as expected} {
+    proc make_hash {seed} {
+        start_server [list tags {"external:skip"} overrides [list hash-seed $seed]] {
+            for {set i 0} {$i < 1000} {incr i} {
+                r hset myhash field:$i value:$i
+            }
+            set h [r hgetall myhash]
+        }
+        return $h
+    }
+
+    set hash1 [make_hash aaaabbbbccccdddd]
+    set hash2 [make_hash aaaabbbbccccdddd]
+    set hash3 [make_hash xxxxxxxxxxxxxxxx]
+    assert_equal $hash1 $hash2
+    assert {$hash1 != $hash3}
+}

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -376,7 +376,7 @@ start_server {tags {"other external:skip"}} {
 
 test {hash-seed configuration works as expected} {
     proc make_hash {seed} {
-        start_server [list tags {"external:skip"} overrides [list hash-seed $seed]] {
+        start_server [list overrides [list hash-seed $seed]] {
             for {set i 0} {$i < 1000} {incr i} {
                 r hset myhash field:$i value:$i
             }
@@ -390,4 +390,4 @@ test {hash-seed configuration works as expected} {
     set hash3 [make_hash xxxxxxxxxxxxxxxx]
     assert_equal $hash1 $hash2
     assert {$hash1 != $hash3}
-}
+} {} {external:skip}


### PR DESCRIPTION
Initializes the dictionary hash function seed with a pre-determined
value, in order to make all hash based operations deterministic.

The hash-seed configuration is immutable and basically intended to
support special use cases where Redis needs to be more deterministic,
like executing certain tests, supporting [RedisRaft](https://github.com/redislabs/redisraft), etc.

This commit also introduces an additional set of preset-seed hash
functions that are used by dictionaries that need to be initialized and
populated early on, before configuration is loaded and the hash-seed
parameter can be inspected and applied.