### PR TITLE
Print IP and port on cluster bus message sanity check

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1793,7 +1793,7 @@ int nodeIp2String(char *buf, clusterLink *link, char *announced_ip) {
         buf[NET_IP_STR_LEN-1] = '\0'; /* We are not sure the input is sane. */
         return C_OK;
     } else {
-        if (connAddrPeerName(link->conn, buf, NET_IP_STR_LEN, NULL) == C_ERR) {
+        if (connAddrPeerName(link->conn, buf, NET_IP_STR_LEN, NULL) == -1) {
             serverLog(LL_NOTICE, "Error converting peer IP to string: %s",
                 link->conn ? connGetLastError(link->conn) : "no link");
             return C_ERR;
@@ -2773,9 +2773,17 @@ void clusterReadHandler(connection *conn) {
                 if (memcmp(hdr->sig,"RCmb",4) != 0 ||
                     ntohl(hdr->totlen) < CLUSTERMSG_MIN_LEN)
                 {
-                    serverLog(LL_WARNING,
-                        "Bad message length or signature received "
-                        "from Cluster bus.");
+                    char ip[NET_IP_STR_LEN];
+                    int port;
+                    if (connAddrPeerName(conn, ip, sizeof(ip), &port) == -1) {
+                        serverLog(LL_WARNING,
+                            "Bad message length or signature received "
+                            "from Cluster bus.");
+                    } else {
+                        serverLog(LL_WARNING,
+                            "Bad message length or signature received "
+                            "from Cluster bus, received from %s:%d", ip, port);
+                    }
                     handleLinkIOError(link);
                     return;
                 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2778,11 +2778,11 @@ void clusterReadHandler(connection *conn) {
                     if (connAddrPeerName(conn, ip, sizeof(ip), &port) == -1) {
                         serverLog(LL_WARNING,
                             "Bad message length or signature received "
-                            "from Cluster bus.");
+                            "on the Cluster bus.");
                     } else {
                         serverLog(LL_WARNING,
                             "Bad message length or signature received "
-                            "from Cluster bus, received from %s:%d", ip, port);
+                            "on the Cluster bus from %s:%d", ip, port);
                     }
                     handleLinkIOError(link);
                     return;


### PR DESCRIPTION
Add a print statement to indicate which IP/port is sending
the error messages. That way we can at least check to see
if it is a node in the cluster or some other nefarious nodes.

It is proposed in #11339.

Unrelated changes: the return check for connAddrPeerName should
be -1 instead of C_ERR, although the value of C_ERR is also -1.