### PR TITLE
Keyspace event for new keys

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1827,6 +1827,7 @@ latency-monitor-threshold 0
 #  z     Sorted set commands
 #  x     Expired events (events generated every time a key expires)
 #  e     Evicted events (events generated when a key is evicted for maxmemory)
+#  n     New key events (Note: not included in the 'A' class)
 #  t     Stream commands
 #  d     Module key type events
 #  m     Key-miss events (Note: It is not included in the 'A' class)

--- a/src/config.c
+++ b/src/config.c
@@ -2691,7 +2691,7 @@ static int setConfigNotifyKeyspaceEventsOption(standardConfig *config, sds *argv
     }
     int flags = keyspaceEventsStringToFlags(argv[0]);
     if (flags == -1) {
-        *err = "Invalid event class character. Use 'Ag$lshzxeKEtmd'.";
+        *err = "Invalid event class character. Use 'Ag$lshzxeKEtmdn'.";
         return 0;
     }
     server.notify_keyspace_events = flags;

--- a/src/db.c
+++ b/src/db.c
@@ -257,6 +257,7 @@ void setKey(client *c, redisDb *db, robj *key, robj *val, int flags) {
 
     if (!keyfound) {
         dbAdd(db,key,val);
+        notifyKeyspaceEvent(NOTIFY_NEW,"new",key,db->id);
     } else {
         dbOverwrite(db,key,val);
     }

--- a/src/db.c
+++ b/src/db.c
@@ -182,6 +182,7 @@ void dbAdd(redisDb *db, robj *key, robj *val) {
     dictSetVal(db->dict, de, val);
     signalKeyAsReady(db, key, val->type);
     if (server.cluster_enabled) slotToKeyAddEntry(de, db);
+    notifyKeyspaceEvent(NOTIFY_NEW,"new",key,db->id);
 }
 
 /* This is a special version of dbAdd() that is used only when loading
@@ -257,7 +258,6 @@ void setKey(client *c, redisDb *db, robj *key, robj *val, int flags) {
 
     if (!keyfound) {
         dbAdd(db,key,val);
-        notifyKeyspaceEvent(NOTIFY_NEW,"new",key,db->id);
     } else {
         dbOverwrite(db,key,val);
     }

--- a/src/notify.c
+++ b/src/notify.c
@@ -57,6 +57,7 @@ int keyspaceEventsStringToFlags(char *classes) {
         case 't': flags |= NOTIFY_STREAM; break;
         case 'm': flags |= NOTIFY_KEY_MISS; break;
         case 'd': flags |= NOTIFY_MODULE; break;
+        case 'n': flags |= NOTIFY_NEW; break;
         default: return -1;
         }
     }
@@ -84,6 +85,7 @@ sds keyspaceEventsFlagsToString(int flags) {
         if (flags & NOTIFY_EVICTED) res = sdscatlen(res,"e",1);
         if (flags & NOTIFY_STREAM) res = sdscatlen(res,"t",1);
         if (flags & NOTIFY_MODULE) res = sdscatlen(res,"d",1);
+        if (flags & NOTIFY_NEW) res = sdscatlen(res,"n",1);
     }
     if (flags & NOTIFY_KEYSPACE) res = sdscatlen(res,"K",1);
     if (flags & NOTIFY_KEYEVENT) res = sdscatlen(res,"E",1);

--- a/src/server.h
+++ b/src/server.h
@@ -603,6 +603,7 @@ typedef enum {
 #define NOTIFY_KEY_MISS (1<<11)   /* m (Note: This one is excluded from NOTIFY_ALL on purpose) */
 #define NOTIFY_LOADED (1<<12)     /* module only key space notification, indicate a key loaded from rdb */
 #define NOTIFY_MODULE (1<<13)     /* d, module key space notification */
+#define NOTIFY_NEW (1<<14)        /* n, new key notification */
 #define NOTIFY_ALL (NOTIFY_GENERIC | NOTIFY_STRING | NOTIFY_LIST | NOTIFY_SET | NOTIFY_HASH | NOTIFY_ZSET | NOTIFY_EXPIRED | NOTIFY_EVICTED | NOTIFY_STREAM | NOTIFY_MODULE) /* A flag */
 
 /* Using the following macro you can run code inside serverCron() with the


### PR DESCRIPTION
Add an optional keyspace event when new keys are added to the db.  

This is useful for applications where clients need to be aware of the redis keyspace. Such an application can SCAN once at startup and then listen for "new" events (plus others associated with DEL, RENAME, etc).

I was unsure if this should be included in the 'A' event class, so I left that out and documented.
It would be great if this could make it into the next 6.2.x release as well as 7.

to do:
- [x] redis-doc PR