### PR TITLE
Fix replica count check in migration tests.

### DIFF
--- a/tests/cluster/tests/07-replica-migration.tcl
+++ b/tests/cluster/tests/07-replica-migration.tcl
@@ -18,7 +18,7 @@ test "Each master should have two replicas attached" {
     foreach_redis_id id {
         if {$id < 5} {
             wait_for_condition 1000 50 {
-                [llength [lindex [R 0 role] 2]] == 2
+                [llength [lindex [R $id role] 2]] == 2
             } else {
                 fail "Master #$id does not have 2 slaves as expected"
             }

--- a/tests/cluster/tests/12-replica-migration-2.tcl
+++ b/tests/cluster/tests/12-replica-migration-2.tcl
@@ -21,7 +21,7 @@ test "Each master should have at least two replicas attached" {
     foreach_redis_id id {
         if {$id < 5} {
             wait_for_condition 1000 50 {
-                [llength [lindex [R 0 role] 2]] >= 2
+                [llength [lindex [R $id role] 2]] >= 2
             } else {
                 fail "Master #$id does not have 2 slaves as expected"
             }

--- a/tests/cluster/tests/12.1-replica-migration-3.tcl
+++ b/tests/cluster/tests/12.1-replica-migration-3.tcl
@@ -19,7 +19,7 @@ test "Each master should have at least two replicas attached" {
     foreach_redis_id id {
         if {$id < 5} {
             wait_for_condition 1000 50 {
-                [llength [lindex [R 0 role] 2]] >= 2
+                [llength [lindex [R $id role] 2]] >= 2
             } else {
                 fail "Master #$id does not have 2 slaves as expected"
             }
@@ -61,7 +61,7 @@ test "Each master should have at least two replicas attached" {
     foreach_redis_id id {
         if {$id < 5} {
             wait_for_condition 1000 50 {
-                [llength [lindex [R 0 role] 2]] >= 2
+                [llength [lindex [R $id role] 2]] >= 2
             } else {
                 fail "Master #$id does not have 2 slaves as expected"
             }


### PR DESCRIPTION
Tests were not using loop index as node id,  checking replica count of the same node over and over.