### PR TITLE
dict: use clz to calc _dictNextExp

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1082,18 +1082,14 @@ static int _dictExpandIfNeeded(dict *d)
     return DICT_OK;
 }
 
-/* TODO: clz optimization */
 /* Our hash table capability is a power of two */
 static signed char _dictNextExp(unsigned long size)
 {
-    unsigned char e = DICT_HT_INITIAL_EXP;
+    unsigned char bits_of_long = 8*sizeof(long);
+    if (size >= LONG_MAX) return (bits_of_long-1);
+    if (size <= DICT_HT_INITIAL_SIZE) return DICT_HT_INITIAL_EXP;
 
-    if (size >= LONG_MAX) return (8*sizeof(long)-1);
-    while(1) {
-        if (((unsigned long)1<<e) >= size)
-            return e;
-        e++;
-    }
+    return bits_of_long - __builtin_clzl(size-1);
 }
 
 /* Returns the index of a free slot that can be populated with


### PR DESCRIPTION
Yet another pr to fix clz TODO since pr #11564 hasn't been updated for a few days. Fixes two drawbacks of it: 1. the msvc code, 2. 32/64-bit compitability.

Signed-off-by: haoyixing <haoyixing@kuaishou.com>