### PR TITLE
COMMAND DOCS avoid adding summary/since if they don't exist

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4437,7 +4437,9 @@ void addReplyCommandInfo(client *c, struct redisCommand *cmd) {
 /* Output the representation of a Redis command. Used by the COMMAND DOCS. */
 void addReplyCommandDocs(client *c, struct redisCommand *cmd) {
     /* Count our reply len so we don't have to use deferred reply. */
-    long maplen = 3;
+    long maplen = 1;
+    if (cmd->summary) maplen++;
+    if (cmd->since) maplen++;
     if (cmd->complexity) maplen++;
     if (cmd->doc_flags) maplen++;
     if (cmd->deprecated_since) maplen++;
@@ -4447,12 +4449,16 @@ void addReplyCommandDocs(client *c, struct redisCommand *cmd) {
     if (cmd->subcommands_dict) maplen++;
     addReplyMapLen(c, maplen);
 
-    addReplyBulkCString(c, "summary");
-    addReplyBulkCString(c, cmd->summary);
+    if (cmd->summary) {
+        addReplyBulkCString(c, "summary");
+        addReplyBulkCString(c, cmd->summary);
+    }
+    if (cmd->since) {
+        addReplyBulkCString(c, "since");
+        addReplyBulkCString(c, cmd->since);
+    }
 
-    addReplyBulkCString(c, "since");
-    addReplyBulkCString(c, cmd->since);
-
+    /* Always have the group, for module commands the group is always "module". */
     addReplyBulkCString(c, "group");
     addReplyBulkCString(c, COMMAND_GROUP_STR[cmd->group]);
 

--- a/tests/unit/moduleapi/subcommands.tcl
+++ b/tests/unit/moduleapi/subcommands.tcl
@@ -15,8 +15,8 @@ start_server {tags {"modules"}} {
         set docs_reply [r command docs subcommands.bitarray]
         set docs [dict create {*}[lindex $docs_reply 1]]
         set subcmds_in_cmd_docs [dict create {*}[dict get $docs subcommands]]
-        assert_equal [dict get $subcmds_in_cmd_docs "subcommands.bitarray|get"] {summary {} since {} group module}
-        assert_equal [dict get $subcmds_in_cmd_docs "subcommands.bitarray|set"] {summary {} since {} group module}
+        assert_equal [dict get $subcmds_in_cmd_docs "subcommands.bitarray|get"] {group module}
+        assert_equal [dict get $subcmds_in_cmd_docs "subcommands.bitarray|set"] {group module}
     }
 
     test "Module pure-container command fails on arity error" {


### PR DESCRIPTION
If summary or since is empty, we used to return NULL in
COMMAND DOCS. Currently all redis commands will have these
two fields.

But not for module command, summary and since are optional
for RM_SetCommandInfo. With the change in #10043, if a module
command doesn't have the summary or since, redis-cli will
crash (see #10250).

In this commit, COMMAND DOCS avoid adding summary or since
when they are missing.