### PR TITLE
Make redis-cli support PSYNC command

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7737,7 +7737,7 @@ unsigned long long sendSync(redisContext *c, int send_sync, char *out_eof, int *
         }
         if (*p == '\n' && p != buf) break;
         if (*p != '\n') p++;
-        if (p >= buf + sizeof(buf)) break;
+        if (p >= buf + sizeof(buf) - 1) break; /* Go back one more char for null-term. */
     }
     *p = '\0';
     if (buf[0] == '-') {
@@ -7762,7 +7762,7 @@ unsigned long long sendSync(redisContext *c, int send_sync, char *out_eof, int *
             }
             if (*p == '\n' && p != buf) break;
             if (*p != '\n') p++;
-            if (p >= buf + sizeof(buf)) break;
+            if (p >= buf + sizeof(buf) - 1) break; /* Go back one more char for null-term. */
         }
         *p = '\0';
 

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7703,7 +7703,7 @@ static ssize_t readConn(redisContext *c, char *buf, size_t len)
  * is unknown, also returns 0 in case a PSYNC +CONTINUE was found (no RDB payload).
  *
  * The out_full_mode parameter if 1 means this is a full sync, if 0 means this is partial mode. */
-unsigned long long sendSync(redisContext *c, char *out_eof, int send_sync, int *out_full_mode) {
+unsigned long long sendSync(redisContext *c, int send_sync, char *out_eof, int *out_full_mode) {
     /* To start we need to send the SYNC command and return the payload.
      * The hiredis client lib does not understand this part of the protocol
      * and we don't want to mess with its buffers, so everything is performed
@@ -7784,7 +7784,7 @@ static void slaveMode(int send_sync) {
     static char lastbytes[RDB_EOF_MARK_SIZE];
     static int usemark = 0;
     static int out_full_mode;
-    unsigned long long payload = sendSync(context, eofmark, send_sync, &out_full_mode);
+    unsigned long long payload = sendSync(context, send_sync, eofmark, &out_full_mode);
     char buf[1024];
     int original_output = config.output;
     char *info = out_full_mode ? "Full resync" : "Partial resync";
@@ -7866,7 +7866,7 @@ static void getRDB(clusterManagerNode *node) {
     static char eofmark[RDB_EOF_MARK_SIZE];
     static char lastbytes[RDB_EOF_MARK_SIZE];
     static int usemark = 0;
-    unsigned long long payload = sendSync(s, eofmark, 1, NULL);
+    unsigned long long payload = sendSync(s, 1, eofmark, NULL);
     char buf[4096];
 
     if (payload == 0) {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7699,8 +7699,8 @@ static ssize_t readConn(redisContext *c, char *buf, size_t len)
  * send_sync if 1 means we will explicitly send SYNC command. If 0 means
  * we will not send SYNC command, will send the command that in c->obuf.
  *
- * returns 0 in case an EOF marker is used.
- * Or returns 0 in case a PSYNC +CONTINUE is used. */
+ * Returns the size of the RDB payload to read, or 0 in case an EOF marker is used and the size
+ * is unknown, also returns 0 in case a PSYNC +CONTINUE was found (no RDB payload). */
 unsigned long long sendSync(redisContext *c, char *out_eof, int send_sync) {
     /* To start we need to send the SYNC command and return the payload.
      * The hiredis client lib does not understand this part of the protocol


### PR DESCRIPTION
The current redis-cli does not support the real PSYNC command, the older
version of redis-cli can support PSYNC is because that we actually issue
the SYNC command instead of PSYNC, so it act like SYNC (always full-sync).
Noted that in this case we will send the SYNC first (triggered by sendSync),
then send the PSYNC (the one in redis-cli input).

Didn't bother to find which version that the order changed, we send PSYNC
first (the one in redis-cli input), and then send the SYNC (the one triggered
by sendSync). So even full-sync is not working anymore, and it will result
this output (mentioned in issue #11246):
```
psync dummy 0
Entering replica output mode...  (press Ctrl-C to quit)
SYNC with master, discarding bytes of bulk transfer until EOF marker...
Error reading RDB payload while SYNCing
```

This PR adds PSYNC support to redis-cli, which can handle +FULLRESYNC and
+CONTINUE responses, and some examples will follow.

SYNC command:
```
127.0.0.1:6379> sync
Entering replica output mode...  (press Ctrl-C to quit)
Full resync with master, discarding 177 bytes of bulk transfer...
Full resync done. Logging commands from master.
"ping"
"SELECT","0"
"incr","counter"
```

SYNC command with EOF marker:
```
127.0.0.1:6379> REPLCONF CAPA EOF
OK
127.0.0.1:6379> sync
Entering replica output mode...  (press Ctrl-C to quit)
Full resync with master, discarding bytes of bulk transfer until EOF marker...
Full resync done after 233 bytes. Logging commands from master.
sending REPLCONF ACK 0
"SELECT","0"
"incr","counter"
```

PSYNC command with +FULLRESYNC:
```
127.0.0.1:6379> psync dummy 0
Entering replica output mode...  (press Ctrl-C to quit)
PSYNC replied +FULLRESYNC 188d44f21759cf12551e0fd36a696bab81c0d794 128
Full resync with master, discarding 194 bytes of bulk transfer...
Full resync done. Logging commands from master.
"ping"
"SELECT","0"
"incr","counter"
```

PSYNC command with +FULLRESYNC, with EOF marker:
```
127.0.0.1:6379> REPLCONF CAPA EOF
OK
127.0.0.1:6379> psync dummy 0
Entering replica output mode...  (press Ctrl-C to quit)
PSYNC replied +FULLRESYNC 188d44f21759cf12551e0fd36a696bab81c0d794 206
Full resync with master, discarding bytes of bulk transfer until EOF marker...
Full resync done after 234 bytes. Logging commands from master.
sending REPLCONF ACK 0
"ping"
"SELECT","1"
"incr","counter"
```

PSYNC command with +CONTINUE:
```
127.0.0.1:6379> psync 188d44f21759cf12551e0fd36a696bab81c0d794 206
Entering replica output mode...  (press Ctrl-C to quit)
PSYNC replied +CONTINUE
Partial resync with master...
Partial resync done. Logging commands from master.
"SELECT"
"0"
"incr","counter"
"ping"
"ping"
"SELECT","1"
"incr","counter"
```

PYSNC COMMAND with +CONTINUE replid:
```
127.0.0.1:6379> REPLCONF CAPA PSYNC2
OK
127.0.0.1:6379> psync 188d44f21759cf12551e0fd36a696bab81c0d794 206
Entering replica output mode...  (press Ctrl-C to quit)
PSYNC replied +CONTINUE 188d44f21759cf12551e0fd36a696bab81c0d794
Partial resync with master...
Partial resync done. Logging commands from master.
"SELECT"
"0"
"incr","counter"
"ping"
"ping"
"SELECT","1"
"incr","counter"
```

Fixes #11246