### PR TITLE
Avoid false positive out-of-bounds in writeForgottenNodePingExt

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2035,7 +2035,7 @@ int writeHostnamePingExt(clusterMsgPingExt **cursor) {
     (*cursor)->type = htons(CLUSTERMSG_EXT_TYPE_HOSTNAME);
     (*cursor)->length = htonl(extension_size);
     /* Make sure the string is NULL terminated by adding 1 */
-    *cursor = (clusterMsgPingExt *) (ext->hostname + EIGHT_BYTE_ALIGN(sdslen(myself->hostname) + 1));
+    *cursor = (clusterMsgPingExt *) ((intptr_t)ext + EIGHT_BYTE_ALIGN(sdslen(myself->hostname) + 1));
     return extension_size;
 }
 
@@ -2050,8 +2050,6 @@ int writeForgottenNodePingExt(clusterMsgPingExt **cursor, sds name, uint64_t ttl
     uint32_t extension_size = sizeof(clusterMsgPingExt) + sizeof(clusterMsgPingExtForgottenNode);
     (*cursor)->type = htons(CLUSTERMSG_EXT_TYPE_FORGOTTEN_NODE);
     (*cursor)->length = htonl(extension_size);
-    /* Using ext+1 instead of ext->name+sizeof(clusterMsgPingExtForgottenNode)
-     * to avoid false positive sanitizer out-of-bounds error. */
     *cursor = (clusterMsgPingExt *) (ext + 1);
     return extension_size;
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2041,7 +2041,13 @@ int writeHostnamePingExt(clusterMsgPingExt **cursor) {
 
 /* Write the forgotten node ping extension at the start of the cursor, update
  * the cursor to point to the end of the written extension and return the number
- * of bytes written. */
+ * of bytes written.
+ *
+ * Sanitizer suppression: In clusterMsgPingExtForgottenNode, sizeof(name) is
+ * CLUSTER_NAMELEN, and sizeof(clusterMsgPingExtForgottenNode) is > CLUSTER_NAMELEN.
+ * Doing a (name + sizeof(clusterMsgPingExtForgottenNode)) sanitizer generates an
+ * out-of-bounds error which is a false positive in here. */
+REDIS_NO_SANITIZE("bounds")
 int writeForgottenNodePingExt(clusterMsgPingExt **cursor, sds name, uint64_t ttl) {
     serverAssert(sdslen(name) == CLUSTER_NAMELEN);
     clusterMsgPingExtForgottenNode *ext = &(*cursor)->ext[0].forgotten_node;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2050,8 +2050,9 @@ int writeForgottenNodePingExt(clusterMsgPingExt **cursor, sds name, uint64_t ttl
     uint32_t extension_size = sizeof(clusterMsgPingExt) + sizeof(clusterMsgPingExtForgottenNode);
     (*cursor)->type = htons(CLUSTERMSG_EXT_TYPE_FORGOTTEN_NODE);
     (*cursor)->length = htonl(extension_size);
-    /* Using ext instead of ext->name to avoid false positive sanitizer out-of-bounds. */
-    *cursor = (clusterMsgPingExt *) (ext + sizeof(clusterMsgPingExtForgottenNode));
+    /* Using ext+1 instead of ext->name+sizeof(clusterMsgPingExtForgottenNode)
+     * to avoid false positive sanitizer out-of-bounds error. */
+    *cursor = (clusterMsgPingExt *) (ext + 1);
     return extension_size;
 }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2042,7 +2042,6 @@ int writeHostnamePingExt(clusterMsgPingExt **cursor) {
 /* Write the forgotten node ping extension at the start of the cursor, update
  * the cursor to point to the end of the written extension and return the number
  * of bytes written. */
-REDIS_NO_SANITIZE("bounds")
 int writeForgottenNodePingExt(clusterMsgPingExt **cursor, sds name, uint64_t ttl) {
     serverAssert(sdslen(name) == CLUSTER_NAMELEN);
     clusterMsgPingExtForgottenNode *ext = &(*cursor)->ext[0].forgotten_node;


### PR DESCRIPTION
In clusterMsgPingExtForgottenNode, sizeof(name) is CLUSTER_NAMELEN,
and sizeof(clusterMsgPingExtForgottenNode) is > CLUSTER_NAMELEN.
Doing a (name + sizeof(clusterMsgPingExtForgottenNode)) sanitizer
generates an out-of-bounds error which is a false positive in here.

Reported in test-sanitizer-undefined (clang):
```
runtime error: index 48 out of bounds for type 'char [40]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
```

In this fix, we are using ext+1 instead of ext->name+sizeof(clusterMsgPingExtForgottenNode)
to avoid false positive sanitizer out-of-bounds error. Also convert writeHostnamePingExt.

introduced in #10869