### PR TITLE
Fix typo in DEBUG REPLYBUFFER RESIZING comment

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -489,7 +489,7 @@ void debugCommand(client *c) {
 "    In case NEVER is provided the last observed peak will never be reset",
 "    In case RESET is provided the peak reset time will be restored to the default value",
 "REPLYBUFFER RESIZING <0|1>",
-"    Enable or disable the replay buffer resize cron job",
+"    Enable or disable the reply buffer resize cron job",
 NULL
         };
         addReplyHelp(c, help);


### PR DESCRIPTION
The current description about `REPLYBUFFER RESIZING` which we get from `DEBUG HELP` is as follows.

```
101) REPLYBUFFER RESIZING <0|1>
102)     Enable or disable the replay buffer resize cron job
```

This command is related with reply buffer, not replay buffer. This PR is for fixing this word.