### PR TITLE
Fix master coredump on commit c1718f9d86

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -217,7 +217,7 @@ int prepareReplicasToWrite(void) {
     while((ln = listNext(&li))) {
         client *slave = ln->value;
         if (!canFeedReplicaReplBuffer(slave)) continue;
-        if (prepareClientToWrite(slave) == C_ERR) continue;
+        if (prepareClientToWrite(slave,1) == C_ERR) continue;
         prepared++;
     }
 
@@ -641,7 +641,7 @@ long long addReplyReplicationBacklog(client *c, long long offset) {
     serverAssert(node != NULL);
 
     /* Install a writer handler first.*/
-    prepareClientToWrite(c);
+    prepareClientToWrite(c,1);
     /* Setting output buffer of the replica. */
     replBufBlock *o = listNodeValue(node);
     o->refcount++;

--- a/src/server.h
+++ b/src/server.h
@@ -2281,7 +2281,7 @@ void acceptTcpHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void acceptTLSHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void acceptUnixHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 void readQueryFromClient(connection *conn);
-int prepareClientToWrite(client *c);
+int prepareClientToWrite(client *c, int replMode);
 void addReplyNull(client *c);
 void addReplyNullArray(client *c);
 void addReplyBool(client *c, int b);

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1227,3 +1227,28 @@ test {replica can handle EINTR if use diskless load} {
         }
     }
 } {} {external:skip}
+
+
+start_server {tags {"repl external:skip"}} {
+    start_server {} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        set replica [srv -1 client]
+        set replica_host [srv -1 host]
+        set replica_port [srv -1 port]
+
+        $replica replicaof $master_host $master_port
+        after 1000
+
+        test {check master is alive after set default user off} {
+            $master acl setuser newuser on allkeys allcommands >passwd
+            $master auth newuser passwd
+
+            $master acl setuser default -@all off
+            after 3000
+            $master ping
+        }
+    }
+}


### PR DESCRIPTION
If we revoke the default user privileges, the Master/slave synchronization by default user will break the chain and resynchronize, resulting in the Master coredump; And same other case reply to slave will result in the same result