### PR TITLE
convert pubsub numsub to maps for resp3

### DIFF
--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -645,7 +645,7 @@ NULL
         /* PUBSUB SHARDNUMSUB [ShardChannel_1 ... ShardChannel_N] */
         int j;
 
-        addReplyArrayLen(c, (c->argc-2)*2);
+        addReplyMapLen(c, c->argc-2);
         for (j = 2; j < c->argc; j++) {
             list *l = dictFetchValue(server.pubsubshard_channels, c->argv[j]);
 

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -625,7 +625,7 @@ NULL
         /* PUBSUB NUMSUB [Channel_1 ... Channel_N] */
         int j;
 
-        addReplyArrayLen(c,(c->argc-2)*2);
+        addReplyMapLen(c, c->argc-2);
         for (j = 2; j < c->argc; j++) {
             list *l = dictFetchValue(server.pubsub_channels,c->argv[j]);
 


### PR DESCRIPTION
currently its a key/value array, which should be stored as a map, so resp3 can see it as a map.

shouldn't impact resp2 usages.