### PR TITLE
Introduce 'dbfilename-save-pattern' config

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -485,6 +485,19 @@ rdbchecksum yes
 # The filename where to dump the DB
 dbfilename dump.rdb
 
+# Generate DB filename by the specified pattern during saving DB. Note that
+# this only affects save/bgsave command.
+# If 'dbfilename-save-pattern' is effective, the auto-generated DB file name
+# will replace the config of 'dbfilename'.
+# Supported patterns:
+#     %e: the name of the calling thread(depending on OS).
+#     %f: the name of the DB filename(specified by dbfilename).
+#     %p: the PID of current executable binary.
+#     %t: the Unix timestamp.
+#     %T: human readable timestamp.
+#     %u: the UID of current executable binary.
+# dbfilename-save-pattern %f-uid_%u-exec_%e-pid_%p-_timestamp_%t
+
 # Remove RDB files used by replication in instances without persistence
 # enabled. By default this option is disabled, however there are environments
 # where for regulations or other security concerns, RDB files persisted on

--- a/src/config.c
+++ b/src/config.c
@@ -2341,6 +2341,16 @@ static int isValidDBfilename(char *val, const char **err) {
     return 1;
 }
 
+static int isValidDBfilenameSavePattern(char *val, const char **err) {
+    sds name = rdbGenerateFilename(val);
+    if (!name) {
+        *err = "invalid dbfilename-save-pattern";
+        return 0;
+    }
+    sdsfree(name);
+    return 1;
+}
+
 static int isValidAOFfilename(char *val, const char **err) {
     if (!strcmp(val, "")) {
         *err = "appendfilename can't be empty";
@@ -3073,6 +3083,7 @@ standardConfig static_configs[] = {
     createStringConfig("cluster-announce-hostname", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_hostname, NULL, isValidAnnouncedHostname, updateClusterHostname),
     createStringConfig("syslog-ident", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.syslog_ident, "redis", NULL, NULL),
     createStringConfig("dbfilename", NULL, MODIFIABLE_CONFIG | PROTECTED_CONFIG, ALLOW_EMPTY_STRING, server.rdb_filename, "dump.rdb", isValidDBfilename, NULL),
+    createStringConfig("dbfilename-save-pattern", NULL, MODIFIABLE_CONFIG | PROTECTED_CONFIG, EMPTY_STRING_IS_NULL, server.rdb_filename_save_pattern, NULL, isValidDBfilenameSavePattern, NULL),
     createStringConfig("appendfilename", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.aof_filename, "appendonly.aof", isValidAOFfilename, NULL),
     createStringConfig("appenddirname", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.aof_dirname, "appendonlydir", isValidAOFdirname, NULL),
     createStringConfig("server_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.server_cpulist, NULL, NULL, NULL),

--- a/src/config.h
+++ b/src/config.h
@@ -303,6 +303,13 @@ int pthread_setname_np(const char *name);
 #endif
 #endif
 
+/* Define for redis_get_thread_title */
+#ifdef __linux__
+#define redis_get_thread_title(name, len) pthread_getname_np(pthread_self(), name, len)
+#else
+#define redis_get_thread_title(name, len) -1
+#endif
+
 /* Check if we can use setcpuaffinity(). */
 #if (defined __linux || defined __NetBSD__ || defined __FreeBSD__ || defined __DragonFly__)
 #define USE_SETCPUAFFINITY

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -178,5 +178,6 @@ int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx* lib_ctx, int rdbflags, s
 int rdbSaveRio(int req, rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi);
 ssize_t rdbSaveFunctions(rio *rdb);
 rdbSaveInfo *rdbPopulateSaveInfo(rdbSaveInfo *rsi);
+sds rdbGenerateFilename(const char *pattern);
 
 #endif

--- a/src/server.h
+++ b/src/server.h
@@ -1713,6 +1713,7 @@ struct redisServer {
     struct saveparam *saveparams;   /* Save points array for RDB */
     int saveparamslen;              /* Number of saving points */
     char *rdb_filename;             /* Name of RDB file */
+    char *rdb_filename_save_pattern;/* Pattern to generate RDB file name */
     int rdb_compression;            /* Use compression in RDB? */
     int rdb_checksum;               /* Use RDB checksum? */
     int rdb_del_sync_files;         /* Remove RDB files used only for SYNC if

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -322,6 +322,7 @@ start_server {tags {"introspection"}} {
             enable-debug-command
             enable-module-command
             dbfilename
+            dbfilename-save-pattern
             logfile
             dir
             socket-mark-id


### PR DESCRIPTION
It's possible to save/bgsave into a auto-generated DB filename which is specified by 'dbfilename-save-pattern' config.
    
Example:
```
redis.conf: dbfilename-save-pattern %f-uid_%u-exec_%e-pid_%p-_timestamp_%T
and run 'save' or 'bgsave' command, get a DB file: dump.rdb-uid_1000-exec_redis-server-pid_1058993-_timestamp_Thu Jan 26 08:09:17 2023
````