### PR TITLE
Fix quicklist node not being recompressed correctly after inserting a new node before or after it

### DIFF
--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -93,6 +93,32 @@ start_server {
         r ping
     }
 
+    test {LINSERT correctly recompress full quicklistNode after inserting a element before it} {
+        r del key
+        config_set list-compress-depth 1
+        r rpush key b
+        r rpush key c
+        r lset key -1 [string repeat x 8192]"969"
+        r lpush key a
+        r rpush key d
+        r linsert key before b f
+        r rpop key
+        r ping
+    }
+
+    test {LINSERT correctly recompress full quicklistNode after inserting a element after it} {
+        r del key
+        config_set list-compress-depth 1
+        r rpush key b
+        r rpush key c
+        r lset key 0 [string repeat x 8192]"969"
+        r lpush key a
+        r rpush key d
+        r linsert key after c f
+        r lpop key
+        r ping
+    }
+
 foreach comp {2 1 0} {
     set cycles 1000
     if {$::accurate} { set cycles 10000 }


### PR DESCRIPTION
Fix CI carsh: https://github.com/redis/redis/runs/4823518404?check_suite_focus=true

### Describe
Introduced by #9849.
When we do any operation on the quicklist, we should make sure that all nodes of the quicklist should not be in the recompressed state.

### Issues
This PR fixes two issues with incorrect recompression.
1. The current quicklist node is full and the previous node isn't full,
    the current node is not recompressed correctly after inserting elements into the previous node.
2. The current quicklist node is full and the next node isn't full,
    the current node is not recompressed correctly after inserting elements into the next node.

### Test
Add two tests to cover incorrect compression issues.

### Other
Fix unittest test failure caused by assertion introduced by #9849.
