### PR TITLE
redis-cli reads specified number of replies for UNSUBSCRIBE/PUNSUBSCRIBE/SUNSUBSCRIBE

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1813,7 +1813,7 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
                 fflush(stdout);
             } while(--argc);
             zfree(argvlen);
-            return REDIS_OK;
+            continue;
         }
 
         if (config.monitor_mode) {


### PR DESCRIPTION
In unsubscribe related commands, we need to read the specified
number of replies according to the number of parameters.

These commands may return multiple RESP replies, and currently
redis-cli only tries to read only one reply.

Fixes #11046, this redis-cli bug seems to be there forever.
Note that the [UN]SUBSCRIBE command response is a bit awkward
see: https://github.com/redis/redis-doc/pull/2327