### PR TITLE
Optimize setGenericCommand(): no need to remove the expiration information if 'expire' is not NULL

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -100,6 +100,7 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
     }
 
     setkey_flags |= (flags & OBJ_KEEPTTL) ? SETKEY_KEEPTTL : 0;
+    setkey_flags |= expire ? SETKEY_KEEPTTL : 0; /* No need to remove TTL in setKey(). setExpire() will overwrite the TTL later. */
     setkey_flags |= found ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST;
 
     setKey(c,c->db,key,val,setkey_flags);


### PR DESCRIPTION
Before this change, when we call setGenericCommand() with expire set, the expiration information(key and its TTL) will be removed in setKey() function, and then later be set back in the setExpire() function. 

Actually, there is no need to remove the expiration information; the setExpire() function can overwrite the key with its new TTL. 

An optimization is to set the SETKEY_KEEPTTL flag when expire is not NULL so that the TTL will not be removed in setKey() before we use setExpire() to overwrite it.