### PR TITLE
Remove unnecessary call to trimStringObjectIfNeeded from tryObjectEnc…

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2339,9 +2339,11 @@ int processMultibulkBuffer(client *c) {
                 c->bulklen >= PROTO_MBULK_BIG_ARG &&
                 sdslen(c->querybuf) == (size_t)(c->bulklen+2))
             {
-                c->argv[c->argc++] = createObject(OBJ_STRING,c->querybuf);
-                c->argv_len_sum += c->bulklen;
                 sdsIncrLen(c->querybuf,-2); /* remove CRLF */
+                robj* o = createObject(OBJ_STRING,c->querybuf);
+                trimStringObjectIfNeeded(o);
+                c->argv[c->argc++] = o;
+                c->argv_len_sum += c->bulklen;
                 /* Assume that if we saw a fat argument we'll see another one
                  * likely... */
                 c->querybuf = sdsnewlen(SDS_NOINIT,c->bulklen+2);

--- a/src/object.c
+++ b/src/object.c
@@ -672,17 +672,6 @@ robj *tryObjectEncoding(robj *o) {
         return emb;
     }
 
-    /* We can't encode the object...
-     *
-     * Do the last try, and at least optimize the SDS string inside
-     * the string object to require little space, in case there
-     * is more than 10% of free space at the end of the SDS string.
-     *
-     * We do that only for relatively large strings as this branch
-     * is only entered if the length of the string is greater than
-     * OBJ_ENCODING_EMBSTR_SIZE_LIMIT. */
-    trimStringObjectIfNeeded(o);
-
     /* Return the original object. */
     return o;
 }


### PR DESCRIPTION
Call `trimStringObjectIfNeeded` only when using the `querybuf` as the object's ptr.

Currently, we call `trimStringObjectIfNeeded` from `tryObjectEncoding` which is called for all set-commands.

However, the only place where we might allocate a larger than necessary string object is when we use the `querybuf` itself as the object's value.

`trimStringObjectIfNeeded` might be expensive as it tries to remove the internal fragmentation (a result of [#7875](https://github.com/redis/redis/pull/7875) change).
 