### PR TITLE
Hide low-level encoding details when removing an element from a set.

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -2957,7 +2957,7 @@ void setTypeReleaseIterator(setTypeIterator *si);
 int setTypeNext(setTypeIterator *si, sds *sdsele, int64_t *llele);
 sds setTypeNextObject(setTypeIterator *si);
 int setTypeRandomElement(robj *setobj, sds *sdsele, int64_t *llele);
-unsigned long setTypeRandomElements(robj *set, unsigned long count, robj *aux_set);
+robj *setTypeRemoveRandom(robj *set);
 unsigned long setTypeSize(const robj *subject);
 void setTypeConvert(robj *subject, int enc);
 robj *setTypeDup(robj *o);


### PR DESCRIPTION
A small change to wrap intset and encoding details when making a change to a set.
It does not cover reading from a set. Those code paths are more numerous.

I removed the setTypeRandomElements forward declaration because that function has been long removed from the code base. 