### PR TITLE
Set default channel permission to resetchannels for 7.0

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1006,15 +1006,7 @@ acllog-max-len 128
 # allchannels: grants access to all Pub/Sub channels
 # resetchannels: revokes access to all Pub/Sub channels
 #
-# To ensure backward compatibility while upgrading Redis 6.0, acl-pubsub-default
-# defaults to the 'allchannels' permission.
-#
-# Future compatibility note: it is very likely that in a future version of Redis
-# the directive's default of 'allchannels' will be changed to 'resetchannels' in
-# order to provide better out-of-the-box Pub/Sub security. Therefore, it is
-# recommended that you explicitly define Pub/Sub permissions for all users
-# rather then rely on implicit default values. Once you've set explicit
-# Pub/Sub for all existing users, you should uncomment the following line.
+# From Redis 7.0, acl-pubsub-default defaults to 'resetchannels' permission.
 #
 # acl-pubsub-default resetchannels
 

--- a/src/config.c
+++ b/src/config.c
@@ -2811,7 +2811,7 @@ standardConfig configs[] = {
     createEnumConfig("maxmemory-policy", NULL, MODIFIABLE_CONFIG, maxmemory_policy_enum, server.maxmemory_policy, MAXMEMORY_NO_EVICTION, NULL, NULL),
     createEnumConfig("appendfsync", NULL, MODIFIABLE_CONFIG, aof_fsync_enum, server.aof_fsync, AOF_FSYNC_EVERYSEC, NULL, NULL),
     createEnumConfig("oom-score-adj", NULL, MODIFIABLE_CONFIG, oom_score_adj_enum, server.oom_score_adj, OOM_SCORE_ADJ_NO, NULL, updateOOMScoreAdj),
-    createEnumConfig("acl-pubsub-default", NULL, MODIFIABLE_CONFIG, acl_pubsub_default_enum, server.acl_pubsub_default, SELECTOR_FLAG_ALLCHANNELS, NULL, NULL),
+    createEnumConfig("acl-pubsub-default", NULL, MODIFIABLE_CONFIG, acl_pubsub_default_enum, server.acl_pubsub_default, 0, NULL, NULL),
     createEnumConfig("sanitize-dump-payload", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, sanitize_dump_payload_enum, server.sanitize_dump_payload, SANITIZE_DUMP_NO, NULL, NULL),
     createEnumConfig("enable-protected-configs", NULL, IMMUTABLE_CONFIG, protected_action_enum, server.enable_protected_configs, PROTECTED_ACTION_ALLOWED_NO, NULL, NULL),
     createEnumConfig("enable-debug-command", NULL, IMMUTABLE_CONFIG, protected_action_enum, server.enable_debug_cmd, PROTECTED_ACTION_ALLOWED_NO, NULL, NULL),

--- a/tests/assets/user.acl
+++ b/tests/assets/user.acl
@@ -1,3 +1,3 @@
-user alice on allcommands allkeys >alice
-user bob on -@all +@set +acl ~set* >bob
-user default on nopass ~* +@all
+user alice on allcommands allkeys &* >alice
+user bob on -@all +@set +acl ~set* &* >bob
+user default on nopass ~* &* +@all

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -20,12 +20,12 @@ start_server {tags {"acl external:skip"}} {
         assert_match "*NOPERM*keys*" $err
     }
 
-    test {Test ACL selectors by default have no permissions (except channels)} {
+    test {Test ACL selectors by default have no permissions} {
         r ACL SETUSER selector-default reset ()
         set user [r ACL GETUSER "selector-default"]
         assert_equal 1 [llength [dict get $user selectors]]
         assert_equal "" [dict get [lindex [dict get $user selectors] 0] keys]
-        assert_equal "&*" [dict get [lindex [dict get $user selectors] 0] channels]
+        assert_equal "" [dict get [lindex [dict get $user selectors] 0] channels]
         assert_equal "-@all" [dict get [lindex [dict get $user selectors] 0] commands]
     }
 
@@ -44,7 +44,7 @@ start_server {tags {"acl external:skip"}} {
         catch {r ACL SETUSER selector-syntax on (this-is-invalid)} e
         assert_match "*ERR Error in ACL SETUSER modifier '(*)*Syntax*" $e
 
-        catch {r ACL SETUSER selector-syntax on (&fail)} e
+        catch {r ACL SETUSER selector-syntax on (&* &fail)} e
         assert_match "*ERR Error in ACL SETUSER modifier '(*)*Adding a pattern after the*" $e
 
         assert_equal "" [r ACL GETUSER selector-syntax]


### PR DESCRIPTION
For backwards compatibility in 6.x, channels default permission was set to `allchannels` however with 7.0, we should modify it and the default value should be `resetchannels` for better security posture. Also, with selectors in ACL, a client doesn't have to set channel rules everytime and by default the value will be `resetchannels`.

This is a breaking change, users that are badly affected by it, can easily revert the config back to the old default.

Before this change
```
127.0.0.1:6379> acl list
1) "user default on nopass ~* &* +@all"
127.0.0.1:6379>  acl setuser hp on nopass +@all ~*
OK
127.0.0.1:6379> acl list
1) "user default on nopass ~* &* +@all"
2) "user hp on nopass ~* &* +@all"
127.0.0.1:6379>  acl setuser hp1 on nopass -@all (%R~sales*)
OK
127.0.0.1:6379> acl list
1) "user default on nopass ~* &* +@all"
2) "user hp on nopass ~* &* +@all"
3) "user hp1 on nopass &* -@all (%R~sales* &* -@all)"
```

After this change
```
127.0.0.1:6379> acl list
1) "user default on nopass ~* &* +@all"
127.0.0.1:6379> acl setuser hp on nopass +@all ~*
OK
127.0.0.1:6379> acl list
1) "user default on nopass ~* &* +@all"
2) "user hp on nopass ~* resetchannels +@all"
127.0.0.1:6379> acl setuser hp1 on nopass -@all (%R~sales*)
OK
127.0.0.1:6379> acl list
1) "user default on nopass ~* &* +@all"
2) "user hp on nopass ~* resetchannels +@all"
3) "user hp1 on nopass resetchannels -@all (%R~sales* resetchannels -@all)"
```