### PR TITLE
isSafeToPerformEvictions: Remove redundant condition

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -492,10 +492,6 @@ static int isSafeToPerformEvictions(void) {
      * expires and evictions of keys not being performed. */
     if (checkClientPauseTimeoutAndReturnIfPaused()) return 0;
 
-    /* We cannot evict if we already have stuff to propagate (for example,
-     * CONFIG SET maxmemory inside a MULTI/EXEC) */
-    if (server.also_propagate.numops != 0) return 0;
-
     return 1;
 }
 


### PR DESCRIPTION
If was first added in #9890 to solve the problem of
CONFIG SET maxmemory causing eviction inside MULTI/EXEC,
but that problem is already fixed (CONFIG SET doesn't evict
directly, it just schedules a later eviction)

Keep that condition may hide bugs (i.e. performEvictions
should always expect to have an empty server.also_propagate)