### PR TITLE
Added authentication failure and access denied metrics

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2479,6 +2479,21 @@ void ACLFreeLogEntry(void *leptr) {
     zfree(le);
 }
 
+/* Update the relevant counter by the reason */
+void ACLUpdateInfoMetrics(int reason){
+    if (reason == ACL_DENIED_AUTH) {
+        server.acl_info.user_auth_failures++;
+    } else if (reason == ACL_DENIED_CMD) {
+        server.acl_info.invalid_cmd_accesses++;
+    } else if (reason == ACL_DENIED_KEY) {
+        server.acl_info.invalid_key_accesses++;
+    } else if (reason == ACL_DENIED_CHANNEL) {
+        server.acl_info.invalid_channel_accesses++;
+    } else {
+        serverPanic("Unknown ACL_DENIED encoding");
+    }
+}
+
 /* Adds a new entry in the ACL log, making sure to delete the old entry
  * if we reach the maximum length allowed for the log. This function attempts
  * to find similar entries in the current log in order to bump the counter of
@@ -2495,6 +2510,9 @@ void ACLFreeLogEntry(void *leptr) {
  * If `object` is not NULL, this functions takes over it.
  */
 void addACLLogEntry(client *c, int reason, int context, int argpos, sds username, sds object) {
+    /* Update ACL info metrics */
+    ACLUpdateInfoMetrics(reason);
+    
     /* Create a new entry. */
     struct ACLLogEntry *le = zmalloc(sizeof(*le));
     le->count = 1;

--- a/src/server.c
+++ b/src/server.c
@@ -5176,10 +5176,10 @@ sds genRedisInfoStringCommandStats(sds info, dict *commands) {
 /* Writes the ACL metrics to the info */
 sds genRedisInfoStringACLStats(sds info) {
     info = sdscatprintf(info,
-         "acl_deny_access_auth:%ld\r\n"
-         "acl_deny_access_cmd:%ld\r\n"
-         "acl_deny_access_key:%ld\r\n"
-         "acl_deny_access_channel:%ld\r\n",
+         "acl_access_denied_auth:%ld\r\n"
+         "acl_access_denied_cmd:%ld\r\n"
+         "acl_access_denied_key:%ld\r\n"
+         "acl_access_denied_channel:%ld\r\n",
          server.acl_info.user_auth_failures,
          server.acl_info.invalid_cmd_accesses,
          server.acl_info.invalid_key_accesses,

--- a/src/server.c
+++ b/src/server.c
@@ -5175,26 +5175,15 @@ sds genRedisInfoStringCommandStats(sds info, dict *commands) {
 
 /* Writes the ACL metrics to the info */
 sds genRedisInfoStringACLStats(sds info) {
-    sds metrics = sdsempty();
-    
-    metrics = sdscatprintf(metrics,
-    "auth_failure_times:%ld\r\n",
-    server.acl_info.user_auth_failures);
-    
-    metrics = sdscatprintf(metrics,
-    "invalid_cmd_accesses:%ld\r\n",
-    server.acl_info.invalid_cmd_accesses);
-    
-    metrics = sdscatprintf(metrics,
-    "invalid_key_accesses:%ld\r\n",
-    server.acl_info.invalid_key_accesses);
-
-    metrics = sdscatprintf(metrics,
-    "invalid_channel_accesses:%ld\r\n",
-    server.acl_info.invalid_channel_accesses);
-
-    info = sdscatprintf(info, metrics);
-    sdsfree(metrics);
+    info = sdscatprintf(info,
+         "acl_deny_access_auth:%ld\r\n"
+         "acl_deny_access_cmd:%ld\r\n"
+         "acl_deny_access_key:%ld\r\n"
+         "acl_deny_access_channel:%ld\r\n",
+         server.acl_info.user_auth_failures,
+         server.acl_info.invalid_cmd_accesses,
+         server.acl_info.invalid_key_accesses,
+         server.acl_info.invalid_channel_accesses);
     return info;
 }
 
@@ -5809,7 +5798,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             server.stat_io_writes_processed,
             server.stat_reply_buffer_shrinks,
             server.stat_reply_buffer_expands);
-            info = genRedisInfoStringACLStats(info);
+        info = genRedisInfoStringACLStats(info);
     }
 
     /* Replication */

--- a/src/server.c
+++ b/src/server.c
@@ -5193,7 +5193,7 @@ sds genRedisInfoStringACLStats(sds info) {
     "invalid_channel_accesses:%ld\r\n",
     server.acl_info.invalid_channel_accesses);
 
-    info = sdscatprintf(info, metrics);
+    info = sdscatprintf(info, "%s", metrics);
     sdsfree(metrics);
     return info;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -5176,10 +5176,10 @@ sds genRedisInfoStringCommandStats(sds info, dict *commands) {
 /* Writes the ACL metrics to the info */
 sds genRedisInfoStringACLStats(sds info) {
     info = sdscatprintf(info,
-         "acl_access_denied_auth:%ld\r\n"
-         "acl_access_denied_cmd:%ld\r\n"
-         "acl_access_denied_key:%ld\r\n"
-         "acl_access_denied_channel:%ld\r\n",
+         "acl_access_denied_auth:%lld\r\n"
+         "acl_access_denied_cmd:%lld\r\n"
+         "acl_access_denied_key:%lld\r\n"
+         "acl_access_denied_channel:%lld\r\n",
          server.acl_info.user_auth_failures,
          server.acl_info.invalid_cmd_accesses,
          server.acl_info.invalid_key_accesses,

--- a/src/server.c
+++ b/src/server.c
@@ -2536,6 +2536,12 @@ void initServer(void) {
     server.repl_good_slaves_count = 0;
     server.last_sig_received = 0;
 
+    /* Initiate acl info struct */
+    server.acl_info.invalid_cmd_accesses = 0;
+    server.acl_info.invalid_key_accesses  = 0;
+    server.acl_info.user_auth_failures = 0;
+    server.acl_info.invalid_channel_accesses = 0;
+
     /* Create the timer callback, this is our way to process many background
      * operations incrementally, like clients timeout, eviction of unaccessed
      * expired keys and so forth. */
@@ -5167,6 +5173,31 @@ sds genRedisInfoStringCommandStats(sds info, dict *commands) {
     return info;
 }
 
+/* Writes the ACL metrics to the info */
+sds genRedisInfoStringACLStats(sds info) {
+    sds metrics = sdsempty();
+    
+    metrics = sdscatprintf(metrics,
+    "auth_failure_times:%ld\r\n",
+    server.acl_info.user_auth_failures);
+    
+    metrics = sdscatprintf(metrics,
+    "invalid_cmd_accesses:%ld\r\n",
+    server.acl_info.invalid_cmd_accesses);
+    
+    metrics = sdscatprintf(metrics,
+    "invalid_key_accesses:%ld\r\n",
+    server.acl_info.invalid_key_accesses);
+
+    metrics = sdscatprintf(metrics,
+    "invalid_channel_accesses:%ld\r\n",
+    server.acl_info.invalid_channel_accesses);
+
+    info = sdscatprintf(info, metrics);
+    sdsfree(metrics);
+    return info;
+}
+
 sds genRedisInfoStringLatencyStats(sds info, dict *commands) {
     struct redisCommand *c;
     dictEntry *de;
@@ -5778,6 +5809,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             server.stat_io_writes_processed,
             server.stat_reply_buffer_shrinks,
             server.stat_reply_buffer_expands);
+            info = genRedisInfoStringACLStats(info);
     }
 
     /* Replication */

--- a/src/server.h
+++ b/src/server.h
@@ -1189,6 +1189,14 @@ typedef struct client {
     char *buf;
 } client;
 
+/* ACL information */
+typedef struct aclInfo {
+    long user_auth_failures; /* Auth failure counts on user level */
+    long invalid_cmd_accesses; /* Invalid command accesses that user doesn't have permission to */
+    long invalid_key_accesses; /* Invalid key accesses that user doesn't have permission to */
+    long invalid_channel_accesses; /* Invalid channel accesses that user doesn't have permission to */
+} aclInfo;
+
 struct saveparam {
     time_t seconds;
     int changes;
@@ -1898,6 +1906,7 @@ struct redisServer {
                                      the old "requirepass" directive for
                                      backward compatibility with Redis <= 5. */
     int acl_pubsub_default;      /* Default ACL pub/sub channels flag */
+    aclInfo acl_info; /* ACL info */
     /* Assert & bug reporting */
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
     /* System hardware info */
@@ -2798,6 +2807,7 @@ void ACLFreeUserAndKillClients(user *u);
 void addACLLogEntry(client *c, int reason, int context, int argpos, sds username, sds object);
 const char* getAclErrorMessage(int acl_res);
 void ACLUpdateDefaultUserPassword(sds password);
+sds genRedisInfoStringACLStats(sds info);
 
 /* Sorted sets data type */
 

--- a/src/server.h
+++ b/src/server.h
@@ -1191,10 +1191,10 @@ typedef struct client {
 
 /* ACL information */
 typedef struct aclInfo {
-    long user_auth_failures; /* Auth failure counts on user level */
-    long invalid_cmd_accesses; /* Invalid command accesses that user doesn't have permission to */
-    long invalid_key_accesses; /* Invalid key accesses that user doesn't have permission to */
-    long invalid_channel_accesses; /* Invalid channel accesses that user doesn't have permission to */
+    long long user_auth_failures; /* Auth failure counts on user level */
+    long long invalid_cmd_accesses; /* Invalid command accesses that user doesn't have permission to */
+    long long invalid_key_accesses; /* Invalid key accesses that user doesn't have permission to */
+    long long invalid_channel_accesses; /* Invalid channel accesses that user doesn't have permission to */
 } aclInfo;
 
 struct saveparam {

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -752,7 +752,7 @@ start_server {tags {"acl external:skip"}} {
        set err
     } {*Redis instance is not configured to use an ACL file*}
 
-    # If there is an AUTH failure the matric increases
+    # If there is an AUTH failure the metric increases
     test {ACL-Metrics user AUTH failure} {
         set current_auth_failures [s acl_access_denied_auth]
         set current_invalid_cmd_accesses [s acl_access_denied_cmd]
@@ -769,7 +769,7 @@ start_server {tags {"acl external:skip"}} {
         assert {[s acl_access_denied_channel] eq $current_invalid_channel_accesses}
     }
 
-    # If a user try to access an unauthorized  command the metric increases
+    # If a user try to access an unauthorized command the metric increases
     test {ACL-Metrics invalid command accesses} {
         set current_auth_failures [s acl_access_denied_auth]
         set current_invalid_cmd_accesses [s acl_access_denied_cmd]
@@ -785,7 +785,7 @@ start_server {tags {"acl external:skip"}} {
         assert {[s acl_access_denied_channel] eq $current_invalid_channel_accesses}
     }
 
-    # If a user try to access an unauthorized  key the metric increases
+    # If a user try to access an unauthorized key the metric increases
     test {ACL-Metrics invalid key accesses} {
         set current_auth_failures [s acl_access_denied_auth]
         set current_invalid_cmd_accesses [s acl_access_denied_cmd]
@@ -801,7 +801,7 @@ start_server {tags {"acl external:skip"}} {
         assert {[s acl_access_denied_channel] eq $current_invalid_channel_accesses}
     }   
 
-    # If a user try to access an unauthorized  channel the metric increases
+    # If a user try to access an unauthorized channel the metric increases
     test {ACL-Metrics invalid channels accesses} {
         set current_auth_failures [s acl_access_denied_auth]
         set current_invalid_cmd_accesses [s acl_access_denied_cmd]

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -754,67 +754,67 @@ start_server {tags {"acl external:skip"}} {
 
     # If there is an AUTH failure the matric increases
     test {ACL-Metrics user AUTH failure} {
-        set current_auth_failures [s auth_failure_times]
-        set current_invalid_cmd_accesses [s invalid_cmd_accesses]
-        set current_invalid_key_accesses [s invalid_key_accesses]
-        set current_invalid_channel_accesses [s invalid_channel_accesses]
+        set current_auth_failures [s acl_access_denied_auth]
+        set current_invalid_cmd_accesses [s acl_access_denied_cmd]
+        set current_invalid_key_accesses [s acl_access_denied_key]
+        set current_invalid_channel_accesses [s acl_access_denied_channel]
         assert_error "*WRONGPASS*" {r AUTH notrealuser 1233456} 
-        assert {[s auth_failure_times] eq [expr $current_auth_failures + 1]}
+        assert {[s acl_access_denied_auth] eq [expr $current_auth_failures + 1]}
         assert_error "*WRONGPASS*" {r HELLO 3 AUTH notrealuser 1233456}
-        assert {[s auth_failure_times] eq [expr $current_auth_failures + 2]}
+        assert {[s acl_access_denied_auth] eq [expr $current_auth_failures + 2]}
         assert_error "*WRONGPASS*" {r HELLO 2 AUTH notrealuser 1233456}
-        assert {[s auth_failure_times] eq [expr $current_auth_failures + 3]}
-        assert {[s invalid_cmd_accesses] eq $current_invalid_cmd_accesses}
-        assert {[s invalid_key_accesses] eq $current_invalid_key_accesses}
-        assert {[s invalid_channel_accesses] eq $current_invalid_channel_accesses}
+        assert {[s acl_access_denied_auth] eq [expr $current_auth_failures + 3]}
+        assert {[s acl_access_denied_cmd] eq $current_invalid_cmd_accesses}
+        assert {[s acl_access_denied_key] eq $current_invalid_key_accesses}
+        assert {[s acl_access_denied_channel] eq $current_invalid_channel_accesses}
     }
 
     # If a user try to access an unauthorized  command the metric increases
     test {ACL-Metrics invalid command accesses} {
-        set current_auth_failures [s auth_failure_times]
-        set current_invalid_cmd_accesses [s invalid_cmd_accesses]
-        set current_invalid_key_accesses [s invalid_key_accesses]
-        set current_invalid_channel_accesses [s invalid_channel_accesses]
+        set current_auth_failures [s acl_access_denied_auth]
+        set current_invalid_cmd_accesses [s acl_access_denied_cmd]
+        set current_invalid_key_accesses [s acl_access_denied_key]
+        set current_invalid_channel_accesses [s acl_access_denied_channel]
         r ACL setuser invalidcmduser on >passwd nocommands
         r AUTH invalidcmduser passwd
         assert_error "*no permissions to run the * command*" {r acl list}
         r AUTH default ""
-        assert {[s auth_failure_times] eq $current_auth_failures}
-        assert {[s invalid_cmd_accesses] eq [expr $current_invalid_cmd_accesses + 1]}
-        assert {[s invalid_key_accesses] eq $current_invalid_key_accesses}
-        assert {[s invalid_channel_accesses] eq $current_invalid_channel_accesses}
+        assert {[s acl_access_denied_auth] eq $current_auth_failures}
+        assert {[s acl_access_denied_cmd] eq [expr $current_invalid_cmd_accesses + 1]}
+        assert {[s acl_access_denied_key] eq $current_invalid_key_accesses}
+        assert {[s acl_access_denied_channel] eq $current_invalid_channel_accesses}
     }
 
     # If a user try to access an unauthorized  key the metric increases
     test {ACL-Metrics invalid key accesses} {
-        set current_auth_failures [s auth_failure_times]
-        set current_invalid_cmd_accesses [s invalid_cmd_accesses]
-        set current_invalid_key_accesses [s invalid_key_accesses]
-        set current_invalid_channel_accesses [s invalid_channel_accesses]
+        set current_auth_failures [s acl_access_denied_auth]
+        set current_invalid_cmd_accesses [s acl_access_denied_cmd]
+        set current_invalid_key_accesses [s acl_access_denied_key]
+        set current_invalid_channel_accesses [s acl_access_denied_channel]
         r ACL setuser invalidkeyuser on >passwd resetkeys allcommands
         r AUTH invalidkeyuser passwd
         assert_error "*no permissions to access one of the keys*" {r get x}
         r AUTH default ""
-        assert {[s auth_failure_times] eq $current_auth_failures}
-        assert {[s invalid_cmd_accesses] eq $current_invalid_cmd_accesses}
-        assert {[s invalid_key_accesses] eq [expr $current_invalid_key_accesses + 1]}
-        assert {[s invalid_channel_accesses] eq $current_invalid_channel_accesses}
-    }
+        assert {[s acl_access_denied_auth] eq $current_auth_failures}
+        assert {[s acl_access_denied_cmd] eq $current_invalid_cmd_accesses}
+        assert {[s acl_access_denied_key] eq [expr $current_invalid_key_accesses + 1]}
+        assert {[s acl_access_denied_channel] eq $current_invalid_channel_accesses}
+    }   
 
     # If a user try to access an unauthorized  channel the metric increases
     test {ACL-Metrics invalid channels accesses} {
-        set current_auth_failures [s auth_failure_times]
-        set current_invalid_cmd_accesses [s invalid_cmd_accesses]
-        set current_invalid_key_accesses [s invalid_key_accesses]
-        set current_invalid_channel_accesses [s invalid_channel_accesses]
+        set current_auth_failures [s acl_access_denied_auth]
+        set current_invalid_cmd_accesses [s acl_access_denied_cmd]
+        set current_invalid_key_accesses [s acl_access_denied_key]
+        set current_invalid_channel_accesses [s acl_access_denied_channel]
         r ACL setuser invalidchanneluser on >passwd resetchannels allcommands
         r AUTH invalidkeyuser passwd
         assert_error "*no permissions to access one of the channels*" {r subscribe x}
         r AUTH default ""
-        assert {[s auth_failure_times] eq $current_auth_failures}
-        assert {[s invalid_cmd_accesses] eq $current_invalid_cmd_accesses}
-        assert {[s invalid_key_accesses] eq $current_invalid_key_accesses}
-        assert {[s invalid_channel_accesses] eq [expr $current_invalid_channel_accesses + 1]}
+        assert {[s acl_access_denied_auth] eq $current_auth_failures}
+        assert {[s acl_access_denied_cmd] eq $current_invalid_cmd_accesses}
+        assert {[s acl_access_denied_key] eq $current_invalid_key_accesses}
+        assert {[s acl_access_denied_channel] eq [expr $current_invalid_channel_accesses + 1]}
     }
 }
 


### PR DESCRIPTION
Description
Adding new ACL metrics to the server, that tracking :

- user invalid command access
- user invaild key access
- user authentication failure

These metrics can give more information about the clients' usage and see if there are server authentication problems.

The metrics will be shown when using the command INFO with sections ALL/ACL/""

Added 4 new info fields:
```
acl_access_denied_auth: Number of AUTH and HELLO commands rejected from invalid username and passwords.
acl_access_denied_cmd: Number of commands rejected because of insufficient command permissions. 
acl_access_denied_key: Number of commands rejected because of insufficient key permissions.
acl_access_denied_channel: Number of commands rejected because of insufficient channel permissions.
```

```
release notes
Added 4 new info fields for authentication errors and commands denied access for keys, channels and commands.
```