### PR TITLE
Fix false valgrind error on new hash test

### DIFF
--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -819,8 +819,11 @@ start_server {tags {"hash"}} {
         set _ $k
     } {ZIP_INT_8B 127 ZIP_INT_16B 32767 ZIP_INT_32B 2147483647 ZIP_INT_64B 9223372036854775808 ZIP_INT_IMM_MIN 0 ZIP_INT_IMM_MAX 12}
 
-    test {HINCRBYFLOAT does not allow NaN or Infinity} {
-        assert_error "*value is NaN or Infinity*" {r hincrbyfloat hfoo field +inf}
-        assert_equal 0 [r exists hfoo]
+    # On some platforms strtold("+inf") with valgrind returns a non-inf result
+    if {!$::valgrind} {
+        test {HINCRBYFLOAT does not allow NaN or Infinity} {
+            assert_error "*value is NaN or Infinity*" {r hincrbyfloat hfoo field +inf}
+            assert_equal 0 [r exists hfoo]
+        }
     }
 }


### PR DESCRIPTION
New test fails on valgrind because strtold("+inf") with valgrind returns a non-inf result
same thing is done in incr.tcl.