### PR TITLE
Fixed incorrect parsing of hostname information from nodes.conf

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -219,6 +219,17 @@ int clusterLoadConfig(char *filename) {
         /* Format for the node address information: 
          * ip:port[@cport][,hostname] */
 
+        /* Hostname is an optional argument that defines the endpoint
+         * that can be reported to clients instead of IP. */
+        char *hostname = strchr(argv[1], ',');
+        if (hostname) {
+            *hostname = '\0';
+            hostname++;
+            n->hostname = sdscpy(n->hostname, hostname);
+        } else if (sdslen(n->hostname) != 0) {
+            sdsclear(n->hostname);
+        }
+
         /* Address and port */
         if ((p = strrchr(argv[1],':')) == NULL) {
             sdsfreesplitres(argv,argc);
@@ -237,17 +248,6 @@ int clusterLoadConfig(char *filename) {
          * In this case we set it to the default offset of 10000 from the
          * base port. */
         n->cport = busp ? atoi(busp) : n->port + CLUSTER_PORT_INCR;
-
-        /* Hostname is an optional argument that defines the endpoint
-         * that can be reported to clients instead of IP. */
-        char *hostname = strchr(p, ',');
-        if (hostname) {
-            *hostname = '\0';
-            hostname++;
-            n->hostname = sdscpy(n->hostname, hostname);
-        } else if (sdslen(n->hostname) != 0) {
-            sdsclear(n->hostname);
-        }
 
         /* The plaintext port for client in a TLS cluster (n->pport) is not
          * stored in nodes.conf. It is received later over the bus protocol. */

--- a/tests/cluster/tests/27-endpoints.tcl
+++ b/tests/cluster/tests/27-endpoints.tcl
@@ -197,6 +197,9 @@ test "Verify the nodes configured with prefer hostname only show hostname for ne
 test "Test restart will keep hostname information" {
     # Set a new hostname, reboot and make sure it sticks
     R 0 config set cluster-announce-hostname "restart-1.com"
+    # Store the hostname in the config
+    R 0 config rewrite
+    kill_instance redis 0
     restart_instance redis 0
     set slot_result [R 0 CLUSTER SLOTS]
     assert_equal [lindex [get_slot_field $slot_result 0 2 3] 1] "restart-1.com"


### PR DESCRIPTION
Resolves the issue brought up here, https://github.com/redis/redis/pull/10293#discussion_r827669805. What I found is that the TCL function "restart_instance" only restarts the instance if the node was actually previously killed, but also mangles the global structure if the node wasn't killed so a subsequent "restart_instance" will fail. The usage in the cluster shards test was correct, but the usage in endpoints.tcl was wrong, it was not actually restarting the instance.

Fixing the usage in endpoints.tcl, it was revealed the underlying code was incorrect. It was always loading in NULL from the nodes.conf file, so that was fixed so now the tests passes. One last change is that in endpoints.tcl, a `config rewrite` is called in order to persist the "cluster-announce-endpoint" setting, since that will overwrite the value of "myself->node_name" in the cluster struct on startup.