### PR TITLE
Harden init-tests for cluster tests

### DIFF
--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -8,7 +8,8 @@
 set ::cluster_master_nodes 0
 set ::cluster_replica_nodes 0
 
-# Returns a parsed CLUSTER NODES output as a list of dictionaries.
+# Returns a parsed CLUSTER NODES output as a list of dictionaries. Optional status field
+# can be specified to only returns entries that match the provided status.
 proc get_cluster_nodes {id {status "*"}} {
     set lines [split [R $id cluster nodes] "\r\n"]
     set nodes {}

--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -9,7 +9,7 @@ set ::cluster_master_nodes 0
 set ::cluster_replica_nodes 0
 
 # Returns a parsed CLUSTER NODES output as a list of dictionaries.
-proc get_cluster_nodes id {
+proc get_cluster_nodes {id {status "*"}} {
     set lines [split [R $id cluster nodes] "\r\n"]
     set nodes {}
     foreach l $lines {
@@ -28,7 +28,9 @@ proc get_cluster_nodes id {
             linkstate [lindex $args 7] \
             slots [lrange $args 8 end] \
         ]
-        lappend nodes $node
+        if {[string match $status [lindex $args 7]]} {
+            lappend nodes $node
+        }
     }
     return $nodes
 }

--- a/tests/cluster/tests/includes/init-tests.tcl
+++ b/tests/cluster/tests/includes/init-tests.tcl
@@ -48,7 +48,9 @@ test "Cluster nodes hard reset" {
     }
 }
 
-test "Cluster Join and auto-discovery test" {
+# Helper function to attempt to have each node in a cluster
+# meet each other.
+proc join_nodes_in_cluster {} {
     # Join node 0 with 1, 1 with 2, ... and so forth.
     # If auto-discovery works all nodes will know every other node
     # eventually.
@@ -63,10 +65,24 @@ test "Cluster Join and auto-discovery test" {
 
     foreach_redis_id id {
         wait_for_condition 1000 50 {
-            [llength [get_cluster_nodes $id]] == [llength $ids]
+            [llength [get_cluster_nodes $id connected]] == [llength $ids]
         } else {
-            fail "Cluster failed to join into a full mesh."
+            return 0
         }
+    }
+    return 1
+}
+
+test "Cluster Join and auto-discovery test" {
+    # Use multiple attempts since sometimes nodes timeout
+    # while attempting to connect.
+    for {set attempts 3} {$attempts > 0} {incr attempts -1} {
+        if {[join_nodes_in_cluster] == 1} {
+            break
+        }
+    }
+    if {$attempts == 0} {
+        fail "Cluster failed to form full mesh"
     }
 }
 


### PR DESCRIPTION
Attempt to harden cluster meeting in cluster tests to avoid issues like https://github.com/redis/redis/actions/runs/3708155803/jobs/6285405227.
```
Testing unit: 00-base.tcl
23:20:35> Cluster Join and auto-discovery test: FAILED: Cluster failed to join into a full mesh.
```

The best guess I have for the failures is that the cluster meet is timing out. The cluster meet is capped at the node timeout, in this case 3 seconds, which is usually sufficient for a single meet. However, within the span of a couple of seconds we are establishing 760 connections. (20 nodes * 19 partners * 2 links). All of the cluster meets are sent near together, so most of these are happening in a short time span. My guess is that under some scenarios this is stalling the connects and if one initial connection times out, it will never finish.

To try to harden it, this PR does 2 things:
1. Retry up to 3 times to join the cluster. Cluster meet is entirely idempotent, so it should stabilize if we missed a node.
2. Validate the connection is actually established, not just exists in the cluster list. Nodes can exist in handshake, but might later get dropped. 

I did some validation dropping the node timeout to 50ms, which was enough to break it before but now it was still able to meet (albeit it's very slow). 

https://github.com/redis/redis/actions/runs/3723202714
https://github.com/redis/redis/actions/runs/3723202741
https://github.com/redis/redis/actions/runs/3723202766