### PR TITLE
cluster slots command does not return pfail nodes

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4842,10 +4842,10 @@ int getSlotOrReply(client *c, robj *o) {
 /* Returns an indication if the replica node is fully available
  * and should be listed in CLUSTER SLOTS response.
  * Returns 1 for available nodes, 0 for nodes that have 
- * not finished their initial sync, in failed state, or are 
+ * not finished their initial sync, in failed pfail state, or are
  * otherwise considered not available to serve read commands. */
 static int isReplicaAvailable(clusterNode *node) {
-    if (nodeFailed(node)) {
+    if (nodeFailed(node) || nodeTimedOut(node)) {
         return 0;
     }
     long long repl_offset = node->repl_offset;


### PR DESCRIPTION
On Tencent Cloud, for a Redis cluster, when readonly is enabled on the slave nodes, we usually use cluster slots to get all the slots information, and then use the slots information to select which slave node to run the command on. However, when the status of the slave node is `fail`, we use `cluster slots` to select which slave node to run the command on. Therefore, Tencent Cloud introduced the `pfail` status judgment of the slave node to solve the problem of the slave node in the `fail?` state obtained by the cluster slots command.
