### PR TITLE
acl: bitfield with get and set|incrby can be executed with readonly permission

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2389,7 +2389,7 @@ int setGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *r
  * read-only if the BITFIELD GET subcommand is used. */
 int bitfieldGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
     keyReference *keys;
-    int readonly = 0;
+    int readonly = 1;
     UNUSED(cmd);
 
     keys = getKeysPrepareResult(result, 1);
@@ -2400,14 +2400,15 @@ int bitfieldGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResu
         int remargs = argc - i - 1; /* Remaining args other than current. */
         char *arg = argv[i]->ptr;
         if (!strcasecmp(arg, "get") && remargs >= 2) {
-            readonly = 1;
             i += 2;
         } else if ((!strcasecmp(arg, "set") || !strcasecmp(arg, "incrby")) && remargs >= 3) {
             readonly = 0;
+            i += 3;
             break;
         } else if (!strcasecmp(arg, "overflow") && remargs >= 1) {
             i += 1;
         } else {
+            readonly = 0; /* Syntax error. safer to assume non-RO. */
             break;
         }
     }

--- a/src/db.c
+++ b/src/db.c
@@ -2401,8 +2401,13 @@ int bitfieldGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResu
         char *arg = argv[i]->ptr;
         if (!strcasecmp(arg, "get") && remargs >= 2) {
             readonly = 1;
+            i += 2;
         } else if ((!strcasecmp(arg, "set") || !strcasecmp(arg, "incrby")) && remargs >= 3) {
             readonly = 0;
+            break;
+        } else if (!strcasecmp(arg, "overflow") && remargs >= 1) {
+            i += 1;
+        } else {
             break;
         }
     }

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -195,6 +195,7 @@ start_server {tags {"acl external:skip"}} {
 
         # We don't have the permission to WRITE key.
         assert_error {*NOPERM*keys*} {$r2 bitfield readstr set u4 0 1}
+        assert_error {*NOPERM*keys*} {$r2 bitfield readstr get u4 0 set u4 0 1}
         assert_error {*NOPERM*keys*} {$r2 bitfield readstr incrby u4 0 1}
     }
 


### PR DESCRIPTION
`bitfield` with `get` may not be readonly.

```
127.0.0.1:6384> acl setuser hello on nopass %R~* +@all
OK
127.0.0.1:6384> auth hello 1
OK
127.0.0.1:6384> bitfield hello set i8 0 1
(error) NOPERM this user has no permissions to access one of the keys used as arguments
127.0.0.1:6384> bitfield hello set i8 0 1 get i8 0
1) (integer) 0
2) (integer) 1
```