### PR TITLE
Use ZIPLIST_END_SIZE macro in ZIPLIST_ENTRY_END macro

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -255,7 +255,7 @@
 
 /* Return the pointer to the last byte of a ziplist, which is, the
  * end of ziplist FF entry. */
-#define ZIPLIST_ENTRY_END(zl)   ((zl)+intrev32ifbe(ZIPLIST_BYTES(zl))-1)
+#define ZIPLIST_ENTRY_END(zl)   ((zl)+intrev32ifbe(ZIPLIST_BYTES(zl))-ZIPLIST_END_SIZE)
 
 /* Increment the number of items field in the ziplist header. Note that this
  * macro should never overflow the unsigned 16 bit integer, since entries are


### PR DESCRIPTION
It would be nice to use ZIPLIST_END_SIZE to represent the 1.
This is just a small cleanup.
```
    #define ZIPLIST_END_SIZE        (sizeof(uint8_t))
    #define ZIPLIST_ENTRY_END(zl)   ((zl)+intrev32ifbe(ZIPLIST_BYTES(zl))-1)
```