### PR TITLE
Fix the bug that caused hash encoding errors when using hincrbyfloat or hincrby commands

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -205,10 +205,11 @@ int hashTypeExists(robj *o, sds field) {
 int hashTypeSet(robj *o, sds field, sds value, int flags) {
     int update = 0;
 
-    /* It's here to serve HINCRBY* and that in case of HSET/HMSET it'll actually be a NOP 
-     * since we have the early check before appending the first item. */
+    /* Check if the field is too long for listpack, and convert before adding the item.
+     * This is needed for HINCRBY* case since in other commands this is handled early by
+     * hashTypeTryConversion, so this check will be a NOP. */
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
-        if (sdslen(field) > server.hash_max_listpack_value || sdslen(value)> server.hash_max_listpack_value)
+        if (sdslen(field) > server.hash_max_listpack_value || sdslen(value) > server.hash_max_listpack_value)
             hashTypeConvert(o, OBJ_ENCODING_HT);
     }
     

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -205,6 +205,13 @@ int hashTypeExists(robj *o, sds field) {
 int hashTypeSet(robj *o, sds field, sds value, int flags) {
     int update = 0;
 
+    /* It's here to serve HINCRBY* and that in case of HSET/HMSET it'll actually be a NOP 
+     * since we have the early check before appending the first item. */
+    if (o->encoding == OBJ_ENCODING_LISTPACK) {
+        if (sdslen(field) > server.hash_max_listpack_value || sdslen(value)> server.hash_max_listpack_value)
+            hashTypeConvert(o, OBJ_ENCODING_HT);
+    }
+    
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl, *fptr, *vptr;
 

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -650,19 +650,19 @@ start_server {tags {"hash"}} {
 
     test {HINCRBYFLOAT over hash-max-listpack-value encoded with a listpack} {
         set original_max_value [lindex [r config get hash-max-ziplist-value] 1]
-        r config set hash-max-ziplist-value 8
+        r config set hash-max-listpack-value 8
         
-        # hash's value exceeds hash-max-ziplist-value
+        # hash's value exceeds hash-max-listpack-value
         r del smallhash
         r del bighash
         r hset smallhash tmp 0
         r hset bighash tmp 0
-        r hincrbyfloat smallhash tmp 12345678
-        r hincrbyfloat bighash tmp 123456789
+        r hincrbyfloat smallhash tmp 0.000005
+        r hincrbyfloat bighash tmp 0.0000005
         assert_encoding listpack smallhash
         assert_encoding hashtable bighash
 
-        # hash's field exceeds hash-max-ziplist-value
+        # hash's field exceeds hash-max-listpack-value
         r del smallhash
         r del bighash
         r hincrbyfloat smallhash 12345678 1
@@ -670,7 +670,7 @@ start_server {tags {"hash"}} {
         assert_encoding listpack smallhash
         assert_encoding hashtable bighash
 
-        r config set hash-max-ziplist-value $original_max_value
+        r config set hash-max-listpack-value $original_max_value
     }
 
     test {Hash ziplist regression test for large keys} {

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -665,8 +665,8 @@ start_server {tags {"hash"}} {
         # hash's field exceeds hash-max-listpack-value
         r del smallhash
         r del bighash
-        r hincrbyfloat smallhash 12345678 1
-        r hincrbyfloat bighash 123456789 1
+        r hincrbyfloat smallhash abcdefgh 1
+        r hincrbyfloat bighash abcdefghi 1
         assert_encoding listpack smallhash
         assert_encoding hashtable bighash
 

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -647,45 +647,30 @@ start_server {tags {"hash"}} {
             assert {$len2 == $len3}
         }
     }
-    
-    test {HINCRBY over hash-max-listpack-value encoded with a listpack} {
-        r config set hash-max-listpack-value 8
-        
-        # bighash's value exceeds hash-max-listpack-value
-        r del smallhash bighash
-        r hset smallhash tmp 0
-        r hset bighash tmp 0
-        r hincrby smallhash tmp 10000000
-        r hincrby bighash tmp 100000000
-        assert_encoding listpack smallhash
-        assert_encoding hashtable bighash
-
-        # bighash's field exceeds hash-max-listpack-value
-        r del smallhash bighash
-        r hincrby smallhash 10000000 1
-        r hincrby bighash 100000000 1
-        assert_encoding listpack smallhash
-        assert_encoding hashtable bighash
-    }
 
     test {HINCRBYFLOAT over hash-max-listpack-value encoded with a listpack} {
-        r config set hash-max-listpack-value 8
+        set original_max_value [lindex [r config get hash-max-ziplist-value] 1]
+        r config set hash-max-ziplist-value 8
         
-        # bighash's value exceeds hash-max-listpack-value
-        r del smallhash bighash
+        # hash's value exceeds hash-max-ziplist-value
+        r del smallhash
+        r del bighash
         r hset smallhash tmp 0
         r hset bighash tmp 0
-        r hincrbyfloat smallhash tmp 10000000
-        r hincrbyfloat bighash tmp 100000000
+        r hincrbyfloat smallhash tmp 12345678
+        r hincrbyfloat bighash tmp 123456789
         assert_encoding listpack smallhash
         assert_encoding hashtable bighash
 
-        # bighash's field exceeds hash-max-listpack-value
-        r del smallhash bighash
-        r hincrbyfloat smallhash 10000000 1
-        r hincrbyfloat bighash 100000000 1
+        # hash's field exceeds hash-max-ziplist-value
+        r del smallhash
+        r del bighash
+        r hincrbyfloat smallhash 12345678 1
+        r hincrbyfloat bighash 123456789 1
         assert_encoding listpack smallhash
         assert_encoding hashtable bighash
+
+        r config set hash-max-ziplist-value $original_max_value
     }
 
     test {Hash ziplist regression test for large keys} {

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -647,6 +647,46 @@ start_server {tags {"hash"}} {
             assert {$len2 == $len3}
         }
     }
+    
+    test {HINCRBY over hash-max-listpack-value encoded with a listpack} {
+        r config set hash-max-listpack-value 8
+        
+        # bighash's value exceeds hash-max-listpack-value
+        r del smallhash bighash
+        r hset smallhash tmp 0
+        r hset bighash tmp 0
+        r hincrby smallhash tmp 10000000
+        r hincrby bighash tmp 100000000
+        assert_encoding listpack smallhash
+        assert_encoding hashtable bighash
+
+        # bighash's field exceeds hash-max-listpack-value
+        r del smallhash bighash
+        r hincrby smallhash 10000000 1
+        r hincrby bighash 100000000 1
+        assert_encoding listpack smallhash
+        assert_encoding hashtable bighash
+    }
+
+    test {HINCRBYFLOAT over hash-max-listpack-value encoded with a listpack} {
+        r config set hash-max-listpack-value 8
+        
+        # bighash's value exceeds hash-max-listpack-value
+        r del smallhash bighash
+        r hset smallhash tmp 0
+        r hset bighash tmp 0
+        r hincrbyfloat smallhash tmp 10000000
+        r hincrbyfloat bighash tmp 100000000
+        assert_encoding listpack smallhash
+        assert_encoding hashtable bighash
+
+        # bighash's field exceeds hash-max-listpack-value
+        r del smallhash bighash
+        r hincrbyfloat smallhash 10000000 1
+        r hincrbyfloat bighash 100000000 1
+        assert_encoding listpack smallhash
+        assert_encoding hashtable bighash
+    }
 
     test {Hash ziplist regression test for large keys} {
         r hset hash kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk a


### PR DESCRIPTION
Fixed a bug that used the `hincrbyfloat` or `hincrby` commands to make the field or value exceed the `hash_max_listpack_value` but did not change the object encoding of the hash structure.

Add a check for field and value in hashTypeSet

If the length of field or value is too long, it will reduce the efficiency of listpack, and the object encoding will become hashtable after AOF restart, so this is also to keep the same before and after AOF restart.

Example:
![](https://s2.loli.net/2022/03/28/kFtIVzqwuJjG52Z.jpg)

After:
![redis_bug1.jpg](https://s2.loli.net/2022/03/28/Xhi5lwVzx4Rjbg1.jpg)