### PR TITLE
Resize notused1 in clusterMsg so that clusterMsg is backward compatible with previous Redis releases

### DIFF
--- a/src/ae_evport.c
+++ b/src/ae_evport.c
@@ -28,7 +28,6 @@
  */
 
 
-#include <assert.h>
 #include <errno.h>
 #include <port.h>
 #include <poll.h>

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -332,10 +332,15 @@ typedef struct {
 
 /* clusterMsg defines the gossip wire protocol exchanged among Redis cluster
  * members, which can be running different versions of redis-server bits,
- * espeically during cluster rolling upgrades. Therefore, fields in this
- * struct should remain at the same offset from release to release. The
- * static asserts below ensures that incomaptibe changes in clusterMsg be
- * caught at compile time. */
+ * especially during cluster rolling upgrades.
+ *
+ * Therefore, fields in this struct should remain at the same offset from
+ * release to release. The static asserts below ensures that incompatible
+ * changes in clusterMsg be caught at compile time.
+ */
+
+/* Avoid static_assert on non-C11 compilers. */
+#if __STDC_VERSION__ >= 201112L
 static_assert(offsetof(clusterMsg, sig) == 0, "unexpected field offset");
 static_assert(offsetof(clusterMsg, totlen) == 4, "unexpected field offset");
 static_assert(offsetof(clusterMsg, ver) == 8, "unexpected field offset");
@@ -357,6 +362,7 @@ static_assert(offsetof(clusterMsg, flags) == 2250, "unexpected field offset");
 static_assert(offsetof(clusterMsg, state) == 2252, "unexpected field offset");
 static_assert(offsetof(clusterMsg, mflags) == 2253, "unexpected field offset");
 static_assert(offsetof(clusterMsg, data) == 2256, "unexpected field offset");
+#endif
 
 #define CLUSTERMSG_MIN_LEN (sizeof(clusterMsg)-sizeof(union clusterMsgData))
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -321,7 +321,7 @@ typedef struct {
     char slaveof[CLUSTER_NAMELEN];
     char myip[NET_IP_STR_LEN];    /* Sender IP, if not all zeroed. */
     uint16_t extensions; /* Number of extensions sent along with this packet. */
-    char notused1[16];  /* 16 bytes reserved for future usage. */
+    char notused1[30];   /* 30 bytes reserved for future usage. */
     uint16_t pport;      /* Sender TCP plaintext port, if base port is TLS */
     uint16_t cport;      /* Sender TCP cluster bus port */
     uint16_t flags;      /* Sender node flags */
@@ -329,6 +329,34 @@ typedef struct {
     unsigned char mflags[3]; /* Message flags: CLUSTERMSG_FLAG[012]_... */
     union clusterMsgData data;
 } clusterMsg;
+
+/* clusterMsg defines the gossip wire protocol exchanged among Redis cluster
+ * members, which can be running different versions of redis-server bits,
+ * espeically during cluster rolling upgrades. Therefore, fields in this
+ * struct should remain at the same offset from release to release. The
+ * static asserts below ensures that incomaptibe changes in clusterMsg be
+ * caught at compile time. */
+static_assert(offsetof(clusterMsg, sig) == 0);
+static_assert(offsetof(clusterMsg, totlen) == 4);
+static_assert(offsetof(clusterMsg, ver) == 8);
+static_assert(offsetof(clusterMsg, port) == 10);
+static_assert(offsetof(clusterMsg, type) == 12);
+static_assert(offsetof(clusterMsg, count) == 14);
+static_assert(offsetof(clusterMsg, currentEpoch) == 16);
+static_assert(offsetof(clusterMsg, configEpoch) == 24);
+static_assert(offsetof(clusterMsg, offset) == 32);
+static_assert(offsetof(clusterMsg, sender) == 40);
+static_assert(offsetof(clusterMsg, myslots) == 80);
+static_assert(offsetof(clusterMsg, slaveof) == 2128);
+static_assert(offsetof(clusterMsg, myip) == 2168);
+static_assert(offsetof(clusterMsg, extensions) == 2214);
+static_assert(offsetof(clusterMsg, notused1) == 2216);
+static_assert(offsetof(clusterMsg, pport) == 2246);
+static_assert(offsetof(clusterMsg, cport) == 2248);
+static_assert(offsetof(clusterMsg, flags) == 2250);
+static_assert(offsetof(clusterMsg, state) == 2252);
+static_assert(offsetof(clusterMsg, mflags) == 2253);
+static_assert(offsetof(clusterMsg, data) == 2256);
 
 #define CLUSTERMSG_MIN_LEN (sizeof(clusterMsg)-sizeof(union clusterMsgData))
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -336,27 +336,27 @@ typedef struct {
  * struct should remain at the same offset from release to release. The
  * static asserts below ensures that incomaptibe changes in clusterMsg be
  * caught at compile time. */
-static_assert(offsetof(clusterMsg, sig) == 0);
-static_assert(offsetof(clusterMsg, totlen) == 4);
-static_assert(offsetof(clusterMsg, ver) == 8);
-static_assert(offsetof(clusterMsg, port) == 10);
-static_assert(offsetof(clusterMsg, type) == 12);
-static_assert(offsetof(clusterMsg, count) == 14);
-static_assert(offsetof(clusterMsg, currentEpoch) == 16);
-static_assert(offsetof(clusterMsg, configEpoch) == 24);
-static_assert(offsetof(clusterMsg, offset) == 32);
-static_assert(offsetof(clusterMsg, sender) == 40);
-static_assert(offsetof(clusterMsg, myslots) == 80);
-static_assert(offsetof(clusterMsg, slaveof) == 2128);
-static_assert(offsetof(clusterMsg, myip) == 2168);
-static_assert(offsetof(clusterMsg, extensions) == 2214);
-static_assert(offsetof(clusterMsg, notused1) == 2216);
-static_assert(offsetof(clusterMsg, pport) == 2246);
-static_assert(offsetof(clusterMsg, cport) == 2248);
-static_assert(offsetof(clusterMsg, flags) == 2250);
-static_assert(offsetof(clusterMsg, state) == 2252);
-static_assert(offsetof(clusterMsg, mflags) == 2253);
-static_assert(offsetof(clusterMsg, data) == 2256);
+static_assert(offsetof(clusterMsg, sig) == 0, "unexpected field offset");
+static_assert(offsetof(clusterMsg, totlen) == 4, "unexpected field offset");
+static_assert(offsetof(clusterMsg, ver) == 8, "unexpected field offset");
+static_assert(offsetof(clusterMsg, port) == 10, "unexpected field offset");
+static_assert(offsetof(clusterMsg, type) == 12, "unexpected field offset");
+static_assert(offsetof(clusterMsg, count) == 14, "unexpected field offset");
+static_assert(offsetof(clusterMsg, currentEpoch) == 16, "unexpected field offset");
+static_assert(offsetof(clusterMsg, configEpoch) == 24, "unexpected field offset");
+static_assert(offsetof(clusterMsg, offset) == 32, "unexpected field offset");
+static_assert(offsetof(clusterMsg, sender) == 40, "unexpected field offset");
+static_assert(offsetof(clusterMsg, myslots) == 80, "unexpected field offset");
+static_assert(offsetof(clusterMsg, slaveof) == 2128, "unexpected field offset");
+static_assert(offsetof(clusterMsg, myip) == 2168, "unexpected field offset");
+static_assert(offsetof(clusterMsg, extensions) == 2214, "unexpected field offset");
+static_assert(offsetof(clusterMsg, notused1) == 2216, "unexpected field offset");
+static_assert(offsetof(clusterMsg, pport) == 2246, "unexpected field offset");
+static_assert(offsetof(clusterMsg, cport) == 2248, "unexpected field offset");
+static_assert(offsetof(clusterMsg, flags) == 2250, "unexpected field offset");
+static_assert(offsetof(clusterMsg, state) == 2252, "unexpected field offset");
+static_assert(offsetof(clusterMsg, mflags) == 2253, "unexpected field offset");
+static_assert(offsetof(clusterMsg, data) == 2256, "unexpected field offset");
 
 #define CLUSTERMSG_MIN_LEN (sizeof(clusterMsg)-sizeof(union clusterMsgData))
 

--- a/src/server.h
+++ b/src/server.h
@@ -36,6 +36,7 @@
 #include "rio.h"
 #include "atomicvar.h"
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Fixes #10205