### PR TITLE
Return 0 when config set out-of-range oom-score-adj-values

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2641,7 +2641,7 @@ static int setConfigOOMScoreAdjValuesOption(standardConfig *config, sds *argv, i
 
         if (*eptr != '\0' || val < -2000 || val > 2000) {
             if (err) *err = "Invalid oom-score-adj-values, elements must be between -2000 and 2000.";
-            return -1;
+            return 0;
         }
 
         values[i] = val;

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -122,5 +122,10 @@ if {$system_name eq {linux}} {
             r config set oom-score-adj absolute
             assert_equal [get_oom_score_adj] $custom_oom
         }
+
+        test {CONFIG SET out-of-range oom score} {
+            assert_error {ERR *must be between -2000 and 2000*} {r config set oom-score-adj-values "-2001 -2001 -2001"} 
+            assert_error {ERR *must be between -2000 and 2000*} {r config set oom-score-adj-values "2001 2001 2001"} 
+        }
     }
 }


### PR DESCRIPTION
When `oom-score-adj-values` is out of range, `setConfigOOMScoreAdjValuesOption` should return 0, not -1, otherwise it will be considered as success.

Before this PR:
```sh
127.0.0.1:6379> config set oom-score-adj-values "2001 2001 2001"
OK

127.0.0.1:6379> config set oom-score-adj-values "-2001 -2001 -2001"
OK
```

this PR:
```sh
127.0.0.1:6379> config set oom-score-adj-values "2001 2001 2001"
(error) ERR CONFIG SET failed (possibly related to argument 'oom-score-adj-values') - Invalid oom-score-adj-values, elements must be between -2000 and 2000.

127.0.0.1:6379> config set oom-score-adj-values "-2001 -2001 -2001"
(error) ERR CONFIG SET failed (possibly related to argument 'oom-score-adj-values') - Invalid oom-score-adj-values, elements must be between -2000 and 2000.
```
