### PR TITLE
Fix CLUSTER RESET command argument number issue

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -471,7 +471,7 @@ NULL
 
 /* CLUSTER MEET history */
 commandHistory CLUSTER_MEET_History[] = {
-{"4.0.0","Added the optional `bus_port` argument."},
+{"4.0.0","Added the optional `cluster_bus_port` argument."},
 {0}
 };
 
@@ -485,7 +485,7 @@ NULL
 struct redisCommandArg CLUSTER_MEET_Args[] = {
 {"ip",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"port",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"bus_port",ARG_TYPE_INTEGER,-1,NULL,NULL,"4.0.0",CMD_ARG_OPTIONAL},
+{"cluster_bus_port",ARG_TYPE_INTEGER,-1,NULL,NULL,"4.0.0",CMD_ARG_OPTIONAL},
 {0}
 };
 
@@ -689,7 +689,7 @@ struct redisCommand CLUSTER_Subcommands[] = {
 {"nodes","Get Cluster config for the node","O(N) where N is the total number of Cluster nodes","3.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_NODES_History,CLUSTER_NODES_tips,clusterCommand,2,CMD_STALE,0},
 {"replicas","List replica nodes of the specified master node","O(1)","5.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_REPLICAS_History,CLUSTER_REPLICAS_tips,clusterCommand,3,CMD_ADMIN|CMD_STALE,0,.args=CLUSTER_REPLICAS_Args},
 {"replicate","Reconfigure a node as a replica of the specified master node","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_REPLICATE_History,CLUSTER_REPLICATE_tips,clusterCommand,3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,0,.args=CLUSTER_REPLICATE_Args},
-{"reset","Reset a Redis Cluster node","O(N) where N is the number of known nodes. The command may execute a FLUSHALL as a side effect.","3.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_RESET_History,CLUSTER_RESET_tips,clusterCommand,3,CMD_ADMIN|CMD_STALE|CMD_NOSCRIPT,0,.args=CLUSTER_RESET_Args},
+{"reset","Reset a Redis Cluster node","O(N) where N is the number of known nodes. The command may execute a FLUSHALL as a side effect.","3.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_RESET_History,CLUSTER_RESET_tips,clusterCommand,-2,CMD_ADMIN|CMD_STALE|CMD_NOSCRIPT,0,.args=CLUSTER_RESET_Args},
 {"saveconfig","Forces the node to save cluster state on disk","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_SAVECONFIG_History,CLUSTER_SAVECONFIG_tips,clusterCommand,2,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,0},
 {"set-config-epoch","Set the configuration epoch in a new node","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_SET_CONFIG_EPOCH_History,CLUSTER_SET_CONFIG_EPOCH_tips,clusterCommand,3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,0,.args=CLUSTER_SET_CONFIG_EPOCH_Args},
 {"setslot","Bind a hash slot to a specific node","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CLUSTER,CLUSTER_SETSLOT_History,CLUSTER_SETSLOT_tips,clusterCommand,-4,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,0,.args=CLUSTER_SETSLOT_Args},

--- a/src/commands/cluster-reset.json
+++ b/src/commands/cluster-reset.json
@@ -4,7 +4,7 @@
         "complexity": "O(N) where N is the number of known nodes. The command may execute a FLUSHALL as a side effect.",
         "group": "cluster",
         "since": "3.0.0",
-        "arity": 3,
+        "arity": -2,
         "container": "CLUSTER",
         "function": "clusterCommand",
         "command_flags": [

--- a/tests/cluster/tests/00-base.tcl
+++ b/tests/cluster/tests/00-base.tcl
@@ -80,3 +80,24 @@ test "Script no-cluster flag" {
     
     assert_match {*Can not run script on cluster, 'no-cluster' flag is set*} $e
 }
+
+test "CLUSTER RESET SOFT test" {
+
+    set last_epoch_node0 [get_info_field [R 0 cluster info] cluster_current_epoch]
+
+    R 0 flushall
+    R 0 CLUSTER RESET 
+
+    assert {[get_info_field [R 0 cluster info] cluster_current_epoch] eq $last_epoch_node0}
+    
+    set last_epoch_node1 [get_info_field [R 1 cluster info] cluster_current_epoch]
+
+    R 1 flushall
+    R 1 CLUSTER RESET SOFT 
+
+    assert {[get_info_field [R 1 cluster info] cluster_current_epoch] eq $last_epoch_node1}
+}
+
+
+
+

--- a/tests/cluster/tests/00-base.tcl
+++ b/tests/cluster/tests/00-base.tcl
@@ -82,22 +82,14 @@ test "Script no-cluster flag" {
 }
 
 test "CLUSTER RESET SOFT test" {
-
     set last_epoch_node0 [get_info_field [R 0 cluster info] cluster_current_epoch]
-
-    R 0 flushall
-    R 0 CLUSTER RESET 
-
+    R 0 FLUSHALL
+    R 0 CLUSTER RESET
     assert {[get_info_field [R 0 cluster info] cluster_current_epoch] eq $last_epoch_node0}
-    
+
     set last_epoch_node1 [get_info_field [R 1 cluster info] cluster_current_epoch]
-
-    R 1 flushall
-    R 1 CLUSTER RESET SOFT 
-
+    R 1 FLUSHALL
+    R 1 CLUSTER RESET SOFT
     assert {[get_info_field [R 1 cluster info] cluster_current_epoch] eq $last_epoch_node1}
 }
-
-
-
 


### PR DESCRIPTION
Fix regression of CLUSTER RESET command in redis 7.0.

cluster reset command format is:
CLUSTER RESET [ HARD | SOFT]  

According to the cluster reset command doc and codes, the third argument is optional, so
the arity in json file should be -2 instead of 3.

Add test to verify future regressions with RESET and RESET SOFT that were not covered.