### PR TITLE
Cleanup: replicationFeedMonitors use the monitor list arg it got

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -543,7 +543,8 @@ void replicationFeedStreamFromMasterStream(char *buf, size_t buflen) {
 }
 
 void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv, int argc) {
-    if (!(listLength(server.monitors) && !server.loading)) return;
+    /* Fast path to return if the monitors list is empty or the server is in loading. */
+    if (monitors == NULL || listLength(monitors) == 0 || server.loading) return;
     listNode *ln;
     listIter li;
     int j;


### PR DESCRIPTION
I think it's more rational to check the `monitors` list instead of `server.monitors` in the function, although they are basically the same in the context.