### PR TITLE
Shorten timeouts of CLIENT PAUSE to avoid hanging when tests fail.

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -851,6 +851,15 @@ proc wait_for_blocked_clients_count {count {maxtries 100} {delay 10}} {
     }
 }
 
+proc wait_for_paused_clients_count {count {maxtries 100} {delay 10}} {
+    wait_for_condition $maxtries $delay  {
+        [s blocked_clients] == $count
+    } else {
+        r client unpause
+        fail "Timeout waiting for blocked clients"
+    }
+}
+
 proc read_from_aof {fp} {
     # Input fp is a blocking binary file descriptor of an opened AOF file.
     if {[gets $fp count] == -1} return ""

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -851,15 +851,6 @@ proc wait_for_blocked_clients_count {count {maxtries 100} {delay 10}} {
     }
 }
 
-proc wait_for_paused_clients_count {count {maxtries 100} {delay 10}} {
-    wait_for_condition $maxtries $delay  {
-        [s blocked_clients] == $count
-    } else {
-        r client unpause
-        fail "Timeout waiting for blocked clients"
-    }
-}
-
 proc read_from_aof {fp} {
     # Input fp is a blocking binary file descriptor of an opened AOF file.
     if {[gets $fp count] == -1} return ""

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -1,6 +1,6 @@
 start_server {tags {"pause network"}} {
     test "Test read commands are not blocked by client pause" {
-        r client PAUSE 100000000 WRITE
+        r client PAUSE 10000 WRITE
         set rd [redis_deferring_client]
         $rd GET FOO
         $rd PING
@@ -11,11 +11,11 @@ start_server {tags {"pause network"}} {
     }
 
     test "Test write commands are paused by RO" {
-        r client PAUSE 100000000 WRITE
+        r client PAUSE 6000 WRITE
 
         set rd [redis_deferring_client]
         $rd SET FOO BAR
-        wait_for_paused_clients_count 1 50 100
+        wait_for_blocked_clients_count 1 50 100
 
         r client unpause
         assert_match "OK" [$rd read]
@@ -24,18 +24,18 @@ start_server {tags {"pause network"}} {
 
     test "Test special commands are paused by RO" {
         r PFADD pause-hll test
-        r client PAUSE 100000000 WRITE
+        r client PAUSE 11000 WRITE
 
         # Test that pfcount, which can replicate, is also blocked
         set rd [redis_deferring_client]
         $rd PFCOUNT pause-hll
-        wait_for_paused_clients_count 1 50 100
+        wait_for_blocked_clients_count 1 50 100
 
         # Test that publish, which adds the message to the replication
         # stream is blocked.
         set rd2 [redis_deferring_client]
         $rd2 publish foo bar
-        wait_for_paused_clients_count 2 50 100
+        wait_for_blocked_clients_count 2 50 100
 
         r client unpause 
         assert_match "1" [$rd read]
@@ -46,7 +46,7 @@ start_server {tags {"pause network"}} {
 
     test "Test read/admin mutli-execs are not blocked by pause RO" {
         r SET FOO BAR
-        r client PAUSE 100000000 WRITE
+        r client PAUSE 10000 WRITE
         set rd [redis_deferring_client]
         $rd MULTI
         assert_equal [$rd read] "OK"
@@ -67,33 +67,33 @@ start_server {tags {"pause network"}} {
         assert_equal [$rd read] "OK"
         $rd SET FOO BAR
         assert_equal [$rd read] "QUEUED"
-        r client PAUSE 100000000 WRITE
+        r client PAUSE 6000 WRITE
         $rd EXEC
-        wait_for_paused_clients_count 1 50 100
+        wait_for_blocked_clients_count 1 50 100
         r client unpause 
         assert_match "OK" [$rd read]
         $rd close
     }
 
     test "Test scripts are blocked by pause RO" {
-        r client PAUSE 100000000 WRITE
+        r client PAUSE 6000 WRITE
         set rd [redis_deferring_client]
         $rd EVAL "return 1" 0
 
-        wait_for_paused_clients_count 1 50 100
+        wait_for_blocked_clients_count 1 50 100
         r client unpause 
         assert_match "1" [$rd read]
         $rd close
     }
 
     test "Test multiple clients can be queued up and unblocked" {
-        r client PAUSE 100000000 WRITE
+        r client PAUSE 6000 WRITE
         set clients [list [redis_deferring_client] [redis_deferring_client] [redis_deferring_client]]
         foreach client $clients {
             $client SET FOO BAR
         }
 
-        wait_for_paused_clients_count 3 50 100
+        wait_for_blocked_clients_count 3 50 100
         r client unpause
         foreach client $clients {
             assert_match "OK" [$client read]
@@ -102,7 +102,7 @@ start_server {tags {"pause network"}} {
     }
 
     test "Test clients with syntax errors will get responses immediately" {
-        r client PAUSE 100000000 WRITE
+        r client PAUSE 10000 WRITE
         catch {r set FOO} err
         assert_match "ERR wrong number of arguments for *" $err
         r client unpause
@@ -113,7 +113,7 @@ start_server {tags {"pause network"}} {
         r multi
         r set foo{t} bar{t} PX 10
         r set bar{t} foo{t} PX 10
-        r client PAUSE 100000000 WRITE
+        r client PAUSE 5000 WRITE
         r exec
 
         wait_for_condition 10 100 {
@@ -138,14 +138,14 @@ start_server {tags {"pause network"}} {
     test "Test that client pause starts at the end of a transaction" {
         r MULTI
         r SET FOO1{t} BAR
-        r client PAUSE 100000000 WRITE
+        r client PAUSE 6000 WRITE
         r SET FOO2{t} BAR
         r exec
 
         set rd [redis_deferring_client]
         $rd SET FOO3{t} BAR
 
-        wait_for_paused_clients_count 1 50 100
+        wait_for_blocked_clients_count 1 50 100
 
         assert_match "BAR" [r GET FOO1{t}]
         assert_match "BAR" [r GET FOO2{t}]

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -1,11 +1,3 @@
-proc wait_for_paused_clients_count {count {maxtries 100} {delay 10}} {
-    wait_for_condition $maxtries $delay  {
-        [s blocked_clients] == $count
-    } else {
-        r client unpause
-        fail "Timeout waiting for blocked clients"
-    }
-}
 start_server {tags {"pause network"}} {
     test "Test read commands are not blocked by client pause" {
         r client PAUSE 100000000 WRITE

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -1,6 +1,6 @@
 start_server {tags {"pause network"}} {
     test "Test read commands are not blocked by client pause" {
-        r client PAUSE 10000 WRITE
+        r client PAUSE 100000 WRITE
         set rd [redis_deferring_client]
         $rd GET FOO
         $rd PING
@@ -11,7 +11,7 @@ start_server {tags {"pause network"}} {
     }
 
     test "Test write commands are paused by RO" {
-        r client PAUSE 6000 WRITE
+        r client PAUSE 60000 WRITE
 
         set rd [redis_deferring_client]
         $rd SET FOO BAR
@@ -24,7 +24,7 @@ start_server {tags {"pause network"}} {
 
     test "Test special commands are paused by RO" {
         r PFADD pause-hll test
-        r client PAUSE 11000 WRITE
+        r client PAUSE 100000 WRITE
 
         # Test that pfcount, which can replicate, is also blocked
         set rd [redis_deferring_client]
@@ -46,7 +46,7 @@ start_server {tags {"pause network"}} {
 
     test "Test read/admin mutli-execs are not blocked by pause RO" {
         r SET FOO BAR
-        r client PAUSE 10000 WRITE
+        r client PAUSE 100000 WRITE
         set rd [redis_deferring_client]
         $rd MULTI
         assert_equal [$rd read] "OK"
@@ -67,7 +67,7 @@ start_server {tags {"pause network"}} {
         assert_equal [$rd read] "OK"
         $rd SET FOO BAR
         assert_equal [$rd read] "QUEUED"
-        r client PAUSE 6000 WRITE
+        r client PAUSE 60000 WRITE
         $rd EXEC
         wait_for_blocked_clients_count 1 50 100
         r client unpause 
@@ -76,7 +76,7 @@ start_server {tags {"pause network"}} {
     }
 
     test "Test scripts are blocked by pause RO" {
-        r client PAUSE 6000 WRITE
+        r client PAUSE 60000 WRITE
         set rd [redis_deferring_client]
         $rd EVAL "return 1" 0
 
@@ -87,7 +87,7 @@ start_server {tags {"pause network"}} {
     }
 
     test "Test multiple clients can be queued up and unblocked" {
-        r client PAUSE 6000 WRITE
+        r client PAUSE 60000 WRITE
         set clients [list [redis_deferring_client] [redis_deferring_client] [redis_deferring_client]]
         foreach client $clients {
             $client SET FOO BAR
@@ -102,7 +102,7 @@ start_server {tags {"pause network"}} {
     }
 
     test "Test clients with syntax errors will get responses immediately" {
-        r client PAUSE 10000 WRITE
+        r client PAUSE 100000 WRITE
         catch {r set FOO} err
         assert_match "ERR wrong number of arguments for *" $err
         r client unpause
@@ -113,7 +113,7 @@ start_server {tags {"pause network"}} {
         r multi
         r set foo{t} bar{t} PX 10
         r set bar{t} foo{t} PX 10
-        r client PAUSE 5000 WRITE
+        r client PAUSE 50000 WRITE
         r exec
 
         wait_for_condition 10 100 {
@@ -138,7 +138,7 @@ start_server {tags {"pause network"}} {
     test "Test that client pause starts at the end of a transaction" {
         r MULTI
         r SET FOO1{t} BAR
-        r client PAUSE 6000 WRITE
+        r client PAUSE 60000 WRITE
         r SET FOO2{t} BAR
         r exec
 


### PR DESCRIPTION
# Intro
If a test fails at `wait_for_blocked_clients_count` after the `PAUSE` command, It won't send `UNPAUSE` to server, leading to the server hanging until timeout, which is bad and hard to debug sometimes when developing.
This PR tries to fix this.
# Changes
Timeout in `CLIENT PAUSE` shortened from 1e5 seconds(extremely long) to 50~100 seconds.