### PR TITLE
Change geohashGetCoordRange function for static variables

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -379,10 +379,8 @@ int membersOfAllNeighbors(robj *zobj, const GeoHashRadius *n, GeoShape *shape, g
 
         /* Debugging info. */
         if (debugmsg) {
-            GeoHashRange long_range, lat_range;
-            geohashGetCoordRange(&long_range,&lat_range);
             GeoHashArea myarea = {{0}};
-            geohashDecode(long_range, lat_range, neighbors[i], &myarea);
+            geohashDecode(geoLongLimit, geoLatLimit, neighbors[i], &myarea);
 
             /* Dump center square. */
             D("neighbors[%d]:\n",i);

--- a/src/geohash.c
+++ b/src/geohash.c
@@ -49,6 +49,10 @@
  * x and y must initially be less than 2**32 (4294967296).
  * From:  https://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN
  */
+
+GeoHashRange geoLatLimit = {.min = GEO_LAT_MIN, .max = GEO_LAT_MAX};
+GeoHashRange geoLongLimit = {.min = GEO_LONG_MIN, .max = GEO_LONG_MAX};
+
 static inline uint64_t interleave64(uint32_t xlo, uint32_t ylo) {
     static const uint64_t B[] = {0x5555555555555555ULL, 0x3333333333333333ULL,
                                  0x0F0F0F0F0F0F0F0FULL, 0x00FF00FF00FF00FFULL,
@@ -109,15 +113,6 @@ static inline uint64_t deinterleave64(uint64_t interleaved) {
     return x | (y << 32);
 }
 
-void geohashGetCoordRange(GeoHashRange *long_range, GeoHashRange *lat_range) {
-    /* These are constraints from EPSG:900913 / EPSG:3785 / OSGEO:41001 */
-    /* We can't geocode at the north/south pole. */
-    long_range->max = GEO_LONG_MAX;
-    long_range->min = GEO_LONG_MIN;
-    lat_range->max = GEO_LAT_MAX;
-    lat_range->min = GEO_LAT_MIN;
-}
-
 int geohashEncode(const GeoHashRange *long_range, const GeoHashRange *lat_range,
                   double longitude, double latitude, uint8_t step,
                   GeoHashBits *hash) {
@@ -151,9 +146,7 @@ int geohashEncode(const GeoHashRange *long_range, const GeoHashRange *lat_range,
 }
 
 int geohashEncodeType(double longitude, double latitude, uint8_t step, GeoHashBits *hash) {
-    GeoHashRange r[2] = {{0}};
-    geohashGetCoordRange(&r[0], &r[1]);
-    return geohashEncode(&r[0], &r[1], longitude, latitude, step, hash);
+    return geohashEncode(&geoLongLimit, &geoLatLimit, longitude, latitude, step, hash);
 }
 
 int geohashEncodeWGS84(double longitude, double latitude, uint8_t step,
@@ -194,9 +187,7 @@ int geohashDecode(const GeoHashRange long_range, const GeoHashRange lat_range,
 }
 
 int geohashDecodeType(const GeoHashBits hash, GeoHashArea *area) {
-    GeoHashRange r[2] = {{0}};
-    geohashGetCoordRange(&r[0], &r[1]);
-    return geohashDecode(r[0], r[1], hash, area);
+    return geohashDecode(geoLongLimit, geoLatLimit, hash, area);
 }
 
 int geohashDecodeWGS84(const GeoHashBits hash, GeoHashArea *area) {

--- a/src/geohash.h
+++ b/src/geohash.h
@@ -72,6 +72,9 @@ typedef struct {
     double max;
 } GeoHashRange;
 
+extern GeoHashRange geoLatLimit;
+extern GeoHashRange geoLongLimit;
+
 typedef struct {
     GeoHashBits hash;
     GeoHashRange longitude;

--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -119,7 +119,6 @@ int geohashBoundingBox(GeoShape *shape, double *bounds) {
  * for the specified position and shape (see geohash.h GeoShape).
  * the bounding box saved in shaple.bounds */
 GeoHashRadius geohashCalculateAreasByShapeWGS84(GeoShape *shape) {
-    GeoHashRange long_range, lat_range;
     GeoHashRadius radius;
     GeoHashBits hash;
     GeoHashNeighbors neighbors;
@@ -145,10 +144,9 @@ GeoHashRadius geohashCalculateAreasByShapeWGS84(GeoShape *shape) {
 
     steps = geohashEstimateStepsByRadius(radius_meters,latitude);
 
-    geohashGetCoordRange(&long_range,&lat_range);
-    geohashEncode(&long_range,&lat_range,longitude,latitude,steps,&hash);
+    geohashEncode(&geoLongLimit,&geoLatLimit,longitude,latitude,steps,&hash);
     geohashNeighbors(&hash,&neighbors);
-    geohashDecode(long_range,lat_range,hash,&area);
+    geohashDecode(geoLongLimit,geoLatLimit,hash,&area);
 
     /* Check if the step is enough at the limits of the covered area.
      * Sometimes when the search area is near an edge of the
@@ -159,10 +157,10 @@ GeoHashRadius geohashCalculateAreasByShapeWGS84(GeoShape *shape) {
     {
         GeoHashArea north, south, east, west;
 
-        geohashDecode(long_range, lat_range, neighbors.north, &north);
-        geohashDecode(long_range, lat_range, neighbors.south, &south);
-        geohashDecode(long_range, lat_range, neighbors.east, &east);
-        geohashDecode(long_range, lat_range, neighbors.west, &west);
+        geohashDecode(geoLongLimit, geoLatLimit, neighbors.north, &north);
+        geohashDecode(geoLongLimit, geoLatLimit, neighbors.south, &south);
+        geohashDecode(geoLongLimit, geoLatLimit, neighbors.east, &east);
+        geohashDecode(geoLongLimit, geoLatLimit, neighbors.west, &west);
 
         if (north.latitude.max < max_lat) 
             decrease_step = 1;
@@ -176,9 +174,9 @@ GeoHashRadius geohashCalculateAreasByShapeWGS84(GeoShape *shape) {
 
     if (steps > 1 && decrease_step) {
         steps--;
-        geohashEncode(&long_range,&lat_range,longitude,latitude,steps,&hash);
+        geohashEncode(&geoLongLimit,&geoLatLimit,longitude,latitude,steps,&hash);
         geohashNeighbors(&hash,&neighbors);
-        geohashDecode(long_range,lat_range,hash,&area);
+        geohashDecode(geoLongLimit,geoLatLimit,hash,&area);
     }
 
     /* Exclude the search areas that are useless. */


### PR DESCRIPTION
This PR might not have a significant impact on performance (though the first run, I had a huge gap), but it clears up some code and feels unnecessary.

![geohashGetCoordRange](https://user-images.githubusercontent.com/44112901/188111820-886a993f-a3ad-4e1a-b983-0b2dcad9a6e0.png)