### PR TITLE
Added test to verify loading Lua binary payload is not possible

### DIFF
--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -735,6 +735,12 @@ start_server {tags {"scripting"}} {
             return redis.acl_check_cmd('invalid-cmd','arg')
         } 0}
     }
+
+    test "Binary code loading failed" {
+        assert_error {ERR *attempt to call a nil value*} {run_script {
+            return loadstring(string.dump(function() return 1 end))()
+        } 0}
+    }
 }
 
 # Start a new server since the last test in this stanza will kill the


### PR DESCRIPTION
The tests verify that loading a binary payload to the Lua interpreter raises an error.
The Lua code modification was done here:  fdf9d455098f54f7666c702ae464e6ea21e25411
https://github.com/redis/redis/blob/effa707e9db3e9d00fff06d45e2a5a81d3d55fa9/deps/lua/src/ldo.c#L498
which force the Lua interpreter to always use the text parser.

- [x] fix test according to the changes here https://github.com/redis/redis/pull/10575 after it will be merged.