### PR TITLE
GETRANGE and SUBSTR should return nil on missing keys, like GET does

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -508,7 +508,7 @@ void getrangeCommand(client *c) {
         return;
     if (getLongLongFromObjectOrReply(c,c->argv[3],&end,NULL) != C_OK)
         return;
-    if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.emptybulk)) == NULL ||
+    if ((o = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp])) == NULL ||
         checkType(c,o,OBJ_STRING)) return;
 
     if (o->encoding == OBJ_ENCODING_INT) {

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -426,7 +426,10 @@ start_server {tags {"string"}} {
 
     test "GETRANGE against non-existing key" {
         r del mykey
-        assert_equal "" [r getrange mykey 0 -1]
+        # Make sure we can distinguish between an empty string and a null response
+        r readraw 1
+        assert_equal {$-1} [r getrange mykey 0 -1]
+        r readraw 0
     }
 
     test "GETRANGE against string value" {


### PR DESCRIPTION
Currently GETRANGE and SUBSTR returns an empty string,
(shared.emptybulk) on missing keys. See #11378, they should
return nil in this case, like GET dose.

This is a breaking change, and will be part of Redis 8.0.
Fixes #11378