### PR TITLE
ACL default newly created user set USER_FLAG_SANITIZE_PAYLOAD flag

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -942,9 +942,9 @@ replica-priority 100
 #               "nopass" status. After "resetpass" the user has no associated
 #               passwords and there is no way to authenticate without adding
 #               some password (or setting it as "nopass" later).
-#  reset        Performs the following actions: resetpass, resetkeys, off,
-#               -@all. The user returns to the same state it has immediately
-#               after its creation.
+#  reset        Performs the following actions: resetpass, resetkeys, resetchannels,
+#               allchannels (if acl-pubsub-default is set), off, clearselectors, -@all.
+#               The user returns to the same state it has immediately after its creation.
 # (<options>)   Create a new selector with the options specified within the
 #               parentheses and attach it to the user. Each option should be 
 #               space separated. The first character must be ( and the last 

--- a/src/acl.c
+++ b/src/acl.c
@@ -384,6 +384,7 @@ user *ACLCreateUser(const char *name, size_t namelen) {
     user *u = zmalloc(sizeof(*u));
     u->name = sdsnewlen(name,namelen);
     u->flags = USER_FLAG_DISABLED;
+    u->flags |= USER_FLAG_SANITIZE_PAYLOAD;
     u->passwords = listCreate();
     listSetMatchMethod(u->passwords,ACLListMatchSds);
     listSetFreeMethod(u->passwords,ACLListFreeSds);
@@ -1146,6 +1147,8 @@ int ACLSetSelector(aclSelector *selector, const char* op, size_t oplen) {
  * off          Disable the user: it's no longer possible to authenticate
  *              with this user, however the already authenticated connections
  *              will still work.
+ * skip-sanitize-payload    RESTORE dump-payload sanitization is skipped.
+ * sanitize-payload         RESTORE dump-payload is sanitized (default).
  * ><password>  Add this password to the list of valid password for the user.
  *              For example >mypass will add "mypass" to the list.
  *              This directive clears the "nopass" flag (see later).
@@ -1179,8 +1182,6 @@ int ACLSetSelector(aclSelector *selector, const char* op, size_t oplen) {
  *                         Note this does not change the "root" user permissions,
  *                         which are the permissions directly applied onto the
  *                         user (outside the parentheses).
- * sanitize-payload        The user require a deep RESTORE payload sanitization.
- * skip-sanitize-payload   The user should skip the deep sanitization of RESTORE payload.
  * 
  * Selector options can also be specified by this function, in which case
  * they update the root selector for the user.
@@ -1293,6 +1294,7 @@ int ACLSetUser(user *u, const char *op, ssize_t oplen) {
         if (server.acl_pubsub_default & SELECTOR_FLAG_ALLCHANNELS)
             serverAssert(ACLSetUser(u,"allchannels",-1) == C_OK);
         serverAssert(ACLSetUser(u,"off",-1) == C_OK);
+        serverAssert(ACLSetUser(u,"sanitize-payload",-1) == C_OK);
         serverAssert(ACLSetUser(u,"clearselectors",-1) == C_OK);
         serverAssert(ACLSetUser(u,"-@all",-1) == C_OK);
     } else {

--- a/src/acl.c
+++ b/src/acl.c
@@ -1168,9 +1168,9 @@ int ACLSetSelector(aclSelector *selector, const char* op, size_t oplen) {
  *              "nopass" status. After "resetpass" the user has no associated
  *              passwords and there is no way to authenticate without adding
  *              some password (or setting it as "nopass" later).
- * reset        Performs the following actions: resetpass, resetkeys, off,
- *              -@all. The user returns to the same state it has immediately
- *              after its creation.
+ * reset        Performs the following actions: resetpass, resetkeys, resetchannels,
+ *              allchannels (if acl-pubsub-default is set), off, clearselectors, -@all.
+ *              The user returns to the same state it has immediately after its creation.
  * (<options>)  Create a new selector with the options specified within the
  *              parentheses and attach it to the user. Each option should be
  *              space separated. The first character must be ( and the last
@@ -1179,6 +1179,8 @@ int ACLSetSelector(aclSelector *selector, const char* op, size_t oplen) {
  *                         Note this does not change the "root" user permissions,
  *                         which are the permissions directly applied onto the
  *                         user (outside the parentheses).
+ * sanitize-payload        The user require a deep RESTORE payload sanitization.
+ * skip-sanitize-payload   The user should skip the deep sanitization of RESTORE payload.
  * 
  * Selector options can also be specified by this function, in which case
  * they update the root selector for the user.
@@ -1291,7 +1293,6 @@ int ACLSetUser(user *u, const char *op, ssize_t oplen) {
         if (server.acl_pubsub_default & SELECTOR_FLAG_ALLCHANNELS)
             serverAssert(ACLSetUser(u,"allchannels",-1) == C_OK);
         serverAssert(ACLSetUser(u,"off",-1) == C_OK);
-        serverAssert(ACLSetUser(u,"sanitize-payload",-1) == C_OK);
         serverAssert(ACLSetUser(u,"clearselectors",-1) == C_OK);
         serverAssert(ACLSetUser(u,"-@all",-1) == C_OK);
     } else {

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -175,7 +175,7 @@ start_server {tags {"acl external:skip"}} {
         set curruser "hpuser"
         foreach user [lshuffle $users] {
             if {[string first $curruser $user] != -1} {
-                assert_equal {user hpuser on nopass resetchannels &foo +@all} $user
+                assert_equal {user hpuser on nopass sanitize-payload resetchannels &foo +@all} $user
             }
         }
 
@@ -469,7 +469,7 @@ start_server {tags {"acl external:skip"}} {
         r AUTH newuser passwd1
     }
 
-    test {ACL SETUSER RESET reverting to default} {
+    test {ACL SETUSER RESET reverting to default newly created user} {
         set current_user "example"
         r ACL DELUSER $current_user
         r ACL SETUSER $current_user

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -469,6 +469,27 @@ start_server {tags {"acl external:skip"}} {
         r AUTH newuser passwd1
     }
 
+    test {ACL SETUSER RESET reverting to default} {
+        set current_user "example"
+        r ACL DELUSER $current_user
+        r ACL SETUSER $current_user
+
+        set users [r ACL LIST]
+        foreach user [lshuffle $users] {
+            if {[string first $current_user $user] != -1} {
+                set current_user_output $user
+            }
+        }
+
+        r ACL SETUSER $current_user reset
+        set users [r ACL LIST]
+        foreach user [lshuffle $users] {
+            if {[string first $current_user $user] != -1} {
+                assert_equal $current_user_output $user
+            }
+        }
+    }
+
     # Note that the order of the generated ACL rules is not stable in Redis
     # so we need to match the different parts and not as a whole string.
     test {ACL GETUSER is able to translate back command permissions} {


### PR DESCRIPTION
Starting from 6.2, after ACL SETUSER user reset, the user
will carry the sanitize-payload flag. It was added in #7807,
and then ACL SETUSER reset is inconsistent with default
newly created user which missing sanitize-payload flag.

Same as `off` and `on` these two bits are mutually exclusive,
the default created user needs to have sanitize-payload flag.
Adds USER_FLAG_SANITIZE_PAYLOAD flag to ACLCreateUser.

Note that the bug don't have any real implications,
since the code in rdb.c (rdbLoadObject) checks for
`USER_FLAG_SANITIZE_PAYLOAD_SKIP`, so the fact that
`USER_FLAG_SANITIZE_PAYLOAD` is missing doesn't really matters.

Added tests to make sure it won't be broken in the future,
and updated the comment in ACLSetUser and redis.conf

Fixes #11278