### PR TITLE
redis-cli: Better --json Unicode support and --quoted-json

### DIFF
--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -372,29 +372,45 @@ void freeCliConnInfo(cliConnInfo connInfo){
     if (connInfo.user) sdsfree(connInfo.user);
 }
 
-sds escapeJsonString(hisds s, const char *p, size_t len) {
-    s = hi_sdscatlen(s,"\"",1);
+/*
+ * Escape a string for JSON output(--json)
+ * Following characters should be escaped with '\' in JSON
+ * " (quotation mark)
+ * \ (reverse solidus)
+ * / (solidus)
+ * b (backspace)
+ * f (form feed)
+ * n (line feed)
+ * r (carriage return)
+ * t (tab)
+ * not printable character (0x00~0x19, 0x80~) should be escaped
+ * with two double quotes, whereas they are escaped with 'one'
+ * double quote in sdscatrepr()
+ * 
+ * ref: https://datatracker.ietf.org/doc/html/rfc7159#section-7
+*/
+sds escapeJsonString(sds s, const char *p, size_t len) {
+    s = sdscatlen(s,"\"",1);
     while(len--) {
         switch(*p) {
         case '/':
         case '\\':
         case '"':
-            s = hi_sdscatprintf(s,"\\%c",*p);
+            s = sdscatprintf(s,"\\%c",*p);
             break;
-        case '\n': s = hi_sdscatlen(s,"\\n",2); break;
-        case '\f': s = hi_sdscatlen(s,"\\f",2); break;
-        case '\r': s = hi_sdscatlen(s,"\\r",2); break;
-        case '\t': s = hi_sdscatlen(s,"\\t",2); break;
-        case '\a': s = hi_sdscatlen(s,"\\a",2); break;
-        case '\b': s = hi_sdscatlen(s,"\\b",2); break;
+        case '\n': s = sdscatlen(s,"\\n",2); break;
+        case '\f': s = sdscatlen(s,"\\f",2); break;
+        case '\r': s = sdscatlen(s,"\\r",2); break;
+        case '\t': s = sdscatlen(s,"\\t",2); break;
+        case '\b': s = sdscatlen(s,"\\b",2); break;
         default:
             if (isprint(*p))
-                s = hi_sdscatprintf(s,"%c",*p);
+                s = sdscatprintf(s,"%c",*p);
             else
-                s = hi_sdscatprintf(s,"\\\\x%02x",(unsigned char)*p);
+                s = sdscatprintf(s,"\\\\x%02x",(unsigned char)*p);
             break;
         }
         p++;
     }
-    return hi_sdscatlen(s,"\"",1);
+    return sdscatlen(s,"\"",1);
 }

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -399,7 +399,7 @@ sds escapeJsonString(sds s, const char *p, size_t len) {
         case '\t': s = sdscatlen(s,"\\t",2); break;
         case '\b': s = sdscatlen(s,"\\b",2); break;
         default:
-            s = sdscatprintf(s,"%c",*p);
+            s = sdscatprintf(s,(*p >= 0 && *p <= 0x1f) ? "\\u%04x" : "%c",*p);
         }
         p++;
     }

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -383,6 +383,8 @@ void freeCliConnInfo(cliConnInfo connInfo){
  * r (carriage return)
  * t (tab)
  * 
+ * and the characters between 0x00~0x1f are printed as \u00??
+ * 
  * ref: https://datatracker.ietf.org/doc/html/rfc7159#section-7
 */
 sds escapeJsonString(sds s, const char *p, size_t len) {

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -371,3 +371,30 @@ void freeCliConnInfo(cliConnInfo connInfo){
     if (connInfo.auth) sdsfree(connInfo.auth);
     if (connInfo.user) sdsfree(connInfo.user);
 }
+
+sds escapeJsonString(hisds s, const char *p, size_t len) {
+    s = hi_sdscatlen(s,"\"",1);
+    while(len--) {
+        switch(*p) {
+        case '/':
+        case '\\':
+        case '"':
+            s = hi_sdscatprintf(s,"\\%c",*p);
+            break;
+        case '\n': s = hi_sdscatlen(s,"\\n",2); break;
+        case '\f': s = hi_sdscatlen(s,"\\f",2); break;
+        case '\r': s = hi_sdscatlen(s,"\\r",2); break;
+        case '\t': s = hi_sdscatlen(s,"\\t",2); break;
+        case '\a': s = hi_sdscatlen(s,"\\a",2); break;
+        case '\b': s = hi_sdscatlen(s,"\\b",2); break;
+        default:
+            if (isprint(*p))
+                s = hi_sdscatprintf(s,"%c",*p);
+            else
+                s = hi_sdscatprintf(s,"\\\\x%02x",(unsigned char)*p);
+            break;
+        }
+        p++;
+    }
+    return hi_sdscatlen(s,"\"",1);
+}

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -373,19 +373,8 @@ void freeCliConnInfo(cliConnInfo connInfo){
 }
 
 /*
- * Escape a string for JSON output(--json)
- * Following characters should be escaped with '\' in JSON
- * " (quotation mark)
- * \ (reverse solidus)
- * b (backspace)
- * f (form feed)
- * n (line feed)
- * r (carriage return)
- * t (tab)
- * 
- * and the characters between 0x00~0x1f are printed as \u00??
- * 
- * ref: https://datatracker.ietf.org/doc/html/rfc7159#section-7
+ * Escape a Unicode string for JSON output (--json), following RFC 7159:
+ * https://datatracker.ietf.org/doc/html/rfc7159#section-7
 */
 sds escapeJsonString(sds s, const char *p, size_t len) {
     s = sdscatlen(s,"\"",1);
@@ -403,15 +392,6 @@ sds escapeJsonString(sds s, const char *p, size_t len) {
         default:
             s = sdscatprintf(s,(*p >= 0 && *p <= 0x1f) ? "\\u%04x" : "%c",*p);
         }
-        p++;
-    }
-    return sdscatlen(s,"\"",1);
-}
-
-sds convertBinaryInJson(sds s, const char *p, size_t len) {
-    s = sdscatlen(s,"\"",1);
-    while(len--) {
-        s = sdscatprintf(s,"\\\\x%02x",(unsigned char)*p);
         p++;
     }
     return sdscatlen(s,"\"",1);

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -49,5 +49,7 @@ void parseRedisUri(const char *uri, const char* tool_name, cliConnInfo *connInfo
 
 void freeCliConnInfo(cliConnInfo connInfo);
 
-char* escapeJsonString(sds s, const char *p, size_t len);
+sds escapeJsonString(sds s, const char *p, size_t len);
+
+sds convertBinaryInJson(sds s, const char *p, size_t len);
 #endif /* __CLICOMMON_H */

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -48,4 +48,6 @@ sds unquoteCString(char *str);
 void parseRedisUri(const char *uri, const char* tool_name, cliConnInfo *connInfo, int *tls_flag);
 
 void freeCliConnInfo(cliConnInfo connInfo);
+
+sds escapeJsonString(hisds s, const char *p, size_t len);
 #endif /* __CLICOMMON_H */

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -51,5 +51,4 @@ void freeCliConnInfo(cliConnInfo connInfo);
 
 sds escapeJsonString(sds s, const char *p, size_t len);
 
-sds convertBinaryInJson(sds s, const char *p, size_t len);
 #endif /* __CLICOMMON_H */

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -49,5 +49,5 @@ void parseRedisUri(const char *uri, const char* tool_name, cliConnInfo *connInfo
 
 void freeCliConnInfo(cliConnInfo connInfo);
 
-sds escapeJsonString(hisds s, const char *p, size_t len);
+char* escapeJsonString(sds s, const char *p, size_t len);
 #endif /* __CLICOMMON_H */

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -8521,6 +8521,7 @@ int main(int argc, char **argv) {
     config.set_errcode = 0;
     config.no_auth_warning = 0;
     config.in_multi = 0;
+    config.json_binary_encoding = 0;
     config.cluster_manager_command.name = NULL;
     config.cluster_manager_command.argc = 0;
     config.cluster_manager_command.argv = NULL;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1243,8 +1243,9 @@ static sds cliFormatReplyJson(sds out, redisReply *r, int mode) {
             if (key->type == REDIS_REPLY_ERROR ||
                 key->type == REDIS_REPLY_STATUS ||
                 key->type == REDIS_REPLY_STRING ||
-                key->type == REDIS_REPLY_VERB) {
-                    out = cliFormatReplyJson(out,key,mode);
+                key->type == REDIS_REPLY_VERB)
+            {
+                out = cliFormatReplyJson(out,key,mode);
             } else {
                 /* According to JSON spec, JSON map keys must be strings,
                  * and in RESP3, they can be other types. 
@@ -1670,7 +1671,7 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--csv")) {
             config.output = OUTPUT_CSV;
         } else if (!strcmp(argv[i],"--json")) {
-            /* Not overwrite explicit value by -3*/
+            /* Not overwrite explicit value by -3 */
             if (config.resp3 == 0) {
                 config.resp3 = 2;
             }

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -239,10 +239,17 @@ start_server {tags {"cli"}} {
         r hset eth test $eth
         assert_equal \"\\xf0e\" [run_cli hget eth test]
         assert_equal \"\xf0e\" [run_cli --json hget eth test]
-        assert_equal \"\\\\xf0\\\\x65\" [run_cli --json --json-binary-encoding hget eth test]
+        assert_equal \"\\\\xf0e\" [run_cli --quoted-json hget eth test]
         # control characters
         r hset control test "Hello\x00\x01\x02\x03World"
         assert_equal \"Hello\\u0000\\u0001\\u0002\\u0003World" [run_cli --json hget control test]
+        # non-string keys
+        r hset numkey 1 One
+        assert_equal \{\"1\":\"One\"\} [run_cli --json hgetall numkey]
+        # non-string, non-printable keys
+        r hset npkey "K\x00\x01ey" "V\x00\x01alue"
+        assert_equal \{\"K\\u0000\\u0001ey\":\"V\\u0000\\u0001alue\"\} [run_cli --json hgetall npkey]
+        assert_equal \{\"K\\\\x00\\\\x01ey\":\"V\\\\x00\\\\x01alue\"\} [run_cli --quoted-json hgetall npkey]
     }
 
     test_nontty_cli "Status reply" {

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -229,16 +229,18 @@ start_server {tags {"cli"}} {
     }
 
     test_tty_cli "Escape character in JSON mode" {
-        # solidus
-        r hset solidus / /
-        assert_equal / / [run_cli hgetall solidus]
-        set escaped_solidus \"\\/\"
-        assert_equal $escaped_solidus $escaped_solidus [run_cli --json hgetall /]
-        # non printable (ð is 0xF0 in ISO 8859-1, not UTF-8(0xC3 0xB0))
+        # reverse solidus
+        r hset solidus \/ \/
+        assert_equal \/ \/ [run_cli hgetall solidus]
+        set escaped_reverse_solidus \"\\"
+        assert_equal $escaped_reverse_solidus $escaped_reverse_solidus [run_cli --json hgetall \/]
+        # non printable (ð is 0xF0 in ISO-8859-1, not UTF-8(0xC3 0xB0))
+        # set ð by ISO-8859-1, not UTF-8, to edit this character please reopen this file with ISO-8859-1
         set eth ð
         r hset eth test $eth
         assert_equal \"\\xf0\" [run_cli hget eth test]
-        assert_equal \"\\\\xf0\" [run_cli --json hget eth test]
+        assert_equal \"ð\" [run_cli --json hget eth test]
+        assert_equal \"\\\\xf0\" [run_cli --json --json-binary-encoding hget eth test]
     }
 
     test_nontty_cli "Status reply" {

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -295,7 +295,6 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
         # unicode
         set gclef 𝄞
         r hset g:clef test $gclef
-        assert_equal $gclef [run_cli hget g:clef test]
         assert_equal "\xf0\x9d\x84\x9e" [run_cli hget g:clef test]
         set escaped_gclef \"\\\\xf0\\\\x9d\\\\x84\\\\x9e\"
         assert_equal $escaped_gclef [run_cli --json hget g:clef test]

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -234,13 +234,16 @@ start_server {tags {"cli"}} {
         assert_equal \/ \/ [run_cli hgetall solidus]
         set escaped_reverse_solidus \"\\"
         assert_equal $escaped_reverse_solidus $escaped_reverse_solidus [run_cli --json hgetall \/]
-        # non printable (ð is 0xF0 in ISO-8859-1, not UTF-8(0xC3 0xB0))
-        # set ð by ISO-8859-1, not UTF-8, to edit this character please reopen this file with ISO-8859-1
-        set eth ð
+        # non printable (0xF0 in ISO-8859-1, not UTF-8(0xC3 0xB0))
+        # set \0xf0 by ISO-8859-1, not UTF-8, to edit this character please reopen this file with ISO-8859-1
+        set eth "\xf0\x65"
         r hset eth test $eth
-        assert_equal \"\\xf0\" [run_cli hget eth test]
-        assert_equal \"ð\" [run_cli --json hget eth test]
-        assert_equal \"\\\\xf0\" [run_cli --json --json-binary-encoding hget eth test]
+        assert_equal \"\\xf0e\" [run_cli hget eth test]
+        assert_equal \"\xf0e\" [run_cli --json hget eth test]
+        assert_equal \"\\\\xf0\\\\x65\" [run_cli --json --json-binary-encoding hget eth test]
+        # control characters
+        r hset control test "Hello\x00\x01\x02\x03World"
+        assert_equal \"Hello\\u0000\\u0001\\u0002\\u0003World" [run_cli --json hget control test]
     }
 
     test_nontty_cli "Status reply" {

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -286,6 +286,21 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
         assert_equal "unquoted-val" [r get {"\x41\x41"}]
     }
 
+    test_nontty_cli "Escape character in JSON mode" {
+        # solidus
+        r hset solidus / /
+        assert_equal / / [run_cli hgetall solidus]
+        set escaped_solidus \"\\/\"
+        assert_equal $escaped_solidus $escaped_solidus [run_cli --json hgetall /]
+        # unicode
+        set gclef 𝄞
+        r hset g:clef test $gclef
+        assert_equal $gclef [run_cli hget g:clef test]
+        assert_equal "\xf0\x9d\x84\x9e" [run_cli hget g:clef test]
+        set escaped_gclef \"\\\\xf0\\\\x9d\\\\x84\\\\x9e\"
+        assert_equal $escaped_gclef [run_cli --json hget g:clef test]
+    }
+
     test_nontty_cli "Invalid quoted input arguments" {
         catch {run_cli --quoted-input set {"Unterminated}} err
         assert_match {*exited abnormally*} $err

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -235,7 +235,6 @@ start_server {tags {"cli"}} {
         set escaped_reverse_solidus \"\\"
         assert_equal $escaped_reverse_solidus $escaped_reverse_solidus [run_cli --json hgetall \/]
         # non printable (0xF0 in ISO-8859-1, not UTF-8(0xC3 0xB0))
-        # set \0xf0 by ISO-8859-1, not UTF-8, to edit this character please reopen this file with ISO-8859-1
         set eth "\xf0\x65"
         r hset eth test $eth
         assert_equal \"\\xf0e\" [run_cli hget eth test]


### PR DESCRIPTION
Normally, `redis-cli` escapes non-printable data received from Redis, using a custom scheme (which is also used to handle quoted input). When using `--json` this is not desired as it is not compatible with RFC 7159, which specifies JSON strings are assumed to be Unicode and how they should be escaped.

This commit changes `--json` to follow RFC 7159, which means that properly encoded Unicode strings in Redis will result with a valid Unicode JSON.

However, this introduces a new problem with `--json` and data that is not valid Unicode (e.g., random binary data, text that follows other encoding, etc.). To address this, we add `--quoted-json` which produces JSON strings that follow the original redis-cli quoting scheme.

For example, a value that consists of only null (0x00) bytes will show up as:
* `"\u0000\u0000\u0000"` when using `--json`
* `"\\x00\\x00\\x00"` when using `--quoted-json`