### PR TITLE
Fixing compilation by removing flock() when compiling on Solaris

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4248,10 +4248,13 @@ int finishShutdown(void) {
     /* Close the listening sockets. Apparently this allows faster restarts. */
     closeListeningSockets(1);
 
+#if !defined(__sun)
     /* Unlock the cluster config file before shutdown */
     if (server.cluster_enabled && server.cluster_config_file_lock_fd != -1) {
         flock(server.cluster_config_file_lock_fd, LOCK_UN|LOCK_NB);
     }
+#endif /* __sun */
+
 
     serverLog(LL_WARNING,"%s is now ready to exit, bye bye...",
         server.sentinel_mode ? "Sentinel" : "Redis");


### PR DESCRIPTION
SunOS/Solaris and its relatives don't support the flock() function. While "redis" has been excluding setting up the lock using flock() on the cluster configuration file in https://github.com/redis/redis/blob/unstable/src/cluster.c#L502 when compiling under Solaris, it was still using flock() in the unlock call while shutting down. 

This pull request eliminates the flock() call also in the unlocking stage for Oracle Solaris and its relatives.

Fix compilation regression from #10912