### PR TITLE
Improve BLMPOP/BZMPOP/WAIT timeout overflow handling and error messages

### DIFF
--- a/src/timeout.c
+++ b/src/timeout.c
@@ -189,13 +189,11 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
     }
 
     if (tval > 0) {
-        tval += now;
-        
-        /* if addition of `now` caused to overflow */
-        if (tval < 0) {
-            addReplyError(c,"timeout is out of range");
+        if  (tval > LLONG_MAX - now) {
+            addReplyError(c,"timeout is out of range"); /* 'tval+now' would overflow */
             return C_ERR;
         }
+        tval += now;
     }
     *timeout = tval;
 

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -172,7 +172,7 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
             return C_ERR;
 
         ftval *= 1000.0;  /* seconds => millisec */
-        if (ftval + now > LLONG_MAX) {
+        if (ftval > LLONG_MAX) {
             addReplyError(c, "timeout is out of range");
             return C_ERR;
         }
@@ -190,6 +190,12 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
 
     if (tval > 0) {
         tval += now;
+        
+        /* if addition of `now` caused to overflow */
+        if (tval < 0) {
+            addReplyError(c,"timeout is out of range");
+            return C_ERR;
+        }
     }
     *timeout = tval;
 

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1183,6 +1183,17 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             assert_error "ERR *is negative*" {$rd read}
             $rd close
         }
+        
+        test "$pop: out of range timeout" {
+            # Timeout is parsed as float and multiplied by 1000, added mstime()
+            # and stored in long-long which might lead to out-of-range value.
+            # (Even though given timeout is smaller than LLONG_MAX, the result
+            # will be bigger)
+            set rd [redis_deferring_client]
+            bpop_command $rd $pop blist1 36028797018963967
+            assert_error "ERR *is out of range*" {$rd read}
+            $rd close
+        }        
 
         test "$pop: with non-integer timeout" {
             set rd [redis_deferring_client]

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1190,7 +1190,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             # (Even though given timeout is smaller than LLONG_MAX, the result
             # will be bigger)
             set rd [redis_deferring_client]
-            bpop_command $rd $pop blist1 36028797018963967
+            bpop_command $rd $pop blist1 0x7FFFFFFFFFFFFF
             assert_error "ERR *is out of range*" {$rd read}
             $rd close
         }        

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1190,7 +1190,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             bpop_command $rd $pop blist1 -1
             assert_error "ERR *is negative*" {$rd read}
             $rd close
-        } 
+        }
 
         test "$pop: with non-integer timeout" {
             set rd [redis_deferring_client]

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -22,9 +22,17 @@ start_server {} {
     test {WAIT out of range timeout (milliseconds)} {
         # Timeout is parsed as milliseconds by getLongLongFromObjectOrReply().
         # Verify we get out of range message if value is behind LLONG_MAX
-         catch {$master wait 2 0x8000000000000000} err
+        # (decimal value equals to 0x8000000000000000)
+         catch {$master wait 2 9223372036854775808} err
          assert_match "*timeout is not an integer or out of range*" $err
+                  
+         # expected to fail by later overflow condition after addition
+         # of mstime(). (decimal value equals to 0x7FFFFFFFFFFFFFFF)
+         catch {$master wait 2 9223372036854775807} err
+         assert_match "*timeout is out of range*" $err
          
+         catch {$master wait 2 -1} err
+         assert_match "*timeout is negative*" $err         
     }
     
     test {WAIT should acknowledge 1 additional copy of the data} {

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -23,16 +23,13 @@ start_server {} {
         # Timeout is parsed as milliseconds by getLongLongFromObjectOrReply().
         # Verify we get out of range message if value is behind LLONG_MAX
         # (decimal value equals to 0x8000000000000000)
-         catch {$master wait 2 9223372036854775808} err
-         assert_match "*timeout is not an integer or out of range*" $err
+         assert_error "*or out of range*" {$master wait 2 9223372036854775808}
                   
          # expected to fail by later overflow condition after addition
          # of mstime(). (decimal value equals to 0x7FFFFFFFFFFFFFFF)
-         catch {$master wait 2 9223372036854775807} err
-         assert_match "*timeout is out of range*" $err
+         assert_error "*timeout is out of range*" {$master wait 2 9223372036854775807}
          
-         catch {$master wait 2 -1} err
-         assert_match "*timeout is negative*" $err         
+         assert_error "*timeout is negative*" {$master wait 2 -1}         
     }
     
     test {WAIT should acknowledge 1 additional copy of the data} {

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -18,7 +18,15 @@ start_server {} {
             fail "Replication not started."
         }
     }
-
+    
+    test {WAIT out of range timeout (milliseconds)} {
+        # Timeout is parsed as milliseconds by getLongLongFromObjectOrReply().
+        # Verify we get out of range message if value is behind LLONG_MAX
+         catch {$master wait 2 0x8000000000000000} err
+         assert_match "*timeout is not an integer or out of range*" $err
+         
+    }
+    
     test {WAIT should acknowledge 1 additional copy of the data} {
         $master set foo 0
         $master incr foo


### PR DESCRIPTION
Refine getTimeoutFromObjectOrReply() out-of-range check.

Timeout is parsed (and verifies out of range) as double and 
multiplied by 1000, added mstime() and stored in long-long 
which might lead to out-of-range value of long-long.
