### PR TITLE
export acl dumping/loading functionality for module usage

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -41,6 +41,7 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/stream \
 --single unit/moduleapi/datatype2 \
 --single unit/moduleapi/cluster \
+--single unit/moduleapi/acl \
 --single unit/moduleapi/aclcheck \
 --single unit/moduleapi/subcommands \
 --single unit/moduleapi/reply \

--- a/src/acl.c
+++ b/src/acl.c
@@ -2067,8 +2067,8 @@ sds loadACLFromBuffer(sds acls) {
         argv = sdssplitlen(lines[i],sdslen(lines[i])," ",1,&argc);
         if (argv == NULL) {
             errors = sdscatprintf(errors,
-                                  "%s:%d: unbalanced quotes in acl line. ",
-                                  server.acl_filename, linenum);
+                     "%s:%d: unbalanced quotes in acl line. ",
+                     server.acl_filename, linenum);
             continue;
         }
 
@@ -2081,9 +2081,9 @@ sds loadACLFromBuffer(sds acls) {
         /* The line should start with the "user" keyword. */
         if (strcmp(argv[0],"user") || argc < 2) {
             errors = sdscatprintf(errors,
-                                  "%s:%d should start with user keyword followed "
-                                  "by the username. ", server.acl_filename,
-                                  linenum);
+                     "%s:%d should start with user keyword followed "
+                     "by the username. ", server.acl_filename,
+                     linenum);
             sdsfreesplitres(argv,argc);
             continue;
         }
@@ -2114,8 +2114,8 @@ sds loadACLFromBuffer(sds acls) {
         sds *acl_args = ACLMergeSelectorArguments(argv + 2, argc - 2, &merged_argc, NULL);
         if (!acl_args) {
             errors = sdscatprintf(errors,
-                                  "%s:%d: Unmatched parenthesis in selector definition.",
-                                  server.acl_filename, linenum);
+                    "%s:%d: Unmatched parenthesis in selector definition.",
+                    server.acl_filename, linenum);
         }
 
         int j;
@@ -2124,8 +2124,8 @@ sds loadACLFromBuffer(sds acls) {
             if (ACLSetUser(u,acl_args[j],sdslen(acl_args[j])) != C_OK) {
                 const char *errmsg = ACLSetUserStringError();
                 errors = sdscatprintf(errors,
-                                      "%s:%d: %s. ",
-                                      server.acl_filename, linenum, errmsg);
+                         "%s:%d: %s. ",
+                         server.acl_filename, linenum, errmsg);
                 continue;
             }
         }

--- a/src/module.c
+++ b/src/module.c
@@ -11519,13 +11519,25 @@ RedisModuleString *RM_DumpACL(RedisModuleCtx *ctx) {
 
 /* Resets the ACL configuration to the state defined by the provided byte array
  * Used in conjunction with RedisModule_DumpACL()
+ *
+ * If no errors were found in the whole file then NULL is returned. Otherwise
+ * a RedisModuleString describing in a single line a description of all the issues
+ * found is returned.
  */
-char *RM_LoadACL(RedisModuleString *aclString) {
+RedisModuleString *RM_LoadACL(RedisModuleCtx *ctx, RedisModuleString *aclString) {
+    RedisModuleString * ret = NULL;
+
     size_t len;
     const char * tmp = RM_StringPtrLen(aclString, &len);
     sds acl = sdsnewlen(tmp, len);
 
-    return loadACLFromBuffer(acl);
+    sds result = loadACLFromBuffer(acl);
+    if (result != NULL) {
+        ret = RM_CreateString(ctx, result, sdslen(result));
+        sdsfree(result);
+    }
+
+    return ret;
 }
 
 /* Register all the APIs we export. Keep this function at the end of the

--- a/src/module.c
+++ b/src/module.c
@@ -11505,6 +11505,14 @@ int RM_GetDbIdFromDefragCtx(RedisModuleDefragCtx *ctx) {
     return ctx->dbid;
 }
 
+char *RM_DumpACL() {
+    return saveACLToBuffer();
+}
+
+char *RM_LoadACL(char *aclString) {
+    return loadACLFromBuffer(aclString);
+}
+
 /* Register all the APIs we export. Keep this function at the end of the
  * file so that's easy to seek it to add new entries. */
 void moduleRegisterCoreAPI(void) {
@@ -11822,4 +11830,6 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(EventLoopDel);
     REGISTER_API(EventLoopAddOneShot);
     REGISTER_API(Yield);
+    REGISTER_API(DumpACL);
+    REGISTER_API(LoadACL);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -11505,6 +11505,10 @@ int RM_GetDbIdFromDefragCtx(RedisModuleDefragCtx *ctx) {
     return ctx->dbid;
 }
 
+/* Returns a byte array that corresponds to a point in time snapshot of the ACL
+ * configuration.  Useful for modules that want to snapshot redis state.
+ * Used in conjunction with RedisModule_LocalACL()
+ */
 RedisModuleString *RM_DumpACL(RedisModuleCtx *ctx) {
     sds acl = saveACLToBuffer();
     RedisModuleString * ret = RM_CreateString(ctx, acl ,sdslen(acl));
@@ -11513,6 +11517,9 @@ RedisModuleString *RM_DumpACL(RedisModuleCtx *ctx) {
     return ret;
 }
 
+/* Resets the ACL configuration to the state defined by the provided byte array
+ * Used in conjunction with RedisModule_DumpACL()
+ */
 char *RM_LoadACL(RedisModuleString *aclString) {
     size_t len;
     const char * tmp = RM_StringPtrLen(aclString, &len);

--- a/src/module.c
+++ b/src/module.c
@@ -11505,12 +11505,20 @@ int RM_GetDbIdFromDefragCtx(RedisModuleDefragCtx *ctx) {
     return ctx->dbid;
 }
 
-char *RM_DumpACL() {
-    return saveACLToBuffer();
+RedisModuleString *RM_DumpACL(RedisModuleCtx *ctx) {
+    sds acl = saveACLToBuffer();
+    RedisModuleString * ret = RM_CreateString(ctx, acl ,sdslen(acl));
+    sdsfree(acl);
+
+    return ret;
 }
 
-char *RM_LoadACL(char *aclString) {
-    return loadACLFromBuffer(aclString);
+char *RM_LoadACL(RedisModuleString *aclString) {
+    size_t len;
+    const char * tmp = RM_StringPtrLen(aclString, &len);
+    sds acl = sdsnewlen(tmp, len);
+
+    return loadACLFromBuffer(acl);
 }
 
 /* Register all the APIs we export. Keep this function at the end of the

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1158,8 +1158,8 @@ REDISMODULE_API const RedisModuleString * (*RedisModule_GetKeyNameFromDefragCtx)
 REDISMODULE_API int (*RedisModule_EventLoopAdd)(int fd, int mask, RedisModuleEventLoopFunc func, void *user_data) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_EventLoopDel)(int fd, int mask) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_EventLoopAddOneShot)(RedisModuleEventLoopOneShotFunc func, void *user_data) REDISMODULE_ATTR;
-REDISMODULE_API char * (*RedisModule_DumpACL)() REDISMODULE_ATTR;
-REDISMODULE_API char * (*RedisModule_LoadACL)(char * aclString) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_DumpACL)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API char * (*RedisModule_LoadACL)(RedisModuleString *aclString) REDISMODULE_ATTR;
 
 #define RedisModule_IsAOFClient(id) ((id) == UINT64_MAX)
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1159,7 +1159,7 @@ REDISMODULE_API int (*RedisModule_EventLoopAdd)(int fd, int mask, RedisModuleEve
 REDISMODULE_API int (*RedisModule_EventLoopDel)(int fd, int mask) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_EventLoopAddOneShot)(RedisModuleEventLoopOneShotFunc func, void *user_data) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString *(*RedisModule_DumpACL)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API char * (*RedisModule_LoadACL)(RedisModuleString *aclString) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleString *(*RedisModule_LoadACL)(RedisModuleCtx *ctx, RedisModuleString *aclString) REDISMODULE_ATTR;
 
 #define RedisModule_IsAOFClient(id) ((id) == UINT64_MAX)
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1158,6 +1158,8 @@ REDISMODULE_API const RedisModuleString * (*RedisModule_GetKeyNameFromDefragCtx)
 REDISMODULE_API int (*RedisModule_EventLoopAdd)(int fd, int mask, RedisModuleEventLoopFunc func, void *user_data) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_EventLoopDel)(int fd, int mask) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_EventLoopAddOneShot)(RedisModuleEventLoopOneShotFunc func, void *user_data) REDISMODULE_ATTR;
+REDISMODULE_API char * (*RedisModule_DumpACL)() REDISMODULE_ATTR;
+REDISMODULE_API char * (*RedisModule_LoadACL)(char * aclString) REDISMODULE_ATTR;
 
 #define RedisModule_IsAOFClient(id) ((id) == UINT64_MAX)
 
@@ -1481,6 +1483,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(EventLoopAdd);
     REDISMODULE_GET_API(EventLoopDel);
     REDISMODULE_GET_API(EventLoopAddOneShot);
+    REDISMODULE_GET_API(DumpACL);
+    REDISMODULE_GET_API(LoadACL);
 
     if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;
     RedisModule_SetModuleAttribs(ctx,name,ver,apiver);

--- a/src/server.h
+++ b/src/server.h
@@ -3450,6 +3450,8 @@ dict *genInfoSectionDict(robj **argv, int argc, char **defaults, int *out_all, i
 void releaseInfoSectionDict(dict *sec);
 sds genRedisInfoString(dict *section_dict, int all_sections, int everything);
 sds genModulesInfoString(sds info);
+sds saveACLToBuffer();
+sds loadACLFromBuffer(sds buf);
 void applyWatchdogPeriod();
 void watchdogScheduleSignal(int period);
 void serverLogHexDump(int level, char *descr, void *value, size_t len);

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -49,6 +49,7 @@ TEST_MODULES = \
     hash.so \
     zset.so \
     stream.so \
+    acl.so \
     aclcheck.so \
     list.so \
     subcommands.so \

--- a/tests/modules/acl.c
+++ b/tests/modules/acl.c
@@ -16,7 +16,7 @@ int load_acl(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return RedisModule_WrongArity(ctx);
     }
 
-    RedisModule_LoadACL(argv[1]);
+    RedisModule_LoadACL(ctx, argv[1]);
 
     RedisModule_ReplyWithSimpleString(ctx, "OK");
 

--- a/tests/modules/acl.c
+++ b/tests/modules/acl.c
@@ -1,0 +1,40 @@
+#include "redismodule.h"
+
+int dump_acl(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    RedisModuleString * ret = RedisModule_DumpACL(ctx);
+
+    RedisModule_ReplyWithString(ctx, ret);
+
+    return REDISMODULE_OK;
+}
+
+int load_acl(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 2) {
+        return RedisModule_WrongArity(ctx);
+    }
+
+    RedisModule_LoadACL(argv[1]);
+
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx,"acl",1,REDISMODULE_APIVER_1)== REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"acl.dump", dump_acl,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"acl.load", load_acl,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    return REDISMODULE_OK;
+}

--- a/tests/modules/acl.c
+++ b/tests/modules/acl.c
@@ -8,6 +8,8 @@ int dump_acl(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     RedisModule_ReplyWithString(ctx, ret);
 
+    RedisModule_FreeString(ctx, ret);
+
     return REDISMODULE_OK;
 }
 

--- a/tests/unit/moduleapi/acl.tcl
+++ b/tests/unit/moduleapi/acl.tcl
@@ -1,0 +1,22 @@
+set testmodule [file normalize tests/modules/acl.so]
+
+start_server {tags {"modules acl"}} {
+    r module load $testmodule
+
+    test {test module dump/reload acls} {
+        # create user
+        assert_equal [r acl setuser test on allkeys allcommands >test ] OK
+        # verify user
+        assert_not_equal [r acl getuser test] {_}
+        # dump acls
+        set acls [r acl.dump]
+        # delete user
+        assert_equal [r acl deluser test ] 1
+        # verify user deleted
+        assert_equal [r acl getuser test] ""
+        # reload acls
+        r acl.load acls
+        # verify user exists
+        assert_equal [r acl getuser test] "hello"
+    }
+}

--- a/tests/unit/moduleapi/acl.tcl
+++ b/tests/unit/moduleapi/acl.tcl
@@ -7,7 +7,8 @@ start_server {tags {"modules acl"}} {
         # create user
         assert_equal [r acl setuser test on allkeys allcommands >test ] OK
         # verify user
-        assert_not_equal [r acl getuser test] {_}
+        set old_acl [r acl getuser test]
+        assert_not_equal old_acl ""
         # dump acls
         set acls [r acl.dump]
         # delete user
@@ -15,8 +16,9 @@ start_server {tags {"modules acl"}} {
         # verify user deleted
         assert_equal [r acl getuser test] ""
         # reload acls
-        r acl.load acls
-        # verify user exists
-        assert_equal [r acl getuser test] "hello"
+        r acl.load $acls
+        # verify user exists and is the same
+        set new_acl [r acl getuser test]
+        assert_equal $old_acl $new_acl
     }
 }


### PR DESCRIPTION
for modules that provide their own database snapshotting capabilities, the current api doesn't allow them to easily/cleanly include ACL state in their snapshots.

This is a small refactor of the ACLSaveToFile/ACLLoadFromFile to enable adding simple module APIs to use the same code path, but only save to a buffer.

TODO:
- [x] make it more "redis module api like"
- [x] memory allocations should be able to associate it to module.
- [ ] documentation
- [x] test(s)