### PR TITLE
Show the elapsed time of single test and speedup some tests

### DIFF
--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -170,7 +170,7 @@ start_server {} {
 }
 
 test {client freed during loading} {
-    start_server [list overrides [list key-load-delay 50 rdbcompression no]] {
+    start_server [list overrides [list key-load-delay 50 loading-process-events-interval-bytes 1024 rdbcompression no]] {
         # create a big rdb that will take long to load. it is important
         # for keys to be big since the server processes events only once in 2mb.
         # 100mb of rdb, 100k keys will load in more than 5 seconds

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -180,6 +180,7 @@ proc test {name code {okpattern undefined} {tags {}}} {
 
     send_data_packet $::test_server_fd testing $name
 
+    set test_start_time [clock milliseconds]
     if {[catch {set retval [uplevel 1 $code]} error]} {
         set assertion [string match "assertion:*" $error]
         if {$assertion || $::durable} {
@@ -207,7 +208,8 @@ proc test {name code {okpattern undefined} {tags {}}} {
     } else {
         if {$okpattern eq "undefined" || $okpattern eq $retval || [string match $okpattern $retval]} {
             incr ::num_passed
-            send_data_packet $::test_server_fd ok $name
+            set elapsed [expr {[clock milliseconds]-$test_start_time}]
+            send_data_packet $::test_server_fd ok $name $elapsed
         } else {
             set msg "Expected '$okpattern' to equal or match '$retval'"
             lappend details $msg

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -368,7 +368,7 @@ proc accept_test_clients {fd addr port} {
 proc read_from_test_client fd {
     set bytes [gets $fd]
     set payload [read $fd $bytes]
-    foreach {status data} $payload break
+    foreach {status data elapsed} $payload break
     set ::last_progress [clock seconds]
 
     if {$status eq {ready}} {
@@ -387,7 +387,7 @@ proc read_from_test_client fd {
         set ::active_clients_task($fd) "(DONE) $data"
     } elseif {$status eq {ok}} {
         if {!$::quiet} {
-            puts "\[[colorstr green $status]\]: $data"
+            puts "\[[colorstr green $status]\]: $data ($elapsed ms)"
         }
         set ::active_clients_task($fd) "(OK) $data"
     } elseif {$status eq {skip}} {
@@ -553,8 +553,8 @@ proc test_client_main server_port {
     }
 }
 
-proc send_data_packet {fd status data} {
-    set payload [list $status $data]
+proc send_data_packet {fd status data {elapsed 0}} {
+    set payload [list $status $data $elapsed]
     puts $fd [string length $payload]
     puts -nonewline $fd $payload
     flush $fd

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -463,7 +463,7 @@ start_server {config "minimal.conf" tags {"introspection external:skip"} overrid
 }
 
 test {config during loading} {
-    start_server [list overrides [list key-load-delay 50 rdbcompression no]] {
+    start_server [list overrides [list key-load-delay 50 loading-process-events-interval-bytes 1024 rdbcompression no]] {
         # create a big rdb that will take long to load. it is important
         # for keys to be big since the server processes events only once in 2mb.
         # 100mb of rdb, 100k keys will load in more than 5 seconds


### PR DESCRIPTION
Following #10038.

This PR introduces two changes.
1. Show the elapsed time of a single test in the test output, in order to have a more detailed understanding of the changes in test run time.

    Output:
    ```
    [ok]: PFADD without arguments creates an HLL value (1 ms)
    [ok]: Approximated cardinality after creation is zero (0 ms)
    [ok]: PFADD returns 1 when at least 1 reg was modified (0 ms)
    [ok]: PFADD returns 0 when no reg was modified (0 ms)
    ```

2. Speedup two tests related to `key-load-delay` configuration.
    By comparing the output of the following thress CIs, other tests do not seem to be affected by #10003.

| Test    | Before #10003  | After #10003   | After this PR |
| ---------- | ------------------------ | ------------------------ | -------- |
| client freed during loading | 9 seconds    | 22 seconds | 7 seconds |
| config during loading | 4 seconds | 15 seconds  | 4 seconds |

### Compare CI:
before #10003: https://github.com/sundb/redis/runs/4712829066?check_suite_focus=true
after #10003: https://github.com/sundb/redis/runs/4679660840?check_suite_focus=true
after this PR: https://github.com/sundb/redis/runs/4712795765?check_suite_focus=true