### PR TITLE
improve malloc efficiency for cluster slots_info_pairs

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4569,7 +4569,7 @@ sds representClusterNodeFlags(sds ci, uint16_t flags) {
  * If the slot ownership is in a contiguous block, it's represented as start-end pair,
  * else each slot is added separately. */
 sds representSlotInfo(sds ci, uint16_t *slot_info_pairs, int slot_info_pairs_count) {
-    for(int i = 0; i< slot_info_pairs_count; i+=2) {
+    for (int i = 0; i< slot_info_pairs_count; i+=2) {
         unsigned long start = slot_info_pairs[i];
         unsigned long end = slot_info_pairs[i+1];
         if (start == end) {
@@ -5044,7 +5044,7 @@ void addShardReplyForClusterShards(client *c, clusterNode *node, uint16_t *slot_
     if (slot_info_pairs) {
         serverAssert((slot_pairs_count % 2) == 0);
         addReplyArrayLen(c, slot_pairs_count);
-        for (int i=0; i<slot_pairs_count; i++)
+        for (int i = 0; i < slot_pairs_count; i++)
             addReplyBulkLongLong(c, (unsigned long)slot_info_pairs[i]);
     } else {
         /* If no slot info pair is provided, the node owns no slots */

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -74,7 +74,8 @@ void clusterCloseAllSlots(void);
 void clusterSetNodeAsMaster(clusterNode *n);
 void clusterDelNode(clusterNode *delnode);
 sds representClusterNodeFlags(sds ci, uint16_t flags);
-sds representSlotInfo(sds ci, list *slot_info_pairs);
+sds representSlotInfo(sds ci, uint16_t *slot_info_pairs, int slot_info_pairs_count);
+void clusterFreeNodesSlotsInfo(clusterNode *n);
 uint64_t clusterGetMaxEpoch(void);
 int clusterBumpConfigEpochWithoutConsensus(void);
 void moduleCallClusterReceivers(const char *sender_id, uint64_t module_id, uint8_t type, const unsigned char *payload, uint32_t len);
@@ -944,6 +945,8 @@ clusterNode *createClusterNode(char *nodename, int flags) {
     node->flags = flags;
     memset(node->slots,0,sizeof(node->slots));
     node->slot_info_pairs = NULL;
+    node->slot_info_pairs_count = 0;
+    node->slot_info_pairs_alloc = 0;
     node->numslots = 0;
     node->numslaves = 0;
     node->slaves = NULL;
@@ -4565,16 +4568,10 @@ sds representClusterNodeFlags(sds ci, uint16_t flags) {
 /* Concatenate the slot ownership information to the given SDS string 'ci'.
  * If the slot ownership is in a contiguous block, it's represented as start-end pair,
  * else each slot is added separately. */
-sds representSlotInfo(sds ci, list *slot_info_pairs) {
-    listIter li;
-    listNode *ln;
-    listRewind(slot_info_pairs, &li);
-    while((ln = listNext(&li))) {
-        unsigned long start = (unsigned long)ln->value;
-        ln = listNext(&li);
-        /* List should have even number of elements */
-        serverAssert(ln != NULL);
-        unsigned long end = (unsigned long)ln->value;
+sds representSlotInfo(sds ci, uint16_t *slot_info_pairs, int slot_info_pairs_count) {
+    for(int i = 0; i< slot_info_pairs_count; i+=2) {
+        unsigned long start = slot_info_pairs[i];
+        unsigned long end = slot_info_pairs[i+1];
         if (start == end) {
             ci = sdscatfmt(ci, " %i", start);
         } else {
@@ -4633,7 +4630,7 @@ sds clusterGenNodeDescription(clusterNode *node, int use_pport) {
     /* Slots served by this instance. If we already have slots info,
      * append it directly, otherwise, generate slots only if it has. */
     if (node->slot_info_pairs) {
-        ci = representSlotInfo(ci, node->slot_info_pairs);
+        ci = representSlotInfo(ci, node->slot_info_pairs, node->slot_info_pairs_count);
     } else if (node->numslots > 0) {
         start = -1;
         for (j = 0; j < CLUSTER_SLOTS; j++) {
@@ -4693,17 +4690,28 @@ void clusterGenNodesSlotsInfo(int filter) {
          * or end of slot. */
         if (i == CLUSTER_SLOTS || n != server.cluster->slots[i]) {
             if (!(n->flags & filter)) {
-                if (n->slot_info_pairs == NULL) {
-                    n->slot_info_pairs = listCreate();
+                if (n->slot_info_pairs_count+2 > n->slot_info_pairs_alloc) {
+                    if (n->slot_info_pairs_alloc == 0)
+                        n->slot_info_pairs_alloc = 8;
+                    else
+                        n->slot_info_pairs_alloc *= 2;
+                    n->slot_info_pairs = zrealloc(n->slot_info_pairs, n->slot_info_pairs_alloc * sizeof(uint16_t));
                 }
-                listAddNodeTail(n->slot_info_pairs, (void *)(unsigned long)start);
-                listAddNodeTail(n->slot_info_pairs, (void *)(unsigned long)(i-1));
+                n->slot_info_pairs[n->slot_info_pairs_count++] = start;
+                n->slot_info_pairs[n->slot_info_pairs_count++] = i-1;
             }
             if (i == CLUSTER_SLOTS) break;
             n = server.cluster->slots[i];
             start = i;
         }
     }
+}
+
+void clusterFreeNodesSlotsInfo(clusterNode *n) {
+    zfree(n->slot_info_pairs);
+    n->slot_info_pairs = NULL;
+    n->slot_info_pairs_count = 0;
+    n->slot_info_pairs_alloc = 0;
 }
 
 /* Generate a csv-alike representation of the nodes we are aware of,
@@ -4740,10 +4748,7 @@ sds clusterGenNodesDescription(int filter, int use_pport) {
         ci = sdscatlen(ci,"\n",1);
 
         /* Release slots info. */
-        if (node->slot_info_pairs != NULL) {
-            listRelease(node->slot_info_pairs);
-            node->slot_info_pairs = NULL;
-        }
+        clusterFreeNodesSlotsInfo(node);
     }
     dictReleaseIterator(di);
     return ci;
@@ -5033,22 +5038,14 @@ void addNodeDetailsToShardReply(client *c, clusterNode *node) {
 }
 
 /* Add the shard reply of a single shard based off the given primary node. */
-void addShardReplyForClusterShards(client *c, clusterNode *node, list *slot_info_pairs) {
+void addShardReplyForClusterShards(client *c, clusterNode *node, uint16_t *slot_info_pairs, int slot_pairs_count) {
     addReplyMapLen(c, 2);
     addReplyBulkCString(c, "slots");
-    uint16_t slot_pair_count = 0;
     if (slot_info_pairs) {
-        slot_pair_count = listLength(slot_info_pairs);
-        serverAssert((slot_pair_count % 2) == 0);
-        addReplyArrayLen(c, slot_pair_count);
-        listIter li;
-        listRewind(slot_info_pairs, &li);
-        listNode *ln;
-        while((ln = listNext(&li))) {
-            addReplyBulkLongLong(c, (unsigned long)listNodeValue(ln));
-            ln = listNext(&li);
-            addReplyBulkLongLong(c, (unsigned long)listNodeValue(ln));
-        }
+        serverAssert((slot_pairs_count % 2) == 0);
+        addReplyArrayLen(c, slot_pairs_count);
+        for (int i=0; i<slot_pairs_count; i++)
+            addReplyBulkLongLong(c, (unsigned long)slot_info_pairs[i]);
     } else {
         /* If no slot info pair is provided, the node owns no slots */
         addReplyArrayLen(c, 0);
@@ -5090,17 +5087,13 @@ void clusterReplyShards(client *c) {
         if (nodeIsSlave(n)) {
             /* You can force a replica to own slots, even though it'll get reverted,
              * so freeing the slot pair here just in case. */
-            if (n->slot_info_pairs) listRelease(n->slot_info_pairs);
-            n->slot_info_pairs = NULL;
+            clusterFreeNodesSlotsInfo(n);
             continue;
         }
         shard_count++;
         /* n->slot_info_pairs is set to NULL when the the node owns no slots. */
-        addShardReplyForClusterShards(c, n, n->slot_info_pairs);
-        if (n->slot_info_pairs) {
-            listRelease(n->slot_info_pairs);
-            n->slot_info_pairs = NULL;
-        }
+        addShardReplyForClusterShards(c, n, n->slot_info_pairs, n->slot_info_pairs_count);
+        clusterFreeNodesSlotsInfo(n);
     }
     dictReleaseIterator(di);
     setDeferredArrayLen(c, shard_replylen, shard_count);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -118,7 +118,9 @@ typedef struct clusterNode {
     int flags;      /* CLUSTER_NODE_... */
     uint64_t configEpoch; /* Last configEpoch observed for this node */
     unsigned char slots[CLUSTER_SLOTS/8]; /* slots handled by this node */
-    list *slot_info_pairs; /* Slots info represented as (start/end) pair (consecutive index). */
+    uint16_t *slot_info_pairs; /* Slots info represented as (start/end) pair (consecutive index). */
+    int slot_info_pairs_count; /* Used number of slots in slot_info_pairs */
+    int slot_info_pairs_alloc; /* Allocated number of slots in slot_info_pairs */
     int numslots;   /* Number of slots handled by this node */
     int numslaves;  /* Number of slave nodes, if this is a master */
     struct clusterNode **slaves; /* pointers to slave nodes */


### PR DESCRIPTION
Recently the cluster tests are consistently failing when executed with ASAN in the CI.
The failure is usually in `04-resharding.tcl`:
```
00:42:54> Verify 50000 keys for consistency with logical content: FAILED: caught an error in the test CLUSTERDOWN The cluster is down
```

when it happens with `test-sanitizer-address (gcc)`
we can later see this:
```
=== REDIS BUG REPORT START: Cut & paste starting from here ===
38902:M 27 Mar 2022 02:33:24.780 # Redis 255.255.255 crashed by signal: 11, si_code: 0
38902:M 27 Mar 2022 02:33:24.780 # Accessing address: 0x3e90000b308
38902:M 27 Mar 2022 02:33:24.781 # Killed by PID: 45832, UID: 1001
38902:M 27 Mar 2022 02:33:24.821 # Crashed running the instruction at: 0x7f04a759789b

------ STACK TRACE ------
EIP:
/lib/x86_64-linux-gnu/libc.so.6(__sched_yield+0xb)[0x7f04a759789b]

Backtrace:
../../../src/redis-server *:30000 [cluster](sigsegvHandler+0x1d2)[0x56170ae5e7b2]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x153c0)[0x7f04a76993c0]
/lib/x86_64-linux-gnu/libc.so.6(__sched_yield+0xb)[0x7f04a759789b]
/lib/x86_64-linux-gnu/libasan.so.5(+0x1323f5)[0x7f04a792e3f5]
/lib/x86_64-linux-gnu/libasan.so.5(+0x13b874)[0x7f04a7[937](https://github.com/redis/redis/runs/5706456172?check_suite_focus=true#step:9:937)874]
/lib/x86_64-linux-gnu/libc.so.6(dl_iterate_phdr+0x185)[0x7f04a75f4375]
/lib/x86_64-linux-gnu/libasan.so.5(+0x13bbd0)[0x7f04a7937bd0]
/lib/x86_64-linux-gnu/libasan.so.5(+0x13b031)[0x7f04a7937031]
/lib/x86_64-linux-gnu/libasan.so.5(+0x13b3b9)[0x7f04a79373b9]
/lib/x86_64-linux-gnu/libc.so.6(__cxa_finalize+0xce)[0x7f04a74dc15e]
/lib/x86_64-linux-gnu/libasan.so.5(+0x22be7)[0x7f04a781ebe7]
```


when it happens with `test-sanitizer-address (clang)` we see:
```
46928:M 28 Mar 2022 01:11:25.753 # Redis 255.255.255 crashed by signal: 11, si_code: 0
46928:M 28 Mar 2022 01:11:25.753 # Accessing address: 0x3e90000c3dc
46928:M 28 Mar 2022 01:11:25.754 # Killed by PID: 50140, UID: 1001
46928:M 28 Mar 2022 01:11:25.754 # Crashed running the instruction at: 0x7f2a964f289b

------ STACK TRACE ------
EIP:
/lib/x86_64-linux-gnu/libc.so.6(__sched_yield+0xb)[0x7f2a964f289b]

Backtrace:
../../../src/redis-server *:30000 [cluster](sigsegvHandler+0x193)[0x688c33]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x153c0)[0x7f2a9660f3c0]
/lib/x86_64-linux-gnu/libc.so.6(__sched_yield+0xb)[0x7f2a964f289b]
../../../src/redis-server *:30000 [cluster][0x4e8765]
../../../src/redis-server *:30000 [cluster][0x4f32ba]
/lib/x86_64-linux-gnu/libc.so.6(dl_iterate_phdr+0x185)[0x7f2a9654f375]
../../../src/redis-server *:30000 [cluster][0x4f328f]
../../../src/redis-server *:30000 [cluster][0x4f0a58]
../../../src/redis-server *:30000 [cluster][0x4f09c2]
/lib/x86_64-linux-gnu/libc.so.6(+0x49a27)[0x7f2a96436a27]
/lib/x86_64-linux-gnu/libc.so.6(on_exit+0x0)[0x7f2a96436be0]
../../../src/redis-server *:30000 [cluster](serverCron+0xfa8)[0x5267b8]
../../../src/redis-server *:30000 [cluster](aeProcessEvents+0xb0a)[0x515eba]
../../../src/redis-server *:30000 [cluster](aeMain+0x3d)[0x5165fd]
../../../src/redis-server *:30000 [cluster](main+0xb81)[0x540251]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3)[0x7f2a964140b3]
../../../src/redis-server *:30000 [cluster](_start+0x2e)[0x44f9ee]
```
these traces indicate that the test suite infra is attempting to terminate the redis instance, and when it refuses to terminate, the test suite sends a SIGSEGV in order to see where it is hung.
we see it is hung inside `exit`

I tried to track down the commit that started it, and it appears to be #10293.
Looking at the commit, i realize it didn't affect this test / flow, other than the replacement of the slots_info_pairs from sds to list.
i concluded that what could be happening is that the slot range is very fragmented, and that results in many allocations.
with sds, it results in one allocation and also, we have a greedy growth mechanism, but with adlist, we just have many many small allocations.
this probably causes stress on ASAN, and causes it to be slow at termination.

This commit improve malloc efficiency of this mechanism by changing adlist into an array being realloced with greedy growth mechanism
.
tests: https://github.com/redis/redis/actions/runs/2052717847