### PR TITLE
 Reduce rewriteClientCommandVector usage on EXPIRE command 

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -651,10 +651,19 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
     } else {
         setExpire(c,c->db,key,when);
         addReply(c,shared.cone);
-        /* Propagate as PEXPIREAT millisecond-timestamp */
-        robj *when_obj = createStringObjectFromLongLong(when);
-        rewriteClientCommandVector(c, 3, shared.pexpireat, key, when_obj);
-        decrRefCount(when_obj);
+        /* Propagate as PEXPIREAT millisecond-timestamp
+         * Only rewrite the command arg if not already PEXPIREAT */
+        if (strcmp(c->argv[0],shared.pexpireat)) {
+            rewriteClientCommandArgument(c,0,shared.pexpireat);
+        }
+
+        /* Avoid creating a string object when it's the same as argv[2] parameter  */
+        if (basetime != 0 || unit == UNIT_SECONDS) {
+            robj *when_obj = createStringObjectFromLongLong(when);
+            rewriteClientCommandArgument(c,2,when_obj);
+            decrRefCount(when_obj);
+        }
+
         signalModifiedKey(c,c->db,key);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);
         server.dirty++;

--- a/src/expire.c
+++ b/src/expire.c
@@ -653,7 +653,7 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         addReply(c,shared.cone);
         /* Propagate as PEXPIREAT millisecond-timestamp
          * Only rewrite the command arg if not already PEXPIREAT */
-        if (strcasecmp(c->argv[0],"pexpireat")) {
+        if (strcasecmp(c->argv[0]->ptr,"pexpireat")) {
             rewriteClientCommandArgument(c,0,shared.pexpireat);
         }
 

--- a/src/expire.c
+++ b/src/expire.c
@@ -653,7 +653,7 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         addReply(c,shared.cone);
         /* Propagate as PEXPIREAT millisecond-timestamp
          * Only rewrite the command arg if not already PEXPIREAT */
-        if (strcasecmp(c->argv[0]->ptr,"pexpireat")) {
+        if (c->cmd != pexpireatCommand) {
             rewriteClientCommandArgument(c,0,shared.pexpireat);
         }
 

--- a/src/expire.c
+++ b/src/expire.c
@@ -653,7 +653,7 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         addReply(c,shared.cone);
         /* Propagate as PEXPIREAT millisecond-timestamp
          * Only rewrite the command arg if not already PEXPIREAT */
-        if (strcmp(c->argv[0],shared.pexpireat)) {
+        if (strcasecmp(c->argv[0],"pexpireat")) {
             rewriteClientCommandArgument(c,0,shared.pexpireat);
         }
 

--- a/src/expire.c
+++ b/src/expire.c
@@ -653,7 +653,7 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         addReply(c,shared.cone);
         /* Propagate as PEXPIREAT millisecond-timestamp
          * Only rewrite the command arg if not already PEXPIREAT */
-        if (c->cmd != pexpireatCommand) {
+        if (c->cmd->proc != pexpireatCommand) {
             rewriteClientCommandArgument(c,0,shared.pexpireat);
         }
 


### PR DESCRIPTION
As being discussed in https://github.com/redis/redis/issues/10981#issuecomment-1341350192 there is overhead on 7.0 EXPIRE command that is not present on 6.2.7. 

We can see that on the unstable profile there are around 7% of CPU cycles spent on rewriteClientCommandVector that are not present on 6.2.7. This was introduced in https://github.com/redis/redis/pull/8474.
This PR reduces the overhead by using 2X rewriteClientCommandArgument instead of rewriteClientCommandVector. In this scenario rewriteClientCommandVector creates 4 arguments. the above usage of rewriteClientCommandArgument reduces the overhead in half. 
This PR should also improve PEXPIREAT performance by avoiding at all rewriteClientCommandArgument usage. 

6.2.7 profile:
﻿﻿
![image](https://user-images.githubusercontent.com/5832149/206596796-68e99132-8fa5-4d16-980e-ea787a838565.png)



unstable profile:
<img width="606" alt="image" src="https://user-images.githubusercontent.com/5832149/206596744-d54ea201-c284-4b66-9fd7-aebf15648ca6.png">


If we populate data as follows:
```
memtier_benchmark --port 6379 --server localhost   --key-minimum=1 --key-maximum 100000 "--data-size" "100" "--command" "HSET __key__ field __value__" "--command-key-pattern" "P" "-c" "50" "-t" "2" "--hide-histogram"
```

And then benchmark:
```
memtier_benchmark  --pipeline 10 --key-minimum=1 --key-maximum 100000 "--data-size" "100" --command "EXPIRE __key__ 3600" --command-key-pattern="R" -c 50 -t 2 --hide-histogram --test-time 180
```

we get the following results on the achievable ops/sec:

test | Version 6.2.7 | unstable branch 8th December 2022 ( 10e4f44dc280dd300009366466cd7d5971191e16 ) | % change unstable vs 6.2.7 | this PR | % change this PR vs 6.2.7
-- | -- | -- | -- | -- | --
EXPIRE ( pipeline 10 ) | 876843 | 770614 | -12.1% | 821241 | -6.3%

