### PR TITLE
Use exit code 1 if redis-cli fails to connect

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -9045,13 +9045,10 @@ int main(int argc, char **argv) {
         return evalMode(argc,argv);
     } else {
         int connected = (cliConnect(CC_QUIET) == REDIS_OK);
-
         /* Try to serve command even we are not connected. e.g. help command */
         int retval = noninteractive(argc,argv);
-        if (retval != REDIS_OK) {
-            /* If failed to connect, exit with "1" for backward compatibility */
-            if (!connected) exit(1);
-        }
+        /* If failed to connect, exit with "1" for backward compatibility */
+        if (retval != REDIS_OK && !connected) exit(1);
         return retval;
     }
 }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -9044,7 +9044,14 @@ int main(int argc, char **argv) {
         if (cliConnect(0) != REDIS_OK) exit(1);
         return evalMode(argc,argv);
     } else {
-        cliConnect(CC_QUIET);
-        return noninteractive(argc,argv);
+        int connected = (cliConnect(CC_QUIET) == REDIS_OK);
+
+        /* Try to serve command even we are not connected. e.g. help command */
+        int retval = noninteractive(argc,argv);
+        if (retval != REDIS_OK) {
+            /* If failed to connect, exit with "1" for backward compatibility */
+            if (!connected) exit(1);
+        }
+        return retval;
     }
 }


### PR DESCRIPTION
Use exit code 1 if redis-cli fails to connect.

Before https://github.com/redis/redis/pull/10382/, on a connection failure, exit code would be 1.  After this PR, whether connection is established or not, `noninteractive()` return value is used as the exit code. On a failure, this function returns `REDIS_ERR` which is `-1`. It becomes `255` as exit codes are between `0-255`.

There is nothing wrong by returning 1 or 255 on failure as far as I know but it'll break things that expect to see 1 as exit code on a connection failure. This is also how we realized the issue. With this PR, changing behavior back to using 1 as exit code to preserve backward compatibility. 

Opened https://github.com/redis/redis/issues/10437, to discuss further improvement for exit codes. 