### PR TITLE
Fix #10705, avoid relinking the same library twice.

### DIFF
--- a/src/functions.h
+++ b/src/functions.h
@@ -106,7 +106,6 @@ struct functionLibInfo {
     dict *functions; /* Functions dictionary */
     engineInfo *ei;  /* Pointer to the function engine */
     sds code;        /* Library code */
-    int is_linked;   /* Indicate that the library is linked to the global dictionaries and can be used */
 };
 
 int functionsRegisterEngine(const char *engine_name, engine *engine_ctx);

--- a/src/functions.h
+++ b/src/functions.h
@@ -106,6 +106,7 @@ struct functionLibInfo {
     dict *functions; /* Functions dictionary */
     engineInfo *ei;  /* Pointer to the function engine */
     sds code;        /* Library code */
+    int is_linked;   /* Indicate that the library is linked to the global dictionaries and can be used */
 };
 
 int functionsRegisterEngine(const char *engine_name, engine *engine_ctx);

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -1141,6 +1141,23 @@ start_server {tags {"scripting"}} {
         r function stats
     } {running_script {} engines {LUA {libraries_count 1 functions_count 1}}}
 
+    test {FUNCTION - test function stats on loading failure} {
+        r FUNCTION FLUSH
+
+        r FUNCTION load {#!lua name=test1
+            redis.register_function('f1', function() return 1 end)
+            redis.register_function('f2', function() return 1 end)
+        }
+
+        catch {r FUNCTION load {#!lua name=test1
+            redis.register_function('f3', function() return 1 end)
+        }} e
+        assert_match "*Library 'test1' already exists*" $e
+        
+
+        r function stats
+    } {running_script {} engines {LUA {libraries_count 1 functions_count 2}}}
+
     test {FUNCTION - function stats cleaned after flush} {
         r function flush
         r function stats


### PR DESCRIPTION
Set `old_li` to NULL to avoid linking it again on error.
Before the fix, loading an already existing library will cause the existing library to be added again. This cause not harm other then wrong statistics. The statistics that are effected  by the issue are:
* `libraries_count` and `functions_count` returned by `function stats` command
* `used_memory_functions` returned on `info memory` command
* `functions.caches` returned on `memory stats` command