### PR TITLE
Fix kill aof rewrite child test

### DIFF
--- a/tests/unit/aofrw.tcl
+++ b/tests/unit/aofrw.tcl
@@ -63,7 +63,7 @@ start_server {tags {"aofrw external:skip"} overrides {aof-use-rdb-preamble no}} 
         waitForBgrewriteaof r
 
         # start a slow AOFRW
-        set k v
+        r set k v
         r config set rdb-key-save-delay 10000000
         r bgrewriteaof
 


### PR DESCRIPTION
The dbs doesn't have any keys, `rdb-key-save-delay`
config has no effect that cause the rewrite to complete.

It was introduced in #10015.