### PR TITLE
Prevent SETEX command vector re-write with an integer robj

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -185,6 +185,14 @@ robj *createStringObjectFromLongLongForValue(long long value) {
     return createStringObjectFromLongLongWithOptions(value,1);
 }
 
+/* Always creates a string object from a long long, unlike createStringObjectFromLongLong() which
+ * may return an integer object. */
+robj *createStringObjectFromLongLongAlwaysString(long long value) {
+    char buf[LONG_STR_SIZE];
+    size_t len = ll2string(buf,sizeof(buf),value);
+    return createStringObject(buf, len);
+}
+
 /* Create a string object from a long double. If humanfriendly is non-zero
  * it does not use exponential format and trims trailing zeroes at the end,
  * however this results in loss of precision. Otherwise exp format is used

--- a/src/server.h
+++ b/src/server.h
@@ -2654,6 +2654,7 @@ robj *getDecodedObject(robj *o);
 size_t stringObjectLen(robj *o);
 robj *createStringObjectFromLongLong(long long value);
 robj *createStringObjectFromLongLongForValue(long long value);
+robj *createStringObjectFromLongLongAlwaysString(long long value);
 robj *createStringObjectFromLongDouble(long double value, int humanfriendly);
 robj *createQuicklistObject(void);
 robj *createSetObject(void);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -111,7 +111,7 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
         setExpire(c,c->db,key,milliseconds);
         /* Propagate as SET Key Value PXAT millisecond-timestamp if there is
          * EX/PX/EXAT/PXAT flag. */
-        robj *milliseconds_obj = createStringObjectFromLongLong(milliseconds);
+        robj *milliseconds_obj = createStringObjectFromLongLongAlwaysString(milliseconds);
         rewriteClientCommandVector(c, 5, shared.set, key, val, shared.pxat, milliseconds_obj);
         decrRefCount(milliseconds_obj);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);


### PR DESCRIPTION
For `SETEX` commands and `SET` commands that specify and expiration time (e.g. `SET key val EX 60`), when the command vector is re-written for propagation in `setGenericCommand()`, the expiration time will usually be represented as an integer-type robj instead of a string-type robj.

There are two reasons to avoid an integer robj in the command vector:
1. It breaks the assumption that command vectors will always consist of string objects. For example, if `setGetKeys()` is called in command post-processing to get the number of keys in a `SETEX` command, it will segfault.
2. It is unnecessary from a performance perspective. Before the command is fed to the replication buffer, the expiration time will need to be converted back to a string anyways.