### PR TITLE
remove doc in redis.conf merged by mistake to 5.0

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1370,31 +1370,6 @@ rdb-save-incremental-fsync yes
 # the main dictionary scan
 # active-defrag-max-scan-fields 1000
 
-# It is possible to pin different threads and processes of Redis to specific
-# CPUs in your system, in order to maximize the performances of the server.
-# This is useful both in order to pin different Redis threads in different
-# CPUs, but also in order to make sure that multiple Redis instances running
-# in the same host will be pinned to different CPUs.
-#
-# Normally you can do this using the "taskset" command, however it is also
-# possible to this via Redis configuration directly, both in Linux and FreeBSD.
-#
-# You can pin the server/IO threads, bio threads, aof rewrite child process, and
-# the bgsave child process. The syntax to specify the cpu list is the same as
-# the taskset command:
-#
-# Set redis server/io threads to cpu affinity 0,2,4,6:
-# server_cpulist 0-7:2
-#
-# Set bio threads to cpu affinity 1,3:
-# bio_cpulist 1,3
-#
-# Set aof rewrite child process to cpu affinity 8,9,10,11:
-# aof_rewrite_cpulist 8-11
-#
-# Set bgsave child process to cpu affinity 1,10,11
-# bgsave_cpulist 1,10-11
-
 # In some cases redis will emit warnings and even refuse to start if it detects
 # that the system is in bad state, it is possible to suppress these warnings
 # by setting the following config which takes a space delimited list of warnings


### PR DESCRIPTION
was merged to 5.0.11 by mistake, probably a bad merge conflict resolution