### PR TITLE
Sentinel: fix a free-after-use issue re-registering Sentinels.

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2880,13 +2880,16 @@ void sentinelProcessHelloMessage(char *hello, int hello_len) {
                     dictIterator *di;
                     dictEntry *de;
 
+                    /* Keep a copy of runid. 'other' about to be deleted in loop. */
+                    sds runid_obsolete = sdsnew(other->runid);
+
                     di = dictGetIterator(sentinel.masters);
                     while((de = dictNext(di)) != NULL) {
                         sentinelRedisInstance *master = dictGetVal(de);
-                        removeMatchingSentinelFromMaster(master, other->runid);
+                        removeMatchingSentinelFromMaster(master, runid_obsolete);
                     }
                     dictReleaseIterator(di);
-
+                    sdsfree(runid_obsolete);
                 }
             }
 


### PR DESCRIPTION
In case HELLO message received from another sentinel, with same address like another instance registered in the past but with different runid. Then there was cumbersome logic to modify the instance the port to 0 to in order to mark as invalid and later on to delete it. But the deletion is happening during update of instances in such a way that we might end up accessing an instance that was deleted just before.

Didn't find a good reason why to postpone the deletion action of an obsolete instance (deletion is taking place instantly, for other cases ) -> Lets delete at once
There is a mixture of logic of Sentinel address update with the logic of deletion of Sentinels that match a given Address -> Split to two!