### PR TITLE
Correctly check for vm.overcommit_memory == 0

### DIFF
--- a/src/syscheck.c
+++ b/src/syscheck.c
@@ -150,7 +150,7 @@ int checkOvercommit(sds *error_msg) {
     }
     fclose(fp);
 
-    if (atoi(buf)) {
+    if (strtol(buf, NULL, 10) == 0) {
         *error_msg = sdsnew(
             "WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. "
             "To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the "


### PR DESCRIPTION
A regression caused by #10636 (released in 7.0.1) causes Redis startup warning about overcommit to be missing when needed and printed when not. 

Also, using atoi() to convert the string's value to an integer cannot discern
between an actual 0 (zero) having been read, or a conversion error. 

### Behavior after fix (warns correctly):
```bash
$ sudo sysctl -w vm.overcommit_memory=0
vm.overcommit_memory = 0
$ ./src/redis-server 2>&1 | grep -F vm.overcommit
69889:M 09 Jun 2022 17:19:22.922 # WARNING WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
^C
$ sudo sysctl -w vm.overcommit_memory=1
vm.overcommit_memory = 1
$ ./src/redis-server 2>&1 | grep -F vm.overcommit
^C
```

### Behavior as of 7.0.1 (bogus warning):
```bash
$ sudo sysctl -w vm.overcommit_memory=0
vm.overcommit_memory = 0
$ ./src/redis-server 2>&1 | grep -F vm.overcommit
^C
$ sudo sysctl -w vm.overcommit_memory=1
vm.overcommit_memory = 1
$ ./src/redis-server 2>&1 | grep -F vm.overcommit
70145:M 09 Jun 2022 17:20:51.930 # WARNING WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
^C
```