### PR TITLE
Add a Config Change Event for Redis Modules

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -709,6 +709,7 @@ void configSetCommand(client *c) {
     const char *invalid_arg_name = NULL;
     const char *err_arg_name = NULL;
     standardConfig **set_configs; /* TODO: make this a dict for better performance */
+    const char **config_names;
     sds *new_values;
     sds *old_values = NULL;
     apply_fn *apply_fns; /* TODO: make this a set for better performance */
@@ -724,6 +725,7 @@ void configSetCommand(client *c) {
     config_count = (c->argc - 2) / 2;
 
     set_configs = zcalloc(sizeof(standardConfig*)*config_count);
+    config_names = zcalloc(sizeof(char*)*config_count);
     new_values = zmalloc(sizeof(sds*)*config_count);
     old_values = zcalloc(sizeof(sds*)*config_count);
     apply_fns = zcalloc(sizeof(apply_fn)*config_count);
@@ -779,6 +781,7 @@ void configSetCommand(client *c) {
             }
         }
         set_configs[i] = config;
+        config_names[i] = config->name;
         new_values[i] = c->argv[2+i*2+1]->ptr;
     }
     
@@ -824,7 +827,8 @@ void configSetCommand(client *c) {
             goto err;
         }
     }
-    moduleFireServerEvent(REDISMODULE_EVENT_CONFIG_CHANGE, 0, NULL);
+    RedisModuleConfigChangeV1 cc = {.num_changes = config_count, .config_names = config_names};
+    moduleFireServerEvent(REDISMODULE_EVENT_CONFIG_CHANGE, 0, &cc);
     addReply(c,shared.ok);
     goto end;
 
@@ -841,6 +845,7 @@ err:
     }
 end:
     zfree(set_configs);
+    zfree(config_names);
     zfree(new_values);
     for (i = 0; i < config_count; i++)
         sdsfree(old_values[i]);

--- a/src/config.c
+++ b/src/config.c
@@ -828,7 +828,7 @@ void configSetCommand(client *c) {
         }
     }
     RedisModuleConfigChangeV1 cc = {.num_changes = config_count, .config_names = config_names};
-    moduleFireServerEvent(REDISMODULE_EVENT_CONFIG_CHANGE, 0, &cc);
+    moduleFireServerEvent(REDISMODULE_EVENT_CONFIG, REDISMODULE_SUBEVENT_CONFIG_CHANGE, &cc);
     addReply(c,shared.ok);
     goto end;
 

--- a/src/config.c
+++ b/src/config.c
@@ -824,6 +824,7 @@ void configSetCommand(client *c) {
             goto err;
         }
     }
+    moduleFireServerEvent(REDISMODULE_EVENT_CONFIG_CHANGE, 0, NULL);
     addReply(c,shared.ok);
     goto end;
 

--- a/src/module.c
+++ b/src/module.c
@@ -9976,7 +9976,7 @@ static uint64_t moduleEventVersions[] = {
     -1, /* REDISMODULE_EVENT_FORK_CHILD */
     -1, /* REDISMODULE_EVENT_REPL_ASYNC_LOAD */
     -1, /* REDISMODULE_EVENT_EVENTLOOP */
-    -1, /* REDISMODULE_EVENT_CONFOG_CHANGE */
+    -1, /* REDISMODULE_EVENT_CONFIG */
 };
 
 /* Register to be notified, via a callback, when the specified server event
@@ -10314,6 +10314,8 @@ int RM_IsSubEventSupported(RedisModuleEvent event, int64_t subevent) {
         return subevent < _REDISMODULE_SUBEVENT_FORK_CHILD_NEXT;
     case REDISMODULE_EVENT_EVENTLOOP:
         return subevent < _REDISMODULE_SUBEVENT_EVENTLOOP_NEXT;
+    case REDISMODULE_EVENT_CONFIG:
+        return subevent < _REDISMODULE_SUBEVENT_CONFIG_NEXT; 
     default:
         break;
     }

--- a/src/module.c
+++ b/src/module.c
@@ -10237,6 +10237,13 @@ static uint64_t moduleEventVersions[] = {
  *     * `REDISMODULE_SUBEVENT_EVENTLOOP_BEFORE_SLEEP`
  *     * `REDISMODULE_SUBEVENT_EVENTLOOP_AFTER_SLEEP`
  *
+ * * RedisModule_Event_Config
+ *
+ *     Called when a configuration event happens
+ *     The following sub events are available:
+ *
+ *     * `REDISMODULE_SUBEVENT_CONFIG_CHANGE`
+ *
  * The function returns REDISMODULE_OK if the module was successfully subscribed
  * for the specified event. If the API is called from a wrong context or unsupported event
  * is given then REDISMODULE_ERR is returned. */

--- a/src/module.c
+++ b/src/module.c
@@ -10390,6 +10390,8 @@ void moduleFireServerEvent(uint64_t eid, int subid, void *data) {
                 moduledata = data;
             } else if (eid == REDISMODULE_EVENT_SWAPDB) {
                 moduledata = data;
+            } else if (eid == REDISMODULE_EVENT_CONFIG_CHANGE) {
+                moduledata = data;
             }
 
             el->module->in_hook++;

--- a/src/module.c
+++ b/src/module.c
@@ -10244,6 +10244,13 @@ static uint64_t moduleEventVersions[] = {
  *
  *     * `REDISMODULE_SUBEVENT_CONFIG_CHANGE`
  *
+ *     The data pointer can be casted to a RedisModuleConfigChange
+ *     structure with the following fields:
+ *
+ *         const char **config_names; // An array of C string pointers containing the
+ *                                    // name of each modified configuration item 
+ *         uint32_t num_changes;      // The number of elements in the config_names array
+ *
  * The function returns REDISMODULE_OK if the module was successfully subscribed
  * for the specified event. If the API is called from a wrong context or unsupported event
  * is given then REDISMODULE_ERR is returned. */

--- a/src/module.c
+++ b/src/module.c
@@ -9976,6 +9976,7 @@ static uint64_t moduleEventVersions[] = {
     -1, /* REDISMODULE_EVENT_FORK_CHILD */
     -1, /* REDISMODULE_EVENT_REPL_ASYNC_LOAD */
     -1, /* REDISMODULE_EVENT_EVENTLOOP */
+    -1, /* REDISMODULE_EVENT_CONFOG_CHANGE */
 };
 
 /* Register to be notified, via a callback, when the specified server event

--- a/src/module.c
+++ b/src/module.c
@@ -10390,7 +10390,7 @@ void moduleFireServerEvent(uint64_t eid, int subid, void *data) {
                 moduledata = data;
             } else if (eid == REDISMODULE_EVENT_SWAPDB) {
                 moduledata = data;
-            } else if (eid == REDISMODULE_EVENT_CONFIG_CHANGE) {
+            } else if (eid == REDISMODULE_EVENT_CONFIG) {
                 moduledata = data;
             }
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -677,6 +677,15 @@ typedef struct RedisModuleModuleChange {
     int32_t module_version; /* Module version. */
 } RedisModuleModuleChangeV1;
 
+#define REDISMODULE_CONFIGCHANGE_VERSION 1
+typedef struct RedisModuleConfigChange {
+    uint64_t version;       /* Not used since this structure is never passed
+                               from the module to the core right now. Here
+                               for future compatibility. */
+    uint32_t num_changes;   /* how many redis config options where changed */
+    const char **config_names; /* the config names that were changed */
+} RedisModuleConfigChangeV1;
+
 #define RedisModuleModuleChange RedisModuleModuleChangeV1
 
 #define REDISMODULE_CRON_LOOP_VERSION 1

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -429,7 +429,8 @@ typedef void (*RedisModuleEventLoopOneShotFunc)(void *user_data);
 #define REDISMODULE_EVENT_FORK_CHILD 13
 #define REDISMODULE_EVENT_REPL_ASYNC_LOAD 14
 #define REDISMODULE_EVENT_EVENTLOOP 15
-#define _REDISMODULE_EVENT_NEXT 16 /* Next event flag, should be updated if a new event added. */
+#define REDISMODULE_EVENT_CONFIG_CHANGE 16
+#define _REDISMODULE_EVENT_NEXT 17 /* Next event flag, should be updated if a new event added. */
 
 typedef struct RedisModuleEvent {
     uint64_t id;        /* REDISMODULE_EVENT_... defines. */
@@ -532,7 +533,11 @@ static const RedisModuleEvent
     RedisModuleEvent_EventLoop = {
         REDISMODULE_EVENT_EVENTLOOP,
         1
-};
+    },
+    RedisModuleEvent_ConfigChange = {
+	REDISMODULE_EVENT_CONFIG_CHANGE,
+	1
+    };
 
 /* Those are values that are used for the 'subevent' callback argument. */
 #define REDISMODULE_SUBEVENT_PERSISTENCE_RDB_START 0

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -535,8 +535,8 @@ static const RedisModuleEvent
         1
     },
     RedisModuleEvent_Config = {
-	REDISMODULE_EVENT_CONFIG,
-	1
+        REDISMODULE_EVENT_CONFIG,
+        1
     };
 
 /* Those are values that are used for the 'subevent' callback argument. */
@@ -580,6 +580,7 @@ static const RedisModuleEvent
 #define _REDISMODULE_SUBEVENT_MODULE_NEXT 2
 
 #define REDISMODULE_SUBEVENT_CONFIG_CHANGE 0
+#define _REDISMODULE_SUBEVENT_CONFIG_NEXT 1
 
 #define REDISMODULE_SUBEVENT_LOADING_PROGRESS_RDB 0
 #define REDISMODULE_SUBEVENT_LOADING_PROGRESS_AOF 1
@@ -686,7 +687,7 @@ typedef struct RedisModuleConfigChange {
     uint64_t version;       /* Not used since this structure is never passed
                                from the module to the core right now. Here
                                for future compatibility. */
-    uint32_t num_changes;   /* how many redis config options where changed */
+    uint32_t num_changes;   /* how many redis config options were changed */
     const char **config_names; /* the config names that were changed */
 } RedisModuleConfigChangeV1;
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -429,7 +429,7 @@ typedef void (*RedisModuleEventLoopOneShotFunc)(void *user_data);
 #define REDISMODULE_EVENT_FORK_CHILD 13
 #define REDISMODULE_EVENT_REPL_ASYNC_LOAD 14
 #define REDISMODULE_EVENT_EVENTLOOP 15
-#define REDISMODULE_EVENT_CONFIG_CHANGE 16
+#define REDISMODULE_EVENT_CONFIG 16
 #define _REDISMODULE_EVENT_NEXT 17 /* Next event flag, should be updated if a new event added. */
 
 typedef struct RedisModuleEvent {
@@ -534,8 +534,8 @@ static const RedisModuleEvent
         REDISMODULE_EVENT_EVENTLOOP,
         1
     },
-    RedisModuleEvent_ConfigChange = {
-	REDISMODULE_EVENT_CONFIG_CHANGE,
+    RedisModuleEvent_Config = {
+	REDISMODULE_EVENT_CONFIG,
 	1
     };
 
@@ -578,6 +578,8 @@ static const RedisModuleEvent
 #define REDISMODULE_SUBEVENT_MODULE_LOADED 0
 #define REDISMODULE_SUBEVENT_MODULE_UNLOADED 1
 #define _REDISMODULE_SUBEVENT_MODULE_NEXT 2
+
+#define REDISMODULE_SUBEVENT_CONFIG_CHANGE 0
 
 #define REDISMODULE_SUBEVENT_LOADING_PROGRESS_RDB 0
 #define REDISMODULE_SUBEVENT_LOADING_PROGRESS_AOF 1
@@ -677,6 +679,8 @@ typedef struct RedisModuleModuleChange {
     int32_t module_version; /* Module version. */
 } RedisModuleModuleChangeV1;
 
+#define RedisModuleModuleChange RedisModuleModuleChangeV1
+
 #define REDISMODULE_CONFIGCHANGE_VERSION 1
 typedef struct RedisModuleConfigChange {
     uint64_t version;       /* Not used since this structure is never passed
@@ -686,7 +690,7 @@ typedef struct RedisModuleConfigChange {
     const char **config_names; /* the config names that were changed */
 } RedisModuleConfigChangeV1;
 
-#define RedisModuleModuleChange RedisModuleModuleChangeV1
+#define RedisModuleConfigChange RedisModuleConfigChangeV1
 
 #define REDISMODULE_CRON_LOOP_VERSION 1
 typedef struct RedisModuleCronLoopInfo {

--- a/tests/modules/hooks.c
+++ b/tests/modules/hooks.c
@@ -267,6 +267,12 @@ void swapDbCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub, void 
     LogNumericEvent(ctx, "swapdb-second", ei->dbnum_second);
 }
 
+void configChangeCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub, void *data)
+{
+    REDISMODULE_NOT_USED(e);
+    LogStringEvent(ctx, "config-change", "config-change");
+}
+
 /* This function must be present on each Redis module. It is used in order to
  * register the commands into the Redis server. */
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -316,6 +322,9 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         RedisModuleEvent_ModuleChange, moduleChangeCallback);
     RedisModule_SubscribeToServerEvent(ctx,
         RedisModuleEvent_SwapDB, swapDbCallback);
+
+    RedisModule_SubscribeToServerEvent(ctx,
+        RedisModuleEvent_ConfigChange, configChangeCallback);
 
     event_log = RedisModule_CreateDict(ctx);
 

--- a/tests/modules/hooks.c
+++ b/tests/modules/hooks.c
@@ -270,7 +270,9 @@ void swapDbCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub, void 
 void configChangeCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub, void *data)
 {
     REDISMODULE_NOT_USED(e);
-    REDISMODULE_NOT_USED(sub);
+    if (sub != REDISMODULE_SUBEVENT_CONFIG_CHANGE) {
+        return;
+    }
 
     RedisModuleConfigChangeV1 *ei = data;
     LogNumericEvent(ctx, "config-change-count", ei->num_changes);
@@ -328,7 +330,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         RedisModuleEvent_SwapDB, swapDbCallback);
 
     RedisModule_SubscribeToServerEvent(ctx,
-        RedisModuleEvent_ConfigChange, configChangeCallback);
+        RedisModuleEvent_Config, configChangeCallback);
 
     event_log = RedisModule_CreateDict(ctx);
 

--- a/tests/modules/hooks.c
+++ b/tests/modules/hooks.c
@@ -270,7 +270,11 @@ void swapDbCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub, void 
 void configChangeCallback(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub, void *data)
 {
     REDISMODULE_NOT_USED(e);
-    LogStringEvent(ctx, "config-change", "config-change");
+    REDISMODULE_NOT_USED(sub);
+
+    RedisModuleConfigChangeV1 *ei = data;
+    LogNumericEvent(ctx, "config-change-count", ei->num_changes);
+    LogStringEvent(ctx, "config-change-first", ei->config_names[0]);
 }
 
 /* This function must be present on each Redis module. It is used in order to

--- a/tests/unit/moduleapi/hooks.tcl
+++ b/tests/unit/moduleapi/hooks.tcl
@@ -150,13 +150,16 @@ tags "modules" {
             r swapdb 0 10
             assert_equal [r hooks.event_last swapdb-first] 0
             assert_equal [r hooks.event_last swapdb-second] 10
+        }
 
+	test {Test configchange hooks} {
+	    r config set rdbcompression no 
+	    assert_equal [r hooks.event_last config-change] "config-change"
         }
 
         # look into the log file of the server that just exited
         test {Test shutdown hook} {
             assert_equal [string match {*module-event-shutdown*} [exec tail -5 < $replica_stdout]] 1
         }
-
     }
 }

--- a/tests/unit/moduleapi/hooks.tcl
+++ b/tests/unit/moduleapi/hooks.tcl
@@ -154,7 +154,8 @@ tags "modules" {
 
 	test {Test configchange hooks} {
 	    r config set rdbcompression no 
-	    assert_equal [r hooks.event_last config-change] "config-change"
+	    assert_equal [r hooks.event_last config-change-count] 1
+	    assert_equal [r hooks.event_last config-change-first] rdbcompression
         }
 
         # look into the log file of the server that just exited

--- a/tests/unit/moduleapi/hooks.tcl
+++ b/tests/unit/moduleapi/hooks.tcl
@@ -152,10 +152,10 @@ tags "modules" {
             assert_equal [r hooks.event_last swapdb-second] 10
         }
 
-	test {Test configchange hooks} {
-	    r config set rdbcompression no 
-	    assert_equal [r hooks.event_last config-change-count] 1
-	    assert_equal [r hooks.event_last config-change-first] rdbcompression
+        test {Test configchange hooks} {
+            r config set rdbcompression no 
+            assert_equal [r hooks.event_last config-change-count] 1
+            assert_equal [r hooks.event_last config-change-first] rdbcompression
         }
 
         # look into the log file of the server that just exited


### PR DESCRIPTION
Adds a simple event that is triggered anytime a config change occurs.

Provides a module unit test to ensure its being triggered