### PR TITLE
Fix two comment issues of set commands

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -805,7 +805,7 @@ void srandmemberWithCountCommand(client *c) {
     }
 }
 
-/* SRANDMEMBER [<count>] */
+/* SRANDMEMBER key [<count>] */
 void srandmemberCommand(client *c) {
     robj *set;
     sds ele;
@@ -850,7 +850,7 @@ int qsortCompareSetsByRevCardinality(const void *s1, const void *s2) {
     return 0;
 }
 
-/* SINTER / SINTERSTORE / SINTERCARD
+/* SINTER / SMEMBERS / SINTERSTORE / SINTERCARD
  *
  * 'cardinality_only' work for SINTERCARD, only return the cardinality
  * with minimum processing and memory overheads.


### PR DESCRIPTION
This PR fix the following minor issues before Redis 7 release:

SINTER and SMEMBERS call the same function sinterCommand and sinterGenericCommand, so add one more SMEMBERS in the 
sinterGenericCommand comment

Fix the missing "key" words in the srandmemberCommand function