### PR TITLE
Flush propagation list in active-expire of writable replicas to fix an assertion

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -396,6 +396,8 @@ void expireSlaveKeys(void) {
                     activeExpireCycleTryExpire(server.db+dbid,expire,start))
                 {
                     expired = 1;
+                    /* Propagate the DEL command */
+                    postExecutionUnitOperations();
                 }
 
                 /* If the key was not expired in this DB, we need to set the

--- a/src/expire.c
+++ b/src/expire.c
@@ -396,7 +396,7 @@ void expireSlaveKeys(void) {
                     activeExpireCycleTryExpire(server.db+dbid,expire,start))
                 {
                     expired = 1;
-                    /* Propagate the DEL command */
+                    /* DELs aren't propagated, but modules may want their hooks. */
                     postExecutionUnitOperations();
                 }
 


### PR DESCRIPTION

Make sure to flush also_propagate after expiring from expireSlaveKeys to avoid an assertion in beforeSleep.

Note that this is an edge case that only happens in case volatile keys were created directly on a writable replica, and that anyway nothing is propagated to sub-replicas.

For Redis 7.2, We need to honor the post-execution-unit API and call it after each KSN.