### PR TITLE
Remove incomplete fix of a broader problem

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2207,9 +2207,6 @@ static int updateMaxmemory(const char **err) {
         }
         performEvictions();
     }
-    /* The function is called via 'CONFIG SET maxmemory', we don't want to propagate it
-     * because server.dirty might have been incremented by performEvictions() */
-    preventCommandPropagation(server.current_client);
     return 1;
 }
 

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -173,6 +173,7 @@ tags "modules" {
 
                     # Note whenever there's double notification: SET with EX issues two separate
                     # notifications: one for "set" and one for "expire"
+                    # "config set" should not be here, see https://github.com/redis/redis/issues/10014
                     assert_replication_stream $repl {
                         {select *}
                         {multi}
@@ -196,6 +197,7 @@ tags "modules" {
                         {del asdf*}
                         {incr notifications}
                         {del asdf*}
+                        {config set maxmemory 1}
                         {multi}
                         {incr notifications}
                         {set asdf4 4}


### PR DESCRIPTION
Preventing COFIG SET maxmemory from propagating is just the tip of the iceberg.
Module that performs a write operation in a notification can cause any
command to be propagated, based on server.dirty

We need to come up with a better solution.