### PR TITLE
Implement stream pubsub.

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -544,7 +544,7 @@ static void handleClientsBlockedOnKey(readyList *rl) {
 
         while((ln = listNext(&li))) {
             client *receiver = listNodeValue(ln);
-            robj *o = lookupKeyReadWithFlags(rl->db, rl->key, LOKKUP_NOEFFECTS);
+            robj *o = lookupKeyReadWithFlags(rl->db, rl->key, LOOKUP_NOEFFECTS);
             /* 1. In case new key was added/touched we need to verify it satisfy the
              *    blocked type, since we might process the wrong key type.
              * 2. We want to serve clients blocked on module keys

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -7289,6 +7289,8 @@ int clusterRedirectBlockedClientIfNeeded(client *c) {
     return 0;
 }
 
+// TODO: stream pubsub unsubscribe when key migrated
+
 /* Slot to Key API. This is used by Redis Cluster in order to obtain in
  * a fast way a key that belongs to a specified hash slot. This is useful
  * while rehashing the cluster and in other conditions when we need to

--- a/src/commands.c
+++ b/src/commands.c
@@ -6231,6 +6231,7 @@ struct redisCommandArg XADD_data_Subargs[] = {
 struct redisCommandArg XADD_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"nomkstream",ARG_TYPE_PURE_TOKEN,-1,"NOMKSTREAM",NULL,"6.2.0",CMD_ARG_OPTIONAL},
+{"publish",ARG_TYPE_PURE_TOKEN,-1,"PUBLISH",NULL,"7.2.0",CMD_ARG_OPTIONAL},
 {"trim",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=XADD_trim_Subargs},
 {"id-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XADD_id_selector_Subargs},
 {"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=XADD_data_Subargs},
@@ -6457,6 +6458,7 @@ struct redisCommandArg XINFO_CONSUMERS_Args[] = {
 /* XINFO GROUPS history */
 commandHistory XINFO_GROUPS_History[] = {
 {"7.0.0","Added the `entries-read` and `lag` fields"},
+{"7.2.0","Added `num-subscribers` fields"},
 {0}
 };
 
@@ -6681,6 +6683,38 @@ struct redisCommandArg XSETID_Args[] = {
 {0}
 };
 
+/********** XSUBSCRIBE ********************/
+
+/* XSUBSCRIBE history */
+#define XSUBSCRIBE_History NULL
+
+/* XSUBSCRIBE tips */
+#define XSUBSCRIBE_tips NULL
+
+/* XSUBSCRIBE argument table */
+struct redisCommandArg XSUBSCRIBE_Args[] = {
+{"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_MULTIPLE},
+{0}
+};
+
+/********** XSUBSCRIBEGROUP ********************/
+
+/* XSUBSCRIBEGROUP history */
+#define XSUBSCRIBEGROUP_History NULL
+
+/* XSUBSCRIBEGROUP tips */
+#define XSUBSCRIBEGROUP_tips NULL
+
+/* XSUBSCRIBEGROUP argument table */
+struct redisCommandArg XSUBSCRIBEGROUP_Args[] = {
+{"group",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"consumer",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"numkeys",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE},
+{"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_MULTIPLE},
+{"noack",ARG_TYPE_PURE_TOKEN,-1,"NOACK",NULL,NULL,CMD_ARG_OPTIONAL},
+{0}
+};
+
 /********** XTRIM ********************/
 
 /* XTRIM history */
@@ -6722,6 +6756,20 @@ struct redisCommandArg XTRIM_trim_Subargs[] = {
 struct redisCommandArg XTRIM_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"trim",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XTRIM_trim_Subargs},
+{0}
+};
+
+/********** XUNSUBSCRIBE ********************/
+
+/* XUNSUBSCRIBE history */
+#define XUNSUBSCRIBE_History NULL
+
+/* XUNSUBSCRIBE tips */
+#define XUNSUBSCRIBE_tips NULL
+
+/* XUNSUBSCRIBE argument table */
+struct redisCommandArg XUNSUBSCRIBE_Args[] = {
+{"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE},
 {0}
 };
 
@@ -7393,7 +7441,10 @@ struct redisCommand redisCommandTable[] = {
 {"xreadgroup","Return new entries from a stream using a consumer group, or access the history of the pending entries for a given consumer. Can block.","For each stream mentioned: O(M) with M being the number of elements returned. If M is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1). On the other side when XREADGROUP blocks, XADD will pay the O(N) time in order to serve the N clients blocked on the stream getting new data.","5.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_STREAM,XREADGROUP_History,XREADGROUP_tips,xreadCommand,-7,CMD_BLOCKING|CMD_WRITE,ACL_CATEGORY_STREAM,{{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_KEYWORD,.bs.keyword={"STREAMS",4},KSPEC_FK_RANGE,.fk.range={-1,1,2}}},xreadGetKeys,.args=XREADGROUP_Args},
 {"xrevrange","Return a range of elements in a stream, with IDs matching the specified IDs interval, in reverse order (from greater to smaller IDs) compared to XRANGE","O(N) with N being the number of elements returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).","5.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_STREAM,XREVRANGE_History,XREVRANGE_tips,xrevrangeCommand,-4,CMD_READONLY,ACL_CATEGORY_STREAM,{{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=XREVRANGE_Args},
 {"xsetid","An internal command for replicating stream values","O(1)","5.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_STREAM,XSETID_History,XSETID_tips,xsetidCommand,-3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STREAM,{{NULL,CMD_KEY_RW|CMD_KEY_UPDATE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=XSETID_Args},
+{"xsubscribe","Listen for messages published to the given streams","O(N) where N is the number of streams to subscribe to.","7.2.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_STREAM,XSUBSCRIBE_History,XSUBSCRIBE_tips,xsubscribeCommand,-2,CMD_NOSCRIPT|CMD_READONLY,ACL_CATEGORY_STREAM,{{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={-1,1,0}}},.args=XSUBSCRIBE_Args},
+{"xsubscribegroup","Listen for messages published to the given streams using consumer group","O(N) where N is the number of streams to subscribe to.","7.2.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_STREAM,XSUBSCRIBEGROUP_History,XSUBSCRIBEGROUP_tips,xsubscribeCommand,-5,CMD_NOSCRIPT|CMD_WRITE,ACL_CATEGORY_STREAM,{{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_INDEX,.bs.index={3},KSPEC_FK_KEYNUM,.fk.keynum={0,1,1}}},xsubscribegroupGetKeys,.args=XSUBSCRIBEGROUP_Args},
 {"xtrim","Trims the stream to (approximately if '~' is passed) a certain size","O(N), with N being the number of evicted entries. Constant times are very small however, since entries are organized in macro nodes containing multiple entries that can be released with a single deallocation.","5.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_STREAM,XTRIM_History,XTRIM_tips,xtrimCommand,-4,CMD_WRITE,ACL_CATEGORY_STREAM,{{NULL,CMD_KEY_RW|CMD_KEY_DELETE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=XTRIM_Args},
+{"xunsubscribe","Stop listening for messages published to the given streams","O(N) where N is the number of streams to unsubscribe from.","7.2.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_STREAM,XUNSUBSCRIBE_History,XUNSUBSCRIBE_tips,xunsubscribeCommand,-1,CMD_NOSCRIPT|CMD_READONLY,ACL_CATEGORY_STREAM,{{NULL,CMD_KEY_RO|CMD_KEY_ACCESS,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={-1,1,0}}},.args=XUNSUBSCRIBE_Args},
 /* string */
 {"append","Append a value to a key","O(1). The amortized time complexity is O(1) assuming the appended value is small and the already present value is of any size, since the dynamic string library used by Redis will double the free space available on every reallocation.","2.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_STRING,APPEND_History,APPEND_tips,appendCommand,3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STRING,{{NULL,CMD_KEY_RW|CMD_KEY_INSERT,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=APPEND_Args},
 {"decr","Decrement the integer value of a key by one","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,COMMAND_GROUP_STRING,DECR_History,DECR_tips,decrCommand,2,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STRING,{{NULL,CMD_KEY_RW|CMD_KEY_ACCESS|CMD_KEY_UPDATE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}},.args=DECR_Args},

--- a/src/commands.c
+++ b/src/commands.c
@@ -6231,7 +6231,6 @@ struct redisCommandArg XADD_data_Subargs[] = {
 struct redisCommandArg XADD_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"nomkstream",ARG_TYPE_PURE_TOKEN,-1,"NOMKSTREAM",NULL,"6.2.0",CMD_ARG_OPTIONAL},
-{"publish",ARG_TYPE_PURE_TOKEN,-1,"PUBLISH",NULL,NULL,CMD_ARG_OPTIONAL},
 {"trim",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=XADD_trim_Subargs},
 {"id-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XADD_id_selector_Subargs},
 {"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=XADD_data_Subargs},

--- a/src/commands.c
+++ b/src/commands.c
@@ -6231,7 +6231,7 @@ struct redisCommandArg XADD_data_Subargs[] = {
 struct redisCommandArg XADD_Args[] = {
 {"key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE},
 {"nomkstream",ARG_TYPE_PURE_TOKEN,-1,"NOMKSTREAM",NULL,"6.2.0",CMD_ARG_OPTIONAL},
-{"publish",ARG_TYPE_PURE_TOKEN,-1,"PUBLISH",NULL,"7.2.0",CMD_ARG_OPTIONAL},
+{"publish",ARG_TYPE_PURE_TOKEN,-1,"PUBLISH",NULL,NULL,CMD_ARG_OPTIONAL},
 {"trim",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,.subargs=XADD_trim_Subargs},
 {"id-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_NONE,.subargs=XADD_id_selector_Subargs},
 {"data",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,.subargs=XADD_data_Subargs},

--- a/src/commands/xadd.json
+++ b/src/commands/xadd.json
@@ -62,6 +62,13 @@
                 "since": "6.2.0"
             },
             {
+                "token": "PUBLISH",
+                "name": "publish",
+                "type": "pure-token",
+                "optional": true,
+                "since": "7.2.0"
+            },
+            {
                 "name": "trim",
                 "type": "block",
                 "optional": true,

--- a/src/commands/xadd.json
+++ b/src/commands/xadd.json
@@ -62,12 +62,6 @@
                 "since": "6.2.0"
             },
             {
-                "token": "PUBLISH",
-                "name": "publish",
-                "type": "pure-token",
-                "optional": true
-            },
-            {
                 "name": "trim",
                 "type": "block",
                 "optional": true,

--- a/src/commands/xadd.json
+++ b/src/commands/xadd.json
@@ -65,8 +65,7 @@
                 "token": "PUBLISH",
                 "name": "publish",
                 "type": "pure-token",
-                "optional": true,
-                "since": "7.2.0"
+                "optional": true
             },
             {
                 "name": "trim",

--- a/src/commands/xsubscribe.json
+++ b/src/commands/xsubscribe.json
@@ -1,23 +1,14 @@
 {
-    "GROUPS": {
-        "summary": "List the consumer groups of a stream",
-        "complexity": "O(1)",
+    "XSUBSCRIBE": {
+        "summary": "Listen for messages published to the given streams",
+        "complexity": "O(N) where N is the number of streams to subscribe to.",
         "group": "stream",
-        "since": "5.0.0",
-        "arity": 3,
-        "container": "XINFO",
-        "history": [
-            [
-                "7.0.0",
-                "Added the `entries-read` and `lag` fields"
-            ],
-            [
-                "7.2.0",
-                "Added `num-subscribers` fields"
-            ]
-        ],
-        "function": "xinfoCommand",
+        "since": "7.2.0",
+        "arity": -2,
+        "function": "xsubscribeCommand",
+        "history": [],
         "command_flags": [
+            "NOSCRIPT",
             "READONLY"
         ],
         "acl_categories": [
@@ -31,12 +22,12 @@
                 ],
                 "begin_search": {
                     "index": {
-                        "pos": 2
+                        "pos": 1
                     }
                 },
                 "find_keys": {
                     "range": {
-                        "lastkey": 0,
+                        "lastkey": -1,
                         "step": 1,
                         "limit": 0
                     }
@@ -47,7 +38,8 @@
             {
                 "name": "key",
                 "type": "key",
-                "key_spec_index": 0
+                "key_spec_index": 0,
+                "multiple": true
             }
         ]
     }

--- a/src/commands/xsubscribegroup.json
+++ b/src/commands/xsubscribegroup.json
@@ -1,0 +1,65 @@
+{
+    "XSUBSCRIBEGROUP": {
+        "summary": "Listen for messages published to the given streams using consumer group",
+        "complexity": "O(N) where N is the number of streams to subscribe to.",
+        "group": "stream",
+        "since": "7.2.0",
+        "arity": -5,
+        "function": "xsubscribeCommand",
+        "get_keys_function": "xsubscribegroupGetKeys",
+        "history": [],
+        "command_flags": [
+            "NOSCRIPT",
+            "WRITE"
+        ],
+        "acl_categories": [
+            "STREAM"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 3
+                    }
+                },
+                "find_keys": {
+                    "keynum": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "step": 1
+                    }
+                }
+            }
+        ],
+        "arguments": [
+            {
+                "name": "group",
+                "type": "string"
+            },
+            {
+                "name": "consumer",
+                "type": "string"
+            },
+            {
+                "name": "numkeys",
+                "type": "integer"
+            },
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            },
+            {
+                "name": "noack",
+                "token": "NOACK",
+                "type": "pure-token",
+                "optional": true
+            }
+        ]
+    }
+}

--- a/src/commands/xunsubscribe.json
+++ b/src/commands/xunsubscribe.json
@@ -1,23 +1,14 @@
 {
-    "GROUPS": {
-        "summary": "List the consumer groups of a stream",
-        "complexity": "O(1)",
+    "XUNSUBSCRIBE": {
+        "summary": "Stop listening for messages published to the given streams",
+        "complexity": "O(N) where N is the number of streams to unsubscribe from.",
         "group": "stream",
-        "since": "5.0.0",
-        "arity": 3,
-        "container": "XINFO",
-        "history": [
-            [
-                "7.0.0",
-                "Added the `entries-read` and `lag` fields"
-            ],
-            [
-                "7.2.0",
-                "Added `num-subscribers` fields"
-            ]
-        ],
-        "function": "xinfoCommand",
+        "since": "7.2.0",
+        "arity": -1,
+        "function": "xunsubscribeCommand",
+        "history": [],
         "command_flags": [
+            "NOSCRIPT",
             "READONLY"
         ],
         "acl_categories": [
@@ -31,12 +22,12 @@
                 ],
                 "begin_search": {
                     "index": {
-                        "pos": 2
+                        "pos": 1
                     }
                 },
                 "find_keys": {
                     "range": {
-                        "lastkey": 0,
+                        "lastkey": -1,
                         "step": 1,
                         "limit": 0
                     }
@@ -47,7 +38,9 @@
             {
                 "name": "key",
                 "type": "key",
-                "key_spec_index": 0
+                "key_spec_index": 0,
+                "optional": true,
+                "multiple": true
             }
         ]
     }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1776,7 +1776,9 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
     if (!strcasecmp(command,"monitor")) config.monitor_mode = 1;
     if (!strcasecmp(command,"subscribe") ||
         !strcasecmp(command,"psubscribe") ||
-        !strcasecmp(command,"ssubscribe")) config.pubsub_mode = 1;
+        !strcasecmp(command,"ssubscribe") || 
+        !strcasecmp(command,"xsubscribe") ||
+        !strcasecmp(command,"xsubscribegroup")) config.pubsub_mode = 1;
     if (!strcasecmp(command,"sync") ||
         !strcasecmp(command,"psync")) config.slave_mode = 1;
 

--- a/src/server.c
+++ b/src/server.c
@@ -1855,7 +1855,6 @@ void createSharedObjects(void) {
     shared.punsubscribebulk = createStringObject("$12\r\npunsubscribe\r\n",19);
 
     shared.xmessagebulk = createStringObject("$8\r\nxmessage\r\n", 14);
-    shared.xgroupmessagebulk = createStringObject("$13\r\nxgroupmessage\r\n", 20);
     shared.xsubscribebulk = createStringObject("$10\r\nxsubscribe\r\n", 17);
     shared.xsubscribegroupbulk = createStringObject("$15\r\nxsubscribegroup\r\n", 22);
     shared.xunsubscribebulk = createStringObject("$12\r\nxunsubscribe\r\n", 19);

--- a/src/server.h
+++ b/src/server.h
@@ -1258,7 +1258,7 @@ struct sharedObjectsStruct {
     *masterdownerr, *roslaveerr, *execaborterr, *noautherr, *noreplicaserr,
     *busykeyerr, *oomerr, *plus, *messagebulk, *pmessagebulk, *subscribebulk,
     *unsubscribebulk, *psubscribebulk, *punsubscribebulk, *xsubscribebulk, 
-    *xsubscribegroupbulk, *xunsubscribebulk, *xmessagebulk, *xgroupmessagebulk,
+    *xsubscribegroupbulk, *xunsubscribebulk, *xmessagebulk,
     *del, *unlink, *rpop, *lpop, *lpush, *rpoplpush, *lmove, *blmove, *zpopmin, 
     *zpopmax, *emptyscan, *multi, *exec, *left, *right, *hset, *srem, *xgroup, 
     *xclaim, *script, *replconf, *eval, *persist, *set, *pexpireat, *pexpire, 

--- a/src/stream.h
+++ b/src/stream.h
@@ -26,7 +26,8 @@ typedef struct stream {
     dict *client_to_subscriber; /* An index for subscribers list, including those in groups.
                                    We use client id as key, and value points to the listNode
                                    holding the corresponding streamSubscriber structure. */
-    list *pub_ids;          /* List of streamIDs that need to be published. */
+    streamID pub_start;     /* The first ID that need to be published. */
+    streamID pub_end;       /* The last ID that need to be published. */
 } stream;
 
 /* We define an iterator to iterate stream items in an abstract way, without

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -62,6 +62,7 @@ int clientsCronHandleTimeout(client *c, mstime_t now_ms) {
         !mustObeyClient(c) &&         /* No timeout for masters and AOF */
         !(c->flags & CLIENT_BLOCKED) && /* No timeout for BLPOP */
         !(c->flags & CLIENT_PUBSUB) &&  /* No timeout for Pub/Sub clients */
+        !(c->flags & CLIENT_KEY_PUBSUB) && /* No timeout for key Pub/Sub clients */
         (now - c->lastinteraction > server.maxidletime))
     {
         serverLog(LL_VERBOSE,"Closing idle client");

--- a/tests/modules/cmdintrospection.c
+++ b/tests/modules/cmdintrospection.c
@@ -61,6 +61,12 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                 .flags = REDISMODULE_CMD_ARG_OPTIONAL
             },
             {
+                .name = "publish",
+                .token = "PUBLISH",
+                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                .flags = REDISMODULE_CMD_ARG_OPTIONAL
+            },
+            {
                 .name = "trim",
                 .type = REDISMODULE_ARG_TYPE_BLOCK,
                 .flags = REDISMODULE_CMD_ARG_OPTIONAL,

--- a/tests/modules/cmdintrospection.c
+++ b/tests/modules/cmdintrospection.c
@@ -61,12 +61,6 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                 .flags = REDISMODULE_CMD_ARG_OPTIONAL
             },
             {
-                .name = "publish",
-                .token = "PUBLISH",
-                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-                .flags = REDISMODULE_CMD_ARG_OPTIONAL
-            },
-            {
                 .name = "trim",
                 .type = REDISMODULE_ARG_TYPE_BLOCK,
                 .flags = REDISMODULE_CMD_ARG_OPTIONAL,


### PR DESCRIPTION
I am working on implementing stream pubsub, to resolve #10809. It is mostly done and I'd like to publish it to see if I missed anything or maybe there are some better ideas.

## Original Issue

The main problem is that while using `XREAD` or `XREADGROUP` to remotely consume a stream, this pull mode has poor performance with twice network delay (consumer sends the command to server, then server returns the data to consumer). 

If a push mode like PUBSUB is implemented in stream, we can half the network delay by actively pushing the message, without consumer sending commands.

Also, a reverse request to persist PUBSUB data to stream was already raised before.
## Design
One direct approach is to copy sharded PUBSUB's code into stream's logic. However, handling keys is much more complicated than handling sharded channels, as we need to notify the client when the subscribed key is deleted, moved or migrated, etc.

Since `XREAD/XREADGROUP` has the `block` option, we can implement this feature by cyclically calling `XREAD/XREADGROUP BLOCK` for the subscribed client on the server side. But we can't actually block the client, so the solution is to create a mechanism parallel to the command block. 

1. When a client sends a subscribe command, the server adds the key and the client to a dict, just like calling `blockForKeys`. 
2. Then when some new data is added to the key (XADD in this PR), or when the key is deleted or expired, it awakens the subscribed key, adding it to a "ready_list". 
3. Finally all the awakened keys are handled after the `call` function and in `beforeSleep`.

### Command
When `XADD` is called, and when there is at least one subscriber, the new added messages will automatically be published.
```
XSUBSCRIBE key [key ...]
XSUBSCRIBEGROUP group consumer numkeys key [key ...] [NOACK]
XUNSUBSCRIBE [key [key ...]]
```
### Data Structure

Just like command block.

In redisDb:
```
dict *subscribed_keys;
dict *publishing_keys;
```
In redisServer:
```
list* publishing_keys;
```
In client:
```
dict *subscribed_keys;
long subscribed_key_cnt;
```
A streamSubscriber struct to record subscription info:

To record the group and the consumer the client is using, create a new streamSubscriber and use two pointers to store the group and consumer the client is using (NULL if it is XSUBSCRIBE), and use a flag to store NOACK and to mark a streamSubscriber invalid (when the group or the consumer is deleted).
```
/* A structure recording each subscriber's information, including group, consumer and flags for noack
   and invalid mark. */
typedef struct streamSubscriber {
    client* c;
    streamCG* group;
    streamConsumer* consumer;
    int flags;
} streamSubscriber;
```
And in stream:

The `subscribers` and `group_subscribers` here is where the data is actually stored. 

The client_to_subscriber is only an index, which is used for quick judging whether a client is already subscribed to a stream, and to find the listNode when a client is going to unsubscribe a stream.

To store the streamIDs that need to be published, we store the start and the end ID.
```
list *subscribers;      /* List of subscribers subscribed by using XSUBSCRIBE. */
dict *group_subscribers;    /* Dict of lists of subscribers subscribed by using XSUBSCRIBEGROUP. */
dict *client_to_subscriber; /* An index for subscribers list, including those in groups.
                               We use client id as key, and value points to the listNode
                               holding the corresponding streamSubscriber structure. */
streamID pub_start;     /* The first ID that need to be published. */
streamID pub_end;       /* The last ID that need to be published. */
```
In streamCG:

The `subscribers` in `streamCG` is only a pointer. It is used for traversing all subscribers in a group.
```
dictEntry *subscribers; /* A pointer to the dictEntry whose value is the list of 
                           subscribers subscribed as a consumer in this group. */
listNode *receiver;     /* The subscriber to which the next group publish message
                           should be sent. */
```
### Subscription/Publication Details

Outside of stream structure, everything is just like command block, except that we don't have "unblock_on_nokey" dict, since it is designed to unsubscribe all clients when the key is deleted.

Inside of the stream structure, things are a little bit complicated. 

To subscribe a stream:
1. add the key to the client's dict
2. add the key and client to DB's dict
3. add a streamSubscriber to the stream's list (XSUBSCRIBE) or dict (XSUBSCRIBEGROUP).

To publish a message: 
1. stream->subscribers will firstly be traversed to publish to all clients subscribed using XSUBSCRIBE
2. stream->group_subscribers is traversed to unsubscribe all invalid subscribers, then for each group, the message will be published to one of the subscribers. Currently, clients in a group will receive the publish message by turns, no load balancing is considered.

### Deleted/Moved/Overwritten Streams

Will `signalPublishStream` just like `signalDeletedKeyAsReady` in block.

### Deleted Group Or Consumer

Will mark the subscribers using the group/consumer as invalid. Then `signalPublishStream`, and unsubscribe them after `call` or in `beforeSleep`.

### Reacquire Lost Message

`XSUBSCRIBEGROUP` and `XADD` will have the same results as `XREADGROUP`, so messages without ACKs will be recorded in PEL, and clients can use `XPENDING` and `XREAD` to reacquire them.

### Mixed Use of Regular Consumer and Group Subscriber

You can consider group subscribers as a special kind of regular consumer, that will `XREADGROUP` a new message once it is added to stream, so regular consumers will not get anything if there is a subscriber in the same group unless you put `XADD` and `XREADGROUP` in the same queue of `MULTI`.

So still, the group will deliver each ID only once, and each subscriber/consumer will not get any same message.

## Yet Still Need To Be Done

- cluster redirect: clients subscribed to migrated streams need to be sent a redirection error
- swapdb: unsubscribe all clients when DB is swaped?
- redis-cli: automatically send back XACK in stream pubsub mode?
- add some fields in XINFO command's return
- TCL tests

## How To Use

Suppose there is a stream "a" with a group "g", using redis-cli, we can:
```
127.0.0.1:6379> xsubscribe a
```
And the following information will be returned:
```
1) "xsubscribe" // a fixed line
2) "a"          // key
3) (integer) 0  // dbnum
4) (integer) 1  // currently subscirbed stream num
```
Using another client to publish:
```
127.0.0.1:6379> xadd a publish * 1 2
```
And the following information will be reveived by the subscriber:
```
1) "xmessage"              // a fixed line
2) "a"                     // key
3) (integer) 0             // dbnum
4) 1) 1) "1673945541549-0" // published stream content
      2) 1) "1"
         2) "2"
```
When MULTI is used, multiple messages will be merged as one:
```
127.0.0.1:6379> multi 
OK
127.0.0.1:6379(TX)> xadd a publish * 3 4
QUEUED
127.0.0.1:6379(TX)> xadd a publish * 5 6
QUEUED
127.0.0.1:6379(TX)> exec
1) "1673945563138-0"
2) "1673945563138-1"
```
```
1) "xmessage"
2) "a"
3) (integer) 0
4) 1) 1) "1673945563138-0"
      2) 1) "3"
         2) "4"
   2) 1) "1673945563138-1"
      2) 1) "5"
         2) "6"
```
Similarly, using XSUBSCRIBEGROUP:
```
127.0.0.1:6379> xsubscribegroup g c 1 a 
```
And the following information will be returned:
```
1) "xsubscribegroup" // a fixed line
2) "a"               // key
3) (integer) 0       // dbnum
4) "g"               // group name
5) "c"               // consumer name
6) (integer) 1       // currently subscirbed stream num
```