### PR TITLE
Document some fields history of CLIENT LIST command

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -840,7 +840,10 @@ struct redisCommandArg CLIENT_KILL_Args[] = {
 commandHistory CLIENT_LIST_History[] = {
 {"2.8.12","Added unique client `id` field."},
 {"5.0.0","Added optional `TYPE` filter."},
-{"6.2.0","Added `laddr` field and the optional `ID` filter."},
+{"6.0.0","Added `user` field."},
+{"6.2.0","Added `argv-mem`, `tot-mem`, `laddr` and `redir` fields and the optional `ID` filter."},
+{"7.0.0","Added `resp`, `multi-mem`, `rbs` and `rbp` fields."},
+{"7.0.3","Added `ssub` field."},
 {0}
 };
 

--- a/src/commands/client-list.json
+++ b/src/commands/client-list.json
@@ -17,8 +17,20 @@
                 "Added optional `TYPE` filter."
             ],
             [
+                "6.0.0",
+                "Added `user` field."
+            ],
+            [
                 "6.2.0",
-                "Added `laddr` field and the optional `ID` filter."
+                "Added `argv-mem`, `tot-mem`, `laddr` and `redir` fields and the optional `ID` filter."
+            ],
+            [
+                "7.0.0",
+                "Added `resp`, `multi-mem`, `rbs` and `rbp` fields."
+            ],
+            [
+                "7.0.3",
+                "Added `ssub` field."
             ]
         ],
         "command_flags": [


### PR DESCRIPTION
Change history:
- `user` added in 6.0.0, 0f42447a0ec841f0b3e83328ac16a573012e2880
- `argv-mem` and `tot-mem` added in 6.2.0, bea40e6a41e31a52e9e6efee77ea5a4bd873b759
- `redir` added in 6.2.0, dd1f20edc5ecda7848c31601782c5e9d7bce4788
- `resp` added in 7.0.0, 7c376398b1cd827282e17804e230c41cbb48a89c
- `multi-mem` added in 7.0.0, 2753429c99425e3d0216cba79e0e61192975f252
- `rbs` and `rbp` added in 7.0.0, 47c51d0c7858dc8ce7747b78b73cf8cec2e59ff3
- `ssub` added in 7.0.3, 35c2ee8716dc9b1d4edbbb409815a585af491335