### PR TITLE
fix missing transform from key-spec to acl permission

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1507,6 +1507,10 @@ static int ACLSelectorCheckKey(aclSelector *selector, const char *key, int keyle
     listRewind(selector->patterns,&li);
 
     int key_flags = 0;
+    if (keyspec_flags & CMD_KEY_RO) key_flags |= ACL_READ_PERMISSION;
+    if (keyspec_flags & CMD_KEY_RW) key_flags |= ACL_WRITE_PERMISSION;
+    if (keyspec_flags & CMD_KEY_OW) key_flags |= ACL_WRITE_PERMISSION;
+    if (keyspec_flags & CMD_KEY_RM) key_flags |= ACL_WRITE_PERMISSION;
     if (keyspec_flags & CMD_KEY_ACCESS) key_flags |= ACL_READ_PERMISSION;
     if (keyspec_flags & CMD_KEY_INSERT) key_flags |= ACL_WRITE_PERMISSION;
     if (keyspec_flags & CMD_KEY_DELETE) key_flags |= ACL_WRITE_PERMISSION;

--- a/src/acl.c
+++ b/src/acl.c
@@ -1508,7 +1508,7 @@ static int ACLSelectorCheckKey(aclSelector *selector, const char *key, int keyle
 
     int key_flags = 0;
     if (keyspec_flags & CMD_KEY_RO) key_flags |= ACL_READ_PERMISSION;
-    if (keyspec_flags & CMD_KEY_RW) key_flags |= ACL_WRITE_PERMISSION;
+    if (keyspec_flags & CMD_KEY_RW) key_flags |= ACL_ALL_PERMISSION;
     if (keyspec_flags & CMD_KEY_OW) key_flags |= ACL_WRITE_PERMISSION;
     if (keyspec_flags & CMD_KEY_RM) key_flags |= ACL_WRITE_PERMISSION;
     if (keyspec_flags & CMD_KEY_ACCESS) key_flags |= ACL_READ_PERMISSION;


### PR DESCRIPTION
Introduced by #9974 #10122, some special commands (i.e. don't touch value like `EXISTS` `HLEN`) miss ACL key check, for example:

```
127.0.0.1:6379> acl setuser test on nopass +@all resetkeys %W~a
OK
127.0.0.1:6379> auth test xxx
OK
127.0.0.1:6379> exists a
(integer) 1
```

User test only have write permission on key `a`, but read command `EXISTS` is still executed successfully.