### PR TITLE
Fix timing issue in slowlog redact test

### DIFF
--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -59,11 +59,11 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         # Make sure normal configs work, but the two sensitive
         # commands are omitted or redacted
         assert_equal 5 [llength $slowlog_resp]
-        assert_equal {slowlog reset} [lindex [lindex [r slowlog get] 4] 3]
-        assert_equal {acl setuser (redacted) (redacted) (redacted)} [lindex [lindex [r slowlog get] 3] 3]
-        assert_equal {config set masterauth (redacted)} [lindex [lindex [r slowlog get] 2] 3]
-        assert_equal {acl setuser (redacted) (redacted) (redacted)} [lindex [lindex [r slowlog get] 1] 3]
-        assert_equal {config set slowlog-log-slower-than 0} [lindex [lindex [r slowlog get] 0] 3]
+        assert_equal {slowlog reset} [lindex [lindex $slowlog_resp 4] 3]
+        assert_equal {acl setuser (redacted) (redacted) (redacted)} [lindex [lindex $slowlog_resp 3] 3]
+        assert_equal {config set masterauth (redacted)} [lindex [lindex $slowlog_resp 2] 3]
+        assert_equal {acl setuser (redacted) (redacted) (redacted)} [lindex [lindex $slowlog_resp 1] 3]
+        assert_equal {config set slowlog-log-slower-than 0} [lindex [lindex $slowlog_resp 0] 3]
     } {} {needs:repl}
 
     test {SLOWLOG - Some commands can redact sensitive fields} {
@@ -72,13 +72,14 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         r migrate [srv 0 host] [srv 0 port] key 9 5000
         r migrate [srv 0 host] [srv 0 port] key 9 5000 AUTH user
         r migrate [srv 0 host] [srv 0 port] key 9 5000 AUTH2 user password
-
         r config set slowlog-log-slower-than -1
+        set slowlog_resp [r slowlog get]
+
         # Make sure all 3 commands were logged, but the sensitive fields are omitted
-        assert_equal 4 [llength [r slowlog get]]
-        assert_match {* key 9 5000} [lindex [lindex [r slowlog get] 2] 3]
-        assert_match {* key 9 5000 AUTH (redacted)} [lindex [lindex [r slowlog get] 1] 3]
-        assert_match {* key 9 5000 AUTH2 (redacted) (redacted)} [lindex [lindex [r slowlog get] 0] 3]
+        assert_equal 4 [llength $slowlog_resp]
+        assert_match {* key 9 5000} [lindex [lindex $slowlog_resp 2] 3]
+        assert_match {* key 9 5000 AUTH (redacted)} [lindex [lindex $slowlog_resp 1] 3]
+        assert_match {* key 9 5000 AUTH2 (redacted) (redacted)} [lindex [lindex $slowlog_resp 0] 3]
     } {} {needs:repl}
 
     test {SLOWLOG - Rewritten commands are logged as their original command} {

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -53,7 +53,7 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         r config set masterauth ""
         r acl setuser slowlog-test-user +get +set
         r config set slowlog-log-slower-than 0
-        r config set slowlog-log-slower-than 10000
+        r config set slowlog-log-slower-than -1
         set slowlog_resp [r slowlog get]
 
         # Make sure normal configs work, but the two sensitive
@@ -73,7 +73,7 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         r migrate [srv 0 host] [srv 0 port] key 9 5000 AUTH user
         r migrate [srv 0 host] [srv 0 port] key 9 5000 AUTH2 user password
 
-        r config set slowlog-log-slower-than 10000
+        r config set slowlog-log-slower-than -1
         # Make sure all 3 commands were logged, but the sensitive fields are omitted
         assert_equal 4 [llength [r slowlog get]]
         assert_match {* key 9 5000} [lindex [lindex [r slowlog get] 2] 3]


### PR DESCRIPTION
This test failed once in my daily CI (test-sanitizer-address (clang))
```
*** [err]: SLOWLOG - Some commands can redact sensitive fields in tests/unit/slowlog.tcl
Expected 'migrate 127.0.0.1 25649 key 9 5000 AUTH2 (redacted) (redacted)' to match '* key 9 5000 AUTH (redacted)' (context: type eval line 12 cmd {assert_match {* key 9 5000 AUTH (redacted)} [lindex [lindex [r slowlog get] 1] 3]} proc ::test)
```

The reason is that with slowlog-log-slower-than 10000,
slowlog get will have a chance to exceed 10ms.

Change slowlog-log-slower-than from 10000 to -1, distable it.
Avoid repeated calls to `SLOWLOG GET`, assert to use the previous execution result.

Also handles a same potentially problematic test above.
This is actually the same timing issue as #10432.