### PR TITLE
Support setlocale via CONFIG operation.

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -412,7 +412,7 @@ proc-title-template "{title} {listen-addr} {server-mode}"
 # Set the local environment which is used for string comparison operations, and 
 # also affect the performance of Lua scripts. Empty String indicates the locale 
 # is derived from the environment variables.
-locale ""
+locale-collate ""
 
 ################################ SNAPSHOTTING  ################################
 

--- a/redis.conf
+++ b/redis.conf
@@ -410,7 +410,8 @@ set-proc-title yes
 proc-title-template "{title} {listen-addr} {server-mode}"
 
 # Set the local environment which is used for string comparison operations, and 
-# also affect the performance of Lua scripts. 
+# also affect the performance of Lua scripts. Empty String indicates the locale 
+# is derived from the environment variables.
 locale ""
 
 ################################ SNAPSHOTTING  ################################

--- a/redis.conf
+++ b/redis.conf
@@ -409,6 +409,10 @@ set-proc-title yes
 #
 proc-title-template "{title} {listen-addr} {server-mode}"
 
+# Set the local environment which is used for string comparison operations, and 
+# also affect the performance of Lua scripts. 
+locale ""
+
 ################################ SNAPSHOTTING  ################################
 
 # Save the DB to disk.

--- a/src/config.c
+++ b/src/config.c
@@ -2401,7 +2401,6 @@ static int isValidProcTitleTemplate(char *val, const char **err) {
     return 1;
 }
 
-
 static int updateLocaleCollate(const char **err) {
     const char *s = setlocale(LC_COLLATE, server.locale_collate);
     if (s == NULL) {

--- a/src/config.c
+++ b/src/config.c
@@ -2401,10 +2401,9 @@ static int isValidProcTitleTemplate(char *val, const char **err) {
     return 1;
 }
 
-/* Validate specified string is a valid locale string, meanwhile do
- * the setting work. */
-static int isValidLocale(char *val, const char **err) {
-    const char *s = setlocale(LC_COLLATE, val);
+
+static int updateLocale(const char **err) {
+    const char *s = setlocale(LC_COLLATE, server.locale);
     if (s == NULL) {
         *err = "Invalid locale name";
         return 0;
@@ -3007,7 +3006,7 @@ standardConfig static_configs[] = {
     createStringConfig("proc-title-template", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.proc_title_template, CONFIG_DEFAULT_PROC_TITLE_TEMPLATE, isValidProcTitleTemplate, updateProcTitleTemplate),
     createStringConfig("bind-source-addr", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.bind_source_addr, NULL, NULL, NULL),
     createStringConfig("logfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.logfile, "", NULL, NULL),
-    createStringConfig("locale", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.locale, "", isValidLocale, NULL),
+    createStringConfig("locale", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.locale, "", NULL, updateLocale),
 
     /* SDS Configs */
     createSDSConfig("masterauth", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.masterauth, NULL, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -2402,8 +2402,8 @@ static int isValidProcTitleTemplate(char *val, const char **err) {
 }
 
 
-static int updateLocale(const char **err) {
-    const char *s = setlocale(LC_COLLATE, server.locale);
+static int updateLocaleCollate(const char **err) {
+    const char *s = setlocale(LC_COLLATE, server.locale_collate);
     if (s == NULL) {
         *err = "Invalid locale name";
         return 0;
@@ -3006,7 +3006,7 @@ standardConfig static_configs[] = {
     createStringConfig("proc-title-template", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.proc_title_template, CONFIG_DEFAULT_PROC_TITLE_TEMPLATE, isValidProcTitleTemplate, updateProcTitleTemplate),
     createStringConfig("bind-source-addr", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.bind_source_addr, NULL, NULL, NULL),
     createStringConfig("logfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.logfile, "", NULL, NULL),
-    createStringConfig("locale", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.locale, "", NULL, updateLocale),
+    createStringConfig("locale-collate", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.locale_collate, "", NULL, updateLocaleCollate),
 
     /* SDS Configs */
     createSDSConfig("masterauth", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.masterauth, NULL, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -35,6 +35,7 @@
 #include <sys/stat.h>
 #include <glob.h>
 #include <string.h>
+#include <locale.h>
 
 /*-----------------------------------------------------------------------------
  * Config file name-value maps.
@@ -2400,6 +2401,13 @@ static int isValidProcTitleTemplate(char *val, const char **err) {
     return 1;
 }
 
+/* Validate specified string is a valid locale string, meanwhile do
+the setting work. */
+static int isValidLocale(char *val, const char **err) {
+    const char *s = setlocale(LC_COLLATE, val);
+    return s != NULL;
+}
+
 static int updateProcTitleTemplate(const char **err) {
     if (redisSetProcTitle(NULL) == C_ERR) {
         *err = "failed to set process title";
@@ -2995,6 +3003,7 @@ standardConfig static_configs[] = {
     createStringConfig("proc-title-template", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.proc_title_template, CONFIG_DEFAULT_PROC_TITLE_TEMPLATE, isValidProcTitleTemplate, updateProcTitleTemplate),
     createStringConfig("bind-source-addr", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.bind_source_addr, NULL, NULL, NULL),
     createStringConfig("logfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.logfile, "", NULL, NULL),
+    createStringConfig("locale", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.locale, "", isValidLocale, NULL),
 
     /* SDS Configs */
     createSDSConfig("masterauth", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.masterauth, NULL, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -2402,10 +2402,14 @@ static int isValidProcTitleTemplate(char *val, const char **err) {
 }
 
 /* Validate specified string is a valid locale string, meanwhile do
-the setting work. */
+ * the setting work. */
 static int isValidLocale(char *val, const char **err) {
     const char *s = setlocale(LC_COLLATE, val);
-    return s != NULL;
+    if (s == NULL) {
+        *err = "Invalid locale name";
+        return 0;
+    }
+    return 1;
 }
 
 static int updateProcTitleTemplate(const char **err) {

--- a/src/server.c
+++ b/src/server.c
@@ -2439,8 +2439,16 @@ void initServer(void) {
     server.cluster_drop_packet_filter = -1;
     server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
     server.reply_buffer_resizing_enabled = 1;
-    resetReplicationBuffer();
 
+    /* Make sure the locale is set on startup based on the config file.*/
+    if (setlocale(LC_COLLATE,server.locale) == NULL) {
+        serverLog(LL_WARNING, "Failed to configure LOCALE. Applying default empty string.");
+        server.locale = "";
+        setlocale(LC_COLLATE, server.locale);
+    }
+    
+    resetReplicationBuffer();
+    
     if ((server.tls_port || server.tls_replication || server.tls_cluster)
                 && tlsConfigure(&server.tls_ctx_config) == C_ERR) {
         serverLog(LL_WARNING, "Failed to configure TLS. Check logs for more info.");
@@ -6816,7 +6824,6 @@ int main(int argc, char **argv) {
 #ifdef INIT_SETPROCTITLE_REPLACEMENT
     spt_init(argc, argv);
 #endif
-    setlocale(LC_COLLATE,"");
     tzset(); /* Populates 'timezone' global. */
     zmalloc_set_oom_handler(redisOutOfMemoryHandler);
 

--- a/src/server.c
+++ b/src/server.c
@@ -2443,7 +2443,7 @@ void initServer(void) {
 
     /* Make sure the locale is set on startup based on the config file. */
     if (setlocale(LC_COLLATE,server.locale_collate) == NULL) {
-        serverLog(LL_WARNING, "Failed to configure LOCALE. %s", strerror(errno));
+        serverLog(LL_WARNING, "Failed to configure LOCALE for invalid locale name.");
         exit(1);
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -2439,16 +2439,14 @@ void initServer(void) {
     server.cluster_drop_packet_filter = -1;
     server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
     server.reply_buffer_resizing_enabled = 1;
-
-    /* Make sure the locale is set on startup based on the config file.*/
-    if (setlocale(LC_COLLATE,server.locale) == NULL) {
-        serverLog(LL_WARNING, "Failed to configure LOCALE. Applying default empty string.");
-        server.locale = "";
-        setlocale(LC_COLLATE, server.locale);
-    }
-    
     resetReplicationBuffer();
-    
+
+    /* Make sure the locale is set on startup based on the config file. */
+    if (setlocale(LC_COLLATE,server.locale) == NULL) {
+        serverLog(LL_WARNING, "Failed to configure LOCALE. %s", strerror(errno));
+        exit(1);
+    }
+
     if ((server.tls_port || server.tls_replication || server.tls_cluster)
                 && tlsConfigure(&server.tls_ctx_config) == C_ERR) {
         serverLog(LL_WARNING, "Failed to configure TLS. Check logs for more info.");

--- a/src/server.c
+++ b/src/server.c
@@ -2442,7 +2442,7 @@ void initServer(void) {
     resetReplicationBuffer();
 
     /* Make sure the locale is set on startup based on the config file. */
-    if (setlocale(LC_COLLATE,server.locale) == NULL) {
+    if (setlocale(LC_COLLATE,server.locale_collate) == NULL) {
         serverLog(LL_WARNING, "Failed to configure LOCALE. %s", strerror(errno));
         exit(1);
     }

--- a/src/server.h
+++ b/src/server.h
@@ -1943,7 +1943,7 @@ struct redisServer {
     long reply_buffer_peak_reset_time; /* The amount of time (in milliseconds) to wait between reply buffer peak resets */
     int reply_buffer_resizing_enabled; /* Is reply buffer resizing enabled (1 by default) */
     /* Local environment*/
-    char *locale;
+    char *locale_collate;
 };
 
 #define MAX_KEYS_BUFFER 256

--- a/src/server.h
+++ b/src/server.h
@@ -1942,6 +1942,8 @@ struct redisServer {
                                                 is down, doesn't affect pubsub global. */
     long reply_buffer_peak_reset_time; /* The amount of time (in milliseconds) to wait between reply buffer peak resets */
     int reply_buffer_resizing_enabled; /* Is reply buffer resizing enabled (1 by default) */
+    /* Local environment*/
+    char *locale;
 };
 
 #define MAX_KEYS_BUFFER 256

--- a/src/server.h
+++ b/src/server.h
@@ -1942,7 +1942,7 @@ struct redisServer {
                                                 is down, doesn't affect pubsub global. */
     long reply_buffer_peak_reset_time; /* The amount of time (in milliseconds) to wait between reply buffer peak resets */
     int reply_buffer_resizing_enabled; /* Is reply buffer resizing enabled (1 by default) */
-    /* Local environment*/
+    /* Local environment */
     char *locale_collate;
 };
 


### PR DESCRIPTION
Till now Redis officially supported tuning it via environment variable see #1074.
But we had other requests to allow changing it at runtime, see #799, and #11041.

Note that `strcoll()` is used as Lua comparison function and also for comparison of certain string objects in Redis, which leads to a problem that, in different regions, for some characters, the result may be different. Below is an example.
```
127.0.0.1:6333> SORT test alpha
1) "<"
2) ">"
3) ","
4) "*"
127.0.0.1:6333> CONFIG GET locale-collate
1) "locale-collate"
2) ""
127.0.0.1:6333> CONFIG SET locale-collate 1
(error) ERR CONFIG SET failed (possibly related to argument 'locale')
127.0.0.1:6333> CONFIG SET locale-collate C
OK
127.0.0.1:6333> SORT test alpha
1) "*"
2) ","
3) "<"
4) ">"
```
That will cause accidental code compatibility issues for Lua scripts and some Redis commands. This commit creates a new config parameter to control the local environment which only affects `Collate` category. Above shows how it affects `SORT` command, and below shows the influence on Lua scripts.
```
127.0.0.1:6333> CONFIG GET locale-collate
1) " locale-collate"
2) "C"
127.0.0.1:6333> EVAL "return ',' < '*'" 0
(nil)
127.0.0.1:6333> CONFIG SET locale-collate ""
OK
127.0.0.1:6333> EVAL "return ',' < '*'" 0
(integer) 1
```
