### PR TITLE
Repurpose redisCommandArg's name as the unique ID

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -155,18 +155,24 @@ commandHistory BITPOS_History[] = {
 /* BITPOS tips */
 #define BITPOS_tips NULL
 
-/* BITPOS range unit argument table */
-struct redisCommandArg BITPOS_range_unit_Subargs[] = {
+/* BITPOS range end_unit_block unit argument table */
+struct redisCommandArg BITPOS_range_end_unit_block_unit_Subargs[] = {
 {"byte",ARG_TYPE_PURE_TOKEN,-1,"BYTE",NULL,NULL,CMD_ARG_NONE},
 {"bit",ARG_TYPE_PURE_TOKEN,-1,"BIT",NULL,NULL,CMD_ARG_NONE},
+{0}
+};
+
+/* BITPOS range end_unit_block argument table */
+struct redisCommandArg BITPOS_range_end_unit_block_Subargs[] = {
+{"end",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,"7.0.0",CMD_ARG_OPTIONAL,.subargs=BITPOS_range_end_unit_block_unit_Subargs},
 {0}
 };
 
 /* BITPOS range argument table */
 struct redisCommandArg BITPOS_range_Subargs[] = {
 {"start",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"end",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL},
-{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,"7.0.0",CMD_ARG_OPTIONAL,.subargs=BITPOS_range_unit_Subargs},
+{"end-unit-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=BITPOS_range_end_unit_block_Subargs},
 {0}
 };
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -610,9 +610,9 @@ NULL
 
 /* CLUSTER SETSLOT subcommand argument table */
 struct redisCommandArg CLUSTER_SETSLOT_subcommand_Subargs[] = {
-{"importing",ARG_TYPE_STRING,-1,"IMPORTING",NULL,NULL,CMD_ARG_NONE,.display="node-id"},
-{"migrating",ARG_TYPE_STRING,-1,"MIGRATING",NULL,NULL,CMD_ARG_NONE,.display="node-id"},
-{"node",ARG_TYPE_STRING,-1,"NODE",NULL,NULL,CMD_ARG_NONE,.display="node-id"},
+{"importing",ARG_TYPE_STRING,-1,"IMPORTING",NULL,NULL,CMD_ARG_NONE,.display_text="node-id"},
+{"migrating",ARG_TYPE_STRING,-1,"MIGRATING",NULL,NULL,CMD_ARG_NONE,.display_text="node-id"},
+{"node",ARG_TYPE_STRING,-1,"NODE",NULL,NULL,CMD_ARG_NONE,.display_text="node-id"},
 {"stable",ARG_TYPE_PURE_TOKEN,-1,"STABLE",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
@@ -835,15 +835,15 @@ struct redisCommandArg CLIENT_KILL_filter_new_format_Subargs[] = {
 {"client-id",ARG_TYPE_INTEGER,-1,"ID",NULL,"2.8.12",CMD_ARG_OPTIONAL},
 {"client-type",ARG_TYPE_ONEOF,-1,"TYPE",NULL,"2.8.12",CMD_ARG_OPTIONAL,.subargs=CLIENT_KILL_filter_new_format_client_type_Subargs},
 {"username",ARG_TYPE_STRING,-1,"USER",NULL,NULL,CMD_ARG_OPTIONAL},
-{"addr",ARG_TYPE_STRING,-1,"ADDR",NULL,NULL,CMD_ARG_OPTIONAL,.display="ip:port"},
-{"laddr",ARG_TYPE_STRING,-1,"LADDR",NULL,"6.2.0",CMD_ARG_OPTIONAL,.display="ip:port"},
-{"skipme",ARG_TYPE_STRING,-1,"SKIPME",NULL,NULL,CMD_ARG_OPTIONAL,.display="yes/no"},
+{"addr",ARG_TYPE_STRING,-1,"ADDR",NULL,NULL,CMD_ARG_OPTIONAL,.display_text="ip:port"},
+{"laddr",ARG_TYPE_STRING,-1,"LADDR",NULL,"6.2.0",CMD_ARG_OPTIONAL,.display_text="ip:port"},
+{"skipme",ARG_TYPE_STRING,-1,"SKIPME",NULL,NULL,CMD_ARG_OPTIONAL,.display_text="yes/no"},
 {0}
 };
 
 /* CLIENT KILL filter argument table */
 struct redisCommandArg CLIENT_KILL_filter_Subargs[] = {
-{"old-format",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.deprecated_since="2.8.12",.display="ip:port"},
+{"old-format",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.deprecated_since="2.8.12",.display_text="ip:port"},
 {"new-format",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=CLIENT_KILL_filter_new_format_Subargs},
 {0}
 };
@@ -1350,7 +1350,7 @@ struct redisCommandArg MIGRATE_authentication_auth2_Subargs[] = {
 
 /* MIGRATE authentication argument table */
 struct redisCommandArg MIGRATE_authentication_Subargs[] = {
-{"auth",ARG_TYPE_STRING,-1,"AUTH",NULL,"4.0.7",CMD_ARG_NONE,.display="password"},
+{"auth",ARG_TYPE_STRING,-1,"AUTH",NULL,"4.0.7",CMD_ARG_NONE,.display_text="password"},
 {"auth2",ARG_TYPE_BLOCK,-1,"AUTH2",NULL,"6.0.0",CMD_ARG_NONE,.subargs=MIGRATE_authentication_auth2_Subargs},
 {0}
 };
@@ -1365,7 +1365,7 @@ struct redisCommandArg MIGRATE_Args[] = {
 {"copy",ARG_TYPE_PURE_TOKEN,-1,"COPY",NULL,"3.0.0",CMD_ARG_OPTIONAL},
 {"replace",ARG_TYPE_PURE_TOKEN,-1,"REPLACE",NULL,"3.0.0",CMD_ARG_OPTIONAL},
 {"authentication",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=MIGRATE_authentication_Subargs},
-{"keys",ARG_TYPE_KEY,1,"KEYS",NULL,"3.0.6",CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,.display="key"},
+{"keys",ARG_TYPE_KEY,1,"KEYS",NULL,"3.0.6",CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,.display_text="key"},
 {0}
 };
 
@@ -1701,9 +1701,9 @@ struct redisCommandArg SORT_order_Subargs[] = {
 /* SORT argument table */
 struct redisCommandArg SORT_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"by-pattern",ARG_TYPE_PATTERN,1,"BY",NULL,NULL,CMD_ARG_OPTIONAL,.display="pattern"},
+{"by-pattern",ARG_TYPE_PATTERN,1,"BY",NULL,NULL,CMD_ARG_OPTIONAL,.display_text="pattern"},
 {"limit",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_limit_Subargs},
-{"get-pattern",ARG_TYPE_PATTERN,1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.display="pattern"},
+{"get-pattern",ARG_TYPE_PATTERN,1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.display_text="pattern"},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_order_Subargs},
 {"sorting",ARG_TYPE_PURE_TOKEN,-1,"ALPHA",NULL,NULL,CMD_ARG_OPTIONAL},
 {"destination",ARG_TYPE_KEY,2,"STORE",NULL,NULL,CMD_ARG_OPTIONAL},
@@ -1735,9 +1735,9 @@ struct redisCommandArg SORT_RO_order_Subargs[] = {
 /* SORT_RO argument table */
 struct redisCommandArg SORT_RO_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"by-pattern",ARG_TYPE_PATTERN,1,"BY",NULL,NULL,CMD_ARG_OPTIONAL,.display="pattern"},
+{"by-pattern",ARG_TYPE_PATTERN,1,"BY",NULL,NULL,CMD_ARG_OPTIONAL,.display_text="pattern"},
 {"limit",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_RO_limit_Subargs},
-{"get-pattern",ARG_TYPE_PATTERN,1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.display="pattern"},
+{"get-pattern",ARG_TYPE_PATTERN,1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.display_text="pattern"},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_RO_order_Subargs},
 {"sorting",ARG_TYPE_PURE_TOKEN,-1,"ALPHA",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
@@ -1969,8 +1969,8 @@ struct redisCommandArg GEORADIUS_Args[] = {
 {"withhash",ARG_TYPE_PURE_TOKEN,-1,"WITHHASH",NULL,NULL,CMD_ARG_OPTIONAL},
 {"count-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_count_block_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_order_Subargs},
-{"storekey",ARG_TYPE_KEY,1,"STORE",NULL,NULL,CMD_ARG_OPTIONAL,.display="key"},
-{"storedistkey",ARG_TYPE_KEY,2,"STOREDIST",NULL,NULL,CMD_ARG_OPTIONAL,.display="key"},
+{"storekey",ARG_TYPE_KEY,1,"STORE",NULL,NULL,CMD_ARG_OPTIONAL,.display_text="key"},
+{"storedistkey",ARG_TYPE_KEY,2,"STOREDIST",NULL,NULL,CMD_ARG_OPTIONAL,.display_text="key"},
 {0}
 };
 
@@ -2016,8 +2016,8 @@ struct redisCommandArg GEORADIUSBYMEMBER_Args[] = {
 {"withhash",ARG_TYPE_PURE_TOKEN,-1,"WITHHASH",NULL,NULL,CMD_ARG_OPTIONAL},
 {"count-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_count_block_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_order_Subargs},
-{"storekey",ARG_TYPE_KEY,1,"STORE",NULL,NULL,CMD_ARG_OPTIONAL,.display="key"},
-{"storedistkey",ARG_TYPE_KEY,2,"STOREDIST",NULL,NULL,CMD_ARG_OPTIONAL,.display="key"},
+{"storekey",ARG_TYPE_KEY,1,"STORE",NULL,NULL,CMD_ARG_OPTIONAL,.display_text="key"},
+{"storedistkey",ARG_TYPE_KEY,2,"STOREDIST",NULL,NULL,CMD_ARG_OPTIONAL,.display_text="key"},
 {0}
 };
 
@@ -3701,7 +3701,7 @@ struct redisCommandArg SENTINEL_CONFIG_action_set_Subargs[] = {
 /* SENTINEL CONFIG action argument table */
 struct redisCommandArg SENTINEL_CONFIG_action_Subargs[] = {
 {"set",ARG_TYPE_BLOCK,-1,"SET",NULL,NULL,CMD_ARG_MULTIPLE,.subargs=SENTINEL_CONFIG_action_set_Subargs},
-{"get",ARG_TYPE_STRING,-1,"GET",NULL,NULL,CMD_ARG_MULTIPLE,.display="parameter"},
+{"get",ARG_TYPE_STRING,-1,"GET",NULL,NULL,CMD_ARG_MULTIPLE,.display_text="parameter"},
 {0}
 };
 
@@ -6399,7 +6399,7 @@ struct redisCommandArg XGROUP_SETID_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"groupname",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"id-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XGROUP_SETID_id_selector_Subargs},
-{"entriesread",ARG_TYPE_INTEGER,-1,"ENTRIESREAD",NULL,NULL,CMD_ARG_OPTIONAL,.display="entries-read"},
+{"entriesread",ARG_TYPE_INTEGER,-1,"ENTRIESREAD",NULL,NULL,CMD_ARG_OPTIONAL,.display_text="entries-read"},
 {0}
 };
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -47,54 +47,54 @@ struct redisCommandArg BITCOUNT_Args[] = {
 /* BITFIELD tips */
 #define BITFIELD_tips NULL
 
-/* BITFIELD operation encoding_offset argument table */
-struct redisCommandArg BITFIELD_operation_encoding_offset_Subargs[] = {
-{"encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+/* BITFIELD operation get_block argument table */
+struct redisCommandArg BITFIELD_operation_get_block_Subargs[] = {
+{"get_encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="encoding"},
 {"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
-/* BITFIELD operation write wrap_sat_fail argument table */
-struct redisCommandArg BITFIELD_operation_write_wrap_sat_fail_Subargs[] = {
+/* BITFIELD operation write overflow_block argument table */
+struct redisCommandArg BITFIELD_operation_write_overflow_block_Subargs[] = {
 {"wrap",ARG_TYPE_PURE_TOKEN,-1,"WRAP",NULL,NULL,CMD_ARG_NONE},
 {"sat",ARG_TYPE_PURE_TOKEN,-1,"SAT",NULL,NULL,CMD_ARG_NONE},
 {"fail",ARG_TYPE_PURE_TOKEN,-1,"FAIL",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
-/* BITFIELD operation write write_operation encoding_offset_value argument table */
-struct redisCommandArg BITFIELD_operation_write_write_operation_encoding_offset_value_Subargs[] = {
-{"encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"value",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+/* BITFIELD operation write write_operation set_block argument table */
+struct redisCommandArg BITFIELD_operation_write_write_operation_set_block_Subargs[] = {
+{"set_encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="encoding"},
+{"set_offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="offset"},
+{"set_value",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="value"},
 {0}
 };
 
-/* BITFIELD operation write write_operation encoding_offset_increment argument table */
-struct redisCommandArg BITFIELD_operation_write_write_operation_encoding_offset_increment_Subargs[] = {
-{"encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"increment",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+/* BITFIELD operation write write_operation incrby_info argument table */
+struct redisCommandArg BITFIELD_operation_write_write_operation_incrby_info_Subargs[] = {
+{"incrby_encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="encoding"},
+{"incrby_offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="offset"},
+{"incrby_increment",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="increment"},
 {0}
 };
 
 /* BITFIELD operation write write_operation argument table */
 struct redisCommandArg BITFIELD_operation_write_write_operation_Subargs[] = {
-{"encoding_offset_value",ARG_TYPE_BLOCK,-1,"SET",NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_write_operation_encoding_offset_value_Subargs},
-{"encoding_offset_increment",ARG_TYPE_BLOCK,-1,"INCRBY",NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_write_operation_encoding_offset_increment_Subargs},
+{"set_block",ARG_TYPE_BLOCK,-1,"SET",NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_write_operation_set_block_Subargs},
+{"incrby_info",ARG_TYPE_BLOCK,-1,"INCRBY",NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_write_operation_incrby_info_Subargs},
 {0}
 };
 
 /* BITFIELD operation write argument table */
 struct redisCommandArg BITFIELD_operation_write_Subargs[] = {
-{"wrap_sat_fail",ARG_TYPE_ONEOF,-1,"OVERFLOW",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=BITFIELD_operation_write_wrap_sat_fail_Subargs},
+{"overflow_block",ARG_TYPE_ONEOF,-1,"OVERFLOW",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=BITFIELD_operation_write_overflow_block_Subargs},
 {"write_operation",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_write_operation_Subargs},
 {0}
 };
 
 /* BITFIELD operation argument table */
 struct redisCommandArg BITFIELD_operation_Subargs[] = {
-{"encoding_offset",ARG_TYPE_BLOCK,-1,"GET",NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_encoding_offset_Subargs},
+{"get_block",ARG_TYPE_BLOCK,-1,"GET",NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_get_block_Subargs},
 {"write",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_Subargs},
 {0}
 };
@@ -155,17 +155,17 @@ commandHistory BITPOS_History[] = {
 /* BITPOS tips */
 #define BITPOS_tips NULL
 
-/* BITPOS index end_index index_unit argument table */
-struct redisCommandArg BITPOS_index_end_index_index_unit_Subargs[] = {
-{"byte",ARG_TYPE_PURE_TOKEN,-1,"BYTE",NULL,NULL,CMD_ARG_NONE},
-{"bit",ARG_TYPE_PURE_TOKEN,-1,"BIT",NULL,NULL,CMD_ARG_NONE},
+/* BITPOS index end_index unit argument table */
+struct redisCommandArg BITPOS_index_end_index_unit_Subargs[] = {
+{"unit_byte",ARG_TYPE_PURE_TOKEN,-1,"BYTE",NULL,NULL,CMD_ARG_NONE,.display="byte"},
+{"unit_bit",ARG_TYPE_PURE_TOKEN,-1,"BIT",NULL,NULL,CMD_ARG_NONE,.display="bit"},
 {0}
 };
 
 /* BITPOS index end_index argument table */
 struct redisCommandArg BITPOS_index_end_index_Subargs[] = {
 {"end",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"index_unit",ARG_TYPE_ONEOF,-1,NULL,NULL,"7.0.0",CMD_ARG_OPTIONAL,.subargs=BITPOS_index_end_index_index_unit_Subargs},
+{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,"7.0.0",CMD_ARG_OPTIONAL,.subargs=BITPOS_index_end_index_unit_Subargs},
 {0}
 };
 
@@ -610,9 +610,9 @@ NULL
 
 /* CLUSTER SETSLOT subcommand argument table */
 struct redisCommandArg CLUSTER_SETSLOT_subcommand_Subargs[] = {
-{"node-id",ARG_TYPE_STRING,-1,"IMPORTING",NULL,NULL,CMD_ARG_NONE},
-{"node-id",ARG_TYPE_STRING,-1,"MIGRATING",NULL,NULL,CMD_ARG_NONE},
-{"node-id",ARG_TYPE_STRING,-1,"NODE",NULL,NULL,CMD_ARG_NONE},
+{"importing",ARG_TYPE_STRING,-1,"IMPORTING",NULL,NULL,CMD_ARG_NONE,.display="node-id"},
+{"migrating",ARG_TYPE_STRING,-1,"MIGRATING",NULL,NULL,CMD_ARG_NONE,.display="node-id"},
+{"node",ARG_TYPE_STRING,-1,"NODE",NULL,NULL,CMD_ARG_NONE,.display="node-id"},
 {"stable",ARG_TYPE_PURE_TOKEN,-1,"STABLE",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
@@ -820,8 +820,8 @@ commandHistory CLIENT_KILL_History[] = {
 /* CLIENT KILL tips */
 #define CLIENT_KILL_tips NULL
 
-/* CLIENT KILL normal_master_slave_pubsub argument table */
-struct redisCommandArg CLIENT_KILL_normal_master_slave_pubsub_Subargs[] = {
+/* CLIENT KILL type argument table */
+struct redisCommandArg CLIENT_KILL_type_Subargs[] = {
 {"normal",ARG_TYPE_PURE_TOKEN,-1,"NORMAL",NULL,NULL,CMD_ARG_NONE},
 {"master",ARG_TYPE_PURE_TOKEN,-1,"MASTER",NULL,"3.2.0",CMD_ARG_NONE},
 {"slave",ARG_TYPE_PURE_TOKEN,-1,"SLAVE",NULL,NULL,CMD_ARG_NONE},
@@ -832,13 +832,13 @@ struct redisCommandArg CLIENT_KILL_normal_master_slave_pubsub_Subargs[] = {
 
 /* CLIENT KILL argument table */
 struct redisCommandArg CLIENT_KILL_Args[] = {
-{"ip:port",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL},
+{"old_format",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.display="ip:port"},
 {"client-id",ARG_TYPE_INTEGER,-1,"ID",NULL,"2.8.12",CMD_ARG_OPTIONAL},
-{"normal_master_slave_pubsub",ARG_TYPE_ONEOF,-1,"TYPE",NULL,"2.8.12",CMD_ARG_OPTIONAL,.subargs=CLIENT_KILL_normal_master_slave_pubsub_Subargs},
+{"type",ARG_TYPE_ONEOF,-1,"TYPE",NULL,"2.8.12",CMD_ARG_OPTIONAL,.subargs=CLIENT_KILL_type_Subargs},
 {"username",ARG_TYPE_STRING,-1,"USER",NULL,NULL,CMD_ARG_OPTIONAL},
-{"ip:port",ARG_TYPE_STRING,-1,"ADDR",NULL,NULL,CMD_ARG_OPTIONAL},
-{"ip:port",ARG_TYPE_STRING,-1,"LADDR",NULL,"6.2.0",CMD_ARG_OPTIONAL},
-{"yes/no",ARG_TYPE_STRING,-1,"SKIPME",NULL,NULL,CMD_ARG_OPTIONAL},
+{"addr",ARG_TYPE_STRING,-1,"ADDR",NULL,NULL,CMD_ARG_OPTIONAL,.display="ip:port"},
+{"laddr",ARG_TYPE_STRING,-1,"LADDR",NULL,"6.2.0",CMD_ARG_OPTIONAL,.display="ip:port"},
+{"skipme",ARG_TYPE_STRING,-1,"SKIPME",NULL,NULL,CMD_ARG_OPTIONAL,.display="yes/no"},
 {0}
 };
 
@@ -867,16 +867,10 @@ struct redisCommandArg CLIENT_LIST_normal_master_replica_pubsub_Subargs[] = {
 {0}
 };
 
-/* CLIENT LIST id argument table */
-struct redisCommandArg CLIENT_LIST_id_Subargs[] = {
-{"client-id",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE},
-{0}
-};
-
 /* CLIENT LIST argument table */
 struct redisCommandArg CLIENT_LIST_Args[] = {
 {"normal_master_replica_pubsub",ARG_TYPE_ONEOF,-1,"TYPE",NULL,"5.0.0",CMD_ARG_OPTIONAL,.subargs=CLIENT_LIST_normal_master_replica_pubsub_Subargs},
-{"id",ARG_TYPE_BLOCK,-1,"ID",NULL,"6.2.0",CMD_ARG_OPTIONAL,.subargs=CLIENT_LIST_id_Subargs},
+{"client-id",ARG_TYPE_INTEGER,-1,"ID",NULL,"6.2.0",CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE},
 {0}
 };
 
@@ -1337,15 +1331,15 @@ struct redisCommandArg MIGRATE_key_or_empty_string_Subargs[] = {
 
 /* MIGRATE authentication username_password argument table */
 struct redisCommandArg MIGRATE_authentication_username_password_Subargs[] = {
-{"username",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"password",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"auth2_username",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="username"},
+{"auth2_password",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="password"},
 {0}
 };
 
 /* MIGRATE authentication argument table */
 struct redisCommandArg MIGRATE_authentication_Subargs[] = {
-{"password",ARG_TYPE_STRING,-1,"AUTH",NULL,"4.0.7",CMD_ARG_OPTIONAL},
-{"username_password",ARG_TYPE_BLOCK,-1,"AUTH2",NULL,"6.0.0",CMD_ARG_OPTIONAL,.subargs=MIGRATE_authentication_username_password_Subargs},
+{"password",ARG_TYPE_STRING,-1,"AUTH",NULL,"4.0.7",CMD_ARG_NONE},
+{"username_password",ARG_TYPE_BLOCK,-1,"AUTH2",NULL,"6.0.0",CMD_ARG_NONE,.subargs=MIGRATE_authentication_username_password_Subargs},
 {0}
 };
 
@@ -1359,7 +1353,7 @@ struct redisCommandArg MIGRATE_Args[] = {
 {"copy",ARG_TYPE_PURE_TOKEN,-1,"COPY",NULL,"3.0.0",CMD_ARG_OPTIONAL},
 {"replace",ARG_TYPE_PURE_TOKEN,-1,"REPLACE",NULL,"3.0.0",CMD_ARG_OPTIONAL},
 {"authentication",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=MIGRATE_authentication_Subargs},
-{"key",ARG_TYPE_KEY,1,"KEYS",NULL,"3.0.6",CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE},
+{"keys",ARG_TYPE_KEY,1,"KEYS",NULL,"3.0.6",CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,.display="key"},
 {0}
 };
 
@@ -1695,9 +1689,9 @@ struct redisCommandArg SORT_order_Subargs[] = {
 /* SORT argument table */
 struct redisCommandArg SORT_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"pattern",ARG_TYPE_PATTERN,1,"BY",NULL,NULL,CMD_ARG_OPTIONAL},
+{"by_pattern",ARG_TYPE_PATTERN,1,"BY",NULL,NULL,CMD_ARG_OPTIONAL,.display="pattern"},
 {"offset_count",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_offset_count_Subargs},
-{"pattern",ARG_TYPE_PATTERN,1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN},
+{"get_pattern",ARG_TYPE_PATTERN,1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.display="pattern"},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_order_Subargs},
 {"sorting",ARG_TYPE_PURE_TOKEN,-1,"ALPHA",NULL,NULL,CMD_ARG_OPTIONAL},
 {"destination",ARG_TYPE_KEY,2,"STORE",NULL,NULL,CMD_ARG_OPTIONAL},
@@ -1729,9 +1723,9 @@ struct redisCommandArg SORT_RO_order_Subargs[] = {
 /* SORT_RO argument table */
 struct redisCommandArg SORT_RO_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"pattern",ARG_TYPE_PATTERN,1,"BY",NULL,NULL,CMD_ARG_OPTIONAL},
+{"by_pattern",ARG_TYPE_PATTERN,1,"BY",NULL,NULL,CMD_ARG_OPTIONAL,.display="pattern"},
 {"offset_count",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_RO_offset_count_Subargs},
-{"pattern",ARG_TYPE_PATTERN,1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN},
+{"get_pattern",ARG_TYPE_PATTERN,1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.display="pattern"},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_RO_order_Subargs},
 {"sorting",ARG_TYPE_PURE_TOKEN,-1,"ALPHA",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
@@ -1937,8 +1931,8 @@ struct redisCommandArg GEORADIUS_unit_Subargs[] = {
 {0}
 };
 
-/* GEORADIUS count argument table */
-struct redisCommandArg GEORADIUS_count_Subargs[] = {
+/* GEORADIUS count_block argument table */
+struct redisCommandArg GEORADIUS_count_block_Subargs[] = {
 {"count",ARG_TYPE_INTEGER,-1,"COUNT",NULL,NULL,CMD_ARG_NONE},
 {"any",ARG_TYPE_PURE_TOKEN,-1,"ANY",NULL,"6.2.0",CMD_ARG_OPTIONAL},
 {0}
@@ -1961,10 +1955,10 @@ struct redisCommandArg GEORADIUS_Args[] = {
 {"withcoord",ARG_TYPE_PURE_TOKEN,-1,"WITHCOORD",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withdist",ARG_TYPE_PURE_TOKEN,-1,"WITHDIST",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withhash",ARG_TYPE_PURE_TOKEN,-1,"WITHHASH",NULL,NULL,CMD_ARG_OPTIONAL},
-{"count",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_count_Subargs},
+{"count_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_count_block_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_order_Subargs},
-{"key",ARG_TYPE_KEY,1,"STORE",NULL,NULL,CMD_ARG_OPTIONAL},
-{"key",ARG_TYPE_KEY,2,"STOREDIST",NULL,NULL,CMD_ARG_OPTIONAL},
+{"storekey",ARG_TYPE_KEY,1,"STORE",NULL,NULL,CMD_ARG_OPTIONAL,.display="key"},
+{"storedistkey",ARG_TYPE_KEY,2,"STOREDIST",NULL,NULL,CMD_ARG_OPTIONAL,.display="key"},
 {0}
 };
 
@@ -1985,8 +1979,8 @@ struct redisCommandArg GEORADIUSBYMEMBER_unit_Subargs[] = {
 {0}
 };
 
-/* GEORADIUSBYMEMBER count argument table */
-struct redisCommandArg GEORADIUSBYMEMBER_count_Subargs[] = {
+/* GEORADIUSBYMEMBER count_block argument table */
+struct redisCommandArg GEORADIUSBYMEMBER_count_block_Subargs[] = {
 {"count",ARG_TYPE_INTEGER,-1,"COUNT",NULL,NULL,CMD_ARG_NONE},
 {"any",ARG_TYPE_PURE_TOKEN,-1,"ANY",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
@@ -2008,10 +2002,10 @@ struct redisCommandArg GEORADIUSBYMEMBER_Args[] = {
 {"withcoord",ARG_TYPE_PURE_TOKEN,-1,"WITHCOORD",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withdist",ARG_TYPE_PURE_TOKEN,-1,"WITHDIST",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withhash",ARG_TYPE_PURE_TOKEN,-1,"WITHHASH",NULL,NULL,CMD_ARG_OPTIONAL},
-{"count",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_count_Subargs},
+{"count_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_count_block_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_order_Subargs},
-{"key",ARG_TYPE_KEY,1,"STORE",NULL,NULL,CMD_ARG_OPTIONAL},
-{"key",ARG_TYPE_KEY,2,"STOREDIST",NULL,NULL,CMD_ARG_OPTIONAL},
+{"storekey",ARG_TYPE_KEY,1,"STORE",NULL,NULL,CMD_ARG_OPTIONAL,.display="key"},
+{"storedistkey",ARG_TYPE_KEY,2,"STOREDIST",NULL,NULL,CMD_ARG_OPTIONAL,.display="key"},
 {0}
 };
 
@@ -2032,8 +2026,8 @@ struct redisCommandArg GEORADIUSBYMEMBER_RO_unit_Subargs[] = {
 {0}
 };
 
-/* GEORADIUSBYMEMBER_RO count argument table */
-struct redisCommandArg GEORADIUSBYMEMBER_RO_count_Subargs[] = {
+/* GEORADIUSBYMEMBER_RO count_block argument table */
+struct redisCommandArg GEORADIUSBYMEMBER_RO_count_block_Subargs[] = {
 {"count",ARG_TYPE_INTEGER,-1,"COUNT",NULL,NULL,CMD_ARG_NONE},
 {"any",ARG_TYPE_PURE_TOKEN,-1,"ANY",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
@@ -2055,7 +2049,7 @@ struct redisCommandArg GEORADIUSBYMEMBER_RO_Args[] = {
 {"withcoord",ARG_TYPE_PURE_TOKEN,-1,"WITHCOORD",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withdist",ARG_TYPE_PURE_TOKEN,-1,"WITHDIST",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withhash",ARG_TYPE_PURE_TOKEN,-1,"WITHHASH",NULL,NULL,CMD_ARG_OPTIONAL},
-{"count",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_RO_count_Subargs},
+{"count_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_RO_count_block_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_RO_order_Subargs},
 {0}
 };
@@ -2080,8 +2074,8 @@ struct redisCommandArg GEORADIUS_RO_unit_Subargs[] = {
 {0}
 };
 
-/* GEORADIUS_RO count argument table */
-struct redisCommandArg GEORADIUS_RO_count_Subargs[] = {
+/* GEORADIUS_RO count_block argument table */
+struct redisCommandArg GEORADIUS_RO_count_block_Subargs[] = {
 {"count",ARG_TYPE_INTEGER,-1,"COUNT",NULL,NULL,CMD_ARG_NONE},
 {"any",ARG_TYPE_PURE_TOKEN,-1,"ANY",NULL,"6.2.0",CMD_ARG_OPTIONAL},
 {0}
@@ -2104,7 +2098,7 @@ struct redisCommandArg GEORADIUS_RO_Args[] = {
 {"withcoord",ARG_TYPE_PURE_TOKEN,-1,"WITHCOORD",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withdist",ARG_TYPE_PURE_TOKEN,-1,"WITHDIST",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withhash",ARG_TYPE_PURE_TOKEN,-1,"WITHHASH",NULL,NULL,CMD_ARG_OPTIONAL},
-{"count",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_RO_count_Subargs},
+{"count_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_RO_count_block_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_RO_order_Subargs},
 {0}
 };
@@ -2131,28 +2125,28 @@ struct redisCommandArg GEOSEARCH_from_Subargs[] = {
 {0}
 };
 
-/* GEOSEARCH by circle unit argument table */
-struct redisCommandArg GEOSEARCH_by_circle_unit_Subargs[] = {
-{"m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE},
-{"km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE},
-{"ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE},
-{"mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE},
+/* GEOSEARCH by circle circle_unit argument table */
+struct redisCommandArg GEOSEARCH_by_circle_circle_unit_Subargs[] = {
+{"circle_m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE,.display="m"},
+{"circle_km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE,.display="km"},
+{"circle_ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE,.display="ft"},
+{"circle_mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE,.display="mi"},
 {0}
 };
 
 /* GEOSEARCH by circle argument table */
 struct redisCommandArg GEOSEARCH_by_circle_Subargs[] = {
 {"radius",ARG_TYPE_DOUBLE,-1,"BYRADIUS",NULL,NULL,CMD_ARG_NONE},
-{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_by_circle_unit_Subargs},
+{"circle_unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_by_circle_circle_unit_Subargs},
 {0}
 };
 
-/* GEOSEARCH by box unit argument table */
-struct redisCommandArg GEOSEARCH_by_box_unit_Subargs[] = {
-{"m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE},
-{"km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE},
-{"ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE},
-{"mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE},
+/* GEOSEARCH by box box_unit argument table */
+struct redisCommandArg GEOSEARCH_by_box_box_unit_Subargs[] = {
+{"box_m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE,.display="m"},
+{"box_km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE,.display="km"},
+{"box_ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE,.display="ft"},
+{"box_mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE,.display="mi"},
 {0}
 };
 
@@ -2160,7 +2154,7 @@ struct redisCommandArg GEOSEARCH_by_box_unit_Subargs[] = {
 struct redisCommandArg GEOSEARCH_by_box_Subargs[] = {
 {"width",ARG_TYPE_DOUBLE,-1,"BYBOX",NULL,NULL,CMD_ARG_NONE},
 {"height",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_by_box_unit_Subargs},
+{"box_unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_by_box_box_unit_Subargs},
 {0}
 };
 
@@ -2178,8 +2172,8 @@ struct redisCommandArg GEOSEARCH_order_Subargs[] = {
 {0}
 };
 
-/* GEOSEARCH count argument table */
-struct redisCommandArg GEOSEARCH_count_Subargs[] = {
+/* GEOSEARCH count_block argument table */
+struct redisCommandArg GEOSEARCH_count_block_Subargs[] = {
 {"count",ARG_TYPE_INTEGER,-1,"COUNT",NULL,NULL,CMD_ARG_NONE},
 {"any",ARG_TYPE_PURE_TOKEN,-1,"ANY",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
@@ -2191,7 +2185,7 @@ struct redisCommandArg GEOSEARCH_Args[] = {
 {"from",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_from_Subargs},
 {"by",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_by_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEOSEARCH_order_Subargs},
-{"count",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEOSEARCH_count_Subargs},
+{"count_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEOSEARCH_count_block_Subargs},
 {"withcoord",ARG_TYPE_PURE_TOKEN,-1,"WITHCOORD",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withdist",ARG_TYPE_PURE_TOKEN,-1,"WITHDIST",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withhash",ARG_TYPE_PURE_TOKEN,-1,"WITHHASH",NULL,NULL,CMD_ARG_OPTIONAL},
@@ -2206,8 +2200,8 @@ struct redisCommandArg GEOSEARCH_Args[] = {
 /* GEOSEARCHSTORE tips */
 #define GEOSEARCHSTORE_tips NULL
 
-/* GEOSEARCHSTORE from longitude_latitude argument table */
-struct redisCommandArg GEOSEARCHSTORE_from_longitude_latitude_Subargs[] = {
+/* GEOSEARCHSTORE from fromlonlat argument table */
+struct redisCommandArg GEOSEARCHSTORE_from_fromlonlat_Subargs[] = {
 {"longitude",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"latitude",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -2216,32 +2210,32 @@ struct redisCommandArg GEOSEARCHSTORE_from_longitude_latitude_Subargs[] = {
 /* GEOSEARCHSTORE from argument table */
 struct redisCommandArg GEOSEARCHSTORE_from_Subargs[] = {
 {"member",ARG_TYPE_STRING,-1,"FROMMEMBER",NULL,NULL,CMD_ARG_NONE},
-{"longitude_latitude",ARG_TYPE_BLOCK,-1,"FROMLONLAT",NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_from_longitude_latitude_Subargs},
+{"fromlonlat",ARG_TYPE_BLOCK,-1,"FROMLONLAT",NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_from_fromlonlat_Subargs},
 {0}
 };
 
-/* GEOSEARCHSTORE by circle unit argument table */
-struct redisCommandArg GEOSEARCHSTORE_by_circle_unit_Subargs[] = {
-{"m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE},
-{"km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE},
-{"ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE},
-{"mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE},
+/* GEOSEARCHSTORE by circle circle_unit argument table */
+struct redisCommandArg GEOSEARCHSTORE_by_circle_circle_unit_Subargs[] = {
+{"circle_m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE,.display="m"},
+{"circle_km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE,.display="km"},
+{"circle_ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE,.display="ft"},
+{"circle_mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE,.display="mi"},
 {0}
 };
 
 /* GEOSEARCHSTORE by circle argument table */
 struct redisCommandArg GEOSEARCHSTORE_by_circle_Subargs[] = {
 {"radius",ARG_TYPE_DOUBLE,-1,"BYRADIUS",NULL,NULL,CMD_ARG_NONE},
-{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_by_circle_unit_Subargs},
+{"circle_unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_by_circle_circle_unit_Subargs},
 {0}
 };
 
-/* GEOSEARCHSTORE by box unit argument table */
-struct redisCommandArg GEOSEARCHSTORE_by_box_unit_Subargs[] = {
-{"m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE},
-{"km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE},
-{"ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE},
-{"mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE},
+/* GEOSEARCHSTORE by box box_unit argument table */
+struct redisCommandArg GEOSEARCHSTORE_by_box_box_unit_Subargs[] = {
+{"box_m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE,.display="m"},
+{"box_km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE,.display="km"},
+{"box_ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE,.display="ft"},
+{"box_mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE,.display="mi"},
 {0}
 };
 
@@ -2249,7 +2243,7 @@ struct redisCommandArg GEOSEARCHSTORE_by_box_unit_Subargs[] = {
 struct redisCommandArg GEOSEARCHSTORE_by_box_Subargs[] = {
 {"width",ARG_TYPE_DOUBLE,-1,"BYBOX",NULL,NULL,CMD_ARG_NONE},
 {"height",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_by_box_unit_Subargs},
+{"box_unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_by_box_box_unit_Subargs},
 {0}
 };
 
@@ -2267,8 +2261,8 @@ struct redisCommandArg GEOSEARCHSTORE_order_Subargs[] = {
 {0}
 };
 
-/* GEOSEARCHSTORE count argument table */
-struct redisCommandArg GEOSEARCHSTORE_count_Subargs[] = {
+/* GEOSEARCHSTORE count_block argument table */
+struct redisCommandArg GEOSEARCHSTORE_count_block_Subargs[] = {
 {"count",ARG_TYPE_INTEGER,-1,"COUNT",NULL,NULL,CMD_ARG_NONE},
 {"any",ARG_TYPE_PURE_TOKEN,-1,"ANY",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
@@ -2281,7 +2275,7 @@ struct redisCommandArg GEOSEARCHSTORE_Args[] = {
 {"from",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_from_Subargs},
 {"by",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_by_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEOSEARCHSTORE_order_Subargs},
-{"count",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEOSEARCHSTORE_count_Subargs},
+{"count_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEOSEARCHSTORE_count_block_Subargs},
 {"storedist",ARG_TYPE_PURE_TOKEN,-1,"STOREDIST",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
 };
@@ -2646,15 +2640,15 @@ struct redisCommandArg PFMERGE_Args[] = {
 
 /* BLMOVE wherefrom argument table */
 struct redisCommandArg BLMOVE_wherefrom_Subargs[] = {
-{"left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE},
-{"right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE},
+{"from_left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE,.display="left"},
+{"from_right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE,.display="right"},
 {0}
 };
 
 /* BLMOVE whereto argument table */
 struct redisCommandArg BLMOVE_whereto_Subargs[] = {
-{"left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE},
-{"right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE},
+{"to_left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE,.display="left"},
+{"to_right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE,.display="right"},
 {0}
 };
 
@@ -2811,15 +2805,15 @@ struct redisCommandArg LLEN_Args[] = {
 
 /* LMOVE wherefrom argument table */
 struct redisCommandArg LMOVE_wherefrom_Subargs[] = {
-{"left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE},
-{"right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE},
+{"from_left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE,.display="left"},
+{"from_right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE,.display="right"},
 {0}
 };
 
 /* LMOVE whereto argument table */
 struct redisCommandArg LMOVE_whereto_Subargs[] = {
-{"left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE},
-{"right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE},
+{"to_left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE,.display="left"},
+{"to_right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE,.display="right"},
 {0}
 };
 
@@ -3069,15 +3063,9 @@ struct redisCommandArg RPUSHX_Args[] = {
 /* PSUBSCRIBE tips */
 #define PSUBSCRIBE_tips NULL
 
-/* PSUBSCRIBE pattern argument table */
-struct redisCommandArg PSUBSCRIBE_pattern_Subargs[] = {
-{"pattern",ARG_TYPE_PATTERN,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{0}
-};
-
 /* PSUBSCRIBE argument table */
 struct redisCommandArg PSUBSCRIBE_Args[] = {
-{"pattern",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=PSUBSCRIBE_pattern_Subargs},
+{"pattern",ARG_TYPE_PATTERN,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE},
 {0}
 };
 
@@ -3412,8 +3400,8 @@ const char *FUNCTION_FLUSH_tips[] = {
 NULL
 };
 
-/* FUNCTION FLUSH async argument table */
-struct redisCommandArg FUNCTION_FLUSH_async_Subargs[] = {
+/* FUNCTION FLUSH flush_type argument table */
+struct redisCommandArg FUNCTION_FLUSH_flush_type_Subargs[] = {
 {"async",ARG_TYPE_PURE_TOKEN,-1,"ASYNC",NULL,NULL,CMD_ARG_NONE},
 {"sync",ARG_TYPE_PURE_TOKEN,-1,"SYNC",NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -3421,7 +3409,7 @@ struct redisCommandArg FUNCTION_FLUSH_async_Subargs[] = {
 
 /* FUNCTION FLUSH argument table */
 struct redisCommandArg FUNCTION_FLUSH_Args[] = {
-{"async",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=FUNCTION_FLUSH_async_Subargs},
+{"flush_type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=FUNCTION_FLUSH_flush_type_Subargs},
 {0}
 };
 
@@ -3599,8 +3587,8 @@ const char *SCRIPT_FLUSH_tips[] = {
 NULL
 };
 
-/* SCRIPT FLUSH async argument table */
-struct redisCommandArg SCRIPT_FLUSH_async_Subargs[] = {
+/* SCRIPT FLUSH flush_type argument table */
+struct redisCommandArg SCRIPT_FLUSH_flush_type_Subargs[] = {
 {"async",ARG_TYPE_PURE_TOKEN,-1,"ASYNC",NULL,NULL,CMD_ARG_NONE},
 {"sync",ARG_TYPE_PURE_TOKEN,-1,"SYNC",NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -3608,7 +3596,7 @@ struct redisCommandArg SCRIPT_FLUSH_async_Subargs[] = {
 
 /* SCRIPT FLUSH argument table */
 struct redisCommandArg SCRIPT_FLUSH_Args[] = {
-{"async",ARG_TYPE_ONEOF,-1,NULL,NULL,"6.2.0",CMD_ARG_OPTIONAL,.subargs=SCRIPT_FLUSH_async_Subargs},
+{"flush_type",ARG_TYPE_ONEOF,-1,NULL,NULL,"6.2.0",CMD_ARG_OPTIONAL,.subargs=SCRIPT_FLUSH_flush_type_Subargs},
 {0}
 };
 
@@ -3693,7 +3681,7 @@ struct redisCommandArg SENTINEL_CKQUORUM_Args[] = {
 
 /* SENTINEL CONFIG set_or_get set_param_value argument table */
 struct redisCommandArg SENTINEL_CONFIG_set_or_get_set_param_value_Subargs[] = {
-{"parameter",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"set_parameter",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="parameter"},
 {"value",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
 };
@@ -3701,7 +3689,7 @@ struct redisCommandArg SENTINEL_CONFIG_set_or_get_set_param_value_Subargs[] = {
 /* SENTINEL CONFIG set_or_get argument table */
 struct redisCommandArg SENTINEL_CONFIG_set_or_get_Subargs[] = {
 {"set_param_value",ARG_TYPE_BLOCK,-1,"SET",NULL,NULL,CMD_ARG_MULTIPLE,.subargs=SENTINEL_CONFIG_set_or_get_set_param_value_Subargs},
-{"parameter",ARG_TYPE_STRING,-1,"GET",NULL,NULL,CMD_ARG_MULTIPLE},
+{"get_parameter",ARG_TYPE_STRING,-1,"GET",NULL,NULL,CMD_ARG_MULTIPLE,.display="parameter"},
 {0}
 };
 
@@ -4353,15 +4341,9 @@ commandHistory CONFIG_GET_History[] = {
 /* CONFIG GET tips */
 #define CONFIG_GET_tips NULL
 
-/* CONFIG GET parameter argument table */
-struct redisCommandArg CONFIG_GET_parameter_Subargs[] = {
-{"parameter",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{0}
-};
-
 /* CONFIG GET argument table */
 struct redisCommandArg CONFIG_GET_Args[] = {
-{"parameter",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=CONFIG_GET_parameter_Subargs},
+{"parameter",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE},
 {0}
 };
 
@@ -4495,8 +4477,8 @@ const char *FLUSHALL_tips[] = {
 NULL
 };
 
-/* FLUSHALL async argument table */
-struct redisCommandArg FLUSHALL_async_Subargs[] = {
+/* FLUSHALL flush_type argument table */
+struct redisCommandArg FLUSHALL_flush_type_Subargs[] = {
 {"async",ARG_TYPE_PURE_TOKEN,-1,"ASYNC",NULL,"4.0.0",CMD_ARG_NONE},
 {"sync",ARG_TYPE_PURE_TOKEN,-1,"SYNC",NULL,"6.2.0",CMD_ARG_NONE},
 {0}
@@ -4504,7 +4486,7 @@ struct redisCommandArg FLUSHALL_async_Subargs[] = {
 
 /* FLUSHALL argument table */
 struct redisCommandArg FLUSHALL_Args[] = {
-{"async",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=FLUSHALL_async_Subargs},
+{"flush_type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=FLUSHALL_flush_type_Subargs},
 {0}
 };
 
@@ -4524,8 +4506,8 @@ const char *FLUSHDB_tips[] = {
 NULL
 };
 
-/* FLUSHDB async argument table */
-struct redisCommandArg FLUSHDB_async_Subargs[] = {
+/* FLUSHDB flush_type argument table */
+struct redisCommandArg FLUSHDB_flush_type_Subargs[] = {
 {"async",ARG_TYPE_PURE_TOKEN,-1,"ASYNC",NULL,"4.0.0",CMD_ARG_NONE},
 {"sync",ARG_TYPE_PURE_TOKEN,-1,"SYNC",NULL,"6.2.0",CMD_ARG_NONE},
 {0}
@@ -4533,7 +4515,7 @@ struct redisCommandArg FLUSHDB_async_Subargs[] = {
 
 /* FLUSHDB argument table */
 struct redisCommandArg FLUSHDB_Args[] = {
-{"async",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=FLUSHDB_async_Subargs},
+{"flush_type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=FLUSHDB_flush_type_Subargs},
 {0}
 };
 
@@ -4855,17 +4837,11 @@ struct redisCommandArg MODULE_LOADEX_configs_Subargs[] = {
 {0}
 };
 
-/* MODULE LOADEX args argument table */
-struct redisCommandArg MODULE_LOADEX_args_Subargs[] = {
-{"arg",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{0}
-};
-
 /* MODULE LOADEX argument table */
 struct redisCommandArg MODULE_LOADEX_Args[] = {
 {"path",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"configs",ARG_TYPE_BLOCK,-1,"CONFIG",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.subargs=MODULE_LOADEX_configs_Subargs},
-{"args",ARG_TYPE_BLOCK,-1,"ARGS",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,.subargs=MODULE_LOADEX_args_Subargs},
+{"args",ARG_TYPE_STRING,-1,"ARGS",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE},
 {0}
 };
 
@@ -6286,7 +6262,7 @@ struct redisCommandArg XCLAIM_Args[] = {
 {"count",ARG_TYPE_INTEGER,-1,"RETRYCOUNT",NULL,NULL,CMD_ARG_OPTIONAL},
 {"force",ARG_TYPE_PURE_TOKEN,-1,"FORCE",NULL,NULL,CMD_ARG_OPTIONAL},
 {"justid",ARG_TYPE_PURE_TOKEN,-1,"JUSTID",NULL,NULL,CMD_ARG_OPTIONAL},
-{"id",ARG_TYPE_STRING,-1,"LASTID",NULL,NULL,CMD_ARG_OPTIONAL},
+{"lastid",ARG_TYPE_STRING,-1,"LASTID",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
 };
 
@@ -6316,8 +6292,8 @@ commandHistory XGROUP_CREATE_History[] = {
 /* XGROUP CREATE tips */
 #define XGROUP_CREATE_tips NULL
 
-/* XGROUP CREATE id argument table */
-struct redisCommandArg XGROUP_CREATE_id_Subargs[] = {
+/* XGROUP CREATE id_type argument table */
+struct redisCommandArg XGROUP_CREATE_id_type_Subargs[] = {
 {"id",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"new_id",ARG_TYPE_PURE_TOKEN,-1,"$",NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -6327,7 +6303,7 @@ struct redisCommandArg XGROUP_CREATE_id_Subargs[] = {
 struct redisCommandArg XGROUP_CREATE_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"groupname",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"id",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XGROUP_CREATE_id_Subargs},
+{"id_type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XGROUP_CREATE_id_type_Subargs},
 {"mkstream",ARG_TYPE_PURE_TOKEN,-1,"MKSTREAM",NULL,NULL,CMD_ARG_OPTIONAL},
 {"entries_read",ARG_TYPE_INTEGER,-1,"ENTRIESREAD",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
@@ -6399,10 +6375,10 @@ commandHistory XGROUP_SETID_History[] = {
 /* XGROUP SETID tips */
 #define XGROUP_SETID_tips NULL
 
-/* XGROUP SETID id argument table */
-struct redisCommandArg XGROUP_SETID_id_Subargs[] = {
+/* XGROUP SETID id_block argument table */
+struct redisCommandArg XGROUP_SETID_id_block_Subargs[] = {
 {"id",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"new_id",ARG_TYPE_PURE_TOKEN,-1,"$",NULL,NULL,CMD_ARG_NONE},
+{"lastid",ARG_TYPE_PURE_TOKEN,-1,"$",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
@@ -6410,7 +6386,7 @@ struct redisCommandArg XGROUP_SETID_id_Subargs[] = {
 struct redisCommandArg XGROUP_SETID_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"groupname",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"id",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XGROUP_SETID_id_Subargs},
+{"id_block",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XGROUP_SETID_id_block_Subargs},
 {"entries_read",ARG_TYPE_INTEGER,-1,"ENTRIESREAD",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
 };
@@ -6489,8 +6465,9 @@ commandHistory XINFO_STREAM_History[] = {
 /* XINFO STREAM tips */
 #define XINFO_STREAM_tips NULL
 
-/* XINFO STREAM full argument table */
-struct redisCommandArg XINFO_STREAM_full_Subargs[] = {
+/* XINFO STREAM full_block argument table */
+struct redisCommandArg XINFO_STREAM_full_block_Subargs[] = {
+{"full",ARG_TYPE_PURE_TOKEN,-1,"FULL",NULL,NULL,CMD_ARG_NONE},
 {"count",ARG_TYPE_INTEGER,-1,"COUNT",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
 };
@@ -6498,7 +6475,7 @@ struct redisCommandArg XINFO_STREAM_full_Subargs[] = {
 /* XINFO STREAM argument table */
 struct redisCommandArg XINFO_STREAM_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"full",ARG_TYPE_BLOCK,-1,"FULL",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=XINFO_STREAM_full_Subargs},
+{"full_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=XINFO_STREAM_full_block_Subargs},
 {0}
 };
 
@@ -6910,7 +6887,7 @@ struct redisCommandArg LCS_Args[] = {
 {"key2",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"len",ARG_TYPE_PURE_TOKEN,-1,"LEN",NULL,NULL,CMD_ARG_OPTIONAL},
 {"idx",ARG_TYPE_PURE_TOKEN,-1,"IDX",NULL,NULL,CMD_ARG_OPTIONAL},
-{"len",ARG_TYPE_INTEGER,-1,"MINMATCHLEN",NULL,NULL,CMD_ARG_OPTIONAL},
+{"min-match-len",ARG_TYPE_INTEGER,-1,"MINMATCHLEN",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withmatchlen",ARG_TYPE_PURE_TOKEN,-1,"WITHMATCHLEN",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
 };

--- a/src/commands.c
+++ b/src/commands.c
@@ -17,25 +17,25 @@ commandHistory BITCOUNT_History[] = {
 /* BITCOUNT tips */
 #define BITCOUNT_tips NULL
 
-/* BITCOUNT index index_unit argument table */
-struct redisCommandArg BITCOUNT_index_index_unit_Subargs[] = {
+/* BITCOUNT range unit argument table */
+struct redisCommandArg BITCOUNT_range_unit_Subargs[] = {
 {"byte",ARG_TYPE_PURE_TOKEN,-1,"BYTE",NULL,NULL,CMD_ARG_NONE},
 {"bit",ARG_TYPE_PURE_TOKEN,-1,"BIT",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
-/* BITCOUNT index argument table */
-struct redisCommandArg BITCOUNT_index_Subargs[] = {
+/* BITCOUNT range argument table */
+struct redisCommandArg BITCOUNT_range_Subargs[] = {
 {"start",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"end",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"index_unit",ARG_TYPE_ONEOF,-1,NULL,NULL,"7.0.0",CMD_ARG_OPTIONAL,.subargs=BITCOUNT_index_index_unit_Subargs},
+{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,"7.0.0",CMD_ARG_OPTIONAL,.subargs=BITCOUNT_range_unit_Subargs},
 {0}
 };
 
 /* BITCOUNT argument table */
 struct redisCommandArg BITCOUNT_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"index",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=BITCOUNT_index_Subargs},
+{"range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=BITCOUNT_range_Subargs},
 {0}
 };
 
@@ -49,7 +49,7 @@ struct redisCommandArg BITCOUNT_Args[] = {
 
 /* BITFIELD operation get_block argument table */
 struct redisCommandArg BITFIELD_operation_get_block_Subargs[] = {
-{"get_encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="encoding"},
+{"encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
 };
@@ -64,37 +64,37 @@ struct redisCommandArg BITFIELD_operation_write_overflow_block_Subargs[] = {
 
 /* BITFIELD operation write write_operation set_block argument table */
 struct redisCommandArg BITFIELD_operation_write_write_operation_set_block_Subargs[] = {
-{"set_encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="encoding"},
-{"set_offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="offset"},
-{"set_value",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="value"},
+{"encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"value",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
-/* BITFIELD operation write write_operation incrby_info argument table */
-struct redisCommandArg BITFIELD_operation_write_write_operation_incrby_info_Subargs[] = {
-{"incrby_encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="encoding"},
-{"incrby_offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="offset"},
-{"incrby_increment",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="increment"},
+/* BITFIELD operation write write_operation incrby_block argument table */
+struct redisCommandArg BITFIELD_operation_write_write_operation_incrby_block_Subargs[] = {
+{"encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"increment",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
 /* BITFIELD operation write write_operation argument table */
 struct redisCommandArg BITFIELD_operation_write_write_operation_Subargs[] = {
-{"set_block",ARG_TYPE_BLOCK,-1,"SET",NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_write_operation_set_block_Subargs},
-{"incrby_info",ARG_TYPE_BLOCK,-1,"INCRBY",NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_write_operation_incrby_info_Subargs},
+{"set-block",ARG_TYPE_BLOCK,-1,"SET",NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_write_operation_set_block_Subargs},
+{"incrby-block",ARG_TYPE_BLOCK,-1,"INCRBY",NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_write_operation_incrby_block_Subargs},
 {0}
 };
 
 /* BITFIELD operation write argument table */
 struct redisCommandArg BITFIELD_operation_write_Subargs[] = {
-{"overflow_block",ARG_TYPE_ONEOF,-1,"OVERFLOW",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=BITFIELD_operation_write_overflow_block_Subargs},
-{"write_operation",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_write_operation_Subargs},
+{"overflow-block",ARG_TYPE_ONEOF,-1,"OVERFLOW",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=BITFIELD_operation_write_overflow_block_Subargs},
+{"write-operation",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_write_operation_Subargs},
 {0}
 };
 
 /* BITFIELD operation argument table */
 struct redisCommandArg BITFIELD_operation_Subargs[] = {
-{"get_block",ARG_TYPE_BLOCK,-1,"GET",NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_get_block_Subargs},
+{"get-block",ARG_TYPE_BLOCK,-1,"GET",NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_get_block_Subargs},
 {"write",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=BITFIELD_operation_write_Subargs},
 {0}
 };
@@ -114,8 +114,8 @@ struct redisCommandArg BITFIELD_Args[] = {
 /* BITFIELD_RO tips */
 #define BITFIELD_RO_tips NULL
 
-/* BITFIELD_RO encoding_offset argument table */
-struct redisCommandArg BITFIELD_RO_encoding_offset_Subargs[] = {
+/* BITFIELD_RO get_block argument table */
+struct redisCommandArg BITFIELD_RO_get_block_Subargs[] = {
 {"encoding",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -124,7 +124,7 @@ struct redisCommandArg BITFIELD_RO_encoding_offset_Subargs[] = {
 /* BITFIELD_RO argument table */
 struct redisCommandArg BITFIELD_RO_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"encoding_offset",ARG_TYPE_BLOCK,-1,"GET",NULL,NULL,CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.subargs=BITFIELD_RO_encoding_offset_Subargs},
+{"get-block",ARG_TYPE_BLOCK,-1,"GET",NULL,NULL,CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.subargs=BITFIELD_RO_get_block_Subargs},
 {0}
 };
 
@@ -155,24 +155,18 @@ commandHistory BITPOS_History[] = {
 /* BITPOS tips */
 #define BITPOS_tips NULL
 
-/* BITPOS index end_index unit argument table */
-struct redisCommandArg BITPOS_index_end_index_unit_Subargs[] = {
-{"unit_byte",ARG_TYPE_PURE_TOKEN,-1,"BYTE",NULL,NULL,CMD_ARG_NONE,.display="byte"},
-{"unit_bit",ARG_TYPE_PURE_TOKEN,-1,"BIT",NULL,NULL,CMD_ARG_NONE,.display="bit"},
+/* BITPOS range unit argument table */
+struct redisCommandArg BITPOS_range_unit_Subargs[] = {
+{"byte",ARG_TYPE_PURE_TOKEN,-1,"BYTE",NULL,NULL,CMD_ARG_NONE},
+{"bit",ARG_TYPE_PURE_TOKEN,-1,"BIT",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
-/* BITPOS index end_index argument table */
-struct redisCommandArg BITPOS_index_end_index_Subargs[] = {
-{"end",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,"7.0.0",CMD_ARG_OPTIONAL,.subargs=BITPOS_index_end_index_unit_Subargs},
-{0}
-};
-
-/* BITPOS index argument table */
-struct redisCommandArg BITPOS_index_Subargs[] = {
+/* BITPOS range argument table */
+struct redisCommandArg BITPOS_range_Subargs[] = {
 {"start",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"end_index",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=BITPOS_index_end_index_Subargs},
+{"end",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL},
+{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,"7.0.0",CMD_ARG_OPTIONAL,.subargs=BITPOS_range_unit_Subargs},
 {0}
 };
 
@@ -180,7 +174,7 @@ struct redisCommandArg BITPOS_index_Subargs[] = {
 struct redisCommandArg BITPOS_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"bit",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"index",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=BITPOS_index_Subargs},
+{"range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=BITPOS_range_Subargs},
 {0}
 };
 
@@ -251,8 +245,8 @@ const char *CLUSTER_ADDSLOTSRANGE_tips[] = {
 NULL
 };
 
-/* CLUSTER ADDSLOTSRANGE start_slot_end_slot argument table */
-struct redisCommandArg CLUSTER_ADDSLOTSRANGE_start_slot_end_slot_Subargs[] = {
+/* CLUSTER ADDSLOTSRANGE range argument table */
+struct redisCommandArg CLUSTER_ADDSLOTSRANGE_range_Subargs[] = {
 {"start-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"end-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -260,7 +254,7 @@ struct redisCommandArg CLUSTER_ADDSLOTSRANGE_start_slot_end_slot_Subargs[] = {
 
 /* CLUSTER ADDSLOTSRANGE argument table */
 struct redisCommandArg CLUSTER_ADDSLOTSRANGE_Args[] = {
-{"start-slot_end-slot",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=CLUSTER_ADDSLOTSRANGE_start_slot_end_slot_Subargs},
+{"range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=CLUSTER_ADDSLOTSRANGE_range_Subargs},
 {0}
 };
 
@@ -337,8 +331,8 @@ const char *CLUSTER_DELSLOTSRANGE_tips[] = {
 NULL
 };
 
-/* CLUSTER DELSLOTSRANGE start_slot_end_slot argument table */
-struct redisCommandArg CLUSTER_DELSLOTSRANGE_start_slot_end_slot_Subargs[] = {
+/* CLUSTER DELSLOTSRANGE range argument table */
+struct redisCommandArg CLUSTER_DELSLOTSRANGE_range_Subargs[] = {
 {"start-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"end-slot",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -346,7 +340,7 @@ struct redisCommandArg CLUSTER_DELSLOTSRANGE_start_slot_end_slot_Subargs[] = {
 
 /* CLUSTER DELSLOTSRANGE argument table */
 struct redisCommandArg CLUSTER_DELSLOTSRANGE_Args[] = {
-{"start-slot_end-slot",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=CLUSTER_DELSLOTSRANGE_start_slot_end_slot_Subargs},
+{"range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=CLUSTER_DELSLOTSRANGE_range_Subargs},
 {0}
 };
 
@@ -485,7 +479,7 @@ NULL
 struct redisCommandArg CLUSTER_MEET_Args[] = {
 {"ip",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"port",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"cluster_bus_port",ARG_TYPE_INTEGER,-1,NULL,NULL,"4.0.0",CMD_ARG_OPTIONAL},
+{"cluster-bus-port",ARG_TYPE_INTEGER,-1,NULL,NULL,"4.0.0",CMD_ARG_OPTIONAL},
 {0}
 };
 
@@ -556,8 +550,8 @@ const char *CLUSTER_RESET_tips[] = {
 NULL
 };
 
-/* CLUSTER RESET hard_soft argument table */
-struct redisCommandArg CLUSTER_RESET_hard_soft_Subargs[] = {
+/* CLUSTER RESET reset_type argument table */
+struct redisCommandArg CLUSTER_RESET_reset_type_Subargs[] = {
 {"hard",ARG_TYPE_PURE_TOKEN,-1,"HARD",NULL,NULL,CMD_ARG_NONE},
 {"soft",ARG_TYPE_PURE_TOKEN,-1,"SOFT",NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -565,7 +559,7 @@ struct redisCommandArg CLUSTER_RESET_hard_soft_Subargs[] = {
 
 /* CLUSTER RESET argument table */
 struct redisCommandArg CLUSTER_RESET_Args[] = {
-{"hard_soft",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=CLUSTER_RESET_hard_soft_Subargs},
+{"reset-type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=CLUSTER_RESET_reset_type_Subargs},
 {0}
 };
 
@@ -832,8 +826,8 @@ struct redisCommandArg CLIENT_KILL_filter_new_format_client_type_Subargs[] = {
 
 /* CLIENT KILL filter new_format argument table */
 struct redisCommandArg CLIENT_KILL_filter_new_format_Subargs[] = {
-{"client_id",ARG_TYPE_INTEGER,-1,"ID",NULL,"2.8.12",CMD_ARG_OPTIONAL,.display="client-id"},
-{"client_type",ARG_TYPE_ONEOF,-1,"TYPE",NULL,"2.8.12",CMD_ARG_OPTIONAL,.subargs=CLIENT_KILL_filter_new_format_client_type_Subargs},
+{"client-id",ARG_TYPE_INTEGER,-1,"ID",NULL,"2.8.12",CMD_ARG_OPTIONAL},
+{"client-type",ARG_TYPE_ONEOF,-1,"TYPE",NULL,"2.8.12",CMD_ARG_OPTIONAL,.subargs=CLIENT_KILL_filter_new_format_client_type_Subargs},
 {"username",ARG_TYPE_STRING,-1,"USER",NULL,NULL,CMD_ARG_OPTIONAL},
 {"addr",ARG_TYPE_STRING,-1,"ADDR",NULL,NULL,CMD_ARG_OPTIONAL,.display="ip:port"},
 {"laddr",ARG_TYPE_STRING,-1,"LADDR",NULL,"6.2.0",CMD_ARG_OPTIONAL,.display="ip:port"},
@@ -843,8 +837,8 @@ struct redisCommandArg CLIENT_KILL_filter_new_format_Subargs[] = {
 
 /* CLIENT KILL filter argument table */
 struct redisCommandArg CLIENT_KILL_filter_Subargs[] = {
-{"old_format",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.deprecated_since="2.8.12",.display="ip:port"},
-{"new_format",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=CLIENT_KILL_filter_new_format_Subargs},
+{"old-format",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.deprecated_since="2.8.12",.display="ip:port"},
+{"new-format",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=CLIENT_KILL_filter_new_format_Subargs},
 {0}
 };
 
@@ -870,8 +864,8 @@ const char *CLIENT_LIST_tips[] = {
 NULL
 };
 
-/* CLIENT LIST normal_master_replica_pubsub argument table */
-struct redisCommandArg CLIENT_LIST_normal_master_replica_pubsub_Subargs[] = {
+/* CLIENT LIST client_type argument table */
+struct redisCommandArg CLIENT_LIST_client_type_Subargs[] = {
 {"normal",ARG_TYPE_PURE_TOKEN,-1,"NORMAL",NULL,NULL,CMD_ARG_NONE},
 {"master",ARG_TYPE_PURE_TOKEN,-1,"MASTER",NULL,NULL,CMD_ARG_NONE},
 {"replica",ARG_TYPE_PURE_TOKEN,-1,"REPLICA",NULL,NULL,CMD_ARG_NONE},
@@ -881,7 +875,7 @@ struct redisCommandArg CLIENT_LIST_normal_master_replica_pubsub_Subargs[] = {
 
 /* CLIENT LIST argument table */
 struct redisCommandArg CLIENT_LIST_Args[] = {
-{"normal_master_replica_pubsub",ARG_TYPE_ONEOF,-1,"TYPE",NULL,"5.0.0",CMD_ARG_OPTIONAL,.subargs=CLIENT_LIST_normal_master_replica_pubsub_Subargs},
+{"client-type",ARG_TYPE_ONEOF,-1,"TYPE",NULL,"5.0.0",CMD_ARG_OPTIONAL,.subargs=CLIENT_LIST_client_type_Subargs},
 {"client-id",ARG_TYPE_INTEGER,-1,"ID",NULL,"6.2.0",CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE},
 {0}
 };
@@ -940,8 +934,8 @@ struct redisCommandArg CLIENT_PAUSE_Args[] = {
 /* CLIENT REPLY tips */
 #define CLIENT_REPLY_tips NULL
 
-/* CLIENT REPLY on_off_skip argument table */
-struct redisCommandArg CLIENT_REPLY_on_off_skip_Subargs[] = {
+/* CLIENT REPLY action argument table */
+struct redisCommandArg CLIENT_REPLY_action_Subargs[] = {
 {"on",ARG_TYPE_PURE_TOKEN,-1,"ON",NULL,NULL,CMD_ARG_NONE},
 {"off",ARG_TYPE_PURE_TOKEN,-1,"OFF",NULL,NULL,CMD_ARG_NONE},
 {"skip",ARG_TYPE_PURE_TOKEN,-1,"SKIP",NULL,NULL,CMD_ARG_NONE},
@@ -950,7 +944,7 @@ struct redisCommandArg CLIENT_REPLY_on_off_skip_Subargs[] = {
 
 /* CLIENT REPLY argument table */
 struct redisCommandArg CLIENT_REPLY_Args[] = {
-{"on_off_skip",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=CLIENT_REPLY_on_off_skip_Subargs},
+{"action",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=CLIENT_REPLY_action_Subargs},
 {0}
 };
 
@@ -1011,8 +1005,8 @@ struct redisCommandArg CLIENT_TRACKING_Args[] = {
 /* CLIENT UNBLOCK tips */
 #define CLIENT_UNBLOCK_tips NULL
 
-/* CLIENT UNBLOCK timeout_error argument table */
-struct redisCommandArg CLIENT_UNBLOCK_timeout_error_Subargs[] = {
+/* CLIENT UNBLOCK unblock_type argument table */
+struct redisCommandArg CLIENT_UNBLOCK_unblock_type_Subargs[] = {
 {"timeout",ARG_TYPE_PURE_TOKEN,-1,"TIMEOUT",NULL,NULL,CMD_ARG_NONE},
 {"error",ARG_TYPE_PURE_TOKEN,-1,"ERROR",NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -1021,7 +1015,7 @@ struct redisCommandArg CLIENT_UNBLOCK_timeout_error_Subargs[] = {
 /* CLIENT UNBLOCK argument table */
 struct redisCommandArg CLIENT_UNBLOCK_Args[] = {
 {"client-id",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"timeout_error",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=CLIENT_UNBLOCK_timeout_error_Subargs},
+{"unblock-type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=CLIENT_UNBLOCK_unblock_type_Subargs},
 {0}
 };
 
@@ -1087,8 +1081,8 @@ commandHistory HELLO_History[] = {
 /* HELLO tips */
 #define HELLO_tips NULL
 
-/* HELLO arguments username_password argument table */
-struct redisCommandArg HELLO_arguments_username_password_Subargs[] = {
+/* HELLO arguments auth argument table */
+struct redisCommandArg HELLO_arguments_auth_Subargs[] = {
 {"username",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"password",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -1097,7 +1091,7 @@ struct redisCommandArg HELLO_arguments_username_password_Subargs[] = {
 /* HELLO arguments argument table */
 struct redisCommandArg HELLO_arguments_Subargs[] = {
 {"protover",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"username_password",ARG_TYPE_BLOCK,-1,"AUTH",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=HELLO_arguments_username_password_Subargs},
+{"auth",ARG_TYPE_BLOCK,-1,"AUTH",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=HELLO_arguments_auth_Subargs},
 {"clientname",ARG_TYPE_STRING,-1,"SETNAME",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
 };
@@ -1334,24 +1328,24 @@ const char *MIGRATE_tips[] = {
 NULL
 };
 
-/* MIGRATE key_or_empty_string argument table */
-struct redisCommandArg MIGRATE_key_or_empty_string_Subargs[] = {
+/* MIGRATE key_selector argument table */
+struct redisCommandArg MIGRATE_key_selector_Subargs[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"empty_string",ARG_TYPE_PURE_TOKEN,-1,"""",NULL,NULL,CMD_ARG_NONE},
+{"empty-string",ARG_TYPE_PURE_TOKEN,-1,"""",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
-/* MIGRATE authentication username_password argument table */
-struct redisCommandArg MIGRATE_authentication_username_password_Subargs[] = {
-{"auth2_username",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="username"},
-{"auth2_password",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="password"},
+/* MIGRATE authentication auth2 argument table */
+struct redisCommandArg MIGRATE_authentication_auth2_Subargs[] = {
+{"username",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"password",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
 /* MIGRATE authentication argument table */
 struct redisCommandArg MIGRATE_authentication_Subargs[] = {
-{"password",ARG_TYPE_STRING,-1,"AUTH",NULL,"4.0.7",CMD_ARG_NONE},
-{"username_password",ARG_TYPE_BLOCK,-1,"AUTH2",NULL,"6.0.0",CMD_ARG_NONE,.subargs=MIGRATE_authentication_username_password_Subargs},
+{"auth",ARG_TYPE_STRING,-1,"AUTH",NULL,"4.0.7",CMD_ARG_NONE,.display="password"},
+{"auth2",ARG_TYPE_BLOCK,-1,"AUTH2",NULL,"6.0.0",CMD_ARG_NONE,.subargs=MIGRATE_authentication_auth2_Subargs},
 {0}
 };
 
@@ -1359,7 +1353,7 @@ struct redisCommandArg MIGRATE_authentication_Subargs[] = {
 struct redisCommandArg MIGRATE_Args[] = {
 {"host",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"port",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"key_or_empty_string",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=MIGRATE_key_or_empty_string_Subargs},
+{"key-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=MIGRATE_key_selector_Subargs},
 {"destination-db",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"timeout",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"copy",ARG_TYPE_PURE_TOKEN,-1,"COPY",NULL,"3.0.0",CMD_ARG_OPTIONAL},
@@ -1684,8 +1678,8 @@ struct redisCommandArg SCAN_Args[] = {
 /* SORT tips */
 #define SORT_tips NULL
 
-/* SORT offset_count argument table */
-struct redisCommandArg SORT_offset_count_Subargs[] = {
+/* SORT limit argument table */
+struct redisCommandArg SORT_limit_Subargs[] = {
 {"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"count",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -1701,9 +1695,9 @@ struct redisCommandArg SORT_order_Subargs[] = {
 /* SORT argument table */
 struct redisCommandArg SORT_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"by_pattern",ARG_TYPE_PATTERN,1,"BY",NULL,NULL,CMD_ARG_OPTIONAL,.display="pattern"},
-{"offset_count",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_offset_count_Subargs},
-{"get_pattern",ARG_TYPE_PATTERN,1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.display="pattern"},
+{"by-pattern",ARG_TYPE_PATTERN,1,"BY",NULL,NULL,CMD_ARG_OPTIONAL,.display="pattern"},
+{"limit",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_limit_Subargs},
+{"get-pattern",ARG_TYPE_PATTERN,1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.display="pattern"},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_order_Subargs},
 {"sorting",ARG_TYPE_PURE_TOKEN,-1,"ALPHA",NULL,NULL,CMD_ARG_OPTIONAL},
 {"destination",ARG_TYPE_KEY,2,"STORE",NULL,NULL,CMD_ARG_OPTIONAL},
@@ -1718,8 +1712,8 @@ struct redisCommandArg SORT_Args[] = {
 /* SORT_RO tips */
 #define SORT_RO_tips NULL
 
-/* SORT_RO offset_count argument table */
-struct redisCommandArg SORT_RO_offset_count_Subargs[] = {
+/* SORT_RO limit argument table */
+struct redisCommandArg SORT_RO_limit_Subargs[] = {
 {"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"count",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -1735,9 +1729,9 @@ struct redisCommandArg SORT_RO_order_Subargs[] = {
 /* SORT_RO argument table */
 struct redisCommandArg SORT_RO_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"by_pattern",ARG_TYPE_PATTERN,1,"BY",NULL,NULL,CMD_ARG_OPTIONAL,.display="pattern"},
-{"offset_count",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_RO_offset_count_Subargs},
-{"get_pattern",ARG_TYPE_PATTERN,1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.display="pattern"},
+{"by-pattern",ARG_TYPE_PATTERN,1,"BY",NULL,NULL,CMD_ARG_OPTIONAL,.display="pattern"},
+{"limit",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_RO_limit_Subargs},
+{"get-pattern",ARG_TYPE_PATTERN,1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.display="pattern"},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SORT_RO_order_Subargs},
 {"sorting",ARG_TYPE_PURE_TOKEN,-1,"ALPHA",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
@@ -1850,8 +1844,8 @@ struct redisCommandArg GEOADD_condition_Subargs[] = {
 {0}
 };
 
-/* GEOADD longitude_latitude_member argument table */
-struct redisCommandArg GEOADD_longitude_latitude_member_Subargs[] = {
+/* GEOADD data argument table */
+struct redisCommandArg GEOADD_data_Subargs[] = {
 {"longitude",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"latitude",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"member",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
@@ -1863,7 +1857,7 @@ struct redisCommandArg GEOADD_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"condition",ARG_TYPE_ONEOF,-1,NULL,NULL,"6.2.0",CMD_ARG_OPTIONAL,.subargs=GEOADD_condition_Subargs},
 {"change",ARG_TYPE_PURE_TOKEN,-1,"CH",NULL,"6.2.0",CMD_ARG_OPTIONAL},
-{"longitude_latitude_member",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=GEOADD_longitude_latitude_member_Subargs},
+{"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=GEOADD_data_Subargs},
 {0}
 };
 
@@ -1967,7 +1961,7 @@ struct redisCommandArg GEORADIUS_Args[] = {
 {"withcoord",ARG_TYPE_PURE_TOKEN,-1,"WITHCOORD",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withdist",ARG_TYPE_PURE_TOKEN,-1,"WITHDIST",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withhash",ARG_TYPE_PURE_TOKEN,-1,"WITHHASH",NULL,NULL,CMD_ARG_OPTIONAL},
-{"count_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_count_block_Subargs},
+{"count-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_count_block_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_order_Subargs},
 {"storekey",ARG_TYPE_KEY,1,"STORE",NULL,NULL,CMD_ARG_OPTIONAL,.display="key"},
 {"storedistkey",ARG_TYPE_KEY,2,"STOREDIST",NULL,NULL,CMD_ARG_OPTIONAL,.display="key"},
@@ -2014,7 +2008,7 @@ struct redisCommandArg GEORADIUSBYMEMBER_Args[] = {
 {"withcoord",ARG_TYPE_PURE_TOKEN,-1,"WITHCOORD",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withdist",ARG_TYPE_PURE_TOKEN,-1,"WITHDIST",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withhash",ARG_TYPE_PURE_TOKEN,-1,"WITHHASH",NULL,NULL,CMD_ARG_OPTIONAL},
-{"count_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_count_block_Subargs},
+{"count-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_count_block_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_order_Subargs},
 {"storekey",ARG_TYPE_KEY,1,"STORE",NULL,NULL,CMD_ARG_OPTIONAL,.display="key"},
 {"storedistkey",ARG_TYPE_KEY,2,"STOREDIST",NULL,NULL,CMD_ARG_OPTIONAL,.display="key"},
@@ -2061,7 +2055,7 @@ struct redisCommandArg GEORADIUSBYMEMBER_RO_Args[] = {
 {"withcoord",ARG_TYPE_PURE_TOKEN,-1,"WITHCOORD",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withdist",ARG_TYPE_PURE_TOKEN,-1,"WITHDIST",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withhash",ARG_TYPE_PURE_TOKEN,-1,"WITHHASH",NULL,NULL,CMD_ARG_OPTIONAL},
-{"count_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_RO_count_block_Subargs},
+{"count-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_RO_count_block_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUSBYMEMBER_RO_order_Subargs},
 {0}
 };
@@ -2110,7 +2104,7 @@ struct redisCommandArg GEORADIUS_RO_Args[] = {
 {"withcoord",ARG_TYPE_PURE_TOKEN,-1,"WITHCOORD",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withdist",ARG_TYPE_PURE_TOKEN,-1,"WITHDIST",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withhash",ARG_TYPE_PURE_TOKEN,-1,"WITHHASH",NULL,NULL,CMD_ARG_OPTIONAL},
-{"count_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_RO_count_block_Subargs},
+{"count-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_RO_count_block_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEORADIUS_RO_order_Subargs},
 {0}
 };
@@ -2123,8 +2117,8 @@ struct redisCommandArg GEORADIUS_RO_Args[] = {
 /* GEOSEARCH tips */
 #define GEOSEARCH_tips NULL
 
-/* GEOSEARCH from longitude_latitude argument table */
-struct redisCommandArg GEOSEARCH_from_longitude_latitude_Subargs[] = {
+/* GEOSEARCH from fromlonlat argument table */
+struct redisCommandArg GEOSEARCH_from_fromlonlat_Subargs[] = {
 {"longitude",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"latitude",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -2133,32 +2127,32 @@ struct redisCommandArg GEOSEARCH_from_longitude_latitude_Subargs[] = {
 /* GEOSEARCH from argument table */
 struct redisCommandArg GEOSEARCH_from_Subargs[] = {
 {"member",ARG_TYPE_STRING,-1,"FROMMEMBER",NULL,NULL,CMD_ARG_NONE},
-{"longitude_latitude",ARG_TYPE_BLOCK,-1,"FROMLONLAT",NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_from_longitude_latitude_Subargs},
+{"fromlonlat",ARG_TYPE_BLOCK,-1,"FROMLONLAT",NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_from_fromlonlat_Subargs},
 {0}
 };
 
-/* GEOSEARCH by circle circle_unit argument table */
-struct redisCommandArg GEOSEARCH_by_circle_circle_unit_Subargs[] = {
-{"circle_m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE,.display="m"},
-{"circle_km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE,.display="km"},
-{"circle_ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE,.display="ft"},
-{"circle_mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE,.display="mi"},
+/* GEOSEARCH by circle unit argument table */
+struct redisCommandArg GEOSEARCH_by_circle_unit_Subargs[] = {
+{"m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE},
+{"km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE},
+{"ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE},
+{"mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
 /* GEOSEARCH by circle argument table */
 struct redisCommandArg GEOSEARCH_by_circle_Subargs[] = {
 {"radius",ARG_TYPE_DOUBLE,-1,"BYRADIUS",NULL,NULL,CMD_ARG_NONE},
-{"circle_unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_by_circle_circle_unit_Subargs},
+{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_by_circle_unit_Subargs},
 {0}
 };
 
-/* GEOSEARCH by box box_unit argument table */
-struct redisCommandArg GEOSEARCH_by_box_box_unit_Subargs[] = {
-{"box_m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE,.display="m"},
-{"box_km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE,.display="km"},
-{"box_ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE,.display="ft"},
-{"box_mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE,.display="mi"},
+/* GEOSEARCH by box unit argument table */
+struct redisCommandArg GEOSEARCH_by_box_unit_Subargs[] = {
+{"m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE},
+{"km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE},
+{"ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE},
+{"mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
@@ -2166,7 +2160,7 @@ struct redisCommandArg GEOSEARCH_by_box_box_unit_Subargs[] = {
 struct redisCommandArg GEOSEARCH_by_box_Subargs[] = {
 {"width",ARG_TYPE_DOUBLE,-1,"BYBOX",NULL,NULL,CMD_ARG_NONE},
 {"height",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"box_unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_by_box_box_unit_Subargs},
+{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_by_box_unit_Subargs},
 {0}
 };
 
@@ -2197,7 +2191,7 @@ struct redisCommandArg GEOSEARCH_Args[] = {
 {"from",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_from_Subargs},
 {"by",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCH_by_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEOSEARCH_order_Subargs},
-{"count_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEOSEARCH_count_block_Subargs},
+{"count-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEOSEARCH_count_block_Subargs},
 {"withcoord",ARG_TYPE_PURE_TOKEN,-1,"WITHCOORD",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withdist",ARG_TYPE_PURE_TOKEN,-1,"WITHDIST",NULL,NULL,CMD_ARG_OPTIONAL},
 {"withhash",ARG_TYPE_PURE_TOKEN,-1,"WITHHASH",NULL,NULL,CMD_ARG_OPTIONAL},
@@ -2226,28 +2220,28 @@ struct redisCommandArg GEOSEARCHSTORE_from_Subargs[] = {
 {0}
 };
 
-/* GEOSEARCHSTORE by circle circle_unit argument table */
-struct redisCommandArg GEOSEARCHSTORE_by_circle_circle_unit_Subargs[] = {
-{"circle_m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE,.display="m"},
-{"circle_km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE,.display="km"},
-{"circle_ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE,.display="ft"},
-{"circle_mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE,.display="mi"},
+/* GEOSEARCHSTORE by circle unit argument table */
+struct redisCommandArg GEOSEARCHSTORE_by_circle_unit_Subargs[] = {
+{"m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE},
+{"km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE},
+{"ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE},
+{"mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
 /* GEOSEARCHSTORE by circle argument table */
 struct redisCommandArg GEOSEARCHSTORE_by_circle_Subargs[] = {
 {"radius",ARG_TYPE_DOUBLE,-1,"BYRADIUS",NULL,NULL,CMD_ARG_NONE},
-{"circle_unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_by_circle_circle_unit_Subargs},
+{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_by_circle_unit_Subargs},
 {0}
 };
 
-/* GEOSEARCHSTORE by box box_unit argument table */
-struct redisCommandArg GEOSEARCHSTORE_by_box_box_unit_Subargs[] = {
-{"box_m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE,.display="m"},
-{"box_km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE,.display="km"},
-{"box_ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE,.display="ft"},
-{"box_mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE,.display="mi"},
+/* GEOSEARCHSTORE by box unit argument table */
+struct redisCommandArg GEOSEARCHSTORE_by_box_unit_Subargs[] = {
+{"m",ARG_TYPE_PURE_TOKEN,-1,"M",NULL,NULL,CMD_ARG_NONE},
+{"km",ARG_TYPE_PURE_TOKEN,-1,"KM",NULL,NULL,CMD_ARG_NONE},
+{"ft",ARG_TYPE_PURE_TOKEN,-1,"FT",NULL,NULL,CMD_ARG_NONE},
+{"mi",ARG_TYPE_PURE_TOKEN,-1,"MI",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
@@ -2255,7 +2249,7 @@ struct redisCommandArg GEOSEARCHSTORE_by_box_box_unit_Subargs[] = {
 struct redisCommandArg GEOSEARCHSTORE_by_box_Subargs[] = {
 {"width",ARG_TYPE_DOUBLE,-1,"BYBOX",NULL,NULL,CMD_ARG_NONE},
 {"height",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"box_unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_by_box_box_unit_Subargs},
+{"unit",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_by_box_unit_Subargs},
 {0}
 };
 
@@ -2287,7 +2281,7 @@ struct redisCommandArg GEOSEARCHSTORE_Args[] = {
 {"from",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_from_Subargs},
 {"by",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=GEOSEARCHSTORE_by_Subargs},
 {"order",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEOSEARCHSTORE_order_Subargs},
-{"count_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEOSEARCHSTORE_count_block_Subargs},
+{"count-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=GEOSEARCHSTORE_count_block_Subargs},
 {"storedist",ARG_TYPE_PURE_TOKEN,-1,"STOREDIST",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
 };
@@ -2443,8 +2437,8 @@ struct redisCommandArg HMGET_Args[] = {
 /* HMSET tips */
 #define HMSET_tips NULL
 
-/* HMSET field_value argument table */
-struct redisCommandArg HMSET_field_value_Subargs[] = {
+/* HMSET data argument table */
+struct redisCommandArg HMSET_data_Subargs[] = {
 {"field",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"value",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -2453,7 +2447,7 @@ struct redisCommandArg HMSET_field_value_Subargs[] = {
 /* HMSET argument table */
 struct redisCommandArg HMSET_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"field_value",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=HMSET_field_value_Subargs},
+{"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=HMSET_data_Subargs},
 {0}
 };
 
@@ -2513,8 +2507,8 @@ commandHistory HSET_History[] = {
 /* HSET tips */
 #define HSET_tips NULL
 
-/* HSET field_value argument table */
-struct redisCommandArg HSET_field_value_Subargs[] = {
+/* HSET data argument table */
+struct redisCommandArg HSET_data_Subargs[] = {
 {"field",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"value",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -2523,7 +2517,7 @@ struct redisCommandArg HSET_field_value_Subargs[] = {
 /* HSET argument table */
 struct redisCommandArg HSET_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"field_value",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=HSET_field_value_Subargs},
+{"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=HSET_data_Subargs},
 {0}
 };
 
@@ -2652,15 +2646,15 @@ struct redisCommandArg PFMERGE_Args[] = {
 
 /* BLMOVE wherefrom argument table */
 struct redisCommandArg BLMOVE_wherefrom_Subargs[] = {
-{"from_left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE,.display="left"},
-{"from_right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE,.display="right"},
+{"left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE},
+{"right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
 /* BLMOVE whereto argument table */
 struct redisCommandArg BLMOVE_whereto_Subargs[] = {
-{"to_left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE,.display="left"},
-{"to_right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE,.display="right"},
+{"left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE},
+{"right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
@@ -2817,15 +2811,15 @@ struct redisCommandArg LLEN_Args[] = {
 
 /* LMOVE wherefrom argument table */
 struct redisCommandArg LMOVE_wherefrom_Subargs[] = {
-{"from_left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE,.display="left"},
-{"from_right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE,.display="right"},
+{"left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE},
+{"right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
 /* LMOVE whereto argument table */
 struct redisCommandArg LMOVE_whereto_Subargs[] = {
-{"to_left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE,.display="left"},
-{"to_right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE,.display="right"},
+{"left",ARG_TYPE_PURE_TOKEN,-1,"LEFT",NULL,NULL,CMD_ARG_NONE},
+{"right",ARG_TYPE_PURE_TOKEN,-1,"RIGHT",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
@@ -3421,7 +3415,7 @@ struct redisCommandArg FUNCTION_FLUSH_flush_type_Subargs[] = {
 
 /* FUNCTION FLUSH argument table */
 struct redisCommandArg FUNCTION_FLUSH_Args[] = {
-{"flush_type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=FUNCTION_FLUSH_flush_type_Subargs},
+{"flush-type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=FUNCTION_FLUSH_flush_type_Subargs},
 {0}
 };
 
@@ -3608,7 +3602,7 @@ struct redisCommandArg SCRIPT_FLUSH_flush_type_Subargs[] = {
 
 /* SCRIPT FLUSH argument table */
 struct redisCommandArg SCRIPT_FLUSH_Args[] = {
-{"flush_type",ARG_TYPE_ONEOF,-1,NULL,NULL,"6.2.0",CMD_ARG_OPTIONAL,.subargs=SCRIPT_FLUSH_flush_type_Subargs},
+{"flush-type",ARG_TYPE_ONEOF,-1,NULL,NULL,"6.2.0",CMD_ARG_OPTIONAL,.subargs=SCRIPT_FLUSH_flush_type_Subargs},
 {0}
 };
 
@@ -3691,23 +3685,23 @@ struct redisCommandArg SENTINEL_CKQUORUM_Args[] = {
 /* SENTINEL CONFIG tips */
 #define SENTINEL_CONFIG_tips NULL
 
-/* SENTINEL CONFIG set_or_get set_param_value argument table */
-struct redisCommandArg SENTINEL_CONFIG_set_or_get_set_param_value_Subargs[] = {
-{"set_parameter",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,.display="parameter"},
+/* SENTINEL CONFIG action set argument table */
+struct redisCommandArg SENTINEL_CONFIG_action_set_Subargs[] = {
+{"parameter",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"value",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
-/* SENTINEL CONFIG set_or_get argument table */
-struct redisCommandArg SENTINEL_CONFIG_set_or_get_Subargs[] = {
-{"set_param_value",ARG_TYPE_BLOCK,-1,"SET",NULL,NULL,CMD_ARG_MULTIPLE,.subargs=SENTINEL_CONFIG_set_or_get_set_param_value_Subargs},
-{"get_parameter",ARG_TYPE_STRING,-1,"GET",NULL,NULL,CMD_ARG_MULTIPLE,.display="parameter"},
+/* SENTINEL CONFIG action argument table */
+struct redisCommandArg SENTINEL_CONFIG_action_Subargs[] = {
+{"set",ARG_TYPE_BLOCK,-1,"SET",NULL,NULL,CMD_ARG_MULTIPLE,.subargs=SENTINEL_CONFIG_action_set_Subargs},
+{"get",ARG_TYPE_STRING,-1,"GET",NULL,NULL,CMD_ARG_MULTIPLE,.display="parameter"},
 {0}
 };
 
 /* SENTINEL CONFIG argument table */
 struct redisCommandArg SENTINEL_CONFIG_Args[] = {
-{"set_or_get",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=SENTINEL_CONFIG_set_or_get_Subargs},
+{"action",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=SENTINEL_CONFIG_action_Subargs},
 {0}
 };
 
@@ -3719,8 +3713,8 @@ struct redisCommandArg SENTINEL_CONFIG_Args[] = {
 /* SENTINEL DEBUG tips */
 #define SENTINEL_DEBUG_tips NULL
 
-/* SENTINEL DEBUG parameter_value argument table */
-struct redisCommandArg SENTINEL_DEBUG_parameter_value_Subargs[] = {
+/* SENTINEL DEBUG data argument table */
+struct redisCommandArg SENTINEL_DEBUG_data_Subargs[] = {
 {"parameter",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"value",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -3728,7 +3722,7 @@ struct redisCommandArg SENTINEL_DEBUG_parameter_value_Subargs[] = {
 
 /* SENTINEL DEBUG argument table */
 struct redisCommandArg SENTINEL_DEBUG_Args[] = {
-{"parameter_value",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=SENTINEL_DEBUG_parameter_value_Subargs},
+{"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=SENTINEL_DEBUG_data_Subargs},
 {0}
 };
 
@@ -3926,8 +3920,8 @@ struct redisCommandArg SENTINEL_SENTINELS_Args[] = {
 /* SENTINEL SET tips */
 #define SENTINEL_SET_tips NULL
 
-/* SENTINEL SET option_value argument table */
-struct redisCommandArg SENTINEL_SET_option_value_Subargs[] = {
+/* SENTINEL SET data argument table */
+struct redisCommandArg SENTINEL_SET_data_Subargs[] = {
 {"option",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"value",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -3936,7 +3930,7 @@ struct redisCommandArg SENTINEL_SET_option_value_Subargs[] = {
 /* SENTINEL SET argument table */
 struct redisCommandArg SENTINEL_SET_Args[] = {
 {"master-name",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"option_value",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=SENTINEL_SET_option_value_Subargs},
+{"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=SENTINEL_SET_data_Subargs},
 {0}
 };
 
@@ -4398,8 +4392,8 @@ const char *CONFIG_SET_tips[] = {
 NULL
 };
 
-/* CONFIG SET parameter_value argument table */
-struct redisCommandArg CONFIG_SET_parameter_value_Subargs[] = {
+/* CONFIG SET data argument table */
+struct redisCommandArg CONFIG_SET_data_Subargs[] = {
 {"parameter",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"value",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -4407,7 +4401,7 @@ struct redisCommandArg CONFIG_SET_parameter_value_Subargs[] = {
 
 /* CONFIG SET argument table */
 struct redisCommandArg CONFIG_SET_Args[] = {
-{"parameter_value",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=CONFIG_SET_parameter_value_Subargs},
+{"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=CONFIG_SET_data_Subargs},
 {0}
 };
 
@@ -4498,7 +4492,7 @@ struct redisCommandArg FLUSHALL_flush_type_Subargs[] = {
 
 /* FLUSHALL argument table */
 struct redisCommandArg FLUSHALL_Args[] = {
-{"flush_type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=FLUSHALL_flush_type_Subargs},
+{"flush-type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=FLUSHALL_flush_type_Subargs},
 {0}
 };
 
@@ -4527,7 +4521,7 @@ struct redisCommandArg FLUSHDB_flush_type_Subargs[] = {
 
 /* FLUSHDB argument table */
 struct redisCommandArg FLUSHDB_Args[] = {
-{"flush_type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=FLUSHDB_flush_type_Subargs},
+{"flush-type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=FLUSHDB_flush_type_Subargs},
 {0}
 };
 
@@ -4987,8 +4981,8 @@ commandHistory SHUTDOWN_History[] = {
 /* SHUTDOWN tips */
 #define SHUTDOWN_tips NULL
 
-/* SHUTDOWN nosave_save argument table */
-struct redisCommandArg SHUTDOWN_nosave_save_Subargs[] = {
+/* SHUTDOWN save_selector argument table */
+struct redisCommandArg SHUTDOWN_save_selector_Subargs[] = {
 {"nosave",ARG_TYPE_PURE_TOKEN,-1,"NOSAVE",NULL,NULL,CMD_ARG_NONE},
 {"save",ARG_TYPE_PURE_TOKEN,-1,"SAVE",NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -4996,7 +4990,7 @@ struct redisCommandArg SHUTDOWN_nosave_save_Subargs[] = {
 
 /* SHUTDOWN argument table */
 struct redisCommandArg SHUTDOWN_Args[] = {
-{"nosave_save",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SHUTDOWN_nosave_save_Subargs},
+{"save-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=SHUTDOWN_save_selector_Subargs},
 {"now",ARG_TYPE_PURE_TOKEN,-1,"NOW",NULL,"7.0.0",CMD_ARG_OPTIONAL},
 {"force",ARG_TYPE_PURE_TOKEN,-1,"FORCE",NULL,"7.0.0",CMD_ARG_OPTIONAL},
 {"abort",ARG_TYPE_PURE_TOKEN,-1,"ABORT",NULL,"7.0.0",CMD_ARG_OPTIONAL},
@@ -5498,8 +5492,8 @@ struct redisCommandArg ZADD_comparison_Subargs[] = {
 {0}
 };
 
-/* ZADD score_member argument table */
-struct redisCommandArg ZADD_score_member_Subargs[] = {
+/* ZADD data argument table */
+struct redisCommandArg ZADD_data_Subargs[] = {
 {"score",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"member",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -5512,7 +5506,7 @@ struct redisCommandArg ZADD_Args[] = {
 {"comparison",ARG_TYPE_ONEOF,-1,NULL,NULL,"6.2.0",CMD_ARG_OPTIONAL,.subargs=ZADD_comparison_Subargs},
 {"change",ARG_TYPE_PURE_TOKEN,-1,"CH",NULL,"3.0.2",CMD_ARG_OPTIONAL},
 {"increment",ARG_TYPE_PURE_TOKEN,-1,"INCR",NULL,"3.0.2",CMD_ARG_OPTIONAL},
-{"score_member",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=ZADD_score_member_Subargs},
+{"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=ZADD_data_Subargs},
 {0}
 };
 
@@ -5790,8 +5784,8 @@ struct redisCommandArg ZRANGE_sortby_Subargs[] = {
 {0}
 };
 
-/* ZRANGE offset_count argument table */
-struct redisCommandArg ZRANGE_offset_count_Subargs[] = {
+/* ZRANGE limit argument table */
+struct redisCommandArg ZRANGE_limit_Subargs[] = {
 {"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"count",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -5804,7 +5798,7 @@ struct redisCommandArg ZRANGE_Args[] = {
 {"stop",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"sortby",ARG_TYPE_ONEOF,-1,NULL,NULL,"6.2.0",CMD_ARG_OPTIONAL,.subargs=ZRANGE_sortby_Subargs},
 {"rev",ARG_TYPE_PURE_TOKEN,-1,"REV",NULL,"6.2.0",CMD_ARG_OPTIONAL},
-{"offset_count",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,"6.2.0",CMD_ARG_OPTIONAL,.subargs=ZRANGE_offset_count_Subargs},
+{"limit",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,"6.2.0",CMD_ARG_OPTIONAL,.subargs=ZRANGE_limit_Subargs},
 {"withscores",ARG_TYPE_PURE_TOKEN,-1,"WITHSCORES",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
 };
@@ -5817,8 +5811,8 @@ struct redisCommandArg ZRANGE_Args[] = {
 /* ZRANGEBYLEX tips */
 #define ZRANGEBYLEX_tips NULL
 
-/* ZRANGEBYLEX offset_count argument table */
-struct redisCommandArg ZRANGEBYLEX_offset_count_Subargs[] = {
+/* ZRANGEBYLEX limit argument table */
+struct redisCommandArg ZRANGEBYLEX_limit_Subargs[] = {
 {"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"count",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -5829,7 +5823,7 @@ struct redisCommandArg ZRANGEBYLEX_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"min",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"max",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"offset_count",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=ZRANGEBYLEX_offset_count_Subargs},
+{"limit",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=ZRANGEBYLEX_limit_Subargs},
 {0}
 };
 
@@ -5844,8 +5838,8 @@ commandHistory ZRANGEBYSCORE_History[] = {
 /* ZRANGEBYSCORE tips */
 #define ZRANGEBYSCORE_tips NULL
 
-/* ZRANGEBYSCORE offset_count argument table */
-struct redisCommandArg ZRANGEBYSCORE_offset_count_Subargs[] = {
+/* ZRANGEBYSCORE limit argument table */
+struct redisCommandArg ZRANGEBYSCORE_limit_Subargs[] = {
 {"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"count",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -5857,7 +5851,7 @@ struct redisCommandArg ZRANGEBYSCORE_Args[] = {
 {"min",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"max",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"withscores",ARG_TYPE_PURE_TOKEN,-1,"WITHSCORES",NULL,"2.0.0",CMD_ARG_OPTIONAL},
-{"offset_count",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=ZRANGEBYSCORE_offset_count_Subargs},
+{"limit",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=ZRANGEBYSCORE_limit_Subargs},
 {0}
 };
 
@@ -5876,8 +5870,8 @@ struct redisCommandArg ZRANGESTORE_sortby_Subargs[] = {
 {0}
 };
 
-/* ZRANGESTORE offset_count argument table */
-struct redisCommandArg ZRANGESTORE_offset_count_Subargs[] = {
+/* ZRANGESTORE limit argument table */
+struct redisCommandArg ZRANGESTORE_limit_Subargs[] = {
 {"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"count",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -5891,7 +5885,7 @@ struct redisCommandArg ZRANGESTORE_Args[] = {
 {"max",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"sortby",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=ZRANGESTORE_sortby_Subargs},
 {"rev",ARG_TYPE_PURE_TOKEN,-1,"REV",NULL,NULL,CMD_ARG_OPTIONAL},
-{"offset_count",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=ZRANGESTORE_offset_count_Subargs},
+{"limit",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=ZRANGESTORE_limit_Subargs},
 {0}
 };
 
@@ -6001,8 +5995,8 @@ struct redisCommandArg ZREVRANGE_Args[] = {
 /* ZREVRANGEBYLEX tips */
 #define ZREVRANGEBYLEX_tips NULL
 
-/* ZREVRANGEBYLEX offset_count argument table */
-struct redisCommandArg ZREVRANGEBYLEX_offset_count_Subargs[] = {
+/* ZREVRANGEBYLEX limit argument table */
+struct redisCommandArg ZREVRANGEBYLEX_limit_Subargs[] = {
 {"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"count",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -6013,7 +6007,7 @@ struct redisCommandArg ZREVRANGEBYLEX_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"max",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"min",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"offset_count",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=ZREVRANGEBYLEX_offset_count_Subargs},
+{"limit",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=ZREVRANGEBYLEX_limit_Subargs},
 {0}
 };
 
@@ -6028,8 +6022,8 @@ commandHistory ZREVRANGEBYSCORE_History[] = {
 /* ZREVRANGEBYSCORE tips */
 #define ZREVRANGEBYSCORE_tips NULL
 
-/* ZREVRANGEBYSCORE offset_count argument table */
-struct redisCommandArg ZREVRANGEBYSCORE_offset_count_Subargs[] = {
+/* ZREVRANGEBYSCORE limit argument table */
+struct redisCommandArg ZREVRANGEBYSCORE_limit_Subargs[] = {
 {"offset",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"count",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -6041,7 +6035,7 @@ struct redisCommandArg ZREVRANGEBYSCORE_Args[] = {
 {"max",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"min",ARG_TYPE_DOUBLE,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"withscores",ARG_TYPE_PURE_TOKEN,-1,"WITHSCORES",NULL,NULL,CMD_ARG_OPTIONAL},
-{"offset_count",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=ZREVRANGEBYSCORE_offset_count_Subargs},
+{"limit",ARG_TYPE_BLOCK,-1,"LIMIT",NULL,NULL,CMD_ARG_OPTIONAL,.subargs=ZREVRANGEBYSCORE_limit_Subargs},
 {0}
 };
 
@@ -6201,15 +6195,15 @@ struct redisCommandArg XADD_trim_Subargs[] = {
 {0}
 };
 
-/* XADD id_or_auto argument table */
-struct redisCommandArg XADD_id_or_auto_Subargs[] = {
-{"auto_id",ARG_TYPE_PURE_TOKEN,-1,"*",NULL,NULL,CMD_ARG_NONE},
+/* XADD id_selector argument table */
+struct redisCommandArg XADD_id_selector_Subargs[] = {
+{"auto-id",ARG_TYPE_PURE_TOKEN,-1,"*",NULL,NULL,CMD_ARG_NONE},
 {"id",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
-/* XADD field_value argument table */
-struct redisCommandArg XADD_field_value_Subargs[] = {
+/* XADD data argument table */
+struct redisCommandArg XADD_data_Subargs[] = {
 {"field",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"value",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -6220,8 +6214,8 @@ struct redisCommandArg XADD_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"nomkstream",ARG_TYPE_PURE_TOKEN,-1,"NOMKSTREAM",NULL,"6.2.0",CMD_ARG_OPTIONAL},
 {"trim",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=XADD_trim_Subargs},
-{"id_or_auto",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XADD_id_or_auto_Subargs},
-{"field_value",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=XADD_field_value_Subargs},
+{"id-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XADD_id_selector_Subargs},
+{"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=XADD_data_Subargs},
 {0}
 };
 
@@ -6304,10 +6298,10 @@ commandHistory XGROUP_CREATE_History[] = {
 /* XGROUP CREATE tips */
 #define XGROUP_CREATE_tips NULL
 
-/* XGROUP CREATE id_type argument table */
-struct redisCommandArg XGROUP_CREATE_id_type_Subargs[] = {
+/* XGROUP CREATE id_selector argument table */
+struct redisCommandArg XGROUP_CREATE_id_selector_Subargs[] = {
 {"id",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"new_id",ARG_TYPE_PURE_TOKEN,-1,"$",NULL,NULL,CMD_ARG_NONE},
+{"new-id",ARG_TYPE_PURE_TOKEN,-1,"$",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
@@ -6315,9 +6309,9 @@ struct redisCommandArg XGROUP_CREATE_id_type_Subargs[] = {
 struct redisCommandArg XGROUP_CREATE_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"groupname",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"id_type",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XGROUP_CREATE_id_type_Subargs},
+{"id-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XGROUP_CREATE_id_selector_Subargs},
 {"mkstream",ARG_TYPE_PURE_TOKEN,-1,"MKSTREAM",NULL,NULL,CMD_ARG_OPTIONAL},
-{"entries_read",ARG_TYPE_INTEGER,-1,"ENTRIESREAD",NULL,NULL,CMD_ARG_OPTIONAL},
+{"entries-read",ARG_TYPE_INTEGER,-1,"ENTRIESREAD",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
 };
 
@@ -6387,10 +6381,10 @@ commandHistory XGROUP_SETID_History[] = {
 /* XGROUP SETID tips */
 #define XGROUP_SETID_tips NULL
 
-/* XGROUP SETID id_block argument table */
-struct redisCommandArg XGROUP_SETID_id_block_Subargs[] = {
+/* XGROUP SETID id_selector argument table */
+struct redisCommandArg XGROUP_SETID_id_selector_Subargs[] = {
 {"id",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"lastid",ARG_TYPE_PURE_TOKEN,-1,"$",NULL,NULL,CMD_ARG_NONE},
+{"new-id",ARG_TYPE_PURE_TOKEN,-1,"$",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 
@@ -6398,8 +6392,8 @@ struct redisCommandArg XGROUP_SETID_id_block_Subargs[] = {
 struct redisCommandArg XGROUP_SETID_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"groupname",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"id_block",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XGROUP_SETID_id_block_Subargs},
-{"entries_read",ARG_TYPE_INTEGER,-1,"ENTRIESREAD",NULL,NULL,CMD_ARG_OPTIONAL},
+{"id-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XGROUP_SETID_id_selector_Subargs},
+{"entriesread",ARG_TYPE_INTEGER,-1,"ENTRIESREAD",NULL,NULL,CMD_ARG_OPTIONAL,.display="entries-read"},
 {0}
 };
 
@@ -6487,7 +6481,7 @@ struct redisCommandArg XINFO_STREAM_full_block_Subargs[] = {
 /* XINFO STREAM argument table */
 struct redisCommandArg XINFO_STREAM_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"full_block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=XINFO_STREAM_full_block_Subargs},
+{"full-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=XINFO_STREAM_full_block_Subargs},
 {0}
 };
 
@@ -6605,8 +6599,8 @@ struct redisCommandArg XREAD_Args[] = {
 /* XREADGROUP tips */
 #define XREADGROUP_tips NULL
 
-/* XREADGROUP group_consumer argument table */
-struct redisCommandArg XREADGROUP_group_consumer_Subargs[] = {
+/* XREADGROUP group_block argument table */
+struct redisCommandArg XREADGROUP_group_block_Subargs[] = {
 {"group",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {"consumer",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -6621,7 +6615,7 @@ struct redisCommandArg XREADGROUP_streams_Subargs[] = {
 
 /* XREADGROUP argument table */
 struct redisCommandArg XREADGROUP_Args[] = {
-{"group_consumer",ARG_TYPE_BLOCK,-1,"GROUP",NULL,NULL,CMD_ARG_NONE,.subargs=XREADGROUP_group_consumer_Subargs},
+{"group-block",ARG_TYPE_BLOCK,-1,"GROUP",NULL,NULL,CMD_ARG_NONE,.subargs=XREADGROUP_group_block_Subargs},
 {"count",ARG_TYPE_INTEGER,-1,"COUNT",NULL,NULL,CMD_ARG_OPTIONAL},
 {"milliseconds",ARG_TYPE_INTEGER,-1,"BLOCK",NULL,NULL,CMD_ARG_OPTIONAL},
 {"noack",ARG_TYPE_PURE_TOKEN,-1,"NOACK",NULL,NULL,CMD_ARG_OPTIONAL},
@@ -6664,8 +6658,8 @@ commandHistory XSETID_History[] = {
 struct redisCommandArg XSETID_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"last-id",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
-{"entries_added",ARG_TYPE_INTEGER,-1,"ENTRIESADDED",NULL,NULL,CMD_ARG_OPTIONAL},
-{"max_deleted_entry_id",ARG_TYPE_STRING,-1,"MAXDELETEDID",NULL,NULL,CMD_ARG_OPTIONAL},
+{"entries-added",ARG_TYPE_INTEGER,-1,"ENTRIESADDED",NULL,NULL,CMD_ARG_OPTIONAL},
+{"max-deleted-id",ARG_TYPE_STRING,-1,"MAXDELETEDID",NULL,NULL,CMD_ARG_OPTIONAL},
 {0}
 };
 
@@ -6933,8 +6927,8 @@ const char *MSET_tips[] = {
 NULL
 };
 
-/* MSET key_value argument table */
-struct redisCommandArg MSET_key_value_Subargs[] = {
+/* MSET data argument table */
+struct redisCommandArg MSET_data_Subargs[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"value",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -6942,7 +6936,7 @@ struct redisCommandArg MSET_key_value_Subargs[] = {
 
 /* MSET argument table */
 struct redisCommandArg MSET_Args[] = {
-{"key_value",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=MSET_key_value_Subargs},
+{"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=MSET_data_Subargs},
 {0}
 };
 
@@ -6958,8 +6952,8 @@ const char *MSETNX_tips[] = {
 NULL
 };
 
-/* MSETNX key_value argument table */
-struct redisCommandArg MSETNX_key_value_Subargs[] = {
+/* MSETNX data argument table */
+struct redisCommandArg MSETNX_data_Subargs[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"value",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
 {0}
@@ -6967,7 +6961,7 @@ struct redisCommandArg MSETNX_key_value_Subargs[] = {
 
 /* MSETNX argument table */
 struct redisCommandArg MSETNX_Args[] = {
-{"key_value",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=MSETNX_key_value_Subargs},
+{"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=MSETNX_data_Subargs},
 {0}
 };
 

--- a/src/commands/bitcount.json
+++ b/src/commands/bitcount.json
@@ -45,7 +45,7 @@
                 "key_spec_index": 0
             },
             {
-                "name": "index",
+                "name": "range",
                 "type": "block",
                 "optional": true,
                 "arguments": [
@@ -58,7 +58,7 @@
                         "type": "integer"
                     },
                     {
-                        "name": "index_unit",
+                        "name": "unit",
                         "type": "oneof",
                         "optional": true,
                         "since": "7.0.0",

--- a/src/commands/bitfield.json
+++ b/src/commands/bitfield.json
@@ -50,14 +50,16 @@
                 "arguments": [
                     {
                         "token": "GET",
-                        "name": "encoding_offset",
+                        "name": "get_block",
                         "type": "block",
                         "arguments": [
                             {
-                                "name": "encoding",
+                                "name": "get_encoding",
+                                "display": "encoding",
                                 "type": "string"
                             },
                             {
+                                "name": "get_offset",
                                 "name": "offset",
                                 "type": "integer"
                             }
@@ -69,7 +71,7 @@
                         "arguments": [
                             {
                                 "token": "OVERFLOW",
-                                "name": "wrap_sat_fail",
+                                "name": "overflow_block",
                                 "type": "oneof",
                                 "optional": true,
                                 "arguments": [
@@ -96,38 +98,44 @@
                                 "arguments": [
                                     {
                                         "token": "SET",
-                                        "name": "encoding_offset_value",
+                                        "name": "set_block",
                                         "type": "block",
                                         "arguments": [
                                             {
-                                                "name": "encoding",
+                                                "name": "set_encoding",
+                                                "display": "encoding",
                                                 "type": "string"
                                             },
                                             {
-                                                "name": "offset",
+                                                "name": "set_offset",
+                                                "display": "offset",
                                                 "type": "integer"
                                             },
                                             {
-                                                "name": "value",
+                                                "name": "set_value",
+                                                "display": "value",
                                                 "type": "integer"
                                             }
                                         ]
                                     },
                                     {
                                         "token": "INCRBY",
-                                        "name": "encoding_offset_increment",
+                                        "name": "incrby_info",
                                         "type": "block",
                                         "arguments": [
                                             {
-                                                "name": "encoding",
+                                                "name": "incrby_encoding",
+                                                "display": "encoding",
                                                 "type": "string"
                                             },
                                             {
-                                                "name": "offset",
+                                                "name": "incrby_offset",
+                                                "display": "offset",
                                                 "type": "integer"
                                             },
                                             {
-                                                "name": "increment",
+                                                "name": "incrby_increment",
+                                                "display": "increment",
                                                 "type": "integer"
                                             }
                                         ]

--- a/src/commands/bitfield.json
+++ b/src/commands/bitfield.json
@@ -50,16 +50,14 @@
                 "arguments": [
                     {
                         "token": "GET",
-                        "name": "get_block",
+                        "name": "get-block",
                         "type": "block",
                         "arguments": [
                             {
-                                "name": "get_encoding",
-                                "display": "encoding",
+                                "name": "encoding",
                                 "type": "string"
                             },
                             {
-                                "name": "get_offset",
                                 "name": "offset",
                                 "type": "integer"
                             }
@@ -71,7 +69,7 @@
                         "arguments": [
                             {
                                 "token": "OVERFLOW",
-                                "name": "overflow_block",
+                                "name": "overflow-block",
                                 "type": "oneof",
                                 "optional": true,
                                 "arguments": [
@@ -93,49 +91,43 @@
                                 ]
                             },
                             {
-                                "name": "write_operation",
+                                "name": "write-operation",
                                 "type": "oneof",
                                 "arguments": [
                                     {
                                         "token": "SET",
-                                        "name": "set_block",
+                                        "name": "set-block",
                                         "type": "block",
                                         "arguments": [
                                             {
-                                                "name": "set_encoding",
-                                                "display": "encoding",
+                                                "name": "encoding",
                                                 "type": "string"
                                             },
                                             {
-                                                "name": "set_offset",
-                                                "display": "offset",
+                                                "name": "offset",
                                                 "type": "integer"
                                             },
                                             {
-                                                "name": "set_value",
-                                                "display": "value",
+                                                "name": "value",
                                                 "type": "integer"
                                             }
                                         ]
                                     },
                                     {
                                         "token": "INCRBY",
-                                        "name": "incrby_info",
+                                        "name": "incrby-block",
                                         "type": "block",
                                         "arguments": [
                                             {
-                                                "name": "incrby_encoding",
-                                                "display": "encoding",
+                                                "name": "encoding",
                                                 "type": "string"
                                             },
                                             {
-                                                "name": "incrby_offset",
-                                                "display": "offset",
+                                                "name": "offset",
                                                 "type": "integer"
                                             },
                                             {
-                                                "name": "incrby_increment",
-                                                "display": "increment",
+                                                "name": "increment",
                                                 "type": "integer"
                                             }
                                         ]

--- a/src/commands/bitfield_ro.json
+++ b/src/commands/bitfield_ro.json
@@ -41,7 +41,7 @@
             },
             {
                 "token": "GET",
-                "name": "encoding_offset",
+                "name": "get-block",
                 "type": "block",
                 "multiple": true,
                 "multiple_token": true,

--- a/src/commands/bitpos.json
+++ b/src/commands/bitpos.json
@@ -67,18 +67,20 @@
                                 "type": "integer"
                             },
                             {
-                                "name": "index_unit",
+                                "name": "unit",
                                 "type": "oneof",
                                 "optional": true,
                                 "since": "7.0.0",
                                 "arguments": [
                                     {
-                                        "name": "byte",
+                                        "name": "unit_byte",
+                                        "display": "byte",
                                         "type": "pure-token",
                                         "token": "BYTE"
                                     },
                                     {
-                                        "name": "bit",
+                                        "name": "unit_bit",
+                                        "display": "bit",
                                         "type": "pure-token",
                                         "token": "BIT"
                                     }

--- a/src/commands/bitpos.json
+++ b/src/commands/bitpos.json
@@ -58,25 +58,31 @@
                         "type": "integer"
                     },
                     {
-                        "name": "end",
-                        "type": "integer",
-                        "optional": true
-                    },
-                    {
-                        "name": "unit",
-                        "type": "oneof",
+                        "name": "end-unit-block",
+                        "type": "block",
                         "optional": true,
-                        "since": "7.0.0",
                         "arguments": [
                             {
-                                "name": "byte",
-                                "type": "pure-token",
-                                "token": "BYTE"
+                                "name": "end",
+                                "type": "integer"
                             },
                             {
-                                "name": "bit",
-                                "type": "pure-token",
-                                "token": "BIT"
+                                "name": "unit",
+                                "type": "oneof",
+                                "optional": true,
+                                "since": "7.0.0",
+                                "arguments": [
+                                    {
+                                        "name": "byte",
+                                        "type": "pure-token",
+                                        "token": "BYTE"
+                                    },
+                                    {
+                                        "name": "bit",
+                                        "type": "pure-token",
+                                        "token": "BIT"
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/src/commands/bitpos.json
+++ b/src/commands/bitpos.json
@@ -49,7 +49,7 @@
                 "type": "integer"
             },
             {
-                "name": "index",
+                "name": "range",
                 "type": "block",
                 "optional": true,
                 "arguments": [
@@ -58,33 +58,25 @@
                         "type": "integer"
                     },
                     {
-                        "name": "end_index",
-                        "type": "block",
+                        "name": "end",
+                        "type": "integer",
+                        "optional": true
+                    },
+                    {
+                        "name": "unit",
+                        "type": "oneof",
                         "optional": true,
+                        "since": "7.0.0",
                         "arguments": [
                             {
-                                "name": "end",
-                                "type": "integer"
+                                "name": "byte",
+                                "type": "pure-token",
+                                "token": "BYTE"
                             },
                             {
-                                "name": "unit",
-                                "type": "oneof",
-                                "optional": true,
-                                "since": "7.0.0",
-                                "arguments": [
-                                    {
-                                        "name": "unit_byte",
-                                        "display": "byte",
-                                        "type": "pure-token",
-                                        "token": "BYTE"
-                                    },
-                                    {
-                                        "name": "unit_bit",
-                                        "display": "bit",
-                                        "type": "pure-token",
-                                        "token": "BIT"
-                                    }
-                                ]
+                                "name": "bit",
+                                "type": "pure-token",
+                                "token": "BIT"
                             }
                         ]
                     }

--- a/src/commands/blmove.json
+++ b/src/commands/blmove.json
@@ -70,14 +70,12 @@
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "from_left",
-                        "display": "left",
+                        "name": "left",
                         "type": "pure-token",
                         "token": "LEFT"
                     },
                     {
-                        "name": "from_right",
-                        "display": "right",
+                        "name": "right",
                         "type": "pure-token",
                         "token": "RIGHT"
                     }
@@ -88,14 +86,12 @@
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "to_left",
-                        "display": "left",
+                        "name": "left",
                         "type": "pure-token",
                         "token": "LEFT"
                     },
                     {
-                        "name": "to_right",
-                        "display": "right",
+                        "name": "right",
                         "type": "pure-token",
                         "token": "RIGHT"
                     }

--- a/src/commands/blmove.json
+++ b/src/commands/blmove.json
@@ -70,12 +70,14 @@
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "left",
+                        "name": "from_left",
+                        "display": "left",
                         "type": "pure-token",
                         "token": "LEFT"
                     },
                     {
-                        "name": "right",
+                        "name": "from_right",
+                        "display": "right",
                         "type": "pure-token",
                         "token": "RIGHT"
                     }
@@ -86,12 +88,14 @@
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "left",
+                        "name": "to_left",
+                        "display": "left",
                         "type": "pure-token",
                         "token": "LEFT"
                     },
                     {
-                        "name": "right",
+                        "name": "to_right",
+                        "display": "right",
                         "type": "pure-token",
                         "token": "RIGHT"
                     }

--- a/src/commands/client-kill.json
+++ b/src/commands/client-kill.json
@@ -41,7 +41,8 @@
         ],
         "arguments": [
             {
-                "name": "ip:port",
+                "name": "old_format",
+                "display": "ip:port",
                 "type": "string",
                 "optional": true
             },
@@ -54,7 +55,7 @@
             },
             {
                 "token": "TYPE",
-                "name": "normal_master_slave_pubsub",
+                "name": "type",
                 "type": "oneof",
                 "optional": true,
                 "since": "2.8.12",
@@ -96,20 +97,23 @@
             },
             {
                 "token": "ADDR",
-                "name": "ip:port",
+                "name": "addr",
+                "display": "ip:port",
                 "type": "string",
                 "optional": true
             },
             {
                 "token": "LADDR",
-                "name": "ip:port",
+                "name": "laddr",
+                "display": "ip:port",
                 "type": "string",
                 "optional": true,
                 "since": "6.2.0"
             },
             {
                 "token": "SKIPME",
-                "name": "yes/no",
+                "name": "skipme",
+                "display": "yes/no",
                 "type": "string",
                 "optional": true
             }

--- a/src/commands/client-kill.json
+++ b/src/commands/client-kill.json
@@ -45,27 +45,26 @@
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "old_format",
+                        "name": "old-format",
                         "display": "ip:port",
                         "type": "string",
                         "deprecated_since": "2.8.12"
                     },
                     {
-                        "name": "new_format",
+                        "name": "new-format",
                         "type": "oneof",
                         "multiple": true,
                         "arguments": [
                             {
                                 "token": "ID",
-                                "name": "client_id",
-                                "display": "client-id",
+                                "name": "client-id",
                                 "type": "integer",
                                 "optional": true,
                                 "since": "2.8.12"
                             },
                             {
                                 "token": "TYPE",
-                                "name": "client_type",
+                                "name": "client-type",
                                 "type": "oneof",
                                 "optional": true,
                                 "since": "2.8.12",

--- a/src/commands/client-list.json
+++ b/src/commands/client-list.json
@@ -65,18 +65,12 @@
                 ]
             },
             {
-                "name": "id",
+                "name": "client-id",
                 "token": "ID",
-                "type": "block",
+                "type": "integer",
                 "optional": true,
-                "since": "6.2.0",
-                "arguments": [
-                    {
-                        "name": "client-id",
-                        "type": "integer",
-                        "multiple": true
-                    }
-                ]
+                "multiple": true,
+                "since": "6.2.0"
             }
         ]
     }

--- a/src/commands/client-list.json
+++ b/src/commands/client-list.json
@@ -37,7 +37,7 @@
         "arguments": [
             {
                 "token": "TYPE",
-                "name": "normal_master_replica_pubsub",
+                "name": "client-type",
                 "type": "oneof",
                 "optional": true,
                 "since": "5.0.0",

--- a/src/commands/client-reply.json
+++ b/src/commands/client-reply.json
@@ -18,7 +18,7 @@
         ],
         "arguments": [
             {
-                "name": "on_off_skip",
+                "name": "action",
                 "type": "oneof",
                 "arguments": [
                     {

--- a/src/commands/client-unblock.json
+++ b/src/commands/client-unblock.json
@@ -23,7 +23,7 @@
                 "type": "integer"
             },
             {
-                "name": "timeout_error",
+                "name": "unblock-type",
                 "type": "oneof",
                 "optional": true,
                 "arguments": [

--- a/src/commands/cluster-addslotsrange.json
+++ b/src/commands/cluster-addslotsrange.json
@@ -17,7 +17,7 @@
         ],
         "arguments": [
             {
-                "name": "start-slot_end-slot",
+                "name": "range",
                 "type": "block",
                 "multiple": true,
                 "arguments": [

--- a/src/commands/cluster-delslotsrange.json
+++ b/src/commands/cluster-delslotsrange.json
@@ -17,7 +17,7 @@
         ],
         "arguments": [
             {
-                "name": "start-slot_end-slot",
+                "name": "range",
                 "type": "block",
                 "multiple": true,
                 "arguments": [

--- a/src/commands/cluster-meet.json
+++ b/src/commands/cluster-meet.json
@@ -31,7 +31,7 @@
                 "type": "integer"
             },
             {
-                "name": "cluster_bus_port",
+                "name": "cluster-bus-port",
                 "type": "integer",
                 "optional": true,
                 "since": "4.0.0"

--- a/src/commands/cluster-reset.json
+++ b/src/commands/cluster-reset.json
@@ -17,7 +17,7 @@
         ],
         "arguments": [
             {
-                "name": "hard_soft",
+                "name": "reset-type",
                 "type": "oneof",
                 "optional": true,
                 "arguments": [

--- a/src/commands/cluster-setslot.json
+++ b/src/commands/cluster-setslot.json
@@ -25,17 +25,20 @@
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "node-id",
+                        "name": "importing",
+                        "display": "node-id",
                         "type": "string",
                         "token": "IMPORTING"
                     },
                     {
-                        "name": "node-id",
+                        "name": "migrating",
+                        "display": "node-id",
                         "type": "string",
                         "token": "MIGRATING"
                     },
                     {
-                        "name": "node-id",
+                        "name": "node",
+                        "display": "node-id",
                         "type": "string",
                         "token": "NODE"
                     },

--- a/src/commands/config-get.json
+++ b/src/commands/config-get.json
@@ -22,14 +22,8 @@
         "arguments": [
             {
                 "name": "parameter",
-                "type": "block",
-                "multiple": true,
-                "arguments": [
-                    {
-                        "name": "parameter",
-                        "type": "string"
-                    }
-                ]
+                "type": "string",
+                "multiple": true
             }
         ]
     }

--- a/src/commands/config-set.json
+++ b/src/commands/config-set.json
@@ -25,7 +25,7 @@
         ],
         "arguments": [
             {
-                "name": "parameter_value",
+                "name": "data",
                 "type": "block",
                 "multiple": true,
                 "arguments": [

--- a/src/commands/flushall.json
+++ b/src/commands/flushall.json
@@ -29,7 +29,7 @@
         ],
         "arguments": [
             {
-                "name": "flush_type",
+                "name": "flush-type",
                 "type": "oneof",
                 "optional": true,
                 "arguments": [

--- a/src/commands/flushall.json
+++ b/src/commands/flushall.json
@@ -29,7 +29,7 @@
         ],
         "arguments": [
             {
-                "name": "async",
+                "name": "flush_type",
                 "type": "oneof",
                 "optional": true,
                 "arguments": [

--- a/src/commands/flushdb.json
+++ b/src/commands/flushdb.json
@@ -29,7 +29,7 @@
         ],
         "arguments": [
             {
-                "name": "flush_type",
+                "name": "flush-type",
                 "type": "oneof",
                 "optional": true,
                 "arguments": [

--- a/src/commands/flushdb.json
+++ b/src/commands/flushdb.json
@@ -29,7 +29,7 @@
         ],
         "arguments": [
             {
-                "name": "async",
+                "name": "flush_type",
                 "type": "oneof",
                 "optional": true,
                 "arguments": [

--- a/src/commands/function-flush.json
+++ b/src/commands/function-flush.json
@@ -20,7 +20,7 @@
         ],
         "arguments": [
             {
-                "name": "async",
+                "name": "flush_type",
                 "type": "oneof",
                 "optional": true,
                 "arguments": [

--- a/src/commands/function-flush.json
+++ b/src/commands/function-flush.json
@@ -20,7 +20,7 @@
         ],
         "arguments": [
             {
-                "name": "flush_type",
+                "name": "flush-type",
                 "type": "oneof",
                 "optional": true,
                 "arguments": [

--- a/src/commands/geoadd.json
+++ b/src/commands/geoadd.json
@@ -71,7 +71,7 @@
                 "since": "6.2.0"
             },
             {
-                "name": "longitude_latitude_member",
+                "name": "data",
                 "type": "block",
                 "multiple": true,
                 "arguments": [

--- a/src/commands/georadius.json
+++ b/src/commands/georadius.json
@@ -146,7 +146,7 @@
                 "optional": true
             },
             {
-                "name": "count",
+                "name": "count_block",
                 "type": "block",
                 "optional": true,
                 "arguments": [
@@ -183,14 +183,16 @@
             },
             {
                 "token": "STORE",
-                "name": "key",
+                "name": "storekey",
+                "display": "key",
                 "type": "key",
                 "key_spec_index": 1,
                 "optional": true
             },
             {
                 "token": "STOREDIST",
-                "name": "key",
+                "name": "storedistkey",
+                "display": "key",
                 "type": "key",
                 "key_spec_index": 2,
                 "optional": true

--- a/src/commands/georadius.json
+++ b/src/commands/georadius.json
@@ -146,7 +146,7 @@
                 "optional": true
             },
             {
-                "name": "count_block",
+                "name": "count-block",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/georadius_ro.json
+++ b/src/commands/georadius_ro.json
@@ -106,7 +106,7 @@
                 "optional": true
             },
             {
-                "name": "count",
+                "name": "count_block",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/georadius_ro.json
+++ b/src/commands/georadius_ro.json
@@ -106,7 +106,7 @@
                 "optional": true
             },
             {
-                "name": "count_block",
+                "name": "count-block",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/georadiusbymember.json
+++ b/src/commands/georadiusbymember.json
@@ -136,7 +136,7 @@
                 "optional": true
             },
             {
-                "name": "count",
+                "name": "count_block",
                 "type": "block",
                 "optional": true,
                 "arguments": [
@@ -172,14 +172,16 @@
             },
             {
                 "token": "STORE",
-                "name": "key",
+                "name": "storekey",
+                "display": "key",
                 "type": "key",
                 "key_spec_index": 1,
                 "optional": true
             },
             {
                 "token": "STOREDIST",
-                "name": "key",
+                "name": "storedistkey",
+                "display": "key",
                 "type": "key",
                 "key_spec_index": 2,
                 "optional": true

--- a/src/commands/georadiusbymember.json
+++ b/src/commands/georadiusbymember.json
@@ -136,7 +136,7 @@
                 "optional": true
             },
             {
-                "name": "count_block",
+                "name": "count-block",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/georadiusbymember_ro.json
+++ b/src/commands/georadiusbymember_ro.json
@@ -96,7 +96,7 @@
                 "optional": true
             },
             {
-                "name": "count",
+                "name": "count_block",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/georadiusbymember_ro.json
+++ b/src/commands/georadiusbymember_ro.json
@@ -96,7 +96,7 @@
                 "optional": true
             },
             {
-                "name": "count_block",
+                "name": "count-block",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/geosearch.json
+++ b/src/commands/geosearch.json
@@ -49,7 +49,7 @@
                     },
                     {
                         "token": "FROMLONLAT",
-                        "name": "longitude_latitude",
+                        "name": "fromlonlat",
                         "type": "block",
                         "arguments": [
                             {
@@ -78,30 +78,26 @@
                                 "type": "double"
                             },
                             {
-                                "name": "circle_unit",
+                                "name": "unit",
                                 "type": "oneof",
                                 "arguments": [
                                     {
-                                        "name": "circle_m",
-                                        "display": "m",
+                                        "name": "m",
                                         "type": "pure-token",
                                         "token": "m"
                                     },
                                     {
-                                        "name": "circle_km",
-                                        "display": "km",
+                                        "name": "km",
                                         "type": "pure-token",
                                         "token": "km"
                                     },
                                     {
-                                        "name": "circle_ft",
-                                        "display": "ft",
+                                        "name": "ft",
                                         "type": "pure-token",
                                         "token": "ft"
                                     },
                                     {
-                                        "name": "circle_mi",
-                                        "display": "mi",
+                                        "name": "mi",
                                         "type": "pure-token",
                                         "token": "mi"
                                     }
@@ -123,30 +119,26 @@
                                 "type": "double"
                             },
                             {
-                                "name": "box_unit",
+                                "name": "unit",
                                 "type": "oneof",
                                 "arguments": [
                                     {
-                                        "name": "box_m",
-                                        "display": "m",
+                                        "name": "m",
                                         "type": "pure-token",
                                         "token": "m"
                                     },
                                     {
-                                        "name": "box_km",
-                                        "display": "km",
+                                        "name": "km",
                                         "type": "pure-token",
                                         "token": "km"
                                     },
                                     {
-                                        "name": "box_ft",
-                                        "display": "ft",
+                                        "name": "ft",
                                         "type": "pure-token",
                                         "token": "ft"
                                     },
                                     {
-                                        "name": "box_mi",
-                                        "display": "mi",
+                                        "name": "mi",
                                         "type": "pure-token",
                                         "token": "mi"
                                     }
@@ -174,7 +166,7 @@
                 ]
             },
             {
-                "name": "count_block",
+                "name": "count-block",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/geosearch.json
+++ b/src/commands/geosearch.json
@@ -78,26 +78,30 @@
                                 "type": "double"
                             },
                             {
-                                "name": "unit",
+                                "name": "circle_unit",
                                 "type": "oneof",
                                 "arguments": [
                                     {
-                                        "name": "m",
+                                        "name": "circle_m",
+                                        "display": "m",
                                         "type": "pure-token",
                                         "token": "m"
                                     },
                                     {
-                                        "name": "km",
+                                        "name": "circle_km",
+                                        "display": "km",
                                         "type": "pure-token",
                                         "token": "km"
                                     },
                                     {
-                                        "name": "ft",
+                                        "name": "circle_ft",
+                                        "display": "ft",
                                         "type": "pure-token",
                                         "token": "ft"
                                     },
                                     {
-                                        "name": "mi",
+                                        "name": "circle_mi",
+                                        "display": "mi",
                                         "type": "pure-token",
                                         "token": "mi"
                                     }
@@ -119,26 +123,30 @@
                                 "type": "double"
                             },
                             {
-                                "name": "unit",
+                                "name": "box_unit",
                                 "type": "oneof",
                                 "arguments": [
                                     {
-                                        "name": "m",
+                                        "name": "box_m",
+                                        "display": "m",
                                         "type": "pure-token",
                                         "token": "m"
                                     },
                                     {
-                                        "name": "km",
+                                        "name": "box_km",
+                                        "display": "km",
                                         "type": "pure-token",
                                         "token": "km"
                                     },
                                     {
-                                        "name": "ft",
+                                        "name": "box_ft",
+                                        "display": "ft",
                                         "type": "pure-token",
                                         "token": "ft"
                                     },
                                     {
-                                        "name": "mi",
+                                        "name": "box_mi",
+                                        "display": "mi",
                                         "type": "pure-token",
                                         "token": "mi"
                                     }
@@ -166,7 +174,7 @@
                 ]
             },
             {
-                "name": "count",
+                "name": "count_block",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/geosearchstore.json
+++ b/src/commands/geosearchstore.json
@@ -73,7 +73,7 @@
                     },
                     {
                         "token": "FROMLONLAT",
-                        "name": "longitude_latitude",
+                        "name": "fromlonlat",
                         "type": "block",
                         "arguments": [
                             {
@@ -102,26 +102,30 @@
                                 "type": "double"
                             },
                             {
-                                "name": "unit",
+                                "name": "circle_unit",
                                 "type": "oneof",
                                 "arguments": [
                                     {
-                                        "name": "m",
+                                        "name": "circle_m",
+                                        "display": "m",
                                         "type": "pure-token",
                                         "token": "m"
                                     },
                                     {
-                                        "name": "km",
+                                        "name": "circle_km",
+                                        "display": "km",
                                         "type": "pure-token",
                                         "token": "km"
                                     },
                                     {
-                                        "name": "ft",
+                                        "name": "circle_ft",
+                                        "display": "ft",
                                         "type": "pure-token",
                                         "token": "ft"
                                     },
                                     {
-                                        "name": "mi",
+                                        "name": "circle_mi",
+                                        "display": "mi",
                                         "type": "pure-token",
                                         "token": "mi"
                                     }
@@ -143,26 +147,30 @@
                                 "type": "double"
                             },
                             {
-                                "name": "unit",
+                                "name": "box_unit",
                                 "type": "oneof",
                                 "arguments": [
                                     {
-                                        "name": "m",
+                                        "name": "box_m",
+                                        "display": "m",
                                         "type": "pure-token",
                                         "token": "m"
                                     },
                                     {
-                                        "name": "km",
+                                        "name": "box_km",
+                                        "display": "km",
                                         "type": "pure-token",
                                         "token": "km"
                                     },
                                     {
-                                        "name": "ft",
+                                        "name": "box_ft",
+                                        "display": "ft",
                                         "type": "pure-token",
                                         "token": "ft"
                                     },
                                     {
-                                        "name": "mi",
+                                        "name": "box_mi",
+                                        "display": "mi",
                                         "type": "pure-token",
                                         "token": "mi"
                                     }
@@ -190,7 +198,7 @@
                 ]
             },
             {
-                "name": "count",
+                "name": "count_block",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/geosearchstore.json
+++ b/src/commands/geosearchstore.json
@@ -102,30 +102,26 @@
                                 "type": "double"
                             },
                             {
-                                "name": "circle_unit",
+                                "name": "unit",
                                 "type": "oneof",
                                 "arguments": [
                                     {
-                                        "name": "circle_m",
-                                        "display": "m",
+                                        "name": "m",
                                         "type": "pure-token",
                                         "token": "m"
                                     },
                                     {
-                                        "name": "circle_km",
-                                        "display": "km",
+                                        "name": "km",
                                         "type": "pure-token",
                                         "token": "km"
                                     },
                                     {
-                                        "name": "circle_ft",
-                                        "display": "ft",
+                                        "name": "ft",
                                         "type": "pure-token",
                                         "token": "ft"
                                     },
                                     {
-                                        "name": "circle_mi",
-                                        "display": "mi",
+                                        "name": "mi",
                                         "type": "pure-token",
                                         "token": "mi"
                                     }
@@ -147,30 +143,26 @@
                                 "type": "double"
                             },
                             {
-                                "name": "box_unit",
+                                "name": "unit",
                                 "type": "oneof",
                                 "arguments": [
                                     {
-                                        "name": "box_m",
-                                        "display": "m",
+                                        "name": "m",
                                         "type": "pure-token",
                                         "token": "m"
                                     },
                                     {
-                                        "name": "box_km",
-                                        "display": "km",
+                                        "name": "km",
                                         "type": "pure-token",
                                         "token": "km"
                                     },
                                     {
-                                        "name": "box_ft",
-                                        "display": "ft",
+                                        "name": "ft",
                                         "type": "pure-token",
                                         "token": "ft"
                                     },
                                     {
-                                        "name": "box_mi",
-                                        "display": "mi",
+                                        "name": "mi",
                                         "type": "pure-token",
                                         "token": "mi"
                                     }
@@ -198,7 +190,7 @@
                 ]
             },
             {
-                "name": "count_block",
+                "name": "count-block",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/hello.json
+++ b/src/commands/hello.json
@@ -36,7 +36,7 @@
                     },
                     {
                         "token": "AUTH",
-                        "name": "username_password",
+                        "name": "auth",
                         "type": "block",
                         "optional": true,
                         "arguments": [

--- a/src/commands/hmset.json
+++ b/src/commands/hmset.json
@@ -46,7 +46,7 @@
                 "key_spec_index": 0
             },
             {
-                "name": "field_value",
+                "name": "data",
                 "type": "block",
                 "multiple": true,
                 "arguments": [

--- a/src/commands/hset.json
+++ b/src/commands/hset.json
@@ -47,7 +47,7 @@
                 "key_spec_index": 0
             },
             {
-                "name": "field_value",
+                "name": "data",
                 "type": "block",
                 "multiple": true,
                 "arguments": [

--- a/src/commands/lcs.json
+++ b/src/commands/lcs.json
@@ -57,7 +57,7 @@
             },
             {
                 "token": "MINMATCHLEN",
-                "name": "len",
+                "name": "min-match-len",
                 "type": "integer",
                 "optional": true
             },

--- a/src/commands/lmove.json
+++ b/src/commands/lmove.json
@@ -68,14 +68,12 @@
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "from_left",
-                        "display": "left",
+                        "name": "left",
                         "type": "pure-token",
                         "token": "LEFT"
                     },
                     {
-                        "name": "from_right",
-                        "display": "right",
+                        "name": "right",
                         "type": "pure-token",
                         "token": "RIGHT"
                     }
@@ -86,14 +84,12 @@
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "to_left",
-                        "display": "left",
+                        "name": "left",
                         "type": "pure-token",
                         "token": "LEFT"
                     },
                     {
-                        "name": "to_right",
-                        "display": "right",
+                        "name": "right",
                         "type": "pure-token",
                         "token": "RIGHT"
                     }

--- a/src/commands/lmove.json
+++ b/src/commands/lmove.json
@@ -68,12 +68,14 @@
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "left",
+                        "name": "from_left",
+                        "display": "left",
                         "type": "pure-token",
                         "token": "LEFT"
                     },
                     {
-                        "name": "right",
+                        "name": "from_right",
+                        "display": "right",
                         "type": "pure-token",
                         "token": "RIGHT"
                     }
@@ -84,12 +86,14 @@
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "left",
+                        "name": "to_left",
+                        "display": "left",
                         "type": "pure-token",
                         "token": "LEFT"
                     },
                     {
-                        "name": "right",
+                        "name": "to_right",
+                        "display": "right",
                         "type": "pure-token",
                         "token": "RIGHT"
                     }

--- a/src/commands/migrate.json
+++ b/src/commands/migrate.json
@@ -133,22 +133,22 @@
                         "token": "AUTH",
                         "name": "password",
                         "type": "string",
-                        "optional": true,
                         "since": "4.0.7"
                     },
                     {
                         "token": "AUTH2",
                         "name": "username_password",
                         "type": "block",
-                        "optional": true,
                         "since": "6.0.0",
                         "arguments": [
                             {
-                                "name": "username",
+                                "name": "auth2_username",
+                                "display": "username",
                                 "type": "string"
                             },
                             {
-                                "name": "password",
+                                "name": "auth2_password",
+                                "display": "password",
                                 "type": "string"
                             }
                         ]
@@ -157,7 +157,8 @@
             },
             {
                 "token": "KEYS",
-                "name": "key",
+                "name": "keys",
+                "display": "key",
                 "type": "key",
                 "key_spec_index": 1,
                 "optional": true,

--- a/src/commands/migrate.json
+++ b/src/commands/migrate.json
@@ -87,7 +87,7 @@
                 "type": "integer"
             },
             {
-                "name": "key_or_empty_string",
+                "name": "key-selector",
                 "type": "oneof",
                 "arguments": [
                     {
@@ -96,7 +96,7 @@
                         "key_spec_index": 0
                     },
                     {
-                        "name": "empty_string",
+                        "name": "empty-string",
                         "type": "pure-token",
                         "token": "\"\""
                     }
@@ -131,24 +131,23 @@
                 "arguments": [
                     {
                         "token": "AUTH",
-                        "name": "password",
+                        "name": "auth",
+                        "display": "password",
                         "type": "string",
                         "since": "4.0.7"
                     },
                     {
                         "token": "AUTH2",
-                        "name": "username_password",
+                        "name": "auth2",
                         "type": "block",
                         "since": "6.0.0",
                         "arguments": [
                             {
-                                "name": "auth2_username",
-                                "display": "username",
+                                "name": "username",
                                 "type": "string"
                             },
                             {
-                                "name": "auth2_password",
-                                "display": "password",
+                                "name": "password",
                                 "type": "string"
                             }
                         ]

--- a/src/commands/module-loadex.json
+++ b/src/commands/module-loadex.json
@@ -39,15 +39,9 @@
             {
                 "name": "args",
                 "token": "ARGS",
-                "type": "block",
+                "type": "string",
                 "multiple": true,
-                "optional": true,
-                "arguments": [
-                    {
-                        "name": "arg",
-                        "type": "string"
-                    }
-                ]
+                "optional": true
             }
         ]
     }

--- a/src/commands/mset.json
+++ b/src/commands/mset.json
@@ -39,7 +39,7 @@
         ],
         "arguments": [
             {
-                "name": "key_value",
+                "name": "data",
                 "type": "block",
                 "multiple": true,
                 "arguments": [

--- a/src/commands/msetnx.json
+++ b/src/commands/msetnx.json
@@ -39,7 +39,7 @@
         ],
         "arguments": [
             {
-                "name": "key_value",
+                "name": "data",
                 "type": "block",
                 "multiple": true,
                 "arguments": [

--- a/src/commands/psubscribe.json
+++ b/src/commands/psubscribe.json
@@ -16,14 +16,8 @@
         "arguments": [
             {
                 "name": "pattern",
-                "type": "block",
-                "multiple": true,
-                "arguments": [
-                    {
-                        "name": "pattern",
-                        "type": "pattern"
-                    }
-                ]
+                "type": "pattern",
+                "multiple": true
             }
         ]
     }

--- a/src/commands/script-flush.json
+++ b/src/commands/script-flush.json
@@ -25,7 +25,7 @@
         ],
         "arguments": [
             {
-                "name": "flush_type",
+                "name": "flush-type",
                 "type": "oneof",
                 "optional": true,
                 "since": "6.2.0",

--- a/src/commands/script-flush.json
+++ b/src/commands/script-flush.json
@@ -25,7 +25,7 @@
         ],
         "arguments": [
             {
-                "name": "async",
+                "name": "flush_type",
                 "type": "oneof",
                 "optional": true,
                 "since": "6.2.0",

--- a/src/commands/sentinel-config.json
+++ b/src/commands/sentinel-config.json
@@ -14,18 +14,17 @@
         ],
         "arguments": [
             {
-                "name":"set_or_get",
+                "name":"action",
                 "type":"oneof",
                 "arguments":[
                     {
-                        "name":"set_param_value",
+                        "name":"set",
                         "token":"SET",
                         "type":"block",
                         "multiple":true,
                         "arguments":[
                             {
-                                "name":"set_parameter",
-                                "display":"parameter",
+                                "name":"parameter",
                                 "type":"string"
                             },
                             {
@@ -37,7 +36,7 @@
                     {
                         "token":"GET",
                         "multiple":true,
-                        "name":"get_parameter",
+                        "name":"get",
                         "display":"parameter",
                         "type":"string"
                     }

--- a/src/commands/sentinel-config.json
+++ b/src/commands/sentinel-config.json
@@ -24,7 +24,8 @@
                         "multiple":true,
                         "arguments":[
                             {
-                                "name":"parameter",
+                                "name":"set_parameter",
+                                "display":"parameter",
                                 "type":"string"
                             },
                             {
@@ -36,7 +37,8 @@
                     {
                         "token":"GET",
                         "multiple":true,
-                        "name":"parameter",
+                        "name":"get_parameter",
+                        "display":"parameter",
                         "type":"string"
                     }
                 ]

--- a/src/commands/sentinel-debug.json
+++ b/src/commands/sentinel-debug.json
@@ -14,7 +14,7 @@
         ],
         "arguments": [
             {
-                "name": "parameter_value",
+                "name": "data",
                 "type": "block",
                 "multiple": true,
                 "arguments": [

--- a/src/commands/sentinel-set.json
+++ b/src/commands/sentinel-set.json
@@ -18,7 +18,7 @@
                 "type": "string"
             },
             {
-                "name": "option_value",
+                "name": "data",
                 "type": "block",
                 "multiple": true,
                 "arguments": [

--- a/src/commands/shutdown.json
+++ b/src/commands/shutdown.json
@@ -23,7 +23,7 @@
         ],
         "arguments": [
             {
-                "name": "nosave_save",
+                "name": "save-selector",
                 "type": "oneof",
                 "optional": true,
                 "arguments": [

--- a/src/commands/sort.json
+++ b/src/commands/sort.json
@@ -71,7 +71,8 @@
             },
             {
                 "token": "BY",
-                "name": "pattern",
+                "name": "by_pattern",
+                "display": "pattern",
                 "type": "pattern",
                 "key_spec_index": 1,
                 "optional": true
@@ -94,7 +95,8 @@
             },
             {
                 "token": "GET",
-                "name": "pattern",
+                "name": "get_pattern",
+                "display": "pattern",
                 "key_spec_index": 1,
                 "type": "pattern",
                 "optional": true,

--- a/src/commands/sort.json
+++ b/src/commands/sort.json
@@ -71,7 +71,7 @@
             },
             {
                 "token": "BY",
-                "name": "by_pattern",
+                "name": "by-pattern",
                 "display": "pattern",
                 "type": "pattern",
                 "key_spec_index": 1,
@@ -79,7 +79,7 @@
             },
             {
                 "token": "LIMIT",
-                "name": "offset_count",
+                "name": "limit",
                 "type": "block",
                 "optional": true,
                 "arguments": [
@@ -95,7 +95,7 @@
             },
             {
                 "token": "GET",
-                "name": "get_pattern",
+                "name": "get-pattern",
                 "display": "pattern",
                 "key_spec_index": 1,
                 "type": "pattern",

--- a/src/commands/sort_ro.json
+++ b/src/commands/sort_ro.json
@@ -57,7 +57,7 @@
             },
             {
                 "token": "BY",
-                "name": "by_pattern",
+                "name": "by-pattern",
                 "display": "pattern",
                 "type": "pattern",
                 "key_spec_index": 1,
@@ -65,7 +65,7 @@
             },
             {
                 "token": "LIMIT",
-                "name": "offset_count",
+                "name": "limit",
                 "type": "block",
                 "optional": true,
                 "arguments": [
@@ -81,7 +81,7 @@
             },
             {
                 "token": "GET",
-                "name": "get_pattern",
+                "name": "get-pattern",
                 "display": "pattern",
                 "key_spec_index": 1,
                 "type": "pattern",

--- a/src/commands/sort_ro.json
+++ b/src/commands/sort_ro.json
@@ -57,7 +57,8 @@
             },
             {
                 "token": "BY",
-                "name": "pattern",
+                "name": "by_pattern",
+                "display": "pattern",
                 "type": "pattern",
                 "key_spec_index": 1,
                 "optional": true
@@ -80,7 +81,8 @@
             },
             {
                 "token": "GET",
-                "name": "pattern",
+                "name": "get_pattern",
+                "display": "pattern",
                 "key_spec_index": 1,
                 "type": "pattern",
                 "optional": true,

--- a/src/commands/xadd.json
+++ b/src/commands/xadd.json
@@ -114,22 +114,22 @@
                 ]
             },
             {
-                "name": "id_or_auto",
+                "name": "id-selector",
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "auto_id",
+                        "name": "auto-id",
                         "type": "pure-token",
                         "token": "*"
                     },
                     {
-                        "name": "ID",
+                        "name": "id",
                         "type": "string"
                     }
                 ]
             },
             {
-                "name": "field_value",
+                "name": "data",
                 "type": "block",
                 "multiple": true,
                 "arguments": [

--- a/src/commands/xclaim.json
+++ b/src/commands/xclaim.json
@@ -90,7 +90,7 @@
                 "optional": true
             },
             {
-                "name": "id",
+                "name": "lastid",
                 "token": "LASTID",
                 "type": "string",
                 "optional": true

--- a/src/commands/xgroup-create.json
+++ b/src/commands/xgroup-create.json
@@ -51,11 +51,11 @@
                 "type": "string"
             },
             {
-                "name": "id",
+                "name": "id_type",
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "ID",
+                        "name": "id",
                         "type": "string"
                     },
                     {

--- a/src/commands/xgroup-create.json
+++ b/src/commands/xgroup-create.json
@@ -51,7 +51,7 @@
                 "type": "string"
             },
             {
-                "name": "id_type",
+                "name": "id-selector",
                 "type": "oneof",
                 "arguments": [
                     {
@@ -59,7 +59,7 @@
                         "type": "string"
                     },
                     {
-                        "name": "new_id",
+                        "name": "new-id",
                         "type": "pure-token",
                         "token": "$"
                     }
@@ -73,7 +73,7 @@
             },
             {
                 "token": "ENTRIESREAD",
-                "name": "entries_read",
+                "name": "entries-read",
                 "type": "integer",
                 "optional": true
             }

--- a/src/commands/xgroup-setid.json
+++ b/src/commands/xgroup-setid.json
@@ -50,7 +50,7 @@
                 "type": "string"
             },
             {
-                "name": "id_block",
+                "name": "id-selector",
                 "type": "oneof",
                 "arguments": [
                     {
@@ -58,14 +58,15 @@
                         "type": "string"
                     },
                     {
-                        "name": "lastid",
+                        "name": "new-id",
                         "type": "pure-token",
                         "token": "$"
                     }
                 ]
             },
             {
-                "name": "entries_read",
+                "name": "entriesread",
+                "display": "entries-read",
                 "token": "ENTRIESREAD",
                 "type": "integer",
                 "optional": true

--- a/src/commands/xgroup-setid.json
+++ b/src/commands/xgroup-setid.json
@@ -50,15 +50,15 @@
                 "type": "string"
             },
             {
-                "name": "id",
+                "name": "id_block",
                 "type": "oneof",
                 "arguments": [
                     {
-                        "name": "ID",
+                        "name": "id",
                         "type": "string"
                     },
                     {
-                        "name": "new_id",
+                        "name": "lastid",
                         "type": "pure-token",
                         "token": "$"
                     }

--- a/src/commands/xinfo-stream.json
+++ b/src/commands/xinfo-stream.json
@@ -50,7 +50,7 @@
                 "key_spec_index": 0
             },
             {
-                "name": "full_block",
+                "name": "full-block",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/xinfo-stream.json
+++ b/src/commands/xinfo-stream.json
@@ -50,11 +50,15 @@
                 "key_spec_index": 0
             },
             {
-                "name": "full",
-                "token": "FULL",
+                "name": "full_block",
                 "type": "block",
                 "optional": true,
                 "arguments": [
+                    {
+                        "name": "full",
+                        "token": "FULL",
+                        "type": "pure-token"
+                    },
                     {
                         "token": "COUNT",
                         "name": "count",

--- a/src/commands/xreadgroup.json
+++ b/src/commands/xreadgroup.json
@@ -38,7 +38,7 @@
         "arguments": [
             {
                 "token": "GROUP",
-                "name": "group_consumer",
+                "name": "group-block",
                 "type": "block",
                 "arguments": [
                     {

--- a/src/commands/xsetid.json
+++ b/src/commands/xsetid.json
@@ -51,13 +51,13 @@
                 "type": "string"
             },
             {
-                "name": "entries_added",
+                "name": "entries-added",
                 "token": "ENTRIESADDED",
                 "type": "integer",
                 "optional": true
             },
             {
-                "name": "max_deleted_entry_id",
+                "name": "max-deleted-id",
                 "token": "MAXDELETEDID",
                 "type": "string",
                 "optional": true

--- a/src/commands/zadd.json
+++ b/src/commands/zadd.json
@@ -105,7 +105,7 @@
                 "since": "3.0.2"
             },
             {
-                "name": "score_member",
+                "name": "data",
                 "type": "block",
                 "multiple": true,
                 "arguments": [

--- a/src/commands/zrange.json
+++ b/src/commands/zrange.json
@@ -79,7 +79,7 @@
             },
             {
                 "token": "LIMIT",
-                "name": "offset_count",
+                "name": "limit",
                 "type": "block",
                 "optional": true,
                 "since": "6.2.0",

--- a/src/commands/zrangebylex.json
+++ b/src/commands/zrangebylex.json
@@ -53,7 +53,7 @@
             },
             {
                 "token": "LIMIT",
-                "name": "offset_count",
+                "name": "limit",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/zrangebyscore.json
+++ b/src/commands/zrangebyscore.json
@@ -66,7 +66,7 @@
             },
             {
                 "token": "LIMIT",
-                "name": "offset_count",
+                "name": "limit",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/zrangestore.json
+++ b/src/commands/zrangestore.json
@@ -95,7 +95,7 @@
             },
             {
                 "token": "LIMIT",
-                "name": "offset_count",
+                "name": "limit",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/zrevrangebylex.json
+++ b/src/commands/zrevrangebylex.json
@@ -53,7 +53,7 @@
             },
             {
                 "token": "LIMIT",
-                "name": "offset_count",
+                "name": "limit",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/commands/zrevrangebyscore.json
+++ b/src/commands/zrevrangebyscore.json
@@ -65,7 +65,7 @@
             },
             {
                 "token": "LIMIT",
-                "name": "offset_count",
+                "name": "limit",
                 "type": "block",
                 "optional": true,
                 "arguments": [

--- a/src/module.c
+++ b/src/module.c
@@ -1927,6 +1927,7 @@ static struct redisCommandArg *moduleCopyCommandArgs(RedisModuleCommandArg *args
         if (arg->summary) realargs[j].summary = zstrdup(arg->summary);
         if (arg->since) realargs[j].since = zstrdup(arg->since);
         if (arg->deprecated_since) realargs[j].deprecated_since = zstrdup(arg->deprecated_since);
+        if (arg->display_text) realargs[j].display_text = zstrdup(arg->display_text);
         realargs[j].flags = moduleConvertArgFlags(arg->flags);
         if (arg->subargs) realargs[j].subargs = moduleCopyCommandArgs(arg->subargs, version);
     }

--- a/src/module.c
+++ b/src/module.c
@@ -11047,6 +11047,7 @@ void moduleFreeArgs(struct redisCommandArg *args, int num_args) {
         zfree((char *)args[j].summary);
         zfree((char *)args[j].since);
         zfree((char *)args[j].deprecated_since);
+        zfree((char *)args[j].display_text);
 
         if (args[j].subargs) {
             moduleFreeArgs(args[j].subargs, args[j].num_args);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -326,6 +326,7 @@ typedef struct RedisModuleCommandArg {
     int flags;                /* The REDISMODULE_CMD_ARG_* macros. */
     const char *deprecated_since;
     struct RedisModuleCommandArg *subargs;
+    const char *display_text;
 } RedisModuleCommandArg;
 
 typedef struct {

--- a/src/server.c
+++ b/src/server.c
@@ -4428,6 +4428,7 @@ void addReplyCommandArgList(client *c, struct redisCommandArg *args, int num_arg
     addReplyArrayLen(c, num_args);
     for (int j = 0; j<num_args; j++) {
         /* Count our reply len so we don't have to use deferred reply. */
+        int has_display = 1;
         long maplen = 2;
         if (args[j].key_spec_index != -1) maplen++;
         if (args[j].token) maplen++;
@@ -4435,8 +4436,11 @@ void addReplyCommandArgList(client *c, struct redisCommandArg *args, int num_arg
         if (args[j].since) maplen++;
         if (args[j].deprecated_since) maplen++;
         if (args[j].flags) maplen++;
-        if (args[j].type == ARG_TYPE_ONEOF || args[j].type == ARG_TYPE_BLOCK)
+        if (args[j].type == ARG_TYPE_ONEOF || args[j].type == ARG_TYPE_BLOCK) {
+            has_display = 0;
             maplen++;
+        }
+        if (has_display) maplen++;
         addReplyMapLen(c, maplen);
 
         addReplyBulkCString(c, "name");
@@ -4445,6 +4449,10 @@ void addReplyCommandArgList(client *c, struct redisCommandArg *args, int num_arg
         addReplyBulkCString(c, "type");
         addReplyBulkCString(c, ARG_TYPE_STR[args[j].type]);
 
+        if (has_display) {
+            addReplyBulkCString(c, "display");
+            addReplyBulkCString(c, args[j].display ? args[j].display : args[j].name);
+        }
         if (args[j].key_spec_index != -1) {
             addReplyBulkCString(c, "key_spec_index");
             addReplyLongLong(c, args[j].key_spec_index);

--- a/src/server.c
+++ b/src/server.c
@@ -4427,7 +4427,7 @@ void addReplyCommandArgList(client *c, struct redisCommandArg *args, int num_arg
     addReplyArrayLen(c, num_args);
     for (int j = 0; j<num_args; j++) {
         /* Count our reply len so we don't have to use deferred reply. */
-        int has_display = 1;
+        int has_display_text = 1;
         long maplen = 2;
         if (args[j].key_spec_index != -1) maplen++;
         if (args[j].token) maplen++;
@@ -4436,10 +4436,10 @@ void addReplyCommandArgList(client *c, struct redisCommandArg *args, int num_arg
         if (args[j].deprecated_since) maplen++;
         if (args[j].flags) maplen++;
         if (args[j].type == ARG_TYPE_ONEOF || args[j].type == ARG_TYPE_BLOCK) {
-            has_display = 0;
+            has_display_text = 0;
             maplen++;
         }
-        if (has_display) maplen++;
+        if (has_display_text) maplen++;
         addReplyMapLen(c, maplen);
 
         addReplyBulkCString(c, "name");
@@ -4448,9 +4448,9 @@ void addReplyCommandArgList(client *c, struct redisCommandArg *args, int num_arg
         addReplyBulkCString(c, "type");
         addReplyBulkCString(c, ARG_TYPE_STR[args[j].type]);
 
-        if (has_display) {
-            addReplyBulkCString(c, "display");
-            addReplyBulkCString(c, args[j].display ? args[j].display : args[j].name);
+        if (has_display_text) {
+            addReplyBulkCString(c, "display_text");
+            addReplyBulkCString(c, args[j].display_text ? args[j].display_text : args[j].name);
         }
         if (args[j].key_spec_index != -1) {
             addReplyBulkCString(c, "key_spec_index");

--- a/src/server.h
+++ b/src/server.h
@@ -2070,6 +2070,7 @@ typedef struct redisCommandArg {
     const char *since;
     int flags;
     const char *deprecated_since;
+    const char *display;
     struct redisCommandArg *subargs;
     /* runtime populated data */
     int num_args;

--- a/src/server.h
+++ b/src/server.h
@@ -1983,7 +1983,7 @@ typedef struct {
  * 2. keynum: there's an arg that contains the number of key args somewhere before the keys themselves
  */
 
-/* Must be synced with generate-command-code.py */
+/* WARNING! Must be synced with generate-command-code.py and RedisModuleKeySpecBeginSearchType */
 typedef enum {
     KSPEC_BS_INVALID = 0, /* Must be 0 */
     KSPEC_BS_UNKNOWN,
@@ -1991,7 +1991,7 @@ typedef enum {
     KSPEC_BS_KEYWORD
 } kspec_bs_type;
 
-/* Must be synced with generate-command-code.py */
+/* WARNING! Must be synced with generate-command-code.py and RedisModuleKeySpecFindKeysType */
 typedef enum {
     KSPEC_FK_INVALID = 0, /* Must be 0 */
     KSPEC_FK_UNKNOWN,
@@ -1999,6 +1999,7 @@ typedef enum {
     KSPEC_FK_KEYNUM
 } kspec_fk_type;
 
+/* WARNING! This struct must match RedisModuleCommandKeySpec */
 typedef struct {
     /* Declarative data */
     const char *notes;
@@ -2066,6 +2067,7 @@ typedef enum {
 #define CMD_ARG_MULTIPLE        (1<<1)
 #define CMD_ARG_MULTIPLE_TOKEN  (1<<2)
 
+/* WARNING! This struct must match RedisModuleCommandArg */
 typedef struct redisCommandArg {
     const char *name;
     redisCommandArgType type;
@@ -2075,8 +2077,8 @@ typedef struct redisCommandArg {
     const char *since;
     int flags;
     const char *deprecated_since;
-    const char *display;
     struct redisCommandArg *subargs;
+    const char *display_text;
     /* runtime populated data */
     int num_args;
 } redisCommandArg;
@@ -2106,6 +2108,7 @@ typedef enum {
     RESP3_NULL,
 } redisCommandRESP3Type;
 
+/* WARNING! This struct must match RedisModuleCommandHistoryEntry */
 typedef struct {
     const char *since;
     const char *changes;

--- a/tests/modules/cmdintrospection.c
+++ b/tests/modules/cmdintrospection.c
@@ -104,7 +104,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                     {
                         .name = "threshold",
                         .type = REDISMODULE_ARG_TYPE_STRING,
-                        .display_text = "threshold" /* Just for coverage, doen't have a visible effect */
+                        .display_text = "threshold" /* Just for coverage, doesn't have a visible effect */
                     },
                     {
                         .name = "count",

--- a/tests/modules/cmdintrospection.c
+++ b/tests/modules/cmdintrospection.c
@@ -116,11 +116,11 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                 }
             },
             {
-                .name = "id_or_auto",
+                .name = "id-selector",
                 .type = REDISMODULE_ARG_TYPE_ONEOF,
                 .subargs = (RedisModuleCommandArg[]){
                     {
-                        .name = "auto_id",
+                        .name = "auto-id",
                         .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                         .token = "*"
                     },
@@ -132,7 +132,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                 }
             },
             {
-                .name = "field_value",
+                .name = "data",
                 .type = REDISMODULE_ARG_TYPE_BLOCK,
                 .flags = REDISMODULE_CMD_ARG_MULTIPLE,
                 .subargs = (RedisModuleCommandArg[]){

--- a/tests/modules/cmdintrospection.c
+++ b/tests/modules/cmdintrospection.c
@@ -104,6 +104,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                     {
                         .name = "threshold",
                         .type = REDISMODULE_ARG_TYPE_STRING,
+                        .display_text = "threshold" /* Just for coverage, doen't have a visible effect */
                     },
                     {
                         .name = "count",

--- a/utils/generate-command-code.py
+++ b/utils/generate-command-code.py
@@ -245,7 +245,7 @@ class Argument(object):
         if "deprecated_since" in self.desc:
             s += ",.deprecated_since=\"%s\"" % self.desc["deprecated_since"]
         if "display" in self.desc:
-            s += ",.display=\"%s\"" % self.desc["display"].lower()
+            s += ",.display_text=\"%s\"" % self.desc["display"].lower()
         if self.subargs:
             s += ",.subargs=%s" % self.subarg_table_name()
 

--- a/utils/generate-command-code.py
+++ b/utils/generate-command-code.py
@@ -185,11 +185,14 @@ def verify_no_dup_names(container_fullname, args):
 
 class Argument(object):
     def __init__(self, parent_name, desc):
+        self.parent_name = parent_name
         self.desc = desc
         self.name = self.desc["name"].lower()
+        if "_" in self.name:
+            print("{}: name ({}) should not contain underscores".format(self.fullname(), self.name))
+            exit(1)
         self.type = self.desc["type"]
         self.key_spec_index = self.desc.get("key_spec_index", None)
-        self.parent_name = parent_name
         self.subargs = []
         self.subargs_name = None
         if self.type in ["oneof", "block"]:


### PR DESCRIPTION
Partial fix of #10948

This PR makes sure that "name" is unique for all arguments in the same
level (i.e. all args of a command and all args within a block/oneof).
This means several argument with identical meaning can be referred to together,
but also if someone needs to refer to a specific one, they can use its full path.

In addition, the "display_text" field has been added, to be used by redis.io
in order to render the syntax of the command (for the vast majority it is
identical to "name" but sometimes we want to use a different string
that is not "name")
The "display" field is exposed via COMMAND DOCS and will be present
for every argument, except "oneof" and "block" (which are container
arguments)

Other changes:
1. Make sure we do not have any container arguments ("oneof" or "block")
   that contain less than two sub-args (otherwise it doesn't make sense)
2. migrate.json: both AUTH and AUTH2 should not be "optional"
3. arg names cannot contain underscores, and force the usage of hyphens (most of these were a result of the script that generated the initial json files from redis.io commands.json). 

- [x] go over all "name"s: make sure they make sense because soon we won't be able to modify them (people may rely on their value)
- [x] validate no underscore in "name"