### PR TITLE
Rename all FUNCTION callbacks

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -196,7 +196,7 @@ int functionsRegisterEngine(const char *engine_name, engine *engine) {
 /*
  * FUNCTION STATS
  */
-void functionsStatsCommand(client *c) {
+void functionStatsCommand(client *c) {
     if (scriptIsRunning() && scriptIsEval()) {
         addReplyErrorObject(c, shared.slowevalerr);
         return;
@@ -235,7 +235,7 @@ void functionsStatsCommand(client *c) {
 /*
  * FUNCTION LIST
  */
-void functionsListCommand(client *c) {
+void functionListCommand(client *c) {
     /* general information on all the functions */
     addReplyArrayLen(c, dictSize(functions_ctx->functions));
     dictIterator *iter = dictGetIterator(functions_ctx->functions);
@@ -260,7 +260,7 @@ void functionsListCommand(client *c) {
 /*
  * FUNCTION INFO <FUNCTION NAME> [WITHCODE]
  */
-void functionsInfoCommand(client *c) {
+void functionInfoCommand(client *c) {
     if (c->argc > 4) {
         addReplyErrorFormat(c,"wrong number of arguments for '%s' command or subcommand", c->cmd->name);
         return;
@@ -300,7 +300,7 @@ void functionsInfoCommand(client *c) {
 /*
  * FUNCTION DELETE <FUNCTION NAME>
  */
-void functionsDeleteCommand(client *c) {
+void functionDeleteCommand(client *c) {
     if (server.masterhost && server.repl_slave_ro && !(c->flags & CLIENT_MASTER)) {
         addReplyError(c, "Can not delete a function on a read only replica");
         return;
@@ -318,7 +318,7 @@ void functionsDeleteCommand(client *c) {
     addReply(c, shared.ok);
 }
 
-void functionsKillCommand(client *c) {
+void functionKillCommand(client *c) {
     scriptKill(c, 0);
 }
 
@@ -370,7 +370,7 @@ void fcallCommandReadOnly(client *c) {
     fcallCommandGeneric(c, 1);
 }
 
-void functionsHelpCommand(client *c) {
+void functionHelpCommand(client *c) {
     const char *help[] = {
 "CREATE <ENGINE NAME> <FUNCTION NAME> [REPLACE] [DESC <FUNCTION DESCRIPTION>] <FUNCTION CODE>",
 "    Create a new function with the given function name and code.",
@@ -442,7 +442,7 @@ int functionsCreateWithFunctionCtx(sds function_name,sds engine_name, sds desc, 
  * DESCRIPTION     - optional, function description
  * FUNCTION CODE   - function code to pass to the engine
  */
-void functionsCreateCommand(client *c) {
+void functionCreateCommand(client *c) {
 
     if (server.masterhost && server.repl_slave_ro && !(c->flags & CLIENT_MASTER)) {
         addReplyError(c, "Can not create a function on a read only replica");

--- a/src/functions.h
+++ b/src/functions.h
@@ -100,15 +100,15 @@ typedef struct functionInfo {
 int functionsRegisterEngine(const char *engine_name, engine *engine_ctx);
 int functionsCreateWithFunctionCtx(sds function_name, sds engine_name, sds desc, sds code,
                                    int replace, sds* err, functionsCtx *functions);
-void functionsCreateCommand(client *c);
+void functionCreateCommand(client *c);
 void fcallCommand(client *c);
 void fcallCommandReadOnly(client *c);
-void functionsDeleteCommand(client *c);
-void functionsKillCommand(client *c);
-void functionsStatsCommand(client *c);
-void functionsInfoCommand(client *c);
-void functionsListCommand(client *c);
-void functionsHelpCommand(client *c);
+void functionDeleteCommand(client *c);
+void functionKillCommand(client *c);
+void functionStatsCommand(client *c);
+void functionInfoCommand(client *c);
+void functionListCommand(client *c);
+void functionHelpCommand(client *c);
 unsigned long functionsMemory();
 unsigned long functionsMemoryOverhead();
 int functionsLoad(rio *rdb, int ver);

--- a/src/server.c
+++ b/src/server.c
@@ -473,25 +473,25 @@ struct redisCommand scriptSubcommands[] = {
 };
 
 struct redisCommand functionSubcommands[] = {
-    {"create",functionsCreateCommand,-5,
+    {"create",functionCreateCommand,-5,
      "may-replicate no-script @scripting"},
 
-    {"delete",functionsDeleteCommand,3,
+    {"delete",functionDeleteCommand,3,
      "may-replicate no-script @scripting"},
 
-    {"kill",functionsKillCommand,2,
+    {"kill",functionKillCommand,2,
      "no-script @scripting"},
 
-    {"info",functionsInfoCommand,-3,
+    {"info",functionInfoCommand,-3,
      "no-script @scripting"},
 
-    {"list",functionsListCommand,2,
+    {"list",functionListCommand,2,
      "no-script @scripting"},
 
-    {"stats",functionsStatsCommand,2,
+    {"stats",functionStatsCommand,2,
      "no-script @scripting"},
 
-    {"help",functionsHelpCommand,2,
+    {"help",functionHelpCommand,2,
      "ok-loading ok-stale @scripting"},
 
     {NULL},
@@ -5515,8 +5515,8 @@ int processCommand(client *c) {
         !(c->cmd->proc == scriptCommand &&
           c->argc == 2 &&
           tolower(((char*)c->argv[1]->ptr)[0]) == 'k') &&
-        !(c->cmd->proc == functionsKillCommand) &&
-        !(c->cmd->proc == functionsStatsCommand))
+        !(c->cmd->proc == functionKillCommand) &&
+        !(c->cmd->proc == functionStatsCommand))
     {
         if (scriptIsEval()) {
             rejectCommand(c, shared.slowevalerr);


### PR DESCRIPTION
To match commands callback convension, rename all `FUNCTION` command callbacks from `functions*` to `function*`:
* `functionsCreateCommand -> functionCreateCommand`
* `functionsDeleteCommand -> functionDeleteCommand`
* `functionsKillCommand   -> functionKillCommand`
* `functionsStatsCommand  -> functionStatsCommand`
* `functionsInfoCommand   -> functionInfoCommand`
* `functionsListCommand   -> functionListCommand`
* `functionsHelpCommand   -> functionHelpCommand`