### PR TITLE
Delete key doesn't dirty client who watched stale key

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -313,13 +313,12 @@ void unwatchAllKeys(client *c) {
         /* Lookup the watched key -> clients list and remove the client's wk
          * from the list */
         wk = listNodeValue(ln);
-        redisDb *db = wk->db;
-        clients = dictFetchValue(db->watched_keys, wk->key);
+        clients = dictFetchValue(wk->db->watched_keys, wk->key);
         serverAssertWithInfo(c,NULL,clients != NULL);
         listDelNode(clients,listSearchKey(clients,wk));
         /* Kill the entry at all if this was the only client */
         if (listLength(clients) == 0)
-            dictDelete(db->watched_keys, wk->key);
+            dictDelete(wk->db->watched_keys, wk->key);
         /* Remove this watched key from the client->watched list */
         listDelNode(c->watched_keys,ln);
         decrRefCount(wk->key);

--- a/src/multi.c
+++ b/src/multi.c
@@ -412,34 +412,20 @@ void touchAllWatchedKeysInDb(redisDb *emptied, redisDb *replaced_with) {
             listRewind(clients,&li);
             while((ln = listNext(&li))) {
                 watchedKey *wk = listNodeValue(ln);
-                if (!replaced_with) {
-                    /* FLUSHDB, etc. Dicts are not yet emptied. */
-                    if (wk->expired) {
-                        /* Expired key will be deleted. No logical change. Clear
-                         * the flag. Deleted keys are not flagged as expired. */
+                if (wk->expired) {
+                    if (!replaced_with || !dictFind(replaced_with->dict, key->ptr)) {
+                        /* Expired key now deleted. No logical change. Clear the
+                         * flag. Deleted keys are not flagged as expired. */
                         wk->expired = 0;
                         continue;
-                    }
-                } else {
-                    /* SWAPDB or swapMainDbWithTempDb. Dicts are already swapped. */
-                    if (wk->expired) {
-                        if (!exists_in_emptied) {
-                            /* Expired key now deleted. No logical change. Clear
-                             * the flag. Deleted keys are not flagged as
-                             * expired. */
-                            wk->expired = 0;
-                            continue;
-                        } else if (keyIsExpired(emptied, key)) {
-                            /* Expired key remains expired. */
-                            continue;
-                        }
-                    } else if (!dictFind(replaced_with->dict, key->ptr) &&
-                               keyIsExpired(emptied, key))
-                    {
-                        /* Non-existing key is replaced with an expired key. */
-                        wk->expired = 1;
+                    } else if (keyIsExpired(replaced_with, key)) {
+                        /* Expired key remains expired. */
                         continue;
                     }
+                } else if (!exists_in_emptied && keyIsExpired(replaced_with, key)) {
+                    /* Non-existing key is replaced with an expired key. */
+                    wk->expired = 1;
+                    continue;
                 }
                 client *c = wk->client;
                 c->flags |= CLIENT_DIRTY_CAS;

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -147,6 +147,18 @@ start_server {tags {"multi"}} {
         r debug set-active-expire 1
     } {OK} {needs:debug}
 
+    test {WATCH stale keys should not fail EXEC} {
+        r del x
+        r debug set-active-expire 0
+        r set x foo px 1
+        after 2
+        r watch x
+        r multi
+        r ping
+        assert_equal {PONG} [r exec]
+        r debug set-active-expire 1
+    } {OK} {needs:debug}
+
     test {After successful EXEC key is no longer watched} {
         r set x 30
         r watch x

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -159,6 +159,20 @@ start_server {tags {"multi"}} {
         r debug set-active-expire 1
     } {OK} {needs:debug}
 
+    test {Delete WATCHed stale keys should not fail EXEC} {
+        r del x
+        r debug set-active-expire 0
+        r set x foo px 1
+        after 2
+        r watch x
+        # EXISTS triggers lazy expiry/deletion
+        assert_equal 0 [r exists x]
+        r multi
+        r ping
+        assert_equal {PONG} [r exec]
+        r debug set-active-expire 1
+    } {OK} {needs:debug}
+
     test {FLUSHDB while watching stale keys should not fail EXEC} {
         r del x
         r debug set-active-expire 0


### PR DESCRIPTION
When WATCH is called on a key that's already logically expired, avoid discarding the transaction when the keys is actually deleted.

This is a revamp of #9234.

When WATCH is called, a flag is stored if the key is already expired
at the time of watch. The expired key is not deleted, only checked.

When a key is "touched", if it is deleted and it was already expired
when a client watched it, the client is not marked as dirty.