### PR TITLE
Delay *SUBSCRIBE inside transactions

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -220,9 +220,9 @@ void execCommand(client *c) {
                 "following reason: %s", reason);
         } else {
             if (c->id == CLIENT_ID_AOF)
-                call(c,CMD_CALL_NONE);
+                checkedCall(c,CMD_CALL_NONE);
             else
-                call(c,CMD_CALL_FULL);
+                checkedCall(c,CMD_CALL_FULL);
 
             serverAssert((c->flags & CLIENT_BLOCKED) == 0);
         }

--- a/src/server.c
+++ b/src/server.c
@@ -3052,6 +3052,28 @@ void propagatePendingCommands() {
     redisOpArrayFree(&server.also_propagate);
 }
 
+void checkedCall(client *c, int flags) {
+    /* Only allow a subset of commands in the context of Pub/Sub if the
+     * connection is in RESP2 mode. With RESP3 there are no limits. */
+    if ((c->flags & CLIENT_PUBSUB && c->resp == 2) &&
+        c->cmd->proc != pingCommand &&
+        c->cmd->proc != subscribeCommand &&
+        c->cmd->proc != ssubscribeCommand &&
+        c->cmd->proc != unsubscribeCommand &&
+        c->cmd->proc != sunsubscribeCommand &&
+        c->cmd->proc != psubscribeCommand &&
+        c->cmd->proc != punsubscribeCommand &&
+        c->cmd->proc != quitCommand &&
+        c->cmd->proc != resetCommand) {
+        rejectCommandFormat(c,
+            "Can't execute '%s': only (P|S)SUBSCRIBE / "
+            "(P|S)UNSUBSCRIBE / PING / QUIT / RESET are allowed in this context",
+            c->cmd->fullname);
+        return;
+    }
+    call(c, flags);
+}
+
 /* Call() is the core of Redis execution of a command.
  *
  * The following flags can be passed:
@@ -3625,25 +3647,6 @@ int processCommand(client *c) {
         return C_OK;
     }
 
-    /* Only allow a subset of commands in the context of Pub/Sub if the
-     * connection is in RESP2 mode. With RESP3 there are no limits. */
-    if ((c->flags & CLIENT_PUBSUB && c->resp == 2) &&
-        c->cmd->proc != pingCommand &&
-        c->cmd->proc != subscribeCommand &&
-        c->cmd->proc != ssubscribeCommand &&
-        c->cmd->proc != unsubscribeCommand &&
-        c->cmd->proc != sunsubscribeCommand &&
-        c->cmd->proc != psubscribeCommand &&
-        c->cmd->proc != punsubscribeCommand &&
-        c->cmd->proc != quitCommand &&
-        c->cmd->proc != resetCommand) {
-        rejectCommandFormat(c,
-            "Can't execute '%s': only (P|S)SUBSCRIBE / "
-            "(P|S)UNSUBSCRIBE / PING / QUIT / RESET are allowed in this context",
-            c->cmd->fullname);
-        return C_OK;
-    }
-
     /* Only allow commands with flag "t", such as INFO, REPLICAOF and so on,
      * when replica-serve-stale-data is no and we are a replica with a broken
      * link with master. */
@@ -3719,7 +3722,7 @@ int processCommand(client *c) {
         queueMultiCommand(c);
         addReply(c,shared.queued);
     } else {
-        call(c,CMD_CALL_FULL);
+        checkedCall(c,CMD_CALL_FULL);
         c->woff = server.master_repl_offset;
         if (listLength(server.ready_keys))
             handleClientsBlockedOnKeys();

--- a/src/server.h
+++ b/src/server.h
@@ -2815,6 +2815,7 @@ struct redisCommand *lookupCommandBySds(sds s);
 struct redisCommand *lookupCommandByCStringLogic(dict *commands, const char *s);
 struct redisCommand *lookupCommandByCString(const char *s);
 struct redisCommand *lookupCommandOrOriginal(robj **argv, int argc);
+void checkedCall(client *c, int flags);
 void call(client *c, int flags);
 void alsoPropagate(int dbid, robj **argv, int argc, int target);
 void propagatePendingCommands();


### PR DESCRIPTION
This change updates the Redis server to deny `(P)SUBSCRIBE` commands when attempting to execute inside a transaction.

Closes #2967