### PR TITLE
Fix unstable test: replication with parallel clients writing in different DBs

### DIFF
--- a/tests/integration/replication-4.tcl
+++ b/tests/integration/replication-4.tcl
@@ -20,6 +20,9 @@ start_server {tags {"repl network external:skip singledb:skip"}} {
         }
 
         test {Test replication with parallel clients writing in different DBs} {
+            # Gives the random workloads a chance to add some complex commands.
+            after 5000
+
             # Make sure all parallel clients have written data.
             wait_for_condition 1000 50 {
                 [$master select 9] == {OK} && [$master dbsize] > 0 &&

--- a/tests/integration/replication-4.tcl
+++ b/tests/integration/replication-4.tcl
@@ -1,4 +1,4 @@
-start_server {tags {"repl network external:skip"}} {
+start_server {tags {"repl network external:skip singledb:skip"}} {
     start_server {} {
 
         set master [srv -1 client]
@@ -12,12 +12,23 @@ start_server {tags {"repl network external:skip"}} {
 
         test {First server should have role slave after SLAVEOF} {
             $slave slaveof $master_host $master_port
-            after 1000
-            s 0 role
-        } {slave}
+            wait_for_condition 50 100 {
+                [s 0 role] eq {slave}
+            } else {
+                fail "Replication not started."
+            }
+        }
 
         test {Test replication with parallel clients writing in different DBs} {
-            after 5000
+            # Make sure all parallel clients have written data.
+            wait_for_condition 1000 50 {
+                [$master select 9] == {OK} && [$master dbsize] > 0 &&
+                [$master select 11] == {OK} && [$master dbsize] > 0 &&
+                [$master select 12] == {OK} && [$master dbsize] > 0
+            } else {
+                fail "Parallel clients are not writing in different DBs."
+            }
+
             stop_bg_complex_data $load_handle0
             stop_bg_complex_data $load_handle1
             stop_bg_complex_data $load_handle2
@@ -34,7 +45,6 @@ start_server {tags {"repl network external:skip"}} {
                 close $fd
                 fail "Master - Replica inconsistency, Run diff -u against /tmp/repldump*.txt for more info"
             }
-            assert {[$master dbsize] > 0}
         }
     }
 }


### PR DESCRIPTION
Failure happens in FreeBSD daily:
```
*** [err]: Test replication with parallel clients writing in different DBs in tests/integration/replication-4.tcl
Expected [::redis::redisHandle2 dbsize] > 0 (context: type eval line 19 cmd {assert {[$master dbsize] > 0}} proc ::test)
```

The test is failing because db 9 has no data (default db), and
according to the log, we can see that db 9 does not have a key:
```
 ### Starting test Test replication with parallel clients writing in different DBs in tests/integration/replication-4.tcl
3338:S 03 Feb 2023 00:15:18.723 - DB 11: 1 keys (0 volatile) in 4 slots HT.
3338:S 03 Feb 2023 00:15:18.723 - DB 12: 141 keys (0 volatile) in 256 slots HT.
```

We use `wait_for_condition` to ensure that parallel clients have
written data before calling stop_bg_complex_data. At the same time,
`wait_for_condition` is also used to remove the above `after 1000`,
which can save time in most cases.