### PR TITLE
fix test timeout wait command

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1379,7 +1379,7 @@ start_server {tags {"repl external:skip"}} {
             $master pexpire s 1
             after 10
             $master sadd s foo
-            assert_equal 1 [$master wait 1 1]
+            assert_equal 1 [$master wait 1 0]
 
             assert_equal "set" [$master type s]
             assert_equal "set" [$slave type s]


### PR DESCRIPTION
Fix `Test replication with lazy expire` to not timeout the wait command. This fix will allow the test to pass on slow environments and when running with valgrind.