### PR TITLE
Avoid crash when a cluster node is a replica of a replica of itself

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1972,7 +1972,13 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG|
                              CLUSTER_TODO_UPDATE_STATE|
                              CLUSTER_TODO_FSYNC_CONFIG);
-    } else if (myself->slaveof && myself->slaveof->slaveof) {
+    } else if (myself->slaveof && myself->slaveof->slaveof &&
+               /* In some rare case when CLUSTER FAILOVER TAKEOVER is used, it
+                * can happen that myself is a replica of a replica of myself. If
+                * this happens, we do nothing to avoid a crash and wait for the
+                * admin to repair the cluster. */
+               myself->slaveof->slaveof != myself)
+    {
         /* Safeguard against sub-replicas. A replica's master can turn itself
          * into a replica if its last slot is removed. If no other node takes
          * over the slot, there is nothing else to trigger replica migration. */


### PR DESCRIPTION
In a configuration with ~100 cluster nodes, where a machine containing 6 nodes is taken down and our internal recovery machinery kicks in, we have observed a crash.

Our internal machinery sends CLUSTER FAILOVER TAKOVER to replicas on other machines who lost their masters (TAKEOVER because we need to handle a scenario when we have only two machines and no majority if one goes down btw) and at the same time the cluster is rebalanced. Whether this is a good idea or not can be debated, but we observed a crash which happens when a node detects that it is a replica of a replica of itself.

The attempt to avoid being a sub-replica was introduced in #10489. Now, if the node is a sub-replica of itself, I suggest we simply skip this attempt and let the node remain a sub-replica of itself and hope that the cluster will be repaired later, either by itself or by an admin.

This is the crash log:

```
27186:M 29 Aug 2022 12:23:41.784 * No cluster configuration found, I'm 1ecbffc6dbe0eb9428eb53e46e66170fd1af8e22
27186:M 29 Aug 2022 12:23:41.788 * Running mode=cluster, port=7103.

...

27186:M 29 Aug 2022 13:15:14.012 # Connection with replica 127.3.6.1:7203 lost.
27186:M 29 Aug 2022 13:15:14.115 # Configuration change detected. Reconfiguring myself as a replica of 0a5070b5b7124bc88f2dd36acc86a6923340a6bf
27186:S 29 Aug 2022 13:15:14.126 * Before turning into a replica, using my own master parameters to synthesize a cached master: I may be able to synchronize with the new master with just a partial transfer.
27186:S 29 Aug 2022 13:15:14.126 * Connecting to MASTER 127.3.6.1:7203
27186:S 29 Aug 2022 13:15:14.126 * MASTER <-> REPLICA sync started
27186:S 29 Aug 2022 13:15:14.163 * Non blocking connect for SYNC fired the event.
27186:S 29 Aug 2022 13:15:14.336 # I'm a sub-replica! Reconfiguring myself as a replica of grandmaster 1ecbffc6dbe0eb9428eb53e46e66170fd1af8e22

=== REDIS BUG REPORT START: Cut & paste starting from here ===
27186:S 29 Aug 2022 13:15:14.336 # === ASSERTION FAILED ===
27186:S 29 Aug 2022 13:15:14.336 # ==> cluster.c:4546 'n != myself' is not true

------ STACK TRACE ------

Backtrace:
/opt/services/epg/bin/redis-server 127.3.0.1:7103 [cluster][0x4bd3b6]
/opt/services/epg/bin/redis-server 127.3.0.1:7103 [cluster](clusterUpdateSlotsConfigWith+0x282)[0x4c3192]
/opt/services/epg/bin/redis-server 127.3.0.1:7103 [cluster](clusterProcessPacket+0x881)[0x4c48e1]
/opt/services/epg/bin/redis-server 127.3.0.1:7103 [cluster](clusterReadHandler+0xfa)[0x4c53da]
/opt/services/epg/bin/redis-server 127.3.0.1:7103 [cluster][0x518ba1]
/opt/services/epg/bin/redis-server 127.3.0.1:7103 [cluster](aeProcessEvents+0x1d9)[0x44c169]
/opt/services/epg/bin/redis-server 127.3.0.1:7103 [cluster](aeMain+0x25)[0x44c535]
/opt/services/epg/bin/redis-server 127.3.0.1:7103 [cluster](main+0x342)[0x448252]
/lib64/libc.so.6(__libc_start_main+0xf0)[0x15555468d6a0]
/opt/services/epg/bin/redis-server 127.3.0.1:7103 [cluster](_start+0x29)[0x448799]
```

Explanation: The assert `'n != myself' is not true` happens in `clusterSetMaster()` when the node attempts turn itself into a replica of itself.

```
Release notes:
Fix a crash when a replica may attempt to set itself as its master as a result of a manual failover. 
```