### PR TITLE
Add bus_port argument in cluster-meet.json

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -452,7 +452,10 @@ NULL
 /********** CLUSTER MEET ********************/
 
 /* CLUSTER MEET history */
-#define CLUSTER_MEET_History NULL
+commandHistory CLUSTER_MEET_History[] = {
+{"4.0.0","Added the optional `bus_port` argument."},
+{0}
+};
 
 /* CLUSTER MEET tips */
 const char *CLUSTER_MEET_tips[] = {
@@ -464,6 +467,7 @@ NULL
 struct redisCommandArg CLUSTER_MEET_Args[] = {
 {"ip",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"port",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"bus_port",ARG_TYPE_INTEGER,-1,NULL,NULL,"4.0.0",CMD_ARG_OPTIONAL},
 {0}
 };
 

--- a/src/commands/cluster-meet.json
+++ b/src/commands/cluster-meet.json
@@ -10,7 +10,7 @@
         "history": [
             [
                 "4.0.0",
-                "Added the optional `bus_port` argument."
+                "Added the optional `cluster_bus_port` argument."
             ]
         ],
         "command_flags": [
@@ -31,7 +31,7 @@
                 "type": "integer"
             },
             {
-                "name": "bus_port",
+                "name": "cluster_bus_port",
                 "type": "integer",
                 "optional": true,
                 "since": "4.0.0"

--- a/src/commands/cluster-meet.json
+++ b/src/commands/cluster-meet.json
@@ -7,6 +7,12 @@
         "arity": -4,
         "container": "CLUSTER",
         "function": "clusterCommand",
+        "history": [
+            [
+                "4.0.0",
+                "Added the optional `bus_port` argument."
+            ]
+        ],
         "command_flags": [
             "NO_ASYNC_LOADING",
             "ADMIN",
@@ -23,6 +29,12 @@
             {
                 "name": "port",
                 "type": "integer"
+            },
+            {
+                "name": "bus_port",
+                "type": "integer",
+                "optional": true,
+                "since": "4.0.0"
             }
         ]
     }


### PR DESCRIPTION
I see that the `bus-port` parameter is listed in cluster help, but not documented in redis-doc
https://github.com/redis/redis/blob/3881f7850f9f81720315bd4f33f2f9dedcc242bb/src/cluster.c#L5022-L5023

In `CLUSTER MEET`, bus-port argument was added in 11436b1.
For cluster announce ip / port implementation, part of the
4.0-RC1.

And in #9389, we add a new cluster-port config and make
cluster bus port configurable, part of the 7.0-RC1.