### PR TITLE
Fix the server log when client use Multiparam Config Set

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -762,7 +762,7 @@ void configSetCommand(client *c) {
                     }
                 }
                 /* Apply function not stored, store it */
-                if (!exists){
+                if (!exists) {
                     apply_fns[j] = set_configs[i]->interface.apply;
                     config_map_fns[j] = i;
                 }

--- a/src/config.c
+++ b/src/config.c
@@ -774,7 +774,7 @@ void configSetCommand(client *c) {
     /* Apply all configs after being set */
     for (i = 0; i < config_count && apply_fns[i] != NULL; i++) {
         if (!apply_fns[i](&errstr)) {
-            serverLog(LL_WARNING, "Failed applying new %s configuration, restoring previous settings.", set_configs[config_map_fns[i]]->name);
+            serverLog(LL_WARNING, "Failed applying new configuration. Possibly related to new %s setting. Restoring previous settings.", set_configs[config_map_fns[i]]->name);
             restoreBackupConfig(set_configs, old_values, config_count, apply_fns);
             goto err;
         }

--- a/src/config.c
+++ b/src/config.c
@@ -680,6 +680,7 @@ void configSetCommand(client *c) {
     apply_fn *apply_fns; /* TODO: make this a set for better performance */
     int config_count, i, j;
     int invalid_args = 0;
+    int *config_map_fns;
 
     /* Make sure we have an even number of arguments: conf-val pairs */
     if (c->argc & 1) {
@@ -692,6 +693,7 @@ void configSetCommand(client *c) {
     new_values = zmalloc(sizeof(sds*)*config_count);
     old_values = zcalloc(sizeof(sds*)*config_count);
     apply_fns = zcalloc(sizeof(apply_fn)*config_count);
+    config_map_fns = zmalloc(sizeof(int)*config_count);
 
     /* Find all relevant configs */
     for (i = 0; i < config_count; i++) {
@@ -760,8 +762,11 @@ void configSetCommand(client *c) {
                     }
                 }
                 /* Apply function not stored, store it */
-                if (!exists)
+                if (!exists){
                     apply_fns[j] = set_configs[i]->interface.apply;
+                    config_map_fns[j] = i;
+                }
+                    
             }
         }
     }
@@ -769,7 +774,7 @@ void configSetCommand(client *c) {
     /* Apply all configs after being set */
     for (i = 0; i < config_count && apply_fns[i] != NULL; i++) {
         if (!apply_fns[i](&errstr)) {
-            serverLog(LL_WARNING, "Failed applying new %s configuration, restoring previous settings.", set_configs[i]->name);
+            serverLog(LL_WARNING, "Failed applying new %s configuration, restoring previous settings.", set_configs[config_map_fns[i]]->name);
             restoreBackupConfig(set_configs, old_values, config_count, apply_fns);
             goto err;
         }
@@ -790,6 +795,7 @@ end:
         sdsfree(old_values[i]);
     zfree(old_values);
     zfree(apply_fns);
+    zfree(config_map_fns);
 }
 
 /*-----------------------------------------------------------------------------

--- a/src/config.c
+++ b/src/config.c
@@ -766,7 +766,6 @@ void configSetCommand(client *c) {
                     apply_fns[j] = set_configs[i]->interface.apply;
                     config_map_fns[j] = i;
                 }
-                    
             }
         }
     }


### PR DESCRIPTION
When clients enter multiply parameters in the CONFIG SET command,  the server side log displays the wrong config parameters.

In the following example, one sentinel instance runs on port 26381.  
When clients enter different config set commands, the server side log display different log. 
Please check the following 4 examples:

Example 1:

config set maxmemory 10000001 client-query-buffer-limit 10m port 26381
![image](https://user-images.githubusercontent.com/51993843/145263734-6178712d-eaa3-4667-9efe-cbdb2089d3ea.png)

Server side log:
![image](https://user-images.githubusercontent.com/51993843/145263770-7d97c2e0-7abd-4b71-9169-7b806d81a800.png)

You can see: the server side report:  Failed applying new client-query-buffer-limit configuration, restoring previous setting.
 But in fact, it should report "Failed applying new port configuration"


Example 2：

![image](https://user-images.githubusercontent.com/51993843/145264030-d2d9baa1-0502-4185-a094-745e91137e7a.png)

Server side log:
![image](https://user-images.githubusercontent.com/51993843/145264067-c6e1cb6b-4458-42c6-b4b2-f8c989a42cb8.png)

The server side should report ""Failed applying new port configuration"" too 

Example 3:

![image](https://user-images.githubusercontent.com/51993843/145264187-421eeb6a-f2e0-40bb-bee2-6f6774a3b0da.png)

Server side log:
![image](https://user-images.githubusercontent.com/51993843/145264222-7466eb7d-7e1c-404d-94ed-f80a99fc6a32.png)

The server side display the correct message.

Example 4：

If we just move port 26381 to the tail of the command as below:
![image](https://user-images.githubusercontent.com/51993843/145264397-a2de6bac-4dc2-4bf1-a8f0-c5296b857725.png)

Server side log:
![image](https://user-images.githubusercontent.com/51993843/145264431-bdf1430b-3834-4648-986c-77300e5e55da.png)

The server side still need to report ""Failed applying new port configuration""

 
This PR fix this bug, and server side always display the correct information according to the above 4 example command:

![image](https://user-images.githubusercontent.com/51993843/145264641-aab4484d-6075-4b65-a5c7-e414a9aa6efd.png)

server side always display "Failed applying new port configuration"












