### PR TITLE
Change the return value of rdbLoad function to enums

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -567,7 +567,7 @@ NULL
         protectClient(c);
         int ret = rdbLoad(server.rdb_filename,NULL,flags);
         unprotectClient(c);
-        if (ret != C_OK) {
+        if (ret != RDB_OK) {
             addReplyError(c,"Error trying to load the RDB dump");
             return;
         }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3256,9 +3256,9 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
 
     fp = fopen(filename, "r");
     if (fp == NULL) {
+        retval = (errno == ENOENT) ? RDB_NOT_EXIST : RDB_OPEN_ERR;
         serverLog(LL_WARNING,"Fatal error: can't open the RDB file %s for reading: %s", filename, strerror(errno));
-        if (errno == ENOENT) return RDB_NOT_EXIST;
-        return RDB_OPEN_ERR;
+        return retval;
     }
 
     if (fstat(fileno(fp), &sb) == -1)

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3256,7 +3256,7 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
 
     fp = fopen(filename, "r");
     if (fp == NULL) {
-        retval = (errno == ENOENT) ? RDB_NOT_EXIST : RDB_OPEN_ERR;
+        retval = (errno == ENOENT) ? RDB_NOT_EXIST : RDB_FAILED;
         serverLog(LL_WARNING,"Fatal error: can't open the RDB file %s for reading: %s", filename, strerror(errno));
         return retval;
     }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3257,7 +3257,8 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
     fp = fopen(filename, "r");
     if (fp == NULL) {
         serverLog(LL_WARNING,"Fatal error: can't open the RDB file %s for reading: %s", filename, strerror(errno));
-        return C_ERR;
+        if (errno == ENOENT) return RDB_NOT_EXIST;
+        return RDB_OPEN_ERR;
     }
 
     if (fstat(fileno(fp), &sb) == -1)
@@ -3270,7 +3271,7 @@ int rdbLoad(char *filename, rdbSaveInfo *rsi, int rdbflags) {
 
     fclose(fp);
     stopLoading(retval==C_OK);
-    return retval;
+    return (retval==C_OK) ? RDB_OK : RDB_FAILED;
 }
 
 /* A background saving child (BGSAVE) terminated its work. Handle this.

--- a/src/replication.c
+++ b/src/replication.c
@@ -2161,7 +2161,7 @@ void readSyncBulkPayload(connection *conn) {
             return;
         }
 
-        if (rdbLoad(server.rdb_filename,&rsi,RDBFLAGS_REPLICATION) != C_OK) {
+        if (rdbLoad(server.rdb_filename,&rsi,RDBFLAGS_REPLICATION) != RDB_OK) {
             serverLog(LL_WARNING,
                 "Failed trying to load the MASTER synchronization "
                 "DB from disk: %s", strerror(errno));

--- a/src/server.c
+++ b/src/server.c
@@ -6515,7 +6515,8 @@ void loadDataFromDisk(void) {
             createReplicationBacklog();
             rdb_flags |= RDBFLAGS_FEED_REPL;
         }
-        if (rdbLoad(server.rdb_filename,&rsi,rdb_flags) == C_OK) {
+        int rdb_load_ret = rdbLoad(server.rdb_filename, &rsi, rdb_flags);
+        if (rdb_load_ret == RDB_OK) {
             serverLog(LL_NOTICE,"DB loaded from disk: %.3f seconds",
                 (float)(ustime()-start)/1000000);
 
@@ -6550,7 +6551,7 @@ void loadDataFromDisk(void) {
                     server.repl_no_slaves_since = time(NULL);
                 }
             }
-        } else if (errno != ENOENT) {
+        } else if (rdb_load_ret != RDB_NOT_EXIST) {
             serverLog(LL_WARNING,"Fatal error loading the DB: %s. Exiting.",strerror(errno));
             exit(1);
         }

--- a/src/server.h
+++ b/src/server.h
@@ -304,8 +304,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 /* RDB return values for rdbLoad. */
 #define RDB_OK 0
 #define RDB_NOT_EXIST 1 /* RDB file doesn't exist. */
-#define RDB_OPEN_ERR 2 /* Failed to open the RDB file. */
-#define RDB_FAILED 3 /* Failed to load the RDB file. */
+#define RDB_FAILED 2 /* Failed to load the RDB file. */
 
 /* Command doc flags */
 #define CMD_DOC_NONE 0

--- a/src/server.h
+++ b/src/server.h
@@ -301,6 +301,12 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define AOF_FAILED 4
 #define AOF_TRUNCATED 5
 
+/* RDB return values for rdbLoad. */
+#define RDB_OK 0
+#define RDB_NOT_EXIST 1 /* RDB file doesn't exist. */
+#define RDB_OPEN_ERR 2 /* Failed to open the RDB file. */
+#define RDB_FAILED 3 /* Failed to load the RDB file. */
+
 /* Command doc flags */
 #define CMD_DOC_NONE 0
 #define CMD_DOC_DEPRECATED (1<<0) /* Command is deprecated */


### PR DESCRIPTION
The reason we do this is because in #11036, we added error
log message when failing to open RDB file for reading.
In loadDdataFromDisk we call rdbLoad and also check errno,
now the logging corrupts errno (reported in alpine daily).

It is not safe to rely on errno as we do today, so we change
the return value of rdbLoad function to enums, like we have
when loading an AOF.