### PR TITLE
Add refcount to redisCommand to avoid module command being ref  after module unload

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -10614,7 +10614,6 @@ void moduleUnregisterCommands(struct RedisModule *module) {
         serverAssert(dictDelete(server.commands, cmd->fullname) == DICT_OK);
         serverAssert(dictDelete(server.orig_commands, cmd->fullname) == DICT_OK);
         cp->func = NULL;
-        // cmd->proc = NULL;
         decrCommandRefCount(cmd);
     }
     dictReleaseIterator(di);

--- a/src/module.c
+++ b/src/module.c
@@ -10568,7 +10568,8 @@ void moduleFreeCommand(struct redisCommand *cmd) {
         cmd->latency_histogram = NULL;
     }
     zfree(cmd->args);
-    zfree((void*)(unsigned long)cmd->getkeys_proc);
+    RedisModuleCommand *cp = (void*)(unsigned long)cmd->getkeys_proc;
+    zfree(cp);
 
     if (cmd->subcommands_dict) {
         dictEntry *de;

--- a/src/module.c
+++ b/src/module.c
@@ -10536,7 +10536,7 @@ void moduleFreeModuleStructure(struct RedisModule *module) {
     zfree(module);
 }
 
-/* Free the command registered with the specified module.
+/* Free the module command.
  * On success C_OK is returned, otherwise C_ERR is returned.
  *
  * Note that caller needs to handle the deletion of the command table dict,

--- a/src/multi.c
+++ b/src/multi.c
@@ -193,8 +193,10 @@ void execCommand(client *c) {
         c->argv_len = c->mstate.commands[j].argv_len;
         c->cmd = c->mstate.commands[j].cmd;
 
+        /* Note that if refcount == 1 means that the module of this
+         * command has been unloaded elsewhere, we need to skip it. */
         if (c->cmd->refcount == 1) {
-            addReplyErrorFormat(c, "Invalid command: %s, the module of this command have been unloaded",
+            addReplyErrorFormat(c, "Invalid command: %s, the module of this command has been unloaded",
                                 c->cmd->fullname);
             continue;
         }

--- a/src/multi.c
+++ b/src/multi.c
@@ -193,14 +193,6 @@ void execCommand(client *c) {
         c->argv_len = c->mstate.commands[j].argv_len;
         c->cmd = c->mstate.commands[j].cmd;
 
-        /* Note that if refcount == 1 means that the module of this
-         * command has been unloaded elsewhere, we need to skip it. */
-        if (c->cmd->refcount == 1) {
-            addReplyErrorFormat(c, "Invalid command: %s, the module of this command has been unloaded",
-                                c->cmd->fullname);
-            continue;
-        }
-
         /* ACL permissions are also checked at the time of execution in case
          * they were changed after the commands were queued. */
         int acl_errpos;

--- a/src/networking.c
+++ b/src/networking.c
@@ -1497,6 +1497,7 @@ void freeClient(client *c) {
     freeReplicaReferencedReplBuffer(c);
     freeClientArgv(c);
     freeClientOriginalArgv(c);
+    decrCommandRefCount(c->lastcmd);
 
     /* Unlink the client: this will close the socket, remove the I/O
      * handlers, and remove references of the client from different

--- a/src/script.c
+++ b/src/script.c
@@ -509,7 +509,9 @@ void scriptCall(scriptRunCtx *run_ctx, robj* *argv, int argc, sds *err) {
         return;
     }
 
+    decrCommandRefCount(c->lastcmd);
     c->cmd = c->lastcmd = cmd;
+    incrCommandRefCount(c->lastcmd);
 
     /* There are commands that are not allowed inside scripts. */
     if (!server.script_disable_deny_script && (cmd->flags & CMD_NOSCRIPT)) {

--- a/src/server.c
+++ b/src/server.c
@@ -2931,21 +2931,6 @@ struct redisCommand *lookupCommandOrOriginal(robj **argv ,int argc) {
     return cmd;
 }
 
-void incrCommandRefCount(struct redisCommand *cmd) {
-    if (!cmd || !(cmd->flags & CMD_MODULE)) return;
-    cmd->refcount++;
-}
-
-void decrCommandRefCount(struct redisCommand *cmd) {
-    if (!cmd || !(cmd->flags & CMD_MODULE)) return;
-    serverAssert(cmd->refcount > 0);
-    if (--cmd->refcount == 0) {
-        sdsfree((sds)cmd->declared_name);
-        sdsfree(cmd->fullname);
-        zfree(cmd);
-    }
-}
-
 static int shouldPropagate(int target) {
     if (!server.replication_allowed || target == PROPAGATE_NONE || server.loading)
         return 0;

--- a/src/server.h
+++ b/src/server.h
@@ -2218,6 +2218,8 @@ struct redisCommand {
     dict *subcommands_dict; /* A dictionary that holds the subcommands, the key is the subcommand sds name
                              * (not the fullname), and the value is the redisCommand structure pointer. */
     struct redisCommand *parent;
+    int refcount; /* Only used for safe free of module commands, in case
+                   * the module is unloaded while it is still referenced. */
 };
 
 struct redisError {
@@ -2821,6 +2823,8 @@ struct redisCommand *lookupCommandBySds(sds s);
 struct redisCommand *lookupCommandByCStringLogic(dict *commands, const char *s);
 struct redisCommand *lookupCommandByCString(const char *s);
 struct redisCommand *lookupCommandOrOriginal(robj **argv, int argc);
+void incrCommandRefCount(struct redisCommand *cmd);
+void decrCommandRefCount(struct redisCommand *cmd);
 void call(client *c, int flags);
 void alsoPropagate(int dbid, robj **argv, int argc, int target);
 void propagatePendingCommands();

--- a/tests/unit/moduleapi/basics.tcl
+++ b/tests/unit/moduleapi/basics.tcl
@@ -56,6 +56,8 @@ start_server {tags {"modules"}} {
         r module load $testmodule
         r test.basics
         assert_equal {OK} [$rd module unload test]
+        # Check test.basics command was removed from command list.
+        assert_error {*ERR unknown command 'test.basics'*} {$rd test.basics}
         assert_match "*cmd=test.basics*" [$rd client list]
     }
 }

--- a/tests/unit/moduleapi/basics.tcl
+++ b/tests/unit/moduleapi/basics.tcl
@@ -32,6 +32,24 @@ start_server {tags {"modules"}} {
     test "Unload the module - test" {
         assert_equal {OK} [r module unload test]
     }
+
+    test "Unload the module in multi - test" {
+        r module load $testmodule
+        r multi
+        r module unload test
+        r test.basics
+        assert_error {*Invalid command: test.basics*} {r exec}
+    }
+
+    test "Unload the module when module command already in multi queue - test" {
+        set rd [redis_deferring_client]
+
+        r module load $testmodule
+        r multi
+        r test.basics
+        $rd module unload test
+        assert_error {*Invalid command: test.basics*} {r exec}
+    }
 }
 
 start_server {tags {"modules external:skip"} overrides {enable-module-command no}} {

--- a/tests/unit/moduleapi/basics.tcl
+++ b/tests/unit/moduleapi/basics.tcl
@@ -43,12 +43,13 @@ start_server {tags {"modules"}} {
 
     test "Unload the module when module command already in multi queue - test" {
         set rd [redis_client]
-
         r module load $testmodule
         r multi
         r test.basics
         assert_equal {OK} [$rd module unload test]
+        # Check that execute test.basics command in mulit will fail.
         assert_error {*Invalid command: test.basics*} {r exec}
+        $rd close
     }
 
     test "Unload the module when module command was referenced by client - test" {
@@ -58,7 +59,9 @@ start_server {tags {"modules"}} {
         assert_equal {OK} [$rd module unload test]
         # Check test.basics command was removed from command list.
         assert_error {*ERR unknown command 'test.basics'*} {$rd test.basics}
+        # Check test.basics command is still being referenced.
         assert_match "*cmd=test.basics*" [$rd client list]
+        $rd close
     }
 }
 

--- a/tests/unit/moduleapi/basics.tcl
+++ b/tests/unit/moduleapi/basics.tcl
@@ -42,13 +42,21 @@ start_server {tags {"modules"}} {
     }
 
     test "Unload the module when module command already in multi queue - test" {
-        set rd [redis_deferring_client]
+        set rd [redis_client]
 
         r module load $testmodule
         r multi
         r test.basics
-        $rd module unload test
+        assert_equal {OK} [$rd module unload test]
         assert_error {*Invalid command: test.basics*} {r exec}
+    }
+
+    test "Unload the module when module command was referenced by client - test" {
+        set rd [redis_client]
+        r module load $testmodule
+        r test.basics
+        assert_equal {OK} [$rd module unload test]
+        assert_match "*cmd=test.basics*" [$rd client list]
     }
 }
 

--- a/tests/unit/moduleapi/subcommands.tcl
+++ b/tests/unit/moduleapi/subcommands.tcl
@@ -50,4 +50,14 @@ start_server {tags {"modules"}} {
     test "Unload the module - subcommands" {
         assert_equal {OK} [r module unload subcommands]
     }
+
+    test "Unload the module when module subcommand was referenced by client - test" {
+        set rd [redis_client]
+        r module load $testmodule
+        r subcommands.sub get_fullname
+        assert_equal {OK} [$rd module unload subcommands]
+        # Check subcommand.sub|get_fullname command was removed from command list.
+        assert_error {*ERR unknown command 'subcommands.sub'*} {$rd subcommands.sub get_fullname}
+        assert_match "*cmd=subcommands.sub|get_fullname*" [$rd client list]
+    }
 }

--- a/tests/unit/moduleapi/subcommands.tcl
+++ b/tests/unit/moduleapi/subcommands.tcl
@@ -56,8 +56,10 @@ start_server {tags {"modules"}} {
         r module load $testmodule
         r subcommands.sub get_fullname
         assert_equal {OK} [$rd module unload subcommands]
-        # Check subcommand.sub|get_fullname command was removed from command list.
+        # Check subcommand.sub|get_fullname subcommand was removed from command list.
         assert_error {*ERR unknown command 'subcommands.sub'*} {$rd subcommands.sub get_fullname}
+        # Check subcommand.sub|get_fullname subcommand is still being referenced.
         assert_match "*cmd=subcommands.sub|get_fullname*" [$rd client list]
+        $rd close
     }
 }


### PR DESCRIPTION
Implement #10177

### Issues

1. When we execute `module unload` command in multi first, and then execute the module command of this module, it will cause a crash (this module command has already been released).

```sh
multi
module unload helloworld
hello.simple
exec
```

2) When we execute module command in multi but not exec, the module of this command is unloaded by another client, which will also cause a crash.

#### Step 1:
```sh
# client1
multi
hello.simple
```

Step 2:
```sh
# client 2
module unload helloworld
```

Step 3:
```sh
# client1
exec
```

3)  The last successfully executed command for each client will be saved in `c->lastcmd` (it may be a module command), and when the module is unloaded, this module command point will still be held, which will result in illegal memory usage (e.g `client list` command).

Step1
```sh
# client1
hello.simple
```

Step2
```sh
# client2
module unload helloworld
client info
# output
# id=4 addr=127.0.0.1:52620 laddr=127.0.0.1:6379 fd=8 name= age=6 idle=6 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 argv-mem=0 multi-mem=0 obl=0 oll=0 omem=0 tot-mem=17074 events=r cmd=hello.simple user=default redir=-1 resp=2
```

### Solution

Added `refcount` in redisCommand to be used only to cal the ref count of the module command.
module unload will not release the module command directly, the module command will be released when it is not referenced anywhere.


### Error reply
If module command is executed after the module has been unloaded, the following error will be replied.
```
Invalid command: [command fullname], the module of this command has been unloaded
```