### PR TITLE
Allow loading RDB with module AUX data even if module is missing.

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3093,6 +3093,9 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             } else {
                 /* Skip the module aux data. We consider a aux data as a module metadata
                  * so we do not want to fail loading the RDB if the module is missing. */
+                if (!rdbCheckMode) {
+                    serverLog(LL_WARNING,"The RDB file contains AUX module data I can't load: no matching module '%s'", name);
+                }
                 robj *aux = rdbSkipModuleValue(rdb,name);
                 decrRefCount(aux);
                 continue; /* Read next opcode. */

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -160,7 +160,7 @@ robj *rdbLoadObject(int type, rio *rdb, sds key, int dbid, int *error);
 void backgroundSaveDoneHandler(int exitcode, int bysignal);
 int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime,int dbid);
 ssize_t rdbSaveSingleModuleAux(rio *rdb, int when, moduleType *mt);
-robj *rdbLoadCheckModuleValue(rio *rdb, char *modulename);
+robj *rdbSkipModuleValue(rio *rdb, char *modulename);
 robj *rdbLoadStringObject(rio *rdb);
 ssize_t rdbSaveStringObject(rio *rdb, robj *obj);
 ssize_t rdbSaveRawString(rio *rdb, unsigned char *s, size_t len);

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -309,7 +309,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             moduleTypeNameByID(name,moduleid);
             rdbCheckInfo("MODULE AUX for: %s", name);
 
-            robj *o = rdbLoadCheckModuleValue(&rdb,name);
+            robj *o = rdbSkipModuleValue(&rdb,name);
             decrRefCount(o);
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_FUNCTION || type == RDB_OPCODE_FUNCTION2) {


### PR DESCRIPTION
An issue that we encounter recently is a user that loaded a module that saves AUX data. The user ended up not using the module, but the RDB that was created did contain the module AUX data. The user ended up not been able to load his data without the module (even though he is not using the module).

Notice that even if the module saves nothing on the module AUX save callback, the module AUX load will still be called when loading the RDB and will failed if the module is missing. So the problem can not be solved on the module level and requires changes in Redis.

## The Solution

We believe the AUX data is used to save module metadata and it is OK to simply skip it if the module isn't loaded. This is what the PR does, if module is not loaded we just skip its AUX data. To conclude:

* Module not loaded -> skip module aux data
* Module loaded -> call the module load callback

## Other Solutions to Consider

The other solutions attempt to recognize the case where the module wrote nothing on the AUX save callback and allow loading the RDB (even if the module is missing) in this case only.
Note that we'll need some mechanism to read-head the next module type opcode so we can detect the EOF marker without damaging the parsing.

1. Skip module AUX data only if **no data was actually written to the RDB by the module AUX save** callback and the **module is not loaded**. If the module is loaded we can not skip calling the load callback because otherwise it can be considered a breaking change. So we have to pass the responsibility of **not** reading any data to the module, but the module can not know that he has nothing to read without reading something :). So we need to give the module an ability to check that there is nothing to read. We can do it with another module API, `RM_LoadHasData`, that will tell the module if something was written to the AUX field. To conclude:
    * Aux field is empty ->
      * Module not loaded -> skip
      * Module loaded -> call the module load callback, module will need to use `RM_LoadHasData` to know if there is a data to read.
    * Aux field not empty ->
      * Module not loaded -> fail
      * Module loaded -> call the module load callback.

2. Break the existing API and decide that if nothing was written on the save callback then we will not call the load callback (even if the module is exists). This can be considered a breaking change but it is easier solution then (1). To conclude:
    * Aux field is empty ->
      * Module not loaded -> skip
      * Module loaded -> skip
    * Aux field not empty ->
      * Module not loaded -> fail
      * Module loaded -> call the module load callback.

3. Same as 2 but with some datatype flag to avoid breaking change. To conclude:
    * Aux field is empty ->
      * Module not loaded -> skip
      * Module loaded -> check datatype flag to decide whether or not to call the module load callback
    * Aux field not empty ->
      * Module not loaded -> fail
      * Module loaded -> call the module load callback.

We do believe the solution in the PR is good enough but we want to hear other opinions.