### PR TITLE
Added functions tests to test_helper.tcl

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -63,6 +63,7 @@ set ::all_tests {
     unit/pubsub
     unit/slowlog
     unit/scripting
+    unit/functions
     unit/maxmemory
     unit/introspection
     unit/introspection-2


### PR DESCRIPTION
`unit/functions` was missing from `test_helper.tcl` which caused functions tests not to run when not directly specify.