### PR TITLE
Safe and organized exit when receiving sigterm while loading

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5566,7 +5566,7 @@ static void sigShutdownHandler(int sig) {
         rdbRemoveTempFile(getpid(), 1);
         exit(1); /* Exit with an error since this was not a clean shutdown. */
     } else if (server.loading) {
-        serverLogFromHandler(LL_WARNING, "Received shutdown signal during loading, scheduling shutdown.");
+        msg = "Received shutdown signal during loading, scheduling shutdown.";
     }
 
     serverLogFromHandler(LL_WARNING, msg);

--- a/src/server.c
+++ b/src/server.c
@@ -1373,7 +1373,6 @@ void whileBlockedCron() {
     /* We received a SIGTERM during loading, shutting down here in a safe way,
      * as it isn't ok doing so inside the signal handler. */
     if (server.shutdown_asap && server.loading) {
-        serverLog(LL_WARNING,"Received shutdown signal during loading, check the logs for more information");
         if (prepareForShutdown(SHUTDOWN_NOSAVE) == C_OK) exit(0);
         serverLog(LL_WARNING,"SIGTERM received but errors trying to shut down the server, check the logs for more information");
         server.shutdown_asap = 0;
@@ -5566,6 +5565,8 @@ static void sigShutdownHandler(int sig) {
         serverLogFromHandler(LL_WARNING, "You insist... exiting now.");
         rdbRemoveTempFile(getpid(), 1);
         exit(1); /* Exit with an error since this was not a clean shutdown. */
+    } else if (server.loading) {
+        serverLogFromHandler(LL_WARNING, "Received shutdown signal during loading, scheduling shutdown.");
     }
 
     serverLogFromHandler(LL_WARNING, msg);


### PR DESCRIPTION
on the signal handler we are enabling server.shutdown_asap flag instead of just doing `exit()`,
and then catch it on the whileBlockedCron() where we prepare for shutdown correctly.

this is a more ore organized and safe termination, the old approach was missing these for example:
1. removal of the pidfile
2. shutdown event to modules