### PR TITLE
remove a piece of redundant comment

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -121,8 +121,6 @@ typedef struct {
     uint64_t allowed_commands[USER_COMMAND_BITS_COUNT/64];
     /* allowed_firstargs is used by ACL rules to block access to a command unless a
      * specific argv[1] is given (or argv[2] in case it is applied on a sub-command).
-     * WARNING: Allowing a first arg of an otherwise blocked command is a misuse of ACL 
-     * and may get disabled in the future.
      *
      * For each command ID (corresponding to the command bit set in allowed_commands),
      * This array points to an array of SDS strings, terminated by a NULL pointer,

--- a/src/acl.c
+++ b/src/acl.c
@@ -121,9 +121,8 @@ typedef struct {
     uint64_t allowed_commands[USER_COMMAND_BITS_COUNT/64];
     /* allowed_firstargs is used by ACL rules to block access to a command unless a
      * specific argv[1] is given (or argv[2] in case it is applied on a sub-command).
-     * For example, a user can use the rule "-select +select|0" to block all
-     * SELECT commands, except "SELECT 0".
-     * And for a sub-command: "+config -config|set +config|set|loglevel"
+     * WARNING: Allowing a first arg of an otherwise blocked command is a misuse of ACL 
+     * and may get disabled in the future.
      *
      * For each command ID (corresponding to the command bit set in allowed_commands),
      * This array points to an array of SDS strings, terminated by a NULL pointer,

--- a/src/acl.c
+++ b/src/acl.c
@@ -120,7 +120,7 @@ typedef struct {
      * understand if the command can be executed. */
     uint64_t allowed_commands[USER_COMMAND_BITS_COUNT/64];
     /* allowed_firstargs is used by ACL rules to block access to a command unless a
-     * specific argv[1] is given (or argv[2] in case it is applied on a sub-command).
+     * specific argv[1] is given.
      *
      * For each command ID (corresponding to the command bit set in allowed_commands),
      * This array points to an array of SDS strings, terminated by a NULL pointer,


### PR DESCRIPTION
introduced in #10147 since we blocked the first-arg mechanism on subcommands