### PR TITLE
Add log message when PID file fails to create

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6117,6 +6117,8 @@ void createPidFile(void) {
     if (fp) {
         fprintf(fp,"%d\n",(int)getpid());
         fclose(fp);
+    } else {
+        serverLog(LL_WARNING, "Failed to write PID file: %s", strerror(errno));
     }
 }
 


### PR DESCRIPTION
Related to https://github.com/redis/redis/issues/11542.

Add an error message when PID file fails to be written. This has historically been considered a best effort failure, but we don't even report the failure.