### PR TITLE
Fix long long to double implicit conversion warning

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -571,7 +571,7 @@ int double2ll(double d, long long *out) {
      * i.e. all double values in that range are representable as a long without precision loss,
      * but not all long values in that range can be represented as a double.
      * we only care about the first part here. */
-    if (d < -LLONG_MAX/2 || d > LLONG_MAX/2)
+    if (d < (double)(-LLONG_MAX/2) || d > (double)(LLONG_MAX/2))
         return 0;
     long long ll = d;
     if (ll == d) {


### PR DESCRIPTION
There is a implicit conversion warning in clang:
```
util.c:574:23: error: implicit conversion from 'long long' to 'double'
changes value from -4611686018427387903 to -4611686018427387904
[-Werror,-Wimplicit-const-int-float-conversion]
    if (d < -LLONG_MAX/2 || d > LLONG_MAX/2)
```

introduced in #10486