### PR TITLE
Add FLUSHEVERYTHING command that also flushes the Redis Functions.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1601,6 +1601,9 @@ struct redisCommand redisCommandTable[] = {
     {"flushall",flushallCommand,-1,
      "write @keyspace @dangerous"},
 
+    {"flusheverything",flusheverythingCommand,-1,
+     "no-script write @keyspace @dangerous"},
+
     {"sort",sortCommand,-2,
      "write use-memory @list @set @sortedset @dangerous",
      {{"read",

--- a/src/server.h
+++ b/src/server.h
@@ -2654,6 +2654,7 @@ robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o);
 
 #define EMPTYDB_NO_FLAGS 0      /* No flags. */
 #define EMPTYDB_ASYNC (1<<0)    /* Reclaim memory in another thread. */
+#define EMPTYDB_WITHSCRIPTS (1<<1)    /* Reclaim memory in another thread. */
 long long emptyDb(int dbnum, int flags, void(callback)(dict*));
 long long emptyDbStructure(redisDb *dbarray, int dbnum, int async, void(callback)(dict*));
 void flushAllDataAndResetRDB(int flags);
@@ -2716,6 +2717,7 @@ int redis_check_aof_main(int argc, char **argv);
 
 /* Scripting */
 void scriptingInit(int setup);
+void scriptingReset(int async);
 int ldbRemoveChild(pid_t pid);
 void ldbKillForkedSessions(void);
 int ldbPendingChildren(void);

--- a/src/server.h
+++ b/src/server.h
@@ -2862,6 +2862,7 @@ void sscanCommand(client *c);
 void syncCommand(client *c);
 void flushdbCommand(client *c);
 void flushallCommand(client *c);
+void flusheverythingCommand(client *c);
 void sortCommand(client *c);
 void sortroCommand(client *c);
 void lremCommand(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -2652,9 +2652,9 @@ int dbSyncDelete(redisDb *db, robj *key);
 int dbDelete(redisDb *db, robj *key);
 robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o);
 
-#define EMPTYDB_NO_FLAGS 0      /* No flags. */
-#define EMPTYDB_ASYNC (1<<0)    /* Reclaim memory in another thread. */
-#define EMPTYDB_WITHSCRIPTS (1<<1)    /* Reclaim memory in another thread. */
+#define EMPTYDB_NO_FLAGS 0            /* No flags. */
+#define EMPTYDB_ASYNC (1<<0)          /* Reclaim memory in another thread. */
+#define EMPTYDB_WITHSCRIPTS (1<<1)    /* Indicate to also flush scripts (eval and functions). */
 long long emptyDb(int dbnum, int flags, void(callback)(dict*));
 long long emptyDbStructure(redisDb *dbarray, int dbnum, int async, void(callback)(dict*));
 void flushAllDataAndResetRDB(int flags);

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -129,6 +129,22 @@ start_server {tags {"scripting"}} {
         r fcall_ro test 0
     } {1}
 
+    test {FUNCTION - test flushall do not clean functions} {
+        r flushall
+        r function list
+    } {{name test engine LUA description {}}}
+
+    test {FUNCTION - test flusheverything cleans functions} {
+        r flusheverything
+        r function list
+    } {}
+
+    test {FUNCTION - test flusheverything can not be called from within a functions} {
+        r function create lua test REPLACE {return redis.call('flusheverything')}
+        catch { r fcall test 0 } e
+        set _ $e
+    } {*Redis command is not allowed from script*}
+
     test {FUNCTION - test keys and argv} {
         r function create lua test REPLACE {return redis.call('set', KEYS[1], ARGV[1])}
         r fcall test 1 x foo


### PR DESCRIPTION
The issue this PR comes to solve is the ability to flush the entire data set (including functions which was introduce on https://github.com/redis/redis/pull/9780).

### Why flushing Redis functions can not be added to `FLUSHALL`?
Flushing the functions on `FLUSHALL` command can be dangerous because `FLUSHALL` can be called from within a function and cause the function structures to be freed while the function is running. In addition, Disallow `FLUSHALL` inside a function will differentiate functions and eval.

### The solution
Introducing `FLUSHEVERYTHING` command that flushes the entire data set, including functions and eval cache. This command is not allowed inside a script (function or eval). The command arguments is just like the `FLUSHALL` command (`sync` or `async`).