### PR TITLE
Show publishshard_sent stat in cluster info

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1680,7 +1680,7 @@ aof-timestamp-enabled no
 # routing. By default this value is only shown as additional metadata in the CLUSTER SLOTS
 # command, but can be changed using 'cluster-preferred-endpoint-type' config. This value is 
 # communicated along the clusterbus to all nodes, setting it to an empty string will remove 
-# the hostname and also propgate the removal. 
+# the hostname and also propagate the removal.
 #
 # cluster-announce-hostname ""
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2567,7 +2567,7 @@ void clusterWriteHandler(connection *conn) {
 
     nwritten = connWrite(conn, link->sndbuf, sdslen(link->sndbuf));
     if (nwritten <= 0) {
-        serverLog(LL_WARNING, "I/O error writing to node link: %s",
+        serverLog(LL_DEBUG, "I/O error writing to node link: %s",
             (nwritten == -1) ? connGetLastError(conn) : "short write");
         handleLinkIOError(link);
         return;
@@ -2586,7 +2586,7 @@ void clusterLinkConnectHandler(connection *conn) {
 
     /* Check if connection succeeded */
     if (connGetState(conn) != CONN_STATE_CONNECTED) {
-        serverLog(LL_WARNING, "Connection with Node %.40s at %s:%d failed: %s",
+        serverLog(LL_VERBOSE, "Connection with Node %.40s at %s:%d failed: %s",
                 node->name, node->ip, node->cport,
                 connGetLastError(conn));
         freeClusterLink(link);
@@ -2663,7 +2663,7 @@ void clusterReadHandler(connection *conn) {
 
         if (nread <= 0) {
             /* I/O error... */
-            serverLog(LL_WARNING, "I/O error reading from node link: %s",
+            serverLog(LL_DEBUG,"I/O error reading from node link: %s",
                 (nread == 0) ? "connection closed" : connGetLastError(conn));
             handleLinkIOError(link);
             return;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -106,7 +106,7 @@ dictType clusterNodesDictType = {
 };
 
 /* Cluster re-addition blacklist. This maps node IDs to the time
- * we can re-add this node. The goal is to avoid readding a removed
+ * we can re-add this node. The goal is to avoid reading a removed
  * node for some time. */
 dictType clusterNodesBlackListDictType = {
         dictSdsCaseHash,            /* hash function */
@@ -2567,7 +2567,7 @@ void clusterWriteHandler(connection *conn) {
 
     nwritten = connWrite(conn, link->sndbuf, sdslen(link->sndbuf));
     if (nwritten <= 0) {
-        serverLog(LL_DEBUG,"I/O error writing to node link: %s",
+        serverLog(LL_WARNING, "I/O error writing to node link: %s",
             (nwritten == -1) ? connGetLastError(conn) : "short write");
         handleLinkIOError(link);
         return;
@@ -2586,7 +2586,7 @@ void clusterLinkConnectHandler(connection *conn) {
 
     /* Check if connection succeeded */
     if (connGetState(conn) != CONN_STATE_CONNECTED) {
-        serverLog(LL_VERBOSE, "Connection with Node %.40s at %s:%d failed: %s",
+        serverLog(LL_WARNING, "Connection with Node %.40s at %s:%d failed: %s",
                 node->name, node->ip, node->cport,
                 connGetLastError(conn));
         freeClusterLink(link);
@@ -2663,7 +2663,7 @@ void clusterReadHandler(connection *conn) {
 
         if (nread <= 0) {
             /* I/O error... */
-            serverLog(LL_DEBUG,"I/O error reading from node link: %s",
+            serverLog(LL_WARNING, "I/O error reading from node link: %s",
                 (nread == 0) ? "connection closed" : connGetLastError(conn));
             handleLinkIOError(link);
             return;
@@ -5283,7 +5283,7 @@ NULL
         addReplySds(c,reply);
     } else if (!strcasecmp(c->argv[1]->ptr,"info") && c->argc == 2) {
         /* CLUSTER INFO */
-        char *statestr[] = {"ok","fail","needhelp"};
+        char *statestr[] = {"ok","fail"};
         int slots_assigned = 0, slots_ok = 0, slots_pfail = 0, slots_fail = 0;
         uint64_t myepoch;
         int j;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2567,7 +2567,7 @@ void clusterWriteHandler(connection *conn) {
 
     nwritten = connWrite(conn, link->sndbuf, sdslen(link->sndbuf));
     if (nwritten <= 0) {
-        serverLog(LL_DEBUG, "I/O error writing to node link: %s",
+        serverLog(LL_DEBUG,"I/O error writing to node link: %s",
             (nwritten == -1) ? connGetLastError(conn) : "short write");
         handleLinkIOError(link);
         return;

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -96,8 +96,8 @@ typedef struct clusterLink {
 #define CLUSTERMSG_TYPE_UPDATE 7        /* Another node slots configuration */
 #define CLUSTERMSG_TYPE_MFSTART 8       /* Pause clients for manual failover */
 #define CLUSTERMSG_TYPE_MODULE 9        /* Module cluster API message. */
-#define CLUSTERMSG_TYPE_COUNT 10        /* Total number of message types. */
-#define CLUSTERMSG_TYPE_PUBLISHSHARD 11 /* Pub/Sub Publish shard propagation */
+#define CLUSTERMSG_TYPE_PUBLISHSHARD 10 /* Pub/Sub Publish shard propagation */
+#define CLUSTERMSG_TYPE_COUNT 11        /* Total number of message types. */
 
 /* Flags that a module can set in order to prevent certain Redis Cluster
  * features to be enabled. Useful when implementing a different distributed


### PR DESCRIPTION
publishshard was added in #8621 (7.0 RC1), but the publishshard_sent
stat is not shown in CLUSTER INFO command.

Other changes:
1. Remove useless `needhelp` statements, it was removed in 3dad819.
2. Fix typos that saw by the way.