### PR TITLE
fix data inconsistency when cluster node restart as replica

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -562,6 +562,11 @@ int clusterLoadConfig(char *filename) {
     if (clusterGetMaxEpoch() > server.cluster->currentEpoch) {
         server.cluster->currentEpoch = clusterGetMaxEpoch();
     }
+
+    if (nodeIsSlave(myself) && myself->slaveof) {
+        replicationSetMaster(myself->slaveof->ip, myself->slaveof->port);
+    }
+
     return C_OK;
 
 fmterr:


### PR DESCRIPTION
In cluster mode, when a node restart as replica, it doesn't sync with master at once, the replication is enabled in `clusterCron`. It means that sometime `server.masterhost` is NULL a master node, but the node's flag is replica, that can lead to data inconsistency, for example about expire:

say we have an RDB contains an expired key `a`:
```
$./redis-check-rdb dump.rdb
[offset 0] Checking RDB file dump.rdb
[offset 26] AUX FIELD redis-ver = '7.0.4'
[offset 40] AUX FIELD redis-bits = '64'
[offset 52] AUX FIELD ctime = '1675419762'
[offset 67] AUX FIELD used-mem = '2268136'
[offset 85] AUX FIELD repl-stream-db = '0'
[offset 135] AUX FIELD repl-id = '022cea3dd1a71287c5317d00b6dd21f096b8779b'
[offset 150] AUX FIELD repl-offset = '0'
[offset 162] AUX FIELD aof-base = '0'
[offset 81] Selecting DB ID 0
[offset 107] Checksum OK
[offset 107] \o/ RDB looks OK! \o/
[info] 1 keys read
[info] 1 expires
[info] 1 already expired
```

start a cluster node with this nodes.conf, all master with `noaddr` flags to avoid trigger `replicationSetMaster` in `clusterCron`:
```
c2106e9ed13a0159b7eb144dfde90cdca68ce5d3 127.0.1:0@10000 master,noaddr - 0 0 1 disconnected 1
4b35892d0d80337d98eabd550589b313b881b395 127.0.0.1:6379@16379 myself,slave 1d7b45cf1c0624944c269d075b796fcfec90f415 0 0 1 connected
1d7b45cf1c0624944c269d075b796fcfec90f415 127.0.1:0@10000 master,noaddr - 0 0 1 disconnected 2-16383
411514554da1e78b0a81a070553eb2c69e110770 127.0.1:0@10000 master,noaddr - 1675417251992 0 1 disconnected 0
vars currentEpoch 1 lastVoteEpoch 0
```

and then get role via `info replication` and `cluster nodes`:
```
127.0.0.1:6379> info replication
# Replication
role:master
connected_slaves:0
master_failover_state:no-failover
master_replid:022cea3dd1a71287c5317d00b6dd21f096b8779b
master_replid2:0000000000000000000000000000000000000000
master_repl_offset:96
second_repl_offset:-1
repl_backlog_active:0
repl_backlog_size:1048576
repl_backlog_first_byte_offset:0
repl_backlog_histlen:0127.0.0.1:6379> cluster nodes
c2106e9ed13a0159b7eb144dfde90cdca68ce5d3 127.0.1:0@10000 master,noaddr - 0 0 1 disconnected 1
4b35892d0d80337d98eabd550589b313b881b395 127.0.0.1:6379@16379 myself,slave,nofailover 1d7b45cf1c0624944c269d075b796fcfec90f415 0 0 1 connected
411514554da1e78b0a81a070553eb2c69e110770 127.0.1:0@10000 master,noaddr - 1675419170292 0 1 disconnected 0
1d7b45cf1c0624944c269d075b796fcfec90f415 127.0.1:0@10000 master,noaddr - 0 0 1 disconnected 2-16383
```

we can see that the role is different.

and because the replication role is master, so read command can delete the expired key:

```
127.0.0.1:6379>info keyspace
# Keyspace
db0:keys=1,expires=1,avg_ttl=0
127.0.0.1:6379> debug object a
Value at:0x7f3978ea4510 refcount:1 encoding:embstr serializedlength:2 lru:14474786 lru_seconds_idle:16
127.0.0.1:6379> readonly
OK
127.0.0.1:6379> get a
(nil)
127.0.0.1:6379> info keyspace
# Keyspace
127.0.0.1:6379> info stats
expired_keys:1
```

after this node connect with its master, it would result in data inconsistency since a replica node should not delete expired key but it did.

not sure if the way in this PR is right, or replace all `server.master == NULL` with `iAmMaster` is better?