### PR TITLE
optimize zset conversion on large ZRANGESTORE

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2952,8 +2952,10 @@ static void zrangeResultFinalizeClient(zrange_result_handler *handler,
 /* Result handler methods for storing the ZRANGESTORE to a zset. */
 static void zrangeResultBeginStore(zrange_result_handler *handler, long length)
 {
-    UNUSED(length);
-    handler->dstobj = createZsetListpackObject();
+    if (length > (long)server.zset_max_listpack_entries)
+        handler->dstobj = createZsetObject();
+    else
+        handler->dstobj = createZsetListpackObject();
 }
 
 static void zrangeResultEmitCBufferForStore(zrange_result_handler *handler,

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2219,10 +2219,13 @@ start_server {tags {"zset"}} {
 
     test {ZRANGESTORE with zset-max-listpack-entries 1 dst key should use skiplist encoding} {
         set original_max [lindex [r config get zset-max-listpack-entries] 1]
-        r config set zset-max-listpack-entries 0
-        r del z1{t} z2{t}
+        r config set zset-max-listpack-entries 1
+        r del z1{t} z2{t} z3{t}
         r zadd z1{t} 1 a 2 b
-        assert_equal 2 [r zrangestore z2{t} z1{t} 0 -1]
+        assert_equal 1 [r zrangestore z2{t} z1{t} 0 0]
+        assert_encoding listpack z2{t}
+        assert_equal 2 [r zrangestore z3{t} z1{t} 0 1]
+        assert_encoding skiplist z3{t}
         r config set zset-max-listpack-entries $original_max
     }
 

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2208,12 +2208,21 @@ start_server {tags {"zset"}} {
         assert_match "*syntax*" $err
     }
 
-    test {ZRANGESTORE with zset-max-listpack-entries 0 dst key should use skiplist encoding} {
+    test {ZRANGESTORE with zset-max-listpack-entries 0 #10767 case} {
         set original_max [lindex [r config get zset-max-listpack-entries] 1]
         r config set zset-max-listpack-entries 0
         r del z1{t} z2{t}
         r zadd z1{t} 1 a
         assert_equal 1 [r zrangestore z2{t} z1{t} 0 -1]
+        r config set zset-max-listpack-entries $original_max
+    }
+
+    test {ZRANGESTORE with zset-max-listpack-entries 1 dst key should use skiplist encoding} {
+        set original_max [lindex [r config get zset-max-listpack-entries] 1]
+        r config set zset-max-listpack-entries 0
+        r del z1{t} z2{t}
+        r zadd z1{t} 1 a 2 b
+        assert_equal 2 [r zrangestore z2{t} z1{t} 0 -1]
         r config set zset-max-listpack-entries $original_max
     }
 


### PR DESCRIPTION
when we know the size of the zset we're gonna store in advance, we can check if it's greater than the listpack encoding threshold, in which case we can create a skiplist from the get go, and avoid converting the listpack to skiplist later after it was already populated.