### PR TITLE
DEPRECATED rename-command config in sentinel

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -288,7 +288,7 @@ sentinel deny-scripts-reconfig yes
 
 # REDIS COMMANDS RENAMING (DEPRECATED)
 #
-# WARNING: avoid using this option if possible, instead using ACLs
+# WARNING: avoid using this option if possible, instead use ACLs.
 #
 # Sometimes the Redis server has certain commands, that are needed for Sentinel
 # to work correctly, renamed to unguessable strings. This is often the case

--- a/sentinel.conf
+++ b/sentinel.conf
@@ -286,7 +286,9 @@ sentinel failover-timeout mymaster 180000
 
 sentinel deny-scripts-reconfig yes
 
-# REDIS COMMANDS RENAMING
+# REDIS COMMANDS RENAMING (DEPRECATED)
+#
+# WARNING: avoid using this option if possible, instead using ACLs
 #
 # Sometimes the Redis server has certain commands, that are needed for Sentinel
 # to work correctly, renamed to unguessable strings. This is often the case

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1964,7 +1964,6 @@ const char *sentinelHandleConfiguration(char **argv, int argc) {
             si->runid = sdsnew(argv[4]);
             sentinelTryConnectionSharing(si);
         }
-      /* rename-command config is deprecated in Redis server and sentinel, using ACL instead */
     } else if (!strcasecmp(argv[0],"rename-command") && argc == 4) {
         /* rename-command <name> <command> <renamed-command> */
         ri = sentinelGetMasterByName(argv[1]);

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1964,6 +1964,7 @@ const char *sentinelHandleConfiguration(char **argv, int argc) {
             si->runid = sdsnew(argv[4]);
             sentinelTryConnectionSharing(si);
         }
+      /* rename-command config is deprecated in Redis server and sentinel, using ACL instead */
     } else if (!strcasecmp(argv[0],"rename-command") && argc == 4) {
         /* rename-command <name> <command> <renamed-command> */
         ri = sentinelGetMasterByName(argv[1]);


### PR DESCRIPTION
Clients could use this config in sentinel only when they already add rename-command in the redis conf file,
but becuase in Redis instance, we already DEPRECATED rename-command config,
thus we should deprecate this in the sentinel part as well.