### PR TITLE
Update Sentinel Debug command json file and add test case for it

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -3706,7 +3706,7 @@ struct redisCommandArg SENTINEL_DEBUG_data_Subargs[] = {
 
 /* SENTINEL DEBUG argument table */
 struct redisCommandArg SENTINEL_DEBUG_Args[] = {
-{"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=SENTINEL_DEBUG_data_Subargs},
+{"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,.subargs=SENTINEL_DEBUG_data_Subargs},
 {0}
 };
 

--- a/src/commands/sentinel-debug.json
+++ b/src/commands/sentinel-debug.json
@@ -16,6 +16,7 @@
             {
                 "name": "data",
                 "type": "block",
+                "optional": true,
                 "multiple": true,
                 "arguments": [
                     {

--- a/tests/sentinel/tests/14-debug-command.tcl
+++ b/tests/sentinel/tests/14-debug-command.tcl
@@ -1,0 +1,9 @@
+source "../tests/includes/init-tests.tcl"
+
+test "sentinel debug test with arguments and without argument" {
+   set current_info_period [lindex [S 0 SENTINEL DEBUG] 1]
+   S 0 SENTINEL DEBUG info-period 8888
+   assert { [lindex [S 0 SENTINEL DEBUG] 1] == {8888} }
+   S 0 SENTINEL DEBUG info-period $current_info_period
+   assert { [lindex [S 0 SENTINEL DEBUG] 1] == $current_info_period }
+}

--- a/tests/sentinel/tests/14-debug-command.tcl
+++ b/tests/sentinel/tests/14-debug-command.tcl
@@ -1,9 +1,9 @@
 source "../tests/includes/init-tests.tcl"
 
-test "sentinel debug test with arguments and without argument" {
+test "Sentinel debug test with arguments and without argument" {
    set current_info_period [lindex [S 0 SENTINEL DEBUG] 1]
    S 0 SENTINEL DEBUG info-period 8888
-   assert { [lindex [S 0 SENTINEL DEBUG] 1] == {8888} }
+   assert_equal [string first [S 0 SENTINEL DEBUG] 8888] -1
    S 0 SENTINEL DEBUG info-period $current_info_period
-   assert { [lindex [S 0 SENTINEL DEBUG] 1] == $current_info_period }
+   assert_equal [string first [S 0 SENTINEL DEBUG] $current_info_period] -1
 }

--- a/tests/sentinel/tests/14-debug-command.tcl
+++ b/tests/sentinel/tests/14-debug-command.tcl
@@ -3,7 +3,7 @@ source "../tests/includes/init-tests.tcl"
 test "Sentinel debug test with arguments and without argument" {
    set current_info_period [lindex [S 0 SENTINEL DEBUG] 1]
    S 0 SENTINEL DEBUG info-period 8888
-   assert_equal [string first [S 0 SENTINEL DEBUG] 8888] -1
+   assert { [lindex [S 0 SENTINEL DEBUG] 1] == {8888} }
    S 0 SENTINEL DEBUG info-period $current_info_period
-   assert_equal [string first [S 0 SENTINEL DEBUG] $current_info_period] -1
+   assert { [lindex [S 0 SENTINEL DEBUG] 1] == $current_info_period }
 }

--- a/tests/sentinel/tests/14-debug-command.tcl
+++ b/tests/sentinel/tests/14-debug-command.tcl
@@ -3,7 +3,7 @@ source "../tests/includes/init-tests.tcl"
 test "Sentinel debug test with arguments and without argument" {
    set current_info_period [lindex [S 0 SENTINEL DEBUG] 1]
    S 0 SENTINEL DEBUG info-period 8888
-   assert { [lindex [S 0 SENTINEL DEBUG] 1] == {8888} }
+   assert_equal {8888} [lindex [S 0 SENTINEL DEBUG] 1] 
    S 0 SENTINEL DEBUG info-period $current_info_period
-   assert { [lindex [S 0 SENTINEL DEBUG] 1] == $current_info_period }
+   assert_equal $current_info_period [lindex [S 0 SENTINEL DEBUG] 1]
 }


### PR DESCRIPTION
Command SENTINEL DEBUG could be no arguments, which display all configurable arguments and their values.
Update the command arguments in the docs (json file) to indicate that arguments are optional.

![image](https://user-images.githubusercontent.com/51993843/202026455-b47411a7-fc03-43e1-8ea5-ec2be69da502.png)
