### PR TITLE
add test case and comments for active expiry in the writeable replica

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -385,7 +385,8 @@ void expireSlaveKeys(void) {
                     activeExpireCycleTryExpire(server.db+dbid,expire,start))
                 {
                     expired = 1;
-                    /* DELs aren't propagated, but modules may want their hooks. */
+                    /* Propagate the DEL (writable replicas do not propagate anything to other replicas,
+                     * but they might propagate to AOF) and trigger module hooks. */
                     postExecutionUnitOperations();
                 }
 

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -577,6 +577,7 @@ start_server {tags {"expire"}} {
             $replica config set replica-read-only no
             foreach {yes_or_no} {yes no} {
                 $replica config set appendonly $yes_or_no
+                waitForBgrewriteaof $replica
                 set prev_expired [s expired_keys]
                 $replica set foo bar PX 1
                 wait_for_condition 100 10 {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -584,6 +584,7 @@ start_server {tags {"expire"}} {
                 } else {
                     fail "key not expired"
                 }
+                assert_equal {} [$replica get foo]
             }
         }
     }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -572,22 +572,21 @@ start_server {tags {"expire"}} {
             }
         }
         test {expired keys which is created in writeable replicas should be delete} {
-            #see https://github.com/redis/redis/issues/11778
             $primary flushall
             $replica config set replica-read-only no
             $replica config set appendonly yes
             $replica set foo bar PX 1
             wait_for_condition 20 100 {
                 [$replica get foo] eq {}
-            } fail {
-                "can't delete expired the keys which is create in writeable replicas."
+            } else {
+                fail "can't delete expired the keys which is create in writeable replicas."
             }
             $replica config set appendonly no
             $replica set foo bar PX 1
             wait_for_condition 20 100 {
                 [$replica get foo] eq {}
-            } fail {
-                "can't delete expired the keys which is create in writeable replicas."
+            } else  {
+                fail "can't delete expired the keys which is create in writeable replicas."
             }
         }
     }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -571,6 +571,25 @@ start_server {tags {"expire"}} {
                 assert_equal [$primary pexpiretime $key] [$replica pexpiretime $key]
             }
         }
+        test {expired keys which is created in writeable replicas should be delete} {
+            #see https://github.com/redis/redis/issues/11778
+            $primary flushall
+            $replica config set replica-read-only no
+            $replica config set appendonly yes
+            $replica set foo bar PX 1
+            wait_for_condition 20 100 {
+                [$replica get foo] eq {}
+            } fail {
+                "can't delete expired the keys which is create in writeable replicas."
+            }
+            $replica config set appendonly no
+            $replica set foo bar PX 1
+            wait_for_condition 20 100 {
+                [$replica get foo] eq {}
+            } fail {
+                "can't delete expired the keys which is create in writeable replicas."
+            }
+        }
     }
 
     test {SET command will remove expire} {


### PR DESCRIPTION
This test case is to cover a edge scenario: when a writable replica enabled AOF at the same time, active expiry keys which was created in writable replicas should propagate to the AOF file, and some versions might crash (fixed by #11615). For details, please refer to #11778 