### PR TITLE
Improve linux overcommit check and warning

### DIFF
--- a/src/syscheck.c
+++ b/src/syscheck.c
@@ -150,9 +150,12 @@ int checkOvercommit(sds *error_msg) {
     }
     fclose(fp);
 
-    if (strtol(buf, NULL, 10) == 0) {
+    if (strtol(buf, NULL, 10) != 1) {
         *error_msg = sdsnew(
-            "overcommit_memory is set to 0! Background save may fail under low memory condition. "
+            "Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. "
+#if defined(USE_JEMALLOC)
+            "Being disabled, it can can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. "
+#endif
             "To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the "
             "command 'sysctl vm.overcommit_memory=1' for this to take effect.");
         return -1;


### PR DESCRIPTION
1. show the overcommit warning when overcommit is disabled (2), not just when it is set to heuristic (0).
2. improve warning text to mention the issue with jemalloc causing VM mapping fragmentation when set to 2.

closes #10234, closes #10319