### PR TITLE
[trivial] change tab to space for consistency

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -555,7 +555,7 @@ size_t zmalloc_get_rss(void) {
     if ((fd = open(filename,O_RDONLY)) == -1) return 0;
     if (ioctl(fd, PIOCPSINFO, &info) == -1) {
         close(fd);
-	return 0;
+        return 0;
     }
 
     close(fd);


### PR DESCRIPTION
It is very trival patch.

I also don't want to distrub commit log. 

but tab and space make unpretty code style.

Thanks. 

I just found only tab for return keyword. I changed it as space.