### PR TITLE
Fix OpenSSL 3.0.x related issues.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -213,7 +213,9 @@ tcp-keepalive 300
 #
 # tls-client-key-file-pass secret
 
-# Configure a DH parameters file to enable Diffie-Hellman (DH) key exchange:
+# Configure a DH parameters file to enable Diffie-Hellman (DH) key exchange,
+# required by older versions of OpenSSL (<3.0). Newer versions do not require
+# this configuration and recommend against it.
 #
 # tls-dh-params-file redis.dh
 


### PR DESCRIPTION
* Drop obsolete initialization calls.
* Use decoder API for DH parameters.
* Enable auto DH parameters if not explicitly used, which should be the
  preferred configuration going forward.
  
  Fixes #10280 