### PR TITLE
In redis-cli interactive mode, QUIT is a command

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2602,8 +2602,7 @@ static void repl(void) {
                 if (historyfile) linenoiseHistorySave(historyfile);
             }
 
-            if (strcasecmp(argv[0],"quit") == 0 ||
-                strcasecmp(argv[0],"exit") == 0)
+            if (strcasecmp(argv[0],"exit") == 0)
             {
                 exit(0);
             } else if (argv[0][0] == ':') {
@@ -2651,6 +2650,9 @@ static void repl(void) {
                 {
                     printf("(%.2fs)\n",(double)elapsed/1000);
                 }
+
+                if (strcasecmp(argv[0], "quit") == 0)
+                    exit(0);
             }
             /* Free the argument vector */
             sdsfreesplitres(argv,argc);

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -477,4 +477,8 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
         assert_equal 3 [exec {*}$cmdline ZCARD new_zset]
         assert_equal "a\n1\nb\n2\nc\n3" [exec {*}$cmdline ZRANGE new_zset 0 -1 WITHSCORES]
     }
+
+    test_interactive_cli "QUIT is a command" {
+        assert_equal "OK" [run_command $fd quit]
+    }
 }


### PR DESCRIPTION
In #9798, QUIT became a command. In redis-cli intercative
mode, we will exit directly if we match quit. Instead of
sending the QUIT command to redis server.

Now in this PR, we will send the real QUIT command to the
redis sever. Execute it as a real command.