### PR TITLE
Fix flaky cluster tests in 24-links.tcl

### DIFF
--- a/tests/cluster/tests/24-links.tcl
+++ b/tests/cluster/tests/24-links.tcl
@@ -59,9 +59,12 @@ test "Disconnect link when send buffer limit reached" {
     set orig_link_p1_to_p2 [get_link_to_peer $primary1_id $primary2_name]
     set orig_link_p1_from_p2 [get_link_from_peer $primary1_id $primary2_name]
 
-    # On primary1, set cluster link send buffer limit to 32MB
+    # On primary1, set cluster link send buffer limit to 256KB, which is large enough to not be
+    # overflowed by regular gossip messages but also small enough that it doesn't take too much
+    # memory to overflow it. If it is set too high, Redis may get OOM killed by kernel before this
+    # limit is overflowed in some RAM-limited test environments.
     set oldlimit [lindex [$primary1 CONFIG get cluster-link-sendbuf-limit] 1]
-    $primary1 CONFIG set cluster-link-sendbuf-limit [expr 32*1024*1024]
+    $primary1 CONFIG set cluster-link-sendbuf-limit [expr 256*1024]
     assert {[get_info_field [$primary1 cluster info] total_cluster_links_buffer_limit_exceeded] eq 0}
 
     # To manufacture an ever-growing send buffer from primary1 to primary2,
@@ -69,22 +72,25 @@ test "Disconnect link when send buffer limit reached" {
     set primary2_pid [get_instance_attrib redis $primary2_id pid]
     exec kill -SIGSTOP $primary2_pid
 
-    # On primary1, send a 10MB Pubsub message. It will stay in send buffer of
-    # the link from primary1 to primary2
-    $primary1 publish channel [prepare_value [expr 10*1024*1024]]
+    # On primary1, send 128KB Pubsub messages in a loop until the send buffer of the link from
+    # primary1 to primary2 exceeds buffer limit therefore be dropped.
+    # For the send buffer to grow, we need to first exhaust TCP send buffer of primary1 and TCP
+    # receive buffer of primary2 first. The sizes of these two buffers vary by OS, but 100 128KB
+    # messages should be sufficient.
+    set i 0
+    wait_for_condition 100 0 {
+        [catch {incr i} e] == 0 &&
+        [catch {$primary1 publish channel [prepare_value [expr 128*1024]]} e] == 0 &&
+        [catch {after 500} e] == 0 &&
+        [get_info_field [$primary1 cluster info] total_cluster_links_buffer_limit_exceeded] eq 1
+    } else {
+        fail "Cluster link not freed as expected"
+    }
+    puts "\n# of 128KB messages needed to overflow 256KB buffer limit: $i"
 
-    # Check the same link has not been disconnected, but its send buffer has grown
-    set same_link_p1_to_p2 [get_link_to_peer $primary1_id $primary2_name]
-    assert {[dict get $same_link_p1_to_p2 create_time] eq [dict get $orig_link_p1_to_p2 create_time]}
-    assert {[dict get $same_link_p1_to_p2 send_buffer_allocated] > [dict get $orig_link_p1_to_p2 send_buffer_allocated]}
-
-    # On primary1, send another 30MB Pubsub message.
-    $primary1 publish channel [prepare_value [expr 30*1024*1024]]
-
-    # Link has exceeded buffer limit and been dropped and recreated
+    # A new link to primary2 should have been recreated
     set new_link_p1_to_p2 [get_link_to_peer $primary1_id $primary2_name]
     assert {[dict get $new_link_p1_to_p2 create_time] > [dict get $orig_link_p1_to_p2 create_time]}
-    assert {[get_info_field [$primary1 cluster info] total_cluster_links_buffer_limit_exceeded] eq 1}
 
     # Link from primary2 should not be affected
     set same_link_p1_from_p2 [get_link_from_peer $primary1_id $primary2_name]


### PR DESCRIPTION
Fix two flaky tests introduced in PR https://github.com/redis/redis/pull/9774

### For test "Each node has two links with each peer"

```
00:39:21> Each node has two links with each peer: FAILED: Expected 19*2 eq 37 (context: type eval line 11 cmd {assert {$num_peers*2 eq $num_links}} proc ::foreach_instance_id)
(Jumping to next unit after error)
```

This test seems to be flaky because cluster cluster is not stable and sometimes a node doesn't have both inbound and outbound connections established with every peer.

This failure is more rare than the next one. The fix is to add retries.

### For test "Disconnect link when send buffer limit reached"

There were two sources of failure.

1.

```
 00:47:22> Disconnect link when send buffer limit reached: error writing "sock802fbc590": broken pipe
    while executing
"$primary1 publish channel [prepare_value [expr 30*1024*1024]]"
```

Redis getting OOM killed by kernel due to out of swap. In the test, I'm allowing cluster link buffers to grow up to 32MB. There are 20 Redis nodes running in parallel in cluster tests. That proved to be too much for the FreeBSD test environment used by the daily runs.

Example failure link: https://github.com/redis/redis/runs/4733591841?check_suite_focus=true

Fix is to use smaller cluster link buffer limits and fill it up by repeatedly sending smallish messages. This approach should be adaptive to different test environments. 

2.

```
00:46:57> Disconnect link when send buffer limit reached: FAILED: Expected [get_info_field [::redis::redisHandle1876 cluster info] total_cluster_links_buffer_limit_exceeded] eq 1 (context: type eval line 36 cmd {assert {[get_info_field [$primary1 cluster info] total_cluster_links_buffer_limit_exceeded] eq 1}} proc ::test)
```

I'm assuming as soon as I send a large PUBLISH command to fill up a cluster link, the link will be freed. But in reality the link will only get freed in the next clusterCron run whenever that happens. My test is not accounting for this race condition. 

Example failure link: https://github.com/redis/redis/runs/4829401183?check_suite_focus=true#step:9:630

Fix is to wait for 0.5s before checking if link has been freed.