### PR TITLE
bug fixes for pattern matching

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -95,9 +95,7 @@ int stringmatchlen(const char *pattern, int patternLen,
                 } else if (pattern[0] == ']') {
                     break;
                 } else if (patternLen == 0) {
-                    pattern--;
-                    patternLen++;
-                    break;
+                    return 0; /* invalid pattern */
                 } else if (patternLen >= 3 && pattern[1] == '-') {
                     int start = pattern[0];
                     int end = pattern[2];


### PR DESCRIPTION
If pattern has '[' but not ']', it should be an invalid pattern and will not match any string.

It was like this before the PR: 
```
127.0.0.1:6379> set hello world
OK
127.0.0.1:6379> keys hell[o
1) "hello"
127.0.0.1:6379>
```