### PR TITLE
Remove redundant checks on mutually exclusive flags

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -221,15 +221,14 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
                    (command_type == COMMAND_SET))
         {
             *flags |= OBJ_SET_GET;
-        } else if (!strcasecmp(opt, "KEEPTTL") && !(*flags & OBJ_PERSIST) &&
+        } else if (!strcasecmp(opt, "KEEPTTL") && (command_type == COMMAND_SET) &&
             !(*flags & OBJ_EX) && !(*flags & OBJ_EXAT) &&
-            !(*flags & OBJ_PX) && !(*flags & OBJ_PXAT) && (command_type == COMMAND_SET))
+            !(*flags & OBJ_PX) && !(*flags & OBJ_PXAT))
         {
             *flags |= OBJ_KEEPTTL;
         } else if (!strcasecmp(opt,"PERSIST") && (command_type == COMMAND_GET) &&
                !(*flags & OBJ_EX) && !(*flags & OBJ_EXAT) &&
-               !(*flags & OBJ_PX) && !(*flags & OBJ_PXAT) &&
-               !(*flags & OBJ_KEEPTTL))
+               !(*flags & OBJ_PX) && !(*flags & OBJ_PXAT))
         {
             *flags |= OBJ_PERSIST;
         } else if ((opt[0] == 'e' || opt[0] == 'E') &&


### PR DESCRIPTION
KEEPTTL and PERSIST flags only exists in SET and GET respectively. There's no need to check for that flag because we already checked for the command_type. I also took the liberty of reordering the checks a bit to make it more clear that they are mutually exclusive.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>