### PR TITLE
Only print ACL syntax errors once and include command names in errors

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2177,7 +2177,7 @@ sds ACLLoadFromFile(const char *filename) {
                 errors = sdscatprintf(errors,
                          "%s:%d: %s. ",
                          server.acl_filename, linenum, errmsg);
-                continue;
+                break;
             }
         }
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -2169,8 +2169,8 @@ sds ACLLoadFromFile(const char *filename) {
                     server.acl_filename, linenum);
         }
 
-        int j;
-        for (j = 0; j < merged_argc; j++) {
+        int syntax_error = 0;
+        for (int j = 0; j < merged_argc; j++) {
             acl_args[j] = sdstrim(acl_args[j],"\t\r\n");
             if (ACLSetUser(u,acl_args[j],sdslen(acl_args[j])) != C_OK) {
                 const char *errmsg = ACLSetUserStringError();
@@ -2180,13 +2180,13 @@ sds ACLLoadFromFile(const char *filename) {
                     errors = sdscatprintf(errors,
                             "%s:%d: Error in applying operation '%s': %s. ",
                             server.acl_filename, linenum, acl_args[j], errmsg);
-                } else {
+                } else if (syntax_error == 0) {
                     /* For all other errors, only print out the first error encountered
                      * since it might affect future operations. */
                     errors = sdscatprintf(errors,
                             "%s:%d: %s. ",
                             server.acl_filename, linenum, errmsg);
-                    break;
+                    syntax_error = 1;
                 }
             }
         }


### PR DESCRIPTION
When you load an ACL file that has an error, it prints out the log with the error. If the line has multiple errors, it prints out multiple errors. This just changes the code so that we only print out the line once in all cases.