### PR TITLE
Fix psync error in redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7705,6 +7705,7 @@ unsigned long long sendSync(redisContext *c, char *out_eof) {
     ssize_t nread;
 
     /* Send the SYNC command. */
+    hi_sdsclear(c->obuf);
     if (cliWriteConn(c, "SYNC\r\n", 6) != 6) {
         fprintf(stderr,"Error writing to master\n");
         exit(1);


### PR DESCRIPTION
This is to fix issue https://github.com/redis/redis/issues/11246 .

`redis-cli` parses the response of `SYNC` to get payload and drop the payload. When `PSYNC` is used, the parsing cannot work and error is raised. 

This patch makes redis-cli ignores the buffered `PSYNC` command and use `SYNC` instead. 