### PR TITLE
Fix Lua compile warning

### DIFF
--- a/deps/lua/src/lua_bit.c
+++ b/deps/lua/src/lua_bit.c
@@ -98,7 +98,8 @@ static int bit_bnot(lua_State *L) { BRET(~barg(L, 1)) }
 
 #define BIT_OP(func, opr) \
   static int func(lua_State *L) { int i; UBits b = barg(L, 1); \
-    for (i = lua_gettop(L); i > 1; i--) b opr barg(L, i); BRET(b) }
+    for (i = lua_gettop(L); i > 1; i--) b opr barg(L, i);      \
+    BRET(b) }
 BIT_OP(bit_band, &=)
 BIT_OP(bit_bor, |=)
 BIT_OP(bit_bxor, ^=)


### PR DESCRIPTION
Apparently, GCC 11.2.0 has a new fancy warning for misleading indentations. It prints a warning when `BRET(b)` is on the same line as the loop.

```
lua_bit.c: In function ‘bit_band’:
lua_bit.c:101:5: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
  101 |     for (i = lua_gettop(L); i > 1; i--) b opr barg(L, i); BRET(b) }
      |     ^~~
lua_bit.c:102:1: note: in expansion of macro ‘BIT_OP’
  102 | BIT_OP(bit_band, &=)
      | ^~~~~~
lua_bit.c:94:18: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘for’
   94 | #define BRET(b)  lua_pushnumber(L, (lua_Number)(SBits)(b)); return 1;
      |                  ^~~~~~~~~~~~~~
lua_bit.c:101:59: note: in expansion of macro ‘BRET’
  101 |     for (i = lua_gettop(L); i > 1; i--) b opr barg(L, i); BRET(b) }
      |                                                           ^~~~
.....
```