### PR TITLE
Fix failing test due to recent change in transaction propagation

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3538,10 +3538,7 @@ int processCommand(client *c) {
         c->cmd->proc != multiCommand &&
         c->cmd->proc != watchCommand &&
         c->cmd->proc != quitCommand &&
-        c->cmd->proc != resetCommand &&
-        c->cmd->proc != bgrewriteaofCommand &&
-        c->cmd->proc != bgsaveCommand &&
-        c->cmd->proc != saveCommand)
+        c->cmd->proc != resetCommand)
     {
         queueMultiCommand(c);
         addReply(c,shared.queued);

--- a/src/server.c
+++ b/src/server.c
@@ -3538,7 +3538,10 @@ int processCommand(client *c) {
         c->cmd->proc != multiCommand &&
         c->cmd->proc != watchCommand &&
         c->cmd->proc != quitCommand &&
-        c->cmd->proc != resetCommand)
+        c->cmd->proc != resetCommand &&
+        c->cmd->proc != bgrewriteaofCommand &&
+        c->cmd->proc != bgsaveCommand &&
+        c->cmd->proc != saveCommand)
     {
         queueMultiCommand(c);
         addReply(c,shared.queued);


### PR DESCRIPTION
PR #9890 may have introduced a problem.
There are tests that use MULTI-EXEC to make sure two BGSAVE / BGREWRITEAOF are executed together.
But now it's not valid to run run commands that create a snapshot inside a transaction (gonna be blocked soon)
This PR modifies the test not to rely on MULTI-EXEC.

Old description 
----

let me describe the phenomenon.

start redis server: `./src/redis-server --appendonly yes --aof-use-rdb-preamble no`

start a redis-cli

then execute the following sequence commands:
```
127.0.0.1:6379> multi
OK
127.0.0.1:6379(TX)> lpush listkey e1
QUEUED
127.0.0.1:6379(TX)> lpush listkey e2
QUEUED
127.0.0.1:6379(TX)> BGREWRITEAOF
QUEUED
127.0.0.1:6379(TX)> exec
1) (integer) 1
2) (integer) 2
3) Background append only file rewriting started
```
Then I get the following AOF:
```
*2
$6
SELECT
$1
0
*4
$5
RPUSH
$7
listkey
$2
e2
$2
e1
*2
$6
SELECT
$1
0
*1
$5
MULTI
*3
$5
lpush
$7
listkey
$2
e1
*3
$5
lpush
$7
listkey
$2
e2
*1
$4
EXEC
```
We can see that `e1` and `e2` have been added twice, restart redis and load AOF:
```
127.0.0.1:6379> llen listkey
(integer) 4
```

Then  i tested the version before the PR #9890 
I get the following AOF:
```
*2
$6
SELECT
$1
0
*4
$5
RPUSH
$7
listkey
$2
e2
$2
e1
*2
$6
SELECT
$1
0
*1
$4
exec
```
Obviously we have got an incomplete transaction record. restart redis server:
```
22656:M 27 Dec 2021 11:09:29.514 # Server initialized
22656:M 27 Dec 2021 11:09:29.514 # == CRITICAL == This server is sending an error to its AOF-loading-client: 'EXEC without MULTI' after processing the command 'exec'
22656:M 27 Dec 2021 11:09:29.515 * DB loaded from append only file: 0.000 seconds
22656:M 27 Dec 2021 11:09:29.515 * Ready to accept connections
```
But we can still get the correct data：
```
127.0.0.1:6379> llen listkey
(integer) 2
```

So, i simply modified the code(without corresponding test), I am not sure if this modification will cause other problems. At least I think that allowing `bgsave/bgrewriteaof/save` commands to be executed in a transaction is not a wise choice.

So I think `bgsave/bgrewriteaof/save` should not be executed in a transaction, they should be executed immediately, and the unfinished data should not be persisted to disk.

