### PR TITLE
Add redis_ prefix for member2struct, avoid redefined warning in FreeBSD

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -387,7 +387,7 @@ void touchWatchedKey(redisDb *db, robj *key) {
     /* Check if we are already watching for this key */
     listRewind(clients,&li);
     while((ln = listNext(&li))) {
-        watchedKey *wk = member2struct(watchedKey, node, ln);
+        watchedKey *wk = redis_member2struct(watchedKey, node, ln);
         client *c = wk->client;
 
         if (wk->expired) {
@@ -440,7 +440,7 @@ void touchAllWatchedKeysInDb(redisDb *emptied, redisDb *replaced_with) {
             if (!clients) continue;
             listRewind(clients,&li);
             while((ln = listNext(&li))) {
-                watchedKey *wk = member2struct(watchedKey, node, ln);
+                watchedKey *wk = redis_member2struct(watchedKey, node, ln);
                 if (wk->expired) {
                     if (!replaced_with || !dictFind(replaced_with->dict, key->ptr)) {
                         /* Expired key now deleted. No logical change. Clear the

--- a/src/server.h
+++ b/src/server.h
@@ -102,7 +102,7 @@ typedef struct redisObject robj;
 #define max(a, b) ((a) > (b) ? (a) : (b))
 
 /* Get the pointer of the outer struct from a member address */
-#define member2struct(struct_name, member_name, member_addr) \
+#define redis_member2struct(struct_name, member_name, member_addr) \
             ((struct_name *)((char*)member_addr - offsetof(struct_name, member_name)))
 
 /* Error codes */


### PR DESCRIPTION
It look like it will generate a warning in FreeBSD:
```
  ./server.h:105:9: warning: 'member2struct' macro redefined [-Wmacro-redefined]
  #define member2struct(struct_name, member_name, member_addr) \
          ^
  /usr/include/sys/param.h:365:9: note: previous definition is here
  #define member2struct(s, m, x)                                          \
          ^
```

Add a `redis_` prefix to it, avoid the warning, introduced in #11511