### PR TITLE
Optimize 'getset' operation: avoid calling lookupKey() twice on the same key

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -3089,6 +3089,7 @@ int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle,
 #define LOOKUP_NOSTATS (1<<2)  /* Don't update keyspace hits/misses counters. */
 #define LOOKUP_WRITE (1<<3)    /* Delete expired keys even in replicas. */
 #define LOOKUP_NOEXPIRE (1<<4) /* Avoid deleting lazy expired keys. */
+#define LOOKUP_READ (1<<5)     /* Afects stats and keyspace notifications for reads. */
 
 void dbAdd(redisDb *db, robj *key, robj *val);
 int dbAddRDBLoad(redisDb *db, sds key, robj *val);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -31,7 +31,7 @@
 #include <math.h> /* isnan(), isinf() */
 
 /* Forward declarations */
-int getGenericCommand(client *c);
+int getGenericCommand(client *c, int write, int *found);
 
 /*-----------------------------------------------------------------------------
  * String Commands
@@ -85,10 +85,10 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
     }
 
     if (flags & OBJ_SET_GET) {
-        if (getGenericCommand(c) == C_ERR) return;
+        if (getGenericCommand(c, 1, &found) == C_ERR) return;
+    } else {
+        found = (lookupKeyWrite(c->db,key) != NULL);
     }
-
-    found = (lookupKeyWrite(c->db,key) != NULL);
 
     if ((flags & OBJ_SET_NX && found) ||
         (flags & OBJ_SET_XX && !found))
@@ -312,11 +312,23 @@ void psetexCommand(client *c) {
     setGenericCommand(c,OBJ_PX,c->argv[1],c->argv[3],c->argv[2],UNIT_MILLISECONDS,NULL,NULL);
 }
 
-int getGenericCommand(client *c) {
+/* The getGenericCommand() function is called in order to implement GET, GETDEL and GETSET command.
+ * If 'write' is zero, we use lookupKeyReadOrReply to look for the key and reply, otherwise we use
+ * lookupKeyWriteOrReply(GETSET command use this). 
+ * If 'found' is not NULL, we set *found to 1 if we found the key, or 0 if the key doesn't exist. */
+int getGenericCommand(client *c, int write, int *found) {
     robj *o;
+    if (found) *found = 0;
 
-    if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp])) == NULL)
-        return C_OK;
+    if (write) {
+        if ((o = lookupKeyWriteOrReply(c,c->argv[1],shared.null[c->resp])) == NULL)
+            return C_OK;
+    } else {
+        if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp])) == NULL)
+            return C_OK;
+    }
+
+    if (found) *found = 1;
 
     if (checkType(c,o,OBJ_STRING)) {
         return C_ERR;
@@ -327,7 +339,7 @@ int getGenericCommand(client *c) {
 }
 
 void getCommand(client *c) {
-    getGenericCommand(c);
+    getGenericCommand(c, 0, NULL);
 }
 
 /*
@@ -411,7 +423,7 @@ void getexCommand(client *c) {
 }
 
 void getdelCommand(client *c) {
-    if (getGenericCommand(c) == C_ERR) return;
+    if (getGenericCommand(c, 0, NULL) == C_ERR) return;
     if (dbSyncDelete(c->db, c->argv[1])) {
         /* Propagate as DEL command */
         rewriteClientCommandVector(c,2,shared.del,c->argv[1]);
@@ -422,9 +434,11 @@ void getdelCommand(client *c) {
 }
 
 void getsetCommand(client *c) {
-    if (getGenericCommand(c) == C_ERR) return;
+    int found, setkey_flags;
+    if (getGenericCommand(c, 1, &found) == C_ERR) return;
     c->argv[2] = tryObjectEncoding(c->argv[2]);
-    setKey(c,c->db,c->argv[1],c->argv[2],0);
+    setkey_flags = found ? SETKEY_ALREADY_EXIST : SETKEY_DOESNT_EXIST;
+    setKey(c,c->db,c->argv[1],c->argv[2],setkey_flags);
     notifyKeyspaceEvent(NOTIFY_STRING,"set",c->argv[1],c->db->id);
     server.dirty++;
 


### PR DESCRIPTION
The 'getset' operation first use `getGenericCommand()` to perform get operation, and then use `setKey()` to perform set.

`getGenericCommand()` calls `lookupKeyReadOrReply()` to look for the key and reply. Then `setKey()` calls `lookupKeyWrite()` to check the existence of the key and because LOOKUP_WRITE flag is set, expire the key if its TTL is reached. 

I think only calling `lookupKeyWrite()` is enough. So this PR updated the `getGenericCommand()` function in the following two places:

1. Use lookupKey**Write**OrReply() instead of  lookupKey**Read**OrReply() in the **getset** case.

2. Use a parameter `int *found` to return the existence of the key, so that `setKey()` **doesn't need to check the existence again**, and here is where this PR optimized.


Also optimize setGenericCommand() function with OBJ_SET_GET flag set.