### PR TITLE
ACL DRYRUN does not validate the verified command args.

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2794,7 +2794,7 @@ setuser_cleanup:
             ((cmd->arity > 0 && cmd->arity != c->argc-3) ||
             (c->argc-3 < -cmd->arity)))
         {
-            rejectCommandFormat(c,"wrong number of arguments for '%s' command", cmd->fullname);
+            addReplyErrorFormat(c,"wrong number of arguments for '%s' command", cmd->fullname);
             return;
         }
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -2790,6 +2790,14 @@ setuser_cleanup:
             return;
         }
 
+        if (doesCommandHaveKeys(cmd) &&
+            ((cmd->arity > 0 && cmd->arity != c->argc-3) ||
+            (c->argc-3 < -cmd->arity)))
+        {
+            rejectCommandFormat(c,"wrong number of arguments for '%s' command", cmd->fullname);
+            return;
+        }
+
         int idx;
         int result = ACLCheckAllUserCommandPerm(u, cmd, c->argv + 3, c->argc - 3, &idx);
         if (result != ACL_OK) {

--- a/src/acl.c
+++ b/src/acl.c
@@ -2790,9 +2790,8 @@ setuser_cleanup:
             return;
         }
 
-        if (doesCommandHaveKeys(cmd) &&
-            ((cmd->arity > 0 && cmd->arity != c->argc-3) ||
-            (c->argc-3 < -cmd->arity)))
+        if ((cmd->arity > 0 && cmd->arity != c->argc-3) ||
+            (c->argc-3 < -cmd->arity))
         {
             addReplyErrorFormat(c,"wrong number of arguments for '%s' command", cmd->fullname);
             return;

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -315,9 +315,9 @@ start_server {tags {"acl external:skip"}} {
         r ACL setuser command-test +@all %R~read* %W~write* %RW~rw*
 
         # Test migrate, which is marked with incomplete keys
-        assert_equal "OK" [r ACL DRYRUN command-test MIGRATE whatever whatever rw]
-        assert_equal "This user has no permissions to access the 'read' key" [r ACL DRYRUN command-test MIGRATE whatever whatever read]
-        assert_equal "This user has no permissions to access the 'write' key" [r ACL DRYRUN command-test MIGRATE whatever whatever write]
+        assert_equal "OK" [r ACL DRYRUN command-test MIGRATE whatever whatever rw 0 500]
+        assert_equal "This user has no permissions to access the 'read' key" [r ACL DRYRUN command-test MIGRATE whatever whatever read 0 500]
+        assert_equal "This user has no permissions to access the 'write' key" [r ACL DRYRUN command-test MIGRATE whatever whatever write 0 500]
         assert_equal "OK" [r ACL DRYRUN command-test MIGRATE whatever whatever "" 0 5000 KEYS rw]
         assert_equal "This user has no permissions to access the 'read' key" [r ACL DRYRUN command-test MIGRATE whatever whatever "" 0 5000 KEYS read]
         assert_equal "This user has no permissions to access the 'write' key" [r ACL DRYRUN command-test MIGRATE whatever whatever "" 0 5000 KEYS write]
@@ -432,6 +432,19 @@ start_server {tags {"acl external:skip"}} {
 
         assert_equal "This user has no permissions to access the 'otherchannel' channel" [r ACL DRYRUN test-channels spublish otherchannel foo]
         assert_equal "This user has no permissions to access the 'otherchannel' channel" [r ACL DRYRUN test-channels ssubscribe otherchannel foo]
+    }
+    
+    test {Test DRYRUN with wrong number of arguments} {
+        r ACL setuser test-dry-run +@all ~v*
+        
+        assert_equal "OK" [r ACL DRYRUN test-dry-run SET v v]
+        
+        catch {r ACL DRYRUN test-dry-run SET v} e
+        assert_equal "ERR wrong number of arguments for 'set' command" $e
+        
+        catch {r ACL DRYRUN test-dry-run SET} e
+        assert_equal "ERR wrong number of arguments for 'set' command" $e
+        
     }
 
     $r2 close


### PR DESCRIPTION
As a result we segfault when parsing and matching the command keys:

example:

>acl setuser FOO +@all ~v*
OK
>acl dryrun FOO eval <-- cause exception

```
=== REDIS BUG REPORT START: Cut & paste starting from here ===
88064:M 09 Mar 2022 14:11:56.706 # Redis 255.255.255 crashed by signal: 11, si_code: 1
88064:M 09 Mar 2022 14:11:56.706 # Accessing address: 0x29
88064:M 09 Mar 2022 14:11:56.706 # Crashed running the instruction at: 0x46399a

------ STACK TRACE ------
EIP:
./src/redis-server *:6379(getKeysUsingKeySpecs+0xea)[0x46399a]

Backtrace:
/lib64/libpthread.so.0(+0x118e0)[0x7f879a8758e0]
./src/redis-server *:6379(getKeysUsingKeySpecs+0xea)[0x46399a]
./src/redis-server *:6379(getKeysFromCommandWithSpecs+0xf4)[0x463d44]
./src/redis-server *:6379[0x4dea8f]
./src/redis-server *:6379(aclCommand+0xa95)[0x4e3485]
./src/redis-server *:6379(call+0x96)[0x43fb66]
./src/redis-server *:6379(processCommand+0x9f6)[0x442656]
./src/redis-server *:6379(processCommandAndResetClient+0x1c)[0x455dfc]
./src/redis-server *:6379(processInputBuffer+0xc0)[0x458420]
./src/redis-server *:6379(readQueryFromClient+0x241)[0x45b271]
./src/redis-server *:6379[0x4e5565]
./src/redis-server *:6379(aeProcessEvents+0x19d)[0x43888d]
./src/redis-server *:6379(aeMain+0x18)[0x438c08]
./src/redis-server *:6379(main+0x301)[0x435141]
/lib64/libc.so.6(__libc_start_main+0xea)[0x7f879a4da13a]
./src/redis-server *:6379(_start+0x2a)[0x4355ba]

```
