### PR TITLE
CI: update macos runner version

### DIFF
--- a/deps/hiredis/.github/workflows/build.yml
+++ b/deps/hiredis/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
         run: $GITHUB_WORKSPACE/test.sh
 
   freebsd:
-    runs-on: macos-10.15
+    runs-on: macos-12
     name:  FreeBSD
     steps:
       - name: Checkout code
@@ -132,7 +132,7 @@ jobs:
           ref: ${{ env.GITHUB_HEAD_REF }}
 
       - name: Build in FreeBSD
-        uses: vmactions/freebsd-vm@v0.1.5
+        uses: vmactions/freebsd-vm@v0.2.0
         with:
           prepare: pkg install -y gmake cmake
           run: |


### PR DESCRIPTION
GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

I have checked [`vmactions/freebsd-vm`](https://github.com/vmactions/freebsd-vm) does support `macos-12` (which requires `vmactions/freebsd-vm@0.2.0`).

I have updated the `runs-on` to `macos-12` and bumped `vmactions/freebsd-vm` to `0.2.0` in the PR.