### PR TITLE
redis-cli set formatted_reply with config.output

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7260,8 +7260,18 @@ static int clusterManagerCommandCall(int argc, char **argv) {
         if (status != REDIS_OK || reply == NULL )
             printf("%s:%d: Failed!\n", n->ip, n->port);
         else {
-            sds formatted_reply = cliFormatReplyRaw(reply);
-            printf("%s:%d: %s\n", n->ip, n->port, (char *) formatted_reply);
+            sds formatted_reply = sdsempty();
+            if (config.output == OUTPUT_RAW) {
+                formatted_reply = cliFormatReplyRaw(reply);
+                formatted_reply = sdscat(formatted_reply,"\n");
+            } else if (config.output == OUTPUT_STANDARD) {
+                formatted_reply = cliFormatReplyTTY(reply,"");
+            } else if (config.output == OUTPUT_CSV) {
+                formatted_reply = cliFormatReplyCSV(reply);
+                formatted_reply = sdscat(formatted_reply,"\n");
+            }
+            printf("%s:%d:\n", n->ip, n->port);
+            printf("%s\n", (char *) formatted_reply);
             sdsfree(formatted_reply);
         }
         if (reply != NULL) freeReplyObject(reply);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7260,19 +7260,7 @@ static int clusterManagerCommandCall(int argc, char **argv) {
         if (status != REDIS_OK || reply == NULL )
             printf("%s:%d: Failed!\n", n->ip, n->port);
         else {
-            sds formatted_reply = sdsempty();
-            if (config.output == OUTPUT_RAW) {
-                formatted_reply = cliFormatReplyRaw(reply);
-                formatted_reply = sdscat(formatted_reply,"\n");
-            } else if (config.output == OUTPUT_STANDARD) {
-                formatted_reply = cliFormatReplyTTY(reply,"");
-            } else if (config.output == OUTPUT_CSV) {
-                formatted_reply = cliFormatReplyCSV(reply);
-                formatted_reply = sdscat(formatted_reply,"\n");
-            } else if (config.output == OUTPUT_JSON || config.output == OUTPUT_QUOTED_JSON) {
-                out = cliFormatReplyJson(sdsempty(), reply, mode);
-                out = sdscatlen(out, "\n", 1);
-            } 
+            sds formatted_reply = cliFormatReply(reply, config.output, 0);
             printf("%s:%d:\n", n->ip, n->port);
             printf("%s\n", (char *) formatted_reply);
             sdsfree(formatted_reply);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7269,7 +7269,7 @@ static int clusterManagerCommandCall(int argc, char **argv) {
             } else if (config.output == OUTPUT_CSV) {
                 formatted_reply = cliFormatReplyCSV(reply);
                 formatted_reply = sdscat(formatted_reply,"\n");
-            } else if (mode == OUTPUT_JSON || mode == OUTPUT_QUOTED_JSON) {
+            } else if (config.output == OUTPUT_JSON || config.output == OUTPUT_QUOTED_JSON) {
                 out = cliFormatReplyJson(sdsempty(), reply, mode);
                 out = sdscatlen(out, "\n", 1);
             } 

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7269,7 +7269,10 @@ static int clusterManagerCommandCall(int argc, char **argv) {
             } else if (config.output == OUTPUT_CSV) {
                 formatted_reply = cliFormatReplyCSV(reply);
                 formatted_reply = sdscat(formatted_reply,"\n");
-            }
+            } else if (mode == OUTPUT_JSON || mode == OUTPUT_QUOTED_JSON) {
+                out = cliFormatReplyJson(sdsempty(), reply, mode);
+                out = sdscatlen(out, "\n", 1);
+            } 
             printf("%s:%d:\n", n->ip, n->port);
             printf("%s\n", (char *) formatted_reply);
             sdsfree(formatted_reply);


### PR DESCRIPTION
This code change is to support different kinds of output format based on config.output options which includes OUTPUT_STANDARD mode to print out full data for --cluster call command to solve the issue that output terminates when meets '\0' character and the left is not printed out.

Below is one example describes the difference of output between raw mode and no-raw mode, and the orignal redis SET operations are below, the first key includes '\0' character, and second one includes '\n' and '\t' characters, and the characters of the last one are all printable.


redis-cli -h 10.245.0.90 -p 6380 SET "foo\0abc" "foo"
redis-cli -h 10.245.0.90 -p 6380 SET "foot\nr\tm" "foo"
redis-cli -h 10.245.0.88 -p 6380 SET "footu" "foo"


bash-4.2$redis-cli -c --no-raw --cluster call --cluster-only-masters 10.245.0.91:6380 KEYS foo*
->>> Calling KEYS foo*
10.245.0.91:6380:
(empty array)

10.245.0.90:6380:
1 ) "foot\\nr\\tm"

10.245.0.88:6380:
1 ) "footu"
2 ) "foo\x00abc"


bash-4.2$redis-cli -c --raw --cluster call --cluster-only-masters 10.245.0.91:6380 KEYS foo*
->>> Calling KEYS foo*
10.245.0.91:6380:


10.245.0.90:6380:
foot\nr\tm

10.245.0.88:6380:
footu
foo