### PR TITLE
Initialize help when using redis-cli help or redis-cli ?

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -9021,7 +9021,7 @@ int main(int argc, char **argv) {
 
     /* Otherwise, we have some arguments to execute */
     if (config.eval) {
-        if (cliConnect(CC_FORCE) != REDIS_OK) exit(1);
+        if (cliConnect(0) != REDIS_OK) exit(1);
         return evalMode(argc,argv);
     } else {
         cliConnect(CC_QUIET);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2425,13 +2425,15 @@ static int confirmWithYes(char *msg, int ignore_force) {
 }
 
 static int issueCommandRepeat(int argc, char **argv, long repeat) {
-    while (1) {
-        if (!config.eval_ldb && /* In debugging mode, let's pass "help" to Redis. */
-            (!strcasecmp(argv[0],"help") || !strcasecmp(argv[0],"?"))) {
-            cliOutputHelp(--argc, ++argv);
-            return REDIS_OK;
-        }
+    /* In debugging mode, let's pass "help" to Redis.
+     * Note we can process the "help" without a connection. */
+    if (!config.eval_ldb &&
+        (!strcasecmp(argv[0],"help") || !strcasecmp(argv[0],"?"))) {
+        cliOutputHelp(--argc, ++argv);
+        return REDIS_OK;
+    }
 
+    while (1) {
         if (config.cluster_reissue_command || context == NULL ||
             context->err == REDIS_ERR_IO || context->err == REDIS_ERR_EOF)
         {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -281,7 +281,7 @@ static void usage(int err);
 static void slaveMode(void);
 char *redisGitSHA1(void);
 char *redisGitDirty(void);
-static int cliConnect(int force);
+static int cliConnect(int flags);
 
 static char *getInfoField(char *info, char *field);
 static long getLongInfoField(char *info, char *field);
@@ -2414,6 +2414,8 @@ static int issueCommandRepeat(int argc, char **argv, long repeat) {
         }
         if (cliSendCommand(argc,argv,repeat) != REDIS_OK) {
             cliPrintContextError();
+            redisFree(context);
+            context = NULL;
             return REDIS_ERR;
         }
 

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -869,6 +869,12 @@ static void cliOutputHelp(int argc, char **argv) {
         group = argv[0]+1;
     }
 
+    if (helpEntries == NULL) {
+        /* Initialize the help using the results of the COMMAND command.
+         * In case we are using redis-cli help XXX, we need to init it. */
+        cliInitHelp();
+    }
+
     assert(argc > 0);
     for (i = 0; i < helpEntriesLen; i++) {
         entry = &helpEntries[i];


### PR DESCRIPTION
The following usage will output an empty newline:
```
> redis-cli help set
empty line
```

The reason is that in interactive mode, we have called
`cliInitHelp`, which initializes help.

When using `redis-cli help xxx` or `redis-cli help ? xxx`,
we can't match the command due to empty `helpEntries`,
so we output an empty newline.

In this commit, we will call `cliInitHelp` to init the help.
Note that in this case, we need to call `cliInitHelp` (COMMAND DOCS)
every time, which i think is acceptable.

So now the output will look like:
```
[redis]# src/redis-cli help get

  GET key
  summary: Get the value of a key
  since: 1.0.0
  group: string

[redis]#
```

Fixes #10378

This PR also fix a redis-cli crash when using `--ldb --eval`:
```
[root]# src/redis-cli --ldb --eval test.lua test 1
Lua debugging session started, please use:
quit    -- End the session.
restart -- Restart the script in debug mode again.
help    -- Show Lua script debugging commands.

* Stopped at 1, stop reason = step over
-> 1   local num = redis.call('GET', KEYS[1]);
redis-cli: redis-cli.c:718: cliCountCommands: Assertion
`commandTable->element[i]->type == 1' failed.
Aborted
```
Because in ldb mode, `COMMAND DOCS` or `COMMAND` will
return an array, only with one element, and the type
is `REDIS_REPLY_STATUS`, the result is `<error> Unknown
Redis Lua debugger command or wrong number of arguments`.

So if we are in the ldb mode, and init the Redis HELP, we
will get the wrong response and crash the redis-cli.
In ldb mode we don't initialize HELP, help is only initialized
after the lua debugging session ends.

It was broken in #10043