### PR TITLE
MEMORY USAGE can take the SAMPLES arg only once

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -1497,25 +1497,22 @@ void memoryCommand(client *c) {
 NULL
         };
         addReplyHelp(c, help);
-    } else if (!strcasecmp(c->argv[1]->ptr,"usage") && c->argc >= 3) {
+    } else if (!strcasecmp(c->argv[1]->ptr,"usage") && (c->argc == 3 || c->argc == 5)) {
         dictEntry *de;
         long long samples = OBJ_COMPUTE_SIZE_DEF_SAMPLES;
-        for (int j = 3; j < c->argc; j++) {
-            if (!strcasecmp(c->argv[j]->ptr,"samples") &&
-                j+1 < c->argc)
-            {
-                if (getLongLongFromObjectOrReply(c,c->argv[j+1],&samples,NULL)
-                     == C_ERR) return;
-                if (samples < 0) {
-                    addReplyErrorObject(c,shared.syntaxerr);
-                    return;
-                }
-                if (samples == 0) samples = LLONG_MAX;
-                j++; /* skip option argument. */
-            } else {
+         if (c->argc == 5) {
+            if (strcasecmp(c->argv[3]->ptr, "samples")) {
                 addReplyErrorObject(c,shared.syntaxerr);
                 return;
             }
+            if (getLongLongFromObjectOrReply(c,c->argv[4],&samples,NULL) == C_ERR)
+                return;
+            if (samples < 0) {
+                addReplyErrorObject(c,shared.syntaxerr);
+                return;
+            }
+            if (samples == 0)
+                samples = LLONG_MAX;
         }
         if ((de = dictFind(c->db->dict,c->argv[2]->ptr)) == NULL) {
             addReplyNull(c);

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -26,6 +26,17 @@ start_server {tags {"introspection"}} {
         r touch key0{t} key1{t} key2{t} key3{t}
     } 2
 
+    test {MEMORY USAGE with SAMPLES syntax} {
+        r lpush foo e1 e2 e3
+        assert_error {ERR syntax*} {r memory usage foo samplestypo 1}
+        assert_error {ERR syntax*} {r memory usage foo samples -1}
+        assert_error {ERR unknown subcommand or wrong number*} {r memory usage foo samples 1 samples 1}
+        assert_morethan [r memory usage foo samples 0] 0
+        assert_morethan [r memory usage foo samples 1] 0
+        assert_morethan [r memory usage foo samples 10] 0
+        r del foo
+    }
+
     test {command stats for GEOADD} {
         r config resetstat
         r GEOADD foo 0 0 bar


### PR DESCRIPTION
For some unknown reason, it seems the code used to accommodate repeated SAMPLES args...