### PR TITLE
Fix potential issue with Lua argv caching, module command filter and libc realloc

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -337,6 +337,7 @@ typedef struct RedisModuleDictIter {
 
 typedef struct RedisModuleCommandFilterCtx {
     RedisModuleString **argv;
+    int argv_len;
     int argc;
 } RedisModuleCommandFilterCtx;
 
@@ -10056,6 +10057,7 @@ void moduleCallCommandFilters(client *c) {
 
     RedisModuleCommandFilterCtx filter = {
         .argv = c->argv,
+        .argv_len = c->argv_len,
         .argc = c->argc
     };
 
@@ -10072,6 +10074,7 @@ void moduleCallCommandFilters(client *c) {
     }
 
     c->argv = filter.argv;
+    c->argv_len = filter.argv_len;
     c->argc = filter.argc;
 }
 
@@ -10103,7 +10106,10 @@ int RM_CommandFilterArgInsert(RedisModuleCommandFilterCtx *fctx, int pos, RedisM
 
     if (pos < 0 || pos > fctx->argc) return REDISMODULE_ERR;
 
-    fctx->argv = zrealloc(fctx->argv, (fctx->argc+1)*sizeof(RedisModuleString *));
+    if (fctx->argv_len < fctx->argc+1) {
+        fctx->argv_len = fctx->argc+1;
+        fctx->argv = zrealloc(fctx->argv, fctx->argv_len*sizeof(RedisModuleString *));
+    }
     for (i = fctx->argc; i > pos; i--) {
         fctx->argv[i] = fctx->argv[i-1];
     }

--- a/tests/unit/moduleapi/commandfilter.tcl
+++ b/tests/unit/moduleapi/commandfilter.tcl
@@ -96,3 +96,23 @@ start_server {tags {"modules"}} {
         assert_equal {OK} [r module unload commandfilter]
     }
 } 
+
+test {RM_CommandFilterArgInsert and script argv caching} {
+    # coverage for scripts calling commands that expand the argv array
+    # an attempt to add coverage for a possible bug in luaArgsToRedisArgv
+    # this test needs a fresh server so that lua_argv_size is 0.
+    # glibc realloc can return the same pointer even when the size changes
+    # still this test isn't able to trigger the issue, but we keep it anyway.
+    start_server {tags {"modules"}} {
+        r module load $testmodule log-key 0
+        r del mylist
+        # command with 6 args
+        r eval {redis.call('rpush', KEYS[1], 'elem1', 'elem2', 'elem3', 'elem4')} 1 mylist
+        # command with 3 args that is changed to 4
+        r eval {redis.call('rpush', KEYS[1], '@insertafter')} 1 mylist
+        # command with 6 args again
+        r eval {redis.call('rpush', KEYS[1], 'elem1', 'elem2', 'elem3', 'elem4')} 1 mylist
+        assert_equal [r lrange mylist 0 -1] {elem1 elem2 elem3 elem4 @insertafter --inserted-after-- elem1 elem2 elem3 elem4}
+    }
+}
+

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -594,7 +594,7 @@ start_server {tags {"scripting"}} {
         start_server {tags {"scripting"}} {
             set repl [attach_to_replication_stream]
             # a command with 5 argsument
-            #r eval {redis.call('hmget', KEYS[1], 1, 2, 3)} 1 key
+            r eval {redis.call('hmget', KEYS[1], 1, 2, 3)} 1 key
             # then a command with 3 that is replicated as one with 4
             r eval {redis.call('incrbyfloat', KEYS[1], 1)} 1 key
             # then a command with 4 args

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -585,6 +585,30 @@ start_server {tags {"scripting"}} {
         close_replication_stream $repl
     } {} {needs:repl}
 
+    test {INCRBYFLOAT: We can call scripts expanding client->argv from Lua} {
+        # coverage for scripts calling commands that expand the argv array
+        # an attempt to add coverage for a possible bug in luaArgsToRedisArgv
+        # this test needs a fresh server so that lua_argv_size is 0.
+        # glibc realloc can return the same pointer even when the size changes
+        # still this test isn't able to trigger the issue, but we keep it anyway.
+        start_server {tags {"scripting"}} {
+            set repl [attach_to_replication_stream]
+            # a command with 5 argsument
+            #r eval {redis.call('hmget', KEYS[1], 1, 2, 3)} 1 key
+            # then a command with 3 that is replicated as one with 4
+            r eval {redis.call('incrbyfloat', KEYS[1], 1)} 1 key
+            # then a command with 4 args
+            r eval {redis.call('set', KEYS[1], '1', 'KEEPTTL')} 1 key
+
+            assert_replication_stream $repl {
+                {select *}
+                {set key 1 KEEPTTL}
+                {set key 1 KEEPTTL}
+            }
+            close_replication_stream $repl
+        }
+    } {} {needs:repl}
+
     } ;# is_eval
 
     test {Call Redis command with many args from Lua (issue #1764)} {


### PR DESCRIPTION
TLDR: solve a problem introduce in Redis 7.0.6 (#11541) with RM_CommandFilterArgInsert being called from scripts, which can lead to memory corruption.

Libc realloc can return the same pointer even if the size was changed. The code in freeLuaRedisArgv had an assumption that if the pointer didn't change, then the allocation didn't change, and the cache can still be reused.
However, if rewriteClientCommandArgument or RM_CommandFilterArgInsert were used, it could be that we realloced the argv array, and the pointer didn't change, then a consecutive command being executed from Lua can use that argv cache reaching beyond its size.
This was actually only possible with modules, since the decision to realloc was based on argc, rather than argv_len.