### PR TITLE
Add __redis__compare_helper to lua globals allow list

### DIFF
--- a/src/scripting.c
+++ b/src/scripting.c
@@ -56,6 +56,7 @@ static char *redis_api_allow_list[] = {
     "redis",
     "__redis__err__handler", /* error handler for eval, currently located on globals.
                                 Should move to registry. */
+    "__redis__compare_helper",
     NULL,
 };
 


### PR DESCRIPTION
`__redis__compare_helper` had been removed in #9780, but when backport #11032  to 6.2, it was left out.
This will result in the following waring.
```
84148:M 26 Jul 2022 11:29:30.933 # A key '__redis__compare_helper' was added to Lua globals which is not on the globals allow list nor listed on the deny list.
```