### PR TITLE
Fix crash due to to reuse iterator entry after list deletion in module

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -4147,10 +4147,7 @@ int RM_ListPush(RedisModuleKey *key, int where, RedisModuleString *ele) {
 
     if (!(key->mode & REDISMODULE_WRITE)) return REDISMODULE_ERR;
     if (key->value && key->value->type != OBJ_LIST) return REDISMODULE_ERR;
-    if (key->iter) {
-        listTypeReleaseIterator(key->iter);
-        key->iter = NULL;
-    }
+    if (key->iter) moduleFreeKeyIterator(key);
     if (key->value == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_LIST);
     listTypePush(key->value, ele,
         (where == REDISMODULE_LIST_HEAD) ? LIST_HEAD : LIST_TAIL);
@@ -4180,10 +4177,7 @@ RedisModuleString *RM_ListPop(RedisModuleKey *key, int where) {
         errno = EBADF;
         return NULL;
     }
-    if (key->iter) {
-        listTypeReleaseIterator(key->iter);
-        key->iter = NULL;
-    }
+    if (key->iter) moduleFreeKeyIterator(key);
     robj *ele = listTypePop(key->value,
         (where == REDISMODULE_LIST_HEAD) ? LIST_HEAD : LIST_TAIL);
     robj *decoded = getDecodedObject(ele);
@@ -4246,8 +4240,7 @@ int RM_ListSet(RedisModuleKey *key, long index, RedisModuleString *value) {
         listTypeReplace(&key->u.list.entry, value);
         /* A note in quicklist.c forbids use of iterator after insert, so
          * probably also after replace. */
-        listTypeReleaseIterator(key->iter);
-        key->iter = NULL;
+        moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
         return REDISMODULE_ERR;
@@ -4292,8 +4285,7 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
         int where = index < 0 ? LIST_TAIL : LIST_HEAD;
         listTypeInsert(&key->u.list.entry, value, where);
         /* A note in quicklist.c forbids use of iterator after insert. */
-        listTypeReleaseIterator(key->iter);
-        key->iter = NULL;
+        moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
         return REDISMODULE_ERR;
@@ -4314,7 +4306,7 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
 int RM_ListDelete(RedisModuleKey *key, long index) {
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         listTypeDelete(key->iter, &key->u.list.entry);
-        moduleDelKeyIfEmpty(key);
+        if (!moduleDelKeyIfEmpty(key)) moduleFreeKeyIterator(key);
         return REDISMODULE_OK;
     } else {
         return REDISMODULE_ERR;

--- a/src/module.c
+++ b/src/module.c
@@ -4306,7 +4306,13 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
 int RM_ListDelete(RedisModuleKey *key, long index) {
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         listTypeDelete(key->iter, &key->u.list.entry);
-        if (!moduleDelKeyIfEmpty(key)) moduleFreeKeyIterator(key);
+        if (moduleDelKeyIfEmpty(key)) return REDISMODULE_OK;
+        if (listTypeNext(key->iter, &key->u.list.entry)) {
+            listTypeIterator *li = key->iter;
+            key->u.list.index += li->direction == LIST_HEAD ? -1 : 0;
+        } else {
+            moduleFreeKeyIterator(key);
+        }
         return REDISMODULE_OK;
     } else {
         return REDISMODULE_ERR;

--- a/tests/modules/list.c
+++ b/tests/modules/list.c
@@ -123,11 +123,11 @@ int list_edit(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     RedisModuleString *v = RedisModule_ListGet(key, index);
     RedisModule_ReplyWithMap(ctx, v ? 5 : 4);
-    RedisModule_ReplyWithCString(ctx, "inserts");
+    RedisModule_ReplyWithCString(ctx, "i");
     RedisModule_ReplyWithLongLong(ctx, num_inserts);
-    RedisModule_ReplyWithCString(ctx, "deletes");
+    RedisModule_ReplyWithCString(ctx, "d");
     RedisModule_ReplyWithLongLong(ctx, num_deletes);
-    RedisModule_ReplyWithCString(ctx, "replaces");
+    RedisModule_ReplyWithCString(ctx, "r");
     RedisModule_ReplyWithLongLong(ctx, num_replaces);
     RedisModule_ReplyWithCString(ctx, "index");
     RedisModule_ReplyWithLongLong(ctx, index);

--- a/tests/modules/list.c
+++ b/tests/modules/list.c
@@ -120,7 +120,18 @@ int list_edit(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         }
     }
 
+    RedisModuleString *v = RedisModule_ListGet(key, index);
+    RedisModule_ReplyWithArray(ctx, v ? 6 : 4);
+    RedisModule_ReplyWithCString(ctx, "num_edits");
     RedisModule_ReplyWithLongLong(ctx, num_edits);
+    RedisModule_ReplyWithCString(ctx, "index");
+    RedisModule_ReplyWithLongLong(ctx, index);
+    if (v) {
+        RedisModule_ReplyWithCString(ctx, "entry");
+        RedisModule_ReplyWithString(ctx, v);
+        RedisModule_FreeString(ctx, v);
+    } 
+
     RedisModule_CloseKey(key);
     return REDISMODULE_OK;
 }

--- a/tests/modules/list.c
+++ b/tests/modules/list.c
@@ -50,7 +50,7 @@ int list_getall(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  * The number of occurrences of "i" and "r" in cmdstr) should correspond to the
  * number of args after cmdstr.
  *
- * Reply with a map, containing the number of edits (inserts, replaces, deletes)
+ * Reply with a RESP3 Map, containing the number of edits (inserts, replaces, deletes)
  * performed, as well as the last index and the entry it points to.
  */
 int list_edit(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -123,11 +123,11 @@ int list_edit(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     RedisModuleString *v = RedisModule_ListGet(key, index);
     RedisModule_ReplyWithMap(ctx, v ? 5 : 4);
-    RedisModule_ReplyWithCString(ctx, "num_inserts");
+    RedisModule_ReplyWithCString(ctx, "inserts");
     RedisModule_ReplyWithLongLong(ctx, num_inserts);
-    RedisModule_ReplyWithCString(ctx, "num_deletes");
+    RedisModule_ReplyWithCString(ctx, "deletes");
     RedisModule_ReplyWithLongLong(ctx, num_deletes);
-    RedisModule_ReplyWithCString(ctx, "num_replaces");
+    RedisModule_ReplyWithCString(ctx, "replaces");
     RedisModule_ReplyWithLongLong(ctx, num_replaces);
     RedisModule_ReplyWithCString(ctx, "index");
     RedisModule_ReplyWithLongLong(ctx, index);

--- a/tests/unit/moduleapi/list.tcl
+++ b/tests/unit/moduleapi/list.tcl
@@ -1,5 +1,15 @@
 set testmodule [file normalize tests/modules/list.so]
 
+proc verify_list_edit_reply {reply inserts deletes replaces index {entry ""}} {
+    assert_equal [dict get $reply "num_inserts"] $inserts
+    assert_equal [dict get $reply "num_deletes"] $deletes
+    assert_equal [dict get $reply "num_replaces"] $replaces
+    assert_equal [dict get $reply "index"] $index
+    if {$entry ne ""} {
+        assert_equal [dict get $reply "entry"] $entry
+    }
+}
+
 start_server {tags {"modules"}} {
     r module load $testmodule
 
@@ -70,49 +80,37 @@ start_server {tags {"modules"}} {
         # delete from start of list (index 0)
         r del l
         r rpush l x y z
-        set reply [r list.edit l dd]
-        assert_equal [lindex $reply 3] 0
-        assert_equal [lindex $reply 5] {z}
+        verify_list_edit_reply [r list.edit l dd] 0 2 0 0 z
         assert_equal [r list.getall l] {z}
 
         # delete from tail of list (index -3)
         r del l
         r rpush l x y z
-        set reply [r list.edit l reverse kkd]
-        assert_equal [lindex $reply 3] -3
-        assert_equal [lindex $reply 5] {}
+        verify_list_edit_reply [r list.edit l reverse kkd] 0 1 0 -3
         assert_equal [r list.getall l] {y z}
 
-        # delete from tail (index 2)
+        # # delete from tail (index 2)
         r del l
         r rpush l x y z
-        set reply [r list.edit l kkd]
-        assert_equal [lindex $reply 3] 2
-        assert_equal [lindex $reply 5] {}
+        verify_list_edit_reply [r list.edit l kkd] 0 1 0 2
         assert_equal [r list.getall l] {x y}
 
-        # delete from tail (index -1)
+        # # delete from tail (index -1)
         r del l
         r rpush l x y z
-        set reply [r list.edit l reverse dd]
-        assert_equal [lindex $reply 3] -1
-        assert_equal [lindex $reply 5] {x}
+        verify_list_edit_reply [r list.edit l reverse dd] 0 2 0 -1 x
         assert_equal [r list.getall l] {x}
 
-        # delete from middle (index 1)
+        # # delete from middle (index 1)
         r del l
         r rpush l x y z
-        set reply [r list.edit l kdd]
-        assert_equal [lindex $reply 3] 1
-        assert_equal [lindex $reply 5] {}
+        verify_list_edit_reply [r list.edit l kdd] 0 2 0 1
         assert_equal [r list.getall l] {x}
 
-        # delete from middle (index -2)
+        # # delete from middle (index -2)
         r del l
         r rpush l x y z
-        set reply [r list.edit l reverse kdd]
-        assert_equal [lindex $reply 3] -2
-        assert_equal [lindex $reply 5] {}
+        verify_list_edit_reply [r list.edit l reverse kdd] 0 2 0 -2
         assert_equal [r list.getall l] {z}
 
         config_set list-max-listpack-size $original_config

--- a/tests/unit/moduleapi/list.tcl
+++ b/tests/unit/moduleapi/list.tcl
@@ -64,6 +64,15 @@ start_server {tags {"modules"}} {
         r list.getall k
     } {bar y foo}
 
+    test {Module list - Crash due to reuse iterator entry after deletion} {
+        set original_config [config_get_set list-max-listpack-size 1]
+        r del k
+        r rpush k x y z
+        r list.edit k dd
+        assert_equal [r list.getall k] {z}
+        config_set list-max-listpack-size $original_config
+    }
+
     test "Unload the module - list" {
         assert_equal {OK} [r module unload list]
     }

--- a/tests/unit/moduleapi/list.tcl
+++ b/tests/unit/moduleapi/list.tcl
@@ -70,37 +70,49 @@ start_server {tags {"modules"}} {
         # delete from start of list (index 0)
         r del l
         r rpush l x y z
-        r list.edit l dd
+        set reply [r list.edit l dd]
+        assert_equal [lindex $reply 3] 0
+        assert_equal [lindex $reply 5] {z}
         assert_equal [r list.getall l] {z}
 
         # delete from tail of list (index -3)
         r del l
         r rpush l x y z
-        r list.edit l reverse kkdi foo
-        assert_equal [r list.getall l] {foo y z}
+        set reply [r list.edit l reverse kkd]
+        assert_equal [lindex $reply 3] -3
+        assert_equal [lindex $reply 5] {}
+        assert_equal [r list.getall l] {y z}
 
         # delete from tail (index 2)
         r del l
         r rpush l x y z
-        r list.edit l kkd
+        set reply [r list.edit l kkd]
+        assert_equal [lindex $reply 3] 2
+        assert_equal [lindex $reply 5] {}
         assert_equal [r list.getall l] {x y}
 
         # delete from tail (index -1)
         r del l
         r rpush l x y z
-        r list.edit l reverse dd
+        set reply [r list.edit l reverse dd]
+        assert_equal [lindex $reply 3] -1
+        assert_equal [lindex $reply 5] {x}
         assert_equal [r list.getall l] {x}
 
         # delete from middle (index 1)
         r del l
         r rpush l x y z
-        r list.edit l kdd
+        set reply [r list.edit l kdd]
+        assert_equal [lindex $reply 3] 1
+        assert_equal [lindex $reply 5] {}
         assert_equal [r list.getall l] {x}
 
         # delete from middle (index -2)
         r del l
         r rpush l x y z
-        r list.edit l reverse kdd
+        set reply [r list.edit l reverse kdd]
+        assert_equal [lindex $reply 3] -2
+        assert_equal [lindex $reply 5] {}
         assert_equal [r list.getall l] {z}
 
         config_set list-max-listpack-size $original_config

--- a/tests/unit/moduleapi/list.tcl
+++ b/tests/unit/moduleapi/list.tcl
@@ -1,11 +1,15 @@
 set testmodule [file normalize tests/modules/list.so]
 
+# The following arguments can be passed to args:
+#   i -- the number of inserts
+#   d -- the number of deletes
+#   r -- the number of replaces
+#   index -- the last index
+#   entry -- The entry pointed to by index
 proc verify_list_edit_reply {reply argv} {
-    if {[dict exists $argv "i"]} { assert_equal [dict get $reply "inserts"] [dict get $argv "i"]}
-    if {[dict exists $argv "d"]} { assert_equal [dict get $reply "deletes"] [dict get $argv "d"]}
-    if {[dict exists $argv "r"]} { assert_equal [dict get $reply "replaces"] [dict get $argv "r"]}
-    if {[dict exists $argv "index"]} { assert_equal [dict get $reply "index"] [dict get $argv "index"]}
-    if {[dict exists $argv "entry"]} { assert_equal [dict get $reply "entry"] [dict get $argv "entry"]}
+    foreach {k v} $argv {
+        assert_equal [dict get $reply $k] $v
+    }
 }
 
 start_server {tags {"modules"}} {

--- a/tests/unit/moduleapi/list.tcl
+++ b/tests/unit/moduleapi/list.tcl
@@ -64,12 +64,45 @@ start_server {tags {"modules"}} {
         r list.getall k
     } {bar y foo}
 
-    test {Module list - Crash due to reuse iterator entry after deletion} {
+    test {Module list - list entry and index should be updated when deletion} {
         set original_config [config_get_set list-max-listpack-size 1]
-        r del k
-        r rpush k x y z
-        r list.edit k dd
-        assert_equal [r list.getall k] {z}
+
+        # delete from start of list (index 0)
+        r del l
+        r rpush l x y z
+        r list.edit l dd
+        assert_equal [r list.getall l] {z}
+
+        # delete from tail of list (index -3)
+        r del l
+        r rpush l x y z
+        r list.edit l reverse kkdi foo
+        assert_equal [r list.getall l] {foo y z}
+
+        # delete from tail (index 2)
+        r del l
+        r rpush l x y z
+        r list.edit l kkd
+        assert_equal [r list.getall l] {x y}
+
+        # delete from tail (index -1)
+        r del l
+        r rpush l x y z
+        r list.edit l reverse dd
+        assert_equal [r list.getall l] {x}
+
+        # delete from middle (index 1)
+        r del l
+        r rpush l x y z
+        r list.edit l kdd
+        assert_equal [r list.getall l] {x}
+
+        # delete from middle (index -2)
+        r del l
+        r rpush l x y z
+        r list.edit l reverse kdd
+        assert_equal [r list.getall l] {z}
+
         config_set list-max-listpack-size $original_config
     }
 


### PR DESCRIPTION
In the module, we will reuse the list iterator entry for RM_ListDelete, but `listTypeDelete` will only update
`quicklistEntry->zi` but not `quicklistEntry->node`, which will result in `quicklistEntry->node` pointing to
a freed memory address if the quicklist node is deleted. 

This PR sync `key->u.list.index` and `key->u.list.entry` to list iterator after `RM_ListDelete`.

This PR also optimizes the release code of the original list iterator.
