### PR TITLE
Include peer-addr:port and local-addr:port when logging accept errors

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1247,13 +1247,9 @@ void clientAcceptHandler(connection *conn) {
     client *c = connGetPrivateData(conn);
 
     if (connGetState(conn) != CONN_STATE_CONNECTED) {
-        char addr[NET_ADDR_STR_LEN] = {0};
-        char laddr[NET_ADDR_STR_LEN] = {0};
-        connFormatAddr(conn, addr, sizeof(addr), 1);
-        connFormatAddr(conn, laddr, sizeof(addr), 0);
         serverLog(LL_WARNING,
                   "Error accepting a client connection: %s (addr=%s laddr=%s)",
-                  connGetLastError(conn), addr, laddr);
+                  connGetLastError(conn), getClientPeerId(c), getClientSockname(c));
         freeClientAsync(c);
         return;
     }


### PR DESCRIPTION
The logged errors include these on the same format as in CLIENT INFO, e.g. "addr=127.0.0.1:12345 laddr=127.0.0.1:6379".

Issue: #11620