### PR TITLE
Prevent Redis from crashing from key tracking invalidations

### DIFF
--- a/src/tracking.c
+++ b/src/tracking.c
@@ -393,7 +393,7 @@ void trackingInvalidateKey(client *c, robj *keyobj, int bcast) {
             continue;
         }
 
-        /* If target is current client and its executing a command, we need schedule key invalidation.
+        /* If target is current client and it's executing a command, we need schedule key invalidation.
          * As the invalidation messages may be interleaved with command
          * response and should after command response. */
         if (target == server.current_client && (server.current_client->flags & CLIENT_EXECUTING_COMMAND)) {

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -393,10 +393,10 @@ void trackingInvalidateKey(client *c, robj *keyobj, int bcast) {
             continue;
         }
 
-        /* If target is current client, we need schedule key invalidation.
+        /* If target is current client and its executing a command, we need schedule key invalidation.
          * As the invalidation messages may be interleaved with command
-         * response and should after command response */
-        if (target == server.current_client){
+         * response and should after command response. */
+        if (target == server.current_client && (server.current_client->flags & CLIENT_EXECUTING_COMMAND)) {
             incrRefCount(keyobj);
             listAddNodeTail(server.tracking_pending_keys, keyobj);
         } else {

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -768,9 +768,9 @@ start_server {tags {"tracking network"}} {
         $rd2 ping
         $rd2 exec
         r debug pause-cron 0
-        $rd_redirection close
-    } {OK} {needs:debug}
+        $rd2 close
+    } {0} {needs:debug}
 
     $rd close
-    $rd2 close
+    $rd_redirection close
 }

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -752,10 +752,11 @@ start_server {tags {"tracking network"}} {
 
         # Set up a client that has listened to 10 keys and start a multi, this
         # sets up the crash for later.
-        r HELLO 3
-        r CLIENT TRACKING on
-        r mget "1{tag}" "2{tag}" "3{tag}" "4{tag}" "0{tag}" "a{tag}" "b{tag}" "c{tag}" "d{tag}" "e{tag}"
-        r multi
+        set rd2 [redis_deferring_client]
+        $rd2 HELLO 3
+        $rd2 CLIENT TRACKING on
+        $rd2 mget "1{tag}" "2{tag}" "3{tag}" "4{tag}" "0{tag}" "a{tag}" "b{tag}" "c{tag}" "d{tag}" "e{tag}"
+        $rd2 multi
 
         # The second client will listen to 10 more keys, which will invalidate 10
         # keys. These invalidations will be random, so we spread the key names out.
@@ -764,11 +765,12 @@ start_server {tags {"tracking network"}} {
         $rd mget "z{tag}" "y{tag}" "x{tag}" "v{tag}" "u{tag}" "9{tag}" "8{tag}" "7{tag}" "6{tag}" "5{tag}"
 
         # This command will get queued, so make sure this command doesn't crash.
-        r ping
-        r exec
+        $rd2 ping
+        $rd2 exec
         r debug pause-cron 0
-    } {} {needs:debug}
+    } {OK} {needs:debug}
 
     $rd_redirection close
     $rd close
+    $rd2 close
 }

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -776,6 +776,6 @@ start_server {tags {"tracking network"}} {
         r debug pause-cron 0
     } {OK} {needs:debug}
 
-    $rd close
     $rd_redirection close
+    $rd close
 }

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -768,9 +768,9 @@ start_server {tags {"tracking network"}} {
         $rd2 ping
         $rd2 exec
         r debug pause-cron 0
+        $rd_redirection close
     } {OK} {needs:debug}
 
-    $rd_redirection close
     $rd close
     $rd2 close
 }

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -754,20 +754,20 @@ start_server {tags {"tracking network"}} {
         # sets up the crash for later.
         r HELLO 3
         r CLIENT TRACKING on
-        r mget a b c d e 1 2 3 4 5
+        r mget "1{tag}" "2{tag}" "3{tag}" "4{tag}" "0{tag}" "a{tag}" "b{tag}" "c{tag}" "d{tag}" "e{tag}"
         r multi
 
         # The second client will listen to 10 more keys, which will invalidate 10
         # keys. These invalidations will be random, so we spread the key names out.
         $rd HELLO 3
         $rd CLIENT TRACKING ON
-        $rd mget z y x v u 9 8 7 6 5
+        $rd mget "z{tag}" "y{tag}" "x{tag}" "v{tag}" "u{tag}" "9{tag}" "8{tag}" "7{tag}" "6{tag}" "5{tag}"
 
         # This command will get queued, so make sure this command doesn't crash.
         r ping
         r exec
         r debug pause-cron 0
-    }
+    } {} {needs:debug}
 
     $rd_redirection close
     $rd close

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -755,11 +755,11 @@ start_server {tags {"tracking network"}} {
         $rd HELLO 3
         $rd read
         $rd CLIENT TRACKING on
-        $rd read
+        assert_match "OK" [$rd read]
         $rd mget "1{tag}" "2{tag}"
-        $rd read
+        assert_match "{} {}" [$rd read]
         $rd multi
-        $rd read
+        assert_match "OK" [$rd read]
 
         # Reduce the tracking table keys to 1, this doesn't immediately take affect, but
         # instead will apply on the next command.
@@ -772,6 +772,7 @@ start_server {tags {"tracking network"}} {
         # Validate we got some invalidation message and then the command was queued.
         assert_match "invalidate *{tag}" [$rd read]
         assert_match "QUEUED" [$rd read]
+        assert_match "PONG" [$rd read]
 
         r debug pause-cron 0
     } {OK} {needs:debug}


### PR DESCRIPTION
Resolves https://github.com/redis/redis/issues/11715.

There is a built in limit to client side tracking keys, which when exceeded will invalidate keys. This occurs in two places, one in the server cron and other before executing a command. If it happens in the second scenario, the invalidations will be queued for later since current client is set. This queue is never drained if a command is not executed (through call) such as a multi-exec command getting queued. This results in a later server assert crashing.

Related: https://github.com/redis/redis/pull/9422.

```
Release notes
Fix a crash that can occur when client side tracking keys are invalidated when the max number of tracked keys has been reached.
```