### PR TITLE
Getex extra options to avoid duplicate options

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -228,14 +228,14 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
         } else if (!strcasecmp(opt,"PERSIST") && (command_type == COMMAND_GET) &&
                !(*flags & OBJ_EX) && !(*flags & OBJ_EXAT) &&
                !(*flags & OBJ_PX) && !(*flags & OBJ_PXAT) &&
-               !(*flags & OBJ_KEEPTTL))
+               !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST))
         {
             *flags |= OBJ_PERSIST;
         } else if ((opt[0] == 'e' || opt[0] == 'E') &&
                    (opt[1] == 'x' || opt[1] == 'X') && opt[2] == '\0' &&
                    !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST) &&
                    !(*flags & OBJ_EXAT) && !(*flags & OBJ_PX) &&
-                   !(*flags & OBJ_PXAT) && next)
+                   !(*flags & OBJ_PXAT) && next && !(*flags & OBJ_EX))
         {
             *flags |= OBJ_EX;
             *expire = next;
@@ -244,7 +244,7 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
                    (opt[1] == 'x' || opt[1] == 'X') && opt[2] == '\0' &&
                    !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST) &&
                    !(*flags & OBJ_EX) && !(*flags & OBJ_EXAT) &&
-                   !(*flags & OBJ_PXAT) && next)
+                   !(*flags & OBJ_PXAT) && next && !(*flags & OBJ_PX))
         {
             *flags |= OBJ_PX;
             *unit = UNIT_MILLISECONDS;
@@ -256,7 +256,7 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
                    (opt[3] == 't' || opt[3] == 'T') && opt[4] == '\0' &&
                    !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST) &&
                    !(*flags & OBJ_EX) && !(*flags & OBJ_PX) &&
-                   !(*flags & OBJ_PXAT) && next)
+                   !(*flags & OBJ_PXAT) && next && !(*flags & OBJ_EXAT))
         {
             *flags |= OBJ_EXAT;
             *expire = next;
@@ -267,7 +267,7 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
                    (opt[3] == 't' || opt[3] == 'T') && opt[4] == '\0' &&
                    !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST) &&
                    !(*flags & OBJ_EX) && !(*flags & OBJ_EXAT) &&
-                   !(*flags & OBJ_PX) && next)
+                   !(*flags & OBJ_PX) && next && !(*flags & OBJ_PXAT))
         {
             *flags |= OBJ_PXAT;
             *unit = UNIT_MILLISECONDS;

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -226,25 +226,21 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
         {
             *flags |= OBJ_KEEPTTL;
         } else if (!strcasecmp(opt,"PERSIST") && (command_type == COMMAND_GET) &&
-               !(*flags & OBJ_EX) && !(*flags & OBJ_EXAT) &&
-               !(*flags & OBJ_PX) && !(*flags & OBJ_PXAT) &&
-               !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST))
+               !(*flags & (OBJ_EX | OBJ_EXAT | OBJ_PX | OBJ_PXAT | OBJ_KEEPTTL | OBJ_PERSIST)))
         {
             *flags |= OBJ_PERSIST;
         } else if ((opt[0] == 'e' || opt[0] == 'E') &&
                    (opt[1] == 'x' || opt[1] == 'X') && opt[2] == '\0' &&
-                   !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST) &&
-                   !(*flags & OBJ_EXAT) && !(*flags & OBJ_PX) &&
-                   !(*flags & OBJ_PXAT) && next && !(*flags & OBJ_EX))
+                   !(*flags & (OBJ_KEEPTTL | OBJ_PERSIST | OBJ_EX | OBJ_EXAT | OBJ_PXAT | OBJ_PX))
+                   && next)
         {
             *flags |= OBJ_EX;
             *expire = next;
             j++;
         } else if ((opt[0] == 'p' || opt[0] == 'P') &&
                    (opt[1] == 'x' || opt[1] == 'X') && opt[2] == '\0' &&
-                   !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST) &&
-                   !(*flags & OBJ_EX) && !(*flags & OBJ_EXAT) &&
-                   !(*flags & OBJ_PXAT) && next && !(*flags & OBJ_PX))
+                   !(*flags & (OBJ_KEEPTTL | OBJ_PERSIST | OBJ_EX | OBJ_EXAT | OBJ_PXAT | OBJ_PX))
+                   && next)
         {
             *flags |= OBJ_PX;
             *unit = UNIT_MILLISECONDS;
@@ -254,9 +250,8 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
                    (opt[1] == 'x' || opt[1] == 'X') &&
                    (opt[2] == 'a' || opt[2] == 'A') &&
                    (opt[3] == 't' || opt[3] == 'T') && opt[4] == '\0' &&
-                   !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST) &&
-                   !(*flags & OBJ_EX) && !(*flags & OBJ_PX) &&
-                   !(*flags & OBJ_PXAT) && next && !(*flags & OBJ_EXAT))
+                   !(*flags & (OBJ_KEEPTTL | OBJ_PERSIST | OBJ_EX | OBJ_EXAT | OBJ_PXAT | OBJ_PX))
+                   && next)
         {
             *flags |= OBJ_EXAT;
             *expire = next;
@@ -265,9 +260,8 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
                    (opt[1] == 'x' || opt[1] == 'X') &&
                    (opt[2] == 'a' || opt[2] == 'A') &&
                    (opt[3] == 't' || opt[3] == 'T') && opt[4] == '\0' &&
-                   !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST) &&
-                   !(*flags & OBJ_EX) && !(*flags & OBJ_EXAT) &&
-                   !(*flags & OBJ_PX) && next && !(*flags & OBJ_PXAT))
+                   !(*flags & (OBJ_KEEPTTL | OBJ_PERSIST | OBJ_EX | OBJ_EXAT | OBJ_PXAT | OBJ_PX))
+                   && next)
         {
             *flags |= OBJ_PXAT;
             *unit = UNIT_MILLISECONDS;


### PR DESCRIPTION
This PR fixes the bug in redis related to getex.
Currently there is no check if duplicate options are added. For example
getex key ex 100 ex 400 will set the expiry to 400 and ignore ex 100
![image](https://user-images.githubusercontent.com/51993843/157755691-db73cc19-e882-473e-9409-e6fe419e3ada.png)

getex key ex x ex 400 will set the expiry to 400 and ignore the wrong argument x for ex
![image](https://user-images.githubusercontent.com/51993843/157755734-f5f8f1ca-41e3-49f1-a683-a68e94799799.png)

After the change we get the following result which is the default error being used in redis
![image](https://user-images.githubusercontent.com/51993843/157755770-2087bce5-1a45-449d-829f-9158c091608a.png)
