### PR TITLE
Add verification for setting the slot status.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4922,6 +4922,10 @@ NULL
                     (char*)c->argv[4]->ptr);
                 return;
             }
+            if (n == myself) {
+                addReplyErrorFormat(c,"Can't migrate hash slot %u to myself",slot);
+                return;
+            }
             if (nodeIsSlave(n)) {
                 addReplyError(c,"Target node is not a master");
                 return;
@@ -4936,6 +4940,10 @@ NULL
             if ((n = clusterLookupNode(c->argv[4]->ptr)) == NULL) {
                 addReplyErrorFormat(c,"I don't know about node %s",
                     (char*)c->argv[4]->ptr);
+                return;
+            }
+            if (n == myself) {
+                addReplyErrorFormat(c,"Can't import hash slot %u to myself",slot);
                 return;
             }
             if (nodeIsSlave(n)) {


### PR DESCRIPTION
if the node is already the owner of the slot, can't migrate or import the slot to itself.