### PR TITLE
persistent storage of slowlogs

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1808,11 +1808,14 @@ aof-timestamp-enabled no
 # stage of command execution where the thread is blocked and can not serve
 # other requests in the meantime).
 #
-# You can configure the slow log with two parameters: one tells Redis
-# what is the execution time, in microseconds, to exceed in order for the
-# command to get logged, and the other parameter is the length of the
+# You can configure the slow log with three parameters: the first parameter
+# is the switch for writing slow log to logfile. the second parameter tells 
+# Redis what is the execution time, in microseconds, to exceed in order for 
+# the command to get logged, and the third parameter is the length of the
 # slow log. When a new command is logged the oldest one is removed from the
 # queue of logged commands.
+
+slowlog-save-in-logfile no
 
 # The following time is expressed in microseconds, so 1000000 is equivalent
 # to one second. Note that a negative number disables the slow log, while

--- a/redis.conf
+++ b/redis.conf
@@ -1815,7 +1815,7 @@ aof-timestamp-enabled no
 # slow log. When a new command is logged the oldest one is removed from the
 # queue of logged commands.
 
-slowlog-save-in-logfile no
+#slowlog-save-in-logfile yes
 
 # The following time is expressed in microseconds, so 1000000 is equivalent
 # to one second. Note that a negative number disables the slow log, while

--- a/src/config.c
+++ b/src/config.c
@@ -3018,6 +3018,7 @@ standardConfig static_configs[] = {
     createBoolConfig("latency-tracking", NULL, MODIFIABLE_CONFIG, server.latency_tracking_enabled, 1, NULL, NULL),
     createBoolConfig("aof-disable-auto-gc", NULL, MODIFIABLE_CONFIG, server.aof_disable_auto_gc, 0, NULL, updateAofAutoGCEnabled),
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
+    createBoolConfig("slowlog-save-in-logfile", NULL, MODIFIABLE_CONFIG, server.slowlog_in_logfile, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/server.c
+++ b/src/server.c
@@ -98,9 +98,8 @@ const char *replstateToString(int replstate);
  * function of Redis may be called from other threads. */
 void nolocks_localtime(struct tm *tmp, time_t t, time_t tz, int dst);
 
-/* Low level logging. To use only for very big messages, otherwise
- * serverLog() is to prefer. */
-void serverLogRaw(int level, const char *msg) {
+/*Write logs to corresponding files.*/
+void writeInLogfile(int level, const char *msg, const char *logfile) {
     const int syslogLevelMap[] = { LOG_DEBUG, LOG_INFO, LOG_NOTICE, LOG_WARNING };
     const char *c = ".-*#";
     FILE *fp;
@@ -111,7 +110,7 @@ void serverLogRaw(int level, const char *msg) {
     level &= 0xff; /* clear flags */
     if (level < server.verbosity) return;
 
-    fp = log_to_stdout ? stdout : fopen(server.logfile,"a");
+    fp = log_to_stdout ? stdout : fopen(logfile,"a");
     if (!fp) return;
 
     if (rawmode) {
@@ -141,6 +140,58 @@ void serverLogRaw(int level, const char *msg) {
 
     if (!log_to_stdout) fclose(fp);
     if (server.syslog_enabled) syslog(syslogLevelMap[level], "%s", msg);
+}
+
+/* Low level logging. To use only for very big messages, otherwise
+ * serverLog() is to prefer. */
+void serverLogRaw(int level, const char *msg) {
+    writeInLogfile(level, msg, server.logfile);
+}
+void redisCheckLogName(const char *logfile, char *logfilename)
+{
+    if(NULL == logfile) return;
+
+    int len = strlen(logfile);
+    int i = len - 4;
+    if (i < 0)
+    {
+        strncpy(logfilename, logfile, len);
+        return;
+    }
+
+    if (logfile[i] == '.' && logfile[i+1] == 'l' &&
+        logfile[i+2] == 'o' && logfile[i+3] == 'g')
+    {
+        strncpy(logfilename, logfile, i);
+    }
+    else
+    {
+        strncpy(logfilename, logfile, len);
+    }
+    return;
+}
+
+void serverSlowLogRaw(int level, const char *msg) {
+    sds fname ;
+    char logfilename[1024] = {0};
+    redisCheckLogName(server.logfile, logfilename);
+    fname = sdsnew(logfilename);
+    fname = sdscat(fname, "-slow.log");
+    writeInLogfile(level, msg, fname);
+    sdsfree(fname);
+}
+
+void serverSlowLog(int level, const char *fmt, ...) {
+    va_list ap;
+    char msg[LOG_MAX_LEN];
+
+    if ((level&0xff) < server.verbosity) return;
+
+    va_start(ap, fmt);
+    vsnprintf(msg, sizeof(msg), fmt, ap);
+    va_end(ap);
+
+    serverSlowLogRaw(level,msg);
 }
 
 /* Like serverLogRaw() but with printf-alike support. This is the function that

--- a/src/server.h
+++ b/src/server.h
@@ -1567,6 +1567,7 @@ struct redisServer {
     long long stat_sync_partial_ok; /* Number of accepted PSYNC requests. */
     long long stat_sync_partial_err;/* Number of unaccepted PSYNC requests. */
     list *slowlog;                  /* SLOWLOG list of commands */
+    int  slowlog_in_logfile;        /* SLOWLOG save in logfile */
     long long slowlog_entry_id;     /* SLOWLOG current entry ID */
     long long slowlog_log_slower_than; /* SLOWLOG time limit (to get logged) */
     unsigned long slowlog_max_len;     /* SLOWLOG max number of items logged */
@@ -3512,6 +3513,7 @@ void lcsCommand(client *c);
 void quitCommand(client *c);
 void resetCommand(client *c);
 void failoverCommand(client *c);
+void serverSlowLog(int level, const char *fmt, ...);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));


### PR DESCRIPTION
 Slowlogs are stored in the memory. therefore, slowlogs cannot be saved when the server stopped and  i also can't view the slowlogs. i add the switch for writing slowlogs to logfile. it can allow us to view slowlogs in this case. 
i add the parameters `slowlog_in_logfile`. when `slowlog_in_logfile` is enabled, it can generate slowlo file. To prevent code redundancy， i change `serverLogRaw` and add `writeInLogfile`. `writeInLogfile` fuction is to write logs to the corresponding files.
persistent storage of slowlogs #11311 