### PR TITLE
Added functions support to redis-check-rdb

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2744,82 +2744,54 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
     }
 }
 
-/* Extract the following library arguments from rio object (and returns them as out parameters):
- * * library name
- * * engine name
- * * description
- * * library blob (payload)
- *
- * On success return C_OK. On error, returns C_ERR and populate error out parameter with
- * a relevant error message. */
-int rdbFunctionLoadArguments(rio *rdb, sds *name, sds *engine_name, sds *desc, sds *blob, sds *error) {
-    sds t_name = NULL;
-    sds t_engine_name = NULL;
-    sds t_desc = NULL;
-    sds t_blob = NULL;
-    uint64_t has_desc;
-
-    if (!(t_name = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL))) {
-        *error = sdsnew("Failed loading library name");
-        goto error;
-    }
-
-    if (!(t_engine_name = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL))) {
-        *error = sdsnew("Failed loading engine name");
-        goto error;
-    }
-
-    if ((has_desc = rdbLoadLen(rdb, NULL)) == RDB_LENERR) {
-        *error = sdsnew("Failed loading library description indicator");
-        goto error;
-    }
-
-    if (has_desc && !(t_desc = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL))) {
-        *error = sdsnew("Failed loading library description");
-        goto error;
-    }
-
-    if (!(t_blob = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL))) {
-        *error = sdsnew("Failed loading library blob");
-        goto error;
-    }
-
-    if (name) *name = t_name;
-    if (engine_name) *engine_name = t_engine_name;
-    if (desc) *desc = t_desc;
-    if (blob) *blob = t_blob;
-    return C_OK;
-
-error:
-    if (t_name) sdsfree(t_name);
-    if (t_engine_name) sdsfree(t_engine_name);
-    if (t_desc) sdsfree(t_desc);
-    if (t_blob) sdsfree(t_blob);
-    return C_ERR;
-}
-
 /* Save the given functions_ctx to the rdb.
  * The err output parameter is optional and will be set with relevant error
  * message on failure, it is the caller responsibility to free the error
- * message on failure. */
+ * message on failure.
+ *
+ * The lib_ctx argument is also optional. If NULL is given, only verfy rdb
+ * structure with out performing the actual functions loading. */
 int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx* lib_ctx, int rdbflags, sds *err) {
     UNUSED(ver);
     sds name = NULL;
     sds engine_name = NULL;
     sds desc = NULL;
     sds blob = NULL;
+    uint64_t has_desc;
     sds error = NULL;
     int res = C_ERR;
-
-    if (rdbFunctionLoadArguments(rdb, &name, &engine_name, &desc, &blob, &error) != C_OK) {
+    if (!(name = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL))) {
+        error = sdsnew("Failed loading library name");
         goto error;
     }
 
-    if (functionsCreateWithLibraryCtx(name, engine_name, desc, blob, rdbflags & RDBFLAGS_ALLOW_DUP, &error, lib_ctx) != C_OK) {
-        if (!error) {
-            error = sdsnew("Failed creating the library");
-        }
+    if (!(engine_name = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL))) {
+        error = sdsnew("Failed loading engine name");
         goto error;
+    }
+
+    if ((has_desc = rdbLoadLen(rdb, NULL)) == RDB_LENERR) {
+        error = sdsnew("Failed loading library description indicator");
+        goto error;
+    }
+
+    if (has_desc && !(desc = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL))) {
+        error = sdsnew("Failed loading library description");
+        goto error;
+    }
+
+    if (!(blob = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL))) {
+        error = sdsnew("Failed loading library blob");
+        goto error;
+    }
+
+    if (lib_ctx) {
+        if (functionsCreateWithLibraryCtx(name, engine_name, desc, blob, rdbflags & RDBFLAGS_ALLOW_DUP, &error, lib_ctx) != C_OK) {
+            if (!error) {
+                error = sdsnew("Failed creating the library");
+            }
+            goto error;
+        }
     }
 
     res = C_OK;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2749,7 +2749,7 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
  * message on failure, it is the caller responsibility to free the error
  * message on failure.
  *
- * The lib_ctx argument is also optional. If NULL is given, only verfy rdb
+ * The lib_ctx argument is also optional. If NULL is given, only verify rdb
  * structure with out performing the actual functions loading. */
 int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx* lib_ctx, int rdbflags, sds *err) {
     UNUSED(ver);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -170,6 +170,7 @@ int rdbLoadBinaryFloatValue(rio *rdb, float *val);
 int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi);
 int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadingCtx *rdb_loading_ctx);
 int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx* lib_ctx, int rdbflags, sds *err);
+int rdbFunctionLoadArguments(rio *rdb, sds *name, sds *engine_name, sds *desc, sds *blob, sds *error);
 int rdbSaveRio(int req, rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi);
 ssize_t rdbSaveFunctions(rio *rdb);
 rdbSaveInfo *rdbPopulateSaveInfo(rdbSaveInfo *rsi);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -170,7 +170,6 @@ int rdbLoadBinaryFloatValue(rio *rdb, float *val);
 int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi);
 int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadingCtx *rdb_loading_ctx);
 int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx* lib_ctx, int rdbflags, sds *err);
-int rdbFunctionLoadArguments(rio *rdb, sds *name, sds *engine_name, sds *desc, sds *blob, sds *error);
 int rdbSaveRio(int req, rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi);
 ssize_t rdbSaveFunctions(rio *rdb);
 rdbSaveInfo *rdbPopulateSaveInfo(rdbSaveInfo *rsi);

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -303,6 +303,14 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             robj *o = rdbLoadCheckModuleValue(&rdb,name);
             decrRefCount(o);
             continue; /* Read type again. */
+        } else if (type == RDB_OPCODE_FUNCTION) {
+            sds err = NULL;
+            if (rdbFunctionLoadArguments(&rdb, NULL, NULL, NULL, NULL, &err) != C_OK) {
+                rdbCheckError("Failed loading library, %s", err);
+                sdsfree(err);
+                goto err;
+            }
+            continue;
         } else {
             if (!rdbIsObjectType(type)) {
                 rdbCheckError("Invalid object type: %d", type);

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -305,7 +305,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_FUNCTION) {
             sds err = NULL;
-            if (rdbFunctionLoadArguments(&rdb, NULL, NULL, NULL, NULL, &err) != C_OK) {
+            if (rdbFunctionLoad(&rdb, rdbver, NULL, 0, &err) != C_OK) {
                 rdbCheckError("Failed loading library, %s", err);
                 sdsfree(err);
                 goto err;


### PR DESCRIPTION
Fix #10133, added functions check to redis-check-rdb.
The PR added the missing verification for functions on redis-check-rdb. The verification only verifies the rdb structure and does not try to load the functions code and verify more advance checks (like compilation of the function code).