### PR TITLE
Cleanups in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -321,7 +321,7 @@ daemonize no
 #
 # When the server runs non daemonized, no pid file is created if none is
 # specified in the configuration. When the server is daemonized, the pid file
-# is used even if not specified, defaulting to "/var/run/redis_6379.pid".
+# is used even if not specified, defaulting to "/var/run/redis.pid".
 #
 # Creating a pid file is best effort: if Redis is not able to create it
 # nothing bad happens, the server will start and run normally.
@@ -1048,7 +1048,6 @@ acllog-max-len 128
 #
 # Once the limit is reached Redis will close all the new connections sending
 # an error 'max number of clients reached'.
-# Or an error 'max number of clients + cluster connections reached' in cluster.
 #
 # IMPORTANT: When Redis Cluster is used, the max number of connections is also
 # shared with the cluster bus: every node in the cluster will use two
@@ -2165,8 +2164,8 @@ rdb-save-incremental-fsync yes
 # defragmentation process. If you are not sure about what they mean it is
 # a good idea to leave the defaults untouched.
 
-# Disabled active defragmentation
-# activedefrag no
+# Enabled active defragmentation
+# activedefrag yes
 
 # Minimum amount of fragmentation waste to start active defrag
 # active-defrag-ignore-bytes 100mb

--- a/redis.conf
+++ b/redis.conf
@@ -2164,8 +2164,8 @@ rdb-save-incremental-fsync yes
 # defragmentation process. If you are not sure about what they mean it is
 # a good idea to leave the defaults untouched.
 
-# Enabled active defragmentation
-# activedefrag yes
+# Active defragmentation is disabled by default
+# activedefrag no
 
 # Minimum amount of fragmentation waste to start active defrag
 # active-defrag-ignore-bytes 100mb

--- a/redis.conf
+++ b/redis.conf
@@ -126,7 +126,7 @@ protected-mode yes
 #
 # no    - Block for any connection (remain immutable)
 # yes   - Allow for any connection (no protection)
-# local - Allow only for local local connections. Ones originating from the
+# local - Allow only for local connections. Ones originating from the
 #         IPv4 address (127.0.0.1), IPv6 address (::1) or Unix domain sockets.
 #
 # enable-protected-configs no
@@ -321,7 +321,7 @@ daemonize no
 #
 # When the server runs non daemonized, no pid file is created if none is
 # specified in the configuration. When the server is daemonized, the pid file
-# is used even if not specified, defaulting to "/var/run/redis.pid".
+# is used even if not specified, defaulting to "/var/run/redis_6379.pid".
 #
 # Creating a pid file is best effort: if Redis is not able to create it
 # nothing bad happens, the server will start and run normally.
@@ -627,7 +627,7 @@ repl-diskless-sync-max-replicas 0
 #
 # In many cases the disk is slower than the network, and storing and loading
 # the RDB file may increase replication time (and even increase the master's
-# Copy on Write memory and slave buffers).
+# Copy on Write memory and replica buffers).
 # However, parsing the RDB file directly from the socket may mean that we have
 # to flush the contents of the current database before the full rdb was
 # received. For this reason we have the following options:
@@ -1048,6 +1048,7 @@ acllog-max-len 128
 #
 # Once the limit is reached Redis will close all the new connections sending
 # an error 'max number of clients reached'.
+# Or an error 'max number of clients + cluster connections reached' in cluster.
 #
 # IMPORTANT: When Redis Cluster is used, the max number of connections is also
 # shared with the cluster bus: every node in the cluster will use two
@@ -1224,7 +1225,7 @@ replica-lazy-flush no
 
 lazyfree-lazy-user-del no
 
-# FLUSHDB, FLUSHALL, and SCRIPT FLUSH support both asynchronous and synchronous
+# FLUSHDB, FLUSHALL, SCRIPT FLUSH and FUNCTION FLUSH support both asynchronous and synchronous
 # deletion, which can be controlled by passing the [SYNC|ASYNC] flags into the
 # commands. When neither flag is passed, this directive will be used to determine
 # if the data should be deleted asynchronously.
@@ -1287,7 +1288,7 @@ lazyfree-lazy-user-flush no
 # attempt to have background child processes killed before all others, and
 # replicas killed before masters.
 #
-# Redis supports three options:
+# Redis supports these options:
 #
 # no:       Don't make changes to oom-score-adj (default).
 # yes:      Alias to "relative" see below.
@@ -1640,7 +1641,7 @@ aof-timestamp-enabled no
 # cluster-replica-no-failover no
 
 # This option, when set to yes, allows nodes to serve read traffic while the
-# the cluster is in a down state, as long as it believes it owns the slots.
+# cluster is in a down state, as long as it believes it owns the slots.
 #
 # This is useful for two cases.  The first case is for when an application
 # doesn't require consistency of data during node failures or network partitions.
@@ -1958,7 +1959,7 @@ activerehashing yes
 # The limit can be set differently for the three different classes of clients:
 #
 # normal -> normal clients including MONITOR clients
-# replica  -> replica clients
+# replica -> replica clients
 # pubsub -> clients subscribed to at least one pubsub channel or pattern
 #
 # The syntax of every client-output-buffer-limit directive is the following:
@@ -2164,7 +2165,7 @@ rdb-save-incremental-fsync yes
 # defragmentation process. If you are not sure about what they mean it is
 # a good idea to leave the defaults untouched.
 
-# Enabled active defragmentation
+# Disabled active defragmentation
 # activedefrag no
 
 # Minimum amount of fragmentation waste to start active defrag


### PR DESCRIPTION
Did some cleanups:
1. local local typo
2. replace the only slave word in the file
3. add FUNCTION FLUSH to `lazyfree-lazy-user-flush` description
4. thought it would be better to use these, there are actually "four" options
5. the the typo
6. remove a extra space
7. change comment next to `activedefrag no` to match the default value