### PR TITLE
MONITOR's response as PUSH type

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -584,7 +584,13 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     listRewind(monitors,&li);
     while((ln = listNext(&li))) {
         client *monitor = ln->value;
-        addReply(monitor,cmdobj);
+        if(monitor->resp > 2) {
+            addReplyPushLen(monitor,2);
+            addReply(monitor,shared.monitorbulk);
+            addReply(monitor,cmdobj);
+        } else {
+            addReply(monitor,cmdobj);
+        }
         updateClientMemUsage(c);
     }
     decrRefCount(cmdobj);

--- a/src/server.c
+++ b/src/server.c
@@ -1768,6 +1768,7 @@ void createSharedObjects(void) {
     shared.ssubscribebulk = createStringObject("$10\r\nssubscribe\r\n", 17);
     shared.sunsubscribebulk = createStringObject("$12\r\nsunsubscribe\r\n", 19);
     shared.smessagebulk = createStringObject("$8\r\nsmessage\r\n", 14);
+    shared.monitorbulk = createStringObject("$7\r\nmonitor\r\n", 13);
     shared.psubscribebulk = createStringObject("$10\r\npsubscribe\r\n",17);
     shared.punsubscribebulk = createStringObject("$12\r\npunsubscribe\r\n",19);
 

--- a/src/server.h
+++ b/src/server.h
@@ -1236,7 +1236,7 @@ struct sharedObjectsStruct {
     *time, *pxat, *absttl, *retrycount, *force, *justid, *entriesread,
     *lastid, *ping, *setid, *keepttl, *load, *createconsumer,
     *getack, *special_asterick, *special_equals, *default_username, *redacted,
-    *ssubscribebulk,*sunsubscribebulk, *smessagebulk,
+    *ssubscribebulk,*sunsubscribebulk, *smessagebulk, *monitorbulk,
     *select[PROTO_SHARED_SELECT_CMDS],
     *integers[OBJ_SHARED_INTEGERS],
     *mbulkhdr[OBJ_SHARED_BULKHDR_LEN], /* "*<value>\r\n" */

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -67,6 +67,20 @@ start_server {tags {"introspection"}} {
         set _ $res
     } {*"set" "foo"*"get" "foo"*}
 
+    test {MONITOR should support RESP3 protocol} {
+        set rd [redis_deferring_client]
+        $rd HELLO 3
+        $rd read ; # Consume the HELLO reply
+
+        $rd monitor
+        $rd read ; # Consume the MONITOR reply
+
+        r set foo bar
+
+        assert_match {monitor*"set"*"foo"*"bar"*} [$rd read]
+        $rd close
+    }
+
     test {MONITOR can log commands issued by the scripting engine} {
         set rd [redis_deferring_client]
         $rd monitor


### PR DESCRIPTION
Hello :) 
A little bit better (at least I hope) support for RESP3 for MONITOR than 3 years ago. As described in this issue https://github.com/redis/redis/issues/6426 at the moment MONITOR is responding with old style resp 2 for resp > 2 clients. 
I wanted to follow https://github.com/antirez/RESP3/blob/master/spec.md but I adjusted a little bit and that is how message looks like 
```
>2
$7
message
+1661805358.629152 [0 127.0.0.1:57480] "publish" "topic" "somemessage"
```
so, first we have bulk string then simple string (I didn't want to create another string object, performance ?). I am not C developer and honestly that is pretty exotic for me so I am not sure about this PR. 

(cc @itamarhaber)