### PR TITLE
Fix BZMPOP gets unblocked by non-key args and returns them

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4041,7 +4041,7 @@ void blockingGenericZpopCommand(client *c, robj **keys, int numkeys, int where,
 
     /* If the keys do not exist we must block */
     struct blockPos pos = {where};
-    blockForKeys(c,BLOCKED_ZSET,c->argv+1,c->argc-2,count,timeout,NULL,&pos,NULL);
+    blockForKeys(c,BLOCKED_ZSET,keys,numkeys,count,timeout,NULL,&pos,NULL);
 }
 
 // BZPOPMIN key [key ...] timeout

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2089,7 +2089,7 @@ start_server {tags {"zset"}} {
 
         $rd1 close
         $rd2 close
-    } {0} {external:skip}
+    } {0} {cluster:skip}
 
     test {ZSET skiplist order consistency when elements are moved} {
         set original_max [lindex [r config get zset-max-ziplist-entries] 1]

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2065,6 +2065,32 @@ start_server {tags {"zset"}} {
         close_replication_stream $repl
     } {} {needs:repl}
 
+    test "BZMPOP should not blocks on non key arguments - #10762" {
+        set rd1 [redis_deferring_client]
+        set rd2 [redis_deferring_client]
+        r del myzset myzset2 myzset3
+
+        $rd1 bzmpop 0 1 myzset min count 10
+        wait_for_blocked_clients_count 1
+        $rd2 bzmpop 0 2 myzset2 myzset3 max count 10
+        wait_for_blocked_clients_count 2
+
+        r zadd 0 100 a ;# timeout value
+        r zadd 1 200 b ;# numkeys value
+        r zadd min 300 c ;# min token
+        r zadd max 400 d ;# max token
+        r zadd count 500 e ;# count token
+        r zadd 10 200 b ;# count value
+
+        r zadd myzset 600 f
+        r zadd myzset3 600 f
+        assert_equal {myzset {{f 600}}} [$rd1 read]
+        assert_equal {myzset3 {{f 600}}} [$rd2 read]
+
+        $rd1 close
+        $rd2 close
+    } {0} {external:skip}
+
     test {ZSET skiplist order consistency when elements are moved} {
         set original_max [lindex [r config get zset-max-ziplist-entries] 1]
         r config set zset-max-ziplist-entries 0

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2075,17 +2075,18 @@ start_server {tags {"zset"}} {
         $rd2 bzmpop 0 2 myzset2 myzset3 max count 10
         wait_for_blocked_clients_count 2
 
-        r zadd 0 100 a ;# timeout value
-        r zadd 1 200 b ;# numkeys value
-        r zadd min 300 c ;# min token
-        r zadd max 400 d ;# max token
-        r zadd count 500 e ;# count token
-        r zadd 10 200 b ;# count value
+        # These non-key keys will not unblock the clients.
+        r zadd 0 100 timeout_value
+        r zadd 1 200 numkeys_value
+        r zadd min 300 min_token
+        r zadd max 400 max_token
+        r zadd count 500 count_token
+        r zadd 10 600 count_value
 
-        r zadd myzset 600 f
-        r zadd myzset3 600 f
-        assert_equal {myzset {{f 600}}} [$rd1 read]
-        assert_equal {myzset3 {{f 600}}} [$rd2 read]
+        r zadd myzset 1 zset
+        r zadd myzset3 1 zset3
+        assert_equal {myzset {{zset 1}}} [$rd1 read]
+        assert_equal {myzset3 {{zset3 1}}} [$rd2 read]
 
         $rd1 close
         $rd2 close


### PR DESCRIPTION
This bug was introduced in #9484 (7.0.0).
It result that BZMPOP blocked on non-key arguments.

Like `bzmpop 0 1 myzset min count 10`, this command will additionally
block in these keys (except for the first and the last argument) and can return their values:
- 0: timeout value
- 1: numkeys value
- min: min/max token
- count: count token

Fixes #10762