### PR TITLE
Move restart_killed_instances and verify_sentinel_auto_discovery to utils

### DIFF
--- a/tests/sentinel/tests/08-hostname-conf.tcl
+++ b/tests/sentinel/tests/08-hostname-conf.tcl
@@ -1,3 +1,5 @@
+source "../tests/includes/utils.tcl"
+
 proc set_redis_announce_ip {addr} {
     foreach_redis_id id {
         R $id config set replica-announce-ip $addr

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -1,27 +1,5 @@
 # Initialization tests -- most units will start including this.
-
-proc restart_killed_instances {} {
-    foreach type {redis sentinel} {
-        foreach_${type}_id id {
-            if {[get_instance_attrib $type $id pid] == -1} {
-                puts -nonewline "$type/$id "
-                flush stdout
-                restart_instance $type $id
-            }
-        }
-    }
-}
-
-proc verify_sentinel_auto_discovery {} {
-    set sentinels [llength $::sentinel_instances]
-    foreach_sentinel_id id {
-        wait_for_condition 1000 50 {
-            [dict get [S $id SENTINEL MASTER mymaster] num-other-sentinels] == ($sentinels-1)
-        } else {
-            fail "At least some sentinel can't detect some other sentinel"
-        }
-    }
-}
+source "../tests/includes/utils.tcl"
 
 test "(init) Restart killed instances" {
     restart_killed_instances

--- a/tests/sentinel/tests/includes/utils.tcl
+++ b/tests/sentinel/tests/includes/utils.tcl
@@ -1,0 +1,22 @@
+proc restart_killed_instances {} {
+    foreach type {redis sentinel} {
+        foreach_${type}_id id {
+            if {[get_instance_attrib $type $id pid] == -1} {
+                puts -nonewline "$type/$id "
+                flush stdout
+                restart_instance $type $id
+            }
+        }
+    }
+}
+
+proc verify_sentinel_auto_discovery {} {
+    set sentinels [llength $::sentinel_instances]
+    foreach_sentinel_id id {
+        wait_for_condition 1000 50 {
+            [dict get [S $id SENTINEL MASTER mymaster] num-other-sentinels] == ($sentinels-1)
+        } else {
+            fail "At least some sentinel can't detect some other sentinel"
+        }
+    }
+}


### PR DESCRIPTION
Create a utils.tcl in sentinel/tests/includes, and move two procs to it.
Allow sentinel test 08-hostname-conf run on its own.

closes #10470