### PR TITLE
Remove duplicate nodeIsSlave(myself) decision logic in clusterCron

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4077,7 +4077,7 @@ void clusterCron(void) {
                 orphaned_masters++;
             }
             if (okslaves > max_slaves) max_slaves = okslaves;
-            if (nodeIsSlave(myself) && myself->slaveof == node)
+            if (myself->slaveof == node)
                 this_slaves = okslaves;
         }
 


### PR DESCRIPTION
On line 4068, redis has a logical nodeIsSlave(myself) on the outer if layer, which you can delete without having to repeat the decision