### PR TITLE
handle variadic configs from cli

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6425,8 +6425,13 @@ int main(int argc, char **argv) {
                 if (sdslen(options)) options = sdscat(options,"\n");
                 options = sdscat(options,argv[j]+2);
                 options = sdscat(options," ");
+                if (++j >= argc) break;
+                /* First option argument (don't look for `--` in this one) */
+                printf("%s\n",argv[j]);
+                options = sdscatrepr(options,argv[j],strlen(argv[j]));
+                options = sdscat(options," ");
             } else {
-                /* Option argument */
+                /* Additional option argument */
                 options = sdscatrepr(options,argv[j],strlen(argv[j]));
                 options = sdscat(options," ");
             }


### PR DESCRIPTION
Previous versions of redis were able to do `src/redis-server --save 1 2 --save 3 4"

Version 7 is also able to handle `src/redis-server --save 1 2 3 4`
and CONFIG was extended to support `CONFIG SET save "1 2 3 4"`
see #9748

This commit adds the ability to pass one arg that contains spaces:
`src/redis-server --save "1 2 3 4"`
and also fixes a problem where this would break:
`src/redis-server --dbfilename --mydb.rdb`

related conversation: https://github.com/redis/redis/pull/9462#discussion_r776682728
Still working on the tests.