### PR TITLE
Avoid link collisions when TLS support is activated

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -684,7 +684,7 @@ void ACLAddAllowedSubcommand(user *u, unsigned long id, const char *sub) {
     /* If this is the first subcommand to be configured for
      * this user, we have to allocate the subcommands array. */
     if (u->allowed_subcommands == NULL) {
-        u->allowed_subcommands = zcalloc(USER_COMMAND_BITS_COUNT *
+        u->allowed_subcommands = redis_zcalloc(USER_COMMAND_BITS_COUNT *
                                  sizeof(sds*));
     }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2551,7 +2551,7 @@ void clusterSendPing(clusterLink *link, int type) {
     /* Note: clusterBuildMessageHdr() expects the buffer to be always at least
      * sizeof(clusterMsg) or more. */
     if (totlen < (int)sizeof(clusterMsg)) totlen = sizeof(clusterMsg);
-    buf = zcalloc(totlen);
+    buf = redis_zcalloc(totlen);
     hdr = (clusterMsg*) buf;
 
     /* Populate the header. */

--- a/src/connection.c
+++ b/src/connection.c
@@ -75,7 +75,7 @@ ConnectionType CT_Socket;
  */
 
 connection *connCreateSocket() {
-    connection *conn = zcalloc(sizeof(connection));
+    connection *conn = redis_zcalloc(sizeof(connection));
     conn->type = &CT_Socket;
     conn->fd = -1;
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -160,7 +160,7 @@ int dictExpand(dict *d, unsigned long size)
     /* Allocate the new hash table and initialize all pointers to NULL */
     n.size = realsize;
     n.sizemask = realsize-1;
-    n.table = zcalloc(realsize*sizeof(dictEntry*));
+    n.table = redis_zcalloc(realsize*sizeof(dictEntry*));
     n.used = 0;
 
     /* Is this the first initialization? If so it's not really a rehashing

--- a/src/geo.c
+++ b/src/geo.c
@@ -413,7 +413,7 @@ void geoaddCommand(client *c) {
 
     int elements = (c->argc - 2) / 3;
     int argc = 2+elements*2; /* ZADD key score ele ... */
-    robj **argv = zcalloc(argc*sizeof(robj*));
+    robj **argv = redis_zcalloc(argc*sizeof(robj*));
     argv[0] = createRawStringObject("zadd",4);
     argv[1] = c->argv[1]; /* key */
     incrRefCount(argv[1]);

--- a/src/module.c
+++ b/src/module.c
@@ -400,7 +400,7 @@ void *RM_Alloc(size_t bytes) {
  * and in general is taken into account as memory allocated by Redis.
  * You should avoid using calloc() directly. */
 void *RM_Calloc(size_t nmemb, size_t size) {
-    return zcalloc(nmemb*size);
+    return redis_zcalloc(nmemb*size);
 }
 
 /* Use like realloc() for memory obtained with RedisModule_Alloc(). */
@@ -3723,7 +3723,7 @@ moduleType *RM_CreateDataType(RedisModuleCtx *ctx, const char *name, int encver,
         } v2;
     } *tms = (struct typemethods*) typemethods_ptr;
 
-    moduleType *mt = zcalloc(sizeof(*mt));
+    moduleType *mt = redis_zcalloc(sizeof(*mt));
     mt->id = id;
     mt->module = ctx->module;
     mt->rdb_load = tms->rdb_load;

--- a/src/object.c
+++ b/src/object.c
@@ -953,7 +953,7 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
     size_t mem_total = 0;
     size_t mem = 0;
     size_t zmalloc_used = zmalloc_used_memory();
-    struct redisMemOverhead *mh = zcalloc(sizeof(*mh));
+    struct redisMemOverhead *mh = redis_zcalloc(sizeof(*mh));
 
     mh->total_allocated = zmalloc_used;
     mh->startup_allocated = server.initial_memory_usage;

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -290,7 +290,7 @@ cleanup:
 static redisConfig *getRedisConfig(const char *ip, int port,
                                    const char *hostsocket)
 {
-    redisConfig *cfg = zcalloc(sizeof(*cfg));
+    redisConfig *cfg = redis_zcalloc(sizeof(*cfg));
     if (!cfg) return NULL;
     redisContext *c = NULL;
     redisReply *reply = NULL, *sub_reply = NULL;
@@ -1263,7 +1263,7 @@ static int fetchClusterSlotsConfiguration(client c) {
         sdsfree(name);
         clusterNode *node = dictGetVal(entry);
         if (node->updated_slots == NULL)
-            node->updated_slots = zcalloc(CLUSTER_SLOTS * sizeof(int));
+            node->updated_slots = redis_zcalloc(CLUSTER_SLOTS * sizeof(int));
         for (slot = from; slot <= to; slot++)
             node->updated_slots[node->updated_slots_count++] = slot;
     }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2792,7 +2792,7 @@ static int clusterManagerGetAntiAffinityScore(clusterManagerNodeArray *ipnodes,
     int node_len = cluster_manager.nodes->len;
     clusterManagerNode **offending_p = NULL;
     if (offending != NULL) {
-        *offending = zcalloc(node_len * sizeof(clusterManagerNode*));
+        *offending = redis_zcalloc(node_len * sizeof(clusterManagerNode*));
         offending_p = *offending;
     }
     /* For each set of nodes in the same host, split by
@@ -2881,7 +2881,7 @@ static void clusterManagerOptimizeAntiAffinity(clusterManagerNodeArray *ipnodes,
         int rand_idx = rand() % offending_len;
         clusterManagerNode *first = offenders[rand_idx],
                            *second = NULL;
-        clusterManagerNode **other_replicas = zcalloc((node_len - 1) *
+        clusterManagerNode **other_replicas = redis_zcalloc((node_len - 1) *
                                                       sizeof(*other_replicas));
         int other_replicas_count = 0;
         listIter li;
@@ -3399,8 +3399,8 @@ static int clusterManagerCompareKeysValues(clusterManagerNode *n1,
 {
     size_t i, argc = keys_reply->elements + 2;
     static const char *hash_zero = "0000000000000000000000000000000000000000";
-    char **argv = zcalloc(argc * sizeof(char *));
-    size_t  *argv_len = zcalloc(argc * sizeof(size_t));
+    char **argv = redis_zcalloc(argc * sizeof(char *));
+    size_t  *argv_len = redis_zcalloc(argc * sizeof(size_t));
     argv[0] = "DEBUG";
     argv_len[0] = 5;
     argv[1] = "DIGEST-VALUE";
@@ -3468,8 +3468,8 @@ static redisReply *clusterManagerMigrateKeysInReply(clusterManagerNode *source,
     if (config.user) c += 1;
     size_t argc = c + reply->elements;
     size_t i, offset = 6; // Keys Offset
-    argv = zcalloc(argc * sizeof(char *));
-    argv_len = zcalloc(argc * sizeof(size_t));
+    argv = redis_zcalloc(argc * sizeof(char *));
+    argv_len = redis_zcalloc(argc * sizeof(size_t));
     char portstr[255];
     char timeoutstr[255];
     snprintf(portstr, 10, "%d", target->port);
@@ -5313,7 +5313,7 @@ static void clusterManagerLog(int level, const char* fmt, ...) {
 static void clusterManagerNodeArrayInit(clusterManagerNodeArray *array,
                                         int alloc_len)
 {
-    array->nodes = zcalloc(alloc_len * sizeof(clusterManagerNode*));
+    array->nodes = redis_zcalloc(alloc_len * sizeof(clusterManagerNode*));
     array->alloc = array->nodes;
     array->len = alloc_len;
     array->count = 0;
@@ -5452,9 +5452,9 @@ static int clusterManagerCommandCreate(int argc, char **argv) {
     clusterManagerLogInfo(">>> Performing hash slots allocation "
                           "on %d nodes...\n", node_len);
     int interleaved_len = 0, ip_count = 0;
-    clusterManagerNode **interleaved = zcalloc(node_len*sizeof(**interleaved));
-    char **ips = zcalloc(node_len * sizeof(char*));
-    clusterManagerNodeArray *ip_nodes = zcalloc(node_len * sizeof(*ip_nodes));
+    clusterManagerNode **interleaved = redis_zcalloc(node_len*sizeof(**interleaved));
+    char **ips = redis_zcalloc(node_len * sizeof(char*));
+    clusterManagerNodeArray *ip_nodes = redis_zcalloc(node_len * sizeof(*ip_nodes));
     listIter li;
     listNode *ln;
     listRewind(cluster_manager.nodes, &li);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2214,7 +2214,7 @@ void zunionInterGenericCommand(client *c, robj *dstkey, int op) {
     }
 
     /* read keys to be used for input */
-    src = zcalloc(sizeof(zsetopsrc) * setnum);
+    src = redis_zcalloc(sizeof(zsetopsrc) * setnum);
     for (i = 0, j = 3; i < setnum; i++, j++) {
         robj *obj = lookupKeyWrite(c->db,c->argv[j]);
         if (obj != NULL) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -333,7 +333,7 @@ typedef struct tls_connection {
 } tls_connection;
 
 connection *connCreateTLS(void) {
-    tls_connection *conn = zcalloc(sizeof(tls_connection));
+    tls_connection *conn = redis_zcalloc(sizeof(tls_connection));
     conn->c.type = &CT_TLS;
     conn->c.fd = -1;
     conn->ssl = SSL_new(redis_tls_ctx);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -132,7 +132,7 @@ void zfree_no_tcache(void *ptr) {
 }
 #endif
 
-void *zcalloc(size_t size) {
+void *redis_zcalloc(size_t size) {
     ASSERT_NO_SIZE_OVERFLOW(size);
     void *ptr = calloc(1, size+PREFIX_SIZE);
 

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -78,7 +78,7 @@
 #endif
 
 void *zmalloc(size_t size);
-void *zcalloc(size_t size);
+void *redis_zcalloc(size_t size);
 void *zrealloc(void *ptr, size_t size);
 void zfree(void *ptr);
 char *zstrdup(const char *s);


### PR DESCRIPTION
If we try to link statically the binaries with TLS support, (we only
have the static archive libcrypto.a, libssl.a and libz.a), we have
multiple definition of the symbol `zcalloc`.

```
/lib/gcc/x86_64-1a-linux-gnu/6.5.0/../../../../x86_64-1a-linux-gnu/bin/ld:
/home/docker/development/opensource-pack-builder/components/redis-server/DEPS/root/lib/libz.a(zutil.o):
in function `zcalloc':
zutil.c:309: multiple definition of `zcalloc';
zmalloc.o:/redis-6.0.9/src/zmalloc.c:135: first defined here
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:318: redis-cli] Error 1
make[1]: *** Waiting for unfinished jobs....
/lib/gcc/x86_64-1a-linux-gnu/6.5.0/../../../../x86_64-1a-linux-gnu/bin/ld:
/home/docker/development/opensource-pack-builder/components/redis-server/DEPS/root/lib/libz.a(zutil.o):
in function `zcalloc':
zutil.c:309: multiple definition of `zcalloc';
zmalloc.o:/redis-6.0.9/src/zmalloc.c:135: first defined here
```

This PR fix that error but I think some symbols should be prefixed to
avoid any future naming collisions.