### PR TITLE
Remove duplicate postExecutionUnitOperation call

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -7373,7 +7373,6 @@ unsigned int delKeysInSlot(unsigned int hashslot) {
         moduleNotifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, server.db[0].id);
         postExecutionUnitOperations();
         decrRefCount(key);
-        postExecutionUnitOperations();
         j++;
         server.dirty++;
     }


### PR DESCRIPTION
Accidentally introduced when merging unstable in #11199