### PR TITLE
Fix function load error message 

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -961,7 +961,7 @@ sds functionsCreateWithLibraryCtx(sds code, int replace, sds* err, functionsLibC
     }
 
     if (functionsVerifyName(md.name)) {
-        *err = sdsnew("Library names can only contain letters, numbers, or underscore(_) and must be at least one character long");
+        *err = sdsnew("Library names can only contain letters, numbers, or underscores(_) and must be at least one character long");
         goto error;
     }
 

--- a/src/functions.c
+++ b/src/functions.c
@@ -245,7 +245,7 @@ functionsLibCtx* functionsLibCtxCreate() {
  */
 int functionLibCreateFunction(sds name, void *function, functionLibInfo *li, sds desc, uint64_t f_flags, sds *err) {
     if (functionsVerifyName(name) != C_OK) {
-        *err = sdsnew("Function names can only contain letters and numbers and must be at least one character long");
+        *err = sdsnew("Library names can only contain letters, numbers, or underscore(_) and must be at least one character long");
         return C_ERR;
     }
 
@@ -819,7 +819,7 @@ void functionFlushCommand(client *c) {
 /* FUNCTION HELP */
 void functionHelpCommand(client *c) {
     const char *help[] = {
-"LOAD <ENGINE NAME> <LIBRARY NAME> [REPLACE] [DESCRIPTION <LIBRARY DESCRIPTION>] <LIBRARY CODE>",
+"LOAD [REPLACE] <FUNCTION CODE>",
 "    Create a new library with the given library name and code.",
 "DELETE <LIBRARY NAME>",
 "    Delete the given library.",
@@ -847,7 +847,7 @@ void functionHelpCommand(client *c) {
 "    * ASYNC: Asynchronously flush the libraries.",
 "    * SYNC: Synchronously flush the libraries.",
 "DUMP",
-"    Returns a serialized payload representing the current libraries, can be restored using FUNCTION RESTORE command",
+"    Return a serialized payload representing the current libraries, can be restored using FUNCTION RESTORE command",
 "RESTORE <PAYLOAD> [FLUSH|APPEND|REPLACE]",
 "    Restore the libraries represented by the given payload, it is possible to give a restore policy to",
 "    control how to handle existing libraries (default APPEND):",
@@ -961,7 +961,7 @@ sds functionsCreateWithLibraryCtx(sds code, int replace, sds* err, functionsLibC
     }
 
     if (functionsVerifyName(md.name)) {
-        *err = sdsnew("Library names can only contain letters and numbers and must be at least one character long");
+        *err = sdsnew("Library names can only contain letters, numbers, or underscore(_) and must be at least one character long");
         goto error;
     }
 

--- a/src/functions.c
+++ b/src/functions.c
@@ -245,7 +245,7 @@ functionsLibCtx* functionsLibCtxCreate() {
  */
 int functionLibCreateFunction(sds name, void *function, functionLibInfo *li, sds desc, uint64_t f_flags, sds *err) {
     if (functionsVerifyName(name) != C_OK) {
-        *err = sdsnew("Library names can only contain letters, numbers, or underscore(_) and must be at least one character long");
+        *err = sdsnew("Library names can only contain letters, numbers, or underscores(_) and must be at least one character long");
         return C_ERR;
     }
 

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -597,7 +597,7 @@ start_server {tags {"scripting"}} {
             }
         } e
         set _ $e
-    } {*Library names can only contain letters, numbers, or underscore(_) and must be at least one character long*}
+    } {*Library names can only contain letters, numbers, or underscores(_) and must be at least one character long*}
 
     test {LIBRARIES - test registration with empty name} {
         catch {
@@ -606,7 +606,7 @@ start_server {tags {"scripting"}} {
             }
         } e
         set _ $e
-    } {*Library names can only contain letters, numbers, or underscore(_) and must be at least one character long*}
+    } {*Library names can only contain letters, numbers, or underscores(_) and must be at least one character long*}
 
     test {LIBRARIES - math.random from function load} {
         catch {

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -38,7 +38,7 @@ start_server {tags {"scripting"}} {
             r function load [get_function_code LUA {bad\0foramat} test {return 'hello1'}]
         } e
         set _ $e
-    } {*Library names can only contain letters, numbers, or underscore(_)*}
+    } {*Library names can only contain letters, numbers, or underscores(_)*}
 
     test {FUNCTION - Create library with unexisting engine} {
         catch {

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -38,7 +38,7 @@ start_server {tags {"scripting"}} {
             r function load [get_function_code LUA {bad\0foramat} test {return 'hello1'}]
         } e
         set _ $e
-    } {*Library names can only contain letters and numbers*}
+    } {*Library names can only contain letters, numbers, or underscore(_)*}
 
     test {FUNCTION - Create library with unexisting engine} {
         catch {
@@ -597,7 +597,7 @@ start_server {tags {"scripting"}} {
             }
         } e
         set _ $e
-    } {*Function names can only contain letters and numbers and must be at least one character long*}
+    } {*Library names can only contain letters, numbers, or underscore(_) and must be at least one character long*}
 
     test {LIBRARIES - test registration with empty name} {
         catch {
@@ -606,7 +606,7 @@ start_server {tags {"scripting"}} {
             }
         } e
         set _ $e
-    } {*Function names can only contain letters and numbers and must be at least one character long*}
+    } {*Library names can only contain letters, numbers, or underscore(_) and must be at least one character long*}
 
     test {LIBRARIES - math.random from function load} {
         catch {


### PR DESCRIPTION
In this PR, we fix the following issues of the Function Load command:

1. According to the source code, Library name can include letters, numbers and underscore(_), but in our current error message, we missed the underscore part.
  
![image](https://user-images.githubusercontent.com/51993843/178339843-8c64b639-f619-4cd2-b059-5e98680e28a3.png)

2. in the message of command function help
Now it displays the following infomation for Redis Function Load command:

![image](https://user-images.githubusercontent.com/51993843/178340585-a80b1b44-9d60-4a7e-b963-177d3f4152c2.png)

But this is just a description of the function load command, it is not command format
Thus, in this pr, we update the command format as below:

![image](https://user-images.githubusercontent.com/51993843/178340711-2c250a42-cb32-45a4-84a5-eb94cad0717e.png)






