### PR TITLE
Remove unnecessary updateClientMemUsageAndBucket() when feeding monitors

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -593,7 +593,6 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     while((ln = listNext(&li))) {
         client *monitor = ln->value;
         addReply(monitor,cmdobj);
-        updateClientMemUsageAndBucket(c);
     }
     decrRefCount(cmdobj);
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -593,6 +593,8 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     while((ln = listNext(&li))) {
         client *monitor = ln->value;
         addReply(monitor,cmdobj);
+        /* Note: If someday we wanna update the monitors' memory usage accurately
+         * that we need to re-add an `updateClientMemoryUsage()` call here. */
     }
     decrRefCount(cmdobj);
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -593,8 +593,6 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     while((ln = listNext(&li))) {
         client *monitor = ln->value;
         addReply(monitor,cmdobj);
-        /* Note: If someday we wanna update the monitors' memory usage accurately
-         * that we need to re-add an `updateClientMemoryUsage()` call here. */
     }
     decrRefCount(cmdobj);
 }

--- a/src/server.c
+++ b/src/server.c
@@ -897,6 +897,10 @@ void removeClientFromMemUsageBucket(client *c, int allow_eviction) {
  * together clients consuming about the same amount of memory and can quickly
  * free them in case we reach maxmemory-clients (client eviction).
  *
+ * Note: This function filters clients of type monitor, master or replica regardless
+ * of whether the eviction is enabled or not, so the memory usage we get from these
+ * types of clients via the INFO command may be out of date.
+ *
  * returns 1 if client eviction for this client is allowed, 0 otherwise.
  */
 int updateClientMemUsageAndBucket(client *c) {

--- a/src/server.c
+++ b/src/server.c
@@ -899,7 +899,9 @@ void removeClientFromMemUsageBucket(client *c, int allow_eviction) {
  *
  * Note: This function filters clients of type monitor, master or replica regardless
  * of whether the eviction is enabled or not, so the memory usage we get from these
- * types of clients via the INFO command may be out of date.
+ * types of clients via the INFO command may be out of date. If someday we wanna
+ * improve that to make monitors' memory usage more accurate, we need to re-add this
+ * function call to `replicationFeedMonitors()`.
  *
  * returns 1 if client eviction for this client is allowed, 0 otherwise.
  */


### PR DESCRIPTION
This call is introduced in #8687, but became irrelevant in #11348, and is currently a no-op.
The fact is that #11348 an unintended side effect, which is that even if the client eviction config
is enabled, there are certain types of clients for which memory consumption is not accurately
tracked, and so unlike normal clients, their memory isn't reported correctly in INFO.