### PR TITLE
Array bio_pending - Remove redundant mutex and change long-long to long

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -72,7 +72,7 @@ static list *bio_jobs[BIO_NUM_OPS];
  * objects shared with the background thread. The main thread will just wait
  * that there are no longer jobs of this type to be executed before performing
  * the sensible operation. This data is also useful for reporting. */
-static redisAtomic unsigned long bio_pending[BIO_NUM_OPS];
+static volatile unsigned long bio_pending[BIO_NUM_OPS];
 
 /* This structure represents a background Job. It is only used locally to this
  * file as the API does not expose the internals at all. */

--- a/src/bio.c
+++ b/src/bio.c
@@ -72,7 +72,7 @@ static list *bio_jobs[BIO_NUM_OPS];
  * objects shared with the background thread. The main thread will just wait
  * that there are no longer jobs of this type to be executed before performing
  * the sensible operation. This data is also useful for reporting. */
-static unsigned long long bio_pending[BIO_NUM_OPS];
+static unsigned long bio_pending[BIO_NUM_OPS];
 
 /* This structure represents a background Job. It is only used locally to this
  * file as the API does not expose the internals at all. */
@@ -265,33 +265,9 @@ void *bioProcessBackgroundJobs(void *arg) {
 }
 
 /* Return the number of pending jobs of the specified type. */
-unsigned long long bioPendingJobsOfType(int type) {
-    unsigned long long val;
-    pthread_mutex_lock(&bio_mutex[type]);
+unsigned long bioPendingJobsOfType(int type) {
+    unsigned long val;
     val = bio_pending[type];
-    pthread_mutex_unlock(&bio_mutex[type]);
-    return val;
-}
-
-/* If there are pending jobs for the specified type, the function blocks
- * and waits that the next job was processed. Otherwise the function
- * does not block and returns ASAP.
- *
- * The function returns the number of jobs still to process of the
- * requested type.
- *
- * This function is useful when from another thread, we want to wait
- * a bio.c thread to do more work in a blocking way.
- */
-unsigned long long bioWaitStepOfType(int type) {
-    unsigned long long val;
-    pthread_mutex_lock(&bio_mutex[type]);
-    val = bio_pending[type];
-    if (val != 0) {
-        pthread_cond_wait(&bio_step_cond[type],&bio_mutex[type]);
-        val = bio_pending[type];
-    }
-    pthread_mutex_unlock(&bio_mutex[type]);
     return val;
 }
 

--- a/src/bio.c
+++ b/src/bio.c
@@ -267,6 +267,7 @@ void *bioProcessBackgroundJobs(void *arg) {
 /* Return the number of pending jobs of the specified type. */
 unsigned long bioPendingJobsOfType(int type) {
     unsigned long val;
+    /* No need to use mutex to read, since value is primitive (unsigned long) */
     val = bio_pending[type];
     return val;
 }

--- a/src/bio.c
+++ b/src/bio.c
@@ -72,7 +72,7 @@ static list *bio_jobs[BIO_NUM_OPS];
  * objects shared with the background thread. The main thread will just wait
  * that there are no longer jobs of this type to be executed before performing
  * the sensible operation. This data is also useful for reporting. */
-static unsigned long bio_pending[BIO_NUM_OPS];
+static redisAtomic unsigned long bio_pending[BIO_NUM_OPS];
 
 /* This structure represents a background Job. It is only used locally to this
  * file as the API does not expose the internals at all. */

--- a/src/bio.h
+++ b/src/bio.h
@@ -34,8 +34,7 @@ typedef void lazy_free_fn(void *args[]);
 
 /* Exported API */
 void bioInit(void);
-unsigned long long bioPendingJobsOfType(int type);
-unsigned long long bioWaitStepOfType(int type);
+unsigned long bioPendingJobsOfType(int type);
 void bioKillThreads(void);
 void bioCreateCloseJob(int fd, int need_fsync);
 void bioCreateFsyncJob(int fd);

--- a/src/bio.h
+++ b/src/bio.h
@@ -35,6 +35,7 @@ typedef void lazy_free_fn(void *args[]);
 /* Exported API */
 void bioInit(void);
 unsigned long bioPendingJobsOfType(int type);
+unsigned long bioWaitStepOfType(int type);
 void bioKillThreads(void);
 void bioCreateCloseJob(int fd, int need_fsync);
 void bioCreateFsyncJob(int fd);

--- a/src/server.c
+++ b/src/server.c
@@ -5564,7 +5564,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                 "aof_base_size:%lld\r\n"
                 "aof_pending_rewrite:%d\r\n"
                 "aof_buffer_length:%zu\r\n"
-                "aof_pending_bio_fsync:%llu\r\n"
+                "aof_pending_bio_fsync:%lu\r\n"
                 "aof_delayed_fsync:%lu\r\n",
                 (long long) server.aof_current_size,
                 (long long) server.aof_rewrite_base_size,


### PR DESCRIPTION
Array `unsigned long long bio_pending[]` holds the number of pending
jobs for every OP type. The basic operations on its entries are increment, 
decrement and read. There is no real need to such big counter. Reduced
to `unsigned long`. There is also no need use mutex to read a primitive. 