### PR TITLE
Replace float zero comparison to FP_ZERO comparison

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -522,7 +522,7 @@ int string2ld(const char *s, size_t slen, long double *dp) {
     if (isspace(buf[0]) || eptr[0] != '\0' ||
         (size_t)(eptr-buf) != slen ||
         (errno == ERANGE &&
-            (value == HUGE_VAL || value == -HUGE_VAL || value == 0)) ||
+            (value == HUGE_VAL || value == -HUGE_VAL || fpclassify(value) == FP_ZERO)) ||
         errno == EINVAL ||
         isnan(value))
         return 0;
@@ -546,7 +546,7 @@ int string2d(const char *s, size_t slen, double *dp) {
         isspace(((const char*)s)[0]) ||
         (size_t)(eptr-(char*)s) != slen ||
         (errno == ERANGE &&
-            (*dp == HUGE_VAL || *dp == -HUGE_VAL || *dp == 0)) ||
+            (*dp == HUGE_VAL || *dp == -HUGE_VAL || fpclassify(*dp) == FP_ZERO)) ||
         isnan(*dp))
         return 0;
     return 1;


### PR DESCRIPTION
I suggest to use "[fpclassify](https://en.cppreference.com/w/cpp/numeric/math/fpclassify)" for float comparison with zero, because of expression "value == 0" with value very close to zero can be considered as true with some performance compiler optimizations.

Note: this code was introduced by 9d520a7f to accept zset scores that get ERANGE in conversion due to precision loss near 0.
But with Intel compilers, ICC and ICX, where optimizations for 0 check are more aggressive, "==0" is true for mentioned functions, however should not be. Behavior is seen starting from O2.
This leads to a failure in the ZSCAN test in scan.tcl