### PR TITLE
Fix timing issue in PSETEX/PEXPIRE sub-second expire tests

### DIFF
--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -97,9 +97,8 @@ start_server {tags {"expire"}} {
         for {set j 0} {$j < 50} {incr j} {
             r del x
             r psetex x 100 somevalue
-            after 80
             set a [r get x]
-            after 120
+            after 101
             set b [r get x]
 
             if {$a eq {somevalue} && $b eq {}} break
@@ -114,9 +113,8 @@ start_server {tags {"expire"}} {
         for {set j 0} {$j < 50} {incr j} {
             r set x somevalue
             r pexpire x 100
-            after 80
             set c [r get x]
-            after 120
+            after 101
             set d [r get x]
 
             if {$c eq {somevalue} && $d eq {}} break
@@ -132,9 +130,8 @@ start_server {tags {"expire"}} {
             r set x somevalue
             set now [r time]
             r pexpireat x [expr ([lindex $now 0]*1000)+([lindex $now 1]/1000)+200]
-            after 20
             set e [r get x]
-            after 220
+            after 201
             set f [r get x]
 
             if {$e eq {somevalue} && $f eq {}} break


### PR DESCRIPTION
These two tests have a high probability of failure
on MacOS. Or it takes many retries to succeed.
Keys often expire before we can access them.

So this time we try to avoid this by reducing the time
of the first `after`, or removeing the first `after`.

The results of doing `20/81` and `0/101` are:
- PEXPIRE (20/81): 1069/1949
- PEXPIREAT (20/81): 1093/1949

- PEXPIRE (0/101): 31936 / 31936
- PEXPIREAT (0/101): 31936 / 31936

The first number is the number of times that the
test succeeded without any retries.
The second number is the total number of executions.

And we can see that `0/101` doesn't even need an extra
retries. Also reduces the time required for testing.
So in the end we chose `0/100`, i.e. remove the first `after`.

As for `PEXPIREAT`, there is no failure, but we still changed
it together, using `0/201`, after 2W tests, none of them failed.