### PR TITLE
some cleanup to file: bio.c

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -61,18 +61,13 @@
 #include "server.h"
 #include "bio.h"
 
+#define MASK_UNUSED_API
+
 static pthread_t bio_threads[BIO_NUM_OPS];
 static pthread_mutex_t bio_mutex[BIO_NUM_OPS];
 static pthread_cond_t bio_newjob_cond[BIO_NUM_OPS];
 static pthread_cond_t bio_step_cond[BIO_NUM_OPS];
 static list *bio_jobs[BIO_NUM_OPS];
-/* The following array is used to hold the number of pending jobs for every
- * OP type. This allows us to export the bioPendingJobsOfType() API that is
- * useful when the main thread wants to perform some operation that may involve
- * objects shared with the background thread. The main thread will just wait
- * that there are no longer jobs of this type to be executed before performing
- * the sensible operation. This data is also useful for reporting. */
-static unsigned long long bio_pending[BIO_NUM_OPS];
 
 /* This structure represents a background Job. It is only used locally to this
  * file as the API does not expose the internals at all. */
@@ -109,7 +104,6 @@ void bioInit(void) {
         pthread_cond_init(&bio_newjob_cond[j],NULL);
         pthread_cond_init(&bio_step_cond[j],NULL);
         bio_jobs[j] = listCreate();
-        bio_pending[j] = 0;
     }
 
     /* Set the stack size as by default it may be small in some system */
@@ -135,7 +129,6 @@ void bioInit(void) {
 void bioSubmitJob(int type, bio_job *job) {
     pthread_mutex_lock(&bio_mutex[type]);
     listAddNodeTail(bio_jobs[type],job);
-    bio_pending[type]++;
     pthread_cond_signal(&bio_newjob_cond[type]);
     pthread_mutex_unlock(&bio_mutex[type]);
 }
@@ -257,22 +250,25 @@ void *bioProcessBackgroundJobs(void *arg) {
          * jobs to process we'll block again in pthread_cond_wait(). */
         pthread_mutex_lock(&bio_mutex[type]);
         listDelNode(bio_jobs[type],ln);
-        bio_pending[type]--;
 
+#ifndef MASK_UNUSED_API
         /* Unblock threads blocked on bioWaitStepOfType() if any. */
         pthread_cond_broadcast(&bio_step_cond[type]);
+#endif
     }
 }
 
 /* Return the number of pending jobs of the specified type. */
-unsigned long long bioPendingJobsOfType(int type) {
+unsigned long bioPendingJobsOfType(int type) {
     unsigned long long val;
     pthread_mutex_lock(&bio_mutex[type]);
-    val = bio_pending[type];
+    val = listLength(bio_jobs[type]);
     pthread_mutex_unlock(&bio_mutex[type]);
+    return val;
     return val;
 }
 
+#ifndef MASK_UNUSED_API
 /* If there are pending jobs for the specified type, the function blocks
  * and waits that the next job was processed. Otherwise the function
  * does not block and returns ASAP.
@@ -286,14 +282,15 @@ unsigned long long bioPendingJobsOfType(int type) {
 unsigned long long bioWaitStepOfType(int type) {
     unsigned long long val;
     pthread_mutex_lock(&bio_mutex[type]);
-    val = bio_pending[type];
+    val = listLength(bio_jobs[type]);
     if (val != 0) {
         pthread_cond_wait(&bio_step_cond[type],&bio_mutex[type]);
-        val = bio_pending[type];
+        val = listLength(bio_jobs[type]);
     }
     pthread_mutex_unlock(&bio_mutex[type]);
     return val;
 }
+#endif
 
 /* Kill the running bio threads in an unclean way. This function should be
  * used only when it's critical to stop the threads for some reason.

--- a/src/bio.c
+++ b/src/bio.c
@@ -61,8 +61,6 @@
 #include "server.h"
 #include "bio.h"
 
-#define MASK_UNUSED_API
-
 static pthread_t bio_threads[BIO_NUM_OPS];
 static pthread_mutex_t bio_mutex[BIO_NUM_OPS];
 static pthread_cond_t bio_newjob_cond[BIO_NUM_OPS];

--- a/src/bio.c
+++ b/src/bio.c
@@ -256,7 +256,6 @@ unsigned long bioPendingJobsOfType(int type) {
     val = listLength(bio_jobs[type]);
     pthread_mutex_unlock(&bio_mutex[type]);
     return val;
-    return val;
 }
 
 /* Kill the running bio threads in an unclean way. This function should be

--- a/src/bio.h
+++ b/src/bio.h
@@ -35,7 +35,6 @@ typedef void lazy_free_fn(void *args[]);
 /* Exported API */
 void bioInit(void);
 unsigned long bioPendingJobsOfType(int type);
-unsigned long long bioWaitStepOfType(int type);
 void bioKillThreads(void);
 void bioCreateCloseJob(int fd, int need_fsync);
 void bioCreateFsyncJob(int fd);

--- a/src/bio.h
+++ b/src/bio.h
@@ -34,7 +34,7 @@ typedef void lazy_free_fn(void *args[]);
 
 /* Exported API */
 void bioInit(void);
-unsigned long long bioPendingJobsOfType(int type);
+unsigned long bioPendingJobsOfType(int type);
 unsigned long long bioWaitStepOfType(int type);
 void bioKillThreads(void);
 void bioCreateCloseJob(int fd, int need_fsync);

--- a/src/server.c
+++ b/src/server.c
@@ -5563,7 +5563,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                 "aof_base_size:%lld\r\n"
                 "aof_pending_rewrite:%d\r\n"
                 "aof_buffer_length:%zu\r\n"
-                "aof_pending_bio_fsync:%llu\r\n"
+                "aof_pending_bio_fsync:%lu\r\n"
                 "aof_delayed_fsync:%lu\r\n",
                 (long long) server.aof_current_size,
                 (long long) server.aof_rewrite_base_size,


### PR DESCRIPTION
- Remove redundant array bio_pending[]. Value at index i in array identically reflects 
the length of array list bio_jobs[i]. Better to use directly list length getter instead of
having another array. No critical section issues to concern about.

- Changed returned value of bioPendingJobsOfType() from "long long" to "long". 
(type of array length is only 'long') 

- Masked unused API. Maybe we will use this API later. Let's keep it for now.