### PR TITLE
Fix bug when AOF enabled after startup. put the new incr file in the manifest only when AOFRW is done.

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -87,7 +87,7 @@ void aofManifestFreeAndUpdate(aofManifest *am);
 #define RDB_FORMAT_SUFFIX          ".rdb"
 #define AOF_FORMAT_SUFFIX          ".aof"
 #define MANIFEST_NAME_SUFFIX       ".manifest"
-#define TEMP_FILE_NAME_PREFIX      "temp_"
+#define TEMP_FILE_NAME_PREFIX      "temp-"
 
 /* AOF manifest key. */
 #define AOF_MANIFEST_KEY_FILE_NAME   "file"

--- a/src/aof.c
+++ b/src/aof.c
@@ -792,9 +792,9 @@ int openNewIncrAofForAppend(void) {
     return C_OK;
 }
 
-/* Called in `rewriteAppendOnlyFileBackground` to open a new temp INCR AOF in 
- * AOF_WAIT_REWRITE state, the AOF information will not appear in server.aof_manifest 
- * and will not be persisted to disk.
+/* Called in `rewriteAppendOnlyFileBackground` to open a new temp INCR AOF when in 
+ * AOF_WAIT_REWRITE state, the AOF information will not be added to server.aof_manifest 
+ * and persisted to manifest file.
  * */
 int openNewTempIncrAofForAppend() {
     serverAssert(server.aof_manifest != NULL);
@@ -2548,9 +2548,9 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
         serverAssert(new_base_filename != NULL);
         sds new_base_filepath = makePath(server.aof_dirname, new_base_filename);
 
-        /* Because in the AOF_WAIT_REWRITE state, the newly opened INCR AOF information 
-         * will not be added to server.aof_manifest, so we use getNewIncrAofName to add 
-         * it to temp_am which will be persisted to the manifest file in the subsequent process. */
+        /* Newly opened INCR AOF information will not be added to server.aof_manifest 
+         * when in AOF_WAIT_REWRITE state, so we use getNewIncrAofName to add it to 
+         * temp_am which will be persisted to the manifest file in the subsequent process. */
         if (server.aof_state == AOF_WAIT_REWRITE) getNewIncrAofName(temp_am);
         
         /* Rename the temporary aof file to 'new_base_filename'. */

--- a/src/aof.c
+++ b/src/aof.c
@@ -759,10 +759,9 @@ int aofFileExist(char *filename) {
  * any step fails, the entire operation will rollback and returns
  * C_ERR, and if all succeeds, it returns C_OK.
  * 
- * If `server.aof_state` is 'AOF_WAIT_REWRITE', it will only open the 
- * INCR AOF but not write it to the manifest file. When AOFRW is 
- * successful, the INCR AOF and the newly generated BASE AOF will 
- * be written into the manifest together.
+ * If `server.aof_state` is 'AOF_WAIT_REWRITE', It will open a temporary INCR AOF 
+ * file to accumulate data during AOF_WAIT_REWRITE, and it will eventually be 
+ * renamed in the backgroundRewriteDoneHandler and written to the manifest file.
  * */
 int openNewIncrAofForAppend(void) {
     serverAssert(server.aof_manifest != NULL);
@@ -817,10 +816,11 @@ int openNewIncrAofForAppend(void) {
 
 cleanup:
     if (newfd != -1) close(newfd);
-    if (temp_am) 
+    if (temp_am) {
         aofManifestFree(temp_am);
-    else
+    } else {
         sdsfree(new_aof_name);
+    }
     return C_ERR;
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -579,7 +579,7 @@ NULL
         aofLoadManifestFromDisk();
         aofDelHistoryFiles();
         int ret = loadAppendOnlyFiles(server.aof_manifest);
-        if (ret != AOF_OK && ret != AOF_EMPTY && ret != AOF_NOT_EXIST)
+        if (ret != AOF_OK && ret != AOF_EMPTY)
             exit(1);
         unprotectClient(c);
         server.dirty = 0; /* Prevent AOF / replication */

--- a/src/debug.c
+++ b/src/debug.c
@@ -579,7 +579,7 @@ NULL
         aofLoadManifestFromDisk();
         aofDelHistoryFiles();
         int ret = loadAppendOnlyFiles(server.aof_manifest);
-        if (ret != AOF_OK && ret != AOF_EMPTY)
+        if (ret != AOF_OK && ret != AOF_EMPTY && ret != AOF_NOT_EXIST)
             exit(1);
         unprotectClient(c);
         server.dirty = 0; /* Prevent AOF / replication */

--- a/src/server.c
+++ b/src/server.c
@@ -1325,8 +1325,11 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
      * however to try every second is enough in case of 'hz' is set to
      * a higher frequency. */
     run_with_period(1000) {
-        if (server.aof_state == AOF_ON && server.aof_last_write_status == C_ERR)
-            flushAppendOnlyFile(0);
+        if ((server.aof_state == AOF_ON || server.aof_state == AOF_WAIT_REWRITE) &&
+            server.aof_last_write_status == C_ERR) 
+            {
+                flushAppendOnlyFile(0);
+            }
     }
 
     /* Clear the paused clients state if needed. */

--- a/src/server.c
+++ b/src/server.c
@@ -2348,6 +2348,7 @@ void resetServerStats(void) {
     }
     server.stat_aof_rewrites = 0;
     server.stat_rdb_saves = 0;
+    server.stat_aofrw_consecutive_failures = 0;
     atomicSet(server.stat_net_input_bytes, 0);
     atomicSet(server.stat_net_output_bytes, 0);
     server.stat_unexpected_error_replies = 0;
@@ -5403,6 +5404,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "aof_current_rewrite_time_sec:%jd\r\n"
             "aof_last_bgrewrite_status:%s\r\n"
             "aof_rewrites:%lld\r\n"
+            "aof_rewrites_consecutive_failures:%lld\r\n"
             "aof_last_write_status:%s\r\n"
             "aof_last_cow_size:%zu\r\n"
             "module_fork_in_progress:%d\r\n"
@@ -5434,6 +5436,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                 -1 : time(NULL)-server.aof_rewrite_time_start),
             (server.aof_lastbgrewrite_status == C_OK) ? "ok" : "err",
             server.stat_aof_rewrites,
+            server.stat_aofrw_consecutive_failures,
             (server.aof_last_write_status == C_OK &&
                 aof_bio_fsync_status == C_OK) ? "ok" : "err",
             server.stat_aof_cow_bytes,

--- a/src/server.h
+++ b/src/server.h
@@ -1401,7 +1401,6 @@ typedef struct {
     list        *history_aof_list;    /* HISTORY AOF list. When the AOFRW success, The aofInfo contained in
                                          `base_aof_info` and `incr_aof_list` will be moved to this list. We
                                          will delete these AOF files when AOFRW finish. */
-    aofInfo     *tmp_incr_aof_info;   /* Temp INCR file info(Used to accumulate data in AOF_WAIT_REWRITE state). */
     long long   curr_base_file_seq;   /* The sequence number used by the current BASE file. */
     long long   curr_incr_file_seq;   /* The sequence number used by the current INCR file. */
     int         dirty;                /* 1 Indicates that the aofManifest in the memory is inconsistent with

--- a/src/server.h
+++ b/src/server.h
@@ -1556,6 +1556,7 @@ struct redisServer {
     monotime stat_last_active_defrag_time; /* Timestamp of current active defrag start */
     size_t stat_peak_memory;        /* Max used memory record */
     long long stat_aof_rewrites;    /* number of aof file rewrites performed */
+    long long stat_aofrw_consecutive_failures; /* The number of consecutive failures of aofrw */
     long long stat_rdb_saves;       /* number of rdb saves performed */
     long long stat_fork_time;       /* Time needed to perform latest fork() */
     double stat_fork_rate;          /* Fork rate in GB/sec. */

--- a/src/server.h
+++ b/src/server.h
@@ -1401,6 +1401,7 @@ typedef struct {
     list        *history_aof_list;    /* HISTORY AOF list. When the AOFRW success, The aofInfo contained in
                                          `base_aof_info` and `incr_aof_list` will be moved to this list. We
                                          will delete these AOF files when AOFRW finish. */
+    aofInfo     *tmp_incr_aof_info;   /* Temp INCR file info(Used to accumulate data in AOF_WAIT_REWRITE state). */
     long long   curr_base_file_seq;   /* The sequence number used by the current BASE file. */
     long long   curr_incr_file_seq;   /* The sequence number used by the current INCR file. */
     int         dirty;                /* 1 Indicates that the aofManifest in the memory is inconsistent with

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -1280,6 +1280,13 @@ tags {"external:skip"} {
                     {file appendonly.aof.1.incr.aof seq 1 type i}
                 }
 
+                # Make sure the next AOFRW has started
+                wait_for_condition 1000 50 {
+                    [s aof_rewrite_in_progress] == 1
+                } else {
+                    fail "aof rewrite did not scheduled"
+                }
+
                 # Do a successful AOFRW
                 set total_forks [s total_forks]
                 r config set rdb-key-save-delay 0

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -1104,7 +1104,11 @@ tags {"external:skip"} {
             # Set a key so that AOFRW can be delayed
             r set k v
 
-            # Let AOFRW fail two times, this will trigger AOFRW limit
+            # Let AOFRW fail 3 times, this will trigger AOFRW limit
+            r bgrewriteaof
+            catch {exec kill -9 [get_child_pid 0]}
+            waitForBgrewriteaof r
+
             r bgrewriteaof
             catch {exec kill -9 [get_child_pid 0]}
             waitForBgrewriteaof r
@@ -1118,6 +1122,7 @@ tags {"external:skip"} {
                 {file appendonly.aof.6.incr.aof seq 6 type i}
                 {file appendonly.aof.7.incr.aof seq 7 type i}
                 {file appendonly.aof.8.incr.aof seq 8 type i}
+                {file appendonly.aof.9.incr.aof seq 9 type i}
             }
             
             # Write 1KB data to trigger AOFRW
@@ -1137,6 +1142,7 @@ tags {"external:skip"} {
                 {file appendonly.aof.6.incr.aof seq 6 type i}
                 {file appendonly.aof.7.incr.aof seq 7 type i}
                 {file appendonly.aof.8.incr.aof seq 8 type i}
+                {file appendonly.aof.9.incr.aof seq 9 type i}
             }
 
             # Turn off auto rewrite
@@ -1154,11 +1160,11 @@ tags {"external:skip"} {
             waitForBgrewriteaof r
 
             # Can create New INCR AOF
-            assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.9${::incr_aof_sufix}${::aof_format_suffix}"]
+            assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.10${::incr_aof_sufix}${::aof_format_suffix}"]
 
             assert_aof_manifest_content $aof_manifest_file {
                 {file appendonly.aof.11.base.rdb seq 11 type b}
-                {file appendonly.aof.9.incr.aof seq 9 type i}
+                {file appendonly.aof.10.incr.aof seq 10 type i}
             }
 
             set d1 [r debug digest]

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -1198,7 +1198,7 @@ tags {"external:skip"} {
                 # Make sure AOFRW was scheduled 3 times
                 set total_forks [s total_forks]
                 set maxtries 1000
-                set delay 10
+                set delay 100
                 while {[incr maxtries -1] >= 0} {
                     if {[s total_forks] == [expr $total_forks + 3]} {
                         break
@@ -1266,7 +1266,7 @@ tags {"external:skip"} {
                 # Make sure AOFRW was scheduled 3 times
                 set total_forks [s total_forks]
                 set maxtries 1000
-                set delay 10
+                set delay 100
                 while {[incr maxtries -1] >= 0} {
                     if {[s total_forks] == [expr $total_forks + 3]} {
                         break

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -1256,11 +1256,11 @@ tags {"external:skip"} {
                 set d2 [r debug digest]
                 assert {$d1 eq $d2}
 
-                set dbsize [r dbsize]
+                assert_equal 0 [s rdb_changes_since_last_save]
                 r config set rdb-key-save-delay 10000000
                 set load_handle0 [start_write_load $master_host $master_port 10]
                 wait_for_condition 50 100 {
-                    [r dbsize] > $dbsize
+                    [s rdb_changes_since_last_save] > 0
                 } else {
                     fail "No write load detected."
                 }

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -1256,8 +1256,14 @@ tags {"external:skip"} {
                 set d2 [r debug digest]
                 assert {$d1 eq $d2}
 
+                set dbsize [r dbsize]
                 r config set rdb-key-save-delay 10000000
                 set load_handle0 [start_write_load $master_host $master_port 10]
+                wait_for_condition 50 100 {
+                    [r dbsize] > $dbsize
+                } else {
+                    fail "No write load detected."
+                }
 
                 # Re-enable AOF
                 r config set appendonly yes

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -1166,5 +1166,138 @@ tags {"external:skip"} {
             set d2 [r debug digest]
             assert {$d1 eq $d2}
         }
+
+        test "AOF will not open incr file until the first AOFRW success when AOF is dynamically enabled" {
+            # Clear all data and delete appenddir to get an empty redis
+            r flushall
+            r config set appendonly no
+            catch {exec rm -rf $aof_dirpath}
+            r debug loadaof
+
+            assert_equal 0 [r dbsize]
+
+            # Increase AOFRW execution time to give us enough time to kill it
+            r config set rdb-key-save-delay 10000000
+
+            # Start write load
+            set load_handle0 [start_write_load $master_host $master_port 10]
+
+            wait_for_condition 50 100 {
+                [r dbsize] > 0
+            } else {
+                fail "No write load detected."
+            }
+
+            r config set appendonly yes
+            
+            # Make sure AOFRW was scheduled 5 times
+            set total_forks [s total_forks]
+            set maxtries 1000
+            set delay 10
+            while {[incr maxtries -1] >= 0} {
+                if {[s total_forks] == [expr $total_forks + 5]} {
+                    break
+                }
+                catch {exec kill -9 [get_child_pid 0]}
+                after $delay
+            }
+            if {$maxtries == -1} {
+                fail "aof rewrite did not scheduled 5 times"
+            }
+           
+            # Make sure manifest file is not created
+            assert_equal 0 [check_file_exist $aof_dirpath $aof_manifest_name]
+            # Make sure BASE AOF is not created
+            assert_equal 0 [check_file_exist $aof_dirpath "${aof_basename}.1${::base_aof_sufix}${::rdb_format_suffix}"]
+            # Make sure temp INCR AOF is created
+            assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.1${::incr_aof_sufix}${::aof_format_suffix}"]
+
+            # Do a successful AOFRW
+            set total_forks [s total_forks]
+            r config set rdb-key-save-delay 0
+            catch {exec kill -9 [get_child_pid 0]}
+            
+            wait_for_condition 1000 10 {
+                [s total_forks] == [expr $total_forks + 1]
+            } else {
+                fail "aof rewrite did not scheduled"
+            }
+            waitForBgrewriteaof r
+
+            # BASE and INCR AOF are successfully created
+            assert_aof_manifest_content $aof_manifest_file {
+                {file appendonly.aof.1.base.rdb seq 1 type b}
+                {file appendonly.aof.1.incr.aof seq 1 type i}
+            }
+
+            stop_write_load $load_handle0
+            wait_load_handlers_disconnected
+
+            set d1 [r debug digest]
+            r debug loadaof
+            set d2 [r debug digest]
+            assert {$d1 eq $d2}
+
+            # Dynamic disable AOF again
+            r config set appendonly no
+
+            # Disabling AOF does not delete previous AOF files
+            r debug loadaof
+            set d2 [r debug digest]
+            assert {$d1 eq $d2}
+
+            r config set rdb-key-save-delay 10000000
+            set load_handle0 [start_write_load $master_host $master_port 10]
+
+            # Re-enable AOF
+            r config set appendonly yes
+
+            # Make sure AOFRW was scheduled 5 times
+            set total_forks [s total_forks]
+            set maxtries 1000
+            set delay 10
+            while {[incr maxtries -1] >= 0} {
+                if {[s total_forks] == [expr $total_forks + 5]} {
+                    break
+                }
+                catch {exec kill -9 [get_child_pid 0]}
+                after $delay
+            }
+            if {$maxtries == -1} {
+                fail "aof rewrite did not scheduled 5 times"
+            }
+
+            # Make sure no new incr AOF was created           
+            assert_aof_manifest_content $aof_manifest_file {
+                {file appendonly.aof.1.base.rdb seq 1 type b}
+                {file appendonly.aof.1.incr.aof seq 1 type i}
+            }
+
+            # Do a successful AOFRW
+            set total_forks [s total_forks]
+            r config set rdb-key-save-delay 0
+            catch {exec kill -9 [get_child_pid 0]}
+            
+            wait_for_condition 1000 10 {
+                [s total_forks] == [expr $total_forks + 1]
+            } else {
+                fail "aof rewrite did not scheduled"
+            }
+            waitForBgrewriteaof r
+
+            # New BASE and INCR AOF are successfully created
+            assert_aof_manifest_content $aof_manifest_file {
+                {file appendonly.aof.2.base.rdb seq 2 type b}
+                {file appendonly.aof.2.incr.aof seq 2 type i}
+            }
+
+            stop_write_load $load_handle0
+            wait_load_handlers_disconnected
+
+            set d1 [r debug digest]
+            r debug loadaof
+            set d2 [r debug digest]
+            assert {$d1 eq $d2}
+        }
     }
 }


### PR DESCRIPTION
Changes:

- When AOF is enabled **after** startup, the data accumulated during `AOF_WAIT_REWRITE` will only be stored in a temp INCR AOF file. Only after the first AOFRW is successful, we will add it to manifest file.
  Before this fix, the manifest referred to the temp file which could cause a restart during that time to load it without it's base.
- Add `aof_rewrites_consecutive_failures` info field for  aofrw limiting implementation.

Now we can guarantee that these behaviors of MP-AOF are the same as before (past redis releases):
- When AOF is enabled after startup, the data accumulated during `AOF_WAIT_REWRITE` will only be stored in a visible place. Only after the first AOFRW is successful, we will add it to manifest file.
- When disable AOF, we did not delete the AOF file in the past so there's no need to change that behavior now (yet).
- When toggling AOF off and then on (could be as part of a full-sync), a crash or restart before the first rewrite is completed, would result with the previous version being loaded (might not be right thing, but that's what we always had).

<s>
One issues:
- `aofRewriteLimited` will not work for AOFRW triggered by enabling AOF after startup (because we won't have many INCR AOFs in this scenario). I think we should no longer judge the AOFRW failures based on the current number of INCR AOFs, but directly based on `aof_lastbgrewrite_status`. But I feel this is best fixed in a separate PR. 
</s>
More discussion: https://github.com/redis/redis/pull/10582#discussion_r853772495