### PR TITLE
Use am instead of using server.aof_manifest directly to call getBaseA…

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1574,7 +1574,7 @@ int loadAppendOnlyFiles(aofManifest *am) {
 
     /* Here we calculate the total size of all BASE and INCR files in
      * advance, it will be set to `server.loading_total_bytes`. */
-    total_size = getBaseAndIncrAppendOnlyFilesSize(server.aof_manifest);
+    total_size = getBaseAndIncrAppendOnlyFilesSize(am);
     startLoading(total_size, RDBFLAGS_AOF_PREAMBLE, 0);
 
     /* Load BASE AOF if needed. */


### PR DESCRIPTION
Use `am` instead of using `server.aof_manifest` directly to call `getBaseAndIncrAppendOnlyFilesSize`.

@oranagra It was a carelessness at the time, sorry.