### PR TITLE
Fix HELLO error message command syntax suggestion

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3419,7 +3419,7 @@ void helloCommand(client *c) {
     /* At this point we need to be authenticated to continue. */
     if (!c->authenticated) {
         addReplyError(c,"-NOAUTH HELLO must be called with the client already "
-                        "authenticated, otherwise the HELLO AUTH <user> <pass> "
+                        "authenticated, otherwise the HELLO <proto> AUTH <user> <pass> "
                         "option can be used to authenticate the client and "
                         "select the RESP protocol version at the same time");
         return;


### PR DESCRIPTION
A simple `HELLO` command to a password protected Redis server replies with an error with another command suggestion. This omits protocol version from HELLO command arguments which causes another error.

```
127.0.0.1:6379> HELLO 
(error) NOAUTH HELLO must be called with the client already authenticated, otherwise the HELLO AUTH <user> <pass> option can be used to authenticate the client and select the RESP protocol version at the same time
127.0.0.1:6379> HELLO AUTH <user> <pass>
(error) ERR Protocol version is not an integer or out of range
```

This PR adds the protocol version in the command suggestion.