### PR TITLE
Fix timing issue with cluster hostname test

### DIFF
--- a/tests/cluster/tests/27-endpoints.tcl
+++ b/tests/cluster/tests/27-endpoints.tcl
@@ -166,6 +166,16 @@ test "Verify the nodes configured with prefer hostname only show hostname for ne
     # Have a replica meet the isolated node
     R 3 cluster meet 127.0.0.1 [get_instance_attrib redis 6 port]
 
+    # Wait for the isolated node to learn about the rest of the cluster,
+    # which correspond to a single entry in cluster nodes. Note this
+    # doesn't mean the isolated node has successfully contacted each
+    # node.
+    wait_for_condition 50 100 {
+        [llength [split [R 6 CLUSTER NODES] "\n"]] eq 21 
+    } else {
+        fail "Isolated node didn't learn about the rest of the cluster *"
+    }
+
     # Now, we wait until the two nodes that aren't filtering packets
     # to accept our isolated nodes connections. At this point they will
     # start showing up in cluster slots. 


### PR DESCRIPTION
I believe this should fix the issue outlined here:
https://github.com/redis/redis/runs/4733590577?check_suite_focus=true
https://github.com/redis/redis/runs/4745050597?check_suite_focus=true

This test is verifying that when a node is joining a cluster, the hostname is shown only when we've exchanged ping/pong messages (I.E. we now know the full state of the node) and just when we learn about a node through gossip. The test was previously assuming that if we had fully connected to 2 other nodes we would have at least reached out to a third node. Although this is highly likely, it's not guaranteed, so now we are waiting on both events. We've learned about every node in the cluster AND we've fully established connections with two particular nodes that have hostnames.