### PR TITLE
Fix failing moduleconfigs tests and memory leak

### DIFF
--- a/tests/modules/moduleconfigs.c
+++ b/tests/modules/moduleconfigs.c
@@ -48,7 +48,7 @@ int setStringConfigCommand(const char *name, RedisModuleString *new, void *privd
         *err = RedisModule_CreateString(NULL, "Cannot set string to 'rejectisfreed'", 36);
         return REDISMODULE_ERR;
     }
-    RedisModule_Free(strval);
+    if (strval) RedisModule_FreeString(NULL, strval);
     RedisModule_RetainString(NULL, new);
     strval = new;
     return REDISMODULE_OK;
@@ -134,6 +134,9 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
 int RedisModule_OnUnload(RedisModuleCtx *ctx) {
     REDISMODULE_NOT_USED(ctx);
-    if (strval) RedisModule_FreeString(ctx, strval);
+    if (strval) {
+        RedisModule_FreeString(ctx, strval);
+        strval = NULL;
+    }
     return REDISMODULE_OK;
 }

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -22,6 +22,9 @@ start_server {tags {"modules"}} {
         assert_equal [r config get moduleconfigs.memory_numeric] "moduleconfigs.memory_numeric 1048576"
         r config set moduleconfigs.string wafflewednesdays
         assert_equal [r config get moduleconfigs.string] "moduleconfigs.string wafflewednesdays"
+        set not_embstr [string repeat A 50]
+        r config set moduleconfigs.string $not_embstr
+        assert_equal [r config get moduleconfigs.string] "moduleconfigs.string $not_embstr"
         r config set moduleconfigs.string \x73\x75\x70\x65\x72\x20\x00\x73\x65\x63\x72\x65\x74\x20\x70\x61\x73\x73\x77\x6f\x72\x64
         assert_equal [r config get moduleconfigs.string] "moduleconfigs.string {super \0secret password}"
         r config set moduleconfigs.enum two


### PR DESCRIPTION
Fix global `strval` not reset to NULL after being freed, causing a crash on alpine (most likely because the dynamic library loader doesn't init globals on reload)
By the way, fix the memory leak of using `RedisModule_Free` to free `RedisModuleString`, and add a corresponding test.

Fail CI:
[redis/redis/runs/5763628464?check_suite_focus=true](https://github.com/redis/redis/runs/5763628464?check_suite_focus=true)
[redis/redis/runs/5763628410?check_suite_focus=true](https://github.com/redis/redis/runs/5763628410?check_suite_focus=true)

module fully ci:
https://github.com/sundb/redis/runs/5770453986?check_suite_focus=true