### PR TITLE
Optimize stream id sds creation on XADD key * (~20% saved cpu cycles)

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1370,7 +1370,7 @@ void streamLastValidID(stream *s, streamID *maxid)
     streamIteratorStop(&si);
 }
 
-/* Maximum size for a stream ID string. In theory 20*2+1 shuld be enough,
+/* Maximum size for a stream ID string. In theory 20*2+1 should be enough,
  * But to avoid chance for off by one issues and null-term, in case this will
  * be used as parsing buffer, we use a slightly larger buffer. On the other
  * hand considering sds header is gonna add 4 bytes, we wanna keep below the

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1370,9 +1370,15 @@ void streamLastValidID(stream *s, streamID *maxid)
     streamIteratorStop(&si);
 }
 
-#define STREAM_ID_STR_LEN 44 /* At least 20 * 2 + 1 */
+/* Maximum size for a stream ID string. In theory 20*2+1 shuld be enough,
+ * But to avoid chance for off by one issues and null-term, in case this will
+ * be used as parsing buffer, we use a slightly larger buffer. On the other
+ * hand considering sds header is gonna add 4 bytes, we wanna keep below the
+ * allocator's 48 bytes bin. */
+#define STREAM_ID_STR_LEN 44
 
 sds createStreamIDString(streamID *id) {
+    /* Optimization: pre-allocate a big enough buffer to avoid reallocs. */
     sds str = sdsnewlen(SDS_NOINIT, STREAM_ID_STR_LEN);
     sdssetlen(str, 0);
     return sdscatfmt(str,"%U-%U", id->ms,id->seq);


### PR DESCRIPTION
we can observe that when adding to a stream without ID there is a duplicate work on sds creation/freeing/sdslen that costs ~11% of the CPU cycles. 

![image](https://user-images.githubusercontent.com/5832149/163021023-f6d8586e-f36d-4370-99c7-47b604d1f981.png)

This PR avoids it by not freeing the sds after the first reply. 
The expected reduction in CPU cycles is around 9-10% as explained on the bellow image:
![image](https://user-images.githubusercontent.com/5832149/163022053-0f5aca20-d4b5-481e-9e36-de3e648e6267.png)

Additionally, we now pre-allocate the sds to the right size, to avoid realloc. this brought another ~10% improvement


To reproduce:
```
memtier_benchmark --test-time 60 -c 10 -t 8 --pipeline 15 --hide-histogram --command="XADD key * field value"
```

baseline on unstable branch ( 6b403f56a523480a08b1143c676ce174d0d0251c ) :

```
ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Xadds      526817.35         2.27484         2.20700         4.41500         4.51100     38992.30 
Totals     526817.35         2.27484         2.20700         4.41500         4.51100     38992.30 
```

First commit of this PR (avoid dup work): 
```
ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Xadds      590160.88         2.03049         1.96700         3.93500         4.03100     43693.61 
Totals     590160.88         2.03049         1.96700         3.93500         4.03100     43693.61 
```

Second commit (avoid reallocs):
```
ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Xadds      624186.13         1.88814         1.82300         3.64700         3.74300     46220.68 
Totals     624186.13         1.88814         1.82300         3.64700         3.74300     46220.68
```

### Platform details
The performance results provided in this PR were collected using:
- *Hardware platform*: A physical HPE ProLiant DL380 Gen10 Server, with one Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz, Maximum memory capacity of 3 TB, disabling CPU Frequency Scaling and with all configurable BIOS and CPU system settings set to performance.
- *OS*: Ubuntu 20.04 Linux release 5.4.0-107.
- *Installed Memory*: 64GB DDR4-SDRAM @ 2933 MHz
- *Compiler*: gcc-11 (Ubuntu 11.1.0-1ubuntu1~20.04) 11.1.0
