### PR TITLE
Optimize unwatchAllKeys() function

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -193,7 +193,7 @@ client *createClient(connection *conn) {
     c->bpop.numreplicas = 0;
     c->bpop.reploffset = 0;
     c->woff = 0;
-    c->watched_keys = listCreate();
+    c->watched_key_index = listCreate();
     c->pubsub_channels = dictCreate(&objectKeyPointerValueDictType);
     c->pubsub_patterns = listCreate();
     c->pubsubshard_channels = dictCreate(&objectKeyPointerValueDictType);
@@ -1582,7 +1582,7 @@ void freeClient(client *c) {
 
     /* UNWATCH all the keys */
     unwatchAllKeys(c);
-    listRelease(c->watched_keys);
+    listRelease(c->watched_key_index);
 
     /* Unsubscribe from all the pubsub channels */
     pubsubUnsubscribeAllChannels(c,0);

--- a/src/server.h
+++ b/src/server.h
@@ -1155,7 +1155,7 @@ typedef struct client {
     int btype;              /* Type of blocking op if CLIENT_BLOCKED. */
     blockingState bpop;     /* blocking state */
     long long woff;         /* Last write global replication offset. */
-    list *watched_keys;     /* Keys WATCHED for MULTI/EXEC CAS */
+    list *watched_key_index;/* Index of keys WATCHED for MULTI/EXEC CAS */
     dict *pubsub_channels;  /* channels a client is interested in (SUBSCRIBE) */
     list *pubsub_patterns;  /* patterns a client is interested in (SUBSCRIBE) */
     dict *pubsubshard_channels;  /* shard level channels a client is interested in (SSUBSCRIBE) */


### PR DESCRIPTION
In unwatchAllKeys() function, we traverse all the keys watched by the client, and for each key we need to remove the client from the list of clients watching that key. This is implemented by listSearchKey which traverse the clients list.

Nodes in `client->watched_keys` list save a `watchedKey` structure shared with the clients list.

In this PR, I convert the node in `client->watched_keys` to save a **reference to the node in clients list**, (listNode save a pointer of listNode), in this way we can reach the watchedKey by one more pointer. And when we traverse the keys watched by the client, we can simply remove the node from clients list in O(1) time, no need to traverse the clients list anymore.

In this way the `client->watched_keys` works like a index of nodes in clients list, so i change the name from `watched_keys` to `watched_key_index`.