### PR TITLE
Fix bitfield_ro argument description to generate correct documentation

### DIFF
--- a/src/commands/bitfield_ro.json
+++ b/src/commands/bitfield_ro.json
@@ -44,6 +44,7 @@
                 "name": "encoding_offset",
                 "type": "block",
                 "multiple": "true",
+                "multiple_token": "true",
                 "arguments": [
                     {
                         "name": "encoding",


### PR DESCRIPTION
Current documentation only states a single GET token is needed which is not true. Marking the command with multiple_token