### PR TITLE
Merge accept handler

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1089,7 +1089,8 @@ acllog-max-len 128
 # minus 32 (as Redis reserves a few file descriptors for internal uses).
 #
 # Once the limit is reached Redis will close all the new connections sending
-# an error 'max number of clients reached'.
+# an error 'max number of clients reached'; or an error
+# 'ERR max number of clients + cluster connections reached' when cluster enabled.
 #
 # IMPORTANT: When Redis Cluster is used, the max number of connections is also
 # shared with the cluster bus: every node in the cluster will use two

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -906,12 +906,7 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
 
         connection *conn = connCreateAccepted(connTypeOfCluster(), cfd, &require_auth);
 
-        /* Make sure connection is not in an error state */
-        if (connGetState(conn) != CONN_STATE_ACCEPTING) {
-            serverLog(LL_VERBOSE,
-                "Error creating an accepting connection for cluster node: %s",
-                    connGetLastError(conn));
-            connClose(conn);
+        if (acceptConnOK(conn, 1) != C_OK) {
             return;
         }
         connEnableTcpNoDelay(conn);

--- a/src/connection.h
+++ b/src/connection.h
@@ -82,7 +82,7 @@ typedef struct ConnectionType {
 
     /* create/close connection */
     connection* (*conn_create)(void);
-    connection* (*conn_create_accepted)(int fd, void *priv);
+    connection* (*conn_create_accepted)(connListener *listener, int fd, void *priv);
     void (*close)(struct connection *conn);
 
     /* connect & accept */
@@ -390,8 +390,8 @@ static inline connection *connCreate(ConnectionType *ct) {
 
 /* Create an accepted connection of specified type.
  * priv is connection type specified argument */
-static inline connection *connCreateAccepted(ConnectionType *ct, int fd, void *priv) {
-    return ct->conn_create_accepted(fd, priv);
+static inline connection *connCreateAccepted(ConnectionType *ct, connListener *listener, int fd, void *priv) {
+    return ct->conn_create_accepted(listener, fd, priv);
 }
 
 /* Configure a connection type. A typical case is to configure TLS.

--- a/src/networking.c
+++ b/src/networking.c
@@ -125,9 +125,6 @@ client *createClient(connection *conn) {
      * in the context of a client. When commands are executed in other
      * contexts (for instance a Lua script) we need a non connected client. */
     if (conn) {
-        connEnableTcpNoDelay(conn);
-        if (server.tcpkeepalive)
-            connKeepAlive(conn,server.tcpkeepalive);
         connSetReadHandler(conn, readQueryFromClient);
         connSetPrivateData(conn, c);
     }
@@ -1325,9 +1322,6 @@ void acceptCommonHandler(connection *conn, int flags, char *ip) {
     client *c;
     char conninfo[100];
     UNUSED(ip);
-
-    if (acceptConnOK(conn, 0) != C_OK)
-        return;
 
     /* Create connection and client */
     if ((c = createClient(conn)) == NULL) {

--- a/src/server.h
+++ b/src/server.h
@@ -2442,6 +2442,7 @@ void setDeferredSetLen(client *c, void *node, long length);
 void setDeferredAttributeLen(client *c, void *node, long length);
 void setDeferredPushLen(client *c, void *node, long length);
 int processInputBuffer(client *c);
+int acceptConnOK(connection *conn, int is_cluster);
 void acceptCommonHandler(connection *conn, int flags, char *ip);
 void readQueryFromClient(connection *conn);
 int prepareClientToWrite(client *c);


### PR DESCRIPTION
The main purpose of this PR:
The cluster accept handler and connection accept handler has a lot of duplicated code, try to reuse the connection accept handler only. Then we can:
* Remove the connection related code from cluster.c
* Fix unexpected `setsockopt` on Unix socket
* Fix the exceeded maxclients when accepting a cluster node
* Drop .conn_create_accepted from connection type, it's possible to extend cluster bus by connection type only(without cluster.c change).

Detailed changes in each commit message.