### PR TITLE
fix race in list test with blocking commands

### DIFF
--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1092,6 +1092,11 @@ if {[lindex [r config get proto-max-bulk-len] 1] == 10000000000} {
         assert_equal 1 [write_big_bulk $str_length "bbb"]
         assert_equal [read_big_bulk {r spop myset} yes "aaa"] $str_length
     } {} {large-memory}
+
+    # restore defaults
+    r config set proto-max-bulk-len 536870912
+    r config set client-query-buffer-limit 1073741824
+
 } ;# skip 32bit builds
 }
 } ;# run_solo


### PR DESCRIPTION
I've seen the `BRPOPLPUSH with multiple blocked clients` test hang.
this probably happened because rd2 blocked before rd1 and then it was also released first, and rd1 remained blocked.

```
        r del blist{t} target1{t} target2{t}
        r set target1{t} nolist
        $rd1 brpoplpush blist{t} target1{t} 0
        $rd2 brpoplpush blist{t} target2{t} 0
        r lpush blist{t} foo

        assert_error "WRONGTYPE*" {$rd1 read}
        assert_equal {foo} [$rd2 read]
        assert_equal {foo} [r lrange target2{t} 0 -1]
```
changes:
* added all missing calls for wait_for_blocked_client after issuing blocking commands)
* removed some excessive `after 100`
* fix undetected crossslot error in BRPOPLPUSH test
* rollback changes to proto-max-bulk-len so external tests can be rerun
