### PR TITLE
Add check min-slave-* feature when evaluating Lua scripts for 6.2

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -686,6 +686,13 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
                 sdsfree(aof_write_err);
             }
             goto cleanup;
+        } else if (server.masterhost == NULL &&
+                   server.repl_min_slaves_max_lag &&
+                   server.repl_min_slaves_to_write &&
+                   server.repl_good_slaves_count < server.repl_min_slaves_to_write)
+        {
+            luaPushError(lua, shared.noreplicaserr->ptr);
+            goto cleanup;
         }
     }
 

--- a/tests/integration/replication-4.tcl
+++ b/tests/integration/replication-4.tcl
@@ -58,28 +58,41 @@ start_server {tags {"repl"}} {
         test {With min-slaves-to-write (1,3): master should be writable} {
             $master config set min-slaves-max-lag 3
             $master config set min-slaves-to-write 1
-            $master set foo bar
-        } {OK}
+            assert_equal OK [$master set foo 123]
+            assert_equal OK [$master eval "return redis.call('set','foo',12345)" 0]
+        }
 
         test {With min-slaves-to-write (2,3): master should not be writable} {
             $master config set min-slaves-max-lag 3
             $master config set min-slaves-to-write 2
-            catch {$master set foo bar} e
-            set e
-        } {NOREPLICAS*}
+            assert_error "*NOREPLICAS*" {$master set foo bar}
+            assert_error "*NOREPLICAS*" {$master eval "redis.call('set','foo','bar')" 0}
+        }
+
+        test {With not enough good slaves, read in Lua script is still accepted} {
+            $master config set min-slaves-max-lag 3
+            $master config set min-slaves-to-write 1
+            $master eval "redis.call('set','foo','bar')" 0
+
+            $master config set min-slaves-to-write 2
+            $master eval "return redis.call('get','foo')" 0
+        } {bar}
 
         test {With min-slaves-to-write: master not writable with lagged slave} {
             $master config set min-slaves-max-lag 2
             $master config set min-slaves-to-write 1
-            assert {[$master set foo bar] eq {OK}}
+            assert_equal OK [$master set foo 123]
+            assert_equal OK [$master eval "return redis.call('set','foo',12345)" 0]
+            # Killing a slave to make it become a lagged slave.
             exec kill -SIGSTOP [srv 0 pid]
+            # Waiting for slave kill.
             wait_for_condition 100 100 {
-                [catch {$master set foo bar}] != 0
+                [catch {$master set foo 123}] != 0
             } else {
                 fail "Master didn't become readonly"
             }
-            catch {$master set foo bar} err
-            assert_match {NOREPLICAS*} $err
+            assert_error "*NOREPLICAS*" {$master set foo 123}
+            assert_error "*NOREPLICAS*" {$master eval "return redis.call('set','foo',12345)" 0}
             exec kill -SIGCONT [srv 0 pid]
         }
     }


### PR DESCRIPTION
### **What problem does this PR solve?**
This PR makes changes in PR #10160 against the 6.2 branch.
### **Check List**
Tests

- Tests added in `integration-4.tcl`.

Code changes

- Add check enough good slaves for write command when evaluating scripts.