### PR TITLE
init client in RM_GetContextFromIO

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -7024,7 +7024,8 @@ void RM_EmitAOF(RedisModuleIO *io, const char *cmdname, const char *fmt, ...) {
 RedisModuleCtx *RM_GetContextFromIO(RedisModuleIO *io) {
     if (io->ctx) return io->ctx; /* Can't have more than one... */
     io->ctx = zmalloc(sizeof(RedisModuleCtx));
-    moduleCreateContext(io->ctx, io->type->module, REDISMODULE_CTX_NONE);
+    moduleCreateContext(io->ctx, io->type->module, REDISMODULE_CTX_TEMP_CLIENT);
+    RM_SelectDb(io->ctx, io->dbid);
     return io->ctx;
 }
 


### PR DESCRIPTION
Context returned from `RM_GetContextFromIO` doesn't have a client, so when I call `RM_CreateTimer` in `rdb_load` callback, the new timer's `dbid` will default to 0.

This PR inits `ctx` with a temp client and proper `dbid`.