### PR TITLE
fix: redis-cli --memkeys-samples add check lastarg

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2061,7 +2061,7 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--memkeys")) {
             config.memkeys = 1;
             config.memkeys_samples = 0; /* use redis default */
-        } else if (!strcmp(argv[i],"--memkeys-samples")) {
+        } else if (!strcmp(argv[i],"--memkeys-samples") && !lastarg) {
             config.memkeys = 1;
             config.memkeys_samples = atoi(argv[++i]);
         } else if (!strcmp(argv[i],"--hotkeys")) {


### PR DESCRIPTION
doing redis-cli --memkeys-samples without any additional arguments would have lead to a crash of the cli.
PR for issue [11267](https://github.com/redis/redis/issues/11267#issuecomment-1247629420)