### PR TITLE
Handle closing paranthesis in acl selectors

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -822,7 +822,7 @@ robj *ACLDescribeUser(user *u) {
         if (selector->flags & SELECTOR_FLAG_ROOT) {
             res = sdscatfmt(res, "%s", default_perm);
         } else {
-            res = sdscatfmt(res, " (%s)", default_perm);
+            res = sdscatfmt(res, " \"(%s)\"", default_perm);
         }
         sdsfree(default_perm);
     }
@@ -2188,7 +2188,7 @@ sds ACLLoadFromFile(const char *filename) {
         if (lines[i][0] == '\0') continue;
 
         /* Split into arguments */
-        argv = sdssplitlen(lines[i],sdslen(lines[i])," ",1,&argc);
+        argv = sdssplitargs(lines[i],&argc);
         if (argv == NULL) {
             errors = sdscatprintf(errors,
                      "%s:%d: unbalanced quotes in acl line. ",

--- a/src/acl.c
+++ b/src/acl.c
@@ -781,6 +781,18 @@ sds ACLDescribeSelector(aclSelector *selector) {
     return res;
 }
 
+int selectorContainsClosingParanthesis(const sds s) {
+    size_t len = sdslen(s);
+    const char *p = s;
+
+    while (len--) {
+        if (*p == ')') return 1;
+        p++;
+    }
+
+    return 0;
+}
+
 /* This is similar to ACLDescribeSelectorCommandRules(), however instead of
  * describing just the user command rules, everything is described: user
  * flags, keys, passwords and finally the command rules obtained via
@@ -822,7 +834,11 @@ robj *ACLDescribeUser(user *u) {
         if (selector->flags & SELECTOR_FLAG_ROOT) {
             res = sdscatfmt(res, "%s", default_perm);
         } else {
-            res = sdscatfmt(res, " \"(%s)\"", default_perm);
+            if (selectorContainsClosingParanthesis(default_perm)) {
+                res = sdscatfmt(res, " \"(%s)\"", default_perm);
+            } else {
+                res = sdscatfmt(res, " (%s)", default_perm);
+            }
         }
         sdsfree(default_perm);
     }

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -491,7 +491,7 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
         assert_equal "ERR wrong number of arguments for 'set' command" $e
     }
 
-    test {Test selectors with closing paranthesis} {
+    test {Test selectors with closing parenthesis} {
         r ACL SETUSER selector-store ON NOPASS +@all "(+@all ~bar))"
         puts [r ACL GETUSER selector-store]
 
@@ -500,7 +500,7 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
         assert_match {*has no permissions to access the 'bar))' key*} [r ACL DRYRUN selector-store SET bar)) world]
     }
 
-    test {Test ACL SAVE/LOAD with selectors containing closing paranthesis} {
+    test {Test ACL SAVE/LOAD with selectors containing closing parenthesis} {
         set users_before_load [r ACL LIST]
         r ACL SAVE
         r ACL LOAD

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -77,8 +77,7 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
 
     test {Test separate read permission} {
         r ACL SETUSER key-permission-R on nopass %R~read* +@all
-        catch {$r2 auth key-permission-R password} err
-        puts $err
+        $r2 auth key-permission-R password
         assert_equal PONG [$r2 PING]
         r set readstr bar
         assert_equal bar [$r2 get readstr]

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -492,7 +492,6 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
 
     test {Test selectors with closing parenthesis} {
         r ACL SETUSER selector-store ON NOPASS +@all "(+@all ~bar))"
-        puts [r ACL GETUSER selector-store]
 
         assert_equal "OK" [r ACL DRYRUN selector-store SET bar) world]
         assert_equal "OK" [r ACL DRYRUN selector-store GET bar)]


### PR DESCRIPTION
Fixes #11600 

Currently ACL selectors doesn't handle a closing paranthesis in key/channel restriction of access string. It treats as the end of the selector. 

This change introduces handling of the access string with closing paranthesis in a selector. The following changes are done:

1. Handle tokenized `"` input of access string.
2. Persist each selector within quotes `"` as part of `ACL SAVE` command. 

Note: redis-cli output adds a `\` in front of a quote as part of `ACL LIST` output, `\` needs to be removed by the user to provide the entry as input.

redis-cli output:
```
> acl list
1) "user default on nopass sanitize-payload ~* &* +@all"
2) "user hp on sanitize-payload resetchannels -@all \"(~test resetchannels +@all)\""
3) "user hp2 on sanitize-payload resetchannels -@all \"(~test) resetchannels +@all)\""
4) "user hp3 on sanitize-payload resetchannels -@all \"(~test))) resetchannels +@all)\""
5) "user hp4 on sanitize-payload resetchannels -@all \"(~test))) resetchannels +@all)\""
6) "user selector-store on nopass sanitize-payload resetchannels +@all \"(~bar) resetchannels +@all)\""
```

aclfile output:
```
user default on nopass sanitize-payload ~* &* +@all
user hp on sanitize-payload resetchannels -@all "(~test resetchannels +@all)"
user hp2 on sanitize-payload resetchannels -@all "(~test) resetchannels +@all)"
user hp3 on sanitize-payload resetchannels -@all "(~test))) resetchannels +@all)"
user hp4 on sanitize-payload resetchannels -@all "(~test))) resetchannels +@all)"
user selector-store on nopass sanitize-payload resetchannels +@all "(~bar) resetchannels +@all)"
```