### PR TITLE
Disable raw output while queueing commands in MULTI

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1743,7 +1743,7 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
     if (context == NULL) return REDIS_ERR;
 
     output_raw = 0;
-    if (!strcasecmp(command,"info") ||
+    if (!config.in_multi && (!strcasecmp(command,"info") ||
         !strcasecmp(command,"lolwut") ||
         (argc >= 2 && !strcasecmp(command,"debug") &&
                        !strcasecmp(argv[1],"htstats")) ||
@@ -1767,7 +1767,7 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
         /* Format PROXY INFO command for Redis Cluster Proxy:
          * https://github.com/artix75/redis-cluster-proxy */
         (argc >= 2 && !strcasecmp(command,"proxy") &&
-                       !strcasecmp(argv[1],"info")))
+                       !strcasecmp(argv[1],"info"))))
     {
         output_raw = 1;
     }

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -252,6 +252,10 @@ start_server {tags {"cli"}} {
         assert_equal \{\"K\\\\x00\\\\x01ey\":\"V\\\\x00\\\\x01alue\"\} [run_cli --quoted-json hgetall npkey]
     }
 
+    test_tty_cli "Disable raw output while queueing commands in MULTI" {
+        assert_equal "OK\nQUEUED\nQUEUED" [run_cli_with_input_pipe x "echo 'multi\ninfo\ninfo'"]
+    }
+
     test_nontty_cli "Status reply" {
         assert_equal "OK" [run_cli set key bar]
         assert_equal "bar" [r get key]


### PR DESCRIPTION
This fixes #3196 by not enabling raw output in the Redis CLI while commands are being queued as part of a transaction. If two commands that required raw output would be queued, this would result in an output of `QUEUEDQUEUED` without a line break.