### PR TITLE
Add runtime detection for MADV_DONTNEED zeroes pages (mostly for qemu)

### DIFF
--- a/deps/jemalloc/include/jemalloc/internal/jemalloc_internal_externs.h
+++ b/deps/jemalloc/include/jemalloc/internal/jemalloc_internal_externs.h
@@ -10,6 +10,7 @@ extern bool malloc_slow;
 /* Run-time options. */
 extern bool opt_abort;
 extern bool opt_abort_conf;
+extern bool opt_trust_madvise;
 extern bool opt_confirm_conf;
 extern const char *opt_junk;
 extern bool opt_junk_alloc;

--- a/deps/jemalloc/src/ctl.c
+++ b/deps/jemalloc/src/ctl.c
@@ -81,6 +81,7 @@ CTL_PROTO(config_utrace)
 CTL_PROTO(config_xmalloc)
 CTL_PROTO(opt_abort)
 CTL_PROTO(opt_abort_conf)
+CTL_PROTO(opt_trust_madvise)
 CTL_PROTO(opt_confirm_conf)
 CTL_PROTO(opt_metadata_thp)
 CTL_PROTO(opt_retain)
@@ -308,6 +309,7 @@ static const ctl_named_node_t	config_node[] = {
 static const ctl_named_node_t opt_node[] = {
 	{NAME("abort"),		CTL(opt_abort)},
 	{NAME("abort_conf"),	CTL(opt_abort_conf)},
+	{NAME("trust_madvise"), CTL(opt_trust_madvise)},
 	{NAME("confirm_conf"),	CTL(opt_confirm_conf)},
 	{NAME("metadata_thp"),	CTL(opt_metadata_thp)},
 	{NAME("retain"),	CTL(opt_retain)},
@@ -1761,6 +1763,7 @@ CTL_RO_CONFIG_GEN(config_xmalloc, bool)
 
 CTL_RO_NL_GEN(opt_abort, opt_abort, bool)
 CTL_RO_NL_GEN(opt_abort_conf, opt_abort_conf, bool)
+CTL_RO_NL_GEN(opt_trust_madvise, opt_trust_madvise, bool)
 CTL_RO_NL_GEN(opt_confirm_conf, opt_confirm_conf, bool)
 CTL_RO_NL_GEN(opt_metadata_thp, metadata_thp_mode_names[opt_metadata_thp],
     const char *)

--- a/deps/jemalloc/src/jemalloc.c
+++ b/deps/jemalloc/src/jemalloc.c
@@ -66,6 +66,13 @@ bool	opt_junk_free =
     false
 #endif
     ;
+bool	opt_trust_madvise =
+#ifdef JEMALLOC_PURGE_MADVISE_DONTNEED_ZEROS
+    false
+#else
+    true
+#endif
+    ;
 
 bool	opt_utrace = false;
 bool	opt_xmalloc = false;
@@ -1174,6 +1181,7 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 
 			CONF_HANDLE_BOOL(opt_abort, "abort")
 			CONF_HANDLE_BOOL(opt_abort_conf, "abort_conf")
+			CONF_HANDLE_BOOL(opt_trust_madvise, "trust_madvise")
 			if (strncmp("metadata_thp", k, klen) == 0) {
 				int i;
 				bool match = false;

--- a/deps/jemalloc/test/unit/mallctl.c
+++ b/deps/jemalloc/test/unit/mallctl.c
@@ -159,6 +159,7 @@ TEST_BEGIN(test_mallctl_opt) {
 
 	TEST_MALLCTL_OPT(bool, abort, always);
 	TEST_MALLCTL_OPT(bool, abort_conf, always);
+	TEST_MALLCTL_OPT(bool, trust_madvise, always);
 	TEST_MALLCTL_OPT(bool, confirm_conf, always);
 	TEST_MALLCTL_OPT(const char *, metadata_thp, always);
 	TEST_MALLCTL_OPT(bool, retain, always);


### PR DESCRIPTION
Related issues: #9561 #10341 #9187 #10162 #10442
Fix pages not being zeroed correctly cause crashes on qemu.
These codes copy from https://github.com/jemalloc/jemalloc/pull/2005.


@oranagra I need to take back my words in https://github.com/redis/redis/issues/10341#issuecomment-1055126227
When detected `MADV_DONTNEED` zeroes pages, `madvise_dont_need_zeros_is_faulty` will be set to `true` and `pages_purge_forced()` will alway return `true`, at this time, jemalloc will use `memset` to force the page to be zeroed.

Reproduce steps:
1) Start redis docker
```sh
docker run -p 6379:6379 --name redis -e ALLOW_EMPTY_PASSWORD=yes bitnami/redis:6.0.16
```

2) Run benchmark
```sh
redis-benchmark -p 6380 -t zadd -r 100000
```

Redis will crash with follow logs
```
=== REDIS BUG REPORT START: Cut & paste starting from here ===
87720:M 22 Mar 2022 04:04:20.900 # Redis 255.255.255 crashed by signal: 11, si_code: 1
87720:M 22 Mar 2022 04:04:20.901 # Accessing address: 0x73696465522022
87720:M 22 Mar 2022 04:04:20.901 # Crashed running the instruction at: 0x400006e6e3

------ STACK TRACE ------
EIP:
./src/redis-server 127.0.0.1:6380(dictSdsKeyCompare+0x33)[0x400006e6e3]
...
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Segmentation fault
```

After this pr, when we start redis in qemu, we will see the following log in the startup log:
```
<jemalloc>: MADV_DONTNEED does not work (memset will be used instead)
<jemalloc>: (This is the expected behaviour if you are running under QEMU)
87730:C 22 Mar 2022 05:39:56.866 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
87730:C 22 Mar 2022 05:39:56.867 # Redis version=255.255.255, bits=64, commit=a6941ebd, modified=1, pid=87730, just started
```

Fully CI: https://github.com/sundb/redis/actions/runs/2019868398
BTW, this PR has been tested pass in m1 docker with qemu.