### PR TITLE
Add RM_ReplyWithHelloResponse

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3132,6 +3132,18 @@ int RM_ReplyWithLongDouble(RedisModuleCtx *ctx, long double ld) {
     return REDISMODULE_OK;
 }
 
+/* Reply with the HELLO command's response. The format (RESP 2 or 3) will
+ * depend on the client's proto field.
+ * This function uses `addReplyHelloResponse` from networking.c.
+ *
+ * The function always returns REDISMODULE_OK. */
+int RM_ReplyWithHelloResponse(RedisModuleCtx *ctx) {
+    client *c = moduleGetReplyClient(ctx);
+    if (c == NULL) return REDISMODULE_OK;
+    addReplyHelloResponse(c);
+    return REDISMODULE_OK;
+}
+
 /* --------------------------------------------------------------------------
  * ## Commands replication API
  * -------------------------------------------------------------------------- */
@@ -12370,6 +12382,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ReplyWithDouble);
     REGISTER_API(ReplyWithBigNumber);
     REGISTER_API(ReplyWithLongDouble);
+    REGISTER_API(ReplyWithHelloResponse);
     REGISTER_API(GetSelectedDb);
     REGISTER_API(SelectDb);
     REGISTER_API(KeyExists);

--- a/src/networking.c
+++ b/src/networking.c
@@ -3420,6 +3420,36 @@ NULL
     }
 }
 
+/* Adds the HELLO Command response to the reply .*/
+void addReplyHelloResponse(client *c) {
+    addReplyMapLen(c,6 + !server.sentinel_mode);
+
+    addReplyBulkCString(c,"server");
+    addReplyBulkCString(c,"redis");
+
+    addReplyBulkCString(c,"version");
+    addReplyBulkCString(c,REDIS_VERSION);
+
+    addReplyBulkCString(c,"proto");
+    addReplyLongLong(c,c->resp);
+
+    addReplyBulkCString(c,"id");
+    addReplyLongLong(c,c->id);
+
+    addReplyBulkCString(c,"mode");
+    if (server.sentinel_mode) addReplyBulkCString(c,"sentinel");
+    else if (server.cluster_enabled) addReplyBulkCString(c,"cluster");
+    else addReplyBulkCString(c,"standalone");
+
+    if (!server.sentinel_mode) {
+        addReplyBulkCString(c,"role");
+        addReplyBulkCString(c,server.masterhost ? "replica" : "master");
+    }
+
+    addReplyBulkCString(c,"modules");
+    addReplyLoadedModules(c);
+}
+
 /* HELLO [<protocol-version> [AUTH <user> <password>] [SETNAME <name>] ] */
 void helloCommand(client *c) {
     long long ver = 0;
@@ -3468,32 +3498,7 @@ void helloCommand(client *c) {
 
     /* Let's switch to the specified RESP mode. */
     if (ver) c->resp = ver;
-    addReplyMapLen(c,6 + !server.sentinel_mode);
-
-    addReplyBulkCString(c,"server");
-    addReplyBulkCString(c,"redis");
-
-    addReplyBulkCString(c,"version");
-    addReplyBulkCString(c,REDIS_VERSION);
-
-    addReplyBulkCString(c,"proto");
-    addReplyLongLong(c,c->resp);
-
-    addReplyBulkCString(c,"id");
-    addReplyLongLong(c,c->id);
-
-    addReplyBulkCString(c,"mode");
-    if (server.sentinel_mode) addReplyBulkCString(c,"sentinel");
-    else if (server.cluster_enabled) addReplyBulkCString(c,"cluster");
-    else addReplyBulkCString(c,"standalone");
-
-    if (!server.sentinel_mode) {
-        addReplyBulkCString(c,"role");
-        addReplyBulkCString(c,server.masterhost ? "replica" : "master");
-    }
-
-    addReplyBulkCString(c,"modules");
-    addReplyLoadedModules(c);
+    addReplyHelloResponse(c);
 }
 
 /* This callback is bound to POST and "Host:" command names. Those are not

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -947,6 +947,7 @@ REDISMODULE_API int (*RedisModule_ReplyWithLongDouble)(RedisModuleCtx *ctx, long
 REDISMODULE_API int (*RedisModule_ReplyWithDouble)(RedisModuleCtx *ctx, double d) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithBigNumber)(RedisModuleCtx *ctx, const char *bignum, size_t len) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithCallReply)(RedisModuleCtx *ctx, RedisModuleCallReply *reply) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithHelloResponse)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StringToLongLong)(const RedisModuleString *str, long long *ll) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StringToDouble)(const RedisModuleString *str, double *d) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StringToLongDouble)(const RedisModuleString *str, long double *d) REDISMODULE_ATTR;
@@ -1244,6 +1245,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ReplyWithDouble);
     REDISMODULE_GET_API(ReplyWithBigNumber);
     REDISMODULE_GET_API(ReplyWithLongDouble);
+    REDISMODULE_GET_API(ReplyWithHelloResponse);
     REDISMODULE_GET_API(GetSelectedDb);
     REDISMODULE_GET_API(SelectDb);
     REDISMODULE_GET_API(KeyExists);

--- a/src/server.h
+++ b/src/server.h
@@ -2486,6 +2486,7 @@ void addReplyPushLen(client *c, long length);
 void addReplyHelp(client *c, const char **help);
 void addReplySubcommandSyntaxError(client *c);
 void addReplyLoadedModules(client *c);
+void addReplyHelloResponse(client *c);
 void copyReplicaOutputBuffer(client *dst, client *src);
 void addListRangeReply(client *c, robj *o, long start, long end, int reverse);
 void deferredAfterErrorReply(client *c, list *errors);

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -354,6 +354,13 @@ int test_rm_call_flags(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
     return REDISMODULE_OK;
 }
 
+int test_reply_with_hello_resp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    RedisModule_ReplyWithHelloResponse(ctx);
+    return REDISMODULE_OK;
+}
+
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
@@ -398,6 +405,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_CreateCommand(ctx, "test.rm_call", test_rm_call,"allow-stale", 0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
     if (RedisModule_CreateCommand(ctx, "test.rm_call_flags", test_rm_call_flags,"allow-stale", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx,"test.rm_reply_with_hello_resp", test_reply_with_hello_resp,"",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     return REDISMODULE_OK;

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -350,6 +350,16 @@ start_server {tags {"modules"}} {
         r set x y
     } {OK}
 
+    test {test module replywithhello api} {
+        # Set the protocol field to 2
+        r HELLO 2
+        assert_equal [r HELLO 2] [r test.rm_reply_with_hello_resp]
+
+        # Set the protocol field to 3
+        r HELLO 3
+        assert_equal [r HELLO 3] [r test.rm_reply_with_hello_resp]
+    }
+
     test "Unload the module - misc" {
         assert_equal {OK} [r module unload misc]
     }


### PR DESCRIPTION
This is a follow up for the issue here - https://github.com/redis/redis/issues/10709 - with which Modules can set the client name and protocol.

## The problem/use-case that the feature addresses
It is very difficult to implement a custom AUTH command, since we also need to support the HELLO case.
Currently, there is no way for a Redis Module to directly reply to the client with the HELLO command’s response.

## Description of the feature
Create a new Module API - `RM_ReplyWithHelloResponse`
When this API is used on a `RedisModuleContext`, it will reply to the client with the HELLO command’s response in the same RESP format that the client has set in its `resp` field.
With this API (and the other two APIs from the earlier issue to set the client name / protocol), Module developers can now create a custom HELLO command.
