### PR TITLE
Trying to fix cluster test

### DIFF
--- a/tests/cluster/tests/28-cluster-shards.tcl
+++ b/tests/cluster/tests/28-cluster-shards.tcl
@@ -196,3 +196,7 @@ test "Regression test for a crash when calling SHARDS during handshake" {
     # connections were in handshake state.
     R 19 CLUSTER SHARDS
 }
+
+test "Cluster is up" {
+    assert_cluster_state ok
+}


### PR DESCRIPTION
#10942 break the new test added in #10449
```
Testing unit: 29-slot-migration-response.tcl
Cluster Join and auto-discovery test: FAILED: Cluster failed to join into a full mesh.
```

It looks like we need to wait for the cluster in 28 to become stable.