### PR TITLE
Fix TLS issues with large replies.

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -834,12 +834,12 @@ static int connTLSWritev(connection *conn_, const struct iovec *iov, int iovcnt)
      * which is not worth doing so much memory copying to reduce system calls,
      * therefore, invoke connTLSWrite() multiple times to avoid memory copies. */
     if (iov_bytes_len > NET_MAX_WRITES_PER_EVENT) {
-        size_t tot_sent = 0;
+        ssize_t tot_sent = 0;
         for (int i = 0; i < iovcnt; i++) {
-            size_t sent = connTLSWrite(conn_, iov[i].iov_base, iov[i].iov_len);
+            ssize_t sent = connTLSWrite(conn_, iov[i].iov_base, iov[i].iov_len);
             if (sent <= 0) return tot_sent > 0 ? tot_sent : sent;
             tot_sent += sent;
-            if (sent != iov[i].iov_len) break;
+            if ((size_t) sent != iov[i].iov_len) break;
         }
         return tot_sent;
     }

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -84,6 +84,16 @@ proc ::redis::redis_safe_read {fd len} {
     error $msg
 }
 
+proc ::redis::redis_safe_gets {fd} {
+    if {[catch {set val [gets $fd]} msg]} {
+        if {[string match "*connection abort*" $msg]} {
+            return {}
+        }
+        error $msg
+    }
+    return $val
+}
+
 # This is a wrapper to the actual dispatching procedure that handles
 # reconnection if needed.
 proc ::redis::__dispatch__ {id method args} {
@@ -224,8 +234,8 @@ proc ::redis::redis_writenl {fd buf} {
 }
 
 proc ::redis::redis_readnl {fd len} {
-    set buf [read $fd $len]
-    read $fd 2 ; # discard CR LF
+    set buf [redis_safe_read $fd $len]
+    redis_safe_read $fd 2 ; # discard CR LF
     return $buf
 }
 
@@ -271,11 +281,11 @@ proc ::redis::redis_read_map {id fd} {
 }
 
 proc ::redis::redis_read_line fd {
-    string trim [gets $fd]
+    string trim [redis_safe_gets $fd]
 }
 
 proc ::redis::redis_read_null fd {
-    gets $fd
+    redis_safe_gets $fd
     return {}
 }
 

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -140,7 +140,7 @@ start_server {tags {"obuf-limits external:skip"}} {
 
         # Read nothing
         set fd [$rd channel]
-        assert_equal {} [read $fd]
+        assert_equal {} [$rd rawread]
     }
 
     # Note: This test assumes that what's written with one write, will be read by redis in one read.
@@ -180,8 +180,7 @@ start_server {tags {"obuf-limits external:skip"}} {
         assert_equal "PONG" [r ping]
         set clients [r client list]
         assert_no_match "*name=multicommands*" $clients
-        set fd [$rd2 channel]
-        assert_equal {} [read $fd]
+        assert_equal {} [$rd2 rawread]
     }
 
     test {Execute transactions completely even if client output buffer limit is enforced} {


### PR DESCRIPTION
This problem was introduced by 496375fc36134c72461e6fb97f314be3adfd8b68 and seems to reproduce on macOS since OpenSSL writes more frequently return with `EAGAIN`.

Reproduced easily by the following test (from [this repository](https://github.com/michael-grunder/hiredis-tls-error-demonstrator) by @michael-grunder):

```c
#include <hiredis/hiredis.h>
#include <hiredis/hiredis_ssl.h>
#include <assert.h>
#include <stdlib.h>

#define REDIS_HOST "127.0.0.1"
#define REDIS_PORT 56443

#define CA_CERT "redis/ca.crt"
#define SSL_CERT "redis/redis.crt"
#define SSL_KEY "redis/redis.key"

#define N 10000

int main(void) {
    redisSSLContext *sctx;
    redisContext *c;
    redisReply *r;

    sctx = redisCreateSSLContext(CA_CERT, NULL, SSL_CERT, SSL_KEY, NULL, NULL);
    assert(sctx != NULL);

    c = redisConnect(REDIS_HOST, REDIS_PORT);
    assert(c != NULL && c->err == 0);

    assert(redisInitiateSSLWithContext(c, sctx) == REDIS_OK);

    for (size_t i = 0; i < 500; i++) {
        assert((r = redisCommand(c, "RPUSH mylist element:%d", i)) != NULL);
        freeReplyObject(r);
    }

    for (size_t i = 0; i < N; i++) {
        assert(redisAppendCommand(c, "LRANGE mylist 0 499") == REDIS_OK);
    }

    for (size_t i = 0; i < N; i++) {
        /* Bug will happen here at some point in the loop */
        if (redisGetReply(c, (void**)&r) != REDIS_OK || c->err != 0 ||
            r->type != REDIS_REPLY_ARRAY || r->elements != 500)
        {
            fprintf(stderr, "[%zu] redisContext error: %s (%d)\n", i, c->errstr, c->err);
            exit(1);
        }

        freeReplyObject(r);
    }
}
```