### PR TITLE
Reuse checkGoodReplicasStatus in script.c

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -181,11 +181,7 @@ int scriptPrepareForRun(scriptRunCtx *run_ctx, client *engine_client, client *ca
 
             /* Don't accept write commands if there are not enough good slaves and
              * user configured the min-slaves-to-write option. */
-            if (server.masterhost == NULL &&
-                server.repl_min_slaves_max_lag &&
-                server.repl_min_slaves_to_write &&
-                server.repl_good_slaves_count < server.repl_min_slaves_to_write)
-            {
+            if (!checkGoodReplicasStatus()) {
                 addReplyErrorObject(caller, shared.noreplicaserr);
                 return C_ERR;
             }


### PR DESCRIPTION
Small refactoring done to reuse `checkGoodReplicasStatus` in `script.c` when checking for status of good replicas.