### PR TITLE
Add maxmemory-reserved-scale parameter to evict keys earlier if maxmemory parameter is set

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1209,6 +1209,9 @@ acllog-max-len 128
 # in the system. It's a tradeoff between memory, CPU and latency.
 #
 # active-expire-effort 1
+#
+# maxmemory-reserved-scale 0
+
 
 ############################# LAZY FREEING ####################################
 

--- a/redis.conf
+++ b/redis.conf
@@ -1209,7 +1209,12 @@ acllog-max-len 128
 # in the system. It's a tradeoff between memory, CPU and latency.
 #
 # active-expire-effort 1
-#
+# 
+# It allows the redis to evict keys earlier. The value of this parameter represents
+# percent of the maxmemory value. It means how much memory the redis instance want to hold
+# not to store the data.
+# Default is 0, and the value could be set between 10 to 60.
+# 
 # maxmemory-reserved-scale 0
 
 

--- a/src/config.c
+++ b/src/config.c
@@ -2463,7 +2463,7 @@ static int updateReplBacklogSize(const char **err) {
     return 1;
 }
 
-static int updateMaxmemoryReserved(const char **err){
+static int updateMaxmemoryReserved(const char **err) {
     UNUSED(err);
     if (server.maxmemory_reserved_scale) {
         if (server.maxmemory_reserved_scale < 10) {

--- a/src/config.c
+++ b/src/config.c
@@ -2472,7 +2472,7 @@ static int updateMaxmemoryReserved(const char **err){
             server.maxmemory_reserved_scale = 60;
         }
     }
-    server.maxmemory_reserved = (unsigned long long)server.maxmemory / 100.0 * server.maxmemory_reserved_scale;
+    server.maxmemory_available= (unsigned long long)server.maxmemory / 100.0 * (100 - server.maxmemory_reserved_scale);
     return 1;
 }
 
@@ -2483,7 +2483,7 @@ static int updateMaxmemory(const char **err) {
         if (server.maxmemory < used) {
             serverLog(LL_WARNING,"WARNING: the new maxmemory value set via CONFIG SET (%llu) is smaller than the current memory usage (%zu). This will result in key eviction and/or the inability to accept new write commands depending on the maxmemory-policy.", server.maxmemory, used);
         }
-        server.maxmemory_reserved = (unsigned long long)server.maxmemory / 100.0 * server.maxmemory_reserved_scale;
+        server.maxmemory_available= (unsigned long long)server.maxmemory / 100.0 * (100 - server.maxmemory_reserved_scale);
         startEvictionTimeProc();
     }
     return 1;

--- a/src/evict.c
+++ b/src/evict.c
@@ -564,10 +564,6 @@ int performEvictions(void) {
     int slaves = listLength(server.slaves);
     int result = EVICT_FAIL;
     
-    //serverLog(LL_WARNING,"-------------------------------------------------");
-    //serverLog(LL_WARNING,"Current maxmemory reserved scale is: %d",server.maxmemory_reserved_scale);
-    //serverLog(LL_WARNING,"Current maxmemory reserved size is: %lld",server.maxmemory_reserved);
-    //serverLog(LL_WARNING,"Current maxmemory is: %lld",server.maxmemory);
     if (getMaxmemoryState(&mem_reported,NULL,&mem_tofree,NULL) == C_OK) {
         result = EVICT_OK;
         goto update_metrics;

--- a/src/evict.c
+++ b/src/evict.c
@@ -409,7 +409,7 @@ int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *lev
     }
 
     if (server.maxmemory_reserved_scale) {
-        if (mem_reported <= server.maxmemory_reserved && !level) return C_OK;
+        if (mem_reported <= server.maxmemory_available && !level) return C_OK;
     } else if (mem_reported <= server.maxmemory && !level) 
         return C_OK;
 
@@ -422,23 +422,23 @@ int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *lev
     /* Compute the ratio of memory usage. */
     if (level) {
         if (server.maxmemory_reserved_scale)
-            *level = (float)mem_used / (float)server.maxmemory_reserved;
+            *level = (float)mem_used / (float)server.maxmemory_available;
         else
             *level = (float)mem_used / (float)server.maxmemory;
     }
 
     if (server.maxmemory_reserved_scale) {
-        if (mem_reported <= server.maxmemory_reserved) return C_OK;
+        if (mem_reported <= server.maxmemory_available) return C_OK;
     } else if (mem_reported <= server.maxmemory) return C_OK;
 
     /* Check if we are still over the memory limit. */
     if (server.maxmemory_reserved_scale) {
-        if (mem_used <= server.maxmemory_reserved) return C_OK;
+        if (mem_used <= server.maxmemory_available) return C_OK;
     } else if (mem_used <= server.maxmemory) return C_OK;
 
     /* Compute how much memory we need to free. */
     if (server.maxmemory_reserved_scale) {
-        mem_tofree = mem_used - server.maxmemory_reserved;
+        mem_tofree = mem_used - server.maxmemory_available;
     } else
         mem_tofree = mem_used - server.maxmemory;
 
@@ -564,10 +564,10 @@ int performEvictions(void) {
     int slaves = listLength(server.slaves);
     int result = EVICT_FAIL;
     
-    serverLog(LL_WARNING,"-------------------------------------------------");
-    serverLog(LL_WARNING,"Current maxmemory reserved scale is: %d",server.maxmemory_reserved_scale);
-    serverLog(LL_WARNING,"Current maxmemory reserved size is: %lld",server.maxmemory_reserved);
-    serverLog(LL_WARNING,"Current maxmemory is: %lld",server.maxmemory);
+    //serverLog(LL_WARNING,"-------------------------------------------------");
+    //serverLog(LL_WARNING,"Current maxmemory reserved scale is: %d",server.maxmemory_reserved_scale);
+    //serverLog(LL_WARNING,"Current maxmemory reserved size is: %lld",server.maxmemory_reserved);
+    //serverLog(LL_WARNING,"Current maxmemory is: %lld",server.maxmemory);
     if (getMaxmemoryState(&mem_reported,NULL,&mem_tofree,NULL) == C_OK) {
         result = EVICT_OK;
         goto update_metrics;

--- a/src/server.c
+++ b/src/server.c
@@ -2538,7 +2538,7 @@ void initServer(void) {
     server.client_mem_usage_buckets = NULL;
     resetReplicationBuffer();
     if (server.maxmemory && server.maxmemory_reserved_scale) {
-        server.maxmemory_reserved = (unsigned long long)server.maxmemory / 100.0 * server.maxmemory_reserved_scale;
+        server.maxmemory_available = (unsigned long long)server.maxmemory / 100.0 * (100 - server.maxmemory_reserved_scale);
     }
 
     /* Make sure the locale is set on startup based on the config file. */
@@ -5524,7 +5524,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         char used_memory_scripts_hmem[64];
         char used_memory_rss_hmem[64];
         char maxmemory_hmem[64];
-        char maxmemory_reserved_hmem[64];
+        char maxmemory_available_hmem[64];
         size_t zmalloc_used = zmalloc_used_memory();
         size_t total_system_mem = server.system_memory_size;
         const char *evict_policy = evictPolicyToString();
@@ -5547,7 +5547,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         bytesToHuman(used_memory_scripts_hmem,sizeof(used_memory_scripts_hmem),mh->lua_caches + mh->functions_caches);
         bytesToHuman(used_memory_rss_hmem,sizeof(used_memory_rss_hmem),server.cron_malloc_stats.process_rss);
         bytesToHuman(maxmemory_hmem,sizeof(maxmemory_hmem),server.maxmemory);
-        bytesToHuman(maxmemory_reserved_hmem,sizeof(maxmemory_reserved_hmem),server.maxmemory_reserved);
+        bytesToHuman(maxmemory_available_hmem,sizeof(maxmemory_available_hmem),server.maxmemory_available);
 
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info,
@@ -5585,8 +5585,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "maxmemory_human:%s\r\n"
             "maxmemory_policy:%s\r\n"
             "maxmemory_reserved_scale:%d\r\n"
-            "maxmemory_reserved:%lld\r\n"
-            "maxmemory_reserved_human:%s\r\n"
+            "maxmemory_available:%lld\r\n"
+            "maxmemory_available_human:%s\r\n"
             "allocator_frag_ratio:%.2f\r\n"
             "allocator_frag_bytes:%zu\r\n"
             "allocator_rss_ratio:%.2f\r\n"
@@ -5639,8 +5639,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             maxmemory_hmem,
             evict_policy,
             server.maxmemory_reserved_scale,
-            server.maxmemory_reserved,
-            maxmemory_reserved_hmem,
+            server.maxmemory_available,
+            maxmemory_available_hmem,
             mh->allocator_frag,
             mh->allocator_frag_bytes,
             mh->allocator_rss,

--- a/src/server.c
+++ b/src/server.c
@@ -2537,7 +2537,7 @@ void initServer(void) {
     server.reply_buffer_resizing_enabled = 1;
     server.client_mem_usage_buckets = NULL;
     resetReplicationBuffer();
-    if (server.maxmemory && server.maxmemory_reserved_scale) {
+    if (server.maxmemory) {
         server.maxmemory_available = (unsigned long long)server.maxmemory / 100.0 * (100 - server.maxmemory_reserved_scale);
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -1830,6 +1830,8 @@ struct redisServer {
     ssize_t maxmemory_clients;       /* Memory limit for total client buffers */
     int maxmemory_policy;           /* Policy for key eviction */
     int maxmemory_samples;          /* Precision of random sampling */
+    int maxmemory_reserved_scale;
+    unsigned long long  maxmemory_reserved;
     int maxmemory_eviction_tenacity;/* Aggressiveness of eviction processing */
     int lfu_log_factor;             /* LFU logarithmic counter factor. */
     int lfu_decay_time;             /* LFU counter decay factor. */

--- a/src/server.h
+++ b/src/server.h
@@ -1831,7 +1831,7 @@ struct redisServer {
     int maxmemory_policy;           /* Policy for key eviction */
     int maxmemory_samples;          /* Precision of random sampling */
     int maxmemory_reserved_scale;
-    unsigned long long  maxmemory_reserved;
+    unsigned long long  maxmemory_available;
     int maxmemory_eviction_tenacity;/* Aggressiveness of eviction processing */
     int lfu_log_factor;             /* LFU logarithmic counter factor. */
     int lfu_decay_time;             /* LFU counter decay factor. */


### PR DESCRIPTION
We want to add one more parameter in redis.conf: maxmemory-reserved-scale
The goal is to begin the key eviction process earlier if the maxmemory parameter is set as well.

Currently key eviction will be triggered after used memory is greater than maxmemory. This PR introduces a new parameter to trigger key eviction earlier, so that redis still have some reserved memoery for other memory consumption counted as used memory during eviction. 

This would be helpful if redis has active eviction in the future like active expire, so key can be evicted before maxmemory is reached and when redis is not busy. 

One example for this paramter：
Assume 

maxmemory 4GB
maxmemory-reserved-scale 20

Then we could check the detail by info memory command:

maxmemory:4294967296  
maxmemory_human:4.00G  
maxmemory_policy:allkeys-lru  
maxmemory_reserved_scale:20  
maxmemory_available:3435973836  
maxmemory_available_human:3.20G

We could also update and get the maxmemory-reserved-scale value during runtime as following:

config set maxmemory-reserved-scale value
config get maxmemory-reserved-scale

Note: the feature reference the Azure link:
https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-memory-management

