### PR TITLE
Fix eval_ro command JSON file format

### DIFF
--- a/src/commands/eval_ro.json
+++ b/src/commands/eval_ro.json
@@ -51,13 +51,13 @@
                 "name": "key",
                 "type": "key",
                 "key_spec_index": 0,
-		"optional":true,
+                "optional":true,
                 "multiple": true
             },
             {
                 "name": "arg",
                 "type": "string",
-		"optional":true,
+                "optional":true,
                 "multiple": true
             }
         ]


### PR DESCRIPTION
We should always **use space instead of Tab**

This PR fix the wrong code format