### PR TITLE
Add socket-mark-id support for marking sockets.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -177,7 +177,7 @@ tcp-keepalive 300
 
 # Assign a cookie ID to the listener socket mostly for IP filtering purpose
 # e.g. ipfw can redirect packets to a specified identifier, 0 is the default.
-#socket-id 0
+# socket-id 0
 
 ################################# TLS/SSL #####################################
 

--- a/redis.conf
+++ b/redis.conf
@@ -179,7 +179,7 @@ tcp-keepalive 300
 # ID, to support advanced routing and filtering capabilities.
 #
 # On Linux, the ID represents a connection mark.
-# On FreeBSD, the ID represnets a socket cookie ID.
+# On FreeBSD, the ID represents a socket cookie ID.
 # On OpenBSD, the ID represents a route table ID.
 #
 # The default value is 0, which implies no marking is required.

--- a/redis.conf
+++ b/redis.conf
@@ -175,6 +175,10 @@ timeout 0
 # Redis default starting with Redis 3.2.1.
 tcp-keepalive 300
 
+# Assign a cookie ID to the listener socket mostly for IP filtering purpose
+# e.g. ipfw can redirect packets to a specified identifier, 0 is the default.
+#socket-id 0
+
 ################################# TLS/SSL #####################################
 
 # By default, TLS/SSL is disabled. To enable it, the "tls-port" configuration

--- a/redis.conf
+++ b/redis.conf
@@ -175,9 +175,15 @@ timeout 0
 # Redis default starting with Redis 3.2.1.
 tcp-keepalive 300
 
-# Assign a cookie ID to the listener socket mostly for IP filtering purpose
-# e.g. ipfw can redirect packets to a specified identifier, 0 is the default.
-# socket-id 0
+# Apply OS-specific mechanism to mark the listening socket with the specified
+# ID, to support advanced routing and filtering capabilities.
+#
+# On Linux, the ID represents a connection mark.
+# On FreeBSD, the ID represnets a socket cookie ID.
+# On OpenBSD, the ID represents a route table ID.
+#
+# The default value is 0, which implies no marking is required.
+# socket-mark-id 0
 
 ################################# TLS/SSL #####################################
 

--- a/src/anet.c
+++ b/src/anet.c
@@ -683,18 +683,17 @@ error:
     return -1;
 }
 
-int anetSockId(char *err, int fd, uint32_t id)
-{
+int anetSockId(char *err, int fd, uint32_t id) {
 #ifdef HAVE_SOCKOPTID
-        if (setsockopt(fd, SOL_SOCKET, SO_USER_COOKIE, (void *)&id, sizeof(id)) == -1) {
-            anetSetError(err, "setsockopt: %s", strerror(errno));
-	    return ANET_ERR;
-        }
-	return ANET_OK;
+    if (setsockopt(fd, SOL_SOCKET, SOCKOPTID, (void *)&id, sizeof(id)) == -1) {
+        anetSetError(err, "setsockopt: %s", strerror(errno));
+        return ANET_ERR;
+    }
+    return ANET_OK;
 #else
-        UNUSED(fd);
-        if (id > 0)
-            anetSetError(err,"anetSockid unsupported on this platform");
-        return ANET_OK;
+    UNUSED(fd);
+    if (id > 0)
+        anetSetError(err,"anetSockid unsupported on this platform");
+    return ANET_OK;
 #endif
 }

--- a/src/anet.c
+++ b/src/anet.c
@@ -692,6 +692,7 @@ int anetSetSockMarkId(char *err, int fd, uint32_t id) {
     return ANET_OK;
 #else
     UNUSED(fd);
+    UNUSED(id);
     anetSetError(err,"anetSetSockMarkid unsupported on this platform");
     return ANET_OK;
 #endif

--- a/src/anet.c
+++ b/src/anet.c
@@ -49,6 +49,8 @@
 #include "anet.h"
 #include "config.h"
 
+#define UNUSED(x) (void)(x)
+
 static void anetSetError(char *err, const char *fmt, ...)
 {
     va_list ap;
@@ -679,4 +681,20 @@ error:
     close(fds[0]);
     close(fds[1]);
     return -1;
+}
+
+int anetSockId(char *err, int fd, uint32_t id)
+{
+#ifdef HAVE_SOCKOPTID
+        if (setsockopt(fd, SOL_SOCKET, SO_USER_COOKIE, (void *)&id, sizeof(id)) == -1) {
+            anetSetError(err, "setsockopt: %s", strerror(errno));
+	    return ANET_ERR;
+        }
+	return ANET_OK;
+#else
+        UNUSED(fd);
+        if (id > 0)
+            anetSetError(err,"anetSockid unsupported on this platform");
+        return ANET_OK;
+#endif
 }

--- a/src/anet.c
+++ b/src/anet.c
@@ -683,17 +683,16 @@ error:
     return -1;
 }
 
-int anetSockId(char *err, int fd, uint32_t id) {
-#ifdef HAVE_SOCKOPTID
-    if (setsockopt(fd, SOL_SOCKET, SOCKOPTID, (void *)&id, sizeof(id)) == -1) {
+int anetSetSockMarkId(char *err, int fd, uint32_t id) {
+#ifdef HAVE_SOCKOPTMARKID
+    if (setsockopt(fd, SOL_SOCKET, SOCKOPTMARKID, (void *)&id, sizeof(id)) == -1) {
         anetSetError(err, "setsockopt: %s", strerror(errno));
         return ANET_ERR;
     }
     return ANET_OK;
 #else
     UNUSED(fd);
-    if (id > 0)
-        anetSetError(err,"anetSockid unsupported on this platform");
+    anetSetError(err,"anetSetSockMarkid unsupported on this platform");
     return ANET_OK;
 #endif
 }

--- a/src/anet.h
+++ b/src/anet.h
@@ -73,5 +73,6 @@ int anetKeepAlive(char *err, int fd, int interval);
 int anetFormatAddr(char *fmt, size_t fmt_len, char *ip, int port);
 int anetFormatFdAddr(int fd, char *buf, size_t buf_len, int fd_to_str_type);
 int anetPipe(int fds[2], int read_flags, int write_flags);
+int anetSockId(char *err, int fd, uint32_t id);
 
 #endif

--- a/src/anet.h
+++ b/src/anet.h
@@ -73,6 +73,6 @@ int anetKeepAlive(char *err, int fd, int interval);
 int anetFormatAddr(char *fmt, size_t fmt_len, char *ip, int port);
 int anetFormatFdAddr(int fd, char *buf, size_t buf_len, int fd_to_str_type);
 int anetPipe(int fds[2], int read_flags, int write_flags);
-int anetSockId(char *err, int fd, uint32_t id);
+int anetSetSockMarkId(char *err, int fd, uint32_t id);
 
 #endif

--- a/src/config.c
+++ b/src/config.c
@@ -2971,6 +2971,7 @@ standardConfig static_configs[] = {
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),
     createUIntConfig("unixsocketperm", NULL, IMMUTABLE_CONFIG, 0, 0777, server.unixsocketperm, 0, OCTAL_CONFIG, NULL, NULL),
+    createUIntConfig("socket-id", NULL, MODIFIABLE_CONFIG, 0, UINT_MAX, server.soid, 0, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned Long configs */
     createULongConfig("active-defrag-max-scan-fields", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, server.active_defrag_max_scan_fields, 1000, INTEGER_CONFIG, NULL, NULL), /* Default: keys with more than 1000 fields will be processed separately */

--- a/src/config.c
+++ b/src/config.c
@@ -2971,7 +2971,7 @@ standardConfig static_configs[] = {
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),
     createUIntConfig("unixsocketperm", NULL, IMMUTABLE_CONFIG, 0, 0777, server.unixsocketperm, 0, OCTAL_CONFIG, NULL, NULL),
-    createUIntConfig("socket-id", NULL, IMMUTABLE_CONFIG, 0, UINT_MAX, server.soid, 0, INTEGER_CONFIG, NULL, NULL),
+    createUIntConfig("socket-mark-id", NULL, IMMUTABLE_CONFIG, 0, UINT_MAX, server.socket_mark_id, 0, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned Long configs */
     createULongConfig("active-defrag-max-scan-fields", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, server.active_defrag_max_scan_fields, 1000, INTEGER_CONFIG, NULL, NULL), /* Default: keys with more than 1000 fields will be processed separately */

--- a/src/config.c
+++ b/src/config.c
@@ -2971,7 +2971,7 @@ standardConfig static_configs[] = {
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),
     createUIntConfig("unixsocketperm", NULL, IMMUTABLE_CONFIG, 0, 0777, server.unixsocketperm, 0, OCTAL_CONFIG, NULL, NULL),
-    createUIntConfig("socket-id", NULL, MODIFIABLE_CONFIG, 0, UINT_MAX, server.soid, 0, INTEGER_CONFIG, NULL, NULL),
+    createUIntConfig("socket-id", NULL, IMMUTABLE_CONFIG, 0, UINT_MAX, server.soid, 0, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned Long configs */
     createULongConfig("active-defrag-max-scan-fields", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, server.active_defrag_max_scan_fields, 1000, INTEGER_CONFIG, NULL, NULL), /* Default: keys with more than 1000 fields will be processed separately */

--- a/src/config.h
+++ b/src/config.h
@@ -113,6 +113,10 @@
 #define redis_fsync(fd) fsync(fd)
 #endif
 
+#if defined(__FreeBSD__)
+#define HAVE_SOCKOPTID 1
+#endif
+
 #if __GNUC__ >= 4
 #define redis_unreachable __builtin_unreachable
 #else

--- a/src/config.h
+++ b/src/config.h
@@ -81,8 +81,8 @@
 #ifdef __linux__
 #define HAVE_MSG_NOSIGNAL 1
 #if defined(SO_MARK)
-#define HAVE_SOCKOPTID 1
-#define SOCKOPTID SO_MARK
+#define HAVE_SOCKOPTMARKID 1
+#define SOCKOPTMARKID SO_MARK
 #endif
 #endif
 
@@ -119,15 +119,15 @@
 
 #if defined(__FreeBSD__)
 #if defined(SO_USER_COOKIE)
-#define HAVE_SOCKOPTID 1
-#define SOCKOPTID SO_USER_COOKIE
+#define HAVE_SOCKOPTMARKID 1
+#define SOCKOPTMARKID SO_USER_COOKIE
 #endif
 #endif
 
 #if defined(__OpenBSD__)
 #if defined(SO_RTABLE)
-#define HAVE_SOCKOPTID 1
-#define SOCKOPTID SO_RTABLE
+#define HAVE_SOCKOPTMARKID 1
+#define SOCKOPTMARKID SO_RTABLE
 #endif
 #endif
 

--- a/src/config.h
+++ b/src/config.h
@@ -80,6 +80,10 @@
 /* MSG_NOSIGNAL. */
 #ifdef __linux__
 #define HAVE_MSG_NOSIGNAL 1
+#if defined(SO_MARK)
+#define HAVE_SOCKOPTID 1
+#define SOCKOPTID SO_MARK
+#endif
 #endif
 
 /* Test for polling API */
@@ -114,7 +118,17 @@
 #endif
 
 #if defined(__FreeBSD__)
+#if defined(SO_USER_COOKIE)
 #define HAVE_SOCKOPTID 1
+#define SOCKOPTID SO_USER_COOKIE
+#endif
+#endif
+
+#if defined(__OpenBSD__)
+#if defined(SO_RTABLE)
+#define HAVE_SOCKOPTID 1
+#define SOCKOPTID SO_RTABLE
+#endif
 #endif
 
 #if __GNUC__ >= 4

--- a/src/server.c
+++ b/src/server.c
@@ -2294,6 +2294,7 @@ int listenToPort(int port, socketFds *sfd) {
             closeSocketListeners(sfd);
             return C_ERR;
         }
+        anetSockId(NULL, sfd->fd[sfd->count], server.soid);
         anetNonBlock(NULL,sfd->fd[sfd->count]);
         anetCloexec(sfd->fd[sfd->count]);
         sfd->count++;

--- a/src/server.c
+++ b/src/server.c
@@ -2294,7 +2294,7 @@ int listenToPort(int port, socketFds *sfd) {
             closeSocketListeners(sfd);
             return C_ERR;
         }
-        anetSockId(NULL, sfd->fd[sfd->count], server.soid);
+        if (server.socket_mark_id > 0) anetSetSockMarkId(NULL, sfd->fd[sfd->count], server.socket_mark_id);
         anetNonBlock(NULL,sfd->fd[sfd->count]);
         anetCloexec(sfd->fd[sfd->count]);
         sfd->count++;

--- a/src/server.h
+++ b/src/server.h
@@ -1494,6 +1494,7 @@ struct redisServer {
     socketFds ipfd;             /* TCP socket file descriptors */
     socketFds tlsfd;            /* TLS socket file descriptors */
     int sofd;                   /* Unix socket file descriptor */
+    uint32_t soid;              /* socket ID for networking filtering purpose (ipfw) */
     socketFds cfd;              /* Cluster bus listening socket */
     list *clients;              /* List of active clients */
     list *clients_to_close;     /* Clients to close asynchronously */

--- a/src/server.h
+++ b/src/server.h
@@ -1494,7 +1494,7 @@ struct redisServer {
     socketFds ipfd;             /* TCP socket file descriptors */
     socketFds tlsfd;            /* TLS socket file descriptors */
     int sofd;                   /* Unix socket file descriptor */
-    uint32_t soid;              /* socket ID for networking filtering purpose (ipfw) */
+    uint32_t socket_mark_id;    /* ID for listen socket marking */
     socketFds cfd;              /* Cluster bus listening socket */
     list *clients;              /* List of active clients */
     list *clients_to_close;     /* Clients to close asynchronously */

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -215,6 +215,7 @@ start_server {tags {"introspection"}} {
             dbfilename
             logfile
             dir
+            socket-id
         }
 
         if {!$::tls} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -215,7 +215,7 @@ start_server {tags {"introspection"}} {
             dbfilename
             logfile
             dir
-            socket-id
+            socket-mark-id
         }
 
         if {!$::tls} {


### PR DESCRIPTION
Add a configuration option to attach an operating system-specific identifier to Redis sockets, supporting advanced network configurations using iptables (Linux) or ipfw (FreeBSD).