### PR TITLE
Update error message for ENTRIESADDED parameter of xSetID command

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2753,7 +2753,7 @@ void xsetidCommand(client *c) {
             if (getLongLongFromObjectOrReply(c,c->argv[i+1],&entries_added,NULL) != C_OK) {
                 return;
             } else if (entries_added < 0) {
-                addReplyError(c,"entries_added must be positive");
+                addReplyError(c,"entries_added can only be 0 or positive");
                 return;
             }
             i += 2;

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -790,7 +790,7 @@ start_server {tags {"stream xsetid"}} {
     test {XSETID errors on negstive offset} {
         catch {r XSETID stream 1-1 ENTRIESADDED -1 MAXDELETEDID 0-0} err
         set _ $err
-    } {ERR *must be positive}
+    } {ERR *can only be 0 or positive}
 
     test {XSETID cannot set the maximal tombstone with larger ID} {
         r DEL x


### PR DESCRIPTION
When I looked at the usage of parameter ENTRIESADDED  of xSetID internal command,
I found the condition is **entries_added < 0**, but the error message is **entries_added must be positive**
Thus they have contradiction.

I check the test cases of command xSetID, i think the 0 is acceptable, so in this PR I update the error message to
**entries_added can only be 0 or positive**