### PR TITLE
Set errno in case XADD with partial ID fails

### DIFF
--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -883,7 +883,7 @@ start_server {tags {"stream"}} {
         assert_equal [dict get $reply max-deleted-entry-id] "2-0"
     }
 
-    test {=XADD with artial ID with maximal seq} {
+    test {XADD with artial ID with maximal seq} {
         r DEL x
         r XADD x 1-18446744073709551615 f1 v1
         assert_error {*The ID specified in XADD is equal or smaller*} {r XADD x 1-* f2 v2}

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -882,6 +882,12 @@ start_server {tags {"stream"}} {
         set reply [r XINFO STREAM x FULL]
         assert_equal [dict get $reply max-deleted-entry-id] "2-0"
     }
+
+    test {=XADD with artial ID with maximal seq} {
+        r DEL x
+        r XADD x 1-18446744073709551615 f1 v1
+        assert_error {*The ID specified in XADD is equal or smaller*} {r XADD x 1-* f2 v2}
+    }
 }
 
 start_server {tags {"stream needs:debug"} overrides {appendonly yes aof-use-rdb-preamble no}} {


### PR DESCRIPTION
This is a rare failure mode of a new feature of redis 7 introduced in #9217 (when the incremental part of the ID overflows).
till now, the outcome of that error was undetermined (could easily result in `Elements are too large to be stored` wrongly, due to unset `errno`).
