### PR TITLE
Fix --save command line regression in redis 7.0

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2592,8 +2592,10 @@ static int setConfigSaveOption(standardConfig *config, sds *argv, int argc, cons
     int j;
 
     /* Special case: treat single arg "" as zero args indicating empty save configuration */
-    if (argc == 1 && !strcasecmp(argv[0],""))
+    if (argc == 1 && !strcasecmp(argv[0],"")) {
+        resetServerSaveParams();
         argc = 0;
+    }
 
     /* Perform sanity check before setting the new config:
     * - Even number of args

--- a/tests/assets/default.conf
+++ b/tests/assets/default.conf
@@ -13,9 +13,8 @@ databases 16
 latency-monitor-threshold 1
 repl-diskless-sync-delay 0
 
+# Note the infrastructure in server.tcl uses a dict, we can't provide several save directives
 save 900 1
-save 300 10
-save 60 10000
 
 rdbcompression yes
 dbfilename dump.rdb

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -166,10 +166,25 @@ start_server {tags {"introspection"}} {
             assert_match [r config get save] {save {3600 1 300 100 60 10000}}
         }
 
-        # First "save" keyword overrides defaults
+        # First "save" keyword overrides hard coded defaults
         start_server {config "minimal.conf" overrides {save {100 100}}} {
             # Defaults
             assert_match [r config get save] {save {100 100}}
+        }
+
+        # First "save" keyword in default config file
+        start_server {config "default.conf"} {
+            assert_match [r config get save] {save {900 1}}
+        }
+
+        # First "save" keyword appends default from config file
+        start_server {config "default.conf" args {--save 100 100}} {
+            assert_match [r config get save] {save {900 1 100 100}}
+        }
+
+        # Empty "save" keyword resets all
+        start_server {config "default.conf" args {--save {}}} {
+            assert_match [r config get save] {save {}}
         }
     } {} {external:skip}
 


### PR DESCRIPTION
Unintentional change in #9644 (since RC1) meant that an empty `--save ""` config
from command line, wouldn't have clear any setting from the config file

Added tests to cover that, and improved test infra to take additional
command line args for redis-server