### PR TITLE
Report slot to keys map size in MEMORY STATS in cluster mode

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -30,7 +30,6 @@
 
 #include "server.h"
 #include "functions.h"
-#include "cluster.h"
 #include <math.h>
 #include <ctype.h>
 
@@ -1237,12 +1236,10 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
         mh->db[mh->num_dbs].overhead_ht_expires = mem;
         mem_total+=mem;
 
-        if (server.cluster_enabled) {
-            /* Account for the slot to keys map in cluster mode */
-            mem = dictSize(db->dict) * sizeof(clusterDictEntryMetadata);
-            mh->db[mh->num_dbs].overhead_ht_slot_to_keys = mem;
-            mem_total+=mem;
-        }
+        /* Account for the slot to keys map in cluster mode */
+        mem = dictSize(db->dict) * dictMetadataSize(db->dict);
+        mh->db[mh->num_dbs].overhead_ht_slot_to_keys = mem;
+        mem_total+=mem;
 
         mh->num_dbs++;
     }

--- a/src/object.c
+++ b/src/object.c
@@ -1236,6 +1236,11 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
         mh->db[mh->num_dbs].overhead_ht_expires = mem;
         mem_total+=mem;
 
+        // Account for the slot to keys map in cluster mode
+        mem = dictSize(db->dict) * dictMetadataSize(db->dict);
+        mh->db[mh->num_dbs].overhead_ht_slot_to_keys = mem;
+        mem_total+=mem;
+
         mh->num_dbs++;
     }
 
@@ -1563,14 +1568,18 @@ NULL
             char dbname[32];
             snprintf(dbname,sizeof(dbname),"db.%zd",mh->db[j].dbid);
             addReplyBulkCString(c,dbname);
-            addReplyMapLen(c,2);
+            addReplyMapLen(c,3);
 
             addReplyBulkCString(c,"overhead.hashtable.main");
             addReplyLongLong(c,mh->db[j].overhead_ht_main);
 
             addReplyBulkCString(c,"overhead.hashtable.expires");
             addReplyLongLong(c,mh->db[j].overhead_ht_expires);
+
+            addReplyBulkCString(c,"overhead.hashtable.slot-to-keys");
+            addReplyLongLong(c,mh->db[j].overhead_ht_slot_to_keys);
         }
+
 
         addReplyBulkCString(c,"overhead.total");
         addReplyLongLong(c,mh->overhead_total);

--- a/src/server.c
+++ b/src/server.c
@@ -2333,6 +2333,8 @@ int dictExpandAllowed(size_t moreMem, double usedRatio) {
  * belonging to the same cluster slot. See the Slot to Key API in cluster.c. */
 size_t dictEntryMetadataSize(dict *d) {
     UNUSED(d);
+    /* NOTICE: this also affect overhead_ht_slot_to_keys in getMemoryOverheadData.
+     * If we ever add non-cluster realted data here, that code must be modified too. */
     return server.cluster_enabled ? sizeof(clusterDictEntryMetadata) : 0;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -2334,7 +2334,7 @@ int dictExpandAllowed(size_t moreMem, double usedRatio) {
 size_t dictEntryMetadataSize(dict *d) {
     UNUSED(d);
     /* NOTICE: this also affect overhead_ht_slot_to_keys in getMemoryOverheadData.
-     * If we ever add non-cluster realted data here, that code must be modified too. */
+     * If we ever add non-cluster related data here, that code must be modified too. */
     return server.cluster_enabled ? sizeof(clusterDictEntryMetadata) : 0;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -1236,6 +1236,7 @@ struct redisMemOverhead {
         size_t dbid;
         size_t overhead_ht_main;
         size_t overhead_ht_expires;
+        size_t overhead_ht_slot_to_keys;
     } *db;
 };
 


### PR DESCRIPTION
Report the cluster slots to keys map size in MEMORY STATS.
Also, include that overhead in MEMORY USAGE.

slots to keys map is implemented as a linked list. 
Two pointers, prev and next, are used to implement the map as a linked list.

Addresses the memory usage reporting part of issue https://github.com/redis/redis/issues/9939


MEMORY STATS output
```
./src/redis-cli -p 30001 memory stats
 1) "peak.allocated"
 2) (integer) 6844896
 3) "total.allocated"
 4) (integer) 6279648
 5) "startup.allocated"
 6) (integer) 1711968
 7) "replication.backlog"
 8) (integer) 1048592
 9) "clients.slaves"
10) (integer) 17384
11) "clients.normal"
12) (integer) 0
13) "aof.buffer"
14) (integer) 1536
15) "lua.caches"
16) (integer) 0
17) "functions.caches"
18) (integer) 200
19) "db.0"
20) 1) "overhead.hashtable.main"
    2) (integer) 1376344
    3) "overhead.hashtable.expires"
    4) (integer) 0
    5) "overhead.hashtable.slot-to-keys"
    6) (integer) 445680
21) "overhead.total"
22) (integer) 4601704
23) "keys.count"
24) (integer) 27855
25) "keys.bytes-per-key"
26) (integer) 163
27) "dataset.bytes"
28) (integer) 1677944
29) "dataset.percentage"
30) "36.735149383544922"
31) "peak.percentage"
32) "91.742050170898438"
33) "allocator.allocated"
34) (integer) 6250448
35) "allocator.active"
36) (integer) 9583616
37) "allocator.resident"
38) (integer) 9583616
39) "allocator-fragmentation.ratio"
40) "1.5332686901092529"
41) "allocator-fragmentation.bytes"
42) (integer) 3333168
43) "allocator-rss.ratio"
44) "1"
45) "allocator-rss.bytes"
46) (integer) 0
47) "rss-overhead.ratio"
48) "1.0039534568786621"
49) "rss-overhead.bytes"
50) (integer) 37888
51) "fragmentation"
52) "1.5393302440643311"
53) "fragmentation.bytes"
54) (integer) 3371056
```

MEMORY USAGE output
```
CMD
yzhaon@3c22fb5d816a redis % ./src/redis-cli set foo foo
OK
yzhaon@3c22fb5d816a redis % ./src/redis-cli memory usage foo
(integer) 72

CME
yzhaon@3c22fb5d816a redis % ./src/redis-cli -p 30001 set foo foo
(error) MOVED 12182 127.0.0.1:30003
yzhaon@3c22fb5d816a redis % ./src/redis-cli -p 30003 set foo foo
OK
yzhaon@3c22fb5d816a redis % ./src/redis-cli -p 30003 memory usage foo
(integer) 88
```