### PR TITLE
Add cluster keynode support

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -421,6 +421,23 @@ const char *CLUSTER_INFO_tips[] = {
 NULL
 };
 
+/********** CLUSTER KEYNODE ********************/
+
+/* CLUSTER KEYNODE history */
+#define CLUSTER_KEYNODE_History NULL
+
+/* CLUSTER KEYNODE tips */
+const char *CLUSTER_KEYNODE_tips[] = {
+"nondeterministic_output",
+NULL
+};
+
+/* CLUSTER KEYNODE argument table */
+struct redisCommandArg CLUSTER_KEYNODE_Args[] = {
+{"key",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{0}
+};
+
 /********** CLUSTER KEYSLOT ********************/
 
 /* CLUSTER KEYSLOT history */
@@ -649,6 +666,7 @@ struct redisCommand CLUSTER_Subcommands[] = {
 {"getkeysinslot","Return local key names in the specified hash slot","O(log(N)) where N is the number of requested keys","3.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_GETKEYSINSLOT_History,CLUSTER_GETKEYSINSLOT_tips,clusterCommand,4,CMD_STALE,0,.args=CLUSTER_GETKEYSINSLOT_Args},
 {"help","Show helpful text about the different subcommands","O(1)","5.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_HELP_History,CLUSTER_HELP_tips,clusterCommand,2,CMD_LOADING|CMD_STALE,0},
 {"info","Provides info about Redis Cluster node state","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_INFO_History,CLUSTER_INFO_tips,clusterCommand,2,CMD_STALE,0},
+{"keynode","Returns the ip and port of the node where the key is located","O(N) where N is the number of bytes in the key","7.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_KEYNODE_History,CLUSTER_KEYNODE_tips,clusterCommand,3,CMD_STALE,0,.args=CLUSTER_KEYNODE_Args},
 {"keyslot","Returns the hash slot of the specified key","O(N) where N is the number of bytes in the key","3.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_KEYSLOT_History,CLUSTER_KEYSLOT_tips,clusterCommand,3,CMD_STALE,0,.args=CLUSTER_KEYSLOT_Args},
 {"links","Returns a list of all TCP links to and from peer nodes in cluster","O(N) where N is the total number of Cluster nodes","7.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_LINKS_History,CLUSTER_LINKS_tips,clusterCommand,2,CMD_STALE,0},
 {"meet","Force a node cluster to handshake with another node","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_MEET_History,CLUSTER_MEET_tips,clusterCommand,-4,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,0,.args=CLUSTER_MEET_Args},

--- a/src/commands/cluster-keynode.json
+++ b/src/commands/cluster-keynode.json
@@ -1,0 +1,23 @@
+{
+    "KEYNODE": {
+        "summary": "Return the node ip and port for <key>",
+        "complexity": "O(N) where N is the number of bytes in the key",
+        "group": "cluster",
+        "since": "7.0",
+        "arity": 3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "STALE"
+        ],
+        "command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "string"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Background:
In some cases, we want to know which node the key is on, rather than which slot, because to get slot->node, we must call `CLUSTER SLOTS` or `CLUSTE NODES`, and parse the return result, so I added the `CLUSTER KEYNODE` command:
```
CLUSTER KEYNODE <key> : Return the node ip and port for <key>
```