### PR TITLE
Fix evalsha_ro command JSON file format

### DIFF
--- a/src/commands/evalsha_ro.json
+++ b/src/commands/evalsha_ro.json
@@ -50,13 +50,13 @@
                 "name": "key",
                 "type": "key",
                 "key_spec_index": 0,
-		"optional":true,
+                "optional":true,
                 "multiple": true
             },
             {
                 "name": "arg",
                 "type": "string",
-		"optional":true,
+                "optional":true,
                 "multiple": true
             }
         ]


### PR DESCRIPTION
Another minor fix for json file format

We should always use space instead of Tab

This PR fix the wrong code format