### PR TITLE
Fix outdated lfu-decay-time doc in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -2167,11 +2167,10 @@ rdb-save-incremental-fsync yes
 # to accumulate hits.
 #
 # The counter decay time is the time, in minutes, that must elapse in order
-# for the key counter to be divided by two (or decremented if it has a value
-# less <= 10).
+# for the key counter to be decremented.
 #
-# The default value for the lfu-decay-time is 1. A special value of 0 means to
-# decay the counter every time it happens to be scanned.
+# The default value for the lfu-decay-time is 1. A special value of 0 means we
+# will never decay the counter.
 #
 # lfu-log-factor 10
 # lfu-decay-time 1


### PR DESCRIPTION
The divided by two and less <= 10 logics were changed in 06ca9d683920da19ad53532f8cd55b54584027bc.
Now we just decrement the counter by num_periods.

The lfu-decay-time special value of 0 's meaning was actually changed in 06ca9d683920da19ad53532f8cd55b54584027bc.
Now we won't do anything on counter if lfu-decay-time is 0.