### PR TITLE
Replace redis-cli default hostname 127.0.0.1 with 'localhost'

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2290,7 +2290,7 @@ static void usage(int err) {
 "redis-cli %s\n"
 "\n"
 "Usage: redis-cli [OPTIONS] [cmd [arg [arg ...]]]\n"
-"  -h <hostname>      Server hostname (default: 127.0.0.1).\n"
+"  -h <hostname>      Server hostname (default: localhost).\n"
 "  -p <port>          Server port (default: 6379).\n"
 "  -s <socket>        Server socket (overrides hostname and port).\n"
 "  -a <password>      Password to use when connecting to the server.\n"
@@ -8886,7 +8886,7 @@ int main(int argc, char **argv) {
     struct timeval tv;
 
     memset(&config.sslconfig, 0, sizeof(config.sslconfig));
-    config.conn_info.hostip = sdsnew("127.0.0.1");
+    config.conn_info.hostip = sdsnew("localhost");
     config.conn_info.hostport = 6379;
     config.hostsocket = NULL;
     config.repeat = 1;


### PR DESCRIPTION
It makes redis-cli more portable out-of-the-box for ipv6 and customized interfaces.
It also gives the option in the future to optimize and connect by default, where possible,
via sockets (and not to be bound to TCPIP stack. mysql client is doing exactly that!).

Extra system calls price (vs. 127.0.0.1):
```
openat(AT_FDCWD, "/etc/host.conf", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/etc/resolv.conf", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/etc/nsswitch.conf", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/etc/ld.so.cache", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/lib/x86_64-linux-gnu/libnss_files.so.2", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/etc/hosts", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/etc/gai.conf", O_RDONLY|O_CLOEXEC) = 3
```