### PR TITLE
Make io_threads_op an atomic variable

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3967,7 +3967,7 @@ typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) threads_pending {
 pthread_t io_threads[IO_THREADS_MAX_NUM];
 pthread_mutex_t io_threads_mutex[IO_THREADS_MAX_NUM];
 threads_pending io_threads_pending[IO_THREADS_MAX_NUM];
-int io_threads_op;      /* IO_THREADS_OP_IDLE, IO_THREADS_OP_READ or IO_THREADS_OP_WRITE. */ // TODO: should access to this be atomic??!
+redisAtomic int io_threads_op;      /* IO_THREADS_OP_IDLE, IO_THREADS_OP_READ or IO_THREADS_OP_WRITE. */
 
 /* This is the list of clients each thread will serve when threaded I/O is
  * used. We spawn io_threads_num-1 threads, since one is the main thread


### PR DESCRIPTION
Make `io_threads_op` an atomic variable so that modifications to it are visible to other threads