### PR TITLE
Pass -flto flag to the linker 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,12 @@
 release_hdr := $(shell sh -c './mkreleasehdr.sh')
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
-OPTIMIZATION?=-O3 -flto
+OPTIMIZATION?=-O3
+ifeq ($(OPTIMIZATION),-O3)
+	REDIS_CFLAGS+=-flto
+	REDIS_LDFLAGS+=-flto
+endif
+
 DEPENDENCY_TARGETS=hiredis linenoise lua hdr_histogram
 NODEPS:=clean distclean
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,6 @@ ifeq ($(OPTIMIZATION),-O3)
 	REDIS_CFLAGS+=-flto
 	REDIS_LDFLAGS+=-flto
 endif
-
 DEPENDENCY_TARGETS=hiredis linenoise lua hdr_histogram
 NODEPS:=clean distclean
 
@@ -97,10 +96,6 @@ ifeq ($(USE_JEMALLOC),no)
 endif
 
 ifdef SANITIZER
-# Remove -flto from Clang sanitizer build as it fails to compile with -flto.
-ifneq (,$(findstring clang,$(CC)))
-	OPT := $(patsubst %-flto,%,$(OPT))
-endif
 ifeq ($(SANITIZER),address)
 	MALLOC=libc
 	CFLAGS+=-fsanitize=address -fno-sanitize-recover=all -fno-omit-frame-pointer

--- a/src/Makefile
+++ b/src/Makefile
@@ -92,6 +92,10 @@ ifeq ($(USE_JEMALLOC),no)
 endif
 
 ifdef SANITIZER
+# Remove -flto from Clang sanitizer build as it fails to compile with -flto.
+ifneq (,$(findstring clang,$(CC)))
+	OPT := $(patsubst %-flto,%,$(OPT))
+endif
 ifeq ($(SANITIZER),address)
 	MALLOC=libc
 	CFLAGS+=-fsanitize=address -fno-sanitize-recover=all -fno-omit-frame-pointer

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -1573,9 +1573,9 @@ REDIS_STATIC void *_quicklistSaver(unsigned char *data, size_t sz) {
  * Returns malloc'd value from quicklist */
 int quicklistPop(quicklist *quicklist, int where, unsigned char **data,
                  size_t *sz, long long *slong) {
-    unsigned char *vstr;
-    size_t vlen;
-    long long vlong;
+    unsigned char *vstr = NULL;
+    size_t vlen = 0;
+    long long vlong = 0;
     if (quicklist->count == 0)
         return 0;
     int ret = quicklistPopCustom(quicklist, where, &vstr, &vlen, &vlong,

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1028,7 +1028,7 @@ unsigned char *zzlDelete(unsigned char *zl, unsigned char *eptr) {
 unsigned char *zzlInsertAt(unsigned char *zl, unsigned char *eptr, sds ele, double score) {
     unsigned char *sptr;
     char scorebuf[MAX_D2STRING_CHARS];
-    int scorelen;
+    int scorelen = 0;
     long long lscore;
     int score_is_long = double2ll(score, &lscore);
     if (!score_is_long)


### PR DESCRIPTION
Currently, we add `-flto` to the compile flags only. We are supposed
to add it to the linker flags as well. Clang build fails because of this. 

Added a change to add `-flto` to  `REDIS_CFLAGS` and `REDIS_LDFLAGS` 
if the build optimization flag is `-O3`. (`noopt` build will not use `-flto`)

Introduced by https://github.com/redis/redis/pull/11207