### PR TITLE
Set errno to EEXIST in redisFork() if child process exists

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5862,8 +5862,10 @@ void closeChildUnusedResourceAfterFork() {
 /* purpose is one of CHILD_TYPE_ types */
 int redisFork(int purpose) {
     if (isMutuallyExclusiveChildType(purpose)) {
-        if (hasActiveChildProcess())
+        if (hasActiveChildProcess()) {
+            errno = EEXIST;
             return -1;
+        }
 
         openChildInfoPipe();
     }

--- a/tests/unit/moduleapi/fork.tcl
+++ b/tests/unit/moduleapi/fork.tcl
@@ -32,4 +32,11 @@ start_server {tags {"modules"}} {
         assert {[count_log_message "fork child exiting"] eq "1"}
     }
 
+    test {Module fork twice} {
+        r fork.create 0
+        after 250
+        catch {r fork.create 0}
+        assert {[count_log_message "Can't fork for module: File exists"] eq "1"}
+    }
+
 }


### PR DESCRIPTION
Callers of redisFork() are logging `strerror(errno)` on failure. `errno` is not set when there is already a child process, causing printing current value of errno which was set before `redisFork()` call. 

Setting errno to EEXIST on this failure to provide more meaningful error message. 