### PR TITLE
Fix outdated comment on zsetAdd

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1412,7 +1412,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 
             if (newscore) *newscore = score;
 
-            /* Remove and re-insert when score changes. */
+            /* Remove and re-insert when score and position changes. */
             if (score != curscore) {
                 znode = zslUpdateScore(zs->zsl,curscore,ele,score);
                 /* Note that we did not removed the original element from


### PR DESCRIPTION
`If the node, after the score update, would be still exactly at the same position, we can just update the score without actually removing and re-inserting the element in the skiplist.` according to #5179