### PR TITLE
Avoid spurious wakeup on deleted timer event

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -241,7 +241,6 @@ int aeDeleteTimeEvent(aeEventLoop *eventLoop, long long id)
     while(te) {
         if (te->id == id) {
             te->id = AE_DELETED_EVENT_ID;
-            te->when = MONOTIME_MAX;
             return AE_OK;
         }
         te = te->next;
@@ -264,7 +263,7 @@ static int64_t usUntilEarliestTimer(aeEventLoop *eventLoop) {
 
     aeTimeEvent *earliest = NULL;
     while (te) {
-        if (!earliest || te->when < earliest->when)
+        if ((!earliest || te->when < earliest->when) && te->id != AE_DELETED_EVENT_ID)
             earliest = te;
         te = te->next;
     }
@@ -333,7 +332,6 @@ static int processTimeEvents(aeEventLoop *eventLoop) {
                 te->when = now + retval * 1000;
             } else {
                 te->id = AE_DELETED_EVENT_ID;
-                te->when = MONOTIME_MAX;
             }
         }
         te = te->next;

--- a/src/ae.c
+++ b/src/ae.c
@@ -241,6 +241,7 @@ int aeDeleteTimeEvent(aeEventLoop *eventLoop, long long id)
     while(te) {
         if (te->id == id) {
             te->id = AE_DELETED_EVENT_ID;
+            te->when = MONOTIME_MAX;
             return AE_OK;
         }
         te = te->next;
@@ -332,6 +333,7 @@ static int processTimeEvents(aeEventLoop *eventLoop) {
                 te->when = now + retval * 1000;
             } else {
                 te->id = AE_DELETED_EVENT_ID;
+                te->when = MONOTIME_MAX;
             }
         }
         te = te->next;

--- a/src/monotonic.h
+++ b/src/monotonic.h
@@ -20,7 +20,6 @@
  * variable is associated with the monotonic clock and should not be confused
  * with other types of time.*/
 typedef uint64_t monotime;
-#define MONOTIME_MAX UINT64_MAX
 
 /* Retrieve counter of micro-seconds relative to an arbitrary point in time.  */
 extern monotime (*getMonotonicUs)(void);

--- a/src/monotonic.h
+++ b/src/monotonic.h
@@ -20,6 +20,7 @@
  * variable is associated with the monotonic clock and should not be confused
  * with other types of time.*/
 typedef uint64_t monotime;
+#define MONOTIME_MAX UINT64_MAX
 
 /* Retrieve counter of micro-seconds relative to an arbitrary point in time.  */
 extern monotime (*getMonotonicUs)(void);


### PR DESCRIPTION
A deleted timer still would be selected by `usUntilEarliestTimer` now, and result in an unnecessary wakeup(if the timer is deleted by `AE_NOMORE` returned by `aeTimeProc`, an immediate wakeup follows) . Here an untouchable time is assigned to the deleted timer to avoid the case.