### PR TITLE
Use `server.dirty++` instead if `forceCommandPropagation` on FUNCTION commands

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -314,7 +314,9 @@ void functionsDeleteCommand(client *c) {
     }
 
     engineFunctionFree(fi, functions_ctx);
-    forceCommandPropagation(c, PROPAGATE_REPL | PROPAGATE_AOF);
+    /* Indicate that the command changed the data so it will be replicated and
+     * counted as a data change (for persistence configuration) */
+    server.dirty++;
     addReply(c, shared.ok);
 }
 
@@ -484,7 +486,9 @@ void functionsCreateCommand(client *c) {
         addReplyErrorSds(c, err);
         return;
     }
-    forceCommandPropagation(c, PROPAGATE_REPL | PROPAGATE_AOF);
+    /* Indicate that the command changed the data so it will be replicated and
+     * counted as a data change (for persistence configuration) */
+    server.dirty++;
     addReply(c, shared.ok);
 }
 


### PR DESCRIPTION
Functions are considered data, so changing a function should be counted as a data change and should affect the persistence policy. For example if we want to persist an RDB each minute if there was a single change, functions should be counted as such change. Using `forceCommandPropagation` will not give us the desired effect and so we must switch to `server.dirty++`.