### PR TITLE
redis-cli: display the start time in latency-history mode

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7464,11 +7464,16 @@ static void latencyMode(void) {
 
         if (config.latency_history && mstime()-history_start > history_interval)
         {
-            printf(" -- %.2f seconds range\n", (float)(mstime()-history_start)/1000);
+            char buf[64];
+            time_t hs = (time_t)(history_start / 1000);
+            struct tm *t = localtime(&hs);
+            strftime(buf,sizeof(buf),"%d %b %Y %H:%M:%S", t);
+            printf(" -- %.2f seconds range, start at %s\n", (float)(mstime()-history_start)/1000, buf);
             history_start = mstime();
             min = max = tot = count = 0;
+        }else {
+            usleep(LATENCY_SAMPLE_RATE * 1000);
         }
-        usleep(LATENCY_SAMPLE_RATE * 1000);
     }
 }
 


### PR DESCRIPTION
changes:
* Print the start time infomation in latency-history mode,  which is convenient to cooperate with monitoring information such as zabbix and promes
* When a new  history-interval cycle begins, we no need to sleep 10ms

Results：
```bash
 ./redis-cli --latency-history -i 1
min: 0, max: 2, avg: 0.82 (91 samples) -- 1.01 seconds range, start at 24 Apr 2022 20:06:56
min: 0, max: 2, avg: 0.74 (90 samples) -- 1.00 seconds range, start at 24 Apr 2022 20:06:57
min: 0, max: 2, avg: 0.85 (89 samples) -- 1.00 seconds range, start at 24 Apr 2022 20:06:58
min: 0, max: 2, avg: 0.88 (90 samples) -- 1.01 seconds range, start at 24 Apr 2022 20:06:59
min: 0, max: 1, avg: 0.76 (90 samples) -- 1.01 seconds range, start at 24 Apr 2022 20:07:00
min: 0, max: 2, avg: 0.87 (90 samples) -- 1.01 seconds range, start at 24 Apr 2022 20:07:01
min: 0, max: 2, avg: 0.94 (88 samples) -- 1.00 seconds range, start at 24 Apr 2022 20:07:02
min: 0, max: 2, avg: 0.85 (89 samples) -- 1.00 seconds range, start at 24 Apr 2022 20:07:03
min: 0, max: 1, avg: 0.63 (91 samples) -- 1.01 seconds range, start at 24 Apr 2022 20:07:04
min: 0, max: 2, avg: 0.74 (91 samples) -- 1.01 seconds range, start at 24 Apr 2022 20:07:05
min: 0, max: 2, avg: 0.73 (90 samples) -- 1.00 seconds range, start at 24 Apr 2022 20:07:06
min: 0, max: 2, avg: 0.77 (92 samples) -- 1.01 seconds range, start at 24 Apr 2022 20:07:07
min: 0, max: 1, avg: 0.67 (91 samples) -- 1.00 seconds range, start at 24 Apr 2022 20:07:08
min: 0, max: 2, avg: 0.70 (90 samples) -- 1.00 seconds range, start at 24 Apr 2022 20:07:09
min: 0, max: 2, avg: 0.83 (89 samples) -- 1.00 seconds range, start at 24 Apr 2022 20:07:10
min: 0, max: 2, avg: 0.83 (90 samples) -- 1.01 seconds range, start at 24 Apr 2022 20:07:11
```