### PR TITLE
Improve cmd_flags for script/functions in RM_Call

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -592,6 +592,7 @@ void moduleReleaseTempClient(client *c) {
     c->bufpos = 0;
     c->flags = CLIENT_MODULE;
     c->user = NULL; /* Root user */
+    c->cmd = c->lastcmd = c->realcmd = NULL;
     moduleTempClients[moduleTempClientCount++] = c;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -3583,6 +3583,19 @@ int commandCheckArity(client *c, sds *err) {
     return 1;
 }
 
+uint64_t getCommandFlags(client *c) {
+    uint64_t cmd_flags = c->cmd->flags;
+
+    if (c->cmd->proc == fcallCommand || c->cmd->proc == fcallroCommand) {
+        cmd_flags = fcallGetCommandFlags(c, cmd_flags);
+    } else if (c->cmd->proc == evalCommand || c->cmd->proc == evalRoCommand ||
+               c->cmd->proc == evalShaCommand || c->cmd->proc == evalShaRoCommand) {
+        cmd_flags = evalGetCommandFlags(c, cmd_flags);
+    }
+
+    return cmd_flags;
+}
+
 /* If this function gets called we already read a whole
  * command, arguments are in the client argv/argc fields.
  * processCommand() execute the command or prepare the
@@ -3650,16 +3663,7 @@ int processCommand(client *c) {
     /* If we're executing a script, try to extract a set of command flags from
      * it, in case it declared them. Note this is just an attempt, we don't yet
      * know the script command is well formed.*/
-    uint64_t cmd_flags = c->cmd->flags;
-    if (c->cmd->proc == evalCommand || c->cmd->proc == evalShaCommand ||
-        c->cmd->proc == evalRoCommand || c->cmd->proc == evalShaRoCommand ||
-        c->cmd->proc == fcallCommand || c->cmd->proc == fcallroCommand)
-    {
-        if (c->cmd->proc == fcallCommand || c->cmd->proc == fcallroCommand)
-            cmd_flags = fcallGetCommandFlags(c, cmd_flags);
-        else
-            cmd_flags = evalGetCommandFlags(c, cmd_flags);
-    }
+    uint64_t cmd_flags = getCommandFlags(c);
 
     int is_read_command = (cmd_flags & CMD_READONLY) ||
                            (c->cmd->proc == execCommand && (c->mstate.cmd_flags & CMD_READONLY));

--- a/src/server.c
+++ b/src/server.c
@@ -3583,13 +3583,17 @@ int commandCheckArity(client *c, sds *err) {
     return 1;
 }
 
+/* If we're executing a script, try to extract a set of command flags from
+ * it, in case it declared them. Note this is just an attempt, we don't yet
+ * know the script command is well formed.*/
 uint64_t getCommandFlags(client *c) {
     uint64_t cmd_flags = c->cmd->flags;
 
     if (c->cmd->proc == fcallCommand || c->cmd->proc == fcallroCommand) {
         cmd_flags = fcallGetCommandFlags(c, cmd_flags);
     } else if (c->cmd->proc == evalCommand || c->cmd->proc == evalRoCommand ||
-               c->cmd->proc == evalShaCommand || c->cmd->proc == evalShaRoCommand) {
+               c->cmd->proc == evalShaCommand || c->cmd->proc == evalShaRoCommand)
+    {
         cmd_flags = evalGetCommandFlags(c, cmd_flags);
     }
 
@@ -3660,9 +3664,6 @@ int processCommand(client *c) {
         }
     }
 
-    /* If we're executing a script, try to extract a set of command flags from
-     * it, in case it declared them. Note this is just an attempt, we don't yet
-     * know the script command is well formed.*/
     uint64_t cmd_flags = getCommandFlags(c);
 
     int is_read_command = (cmd_flags & CMD_READONLY) ||

--- a/src/server.h
+++ b/src/server.h
@@ -2878,6 +2878,7 @@ int zslLexValueLteMax(sds value, zlexrangespec *spec);
 int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *level);
 size_t freeMemoryGetNotCountedMemory();
 int overMaxmemoryAfterAlloc(size_t moremem);
+uint64_t getCommandFlags(client *c);
 int processCommand(client *c);
 int processPendingCommandAndInputBuffer(client *c);
 void setupSignalHandlers(void);

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -177,22 +177,20 @@ start_server {tags {"modules"}} {
         r config set maxmemory 1
         r config set maxmemory-policy volatile-lru
 
-        # add the M flag without flags
+        # use the M flag without allow-oom shebang flag
         assert_error {OOM *} {
             r test.rm_call_flags M eval {#!lua
-                                                   redis.call('set','x',1)
-                                                   return 1
-                                               } 1 x
-
+                redis.call('set','x',1)
+                return 1
+            } 1 x
         }
 
-        # add the M flag with allow-oom flags
+        # add the M flag with allow-oom shebang flag
         assert_equal {1} [
             r test.rm_call_flags M eval {#!lua flags=allow-oom
-                                                           redis.call('set','x',1)
-                                                           return 1
-                                                       } 1 x
-
+                redis.call('set','x',1)
+                return 1
+            } 1 x
         ]
 
         r config set maxmemory 0

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -173,6 +173,31 @@ start_server {tags {"modules"}} {
         r config set maxmemory 0
     } {OK} {needs:config-maxmemory}
 
+    test {rm_call OOM Eval} {
+        r config set maxmemory 1
+        r config set maxmemory-policy volatile-lru
+
+        # add the M flag without flags
+        assert_error {OOM *} {
+            r test.rm_call_flags M eval {#!lua
+                                                   redis.call('set','x',1)
+                                                   return 1
+                                               } 1 x
+
+        }
+
+        # add the M flag with allow-oom flags
+        assert_equal {1} [
+            r test.rm_call_flags M eval {#!lua flags=allow-oom
+                                                           redis.call('set','x',1)
+                                                           return 1
+                                                       } 1 x
+
+        ]
+
+        r config set maxmemory 0
+    } {OK} {needs:config-maxmemory}
+
     test {rm_call write flag} {
         # add the W flag
         assert_error {ERR Write command 'set' was called while write is not allowed.} {


### PR DESCRIPTION
When RM_Call was used with `M` (reject OOM), `W` (reject writes), as well as `S` (rejecting stale or write commands in "Script mode"), it would have only checked the command flags, but not the declared [script flag](https://redis.io/topics/lua-api#script_flags) in case it's a command that runs a script.

Refactoring: extracts out similar code in server.c's processCommand to be usable in RM_Call as well.