### PR TITLE
Fix: fix mistake / outdated doc comment

### DIFF
--- a/src/geohash.c
+++ b/src/geohash.c
@@ -46,7 +46,7 @@
 
 /* Interleave lower bits of x and y, so the bits of x
  * are in the even positions and bits from y in the odd;
- * x and y must initially be less than 2**32 (65536).
+ * x and y must initially be less than 2**32 (4294967296).
  * From:  https://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN
  */
 static inline uint64_t interleave64(uint32_t xlo, uint32_t ylo) {


### PR DESCRIPTION
My pr just fix the problem that I mentioned at #10520
Unlike original reference code, Redis uses 64bit variable, so half the bits make it 32bit, not 16