### PR TITLE
GEOSEARCH BYBOX: Reduce wastefull computation on geohashGetDistanceIfInRectangle and geohashGetDistance

### DIFF
--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -257,12 +257,14 @@ int geohashGetDistanceIfInRadiusWGS84(double x1, double y1, double x2,
  */
 int geohashGetDistanceIfInRectangle(double width_m, double height_m, double x1, double y1,
                                     double x2, double y2, double *distance) {
-    double lon_distance = geohashGetDistance(x2, y2, x1, y2);
-    if (lon_distance > width_m/2) {
-        return 0;
-    }
+    /* latitude distance is less expensive to compute than longitude distance
+     * so we check first for the latitude condition */
     double lat_distance = geohashGetDistance(x2, y2, x2, y1);
     if (lat_distance > height_m/2) {
+        return 0;
+    }
+    double lon_distance = geohashGetDistance(x2, y2, x1, y2);
+    if (lon_distance > width_m/2) {
         return 0;
     }
     *distance = geohashGetDistance(x1, y1, x2, y2);

--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -225,8 +225,14 @@ double geohashGetDistance(double lon1d, double lat1d, double lon2d, double lat2d
     lon2r = deg_rad(lon2d);
     u = sin((lat2r - lat1r) / 2);
     v = sin((lon2r - lon1r) / 2);
-    return 2.0 * EARTH_RADIUS_IN_METERS *
-           asin(sqrt(u * u + cos(lat1r) * cos(lat2r) * v * v));
+    double a = u * u;
+    double sqrt_a = u;
+    // if v == 0 we can avoid doing expensive math
+    if (v != 0.0){
+        a += cos(lat1r) * cos(lat2r) * v * v;
+        sqrt_a = sqrt(a);
+    }
+    return 2.0 * EARTH_RADIUS_IN_METERS * asin(sqrt_a);
 }
 
 int geohashGetDistanceIfInRadius(double x1, double y1,

--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -226,13 +226,11 @@ double geohashGetDistance(double lon1d, double lat1d, double lon2d, double lat2d
     u = sin((lat2r - lat1r) / 2);
     v = sin((lon2r - lon1r) / 2);
     double a = u * u;
-    double sqrt_a = u;
     // if v == 0 we can avoid doing expensive math
     if (v != 0.0){
         a += cos(lat1r) * cos(lat2r) * v * v;
-        sqrt_a = sqrt(a);
     }
-    return 2.0 * EARTH_RADIUS_IN_METERS * asin(sqrt_a);
+    return 2.0 * EARTH_RADIUS_IN_METERS * asin(sqrt(a));
 }
 
 int geohashGetDistanceIfInRadius(double x1, double y1,

--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -226,7 +226,7 @@ double geohashGetDistance(double lon1d, double lat1d, double lon2d, double lat2d
     u = sin((lat2r - lat1r) / 2);
     v = sin((lon2r - lon1r) / 2);
     double a = u * u;
-    // if v == 0 we can avoid doing expensive math
+    /* if v == 0 we can avoid doing expensive math */
     if (v != 0.0){
         a += cos(lat1r) * cos(lat2r) * v * v;
     }

--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -258,8 +258,11 @@ int geohashGetDistanceIfInRadiusWGS84(double x1, double y1, double x2,
 int geohashGetDistanceIfInRectangle(double width_m, double height_m, double x1, double y1,
                                     double x2, double y2, double *distance) {
     double lon_distance = geohashGetDistance(x2, y2, x1, y2);
+    if (lon_distance > width_m/2) {
+        return 0;
+    }
     double lat_distance = geohashGetDistance(x2, y2, x2, y1);
-    if (lon_distance > width_m/2 || lat_distance > height_m/2) {
+    if (lat_distance > height_m/2) {
         return 0;
     }
     *distance = geohashGetDistance(x1, y1, x2, y2);


### PR DESCRIPTION
If we run the following benchmark
```
memtier_benchmark -c 1 -t 1 --pipeline 1 --test-time 60 --command "GEOSEARCH key FROMLONLAT 7 55 BYBOX 200 200 KM" --hide-histogram
```
and profile it:
![image](https://user-images.githubusercontent.com/5832149/203671764-2d956f47-f350-4dd2-b44d-c11cc6bfb02f.png)

We see that 54.78% of cpu cycles are from geohashGetDistanceIfInRectangle.
Within it we're calling 3x geohashGetDistance. The first 2 times we call them to produce intermediate results.
This PR focus on optimizing for those 2 intermediate results.

- 1 Reduce expensive computation on intermediate geohashGetDistance with same long ( 48895ee2815164749b04a3454c41220c41c6e87c )
- 2 Avoid expensive lon_distance calculation if lat_distance fails beforehand ( 6e2ecc7f45fbc5c7cb2d382174037c7b7366fb3d )

## Results

On pipeline 1, single client benchmark, we move from average latency (including RTT) of 93.59895 ms to 73.04606 ms ( approximately 22% latency drop ).

Furthermore we can see that the command latency distribution is now more stable ( check avg, p50, p99 and p999 for last result )

### baseline from unstable branch ( 3b462ce566e577ffcb35822a0a2372f691326cd4 )
```
ALL STATS
=====================================================================================================
Type            Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
-----------------------------------------------------------------------------------------------------
Geosearchs        10.67        93.59895        97.27900        97.79100        97.79100      1596.95 
Totals            10.67        93.59895        97.27900        97.79100        97.79100      1596.95 
```

### After 1 Reduce expensive computation on intermediate geohashGetDistance with same long ( 48895ee2815164749b04a3454c41220c41c6e87c )
```
ALL STATS
=====================================================================================================
Type            Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
-----------------------------------------------------------------------------------------------------
Geosearchs        11.43        87.40721        87.55100        90.62300        91.13500      1709.95 
Totals            11.43        87.40721        87.55100        90.62300        91.13500      1709.95 
```

#### This PR at b27590a26f8f9a55683c763ab825d03a18791a89
```
ALL STATS
=====================================================================================================
Type            Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
-----------------------------------------------------------------------------------------------------
Geosearchs        12.67        79.07036        79.35900        79.35900        79.87100      1895.72 
Totals            12.67        79.07036        79.35900        79.35900        79.87100      1895.72 
```


### After 2 Avoid expensive lon_distance calculation if lat_distance fails beforehand ( 6e2ecc7f45fbc5c7cb2d382174037c7b7366fb3d )
```
ALL STATS
=====================================================================================================
Type            Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
-----------------------------------------------------------------------------------------------------
Geosearchs        13.67        73.04606        73.21500        73.72700        74.23900      2046.08 
Totals            13.67        73.04606        73.21500        73.72700        74.23900      2046.08 
```