### PR TITLE
fix typo in "lcsCommand"

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -792,7 +792,7 @@ void lcsCommand(client *c) {
 
     /* Setup an uint32_t array to store at LCS[i,j] the length of the
      * LCS A0..i-1, B0..j-1. Note that we have a linear array here, so
-     * we index it as LCS[j+(blen+1)*j] */
+     * we index it as LCS[j+(blen+1)*i] */
     #define LCS(A,B) lcs[(B)+((A)*(blen+1))]
 
     /* Try to allocate the LCS table, and abort on overflow or insufficient memory. */


### PR DESCRIPTION
fix typo. `LCS[j+(blen+1)*j]` -> `LCS[j+(blen+1)*i]`