### PR TITLE
Added AOF rewrite support for functions.

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -2102,6 +2102,35 @@ int rewriteModuleObject(rio *r, robj *key, robj *o, int dbid) {
     return io.error ? 0 : 1;
 }
 
+static int rewriteFunctions(rio *aof) {
+    dict *functions = functionsLibGet();
+    dictIterator *iter = dictGetIterator(functions);
+    dictEntry *entry = NULL;
+    while ((entry = dictNext(iter))) {
+        functionLibInfo *li = dictGetVal(entry);
+        if (li->desc) {
+            if (rioWrite(aof, "*7\r\n", strlen("*7\r\n")) == 0) goto werr;
+        } else {
+            if (rioWrite(aof, "*5\r\n", strlen("*5\r\n")) == 0) goto werr;
+        }
+        char fucntion_load[] = "$8\r\nFUNCTION\r\n$4\r\nLOAD\r\n";
+        if (rioWrite(aof, fucntion_load, sizeof(fucntion_load) - 1) == 0) goto werr;
+        if (rioWriteBulkString(aof, li->ei->name, sdslen(li->ei->name)) == 0) goto werr;
+        if (rioWriteBulkString(aof, li->name, sdslen(li->name)) == 0) goto werr;
+        if (li->desc) {
+            if (rioWriteBulkString(aof, "description", strlen("description")) == 0) goto werr;
+            if (rioWriteBulkString(aof, li->desc, sdslen(li->desc)) == 0) goto werr;
+        }
+        if (rioWriteBulkString(aof, li->code, sdslen(li->code)) == 0) goto werr;
+    }
+    dictReleaseIterator(iter);
+    return 1;
+
+werr:
+    dictReleaseIterator(iter);
+    return 0;
+}
+
 int rewriteAppendOnlyFileRio(rio *aof) {
     dictIterator *di = NULL;
     dictEntry *de;
@@ -2115,6 +2144,8 @@ int rewriteAppendOnlyFileRio(rio *aof) {
         if (rioWrite(aof,ts,sdslen(ts)) == 0) { sdsfree(ts); goto werr; }
         sdsfree(ts);
     }
+
+    if (rewriteFunctions(aof) == 0) goto werr;
 
     for (j = 0; j < server.dbnum; j++) {
         char selectcmd[] = "*2\r\n$6\r\nSELECT\r\n";

--- a/src/aof.c
+++ b/src/aof.c
@@ -2109,16 +2109,16 @@ static int rewriteFunctions(rio *aof) {
     while ((entry = dictNext(iter))) {
         functionLibInfo *li = dictGetVal(entry);
         if (li->desc) {
-            if (rioWrite(aof, "*7\r\n", strlen("*7\r\n")) == 0) goto werr;
+            if (rioWrite(aof, "*7\r\n", 4) == 0) goto werr;
         } else {
-            if (rioWrite(aof, "*5\r\n", strlen("*5\r\n")) == 0) goto werr;
+            if (rioWrite(aof, "*5\r\n", 4) == 0) goto werr;
         }
         char fucntion_load[] = "$8\r\nFUNCTION\r\n$4\r\nLOAD\r\n";
         if (rioWrite(aof, fucntion_load, sizeof(fucntion_load) - 1) == 0) goto werr;
         if (rioWriteBulkString(aof, li->ei->name, sdslen(li->ei->name)) == 0) goto werr;
         if (rioWriteBulkString(aof, li->name, sdslen(li->name)) == 0) goto werr;
         if (li->desc) {
-            if (rioWriteBulkString(aof, "description", strlen("description")) == 0) goto werr;
+            if (rioWriteBulkString(aof, "description", 11) == 0) goto werr;
             if (rioWriteBulkString(aof, li->desc, sdslen(li->desc)) == 0) goto werr;
         }
         if (rioWriteBulkString(aof, li->code, sdslen(li->code)) == 0) goto werr;

--- a/tests/unit/aofrw.tcl
+++ b/tests/unit/aofrw.tcl
@@ -74,6 +74,7 @@ start_server {tags {"aofrw external:skip"} overrides {aof-use-rdb-preamble no}} 
         } else {
             fail "Can't find 'Killing AOF child' into recent logs"
         }
+        r config set rdb-key-save-delay 0
     }
 
     foreach d {string int} {
@@ -189,8 +190,10 @@ start_server {tags {"aofrw external:skip"} overrides {aof-use-rdb-preamble no}} 
         }
         r bgrewriteaof
         waitForBgrewriteaof r
+        r function flush
         r debug loadaof
-        r FUNCTION LIST 
+        assert_equal [r fcall test 0] 1
+        r FUNCTION LIST
     } {{library_name test engine LUA description desc functions {{name test description {} flags {}}}}}
 
     test {BGREWRITEAOF is delayed if BGSAVE is in progress} {

--- a/tests/unit/aofrw.tcl
+++ b/tests/unit/aofrw.tcl
@@ -182,6 +182,17 @@ start_server {tags {"aofrw external:skip"} overrides {aof-use-rdb-preamble no}} 
         }
     }
 
+    test "AOF rewrite functions" {
+        r flushall
+        r FUNCTION LOAD LUA test DESCRIPTION {desc} {
+            redis.register_function('test', function() return 1 end)
+        }
+        r bgrewriteaof
+        waitForBgrewriteaof r
+        r debug loadaof
+        r FUNCTION LIST 
+    } {{library_name test engine LUA description desc functions {{name test description {} flags {}}}}}
+
     test {BGREWRITEAOF is delayed if BGSAVE is in progress} {
         r flushall
         r set k v


### PR DESCRIPTION
Function PR was merged without AOF rw support because we thought this feature was going to be removed on Redis 7. As I understood it was eventually decided to keep and so adding AOF rw support for functions.

Tests was added on aofrw.tcl
Other existing aofrw tests where slow due to unwanted rdb-key-save-delay