### PR TITLE
Use correct atomic operation while generating client id

### DIFF
--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -103,6 +103,12 @@
 } while(0)
 #define atomicSetWithSync(var,value) \
     atomic_store_explicit(&var,value,memory_order_seq_cst)
+#define atomicIncrWithSync(var,count) atomic_fetch_add_explicit(&var,(count),memory_order_seq_cst)
+#define atomicGetIncrWithSync(var,oldvalue_var,count) do { \
+    oldvalue_var = atomic_fetch_add_explicit(&var,(count),memory_order_seq_cst); \
+} while(0)
+#define atomicDecrWithSync(var,count) atomic_fetch_sub_explicit(&var,(count),memory_order_seq_cst)
+
 #define REDIS_ATOMIC_API "c11-builtin"
 
 #elif !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && \
@@ -124,6 +130,11 @@
 } while(0)
 #define atomicSetWithSync(var,value) \
     __atomic_store_n(&var,value,__ATOMIC_SEQ_CST)
+#define atomicIncrWithSync(var,count) __atomic_add_fetch(&var,(count),__ATOMIC_SEQ_CST)
+#define atomicGetIncrWithSync(var,oldvalue_var,count) do { \
+    oldvalue_var = __atomic_fetch_add(&var,(count),__ATOMIC_SEQ_CST); \
+} while(0)
+#define atomicDecrWithSync(var,count) __atomic_sub_fetch(&var,(count),__ATOMIC_SEQ_CST)
 #define REDIS_ATOMIC_API "atomic-builtin"
 
 #elif defined(HAVE_ATOMIC)
@@ -149,6 +160,9 @@
     ANNOTATE_HAPPENS_BEFORE(&var);  \
     while(!__sync_bool_compare_and_swap(&var,var,value,__sync_synchronize)); \
 } while(0)
+#define atomicIncrWithSync atomicIncr
+#define atomicGetIncrWithSync atomicGetIncr
+#define atomicDecrWithSync atomicDecr
 #define REDIS_ATOMIC_API "sync-builtin"
 
 #else

--- a/src/networking.c
+++ b/src/networking.c
@@ -134,7 +134,7 @@ client *createClient(connection *conn) {
 
     selectDb(c,0);
     uint64_t client_id;
-    atomicGetIncr(server.next_client_id, client_id, 1);
+    atomicGetIncrWithSync(server.next_client_id, client_id, 1);
     c->id = client_id;
     c->resp = 2;
     c->conn = conn;


### PR DESCRIPTION
To generate a client id, atomicGetIncr() is called. atomicGetIncr() uses memory_order_relaxed which does not guarantee visibility. If createClient() is called from different threads, it might cause generating same id for different clients. 

This PR adds incr/decr atomic operations with visibility guarantees and uses atomicGetIncrWithSync() for client id generation. 