### PR TITLE
fix redis crached by using eval with access to volatile keys

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -413,7 +413,7 @@ void scriptCall(scriptRunCtx *run_ctx, robj* *argv, int argc, sds *err) {
 
 /* Returns the time when the script invocation started */
 mstime_t scriptTimeSnapshot() {
-    serverAssert(!curr_run_ctx);
+    serverAssert(curr_run_ctx);
     return curr_run_ctx->snapshot_time;
 }
 


### PR DESCRIPTION
fix :https://github.com/redis/redis/issues/10079 

And I passed my test in https://github.com/redis/redis/issues/10079 

This is a recent regression from the Redis Functions commits