### PR TITLE
Tests (cluster / sentinel): add --stop and--loop options

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -34,6 +34,7 @@ set ::leaked_fds_file [file normalize "tmp/leaked_fds.txt"]
 set ::pids {} ; # We kill everything at exit
 set ::dirs {} ; # We remove all the temp dirs at exit
 set ::run_matching {} ; # If non empty, only tests matching pattern are run.
+set ::loop 0
 
 if {[catch {cd tmp}]} {
     puts "tmp directory not found."
@@ -280,6 +281,8 @@ proc parse_options {} {
             set val2 [lindex $::argv [expr $j+2]]
             dict set ::global_config $val $val2
             incr j 2
+        } elseif {$opt eq {--loop}} {
+            set ::loop 1
         } elseif {$opt eq "--help"} {
             puts "--single <pattern>      Only runs tests specified by pattern."
             puts "--dont-clean            Keep log files on exit."
@@ -289,6 +292,7 @@ proc parse_options {} {
             puts "--tls                   Run tests in TLS mode."
             puts "--host <host>           Use hostname instead of 127.0.0.1."
             puts "--config <k> <v>        Extra config argument(s)."
+            puts "--loop                  Execute the specified set of tests forever."
             puts "--help                  Shows this help."
             exit 0
         } else {
@@ -435,6 +439,8 @@ proc check_leaks instance_types {
 # Execute all the units inside the 'tests' directory.
 proc run_tests {} {
     set tests [lsort [glob ../tests/*]]
+
+while 1 {
     foreach test $tests {
         # Remove leaked_fds file before starting
         if {$::leaked_fds_file != "" && [file exists $::leaked_fds_file]} {
@@ -462,6 +468,9 @@ proc run_tests {} {
             incr ::failed
         }
     }
+
+    if {$::loop == 0} { break }
+} ;# while 1
 }
 
 # Print a message and exists with 0 / 1 according to zero or more failures.


### PR DESCRIPTION
--stop: Blocks once the first test fails.
--loop: Execute the specified set of tests forever.
It is useful when we debug some test failures.