### PR TITLE
Fix auth reset after wrong password

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2986,6 +2986,7 @@ void authCommand(client *c) {
     if (ACLAuthenticateUser(c,username,password) == C_OK) {
         addReply(c,shared.ok);
     } else {
+        c->authenticated = 0;
         addReplyError(c,"-WRONGPASS invalid username-password pair or user is disabled.");
     }
 }


### PR DESCRIPTION
This fixes the bug mentioned in https://github.com/redis/redis/issues/10491.
A unit test is also added to check this behavior.

