### PR TITLE
Test: RM_Call from within "expired" notification

### DIFF
--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -79,6 +79,17 @@ static int KeySpace_NotificationGeneric(RedisModuleCtx *ctx, int type, const cha
     return REDISMODULE_OK;
 }
 
+static int KeySpace_NotificationExpired(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
+    REDISMODULE_NOT_USED(type);
+    REDISMODULE_NOT_USED(event);
+    REDISMODULE_NOT_USED(key);
+
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, "INCR", "c!", "testkeyspace:expired");
+    RedisModule_FreeCallReply(rep);
+
+    return REDISMODULE_OK;
+}
+
 static int KeySpace_NotificationModule(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
     REDISMODULE_NOT_USED(ctx);
     REDISMODULE_NOT_USED(type);
@@ -230,6 +241,10 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     }
 
     if(RedisModule_SubscribeToKeyspaceEvents(ctx, REDISMODULE_NOTIFY_GENERIC, KeySpace_NotificationGeneric) != REDISMODULE_OK){
+        return REDISMODULE_ERR;
+    }
+
+    if(RedisModule_SubscribeToKeyspaceEvents(ctx, REDISMODULE_NOTIFY_EXPIRED, KeySpace_NotificationExpired) != REDISMODULE_OK){
         return REDISMODULE_ERR;
     }
 

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -85,8 +85,8 @@ tags "modules" {
 
         test {Test expired key space event} {
             set prev_expired [s expired_keys]
-            r set exp 1 PX 300
-            wait_for_condition 100 800 {
+            r set exp 1 PX 10
+            wait_for_condition 10 10 {
                 [s expired_keys] eq $prev_expired + 1
             } else {
                 fail "key not expired"

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -86,7 +86,7 @@ tags "modules" {
         test {Test expired key space event} {
             set prev_expired [s expired_keys]
             r set exp 1 PX 10
-            wait_for_condition 10 10 {
+            wait_for_condition 100 10 {
                 [s expired_keys] eq $prev_expired + 1
             } else {
                 fail "key not expired"

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -83,6 +83,17 @@ tags "modules" {
             $rd1 close
         }
 
+        test {Test expired key space event} {
+            set prev_expired [s expired_keys]
+            r set exp 1 PX 300
+            wait_for_condition 100 800 {
+                [s expired_keys] eq $prev_expired + 1
+            } else {
+                fail "key not expired"
+            }
+            assert_equal [r get testkeyspace:expired] 1
+        }
+
         test "Unload the module - testkeyspace" {
             assert_equal {OK} [r module unload testkeyspace]
         }

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -108,10 +108,16 @@ tags "modules" {
                         {set asdf3 3 PXAT *}
                         {exec}
                         {incr notifications}
+                        {incr notifications}
+                        {incr testkeyspace:expired}
                         {del asdf*}
                         {incr notifications}
+                        {incr notifications}
+                        {incr testkeyspace:expired}
                         {del asdf*}
                         {incr notifications}
+                        {incr notifications}
+                        {incr testkeyspace:expired}
                         {del asdf*}
                     }
                     close_replication_stream $repl


### PR DESCRIPTION
This case is interesting because it originates from cron,
rather than from another command.

The idea came from looking at https://github.com/redis/redis/pull/9890 and https://github.com/redis/redis/pull/10573, and I was wondering if RM_Call would work properly when `server.current_client == NULL`