### PR TITLE
Run large-memory tests as solo.

### DIFF
--- a/tests/unit/bitops.tcl
+++ b/tests/unit/bitops.tcl
@@ -546,7 +546,10 @@ start_server {tags {"bitops"}} {
             }
         }
     }
+}
 
+run_solo {bitops-large-memory} {
+start_server {tags {"bitops"}} {
     test "BIT pos larger than UINT_MAX" {
         set bytes [expr (1 << 29) + 1]
         set bitpos [expr (1 << 32)]
@@ -587,3 +590,4 @@ start_server {tags {"bitops"}} {
         r del mykey
     } {1} {large-memory needs:debug}
 }
+} ;#run_solo

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -252,6 +252,7 @@ start_server [list overrides [list save ""] ] {
     } {} {needs:debug}
 }
 
+run_solo {list-large-memory} {
 start_server [list overrides [list save ""] ] {
 
 # test if the server supports such large configs (avoid 32 bit builds)
@@ -349,6 +350,7 @@ if {[lindex [r config get proto-max-bulk-len] 1] == 10000000000} {
    } {} {large-memory}
 } ;# skip 32bit builds
 }
+} ;# run_solo
 
 start_server {
     tags {"list"}

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -935,6 +935,7 @@ start_server {
     }
 }
 
+run_solo {set-large-memory} {
 start_server [list overrides [list save ""] ] {
 
 # test if the server supports such large configs (avoid 32 bit builds)
@@ -969,3 +970,4 @@ if {[lindex [r config get proto-max-bulk-len] 1] == 10000000000} {
     } {} {large-memory}
 } ;# skip 32bit builds
 }
+} ;# run_solo

--- a/tests/unit/violations.tcl
+++ b/tests/unit/violations.tcl
@@ -1,5 +1,6 @@
 # One XADD with one huge 5GB field
 # Expected to fail resulting in an empty stream
+run_solo {violations} {
 start_server [list overrides [list save ""] ] {
     test {XADD one huge field} {
         r config set proto-max-bulk-len 10000000000 ;#10gb
@@ -85,7 +86,7 @@ start_server [list overrides [list save ""] ] {
         r object encoding H1
     } {hashtable} {large-memory}
 }
-
+} ;# run_solo
 
 # SORT which stores an integer encoded element into a list.
 # Just for coverage, no news here.


### PR DESCRIPTION
This avoids random memory spikes and enables --large-memory tests to run
on moderately sized systems.