### PR TITLE
Correctly handle scripts with shebang (not read-only) on a cluster replica

### DIFF
--- a/tests/cluster/tests/16-transactions-on-replica.tcl
+++ b/tests/cluster/tests/16-transactions-on-replica.tcl
@@ -69,3 +69,11 @@ test "read-only blocking operations from replica" {
     assert {$res eq {foo bar}}
     $rd close
 }
+
+test "reply MOVED when eval from replica for update" {
+    catch {[$replica eval {#!lua
+        return redis.call('del','a')
+        } 1 a
+    ]} err
+    assert {[string range $err 0 4] eq {MOVED}}
+}


### PR DESCRIPTION
EVAL scripts are by default not considered `write` commands, so they were allowed on a replica.
But when adding a shebang, they become `write` command (unless the `no-writes` flag is added).
With this change we'll handle them as write commands, and reply with MOVED instead of READONLY when executed on a redis cluster replica.