### PR TITLE
Add 2 test cases for XDEL and XGROUP CREATE command

### DIFF
--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -11,26 +11,26 @@ start_server {
 
     test {XGROUP CREATE: with ENTRIESREAD parameter} {
         r DEL mystream
-	r XADD mystream 1-1 a 1
-	r XADD mystream 1-2 b 2
-	r XADD mystream 1-3 c 3
-	r XADD mystream 1-4 d 4
+        r XADD mystream 1-1 a 1
+        r XADD mystream 1-2 b 2
+        r XADD mystream 1-3 c 3
+        r XADD mystream 1-4 d 4
         assert_error "*value for ENTRIESREAD must be positive or -1*" {r XGROUP CREATE mystream mygroup $ ENTRIESREAD -3}
 
-	r XGROUP CREATE mystream mygroup1 $ ENTRIESREAD 0
-	r XGROUP CREATE mystream mygroup2 $ ENTRIESREAD 3
+        r XGROUP CREATE mystream mygroup1 $ ENTRIESREAD 0
+        r XGROUP CREATE mystream mygroup2 $ ENTRIESREAD 3
 
-	set reply [r xinfo groups mystream]
-	foreach group_info $reply {
-	   set group_name [dict get $group_info name]
-           set entries_read [dict get $group_info entries-read]
-	   if {$group_name == "mygroup1"} {
-		assert_equal $entries_read 0
-	   } else {
-		assert_equal $entries_read 3
-	   }
-	}
-    } 
+        set reply [r xinfo groups mystream]
+        foreach group_info $reply {
+            set group_name [dict get $group_info name]
+            set entries_read [dict get $group_info entries-read]
+            if {$group_name == "mygroup1"} {
+                assert_equal $entries_read 0
+            } else {
+                assert_equal $entries_read 3
+            }
+        }
+    }
 
     test {XGROUP CREATE: automatic stream creation fails without MKSTREAM} {
         r DEL mystream

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -22,11 +22,11 @@ start_server {
 
 	set reply [r xinfo groups mystream]
         set group_info1 [lindex $reply 0]
-        set entries_read1 [lindex $group_info1 9]
+        set entries_read1 [dict get $group_info1 entries-read]
         assert_equal $entries_read1 0
 
         set group_info2 [lindex $reply 1]
-        set entries_read2 [lindex $group_info2 9]
+        set entries_read2 [dict get $group_info2 entries-read]
         assert_equal $entries_read2 3
     } 
 

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -21,13 +21,15 @@ start_server {
 	r XGROUP CREATE mystream mygroup2 $ ENTRIESREAD 3
 
 	set reply [r xinfo groups mystream]
-        set group_info1 [lindex $reply 0]
-        set entries_read1 [dict get $group_info1 entries-read]
-        assert_equal $entries_read1 0
-
-        set group_info2 [lindex $reply 1]
-        set entries_read2 [dict get $group_info2 entries-read]
-        assert_equal $entries_read2 3
+	foreach group_info $reply {
+	   set group_name [dict get $group_info name]
+           set entries_read [dict get $group_info entries-read]
+	   if {$group_name == "mygroup1"} {
+		assert_equal $entries_read 0
+	   } else {
+		assert_equal $entries_read 3
+	   }
+	}
     } 
 
     test {XGROUP CREATE: automatic stream creation fails without MKSTREAM} {

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -9,6 +9,27 @@ start_server {
         set err
     } {BUSYGROUP*}
 
+    test {XGROUP CREATE: with ENTRIESREAD parameter} {
+        r DEL mystream
+	r XADD mystream 1-1 a 1
+	r XADD mystream 1-2 b 2
+	r XADD mystream 1-3 c 3
+	r XADD mystream 1-4 d 4
+        assert_error "*value for ENTRIESREAD must be positive or -1*" {r XGROUP CREATE mystream mygroup $ ENTRIESREAD -3}
+
+	r XGROUP CREATE mystream mygroup1 $ ENTRIESREAD 0
+	r XGROUP CREATE mystream mygroup2 $ ENTRIESREAD 3
+
+	set reply [r xinfo groups mystream]
+        set group_info1 [lindex $reply 0]
+        set entries_read1 [lindex $group_info1 9]
+        assert_equal $entries_read1 0
+
+        set group_info2 [lindex $reply 1]
+        set entries_read2 [lindex $group_info2 9]
+        assert_equal $entries_read2 3
+    } 
+
     test {XGROUP CREATE: automatic stream creation fails without MKSTREAM} {
         r DEL mystream
         catch {r XGROUP CREATE mystream mygroup $} err

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -471,14 +471,14 @@ start_server {
 
     test {XDEL multiply id test} {
         r del somestream
-	r xadd somestream 1-1 a 1
-	r xadd somestream 1-2 b 2
-	r xadd somestream 1-3 c 3
-	r xadd somestream 1-4 d 4
-	r xadd somestream 1-5 e 5
-	assert {[r xlen somestream] == 5}
-	assert {[r xdel somestream 1-1 1-4 1-5 2-1] == 3}
-	assert {[r xlen somestream] == 2}
+        r xadd somestream 1-1 a 1
+        r xadd somestream 1-2 b 2
+        r xadd somestream 1-3 c 3
+        r xadd somestream 1-4 d 4
+        r xadd somestream 1-5 e 5
+        assert {[r xlen somestream] == 5}
+        assert {[r xdel somestream 1-1 1-4 1-5 2-1] == 3}
+        assert {[r xlen somestream] == 2}
         set result [r xrange somestream - +]
         assert {[dict get [lindex $result 0 1] b] eq {2}}
         assert {[dict get [lindex $result 1 1] c] eq {3}}

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -480,8 +480,8 @@ start_server {
 	assert {[r xdel somestream 1-1 1-4 1-5 2-1] == 3}
 	assert {[r xlen somestream] == 2}
         set result [r xrange somestream - +]
-        assert {[lindex $result 0 1 1] eq {2}}
-        assert {[lindex $result 1 1 1] eq {3}}
+        assert {[dict get [lindex $result 0 1] b] eq {2}}
+        assert {[dict get [lindex $result 1 1] c] eq {3}}
     }
     # Here the idea is to check the consistency of the stream data structure
     # as we remove all the elements down to zero elements.

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -469,6 +469,20 @@ start_server {
         assert {[lindex $result 1 1 1] eq {value2}}
     }
 
+    test {XDEL multiply id test} {
+        r del somestream
+	r xadd somestream 1-1 a 1
+	r xadd somestream 1-2 b 2
+	r xadd somestream 1-3 c 3
+	r xadd somestream 1-4 d 4
+	r xadd somestream 1-5 e 5
+	assert {[r xlen somestream] == 5}
+	assert {[r xdel somestream 1-1 1-4 1-5 2-1] == 3}
+	assert {[r xlen somestream] == 2}
+        set result [r xrange somestream - +]
+        assert {[lindex $result 0 1 1] eq {2}}
+        assert {[lindex $result 1 1 1] eq {3}}
+    }
     # Here the idea is to check the consistency of the stream data structure
     # as we remove all the elements down to zero elements.
     test {XDEL fuzz test} {


### PR DESCRIPTION
This PR includes 2 missed test cases of XDEL and XGROUP CREATE command

1. one test case: XDEL delete multiply id once
2. 3 test cases:  XGROUP CREATE has ENTRIESREAD parameter, which equal 0 (special positive number), 3 and negative value.
