### PR TITLE
Improve cluster slot bit set/clear logic.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4033,7 +4033,7 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t handshake_
         link->conn = connCreate(connTypeOfCluster());
         connSetPrivateData(link->conn, link);
         if (connConnect(link->conn, node->ip, node->cport, server.bind_source_addr,
-                    clusterLinkConnectHandler) == -1) {
+                    clusterLinkConnectHandler) == C_ERR) {
             /* We got a synchronous error from connect before
              * clusterSendPing() had a chance to be called.
              * If node->ping_sent is zero, failure detection can't work,
@@ -4363,8 +4363,8 @@ int clusterMastersHaveSlaves(void) {
 /* Set the slot bit and return the old value. */
 int clusterNodeSetSlotBit(clusterNode *n, int slot) {
     int old = bitmapTestBit(n->slots,slot);
-    bitmapSetBit(n->slots,slot);
     if (!old) {
+        bitmapSetBit(n->slots,slot);
         n->numslots++;
         /* When a master gets its first slot, even if it has no slaves,
          * it gets flagged with MIGRATE_TO, that is, the master is a valid
@@ -4388,8 +4388,10 @@ int clusterNodeSetSlotBit(clusterNode *n, int slot) {
 /* Clear the slot bit and return the old value. */
 int clusterNodeClearSlotBit(clusterNode *n, int slot) {
     int old = bitmapTestBit(n->slots,slot);
-    bitmapClearBit(n->slots,slot);
-    if (old) n->numslots--;
+    if (old) {
+        bitmapClearBit(n->slots,slot);
+        n->numslots--;
+    }
     return old;
 }
 


### PR DESCRIPTION
Two minor fix for redis cluster:
1. `clusterNodeClearSlotBit()/clusterNodeSetSlotBit()`, only set bit when slot does not exist and clear bit when slot does exist.
 2. ~~`clusterNodeCronHandleReconnect()`, when try to connect a new node and create new link, add link memory usage~~. 