### PR TITLE
Updating jemalloc rules for armv8l and aarch64

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -59,8 +59,12 @@ endif
 MALLOC=libc
 ifneq ($(uname_M),armv6l)
 ifneq ($(uname_M),armv7l)
+ifneq ($(uname_M),armv8l)
+ifneq ($(uname_M),aarch64)
 ifeq ($(uname_S),Linux)
 	MALLOC=jemalloc
+endif
+endif
 endif
 endif
 endif


### PR DESCRIPTION
The makefile in [src](https://github.com/redis/redis/blob/a5349832fe5d6a663096525a20dc237fa8ba3503/src/Makefile#L63) currently states that on ARM, jemalloc is to avoid being used. However, this only applies to armv6l and armv7l.

This PR extends the arm platforms to include arm8l and aarch64.  Realistically, we could instead, probably check if the arm platform exists within a list, and use that - if that's the desired approach.
