### PR TITLE
skip new page cache reclame unit test when running in valgrind

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -406,7 +406,7 @@ jobs:
     - name: unittest
       if: true && !contains(github.event.inputs.skiptests, 'unittest')
       run: |
-        valgrind --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.txt ./src/redis-server test all
+        valgrind --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.txt ./src/redis-server test all --valgrind
         if grep -q 0x err.txt; then cat err.txt; exit 1; fi
 
   test-valgrind-no-malloc-usable-size-test:
@@ -463,7 +463,7 @@ jobs:
     - name: unittest
       if: true && !contains(github.event.inputs.skiptests, 'unittest')
       run: |
-        valgrind --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.txt ./src/redis-server test all
+        valgrind --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.txt ./src/redis-server test all --valgrind
         if grep -q 0x err.txt; then cat err.txt; exit 1; fi
 
   test-sanitizer-address:

--- a/src/server.c
+++ b/src/server.c
@@ -6953,6 +6953,7 @@ int main(int argc, char **argv) {
             char *arg = argv[j];
             if (!strcasecmp(arg, "--accurate")) flags |= REDIS_TEST_ACCURATE;
             else if (!strcasecmp(arg, "--large-memory")) flags |= REDIS_TEST_LARGE_MEMORY;
+            else if (!strcasecmp(arg, "--valgrind")) flags |= REDIS_TEST_VALGRIND;
         }
 
         if (!strcasecmp(argv[2], "all")) {

--- a/src/testhelp.h
+++ b/src/testhelp.h
@@ -41,6 +41,7 @@
 
 #define REDIS_TEST_ACCURATE     (1<<0)
 #define REDIS_TEST_LARGE_MEMORY (1<<1)
+#define REDIS_TEST_VALGRIND     (1<<2)
 
 extern int __failed_tests;
 extern int __test_num;

--- a/src/util.c
+++ b/src/util.c
@@ -1132,6 +1132,7 @@ int reclaimFilePageCache(int fd, size_t offset, size_t length) {
 #ifdef REDIS_TEST
 #include <assert.h>
 #include <sys/mman.h>
+#include "testhelp.h"
 
 static void test_string2ll(void) {
     char buf[32];
@@ -1388,10 +1389,6 @@ static void test_reclaimFilePageCache(void) {
 }
 #endif
 
-#if defined(__linux__)
-#include <valgrind/valgrind.h>
-#endif
-
 int utilTest(int argc, char **argv, int flags) {
     UNUSED(argc);
     UNUSED(argv);
@@ -1403,7 +1400,7 @@ int utilTest(int argc, char **argv, int flags) {
     test_ld2string();
     test_fixedpoint_d2string();
 #if defined(__linux__)
-    if (!RUNNING_ON_VALGRIND) {
+    if (!(flags & REDIS_TEST_VALGRIND)) {
         test_reclaimFilePageCache();
     }
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -1388,6 +1388,10 @@ static void test_reclaimFilePageCache(void) {
 }
 #endif
 
+#if defined(__linux__)
+#include <valgrind/valgrind.h>
+#endif
+
 int utilTest(int argc, char **argv, int flags) {
     UNUSED(argc);
     UNUSED(argv);
@@ -1399,8 +1403,11 @@ int utilTest(int argc, char **argv, int flags) {
     test_ld2string();
     test_fixedpoint_d2string();
 #if defined(__linux__)
-    test_reclaimFilePageCache();
+    if (!RUNNING_ON_VALGRIND) {
+        test_reclaimFilePageCache();
+    }
 #endif
+    printf("Done testing util\n");
     return 0;
 }
 #endif


### PR DESCRIPTION
the new test is incompatible with valgrind.
added a new `--valgrind` argument to `redis-server tests` mode, which will cause that test to be skipped..