### PR TITLE
fix unused argument warning in ae_select.c

### DIFF
--- a/src/ae_select.c
+++ b/src/ae_select.c
@@ -50,6 +50,7 @@ static int aeApiCreate(aeEventLoop *eventLoop) {
 }
 
 static int aeApiResize(aeEventLoop *eventLoop, int setsize) {
+    AE_NOTUSED(eventLoop);
     /* Just ensure we have enough room in the fd_set type. */
     if (setsize >= FD_SETSIZE) return -1;
     return 0;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38821215/172370947-7d1d4668-6f53-4837-bfe1-d495985514f6.png)
branch 7.0 

windows