### PR TITLE
Allow calling RM_FreeString with NULL pointer

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -2390,6 +2390,13 @@ RedisModuleString *RM_CreateStringFromStreamID(RedisModuleCtx *ctx, const RedisM
  * the context, so if you want to free a string out of context later, make sure
  * to create it using a NULL context. */
 void RM_FreeString(RedisModuleCtx *ctx, RedisModuleString *str) {
+    if (!str) {
+        char *module_name = (ctx && ctx->module) ? ctx->module->name : "module";
+        serverLog(LL_NOTICE, "Module <%s> called RM_FreeString with NULL value. "
+                  "This is valid but may crash on older Redis version. Please make sure this is intentional.",
+                  module_name);
+        return;
+    }
     decrRefCount(str);
     if (ctx != NULL) autoMemoryFreed(ctx,REDISMODULE_AM_STRING,str);
 }

--- a/tests/modules/basics.c
+++ b/tests/modules/basics.c
@@ -380,6 +380,16 @@ fail:
     return REDISMODULE_OK;
 }
 
+/* TEST.STRING.FREENULL -- Test calling RM_FreeString with a NULL pointer. */
+int TestStringFreeNull(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    RedisModule_FreeString(ctx,NULL);
+    RedisModule_ReplyWithSimpleString(ctx,"OK");
+    return REDISMODULE_OK;
+}
+
 /* TEST.STRING.APPEND -- Test appending to an existing string object. */
 int TestStringAppend(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
@@ -838,6 +848,9 @@ int TestBasics(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     T("test.ctxflags","");
     if (!TestAssertStringReply(ctx,reply,"OK",2)) goto fail;
 
+    T("test.string.freenull","");
+    if (!TestAssertStringReply(ctx,reply,"OK",2)) goto fail;
+
     T("test.string.append","");
     if (!TestAssertStringReply(ctx,reply,"foobar",6)) goto fail;
 
@@ -935,6 +948,10 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     if (RedisModule_CreateCommand(ctx,"test.callreplywithverbatimstringreply",
         TestCallResp3Verbatim,"write deny-oom",1,1,1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"test.string.freenull",
+        TestStringFreeNull,"write deny-oom",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx,"test.string.append",


### PR DESCRIPTION
Previously RM_FreeString did not handle NULL pointers, which is inconvenient
and inconsistent with other existing APIs like free() and RM_Free().

An informational message will be logged each time the function is called with a
NULL pointer. This is to help prevent backwards compatibility issues, where
modules developed and tested on the latest Redis could crash when loaded into
an older version if they implicitly relied on this behaviour.

This log message may be removed when non-supporting versions of Redis are old
enough.

Resolves #10887