### PR TITLE
fix an unclear comment and add  a comment to 'zi' in 'quicklist.h'

### DIFF
--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -116,7 +116,7 @@ typedef struct quicklist {
 typedef struct quicklistIter {
     quicklist *quicklist;
     quicklistNode *current;
-    unsigned char *zi;
+    unsigned char *zi; /* points to the current element */
     long offset; /* offset in current listpack */
     int direction;
 } quicklistIter;
@@ -141,7 +141,7 @@ typedef struct quicklistEntry {
 /* quicklist compression disable */
 #define QUICKLIST_NOCOMPRESS 0
 
-/* quicklist container formats */
+/* quicklist node container formats */
 #define QUICKLIST_NODE_CONTAINER_PLAIN 1
 #define QUICKLIST_NODE_CONTAINER_PACKED 2
 


### PR DESCRIPTION
fix an unclear comment ` quicklist container formats ` to `quicklist node container formats`
Add a comment to 'zi' in `quicklistIter` (Where it first appeared)
Why do I add a comment to `zi`:
Because it is not a variable name with a clear meaning, and its name seems to be from the deprecated ziplist.