### PR TITLE
Sentinel: return an error if configuration save fails

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3143,8 +3143,10 @@ void sentinelConfigSetCommand(client *c) {
         return;
     }
 
-    sentinelFlushConfig();
-    addReply(c, shared.ok);
+    if (sentinelFlushConfig() == C_ERR) 
+        addReplyErrorFormat(c,"Failed to save Sentinel new configuration on disk");
+    else
+        addReply(c, shared.ok);
 
     /* Drop Sentinel connections to initiate a reconnect if needed. */
     if (drop_conns)
@@ -3898,14 +3900,18 @@ NULL
         if (ri == NULL) {
             addReplyError(c,sentinelCheckCreateInstanceErrors(SRI_MASTER));
         } else {
-            sentinelFlushConfig();
+            if (sentinelFlushConfig() == C_ERR) 
+                addReplyErrorFormat(c,"Failed to save Sentinel new configuration on disk");
+            else
+                addReply(c,shared.ok);
             sentinelEvent(LL_WARNING,"+monitor",ri,"%@ quorum %d",ri->quorum);
-            addReply(c,shared.ok);
         }
     } else if (!strcasecmp(c->argv[1]->ptr,"flushconfig")) {
         if (c->argc != 2) goto numargserr;
-        sentinelFlushConfig();
-        addReply(c,shared.ok);
+        if (sentinelFlushConfig() == C_ERR) 
+            addReplyErrorFormat(c,"Failed to save Sentinel new configuration on disk");
+        else
+            addReply(c,shared.ok);
         return;
     } else if (!strcasecmp(c->argv[1]->ptr,"remove")) {
         /* SENTINEL REMOVE <name> */
@@ -3916,8 +3922,10 @@ NULL
             == NULL) return;
         sentinelEvent(LL_WARNING,"-monitor",ri,"%@");
         dictDelete(sentinel.masters,c->argv[2]->ptr);
-        sentinelFlushConfig();
-        addReply(c,shared.ok);
+        if (sentinelFlushConfig() == C_ERR) 
+            addReplyErrorFormat(c,"Failed to save Sentinel new configuration on disk");
+        else
+            addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"ckquorum")) {
         /* SENTINEL CKQUORUM <name> */
         sentinelRedisInstance *ri;

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2270,7 +2270,7 @@ werr:
  */
 static void sentinelFlushConfigAndReply(client *c) {
     if (sentinelFlushConfig() == C_ERR)
-        addReplyErrorFormat(c,"failed to save config file");
+        addReplyErrorFormat(c,"Failed to save config file");
     else
         addReply(c, shared.ok);
 }

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2265,6 +2265,16 @@ werr:
     return C_ERR;
 }
 
+/* Call sentinelFlushConfig() produce a success/error reply to the
+ * calling client.
+ */
+static void sentinelFlushConfigAndReply(client *c) {
+    if (sentinelFlushConfig() == C_ERR)
+        addReplyErrorFormat(c,"failed to save config file");
+    else
+        addReply(c, shared.ok);
+}
+
 /* ====================== hiredis connection handling ======================= */
 
 /* Send the AUTH command with the specified master password if needed.
@@ -3143,10 +3153,7 @@ void sentinelConfigSetCommand(client *c) {
         return;
     }
 
-    if (sentinelFlushConfig() == C_ERR) 
-        addReplyErrorFormat(c,"Failed to save Sentinel new configuration on disk");
-    else
-        addReply(c, shared.ok);
+    sentinelFlushConfigAndReply(c);
 
     /* Drop Sentinel connections to initiate a reconnect if needed. */
     if (drop_conns)
@@ -3900,18 +3907,12 @@ NULL
         if (ri == NULL) {
             addReplyError(c,sentinelCheckCreateInstanceErrors(SRI_MASTER));
         } else {
-            if (sentinelFlushConfig() == C_ERR) 
-                addReplyErrorFormat(c,"Failed to save Sentinel new configuration on disk");
-            else
-                addReply(c,shared.ok);
+            sentinelFlushConfigAndReply(c);
             sentinelEvent(LL_WARNING,"+monitor",ri,"%@ quorum %d",ri->quorum);
         }
     } else if (!strcasecmp(c->argv[1]->ptr,"flushconfig")) {
         if (c->argc != 2) goto numargserr;
-        if (sentinelFlushConfig() == C_ERR) 
-            addReplyErrorFormat(c,"Failed to save Sentinel new configuration on disk");
-        else
-            addReply(c,shared.ok);
+        sentinelFlushConfigAndReply(c);
         return;
     } else if (!strcasecmp(c->argv[1]->ptr,"remove")) {
         /* SENTINEL REMOVE <name> */
@@ -3922,10 +3923,7 @@ NULL
             == NULL) return;
         sentinelEvent(LL_WARNING,"-monitor",ri,"%@");
         dictDelete(sentinel.masters,c->argv[2]->ptr);
-        if (sentinelFlushConfig() == C_ERR) 
-            addReplyErrorFormat(c,"Failed to save Sentinel new configuration on disk");
-        else
-            addReply(c,shared.ok);
+        sentinelFlushConfigAndReply(c);
     } else if (!strcasecmp(c->argv[1]->ptr,"ckquorum")) {
         /* SENTINEL CKQUORUM <name> */
         sentinelRedisInstance *ri;
@@ -4326,22 +4324,16 @@ void sentinelSetCommand(client *c) {
             break;
         }
     }
-    if (changes && sentinelFlushConfig() == C_ERR) {
-        addReplyErrorFormat(c,"Failed to save Sentinel new configuration on disk");
-        return;
-    }
-    addReply(c,shared.ok);
+    if (changes) sentinelFlushConfigAndReply(c);
     return;
 
 badfmt: /* Bad format errors */
     addReplyErrorFormat(c,"Invalid argument '%s' for SENTINEL SET '%s'",
         (char*)c->argv[badarg]->ptr,option);
 seterr:
-    if (changes && sentinelFlushConfig() == C_ERR) {
-        addReplyErrorFormat(c,"Failed to save Sentinel new configuration on disk");
-        return;
-    }
-    return;
+    /* TODO: Handle the case of both bad input and save error, possibly handling
+     * SENTINEL SET atomically. */
+    if (changes) sentinelFlushConfig();
 }
 
 /* Our fake PUBLISH command: it is actually useful only to receive hello messages

--- a/tests/sentinel/tests/03-runtime-reconf.tcl
+++ b/tests/sentinel/tests/03-runtime-reconf.tcl
@@ -55,7 +55,6 @@ test "Sentinel Set with other error situations" {
 
    catch {[S 0 SENTINEL SET mymaster quorum $update_quorum]} err
    exec chmod 644 $configfilename
-   assert_equal "ERR Failed to save Sentinel new configuration on disk" $err
-   
+   assert_equal "ERR failed to save config file" $err
 }
 

--- a/tests/sentinel/tests/03-runtime-reconf.tcl
+++ b/tests/sentinel/tests/03-runtime-reconf.tcl
@@ -53,8 +53,9 @@ test "Sentinel Set with other error situations" {
    set configfilename [file join "sentinel_$sentinel_id" "sentinel.conf"]
    exec chmod 000 $configfilename
 
-   assert_error "ERR Failed to save Sentinel new configuration on disk" {S 0 SENTINEL SET mymaster quorum $update_quorum}
-
+   catch {[S 0 SENTINEL SET mymaster quorum $update_quorum]} err
    exec chmod 644 $configfilename
+   assert_equal "ERR Failed to save Sentinel new configuration on disk" $err
+   
 }
 

--- a/tests/sentinel/tests/03-runtime-reconf.tcl
+++ b/tests/sentinel/tests/03-runtime-reconf.tcl
@@ -55,6 +55,6 @@ test "Sentinel Set with other error situations" {
 
    catch {[S 0 SENTINEL SET mymaster quorum $update_quorum]} err
    exec chmod 644 $configfilename
-   assert_equal "ERR failed to save config file" $err
+   assert_equal "ERR Failed to save config file" $err
 }
 

--- a/tests/sentinel/tests/03-runtime-reconf.tcl
+++ b/tests/sentinel/tests/03-runtime-reconf.tcl
@@ -44,5 +44,17 @@ test "Sentinel Set with other error situations" {
 
    # unknown parameter option
    assert_error "ERR Unknown option or number of arguments for SENTINEL SET 'fakeoption'" {S 0 SENTINEL SET mymaster fakeoption fakevalue}
+
+   # save new config to disk failed
+   set info [S 0 SENTINEL master mymaster]
+   set origin_quorum [dict get $info quorum]
+   set update_quorum [expr $origin_quorum+1]
+   set sentinel_id 0
+   set configfilename [file join "sentinel_$sentinel_id" "sentinel.conf"]
+   exec chmod 000 $configfilename
+
+   assert_error "ERR Failed to save Sentinel new configuration on disk" {S 0 SENTINEL SET mymaster quorum $update_quorum}
+
+   exec chmod 644 $configfilename
 }
 


### PR DESCRIPTION
When performing `SENTINEL SET`, Sentinel updates the local configuration file. Before this commit, failure to update the file would still result with an `+OK` reply. Now, a `-ERR Failed to save config file` error will be returned.