### PR TITLE
fix benchmark failure in daily test with TLS

### DIFF
--- a/tests/integration/redis-benchmark.tcl
+++ b/tests/integration/redis-benchmark.tcl
@@ -122,7 +122,7 @@ start_server {tags {"benchmark network external:skip"}} {
             set original_maxclients [lindex [r config get maxclients] 1]
             r config set maxclients 1
             catch { exec {*}$cmd } error
-            assert_match "*ERR max number of clients reached*" $error
+            assert_match "*Error*" $error
             r config set maxclients $original_maxclients
         }
 

--- a/tests/integration/redis-benchmark.tcl
+++ b/tests/integration/redis-benchmark.tcl
@@ -118,9 +118,9 @@ start_server {tags {"benchmark network external:skip"}} {
         }
         
         test {benchmark: clients idle mode should return error when reached maxclients limit} {
-            set cmd [redisbenchmark $master_host $master_port "-c 2 -I"]
+            set cmd [redisbenchmark $master_host $master_port "-c 10 -I"]
             set original_maxclients [lindex [r config get maxclients] 1]
-            r config set maxclients 1
+            r config set maxclients 5
             catch { exec {*}$cmd } error
             assert_match "*Error*" $error
             r config set maxclients $original_maxclients


### PR DESCRIPTION
The new test added in #10891 fails with TLS with this error:
```
[err]: benchmark: clients idle mode should return error when reached maxclients limit in tests/integration/redis-benchmark.tcl
Expected 'Creating 2 idle connections and waiting forever (Ctrl+C when done)
ERROR: failed to fetch CONFIG from 127.0.0.1:26613
WARNING: Could not fetch server CONFIG
Error: SSL_connect failed: Success' to match '*ERR max number of clients reached*' (context: type eval line 6 cmd {assert_match "*ERR max number of clients reached*" $error} proc ::test) 
```