### PR TITLE
A minor fix to clusterbus extension estlen

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1999,7 +1999,7 @@ int writeHostnamePingExt(clusterMsgPingExt **cursor) {
     uint32_t extension_size = getHostnamePingExtSize();
 
     /* Move the write cursor */
-    (*cursor)->type = CLUSTERMSG_EXT_TYPE_HOSTNAME;
+    (*cursor)->type = htons(CLUSTERMSG_EXT_TYPE_HOSTNAME);
     (*cursor)->length = htonl(extension_size);
     /* Make sure the string is NULL terminated by adding 1 */
     *cursor = (clusterMsgPingExt *) (ext->hostname + EIGHT_BYTE_ALIGN(sdslen(myself->hostname) + 1));

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2928,7 +2928,7 @@ void clusterSendPing(clusterLink *link, int type) {
      * to put inside the packet. */
     estlen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
     estlen += (sizeof(clusterMsgDataGossip)*(wanted + pfail_wanted));
-    estlen += sizeof(clusterMsgPingExt) + getHostnamePingExtSize();
+    estlen += getHostnamePingExtSize();
 
     /* Note: clusterBuildMessageHdr() expects the buffer to be always at least
      * sizeof(clusterMsg) or more. */


### PR DESCRIPTION
`sizeof(clusterMsgPingExt)` here seems needless. The original discussion is at https://github.com/redis/redis/pull/9530#discussion_r907189733.