### PR TITLE
fix a description of rax tree comment in rax.h

### DIFF
--- a/src/rax.h
+++ b/src/rax.h
@@ -61,7 +61,7 @@
  * provided inside the representation. So the above representation is turned
  * into:
  *
- *                  ["foo"] ""
+ *                  ("foo") ""
  *                     |
  *                  [t   b] "foo"
  *                  /     \


### PR DESCRIPTION
There is a convention in the description of rax tree comment as follows:

`When the node represents a key inside the radix tree, we write it between [], otherwise it is written between ().`

According to the vanilla representation :
```
 *              (f) ""
 *                \
 *                (o) "f"
 *                  \
 *                  (o) "fo"
 *                    \
 *                  [t   b] "foo"
 *                  /     \
 *         "foot" (e)     (a) "foob"
 *                /         \
 *      "foote" (r)         (r) "fooba"
 *              /             \
 *    "footer" []             [] "foobar"
```

the compressed node  that has a string of characters `"foo"` is not a key, but it was written into `[]`

```
 *                  ["foo"] ""
 *                     |
 *                  [t   b] "foo"
 *                  /     \
 *        "foot" ("er")    ("ar") "foob"
 *                 /          \
 *       "footer" []          [] "foobar"
```
should it be changed to `()` ?