### PR TITLE
Fix crash on RM_Call with script mode.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -5788,8 +5788,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
                 /* On background thread we can not count on server.pre_command_oom_state.
                  * Because it is only set on the main thread, in such case we will check
                  * the actual memory usage. */
-                float level;
-                oom_state = (getMaxmemoryState(NULL,NULL,NULL,&level) == C_ERR);
+                oom_state = (getMaxmemoryState(NULL,NULL,NULL,NULL) == C_ERR);
             } else {
                 oom_state = server.pre_command_oom_state;
             }

--- a/src/module.c
+++ b/src/module.c
@@ -5785,7 +5785,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
         if (cmd->flags & CMD_DENYOOM) {
             int oom_state;
             if (ctx->flags & REDISMODULE_CTX_THREAD_SAFE) {
-                /* On backgound thread we can not count on server.pre_command_oom_state.
+                /* On background thread we can not count on server.pre_command_oom_state.
                  * Because it is only set on the main thread, in such case we will check
                  * the actual memory usage. */
                 float level;

--- a/src/module.c
+++ b/src/module.c
@@ -5783,7 +5783,17 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
 
     if (flags & REDISMODULE_ARGV_RESPECT_DENY_OOM) {
         if (cmd->flags & CMD_DENYOOM) {
-            if (server.pre_command_oom_state) {
+            int oom_state;
+            if (ctx->flags & REDISMODULE_CTX_THREAD_SAFE) {
+                /* On backgound thread we can not count on server.pre_command_oom_state.
+                 * Because it is only set on the main thread, in such case we will check
+                 * the actual memory usage. */
+                float level;
+                oom_state = (getMaxmemoryState(NULL,NULL,NULL,&level) == C_ERR);
+            } else {
+                oom_state = server.pre_command_oom_state;
+            }
+            if (oom_state) {
                 errno = ENOSPC;
                 if (error_as_call_replies) {
                     sds msg = sdsdup(shared.oomerr->ptr);
@@ -5823,7 +5833,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
             }
 
             int deny_write_type = writeCommandsDeniedByDiskError();
-            int obey_client = mustObeyClient(server.current_client);
+            int obey_client = (server.current_client && mustObeyClient(server.current_client));
 
             if (deny_write_type != DISK_ERROR_TYPE_NONE && !obey_client) {
                 errno = ESPIPE;

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -131,8 +131,8 @@ void *bg_call_worker(void *arg) {
         RedisModule_StringAppendBuffer(NULL, format_redis_str, "E", 1);
     }
     const char *format = RedisModule_StringPtrLen(format_redis_str, NULL);
-    const char* cmd = RedisModule_StringPtrLen(bg->argv[cmd_pos], NULL);
-    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, format, bg->argv + cmd_pos + 1, bg->argc - cmd_pos - 1);
+    const char *cmd = RedisModule_StringPtrLen(bg->argv[cmd_pos], NULL);
+    RedisModuleCallReply *rep = RedisModule_Call(ctx, cmd, format, bg->argv + cmd_pos + 1, bg->argc - cmd_pos - 1);
     RedisModule_FreeString(NULL, format_redis_str);
 
     // Release GIL

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -77,7 +77,7 @@ start_server {tags {"modules"}} {
     } {foo bar}
 
     test {RM_Call from blocked client with script mode} {
-        r do_bg_script_rm_call hset k foo bar
+        r do_bg_rm_call_format S hset k foo bar
     } {1}
 
     test {RM_Call from blocked client with oom mode} {
@@ -86,7 +86,7 @@ start_server {tags {"modules"}} {
         assert_error {OOM command not allowed*} {r hset hash foo bar}
         r config set maxmemory 0
         # now its should be OK to call OOM commands
-        r do_bg_oom_rm_call hset k1 foo bar
+        r do_bg_rm_call_format M hset k1 foo bar
     } {1} {needs:config-maxmemory}
 
     test {RESP version carries through to blocked client} {

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -76,6 +76,19 @@ start_server {tags {"modules"}} {
         r do_bg_rm_call hgetall hash
     } {foo bar}
 
+    test {RM_Call from blocked client with script mode} {
+        r do_bg_script_rm_call hset k foo bar
+    } {1}
+
+    test {RM_Call from blocked client with oom mode} {
+        r config set maxmemory 1
+        # will set server.pre_command_oom_state to 1
+        assert_error {OOM command not allowed*} {r hset hash foo bar}
+        r config set maxmemory 0
+        # now its should be OK to call OOM commands
+        r do_bg_oom_rm_call hset k1 foo bar
+    } {1}
+
     test {RESP version carries through to blocked client} {
         for {set client_proto 2} {$client_proto <= 3} {incr client_proto} {
             r hello $client_proto

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -87,7 +87,7 @@ start_server {tags {"modules"}} {
         r config set maxmemory 0
         # now its should be OK to call OOM commands
         r do_bg_oom_rm_call hset k1 foo bar
-    } {1}
+    } {1} {needs:config-maxmemory}
 
     test {RESP version carries through to blocked client} {
         for {set client_proto 2} {$client_proto <= 3} {incr client_proto} {


### PR DESCRIPTION
The PR fixes 2 issues:

### RM_Call crash on script mode

`RM_Call` can potentially be called from a background thread where `server.current_client`
are not set. In such case we get a crash on `NULL` dereference.
The fix is to check first if `server.current_client` is `NULL`, if it does we should
verify disc errors and readonly replica as we do to any normal clients (no masters nor AOF).

### RM_Call block OOM commands when not needed

Again `RM_Call` can be executed on a background thread using a `ThreadSafeCtx`. In such case `server.pre_command_oom_state` can be irrelevant and should not be considered when check OOM state. This cause OOM commands to be blocked when not necessarily needed.

In such case, check the actual used memory (and not the cached value). Notice that in order to know if the cached value can be used, we check that the ctx that was used on the `RM_Call` is a ThreadSafeCtx. Module writer can potentially abuse the API and use ThreadSafeCtx on the main thread. We consider this as a API miss used.