### PR TITLE
Avoid crash on crash report when a bad function pointer was called

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1132,28 +1132,28 @@ static void* getAndSetMcontextEip(ucontext_t *uc, void *eip) {
     return NULL;\
 } while(0)
 #define GET_SET_RETURN(target_var, new_val) do {\
-    void *old_val = (void*)add; \
-    if (val) { \
-        void **temp = (void**)&add; \
-        *temp = val; \
+    void *old_val = (void*)target_var; \
+    if (new_val) { \
+        void **temp = (void**)&target_var; \
+        *temp = new_val; \
     } \
     return old_val; \
 } while(0)
 #if defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_6)
     /* OSX < 10.6 */
     #if defined(__x86_64__)
-    GET_SET_VALUD_AT(uc->uc_mcontext->__ss.__rip, eip);
+    GET_SET_RETURN(uc->uc_mcontext->__ss.__rip, eip);
     #elif defined(__i386__)
-    GET_SET_VALUD_AT(uc->uc_mcontext->__ss.__eip, eip);
+    GET_SET_RETURN(uc->uc_mcontext->__ss.__eip, eip);
     #else
-    GET_SET_VALUD_AT(uc->uc_mcontext->__ss.__srr0, eip);
+    GET_SET_RETURN(uc->uc_mcontext->__ss.__srr0, eip);
     #endif
 #elif defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)
     /* OSX >= 10.6 */
     #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
-    GET_SET_VALUD_AT(uc->uc_mcontext->__ss.__rip, eip);
+    GET_SET_RETURN(uc->uc_mcontext->__ss.__rip, eip);
     #elif defined(__i386__)
-    GET_SET_VALUD_AT(uc->uc_mcontext->__ss.__eip, eip);
+    GET_SET_RETURN(uc->uc_mcontext->__ss.__eip, eip);
     #else
     /* OSX ARM64 */
     void *old_val = (void*)arm_thread_state64_get_pc(uc->uc_mcontext->__ss);
@@ -1165,46 +1165,46 @@ static void* getAndSetMcontextEip(ucontext_t *uc, void *eip) {
 #elif defined(__linux__)
     /* Linux */
     #if defined(__i386__) || ((defined(__X86_64__) || defined(__x86_64__)) && defined(__ILP32__))
-    GET_SET_VALUD_AT(uc->uc_mcontext.gregs[14], eip);
+    GET_SET_RETURN(uc->uc_mcontext.gregs[14], eip);
     #elif defined(__X86_64__) || defined(__x86_64__)
-    GET_SET_VALUD_AT(uc->uc_mcontext.gregs[16], eip);
+    GET_SET_RETURN(uc->uc_mcontext.gregs[16], eip);
     #elif defined(__ia64__) /* Linux IA64 */
-    GET_SET_VALUD_AT(uc->uc_mcontext.sc_ip, eip);
+    GET_SET_RETURN(uc->uc_mcontext.sc_ip, eip);
     #elif defined(__arm__) /* Linux ARM */
-    GET_SET_VALUD_AT(uc->uc_mcontext.arm_pc, eip);
+    GET_SET_RETURN(uc->uc_mcontext.arm_pc, eip);
     #elif defined(__aarch64__) /* Linux AArch64 */
-    GET_SET_VALUD_AT(uc->uc_mcontext.pc, eip);
+    GET_SET_RETURN(uc->uc_mcontext.pc, eip);
     #else
     NOT_SUPPORTED();
     #endif
 #elif defined(__FreeBSD__)
     /* FreeBSD */
     #if defined(__i386__)
-    GET_SET_VALUD_AT(uc->uc_mcontext.mc_eip, eip);
+    GET_SET_RETURN(uc->uc_mcontext.mc_eip, eip);
     #elif defined(__x86_64__)
-    GET_SET_VALUD_AT(uc->uc_mcontext.mc_rip, eip);
+    GET_SET_RETURN(uc->uc_mcontext.mc_rip, eip);
     #else
     NOT_SUPPORTED();
     #endif
 #elif defined(__OpenBSD__)
     /* OpenBSD */
     #if defined(__i386__)
-    GET_SET_VALUD_AT(uc->sc_eip, eip);
+    GET_SET_RETURN(uc->sc_eip, eip);
     #elif defined(__x86_64__)
-    GET_SET_VALUD_AT(uc->sc_rip, eip);
+    GET_SET_RETURN(uc->sc_rip, eip);
     #else
     NOT_SUPPORTED();
     #endif
 #elif defined(__NetBSD__)
     #if defined(__i386__)
-    GET_SET_VALUD_AT(uc->uc_mcontext.__gregs[_REG_EIP], eip);
+    GET_SET_RETURN(uc->uc_mcontext.__gregs[_REG_EIP], eip);
     #elif defined(__x86_64__)
-    GET_SET_VALUD_AT(uc->uc_mcontext.__gregs[_REG_RIP], eip);
+    GET_SET_RETURN(uc->uc_mcontext.__gregs[_REG_RIP], eip);
     #else
     NOT_SUPPORTED();
     #endif
 #elif defined(__DragonFly__)
-    GET_SET_VALUD_AT(uc->uc_mcontext.mc_rip, eip);
+    GET_SET_RETURN(uc->uc_mcontext.mc_rip, eip);
 #else
     NOT_SUPPORTED();
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -1201,21 +1201,25 @@ static void setMcontextEip(ucontext_t *uc, void *eip) {
     UNUSED(uc);\
     UNUSED(eip);\
 } while(0)
+#define SET_VALUD_AT(add, val) do {\
+    void **temp = (void**)&add; \
+    *temp = val; \
+} while(0)
 #if defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_6)
     /* OSX < 10.6 */
     #if defined(__x86_64__)
-    *((void**)&uc->uc_mcontext->__ss.__rip) = eip;
+    SET_VALUD_AT(uc->uc_mcontext->__ss.__rip, eip);
     #elif defined(__i386__)
-    *((void**)&uc->uc_mcontext->__ss.__eip) = eip;
+    SET_VALUD_AT(uc->uc_mcontext->__ss.__eip, eip);
     #else
-    *((void**)&uc->uc_mcontext->__ss.__srr0) = eip;
+    SET_VALUD_AT(uc->uc_mcontext->__ss.__srr0, eip);
     #endif
 #elif defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)
     /* OSX >= 10.6 */
     #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
-    *((void**)&uc->uc_mcontext->__ss.__rip) = eip;
+    SET_VALUD_AT(uc->uc_mcontext->__ss.__rip, eip);
     #elif defined(__i386__)
-    *((void**)&uc->uc_mcontext->__ss.__eip) = eip;
+    SET_VALUD_AT(uc->uc_mcontext->__ss.__eip, eip);
     #else
     /* OSX ARM64 */
     arm_thread_state64_set_pc_fptr(uc->uc_mcontext->__ss, eip);
@@ -1223,46 +1227,46 @@ static void setMcontextEip(ucontext_t *uc, void *eip) {
 #elif defined(__linux__)
     /* Linux */
     #if defined(__i386__) || ((defined(__X86_64__) || defined(__x86_64__)) && defined(__ILP32__))
-    *((void**)&uc->uc_mcontext.gregs[14]) = eip; /* Linux 32 */
+    SET_VALUD_AT(uc->uc_mcontext.gregs[14], eip);
     #elif defined(__X86_64__) || defined(__x86_64__)
-    *((void**)&uc->uc_mcontext.gregs[16]) = eip; /* Linux 64 */
+    SET_VALUD_AT(uc->uc_mcontext.gregs[16], eip);
     #elif defined(__ia64__) /* Linux IA64 */
-    *((void**)&uc->uc_mcontext.sc_ip) = eip;
+    SET_VALUD_AT(uc->uc_mcontext.sc_ip, eip);
     #elif defined(__arm__) /* Linux ARM */
-    *((void**)&uc->uc_mcontext.arm_pc) = eip;
+    SET_VALUD_AT(uc->uc_mcontext.arm_pc, eip);
     #elif defined(__aarch64__) /* Linux AArch64 */
-    *((void**)&uc->uc_mcontext.pc) = eip;
+    SET_VALUD_AT(uc->uc_mcontext.pc, eip);
     #else
     NOT_SUPPORTED();
     #endif
 #elif defined(__FreeBSD__)
     /* FreeBSD */
     #if defined(__i386__)
-    *((void**)&uc->uc_mcontext.mc_eip) = eip;
+    SET_VALUD_AT(uc->uc_mcontext.mc_eip, eip);
     #elif defined(__x86_64__)
-    *((void**)&uc->uc_mcontext.mc_rip) = eip;
+    SET_VALUD_AT(uc->uc_mcontext.mc_rip, eip);
     #else
     NOT_SUPPORTED();
     #endif
 #elif defined(__OpenBSD__)
     /* OpenBSD */
     #if defined(__i386__)
-    *((void**)&uc->sc_eip) = eip;
+    SET_VALUD_AT(uc->sc_eip, eip);
     #elif defined(__x86_64__)
-    *((void**)&uc->sc_rip) = eip;
+    SET_VALUD_AT(uc->sc_rip, eip);
     #else
     NOT_SUPPORTED();
     #endif
 #elif defined(__NetBSD__)
     #if defined(__i386__)
-    *((void**)&uc->uc_mcontext.__gregs[_REG_EIP]) = eip;
+    SET_VALUD_AT(uc->uc_mcontext.__gregs[_REG_EIP], eip);
     #elif defined(__x86_64__)
-    *((void**)&uc->uc_mcontext.__gregs[_REG_RIP]) = eip;
+    SET_VALUD_AT(uc->uc_mcontext.__gregs[_REG_RIP], eip);
     #else
     NOT_SUPPORTED();
     #endif
 #elif defined(__DragonFly__)
-    *((void**)&uc->uc_mcontext.mc_rip) = eip;
+    SET_VALUD_AT(uc->uc_mcontext.mc_rip, eip);
 #else
     NOT_SUPPORTED();
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -1995,9 +1995,8 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
 
     if (eip == info->si_addr) {
         /* When eip matches the bad address, it's an indication that we crashed when calling a non-mapped
-         *  function pointer. In that case the call to backtrace will crash trying to access that address and we
+         * function pointer. In that case the call to backtrace will crash trying to access that address and we
          * won't get a crash report logged. Set it to a valid point to avoid that crash. */
-        serverLog(LL_WARNING, "Crashed caused by calling to invalid function pointer %p.", eip);
 
         /* This trick allow to avoid compiler warning */
         void *ptr;

--- a/src/debug.c
+++ b/src/debug.c
@@ -1131,7 +1131,7 @@ static void* getAndSetMcontextEip(ucontext_t *uc, void *eip) {
     UNUSED(eip);\
     return NULL;\
 } while(0)
-#define GET_SET_VALUD_AT(add, val) do {\
+#define GET_SET_RETURN(target_var, new_val) do {\
     void *old_val = (void*)add; \
     if (val) { \
         void **temp = (void**)&add; \
@@ -1994,9 +1994,9 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     }
 
     if (eip == info->si_addr) {
-        /* We crashed when calling a none mapped pointer.
-         * Set pointer to some valid address otherwise logStackTrace will crash
-         * when tryint to access this pointer. */
+        /* When eip matches the bad address, it's an indication that we crashed when calling a non-mapped
+         *  function pointer. In that case the call to backtrace will crash trying to access that address and we
+         * won't get a crash report logged. Set it to a valid point to avoid that crash. */
         serverLog(LL_WARNING, "Crashed caused by calling to invalid function pointer %p.", eip);
 
         /* This trick allow to avoid compiler warning */

--- a/src/debug.c
+++ b/src/debug.c
@@ -1123,150 +1123,88 @@ void bugReportStart(void) {
 }
 
 #ifdef HAVE_BACKTRACE
-static void *getMcontextEip(ucontext_t *uc) {
-#define NOT_SUPPORTED() do {\
-    UNUSED(uc);\
-    return NULL;\
-} while(0)
-#if defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_6)
-    /* OSX < 10.6 */
-    #if defined(__x86_64__)
-    return (void*) uc->uc_mcontext->__ss.__rip;
-    #elif defined(__i386__)
-    return (void*) uc->uc_mcontext->__ss.__eip;
-    #else
-    return (void*) uc->uc_mcontext->__ss.__srr0;
-    #endif
-#elif defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)
-    /* OSX >= 10.6 */
-    #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
-    return (void*) uc->uc_mcontext->__ss.__rip;
-    #elif defined(__i386__)
-    return (void*) uc->uc_mcontext->__ss.__eip;
-    #else
-    /* OSX ARM64 */
-    return (void*) arm_thread_state64_get_pc(uc->uc_mcontext->__ss);
-    #endif
-#elif defined(__linux__)
-    /* Linux */
-    #if defined(__i386__) || ((defined(__X86_64__) || defined(__x86_64__)) && defined(__ILP32__))
-    return (void*) uc->uc_mcontext.gregs[14]; /* Linux 32 */
-    #elif defined(__X86_64__) || defined(__x86_64__)
-    return (void*) uc->uc_mcontext.gregs[16]; /* Linux 64 */
-    #elif defined(__ia64__) /* Linux IA64 */
-    return (void*) uc->uc_mcontext.sc_ip;
-    #elif defined(__arm__) /* Linux ARM */
-    return (void*) uc->uc_mcontext.arm_pc;
-    #elif defined(__aarch64__) /* Linux AArch64 */
-    return (void*) uc->uc_mcontext.pc;
-    #else
-    NOT_SUPPORTED();
-    #endif
-#elif defined(__FreeBSD__)
-    /* FreeBSD */
-    #if defined(__i386__)
-    return (void*) uc->uc_mcontext.mc_eip;
-    #elif defined(__x86_64__)
-    return (void*) uc->uc_mcontext.mc_rip;
-    #else
-    NOT_SUPPORTED();
-    #endif
-#elif defined(__OpenBSD__)
-    /* OpenBSD */
-    #if defined(__i386__)
-    return (void*) uc->sc_eip;
-    #elif defined(__x86_64__)
-    return (void*) uc->sc_rip;
-    #else
-    NOT_SUPPORTED();
-    #endif
-#elif defined(__NetBSD__)
-    #if defined(__i386__)
-    return (void*) uc->uc_mcontext.__gregs[_REG_EIP];
-    #elif defined(__x86_64__)
-    return (void*) uc->uc_mcontext.__gregs[_REG_RIP];
-    #else
-    NOT_SUPPORTED();
-    #endif
-#elif defined(__DragonFly__)
-    return (void*) uc->uc_mcontext.mc_rip;
-#else
-    NOT_SUPPORTED();
-#endif
-#undef NOT_SUPPORTED
-}
 
-static void setMcontextEip(ucontext_t *uc, void *eip) {
+/* Returns the current eip and set it to the given new value (if its not NULL) */
+static void* getAndSetMcontextEip(ucontext_t *uc, void *eip) {
 #define NOT_SUPPORTED() do {\
     UNUSED(uc);\
     UNUSED(eip);\
+    return NULL;\
 } while(0)
-#define SET_VALUD_AT(add, val) do {\
-    void **temp = (void**)&add; \
-    *temp = val; \
+#define GET_SET_VALUD_AT(add, val) do {\
+    void *old_val = (void*)add; \
+    if (val) { \
+        void **temp = (void**)&add; \
+        *temp = val; \
+    } \
+    return old_val; \
 } while(0)
 #if defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_6)
     /* OSX < 10.6 */
     #if defined(__x86_64__)
-    SET_VALUD_AT(uc->uc_mcontext->__ss.__rip, eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext->__ss.__rip, eip);
     #elif defined(__i386__)
-    SET_VALUD_AT(uc->uc_mcontext->__ss.__eip, eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext->__ss.__eip, eip);
     #else
-    SET_VALUD_AT(uc->uc_mcontext->__ss.__srr0, eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext->__ss.__srr0, eip);
     #endif
 #elif defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)
     /* OSX >= 10.6 */
     #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
-    SET_VALUD_AT(uc->uc_mcontext->__ss.__rip, eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext->__ss.__rip, eip);
     #elif defined(__i386__)
-    SET_VALUD_AT(uc->uc_mcontext->__ss.__eip, eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext->__ss.__eip, eip);
     #else
     /* OSX ARM64 */
-    arm_thread_state64_set_pc_fptr(uc->uc_mcontext->__ss, eip);
+    void *old_val = (void*)arm_thread_state64_get_pc(uc->uc_mcontext->__ss);
+    if (eip) {
+        arm_thread_state64_set_pc_fptr(uc->uc_mcontext->__ss, eip);
+    }
+    return old_val;
     #endif
 #elif defined(__linux__)
     /* Linux */
     #if defined(__i386__) || ((defined(__X86_64__) || defined(__x86_64__)) && defined(__ILP32__))
-    SET_VALUD_AT(uc->uc_mcontext.gregs[14], eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext.gregs[14], eip);
     #elif defined(__X86_64__) || defined(__x86_64__)
-    SET_VALUD_AT(uc->uc_mcontext.gregs[16], eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext.gregs[16], eip);
     #elif defined(__ia64__) /* Linux IA64 */
-    SET_VALUD_AT(uc->uc_mcontext.sc_ip, eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext.sc_ip, eip);
     #elif defined(__arm__) /* Linux ARM */
-    SET_VALUD_AT(uc->uc_mcontext.arm_pc, eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext.arm_pc, eip);
     #elif defined(__aarch64__) /* Linux AArch64 */
-    SET_VALUD_AT(uc->uc_mcontext.pc, eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext.pc, eip);
     #else
     NOT_SUPPORTED();
     #endif
 #elif defined(__FreeBSD__)
     /* FreeBSD */
     #if defined(__i386__)
-    SET_VALUD_AT(uc->uc_mcontext.mc_eip, eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext.mc_eip, eip);
     #elif defined(__x86_64__)
-    SET_VALUD_AT(uc->uc_mcontext.mc_rip, eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext.mc_rip, eip);
     #else
     NOT_SUPPORTED();
     #endif
 #elif defined(__OpenBSD__)
     /* OpenBSD */
     #if defined(__i386__)
-    SET_VALUD_AT(uc->sc_eip, eip);
+    GET_SET_VALUD_AT(uc->sc_eip, eip);
     #elif defined(__x86_64__)
-    SET_VALUD_AT(uc->sc_rip, eip);
+    GET_SET_VALUD_AT(uc->sc_rip, eip);
     #else
     NOT_SUPPORTED();
     #endif
 #elif defined(__NetBSD__)
     #if defined(__i386__)
-    SET_VALUD_AT(uc->uc_mcontext.__gregs[_REG_EIP], eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext.__gregs[_REG_EIP], eip);
     #elif defined(__x86_64__)
-    SET_VALUD_AT(uc->uc_mcontext.__gregs[_REG_RIP], eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext.__gregs[_REG_RIP], eip);
     #else
     NOT_SUPPORTED();
     #endif
 #elif defined(__DragonFly__)
-    SET_VALUD_AT(uc->uc_mcontext.mc_rip, eip);
+    GET_SET_VALUD_AT(uc->uc_mcontext.mc_rip, eip);
 #else
     NOT_SUPPORTED();
 #endif
@@ -2049,7 +1987,7 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
 
 #ifdef HAVE_BACKTRACE
     ucontext_t *uc = (ucontext_t*) secret;
-    void *eip = getMcontextEip(uc);
+    void *eip = getAndSetMcontextEip(uc, NULL);
     if (eip != NULL) {
         serverLog(LL_WARNING,
         "Crashed running the instruction at: %p", eip);
@@ -2065,14 +2003,14 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
         void *ptr;
         invalidFunctionWasCalledType *ptr_ptr = (invalidFunctionWasCalledType*)&ptr;
         *ptr_ptr = invalidFunctionWasCalled;
-        setMcontextEip(uc, ptr);
+        getAndSetMcontextEip(uc, ptr);
     }
 
-    logStackTrace(getMcontextEip(uc), 1);
+    logStackTrace(eip, 1);
 
     if (eip == info->si_addr) {
         /* Restore old eip */
-        setMcontextEip(uc, eip);
+        getAndSetMcontextEip(uc, eip);
     }
 
     logRegisters(uc);
@@ -2178,7 +2116,7 @@ void watchdogSignalHandler(int sig, siginfo_t *info, void *secret) {
 
     serverLogFromHandler(LL_WARNING,"\n--- WATCHDOG TIMER EXPIRED ---");
 #ifdef HAVE_BACKTRACE
-    logStackTrace(getMcontextEip(uc), 1);
+    logStackTrace(getAndSetMcontextEip(uc, NULL), 1);
 #else
     serverLogFromHandler(LL_WARNING,"Sorry: no support for backtrace().");
 #endif


### PR DESCRIPTION
If Redis crashes due to calling an invalid function pointer, the `backtrace` function will try to de-reference this invalid pointer which will cause a crash inside the crash report and will kill the processes without having all the crash report information.

Example:

```
=== REDIS BUG REPORT START: Cut & paste starting from here ===
198672:M 19 Sep 2022 18:06:12.936 # Redis 255.255.255 crashed by signal: 11, si_code: 1
198672:M 19 Sep 2022 18:06:12.936 # Accessing address: 0x1
198672:M 19 Sep 2022 18:06:12.936 # Crashed running the instruction at: 0x1
// here the processes is crashing
```

This PR tries to fix this crash by:
1. Identify the issue when it happened.
2. Replace the invalid pointer with a pointer to some dummy function so that `backtrace` will not crash.

The identification is done by comparing `eip` to `info->si_addr`, if they are the same we know that the crash happened on the same address it tries to accesses and we can conclude that it tries to call and invalid function pointer.

To replace the invalid pointer we introduce a new function, `setAndGetMcontextEip`, which replaces `getMcontextEip` and allow to set the Eip for the different supported OS's. After printing the trace we retrieve the old `Eip` value.