### PR TITLE
Bump vmactions/freebsd-vm to 0.3.0 to fix FreeBSD daily

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -690,7 +690,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: test
-      uses: vmactions/freebsd-vm@v0.2.4
+      uses: vmactions/freebsd-vm@v0.3.0
       with:
         usesh: true
         sync: rsync
@@ -718,7 +718,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: test
-      uses: vmactions/freebsd-vm@v0.2.4
+      uses: vmactions/freebsd-vm@v0.3.0
       with:
         usesh: true
         sync: rsync
@@ -745,7 +745,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: test
-      uses: vmactions/freebsd-vm@v0.2.4
+      uses: vmactions/freebsd-vm@v0.3.0
       with:
         usesh: true
         sync: rsync


### PR DESCRIPTION
Our FreeBSD daily has been failing recently:
```
  Config file: freebsd-13.1.conf
  cd: /Users/runner/work/redis/redis: No such file or directory
  gmake: *** No targets specified and no makefile found.  Stop.
```

Upgrade vmactions/freebsd-vm to the latest version (0.3.0) can work.
I've tested it, but don't know why, but first let's fix it.