### PR TITLE
Fix use after free (crash), on config rewrite (for 7.0-rc3)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1848,7 +1848,7 @@ static sds sdsConfigGet(standardConfig *config) {
 static void sdsConfigRewrite(standardConfig *config, const char *name, struct rewriteConfigState *state) {
     sds val = config->flags & MODULE_CONFIG ? getModuleStringConfig(config->privdata) : *config->data.sds.config;
     rewriteConfigSdsOption(state, name, val, config->data.sds.default_value);
-    if (val) sdsfree(val);
+    if ((val) && (config->flags & MODULE_CONFIG)) sdsfree(val);
 }
 
 


### PR DESCRIPTION
Fixing sdsConfigRewrite() which wrongly frees config->data.sds.config.
Affects config rewrite of masterauth and requirepass

Following bda9d74da, at function `sdsConfigRewrite()`, if reached  as non-module
configuration, then `*config->data.sds.config` is referenced (with `val`) and get
deleted at the end of the function as if it is temporary variable. Later on, accessing
this parameter can cause various issues, such as file configuration corruption, crash,
and so on.