### PR TITLE
Ignore -Wstringop-overread warning for SHA1Transform() on GCC 12

### DIFF
--- a/src/sha1.c
+++ b/src/sha1.c
@@ -125,6 +125,14 @@ void SHA1Init(SHA1_CTX* context)
     context->count[0] = context->count[1] = 0;
 }
 
+/* This source code is referenced from
+ * https://github.com/libevent/libevent/commit/e1d7d3e40a7fd50348d849046fbfd9bf976e643c */
+#if defined(__GNUC__) && __GNUC__ >= 12
+#pragma GCC diagnostic push
+/* Ignore the case when SHA1Transform() called with 'char *', that code passed
+ * buffer of 64 bytes anyway (at least now) */
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
 
 /* Run your data through this. */
 
@@ -149,6 +157,9 @@ void SHA1Update(SHA1_CTX* context, const unsigned char* data, uint32_t len)
     memcpy(&context->buffer[j], &data[i], len - i);
 }
 
+#if defined(__GNUC__) && __GNUC__ >= 12
+#pragma GCC diagnostic pop
+#endif
 
 /* Add padding and return the message digest. */
 


### PR DESCRIPTION
Fix compile warning for SHA1Transform() method under alpine with GCC 12.

Warning:
```
In function 'SHA1Update',
    inlined from 'SHA1Final' at sha1.c:187:9:
sha1.c:144:13: error: 'SHA1Transform' reading 64 bytes from a region of size 0 [-Werror=stringop-overread]
  144 |             SHA1Transform(context->state, &data[i]);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sha1.c:144:13: note: referencing argument 2 of type 'const unsigned char[64]'
sha1.c: In function 'SHA1Final':
sha1.c:56:6: note: in a call to function 'SHA1Transform'
   56 | void SHA1Transform(uint32_t state[5], const unsigned char buffer[64])
      |      ^~~~~~~~~~~~~
```

This warning is a false positive because it has been determined in the loop judgment that there must be 64 chars after position `i`
```c
for ( ; i + 63 < len; i += 64) {
    SHA1Transform(context->state, &data[i]);
}
```

apline daily CI: https://github.com/sundb/redis/actions/runs/3540293593

Reference: https://github.com/libevent/libevent/commit/e1d7d3e40a7fd50348d849046fbfd9bf976e643c