### PR TITLE
Added missing documentation about the ACL GETUSER changes in acl-v2

### DIFF
--- a/src/commands/acl-getuser.json
+++ b/src/commands/acl-getuser.json
@@ -11,6 +11,10 @@
             [
                 "6.2.0",
                 "Added Pub/Sub channel patterns."
+            ],
+            [
+                "7.0.0",
+                "Added selectors and changed the format of key and channel patterns from a list to their rule representation."
             ]
         ],
         "command_flags": [


### PR DESCRIPTION
In ACL v2 there are two changes to the GETUSER command, that weren't documented as part of history.
1) There is a new 6th field, selectors.
2) The format of the keys and channels responses was changed from a list representation to the DLS representation.