### PR TITLE
Support whitespace characters in appendfilename, and ban them in appenddirname

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -113,6 +113,22 @@ aofInfo *aofInfoDup(aofInfo *orig) {
     return ai;
 }
 
+/* Format aofInfo as a string and it will be a line in the manifest. */
+sds aofInfoFormat(sds buf, aofInfo *ai) {
+    if (includeSpace(ai->file_name)) {
+        /* If file_name contains spaces we wrap it in quotes. */
+        return sdscatprintf(buf, "%s \"%s\" %s %lld %s %c\n", 
+            AOF_MANIFEST_KEY_FILE_NAME, ai->file_name, 
+            AOF_MANIFEST_KEY_FILE_SEQ, ai->file_seq, 
+            AOF_MANIFEST_KEY_FILE_TYPE, ai->file_type);
+    } else {
+        return sdscatprintf(buf, "%s %s %s %lld %s %c\n", 
+            AOF_MANIFEST_KEY_FILE_NAME, ai->file_name, 
+            AOF_MANIFEST_KEY_FILE_SEQ, ai->file_seq, 
+            AOF_MANIFEST_KEY_FILE_TYPE, ai->file_type);
+    }
+}
+
 /* Method to free AOF list elements. */
 void aofListFree(void *item) {
     aofInfo *ai = (aofInfo *)item;
@@ -169,12 +185,6 @@ sds getTempAofManifestFileName() {
  * The base file, if exists, will always be first, followed by history files,
  * and incremental files.
  */
-#define AOF_INFO_FORMAT_AND_CAT(buf, info)                      \
-    sdscatprintf((buf), "%s \"%s\" %s %lld %s %c\n",            \
-                 AOF_MANIFEST_KEY_FILE_NAME, (info)->file_name, \
-                 AOF_MANIFEST_KEY_FILE_SEQ, (info)->file_seq,   \
-                 AOF_MANIFEST_KEY_FILE_TYPE, (info)->file_type)
-
 sds getAofManifestAsString(aofManifest *am) {
     serverAssert(am != NULL);
 
@@ -185,21 +195,21 @@ sds getAofManifestAsString(aofManifest *am) {
     /* 1. Add BASE File information, it is always at the beginning
      * of the manifest file. */
     if (am->base_aof_info) {
-        buf = AOF_INFO_FORMAT_AND_CAT(buf, am->base_aof_info);
+        buf = aofInfoFormat(buf, am->base_aof_info);
     }
 
     /* 2. Add HISTORY type AOF information. */
     listRewind(am->history_aof_list, &li);
     while ((ln = listNext(&li)) != NULL) {
         aofInfo *ai = (aofInfo*)ln->value;
-        buf = AOF_INFO_FORMAT_AND_CAT(buf, ai);
+        buf = aofInfoFormat(buf, ai);
     }
 
     /* 3. Add INCR type AOF information. */
     listRewind(am->incr_aof_list, &li);
     while ((ln = listNext(&li)) != NULL) {
         aofInfo *ai = (aofInfo*)ln->value;
-        buf = AOF_INFO_FORMAT_AND_CAT(buf, ai);
+        buf = aofInfoFormat(buf, ai);
     }
 
     return buf;

--- a/src/aof.c
+++ b/src/aof.c
@@ -285,8 +285,9 @@ void aofLoadManifestFromDisk(void) {
             goto loaderr;
         }
 
-        /* Because we need to deal with the ugly design that 'appendfilename' may 
-         * contain spaces, we have to deal with it separately. */
+        /* Because we have to deal with the case where 'appendfilename' 
+         * contains spaces, we have to deal with AOF_MANIFEST_KEY_FILE_NAME
+         * separately. */
         char *file_pos = strstr(line, AOF_MANIFEST_KEY_FILE_NAME);
         char *seq_pos = rstrstr(line, AOF_MANIFEST_KEY_FILE_SEQ);
         if (file_pos == NULL || seq_pos == NULL) {

--- a/src/aof.c
+++ b/src/aof.c
@@ -280,22 +280,46 @@ void aofLoadManifestFromDisk(void) {
         }
 
         line = sdstrim(sdsnew(buf), " \t\r\n");
-        argv = sdssplitargs(line, &argc);
-        /* 'argc < 6' was done for forward compatibility. */
-        if (argv == NULL || argc < 6 || (argc % 2)) {
+        if (!sdslen(line)) {
+            err = "The AOF manifest file is invalid format";
+            goto loaderr;
+        }
+
+        /* Because we need to deal with the ugly design that 'appendfilename' may 
+         * contain spaces, we have to deal with it separately. */
+        char *file_pos = strstr(line, AOF_MANIFEST_KEY_FILE_NAME);
+        char *seq_pos = rstrstr(line, AOF_MANIFEST_KEY_FILE_SEQ);
+        if (file_pos == NULL || seq_pos == NULL) {
+            err = "The AOF manifest file is invalid format";
+            goto loaderr;
+        }
+
+        char *filename_pos = file_pos + strlen(AOF_MANIFEST_KEY_FILE_NAME) + 1;
+        sds file_name = sdsnewlen(filename_pos, seq_pos - filename_pos - 1);
+        if (!sdslen(file_name)) {
+            sdsfree(file_name);
+            err = "The AOF manifest file is invalid format";
+            goto loaderr;
+        }
+
+        /* The remaining parameters are processed uniformly. */
+        argv = sdssplitargs(seq_pos, &argc);
+        /* 'argc < 4' was done for forward compatibility. */
+        if (argv == NULL || argc < 4 || (argc % 2)) {
+            sdsfree(file_name);
             err = "The AOF manifest file is invalid format";
             goto loaderr;
         }
 
         ai = aofInfoCreate();
+        ai->file_name = file_name;
+        if (!pathIsBaseName(ai->file_name)) {
+            err = "File can't be a path, just a filename";
+            goto loaderr;
+        }
+
         for (int i = 0; i < argc; i += 2) {
-            if (!strcasecmp(argv[i], AOF_MANIFEST_KEY_FILE_NAME)) {
-                ai->file_name = sdsnew(argv[i+1]);
-                if (!pathIsBaseName(ai->file_name)) {
-                    err = "File can't be a path, just a filename";
-                    goto loaderr;
-                }
-            } else if (!strcasecmp(argv[i], AOF_MANIFEST_KEY_FILE_SEQ)) {
+            if (!strcasecmp(argv[i], AOF_MANIFEST_KEY_FILE_SEQ)) {
                 ai->file_seq = atoll(argv[i+1]);
             } else if (!strcasecmp(argv[i], AOF_MANIFEST_KEY_FILE_TYPE)) {
                 ai->file_type = (argv[i+1])[0];
@@ -305,7 +329,7 @@ void aofLoadManifestFromDisk(void) {
 
         /* We have to make sure we load all the information. */
         if (!ai->file_name || !ai->file_seq || !ai->file_type) {
-            err = "Mismatched manifest key";
+            err = "The AOF manifest file is invalid format";
             goto loaderr;
         }
 

--- a/src/config.c
+++ b/src/config.c
@@ -2154,6 +2154,10 @@ static int isValidAOFfilename(char *val, const char **err) {
         *err = "appendfilename can't be empty";
         return 0;
     }
+    if (includeSpace(val)) {
+        *err = "appendfilename can't contain whitespace characters";
+        return 0;
+    }
     if (!pathIsBaseName(val)) {
         *err = "appendfilename can't be a path, just a filename";
         return 0;
@@ -2164,6 +2168,10 @@ static int isValidAOFfilename(char *val, const char **err) {
 static int isValidAOFdirname(char *val, const char **err) {
     if (!strcmp(val, "")) {
         *err = "appenddirname can't be empty";
+        return 0;
+    }
+    if (includeSpace(val)) {
+        *err = "appenddirname can't contain whitespace characters";
         return 0;
     }
     if (!pathIsBaseName(val)) {

--- a/src/config.c
+++ b/src/config.c
@@ -2154,10 +2154,6 @@ static int isValidAOFfilename(char *val, const char **err) {
         *err = "appendfilename can't be empty";
         return 0;
     }
-    if (includeSpace(val)) {
-        *err = "appendfilename can't contain whitespace characters";
-        return 0;
-    }
     if (!pathIsBaseName(val)) {
         *err = "appendfilename can't be a path, just a filename";
         return 0;

--- a/src/util.c
+++ b/src/util.c
@@ -900,13 +900,6 @@ int includeSpace(char *s) {
     return 0;
 }
 
-char *rstrstr(const char *haystack, const char *needle) {
-    char *ptr, *last=NULL;
-    ptr = (char*)haystack;
-    while((ptr = strstr(ptr, needle))) last = ptr++;
-    return last;
-}
-
 #ifdef REDIS_TEST
 #include <assert.h>
 

--- a/src/util.c
+++ b/src/util.c
@@ -900,6 +900,13 @@ int includeSpace(char *s) {
     return 0;
 }
 
+char *rstrstr(const char *haystack, const char *needle) {
+    char *ptr, *last=NULL;
+    ptr = (char*)haystack;
+    while((ptr = strstr(ptr, needle))) last = ptr++;
+    return last;
+}
+
 #ifdef REDIS_TEST
 #include <assert.h>
 

--- a/src/util.c
+++ b/src/util.c
@@ -890,6 +890,16 @@ sds makePath(char *path, char *filename) {
     return sdscatfmt(sdsempty(), "%s/%s", path, filename);
 }
 
+int includeSpace(char *s) {
+    if (s == NULL) return 0;
+    for (size_t i = 0; i < strlen(s); i++) {
+        if (isspace(s[i])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 #ifdef REDIS_TEST
 #include <assert.h>
 

--- a/src/util.h
+++ b/src/util.h
@@ -70,6 +70,7 @@ int dirExists(char *dname);
 int dirRemove(char *dname);
 int fileExist(char *filename);
 sds makePath(char *path, char *filename);
+int includeSpace(char *s);
 
 #ifdef REDIS_TEST
 int utilTest(int argc, char **argv, int flags);

--- a/src/util.h
+++ b/src/util.h
@@ -71,7 +71,6 @@ int dirRemove(char *dname);
 int fileExist(char *filename);
 sds makePath(char *path, char *filename);
 int includeSpace(char *s);
-char *rstrstr(const char *haystack, const char *needle);
 
 #ifdef REDIS_TEST
 int utilTest(int argc, char **argv, int flags);

--- a/src/util.h
+++ b/src/util.h
@@ -71,6 +71,7 @@ int dirRemove(char *dname);
 int fileExist(char *filename);
 sds makePath(char *path, char *filename);
 int includeSpace(char *s);
+char *rstrstr(const char *haystack, const char *needle);
 
 #ifdef REDIS_TEST
 int utilTest(int argc, char **argv, int flags);

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -427,8 +427,8 @@ tags {"external:skip"} {
             assert_equal 1 [check_file_exist $aof_dirpath $aof_basename]
 
             assert_aof_manifest_content $aof_manifest_file  {
-                {file "appendonly.aof" seq 1 type b}
-                {file "appendonly.aof.1.incr.aof" seq 1 type i}
+                {file appendonly.aof seq 1 type b}
+                {file appendonly.aof.1.incr.aof seq 1 type i}
             }
 
             assert_equal OK [$client set k4 v4]
@@ -439,8 +439,8 @@ tags {"external:skip"} {
             assert_equal OK [$client set k5 v5]
 
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.2.base.rdb" seq 2 type b}
-                {file "appendonly.aof.2.incr.aof" seq 2 type i}
+                {file appendonly.aof.2.base.rdb seq 2 type b}
+                {file appendonly.aof.2.incr.aof seq 2 type i}
             }
 
             set d1 [$client debug digest]
@@ -469,8 +469,8 @@ tags {"external:skip"} {
             assert_equal 1 [check_file_exist $aof_dirpath $aof_basename]
 
             assert_aof_manifest_content $aof_manifest_file  {
-                {file "appendonly.aof" seq 1 type b}
-                {file "appendonly.aof.1.incr.aof" seq 1 type i}
+                {file appendonly.aof seq 1 type b}
+                {file appendonly.aof.1.incr.aof seq 1 type i}
             }
 
             assert_equal OK [$client set k4 v4]
@@ -481,8 +481,8 @@ tags {"external:skip"} {
             assert_equal OK [$client set k5 v5]
 
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.2.base.rdb" seq 2 type b}
-                {file "appendonly.aof.2.incr.aof" seq 2 type i}
+                {file appendonly.aof.2.base.rdb seq 2 type b}
+                {file appendonly.aof.2.incr.aof seq 2 type i}
             }
 
             set d1 [$client debug digest]
@@ -520,8 +520,8 @@ tags {"external:skip"} {
             assert_equal 1 [check_file_exist $aof_dirpath $aof_basename]
 
             assert_aof_manifest_content $aof_manifest_file  {
-                {file "appendonly.aof" seq 1 type b}
-                {file "appendonly.aof.1.incr.aof" seq 1 type i}
+                {file appendonly.aof seq 1 type b}
+                {file appendonly.aof.1.incr.aof seq 1 type i}
             }
         }
 
@@ -563,8 +563,8 @@ tags {"external:skip"} {
             assert_equal 1 [check_file_exist $aof_dirpath $aof_basename]
 
             assert_aof_manifest_content $aof_manifest_file  {
-                {file "appendonly.aof" seq 1 type b}
-                {file "appendonly.aof.1.incr.aof" seq 1 type i}
+                {file appendonly.aof seq 1 type b}
+                {file appendonly.aof.1.incr.aof seq 1 type i}
             }
         }
 
@@ -620,8 +620,8 @@ tags {"external:skip"} {
                     assert_equal 0 [$redis1 exists k6]
 
                     assert_aof_manifest_content $aof_manifest_file  {
-                        {file "appendonly.aof" seq 1 type b}
-                        {file "appendonly.aof.1.incr.aof" seq 1 type i}
+                        {file appendonly.aof seq 1 type b}
+                        {file appendonly.aof.1.incr.aof seq 1 type i}
                     }
 
                     $redis1 bgrewriteaof
@@ -630,8 +630,8 @@ tags {"external:skip"} {
                     assert_equal OK [$redis1 set k v]
 
                     assert_aof_manifest_content $aof_manifest_file {
-                        {file "appendonly.aof.2.base.rdb" seq 2 type b}
-                        {file "appendonly.aof.2.incr.aof" seq 2 type i}
+                        {file appendonly.aof.2.base.rdb seq 2 type b}
+                        {file appendonly.aof.2.incr.aof seq 2 type i}
                     }
 
                     set d1 [$redis1 debug digest]
@@ -652,8 +652,8 @@ tags {"external:skip"} {
                     assert_equal v6 [$redis2 get k6]
 
                     assert_aof_manifest_content $aof_manifest_file2  {
-                        {file "appendonly.aof2" seq 1 type b}
-                        {file "appendonly.aof2.1.incr.aof" seq 1 type i}
+                        {file appendonly.aof2 seq 1 type b}
+                        {file appendonly.aof2.1.incr.aof seq 1 type i}
                     }
 
                     $redis2 bgrewriteaof
@@ -662,8 +662,8 @@ tags {"external:skip"} {
                     assert_equal OK [$redis2 set k v]
 
                     assert_aof_manifest_content $aof_manifest_file2 {
-                        {file "appendonly.aof2.2.base.rdb" seq 2 type b}
-                        {file "appendonly.aof2.2.incr.aof" seq 2 type i}
+                        {file appendonly.aof2.2.base.rdb seq 2 type b}
+                        {file appendonly.aof2.2.incr.aof seq 2 type i}
                     }
 
                     set d1 [$redis2 debug digest]
@@ -741,8 +741,8 @@ tags {"external:skip"} {
 
             # First AOFRW done
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.1.base.rdb" seq 1 type b}
-                {file "appendonly.aof.1.incr.aof" seq 1 type i}
+                {file appendonly.aof.1.base.rdb seq 1 type b}
+                {file appendonly.aof.1.incr.aof seq 1 type i}
             }
 
             # Check we really have these files
@@ -755,8 +755,8 @@ tags {"external:skip"} {
 
             # The second AOFRW done
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.2.base.rdb" seq 2 type b}
-                {file "appendonly.aof.2.incr.aof" seq 2 type i}
+                {file appendonly.aof.2.base.rdb seq 2 type b}
+                {file appendonly.aof.2.incr.aof seq 2 type i}
             }
 
             assert_equal 1 [check_file_exist $aof_dirpath $aof_manifest_name]
@@ -814,11 +814,11 @@ tags {"external:skip"} {
 
             # We will have four INCR AOFs
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.2.base.rdb" seq 2 type b}
-                {file "appendonly.aof.2.incr.aof" seq 2 type i}
-                {file "appendonly.aof.3.incr.aof" seq 3 type i}
-                {file "appendonly.aof.4.incr.aof" seq 4 type i}
-                {file "appendonly.aof.5.incr.aof" seq 5 type i}
+                {file appendonly.aof.2.base.rdb seq 2 type b}
+                {file appendonly.aof.2.incr.aof seq 2 type i}
+                {file appendonly.aof.3.incr.aof seq 3 type i}
+                {file appendonly.aof.4.incr.aof seq 4 type i}
+                {file appendonly.aof.5.incr.aof seq 5 type i}
             }
 
             assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.2${::base_aof_sufix}${::rdb_format_suffix}"]
@@ -850,8 +850,8 @@ tags {"external:skip"} {
             # All previous INCR AOFs have become history
             # and have be deleted
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.3.base.rdb" seq 3 type b}
-                {file "appendonly.aof.6.incr.aof" seq 6 type i}
+                {file appendonly.aof.3.base.rdb seq 3 type b}
+                {file appendonly.aof.6.incr.aof seq 6 type i}
             }
 
             # Wait bio delete history
@@ -882,7 +882,7 @@ tags {"external:skip"} {
 
             # We only have BASE AOF, no INCR AOF
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.4.base.rdb" seq 4 type b}
+                {file appendonly.aof.4.base.rdb seq 4 type b}
             }
 
             assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.4${::base_aof_sufix}${::rdb_format_suffix}"]
@@ -904,8 +904,8 @@ tags {"external:skip"} {
 
             # A new INCR AOF was created
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.5.base.rdb" seq 5 type b}
-                {file "appendonly.aof.1.incr.aof" seq 1 type i}
+                {file appendonly.aof.5.base.rdb seq 5 type b}
+                {file appendonly.aof.1.incr.aof seq 1 type i}
             }
 
             # Wait bio delete history
@@ -930,12 +930,12 @@ tags {"external:skip"} {
 
             # We can see four history AOFs (Evolved from two BASE and two INCR)
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.7.base.rdb" seq 7 type b}
-                {file "appendonly.aof.2.incr.aof" seq 2 type h}
-                {file "appendonly.aof.6.base.rdb" seq 6 type h}
-                {file "appendonly.aof.1.incr.aof" seq 1 type h}
-                {file "appendonly.aof.5.base.rdb" seq 5 type h}
-                {file "appendonly.aof.3.incr.aof" seq 3 type i}
+                {file appendonly.aof.7.base.rdb seq 7 type b}
+                {file appendonly.aof.2.incr.aof seq 2 type h}
+                {file appendonly.aof.6.base.rdb seq 6 type h}
+                {file appendonly.aof.1.incr.aof seq 1 type h}
+                {file appendonly.aof.5.base.rdb seq 5 type h}
+                {file appendonly.aof.3.incr.aof seq 3 type i}
             }
 
             assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.5${::base_aof_sufix}${::rdb_format_suffix}"]
@@ -947,8 +947,8 @@ tags {"external:skip"} {
 
             # Auto gc success
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.7.base.rdb" seq 7 type b}
-                {file "appendonly.aof.3.incr.aof" seq 3 type i}
+                {file appendonly.aof.7.base.rdb seq 7 type b}
+                {file appendonly.aof.3.incr.aof seq 3 type i}
             }
 
             # wait bio delete history
@@ -965,8 +965,8 @@ tags {"external:skip"} {
         test "AOF can produce consecutive sequence number after reload" {
             # Current manifest, BASE seq 7 and INCR seq 3
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.7.base.rdb" seq 7 type b}
-                {file "appendonly.aof.3.incr.aof" seq 3 type i}
+                {file appendonly.aof.7.base.rdb seq 7 type b}
+                {file appendonly.aof.3.incr.aof seq 3 type i}
             }
 
             r debug loadaof
@@ -977,8 +977,8 @@ tags {"external:skip"} {
 
             # Now BASE seq is 8 and INCR seq is 4
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.8.base.rdb" seq 8 type b}
-                {file "appendonly.aof.4.incr.aof" seq 4 type i}
+                {file appendonly.aof.8.base.rdb seq 8 type b}
+                {file appendonly.aof.4.incr.aof seq 4 type i}
             }
         }
 
@@ -1002,8 +1002,8 @@ tags {"external:skip"} {
 
             # Not open new INCR aof
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.8.base.rdb" seq 8 type b}
-                {file "appendonly.aof.4.incr.aof" seq 4 type i}
+                {file appendonly.aof.8.base.rdb seq 8 type b}
+                {file appendonly.aof.4.incr.aof seq 4 type i}
             }
 
             r set k2 v2
@@ -1032,8 +1032,8 @@ tags {"external:skip"} {
             waitForBgrewriteaof r
 
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.9.base.rdb" seq 9 type b}
-                {file "appendonly.aof.5.incr.aof" seq 5 type i}
+                {file appendonly.aof.9.base.rdb seq 9 type b}
+                {file appendonly.aof.5.incr.aof seq 5 type i}
             }
 
             r set k3 v3
@@ -1057,10 +1057,10 @@ tags {"external:skip"} {
             waitForBgrewriteaof r
 
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.9.base.rdb" seq 9 type b}
-                {file "appendonly.aof.5.incr.aof" seq 5 type i}
-                {file "appendonly.aof.6.incr.aof" seq 6 type i}
-                {file "appendonly.aof.7.incr.aof" seq 7 type i}
+                {file appendonly.aof.9.base.rdb seq 9 type b}
+                {file appendonly.aof.5.incr.aof seq 5 type i}
+                {file appendonly.aof.6.incr.aof seq 6 type i}
+                {file appendonly.aof.7.incr.aof seq 7 type i}
             }
 
             set orig_size [r dbsize]
@@ -1082,10 +1082,10 @@ tags {"external:skip"} {
 
             # No new INCR AOF be created
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.9.base.rdb" seq 9 type b}
-                {file "appendonly.aof.5.incr.aof" seq 5 type i}
-                {file "appendonly.aof.6.incr.aof" seq 6 type i}
-                {file "appendonly.aof.7.incr.aof" seq 7 type i}
+                {file appendonly.aof.9.base.rdb seq 9 type b}
+                {file appendonly.aof.5.incr.aof seq 5 type i}
+                {file appendonly.aof.6.incr.aof seq 6 type i}
+                {file appendonly.aof.7.incr.aof seq 7 type i}
             }
 
             # Turn off auto rewrite
@@ -1106,8 +1106,8 @@ tags {"external:skip"} {
             assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.8${::incr_aof_sufix}${::aof_format_suffix}"]
 
             assert_aof_manifest_content $aof_manifest_file {
-                {file "appendonly.aof.10.base.rdb" seq 10 type b}
-                {file "appendonly.aof.8.incr.aof" seq 8 type i}
+                {file appendonly.aof.10.base.rdb seq 10 type b}
+                {file appendonly.aof.8.incr.aof seq 8 type i}
             }
 
             stop_write_load $load_handle0

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -427,8 +427,8 @@ tags {"external:skip"} {
             assert_equal 1 [check_file_exist $aof_dirpath $aof_basename]
 
             assert_aof_manifest_content $aof_manifest_file  {
-                {file appendonly.aof seq 1 type b}
-                {file appendonly.aof.1.incr.aof seq 1 type i}
+                {file "appendonly.aof" seq 1 type b}
+                {file "appendonly.aof.1.incr.aof" seq 1 type i}
             }
 
             assert_equal OK [$client set k4 v4]
@@ -439,8 +439,8 @@ tags {"external:skip"} {
             assert_equal OK [$client set k5 v5]
 
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.2.base.rdb seq 2 type b}
-                {file appendonly.aof.2.incr.aof seq 2 type i}
+                {file "appendonly.aof.2.base.rdb" seq 2 type b}
+                {file "appendonly.aof.2.incr.aof" seq 2 type i}
             }
 
             set d1 [$client debug digest]
@@ -469,8 +469,8 @@ tags {"external:skip"} {
             assert_equal 1 [check_file_exist $aof_dirpath $aof_basename]
 
             assert_aof_manifest_content $aof_manifest_file  {
-                {file appendonly.aof seq 1 type b}
-                {file appendonly.aof.1.incr.aof seq 1 type i}
+                {file "appendonly.aof" seq 1 type b}
+                {file "appendonly.aof.1.incr.aof" seq 1 type i}
             }
 
             assert_equal OK [$client set k4 v4]
@@ -481,8 +481,8 @@ tags {"external:skip"} {
             assert_equal OK [$client set k5 v5]
 
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.2.base.rdb seq 2 type b}
-                {file appendonly.aof.2.incr.aof seq 2 type i}
+                {file "appendonly.aof.2.base.rdb" seq 2 type b}
+                {file "appendonly.aof.2.incr.aof" seq 2 type i}
             }
 
             set d1 [$client debug digest]
@@ -520,8 +520,8 @@ tags {"external:skip"} {
             assert_equal 1 [check_file_exist $aof_dirpath $aof_basename]
 
             assert_aof_manifest_content $aof_manifest_file  {
-                {file appendonly.aof seq 1 type b}
-                {file appendonly.aof.1.incr.aof seq 1 type i}
+                {file "appendonly.aof" seq 1 type b}
+                {file "appendonly.aof.1.incr.aof" seq 1 type i}
             }
         }
 
@@ -563,8 +563,8 @@ tags {"external:skip"} {
             assert_equal 1 [check_file_exist $aof_dirpath $aof_basename]
 
             assert_aof_manifest_content $aof_manifest_file  {
-                {file appendonly.aof seq 1 type b}
-                {file appendonly.aof.1.incr.aof seq 1 type i}
+                {file "appendonly.aof" seq 1 type b}
+                {file "appendonly.aof.1.incr.aof" seq 1 type i}
             }
         }
 
@@ -620,8 +620,8 @@ tags {"external:skip"} {
                     assert_equal 0 [$redis1 exists k6]
 
                     assert_aof_manifest_content $aof_manifest_file  {
-                        {file appendonly.aof seq 1 type b}
-                        {file appendonly.aof.1.incr.aof seq 1 type i}
+                        {file "appendonly.aof" seq 1 type b}
+                        {file "appendonly.aof.1.incr.aof" seq 1 type i}
                     }
 
                     $redis1 bgrewriteaof
@@ -630,8 +630,8 @@ tags {"external:skip"} {
                     assert_equal OK [$redis1 set k v]
 
                     assert_aof_manifest_content $aof_manifest_file {
-                        {file appendonly.aof.2.base.rdb seq 2 type b}
-                        {file appendonly.aof.2.incr.aof seq 2 type i}
+                        {file "appendonly.aof.2.base.rdb" seq 2 type b}
+                        {file "appendonly.aof.2.incr.aof" seq 2 type i}
                     }
 
                     set d1 [$redis1 debug digest]
@@ -652,8 +652,8 @@ tags {"external:skip"} {
                     assert_equal v6 [$redis2 get k6]
 
                     assert_aof_manifest_content $aof_manifest_file2  {
-                        {file appendonly.aof2 seq 1 type b}
-                        {file appendonly.aof2.1.incr.aof seq 1 type i}
+                        {file "appendonly.aof2" seq 1 type b}
+                        {file "appendonly.aof2.1.incr.aof" seq 1 type i}
                     }
 
                     $redis2 bgrewriteaof
@@ -662,8 +662,8 @@ tags {"external:skip"} {
                     assert_equal OK [$redis2 set k v]
 
                     assert_aof_manifest_content $aof_manifest_file2 {
-                        {file appendonly.aof2.2.base.rdb seq 2 type b}
-                        {file appendonly.aof2.2.incr.aof seq 2 type i}
+                        {file "appendonly.aof2.2.base.rdb" seq 2 type b}
+                        {file "appendonly.aof2.2.incr.aof" seq 2 type i}
                     }
 
                     set d1 [$redis2 debug digest]
@@ -678,6 +678,7 @@ tags {"external:skip"} {
     test {Multi Part AOF can handle appendfilename contains spaces} {
         start_server [list overrides [list appendonly yes appendfilename "\" file seq .aof \""]] {
             set dir [get_redis_dir]
+            set aof_manifest_name [format "%s/%s/%s%s" $dir "appendonlydir" " file seq .aof " $::manifest_suffix]
             set redis [redis [srv host] [srv port] 0 $::tls]
 
             assert_equal OK [$redis set k1 v1]
@@ -685,15 +686,10 @@ tags {"external:skip"} {
             $redis bgrewriteaof
             waitForBgrewriteaof $redis
 
-            set d1 [$redis debug digest]
-            $redis debug loadaof
-            set d2 [$redis debug digest]
-            assert {$d1 eq $d2}
-
-            assert_equal OK [$redis set k2 v2]
-
-            $redis bgrewriteaof
-            waitForBgrewriteaof $redis
+            assert_aof_manifest_content $aof_manifest_name {
+                {file " file seq .aof .1.base.rdb" seq 1 type b}
+                {file " file seq .aof .2.incr.aof" seq 2 type i}
+            }
 
             set d1 [$redis debug digest]
             $redis debug loadaof
@@ -745,8 +741,8 @@ tags {"external:skip"} {
 
             # First AOFRW done
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.1.base.rdb seq 1 type b}
-                {file appendonly.aof.1.incr.aof seq 1 type i}
+                {file "appendonly.aof.1.base.rdb" seq 1 type b}
+                {file "appendonly.aof.1.incr.aof" seq 1 type i}
             }
 
             # Check we really have these files
@@ -759,8 +755,8 @@ tags {"external:skip"} {
 
             # The second AOFRW done
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.2.base.rdb seq 2 type b}
-                {file appendonly.aof.2.incr.aof seq 2 type i}
+                {file "appendonly.aof.2.base.rdb" seq 2 type b}
+                {file "appendonly.aof.2.incr.aof" seq 2 type i}
             }
 
             assert_equal 1 [check_file_exist $aof_dirpath $aof_manifest_name]
@@ -818,11 +814,11 @@ tags {"external:skip"} {
 
             # We will have four INCR AOFs
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.2.base.rdb seq 2 type b}
-                {file appendonly.aof.2.incr.aof seq 2 type i}
-                {file appendonly.aof.3.incr.aof seq 3 type i}
-                {file appendonly.aof.4.incr.aof seq 4 type i}
-                {file appendonly.aof.5.incr.aof seq 5 type i}
+                {file "appendonly.aof.2.base.rdb" seq 2 type b}
+                {file "appendonly.aof.2.incr.aof" seq 2 type i}
+                {file "appendonly.aof.3.incr.aof" seq 3 type i}
+                {file "appendonly.aof.4.incr.aof" seq 4 type i}
+                {file "appendonly.aof.5.incr.aof" seq 5 type i}
             }
 
             assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.2${::base_aof_sufix}${::rdb_format_suffix}"]
@@ -854,8 +850,8 @@ tags {"external:skip"} {
             # All previous INCR AOFs have become history
             # and have be deleted
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.3.base.rdb seq 3 type b}
-                {file appendonly.aof.6.incr.aof seq 6 type i}
+                {file "appendonly.aof.3.base.rdb" seq 3 type b}
+                {file "appendonly.aof.6.incr.aof" seq 6 type i}
             }
 
             # Wait bio delete history
@@ -886,7 +882,7 @@ tags {"external:skip"} {
 
             # We only have BASE AOF, no INCR AOF
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.4.base.rdb seq 4 type b}
+                {file "appendonly.aof.4.base.rdb" seq 4 type b}
             }
 
             assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.4${::base_aof_sufix}${::rdb_format_suffix}"]
@@ -908,8 +904,8 @@ tags {"external:skip"} {
 
             # A new INCR AOF was created
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.5.base.rdb seq 5 type b}
-                {file appendonly.aof.1.incr.aof seq 1 type i}
+                {file "appendonly.aof.5.base.rdb" seq 5 type b}
+                {file "appendonly.aof.1.incr.aof" seq 1 type i}
             }
 
             # Wait bio delete history
@@ -934,12 +930,12 @@ tags {"external:skip"} {
 
             # We can see four history AOFs (Evolved from two BASE and two INCR)
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.7.base.rdb seq 7 type b}
-                {file appendonly.aof.2.incr.aof seq 2 type h}
-                {file appendonly.aof.6.base.rdb seq 6 type h}
-                {file appendonly.aof.1.incr.aof seq 1 type h}
-                {file appendonly.aof.5.base.rdb seq 5 type h}
-                {file appendonly.aof.3.incr.aof seq 3 type i}
+                {file "appendonly.aof.7.base.rdb" seq 7 type b}
+                {file "appendonly.aof.2.incr.aof" seq 2 type h}
+                {file "appendonly.aof.6.base.rdb" seq 6 type h}
+                {file "appendonly.aof.1.incr.aof" seq 1 type h}
+                {file "appendonly.aof.5.base.rdb" seq 5 type h}
+                {file "appendonly.aof.3.incr.aof" seq 3 type i}
             }
 
             assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.5${::base_aof_sufix}${::rdb_format_suffix}"]
@@ -951,8 +947,8 @@ tags {"external:skip"} {
 
             # Auto gc success
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.7.base.rdb seq 7 type b}
-                {file appendonly.aof.3.incr.aof seq 3 type i}
+                {file "appendonly.aof.7.base.rdb" seq 7 type b}
+                {file "appendonly.aof.3.incr.aof" seq 3 type i}
             }
 
             # wait bio delete history
@@ -969,8 +965,8 @@ tags {"external:skip"} {
         test "AOF can produce consecutive sequence number after reload" {
             # Current manifest, BASE seq 7 and INCR seq 3
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.7.base.rdb seq 7 type b}
-                {file appendonly.aof.3.incr.aof seq 3 type i}
+                {file "appendonly.aof.7.base.rdb" seq 7 type b}
+                {file "appendonly.aof.3.incr.aof" seq 3 type i}
             }
 
             r debug loadaof
@@ -981,8 +977,8 @@ tags {"external:skip"} {
 
             # Now BASE seq is 8 and INCR seq is 4
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.8.base.rdb seq 8 type b}
-                {file appendonly.aof.4.incr.aof seq 4 type i}
+                {file "appendonly.aof.8.base.rdb" seq 8 type b}
+                {file "appendonly.aof.4.incr.aof" seq 4 type i}
             }
         }
 
@@ -1006,8 +1002,8 @@ tags {"external:skip"} {
 
             # Not open new INCR aof
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.8.base.rdb seq 8 type b}
-                {file appendonly.aof.4.incr.aof seq 4 type i}
+                {file "appendonly.aof.8.base.rdb" seq 8 type b}
+                {file "appendonly.aof.4.incr.aof" seq 4 type i}
             }
 
             r set k2 v2
@@ -1036,8 +1032,8 @@ tags {"external:skip"} {
             waitForBgrewriteaof r
 
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.9.base.rdb seq 9 type b}
-                {file appendonly.aof.5.incr.aof seq 5 type i}
+                {file "appendonly.aof.9.base.rdb" seq 9 type b}
+                {file "appendonly.aof.5.incr.aof" seq 5 type i}
             }
 
             r set k3 v3
@@ -1061,10 +1057,10 @@ tags {"external:skip"} {
             waitForBgrewriteaof r
 
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.9.base.rdb seq 9 type b}
-                {file appendonly.aof.5.incr.aof seq 5 type i}
-                {file appendonly.aof.6.incr.aof seq 6 type i}
-                {file appendonly.aof.7.incr.aof seq 7 type i}
+                {file "appendonly.aof.9.base.rdb" seq 9 type b}
+                {file "appendonly.aof.5.incr.aof" seq 5 type i}
+                {file "appendonly.aof.6.incr.aof" seq 6 type i}
+                {file "appendonly.aof.7.incr.aof" seq 7 type i}
             }
 
             set orig_size [r dbsize]
@@ -1086,10 +1082,10 @@ tags {"external:skip"} {
 
             # No new INCR AOF be created
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.9.base.rdb seq 9 type b}
-                {file appendonly.aof.5.incr.aof seq 5 type i}
-                {file appendonly.aof.6.incr.aof seq 6 type i}
-                {file appendonly.aof.7.incr.aof seq 7 type i}
+                {file "appendonly.aof.9.base.rdb" seq 9 type b}
+                {file "appendonly.aof.5.incr.aof" seq 5 type i}
+                {file "appendonly.aof.6.incr.aof" seq 6 type i}
+                {file "appendonly.aof.7.incr.aof" seq 7 type i}
             }
 
             # Turn off auto rewrite
@@ -1110,8 +1106,8 @@ tags {"external:skip"} {
             assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.8${::incr_aof_sufix}${::aof_format_suffix}"]
 
             assert_aof_manifest_content $aof_manifest_file {
-                {file appendonly.aof.10.base.rdb seq 10 type b}
-                {file appendonly.aof.8.incr.aof seq 8 type i}
+                {file "appendonly.aof.10.base.rdb" seq 10 type b}
+                {file "appendonly.aof.8.incr.aof" seq 8 type i}
             }
 
             stop_write_load $load_handle0

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -186,7 +186,7 @@ tags {"external:skip"} {
                 fail "AOF loading didn't fail"
             }
 
-            assert_equal 1 [count_message_lines $server_path/stdout "Mismatched manifest key"]
+            assert_equal 2 [count_message_lines $server_path/stdout "The AOF manifest file is invalid format"]
         }
 
         clean_aof_persistence $aof_dirpath
@@ -213,7 +213,7 @@ tags {"external:skip"} {
                 fail "AOF loading didn't fail"
             }
 
-            assert_equal 2 [count_message_lines $server_path/stdout "The AOF manifest file is invalid format"]
+            assert_equal 3 [count_message_lines $server_path/stdout "The AOF manifest file is invalid format"]
         }
 
         clean_aof_persistence $aof_dirpath
@@ -267,7 +267,7 @@ tags {"external:skip"} {
                 fail "AOF loading didn't fail"
             }
 
-            assert_equal 3 [count_message_lines $server_path/stdout "The AOF manifest file is invalid format"]
+            assert_equal 4 [count_message_lines $server_path/stdout "The AOF manifest file is invalid format"]
         }
 
         clean_aof_persistence $aof_dirpath
@@ -672,6 +672,33 @@ tags {"external:skip"} {
                     assert {$d1 eq $d2}
                 }
             }
+        }
+    }
+
+    test {Multi Part AOF can handle appendfilename contains spaces} {
+        start_server [list overrides [list appendonly yes appendfilename "\" file seq .aof \""]] {
+            set dir [get_redis_dir]
+            set redis [redis [srv host] [srv port] 0 $::tls]
+
+            assert_equal OK [$redis set k1 v1]
+
+            $redis bgrewriteaof
+            waitForBgrewriteaof $redis
+
+            set d1 [$redis debug digest]
+            $redis debug loadaof
+            set d2 [$redis debug digest]
+            assert {$d1 eq $d2}
+
+            assert_equal OK [$redis set k2 v2]
+
+            $redis bgrewriteaof
+            waitForBgrewriteaof $redis
+
+            set d1 [$redis debug digest]
+            $redis debug loadaof
+            set d2 [$redis debug digest]
+            assert {$d1 eq $d2}
         }
     }
 


### PR DESCRIPTION
fix [issue](https://github.com/redis/redis/pull/9788#issuecomment-1004114535)  .

1. Ban whitespace characters in `appenddirname`   
2. Handle the case where `appendfilename` contains spaces (for backwards compatibility)