### PR TITLE
doc improvement about acl first-arg

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -860,10 +860,11 @@ replica-priority 100
 #               The special category @all means all the commands, but currently
 #               present in the server, and that will be loaded in the future
 #               via modules.
-#  +<command>|first-arg    Allow a specific first argument of an otherwise
-#                          disabled command. Note that this form is not
-#                          allowed as negative like -SELECT|1, but
-#                          only additive starting with "+".
+#  +<command>|first-arg  Allow a specific first argument of an otherwise
+#                        disabled command. It is only supported on commands with
+#                        no sub-commands, and is not allowed as negative form
+#                        like -SELECT|1, only additive starting with "+". This
+#                        feature is deprecated and may be removed in the future.
 #  allcommands  Alias for +@all. Note that it implies the ability to execute
 #               all the future commands loaded via the modules system.
 #  nocommands   Alias for -@all.


### PR DESCRIPTION
We recently removed capabilities from the first-arg feature of ACL and added a warning. but we didn't document it. 
ref: #10147 and https://github.com/redis/redis-doc/pull/1761