### PR TITLE
simplify rdb_fsync_range write and wait before

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -158,7 +158,7 @@
  * the plain fsync() call. */
 #if (defined(__linux__) && defined(SYNC_FILE_RANGE_WAIT_BEFORE))
 #define HAVE_SYNC_FILE_RANGE 1
-#define rdb_fsync_range(fd,off,size) sync_file_range(fd,off,size,SYNC_FILE_RANGE_WAIT_BEFORE|SYNC_FILE_RANGE_WRITE)
+#define rdb_fsync_range(fd,off,size) sync_file_range(fd,0,(off)+(size),SYNC_FILE_RANGE_WAIT_BEFORE|SYNC_FILE_RANGE_WRITE)
 #elif defined(__APPLE__)
 #define rdb_fsync_range(fd,off,size) fcntl(fd, F_FULLFSYNC)
 #else


### PR DESCRIPTION
Simplify the logic that issue the writeback request for the newly written data, as well as wait for the previous written data.

Also solve the problem https://github.com/redis/redis/pull/11150 mentioned, that in replication rdb_fsync_range don't wait for previous written data, so the last fsync after receiving RDB may block for a long time.