### PR TITLE
Solve race in a BGSAVE test

### DIFF
--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -147,8 +147,8 @@ start_server {} {
         r bgsave
         assert_equal [s rdb_bgsave_in_progress] 1
         r flushall
-        # wait half a second max
-        wait_for_condition 5 100 {
+        # wait a second max
+        wait_for_condition 10 100 {
             [s rdb_bgsave_in_progress] == 0
         } else {
             fail "bgsave not aborted"

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -139,21 +139,21 @@ start_server_and_kill_it [list "dir" $server_path] {
 
 start_server {} {
     test {Test FLUSHALL aborts bgsave} {
-        # 1000 keys with 1ms sleep per key should take 1 second
         r config set save ""
+        # 5000 keys with 1ms sleep per key should take 5 second
         r config set rdb-key-save-delay 1000
-        populate 1000
+        populate 5000
         assert_lessthan 999 [s rdb_changes_since_last_save]
         r bgsave
         assert_equal [s rdb_bgsave_in_progress] 1
         r flushall
-        # wait a second max
+        # wait a second max (bgsave should take 5)
         wait_for_condition 10 100 {
             [s rdb_bgsave_in_progress] == 0
         } else {
             fail "bgsave not aborted"
         }
-        # veirfy that bgsave failed, by checking that the change counter is still high
+        # verify that bgsave failed, by checking that the change counter is still high
         assert_lessthan 999 [s rdb_changes_since_last_save]
         # make sure the server is still writable
         r set x xx

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -140,8 +140,10 @@ start_server_and_kill_it [list "dir" $server_path] {
 start_server {} {
     test {Test FLUSHALL aborts bgsave} {
         # 1000 keys with 1ms sleep per key should take 1 second
+        r config set save ""
         r config set rdb-key-save-delay 1000
-        r debug populate 1000
+        populate 1000
+        assert_lessthan 999 [s rdb_changes_since_last_save]
         r bgsave
         assert_equal [s rdb_bgsave_in_progress] 1
         r flushall


### PR DESCRIPTION
This PR attempts to solve two problems that happen sometime in valgrind:
`ERR Background save already in progress`
and
`not bgsave not aborted`

the test used to populate the database with DEBUG, which didn't
increment the dirty counter, so couldn't trigger an automatic bgsave.
then it used a manual bgsave, and aborted it (when it got aborted it
populated the dirty counter), and then it tried to do another bgsave.
that other bgsave could have failed if the automatic one already
started.