### PR TITLE
redis-server command line arguments allow passing config name and value in the same arg

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6908,12 +6908,21 @@ int main(int argc, char **argv) {
                     if ((j != argc-1) && argv[j+1][0] == '-' && argv[j+1][1] == '-' &&
                         !strcasecmp(argv[j], "--save"))
                     {
-                        /* Special case: handle some thing like `--save --config value`.
+                        /* Special case: handle some things like `--save --config value`.
                          * In this case, if next argument starts with `--`, we will reset
                          * handled_last_config_arg flag and append an empty "" config value
-                         * to the options, so it will become `--save "" --config value`. */
+                         * to the options, so it will become `--save "" --config value`.
+                         * We are doing it to be compatible with pre 7.0 behavior (which we
+                         * break it in #10660, 7.0.1), since there might be users who generate
+                         * a command line from an array and when it's empty that's what they produce. */
                         options = sdscat(options, "\"\"");
                         handled_last_config_arg = 1;
+                    }
+                    else if ((j == argc-1) && !strcasecmp(argv[j], "--save")) {
+                        /* Special case: when emtpy save is the last argument.
+                         * In this case, we append an empty "" config value to the options,
+                         * so it will become `--save ""` and will follow the same reset thing. */
+                        options = sdscat(options, "\"\"");
                     }
                 } else {
                     /* Means that we are passing both config name and it's value in the same arg,

--- a/src/server.c
+++ b/src/server.c
@@ -6919,7 +6919,7 @@ int main(int argc, char **argv) {
                         handled_last_config_arg = 1;
                     }
                     else if ((j == argc-1) && !strcasecmp(argv[j], "--save")) {
-                        /* Special case: when emtpy save is the last argument.
+                        /* Special case: when empty save is the last argument.
                          * In this case, we append an empty "" config value to the options,
                          * so it will become `--save ""` and will follow the same reset thing. */
                         options = sdscat(options, "\"\"");

--- a/src/server.c
+++ b/src/server.c
@@ -6930,8 +6930,6 @@ int main(int argc, char **argv) {
             j++;
         }
 
-        serverLog(LL_WARNING, "options: \n %s", options);
-
         loadServerConfig(server.configfile, config_from_stdin, options);
         if (server.sentinel_mode) loadSentinelConfigFromQueue();
         sdsfree(options);

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -503,8 +503,30 @@ start_server {tags {"introspection"}} {
         assert_match {*'replicaof "--127.0.0.1"'*wrong number of arguments*} $err
     } {} {external:skip}
 
+    test {redis-server command line arguments - allow passing option name and option value in the same arg} {
+        start_server {config "default.conf" args {"--maxmemory 700mb" "--maxmemory-policy volatile-lru"}} {
+            assert_match [r config get maxmemory] {maxmemory 734003200}
+            assert_match [r config get maxmemory-policy] {maxmemory-policy volatile-lru}
+        }
+    } {} {external:skip}
+
+    test {redis-server command line arguments - wrong usage} {
+        start_server {config "default.conf" args {loglevel verbose "--maxmemory '700mb'" "--maxmemory-policy 'volatile-lru'"}} {
+            assert_match [r config get loglevel] {loglevel verbose}
+            assert_match [r config get maxmemory] {maxmemory 734003200}
+            assert_match [r config get maxmemory-policy] {maxmemory-policy volatile-lru}
+        }
+    } {} {external:skip}
+
     test {redis-server command line arguments - allow option value to use the `--` prefix} {
         start_server {config "default.conf" args {--proc-title-template --my--title--template --loglevel verbose}} {
+            assert_match [r config get proc-title-template] {proc-title-template --my--title--template}
+            assert_match [r config get loglevel] {loglevel verbose}
+        }
+    } {} {external:skip}
+
+    test {redis-server command line arguments - option name and option value in the same arg and `--` prefix} {
+        start_server {config "default.conf" args {"--proc-title-template --my--title--template" "--loglevel verbose"}} {
             assert_match [r config get proc-title-template] {proc-title-template --my--title--template}
             assert_match [r config get loglevel] {loglevel verbose}
         }

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -510,7 +510,7 @@ start_server {tags {"introspection"}} {
         }
     } {} {external:skip}
 
-    test {redis-server command line arguments - wrong usage} {
+    test {redis-server command line arguments - wrong usage that we support anyway} {
         start_server {config "default.conf" args {loglevel verbose "--maxmemory '700mb'" "--maxmemory-policy 'volatile-lru'"}} {
             assert_match [r config get loglevel] {loglevel verbose}
             assert_match [r config get maxmemory] {maxmemory 734003200}
@@ -539,8 +539,7 @@ start_server {tags {"introspection"}} {
         }
 
         start_server {config "default.conf" args {--loglevel verbose --save}} {
-            # --save is the last arg, in this case we won't reset the save params
-            assert_match [r config get save] {save {900 1}}
+            assert_match [r config get save] {save {}}
             assert_match [r config get loglevel] {loglevel verbose}
         }
 


### PR DESCRIPTION
This PR has two topics.

## Passing config name and value in the same arg
In #10660 (Redis 7.0.1), when we supported the config values that can start with `--` prefix (one of the two topics of that PR),
we broke another pattern: `redis-server redis.config "name value"`, passing both config name
and it's value in the same arg, see #10865

This wasn't a intended change (i.e we didn't realize this pattern used to work).
Although this is a wrong usage, we still like to fix it.

Now we support something like:
```
src/redis-server redis.conf "--maxmemory '700mb'" "--maxmemory-policy volatile-lru" --proc-title-template --my--title--template --loglevel verbose
```

## Changes around --save
Also in this PR, we undo the breaking change we made in #10660 on purpose.
1. `redis-server redis.conf --save --loglevel verbose` (missing `save` argument before anotehr argument).
    In 7.0.1, it was throwing an wrong arg error.
    Now it will work and reset the save, similar to how it used to be in 7.0.0 and 6.2.x.
3. `redis-server redis.conf --loglevel verbose --save` (missing `save` argument as last argument).
    In 6.2, it did not reset the save, which was a bug (inconsistent with the previous bullet).
    Now we will make it work and reset the save as well (a bug fix).