### PR TITLE
CLUSTER SHARDS should returns slots as integers, not strings

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5071,7 +5071,7 @@ void addShardReplyForClusterShards(client *c, clusterNode *node, uint16_t *slot_
         serverAssert((slot_pairs_count % 2) == 0);
         addReplyArrayLen(c, slot_pairs_count);
         for (int i = 0; i < slot_pairs_count; i++)
-            addReplyBulkLongLong(c, (unsigned long)slot_info_pairs[i]);
+            addReplyLongLong(c, (unsigned long)slot_info_pairs[i]);
     } else {
         /* If no slot info pair is provided, the node owns no slots */
         addReplyArrayLen(c, 0);


### PR DESCRIPTION
It used to returns slots as strings, like:
```
redis> cluster shards
1) 1) "slots"
   2) 1) "10923"
      2) "16383"
```

CLUSTER SHARDS docs and the top comment of #10293 says that it returns integers.
Note other commands like CLUSTER SLOTS, it returns slots as integers.
Use addReplyLongLong instead of addReplyBulkLongLong, now it returns slots as integers:
```
redis> cluster shards
1) 1) "slots"
   2) 1) (integer) 10923
      2) (integer) 16383
```

This is a small breaking change, introduced in 7.0.0 (7.0 RC3, #10293)

Fixes #10680