### PR TITLE
acl dryrun should return the command if the user doesn't have access to it

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2799,7 +2799,7 @@ setuser_cleanup:
             sds err = sdsempty();
             if (result == ACL_DENIED_CMD) {
                 err = sdscatfmt(err, "This user has no permissions to run "
-                    "the '%s' command", c->cmd->fullname);
+                    "the '%s' command", cmd->fullname);
             } else if (result == ACL_DENIED_KEY) {
                 err = sdscatfmt(err, "This user has no permissions to access "
                     "the '%s' key", c->argv[idx + 3]->ptr);

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -305,6 +305,12 @@ start_server {tags {"acl external:skip"}} {
         assert_equal "ERR Command 'not-a-command' not found" $e
     }
 
+    test {Test various commands for command permissions} {
+        r ACL setuser command-test -@all
+        assert_equal "This user has no permissions to run the 'set' command" [r ACL DRYRUN command-test set somekey somevalue]
+        assert_equal "This user has no permissions to run the 'get' command" [r ACL DRYRUN command-test get somekey]
+    }
+
     test {Test various odd commands for key permissions} {
         r ACL setuser command-test +@all %R~read* %W~write* %RW~rw*
 


### PR DESCRIPTION
Before the change

```
127.0.0.1:6379> acl dryrun hp set r 5
(error) NOPERM this user has no permissions to run the 'acl|dryrun' command
```

After the change

```
127.0.0.1:6379> acl dryrun hp set r 5
"This user has no permissions to run the 'set' command"
```