### PR TITLE
adding the ability to benchmark streams command xadd to the redis-benchmark tool

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -2030,6 +2030,12 @@ int main(int argc, char **argv) {
             sdsfree(key_placeholder);
         }
 
+        if (test_is_selected("xadd")) {
+            len = redisFormatCommand(&cmd,"XADD mystream%s * myfield %s", tag, data);
+            benchmark("XADD",cmd,len);
+            free(cmd); 
+        }        
+
         if (!config.csv) printf("\n");
     } while(config.loop);
 


### PR DESCRIPTION
Added code to support xadd as one of the commands that can be run via redis-benchmarking tool

Here is how you would use this command

``` redis-benchmark --cluster -h HOST -p PORT -t xadd -n 1000 -c 20 ```

Happy to make improvements as needed - please review.

Thanks,
Maheedhar