### PR TITLE
Try to fix a race in psync2 test

### DIFF
--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -304,6 +304,10 @@ start_server {} {
         # In absence of pings, are the instances really able to have
         # the exact same offset?
         $R($master_id) config set repl-ping-replica-period 3600
+        for {set j 0} {$j < 5} {incr j} {
+            if {$j == $master_id} continue
+            $R($j) config set repl-timeout 10000
+        }
         wait_for_condition 500 100 {
             [status $R($master_id) master_repl_offset] == [status $R(0) master_repl_offset] &&
             [status $R($master_id) master_repl_offset] == [status $R(1) master_repl_offset] &&


### PR DESCRIPTION
This test sets the master ping interval to 1 hour, in order to avoid pings in the replicatoin stream incrementing the replication offset, however, it didn't increase the repl-timeout so on slow machines where the test took more than 60 seconds, the replicas would drop and reconnect.

```
*** [err]: PSYNC2: Partial resync after restart using RDB aux fields in tests/integration/psync2.tcl
Replica didn't partial sync
```
The test would detect 4 additional partial syncs where it expects only one.