### PR TITLE
Fix continuously forking that starve persistence related forks

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -961,6 +961,7 @@ void stopAppendOnly(void) {
     server.aof_selected_db = -1;
     server.aof_state = AOF_OFF;
     server.aof_rewrite_scheduled = 0;
+    server.aof_rewrite_pending = 0;
     server.aof_last_incr_size = 0;
     killAppendOnlyChild();
     sdsfree(server.aof_buf);
@@ -2472,6 +2473,7 @@ int rewriteAppendOnlyFileBackground(void) {
         serverLog(LL_NOTICE,
             "Background append only file rewriting started by pid %ld",(long) childpid);
         server.aof_rewrite_scheduled = 0;
+        server.aof_rewrite_pending = 0;
         server.aof_rewrite_time_start = time(NULL);
         return C_OK;
     }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1490,6 +1490,10 @@ int rdbSaveBackground(int req, char *filename, rdbSaveInfo *rsi) {
             return C_ERR;
         }
         serverLog(LL_NOTICE,"Background saving started by pid %ld",(long) childpid);
+        if (req == SLAVE_REQ_NONE) {
+            server.rdb_bgsave_scheduled = 0;
+            server.rdb_bgsave_pending = 0;
+        }
         server.rdb_save_time_start = time(NULL);
         server.rdb_child_type = RDB_CHILD_TYPE_DISK;
         return C_OK;

--- a/src/server.c
+++ b/src/server.c
@@ -1128,6 +1128,22 @@ void checkChildrenDone(void) {
             }
         }
 
+        /* Start any pending bgsave immediately. */
+        if (!hasActiveChildProcess() &&
+            (server.rdb_bgsave_pending || server.rdb_bgsave_scheduled))
+        {
+            rdbSaveInfo rsi, *rsiptr;
+            rsiptr = rdbPopulateSaveInfo(&rsi);
+            rdbSaveBackground(SLAVE_REQ_NONE, server.rdb_filename, rsiptr);
+        }
+
+        /* Start any pending aof rewrite immediately. */
+        if (!hasActiveChildProcess() &&
+            (server.aof_rewrite_pending || server.aof_rewrite_scheduled))
+        {
+            rewriteAppendOnlyFileBackground();
+        }
+
         /* start any pending forks immediately. */
         replicationStartPendingFork();
     }
@@ -1314,7 +1330,11 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     {
         run_with_period(1000) receiveChildInfo();
         checkChildrenDone();
-    } else {
+    }
+
+    if (!hasActiveChildProcess() ||
+        (hasActiveChildProcess() && !server.rdb_bgsave_pending))
+    {
         /* If there is not a background saving/rewrite in progress check if
          * we have to save/rewrite now. */
         for (j = 0; j < server.saveparamslen; j++) {
@@ -1330,18 +1350,28 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
                  CONFIG_BGSAVE_RETRY_DELAY ||
                  server.lastbgsave_status == C_OK))
             {
-                serverLog(LL_NOTICE,"%d changes in %d seconds. Saving...",
-                    sp->changes, (int)sp->seconds);
-                rdbSaveInfo rsi, *rsiptr;
-                rsiptr = rdbPopulateSaveInfo(&rsi);
-                rdbSaveBackground(SLAVE_REQ_NONE,server.rdb_filename,rsiptr);
+                if (!hasActiveChildProcess()) {
+                    serverLog(LL_NOTICE,"%d changes in %d seconds. Saving...",
+                        sp->changes, (int)sp->seconds);
+                    rdbSaveInfo rsi, *rsiptr;
+                    rsiptr = rdbPopulateSaveInfo(&rsi);
+                    rdbSaveBackground(SLAVE_REQ_NONE,server.rdb_filename,rsiptr);
+                } else {
+                    serverLog(LL_NOTICE,"%d changes in %d seconds. "
+                                        "But there is a active child running, pending the save.",
+                                        sp->changes, (int)sp->seconds);
+                    server.rdb_bgsave_pending = 1;
+                }
                 break;
             }
         }
+    }
 
+    if (!hasActiveChildProcess() ||
+        (hasActiveChildProcess() && !server.aof_rewrite_pending))
+    {
         /* Trigger an AOF rewrite if needed. */
         if (server.aof_state == AOF_ON &&
-            !hasActiveChildProcess() &&
             server.aof_rewrite_perc &&
             server.aof_current_size > server.aof_rewrite_min_size)
         {
@@ -1349,15 +1379,20 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
                 server.aof_rewrite_base_size : 1;
             long long growth = (server.aof_current_size*100/base) - 100;
             if (growth >= server.aof_rewrite_perc && !aofRewriteLimited()) {
-                serverLog(LL_NOTICE,"Starting automatic rewriting of AOF on %lld%% growth",growth);
-                rewriteAppendOnlyFileBackground();
+                if (!hasActiveChildProcess()) {
+                    serverLog(LL_NOTICE,"Starting automatic rewriting of AOF on %lld%% growth",growth);
+                    rewriteAppendOnlyFileBackground();
+                } else {
+                    serverLog(LL_NOTICE,"There is a active child, pending the automatic rewriting of AOF on %lld%% growth",growth);
+                    server.aof_rewrite_pending = 1;
+                }
             }
         }
     }
+
     /* Just for the sake of defensive programming, to avoid forgetting to
      * call this function when needed. */
     updateDictResizePolicy();
-
 
     /* AOF postponed flush: Try at every cron cycle if the slow fsync
      * completed. */
@@ -1429,8 +1464,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     {
         rdbSaveInfo rsi, *rsiptr;
         rsiptr = rdbPopulateSaveInfo(&rsi);
-        if (rdbSaveBackground(SLAVE_REQ_NONE,server.rdb_filename,rsiptr) == C_OK)
-            server.rdb_bgsave_scheduled = 0;
+        rdbSaveBackground(SLAVE_REQ_NONE, server.rdb_filename, rsiptr);
     }
 
     run_with_period(100) {
@@ -1897,6 +1931,7 @@ void initServerConfig(void) {
     server.aof_state = AOF_OFF;
     server.aof_rewrite_base_size = 0;
     server.aof_rewrite_scheduled = 0;
+    server.aof_rewrite_pending = 0;
     server.aof_flush_sleep = 0;
     server.aof_last_fsync = time(NULL);
     server.aof_cur_timestamp = 0;
@@ -2523,6 +2558,7 @@ void initServer(void) {
     server.rdb_pipe_buff = NULL;
     server.rdb_pipe_bufflen = 0;
     server.rdb_bgsave_scheduled = 0;
+    server.rdb_bgsave_pending = 0;
     server.child_info_pipe[0] = -1;
     server.child_info_pipe[1] = -1;
     server.child_info_nread = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -1129,19 +1129,19 @@ void checkChildrenDone(void) {
         }
 
         /* Start any pending bgsave immediately. */
-        if (!hasActiveChildProcess() &&
-            (server.rdb_bgsave_pending || server.rdb_bgsave_scheduled))
+        if (!hasActiveChildProcess() && server.rdb_bgsave_pending)
         {
             rdbSaveInfo rsi, *rsiptr;
             rsiptr = rdbPopulateSaveInfo(&rsi);
             rdbSaveBackground(SLAVE_REQ_NONE, server.rdb_filename, rsiptr);
+            server.rdb_bgsave_pending = 0;
         }
 
         /* Start any pending aof rewrite immediately. */
-        if (!hasActiveChildProcess() &&
-            (server.aof_rewrite_pending || server.aof_rewrite_scheduled))
+        if (!hasActiveChildProcess() && server.aof_rewrite_pending)
         {
             rewriteAppendOnlyFileBackground();
+            server.aof_rewrite_pending = 0;
         }
 
         /* start any pending forks immediately. */

--- a/src/server.h
+++ b/src/server.h
@@ -1659,6 +1659,7 @@ struct redisServer {
     off_t aof_fsync_offset;         /* AOF offset which is already synced to disk. */
     int aof_flush_sleep;            /* Micros to sleep before flush. (used by tests) */
     int aof_rewrite_scheduled;      /* Rewrite once BGSAVE terminates. */
+    int aof_rewrite_pending;        /* Rewrite once child process terminates. */
     sds aof_buf;      /* AOF buffer, written before entering the event loop */
     int aof_fd;       /* File descriptor of currently selected AOF file */
     int aof_selected_db; /* Currently selected DB in AOF */
@@ -1699,6 +1700,7 @@ struct redisServer {
     time_t rdb_save_time_last;      /* Time used by last RDB save run. */
     time_t rdb_save_time_start;     /* Current RDB save start time. */
     int rdb_bgsave_scheduled;       /* BGSAVE when possible if true. */
+    int rdb_bgsave_pending;         /* BGSAVE once child process terminates. */
     int rdb_child_type;             /* Type of save by active child. */
     int lastbgsave_status;          /* C_OK or C_ERR */
     int stop_writes_on_bgsave_err;  /* Don't allow writes if can't BGSAVE */


### PR DESCRIPTION
If a replica for some reasons goes into a loop of requesting a
full sync from the master, it'll cause the master to continuously
fork for RDB generation (either disk-less or or disk-based).
This is normal and can happen if for instance the slave fails to
load the RDB because of memory issues.

The problem is that we allow only a single fork on the master and
this fork will constantly be used to generate the replication bulk RDB.
All cron jobs related to persistence will be starved because the "fork lock"
will be used for replication. So a faulty replica will effectively disable
persistence on the master.

In this PR, we added the `rdb_bgsave_pending` and `aof_rewrite_pending` flags,
which are updated in `serverCron`, to flag there is a pending snapshot or rewrite
operation. And once we're done forking, like in `checkChildrenDone`, if the flags
is on, we will do the snapshot or the rewrite operation immediately.

Fixes #9991, thanks to @yoav-steinberg for the detailed report.