### PR TITLE
Harden cluster init

### DIFF
--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -9,7 +9,7 @@ set ::cluster_master_nodes 0
 set ::cluster_replica_nodes 0
 
 # Returns a parsed CLUSTER NODES output as a list of dictionaries.
-proc get_cluster_nodes id {
+proc get_cluster_nodes {id {status "*"}} {
     set lines [split [R $id cluster nodes] "\r\n"]
     set nodes {}
     foreach l $lines {
@@ -28,7 +28,9 @@ proc get_cluster_nodes id {
             linkstate [lindex $args 7] \
             slots [lrange $args 8 end] \
         ]
-        lappend nodes $node
+        if {[string match $status [lindex $args 7]]} {
+            lappend nodes $node
+        }
     }
     return $nodes
 }

--- a/tests/cluster/tests/includes/init-tests.tcl
+++ b/tests/cluster/tests/includes/init-tests.tcl
@@ -43,7 +43,6 @@ test "Cluster nodes hard reset" {
         R $id config set key-load-delay 0
         R $id config set repl-diskless-load disabled
         R $id config set cluster-announce-hostname ""
-        R $id config set cluster-ping-interval 100
         R $id DEBUG DROP-CLUSTER-PACKET-FILTER -1
         R $id config rewrite
     }


### PR DESCRIPTION
Attempt to harden cluster meeting in cluster tests to avoid issues like https://github.com/redis/redis/actions/runs/3708155803/jobs/6285405227.

The best guess I have for the failures is that the cluster meet is timing out. The cluster meet is capped at the node timeout, in this case 3 seconds, which is usually sufficient for a single meet. However, within the span of a couple of seconds we are establishing 760 connections. (20 nodes * 19 partners * 2 links). All of the cluster meets are sent near together, so most of these are happening in a short time span. My guess is that under some scenarios this is stalling the connects and if one initial connection times out, it will never finish.

To try to harden it, this PR does 2 things:
1. Validate each node is able to join before progressing, instead of at the end. This limits the number of ongoing connections being established and puts a little bit of back pressure if it's slow.
2. Validate the connection is actually established, not just exists in the cluster list. Nodes can exist in handshake, but might later get dropped. 

I did some validation dropping the node timeout to 50ms, which was enough to break it before but now it was still able to meet (albeit it's very slow). 