### PR TITLE
Some adjustments to command hints.

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -3449,8 +3449,9 @@ struct redisCommandArg FUNCTION_RESTORE_Args[] = {
 
 /* FUNCTION STATS tips */
 const char *FUNCTION_STATS_tips[] = {
+"nondeterministic_output",
 "request_policy:all_shards",
-"response_policy:one_succeeded",
+"response_policy:special",
 NULL
 };
 
@@ -4381,7 +4382,12 @@ struct redisCommandArg LATENCY_GRAPH_Args[] = {
 #define LATENCY_HISTOGRAM_History NULL
 
 /* LATENCY HISTOGRAM tips */
-#define LATENCY_HISTOGRAM_tips NULL
+const char *LATENCY_HISTOGRAM_tips[] = {
+"nondeterministic_output",
+"request_policy:all_nodes",
+"response_policy:special",
+NULL
+};
 
 /* LATENCY HISTOGRAM argument table */
 struct redisCommandArg LATENCY_HISTOGRAM_Args[] = {
@@ -4395,7 +4401,12 @@ struct redisCommandArg LATENCY_HISTOGRAM_Args[] = {
 #define LATENCY_HISTORY_History NULL
 
 /* LATENCY HISTORY tips */
-#define LATENCY_HISTORY_tips NULL
+const char *LATENCY_HISTORY_tips[] = {
+"nondeterministic_output",
+"request_policy:all_nodes",
+"response_policy:special",
+NULL
+};
 
 /* LATENCY HISTORY argument table */
 struct redisCommandArg LATENCY_HISTORY_Args[] = {
@@ -4409,7 +4420,12 @@ struct redisCommandArg LATENCY_HISTORY_Args[] = {
 #define LATENCY_LATEST_History NULL
 
 /* LATENCY LATEST tips */
-#define LATENCY_LATEST_tips NULL
+const char *LATENCY_LATEST_tips[] = {
+"nondeterministic_output",
+"request_policy:all_nodes",
+"response_policy:special",
+NULL
+};
 
 /********** LATENCY RESET ********************/
 
@@ -4417,7 +4433,11 @@ struct redisCommandArg LATENCY_HISTORY_Args[] = {
 #define LATENCY_RESET_History NULL
 
 /* LATENCY RESET tips */
-#define LATENCY_RESET_tips NULL
+const char *LATENCY_RESET_tips[] = {
+"request_policy:all_nodes",
+"response_policy:all_succeeded",
+NULL
+};
 
 /* LATENCY RESET argument table */
 struct redisCommandArg LATENCY_RESET_Args[] = {
@@ -4505,6 +4525,8 @@ NULL
 /* MEMORY STATS tips */
 const char *MEMORY_STATS_tips[] = {
 "nondeterministic_output",
+"request_policy:all_shards",
+"response_policy:special",
 NULL
 };
 

--- a/src/commands/function-stats.json
+++ b/src/commands/function-stats.json
@@ -15,8 +15,9 @@
             "SCRIPTING"
         ],
         "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
             "REQUEST_POLICY:ALL_SHARDS",
-            "RESPONSE_POLICY:ONE_SUCCEEDED"
+            "RESPONSE_POLICY:SPECIAL"
         ]
     }
 }

--- a/src/commands/latency-histogram.json
+++ b/src/commands/latency-histogram.json
@@ -13,6 +13,11 @@
             "LOADING",
             "STALE"
         ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
         "arguments": [
             {
                 "name": "COMMAND",

--- a/src/commands/latency-history.json
+++ b/src/commands/latency-history.json
@@ -13,7 +13,12 @@
             "LOADING",
             "STALE"
         ],
-        "arguments": [
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:SPECIAL"
+        ],
+       "arguments": [
             {
                 "name": "event",
                 "type": "string"

--- a/src/commands/latency-latest.json
+++ b/src/commands/latency-latest.json
@@ -12,6 +12,11 @@
             "NOSCRIPT",
             "LOADING",
             "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:SPECIAL"
         ]
     }
 }

--- a/src/commands/latency-reset.json
+++ b/src/commands/latency-reset.json
@@ -13,6 +13,10 @@
             "LOADING",
             "STALE"
         ],
+        "command_tips": [
+            "REQUEST_POLICY:ALL_NODES",
+            "RESPONSE_POLICY:ALL_SUCCEEDED"
+        ],
         "arguments": [
             {
                 "name": "event",

--- a/src/commands/memory-stats.json
+++ b/src/commands/memory-stats.json
@@ -8,7 +8,9 @@
         "container": "MEMORY",
         "function": "memoryCommand",
         "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
+            "NONDETERMINISTIC_OUTPUT",
+            "REQUEST_POLICY:ALL_SHARDS",
+            "RESPONSE_POLICY:SPECIAL"
         ]
     }
 }


### PR DESCRIPTION
* stats and latency commands have non-deterministic output.
* the ones about latency should be sent to ALL_NODES (considering
  reads from replicas)
* the ones about running scripts and memory usage only to masters.
* stats aggregation is SPECIAL (like in INFO)