### PR TITLE
Add new config script-readonly-timeout-behavior

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1573,6 +1573,12 @@ aof-timestamp-enabled no
 # the same:
 # lua-time-limit 5000
 # busy-reply-threshold 5000
+# 
+# One can also control the behavior of the engine when we exceed busy-reply-threshold
+# with script-readonly-timeout-beahvior, which provides two options: kill and yield.
+# "kill" will kill any readonly scripts that exceed the configured time threshold automatically.
+# "yield" will allow the script to continue executing, returning BUSY for most commands.
+# script-readonly-timeout-behavior yield
 
 ################################ REDIS CLUSTER  ###############################
 

--- a/src/config.c
+++ b/src/config.c
@@ -161,6 +161,12 @@ configEnum propagation_error_behavior_enum[] = {
     {NULL, 0}
 };
 
+configEnum script_readonly_timeout_behavior_enum[] = {
+    {"yield", SCRIPT_READONLY_TIMEOUT_YIELD},
+    {"kill", SCRIPT_READONLY_TIMEOUT_KILL},
+    {NULL, 0}
+};
+
 /* Output buffer limits presets. */
 clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT] = {
     {0, 0, 0}, /* normal */
@@ -3106,6 +3112,7 @@ standardConfig static_configs[] = {
     createEnumConfig("propagation-error-behavior", NULL, MODIFIABLE_CONFIG, propagation_error_behavior_enum, server.propagation_error_behavior, PROPAGATION_ERR_BEHAVIOR_IGNORE, NULL, NULL),
     createEnumConfig("shutdown-on-sigint", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, shutdown_on_sig_enum, server.shutdown_on_sigint, 0, isValidShutdownOnSigFlags, NULL),
     createEnumConfig("shutdown-on-sigterm", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, shutdown_on_sig_enum, server.shutdown_on_sigterm, 0, isValidShutdownOnSigFlags, NULL),
+    createEnumConfig("script-readonly-timeout-behavior", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, script_readonly_timeout_behavior_enum, server.script_readonly_timeout_behavior, SCRIPT_READONLY_TIMEOUT_YIELD, NULL, NULL),
 
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),

--- a/src/script.c
+++ b/src/script.c
@@ -89,6 +89,10 @@ int scriptInterrupt(scriptRunCtx *run_ctx) {
     if (elapsed < server.busy_reply_threshold) {
         return SCRIPT_CONTINUE;
     }
+    else if (!(run_ctx->flags & SCRIPT_WRITE_DIRTY) && server.script_readonly_timeout_behavior == SCRIPT_READONLY_TIMEOUT_KILL) {
+         run_ctx->flags |= SCRIPT_KILLED;
+         return SCRIPT_KILL_ENGINE;
+    }
 
     serverLog(LL_WARNING,
             "Slow script detected: still in execution after %lld milliseconds. "

--- a/src/script.h
+++ b/src/script.h
@@ -56,6 +56,7 @@
  */
 #define SCRIPT_KILL 1
 #define SCRIPT_CONTINUE 2
+#define SCRIPT_KILL_ENGINE 3
 
 /* runCtx flags */
 #define SCRIPT_WRITE_DIRTY            (1ULL<<0) /* indicate that the current script already performed a write command */

--- a/src/server.h
+++ b/src/server.h
@@ -624,6 +624,12 @@ typedef enum {
     CLUSTER_ENDPOINT_TYPE_UNKNOWN_ENDPOINT /* Show NULL or empty */
 } cluster_endpoint_type;
 
+/* Script behavior types, kill/yield readonly script */
+typedef enum {
+    SCRIPT_READONLY_TIMEOUT_YIELD = 0,
+    SCRIPT_READONLY_TIMEOUT_KILL = 1
+} script_readonly_timeout_behavior;
+
 /* RDB active child save type. */
 #define RDB_CHILD_TYPE_NONE 0
 #define RDB_CHILD_TYPE_DISK 1     /* RDB is written to disk. */
@@ -1915,6 +1921,7 @@ struct redisServer {
     mstime_t busy_reply_threshold;  /* Script / module timeout in milliseconds */
     int pre_command_oom_state;         /* OOM before command (script?) was started */
     int script_disable_deny_script;    /* Allow running commands marked "no-script" inside a script. */
+    int script_readonly_timeout_behavior;    /* Determines if we kill the script or return busy errors. */
     /* Lazy free */
     int lazyfree_lazy_eviction;
     int lazyfree_lazy_expire;


### PR DESCRIPTION
At AWS we've seen customers run scripts that are unexpectedly too long (exceeding busy-reply-threshold) - thus entailing unexpected downtime for other clients. While we can't kill any scripts that have performed a write, we can kill read-only scripts.

This introduces a new config "script-readonly-timeout-behavior" with two options: yield and kill. "yield" is what the engine currently does when we exceed busy-reply-threshold, in that we serverLog a message and return BUSY errors until a SCRIPT KILL or SHUTDOWN NOSAVE is executed or the script completes. When set to "kill" the engine will kill readonly scripts that exceed busy-reply-threshold.

While this logic could be done client-side - it simplifies these workloads significantly.