### PR TITLE
Fix module redact test for valgrind

### DIFF
--- a/tests/unit/moduleapi/auth.tcl
+++ b/tests/unit/moduleapi/auth.tcl
@@ -73,15 +73,15 @@ start_server {tags {"modules"}} {
         r slowlog reset
         r auth.redact 1 2 3 4
         r auth.redact 1 2 3
-        r config set slowlog-log-slower-than 10000
+        r config set slowlog-log-slower-than -1
         set slowlog_resp [r slowlog get]
 
         # There will be 3 records, slowlog reset and the
         # two auth redact calls.
         assert_equal 3 [llength $slowlog_resp]
-        assert_equal {slowlog reset} [lindex [lindex [r slowlog get] 2] 3]
-        assert_equal {auth.redact 1 (redacted) 3 (redacted)} [lindex [lindex [r slowlog get] 1] 3]
-        assert_equal {auth.redact (redacted) 2 (redacted)} [lindex [lindex [r slowlog get] 0] 3]
+        assert_equal {slowlog reset} [lindex [lindex $slowlog_resp 2] 3]
+        assert_equal {auth.redact 1 (redacted) 3 (redacted)} [lindex [lindex $slowlog_resp 1] 3]
+        assert_equal {auth.redact (redacted) 2 (redacted)} [lindex [lindex $slowlog_resp 0] 3]
     }
 
     test "Unload the module - testacl" {


### PR DESCRIPTION
The new module redact test will fail with valgrind:
```
[err]: modules can redact arguments in tests/unit/moduleapi/auth.tcl
Expected 'slowlog reset' to be equal to 'auth.redact 1 (redacted) 3 (redacted)' (context: type eval line 12 cmd {assert_equal {slowlog reset} [lindex [lindex [r slowlog get] 2] 3]} proc ::test)
```

The reason is that with `slowlog-log-slower-than 10000`,
`slowlog get` will have a chance to exceed 10ms.

Made two changes to avoid failure:
1. change `slowlog-log-slower-than` from 10000 to -1, distable it.
2. assert to use the previous execution result.

In theory, the second one can actually be left unchanged, but i
think it will be better if it is changed.