### PR TITLE
fix arm build warning due to new compiler optimizations

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -882,8 +882,10 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char 
     if (!delete) {
         if (enctype == LP_ENCODING_INT) {
             memcpy(dst,eleint,enclen);
-        } else {
+        } else if (elestr) {
             lpEncodeString(dst,elestr,size);
+        } else {
+            redis_unreachable();
         }
         dst += enclen;
         memcpy(dst,backlen,backlen_size);

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1754,7 +1754,7 @@ static void stress(int pos, int num, int maxsize, int dnum) {
 static unsigned char *pop(unsigned char *zl, int where) {
     unsigned char *p, *vstr;
     unsigned int vlen;
-    long long vlong;
+    long long vlong = 0;
 
     p = ziplistIndex(zl,where == ZIPLIST_HEAD ? 0 : -1);
     if (ziplistGet(p,&vstr,&vlen,&vlong)) {


### PR DESCRIPTION
Build fails with warnings in ARM CI after adding more aggressive optimizations (#11350)
probably a result of more aggressive inlining

```
ziplist.c: In function ‘pop.constprop’:
ziplist.c:1770:13: error: ‘vlong’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
             printf("%lld", vlong);
             ^~~~~~~~~~~~~~~~~~~~~
```

```
listpack.c: In function ‘lpInsert.constprop’:
listpack.c:406:9: error: argument 2 null where non-null expected [-Werror=nonnull]
         memcpy(buf+1,s,len);
         ^~~~~~~~~~~~~~~~~~~
```