### PR TITLE
Add log when clusterSaveConfig fails

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -430,6 +430,7 @@ int clusterSaveConfig(int do_fsync) {
     return 0;
 
 err:
+    serverLog(LL_WARNING, "WARNING: Cluster was not able to save the new configuration on disk: %s", strerror(errno));
     if (fd != -1) close(fd);
     sdsfree(ci);
     return -1;


### PR DESCRIPTION
In `clusterSaveConfigOrDie`, we will call `clusterSaveConfig`,
and if it fails, we will exit without any error logs.
The log format is from `sentinelFlushConfig`.

clusterSaveConfigOrDie: 
https://github.com/redis/redis/blob/e3ef73dc2a557232c60c732705e8e6ff2050eba9/src/cluster.c#L432-L443

sentinel log format:
https://github.com/redis/redis/blob/e3ef73dc2a557232c60c732705e8e6ff2050eba9/src/sentinel.c#L2274-L2278