### PR TITLE
Fix src/modules build issue on OS X 11

### DIFF
--- a/src/modules/Makefile
+++ b/src/modules/Makefile
@@ -11,6 +11,13 @@ else
 	SHOBJ_LDFLAGS ?= -bundle -undefined dynamic_lookup
 endif
 
+# OS X 11.x doesn't have /usr/lib/libSystem.dylib and needs an explicit setting.
+ifeq ($(uname_S),Darwin)
+ifeq ("$(wildcard /usr/lib/libSystem.dylib)","")
+LIBS = -L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lsystem
+endif
+endif
+
 .SUFFIXES: .c .so .xo .o
 
 all: helloworld.so hellotype.so helloblock.so hellocluster.so hellotimer.so hellodict.so hellohook.so helloacl.so

--- a/src/modules/hellocluster.c
+++ b/src/modules/hellocluster.c
@@ -76,7 +76,7 @@ int ListCommand_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 void PingReceiver(RedisModuleCtx *ctx, const char *sender_id, uint8_t type, const unsigned char *payload, uint32_t len) {
     RedisModule_Log(ctx,"notice","PING (type %d) RECEIVED from %.*s: '%.*s'",
         type,REDISMODULE_NODE_ID_LEN,sender_id,(int)len, payload);
-    RedisModule_SendClusterMessage(ctx,NULL,MSGTYPE_PONG,(unsigned char*)"Ohi!",4);
+    RedisModule_SendClusterMessage(ctx,NULL,MSGTYPE_PONG,"Ohi!",4);
     RedisModuleCallReply *reply = RedisModule_Call(ctx, "INCR", "c", "pings_received");
     RedisModule_FreeCallReply(reply);
 }


### PR DESCRIPTION
1) Following #9658.
Fix build failed due to OS X 11.x doesn't have /usr/lib/libSystem.dylib.
2) Fix a compile warning introduced by #10064.