### PR TITLE
Remove the NONDETERMINISTIC_OUTPUT flag from most CLUSTER sub-commands.

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -229,10 +229,7 @@ struct redisCommandArg SETBIT_Args[] = {
 #define CLUSTER_ADDSLOTS_History NULL
 
 /* CLUSTER ADDSLOTS tips */
-const char *CLUSTER_ADDSLOTS_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_ADDSLOTS_tips NULL
 
 /* CLUSTER ADDSLOTS argument table */
 struct redisCommandArg CLUSTER_ADDSLOTS_Args[] = {
@@ -246,10 +243,7 @@ struct redisCommandArg CLUSTER_ADDSLOTS_Args[] = {
 #define CLUSTER_ADDSLOTSRANGE_History NULL
 
 /* CLUSTER ADDSLOTSRANGE tips */
-const char *CLUSTER_ADDSLOTSRANGE_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_ADDSLOTSRANGE_tips NULL
 
 /* CLUSTER ADDSLOTSRANGE range argument table */
 struct redisCommandArg CLUSTER_ADDSLOTSRANGE_range_Subargs[] = {
@@ -315,10 +309,7 @@ struct redisCommandArg CLUSTER_COUNTKEYSINSLOT_Args[] = {
 #define CLUSTER_DELSLOTS_History NULL
 
 /* CLUSTER DELSLOTS tips */
-const char *CLUSTER_DELSLOTS_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_DELSLOTS_tips NULL
 
 /* CLUSTER DELSLOTS argument table */
 struct redisCommandArg CLUSTER_DELSLOTS_Args[] = {
@@ -332,10 +323,7 @@ struct redisCommandArg CLUSTER_DELSLOTS_Args[] = {
 #define CLUSTER_DELSLOTSRANGE_History NULL
 
 /* CLUSTER DELSLOTSRANGE tips */
-const char *CLUSTER_DELSLOTSRANGE_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_DELSLOTSRANGE_tips NULL
 
 /* CLUSTER DELSLOTSRANGE range argument table */
 struct redisCommandArg CLUSTER_DELSLOTSRANGE_range_Subargs[] = {
@@ -356,10 +344,7 @@ struct redisCommandArg CLUSTER_DELSLOTSRANGE_Args[] = {
 #define CLUSTER_FAILOVER_History NULL
 
 /* CLUSTER FAILOVER tips */
-const char *CLUSTER_FAILOVER_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_FAILOVER_tips NULL
 
 /* CLUSTER FAILOVER options argument table */
 struct redisCommandArg CLUSTER_FAILOVER_options_Subargs[] = {
@@ -380,10 +365,7 @@ struct redisCommandArg CLUSTER_FAILOVER_Args[] = {
 #define CLUSTER_FLUSHSLOTS_History NULL
 
 /* CLUSTER FLUSHSLOTS tips */
-const char *CLUSTER_FLUSHSLOTS_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_FLUSHSLOTS_tips NULL
 
 /********** CLUSTER FORGET ********************/
 
@@ -391,10 +373,7 @@ NULL
 #define CLUSTER_FORGET_History NULL
 
 /* CLUSTER FORGET tips */
-const char *CLUSTER_FORGET_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_FORGET_tips NULL
 
 /* CLUSTER FORGET argument table */
 struct redisCommandArg CLUSTER_FORGET_Args[] = {
@@ -445,10 +424,7 @@ NULL
 #define CLUSTER_KEYSLOT_History NULL
 
 /* CLUSTER KEYSLOT tips */
-const char *CLUSTER_KEYSLOT_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_KEYSLOT_tips NULL
 
 /* CLUSTER KEYSLOT argument table */
 struct redisCommandArg CLUSTER_KEYSLOT_Args[] = {
@@ -476,10 +452,7 @@ commandHistory CLUSTER_MEET_History[] = {
 };
 
 /* CLUSTER MEET tips */
-const char *CLUSTER_MEET_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_MEET_tips NULL
 
 /* CLUSTER MEET argument table */
 struct redisCommandArg CLUSTER_MEET_Args[] = {
@@ -495,10 +468,7 @@ struct redisCommandArg CLUSTER_MEET_Args[] = {
 #define CLUSTER_MYID_History NULL
 
 /* CLUSTER MYID tips */
-const char *CLUSTER_MYID_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_MYID_tips NULL
 
 /********** CLUSTER NODES ********************/
 
@@ -534,10 +504,7 @@ struct redisCommandArg CLUSTER_REPLICAS_Args[] = {
 #define CLUSTER_REPLICATE_History NULL
 
 /* CLUSTER REPLICATE tips */
-const char *CLUSTER_REPLICATE_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_REPLICATE_tips NULL
 
 /* CLUSTER REPLICATE argument table */
 struct redisCommandArg CLUSTER_REPLICATE_Args[] = {
@@ -551,10 +518,7 @@ struct redisCommandArg CLUSTER_REPLICATE_Args[] = {
 #define CLUSTER_RESET_History NULL
 
 /* CLUSTER RESET tips */
-const char *CLUSTER_RESET_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_RESET_tips NULL
 
 /* CLUSTER RESET reset_type argument table */
 struct redisCommandArg CLUSTER_RESET_reset_type_Subargs[] = {
@@ -575,10 +539,7 @@ struct redisCommandArg CLUSTER_RESET_Args[] = {
 #define CLUSTER_SAVECONFIG_History NULL
 
 /* CLUSTER SAVECONFIG tips */
-const char *CLUSTER_SAVECONFIG_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_SAVECONFIG_tips NULL
 
 /********** CLUSTER SET_CONFIG_EPOCH ********************/
 
@@ -586,10 +547,7 @@ NULL
 #define CLUSTER_SET_CONFIG_EPOCH_History NULL
 
 /* CLUSTER SET_CONFIG_EPOCH tips */
-const char *CLUSTER_SET_CONFIG_EPOCH_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_SET_CONFIG_EPOCH_tips NULL
 
 /* CLUSTER SET_CONFIG_EPOCH argument table */
 struct redisCommandArg CLUSTER_SET_CONFIG_EPOCH_Args[] = {
@@ -603,10 +561,7 @@ struct redisCommandArg CLUSTER_SET_CONFIG_EPOCH_Args[] = {
 #define CLUSTER_SETSLOT_History NULL
 
 /* CLUSTER SETSLOT tips */
-const char *CLUSTER_SETSLOT_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_SETSLOT_tips NULL
 
 /* CLUSTER SETSLOT subcommand argument table */
 struct redisCommandArg CLUSTER_SETSLOT_subcommand_Subargs[] = {

--- a/src/commands.c
+++ b/src/commands.c
@@ -292,10 +292,7 @@ struct redisCommandArg CLUSTER_COUNT_FAILURE_REPORTS_Args[] = {
 #define CLUSTER_COUNTKEYSINSLOT_History NULL
 
 /* CLUSTER COUNTKEYSINSLOT tips */
-const char *CLUSTER_COUNTKEYSINSLOT_tips[] = {
-"nondeterministic_output",
-NULL
-};
+#define CLUSTER_COUNTKEYSINSLOT_tips NULL
 
 /* CLUSTER COUNTKEYSINSLOT argument table */
 struct redisCommandArg CLUSTER_COUNTKEYSINSLOT_Args[] = {

--- a/src/commands/cluster-addslots.json
+++ b/src/commands/cluster-addslots.json
@@ -12,9 +12,6 @@
             "ADMIN",
             "STALE"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "slot",

--- a/src/commands/cluster-addslotsrange.json
+++ b/src/commands/cluster-addslotsrange.json
@@ -12,9 +12,6 @@
             "ADMIN",
             "STALE"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "range",

--- a/src/commands/cluster-countkeysinslot.json
+++ b/src/commands/cluster-countkeysinslot.json
@@ -10,9 +10,6 @@
         "command_flags": [
             "STALE"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "slot",

--- a/src/commands/cluster-delslots.json
+++ b/src/commands/cluster-delslots.json
@@ -12,9 +12,6 @@
             "ADMIN",
             "STALE"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "slot",

--- a/src/commands/cluster-delslotsrange.json
+++ b/src/commands/cluster-delslotsrange.json
@@ -12,9 +12,6 @@
             "ADMIN",
             "STALE"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "range",

--- a/src/commands/cluster-failover.json
+++ b/src/commands/cluster-failover.json
@@ -12,9 +12,6 @@
             "ADMIN",
             "STALE"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "options",

--- a/src/commands/cluster-flushslots.json
+++ b/src/commands/cluster-flushslots.json
@@ -11,9 +11,6 @@
             "NO_ASYNC_LOADING",
             "ADMIN",
             "STALE"
-        ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
         ]
     }
 }

--- a/src/commands/cluster-forget.json
+++ b/src/commands/cluster-forget.json
@@ -12,9 +12,6 @@
             "ADMIN",
             "STALE"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "node-id",

--- a/src/commands/cluster-keyslot.json
+++ b/src/commands/cluster-keyslot.json
@@ -10,9 +10,6 @@
         "command_flags": [
             "STALE"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "key",

--- a/src/commands/cluster-meet.json
+++ b/src/commands/cluster-meet.json
@@ -18,9 +18,6 @@
             "ADMIN",
             "STALE"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "ip",

--- a/src/commands/cluster-myid.json
+++ b/src/commands/cluster-myid.json
@@ -9,9 +9,6 @@
         "function": "clusterCommand",
         "command_flags": [
             "STALE"
-        ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
         ]
     }
 }

--- a/src/commands/cluster-replicate.json
+++ b/src/commands/cluster-replicate.json
@@ -12,9 +12,6 @@
             "ADMIN",
             "STALE"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "node-id",

--- a/src/commands/cluster-reset.json
+++ b/src/commands/cluster-reset.json
@@ -12,9 +12,6 @@
             "STALE",
             "NOSCRIPT"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "reset-type",

--- a/src/commands/cluster-saveconfig.json
+++ b/src/commands/cluster-saveconfig.json
@@ -11,9 +11,6 @@
             "NO_ASYNC_LOADING",
             "ADMIN",
             "STALE"
-        ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
         ]
     }
 }

--- a/src/commands/cluster-set-config-epoch.json
+++ b/src/commands/cluster-set-config-epoch.json
@@ -12,9 +12,6 @@
             "ADMIN",
             "STALE"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "config-epoch",

--- a/src/commands/cluster-setslot.json
+++ b/src/commands/cluster-setslot.json
@@ -12,9 +12,6 @@
             "ADMIN",
             "STALE"
         ],
-        "command_tips": [
-            "NONDETERMINISTIC_OUTPUT"
-        ],
         "arguments": [
             {
                 "name": "slot",


### PR DESCRIPTION
TLDR: the CLUSTER command originally had the `random` flag,
so all the sub-commands initially got that new flag, but in fact many
of them don't need it.
The only effect of this change is on the output of COMMAND INFO.

Original text:

`cluster keyslot` is deterministic.
I doubt whether other cluster commands is `NONDETERMINISTIC_OUTPUT`.
`cluster myid`
`cluster flushslots`

What definition of `NONDETERMINISTIC_OUTPUT` really is?