### PR TITLE
Fix heap overflow corruption in XAUTOCLAIM (CVE-2022-31144)

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3421,6 +3421,7 @@ void xautoclaimCommand(client *c) {
             /* Remember the ID for later */
             deleted_ids[deleted_id_num++] = id;
             raxSeek(&ri,">=",ri.key,ri.key_len);
+            count--; /* Count is a limit of the command response size. */
             continue;
         }
 


### PR DESCRIPTION
The temporary array for deleted entries reply of XAUTOCLAIM was
insufficient, but also in fact the COUNT argument should be used to
control the size of the reply, so instead of terminating the loop by
only counting the claimed entries, we'll count deleted entries as well.

Fix #10968
Addresses CVE-2022-31144