### PR TITLE
fix redis-benchmark's bug: check if clients are created successfully in idle mode

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -847,7 +847,7 @@ static client createClient(char *cmd, size_t len, client from, int thread_id) {
     if (config.idlemode == 0)
         aeCreateFileEvent(el,c->context->fd,AE_WRITABLE,writeHandler,c);
     else
-        /*in idle mode, clients still need to register readHandler for catching error */
+        /* In idle mode, clients still need to register readHandler for catching errors */
         aeCreateFileEvent(el,c->context->fd,AE_READABLE,readHandler,c);
 
     listAddNodeTail(config.clients,c);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -846,6 +846,10 @@ static client createClient(char *cmd, size_t len, client from, int thread_id) {
     }
     if (config.idlemode == 0)
         aeCreateFileEvent(el,c->context->fd,AE_WRITABLE,writeHandler,c);
+    else
+        /*in idle mode, clients still need to register readHandler for catching error */
+        aeCreateFileEvent(el,c->context->fd,AE_WRITABLE,readHandler,c);
+
     listAddNodeTail(config.clients,c);
     atomicIncr(config.liveclients, 1);
     atomicGet(config.slots_last_update, c->slots_last_update);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -848,7 +848,7 @@ static client createClient(char *cmd, size_t len, client from, int thread_id) {
         aeCreateFileEvent(el,c->context->fd,AE_WRITABLE,writeHandler,c);
     else
         /*in idle mode, clients still need to register readHandler for catching error */
-        aeCreateFileEvent(el,c->context->fd,AE_WRITABLE,readHandler,c);
+        aeCreateFileEvent(el,c->context->fd,AE_READABLE,readHandler,c);
 
     listAddNodeTail(config.clients,c);
     atomicIncr(config.liveclients, 1);

--- a/tests/integration/redis-benchmark.tcl
+++ b/tests/integration/redis-benchmark.tcl
@@ -116,6 +116,15 @@ start_server {tags {"benchmark network external:skip"}} {
             # ensure the keyspace has the desired size
             assert_match  {50} [scan [regexp -inline {keys\=([\d]*)} [r info keyspace]] keys=%d]
         }
+        
+        test {benchmark: clients idle mode should return error when reached maxclients limit} {
+            set cmd [redisbenchmark $master_host $master_port "-c 2 -I"]
+            set original_maxclients [lindex [r config get maxclients] 1]
+            r config set maxclients 1
+            catch { exec {*}$cmd } error
+            assert_match "*ERR max number of clients reached*" $error
+            r config set maxclients $original_maxclients
+        }
 
         # tls specific tests
         if {$::tls} {


### PR DESCRIPTION
my maxclients config:
```
redis-cli config get maxclients
1) "maxclients"
2) "4064"
```

Before this bug was fixed, creating 4065 clients appeared to be successful, but only 4064 were actually created```
```
./redis-benchmark -c 4065 -I
Creating 4065 idle connections and waiting forever (Ctrl+C when done)
cients: 4065
```

now :
```
./redis-benchmark -c 4065 -I
Creating 4065 idle connections and waiting forever (Ctrl+C when done)
Error from server: ERR max number of clients reached

./redis-benchmark -c 4064 -I
Creating 4064 idle connections and waiting forever (Ctrl+C when done)
clients: 4064

```