### PR TITLE
Cleanup in GETDEL: Strings are never freed lazily

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -412,7 +412,7 @@ void getexCommand(client *c) {
 void getdelCommand(client *c) {
     if (getGenericCommand(c) == C_ERR) return;
     if (dbSyncDelete(c->db, c->argv[1])) {
-        /* Propagate as DEL/UNLINK command */
+        /* Propagate as DEL command */
         rewriteClientCommandVector(c,2,shared.del,c->argv[1]);
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -411,12 +411,9 @@ void getexCommand(client *c) {
 
 void getdelCommand(client *c) {
     if (getGenericCommand(c) == C_ERR) return;
-    int deleted = server.lazyfree_lazy_user_del ? dbAsyncDelete(c->db, c->argv[1]) :
-                  dbSyncDelete(c->db, c->argv[1]);
-    if (deleted) {
+    if (dbSyncDelete(c->db, c->argv[1])) {
         /* Propagate as DEL/UNLINK command */
-        robj *aux = server.lazyfree_lazy_user_del ? shared.unlink : shared.del;
-        rewriteClientCommandVector(c,2,aux,c->argv[1]);
+        rewriteClientCommandVector(c,2,shared.del,c->argv[1]);
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
         server.dirty++;


### PR DESCRIPTION
The GETDEL command only operates on strings, and strings are never freed lazily, so there's no need to use `dbAsyncDelete` or `shared.unlink`.