### PR TITLE
Update some comments in stream command docs

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1986,7 +1986,7 @@ void streamRewriteTrimArgument(client *c, stream *s, int trim_strategy, int idx)
     decrRefCount(arg);
 }
 
-/* XADD key [NOMKSTREAM] [(MAXLEN [~|=] <count> | MINID [~|=] <id>) [LIMIT <entries>]]  <ID or *> field value [field value...] */
+/* XADD key [(MAXLEN [~|=] <count> | MINID [~|=] <id>) [LIMIT <entries>]] [NOMKSTREAM] <ID or *> [field value] [field value] ... */
 void xaddCommand(client *c) {
     /* Parse options. */
     streamAddTrimArgs parsed_args;
@@ -2153,9 +2153,9 @@ void xlenCommand(client *c) {
     addReplyLongLong(c,s->length);
 }
 
-/* XREAD [BLOCK <milliseconds>] [COUNT <count>] STREAMS key [key...] id [id...] 
+/* XREAD [BLOCK <milliseconds>] [COUNT <count>] STREAMS key_1 key_2 ... key_N
+ *       ID_1 ID_2 ... ID_N 
  *       
- *
  * This function also implements the XREADGROUP command, which is like XREAD
  * but accepting the [GROUP group-name consumer-name] additional option.
  * This is useful because while XREAD is a read command and can be called
@@ -3045,7 +3045,7 @@ void xpendingCommand(client *c) {
     }
 }
 
-/* XCLAIM <key> <group> <consumer> <min-idle-time> <ID> [<ID>...]
+/* XCLAIM <key> <group> <consumer> <min-idle-time> <ID-1> <ID-2>
  *        [IDLE <milliseconds>] [TIME <mstime>] [RETRYCOUNT <count>]
  *        [FORCE] [JUSTID]
  *
@@ -3494,7 +3494,7 @@ void xautoclaimCommand(client *c) {
     preventCommandPropagation(c);
 }
 
-/* XDEL <key> <ID1> [<ID2> ... <IDN>]
+/* XDEL <key> [<ID1> <ID2> ... <IDN>]
  *
  * Removes the specified entries from the stream. Returns the number
  * of items actually deleted, that may be different from the number

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2154,8 +2154,8 @@ void xlenCommand(client *c) {
 }
 
 /* XREAD [BLOCK <milliseconds>] [COUNT <count>] STREAMS key_1 key_2 ... key_N
- *       ID_1 ID_2 ... ID_N 
- *       
+ *       ID_1 ID_2 ... ID_N
+ *
  * This function also implements the XREADGROUP command, which is like XREAD
  * but accepting the [GROUP group-name consumer-name] additional option.
  * This is useful because while XREAD is a read command and can be called

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2153,7 +2153,7 @@ void xlenCommand(client *c) {
     addReplyLongLong(c,s->length);
 }
 
-/* XREAD [COUNT <count>] [BLOCK <milliseconds>] STREAMS key [key...] id [id...] 
+/* XREAD [BLOCK <milliseconds>] [COUNT <count>] STREAMS key [key...] id [id...] 
  *       
  *
  * This function also implements the XREADGROUP command, which is like XREAD
@@ -2734,7 +2734,7 @@ NULL
     }
 }
 
-/* XSETID <key> <id> [ENTRIESADDED entries_added] [MAXDELETEDID max_deleted_entry_id]
+/* XSETID <stream> <id> [ENTRIESADDED entries_added] [MAXDELETEDID max_deleted_entry_id]
  *
  * Set the internal "last ID", "added entries" and "maximal deleted entry ID"
  * of a stream. */
@@ -2804,8 +2804,7 @@ void xsetidCommand(client *c) {
     notifyKeyspaceEvent(NOTIFY_STREAM,"xsetid",c->argv[1],c->db->id);
 }
 
-/* XACK <key> <group> <id> [<id>...]
- *
+/* XACK <key> <group> <id> <id> ... <id>
  * Acknowledge a message as processed. In practical terms we just check the
  * pending entries list (PEL) of the group, and delete the PEL entry both from
  * the group and the consumer (pending messages are referenced in both places).


### PR DESCRIPTION
When I take a look the XStream data type, I found some comments does not match with our current documentation or command format, thus I update them to latest version.