### PR TITLE
Add RM_MallocSizeString, RM_MallocSizeDict

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -40,6 +40,7 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/zset \
 --single unit/moduleapi/list \
 --single unit/moduleapi/stream \
+--single unit/moduleapi/mallocsize \
 --single unit/moduleapi/datatype2 \
 --single unit/moduleapi/cluster \
 --single unit/moduleapi/aclcheck \

--- a/src/module.c
+++ b/src/module.c
@@ -9738,7 +9738,7 @@ size_t RM_MallocSize(void* ptr) {
  */
 size_t RM_MallocSizeString(RedisModuleString* str) {
     serverAssert(str->type == OBJ_STRING);
-    return objectComputeSize(NULL, str, 0, 0);
+    return sizeof(*str) + getStringObjectSdsUsedMemory(str);
 }
 
 /* Same as RM_MallocSize, except it works on RedisModuleDict pointers.
@@ -9746,10 +9746,9 @@ size_t RM_MallocSizeString(RedisModuleString* str) {
  * it does not include the allocation size of the keys and values.
  */
 size_t RM_MallocSizeDict(RedisModuleDict* dict) {
-    /* See streamRadixTreeMemoryUsage */
-    size_t size = sizeof(RedisModuleDict);
+    size_t size = sizeof(RedisModuleDict) + sizeof(rax);
     size += dict->rax->numnodes * sizeof(raxNode);
-    /* Add a fixed overhead due to the aux data pointer, children, ... */
+    /* For more info about this weird line, see streamRadixTreeMemoryUsage */
     size += dict->rax->numnodes * sizeof(long)*30;
     return size;
 }

--- a/src/object.c
+++ b/src/object.c
@@ -957,12 +957,12 @@ char *strEncoding(int encoding) {
  * Actually the number of nodes and keys may be different depending
  * on the insertion speed and thus the ability of the radix tree
  * to compress prefixes. */
-size_t streamRadixTreeMemoryUsage(rax *rax) {
-    size_t size;
-    size = rax->numele * sizeof(streamID);
-    size += rax->numnodes * sizeof(raxNode);
+size_t streamRadixTreeMemoryUsage(rax *r) {
+    size_t size = sizeof(r);
+    size = r->numele * sizeof(streamID);
+    size += r->numnodes * sizeof(raxNode);
     /* Add a fixed overhead due to the aux data pointer, children, ... */
-    size += rax->numnodes * sizeof(long)*30;
+    size += r->numnodes * sizeof(long)*30;
     return size;
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -957,12 +957,12 @@ char *strEncoding(int encoding) {
  * Actually the number of nodes and keys may be different depending
  * on the insertion speed and thus the ability of the radix tree
  * to compress prefixes. */
-size_t streamRadixTreeMemoryUsage(rax *r) {
-    size_t size = sizeof(r);
-    size = r->numele * sizeof(streamID);
-    size += r->numnodes * sizeof(raxNode);
+size_t streamRadixTreeMemoryUsage(rax *rax) {
+    size_t size = sizeof(*rax);
+    size = rax->numele * sizeof(streamID);
+    size += rax->numnodes * sizeof(raxNode);
     /* Add a fixed overhead due to the aux data pointer, children, ... */
-    size += r->numnodes * sizeof(long)*30;
+    size += rax->numnodes * sizeof(long)*30;
     return size;
 }
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1149,6 +1149,8 @@ REDISMODULE_API int (*RedisModule_ExitFromChild)(int retcode) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_KillForkChild)(int child_pid) REDISMODULE_ATTR;
 REDISMODULE_API float (*RedisModule_GetUsedMemoryRatio)() REDISMODULE_ATTR;
 REDISMODULE_API size_t (*RedisModule_MallocSize)(void* ptr) REDISMODULE_ATTR;
+REDISMODULE_API size_t (*RedisModule_MallocSizeString)(RedisModuleString* str) REDISMODULE_ATTR;
+REDISMODULE_API size_t (*RedisModule_MallocSizeDict)(RedisModuleDict* dict) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleUser * (*RedisModule_CreateModuleUser)(const char *name) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_FreeModuleUser)(RedisModuleUser *user) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetModuleUserACL)(RedisModuleUser *user, const char* acl) REDISMODULE_ATTR;
@@ -1478,6 +1480,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(KillForkChild);
     REDISMODULE_GET_API(GetUsedMemoryRatio);
     REDISMODULE_GET_API(MallocSize);
+    REDISMODULE_GET_API(MallocSizeString);
+    REDISMODULE_GET_API(MallocSizeDict);
     REDISMODULE_GET_API(CreateModuleUser);
     REDISMODULE_GET_API(FreeModuleUser);
     REDISMODULE_GET_API(SetModuleUserACL);

--- a/src/server.h
+++ b/src/server.h
@@ -2903,7 +2903,6 @@ unsigned int LRU_CLOCK(void);
 const char *evictPolicyToString(void);
 struct redisMemOverhead *getMemoryOverheadData(void);
 void freeMemoryOverheadData(struct redisMemOverhead *mh);
-size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid);
 void checkChildrenDone(void);
 int setOOMScoreAdj(int process_class);
 void rejectCommandFormat(client *c, const char *fmt, ...);

--- a/src/server.h
+++ b/src/server.h
@@ -2903,6 +2903,7 @@ unsigned int LRU_CLOCK(void);
 const char *evictPolicyToString(void);
 struct redisMemOverhead *getMemoryOverheadData(void);
 void freeMemoryOverheadData(struct redisMemOverhead *mh);
+size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid);
 void checkChildrenDone(void);
 int setOOMScoreAdj(int process_class);
 void rejectCommandFormat(client *c, const char *fmt, ...);

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -49,6 +49,7 @@ TEST_MODULES = \
     hash.so \
     zset.so \
     stream.so \
+    mallocsize.so \
     aclcheck.so \
     list.so \
     subcommands.so \

--- a/tests/modules/mallocsize.c
+++ b/tests/modules/mallocsize.c
@@ -150,10 +150,7 @@ int cmd_setraw(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
     udt_t *udt = RedisModule_ModuleTypeGetValue(key);
-    if (udt) {
-        udt_free(udt);
-        udt = NULL;
-    }
+
     udt = RedisModule_Alloc(sizeof(*udt));
     
     long long raw_len;
@@ -173,11 +170,7 @@ int cmd_setstr(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return RedisModule_WrongArity(ctx);
         
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
-    udt_t *udt = RedisModule_ModuleTypeGetValue(key);
-    if (udt) {
-        udt_free(udt);
-        udt = NULL;
-    }
+
     udt = RedisModule_Alloc(sizeof(*udt));
     
     udt->data.str = argv[2];
@@ -196,10 +189,7 @@ int cmd_setdict(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
     udt_t *udt = RedisModule_ModuleTypeGetValue(key);
-    if (udt) {
-        udt_free(udt);
-        udt = NULL;
-    }
+
     udt = RedisModule_Alloc(sizeof(*udt));
     
     udt->data.dict = RedisModule_CreateDict(ctx);

--- a/tests/modules/mallocsize.c
+++ b/tests/modules/mallocsize.c
@@ -58,7 +58,9 @@ void rsd_rdb_save(RedisModuleIO *rdb, void *value) {
     while((dk = RedisModule_DictNext(NULL, iter, (void **)&dv)) != NULL) {
         RedisModule_SaveString(rdb, dk);
         RedisModule_SaveString(rdb, dv);
+        RedisModule_FreeString(dk);
     }
+    RedisModule_DictIteratorStop(iter);
 }
 
 size_t rsd_mem_usage(RedisModuleKeyOptCtx *ctx, const void *value, size_t sample_size) {
@@ -75,6 +77,7 @@ size_t rsd_mem_usage(RedisModuleKeyOptCtx *ctx, const void *value, size_t sample
     while((dk = RedisModule_DictNext(NULL, iter, (void **)&dv)) != NULL) {
         size += RedisModule_MallocSizeString(dk);
         size += RedisModule_MallocSizeString(dv);
+        RedisModule_FreeString(dk);
     }
     RedisModule_DictIteratorStop(iter);
     
@@ -110,7 +113,6 @@ int cmd_mallocsize_set(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         RedisModule_DictSet(rsd->d, argv[i], argv[i+1]);
         RedisModule_RetainString(ctx, argv[i]);
         RedisModule_RetainString(ctx, argv[i+1]);
-        
     }
         
     RedisModule_ModuleTypeSetValue(key, mallocsize_type, rsd);

--- a/tests/modules/mallocsize.c
+++ b/tests/modules/mallocsize.c
@@ -1,0 +1,65 @@
+#include "redismodule.h"
+#include <string.h>
+#include <assert.h>
+#include <unistd.h>
+
+#define UNUSED(V) ((void) V)
+
+int cmd_raw(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+{
+    if (argc != 2)
+        return RedisModule_WrongArity(ctx);
+        
+    long long len;
+    RedisModule_StringToLongLong(argv[1], &len);
+    void *p = RedisModule_Alloc(len);
+    long long size = RedisModule_MallocSize(p);
+    RedisModule_Free(p);
+    RedisModule_ReplyWithLongLong(ctx, size);
+    return REDISMODULE_OK;
+}
+
+int cmd_string(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+{
+    if (argc != 2)
+        return RedisModule_WrongArity(ctx);
+        
+    void *s = RedisModule_CreateStringFromString(ctx, argv[1]);
+    long long size = RedisModule_MallocSizeString(s);
+    RedisModule_FreeString(ctx, s);
+    RedisModule_ReplyWithLongLong(ctx, size);
+    return REDISMODULE_OK;
+}
+
+int cmd_dict(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+{
+    if (!(argc % 2))
+        return RedisModule_WrongArity(ctx);
+        
+    RedisModuleDict *d = RedisModule_CreateDict(ctx);
+    for (int i = 1; i < argc; i += 2)
+        RedisModule_DictSet(d, argv[i], argv[i+1]);
+    long long size = RedisModule_MallocSizeDict(d);
+    RedisModule_FreeDict(ctx, d);
+    RedisModule_ReplyWithLongLong(ctx, size);
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(argv);
+    UNUSED(argc);
+    if (RedisModule_Init(ctx,"mallocsize",1,REDISMODULE_APIVER_1)== REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"mallocsize.raw",cmd_raw,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+        
+    if (RedisModule_CreateCommand(ctx,"mallocsize.string",cmd_string,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+        
+    if (RedisModule_CreateCommand(ctx,"mallocsize.dict",cmd_dict,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+
+    return REDISMODULE_OK;
+}

--- a/tests/modules/mallocsize.c
+++ b/tests/modules/mallocsize.c
@@ -149,9 +149,8 @@ int cmd_setraw(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return RedisModule_WrongArity(ctx);
         
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
-    udt_t *udt = RedisModule_ModuleTypeGetValue(key);
 
-    udt = RedisModule_Alloc(sizeof(*udt));
+    udt_t *udt = RedisModule_Alloc(sizeof(*udt));
     
     long long raw_len;
     RedisModule_StringToLongLong(argv[2], &raw_len);
@@ -171,7 +170,7 @@ int cmd_setstr(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
 
-    udt = RedisModule_Alloc(sizeof(*udt));
+    udt_t *udt = RedisModule_Alloc(sizeof(*udt));
     
     udt->data.str = argv[2];
     RedisModule_RetainString(ctx, argv[2]);
@@ -188,9 +187,8 @@ int cmd_setdict(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return RedisModule_WrongArity(ctx);
         
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
-    udt_t *udt = RedisModule_ModuleTypeGetValue(key);
 
-    udt = RedisModule_Alloc(sizeof(*udt));
+    udt_t *udt = RedisModule_Alloc(sizeof(*udt));
     
     udt->data.dict = RedisModule_CreateDict(ctx);
     for (int i = 2; i < argc; i += 2) {

--- a/tests/modules/mallocsize.c
+++ b/tests/modules/mallocsize.c
@@ -151,6 +151,7 @@ int cmd_setraw(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
 
     udt_t *udt = RedisModule_Alloc(sizeof(*udt));
+    udt->type = UDT_RAW;
     
     long long raw_len;
     RedisModule_StringToLongLong(argv[2], &raw_len);
@@ -171,6 +172,7 @@ int cmd_setstr(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
 
     udt_t *udt = RedisModule_Alloc(sizeof(*udt));
+    udt->type = UDT_STRING;
     
     udt->data.str = argv[2];
     RedisModule_RetainString(ctx, argv[2]);
@@ -189,6 +191,7 @@ int cmd_setdict(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE);
 
     udt_t *udt = RedisModule_Alloc(sizeof(*udt));
+    udt->type = UDT_DICT;
     
     udt->data.dict = RedisModule_CreateDict(ctx);
     for (int i = 2; i < argc; i += 2) {

--- a/tests/modules/mallocsize.c
+++ b/tests/modules/mallocsize.c
@@ -58,7 +58,7 @@ void rsd_rdb_save(RedisModuleIO *rdb, void *value) {
     while((dk = RedisModule_DictNext(NULL, iter, (void **)&dv)) != NULL) {
         RedisModule_SaveString(rdb, dk);
         RedisModule_SaveString(rdb, dv);
-        RedisModule_FreeString(dk);
+        RedisModule_FreeString(NULL, dk);
     }
     RedisModule_DictIteratorStop(iter);
 }
@@ -77,7 +77,7 @@ size_t rsd_mem_usage(RedisModuleKeyOptCtx *ctx, const void *value, size_t sample
     while((dk = RedisModule_DictNext(NULL, iter, (void **)&dv)) != NULL) {
         size += RedisModule_MallocSizeString(dk);
         size += RedisModule_MallocSizeString(dv);
-        RedisModule_FreeString(dk);
+        RedisModule_FreeString(NULL, dk);
     }
     RedisModule_DictIteratorStop(iter);
     
@@ -112,7 +112,7 @@ int cmd_mallocsize_set(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     for (int i = 4; i < argc; i += 2) {
         RedisModule_DictSet(rsd->d, argv[i], argv[i+1]);
         RedisModule_RetainString(ctx, argv[i]);
-        RedisModule_RetainString(ctx, argv[i+1]);
+        RedisModule_RetainString(ctx, argv[i+1]);   
     }
         
     RedisModule_ModuleTypeSetValue(key, mallocsize_type, rsd);

--- a/tests/unit/moduleapi/mallocsize.tcl
+++ b/tests/unit/moduleapi/mallocsize.tcl
@@ -1,0 +1,25 @@
+set testmodule [file normalize tests/modules/mallocsize.so]
+
+
+start_server {tags {"modules"}} {
+    r module load $testmodule
+
+    test {MallocSize raw} {
+        assert_equal [r mallocsize.raw 7] 8
+        assert_equal [r mallocsize.raw 32] 32
+        assert_equal [r mallocsize.raw 33] 40
+    }
+    
+    test {MallocSize string} {
+        assert_equal [r mallocsize.string 123] 24
+        assert_equal [r mallocsize.string 1234567890] 32
+        assert_equal [r mallocsize.string 12345678901234567890] 40
+    }
+    
+    test {MallocSize dict} {
+        assert_equal [r mallocsize.dict k v] 520
+        assert_equal [r mallocsize.dict kkkkkkkkk vvvvvvvvv] 520
+        assert_equal [r mallocsize.dict k v k2 v2] 764
+        assert_equal [r mallocsize.dict k1 v1 k2 v2] 1008  ;# The former is smaller because it has less rax nodes
+    }
+}

--- a/tests/unit/moduleapi/mallocsize.tcl
+++ b/tests/unit/moduleapi/mallocsize.tcl
@@ -6,16 +6,16 @@ start_server {tags {"modules"}} {
 
     test {MallocSize of raw bytes} {
         assert_equal [r mallocsize.setraw key 40] {OK}
-        assert_morethan [memory_usage key] 0
+        assert_morethan [memory_usage key] 40
     }
     
     test {MallocSize of string} {
         assert_equal [r mallocsize.setstr key abcdefg] {OK}
-        assert_morethan [memory_usage key] 0
+        assert_morethan [memory_usage key] 7 ;# Length of "abcdefg"
     }
     
     test {MallocSize of dict} {
         assert_equal [r mallocsize.setdict key f1 v1 f2 v2] {OK}
-        assert_morethan [memory_usage key] 0
+        assert_morethan [memory_usage key] 8 ;# Length of "f1v1f2v2"
     }
 }

--- a/tests/unit/moduleapi/mallocsize.tcl
+++ b/tests/unit/moduleapi/mallocsize.tcl
@@ -4,22 +4,8 @@ set testmodule [file normalize tests/modules/mallocsize.so]
 start_server {tags {"modules"}} {
     r module load $testmodule
 
-    test {MallocSize raw} {
-        assert_equal [r mallocsize.raw 7] 8
-        assert_equal [r mallocsize.raw 32] 32
-        assert_equal [r mallocsize.raw 33] 40
-    }
-    
-    test {MallocSize string} {
-        assert_equal [r mallocsize.string 123] 24
-        assert_equal [r mallocsize.string 1234567890] 32
-        assert_equal [r mallocsize.string 12345678901234567890] 40
-    }
-    
-    test {MallocSize dict} {
-        assert_equal [r mallocsize.dict k v] 520
-        assert_equal [r mallocsize.dict kkkkkkkkk vvvvvvvvv] 520
-        assert_equal [r mallocsize.dict k v k2 v2] 764
-        assert_equal [r mallocsize.dict k1 v1 k2 v2] 1008  ;# The former is smaller because it has less rax nodes
+    test {MallocSize of raw, string and dict} {
+        assert_equal [r mallocsize.set key 12 abc k1 v1 k2 v2] {OK}
+        assert_equal [r memory usage key] 168
     }
 }

--- a/tests/unit/moduleapi/mallocsize.tcl
+++ b/tests/unit/moduleapi/mallocsize.tcl
@@ -6,6 +6,6 @@ start_server {tags {"modules"}} {
 
     test {MallocSize of raw, string and dict} {
         assert_equal [r mallocsize.set key 12 abc k1 v1 k2 v2] {OK}
-        assert_equal [r memory usage key] 168
+        assert_morethan [memory_usage key] 100
     }
 }

--- a/tests/unit/moduleapi/mallocsize.tcl
+++ b/tests/unit/moduleapi/mallocsize.tcl
@@ -4,8 +4,18 @@ set testmodule [file normalize tests/modules/mallocsize.so]
 start_server {tags {"modules"}} {
     r module load $testmodule
 
-    test {MallocSize of raw, string and dict} {
-        assert_equal [r mallocsize.set key 12 abc k1 v1 k2 v2] {OK}
-        assert_morethan [memory_usage key] 100
+    test {MallocSize of raw bytes} {
+        assert_equal [r mallocsize.setraw key 40] {OK}
+        assert_morethan [memory_usage key] 0
+    }
+    
+    test {MallocSize of string} {
+        assert_equal [r mallocsize.setstr key abcdefg] {OK}
+        assert_morethan [memory_usage key] 0
+    }
+    
+    test {MallocSize of dict} {
+        assert_equal [r mallocsize.setdict key f1 v1 f2 v2] {OK}
+        assert_morethan [memory_usage key] 0
     }
 }

--- a/tests/unit/moduleapi/mallocsize.tcl
+++ b/tests/unit/moduleapi/mallocsize.tcl
@@ -6,16 +6,16 @@ start_server {tags {"modules"}} {
 
     test {MallocSize of raw bytes} {
         assert_equal [r mallocsize.setraw key 40] {OK}
-        assert_morethan [memory_usage key] 40
+        assert_morethan [r memory usage key] 40
     }
     
     test {MallocSize of string} {
         assert_equal [r mallocsize.setstr key abcdefg] {OK}
-        assert_morethan [memory_usage key] 7 ;# Length of "abcdefg"
+        assert_morethan [r memory usage key] 7 ;# Length of "abcdefg"
     }
     
     test {MallocSize of dict} {
         assert_equal [r mallocsize.setdict key f1 v1 f2 v2] {OK}
-        assert_morethan [memory_usage key] 8 ;# Length of "f1v1f2v2"
+        assert_morethan [r memory usage key] 8 ;# Length of "f1v1f2v2"
     }
 }


### PR DESCRIPTION
Add APIs to allow modules to compute the memory consumption of opaque objects owned by redis.
Without these, the `mem_usage` callbacks of module data types are useless in many cases.

Other changes:
Fix streamRadixTreeMemoryUsage to include the size of the rax structure itself

to do:
- [x] add test coverage