### PR TITLE
fix the client type in trackingInvalidateKey()

### DIFF
--- a/src/tracking.c
+++ b/src/tracking.c
@@ -388,7 +388,7 @@ void trackingInvalidateKey(client *c, robj *keyobj, int bcast) {
         /* If the client enabled the NOLOOP mode, don't send notifications
          * about keys changed by the client itself. */
         if (target->flags & CLIENT_TRACKING_NOLOOP &&
-            target == c)
+            target == server.current_client)
         {
             continue;
         }

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -241,7 +241,7 @@ start_server {tags {"tracking network"}} {
         r HELLO 3
         r SET key1 1
         assert_equal "1" [r GET key1]
-        r eval "return redis.call('set', 'key1', '2')" 0
+        r eval "return redis.call('set', 'key1', '2')" 1 key1
         assert_equal "2" [r GET key1]
     }
 

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -208,6 +208,19 @@ start_server {tags {"tracking network"}} {
         assert {$res eq {key1}}
     }
 
+    test {Invalid keys should not be tracked for scripts in NOLOOP mode} {
+        $rd_sg CLIENT TRACKING off
+        $rd_sg CLIENT TRACKING on NOLOOP
+        $rd_sg HELLO 3
+        $rd_sg SET key1 1
+        assert_equal "1" [$rd_sg GET key1]
+
+        # For write command in script, invalid key should not be tracked with NOLOOP flag
+        $rd_sg eval "return redis.call('set', 'key1', '2')" 1 key1
+        assert_equal "2" [$rd_sg GET key1]
+        $rd_sg CLIENT TRACKING off
+    }
+
     test {Tracking only occurs for scripts when a command calls a read-only command} {
         r CLIENT TRACKING off
         r CLIENT TRACKING on
@@ -233,16 +246,6 @@ start_server {tags {"tracking network"}} {
         assert_equal {invalidate key1{t}} [r read]
 
         assert_equal "PONG" [r ping]
-    }
-
-    test {Tracking should not occur for scripts in NOLOOP mode} {
-        r CLIENT TRACKING off
-        r CLIENT TRACKING on NOLOOP
-        r HELLO 3
-        r SET key1 1
-        assert_equal "1" [r GET key1]
-        r eval "return redis.call('set', 'key1', '2')" 1 key1
-        assert_equal "2" [r GET key1]
     }
 
     test {RESP3 Client gets tracking-redir-broken push message after cached key changed when rediretion client is terminated} {

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -235,6 +235,16 @@ start_server {tags {"tracking network"}} {
         assert_equal "PONG" [r ping]
     }
 
+    test {Tracking should not occur for scripts in NOLOOP mode} {
+        r CLIENT TRACKING off
+        r CLIENT TRACKING on NOLOOP
+        r HELLO 3
+        r SET key1 1
+        assert_equal "1" [r GET key1]
+        r eval "return redis.call('set', 'key1', '2')" 0
+        assert_equal "2" [r GET key1]
+    }
+
     test {RESP3 Client gets tracking-redir-broken push message after cached key changed when rediretion client is terminated} {
         r CLIENT TRACKING on REDIRECT $redir_id
         $rd_sg SET key1 1


### PR DESCRIPTION
> Release notes: Fix bug with scripts ignoring client tracking NOLOOP

## Reproduce the bug
```
127.0.0.1:6379> hello 3
1# "server" => "redis"
2# "version" => "255.255.255"
3# "proto" => (integer) 3
4# "id" => (integer) 3
5# "mode" => "standalone"
6# "role" => "master"
7# "modules" => (empty array)
127.0.0.1:6379> CLIENT TRACKING ON OPTOUT NOLOOP
OK
127.0.0.1:6379> get k
"2"
127.0.0.1:6379> eval "return redis.call('set', 'k', '2')" 0
OK
127.0.0.1:6379> get k
-> invalidate: 'k'
"2"
127.0.0.1:6379>
```
I got unexpected `invalidate: 'k'` when set client tracking with OPTOUT NOLOOP,  fix the client type.