### PR TITLE
Delete the residual code related to aof rewrite buf

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -2328,9 +2328,7 @@ int rewriteAppendOnlyFileBackground(void) {
     }
 
     /* We set aof_selected_db to -1 in order to force the next call to the
-     * feedAppendOnlyFile() to issue a SELECT command, so the differences
-     * accumulated by the parent into server.aof_rewrite_buf will start
-     * with a SELECT statement and it will be safe to merge. */
+     * feedAppendOnlyFile() to issue a SELECT command. */
     server.aof_selected_db = -1;
     flushAppendOnlyFile(1);
     if (openNewIncrAofForAppend() != C_OK) return C_ERR;

--- a/src/server.h
+++ b/src/server.h
@@ -1616,7 +1616,6 @@ struct redisServer {
     off_t aof_fsync_offset;         /* AOF offset which is already synced to disk. */
     int aof_flush_sleep;            /* Micros to sleep before flush. (used by tests) */
     int aof_rewrite_scheduled;      /* Rewrite once BGSAVE terminates. */
-    list *aof_rewrite_buf_blocks;   /* Hold changes during an AOF rewrite. */
     sds aof_buf;      /* AOF buffer, written before entering the event loop */
     int aof_fd;       /* File descriptor of currently selected AOF file */
     int aof_selected_db; /* Currently selected DB in AOF */


### PR DESCRIPTION
Although I tried to delete the `rewrite buf `related code before, I found that there are still fish that slipped through the net today. This time I tried searching with the keywords `rewrite-buf`, `rewrite_buf `and `rewrite buf`, and I think I can be sure to delete them all.

@oranagra PLZ review it, thanks.