### PR TITLE
Add tests for blocking XREAD[GROUP] when the stream ran dry

### DIFF
--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -371,7 +371,7 @@ start_server {
         assert_error ERR*equal*smaller* {r XADD mystream 666 key value}
 
         # Entered blocking state and then release because of the new entry.
-        $rd XREAD BLOCK 10 STREAMS mystream 665
+        $rd XREAD BLOCK 0 STREAMS mystream 665
         wait_for_blocked_clients_count 1
         r XADD mystream 667 key value
         assert_equal [$rd read] {{mystream {{667-0 {key value}}}}}


### PR DESCRIPTION
The purpose of this commit is to add some tests to
cover #5299, which was fixed in #5300 but without tests.

This commit should close #5306 and #5299.

Also add `wait_for_blocked_clients_count` for some test cases in
`stream-cgroups` to prevent timing issues.