### PR TITLE
Correctly handle minimum arity checks in scripts

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -210,7 +210,7 @@ void scriptKill(client *c, int is_eval) {
 }
 
 static int scriptVerifyCommandArity(struct redisCommand *cmd, int argc, sds *err) {
-    if (!cmd || ((cmd->arity > 0 && cmd->arity != argc) || (argc < cmd->arity))) {
+    if (!cmd || ((cmd->arity > 0 && cmd->arity != argc) || (argc < -cmd->arity))) {
         if (cmd)
             *err = sdsnew("Wrong number of args calling Redis command from script");
         else

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -598,6 +598,11 @@ start_server {tags {"scripting"}} {
         set e
     } {ERR Number of keys can't be negative}
 
+    test {Scripts can handle commands with incorrect arity} {
+        assert_error "*Wrong number of args calling Redis command from script" {run_script "redis.call('set','invalid')" 0}
+        assert_error "*Wrong number of args calling Redis command from script" {run_script "redis.call('incr')" 0}
+    }
+
     test {Correct handling of reused argv (issue #1939)} {
         run_script {
               for i = 0, 10 do
@@ -1211,11 +1216,6 @@ start_server {tags {"scripting needs:debug"}} {
         assert_equal [run_script "return redis.call('EXISTS', 'key')" 0] 0
         assert_equal 0 [r EXISTS key]
         r DEBUG set-active-expire 1
-    }
-
-    test "Scripts can handle commands with incorrect arity" {
-        assert_error "*Wrong number of args calling Redis command from script" {run_script "redis.call('set','invalid')" 0}
-        assert_error "*Wrong number of args calling Redis command from script" {run_script "redis.call('incr')" 0}
     }
 
     r debug set-disable-deny-scripts 0

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1214,8 +1214,8 @@ start_server {tags {"scripting needs:debug"}} {
     }
 
     test "Scripts can handle commands with incorrect arity" {
-        assert_error "*Wrong number of args calling Redis command from script" {r eval "redis.call('set','invalid')" 0}
-        assert_error "*Wrong number of args calling Redis command from script" {r eval "redis.call('incr')" 0}
+        assert_error "*Wrong number of args calling Redis command from script" {run_script "redis.call('set','invalid')" 0}
+        assert_error "*Wrong number of args calling Redis command from script" {run_script "redis.call('incr')" 0}
     }
 
     r debug set-disable-deny-scripts 0

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1213,6 +1213,11 @@ start_server {tags {"scripting needs:debug"}} {
         r DEBUG set-active-expire 1
     }
 
+    test "Scripts can handle commands with incorrect arity" {
+        assert_error "*Wrong number of args calling Redis command from script" {r eval "redis.call('set','invalid')" 0}
+        assert_error "*Wrong number of args calling Redis command from script" {r eval "redis.call('incr')" 0}
+    }
+
     r debug set-disable-deny-scripts 0
 }
 } ;# foreach is_eval


### PR DESCRIPTION
The previous code was checking if the argc was greater than a negative number, which was always true. Which was causing some confusing crashes.