### PR TITLE
save errno in case of being tainted by serverLog()

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3033,8 +3033,10 @@ void configRewriteCommand(client *c) {
         return;
     }
     if (rewriteConfig(server.configfile, 0) == -1) {
-        serverLog(LL_WARNING,"CONFIG REWRITE failed: %s", strerror(errno));
-        addReplyErrorFormat(c,"Rewriting config file: %s", strerror(errno));
+        /* save errno in case of being tainted. */
+        int err = errno;
+        serverLog(LL_WARNING,"CONFIG REWRITE failed: %s", strerror(err));
+        addReplyErrorFormat(c,"Rewriting config file: %s", strerror(err));
     } else {
         serverLog(LL_WARNING,"CONFIG REWRITE executed with success.");
         addReply(c,shared.ok);


### PR DESCRIPTION
`errno` would be potentially tainted during the serverLog() by the file io functions, such as fopen and fflush.
```
The fopen(), fdopen(), and freopen() functions may also fail and
set [errno](https://man7.org/linux/man-pages/man3/errno.3.html) for any of the errors specified for the routine
[malloc(3)](https://man7.org/linux/man-pages/man3/malloc.3.html).
---
The function fflush() may also fail and set [errno](https://man7.org/linux/man-pages/man3/errno.3.html) for any of the
errors specified for [write(2)](https://man7.org/linux/man-pages/man2/write.2.html).
---
(referring from https://man7.org/linux/man-pages/man3/fopen.3.html#ERRORS, 
https://man7.org/linux/man-pages/man3/fflush.3.html#ERRORS)
```

It would cause to make a misleading reply error and inconsistency between reply and logs.
This PR aims to fix this issue.