### PR TITLE
Make redis swallow annotations

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1939,6 +1939,15 @@ int processInlineBuffer(client *c) {
 
     /* Split the input buffer up to the \r\n */
     querylen = newline-(c->querybuf+c->qb_pos);
+
+    /* Handle annotations, begin with '#' prefix. */
+    if (querylen > 0 && *(c->querybuf+c->qb_pos) == '#') {
+        /* Move querybuffer position to the next query in the buffer, then
+         * return directly, since we don't process annotations now. */
+        c->qb_pos += querylen+linefeed_chars;
+        return C_OK;
+    }
+
     aux = sdsnewlen(c->querybuf+c->qb_pos,querylen);
     argv = sdssplitargs(aux,&argc);
     sdsfree(aux);

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -239,3 +239,21 @@ start_server {tags {"regression"}} {
         $rd close
     }
 }
+
+start_server {tags {"protocol"}} {
+    test {Redis can swallow annotations} {
+        set commands "#TS:1647871901\r\n"
+        append commands [formatCommand set foo1 bar1]
+        append commands "#TS:1647871902\r\n"
+        append commands [formatCommand set foo2 bar2]
+        append commands [formatCommand set foo3 bar3]
+        r write $commands
+        r flush
+        assert_equal {OK} [r read]
+        assert_equal {OK} [r read]
+        assert_equal {OK} [r read]
+        assert_equal {bar1} [r get foo1]
+        assert_equal {bar2} [r get foo2]
+        assert_equal {bar3} [r get foo3]
+    }
+}


### PR DESCRIPTION
In some cases, we want inject AOF files into an online redis, but from 7.0, we may add timestamp annotations into AOF, so we should can handle annotations when processing users' requests.