### PR TITLE
Exclude port.h, sys/event.h

### DIFF
--- a/src/ae_evport.c
+++ b/src/ae_evport.c
@@ -29,7 +29,9 @@
 
 
 #include <errno.h>
+#ifndef __INTEL_COMPILER
 #include <port.h>
+#endif
 #include <poll.h>
 
 #include <sys/types.h>

--- a/src/ae_kqueue.c
+++ b/src/ae_kqueue.c
@@ -30,7 +30,9 @@
 
 
 #include <sys/types.h>
+#ifndef __INTEL_COMPILER
 #include <sys/event.h>
+#endif
 #include <sys/time.h>
 
 typedef struct aeApiState {


### PR DESCRIPTION
 I faced with build issue during building Redis with ICC:
```
$ icc --version
icc (ICC) 2021.5.0 20211109
Copyright (C) 1985-2021 Intel Corporation.  All rights reserved.
$ CC=icc CXX=icpc make
cd src && make all
make[1]: Entering directory '/home/mmarkova/Work/redis_icc/src'
    CC Makefile.dep
Makefile.dep:11: *** target pattern contains no '%'.  Stop.
make[1]: Leaving directory '/home/mmarkova/Work/redis_icc/src'
make: *** [Makefile:6: all] Error 2
```
Fail reason which I've found - files "port.h" and "sys/event.h" are absent on my system. I am using Ubuntu 20.4. 
So, to fix this particular issue is enough to add check for used compiler before these files including. 

However, issue and possible fix can be wider. I've found that w/o these 2 "includes" GCC and Clang also build Redis successfully. Basically looks like these includes are ignored by GCC and Clang too on Ubuntu, but build process is not fail due to difference in processing. 
As alternative way I see:
1) Excluding these files on Ubuntu (if they are required on other platforms)
2) Excluding there files at all (if they are not really needed)

Could you please revise necessity of these 2 includes in for redis build?
#include <port.h>
#include <sys/event.h>
