### PR TITLE
Fix non-existent directive name in redis.conf comments

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1782,9 +1782,9 @@ aof-timestamp-enabled no
 # published in the header of the bus packets so that other nodes will be able to
 # correctly map the address of the node publishing the information.
 #
-# If cluster-tls is set to yes and cluster-announce-tls-port is omitted or set
+# If tls-cluster is set to yes and cluster-announce-tls-port is omitted or set
 # to zero, then cluster-announce-port refers to the TLS port. Note also that
-# cluster-announce-tls-port has no effect if cluster-tls is set to no.
+# cluster-announce-tls-port has no effect if tls-cluster is set to no.
 #
 # If the above options are not used, the normal Redis Cluster auto-detection
 # will be used instead.


### PR DESCRIPTION
```
s/cluster-tls/tls-cluster/g
```