### PR TITLE
`RedisModule_ResetDataset` should not clear the functions.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3891,7 +3891,7 @@ int RM_SetAbsExpire(RedisModuleKey *key, mstime_t expire) {
  * When async is set to true, db contents will be freed by a background thread. */
 void RM_ResetDataset(int restart_aof, int async) {
     if (restart_aof && server.aof_state != AOF_OFF) stopAppendOnly();
-    flushAllDataAndResetRDB(async? EMPTYDB_ASYNC: EMPTYDB_NO_FLAGS);
+    flushAllDataAndResetRDB((async? EMPTYDB_ASYNC: EMPTYDB_NO_FLAGS) | EMPTYDB_NOFUNCTIONS);
     if (server.aof_enabled && restart_aof) restartAOFAfterSYNC();
 }
 

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -44,6 +44,16 @@ start_server {tags {"modules"}} {
         assert_equal [r test.dbsize] 0
     }
 
+    test {test RedisModule_ResetDataset do not reset functions} {
+        r function load {#!lua name=lib
+            redis.register_function('test', function() return 1 end)
+        }
+        assert_equal [r function list] {{library_name lib engine LUA functions {{name test description {} flags {}}}}}
+        r test.flushall
+        assert_equal [r function list] {{library_name lib engine LUA functions {{name test description {} flags {}}}}}
+        r function flush
+    }
+
     test {test module keyexists} {
         r set x foo
         assert_equal 1 [r test.keyexists x]


### PR DESCRIPTION
Discussed on: https://github.com/redis/redis/pull/9953#issuecomment-1120432030

As mentioned on docs, `RM_ResetDataset` Performs similar operation to FLUSHALL. As FLUSHALL do not clean the function, `RM_ResetDataset` should not clean the functions as well.

This raise the question, do we want to add a RedisModuleAPI to clean functions or do we think that RM_Call is good enough for this?

Also we need to decide if this change is considered a breaking change.