### PR TITLE
Cleanup around script_caller, fix tracking of scripts and ACL logging for RM_Call

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2511,8 +2511,8 @@ void addACLLogEntry(client *c, int reason, int context, int argpos, sds username
         }
     }
 
-    client *realclient = c;
-    if (realclient->flags & CLIENT_SCRIPT) realclient = server.script_caller;
+    /* if we have a real client from the network, use it (could be missing on module timers) */
+    client *realclient = server.current_client? server.current_client : c;
 
     le->cinfo = catClientInfoString(sdsempty(),realclient);
     le->context = context;

--- a/src/debug.c
+++ b/src/debug.c
@@ -1815,14 +1815,13 @@ void logModulesInfo(void) {
 /* Log information about the "current" client, that is, the client that is
  * currently being served by Redis. May be NULL if Redis is not serving a
  * client right now. */
-void logCurrentClient(void) {
-    if (server.current_client == NULL) return;
+void logCurrentClient(client *cc, const char *title) {
+    if (cc == NULL) return;
 
-    client *cc = server.current_client;
     sds client;
     int j;
 
-    serverLogRaw(LL_WARNING|LL_RAW, "\n------ CURRENT CLIENT INFO ------\n");
+    serverLog(LL_WARNING|LL_RAW, "\n------ %s CLIENT INFO ------\n", title);
     client = catClientInfoString(sdsempty(),cc);
     serverLog(LL_WARNING|LL_RAW,"%s\n", client);
     sdsfree(client);
@@ -2081,7 +2080,8 @@ void printCrashReport(void) {
     logServerInfo();
 
     /* Log the current client */
-    logCurrentClient();
+    logCurrentClient(server.current_client, "CURRENT");
+    logCurrentClient(server.executing_client, "EXECUTING");
 
     /* Log modules info. Something we wanna do last since we fear it may crash. */
     logModulesInfo();

--- a/src/eval.c
+++ b/src/eval.c
@@ -185,7 +185,6 @@ void scriptingInit(int setup) {
 
     if (setup) {
         lctx.lua_client = NULL;
-        server.script_caller = NULL;
         server.script_disable_deny_script = 0;
         ldbInit();
     }
@@ -468,22 +467,6 @@ sds luaCreateFunction(client *c, robj *body) {
     lctx.lua_scripts_mem += sdsZmallocSize(sha) + getStringObjectSdsUsedMemory(body);
     incrRefCount(body);
     return sha;
-}
-
-void prepareLuaClient(void) {
-    /* Select the right DB in the context of the Lua client */
-    selectDb(lctx.lua_client,server.script_caller->db->id);
-    lctx.lua_client->resp = 2; /* Default is RESP2, scripts can change it. */
-
-    /* If we are in MULTI context, flag Lua client as CLIENT_MULTI. */
-    if (server.script_caller->flags & CLIENT_MULTI) {
-        lctx.lua_client->flags |= CLIENT_MULTI;
-    }
-}
-
-void resetLuaClient(void) {
-    /* After the script done, remove the MULTI state. */
-    lctx.lua_client->flags &= ~CLIENT_MULTI;
 }
 
 void evalGenericCommand(client *c, int evalsha) {
@@ -1680,6 +1663,5 @@ void luaLdbLineHook(lua_State *lua, lua_Debug *ar) {
             luaError(lua);
         }
         rctx->start_time = getMonotonicUs();
-        rctx->snapshot_time = mstime();
     }
 }

--- a/src/module.c
+++ b/src/module.c
@@ -6097,10 +6097,10 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
         acl_retval = ACLCheckAllUserCommandPerm(user,c->cmd,c->argv,c->argc,&acl_errpos);
         if (acl_retval != ACL_OK) {
             sds object = (acl_retval == ACL_DENIED_CMD) ? sdsdup(c->cmd->fullname) : sdsdup(c->argv[acl_errpos]->ptr);
-            addACLLogEntry(ctx->client, acl_retval, ACL_LOG_CTX_MODULE, -1, ctx->client->user->name, object);
+            addACLLogEntry(ctx->client, acl_retval, ACL_LOG_CTX_MODULE, -1, c->user->name, object);
             if (error_as_call_replies) {
                 /* verbosity should be same as processCommand() in server.c */
-                sds acl_msg = getAclErrorMessage(acl_retval, ctx->client->user, c->cmd, c->argv[acl_errpos]->ptr, 0);
+                sds acl_msg = getAclErrorMessage(acl_retval, c->user, c->cmd, c->argv[acl_errpos]->ptr, 0);
                 sds msg = sdscatfmt(sdsempty(), "-NOPERM %S\r\n", acl_msg);
                 sdsfree(acl_msg);
                 reply = callReplyCreateError(msg, ctx);

--- a/src/networking.c
+++ b/src/networking.c
@@ -3942,6 +3942,13 @@ void processEventsWhileBlocked(void) {
      * interaction time with clients and for other important things. */
     updateCachedTime(0);
 
+    /* For the few commands that are allowed during busy scripts, we rather
+     * provide a fresher time than the one from when the script started (they
+     * still won't get the from call due to execution_nesting. For commands
+     * during loading this doesn't matter. */
+    mstime_t prev_cmd_time_snapshot = server.cmd_time_snapshot;
+    server.cmd_time_snapshot = server.mstime;
+
     /* Note: when we are processing events while blocked (for instance during
      * busy Lua scripts), we set a global flag. When such flag is set, we
      * avoid handling the read part of clients using threaded I/O.
@@ -3966,6 +3973,8 @@ void processEventsWhileBlocked(void) {
 
     ProcessingEventsWhileBlocked--;
     serverAssert(ProcessingEventsWhileBlocked >= 0);
+
+    server.cmd_time_snapshot = prev_cmd_time_snapshot;
 }
 
 /* ==========================================================================

--- a/src/networking.c
+++ b/src/networking.c
@@ -3944,7 +3944,7 @@ void processEventsWhileBlocked(void) {
 
     /* For the few commands that are allowed during busy scripts, we rather
      * provide a fresher time than the one from when the script started (they
-     * still won't get the from call due to execution_nesting. For commands
+     * still won't get it from the call due to execution_nesting. For commands
      * during loading this doesn't matter. */
     mstime_t prev_cmd_time_snapshot = server.cmd_time_snapshot;
     server.cmd_time_snapshot = server.mstime;

--- a/src/script.c
+++ b/src/script.c
@@ -212,7 +212,6 @@ int scriptPrepareForRun(scriptRunCtx *run_ctx, client *engine_client, client *ca
 
     client *script_client = run_ctx->c;
     client *curr_client = run_ctx->original_client;
-    server.script_caller = curr_client;
 
     /* Select the right DB in the context of the Lua client */
     selectDb(script_client, curr_client->db->id);
@@ -224,7 +223,6 @@ int scriptPrepareForRun(scriptRunCtx *run_ctx, client *engine_client, client *ca
     }
 
     run_ctx->start_time = getMonotonicUs();
-    run_ctx->snapshot_time = mstime();
 
     run_ctx->flags = 0;
     run_ctx->repl_flags = PROPAGATE_AOF | PROPAGATE_REPL;
@@ -256,8 +254,6 @@ void scriptResetRun(scriptRunCtx *run_ctx) {
 
     /* After the script done, remove the MULTI state. */
     run_ctx->c->flags &= ~CLIENT_MULTI;
-
-    server.script_caller = NULL;
 
     if (scriptIsTimedout()) {
         exitScriptTimedoutMode(run_ctx);
@@ -573,12 +569,6 @@ void scriptCall(scriptRunCtx *run_ctx, sds *err) {
 error:
     afterErrorReply(c, *err, sdslen(*err), 0);
     incrCommandStatsOnError(cmd, ERROR_COMMAND_REJECTED);
-}
-
-/* Returns the time when the script invocation started */
-mstime_t scriptTimeSnapshot() {
-    serverAssert(curr_run_ctx);
-    return curr_run_ctx->snapshot_time;
 }
 
 long long scriptRunDuration() {

--- a/src/script.h
+++ b/src/script.h
@@ -74,7 +74,6 @@ struct scriptRunCtx {
     int flags;
     int repl_flags;
     monotime start_time;
-    mstime_t snapshot_time;
 };
 
 /* Scripts flags */
@@ -107,7 +106,6 @@ int scriptIsEval();
 int scriptIsTimedout();
 client* scriptGetClient();
 client* scriptGetCaller();
-mstime_t scriptTimeSnapshot();
 long long scriptRunDuration();
 
 #endif /* __SCRIPT_H_ */

--- a/src/server.c
+++ b/src/server.c
@@ -220,7 +220,7 @@ mstime_t commandTimeSnapshot(void) {
      * pretend that time freezes. This way a key can expire only the first time
      * it is accessed and not in the middle of the script execution, making
      * propagation to slaves / AOF consistent. See issue #1525 for more info.
-     * Note that we cannot use the cached server.mstime because it can chagne
+     * Note that we cannot use the cached server.mstime because it can change
      * in processEventsWhileBlocked etc. */
     return server.cmd_time_snapshot;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -3597,12 +3597,11 @@ void call(client *c, int flags) {
         /* We use the tracking flag of the original external client that
          * triggered the command, but we take the keys from the actual command
          * being executed. */
-        /* if we have a real client from the network, use it (could be missing on module timers) */
-        client *realclient = server.current_client? server.current_client : c;
-        if (realclient->flags & CLIENT_TRACKING &&
-            !(realclient->flags & CLIENT_TRACKING_BCAST))
+        if (server.current_client &&
+            (server.current_client->flags & CLIENT_TRACKING) &&
+            !(server.current_client->flags & CLIENT_TRACKING_BCAST))
         {
-            trackingRememberKeys(realclient, c);
+            trackingRememberKeys(server.current_client, c);
         }
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -1718,8 +1718,9 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
      * releasing the GIL. Redis main thread will not touch anything at this
      * time. */
     if (moduleCount()) moduleReleaseGIL();
-
-    /* Do NOT add anything below moduleReleaseGIL !!! */
+    /********************* WARNING ********************
+     * Do NOT add anything below moduleReleaseGIL !!! *
+     ***************************** ********************/
 }
 
 /* This function is called immediately after the event loop multiplexing
@@ -1727,9 +1728,11 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
  * the different events callbacks. */
 void afterSleep(struct aeEventLoop *eventLoop) {
     UNUSED(eventLoop);
-    /* Do NOT add anything above moduleAcquireGIL !!! */
-    /* Acquire the modules GIL so that their threads won't touch anything. */
+    /********************* WARNING ********************
+     * Do NOT add anything above moduleAcquireGIL !!! *
+     ***************************** ********************/
     if (!ProcessingEventsWhileBlocked) {
+        /* Acquire the modules GIL so that their threads won't touch anything. */
         if (moduleCount()) {
             mstime_t latency;
             latencyStartMonitor(latency);

--- a/src/server.h
+++ b/src/server.h
@@ -1535,8 +1535,8 @@ struct redisServer {
     list *clients_pending_write; /* There is to write or install handler. */
     list *clients_pending_read;  /* Client has pending read socket buffers. */
     list *slaves, *monitors;    /* List of slaves and MONITORs */
-    client *current_client;     /* External client that triggered the command execution. */
-    client *executing_client;   /* Current (possibly script or module) client executing the command. */
+    client *current_client;     /* The client that triggered the command execution (External or AOF). */
+    client *executing_client;   /* The client executing the current command (possibly script or module). */
 
     /* Stuff for client mem eviction */
     clientMemUsageBucket* client_mem_usage_buckets;

--- a/src/server.h
+++ b/src/server.h
@@ -1873,6 +1873,7 @@ struct redisServer {
     int daylight_active;        /* Currently in daylight saving time. */
     mstime_t mstime;            /* 'unixtime' in milliseconds. */
     ustime_t ustime;            /* 'unixtime' in microseconds. */
+    mstime_t cmd_time_snapshot; /* Time snapshot of the root execution nesting. */
     size_t blocking_op_nesting; /* Nesting level of blocking operation, used to reset blocked_last_cron. */
     long long blocked_last_cron; /* Indicate the mstime of the last time we did cron jobs from a blocking operation */
     /* Pubsub */

--- a/src/server.h
+++ b/src/server.h
@@ -1535,7 +1535,8 @@ struct redisServer {
     list *clients_pending_write; /* There is to write or install handler. */
     list *clients_pending_read;  /* Client has pending read socket buffers. */
     list *slaves, *monitors;    /* List of slaves and MONITORs */
-    client *current_client;     /* Current client executing the command. */
+    client *current_client;     /* External client that triggered the command execution. */
+    client *executing_client;   /* Current (possibly script or module) client executing the command. */
 
     /* Stuff for client mem eviction */
     clientMemUsageBucket* client_mem_usage_buckets;
@@ -1911,7 +1912,6 @@ struct redisServer {
     int cluster_drop_packet_filter; /* Debug config that allows tactically
                                    * dropping packets of a specific type */
     /* Scripting */
-    client *script_caller;       /* The client running script right now, or NULL */
     mstime_t busy_reply_threshold;  /* Script / module timeout in milliseconds */
     int pre_command_oom_state;         /* OOM before command (script?) was started */
     int script_disable_deny_script;    /* Allow running commands marked "no-script" inside a script. */
@@ -2594,7 +2594,7 @@ void addReplyStatusFormat(client *c, const char *fmt, ...);
 /* Client side caching (tracking mode) */
 void enableTracking(client *c, uint64_t redirect_to, uint64_t options, robj **prefix, size_t numprefix);
 void disableTracking(client *c);
-void trackingRememberKeys(client *c);
+void trackingRememberKeys(client *tracking, client *executing);
 void trackingInvalidateKey(client *c, robj *keyobj, int bcast);
 void trackingScheduleKeyInvalidation(uint64_t client_id, robj *keyobj);
 void trackingHandlePendingKeyInvalidations(void);

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -245,12 +245,15 @@ start_server {tags {"repl external:skip"}} {
             # DB is empty.
             r -1 flushdb
             r -1 flushdb
-            r -1 flushdb
+            r -1 eval {redis.call("flushdb")} 0
 
             # DBs are empty.
             r -1 flushall
             r -1 flushall
-            r -1 flushall
+            r -1 eval {redis.call("flushall")} 0
+
+            # add another command to check nothing else was propagated after the above
+            r -1 incr x
 
             # Assert that each FLUSHDB command is replicated even the DB is empty.
             # Assert that each FLUSHALL command is replicated even the DBs are empty.
@@ -265,6 +268,7 @@ start_server {tags {"repl external:skip"}} {
                 {flushall}
                 {flushall}
                 {flushall}
+                {incr x}
             }
             close_replication_stream $repl
         }

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -629,6 +629,7 @@ start_server {tags {"acl external:skip"}} {
         assert {[dict get $entry context] eq {toplevel}}
         assert {[dict get $entry reason] eq {command}}
         assert {[dict get $entry object] eq {get}}
+        assert_match {*cmd=get*} [dict get $entry client-info]
     }
 
     test "ACL LOG shows failed subcommand executions at toplevel" {
@@ -705,6 +706,7 @@ start_server {tags {"acl external:skip"}} {
         set entry [lindex [r ACL LOG] 0]
         assert {[dict get $entry context] eq {multi}}
         assert {[dict get $entry object] eq {incr}}
+        assert_match {*cmd=exec*} [dict get $entry client-info]
         r ACL SETUSER antirez -incr
     }
 
@@ -715,6 +717,7 @@ start_server {tags {"acl external:skip"}} {
         set entry [lindex [r ACL LOG] 0]
         assert {[dict get $entry context] eq {lua}}
         assert {[dict get $entry object] eq {incr}}
+        assert_match {*cmd=eval*} [dict get $entry client-info]
     }
 
     test {ACL LOG can accept a numerical argument to show less entries} {


### PR DESCRIPTION
* Make it clear that current_client is the root client that was called by external connection
* add executing_client which is the client that runs the current command (can be a module or a script)
* Remove script_caller that was used for commands that have CLIENT_SCRIPT to get the client that called the script. in most cases, that's the current_client, and in others (when being called from a module), it could be an intermediate client when we actually want the original one used by the external connection.

bugfixes:
* RM_Call with C flag should log ACL errors with the requested user rather than the one used by the original client, this also solves a crash when RM_Call is used with C flag from a detached thread safe context.
* addACLLogEntry would have logged info about the script_caller, but in case the script was issued by a module command we actually want the current_client. the exception is when RM_Call is called from a timer event, in which case we don't have a current_client.

behavior changes:
* client side tracking for scripts now tracks the keys that are read by the script instead of the keys that are declared by the caller for EVAL

other changes:
* Log both current_client and executing_client in the crash log.
* remove prepareLuaClient and resetLuaClient, being dead code that was forgotten.
* remove scriptTimeSnapshot and snapshot_time and instead add cmd_time_snapshot that serves all commands and is reset only when execution nesting starts.
* remove code to propagate CLIENT_FORCE_REPL from the executed command to the script caller since scripts aren't propagated anyway these days and anyway this flag wouldn't have had an effect since CLIENT_PREVENT_PROP is added by scriptResetRun.
* fix a module GIL violation issue in afterSleep that was introduced in #10300 (unreleased)