### PR TITLE
fixes for fork child exit and test: #11463

### DIFF
--- a/src/childinfo.c
+++ b/src/childinfo.c
@@ -114,7 +114,7 @@ void sendChildInfoGeneric(childInfoType info_type, size_t keys, double progress,
     if (write(server.child_info_pipe[1], &data, wlen) != wlen) {
         /* Failed writing to parent, it could have been killed, exit. */
         serverLog(LL_WARNING,"Child failed reporting info to parent, exiting. %s", strerror(errno));
-        exit(1);
+        exitFromChild(1);
     }
 }
 

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1013,7 +1013,7 @@ test "diskless replication child being killed is collected" {
 } {} {external:skip}
 
 foreach mdl {yes no} {
-    test "replication dies when parent is killed - diskless: $mdl" {
+    test "replication child dies when parent is killed - diskless: $mdl" {
         # when master is killed, make sure the fork child can detect that and exit
         start_server {tags {"repl"}} {
             set master [srv 0 client]

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -631,6 +631,7 @@ proc process_is_alive pid {
     if {[catch {exec ps -p $pid} err]} {
         return 0
     } else {
+        if {[string match "*<defunct>*" $err]} { return 0 }
         return 1
     }
 }


### PR DESCRIPTION
Fix a few issues with the recent #11463
* use exitFromChild instead of exit
* test should ignore defunct process since that's what we expect to happen for thees child processes when the parent dies.
* fix typo