### PR TITLE
Introduce replica_shutdown_nosave config

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1492,6 +1492,13 @@ aof-timestamp-enabled no
 #
 # shutdown-timeout 10
 
+# When save configuration is enabled, an RDB snapshot is flushed to disk on 
+# shutdown. This operation is blocking and may cause timeouts on clients.
+# Not saving latest snapshot before shutting down means recent data can be
+# lost. If this is desired, SAVE on shutdown can be turned off on replicas.
+#
+# replica-shutdown-nosave no
+
 ################ NON-DETERMINISTIC LONG BLOCKING COMMANDS #####################
 
 # Maximum time in milliseconds for EVAL scripts, functions and in some cases

--- a/src/config.c
+++ b/src/config.c
@@ -2887,6 +2887,7 @@ standardConfig static_configs[] = {
     createBoolConfig("replica-announced", NULL, MODIFIABLE_CONFIG, server.replica_announced, 1, NULL, NULL),
     createBoolConfig("latency-tracking", NULL, MODIFIABLE_CONFIG, server.latency_tracking_enabled, 1, NULL, NULL),
     createBoolConfig("aof-disable-auto-gc", NULL, MODIFIABLE_CONFIG, server.aof_disable_auto_gc, 0, NULL, updateAofAutoGCEnabled),
+    createBoolConfig("replica-shutdown-nosave", NULL, MODIFIABLE_CONFIG, server.replica_shutdown_nosave, 0, NULL, NULL),
     
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/server.c
+++ b/src/server.c
@@ -3899,8 +3899,9 @@ int prepareForShutdown(int flags) {
      * the dataset on shutdown (otherwise it could overwrite the current DB
      * with half-read data).
      *
-     * Also when in Sentinel mode clear the SAVE flag and force NOSAVE. */
-    if (server.loading || server.sentinel_mode)
+     * Also clear the SAVE flag and force NOSAVE when either in Sentinel mode
+     * or replica_shutdown_nosave configuration is enabled. */
+    if (server.loading || server.sentinel_mode || (server.masterhost && server.replica_shutdown_nosave))
         flags = (flags & ~SHUTDOWN_SAVE) | SHUTDOWN_NOSAVE;
 
     server.shutdown_flags = flags;

--- a/src/server.h
+++ b/src/server.h
@@ -1717,6 +1717,7 @@ struct redisServer {
                                      * abort(). useful for Valgrind. */
     /* Shutdown */
     int shutdown_timeout;           /* Graceful shutdown time limit in seconds. */
+    int replica_shutdown_nosave;    /* Disable auto RDB SAVE on shutdown for replicas. */
 
     /* Replication (master) */
     char replid[CONFIG_RUN_ID_SIZE+1];  /* My current replication ID. */


### PR DESCRIPTION
The blocking behavior of SAVE during shutdown can be undesired if we want a stable and responsive connection without compromising. Switching to a viable server should be fast.
On replicas using RDB, it can be acceptable to not save the latest data, especially if we know it will never become a master.
Sometimes the periodic SAVE in background is enough.
Also, if guaranteed durability is desired AOF could be used instead.
Here I suggest introducing the boolean option `replica_shutdown_nosave` to disable auto SAVE on shutdown, and explicitly restricting this to replicas, where it most matters to have responsive connections.

An alternative (maybe even better) would be to close all normal client connections as soon as SAVE starts on shutdown and not accept any new normal connection.

Tests to be include if proposal is accepted.