### PR TITLE
Fix cursor type in RedisModuleScanCursor to handle more than 2^31 elements

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -9809,7 +9809,7 @@ typedef struct {
 } ScanCBData;
 
 typedef struct RedisModuleScanCursor{
-    int cursor;
+    unsigned long cursor;
     int done;
 }RedisModuleScanCursor;
 


### PR DESCRIPTION
Changed `cursor`'s type from `int` to `unsigned long`. 

`cursor` is the return value of `dictScan()`:

https://github.com/redis/redis/blob/6b44e4ea92edd0f06971b5b7354769255fde66a8/src/module.c#L9914

`dictScan()` returns `unsigned long` but cursor was `int`. Slicing/UB can occur if `dictScan()` returns a value larger than 2^31.  