### PR TITLE
Changed latency histogram output to omit trailing 0s and periods

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1781,7 +1781,7 @@ latency-monitor-threshold 0
 
 # By default the exported latency percentiles via the INFO latencystats command
 # are the p50, p99, and p999.
-# latency-tracking-info-percentiles 50.0 99.0 99.9
+# latency-tracking-info-percentiles 50 99 99.9
 
 ############################# EVENT NOTIFICATION ##############################
 

--- a/src/config.c
+++ b/src/config.c
@@ -2721,7 +2721,7 @@ void rewriteConfigLatencyTrackingInfoPercentilesOutputOption(typeData data, cons
     } else {
         for (int j = 0; j < server.latency_tracking_info_percentiles_len; j++) {
             char fbuf[128];
-            size_t len = sprintf(fbuf, "%f", server.latency_tracking_info_percentiles[j]);
+            size_t len = sprintf(fbuf, " %f", server.latency_tracking_info_percentiles[j]);
             len = trimDoubleString(fbuf, len);
             line = sdscatlen(line, fbuf, len);
         }

--- a/src/config.c
+++ b/src/config.c
@@ -2698,8 +2698,10 @@ static sds getConfigLatencyTrackingInfoPercentilesOutputOption(typeData data) {
     UNUSED(data);
     sds buf = sdsempty();
     for (int j = 0; j < server.latency_tracking_info_percentiles_len; j++) {
-        buf = sdscatprintf(buf,"%f",
-                        server.latency_tracking_info_percentiles[j]);
+        char fbuf[128];
+        size_t len = sprintf(fbuf, "%f", server.latency_tracking_info_percentiles[j]);
+        len = trimDoubleString(fbuf, len);
+        buf = sdscatlen(buf, fbuf, len);
         if (j != server.latency_tracking_info_percentiles_len-1)
             buf = sdscatlen(buf," ",1);
     }
@@ -2718,8 +2720,10 @@ void rewriteConfigLatencyTrackingInfoPercentilesOutputOption(typeData data, cons
         line = sdscat(line," \"\"");
     } else {
         for (int j = 0; j < server.latency_tracking_info_percentiles_len; j++) {
-            line = sdscatprintf(line," %f",
-                server.latency_tracking_info_percentiles[j]);
+            char fbuf[128];
+            size_t len = sprintf(fbuf, "%f", server.latency_tracking_info_percentiles[j]);
+            len = trimDoubleString(fbuf, len);
+            line = sdscatlen(line, fbuf, len);
         }
     }
     rewriteConfigRewriteLine(state,name,line,1);

--- a/src/server.c
+++ b/src/server.c
@@ -1782,7 +1782,6 @@ void initServerConfig(void) {
     server.page_size = sysconf(_SC_PAGESIZE);
     server.pause_cron = 0;
 
-    server.latency_tracking_enabled = 1;
     server.latency_tracking_info_percentiles_len = 3;
     server.latency_tracking_info_percentiles = zmalloc(sizeof(double)*(server.latency_tracking_info_percentiles_len));
     server.latency_tracking_info_percentiles[0] = 50.0;  /* p50 */
@@ -4618,7 +4617,10 @@ void bytesToHuman(char *s, unsigned long long n) {
 sds fillPercentileDistributionLatencies(sds info, const char* histogram_name, struct hdr_histogram* histogram) {
     info = sdscatfmt(info,"latency_percentiles_usec_%s:",histogram_name);
     for (int j = 0; j < server.latency_tracking_info_percentiles_len; j++) {
-        info = sdscatprintf(info,"p%f=%.3f", server.latency_tracking_info_percentiles[j],
+        char fbuf[128];
+        size_t len = sprintf(fbuf, "%f", server.latency_tracking_info_percentiles[j]);
+        len = trimDoubleString(fbuf, len);
+        info = sdscatprintf(info,"p%s=%.3f", fbuf,
             ((double)hdr_value_at_percentile(histogram,server.latency_tracking_info_percentiles[j]))/1000.0f);
         if (j != server.latency_tracking_info_percentiles_len-1)
             info = sdscatlen(info,",",1);

--- a/src/util.c
+++ b/src/util.c
@@ -594,6 +594,20 @@ int d2string(char *buf, size_t len, double value) {
     return len;
 }
 
+/* Trims off trailing zeros from a string representing a double. */
+int trimDoubleString(char *buf, size_t len) {
+    if (strchr(buf,'.') != NULL) {
+        char *p = buf+len-1;
+        while(*p == '0') {
+            p--;
+            len--;
+        }
+        if (*p == '.') len--;
+    }
+    buf[len] = '\0';
+    return len;
+}
+
 /* Create a string object from a long double.
  * If mode is humanfriendly it does not use exponential format and trims trailing
  * zeroes at the end (may result in loss of precision).

--- a/src/util.h
+++ b/src/util.h
@@ -60,6 +60,7 @@ int string2ull(const char *s, unsigned long long *value);
 int string2l(const char *s, size_t slen, long *value);
 int string2ld(const char *s, size_t slen, long double *dp);
 int string2d(const char *s, size_t slen, double *dp);
+int trimDoubleString(char *buf, size_t len);
 int d2string(char *buf, size_t len, double value);
 int ld2string(char *buf, size_t len, long double value, ld2string_mode mode);
 sds getAbsolutePath(char *filename);

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -20,7 +20,7 @@ start_server {tags {"info" "external:skip"}} {
             assert_match {} [latency_percentiles_usec set]
             r CONFIG SET latency-tracking yes
             r set a b
-            assert_match {*p50.000000=*,p99.000000=*,p99.900000=*} [latency_percentiles_usec set]
+            assert_match {*p50=*,p99=*,p99.9=*} [latency_percentiles_usec set]
             r config resetstat
             assert_match {} [latency_percentiles_usec set]
         }
@@ -31,12 +31,12 @@ start_server {tags {"info" "external:skip"}} {
             r CONFIG SET latency-tracking yes
             r SET a b
             r GET a
-            assert_match {*p50.000000=*,p99.000000=*,p99.900000=*} [latency_percentiles_usec set]
-            assert_match {*p50.000000=*,p99.000000=*,p99.900000=*} [latency_percentiles_usec get]
+            assert_match {*p50=*,p99=*,p99.9=*} [latency_percentiles_usec set]
+            assert_match {*p50=*,p99=*,p99.9=*} [latency_percentiles_usec get]
             r CONFIG SET latency-tracking-info-percentiles "0.0 50.0 100.0"
-            assert_match [r config get latency-tracking-info-percentiles] {latency-tracking-info-percentiles {0.000000 50.000000 100.000000}}
-            assert_match {*p0.000000=*,p50.000000=*,p100.000000=*} [latency_percentiles_usec set]
-            assert_match {*p0.000000=*,p50.000000=*,p100.000000=*} [latency_percentiles_usec get]
+            assert_match [r config get latency-tracking-info-percentiles] {latency-tracking-info-percentiles {0 50 100}}
+            assert_match {*p0=*,p50=*,p100=*} [latency_percentiles_usec set]
+            assert_match {*p0=*,p50=*,p100=*} [latency_percentiles_usec get]
             r config resetstat
             assert_match {} [latency_percentiles_usec set]
         }
@@ -71,7 +71,7 @@ start_server {tags {"info" "external:skip"}} {
             wait_for_blocked_client
             r lpush list1{t} b
             assert_equal [$rd read] {list1{t} b}
-            assert_match {*p50.000000=*,p99.000000=*,p99.900000=*} [latency_percentiles_usec blpop]
+            assert_match {*p50=*,p99=*,p99.9=*} [latency_percentiles_usec blpop]
             $rd close
         }
 
@@ -83,8 +83,8 @@ start_server {tags {"info" "external:skip"}} {
             r SET k v
             set latencystatline_debug [latency_percentiles_usec debug]
             set latencystatline_set [latency_percentiles_usec set]
-            regexp "p50.000000=(.+\..+)" $latencystatline_debug -> p50_debug
-            regexp "p50.000000=(.+\..+)" $latencystatline_set -> p50_set
+            regexp "p50=(.+\..+)" $latencystatline_debug -> p50_debug
+            regexp "p50=(.+\..+)" $latencystatline_set -> p50_set
             assert {$p50_debug >= 50000}
             assert {$p50_set >= 0}
             assert {$p50_debug >= $p50_set}

--- a/tests/unit/moduleapi/blockonbackground.tcl
+++ b/tests/unit/moduleapi/blockonbackground.tcl
@@ -31,7 +31,7 @@ start_server {tags {"modules"}} {
         set latencystatline_debug [latency_percentiles_usec block.debug]
 
         regexp "calls=1,usec=(.*?),usec_per_call=(.*?),rejected_calls=0,failed_calls=0" $cmdstatline -> usec usec_per_call
-        regexp "p50.000000=(.+\..+)" $latencystatline_debug  -> p50
+        regexp "p50=(.+\..+)" $latencystatline_debug  -> p50
         assert {$usec >= 100000}
         assert {$usec_per_call >= 100000}
         assert {$p50 >= 100000}


### PR DESCRIPTION
I found it slightly verbose that latency histogram info values are written out to full precision. So I changed that. I also removed setting the default value for tracking, which is not needed since it's set by the config infra. 

previous
```
latency_percentiles_usec_sadd:p50.000000=0.001,p99.000000=1.003,p99.900000=3.007
```

now
```
latency_percentiles_usec_sadd:p50=0.001,p99=1.003,p99.9=3.007
``