### PR TITLE
Script that made modification will not break with unexpected NOREPLICAS error

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -363,6 +363,11 @@ static int scriptVerifyWriteCommandAllow(scriptRunCtx *run_ctx, char **err) {
     if (!(run_ctx->c->cmd->flags & CMD_WRITE))
         return C_OK;
 
+    /* If the script already made a modification to the dataset, we can't
+     * fail it on unpredictable error state. */
+    if ((run_ctx->flags & SCRIPT_WRITE_DIRTY))
+        return C_OK;
+
     /* Write commands are forbidden against read-only slaves, or if a
      * command marked as non-deterministic was already called in the context
      * of this script. */

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1596,7 +1596,11 @@ start_server {tags {"scripting"}} {
                 return 1
             } 1 x
 
-            after 100
+            wait_for_condition 50 100 {
+                [catch {r -1 ping} e] == 1
+            } else {
+                fail "Can't wait for script to start running"
+            }
             catch {r -1 ping} e
             assert_match {BUSY*} $e
 

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1585,14 +1585,14 @@ start_server {tags {"scripting"}} {
 
             set rd [redis_deferring_client -1]
             $rd eval {
-                    redis.call('set','x',"script value")
-                    while true do
-                        local info = redis.call('info','replication')
-                        if (string.match(info, "connected_slaves:0")) then
-                            redis.call('set','x',info)
-                            break
-                        end
+                redis.call('set','x',"script value")
+                while true do
+                    local info = redis.call('info','replication')
+                    if (string.match(info, "connected_slaves:0")) then
+                        redis.call('set','x',info)
+                        break
                     end
+                end
                 return 1
             } 1 x
 

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1596,7 +1596,7 @@ start_server {tags {"scripting"}} {
                 return 1
             } 1 x
 
-            wait_for_condition 50 100 {
+            wait_for_condition 100 100 {
                 [catch {r -1 ping} e] == 1
             } else {
                 fail "Can't wait for script to start running"


### PR DESCRIPTION
If a script made a modification and then was interrupted for taking too long.
there's a chance redis will detect that a replica dropped and would like to reject
write commands with NOREPLICAS due to insufficient good replicas.
returning an error on a command in this case breaks the script atomicity.

The same could in theory happen with READONLY, MISCONF, but i don't think
these state changes can happen during script execution.