### PR TITLE
fix aeWait and connSocketBlockingConnect

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -474,34 +474,47 @@ int aeProcessEvents(aeEventLoop *eventLoop, int flags)
 }
 
 /* Wait for milliseconds until the given file descriptor becomes
- * writable/readable/exception */
+ * writable/readable/exception. If milliseconds is 0, then aeWait() will
+ * return without blocking. If the value of milliseconds is -1, the aeWait
+ * blocks indefinitely.
+ * */
 int aeWait(int fd, int mask, long long milliseconds) {
     struct pollfd pfd;
     int retmask = 0, retval;
+    monotime begin, now;
+    long long timeout;
 
     memset(&pfd, 0, sizeof(pfd));
     pfd.fd = fd;
     if (mask & AE_READABLE) pfd.events |= POLLIN;
     if (mask & AE_WRITABLE) pfd.events |= POLLOUT;
 
-    monotime begin = getMonotonicUs();
-    monotime now = begin;
+    monotonicInitIfNeeded();
+    begin = getMonotonicUs();
+    now = begin;
     while (1) {
-        long long left = milliseconds - (long long)(now - begin) / 1000;
-        if ((retval = poll(&pfd, 1, left))== 1) {
+        if (milliseconds > 0) {
+            timeout = milliseconds - (long long)(now - begin) / 1000;
+            if (timeout < 0) timeout = 0; /* just to be on the safe side */
+        } else {
+            timeout = milliseconds;
+        }
+
+        if ((retval = poll(&pfd, 1, timeout)) == 1) {
             if (pfd.revents & POLLIN) retmask |= AE_READABLE;
             if (pfd.revents & POLLOUT) retmask |= AE_WRITABLE;
-            if (pfd.revents & POLLERR) retmask |= AE_WRITABLE;
-            if (pfd.revents & POLLHUP) retmask |= AE_WRITABLE;
+            if (pfd.revents & POLLERR) retmask |= AE_WRITABLE|AE_READABLE;
+            if (pfd.revents & POLLHUP) retmask |= AE_WRITABLE|AE_READABLE;
             return retmask;
         } else if (retval == 0) {
             /* Timeout */
             return 0;
         } else if (retval == -1 && errno != EINTR) {
             panic("aeWait: poll, %s", strerror(errno));
+        } else {
+            /* Interrupted, try again */
+            now = getMonotonicUs();
         }
-        /* Interrupted, try again */
-        now = getMonotonicUs();
     }
 }
 

--- a/src/monotonic.h
+++ b/src/monotonic.h
@@ -58,4 +58,10 @@ static inline uint64_t elapsedMs(monotime start_time) {
     return elapsedUs(start_time) / 1000;
 }
 
+/* The same with monotonicInit, except saving a function call if initialization
+ * is done */
+static inline void monotonicInitIfNeeded() {
+    if (getMonotonicUs == NULL)  monotonicInit();
+}
+
 #endif

--- a/src/socket.c
+++ b/src/socket.c
@@ -355,15 +355,23 @@ static int connSocketBlockingConnect(connection *conn, const char *addr, int por
         conn->last_errno = errno;
         return C_ERR;
     }
+    conn->fd = fd;
 
-    if ((aeWait(fd, AE_WRITABLE, timeout) & AE_WRITABLE) == 0) {
+    if ((aeWait(conn->fd, AE_WRITABLE, timeout) & AE_WRITABLE) == 0) {
         conn->state = CONN_STATE_ERROR;
         conn->last_errno = ETIMEDOUT;
+        return C_ERR;
     }
-
-    conn->fd = fd;
-    conn->state = CONN_STATE_CONNECTED;
-    return C_OK;
+    
+    int conn_error = anetGetError(conn->fd);
+    if (conn_error) {
+        conn->state = CONN_STATE_ERROR;
+        conn->last_errno = conn_error;
+        return C_ERR;
+    } else {
+        conn->state = CONN_STATE_CONNECTED;
+        return C_OK;
+    }
 }
 
 /* Connection-based versions of syncio.c functions.


### PR DESCRIPTION
aeWait doesn't deal with the interrupt case, but return -1 to caller, which & AE_WRITABLE and & AE_READABLE both is true. So a interrupt would be regard as a write/read event by mistake, however the truth is nothing except an interrupt happens.

connSocketBlockingConnect doesn't check the status of fd, so an unconnected fd would mistake for  connected fd.