### PR TITLE
Stringify JSON key of --json option result

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1200,6 +1200,7 @@ static sds cliFormatReplyJson(sds out, redisReply *r) {
             } else {
                 sds tmp = cliFormatReplyJson(sdsempty(), key);
                 out = sdscatrepr(out,tmp,sdslen(tmp));
+                sdsfree(tmp);
             }
             out = sdscat(out,":");
 

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1192,8 +1192,15 @@ static sds cliFormatReplyJson(sds out, redisReply *r) {
     case REDIS_REPLY_MAP:
         out = sdscat(out,"{");
         for (i = 0; i < r->elements; i += 2) {
-            out = cliFormatReplyJson(out, r->element[i]);
-
+            redisReply *key = r->element[i];
+            if (key->type == REDIS_REPLY_STATUS ||
+                key->type == REDIS_REPLY_STRING ||
+                key->type == REDIS_REPLY_VERB) {
+                out = cliFormatReplyJson(out, key);
+            } else {
+                sds tmp = cliFormatReplyJson(sdsempty(), key);
+                out = sdscatrepr(out,tmp,sdslen(tmp));
+            }
             out = sdscat(out,":");
 
             out = cliFormatReplyJson(out, r->element[i+1]);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1198,7 +1198,7 @@ static sds cliFormatReplyJson(sds out, redisReply *r) {
                 key->type == REDIS_REPLY_VERB) {
                 out = cliFormatReplyJson(out, key);
             } else {
-                /* Accoring to JSON spec, JSON map keys must be strings, */
+                /* According to JSON spec, JSON map keys must be strings, */
                 /* and in RESP3, they can be other types. */
                 sds tmp = cliFormatReplyJson(sdsempty(), key);
                 out = sdscatrepr(out,tmp,sdslen(tmp));

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1198,6 +1198,8 @@ static sds cliFormatReplyJson(sds out, redisReply *r) {
                 key->type == REDIS_REPLY_VERB) {
                 out = cliFormatReplyJson(out, key);
             } else {
+                /* Accoring to JSON spec, JSON map keys must be strings, */
+                /* and in RESP3, they can be other types. */
                 sds tmp = cliFormatReplyJson(sdsempty(), key);
                 out = sdscatrepr(out,tmp,sdslen(tmp));
                 sdsfree(tmp);


### PR DESCRIPTION
Fixing https://github.com/redis/redis/pull/9954#issuecomment-1003914049

About RESP3 an ordered collection of key-value pairs, keys and value can
be any other RESP3 type, but a key should be string in JSON spec.

AS IS
```
./src/redis-cli -3 --json latency histogram | jq
parse error: Object keys must be strings at line 1, column 39

./src/redis-cli -3 --json latency histogram
{"zadd":{"calls":3,"histogram_usec":{8:1,16:2,33:3}},"info":{"calls":1,"histogram_usec":{264:1}},"hset":{"calls":1,"histogram_usec":{16:1}},"zrange":{"calls":1,"histogram_usec":{66:1}},"command":{"calls":1,"histogram_usec":{8454:1}},"hello":{"calls":22,"histogram_usec":{4:8,8:22}},"hgetall":{"calls":3,"histogram_usec":{4:1,8:3}},"scan":{"calls":2,"histogram_usec":{8:1,33:2}}}
```

TO BE
```
./src/redis-cli -3 --json latency histogram | jq
{
  "zadd": {
    "calls": 3,
    "histogram_usec": {
      "8": 1,
      "16": 2,
      "33": 3
    }
  },
  "info": {
    "calls": 1,
    "histogram_usec": {
      "264": 1
    }
  },
  "hset": {
    "calls": 1,
    "histogram_usec": {
      "16": 1
    }
  },
  "zrange": {
    "calls": 1,
    "histogram_usec": {
      "66": 1
    }
  },
  "command": {
    "calls": 1,
    "histogram_usec": {
      "8454": 1
    }
  },
  "hello": {
    "calls": 13,
    "histogram_usec": {
      "4": 5,
      "8": 13
    }
  }
}
```
