### PR TITLE
script should not allow may-replicate commands when client pause write

### DIFF
--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -86,6 +86,14 @@ start_server {tags {"pause network"}} {
         $rd close
     }
 
+    test "Test may-replicate commands are rejected in ro script by pause RO" {
+        r client PAUSE 60000 WRITE
+        assert_error {ERR May-replicate commands are not allowed when client pause write*} {
+            r EVAL_RO "return redis.call('publish','ch','msg')" 0
+        }
+        r client unpause
+    }
+
     test "Test multiple clients can be queued up and unblocked" {
         r client PAUSE 60000 WRITE
         set clients [list [redis_deferring_client] [redis_deferring_client] [redis_deferring_client]]


### PR DESCRIPTION
In some special commands like `eval_ro`/`fcall_ro` we allow no-writes commands. But may-replicate commands are no-writes too, that leads crash when client pause write:
```
=== REDIS BUG REPORT START: Cut & paste starting from here ===
51328:M 01 Mar 2022 17:08:59.273 # === ASSERTION FAILED ===
51328:M 01 Mar 2022 17:08:59.273 # ==> server.c:3036 '!(areClientsPaused() && !server.client_pause_in_transaction)' is not true

------ STACK TRACE ------

Backtrace:
./redis-server *:6789[0x447127]
./redis-server *:6789(propagatePendingCommands+0x72)[0x44ab82]
./redis-server *:6789(afterCommand+0x33)[0x44ae53]
./redis-server *:6789(call+0x31a)[0x44b17a]
./redis-server *:6789(processCommand+0x990)[0x44cf90]
./redis-server *:6789(processCommandAndResetClient+0x1c)[0x462a5c]
./redis-server *:6789(processInputBuffer+0xd1)[0x465541]
./redis-server *:6789(readQueryFromClient+0x238)[0x468558]
./redis-server *:6789[0x4fd373]
./redis-server *:6789(aeProcessEvents+0x235)[0x443735]
./redis-server *:6789(aeMain+0x1d)[0x443a7d]
./redis-server *:6789(main+0x406)[0x43fe16]
/lib64/libc.so.6(__libc_start_main+0xf5)[0x7f509184f445]
./redis-server *:6789[0x4401cd]

...

------ CURRENT CLIENT INFO ------
id=3 addr=127.0.0.1:46466 laddr=127.0.0.1:6789 fd=7 name= age=3 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=67 qbuf-free=20407 argv-mem=44 multi-mem=0 rbs=1024 rbp=5 obl=4 oll=0 omem=0 tot-mem=22340 events=r cmd=eval_ro user=default redir=-1 resp=2
argv[0]: '"eval_ro"'
argv[1]: '"return redis.call('publish','ch','msg')"'
argv[2]: '"0"'
```