### PR TITLE
Blocking command with a 0.001 seconds timeout blocks indefinitely

### DIFF
--- a/src/timeout.c
+++ b/src/timeout.c
@@ -176,6 +176,7 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
             return C_ERR;
         }
         tval = (long long) ftval;
+        if (tval == 0 && ftval > 0) tval = 1;
     } else {
         if (getLongLongFromObjectOrReply(c,object,&tval,
             "timeout is not an integer or out of range") != C_OK)

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -29,6 +29,8 @@
 #include "server.h"
 #include "cluster.h"
 
+#include <math.h>
+
 /* ========================== Clients timeouts ============================= */
 
 /* Check if this blocked client timedout (does nothing if the client is
@@ -175,8 +177,7 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
             addReplyError(c, "timeout is out of range");
             return C_ERR;
         }
-        tval = (long long) ftval;
-        if (tval == 0 && ftval > 0) tval = 1;
+        tval = (long long) ceil(ftval);
     } else {
         if (getLongLongFromObjectOrReply(c,object,&tval,
             "timeout is not an integer or out of range") != C_OK)

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -177,7 +177,7 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
             addReplyError(c, "timeout is out of range");
             return C_ERR;
         }
-        tval = (long long) ceil(ftval);
+        tval = (long long) ceill(ftval);
     } else {
         if (getLongLongFromObjectOrReply(c,object,&tval,
             "timeout is not an integer or out of range") != C_OK)

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1263,6 +1263,16 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             $rd close
         }
 
+        test "$pop: with 0.001 timeout should not block indefinitely" {
+            # Use a timeout of 0.001 and wait for the number of blocked clients to equal 0.
+            # Validate the empty read from the deferring client.
+            set rd [redis_deferring_client]
+            bpop_command $rd $pop blist1 0.001
+            wait_for_blocked_clients_count 0
+            assert_equal {} [$rd read]
+            $rd close
+        }
+
         test "$pop: second argument is not a list" {
             set rd [redis_deferring_client]
             r del blist1{t} blist2{t}


### PR DESCRIPTION
Any value in the range of [0-1) turns to 0 when being cast from double to long long.

https://github.com/redis/redis/issues/11687

```
Release Notes
Fix a bug where blocking commands with a non-zero blocking time in seconds were blocking forever.
```