### PR TITLE
Fix master client check in expireIfNeeded() for read only replica

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1708,7 +1708,7 @@ int expireIfNeeded(redisDb *db, robj *key, int flags) {
      * When replicating commands from the master, keys are never considered
      * expired. */
     if (server.masterhost != NULL) {
-        if (server.current_client == server.master) return 0;
+        if (server.current_client && (server.current_client->flags & CLIENT_MASTER)) return 0;
         if (!(flags & EXPIRE_FORCE_DELETE_EXPIRED)) return 1;
     }
 


### PR DESCRIPTION
Redis 7.0 introduced new logic in `expireIfNeeded()` where a read-only replica would never consider a key as expired when replicating commands from the master. See https://github.com/redis/redis/commit/acf3495eb823df8d1f358b1fe59b759fcc49666f. This was done by checking `server.current_client` with `server.master`. However, we should instead check for `CLIENT_MASTER` flag for this logic to be more robust and consistent with the rest of the Redis code base. 

This was discovered via one of our internal features where replica can't immediately process the incoming `SET` commands from the master due to various conditions, and we would create a separate AOF client as a fake master client to process this command later. In this case, this client would fall through this check if it tries to update a key that has logically expired on the replica and led to a crash later on. i.e. in `setKey()`, `dbLookup()` somehow believes the key doesn't exist due to this logic here https://github.com/redis/redis/blob/unstable/src/db.c#L284, and later `dbAdd()` will assert because it finds the key actually exists in Redis. This fix would address this issue. 