### PR TITLE
Fix the missing server.dirty increment and redundant signalModifiedKey in serveClientBlockedOnList

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -2583,7 +2583,7 @@ robj *listTypeDup(robj *o);
 int listTypeDelRange(robj *o, long start, long stop);
 void unblockClientWaitingData(client *c);
 void popGenericCommand(client *c, int where);
-void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, int *deleted);
+void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, int signal, int *deleted);
 
 /* MULTI/EXEC/WATCH... */
 void unwatchAllKeys(client *c);

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1915,6 +1915,25 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         r ping
     } {PONG}
 
+    test "BLPOP/BLMOVE should increase dirty" {
+        r del lst{t} lst1{t}
+        set rd [redis_deferring_client]
+
+        set dirty [s rdb_changes_since_last_save]
+        $rd blpop lst{t} 0
+        r lpush lst{t} a
+        set dirty2 [s rdb_changes_since_last_save]
+        assert {$dirty2 == $dirty + 2}
+
+        set dirty [s rdb_changes_since_last_save]
+        $rd blmove lst{t} lst1{t} left left 0
+        r lpush lst{t} a
+        set dirty2 [s rdb_changes_since_last_save]
+        assert {$dirty2 == $dirty + 2}
+
+        $rd close
+    }
+
 foreach {pop} {BLPOP BLMPOP_RIGHT} {
     test "client unblock tests" {
         r del l

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1922,12 +1922,14 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         set dirty [s rdb_changes_since_last_save]
         $rd blpop lst{t} 0
         r lpush lst{t} a
+        assert_equal {lst{t} a} [$rd read]
         set dirty2 [s rdb_changes_since_last_save]
         assert {$dirty2 == $dirty + 2}
 
         set dirty [s rdb_changes_since_last_save]
         $rd blmove lst{t} lst1{t} left left 0
         r lpush lst{t} a
+        assert_equal {a} [$rd read]
         set dirty2 [s rdb_changes_since_last_save]
         assert {$dirty2 == $dirty + 2}
 


### PR DESCRIPTION
Mainly fix two minor bug
1. When handle BL*POP/BLMOVE commands with blocked clients, we should increment server.dirty.
2.  `listPopRangeAndReplyWithKey()` in `serveClientBlockedOnList()` should not repeat calling `signalModifiedKey()` which has been called when an element was pushed on the list.

Other optimization
add `signal` param for `listElementsRemoved` to skip `signalModifiedKey()` to unify all pop operation.

Unifying all pop operations also prepares us for #11303, so that we can avoid having to deal with the conversion from quicklist to listpack() in various places when the list shrinks.