### PR TITLE
Use dismissMemory to dismiss COW of client output buffer

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6418,7 +6418,7 @@ void dismissMemory(void* ptr, size_t size_hint) {
 /* Dismiss big chunks of memory inside a client structure, see dismissMemory() */
 void dismissClientMemory(client *c) {
     /* Dismiss client query buffer and static reply buffer. */
-    dismissSds(c->buf);
+    dismissMemory(c->buf, c->buf_usable_size);
     dismissSds(c->querybuf);
     dismissSds(c->pending_querybuf);
     /* Dismiss argv array only if we estimate it contains a big buffer. */


### PR DESCRIPTION
Fail CI: https://github.com/redis/redis/runs/5473064515?check_suite_focus=true
`c->buf` is not `sds`, so we should use `dismissMemory` instead of `dismissSds` to dismiss it.
Fullly CI: https://github.com/sundb/redis/actions/runs/1955336170