### PR TITLE
Adding parentheses and do-while(0) to macros

### DIFF
--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -141,7 +141,7 @@
     while(!__sync_bool_compare_and_swap(&var,var,value)); \
 } while(0)
 /* Actually the builtin issues a full memory barrier by default. */
-#define atomicGetWithSync(var,dstvar) { \
+#define atomicGetWithSync(var,dstvar) do { \
     dstvar = __sync_sub_and_fetch(&var,0,__sync_synchronize); \
     ANNOTATE_HAPPENS_AFTER(&var); \
 } while(0)

--- a/src/dict.h
+++ b/src/dict.h
@@ -110,9 +110,10 @@ typedef void (dictScanBucketFunction)(dict *d, dictEntry **bucketref);
 #define DICT_HT_INITIAL_SIZE     (1<<(DICT_HT_INITIAL_EXP))
 
 /* ------------------------------- Macros ------------------------------------*/
-#define dictFreeVal(d, entry) \
-    if ((d)->type->valDestructor) \
-        (d)->type->valDestructor((d), (entry)->v.val)
+#define dictFreeVal(d, entry) do {                     \
+    if ((d)->type->valDestructor)                      \
+        (d)->type->valDestructor((d), (entry)->v.val); \
+   } while(0)
 
 #define dictSetVal(d, entry, _val_) do { \
     if ((d)->type->valDup) \
@@ -150,7 +151,7 @@ typedef void (dictScanBucketFunction)(dict *d, dictEntry **bucketref);
 #define dictMetadataSize(d) ((d)->type->dictEntryMetadataBytes \
                              ? (d)->type->dictEntryMetadataBytes(d) : 0)
 
-#define dictHashKey(d, key) (d)->type->hashFunction(key)
+#define dictHashKey(d, key) ((d)->type->hashFunction(key))
 #define dictGetKey(he) ((he)->key)
 #define dictGetVal(he) ((he)->v.val)
 #define dictGetSignedIntegerVal(he) ((he)->v.s64)
@@ -159,8 +160,8 @@ typedef void (dictScanBucketFunction)(dict *d, dictEntry **bucketref);
 #define dictSlots(d) (DICTHT_SIZE((d)->ht_size_exp[0])+DICTHT_SIZE((d)->ht_size_exp[1]))
 #define dictSize(d) ((d)->ht_used[0]+(d)->ht_used[1])
 #define dictIsRehashing(d) ((d)->rehashidx != -1)
-#define dictPauseRehashing(d) (d)->pauserehash++
-#define dictResumeRehashing(d) (d)->pauserehash--
+#define dictPauseRehashing(d) ((d)->pauserehash++)
+#define dictResumeRehashing(d) ((d)->pauserehash--)
 
 /* If our unsigned long type can store a 64 bit number, use a 64 bit PRNG. */
 #if ULONG_MAX >= 0xffffffffffffffff

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -349,15 +349,15 @@ static char *invalid_hll_err = "-INVALIDOBJ Corrupted HLL object detected";
 /* Set the value of the register at position 'regnum' to 'val'.
  * 'p' is an array of unsigned bytes. */
 #define HLL_DENSE_SET_REGISTER(p,regnum,val) do { \
-    uint8_t *_p = (uint8_t*) p; \
-    unsigned long _byte = regnum*HLL_BITS/8; \
-    unsigned long _fb = regnum*HLL_BITS&7; \
-    unsigned long _fb8 = 8 - _fb; \
-    unsigned long _v = val; \
-    _p[_byte] &= ~(HLL_REGISTER_MAX << _fb); \
-    _p[_byte] |= _v << _fb; \
-    _p[_byte+1] &= ~(HLL_REGISTER_MAX >> _fb8); \
-    _p[_byte+1] |= _v >> _fb8; \
+    uint8_t *_p = (uint8_t*) (p);                 \
+    unsigned long _byte = (regnum)*HLL_BITS/8;    \
+    unsigned long _fb = (regnum)*HLL_BITS&7;      \
+    unsigned long _fb8 = 8 - _fb;                 \
+    unsigned long _v = (val);                     \
+    _p[_byte] &= ~(HLL_REGISTER_MAX << _fb);      \
+    _p[_byte] |= _v << _fb;                       \
+    _p[_byte+1] &= ~(HLL_REGISTER_MAX >> _fb8);   \
+    _p[_byte+1] |= _v >> _fb8;                    \
 } while(0)
 
 /* Macros to access the sparse representation.

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -349,15 +349,15 @@ static char *invalid_hll_err = "-INVALIDOBJ Corrupted HLL object detected";
 /* Set the value of the register at position 'regnum' to 'val'.
  * 'p' is an array of unsigned bytes. */
 #define HLL_DENSE_SET_REGISTER(p,regnum,val) do { \
-    uint8_t *_p = (uint8_t*) (p);                 \
-    unsigned long _byte = (regnum)*HLL_BITS/8;    \
-    unsigned long _fb = (regnum)*HLL_BITS&7;      \
-    unsigned long _fb8 = 8 - _fb;                 \
-    unsigned long _v = (val);                     \
-    _p[_byte] &= ~(HLL_REGISTER_MAX << _fb);      \
-    _p[_byte] |= _v << _fb;                       \
-    _p[_byte+1] &= ~(HLL_REGISTER_MAX >> _fb8);   \
-    _p[_byte+1] |= _v >> _fb8;                    \
+    uint8_t *_p = (uint8_t*) p; \
+    unsigned long _byte = (regnum)*HLL_BITS/8; \
+    unsigned long _fb = (regnum)*HLL_BITS&7; \
+    unsigned long _fb8 = 8 - _fb; \
+    unsigned long _v = (val); \
+    _p[_byte] &= ~(HLL_REGISTER_MAX << _fb); \
+    _p[_byte] |= _v << _fb; \
+    _p[_byte+1] &= ~(HLL_REGISTER_MAX >> _fb8); \
+    _p[_byte+1] |= _v >> _fb8; \
 } while(0)
 
 /* Macros to access the sparse representation.

--- a/src/module.c
+++ b/src/module.c
@@ -363,7 +363,7 @@ typedef struct RedisModuleServerInfoData {
  * we assume default behavior, that is, Redis signals.
  * (see RM_GetThreadSafeContext) */
 #define SHOULD_SIGNAL_MODIFIED_KEYS(ctx) \
-    ctx->module? !(ctx->module->options & REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED) : 1
+    ((ctx)->module? !((ctx)->module->options & REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED) : 1)
 
 /* Server events hooks data structures and defines: this modules API
  * allow modules to subscribe to certain events in Redis, such as

--- a/src/rax.c
+++ b/src/rax.c
@@ -154,7 +154,7 @@ static inline void raxStackFree(raxStack *ts) {
  * 'nodesize'. The padding is needed to store the child pointers to aligned
  * addresses. Note that we add 4 to the node size because the node has a four
  * bytes header. */
-#define raxPadding(nodesize) ((sizeof(void*)-((nodesize+4) % sizeof(void*))) & (sizeof(void*)-1))
+#define raxPadding(nodesize) ((sizeof(void*)-(((nodesize)+4) % sizeof(void*))) & (sizeof(void*)-1))
 
 /* Return the pointer to the last child pointer in a node. For the compressed
  * nodes this is the only child pointer. */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -51,7 +51,7 @@
 
 /* This macro tells if we are in the context of a RESTORE command, and not loading an RDB or AOF. */
 #define isRestoreContext() \
-    (server.current_client == NULL || server.current_client->id == CLIENT_ID_AOF) ? 0 : 1
+    ((server.current_client == NULL || server.current_client->id == CLIENT_ID_AOF) ? 0 : 1)
 
 char* rdbFileBeingLoaded = NULL; /* used for rdb checking on read error */
 extern int rdbCheckMode;

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -98,7 +98,7 @@
 /* NOTE: WHEN ADDING NEW RDB TYPE, UPDATE rdbIsObjectType() BELOW */
 
 /* Test if a type is an object type. */
-#define rdbIsObjectType(t) ((t >= 0 && t <= 7) || (t >= 9 && t <= 19))
+#define rdbIsObjectType(t) (((t) >= 0 && (t) <= 7) || ((t) >= 9 && (t) <= 19))
 
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
 #define RDB_OPCODE_FUNCTION2  245   /* function library data */

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -91,15 +91,15 @@
     "address (ie. 120.0.0.1:7000) or space separated IP " \
     "and port (ie. 120.0.0.1 7000)\n"
 #define CLUSTER_MANAGER_MODE() (config.cluster_manager_command.name != NULL)
-#define CLUSTER_MANAGER_MASTERS_COUNT(nodes, replicas) (nodes/(replicas + 1))
+#define CLUSTER_MANAGER_MASTERS_COUNT(nodes, replicas) ((nodes)/((replicas) + 1))
 #define CLUSTER_MANAGER_COMMAND(n,...) \
-        (redisCommand(n->context, __VA_ARGS__))
+        (redisCommand((n)->context, __VA_ARGS__))
 
-#define CLUSTER_MANAGER_NODE_ARRAY_FREE(array) zfree(array->alloc)
+#define CLUSTER_MANAGER_NODE_ARRAY_FREE(array) zfree((array)->alloc)
 
 #define CLUSTER_MANAGER_PRINT_REPLY_ERROR(n, err) \
     clusterManagerLogErr("Node %s:%d replied with error:\n%s\n", \
-                         n->ip, n->port, err);
+                         (n)->ip, (n)->port, (err));
 
 #define clusterManagerLogInfo(...) \
     clusterManagerLog(CLUSTER_MANAGER_LOG_LVL_INFO,__VA_ARGS__)

--- a/src/server.h
+++ b/src/server.h
@@ -618,7 +618,7 @@ typedef enum {
 /* Using the following macro you can run code inside serverCron() with the
  * specified period, specified in milliseconds.
  * The actual resolution depends on server.hz. */
-#define run_with_period(_ms_) if ((_ms_ <= 1000/server.hz) || !(server.cronloops%((_ms_)/(1000/server.hz))))
+#define run_with_period(_ms_) if (((_ms_) <= 1000/server.hz) || !(server.cronloops%((_ms_)/(1000/server.hz))))
 
 /* We can print the stacktrace, so our assert is defined this way: */
 #define serverAssertWithInfo(_c,_o,_e) ((_e)?(void)0 : (_serverAssertWithInfo(_c,_o,#_e,__FILE__,__LINE__),redis_unreachable()))
@@ -667,8 +667,8 @@ typedef enum {
 /* Extract encver / signature from a module type ID. */
 #define REDISMODULE_TYPE_ENCVER_BITS 10
 #define REDISMODULE_TYPE_ENCVER_MASK ((1<<REDISMODULE_TYPE_ENCVER_BITS)-1)
-#define REDISMODULE_TYPE_ENCVER(id) (id & REDISMODULE_TYPE_ENCVER_MASK)
-#define REDISMODULE_TYPE_SIGN(id) ((id & ~((uint64_t)REDISMODULE_TYPE_ENCVER_MASK)) >>REDISMODULE_TYPE_ENCVER_BITS)
+#define REDISMODULE_TYPE_ENCVER(id) ((id) & REDISMODULE_TYPE_ENCVER_MASK)
+#define REDISMODULE_TYPE_SIGN(id) (((id) & ~((uint64_t)REDISMODULE_TYPE_ENCVER_MASK)) >>REDISMODULE_TYPE_ENCVER_BITS)
 
 /* Bit flags for moduleTypeAuxSaveFunc */
 #define REDISMODULE_AUX_BEFORE_RDB (1<<0)
@@ -801,14 +801,14 @@ typedef struct RedisModuleIO {
 /* Macro to initialize an IO context. Note that the 'ver' field is populated
  * inside rdb.c according to the version of the value to load. */
 #define moduleInitIOContext(iovar,mtype,rioptr,keyptr,db) do { \
-    iovar.rio = rioptr; \
-    iovar.type = mtype; \
-    iovar.bytes = 0; \
-    iovar.error = 0; \
-    iovar.ver = 0; \
-    iovar.key = keyptr; \
-    iovar.dbid = db; \
-    iovar.ctx = NULL; \
+    (iovar).rio = (rioptr); \
+    (iovar).type = (mtype); \
+    (iovar).bytes = 0; \
+    (iovar).error = 0; \
+    (iovar).ver = 0; \
+    (iovar).key = (keyptr); \
+    (iovar).dbid = (db); \
+    (iovar).ctx = NULL; \
 } while(0)
 
 /* This is a structure used to export DEBUG DIGEST capabilities to Redis
@@ -825,8 +825,8 @@ typedef struct RedisModuleDigest {
 
 /* Just start with a digest composed of all zero bytes. */
 #define moduleInitDigestContext(mdvar) do { \
-    memset(mdvar.o,0,sizeof(mdvar.o)); \
-    memset(mdvar.x,0,sizeof(mdvar.x)); \
+    memset((mdvar).o,0,sizeof((mdvar).o)); \
+    memset((mdvar).x,0,sizeof((mdvar).x)); \
 } while(0)
 
 /* Objects encoding. Some kind of objects like Strings and Hashes can be
@@ -872,10 +872,10 @@ char *getObjectTypeName(robj*);
  * we'll update it when the structure is changed, to avoid bugs like
  * bug #85 introduced exactly in this way. */
 #define initStaticStringObject(_var,_ptr) do { \
-    _var.refcount = OBJ_STATIC_REFCOUNT; \
-    _var.type = OBJ_STRING; \
-    _var.encoding = OBJ_ENCODING_RAW; \
-    _var.ptr = _ptr; \
+    (_var).refcount = OBJ_STATIC_REFCOUNT; \
+    (_var).type = OBJ_STRING; \
+    (_var).encoding = OBJ_ENCODING_RAW; \
+    (_var).ptr = _ptr; \
 } while(0)
 
 struct evictionPoolEntry; /* Defined in evict.c */

--- a/src/server.h
+++ b/src/server.h
@@ -801,14 +801,14 @@ typedef struct RedisModuleIO {
 /* Macro to initialize an IO context. Note that the 'ver' field is populated
  * inside rdb.c according to the version of the value to load. */
 #define moduleInitIOContext(iovar,mtype,rioptr,keyptr,db) do { \
-    (iovar).rio = (rioptr); \
-    (iovar).type = (mtype); \
-    (iovar).bytes = 0; \
-    (iovar).error = 0; \
-    (iovar).ver = 0; \
-    (iovar).key = (keyptr); \
-    (iovar).dbid = (db); \
-    (iovar).ctx = NULL; \
+    iovar.rio = rioptr; \
+    iovar.type = mtype; \
+    iovar.bytes = 0; \
+    iovar.error = 0; \
+    iovar.ver = 0; \
+    iovar.key = keyptr; \
+    iovar.dbid = db; \
+    iovar.ctx = NULL; \
 } while(0)
 
 /* This is a structure used to export DEBUG DIGEST capabilities to Redis

--- a/src/server.h
+++ b/src/server.h
@@ -825,8 +825,8 @@ typedef struct RedisModuleDigest {
 
 /* Just start with a digest composed of all zero bytes. */
 #define moduleInitDigestContext(mdvar) do { \
-    memset((mdvar).o,0,sizeof((mdvar).o)); \
-    memset((mdvar).x,0,sizeof((mdvar).x)); \
+    memset(mdvar.o,0,sizeof(mdvar.o)); \
+    memset(mdvar.x,0,sizeof(mdvar.x)); \
 } while(0)
 
 /* Objects encoding. Some kind of objects like Strings and Hashes can be
@@ -872,10 +872,10 @@ char *getObjectTypeName(robj*);
  * we'll update it when the structure is changed, to avoid bugs like
  * bug #85 introduced exactly in this way. */
 #define initStaticStringObject(_var,_ptr) do { \
-    (_var).refcount = OBJ_STATIC_REFCOUNT; \
-    (_var).type = OBJ_STRING; \
-    (_var).encoding = OBJ_ENCODING_RAW; \
-    (_var).ptr = _ptr; \
+    _var.refcount = OBJ_STATIC_REFCOUNT; \
+    _var.type = OBJ_STRING; \
+    _var.encoding = OBJ_ENCODING_RAW; \
+    _var.ptr = _ptr; \
 } while(0)
 
 struct evictionPoolEntry; /* Defined in evict.c */

--- a/utils/lru/lfu-simulation.c
+++ b/utils/lru/lfu-simulation.c
@@ -18,7 +18,7 @@ struct entry {
     time_t ctime;       /* Key creation time. */
 };
 
-#define to_16bit_minutes(x) (((x)/60) & 65535)
+#define to_16bit_minutes(x) ((x/60) & 65535)
 #define LFU_INIT_VAL 5
 
 /* Compute the difference in minutes between two 16 bit minutes times

--- a/utils/lru/lfu-simulation.c
+++ b/utils/lru/lfu-simulation.c
@@ -18,7 +18,7 @@ struct entry {
     time_t ctime;       /* Key creation time. */
 };
 
-#define to_16bit_minutes(x) ((x/60) & 65535)
+#define to_16bit_minutes(x) (((x)/60) & 65535)
 #define LFU_INIT_VAL 5
 
 /* Compute the difference in minutes between two 16 bit minutes times


### PR DESCRIPTION
Fixing few macros that doesn't follows most basic safety conventions
which is wrapping any usage of passed variable
with parentheses and if written more than one command, then wrap
it with do-while(0) (or parentheses).

Needless to say, whenever possible we should prefer inline functions
over using macros.