### PR TITLE
Ignore RM_Call deny-oom flag if maxmemory is zero

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -5869,7 +5869,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
         }
     }
 
-    if (flags & REDISMODULE_ARGV_RESPECT_DENY_OOM) {
+    if (flags & REDISMODULE_ARGV_RESPECT_DENY_OOM && server.maxmemory) {
         if (cmd_flags & CMD_DENYOOM) {
             int oom_state;
             if (ctx->flags & REDISMODULE_CTX_THREAD_SAFE) {

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -173,6 +173,21 @@ start_server {tags {"modules"}} {
         r config set maxmemory 0
     } {OK} {needs:config-maxmemory}
 
+    test {rm_call clear OOM} {
+        r config set maxmemory 1
+
+        # verify rm_call fails with OOM
+        assert_error {OOM *} {
+            r test.rm_call_flags M set x 1
+        }
+
+        # clear OOM state
+        r config set maxmemory 0
+
+        # test set command is allowed
+        r test.rm_call_flags M set x 1
+    } {OK} {needs:config-maxmemory}
+
     test {rm_call OOM Eval} {
         r config set maxmemory 1
         r config set maxmemory-policy volatile-lru


### PR DESCRIPTION
If a command gets an OOM response and then if we set maxmemory to zero
to disable the limit, `server.pre_command_oom_state` never gets updated
and it stays true. As `RM_Call()` calls with "respect deny-oom" flag checks 
`server.pre_command_oom_state`, all calls will fail with OOM.

Added `server.maxmemory` check in `RM_Call()` to process deny-oom flag
only if maxmemory is configured.