### PR TITLE
optimize unwatchAllKeys()

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -139,6 +139,22 @@ list *listAddNodeTail(list *list, void *value)
     return list;
 }
 
+/*
+ * Add a node that has already been allocated to the tail of list
+ */
+void listLinkNodeTail(list *list, listNode *node) {
+    if (list->len == 0) {
+        list->head = list->tail = node;
+        node->prev = node->next = NULL;
+    } else {
+        node->prev = list->tail;
+        node->next = NULL;
+        list->tail->next = node;
+        list->tail = node;
+    }
+    list->len++;
+}
+
 list *listInsertNode(list *list, listNode *old_node, void *value, int after) {
     listNode *node;
 

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -90,6 +90,7 @@ void listRotateHeadToTail(list *list);
 void listJoin(list *l, list *o);
 void listInitNode(listNode *node, void *value);
 void listLinkNodeHead(list *list, listNode *node);
+void listLinkNodeTail(list *list, listNode *node);
 void listUnlinkNode(list *list, listNode *node);
 
 /* Directions for iterators */

--- a/src/server.h
+++ b/src/server.h
@@ -97,6 +97,13 @@ typedef struct redisObject robj;
 #define min(a, b) ((a) < (b) ? (a) : (b))
 #define max(a, b) ((a) > (b) ? (a) : (b))
 
+/* Offset of a member in a struct */
+#define member_offset(struct_name, member_name) ((size_t)&(((struct_name *)0)->member_name))
+
+/* Get the pointer of the outer struct from a member address */
+#define member2struct(struct_name, member_name, member_addr) \
+            ((struct_name *)((uint8_t*)member_addr - member_offset(struct_name, member_name)))
+
 /* Error codes */
 #define C_OK                    0
 #define C_ERR                   -1


### PR DESCRIPTION
In unwatchAllKeys() function, we traverse all the keys watched by the client, and for each key we need to remove the client from the list of clients watching that key. This is implemented by listSearchKey which traverses the list of clients.

If we can reach the node of the list of clients from watchedKey in O(1) time, then we do not need to call listSearchKey anymore.

Changes in this PR: put the node of the list of clients of each watched key in the db inside the watchedKey structure.
In this way, for every key watched by the client, we can get the watchedKey structure and then reach the node in the list of clients in db->watched_keys to remove it from that list.
From the perspective of the list of clients watching the key, the list node is inside a watchedKey structure, so we can get to the watchedKey struct from the listnode by struct member offset math. And because of this, node->value is not used, we can point node->value to the list itself, so that we don't need to fetch the list of clients from the dict.

If a client is watching at key0 and key1, and these two keys are also watched by some other clients, then the structure looks like this:
![](https://wx2.sinaimg.cn/mw690/006XXwaCgy1h85y8vs32fj30ny0o7tbg.jpg)

In this picture if we call unwatchAllKeys() for the client, then for each node in the BLUE list we need to traverse the corresponding GREEN list to remove the node of the list of clients.

And after this PR the structure looks like this:
![](https://wx1.sinaimg.cn/mw690/006XXwaCgy1h85y8vlhh3j30n70pe0wd.jpg)

When we call unwatchAllKeys() in this picture, for each node in the BLUE list, we can reach the RED watchedKey structure and then get the node in the GREEN list in O(1) time.



