### PR TITLE
Set replicas' configEpoch to 0 when loaded from cluster configuration file

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5534,12 +5534,6 @@ NULL
             (unsigned long long) myepoch
         );
 
-        if (nodeIsSlave(myself) && myself->slaveof) {
-            info = sdscatprintf(info,
-                                "cluster_my_replica_epoch:%llu\r\n",
-                                (unsigned long long) myself->configEpoch);
-        }
-
         /* Show stats about messages sent and received. */
         long long tot_msg_sent = 0;
         long long tot_msg_received = 0;


### PR DESCRIPTION
tl;dr: Prevent replicas from incorrectly loading a configEpoch that is the highest in the cluster, preventing `CLUSTER FAILOVER TAKEOVER` from being acknowledged within the cluster.

1. The configEpoch shown by the 'cluster nodes/info' command (cluster_my_epoch in 'cluster info', or index 6 in the node line in 'cluster nodes') is of the primary of the shard, and there is no indication of the config epoch of any of the replicas, as stored in myself->configEpoch.
```
        myepoch = (nodeIsSlave(myself) && myself->slaveof) ?
                  myself->slaveof->configEpoch : myself->configEpoch;
            ...
        sds info = sdscatprintf(sdsempty(),
            ...
            "cluster_my_epoch:%llu\r\n"
            (unsigned long long) myepoch,
```

2. When Redis is being started with cluster configuration file (nodes.conf) it loads the configEpoch from the file, which contains the output of 'cluster nodes' command. That means, that if Redis is being restarted on a replica and a cluster configuration file is being loaded, the replica will be configured with the primary's config epoch. That is because the cluster nodes output contains only the primaries configuration epochs, and as explained in (1), we don't have indication for the real config epoch of the replica.
Here's a short example:
(*I added cluster_my_replica_epoch to the 'cluster info' command to show the actual configEpoch of the replica.*) 
 - Before restarting replica node 16379:
```
ec2-user@ip-172-31-113-41 ~/redis (unstable) $ redis-cli -p 16379 cluster info
...
cluster_my_epoch:11
cluster_my_replica_epoch:1
```
 -  Restart Redis on replica 16379 with this cluster configuration:
```
a55b0db29d7326891f58e07f0ff62a00eb2077e7 127.0.0.1:16383@26383 slave 63fef265453ad4c7853a3d3c7852f3b20fff02d4 0 1653928756000 3 connected
4c771033854e5b345b05fbf599b46969e76b2110 127.0.0.1:16387@26387 slave cfdc5605449628edd73fd2734a20fc1c2d1be25b 0 1653928757379 2 connected
e379c456fc7851e22d3092dd4c3e5e3c320ce2aa 127.0.0.1:16386@26386 slave e6fa3c8db3fb522596d63322569af478aa0d5eab 0 1653928756000 11 connected
d02e89ef37de64bde93e3eaf60eefd1cf3dc51c0 127.0.0.1:16379@26379 myself,slave e6fa3c8db3fb522596d63322569af478aa0d5eab 0 1653928748000 11 connected
e6fa3c8db3fb522596d63322569af478aa0d5eab 127.0.0.1:16388@26388 master - 0 1653928754000 11 connected 0-5460
cfdc5605449628edd73fd2734a20fc1c2d1be25b 127.0.0.1:16380@26380 master - 0 1653928756377 2 connected 5461-10922
881114f5c6fb875cb1d2b0af20592be2773fa216 127.0.0.1:16385@26385 slave 63fef265453ad4c7853a3d3c7852f3b20fff02d4 0 1653928756000 3 connected
63fef265453ad4c7853a3d3c7852f3b20fff02d4 127.0.0.1:16381@26381 master - 0 1653928755000 3 connected 10923-16383
a35e7cac6de26444fb53d520292d8dddf323bbed 127.0.0.1:16384@26384 slave e6fa3c8db3fb522596d63322569af478aa0d5eab 0 1653928754000 11 connected
b45422e62de3b69532a70197404c3a0ca8b6fa66 127.0.0.1:16382@26382 slave cfdc5605449628edd73fd2734a20fc1c2d1be25b 0 1653928756578 2 connected
```

 - After the replica was restated and the configuration file is loaded:
```
ec2-user@ip-172-31-113-41 ~/redis (unstable) $ redis-cli -p 16379 cluster info
...
cluster_my_epoch:11
cluster_my_replica_epoch:11
```

3. How can it be a problem? If we'll now initiate 'cluster failover takeover' on this replica, it will have the greatest epoch in the cluster, and therefore the cluster epoch won't be bumped (see [cluster failover takeover](https://redis.io/commands/cluster-failover/#takeover-option-manual-failover-without-cluster-consensus)). If the epoch isn't bumped, other nodes in the cluster won't recognize the rebinding of slots to the new primary.
4. As the configEpoch of the primary, when the replica is just being started, does not reflect the real status of the replica, I propose that it be set to zero when loading configuration files. 

Changes summary:
- Changed clusterLoadConfig to set the config epoch of replica nodes to 0 when loaded.