### PR TITLE
Use jemalloc by default also on ARM

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1,6 +1,7 @@
 # Redis dependency Makefile
 
 uname_S:= $(shell sh -c 'uname -s 2>/dev/null || echo not')
+uname_M:= $(shell sh -c 'uname -m 2>/dev/null || echo not')
 
 LUA_DEBUG?=no
 
@@ -103,6 +104,19 @@ JEMALLOC_LDFLAGS= $(LDFLAGS)
 ifneq ($(DEB_HOST_GNU_TYPE),)
 JEMALLOC_CONFIGURE_OPTS += --host=$(DEB_HOST_GNU_TYPE)
 endif
+
+# ARM platforms share the same instruction set, but vary in page size.
+# In order to make the binary portable, we define a larger maximal page size
+# at build time, see https://github.com/jemalloc/jemalloc/issues/467
+ifneq (,$(filter aarch64 armv%,$(uname_M)))
+	PAGE_BITS=$(shell getconf PAGESIZE | awk '{print log($$1)/log(2)}')
+	# Set page size to at least 64k (or larger if that's what used on build machine)
+	ifeq ($(shell test $(PAGE_BITS) -lt 16; echo $$?),0)
+		PAGE_BITS := 16
+	endif
+	JEMALLOC_CONFIGURE_OPTS += --with-lg-page=$(PAGE_BITS)
+endif
+
 
 jemalloc: .make-prerequisites
 	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1,7 +1,6 @@
 # Redis dependency Makefile
 
 uname_S:= $(shell sh -c 'uname -s 2>/dev/null || echo not')
-uname_M:= $(shell sh -c 'uname -m 2>/dev/null || echo not')
 
 LUA_DEBUG?=no
 
@@ -104,19 +103,6 @@ JEMALLOC_LDFLAGS= $(LDFLAGS)
 ifneq ($(DEB_HOST_GNU_TYPE),)
 JEMALLOC_CONFIGURE_OPTS += --host=$(DEB_HOST_GNU_TYPE)
 endif
-
-# ARM platforms share the same instruction set, but vary in page size.
-# In order to make the binary portable, we define a larger maximal page size
-# at build time, see https://github.com/jemalloc/jemalloc/issues/467
-ifneq (,$(filter aarch64 armv%,$(uname_M)))
-	PAGE_BITS=$(shell getconf PAGESIZE | awk '{print log($$1)/log(2)}')
-	# Set page size to at least 64k (or larger if that's what used on build machine)
-	ifeq ($(shell test $(PAGE_BITS) -lt 16; echo $$?),0)
-		PAGE_BITS := 16
-	endif
-	JEMALLOC_CONFIGURE_OPTS += --with-lg-page=$(PAGE_BITS)
-endif
-
 
 jemalloc: .make-prerequisites
 	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -59,23 +59,15 @@ ifndef PYTHON
 PYTHON := $(shell which python3 || which python)
 endif
 
-# Default allocator defaults to Jemalloc if it's not an ARM
+# Default allocator defaults to Jemalloc on Linux and libc otherwise
 MALLOC=libc
-ifneq ($(uname_M),armv6l)
-ifneq ($(uname_M),armv7l)
 ifeq ($(uname_S),Linux)
 	MALLOC=jemalloc
 endif
-endif
-endif
 
 # To get ARM stack traces if Redis crashes we need a special C flag.
-ifneq (,$(filter aarch64 armv,$(uname_M)))
+ifneq (,$(filter aarch64 armv%,$(uname_M)))
         CFLAGS+=-funwind-tables
-else
-ifneq (,$(findstring armv,$(uname_M)))
-        CFLAGS+=-funwind-tables
-endif
 endif
 
 # Backwards compatibility for selecting an allocator


### PR DESCRIPTION
Till now Redis attempted to avoid using jemalloc on ARM, but didn't do that properly (missing armv8l and aarch64), so in fact we did you jemalloc on these without a problem.

Side notes:

Some ARM platforms, which share instruction set and can share binaries (docker images), may have different page size, and apparently jemalloc uses the page size of the build machine as the maximum page size to be supported by the build.
see https://github.com/redis-stack/redis-stack/issues/187

To work around that, when building for ARM, one can change the maximum page size to 64k (or greater if present on the build machine) In recent versions of jemalloc, this should not have any severe side effects (like VM map fragmentation), see:
https://github.com/jemalloc/jemalloc/issues/467
https://github.com/redis/redis/pull/11170#issuecomment-1236265230

To do that, one can use:
```
JEMALLOC_CONFIGURE_OPTS="--with-lg-page=16" make
```

Besides that, this PR fixes a messy makefile condition that was created
here: f30b18f4de