### PR TITLE
redis-server command line arguments support take one bulk string with spaces for MULTI_ARG configs parsing. And allow options value to use the -- prefix

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -488,8 +488,9 @@ void loadServerConfigFromString(char *config) {
                 goto loaderr;
             }
 
-            if ((config->flags & MULTI_ARG_CONFIG) && argc == 2) {
+            if ((config->flags & MULTI_ARG_CONFIG) && argc == 2 && strcasecmp(argv[1], "")) {
                 /* For MULTI_ARG_CONFIGs, if we only have one argument, try to split it by spaces.
+                 * Only if the argument is not empty, otherwise something like --save "" will fail.
                  * So that we can support something like --config "arg1 arg2 arg3". */
                 sds *new_argv;
                 int new_argc;

--- a/src/config.c
+++ b/src/config.c
@@ -494,14 +494,12 @@ void loadServerConfigFromString(char *config) {
                 if (!config->interface.set(config, new_argv, new_argc, &err)) {
                     goto loaderr;
                 }
-                sdsfreesplitres(argv, argc);
                 sdsfreesplitres(new_argv, new_argc);
-                continue;
-            }
-
-            /* Set config using all arguments that follows */
-            if (!config->interface.set(config, &argv[1], argc-1, &err)) {
-                goto loaderr;
+            } else {
+                /* Set config using all arguments that follows */
+                if (!config->interface.set(config, &argv[1], argc-1, &err)) {
+                    goto loaderr;
+                }
             }
 
             sdsfreesplitres(argv,argc);

--- a/src/config.c
+++ b/src/config.c
@@ -485,26 +485,18 @@ void loadServerConfigFromString(char *config) {
                 goto loaderr;
             }
 
-            if (config->flags & MULTI_ARG_CONFIG) {
-                if (argc == 1 && !(config->flags & ALLOW_EMPTY_ARG_CONFIG)) {
-                    /* For MULTI_ARG_CONFIGs, we need to consume at least one argument.
-                     * Except for ALLOW_EMPTY_ARG which can accept empty parameters, like save "". */
-                    err = "wrong number of arguments";
+            if ((config->flags & MULTI_ARG_CONFIG) && argc == 2) {
+                /* For MULTI_ARG_CONFIGs, if we only have one argument, try to split it by spaces.
+                 * So that we can support something like --config "arg1 arg2 arg3". */
+                sds *new_argv;
+                int new_argc;
+                new_argv = sdssplitargs(argv[1], &new_argc);
+                if (!config->interface.set(config, new_argv, new_argc, &err)) {
                     goto loaderr;
-                } else if (argc == 2) {
-                    /* For MULTI_ARG_CONFIGs, if we only have one argument, try to split it by spaces.
-                     * So that we can support something like --config "arg1 arg2 arg3". */
-                    sds *new_argv;
-                    int new_argc;
-                    new_argv = sdssplitargs(argv[1], &new_argc);
-                    if (!config->interface.set(config, &new_argv[0], new_argc, &err)) {
-                        goto loaderr;
-                    }
-                    sdsfreesplitres(argv, argc);
-                    sdsfreesplitres(new_argv, new_argc);
-                    continue;
                 }
-                /* In other cases, like --config arg1 arg2 arg3, enter the following `interface.set`. */
+                sdsfreesplitres(argv, argc);
+                sdsfreesplitres(new_argv, new_argc);
+                continue;
             }
 
             /* Set config using all arguments that follows */
@@ -3117,13 +3109,13 @@ standardConfig static_configs[] = {
 
     /* Special configs */
     createSpecialConfig("dir", NULL, MODIFIABLE_CONFIG | PROTECTED_CONFIG | DENY_LOADING_CONFIG, setConfigDirOption, getConfigDirOption, rewriteConfigDirOption, NULL),
-    createSpecialConfig("save", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG | ALLOW_EMPTY_ARG_CONFIG, setConfigSaveOption, getConfigSaveOption, rewriteConfigSaveOption, NULL),
+    createSpecialConfig("save", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigSaveOption, getConfigSaveOption, rewriteConfigSaveOption, NULL),
     createSpecialConfig("client-output-buffer-limit", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigClientOutputBufferLimitOption, getConfigClientOutputBufferLimitOption, rewriteConfigClientOutputBufferLimitOption, NULL),
     createSpecialConfig("oom-score-adj-values", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigOOMScoreAdjValuesOption, getConfigOOMScoreAdjValuesOption, rewriteConfigOOMScoreAdjValuesOption, updateOOMScoreAdj),
     createSpecialConfig("notify-keyspace-events", NULL, MODIFIABLE_CONFIG, setConfigNotifyKeyspaceEventsOption, getConfigNotifyKeyspaceEventsOption, rewriteConfigNotifyKeyspaceEventsOption, NULL),
-    createSpecialConfig("bind", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG | ALLOW_EMPTY_ARG_CONFIG, setConfigBindOption, getConfigBindOption, rewriteConfigBindOption, applyBind),
+    createSpecialConfig("bind", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigBindOption, getConfigBindOption, rewriteConfigBindOption, applyBind),
     createSpecialConfig("replicaof", "slaveof", IMMUTABLE_CONFIG | MULTI_ARG_CONFIG, setConfigReplicaOfOption, getConfigReplicaOfOption, rewriteConfigReplicaOfOption, NULL),
-    createSpecialConfig("latency-tracking-info-percentiles", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG | ALLOW_EMPTY_ARG_CONFIG, setConfigLatencyTrackingInfoPercentilesOutputOption, getConfigLatencyTrackingInfoPercentilesOutputOption, rewriteConfigLatencyTrackingInfoPercentilesOutputOption, NULL),
+    createSpecialConfig("latency-tracking-info-percentiles", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigLatencyTrackingInfoPercentilesOutputOption, getConfigLatencyTrackingInfoPercentilesOutputOption, rewriteConfigLatencyTrackingInfoPercentilesOutputOption, NULL),
 
     /* NULL Terminator, this is dropped when we convert to the runtime array. */
     {NULL}

--- a/src/config.c
+++ b/src/config.c
@@ -488,7 +488,7 @@ void loadServerConfigFromString(char *config) {
                 goto loaderr;
             }
 
-            if ((config->flags & MULTI_ARG_CONFIG) && argc == 2 && strcasecmp(argv[1], "")) {
+            if ((config->flags & MULTI_ARG_CONFIG) && argc == 2 && sdslen(argv[1])) {
                 /* For MULTI_ARG_CONFIGs, if we only have one argument, try to split it by spaces.
                  * Only if the argument is not empty, otherwise something like --save "" will fail.
                  * So that we can support something like --config "arg1 arg2 arg3". */

--- a/src/server.c
+++ b/src/server.c
@@ -6962,7 +6962,6 @@ int main(int argc, char **argv) {
             server.exec_argv[1] = zstrdup(server.configfile);
             j = 2; // Skip this arg when parsing options
         }
-        int handled_last_config_arg = 1;
         while(j < argc) {
             /* Either first or last argument - Should we read config from stdin? */
             if (argv[j][0] == '-' && argv[j][1] == '\0' && (j == 1 || j == argc-1)) {
@@ -6972,19 +6971,17 @@ int main(int argc, char **argv) {
              * configuration file. For instance --port 6380 will generate the
              * string "port 6380\n" to be parsed after the actual config file
              * and stdin input are parsed (if they exist).
-             * Only consider that if the last config has at least one argument. */
-            else if (handled_last_config_arg && argv[j][0] == '-' && argv[j][1] == '-') {
+             * Note that we do not allow options values to start with the `--` prefix. */
+            else if (argv[j][0] == '-' && argv[j][1] == '-') {
                 /* Option name */
                 if (sdslen(options)) options = sdscat(options,"\n");
                 /* argv[j]+2 for removing the preceding `--` */
                 options = sdscat(options,argv[j]+2);
                 options = sdscat(options," ");
-                handled_last_config_arg = 0;
             } else {
                 /* Option argument */
                 options = sdscatrepr(options,argv[j],strlen(argv[j]));
                 options = sdscat(options," ");
-                handled_last_config_arg = 1;
             }
             j++;
         }

--- a/src/server.c
+++ b/src/server.c
@@ -6962,7 +6962,7 @@ int main(int argc, char **argv) {
             server.exec_argv[1] = zstrdup(server.configfile);
             j = 2; // Skip this arg when parsing options
         }
-        int last_config_have_value = 0;
+        int last_config_args = -1;
         while(j < argc) {
             /* Either first or last argument - Should we read config from stdin? */
             if (argv[j][0] == '-' && argv[j][1] == '\0' && (j == 1 || j == argc-1)) {
@@ -6971,19 +6971,20 @@ int main(int argc, char **argv) {
             /* All the other options are parsed and conceptually appended to the
              * configuration file. For instance --port 6380 will generate the
              * string "port 6380\n" to be parsed after the actual config file
-             * and stdin input are parsed (if they exist). */
-            else if (!last_config_have_value && argv[j][0] == '-' && argv[j][1] == '-') {
+             * and stdin input are parsed (if they exist).
+	     * Only consider that if the last config has at least one argument. */
+            else if (last_config_args && argv[j][0] == '-' && argv[j][1] == '-') {
                 /* Option name */
                 if (sdslen(options)) options = sdscat(options,"\n");
                 /* argv[j]+2 for removing the preceding `--` */
                 options = sdscat(options,argv[j]+2);
                 options = sdscat(options," ");
-                last_config_have_value = 1;
+                last_config_args = 0;
             } else {
                 /* Option argument */
                 options = sdscatrepr(options,argv[j],strlen(argv[j]));
                 options = sdscat(options," ");
-                last_config_have_value = 0;
+                last_config_args++;
             }
             j++;
         }

--- a/src/server.c
+++ b/src/server.c
@@ -6962,6 +6962,7 @@ int main(int argc, char **argv) {
             server.exec_argv[1] = zstrdup(server.configfile);
             j = 2; // Skip this arg when parsing options
         }
+        int handled_last_config_arg = 1;
         while(j < argc) {
             /* Either first or last argument - Should we read config from stdin? */
             if (argv[j][0] == '-' && argv[j][1] == '\0' && (j == 1 || j == argc-1)) {
@@ -6971,17 +6972,19 @@ int main(int argc, char **argv) {
              * configuration file. For instance --port 6380 will generate the
              * string "port 6380\n" to be parsed after the actual config file
              * and stdin input are parsed (if they exist).
-             * Note that we do not allow options values to start with the `--` prefix. */
-            else if (argv[j][0] == '-' && argv[j][1] == '-') {
+             * Only consider that if the last config has at least one argument. */
+            else if (handled_last_config_arg && argv[j][0] == '-' && argv[j][1] == '-') {
                 /* Option name */
                 if (sdslen(options)) options = sdscat(options,"\n");
                 /* argv[j]+2 for removing the preceding `--` */
                 options = sdscat(options,argv[j]+2);
                 options = sdscat(options," ");
+                handled_last_config_arg = 0;
             } else {
                 /* Option argument */
                 options = sdscatrepr(options,argv[j],strlen(argv[j]));
                 options = sdscat(options," ");
+                handled_last_config_arg = 1;
             }
             j++;
         }

--- a/src/server.c
+++ b/src/server.c
@@ -6962,36 +6962,30 @@ int main(int argc, char **argv) {
             server.exec_argv[1] = zstrdup(server.configfile);
             j = 2; // Skip this arg when parsing options
         }
+        int last_config_have_value = 0;
         while(j < argc) {
             /* Either first or last argument - Should we read config from stdin? */
             if (argv[j][0] == '-' && argv[j][1] == '\0' && (j == 1 || j == argc-1)) {
                 config_from_stdin = 1;
-                j++;
             }
             /* All the other options are parsed and conceptually appended to the
              * configuration file. For instance --port 6380 will generate the
              * string "port 6380\n" to be parsed after the actual config file
              * and stdin input are parsed (if they exist). */
-            else {
+            else if (!last_config_have_value && argv[j][0] == '-' && argv[j][1] == '-') {
                 /* Option name */
                 if (sdslen(options)) options = sdscat(options,"\n");
-                if (argv[j][0] == '-' && argv[j][1] == '-') {
-                    /* argv[j]+2 for removing the preceding `--` */
-                    options = sdscat(options,argv[j]+2);
-                } else {
-                    /* Invalid options, add them directly, and verify them in config.c */
-                    options = sdscat(options,argv[j]);
-                }
+                /* argv[j]+2 for removing the preceding `--` */
+                options = sdscat(options,argv[j]+2);
                 options = sdscat(options," ");
-                j++;
-
+                last_config_have_value = 1;
+            } else {
                 /* Option argument */
-                if (j < argc) {
-                    options = sdscatrepr(options,argv[j],strlen(argv[j]));
-                    options = sdscat(options," ");
-                    j++;
-                }
+                options = sdscatrepr(options,argv[j],strlen(argv[j]));
+                options = sdscat(options," ");
+                last_config_have_value = 0;
             }
+            j++;
         }
 
         loadServerConfig(server.configfile, config_from_stdin, options);

--- a/src/server.c
+++ b/src/server.c
@@ -6962,7 +6962,7 @@ int main(int argc, char **argv) {
             server.exec_argv[1] = zstrdup(server.configfile);
             j = 2; // Skip this arg when parsing options
         }
-        int last_config_args = -1;
+        int handled_last_config_arg = 1;
         while(j < argc) {
             /* Either first or last argument - Should we read config from stdin? */
             if (argv[j][0] == '-' && argv[j][1] == '\0' && (j == 1 || j == argc-1)) {
@@ -6972,19 +6972,19 @@ int main(int argc, char **argv) {
              * configuration file. For instance --port 6380 will generate the
              * string "port 6380\n" to be parsed after the actual config file
              * and stdin input are parsed (if they exist).
-	     * Only consider that if the last config has at least one argument. */
-            else if (last_config_args && argv[j][0] == '-' && argv[j][1] == '-') {
+             * Only consider that if the last config has at least one argument. */
+            else if (handled_last_config_arg && argv[j][0] == '-' && argv[j][1] == '-') {
                 /* Option name */
                 if (sdslen(options)) options = sdscat(options,"\n");
                 /* argv[j]+2 for removing the preceding `--` */
                 options = sdscat(options,argv[j]+2);
                 options = sdscat(options," ");
-                last_config_args = 0;
+                handled_last_config_arg = 0;
             } else {
                 /* Option argument */
                 options = sdscatrepr(options,argv[j],strlen(argv[j]));
                 options = sdscat(options," ");
-                last_config_args++;
+                handled_last_config_arg = 1;
             }
             j++;
         }

--- a/src/server.h
+++ b/src/server.h
@@ -3010,7 +3010,7 @@ sds keyspaceEventsFlagsToString(int flags);
 #define DENY_LOADING_CONFIG (1ULL<<6) /* This config is forbidden during loading. */
 #define ALIAS_CONFIG (1ULL<<7) /* For configs with multiple names, this flag is set on the alias. */
 #define MODULE_CONFIG (1ULL<<8) /* This config is a module config */
-#define ALLOW_EMPTY_ARG_CONFIG (1ULL<<8) /* This config allow setting empty arg. */
+#define ALLOW_EMPTY_ARG_CONFIG (1ULL<<9) /* This config allow setting empty arg. */
 
 #define INTEGER_CONFIG 0 /* No flags means a simple integer configuration */
 #define MEMORY_CONFIG (1<<0) /* Indicates if this value can be loaded as a memory value */

--- a/src/server.h
+++ b/src/server.h
@@ -3010,7 +3010,6 @@ sds keyspaceEventsFlagsToString(int flags);
 #define DENY_LOADING_CONFIG (1ULL<<6) /* This config is forbidden during loading. */
 #define ALIAS_CONFIG (1ULL<<7) /* For configs with multiple names, this flag is set on the alias. */
 #define MODULE_CONFIG (1ULL<<8) /* This config is a module config */
-#define ALLOW_EMPTY_ARG_CONFIG (1ULL<<9) /* This config allow setting empty arg. */
 
 #define INTEGER_CONFIG 0 /* No flags means a simple integer configuration */
 #define MEMORY_CONFIG (1<<0) /* Indicates if this value can be loaded as a memory value */

--- a/src/server.h
+++ b/src/server.h
@@ -3010,6 +3010,7 @@ sds keyspaceEventsFlagsToString(int flags);
 #define DENY_LOADING_CONFIG (1ULL<<6) /* This config is forbidden during loading. */
 #define ALIAS_CONFIG (1ULL<<7) /* For configs with multiple names, this flag is set on the alias. */
 #define MODULE_CONFIG (1ULL<<8) /* This config is a module config */
+#define ALLOW_EMPTY_ARG_CONFIG (1ULL<<8) /* This config allow setting empty arg. */
 
 #define INTEGER_CONFIG 0 /* No flags means a simple integer configuration */
 #define MEMORY_CONFIG (1<<0) /* Indicates if this value can be loaded as a memory value */

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -458,11 +458,11 @@ start_server {tags {"introspection"}} {
 
         # Take 6380 as a new option (name).
         catch {exec src/redis-server --port 6379 6380} err
-        assert_match {*6380*Bad directive or wrong number of arguments*} $err
+        assert_match {*port*wrong number of arguments*} $err
 
-        # Take `--loglevel` as the port option value.
+        # Take `--loglevel` and `verbose` as the port option value.
         catch {exec src/redis-server --port --loglevel verbose} err
-        assert_match {*port*argument couldn't be parsed into an integer*} $err
+        assert_match {*port*wrong number of arguments*} $err
 
         # Take `--bla` as the port option value.
         catch {exec src/redis-server --port --bla --loglevel verbose} err

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -474,7 +474,7 @@ start_server {tags {"introspection"}} {
         catch {exec src/redis-server --logfile --my--log--file --loglevel --bla} err
         assert_match {*'loglevel "--bla"'*argument(s) must be one of the following*} $err
 
-        # Using MULTI_ARG's own check, emtpy option value
+        # Using MULTI_ARG's own check, empty option value
         catch {exec src/redis-server --shutdown-on-sigint} err
         assert_match {*'shutdown-on-sigint'*argument(s) must be one of the following*} $err
         catch {exec src/redis-server --shutdown-on-sigint "now force" --shutdown-on-sigterm} err

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -460,17 +460,17 @@ start_server {tags {"introspection"}} {
         catch {exec src/redis-server --port 6379 6380} err
         assert_match {*'port "6379" "6380"'*wrong number of arguments*} $err
 
-        # Take `--loglevel` and `verbose` as the port option value.
+        # We will not take `--loglevel` and `verbose` as the port option value.
         catch {exec src/redis-server --port --loglevel verbose} err
-        assert_match {*'port "--loglevel" "verbose"'*wrong number of arguments*} $err
+        assert_match {*'port'*wrong number of arguments*} $err
 
-        # Take `--bla` as the port option value.
+        # We will not take `--bla` as the port option value.
         catch {exec src/redis-server --port --bla --loglevel verbose} err
-        assert_match {*'port "--bla"'*argument couldn't be parsed into an integer*} $err
+        assert_match {*'port'*wrong number of arguments*} $err
 
-        # Take `--bla` as the loglevel option value.
+        # We will not take `--my--log--file` as the logfile option value.
         catch {exec src/redis-server --logfile --my--log--file --loglevel --bla} err
-        assert_match {*'loglevel "--bla"'*argument(s) must be one of the following*} $err
+        assert_match {*'logfile'*wrong number of arguments*} $err
 
         # Using MULTI_ARG's own check, empty option value
         catch {exec src/redis-server --shutdown-on-sigint} err
@@ -478,20 +478,25 @@ start_server {tags {"introspection"}} {
         catch {exec src/redis-server --shutdown-on-sigint "now force" --shutdown-on-sigterm} err
         assert_match {*'shutdown-on-sigterm'*argument(s) must be one of the following*} $err
 
-        # Something like `redis-server --some-config --config-value1 --config-value2 --loglevel debug` would break,
-        # because if you want to pass a value to a config starting with `--`, it can only be a single value.
+        # Not allow options values to start with the `--` prefix.
         catch {exec src/redis-server --replicaof 127.0.0.1 abc} err
         assert_match {*'replicaof "127.0.0.1" "abc"'*Invalid master port*} $err
         catch {exec src/redis-server --replicaof --127.0.0.1 abc} err
-        assert_match {*'replicaof "--127.0.0.1" "abc"'*Invalid master port*} $err
+        assert_match {*'replicaof'*wrong number of arguments*} $err
         catch {exec src/redis-server --replicaof --127.0.0.1 --abc} err
-        assert_match {*'replicaof "--127.0.0.1"'*wrong number of arguments*} $err
+        assert_match {*'replicaof'*wrong number of arguments*} $err
     } {} {external:skip}
 
-    test {redis-server command line arguments - allow option value to use the `--` prefix} {
+    test {redis-server command line arguments - save with empty input} {
         set port [find_available_port $::baseport $::portcount]
-        exec src/redis-server --port $port --daemonize yes --logfile --my--log--file --loglevel verbose
-        assert_equal {--my--log--file} [lindex [exec src/redis-cli -p $port config get logfile] 1]
+        exec src/redis-server --port $port --daemonize yes --save --loglevel verbose
+        assert_equal {} [lindex [exec src/redis-cli -p $port config get save] 1]
+        assert_equal {verbose} [lindex [exec src/redis-cli -p $port config get loglevel] 1]
+
+        set port [find_available_port $::baseport $::portcount]
+        exec src/redis-server --port $port --daemonize yes --save "" --loglevel warning
+        assert_equal {} [lindex [exec src/redis-cli -p $port config get save] 1]
+        assert_equal {warning} [lindex [exec src/redis-cli -p $port config get loglevel] 1]
     } {} {external:skip}
 
     test {redis-server command line arguments - take one bulk string with spaces for MULTI_ARG configs parsing} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -494,6 +494,17 @@ start_server {tags {"introspection"}} {
         assert_equal {--my--log--file} [lindex [exec src/redis-cli -p $port config get logfile] 1]
     } {} {external:skip}
 
+    test {redis-server command line arguments - save with empty input} {
+        # Take `--loglevel` as the save option value.
+        catch {exec src/redis-server --save --loglevel verbose} err
+        assert_match {*'save "--loglevel" "verbose"'*Invalid save parameters*} $err
+
+        set port [find_available_port $::baseport $::portcount]
+        exec src/redis-server --port $port --daemonize yes --save "" --loglevel verbose
+        assert_equal {} [lindex [exec src/redis-cli -p $port config get save] 1]
+        assert_equal {verbose} [lindex [exec src/redis-cli -p $port config get loglevel] 1]
+    } {} {external:skip}
+
     test {redis-server command line arguments - take one bulk string with spaces for MULTI_ARG configs parsing} {
         set port [find_available_port $::baseport $::portcount]
         exec src/redis-server --port $port --daemonize yes --shutdown-on-sigint nosave force now --shutdown-on-sigterm "nosave force"


### PR DESCRIPTION
## Take one bulk string with spaces for MULTI_ARG configs parsing
Currently redis-server looks for arguments that start with `--`,
and anything in between them is considered arguments for the config.
like: `src/redis-server --shutdown-on-sigint nosave force now --port 6380`

MULTI_ARG configs behave differently for CONFIG command, vs the command
line argument for redis-server.
i.e. CONFIG command takes one bulk string with spaces in it, while the
command line takes an argv array with multiple values.

In this PR, in config.c, if `argc > 1` we can take them as is,
and if the config is a `MULTI_ARG` and `argc == 1`, we will split it by spaces.

So both of these will be the same:
```
redis-server --shutdown-on-sigint nosave force now --shutdown-on-sigterm nosave force
redis-server --shutdown-on-sigint nosave "force now" --shutdown-on-sigterm nosave force
redis-server --shutdown-on-sigint nosave "force now" --shutdown-on-sigterm "nosave force"
```

## Allow options value to use the `--` prefix
Currently it decides to switch to the next config, as soon as it sees `--`, 
even if there was not a single value provided yet to the last config,
this makes it impossible to define a config value that has `--` prefix in it.

For instance, if we want to set the logfile to `--my--log--file`,
like `redis-server --logfile --my--log--file --loglevel verbose`,
current code will handle that incorrectly.

In this PR, now we allow a config value that has `--` prefix in it.
**But note that** something like `redis-server --some-config --config-value1 --config-value2 --loglevel debug`
would not work, because if you want to pass a value to a config starting with `--`, it can only be a single value.
like: `redis-server --some-config "--config-value1 --config-value2" --loglevel debug`

An example (using `--` prefix config value):
```
redis-server --logfile --my--log--file --loglevel verbose
redis-cli config get logfile loglevel
1) "loglevel"
2) "verbose"
3) "logfile"
4) "--my--log--file"
```

This is mentioned in https://github.com/redis/redis/pull/10594#issuecomment-1109638304

### Potentially breaking change
`redis-server --save --loglevel verbose` used to work the same as `redis-server --save "" --loglevel verbose`
now, it'll error!

Note that this breaking change was undo in #10866 (7.0.3)