### PR TITLE
Module CLIENT_CHANGE, Fix crash on free blocked client with DB!=0

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -8094,7 +8094,6 @@ void moduleCallClusterReceivers(const char *sender_id, uint64_t module_id, uint8
         if (r->module_id == module_id) {
             RedisModuleCtx ctx;
             moduleCreateContext(&ctx, r->module, REDISMODULE_CTX_TEMP_CLIENT);
-            selectDb(ctx.client, 0);
             r->callback(&ctx,sender_id,type,payload,len);
             moduleFreeContext(&ctx);
             return;
@@ -10907,11 +10906,6 @@ void moduleFireServerEvent(uint64_t eid, int subid, void *data) {
             RedisModuleClientInfoV1 civ1;
             RedisModuleReplicationInfoV1 riv1;
             RedisModuleModuleChangeV1 mcv1;
-            /* Start at DB zero by default when calling the handler. It's
-             * up to the specific event setup to change it when it makes
-             * sense. For instance for FLUSHDB events we select the correct
-             * DB automatically. */
-            selectDb(ctx.client, 0);
 
             /* Event specific context and data pointer setup. */
             if (eid == REDISMODULE_EVENT_CLIENT_CHANGE) {
@@ -11396,7 +11390,6 @@ int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loa
     }
     RedisModuleCtx ctx;
     moduleCreateContext(&ctx, NULL, REDISMODULE_CTX_TEMP_CLIENT); /* We pass NULL since we don't have a module yet. */
-    selectDb(ctx.client, 0);
     if (onload((void*)&ctx,module_argv,module_argc) == REDISMODULE_ERR) {
         serverLog(LL_WARNING,
             "Module %s initialization failed. Module not loaded",path);

--- a/tests/unit/moduleapi/hooks.tcl
+++ b/tests/unit/moduleapi/hooks.tcl
@@ -25,6 +25,7 @@ tags "modules" {
             r client kill skipme yes
             # assert server is still up
             assert_equal [r ping] PONG
+            $rd close
         } 
 
         test {Test module cron hook} {

--- a/tests/unit/moduleapi/hooks.tcl
+++ b/tests/unit/moduleapi/hooks.tcl
@@ -15,6 +15,18 @@ tags "modules" {
             assert {[r hooks.event_count client-disconnected] > 1}
         }
 
+        test {Test module client change event for blocked client} {
+            set rd [redis_deferring_client]
+            # select db other than 0
+            $rd select 1
+            # block on key
+            $rd brpop foo 0
+            # kill blocked client
+            r client kill skipme yes
+            # assert server is still up
+            assert_equal [r ping] PONG
+        } 
+
         test {Test module cron hook} {
             after 100
             assert {[r hooks.event_count cron-loop] > 0}


### PR DESCRIPTION
In `moduleFireServerEvent` we change the real client DB to 0 on `freeClient` in case the event is `REDISMODULE_EVENT_CLIENT_CHANGE`.
It results in a crash if the client is blocked on a key on other than DB 0.

The DB change is not necessary even for module-client, as we set its DB to 0 on either `createClient` or `moduleReleaseTempClient`.


Backtrace:
```
Backtrace:
src/redis-server 127.0.0.1:21111(_serverAssertWithInfo+0x5d)[0x50f9bd]
src/redis-server 127.0.0.1:21111(unblockClientWaitingData+0x150)[0x4ad150]
src/redis-server 127.0.0.1:21111(unblockClient+0xa0)[0x4ad270]
src/redis-server 127.0.0.1:21111(freeClient+0x45a)[0x50446a]
src/redis-server 127.0.0.1:21111(clientCommand+0x899)[0x5097b9]
src/redis-server 127.0.0.1:21111(call+0xb0)[0x4fc680]
src/redis-server 127.0.0.1:21111(processCommand+0xa5b)[0x4fd64b]
```

```
Release notes:
Fix a crash when a client is disconnected while blocking on a key outside of DB 0 while a module is listening for client change events.
Fix bug in which module listening on CLIENT_CHANGE event would always see DB 0 being selected, even if the client had another db.
```