### PR TITLE
Check target node is a primary during cluster setslot.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5226,6 +5226,10 @@ NULL
                     (char*)c->argv[4]->ptr);
                 return;
             }
+            if (nodeIsSlave(n)) {
+                addReplyError(c,"Target node is not a master");
+                return;
+            }
             /* If this hash slot was served by 'myself' before to switch
              * make sure there are no longer local keys for this hash slot. */
             if (server.cluster->slots[slot] == myself && n != myself) {


### PR DESCRIPTION
A replica can't own a slot, only primaries can own the slot. Hence, we need to disable the slot transfer from a primary to a replica. 

Verify if the target node is a primary during `cluster setslot <slot> NODE <id>`

Before the change
```
127.0.0.1:7379> CLUSTER SETSLOT 1 NODE e2acf1a97c055fd09dcc2c0dcc62b19a6905dbc8
OK
127.0.0.1:7379> cluster nodes
b7e9acc0def782aabe6b596f67f06c73c2ffff93 127.0.0.1:7379@17379 myself,master - 0 1644506261000 18 connected 0 5-5460 11111-11112 16112
1461967c62eab0e821ed54f2c98e594fccfd8736 127.0.0.1:7381@17381 slave,fail? 71f058078c142a73b94767a4e78e9033d195dfb4 1644506176155 1644506173615 3 disconnected
9215e30cd4a71070088778080565de6ef75fd459 127.0.0.1:6380@16380 master,fail? - 1644506176155 1644506173615 16 disconnected 5461-10922
e2acf1a97c055fd09dcc2c0dcc62b19a6905dbc8 127.0.0.1:6379@16379 slave b7e9acc0def782aabe6b596f67f06c73c2ffff93 0 1644506261963 18 connected 1-4
71f058078c142a73b94767a4e78e9033d195dfb4 127.0.0.1:6381@16381 master,fail? - 1644506175545 1644506173615 3 disconnected 10923-11110 11113-16111 16113-16383
877fa59da72cb902d0563d3d8def3437fc3a0196 127.0.0.1:7380@17380 slave,fail? 9215e30cd4a71070088778080565de6ef75fd459 1644506174532 1644506173615 16 disconnected
1
```

After the change
```
127.0.0.1:6379> CLUSTER SETSLOT 1 NODE e2acf1a97c055fd09dcc2c0dcc62b19a6905dbc8
(error) ERR Please use SETSLOT only with masters.
127.0.0.1:6379> CLUSTER NODES
b7e9acc0def782aabe6b596f67f06c73c2ffff93 127.0.0.1:7379@17379 master - 0 1644518177561 18 connected 0-5460 11111-11112 16112
e2acf1a97c055fd09dcc2c0dcc62b19a6905dbc8 127.0.0.1:6379@16379 myself,slave b7e9acc0def782aabe6b596f67f06c73c2ffff93 0 1644518177000 18 connected
1461967c62eab0e821ed54f2c98e594fccfd8736 127.0.0.1:7381@17381 slave,fail? 71f058078c142a73b94767a4e78e9033d195dfb4 1644505039475 1644505037542 3 disconnected
9215e30cd4a71070088778080565de6ef75fd459 127.0.0.1:6380@16380 master,fail? - 1644505040086 1644505037542 16 disconnected 5461-10922
71f058078c142a73b94767a4e78e9033d195dfb4 127.0.0.1:6381@16381 master,fail? - 1644505040086 1644505037542 3 disconnected 10923-11110 11113-16111 16113-16383
877fa59da72cb902d0563d3d8def3437fc3a0196 127.0.0.1:7380@17380 slave,fail? 9215e30cd4a71070088778080565de6ef75fd459 1644505038461 1644505037542 16 disconnected
```