### PR TITLE
changing addReplySds and sdscat to addReplyStatusLength() within luaReplyToRedisReply()

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -654,14 +654,14 @@ void addReplyErrorExpireTime(client *c) {
                         c->cmd->fullname);
 }
 
-void addReplySimpleString(client *c, const char *s, size_t len) {
+void addReplyStatusLength(client *c, const char *s, size_t len) {
     addReplyProto(c,"+",1);
     addReplyProto(c,s,len);
     addReplyProto(c,"\r\n",2);
 }
 
 void addReplyStatus(client *c, const char *status) {
-    addReplySimpleString(c,status,strlen(status));
+    addReplyStatusLength(c,status,strlen(status));
 }
 
 void addReplyStatusFormat(client *c, const char *fmt, ...) {
@@ -669,7 +669,7 @@ void addReplyStatusFormat(client *c, const char *fmt, ...) {
     va_start(ap,fmt);
     sds s = sdscatvprintf(sdsempty(),fmt,ap);
     va_end(ap);
-    addReplySimpleString(c,s,sdslen(s));
+    addReplyStatusLength(c,s,sdslen(s));
     sdsfree(s);
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -654,14 +654,14 @@ void addReplyErrorExpireTime(client *c) {
                         c->cmd->fullname);
 }
 
-void addReplyStatusLength(client *c, const char *s, size_t len) {
+void addReplySimpleString(client *c, const char *s, size_t len) {
     addReplyProto(c,"+",1);
     addReplyProto(c,s,len);
     addReplyProto(c,"\r\n",2);
 }
 
 void addReplyStatus(client *c, const char *status) {
-    addReplyStatusLength(c,status,strlen(status));
+    addReplySimpleString(c,status,strlen(status));
 }
 
 void addReplyStatusFormat(client *c, const char *fmt, ...) {
@@ -669,7 +669,7 @@ void addReplyStatusFormat(client *c, const char *fmt, ...) {
     va_start(ap,fmt);
     sds s = sdscatvprintf(sdsempty(),fmt,ap);
     va_end(ap);
-    addReplyStatusLength(c,s,sdslen(s));
+    addReplySimpleString(c,s,sdslen(s));
     sdsfree(s);
 }
 

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -653,10 +653,7 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
         if (t == LUA_TSTRING) {
             sds ok = sdsnew(lua_tostring(lua,-1));
             sdsmapchars(ok,"\r\n","  ",2);
-            const size_t msgLen = strlen(ok);
-            addReplyProto(c,"+",1);
-            addReplyProto(c,ok,msgLen);
-            addReplyProto(c,"\r\n",2);
+            addReplyStatusLength(ok, strlen(ok));
             sdsfree(ok);
             lua_pop(lua,2);
             return;

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -653,7 +653,7 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
         if (t == LUA_TSTRING) {
             sds ok = sdsnew(lua_tostring(lua,-1));
             sdsmapchars(ok,"\r\n","  ",2);
-            addReplySimpleString(c, ok, strlen(ok));
+            addReplySimpleString(c, ok, sdslen(ok));
             sdsfree(ok);
             lua_pop(lua,2);
             return;

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -653,7 +653,7 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
         if (t == LUA_TSTRING) {
             sds ok = sdsnew(lua_tostring(lua,-1));
             sdsmapchars(ok,"\r\n","  ",2);
-            addReplyStatusLength(ok, strlen(ok));
+            addReplySimpleString(c, ok, strlen(ok));
             sdsfree(ok);
             lua_pop(lua,2);
             return;

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -653,7 +653,10 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
         if (t == LUA_TSTRING) {
             sds ok = sdsnew(lua_tostring(lua,-1));
             sdsmapchars(ok,"\r\n","  ",2);
-            addReplySds(c,sdscatprintf(sdsempty(),"+%s\r\n",ok));
+            const size_t msgLen = strlen(ok);
+            addReplyProto(c,"+",1);
+            addReplyProto(c,ok,msgLen);
+            addReplyProto(c,"\r\n",2);
             sdsfree(ok);
             lua_pop(lua,2);
             return;

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -653,7 +653,7 @@ static void luaReplyToRedisReply(client *c, client* script_client, lua_State *lu
         if (t == LUA_TSTRING) {
             sds ok = sdsnew(lua_tostring(lua,-1));
             sdsmapchars(ok,"\r\n","  ",2);
-            addReplySimpleString(c, ok, sdslen(ok));
+            addReplyStatusLength(c, ok, sdslen(ok));
             sdsfree(ok);
             lua_pop(lua,2);
             return;

--- a/src/server.h
+++ b/src/server.h
@@ -2499,6 +2499,7 @@ void addReplyBulkCString(client *c, const char *s);
 void addReplyBulkCBuffer(client *c, const void *p, size_t len);
 void addReplyBulkLongLong(client *c, long long ll);
 void addReply(client *c, robj *obj);
+void addReplySimpleString(client *c, const char *s, size_t len);
 void addReplySds(client *c, sds s);
 void addReplyBulkSds(client *c, sds s);
 void setDeferredReplyBulkSds(client *c, void *node, sds s);

--- a/src/server.h
+++ b/src/server.h
@@ -2499,7 +2499,7 @@ void addReplyBulkCString(client *c, const char *s);
 void addReplyBulkCBuffer(client *c, const void *p, size_t len);
 void addReplyBulkLongLong(client *c, long long ll);
 void addReply(client *c, robj *obj);
-void addReplySimpleString(client *c, const char *s, size_t len);
+void addReplyStatusLength(client *c, const char *s, size_t len);
 void addReplySds(client *c, sds s);
 void addReplyBulkSds(client *c, sds s);
 void setDeferredReplyBulkSds(client *c, void *node, sds s);


### PR DESCRIPTION
profiling EVALSHA after the merge of https://github.com/redis/redis/pull/11521 ( commit 7dfd7b9197bbe216912049eebecbda3f1684925e ) we can see that luaReplyToRedisReply takes 8.73% out of the 56.90% of luaCallFunction CPU cycles. The new approach drops  luaReplyToRedisReply CPU cycles to 3.77%                                                                                                                                           

![image](https://user-images.githubusercontent.com/5832149/204578761-105174db-a7c4-4f05-a7b8-6b8f41bf8660.png)

using addReplyStatusLength instead of directly composing the protocol to avoid sdscatprintf and addReplySds ( which imply multiple sdslen calls ) we get the following improvement on the overall ops/sec:

```
redis-cli SCRIPT load "redis.call('hset', 'h1', 'k', 'v');redis.call('hset', 'h2', 'k', 'v');return redis.call('ping')"
memtier_benchmark --command="EVALSHA 7cecb99fd9091d8e66d5cccf8979cf3aec5c4951 0" --hide-histogram --test-time 60 --pipeline 10 -x 3
memtier_benchmark --command="eval \"redis.call('hset', 'h1', 'k', 'v');redis.call('hset', 'h2', 'k', 'v');return redis.call('ping')\" 0"  --hide-histogram --test-time 60 --pipeline 10 -x 3
```


COMMAND | 6.2.6 | unstable ( 7dfd7b9197bbe216912049eebecbda3f1684925e ) | this PR ( 20403fa0634b6a4975f98cdd61587012a23ab657 ) | % Improvement vs unstable | % Drop vs 6.2.6
-- | -- | -- | -- | -- | --
EVAL | 223744 | 187298 | 198282 | 5.86% | -11.38%
EVALSHA | 264411 | 207848 | 221750 | 6.69% | -16.13%


