### PR TITLE
Remove redundant arity checks in XINFO

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3838,11 +3838,6 @@ void xinfoCommand(client *c) {
 
     /* HELP is special. Handle it ASAP. */
     if (!strcasecmp(c->argv[1]->ptr,"HELP")) {
-        if (c->argc != 2) {
-            addReplySubcommandSyntaxError(c);
-            return;
-        }
-
         const char *help[] = {
 "CONSUMERS <key> <groupname>",
 "    Show consumers of <groupname>.",
@@ -3853,9 +3848,6 @@ void xinfoCommand(client *c) {
 NULL
         };
         addReplyHelp(c, help);
-        return;
-    } else if (c->argc < 3) {
-        addReplySubcommandSyntaxError(c);
         return;
     }
 


### PR DESCRIPTION
The arity in the JSON files of the subcommands reneder this code unreachable