### PR TITLE
Introduce .is_local method for connection layer

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2904,7 +2904,7 @@ static sds getConfigReplicaOfOption(standardConfig *config) {
 
 int allowProtectedAction(int config, client *c) {
     return (config == PROTECTED_ACTION_ALLOWED_YES) ||
-           (config == PROTECTED_ACTION_ALLOWED_LOCAL && islocalClient(c));
+           (config == PROTECTED_ACTION_ALLOWED_LOCAL && (connIsLocal(c->conn) == 1));
 }
 
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -78,6 +78,7 @@ typedef struct ConnectionType {
     void (*ae_handler)(struct aeEventLoop *el, int fd, void *clientData, int mask);
     aeFileProc *accept_handler;
     int (*addr)(connection *conn, char *ip, size_t ip_len, int *port, int remote);
+    int (*is_local)(connection *conn);
     int (*listen)(connListener *listener);
 
     /* create/shutdown/close connection */
@@ -313,6 +314,16 @@ static inline int connAddrPeerName(connection *conn, char *ip, size_t ip_len, in
 
 static inline int connAddrSockName(connection *conn, char *ip, size_t ip_len, int *port) {
     return connAddr(conn, ip, ip_len, port, 0);
+}
+
+/* Test a connection is local or loopback.
+ * Return -1 on failure, 0 is not a local connection, 1 is a local connection */
+static inline int connIsLocal(connection *conn) {
+    if (conn && conn->type->is_local) {
+        return conn->type->is_local(conn);
+    }
+
+    return -1;
 }
 
 static inline int connGetState(connection *conn) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -1230,18 +1230,6 @@ int clientHasPendingReplies(client *c) {
     }
 }
 
-/* Return true if client connected from loopback interface */
-int islocalClient(client *c) {
-    /* unix-socket */
-    if (c->flags & CLIENT_UNIX_SOCKET) return 1;
-
-    /* tcp */
-    char cip[NET_IP_STR_LEN+1] = { 0 };
-    connAddrPeerName(c->conn, cip, sizeof(cip)-1, NULL);
-
-    return !strcmp(cip,"127.0.0.1") || !strcmp(cip,"::1");
-}
-
 void clientAcceptHandler(connection *conn) {
     client *c = connGetPrivateData(conn);
 
@@ -1260,7 +1248,7 @@ void clientAcceptHandler(connection *conn) {
     if (server.protected_mode &&
         DefaultUser->flags & USER_FLAG_NOPASS)
     {
-        if (!islocalClient(c)) {
+        if (connIsLocal(conn) != 1) {
             char *err =
                 "-DENIED Redis is running in protected mode because protected "
                 "mode is enabled and no password is set for the default user. "

--- a/src/server.h
+++ b/src/server.h
@@ -2576,7 +2576,6 @@ int handleClientsWithPendingWritesUsingThreads(void);
 int handleClientsWithPendingReadsUsingThreads(void);
 int stopThreadedIOIfNeeded(void);
 int clientHasPendingReplies(client *c);
-int islocalClient(client *c);
 int updateClientMemUsageAndBucket(client *c);
 void removeClientFromMemUsageBucket(client *c, int allow_eviction);
 void unlinkClient(client *c);

--- a/src/socket.c
+++ b/src/socket.c
@@ -335,6 +335,15 @@ static int connSocketAddr(connection *conn, char *ip, size_t ip_len, int *port, 
     return C_ERR;
 }
 
+static int connSocketIsLocal(connection *conn) {
+    char cip[NET_IP_STR_LEN + 1] = { 0 };
+
+    if (connSocketAddr(conn, cip, sizeof(cip) - 1, NULL, 1) == C_ERR)
+        return -1;
+
+    return !strcmp(cip,"127.0.0.1") || !strcmp(cip,"::1");
+}
+
 static int connSocketListen(connListener *listener) {
     return listenToPort(listener);
 }
@@ -392,6 +401,7 @@ static ConnectionType CT_Socket = {
     .ae_handler = connSocketEventHandler,
     .accept_handler = connSocketAcceptHandler,
     .addr = connSocketAddr,
+    .is_local = connSocketIsLocal,
     .listen = connSocketListen,
 
     /* create/shutdown/close connection */

--- a/src/tls.c
+++ b/src/tls.c
@@ -787,6 +787,10 @@ static int connTLSAddr(connection *conn, char *ip, size_t ip_len, int *port, int
     return anetFdToString(conn->fd, ip, ip_len, port, remote);
 }
 
+static int connTLSIsLocal(connection *conn) {
+    return connectionTypeTcp()->is_local(conn);
+}
+
 static int connTLSListen(connListener *listener) {
     return listenToPort(listener);
 }
@@ -1114,6 +1118,7 @@ static ConnectionType CT_TLS = {
     .ae_handler = tlsEventHandler,
     .accept_handler = tlsAcceptHandler,
     .addr = connTLSAddr,
+    .is_local = connTLSIsLocal,
     .listen = connTLSListen,
 
     /* create/shutdown/close connection */

--- a/src/unix.c
+++ b/src/unix.c
@@ -43,6 +43,12 @@ static int connUnixAddr(connection *conn, char *ip, size_t ip_len, int *port, in
     return connectionTypeTcp()->addr(conn, ip, ip_len, port, remote);
 }
 
+static int connUnixIsLocal(connection *conn) {
+    UNUSED(conn);
+
+    return 1; /* Unix socket is always local connection */
+}
+
 static int connUnixListen(connListener *listener) {
     int fd;
     mode_t *perm = (mode_t *)listener->priv;
@@ -164,6 +170,7 @@ static ConnectionType CT_Unix = {
     .ae_handler = connUnixEventHandler,
     .accept_handler = connUnixAcceptHandler,
     .addr = connUnixAddr,
+    .is_local = connUnixIsLocal,
     .listen = connUnixListen,
 
     /* create/shutdown/close connection */


### PR DESCRIPTION
Introduce .is_local method to connection, and implement for TCP/TLS/ Unix socket, also drop 'int islocalClient(client *c)'. Then we can hide the detail into the specific connection types. Uplayer tests a connection is local or not by abstract method only.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>