### PR TITLE
Speed up test: client evicted due to client tracking prefixes

### DIFF
--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -52,7 +52,7 @@ proc kb {v} {
 start_server {} {
     set maxmemory_clients 3000000
     r config set maxmemory-clients $maxmemory_clients
-    
+
     test "client evicted due to large argv" {
         r flushdb
         lassign [gen_client] rr cname
@@ -69,7 +69,7 @@ start_server {} {
         r flushdb
         lassign [gen_client] rr cname
         # Attempt to fill the query buff without completing the argument above the limit, causing client eviction
-        catch { 
+        catch {
             $rr write [join [list "*1\r\n\$$maxmemory_clients\r\n" [string repeat v $maxmemory_clients]] ""]
             $rr flush
             $rr read
@@ -81,11 +81,11 @@ start_server {} {
     test "client evicted due to percentage of maxmemory" {
         set maxmemory [mb 6]
         r config set maxmemory $maxmemory
-        # Set client eviction threshold to 7% of maxmemory        
+        # Set client eviction threshold to 7% of maxmemory
         set maxmemory_clients_p 7
         r config set maxmemory-clients $maxmemory_clients_p%
         r flushdb
-        
+
         set maxmemory_clients_actual [expr $maxmemory * $maxmemory_clients_p / 100]
 
         lassign [gen_client] rr cname
@@ -95,17 +95,17 @@ start_server {} {
         $rr flush
         set tot_mem [client_field $cname tot-mem]
         assert {$tot_mem >= $n && $tot_mem < $maxmemory_clients_actual}
-        
+
         # Attempt to fill the query buff with the percentage threshold of maxmemory and verify we're evicted
         $rr close
         lassign [gen_client] rr cname
-        catch { 
+        catch {
             $rr write [join [list "*1\r\n\$$maxmemory_clients_actual\r\n" [string repeat v $maxmemory_clients_actual]] ""]
             $rr flush
         } e
         assert {![client_exists $cname]}
         $rr close
-        
+
         # Restore settings
         r config set maxmemory 0
         r config set maxmemory-clients $maxmemory_clients
@@ -114,7 +114,7 @@ start_server {} {
     test "client evicted due to large multi buf" {
         r flushdb
         lassign [gen_client] rr cname
-        
+
         # Attempt a multi-exec where sum of commands is less than maxmemory_clients
         $rr multi
         $rr set k [string repeat v [expr $maxmemory_clients / 4]]
@@ -123,7 +123,7 @@ start_server {} {
 
         # Attempt a multi-exec where sum of commands is more than maxmemory_clients, causing client eviction
         $rr multi
-        catch { 
+        catch {
             for {set j 0} {$j < 5} {incr j} {
                 $rr set k [string repeat v [expr $maxmemory_clients / 4]]
             }
@@ -135,27 +135,27 @@ start_server {} {
     test "client evicted due to watched key list" {
         r flushdb
         set rr [redis_client]
-        
-        # Since watched key list is a small overheatd this test uses a minimal maxmemory-clients config
+
+        # Since watched key list is a small overhead this test uses a minimal maxmemory-clients config
         set temp_maxmemory_clients 200000
         r config set maxmemory-clients $temp_maxmemory_clients
-        
+
         # Append watched keys until list maxes out maxmemory clients and causes client eviction
-        catch { 
+        catch {
             for {set j 0} {$j < $temp_maxmemory_clients} {incr j} {
                 $rr watch $j
             }
         } e
         assert_match {I/O error reading reply} $e
         $rr close
-        
+
         # Restore config for next tests
         r config set maxmemory-clients $maxmemory_clients
     }
 
     test "client evicted due to pubsub subscriptions" {
         r flushdb
-        
+
         # Since pubsub subscriptions cause a small overhead this test uses a minimal maxmemory-clients config
         set temp_maxmemory_clients 200000
         r config set maxmemory-clients $temp_maxmemory_clients
@@ -163,7 +163,7 @@ start_server {} {
         # Test eviction due to pubsub patterns
         set rr [redis_client]
         # Add patterns until list maxes out maxmemory clients and causes client eviction
-        catch { 
+        catch {
             for {set j 0} {$j < $temp_maxmemory_clients} {incr j} {
                 $rr psubscribe $j
             }
@@ -174,7 +174,7 @@ start_server {} {
         # Test eviction due to pubsub channels
         set rr [redis_client]
         # Subscribe to global channels until list maxes out maxmemory clients and causes client eviction
-        catch { 
+        catch {
             for {set j 0} {$j < $temp_maxmemory_clients} {incr j} {
                 $rr subscribe $j
             }
@@ -185,22 +185,22 @@ start_server {} {
         # Test eviction due to sharded pubsub channels
         set rr [redis_client]
         # Subscribe to sharded pubsub channels until list maxes out maxmemory clients and causes client eviction
-        catch { 
+        catch {
             for {set j 0} {$j < $temp_maxmemory_clients} {incr j} {
                 $rr ssubscribe $j
             }
         } e
         assert_match {I/O error reading reply} $e
         $rr close
-       
+
         # Restore config for next tests
         r config set maxmemory-clients $maxmemory_clients
     }
-    
+
     test "client evicted due to tracking redirection" {
         r flushdb
         set rr [redis_client]
-        set redirected_c [redis_client] 
+        set redirected_c [redis_client]
         $redirected_c client setname redirected_client
         set redir_id [$redirected_c client id]
         $redirected_c SUBSCRIBE __redis__:invalidate
@@ -211,7 +211,7 @@ start_server {} {
         # Use a script so we won't need to pass the long key name when dirtying it in the loop
         set script_sha [$rr script load "redis.call('incr', '$long_key')"]
 
-        # Pause serverCron so it won't update memory usage since we're testing the update logic when 
+        # Pause serverCron so it won't update memory usage since we're testing the update logic when
         # writing tracking redirection output
         r debug pause-cron 1
 
@@ -224,7 +224,7 @@ start_server {} {
             }
         } e
         assert_match {no client named redirected_client found*} $e
-     
+
         r debug pause-cron 0
         $rr close
         $redirected_c close
@@ -233,15 +233,18 @@ start_server {} {
     test "client evicted due to client tracking prefixes" {
         r flushdb
         set rr [redis_client]
-        
-        # Since tracking prefixes list is a small overheatd this test uses a minimal maxmemory-clients config
+
+        # Since tracking prefixes list is a small overhead this test uses a minimal maxmemory-clients config
         set temp_maxmemory_clients 200000
         r config set maxmemory-clients $temp_maxmemory_clients
-        
-        # Append tracking prefixes until list maxes out maxmemroy clients and causes client eviction
-        catch { 
+
+        # Append tracking prefixes until list maxes out maxmemory clients and causes client eviction
+        # Combine more prefixes in each command to speed up the test. Because we did not actually count
+        # the memory usage of all prefixes, see getClientMemoryUsage, so we can not use larger prefixes
+        # to speed up the test here.
+        catch {
             for {set j 0} {$j < $temp_maxmemory_clients} {incr j} {
-                $rr client tracking on prefix [format %012s $j] bcast
+                $rr client tracking on prefix [format a%09s $j] prefix [format b%09s $j] prefix [format c%09s $j] bcast
             }
         } e
         assert_match {I/O error reading reply} $e
@@ -265,7 +268,7 @@ start_server {} {
         set mem [client_field test_client tot-mem]
         assert {$mem < $maxmemory_clients}
 
-        # Fill output buff in loop without reading it and make sure 
+        # Fill output buff in loop without reading it and make sure
         # we're eventually disconnected, but before reaching maxmemory_clients
         while true {
             if { [catch {
@@ -288,7 +291,7 @@ start_server {} {
             r client no-evict on ;# Avoid evicting the main connection
             lassign [gen_client] rr cname
             $rr client no-evict $no_evict
-        
+
             # Overflow maxmemory-clients
             set qbsize [expr {$maxmemory_clients + 1}]
             if {[catch {
@@ -303,7 +306,7 @@ start_server {} {
                 assert {![client_exists $cname]}
             } elseif {$no_evict == on} {
                 assert {[client_field $cname tot-mem] > $maxmemory_clients}
-            }            
+            }
             $rr close
         }
     }
@@ -339,7 +342,7 @@ start_server {} {
         } else {
             fail "Failed to fill qbuf for test"
         }
-        
+
         # Make the other two obuf-clients pass obuf limit and also pass maxmemory-clients
         # We use two obuf-clients to make sure that even if client eviction is attempted
         # between two command processing (with no sleep) we don't perform any client eviction
@@ -350,13 +353,13 @@ start_server {} {
         $rr3 get k
         $rr3 flush
         exec kill -SIGCONT $server_pid
-        
+
         # Validate obuf-clients were disconnected (because of obuf limit)
         catch {client_field obuf-client1 name} e
         assert_match {no client named obuf-client1 found*} $e
         catch {client_field obuf-client2 name} e
         assert_match {no client named obuf-client2 found*} $e
-        
+
         # Validate qbuf-client is still connected and wasn't evicted
         assert_equal [client_field qbuf-client name] {qbuf-client}
 
@@ -388,16 +391,16 @@ start_server {} {
                 fail "Failed to fill qbuf for test"
             }
         }
-        
+
         # Make sure all clients are still connected
         set connected_clients [llength [lsearch -all [split [string trim [r client list]] "\r\n"] *name=client*]]
         assert {$connected_clients == $client_count}
-        
+
         # Decrease maxmemory_clients and expect client eviction
         r config set maxmemory-clients [expr $maxmemory_clients / 2]
         set connected_clients [llength [lsearch -all [split [string trim [r client list]] "\r\n"] *name=client*]]
         assert {$connected_clients > 0 && $connected_clients < $client_count}
-        
+
         foreach rr $rrs {$rr close}
     }
 }
@@ -410,7 +413,7 @@ start_server {} {
         r config set maxmemory-clients 0
         r client setname control
         r client no-evict on
-        
+
         # Make multiple clients consume together roughly 1mb less than maxmemory_clients
         set total_client_mem 0
         set max_client_mem 0
@@ -448,7 +451,7 @@ start_server {} {
         # Set maxmemory-clients to accommodate half our clients (taking into account the control client)
         set maxmemory_clients [expr ($max_client_mem * $client_count) / 2 + [client_field control tot-mem]]
         r config set maxmemory-clients $maxmemory_clients
-        
+
         # Make sure total used memory is below maxmemory_clients
         set total_client_mem [clients_sum tot-mem]
         assert {$total_client_mem <= $maxmemory_clients}
@@ -459,14 +462,14 @@ start_server {} {
 
         # Restore the reply buffer resize to default
         r debug replybuffer resizing 1
-        
+
         foreach rr $rrs {$rr close}
     } {} {needs:debug}
 }
 
 start_server {} {
     test "evict clients in right order (large to small)" {
-        # Note that each size step needs to be at least x2 larger than previous step 
+        # Note that each size step needs to be at least x2 larger than previous step
         # because of how the client-eviction size bucketing works
         set sizes [list [kb 128] [mb 1] [mb 3]]
         set clients_per_size 3
@@ -474,7 +477,7 @@ start_server {} {
         r client no-evict on
         r config set maxmemory-clients 0
         r debug replybuffer resizing 0
-        
+
         # Run over all sizes and create some clients using up that size
         set total_client_mem 0
         set rrs {}
@@ -489,22 +492,22 @@ start_server {} {
                 $rr flush
             }
             set client_mem [client_field client-$i tot-mem]
-    
-            # Update our size list based on actual used up size (this is usually 
+
+            # Update our size list based on actual used up size (this is usually
             # slightly more than expected because of allocator bins
             assert {$client_mem >= $size}
             set sizes [lreplace $sizes $i $i $client_mem]
-            
+
             # Account total client memory usage
             incr total_mem [expr $clients_per_size * $client_mem]
         }
-        
+
         # Make sure all clients are connected
         set clients [split [string trim [r client list]] "\r\n"]
         for {set i 0} {$i < [llength $sizes]} {incr i} {
-            assert_equal [llength [lsearch -all $clients "*name=client-$i *"]] $clients_per_size        
+            assert_equal [llength [lsearch -all $clients "*name=client-$i *"]] $clients_per_size
         }
-        
+
         # For each size reduce maxmemory-clients so relevant clients should be evicted
         # do this from largest to smallest
         foreach size [lreverse $sizes] {
@@ -523,10 +526,10 @@ start_server {} {
                 }
             }
         }
-        
+
         # Restore the reply buffer resize to default
         r debug replybuffer resizing 1
-        
+
         foreach rr $rrs {$rr close}
     } {} {needs:debug}
 }


### PR DESCRIPTION
We noticed that `client evicted due to client tracking prefixes`
takes over 200 seconds with valgrind.

We combine three prefixes in each command, this will probably
save us half the testing time.

Before: normal: 3508ms, valgrind: 289503ms -> 290s
With three prefixes, normal: 1500ms, valgrind: 135742ms -> 136s

Since we did not actually count the memory usage of all prefixes, see
getClientMemoryUsage, so we can not use larger prefixes to speed up the
test here. Also this PR cleaned up some spaces (IDE jobs) and typos.