### PR TITLE
forbid module to unload when it holds ongoing timer

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -45,5 +45,6 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/subcommands \
 --single unit/moduleapi/reply \
 --single unit/moduleapi/eventloop \
+--single unit/moduleapi/timer \
 "${@}"
 

--- a/src/module.c
+++ b/src/module.c
@@ -10143,6 +10143,7 @@ int moduleLoad(const char *path, void **module_argv, int module_argc) {
  * * EBUSY: The module exports a new data type and can only be reloaded. 
  * * EPERM: The module exports APIs which are used by other module. 
  * * EAGAIN: The module has blocked clients. 
+ * * EINPROGRESS: The module holds timer not fired.
  * * ECANCELED: Unload module error.  */
 int moduleUnload(sds name) {
     struct RedisModule *module = dictFetchValue(modules,name);

--- a/src/module.c
+++ b/src/module.c
@@ -7434,7 +7434,7 @@ int moduleHoldsTimer(struct RedisModule *module) {
     int found = 0;
     raxStart(&iter,Timers);
     raxSeek(&iter,"^",NULL,0);
-    while(raxNext(&iter)) {
+    while (raxNext(&iter)) {
         RedisModuleTimer *timer = iter.data;
         if (timer->module == module) {
             found = 1;

--- a/src/module.c
+++ b/src/module.c
@@ -10161,7 +10161,7 @@ int moduleUnload(sds name) {
         return C_ERR;
     } else if (moduleHoldsTimer(module)) {
         errno = EINPROGRESS;
-        return REDISMODULE_ERR;
+        return C_ERR;
     }
 
     /* Give module a chance to clean up. */

--- a/src/module.c
+++ b/src/module.c
@@ -10366,6 +10366,10 @@ NULL
                 errmsg = "the module has blocked clients. "
                          "Please wait them unblocked and try again";
                 break;
+            case EINPROGRESS:
+                errmsg = "the module holds timer that is not fired. "
+                         "Please stop the timer or wait until it fires. ";
+                break;
             default:
                 errmsg = "operation not possible.";
                 break;

--- a/src/module.c
+++ b/src/module.c
@@ -10368,7 +10368,7 @@ NULL
                 break;
             case EINPROGRESS:
                 errmsg = "the module holds timer that is not fired. "
-                         "Please stop the timer or wait until it fires. ";
+                         "Please stop the timer or wait until it fires.";
                 break;
             default:
                 errmsg = "operation not possible.";

--- a/tests/unit/moduleapi/timer.tcl
+++ b/tests/unit/moduleapi/timer.tcl
@@ -58,11 +58,14 @@ start_server {tags {"modules"}} {
 
     test "Module can be unloaded only when timer was finished" {
         r set "timer-incr-key" 0
-        set id [r test.createtimer 1000 timer-incr-key]
+        set id [r test.createtimer 100 timer-incr-key]
 
         # Wait to be sure timer has been finished
-        after 2000
-        assert_equal 1 [r get timer-incr-key]
+        wait_for_condition 10 100 {
+            [r get timer-incr-key] == 1
+        } else {
+            fail "Timer not fired"
+        }
         # all timers are clean, can do the unloading now.
         assert_equal {OK} [r module unload timer]
     }

--- a/tests/unit/moduleapi/timer.tcl
+++ b/tests/unit/moduleapi/timer.tcl
@@ -58,7 +58,7 @@ start_server {tags {"modules"}} {
 
     test "Module can be unloaded when timer was finished" {
         r set "timer-incr-key" 0
-        r test.createtimer 2000 timer-incr-key
+        r test.createtimer 500 timer-incr-key
 
         # Make sure the Timer has not been fired
         assert_equal 0 [r get timer-incr-key]

--- a/tests/unit/moduleapi/timer.tcl
+++ b/tests/unit/moduleapi/timer.tcl
@@ -26,6 +26,8 @@ start_server {tags {"modules"}} {
         assert_equal "timer-incr-key" [lindex $info 0]
         set remaining [lindex $info 1]
         assert {$remaining < 10000 && $remaining > 1}
+        # Stop the timer after get timer test
+        assert_equal 1 [r test.stoptimer $id]
     }
 
     test {RM_StopTimer: basic sanity} {
@@ -54,7 +56,14 @@ start_server {tags {"modules"}} {
         assert_equal {} [r test.gettimer $id]
     }
 
-    test "Unload the module - timer" {
+    test "Module can be unloaded only when timer was finished" {
+        r set "timer-incr-key" 0
+        set id [r test.createtimer 1000 timer-incr-key]
+
+        # Wait to be sure timer has been finished
+        after 2000
+        assert_equal 1 [r get timer-incr-key]
+        # all timers are clean, can do the unloading now.
         assert_equal {OK} [r module unload timer]
     }
 }

--- a/tests/unit/moduleapi/timer.tcl
+++ b/tests/unit/moduleapi/timer.tcl
@@ -58,10 +58,15 @@ start_server {tags {"modules"}} {
 
     test "Module can be unloaded only when timer was finished" {
         r set "timer-incr-key" 0
-        set id [r test.createtimer 100 timer-incr-key]
+        set id [r test.createtimer 2000 timer-incr-key]
+
+        # Make sure the Timer has not been fired
+        assert_equal 0 [r get timer-incr-key]
+        # Module can not be unload since the timer was ongoing 
+        assert_match {ERR*} [r module unload timer]
 
         # Wait to be sure timer has been finished
-        wait_for_condition 10 100 {
+        wait_for_condition 10 1000 {
             [r get timer-incr-key] == 1
         } else {
             fail "Timer not fired"

--- a/tests/unit/moduleapi/timer.tcl
+++ b/tests/unit/moduleapi/timer.tcl
@@ -63,7 +63,8 @@ start_server {tags {"modules"}} {
         # Make sure the Timer has not been fired
         assert_equal 0 [r get timer-incr-key]
         # Module can not be unload since the timer was ongoing 
-        assert_match {ERR*} [r module unload timer]
+        catch [r module unload timer] err
+        assert_match {ERR*} $err
 
         # Wait to be sure timer has been finished
         wait_for_condition 10 1000 {


### PR DESCRIPTION
This is done to avoid a crash when the timer fires after the module was unloaded.
Or memory leaks in case we wanted to just ignore the timer.
It'll cause the MODULE UNLOAD command to return with an error
fix https://github.com/redis/redis/issues/10186