### PR TITLE
fix test Migrate the last slot away from a node using redis-cli

### DIFF
--- a/tests/support/cluster_helper.tcl
+++ b/tests/support/cluster_helper.tcl
@@ -16,12 +16,31 @@ proc cluster_config_consistent {} {
     return 1
 }
 
+# Check if cluster size is consistent.
+proc cluster_size_consistent {cluster_size} {
+    for {set j 0} {$j < $cluster_size} {incr j} {
+        if {[CI $j cluster_known_nodes] ne $cluster_size} {
+            return 0
+        }
+    }
+    return 1
+}
+
 # Wait for cluster configuration to propagate and be consistent across nodes.
 proc wait_for_cluster_propagation {} {
     wait_for_condition 50 100 {
         [cluster_config_consistent] eq 1
     } else {
         fail "cluster config did not reach a consistent state"
+    }
+}
+
+# Wait for cluster size to be consistent across nodes.
+proc wait_for_cluster_size {cluster_size} {
+    wait_for_condition 50 100 {
+        [cluster_size_consistent $cluster_size] eq 1
+    } else {
+        fail "cluster size did not reach a consistent size $cluster_size"
     }
 }
 

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -229,7 +229,10 @@ test {Migrate the last slot away from a node using redis-cli} {
         exec src/redis-cli --cluster-yes --cluster add-node \
                      127.0.0.1:[srv -3 port] \
                      127.0.0.1:[srv 0 port]
-
+        
+        # First we wait for new node to be recognized by entire cluster 
+        wait_for_cluster_size 4
+        
         wait_for_condition 1000 50 {
             [CI 0 cluster_state] eq {ok} &&
             [CI 1 cluster_state] eq {ok} &&


### PR DESCRIPTION
When using cli to add node, there can potentially be a race condition in
which all nodes presenting cluster state o.k even though the added node
did not yet meet all cluster nodes.
this adds another utility function to wait untill all cluster nodes
see the same cluster size