### PR TITLE
Optimize number of realloc syscall during multi/exec flow

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -38,6 +38,7 @@ void initClientMultiState(client *c) {
     c->mstate.cmd_flags = 0;
     c->mstate.cmd_inv_flags = 0;
     c->mstate.argv_len_sums = 0;
+    c->mstate.alloc_count = 0;
 }
 
 /* Release all the resources associated with MULTI/EXEC state */
@@ -65,9 +66,17 @@ void queueMultiCommand(client *c, uint64_t cmd_flags) {
      * aborted. */
     if (c->flags & (CLIENT_DIRTY_CAS|CLIENT_DIRTY_EXEC))
         return;
-
-    c->mstate.commands = zrealloc(c->mstate.commands,
-            sizeof(multiCmd)*(c->mstate.count+1));
+    if (c->mstate.count == 0) {
+        /* If a client is using multi/exec, assuming it is used to execute at least
+         * two commands. Hence, creating by default size of 2. */
+        c->mstate.commands = zmalloc(2 * sizeof(multiCmd));
+        c->mstate.alloc_count = 2;
+    }
+    if (c->mstate.count == c->mstate.alloc_count) {
+        c->mstate.commands = zrealloc(c->mstate.commands,
+                sizeof(multiCmd)*(c->mstate.alloc_count*2));
+        c->mstate.alloc_count = c->mstate.alloc_count * 2;
+    }
     mc = c->mstate.commands+c->mstate.count;
     mc->cmd = c->cmd;
     mc->argc = c->argc;

--- a/src/server.h
+++ b/src/server.h
@@ -959,6 +959,7 @@ typedef struct multiState {
                                is possible to know if all the commands have a
                                certain flag. */
     size_t argv_len_sums;    /* mem used by all commands arguments */
+    int alloc_count;         /* total number of multiCmd struct memory reserved. */
 } multiState;
 
 /* This structure holds the blocking operation state for a client.


### PR DESCRIPTION
## Issue
During the MULTI/EXEC flow, each command gets queued until the `EXEC` command is received and during this phase on every command queue, a `realloc` is being invoked. This could be expensive based on the realloc behaviour (if copy to a new memory location). 


## Solution
In order to reduce the no. of syscall, couple of optimization I've used.

1. By default, reserve memory for atleast two commands. `MULTI/EXEC` for a single command doesn't have any significance. Hence, I believe customer wouldn't use it.
2. For further reservation, increase the memory allocation in exponent growth (power of 2). This reduces the no. of `realloc` call from `N` to `log(N)` times.

## Alternative(s)

@madolson had a nice suggestion to have static memory allocation of a fixed size (16) and use dynamic allocation for further increase. This would completely remove the memory allocation/deallocation for majority of the cases however I didn't want to have two separate code path hence avoided this approach.

## Testing
### Script

```
import redis

r=redis.Redis()
p = r.pipeline()
for j in range(100000000):
    print("Step #", j)
    for i in range(100):
        p.mset({"Croatia" + str(i) + str(j): "Zagreb", "Bahamas" + str(i) + str(j): "Nassau"})
    p.execute()
```

### Machine
c5.4xlarge

### Observation
Ran the above script for 3 mins with new key generation on each iteration, there was a drop in sample collection and CPU utilization from `260 samples,1.49%` to `78 samples, 0.46%`. Here are the flamegraph images:

### FlameGraph on the current branch
![FlameGraph on the current branch](https://gist.githubusercontent.com/hpatro/8b9434055dc241827737f7870402dbb5/raw/fe96bb965d2d04e0a4573f8444fb2a56538d940e/realloc_opt%2520(depth%2520100)%2520(3%2520mins).svg)

### FlameGraph on the unstable branch
![FlameGraph on the unstable branch](https://gist.githubusercontent.com/hpatro/ee0e147624e7fc9a2c603fc76a410cac/raw/449911afb9f88c87887f0d40f1f4c8a060e445c8/unstable%2520(depth%2520100)%2520(3%2520mins).svg)

## Other changes:

* Include multi exec queued command array in client memory consumption calculation (affects client eviction too)