### PR TITLE
Changed fuction name to be case insensitive.

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -462,7 +462,7 @@ static int functionsVerifyName(sds name) {
 int functionsCreateWithFunctionCtx(sds function_name,sds engine_name, sds desc, sds code,
                                    int replace, sds* err, functionsCtx *functions) {
     if (functionsVerifyName(function_name)) {
-        *err = sdsnew("Bad function name given, function name should follow the following format: [a-zA-Z0-9_][a-zA-Z0-9_]?");
+        *err = sdsnew("Function names can only contain letters and numbers and must be at least one character long");
         return C_ERR;
     }
 

--- a/src/functions.c
+++ b/src/functions.c
@@ -438,10 +438,39 @@ NULL };
     addReplyHelp(c, help);
 }
 
+/* Verify that the function name is of the format: [a-zA-Z0-9_][a-zA-Z0-9_]? */
+static int functionsVerifyName(sds name) {
+    if (sdslen(name) == 0) {
+        return C_ERR;
+    }
+    for (size_t i = 0 ; i < sdslen(name) ; ++i) {
+        char curr_char = name[i];
+        if (curr_char >= 'a' && curr_char <= 'z') {
+            continue;
+        }
+        if (curr_char >= 'A' && curr_char <= 'Z') {
+            continue;
+        }
+        if (curr_char >= '0' && curr_char <= '9') {
+            continue;
+        }
+        if (curr_char == '_') {
+            continue;
+        }
+        return C_ERR;
+    }
+    return C_OK;
+}
+
 /* Compile and save the given function, return C_OK on success and C_ERR on failure.
  * In case on failure the err out param is set with relevant error message */
 int functionsCreateWithFunctionCtx(sds function_name,sds engine_name, sds desc, sds code,
                                    int replace, sds* err, functionsCtx *functions) {
+    if (functionsVerifyName(function_name)) {
+        *err = sdsnew("Bad function name given, function name should follow the following format: [a-zA-Z0-9_][a-zA-Z0-9_]?");
+        return C_ERR;
+    }
+
     engineInfo *ei = dictFetchValue(engines, engine_name);
     if (!ei) {
         *err = sdsnew("Engine not found");

--- a/src/functions.c
+++ b/src/functions.c
@@ -54,10 +54,10 @@ dictType engineDictType = {
 };
 
 dictType functionDictType = {
-        dictSdsHash,          /* hash function */
+        dictSdsCaseHash,      /* hash function */
         dictSdsDup,           /* key dup */
         NULL,                 /* val dup */
-        dictSdsKeyCompare,    /* key compare */
+        dictSdsKeyCaseCompare,/* key compare */
         dictSdsDestructor,    /* key destructor */
         engineFunctionDispose,/* val destructor */
         NULL                  /* allow to expand */

--- a/src/functions.c
+++ b/src/functions.c
@@ -445,16 +445,11 @@ static int functionsVerifyName(sds name) {
     }
     for (size_t i = 0 ; i < sdslen(name) ; ++i) {
         char curr_char = name[i];
-        if (curr_char >= 'a' && curr_char <= 'z') {
-            continue;
-        }
-        if (curr_char >= 'A' && curr_char <= 'Z') {
-            continue;
-        }
-        if (curr_char >= '0' && curr_char <= '9') {
-            continue;
-        }
-        if (curr_char == '_') {
+        if ((curr_char >= 'a' && curr_char <= 'z') ||
+            (curr_char >= 'A' && curr_char <= 'Z') ||
+            (curr_char >= '0' && curr_char <= '9') ||
+            (curr_char == '_'))
+        {
             continue;
         }
         return C_ERR;

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -18,6 +18,13 @@ start_server {tags {"scripting"}} {
         set _ $e
     } {*Function already exists*}
 
+    test {FUNCTION - Create a function with wrong name format} {
+        catch {
+            r function create LUA {bad\0foramat} {return 'hello1'}
+        } e
+        set _ $e
+    } {*Bad function name*}
+
     test {FUNCTION - Create function with unexisting engine} {
         catch {
             r function create bad_engine test {return 'hello1'}

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -11,6 +11,13 @@ start_server {tags {"scripting"}} {
         set _ $e
     } {*Function already exists*}
 
+    test {FUNCTION - Create an already exiting function raise error (case insensitive)} {
+        catch {
+            r function create LUA TEST {return 'hello1'}
+        } e
+        set _ $e
+    } {*Function already exists*}
+
     test {FUNCTION - Create function with unexisting engine} {
         catch {
             r function create bad_engine test {return 'hello1'}
@@ -28,6 +35,10 @@ start_server {tags {"scripting"}} {
     test {FUNCTION - test replace argument} {
         r function create LUA test REPLACE {return 'hello1'}
         r fcall test 0
+    } {hello1}
+
+    test {FUNCTION - test function case insensitive} {
+        r fcall TEST 0
     } {hello1}
 
     test {FUNCTION - test replace argument with function creation failure keeps old function} {

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -23,7 +23,7 @@ start_server {tags {"scripting"}} {
             r function create LUA {bad\0foramat} {return 'hello1'}
         } e
         set _ $e
-    } {*Bad function name*}
+    } {*Function names can only contain letters and numbers*}
 
     test {FUNCTION - Create function with unexisting engine} {
         catch {


### PR DESCRIPTION
Use case insensitive string comparison for function names (like we do for commands and configs)
In addition, add verification that the functions only use the following characters: `[a-zA-Z0-9_]`

Before this fix:
```
> FUNCTION CREATE LUA TEST "return 1"
OK
> FCALL TEST 0
1
> FCALL test 0
ERR Function not found
```

After this fix:
```
> FUNCTION CREATE LUA TEST "return 1"
OK
> FCALL TEST 0
1
> FCALL test 0
1
```

