### PR TITLE
use $^ instead of $< for linker in module makefile

### DIFF
--- a/src/modules/Makefile
+++ b/src/modules/Makefile
@@ -28,42 +28,42 @@ all: helloworld.so hellotype.so helloblock.so hellocluster.so hellotimer.so hell
 helloworld.xo: ../redismodule.h
 
 helloworld.so: helloworld.xo
-	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
+	$(LD) -o $@ $^ $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
 hellotype.xo: ../redismodule.h
 
 hellotype.so: hellotype.xo
-	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
+	$(LD) -o $@ $^ $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
 helloblock.xo: ../redismodule.h
 
 helloblock.so: helloblock.xo
-	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lpthread -lc
+	$(LD) -o $@ $^ $(SHOBJ_LDFLAGS) $(LIBS) -lpthread -lc
 
 hellocluster.xo: ../redismodule.h
 
 hellocluster.so: hellocluster.xo
-	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
+	$(LD) -o $@ $^ $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
 hellotimer.xo: ../redismodule.h
 
 hellotimer.so: hellotimer.xo
-	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
+	$(LD) -o $@ $^ $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
 hellodict.xo: ../redismodule.h
 
 hellodict.so: hellodict.xo
-	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
+	$(LD) -o $@ $^ $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
 hellohook.xo: ../redismodule.h
 
 hellohook.so: hellohook.xo
-	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
+	$(LD) -o $@ $^ $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
 helloacl.xo: ../redismodule.h
 
 helloacl.so: helloacl.xo
-	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
+	$(LD) -o $@ $^ $(SHOBJ_LDFLAGS) $(LIBS) -lc
 
 clean:
 	rm -rf *.xo *.so

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -69,7 +69,7 @@ all: $(TEST_MODULES)
 	$(CC) -I../../src $(CFLAGS) $(SHOBJ_CFLAGS) -fPIC -c $< -o $@
 
 %.so: %.xo
-	$(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LDFLAGS) $(LIBS)
+	$(LD) -o $@ $^ $(SHOBJ_LDFLAGS) $(LDFLAGS) $(LIBS)
 
 .PHONY: clean
 


### PR DESCRIPTION
when my module have multi source files, such as A.c and B.c; and my Makefile copy from redis module demo
``` makefile
mymodule.so: A.xo B.xo
    $(LD) -o $@ $< $(SHOBJ_LDFLAGS) $(LIBS) -lc
```
my target file  was only include the symbols of A.xo file, no symbols from B.xo file

from the mananl of GUN Make[makefile document](https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html#Automatic-Variables)
* `$<` : The name of the first prerequisite.
* `$^`:  The names of all the prerequisites, with spaces between them. 

I think using the `$^` is better than `$<` when our target file is a shared object 