### PR TITLE
Client connections created for TLS-based replication use SNI if possible

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -44,6 +44,7 @@
 #include <openssl/decoder.h>
 #endif
 #include <sys/uio.h>
+#include <arpa/inet.h>
 
 #define REDIS_TLS_PROTO_TLSv1       (1<<0)
 #define REDIS_TLS_PROTO_TLSv1_1     (1<<1)
@@ -802,9 +803,15 @@ static int connTLSAccept(connection *_conn, ConnectionCallbackFunc accept_handle
 
 static int connTLSConnect(connection *conn_, const char *addr, int port, const char *src_addr, ConnectionCallbackFunc connect_handler) {
     tls_connection *conn = (tls_connection *) conn_;
+    unsigned char addr_buf[sizeof(struct in6_addr)];
 
     if (conn->c.state != CONN_STATE_NONE) return C_ERR;
     ERR_clear_error();
+
+    /* Check whether addr is an IP address, if not, use the value for Server Name Indication */
+    if (inet_pton(AF_INET, addr, addr_buf) != 1 && inet_pton(AF_INET6, addr, addr_buf) != 1) {
+        SSL_set_tlsext_host_name(conn->ssl, addr);
+    }
 
     /* Initiate Socket connection first */
     if (connectionTypeTcp()->connect(conn_, addr, port, src_addr, connect_handler) == C_ERR) return C_ERR;


### PR DESCRIPTION
It is not possible to reliably select the target server instance for TLS replication in case that the target sits behind a TLS (terminating or pass-through) proxy, as there's no SNI extension in the ClientHello message sent via the connection created for the sake of replication.

This is a simple attempt at setting the SNI to the value of the master server's address, in case that address is not actually an IP