### PR TITLE
fix "Connect multiple replicas at the same time" test

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -318,7 +318,7 @@ foreach mdl {no yes} {
                             stop_write_load $load_handle4
 
                             # Make sure no more commands processed
-                            wait_load_handlers_disconnected
+                            wait_load_handlers_disconnected -3
 
                             wait_for_ofs_sync $master [lindex $slaves 0]
                             wait_for_ofs_sync $master [lindex $slaves 1]


### PR DESCRIPTION
In order to make sure no more commands processed, we wait that
the 'load handlers' will disconncet.

The test by mistake waited on the (last) slave instead of the master.