### PR TITLE
Add --version support for redis-check-rdb

### DIFF
--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -357,6 +357,20 @@ err:
     return 1;
 }
 
+static sds checkRdbVersion(void) {
+    sds version;
+    version = sdscatprintf(sdsempty(), "%s", REDIS_VERSION);
+
+    /* Add git commit and working tree status when available */
+    if (strtoll(redisGitSHA1(),NULL,16)) {
+        version = sdscatprintf(version, " (git:%s", redisGitSHA1());
+        if (strtoll(redisGitDirty(),NULL,10))
+            version = sdscatprintf(version, "-dirty");
+        version = sdscat(version, ")");
+    }
+    return version;
+}
+
 /* RDB check main: called form server.c when Redis is executed with the
  * redis-check-rdb alias, on during RDB loading errors.
  *
@@ -375,6 +389,11 @@ int redis_check_rdb_main(int argc, char **argv, FILE *fp) {
     if (argc != 2 && fp == NULL) {
         fprintf(stderr, "Usage: %s <rdb-file-name>\n", argv[0]);
         exit(1);
+    } else if (!strcmp(argv[1],"-v") || !strcmp(argv[1], "--version")) {
+        sds version = checkRdbVersion();
+        printf("redis-check-rdb %s\n", version);
+        sdsfree(version);
+        exit(0);
     }
 
     gettimeofday(&tv, NULL);


### PR DESCRIPTION
Let's you see which version of redis this tool is part of (similarly to redis-cli and redis-benchmark)