### PR TITLE
Fix assertion when a key is lazy expired during cluster key migration

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -6767,7 +6767,7 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
              * slot migration, the channel will be served from the source
              * node until the migration completes with CLUSTER SETSLOT <slot>
              * NODE <node-id>. */
-            int flags = LOOKUP_NOTOUCH | LOOKUP_NOSTATS | LOOKUP_NONOTIFY;
+            int flags = LOOKUP_NOTOUCH | LOOKUP_NOSTATS | LOOKUP_NONOTIFY | LOOKUP_NOEXPIRE;
             if ((migrating_slot || importing_slot) && !is_pubsubshard)
             {
                 if (lookupKeyReadWithFlags(&server.db[0], thiskey, flags) == NULL) missing_keys++;

--- a/src/db.c
+++ b/src/db.c
@@ -72,6 +72,8 @@ void updateLFU(robj *val) {
  *  LOOKUP_NOSTATS: Don't increment key hits/misses counters.
  *  LOOKUP_WRITE: Prepare the key for writing (delete expired keys even on
  *                replicas, use separate keyspace stats and events (TODO)).
+ *  LOOKUP_NOEXPIRE: Perform expiration check, but avoid deleting the key,
+ *                   so that we don't have to propagate the deletion.
  *
  * Note: this function also returns NULL if the key is logically expired but
  * still existing, in case this is a replica and the LOOKUP_WRITE is not set.

--- a/src/db.c
+++ b/src/db.c
@@ -101,7 +101,7 @@ robj *lookupKey(redisDb *db, robj *key, int flags) {
         int expire_flags = 0;
         if (flags & LOOKUP_WRITE && !is_ro_replica)
             expire_flags |= EXPIRE_FORCE_DELETE_EXPIRED;
-        if (flags&LOOKUP_NOEXPIRE)
+        if (flags & LOOKUP_NOEXPIRE)
             expire_flags |= EXPIRE_AVOID_DELETE_EXPIRED;
         if (expireIfNeeded(db, key, expire_flags)) {
             /* The key is no longer valid. */
@@ -1667,7 +1667,7 @@ int keyIsExpired(redisDb *db, robj *key) {
  *
  * On replicas, this function does not delete expired keys by default, but
  * it still returns 1 if the key is logically expired. To force deletion
- * of logically expired keys even on replicas, use the EXPIRE_FORCE_DELETE_EXPIRED.
+ * of logically expired keys even on replicas, use the EXPIRE_FORCE_DELETE_EXPIRED
  * flag. Note though that if the current client is executing
  * replicated commands from the master, keys are never considered expired.
  *

--- a/src/server.h
+++ b/src/server.h
@@ -3112,6 +3112,7 @@ int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle,
 #define LOOKUP_NONOTIFY (1<<1) /* Don't trigger keyspace event on key misses. */
 #define LOOKUP_NOSTATS (1<<2)  /* Don't update keyspace hits/misses counters. */
 #define LOOKUP_WRITE (1<<3)    /* Delete expired keys even in replicas. */
+#define LOOKUP_NOEXPIRE (1<<4) /* Avoid deleting lazy expired keys. */
 
 void dbAdd(redisDb *db, robj *key, robj *val);
 int dbAddRDBLoad(redisDb *db, sds key, robj *val);

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -95,6 +95,7 @@ set ::all_tests {
     unit/client-eviction
     unit/violations
     unit/replybufsize
+    unit/cluster/misc
     unit/cluster/cli
     unit/cluster/scripting
     unit/cluster/hostnames

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -1,0 +1,16 @@
+start_cluster 2 2 {tags {external:skip cluster}} {
+    test {Key lazy expires during key migration} {
+        R 0 DEBUG SET-ACTIVE-EXPIRE 0
+
+        set key_slot [R 0 CLUSTER KEYSLOT FOO]
+        R 0 set FOO BAR PX 10
+        set src_id [R 0 CLUSTER MYID]
+        set trg_id [R 1 CLUSTER MYID]
+        R 0 CLUSTER SETSLOT $key_slot MIGRATING $trg_id
+        R 1 CLUSTER SETSLOT $key_slot IMPORTING $src_id
+        after 11
+        assert_error {ASK*} {R 0 GET FOO}
+        R 0 ping
+    } {PONG}
+}
+


### PR DESCRIPTION
Redis 7.0 has #9890 which added an assertion when the propagation queue
was not flushed and we got to beforeSleep.
But it turns out that when processCommands calls getNodeByQuery and
decides to reject the command, it can lead to a key that was lazy
expired and is deleted without later flushing the propagation queue.

This change prevents lazy expiry from deleting the key at this stage
(not as part of a command being processed in `call`)

Closes #11014