### PR TITLE
Clarifying that sdshdr5 is not "never used"

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -1341,34 +1341,41 @@ int sdsTest(int argc, char **argv, int flags) {
         sds x = sdsnew("foo"), y;
 
         test_cond("Create a string and obtain the length",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(x) == 3 && memcmp(x,"foo\0",4) == 0);
 
         sdsfree(x);
         x = sdsnewlen("foo",2);
         test_cond("Create a string with specified length",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(x) == 2 && memcmp(x,"fo\0",3) == 0);
 
         x = sdscat(x,"bar");
         test_cond("Strings concatenation",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_8 &&
             sdslen(x) == 5 && memcmp(x,"fobar\0",6) == 0);
 
         x = sdscpy(x,"a");
         test_cond("sdscpy() against an originally longer string",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_8 &&
             sdslen(x) == 1 && memcmp(x,"a\0",2) == 0);
 
         x = sdscpy(x,"xyzxxxxxxxxxxyyyyyyyyyykkkkkkkkkk");
         test_cond("sdscpy() against an originally shorter string",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_8 &&
             sdslen(x) == 33 &&
             memcmp(x,"xyzxxxxxxxxxxyyyyyyyyyykkkkkkkkkk\0",33) == 0);
 
         sdsfree(x);
         x = sdscatprintf(sdsempty(),"%d",123);
         test_cond("sdscatprintf() seems working in the base case",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_8 &&
             sdslen(x) == 3 && memcmp(x,"123\0",4) == 0);
 
         sdsfree(x);
         x = sdscatprintf(sdsempty(),"a%cb",0);
         test_cond("sdscatprintf() seems working with \\0 inside of result",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_8 &&
             sdslen(x) == 3 && memcmp(x,"a\0""b\0",4) == 0);
 
         {
@@ -1379,6 +1386,7 @@ int sdsTest(int argc, char **argv, int flags) {
             }
             x = sdscatprintf(sdsempty(),"%0*d",(int)sizeof(etalon),0);
             test_cond("sdscatprintf() can print 1MB",
+                (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_32 &&
                 sdslen(x) == sizeof(etalon) && memcmp(x,etalon,sizeof(etalon)) == 0);
         }
 
@@ -1387,80 +1395,92 @@ int sdsTest(int argc, char **argv, int flags) {
         x = sdscatfmt(x, "Hello %s World %I,%I--", "Hi!", LLONG_MIN,LLONG_MAX);
         test_cond("sdscatfmt() seems working in the base case",
             sdslen(x) == 60 &&
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_8 &&
             memcmp(x,"--Hello Hi! World -9223372036854775808,"
                      "9223372036854775807--",60) == 0);
-        printf("[%s]\n",x);
 
         sdsfree(x);
         x = sdsnew("--");
         x = sdscatfmt(x, "%u,%U--", UINT_MAX, ULLONG_MAX);
         test_cond("sdscatfmt() seems working with unsigned numbers",
             sdslen(x) == 35 &&
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_8 &&
             memcmp(x,"--4294967295,18446744073709551615--",35) == 0);
 
         sdsfree(x);
         x = sdsnew(" x ");
         sdstrim(x," x");
         test_cond("sdstrim() works when all chars match",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(x) == 0);
 
         sdsfree(x);
         x = sdsnew(" x ");
         sdstrim(x," ");
         test_cond("sdstrim() works when a single char remains",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(x) == 1 && x[0] == 'x');
 
         sdsfree(x);
         x = sdsnew("xxciaoyyy");
         sdstrim(x,"xy");
         test_cond("sdstrim() correctly trims characters",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(x) == 4 && memcmp(x,"ciao\0",5) == 0);
 
         y = sdsdup(x);
         sdsrange(y,1,1);
         test_cond("sdsrange(...,1,1)",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(y) == 1 && memcmp(y,"i\0",2) == 0);
 
         sdsfree(y);
         y = sdsdup(x);
         sdsrange(y,1,-1);
         test_cond("sdsrange(...,1,-1)",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(y) == 3 && memcmp(y,"iao\0",4) == 0);
 
         sdsfree(y);
         y = sdsdup(x);
         sdsrange(y,-2,-1);
         test_cond("sdsrange(...,-2,-1)",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(y) == 2 && memcmp(y,"ao\0",3) == 0);
 
         sdsfree(y);
         y = sdsdup(x);
         sdsrange(y,2,1);
         test_cond("sdsrange(...,2,1)",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(y) == 0 && memcmp(y,"\0",1) == 0);
 
         sdsfree(y);
         y = sdsdup(x);
         sdsrange(y,1,100);
         test_cond("sdsrange(...,1,100)",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(y) == 3 && memcmp(y,"iao\0",4) == 0);
 
         sdsfree(y);
         y = sdsdup(x);
         sdsrange(y,100,100);
         test_cond("sdsrange(...,100,100)",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(y) == 0 && memcmp(y,"\0",1) == 0);
 
         sdsfree(y);
         y = sdsdup(x);
         sdsrange(y,4,6);
         test_cond("sdsrange(...,4,6)",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(y) == 0 && memcmp(y,"\0",1) == 0);
 
         sdsfree(y);
         y = sdsdup(x);
         sdsrange(y,3,6);
         test_cond("sdsrange(...,3,6)",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             sdslen(y) == 1 && memcmp(y,"o\0",2) == 0);
 
         sdsfree(y);
@@ -1486,6 +1506,7 @@ int sdsTest(int argc, char **argv, int flags) {
         x = sdsnewlen("\a\n\0foo\r",7);
         y = sdscatrepr(sdsempty(),x,sdslen(x));
         test_cond("sdscatrepr(...data...)",
+            (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5 &&
             memcmp(y,"\"\\a\\n\\x00foo\\r\"",15) == 0);
 
         {
@@ -1519,6 +1540,7 @@ int sdsTest(int argc, char **argv, int flags) {
                 sdsIncrLen(x,step);
             }
             test_cond("sdsMakeRoomFor() content",
+                (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_8 &&
                 memcmp("0ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ",x,101) == 0);
             test_cond("sdsMakeRoomFor() final length",sdslen(x)==101);
 
@@ -1528,6 +1550,7 @@ int sdsTest(int argc, char **argv, int flags) {
         /* Simple template */
         x = sdstemplate("v1={variable1} v2={variable2}", sdsTestTemplateCallback, NULL);
         test_cond("sdstemplate() normal flow",
+                  (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_8 &&
                   memcmp(x,"v1=value1 v2=value2",19) == 0);
         sdsfree(x);
 
@@ -1546,6 +1569,7 @@ int sdsTest(int argc, char **argv, int flags) {
         /* Template with quoting */
         x = sdstemplate("v1={{{variable1}} {{} v2={variable2}", sdsTestTemplateCallback, NULL);
         test_cond("sdstemplate() with quoting",
+                  (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_8 &&
                   memcmp(x,"v1={value1} {} v2=value2",24) == 0);
         sdsfree(x);
 
@@ -1575,8 +1599,16 @@ int sdsTest(int argc, char **argv, int flags) {
         test_cond("sdsrezie() crop len", sdslen(x) == 4);
         test_cond("sdsrezie() crop strlen", strlen(x) == 4);
         test_cond("sdsrezie() crop alloc", sdsalloc(x) == 4);
+        test_cond("sdsrezie() crop type", (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_8);
         sdsfree(x);
     }
+
+    if (__failed_tests != 0) {
+        printf("%d tests failed, please check.\n", __failed_tests);
+        return 1;
+    }
+
+    printf("ALL TESTS PASSED!\n");
     return 0;
 }
 #endif

--- a/src/sds.h
+++ b/src/sds.h
@@ -42,8 +42,6 @@ extern const char *SDS_NOINIT;
 
 typedef char *sds;
 
-/* Note: sdshdr5 is never used, we just access the flags byte directly.
- * However is here to document the layout of type 5 SDS strings. */
 struct __attribute__ ((__packed__)) sdshdr5 {
     unsigned char flags; /* 3 lsb of type, and 5 msb of string length */
     char buf[];


### PR DESCRIPTION
I was once asked that if sdshrd5 is really not used.
One thing i can confirm is that the "key" with string length
less than 32 are using sdshdr5. Like sdsnew("abc") is using sdshdr5.

These key names like "a", "abc" below stored in `db->dict` will use sdshdr5:
```
set a 1
set abc 3
set 1234567890123456789012345678901 31
```

This commit also adds some type of judgement in sdsTest.
It should be easy for people to find it, if searching for type references.
Previously when sdsTest failed, it also returned 0, also fixed it.