### PR TITLE
Fix sanitizer warning, use offsetof instread of member_offset

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -39,6 +39,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stddef.h>
 #include <string.h>
 #include <time.h>
 #include <limits.h>
@@ -100,12 +101,9 @@ typedef struct redisObject robj;
 #define min(a, b) ((a) < (b) ? (a) : (b))
 #define max(a, b) ((a) > (b) ? (a) : (b))
 
-/* Offset of a member in a struct */
-#define member_offset(struct_name, member_name) ((size_t)&(((struct_name *)0)->member_name))
-
 /* Get the pointer of the outer struct from a member address */
 #define member2struct(struct_name, member_name, member_addr) \
-            ((struct_name *)((uint8_t*)member_addr - member_offset(struct_name, member_name)))
+            ((struct_name *)((char*)member_addr - offsetof(struct_name, member_name)))
 
 /* Error codes */
 #define C_OK                    0


### PR DESCRIPTION
In #11511 we introduced member_offset which has a sanitizer warning:
```
multi.c:390:26: runtime error: member access within null pointer of type 'watchedKey' (aka 'struct watchedKey')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior multi.c:390:26
```

We can use offsetof() from stddef.h. This is part of the standard lib
just to avoid this UB :) Sanitizer should not complain after we change
this.

1. Use offsetof instead of member_offset, so we can delete this now
2. Changed (uint8_t*) cast to (char*).

This does not matter much but according to standard, we are only allowed
to cast pointers to its own type, char* and void*. Let's try to follow
the rules.

This change was suggested by tezc and the comments is also from him.