### PR TITLE
fix crash in debug protocol push

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -795,9 +795,11 @@ NULL
              * also have a normal reply type after the attribute. */
             addReplyBulkCString(c,"Some real reply following the attribute");
         } else if (!strcasecmp(name,"push")) {
-            addReplyPushLen(c,2);
-            addReplyBulkCString(c,"server-cpu-usage");
-            addReplyLongLong(c,42);
+            if (c->resp >= 3) {
+                addReplyPushLen(c, 2);
+                addReplyBulkCString(c, "server-cpu-usage");
+                addReplyLongLong(c, 42);
+            }
             /* Push replies are not synchronous replies, so we emit also a
              * normal reply in order for blocking clients just discarding the
              * push reply, to actually consume the reply and continue. */

--- a/src/debug.c
+++ b/src/debug.c
@@ -799,11 +799,13 @@ NULL
                 addReplyPushLen(c, 2);
                 addReplyBulkCString(c, "server-cpu-usage");
                 addReplyLongLong(c, 42);
+                /* Push replies are not synchronous replies, so we emit also a
+                 * normal reply in order for blocking clients just discarding the
+                 * push reply, to actually consume the reply and continue. */
+                addReplyBulkCString(c,"Some real reply following the push reply");
+            } else {
+                addReplyError(c,"RESP2 is not supported by this command");
             }
-            /* Push replies are not synchronous replies, so we emit also a
-             * normal reply in order for blocking clients just discarding the
-             * push reply, to actually consume the reply and continue. */
-            addReplyBulkCString(c,"Some real reply following the push reply");
         } else if (!strcasecmp(name,"true")) {
             addReplyBool(c,1);
         } else if (!strcasecmp(name,"false")) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -799,9 +799,9 @@ NULL
                 addReplyError(c,"RESP2 is not supported by this command");
                 return;
 	    }
-            addReplyPushLen(c, 2);
-            addReplyBulkCString(c, "server-cpu-usage");
-            addReplyLongLong(c, 42);
+            addReplyPushLen(c,2);
+            addReplyBulkCString(c,"server-cpu-usage");
+            addReplyLongLong(c,42);
             /* Push replies are not synchronous replies, so we emit also a
              * normal reply in order for blocking clients just discarding the
              * push reply, to actually consume the reply and continue. */

--- a/src/debug.c
+++ b/src/debug.c
@@ -795,17 +795,17 @@ NULL
              * also have a normal reply type after the attribute. */
             addReplyBulkCString(c,"Some real reply following the attribute");
         } else if (!strcasecmp(name,"push")) {
-            if (c->resp >= 3) {
-                addReplyPushLen(c, 2);
-                addReplyBulkCString(c, "server-cpu-usage");
-                addReplyLongLong(c, 42);
-                /* Push replies are not synchronous replies, so we emit also a
-                 * normal reply in order for blocking clients just discarding the
-                 * push reply, to actually consume the reply and continue. */
-                addReplyBulkCString(c,"Some real reply following the push reply");
-            } else {
+            if (c->resp < 3) {
                 addReplyError(c,"RESP2 is not supported by this command");
-            }
+                return;
+	    }
+            addReplyPushLen(c, 2);
+            addReplyBulkCString(c, "server-cpu-usage");
+            addReplyLongLong(c, 42);
+            /* Push replies are not synchronous replies, so we emit also a
+             * normal reply in order for blocking clients just discarding the
+             * push reply, to actually consume the reply and continue. */
+            addReplyBulkCString(c,"Some real reply following the push reply");
         } else if (!strcasecmp(name,"true")) {
             addReplyBool(c,1);
         } else if (!strcasecmp(name,"false")) {

--- a/src/module.c
+++ b/src/module.c
@@ -2892,7 +2892,7 @@ void RM_ReplySetSetLength(RedisModuleCtx *ctx, long len) {
 /* Very similar to RedisModule_ReplySetMapLength
  * Visit https://github.com/antirez/RESP3/blob/master/spec.md for more info about RESP3.
  *
- * Not supported by RESP2 and will return void. */
+ * Must not be called if RM_ReplyWithAttribute returned an error. */
 void RM_ReplySetAttributeLength(RedisModuleCtx *ctx, long len) {
     if (ctx->client->resp == 2) return;
     moduleReplySetCollectionLength(ctx, len, COLLECTION_REPLY_ATTRIBUTE);

--- a/src/module.c
+++ b/src/module.c
@@ -2890,8 +2890,11 @@ void RM_ReplySetSetLength(RedisModuleCtx *ctx, long len) {
 }
 
 /* Very similar to RedisModule_ReplySetMapLength
- * Visit https://github.com/antirez/RESP3/blob/master/spec.md for more info about RESP3. */
+ * Visit https://github.com/antirez/RESP3/blob/master/spec.md for more info about RESP3.
+ *
+ * Not supported by RESP2 and will return void. */
 void RM_ReplySetAttributeLength(RedisModuleCtx *ctx, long len) {
+    if (ctx->client->resp == 2) return;
     moduleReplySetCollectionLength(ctx, len, COLLECTION_REPLY_ATTRIBUTE);
 }
 


### PR DESCRIPTION
a missing of resp3 judgement which may lead to the crash using `debug protocol push`
introduced in #9235
Similar improvement in RM_ReplySetAttributeLength in case the module ignored the error that returned from RM_ReplyWithAttribute.