### PR TITLE
Bump codespell from 2.1.0 to 2.2.1 in /.codespell

### DIFF
--- a/.codespell/requirements.txt
+++ b/.codespell/requirements.txt
@@ -1,1 +1,1 @@
-codespell==2.1.0
+codespell==2.2.1

--- a/.codespell/wordlist.txt
+++ b/.codespell/wordlist.txt
@@ -16,3 +16,6 @@ cancelability
 ist
 statics
 filetest
+ro
+exat
+clen

--- a/src/object.c
+++ b/src/object.c
@@ -62,7 +62,7 @@ robj *createObject(int type, void *ptr) {
  * objects such as small integers from different threads without any
  * mutex.
  *
- * A common patter to create shared objects:
+ * A common pattern to create shared objects:
  *
  * robj *myobject = makeObjectShared(createObject(...));
  *

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -200,7 +200,7 @@ typedef struct sentinelRedisInstance {
     dict *renamed_commands;     /* Commands renamed in this instance:
                                    Sentinel will use the alternative commands
                                    mapped on this table to send things like
-                                   SLAVEOF, CONFING, INFO, ... */
+                                   SLAVEOF, CONFIG, INFO, ... */
 
     /* Role and the first time we observed it.
      * This is useful in order to delay replacing what the instance reports

--- a/src/tls.c
+++ b/src/tls.c
@@ -313,7 +313,7 @@ static int tlsConfigure(void *priv, int reconfigure) {
     int protocols = parseProtocolsConfig(ctx_config->protocols);
     if (protocols == -1) goto error;
 
-    /* Create server side/generla context */
+    /* Create server side/general context */
     ctx = createSSLContext(ctx_config, protocols, 0);
     if (!ctx) goto error;
 

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -158,7 +158,7 @@ proc count_log_lines {srv_idx} {
 # returns the number of times a line with that pattern appears in a file
 proc count_message_lines {file pattern} {
     set res 0
-    # exec fails when grep exists with status other than 0 (when the patter wasn't found)
+    # exec fails when grep exists with status other than 0 (when the pattern wasn't found)
     catch {
         set res [string trim [exec grep $pattern $file 2> /dev/null | wc -l]]
     }

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -91,7 +91,7 @@ start_server {tags {"dump"}} {
         r get foo
     } {bar2}
 
-    test {RESTORE can detect a syntax error for unrecongized options} {
+    test {RESTORE can detect a syntax error for unrecognized options} {
         catch {r restore foo 0 "..." invalid-option} e
         set e
     } {*syntax*}

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -468,7 +468,7 @@ start_server {
         assert {[llength [lindex $reply 0 1 0 1]] == 2}
         assert {[lindex $reply 0 1 0 1] eq {a 1}}
 
-        # make sure the entry is present in both the gorup, and the right consumer
+        # make sure the entry is present in both the group, and the right consumer
         assert {[llength [r XPENDING mystream mygroup - + 10]] == 1}
         assert {[llength [r XPENDING mystream mygroup - + 10 consumer1]] == 1}
         assert {[llength [r XPENDING mystream mygroup - + 10 consumer2]] == 0}
@@ -480,7 +480,7 @@ start_server {
         assert {[llength [lindex $reply 0 1]] == 2}
         assert {[lindex $reply 0 1] eq {a 1}}
 
-        # make sure the entry is present in both the gorup, and the right consumer
+        # make sure the entry is present in both the group, and the right consumer
         assert {[llength [r XPENDING mystream mygroup - + 10]] == 1}
         assert {[llength [r XPENDING mystream mygroup - + 10 consumer1]] == 0}
         assert {[llength [r XPENDING mystream mygroup - + 10 consumer2]] == 1}

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -865,7 +865,7 @@ start_server {tags {"stream"}} {
         assert_equal [dict get $reply recorded-first-entry-id] "4-0"
     }
 
-    test {Maxmimum XDEL ID behaves correctly} {
+    test {Maximum XDEL ID behaves correctly} {
         r DEL x
         r XADD x 1-0 data a
         r XADD x 2-0 data b


### PR DESCRIPTION
add a few terms to the white list, and fix a few newly detected typos