### PR TITLE
Restore ::singledb after cluster test

### DIFF
--- a/tests/unit/cluster.tcl
+++ b/tests/unit/cluster.tcl
@@ -19,6 +19,7 @@ proc csi {args} {
 }
 
 # make sure the test infra won't use SELECT
+set old_singledb $::singledb
 set ::singledb 1
 
 # cluster creation is complicated with TLS, and the current tests don't really need that coverage
@@ -285,3 +286,5 @@ test {Migrate the last slot away from a node using redis-cli} {
 }
 
 } ;# tags
+
+set ::singledb $old_singledb

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -22,6 +22,7 @@ set testmodule [file normalize tests/modules/blockonkeys.so]
 set testmodule_nokey [file normalize tests/modules/blockonbackground.so]
 
 # make sure the test infra won't use SELECT
+set old_singledb $::singledb
 set ::singledb 1
 
 # cluster creation is complicated with TLS, and the current tests don't really need that coverage
@@ -203,3 +204,5 @@ start_server [list overrides $base_conf] {
 }
 
 } ;# tags
+
+set ::singledb $old_singledb


### PR DESCRIPTION
When `::singledb` is 0, we will use db 9 for the test db.
Since `::singledb` is set to 1 in the cluster-related tests, but not restored, some subsequent tests associated with db 9 will fail.

For example:
```tcl
# unit/moduleapi/keyspace_events.tcl
test "Keyspace notifications: module events test" {
    ...
   assert_equal {pmessage * __keyspace@9__:x notify} [$rd1 read]
    ...
}
```

```tcl
# unit/moduleapi/hooks
test {Test flushdb hooks} {
    r flushdb
    assert_equal [r hooks.event_last flush-start] 9
    assert_equal [r hooks.event_last flush-end] 9
    r flushall
    assert_equal [r hooks.event_last flush-start] -1
    assert_equal [r hooks.event_last flush-end] -1
}
```