### PR TITLE
Fix (?) sentinel test issue with sanitizer.

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1190,11 +1190,11 @@ int sentinelUpdateSentinelAddressInAllMasters(sentinelRedisInstance *ri) {
         if (match->link->pc != NULL)
             instanceLinkCloseConnection(match->link,match->link->pc);
 
+        if (match == ri) continue; /* Address already updated for it. */
+
         /* Remove any sentinel with port number set to 0 */
         if (match->addr->port == 0)
             dictDelete(master->sentinels,match->name);
-
-        if (match == ri) continue; /* Address already updated for it. */
 
         /* Update the address of the matching Sentinel by copying the address
          * of the Sentinel object that received the address update. */


### PR DESCRIPTION
Running sentinel tests on macOS with address sanitizer results with the
error below.

```
=================================================================
==26381==ERROR: AddressSanitizer: heap-use-after-free on address 0x61300000cd10 at pc 0x00010f90c934 bp 0x7ffee04eb070 sp 0x7ffee04eb068
READ of size 8 at 0x61300000cd10 thread T0
    #0 0x10f90c933 in sentinelUpdateSentinelAddressInAllMasters sentinel.c:1182
    #1 0x10f91a50b in sentinelProcessHelloMessage sentinel.c:2883
    #2 0x10f925038 in sentinelPublishCommand sentinel.c:4384
    #3 0x10f7460c3 in call server.c:3156
    #4 0x10f749a80 in processCommand server.c:3756
    #5 0x10f7af057 in processInputBuffer networking.c:2380
    #6 0x10f7944ce in readQueryFromClient networking.c:2492
    #7 0x10f9e5e35 in connSocketEventHandler connection.c:295
    #8 0x10f723868 in aeProcessEvents ae.c:436
    #9 0x10f7245bc in aeMain ae.c:496
    #10 0x10f75e2ce in main server.c:6906
    #11 0x7fff20954f3c in start+0x0 (libdyld.dylib:x86_64+0x15f3c)

0x61300000cd10 is located 16 bytes inside of 344-byte region [0x61300000cd00,0x61300000ce58)
freed by thread T0 here:
    #0 0x10ffcc4e9 in wrap_free+0xa9 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x444e9)
    #1 0x10f72a9b4 in dictGenericDelete dict.c:421
    #2 0x10f72a4aa in dictDelete dict.c:437
    #3 0x10f90c6af in sentinelUpdateSentinelAddressInAllMasters sentinel.c:1195
    #4 0x10f91a50b in sentinelProcessHelloMessage sentinel.c:2883
    #5 0x10f925038 in sentinelPublishCommand sentinel.c:4384
    #6 0x10f7460c3 in call server.c:3156
    #7 0x10f749a80 in processCommand server.c:3756
    #8 0x10f7af057 in processInputBuffer networking.c:2380
    #9 0x10f7944ce in readQueryFromClient networking.c:2492
    #10 0x10f9e5e35 in connSocketEventHandler connection.c:295
    #11 0x10f723868 in aeProcessEvents ae.c:436
    #12 0x10f7245bc in aeMain ae.c:496
    #13 0x10f75e2ce in main server.c:6906
    #14 0x7fff20954f3c in start+0x0 (libdyld.dylib:x86_64+0x15f3c)

previously allocated by thread T0 here:
    #0 0x10ffcc3a0 in wrap_malloc+0xa0 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x443a0)
    #1 0x10f770f6a in zmalloc zmalloc.c:126
    #2 0x10f90cf0b in createSentinelRedisInstance sentinel.c:1301
    #3 0x10f91a56e in sentinelProcessHelloMessage sentinel.c:2888
    #4 0x10fa088c0 in redisProcessCallbacks async.c:572
    #5 0x10f723868 in aeProcessEvents ae.c:436
    #6 0x10f7245bc in aeMain ae.c:496
    #7 0x10f75e2ce in main server.c:6906
    #8 0x7fff20954f3c in start+0x0 (libdyld.dylib:x86_64+0x15f3c)
```