### PR TITLE
Added history for cluster-slots changes for hostnames

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -624,6 +624,7 @@ struct redisCommandArg CLUSTER_SLAVES_Args[] = {
 /* CLUSTER SLOTS history */
 commandHistory CLUSTER_SLOTS_History[] = {
 {"4.0.0","Added node IDs."},
+{"7.0.0","Added additional networking metadata and added support for hostnames and unknown endpoints."},
 {0}
 };
 

--- a/src/commands/cluster-slots.json
+++ b/src/commands/cluster-slots.json
@@ -11,6 +11,10 @@
             [
                 "4.0.0",
                 "Added node IDs."
+            ],
+            [
+                "7.0.0",
+                "Added additional networking metadata and added support for hostnames and unknown endpoints."
             ]
         ],
         "command_flags": [


### PR DESCRIPTION
Cluster hostnames changed 2 parts of the cluster-slots output array for nodes:
* The first field was previously only an IP address, it can now be a hostname or NULL.
* There is now a fourth field, which has more information.

Reference PR: https://github.com/redis/redis/pull/9530.

The change for hostnames got merged at an awkward time (it was merged about the same time as the command json files) and it looks like the history update got dropped. So re-adding it now.