### PR TITLE
Solve usleep compilation warning in keyspace_events.c

### DIFF
--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -30,6 +30,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _BSD_SOURCE
 #define _DEFAULT_SOURCE /* For usleep */
 
 #include "redismodule.h"


### PR DESCRIPTION
There is a -Wimplicit-function-declaration warning in here:
```
keyspace_events.c: In function ‘KeySpace_NotificationGeneric’:
keyspace_events.c:67:9: warning: implicit declaration of function ‘usleep’; did you mean ‘sleep’? [-Wimplicit-function-declaration]
   67 |         usleep(1);
      |         ^~~~~~
      |         sleep
```

Introduced in #11016