### PR TITLE
Fix race in propagation test

### DIFF
--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -157,11 +157,12 @@ tags "modules" {
 
                     # Please note we use volatile eviction to prevent the loop described in the test above.
                     # "notifications" is not volatile so it always remains
+                    $master config resetstat
                     $master config set maxmemory-policy volatile-ttl
                     $master config set maxmemory 1
 
                     wait_for_condition 500 10 {
-                        [$replica dbsize] eq 1
+                        [s evicted_keys] eq 3
                     } else {
                         fail "Not all keys have been evicted"
                     }
@@ -207,14 +208,14 @@ tags "modules" {
                 test {module propagation with timer and CONFIG SET maxmemory} {
                     set repl [attach_to_replication_stream]
 
+                    $master config resetstat
                     $master config set maxmemory-policy volatile-random
 
                     $master propagate-test.timer-maxmemory
 
-                    # The replica will have two keys: "notifications" and "timer-maxmemory-middle"
-                    # which are not volatile
+                    # Wait until the volatile keys are evicted
                     wait_for_condition 500 10 {
-                        [$replica dbsize] eq 2
+                        [s evicted_keys] eq 2
                     } else {
                         fail "Not all keys have been evicted"
                     }


### PR DESCRIPTION
There's a race between testing DBSIZE and the thread starting.
If the thread hadn't started by the time we checked DBISZE, no
keys will have been evicted.
The correct way is to check the evicted_keys stat.