### PR TITLE
Updated HDR histogram from upsteam after they merged our fix in #10606.

### DIFF
--- a/deps/README.md
+++ b/deps/README.md
@@ -100,8 +100,8 @@ Hdr_Histogram
 ---
 
 Updated source can be found here: https://github.com/HdrHistogram/HdrHistogram_c
-We use a customized version 0.11.5
-1. Compare all changes under /hdr_histogram directory to version 0.11.5
+We use a customized version based on master branch commit e4448cf6d1cd08fff519812d3b1e58bd5a94ac42.
+1. Compare all changes under /hdr_histogram directory to upstream master commit e4448cf6d1cd08fff519812d3b1e58bd5a94ac42
 2. Copy updated files from newer version onto files in /hdr_histogram.
 3. Apply the changes from 1 above to the updated files.
 

--- a/deps/hdr_histogram/README.md
+++ b/deps/hdr_histogram/README.md
@@ -1,10 +1,78 @@
-HdrHistogram_c v0.11.5
+HdrHistogram_c: 'C' port of High Dynamic Range (HDR) Histogram
 
+HdrHistogram
 ----------------------------------------------
 
-This port contains a subset of the 'C' version of High Dynamic Range (HDR) Histogram available at [github.com/HdrHistogram/HdrHistogram_c](https://github.com/HdrHistogram/HdrHistogram_c).
+[![Gitter chat](https://badges.gitter.im/HdrHistogram/HdrHistogram.png)](https://gitter.im/HdrHistogram/HdrHistogram)
 
+This port contains a subset of the functionality supported by the Java
+implementation.  The current supported features are:
 
-The code present on `hdr_histogram.c`, `hdr_histogram.h`, and `hdr_atomic.c` was Written by Gil Tene, Michael Barker,
-and Matt Warren, and released to the public domain, as explained at
-http://creativecommons.org/publicdomain/zero/1.0/.
+* Standard histogram with 64 bit counts (32/16 bit counts not supported)
+* All iterator types (all values, recorded, percentiles, linear, logarithmic)
+* Histogram serialisation (encoding version 1.2, decoding 1.0-1.2)
+* Reader/writer phaser and interval recorder
+
+Features not supported, but planned
+
+* Auto-resizing of histograms
+
+Features unlikely to be implemented
+
+* Double histograms
+* Atomic/Concurrent histograms
+* 16/32 bit histograms
+
+# Simple Tutorial
+
+## Recording values
+
+```C
+#include <hdr_histogram.h>
+
+struct hdr_histogram* histogram;
+
+// Initialise the histogram
+hdr_init(
+    1,  // Minimum value
+    INT64_C(3600000000),  // Maximum value
+    3,  // Number of significant figures
+    &histogram)  // Pointer to initialise
+
+// Record value
+hdr_record_value(
+    histogram,  // Histogram to record to
+    value)  // Value to record
+
+// Record value n times
+hdr_record_values(
+    histogram,  // Histogram to record to
+    value,  // Value to record
+    10)  // Record value 10 times
+
+// Record value with correction for co-ordinated omission.
+hdr_record_corrected_value(
+    histogram,  // Histogram to record to
+    value,  // Value to record
+    1000)  // Record with expected interval of 1000.
+
+// Print out the values of the histogram
+hdr_percentiles_print(
+    histogram,
+    stdout,  // File to write to
+    5,  // Granularity of printed values
+    1.0,  // Multiplier for results
+    CLASSIC);  // Format CLASSIC/CSV supported.
+```
+
+## More examples
+
+For more detailed examples of recording and logging results look at the
+[hdr_decoder](examples/hdr_decoder.c)
+and [hiccup](examples/hiccup.c)
+examples.  You can run hiccup and decoder
+and pipe the results of one into the other.
+
+```
+$ ./examples/hiccup | ./examples/hdr_decoder
+```


### PR DESCRIPTION
The code is based on upstream https://github.com/HdrHistogram/HdrHistogram_c master branch latest commit (e4448cf6d1cd08fff519812d3b1e58bd5a94ac42). The reason to pull this in now is that their final version of our optimization is even faster. See: https://github.com/HdrHistogram/HdrHistogram_c/pull/107.

Original:
```console
yoav@yoav-thinkpad:~/HdrHistogram_c/build$ ./test/hdr_histogram_benchmark --benchmark_filter=BM_hdr_value_at_percentile/3/86400000 --benchmark_min_time=10
2022-03-21 12:41:46
Running ./test/hdr_histogram_benchmark
Run on (12 X 4600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x6)
  L1 Instruction 32K (x6)
  L2 Unified 256K (x6)
  L3 Unified 12288K (x1)
Load Average: 0.68, 0.81, 0.89
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
BM_hdr_value_at_percentile/3/86400000         34937 ns        34955 ns       404859
BM_hdr_value_at_percentile/3/86400000000      36561 ns        36581 ns       398987
```

After our original optimization:
```console
yoav@yoav-thinkpad:~/HdrHistogram_c/build$ ./test/hdr_histogram_benchmark --benchmark_filter=BM_hdr_value_at_percentile/3/86400000 --benchmark_min_time=10
2022-03-21 13:36:17
Running ./test/hdr_histogram_benchmark
Run on (12 X 4600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x6)
  L1 Instruction 32K (x6)
  L2 Unified 256K (x6)
  L3 Unified 12288K (x1)
Load Average: 0.86, 0.96, 1.26
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
BM_hdr_value_at_percentile/3/86400000          5070 ns         5083 ns      2795009
BM_hdr_value_at_percentile/3/86400000000       5124 ns         5135 ns      2753732
```

Latest (this PR):

```console
yoav@yoav-thinkpad:~/HdrHistogram_c/build(master)$ ./test/hdr_histogram_benchmark --benchmark_filter=BM_hdr_value_at_percentile/3/86400000 --benchmark_min_time=10
2022-05-20T17:01:52+03:00
Running ./test/hdr_histogram_benchmark
Run on (12 X 4600 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 12288 KiB (x1)
Load Average: 0.51, 1.22, 1.53
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
BM_hdr_value_at_percentile/3/86400000          2583 ns         2597 ns      5424698
BM_hdr_value_at_percentile/3/86400000000       2565 ns         2578 ns      4944717
```
