### PR TITLE
Fix outdated save key word in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -413,8 +413,8 @@ proc-title-template "{title} {listen-addr} {server-mode}"
 #
 # Unless specified otherwise, by default Redis will save the DB:
 #   * After 3600 seconds (an hour) if at least 1 change was performed
-#   * After 300 seconds (5 minutes) if at least 100 changes was performed
-#   * After 60 seconds if at least 10000 changes was performed
+#   * After 300 seconds (5 minutes) if at least 100 changes were performed
+#   * After 60 seconds if at least 10000 changes were performed
 #
 # You can set these explicitly by uncommenting the following line.
 #

--- a/redis.conf
+++ b/redis.conf
@@ -412,9 +412,9 @@ proc-title-template "{title} {listen-addr} {server-mode}"
 # save ""
 #
 # Unless specified otherwise, by default Redis will save the DB:
-#   * After 3600 seconds (an hour) if at least 1 key changed
-#   * After 300 seconds (5 minutes) if at least 100 keys changed
-#   * After 60 seconds if at least 10000 keys changed
+#   * After 3600 seconds (an hour) if at least 1 change was performed
+#   * After 300 seconds (5 minutes) if at least 100 changes was performed
+#   * After 60 seconds if at least 10000 changes was performed
 #
 # You can set these explicitly by uncommenting the following line.
 #


### PR DESCRIPTION
For some complex data types, server.dirty actually counts
the number of elements that have been changed.
And in FLUSHDB or FLUSHALL, we count the number of keys.

So the word "key" is not strictly correct and is outdated.
Some discussion can be seen at #8140.