### PR TITLE
add RM_GetTotalUsedMemory api call

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -9794,6 +9794,13 @@ float RM_GetUsedMemoryRatio(){
     return level;
 }
 
+/* Return the total amount of bytes used */
+size_t RM_GetTotalUsedMemory() {
+    size_t total;
+    getMaxmemoryState(&total, NULL, NULL, NULL);
+    return total;
+}
+
 /* --------------------------------------------------------------------------
  * ## Scanning keyspace and hashes
  * -------------------------------------------------------------------------- */
@@ -12564,6 +12571,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(SignalKeyAsReady);
     REGISTER_API(GetBlockedClientReadyKey);
     REGISTER_API(GetUsedMemoryRatio);
+    REGISTER_API(GetTotalUsedMemory);
     REGISTER_API(MallocSize);
     REGISTER_API(MallocSizeString);
     REGISTER_API(MallocSizeDict);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1160,6 +1160,7 @@ REDISMODULE_API void (*RedisModule_SendChildHeartbeat)(double progress) REDISMOD
 REDISMODULE_API int (*RedisModule_ExitFromChild)(int retcode) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_KillForkChild)(int child_pid) REDISMODULE_ATTR;
 REDISMODULE_API float (*RedisModule_GetUsedMemoryRatio)() REDISMODULE_ATTR;
+REDISMODULE_API size_t (*RedisModule_GetTotalUsedMemory)() REDISMODULE_ATTR;
 REDISMODULE_API size_t (*RedisModule_MallocSize)(void* ptr) REDISMODULE_ATTR;
 REDISMODULE_API size_t (*RedisModule_MallocSizeString)(RedisModuleString* str) REDISMODULE_ATTR;
 REDISMODULE_API size_t (*RedisModule_MallocSizeDict)(RedisModuleDict* dict) REDISMODULE_ATTR;
@@ -1493,6 +1494,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ExitFromChild);
     REDISMODULE_GET_API(KillForkChild);
     REDISMODULE_GET_API(GetUsedMemoryRatio);
+    REDISMODULE_GET_API(GetTotalUsedMemory);
     REDISMODULE_GET_API(MallocSize);
     REDISMODULE_GET_API(MallocSizeString);
     REDISMODULE_GET_API(MallocSizeDict);


### PR DESCRIPTION
return the total amount of memory redis has allocated so modules can do their own enforcment of memory limits