### PR TITLE
Module api doc generator, fixing issue with negative lookback terminating at "."

### DIFF
--- a/utils/generate-module-api-doc.rb
+++ b/utils/generate-module-api-doc.rb
@@ -20,7 +20,7 @@ def markdown(s)
             # Add backquotes around RedisModule functions and type where missing.
             l = l.gsub(/(?<!`)RedisModule[A-z]+(?:\*?\(\))?/){|x| "`#{x}`"}
             # Add backquotes around c functions like malloc() where missing.
-            l = l.gsub(/(?<![`A-z])[a-z_]+\(\)/, '`\0`')
+            l = l.gsub(/(?<![`A-z.])[a-z_]+\(\)/, '`\0`')
             # Add backquotes around macro and var names containing underscores.
             l = l.gsub(/(?<![`A-z\*])[A-Za-z]+_[A-Za-z0-9_]+/){|x| "`#{x}`"}
             # Link URLs preceded by space or newline (not already linked)


### PR DESCRIPTION
@oranagra Turns out there is a little regex that wraps up all the free-floating functions in the doc-block e.g. malloc() with backticks - looks like the issue that you pointed out in redis/redis-doc#1991 originates from this regex looking at

```
`redis.call()`
```

and terminating on the period - hence wrapping call() in backticks see [here](https://github.com/redis/redis-doc/blob/a14b449a95b12874085a1dde6df0cf066d7548b6/docs/reference/modules/modules-api-ref.md?plain=1#L5903)

Adding a period to the negative lookback appears to produce an identical file to the current state of the module API ref in redis-doc (after you fixed the markdown)