### PR TITLE
Fix RM_SetModuleOptions flag collision

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -10776,6 +10776,8 @@ sds genModulesInfoStringRenderModuleOptions(struct RedisModule *module) {
         output = sdscat(output,"handle-io-errors|");
     if (module->options & REDISMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD)
         output = sdscat(output,"handle-repl-async-load|");
+    if (module->options & REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED)
+        output = sdscat(output,"no-implicit-signal-modified|");
     output = sdstrim(output,"|");
     output = sdscat(output,"]");
     return output;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -242,7 +242,7 @@ typedef uint64_t RedisModuleTimerID;
 /* When set, Redis will not call RedisModule_SignalModifiedKey(), implicitly in
  * RedisModule_CloseKey, and the module needs to do that when manually when keys
  * are modified from the user's sperspective, to invalidate WATCH. */
-#define REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED (1<<1)
+#define REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED (1<<2)
 
 /* Definitions for RedisModule_SetCommandInfo. */
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -236,13 +236,13 @@ typedef uint64_t RedisModuleTimerID;
 /* Declare that the module can handle errors with RedisModule_SetModuleOptions. */
 #define REDISMODULE_OPTIONS_HANDLE_IO_ERRORS    (1<<0)
 
-/* Declare that the module can handle diskless async replication with RedisModule_SetModuleOptions. */
-#define REDISMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD    (1<<1)
-
 /* When set, Redis will not call RedisModule_SignalModifiedKey(), implicitly in
  * RedisModule_CloseKey, and the module needs to do that when manually when keys
  * are modified from the user's sperspective, to invalidate WATCH. */
-#define REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED (1<<2)
+#define REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED (1<<1)
+
+/* Declare that the module can handle diskless async replication with RedisModule_SetModuleOptions. */
+#define REDISMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD    (1<<2)
 
 /* Definitions for RedisModule_SetCommandInfo. */
 

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -47,6 +47,12 @@ tags "modules" {
         }
     }
 
+    test {Verify module options info} {
+        start_server [list overrides [list loadmodule "$testmodule"]] {
+            assert_match "*\[handle-io-errors|handle-repl-async-load\]*" [r info modules]
+        }
+    }
+
     tags {repl} {
         test {diskless loading short read with module} {
             start_server [list overrides [list loadmodule "$testmodule"]] {


### PR DESCRIPTION
The bug is introduced by #9323. (released in 7.0 RC1)
The define of `REDISMODULE_OPTIONS_HANDLE_IO_ERRORS` and `REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED` have the same value.

This will result in skipping `signalModifiedKey()` after `RM_CloseKey()` if the module has set `REDISMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD` option.
The implication is missing WATCH and client side tracking invalidations.

Other changes:
- add `no-implicit-signal-modified` to the options in INFO modules