### PR TITLE
Adds RM_Microseconds and RM_CachedMicroseconds

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -970,21 +970,6 @@ void RM_ChannelAtPosWithFlags(RedisModuleCtx *ctx, int pos, int flags) {
     res->numkeys++;
 }
 
-/* Return the wall-clock Unix time, in microseconds */
-long long RM_Time() {
-    return ustime();
-}
-
-/* Returns a cached copy of th Unix time, in microseconds.
- * It is updated in the server cron job and before executing a command.
- * It is useful for complex call stacks, such as a command causing a
- * key space notification, causing a module to execute a RedisModule_Call,
- * causing another notification, etc.
- * It makes sense that all this callbacks would use the same clock. */
-long long RM_CachedTime() {
-    return server.ustime;
-}
-
 /* Helper for RM_CreateCommand(). Turns a string representing command
  * flags into the command flags used by the Redis core.
  *
@@ -2042,13 +2027,28 @@ int RM_IsModuleNameBusy(const char *name) {
 }
 
 /* Return the current UNIX time in milliseconds. */
-long long RM_Milliseconds(void) {
+mstime_t RM_Milliseconds(void) {
     return mstime();
 }
 
 /* Return counter of micro-seconds relative to an arbitrary point in time. */
 uint64_t RM_MonotonicMicroseconds(void) {
     return getMonotonicUs();
+}
+
+/* Return the current UNIX time in microseconds */
+ustime_t RM_Microseconds() {
+    return ustime();
+}
+
+/* Return the cached UNIX time in microseconds.
+ * It is updated in the server cron job and before executing a command.
+ * It is useful for complex call stacks, such as a command causing a
+ * key space notification, causing a module to execute a RedisModule_Call,
+ * causing another notification, etc.
+ * It makes sense that all this callbacks would use the same clock. */
+long long RM_CachedMicroseconds() {
+    return server.ustime;
 }
 
 /* Mark a point in time that will be used as the start time to calculate
@@ -12530,8 +12530,6 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(KeyAtPosWithFlags);
     REGISTER_API(IsChannelsPositionRequest);
     REGISTER_API(ChannelAtPosWithFlags);
-    REGISTER_API(Time);
-    REGISTER_API(CachedTime);
     REGISTER_API(GetClientId);
     REGISTER_API(GetClientUserNameById);
     REGISTER_API(GetContextFlags);
@@ -12593,6 +12591,8 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(AbortBlock);
     REGISTER_API(Milliseconds);
     REGISTER_API(MonotonicMicroseconds);
+    REGISTER_API(Microseconds);
+    REGISTER_API(CachedMicroseconds);
     REGISTER_API(BlockedClientMeasureTimeStart);
     REGISTER_API(BlockedClientMeasureTimeEnd);
     REGISTER_API(GetThreadSafeContext);

--- a/src/module.c
+++ b/src/module.c
@@ -970,6 +970,21 @@ void RM_ChannelAtPosWithFlags(RedisModuleCtx *ctx, int pos, int flags) {
     res->numkeys++;
 }
 
+/* Return the wall-clock Unix time, in microseconds */
+long long RM_Time() {
+    return ustime();
+}
+
+/* Returns a cached copy of th Unix time, in microseconds.
+ * It is updated in the server cron job and before executing a command.
+ * It is useful for complex call stacks, such as a command causing a
+ * key space notification, causing a module to execute a RedisModule_Call,
+ * causing another notification, etc.
+ * It makes sense that all this callbacks would use the same clock. */
+long long RM_CachedTime() {
+    return server.ustime;
+}
+
 /* Helper for RM_CreateCommand(). Turns a string representing command
  * flags into the command flags used by the Redis core.
  *
@@ -12515,6 +12530,8 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(KeyAtPosWithFlags);
     REGISTER_API(IsChannelsPositionRequest);
     REGISTER_API(ChannelAtPosWithFlags);
+    REGISTER_API(Time);
+    REGISTER_API(CachedTime);
     REGISTER_API(GetClientId);
     REGISTER_API(GetClientUserNameById);
     REGISTER_API(GetContextFlags);

--- a/src/module.c
+++ b/src/module.c
@@ -2047,7 +2047,7 @@ ustime_t RM_Microseconds() {
  * key space notification, causing a module to execute a RedisModule_Call,
  * causing another notification, etc.
  * It makes sense that all this callbacks would use the same clock. */
-long long RM_CachedMicroseconds() {
+ustime_t RM_CachedMicroseconds() {
     return server.ustime;
 }
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -752,6 +752,7 @@ typedef enum {
 #ifndef REDISMODULE_CORE
 
 typedef long long mstime_t;
+typedef long long ustime_t;
 
 /* Macro definitions specific to individual compilers */
 #ifndef REDISMODULE_ATTR_UNUSED
@@ -1001,8 +1002,6 @@ REDISMODULE_API void (*RedisModule_KeyAtPos)(RedisModuleCtx *ctx, int pos) REDIS
 REDISMODULE_API void (*RedisModule_KeyAtPosWithFlags)(RedisModuleCtx *ctx, int pos, int flags) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsChannelsPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ChannelAtPosWithFlags)(RedisModuleCtx *ctx, int pos, int flags) REDISMODULE_ATTR;
-REDISMODULE_API long long (*RedisModule_Time)() REDISMODULE_ATTR;
-REDISMODULE_API long long (*RedisModule_CachedTime)() REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_GetClientId)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_GetClientUserNameById)(RedisModuleCtx *ctx, uint64_t id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetClientInfoById)(void *ci, uint64_t id) REDISMODULE_ATTR;
@@ -1057,8 +1056,10 @@ REDISMODULE_API int (*RedisModule_GetDbIdFromOptCtx)(RedisModuleKeyOptCtx *ctx) 
 REDISMODULE_API int (*RedisModule_GetToDbIdFromOptCtx)(RedisModuleKeyOptCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API const RedisModuleString * (*RedisModule_GetKeyNameFromOptCtx)(RedisModuleKeyOptCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API const RedisModuleString * (*RedisModule_GetToKeyNameFromOptCtx)(RedisModuleKeyOptCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API long long (*RedisModule_Milliseconds)(void) REDISMODULE_ATTR;
+REDISMODULE_API mstime_t (*RedisModule_Milliseconds)(void) REDISMODULE_ATTR;
 REDISMODULE_API uint64_t (*RedisModule_MonotonicMicroseconds)(void) REDISMODULE_ATTR;
+REDISMODULE_API ustime_t (*RedisModule_Microseconds)(void) REDISMODULE_ATTR;
+REDISMODULE_API ustime_t (*RedisModule_CachedMicroseconds)(void) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_DigestAddStringBuffer)(RedisModuleDigest *md, const char *ele, size_t len) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_DigestAddLongLong)(RedisModuleDigest *md, long long ele) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_DigestEndSequence)(RedisModuleDigest *md) REDISMODULE_ATTR;
@@ -1341,8 +1342,6 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(KeyAtPosWithFlags);
     REDISMODULE_GET_API(IsChannelsPositionRequest);
     REDISMODULE_GET_API(ChannelAtPosWithFlags);
-    REDISMODULE_GET_API(Time);
-    REDISMODULE_GET_API(CachedTime);
     REDISMODULE_GET_API(GetClientId);
     REDISMODULE_GET_API(GetClientUserNameById);
     REDISMODULE_GET_API(GetContextFlags);
@@ -1394,6 +1393,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(GetToDbIdFromOptCtx);
     REDISMODULE_GET_API(Milliseconds);
     REDISMODULE_GET_API(MonotonicMicroseconds);
+    REDISMODULE_GET_API(Microseconds);
+    REDISMODULE_GET_API(CachedMicroseconds);
     REDISMODULE_GET_API(DigestAddStringBuffer);
     REDISMODULE_GET_API(DigestAddLongLong);
     REDISMODULE_GET_API(DigestEndSequence);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1001,6 +1001,8 @@ REDISMODULE_API void (*RedisModule_KeyAtPos)(RedisModuleCtx *ctx, int pos) REDIS
 REDISMODULE_API void (*RedisModule_KeyAtPosWithFlags)(RedisModuleCtx *ctx, int pos, int flags) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsChannelsPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_ChannelAtPosWithFlags)(RedisModuleCtx *ctx, int pos, int flags) REDISMODULE_ATTR;
+REDISMODULE_API long long (*RedisModule_Time)() REDISMODULE_ATTR;
+REDISMODULE_API long long (*RedisModule_CachedTime)() REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_GetClientId)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_GetClientUserNameById)(RedisModuleCtx *ctx, uint64_t id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetClientInfoById)(void *ci, uint64_t id) REDISMODULE_ATTR;
@@ -1339,6 +1341,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(KeyAtPosWithFlags);
     REDISMODULE_GET_API(IsChannelsPositionRequest);
     REDISMODULE_GET_API(ChannelAtPosWithFlags);
+    REDISMODULE_GET_API(Time);
+    REDISMODULE_GET_API(CachedTime);
     REDISMODULE_GET_API(GetClientId);
     REDISMODULE_GET_API(GetClientUserNameById);
     REDISMODULE_GET_API(GetContextFlags);

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -30,10 +30,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _DEFAULT_SOURCE /* For usleep */
 
 #include "redismodule.h"
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 ustime_t cached_time = 0;
 
@@ -63,6 +65,7 @@ static int KeySpace_NotificationGeneric(RedisModuleCtx *ctx, int type, const cha
 
     if (cached_time) {
         RedisModule_Assert(cached_time == RedisModule_CachedMicroseconds());
+        usleep(1);
         RedisModule_Assert(cached_time != RedisModule_Microseconds());
     }
 

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <string.h>
 
-long long cached_time = 0;
+ustime_t cached_time = 0;
 
 /** stores all the keys on which we got 'loaded' keyspace notification **/
 RedisModuleDict *loaded_event_log = NULL;
@@ -62,8 +62,8 @@ static int KeySpace_NotificationGeneric(RedisModuleCtx *ctx, int type, const cha
     REDISMODULE_NOT_USED(type);
 
     if (cached_time) {
-        RedisModule_Assert(cached_time == RedisModule_CachedTime());
-        RedisModule_Assert(cached_time != RedisModule_Time());
+        RedisModule_Assert(cached_time == RedisModule_CachedMicroseconds());
+        RedisModule_Assert(cached_time != RedisModule_Microseconds());
     }
 
     if (strcmp(event, "del") == 0) {
@@ -165,7 +165,7 @@ static int cmdDelKeyCopy(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     if (argc != 2)
         return RedisModule_WrongArity(ctx);
 
-    cached_time = RedisModule_CachedTime();
+    cached_time = RedisModule_CachedMicroseconds();
 
     RedisModuleCallReply* rep = RedisModule_Call(ctx, "DEL", "s!", argv[1]);
     if (!rep) {

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -35,6 +35,8 @@
 #include <stdio.h>
 #include <string.h>
 
+long long cached_time = 0;
+
 /** stores all the keys on which we got 'loaded' keyspace notification **/
 RedisModuleDict *loaded_event_log = NULL;
 /** stores all the keys on which we got 'module' keyspace notification **/
@@ -58,6 +60,11 @@ static int KeySpace_NotificationLoaded(RedisModuleCtx *ctx, int type, const char
 
 static int KeySpace_NotificationGeneric(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key) {
     REDISMODULE_NOT_USED(type);
+
+    if (cached_time) {
+        RedisModule_Assert(cached_time == RedisModule_CachedTime());
+        RedisModule_Assert(cached_time != RedisModule_Time());
+    }
 
     if (strcmp(event, "del") == 0) {
         RedisModuleString *copykey = RedisModule_CreateStringPrintf(ctx, "%s_copy", RedisModule_StringPtrLen(key, NULL));
@@ -158,6 +165,8 @@ static int cmdDelKeyCopy(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     if (argc != 2)
         return RedisModule_WrongArity(ctx);
 
+    cached_time = RedisModule_CachedTime();
+
     RedisModuleCallReply* rep = RedisModule_Call(ctx, "DEL", "s!", argv[1]);
     if (!rep) {
         RedisModule_ReplyWithError(ctx, "NULL reply returned");
@@ -165,6 +174,7 @@ static int cmdDelKeyCopy(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
         RedisModule_ReplyWithCallReply(ctx, rep);
         RedisModule_FreeCallReply(rep);
     }
+    cached_time = 0;
     return REDISMODULE_OK;
 }
 


### PR DESCRIPTION
RM_Microseconds
Return the wall-clock Unix time, in microseconds

RM_CachedMicroseconds
Returns a cached copy of the Unix time, in microseconds.
It is updated in the server cron job and before executing a command.
It is useful for complex call stacks, such as a command causing a
key space notification, causing a module to execute a RedisModule_Call,
causing another notification, etc.
It makes sense that all these callbacks would use the same clock.