### PR TITLE
remove redundant condition in sds.c

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -106,7 +106,7 @@ sds _sdsnewlen(const void *init, size_t initlen, int trymalloc) {
     char type = sdsReqType(initlen);
     /* Empty strings are usually created in order to append. Use type 8
      * since type 5 is not good at this. */
-    if (type == SDS_TYPE_5 && initlen == 0) type = SDS_TYPE_8;
+    if (initlen == 0) type = SDS_TYPE_8;
     int hdrlen = sdsHdrSize(type);
     unsigned char *fp; /* flags pointer. */
     size_t usable;


### PR DESCRIPTION
The condition `type == HI_SDS_TYPE_5` seems to be unnecessary, so it would be better to remove it.