### PR TITLE
Fix EVAL timeout test failed on freebsd

### DIFF
--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -478,22 +478,14 @@ tags {"aof external:skip"} {
     }
 
     test {EVAL timeout with slow verbatim Lua script from AOF} {
-        start_server [list overrides [list dir $server_path appendonly yes lua-time-limit 1 aof-use-rdb-preamble no]] {
-            # generate a long running script that is propagated to the AOF as script
-            # make sure that the script times out during loading
-            create_aof $aof_dirpath $aof_file {
-                append_to_aof [formatCommand select 9]
-                append_to_aof [formatCommand eval {redis.call('set',KEYS[1],'y'); for i=1,1500000 do redis.call('ping') end return 'ok'} 1 x]
-            }
-            set rd [redis_deferring_client]
-            set start [clock clicks -milliseconds]
-            $rd debug loadaof
-            $rd flush
+        # generate a long running script that is propagated to the AOF as script
+        # make sure that the script times out during loading
+        create_aof $aof_dirpath $aof_file {
+            append_to_aof [formatCommand select 9]
+            append_to_aof [formatCommand eval {redis.call('set',KEYS[1],'y'); for i=1,1500000 do redis.call('ping') end return 'ok'} 1 x]
+        }
+        start_server [list overrides [list dir $server_path appendonly yes lua-time-limit 1 aof-use-rdb-preamble no]] {  
             wait_for_log_messages 0 {"*Slow script detected*"} 0 100 100
-            $rd read
-            set elapsed [expr [clock clicks -milliseconds]-$start]
-            if {$::verbose} { puts "loading took $elapsed milliseconds" }
-            $rd close
             assert_equal [r get x] y
         }
     }

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -488,7 +488,11 @@ tags {"aof external:skip"} {
             set rd [redis_deferring_client]
             $rd debug loadaof
             $rd flush
-            after 200
+            wait_for_condition 100 10 {
+                [s loading] == 1
+            } else {
+                fail "server didn't start loading"
+            }
             catch {r ping} err
             assert_match {LOADING*} $err
             $rd read

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -489,11 +489,7 @@ tags {"aof external:skip"} {
             set start [clock clicks -milliseconds]
             $rd debug loadaof
             $rd flush
-            wait_for_condition 1000 100 {
-                [count_log_message 0 "Slow script detected"] eq 1
-            } else {
-                fail "Redis didn't detect slow script"
-            }
+            wait_for_log_messages 0 {"*Slow script detected*"} 0 100 100
             $rd read
             set elapsed [expr [clock clicks -milliseconds]-$start]
             if {$::verbose} { puts "loading took $elapsed milliseconds" }

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -489,12 +489,7 @@ tags {"aof external:skip"} {
             set start [clock clicks -milliseconds]
             $rd debug loadaof
             $rd flush
-            wait_for_condition 50 100 {
-                [s loading] eq 1
-            } else {
-                fail "Redis didn't enter LOADING"
-            }
-            wait_for_condition 50 100 {
+            wait_for_condition 1000 100 {
                 [count_log_message 0 "Slow script detected"] eq 1
             } else {
                 fail "Redis didn't detect slow script"

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -494,12 +494,16 @@ tags {"aof external:skip"} {
             } else {
                 fail "Redis didn't enter LOADING"
             }
+            wait_for_condition 50 100 {
+                [count_log_message 0 "Slow script detected"] eq 1
+            } else {
+                fail "Redis didn't detect slow script"
+            }
             $rd read
             set elapsed [expr [clock clicks -milliseconds]-$start]
             if {$::verbose} { puts "loading took $elapsed milliseconds" }
             $rd close
             assert_equal [r get x] y
-            assert_equal [count_log_message 0 "Slow script detected"] 1
         }
     }
 

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -491,9 +491,11 @@ tags {"aof external:skip"} {
             set start [clock clicks -milliseconds]
             $rd debug loadaof
             $rd flush
-            after 100
-            catch {r ping} err
-            assert_match {LOADING*} $err
+            wait_for_condition 50 100 {
+                [catch {r ping} e] == 1
+            } else {
+                fail "Redis didn't enter LOADING"
+            }
             $rd read
             set elapsed [expr [clock clicks -milliseconds]-$start]
             if {$::verbose} { puts "loading took $elapsed milliseconds" }

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -505,7 +505,10 @@ proc start_server {options {code undefined}} {
         close $fd
     }
 
-    set before_start_ready_count [count_message_lines $stdout "Ready to accept"]
+    # We may have a stdout left over from the previous tests, so we need
+    # to get the current count of ready logs
+    set previous_ready_count [count_message_lines $stdout "Ready to accept"]
+
     # We need a loop here to retry with different ports.
     set server_started 0
     while {$server_started == 0} {
@@ -586,7 +589,7 @@ proc start_server {options {code undefined}} {
 
         while 1 {
             # check that the server actually started and is ready for connections
-            if {[count_message_lines $stdout "Ready to accept"] == [expr $before_start_ready_count + 1]} {
+            if {[count_message_lines $stdout "Ready to accept"] > $previous_ready_count} {
                 break
             }
             after 10

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -505,6 +505,7 @@ proc start_server {options {code undefined}} {
         close $fd
     }
 
+    set before_start_ready_count [count_message_lines $stdout "Ready to accept"]
     # We need a loop here to retry with different ports.
     set server_started 0
     while {$server_started == 0} {
@@ -585,7 +586,7 @@ proc start_server {options {code undefined}} {
 
         while 1 {
             # check that the server actually started and is ready for connections
-            if {[count_message_lines $stdout "Ready to accept"] > 0} {
+            if {[count_message_lines $stdout "Ready to accept"] == [expr $before_start_ready_count + 1]} {
                 break
             }
             after 10


### PR DESCRIPTION
 CI link:  https://github.com/redis/redis/runs/4769005256?check_suite_focus=true#step:4:7328

Modifications:
1. Refactor EVAL timeout test
2. since the test used `r config set appendonly yes` which generates a rewrite, it missed it's purpose
2. Fix the bug that `start_server` returns before redis starts ready, which affects when multiple tests share the same dir.