### PR TITLE
solve race in expiration test

### DIFF
--- a/tests/integration/replication-4.tcl
+++ b/tests/integration/replication-4.tcl
@@ -108,7 +108,7 @@ start_server {tags {"repl external:skip"}} {
             # to the replica after the key is logically expired.
             exec kill -SIGCONT [srv 0 pid]
             wait_for_ofs_sync $master $slave
-            # Check that k is locigally expired but is present in the replica.
+            # Check that k is logically expired but is present in the replica.
             assert_equal 0 [$slave exists k]
             $slave debug object k ; # Raises exception if k is gone.
         }

--- a/tests/integration/replication-4.tcl
+++ b/tests/integration/replication-4.tcl
@@ -103,7 +103,7 @@ start_server {tags {"repl external:skip"}} {
             wait_for_ofs_sync $master $slave
             exec kill -SIGSTOP [srv 0 pid]
             $master incr k
-            after 1000
+            after 1001
             # Stopping the replica for one second to makes sure the INCR arrives
             # to the replica after the key is logically expired.
             exec kill -SIGCONT [srv 0 pid]


### PR DESCRIPTION
Failed on a non-valgrind run. on this line:
```
assert_equal 0 [$slave exists k]
```
the condition in `keyIsExpired` is `now > when`.
so if the test is really fast, maybe it can get to EXISTS exactly 1000 milliseconds after the
expiration was set, and the key isn't yet gone)