### PR TITLE
Hide client command arguments

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -388,6 +388,11 @@ databases 16
 # ASCII art logo in startup logs by setting the following option to yes.
 always-show-logo no
 
+# To avoid logging personal identifiable information (PII) into server log file,
+# uncomment the following:
+#
+# hide-client-log yes
+
 # By default, Redis modifies the process title (as seen in 'top' and 'ps') to
 # provide some runtime information. It is possible to disable this and leave
 # the process name as executed by setting the following to no.

--- a/src/config.c
+++ b/src/config.c
@@ -3095,6 +3095,7 @@ standardConfig static_configs[] = {
     createBoolConfig("latency-tracking", NULL, MODIFIABLE_CONFIG, server.latency_tracking_enabled, 1, NULL, NULL),
     createBoolConfig("aof-disable-auto-gc", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.aof_disable_auto_gc, 0, NULL, updateAofAutoGCEnabled),
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
+    createBoolConfig("hide-client-log", NULL, MODIFIABLE_CONFIG, server.hide_client_log, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/debug.c
+++ b/src/debug.c
@@ -1067,6 +1067,11 @@ void _serverAssert(const char *estr, const char *file, int line) {
     bugReportEnd(0, 0);
 }
 
+/* Returns the amount of client's command arguments we allow logging */
+int clientArgsToLog(const client *c) {
+    return server.hide_client_log ? 1 : c->argc;
+}
+
 void _serverAssertPrintClientInfo(const client *c) {
     int j;
     char conninfo[CONN_INFO_LEN];
@@ -1077,6 +1082,10 @@ void _serverAssertPrintClientInfo(const client *c) {
     serverLog(LL_WARNING,"client->conn = %s", connGetInfo(c->conn, conninfo, sizeof(conninfo)));
     serverLog(LL_WARNING,"client->argc = %d", c->argc);
     for (j=0; j < c->argc; j++) {
+        if (j >= clientArgsToLog(c)){
+            serverLog(LL_WARNING|LL_RAW,"client->argv[%d]: *redacted*\n", j);
+            continue;
+        }
         char buf[128];
         char *arg;
 
@@ -1268,6 +1277,10 @@ static void* getAndSetMcontextEip(ucontext_t *uc, void *eip) {
 
 REDIS_NO_SANITIZE("address")
 void logStackContent(void **sp) {
+    if (server.hide_client_log) {
+        serverLog(LL_NOTICE,"hide-client-log is on, skip logging stack content to avid spilling PII.");
+        return;
+    }
     int i;
     for (i = 15; i >= 0; i--) {
         unsigned long addr = (unsigned long) sp+i;
@@ -1917,6 +1930,10 @@ void logCurrentClient(client *cc, const char *title) {
     sdsfree(client);
     serverLog(LL_WARNING|LL_RAW,"argc: '%d'\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
+        if (j >= clientArgsToLog(cc)){
+            serverLog(LL_WARNING|LL_RAW,"client->argv[%d]: *redacted*\n", j);
+            continue;
+        }
         robj *decoded;
         decoded = getDecodedObject(cc->argv[j]);
         sds repr = sdscatrepr(sdsempty(),decoded->ptr, min(sdslen(decoded->ptr), 128));

--- a/src/debug.c
+++ b/src/debug.c
@@ -1931,7 +1931,7 @@ void logCurrentClient(client *cc, const char *title) {
     serverLog(LL_WARNING|LL_RAW,"argc: '%d'\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
         if (j >= clientArgsToLog(cc)){
-            serverLog(LL_WARNING|LL_RAW,"client->argv[%d]: *redacted*\n", j);
+            serverLog(LL_WARNING|LL_RAW,"argv[%d]: *redacted*\n", j);
             continue;
         }
         robj *decoded;

--- a/src/replication.c
+++ b/src/replication.c
@@ -1170,7 +1170,6 @@ void syncCommand(client *c) {
  * result in an empty RDB. */
 void replconfCommand(client *c) {
     int j;
-    
     if ((c->argc % 2) == 0) {
         /* Number of arguments must be odd to make sure that every
          * option has a corresponding value. */

--- a/src/server.h
+++ b/src/server.h
@@ -1717,6 +1717,7 @@ struct redisServer {
 
     /* Configuration */
     int verbosity;                  /* Loglevel in redis.conf */
+    int hide_client_log;           /* In the event of an assertion failure, hide command arguments from the operator */
     int maxidletime;                /* Client timeout in seconds */
     int tcpkeepalive;               /* Set SO_KEEPALIVE if non-zero. */
     int active_expire_enabled;      /* Can be disabled for testing purposes. */

--- a/src/server.h
+++ b/src/server.h
@@ -1717,7 +1717,7 @@ struct redisServer {
 
     /* Configuration */
     int verbosity;                  /* Loglevel in redis.conf */
-    int hide_client_log;           /* In the event of an assertion failure, hide command arguments from the operator */
+    int hide_client_log;            /* In the event of an assertion failure, hide command arguments from the operator */
     int maxidletime;                /* Client timeout in seconds */
     int tcpkeepalive;               /* Set SO_KEEPALIVE if non-zero. */
     int active_expire_enabled;      /* Can be disabled for testing purposes. */


### PR DESCRIPTION
In the event of an assertion failure, hide command arguments from the operator.

In some cases, private client information can be voluntarily exposed when a redis instance crashes due to an assertion failure.
This commit prevent וnintentional client info exposure.
Operators can still access the hidden data, but they must actively request it. 
Any of the client info commands remains the unchanged.