### PR TITLE
Prevent use after free for inbound cluster link

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -845,10 +845,15 @@ void setClusterNodeToInboundClusterLink(clusterNode *node, clusterLink *link) {
         /* A peer may disconnect and then reconnect with us, and it's not guaranteed that
          * we would always process the disconnection of the existing inbound link before
          * accepting a new existing inbound link. Therefore, it's possible to have more than
-         * one inbound link from the same node at the same time. */
+         * one inbound link from the same node at the same time. Our cleanup logic assumes
+         * a one to one relationship between nodes and inbound links, so we need to kill
+         * one of the links. The existing link is more likely the outdated one, but it's
+         * possible the the other node may need to open another link. */
         serverLog(LL_DEBUG, "Replacing inbound link fd %d from node %.40s with fd %d",
                 node->inbound_link->conn->fd, node->name, link->conn->fd);
+        freeClusterLink(node->inbound_link);
     }
+    serverAssert(!node->inbound_link);
     node->inbound_link = link;
     link->node = node;
 }


### PR DESCRIPTION
As part of https://github.com/redis/redis/pull/9774, we introduced a change so that we keep track of both the inbound and outbound links for cluster nodes. However, it's possible to have multiple inbound links at the same time when the remote node is attempting to reconnect. The current code replaces the `inbound_link` with the new link. This leaves a dangling reference to the node on the older cluster link Since nodes and links have mutual references. The solution here is just to drop the old link.