### PR TITLE
Add state to the Rax iterator to avoid re-scans for children

### DIFF
--- a/src/rax.c
+++ b/src/rax.c
@@ -1646,7 +1646,7 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
      * perform a lookup, and later invoke the prev/next key code that
      * we already use for iteration. */
     int splitpos = 0;
-    size_t i = raxLowWalkSeek(ele,len,&splitpos, it);
+    size_t i = raxLowWalkSeek(it, ele, len, &splitpos);
 
     /* Return OOM on incomplete stack info. */
     if (it->stack.oom) return 0;

--- a/src/rax.c
+++ b/src/rax.c
@@ -527,7 +527,7 @@ int raxIteratorPushChildOffset(raxIterator *it, uint8_t child_offset) {
     return 1;
 }
 
- uint8_t raxIteratorPopChildOffset(raxIterator *it) {
+uint8_t raxIteratorPopChildOffset(raxIterator *it) {
     if (it->cpos == 0) return 0;
     it->cpos--;
     return it->child_offset_stack[it->cpos];

--- a/src/rax.c
+++ b/src/rax.c
@@ -1460,8 +1460,6 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
     uint8_t orig_child_offset = it->child_offset;
 
     while(1) {
-        int old_noup = noup;
-
         /* Already on head? Can't go up, iteration finished. */
         if (!noup && it->node == it->rt->head) {
             it->flags |= RAX_ITER_EOF;
@@ -1485,8 +1483,8 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
 
         /* Try visiting the prev child if there is at least one
          * child. */
-        if (!it->node->iscompr && it->child_offset >= (old_noup ? 0 : 1)) {
-            it->child_offset -= (old_noup ? 0 : 1);
+        if (!it->node->iscompr && it->child_offset >= 1) {
+            it->child_offset -= 1;
             raxNode **cp = raxNodeFirstChildPtr(it->node) + it->child_offset;
             debugf("SCAN found a new node\n");
             /* Enter the node we just found. */

--- a/src/rax.c
+++ b/src/rax.c
@@ -534,9 +534,9 @@ uint8_t raxIteratorPopChildOffset(raxIterator *it) {
 }
 
 /* See cmts in raxLowWalk() above */
-static inline size_t raxLowWalkSeek(
-    unsigned char *s, size_t len, int *splitpos, raxIterator* it
-) {
+static inline size_t raxLowWalkSeek(raxIterator* it, unsigned char *s,
+                                    size_t len, int *splitpos)
+{
     raxNode *h = it->rt->head;
 
     size_t i = 0;

--- a/src/rax.c
+++ b/src/rax.c
@@ -1460,8 +1460,6 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
     uint8_t orig_child_offset = it->child_offset;
 
     while(1) {
-        int old_noup = noup;
-
         /* Already on head? Can't go up, iteration finished. */
         if (!noup && it->node == it->rt->head) {
             it->flags |= RAX_ITER_EOF;
@@ -1485,8 +1483,8 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
 
         /* Try visiting the prev child if there is at least one
          * child. */
-        if (!it->node->iscompr && it->node->size > (old_noup ? 0 : 1) && it->child_offset != 0) {
-            it->child_offset -= 1;
+        if (!it->node->iscompr && it->child_offset >= (noup ? 0 : 1)) {
+            it->child_offset -= (noup ? 0 : 1);
             raxNode **cp = raxNodeFirstChildPtr(it->node) + it->child_offset;
             debugf("SCAN found a new node\n");
             /* Enter the node we just found. */

--- a/src/rax.c
+++ b/src/rax.c
@@ -492,7 +492,6 @@ static inline size_t raxLowWalk(
 
     size_t i = 0; /* Position in the string. */
     size_t j = 0; /* Position in the node children (or bytes if compressed).*/
-    size_t k = 0; /* Current child offset or mismatch offset */
     while(h->size && i < len) {
         debugnode("Lookup current node",h);
         unsigned char *v = h->data;
@@ -505,15 +504,7 @@ static inline size_t raxLowWalk(
             for (j = 0; j < h->size; j++) {
                 if (v[j] >= s[i]) break;
             }
-            if (v[j] > s[i]) {
-                k = j;
-                j = h->size;
-                break;
-            }
-            if (j == h->size) {
-                k = j;
-                break;
-            }
+            if (v[j] > s[i] || j == h->size) break;
             i++;
         } else {
             /* Even when h->size is large, linear scan provides good
@@ -538,7 +529,7 @@ static inline size_t raxLowWalk(
     }
     debugnode("Lookup stop node is",h);
     if (stopnode) *stopnode = h;
-    if (stopoffset) *stopoffset = k;
+    if (stopoffset) *stopoffset = j;
     if (plink) *plink = parentlink;
     if (splitpos && h->iscompr) *splitpos = j;
     return i;

--- a/src/rax.c
+++ b/src/rax.c
@@ -144,7 +144,7 @@ static inline int raxStackPush(raxStack *ts, void *ptr, uint8_t offset) {
 
 /* Pop an item from the stack, the function returns NULL if there are no
  * items to pop. */
-static inline void *raxStackPop(raxStack *ts, uint8_t* poffset) {
+static inline void *raxStackPop(raxStack *ts, uint8_t *poffset) {
     if (ts->items == 0) {
         if (poffset != NULL) *poffset = 0;
         return NULL;

--- a/src/rax.c
+++ b/src/rax.c
@@ -199,9 +199,11 @@ raxNode *raxNewNode(size_t children, int datafield) {
     return node;
 }
 
-/* Allocate a new rax and return its pointer. */
+/* Allocate a new rax and return its pointer. On out of memory the function
+ * returns NULL. */
 rax *raxNew(void) {
     rax *rax = rax_malloc(sizeof(*rax));
+    if (rax == NULL) return NULL;
     rax->numele = 0;
     rax->numnodes = 1;
     rax->head = raxNewNode(0,0);
@@ -1158,6 +1160,12 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
             size_t nodesize =
                 sizeof(raxNode)+comprsize+raxPadding(comprsize)+sizeof(raxNode*);
             raxNode *new = rax_malloc(nodesize);
+            /* An out of memory here just means we cannot optimize this
+             * node, but the tree is left in a consistent state. */
+            if (new == NULL) {
+                raxStackFree(&ts);
+                return 1;
+            }
             new->iskey = 0;
             new->isnull = 0;
             new->iscompr = 1;

--- a/src/rax.c
+++ b/src/rax.c
@@ -483,10 +483,9 @@ raxNode *raxCompressNode(raxNode *n, unsigned char *s, size_t len, raxNode **chi
  * means that the current node represents the key (that is, none of the
  * compressed node characters are needed to represent the key, just all
  * its parents nodes). */
-static inline size_t raxLowWalk(
-    rax *rax, unsigned char *s, size_t len, raxNode **stopnode, raxNode ***plink, int *splitpos, raxStack *ts,
-    uint8_t *stopoffset
-) {
+static inline size_t raxLowWalk(rax *rax, unsigned char *s, size_t len, raxNode **stopnode,
+                                raxNode ***plink, int *splitpos, raxStack *ts, uint8_t *stopoffset)
+{
     raxNode *h = rax->head;
     raxNode **parentlink = &rax->head;
 
@@ -551,7 +550,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
     raxNode *h, **parentlink;
 
     debugf("### Insert %.*s with value %p\n", (int)len, s, data);
-    i = raxLowWalk(rax,s,len,&h,&parentlink,&j,NULL, NULL);
+    i = raxLowWalk(rax,s,len,&h,&parentlink,&j,NULL,NULL);
 
     /* If i == len we walked following the whole string. If we are not
      * in the middle of a compressed node, the string is either already
@@ -956,7 +955,7 @@ void *raxFind(rax *rax, unsigned char *s, size_t len) {
 
     debugf("### Lookup: %.*s\n", (int)len, s);
     int splitpos = 0;
-    size_t i = raxLowWalk(rax,s,len,&h,NULL,&splitpos,NULL, NULL);
+    size_t i = raxLowWalk(rax,s,len,&h,NULL,&splitpos,NULL,NULL);
     if (i != len || (h->iscompr && splitpos != 0) || !h->iskey)
         return raxNotFound;
     return raxGetData(h);
@@ -1038,7 +1037,7 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
     debugf("### Delete: %.*s\n", (int)len, s);
     raxStackInit(&ts);
     int splitpos = 0;
-    size_t i = raxLowWalk(rax,s,len,&h,NULL,&splitpos,&ts, NULL);
+    size_t i = raxLowWalk(rax,s,len,&h,NULL,&splitpos,&ts,NULL);
     if (i != len || (h->iscompr && splitpos != 0) || !h->iskey) {
         raxStackFree(&ts);
         return 0;

--- a/src/rax.c
+++ b/src/rax.c
@@ -1361,6 +1361,7 @@ void raxStart(raxIterator *it, rax *rt) {
  * is a low level function used to implement the iterator, not callable by
  * the user. Returns 0 on out of memory, otherwise 1 is returned. */
 int raxIteratorAddChars(raxIterator *it, unsigned char *s, size_t len) {
+    if (len == 0) return 1;
     if (it->key_max < it->key_len+len) {
         unsigned char *old = (it->key == it->key_static_string) ? NULL :
                                                                   it->key;
@@ -1473,7 +1474,7 @@ int raxIteratorNextStep(raxIterator *it, int noup) {
                 if (!it->node->iscompr && it->node->size > (old_noup ? 0 : 1)) {
                     debugf("it->node->size: %d\n", it->node->size);
                     if (it->child_offset + (old_noup ? 0 : 1) != it->node->size) {
-                        it->child_offset += (old_noup ? 0 : 1); // set parent offset to current child
+                        it->child_offset += (old_noup ? 0 : 1); /* set parent offset to current child */
                         raxNode **cp = raxNodeFirstChildPtr(it->node) + it->child_offset;
                         debugf("SCAN found a new node\n");
                         raxIteratorAddChars(it,it->node->data + it->child_offset, 1);

--- a/src/rax.c
+++ b/src/rax.c
@@ -1396,26 +1396,23 @@ int raxIteratorNextStep(raxIterator *it, int noup) {
 
                 /* Try visiting the next child if there was at least one
                  * additional child. */
-                if (!it->node->iscompr && it->node->size > (old_noup ? 0 : 1)) {
-                    debugf("it->node->size: %d\n", it->node->size);
-                    if (it->child_offset + (old_noup ? 0 : 1) != it->node->size) {
-                        it->child_offset += (old_noup ? 0 : 1); /* set parent offset to current child */
-                        raxNode **cp = raxNodeFirstChildPtr(it->node) + it->child_offset;
-                        debugf("SCAN found a new node\n");
-                        raxIteratorAddChars(it,it->node->data + it->child_offset, 1);
-                        if (!raxStackPush(&it->stack, it->node, it->child_offset)) return 0;
-                        memcpy(&it->node,cp,sizeof(it->node));
-                        it->child_offset = 0;
-                        /* Call the node callback if any, and replace the node
-                         * pointer if the callback returns true. */
-                        if (it->node_cb && it->node_cb(&it->node))
-                            memcpy(cp,&it->node,sizeof(it->node));
-                        if (it->node->iskey) {
-                            it->data = raxGetData(it->node);
-                            return 1;
-                        }
-                        break;
+                if (!it->node->iscompr && it->child_offset + (old_noup ? 0 : 1) != it->node->size) {
+                    it->child_offset += (old_noup ? 0 : 1); /* set parent offset to current child */
+                    raxNode **cp = raxNodeFirstChildPtr(it->node) + it->child_offset;
+                    debugf("SCAN found a new node\n");
+                    raxIteratorAddChars(it,it->node->data + it->child_offset, 1);
+                    if (!raxStackPush(&it->stack, it->node, it->child_offset)) return 0;
+                    memcpy(&it->node,cp,sizeof(it->node));
+                    it->child_offset = 0;
+                    /* Call the node callback if any, and replace the node
+                        * pointer if the callback returns true. */
+                    if (it->node_cb && it->node_cb(&it->node))
+                        memcpy(cp,&it->node,sizeof(it->node));
+                    if (it->node->iskey) {
+                        it->data = raxGetData(it->node);
+                        return 1;
                     }
+                    break;
                 }
             }
         }

--- a/src/rax.c
+++ b/src/rax.c
@@ -1485,18 +1485,16 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
 
         /* Try visiting the prev child if there is at least one
          * child. */
-        if (!it->node->iscompr && it->node->size > (old_noup ? 0 : 1)) {
-            if (it->child_offset != 0) {
-                it-> child_offset -= 1;
-                raxNode **cp = raxNodeFirstChildPtr(it->node) + it->child_offset;
-                debugf("SCAN found a new node\n");
-                /* Enter the node we just found. */
-                if (!raxIteratorAddChars(it,it->node->data + it->child_offset, 1)) return 0;
-                if (!raxStackPush(&it->stack, it->node, it->child_offset)) return 0;
-                memcpy(&it->node,cp,sizeof(it->node));
-                /* Seek sub-tree max. */
-                if (!raxSeekGreatest(it)) return 0;
-            }
+        if (!it->node->iscompr && it->node->size > (old_noup ? 0 : 1) && it->child_offset != 0) {
+            it->child_offset -= 1;
+            raxNode **cp = raxNodeFirstChildPtr(it->node) + it->child_offset;
+            debugf("SCAN found a new node\n");
+            /* Enter the node we just found. */
+            if (!raxIteratorAddChars(it,it->node->data + it->child_offset, 1)) return 0;
+            if (!raxStackPush(&it->stack, it->node, it->child_offset)) return 0;
+            memcpy(&it->node,cp,sizeof(it->node));
+            /* Seek sub-tree max. */
+            if (!raxSeekGreatest(it)) return 0;
         }
 
         /* Return the key: this could be the key we found scanning a new

--- a/src/rax.c
+++ b/src/rax.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <math.h>
-#include <ctype.h>
 #include "rax.h"
 
 #ifndef RAX_MALLOC_INCLUDE

--- a/src/rax.c
+++ b/src/rax.c
@@ -1460,6 +1460,8 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
     uint8_t orig_child_offset = it->child_offset;
 
     while(1) {
+        int old_noup = noup;
+
         /* Already on head? Can't go up, iteration finished. */
         if (!noup && it->node == it->rt->head) {
             it->flags |= RAX_ITER_EOF;
@@ -1483,8 +1485,8 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
 
         /* Try visiting the prev child if there is at least one
          * child. */
-        if (!it->node->iscompr && it->child_offset >= (noup ? 0 : 1)) {
-            it->child_offset -= (noup ? 0 : 1);
+        if (!it->node->iscompr && it->child_offset >= (old_noup ? 0 : 1)) {
+            it->child_offset -= (old_noup ? 0 : 1);
             raxNode **cp = raxNodeFirstChildPtr(it->node) + it->child_offset;
             debugf("SCAN found a new node\n");
             /* Enter the node we just found. */

--- a/src/rax.c
+++ b/src/rax.c
@@ -95,23 +95,43 @@ static inline void raxStackInit(raxStack *ts) {
     ts->stack = ts->static_items;
     ts->items = 0;
     ts->maxitems = RAX_STACK_STATIC_ITEMS;
+    ts->oom = 0;
     ts->offsets = ts->static_offsets;
 }
 
-/* Push an item into the stack. */
-static inline void raxStackPush(raxStack *ts, void *ptr, uint8_t offset) {
+/* Push an item into the stack, returns 1 on success, 0 on out of memory. */
+static inline int raxStackPush(raxStack *ts, void *ptr, uint8_t offset) {
     if (ts->items == ts->maxitems) {
         if (ts->stack == ts->static_items) {
             ts->stack = rax_malloc(sizeof(void*)*ts->maxitems*2);
+            if (ts->stack == NULL) {
+                ts->stack = ts->static_items;
+                ts->oom = 1;
+                errno = ENOMEM;
+                return 0;
+            }
             memcpy(ts->stack,ts->static_items,sizeof(void*)*ts->maxitems);
         } else {
             void **newalloc = rax_realloc(ts->stack,sizeof(void*)*ts->maxitems*2);
+            if (newalloc == NULL) {
+                ts->oom = 1;
+                errno = ENOMEM;
+                return 0;
+            }
             ts->stack = newalloc;
         }
 
         uint8_t *old = ts->offsets == ts->static_offsets ? NULL : ts->offsets;
         size_t new_max = ts->maxitems * 2;
         ts->offsets = rax_realloc(old, new_max);
+
+        if (ts->offsets == NULL) {
+            ts->offsets = (!old) ? ts->static_offsets : old;
+            ts->oom = 1;
+            errno = ENOMEM;
+            return 0;
+        }
+
         if (old == NULL) memcpy(ts->offsets, ts->static_offsets, ts->maxitems);
         ts->maxitems *= 2;
     }
@@ -119,7 +139,7 @@ static inline void raxStackPush(raxStack *ts, void *ptr, uint8_t offset) {
     ts->stack[ts->items] = ptr;
     ts->offsets[ts->items] = offset;
     ts->items++;
-    return;
+    return 1;
 }
 
 /* Pop an item from the stack, the function returns NULL if there are no
@@ -135,7 +155,7 @@ static inline void *raxStackPop(raxStack *ts, uint8_t *poffset) {
     return ts->stack[ts->items];
 }
 
-/* Return the stack item and offset at the top of the stack without actually consuming
+/* Return the stack item at the top of the stack without actually consuming
  * it. */
 static inline void *raxStackPeek(raxStack *ts) {
     if (ts->items == 0) return NULL;
@@ -192,6 +212,7 @@ raxNode *raxNewNode(size_t children, int datafield) {
                       sizeof(raxNode*)*children;
     if (datafield) nodesize += sizeof(void*);
     raxNode *node = rax_malloc(nodesize);
+    if (node == NULL) return NULL;
     node->iskey = 0;
     node->isnull = 0;
     node->iscompr = 0;
@@ -207,11 +228,16 @@ rax *raxNew(void) {
     rax->numele = 0;
     rax->numnodes = 1;
     rax->head = raxNewNode(0,0);
-    return rax;
+    if (rax->head == NULL) {
+        rax_free(rax);
+        return NULL;
+    } else {
+        return rax;
+    }
 }
 
 /* realloc the node to make room for auxiliary data in order
- * to store an item in that node. */
+ * to store an item in that node. On out of memory NULL is returned. */
 raxNode *raxReallocForData(raxNode *n, void *data) {
     if (data == NULL) return n; /* No reallocation needed, setting isnull=1 */
     size_t curlen = raxNodeCurrentLength(n);
@@ -248,7 +274,7 @@ void *raxGetData(raxNode *n) {
  *
  * On success the new parent node pointer is returned (it may change because
  * of the realloc, so the caller should discard 'n' and use the new value).
- */
+ * On out of memory NULL is returned, and the old node is still valid. */
 raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode ***parentlink) {
     assert(n->iscompr == 0);
 
@@ -260,9 +286,14 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
 
     /* Alloc the new child we will link to 'n'. */
     raxNode *child = raxNewNode(0,0);
+    if (child == NULL) return NULL;
 
     /* Make space in the original node. */
     raxNode *newn = rax_realloc(n,newlen);
+    if (newn == NULL) {
+        rax_free(child);
+        return NULL;
+    }
     n = newn;
 
     /* After the reallocation, we have up to 8/16 (depending on the system
@@ -394,6 +425,7 @@ raxNode *raxCompressNode(raxNode *n, unsigned char *s, size_t len, raxNode **chi
 
     /* Allocate the child to link to this node. */
     *child = raxNewNode(0,0);
+    if (*child == NULL) return NULL;
 
     /* Make space in the parent node. */
     newsize = sizeof(raxNode)+len+raxPadding(len)+sizeof(raxNode*);
@@ -402,6 +434,10 @@ raxNode *raxCompressNode(raxNode *n, unsigned char *s, size_t len, raxNode **chi
         if (!n->isnull) newsize += sizeof(void*);
     }
     raxNode *newn = rax_realloc(n,newsize);
+    if (newn == NULL) {
+        rax_free(*child);
+        return NULL;
+    }
     n = newn;
 
     n->iscompr = 1;
@@ -565,6 +601,10 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         if (!h->iskey || (h->isnull && overwrite)) {
             h = raxReallocForData(h,data);
             if (h) memcpy(parentlink,&h,sizeof(h));
+        }
+        if (h == NULL) {
+            errno = ENOMEM;
+            return 0;
         }
 
         /* Update the existing key if there is already one. */
@@ -749,6 +789,17 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             postfix = rax_malloc(nodesize);
         }
 
+        /* OOM? Abort now that the tree is untouched. */
+        if (splitnode == NULL ||
+            (trimmedlen && trimmed == NULL) ||
+            (postfixlen && postfix == NULL))
+        {
+            rax_free(splitnode);
+            rax_free(trimmed);
+            rax_free(postfix);
+            errno = ENOMEM;
+            return 0;
+        }
         splitnode->data[0] = h->data[j];
 
         if (j == 0) {
@@ -818,6 +869,13 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         if (h->iskey && !h->isnull) nodesize += sizeof(void*);
         raxNode *trimmed = rax_malloc(nodesize);
 
+        if (postfix == NULL || trimmed == NULL) {
+            rax_free(postfix);
+            rax_free(trimmed);
+            errno = ENOMEM;
+            return 0;
+        }
+
         /* 1: Save next pointer. */
         raxNode **childfield = raxNodeLastChildPtr(h);
         raxNode *next;
@@ -872,6 +930,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             if (comprsize > RAX_NODE_MAX_SIZE)
                 comprsize = RAX_NODE_MAX_SIZE;
             raxNode *newh = raxCompressNode(h,s+i,comprsize,&child);
+            if (newh == NULL) goto oom;
             h = newh;
             memcpy(parentlink,&h,sizeof(h));
             parentlink = raxNodeLastChildPtr(h);
@@ -880,6 +939,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             debugf("Inserting normal node\n");
             raxNode **new_parentlink;
             raxNode *newh = raxAddChild(h,s[i],&child,&new_parentlink);
+            if (newh == NULL) goto oom;
             h = newh;
             memcpy(parentlink,&h,sizeof(h));
             parentlink = new_parentlink;
@@ -889,11 +949,27 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         h = child;
     }
     raxNode *newh = raxReallocForData(h,data);
+    if (newh == NULL) goto oom;
     h = newh;
     if (!h->iskey) rax->numele++;
     raxSetData(h,data);
     memcpy(parentlink,&h,sizeof(h));
     return 1; /* Element inserted. */
+
+oom:
+    /* This code path handles out of memory after part of the sub-tree was
+     * already modified. Set the node as a key, and then remove it. However we
+     * do that only if the node is a terminal node, otherwise if the OOM
+     * happened reallocating a node in the middle, we don't need to free
+     * anything. */
+    if (h->size == 0) {
+        h->isnull = 1;
+        h->iskey = 1;
+        rax->numele++; /* Compensate the next remove. */
+        assert(raxRemove(rax,s,i,NULL) != 0);
+    }
+    errno = ENOMEM;
+    return 0;
 }
 
 /* Overwriting insert. Just a wrapper for raxGenericInsert() that will
@@ -1009,7 +1085,9 @@ raxNode *raxRemoveChild(raxNode *parent, raxNode *child) {
     if (newnode) {
         debugnode("raxRemoveChild after", newnode);
     }
-    return newnode;
+    /* Note: if rax_realloc() fails we just return the old address, which
+     * is valid. */
+    return newnode ? newnode : parent;
 }
 
 /* Remove the specified item. Returns 1 if the item was found and
@@ -1080,6 +1158,10 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
          * further compression with adjacent nodes is potentially possible. */
         trycompress = 1;
     }
+
+    /* Don't try node compression if our nodes pointers stack is not
+     * complete because of OOM while executing raxLowWalk() */
+    if (trycompress && ts.oom) trycompress = 0;
 
     /* Recompression: if trycompress is true, 'h' points to a radix tree node
      * that changed in a way that could allow to compress nodes in this
@@ -1260,14 +1342,19 @@ void raxStart(raxIterator *it, rax *rt) {
 
 /* Append characters at the current key string of the iterator 'it'. This
  * is a low level function used to implement the iterator, not callable by
- * the user. */
-void raxIteratorAddChars(raxIterator *it, unsigned char *s, size_t len) {
-    if (len == 0) return;
+ * the user. Returns 0 on out of memory, otherwise 1 is returned. */
+int raxIteratorAddChars(raxIterator *it, unsigned char *s, size_t len) {
+    if (len == 0) return 1;
     if (it->key_max < it->key_len+len) {
         unsigned char *old = (it->key == it->key_static_string) ? NULL :
                                                                   it->key;
         size_t new_max = (it->key_len+len)*2;
         it->key = rax_realloc(old,new_max);
+        if (it->key == NULL) {
+            it->key = (!old) ? it->key_static_string : old;
+            errno = ENOMEM;
+            return 0;
+        }
         if (old == NULL) memcpy(it->key,it->key_static_string,it->key_len);
         it->key_max = new_max;
     }
@@ -1275,7 +1362,7 @@ void raxIteratorAddChars(raxIterator *it, unsigned char *s, size_t len) {
      * it->key when we use the current key in order to re-seek. */
     memmove(it->key+it->key_len,s,len);
     it->key_len += len;
-    return;
+    return 1;
 }
 
 /* Remove the specified number of chars from the right of the current
@@ -1295,13 +1382,15 @@ void raxIteratorDelChars(raxIterator *it, size_t count) {
  * the parent will be skipped. This option is used by raxSeek() when
  * implementing seeking a non existing element with the ">" or "<" options:
  * the starting node is not a key in that particular case, so we start the scan
- * from a node that does not represent the key set. */
-void raxIteratorNextStep(raxIterator *it, int noup) {
+ * from a node that does not represent the key set.
+ *
+ * The function returns 1 on success or 0 on out of memory. */
+int raxIteratorNextStep(raxIterator *it, int noup) {
     if (it->flags & RAX_ITER_EOF) {
-        return;
+        return 1;
     } else if (it->flags & RAX_ITER_JUST_SEEKED) {
         it->flags &= ~RAX_ITER_JUST_SEEKED;
-        return;
+        return 1;
     }
 
     /* Save key len, stack items and the node where we are currently
@@ -1317,10 +1406,10 @@ void raxIteratorNextStep(raxIterator *it, int noup) {
             /* Seek the lexicographically smaller key in this subtree, which
              * is the first one found always going towards the first child
              * of every successive node. */
-            raxStackPush(&it->stack, it->node, it->child_offset);
+            if (!raxStackPush(&it->stack, it->node, it->child_offset)) return 0;
             raxNode **cp = raxNodeFirstChildPtr(it->node);
-            raxIteratorAddChars(it,it->node->data,
-                it->node->iscompr ? it->node->size : 1);
+            if (!raxIteratorAddChars(it,it->node->data,
+                it->node->iscompr ? it->node->size : 1)) return 0;
             memcpy(&it->node,cp,sizeof(it->node));
             it->child_offset = 0;
             /* Call the node callback if any, and replace the node pointer
@@ -1332,7 +1421,7 @@ void raxIteratorNextStep(raxIterator *it, int noup) {
              * what follows in the sub-children. */
             if (it->node->iskey) {
                 it->data = raxGetData(it->node);
-                return;
+                return 1;
             }
         } else {
             /* If we finished exploring the previous sub-tree, switch to the
@@ -1348,7 +1437,7 @@ void raxIteratorNextStep(raxIterator *it, int noup) {
                     it->stack.items = orig_stack_items;
                     it->key_len = orig_key_len;
                     it->node = orig_node;
-                    return;
+                    return 1;
                 }
                 /* If there are no children at the current node, try parent's
                  * next child. */
@@ -1371,7 +1460,7 @@ void raxIteratorNextStep(raxIterator *it, int noup) {
                         raxNode **cp = raxNodeFirstChildPtr(it->node) + it->child_offset;
                         debugf("SCAN found a new node\n");
                         raxIteratorAddChars(it,it->node->data + it->child_offset, 1);
-                        raxStackPush(&it->stack, it->node, it->child_offset);
+                        if (!raxStackPush(&it->stack, it->node, it->child_offset)) return 0;
                         memcpy(&it->node,cp,sizeof(it->node));
                         it->child_offset = 0;
                         /* Call the node callback if any, and replace the node
@@ -1380,7 +1469,7 @@ void raxIteratorNextStep(raxIterator *it, int noup) {
                             memcpy(cp,&it->node,sizeof(it->node));
                         if (it->node->iskey) {
                             it->data = raxGetData(it->node);
-                            return;
+                            return 1;
                         }
                         break;
                     }
@@ -1393,33 +1482,34 @@ void raxIteratorNextStep(raxIterator *it, int noup) {
 /* Seek the greatest key in the subtree at the current node. Return 0 on
  * out of memory, otherwise 1. This is a helper function for different
  * iteration functions below. */
-void raxSeekGreatest(raxIterator *it) {
+int raxSeekGreatest(raxIterator *it) {
     while(it->node->size) {
         uint8_t child_offset;
         if (it->node->iscompr) {
-            raxIteratorAddChars(it,it->node->data, it->node->size);
+            if (!raxIteratorAddChars(it,it->node->data, it->node->size)) return 0;
             child_offset = 0;
         } else {
-            raxIteratorAddChars(it,it->node->data+it->node->size-1,1);
+            if (!raxIteratorAddChars(it,it->node->data+it->node->size-1,1))
+                return 0;
             child_offset = it->node->size - 1;
         }
         raxNode **cp = raxNodeLastChildPtr(it->node);
-        raxStackPush(&it->stack, it->node, child_offset);
+        if (!raxStackPush(&it->stack, it->node, child_offset)) return 0;
         memcpy(&it->node,cp,sizeof(it->node));
         it->child_offset = 0; /* placeholder will be overwritten on next iteration */
     }
-    return;
+    return 1;
 }
 
 /* Like raxIteratorNextStep() but implements an iteration step moving
  * to the lexicographically previous element. The 'noup' option has a similar
  * effect to the one of raxIteratorNextStep(). */
-void raxIteratorPrevStep(raxIterator *it, int noup) {
+int raxIteratorPrevStep(raxIterator *it, int noup) {
     if (it->flags & RAX_ITER_EOF) {
-        return;
+        return 1;
     } else if (it->flags & RAX_ITER_JUST_SEEKED) {
         it->flags &= ~RAX_ITER_JUST_SEEKED;
-        return;
+        return 1;
     }
 
     /* Save key len, stack items and the node where we are currently
@@ -1437,7 +1527,7 @@ void raxIteratorPrevStep(raxIterator *it, int noup) {
             it->stack.items = orig_stack_items;
             it->key_len = orig_key_len;
             it->node = orig_node;
-            return;
+            return 1;
         }
 
         if (!noup) {
@@ -1459,11 +1549,11 @@ void raxIteratorPrevStep(raxIterator *it, int noup) {
                 raxNode **cp = raxNodeFirstChildPtr(it->node) + it->child_offset;
                 debugf("SCAN found a new node\n");
                 /* Enter the node we just found. */
-                raxIteratorAddChars(it,it->node->data + it->child_offset, 1);
-                raxStackPush(&it->stack, it->node, it->child_offset);
+                if (!raxIteratorAddChars(it,it->node->data + it->child_offset, 1)) return 0;
+                if (!raxStackPush(&it->stack, it->node, it->child_offset)) return 0;
                 memcpy(&it->node,cp,sizeof(it->node));
                 /* Seek sub-tree max. */
-                raxSeekGreatest(it);
+                if (!raxSeekGreatest(it)) return 0;
             }
         }
 
@@ -1472,14 +1562,15 @@ void raxIteratorPrevStep(raxIterator *it, int noup) {
          * before giving up with this node, check if it's a key itself. */
         if (it->node->iskey) {
             it->data = raxGetData(it->node);
-            return;
+            return 1;
         }
     }
 }
 
 /* Seek an iterator at the specified element.
- * Return 0 if the seek failed for syntax error. Otherwise
- * 1 is returned. */
+ * Return 0 if the seek failed for syntax error or out of memory. Otherwise
+ * 1 is returned. When 0 is returned for out of memory, errno is set to
+ * the ENOMEM value. */
 int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
     int eq = 0, lt = 0, gt = 0, first = 0, last = 0;
 
@@ -1525,7 +1616,7 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
         /* Find the greatest key taking always the last child till a
          * final node is found. */
         it->node = it->rt->head;
-        raxSeekGreatest(it);
+        if (!raxSeekGreatest(it)) return 0;
         assert(it->node->iskey);
         it->data = raxGetData(it->node);
         return 1;
@@ -1537,12 +1628,15 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
     int splitpos = 0;
     size_t i = raxLowWalkSeek(it, ele, len, &splitpos);
 
+    /* Return OOM on incomplete stack info. */
+    if (it->stack.oom) return 0;
+
     if (eq && i == len && (!it->node->iscompr || splitpos == 0) &&
         it->node->iskey)
     {
         /* We found our node, since the key matches and we have an
          * "equal" condition. */
-        raxIteratorAddChars(it,ele,len);
+        if (!raxIteratorAddChars(it,ele,len)) return 0; /* OOM. */
         it->data = raxGetData(it->node);
     } else if (lt || gt) {
         /* Exact key not found or eq flag not set. We have to set as current
@@ -1560,13 +1654,13 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
              * and call the iterator with the 'noup' flag so that it will try
              * to seek the next/prev child in the current node directly based
              * on the mismatching character. */
-            raxIteratorAddChars(it,ele+i,1);
+            if (!raxIteratorAddChars(it,ele+i,1)) return 0;
             debugf("Seek normal node on mismatch: %.*s\n",
                 (int)it->key_len, (char*)it->key);
 
             it->flags &= ~RAX_ITER_JUST_SEEKED;
-            if (lt) raxIteratorPrevStep(it,1);
-            if (gt) raxIteratorNextStep(it,1);
+            if (lt && !raxIteratorPrevStep(it,1)) return 0;
+            if (gt && !raxIteratorNextStep(it,1)) return 0;
             it->flags |= RAX_ITER_JUST_SEEKED; /* Ignore next call. */
         } else if (i != len && it->node->iscompr) {
             debugf("Compressed mismatch: %.*s\n",
@@ -1580,10 +1674,11 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
                  * than our seek element, continue forward, otherwise set the
                  * state in order to go back to the next sub-tree. */
                 if (nodechar > keychar) {
-                    raxIteratorNextStep(it,0);
+                    if (!raxIteratorNextStep(it,0)) return 0;
                 } else {
-                    raxIteratorAddChars(it,it->node->data,it->node->size);
-                    raxIteratorNextStep(it,1);
+                    if (!raxIteratorAddChars(it,it->node->data,it->node->size))
+                        return 0;
+                    if (!raxIteratorNextStep(it,1)) return 0;
                 }
             }
             if (lt) {
@@ -1592,11 +1687,12 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
                  * subtree, otherwise set the state in order to go back to
                  * the previous sub-tree. */
                 if (nodechar < keychar) {
-                    raxSeekGreatest(it);
+                    if (!raxSeekGreatest(it)) return 0;
                     it->data = raxGetData(it->node);
                 } else {
-                    raxIteratorAddChars(it,it->node->data,it->node->size);
-                    raxIteratorPrevStep(it,1);
+                    if (!raxIteratorAddChars(it,it->node->data,it->node->size))
+                        return 0;
+                    if (!raxIteratorPrevStep(it,1)) return 0;
                 }
             }
             it->flags |= RAX_ITER_JUST_SEEKED; /* Ignore next call. */
@@ -1624,8 +1720,8 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
                  * So in that case, we don't seek backward. */
                 it->data = raxGetData(it->node);
             } else {
-                if (gt) raxIteratorNextStep(it,0);
-                if (lt) raxIteratorPrevStep(it,0);
+                if (gt && !raxIteratorNextStep(it,0)) return 0;
+                if (lt && !raxIteratorPrevStep(it,0)) return 0;
             }
             it->flags |= RAX_ITER_JUST_SEEKED; /* Ignore next call. */
         }
@@ -1641,7 +1737,10 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
  * If EOF (or out of memory) is reached, 0 is returned, otherwise 1 is
  * returned. In case 0 is returned because of OOM, errno is set to ENOMEM. */
 int raxNext(raxIterator *it) {
-    raxIteratorNextStep(it,0);
+    if (!raxIteratorNextStep(it,0)) {
+        errno = ENOMEM;
+        return 0;
+    }
     if (it->flags & RAX_ITER_EOF) {
         errno = 0;
         return 0;
@@ -1653,7 +1752,10 @@ int raxNext(raxIterator *it) {
  * If EOF (or out of memory) is reached, 0 is returned, otherwise 1 is
  * returned. In case 0 is returned because of OOM, errno is set to ENOMEM. */
 int raxPrev(raxIterator *it) {
-    raxIteratorPrevStep(it,0);
+    if (!raxIteratorPrevStep(it,0)) {
+        errno = ENOMEM;
+        return 0;
+    }
     if (it->flags & RAX_ITER_EOF) {
         errno = 0;
         return 0;
@@ -1662,7 +1764,7 @@ int raxPrev(raxIterator *it) {
 }
 
 /* Perform a random walk starting in the current position of the iterator.
- * Return 0 if the tree is empty. Otherwise 1 is returned
+ * Return 0 if the tree is empty or on out of memory. Otherwise 1 is returned
  * and the iterator is set to the node reached after doing a random walk
  * of 'steps' steps. If the 'steps' argument is 0, the random walk is performed
  * using a random number of steps between 1 and two times the logarithm of
@@ -1700,12 +1802,12 @@ int raxRandomWalk(raxIterator *it, size_t steps) {
         } else {
             /* Select a random child. */
             if (n->iscompr) {
-                raxIteratorAddChars(it,n->data,n->size);
+                if (!raxIteratorAddChars(it,n->data,n->size)) return 0;
             } else {
-                raxIteratorAddChars(it,n->data+child_offset,1);
+                if (!raxIteratorAddChars(it,n->data+child_offset,1)) return 0;
             }
             raxNode **cp = raxNodeFirstChildPtr(n)+child_offset;
-            raxStackPush(&it->stack,n, child_offset);
+            if (!raxStackPush(&it->stack,n, child_offset)) return 0;
             memcpy(&n,cp,sizeof(n));
             child_offset = 0;
         }

--- a/src/rax.c
+++ b/src/rax.c
@@ -199,11 +199,9 @@ raxNode *raxNewNode(size_t children, int datafield) {
     return node;
 }
 
-/* Allocate a new rax and return its pointer. On out of memory the function
- * returns NULL. */
+/* Allocate a new rax and return its pointer. */
 rax *raxNew(void) {
     rax *rax = rax_malloc(sizeof(*rax));
-    if (rax == NULL) return NULL;
     rax->numele = 0;
     rax->numnodes = 1;
     rax->head = raxNewNode(0,0);
@@ -1160,12 +1158,6 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
             size_t nodesize =
                 sizeof(raxNode)+comprsize+raxPadding(comprsize)+sizeof(raxNode*);
             raxNode *new = rax_malloc(nodesize);
-            /* An out of memory here just means we cannot optimize this
-             * node, but the tree is left in a consistent state. */
-            if (new == NULL) {
-                raxStackFree(&ts);
-                return 1;
-            }
             new->iskey = 0;
             new->isnull = 0;
             new->iscompr = 1;

--- a/src/rax.h
+++ b/src/rax.h
@@ -182,11 +182,11 @@ typedef struct raxIterator {
     void *data;             /* Data associated to this key. */
     size_t key_len;         /* Current key length. */
     size_t key_max;         /* Max key len the current key buffer can hold. */
-    unsigned char key_static_string[RAX_ITER_STATIC_LEN];
     raxNode *node;          /* Current node. Only for unsafe iteration. */
-    raxStack stack;         /* Stack used for unsafe iteration. */
-    raxNodeCallback node_cb; /* Optional node callback. Normally set to NULL. */
     uint8_t child_offset;    /* Current child offset. */
+    raxNodeCallback node_cb; /* Optional node callback. Normally set to NULL. */
+    unsigned char key_static_string[RAX_ITER_STATIC_LEN];
+    raxStack stack;         /* Stack used for unsafe iteration. */
 } raxIterator;
 
 /* A special pointer returned for not found items. */

--- a/src/rax.h
+++ b/src/rax.h
@@ -172,8 +172,6 @@ typedef int (*raxNodeCallback)(raxNode **noderef);
                                        element for the first iteration and
                                        clear the flag. */
 #define RAX_ITER_EOF (1<<1)    /* End of iteration reached. */
-#define RAX_ITER_SAFE (1<<2)   /* Safe iterator, allows operations while
-                                  iterating. But it is slower. */
 
 typedef struct raxIterator {
     int flags;

--- a/src/rax.h
+++ b/src/rax.h
@@ -147,6 +147,7 @@ typedef struct raxStack {
     /* Up to RAXSTACK_STACK_ITEMS items we avoid to allocate on the heap
      * and use this static array of pointers instead. */
     void *static_items[RAX_STACK_STATIC_ITEMS];
+    int oom; /* True if pushing into this stack failed for OOM at some point. */
     uint8_t static_offsets[RAX_STACK_STATIC_ITEMS];
 } raxStack;
 

--- a/src/rax.h
+++ b/src/rax.h
@@ -147,7 +147,6 @@ typedef struct raxStack {
     /* Up to RAXSTACK_STACK_ITEMS items we avoid to allocate on the heap
      * and use this static array of pointers instead. */
     void *static_items[RAX_STACK_STATIC_ITEMS];
-    int oom; /* True if pushing into this stack failed for OOM at some point. */
     uint8_t static_offsets[RAX_STACK_STATIC_ITEMS];
 } raxStack;
 

--- a/src/rax.h
+++ b/src/rax.h
@@ -142,12 +142,12 @@ typedef struct rax {
 #define RAX_STACK_STATIC_ITEMS 32
 typedef struct raxStack {
     void **stack; /* Points to static_items or an heap allocated array. */
+    uint8_t *offsets; /* stack (vector) of offsets */
     size_t items, maxitems; /* Number of items contained and total space. */
     /* Up to RAXSTACK_STACK_ITEMS items we avoid to allocate on the heap
      * and use this static array of pointers instead. */
     void *static_items[RAX_STACK_STATIC_ITEMS];
     int oom; /* True if pushing into this stack failed for OOM at some point. */
-    uint8_t *offsets; /* stack (vector) of offsets */
     uint8_t static_offsets[RAX_STACK_STATIC_ITEMS];
 } raxStack;
 

--- a/src/rax.h
+++ b/src/rax.h
@@ -172,6 +172,8 @@ typedef int (*raxNodeCallback)(raxNode **noderef);
 #define RAX_ITER_EOF (1<<1)    /* End of iteration reached. */
 #define RAX_ITER_SAFE (1<<2)   /* Safe iterator, allows operations while
                                   iterating. But it is slower. */
+#define RAX_ITER_CHILD_STATIC_LEN 32
+
 typedef struct raxIterator {
     int flags;
     rax *rt;                /* Radix tree we are iterating. */
@@ -183,6 +185,11 @@ typedef struct raxIterator {
     raxNode *node;          /* Current node. Only for unsafe iteration. */
     raxStack stack;         /* Stack used for unsafe iteration. */
     raxNodeCallback node_cb; /* Optional node callback. Normally set to NULL. */
+    size_t child_offset;    /* current child offset */
+    size_t cpos_max;        /* max number of child offsets the current stack can hold */
+    size_t cpos;            /* current position in the stack of child offsets */
+    uint8_t *child_offset_stack; /* stack (vector) of child offsets */
+    uint8_t child_offset_stack_static[RAX_ITER_CHILD_STATIC_LEN];
 } raxIterator;
 
 /* A special pointer returned for not found items. */

--- a/src/rax.h
+++ b/src/rax.h
@@ -147,6 +147,8 @@ typedef struct raxStack {
      * and use this static array of pointers instead. */
     void *static_items[RAX_STACK_STATIC_ITEMS];
     int oom; /* True if pushing into this stack failed for OOM at some point. */
+    uint8_t *offsets; /* stack (vector) of offsets */
+    uint8_t static_offsets[RAX_STACK_STATIC_ITEMS];
 } raxStack;
 
 /* Optional callback used for iterators and be notified on each rax node,
@@ -172,7 +174,6 @@ typedef int (*raxNodeCallback)(raxNode **noderef);
 #define RAX_ITER_EOF (1<<1)    /* End of iteration reached. */
 #define RAX_ITER_SAFE (1<<2)   /* Safe iterator, allows operations while
                                   iterating. But it is slower. */
-#define RAX_ITER_CHILD_STATIC_LEN 32
 
 typedef struct raxIterator {
     int flags;
@@ -185,11 +186,7 @@ typedef struct raxIterator {
     raxNode *node;          /* Current node. Only for unsafe iteration. */
     raxStack stack;         /* Stack used for unsafe iteration. */
     raxNodeCallback node_cb; /* Optional node callback. Normally set to NULL. */
-    size_t child_offset;    /* current child offset */
-    size_t cpos_max;        /* max number of child offsets the current stack can hold */
-    size_t cpos;            /* current position in the stack of child offsets */
-    uint8_t *child_offset_stack; /* stack (vector) of child offsets */
-    uint8_t child_offset_stack_static[RAX_ITER_CHILD_STATIC_LEN];
+    uint8_t child_offset;    /* Current child offset. */
 } raxIterator;
 
 /* A special pointer returned for not found items. */


### PR DESCRIPTION
This PR addresses the top TODO for Rax by antirez: "Take more state in the iterator so that we do not need to re-scan children in order to go to the next one. This may speedup iteration significantly at the cost of mroe complexity. However now we have enough fuzz and unit tests to spot potential bugs with great probability."

The PR:
- Adds a byte stack to ``raxIterator`` that contains child offsets.
- Adds a separate, more complicated and slightly slower raxLowWalkSeek() for use by raxSeek() - this preserves the speed of the simpler original raxLowWalk() which is heavily used by raxFind() etc.
- Modifies the raxSeek(), raxNext() and raxPrior() functions to use the above.

The Rax tests pass, including the fuzz tests.

Rax Iterator scans are used throughout the Redis code base. I counted 57 instances of ``raxNext()`` invocations in 14 source files. In almost all instances the invocations were in loops.