### PR TITLE
Add zlib link option when TLS enabled

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -216,14 +216,16 @@ ifeq ($(LIBSSL_PKGCONFIG),0)
 	LIBSSL_LIBS=$(shell $(PKG_CONFIG) --libs libssl)
 else
 	LIBSSL_LIBS=-lssl
+	LIBZ_LIBS=-lz
 endif
 	LIBCRYPTO_PKGCONFIG := $(shell $(PKG_CONFIG) --exists libcrypto && echo $$?)
 ifeq ($(LIBCRYPTO_PKGCONFIG),0)
 	LIBCRYPTO_LIBS=$(shell $(PKG_CONFIG) --libs libcrypto)
 else
 	LIBCRYPTO_LIBS=-lcrypto
+	LIBZ_LIBS=-lz
 endif
-	FINAL_LIBS += ../deps/hiredis/libhiredis_ssl.a $(LIBSSL_LIBS) $(LIBCRYPTO_LIBS)
+	FINAL_LIBS += ../deps/hiredis/libhiredis_ssl.a $(LIBSSL_LIBS) $(LIBCRYPTO_LIBS) $(LIBZ_LIBS)
 endif
 
 REDIS_CC=$(QUIET_CC)$(CC) $(FINAL_CFLAGS)


### PR DESCRIPTION
The current behaviour is to run pkg-config to get the right link flags.
This is good for systems that can rely upon the this.

On some, we cannot rely on it. In that case, the Makefile add the
hardcoded `-lcrypto` and `-lssl` but the `-lz` is missing.

Moreover, it does not help to set it in the `REDIS_LDFLAGS`.

The idea is that, if we need to add openssl link flags, let's add zlib
too.