### PR TITLE
Optimize setGenericCommand(): no need to remove the expiration entry when 'expire' is not NULL

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -99,7 +99,7 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
         return;
     }
 
-    /* When expire is not NULL, we avoid deleting so it can be updated later instead of first deleted and then created again. */
+    /* When expire is not NULL, we avoid deleting the TTL so it can be updated later instead of being deleted and then created again. */
     setkey_flags |= ((flags & OBJ_KEEPTTL) || expire) ? SETKEY_KEEPTTL : 0;
     setkey_flags |= found ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST;
 

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -99,7 +99,8 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
         return;
     }
 
-    setkey_flags |= (flags & OBJ_KEEPTTL) ? SETKEY_KEEPTTL : 0;
+    /* When expire is not NULL, we avoid deleting so it can be updated later instead of first deleted and then created again. */
+    setkey_flags |= ((flags & OBJ_KEEPTTL) || expire) ? SETKEY_KEEPTTL : 0;
     setkey_flags |= found ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST;
 
     setKey(c,c->db,key,val,setkey_flags);


### PR DESCRIPTION
In setGenericComannd() function, we remove the expiration entry from db->expires. However, I think we don't need to do this when 'expire' is not NULL, because in this case, we will call setExpire() later, which will overwrite the expiration entry with a new TTL. So we don't need to remove the entry now. We can keep it by setting the 'SETKEY_KEEPTTL' flag.