### PR TITLE
Fix overflow in redis-benchmark

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -235,13 +235,7 @@ static long long ustime(void) {
 }
 
 static long long mstime(void) {
-    struct timeval tv;
-    long long mst;
-
-    gettimeofday(&tv, NULL);
-    mst = ((long long)tv.tv_sec)*1000;
-    mst += tv.tv_usec/1000;
-    return mst;
+    return ustime()/1000;
 }
 
 static uint64_t dictSdsHash(const void *key) {

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -229,7 +229,7 @@ static long long ustime(void) {
     long long ust;
 
     gettimeofday(&tv, NULL);
-    ust = ((long)tv.tv_sec)*1000000;
+    ust = ((long long)tv.tv_sec)*1000000;
     ust += tv.tv_usec;
     return ust;
 }


### PR DESCRIPTION
Fix overflow in redis-benchmark affecting latency measurements on 32bit builds.

If `long` is 4 bytes (typical on 32 bit systems), multiplication overflows. Using `long long` will fix the issue as it is guaranteed to be at least 8 bytes. 

Also, I've added a change to reuse `ustime()` for `mstime()`. 