### PR TITLE
fix hincrbyfloat not to create a key if the new value is invalid

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -666,6 +666,10 @@ void hincrbyfloatCommand(client *c) {
     unsigned int vlen;
 
     if (getLongDoubleFromObjectOrReply(c,c->argv[3],&incr,NULL) != C_OK) return;
+    if (isnan(incr) || isinf(incr)) {
+        addReplyError(c,"value is NaN or Infinity");
+        return;
+    }
     if ((o = hashTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
     if (hashTypeGetValue(o,c->argv[2]->ptr,&vstr,&vlen,&ll) == C_OK) {
         if (vstr) {

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -819,11 +819,8 @@ start_server {tags {"hash"}} {
         set _ $k
     } {ZIP_INT_8B 127 ZIP_INT_16B 32767 ZIP_INT_32B 2147483647 ZIP_INT_64B 9223372036854775808 ZIP_INT_IMM_MIN 0 ZIP_INT_IMM_MAX 12}
 
-    if {!$::valgrind} {
-        test {HINCRBYFLOAT does not allow NaN or Infinity} {
-            catch {r hincrbyfloat hfoo field +inf} err
-            assert_match "*would produce*" $err
-            assert_equal 0 [r exists hfoo]
-        }
+    test {HINCRBYFLOAT does not allow NaN or Infinity} {
+        assert_error "*value is NaN or Infinity*" {r hincrbyfloat hfoo field +inf}
+        assert_equal 0 [r exists hfoo]
     }
 }

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -819,4 +819,11 @@ start_server {tags {"hash"}} {
         set _ $k
     } {ZIP_INT_8B 127 ZIP_INT_16B 32767 ZIP_INT_32B 2147483647 ZIP_INT_64B 9223372036854775808 ZIP_INT_IMM_MIN 0 ZIP_INT_IMM_MAX 12}
 
+    if {!$::valgrind} {
+        test {HINCRBYFLOAT does not allow NaN or Infinity} {
+            catch {r hincrbyfloat hfoo field +inf} err
+            assert_match "*would produce*" $err
+            assert_equal 0 [r exists hfoo]
+        }
+    }
 }


### PR DESCRIPTION
Check the validity of the value before performing the create operation, prevents new data from being generated even if the request fails to execute.