### PR TITLE
improve malloc efficiency: reduce call times of zrealloc

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4689,9 +4689,10 @@ void clusterGenNodesSlotsInfo(int filter) {
          * or end of slot. */
         if (i == CLUSTER_SLOTS || n != server.cluster->slots[i]) {
             if (!(n->flags & filter)) {
-                if(!n->slot_info_pairs) {
-                    n->slot_info_pairs = zrealloc(n->slot_info_pairs, 2 * n->numslots * sizeof(uint16_t));
+                if (!n->slot_info_pairs) {
+                    n->slot_info_pairs = zmalloc(2 * n->numslots * sizeof(uint16_t));
                 }
+                serverAssert((n->slot_info_pairs_count + 1) < (2 * n->numslots));
                 n->slot_info_pairs[n->slot_info_pairs_count++] = start;
                 n->slot_info_pairs[n->slot_info_pairs_count++] = i-1;
             }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -946,7 +946,6 @@ clusterNode *createClusterNode(char *nodename, int flags) {
     memset(node->slots,0,sizeof(node->slots));
     node->slot_info_pairs = NULL;
     node->slot_info_pairs_count = 0;
-    node->slot_info_pairs_alloc = 0;
     node->numslots = 0;
     node->numslaves = 0;
     node->slaves = NULL;
@@ -4690,12 +4689,8 @@ void clusterGenNodesSlotsInfo(int filter) {
          * or end of slot. */
         if (i == CLUSTER_SLOTS || n != server.cluster->slots[i]) {
             if (!(n->flags & filter)) {
-                if (n->slot_info_pairs_count+2 > n->slot_info_pairs_alloc) {
-                    if (n->slot_info_pairs_alloc == 0)
-                        n->slot_info_pairs_alloc = 8;
-                    else
-                        n->slot_info_pairs_alloc *= 2;
-                    n->slot_info_pairs = zrealloc(n->slot_info_pairs, n->slot_info_pairs_alloc * sizeof(uint16_t));
+                if(!n->slot_info_pairs) {
+                    n->slot_info_pairs = zrealloc(n->slot_info_pairs, 2 * n->numslots * sizeof(uint16_t));
                 }
                 n->slot_info_pairs[n->slot_info_pairs_count++] = start;
                 n->slot_info_pairs[n->slot_info_pairs_count++] = i-1;
@@ -4711,7 +4706,6 @@ void clusterFreeNodesSlotsInfo(clusterNode *n) {
     zfree(n->slot_info_pairs);
     n->slot_info_pairs = NULL;
     n->slot_info_pairs_count = 0;
-    n->slot_info_pairs_alloc = 0;
 }
 
 /* Generate a csv-alike representation of the nodes we are aware of,

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -120,7 +120,6 @@ typedef struct clusterNode {
     unsigned char slots[CLUSTER_SLOTS/8]; /* slots handled by this node */
     uint16_t *slot_info_pairs; /* Slots info represented as (start/end) pair (consecutive index). */
     int slot_info_pairs_count; /* Used number of slots in slot_info_pairs */
-    int slot_info_pairs_alloc; /* Allocated number of slots in slot_info_pairs */
     int numslots;   /* Number of slots handled by this node */
     int numslaves;  /* Number of slave nodes, if this is a master */
     struct clusterNode **slaves; /* pointers to slave nodes */


### PR DESCRIPTION
**What this PR does :**

1. Remove confusing fields :**slot_info_pairs_alloc** 

> **slot_info_pairs_alloc** is used to preallocate **slot_info_pairs** memory size.But **slot_info_pairs_count** is fixed for one  unique clusterNode and It less than **2*n->numslots**. So I remove field **slot_info_pairs_alloc**,use **2*n->numslots** instead.

2. Performance improvement

> To one unique clusterNode,function zrealloc is called only once  after modification.So this PR reduce the call times of brk system call and reduces memory fragmentation.  


**Related PR**:
improve malloc efficiency for cluster slots_info_pairs https://github.com/redis/redis/pull/10488

Add cluster shards support : https://github.com/redis/redis/pull/10293
