### PR TITLE
Make sure replicas don't write their own replies to the replication link

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -2354,6 +2354,7 @@ void redisSetCpuAffinity(const char *cpulist);
 client *createClient(connection *conn);
 void freeClient(client *c);
 void freeClientAsync(client *c);
+void logInvalidUseAndFreeClientAsync(client *c, const char *fmt, ...);
 int beforeNextClient(client *c);
 void resetClient(client *c);
 void freeClientOriginalArgv(client *c);


### PR DESCRIPTION
The following steps will crash redis-server:
```
[root]# cat crash
PSYNC replicationid -1
SLOWLOG GET
GET key
[root]# nc 127.0.0.1 6379 < crash
```

This one following #10020 and the crash was reported in #10076.
Add a new common function name `logInvalidUseAndFreeClient`
that will log the errors and free the client in async way.

Other changes about the output info:
1. Cmd with a full name by using `getFullCommandName`, now it will print the right subcommand name like `slowlog|get`.
2. Print the full client info by using `catClientInfoString`, the info is also valuable.

Now the log will like this:
```
31518:M 09 Jan 2022 18:35:19.849 # Replica generated a reply to command slowlog|get, disconnecting it: id=4 addr=127.0.0.1:45208 laddr=127.0.0.1:6379 fd=8 name= age=0 idle=0 flags=S db=0 sub=0 psub=0 multi=-1 qbuf=42 qbuf-free=20432 argv-mem=10 multi-mem=0 obl=0 oll=0 omem=0 tot-mem=40986 events=r cmd=slowlog|get user=default redir=-1 resp=2
```