### PR TITLE
acl check api for functions and eval

### DIFF
--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -798,6 +798,7 @@ cleanup:
     /* Clean up. Command code may have changed argv/argc so we use the
      * argv/argc of the client instead of the local variables. */
     freeClientArgv(c);
+    c->user = NULL;
     inuse--;
 
     if (raise_error) {
@@ -905,7 +906,6 @@ static int luaRedisAclCheckCmdPermissionsCommand(lua_State *lua) {
         lua_pushstring(lua, "redis.acl_check_cmd can only be called inside a script invocation");
         return lua_error(lua);
     }
-    client* c = rctx->original_client;
     int raise_error = 0;
 
     int argc;
@@ -921,7 +921,7 @@ static int luaRedisAclCheckCmdPermissionsCommand(lua_State *lua) {
         raise_error = 1;
     } else {
         int keyidxptr;
-        if (ACLCheckAllUserCommandPerm(c->user, cmd, argv, argc, &keyidxptr) != ACL_OK) {
+        if (ACLCheckAllUserCommandPerm(rctx->original_client->user, cmd, argv, argc, &keyidxptr) != ACL_OK) {
             lua_pushboolean(lua, 0);
         } else {
             lua_pushboolean(lua, 1);

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -896,13 +896,13 @@ static int luaRedisSetReplCommand(lua_State *lua) {
     return 0;
 }
 
-/* redis.acl_check_cmd_permissions()
+/* redis.acl_check_cmd()
  *
  * Checks ACL permissions for given command for the current user. */
 static int luaRedisAclCheckCmdPermissionsCommand(lua_State *lua) {
     scriptRunCtx* rctx = luaGetFromRegistry(lua, REGISTRY_RUN_CTX_NAME);
     if (!rctx) {
-        lua_pushstring(lua, "redis.acl_check_cmd_permissions can only be called inside a script invocation");
+        lua_pushstring(lua, "redis.acl_check_cmd can only be called inside a script invocation");
         return lua_error(lua);
     }
     client* c = rctx->original_client;
@@ -917,7 +917,7 @@ static int luaRedisAclCheckCmdPermissionsCommand(lua_State *lua) {
     /* Find command */
     struct redisCommand *cmd;
     if ((cmd = lookupCommand(argv, argc)) == NULL) {
-        lua_pushstring(lua, "Invalid command passed to redis.acl_check_cmd_permissions()");
+        lua_pushstring(lua, "Invalid command passed to redis.acl_check_cmd()");
         raise_error = 1;
     } else {
         int keyidxptr;
@@ -1251,8 +1251,8 @@ void luaRegisterRedisAPI(lua_State* lua) {
     lua_pushnumber(lua,PROPAGATE_AOF|PROPAGATE_REPL);
     lua_settable(lua,-3);
 
-    /* redis.acl_check_cmd_permissions */
-    lua_pushstring(lua,"acl_check_cmd_permissions");
+    /* redis.acl_check_cmd */
+    lua_pushstring(lua,"acl_check_cmd");
     lua_pushcfunction(lua,luaRedisAclCheckCmdPermissionsCommand);
     lua_settable(lua,-3);
 

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -727,7 +727,7 @@ static int luaRedisGenericCommand(lua_State *lua, int raise_error) {
 
     static int inuse = 0;   /* Recursive calls detection. */
 
-    /* By using Lua debug hooks it is possible to trigger a re4f686555cecursive call
+    /* By using Lua debug hooks it is possible to trigger a recursive call
      * to luaRedisGenericCommand(), which normally should never happen.
      * To make this function reentrant is futile and makes it slower, but
      * we should at least detect such a misuse, and abort. */

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -655,55 +655,19 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
  * Lua redis.* functions implementations.
  * ------------------------------------------------------------------------- */
 
-#define LUA_CMD_OBJCACHE_SIZE 32
-#define LUA_CMD_OBJCACHE_MAX_LEN 64
-static int luaRedisGenericCommand(lua_State *lua, int raise_error) {
-    int j, argc = lua_gettop(lua);
-    scriptRunCtx* rctx = luaGetFromRegistry(lua, REGISTRY_RUN_CTX_NAME);
-    if (!rctx) {
-        luaPushError(lua, "redis.call/pcall can only be called inside a script invocation");
-        return luaRaiseError(lua);
-    }
-    sds err = NULL;
-    client* c = rctx->c;
-    sds reply;
-
-    /* Cached across calls. */
-    static robj **argv = NULL;
-    static int argv_size = 0;
-    static robj *cached_objects[LUA_CMD_OBJCACHE_SIZE];
-    static size_t cached_objects_len[LUA_CMD_OBJCACHE_SIZE];
-    static int inuse = 0;   /* Recursive calls detection. */
-
-    /* By using Lua debug hooks it is possible to trigger a recursive call
-     * to luaRedisGenericCommand(), which normally should never happen.
-     * To make this function reentrant is futile and makes it slower, but
-     * we should at least detect such a misuse, and abort. */
-    if (inuse) {
-        char *recursion_warning =
-            "luaRedisGenericCommand() recursive call detected. "
-            "Are you doing funny stuff with Lua debug hooks?";
-        serverLog(LL_WARNING,"%s",recursion_warning);
-        luaPushError(lua,recursion_warning);
-        return 1;
-    }
-    inuse++;
-
+static robj **luaArgsToRedisArgv(lua_State *lua, int *argc) {
+    int j;
     /* Require at least one argument */
-    if (argc == 0) {
-        luaPushError(lua,
-            "Please specify at least one argument for redis.call()");
-        inuse--;
-        return raise_error ? luaRaiseError(lua) : 1;
+    *argc = lua_gettop(lua);
+    if (*argc == 0) {
+        luaPushError(lua, "Please specify at least one argument for this redis lib call");
+        return NULL;
     }
 
     /* Build the arguments vector */
-    if (argv_size < argc) {
-        argv = zrealloc(argv,sizeof(robj*)*argc);
-        argv_size = argc;
-    }
+    robj **argv = zcalloc(sizeof(robj*) * *argc);
 
-    for (j = 0; j < argc; j++) {
+    for (j = 0; j < *argc; j++) {
         char *obj_s;
         size_t obj_len;
         char dbuf[64];
@@ -720,38 +684,62 @@ static int luaRedisGenericCommand(lua_State *lua, int raise_error) {
             if (obj_s == NULL) break; /* Not a string. */
         }
 
-        /* Try to use a cached object. */
-        if (j < LUA_CMD_OBJCACHE_SIZE && cached_objects[j] &&
-            cached_objects_len[j] >= obj_len)
-        {
-            sds s = cached_objects[j]->ptr;
-            argv[j] = cached_objects[j];
-            cached_objects[j] = NULL;
-            memcpy(s,obj_s,obj_len+1);
-            sdssetlen(s, obj_len);
-        } else {
-            argv[j] = createStringObject(obj_s, obj_len);
-        }
+        argv[j] = createStringObject(obj_s, obj_len);
     }
+
+    /* Pop all arguments from the stack, we do not need them anymore
+     * and this way we guaranty we will have room on the stack for the result. */
+    lua_pop(lua, *argc);
 
     /* Check if one of the arguments passed by the Lua script
      * is not a string or an integer (lua_isstring() return true for
      * integers as well). */
-    if (j != argc) {
+    if (j != *argc) {
         j--;
         while (j >= 0) {
             decrRefCount(argv[j]);
             j--;
         }
-        luaPushError(lua,
-            "Lua redis() command arguments must be strings or integers");
-        inuse--;
+        zfree(argv);
+        luaPushError(lua, "Lua redis lib command arguments must be strings or integers");
+        return NULL;
+    }
+
+    return argv;
+}
+
+static int luaRedisGenericCommand(lua_State *lua, int raise_error) {
+    int j;
+    scriptRunCtx* rctx = luaGetFromRegistry(lua, REGISTRY_RUN_CTX_NAME);
+    if (!rctx) {
+        luaPushError(lua, "redis.call/pcall can only be called inside a script invocation");
+        return luaRaiseError(lua);
+    }
+    sds err = NULL;
+    client* c = rctx->c;
+    sds reply;
+
+    int argc;
+    robj **argv = luaArgsToRedisArgv(lua, &argc);
+    if (argv == NULL) {
         return raise_error ? luaRaiseError(lua) : 1;
     }
 
-    /* Pop all arguments from the stack, we do not need them anymore
-     * and this way we guaranty we will have room on the stack for the result. */
-    lua_pop(lua, argc);
+    static int inuse = 0;   /* Recursive calls detection. */
+
+    /* By using Lua debug hooks it is possible to trigger a re4f686555cecursive call
+     * to luaRedisGenericCommand(), which normally should never happen.
+     * To make this function reentrant is futile and makes it slower, but
+     * we should at least detect such a misuse, and abort. */
+    if (inuse) {
+        char *recursion_warning =
+                "luaRedisGenericCommand() recursive call detected. "
+                "Are you doing funny stuff with Lua debug hooks?";
+        serverLog(LL_WARNING,"%s",recursion_warning);
+        luaPushError(lua,recursion_warning);
+        return 1;
+    }
+    inuse++;
 
     /* Log the command if debugging is active. */
     if (ldbIsEnabled()) {
@@ -768,7 +756,6 @@ static int luaRedisGenericCommand(lua_State *lua, int raise_error) {
         }
         ldbLog(cmdlog);
     }
-
 
     scriptCall(rctx, argv, argc, &err);
     if (err) {
@@ -810,45 +797,15 @@ static int luaRedisGenericCommand(lua_State *lua, int raise_error) {
 cleanup:
     /* Clean up. Command code may have changed argv/argc so we use the
      * argv/argc of the client instead of the local variables. */
-    for (j = 0; j < c->argc; j++) {
-        robj *o = c->argv[j];
-
-        /* Try to cache the object in the cached_objects array.
-         * The object must be small, SDS-encoded, and with refcount = 1
-         * (we must be the only owner) for us to cache it. */
-        if (j < LUA_CMD_OBJCACHE_SIZE &&
-            o->refcount == 1 &&
-            (o->encoding == OBJ_ENCODING_RAW ||
-             o->encoding == OBJ_ENCODING_EMBSTR) &&
-            sdslen(o->ptr) <= LUA_CMD_OBJCACHE_MAX_LEN)
-        {
-            sds s = o->ptr;
-            if (cached_objects[j]) decrRefCount(cached_objects[j]);
-            cached_objects[j] = o;
-            cached_objects_len[j] = sdsalloc(s);
-        } else {
-            decrRefCount(o);
-        }
-    }
-
-    if (c->argv != argv) {
-        zfree(c->argv);
-        argv = NULL;
-        argv_size = 0;
-    }
-
-    c->user = NULL;
-    c->argv = NULL;
-    c->argc = 0;
+    freeClientArgv(c);
+    inuse--;
 
     if (raise_error) {
         /* If we are here we should have an error in the stack, in the
          * form of a table with an "err" field. Extract the string to
          * return the plain error. */
-        inuse--;
         return luaRaiseError(lua);
     }
-    inuse--;
     return 1;
 }
 
@@ -943,7 +900,6 @@ static int luaRedisSetReplCommand(lua_State *lua) {
  *
  * Checks ACL permissions for given command for the current user. */
 static int luaRedisAclCheckCmdPermissionsCommand(lua_State *lua) {
-    int j, argc = lua_gettop(lua);
     scriptRunCtx* rctx = luaGetFromRegistry(lua, REGISTRY_RUN_CTX_NAME);
     if (!rctx) {
         lua_pushstring(lua, "redis.acl_check_cmd_permissions can only be called inside a script invocation");
@@ -952,43 +908,11 @@ static int luaRedisAclCheckCmdPermissionsCommand(lua_State *lua) {
     client* c = rctx->original_client;
     int raise_error = 0;
 
-    robj **argv = NULL;
+    int argc;
+    robj **argv = luaArgsToRedisArgv(lua, &argc);
 
     /* Require at least one argument */
-    if (argc == 0) {
-        lua_pushstring(lua, "Please specify at least one argument for redis.acl_check_cmd_permissions()");
-        return lua_error(lua);
-    }
-
-    argv = zcalloc(sizeof(robj*)*argc);
-
-    for (j = 0; j < argc; j++) {
-        char *obj_s;
-        size_t obj_len;
-        char dbuf[64];
-
-        if (lua_type(lua,j+1) == LUA_TNUMBER) {
-            /* We can't use lua_tolstring() for number -> string conversion
-             * since Lua uses a format specifier that loses precision. */
-            lua_Number num = lua_tonumber(lua,j+1);
-
-            obj_len = snprintf(dbuf,sizeof(dbuf),"%.17g",(double)num);
-            obj_s = dbuf;
-        } else {
-            obj_s = (char*)lua_tolstring(lua,j+1,&obj_len);
-            if (obj_s == NULL) break; /* Not a string. */
-        }
-
-        argv[j] = createStringObject(obj_s, obj_len);
-    }
-
-    /* Check if one of the arguments passed by the Lua script
-     * is not a string or an integer (lua_isstring() return true for
-     * integers as well). */
-    if (j != argc) {
-        lua_pushstring(lua, "Lua redis() command arguments must be strings or integers");
-        goto cleanup;
-    }
+    if (argv == NULL) return lua_error(lua);
 
     /* Find command */
     struct redisCommand *cmd;
@@ -1004,11 +928,7 @@ static int luaRedisAclCheckCmdPermissionsCommand(lua_State *lua) {
         }
     }
 
-cleanup:
-    for (j = 0; j < argc; j++) {
-        if (argv[j])
-            decrRefCount(argv[j]);
-    }
+    while (argc--) decrRefCount(argv[argc]);
     zfree(argv);
     if (raise_error)
         return lua_error(lua);

--- a/src/server.h
+++ b/src/server.h
@@ -2377,6 +2377,7 @@ int beforeNextClient(client *c);
 void clearClientConnectionState(client *c);
 void resetClient(client *c);
 void freeClientOriginalArgv(client *c);
+void freeClientArgv(client *c);
 void sendReplyToClient(connection *conn);
 void *addReplyDeferredLen(client *c);
 void setDeferredArrayLen(client *c, void *node, long length);

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -709,14 +709,15 @@ start_server {tags {"scripting"}} {
         # Check permission granted
         assert_equal [run_script {
             return redis.acl_check_cmd('set','xx',1)
-        } 0] 1
+        } 1 xx] 1
 
         # Check permission denied unauthorised command
         assert_equal [run_script {
-            return redis.acl_check_cmd('hset','h','f',1)
-        } 0] {}
+            return redis.acl_check_cmd('hset','xx','f',1)
+        } 1 xx] {}
         
         # Check permission denied unauthorised key
+        # Note: we don't pass the "yy" key as an argument to the script so key acl checks won't block the script
         assert_equal [run_script {
             return redis.acl_check_cmd('set','yy',1)
         } 0] {}

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -708,22 +708,22 @@ start_server {tags {"scripting"}} {
         
         # Check permission granted
         assert_equal [run_script {
-            return redis.acl_check_cmd_permissions('set','xx',1)
+            return redis.acl_check_cmd('set','xx',1)
         } 0] 1
 
         # Check permission denied unauthorised command
         assert_equal [run_script {
-            return redis.acl_check_cmd_permissions('hset','h','f',1)
+            return redis.acl_check_cmd('hset','h','f',1)
         } 0] {}
         
         # Check permission denied unauthorised key
         assert_equal [run_script {
-            return redis.acl_check_cmd_permissions('set','yy',1)
+            return redis.acl_check_cmd('set','yy',1)
         } 0] {}
 
         # Check error due to invalid command
-        assert_error {ERR *Invalid command passed to redis.acl_check_cmd_permissions()} {run_script {
-            return redis.acl_check_cmd_permissions('invalid-cmd','arg')
+        assert_error {ERR *Invalid command passed to redis.acl_check_cmd()} {run_script {
+            return redis.acl_check_cmd('invalid-cmd','arg')
         } 0}
     }
 }


### PR DESCRIPTION
See issue #10091.
This PR:
1. Adds the `redis.acl_check_cmd()` api to lua scripts. It can be used to check if the current user has permissions to execute a given command. The new function receives the command to check as an argument exactly like `redis.call()` receives the command to execute as an argument.
2. In the PR I unified the code used to convert lua arguments to redis argv arguments from both the new `redis.acl_check_cmd()` API and the `redis.[p]call()` API. This cleans up potential duplicate code.
3. While doing the refactoring in 2 I noticed there's an optimization to reduce allocation calls when parsing lua arguments into an `argv` array in the `redis.[p]call()` implementation. These optimizations were introduced years ago in 48c49c485155ba9e4a7851fd1644c171674c6f0f and 4f686555ce962e6632235d824512ea8fdeda003c. It is unclear why this was added. The original commit message claims a 4% performance increase which I couldn't recreate and might not be worth it even if it did recreate. This PR removes that optimization. Following are details of the benchmark I did that couldn't reveal any performance improvements due to this optimization:

```
benchmark 1: src/redis-benchmark -P 500 -n 10000000 eval 'return redis.call("ping")' 0
benchmark 2: src/redis-benchmark -P 500 -r 1000 -n 1000000 eval 'return redis.call("mset","k1__rand_int__","v1__rand_int__","k2__rand_int__","v2__rand_int__","k3__rand_int__","v3__rand_int__","k4__rand_int__","v4__rand_int__")' 0
benchmark 3: src/redis-benchmark -P 500 -r 1000 -n 100000 eval "for i=1,100,1 do redis.call('set','kk'..i,'vv'..__rand_int__) end return redis.call('get','kk5')" 0
benchmark 4: src/redis-benchmark -P 500 -r 1000 -n 1000000 eval 'return redis.call("mset","k1__rand_int__","v1__rand_int__","k2__rand_int__","v2__rand_int__","k3__rand_int__","v3__rand_int__","k4__rand_int__","v4__rand_int__xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")'
```
I ran the benchmark on this branch with and without commit 68b71680a4d3bb8f0509e06578a9f15d05b92a47
Results in requests per second:
cmd | without optimization | without optimization 2nd run | with original optimization | with original optimization 2nd run
-- | -- | -- | -- | --
1 | 461233.34 | 477395.31 | 471098.16 | 469946.91
2 | 34774.14 | 35469.8 | 35149.38 | 34464.93
3 | 6390.59 | 6281.41 | 6146.28 | 6464.12
4 | 28005.71 |   | 27965.77 |  

As you can see, different use cases showed identical or negligible performance differences. So finally I decided to chuck the original optimization and simplify the code.