### PR TITLE
Don't update node ip when peer ip is unreachable

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1747,7 +1747,7 @@ int nodeIp2String(char *buf, clusterLink *link, char *announced_ip) {
         return C_OK;
     } else {
         if (connPeerToString(link->conn, buf, NET_IP_STR_LEN, NULL) == C_ERR) {
-            serverLog(LL_WARNING, "ERROR get peer IP: %s", 
+            serverLog(LL_NOTICE, "Error converting peer IP to string: %s",
                 link->conn ? connGetLastError(link->conn) : "no link");
             return C_ERR;
         }
@@ -2240,7 +2240,7 @@ int clusterProcessPacket(clusterLink *link) {
             clusterNode *node;
 
             node = createClusterNode(NULL,CLUSTER_NODE_HANDSHAKE);
-            nodeIp2String(node->ip,link,hdr->myip);
+            serverAssert(nodeIp2String(node->ip,link,hdr->myip) == C_OK);
             node->port = ntohs(hdr->port);
             node->pport = ntohs(hdr->pport);
             node->cport = ntohs(hdr->cport);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1747,7 +1747,8 @@ int nodeIp2String(char *buf, clusterLink *link, char *announced_ip) {
         return C_OK;
     } else {
         if (connPeerToString(link->conn, buf, NET_IP_STR_LEN, NULL) == C_ERR) {
-            serverLog(LL_WARNING, "ERROR get peer IP: %s", connGetLastError(link->conn));
+            serverLog(LL_WARNING, "ERROR get peer IP: %s", 
+                link->conn ? connGetLastError(link->conn) : "no link");
             return C_ERR;
         }
         return C_OK;

--- a/src/connection.c
+++ b/src/connection.c
@@ -390,7 +390,7 @@ int connGetSocketError(connection *conn) {
 
 int connPeerToString(connection *conn, char *ip, size_t ip_len, int *port) {
     if (anetFdToString(conn ? conn->fd : -1, ip, ip_len, port, FD_TO_PEER_NAME) == -1) {
-        conn->last_errno = errno;
+        if (conn) conn->last_errno = errno;
         return C_ERR;
     }
     return C_OK;

--- a/src/connection.c
+++ b/src/connection.c
@@ -389,7 +389,11 @@ int connGetSocketError(connection *conn) {
 }
 
 int connPeerToString(connection *conn, char *ip, size_t ip_len, int *port) {
-    return anetFdToString(conn ? conn->fd : -1, ip, ip_len, port, FD_TO_PEER_NAME);
+    if (anetFdToString(conn ? conn->fd : -1, ip, ip_len, port, FD_TO_PEER_NAME) == -1) {
+        conn->last_errno = errno;
+        return C_ERR;
+    }
+    return C_OK;
 }
 
 int connSockName(connection *conn, char *ip, size_t ip_len, int *port) {


### PR DESCRIPTION
As discussed in #9351, @bjosv mentioned that the cluster node IP may be updated to `?` when `getpeername()` fails due to some reasons like the fd is invalid somehow, and the log looks like:
```
15:S 27 Apr 2022 00:38:49.999 # Address updated for node f55db6b9314afec8816cbb258cf8a8358ad1718c, now ?:6380
15:S 27 Apr 2022 00:38:49.999 # Address updated for node c16a99900ec94d8bfd4dc4e1b0c76340f7e853a6, now ?:6380
15:S 27 Apr 2022 00:38:49.999 # Address updated for node 530b194579251e73473b6c9f94b2ce79ab1ad7eb, now ?:6380
```
To solve this issue, the patch primarily do 2 things:
1. forward the error code outside when the try to get peer name fails, and skip the current IP update in `nodeUpdateAddressIfNeeded`. It won't affect the normal IP update process as it will be retried the next round of PING.
2. log the failure info of `getpeername()`,  for further debug and so on

```
release notes:
Fix a bug where a cluster enabled replica node may permanently set its master's hostname to '?'.
```