### PR TITLE
Update musl libc detection pattern

### DIFF
--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -9,7 +9,7 @@ if {$system_name eq {darwin}} {
 } elseif {$system_name eq {linux}} {
     # Avoid the test on libmusl, which does not support backtrace
     set ldd [exec ldd src/redis-server]
-    if {![string match {*libc.musl*} $ldd]} {
+    if {![string match {*libc.*musl*} $ldd]} {
         set backtrace_supported 1
     }
 }


### PR DESCRIPTION
This change fixes failing `integration/logging.tcl` test in Gentoo with musl libc, where `ldd` returns
```
libc.so => /lib/ld-musl-x86_64.so.1 (0x7f9d5f171000)
```
unlike Alpine's
```
libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7f82cfa16000)
```
The solution is to extend matching pattern introduced in #8532 by @yossigo.