### PR TITLE
Revert the attempt to fix cluster rebalance test (#10207)

### DIFF
--- a/tests/cluster/tests/12-replica-migration-2.tcl
+++ b/tests/cluster/tests/12-replica-migration-2.tcl
@@ -6,7 +6,6 @@
 
 source "../tests/includes/init-tests.tcl"
 source "../../../tests/support/cli.tcl"
-source "../tests/includes/utils.tcl"
 
 # Create a cluster with 5 master and 15 slaves, to make sure there are no
 # empty masters and make rebalancing simpler to handle during the test.
@@ -28,10 +27,6 @@ test "Each master should have at least two replicas attached" {
             }
         }
     }
-}
-
-test "Wait cluster to be stable" {
-    wait_cluster_stable
 }
 
 test "Set allow-replica-migration yes" {
@@ -58,23 +53,16 @@ test "Master #0 should lose its replicas" {
     }
 }
 
-# Wait for the cluster config to propagate before attempting a
-# new resharding.
-test "Wait cluster to be stable" {
-    wait_cluster_stable
-}
-
 test "Resharding back some slot to master #0" {
+    # Wait for the cluster config to propagate before attempting a
+    # new resharding.
+    after 10000
     set output [exec \
         ../../../src/redis-cli --cluster rebalance \
         127.0.0.1:[get_instance_attrib redis 0 port] \
         {*}[rediscli_tls_config "../../../tests"] \
         --cluster-weight ${master0_id}=.01 \
         --cluster-use-empty-masters  >@ stdout]
-}
-
-test "Wait cluster to be stable" {
-    wait_cluster_stable
 }
 
 test "Master #0 should re-acquire one or more replicas" {

--- a/tests/cluster/tests/12.1-replica-migration-3.tcl
+++ b/tests/cluster/tests/12.1-replica-migration-3.tcl
@@ -34,10 +34,6 @@ test "Set allow-replica-migration no" {
     }
 }
 
-test "Wait cluster to be stable" {
-    wait_cluster_stable
-}
-
 set master0_id [dict get [get_myself 0] id]
 test "Resharding all the master #0 slots away from it" {
     set output [exec \

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -257,7 +257,7 @@ proc parse_options {} {
         set val [lindex $::argv [expr $j+1]]
         if {$opt eq "--single"} {
             incr j
-            set ::run_matching "*${val}*"
+            lappend ::run_matching "*${val}*"
         } elseif {$opt eq "--pause-on-error"} {
             set ::pause_on_error 1
         } elseif {$opt eq {--dont-clean}} {
@@ -441,7 +441,7 @@ proc run_tests {} {
             file delete $::leaked_fds_file
         }
 
-        if {$::run_matching ne {} && [string match $::run_matching $test] == 0} {
+        if {[llength $::run_matching] != 0 && [search_pattern_list $test $::run_matching true] == -1} {
             continue
         }
         if {[file isdirectory $test]} continue

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -126,10 +126,11 @@ proc wait_for_condition {maxtries delay e _else_ elsescript} {
     }
 }
 
-proc search_pattern_list {value pattern_list} {
+# try to match a value to a list of patterns that is either regex, or plain sub-string
+proc search_pattern_list {value pattern_list {substr false}} {
     set n 0
     foreach el $pattern_list {
-        if {[string length $el] > 0 && [regexp -- $el $value]} {
+        if {[string length $el] > 0 && ((!$substr && [regexp -- $el $value]) || ($substr && [string match $el $value]))} {
             return $n
         }
         incr n


### PR DESCRIPTION
It seems that fix didn't really solve the problem with ASAN,
and also introduced issues with other CI runs.

unrelated:
- make runtest-cluster able to take multiple --single arguments