### PR TITLE
Update XXX help subcommand message to make its first letter consistent with other message

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1080,7 +1080,7 @@ void addReplyHelp(client *c, const char **help) {
     while (help[blen]) addReplyStatus(c,help[blen++]);
 
     addReplyStatus(c,"HELP");
-    addReplyStatus(c,"    Prints this help.");
+    addReplyStatus(c,"    Print this help.");
 
     blen += 1;  /* Account for the header. */
     blen += 2;  /* Account for the footer. */


### PR DESCRIPTION
For any command with supporting XXX help command,  we could see it alwasy return:  **Prints this help**, it should be return
**Print this help**

![image](https://user-images.githubusercontent.com/51993843/178343599-119487df-8fb5-4d00-a968-78c0fba02e04.png)
