### PR TITLE
[DRAFT] Implements link feature

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1166,17 +1166,10 @@ struct redisCommandArg KEYS_Args[] = {
 /* LINK hints */
 #define LINK_Hints NULL
 
-/* LINK condition argument table */
-struct redisCommandArg LINK_condition_Subargs[] = {
-{"soft",ARG_TYPE_PURE_TOKEN,-1,"SOFT",NULL,NULL,CMD_ARG_NONE},
-{0}
-};
-
 /* LINK argument table */
 struct redisCommandArg LINK_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"target",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"condition",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=LINK_condition_Subargs},
 {0}
 };
 
@@ -6384,7 +6377,7 @@ struct redisCommand redisCommandTable[] = {
 {"expireat","Set the expiration for a key as a UNIX timestamp","O(1)","1.2.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,EXPIREAT_History,EXPIREAT_Hints,expireatCommand,-3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_WRITE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=EXPIREAT_Args},
 {"expiretime","Get the expiration Unix timestamp for a key","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,EXPIRETIME_History,EXPIRETIME_Hints,expiretimeCommand,2,CMD_READONLY|CMD_RANDOM|CMD_FAST,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_READ,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=EXPIRETIME_Args},
 {"keys","Find all keys matching the given pattern","O(N) with N being the number of keys in the database, under the assumption that the key names in the database and the given pattern have limited length.","1.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,KEYS_History,KEYS_Hints,keysCommand,2,CMD_READONLY|CMD_SORT_FOR_SCRIPT,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,.args=KEYS_Args},
-{"link","Create the link to a key","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,LINK_History,LINK_Hints,linkCommand,-3,CMD_WRITE,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_WRITE|CMD_KEY_READ,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=LINK_Args},
+{"link","Create the link to a key","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,LINK_History,LINK_Hints,linkCommand,3,CMD_WRITE,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_WRITE|CMD_KEY_READ,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=LINK_Args},
 {"migrate","Atomically transfer a key from a Redis instance to another one.","This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.","2.6.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,MIGRATE_History,MIGRATE_Hints,migrateCommand,-6,CMD_WRITE|CMD_RANDOM,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,{{CMD_KEY_WRITE,KSPEC_BS_INDEX,.bs.index={3},KSPEC_FK_RANGE,.fk.range={0,1,0}},{CMD_KEY_WRITE|CMD_KEY_INCOMPLETE,KSPEC_BS_KEYWORD,.bs.keyword={"KEYS",-2},KSPEC_FK_RANGE,.fk.range={-1,1,0}}},migrateGetKeys,.args=MIGRATE_Args},
 {"move","Move a key to another database","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,MOVE_History,MOVE_Hints,moveCommand,3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_WRITE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=MOVE_Args},
 {"object","A container for object introspection commands","Depends on subcommand.","2.2.3",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,OBJECT_History,OBJECT_Hints,NULL,-2,0,0,.subcommands=OBJECT_Subcommands},

--- a/src/commands.c
+++ b/src/commands.c
@@ -1158,6 +1158,28 @@ struct redisCommandArg KEYS_Args[] = {
 {0}
 };
 
+/********** LINK ********************/
+
+/* LINK history */
+#define LINK_History NULL
+
+/* LINK hints */
+#define LINK_Hints NULL
+
+/* LINK condition argument table */
+struct redisCommandArg LINK_condition_Subargs[] = {
+{"soft",ARG_TYPE_PURE_TOKEN,-1,"SOFT",NULL,NULL,CMD_ARG_NONE},
+{0}
+};
+
+/* LINK argument table */
+struct redisCommandArg LINK_Args[] = {
+{"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
+{"target",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"condition",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=LINK_condition_Subargs},
+{0}
+};
+
 /********** MIGRATE ********************/
 
 /* MIGRATE history */
@@ -6362,6 +6384,7 @@ struct redisCommand redisCommandTable[] = {
 {"expireat","Set the expiration for a key as a UNIX timestamp","O(1)","1.2.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,EXPIREAT_History,EXPIREAT_Hints,expireatCommand,-3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_WRITE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=EXPIREAT_Args},
 {"expiretime","Get the expiration Unix timestamp for a key","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,EXPIRETIME_History,EXPIRETIME_Hints,expiretimeCommand,2,CMD_READONLY|CMD_RANDOM|CMD_FAST,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_READ,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=EXPIRETIME_Args},
 {"keys","Find all keys matching the given pattern","O(N) with N being the number of keys in the database, under the assumption that the key names in the database and the given pattern have limited length.","1.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,KEYS_History,KEYS_Hints,keysCommand,2,CMD_READONLY|CMD_SORT_FOR_SCRIPT,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,.args=KEYS_Args},
+{"link","Create the link to a key","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,LINK_History,LINK_Hints,linkCommand,-3,CMD_WRITE,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_WRITE|CMD_KEY_READ,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=LINK_Args},
 {"migrate","Atomically transfer a key from a Redis instance to another one.","This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.","2.6.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,MIGRATE_History,MIGRATE_Hints,migrateCommand,-6,CMD_WRITE|CMD_RANDOM,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,{{CMD_KEY_WRITE,KSPEC_BS_INDEX,.bs.index={3},KSPEC_FK_RANGE,.fk.range={0,1,0}},{CMD_KEY_WRITE|CMD_KEY_INCOMPLETE,KSPEC_BS_KEYWORD,.bs.keyword={"KEYS",-2},KSPEC_FK_RANGE,.fk.range={-1,1,0}}},migrateGetKeys,.args=MIGRATE_Args},
 {"move","Move a key to another database","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,MOVE_History,MOVE_Hints,moveCommand,3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_WRITE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=MOVE_Args},
 {"object","A container for object introspection commands","Depends on subcommand.","2.2.3",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,OBJECT_History,OBJECT_Hints,NULL,-2,0,0,.subcommands=OBJECT_Subcommands},

--- a/src/commands.c
+++ b/src/commands.c
@@ -1166,10 +1166,17 @@ struct redisCommandArg KEYS_Args[] = {
 /* LINK hints */
 #define LINK_Hints NULL
 
+/* LINK condition argument table */
+struct redisCommandArg LINK_condition_Subargs[] = {
+{"soft",ARG_TYPE_PURE_TOKEN,-1,"SOFT",NULL,NULL,CMD_ARG_NONE},
+{0}
+};
+
 /* LINK argument table */
 struct redisCommandArg LINK_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"target",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"condition",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=LINK_condition_Subargs},
 {0}
 };
 
@@ -6377,7 +6384,7 @@ struct redisCommand redisCommandTable[] = {
 {"expireat","Set the expiration for a key as a UNIX timestamp","O(1)","1.2.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,EXPIREAT_History,EXPIREAT_Hints,expireatCommand,-3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_WRITE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=EXPIREAT_Args},
 {"expiretime","Get the expiration Unix timestamp for a key","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,EXPIRETIME_History,EXPIRETIME_Hints,expiretimeCommand,2,CMD_READONLY|CMD_RANDOM|CMD_FAST,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_READ,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=EXPIRETIME_Args},
 {"keys","Find all keys matching the given pattern","O(N) with N being the number of keys in the database, under the assumption that the key names in the database and the given pattern have limited length.","1.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,KEYS_History,KEYS_Hints,keysCommand,2,CMD_READONLY|CMD_SORT_FOR_SCRIPT,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,.args=KEYS_Args},
-{"link","Create the link to a key","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,LINK_History,LINK_Hints,linkCommand,3,CMD_WRITE,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_WRITE|CMD_KEY_READ,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=LINK_Args},
+{"link","Create the link to a key","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,LINK_History,LINK_Hints,linkCommand,-3,CMD_WRITE,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_WRITE|CMD_KEY_READ,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=LINK_Args},
 {"migrate","Atomically transfer a key from a Redis instance to another one.","This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.","2.6.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,MIGRATE_History,MIGRATE_Hints,migrateCommand,-6,CMD_WRITE|CMD_RANDOM,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,{{CMD_KEY_WRITE,KSPEC_BS_INDEX,.bs.index={3},KSPEC_FK_RANGE,.fk.range={0,1,0}},{CMD_KEY_WRITE|CMD_KEY_INCOMPLETE,KSPEC_BS_KEYWORD,.bs.keyword={"KEYS",-2},KSPEC_FK_RANGE,.fk.range={-1,1,0}}},migrateGetKeys,.args=MIGRATE_Args},
 {"move","Move a key to another database","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,MOVE_History,MOVE_Hints,moveCommand,3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_KEYSPACE,{{CMD_KEY_WRITE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=MOVE_Args},
 {"object","A container for object introspection commands","Depends on subcommand.","2.2.3",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_GENERIC,OBJECT_History,OBJECT_Hints,NULL,-2,0,0,.subcommands=OBJECT_Subcommands},

--- a/src/commands/link.json
+++ b/src/commands/link.json
@@ -4,7 +4,7 @@
         "complexity": "O(1)",
         "group": "generic",
         "since": "7.0.0",
-        "arity": -3,
+        "arity": 3,
         "function": "linkCommand",
         "history": [
         ],
@@ -43,18 +43,6 @@
             {
                 "name": "target",
                 "type": "string"
-            },
-            {
-                "name": "condition",
-                "type": "oneof",
-                "optional": true,
-                "arguments": [
-                    {
-                        "name": "soft",
-                        "type": "pure-token",
-                        "token": "SOFT"
-                    }
-                ]
             }
         ]
     }

--- a/src/commands/link.json
+++ b/src/commands/link.json
@@ -4,7 +4,7 @@
         "complexity": "O(1)",
         "group": "generic",
         "since": "7.0.0",
-        "arity": 3,
+        "arity": -3,
         "function": "linkCommand",
         "history": [
         ],
@@ -43,6 +43,18 @@
             {
                 "name": "target",
                 "type": "string"
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "soft",
+                        "type": "pure-token",
+                        "token": "SOFT"
+                    }
+                ]
             }
         ]
     }

--- a/src/commands/link.json
+++ b/src/commands/link.json
@@ -1,0 +1,61 @@
+{
+    "LINK": {
+        "summary": "Create the link to a key",
+        "complexity": "O(1)",
+        "group": "generic",
+        "since": "7.0.0",
+        "arity": -3,
+        "function": "linkCommand",
+        "history": [
+        ],
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "WRITE",
+                    "READ"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "target",
+                "type": "string"
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "soft",
+                        "type": "pure-token",
+                        "token": "SOFT"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/src/config.c
+++ b/src/config.c
@@ -2717,6 +2717,7 @@ standardConfig configs[] = {
     createIntConfig("min-replicas-to-write", "min-slaves-to-write", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_to_write, 0, INTEGER_CONFIG, NULL, updateGoodSlaves),
     createIntConfig("min-replicas-max-lag", "min-slaves-max-lag", MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_min_slaves_max_lag, 10, INTEGER_CONFIG, NULL, updateGoodSlaves),
     createIntConfig("watchdog-period", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.watchdog_period, 0, INTEGER_CONFIG, NULL, updateWatchdogPeriod),
+    createIntConfig("lookup-levels-limit", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1, 10, server.lookup_levels_limit, 1, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),

--- a/src/db.c
+++ b/src/db.c
@@ -146,15 +146,11 @@ static short lookup_link_loops;
 robj *lookupKeyRead(redisDb *db, robj *key) {
     robj *o = lookupKeyReadWithFlags(db,key,LOOKUP_NONE);
     if (o && o->type == OBJ_LINK) {
-        if (o->encoding == OBJ_ENCODING_POINTER) {
-            o = o->ptr;
-        } else {
-            if (lookup_link_loops > 2) {
-                return NULL;
-            }
-            lookup_link_loops++;
-            o = lookupKeyRead(db,o->ptr);
+        if (lookup_link_loops > 2) {
+            return NULL;
         }
+        lookup_link_loops++;
+        o = lookupKeyRead(db,o->ptr);
     }
     return o;
 }
@@ -1037,6 +1033,7 @@ char* getObjectTypeName(robj *o) {
         case OBJ_ZSET: type = "zset"; break;
         case OBJ_HASH: type = "hash"; break;
         case OBJ_STREAM: type = "stream"; break;
+        case OBJ_LINK: type = "link"; break;
         case OBJ_MODULE: {
             moduleValue *mv = o->ptr;
             type = mv->type->name;

--- a/src/db.c
+++ b/src/db.c
@@ -146,7 +146,7 @@ static short lookup_link_loops;
 robj *lookupKeyRead(redisDb *db, robj *key) {
     robj *o = lookupKeyReadWithFlags(db,key,LOOKUP_NONE);
     if (o && o->type == OBJ_LINK) {
-        if (lookup_link_loops > 2) {
+        if (lookup_link_loops > server.lookup_levels_limit) {
             return NULL;
         }
         lookup_link_loops++;
@@ -173,7 +173,7 @@ robj *lookupKeyReadOrReply(client *c, robj *key, robj *reply) {
     lookup_link_loops = 0;
     robj *o = lookupKeyRead(c->db, key);
     if (!o) {
-        if (lookup_link_loops > 2) {
+        if (lookup_link_loops > server.lookup_levels_limit) {
             addReplyError(c, "Too many levels of symbolic links");
         } else {
             addReplyOrErrorObject(c, reply);

--- a/src/object.c
+++ b/src/object.c
@@ -287,11 +287,8 @@ robj *createModuleObject(moduleType *mt, void *value) {
     return createObject(OBJ_MODULE,mv);
 }
 
-robj *createLinkObject(void *ptr, int soft) {
+robj *createLinkObject(void *ptr) {
     robj *o = createObject(OBJ_LINK, ptr);
-    if (!soft) {
-        o->encoding = OBJ_ENCODING_POINTER;
-    }
     return o;
 }
 
@@ -1662,29 +1659,13 @@ NULL
  *
  * Usage: LINK <key> <target> [soft]*/
 void linkCommand(client *c) {
-    int soft = 0, found = 0;
+    int found = 0;
     robj *o = NULL, *target = NULL;
-
-    if (c->argc == 4) {
-        if (!strcasecmp(c->argv[3]->ptr, "soft")) { 
-            soft = 1; 
-        } else {
-            addReply(c, shared.syntaxerr);
-            return;
-        }
-    }
     
     if (!(o = lookupKeyReadOrReply(c, c->argv[1], shared.nokeyerr))) return;
     found = (lookupKeyWrite(c->db, c->argv[2]) != NULL);
-
-    if (soft) {
-        incrRefCount(c->argv[1]);
-        target = createLinkObject(c->argv[1], soft);
-    } else {
-        incrRefCount(o);
-        target = createLinkObject(o, soft);
-    }
-
+    
+    target = createLinkObject(c->argv[1]);
     if (found) {
         dbOverwrite(c->db, c->argv[2], target);
     } else {

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -94,11 +94,12 @@
 #define RDB_TYPE_HASH_LISTPACK 16
 #define RDB_TYPE_ZSET_LISTPACK 17
 #define RDB_TYPE_LIST_QUICKLIST_2   18
+#define RDB_TYPE_LINK 19
+
 /* NOTE: WHEN ADDING NEW RDB TYPE, UPDATE rdbIsObjectType() BELOW */
 
 /* Test if a type is an object type. */
-#define rdbIsObjectType(t) ((t >= 0 && t <= 7) || (t >= 9 && t <= 18))
-
+#define rdbIsObjectType(t) ((t >= 0 && t <= 7) || (t >= 9 && t <= 19))
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
 #define RDB_OPCODE_FUNCTION   246   /* engine data */
 #define RDB_OPCODE_MODULE_AUX 247   /* Module auxiliary data. */

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -95,11 +95,12 @@
 #define RDB_TYPE_ZSET_LISTPACK 17
 #define RDB_TYPE_LIST_QUICKLIST_2   18
 #define RDB_TYPE_LINK 19
+#define RDB_TYPE_LINK_POINTER 20
 
 /* NOTE: WHEN ADDING NEW RDB TYPE, UPDATE rdbIsObjectType() BELOW */
 
 /* Test if a type is an object type. */
-#define rdbIsObjectType(t) ((t >= 0 && t <= 7) || (t >= 9 && t <= 19))
+#define rdbIsObjectType(t) ((t >= 0 && t <= 7) || (t >= 9 && t <= 20))
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
 #define RDB_OPCODE_FUNCTION   246   /* engine data */
 #define RDB_OPCODE_MODULE_AUX 247   /* Module auxiliary data. */

--- a/src/server.h
+++ b/src/server.h
@@ -230,6 +230,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define ACL_CATEGORY_CONNECTION (1ULL<<18)
 #define ACL_CATEGORY_TRANSACTION (1ULL<<19)
 #define ACL_CATEGORY_SCRIPTING (1ULL<<20)
+#define ACL_CATEGORY_LINK (1ULL<<21)
 
 /* Key argument flags. Please check the command table defined in the server.c file
  * for more information about the meaning of every flag. */
@@ -564,6 +565,8 @@ typedef enum {
 #define OBJ_MODULE 5    /* Module object. */
 #define OBJ_STREAM 6    /* Stream object. */
 
+#define OBJ_LINK 7      /* Linked object. */
+
 /* Extract encver / signature from a module type ID. */
 #define REDISMODULE_TYPE_ENCVER_BITS 10
 #define REDISMODULE_TYPE_ENCVER_MASK ((1<<REDISMODULE_TYPE_ENCVER_BITS)-1)
@@ -741,6 +744,7 @@ typedef struct RedisModuleDigest {
 #define OBJ_ENCODING_QUICKLIST 9 /* Encoded as linked list of listpacks */
 #define OBJ_ENCODING_STREAM 10 /* Encoded as a radix tree of listpacks */
 #define OBJ_ENCODING_LISTPACK 11 /* Encoded as a listpack */
+#define OBJ_ENCODING_POINTER 12 /* Encoded as a pointer */
 
 #define LRU_BITS 24
 #define LRU_CLOCK_MAX ((1<<LRU_BITS)-1) /* Max value of obj->lru */
@@ -1969,7 +1973,7 @@ typedef enum {
     COMMAND_GROUP_GEO,
     COMMAND_GROUP_STREAM,
     COMMAND_GROUP_BITMAP,
-    COMMAND_GROUP_MODULE,
+    COMMAND_GROUP_MODULE
 } redisCommandGroup;
 
 typedef void redisCommandProc(client *c);
@@ -2458,6 +2462,7 @@ robj *createZsetObject(void);
 robj *createZsetListpackObject(void);
 robj *createStreamObject(void);
 robj *createModuleObject(moduleType *mt, void *value);
+robj *createLinkObject(void *ptr, int soft);
 int getLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg);
 int getPositiveLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg);
 int getRangeLongFromObjectOrReply(client *c, robj *o, long min, long max, long *target, const char *msg);
@@ -3231,6 +3236,7 @@ void lcsCommand(client *c);
 void quitCommand(client *c);
 void resetCommand(client *c);
 void failoverCommand(client *c);
+void linkCommand(client *c);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));

--- a/src/server.h
+++ b/src/server.h
@@ -1796,6 +1796,8 @@ struct redisServer {
                                 * failover then any replica can be used. */
     int target_replica_port; /* Failover target port */
     int failover_state; /* Failover state */
+    /* link levels limit */
+    int lookup_levels_limit; /* lookup levels limit */
 };
 
 #define MAX_KEYS_BUFFER 256

--- a/src/server.h
+++ b/src/server.h
@@ -744,6 +744,7 @@ typedef struct RedisModuleDigest {
 #define OBJ_ENCODING_QUICKLIST 9 /* Encoded as linked list of listpacks */
 #define OBJ_ENCODING_STREAM 10 /* Encoded as a radix tree of listpacks */
 #define OBJ_ENCODING_LISTPACK 11 /* Encoded as a listpack */
+#define OBJ_ENCODING_POINTER 12 /* Encoded as a pointer */
 
 #define LRU_BITS 24
 #define LRU_CLOCK_MAX ((1<<LRU_BITS)-1) /* Max value of obj->lru */
@@ -2463,7 +2464,7 @@ robj *createZsetObject(void);
 robj *createZsetListpackObject(void);
 robj *createStreamObject(void);
 robj *createModuleObject(moduleType *mt, void *value);
-robj *createLinkObject(void *ptr);
+robj *createLinkObject(void *ptr, int soft);
 int getLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg);
 int getPositiveLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg);
 int getRangeLongFromObjectOrReply(client *c, robj *o, long min, long max, long *target, const char *msg);

--- a/src/server.h
+++ b/src/server.h
@@ -744,7 +744,6 @@ typedef struct RedisModuleDigest {
 #define OBJ_ENCODING_QUICKLIST 9 /* Encoded as linked list of listpacks */
 #define OBJ_ENCODING_STREAM 10 /* Encoded as a radix tree of listpacks */
 #define OBJ_ENCODING_LISTPACK 11 /* Encoded as a listpack */
-#define OBJ_ENCODING_POINTER 12 /* Encoded as a pointer */
 
 #define LRU_BITS 24
 #define LRU_CLOCK_MAX ((1<<LRU_BITS)-1) /* Max value of obj->lru */
@@ -2462,7 +2461,7 @@ robj *createZsetObject(void);
 robj *createZsetListpackObject(void);
 robj *createStreamObject(void);
 robj *createModuleObject(moduleType *mt, void *value);
-robj *createLinkObject(void *ptr, int soft);
+robj *createLinkObject(void *ptr);
 int getLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg);
 int getPositiveLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg);
 int getRangeLongFromObjectOrReply(client *c, robj *o, long min, long max, long *target, const char *msg);


### PR DESCRIPTION
This pr is only draft about #10051, and Just to verify the feasibility of this design, so don't do a deep review yet.

it's work and need more test.
Maybe have other better implements.

**The problem/use-case that the feature addresses**

This issue is discuss how to implement **link** feature on #2668.

**Description of the feature**

Add the link command, and it has two mode, which is like file systems comamnd **ln**: 
- hard link
- soft link

The command format like this: `link source_key target_key [soft]`.

**Additional information(design principles)**

Whether it‘s hard link or soft link, use native data structures whenever possible, and keep the overall logic of the original code. 

This design need a new redis object type, we call it `OBJECT_TYPE_LINK` and a new object encoding `OBJECT_ENCODING_POINTER` for the hard link.  By the new type,  linked key will have separate properties(expiration tim,  lru, lfu and other).

1. The hard link:
- use the robj pointer and refcount implements the object pointer ; e.g. `o->ptr = sourceValObject; incrRefCount(sourceValObject);...`; when lookupKey, we only return o->ptr;

- rdb save only save the new type `RDB_TYPE_LINK_POINTER` and the sources_key;  
on load data from rdb could use pending list because we not sure whether the key is written, when parsed one db, handle the pending list and reload data to the hash table

2. The soft link:
- the object ptr save the source key; like this: `incrRefCount(c->argv[1]); o->ptr = c->argv[1]`, the c->argv[1] is the key object on parse protocol;
- on lookupKey, we need to pay attention to the problem of circular lookup problem; e.g. `a->b, b->c, c->d, d->e`, we lookup e, will trigger circular lookup
- rdb save and load, only keep the overall logic of the original code and add new branch with the new object type `OBJECT_TYPE_LINK`.

Maybe there are other better desings.
Everyone is also welcome to discuss.