### PR TITLE
When converting a set to dict, presize for one more element to be added

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1221,6 +1221,15 @@ size_t lpBytes(unsigned char *lp) {
     return lpGetTotalBytes(lp);
 }
 
+/* Returns the size of a listpack consisting of an integer repeated 'rep' times. */
+size_t lpEstimateBytesRepeatedInteger(long long lval, unsigned long rep) {
+    uint64_t enclen;
+    unsigned char intenc[LP_MAX_INT_ENCODING_LEN];
+    lpEncodeIntegerGetType(lval, intenc, &enclen);
+    unsigned long backlen = lpEncodeBacklen(NULL, enclen);
+    return LP_HDR_SIZE + (enclen + backlen) * rep + 1;
+}
+
 /* Seek the specified element and returns the pointer to the seeked element.
  * Positive indexes specify the zero-based element to seek from the head to
  * the tail, negative indexes specify elements starting from the tail, where

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -82,6 +82,7 @@ unsigned char *lpLast(unsigned char *lp);
 unsigned char *lpNext(unsigned char *lp, unsigned char *p);
 unsigned char *lpPrev(unsigned char *lp, unsigned char *p);
 size_t lpBytes(unsigned char *lp);
+size_t lpEstimateBytesRepeatedInteger(long long lval, unsigned long rep);
 unsigned char *lpSeek(unsigned char *lp, long index);
 typedef int (*listpackValidateEntryCB)(unsigned char *p, unsigned int head_count, void *userdata);
 int lpValidateIntegrity(unsigned char *lp, size_t size, int deep,

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1875,14 +1875,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                      * of many small ones. It's OK since lpSafeToAdd doesn't
                      * care about individual elements, only the total size. */
                     setTypeConvert(o, OBJ_ENCODING_LISTPACK);
-                } else {
-                    setTypeConvert(o,OBJ_ENCODING_HT);
-                    if (dictTryExpand(o->ptr,len) != DICT_OK) {
-                        rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)len);
-                        sdsfree(sdsele);
-                        decrRefCount(o);
-                        return NULL;
-                    }
+                } else if (setTypeConvertAndExpand(o, OBJ_ENCODING_HT, len, 0) != C_OK) {
+                    rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)len);
+                    sdsfree(sdsele);
+                    decrRefCount(o);
+                    return NULL;
                 }
             }
 
@@ -1901,15 +1898,12 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                         return NULL;
                     }
                     o->ptr = lpAppend(o->ptr, (unsigned char *)sdsele, elelen);
-                } else {
-                    setTypeConvert(o, OBJ_ENCODING_HT);
-                    if (dictTryExpand(o->ptr, len) != DICT_OK) {
-                        rdbReportCorruptRDB("OOM in dictTryExpand %llu",
-                                            (unsigned long long)len);
-                        sdsfree(sdsele);
-                        decrRefCount(o);
-                        return NULL;
-                    }
+                } else if (setTypeConvertAndExpand(o, OBJ_ENCODING_HT, len, 0) != C_OK) {
+                    rdbReportCorruptRDB("OOM in dictTryExpand %llu",
+                                        (unsigned long long)len);
+                    sdsfree(sdsele);
+                    decrRefCount(o);
+                    return NULL;
                 }
             }
 

--- a/src/server.h
+++ b/src/server.h
@@ -3021,6 +3021,7 @@ int setTypeRandomElement(robj *setobj, char **str, size_t *len, int64_t *llele);
 unsigned long setTypeRandomElements(robj *set, unsigned long count, robj *aux_set);
 unsigned long setTypeSize(const robj *subject);
 void setTypeConvert(robj *subject, int enc);
+int setTypeConvertAndExpand(robj *setobj, int enc, unsigned long cap, int panic);
 robj *setTypeDup(robj *o);
 
 /* Hash data type */

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -174,7 +174,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
                 return 1;
             }
         } else {
-            /* Check if listpack encoding is possible. */
+            /* Check if listpack encoding is safe not to cross any threshold. */
             size_t maxelelen = 0, totsize = 0;
             unsigned long n = intsetLen(set->ptr);
             if (n != 0) {

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -477,7 +477,7 @@ void setTypeConvert(robj *setobj, int enc) {
         sds element;
 
         /* Presize the dict to avoid rehashing */
-        dictExpand(d, setTypeSize(setobj));
+        dictExpand(d, setTypeSize(setobj) + 1);
 
         /* To add the elements we extract integers and create redis objects */
         si = setTypeInitIterator(setobj);

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -470,7 +470,7 @@ unsigned long setTypeSize(const robj *subject) {
  * to a hash table) is presized to hold the number of elements in the original
  * set. */
 void setTypeConvert(robj *setobj, int enc) {
-    setTypeConvertAndPresize(setobj, enc, setTypeSize(setobj), 1);
+    setTypeConvertAndExpand(setobj, enc, setTypeSize(setobj), 1);
 }
 
 /* Converts a set to the specified encoding, pre-sizing it for 'cap' elements.

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -516,7 +516,7 @@ int setTypeConvertAndExpand(robj *setobj, int enc, unsigned long cap, int panic)
     } else if (enc == OBJ_ENCODING_LISTPACK) {
         /* Preallocate the minimum two bytes per element (enc/value + backlen) */
         size_t estcap = cap * 2;
-        if (setobj->encoding == OBJ_ENCODING_INTSET) {
+        if (setobj->encoding == OBJ_ENCODING_INTSET && setTypeSize(setobj) > 0) {
             /* If we're converting from intset, we have a better estimate. */
             size_t s1 = lpEstimateBytesRepeatedInteger(intsetMin(setobj->ptr), cap);
             size_t s2 = lpEstimateBytesRepeatedInteger(intsetMax(setobj->ptr), cap);


### PR DESCRIPTION
In most cases when a listpack or intset is converted to a dict, the conversion is trigged when adding an element. The extra element is added after conversion to dict (in all cases except when the conversion is triggered by set-max-intset-entries being reached).

If set-max-listpack-entries is set to a power of two, let's say 128, when adding the 129th element, the 128 element listpack is first converted to a dict with a hashtable presized for 128 elements. After converting to dict, the 129th element is added to the dict which immediately triggers incremental rehashing to size 256.

This commit instead presizes the dict to one more element, with the assumtion that conversion to dict is followed by adding another element, so the dict doesn't immediately need rehashing.