### PR TITLE
Module commands to have ACL categories.

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -638,7 +638,7 @@ void ACLSetSelectorCommandBitsForCategory(dict *commands, aclSelector *selector,
     dictReleaseIterator(di);
 }
 
-/* This funtion is responsible for recomputing the command bits for all selectors of the existing users.
+/* This function is responsible for recomputing the command bits for all selectors of the existing users.
  * It uses the 'command_rules', a string representation of the ordered categories and commands, 
  * to recompute the command bits. */
 void ACLRecomputeCommandBitsFromCommandRulesAllUsers() {

--- a/src/acl.c
+++ b/src/acl.c
@@ -627,7 +627,7 @@ void ACLSetSelectorCommandBitsForCategory(dict *commands, aclSelector *selector,
     dictEntry *de;
     while ((de = dictNext(di)) != NULL) {
         struct redisCommand *cmd = dictGetVal(de);
-        if (cmd->flags & CMD_MODULE) continue; /* Ignore modules commands. */
+        if (cmd->flags & CMD_MODULE && !(cmd->acl_categories)) continue; /* Ignore modules commands unless they have acl category. */
         if (cmd->acl_categories & cflag) {
             ACLChangeSelectorPerm(selector,cmd,value);
         }
@@ -636,6 +636,43 @@ void ACLSetSelectorCommandBitsForCategory(dict *commands, aclSelector *selector,
         }
     }
     dictReleaseIterator(di);
+}
+
+/* This funtion is responsible for recomputing the command bits for all selectors of the existing users.
+ * It uses the 'command_rules', a string representation of the ordered categories and commands, 
+ * to recompute the command bits. */
+void ACLRecomputeCommandBitsFromCommandRulesAllUsers() {
+    raxIterator ri;
+    raxStart(&ri,Users);
+    raxSeek(&ri,"^",NULL,0);
+    while(raxNext(&ri)){
+        user *u = ri.data;
+        listIter li;
+        listNode *ln;
+        listRewind(u->selectors,&li);
+        while((ln = listNext(&li))){
+            aclSelector *selector = (aclSelector *) listNodeValue(ln);
+            int argc = 0;
+            sds *argv = sdssplitargs(selector->command_rules, &argc);
+            serverAssert(argv != NULL);
+            if (ACLSelectorCanExecuteFutureCommands(selector)) {
+                int res = ACLSetSelector(selector,"+@all",-1);
+                serverAssert(res == C_OK);
+            } else {
+                int res = ACLSetSelector(selector,"-@all",-1);
+                serverAssert(res == C_OK);
+            }
+
+            /* Apply all of the commands and categories to this selector. */
+            for(int i = 0; i < argc; i++) {
+                int res = ACLSetSelector(selector, argv[i], sdslen(argv[i]));
+                serverAssert(res == C_OK);
+            }
+            sdsfreesplitres(argv, argc);
+        }
+    }
+    raxStop(&ri);
+
 }
 
 int ACLSetSelectorCategory(aclSelector *selector, const char *category, int allow) {

--- a/src/acl.c
+++ b/src/acl.c
@@ -627,7 +627,6 @@ void ACLSetSelectorCommandBitsForCategory(dict *commands, aclSelector *selector,
     dictEntry *de;
     while ((de = dictNext(di)) != NULL) {
         struct redisCommand *cmd = dictGetVal(de);
-        if (cmd->flags & CMD_MODULE && !(cmd->acl_categories)) continue; /* Ignore modules commands unless they have acl category. */
         if (cmd->acl_categories & cflag) {
             ACLChangeSelectorPerm(selector,cmd,value);
         }
@@ -655,6 +654,7 @@ void ACLRecomputeCommandBitsFromCommandRulesAllUsers() {
             int argc = 0;
             sds *argv = sdssplitargs(selector->command_rules, &argc);
             serverAssert(argv != NULL);
+            /* Checking selector's permissions for all commands to start with a clean state. */
             if (ACLSelectorCanExecuteFutureCommands(selector)) {
                 int res = ACLSetSelector(selector,"+@all",-1);
                 serverAssert(res == C_OK);

--- a/src/acl.c
+++ b/src/acl.c
@@ -645,12 +645,12 @@ void ACLRecomputeCommandBitsFromCommandRulesAllUsers() {
     raxIterator ri;
     raxStart(&ri,Users);
     raxSeek(&ri,"^",NULL,0);
-    while(raxNext(&ri)){
+    while(raxNext(&ri)) {
         user *u = ri.data;
         listIter li;
         listNode *ln;
         listRewind(u->selectors,&li);
-        while((ln = listNext(&li))){
+        while((ln = listNext(&li))) {
             aclSelector *selector = (aclSelector *) listNodeValue(ln);
             int argc = 0;
             sds *argv = sdssplitargs(selector->command_rules, &argc);

--- a/src/module.c
+++ b/src/module.c
@@ -1317,7 +1317,7 @@ RedisModuleCommand *RM_GetCommand(RedisModuleCtx *ctx, const char *name) {
  * * `parent` is already a subcommand (we do not allow more than one level of command nesting)
  * * `parent` is a command with an implementation (RedisModuleCmdFunc) (A parent command should be a pure container of subcommands)
  * * `parent` already has a subcommand called `name`
- * * Creating a subcommand is called outside of the RedisModule_OnLoad.
+ * * Creating a subcommand is called outside of RedisModule_OnLoad.
  */
 int RM_CreateSubcommand(RedisModuleCommand *parent, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) {
     if (!parent->module->onload)
@@ -6524,9 +6524,9 @@ robj *moduleTypeDupOrReply(client *c, robj *fromkey, robj *tokey, int todb, robj
  * Note: the module name "AAAAAAAAA" is reserved and produces an error, it
  * happens to be pretty lame as well.
  *
- * If RedisModule_CreateDataType() is called outside of the RedisModule_OnLoad() function,
- * and if there is already a module registering a type with the same name,
- * and if the module name or encver is invalid, NULL is returned.
+ * If RedisModule_CreateDataType() is called outside of RedisModule_OnLoad() function,
+ * there is already a module registering a type with the same name,
+ * or if the module name or encver is invalid, NULL is returned.
  * Otherwise the new type is registered into Redis, and a reference of
  * type RedisModuleType is returned: the caller of the function should store
  * this reference into a global variable to make future use of it in the
@@ -11618,7 +11618,7 @@ int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loa
 
     /* If module commands have ACL categories, recompute command bits 
      * for all existing users once the modules has been registered. */
-    if(ctx.module->num_commands_with_acl_categories) {
+    if (ctx.module->num_commands_with_acl_categories) {
         ACLRecomputeCommandBitsFromCommandRulesAllUsers();
     }
     serverLog(LL_NOTICE,"Module '%s' loaded from %s",ctx.module->name,path);
@@ -12259,7 +12259,7 @@ int RM_RegisterNumericConfig(RedisModuleCtx *ctx, const char *name, long long de
 
 /* Applies all pending configurations on the module load. This should be called
  * after all of the configurations have been registered for the module inside of RedisModule_OnLoad.
- * This will return REDISMODULE_ERR if it is called outside the RedisModule_OnLoad.
+ * This will return REDISMODULE_ERR if it is called outside RedisModule_OnLoad.
  * This API needs to be called when configurations are provided in either `MODULE LOADEX`
  * or provided as startup arguments. */
 int RM_LoadConfigs(RedisModuleCtx *ctx) {

--- a/src/module.c
+++ b/src/module.c
@@ -1166,7 +1166,7 @@ RedisModuleCommand *moduleCreateCommandProxy(struct RedisModule *module, sds dec
  * only be used to find keys that exist at constant indices.
  * For non-trivial key arguments, you may pass 0,0,0 and use
  * RedisModule_SetCommandInfo to set key specs using a more advanced scheme and use
- * RedisModule_SetCommandCategories to set Redis ACL categories of the commands. */
+ * RedisModule_SetCommandACLCategories to set Redis ACL categories of the commands. */
 int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) {
     if (!ctx->module->onload)
         return REDISMODULE_ERR;
@@ -1362,7 +1362,7 @@ int matchAclCategoryFlag(char *flag, int64_t *acl_categories_flags) {
     return 0; /* Unrecognized */
 }
 
-/* Helper for RM_SetCommandCategories(). Turns a string representing acl category
+/* Helper for RM_SetCommandACLCategories(). Turns a string representing acl category
  * flags into the acl category flags used by Redis ACL which allows users to access 
  * the module commands by acl categories.
  * 
@@ -1383,12 +1383,12 @@ int64_t categoryFlagsFromString(char *aclflags) {
     return acl_categories_flags;
 }
 
-/* RedisModule_SetCommandCategories can be used to set ACL categories to module
+/* RedisModule_SetCommandACLCategories can be used to set ACL categories to module
  * commands and subcommands. The set of ACL categories should be passed as
  * a space separated C string 'aclflags'.
  * 
  * Example, 'write slow' marks the command as part of the write and slow ACL categories. */
-int RM_SetCommandCategories(RedisModuleCommand *command, const char *aclflags) {
+int RM_SetCommandACLCategories(RedisModuleCommand *command, const char *aclflags) {
     if (!command || !command->module || !command->module->onload) return REDISMODULE_ERR;
     int64_t categories_flags = aclflags ? categoryFlagsFromString((char*)aclflags) : 0;
     if (categories_flags == -1) return REDISMODULE_ERR;
@@ -12853,7 +12853,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(GetCommand);
     REGISTER_API(CreateSubcommand);
     REGISTER_API(SetCommandInfo);
-    REGISTER_API(SetCommandCategories);
+    REGISTER_API(SetCommandACLCategories);
     REGISTER_API(SetModuleAttribs);
     REGISTER_API(IsModuleNameBusy);
     REGISTER_API(WrongArity);

--- a/src/module.c
+++ b/src/module.c
@@ -1348,12 +1348,12 @@ moduleCmdArgAt(const RedisModuleCommandInfoVersion *version,
     return (RedisModuleCommandArg *)((char *)(args) + offset);
 }
 
-/* Helper for categoryFlagsFromString(). Turns a string representing command
- * flags into the ACL Category Flags.
+/* Helper for categoryFlagsFromString(). Attempts to find an acl flag representing the provided flag string
+ * and adds that flag to acl_categories_flags if a match is found.
  *
  * Returns '1' if acl category flag is recognized or
  * returns '0' if not recognized  */
-int matchAclCategoriesFlags(char *flag, int64_t *acl_categories_flags) {
+int matchAclCategoryFlag(char *flag, int64_t *acl_categories_flags) {
     uint64_t this_flag = ACLGetCommandCategoryFlagByName(flag);
     if (this_flag) {
         *acl_categories_flags |= (int64_t) this_flag;
@@ -1373,7 +1373,7 @@ int64_t categoryFlagsFromString(char *aclflags) {
     sds *tokens = sdssplitlen(aclflags,strlen(aclflags)," ",1,&count);
     for (j = 0; j < count; j++) {
         char *t = tokens[j];
-        if (!matchAclCategoriesFlags(t, &acl_categories_flags)) {
+        if (!matchAclCategoryFlag(t, &acl_categories_flags)) {
             serverLog(LL_WARNING,"Unrecognized categories flag %s on module load", t);
             break;
         }

--- a/src/module.c
+++ b/src/module.c
@@ -1215,7 +1215,7 @@ int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc c
     cp->rediscmd->id = ACLGetCommandID(declared_name); /* ID used for ACL. */
     cp->rediscmd->acl_categories = acl_categories; /* ACL categories flags for module command */
     /* If commands have acl_categories, recompute the command bits for the existing 
-     *  users to have access to these commands */  
+     * users to have access to these commands */  
     if (acl_categories) ACLRecomputeCommandBitsFromCommandRulesAllUsers(); 
     return REDISMODULE_OK;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -11709,7 +11709,7 @@ int moduleUnload(sds name) {
     module->name = NULL; /* The name was already freed by dictDelete(). */
     moduleFreeModuleStructure(module);
 
-    /* Recompute Commmand Bits for all users once the modules has been completely unloaded */
+    /* Recompute command bits for all users once the modules has been completely unloaded. */
     ACLRecomputeCommandBitsFromCommandRulesAllUsers();
     return C_OK;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -1061,7 +1061,7 @@ int64_t commandFlagsFromString(char *s) {
         else if (!strcasecmp(t,"getchannels-api")) flags |= CMD_MODULE_GETCHANNELS;
         else if (!strcasecmp(t,"no-cluster")) flags |= CMD_MODULE_NO_CLUSTER;
         else if (!strcasecmp(t,"no-mandatory-keys")) flags |= CMD_NO_MANDATORY_KEYS;
-        else if (!strcasecmp(t,"allow-busy")) flags |= CMD_ALLOW_BUSY; 
+        else if (!strcasecmp(t,"allow-busy")) flags |= CMD_ALLOW_BUSY;
         else break;
     }
     sdsfreesplitres(tokens,count);
@@ -1374,8 +1374,8 @@ int64_t categoriesFlagsFromString(char *aclflags) {
     for (j = 0; j < count; j++) {
         char *t = tokens[j];
         if (!matchAclCategoriesFlags(t, &acl_categories_flags)) {
-                serverLog(LL_WARNING,"Unrecognized categories flag %s on module load", t);
-                break;
+            serverLog(LL_WARNING,"Unrecognized categories flag %s on module load", t);
+            break;
         }
     }
     sdsfreesplitres(tokens,count);

--- a/src/module.c
+++ b/src/module.c
@@ -1348,7 +1348,7 @@ moduleCmdArgAt(const RedisModuleCommandInfoVersion *version,
     return (RedisModuleCommandArg *)((char *)(args) + offset);
 }
 
-/* Helper for categoriesFlagsFromString(). Turns a string representing command
+/* Helper for categoryFlagsFromString(). Turns a string representing command
  * flags into the ACL Category Flags.
  *
  * Returns '1' if acl category flag is recognized or
@@ -1362,12 +1362,12 @@ int matchAclCategoriesFlags(char *flag, int64_t *acl_categories_flags) {
     return 0; /* Unrecognized */
 }
 
-/* Helper for RM_SetCommandCategories(). Turns a string representing command
+/* Helper for RM_SetCommandCategories(). Turns a string representing acl category
  * flags into the acl category flags used by Redis ACL which allows users to access 
  * the module commands by acl categories.
  * 
  * It returns the set of acl flags, or -1 if unknown flags are found. */
-int64_t categoriesFlagsFromString(char *aclflags) {
+int64_t categoryFlagsFromString(char *aclflags) {
     int count, j;
     int64_t acl_categories_flags = 0;
     sds *tokens = sdssplitlen(aclflags,strlen(aclflags)," ",1,&count);
@@ -1387,7 +1387,7 @@ int64_t categoriesFlagsFromString(char *aclflags) {
  * commands and subcommands. The set of ACL categories should be passed as
  * a space separated C string 'aclflags'.
  * 
- * Example, 'write' marks the command as part of the write ACL category. */
+ * Example, 'write slow' marks the command as part of the write and slow ACL categories. */
 int RM_SetCommandCategories(RedisModuleCommand *command, const char *aclflags) {
     if (!command || !command->module || !command->module->onload) return REDISMODULE_ERR;
     int64_t categories_flags = aclflags ? categoriesFlagsFromString((char*)aclflags) : 0;

--- a/src/module.c
+++ b/src/module.c
@@ -1387,7 +1387,14 @@ int64_t categoryFlagsFromString(char *aclflags) {
  * commands and subcommands. The set of ACL categories should be passed as
  * a space separated C string 'aclflags'.
  * 
- * Example, 'write slow' marks the command as part of the write and slow ACL categories. */
+ * Example, the acl flags 'write slow' marks the command as part of the write and 
+ * slow ACL categories.
+ * 
+ * On success REDISMODULE_OK is returned. On error REDISMODULE_ERR is returned.
+ * 
+ * This function can only be called during the RedisModule_OnLoad function. If called
+ * outside of this function, an error is returned.
+ */
 int RM_SetCommandACLCategories(RedisModuleCommand *command, const char *aclflags) {
     if (!command || !command->module || !command->module->onload) return REDISMODULE_ERR;
     int64_t categories_flags = aclflags ? categoryFlagsFromString((char*)aclflags) : 0;

--- a/src/module.c
+++ b/src/module.c
@@ -1390,7 +1390,7 @@ int64_t categoryFlagsFromString(char *aclflags) {
  * Example, 'write slow' marks the command as part of the write and slow ACL categories. */
 int RM_SetCommandCategories(RedisModuleCommand *command, const char *aclflags) {
     if (!command || !command->module || !command->module->onload) return REDISMODULE_ERR;
-    int64_t categories_flags = aclflags ? categoriesFlagsFromString((char*)aclflags) : 0;
+    int64_t categories_flags = aclflags ? categoryFlagsFromString((char*)aclflags) : 0;
     if (categories_flags == -1) return REDISMODULE_ERR;
     struct redisCommand *rcmd = command->rediscmd;
     rcmd->acl_categories = categories_flags; /* ACL categories flags for module command */

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -947,6 +947,7 @@ REDISMODULE_API int (*RedisModule_CreateCommand)(RedisModuleCtx *ctx, const char
 REDISMODULE_API RedisModuleCommand *(*RedisModule_GetCommand)(RedisModuleCtx *ctx, const char *name) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CreateSubcommand)(RedisModuleCommand *parent, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandInfo)(RedisModuleCommand *command, const RedisModuleCommandInfo *info) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_SetCommandCategories)(RedisModuleCommand *command, const char *ctgrsflags) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetModuleAttribs)(RedisModuleCtx *ctx, const char *name, int ver, int apiver) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsModuleNameBusy)(const char *name) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_WrongArity)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -1293,6 +1294,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(GetCommand);
     REDISMODULE_GET_API(CreateSubcommand);
     REDISMODULE_GET_API(SetCommandInfo);
+    REDISMODULE_GET_API(SetCommandCategories);
     REDISMODULE_GET_API(SetModuleAttribs);
     REDISMODULE_GET_API(IsModuleNameBusy);
     REDISMODULE_GET_API(WrongArity);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -947,7 +947,7 @@ REDISMODULE_API int (*RedisModule_CreateCommand)(RedisModuleCtx *ctx, const char
 REDISMODULE_API RedisModuleCommand *(*RedisModule_GetCommand)(RedisModuleCtx *ctx, const char *name) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CreateSubcommand)(RedisModuleCommand *parent, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandInfo)(RedisModuleCommand *command, const RedisModuleCommandInfo *info) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetCommandCategories)(RedisModuleCommand *command, const char *ctgrsflags) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_SetCommandACLCategories)(RedisModuleCommand *command, const char *ctgrsflags) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetModuleAttribs)(RedisModuleCtx *ctx, const char *name, int ver, int apiver) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsModuleNameBusy)(const char *name) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_WrongArity)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -1294,7 +1294,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(GetCommand);
     REDISMODULE_GET_API(CreateSubcommand);
     REDISMODULE_GET_API(SetCommandInfo);
-    REDISMODULE_GET_API(SetCommandCategories);
+    REDISMODULE_GET_API(SetCommandACLCategories);
     REDISMODULE_GET_API(SetModuleAttribs);
     REDISMODULE_GET_API(IsModuleNameBusy);
     REDISMODULE_GET_API(WrongArity);

--- a/src/server.h
+++ b/src/server.h
@@ -803,6 +803,8 @@ struct RedisModule {
     RedisModuleInfoFunc info_cb; /* Callback for module to add INFO fields. */
     RedisModuleDefragFunc defrag_cb;    /* Callback for global data defrag. */
     struct moduleLoadQueueEntry *loadmod; /* Module load arguments for config rewrite. */
+    int num_commands_with_acl_categories; /* Number of commands in this module included in acl categories */
+    int onload;     /* Flag to identify if the call is being made from Onload (0 or 1) */
 };
 typedef struct RedisModule RedisModule;
 

--- a/src/server.h
+++ b/src/server.h
@@ -2850,6 +2850,7 @@ void addACLLogEntry(client *c, int reason, int context, int argpos, sds username
 sds getAclErrorMessage(int acl_res, user *user, struct redisCommand *cmd, sds errored_val, int verbose);
 void ACLUpdateDefaultUserPassword(sds password);
 sds genRedisInfoStringACLStats(sds info);
+void ACLRecomputeCommandBitsFromCommandRulesAllUsers();
 
 /* Sorted sets data type */
 

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -183,6 +183,13 @@ int rm_call_aclcheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
     return REDISMODULE_OK;
 }
 
+int module_test_acl_category(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
@@ -191,6 +198,15 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx,"aclcheck.set.check.key", set_aclcheck_key,"write",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"aclcheck.module.command.aclcategories.write", module_test_acl_category, "write @write", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"aclcheck.module.command.aclcategories.write.function.read.category", module_test_acl_category, "write @read", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"aclcheck.module.command.aclcategories.read.only.category", module_test_acl_category, "@read", 0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx,"aclcheck.publish.check.channel", publish_aclcheck_channel,"",0,0,0) == REDISMODULE_ERR)

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -226,21 +226,21 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
     RedisModuleCommand *aclcategories_write = RedisModule_GetCommand(ctx,"aclcheck.module.command.aclcategories.write");
 
-    if (RedisModule_SetCommandCategories(aclcategories_write, "write") == REDISMODULE_ERR)
+    if (RedisModule_SetCommandACLCategories(aclcategories_write, "write") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx,"aclcheck.module.command.aclcategories.write.function.read.category", module_test_acl_category,"write",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
     RedisModuleCommand *read_category = RedisModule_GetCommand(ctx,"aclcheck.module.command.aclcategories.write.function.read.category");
 
-    if (RedisModule_SetCommandCategories(read_category, "read") == REDISMODULE_ERR)
+    if (RedisModule_SetCommandACLCategories(read_category, "read") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx,"aclcheck.module.command.aclcategories.read.only.category", module_test_acl_category,"",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
     RedisModuleCommand *read_only_category = RedisModule_GetCommand(ctx,"aclcheck.module.command.aclcategories.read.only.category");
 
-    if (RedisModule_SetCommandCategories(read_only_category, "read") == REDISMODULE_ERR)
+    if (RedisModule_SetCommandACLCategories(read_only_category, "read") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx,"aclcheck.publish.check.channel", publish_aclcheck_channel,"",0,0,0) == REDISMODULE_ERR)

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -198,11 +198,16 @@ int commandBlockCheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     response_ok |= (result == REDISMODULE_OK);
 
     RedisModuleCommand *parent = RedisModule_GetCommand(ctx,"block.commands.outside.onload");
+    result = RedisModule_SetCommandACLCategories(parent, "write");
+    response_ok |= (result == REDISMODULE_OK);
+
     result = RedisModule_CreateSubcommand(parent,"subcommand.that.should.fail",module_test_acl_category,"",0,0,0);
     response_ok |= (result == REDISMODULE_OK);
     
+    /* This validates that it's not possible to create commands outside OnLoad,
+     * thus returns an error if they succeed. */
     if (response_ok) {
-        RedisModule_ReplyWithError(ctx, "NOPERM");
+        RedisModule_ReplyWithError(ctx, "UNEXPECTEDOK");
     } else {
         RedisModule_ReplyWithSimpleString(ctx, "OK");
     }

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -217,16 +217,28 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_CreateCommand(ctx,"aclcheck.set.check.key", set_aclcheck_key,"write",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"block.commands.outside.onload", commandBlockCheck, "write", 0, 0, 0) == REDISMODULE_ERR)
+    if (RedisModule_CreateCommand(ctx,"block.commands.outside.onload", commandBlockCheck,"write",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"aclcheck.module.command.aclcategories.write", module_test_acl_category, "write @write", 0, 0, 0) == REDISMODULE_ERR)
+    if (RedisModule_CreateCommand(ctx,"aclcheck.module.command.aclcategories.write", module_test_acl_category,"write",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    RedisModuleCommand *aclcategories_write = RedisModule_GetCommand(ctx,"aclcheck.module.command.aclcategories.write");
+
+    if (RedisModule_SetCommandCategories(aclcategories_write, "write") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"aclcheck.module.command.aclcategories.write.function.read.category", module_test_acl_category, "write @read", 0, 0, 0) == REDISMODULE_ERR)
+    if (RedisModule_CreateCommand(ctx,"aclcheck.module.command.aclcategories.write.function.read.category", module_test_acl_category,"write",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    RedisModuleCommand *read_category = RedisModule_GetCommand(ctx,"aclcheck.module.command.aclcategories.write.function.read.category");
+
+    if (RedisModule_SetCommandCategories(read_category, "read") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (RedisModule_CreateCommand(ctx,"aclcheck.module.command.aclcategories.read.only.category", module_test_acl_category, "@read", 0, 0, 0) == REDISMODULE_ERR)
+    if (RedisModule_CreateCommand(ctx,"aclcheck.module.command.aclcategories.read.only.category", module_test_acl_category,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    RedisModuleCommand *read_only_category = RedisModule_GetCommand(ctx,"aclcheck.module.command.aclcategories.read.only.category");
+
+    if (RedisModule_SetCommandCategories(read_only_category, "read") == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx,"aclcheck.publish.check.channel", publish_aclcheck_channel,"",0,0,0) == REDISMODULE_ERR)

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -193,13 +193,15 @@ int module_test_acl_category(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 int commandBlockCheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
-    int error = 0;
+    int response_ok = 0;
     int result = RedisModule_CreateCommand(ctx,"command.that.should.fail", module_test_acl_category, "", 0, 0, 0);
-    error |= (result == REDISMODULE_ERR);
+    response_ok |= (result == REDISMODULE_OK);
+
     RedisModuleCommand *parent = RedisModule_GetCommand(ctx,"block.commands.outside.onload");
     result = RedisModule_CreateSubcommand(parent,"subcommand.that.should.fail",module_test_acl_category,"",0,0,0);
-    error |= (result == REDISMODULE_ERR);
-    if (error) {
+    response_ok |= (result == REDISMODULE_OK);
+    
+    if (response_ok) {
         RedisModule_ReplyWithError(ctx, "NOPERM");
     } else {
         RedisModule_ReplyWithSimpleString(ctx, "OK");

--- a/tests/modules/datatype.c
+++ b/tests/modules/datatype.c
@@ -234,11 +234,37 @@ static int datatype_is_in_slow_loading(RedisModuleCtx *ctx, RedisModuleString **
     return REDISMODULE_OK;
 }
 
+int createDataTypeBlockCheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+    static RedisModuleType *datatype_outside_onload = NULL;
+
+    RedisModuleTypeMethods datatype_methods = {
+        .version = REDISMODULE_TYPE_METHOD_VERSION,
+        .rdb_load = datatype_load,
+        .rdb_save = datatype_save,
+        .free = datatype_free,
+        .copy = datatype_copy
+    };
+
+    datatype_outside_onload = RedisModule_CreateDataType(ctx, "test_dt_outside_onload", 1, &datatype_methods);
+    if (datatype_outside_onload == NULL) {
+        RedisModule_ReplyWithError(ctx, "NOPERM");
+    } else {
+        RedisModule_ReplyWithSimpleString(ctx, "OK");
+    }
+    return REDISMODULE_OK;
+}
+
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
 
     if (RedisModule_Init(ctx,"datatype",DATATYPE_ENC_VER,REDISMODULE_APIVER_1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    /* Creates a command which creates a datatype outside OnLoad() function. */
+    if (RedisModule_CreateCommand(ctx,"block.create.datatype.outside.onload", createDataTypeBlockCheck, "write", 0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     RedisModule_SetModuleOptions(ctx, REDISMODULE_OPTIONS_HANDLE_IO_ERRORS);

--- a/tests/modules/datatype.c
+++ b/tests/modules/datatype.c
@@ -249,9 +249,9 @@ int createDataTypeBlockCheck(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 
     datatype_outside_onload = RedisModule_CreateDataType(ctx, "test_dt_outside_onload", 1, &datatype_methods);
     if (datatype_outside_onload == NULL) {
-        RedisModule_ReplyWithError(ctx, "NOPERM");
-    } else {
         RedisModule_ReplyWithSimpleString(ctx, "OK");
+    } else {
+        RedisModule_ReplyWithError(ctx, "NOPERM");
     }
     return REDISMODULE_OK;
 }

--- a/tests/modules/datatype.c
+++ b/tests/modules/datatype.c
@@ -248,10 +248,13 @@ int createDataTypeBlockCheck(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     };
 
     datatype_outside_onload = RedisModule_CreateDataType(ctx, "test_dt_outside_onload", 1, &datatype_methods);
+
+    /* This validates that it's not possible to create datatype outside OnLoad,
+     * thus returns an error if it succeeds. */
     if (datatype_outside_onload == NULL) {
         RedisModule_ReplyWithSimpleString(ctx, "OK");
     } else {
-        RedisModule_ReplyWithError(ctx, "NOPERM");
+        RedisModule_ReplyWithError(ctx, "UNEXPECTEDOK");
     }
     return REDISMODULE_OK;
 }

--- a/tests/modules/moduleconfigs.c
+++ b/tests/modules/moduleconfigs.c
@@ -123,9 +123,11 @@ int registerBlockCheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     result = RedisModule_LoadConfigs(ctx);
     response_ok |= (result == REDISMODULE_OK);
-
+    
+    /* This validates that it's not possible to register/load configs outside OnLoad,
+     * thus returns an error if they succeed. */
     if (response_ok) {
-        RedisModule_ReplyWithError(ctx, "NOPERM");
+        RedisModule_ReplyWithError(ctx, "UNEXPECTEDOK");
     } else {
         RedisModule_ReplyWithSimpleString(ctx, "OK");
     }

--- a/tests/modules/moduleconfigs.c
+++ b/tests/modules/moduleconfigs.c
@@ -106,25 +106,25 @@ int longlongApplyFunc(RedisModuleCtx *ctx, void *privdata, RedisModuleString **e
 int registerBlockCheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
-    int error = 0;
+    int response_ok = 0;
     int result = RedisModule_RegisterBoolConfig(ctx, "mutable_bool", 1, REDISMODULE_CONFIG_DEFAULT, getBoolConfigCommand, setBoolConfigCommand, boolApplyFunc, &mutable_bool_val);
-    error |= (result == REDISMODULE_ERR);
+    response_ok |= (result == REDISMODULE_OK);
 
     result = RedisModule_RegisterStringConfig(ctx, "string", "secret password", REDISMODULE_CONFIG_DEFAULT, getStringConfigCommand, setStringConfigCommand, NULL, NULL);
-    error |= (result == REDISMODULE_ERR);
+    response_ok |= (result == REDISMODULE_OK);
 
     const char *enum_vals[] = {"none", "five", "one", "two", "four"};
     const int int_vals[] = {0, 5, 1, 2, 4};
     result = RedisModule_RegisterEnumConfig(ctx, "enum", 1, REDISMODULE_CONFIG_DEFAULT, enum_vals, int_vals, 5, getEnumConfigCommand, setEnumConfigCommand, NULL, NULL);
-    error |= (result == REDISMODULE_ERR);
+    response_ok |= (result == REDISMODULE_OK);
 
     result = RedisModule_RegisterNumericConfig(ctx, "numeric", -1, REDISMODULE_CONFIG_DEFAULT, -5, 2000, getNumericConfigCommand, setNumericConfigCommand, longlongApplyFunc, &longval);
-    error |= (result == REDISMODULE_ERR);
+    response_ok |= (result == REDISMODULE_OK);
 
     result = RedisModule_LoadConfigs(ctx);
-    error |= (result == REDISMODULE_ERR);
+    response_ok |= (result == REDISMODULE_OK);
 
-    if (error) {
+    if (response_ok) {
         RedisModule_ReplyWithError(ctx, "NOPERM");
     } else {
         RedisModule_ReplyWithSimpleString(ctx, "OK");

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -107,13 +107,24 @@ start_server {tags {"modules acl"}} {
         assert_equal [r acl DRYRUN j3 aclcheck.module.command.aclcategories.write] OK
     }
 
-    test {test users without permissions, do not have access to module commands.} {
+    test {test existing users without permissions, do not have access to module commands loaded on runtime.} {
+        assert_equal [r module unload aclcheck] OK
         r acl SETUSER j4 on >password -@all +@READ
+        r acl SETUSER j5 on >password -@all +@WRITE
+        assert_equal [r module load $testmodule] OK
         catch {r acl DRYRUN j4 aclcheck.module.command.aclcategories.write} e
         assert_equal {User j4 has no permissions to run the 'aclcheck.module.command.aclcategories.write' command} $e
-        r acl SETUSER j5 on >password -@all +@WRITE
         catch {r acl DRYRUN j5 aclcheck.module.command.aclcategories.write.function.read.category} e
         assert_equal {User j5 has no permissions to run the 'aclcheck.module.command.aclcategories.write.function.read.category' command} $e
+    }
+
+    test {test users without permissions, do not have access to module commands.} {
+        r acl SETUSER j6 on >password -@all +@READ
+        catch {r acl DRYRUN j6 aclcheck.module.command.aclcategories.write} e
+        assert_equal {User j6 has no permissions to run the 'aclcheck.module.command.aclcategories.write' command} $e
+        r acl SETUSER j7 on >password -@all +@WRITE
+        catch {r acl DRYRUN j7 aclcheck.module.command.aclcategories.write.function.read.category} e
+        assert_equal {User j7 has no permissions to run the 'aclcheck.module.command.aclcategories.write.function.read.category' command} $e
     }
 
     test "Unload the module - aclcheck" {

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -92,6 +92,10 @@ start_server {tags {"modules acl"}} {
         assert {[dict get $entry reason] eq {command}}
     }
 
+    test {test blocking of Commands outside of OnLoad} {
+        assert_error {NOPERM} {r block.commands.outside.onload}
+    }
+
     test {test users to have access to module commands having acl categories} {
         r acl SETUSER j1 on >password -@all +@WRITE
         r acl SETUSER j2 on >password -@all +@READ

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -93,7 +93,7 @@ start_server {tags {"modules acl"}} {
     }
 
     test {test blocking of Commands outside of OnLoad} {
-        assert_error {NOPERM} {r block.commands.outside.onload}
+        assert_equal [r block.commands.outside.onload] OK
     }
 
     test {test users to have access to module commands having acl categories} {

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -8,6 +8,10 @@ start_server {tags {"modules"}} {
         assert {[r datatype.get dtkey] eq {100 stringval}}
     }
 
+    test {test blocking of datatype creation outside of OnLoad} {
+        assert_error {NOPERM} {r block.create.datatype.outside.onload}
+    }
+
     test {DataType: RM_SaveDataTypeToString(), RM_LoadDataTypeFromStringEncver() work} {
         r datatype.set dtkey -1111 MyString
         set encoded [r datatype.dump dtkey]

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -9,7 +9,7 @@ start_server {tags {"modules"}} {
     }
 
     test {test blocking of datatype creation outside of OnLoad} {
-        assert_error {NOPERM} {r block.create.datatype.outside.onload}
+        assert_equal [r block.create.datatype.outside.onload] OK
     }
 
     test {DataType: RM_SaveDataTypeToString(), RM_LoadDataTypeFromStringEncver() work} {

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -77,6 +77,10 @@ start_server {tags {"modules"}} {
         assert_match {*must be one of the following*} $e
     }
 
+    test {test blocking of config registration and load outside of OnLoad} {
+        assert_error {NOPERM} {r block.register.configs.outside.onload}
+    }
+
     test {Unload removes module configs} {
         r module unload moduleconfigs
         assert_equal [r config get moduleconfigs.*] ""

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -78,7 +78,7 @@ start_server {tags {"modules"}} {
     }
 
     test {test blocking of config registration and load outside of OnLoad} {
-        assert_error {NOPERM} {r block.register.configs.outside.onload}
+        assert_equal [r block.register.configs.outside.onload] OK
     }
 
     test {Unload removes module configs} {


### PR DESCRIPTION
Related to issues #11516 #11083 

This allows modules to register commands to existing ACL categories and blocks the creation of [sub]commands, datatypes and registering the configs outside of the OnLoad function.

For allowing modules to register commands to existing ACL categories,
This PR implements a new API `int RM_SetCommandACLCategories()` which takes a pointer to a `RedisModuleCommand` and a C string `aclflags` containing the set of space separated ACL categories.
Example, `'write slow'` marks the command as part of the write and slow ACL categories.

The C string `aclflags` is tokenized by implementing a helper function `categoryFlagsFromString()`. Theses tokens are matched and the corresponding ACL categories flags are set by a helper function `matchAclCategoriesFlags`. The helper function `categoryFlagsFromString()` returns the corresponding `categories_flags` or returns `-1` if some token not processed correctly.

If the module contains commands which are registered to existing ACL categories, the number of [sub]commands are tracked by `num_commands_with_acl_categories` in `struct RedisModule`. Further, the allowed command bit-map of the existing users are recomputed from the `command_rules` list, by implementing a function called `ACLRecomputeCommandBitsFromCommandRulesAllUsers()` for the existing users to have access to the module commands on runtime.


## Breaking change

This change requires that registering commands and subcommands only occur during a modules "OnLoad" function, in order to allow efficient recompilation of ACL bits. We also chose to block registering configs and types, since we believe it's only valid for those to be created during onLoad. We check for this `onload` flag in `struct RedisModule` to check if the call is made from the `OnLoad` function.