### PR TITLE
Expose Lua error in case of string error.

### DIFF
--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -1651,8 +1651,11 @@ void luaCallFunction(scriptRunCtx* run_ctx, lua_State *lua, robj** keys, size_t 
          * {err='<error msg>', source='<source file>', line=<line>}
          * We can construct the error message from this information */
         if (!lua_istable(lua, -1)) {
-            /* Should not happened, and we should considered assert it */
-            addReplyErrorFormat(c,"Error running script (call to %s)\n", run_ctx->funcname);
+            const char *msg = "execution failure";
+            if (lua_isstring(lua, -1)) {
+                msg = lua_tostring(lua, -1);
+            }
+            addReplyErrorFormat(c,"Error running script %s, %.100s\n", run_ctx->funcname, msg);
         } else {
             errorInfo err_info = {0};
             sds final_msg = sdsempty();


### PR DESCRIPTION
In general, our error handler make sure the error object is always a table. In some rare cases (such as OOM error), the error handler will not be called and the error object will be a string. The PR expose the error even if its a string and not a table.

Currently there is no way to test it but if it'll ever happen, it is better to propagate this string upwards than just generate a generic error without any specific info.