### PR TITLE
memory purge command for non jemalloc build mostly.

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -1644,7 +1644,7 @@ NULL
         addReplyVerbatim(c,report,sdslen(report),"txt");
         sdsfree(report);
     } else if (!strcasecmp(c->argv[1]->ptr,"purge") && c->argc == 2) {
-        if (jemalloc_purge() == 0)
+        if (zlibc_purge() == 0)
             addReply(c, shared.ok);
         else
             addReplyError(c, "Error purging dirty pages");

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -41,6 +41,9 @@
 #ifdef __linux__
 #include <sys/mman.h>
 #endif
+#ifdef __APPLE__
+#include <malloc/malloc.h>
+#endif
 
 /* This function provide us access to the original libc free(). This is useful
  * for instance to free results obtained by backtrace_symbols(). We need
@@ -775,6 +778,20 @@ size_t zmalloc_get_memory_size(void) {
 #endif
 #else
     return 0L;          /* Unknown OS. */
+#endif
+}
+
+int zlibc_purge(void) {
+#if defined(USE_JEMALLOC)
+    return jemalloc_purge();
+#elif defined(__linux__)
+    /* We try to return free memory back to the OS */
+    return malloc_trim(0) == 1 ? 0 : -1;
+#elif defined(__APPLE__)
+    /* All memory zones are passed through and */
+    /* an attempt is made to release the pressure upon */
+    size_t rel = malloc_zone_pressure_relief(NULL, 0);
+    return rel > 0 ? 0 : -1;
 #endif
 }
 

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -122,6 +122,7 @@ size_t zmalloc_get_private_dirty(long pid);
 size_t zmalloc_get_smap_bytes_by_field(char *field, long pid);
 size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
+int zlibc_purge(void);
 void zmadvise_dontneed(void *ptr);
 
 #ifdef HAVE_DEFRAG


### PR DESCRIPTION
- on Linux using malloc_trim w/o padding, pushing back to the OS
 freed memory.
- on macOs memory zones will be examined and freed as much as possible.