### PR TITLE
Fix geo search bounding box check causing missing results

### DIFF
--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -91,8 +91,8 @@ uint8_t geohashEstimateStepsByRadius(double range_meters, double lat) {
  *    \-----------------/          --------               \-----------------/
  *     \               /         /          \              \               /
  *      \  (long,lat) /         / (long,lat) \              \  (long,lat) /
- *       \           /         /              \              /            \
- *         ---------          /----------------\            /--------------\
+ *       \           /         /              \             /             \
+ *         ---------          /----------------\           /---------------\
  *  Northern Hemisphere       Southern Hemisphere         Around the equator
  */
 int geohashBoundingBox(GeoShape *shape, double *bounds) {
@@ -172,7 +172,6 @@ GeoHashRadius geohashCalculateAreasByShapeWGS84(GeoShape *shape) {
             decrease_step = 1;
         if (west.longitude.min > min_lon)  
             decrease_step = 1;
-
     }
 
     if (steps > 1 && decrease_step) {

--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -169,7 +169,7 @@ GeoHashRadius geohashCalculateAreasByShapeWGS84(GeoShape *shape) {
         if (south.latitude.min > min_lat) 
             decrease_step = 1;
         if (east.longitude.max < max_lon) 
-             decrease_step = 1;
+            decrease_step = 1;
         if (west.longitude.min > min_lon)  
             decrease_step = 1;
 

--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -164,14 +164,15 @@ GeoHashRadius geohashCalculateAreasByShapeWGS84(GeoShape *shape) {
         geohashDecode(long_range, lat_range, neighbors.east, &east);
         geohashDecode(long_range, lat_range, neighbors.west, &west);
 
-        if (geohashGetDistance(longitude,latitude,longitude,north.latitude.max)
-            < radius_meters) decrease_step = 1;
-        if (geohashGetDistance(longitude,latitude,longitude,south.latitude.min)
-            < radius_meters) decrease_step = 1;
-        if (geohashGetDistance(longitude,latitude,east.longitude.max,latitude)
-            < radius_meters) decrease_step = 1;
-        if (geohashGetDistance(longitude,latitude,west.longitude.min,latitude)
-            < radius_meters) decrease_step = 1;
+        if (north.latitude.max < max_lat) 
+            decrease_step = 1;
+        if (south.latitude.min > min_lat) 
+            decrease_step = 1;
+        if (east.longitude.max < max_lon) 
+             decrease_step = 1;
+        if (west.longitude.min > min_lon)  
+            decrease_step = 1;
+
     }
 
     if (steps > 1 && decrease_step) {

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -294,7 +294,7 @@ start_server {tags {"geo"}} {
         r georadiusbymember nyc "wtc one" 7 km
     } {{wtc one} {union square} {central park n/q/r} 4545 {lic market}}
     
-    test {GEORADIUSBYMEMBER search areas contain satified points in oblique direction} {
+    test {GEORADIUSBYMEMBER search areas contain satisfied points in oblique direction} {
         r del k1
         
         r geoadd k1 -0.15307903289794921875 85 n1 0.3515625 85.00019260486917005437 n2

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -324,7 +324,7 @@ start_server {tags {"geo"}} {
     } {{wtc one} {union square} {central park n/q/r} 4545 {lic market} q4}
 
     test {GEOSEARCH vs GEORADIUS} {
-        r del  
+        r del Sicily
         r geoadd Sicily 13.361389 38.115556 "Palermo" 15.087269 37.502669 "Catania"
         r geoadd Sicily 12.758489 38.788135 "edge1"   17.241510 38.788135 "eage2"
         set ret1 [r georadius Sicily 15 37 200 km asc]

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -293,13 +293,38 @@ start_server {tags {"geo"}} {
     test {GEORADIUSBYMEMBER simple (sorted)} {
         r georadiusbymember nyc "wtc one" 7 km
     } {{wtc one} {union square} {central park n/q/r} 4545 {lic market}}
+    
+    test {GEORADIUSBYMEMBER search areas contain satified points in oblique direction} {
+        r del k1
+        
+        r geoadd k1 -0.15307903289794921875 85 n1 0.3515625 85.00019260486917005437 n2
+        set ret1 [r GEORADIUSBYMEMBER k1 n1 4891.94 m]
+        assert_equal $ret1 {n1 n2}
+        
+        r zrem k1 n1 n2
+        r geoadd k1 -4.95211958885192871094 85 n3 11.25 85.0511 n4
+        set ret2 [r GEORADIUSBYMEMBER k1 n3 156544 m]
+        assert_equal $ret2 {n3 n4}
+        
+        r zrem k1 n3 n4
+        r geoadd k1 -45 65.50900022111811438208 n5 90 85.0511 n6
+        set ret3 [r GEORADIUSBYMEMBER k1 n5 5009431 m]
+        assert_equal $ret3 {n5 n6}
+    }
+
+    test {GEORADIUSBYMEMBER crossing pole search} {
+        r del k1
+        r geoadd k1 45 65 n1 -135 85.05 n2
+        set ret [r GEORADIUSBYMEMBER k1 n1 5009431 m]
+        assert_equal $ret {n1 n2}
+    }
 
     test {GEOSEARCH FROMMEMBER simple (sorted)} {
         r geosearch nyc frommember "wtc one" bybox 14 14 km
     } {{wtc one} {union square} {central park n/q/r} 4545 {lic market} q4}
 
     test {GEOSEARCH vs GEORADIUS} {
-        r del Sicily
+        r del  
         r geoadd Sicily 13.361389 38.115556 "Palermo" 15.087269 37.502669 "Catania"
         r geoadd Sicily 12.758489 38.788135 "edge1"   17.241510 38.788135 "eage2"
         set ret1 [r georadius Sicily 15 37 200 km asc]


### PR DESCRIPTION
Consider the following example:
1. geoadd k1 -0.15307903289794921875 85 n1 0.3515625 85.00019260486917005437 n2.
2. geodist k1 n1 n2 returns  "4891.9380"
3. but GEORADIUSBYMEMBER k1 n1 4891.94 m only returns n1.
n2 is in the  boundingbox but out of search areas.So we let  search areas contain boundingbox to get n2.