### PR TITLE
Fixes typo in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1636,7 +1636,7 @@ lua-time-limit 5000
 #
 # cluster-allow-reads-when-down no
 
-# This option, when set to yes, allows nodes to serve pubsub shard traffic while the
+# This option, when set to yes, allows nodes to serve pubsub shard traffic while
 # the cluster is in a down state, as long as it believes it owns the slots.
 #
 # This is useful if the application would like to use the pubsub feature even when


### PR DESCRIPTION
Fixes minor typo in `redis.conf`

- Origin: shard traffic while `the the` cluster
- Changed: shard traffic while `the` cluster