### PR TITLE
Add test to cover NAN reply using a module

### DIFF
--- a/tests/modules/reply.c
+++ b/tests/modules/reply.c
@@ -3,6 +3,7 @@
  */
 
 #include "redismodule.h"
+#include <math.h>
 
 int rw_string(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 2) return RedisModule_WrongArity(ctx);
@@ -30,6 +31,9 @@ int rw_int(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 /* When one argument is given, it is returned as a double,
  * when two arguments are given, it returns a/b. */
 int rw_double(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc==1)
+        return RedisModule_ReplyWithDouble(ctx, NAN);
+
     if (argc != 2 && argc != 3) return RedisModule_WrongArity(ctx);
 
     double dbl, dbl2;

--- a/tests/modules/reply.c
+++ b/tests/modules/reply.c
@@ -27,12 +27,19 @@ int rw_int(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithLongLong(ctx, integer);
 }
 
+/* When one argument is given, it is returned as a double,
+ * when two arguments are given, it returns a/b. */
 int rw_double(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    if (argc != 2) return RedisModule_WrongArity(ctx);
+    if (argc != 2 && argc != 3) return RedisModule_WrongArity(ctx);
 
-    double dbl;
+    double dbl, dbl2;
     if (RedisModule_StringToDouble(argv[1], &dbl) != REDISMODULE_OK)
         return RedisModule_ReplyWithError(ctx, "Arg cannot be parsed as a double");
+    if (argc == 3) {
+        if (RedisModule_StringToDouble(argv[2], &dbl2) != REDISMODULE_OK)
+            return RedisModule_ReplyWithError(ctx, "Arg cannot be parsed as a double");
+        dbl /= dbl2;
+    }
 
     return RedisModule_ReplyWithDouble(ctx, dbl);
 }

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -41,10 +41,12 @@ start_server {tags {"modules"}} {
         test "RESP$proto: RM_ReplyWithDouble: NaN" {
             if {$proto == 2} {
                 assert_equal "-nan" [r rw.double 0 0]
+                assert_equal "nan" [r rw.double]
             } else {
                 # TCL won't convert nan into a double, use readraw to verify the protocol
                 r readraw 1
                 assert_equal ",-nan" [r rw.double 0 0]
+                assert_equal ",nan" [r rw.double]
                 r readraw 0
             }
         }

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -28,6 +28,27 @@ start_server {tags {"modules"}} {
             assert_equal 3.141 [r rw.double 3.141]
         }
 
+        test "RESP$proto: RM_ReplyWithDouble: inf" {
+            if {$proto == 2} {
+                assert_equal "inf" [r rw.double inf]
+                assert_equal "-inf" [r rw.double -inf]
+            } else {
+                assert_equal Inf [r rw.double inf]
+                assert_equal -Inf [r rw.double -inf]
+            }
+        }
+
+        test "RESP$proto: RM_ReplyWithDouble: NaN" {
+            if {$proto == 2} {
+                assert_equal "-nan" [r rw.double 0 0]
+            } else {
+                # TCL won't convert nan into a double, use readraw to verify the protocol
+                r readraw 1
+                assert_equal ",-nan" [r rw.double 0 0]
+                r readraw 0
+            }
+        }
+
         set ld 0.00000000000000001
         test "RESP$proto: RM_ReplyWithLongDouble: a float reply" {
             if {$proto == 2} {


### PR DESCRIPTION
Adding a test to cover the already existing behavior of NAN replies, to accompany the PR that adds them to the RESP3 spec: https://github.com/redis/redis-specifications/pull/10

This PR also covers Inf replies that are already in the spec, as well as RESP2 coverage.