### PR TITLE
Fix timing issue in shards test and fix displayed TLS port

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4973,7 +4973,7 @@ void addNodeDetailsToShardReply(client *c, clusterNode *node) {
     reply_count++;
 
     /* We use server.tls_cluster as a proxy for whether or not
-     * the remote pport is the tls port or not */
+     * the remote port is the tls port or not */
     int plaintext_port = server.tls_cluster ? node->pport : node->port;
     int tls_port = server.tls_cluster ? node->port : 0;
     if (plaintext_port) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4972,14 +4972,16 @@ void addNodeDetailsToShardReply(client *c, clusterNode *node) {
     addReplyBulkCBuffer(c, node->name, CLUSTER_NAMELEN);
     reply_count++;
 
-    int port = server.cluster_announce_port ? server.cluster_announce_port : server.port;
-    if (port) {
+    /* We use server.tls_cluster as a proxy for whether or not
+     * the remote pport is the tls port or not */
+    int plaintext_port = server.tls_cluster ? node->pport : node->port;
+    int tls_port = server.tls_cluster ? node->port : 0;
+    if (plaintext_port) {
         addReplyBulkCString(c, "port");
-        addReplyLongLong(c, node->port);
+        addReplyLongLong(c, plaintext_port);
         reply_count++;
     }
 
-    int tls_port = server.cluster_announce_tls_port ? server.cluster_announce_tls_port : server.tls_port;
     if (tls_port) {
         addReplyBulkCString(c, "tls-port");
         addReplyLongLong(c, tls_port);

--- a/tests/cluster/tests/28-cluster-shards.tcl
+++ b/tests/cluster/tests/28-cluster-shards.tcl
@@ -131,7 +131,7 @@ test "Instance #0 gets converted into a replica" {
 test "Test the replica reports a loading state while it's loading" {
     # Test the command is good for verifying everything moves to a happy state
     set replica_cluster_id [R $replica_id CLUSTER MYID]
-    wait_for_condition 50 100 {
+    wait_for_condition 50 1000 {
         [dict get [get_node_info_from_shard $replica_cluster_id $primary_id "node"] health] eq "online"
     } else {
         fail "Replica never transitioned to online"
@@ -165,7 +165,7 @@ test "Test the replica reports a loading state while it's loading" {
     R $primary_id exec
 
     # The replica should reconnect and start a full sync, it will gossip about it's health to the primary.
-    wait_for_condition 50 100 {
+    wait_for_condition 50 1000 {
         "loading" eq [dict get [get_node_info_from_shard $replica_cluster_id $primary_id "node"] health]
     } else {
         fail "Replica never transitioned to loading"
@@ -174,7 +174,7 @@ test "Test the replica reports a loading state while it's loading" {
     # Speed up the key loading and verify everything resumes
     R $replica_id config set key-load-delay 0
 
-    wait_for_condition 50 100 {
+    wait_for_condition 50 1000 {
         "online" eq [dict get [get_node_info_from_shard $replica_cluster_id $primary_id "node"] health]
     } else {
         fail "Replica never transitioned to online"


### PR DESCRIPTION
Fixes two bugs:
1. We weren't correctly using tls port, like at all, now we are correctly choosing the port. (Test was correct though)
2. Some of the replication related timing tests weren't succeeding, so extending the wait_for made them much more reliable.

Related test run: https://github.com/redis/redis/actions/runs/2007096938