### PR TITLE
Add bzmove,zmove,zmovemember commands

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -8948,6 +8948,39 @@ struct COMMAND_ARG SUNIONSTORE_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,0,NULL)},
 };
 
+/********** BZMOVE ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* BZMOVE history */
+#define BZMOVE_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* BZMOVE tips */
+#define BZMOVE_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* BZMOVE key specs */
+keySpec BZMOVE_Keyspecs[2] = {
+{NULL,CMD_KEY_RW|CMD_KEY_ACCESS|CMD_KEY_DELETE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}},{NULL,CMD_KEY_RW|CMD_KEY_INSERT,KSPEC_BS_INDEX,.bs.index={2},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+};
+#endif
+
+/* BZMOVE where argument table */
+struct COMMAND_ARG BZMOVE_where_Subargs[] = {
+{MAKE_ARG("min",ARG_TYPE_PURE_TOKEN,-1,"MIN",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("max",ARG_TYPE_PURE_TOKEN,-1,"MAX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* BZMOVE argument table */
+struct COMMAND_ARG BZMOVE_Args[] = {
+{MAKE_ARG("source",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("destination",ARG_TYPE_KEY,1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("where",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=BZMOVE_where_Subargs},
+{MAKE_ARG("timeout",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
 /********** BZMPOP ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -9341,6 +9374,64 @@ struct COMMAND_ARG ZLEXCOUNT_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("min",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("max",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/********** ZMOVE ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* ZMOVE history */
+#define ZMOVE_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* ZMOVE tips */
+#define ZMOVE_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* ZMOVE key specs */
+keySpec ZMOVE_Keyspecs[2] = {
+{NULL,CMD_KEY_RW|CMD_KEY_ACCESS|CMD_KEY_DELETE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}},{NULL,CMD_KEY_RW|CMD_KEY_INSERT,KSPEC_BS_INDEX,.bs.index={2},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+};
+#endif
+
+/* ZMOVE where argument table */
+struct COMMAND_ARG ZMOVE_where_Subargs[] = {
+{MAKE_ARG("min",ARG_TYPE_PURE_TOKEN,-1,"MIN",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("max",ARG_TYPE_PURE_TOKEN,-1,"MAX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* ZMOVE argument table */
+struct COMMAND_ARG ZMOVE_Args[] = {
+{MAKE_ARG("source",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("destination",ARG_TYPE_KEY,1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("where",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=ZMOVE_where_Subargs},
+};
+
+/********** ZMOVEMEMBER ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* ZMOVEMEMBER history */
+#define ZMOVEMEMBER_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* ZMOVEMEMBER tips */
+#define ZMOVEMEMBER_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* ZMOVEMEMBER key specs */
+keySpec ZMOVEMEMBER_Keyspecs[2] = {
+{NULL,CMD_KEY_RW|CMD_KEY_ACCESS|CMD_KEY_DELETE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}},{NULL,CMD_KEY_RW|CMD_KEY_INSERT,KSPEC_BS_INDEX,.bs.index={2},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+};
+#endif
+
+/* ZMOVEMEMBER argument table */
+struct COMMAND_ARG ZMOVEMEMBER_Args[] = {
+{MAKE_ARG("source",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("destination",ARG_TYPE_KEY,1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("member",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
 /********** ZMPOP ********************/
@@ -12020,6 +12111,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("sunion","Returns the union of multiple sets.","O(N) where N is the total number of elements in all given sets.","1.0.0",CMD_DOC_NONE,NULL,NULL,"set",COMMAND_GROUP_SET,SUNION_History,0,SUNION_Tips,1,sunionCommand,-2,CMD_READONLY,ACL_CATEGORY_SET,SUNION_Keyspecs,1,NULL,1),.args=SUNION_Args},
 {MAKE_CMD("sunionstore","Stores the union of multiple sets in a key.","O(N) where N is the total number of elements in all given sets.","1.0.0",CMD_DOC_NONE,NULL,NULL,"set",COMMAND_GROUP_SET,SUNIONSTORE_History,0,SUNIONSTORE_Tips,0,sunionstoreCommand,-3,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_SET,SUNIONSTORE_Keyspecs,2,NULL,2),.args=SUNIONSTORE_Args},
 /* sorted_set */
+{MAKE_CMD("bzmove","Returns a highest- or lowest-scoring member after moving it from one sorted set to another. Blocks until a member is available otherwise. Deletes the source sorted set if the last member was moved.","O(log(N)+log(M)) with N being the number of elements in the source sorted set and M being the number of elements in the destination sorted set.","8.8.0",CMD_DOC_NONE,NULL,NULL,"sorted_set",COMMAND_GROUP_SORTED_SET,BZMOVE_History,0,BZMOVE_Tips,0,bzmoveCommand,5,CMD_WRITE|CMD_DENYOOM|CMD_BLOCKING,ACL_CATEGORY_SORTEDSET,BZMOVE_Keyspecs,2,NULL,4),.args=BZMOVE_Args},
 {MAKE_CMD("bzmpop","Removes and returns a member by score from one or more sorted sets. Blocks until a member is available otherwise. Deletes the sorted set if the last element was popped.","O(K) + O(M*log(N)) where K is the number of provided keys, N being the number of elements in the sorted set, and M being the number of elements popped.","7.0.0",CMD_DOC_NONE,NULL,NULL,"sorted_set",COMMAND_GROUP_SORTED_SET,BZMPOP_History,0,BZMPOP_Tips,0,bzmpopCommand,-5,CMD_WRITE|CMD_BLOCKING,ACL_CATEGORY_SORTEDSET,BZMPOP_Keyspecs,1,blmpopGetKeys,5),.args=BZMPOP_Args},
 {MAKE_CMD("bzpopmax","Removes and returns the member with the highest score from one or more sorted sets. Blocks until a member available otherwise.  Deletes the sorted set if the last element was popped.","O(log(N)) with N being the number of elements in the sorted set.","5.0.0",CMD_DOC_NONE,NULL,NULL,"sorted_set",COMMAND_GROUP_SORTED_SET,BZPOPMAX_History,1,BZPOPMAX_Tips,0,bzpopmaxCommand,-3,CMD_WRITE|CMD_FAST|CMD_BLOCKING,ACL_CATEGORY_SORTEDSET,BZPOPMAX_Keyspecs,1,NULL,2),.args=BZPOPMAX_Args},
 {MAKE_CMD("bzpopmin","Removes and returns the member with the lowest score from one or more sorted sets. Blocks until a member is available otherwise. Deletes the sorted set if the last element was popped.","O(log(N)) with N being the number of elements in the sorted set.","5.0.0",CMD_DOC_NONE,NULL,NULL,"sorted_set",COMMAND_GROUP_SORTED_SET,BZPOPMIN_History,1,BZPOPMIN_Tips,0,bzpopminCommand,-3,CMD_WRITE|CMD_FAST|CMD_BLOCKING,ACL_CATEGORY_SORTEDSET,BZPOPMIN_Keyspecs,1,NULL,2),.args=BZPOPMIN_Args},
@@ -12033,6 +12125,8 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("zintercard","Returns the number of members of the intersect of multiple sorted sets.","O(N*K) worst case with N being the smallest input sorted set, K being the number of input sorted sets.","7.0.0",CMD_DOC_NONE,NULL,NULL,"sorted_set",COMMAND_GROUP_SORTED_SET,ZINTERCARD_History,0,ZINTERCARD_Tips,0,zinterCardCommand,-3,CMD_READONLY,ACL_CATEGORY_SORTEDSET,ZINTERCARD_Keyspecs,1,zunionInterDiffGetKeys,3),.args=ZINTERCARD_Args},
 {MAKE_CMD("zinterstore","Stores the intersect of multiple sorted sets in a key.","O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted set, K being the number of input sorted sets and M being the number of elements in the resulting sorted set.","2.0.0",CMD_DOC_NONE,NULL,NULL,"sorted_set",COMMAND_GROUP_SORTED_SET,ZINTERSTORE_History,1,ZINTERSTORE_Tips,0,zinterstoreCommand,-4,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_SORTEDSET,ZINTERSTORE_Keyspecs,2,zunionInterDiffStoreGetKeys,5),.args=ZINTERSTORE_Args},
 {MAKE_CMD("zlexcount","Returns the number of members in a sorted set within a lexicographical range.","O(log(N)) with N being the number of elements in the sorted set.","2.8.9",CMD_DOC_NONE,NULL,NULL,"sorted_set",COMMAND_GROUP_SORTED_SET,ZLEXCOUNT_History,0,ZLEXCOUNT_Tips,0,zlexcountCommand,4,CMD_READONLY|CMD_FAST,ACL_CATEGORY_SORTEDSET,ZLEXCOUNT_Keyspecs,1,NULL,3),.args=ZLEXCOUNT_Args},
+{MAKE_CMD("zmove","Returns a highest- or lowest-scoring member after moving it from one sorted set to another. Deletes the source sorted set if the last member was moved.","O(log(N)+log(M)) with N being the number of elements in the source sorted set and M being the number of elements in the destination sorted set.","8.8.0",CMD_DOC_NONE,NULL,NULL,"sorted_set",COMMAND_GROUP_SORTED_SET,ZMOVE_History,0,ZMOVE_Tips,0,zmoveCommand,4,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_SORTEDSET,ZMOVE_Keyspecs,2,NULL,3),.args=ZMOVE_Args},
+{MAKE_CMD("zmovemember","Returns a member and its score after moving the member from one sorted set to another. Deletes the source sorted set if the last member was moved.","O(log(N)+log(M)) with N being the number of elements in the source sorted set and M being the number of elements in the destination sorted set.","8.8.0",CMD_DOC_NONE,NULL,NULL,"sorted_set",COMMAND_GROUP_SORTED_SET,ZMOVEMEMBER_History,0,ZMOVEMEMBER_Tips,0,zmovememberCommand,4,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_SORTEDSET,ZMOVEMEMBER_Keyspecs,2,NULL,3),.args=ZMOVEMEMBER_Args},
 {MAKE_CMD("zmpop","Returns the highest- or lowest-scoring members from one or more sorted sets after removing them. Deletes the sorted set if the last member was popped.","O(K) + O(M*log(N)) where K is the number of provided keys, N being the number of elements in the sorted set, and M being the number of elements popped.","7.0.0",CMD_DOC_NONE,NULL,NULL,"sorted_set",COMMAND_GROUP_SORTED_SET,ZMPOP_History,0,ZMPOP_Tips,0,zmpopCommand,-4,CMD_WRITE,ACL_CATEGORY_SORTEDSET,ZMPOP_Keyspecs,1,zmpopGetKeys,4),.args=ZMPOP_Args},
 {MAKE_CMD("zmscore","Returns the score of one or more members in a sorted set.","O(N) where N is the number of members being requested.","6.2.0",CMD_DOC_NONE,NULL,NULL,"sorted_set",COMMAND_GROUP_SORTED_SET,ZMSCORE_History,0,ZMSCORE_Tips,0,zmscoreCommand,-3,CMD_READONLY|CMD_FAST,ACL_CATEGORY_SORTEDSET,ZMSCORE_Keyspecs,1,NULL,2),.args=ZMSCORE_Args},
 {MAKE_CMD("zpopmax","Returns the highest-scoring members from a sorted set after removing them. Deletes the sorted set if the last member was popped.","O(log(N)*M) with N being the number of elements in the sorted set, and M being the number of elements popped.","5.0.0",CMD_DOC_NONE,NULL,NULL,"sorted_set",COMMAND_GROUP_SORTED_SET,ZPOPMAX_History,0,ZPOPMAX_Tips,0,zpopmaxCommand,-2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_SORTEDSET,ZPOPMAX_Keyspecs,1,NULL,2),.args=ZPOPMAX_Args},

--- a/src/commands/bzmove.json
+++ b/src/commands/bzmove.json
@@ -1,0 +1,113 @@
+{
+    "BZMOVE": {
+        "summary": "Returns a highest- or lowest-scoring member after moving it from one sorted set to another. Blocks until a member is available otherwise. Deletes the source sorted set if the last member was moved.",
+        "complexity": "O(log(N)+log(M)) with N being the number of elements in the source sorted set and M being the number of elements in the destination sorted set.",
+        "group": "sorted_set",
+        "since": "8.8.0",
+        "arity": 5,
+        "function": "bzmoveCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "BLOCKING"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Timeout reached and no member was moved, blocking was denied, or source and destination are the same sorted set.",
+                    "type": "null"
+                },
+                {
+                    "description": "The moved member and its score.",
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "description": "Member",
+                            "type": "string"
+                        },
+                        {
+                            "description": "Score",
+                            "type": "number"
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "source",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 1
+            },
+            {
+                "name": "where",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                    },
+                    {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                    }
+                ]
+            },
+            {
+                "name": "timeout",
+                "type": "double"
+            }
+        ]
+    }
+}

--- a/src/commands/zmove.json
+++ b/src/commands/zmove.json
@@ -1,0 +1,108 @@
+{
+    "ZMOVE": {
+        "summary": "Returns a highest- or lowest-scoring member after moving it from one sorted set to another. Deletes the source sorted set if the last member was moved.",
+        "complexity": "O(log(N)+log(M)) with N being the number of elements in the source sorted set and M being the number of elements in the destination sorted set.",
+        "group": "sorted_set",
+        "since": "8.8.0",
+        "arity": 4,
+        "function": "zmoveCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The source key does not exist, or source and destination are the same sorted set.",
+                    "type": "null"
+                },
+                {
+                    "description": "The moved member and its score.",
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "description": "Member",
+                            "type": "string"
+                        },
+                        {
+                            "description": "Score",
+                            "type": "number"
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "source",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 1
+            },
+            {
+                "name": "where",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                    },
+                    {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/src/commands/zmovemember.json
+++ b/src/commands/zmovemember.json
@@ -1,0 +1,96 @@
+{
+    "ZMOVEMEMBER": {
+        "summary": "Returns a member and its score after moving the member from one sorted set to another. Deletes the source sorted set if the last member was moved.",
+        "complexity": "O(log(N)+log(M)) with N being the number of elements in the source sorted set and M being the number of elements in the destination sorted set.",
+        "group": "sorted_set",
+        "since": "8.8.0",
+        "arity": 4,
+        "function": "zmovememberCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "SORTEDSET"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            },
+            {
+                "flags": [
+                    "RW",
+                    "INSERT"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The source key does not exist, the member does not exist in the source key, or source and destination are the same sorted set.",
+                    "type": "null"
+                },
+                {
+                    "description": "The moved member and its score.",
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                        {
+                            "description": "Member",
+                            "type": "string"
+                        },
+                        {
+                            "description": "Score",
+                            "type": "number"
+                        }
+                    ]
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "source",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "destination",
+                "type": "key",
+                "key_spec_index": 1
+            },
+            {
+                "name": "member",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/src/server.c
+++ b/src/server.c
@@ -2240,6 +2240,7 @@ void createSharedObjects(void) {
     shared.blmove = createStringObject("BLMOVE",6);
     shared.zpopmin = createStringObject("ZPOPMIN",7);
     shared.zpopmax = createStringObject("ZPOPMAX",7);
+    shared.zmove = createStringObject("ZMOVE",5);
     shared.multi = createStringObject("MULTI",5);
     shared.exec = createStringObject("EXEC",4);
     shared.hset = createStringObject("HSET",4);

--- a/src/server.h
+++ b/src/server.h
@@ -1713,7 +1713,7 @@ struct sharedObjectsStruct {
     *masterdownerr, *roslaveerr, *execaborterr, *noautherr, *noreplicaserr,
     *busykeyerr, *oomerr, *plus, *messagebulk, *pmessagebulk, *subscribebulk,
     *unsubscribebulk, *psubscribebulk, *punsubscribebulk, *del, *unlink,
-    *rpop, *lpop, *lpush, *rpoplpush, *lmove, *blmove, *zpopmin, *zpopmax,
+    *rpop, *lpop, *lpush, *rpoplpush, *lmove, *blmove, *zpopmin, *zpopmax, *zmove,
     *emptyscan, *multi, *exec, *left, *right, *hset, *srem, *xgroup, *xclaim, *xack,
     *script, *replconf, *eval, *persist, *set, *pexpireat, *pexpire,
     *hdel, *hpexpireat, *hpersist, *hsetex,
@@ -4348,9 +4348,12 @@ void zremrangebylexCommand(client *c);
 void zpopminCommand(client *c);
 void zpopmaxCommand(client *c);
 void zmpopCommand(client *c);
+void zmoveCommand(client *c);
+void zmovememberCommand(client *c);
 void bzpopminCommand(client *c);
 void bzpopmaxCommand(client *c);
 void bzmpopCommand(client *c);
+void bzmoveCommand(client *c);
 void zrandmemberCommand(client *c);
 void multiCommand(client *c);
 void execCommand(client *c);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1954,6 +1954,52 @@ void zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, listpackEntry 
     }
 }
 
+/* Return the minimum or maximum score element from a non-empty sorted set.
+ * The returned SDS in 'ele' must be freed by the caller. */
+static void zsetGetMinMax(client *c, robj *zobj, sds *ele, double *score, int where) {
+    if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
+        unsigned char *zl = zobj->ptr;
+        unsigned char *eptr, *sptr;
+        unsigned char *vstr;
+        unsigned int vlen;
+        long long vlong;
+
+        eptr = lpSeek(zl, where == ZSET_MAX ? -2 : 0);
+        serverAssertWithInfo(c, zobj, eptr != NULL);
+        vstr = lpGetValue(eptr, &vlen, &vlong);
+        if (vstr == NULL)
+            *ele = sdsfromlonglong(vlong);
+        else
+            *ele = sdsnewlen(vstr, vlen);
+
+        sptr = lpNext(zl, eptr);
+        serverAssertWithInfo(c, zobj, sptr != NULL);
+        *score = zzlGetScore(sptr);
+    } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
+        zset *zs = zobj->ptr;
+        zskiplistNode *zln;
+
+        zln = (where == ZSET_MAX) ? zs->zsl->tail : zs->zsl->header->level[0].forward;
+        serverAssertWithInfo(c, zobj, zln != NULL);
+        *ele = sdsdup(zslGetNodeElement(zln));
+        *score = zln->score;
+    } else {
+        serverPanic("Unknown sorted set encoding");
+    }
+}
+
+static int zsetGetPositionOrReply(client *c, robj *arg, int *where) {
+    if (!strcasecmp(arg->ptr, "MIN")) {
+        *where = ZSET_MIN;
+    } else if (!strcasecmp(arg->ptr, "MAX")) {
+        *where = ZSET_MAX;
+    } else {
+        addReplyErrorObject(c, shared.syntaxerr);
+        return C_ERR;
+    }
+    return C_OK;
+}
+
 /*-----------------------------------------------------------------------------
  * Sorted set commands
  *----------------------------------------------------------------------------*/
@@ -4290,42 +4336,7 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
 
     /* Remove the element. */
     do {
-        if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
-            unsigned char *zl = zobj->ptr;
-            unsigned char *eptr, *sptr;
-            unsigned char *vstr;
-            unsigned int vlen;
-            long long vlong;
-
-            /* Get the first or last element in the sorted set. */
-            eptr = lpSeek(zl,where == ZSET_MAX ? -2 : 0);
-            serverAssertWithInfo(c,zobj,eptr != NULL);
-            vstr = lpGetValue(eptr,&vlen,&vlong);
-            if (vstr == NULL)
-                ele = sdsfromlonglong(vlong);
-            else
-                ele = sdsnewlen(vstr,vlen);
-
-            /* Get the score. */
-            sptr = lpNext(zl,eptr);
-            serverAssertWithInfo(c,zobj,sptr != NULL);
-            score = zzlGetScore(sptr);
-        } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-            zset *zs = zobj->ptr;
-            zskiplist *zsl = zs->zsl;
-            zskiplistNode *zln;
-
-            /* Get the first or last element in the sorted set. */
-            zln = (where == ZSET_MAX ? zsl->tail :
-                                       zsl->header->level[0].forward);
-
-            /* There must be an element in the sorted set. */
-            serverAssertWithInfo(c,zobj,zln != NULL);
-            ele = sdsdup(zslGetNodeElement(zln));
-            score = zln->score;
-        } else {
-            serverPanic("Unknown sorted set encoding");
-        }
+        zsetGetMinMax(c, zobj, &ele, &score, where);
 
         serverAssertWithInfo(c,zobj,zsetDel(zobj,ele));
         server.dirty++;
@@ -4775,14 +4786,8 @@ void zmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
         addReplyErrorObject(c, shared.syntaxerr);
         return;
     }
-    if (!strcasecmp(c->argv[where_idx]->ptr, "MIN")) {
-        where = ZSET_MIN;
-    } else if (!strcasecmp(c->argv[where_idx]->ptr, "MAX")) {
-        where = ZSET_MAX;
-    } else {
-        addReplyErrorObject(c, shared.syntaxerr);
+    if (zsetGetPositionOrReply(c, c->argv[where_idx], &where) != C_OK)
         return;
-    }
 
     /* Parse the optional arguments. */
     for (j = where_idx + 1; j < c->argc; j++) {
@@ -4819,6 +4824,139 @@ void zmpopCommand(client *c) {
 /* BZMPOP timeout numkeys key [<key> ...] MIN|MAX [COUNT count] */
 void bzmpopCommand(client *c) {
     zmpopGenericCommand(c, 2, 1);
+}
+
+static void zmoveGenericCommand(client *c, robj *srckey, robj *dstkey, int where, robj *member) {
+    kvobj *sobj = lookupKeyWriteOrReply(c, srckey, shared.nullarray[c->resp]);
+    if (sobj == NULL || checkType(c, sobj, OBJ_ZSET)) return;
+
+    kvobj *dobj = lookupKeyWrite(c->db, dstkey);
+    if (checkType(c, dobj, OBJ_ZSET)) return;
+
+    /* ZMOVE is a no-op when source and destination are the same object. */
+    if (sobj == dobj) {
+        addReplyNullArray(c);
+        return;
+    }
+
+    /* Empty sorted sets are normally deleted, but keep this defensive guard for
+     * modules or future internal callers that may create one transiently. */
+    if (zsetLength(sobj) == 0) {
+        addReplyNullArray(c);
+        return;
+    }
+
+    sds ele;
+    double score;
+
+    if (member) {
+        if (zsetScore(sobj, member->ptr, &score) == C_ERR) {
+            addReplyNullArray(c);
+            return;
+        }
+        ele = sdsdup(member->ptr);
+    } else {
+        zsetGetMinMax(c, sobj, &ele, &score, where);
+    }
+
+    size_t src_old_size = 0, dst_old_size = 0;
+    if (server.memory_tracking_enabled)
+        src_old_size = kvobjAllocSize(sobj);
+
+    int64_t src_old_len = (int64_t)zsetLength(sobj);
+    serverAssertWithInfo(c, sobj, zsetDel(sobj, ele));
+    if (server.memory_tracking_enabled)
+        updateSlotAllocSize(c->db, getKeySlot(srckey->ptr), sobj, src_old_size, kvobjAllocSize(sobj));
+
+    if (member) {
+        notifyKeyspaceEvent(NOTIFY_ZSET, "zrem", srckey, c->db->id);
+    } else {
+        char *events[2] = {"zpopmin", "zpopmax"};
+        notifyKeyspaceEvent(NOTIFY_ZSET, events[where], srckey, c->db->id);
+    }
+
+    int64_t src_new_len = src_old_len - 1;
+    if (src_new_len == 0) {
+        dbDeleteSkipKeysizesUpdate(c->db, srckey);
+        notifyKeyspaceEvent(NOTIFY_GENERIC, "del", srckey, c->db->id);
+        src_new_len = -1;
+    }
+    updateKeysizesHist(c->db, OBJ_ZSET, src_old_len, src_new_len);
+    keyModified(c, c->db, srckey, src_new_len > 0 ? sobj : NULL, 1);
+    server.dirty++;
+
+    int64_t dst_old_len = 0;
+    if (!dobj) {
+        robj *newobj = zsetTypeCreate(1, sdslen(ele));
+        dobj = dbAdd(c->db, dstkey, &newobj);
+    } else {
+        dst_old_len = (int64_t)zsetLength(dobj);
+    }
+
+    if (server.memory_tracking_enabled)
+        dst_old_size = kvobjAllocSize(dobj);
+
+    int retflags = 0;
+    int retval = zsetAdd(dobj, score, ele, ZADD_IN_NONE, &retflags, NULL);
+    serverAssert(retval);
+
+    if (server.memory_tracking_enabled)
+        updateSlotAllocSize(c->db, getKeySlot(dstkey->ptr), dobj, dst_old_size, kvobjAllocSize(dobj));
+
+    if (retflags & ZADD_OUT_ADDED) {
+        updateKeysizesHist(c->db, OBJ_ZSET, dst_old_len, dst_old_len + 1);
+    }
+    if (retflags & (ZADD_OUT_ADDED | ZADD_OUT_UPDATED)) {
+        keyModified(c, c->db, dstkey, dobj, 1);
+        notifyKeyspaceEvent(NOTIFY_ZSET, "zadd", dstkey, c->db->id);
+        server.dirty++;
+    }
+
+    addReplyArrayLen(c, 2);
+    addReplyBulkCBuffer(c, ele, sdslen(ele));
+    addReplyDouble(c, score);
+    sdsfree(ele);
+
+    if (c->cmd->proc == bzmoveCommand) {
+        rewriteClientCommandVector(c, 4, shared.zmove, c->argv[1], c->argv[2], c->argv[3]);
+    }
+}
+
+/* ZMOVEMEMBER <source> <destination> <member> */
+void zmovememberCommand(client *c) {
+    zmoveGenericCommand(c, c->argv[1], c->argv[2], 0, c->argv[3]);
+}
+
+/* ZMOVE <source> <destination> MIN|MAX */
+void zmoveCommand(client *c) {
+    int where;
+    if (zsetGetPositionOrReply(c, c->argv[3], &where) != C_OK)
+        return;
+    zmoveGenericCommand(c, c->argv[1], c->argv[2], where, NULL);
+}
+
+/* BZMOVE <source> <destination> MIN|MAX <timeout> */
+void bzmoveCommand(client *c) {
+    mstime_t timeout;
+    int where;
+
+    if (zsetGetPositionOrReply(c, c->argv[3], &where) != C_OK)
+        return;
+    if (getTimeoutFromObjectOrReply(c, c->argv[4], &timeout, UNIT_SECONDS) != C_OK)
+        return;
+
+    robj *key = lookupKeyWrite(c->db, c->argv[1]);
+    if (checkType(c, key, OBJ_ZSET)) return;
+
+    if (key == NULL || zsetLength(key) == 0) {
+        if (c->flags & CLIENT_DENY_BLOCKING || equalStringObjects(c->argv[1], c->argv[2])) {
+            addReplyNullArray(c);
+        } else {
+            blockForKeys(c, BLOCKED_ZSET, c->argv + 1, 1, timeout, 0);
+        }
+    } else {
+        zmoveGenericCommand(c, c->argv[1], c->argv[2], where, NULL);
+    }
 }
 
 #ifdef REDIS_TEST

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -186,6 +186,33 @@ start_server {tags {"repl external:skip"}} {
             }
         }
 
+        foreach position {min max} {
+            test "BZMOVE $position replication, when blocking against empty zset" {
+                r del z1 z2
+                $A config resetstat
+                set rd [redis_deferring_client]
+                $rd bzmove z1 z2 $position 5
+                $rd flush
+                wait_for_blocked_client
+                r zadd z1 0 a
+                wait_for_ofs_sync $B $A
+                assert_equal [$A debug digest] [$B debug digest]
+                assert_match {*calls=1,*} [cmdrstat zmove $A]
+                assert_equal [$rd read] {a 0}
+                $rd close
+            }
+
+            test "BZMOVE $position replication, zset exists" {
+                r del z1
+                $A config resetstat
+                r zadd z1 -1 a 0 b 1 c 2 d
+                r bzmove z1 z2 $position 5
+                wait_for_ofs_sync $B $A
+                assert_equal [$A debug digest] [$B debug digest]
+                assert_match {*calls=1,*} [cmdrstat zmove $A]
+            }
+        }
+
         test {BLPOP followed by role change, issue #2473} {
             set rd [redis_deferring_client]
             $rd blpop foo 0 ; # Block while B is a master

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -32,5 +32,10 @@ start_cluster 2 2 {tags {external:skip cluster}} {
         
         # Test MGET with keys in different slots
         assert_error {*CROSSSLOT Keys in request don't hash to the same slot*} {R 0 MGET foo bar}
+
+        # Sorted set move commands also declare both source and destination keys.
+        assert_error {*CROSSSLOT Keys in request don't hash to the same slot*} {R 0 ZMOVE foo bar MIN}
+        assert_error {*CROSSSLOT Keys in request don't hash to the same slot*} {R 0 ZMOVEMEMBER foo bar member}
+        assert_error {*CROSSSLOT Keys in request don't hash to the same slot*} {R 0 BZMOVE foo bar MIN 0}
     } 
 }

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -150,6 +150,9 @@ start_server {tags {"introspection"}} {
         assert_equal {{k1 {OW update}}} [r command getkeysandflags set k1 v1]
         assert_equal {{k1 {OW update}} {k2 {OW update}}} [r command getkeysandflags mset k1 v1 k2 v2]
         assert_equal {{k1 {RW access delete}} {k2 {RW insert}}} [r command getkeysandflags LMOVE k1 k2 left right]
+        assert_equal {{k1 {RW access delete}} {k2 {RW insert}}} [r command getkeysandflags ZMOVE k1 k2 min]
+        assert_equal {{k1 {RW access delete}} {k2 {RW insert}}} [r command getkeysandflags ZMOVEMEMBER k1 k2 member]
+        assert_equal {{k1 {RW access delete}} {k2 {RW insert}}} [r command getkeysandflags BZMOVE k1 k2 min 0]
         assert_equal {{k1 {RO access}} {k2 {OW update}}} [r command getkeysandflags sort k1 store k2]
         assert_equal {{k1 {RW update}}} [r command getkeysandflags set k1 v1 IFEQ v1]
         assert_equal {{k1 {RW access update}}} [r command getkeysandflags set k1 v1 GET]
@@ -275,7 +278,7 @@ start_server {tags {"introspection"}} {
         assert_equal {{}} [r command info config|get|key]
     }
 
-    foreach cmd {SET GET MSET BITFIELD LMOVE LPOP BLPOP PING MEMORY MEMORY|USAGE RENAME GEORADIUS_RO} {
+    foreach cmd {SET GET MSET BITFIELD LMOVE ZMOVE ZMOVEMEMBER BZMOVE LPOP BLPOP PING MEMORY MEMORY|USAGE RENAME GEORADIUS_RO} {
         test "$cmd command will not be marked with movablekeys" {
             set info [lindex [r command info $cmd] 0]
             assert_no_match {*movablekeys*} [lindex $info 2]

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1333,6 +1333,73 @@ start_server {tags {"zset"}} {
         }
     }
 
+        foreach position {min max} {
+            test "ZMOVE $position - $encoding" {
+                r del target{t}
+                create_zset zset{t} {-1 a 1 b 2 c 3 d}
+
+                if {$position eq "min"} {
+                    assert_equal {a -1} [r zmove zset{t} target{t} $position]
+                    assert_equal {b c d} [r zrange zset{t} 0 -1]
+                    assert_equal {a -1} [r zrange target{t} 0 -1 withscores]
+                } else {
+                    assert_equal {d 3} [r zmove zset{t} target{t} $position]
+                    assert_equal {a b c} [r zrange zset{t} 0 -1]
+                    assert_equal {d 3} [r zrange target{t} 0 -1 withscores]
+                }
+            }
+
+            test "BZMOVE $position non-blocking path - $encoding" {
+                r del target{t}
+                create_zset zset{t} {-1 a 1 b 2 c 3 d}
+
+                if {$position eq "min"} {
+                    assert_equal {a -1} [r bzmove zset{t} target{t} $position 1]
+                    assert_equal {b c d} [r zrange zset{t} 0 -1]
+                    assert_equal {a -1} [r zrange target{t} 0 -1 withscores]
+                } else {
+                    assert_equal {d 3} [r bzmove zset{t} target{t} $position 1]
+                    assert_equal {a b c} [r zrange zset{t} 0 -1]
+                    assert_equal {d 3} [r zrange target{t} 0 -1 withscores]
+                }
+            }
+
+            test "ZMOVE $position with the same zset as source and destination - $encoding" {
+                create_zset zset{t} {-1 a 1 b 2 c 3 d}
+                assert_equal {} [r zmove zset{t} zset{t} $position]
+                assert_equal {a b c d} [r zrange zset{t} 0 -1]
+            }
+        }
+
+        test "ZMOVEMEMBER - $encoding" {
+            r del target{t}
+            create_zset zset{t} {-1 a 1 b 2 c 3 d}
+
+            assert_equal {b 1} [r zmovemember zset{t} target{t} b]
+            assert_equal {b 1} [r zrange target{t} 0 -1 withscores]
+            assert_equal {a c d} [r zrange zset{t} 0 -1]
+        }
+
+        test "ZMOVEMEMBER updates existing destination member - $encoding" {
+            create_zset zset{t} {-1 a 1 b 2 c 3 d}
+            r del target{t}
+            r zadd target{t} 42 b
+
+            assert_equal {b 1} [r zmovemember zset{t} target{t} b]
+            assert_equal {b 1} [r zrange target{t} 0 -1 withscores]
+            assert_equal {a c d} [r zrange zset{t} 0 -1]
+        }
+
+        test "ZMOVEMEMBER with missing member or same source and destination - $encoding" {
+            create_zset zset{t} {-1 a 1 b 2 c 3 d}
+            r del target{t}
+
+            assert_equal {} [r zmovemember zset{t} target{t} missing]
+            assert_equal {} [r zmovemember zset{t} zset{t} a]
+            assert_equal {a b c d} [r zrange zset{t} 0 -1]
+            assert_equal 0 [r exists target{t}]
+        }
+
         r config set zset-max-ziplist-entries $original_max_entries
         r config set zset-max-ziplist-value $original_max_value
     }
@@ -1351,11 +1418,18 @@ start_server {tags {"zset"}} {
         assert_error "*WRONGTYPE*" {r zmpop 1 foo{t} min}
         assert_error "*WRONGTYPE*" {r zmpop 1 foo{t} max}
         assert_error "*WRONGTYPE*" {r zmpop 1 foo{t} max count 200}
+        assert_error "*WRONGTYPE*" {r zmove foo{t} dst{t} min}
+        assert_error "*WRONGTYPE*" {r zmovemember foo{t} dst{t} member}
+        assert_error "*WRONGTYPE*" {r bzmove foo{t} dst{t} max 1}
 
         r del foo{t}
         r set foo2{t} bar
         assert_error "*WRONGTYPE*" {r zmpop 2 foo{t} foo2{t} min}
         assert_error "*WRONGTYPE*" {r zmpop 2 foo2{t} foo1{t} max count 1}
+        r zadd zset{t} 1 a
+        assert_error "*WRONGTYPE*" {r zmove zset{t} foo2{t} min}
+        assert_error "*WRONGTYPE*" {r zmovemember zset{t} foo2{t} a}
+        assert_error "*WRONGTYPE*" {r bzmove zset{t} foo2{t} min 1}
     }
 
     test "ZMPOP with illegal argument" {
@@ -1378,6 +1452,10 @@ start_server {tags {"zset"}} {
         assert_error "ERR count*" {r zmpop 1 myzset{t} MAX COUNT a}
         assert_error "ERR count*" {r zmpop 1 myzset{t} MIN COUNT -1}
         assert_error "ERR count*" {r zmpop 2 myzset{t} myzset2{t} MAX COUNT -1}
+
+        assert_error "ERR syntax error*" {r zmove myzset{t} dst{t} middle}
+        assert_error "ERR syntax error*" {r bzmove myzset{t} dst{t} middle 1}
+        assert_error "ERR timeout*" {r bzmove myzset{t} dst{t} min invalid-timeout}
     }
 
     test "ZMPOP propagate as pop with count command to replica" {
@@ -1585,6 +1663,39 @@ start_server {tags {"zset"}} {
             assert_equal [$rd read] {b}
             verify_score_response $rd $resp 2
 
+        }
+
+        test "ZMOVE/BZMOVE/ZMOVEMEMBER readraw in RESP$resp" {
+            r del missing{t} target{t}
+            create_zset zset2{t} {1 a 2 b 3 c 4 d 5 e}
+
+            r readraw 1
+            $rd readraw 1
+
+            verify_nil_response $resp [r zmove missing{t} target{t} min]
+            verify_nil_response $resp [r zmovemember missing{t} target{t} a]
+
+            assert_equal {*2} [r zmove zset2{t} target{t} min]
+            assert_equal [r read] {$1}
+            assert_equal [r read] {a}
+            verify_score_response r $resp 1
+
+            assert_equal {*2} [r zmovemember zset2{t} target{t} b]
+            assert_equal [r read] {$1}
+            assert_equal [r read] {b}
+            verify_score_response r $resp 2
+
+            $rd bzmove missing{t} target{t} max 0.01
+            verify_nil_response $resp [$rd read]
+
+            $rd bzmove zset2{t} target{t} max 0.01
+            assert_equal [$rd read] {*2}
+            assert_equal [$rd read] {$1}
+            assert_equal [$rd read] {e}
+            verify_score_response $rd $resp 5
+
+            r readraw 0
+            $rd readraw 0
         }
 
         $rd close
@@ -2361,6 +2472,102 @@ start_server {tags {"zset"}} {
         $rd1 close
         $rd2 close
     } {0} {cluster:skip}
+
+    foreach position {min max} {
+        test "BZMOVE $position with timeout" {
+            r del zset{t} target{t}
+            assert_equal {} [r bzmove zset{t} target{t} $position 0.01]
+            assert_equal 0 [r exists target{t}]
+        }
+
+        test "BZMOVE $position with zero timeout should block indefinitely" {
+            set rd [redis_deferring_client]
+            r del zset{t} target{t}
+            $rd bzmove zset{t} target{t} $position 0
+            wait_for_blocked_client
+            r zadd zset{t} 0 foo
+            assert_equal {foo 0} [$rd read]
+            assert_equal {foo 0} [r zrange target{t} 0 -1 withscores]
+            $rd close
+        }
+
+        test "BZMOVE $position with multiple blocked clients" {
+            set rd1 [redis_deferring_client]
+            set rd2 [redis_deferring_client]
+            set rd3 [redis_deferring_client]
+            r del zset{t} target{t}
+
+            $rd1 bzmove zset{t} target{t} $position 0
+            wait_for_blocked_clients_count 1
+            $rd2 bzmove zset{t} target{t} $position 0
+            wait_for_blocked_clients_count 2
+            $rd3 bzmove zset{t} target{t} $position 0
+            wait_for_blocked_clients_count 3
+
+            r zadd zset{t} -1 a 1 b 2 c 3 d
+
+            if {$position eq "min"} {
+                assert_equal {a -1} [$rd1 read]
+                assert_equal {b 1} [$rd2 read]
+                assert_equal {c 2} [$rd3 read]
+            } else {
+                assert_equal {d 3} [$rd1 read]
+                assert_equal {c 2} [$rd2 read]
+                assert_equal {b 1} [$rd3 read]
+            }
+
+            $rd1 close
+            $rd2 close
+            $rd3 close
+        }
+    }
+
+    test "BZMOVE with the same source and destination should not block" {
+        r del zset{t}
+        set start [clock milliseconds]
+        assert_equal {} [r bzmove zset{t} zset{t} min 5]
+        assert_lessthan [expr {[clock milliseconds]-$start}] 1000
+    }
+
+    test "BZMOVE inside MULTI should not block" {
+        r del zset{t} target{t}
+        r readraw 1
+
+        assert_equal {+OK} [r multi]
+        assert_equal {+QUEUED} [r bzmove zset{t} target{t} min 0]
+        assert_equal {*1} [r exec]
+        verify_nil_response 2 [r read]
+
+        r readraw 0
+        assert_equal 0 [r exists target{t}]
+    }
+
+    test "BZMOVE should not block on the destination key" {
+        set rd [redis_deferring_client]
+        r del source{t} target{t}
+        $rd bzmove source{t} target{t} min 0
+        wait_for_blocked_client
+
+        r zadd target{t} 1 target_member
+        wait_for_blocked_client
+
+        r zadd source{t} 2 source_member
+        assert_equal {source_member 2} [$rd read]
+        assert_equal {target_member 1 source_member 2} [r zrange target{t} 0 -1 withscores]
+        $rd close
+    }
+
+    test "BZMOVE compares source and destination keys binary-safely" {
+        set rd [redis_deferring_client]
+        r del source{t} SOURCE{t}
+        $rd bzmove source{t} SOURCE{t} min 0
+        wait_for_blocked_client
+
+        r zadd source{t} 1 member
+        assert_equal {member 1} [$rd read]
+        assert_equal {member 1} [r zrange SOURCE{t} 0 -1 withscores]
+        $rd close
+    }
 
     test {ZSET skiplist order consistency when elements are moved} {
         set original_max [lindex [r config get zset-max-ziplist-entries] 1]


### PR DESCRIPTION
`zmove` is like `lmove`,the format is `ZMOVE <source> <destination> MIN|MAX`, when specify min the moved element will be the minimum score element in the source.

`bzmove` is the blocking version of `zmove`.

`zmovmember` is like `smove`, the format is `ZMOVEMEMBER <source> <destination> member`.

see #9989

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new write and blocking sorted-set commands that modify keyspace events, replication rewriting, and memory/keysize accounting paths; mistakes could cause inconsistent state or replication divergence.
> 
> **Overview**
> Adds three new sorted-set commands: `ZMOVE` (move min/max element), `ZMOVEMEMBER` (move a specific member), and blocking `BZMOVE` (wait for an element, then move it).
> 
> Implements shared move logic in `t_zset.c`, including helpers to fetch min/max elements across encodings, proper deletion/creation of source/destination keys, keyspace notifications, dirty/memory/keysize accounting, and replication rewriting (`BZMOVE` propagates as `ZMOVE`).
> 
> Updates command metadata (`commands.def` and new `src/commands/*.json`), registers new shared object/prototypes, and adds extensive integration/unit tests for clustering (CROSSSLOT), COMMAND introspection, replication behavior, blocking semantics, RESP parsing, and wrong-type/syntax handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1733a7ce5b003c543720a9416d285671e7970d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->