### PR TITLE
Fix new / failing cluster slot migration test

### DIFF
--- a/tests/unit/cluster.tcl
+++ b/tests/unit/cluster.tcl
@@ -274,14 +274,6 @@ test {Migrate the last slot away from a node using redis-cli} {
         # Check that the key foo has been migrated back to the original owner.
         catch { $newnode_r get foo } e
         assert_equal "MOVED $slot $owner_host:$owner_port" $e
-
-        # Check that the empty node has turned itself into a replica of the new
-        # owner and that the new owner knows that.
-        wait_for_condition 5000 100 {
-            [string match "*slave*" [$owner_r CLUSTER REPLICAS $owner_id]]
-        } else {
-            fail "Empty node didn't turn itself into a replica."
-        }
     }
 }
 


### PR DESCRIPTION
#10381 fixed an issue in `redis-cli --cluster reshard` that used to fail it (redis-cli) because of a race condition.
the race condition is / was that when moving the last slot from a node, sometimes the PONG messages delivering the configuration change arrive to that node before the SETSLOT arrives to it, and it becomes a replica.
other times the the SETSLOT arrive first, and then PONG **doesn't** demote it.

**however**, the PR also added a new test that suffers from exactly the same race condition, and the tests started failing a lot.

The fact is (if i understand it correctly), that this test (the one being deleted here), isn't related to the fix that PR fixed (which was to fix redis-cli).
The race condition in the cluster code still happens, and as long as we don't solve it, there's no reason to test it.

p.s. IIUC, the state in which we have a master with no slots, is an invalid state, so race condition or not, we must fix this, right?
@enjoy-binbin investigated it and suggested a fix here: https://github.com/redis/redis/pull/10381#issuecomment-1074859036

For now, even if my understandings are wrong, i'm gonna delete that failing test, since as far as i understand, #10381 didn't introduce any new risks for that matter (which are gonna be compromised by removing this check), this race existed since forever, and still exists, and the fact that redis-cli is now immune to it is still being tested.

Additional work should be carried to fix it, and i live it for other PRs to handle