### PR TITLE
Fix `FUNCTION LOAD` ignores unknown parameter.

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -966,6 +966,8 @@ void functionLoadCommand(client *c) {
             desc = c->argv[argc_pos++]->ptr;
             continue;
         }
+        addReplyErrorFormat(c, "Unkowns option given: %s", (char*)next_arg->ptr);
+        return;
     }
 
     if (argc_pos >= c->argc) {

--- a/src/functions.c
+++ b/src/functions.c
@@ -966,7 +966,7 @@ void functionLoadCommand(client *c) {
             desc = c->argv[argc_pos++]->ptr;
             continue;
         }
-        addReplyErrorFormat(c, "Unkowns option given: %s", (char*)next_arg->ptr);
+        addReplyErrorFormat(c, "Unknown option given: %s", (char*)next_arg->ptr);
         return;
     }
 

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -17,7 +17,7 @@ start_server {tags {"scripting"}} {
             r function load LUA test foo bar [get_function_code test {return 'hello'}]
         } e
         set _ $e
-    } {*Unkowns option given*}
+    } {*Unknown option given*}
 
     test {FUNCTION - Create an already exiting library raise error} {
         catch {

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -12,6 +12,13 @@ start_server {tags {"scripting"}} {
         r fcall test 0
     } {hello}
 
+    test {FUNCTION - Load with unknown argument} {
+        catch {
+            r function load LUA test foo bar [get_function_code test {return 'hello'}]
+        } e
+        set _ $e
+    } {*Unkowns option given*}
+
     test {FUNCTION - Create an already exiting library raise error} {
         catch {
             r function load LUA test [get_function_code test {return 'hello1'}]


### PR DESCRIPTION
Following discussion on: https://github.com/redis/redis/issues/9899#issuecomment-1014689385
Raise error if unknown parameter is given to `FUNCTION LOAD`.

Before the fix:
```
127.0.0.1:6379> function load LUA lib2 foo bar "local function test1() return 5 end redis.register_function('test1', test1)"
OK
```

After the fix:
```
127.0.0.1:6379> function load LUA lib2 foo bar "local function test1() return 5 end redis.register_function('test1', test1)"
(error) ERR Unknown option given: foo
```