### PR TITLE
Update redis.conf shutdown-timeout comment

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1525,7 +1525,7 @@ aof-timestamp-enabled no
 # Maximum time to wait for replicas when shutting down, in seconds.
 #
 # During shut down, a grace period allows any lagging replicas to catch up with
-# the latest replication offset before the master doesn't exist. This period can
+# the latest replication offset before the master exits. This period can
 # prevent data loss, especially for deployments without configured disk backups.
 #
 # The 'shutdown-timeout' value is the grace period's duration in seconds. It is

--- a/redis.conf
+++ b/redis.conf
@@ -1525,7 +1525,7 @@ aof-timestamp-enabled no
 # Maximum time to wait for replicas when shutting down, in seconds.
 #
 # During shut down, a grace period allows any lagging replicas to catch up with
-# the latest replication offset before the master exists. This period can
+# the latest replication offset before the master doesn't exist. This period can
 # prevent data loss, especially for deployments without configured disk backups.
 #
 # The 'shutdown-timeout' value is the grace period's duration in seconds. It is


### PR DESCRIPTION
The meaning of shutdown-timeout should be a grace period before the master down.