### PR TITLE
Update outdated commands descriptions and cleanups in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,17 +488,15 @@ void foobarCommand(client *c) {
 }
 ```
 
-The command is then referenced inside `commands.c`, see above file part for more details.
-Each command will have a JSON file that stores its metadata, see `ping.json` and `PingCommand` for examples.
-
-Commands will have a command_flags attribute, the command flags are documented in the `redisCommand` top comment inside `server.h`.
+The command function is referenced by a JSON file, together with its metadata, see `commands.c` descibed above for details.
+The command flags are documented in the comment above the `struct redisCommand` in `server.h`.
 For other details, please refer to the `COMMAND` command. https://redis.io/commands/command/
 
 After the command operates in some way, it returns a reply to the client,
 usually using `addReply()` or a similar function defined inside `networking.c`.
 
 There are tons of command implementations inside the Redis source code
-that can serve as examples of actual commands implementations. Writing
+that can serve as examples of actual commands implementations (e.g. pingCommand). Writing
 a few toy commands can be a good exercise to get familiar with the code base.
 
 There are also many other files not described here, but it is useless to

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ void foobarCommand(client *c) {
 }
 ```
 
-The command function is referenced by a JSON file, together with its metadata, see `commands.c` descibed above for details.
+The command function is referenced by a JSON file, together with its metadata, see `commands.c` described above for details.
 The command flags are documented in the comment above the `struct redisCommand` in `server.h`.
 For other details, please refer to the `COMMAND` command. https://redis.io/commands/command/
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ command in order to really clean everything and rebuild from scratch:
 
     % make distclean
 
-This will clean: jemalloc, lua, hiredis, linenoise and hdr_histogram.
+This will clean: jemalloc, lua, hiredis, linenoise and other dependencies.
 
 Also if you force certain build options like 32bit target, no C compiler
 optimizations (for debugging purposes), and other similar build time options,
@@ -488,43 +488,11 @@ void foobarCommand(client *c) {
 }
 ```
 
-There will be a `foobar.json` JSON file to record all the metadata for this command:
+The command is then referenced inside `commands.c`, see above file part for more details.
+Each command will have a JSON file that stores its metadata, see `ping.json` and `PingCommand` for examples.
 
-```json
-{
-    "FOOBAR": {
-        "summary": "A foobar command.",
-        "complexity": "O(1)",
-        "group": "connection",
-        "since": "x.0.0",
-        "arity": 2,
-        "function": "foobarCommand",
-        "command_flags": [
-            "LOADING",
-            "FAST"
-        ],
-        "acl_categories": [
-            "CONNECTION"
-        ],
-        "arguments": [
-            {
-                "name": "message",
-                "type": "string"
-            }
-        ]
-    }
-}
-```
-
-The command is then referenced inside `commands.c`, see above file part for more details:
-
-```c
-{"foobar","A foobar command.","O(1)","x.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_CONNECTION,FOOBAR_History,FOOBAR_tips,foobarCommand,2,CMD_LOADING|CMD_FAST,ACL_CATEGORY_CONNECTION,.args=FOOBAR_Args},
-```
-
-In the above example `2` is the number of arguments the command takes,
-while `CMD_LOADING` and `CMD_FAST` are the command flags, as documented in the `redisCommand`
-top comment inside `server.h`. For more details, please refer to the `COMMAND` command.
+Commands will have a command_flags attribute, the command flags are documented in the `redisCommand` top comment inside `server.h`.
+For other details, please refer to the `COMMAND` command. https://redis.io/commands/command/
 
 After the command operates in some way, it returns a reply to the client,
 usually using `addReply()` or a similar function defined inside `networking.c`.


### PR DESCRIPTION
Redis commands has been significantly refactored in 7.0.
This PR updates the outdated README.md to reflect it.

Based on #10864, doing some additional cleanups.

Co-authored-by: theoboldalex <theoboldalex@gmail.com>