### PR TITLE
Move the define guard ahead of other header inclusion

### DIFF
--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -49,11 +49,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <pthread.h>
-#include "config.h"
-
 #ifndef __ATOMIC_VAR_H
 #define __ATOMIC_VAR_H
+
+#include <pthread.h>
+#include "config.h"
 
 /* Define redisAtomic for atomic variable. */
 #define redisAtomic

--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -28,10 +28,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdint.h> // for UINTPTR_MAX
-
 #ifndef __QUICKLIST_H__
 #define __QUICKLIST_H__
+
+#include <stdint.h> // for UINTPTR_MAX
 
 /* Node, quicklist, and Iterator are the only data structures used currently. */
 


### PR DESCRIPTION
header inclusions should be contained by the define guards.
Move define guard ahead of them.