### PR TITLE
Skip external server and codeql cron tests on forks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    if: (github.event_name == 'schedule' && github.repository != 'redis/redis') == false
+    if: github.event_name != 'schedule' || github.repository == 'redis/redis'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository != 'redis/redis') == false
 
     strategy:
       fail-fast: false

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-external-standalone:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'schedule' && github.repository != 'redis/redis') == false
+    if: github.event_name != 'schedule' || github.repository == 'redis/redis'
     timeout-minutes: 14400
     steps:
     - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
 
   test-external-cluster:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'schedule' && github.repository != 'redis/redis') == false
+    if: github.event_name != 'schedule' || github.repository == 'redis/redis'
     timeout-minutes: 14400
     steps:
     - uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
 
   test-external-nodebug:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'schedule' && github.repository != 'redis/redis') == false
+    if: github.event_name != 'schedule' || github.repository == 'redis/redis'
     timeout-minutes: 14400
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test-external-standalone:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository != 'redis/redis') == false
     timeout-minutes: 14400
     steps:
     - uses: actions/checkout@v2
@@ -32,6 +33,7 @@ jobs:
 
   test-external-cluster:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository != 'redis/redis') == false
     timeout-minutes: 14400
     steps:
     - uses: actions/checkout@v2
@@ -58,6 +60,7 @@ jobs:
 
   test-external-nodebug:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository != 'redis/redis') == false
     timeout-minutes: 14400
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
keep the push triggers for all repos, but run the scheduled ones only on redis/redis