### PR TITLE
Add missing REDISMODULE_CLIENTINFO_INITIALIZER

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3327,8 +3327,8 @@ int modulePopulateReplicationInfoStructure(void *ri, int structver) {
  * is returned.
  *
  * When the client exist and the `ci` pointer is not NULL, but points to
- * a structure of type RedisModuleClientInfo, previously initialized with
- * the correct REDISMODULE_CLIENTINFO_INITIALIZER, the structure is populated
+ * a structure of type RedisModuleClientInfoV1, previously initialized with
+ * the correct REDISMODULE_CLIENTINFO_INITIALIZER_V1, the structure is populated
  * with the following fields:
  *
  *      uint64_t flags;         // REDISMODULE_CLIENTINFO_FLAG_*

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -656,6 +656,9 @@ typedef struct RedisModuleClientInfo {
 
 #define RedisModuleClientInfo RedisModuleClientInfoV1
 
+#define REDISMODULE_CLIENTINFO_INITIALIZER              \
+    { .version = REDISMODULE_CLIENTINFO_VERSION }
+
 #define REDISMODULE_REPLICATIONINFO_VERSION 1
 typedef struct RedisModuleReplicationInfo {
     uint64_t version;       /* Not used since this structure is never passed

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -656,8 +656,7 @@ typedef struct RedisModuleClientInfo {
 
 #define RedisModuleClientInfo RedisModuleClientInfoV1
 
-#define REDISMODULE_CLIENTINFO_INITIALIZER              \
-    { .version = REDISMODULE_CLIENTINFO_VERSION }
+#define REDISMODULE_CLIENTINFO_INITIALIZER_V1 { .version = 1 }
 
 #define REDISMODULE_REPLICATIONINFO_VERSION 1
 typedef struct RedisModuleReplicationInfo {

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -239,14 +239,16 @@ int test_clientinfo(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     (void) argv;
     (void) argc;
 
-    RedisModuleClientInfo ci = REDISMODULE_CLIENTINFO_INITIALIZER;
+    RedisModuleClientInfoV1 ci = REDISMODULE_CLIENTINFO_INITIALIZER_V1;
     uint64_t client_id = RedisModule_GetClientId(ctx);
 
+    /* Check expected result from the V1 initializer. */
+    assert(ci.version == 1);
     /* Trying to populate a future version of the struct should fail. */
-    ci.version++;
+    ci.version = REDISMODULE_CLIENTINFO_VERSION + 1;
     assert(RedisModule_GetClientInfoById(&ci, client_id) == REDISMODULE_ERR);
-    ci.version--;
 
+    ci.version = 1;
     if (RedisModule_GetClientInfoById(&ci, client_id) == REDISMODULE_ERR) {
             RedisModule_ReplyWithError(ctx, "failed to get client info");
             return REDISMODULE_OK;

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -239,9 +239,15 @@ int test_clientinfo(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     (void) argv;
     (void) argc;
 
-    RedisModuleClientInfo ci = { .version = REDISMODULE_CLIENTINFO_VERSION };
+    RedisModuleClientInfo ci = REDISMODULE_CLIENTINFO_INITIALIZER;
+    uint64_t client_id = RedisModule_GetClientId(ctx);
 
-    if (RedisModule_GetClientInfoById(&ci, RedisModule_GetClientId(ctx)) == REDISMODULE_ERR) {
+    /* Trying to populate a future version of the struct should fail. */
+    ci.version++;
+    assert(RedisModule_GetClientInfoById(&ci, client_id) == REDISMODULE_ERR);
+    ci.version--;
+
+    if (RedisModule_GetClientInfoById(&ci, client_id) == REDISMODULE_ERR) {
             RedisModule_ReplyWithError(ctx, "failed to get client info");
             return REDISMODULE_OK;
     }


### PR DESCRIPTION
The module API docs mentions this macro, but it was not defined (so no one could have used it).

Instead of adding it as is, we decided to add a _V1 macro, so that if / when we some day extend this struct,
modules that use this API and don't need the extra fields, will still use the old version
and still be compatible with older redis version (despite being compiled with newer redismodule.h)

See #10839 and #9987