### PR TITLE
[PERF] use snprintf once in addReplyDouble

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -828,7 +828,9 @@ void setDeferredPushLen(client *c, void *node, long length) {
     setDeferredAggregateLen(c,node,length,'>');
 }
 
-inline void utoa(char *buf, uint32_t val, int len) {
+/* Prints to a buffer unsigned integer `val` with `len` characters.
+ * The number string is not null terminated. */
+inline void rds_utoa(char *buf, uint32_t val, int len) {
 	for(; val && len ; --len, val /= 10)
 		buf[len - 1] = "0123456789"[val % 10];
 }
@@ -848,12 +850,13 @@ void addReplyDouble(client *c, double d) {
         char dbuf[MAX_LONG_DOUBLE_CHARS+32];
         int dlen = 0;
         if (c->resp == 2) {
-            // Preserve chars before the double for $0000\r\n, and trim unused.
+            /* Preserve space for maximum header `$0000\r\n` and print double.
+             * Add resp format and send with `start` offset. */
             int dlen = snprintf(dbuf+7,sizeof(dbuf) - 7,"%.17g",d);
             int digits = digits10(dlen);
             int start = 4 - digits;
             dbuf[start] = '$';
-            utoa(dbuf+start+1,dlen,digits);
+            rds_utoa(dbuf+start+1,dlen,digits);
             dbuf[5] = '\r';
             dbuf[6] = '\n';
             dbuf[dlen+7] = '\r';

--- a/src/networking.c
+++ b/src/networking.c
@@ -844,15 +844,16 @@ void addReplyDouble(client *c, double d) {
         int dlen = 0;
         if (c->resp == 2) {
             /* In order to prepend the string length before the formatted number,
-	         * but still avoid an extra memcpy of the whole number, we reserve space
-	         * for maximum header `$0000\r\n`, print double, add the resp header in
-	         * front of it, and then send the buffer with the right `start` offset. */
+             * but still avoid an extra memcpy of the whole number, we reserve space
+             * for maximum header `$0000\r\n`, print double, add the resp header in
+             * front of it, and then send the buffer with the right `start` offset. */
             int dlen = snprintf(dbuf+7,sizeof(dbuf) - 7,"%.17g",d);
             int digits = digits10(dlen);
             int start = 4 - digits;
             dbuf[start] = '$';
 
-            /* copy `dlen` digits after '$' and before the Double */
+            /* Convert `dlen` to string, putting it's digits after '$' and before the
+	     * formatted double string. */
             for(int i = digits, val = dlen; val && i > 0 ; --i, val /= 10) {
                 dbuf[start + i] = "0123456789"[val % 10];
             }


### PR DESCRIPTION
The previous implementation calls `snprintf` twice, the second time used to
'memcpy' the output of the first, which could be a very large string.
The new implementation reserves space for the protocol header ahead
of the formatted double, and then prepends the string length ahead of it.

Measured improvement of simple ZADD of some 25%.