### PR TITLE
Add clangd stuff to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ Makefile.dep
 .idea/*
 .ccls
 .ccls-cache/*
+.cache/*
 compile_commands.json
 redis.code-workspace


### PR DESCRIPTION
`$PROJECT/.cache/clangd/index` is the location for project index data from [clangd](https://clangd.llvm.org/).

It will generate a bunch of stuff like this.
<img width="387" alt="image" src="https://user-images.githubusercontent.com/55286565/165572472-12e4ee8c-3732-4033-b9f4-fa37599985a6.png">


Signed-off-by: cndoit18 <cndoit18@outlook.com>