### PR TITLE
Fix misleading error message in XREADGROUP

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2205,7 +2205,7 @@ void xreadCommand(client *c) {
             streams_arg = i+1;
             streams_count = (c->argc-streams_arg);
             if ((streams_count % 2) != 0) {
-                addReplyErrorFormat(c,"Unbalanced %s list of streams: "
+                addReplyErrorFormat(c,"Unbalanced '%s' list of streams: "
                                       "for each stream key an ID or '>' must be "
                                       "specified.", c->cmd->fullname);
                 return;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2205,9 +2205,9 @@ void xreadCommand(client *c) {
             streams_arg = i+1;
             streams_count = (c->argc-streams_arg);
             if ((streams_count % 2) != 0) {
-                addReplyError(c,"Unbalanced XREAD list of streams: "
-                                "for each stream key an ID or '$' must be "
-                                "specified.");
+                addReplyErrorFormat(c,"Unbalanced %s list of streams: "
+                                      "for each stream key an ID or '>' must be "
+                                      "specified.", (char *)c->argv[0]->ptr);
                 return;
             }
             streams_count /= 2; /* We have two arguments for each stream. */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2207,7 +2207,7 @@ void xreadCommand(client *c) {
             if ((streams_count % 2) != 0) {
                 addReplyErrorFormat(c,"Unbalanced %s list of streams: "
                                       "for each stream key an ID or '>' must be "
-                                      "specified.", (char *)c->argv[0]->ptr);
+                                      "specified.", c->cmd->fullname);
                 return;
             }
             streams_count /= 2; /* We have two arguments for each stream. */


### PR DESCRIPTION
XREADGROUP can output a misleading error message regarding use of the $ special ID.

Here is the example (with some newlines):
```
redis> xreadgroup group workers worker1 count 1 streams mystream
(error) ERR Unbalanced XREAD list of streams: for each stream key an ID or '$' must be specified.

redis> xreadgroup group workers worker1 count 1 streams mystream $
(error) ERR The $ ID is meaningless in the context of XREADGROUP: you want to read the history of this
consumer by specifying a proper ID, or use the > ID to get new messages. The $ ID would just return an empty result set.

redis> xreadgroup group workers worker1 count 1 streams mystream >
1) 1) "mystream"
   2) 1) 1) "1673544607848-0"
         2) 1) "n"
            2) "1"
```

Note that XREADGROUP first returns an error with the following problems in it:
- Command name in the error should be XREADGROUP not XREAD.
- It recommends using $ as an option for a stream ID, then when you try this
  (see second XREADGROUP command above), it errors telling you that `$` doesn't
  make sense in this context even though the previous error message told you to use it

Suggest that the command name be fixed in the first message, and the second part error
message be amended not to talk about using `$` but `>` instead, this works, see the third
and final XREADGROUP example above.

Fixes #11730, commit message took from simonprickett.