### PR TITLE
Fix recent daily CI test failures

### DIFF
--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -107,7 +107,7 @@ typedef struct quicklist {
     quicklistNode *tail;
     unsigned long count;        /* total count of all entries in all listpacks */
     unsigned long len;          /* number of quicklistNodes */
-    unsigned int fill : QL_FILL_BITS;     /* fill factor for individual nodes */
+    signed int fill : QL_FILL_BITS;       /* fill factor for individual nodes */
     unsigned int compress : QL_COMP_BITS; /* depth of end nodes not to compress;0=off */
     unsigned int bookmark_count: QL_BM_BITS;
     quicklistBookmark bookmarks[];

--- a/src/server.c
+++ b/src/server.c
@@ -3215,7 +3215,7 @@ int processCommand(client *c) {
         if ((c->cmd->proc == debugCommand && !allowProtectedAction(server.enable_debug_cmd, c)) ||
             (c->cmd->proc == moduleCommand && !allowProtectedAction(server.enable_module_cmd, c)))
         {
-            rejectCommandFormat(c,"%s command not allowed. If the %s option is set to \"local\","
+            rejectCommandFormat(c,"%s command not allowed. If the %s option is set to \"local\", "
                                   "you can run it from a local connection, otherwise you need to set this option "
                                   "in the configuration file, and then restart the server.",
                                   c->cmd->proc == debugCommand ? "DEBUG" : "MODULE",

--- a/tests/cluster/run.tcl
+++ b/tests/cluster/run.tcl
@@ -15,6 +15,7 @@ proc main {} {
     spawn_instance redis $::redis_base_port $::instances_count {
         "cluster-enabled yes"
         "appendonly yes"
+        "enable-debug-command yes"
     }
     run_tests
     cleanup

--- a/tests/cluster/run.tcl
+++ b/tests/cluster/run.tcl
@@ -15,6 +15,7 @@ proc main {} {
     spawn_instance redis $::redis_base_port $::instances_count {
         "cluster-enabled yes"
         "appendonly yes"
+        "enable-protected-configs yes"
         "enable-debug-command yes"
     }
     run_tests

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -14,7 +14,7 @@ proc main {} {
         set ::env(LEAKED_FDS_FILE) $::leaked_fds_file
     }
     spawn_instance sentinel $::sentinel_base_port $::instances_count [list "sentinel deny-scripts-reconfig no"] "../tests/includes/sentinel.conf"
-    spawn_instance redis $::redis_base_port $::instances_count
+    spawn_instance redis $::redis_base_port $::instances_count [list "enable-protected-configs yes" "enable-debug-command yes"]
     run_tests
     cleanup
     end_tests

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -13,8 +13,16 @@ proc main {} {
     if {$::leaked_fds_file != ""} {
         set ::env(LEAKED_FDS_FILE) $::leaked_fds_file
     }
-    spawn_instance sentinel $::sentinel_base_port $::instances_count [list "sentinel deny-scripts-reconfig no"] "../tests/includes/sentinel.conf"
-    spawn_instance redis $::redis_base_port $::instances_count [list "enable-protected-configs yes" "enable-debug-command yes"]
+    spawn_instance sentinel $::sentinel_base_port $::instances_count {
+        "sentinel deny-scripts-reconfig no"
+        "enable-protected-configs yes"
+        "enable-debug-command yes"
+    } "../tests/includes/sentinel.conf"
+
+    spawn_instance redis $::redis_base_port $::instances_count {
+        "enable-protected-configs yes"
+        "enable-debug-command yes"
+    }
     run_tests
     cleanup
     end_tests


### PR DESCRIPTION
Recent PRs have introduced some failures, this commit
try to fix these CI failures. Here are the changes:

1. Enable debug-command in sentinel test.
```
Master reboot in very short time: ERR DEBUG command not allowed. If the
enable-debug-command option is set to "local", you can run it from a
local connection, otherwise you need to set this option in the
configuration file, and then restart the server.
```

2. Enable protected-config in sentinel test.
```
SDOWN is triggered by misconfigured instance replying with errors: ERR
CONFIG SET failed (possibly related to argument 'dir') - can't set
protected config
```

3. Enable debug-command in cluster test.
```
Verify slaves consistency: ERR DEBUG command not allowed. If the
enable-debug-command option is set to "local", you can run it from a
local connection, otherwise you need to set this option in the
configuration file, and then restart the server.
```

4. quicklist fill should be signed int.
The reason for the modification is to eliminate the warning.
Modify `int fill: QL_FILL_BITS` to `signed int fill: QL_FILL_BITS`

The first three were introduced at #9920 (same issue).
And the last one was introduced at #9962.