### PR TITLE
Fix replication inconsistency on modules that uses key space notifications

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1280,6 +1280,14 @@ sds genAofTimestampAnnotationIfNeeded(int force) {
     return ts;
 }
 
+/* Write the given command to the aof file.
+ * dictid - dictionary id the command should be applied to,
+ *          this is used in order to decide if a `select` command
+ *          should also be writen to the aof. Value of -1 means
+ *          to avoid writing `select` command in any case.
+ * argv   - The command to write to the aof.
+ * argc   - Number of values in argv
+ */
 void feedAppendOnlyFile(int dictid, robj **argv, int argc) {
     sds buf = sdsempty();
 

--- a/src/aof.c
+++ b/src/aof.c
@@ -1283,7 +1283,7 @@ sds genAofTimestampAnnotationIfNeeded(int force) {
 /* Write the given command to the aof file.
  * dictid - dictionary id the command should be applied to,
  *          this is used in order to decide if a `select` command
- *          should also be writen to the aof. Value of -1 means
+ *          should also be written to the aof. Value of -1 means
  *          to avoid writing `select` command in any case.
  * argv   - The command to write to the aof.
  * argc   - Number of values in argv

--- a/src/aof.c
+++ b/src/aof.c
@@ -1283,7 +1283,7 @@ sds genAofTimestampAnnotationIfNeeded(int force) {
 void feedAppendOnlyFile(int dictid, robj **argv, int argc) {
     sds buf = sdsempty();
 
-    serverAssert(dictid >= 0 && dictid < server.dbnum);
+    serverAssert(dictid == -1 || (dictid >= 0 && dictid < server.dbnum));
 
     /* Feed timestamp if needed */
     if (server.aof_timestamp_enabled) {
@@ -1296,7 +1296,7 @@ void feedAppendOnlyFile(int dictid, robj **argv, int argc) {
 
     /* The DB this command was targeting is not the same as the last command
      * we appended. To issue a SELECT command is needed. */
-    if (dictid != server.aof_selected_db) {
+    if (dictid != -1 && dictid != server.aof_selected_db) {
         char seldb[64];
 
         snprintf(seldb,sizeof(seldb),"%d",dictid);

--- a/src/db.c
+++ b/src/db.c
@@ -1557,9 +1557,9 @@ void deleteExpiredKeyAndPropagate(redisDb *db, robj *keyobj) {
         dbSyncDelete(db,keyobj);
     latencyEndMonitor(expire_latency);
     latencyAddSampleIfNeeded("expire-del",expire_latency);
-    notifyKeyspaceEvent(NOTIFY_EXPIRED,"expired",keyobj,db->id);
     signalModifiedKey(NULL, db, keyobj);
     propagateDeletion(db,keyobj,server.lazyfree_lazy_expire);
+    notifyKeyspaceEvent(NOTIFY_EXPIRED,"expired",keyobj,db->id);
     server.stat_expiredkeys++;
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -852,7 +852,7 @@ NULL
         server.aof_flush_sleep = atoi(c->argv[2]->ptr);
         addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"replicate") && c->argc >= 3) {
-        replicationFeedSlaves(server.slaves, server.slaveseldb,
+        replicationFeedSlaves(server.slaves, -1,
                 c->argv + 2, c->argc - 2);
         addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"error") && c->argc == 3) {

--- a/src/evict.c
+++ b/src/evict.c
@@ -574,6 +574,11 @@ int performEvictions(void) {
     int prev_core_propagates = server.core_propagates;
     serverAssert(server.also_propagate.numops == 0);
     server.core_propagates = 1;
+
+    /* Increase nested call counter
+     * we add this in order to prevent any RM_Call that may exist
+     * in the notify CB to be propagated immediately.
+     * we want them in multi/exec with the DEL command */
     server.in_nested_call++;
 
     while (mem_freed < (long long)mem_tofree) {

--- a/src/expire.c
+++ b/src/expire.c
@@ -266,7 +266,7 @@ void activeExpireCycle(int type) {
                         ttl = dictGetSignedIntegerVal(e)-now;
                         if (activeExpireCycleTryExpire(db,e,now)) {
                             expired++;
-                            /* Propagate all DELs */
+                            /* Propagate the DEL command */
                             propagatePendingCommands();
                         }
                         if (ttl > 0) {

--- a/src/expire.c
+++ b/src/expire.c
@@ -186,7 +186,7 @@ void activeExpireCycle(int type) {
      * we're in cron */
     serverAssert(server.also_propagate.numops == 0);
     server.core_propagates = 1;
-    server.propagate_no_multi = 1;
+    server.in_nested_call++;
 
     for (j = 0; j < dbs_per_call && timelimit_exit == 0; j++) {
         /* Expired and checked in a single loop. */
@@ -264,7 +264,11 @@ void activeExpireCycle(int type) {
                         de = de->next;
 
                         ttl = dictGetSignedIntegerVal(e)-now;
-                        if (activeExpireCycleTryExpire(db,e,now)) expired++;
+                        if (activeExpireCycleTryExpire(db,e,now)) {
+                            expired++;
+                            /* Propagate all DELs */
+                            propagatePendingCommands();
+                        }
                         if (ttl > 0) {
                             /* We want the average TTL of keys yet
                              * not expired. */
@@ -310,11 +314,8 @@ void activeExpireCycle(int type) {
 
     serverAssert(server.core_propagates); /* This function should not be re-entrant */
 
-    /* Propagate all DELs */
-    propagatePendingCommands();
-
     server.core_propagates = 0;
-    server.propagate_no_multi = 0;
+    server.in_nested_call--;
 
     elapsed = ustime()-start;
     server.stat_expire_cycle_time_used += elapsed;

--- a/src/module.c
+++ b/src/module.c
@@ -7826,7 +7826,6 @@ void moduleReleaseGIL(void) {
  * so notification callbacks must to be fast, or they would slow Redis down.
  * If you need to take long actions, use threads to offload them.
  *
- * Warning: keymiss notification is a special type
  * See https://redis.io/topics/notifications for more information.
  */
 int RM_SubscribeToKeyspaceEvents(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc callback) {

--- a/src/module.c
+++ b/src/module.c
@@ -7789,6 +7789,12 @@ void moduleReleaseGIL(void) {
  *  - REDISMODULE_NOTIFY_STREAM: Stream events
  *  - REDISMODULE_NOTIFY_MODULE: Module types events
  *  - REDISMODULE_NOTIFY_KEYMISS: Key-miss events
+ *                                Notice, key-miss event is the only type
+ *                                of event that is fired from within a read command.
+ *                                Performing RM_Call with a write command from within
+ *                                this notification is wrong and discourage. It will
+ *                                cause the read command that trigger the event to be
+ *                                replicated to the AOF/Replica.
  *  - REDISMODULE_NOTIFY_ALL: All events (Excluding REDISMODULE_NOTIFY_KEYMISS)
  *  - REDISMODULE_NOTIFY_LOADED: A special notification available only for modules,
  *                               indicates that the key was loaded from persistence.
@@ -7820,6 +7826,7 @@ void moduleReleaseGIL(void) {
  * so notification callbacks must to be fast, or they would slow Redis down.
  * If you need to take long actions, use threads to offload them.
  *
+ * Warning: keymiss notification is a special type
  * See https://redis.io/topics/notifications for more information.
  */
 int RM_SubscribeToKeyspaceEvents(RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc callback) {

--- a/src/replication.c
+++ b/src/replication.c
@@ -420,7 +420,7 @@ void replicationFeedSlaves(list *slaves, int dictid, robj **argv, int argc) {
     char llstr[LONG_STR_SIZE];
 
     /* In case we propagate a command that doesn't touch keys (PING, REPLCONF) we
-     * pass dbid=server.slaveseldb which may be -1. */
+     * pass dbid=-1 that indicate there is no need to replicate `select` command. */
     serverAssert(dictid == -1 || (dictid >= 0 && dictid < server.dbnum));
 
     /* If the instance is not a top level master, return ASAP: we'll just proxy
@@ -3615,7 +3615,7 @@ void replicationCron(void) {
 
         if (!manual_failover_in_progress) {
             ping_argv[0] = shared.ping;
-            replicationFeedSlaves(server.slaves, server.slaveseldb,
+            replicationFeedSlaves(server.slaves, -1,
                 ping_argv, 1);
         }
     }

--- a/src/replication.c
+++ b/src/replication.c
@@ -442,7 +442,7 @@ void replicationFeedSlaves(list *slaves, int dictid, robj **argv, int argc) {
     prepareReplicasToWrite();
 
     /* Send SELECT command to every slave if needed. */
-    if (server.slaveseldb != dictid) {
+    if (dictid != -1 && server.slaveseldb != dictid) {
         robj *selectcmd;
 
         /* For a few DBs we have pre-computed SELECT command. */

--- a/src/server.c
+++ b/src/server.c
@@ -2926,7 +2926,7 @@ void redisOpArraySet(redisOpArray *oa, int dbid, robj **argv, int argc, int targ
  * dbid - the id of the database to apply the operation on
  * argv - operations arguments (including the command)
  * argc - size of argv
- * target - indicating how to propagate the opperation (PROPAGATE_AOF,PROPAGATE_REPL)
+ * target - indicating how to propagate the operation (PROPAGATE_AOF,PROPAGATE_REPL)
  *
  * Special case is when used with target 0, in this case the operation is a placeholder
  * that is expected to be filled later on using redisOpArraySet. */

--- a/src/server.c
+++ b/src/server.c
@@ -2922,15 +2922,17 @@ int redisOpArrayAppend(redisOpArray *oa, int dbid, robj **argv, int argc, int ta
 
     if (prev_capacity != oa->capacity)
         oa->ops = zrealloc(oa->ops,sizeof(redisOp)*oa->capacity);
-    op = oa->ops+oa->used;
+    int idx = oa->used;
+    op = oa->ops+idx;
     op->dbid = dbid;
     op->argv = argv;
     op->argc = argc;
     op->target = target;
+    oa->used++;
     if (op->target) {
         oa->numops++;
     }
-    return oa->used++; /* return the index of the appended operation */
+    return idx; /* return the index of the appended operation */
 }
 
 void redisOpArrayTrim(redisOpArray *oa) {

--- a/src/server.c
+++ b/src/server.c
@@ -2911,7 +2911,7 @@ void resetErrorTableStats(void) {
 /* ========================== Redis OP Array API ============================ */
 
 /* Used to update a placeholder previously created using `redisOpArrayAppendPlaceholder`.
- * We assume the updated placeholder as no target set yet (otherwise its not a placeholder). */
+ * We assume the updated placeholder has no target set yet (otherwise its not a placeholder). */
 void redisOpArraySet(redisOpArray *oa, int dbid, robj **argv, int argc, int target, int index) {
     redisOp *op = oa->ops+index;
     serverAssert(!op->target);

--- a/src/server.c
+++ b/src/server.c
@@ -3498,7 +3498,7 @@ void call(client *c, int flags) {
         /* Call alsoPropagate() only if at least one of AOF / replication
          * propagation is needed. */
         if (propagate_flags != PROPAGATE_NONE)
-            /* if we got here without a placeholder, the command will be added to the end
+            /* If we got here with cmd_prop_index == -1, the command will be added to the end
              * of the replication buffer, this can only happened on a read that causes a key
              * miss event which causes the module to perform a write command using RM_Call.
              * In such case we will propagate a read command (or a write command that has no effect

--- a/src/server.h
+++ b/src/server.h
@@ -1296,7 +1296,7 @@ typedef struct redisOpArray {
                      differenced between the actual number of operations
                      and the used spots because there might be spots
                      that was saved as a placeholder for future command
-                     but was never actally used */
+                     but was never actually used */
     int capacity; /* The ops array capacity */
 } redisOpArray;
 

--- a/src/server.h
+++ b/src/server.h
@@ -1292,6 +1292,7 @@ typedef struct redisOp {
 typedef struct redisOpArray {
     redisOp *ops;
     int numops;
+    int len;
     int capacity;
 } redisOpArray;
 
@@ -2897,7 +2898,7 @@ int incrCommandStatsOnError(struct redisCommand *cmd, int flags);
 void call(client *c, int flags);
 void alsoPropagate(int dbid, robj **argv, int argc, int target);
 void propagatePendingCommands();
-void redisOpArrayInit(redisOpArray *oa);
+void redisOpArrayReset(redisOpArray *oa);
 void redisOpArrayFree(redisOpArray *oa);
 void forceCommandPropagation(client *c, int flags);
 void preventCommandPropagation(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -1290,10 +1290,14 @@ typedef struct redisOp {
  * redisOpArrayFree();
  */
 typedef struct redisOpArray {
-    redisOp *ops;
-    int numops;
-    int len;
-    int capacity;
+    redisOp *ops; /* The array of operation to replicated */
+    int numops;   /* The actual number of operations in the array */
+    int used;     /* Spots that is used in the ops array, we need to
+                     differenced between the actual number of operations
+                     and the used spots because there might be spots
+                     that was saved as a placeholder for future command
+                     but was never actally used */
+    int capacity; /* The ops array capacity */
 } redisOpArray;
 
 /* This structure is returned by the getMemoryOverheadData() function in
@@ -1484,7 +1488,6 @@ struct redisServer {
     int busy_module_yield_flags;         /* Are we inside a busy module? (triggered by RM_Yield). see BUSY_MODULE_YIELD_ flags. */
     const char *busy_module_yield_reply; /* When non-null, we are inside RM_Yield. */
     int core_propagates;        /* Is the core (in oppose to the module subsystem) is in charge of calling propagatePendingCommands? */
-    int propagate_no_multi;     /* True if propagatePendingCommands should avoid wrapping command in MULTI/EXEC */
     int module_ctx_nesting;     /* moduleCreateContext() nesting level */
     char *ignore_warnings;      /* Config: warnings that should be ignored. */
     int client_pause_in_transaction; /* Was a client pause executed during this Exec? */

--- a/src/server.h
+++ b/src/server.h
@@ -1279,6 +1279,7 @@ extern clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUN
  * after the propagation of the executed command. */
 typedef struct redisOp {
     robj **argv;
+    /* target=0 means the operation should not be propagate (unused placeholder), for more info look at redisOpArray */
     int argc, dbid, target;
 } redisOp;
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -490,11 +490,17 @@ void spopWithCountCommand(client *c) {
 
         /* Delete the set as it is now empty */
         dbDelete(c->db,c->argv[1]);
+
+        /* Propagate del command */
+        robj *propagate[2];
+        propagate[0] = shared.del;
+        propagate[1] = c->argv[1];
+        alsoPropagate(c->db->id,propagate,2,PROPAGATE_AOF|PROPAGATE_REPL);
+
         notifyKeyspaceEvent(NOTIFY_GENERIC,"del",c->argv[1],c->db->id);
 
-        /* Propagate this command as a DEL operation */
-        rewriteClientCommandVector(c,2,shared.del,c->argv[1]);
         signalModifiedKey(c,c->db,c->argv[1]);
+        preventCommandPropagation(c);
         return;
     }
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -491,6 +491,9 @@ void spopWithCountCommand(client *c) {
         /* Delete the set as it is now empty */
         dbDelete(c->db,c->argv[1]);
 
+        /* todo: Move the spop notification to be executed after the command logic.
+         * We can then decide if we want to keep the `alsoPropagate` or move to `rewriteClientCommandVector`. */
+
         /* Propagate del command */
         robj *propagate[2];
         propagate[0] = shared.del;

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -93,7 +93,7 @@ static int KeySpace_NotificationExpired(RedisModuleCtx *ctx, int type, const cha
 /* This key miss notification handler is performing a write command inside the notification callback.
  * Notice, it is discourage and currently wrong to perform a write command inside key miss event.
  * It can cause read commands to be replicated to the replica/aof. This test is here temporary (for coverage and
- * verification that its not crashing). */
+ * verification that it's not crashing). */
 static int KeySpace_NotificationModuleKeyMiss(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
     REDISMODULE_NOT_USED(type);
     REDISMODULE_NOT_USED(event);

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -90,6 +90,17 @@ static int KeySpace_NotificationExpired(RedisModuleCtx *ctx, int type, const cha
     return REDISMODULE_OK;
 }
 
+static int KeySpace_NotificationModuleKeyMiss(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
+    REDISMODULE_NOT_USED(type);
+    REDISMODULE_NOT_USED(event);
+    REDISMODULE_NOT_USED(key);
+
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, "incr", "!c", "missed");
+    RedisModule_FreeCallReply(rep);
+
+    return REDISMODULE_OK;
+}
+
 static int KeySpace_NotificationModule(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
     REDISMODULE_NOT_USED(ctx);
     REDISMODULE_NOT_USED(type);
@@ -249,6 +260,10 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     }
 
     if(RedisModule_SubscribeToKeyspaceEvents(ctx, REDISMODULE_NOTIFY_MODULE, KeySpace_NotificationModule) != REDISMODULE_OK){
+        return REDISMODULE_ERR;
+    }
+
+    if(RedisModule_SubscribeToKeyspaceEvents(ctx, REDISMODULE_NOTIFY_KEY_MISS, KeySpace_NotificationModuleKeyMiss) != REDISMODULE_OK){
         return REDISMODULE_ERR;
     }
 

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -95,6 +95,12 @@ static int KeySpace_NotificationModuleKeyMiss(RedisModuleCtx *ctx, int type, con
     REDISMODULE_NOT_USED(event);
     REDISMODULE_NOT_USED(key);
 
+    int flags = RedisModule_GetContextFlags(ctx);
+    if (!(flags & REDISMODULE_CTX_FLAGS_MASTER)) {
+        return REDISMODULE_OK; // ignore the event on replica
+    }
+
+
     RedisModuleCallReply* rep = RedisModule_Call(ctx, "incr", "!c", "missed");
     RedisModule_FreeCallReply(rep);
 

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -90,6 +90,10 @@ static int KeySpace_NotificationExpired(RedisModuleCtx *ctx, int type, const cha
     return REDISMODULE_OK;
 }
 
+/* This key miss notification handler is performing a write command inside the notification callback.
+ * Notice, it is discourage and currently wrong to perform a write command inside key miss event.
+ * It can cause read commands to be replicated to the replica/aof. This test is here temporary (for coverage and
+ * verification that its not crashing). */
 static int KeySpace_NotificationModuleKeyMiss(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
     REDISMODULE_NOT_USED(type);
     REDISMODULE_NOT_USED(event);

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -100,7 +100,6 @@ static int KeySpace_NotificationModuleKeyMiss(RedisModuleCtx *ctx, int type, con
         return REDISMODULE_OK; // ignore the event on replica
     }
 
-
     RedisModuleCallReply* rep = RedisModule_Call(ctx, "incr", "!c", "missed");
     RedisModule_FreeCallReply(rep);
 

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -746,7 +746,7 @@ start_server {tags {"expire"}} {
         assert_equal [r EXPIRE none 100 LT] 0
     } {}
 
-    test {Redis should propagate the read command on lazy expire} {
+    test {Redis should not propagate the read command on lazy expire} {
         r debug set-active-expire 0
         r flushall ; # Clean up keyspace to avoid interference by keys from other tests
         r set foo bar PX 1

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -757,9 +757,13 @@ start_server {tags {"expire"}} {
             fail "Replication not started."
         }
 
+        # dummy command to verify nothing else gets into the replication stream.
+        r set x 1
+
         assert_replication_stream $repl {
             {select *}
             {del foo}
+            {set x 1}
         }
         close_replication_stream $repl
         assert_equal [r debug set-active-expire 1] {OK}

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -558,8 +558,8 @@ start_server {tags {"maxmemory" "external:skip"}} {
         }
 
         assert_replication_stream $repl {
-            {select *}
             {multi}
+            {select *}
             {incr x}
             {incr x}
             {exec}

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -149,7 +149,7 @@ tags "modules" {
                     # Bottom line: "notifications" always exists and we can't really determine the order of evictions
                     # This test is here only for sanity
 
-                    # slave will get the notification with multi exec and we have a generic notification handler
+                    # The replica will get the notification with multi exec and we have a generic notification handler
                     # that performs `RedisModule_Call(ctx, "INCR", "c", "multi");` if the notification is inside multi exec.
                     # so we will have 2 keys, "notifications" and "multi".
                     wait_for_condition 500 10 {

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -149,7 +149,7 @@ tags "modules" {
                     # Bottom line: "notifications" always exists and we can't really determine the order of evictions
                     # This test is here only for sanity
 
-                    # slave will get the notification with multi exec and we have a generic notifcation handler
+                    # slave will get the notification with multi exec and we have a generic notification handler
                     # that performs `RedisModule_Call(ctx, "INCR", "c", "multi");` if the notification is inside multi exec.
                     # so we will have 2 keys, "notifications" and "multi".
                     wait_for_condition 500 10 {

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -618,6 +618,9 @@ tags "modules" {
                         fail "Failed to wait for set to be replicated"
                     }
 
+                    # Currently the `del` command comes after the notification.
+                    # When we fix spop to fire notification at the end (like all other commands),
+                    # the `del` will come first.
                     assert_replication_stream $repl {
                         {multi}
                         {select *}

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -646,12 +646,15 @@ tags "modules" {
                         fail "Failed to wait for set to be replicated"
                     }
 
+                    # Test is checking a wrong!!! behavior that causes a read command to be replicated to replica/aof.
+                    # We keep the test to verify that such a wrong behavior does not cause any crashes.
                     assert_replication_stream $repl {
                         {select *}
                         {flushall}
                         {multi}
                         {incr missed}
                         {incr notifications}
+                        {get unexisting_key}
                         {exec}
                     }
                     

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -421,8 +421,8 @@ start_server {tags {"multi"}} {
         r exec
 
         assert_replication_stream $repl {
-            {select *}
             {multi}
+            {select *}
             {set foo{t} bar}
             {set foo2{t} bar2}
             {set foo3{t} bar3}
@@ -446,8 +446,8 @@ start_server {tags {"multi"}} {
         r exec
 
         assert_replication_stream $repl {
-            {select *}
             {multi}
+            {select *}
             {set foo{t} bar}
             {select *}
             {set foo2{t} bar2}
@@ -904,8 +904,8 @@ start_server {overrides {appendonly {yes} appendfilename {appendonly.aof} append
         r flushall
         r exec
         assert_aof_content $aof {
-            {select *}
             {multi}
+            {select *}
             {set *}
             {flushall}
             {exec}


### PR DESCRIPTION
NOTICE! The main part of this change has been later reverted in #11178, and isn't included in 7.2 RC1, despite what the release notes state
see https://github.com/redis/redis/pull/10969#issuecomment-1223771006 as to why

-----

Fix replication inconsistency on modules that uses key space notifications.

### The Problem

In general, key space notifications are invoked after the command logic was executed (this is not always the case, we will discuss later about specific command that do not follow this rules). For example, the `set x 1` will trigger a `set` notification that will be invoked after the `set` logic was performed, so if the notification logic will try to fetch `x`, it will see the new data that was written.
Consider the scenario on which the notification logic performs some write commands. for example, the notification logic increase some counter, `incr x{counter}`, indicating how many times `x` was changed. The logical order by which the logic was executed is has follow:

```
set x 1
incr x{counter}
```

The issue is that the `set x 1` command is added to the replication buffer at the end of the command invocation (specifically after the key space notification logic was invoked and performed the `incr` command). The replication/aof sees the commands in the wrong order:

```
incr x{counter}
set x 1
```

In this specific example the order is less important. But if, for example, the notification would have deleted `x` then we would end up with primary-replica inconsistency.

### The Solution

Put the command that cause the notification in its rightful place. In the above example, the `set x 1` command logic was executed before the notification logic, so it should be added to the replication buffer before the commands that is invoked by the notification logic. To achieve this, without a major code refactoring, we save a placeholder in the replication buffer, when finishing invoking the command logic we check if the command need to be replicated, and if it does, we use the placeholder to add it to the replication buffer instead of appending it to the end.

To be efficient and not allocating memory on each command to save the placeholder, the replication buffer array was modified to reuse memory (instead of allocating it each time we want to replicate commands). Also, to avoid saving a placeholder when not needed, we do it only for WRITE or MAY_REPLICATE commands.

#### Additional Fixes

* Expire and Eviction notifications:
  * Expire/Eviction logical order was to first perform the Expire/Eviction and then the notification logic. The replication buffer got this in the other way around (first notification effect and then the `del` command). The PR fixes this issue.
  * The notification effect and the `del` command was not wrap with `multi-exec` (if needed). The PR also fix this issue.
* SPOP command:
  * On spop, the `spop` notification was fired before the command logic was executed. The change in this PR would have cause the replication order to be change (first `spop` command and then notification `logic`) although the logical order is first the notification logic and then the `spop` logic. The right fix would have been to move the notification to be fired after the command was executed (like all the other commands), but this can be considered a breaking change. To overcome this, the PR keeps the current behaviour and changes the `spop` code to keep the right logical order when pushing commands to the replication buffer. Another PR will follow to fix the SPOP properly and match it to the other command (we split it to 2 separate PR's so it will be easy to cherry-pick this PR to 7.0 if we chose to).

#### Unhanded Known Limitations

* key miss event:
   *  On key miss event, if a module performed some write command on the event (using `RM_Call`), the `dirty` counter would increase and the read command that cause the key miss event would be replicated to the replication and aof. This problem can also happened on a write command that open some keys but eventually decides not to perform any action. We decided not to handle this problem on this PR because the solution is complex and will cause additional risks in case we will want to cherry-pick this PR. We should decide if we want to handle it in future PR's (@oranagra @yossigo @madolson FYI). For now, modules writers is advice not to perform any write commands on key miss event.

#### Testing

* We already have tests to cover cases where a notification is invoking write commands that are also added to the replication buffer, the tests was modified to verify that the replica gets the command in the correct logical order.
* Test was added to verify that `spop` behaviour was kept unchanged.
* Test was added to verify key miss event behave as expected.
* Test was added to verify the changes do not break lazy expiration.

#### Additional Changes

* Follow @guybe7 suggestion, `propagateNow` function can accept a special dbid, -1, indicating not to replicate `select`. We use this to replicate `multi/exec` on `propagatePendingCommands` function. The side effect of this change is that now the `select` command will appear inside the `multi/exec` block on the replication stream (instead of outside of the `multi/exec` block). Tests was modified to match this new behaviour.