### PR TITLE
Optimize the performance of multi-key commands in cluster mode

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -6756,7 +6756,7 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
                 }
                 if (importing_slot && !multiple_keys && !equalStringObjects(firstkey,thiskey)) {
                     /* Flag this request as one with multiple different
-                     * keys/channels. */
+                     * keys/channels when the slot is in importing state. */
                     multiple_keys = 1;
                 }
             }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -6747,18 +6747,17 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
             } else {
                 /* If it is not the first key/channel, make sure it is exactly
                  * the same key/channel as the first we saw. */
-                if (!equalStringObjects(firstkey,thiskey)) {
-                    if (slot != thisslot) {
-                        /* Error: multiple keys from different slots. */
-                        getKeysFreeResult(&result);
-                        if (error_code)
-                            *error_code = CLUSTER_REDIR_CROSS_SLOT;
-                        return NULL;
-                    } else {
-                        /* Flag this request as one with multiple different
-                         * keys/channels. */
-                        multiple_keys = 1;
-                    }
+                if (slot != thisslot) {
+                    /* Error: multiple keys from different slots. */
+                    getKeysFreeResult(&result);
+                    if (error_code)
+                        *error_code = CLUSTER_REDIR_CROSS_SLOT;
+                    return NULL;                  
+                }
+                if (importing_slot && !multiple_keys && !equalStringObjects(firstkey,thiskey)) {
+                    /* Flag this request as one with multiple different
+                     * keys/channels. */
+                    multiple_keys = 1;
                 }
             }
 


### PR DESCRIPTION
optimize the performance of multi-key commands in cluster mode by avoid `equalStringObjects` calls.

`multiple_keys` flag  be only used  in importing slot, we can avoid comparing string objects in most scenarios.
in my bench test, mset command with 10 keys improved by 16%.

bench command:
`memtier_benchmark -p 6385  --key-prefix="{asdfghjkl}" --command="mset __key__ 1 __key__ 2 __key__ 3 __key__ 4 __key__ 5 __key__ 6 __key__ 7 __key__ 8 __key__ 9 __key__ 10 "`


Optimized result

```
ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency    p100 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Msets       26018.15         7.68145         6.84700        19.96700        39.93500      8635.69
Totals      26018.15         7.68145         6.84700        19.96700        39.93500      8635.69

```

Before optimization
```
 ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency    p100 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Msets       22383.81         8.92822         7.42300        33.27900        88.57500      7429.42
Totals      22383.81         8.92822         7.42300        33.27900        88.57500      7429.42
```

```
Release notes:
Optimize the performance of commands with multiple keys in cluster mode
```