### PR TITLE
Modules: Mark APIs non-experimental

### DIFF
--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -876,9 +876,6 @@ REDISMODULE_API int (*RedisModule_SetCommandKeySpecBeginSearchKeyword)(RedisModu
 REDISMODULE_API int (*RedisModule_SetCommandKeySpecFindKeysRange)(RedisModuleCommand *command, int spec_id, int lastkey, int keystep, int limit) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandKeySpecFindKeysKeynum)(RedisModuleCommand *command, int spec_id, int keynumidx, int firstkey, int keystep) REDISMODULE_ATTR;
 
-/* Experimental APIs */
-#ifdef REDISMODULE_EXPERIMENTAL_API
-#define REDISMODULE_EXPERIMENTAL_API_VERSION 3
 REDISMODULE_API RedisModuleBlockedClient * (*RedisModule_BlockClient)(RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback, RedisModuleCmdFunc timeout_callback, void (*free_privdata)(RedisModuleCtx*,void*), long long timeout_ms) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_UnblockClient)(RedisModuleBlockedClient *bc, void *privdata) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsBlockedReplyRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -950,7 +947,6 @@ REDISMODULE_API int (*RedisModule_DefragCursorSet)(RedisModuleDefragCtx *ctx, un
 REDISMODULE_API int (*RedisModule_DefragCursorGet)(RedisModuleDefragCtx *ctx, unsigned long *cursor) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetDbIdFromDefragCtx)(RedisModuleDefragCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API const RedisModuleString * (*RedisModule_GetKeyNameFromDefragCtx)(RedisModuleDefragCtx *ctx) REDISMODULE_ATTR;
-#endif
 
 #define RedisModule_IsAOFClient(id) ((id) == UINT64_MAX)
 
@@ -1198,8 +1194,6 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(SetCommandKeySpecBeginSearchKeyword);
     REDISMODULE_GET_API(SetCommandKeySpecFindKeysRange);
     REDISMODULE_GET_API(SetCommandKeySpecFindKeysKeynum);
-
-#ifdef REDISMODULE_EXPERIMENTAL_API
     REDISMODULE_GET_API(GetThreadSafeContext);
     REDISMODULE_GET_API(GetDetachedThreadSafeContext);
     REDISMODULE_GET_API(FreeThreadSafeContext);
@@ -1271,7 +1265,6 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(DefragCursorGet);
     REDISMODULE_GET_API(GetKeyNameFromDefragCtx);
     REDISMODULE_GET_API(GetDbIdFromDefragCtx);
-#endif
 
     if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;
     RedisModule_SetModuleAttribs(ctx,name,ver,apiver);

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -1,4 +1,3 @@
-#define REDISMODULE_EXPERIMENTAL_API
 
 #include "redismodule.h"
 #include <errno.h>

--- a/tests/modules/auth.c
+++ b/tests/modules/auth.c
@@ -1,4 +1,3 @@
-#define REDISMODULE_EXPERIMENTAL_API
 #include "redismodule.h"
 
 // A simple global user

--- a/tests/modules/basics.c
+++ b/tests/modules/basics.c
@@ -30,7 +30,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define REDISMODULE_EXPERIMENTAL_API
 #include "redismodule.h"
 #include <string.h>
 #include <stdlib.h>

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -1,4 +1,3 @@
-#define REDISMODULE_EXPERIMENTAL_API
 #include "redismodule.h"
 #include <assert.h>
 #include <stdio.h>

--- a/tests/modules/blockonbackground.c
+++ b/tests/modules/blockonbackground.c
@@ -1,4 +1,3 @@
-#define REDISMODULE_EXPERIMENTAL_API
 #define _XOPEN_SOURCE 700
 #include "redismodule.h"
 #include <stdio.h>

--- a/tests/modules/blockonkeys.c
+++ b/tests/modules/blockonkeys.c
@@ -1,4 +1,3 @@
-#define REDISMODULE_EXPERIMENTAL_API
 #include "redismodule.h"
 
 #include <string.h>

--- a/tests/modules/commandfilter.c
+++ b/tests/modules/commandfilter.c
@@ -1,4 +1,3 @@
-#define REDISMODULE_EXPERIMENTAL_API
 #include "redismodule.h"
 
 #include <string.h>

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -1,7 +1,6 @@
 /* A module that implements defrag callback mechanisms.
  */
 
-#define REDISMODULE_EXPERIMENTAL_API
 #include "redismodule.h"
 #include <stdlib.h>
 

--- a/tests/modules/fork.c
+++ b/tests/modules/fork.c
@@ -1,4 +1,3 @@
-#define REDISMODULE_EXPERIMENTAL_API
 
 /* define macros for having usleep */
 #define _BSD_SOURCE

--- a/tests/modules/getkeys.c
+++ b/tests/modules/getkeys.c
@@ -1,4 +1,3 @@
-#define REDISMODULE_EXPERIMENTAL_API
 
 #include "redismodule.h"
 #include <strings.h>

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -30,7 +30,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define REDISMODULE_EXPERIMENTAL_API
 
 #include "redismodule.h"
 #include <stdio.h>

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -1,4 +1,3 @@
-#define REDISMODULE_EXPERIMENTAL_API
 #include "redismodule.h"
 
 #include <string.h>

--- a/tests/modules/propagate.c
+++ b/tests/modules/propagate.c
@@ -37,7 +37,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define REDISMODULE_EXPERIMENTAL_API
 #include "redismodule.h"
 #include <pthread.h>
 

--- a/tests/modules/timer.c
+++ b/tests/modules/timer.c
@@ -1,5 +1,4 @@
 
-#define REDISMODULE_EXPERIMENTAL_API
 #include "redismodule.h"
 
 static void timer_callback(RedisModuleCtx *ctx, void *data)


### PR DESCRIPTION
Many API functions have existed since Redis 4 and it makes no sense that they're flagged as experimental.

The API reference doesn't even mention that some of them are experimental. It makes them hard to use without source code debugging (which shouldn't be necessary with good docs).

Here I simply make all of them non-experimental, but if some of them are new enough and should remain experimental, just say so.

This is thing no. 4 in #6860 and "Graduate from experimental API some of the stuff" in #8157.