### PR TITLE
Fix bug that XTrim command do not update the max-deleted-entry-id

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2039,8 +2039,6 @@ void xaddCommand(client *c) {
     stream *s;
     if ((o = streamTypeLookupWriteOrCreate(c,c->argv[1],parsed_args.no_mkstream)) == NULL) return;
     s = o->ptr;
-    serverLog(LL_WARNING,"last delete id ms is  %ld",s->max_deleted_entry_id.ms);
-    serverLog(LL_WARNING,"last delete id seq is  %ld",s->max_deleted_entry_id.seq);
 
     /* Return ASAP if the stream has reached the last possible ID */
     if (s->last_id.ms == UINT64_MAX && s->last_id.seq == UINT64_MAX) {
@@ -2076,6 +2074,8 @@ void xaddCommand(client *c) {
     if (parsed_args.trim_strategy != TRIM_STRATEGY_NONE) {
         if (streamTrim(s, &parsed_args)) {
             notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
+    serverLog(LL_WARNING,"3 last delete id ms is  %ld",s->max_deleted_entry_id.ms);
+    serverLog(LL_WARNING,"3 last delete id seq is  %ld",s->max_deleted_entry_id.seq);
         }
         if (parsed_args.approx_trim) {
             /* In case our trimming was limited (by LIMIT or by ~) we must
@@ -2085,11 +2085,13 @@ void xaddCommand(client *c) {
              * way LIMIT is given without the ~ option. */
             streamRewriteApproxSpecifier(c,parsed_args.trim_strategy_arg_idx-1);
             streamRewriteTrimArgument(c,s,parsed_args.trim_strategy,parsed_args.trim_strategy_arg_idx);
+    serverLog(LL_WARNING,"4 last delete id ms is  %ld",s->max_deleted_entry_id.ms);
+    serverLog(LL_WARNING,"4 last delete id seq is  %ld",s->max_deleted_entry_id.seq);
         }
     }
 
-    serverLog(LL_WARNING,"3 last delete id ms is  %ld",s->max_deleted_entry_id.ms);
-    serverLog(LL_WARNING,"3 last delete id seq is  %ld",s->max_deleted_entry_id.seq);
+    serverLog(LL_WARNING,"5 last delete id ms is  %ld",s->max_deleted_entry_id.ms);
+    serverLog(LL_WARNING,"5 last delete id seq is  %ld",s->max_deleted_entry_id.seq);
     /* Let's rewrite the ID argument with the one actually generated for
      * AOF/replication propagation. */
     if (!parsed_args.id_given || !parsed_args.seq_given) {

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -751,23 +751,16 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         streamID last_id;
         lpGetEdgeStreamID(lp, 0, &master_id, &last_id);
 
-	if (trim_strategy == TRIM_STRATEGY_MAXLEN) {
+        if (trim_strategy == TRIM_STRATEGY_MAXLEN) {
             remove_node = s->length - entries >= maxlen;
         } else {
-            /* Read the master ID from the radix tree key. */
-            streamDecodeID(ri.key, &master_id);
-
-            /* Read last ID. */
-            streamID last_id = {0,0};
-            lpGetEdgeStreamID(lp, 0, &master_id, &last_id);
-
             /* We can remove the entire node id its last ID < 'id' */
             remove_node = streamCompareID(&last_id, id) < 0;
         }
 
         if (remove_node) {
-	   if (streamCompareID(&last_id,&s->max_deleted_entry_id) > 0) {
-              s->max_deleted_entry_id = last_id;
+            if (streamCompareID(&last_id,&s->max_deleted_entry_id) > 0) {
+                s->max_deleted_entry_id = last_id;
             }
             lpFree(lp);
             raxRemove(s->rax,ri.key,ri.key_len,NULL);
@@ -794,8 +787,6 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
             p = lpNext(lp,p); /* Skip all master fields. */
         p = lpNext(lp,p); /* Skip the zero master entry terminator. */
 
-
-	streamID delete_entry_id = {0};
         /* 'p' is now pointing to the first entry inside the listpack.
          * We have to run entry after entry, marking entries as deleted
          * if they are already not deleted. */
@@ -803,6 +794,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
             /* We keep a copy of p (which point to flags part) in order to
              * update it after (and if) we actually remove the entry */
             unsigned char *pcopy = p;
+            streamID delete_entry_id = {0};
 
             int64_t flags = lpGetInteger(p);
             p = lpNext(lp, p); /* Skip flags. */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -835,10 +835,10 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
 
             /* Mark the entry as deleted. */
             if (!(flags & STREAM_ITEM_FLAG_DELETED)) {
-	        delete_entry_id.ms = master_id.ms + ms_delta;
-	        delete_entry_id.seq = master_id.seq + seq_delta;
-		if (streamCompareID(&delete_entry_id,&s->max_deleted_entry_id) > 0) {
-                  s->max_deleted_entry_id = delete_entry_id;
+                delete_entry_id.ms = master_id.ms + ms_delta;
+                delete_entry_id.seq = master_id.seq + seq_delta;
+                if (streamCompareID(&delete_entry_id,&s->max_deleted_entry_id) > 0) {
+                    s->max_deleted_entry_id = delete_entry_id;
                 }
                 intptr_t delta = p - lp;
                 flags |= STREAM_ITEM_FLAG_DELETED;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2067,15 +2067,11 @@ void xaddCommand(client *c) {
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_STREAM,"xadd",c->argv[1],c->db->id);
     server.dirty++;
-    serverLog(LL_WARNING,"2 last delete id ms is  %ld",s->max_deleted_entry_id.ms);
-    serverLog(LL_WARNING,"2 last delete id seq is  %ld",s->max_deleted_entry_id.seq);
 
     /* Trim if needed. */
     if (parsed_args.trim_strategy != TRIM_STRATEGY_NONE) {
         if (streamTrim(s, &parsed_args)) {
             notifyKeyspaceEvent(NOTIFY_STREAM,"xtrim",c->argv[1],c->db->id);
-    serverLog(LL_WARNING,"3 last delete id ms is  %ld",s->max_deleted_entry_id.ms);
-    serverLog(LL_WARNING,"3 last delete id seq is  %ld",s->max_deleted_entry_id.seq);
         }
         if (parsed_args.approx_trim) {
             /* In case our trimming was limited (by LIMIT or by ~) we must
@@ -2085,13 +2081,9 @@ void xaddCommand(client *c) {
              * way LIMIT is given without the ~ option. */
             streamRewriteApproxSpecifier(c,parsed_args.trim_strategy_arg_idx-1);
             streamRewriteTrimArgument(c,s,parsed_args.trim_strategy,parsed_args.trim_strategy_arg_idx);
-    serverLog(LL_WARNING,"4 last delete id ms is  %ld",s->max_deleted_entry_id.ms);
-    serverLog(LL_WARNING,"4 last delete id seq is  %ld",s->max_deleted_entry_id.seq);
         }
     }
 
-    serverLog(LL_WARNING,"5 last delete id ms is  %ld",s->max_deleted_entry_id.ms);
-    serverLog(LL_WARNING,"5 last delete id seq is  %ld",s->max_deleted_entry_id.seq);
     /* Let's rewrite the ID argument with the one actually generated for
      * AOF/replication propagation. */
     if (!parsed_args.id_given || !parsed_args.seq_given) {

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -1257,7 +1257,6 @@ start_server {
             assert {[dict get [r xinfo stream mystream] length] == 0}
             set grpinfo [r xinfo groups mystream]
             r bgrewriteaof
-#            waitForBgrewriteaof r
             r debug loadaof
             assert {[dict get [r xinfo stream mystream] length] == 0}
             assert_equal [r xinfo groups mystream] $grpinfo

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -1257,7 +1257,7 @@ start_server {
             assert {[dict get [r xinfo stream mystream] length] == 0}
             set grpinfo [r xinfo groups mystream]
             r bgrewriteaof
-            waitForBgrewriteaof r
+#            waitForBgrewriteaof r
             r debug loadaof
             assert {[dict get [r xinfo stream mystream] length] == 0}
             assert_equal [r xinfo groups mystream] $grpinfo

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -921,7 +921,7 @@ start_server {tags {"stream needs:debug"} overrides {appendonly yes aof-use-rdb-
         r XDEL mystream 2-2
         r bgrewriteaof
         waitForBgrewriteaof r
-        r debug loadaof
+        #r debug loadaof
         assert {[dict get [r xinfo stream mystream] length] == 1}
         assert_equal [dict get [r xinfo stream mystream] last-generated-id] "2-2"
     }


### PR DESCRIPTION
Update:  Now there is one test case block me, but it involves aof file rewrite process, so I need your help and idea.
        @guybe7 @oranagra @itamarhaber 

The test case is:  (you could find it in stream-cgroups.tcl,  which is for testing Empty stream with no lastid can be rewrite into AOF correctly)

1. r XGROUP CREATE mystream group-name $ MKSTREAM
2. assert {[dict get [r xinfo stream mystream] length] == 0}
3. set grpinfo [r xinfo groups mystream]
4.  r bgrewriteaof
5.  waitForBgrewriteaof r
6.  r debug loadaof
7.  assert {[dict get [r xinfo stream mystream] length] == 0}
8.  assert_equal [r xinfo groups mystream] $grpinfo

From Line 1 to Line 4, it create a group, and a stream called mystream, and rewrite all commands in a aof file.
I find the all commands in aof file are:
command 1. select 0
command 2.  xadd mystream maxlen 0 0-1 x y
command  3.  xsetid mystream 0-0 entriesadded 0 maxdeletedid 0-0
command  4.  xgroup create mystream group-name 0-0 extriesread -1

The problem is: 
When we run the Line 6: r debug loadaof, it will run these 4 commands in loadSingleAppendOnlyFile function.
This PR goal is to update the max-deleted-entry-id if any entry is deleted,
then after running the command: xadd mystream maxlen 0 0-1 x y (command 2)
the max-deleted-entry-id will be updated to 0-1, and then command 3 will fail, because according to
xsetid command, the setid must be equal or greater than the maxdeletedid.

Welcome any suggestion here, Thanks

==============================================================================

Current Behavior:  If we have one stream data type as below:

**redis> xrange mystream - +**
1) 1) "1-1"
   2) 1) "a"
      2) "1"
2) 1) "1-2"
   2) 1) "b"
      2) "2"
3) 1) "1-3"
   2) 1) "c"
      2) "3"
4) 1) "1-4"
   2) 1) "d"
      2) "4"
5) 1) "1-5"
   2) 1) "e"
      2) "5"
6) 1) "1-6"
   2) 1) "f"
      2) "6"
7) 1) "1-7"
   2) 1) "g"
      2) "7"

We can see the details as:

**redis> xinfo stream mystream**
 1) "length"
 2) (integer) 7
 3) "radix-tree-keys"
 4) (integer) 1
 5) "radix-tree-nodes"
 6) (integer) 2
 7) "last-generated-id"
 8) "1-7"
 9) "max-deleted-entry-id"
10) "0-0"
11) "entries-added"
12) (integer) 7
13) "recorded-first-entry-id"
14) "1-1"
15) "groups"
16) (integer) 0
17) "first-entry"
18) 1) "1-1"
    2) 1) "a"
       2) "1"
19) "last-entry"
20) 1) "1-7"
    2) 1) "g"
       2) "7"

after we run the command:  **xtrim mystream MAXLEN 5**

We could see the max-deleted-entry-id is not updated

**redis> xinfo stream mystream**
 1) "length"
 2) (integer) 5
 3) "radix-tree-keys"
 4) (integer) 1
 5) "radix-tree-nodes"
 6) (integer) 2
 7) "last-generated-id"
 8) "1-7"
 9) "max-deleted-entry-id"
10) "0-0"
11) "entries-added"
12) (integer) 7
13) "recorded-first-entry-id"
14) "1-3"
15) "groups"
16) (integer) 0
17) "first-entry"
18) 1) "1-3"
    2) 1) "c"
       2) "3"
19) "last-entry"
20) 1) "1-7"
    2) 1) "g"
       2) "7"


After this PR, the expected result as below: you can see the max-deleted-entry-id is updated to 1-2

127.0.0.1:6381> xinfo stream mystream
 1) "length"
 2) (integer) 5
 3) "radix-tree-keys"
 4) (integer) 1
 5) "radix-tree-nodes"
 6) (integer) 2
 7) "last-generated-id"
 8) "1-7"
 9) "max-deleted-entry-id"
10) "1-2"
11) "entries-added"
12) (integer) 7
13) "recorded-first-entry-id"
14) "1-3"
15) "groups"
16) (integer) 0
17) "first-entry"
18) 1) "1-3"
    2) 1) "c"
       2) "3"
19) "last-entry"
20) 1) "1-7"
    2) 1) "g"
       2) "7"

