### PR TITLE
Re-enable aof-race integration tests

### DIFF
--- a/tests/integration/aof-race.tcl
+++ b/tests/integration/aof-race.tcl
@@ -1,21 +1,20 @@
+source tests/support/aofmanifest.tcl
 set defaults { appendonly {yes} appendfilename {appendonly.aof} appenddirname {appendonlydir} aof-use-rdb-preamble {no} }
 set server_path [tmpdir server.aof]
 
-proc start_server_aof {overrides code} {
-    upvar defaults defaults srv srv server_path server_path
-    set config [concat $defaults $overrides]
-    start_server [list overrides $config] $code
-}
-
-tags {"aof"} {
+tags {"aof external:skip"} {
     # Specific test for a regression where internal buffers were not properly
     # cleaned after a child responsible for an AOF rewrite exited. This buffer
     # was subsequently appended to the new AOF, resulting in duplicate commands.
     start_server_aof [list dir $server_path] {
-        set client [redis [srv host] [srv port] 0 $::tls]
-        set bench [open "|src/redis-benchmark -q -s [srv unixsocket] -c 20 -n 20000 incr foo" "r+"]
+        set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+        set bench [open "|src/redis-benchmark -q -s [dict get $srv unixsocket] -c 20 -n 20000 incr foo" "r+"]
 
-        after 100
+        wait_for_condition 100 1 {
+            [$client get foo] > 0
+        } else {
+            # Don't care if it fails.
+        }
 
         # Benchmark should be running by now: start background rewrite
         $client bgrewriteaof
@@ -23,13 +22,16 @@ tags {"aof"} {
         # Read until benchmark pipe reaches EOF
         while {[string length [read $bench]] > 0} {}
 
+        waitForBgrewriteaof $client
+
         # Check contents of foo
         assert_equal 20000 [$client get foo]
     }
 
     # Restart server to replay AOF
     start_server_aof [list dir $server_path] {
-        set client [redis [srv host] [srv port] 0 $::tls]
+        set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+        wait_done_loading $client
         assert_equal 20000 [$client get foo]
     }
 }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -50,6 +50,7 @@ set ::all_tests {
     integration/replication-buffer
     integration/shutdown
     integration/aof
+    integration/aof-race
     integration/aof-multi-part
     integration/rdb
     integration/corrupt-dump


### PR DESCRIPTION
This is the history of aof-race related changes:
1. added in 3aa4b0097062b13031506b6b52fc8fc4bfec6dfc
2. disabled in dcdfd005a0133a347cc0aae54c690cd8c845fed7
3. enabled in 5c63922691ed8a821bd7f9f2837a8270f1154268
4. disabled in 53a2af3941b0c6cd8057983ee92775916f1490ab

This PR refreshes the aof-race test, re-enable it.
Closes #10971