### PR TITLE
remove data_delay check for cluster link timeout

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4186,9 +4186,7 @@ void clusterCron(void) {
             server.cluster_node_timeout && /* was not already reconnected */
             node->ping_sent && /* we already sent a ping */
             /* and we are waiting for the pong more than timeout/2 */
-            ping_delay > server.cluster_node_timeout/2 &&
-            /* and in such interval we are not seeing any traffic at all. */
-            data_delay > server.cluster_node_timeout/2)
+            ping_delay > server.cluster_node_timeout/2)
         {
             /* Disconnect the link, it will be reconnected automatically. */
             freeClusterLink(node->link);


### PR DESCRIPTION
"node->data_received" will be update not only by node.link, but also by the link from peer node, so use "node->data_received" to judge if need to freeClusterlink(node.link) is not not reasonable.