### PR TITLE
redis_memzero introduction proposal and using in sha1/sha256.

### DIFF
--- a/src/sha1.c
+++ b/src/sha1.c
@@ -26,6 +26,7 @@ A million repetitions of "a"
 #include <stdint.h>
 #include "solarisfixes.h"
 #include "sha1.h"
+#include "util.h"
 #include "config.h"
 
 #define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))
@@ -192,7 +193,7 @@ void SHA1Final(unsigned char digest[20], SHA1_CTX* context)
          ((context->state[i>>2] >> ((3-(i & 3)) * 8) ) & 255);
     }
     /* Wipe variables */
-    memset(context, '\0', sizeof(*context));
+    redis_memzero(context, sizeof(*context));
     memset(&finalcount, '\0', sizeof(finalcount));
 }
 /* ================ end of sha1.c ================ */

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "sha256.h"
+#include "util.h"
 
 /****************************** MACROS ******************************/
 #define ROTLEFT(a,b) (((a) << (b)) | ((a) >> (32-(b))))
@@ -133,7 +134,7 @@ void sha256_final(SHA256_CTX *ctx, BYTE hash[])
 		while (i < 64)
 			ctx->data[i++] = 0x00;
 		sha256_transform(ctx, ctx->data);
-		memset(ctx->data, 0, 56);
+		redis_memzero(ctx->data, 56);
 	}
 
 	// Append to the padding the total message's length in bits and transform.

--- a/src/util.h
+++ b/src/util.h
@@ -89,6 +89,7 @@ int fsyncFileDir(const char *filename);
 
 size_t redis_strlcpy(char *dst, const char *src, size_t dsize);
 size_t redis_strlcat(char *dst, const char *src, size_t dsize);
+void redis_memzero(void *src, size_t ssize);
 
 #ifdef REDIS_TEST
 int utilTest(int argc, char **argv, int flags);


### PR DESCRIPTION
With the LTO and possible compiler optimizations, memset calls might not be generated
so proposal here is to introduce a new utility which circumvent those optimizations
like explicit_bzero but using a platform agnostic solution instead.
it is to be used only where memory data access is a concern since performance decrease
is to be expected.

Specifically, calling it in Sha1 and Sha256's "final" stage, which are there to wipe the remains
of the input (unwashed password).