### PR TITLE
improve string2ll() to avoid extra conversion for long integer string.

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -165,7 +165,6 @@ typedef long long ustime_t; /* microsecond time type. */
 #define PROTO_MBULK_BIG_ARG     (1024*32)
 #define PROTO_RESIZE_THRESHOLD  (1024*32) /* Threshold for determining whether to resize query buffer */
 #define PROTO_REPLY_MIN_BYTES   (1024) /* the lower limit on reply buffer size */
-#define LONG_STR_SIZE      21          /* Bytes needed for long -> str + '\0' */
 #define REDIS_AUTOSYNC_BYTES (1024*1024*4) /* Sync file every 4MB. */
 
 #define LIMIT_PENDING_QUERYBUF (4*1024*1024) /* 4mb */

--- a/src/util.c
+++ b/src/util.c
@@ -405,8 +405,8 @@ int string2ll(const char *s, size_t slen, long long *value) {
     int negative = 0;
     unsigned long long v;
 
-    /* A zero length string is not a valid number. */
-    if (plen == slen)
+    /* A string of zero length or excessive length is not a valid number. */
+    if (plen == slen || slen >= LONG_STR_SIZE)
         return 0;
 
     /* Special case: first and only digit is 0. */

--- a/src/util.h
+++ b/src/util.h
@@ -38,6 +38,9 @@
  * This should be the size of the buffer given to ld2string */
 #define MAX_LONG_DOUBLE_CHARS 5*1024
 
+/* Bytes needed for long -> str + '\0' */
+#define LONG_STR_SIZE      21
+
 /* long double to string conversion options */
 typedef enum {
     LD_STR_AUTO,     /* %.17Lg */


### PR DESCRIPTION
For an integer string like "123456789012345678901" which could cause overflow-failure in string2ll() conversion, 
we could compare its length at the beginning to avoid extra work. 