### PR TITLE
Fix crash when overcommit_memory is inaccessible

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6028,7 +6028,7 @@ static int THPDisable(void) {
 }
 
 void linuxMemoryWarnings(void) {
-    sds err_msg;
+    sds err_msg = NULL;
     if (checkOvercommit(&err_msg) < 0) {
         serverLog(LL_WARNING,"WARNING %s", err_msg);
         sdsfree(err_msg);
@@ -6939,7 +6939,7 @@ int main(int argc, char **argv) {
         serverLog(LL_WARNING,"Server initialized");
     #ifdef __linux__
         linuxMemoryWarnings();
-        sds err_msg;
+        sds err_msg = NULL;
         if (checkXenClocksource(&err_msg) < 0) {
             serverLog(LL_WARNING, "WARNING %s", err_msg);
             sdsfree(err_msg);

--- a/src/syscheck.c
+++ b/src/syscheck.c
@@ -143,7 +143,7 @@ int checkOvercommit(sds *error_msg) {
     FILE *fp = fopen("/proc/sys/vm/overcommit_memory","r");
     char buf[64];
 
-    if (!fp) return -1;
+    if (!fp) return 0;
     if (fgets(buf,64,fp) == NULL) {
         fclose(fp);
         return 0;
@@ -152,7 +152,7 @@ int checkOvercommit(sds *error_msg) {
 
     if (atoi(buf)) {
         *error_msg = sdsnew(
-            "WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. "
+            "overcommit_memory is set to 0! Background save may fail under low memory condition. "
             "To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the "
             "command 'sysctl vm.overcommit_memory=1' for this to take effect.");
         return -1;

--- a/src/syscheck.c
+++ b/src/syscheck.c
@@ -351,7 +351,7 @@ check checks[] = {
 int syscheck(void) {
     check *cur_check = checks;
     int ret = 1;
-    sds err_msg;
+    sds err_msg = NULL;
     while (cur_check->check_fn) {
         int res = cur_check->check_fn(&err_msg);
         printf("[%s]...", cur_check->name);


### PR DESCRIPTION
When `/proc/sys/vm/overcommit_memory` is inaccessible, fp is NULL.
`checkOvercommit` will return -1 without setting err_msg, and then
the err_msg is used to print the log, crash the server.
Set the err_msg variables to Null when declaring it, seems safer.

And the overcommit_memory error log will print two "WARNING",
like `WARNING WARNING overcommit_memory is set to 0!`, this PR
also removes the second WARNING in `checkOvercommit`.

Reported in #10846. Fixes #10846. Introduced in #10636 (7.0.1)