### PR TITLE
Build commands.c in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -48,6 +48,7 @@ PREFIX?=/usr/local
 INSTALL_BIN=$(PREFIX)/bin
 INSTALL=install
 PKG_CONFIG?=pkg-config
+PYTHON?=python
 
 # Default allocator defaults to Jemalloc if it's not an ARM
 MALLOC=libc
@@ -393,6 +394,9 @@ DEP = $(REDIS_SERVER_OBJ:%.o=%.d) $(REDIS_CLI_OBJ:%.o=%.d) $(REDIS_BENCHMARK_OBJ
 # depending on a single artifact, build all dependencies first.
 %.o: %.c .make-prerequisites
 	$(REDIS_CC) -MMD -o $@ -c $<
+
+commands.c: commands/*.json ../utils/generate-command-code.py
+	$(PYTHON) ../utils/generate-command-code.py
 
 clean:
 	rm -rf $(REDIS_SERVER_NAME) $(REDIS_SENTINEL_NAME) $(REDIS_CLI_NAME) $(REDIS_BENCHMARK_NAME) $(REDIS_CHECK_RDB_NAME) $(REDIS_CHECK_AOF_NAME) *.o *.gcda *.gcno *.gcov redis.info lcov-html Makefile.dep

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,7 +50,7 @@ INSTALL=install
 PKG_CONFIG?=pkg-config
 
 ifndef PYTHON
-PYTHON := $(shell which python || which python3)
+PYTHON := $(shell which python3 || which python)
 endif
 
 # Default allocator defaults to Jemalloc if it's not an ARM

--- a/src/Makefile
+++ b/src/Makefile
@@ -48,7 +48,10 @@ PREFIX?=/usr/local
 INSTALL_BIN=$(PREFIX)/bin
 INSTALL=install
 PKG_CONFIG?=pkg-config
-PYTHON?=python
+
+ifndef PYTHON
+PYTHON := $(shell which python || which python3)
+endif
 
 # Default allocator defaults to Jemalloc if it's not an ARM
 MALLOC=libc
@@ -304,6 +307,7 @@ ENDCOLOR="\033[0m"
 
 ifndef V
 QUIET_CC = @printf '    %b %b\n' $(CCCOLOR)CC$(ENDCOLOR) $(SRCCOLOR)$@$(ENDCOLOR) 1>&2;
+QUIET_GEN = @printf '    %b %b\n' $(CCCOLOR)GEN$(ENDCOLOR) $(SRCCOLOR)$@$(ENDCOLOR) 1>&2;
 QUIET_LINK = @printf '    %b %b\n' $(LINKCOLOR)LINK$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
 QUIET_INSTALL = @printf '    %b %b\n' $(LINKCOLOR)INSTALL$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
 endif
@@ -395,8 +399,12 @@ DEP = $(REDIS_SERVER_OBJ:%.o=%.d) $(REDIS_CLI_OBJ:%.o=%.d) $(REDIS_BENCHMARK_OBJ
 %.o: %.c .make-prerequisites
 	$(REDIS_CC) -MMD -o $@ -c $<
 
+# The file commands.c is checked in and doesn't normally need to be rebuilt. It
+# is built only if python is available and its prereqs are modified.
+ifneq (,$(PYTHON))
 commands.c: commands/*.json ../utils/generate-command-code.py
-	$(PYTHON) ../utils/generate-command-code.py
+	$(QUIET_GEN)$(PYTHON) ../utils/generate-command-code.py
+endif
 
 clean:
 	rm -rf $(REDIS_SERVER_NAME) $(REDIS_SENTINEL_NAME) $(REDIS_CLI_NAME) $(REDIS_BENCHMARK_NAME) $(REDIS_CHECK_RDB_NAME) $(REDIS_CHECK_AOF_NAME) *.o *.gcda *.gcno *.gcov redis.info lcov-html Makefile.dep


### PR DESCRIPTION
With this rule, the script to generate commands.c from JSON runs whenever commands.o is built if any of commands/*.json are modified. Without such rule, it's easy to forget to run the script when updating the JSON files.

It's a follow-up on #9656 and #9951.