### PR TITLE
Optimize the performance of msetnx command by call lookupkey only once

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -553,6 +553,7 @@ void mgetCommand(client *c) {
 
 void msetGenericCommand(client *c, int nx) {
     int j;
+    int setkey_flags = 0;
 
     if ((c->argc % 2) == 0) {
         addReplyErrorArity(c);
@@ -568,11 +569,12 @@ void msetGenericCommand(client *c, int nx) {
                 return;
             }
         }
+        setkey_flags |= SETKEY_DOESNT_EXIST;
     }
 
     for (j = 1; j < c->argc; j += 2) {
         c->argv[j+1] = tryObjectEncoding(c->argv[j+1]);
-        setKey(c,c->db,c->argv[j],c->argv[j+1],0);
+        setKey(c, c->db, c->argv[j], c->argv[j + 1], setkey_flags);
         notifyKeyspaceEvent(NOTIFY_STRING,"set",c->argv[j],c->db->id);
     }
     server.dirty += (c->argc-1)/2;


### PR DESCRIPTION
This is a small addition to #9640
It improves performance by avoiding double lookup of the the key.