### PR TITLE
Improve redis.conf documentation on repl-diskless-load

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -629,10 +629,8 @@ repl-diskless-sync-delay 5
 repl-diskless-sync-max-replicas 0
 
 # -----------------------------------------------------------------------------
-# WARNING: RDB diskless load is experimental. Since in this setup the replica
-# does not immediately store an RDB on disk, it may cause data loss during
-# failovers. RDB diskless load + Redis modules not handling I/O reads may also
-# cause Redis to abort in case of I/O errors during the initial synchronization
+# WARNING: RDB diskless load + Redis modules not handling I/O reads may cause
+# Redis to abort in case of I/O errors during the initial synchronization
 # stage with the master. Use only if you know what you are doing.
 # -----------------------------------------------------------------------------
 #
@@ -643,15 +641,18 @@ repl-diskless-sync-max-replicas 0
 # In many cases the disk is slower than the network, and storing and loading
 # the RDB file may increase replication time (and even increase the master's
 # Copy on Write memory and replica buffers).
-# However, parsing the RDB file directly from the socket may mean that we have
-# to flush the contents of the current database before the full rdb was
-# received. For this reason we have the following options:
+# However, when parsing the RDB file directly from the socket, in order to avoid
+# data loss it's only safe to flush the current dataset when the new dataset is
+# fully loaded in memory, resulting in higher memory usage.
+# For this reason we have the following options:
 #
 # "disabled"    - Don't use diskless load (store the rdb file to the disk first)
-# "on-empty-db" - Use diskless load only when it is completely safe.
+# "on-empty-db" - Use diskless load only when current dataset is empty, in order
+#                 to avoid having old and new dataset loaded side by side during
+#                 replication.
 # "swapdb"      - Keep current db contents in RAM while parsing the data directly
 #                 from the socket. Replicas in this mode can keep serving current
-#                 data set while replication is in progress, except for cases where
+#                 dataset while replication is in progress, except for cases where
 #                 they can't recognize master as having a data set from same
 #                 replication history.
 #                 Note that this requires sufficient memory, if you don't have it,

--- a/redis.conf
+++ b/redis.conf
@@ -629,9 +629,10 @@ repl-diskless-sync-delay 5
 repl-diskless-sync-max-replicas 0
 
 # -----------------------------------------------------------------------------
-# WARNING: RDB diskless load + Redis modules not handling I/O reads may cause
-# Redis to abort in case of I/O errors during the initial synchronization
-# stage with the master.
+# WARNING: Since in this setup the replica does not immediately store an RDB on
+# disk, it may cause data loss during failovers. RDB diskless load + Redis
+# modules not handling I/O reads may cause Redis to abort in case of I/O errors
+# during the initial synchronization stage with the master.
 # -----------------------------------------------------------------------------
 #
 # Replica can load the RDB it reads from the replication link directly from the
@@ -647,9 +648,9 @@ repl-diskless-sync-max-replicas 0
 # For this reason we have the following options:
 #
 # "disabled"    - Don't use diskless load (store the rdb file to the disk first)
-# "on-empty-db" - Use diskless load only when current dataset is empty, in order
-#                 to avoid having old and new dataset loaded side by side during
-#                 replication.
+# "on-empty-db" - Use diskless load only when current dataset is empty. This is 
+#                 safer and avoid having old and new dataset loaded side by side
+#                 during replication.
 # "swapdb"      - Keep current db contents in RAM while parsing the data directly
 #                 from the socket. Replicas in this mode can keep serving current
 #                 dataset while replication is in progress, except for cases where

--- a/redis.conf
+++ b/redis.conf
@@ -631,7 +631,7 @@ repl-diskless-sync-max-replicas 0
 # -----------------------------------------------------------------------------
 # WARNING: RDB diskless load + Redis modules not handling I/O reads may cause
 # Redis to abort in case of I/O errors during the initial synchronization
-# stage with the master. Use only if you know what you are doing.
+# stage with the master.
 # -----------------------------------------------------------------------------
 #
 # Replica can load the RDB it reads from the replication link directly from the

--- a/redis.conf
+++ b/redis.conf
@@ -648,9 +648,6 @@ repl-diskless-sync-max-replicas 0
 # For this reason we have the following options:
 #
 # "disabled"    - Don't use diskless load (store the rdb file to the disk first)
-# "on-empty-db" - Use diskless load only when current dataset is empty. This is 
-#                 safer and avoid having old and new dataset loaded side by side
-#                 during replication.
 # "swapdb"      - Keep current db contents in RAM while parsing the data directly
 #                 from the socket. Replicas in this mode can keep serving current
 #                 dataset while replication is in progress, except for cases where
@@ -658,6 +655,9 @@ repl-diskless-sync-max-replicas 0
 #                 replication history.
 #                 Note that this requires sufficient memory, if you don't have it,
 #                 you risk an OOM kill.
+# "on-empty-db" - Use diskless load only when current dataset is empty. This is 
+#                 safer and avoid having old and new dataset loaded side by side
+#                 during replication.
 repl-diskless-load disabled
 
 # Master send PINGs to its replicas in a predefined interval. It's possible to


### PR DESCRIPTION
Just noticed that there are some inaccurate, or at least confusing information about `repl-diskless-load` in `redis.conf`
It shouldn't scare away users willing to spend the extra memory.

`may mean that we have to flush the contents of the current database before the full rdb was received.`: this is likely related to the time when there was an option `always`, where content on replica was flushed before loading from master.