### PR TITLE
Optimize deferred replies to use shared objects instead of sprintf

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -718,7 +718,7 @@ void setDeferredAggregateLen(client *c, void *node, long length, char prefix) {
      * so we have a few shared objects to use if the integer is small
      * like it is most of the times. */
     if (prefix == '*' && length < OBJ_SHARED_BULKHDR_LEN) {
-        setDeferredReply(c, node, shared.mbulkhdr[length]->ptr, (length < 10) ? 4 : 5);
+        setDeferredReply(c, node, shared.mbulkhdr[length]->ptr, sdslen(shared.mbulkhdr[length]->ptr));
         return;
     }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -714,6 +714,14 @@ void setDeferredAggregateLen(client *c, void *node, long length, char prefix) {
      * we return NULL in addReplyDeferredLen() */
     if (node == NULL) return;
 
+    /* Things like *2\r\n or *3\r\n are emitted very often by the protocol
+     * so we have a few shared objects to use if the integer is small
+     * like it is most of the times. */
+    if (prefix == '*' && length < OBJ_SHARED_BULKHDR_LEN) {
+        setDeferredReply(c, node, shared.mbulkhdr[length]->ptr, (length < 10) ? 4 : 5);
+        return;
+    }
+
     char lenstr[128];
     size_t lenstr_len = sprintf(lenstr, "%c%ld\r\n", prefix, length);
     setDeferredReply(c, node, lenstr, lenstr_len);

--- a/src/networking.c
+++ b/src/networking.c
@@ -717,7 +717,7 @@ void setDeferredAggregateLen(client *c, void *node, long length, char prefix) {
     /* Things like *2\r\n, %3\r\n or ~4\r\n are emitted very often by the protocol
      * so we have a few shared objects to use if the integer is small
      * like it is most of the times. */
-    const size_t hdr_len = length < 10 ? 4 : 5;
+    const size_t hdr_len = OBJ_SHARED_HDR_STRLEN(length);
     const int opt_hdr = length < OBJ_SHARED_BULKHDR_LEN;
     if (prefix == '*' && opt_hdr) {
         setDeferredReply(c, node, shared.mbulkhdr[length]->ptr, hdr_len);

--- a/src/networking.c
+++ b/src/networking.c
@@ -721,10 +721,10 @@ void setDeferredAggregateLen(client *c, void *node, long length, char prefix) {
         setDeferredReply(c, node, shared.mbulkhdr[length]->ptr, sdslen(shared.mbulkhdr[length]->ptr));
         return;
     } else if (prefix == '%' && length < OBJ_SHARED_BULKHDR_LEN) {
-        setDeferredReply(c, node, shared.maphdr[length]->ptr, (length < 10) ? 4 : 5);
+        setDeferredReply(c, node, shared.maphdr[length]->ptr, sdslen(shared.maphdr[length]->ptr));
         return;
     } else if (prefix == '~' && length < OBJ_SHARED_BULKHDR_LEN) {
-        setDeferredReply(c, node, shared.sethdr[length]->ptr, (length < 10) ? 4 : 5);
+        setDeferredReply(c, node, shared.sethdr[length]->ptr, sdslen(shared.sethdr[length]->ptr));
         return;
     }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -717,14 +717,18 @@ void setDeferredAggregateLen(client *c, void *node, long length, char prefix) {
     /* Things like *2\r\n, %3\r\n or ~4\r\n are emitted very often by the protocol
      * so we have a few shared objects to use if the integer is small
      * like it is most of the times. */
-    if (prefix == '*' && length < OBJ_SHARED_BULKHDR_LEN) {
-        setDeferredReply(c, node, shared.mbulkhdr[length]->ptr, sdslen(shared.mbulkhdr[length]->ptr));
+    const size_t hdr_len = length < 10 ? 4 : 5;
+    const int opt_hdr = length < OBJ_SHARED_BULKHDR_LEN;
+    if (prefix == '*' && opt_hdr) {
+        setDeferredReply(c, node, shared.mbulkhdr[length]->ptr, hdr_len);
         return;
-    } else if (prefix == '%' && length < OBJ_SHARED_BULKHDR_LEN) {
-        setDeferredReply(c, node, shared.maphdr[length]->ptr, sdslen(shared.maphdr[length]->ptr));
+    }
+    if (prefix == '%' && opt_hdr) {
+        setDeferredReply(c, node, shared.maphdr[length]->ptr, hdr_len);
         return;
-    } else if (prefix == '~' && length < OBJ_SHARED_BULKHDR_LEN) {
-        setDeferredReply(c, node, shared.sethdr[length]->ptr, sdslen(shared.sethdr[length]->ptr));
+    }
+    if (prefix == '~' && opt_hdr) {
+        setDeferredReply(c, node, shared.sethdr[length]->ptr, hdr_len);
         return;
     }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -714,11 +714,17 @@ void setDeferredAggregateLen(client *c, void *node, long length, char prefix) {
      * we return NULL in addReplyDeferredLen() */
     if (node == NULL) return;
 
-    /* Things like *2\r\n or *3\r\n are emitted very often by the protocol
+    /* Things like *2\r\n, %3\r\n or ~4\r\n are emitted very often by the protocol
      * so we have a few shared objects to use if the integer is small
      * like it is most of the times. */
     if (prefix == '*' && length < OBJ_SHARED_BULKHDR_LEN) {
         setDeferredReply(c, node, shared.mbulkhdr[length]->ptr, (length < 10) ? 4 : 5);
+        return;
+    } else if (prefix == '%' && length < OBJ_SHARED_BULKHDR_LEN) {
+        setDeferredReply(c, node, shared.maphdr[length]->ptr, (length < 10) ? 4 : 5);
+        return;
+    } else if (prefix == '~' && length < OBJ_SHARED_BULKHDR_LEN) {
+        setDeferredReply(c, node, shared.sethdr[length]->ptr, (length < 10) ? 4 : 5);
         return;
     }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -824,11 +824,18 @@ void addReplyLongLongWithPrefix(client *c, long long ll, char prefix) {
     /* Things like $3\r\n or *2\r\n are emitted very often by the protocol
      * so we have a few shared objects to use if the integer is small
      * like it is most of the times. */
-    if (prefix == '*' && ll < OBJ_SHARED_BULKHDR_LEN && ll >= 0) {
+    const int opt_hdr = ll < OBJ_SHARED_BULKHDR_LEN && ll >= 0;
+    if (prefix == '*' && opt_hdr) {
         addReply(c,shared.mbulkhdr[ll]);
         return;
-    } else if (prefix == '$' && ll < OBJ_SHARED_BULKHDR_LEN && ll >= 0) {
+    } else if (prefix == '$' && opt_hdr) {
         addReply(c,shared.bulkhdr[ll]);
+        return;
+    } else if (prefix == '%' && opt_hdr) {
+        addReply(c,shared.maphdr[ll]);
+        return;
+    } else if (prefix == '~' && opt_hdr) {
+        addReply(c,shared.sethdr[ll]);
         return;
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -1790,6 +1790,10 @@ void createSharedObjects(void) {
             sdscatprintf(sdsempty(),"*%d\r\n",j));
         shared.bulkhdr[j] = createObject(OBJ_STRING,
             sdscatprintf(sdsempty(),"$%d\r\n",j));
+        shared.maphdr[j] = createObject(OBJ_STRING,
+            sdscatprintf(sdsempty(),"%%%d\r\n",j));
+        shared.sethdr[j] = createObject(OBJ_STRING,
+            sdscatprintf(sdsempty(),"~%d\r\n",j));
     }
     /* The following two shared objects, minstring and maxstring, are not
      * actually used for their value but as a special object meaning

--- a/src/server.h
+++ b/src/server.h
@@ -109,7 +109,7 @@ typedef long long ustime_t; /* microsecond time type. */
 #define PROTO_SHARED_SELECT_CMDS 10
 #define OBJ_SHARED_INTEGERS 10000
 #define OBJ_SHARED_BULKHDR_LEN 32
-#define OBJ_SHARED_HDR_STRLEN(_len_) ((_len_ < 10) ? 4 : 5)
+#define OBJ_SHARED_HDR_STRLEN(_len_) (((_len_) < 10) ? 4 : 5) /* see shared.mbulkhdr etc. */
 #define LOG_MAX_LEN    1024 /* Default maximum length of syslog messages.*/
 #define AOF_REWRITE_ITEMS_PER_CMD 64
 #define AOF_ANNOTATION_LINE_MAX_LEN 1024

--- a/src/server.h
+++ b/src/server.h
@@ -1229,7 +1229,9 @@ struct sharedObjectsStruct {
     *select[PROTO_SHARED_SELECT_CMDS],
     *integers[OBJ_SHARED_INTEGERS],
     *mbulkhdr[OBJ_SHARED_BULKHDR_LEN], /* "*<value>\r\n" */
-    *bulkhdr[OBJ_SHARED_BULKHDR_LEN];  /* "$<value>\r\n" */
+    *bulkhdr[OBJ_SHARED_BULKHDR_LEN],  /* "$<value>\r\n" */
+    *maphdr[OBJ_SHARED_BULKHDR_LEN],   /* "%<value>\r\n" */
+    *sethdr[OBJ_SHARED_BULKHDR_LEN];   /* "~<value>\r\n" */
     sds minstring, maxstring;
 };
 

--- a/src/server.h
+++ b/src/server.h
@@ -109,6 +109,7 @@ typedef long long ustime_t; /* microsecond time type. */
 #define PROTO_SHARED_SELECT_CMDS 10
 #define OBJ_SHARED_INTEGERS 10000
 #define OBJ_SHARED_BULKHDR_LEN 32
+#define OBJ_SHARED_HDR_STRLEN(_len_) ((_len_ < 10) ? 4 : 5)
 #define LOG_MAX_LEN    1024 /* Default maximum length of syslog messages.*/
 #define AOF_REWRITE_ITEMS_PER_CMD 64
 #define AOF_ANNOTATION_LINE_MAX_LEN 1024


### PR DESCRIPTION
This was raised on https://github.com/redis/redis/issues/10310#issuecomment-1048608645 in a discussion with @oranagra . 
![image](https://user-images.githubusercontent.com/5832149/155320701-9c73488f-eedf-4120-8d9d-ca254c6992d5.png)

Given that `sprintf` is consuming 1.6% of CPU cycles of the process on pipeline 1 tests,  trying to avoid it will benefit any command that uses deferred replies. Pipelining will make the difference even more evident.
ZREVRANGE results:
- pipeline 1: 
   - unstable: 488aecb3abca3088735f1bffa60a74e22832d44b : 138479 ops/sec. p50(ms)=1.43900
   - this PR: 143115 ops/sec. p50(ms)=1.39100. **%change = 3.4%**

- pipeline 16 ( reduces the relative percentage of `__GI___writev` and makes more evident the command performance ): 
   - unstable: 488aecb3abca3088735f1bffa60a74e22832d44b : 621587 ops/sec. p50(ms)=4.25500
   - this PR: 680124 ops/sec. p50(ms)=3.83900. **%change = 9.4%**

To reproduce:
```
rm dump.rdb ; src/redis-server --save "" &
redis-cli zadd zz 0 a 1 b 2 c 3 d 4 e 5 f
memtier_benchmark --pipeline 16 --command "zrange zz 0 -1" --hide-histogram
```