### PR TITLE
Fix function no-cluster flag test

### DIFF
--- a/tests/cluster/tests/00-base.tcl
+++ b/tests/cluster/tests/00-base.tcl
@@ -64,7 +64,9 @@ test "It is possible to write and read from the cluster" {
 }
 
 test "Function no-cluster flag" {
-    R 1 function load lua test {redis.register_function('f1', function() return 'hello' end, {'no-cluster'})}
+    R 1 function load lua test {
+        redis.register_function{function_name='f1', callback=function() return 'hello' end, flags={'no-cluster'}}
+    }
     catch {R 1 fcall f1 0} e
     assert_match {*Can not run function on cluster, 'no-cluster' flag is set*} $e
 }


### PR DESCRIPTION
Fixes cluster test introduced in #10066.
```
Function no-cluster flag: ERR Error registering functions: @user_function: 1: wrong number of arguments to redis.register_function
```