### PR TITLE
Allow clients to subscribe to slot migrations

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -82,6 +82,7 @@ void removeChannelsInSlot(unsigned int slot);
 unsigned int countKeysInSlot(unsigned int hashslot);
 unsigned int countChannelsInSlot(unsigned int hashslot);
 unsigned int delKeysInSlot(unsigned int hashslot);
+const char *getPreferredEndpoint(clusterNode *n);
 
 /* Links to the next and previous entries for keys in the same slot are stored
  * in the dict entry metadata. See Slot to Key API below. */
@@ -117,6 +118,10 @@ dictType clusterNodesBlackListDictType = {
         NULL,                       /* val destructor */
         NULL                        /* allow to expand */
 };
+
+/* Special values for server.cluster->moved_slot_since_sleep */
+#define MOVED_SLOT_NONE     -1
+#define MOVED_SLOT_MULTIPLE -2
 
 /* -----------------------------------------------------------------------------
  * Initialization
@@ -596,6 +601,9 @@ void clusterInit(void) {
     server.cluster->state = CLUSTER_FAIL;
     server.cluster->size = 1;
     server.cluster->todo_before_sleep = 0;
+    server.cluster->moved_slot_since_sleep = MOVED_SLOT_NONE;
+    server.cluster->moved_slot_channel =
+        createObject(OBJ_STRING, sdsnew("__redis__:moved"));
     server.cluster->nodes = dictCreate(&clusterNodesDictType);
     server.cluster->nodes_black_list =
         dictCreate(&clusterNodesBlackListDictType);
@@ -4147,6 +4155,36 @@ void clusterCron(void) {
         clusterUpdateState();
 }
 
+/* Notify clients subscribed to slot moved events. */
+void notifyMovedSlot(int moved_slot, list *clients) {
+    clusterNode *n = server.cluster->slots[moved_slot];
+    /* As for -MOVED redirects, the port in the message depends on whether the
+     * client is using TLS or not. Use node's plaintext port if cluster is TLS
+     * but client is non-TLS. Otherwise, use the node's regular port. */
+    robj *messages[2] = {NULL, NULL}; /* Created lazily. */
+    listNode *ln;
+    listIter li;
+    listRewind(clients, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        client *c = ln->value;
+        int use_pport = (server.tls_cluster && n->pport &&
+                         c->conn && connGetType(c->conn) != CONN_TYPE_TLS);
+        if (messages[use_pport] == NULL) {
+            sds s = sdscatprintf(sdsempty(),
+                                 "MOVED %d %s:%d",
+                                 moved_slot,
+                                 getPreferredEndpoint(n),
+                                 use_pport ? n->pport : n->port);
+            messages[use_pport] = createObject(OBJ_STRING, s);
+        }
+        addReplyPubsubMessage(c, server.cluster->moved_slot_channel,
+                              messages[use_pport]);
+        updateClientMemUsage(c);
+    }
+    if (messages[0]) decrRefCount(messages[0]);
+    if (messages[1]) decrRefCount(messages[1]);
+}
+
 /* This function is called before the event handler returns to sleep for
  * events. It is useful to perform operations that must be done ASAP in
  * reaction to events fired but that are not safe to perform inside event
@@ -4154,10 +4192,12 @@ void clusterCron(void) {
  * a single time before replying to clients. */
 void clusterBeforeSleep(void) {
     int flags = server.cluster->todo_before_sleep;
+    int moved_slot = server.cluster->moved_slot_since_sleep;
 
     /* Reset our flags (not strictly needed since every single function
      * called for flags set should be able to clear its flag). */
     server.cluster->todo_before_sleep = 0;
+    server.cluster->moved_slot_since_sleep = MOVED_SLOT_NONE;
 
     if (flags & CLUSTER_TODO_HANDLE_MANUALFAILOVER) {
         /* Handle manual failover as soon as possible so that won't have a 100ms
@@ -4176,6 +4216,16 @@ void clusterBeforeSleep(void) {
     /* Update the cluster state. */
     if (flags & CLUSTER_TODO_UPDATE_STATE)
         clusterUpdateState();
+
+    /* Notify clients subscribed to moved slot events. To avoid flooding the
+     * clients, we only publish the moved slot message if exactly one slot has
+     * been migrated. In cases like failover, clients will receive -MOVED
+     * redirects and will need to refresh the full slot mapping with nodes
+     * including replicas. */
+    if (moved_slot >= 0) {
+        list *clients = pubsubGetSubscribers(server.cluster->moved_slot_channel);
+        if (clients) notifyMovedSlot(moved_slot, clients);
+    }
 
     /* Save the config, possibly using fsync. */
     if (flags & CLUSTER_TODO_SAVE_CONFIG) {
@@ -4277,6 +4327,10 @@ int clusterAddSlot(clusterNode *n, int slot) {
     if (server.cluster->slots[slot]) return C_ERR;
     clusterNodeSetSlotBit(n,slot);
     server.cluster->slots[slot] = n;
+    if (server.cluster->moved_slot_since_sleep == MOVED_SLOT_NONE)
+        server.cluster->moved_slot_since_sleep = slot;
+    else
+       server.cluster->moved_slot_since_sleep = MOVED_SLOT_MULTIPLE;
     return C_OK;
 }
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -196,7 +196,10 @@ typedef struct clusterState {
                                    can start requesting masters vote. */
     /* The following fields are used by masters to take state on elections. */
     uint64_t lastVoteEpoch;     /* Epoch of the last vote granted. */
-    int todo_before_sleep; /* Things to do in clusterBeforeSleep(). */
+    int todo_before_sleep;      /* Things to do in clusterBeforeSleep(). */
+    int moved_slot_since_sleep; /* Single slot moved since last sleep or
+                                 * -1 for none or -2 for multiple. */
+    robj *moved_slot_channel;   /* Shared robj string object. */
     /* Stats */
     /* Messages received and sent by type. */
     long long stats_bus_messages_sent[CLUSTERMSG_TYPE_COUNT];

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -441,6 +441,14 @@ int pubsubUnsubscribeAllPatterns(client *c, int notify) {
     return count;
 }
 
+/* Returns a list of clients subscribed to the given channel or NULL if the
+ * channel has no subscribers. The channel is non-sharded. Pattern subscriptions
+ * are not included. */
+list *pubsubGetSubscribers(robj *channel) {
+    dictEntry *de = dictFind(*pubSubType.serverPubSubChannels, channel);
+    return de ? dictGetVal(de) : NULL;
+}
+
 /*
  * Publish a message to all the subscribers.
  */

--- a/src/server.h
+++ b/src/server.h
@@ -2962,6 +2962,7 @@ int pubsubUnsubscribeAllPatterns(client *c, int notify);
 int pubsubPublishMessage(robj *channel, robj *message);
 int pubsubPublishMessageShard(robj *channel, robj *message);
 void addReplyPubsubMessage(client *c, robj *channel, robj *msg);
+list *pubsubGetSubscribers(robj *channel);
 int serverPubsubSubscriptionCount();
 int serverPubsubShardSubscriptionCount();
 

--- a/tests/cluster/tests/15-cluster-slots.tcl
+++ b/tests/cluster/tests/15-cluster-slots.tcl
@@ -57,15 +57,11 @@ test "slot migration is valid from primary to another primary" {
     array set nodefrom [$cluster masternode_for_slot $slot]
     array set nodeto [$cluster masternode_notfor_slot $slot]
     array set node3 [$cluster masternode_notfor_slot $slot]
-    while { $node3(port) eq $nodefrom(port) || $node3(port) eq $nodeto(port) } {
+    while {$node3(port) eq $nodeto(port)} {
         array set node3 [$cluster masternode_notfor_slot $slot]
     }
-    # Check that all nodes are different
-    assert_not_equal $nodefrom(port) $nodeto(port)
-    assert_not_equal $nodefrom(port) $node3(port)
-    assert_not_equal $nodeto(port)   $node3(port)
 
-    # Test subscribe to moved slot notifications
+    # Subscribe to moved slot notifications
     set rd1 [redis_deferring_client_by_addr 127.0.0.1 $nodefrom(port)]
     set rd2 [redis_deferring_client_by_addr 127.0.0.1 $nodeto(port)]
     set rd3 [redis_deferring_client_by_addr 127.0.0.1 $node3(port)]
@@ -73,15 +69,15 @@ test "slot migration is valid from primary to another primary" {
     assert_equal {1} [subscribe $rd2 {__redis__:moved}]
     assert_equal {1} [subscribe $rd3 {__redis__:moved}]
 
+    # Move the slot
     assert_equal {OK} [$nodeto(link) cluster setslot $slot importing $nodefrom(id)]
     assert_equal {OK} [$nodefrom(link) cluster setslot $slot migrating $nodeto(id)]
-
     assert_equal {OK} [$nodefrom(link) cluster setslot $slot node $nodeto(id)]
     assert_equal {OK} [$nodeto(link) cluster setslot $slot node $nodeto(id)]
 
     # Check that we got the pubsub MOVED message from all nodes.
     set expect_content "MOVED $slot 127.0.0.1:$nodeto(port)"
-    set expect_publish "message __redis__:moved {$expect_content}"
+    set expect_publish [list message __redis__:moved $expect_content]
     assert_equal $expect_publish [$rd1 read]
     assert_equal $expect_publish [$rd2 read]
     assert_equal $expect_publish [$rd3 read]

--- a/tests/cluster/tests/15-cluster-slots.tcl
+++ b/tests/cluster/tests/15-cluster-slots.tcl
@@ -50,14 +50,44 @@ test "client can handle keys with hash tag" {
 }
 
 test "slot migration is valid from primary to another primary" {
-    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+    set startup_port [get_instance_attrib redis 0 port]
+    set cluster [redis_cluster 127.0.0.1:$startup_port]
     set key order1
     set slot [$cluster cluster keyslot $key]
     array set nodefrom [$cluster masternode_for_slot $slot]
     array set nodeto [$cluster masternode_notfor_slot $slot]
+    array set node3 [$cluster masternode_notfor_slot $slot]
+    while { $node3(port) eq $nodefrom(port) || $node3(port) eq $nodeto(port) } {
+        array set node3 [$cluster masternode_notfor_slot $slot]
+    }
+    # Check that all nodes are different
+    assert_not_equal $nodefrom(port) $nodeto(port)
+    assert_not_equal $nodefrom(port) $node3(port)
+    assert_not_equal $nodeto(port)   $node3(port)
+
+    # Test subscribe to moved slot notifications
+    set rd1 [redis_deferring_client_by_addr 127.0.0.1 $nodefrom(port)]
+    set rd2 [redis_deferring_client_by_addr 127.0.0.1 $nodeto(port)]
+    set rd3 [redis_deferring_client_by_addr 127.0.0.1 $node3(port)]
+    assert_equal {1} [subscribe $rd1 {__redis__:moved}]
+    assert_equal {1} [subscribe $rd2 {__redis__:moved}]
+    assert_equal {1} [subscribe $rd3 {__redis__:moved}]
+
+    assert_equal {OK} [$nodeto(link) cluster setslot $slot importing $nodefrom(id)]
+    assert_equal {OK} [$nodefrom(link) cluster setslot $slot migrating $nodeto(id)]
 
     assert_equal {OK} [$nodefrom(link) cluster setslot $slot node $nodeto(id)]
     assert_equal {OK} [$nodeto(link) cluster setslot $slot node $nodeto(id)]
+
+    # Check that we got the pubsub MOVED message from all nodes.
+    set expect_content "MOVED $slot 127.0.0.1:$nodeto(port)"
+    set expect_publish "message __redis__:moved {$expect_content}"
+    assert_equal $expect_publish [$rd1 read]
+    assert_equal $expect_publish [$rd2 read]
+    assert_equal $expect_publish [$rd3 read]
+    $rd1 close
+    $rd2 close
+    $rd3 close
 }
 
 test "slot migration is invalid from primary to replica" {

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -157,11 +157,6 @@ proc ::redis_cluster::__method__refresh_nodes_map {id} {
     set ::redis_cluster::startup_nodes($id) [lsort -unique $::redis_cluster::startup_nodes($id)]
 }
 
-# Returns the list of nodes (each is an info dict) of a cluster.
-proc ::redis_cluster::__get_nodes {$id} {
-    return [dict values $::redis_cluster::nodes($id)]
-}
-
 # Free a redis_cluster handle.
 proc ::redis_cluster::__method__close {id} {
     catch {

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -157,6 +157,11 @@ proc ::redis_cluster::__method__refresh_nodes_map {id} {
     set ::redis_cluster::startup_nodes($id) [lsort -unique $::redis_cluster::startup_nodes($id)]
 }
 
+# Returns the list of nodes (each is an info dict) of a cluster.
+proc ::redis_cluster::__get_nodes {$id} {
+    return [dict values $::redis_cluster::nodes($id)]
+}
+
 # Free a redis_cluster handle.
 proc ::redis_cluster::__method__close {id} {
     catch {


### PR DESCRIPTION
The cluster bus doesn't distinguish between migrations and other actions.
This commit detects a migration by checking if exactly one slot has a new
owner.

Only one moved slot per cluster bus message or command is notified. This
is to avoid flooding the clients. In other cases, such as failovers,
clients will need to handle MOVED redirects and update the slot mapping
as before.

A special pubsub channel `__redis__:moved` is used (naming style as in
client-side caching). The message is a string on the form "MOVED slot
endpoint:port" very similar to MOVED redirects.

Some special logic added to avoid creating the pubsub message if there
are no subscribers.

Fixes #10150.