### PR TITLE
Fix CLUSTER SHARDS showing empty hostname

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5122,7 +5122,7 @@ void addNodeDetailsToShardReply(client *c, clusterNode *node) {
     addReplyBulkCString(c, getPreferredEndpoint(node));
     reply_count++;
 
-    if (node->hostname) {
+    if (sdslen(node->hostname) != 0) {
         addReplyBulkCString(c, "hostname");
         addReplyBulkCString(c, node->hostname);
         reply_count++;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5040,7 +5040,11 @@ void addNodeToNodeReply(client *c, clusterNode *node) {
     if (server.cluster_preferred_endpoint_type == CLUSTER_ENDPOINT_TYPE_IP) {
         addReplyBulkCString(c, node->ip);
     } else if (server.cluster_preferred_endpoint_type == CLUSTER_ENDPOINT_TYPE_HOSTNAME) {
-        addReplyBulkCString(c, sdslen(node->hostname) != 0 ? node->hostname : "?");
+        if (sdslen(node->hostname) != 0) {
+            addReplyBulkCBuffer(c, node->hostname, sdslen(node->hostname));
+        } else {
+            addReplyBulkCString(c, "?");
+        }
     } else if (server.cluster_preferred_endpoint_type == CLUSTER_ENDPOINT_TYPE_UNKNOWN_ENDPOINT) {
         addReplyNull(c);
     } else {
@@ -5066,7 +5070,7 @@ void addNodeToNodeReply(client *c, clusterNode *node) {
         && sdslen(node->hostname) != 0)
     {
         addReplyBulkCString(c, "hostname");
-        addReplyBulkCString(c, node->hostname);
+        addReplyBulkCBuffer(c, node->hostname, sdslen(node->hostname));
         length++;
     }
     setDeferredMapLen(c, deflen, length);
@@ -5124,7 +5128,7 @@ void addNodeDetailsToShardReply(client *c, clusterNode *node) {
 
     if (sdslen(node->hostname) != 0) {
         addReplyBulkCString(c, "hostname");
-        addReplyBulkCString(c, node->hostname);
+        addReplyBulkCBuffer(c, node->hostname, sdslen(node->hostname));
         reply_count++;
     }
 


### PR DESCRIPTION
In #10290, we changed clusterNode hostname from `char*` to `sds`, and the old `node->hostname` was changed to `sdslen(node->hostname)!=0`.

But in `addNodeDetailsToShardReply` it is missing. It results in the return of an empty string hostname in CLUSTER SHARDS command if it unavailable.

Like this (note that we listed it as optional in the doc):
```
 9) "hostname"
10) ""
```

```
Release notes:
Fix a bug where an empty hostname was displayed in `CLUSTER SHARDS` when no hostname was configured.
```