### PR TITLE
Update json command files so they only include syntax related information

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -624,7 +624,7 @@ struct redisCommandArg CLUSTER_SLAVES_Args[] = {
 /* CLUSTER SLOTS history */
 commandHistory CLUSTER_SLOTS_History[] = {
 {"4.0.0","Added node IDs."},
-{"7.0.0","Added additional networking metadata and added support for hostnames and unknown endpoints."},
+{"7.0.0","Added additional networking metadata field."},
 {0}
 };
 
@@ -871,7 +871,6 @@ struct redisCommandArg CLIENT_NO_EVICT_Args[] = {
 
 /* CLIENT PAUSE history */
 commandHistory CLIENT_PAUSE_History[] = {
-{"3.2.10","Client pause prevents client pause and key eviction as well."},
 {"6.2.0","`CLIENT PAUSE WRITE` mode added along with the `mode` option."},
 {0}
 };
@@ -1549,10 +1548,7 @@ NULL
 /********** RENAME ********************/
 
 /* RENAME history */
-commandHistory RENAME_History[] = {
-{"3.2.0","The command no longer returns an error when source and destination names are the same."},
-{0}
-};
+#define RENAME_History NULL
 
 /* RENAME tips */
 #define RENAME_tips NULL
@@ -3157,10 +3153,7 @@ struct redisCommandArg SSUBSCRIBE_Args[] = {
 /********** SUBSCRIBE ********************/
 
 /* SUBSCRIBE history */
-commandHistory SUBSCRIBE_History[] = {
-{"6.2.0","`RESET` can be called to exit subscribed state."},
-{0}
-};
+#define SUBSCRIBE_History NULL
 
 /* SUBSCRIBE tips */
 #define SUBSCRIBE_tips NULL
@@ -3514,7 +3507,7 @@ struct redisCommandArg SCRIPT_EXISTS_Args[] = {
 
 /* SCRIPT FLUSH history */
 commandHistory SCRIPT_FLUSH_History[] = {
-{"6.2.0","Added the `ASYNC` and `SYNC` flushing mode modifiers, as well as the  **lazyfree-lazy-user-flush** configuration directive."},
+{"6.2.0","Added the `ASYNC` and `SYNC` flushing mode modifiers."},
 {0}
 };
 
@@ -4253,7 +4246,7 @@ struct redisCommandArg FAILOVER_Args[] = {
 /* FLUSHALL history */
 commandHistory FLUSHALL_History[] = {
 {"4.0.0","Added the `ASYNC` flushing mode modifier."},
-{"6.2.0","Added the `SYNC` flushing mode modifier and the **lazyfree-lazy-user-flush** configuration directive."},
+{"6.2.0","Added the `SYNC` flushing mode modifier."},
 {0}
 };
 
@@ -4282,7 +4275,7 @@ struct redisCommandArg FLUSHALL_Args[] = {
 /* FLUSHDB history */
 commandHistory FLUSHDB_History[] = {
 {"4.0.0","Added the `ASYNC` flushing mode modifier."},
-{"6.2.0","Added the `SYNC` flushing mode modifier and the **lazyfree-lazy-user-flush** configuration directive."},
+{"6.2.0","Added the `SYNC` flushing mode modifier."},
 {0}
 };
 
@@ -4601,12 +4594,7 @@ struct redisCommand MODULE_Subcommands[] = {
 /********** MONITOR ********************/
 
 /* MONITOR history */
-commandHistory MONITOR_History[] = {
-{"6.0.0","`AUTH` excluded from the command's output."},
-{"6.2.0","`RESET` can be called to exit monitor mode."},
-{"6.2.4","`AUTH`, `HELLO`, `EVAL`, `EVAL_RO`, `EVALSHA` and `EVALSHA_RO` included in the command's output."},
-{0}
-};
+#define MONITOR_History NULL
 
 /* MONITOR tips */
 #define MONITOR_tips NULL
@@ -4677,7 +4665,7 @@ struct redisCommandArg REPLICAOF_Args[] = {
 
 /* SHUTDOWN history */
 commandHistory SHUTDOWN_History[] = {
-{"7.0.0","Added the `NOW`, `FORCE` and `ABORT` modifiers. Introduced waiting for lagging replicas before exiting."},
+{"7.0.0","Added the `NOW`, `FORCE` and `ABORT` modifiers."},
 {0}
 };
 

--- a/src/commands/client-pause.json
+++ b/src/commands/client-pause.json
@@ -9,10 +9,6 @@
         "function": "clientCommand",
         "history": [
             [
-                "3.2.10",
-                "Client pause prevents client pause and key eviction as well."
-            ],
-            [
                 "6.2.0",
                 "`CLIENT PAUSE WRITE` mode added along with the `mode` option."
             ]

--- a/src/commands/cluster-slots.json
+++ b/src/commands/cluster-slots.json
@@ -14,7 +14,7 @@
             ],
             [
                 "7.0.0",
-                "Added additional networking metadata and added support for hostnames and unknown endpoints."
+                "Added additional networking metadata field."
             ]
         ],
         "command_flags": [

--- a/src/commands/flushall.json
+++ b/src/commands/flushall.json
@@ -13,7 +13,7 @@
             ],
             [
                 "6.2.0",
-                "Added the `SYNC` flushing mode modifier and the **lazyfree-lazy-user-flush** configuration directive."
+                "Added the `SYNC` flushing mode modifier."
             ]
         ],
         "command_flags": [

--- a/src/commands/flushdb.json
+++ b/src/commands/flushdb.json
@@ -13,7 +13,7 @@
             ],
             [
                 "6.2.0",
-                "Added the `SYNC` flushing mode modifier and the **lazyfree-lazy-user-flush** configuration directive."
+                "Added the `SYNC` flushing mode modifier."
             ]
         ],
         "command_flags": [

--- a/src/commands/monitor.json
+++ b/src/commands/monitor.json
@@ -5,20 +5,7 @@
         "since": "1.0.0",
         "arity": 1,
         "function": "monitorCommand",
-        "history": [
-            [
-                "6.0.0",
-                "`AUTH` excluded from the command's output."
-            ],
-            [
-                "6.2.0",
-                "`RESET` can be called to exit monitor mode."
-            ],
-            [
-                "6.2.4",
-                "`AUTH`, `HELLO`, `EVAL`, `EVAL_RO`, `EVALSHA` and `EVALSHA_RO` included in the command's output."
-            ]
-        ],
+        "history": [],
         "command_flags": [
             "ADMIN",
             "NOSCRIPT",

--- a/src/commands/rename.json
+++ b/src/commands/rename.json
@@ -6,12 +6,7 @@
         "since": "1.0.0",
         "arity": 3,
         "function": "renameCommand",
-        "history": [
-            [
-                "3.2.0",
-                "The command no longer returns an error when source and destination names are the same."
-            ]
-        ],
+        "history": [],
         "command_flags": [
             "WRITE"
         ],

--- a/src/commands/script-flush.json
+++ b/src/commands/script-flush.json
@@ -10,7 +10,7 @@
         "history": [
             [
                 "6.2.0",
-                "Added the `ASYNC` and `SYNC` flushing mode modifiers, as well as the  **lazyfree-lazy-user-flush** configuration directive."
+                "Added the `ASYNC` and `SYNC` flushing mode modifiers."
             ]
         ],
         "command_flags": [

--- a/src/commands/shutdown.json
+++ b/src/commands/shutdown.json
@@ -9,7 +9,7 @@
         "history": [
             [
                 "7.0.0",
-                "Added the `NOW`, `FORCE` and `ABORT` modifiers. Introduced waiting for lagging replicas before exiting."
+                "Added the `NOW`, `FORCE` and `ABORT` modifiers."
             ]
         ],
         "command_flags": [

--- a/src/commands/subscribe.json
+++ b/src/commands/subscribe.json
@@ -6,12 +6,7 @@
         "since": "2.0.0",
         "arity": -2,
         "function": "subscribeCommand",
-        "history": [
-            [
-                "6.2.0",
-                "`RESET` can be called to exit subscribed state."
-            ]
-        ],
+        "history": [],
         "command_flags": [
             "PUBSUB",
             "NOSCRIPT",


### PR DESCRIPTION
The command json documents should just include information about the "arguments" and the "outputs". I removed all of the 'functional wording' so it's clear. Maybe we should document the history field somewhere too?

to do:
- [x] add all of this information manually to the docs once we have consensus here