### PR TITLE
Fix cluster hostnames test causing failover while running valgrind

### DIFF
--- a/tests/unit/cluster/hostnames.tcl
+++ b/tests/unit/cluster/hostnames.tcl
@@ -214,7 +214,7 @@ test "Test restart will keep hostname information" {
     restart_server 0 true false
     set slot_result [R 0 CLUSTER SLOTS]
     assert_equal [lindex [get_slot_field $slot_result 0 2 3] 1] "restart-1.com"
-    
+
     # As a sanity check, make sure everyone eventually agrees
     wait_for_cluster_propagation
 }

--- a/tests/unit/cluster/hostnames.tcl
+++ b/tests/unit/cluster/hostnames.tcl
@@ -203,12 +203,18 @@ test "Verify the nodes configured with prefer hostname only show hostname for ne
 test "Test restart will keep hostname information" {
     # Set a new hostname, reboot and make sure it sticks
     R 0 config set cluster-announce-hostname "restart-1.com"
+    
     # Store the hostname in the config
     R 0 config rewrite
+
+    # If the primary is slow to reboot it might get demoted, so prevent the replica
+    # from nominating itself.
+    R 3 config set cluster-replica-no-failover yes
+
     restart_server 0 true false
     set slot_result [R 0 CLUSTER SLOTS]
     assert_equal [lindex [get_slot_field $slot_result 0 2 3] 1] "restart-1.com"
-
+    
     # As a sanity check, make sure everyone eventually agrees
     wait_for_cluster_propagation
 }


### PR DESCRIPTION
In the newly added cluster hostnames test, the primary is failing over during the reboot for valgrind so we are validating the wrong node. This change just sets the replica to prevent taking over, which seems to fix the test.

We could have also set the timeout higher, but it slows down the test.

```
dev-dsk-matolson-2c-96119f9f % ./runtest --valgrind --no-latency --verbose --clients 1 --timeout 2400 --dump-logs --single unit/cluster/hostnames
Cleanup: may take some time... OK
Starting test server at port 21079
[ready]: 22670
Testing unit/cluster/hostnames
=== (external:skip cluster) Starting server 127.0.0.1:21111 ok
=== (external:skip cluster) Starting server 127.0.0.1:21112 ok
=== (external:skip cluster) Starting server 127.0.0.1:21113 ok
=== (external:skip cluster) Starting server 127.0.0.1:21114 ok
=== (external:skip cluster) Starting server 127.0.0.1:21115 ok
=== (external:skip cluster) Starting server 127.0.0.1:21116 ok
=== (external:skip cluster) Starting server 127.0.0.1:21117 ok
[ok]: Set cluster hostnames and verify they are propagated (1108 ms)
[ok]: Update hostnames and make sure they are all eventually propagated (862 ms)
[ok]: Remove hostnames and make sure they are all eventually propagated (963 ms)
[ok]: Verify cluster-preferred-endpoint-type behavior for redirects and info (993 ms)
[ok]: Verify the nodes configured with prefer hostname only show hostname for new nodes (3161 ms)
[ok]: Test restart will keep hostname information (2562 ms)
[ok]: Test hostname validation (17 ms)
[1/1 done]: unit/cluster/hostnames (27 seconds)

                   The End

Execution time of different units:
  27 seconds - unit/cluster/hostnames
```