### PR TITLE
RM_Call - only enforce OOM on scripts if 'M' flag is sent

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -5654,6 +5654,8 @@ void RM_SetContextUser(RedisModuleCtx *ctx, const RedisModuleUser *user) {
  *     "3" -> REDISMODULE_ARGV_RESP_3
  *     "0" -> REDISMODULE_ARGV_RESP_AUTO
  *     "C" -> REDISMODULE_ARGV_RUN_AS_USER
+ *     "C" -> REDISMODULE_ARGV_CHECK_ACL
+ *     "O" -> REDISMODULE_ARGV_ALLOW_OOM_IN_SCRIPTS
  *
  * On error (format specifier error) NULL is returned and nothing is
  * allocated. On success the argument vector is returned. */
@@ -5934,6 +5936,9 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
                 goto cleanup;
             }
         }
+    } else {
+        /* if we aren't OOM checking in RM_Call, we want further executions from this client to also not fail on OOM */
+        c->flags |= CLIENT_ALLOW_OOM;
     }
 
     if (flags & REDISMODULE_ARGV_NO_WRITES) {

--- a/src/module.c
+++ b/src/module.c
@@ -5654,8 +5654,7 @@ void RM_SetContextUser(RedisModuleCtx *ctx, const RedisModuleUser *user) {
  *     "3" -> REDISMODULE_ARGV_RESP_3
  *     "0" -> REDISMODULE_ARGV_RESP_AUTO
  *     "C" -> REDISMODULE_ARGV_RUN_AS_USER
- *     "C" -> REDISMODULE_ARGV_CHECK_ACL
- *     "O" -> REDISMODULE_ARGV_ALLOW_OOM_IN_SCRIPTS
+ *     "M" -> REDISMODULE_ARGV_RESPECT_DENY_OOM
  *
  * On error (format specifier error) NULL is returned and nothing is
  * allocated. On success the argument vector is returned. */

--- a/src/server.h
+++ b/src/server.h
@@ -369,6 +369,8 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
                                           RDB without replication buffer. */
 #define CLIENT_NO_EVICT (1ULL<<43) /* This client is protected against client
                                       memory eviction. */
+#define CLIENT_ALLOW_OOM (1ULL<<44) /* Client used by RM_Call is allowed to fully execute
+                                       scripts even when in OOM */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -263,7 +263,7 @@ start_server {tags {"modules"}} {
             return 2
         } 1 x
 
-        # script wiht no-writes flag, implies allow-oom, succeeds
+        # script with no-writes flag, implies allow-oom, succeeds
         r test.rm_call_flags M eval {#!lua flags=no-writes
             redis.call('get','x')
             return 2


### PR DESCRIPTION
RM_Call is designed to let modules call redis commands disregarding the OOM state (the module is responsible to declare its command flags to redis, or perform the necessary checks).
The other (new) alternative is to pass the "M" flag to RM_Call so that redis can OOM reject commands implicitly.

However, Currently, RM_Call enforces OOM on scripts (excluding scripts that declared `allow-oom`) in all cases, regardless of the RM_Call "M" flag being present.

This PR fixes scripts to be consistent with other commands being executed by RM_Call.
It modifies the flow in effect treats scripts as if they if they have the ALLOW_OOM script flag, if the "M" flag is not passed (i.e. no OOM checking is being performed by RM_Call, so no OOM checking should be done on script).

This replaced https://github.com/redis/redis/pull/11161 instead of requiring a new flag, it redefines how RM_call treats the M flag (or the lack of M flag).