### PR TITLE
fast path when SDIFF command has the same key as the first key

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1067,11 +1067,11 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             zfree(sets);
             return;
         }
+        sets[j] = setobj;
         if (j > 0 && sets[0] == sets[j]) {
             sameset = 1; 
             break;
         }
-        sets[j] = setobj;
     }
 
     /* Select what DIFF algorithm to use.

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1131,7 +1131,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
          * This way we perform at max N*M operations, where N is the size of
          * the first set, and M the number of sets. */
         si = setTypeInitIterator(sets[0]);
-         while((ele = setTypeNextObject(si)) != NULL) {
+        while((ele = setTypeNextObject(si)) != NULL) {
             for (j = 1; j < setnum; j++) {
                 if (!sets[j]) continue; /* no key is an empty set. */
                 if (sets[j] == sets[0]) break; /* same set! */

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1088,9 +1088,8 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
 
         for (j = 0; j < setnum; j++) {
             if (sets[j] == NULL) continue;
-            if(j > 0 && sets[0] == sets[j]) {
-                goto output;
-            }
+            if(j > 0 && sets[0] == sets[j]) goto output;
+
             algo_one_work += setTypeSize(sets[0]);
             algo_two_work += setTypeSize(sets[j]);
         }
@@ -1132,15 +1131,10 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
          * This way we perform at max N*M operations, where N is the size of
          * the first set, and M the number of sets. */
         si = setTypeInitIterator(sets[0]);
-        int sameset = 0;
-        while((ele = setTypeNextObject(si)) != NULL) {
+         while((ele = setTypeNextObject(si)) != NULL) {
             for (j = 1; j < setnum; j++) {
                 if (!sets[j]) continue; /* no key is an empty set. */
-                if (sets[j] == sets[0]) {
-                    /* same set! */
-                    sameset = 1;
-                    break;
-                }
+                if (sets[j] == sets[0]) break; /* same set! */
                 if (setTypeIsMember(sets[j],ele)) break;
             }
             if (j == setnum) {
@@ -1149,11 +1143,6 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
                 cardinality++;
             }
             sdsfree(ele);
-            if (sameset) {
-                /* If we have a set that is the same as the sets[0], 
-                 * then the result is always an empty set */
-                break;
-            }
         }
         setTypeReleaseIterator(si);
     } else if (op == SET_OP_DIFF && sets[0] && diff_algo == 2) {

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1130,10 +1130,15 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
          * This way we perform at max N*M operations, where N is the size of
          * the first set, and M the number of sets. */
         si = setTypeInitIterator(sets[0]);
+        int sameset = 0;
         while((ele = setTypeNextObject(si)) != NULL) {
             for (j = 1; j < setnum; j++) {
                 if (!sets[j]) continue; /* no key is an empty set. */
-                if (sets[j] == sets[0]) break; /* same set! */
+                if (sets[j] == sets[0]) {
+                    /* same set! */
+                    sameset = 1;
+                    break;
+                }
                 if (setTypeIsMember(sets[j],ele)) break;
             }
             if (j == setnum) {
@@ -1142,6 +1147,11 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
                 cardinality++;
             }
             sdsfree(ele);
+            if (sameset) {
+                /* If we have a set that is the same as the largest set, 
+                 * then the result is always an empty set */
+                break;
+            }
         }
         setTypeReleaseIterator(si);
     } else if (op == SET_OP_DIFF && sets[0] && diff_algo == 2) {

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1125,7 +1125,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             setTypeReleaseIterator(si);
         }
     } else if (op == SET_OP_DIFF && sameset) {
-        /* At least one of the sets is the same one (same key) and the first one, result must be empty. */
+        /* At least one of the sets is the same one (same key) as the first one, result must be empty. */
     } else if (op == SET_OP_DIFF && sets[0] && diff_algo == 1) {
         /* DIFF Algorithm 1:
          *

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1097,7 +1097,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
         algo_one_work /= 2;
         diff_algo = (algo_one_work <= algo_two_work) ? 1 : 2;
 
-        if (diff_algo == 1 && setnum > 1 && !sameset) {
+        if (diff_algo == 1 && setnum > 1) {
             /* With algorithm 1 it is better to order the sets to subtract
              * by decreasing size, so that we are more likely to find
              * duplicated elements ASAP. */

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1068,13 +1068,8 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             return;
         }
         sets[j] = setobj;
-        if (op == SET_OP_DIFF) {
-            if (!sets[0]) {
-                break;
-            } else if (j > 0 && sets[0] == sets[j]) {
-                sameset = 1; 
-                break;
-            }
+        if (j > 0 && sets[0] == sets[j]) {
+            sameset = 1; 
         }
     }
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1068,9 +1068,13 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             return;
         }
         sets[j] = setobj;
-        if (j > 0 && sets[0] == sets[j]) {
-            sameset = 1; 
-            break;
+        if (op == SET_OP_DIFF) {
+            if (!sets[0]) {
+                break;
+            } else if (j > 0 && sets[0] == sets[j]) {
+                sameset = 1; 
+                break;
+            }
         }
     }
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1148,7 +1148,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             }
             sdsfree(ele);
             if (sameset) {
-                /* If we have a set that is the same as the largest set, 
+                /* If we have a set that is the same as the sets[0], 
                  * then the result is always an empty set */
                 break;
             }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1125,7 +1125,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             setTypeReleaseIterator(si);
         }
     } else if (op == SET_OP_DIFF && sameset) {
-        /* nothing to do... */
+        /* At least one of the sets is the same one (same key) and the first one, result must be empty. */
     } else if (op == SET_OP_DIFF && sets[0] && diff_algo == 1) {
         /* DIFF Algorithm 1:
          *

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -203,7 +203,7 @@ sds setTypeNextObject(setTypeIterator *si) {
  * The caller provides both pointers to be populated with the right
  * object. The return value of the function is the object->encoding
  * field of the object and is used by the caller to check if the
- * int64_t pointer or the redis object pointer was populated.
+ * int64_t pointer or the sds pointer was populated.
  *
  * Note that both the sdsele and llele pointers should be passed and cannot
  * be NULL since the function will try to defensively populate the non
@@ -1055,6 +1055,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
     sds ele;
     int j, cardinality = 0;
     int diff_algo = 1;
+    int sameset = 0; 
 
     for (j = 0; j < setnum; j++) {
         robj *setobj = lookupKeyRead(c->db, setkeys[j]);
@@ -1066,13 +1067,12 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             zfree(sets);
             return;
         }
+        if (j > 0 && sets[0] == sets[j]) {
+            sameset = 1; 
+            break;
+        }
         sets[j] = setobj;
     }
-
-    /* We need a temp set object to store our union. If the dstkey
-     * is not NULL (that is, we are inside an SUNIONSTORE operation) then
-     * this set object will be the resulting object to set into the target key*/
-    dstset = createIntsetObject();
 
     /* Select what DIFF algorithm to use.
      *
@@ -1083,12 +1083,11 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
      * the sets.
      *
      * We compute what is the best bet with the current input here. */
-    if (op == SET_OP_DIFF && sets[0]) {
+    if (op == SET_OP_DIFF && sets[0] && !sameset) {
         long long algo_one_work = 0, algo_two_work = 0;
 
         for (j = 0; j < setnum; j++) {
             if (sets[j] == NULL) continue;
-            if(j > 0 && sets[0] == sets[j]) goto output;
 
             algo_one_work += setTypeSize(sets[0]);
             algo_two_work += setTypeSize(sets[j]);
@@ -1099,7 +1098,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
         algo_one_work /= 2;
         diff_algo = (algo_one_work <= algo_two_work) ? 1 : 2;
 
-        if (diff_algo == 1 && setnum > 1) {
+        if (diff_algo == 1 && setnum > 1 && !sameset) {
             /* With algorithm 1 it is better to order the sets to subtract
              * by decreasing size, so that we are more likely to find
              * duplicated elements ASAP. */
@@ -1107,6 +1106,11 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
                 qsortCompareSetsByRevCardinality);
         }
     }
+
+    /* We need a temp set object to store our union. If the dstkey
+     * is not NULL (that is, we are inside an SUNIONSTORE operation) then
+     * this set object will be the resulting object to set into the target key*/
+    dstset = createIntsetObject();
 
     if (op == SET_OP_UNION) {
         /* Union is trivial, just add every element of every set to the
@@ -1121,6 +1125,8 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
             }
             setTypeReleaseIterator(si);
         }
+    } else if (op == SET_OP_DIFF && sameset) {
+        /* nothing to do... */
     } else if (op == SET_OP_DIFF && sets[0] && diff_algo == 1) {
         /* DIFF Algorithm 1:
          *
@@ -1173,7 +1179,6 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
         }
     }
 
-output:
     /* Output the content of the resulting set, if not in STORE mode */
     if (!dstkey) {
         addReplySetLen(c,cardinality);

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -241,11 +241,6 @@ start_server {
             assert_equal $expected [lsort [r sunion set1{t} set2{t}]]
         }
 
-        test "SUNION with three same sets - $type" {
-            set expected [lsort -uniq "[r smembers set1{t}] [r smembers set1{t}] [r smembers set1{t}]"]
-            assert_equal $expected [lsort [r sunion set1{t} set1{t} set1{t}]]
-        }
-
         test "SUNIONSTORE with two sets - $type" {
             r sunionstore setres{t} set1{t} set2{t}
             assert_encoding $type setres{t}
@@ -289,6 +284,14 @@ start_server {
                 assert_encoding intset setres{t}
             }
             assert_equal {1 2 3 4} [lsort [r smembers setres{t}]]
+        }
+
+        test "SINTER/SUNION/SDIFF with three same sets - $type" {
+            set expected [lsort "[r smembers set1{t}]"]
+            assert_equal $expected [lsort [r sinter set1{t} set1{t} set1{t}]]
+            set expected [lsort -uniq "[r smembers set1{t}] [r smembers set1{t}] [r smembers set1{t}]"]
+            assert_equal $expected [lsort [r sunion set1{t} set1{t} set1{t}]]
+            assert_equal {} [lsort [r sdiff set1{t} set1{t} set1{t}]]
         }
     }
 

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -289,7 +289,6 @@ start_server {
         test "SINTER/SUNION/SDIFF with three same sets - $type" {
             set expected [lsort "[r smembers set1{t}]"]
             assert_equal $expected [lsort [r sinter set1{t} set1{t} set1{t}]]
-            set expected [lsort -uniq "[r smembers set1{t}] [r smembers set1{t}] [r smembers set1{t}]"]
             assert_equal $expected [lsort [r sunion set1{t} set1{t} set1{t}]]
             assert_equal {} [lsort [r sdiff set1{t} set1{t} set1{t}]]
         }

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -241,6 +241,11 @@ start_server {
             assert_equal $expected [lsort [r sunion set1{t} set2{t}]]
         }
 
+        test "SUNION with three same sets - $type" {
+            set expected [lsort -uniq "[r smembers set1{t}] [r smembers set1{t}] [r smembers set1{t}]"]
+            assert_equal $expected [lsort [r sunion set1{t} set1{t} set1{t}]]
+        }
+
         test "SUNIONSTORE with two sets - $type" {
             r sunionstore setres{t} set1{t} set2{t}
             assert_encoding $type setres{t}


### PR DESCRIPTION
When user uses the same input key for SDIFF as the first one, the result must be empty, so we don't need to process the elements to test.