### PR TITLE
correct cluster inbound link keepalive time

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1153,7 +1153,7 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
         connEnableTcpNoDelay(conn);
-        connKeepAlive(conn,server.cluster_node_timeout * 2);
+        connKeepAlive(conn,server.cluster_node_timeout / 1000 * 2);
 
         /* Use non-blocking I/O for cluster messages. */
         serverLog(LL_VERBOSE,"Accepting cluster node connection from %s:%d", cip, cport);


### PR DESCRIPTION
since `cluster_node_timeout` is millisecond, we need correct it when set keep alive.