### PR TITLE
fix flaky latency test

### DIFF
--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -124,6 +124,7 @@ start_server {tags {"latency-monitor needs:latency"}} {
             fail "key wasn't expired"
         }
         assert_match {*expire-cycle*} [r latency latest]
+        r config set latency-monitor-threshold 200
     }
 
     test {LATENCY HISTORY / RESET with wrong event name is fine} {


### PR DESCRIPTION
Fix a flaky test that probably fails on overload timing issues.

This unit starts with
```
    # Set a threshold high enough to avoid spurious latency events.
    r config set latency-monitor-threshold 200
```

but later the test measuring expire event changes the threshold.
this fix is to revert it to 200 after that test.

Got this error (ARM+TLS)
```
*** [err]: LATENCY RESET is able to reset events in tests/unit/latency-monitor.tcl
Expected [r latency latest] eq {} (context: type eval line 3 cmd {assert {[r latency latest] eq {}}} proc ::test)
```