### PR TITLE
remove allow-oom from scripts and add no-deny-oom for scripts

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -37,6 +37,7 @@ scriptFlag scripts_flags_def[] = {
     {.flag = SCRIPT_FLAG_ALLOW_STALE, .str = "allow-stale"},
     {.flag = SCRIPT_FLAG_NO_CLUSTER, .str = "no-cluster"},
     {.flag = SCRIPT_FLAG_ALLOW_CROSS_SLOT, .str = "allow-cross-slot-keys"},
+    {.flag = SCRIPT_FLAG_NO_INCREASE_MEMORY, .str = "no-increase-memory"},
     {.flag = 0, .str = NULL}, /* flags array end */
 };
 
@@ -113,7 +114,7 @@ uint64_t scriptFlagsToCmdFlags(uint64_t cmd_flags, uint64_t script_flags) {
     cmd_flags &= ~(CMD_STALE | CMD_DENYOOM | CMD_WRITE);
 
     /* NO_WRITES implies ALLOW_OOM */
-    if (!(script_flags & (SCRIPT_FLAG_ALLOW_OOM | SCRIPT_FLAG_NO_WRITES)))
+    if (!(script_flags & (SCRIPT_FLAG_ALLOW_OOM | SCRIPT_FLAG_NO_WRITES | SCRIPT_FLAG_NO_INCREASE_MEMORY)))
         cmd_flags |= CMD_DENYOOM;
     if (!(script_flags & SCRIPT_FLAG_NO_WRITES))
         cmd_flags |= CMD_WRITE;
@@ -194,9 +195,10 @@ int scriptPrepareForRun(scriptRunCtx *run_ctx, client *engine_client, client *ca
         /* Check OOM state. the no-writes flag imply allow-oom. we tested it
          * after the no-write error, so no need to mention it in the error reply. */
         if (server.pre_command_oom_state && server.maxmemory &&
-            !(script_flags & (SCRIPT_FLAG_ALLOW_OOM|SCRIPT_FLAG_NO_WRITES)))
+            !(script_flags & (SCRIPT_FLAG_ALLOW_OOM|SCRIPT_FLAG_NO_WRITES|SCRIPT_FLAG_NO_INCREASE_MEMORY)))
         {
-            addReplyError(caller, "-OOM allow-oom flag is not set on the script, "
+            addReplyError(caller, "-OOM allow-oom, no-writes or no-increase-memory flag "
+                                  "is not set on the script, "
                                   "can not run it when used memory > 'maxmemory'");
             return C_ERR;
         }
@@ -239,12 +241,16 @@ int scriptPrepareForRun(scriptRunCtx *run_ctx, client *engine_client, client *ca
     }
     if (!(script_flags & SCRIPT_FLAG_EVAL_COMPAT_MODE) && (script_flags & SCRIPT_FLAG_ALLOW_OOM)) {
         /* Note: we don't need to test the no-writes flag here and set this run_ctx flag,
-         * since only write commands can are deny-oom. */
+         * since only write commands can be deny-oom. */
         run_ctx->flags |= SCRIPT_ALLOW_OOM;
     }
 
     if ((script_flags & SCRIPT_FLAG_EVAL_COMPAT_MODE) || (script_flags & SCRIPT_FLAG_ALLOW_CROSS_SLOT)) {
         run_ctx->flags |= SCRIPT_ALLOW_CROSS_SLOT;
+    }
+
+    if (!(script_flags & SCRIPT_FLAG_EVAL_COMPAT_MODE) && (script_flags & SCRIPT_FLAG_NO_INCREASE_MEMORY)) {
+        run_ctx->flags |= SCRIPT_NO_INCREASE_MEMORY;
     }
 
     /* set the curr_run_ctx so we can use it to kill the script if needed */
@@ -458,6 +464,18 @@ static int scriptVerifyClusterState(scriptRunCtx *run_ctx, client *c, client *or
     return C_OK;
 }
 
+static int scriptVerifyNoIncreaseMemory(scriptRunCtx *run_ctx, char **err) {
+    if (!(run_ctx->c->cmd->flags & CMD_DENYOOM)) {
+        return C_OK;
+    }
+
+    if (run_ctx->flags & SCRIPT_NO_INCREASE_MEMORY) {
+        *err = sdsnew("Deny-OOM commands are not allowed from no-increase-memory scripts.");
+        return C_ERR;
+    }
+    return C_OK;
+}
+
 /* set RESP for a given run_ctx */
 int scriptSetResp(scriptRunCtx *run_ctx, int resp) {
     if (resp != 2 && resp != 3) {
@@ -543,6 +561,10 @@ void scriptCall(scriptRunCtx *run_ctx, robj* *argv, int argc, sds *err) {
     }
 
     if (scriptVerifyWriteCommandAllow(run_ctx, err) != C_OK) {
+        goto error;
+    }
+
+    if (scriptVerifyNoIncreaseMemory(run_ctx, err) != C_OK) {
         goto error;
     }
 

--- a/src/script.c
+++ b/src/script.c
@@ -33,11 +33,10 @@
 
 scriptFlag scripts_flags_def[] = {
     {.flag = SCRIPT_FLAG_NO_WRITES, .str = "no-writes"},
-    {.flag = SCRIPT_FLAG_ALLOW_OOM, .str = "allow-oom"},
+    {.flag = SCRIPT_FLAG_NO_DENY_OOM, .str = "no-deny-oom"},
     {.flag = SCRIPT_FLAG_ALLOW_STALE, .str = "allow-stale"},
     {.flag = SCRIPT_FLAG_NO_CLUSTER, .str = "no-cluster"},
     {.flag = SCRIPT_FLAG_ALLOW_CROSS_SLOT, .str = "allow-cross-slot-keys"},
-    {.flag = SCRIPT_FLAG_NO_DENY_OOM, .str = "no-deny-oom"},
     {.flag = 0, .str = NULL}, /* flags array end */
 };
 
@@ -113,8 +112,8 @@ uint64_t scriptFlagsToCmdFlags(uint64_t cmd_flags, uint64_t script_flags) {
     /* If the script declared flags, clear the ones from the command and use the ones it declared.*/
     cmd_flags &= ~(CMD_STALE | CMD_DENYOOM | CMD_WRITE);
 
-    /* NO_WRITES implies ALLOW_OOM */
-    if (!(script_flags & (SCRIPT_FLAG_ALLOW_OOM | SCRIPT_FLAG_NO_WRITES | SCRIPT_FLAG_NO_DENY_OOM)))
+    /* NO_WRITES implies NO_DENY_OOM */
+    if (!(script_flags & (SCRIPT_FLAG_NO_WRITES | SCRIPT_FLAG_NO_DENY_OOM)))
         cmd_flags |= CMD_DENYOOM;
     if (!(script_flags & SCRIPT_FLAG_NO_WRITES))
         cmd_flags |= CMD_WRITE;
@@ -192,12 +191,12 @@ int scriptPrepareForRun(scriptRunCtx *run_ctx, client *engine_client, client *ca
             }
         }
 
-        /* Check OOM state. the no-writes flag imply allow-oom. we tested it
+        /* Check OOM state. the no-writes flag imply no-deny-oom. we tested it
          * after the no-write error, so no need to mention it in the error reply. */
         if (server.pre_command_oom_state && server.maxmemory &&
-            !(script_flags & (SCRIPT_FLAG_ALLOW_OOM|SCRIPT_FLAG_NO_WRITES|SCRIPT_FLAG_NO_DENY_OOM)))
+            !(script_flags & (SCRIPT_FLAG_NO_WRITES|SCRIPT_FLAG_NO_DENY_OOM)))
         {
-            addReplyError(caller, "-OOM allow-oom, no-writes or no-deny-oom flag "
+            addReplyError(caller, "-OOM no-writes or no-deny-oom flag "
                                   "is not set on the script, "
                                   "can not run it when used memory > 'maxmemory'");
             return C_ERR;
@@ -239,18 +238,15 @@ int scriptPrepareForRun(scriptRunCtx *run_ctx, client *engine_client, client *ca
          * flag, we will not allow write commands. */
         run_ctx->flags |= SCRIPT_READ_ONLY;
     }
-    if (!(script_flags & SCRIPT_FLAG_EVAL_COMPAT_MODE) && (script_flags & SCRIPT_FLAG_ALLOW_OOM)) {
+
+    if (!(script_flags & SCRIPT_FLAG_EVAL_COMPAT_MODE) && (script_flags & SCRIPT_FLAG_NO_DENY_OOM)) {
         /* Note: we don't need to test the no-writes flag here and set this run_ctx flag,
          * since only write commands can be deny-oom. */
-        run_ctx->flags |= SCRIPT_ALLOW_OOM;
+        run_ctx->flags |= SCRIPT_NO_DENY_OOM;
     }
 
     if ((script_flags & SCRIPT_FLAG_EVAL_COMPAT_MODE) || (script_flags & SCRIPT_FLAG_ALLOW_CROSS_SLOT)) {
         run_ctx->flags |= SCRIPT_ALLOW_CROSS_SLOT;
-    }
-
-    if (!(script_flags & SCRIPT_FLAG_EVAL_COMPAT_MODE) && (script_flags & SCRIPT_FLAG_NO_DENY_OOM)) {
-        run_ctx->flags |= SCRIPT_NO_DENY_OOM;
     }
 
     /* set the curr_run_ctx so we can use it to kill the script if needed */
@@ -399,8 +395,8 @@ static int scriptVerifyWriteCommandAllow(scriptRunCtx *run_ctx, char **err) {
 }
 
 static int scriptVerifyOOM(scriptRunCtx *run_ctx, char **err) {
-    if (run_ctx->flags & SCRIPT_ALLOW_OOM) {
-        /* Allow running any command even if OOM reached */
+    if (run_ctx->flags & SCRIPT_NO_DENY_OOM) {
+        /* Allow running no deny-oom command even if OOM reached */
         return C_OK;
     }
 

--- a/src/script.h
+++ b/src/script.h
@@ -65,6 +65,7 @@
 #define SCRIPT_ALLOW_OOM              (1ULL<<6) /* indicate to allow any command even if OOM reached */
 #define SCRIPT_EVAL_MODE              (1ULL<<7) /* Indicate that the current script called from legacy Lua */
 #define SCRIPT_ALLOW_CROSS_SLOT       (1ULL<<8) /* Indicate that the current script may access keys from multiple slots */
+#define SCRIPT_NO_INCREASE_MEMORY     (1ULL<<9) /* Indicate that the current script would not increase data memory usage */
 typedef struct scriptRunCtx scriptRunCtx;
 
 struct scriptRunCtx {
@@ -78,12 +79,13 @@ struct scriptRunCtx {
 };
 
 /* Scripts flags */
-#define SCRIPT_FLAG_NO_WRITES        (1ULL<<0)
-#define SCRIPT_FLAG_ALLOW_OOM        (1ULL<<1)
-#define SCRIPT_FLAG_ALLOW_STALE      (1ULL<<2)
-#define SCRIPT_FLAG_NO_CLUSTER       (1ULL<<3)
-#define SCRIPT_FLAG_EVAL_COMPAT_MODE (1ULL<<4) /* EVAL Script backwards compatible behavior, no shebang provided */
-#define SCRIPT_FLAG_ALLOW_CROSS_SLOT (1ULL<<5)
+#define SCRIPT_FLAG_NO_WRITES          (1ULL<<0)
+#define SCRIPT_FLAG_ALLOW_OOM          (1ULL<<1)
+#define SCRIPT_FLAG_ALLOW_STALE        (1ULL<<2)
+#define SCRIPT_FLAG_NO_CLUSTER         (1ULL<<3)
+#define SCRIPT_FLAG_EVAL_COMPAT_MODE   (1ULL<<4) /* EVAL Script backwards compatible behavior, no shebang provided */
+#define SCRIPT_FLAG_ALLOW_CROSS_SLOT   (1ULL<<5)
+#define SCRIPT_FLAG_NO_INCREASE_MEMORY (1ULL<<6)
 
 /* Defines a script flags */
 typedef struct scriptFlag {

--- a/src/script.h
+++ b/src/script.h
@@ -62,10 +62,9 @@
 #define SCRIPT_TIMEDOUT               (1ULL<<3) /* indicate that the current script timedout */
 #define SCRIPT_KILLED                 (1ULL<<4) /* indicate that the current script was marked to be killed */
 #define SCRIPT_READ_ONLY              (1ULL<<5) /* indicate that the current script should only perform read commands */
-#define SCRIPT_ALLOW_OOM              (1ULL<<6) /* indicate to allow any command even if OOM reached */
+#define SCRIPT_NO_DENY_OOM            (1ULL<<6) /* Indicate that the current script should not perform deny-oom commands */
 #define SCRIPT_EVAL_MODE              (1ULL<<7) /* Indicate that the current script called from legacy Lua */
 #define SCRIPT_ALLOW_CROSS_SLOT       (1ULL<<8) /* Indicate that the current script may access keys from multiple slots */
-#define SCRIPT_NO_DENY_OOM     (1ULL<<9) /* Indicate that the current script should not perform deny-oom commands */
 typedef struct scriptRunCtx scriptRunCtx;
 
 struct scriptRunCtx {
@@ -80,12 +79,11 @@ struct scriptRunCtx {
 
 /* Scripts flags */
 #define SCRIPT_FLAG_NO_WRITES          (1ULL<<0)
-#define SCRIPT_FLAG_ALLOW_OOM          (1ULL<<1)
+#define SCRIPT_FLAG_NO_DENY_OOM        (1ULL<<1)
 #define SCRIPT_FLAG_ALLOW_STALE        (1ULL<<2)
 #define SCRIPT_FLAG_NO_CLUSTER         (1ULL<<3)
 #define SCRIPT_FLAG_EVAL_COMPAT_MODE   (1ULL<<4) /* EVAL Script backwards compatible behavior, no shebang provided */
 #define SCRIPT_FLAG_ALLOW_CROSS_SLOT   (1ULL<<5)
-#define SCRIPT_FLAG_NO_DENY_OOM (1ULL<<6)
 
 /* Defines a script flags */
 typedef struct scriptFlag {

--- a/src/script.h
+++ b/src/script.h
@@ -65,7 +65,7 @@
 #define SCRIPT_ALLOW_OOM              (1ULL<<6) /* indicate to allow any command even if OOM reached */
 #define SCRIPT_EVAL_MODE              (1ULL<<7) /* Indicate that the current script called from legacy Lua */
 #define SCRIPT_ALLOW_CROSS_SLOT       (1ULL<<8) /* Indicate that the current script may access keys from multiple slots */
-#define SCRIPT_NO_INCREASE_MEMORY     (1ULL<<9) /* Indicate that the current script would not increase data memory usage */
+#define SCRIPT_NO_DENY_OOM     (1ULL<<9) /* Indicate that the current script should not perform deny-oom commands */
 typedef struct scriptRunCtx scriptRunCtx;
 
 struct scriptRunCtx {
@@ -85,7 +85,7 @@ struct scriptRunCtx {
 #define SCRIPT_FLAG_NO_CLUSTER         (1ULL<<3)
 #define SCRIPT_FLAG_EVAL_COMPAT_MODE   (1ULL<<4) /* EVAL Script backwards compatible behavior, no shebang provided */
 #define SCRIPT_FLAG_ALLOW_CROSS_SLOT   (1ULL<<5)
-#define SCRIPT_FLAG_NO_INCREASE_MEMORY (1ULL<<6)
+#define SCRIPT_FLAG_NO_DENY_OOM (1ULL<<6)
 
 /* Defines a script flags */
 typedef struct scriptFlag {

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -195,7 +195,7 @@ start_server {tags {"modules"}} {
             return 2
         } 1 x
 
-        assert_error {OOM allow-oom flag is not set on the script,*} {
+        assert_error {OOM no-writes or no-deny-oom flag is not set on the script,*} {
             r test.rm_call eval {#!lua
                 redis.call('get','x')
                 return 3

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1389,14 +1389,14 @@ start_server {tags {"scripting"}} {
 
     test "Unknown shebang flag" {
         catch {
-            r eval {#!lua flags=allow-oom,what?
+            r eval {#!lua flags=what?
                 return 1
             } 0
         } e
         assert_match {*Unexpected flag in script shebang*} $e
     }
 
-    test "allow-oom shebang flag" {
+    test "no-deny-oom shebang flag" {
         r set x 123
     
         r config set maxmemory 1
@@ -1422,15 +1422,15 @@ start_server {tags {"scripting"}} {
             } 0
         }
 
-        # Script with allow-oom can write despite being in OOM state
+        # no-deny-oom scripts can be executed in OOM state
         assert_equal [
-            r eval {#!lua flags=allow-oom
-                redis.call('set','x',1)
+            r eval {#!lua flags=no-deny-oom
+                redis.call('del','no-one')
                 return 1
-            } 1 x
+            } 0
         ] 1
 
-        # read-only scripts implies allow-oom
+        # read-only scripts implies no-deny-oom
         assert_equal [
             r eval {#!lua flags=no-writes
                 redis.call('get','x')
@@ -1442,14 +1442,6 @@ start_server {tags {"scripting"}} {
                 redis.call('get','x')
                 return 1
             } 1 x
-        ] 1
-
-        # no-deny-oom scripts can be executed in OOM state
-        assert_equal [
-            r eval {#!lua flags=no-deny-oom
-                redis.call('del','no-one')
-                return 1
-            } 0
         ] 1
 
         # Script with no shebang can read in OOM state

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1444,9 +1444,9 @@ start_server {tags {"scripting"}} {
             } 1 x
         ] 1
 
-        # no-increase-memory scripts can be executed in OOM state
+        # no-deny-oom scripts can be executed in OOM state
         assert_equal [
-            r eval {#!lua flags=no-increase-memory
+            r eval {#!lua flags=no-deny-oom
                 redis.call('del','no-one')
                 return 1
             } 0
@@ -1471,17 +1471,17 @@ start_server {tags {"scripting"}} {
         r config set maxmemory 0
     } {OK} {needs:config-maxmemory}
 
-    test "no-increase-memory shebang flag" {
-        assert_error {ERR Deny-OOM commands are not allowed from no-increase-memory scripts*} {
-            r eval {#!lua flags=no-increase-memory
+    test "no-deny-oom shebang flag" {
+        assert_error {ERR Deny-OOM commands are not allowed from no-deny-oom scripts*} {
+            r eval {#!lua flags=no-deny-oom
                 redis.call('set','x',1)
                 return 1
             } 1 x
         }
 
-        # Script with no-increase-memory flag can execute read and non deny-oom write command
+        # Script with no-deny-oom flag can execute read and non deny-oom write command
         assert_equal [
-            r eval {#!lua flags=no-increase-memory
+            r eval {#!lua flags=no-deny-oom
                 redis.call('get','x')
                 redis.call('del','x')
                 return 1


### PR DESCRIPTION
Adds `no-increase-memory` flag to Eval scripts and Functions, this flag has two meanings:
1. scripts with this flag cannot run `deny-oom` commands like `SET`, but can run other read and write commands like `GET` and `DEL` (it's a write command but doesn't increase memory)
2. scripts with this flag can run in OOM state

It's a supplement to `allow-oom` flag, the `allow-oom` flag is introduced in #10066 to fix issue #8478, but I don't think it's a perfect and final way, maybe in the future we can find a better method to fix it (one idea is just like MULTI and EXEC, check all `redis.call()` before execute the script or function).

In my POV `allow-oom` flag is very dangerous, it's very easy to write a script breaking `maxmemory` limit. For example when `maxmeory-policy` is `no-evcition`, scripts with `allow-oom` flag can still write (insert) to redis.

I'm not trying to remove `allow-oom` flag in this PR, I just wanna give another flag to some users who knows the danger of `allow-oom` flag. And they can use the new flag to delete data in OOM state, as I know a lot of users run scripts like `eval "redis.call(scan,index,match,pattern) ... redis.call(del,key)"`, and then they can use the `no-increase-memory` to replace `allow-oom` in these scripts.