### PR TITLE
tracking pending invalidation message of flushdb sent wrong

### DIFF
--- a/src/tracking.c
+++ b/src/tracking.c
@@ -423,9 +423,15 @@ void trackingHandlePendingKeyInvalidations() {
         robj *key = listNodeValue(ln);
         /* current_client maybe freed, so we need to send invalidation
          * message only when current_client is still alive */
-        if (server.current_client != NULL)
-            sendTrackingMessage(server.current_client,(char *)key->ptr,sdslen(key->ptr),0);
-        decrRefCount(key);
+        if (server.current_client != NULL) {
+            if (key != NULL) {
+                sendTrackingMessage(server.current_client,(char *)key->ptr,sdslen(key->ptr),0);
+            } else {
+                sendTrackingMessage(server.current_client,shared.null[server.current_client->resp]->ptr,
+                    sdslen(shared.null[server.current_client->resp]->ptr),1);
+            }
+        }
+        if (key != NULL) decrRefCount(key);
     }
     listEmpty(server.tracking_pending_keys);
 }
@@ -455,8 +461,8 @@ void trackingInvalidateKeysOnFlush(int async) {
             client *c = listNodeValue(ln);
             if (c->flags & CLIENT_TRACKING) {
                 if (c == server.current_client) {
-                    incrRefCount(shared.null[c->resp]);
-                    listAddNodeTail(server.tracking_pending_keys,shared.null[c->resp]);
+                    /* We use a special NULL to indicate that we should send null */
+                    listAddNodeTail(server.tracking_pending_keys,NULL);
                 } else {
                     sendTrackingMessage(c,shared.null[c->resp]->ptr,sdslen(shared.null[c->resp]->ptr),1);
                 }

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -560,7 +560,7 @@ start_server {tags {"tracking network"}} {
         assert_equal $res {OK}
         # Consume the invalidate message which is after command response
         r read
-    } {invalidate *_*}
+    } {invalidate {}}
 
     # Keys are defined to be evicted 100 at a time by default.
     # If after eviction the number of keys still surpasses the limit


### PR DESCRIPTION
tracking pending invalidation message of flushdb sent by trackingHandlePendingKeyInvalidations should use proto.
This is caused by https://github.com/redis/redis/pull/11038.