### PR TITLE
Fix memory leak in RM_StreamIteratorStop and moduleFreeKeyIterator

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -596,7 +596,10 @@ static void moduleFreeKeyIterator(RedisModuleKey *key) {
     serverAssert(key->iter != NULL);
     switch (key->value->type) {
     case OBJ_LIST: listTypeReleaseIterator(key->iter); break;
-    case OBJ_STREAM: zfree(key->iter); break;
+    case OBJ_STREAM:
+        streamIteratorStop(key->iter);
+        zfree(key->iter);
+        break;
     default: serverAssert(0); /* No key->iter for other types. */
     }
     key->iter = NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -5103,6 +5103,7 @@ int RM_StreamIteratorStop(RedisModuleKey *key) {
         errno = EBADF;
         return REDISMODULE_ERR;
     }
+	streamIteratorStop(key->iter);
     zfree(key->iter);
     key->iter = NULL;
     return REDISMODULE_OK;

--- a/src/module.c
+++ b/src/module.c
@@ -5103,7 +5103,7 @@ int RM_StreamIteratorStop(RedisModuleKey *key) {
         errno = EBADF;
         return REDISMODULE_ERR;
     }
-	streamIteratorStop(key->iter);
+    streamIteratorStop(key->iter);
     zfree(key->iter);
     key->iter = NULL;
     return REDISMODULE_OK;


### PR DESCRIPTION
Forget to call `streamIteratorStop` after `streamIteratorStart`