### PR TITLE
Optimize dict resize to use in-place realloc() 

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -167,11 +167,11 @@ long dictIterDefragEntry(dictIterator *iter) {
         }
     }
     /* handle the case of the first entry in the hash bucket. */
-    if (iter->d->ht_table[iter->table][iter->index] == iter->entry) {
+    if (iter->d->ht_table[iter->index] == iter->entry) {
         dictEntry *newde = activeDefragAlloc(iter->entry);
         if (newde) {
             iter->entry = newde;
-            iter->d->ht_table[iter->table][iter->index] = newde;
+            iter->d->ht_table[iter->index] = newde;
             defragged++;
         }
     }
@@ -184,16 +184,14 @@ long dictIterDefragEntry(dictIterator *iter) {
 long dictDefragTables(dict* d) {
     dictEntry **newtable;
     long defragged = 0;
-    /* handle the first hash table */
-    newtable = activeDefragAlloc(d->ht_table[0]);
-    if (newtable)
-        defragged++, d->ht_table[0] = newtable;
-    /* handle the second hash table */
-    if (d->ht_table[1]) {
-        newtable = activeDefragAlloc(d->ht_table[1]);
-        if (newtable)
-            defragged++, d->ht_table[1] = newtable;
+
+    /* handle the hash table */
+    newtable = activeDefragAlloc(d->ht_table);
+    if (newtable) {
+        d->ht_table = newtable;
+        defragged++;
     }
+
     return defragged;
 }
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -233,10 +233,10 @@ int dictRehash(dict *d, int bucket_visits) {
     while (bucket_visits > 0) {
         dictEntry *entries_to_rehash = d->ht_table[d->rehashidx];
 
-        /* If HT grows, need to set to NULL current bucket and corresponding new ones
-         * before rehashing back entries (as we avoid from using memset when
-         * expanded the table). If shrinks this loop iterates once and set to NULL
-         * current bucket.  */
+        /* If HT grows, set current bucket to NULL and corresponding new ones
+         * before rehashing back entries (since we avoid earlier from using
+         * memset() when expanded the table). If shrinks this loop iterates once
+         * and set to NULL only current bucket. */
         long idx = d->rehashidx ;
         do {
             d->ht_table[idx] = NULL;

--- a/src/dict.c
+++ b/src/dict.c
@@ -114,7 +114,7 @@ static void _dictReset(dict *d) {
 dict *dictCreate(dictType *type) {
     dict *d = zmalloc(sizeof(*d));
 
-    _dictInit(d, type);
+    _dictInit(d,type);
     return d;
 }
 
@@ -168,8 +168,7 @@ int _dictResize(dict *d, unsigned long size, int *malloc_failed) {
     if (d->ht_size_exp < new_ht_size_exp) {
         /* Realloc the hash table (without initializing new buckets to NULL) */
         if (malloc_failed) {
-            new_ht_table = ztryrealloc(d->ht_table,
-                                       newsize * sizeof(dictEntry *));
+            new_ht_table = ztryrealloc(d->ht_table,newsize * sizeof(dictEntry *));
             *malloc_failed = new_ht_table == NULL;
             if (*malloc_failed)
                 return DICT_ERR;

--- a/src/object.c
+++ b/src/object.c
@@ -438,8 +438,7 @@ void dismissSetObject(robj *o, size_t size_hint) {
         }
 
         /* Dismiss hash table memory. */
-        dismissMemory(set->ht_table[0], DICTHT_SIZE(set->ht_size_exp[0])*sizeof(dictEntry*));
-        dismissMemory(set->ht_table[1], DICTHT_SIZE(set->ht_size_exp[1])*sizeof(dictEntry*));
+        dismissMemory(set->ht_table, DICTHT_SIZE(set->ht_size_exp)*sizeof(dictEntry*));
     } else if (o->encoding == OBJ_ENCODING_INTSET) {
         dismissMemory(o->ptr, intsetBlobLen((intset*)o->ptr));
     } else {
@@ -465,8 +464,7 @@ void dismissZsetObject(robj *o, size_t size_hint) {
 
         /* Dismiss hash table memory. */
         dict *d = zs->dict;
-        dismissMemory(d->ht_table[0], DICTHT_SIZE(d->ht_size_exp[0])*sizeof(dictEntry*));
-        dismissMemory(d->ht_table[1], DICTHT_SIZE(d->ht_size_exp[1])*sizeof(dictEntry*));
+        dismissMemory(d->ht_table, DICTHT_SIZE(d->ht_size_exp)*sizeof(dictEntry*));
     } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
         dismissMemory(o->ptr, lpBytes((unsigned char*)o->ptr));
     } else {
@@ -493,8 +491,7 @@ void dismissHashObject(robj *o, size_t size_hint) {
         }
 
         /* Dismiss hash table memory. */
-        dismissMemory(d->ht_table[0], DICTHT_SIZE(d->ht_size_exp[0])*sizeof(dictEntry*));
-        dismissMemory(d->ht_table[1], DICTHT_SIZE(d->ht_size_exp[1])*sizeof(dictEntry*));
+        dismissMemory(d->ht_table, DICTHT_SIZE(d->ht_size_exp)*sizeof(dictEntry*));
     } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
         dismissMemory(o->ptr, lpBytes((unsigned char*)o->ptr));
     } else {

--- a/src/server.h
+++ b/src/server.h
@@ -2321,7 +2321,6 @@ extern struct sharedObjectsStruct shared;
 extern dictType objectKeyPointerValueDictType;
 extern dictType objectKeyHeapPointerValueDictType;
 extern dictType setDictType;
-extern dictType BenchmarkDictType;
 extern dictType zsetDictType;
 extern dictType dbDictType;
 extern double R_Zero, R_PosInf, R_NegInf, R_Nan;


### PR DESCRIPTION
Optimize dict resize implementation to use in-place realloc(). That is,            
avoid from allocating a new hash table and starting to move entries gradually   
to new HT. Basically, it extends the hash table to the desired size by calling  
realloc() and start iterating over the table and rehash each entry to its          
updated bucket.                                                  
In case of big rehash, this approach relaxes the risk to keys eviction since it  
avoids from holding two hash tables until rehashing ends, which might take quite 
some time. 
Another outcome of this change, and in continuation to earlier effort, is reducing
further dict struct size from 56 bytes to 40 bytes.                                                                     
                                                                                    
Preliminary performance tests available here:  https://tinyurl.com/yc882naf