### PR TITLE
Add new RM_Call flags for script mode, no writes, and error replies.

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2422,7 +2422,7 @@ const char* getAclErrorMessage(int acl_res) {
     default:
         return "lacking the permissions for the command";
     }
-    serverAssert(false);
+    serverPanic("Reached deadcode on getAclErrorMessage");
 }
 
 /* =============================================================================

--- a/src/acl.c
+++ b/src/acl.c
@@ -2411,6 +2411,20 @@ void addACLLogEntry(client *c, int reason, int context, int argpos, sds username
     }
 }
 
+const char* getAclErrorMessage(int acl_res) {
+    switch (acl_res) {
+    case ACL_DENIED_CMD:
+        return "can't run this command or subcommand";
+    case ACL_DENIED_KEY:
+        return "can't access at least one of the keys mentioned in the command arguments";
+    case ACL_DENIED_CHANNEL:
+        return "can't publish to the channel mentioned in the command";
+    default:
+        return "lacking the permissions for the command";
+    }
+    serverAssert(false);
+}
+
 /* =============================================================================
  * ACL related commands
  * ==========================================================================*/

--- a/src/acl.c
+++ b/src/acl.c
@@ -2412,6 +2412,8 @@ void addACLLogEntry(client *c, int reason, int context, int argpos, sds username
 }
 
 const char* getAclErrorMessage(int acl_res) {
+    /* Notice that a variant of this code also exists on aclCommand so
+     * it also need to be updated on changed. */
     switch (acl_res) {
     case ACL_DENIED_CMD:
         return "can't run this command or subcommand";
@@ -2809,6 +2811,8 @@ setuser_cleanup:
 
         int idx;
         int result = ACLCheckAllUserCommandPerm(u, cmd, c->argv + 3, c->argc - 3, &idx);
+        /* Notice that a variant of this code also exists on getAclErrorMessage so
+         * it also need to be updated on changed. */
         if (result != ACL_OK) {
             sds err = sdsempty();
             if (result == ACL_DENIED_CMD) {

--- a/src/call_reply.c
+++ b/src/call_reply.c
@@ -530,8 +530,11 @@ CallReply *callReplyCreate(sds reply, list *deferred_error_list, void *private_d
  * Automatically creating deferred_error_list and set a copy of the reply in it.
  * Refer to callReplyCreate for detailed explanation. */
 CallReply *callReplyCreateError(sds reply, void *private_data) {
-    sds err_buff = sdscatfmt(sdsempty(), "-%S\r\n", reply);
-    sdsfree(reply);
+    sds err_buff = reply;
+    if (err_buff[0] != '-') {
+        err_buff = sdscatfmt(sdsempty(), "-ERR %S\r\n", reply);
+        sdsfree(reply);
+    }
     list *deferred_error_list = listCreate();
     listSetFreeMethod(deferred_error_list, (void (*)(void*))sdsfree);
     listAddNodeTail(deferred_error_list, sdsnew(err_buff));

--- a/src/call_reply.c
+++ b/src/call_reply.c
@@ -525,3 +525,15 @@ CallReply *callReplyCreate(sds reply, list *deferred_error_list, void *private_d
     res->deferred_error_list = deferred_error_list;
     return res;
 }
+
+/* Create a new CallReply struct from the reply blob representing an error message.
+ * Automatically creating deferred_error_list and set a copy of the reply in it.
+ * Refer to callReplyCreate for detailed explanation. */
+CallReply *callReplyCreateError(sds reply, void *private_data) {
+    sds err_buff = sdscatfmt(sdsempty(), "-%s\r\n", reply);
+    sdsfree(reply);
+    list *deferred_error_list = listCreate();
+    listSetFreeMethod(deferred_error_list, (void (*)(void*))sdsfree);
+    listAddNodeTail(deferred_error_list, sdsnew(err_buff));
+    return callReplyCreate(err_buff, deferred_error_list, private_data);
+}

--- a/src/call_reply.c
+++ b/src/call_reply.c
@@ -530,7 +530,7 @@ CallReply *callReplyCreate(sds reply, list *deferred_error_list, void *private_d
  * Automatically creating deferred_error_list and set a copy of the reply in it.
  * Refer to callReplyCreate for detailed explanation. */
 CallReply *callReplyCreateError(sds reply, void *private_data) {
-    sds err_buff = sdscatfmt(sdsempty(), "-%s\r\n", reply);
+    sds err_buff = sdscatfmt(sdsempty(), "-%S\r\n", reply);
     sdsfree(reply);
     list *deferred_error_list = listCreate();
     listSetFreeMethod(deferred_error_list, (void (*)(void*))sdsfree);

--- a/src/call_reply.h
+++ b/src/call_reply.h
@@ -35,6 +35,7 @@
 typedef struct CallReply CallReply;
 
 CallReply *callReplyCreate(sds reply, list *deferred_error_list, void *private_data);
+CallReply *callReplyCreateError(sds reply, void *private_data);
 int callReplyType(CallReply *rep);
 const char *callReplyGetString(CallReply *rep, size_t *len);
 long long callReplyGetLongLong(CallReply *rep);

--- a/src/module.c
+++ b/src/module.c
@@ -5597,7 +5597,7 @@ fmterr:
  *              probably used when you want to pass the reply directly to the client.
  *     * `C` -- Check if command can be executed according to ACL rules.
  *     * 'S' -- Run the command in a script mode, this means that it will raise an error
- *              if a command which are not allowed inside a script (flaged with the no-script flag)
+ *              if a command which are not allowed inside a script (flagged with the no-script flag)
  *              is invoke (like shutdown).
  *              In addition, on script mode, write commands are not allowed if there is
  *              not enough good replicas (as configured with repl_min_slaves_to_write)

--- a/src/module.c
+++ b/src/module.c
@@ -5596,13 +5596,13 @@ fmterr:
  *              same as the client attached to the given RedisModuleCtx. This will
  *              probably used when you want to pass the reply directly to the client.
  *     * `C` -- Check if command can be executed according to ACL rules.
- *     * 'S' -- Run the command in a script mode, this means that it will raise an error
- *              if a command which are not allowed inside a script (flagged with the no-script flag)
- *              is invoked (like SHUTDOWN).
+ *     * 'S' -- Run the command in a script mode, this means that it will raise
+ *              an error if a command which are not allowed inside a script
+ *              (flagged with the `deny-script` flag) is invoked (like SHUTDOWN).
  *              In addition, on script mode, write commands are not allowed if there are
  *              not enough good replicas (as configured with repl_min_slaves_to_write)
  *              or when the server is unable to persist to the disk.
- *     * 'W' -- Do not allow to run any write command (flagged with the write flag).
+ *     * 'W' -- Do not allow to run any write command (flagged with the `write` flag).
  *     * 'E' -- Return error as RedisModuleCallReply. If there is an error before
  *              invoking the command, the error is returned using errno mechanism.
  *              This flag allows to get the error also as an error CallReply with

--- a/src/module.c
+++ b/src/module.c
@@ -5600,7 +5600,7 @@ fmterr:
  *              an error if a command which are not allowed inside a script
  *              (flagged with the `deny-script` flag) is invoked (like SHUTDOWN).
  *              In addition, on script mode, write commands are not allowed if there are
- *              not enough good replicas (as configured with repl_min_slaves_to_write)
+ *              not enough good replicas (as configured with `min-replicas-to-write`)
  *              or when the server is unable to persist to the disk.
  *     * 'W' -- Do not allow to run any write command (flagged with the `write` flag).
  *     * 'E' -- Return error as RedisModuleCallReply. If there is an error before

--- a/src/module.c
+++ b/src/module.c
@@ -5598,10 +5598,10 @@ fmterr:
  *     * `C` -- Check if command can be executed according to ACL rules.
  *     * 'S' -- Run the command in a script mode, this means that it will raise an error
  *              if a command which are not allowed inside a script (flagged with the no-script flag)
- *              is invoked (like shutdown).
- *              In addition, on script mode, write commands are not allowed if there is
+ *              is invoked (like SHUTDOWN).
+ *              In addition, on script mode, write commands are not allowed if there are
  *              not enough good replicas (as configured with repl_min_slaves_to_write)
- *              and/or a disk error happened.
+ *              or when the server is unable to persist to the disk.
  *     * 'W' -- Do not allow to run any write command (flagged with the write flag).
  *     * 'E' -- Return error as RedisModuleCallReply. If there is an error before
  *              invoking the command, the error is returned using errno mechanism.

--- a/src/module.c
+++ b/src/module.c
@@ -5598,7 +5598,7 @@ fmterr:
  *     * `C` -- Check if command can be executed according to ACL rules.
  *     * 'S' -- Run the command in a script mode, this means that it will raise an error
  *              if a command which are not allowed inside a script (flagged with the no-script flag)
- *              is invoke (like shutdown).
+ *              is invoked (like shutdown).
  *              In addition, on script mode, write commands are not allowed if there is
  *              not enough good replicas (as configured with repl_min_slaves_to_write)
  *              and/or a disk error happened.
@@ -5735,8 +5735,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
              * We will not run it if we encounter disk error
              * or we do not have enough replicas */
 
-            if (!checkGoodReplicasStatus())
-            {
+            if (!checkGoodReplicasStatus()) {
                 errno = EACCES;
                 if (error_as_call_replies) {
                     sds msg = sdsdup(shared.noreplicaserr->ptr);

--- a/src/module.c
+++ b/src/module.c
@@ -5599,7 +5599,7 @@ fmterr:
  *     * 'S' -- Run the command in a safe mode, this means that it will raise an error
  *              if a dangerous command is invoke (like shutdown). All the commands
  *              which are flag with the no-script flag is considered dangerous.
- *     * 'W' -- Do not allow to run any write command (flaged with the write flag).
+ *     * 'W' -- Do not allow to run any write command (flagged with the write flag).
  *     * 'E' -- Return error as RedisModuleCallReply. If there is an error before
  *              invoking the command, the error is returned using errno mechanism.
  *              This flag allows to get the error also as an error CallReply with

--- a/src/module.c
+++ b/src/module.c
@@ -5685,7 +5685,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
         errno = ENOENT;
         if (error_as_call_replies) {
             sds msg = sdscatfmt(sdsempty(),"ERR Unknown Redis "
-                                           "command %s.",c->argv[0]->ptr);
+                                           "command %S.",c->argv[0]->ptr);
             reply = callReplyCreateError(msg, ctx);
         }
         goto cleanup;
@@ -5697,7 +5697,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
         errno = EINVAL;
         if (error_as_call_replies) {
             sds msg = sdscatfmt(sdsempty(), "ERR Wrong number of "
-                                            "args calling Redis command %s.", c->argv[0]->ptr);
+                                            "args calling Redis command %S.", c->argv[0]->ptr);
             reply = callReplyCreateError(msg, ctx);
         }
         goto cleanup;
@@ -5710,7 +5710,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
             errno = EACCES;
             if (error_as_call_replies) {
                 sds msg = sdscatfmt(sdsempty(), "ERR Unsafe command "
-                                                "%s was called.", c->argv[0]->ptr);
+                                                "%S was called.", c->argv[0]->ptr);
                 reply = callReplyCreateError(msg, ctx);
             }
             goto cleanup;
@@ -5721,7 +5721,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
         if (cmd->flags & CMD_WRITE) {
             errno = EACCES;
             if (error_as_call_replies) {
-                sds msg = sdscatfmt(sdsempty(), "ERR Write command %s was "
+                sds msg = sdscatfmt(sdsempty(), "ERR Write command %S was "
                                                 "called while write is not allowed.", c->argv[0]->ptr);
                 reply = callReplyCreateError(msg, ctx);
             }
@@ -5784,12 +5784,12 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
             sds msg = NULL;
             if (error_code == CLUSTER_REDIR_DOWN_RO_STATE) {
                 if (error_as_call_replies) {
-                    msg = sdscatfmt(sdsempty(), "ERR Can not execute a write command %s while the cluster is down and readonly", c->argv[0]->ptr);
+                    msg = sdscatfmt(sdsempty(), "ERR Can not execute a write command %S while the cluster is down and readonly", c->argv[0]->ptr);
                 }
                 errno = EROFS;
             } else if (error_code == CLUSTER_REDIR_DOWN_STATE) {
                 if (error_as_call_replies) {
-                    msg = sdscatfmt(sdsempty(), "ERR Can not execute a command %s while the cluster is down", c->argv[0]->ptr);
+                    msg = sdscatfmt(sdsempty(), "ERR Can not execute a command %S while the cluster is down", c->argv[0]->ptr);
                 }
                 errno = ENETDOWN;
             } else {

--- a/src/replication.c
+++ b/src/replication.c
@@ -3342,6 +3342,14 @@ void refreshGoodSlavesCount(void) {
     server.repl_good_slaves_count = good;
 }
 
+/* return true if status of good replicas is OK. otherwise false */
+int checkGoodReplicasStatus(void) {
+    return server.masterhost || /* not a primary status should be OK */
+           !server.repl_min_slaves_max_lag || /* Min slave max lag not configured */
+           !server.repl_min_slaves_to_write || /* Min slave to write not configured */
+           server.repl_good_slaves_count >= server.repl_min_slaves_to_write; /* check if we have enough slaves */
+}
+
 /* ----------------------- SYNCHRONOUS REPLICATION --------------------------
  * Redis synchronous replication design can be summarized in points:
  *

--- a/src/script.c
+++ b/src/script.c
@@ -350,8 +350,7 @@ static int scriptVerifyWriteCommandAllow(scriptRunCtx *run_ctx, char **err) {
      * user configured the min-slaves-to-write option. Note this only reachable
      * for Eval scripts that didn't declare flags, see the other check in
      * scriptPrepareForRun */
-    if (!checkGoodReplicasStatus())
-    {
+    if (!checkGoodReplicasStatus()) {
         *err = sdsdup(shared.noreplicaserr->ptr);
         return C_ERR;
     }

--- a/src/script.c
+++ b/src/script.c
@@ -312,25 +312,7 @@ static int scriptVerifyACL(client *c, sds *err) {
     int acl_retval = ACLCheckAllPerm(c, &acl_errpos);
     if (acl_retval != ACL_OK) {
         addACLLogEntry(c,acl_retval,ACL_LOG_CTX_LUA,acl_errpos,NULL,NULL);
-        switch (acl_retval) {
-        case ACL_DENIED_CMD:
-            *err = sdsnew("The user executing the script can't run this "
-                          "command or subcommand");
-            break;
-        case ACL_DENIED_KEY:
-            *err = sdsnew("The user executing the script can't access "
-                          "at least one of the keys mentioned in the "
-                          "command arguments");
-            break;
-        case ACL_DENIED_CHANNEL:
-            *err = sdsnew("The user executing the script can't publish "
-                          "to the channel mentioned in the command");
-            break;
-        default:
-            *err = sdsnew("The user executing the script is lacking the "
-                          "permissions for the command");
-            break;
-        }
+        *err = sdscatfmt(sdsempty(), "The user executing the script %s", getAclErrorMessage(acl_retval));
         return C_ERR;
     }
     return C_OK;
@@ -360,14 +342,7 @@ static int scriptVerifyWriteCommandAllow(scriptRunCtx *run_ctx, char **err) {
     }
 
     if (deny_write_type != DISK_ERROR_TYPE_NONE) {
-        if (deny_write_type == DISK_ERROR_TYPE_RDB) {
-            *err = sdsdup(shared.bgsaveerr->ptr);
-        } else {
-            *err = sdsempty();
-            *err = sdscatfmt(*err,
-                    "-MISCONF Errors writing to the AOF file: %s\r\n",
-                    strerror(server.aof_last_write_errno));
-        }
+        *err = writeCommandsGetDiskErrorMessage(deny_write_type);
         return C_ERR;
     }
 
@@ -375,10 +350,7 @@ static int scriptVerifyWriteCommandAllow(scriptRunCtx *run_ctx, char **err) {
      * user configured the min-slaves-to-write option. Note this only reachable
      * for Eval scripts that didn't declare flags, see the other check in
      * scriptPrepareForRun */
-    if (server.masterhost == NULL &&
-        server.repl_min_slaves_max_lag &&
-        server.repl_min_slaves_to_write &&
-        server.repl_good_slaves_count < server.repl_min_slaves_to_write)
+    if (!checkGoodReplicasStatus())
     {
         *err = sdsdup(shared.noreplicaserr->ptr);
         return C_ERR;

--- a/src/server.c
+++ b/src/server.c
@@ -4170,6 +4170,19 @@ int writeCommandsDeniedByDiskError(void) {
     return DISK_ERROR_TYPE_NONE;
 }
 
+sds writeCommandsGetDiskErrorMessage(int error_code) {
+    sds ret = NULL;
+    if (error_code == DISK_ERROR_TYPE_RDB) {
+        ret = sdsdup(shared.bgsaveerr->ptr);
+    } else {
+        ret = sdsempty();
+        ret = sdscatfmt(sdsempty(),
+                "-MISCONF Errors writing to the AOF file: %s\r\n",
+                strerror(server.aof_last_write_errno));
+    }
+    return ret;
+}
+
 /* The PING command. It works in a different way if the client is in
  * in Pub/Sub mode. */
 void pingCommand(client *c) {

--- a/src/server.c
+++ b/src/server.c
@@ -3430,6 +3430,16 @@ void rejectCommand(client *c, robj *reply) {
     }
 }
 
+void rejectCommandSds(client *c, sds s) {
+    if (c->cmd && c->cmd->proc == execCommand) {
+        execCommandAbort(c, s);
+        sdsfree(s);
+    } else {
+        /* The following frees 's'. */
+        addReplyErrorSds(c, s);
+    }
+}
+
 void rejectCommandFormat(client *c, const char *fmt, ...) {
     if (c->cmd) c->cmd->rejected_calls++;
     flagTransaction(c);
@@ -3440,13 +3450,7 @@ void rejectCommandFormat(client *c, const char *fmt, ...) {
     /* Make sure there are no newlines in the string, otherwise invalid protocol
      * is emitted (The args come from the user, they may contain any character). */
     sdsmapchars(s, "\r\n", "  ",  2);
-    if (c->cmd && c->cmd->proc == execCommand) {
-        execCommandAbort(c, s);
-        sdsfree(s);
-    } else {
-        /* The following frees 's'. */
-        addReplyErrorSds(c, s);
-    }
+    rejectCommandSds(c, s);
 }
 
 /* This is called after a command in call, we can do some maintenance job in it. */
@@ -3729,23 +3733,14 @@ int processCommand(client *c) {
         server.masterhost == NULL &&
         (is_write_command ||c->cmd->proc == pingCommand))
     {
-        if (deny_write_type == DISK_ERROR_TYPE_RDB)
-            rejectCommand(c, shared.bgsaveerr);
-        else
-            rejectCommandFormat(c,
-                "-MISCONF Errors writing to the AOF file: %s",
-                strerror(server.aof_last_write_errno));
+        sds err = writeCommandsGetDiskErrorMessage(deny_write_type);
+        rejectCommandSds(c, err);
         return C_OK;
     }
 
     /* Don't accept write commands if there are not enough good slaves and
      * user configured the min-slaves-to-write option. */
-    if (server.masterhost == NULL &&
-        server.repl_min_slaves_to_write &&
-        server.repl_min_slaves_max_lag &&
-        is_write_command &&
-        server.repl_good_slaves_count < server.repl_min_slaves_to_write)
-    {
+    if (is_write_command && !checkGoodReplicasStatus()) {
         rejectCommand(c, shared.noreplicaserr);
         return C_OK;
     }
@@ -4175,9 +4170,8 @@ sds writeCommandsGetDiskErrorMessage(int error_code) {
     if (error_code == DISK_ERROR_TYPE_RDB) {
         ret = sdsdup(shared.bgsaveerr->ptr);
     } else {
-        ret = sdsempty();
         ret = sdscatfmt(sdsempty(),
-                "-MISCONF Errors writing to the AOF file: %s\r\n",
+                "-MISCONF Errors writing to the AOF file: %s",
                 strerror(server.aof_last_write_errno));
     }
     return ret;

--- a/src/server.h
+++ b/src/server.h
@@ -2651,6 +2651,7 @@ void resizeReplicationBacklog();
 void replicationSetMaster(char *ip, int port);
 void replicationUnsetMaster(void);
 void refreshGoodSlavesCount(void);
+int checkGoodReplicasStatus(void);
 void processClientsWaitingReplicas(void);
 void unblockClientWaitingReplicas(client *c);
 int replicationCountAcksByOffset(long long offset);
@@ -2691,6 +2692,7 @@ int allPersistenceDisabled(void);
 #define DISK_ERROR_TYPE_RDB 2       /* Don't accept writes: RDB errors. */
 #define DISK_ERROR_TYPE_NONE 0      /* No problems, we can accept writes. */
 int writeCommandsDeniedByDiskError(void);
+sds writeCommandsGetDiskErrorMessage(int);
 
 /* RDB persistence */
 #include "rdb.h"
@@ -2771,6 +2773,7 @@ void addReplyCommandCategories(client *c, struct redisCommand *cmd);
 user *ACLCreateUnlinkedUser();
 void ACLFreeUserAndKillClients(user *u);
 void addACLLogEntry(client *c, int reason, int context, int argpos, sds username, sds object);
+const char* getAclErrorMessage(int acl_res);
 void ACLUpdateDefaultUserPassword(sds password);
 
 /* Sorted sets data type */

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -136,6 +136,22 @@ int rm_call_aclcheck_cmd_module_user(RedisModuleCtx *ctx, RedisModuleString **ar
     return res;
 }
 
+int rm_call_aclcheck_with_errors(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if(argc < 2){
+        return RedisModule_WrongArity(ctx);
+    }
+
+    const char* cmd = RedisModule_StringPtrLen(argv[1], NULL);
+
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "vEC", argv + 2, argc - 2);
+    RedisModule_ReplyWithCallReply(ctx, rep);
+    RedisModule_FreeCallReply(rep);
+    return REDISMODULE_OK;
+}
+
 /* A wrap for RM_Call that pass the 'C' flag to do ACL check on the command. */
 int rm_call_aclcheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
     REDISMODULE_NOT_USED(argv);
@@ -189,6 +205,10 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_CreateCommand(ctx,"aclcheck.rm_call", rm_call_aclcheck,
                                   "write",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"aclcheck.rm_call_with_errors", rm_call_aclcheck_with_errors,
+                                      "write",0,0,0) == REDISMODULE_ERR)
+            return REDISMODULE_ERR;
 
     return REDISMODULE_OK;
 }

--- a/tests/modules/basics.c
+++ b/tests/modules/basics.c
@@ -866,16 +866,16 @@ int TestBasics(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (!TestAssertStringReply(ctx,RedisModule_CallReplyArrayElement(reply, 1),"1234",4)) goto fail;
 
     T("foo", "E");
-    if (!TestAssertErrorReply(ctx,reply,"ERR Unknown Redis command foo.",30)) goto fail;
+    if (!TestAssertErrorReply(ctx,reply,"ERR Unknown Redis command 'foo'.",32)) goto fail;
 
     T("set", "Ec", "x");
-    if (!TestAssertErrorReply(ctx,reply,"ERR Wrong number of args calling Redis command set.",51)) goto fail;
+    if (!TestAssertErrorReply(ctx,reply,"ERR Wrong number of args calling Redis command 'set'.",53)) goto fail;
 
     T("shutdown", "SE");
-    if (!TestAssertErrorReply(ctx,reply,"ERR Unsafe command shutdown was called.",39)) goto fail;
+    if (!TestAssertErrorReply(ctx,reply,"ERR command 'shutdown' is not allowed on script mode",52)) goto fail;
 
     T("set", "WEcc", "x", "1");
-    if (!TestAssertErrorReply(ctx,reply,"ERR Write command set was called while write is not allowed.",60)) goto fail;
+    if (!TestAssertErrorReply(ctx,reply,"ERR Write command 'set' was called while write is not allowed.",62)) goto fail;
 
     RedisModule_ReplyWithSimpleString(ctx,"ALL TESTS PASSED");
     return REDISMODULE_OK;

--- a/tests/modules/basics.c
+++ b/tests/modules/basics.c
@@ -718,6 +718,25 @@ end:
 
 /* Return 1 if the reply matches the specified string, otherwise log errors
  * in the server log and return 0. */
+int TestAssertErrorReply(RedisModuleCtx *ctx, RedisModuleCallReply *reply, char *str, size_t len) {
+    RedisModuleString *mystr, *expected;
+    if (RedisModule_CallReplyType(reply) != REDISMODULE_REPLY_ERROR) {
+        return 0;
+    }
+
+    mystr = RedisModule_CreateStringFromCallReply(reply);
+    expected = RedisModule_CreateString(ctx,str,len);
+    if (RedisModule_StringCompare(mystr,expected) != 0) {
+        const char *mystr_ptr = RedisModule_StringPtrLen(mystr,NULL);
+        const char *expected_ptr = RedisModule_StringPtrLen(expected,NULL);
+        RedisModule_Log(ctx,"warning",
+            "Unexpected Error reply reply '%s' (instead of '%s')",
+            mystr_ptr, expected_ptr);
+        return 0;
+    }
+    return 1;
+}
+
 int TestAssertStringReply(RedisModuleCtx *ctx, RedisModuleCallReply *reply, char *str, size_t len) {
     RedisModuleString *mystr, *expected;
 
@@ -845,6 +864,18 @@ int TestBasics(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (RedisModule_CallReplyLength(reply) != 2) goto fail;
     if (!TestAssertStringReply(ctx,RedisModule_CallReplyArrayElement(reply, 0),"test",4)) goto fail;
     if (!TestAssertStringReply(ctx,RedisModule_CallReplyArrayElement(reply, 1),"1234",4)) goto fail;
+
+    T("foo", "E");
+    if (!TestAssertErrorReply(ctx,reply,"ERR Unknown Redis command foo.",30)) goto fail;
+
+    T("set", "Ec", "x");
+    if (!TestAssertErrorReply(ctx,reply,"ERR Wrong number of args calling Redis command set.",51)) goto fail;
+
+    T("shutdown", "SE");
+    if (!TestAssertErrorReply(ctx,reply,"ERR Unsafe command shutdown was called.",39)) goto fail;
+
+    T("set", "WEcc", "x", "1");
+    if (!TestAssertErrorReply(ctx,reply,"ERR Write command set was called while write is not allowed.",60)) goto fail;
 
     RedisModule_ReplyWithSimpleString(ctx,"ALL TESTS PASSED");
     return REDISMODULE_OK;

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -195,7 +195,7 @@ int do_rm_call(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
 
     const char* cmd = RedisModule_StringPtrLen(argv[1], NULL);
 
-    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "v", argv + 2, argc - 2);
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "Ev", argv + 2, argc - 2);
     if(!rep){
         RedisModule_ReplyWithError(ctx, "NULL reply returned");
     }else{

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -62,13 +62,13 @@ start_server {tags {"modules acl"}} {
         # rm call check for key permission (y: only WRITE)
         assert_equal [r aclcheck.rm_call set y 5] OK
         assert_error {*NOPERM*} {r aclcheck.rm_call set y 5 get}
-        assert_error {ERR acl verification failed, the user can't access at least one of the keys mentioned in the command arguments.} {r aclcheck.rm_call_with_errors set y 5 get}
+        assert_error {ERR acl verification failed, can't access at least one of the keys mentioned in the command arguments.} {r aclcheck.rm_call_with_errors set y 5 get}
 
         # rm call check for key permission (z: only READ)
         assert_error {*NOPERM*} {r aclcheck.rm_call set z 5}
-        assert_error {ERR acl verification failed, the user can't access at least one of the keys mentioned in the command arguments.} {r aclcheck.rm_call_with_errors set z 5}
+        assert_error {ERR acl verification failed, can't access at least one of the keys mentioned in the command arguments.} {r aclcheck.rm_call_with_errors set z 5}
         assert_error {*NOPERM*} {r aclcheck.rm_call set z 6 get}
-        assert_error {ERR acl verification failed, the user can't access at least one of the keys mentioned in the command arguments.} {r aclcheck.rm_call_with_errors set z 6 get}
+        assert_error {ERR acl verification failed, can't access at least one of the keys mentioned in the command arguments.} {r aclcheck.rm_call_with_errors set z 6 get}
 
         # verify that new log entry added
         set entry [lindex [r ACL LOG] 0]
@@ -81,7 +81,7 @@ start_server {tags {"modules acl"}} {
         catch {r aclcheck.rm_call set x 5} e
         assert_match {*NOPERM*} $e
         catch {r aclcheck.rm_call_with_errors set x 5} e
-        assert_match {ERR acl verification failed, the user can't run this command or subcommand.} $e
+        assert_match {ERR acl verification failed, can't run this command or subcommand.} $e
 
         # verify that new log entry added
         set entry [lindex [r ACL LOG] 0]

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -62,10 +62,13 @@ start_server {tags {"modules acl"}} {
         # rm call check for key permission (y: only WRITE)
         assert_equal [r aclcheck.rm_call set y 5] OK
         assert_error {*NOPERM*} {r aclcheck.rm_call set y 5 get}
+        assert_error {ERR acl verification failed, the user can't access at least one of the keys mentioned in the command arguments.} {r aclcheck.rm_call_with_errors set y 5 get}
 
         # rm call check for key permission (z: only READ)
         assert_error {*NOPERM*} {r aclcheck.rm_call set z 5}
+        assert_error {ERR acl verification failed, the user can't access at least one of the keys mentioned in the command arguments.} {r aclcheck.rm_call_with_errors set z 5}
         assert_error {*NOPERM*} {r aclcheck.rm_call set z 6 get}
+        assert_error {ERR acl verification failed, the user can't access at least one of the keys mentioned in the command arguments.} {r aclcheck.rm_call_with_errors set z 6 get}
 
         # verify that new log entry added
         set entry [lindex [r ACL LOG] 0]
@@ -77,6 +80,8 @@ start_server {tags {"modules acl"}} {
         r acl setuser default -set
         catch {r aclcheck.rm_call set x 5} e
         assert_match {*NOPERM*} $e
+        catch {r aclcheck.rm_call_with_errors set x 5} e
+        assert_match {ERR acl verification failed, the user can't run this command or subcommand.} $e
 
         # verify that new log entry added
         set entry [lindex [r ACL LOG] 0]

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -184,7 +184,7 @@ start_server {tags {"modules"}} {
         r config resetstat
 
         # simple module command that replies with string error
-        assert_error "ERR Unknown Redis command hgetalllll." {r do_rm_call hgetalllll}
+        assert_error "ERR Unknown Redis command 'hgetalllll'." {r do_rm_call hgetalllll}
         assert_equal [errorrstat ERR r] {count=1}
 
         # module command that replies with string error from bg thread

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -184,17 +184,17 @@ start_server {tags {"modules"}} {
         r config resetstat
 
         # simple module command that replies with string error
-        assert_error "NULL reply returned" {r do_rm_call hgetalllll}
-        assert_equal [errorrstat NULL r] {count=1}
+        assert_error "ERR Unknown Redis command hgetalllll." {r do_rm_call hgetalllll}
+        assert_equal [errorrstat ERR r] {count=1}
 
         # module command that replies with string error from bg thread
         assert_error "NULL reply returned" {r do_bg_rm_call hgetalllll}
-        assert_equal [errorrstat NULL r] {count=2}
+        assert_equal [errorrstat NULL r] {count=1}
 
         # module command that returns an arity error
         r do_rm_call set x x
         assert_error "ERR wrong number of arguments for 'do_rm_call' command" {r do_rm_call}
-        assert_equal [errorrstat ERR r] {count=1}
+        assert_equal [errorrstat ERR r] {count=2}
 
         # RM_Call that propagates an error
         assert_error "WRONGTYPE*" {r do_rm_call hgetall x}

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -199,7 +199,7 @@ start_server [list overrides $base_conf] {
     }
 
     test "Verify command RM_Call is rejected when cluster is down" {
-        assert_error "ERR Can not execute a command set while the cluster is down" {$node1 do_rm_call set x 1}
+        assert_error "ERR Can not execute a command 'set' while the cluster is down" {$node1 do_rm_call set x 1}
     }
 
     exec kill -SIGCONT $node3_pid

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -20,6 +20,7 @@ proc csi {args} {
 
 set testmodule [file normalize tests/modules/blockonkeys.so]
 set testmodule_nokey [file normalize tests/modules/blockonbackground.so]
+set testmodule_blockedclient [file normalize tests/modules/blockedclient.so]
 
 # make sure the test infra won't use SELECT
 set ::singledb 1
@@ -42,6 +43,10 @@ start_server [list overrides $base_conf] {
     $node1 module load $testmodule_nokey
     $node2 module load $testmodule_nokey
     $node3 module load $testmodule_nokey
+
+    $node1 module load $testmodule_blockedclient
+    $node2 module load $testmodule_blockedclient
+    $node3 module load $testmodule_blockedclient
 
     test {Create 3 node cluster} {
         exec src/redis-cli --cluster-yes --cluster create \
@@ -191,6 +196,10 @@ start_server [list overrides $base_conf] {
         # verify there are no blocked clients
         assert_equal [s 0 blocked_clients]  {0}
         assert_equal [s -1 blocked_clients]  {0}
+    }
+
+    test "Verify command RM_Call is rejected when cluster is down" {
+        assert_error "ERR Can not execute a command set while the cluster is down" {$node1 do_rm_call set x 1}
     }
 
     exec kill -SIGCONT $node3_pid


### PR DESCRIPTION
The PR extends RM_Call with 3 new capabilities using new flags that are given to RM_Call as part of the `fmt` argument.
It aims to assist modules that are getting a list of commands to be executed from the user (not hard coded as part of the module logic), think of a module that implements a new scripting language...

* `S` - Run the command in a script mode, this means that it will raise an error if a command which are not allowed inside a script (flaged with the `deny-script` flag) is invoked (like SHUTDOWN). In addition, on script mode, write commands are not allowed if there is not enough good replicas (as configured with `min-replicas-to-write`) and/or a disk error happened.

* `W` - no writes mode, Redis will reject any command that is marked with `write` flag. Again can be useful to modules that implement a new scripting language and wants to prevent any write commands.

* `E` - Return errors as RedisModuleCallReply. Today the errors that happened before the command was invoked (like unknown commands or acl error) return a NULL reply and set errno. This might be missing important information about the failure and it is also impossible to just pass the error to the user using RM_ReplyWithCallReply. This new flag allows you to get a RedisModuleCallReply object with the relevant error message and treat it as if it was an error that was raised by the command invocation.

Tests were added to verify the new code paths.

In addition small refactoring was done to share some code between modules, scripts, and `processCommand` function:
1. `getAclErrorMessage` was added to `acl.c` to unified to log message extraction from the acl result
2. `checkGoodReplicasStatus` was added to `replication.c` to check the status of good replicas. It is used on `scriptVerifyWriteCommandAllow`, `RM_Call`, and `processCommand`.
3. `writeCommandsGetDiskErrorMessage` was added to `server.c` to get the error message on persistence failure. Again it is used on `scriptVerifyWriteCommandAllow`, `RM_Call`, and `processCommand`.