### PR TITLE
Sync argv_len var back after command call in execCommand

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -230,6 +230,7 @@ void execCommand(client *c) {
         /* Commands may alter argc/argv, restore mstate. */
         c->mstate.commands[j].argc = c->argc;
         c->mstate.commands[j].argv = c->argv;
+        c->mstate.commands[j].argv_len = c->argv_len;
         c->mstate.commands[j].cmd = c->cmd;
     }
 


### PR DESCRIPTION
This is harmless, we only restore mstate to make sure we
free the right pointer in freeClientMultiState, but it'll
be nicer to also sync that argv_len var back.

mention in https://github.com/redis/redis/pull/9602#pullrequestreview-1019372509