### PR TITLE
add an 'I'ncompatible (non backwards compat) flag for RM_Call

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -380,7 +380,7 @@ int evalExtractShebangFlags(sds body, uint64_t *out_flags, ssize_t *out_shebang_
 
 /* Try to extract command flags if we can, returns the modified flags.
  * Note that it does not guarantee the command arguments are right. */
-uint64_t evalGetCommandFlags(client *c, uint64_t cmd_flags) {
+uint64_t evalGetCommandFlags(client *c, uint64_t cmd_flags, bool incompat) {
     char funcname[43];
     int evalsha = c->cmd->proc == evalShaCommand || c->cmd->proc == evalShaRoCommand;
     if (evalsha && sdslen(c->argv[1]->ptr) != 40)
@@ -398,7 +398,7 @@ uint64_t evalGetCommandFlags(client *c, uint64_t cmd_flags) {
         luaScript *l = dictGetVal(de);
         script_flags = l->flags;
     }
-    if (script_flags & SCRIPT_FLAG_EVAL_COMPAT_MODE)
+    if (!incompat && script_flags & SCRIPT_FLAG_EVAL_COMPAT_MODE)
         return cmd_flags;
     return scriptFlagsToCmdFlags(cmd_flags, script_flags);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -5633,7 +5633,7 @@ RedisModuleString *RM_CreateStringFromCallReply(RedisModuleCallReply *reply) {
  *     "0" -> REDISMODULE_ARGV_RESP_AUTO
  *     "C" -> REDISMODULE_ARGV_CHECK_ACL
  *     "I" -> REDISMODULE_ARGV_SCRIPTS_INCOMPAT_MODE
- *          Treats non shbang lua scripts in eval as if they have an empty shbang instead of COMPAT mode
+ *          Treats non shebang lua scripts in eval as if they have an empty shebang instead of COMPAT mode
  *
  * On error (format specifier error) NULL is returned and nothing is
  * allocated. On success the argument vector is returned. */
@@ -5760,7 +5760,7 @@ fmterr:
  *              This flag allows to get the error also as an error CallReply with
  *              relevant error message.
  *     * 'I' -- Treat backwards compatible lua scripts as non backwards compatible, i.e.
- *              as if no shbang flags.  ex: will be treated as DENY_OOM
+ *              as if no shebang flags.  ex: will be treated as DENY_OOM
  * * **...**: The actual arguments to the Redis command.
  *
  * On success a RedisModuleCallReply object is returned, otherwise

--- a/src/server.c
+++ b/src/server.c
@@ -3607,7 +3607,7 @@ int commandCheckArity(client *c, sds *err) {
 /* If we're executing a script, try to extract a set of command flags from
  * it, in case it declared them. Note this is just an attempt, we don't yet
  * know the script command is well formed.*/
-uint64_t getCommandFlags(client *c) {
+uint64_t getCommandFlags(client *c, int incompat) {
     uint64_t cmd_flags = c->cmd->flags;
 
     if (c->cmd->proc == fcallCommand || c->cmd->proc == fcallroCommand) {
@@ -3615,7 +3615,7 @@ uint64_t getCommandFlags(client *c) {
     } else if (c->cmd->proc == evalCommand || c->cmd->proc == evalRoCommand ||
                c->cmd->proc == evalShaCommand || c->cmd->proc == evalShaRoCommand)
     {
-        cmd_flags = evalGetCommandFlags(c, cmd_flags);
+        cmd_flags = evalGetCommandFlags(c, cmd_flags, incompat);
     }
 
     return cmd_flags;
@@ -3685,7 +3685,7 @@ int processCommand(client *c) {
         }
     }
 
-    uint64_t cmd_flags = getCommandFlags(c);
+    uint64_t cmd_flags = getCommandFlags(c, false);
 
     int is_read_command = (cmd_flags & CMD_READONLY) ||
                            (c->cmd->proc == execCommand && (c->mstate.cmd_flags & CMD_READONLY));

--- a/src/server.h
+++ b/src/server.h
@@ -2864,7 +2864,7 @@ int zslLexValueLteMax(sds value, zlexrangespec *spec);
 int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *level);
 size_t freeMemoryGetNotCountedMemory();
 int overMaxmemoryAfterAlloc(size_t moremem);
-uint64_t getCommandFlags(client *c);
+uint64_t getCommandFlags(client *c, int incompat);
 int processCommand(client *c);
 int processPendingCommandAndInputBuffer(client *c);
 void setupSignalHandlers(void);
@@ -3194,7 +3194,7 @@ void sha1hex(char *digest, char *script, size_t len);
 unsigned long evalMemory();
 dict* evalScriptsDict();
 unsigned long evalScriptsMemory();
-uint64_t evalGetCommandFlags(client *c, uint64_t orig_flags);
+uint64_t evalGetCommandFlags(client *c, uint64_t orig_flags, bool incompat);
 uint64_t fcallGetCommandFlags(client *c, uint64_t orig_flags);
 int isInsideYieldingLongCommand();
 


### PR DESCRIPTION
Currently, if one adds a script to Redis without shbang flags, it will get the SCRIPT_FLAG_EVAL_COMPAT_MODE flag instead.

For OOM situations this means, that even if we call RM_Call with 'M' to prevent execution of "deny oom" commands (which this script would be without the compat mode), it won't be considered deny-oom and will just fail with an OOM during script execution.

This flag allows RM_Call to treat such scripts as if they had no flags at all and be derived from there.  For 'M' this means that the scripts will be treated as DENY_OOM, and if a user wanted to allow them to run in an OOM situation, would have to use the appropriate shbang flags.