### PR TITLE
Fix Lua compile warning on GCC 12.1

### DIFF
--- a/deps/lua/src/ldump.c
+++ b/deps/lua/src/ldump.c
@@ -60,7 +60,7 @@ static void DumpVector(const void* b, int n, size_t size, DumpState* D)
 
 static void DumpString(const TString* s, DumpState* D)
 {
- if (s==NULL || getstr(s)==NULL)
+ if (s==NULL)
  {
   size_t size=0;
   DumpVar(size,D);


### PR DESCRIPTION
Fix Lua compile warning on GCC 12.1

GCC 12.1 prints a warning on compile: 
```
ldump.c: In function ‘DumpString’:
ldump.c:63:26: warning: the comparison will always evaluate as ‘false’ for the pointer operand in ‘s + 24’ must not be NULL [-Waddress]
   63 |  if (s==NULL || getstr(s)==NULL)

```

It seems correct, `getstr(s)` can't be `NULL`.  
Also, I see Lua v5.2 does not have that check: https://github.com/lua/lua/blob/v5-2/ldump.c#L63
I assume it is safe to delete this check just to silence warning. 
