### PR TITLE
GEOSEARCH BYBOX: Simplified haversine distance formula when longitude diff is 0

### DIFF
--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -219,7 +219,7 @@ GeoHashFix52Bits geohashAlign52Bits(const GeoHashBits hash) {
 /* Calculate distance using simplified haversine great circle distance formula.
  * Given longitude diff is 0 the asin(sqrt(a)) on the haversine is asin(sin(abs(u))).
  * arcsin(sin(x)) equal to x when x ∈[−𝜋/2,𝜋/2]. Given latitude is between [−𝜋/2,𝜋/2]
- * we can simplifiy arcsin(sin(x)) to x.
+ * we can simplify arcsin(sin(x)) to x.
  */
 double geohashGetLatDistance(double lat1d, double lat2d) {
     return EARTH_RADIUS_IN_METERS * fabs(deg_rad(lat2d) - deg_rad(lat1d));

--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -227,19 +227,18 @@ double geohashGetLatDistance(double lat1d, double lat2d) {
 
 /* Calculate distance using haversine great circle distance formula. */
 double geohashGetDistance(double lon1d, double lat1d, double lon2d, double lat2d) {
-    const double lon1r = deg_rad(lon1d);
-    const double lon2r = deg_rad(lon2d);
-    const double v = sin((lon2r - lon1r) / 2);
-    /* if v == 0 we can avoid doing expensive math */
-    if (v != 0.0){
-        const double lat1r = deg_rad(lat1d);
-        const double lat2r = deg_rad(lat2d);
-        double a = cos(lat1r) * cos(lat2r) * v * v;
-        const double u = sin((lat2r - lat1r) / 2);
-        a += (u * u);
-        return 2.0 * EARTH_RADIUS_IN_METERS * asin(sqrt(a));
-    }
-    return geohashGetLatDistance(lat1d, lat2d);
+    double lat1r, lon1r, lat2r, lon2r, u, v, a;
+    lon1r = deg_rad(lon1d);
+    lon2r = deg_rad(lon2d);
+    v = sin((lon2r - lon1r) / 2);
+    /* if v == 0 we can avoid doing expensive math when lons are practically the same */
+    if (v == 0.0)
+        return geohashGetLatDistance(lat1d, lat2d);
+    lat1r = deg_rad(lat1d);
+    lat2r = deg_rad(lat2d);
+    u = sin((lat2r - lat1r) / 2);
+    a = u * u + cos(lat1r) * cos(lat2r) * v * v;
+    return 2.0 * EARTH_RADIUS_IN_METERS * asin(sqrt(a));
 }
 
 int geohashGetDistanceIfInRadius(double x1, double y1,


### PR DESCRIPTION
This is take 2 of `GEOSEARCH BYBOX` optimizations based on haversine distance formula when longitude diff is 0. The first one was in https://github.com/redis/redis/pull/11535 . 

- Given longitude diff is 0 the asin(sqrt(a)) on the haversine is asin(sin(abs(u))).
- arcsin(sin(x)) equal to x when x ∈[−𝜋/2,𝜋/2]. 
- Given latitude is between [−𝜋/2,𝜋/2] we can simplifiy arcsin(sin(x)) to x.

To test it we can simply focus on the geo.tcl 

```
tclsh tests/test_helper.tcl --single unit/geo
```

Notice that this logic is covered/tested in the "GEOSEARCH box edges fuzzy test" scenario. 


**On the sample dataset with 60M datapoints, we've measured 55% increase in the achievable ops/sec.**

We can benchmark this improvement using the following dataset with 60M datapoints on the GEO key. https://s3.us-east-2.amazonaws.com/redis.benchmarks.spec/datasets/geopoint/dump.rdb


and command: 
```
memtier_benchmark -c 1 -t 1 --pipeline 1 --test-time 60 --command "GEOSEARCH key FROMLONLAT 7 55 BYBOX 200 200 KM" --hide-histogram
```

## unstable ( 61c85a2b2081dffaf45eb8c6b7754b8d9a80c60d )

```
ALL STATS
=====================================================================================================
Type            Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
-----------------------------------------------------------------------------------------------------
Geosearchs        32.90        30.38723        30.20700        34.04700        35.32700      4922.83 
Totals            32.90        30.38723        30.20700        34.04700        35.32700      4922.83 
```


## This PR

```
ALL STATS
=====================================================================================================
Type            Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
-----------------------------------------------------------------------------------------------------
Geosearchs        51.20        19.51808        19.45500        22.01500        23.03900      7662.12 
Totals            51.20        19.51808        19.45500        22.01500        23.03900      7662.12 
```