### PR TITLE
redis-cli: Add OUTPUT_JSON format type

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -727,7 +727,7 @@ static int cliSelect(void) {
 /* Select RESP3 mode if redis-cli was started with the -3 option.  */
 static int cliSwitchProto(void) {
     redisReply *reply;
-    if (config.resp3 == 0 || config.resp2) return REDIS_OK;
+    if (!config.resp3 || config.resp2) return REDIS_OK;
 
     reply = redisCommand(context,"HELLO 3");
     if (reply == NULL) {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1194,8 +1194,8 @@ static sds cliFormatReplyJson(redisReply *r) {
 
             tmp = cliFormatReplyJson(r->element[i+1]);
             out = sdscatlen(out,tmp,sdslen(tmp));
+            if (i != r->elements-2) out = sdscat(out,",");
             sdsfree(tmp);
-            if (i != r->elements-1) out = sdscat(out,",");
         }
         out = sdscat(out,"}");
         break;
@@ -1905,7 +1905,7 @@ static void usage(int err) {
 "  --no-raw           Force formatted output even when STDOUT is not a tty.\n"
 "  --quoted-input     Force input to be handled as quoted strings.\n"
 "  --csv              Output in CSV format.\n"
-"  --json             Output in Json format.\n"
+"  --json             Output in JSON format.\n"
 "  --show-pushes <yn> Whether to print RESP3 PUSH messages.  Enabled by default when\n"
 "                     STDOUT is a tty but can be overridden with --show-pushes no.\n"
 "  --stat             Print rolling stats about server: mem, clients, ...\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1925,16 +1925,16 @@ static void usage(int err) {
 "  --json             Output in JSON format (default RESP3, use -2 if you want to use with RESP2).\n"
 "  --show-pushes <yn> Whether to print RESP3 PUSH messages.  Enabled by default when\n"
 "                     STDOUT is a tty but can be overridden with --show-pushes no.\n"
-"  --stat             Print rolling stats about server: mem, clients, ...\n"
+"  --stat             Print rolling stats about server: mem, clients, ...\n",version);
+
+    fprintf(target,
 "  --latency          Enter a special mode continuously sampling latency.\n"
 "                     If you use this mode in an interactive session it runs\n"
 "                     forever displaying real-time stats. Otherwise if --raw or\n"
 "                     --csv is specified, or if you redirect the output to a non\n"
 "                     TTY, it samples the latency for 1 second (you can use\n"
 "                     -i to change the interval), then produces a single output\n"
-"                     and exits.\n",version);
-
-    fprintf(target,
+"                     and exits.\n"
 "  --latency-history  Like --latency but tracking latency changes over time.\n"
 "                     Default time interval is 15 sec. Change it using -i.\n"
 "  --latency-dist     Shows latency as a spectrum, requires xterm 256 colors.\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -254,7 +254,7 @@ static struct config {
     clusterManagerCommand cluster_manager_command;
     int no_auth_warning;
     int resp2;
-    int resp3; /* value of 1: specified explicitly, value of 2: inplicit like --json option */
+    int resp3; /* value of 1: specified explicitly, value of 2: implicit like --json option */
     int in_multi;
     int pre_multi_dbnum;
 } config;


### PR DESCRIPTION
Introduce `redis-cli --json` option.
CSV doesn't support Map type, then parsing SLOWLOG or HMSET with multiple args are not helpful.

By default the `--json` implies RESP3, which makes it much more useful, and a `-2` option was added to force RESP2.
When `HELLO 3` fails, it prints a warning message (which can be silenced with `-2`).
If a user passed `-3` explicitly, the non-interactive mode will also exit with error without running the command, while in interactive session it'll keep running after printing the warning.

JSON output would be helpful to parse Redis replies with other tools like jq.

```
redis-cli --json slowlog get | jq

[
  [
    1,
    1639677545,
    322362,
    [
      "HMSET",
      "dummy-key",
      "field1",
      "123,456,789... (152 more bytes)",
      "field2",
      "111,222,333... (140 more bytes)",
      "field3",
      "... (349 more arguments)"
    ],
    "127.0.0.1:49312",
    ""
  ]
]

```