### PR TITLE
Avoid double multiplication of alloc_count

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -74,7 +74,7 @@ void queueMultiCommand(client *c, uint64_t cmd_flags) {
     }
     if (c->mstate.count == c->mstate.alloc_count) {
         c->mstate.alloc_count = c->mstate.alloc_count < INT_MAX/2 ? c->mstate.alloc_count*2 : INT_MAX;
-        c->mstate.commands = zrealloc(c->mstate.commands, sizeof(multiCmd)*(c->mstate.alloc_count*2));
+        c->mstate.commands = zrealloc(c->mstate.commands, sizeof(multiCmd)*(c->mstate.alloc_count));
     }
     mc = c->mstate.commands+c->mstate.count;
     mc->cmd = c->cmd;


### PR DESCRIPTION
Ref #10921

While addressing feedback on the above PR, double multiplication was done on `alloc_count`. This could lead to over allocation and overflow.