### PR TITLE
Register abs-expire module APIs

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -12483,6 +12483,8 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(StringTruncate);
     REGISTER_API(SetExpire);
     REGISTER_API(GetExpire);
+    REGISTER_API(SetAbsExpire);
+    REGISTER_API(GetAbsExpire);
     REGISTER_API(ResetDataset);
     REGISTER_API(DbSize);
     REGISTER_API(RandomKey);


### PR DESCRIPTION
RM_SetAbsExpire and RM_GetAbsExpire were not actually operational since they were introduced, due to omission in API registration.
Sorry this was an omission in the previous PR #8564