### PR TITLE
Fix CLUSTERDOWN issue in cluster reshard unblock test

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -6929,8 +6929,8 @@ int clusterRedirectBlockedClientIfNeeded(client *c) {
             return 1;
         }
 
-        /* If the client is blocked on module, but ont on a specific key,
-         * don't unblock it (except for the CLSUTER_FAIL case above). */
+        /* If the client is blocked on module, but not on a specific key,
+         * don't unblock it (except for the CLUSTER_FAIL case above). */
         if (c->btype == BLOCKED_MODULE && !moduleClientIsBlockedOnKeys(c))
             return 0;
 

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -57,7 +57,7 @@ start_multiple_servers 3 [list overrides $base_conf] {
         # this (read) will wait for the node3 to realize the new topology and then unblock via MOVED,
         # or it will unblock with CLUSTERDOWN, depending on the cluster state when clientsCron is called.
         catch {$node3_rd read} err
-        assert {([string range $err 0 4] eq {MOVED}) || ([string range $err 0 10] eq {CLUSTERDOWN})}
+        assert {[string match "*MOVED*" $err] || [string match "*CLUSTERDOWN*" $err]}
 
         # verify there are no blocked clients
         assert_equal [s 0 blocked_clients]  {0}

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -10,7 +10,7 @@ set ::singledb 1
 tags {tls:skip external:skip cluster} {
 
 # start three servers
-set base_conf [list cluster-enabled yes cluster-node-timeout 1]
+set base_conf [list cluster-enabled yes cluster-node-timeout 1000]
 start_multiple_servers 3 [list overrides $base_conf] {
 
     set node1 [srv 0 client]
@@ -54,10 +54,8 @@ start_multiple_servers 3 [list overrides $base_conf] {
     }
 
     test "Verify command got unblocked after resharding" {
-        # this (read) will wait for the node3 to realize the new topology and then unblock via MOVED,
-        # or it will unblock with CLUSTERDOWN, depending on the cluster state when clientsCron is called.
-        catch {$node3_rd read} err
-        assert {[string match "*MOVED*" $err] || [string match "*CLUSTERDOWN*" $err]}
+        # this (read) will wait for the node3 to realize the new topology
+        assert_error {*MOVED*} {$node3_rd read}
 
         # verify there are no blocked clients
         assert_equal [s 0 blocked_clients]  {0}


### PR DESCRIPTION
A timing issue like this was reported in freebsd daily CI:
```
*** [err]: Verify command got unblocked after resharding in tests/unit/cluster/cli.tcl
Expected 'CLUSTERDOWN The cluster is down' to match '*MOVED*'
```

The reason is, in clusterRedirectBlockedClientIfNeeded (which is
called by clientsCron), it is possible for the client to unblock
because of CLUSTERDOWN, depending on the cluster state when clientsCron
is called.

The cluster-down might be because cluster-node-timeout is set to 1.
In this fix, we change the cluster-node-timeout from 1 to 1000.
It will stabilize the test a bit. And additionally fix some typos.
