### PR TITLE
Flushdb keyspace notification

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -487,7 +487,7 @@ long long emptyData(int dbnum, int flags, void(callback)(dict*)) {
                           REDISMODULE_SUBEVENT_FLUSHDB_START,
                           &fi);
 
-    /* Make sure the WATCHed keys are affected by the FLUSH* commands.
+   /* Make sure the WATCHed keys are affected by the FLUSH* commands.
      * Note that we need to call the function while the keys are still
      * there. */
     signalFlushedDb(dbnum, async);
@@ -586,20 +586,25 @@ void signalModifiedKey(client *c, redisDb *db, robj *key) {
 
 void signalFlushedDb(int dbid, int async) {
     int startdb, enddb;
+    robj *msgobj;
     if (dbid == -1) {
         startdb = 0;
         enddb = server.dbnum-1;
     } else {
         startdb = enddb = dbid;
     }
+    if (async)
+        msgobj = createStringObject("async",sizeof("async")-1);
+    else
+        msgobj  = createStringObject("sync",sizeof("sync")-1);
 
     for (int j = startdb; j <= enddb; j++) {
         scanDatabaseForDeletedKeys(&server.db[j], NULL);
         touchAllWatchedKeysInDb(&server.db[j], NULL);
+        notifyDBEvent(NOTIFY_FLUSHDB, "flushdb", msgobj, server.db[j].id);
     }
-
+    decrRefCount(msgobj);
     trackingInvalidateKeysOnFlush(async);
-
     /* Changes in this method may take place in swapMainDbWithTempDb as well,
      * where we execute similar calls, but with subtle differences as it's
      * not simply flushing db. */
@@ -1544,6 +1549,8 @@ void swapdbCommand(client *c) {
         return;
     } else {
         RedisModuleSwapDbInfo si = {REDISMODULE_SWAPDBINFO_VERSION,id1,id2};
+        notifyDBEvent(NOTIFY_SWAPDB, "swapdb", c->argv[2], id1);
+        notifyDBEvent(NOTIFY_SWAPDB, "swapdb", c->argv[1], id2);
         moduleFireServerEvent(REDISMODULE_EVENT_SWAPDB,0,&si);
         server.dirty++;
         addReply(c,shared.ok);

--- a/src/db.c
+++ b/src/db.c
@@ -596,7 +596,7 @@ void signalFlushedDb(int dbid, int async) {
     if (async)
         msgobj = createStringObject("async",strlen("async"));
     else
-        msgobj  = createStringObject("sync",sizeof("sync")-1);
+        msgobj = createStringObject("sync",strlen("sync"));
 
     for (int j = startdb; j <= enddb; j++) {
         scanDatabaseForDeletedKeys(&server.db[j], NULL);

--- a/src/db.c
+++ b/src/db.c
@@ -487,7 +487,7 @@ long long emptyData(int dbnum, int flags, void(callback)(dict*)) {
                           REDISMODULE_SUBEVENT_FLUSHDB_START,
                           &fi);
 
-   /* Make sure the WATCHed keys are affected by the FLUSH* commands.
+    /* Make sure the WATCHed keys are affected by the FLUSH* commands.
      * Note that we need to call the function while the keys are still
      * there. */
     signalFlushedDb(dbnum, async);

--- a/src/db.c
+++ b/src/db.c
@@ -594,7 +594,7 @@ void signalFlushedDb(int dbid, int async) {
         startdb = enddb = dbid;
     }
     if (async)
-        msgobj = createStringObject("async",sizeof("async")-1);
+        msgobj = createStringObject("async",strlen("async"));
     else
         msgobj  = createStringObject("sync",sizeof("sync")-1);
 

--- a/src/notify.c
+++ b/src/notify.c
@@ -58,6 +58,9 @@ int keyspaceEventsStringToFlags(char *classes) {
         case 'm': flags |= NOTIFY_KEY_MISS; break;
         case 'd': flags |= NOTIFY_MODULE; break;
         case 'n': flags |= NOTIFY_NEW; break;
+        case 'D': flags |= NOTIFY_DBEVENT; break;
+        case 'f': flags |= NOTIFY_FLUSHDB; break;
+        case 'w': flags |= NOTIFY_SWAPDB; break;
         default: return -1;
         }
     }
@@ -86,9 +89,12 @@ sds keyspaceEventsFlagsToString(int flags) {
         if (flags & NOTIFY_STREAM) res = sdscatlen(res,"t",1);
         if (flags & NOTIFY_MODULE) res = sdscatlen(res,"d",1);
         if (flags & NOTIFY_NEW) res = sdscatlen(res,"n",1);
+        if (flags & NOTIFY_FLUSHDB) res = sdscatlen(res,"f",1);
+        if (flags & NOTIFY_SWAPDB) res = sdscatlen(res,"w",1);
     }
     if (flags & NOTIFY_KEYSPACE) res = sdscatlen(res,"K",1);
     if (flags & NOTIFY_KEYEVENT) res = sdscatlen(res,"E",1);
+    if (flags & NOTIFY_DBEVENT) res = sdscatlen(res,"D",1);
     if (flags & NOTIFY_KEY_MISS) res = sdscatlen(res,"m",1);
     return res;
 }
@@ -111,7 +117,7 @@ void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
      * This bypasses the notifications configuration, but the module engine
      * will only call event subscribers if the event type matches the types
      * they are interested in. */
-     moduleNotifyKeyspaceEvent(type, event, key, dbid);
+    moduleNotifyKeyspaceEvent(type, event, key, dbid);
 
     /* If notifications for this class of events are off, return ASAP. */
     if (!(server.notify_keyspace_events & type)) return;
@@ -143,3 +149,36 @@ void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
     }
     decrRefCount(eventobj);
 }
+
+/* The API provided to the rest of the Redis core is a simple function:
+ *
+ * notifyDBEvent(int type, char *event, char *msg, int dbid);
+ *
+ * 'type' is the notification class we define in `server.h`.
+ * 'event' is a C string representing the event name.
+ * 'msg' is the massage content related to the event
+ * 'dbid' is the database ID where the key lives.  */
+void notifyDBEvent(int type, char *event, robj *msg, int dbid) {
+    sds chan;
+    robj *chanobj, *eventobj;
+    int len = -1;
+    char buf[24];
+
+    /* If notifications for this class of events are off, return ASAP. */
+    if (!(server.notify_keyspace_events & type)) return;
+
+    if (server.notify_keyspace_events & NOTIFY_DBEVENT) {
+        eventobj = createStringObject(event,strlen(event));
+        chan = sdsnewlen("__dbevent@",10);
+        if (len == -1) len = ll2string(buf,sizeof(buf),dbid);
+        chan = sdscatlen(chan, buf, len);
+        chan = sdscatlen(chan, "__:", 3);
+        chan = sdscatsds(chan, eventobj->ptr);
+        chanobj = createObject(OBJ_STRING, chan);
+        pubsubPublishMessage(chanobj, msg, 0);
+        decrRefCount(chanobj);
+        decrRefCount(eventobj);
+    }
+
+}
+

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -105,10 +105,11 @@ pubsubtype pubSubShardType = {
  * to send a special message (for instance an Array type) by using the
  * addReply*() API family. */
 void addReplyPubsubMessage(client *c, robj *channel, robj *msg, robj *message_bulk) {
+    const unsigned int reply_len = msg ? 3 : 2;
     if (c->resp == 2)
-        addReply(c,shared.mbulkhdr[3]);
+        addReply(c,shared.mbulkhdr[reply_len]);
     else
-        addReplyPushLen(c,3);
+        addReplyPushLen(c,reply_len);
     addReply(c,message_bulk);
     addReplyBulk(c,channel);
     if (msg) addReplyBulk(c,msg);
@@ -118,14 +119,15 @@ void addReplyPubsubMessage(client *c, robj *channel, robj *msg, robj *message_bu
  * with the "message" type delivered by addReplyPubsubMessage() is that
  * this message format also includes the pattern that matched the message. */
 void addReplyPubsubPatMessage(client *c, robj *pat, robj *channel, robj *msg) {
+    const unsigned int reply_len = msg ? 4 : 3;
     if (c->resp == 2)
-        addReply(c,shared.mbulkhdr[4]);
+        addReply(c,shared.mbulkhdr[reply_len]);
     else
-        addReplyPushLen(c,4);
+        addReplyPushLen(c,reply_len);
     addReply(c,shared.pmessagebulk);
     addReplyBulk(c,pat);
     addReplyBulk(c,channel);
-    addReplyBulk(c,msg);
+    if (msg) addReplyBulk(c,msg);
 }
 
 /* Send the pubsub subscription notification to the client. */

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -105,11 +105,10 @@ pubsubtype pubSubShardType = {
  * to send a special message (for instance an Array type) by using the
  * addReply*() API family. */
 void addReplyPubsubMessage(client *c, robj *channel, robj *msg, robj *message_bulk) {
-    const unsigned int reply_len = msg ? 3 : 2;
     if (c->resp == 2)
-        addReply(c,shared.mbulkhdr[reply_len]);
+        addReply(c,shared.mbulkhdr[3]);
     else
-        addReplyPushLen(c,reply_len);
+        addReplyPushLen(c,3);
     addReply(c,message_bulk);
     addReplyBulk(c,channel);
     if (msg) addReplyBulk(c,msg);
@@ -119,15 +118,14 @@ void addReplyPubsubMessage(client *c, robj *channel, robj *msg, robj *message_bu
  * with the "message" type delivered by addReplyPubsubMessage() is that
  * this message format also includes the pattern that matched the message. */
 void addReplyPubsubPatMessage(client *c, robj *pat, robj *channel, robj *msg) {
-    const unsigned int reply_len = msg ? 4 : 3;
     if (c->resp == 2)
-        addReply(c,shared.mbulkhdr[reply_len]);
+        addReply(c,shared.mbulkhdr[4]);
     else
-        addReplyPushLen(c,reply_len);
+        addReplyPushLen(c,4);
     addReply(c,shared.pmessagebulk);
     addReplyBulk(c,pat);
     addReplyBulk(c,channel);
-    if (msg) addReplyBulk(c,msg);
+    addReplyBulk(c,msg);
 }
 
 /* Send the pubsub subscription notification to the client. */

--- a/src/server.h
+++ b/src/server.h
@@ -647,7 +647,10 @@ typedef enum {
 #define NOTIFY_LOADED (1<<12)     /* module only key space notification, indicate a key loaded from rdb */
 #define NOTIFY_MODULE (1<<13)     /* d, module key space notification */
 #define NOTIFY_NEW (1<<14)        /* n, new key notification */
-#define NOTIFY_ALL (NOTIFY_GENERIC | NOTIFY_STRING | NOTIFY_LIST | NOTIFY_SET | NOTIFY_HASH | NOTIFY_ZSET | NOTIFY_EXPIRED | NOTIFY_EVICTED | NOTIFY_STREAM | NOTIFY_MODULE) /* A flag */
+#define NOTIFY_DBEVENT (1<<15)    /* D */
+#define NOTIFY_FLUSHDB (1<<16)    /* f */
+#define NOTIFY_SWAPDB (1<<17)     /* w */
+#define NOTIFY_ALL (NOTIFY_GENERIC | NOTIFY_STRING | NOTIFY_LIST | NOTIFY_SET | NOTIFY_HASH | NOTIFY_ZSET | NOTIFY_EXPIRED | NOTIFY_EVICTED | NOTIFY_STREAM | NOTIFY_MODULE | NOTIFY_FLUSHDB | NOTIFY_SWAPDB) /* A flag */
 
 /* Using the following macro you can run code inside serverCron() with the
  * specified period, specified in milliseconds.
@@ -3064,6 +3067,7 @@ size_t pubsubMemOverhead(client *c);
 
 /* Keyspace events notification */
 void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid);
+void notifyDBEvent(int type, char *event, robj *msg, int dbid);
 int keyspaceEventsStringToFlags(char *classes);
 sds keyspaceEventsFlagsToString(int flags);
 

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -445,5 +445,5 @@ start_server {tags {"pubsub network"}} {
         assert_equal "pmessage * __dbevent@1__:swapdb 9" [$rd1 read]
         assert_equal "pmessage * __dbevent@9__:swapdb 1" [$rd1 read]
         $rd1 close
-    } {} {cluster:skip}
+    } {0} {cluster:skip}
 }

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -445,5 +445,5 @@ start_server {tags {"pubsub network"}} {
         assert_equal "pmessage * __dbevent@1__:swapdb 9" [$rd1 read]
         assert_equal "pmessage * __dbevent@9__:swapdb 1" [$rd1 read]
         $rd1 close
-    } {cluster:skip}
+    } {} {cluster:skip}
 }

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -445,5 +445,5 @@ start_server {tags {"pubsub network"}} {
         assert_equal "pmessage * __dbevent@1__:swapdb 9" [$rd1 read]
         assert_equal "pmessage * __dbevent@9__:swapdb 1" [$rd1 read]
         $rd1 close
-    }
+    } {cluster:skip}
 }


### PR DESCRIPTION
Introduce DB based keyspace notifications (solves #3782)

Some commands can cause a "DB level" event which effects the keyspace.
Commands like swapdb and flushdb will not be reported by the current
keyspace-notifications  mechanism since they do not operate on a key
level.
This PR introduce a new type of notification: "DBEVENT".
the DBEVENT will be reported into a new pubsub channel following a
similar logic as regular keyspace-notifications do.
the reported notification will have the following structure:
__dbevent@0\_\_:<event> <msg>
where the event will match the action (currently swapdb and flushdb)
and the massage will be different for each event (for example sync/async
for flush and the swapped db id in case of swapdb)

this PR contains:
1. add config values to notify-keyspace-events:
  - 'D' (NOTIFY_DBEVENT) - to enable getting DB level notifications
  - 'f' (NOTIFY_FLUSHDB) - to enable flushdb notifications
  - 'w' (NOTIFY_SWAPDB)  - to enable swapdb notifications

2. added notify API notifyDBEvent which is much like notifyKeyspaceEvent
 only instead of key it will accept a generic msg.

3. emit flushdb notification in signalFlushedDb

4. emit swapdb notifications in swapdbCommand

5. added tests in pubsub.tcl for swapdb, flushall, flushdb

Open issues:
- [ ] do we want to issue separate event for each DB on flushall?
- [ ] currently modules will not be notified for db events, since they will
 not get a key. do we want a new module API to handle DB events?
- [ ] do we want 2 separate events for before/after flushdb and swapdb?
