### PR TITLE
Use cached value correctly inside connectionTypeTls()

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -82,6 +82,8 @@ ConnectionType *connectionByType(const char *typename) {
             return ct;
     }
 
+    serverLog(LL_WARNING, "Missing implement of connection type %s", typename);
+
     return NULL;
 }
 
@@ -101,11 +103,13 @@ ConnectionType *connectionTypeTcp() {
 /* Cache TLS connection type, query it by string once */
 ConnectionType *connectionTypeTls() {
     static ConnectionType *ct_tls = NULL;
+    static int cached = 0;
 
-    if (ct_tls != NULL)
-        return ct_tls;
+    if (!cached) {
+        cached = 1;
+        ct_tls = connectionByType(CONN_TYPE_TLS);
+    }
 
-    ct_tls = connectionByType(CONN_TYPE_TLS);
     return ct_tls;
 }
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -105,6 +105,8 @@ ConnectionType *connectionTypeTls() {
     static ConnectionType *ct_tls = NULL;
     static int cached = 0;
 
+    /* Unlike the TCP and Unix connections, the TLS one can be missing
+     * So we need the cached pointer to handle NULL correctly too. */
     if (!cached) {
         cached = 1;
         ct_tls = connectionByType(CONN_TYPE_TLS);

--- a/src/connection.c
+++ b/src/connection.c
@@ -82,8 +82,6 @@ ConnectionType *connectionByType(const char *typename) {
             return ct;
     }
 
-    serverLog(LL_WARNING, "Missing implement of connection type %s", typename);
-
     return NULL;
 }
 


### PR DESCRIPTION
When Redis is built without TLS support, connectionTypeTls() function 
keeps searching connection type as cached connection type is NULL. 

Added another variable to track if we cached the connection type to 
prevent search after the first time. 

Noticed a log warning message is printed repeatedly by connectionTypeTls.

Introduced by https://github.com/redis/redis/pull/9320