### PR TITLE
Fixing test to consider statically linked binaries

### DIFF
--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -8,8 +8,8 @@ if {$system_name eq {darwin}} {
     set backtrace_supported 1
 } elseif {$system_name eq {linux}} {
     # Avoid the test on libmusl, which does not support backtrace
-    set static [exec file src/redis-server]
-    if {![string match {*statically linked*} $static]} {
+    # and on static binaries (ldd exit code 1) where we can't detect libmusl
+    catch {
         set ldd [exec ldd src/redis-server]
         if {![string match {*libc.*musl*} $ldd]} {
             set backtrace_supported 1

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -8,9 +8,12 @@ if {$system_name eq {darwin}} {
     set backtrace_supported 1
 } elseif {$system_name eq {linux}} {
     # Avoid the test on libmusl, which does not support backtrace
-    set ldd [exec ldd src/redis-server]
-    if {![string match {*libc.*musl*} $ldd]} {
-        set backtrace_supported 1
+    set static [exec file src/redis-server]
+    if {![string match {*statically linked*} $static]} {
+        set ldd [exec ldd src/redis-server]
+        if {![string match {*libc.*musl*} $ldd]} {
+            set backtrace_supported 1
+        }
     }
 }
 


### PR DESCRIPTION
The test calls `ldd` on `redis-server` in order to find out whether the binary
was linked against `libmusl`; However, `ldd` returns a value different from `0`
when statically linking the binaries agains libc-musl, because `redis-server` is
not a dynamic executable (as given by the exception thrown by the failing test),
and `make test` terminates with an error:

    $ ldd src/redis-server
        not a dynamic executable
    $ echo $?
    1

This commit fixes the test by adding another check to find out whether `Redis`
was statically linked, and only call `ldd` if this is not the case.

With that fix, all tests pass without errors, when building statically linked
binaries.