### PR TITLE
Change replica migration tests to use continous slots to improve speed

### DIFF
--- a/tests/cluster/tests/12-replica-migration-2.tcl
+++ b/tests/cluster/tests/12-replica-migration-2.tcl
@@ -10,7 +10,7 @@ source "../../../tests/support/cli.tcl"
 # Create a cluster with 5 master and 15 slaves, to make sure there are no
 # empty masters and make rebalancing simpler to handle during the test.
 test "Create a 5 nodes cluster" {
-    create_cluster 5 15
+    cluster_create_with_continuous_slots 5 15
 }
 
 test "Cluster is up" {

--- a/tests/cluster/tests/12.1-replica-migration-3.tcl
+++ b/tests/cluster/tests/12.1-replica-migration-3.tcl
@@ -9,7 +9,7 @@ source "../tests/includes/utils.tcl"
 # Create a cluster with 5 master and 15 slaves, to make sure there are no
 # empty masters and make rebalancing simpler to handle during the test.
 test "Create a 5 nodes cluster" {
-    create_cluster 5 15
+    cluster_create_with_continuous_slots 5 15
 }
 
 test "Cluster is up" {


### PR DESCRIPTION
Perhaps a fix to the issue where redis-cli rebalance was failing, https://github.com/redis/redis/runs/4999431011?check_suite_focus=true#step:9:453. My hypothesis is that a failover is happening during the migration, and the only mechanism I could find that might cause that is that we are consuming a lot of CPU processing `CLUSTER SLOTS`. After each rebalance, `CLUSTER SLOTS` is sent which is very inefficient since slots are interleaved. The output was several megabytes, which is a lot to process. Moving to continuous slots reduces the output side to under a kb. This also has a side effect of making the test way faster!

Not sure if this is definitive, but it did pass here: https://github.com/redis/redis/runs/5001700638?check_suite_focus=true. (Ran it again, still passes, so perhaps good enough: https://github.com/redis/redis/runs/5001822532?check_suite_focus=true)