### PR TITLE
Fix crash during handshake and cluster shards call

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1224,10 +1224,11 @@ clusterNode *clusterLookupNode(const char *name, int length) {
 list *clusterGetNodesServingMySlots(clusterNode *node) {
     list *nodes_for_slot = listCreate();
     clusterNode *my_primary = nodeIsMaster(node) ? node : node->slaveof;
-    if (!my_primary) {
-        listAddNodeTail(nodes_for_slot, node);
-        return nodes_for_slot;
-    }
+
+    /* This function is only valid for fully connected nodes, so
+     * they should have a known primary. */
+    serverAssert(my_primary);
+    listAddNodeTail(nodes_for_slot, my_primary);
     for (int i=0; i < my_primary->numslaves; i++) {
         listAddNodeTail(nodes_for_slot, my_primary->slaves[i]);
     }

--- a/tests/cluster/tests/28-cluster-shards.tcl
+++ b/tests/cluster/tests/28-cluster-shards.tcl
@@ -185,7 +185,7 @@ test "Test the replica reports a loading state while it's loading" {
 }
 
 test "Regression test for a crash when calling SHARDS during handshake" {
-    # Reset a node and forget a node, so we can use it as part of a handshake
+    # Reset forget a node, so we can use it to establish handshaking connections
     set id [R 19 CLUSTER MYID]
     R 19 CLUSTER RESET HARD
     for {set i 0} {$i < 19} {incr i} {

--- a/tests/cluster/tests/28-cluster-shards.tcl
+++ b/tests/cluster/tests/28-cluster-shards.tcl
@@ -183,3 +183,16 @@ test "Test the replica reports a loading state while it's loading" {
     # Final sanity, the replica agrees it is online. 
     assert_equal "online" [dict get [get_node_info_from_shard $replica_cluster_id $replica_id "node"] health]
 }
+
+test "Regression test for a crash when calling SHARDS during handshake" {
+    # Reset a node, this will cause everyone to re-handshake with the node
+    set id [R 19 CLUSTER MYID]
+    R 19 CLUSTER RESET HARD
+    for {set i 0} {$i < 19} {incr i} {
+        R $i CLUSTER FORGET $id
+    }
+    R 19 cluster meet 127.0.0.1 [get_instance_attrib redis 0 port]
+    # This should line would previously crash, since all the outbound
+    # connections were in handshake state.
+    R 19 CLUSTER SHARDS
+}

--- a/tests/cluster/tests/28-cluster-shards.tcl
+++ b/tests/cluster/tests/28-cluster-shards.tcl
@@ -185,7 +185,7 @@ test "Test the replica reports a loading state while it's loading" {
 }
 
 test "Regression test for a crash when calling SHARDS during handshake" {
-    # Reset a node, this will cause everyone to re-handshake with the node
+    # Reset a node and forget a node, so we can use it as part of a handshake
     set id [R 19 CLUSTER MYID]
     R 19 CLUSTER RESET HARD
     for {set i 0} {$i < 19} {incr i} {


### PR DESCRIPTION
A node that is in handshaking is neither a MASTER nor a REPLICA until we learn more about the node. During cluster shards, we want to loop over all the masters to determine the "shards". The current code checks to see if a node is a replica, which will return false when we don't know what the node is yet. Later on we will check the replicas of the node, and crash because it doesn't have any.

This change does two things:
1. Update the code to bail out if the node is not a primary as far as the current node is concerned.
2. Add a defensive check that asserts that the primary is not NULL.
