### PR TITLE
Try to compress rax compressed node after removing its key

### DIFF
--- a/src/rax.c
+++ b/src/rax.c
@@ -1080,8 +1080,8 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
                 h = new;
             }
         }
-    } else if (h->size == 1) {
-        /* If the node had just one child, after the removal of the key
+    } else if (h->size == 1 || h->iscompr) {
+        /* If the node had just one child, or a compressed node, after the removal of the key
          * further compression with adjacent nodes is potentially possible. */
         trycompress = 1;
     }


### PR DESCRIPTION
As the comments in the code indicate, when rax deletes a key, if the node is a compressed node,
we should also try to compress it.

```
* Example of case "1". A tree stores the keys "FOO" = 1 and
* "FOOBAR" = 2:
*
*
* "FOO" -> "BAR" -> [] (2)
*           (1)
*
* After the removal of "FOO" the tree can be compressed as:
*
* "FOOBAR" -> [] (2)
```

## Test code:
```c
    rax *r = raxNew();
    raxInsert(r,(unsigned char*)"FOO",3,(void*)1,NULL);
    raxInsert(r,(unsigned char*)"FOOBAR",6,(void*)2,NULL);
    raxRemove(r, (unsigned char*)"FOO",3, NULL);
    raxShow(r);
```

## Output
Before this PR:
```
"FOO" -> "BAR" -> []=0x2
```

After this PR:
```
"FOOBAR" -> []=0x2
```