### PR TITLE
Fix redis-benchmark hang when it fails to connect to redis

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -320,7 +320,7 @@ static redisConfig *getRedisConfig(const char *ip, int port,
     c = getRedisContext(ip, port, hostsocket);
     if (c == NULL) {
         freeRedisConfig(cfg);
-        return NULL;
+        exit(1);
     }
     redisAppendCommand(c, "CONFIG GET %s", "save");
     redisAppendCommand(c, "CONFIG GET %s", "appendonly");


### PR DESCRIPTION
Forgot to start redis-server when testing performance. When opening the benchmark for testing, it will always be stuck, and the process cpu will reach 100%.