### PR TITLE
Retain ACL categories used to generate ACL for displaying them later

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -536,7 +536,7 @@ void ACLSelectorRemoveCommandRule(aclSelector *selector, sds new_rule) {
     char *existing_rule = selector->command_rules;
 
     /* Loop over the existing rules, trying to find a rule that "matches"
-     * it. If we find a match, then remove the command from the string by
+     * the new rule. If we find a match, then remove the command from the string by
      * copying the later rules over it. */
     while(existing_rule[0]) {
         /* The first character of the rule is +/-, which we don't need to compare. */

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -512,13 +512,13 @@ start_server {tags {"acl external:skip"}} {
         }
     }
 
-    # Test that only self-consistent ACL compactions occur.
+    # Test that only lossless compation of ACLs occur.
     test {ACL GETUSER provides correct results} {
         r ACL SETUSER adv-test
         r ACL SETUSER adv-test +@all -@hash -@slow +hget
         assert_equal "+@all -@hash -@slow +hget" [dict get [r ACL getuser adv-test] commands]
 
-        # Categories are re-ordered if re-added and reset command bits
+        # Categories are re-ordered if re-added
         r ACL SETUSER adv-test -@hash
         assert_equal "+@all -@slow +hget -@hash" [dict get [r ACL getuser adv-test] commands]
 
@@ -529,6 +529,8 @@ start_server {tags {"acl external:skip"}} {
         # Inverting the all category compacts everything
         r ACL SETUSER adv-test -@all
         assert_equal "-@all" [dict get [r ACL getuser adv-test] commands]
+        r ACL SETUSER adv-test -@string -@slow +@all
+        assert_equal "+@all" [dict get [r ACL getuser adv-test] commands]
 
         # Make sure categories are case insensitive
         r ACL SETUSER adv-test -@all +@HASH +@hash +@HaSh

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -512,7 +512,7 @@ start_server {tags {"acl external:skip"}} {
         }
     }
 
-    # Test that only lossless compation of ACLs occur.
+    # Test that only lossless compaction of ACLs occur.
     test {ACL GETUSER provides correct results} {
         r ACL SETUSER adv-test
         r ACL SETUSER adv-test +@all -@hash -@slow +hget

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -421,9 +421,10 @@ start_server {tags {"acl external:skip"}} {
 
         # Appending to the existing access string of bob.
         r ACL setuser bob +@all +client|id
-        # Validate the new commands has got engulfed to +@all.
+        # Although this does nothing, we retain it anyways so we can reproduce
+        # the original ACL. 
         set cmdstr [dict get [r ACL getuser bob] commands]
-        assert_equal {+@all} $cmdstr
+        assert_equal {+@all +client|id} $cmdstr
 
         r ACL setuser bob >passwd1 on
         r AUTH bob passwd1
@@ -519,25 +520,41 @@ start_server {tags {"acl external:skip"}} {
 
         # Categories are re-ordered if re-added and reset command bits
         r ACL SETUSER adv-test -@hash
-        assert_equal "+@all -@slow -@hash" [dict get [r ACL getuser adv-test] commands]
+        assert_equal "+@all -@slow +hget -@hash" [dict get [r ACL getuser adv-test] commands]
 
         # Inverting categories removes existing categories
         r ACL SETUSER adv-test +@hash
-        assert_equal "+@all -@slow +@hash" [dict get [r ACL getuser adv-test] commands]
+        assert_equal "+@all -@slow +hget +@hash" [dict get [r ACL getuser adv-test] commands]
 
         # Inverting the all category compacts everything
         r ACL SETUSER adv-test -@all
         assert_equal "-@all" [dict get [r ACL getuser adv-test] commands]
 
         # Make sure categories are case insensitive
-        r ACL SETUSER adv-test -@all +@HASH
+        r ACL SETUSER adv-test -@all +@HASH +@hash +@HaSh
         assert_equal "-@all +@hash" [dict get [r ACL getuser adv-test] commands]
+
+        # Make sure commands are case insensitive
+        r ACL SETUSER adv-test -@all +HGET +hget +hGeT
+        assert_equal "-@all +hget" [dict get [r ACL getuser adv-test] commands]
 
         # Arbitrary category additions and removals are handled
         r ACL SETUSER adv-test -@all +@hash +@slow +@set +@set +@slow +@hash
         assert_equal "-@all +@set +@slow +@hash" [dict get [r ACL getuser adv-test] commands]
 
-        # Unecesary categories are retained for potentional future compatibility
+        # Arbitrary command additions and removals are handled
+        r ACL SETUSER adv-test -@all +hget -hset +hset -hget
+        assert_equal "-@all +hset -hget" [dict get [r ACL getuser adv-test] commands]
+
+        # Arbitrary subcommands are compacted
+        r ACL SETUSER adv-test -@all +client|list +client|list +config|get +config +acl|list -acl
+        assert_equal "-@all +client|list +config -acl" [dict get [r ACL getuser adv-test] commands]
+
+        # Deprecated subcommand usage is handled
+        r ACL SETUSER adv-test -@all +select|0 +select|0 +debug|segfault +debug
+        assert_equal "-@all +select|0 +debug" [dict get [r ACL getuser adv-test] commands]
+
+        # Unnecessary categories are retained for potentional future compatibility
         r ACL SETUSER adv-test -@all -@dangerous
         assert_equal "-@all -@dangerous" [dict get [r ACL getuser adv-test] commands]
     }


### PR DESCRIPTION
A suggestion for how to resolve part of https://github.com/redis/redis/issues/11083. The idea is that we should retain categories and commands so we can correctly produce ACL strings that represent the original intention of the user. 

The new strategy is as follow:
1. Retain the exact order of categories and commands provided from the user, stored in a string. 
2. Completely compact commands and categories when +@all or -@all are used.
3. Remove duplicate command, categories, or subcommands. Note: That deduping commands will remove extra subcommands. 

Note, this does provide a slightly different output. Rules which don't "do" anything will be kept and printed back out. Some examples:
1. "+@all +hget": Hget can't do anything since all commands were previously added.
2. "+@all -@hash -hget": -Hget is implicitly covered as part of -@hash. Since something may change in the future with modules, we leave the hget.

Some of these, like 1, could be resolved but it would add complexity that isn't really needed.

```
Release notes
The way ACL users are stored internally no longer removes redundant command and category rules, which may alter the way those rules are displayed as part of `ACL SAVE`, `ACL GETUSER` and `ACL LIST`. 
```