### PR TITLE
Update networking.c

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1804,7 +1804,7 @@ static int _writevToClient(client *c, ssize_t *nwritten) {
         }
 
         iov[iovcnt].iov_base = o->buf + offset;
-        iov[iovcnt].iov_len = o->used - offset;
+        iov[iovcnt].iov_len = (o->used - offset)>(NET_MAX_WRITES_PER_EVENT)?(NET_MAX_WRITES_PER_EVENT):(o->used - offset);
         iov_bytes_len += iov[iovcnt++].iov_len;
         offset = 0;
     }


### PR DESCRIPTION
make it sure: writev just send  the length  from   64KB ~ 128KB bytes，just case big value  (like 100MB value) lead redis hang the writev api too much time,then may lead other client hang timeout.  in fact 6.0 has not check the buffer length  before write it .