### PR TITLE
Fix double negative nan test, ignoring sign

### DIFF
--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -31,6 +31,13 @@ proc assert_match {pattern value {detail ""}} {
     }
 }
 
+proc assert_match_nocase {pattern value {detail ""}} {
+    if {![string match -nocase $pattern $value]} {
+        set context "(context: [info frame -1])"
+        error "assertion:Expected '$value' to match (no case) '$pattern' $context $detail"
+    }
+}
+
 proc assert_failed {expected_err detail} {
      if {$detail ne ""} {
         set detail "(detail: $detail)"

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -31,13 +31,6 @@ proc assert_match {pattern value {detail ""}} {
     }
 }
 
-proc assert_match_nocase {pattern value {detail ""}} {
-    if {![string match -nocase $pattern $value]} {
-        set context "(context: [info frame -1])"
-        error "assertion:Expected '$value' to match (no case) '$pattern' $context $detail"
-    }
-}
-
 proc assert_failed {expected_err detail} {
      if {$detail ne ""} {
         set detail "(detail: $detail)"

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -43,16 +43,16 @@ start_server {tags {"modules"}} {
         }
 
         test "RESP$proto: RM_ReplyWithDouble: NaN" {
+            # On some platforms one of these can be -nan but we don't care since they are
+            # synonym, so here we match ignoring the sign
             if {$proto == 2} {
-                # nan on ARM, -nan on others, so here we match ignoring case and sign
-                assert_match_nocase "*nan" [r rw.double 0 0]
-                assert_equal "nan" [r rw.double]
+                assert_match "*nan" [r rw.double 0 0]
+                assert_match "*nan" [r rw.double]
             } else {
                 # TCL won't convert nan into a double, use readraw to verify the protocol
                 r readraw 1
-                # nan on ARM, -nan on others, so here we match ignoring case and sign
-                assert_match_nocase ",*nan" [r rw.double 0 0]
-                assert_equal ",nan" [r rw.double]
+                assert_match ",*nan" [r rw.double 0 0]
+                assert_match ",*nan" [r rw.double]
                 r readraw 0
             }
         }

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -44,11 +44,13 @@ start_server {tags {"modules"}} {
 
         test "RESP$proto: RM_ReplyWithDouble: NaN" {
             if {$proto == 2} {
+                # nan on ARM, -nan on others, so here we match ignoring case and sign
                 assert_match_nocase "*nan" [r rw.double 0 0]
                 assert_equal "nan" [r rw.double]
             } else {
                 # TCL won't convert nan into a double, use readraw to verify the protocol
                 r readraw 1
+                # nan on ARM, -nan on others, so here we match ignoring case and sign
                 assert_match_nocase ",*nan" [r rw.double 0 0]
                 assert_equal ",nan" [r rw.double]
                 r readraw 0

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -44,12 +44,12 @@ start_server {tags {"modules"}} {
 
         test "RESP$proto: RM_ReplyWithDouble: NaN" {
             if {$proto == 2} {
-                assert_equal "-nan" [r rw.double 0 0]
+                assert_match_nocase "*nan" [r rw.double 0 0]
                 assert_equal "nan" [r rw.double]
             } else {
                 # TCL won't convert nan into a double, use readraw to verify the protocol
                 r readraw 1
-                assert_equal ",-nan" [r rw.double 0 0]
+                assert_match_nocase ",*nan" [r rw.double 0 0]
                 assert_equal ",nan" [r rw.double]
                 r readraw 0
             }


### PR DESCRIPTION
The test introduced in #11482 fail on ARM (extra CI):
```
*** [err]: RESP2: RM_ReplyWithDouble: NaN in tests/unit/moduleapi/reply.tcl
Expected '-nan' to be equal to 'nan' (context: type eval line 3 cmd
{assert_equal "-nan" [r rw.double 0 0]} proc ::test)

*** [err]: RESP3: RM_ReplyWithDouble: NaN in tests/unit/moduleapi/reply.tcl
Expected ',-nan' to be equal to ',nan' (context: type eval line 8 cmd
{assert_equal ",-nan" [r rw.double 0 0]} proc ::test)
```

It looks like there is no nagative nan on ARM. 