### PR TITLE
Fix sentinel update loglevel tls test

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -518,7 +518,7 @@ jobs:
       if: true && !contains(github.event.inputs.skiptests, 'cluster')
       run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
-  test-centos7-tls:
+  test-centos7-tls-module:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
@@ -561,7 +561,7 @@ jobs:
       run: |
         ./runtest-cluster --tls-module ${{github.event.inputs.cluster_test_args}}
 
-  test-centos7-tls-no-tls:
+  test-centos7-tls-module-no-tls-module:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -561,7 +561,7 @@ jobs:
       run: |
         ./runtest-cluster --tls-module ${{github.event.inputs.cluster_test_args}}
 
-  test-centos7-tls-module-no-tls-module:
+  test-centos7-tls-module-no-tls:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -102,6 +102,7 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
             puts $cfg [format "tls-client-key-file %s/../../tls/client.key" [pwd]]
             puts $cfg [format "tls-dh-params-file %s/../../tls/redis.dh" [pwd]]
             puts $cfg [format "tls-ca-cert-file %s/../../tls/ca.crt" [pwd]]
+            # Note that this loglevel set will effect `Update log level` sentinel test.
             puts $cfg "loglevel debug"
         } else {
             puts $cfg "port $port"

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -102,8 +102,6 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
             puts $cfg [format "tls-client-key-file %s/../../tls/client.key" [pwd]]
             puts $cfg [format "tls-dh-params-file %s/../../tls/redis.dh" [pwd]]
             puts $cfg [format "tls-ca-cert-file %s/../../tls/ca.crt" [pwd]]
-            # Note that this loglevel set will effect `Update log level` sentinel test.
-            puts $cfg "loglevel debug"
         } else {
             puts $cfg "port $port"
         }

--- a/tests/sentinel/tests/01-conf-update.tcl
+++ b/tests/sentinel/tests/01-conf-update.tcl
@@ -40,7 +40,12 @@ test "New master [join $addr {:}] role matches" {
 
 test "Update log level" {
     set current_loglevel [S 0 SENTINEL CONFIG GET loglevel]
-    assert {[lindex $current_loglevel 1] == {notice}}
+    if {$::tls} {
+        # In spawn_instance, we set loglevel to debug for tls.
+        assert {[lindex $current_loglevel 1] == {debug}}
+    } else {
+        assert {[lindex $current_loglevel 1] == {notice}}
+    }
     S 0 SENTINEL CONFIG SET loglevel warning
     set updated_loglevel [S 0 SENTINEL CONFIG GET loglevel]
     assert {[lindex $updated_loglevel 1] == {warning}}

--- a/tests/sentinel/tests/01-conf-update.tcl
+++ b/tests/sentinel/tests/01-conf-update.tcl
@@ -40,12 +40,7 @@ test "New master [join $addr {:}] role matches" {
 
 test "Update log level" {
     set current_loglevel [S 0 SENTINEL CONFIG GET loglevel]
-    if {$::tls} {
-        # In spawn_instance, we set loglevel to debug for tls.
-        assert {[lindex $current_loglevel 1] == {debug}}
-    } else {
-        assert {[lindex $current_loglevel 1] == {notice}}
-    }
+    assert {[lindex $current_loglevel 1] == {notice}}
     S 0 SENTINEL CONFIG SET loglevel warning
     set updated_loglevel [S 0 SENTINEL CONFIG GET loglevel]
     assert {[lindex $updated_loglevel 1] == {warning}}


### PR DESCRIPTION
Apparently we used to set `loglevel debug` for tls in spawn_instance.
I.e. cluster and sentinel tests used to run with debug logging, only when tls mode was enabled.
this was probably a leftover from when creating the tls mode tests.
it cause a new test created for #11214 to fail in tls mode.

At the same time, in order to better distinguish the tests, change the
name of `test-centos7-tls` to `test-centos7-tls-module`, change the name
of `test-centos7-tls-no-tls` to `test-centos7-tls-module-no-tls`.

Note that in `test-centos7-tls-module`, we did not pass `--tls-module`
in sentinel test because it is not supported, see 4faddf1, added in #9320.
So only `test-ubuntu-tls` fails in daily CI.