### PR TITLE
Remove redundancy GETNAME in client help command message

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2868,8 +2868,6 @@ void clientCommand(client *c) {
 "    Control the replies sent to the current connection.",
 "SETNAME <name>",
 "    Assign the name <name> to the current connection.",
-"GETNAME",
-"    Get the name of the current connection.",
 "UNBLOCK <clientid> [TIMEOUT|ERROR]",
 "    Unblock the specified blocked client.",
 "TRACKING (ON|OFF) [REDIRECT <id>] [BCAST] [PREFIX <prefix> [...]]",


### PR DESCRIPTION
It maybe a copy-paste error, the getname part occurs twice, this pr remove the redundancy one