### PR TITLE
Use binary representation for key values dumped to crash log

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1616,8 +1616,14 @@ void logCurrentClient(void) {
         robj *decoded;
 
         decoded = getDecodedObject(cc->argv[j]);
+        size_t repr_len = sdslen(decoded->ptr);
+        if (repr_len > 128) {
+            repr_len = 128;
+        }
+        sds repr = sdscatrepr(sdsempty(),decoded->ptr, repr_len);
         serverLog(LL_WARNING|LL_RAW,"argv[%d]: '%s'\n", j,
-            (char*)decoded->ptr);
+            (char*)repr);
+        sdsfree(repr);
         decrRefCount(decoded);
     }
     /* Check if the first argument, usually a key, is found inside the

--- a/src/debug.c
+++ b/src/debug.c
@@ -1614,15 +1614,9 @@ void logCurrentClient(void) {
     sdsfree(client);
     for (j = 0; j < cc->argc; j++) {
         robj *decoded;
-
         decoded = getDecodedObject(cc->argv[j]);
-        size_t repr_len = sdslen(decoded->ptr);
-        if (repr_len > 128) {
-            repr_len = 128;
-        }
-        sds repr = sdscatrepr(sdsempty(),decoded->ptr, repr_len);
-        serverLog(LL_WARNING|LL_RAW,"argv[%d]: '%s'\n", j,
-            (char*)repr);
+        sds repr = sdscatrepr(sdsempty(),decoded->ptr, min(sdslen(decoded->ptr), 128));
+        serverLog(LL_WARNING|LL_RAW,"argv[%d]: '%s'\n", j, (char*)repr);
         sdsfree(repr);
         decrRefCount(decoded);
     }


### PR DESCRIPTION
Allow binary value of a key, such as embedded nulls, to be seen in the log.
Additionally limit their length to 128 chars

Test case:
Use rejson.so from [2.0.6 module](http://redismodules.s3.amazonaws.com/rejson/rejson.Linux-ubuntu18.04-x86_64.2.0.6.zip)
```
MODULE LOAD /path_to/rejson.so
json.set test $ '{}'
json.get test "\x00abcdefghijklmnopqrstuvwxyz\x00ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"

```
This leads to a crash (fixed on RedisJson master)
Before this fix, the value in the crash report is seen as empty `''`
After this fix, up to 128 chars of the value are seen in the log (nulls will be seen as `\x00`):
...
argv[1]: '"test"'
argv[2]: `'"\x00abcdefghijklmnopqrstuvwxyz\x00ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuv"'`
...
