### PR TITLE
Remove redundant calls to update refcount of shared integers

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -158,7 +158,6 @@ robj *createStringObjectFromLongLongWithOptions(long long value, int valueobj) {
     }
 
     if (value >= 0 && value < OBJ_SHARED_INTEGERS && valueobj == 0) {
-        incrRefCount(shared.integers[value]);
         o = shared.integers[value];
     } else {
         if (value >= LONG_MIN && value <= LONG_MAX) {
@@ -636,7 +635,6 @@ robj *tryObjectEncoding(robj *o) {
             value < OBJ_SHARED_INTEGERS)
         {
             decrRefCount(o);
-            incrRefCount(shared.integers[value]);
             return shared.integers[value];
         } else {
             if (o->encoding == OBJ_ENCODING_RAW) {


### PR DESCRIPTION
AFAIK, these are never mutated anyways.

```
hbina@akarin ~/g/redis (unstable)> rg "shared.integers\[" --after-context 5
src/server.c
1846:        shared.integers[j] =
1847-            makeObjectShared(createObject(OBJ_STRING,(void*)(long)j));
1848:        shared.integers[j]->encoding = OBJ_ENCODING_INT;
1849-    }
1850-    for (j = 0; j < OBJ_SHARED_BULKHDR_LEN; j++) {
1851-        shared.mbulkhdr[j] = createObject(OBJ_STRING,
1852-            sdscatprintf(sdsempty(),"*%d\r\n",j));
1853-        shared.bulkhdr[j] = createObject(OBJ_STRING,

src/t_stream.c
1563:    argv[4] = shared.integers[0];
1564-    argv[5] = id;
1565-    argv[6] = shared.time;
1566-    argv[7] = createStringObjectFromLongLong(nack->delivery_time);
1567-    argv[8] = shared.retrycount;
1568-    argv[9] = createStringObjectFromLongLong(nack->delivery_count);

src/object.c
161:        incrRefCount(shared.integers[value]);
162:        o = shared.integers[value];
163-    } else {
164-        if (value >= LONG_MIN && value <= LONG_MAX) {
165-            o = createObject(OBJ_STRING, NULL);
166-            o->encoding = OBJ_ENCODING_INT;
167-            o->ptr = (void*)((long)value);
--
639:            incrRefCount(shared.integers[value]);
640:            return shared.integers[value];
641-        } else {
642-            if (o->encoding == OBJ_ENCODING_RAW) {
643-                sdsfree(o->ptr);
644-                o->encoding = OBJ_ENCODING_INT;
645-                o->ptr = (void*) value;

src/redis-check-rdb.c
432:    if (shared.integers[0] == NULL)
433-        createSharedObjects();
434-    server.loading_process_events_interval_bytes = 0;
435-    server.sanitize_dump_payload = SANITIZE_DUMP_YES;
436-    rdbCheckMode = 1;
437-    rdbCheckInfo("Checking RDB file %s", argv[1]);
```

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>