### PR TITLE
solve race in replication test due to ping

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -187,8 +187,6 @@ start_server {tags {"repl external:skip"}} {
     }
 }
 
-
-
 start_server {tags {"repl external:skip"}} {
     r set mykey foo
 

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -187,6 +187,8 @@ start_server {tags {"repl external:skip"}} {
     }
 }
 
+
+
 start_server {tags {"repl external:skip"}} {
     r set mykey foo
 
@@ -226,6 +228,9 @@ start_server {tags {"repl external:skip"}} {
         }
 
         test {FLUSHDB / FLUSHALL should replicate} {
+            # we're attaching to a sub-replica, so we need to stop pings on the real master
+            r -1 config set repl-ping-replica-period 3600
+
             set repl [attach_to_replication_stream]
 
             r -1 set key value


### PR DESCRIPTION
attach_to_replication_stream already stops pings, but it stops them on the server we connect to, and in this case it's a replica, and we need to stop them on the real master.