### PR TITLE
Fix sentinel disconnect test timing issue after auth-pass change

### DIFF
--- a/tests/sentinel/tests/03-runtime-reconf.tcl
+++ b/tests/sentinel/tests/03-runtime-reconf.tcl
@@ -79,8 +79,10 @@ test "Sentinels (re)connection following SENTINEL SET mymaster auth-pass" {
     restart_instance sentinel $sent2re
 
     # Verify sentinel that restarted failed to connect master
-    if {![string match "*disconnected*" [dict get [S $sent2re SENTINEL MASTER mymaster] flags]]} {
-       fail "Expected to be disconnected from master due to wrong password"
+    wait_for_condition 100 50 {
+        [string match "*disconnected*" [dict get [S $sent2re SENTINEL MASTER mymaster] flags]] != 0
+    } else {
+        fail "Expected to be disconnected from master due to wrong password"
     }
 
     # Update restarted sentinel with master password


### PR DESCRIPTION
There is a timing issue reported in test-sanitizer-address (gcc):
```
Sentinels (re)connection following SENTINEL SET mymaster auth-pass:
FAILED: Expected to be disconnected from master due to wrong password
```

The reason we reach it, is because the test is fast enough to modify
auth-pass and test sentinel connection status with the server,
before its scheduled operation got the chance to update connection
status with the server.

We need to wait for `sentinelTimer` to kick in, and then update the
connection status. Replace condition with wait_for_condition on the check.

Fix just like #10480 did