### PR TITLE
Tests: don't rely on the response of MEMORY USAGE when mem_allocator is not jemalloc

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -1002,3 +1002,11 @@ proc prepare_value {size} {
     }
     return $_v
 }
+
+proc memory_usage {key} {
+    set usage 1
+    if {[string match {*jemalloc*} [s mem_allocator]]} {
+        set usage [r memory usage $key]
+    }
+    return $usage
+}

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -1004,9 +1004,11 @@ proc prepare_value {size} {
 }
 
 proc memory_usage {key} {
-    set usage 1
-    if {[string match {*jemalloc*} [s mem_allocator]]} {
-        set usage [r memory usage $key]
+    set usage [r memory usage $key]
+    if {![string match {*jemalloc*} [s mem_allocator]]} {
+        # libc allocator can sometimes return a different size allocation for the same requested size
+        # this makes tests that rely on MEMORY USAGE unreliable, so instead we return a constant 1
+        set usage 1
     }
     return $usage
 }

--- a/tests/unit/moduleapi/datatype2.tcl
+++ b/tests/unit/moduleapi/datatype2.tcl
@@ -214,21 +214,19 @@ start_server {tags {"modules"}} {
         assert_equal $digest0 $digest1
     }
 
-    if {[string match {*jemalloc*} [s mem_allocator]]} {
-        test "datatype2: test memusage" {
-            r flushall
+    test "datatype2: test memusage" {
+        r flushall
 
-            set data k1
-            assert_equal 3 [r mem.alloc k1 3]
-            assert_equal [string length $data] [r mem.write k1 1 $data]
-            assert_equal $data [r mem.read k1 1]
+        set data k1
+        assert_equal 3 [r mem.alloc k1 3]
+        assert_equal [string length $data] [r mem.write k1 1 $data]
+        assert_equal $data [r mem.read k1 1]
 
-            set data k2
-            assert_equal 3 [r mem.alloc k2 3]
-            assert_equal [string length $data] [r mem.write k2 0 $data]
-            assert_equal $data [r mem.read k2 0]
+        set data k2
+        assert_equal 3 [r mem.alloc k2 3]
+        assert_equal [string length $data] [r mem.write k2 0 $data]
+        assert_equal $data [r mem.read k2 0]
 
-            assert_equal [r memory usage k1] [r memory usage k2] 
-        }
+        assert_equal [memory_usage k1] [memory_usage k2] 
     }
 }

--- a/tests/unit/moduleapi/datatype2.tcl
+++ b/tests/unit/moduleapi/datatype2.tcl
@@ -5,12 +5,12 @@ start_server {tags {"modules"}} {
 
     test "datatype2: test mem alloc and free" {
         r flushall
+
         r select 0
         assert_equal 3 [r mem.alloc k1 3]
         assert_equal 2 [r mem.alloc k2 2]
 
         r select 1
-
         assert_equal 1 [r mem.alloc k1 1]
         assert_equal 5 [r mem.alloc k2 5]
 
@@ -25,6 +25,7 @@ start_server {tags {"modules"}} {
 
     test "datatype2: test del and unlink" {
         r flushall
+
         assert_equal 100 [r mem.alloc k1 100]
         assert_equal 60 [r mem.alloc k2 60]
 
@@ -44,8 +45,8 @@ start_server {tags {"modules"}} {
 
     test "datatype2: test rdb save and load" {
         r flushall
-        r select 0
 
+        r select 0
         set data k1
         assert_equal 3 [r mem.alloc k1 3]
         assert_equal [string length $data] [r mem.write k1 1 $data]
@@ -55,7 +56,6 @@ start_server {tags {"modules"}} {
         assert_equal [string length $data] [r mem.write k2 0 $data]
 
         r select 1
-
         set data k3
         assert_equal 3 [r mem.alloc k3 3]
         assert_equal [string length $data] [r mem.write k3 1 $data]
@@ -79,8 +79,8 @@ start_server {tags {"modules"}} {
 
     test "datatype2: test aof rewrite" {
         r flushall
-        r select 0
 
+        r select 0
         set data k1
         assert_equal 3 [r mem.alloc k1 3]
         assert_equal [string length $data] [r mem.write k1 1 $data]
@@ -90,7 +90,6 @@ start_server {tags {"modules"}} {
         assert_equal [string length $data] [r mem.write k2 0 $data]
 
         r select 1
-
         set data k3
         assert_equal 3 [r mem.alloc k3 3]
         assert_equal [string length $data] [r mem.write k3 1 $data]
@@ -114,8 +113,8 @@ start_server {tags {"modules"}} {
 
     test "datatype2: test copy" {
         r flushall
-        r select 0
 
+        r select 0
         set data k1
         assert_equal 3 [r mem.alloc k1 3]
         assert_equal [string length $data] [r mem.write k1 1 $data]
@@ -126,9 +125,7 @@ start_server {tags {"modules"}} {
         assert_equal [string length $data] [r mem.write k2 0 $data]
         assert_equal $data [r mem.read k2 0]
 
-       
         r select 1
-
         set data k3
         assert_equal 3 [r mem.alloc k3 3]
         assert_equal [string length $data] [r mem.write k3 1 $data]
@@ -141,24 +138,21 @@ start_server {tags {"modules"}} {
         assert_equal {total 5 used 2} [r mem.usage 1]
 
         r select 0
-
         assert_equal 1 [r copy k1 k3]
         assert_equal k1 [r mem.read k3 1]
-
         assert_equal {total 8 used 3} [r mem.usage 0]
- 
         assert_equal 1 [r copy k2 k1 db 1]
+
         r select 1
         assert_equal k2 [r mem.read k1 0]
-
         assert_equal {total 8 used 3} [r mem.usage 0]
         assert_equal {total 7 used 3} [r mem.usage 1]
     }
 
     test "datatype2: test swapdb" {
         r flushall
-        r select 0
 
+        r select 0
         set data k1
         assert_equal 5 [r mem.alloc k1 5]
         assert_equal [string length $data] [r mem.write k1 1 $data]
@@ -169,9 +163,7 @@ start_server {tags {"modules"}} {
         assert_equal [string length $data] [r mem.write k2 0 $data]
         assert_equal $data [r mem.read k2 0]
 
-       
         r select 1
-
         set data k1
         assert_equal 3 [r mem.alloc k3 3]
         assert_equal [string length $data] [r mem.write k3 1 $data]
@@ -184,15 +176,14 @@ start_server {tags {"modules"}} {
         assert_equal {total 5 used 2} [r mem.usage 1]
 
         assert_equal OK [r swapdb 0 1]
-
         assert_equal {total 9 used 2} [r mem.usage 1]
         assert_equal {total 5 used 2} [r mem.usage 0]
     }
 
     test "datatype2: test digest" {
         r flushall
-        r select 0
 
+        r select 0
         set data k1
         assert_equal 3 [r mem.alloc k1 3]
         assert_equal [string length $data] [r mem.write k1 1 $data]
@@ -204,7 +195,6 @@ start_server {tags {"modules"}} {
         assert_equal $data [r mem.read k2 0]
 
         r select 1
-
         set data k1
         assert_equal 3 [r mem.alloc k1 3]
         assert_equal [string length $data] [r mem.write k1 1 $data]
@@ -214,7 +204,6 @@ start_server {tags {"modules"}} {
         assert_equal 2 [r mem.alloc k2 2]
         assert_equal [string length $data] [r mem.write k2 0 $data]
         assert_equal $data [r mem.read k2 0]
-
 
         r select 0
         set digest0 [debug_digest]
@@ -225,19 +214,21 @@ start_server {tags {"modules"}} {
         assert_equal $digest0 $digest1
     }
 
-    test "datatype2: test memusage" {
-        r flushall
+    if {[string match {*jemalloc*} [s mem_allocator]]} {
+        test "datatype2: test memusage" {
+            r flushall
 
-        set data k1
-        assert_equal 3 [r mem.alloc k1 3]
-        assert_equal [string length $data] [r mem.write k1 1 $data]
-        assert_equal $data [r mem.read k1 1]
+            set data k1
+            assert_equal 3 [r mem.alloc k1 3]
+            assert_equal [string length $data] [r mem.write k1 1 $data]
+            assert_equal $data [r mem.read k1 1]
 
-        set data k2
-        assert_equal 3 [r mem.alloc k2 3]
-        assert_equal [string length $data] [r mem.write k2 0 $data]
-        assert_equal $data [r mem.read k2 0]
+            set data k2
+            assert_equal 3 [r mem.alloc k2 3]
+            assert_equal [string length $data] [r mem.write k2 0 $data]
+            assert_equal $data [r mem.read k2 0]
 
-        assert_equal [r memory usage k1] [r memory usage k2] 
+            assert_equal [r memory usage k1] [r memory usage k2] 
+        }
     }
 }

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -41,7 +41,7 @@ start_server {tags {"hash"}} {
         assert_encoding $type myhash
 
         # coverage for objectComputeSize
-        assert_morethan [r memory usage myhash] 0
+        assert_morethan [memory_usage myhash] 0
 
         test "HRANDFIELD - $type" {
             unset -nocomplain myhash


### PR DESCRIPTION
It turns out that libc malloc can return an allocation of a different size on requests of the same size.
this means that matching MEMORY USAGE of one key to another copy of the same data can fail.

Solution:
Keep running the test that calls MEMORY USAGE, but ignore the response.
We do that by introducing a new utility function to get the memory usage, which always returns 1 when the allocator is not jemalloc.

Other changes:
Some formatting for datatype2.tcl

For detailed discussion, please see:  https://github.com/redis/redis/pull/8999#issuecomment-1001428093