### PR TITLE
Fix #10508, on error, pop function and error handler from Lua stack.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -508,6 +508,7 @@ void evalGenericCommand(client *c, int evalsha) {
 
     scriptRunCtx rctx;
     if (scriptPrepareForRun(&rctx, lctx.lua_client, c, lua_cur_script, l->flags, ro) != C_OK) {
+        lua_pop(lua,2); /* Remove the function and error handler. */
         return;
     }
     rctx.flags |= SCRIPT_EVAL_MODE; /* mark the current run as EVAL (as opposed to FCALL) so we'll

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1399,6 +1399,19 @@ start_server {tags {"scripting"}} {
         r config set replica-serve-stale-data yes
         set _ {}
     } {} {external:skip}
+
+    test "reject script do not cause a Lua stack leak" {
+        r config set maxmemory 1
+        for {set i 0} {$i < 50} {incr i} {
+            assert_error {OOM allow-oom flag is not set on the script, can not run it when used memory > 'maxmemory'} {r eval {#!lua
+                return 1
+            } 0}
+        }
+        r config set maxmemory 0
+        assert_equal [r eval {#!lua
+            return 1
+        } 0] 1
+    }
 }
 
 # Additional eval only tests


### PR DESCRIPTION
Fix #10508, on error, pop function and error handler from Lua stack. 
If, for some reason, Redis decides not to execute the script, we need to pop the function and error handler from Lua stack. Otherwise, eventually the Lua stack will explode.

Relevant only for 7.0-rc1 and 7.0-rc2.