### PR TITLE
Reintroduce lua argument cache in luaRedisGenericCommand removed in v7.0 

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1378,8 +1378,7 @@ void freeClientArgv(client *c) {
     c->cmd = NULL;
     c->argv_len_sum = 0;
     c->argv_len = 0;
-    if(c->argv)
-        zfree(c->argv);
+    zfree(c->argv);
     c->argv = NULL;
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1378,7 +1378,8 @@ void freeClientArgv(client *c) {
     c->cmd = NULL;
     c->argv_len_sum = 0;
     c->argv_len = 0;
-    zfree(c->argv);
+    if(c->argv)
+        zfree(c->argv);
     c->argv = NULL;
 }
 

--- a/src/script.c
+++ b/src/script.c
@@ -513,22 +513,18 @@ static int scriptVerifyAllowStale(client *c, sds *err) {
  * up to the engine to take and parse.
  * The err out variable is set only if error occurs and describe the error.
  * If err is set on reply is written to the run_ctx client. */
-void scriptCall(scriptRunCtx *run_ctx, robj* *argv, int argc, sds *err) {
+void scriptCall(scriptRunCtx *run_ctx, sds *err) {
     client *c = run_ctx->c;
 
     /* Setup our fake client for command execution */
-    c->argv = argv;
-    c->argc = argc;
     c->user = run_ctx->original_client->user;
 
     /* Process module hooks */
     moduleCallCommandFilters(c);
-    argv = c->argv;
-    argc = c->argc;
 
-    struct redisCommand *cmd = lookupCommand(argv, argc);
+    struct redisCommand *cmd = lookupCommand(c->argv, c->argc);
     c->cmd = c->lastcmd = c->realcmd = cmd;
-    if (scriptVerifyCommandArity(cmd, argc, err) != C_OK) {
+    if (scriptVerifyCommandArity(cmd, c->argc, err) != C_OK) {
         goto error;
     }
 

--- a/src/script.h
+++ b/src/script.h
@@ -98,7 +98,7 @@ int scriptPrepareForRun(scriptRunCtx *r_ctx, client *engine_client, client *call
 void scriptResetRun(scriptRunCtx *r_ctx);
 int scriptSetResp(scriptRunCtx *r_ctx, int resp);
 int scriptSetRepl(scriptRunCtx *r_ctx, int repl);
-void scriptCall(scriptRunCtx *r_ctx, robj **argv, int argc, sds *err);
+void scriptCall(scriptRunCtx *r_ctx, sds *err);
 int scriptInterrupt(scriptRunCtx *r_ctx);
 void scriptKill(client *c, int is_eval);
 int scriptIsRunning();

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -980,6 +980,7 @@ cleanup:
     /* Clean up. Command code may have changed argv/argc so we use the
      * argv/argc of the client instead of the local variables. */
     freeLuaRedisArgv(c->argv, &c->argc);
+    freeClientArgv(c);
     c->user = NULL;
     inuse--;
 

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -1148,7 +1148,6 @@ static int luaRedisAclCheckCmdPermissionsCommand(lua_State *lua) {
     }
 
     while (argc--) decrRefCount(argv[argc]);
-    zfree(argv);
     if (raise_error)
         return luaError(lua);
     else

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -783,6 +783,28 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
 /* ---------------------------------------------------------------------------
  * Lua redis.* functions implementations.
  * ------------------------------------------------------------------------- */
+#define LUA_CMD_OBJCACHE_SIZE 32
+#define LUA_CMD_OBJCACHE_MAX_LEN 64
+static robj ** getLuaArgv(){
+    static robj **argv = NULL;
+    return argv;
+}
+
+static int getArgvSize(){
+    static int argv_size = 0;
+    return argv_size;
+}
+
+static robj ** getLuaCachedObjects(){
+    static robj *cached_objects[LUA_CMD_OBJCACHE_SIZE];
+    return cached_objects;
+}
+
+
+static size_t * getLuaCachedObjectsLen(){
+    static size_t cached_objects_len[LUA_CMD_OBJCACHE_SIZE];
+    return cached_objects_len;
+}
 
 static robj **luaArgsToRedisArgv(lua_State *lua, int *argc) {
     int j;
@@ -792,9 +814,17 @@ static robj **luaArgsToRedisArgv(lua_State *lua, int *argc) {
         luaPushError(lua, "Please specify at least one argument for this redis lib call");
         return NULL;
     }
+    /* Cached across calls. */
+    robj **argv = getLuaArgv();
+    int argv_size = getArgvSize();
+    robj **cached_objects = getLuaCachedObjects();
+    size_t *cached_objects_len = getLuaCachedObjectsLen();
 
     /* Build the arguments vector */
-    robj **argv = zcalloc(sizeof(robj*) * *argc);
+    if (argv_size < *argc) {
+        argv = zrealloc(argv,sizeof(robj*)* *argc);
+        argv_size = *argc;
+    }
 
     for (j = 0; j < *argc; j++) {
         char *obj_s;
@@ -812,8 +842,18 @@ static robj **luaArgsToRedisArgv(lua_State *lua, int *argc) {
             obj_s = (char*)lua_tolstring(lua,j+1,&obj_len);
             if (obj_s == NULL) break; /* Not a string. */
         }
-
-        argv[j] = createStringObject(obj_s, obj_len);
+        /* Try to use a cached object. */
+        if (j < LUA_CMD_OBJCACHE_SIZE && cached_objects[j] &&
+            cached_objects_len[j] >= obj_len)
+        {
+            sds s = cached_objects[j]->ptr;
+            argv[j] = cached_objects[j];
+            cached_objects[j] = NULL;
+            memcpy(s,obj_s,obj_len+1);
+            sdssetlen(s, obj_len);
+        } else {
+            argv[j] = createStringObject(obj_s, obj_len);
+        }
     }
 
     /* Pop all arguments from the stack, we do not need them anymore
@@ -829,7 +869,6 @@ static robj **luaArgsToRedisArgv(lua_State *lua, int *argc) {
             decrRefCount(argv[j]);
             j--;
         }
-        zfree(argv);
         luaPushError(lua, "Lua redis lib command arguments must be strings or integers");
         return NULL;
     }
@@ -837,21 +876,56 @@ static robj **luaArgsToRedisArgv(lua_State *lua, int *argc) {
     return argv;
 }
 
-#define LUA_CMD_OBJCACHE_SIZE 32
-#define LUA_CMD_OBJCACHE_MAX_LEN 64
+void freeLuaRedisArgv(client *c){
+    int j;
+    /* Cached across calls. */
+    robj **argv = getLuaArgv();
+    int argv_size = getArgvSize();
+    robj **cached_objects = getLuaCachedObjects();
+    size_t *cached_objects_len = getLuaCachedObjectsLen();
+    for (j = 0; j < c->argc; j++) {
+        robj *o = c->argv[j];
+
+        /* Try to cache the object in the cached_objects array.
+         * The object must be small, SDS-encoded, and with refcount = 1
+         * (we must be the only owner) for us to cache it. */
+        if (j < LUA_CMD_OBJCACHE_SIZE &&
+            o->refcount == 1 &&
+            (o->encoding == OBJ_ENCODING_RAW ||
+             o->encoding == OBJ_ENCODING_EMBSTR) &&
+            sdslen(o->ptr) <= LUA_CMD_OBJCACHE_MAX_LEN)
+        {
+            sds s = o->ptr;
+            if (cached_objects[j]) decrRefCount(cached_objects[j]);
+            cached_objects[j] = o;
+            cached_objects_len[j] = sdsalloc(s);
+        } else {
+            decrRefCount(o);
+        }
+    }
+    if (c->argv != argv) {
+        zfree(c->argv);
+        argv = NULL;
+        argv_size = 0;
+    }
+    c->argv = NULL;
+    c->argc = 0;
+}
+
 static int luaRedisGenericCommand(lua_State *lua, int raise_error) {
-    int j, argc = lua_gettop(lua);
+    int j;
     scriptRunCtx* rctx = luaGetFromRegistry(lua, REGISTRY_RUN_CTX_NAME);
     serverAssert(rctx); /* Only supported inside script invocation */
     sds err = NULL;
     client* c = rctx->c;
     sds reply;
 
-    /* Cached across calls. */
-    static robj **argv = NULL;
-    static int argv_size = 0;
-    static robj *cached_objects[LUA_CMD_OBJCACHE_SIZE];
-    static size_t cached_objects_len[LUA_CMD_OBJCACHE_SIZE];
+    int argc;
+    robj **argv = luaArgsToRedisArgv(lua, &argc);
+    if (argv == NULL) {
+        return raise_error ? luaError(lua) : 1;
+    }
+
     static int inuse = 0;   /* Recursive calls detection. */
 
     /* By using Lua debug hooks it is possible to trigger a recursive call
@@ -867,70 +941,6 @@ static int luaRedisGenericCommand(lua_State *lua, int raise_error) {
         return 1;
     }
     inuse++;
-
-    /* Require at least one argument */
-    if (argc == 0) {
-        luaPushError(lua,
-            "Please specify at least one argument for redis.call()");
-        inuse--;
-        return raise_error ? luaError(lua) : 1;
-    }
-
-    /* Build the arguments vector */
-    if (argv_size < argc) {
-        argv = zrealloc(argv,sizeof(robj*)*argc);
-        argv_size = argc;
-    }
-
-    for (j = 0; j < argc; j++) {
-        char *obj_s;
-        size_t obj_len;
-        char dbuf[64];
-
-        if (lua_type(lua,j+1) == LUA_TNUMBER) {
-            /* We can't use lua_tolstring() for number -> string conversion
-             * since Lua uses a format specifier that loses precision. */
-            lua_Number num = lua_tonumber(lua,j+1);
-
-            obj_len = snprintf(dbuf,sizeof(dbuf),"%.17g",(double)num);
-            obj_s = dbuf;
-        } else {
-            obj_s = (char*)lua_tolstring(lua,j+1,&obj_len);
-            if (obj_s == NULL) break; /* Not a string. */
-        }
-
-        /* Try to use a cached object. */
-        if (j < LUA_CMD_OBJCACHE_SIZE && cached_objects[j] &&
-            cached_objects_len[j] >= obj_len)
-        {
-            sds s = cached_objects[j]->ptr;
-            argv[j] = cached_objects[j];
-            cached_objects[j] = NULL;
-            memcpy(s,obj_s,obj_len+1);
-            sdssetlen(s, obj_len);
-        } else {
-            argv[j] = createStringObject(obj_s, obj_len);
-        }
-    }
-
-    /* Check if one of the arguments passed by the Lua script
-     * is not a string or an integer (lua_isstring() return true for
-     * integers as well). */
-    if (j != argc) {
-        j--;
-        while (j >= 0) {
-            decrRefCount(argv[j]);
-            j--;
-        }
-        luaPushError(lua,
-            "Lua redis() command arguments must be strings or integers");
-        inuse--;
-        return raise_error ? luaError(lua) : 1;
-    }
-
-    /* Pop all arguments from the stack, we do not need them anymore
-     * and this way we guaranty we will have room on the stack for the result. */
-    lua_pop(lua, argc);
 
     /* Log the command if debugging is active. */
     if (ldbIsEnabled()) {
@@ -993,37 +1003,9 @@ static int luaRedisGenericCommand(lua_State *lua, int raise_error) {
 cleanup:
     /* Clean up. Command code may have changed argv/argc so we use the
      * argv/argc of the client instead of the local variables. */
-    for (j = 0; j < c->argc; j++) {
-        robj *o = c->argv[j];
-
-        /* Try to cache the object in the cached_objects array.
-         * The object must be small, SDS-encoded, and with refcount = 1
-         * (we must be the only owner) for us to cache it. */
-        if (j < LUA_CMD_OBJCACHE_SIZE &&
-            o->refcount == 1 &&
-            (o->encoding == OBJ_ENCODING_RAW ||
-             o->encoding == OBJ_ENCODING_EMBSTR) &&
-            sdslen(o->ptr) <= LUA_CMD_OBJCACHE_MAX_LEN)
-        {
-            sds s = o->ptr;
-            if (cached_objects[j]) decrRefCount(cached_objects[j]);
-            cached_objects[j] = o;
-            cached_objects_len[j] = sdsalloc(s);
-        } else {
-            decrRefCount(o);
-        }
-    }
-
-    if (c->argv != argv) {
-        zfree(c->argv);
-        argv = NULL;
-        argv_size = 0;
-    }
-
+    freeLuaRedisArgv(c);
     c->user = NULL;
     inuse--;
-    c->argv = NULL;
-    c->argc = 0;
 
     if (raise_error) {
         /* If we are here we should have an error in the stack, in the

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -785,26 +785,12 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
  * ------------------------------------------------------------------------- */
 #define LUA_CMD_OBJCACHE_SIZE 32
 #define LUA_CMD_OBJCACHE_MAX_LEN 64
-static robj ** getLuaArgv(){
-    static robj **argv = NULL;
-    return argv;
-}
 
-static int getArgvSize(){
-    static int argv_size = 0;
-    return argv_size;
-}
-
-static robj ** getLuaCachedObjects(){
-    static robj *cached_objects[LUA_CMD_OBJCACHE_SIZE];
-    return cached_objects;
-}
-
-
-static size_t * getLuaCachedObjectsLen(){
-    static size_t cached_objects_len[LUA_CMD_OBJCACHE_SIZE];
-    return cached_objects_len;
-}
+/* Cached across calls. */
+static robj **argv = NULL;
+static int argv_size = 0;
+static robj *cached_objects[LUA_CMD_OBJCACHE_SIZE];
+static size_t cached_objects_len[LUA_CMD_OBJCACHE_SIZE];
 
 static robj **luaArgsToRedisArgv(lua_State *lua, int *argc) {
     int j;
@@ -814,11 +800,6 @@ static robj **luaArgsToRedisArgv(lua_State *lua, int *argc) {
         luaPushError(lua, "Please specify at least one argument for this redis lib call");
         return NULL;
     }
-    /* Cached across calls. */
-    robj **argv = getLuaArgv();
-    int argv_size = getArgvSize();
-    robj **cached_objects = getLuaCachedObjects();
-    size_t *cached_objects_len = getLuaCachedObjectsLen();
 
     /* Build the arguments vector */
     if (argv_size < *argc) {
@@ -878,11 +859,6 @@ static robj **luaArgsToRedisArgv(lua_State *lua, int *argc) {
 
 void freeLuaRedisArgv(client *c){
     int j;
-    /* Cached across calls. */
-    robj **argv = getLuaArgv();
-    int argv_size = getArgvSize();
-    robj **cached_objects = getLuaCachedObjects();
-    size_t *cached_objects_len = getLuaCachedObjectsLen();
     for (j = 0; j < c->argc; j++) {
         robj *o = c->argv[j];
 

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -980,7 +980,6 @@ cleanup:
     /* Clean up. Command code may have changed argv/argc so we use the
      * argv/argc of the client instead of the local variables. */
     freeLuaRedisArgv(c->argv, &c->argc);
-    freeClientArgv(c);
     c->user = NULL;
     inuse--;
 

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -783,7 +783,7 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
 /* ---------------------------------------------------------------------------
  * Lua redis.* functions implementations.
  * ------------------------------------------------------------------------- */
-void freeLuaRedisArgv(robj **argv, int* argc);
+void freeLuaRedisArgv(robj **argv, int argc);
 
 /* Cached argv array across calls. */
 static robj **lua_argv = NULL;
@@ -848,7 +848,7 @@ static robj **luaArgsToRedisArgv(lua_State *lua, int *argc) {
      * is not a string or an integer (lua_isstring() return true for
      * integers as well). */
     if (j != *argc) {
-        freeLuaRedisArgv(lua_argv, &j);
+        freeLuaRedisArgv(lua_argv, j);
         luaPushError(lua, "Lua redis lib command arguments must be strings or integers");
         return NULL;
     }
@@ -856,9 +856,9 @@ static robj **luaArgsToRedisArgv(lua_State *lua, int *argc) {
     return lua_argv;
 }
 
-void freeLuaRedisArgv(robj **argv, int* argc) {
+void freeLuaRedisArgv(robj **argv, int argc) {
     int j;
-    for (j = 0; j < *argc; j++) {
+    for (j = 0; j < argc; j++) {
         robj *o = argv[j];
 
         /* Try to cache the object in the lua_args_cached_objects array.
@@ -977,7 +977,7 @@ static int luaRedisGenericCommand(lua_State *lua, int raise_error) {
 cleanup:
     /* Clean up. Command code may have changed argv/argc so we use the
      * argv/argc of the client instead of the local variables. */
-    freeLuaRedisArgv(c->argv, &c->argc);
+    freeLuaRedisArgv(c->argv, c->argc);
     c->argc = c->argv_len = 0;
     c->user = NULL;
     c->argv = NULL;
@@ -1148,7 +1148,7 @@ static int luaRedisAclCheckCmdPermissionsCommand(lua_State *lua) {
         }
     }
 
-    freeLuaRedisArgv(argv, &argc);
+    freeLuaRedisArgv(argv, argc);
     if (raise_error)
         return luaError(lua);
     else

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -980,6 +980,8 @@ cleanup:
     /* Clean up. Command code may have changed argv/argc so we use the
      * argv/argc of the client instead of the local variables. */
     freeLuaRedisArgv(c->argv, &c->argc);
+    c->argv_len_sum = 0;
+    c->argv_len = 0;
     c->user = NULL;
     inuse--;
 

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1956,5 +1956,21 @@ start_server {tags {"scripting"}} {
             r eval {local status, res = pcall(function() return foo end); return 'status: ' .. tostring(status) .. ' result: ' .. res} 0
         ]
     }
+
+    test "LUA test pcall with non string/integer arg" {
+        assert_error "ERR Lua redis lib command arguments must be strings or integers*" {
+            r eval {
+                local x={}
+                return redis.call("ping", x)
+            } 0
+        }
+        # run another command, to make sure the cached argv array survived
+        assert_equal [
+            r eval {
+                local x={}
+                return redis.call("ping", "asdf")
+            } 0
+        ] {asdf}
+    }
 }
 

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1967,7 +1967,6 @@ start_server {tags {"scripting"}} {
         # run another command, to make sure the cached argv array survived
         assert_equal [
             r eval {
-                local x={}
                 return redis.call("ping", "asdf")
             } 0
         ] {asdf}


### PR DESCRIPTION
As discussed in https://github.com/redis/redis/issues/10981#issuecomment-1321070278 this PR re-enables argv argument caching.

This mechanism aims to reduce calls to malloc and free when preparing the arguments the script sends to redis commands.
This is a mechanism was originally implemented in 48c49c4 and 4f68655, and was removed in #10220 (thinking it's not needed and that it has no impact), but it now turns out it was wrong, and it indeed provides some 5% performance improvement.

The implementation is a little bit too simplistic, it assumes consecutive calls use the same size in the same arg index, but that's arguably sufficient since it's only aimed at caching very small things.

We could even consider always pre-allocating args to the full LUA_CMD_OBJCACHE_MAX_LEN (64 bytes) rather than the right size for the argument, that would increase the chance they'll be able to be re-used.
But in some way this is already happening since we're using sdsalloc, which in turn uses s_malloc_usable and takes ownership of the full side of the allocation, so we are padded to the allocator bucket size.

To easily test it:
```
tclsh tests/test_helper.tcl --single unit/scripting
```

Here's the impact using the following benchmark command:

```
memtier_benchmark --command="eval \"redis.call('hset', 'h1', 'k', 'v');redis.call('hset', 'h2', 'k', 'v');return redis.call('ping')\" 0"  - --hide-histogram --test-time 60 --pipeline 10 -x 1
```


### v6.2.6 ~ 222K ops/sec -- 4930d19e70c391750479951022e207e19111eb55 
```
ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Evals      223707.29         8.93841         8.83100        17.53500        21.37500     28400.34 
Totals     223707.29         8.93841         8.83100        17.53500        21.37500     28400.34
```

### Unstable ~ 164K ops/sec -- abc345ad2837cb36ade137982859b6a8666b2735  
```
ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Evals      163821.59        12.20666        12.03100        24.06300        24.31900     20797.66 
Totals     163821.59        12.20666        12.03100        24.06300        24.31900     20797.66 
```

### This PR ~ 184K ops/sec -- 6310ea87d354f8fab35c000237f872f098ff820f  

```
ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Evals      183052.96        10.92378        10.81500        21.37500        25.21500     23239.15 
Totals     183052.96        10.92378        10.81500        21.37500        25.21500     23239.15 
```
