### PR TITLE
Fix ZRANGESTORE crash when zset_max_listpack_entries is 0

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -620,12 +620,7 @@ int moduleCreateEmptyKey(RedisModuleKey *key, int type) {
                             server.list_compress_depth);
         break;
     case REDISMODULE_KEYTYPE_ZSET:
-        if (server.zset_max_listpack_entries > 0) {
-            obj = createZsetListpackObject();
-        } else {
-            /* Use skiplist if listpack is disabled to avoid redundant conversion on add. */
-            obj = createZsetObject();
-        }
+        obj = createZsetListpackObject();
         break;
     case REDISMODULE_KEYTYPE_HASH:
         obj = createHashObject();

--- a/src/module.c
+++ b/src/module.c
@@ -620,7 +620,12 @@ int moduleCreateEmptyKey(RedisModuleKey *key, int type) {
                             server.list_compress_depth);
         break;
     case REDISMODULE_KEYTYPE_ZSET:
-        obj = createZsetListpackObject();
+        if (server.zset_max_listpack_entries > 0) {
+            obj = createZsetListpackObject();
+        } else {
+            /* Use skiplist if listpack is disabled to avoid redundant conversion on add. */
+            obj = createZsetObject();
+        }
         break;
     case REDISMODULE_KEYTYPE_HASH:
         obj = createHashObject();

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2952,7 +2952,11 @@ static void zrangeResultFinalizeClient(zrange_result_handler *handler,
 static void zrangeResultBeginStore(zrange_result_handler *handler, long length)
 {
     UNUSED(length);
-    handler->dstobj = createZsetListpackObject();
+    if (server.zset_max_listpack_entries > 0) {
+        handler->dstobj = createZsetListpackObject();
+    } else { // Use skiplist if listpack is disabled to avoid redundant conversion on add.
+        handler->dstobj = createZsetObject();
+    }
 }
 
 static void zrangeResultEmitCBufferForStore(zrange_result_handler *handler,

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1186,23 +1186,23 @@ void zsetConvert(robj *zobj, int encoding) {
         zs->zsl = zslCreate();
 
         eptr = lpSeek(zl,0);
-        serverAssertWithInfo(NULL,zobj,eptr != NULL);
-        sptr = lpNext(zl,eptr);
-        serverAssertWithInfo(NULL,zobj,sptr != NULL);
+        if (eptr != NULL) {
+            sptr = lpNext(zl, eptr);
+            serverAssertWithInfo(NULL, zobj, sptr != NULL);
 
-        while (eptr != NULL) {
-            score = zzlGetScore(sptr);
-            vstr = lpGetValue(eptr,&vlen,&vlong);
-            if (vstr == NULL)
-                ele = sdsfromlonglong(vlong);
-            else
-                ele = sdsnewlen((char*)vstr,vlen);
+            while (eptr != NULL) {
+                score = zzlGetScore(sptr);
+                vstr = lpGetValue(eptr, &vlen, &vlong);
+                if (vstr == NULL)
+                    ele = sdsfromlonglong(vlong);
+                else
+                    ele = sdsnewlen((char *) vstr, vlen);
 
-            node = zslInsert(zs->zsl,score,ele);
-            serverAssert(dictAdd(zs->dict,ele,&node->score) == DICT_OK);
-            zzlNext(zl,&eptr,&sptr);
+                node = zslInsert(zs->zsl, score, ele);
+                serverAssert(dictAdd(zs->dict, ele, &node->score) == DICT_OK);
+                zzlNext(zl, &eptr, &sptr);
+            }
         }
-
         zfree(zobj->ptr);
         zobj->ptr = zs;
         zobj->encoding = OBJ_ENCODING_SKIPLIST;
@@ -2954,7 +2954,8 @@ static void zrangeResultBeginStore(zrange_result_handler *handler, long length)
     UNUSED(length);
     if (server.zset_max_listpack_entries > 0) {
         handler->dstobj = createZsetListpackObject();
-    } else { // Use skiplist if listpack is disabled to avoid redundant conversion on add.
+    } else {
+        /* Use skiplist if listpack is disabled to avoid redundant conversion on add. */
         handler->dstobj = createZsetObject();
     }
 }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1189,19 +1189,19 @@ void zsetConvert(robj *zobj, int encoding) {
         if (eptr != NULL) {
             sptr = lpNext(zl, eptr);
             serverAssertWithInfo(NULL, zobj, sptr != NULL);
+        }
 
-            while (eptr != NULL) {
-                score = zzlGetScore(sptr);
-                vstr = lpGetValue(eptr, &vlen, &vlong);
-                if (vstr == NULL)
-                    ele = sdsfromlonglong(vlong);
-                else
-                    ele = sdsnewlen((char *) vstr, vlen);
+        while (eptr != NULL) {
+            score = zzlGetScore(sptr);
+            vstr = lpGetValue(eptr, &vlen, &vlong);
+            if (vstr == NULL)
+                ele = sdsfromlonglong(vlong);
+            else
+                ele = sdsnewlen((char *) vstr, vlen);
 
-                node = zslInsert(zs->zsl, score, ele);
-                serverAssert(dictAdd(zs->dict, ele, &node->score) == DICT_OK);
-                zzlNext(zl, &eptr, &sptr);
-            }
+            node = zslInsert(zs->zsl, score, ele);
+            serverAssert(dictAdd(zs->dict, ele, &node->score) == DICT_OK);
+            zzlNext(zl, &eptr, &sptr);
         }
         zfree(zobj->ptr);
         zobj->ptr = zs;
@@ -2952,12 +2952,7 @@ static void zrangeResultFinalizeClient(zrange_result_handler *handler,
 static void zrangeResultBeginStore(zrange_result_handler *handler, long length)
 {
     UNUSED(length);
-    if (server.zset_max_listpack_entries > 0) {
-        handler->dstobj = createZsetListpackObject();
-    } else {
-        /* Use skiplist if listpack is disabled to avoid redundant conversion on add. */
-        handler->dstobj = createZsetObject();
-    }
+    handler->dstobj = createZsetListpackObject();
 }
 
 static void zrangeResultEmitCBufferForStore(zrange_result_handler *handler,

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1187,21 +1187,21 @@ void zsetConvert(robj *zobj, int encoding) {
 
         eptr = lpSeek(zl,0);
         if (eptr != NULL) {
-            sptr = lpNext(zl, eptr);
-            serverAssertWithInfo(NULL, zobj, sptr != NULL);
+            sptr = lpNext(zl,eptr);
+            serverAssertWithInfo(NULL,zobj,sptr != NULL);
         }
 
         while (eptr != NULL) {
             score = zzlGetScore(sptr);
-            vstr = lpGetValue(eptr, &vlen, &vlong);
+            vstr = lpGetValue(eptr,&vlen,&vlong);
             if (vstr == NULL)
                 ele = sdsfromlonglong(vlong);
             else
-                ele = sdsnewlen((char *) vstr, vlen);
+                ele = sdsnewlen((char*)vstr,vlen);
 
-            node = zslInsert(zs->zsl, score, ele);
-            serverAssert(dictAdd(zs->dict, ele, &node->score) == DICT_OK);
-            zzlNext(zl, &eptr, &sptr);
+            node = zslInsert(zs->zsl,score,ele);
+            serverAssert(dictAdd(zs->dict,ele,&node->score) == DICT_OK);
+            zzlNext(zl,&eptr,&sptr);
         }
         zfree(zobj->ptr);
         zobj->ptr = zs;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1203,6 +1203,7 @@ void zsetConvert(robj *zobj, int encoding) {
             serverAssert(dictAdd(zs->dict,ele,&node->score) == DICT_OK);
             zzlNext(zl,&eptr,&sptr);
         }
+
         zfree(zobj->ptr);
         zobj->ptr = zs;
         zobj->encoding = OBJ_ENCODING_SKIPLIST;

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2208,14 +2208,13 @@ start_server {tags {"zset"}} {
         assert_match "*syntax*" $err
     }
 
-    test {ZRANGESTORE skiplist} {
-        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
-        r config set zset-max-ziplist-entries 0
-        r flushall
+    test {ZRANGESTORE with zset-max-listpack-entries 0 dst key should use skiplist encoding} {
+        set original_max [lindex [r config get zset-max-listpack-entries] 1]
+        r config set zset-max-listpack-entries 0
+        r del z1{t} z2{t}
         r zadd z1{t} 1 a
-        set res [r zrangestore z2{t} z1{t} 0 -1]
-        assert_equal $res 1
-        r config set zset-max-ziplist-entries $original_max
+        assert_equal 1 [r zrangestore z2{t} z1{t} 0 -1]
+        r config set zset-max-listpack-entries $original_max
     }
 
     test {ZRANGE invalid syntax} {

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2208,6 +2208,16 @@ start_server {tags {"zset"}} {
         assert_match "*syntax*" $err
     }
 
+    test {ZRANGESTORE skiplist} {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+        r flushall
+        r zadd z1{t} 1 a
+        set res [r zrangestore z2{t} z1{t} 0 -1]
+        assert_equal $res 1
+        r config set zset-max-ziplist-entries $original_max
+    }
+
     test {ZRANGE invalid syntax} {
         catch {r zrange z1{t} 0 -1 limit 1 2} err
         assert_match "*syntax*" $err


### PR DESCRIPTION
When `zrangestore` is called container destination object is created. 
Before this PR we used to create a listpack based object even if `zset-max-ziplist-entries` or equivalent`zset-max-listpack-entries` was set to 0.
This triggered immediate conversion of the listpack into a skiplist in `zrangestore`, which hits an assertion [here](https://github.com/redis/redis/blob/unstable/src/t_zset.c#L1189) resulting in an engine crash.

[EDIT] This crash also happens when the first entry being inserted to the zset by ZRANGESTORE is bigger than `zset-max-ziplist-value` (default to 64).
This makes it even more severe.

Added a TCL test that reproduces this issue.