### PR TITLE
Adds listnode to client struct for clients_pending_write list

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -98,7 +98,7 @@ list *listAddNodeHead(list *list, void *value)
 }
 
 /*
- * Add a node that has already been mallocced to the head of list
+ * Add a node that has already been allocated to the head of list
 */
 void listLinkNodeHead(list* list, listNode *node) {
     if (list->len == 0) {
@@ -180,8 +180,8 @@ void listDelNode(list *list, listNode *node)
 }
 
 /*
- * Remove node from list without freeing node
-*/
+ * Remove the specified node from list without freeing it.
+ */
 void listUnlinkNode(list *list, listNode *node) {
     if (node->prev)
         node->prev->next = node->next;

--- a/src/adlist.c
+++ b/src/adlist.c
@@ -93,6 +93,14 @@ list *listAddNodeHead(list *list, void *value)
     if ((node = zmalloc(sizeof(*node))) == NULL)
         return NULL;
     node->value = value;
+    listLinkNodeHead(list, node);
+    return list;
+}
+
+/*
+ * Add a node that has already been mallocced to the head of list
+*/
+void listLinkNodeHead(list* list, listNode *node) {
     if (list->len == 0) {
         list->head = list->tail = node;
         node->prev = node->next = NULL;
@@ -103,7 +111,6 @@ list *listAddNodeHead(list *list, void *value)
         list->head = node;
     }
     list->len++;
-    return list;
 }
 
 /* Add a new node to the list, to tail, containing the specified 'value'
@@ -162,11 +169,20 @@ list *listInsertNode(list *list, listNode *old_node, void *value, int after) {
 }
 
 /* Remove the specified node from the specified list.
- * It's up to the caller to free the private value of the node.
+ * The node is freed but it's up to the caller to free the private value of the node.
  *
  * This function can't fail. */
 void listDelNode(list *list, listNode *node)
 {
+    listUnlinkNode(list, node);
+    if (list->free) list->free(node->value);
+    zfree(node);
+}
+
+/*
+ * Remove node from list without freeing node
+*/
+void listUnlinkNode(list *list, listNode *node) {
     if (node->prev)
         node->prev->next = node->next;
     else
@@ -175,8 +191,10 @@ void listDelNode(list *list, listNode *node)
         node->next->prev = node->prev;
     else
         list->tail = node->prev;
-    if (list->free) list->free(node->value);
-    zfree(node);
+
+    node->next = NULL;
+    node->prev = NULL;
+
     list->len--;
 }
 

--- a/src/adlist.c
+++ b/src/adlist.c
@@ -99,7 +99,7 @@ list *listAddNodeHead(list *list, void *value)
 
 /*
  * Add a node that has already been allocated to the head of list
-*/
+ */
 void listLinkNodeHead(list* list, listNode *node) {
     if (list->len == 0) {
         list->head = list->tail = node;
@@ -180,7 +180,7 @@ void listDelNode(list *list, listNode *node)
 }
 
 /*
- * Remove the specified node from list without freeing it.
+ * Remove the specified node from the list without freeing it.
  */
 void listUnlinkNode(list *list, listNode *node) {
     if (node->prev)

--- a/src/adlist.c
+++ b/src/adlist.c
@@ -169,7 +169,7 @@ list *listInsertNode(list *list, listNode *old_node, void *value, int after) {
 }
 
 /* Remove the specified node from the specified list.
- * The node is freed but it's up to the caller to free the private value of the node.
+ * The node is freed. If free callback is provided the value is freed as well.
  *
  * This function can't fail. */
 void listDelNode(list *list, listNode *node)
@@ -398,4 +398,13 @@ void listJoin(list *l, list *o) {
     /* Setup other as an empty list. */
     o->head = o->tail = NULL;
     o->len = 0;
+}
+
+/* Initializes the node's value and sets its pointers
+ * so that it is initially not a member of any list.
+ */
+void listInitNode(listNode *node, void *value) {
+    node->prev = NULL;
+    node->next = NULL;
+    node->value = value;
 }

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -88,11 +88,7 @@ void listRewindTail(list *list, listIter *li);
 void listRotateTailToHead(list *list);
 void listRotateHeadToTail(list *list);
 void listJoin(list *l, list *o);
-static inline void listInitNode(listNode *node, void *value) {
-    node->prev = (void * )0;
-    node->next = (void * )0;
-    node->value = value;
-}
+void listInitNode(listNode *node, void *value);
 void listLinkNodeHead(list *list, listNode *node);
 void listUnlinkNode(list *list, listNode *node);
 

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -88,6 +88,13 @@ void listRewindTail(list *list, listIter *li);
 void listRotateTailToHead(list *list);
 void listRotateHeadToTail(list *list);
 void listJoin(list *l, list *o);
+static inline void listInitNode(listNode *node, void *value) {
+    node->prev = (void * )0;
+    node->next = (void * )0;
+    node->value = value;
+}
+void listLinkNodeHead(list *list, listNode *node);
+void listUnlinkNode(list *list, listNode *node);
 
 /* Directions for iterators */
 #define AL_START_HEAD 0

--- a/src/module.c
+++ b/src/module.c
@@ -7522,7 +7522,7 @@ void moduleHandleBlockedClients(void) {
                 !(c->flags & CLIENT_PENDING_WRITE))
             {
                 c->flags |= CLIENT_PENDING_WRITE;
-                listAddNodeHead(server.clients_pending_write,c);
+                listLinkNodeHead(server.clients_pending_write, &c->clients_pending_write_node);
             }
         }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -207,6 +207,7 @@ client *createClient(connection *conn) {
     c->auth_callback = NULL;
     c->auth_callback_privdata = NULL;
     c->auth_module = NULL;
+    listInitNode(&c->clients_pending_write_node, c);
     listSetFreeMethod(c->pubsub_patterns,decrRefCountVoid);
     listSetMatchMethod(c->pubsub_patterns,listMatchObjects);
     c->mem_usage_bucket = NULL;
@@ -255,7 +256,7 @@ void putClientInPendingWriteQueue(client *c) {
          * a system call. We'll only really install the write handler if
          * we'll not be able to write the whole reply at once. */
         c->flags |= CLIENT_PENDING_WRITE;
-        listAddNodeHead(server.clients_pending_write,c);
+        listLinkNodeHead(server.clients_pending_write, &c->clients_pending_write_node);
     }
 }
 
@@ -1499,9 +1500,9 @@ void unlinkClient(client *c) {
 
     /* Remove from the list of pending writes if needed. */
     if (c->flags & CLIENT_PENDING_WRITE) {
-        ln = listSearchKey(server.clients_pending_write,c);
-        serverAssert(ln != NULL);
-        listDelNode(server.clients_pending_write,ln);
+        serverAssert(&c->clients_pending_write_node.next != NULL || 
+                     &c->clients_pending_write_node.prev != NULL);
+        listUnlinkNode(server.clients_pending_write, &c->clients_pending_write_node);
         c->flags &= ~CLIENT_PENDING_WRITE;
     }
 
@@ -2035,7 +2036,7 @@ int handleClientsWithPendingWrites(void) {
     while((ln = listNext(&li))) {
         client *c = listNodeValue(ln);
         c->flags &= ~CLIENT_PENDING_WRITE;
-        listDelNode(server.clients_pending_write,ln);
+        listUnlinkNode(server.clients_pending_write,ln);
 
         /* If a client is protected, don't do anything,
          * that may trigger write error or recreate handler. */
@@ -4216,7 +4217,7 @@ int handleClientsWithPendingWritesUsingThreads(void) {
         /* Remove clients from the list of pending writes since
          * they are going to be closed ASAP. */
         if (c->flags & CLIENT_CLOSE_ASAP) {
-            listDelNode(server.clients_pending_write, ln);
+            listUnlinkNode(server.clients_pending_write, ln);
             continue;
         }
 
@@ -4275,7 +4276,9 @@ int handleClientsWithPendingWritesUsingThreads(void) {
             installClientWriteHandler(c);
         }
     }
-    listEmpty(server.clients_pending_write);
+    while(listLength(server.clients_pending_write) > 0) {
+        listUnlinkNode(server.clients_pending_write, server.clients_pending_write->head);
+    }
 
     /* Update processed count on server */
     server.stat_io_writes_processed += processed;

--- a/src/server.h
+++ b/src/server.h
@@ -1186,6 +1186,8 @@ typedef struct client {
     size_t ref_block_pos;        /* Access position of referenced buffer block,
                                   * i.e. the next offset to send. */
 
+    /* list node in clients_pending_write list */
+    listNode clients_pending_write_node;
     /* Response buffer */
     size_t buf_peak; /* Peak used size of buffer in last 5 sec interval. */
     mstime_t buf_peak_last_reset_time; /* keeps the last time the buffer peak value was reset */


### PR DESCRIPTION
### Intro
When a client has a pending write the corresponding client struct is added to the global server.clients_pending_write list. When a pending write is handled the corresponding client struct is removed from the clients_pending_write list.

### Current Behavior:
When a client struct is added to the clients_pending_write list, a new listnode is malloced and its ptr field is set to point to the client struct. When a client struct is removed from cleints_pending_write the listnode pointing to that client is freed.
 
 
We observed that in an 800 client test scenario, redis spends about 3% of its time mallocing and freeing listnodes for the clients_pending_write list.

### Proposed Behavior:
We take inspiration from the linked list implementation of the linux kernel and suggest adding a listnode field to the client struct to be used in the clients_pending_write list. The clients "point to each other" instead of being pointed to by external list nodes. This spares a malloc call when adding a client struct to the list, and spares a free call when removing a client from the list.

### Numbers we observed:
Our benchmarks showed a 3% improvement on the m5.xlarge series of AWS EC2 instances.
We used 20% set 80% get with 512 bytes data size and 100% hit ratio

Redis 7 before the change: Average of 212612 RPS
Redis 7 after the chang: Average of 220331 RPS
3.6% improvement

Redis 6.2 before the change: Average of 227134 RPS
Redis 6.2 after the change 231979 RPS
2% improvement 

Also note that it is not expected to affect the memory footprint as it is expected that each client struct will be added to the clients_pending_write list (since clients expect a response)

```
Release notes
Minor performance improvement for workloads that use commands without pipelining.
```