### PR TITLE
Update sentinel-config.json to consistent with Config Get and Set operation

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -3662,8 +3662,8 @@ struct redisCommandArg SENTINEL_CONFIG_action_set_Subargs[] = {
 
 /* SENTINEL CONFIG action argument table */
 struct redisCommandArg SENTINEL_CONFIG_action_Subargs[] = {
-{"set",ARG_TYPE_BLOCK,-1,"SET",NULL,NULL,CMD_ARG_MULTIPLE,.subargs=SENTINEL_CONFIG_action_set_Subargs},
-{"get",ARG_TYPE_STRING,-1,"GET",NULL,NULL,CMD_ARG_MULTIPLE,.display_text="parameter"},
+{"set",ARG_TYPE_BLOCK,-1,"SET",NULL,NULL,CMD_ARG_NONE,.subargs=SENTINEL_CONFIG_action_set_Subargs},
+{"parameter",ARG_TYPE_STRING,-1,"GET",NULL,NULL,CMD_ARG_NONE},
 {0}
 };
 

--- a/src/commands/sentinel-config.json
+++ b/src/commands/sentinel-config.json
@@ -21,7 +21,6 @@
                         "name":"set",
                         "token":"SET",
                         "type":"block",
-                        "multiple":true,
                         "arguments":[
                             {
                                 "name":"parameter",
@@ -35,9 +34,7 @@
                     },
                     {
                         "token":"GET",
-                        "multiple":true,
-                        "name":"get",
-                        "display":"parameter",
+                        "name":"parameter",
                         "type":"string"
                     }
                 ]


### PR DESCRIPTION
Now commands:

**sentinel config set parameter value
sentinel config get parameter**

do not support multiply parameters, so this PR changes remove the **multiply** keywords in order to keep consistent with 
current feature.

However, @moticless do you think we should support multiply parameters later? 