### PR TITLE
Simplified geoAppendIfWithinShape() and removed spurious calls do sdsdup and sdsfree

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -210,33 +210,22 @@ void addReplyDoubleDistance(client *c, double d) {
 }
 
 /* Helper function for geoGetPointsInRange(): given a sorted set score
- * representing a point, and a GeoShape, appends this entry as a geoPoint
- * into the specified geoArray only if the point is within the search area.
+ * representing a point, and a GeoShape, checks if the point is within the search area.
  *
- * returns C_OK if the point is included, or C_ERR if it is outside. */
-int geoAppendIfWithinShape(geoArray *ga, GeoShape *shape, double score, sds member) {
-    double distance = 0, xy[2];
-
+ * returns C_OK if the point is within search area, or C_ERR if it is outside. */
+int geoWithinShape(GeoShape *shape, double score, double *xy, double *distance) {
     if (!decodeGeohash(score,xy)) return C_ERR; /* Can't decode. */
     /* Note that geohashGetDistanceIfInRadiusWGS84() takes arguments in
      * reverse order: longitude first, latitude later. */
     if (shape->type == CIRCULAR_TYPE) {
         if (!geohashGetDistanceIfInRadiusWGS84(shape->xy[0], shape->xy[1], xy[0], xy[1],
-                                               shape->t.radius*shape->conversion, &distance)) return C_ERR;
+                                               shape->t.radius*shape->conversion, distance)) return C_ERR;
     } else if (shape->type == RECTANGLE_TYPE) {
         if (!geohashGetDistanceIfInRectangle(shape->t.r.width * shape->conversion,
                                              shape->t.r.height * shape->conversion,
-                                             shape->xy[0], shape->xy[1], xy[0], xy[1], &distance))
+                                             shape->xy[0], shape->xy[1], xy[0], xy[1], distance))
             return C_ERR;
     }
-
-    /* Append the new element. */
-    geoPoint *gp = geoArrayAppend(ga);
-    gp->longitude = xy[0];
-    gp->latitude = xy[1];
-    gp->dist = distance;
-    gp->member = member;
-    gp->score = score;
     return C_OK;
 }
 
@@ -257,8 +246,6 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
     /* That's: min <= val < max */
     zrangespec range = { .min = min, .max = max, .minex = 0, .maxex = 1 };
     size_t origincount = ga->used;
-    sds member;
-
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = zobj->ptr;
         unsigned char *eptr, *sptr;
@@ -274,6 +261,8 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
 
         sptr = lpNext(zl, eptr);
         while (eptr) {
+            double xy[2];
+            double distance = 0;
             score = zzlGetScore(sptr);
 
             /* If we fell out of range, break. */
@@ -281,10 +270,17 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
                 break;
 
             vstr = lpGetValue(eptr, &vlen, &vlong);
-            member = (vstr == NULL) ? sdsfromlonglong(vlong) :
-                                      sdsnewlen(vstr,vlen);
-            if (geoAppendIfWithinShape(ga,shape,score,member)
-                == C_ERR) sdsfree(member);
+            if (geoWithinShape(shape,score, xy, &distance)
+                == C_OK) {
+                /* Append the new element. */
+                geoPoint *gp = geoArrayAppend(ga);
+                gp->longitude = xy[0];
+                gp->latitude = xy[1];
+                gp->dist = distance;
+                gp->member = (vstr == NULL) ? sdsfromlonglong(vlong) :
+                         sdsnewlen(vstr,vlen);
+                gp->score = score;
+            }
             if (ga->used && limit && ga->used >= limit) break;
             zzlNext(zl, &eptr, &sptr);
         }
@@ -299,14 +295,21 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
         }
 
         while (ln) {
-            sds ele = ln->ele;
+            double xy[2];
+            double distance = 0;
             /* Abort when the node is no longer in range. */
             if (!zslValueLteMax(ln->score, &range))
                 break;
-
-            ele = sdsdup(ele);
-            if (geoAppendIfWithinShape(ga,shape,ln->score,ele)
-                == C_ERR) sdsfree(ele);
+            if (geoWithinShape(shape,ln->score, xy, &distance)
+                == C_OK) {
+                /* Append the new element. */
+                geoPoint *gp = geoArrayAppend(ga);
+                gp->longitude = xy[0];
+                gp->latitude = xy[1];
+                gp->dist = distance;
+                gp->member = sdsdup(ln->ele);
+                gp->score = ln->score;
+            }
             if (ga->used && limit && ga->used >= limit) break;
             ln = ln->level[0].forward;
         }

--- a/src/geo.c
+++ b/src/geo.c
@@ -62,7 +62,8 @@ geoArray *geoArrayCreate(void) {
 
 /* Add and populate with data a new entry to the geoArray. */
 geoPoint *geoArrayAppend(geoArray *ga, double *xy, double dist,
-                         double score, char *member) {
+                         double score, char *member)
+{
     if (ga->used == ga->buckets) {
         ga->buckets = (ga->buckets == 0) ? 8 : ga->buckets*2;
         ga->array = zrealloc(ga->array,sizeof(geoPoint)*ga->buckets);
@@ -218,9 +219,9 @@ void addReplyDoubleDistance(client *c, double d) {
  * representing a point, and a GeoShape, checks if the point is within the search area.
  *
  * shape: the rectangle
- * score : the encoded version of lat,long
- * xy : the decoded lat,long
- * distance: the distance between the center of the shape and the point
+ * score: the encoded version of lat,long
+ * xy: output variable, the decoded lat,long
+ * distance: output variable, the distance between the center of the shape and the point
  *
  * Return values:
  *
@@ -286,8 +287,7 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
                 break;
 
             vstr = lpGetValue(eptr, &vlen, &vlong);
-            if (geoWithinShape(shape,score, xy, &distance)
-                == C_OK) {
+            if (geoWithinShape(shape, score, xy, &distance) == C_OK) {
                 /* Append the new element. */
                 char *member = (vstr == NULL) ? sdsfromlonglong(vlong) : sdsnewlen(vstr, vlen);
                 geoArrayAppend(ga, xy, distance, score, member);
@@ -311,8 +311,7 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
             /* Abort when the node is no longer in range. */
             if (!zslValueLteMax(ln->score, &range))
                 break;
-            if (geoWithinShape(shape,ln->score, xy, &distance)
-                == C_OK) {
+            if (geoWithinShape(shape, ln->score, xy, &distance) == C_OK) {
                 /* Append the new element. */
                 geoArrayAppend(ga, xy, distance, ln->score, sdsdup(ln->ele));
             }

--- a/src/geo.c
+++ b/src/geo.c
@@ -290,7 +290,7 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
                 == C_OK) {
                 /* Append the new element. */
                 char *member = (vstr == NULL) ? sdsfromlonglong(vlong) : sdsnewlen(vstr, vlen);
-                geoPoint *gp = geoArrayAppend(ga, xy, distance, score, member);
+                geoArrayAppend(ga, xy, distance, score, member);
             }
             if (ga->used && limit && ga->used >= limit) break;
             zzlNext(zl, &eptr, &sptr);
@@ -314,7 +314,7 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
             if (geoWithinShape(shape,ln->score, xy, &distance)
                 == C_OK) {
                 /* Append the new element. */
-                geoPoint *gp = geoArrayAppend(ga, xy, distance, ln->score, sdsdup(ln->ele));
+                geoArrayAppend(ga, xy, distance, ln->score, sdsdup(ln->ele));
             }
             if (ga->used && limit && ga->used >= limit) break;
             ln = ln->level[0].forward;

--- a/src/geo.c
+++ b/src/geo.c
@@ -234,7 +234,8 @@ int geoWithinShape(GeoShape *shape, double score, double *xy, double *distance) 
      * reverse order: longitude first, latitude later. */
     if (shape->type == CIRCULAR_TYPE) {
         if (!geohashGetDistanceIfInRadiusWGS84(shape->xy[0], shape->xy[1], xy[0], xy[1],
-                                               shape->t.radius*shape->conversion, distance)) return C_ERR;
+                                               shape->t.radius*shape->conversion, distance))
+            return C_ERR;
     } else if (shape->type == RECTANGLE_TYPE) {
         if (!geohashGetDistanceIfInRectangle(shape->t.r.width * shape->conversion,
                                              shape->t.r.height * shape->conversion,


### PR DESCRIPTION
In scenarios in which we have large datasets and the elements are not contained within the range we do spurious calls do sdsdup and sdsfree.
I.e. instead of pre-creating an sds before we know if we're gonna use it or not, change the role of geoAppendIfWithinShape to just do geoWithinShape, and let the caller create the string only when needed.

<img width="589" alt="Screenshot 2022-11-17 at 23 43 21" src="https://user-images.githubusercontent.com/5832149/202583542-56e55b3d-4ec6-479f-886d-bb6ba1d01b97.png">

Benchmarking within a geo key with 23244458 elements and the query returns 90K elements, we noticed an improvement from 20.44 ops/sec to 25.01 ops/sec and a drop in the p50 latency from 48.63900 ms to 41.72700 ms. 

To benchmark:

```
memtier_benchmark -c 1 -t 1 --test-time 60 --command "GEOSEARCH key FROMLONLAT 7.0 55.0 BYRADIUS 200 KM" --hide-histogram
``` 

## unstable ( 203b12e41ff7981f0fae5b23819f072d61594813 )

```
ALL STATS
=====================================================================================================
Type            Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
-----------------------------------------------------------------------------------------------------
Geosearchs        20.44        48.93554        48.63900        50.17500        50.43100     24634.70 
Totals            20.44        48.93554        48.63900        50.17500        50.43100     24634.70 
```


## this PR 

```
ALL STATS
=====================================================================================================
Type            Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
-----------------------------------------------------------------------------------------------------
Geosearchs        25.01        39.96836        41.72700        42.23900        43.26300     30147.47 
Totals            25.01        39.96836        41.72700        42.23900        43.26300     30147.47 

```