### PR TITLE
fix return value of loadAppendOnlyFiles

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -2443,7 +2443,7 @@ off_t getBaseAndIncrAppendOnlyFilesSize(aofManifest *am, int *status) {
         serverAssert(am->base_aof_info->file_type == AOF_FILE_TYPE_BASE);
 
         size += getAppendOnlyFileSize(am->base_aof_info->file_name, status);
-        if (status != AOF_OK) return 0;
+        if (*status != AOF_OK) return 0;
     }
 
     listRewind(am->incr_aof_list, &li);
@@ -2451,7 +2451,7 @@ off_t getBaseAndIncrAppendOnlyFilesSize(aofManifest *am, int *status) {
         aofInfo *ai = (aofInfo*)ln->value;
         serverAssert(ai->file_type == AOF_FILE_TYPE_INCR);
         size += getAppendOnlyFileSize(ai->file_name, status);
-        if (status != AOF_OK) return 0;
+        if (*status != AOF_OK) return 0;
     }
 
     return size;

--- a/src/aof.c
+++ b/src/aof.c
@@ -1645,7 +1645,7 @@ int loadAppendOnlyFiles(aofManifest *am) {
 
     /* If the last status is AOF_EMPTY but total_size > 0, it means
      * that we succeeded to load (at least) one of the AOF files */
-    if (ret == AOF_EMPTY && total_size > 0) AOF_OK;
+    if (ret == AOF_EMPTY && total_size > 0) ret = AOF_OK;
 
 cleanup:
     stopLoading(ret == AOF_OK || ret == AOF_TRUNCATED || ret == AOF_EMPTY);

--- a/src/aof.c
+++ b/src/aof.c
@@ -2435,7 +2435,7 @@ off_t getAppendOnlyFileSize(sds filename, int *status) {
 }
 
 /* Get size of all AOF files referred by the manifest (excluding history).
- * The status argument is an optional output argument to be filled with
+ * The status argument is an output argument to be filled with
  * one of the AOF_ status values. */
 off_t getBaseAndIncrAppendOnlyFilesSize(aofManifest *am, int *status) {
     off_t size = 0;
@@ -2452,8 +2452,6 @@ off_t getBaseAndIncrAppendOnlyFilesSize(aofManifest *am, int *status) {
     listRewind(am->incr_aof_list, &li);
     while ((ln = listNext(&li)) != NULL) {
         aofInfo *ai = (aofInfo*)ln->value;
-        if (ai->file_type == AOF_FILE_TYPE_HIST)
-            continue;
         serverAssert(ai->file_type == AOF_FILE_TYPE_INCR);
         size += getAppendOnlyFileSize(ai->file_name, status);
         if (*status != AOF_OK) return 0;

--- a/src/aof.c
+++ b/src/aof.c
@@ -1651,7 +1651,7 @@ int loadAppendOnlyFiles(aofManifest *am) {
     if (aof_loaded && ret == AOF_EMPTY) ret = AOF_OK;
 
 cleanup:
-    stopLoading(ret == AOF_OK);
+    stopLoading(ret == AOF_OK || ret == AOF_TRUNCATED || ret == AOF_EMPTY);
     return ret;
 }
 

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -45,7 +45,7 @@ tags {"external:skip"} {
                 fail "AOF loading didn't fail"
             }
 
-            assert_equal 1 [count_message_lines $server_path/stdout "appendonly.aof.1.incr.aof.*No such file or directory"]
+            assert_equal 1 [count_message_lines $server_path/stdout "appendonly.aof.1.incr.aof .*No such file or directory"]
         }
 
         clean_aof_persistence $aof_dirpath
@@ -584,7 +584,7 @@ tags {"external:skip"} {
                 fail "AOF loading didn't fail"
             }
 
-            assert_equal 1 [count_message_lines $server_path/stdout "appendonly.aof.*No such file or directory"]
+            assert_equal 1 [count_message_lines $server_path/stdout "appendonly.aof .*No such file or directory"]
         }
 
         clean_aof_persistence $aof_dirpath

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -45,7 +45,7 @@ tags {"external:skip"} {
                 fail "AOF loading didn't fail"
             }
 
-            assert_equal 1 [count_message_lines $server_path/stdout "appendonly.aof.1.incr.aof doesn't exist"]
+            assert_equal 1 [count_message_lines $server_path/stdout "appendonly.aof.1.incr.aof.*No such file or directory"]
         }
 
         clean_aof_persistence $aof_dirpath
@@ -584,7 +584,7 @@ tags {"external:skip"} {
                 fail "AOF loading didn't fail"
             }
 
-            assert_equal 1 [count_message_lines $server_path/stdout "appendonly.aof doesn't exist"]
+            assert_equal 1 [count_message_lines $server_path/stdout "appendonly.aof.*No such file or directory"]
         }
 
         clean_aof_persistence $aof_dirpath


### PR DESCRIPTION
Make sure the status return from loading multiple AOF files reflects the overall
result, not just the one of the last file.

When one of the AOF files succeeded to load, but the last AOF file
was empty, the loadAppendOnlyFiles will return AOF_EMPTY.
This commit changes this behavior, and return AOF_OK in that case.

This can happen for example, when loading old AOF file, and no more commands processed,
the manifest file will include base AOF file with data, and empty incr AOF file.