### PR TITLE
Prevent command propagation in "RM_Replicate"

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3234,6 +3234,9 @@ int RM_Replicate(RedisModuleCtx *ctx, const char *cmdname, const char *fmt, ...)
     /* Release the argv. */
     for (j = 0; j < argc; j++) decrRefCount(argv[j]);
     zfree(argv);
+
+    if (server.current_client != NULL) preventCommandPropagation(server.current_client);
+
     server.dirty++;
     return REDISMODULE_OK;
 }
@@ -3253,6 +3256,9 @@ int RM_ReplicateVerbatim(RedisModuleCtx *ctx) {
     alsoPropagate(ctx->client->db->id,
         ctx->client->argv,ctx->client->argc,
         PROPAGATE_AOF|PROPAGATE_REPL);
+
+    if (server.current_client != NULL) preventCommandPropagation(server.current_client);
+
     server.dirty++;
     return REDISMODULE_OK;
 }


### PR DESCRIPTION
In Redis 7, there is a new type of module API that supports adding module config and register callback function to handle it.

For example:
https://redis.io/docs/reference/modules/modules-api-ref/#RedisModule_RegisterBoolConfig

The issue is if a module introduces a new config, and the config handler tries to replicate the config, by passing "CONFIG SET" to "RM_Replicate", the config command will appear twice in the replication stream.

To prevent this, the existing function "preventCommandPropagation" is called inside "RM_Replicate" so the second call of "alsoPropagate" in "call()" is skipped.

(This is a straightforward fix; the problem behind is that some improvements are needed for module command handling. Any comments or suggestions would be appreciated.)