### PR TITLE
Fix how the child process exists inside checkLinuxMadvFreeForkBug

### DIFF
--- a/src/syscheck.c
+++ b/src/syscheck.c
@@ -46,6 +46,7 @@
 #include <sys/mman.h>
 #endif
 
+void exitFromChild(int retcode);
 
 #ifdef __linux__
 static sds read_sysfs_line(char *path) {
@@ -291,7 +292,7 @@ int checkLinuxMadvFreeForkBug(sds *error_msg) {
             res = 0;
 
         ret = write(pipefd[1], &res, sizeof(res)); /* Assume success, ignore return value*/
-        exit(0);
+        exitFromChild(0);
     } else {
         /* Read the result from the child. */
         ret = read(pipefd[0], &res, sizeof(res));


### PR DESCRIPTION
Fix how the child process exists inside `checkLinuxMadvFreeForkBug` since we do not want the forked child to delete any threads that some module might use etc. Hence  we do not want it to call `exit()` that will do additional cleanups before terminating the process and we better use` _exit()` that does not perform any such cleaning operations