### PR TITLE
Use exit code 1 on error in redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2755,7 +2755,7 @@ static int noninteractive(int argc, char **argv) {
 
     retval = issueCommand(argc, sds_args);
     sdsfreesplitres(sds_args, argc);
-    return retval;
+    return retval == REDIS_OK ? 0 : 1;
 }
 
 /*------------------------------------------------------------------------------
@@ -2842,7 +2842,7 @@ static int evalMode(int argc, char **argv) {
             break; /* Return to the caller. */
         }
     }
-    return retval;
+    return retval == REDIS_OK ? 0 : 1;
 }
 
 /*------------------------------------------------------------------------------
@@ -9044,11 +9044,7 @@ int main(int argc, char **argv) {
         if (cliConnect(0) != REDIS_OK) exit(1);
         return evalMode(argc,argv);
     } else {
-        int connected = (cliConnect(CC_QUIET) == REDIS_OK);
-        /* Try to serve command even we are not connected. e.g. help command */
-        int retval = noninteractive(argc,argv);
-        /* If failed to connect, exit with "1" for backward compatibility */
-        if (retval != REDIS_OK && !connected) exit(1);
-        return retval;
+        cliConnect(CC_QUIET);
+        return noninteractive(argc,argv);
     }
 }


### PR DESCRIPTION
Use exit code 1 on error in redis-cli.

On error, redis-cli was returning `REDIS_ERR` on some cases by mistake. `REDIS_ERR` is `-1` which becomes `255` as exit code. This PR changes it and returns `1` on errors to be consistent. 

Related discussion: https://github.com/redis/redis/issues/10437