### PR TITLE
When client tracking is on, invalidation message of flushdb in a transaction

### DIFF
--- a/src/tracking.c
+++ b/src/tracking.c
@@ -454,7 +454,12 @@ void trackingInvalidateKeysOnFlush(int async) {
         while ((ln = listNext(&li)) != NULL) {
             client *c = listNodeValue(ln);
             if (c->flags & CLIENT_TRACKING) {
-                sendTrackingMessage(c,shared.null[c->resp]->ptr,sdslen(shared.null[c->resp]->ptr),1);
+                if (c == server.current_client) {
+                    incrRefCount(shared.null[c->resp]);
+                    listAddNodeTail(server.tracking_pending_keys,shared.null[c->resp]);
+                } else {
+                    sendTrackingMessage(c,shared.null[c->resp]->ptr,sdslen(shared.null[c->resp]->ptr),1);
+                }
             }
         }
     }


### PR DESCRIPTION
When FLUSHDB / FLUSHALL / SWAPDB is inside MULTI / EXEC, the client side tracking invalidation message was interleaved with transaction response causing broken protocol.

Fix https://github.com/redis/redis/issues/8935