### PR TITLE
optimize _dictNextExp with __builtin_clzl

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1412,18 +1412,12 @@ static int _dictExpandIfNeeded(dict *d)
     return DICT_OK;
 }
 
-/* TODO: clz optimization */
 /* Our hash table capability is a power of two */
 static signed char _dictNextExp(unsigned long size)
 {
-    unsigned char e = DICT_HT_INITIAL_EXP;
-
-    if (size >= LONG_MAX) return (8*sizeof(long)-1);
-    while(1) {
-        if (((unsigned long)1<<e) >= size)
-            return e;
-        e++;
-    }
+    if (size >= LONG_MAX) return (8 * sizeof(long) - 1);
+    if (size < DICT_HT_INITIAL_SIZE) return DICT_HT_INITIAL_EXP;
+    return 8 * sizeof(unsigned long) - __builtin_clzl(size - 1);
 }
 
 /* Finds and returns the position within the dict where the provided key should


### PR DESCRIPTION
Use clz to optimize _dictNextExp.
I write the following micro benchmark:
```
#include <limits.h>
#include <stdio.h>
#include <stdlib.h>
#include <sys/time.h>
#include <time.h>
#include <assert.h>

#define DICT_HT_INITIAL_EXP      2
#define DICT_HT_INITIAL_SIZE     (1<<(DICT_HT_INITIAL_EXP))

static signed char _dictNextExpLoop(unsigned long size)
{
    unsigned char e = DICT_HT_INITIAL_EXP;

    if (size >= LONG_MAX) return (8*sizeof(long)-1);
    while(1) {
        if (((unsigned long)1<<e) >= size)
            return e;
        e++;
    }
}

static signed char _dictNextExpClz(unsigned long size)
{
    if (size >= LONG_MAX) return (8 * sizeof(long) - 1);
    if (size < DICT_HT_INITIAL_SIZE) return DICT_HT_INITIAL_EXP;
    return 8 * sizeof(unsigned long) - __builtin_clzl(size - 1);
}

int main(){
    int n = 1e9;
    int i;
    assert(_dictNextExpClz(LONG_MAX) == _dictNextExpLoop(LONG_MAX));
    assert(_dictNextExpClz(LONG_MAX + 10ULL) == _dictNextExpLoop(LONG_MAX + 10ULL));
    for(i = 0; i < 100000; i++)
        assert(_dictNextExpClz(i) == _dictNextExpLoop(i));
    struct timeval start, end;
    signed char loop_exp, clz_exp;
    double loop, clz;
    loop = clz = 0;
    srand(time(0));
    for(i = 0; i < n; i++)
    {
        volatile unsigned long size = (rand() << 31UL) + rand();
        gettimeofday(&start, NULL);
        clz_exp = _dictNextExpClz(size);
        gettimeofday(&end, NULL);
        clz += (end.tv_sec - start.tv_sec) * 1000.0 + (end.tv_usec - start.tv_usec) / 1000.0;
        gettimeofday(&start, NULL);
        loop_exp = _dictNextExpLoop(size);
        gettimeofday(&end, NULL);
        loop += (end.tv_sec - start.tv_sec) * 1000.0 + (end.tv_usec - start.tv_usec) / 1000.0;
        assert(loop_exp = clz_exp);
    }
    printf("loop: %fms\nclz: %fms\nperformance improvement: %f%%\n", loop, clz, (100.0 * (loop - clz)) / loop);
    return 0;
}
```
before: 42.7s
after: 21.6s
improvement: 49.5%