### PR TITLE
Added fields to ACL LOG error entries for precise time logging

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -4103,7 +4103,10 @@ struct redisCommandArg ACL_GETUSER_Args[] = {
 /********** ACL LOG ********************/
 
 /* ACL LOG history */
-#define ACL_LOG_History NULL
+commandHistory ACL_LOG_History[] = {
+{"7.2.0","Added entry ID, timestamp created, and timestamp last updated."},
+{0}
+};
 
 /* ACL LOG tips */
 #define ACL_LOG_tips NULL

--- a/src/commands/acl-log.json
+++ b/src/commands/acl-log.json
@@ -7,6 +7,12 @@
         "arity": -2,
         "container": "ACL",
         "function": "aclCommand",
+        "history": [
+            [
+                "7.2.0",
+                "Added entry ID, timestamp created, and timestamp last updated."
+            ]
+        ],
         "command_flags": [
             "ADMIN",
             "NOSCRIPT",


### PR DESCRIPTION
Added 3 fields to the ACL LOG - adds entry_id, timestamp_created and timestamp_last_updated, which updates similar existing log error entries. The pair - entry_id, timestamp_created is a unique identifier of this entry, in case the node dies and is restarted, it can detect that if it's a new series.

The primary use case of Unique id is to uniquely identify the error messages and not to detect if the server has restarted.

1. entry-id is the sequence number of the entry (starting at 0) since the server process started. Can also be used to check if items were "lost" if they fell between periods.
2. timestamp-created is the unix-time in ms at the time the entry was first created.
3. timestamp-last-updated is the unix-time in ms at the time the entry was last updated

Time_created gives the absolute time which better accounts for network time as compared to time since. It can also be older than 60 secs and presently there is no field that can display the original time of creation once the error entry is updated.
The reason of timestamp_last_updated field is that it provides a more precise value for the “last time” an error was seen where as, presently it is only in the 60 second period.

Changes in acl.c: adds entry_id, timestamp_created and timestamp_last_updated to ACL LOG.

Changes in acl.tcl: adds test that verify that all of the additional fields are available in the reply when the ACL LOG commands and verifies that timestamp_created does not change when log entry is updated and that timestamp-last-updated is updated when entry is updated. Also checks if a new unique id is assigned to a new task.

```
Release notes
Add entry id, timestamp created, and timestamp last updated time to ACL log entries.
```