### PR TITLE
 Add force as an option to lazyfree-lazy-user-flush to force async flush regardless of arguments

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1268,8 +1268,10 @@ lazyfree-lazy-user-del no
 
 # FLUSHDB, FLUSHALL, SCRIPT FLUSH and FUNCTION FLUSH support both asynchronous and synchronous
 # deletion, which can be controlled by passing the [SYNC|ASYNC] flags into the
-# commands. When neither flag is passed, this directive will be used to determine
-# if the data should be deleted asynchronously.
+# commands. When this flag is set to yes, this directive will be used to determine
+# if the data should be deleted asynchronously when no flag is passed in in the command.
+# When this flag is set to force, every flush will execute asynchronously even if the SYNC
+# argument is explicitly provided.
 
 lazyfree-lazy-user-flush no
 

--- a/src/config.c
+++ b/src/config.c
@@ -112,6 +112,13 @@ configEnum repl_diskless_load_enum[] = {
     {NULL, 0}
 };
 
+configEnum lazyfree_lazy_user_flush_enum[] = {
+    {"yes", ASYNC_FLUSH_DEFAULT_ON},
+    {"no", ASYNC_FLUSH_DEFAULT_OFF},
+    {"force", ASYNC_FLUSH_FORCE},
+    {NULL, 0}
+};
+
 configEnum tls_auth_clients_enum[] = {
     {"no", TLS_CLIENT_AUTH_NO},
     {"yes", TLS_CLIENT_AUTH_YES},
@@ -2987,7 +2994,7 @@ standardConfig static_configs[] = {
     createBoolConfig("lazyfree-lazy-expire", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_expire, 0, NULL, NULL),
     createBoolConfig("lazyfree-lazy-server-del", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_server_del, 0, NULL, NULL),
     createBoolConfig("lazyfree-lazy-user-del", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_user_del , 0, NULL, NULL),
-    createBoolConfig("lazyfree-lazy-user-flush", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_user_flush , 0, NULL, NULL),
+    createEnumConfig("lazyfree-lazy-user-flush", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, lazyfree_lazy_user_flush_enum, server.lazyfree_lazy_user_flush, ASYNC_FLUSH_DEFAULT_OFF, NULL, NULL),
     createBoolConfig("repl-disable-tcp-nodelay", NULL, MODIFIABLE_CONFIG, server.repl_disable_tcp_nodelay, 0, NULL, NULL),
     createBoolConfig("repl-diskless-sync", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.repl_diskless_sync, 1, NULL, NULL),
     createBoolConfig("aof-rewrite-incremental-fsync", NULL, MODIFIABLE_CONFIG, server.aof_rewrite_incremental_fsync, 1, NULL, NULL),

--- a/src/db.c
+++ b/src/db.c
@@ -593,11 +593,12 @@ void signalFlushedDb(int dbid, int async) {
 int getFlushCommandFlags(client *c, int *flags) {
     /* Parse the optional ASYNC option. */
     if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"sync")) {
-        *flags = EMPTYDB_NO_FLAGS;
+        *flags = (server.lazyfree_lazy_user_flush == ASYNC_FLUSH_FORCE) ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS;
     } else if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"async")) {
         *flags = EMPTYDB_ASYNC;
     } else if (c->argc == 1) {
-        *flags = server.lazyfree_lazy_user_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS;
+        *flags = (server.lazyfree_lazy_user_flush == ASYNC_FLUSH_FORCE || server.lazyfree_lazy_user_flush == ASYNC_FLUSH_DEFAULT_ON)
+                 ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS;
     } else {
         addReplyErrorObject(c,shared.syntaxerr);
         return C_ERR;

--- a/src/eval.c
+++ b/src/eval.c
@@ -609,11 +609,12 @@ NULL
     } else if (c->argc >= 2 && !strcasecmp(c->argv[1]->ptr,"flush")) {
         int async = 0;
         if (c->argc == 3 && !strcasecmp(c->argv[2]->ptr,"sync")) {
-            async = 0;
+            async = (server.lazyfree_lazy_user_flush == ASYNC_FLUSH_FORCE) ? 1 : 0;
         } else if (c->argc == 3 && !strcasecmp(c->argv[2]->ptr,"async")) {
             async = 1;
         } else if (c->argc == 2) {
-            async = server.lazyfree_lazy_user_flush ? 1 : 0;
+            async = (server.lazyfree_lazy_user_flush == ASYNC_FLUSH_FORCE || server.lazyfree_lazy_user_flush == ASYNC_FLUSH_DEFAULT_ON)
+                    ? 1 : 0;
         } else {
             addReplyError(c,"SCRIPT FLUSH only support SYNC|ASYNC option");
             return;

--- a/src/functions.c
+++ b/src/functions.c
@@ -805,11 +805,12 @@ void functionFlushCommand(client *c) {
     }
     int async = 0;
     if (c->argc == 3 && !strcasecmp(c->argv[2]->ptr,"sync")) {
-        async = 0;
+        async = (server.lazyfree_lazy_user_flush == ASYNC_FLUSH_FORCE) ? 1 : 0;
     } else if (c->argc == 3 && !strcasecmp(c->argv[2]->ptr,"async")) {
         async = 1;
     } else if (c->argc == 2) {
-        async = server.lazyfree_lazy_user_flush ? 1 : 0;
+        async = (server.lazyfree_lazy_user_flush == ASYNC_FLUSH_FORCE || server.lazyfree_lazy_user_flush == ASYNC_FLUSH_DEFAULT_ON)
+                ? 1 : 0;
     } else {
         addReplyError(c,"FUNCTION FLUSH only supports SYNC|ASYNC option");
         return;

--- a/src/server.h
+++ b/src/server.h
@@ -526,6 +526,11 @@ typedef enum {
 #define OOM_SCORE_RELATIVE 1
 #define OOM_SCORE_ADJ_ABSOLUTE 2
 
+/* lazyfree-lazy-user-flush enum configs */
+#define ASYNC_FLUSH_DEFAULT_ON 0
+#define ASYNC_FLUSH_DEFAULT_OFF 1
+#define ASYNC_FLUSH_FORCE 2
+
 /* Redis maxmemory strategies. Instead of using just incremental number
  * for this defines, we use a set of flags so that testing for certain
  * properties common to multiple policies is faster. */

--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -87,4 +87,28 @@ start_server {tags {"lazyfree"}} {
         }
         assert_equal [s lazyfreed_objects] 0
     } {} {needs:config-resetstat}
+
+    test "lazyfree-lazy-user-flush force forces async flushall in all circumstances" {
+        r config resetstat
+        r set key val
+        r set key1 val1
+        r set key2 val2
+
+        r config set lazyfree-lazy-user-flush force
+        r flushall sync
+        wait_lazyfree_done r
+
+        assert_equal [s lazyfreed_objects] 3
+
+        r config resetstat
+        r set key val
+        r set key1 val1
+        r set key2 val2
+        
+        r flushall
+        wait_lazyfree_done r
+
+        assert_equal [s lazyfreed_objects] 3
+        r config set lazyfree-lazy-user-flush no
+    }
 }

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -157,6 +157,7 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
         }
         r config set appendonly no
         r config set key-load-delay 0
+        r config set lazyfree-lazy-user-flush no
         
         test "Active defrag eval scripts" {
             r flushdb

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -421,6 +421,37 @@ start_server {tags {"scripting"}} {
         assert { [string match "*number_of_cached_scripts:100*" [r info Memory]] }
         r script flush async
         assert { [string match "*number_of_cached_scripts:0*" [r info Memory]] }
+        assert_equal [s lazyfreed_objects] 100
+    }
+
+    test {SCRIPTING flush lazyfree-lazy-user-flush force async} {
+        r config resetstat
+        r config set lazyfree-lazy-user-flush force
+        for {set j 0} {$j < 100} {incr j} {
+            r script load "return $j"
+        }
+        assert_match "*number_of_cached_scripts:100*" [r info memory]
+        r script flush sync
+        assert_match "*number_of_cached_scripts:0*" [r info memory]
+        assert_equal [s lazyfreed_objects] 100
+        wait_for_condition 50 100 {
+            [s lazyfreed_objects == 100]
+        } else {
+            fail "Did not lazyflush when lazyfree-lazy-user-flush was set to force"
+        }
+        for {set j 0} {$j < 100} {incr j} {
+            r script load "return $j"
+        }
+        r config resetstat
+        assert_match "*number_of_cached_scripts:100*" [r info memory]
+        r script flush
+        assert_match "*number_of_cached_scripts:0*" [r info memory]
+        wait_for_condition 50 100 {
+            [s lazyfreed_objects == 100]
+        } else {
+            fail "Did not lazyflush when lazyfree-lazy-user-flush was set to force"
+        }
+        r config set lazyfree-lazy-user-flush no
     }
 
     test {SCRIPT EXISTS - can detect already defined scripts?} {


### PR DESCRIPTION
At AWS we've found that synchronous flush blocking the main thread for extended periods of time can create a multitude of different issues. From a clients perspective, asynchronous flush and synchronous flush are functionally the same since we immediately instantiate new, empty objects to write to, but asynchronous flush frees up the main thread significantly more quickly for command processing. This change (when lazyfree-lazy-user-flush is set to "force") forces an async flush even if the client explicitly provides the "sync" argument. This applies to all three classes of flush (i.e. for keys, scripts, and functions).