### PR TITLE
Use cached time in [P]EXPIRE commands

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -6107,7 +6107,7 @@ void restoreCommand(client *c) {
     if (replace)
         deleted = dbDelete(c->db,key);
 
-    if (ttl && !absttl) ttl+=mstime();
+    if (ttl && !absttl) ttl+=server.mstime;
     if (ttl && checkAlreadyExpired(ttl)) {
         if (deleted) {
             rewriteClientCommandVector(c,2,shared.del,key);

--- a/src/expire.c
+++ b/src/expire.c
@@ -488,7 +488,7 @@ int checkAlreadyExpired(long long when) {
      *
      * Instead we add the already expired key to the database with expire time
      * (possibly in the past) and wait for an explicit DEL from the master. */
-    return (when <= mstime() && !server.loading && !server.masterhost);
+    return (when <= server.mstime && !server.loading && !server.masterhost);
 }
 
 #define EXPIRE_NX (1<<0)
@@ -665,7 +665,7 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
 
 /* EXPIRE key seconds [ NX | XX | GT | LT] */
 void expireCommand(client *c) {
-    expireGenericCommand(c,mstime(),UNIT_SECONDS);
+    expireGenericCommand(c,server.mstime,UNIT_SECONDS);
 }
 
 /* EXPIREAT key unix-time-seconds [ NX | XX | GT | LT] */
@@ -675,7 +675,7 @@ void expireatCommand(client *c) {
 
 /* PEXPIRE key milliseconds [ NX | XX | GT | LT] */
 void pexpireCommand(client *c) {
-    expireGenericCommand(c,mstime(),UNIT_MILLISECONDS);
+    expireGenericCommand(c,server.mstime,UNIT_MILLISECONDS);
 }
 
 /* PEXPIREAT key unix-time-milliseconds [ NX | XX | GT | LT] */


### PR DESCRIPTION
EXPIRE and PEXPIRE used to get a fresh copy of the time twice: once to get the base-time for expiration, and again to check if the key is already expired.

In some rare cases, a very short PEXPIRE can cause the key to be deleted immediately instead of having its expiry set.

Now, both accesses to get time use the cached time, so there's no danger of premature deletion.

While not a real-world problem, some tests use short PEXPIRE times and turn off active-expire in order to simulate a scenario where we have a logically expired key in the dataset.