### PR TITLE
add Certificate Revocation List（crl）

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -201,6 +201,10 @@ tcp-keepalive 300
 # tls-cert-file redis.crt
 # tls-key-file redis.key
 #
+# if crl needs to be added,it can be included here as well.
+#
+# tls-crl-file redis.crl
+#
 # If the key file is encrypted using a passphrase, it can be included here
 # as well.
 #

--- a/src/config.c
+++ b/src/config.c
@@ -3162,6 +3162,7 @@ standardConfig static_configs[] = {
     createStringConfig("tls-dh-params-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.dh_params_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-ca-cert-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ca_cert_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-ca-cert-dir", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ca_cert_dir, NULL, NULL, applyTlsCfg),
+    createStringConfig("tls-crl-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.crl_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-protocols", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.protocols, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-ciphers", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ciphers, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-ciphersuites", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.ciphersuites, NULL, NULL, applyTlsCfg),

--- a/src/server.h
+++ b/src/server.h
@@ -1387,6 +1387,7 @@ typedef struct redisTLSContextConfig {
     char *dh_params_file;
     char *ca_cert_file;
     char *ca_cert_dir;
+    char *crl_file;
     char *protocols;
     char *ciphers;
     char *ciphersuites;

--- a/src/tls.c
+++ b/src/tls.c
@@ -259,6 +259,11 @@ static SSL_CTX *createSSLContext(redisTLSContextConfig *ctx_config, int protocol
         goto error;
     }
 
+    if (ctx_config->crl_file != NULL && SSL_CTX_load_verify_locations(ctx, ctx_config->crl_file, 0)) {
+        X509_STORE *st = SSL_CTX_get_cert_store(ctx);
+        X509_STORE_set_flags(st, X509_V_FLAG_CRL_CHECK|X509_V_FLAG_CRL_CHECK_ALL);
+    }
+
     if (ctx_config->ciphers && !SSL_CTX_set_cipher_list(ctx, ctx_config->ciphers)) {
         serverLog(LL_WARNING, "Failed to configure ciphers: %s", ctx_config->ciphers);
         goto error;


### PR DESCRIPTION
redis can use tls, but there is no CRL interface. lack of ability to revoke certificates.

 