### PR TITLE
Fix double inf test, use readraw to verify the protocol

### DIFF
--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -33,8 +33,12 @@ start_server {tags {"modules"}} {
                 assert_equal "inf" [r rw.double inf]
                 assert_equal "-inf" [r rw.double -inf]
             } else {
-                assert_equal Inf [r rw.double inf]
-                assert_equal -Inf [r rw.double -inf]
+                # TCL convert inf to different results on different platforms, e.g. inf on mac
+                # and Inf on others, so use readraw to verify the protocol
+                r readraw 1
+                assert_equal ",inf" [r rw.double inf]
+                assert_equal ",-inf" [r rw.double -inf]
+                r readraw 0
             }
         }
 


### PR DESCRIPTION
The test introduced in #11482 fail on mac:
```
*** [err]: RESP3: RM_ReplyWithDouble: inf in tests/unit/moduleapi/reply.tcl
Expected 'Inf' to be equal to 'inf'
(context: type eval line 6 cmd {assert_equal Inf [r rw.double inf]} proc ::test)
```

Looks like the mac platform returns inf instead of Inf in this case, this PR uses readraw to verify the protocol.