### PR TITLE
Avoid the sdslen() on shared.crlf given we know its size beforehand. Improve ~3-4% of cpu cycles to lrange logic

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -860,7 +860,7 @@ void addReplyBigNum(client *c, const char* num, size_t len) {
     } else {
         addReplyProto(c,"(",1);
         addReplyProto(c,num,len);
-        addReplyProto(c,shared.crlf->ptr,2);
+        addReplyProto(c,"\r\n",2);
     }
 }
 
@@ -991,21 +991,21 @@ void addReplyBulkLen(client *c, robj *obj) {
 void addReplyBulk(client *c, robj *obj) {
     addReplyBulkLen(c,obj);
     addReply(c,obj);
-    addReplyProto(c,shared.crlf->ptr,2);
+    addReplyProto(c,"\r\n",2);
 }
 
 /* Add a C buffer as bulk reply */
 void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
     addReplyLongLongWithPrefix(c,len,'$');
     addReplyProto(c,p,len);
-    addReplyProto(c,shared.crlf->ptr,2);
+    addReplyProto(c,"\r\n",2);
 }
 
 /* Add sds to reply (takes ownership of sds and frees it) */
 void addReplyBulkSds(client *c, sds s)  {
     addReplyLongLongWithPrefix(c,sdslen(s),'$');
     addReplySds(c,s);
-    addReplyProto(c,shared.crlf->ptr,2);
+    addReplyProto(c,"\r\n",2);
 }
 
 /* Set sds to a deferred reply (for symmetry with addReplyBulkSds it also frees the sds) */

--- a/src/networking.c
+++ b/src/networking.c
@@ -860,7 +860,7 @@ void addReplyBigNum(client *c, const char* num, size_t len) {
     } else {
         addReplyProto(c,"(",1);
         addReplyProto(c,num,len);
-        addReply(c,shared.crlf);
+        addReplyProto(c,shared.crlf->ptr,2);
     }
 }
 
@@ -991,21 +991,21 @@ void addReplyBulkLen(client *c, robj *obj) {
 void addReplyBulk(client *c, robj *obj) {
     addReplyBulkLen(c,obj);
     addReply(c,obj);
-    addReply(c,shared.crlf);
+    addReplyProto(c,shared.crlf->ptr,2);
 }
 
 /* Add a C buffer as bulk reply */
 void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
     addReplyLongLongWithPrefix(c,len,'$');
     addReplyProto(c,p,len);
-    addReply(c,shared.crlf);
+    addReplyProto(c,shared.crlf->ptr,2);
 }
 
 /* Add sds to reply (takes ownership of sds and frees it) */
 void addReplyBulkSds(client *c, sds s)  {
     addReplyLongLongWithPrefix(c,sdslen(s),'$');
     addReplySds(c,s);
-    addReply(c,shared.crlf);
+    addReplyProto(c,shared.crlf->ptr,2);
 }
 
 /* Set sds to a deferred reply (for symmetry with addReplyBulkSds it also frees the sds) */

--- a/src/server.c
+++ b/src/server.c
@@ -1680,7 +1680,6 @@ void createSharedObjects(void) {
     int j;
 
     /* Shared command responses */
-    shared.crlf = createObject(OBJ_STRING,sdsnew("\r\n"));
     shared.ok = createObject(OBJ_STRING,sdsnew("+OK\r\n"));
     shared.emptybulk = createObject(OBJ_STRING,sdsnew("$0\r\n\r\n"));
     shared.czero = createObject(OBJ_STRING,sdsnew(":0\r\n"));

--- a/src/server.h
+++ b/src/server.h
@@ -1217,7 +1217,7 @@ struct sentinelConfig {
 };
 
 struct sharedObjectsStruct {
-    robj *crlf, *ok, *err, *emptybulk, *czero, *cone, *pong, *space,
+    robj *ok, *err, *emptybulk, *czero, *cone, *pong, *space,
     *queued, *null[4], *nullarray[4], *emptymap[4], *emptyset[4],
     *emptyarray, *wrongtypeerr, *nokeyerr, *syntaxerr, *sameobjecterr,
     *outofrangeerr, *noscripterr, *loadingerr,


### PR DESCRIPTION
Fixes https://github.com/redis/redis/issues/10986

Problem description:
Using the lrange benchmarks of redis benchmark ( I was investigating it due to #10981 ) we can see that we're wasting a large ammount of cpu cycles on sdslen() computing the sizes we already know:

```
                           - 77.55% lrangeCommand                                                                                                                                                          ▒
                              - 77.31% addListRangeReply                                                                                                                                                   ▒
                                 + 35.46% addReplyBulkCBuffer                                                                                                                                              ▒
                                 + 21.34% listTypeNext (inlined)                                                                                                                                           ▒
                                 - 11.32% addReply (inlined)                                                                                                                                               ▒
                                      6.55% sdslen (inlined)                                                                                                                                               ▒
                                      0.41% _addReplyToBufferOrList (inlined)                                                                                                                              ▒
                                 + 6.88% _addReplyToBufferOrList (inlined)                                                                                                                                 ▒
                                 + 0.60% addReplyLongLongWithPrefix                                                                                                                                        ▒
                                   0.50% prepareClientToWrite                                                                                                                                              ▒
                                   0.15% listTypeReleaseIterator (inlined)  
```

Fix: 

The fix is a simple replace of using addReply with addReplyProto for the `shared.crlf` related replies. 

-------

On the LRANGE_600 benchmark we get:

benchmark command:
```
redis-benchmark  -n 1000000 --threads 3 "LRANGE" "mylist" "0" "599"
```

Unstable
```
Summary:
  throughput summary: 22055.58 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        1.585     0.080     1.607     2.391     3.015     4.575
```
New
```
Summary:
  throughput summary: 22821.67 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        1.623     0.056     1.639     2.375     2.959     7.935
```