### PR TITLE
Increase frequency of failover log and emit the status of the election to help debugging

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3869,7 +3869,7 @@ void clusterLogCantFailover(int reason) {
         break;
     }
     lastlog_time = time(NULL);
-    serverLog(LL_WARNING,"Currently unable to failover: %s", msg);
+    serverLog(LL_NOTICE,"Currently unable to failover: %s", msg);
 }
 
 /* This function emits a log when an election is attempted but doesn't succeed because the quorum is not reached. */
@@ -3887,7 +3887,7 @@ static void clusterLogNeededquorumNotReached(int cur_vote, int cur_quorum) {
     last_vote = cur_vote;
     last_quorum = cur_quorum;
     lastlog_time = time(NULL);
-    serverLog(LL_WARNING, "Currently unable to failover as the majority was not reached. Needed quorum: %i. Number of votes received so far: %i", cur_quorum, cur_vote);
+    serverLog(LL_NOTICE, "Currently unable to failover as the majority was not reached. Needed quorum: %i. Number of votes received so far: %i", cur_quorum, cur_vote);
 }
 
 /* This function implements the final part of automatic and manual failovers,

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3871,6 +3871,7 @@ void clusterLogCantFailover(int reason) {
     lastlog_time = time(NULL);
     serverLog(LL_WARNING,"Currently unable to failover: %s", msg);
 }
+
 /* This function emits a log when an election is attempted but doesn't succeed. */
 static void clusterLogNeededquorumNotReached(int cur_vote, int cur_quorum) {
     static time_t lastlog_time = 0;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3873,7 +3873,7 @@ void clusterLogCantFailover(int reason) {
     
     int cur_vote = server.cluster->failover_auth_count;
     int cur_quorum = (server.cluster->size / 2) + 1;
-    /* Emits a log when an election is attemped but doesn't succeed or failover attempt expired. */
+    /* Emits a log when an election is in progress and waiting for votes or when the failover attempt expired. */
     if (reason == CLUSTER_CANT_FAILOVER_WAITING_VOTES || reason == CLUSTER_CANT_FAILOVER_EXPIRED) {
         serverLog(LL_NOTICE, "Needed quorum: %d. Number of votes received so far: %d", cur_quorum, cur_vote);
     } 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3873,8 +3873,7 @@ void clusterLogCantFailover(int reason) {
     
     int cur_vote = server.cluster->failover_auth_count;
     int cur_quorum = (server.cluster->size / 2) + 1;
-    /* Emits a log when an election is attemped but doesn't succeed or failover attempt expired.
-       But don't log if we have same vote and quorum as last time. */
+    /* Emits a log when an election is attemped but doesn't succeed or failover attempt expired. */
     if (reason == CLUSTER_CANT_FAILOVER_WAITING_VOTES || reason == CLUSTER_CANT_FAILOVER_EXPIRED) {
         serverLog(LL_NOTICE, "Needed quorum: %d. Number of votes received so far: %d", cur_quorum, cur_vote);
     } 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3872,7 +3872,7 @@ void clusterLogCantFailover(int reason) {
     serverLog(LL_WARNING,"Currently unable to failover: %s", msg);
 }
 
-/* This function emits a log when an election is attempted but doesn't succeed. */
+/* This function emits a log when an election is attempted but doesn't succeed because the quorum is not reached. */
 static void clusterLogNeededquorumNotReached(int cur_vote, int cur_quorum) {
     static time_t lastlog_time = 0;
     static int last_vote;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3871,17 +3871,12 @@ void clusterLogCantFailover(int reason) {
     lastlog_time = time(NULL);
     serverLog(LL_NOTICE,"Currently unable to failover: %s", msg);
     
-    static int last_vote;
-    static int last_quorum;
     int cur_vote = server.cluster->failover_auth_count;
     int cur_quorum = (server.cluster->size / 2) + 1;
-    /* Emits a log when an election is attemped but doesn't succeed.
+    /* Emits a log when an election is attemped but doesn't succeed or failover attempt expired.
        But don't log if we have same vote and quorum as last time. */
-    if (reason == CLUSTER_CANT_FAILOVER_WAITING_VOTES) {
-        if (last_vote == cur_vote && last_quorum == cur_quorum) return;
-        last_vote = cur_vote;
-        last_quorum = cur_quorum;
-        serverLog(LL_NOTICE, "Needed quorum: %i. Number of votes received so far: %i", cur_quorum, cur_vote);
+    if (reason == CLUSTER_CANT_FAILOVER_WAITING_VOTES || reason == CLUSTER_CANT_FAILOVER_EXPIRED) {
+        serverLog(LL_NOTICE, "Needed quorum: %d. Number of votes received so far: %d", cur_quorum, cur_vote);
     } 
 }
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -73,7 +73,7 @@ typedef struct clusterLink {
 #define CLUSTER_CANT_FAILOVER_WAITING_DELAY 2
 #define CLUSTER_CANT_FAILOVER_EXPIRED 3
 #define CLUSTER_CANT_FAILOVER_WAITING_VOTES 4
-#define CLUSTER_CANT_FAILOVER_RELOG_PERIOD (25) /* seconds. */
+#define CLUSTER_CANT_FAILOVER_RELOG_PERIOD (10) /* seconds. */
 
 /* clusterState todo_before_sleep flags. */
 #define CLUSTER_TODO_HANDLE_FAILOVER (1<<0)

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -73,7 +73,7 @@ typedef struct clusterLink {
 #define CLUSTER_CANT_FAILOVER_WAITING_DELAY 2
 #define CLUSTER_CANT_FAILOVER_EXPIRED 3
 #define CLUSTER_CANT_FAILOVER_WAITING_VOTES 4
-#define CLUSTER_CANT_FAILOVER_RELOG_PERIOD (60*5) /* seconds. */
+#define CLUSTER_CANT_FAILOVER_RELOG_PERIOD (25) /* seconds. */
 
 /* clusterState todo_before_sleep flags. */
 #define CLUSTER_TODO_HANDLE_FAILOVER (1<<0)


### PR DESCRIPTION
Hey, I am from AWS Elasticache Team.

This change increase the frequency of the failover log from 5 minutes to 10 seconds. This log is only emitted when a replica has an outstanding election is progress, and waiting 5 minutes for the next log makes debugging and alarming on the log messages too slow. It also now prints out the number of votes the replica has currently received as well as the number of votes it needs to achieve quorum so that we can track the progress if it's running slowly.

Harry Lin