### PR TITLE
fix mark node fail bug

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1403,7 +1403,7 @@ void markNodeAsFailingIfNeeded(clusterNode *node) {
 
     failures = clusterNodeFailureReportsCount(node);
     /* Also count myself as a voter if I'm a master. */
-    if (nodeIsMaster(myself)) failures++;
+    if (nodeIsMaster(myself) && node->numslots) failures++;
     if (failures < needed_quorum) return; /* No weak agreement from masters. */
 
     serverLog(LL_NOTICE,
@@ -1568,7 +1568,7 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
         if (node) {
             /* We already know this node.
                Handle failure reports, only when the sender is a master. */
-            if (sender && nodeIsMaster(sender) && node != myself) {
+            if (sender && nodeIsMaster(sender) && node->numslots && node != myself) {
                 if (flags & (CLUSTER_NODE_FAIL|CLUSTER_NODE_PFAIL)) {
                     if (clusterNodeAddFailureReport(node,sender)) {
                         serverLog(LL_VERBOSE,


### PR DESCRIPTION
redis mark node fail when pfail msg from master more than half of
server.cluster->size, server.cluster->size is the size of master
 node which contain slots, but we don't check slot when add
fail_reports list.