### PR TITLE
Fix timing issue in rehash test

### DIFF
--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -333,6 +333,7 @@ start_server {tags {"other external:skip"}} {
         assert_no_match "*table size: 8192*" [r debug HTSTATS 9]
         exec kill -9 [get_child_pid 0]
         waitForBgsave r
+        after 200 ;# waiting for serverCron
 
         # Hash table should rehash since there is no child process,
         # size is power of two and over 4098, so it is 8192

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -332,7 +332,7 @@ start_server {tags {"other external:skip"}} {
         # Hash table should not rehash
         assert_no_match "*table size: 8192*" [r debug HTSTATS 9]
         exec kill -9 [get_child_pid 0]
-        after 200
+        waitForBgsave r
 
         # Hash table should rehash since there is no child process,
         # size is power of two and over 4098, so it is 8192


### PR DESCRIPTION
`Expected '*table size: 4096*' to match '*table size: 8192*'`

This test failed once on daily macOS, the reason is because
the bgsave has not stopped after the kill and `after 200`.
So there is a child process and no rehash triggered.

This commit use `waitForBgsave` to wait for it to finish.