### PR TITLE
add test suite infra to test RESP3 attributes

### DIFF
--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -35,6 +35,7 @@ array set ::redis::addr {}
 array set ::redis::blocking {}
 array set ::redis::deferred {}
 array set ::redis::readraw {}
+array set ::redis::attributes {} ;# Holds the RESP3 attributes from the last call
 array set ::redis::reconnect {}
 array set ::redis::tls {}
 array set ::redis::callback {}
@@ -105,6 +106,7 @@ proc ::redis::__dispatch__raw__ {id method argv} {
         set argv [lrange $argv 0 end-1]
     }
     if {[info command ::redis::__method__$method] eq {}} {
+        catch {unset ::redis::attributes($id)}
         set cmd "*[expr {[llength $argv]+1}]\r\n"
         append cmd "$[string length $method]\r\n$method\r\n"
         foreach a $argv {
@@ -165,6 +167,7 @@ proc ::redis::__method__close {id fd} {
     catch {unset ::redis::blocking($id)}
     catch {unset ::redis::deferred($id)}
     catch {unset ::redis::readraw($id)}
+    catch {unset ::redis::attributes($id)}
     catch {unset ::redis::reconnect($id)}
     catch {unset ::redis::tls($id)}
     catch {unset ::redis::state($id)}
@@ -183,6 +186,10 @@ proc ::redis::__method__deferred {id fd val} {
 
 proc ::redis::__method__readraw {id fd val} {
     set ::redis::readraw($id) $val
+}
+
+proc ::redis::__method__attributes {id fd} {
+    set _ $::redis::attributes($id)
 }
 
 proc ::redis::redis_write {fd buf} {
@@ -286,8 +293,8 @@ proc ::redis::redis_read_reply {id fd} {
             * {return [redis_multi_bulk_read $id $fd]}
             % {return [redis_read_map $id $fd]}
             | {
-                # ignore attributes for now (nowhere to store them)
-                redis_read_map $id $fd
+                set attrib [redis_read_map $id $fd]
+                set ::redis::attributes($id) $attrib
                 continue
             }
             default {

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -139,13 +139,17 @@ start_server {tags {"protocol network"}} {
 
     test {RESP3 attributes} {
         r hello 3
-        set res [r debug protocol attrib]
-        # currently the parser in redis.tcl ignores the attributes
+        assert_equal {Some real reply following the attribute} [r debug protocol attrib]
+        assert_equal {key-popularity {key:123 90}} [r attributes]
+
+        # make sure attributes are not kept from previous command
+        r ping
+        assert_error {*attributes* no such element in array} {r attributes}
 
         # restore state
         r hello 2
-        set _ $res
-    } {Some real reply following the attribute} {needs:debug resp3}
+        set _ ""
+    } {} {needs:debug resp3}
 
     test {RESP3 attributes readraw} {
         r hello 3


### PR DESCRIPTION
So far we only tested attributes using `readraw`, not the resp parser caches them, so that after getting the reply, you can query them if you want.