### PR TITLE
Fsync directory while persisting AOF manifest, RDB file, and config file

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1642,6 +1642,7 @@ int rewriteConfigOverwriteFile(char *configfile, sds content) {
     const char *tmp_suffix = ".XXXXXX";
     size_t offset = 0;
     ssize_t written_bytes = 0;
+    int old_errno;
 
     int tmp_path_len = snprintf(tmp_conffile, sizeof(tmp_conffile), "%s%s", configfile, tmp_suffix);
     if (tmp_path_len <= 0 || (unsigned int)tmp_path_len >= sizeof(tmp_conffile)) {
@@ -1686,7 +1687,7 @@ int rewriteConfigOverwriteFile(char *configfile, sds content) {
     }
 
 cleanup:
-    int old_errno = errno;
+    old_errno = errno;
     close(fd);
     if (retval) unlink(tmp_conffile);
     errno = old_errno;

--- a/src/config.c
+++ b/src/config.c
@@ -1687,7 +1687,12 @@ int rewriteConfigOverwriteFile(char *configfile, sds content) {
 
 cleanup:
     close(fd);
-    if (retval) unlink(tmp_conffile);
+    if (retval) {
+        /* try to unlink the temp, ignoring possible errors */
+        int old_errno = errno;
+        unlink(tmp_conffile);
+        errno = old_errno;
+    }
     return retval;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -1678,6 +1678,8 @@ int rewriteConfigOverwriteFile(char *configfile, sds content) {
         serverLog(LL_WARNING, "Could not chmod config file (%s)", strerror(errno));
     else if (rename(tmp_conffile, configfile) == -1)
         serverLog(LL_WARNING, "Could not rename tmp config file (%s)", strerror(errno));
+    else if (fsyncFileDir(configfile) == -1)
+        serverLog(LL_WARNING, "Could not sync config file dir (%s)", strerror(errno));
     else {
         retval = 0;
         serverLog(LL_DEBUG, "Rewritten config file (%s) successfully", configfile);

--- a/src/config.c
+++ b/src/config.c
@@ -1686,13 +1686,10 @@ int rewriteConfigOverwriteFile(char *configfile, sds content) {
     }
 
 cleanup:
+    int old_errno = errno;
     close(fd);
-    if (retval) {
-        /* try to unlink the temp, ignoring possible errors */
-        int old_errno = errno;
-        unlink(tmp_conffile);
-        errno = old_errno;
-    }
+    if (retval) unlink(tmp_conffile);
+    errno = old_errno;
     return retval;
 }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1445,6 +1445,7 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
         stopSaving(0);
         return C_ERR;
     }
+    if (fsyncFileDir(filename) == -1) goto werr;
 
     serverLog(LL_NOTICE,"DB saved on disk");
     server.dirty = 0;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1397,6 +1397,7 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
     FILE *fp = NULL;
     rio rdb;
     int error = 0;
+    char *err_op;    /* For a detailed log */
 
     snprintf(tmpfile,256,"temp-%d.rdb", (int) getpid());
     fp = fopen(tmpfile,"w");
@@ -1420,13 +1421,14 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
 
     if (rdbSaveRio(req,&rdb,&error,RDBFLAGS_NONE,rsi) == C_ERR) {
         errno = error;
+        err_op = "rdbSaveRio";
         goto werr;
     }
 
     /* Make sure data will not remain on the OS's output buffers */
-    if (fflush(fp)) goto werr;
-    if (fsync(fileno(fp))) goto werr;
-    if (fclose(fp)) { fp = NULL; goto werr; }
+    if (fflush(fp)) { err_op = "fflush"; goto werr; }
+    if (fsync(fileno(fp))) { err_op = "fsync"; goto werr; }
+    if (fclose(fp)) { fp = NULL; err_op = "fclose"; goto werr; }
     fp = NULL;
     
     /* Use RENAME to make sure the DB file is changed atomically only
@@ -1445,7 +1447,7 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
         stopSaving(0);
         return C_ERR;
     }
-    if (fsyncFileDir(filename) == -1) goto werr;
+    if (fsyncFileDir(filename) == -1) { err_op = "fsyncFileDir"; goto werr; }
 
     serverLog(LL_NOTICE,"DB saved on disk");
     server.dirty = 0;
@@ -1455,7 +1457,7 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi) {
     return C_OK;
 
 werr:
-    serverLog(LL_WARNING,"Write error saving DB on disk: %s", strerror(errno));
+    serverLog(LL_WARNING,"Write error saving DB on disk(%s): %s", err_op, strerror(errno));
     if (fp) fclose(fp);
     unlink(tmpfile);
     stopSaving(0);

--- a/src/replication.c
+++ b/src/replication.c
@@ -2143,8 +2143,19 @@ void readSyncBulkPayload(connection *conn) {
             if (old_rdb_fd != -1) close(old_rdb_fd);
             return;
         }
+
         /* Close old rdb asynchronously. */
         if (old_rdb_fd != -1) bioCreateCloseJob(old_rdb_fd);
+        
+        /* Sync the directory to ensure rename is persisted */
+        if (fsyncFileDir(server.rdb_filename) == -1) {
+            serverLog(LL_WARNING,
+                "Failed trying to sync DB directory %s in "
+                "MASTER <-> REPLICA synchronization: %s",
+                server.rdb_filename, strerror(errno));
+            cancelReplicationHandshake(1);
+            return;
+        }
 
         if (rdbLoad(server.rdb_filename,&rsi,RDBFLAGS_REPLICATION) != C_OK) {
             serverLog(LL_WARNING,

--- a/src/replication.c
+++ b/src/replication.c
@@ -2143,19 +2143,8 @@ void readSyncBulkPayload(connection *conn) {
             if (old_rdb_fd != -1) close(old_rdb_fd);
             return;
         }
-
         /* Close old rdb asynchronously. */
         if (old_rdb_fd != -1) bioCreateCloseJob(old_rdb_fd);
-        
-        /* Sync the directory to ensure rename is persisted */
-        if (fsyncFileDir(server.rdb_filename) == -1) {
-            serverLog(LL_WARNING,
-                "Failed trying to sync DB directory %s in "
-                "MASTER <-> REPLICA synchronization: %s",
-                server.rdb_filename, strerror(errno));
-            cancelReplicationHandshake(1);
-            return;
-        }
 
         if (rdbLoad(server.rdb_filename,&rsi,RDBFLAGS_REPLICATION) != C_OK) {
             serverLog(LL_WARNING,

--- a/src/replication.c
+++ b/src/replication.c
@@ -2145,7 +2145,7 @@ void readSyncBulkPayload(connection *conn) {
         }
         /* Close old rdb asynchronously. */
         if (old_rdb_fd != -1) bioCreateCloseJob(old_rdb_fd);
-                
+
         /* Sync the directory to ensure rename is persisted */
         if (fsyncFileDir(server.rdb_filename) == -1) {
             serverLog(LL_WARNING,

--- a/src/replication.c
+++ b/src/replication.c
@@ -2145,6 +2145,16 @@ void readSyncBulkPayload(connection *conn) {
         }
         /* Close old rdb asynchronously. */
         if (old_rdb_fd != -1) bioCreateCloseJob(old_rdb_fd);
+                
+        /* Sync the directory to ensure rename is persisted */
+        if (fsyncFileDir(server.rdb_filename) == -1) {
+            serverLog(LL_WARNING,
+                "Failed trying to sync DB directory %s in "
+                "MASTER <-> REPLICA synchronization: %s",
+                server.rdb_filename, strerror(errno));
+            cancelReplicationHandshake(1);
+            return;
+        }
 
         if (rdbLoad(server.rdb_filename,&rsi,RDBFLAGS_REPLICATION) != C_OK) {
             serverLog(LL_WARNING,

--- a/src/util.c
+++ b/src/util.c
@@ -941,6 +941,11 @@ int fsyncFileDir(const char *filename) {
     char *dname;
     int dir_fd;
 
+    if (strlen(filename) > PATH_MAX) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+
     /* In the glibc implementation dirname may modify their argument. */
     memcpy(temp_filename, filename, strlen(filename) + 1);
     dname = dirname(temp_filename);

--- a/src/util.c
+++ b/src/util.c
@@ -952,9 +952,9 @@ int fsyncFileDir(const char *filename) {
 
     dir_fd = open(dname, O_RDONLY);
     if (dir_fd == -1) {
-        /* Some OSs don't allow us to open directories at all (Windows returns
-         * EACCES), just ignore the error in that case */
-        if (errno == EISDIR || errno == EACCES) {
+        /* Some OSs don't allow us to open directories at all, just
+         * ignore the error in that case */
+        if (errno == EISDIR) {
             return 0;
         }
         return -1;

--- a/src/util.c
+++ b/src/util.c
@@ -952,10 +952,19 @@ int fsyncFileDir(const char *filename) {
 
     dir_fd = open(dname, O_RDONLY);
     if (dir_fd == -1) {
+        /* Some OSs don't allow us to open directories at all (Windows returns
+	     * EACCES), just ignore the error in that case */
+        if (errno == EISDIR || errno == EACCES) {
+		    return 0;
+        }
         return -1;
     }
-    if (redis_fsync(dir_fd) == -1) {
+    /* Some OSs don't allow us to fsync directories at all, so we can ignore
+	 * those errors. */
+    if (redis_fsync(dir_fd) == -1 && !(errno == EBADF || errno == EINVAL)) {
+        int	save_errno = errno;
         close(dir_fd);
+        errno = save_errno;
         return -1;
     }
     

--- a/src/util.c
+++ b/src/util.c
@@ -955,12 +955,12 @@ int fsyncFileDir(const char *filename) {
         /* Some OSs don't allow us to open directories at all (Windows returns
          * EACCES), just ignore the error in that case */
         if (errno == EISDIR || errno == EACCES) {
-		    return 0;
+            return 0;
         }
         return -1;
     }
     /* Some OSs don't allow us to fsync directories at all, so we can ignore
-	 * those errors. */
+     * those errors. */
     if (redis_fsync(dir_fd) == -1 && !(errno == EBADF || errno == EINVAL)) {
         int save_errno = errno;
         close(dir_fd);

--- a/src/util.c
+++ b/src/util.c
@@ -953,7 +953,7 @@ int fsyncFileDir(const char *filename) {
     dir_fd = open(dname, O_RDONLY);
     if (dir_fd == -1) {
         /* Some OSs don't allow us to open directories at all (Windows returns
-	     * EACCES), just ignore the error in that case */
+         * EACCES), just ignore the error in that case */
         if (errno == EISDIR || errno == EACCES) {
 		    return 0;
         }
@@ -962,7 +962,7 @@ int fsyncFileDir(const char *filename) {
     /* Some OSs don't allow us to fsync directories at all, so we can ignore
 	 * those errors. */
     if (redis_fsync(dir_fd) == -1 && !(errno == EBADF || errno == EINVAL)) {
-        int	save_errno = errno;
+        int save_errno = errno;
         close(dir_fd);
         errno = save_errno;
         return -1;

--- a/src/util.c
+++ b/src/util.c
@@ -933,6 +933,10 @@ sds makePath(char *path, char *filename) {
  * 4. rename the temp file to the appropriate name
  * 5. fsync() the containing directory */
 int fsyncFileDir(const char *filename) {
+#ifdef _AIX
+    /* AIX is unable to fsync a directory */
+    return 0;
+#endif
     char temp_filename[PATH_MAX + 1];
     char *dname;
     int dir_fd;

--- a/src/util.h
+++ b/src/util.h
@@ -85,6 +85,7 @@ int dirExists(char *dname);
 int dirRemove(char *dname);
 int fileExist(char *filename);
 sds makePath(char *path, char *filename);
+int fsyncFileDir(const char *filename);
 
 #ifdef REDIS_TEST
 int utilTest(int argc, char **argv, int flags);


### PR DESCRIPTION
The current process to persist files is `write` the data, `fsync` and `rename` the file, but a underlying problem is that the rename may be lost when a sudden crash like power outage and the directory hasn't been persisted.

The article [Ensuring data reaches disk](https://lwn.net/Articles/457667/) mentions a safe way to update file should be:
1. create a new temp file (on the same file system!)
2. write data to the temp file
3. fsync() the temp file
4. rename the temp file to the appropriate name
5. fsync() the containing directory

Referring to [Leveldb](https://github.com/google/leveldb/blob/d019e3605f222ebc5a3a2484a2cb29db537551dd/util/env_posix.cc#L334 ) , 
```
  Status Sync() override {
    // Ensure new files referred to by the manifest are in the filesystem.
    //
    // This needs to happen before the manifest file is flushed to disk, to
    // avoid crashing in a state where the manifest refers to files that are not
    // yet on disk.
    Status status = SyncDirIfManifest();
    if (!status.ok()) {
      return status;
    }

    status = FlushBuffer();
    if (!status.ok()) {
      return status;
    }

    return SyncFd(fd_, filename_);
  }
```
So we should also fsync the directory to ensure the safety.

This PR handles CONFIG REWRITE, AOF manifest, and RDB file (both for persistence, and the one the replica gets from the master).
It doesn't handle (yet), ACL SAVE and Cluster configs, since these don't yet follow this pattern.