### PR TITLE
Fixes around AOF failed rewrite rate limiting

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -845,7 +845,6 @@ int aofRewriteLimited(void) {
     }
 
     next_rewrite_time = server.unixtime + next_delay_minutes * 60;
-    /* only one incr file in normal state, so the failed times should be 'incr_aof_num-1' */
     serverLog(LL_WARNING,
         "Background AOF rewrite has repeatedly failed and triggered the limit, will retry in %d minutes", next_delay_minutes);
     return 1;

--- a/src/aof.c
+++ b/src/aof.c
@@ -812,7 +812,7 @@ int openNewIncrAofForAppend(void) {
  * AOFRW, which may be that we have reached the 'next_rewrite_time' or the number of INCR
  * AOFs has not reached the limit threshold.
  * */
-#define AOF_REWRITE_LIMITE_THRESHOLD    3
+#define AOF_REWRITE_LIMITE_THRESHOLD    2
 #define AOF_REWRITE_LIMITE_MAX_MINUTES  60 /* 1 hour */
 int aofRewriteLimited(void) {
     static int next_delay_minutes = 0;

--- a/src/aof.c
+++ b/src/aof.c
@@ -823,9 +823,9 @@ int aofRewriteLimited(void) {
      * will not limit the AOFRW. */
     unsigned long incr_aof_num = listLength(server.aof_manifest->incr_aof_list);
     if (incr_aof_num < AOF_REWRITE_LIMITE_THRESHOLD || server.aof_lastbgrewrite_status == C_OK) {
-         /* We may be recovering from limited state, so reset all states. */
+        /* We may be recovering from limited state, so reset all states. */
         next_delay_minutes = 0;
-        next_rewrite_time  = 0;
+        next_rewrite_time = 0;
         return 0;
     }
     
@@ -839,7 +839,7 @@ int aofRewriteLimited(void) {
         }
     }
 
-    next_delay_minutes = (next_delay_minutes == 0) ? 1:(next_delay_minutes * 2);
+    next_delay_minutes = (next_delay_minutes == 0) ? 1 : (next_delay_minutes * 2);
     if (next_delay_minutes > AOF_REWRITE_LIMITE_MAX_MINUTES) {
         next_delay_minutes = AOF_REWRITE_LIMITE_MAX_MINUTES;
     }

--- a/src/server.c
+++ b/src/server.c
@@ -1296,13 +1296,12 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
         if (server.aof_state == AOF_ON &&
             !hasActiveChildProcess() &&
             server.aof_rewrite_perc &&
-            server.aof_current_size > server.aof_rewrite_min_size &&
-            !aofRewriteLimited())
+            server.aof_current_size > server.aof_rewrite_min_size)
         {
             long long base = server.aof_rewrite_base_size ?
                 server.aof_rewrite_base_size : 1;
             long long growth = (server.aof_current_size*100/base) - 100;
-            if (growth >= server.aof_rewrite_perc) {
+            if (growth >= server.aof_rewrite_perc && !aofRewriteLimited()) {
                 serverLog(LL_NOTICE,"Starting automatic rewriting of AOF on %lld%% growth",growth);
                 rewriteAppendOnlyFileBackground();
             }

--- a/src/server.c
+++ b/src/server.c
@@ -1256,8 +1256,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     /* Start a scheduled AOF rewrite if this was requested by the user while
      * a BGSAVE was in progress. */
     if (!hasActiveChildProcess() &&
-        server.aof_rewrite_scheduled &&
-        !aofRewriteLimited())
+        server.aof_rewrite_scheduled)
     {
         rewriteAppendOnlyFileBackground();
     }

--- a/src/server.c
+++ b/src/server.c
@@ -1256,7 +1256,8 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     /* Start a scheduled AOF rewrite if this was requested by the user while
      * a BGSAVE was in progress. */
     if (!hasActiveChildProcess() &&
-        server.aof_rewrite_scheduled)
+        server.aof_rewrite_scheduled &&
+        !aofRewriteLimited())
     {
         rewriteAppendOnlyFileBackground();
     }


### PR DESCRIPTION
Changes:
1. Check the failed rewrite time threshold only when we actually consider triggering a rewrite.
  i.e. this should be the last condition tested, since the test has side effects (increasing time threshold)
  Could have happened in some rare scenarios 
2. no limit in startup state (e.g. after restarting redis that previously failed and had many incr files)
3. the “triggered the limit” log would be recorded only when the limit status is returned
4. remove failure count in log (could be misleading in some cases)

Background:

MP-aof is an exciting update, recently I was testing it and found some issues with the current aofwrite limit, the log is as follows

```bash
#cat appendonly.aof.manifest
file appendonly.aof.38.base.rdb seq 38 type b
file appendonly.aof.45.incr.aof seq 45 type i
file appendonly.aof.46.incr.aof seq 46 type i
file appendonly.aof.47.incr.aof seq 47 type i
```
```
redislog
9136:M 13 Apr 2022 23:50:47.885 # Background AOF rewrite has repeatedly failed 3 times and triggered the limit, will retry in 1 minutes
9136:M 13 Apr 2022 23:51:47.045 # Background AOF rewrite has repeatedly failed 3 times and triggered the limit, will retry in 2 minutes
9136:M 13 Apr 2022 23:53:47.065 # Background AOF rewrite has repeatedly failed 3 times and triggered the limit, will retry in 4 minutes
9136:M 13 Apr 2022 23:57:47.070 # Background AOF rewrite has repeatedly failed 3 times and triggered the limit, will retry in 8 minutes
9136:M 14 Apr 2022 00:05:47.041 # Background AOF rewrite has repeatedly failed 3 times and triggered the limit, will retry in 16 minutes
```
I explain the problems of the log above:
1. Failed twice, but the log was printed "3 times"
2. When the grow percent is not reached, the limit time will continue to increase until it reaches 60 minutes
3. When my grow percent already needs to be rewritten, I have to wait for this time limit to arrive, which may take 60 minutes
4. There are some unclear places in the code， when the log records "will retry in xx minutes", the actual return value may be 'no limit'

I optimized this function and where it is called to fix this problems