### PR TITLE
Add CONFIG SET and GET loglevel feature in Sentinel

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -19,6 +19,14 @@ daemonize no
 # location here.
 pidfile /var/run/redis-sentinel.pid
 
+# Specify the server verbosity level.
+# This can be one of:
+# debug (a lot of information, useful for development/testing)
+# verbose (many rarely useful info, but not a mess like the debug level)
+# notice (moderately verbose, what you want in production probably)
+# warning (only very important / critical messages are logged)
+loglevel notice
+
 # Specify the log file name. Also the empty string can be used to force
 # Sentinel to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3182,7 +3182,7 @@ void sentinelSendPeriodicCommands(sentinelRedisInstance *ri) {
 
 /* =========================== SENTINEL command ============================= */
 
-const char* getLogLevel(){
+const char* getLogLevel() {
    switch (server.verbosity) {
     case LL_DEBUG: return "debug";
     case LL_VERBOSE: return "verbose";

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3182,6 +3182,16 @@ void sentinelSendPeriodicCommands(sentinelRedisInstance *ri) {
 
 /* =========================== SENTINEL command ============================= */
 
+const char* getLogLevel(){
+   switch (server.verbosity) {
+    case LL_DEBUG: return "debug";
+    case LL_VERBOSE: return "verbose";
+    case LL_NOTICE: return "notice";
+    case LL_WARNING: return "warning";
+    }
+    return "unknown";
+}
+
 /* SENTINEL CONFIG SET <option> */
 void sentinelConfigSetCommand(client *c) {
     robj *o = c->argv[3];
@@ -3275,6 +3285,11 @@ void sentinelConfigGetCommand(client *c) {
         matches++;
     }
 
+    if (stringmatch(pattern, "loglevel", 1)) {
+        addReplyBulkCString(c, "loglevel");
+        addReplyBulkCString(c, getLogLevel());
+        matches++;
+    }
     setDeferredMapLen(c, replylen, matches);
 }
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3192,7 +3192,7 @@ const char* getLogLevel(){
     return "unknown";
 }
 
-/* SENTINEL CONFIG SET <option> */
+/* SENTINEL CONFIG SET <option> <value>*/
 void sentinelConfigSetCommand(client *c) {
     robj *o = c->argv[3];
     robj *val = c->argv[4];
@@ -3223,6 +3223,17 @@ void sentinelConfigSetCommand(client *c) {
         sentinel.sentinel_auth_pass = sdslen(val->ptr) == 0 ?
             NULL : sdsdup(val->ptr);
         drop_conns = 1;
+    } else if (!strcasecmp(o->ptr, "loglevel")) {
+        if (!strcasecmp(val->ptr, "debug"))
+            server.verbosity = LL_DEBUG;
+        else if (!strcasecmp(val->ptr, "verbose"))
+            server.verbosity = LL_VERBOSE;
+        else if (!strcasecmp(val->ptr, "notice"))
+            server.verbosity = LL_NOTICE;
+        else if (!strcasecmp(val->ptr, "warning"))
+            server.verbosity = LL_WARNING;
+        else
+            goto badfmt;
     } else {
         addReplyErrorFormat(c, "Invalid argument '%s' to SENTINEL CONFIG SET",
                             (char *) o->ptr);

--- a/src/server.c
+++ b/src/server.c
@@ -5128,16 +5128,6 @@ const char *replstateToString(int replstate) {
     }
 }
 
-const char *getLogLevel() {
-    switch (server.verbosity) {
-    case LL_DEBUG: return "debug";
-    case LL_VERBOSE: return "verbose";
-    case LL_NOTICE: return "notice";
-    case LL_WARNING: return "warning";
-    }
-    return "unknown";
-}
-
 /* Characters we sanitize on INFO output to maintain expected format. */
 static char unsafe_info_chars[] = "#:\n\r";
 static char unsafe_info_chars_substs[] = "____";   /* Must be same length as above */
@@ -5296,7 +5286,6 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         static struct utsname name;
         char *mode;
         char *supervised;
-	sds logfileDir = getAbsolutePath(server.logfile);
 
         if (server.cluster_enabled) mode = "cluster";
         else if (server.sentinel_mode) mode = "sentinel";
@@ -5345,8 +5334,6 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "lru_clock:%u\r\n"
             "executable:%s\r\n"
             "config_file:%s\r\n"
-            "log_level:%s\r\n"
-            "log_file:%s\r\n"
             "io_threads_active:%i\r\n",
             REDIS_VERSION,
             redisGitSHA1(),
@@ -5375,8 +5362,6 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             lruclock,
             server.executable ? server.executable : "",
             server.configfile ? server.configfile : "",
-            getLogLevel(),
-            logfileDir,
             server.io_threads_active);
 
         /* Conditional properties */
@@ -5388,7 +5373,6 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
 
         /* get all the listeners information */
         info = getListensInfoString(info);
-	sdsfree(logfileDir);
     }
 
     /* Clients */

--- a/src/server.c
+++ b/src/server.c
@@ -5128,6 +5128,16 @@ const char *replstateToString(int replstate) {
     }
 }
 
+const char *getLogLevel() {
+    switch (server.verbosity) {
+    case LL_DEBUG: return "debug";
+    case LL_VERBOSE: return "verbose";
+    case LL_NOTICE: return "notice";
+    case LL_WARNING: return "warning";
+    }
+    return "unknown";
+}
+
 /* Characters we sanitize on INFO output to maintain expected format. */
 static char unsafe_info_chars[] = "#:\n\r";
 static char unsafe_info_chars_substs[] = "____";   /* Must be same length as above */
@@ -5334,6 +5344,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "lru_clock:%u\r\n"
             "executable:%s\r\n"
             "config_file:%s\r\n"
+            "log_level:%s\r\n"
+            "log_file:%s\r\n"
             "io_threads_active:%i\r\n",
             REDIS_VERSION,
             redisGitSHA1(),
@@ -5362,6 +5374,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             lruclock,
             server.executable ? server.executable : "",
             server.configfile ? server.configfile : "",
+            getLogLevel(),
+            getAbsolutePath(server.logfile),
             server.io_threads_active);
 
         /* Conditional properties */

--- a/src/server.c
+++ b/src/server.c
@@ -5296,6 +5296,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         static struct utsname name;
         char *mode;
         char *supervised;
+	sds logfileDir = getAbsolutePath(server.logfile);
 
         if (server.cluster_enabled) mode = "cluster";
         else if (server.sentinel_mode) mode = "sentinel";
@@ -5375,7 +5376,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             server.executable ? server.executable : "",
             server.configfile ? server.configfile : "",
             getLogLevel(),
-            getAbsolutePath(server.logfile),
+            logfileDir,
             server.io_threads_active);
 
         /* Conditional properties */
@@ -5387,6 +5388,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
 
         /* get all the listeners information */
         info = getListensInfoString(info);
+	sdsfree(logfileDir);
     }
 
     /* Clients */

--- a/tests/sentinel/tests/01-conf-update.tcl
+++ b/tests/sentinel/tests/01-conf-update.tcl
@@ -37,3 +37,11 @@ test "After Sentinel 1 is restarted, its config gets updated" {
 test "New master [join $addr {:}] role matches" {
     assert {[RI $master_id role] eq {master}}
 }
+
+test "Update log level" {
+    set current_loglevel [S 0 SENTINEL CONFIG GET loglevel]
+    assert {[lindex $$current_loglevel 1] == {notice}}
+    S 0 SENTINEL CONFIG SET loglevel warning
+    set updated_loglevel [S 0 SENTINEL CONFIG GET loglevel]
+    assert {[lindex $$updated_loglevel 1] == {warning}}
+}

--- a/tests/sentinel/tests/01-conf-update.tcl
+++ b/tests/sentinel/tests/01-conf-update.tcl
@@ -40,8 +40,8 @@ test "New master [join $addr {:}] role matches" {
 
 test "Update log level" {
     set current_loglevel [S 0 SENTINEL CONFIG GET loglevel]
-    assert {[lindex $$current_loglevel 1] == {notice}}
+    assert {[lindex $current_loglevel 1] == {notice}}
     S 0 SENTINEL CONFIG SET loglevel warning
     set updated_loglevel [S 0 SENTINEL CONFIG GET loglevel]
-    assert {[lindex $$updated_loglevel 1] == {warning}}
+    assert {[lindex $updated_loglevel 1] == {warning}}
 }


### PR DESCRIPTION
Till now Sentinel allowed modifying the log level in the config file, but not at runtime.
this makes it possible to tune the log level at runtime