### PR TITLE
redis-cli: Fix print of keys per cluster host when over int max

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3889,7 +3889,7 @@ static void clusterManagerShowClusterInfo(void) {
                 return;
             };
             if (reply != NULL) freeReplyObject(reply);
-            printf("%s:%d (%s...) -> %d keys | %d slots | %d slaves.\n",
+            printf("%s:%d (%s...) -> %lld keys | %d slots | %d slaves.\n",
                    node->ip, node->port, name, dbsize,
                    node->slots_count, replicas);
             masters++;

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3854,7 +3854,7 @@ static void clusterManagerShowNodes(void) {
 
 static void clusterManagerShowClusterInfo(void) {
     int masters = 0;
-    int keys = 0;
+    long long keys = 0;
     listIter li;
     listNode *ln;
     listRewind(cluster_manager.nodes, &li);
@@ -3863,7 +3863,7 @@ static void clusterManagerShowClusterInfo(void) {
         if (!(node->flags & CLUSTER_MANAGER_FLAG_SLAVE)) {
             if (!node->name) continue;
             int replicas = 0;
-            int dbsize = -1;
+            long long dbsize = -1;
             char name[9];
             memcpy(name, node->name, 8);
             name[8] = '\0';

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3896,7 +3896,7 @@ static void clusterManagerShowClusterInfo(void) {
             keys += dbsize;
         }
     }
-    clusterManagerLogOk("[OK] %d keys in %d masters.\n", keys, masters);
+    clusterManagerLogOk("[OK] %lld keys in %d masters.\n", keys, masters);
     float keys_per_slot = keys / (float) CLUSTER_MANAGER_SLOTS;
     printf("%.2f keys per slot on average.\n", keys_per_slot);
 }


### PR DESCRIPTION
When running cluster info, and the number of keys overflows the integer value, the summary no longer makes sense. This fixes by using an appropriate type to handle values over the max int value.

```
tylerbream@unique-service-redis-1:~$ redis-cli --cluster info localhost:6379
20.0.*.*:6379 (5ba6400d...) -> 258386540 keys | 994 slots | 2 slaves.
20.0.*.*:6379 (a6165089...) -> 257990944 keys | 991 slots | 2 slaves.
20.0.*.*:6379 (e42fc6d7...) -> 258346175 keys | 994 slots | 2 slaves.
20.0.*.*:6379 (3a918211...) -> 124965126 keys | 486 slots | 2 slaves.
20.0.*.*:6379 (5ec5dcd8...) -> 127660401 keys | 496 slots | 2 slaves.
20.0.*.*:6379 (70e711fd...) -> 127895119 keys | 497 slots | 2 slaves.
20.0.*.*:6379 (e9beda89...) -> 127634622 keys | 496 slots | 2 slaves.
20.0.*.*:6379 (ad2036f0...) -> 127620813 keys | 496 slots | 2 slaves.
20.0.*.*:6379 (effb464e...) -> 127887459 keys | 497 slots | 2 slaves.
20.0.*.*:6379 (e61f9cce...) -> 127582083 keys | 496 slots | 2 slaves.
20.0.*.*:6379 (8d710b8c...) -> 127602269 keys | 496 slots | 2 slaves.
20.0.*.*:6379 (300597f3...) -> 127932883 keys | 497 slots | 2 slaves.
20.0.*.*:6379 (38b90fee...) -> 127658378 keys | 496 slots | 2 slaves.
20.0.*.*:6379 (a66b9dd7...) -> 127633387 keys | 496 slots | 2 slaves.
20.0.*.*:6379 (e692a243...) -> 258046481 keys | 993 slots | 2 slaves.
20.0.*.*:6379 (da431ce4...) -> 258033765 keys | 993 slots | 2 slaves.
20.0.*.*:6379 (7de68cb5...) -> 261471098 keys | 1006 slots | 2 slaves.
20.0.*.*:6379 (116b1d64...) -> 258326490 keys | 994 slots | 2 slaves.
20.0.*.*:6379 (f830e971...) -> 127646850 keys | 496 slots | 2 slaves.
20.0.*.*:6379 (63d45ca2...) -> 254979307 keys | 981 slots | 2 slaves.
20.0.*.*:6379 (435002bf...) -> 127887872 keys | 497 slots | 2 slaves.
20.0.*.*:6379 (d2526757...) -> 260664072 keys | 1003 slots | 2 slaves.
20.0.*.*:6379 (acc7d1ce...) -> 230822 keys | 1 slots | 2 slaves.
20.0.*.*:6379 (143b0757...) -> 257767131 keys | 992 slots | 2 slaves.
[OK] -53117209 keys in 24 masters.
-3242.02 keys per slot on average.
```