### PR TITLE
Explicitly send function commands to monitor

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -616,6 +616,9 @@ uint64_t fcallGetCommandFlags(client *c, uint64_t cmd_flags) {
 }
 
 static void fcallCommandGeneric(client *c, int ro) {
+    /* Functions need to be fed to monitors before the commands they execute. */
+    replicationFeedMonitors(c,server.monitors,c->db->id,c->argv,c->argc);
+
     robj *function_name = c->argv[1];
     functionInfo *fi = dictFetchValue(curr_functions_lib_ctx->functions, function_name->ptr);
     if (!fi) {


### PR DESCRIPTION
Resolves https://github.com/redis/redis/issues/11507.

Both functions and eval are marked as "no-monitor", since we want to explicitly feed in the script command before the commands generated by the script. Note that we want this behavior generally, so that commands can redact arguments before being added to the monitor.

Eval solves this problem by explicitly replicating commands, but it seems like functions missed it? I didn't find any explicit conversation here https://github.com/redis/redis/pull/10004. 

```
Release notes
Fix a bug where FCALL and FCALL_RO where not being reported in monitor.
```