### PR TITLE
Fix timing issue in new ACL log test

### DIFF
--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -623,6 +623,7 @@ start_server {tags {"acl external:skip"}} {
          set entry_id_initial_error [dict get [lindex [r ACL LOG] 0] entry-id]
          set timestamp_created_original [dict get [lindex [r ACL LOG] 0] timestamp-created]
          set timestamp_last_update_original [dict get [lindex [r ACL LOG] 0] timestamp-last-updated]
+         after 1
          for {set j 0} {$j < 10} {incr j} {
              assert_error "*WRONGPASS*" {r AUTH user1 doo}
          }


### PR DESCRIPTION
There is a timing issue in the new ACL log test:
```
*** [err]: ACL LOG aggregates similar errors together and assigns unique entry-id to new errors in tests/unit/acl.tcl
Expected 1675382873989 < 1675382873989 (context: type eval line 15 cmd {assert {$timestamp_last_update_original < $timestamp_last_updated_after_update}} proc ::test)
```

Looking at the test code, we will check the `timestamp-last-updated` before
and after a new ACL error occurs. Actually `WRONGPASS` errors can be executed
very quickly on fast machines. For example, in the this case, the execution is
completed within one millisecond.

The error is easy to reproduce, if we reduce the number of the for loops, for
example set to 2, and using --loop and --stop. Avoid this timing issue by adding
an `after 1` before the new errors.

The test was introduced in #11477.