### PR TITLE
keyIsExpired checks server.loading before calling getExpire

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1612,13 +1612,13 @@ void propagateDeletion(redisDb *db, robj *key, int lazy) {
 
 /* Check if the key is expired. */
 int keyIsExpired(redisDb *db, robj *key) {
+    /* Don't expire anything while loading. It will be done later. */
+    if (server.loading) return 0;
+
     mstime_t when = getExpire(db,key);
     mstime_t now;
 
     if (when < 0) return 0; /* No expire for this key */
-
-    /* Don't expire anything while loading. It will be done later. */
-    if (server.loading) return 0;
 
     now = commandTimeSnapshot();
 


### PR DESCRIPTION
In function `keyIsExpired`,  it's designed to not expire any key while loading. But I'm confused why check if server is loading after `getExpire`, which seems not necessary to getExpire in advance.

so I adjust the sequence of it and pls let me know if there's anything missing. thanks!