### PR TITLE
Try to solve valgrind CI test error with client-eviction test

### DIFF
--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -350,6 +350,7 @@ start_server {} {
         $rr3 get k
         $rr3 flush
         exec kill -SIGCONT $server_pid
+        r ping ;# make sure a full event loop cycle is processed before issuing CLIENT LIST
         
         # Validate obuf-clients were disconnected (because of obuf limit)
         catch {client_field obuf-client1 name} e


### PR DESCRIPTION
The test sporadically failed with valgrind trying to match `no client named obuf-client1 found*`
in the log it looks like `obuf-client1` was indeed dropped, so i'm guessing it's because CLIENT LIST was processed first.

https://github.com/redis/redis/actions/runs/4199325173/jobs/7284050432