### PR TITLE
clean a redundant free

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3557,7 +3557,6 @@ void replaceClientCommandVector(client *c, int argc, robj **argv) {
     int j;
     retainOriginalCommandVector(c);
     freeClientArgv(c);
-    zfree(c->argv);
     c->argv = argv;
     c->argc = argc;
     c->argv_len_sum = 0;


### PR DESCRIPTION
In `freeClientArgv`  `c->argv ` has been freed, so it's unnecessary to free it again(a trivial code clean).