### PR TITLE
Forbid replicaof myself

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -2676,6 +2676,8 @@ void clearFailoverState(void);
 void updateFailoverStatus(void);
 void abortFailover(const char *err);
 const char *getFailoverStateString();
+dict *getLocalIPAddrs(void);
+dict *getRemoteIPAddrs(const char *addr);
 
 /* Generic persistence functions */
 void startLoadingFile(size_t size, char* filename, int rdbflags);
@@ -3522,6 +3524,7 @@ void killIOThreads(void);
 void killThreads(void);
 void makeThreadKillable(void);
 void swapMainDbWithTempDb(redisDb *tempDb);
+int replicaofMyself(const char *addr, int port);
 
 /* Use macro for checking log level to avoid evaluating arguments in cases log
  * should be ignored due to low level. */


### PR DESCRIPTION
# Describe
Currently, redis can perform `replicaof` to myself, and the reply message is `OK`, but in fact, redis cannot perform replication.

**Examples：**
1. replicaof myself：
```bash
bugwz@local $ redis-cli -p 5553 slaveof 127.0.0.1 5553
OK
```
2. redis logs：
```bash
36511:S 17 Apr 2022 02:06:24.591 * Connecting to MASTER 127.0.0.1:5553
36511:S 17 Apr 2022 02:06:24.591 * MASTER <-> REPLICA sync started
36511:S 17 Apr 2022 02:06:24.591 * REPLICAOF 127.0.0.1:5553 enabled (user request from 'id=3 addr=127.0.0.1:55177 laddr=127.0.0.1:5553 fd=8 name= age=0 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=42 qbuf-free=16848 argv-mem=20 multi-mem=0 rbs=16384 rbp=16384 obl=0 oll=0 omem=0 tot-mem=34044 events=r cmd=slaveof user=default redir=-1 resp=2')
36511:S 17 Apr 2022 02:06:24.591 * Non blocking connect for SYNC fired the event.
36511:S 17 Apr 2022 02:06:24.592 * Master replied to PING, replication can continue...
36511:S 17 Apr 2022 02:06:24.592 * Trying a partial resynchronization (request a89c27304a84b7d36b8884334117a6256e7ca97e:1).
36511:S 17 Apr 2022 02:06:24.592 * Master is currently unable to PSYNC but should be in the future: -NOMASTERLINK Can't SYNC while not connected with my master
```

# Thinking
I don't think redis should allow synchronization operations on itself, so I want to limit the following scenarios. The address of the master may be in the following situations:
+ ip address（eg. 127.0.0.1）
+ domain address（eg. local.redis.com）
+ vip address

Therefore, I try to restrict the execution of `replicaof myself` by comparing the ip addresses of the local and the expected master address. But it doesn't seem to work for the `vip address`. I have no idea how to restrict vip for the time being.
