### PR TITLE
Fix a prototype inconsitency of `_serverAssert` between redisassert.h and redis.h

### DIFF
--- a/src/redisassert.h
+++ b/src/redisassert.h
@@ -43,7 +43,7 @@
 #define assert(_e) (likely((_e))?(void)0 : (_serverAssert(#_e,__FILE__,__LINE__),redis_unreachable()))
 #define panic(...) _serverPanic(__FILE__,__LINE__,__VA_ARGS__),redis_unreachable()
 
-void _serverAssert(char *estr, char *file, int line);
+void _serverAssert(const char *estr, const char *file, int line);
 void _serverPanic(const char *file, int line, const char *msg, ...);
 
 #endif


### PR DESCRIPTION
https://github.com/redis/redis/pull/5476#issuecomment-1157159541

https://github.com/redis/redis/blob/7.0.2/src/redisassert.c#L42 uses `const char *` 
```c
void _serverAssert(const char *estr, const char *file, int line) {
```

https://github.com/redis/redis/blob/7.0.2/src/server.h#L3532 also uses `const char *`
```c
void _serverAssert(const char *estr, const char *file, int line);
```

but https://github.com/redis/redis/blob/7.0.2/src/redisassert.h#L46 uses `char *`
```c
void _serverAssert(char *estr, char *file, int line);
```
