### PR TITLE
Fix command BITFIELD_RO and BITFIELD argument json file, add some test cases for them

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -124,7 +124,7 @@ struct redisCommandArg BITFIELD_RO_get_block_Subargs[] = {
 /* BITFIELD_RO argument table */
 struct redisCommandArg BITFIELD_RO_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"get-block",ARG_TYPE_BLOCK,-1,"GET",NULL,NULL,CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.subargs=BITFIELD_RO_get_block_Subargs},
+{"get-block",ARG_TYPE_BLOCK,-1,"GET",NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE|CMD_ARG_MULTIPLE_TOKEN,.subargs=BITFIELD_RO_get_block_Subargs},
 {0}
 };
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -102,7 +102,7 @@ struct redisCommandArg BITFIELD_operation_Subargs[] = {
 /* BITFIELD argument table */
 struct redisCommandArg BITFIELD_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
-{"operation",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=BITFIELD_operation_Subargs},
+{"operation",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,.subargs=BITFIELD_operation_Subargs},
 {0}
 };
 

--- a/src/commands/bitfield.json
+++ b/src/commands/bitfield.json
@@ -47,6 +47,7 @@
                 "name": "operation",
                 "type": "oneof",
                 "multiple": true,
+                "optional": true,
                 "arguments": [
                     {
                         "token": "GET",

--- a/src/commands/bitfield_ro.json
+++ b/src/commands/bitfield_ro.json
@@ -43,6 +43,7 @@
                 "token": "GET",
                 "name": "get-block",
                 "type": "block",
+                "optional": true,
                 "multiple": true,
                 "multiple_token": true,
                 "arguments": [

--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -17,6 +17,22 @@ start_server {tags {"bitops"}} {
         set results
     } {0 255 100}
 
+    test {BITFIELD signed SET and GET together} {
+        r del bits
+        set results [r bitfield bits set i8 0 255 set i8 0 100 get i8 0]
+    } {0 -1 100}
+ 
+    test {BITFIELD unsigned with SET, GET and INCRBY arguments} {
+        r del bits
+        set results [r bitfield bits set u8 0 255 incrby u8 0 100 get u8 0]
+    } {0 99 99}
+
+    test {BITFIELD with only key as argument} {
+        r del bits
+        set result [r bitfield bits]
+        assert {$result eq {}}
+    }
+
     test {BITFIELD #<idx> form} {
         r del bits
         set results {}
@@ -222,6 +238,11 @@ start_server {tags {"repl external:skip"}} {
             assert_equal 255 [$master bitfield bits set u8 0 100]
             wait_for_ofs_sync $master $slave
             assert_equal 100 [$slave bitfield_ro bits get u8 0]
+        }
+
+        test {BITFIELD_RO with only key as argument} {
+            set res [$slave bitfield_ro bits]
+            assert {$res eq {}}
         }
 
         test {BITFIELD_RO fails when write option is used} {


### PR DESCRIPTION
It is similar to the pr https://github.com/redis/redis/pull/11417,

According to the source code, the commands can be executed with only key name,
and no GET/SET/INCR operation arguments.
change the docs to reflect that by marking these arguments as optional.
also add tests.