### PR TITLE
fix cluster rebalance test race

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -4069,13 +4069,17 @@ static int clusterManagerMoveSlot(clusterManagerNode *source,
                                                     slot, "node",
                                                     target->name);
             success = (r != NULL);
-            if (!success) return 0;
+            if (!success) {
+                if (err) *err = zstrdup("CLUSTER SETSLOT failed to run");
+                return 0;
+            }
             if (r->type == REDIS_REPLY_ERROR) {
                 success = 0;
                 if (err != NULL) {
                     *err = zmalloc((r->len + 1) * sizeof(char));
                     strcpy(*err, r->str);
-                    CLUSTER_MANAGER_PRINT_REPLY_ERROR(n, *err);
+                } else {
+                    CLUSTER_MANAGER_PRINT_REPLY_ERROR(n, r->str);
                 }
             }
             freeReplyObject(r);
@@ -6402,7 +6406,7 @@ static int clusterManagerCommandReshard(int argc, char **argv) {
                                         opts, &err);
         if (!result) {
             if (err != NULL) {
-                //clusterManagerLogErr("\n%s\n", err);
+                clusterManagerLogErr("clusterManagerMoveSlot failed: %s\n", err);
                 zfree(err);
             }
             goto cleanup;
@@ -6431,6 +6435,7 @@ static int clusterManagerCommandRebalance(int argc, char **argv) {
             char *name = config.cluster_manager_command.weight[i];
             char *p = strchr(name, '=');
             if (p == NULL) {
+                clusterManagerLogErr("*** invalid input %s\n", name);
                 result = 0;
                 goto cleanup;
             }
@@ -6576,11 +6581,16 @@ static int clusterManagerCommandRebalance(int argc, char **argv) {
                 listRewind(table, &li);
                 while ((ln = listNext(&li)) != NULL) {
                     clusterManagerReshardTableItem *item = ln->value;
+                    char *err;
                     result = clusterManagerMoveSlot(item->source,
                                                     dst,
                                                     item->slot,
-                                                    opts, NULL);
-                    if (!result) goto end_move;
+                                                    opts, &err);
+                    if (!result) {
+                        clusterManagerLogErr("*** clusterManagerMoveSlot: %s\n", err);
+                        zfree(err);
+                        goto end_move;
+                    }
                     printf("#");
                     fflush(stdout);
                 }

--- a/tests/cluster/tests/12-replica-migration-2.tcl
+++ b/tests/cluster/tests/12-replica-migration-2.tcl
@@ -6,6 +6,7 @@
 
 source "../tests/includes/init-tests.tcl"
 source "../../../tests/support/cli.tcl"
+source "../tests/includes/utils.tcl"
 
 # Create a cluster with 5 master and 15 slaves, to make sure there are no
 # empty masters and make rebalancing simpler to handle during the test.
@@ -27,6 +28,10 @@ test "Each master should have at least two replicas attached" {
             }
         }
     }
+}
+
+test "Wait cluster to be stable" {
+    wait_cluster_stable
 }
 
 test "Set allow-replica-migration yes" {
@@ -53,16 +58,23 @@ test "Master #0 should lose its replicas" {
     }
 }
 
+# Wait for the cluster config to propagate before attempting a
+# new resharding.
+test "Wait cluster to be stable" {
+    wait_cluster_stable
+}
+
 test "Resharding back some slot to master #0" {
-    # Wait for the cluster config to propagate before attempting a
-    # new resharding.
-    after 10000
     set output [exec \
         ../../../src/redis-cli --cluster rebalance \
         127.0.0.1:[get_instance_attrib redis 0 port] \
         {*}[rediscli_tls_config "../../../tests"] \
         --cluster-weight ${master0_id}=.01 \
         --cluster-use-empty-masters  >@ stdout]
+}
+
+test "Wait cluster to be stable" {
+    wait_cluster_stable
 }
 
 test "Master #0 should re-acquire one or more replicas" {

--- a/tests/cluster/tests/12.1-replica-migration-3.tcl
+++ b/tests/cluster/tests/12.1-replica-migration-3.tcl
@@ -4,6 +4,7 @@
 # migrate when master becomes empty.
 
 source "../tests/includes/init-tests.tcl"
+source "../tests/includes/utils.tcl"
 
 # Create a cluster with 5 master and 15 slaves, to make sure there are no
 # empty masters and make rebalancing simpler to handle during the test.
@@ -33,6 +34,10 @@ test "Set allow-replica-migration no" {
     }
 }
 
+test "Wait cluster to be stable" {
+    wait_cluster_stable
+}
+
 set master0_id [dict get [get_myself 0] id]
 test "Resharding all the master #0 slots away from it" {
     set output [exec \
@@ -43,14 +48,7 @@ test "Resharding all the master #0 slots away from it" {
 }
 
 test "Wait cluster to be stable" {
-    wait_for_condition 1000 50 {
-        [catch {exec ../../../src/redis-cli --cluster \
-            check 127.0.0.1:[get_instance_attrib redis 0 port] \
-            {*}[rediscli_tls_config "../../../tests"] \
-            }] == 0
-    } else {
-        fail "Cluster doesn't stabilize"
-    }
+    wait_cluster_stable
 }
 
 test "Master #0 still should have its replicas" {

--- a/tests/cluster/tests/includes/utils.tcl
+++ b/tests/cluster/tests/includes/utils.tcl
@@ -23,3 +23,14 @@ proc fix_cluster {addr} {
         fail "Cluster could not settle with configuration"
     }
 }
+
+proc wait_cluster_stable {} {
+    wait_for_condition 1000 50 {
+        [catch {exec ../../../src/redis-cli --cluster \
+            check 127.0.0.1:[get_instance_attrib redis 0 port] \
+            {*}[rediscli_tls_config "../../../tests"] \
+            }] == 0
+    } else {
+        fail "Cluster doesn't stabilize"
+    }
+}

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -446,7 +446,12 @@ proc run_tests {} {
         }
         if {[file isdirectory $test]} continue
         puts [colorstr yellow "Testing unit: [lindex [file split $test] end]"]
-        source $test
+        if {[catch { source $test } err]} {
+            puts "FAILED: caught an error in the test $err"
+            puts $::errorInfo
+            incr ::failed
+            # letting the tests resume, so we'll eventually reach the cleanup and report crashes
+        }
         check_leaks {redis sentinel}
 
         # Check if a leaked fds file was created and abort the test.


### PR DESCRIPTION
Try to fix the rebalance cluster test that's failing with ASAN daily:
https://github.com/redis/redis/runs/4987852171?check_suite_focus=true

Looks like `redis-cli --cluster rebalance` gets `ERR Please use SETSLOT only with masters` in `clusterManagerMoveSlot()`.
it happens when `12-replica-migration-2.tcl` is run with ASAN in GH Actions.
in `Resharding all the master #0 slots away from it`

So the fix (assuming i got it right) is to call `redis-cli --cluster check` before `--cluster rebalance`.
p.s. it looks like a few other checks in these tests needed that wait, added them too.

Other changes:
* in instances.tcl, make sure to catch tcl test crashes and let the rest of the code proceed, so that if there was a redis crash, we'll find it and print it too.
* redis-cli, try to make sure it prints an error instead of silently exiting.

specifically about redis-cli:
1. clusterManagerMoveSlot used to print an error, only if the caller also asked for it (should be the other way around).
2. clusterManagerCommandReshard asked for an error, but didn't use it (probably tried to avoid the double print).
3. clusterManagerCommandRebalance didn't ask for the error, now it does.
4. making sure that other places in clusterManagerCommandRebalance print something before exiting with an error.
  