### PR TITLE
Account sharded pubsub channels memory consumption

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3669,9 +3669,7 @@ size_t getClientMemoryUsage(client *c, size_t *output_buffer_mem_usage) {
 
     /* Add memory overhead of pubsub channels and patterns. Note: this is just the overhead of the robj pointers
      * to the strings themselves because they aren't stored per client. */
-    mem += listLength(c->pubsub_patterns) * sizeof(listNode);
-    mem += dictSize(c->pubsub_channels) * sizeof(dictEntry) +
-           dictSlots(c->pubsub_channels) * sizeof(dictEntry*);
+    mem += pubsubMemOverhead(c);
 
     /* Add memory overhead of the tracking prefixes, this is an underestimation so we don't need to traverse the entire rax */
     if (c->client_tracking_prefixes)

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -724,12 +724,12 @@ void sunsubscribeCommand(client *c) {
 }
 
 size_t pubsubMemOverhead(client *c) {
-    // PubSub patterns
+    /* PubSub patterns */
     size_t mem = listLength(c->pubsub_patterns) * sizeof(listNode);
-    // Global PubSub channels
+    /* Global PubSub channels */
     mem += dictSize(c->pubsub_channels) * sizeof(dictEntry) +
            dictSlots(c->pubsub_channels) * sizeof(dictEntry*);
-    // Sharded PubSub channels
+    /* Sharded PubSub channels */
     mem += dictSize(c->pubsubshard_channels) * sizeof(dictEntry) +
            dictSlots(c->pubsubshard_channels) * sizeof(dictEntry*);
     return mem;

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -722,3 +722,15 @@ void sunsubscribeCommand(client *c) {
     }
     if (clientTotalPubSubSubscriptionCount(c) == 0) c->flags &= ~CLIENT_PUBSUB;
 }
+
+size_t pubsubMemOverhead(client *c) {
+    // PubSub patterns
+    size_t mem = listLength(c->pubsub_patterns) * sizeof(listNode);
+    // Global PubSub channels
+    mem += dictSize(c->pubsub_channels) * sizeof(dictEntry) +
+           dictSlots(c->pubsub_channels) * sizeof(dictEntry*);
+    // Sharded PubSub channels
+    mem += dictSize(c->pubsubshard_channels) * sizeof(dictEntry) +
+           dictSlots(c->pubsubshard_channels) * sizeof(dictEntry*);
+    return mem;
+}

--- a/src/server.h
+++ b/src/server.h
@@ -3000,6 +3000,7 @@ int pubsubPublishMessageAndPropagateToCluster(robj *channel, robj *message, int 
 void addReplyPubsubMessage(client *c, robj *channel, robj *msg, robj *message_bulk);
 int serverPubsubSubscriptionCount();
 int serverPubsubShardSubscriptionCount();
+size_t pubsubMemOverhead(client *c);
 
 /* Keyspace events notification */
 void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid);


### PR DESCRIPTION
Account sharded pubsub channels memory consumption in client memory usage computation to accurately evict client based on the set threshold for `maxmemory-clients`.