### PR TITLE
Moving client flags to a more cache friendly position within client struct

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1079,6 +1079,7 @@ typedef struct {
 
 typedef struct client {
     uint64_t id;            /* Client incremental unique ID. */
+    uint64_t flags;         /* Client flags: CLIENT_* macros. */
     connection *conn;
     int resp;               /* RESP protocol version. Can be 2 or 3. */
     redisDb *db;            /* Pointer to currently SELECTed DB. */
@@ -1112,7 +1113,6 @@ typedef struct client {
     int slot;               /* The slot the client is executing against. Set to -1 if no slot is being used */
     time_t lastinteraction; /* Time of the last interaction, used for timeout */
     time_t obuf_soft_limit_reached_time;
-    uint64_t flags;         /* Client flags: CLIENT_* macros. */
     int authenticated;      /* Needed when the default user requires auth. */
     int replstate;          /* Replication state if this is a slave. */
     int repl_start_cmd_stream_on_ack; /* Install slave write handler on first ACK. */


### PR DESCRIPTION
Fixes #10648 .
Following @oranagra 's recommendation to move the client flags to a more cache friendly position within the client struct we indeed regain the lost 2% of CPU cycles since v6.2 ( from 630532.57 to 647449.80 ops/sec ).  

## to reproduce:
```
# spin a standalone redis 
taskset -c 0 `pwd`/src/redis-server --logfile redis-opt.log --save "" --daemonize yes

# populate with data
redis-cli "RPUSH" "list:10" "lysbgqqfqw" "mtccjerdon" "jekkafodvk" "nmgxcctxpn" "vyqqkuszzh" "pytrnqdhvs" "oguwnmniig" "gekntrykfh" "nhfnbxqgol" "cgoeihlnei"

# benchmark 
taskset -c 1-5 memtier_benchmark --command="LRANGE list:10 0 -1"  --hide-histogram --test-time 60 --pipeline 10 -x 3
```

unstable 2bcd890d8aa645cab0d8fd0ed765c52a997de4f5 (merge-base )
```
BEST RUN RESULTS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Lranges    630593.68         3.16045         3.40700         4.31900         4.60700    134863.30 
Totals     630593.68         3.16045         3.40700         4.31900         4.60700    134863.30 


WORST RUN RESULTS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Lranges    630444.65         3.16119         3.40700         4.31900         4.60700    134831.42 
Totals     630444.65         3.16119         3.40700         4.31900         4.60700    134831.42 


AGGREGATED AVERAGE RESULTS (3 runs)
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Lranges    630532.57         3.16075         3.40700         4.31900         4.60700    134850.23 
Totals     630532.57         3.16075         3.40700         4.31900         4.60700    134850.23 

```

this PR
```
BEST RUN RESULTS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Lranges    647852.82         3.07598         3.31100         4.25500         4.51100    138554.46 
Totals     647852.82         3.07598         3.31100         4.25500         4.51100    138554.46 


WORST RUN RESULTS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Lranges    646919.60         3.08041         3.31100         4.25500         4.54300    138354.88 
Totals     646919.60         3.08041         3.31100         4.25500         4.54300    138354.88 


AGGREGATED AVERAGE RESULTS (3 runs)
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Lranges    647449.80         3.07789         3.31100         4.25500         4.54300    138468.27 
Totals     647449.80         3.07789         3.31100         4.25500         4.54300    138468.27 

```

