### PR TITLE
rewrite alias config to original name

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1171,18 +1171,13 @@ struct rewriteConfigState *rewriteConfigReadOldFile(char *path) {
          * Append the line and populate the option -> line numbers map. */
         rewriteConfigAppendLine(state,line);
 
-        /* Translate options using the word "slave" to the corresponding name
-         * "replica", before adding such option to the config name -> lines
-         * mapping. */
-        char *p = strstr(argv[0],"slave");
-        if (p) {
-            sds alt = sdsempty();
-            alt = sdscatlen(alt,argv[0],p-argv[0]);
-            alt = sdscatlen(alt,"replica",7);
-            alt = sdscatlen(alt,p+5,strlen(p+5));
+        /* If this is a alias config, replace it with the original name. */
+        standardConfig *s_conf = lookupConfig(argv[0]);
+        if (s_conf && s_conf->flags & ALIAS_CONFIG) {
             sdsfree(argv[0]);
-            argv[0] = alt;
+            argv[0] = sdsnew(s_conf->alias);
         }
+
         /* If this is sentinel config, we use sentinel "sentinel <config>" as option 
             to avoid messing up the sequence. */
         if (server.sentinel_mode && argc > 1 && !strcasecmp(argv[0],"sentinel")) {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -594,3 +594,14 @@ test {CONFIG REWRITE handles rename-command properly} {
     }
 } {} {external:skip}
 
+test {CONFIG REWRITE handles alias config properly} {
+    start_server {tags {"introspection"} overrides {hash-max-listpack-entries 20 hash-max-ziplist-entries 20}} {
+        assert_equal [r config get hash-max-listpack-entries] {hash-max-listpack-entries 20}
+        r config set hash-max-listpack-entries 100
+
+        r config rewrite
+        restart_server 0 true false
+
+        assert_equal [r config get hash-max-listpack-entries] {hash-max-listpack-entries 100}
+    }
+} {} {external:skip}

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -595,8 +595,20 @@ test {CONFIG REWRITE handles rename-command properly} {
 } {} {external:skip}
 
 test {CONFIG REWRITE handles alias config properly} {
-    start_server {tags {"introspection"} overrides {hash-max-listpack-entries 20 hash-max-ziplist-entries 20}} {
-        assert_equal [r config get hash-max-listpack-entries] {hash-max-listpack-entries 20}
+    start_server {tags {"introspection"} overrides {hash-max-listpack-entries 20 hash-max-ziplist-entries 21}} {
+        assert_equal [r config get hash-max-listpack-entries] {hash-max-listpack-entries 21}
+        assert_equal [r config get hash-max-ziplist-entries] {hash-max-ziplist-entries 21}
+        r config set hash-max-listpack-entries 100
+
+        r config rewrite
+        restart_server 0 true false
+
+        assert_equal [r config get hash-max-listpack-entries] {hash-max-listpack-entries 100}
+    }
+    # test the order doesn't matter
+    start_server {tags {"introspection"} overrides {hash-max-ziplist-entries 20 hash-max-listpack-entries 21}} {
+        assert_equal [r config get hash-max-listpack-entries] {hash-max-listpack-entries 21}
+        assert_equal [r config get hash-max-ziplist-entries] {hash-max-ziplist-entries 21}
         r config set hash-max-listpack-entries 100
 
         r config rewrite


### PR DESCRIPTION
Redis 7 adds some new alias config like `hash-max-listpack-entries` alias `hash-max-ziplist-entries`.

If a config file contains both real name and alias like this:
```
hash-max-listpack-entries 20
hash-max-ziplist-entries 20
```

after set `hash-max-listpack-entries` to 100 and `config rewrite`, the config file becomes to:
```
hash-max-listpack-entries 100
hash-max-ziplist-entries 20
```

we can see that the alias config is not modified, and users will get wrong config after restart.

6.0 and 6.2 doesn't have this bug, since they only have the `slave` word alias.