### PR TITLE
Return ASAP when lua error is string in luaExtractErrorInformation

### DIFF
--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -1553,6 +1553,7 @@ void luaExtractErrorInformation(lua_State *lua, errorInfo *err_info) {
         err_info->line = NULL;
         err_info->source = NULL;
         err_info->ignore_err_stats_update = 0;
+        return;
     }
 
     lua_getfield(lua, -1, "err");


### PR DESCRIPTION
This is a harmless optimization/bug.
When the top of the lua stack is a string, we should not continue to use `lua_getfield` to get the table fields.