### PR TITLE
Fix test and improve assert_replication_stream print the whole stream

### DIFF
--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -24,9 +24,11 @@ proc assert_no_match {pattern value} {
     }
 }
 
-proc assert_match {pattern value {detail ""}} {
+proc assert_match {pattern value {detail ""} {context ""}} {
     if {![string match $pattern $value]} {
-        set context "(context: [info frame -1])"
+        if {$context eq ""} {
+            set context "(context: [info frame -1])"
+        }
         error "assertion:Expected '$value' to match '$pattern' $context $detail"
     }
 }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -858,18 +858,21 @@ proc read_from_replication_stream {s} {
 
 proc assert_replication_stream {s patterns} {
     set errors 0
-    set values {}
+    set values_list {}
+    set patterns_list {}
     for {set j 0} {$j < [llength $patterns]} {incr j} {
         set pattern [lindex $patterns $j]
+        lappend patterns_list $pattern
         set value [read_from_replication_stream $s]
-        lappend values $value
+        lappend values_list $value
         if {![string match $pattern $value]} { incr errors }
     }
 
     if {$errors == 0} { return }
 
+    set context [info frame -1]
     close_replication_stream $s ;# for fast exit
-    assert_match $patterns $values
+    assert_match $patterns_list $values_list "" $context
 }
 
 proc close_replication_stream {s} {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -868,13 +868,8 @@ proc assert_replication_stream {s patterns} {
 
     if {$errors == 0} { return }
 
-    puts "replication stream start:"
-    foreach value $values { puts "$value" }
-    puts "replication stream end."
-
     close_replication_stream $s ;# for fast exit
-    set context "(context: [info frame -1])"
-    assert_equal $errors 0 $context
+    assert_match $patterns $values
 }
 
 proc close_replication_stream {s} {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -611,6 +611,9 @@ start_server {tags {"expire"}} {
     } {-1} {needs:debug}
 
     test {GETEX propagate as to replica as PERSIST, DEL, or nothing} {
+        # In the above tests, many keys with random expiration times are set, flush
+        # the DBs to avoid active expiry kicking in and messing the replication streams.
+        r flushall
        set repl [attach_to_replication_stream]
        r set foo bar EX 100
        r getex foo PERSIST


### PR DESCRIPTION
This PR has two parts:

1. Fix flaky test case, the previous tests set a lot of volatile keys,
it injects an unexpected DEL command into the replication stream during
the later test, causing it to fail. Add a flushall to avoid it.

2. Improve assert_replication_stream, now it can print the whole stream
rather than just the failing line.