### PR TITLE
Event name of INCRBY command is being used by for INCR, DECR and DECRBY commands as well

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -638,7 +638,7 @@ void incrDecrCommand(client *c, long long incr, const char *event) {
     }
     addReplyLongLongFromStr(c,new);
     signalModifiedKey(c,c->db,c->argv[1]);
-    notifyKeyspaceEvent(NOTIFY_STRING, event,c->argv[1],c->db->id);
+    notifyKeyspaceEvent(NOTIFY_STRING,event,c->argv[1],c->db->id);
     server.dirty++;
 }
 

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -601,7 +601,7 @@ void msetnxCommand(client *c) {
     msetGenericCommand(c,1);
 }
 
-void incrDecrCommand(client *c, long long incr, char * const event) {
+void incrDecrCommand(client *c, long long incr, const char *event) {
     long long value, oldvalue;
     robj *new;
     dictEntryLink link;

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -601,7 +601,7 @@ void msetnxCommand(client *c) {
     msetGenericCommand(c,1);
 }
 
-void incrDecrCommand(client *c, long long incr) {
+void incrDecrCommand(client *c, long long incr, char * const event) {
     long long value, oldvalue;
     robj *new;
     dictEntryLink link;
@@ -638,23 +638,23 @@ void incrDecrCommand(client *c, long long incr) {
     }
     addReplyLongLongFromStr(c,new);
     signalModifiedKey(c,c->db,c->argv[1]);
-    notifyKeyspaceEvent(NOTIFY_STRING,"incrby",c->argv[1],c->db->id);
+    notifyKeyspaceEvent(NOTIFY_STRING, event,c->argv[1],c->db->id);
     server.dirty++;
 }
 
 void incrCommand(client *c) {
-    incrDecrCommand(c,1);
+    incrDecrCommand(c,1, "incr");
 }
 
 void decrCommand(client *c) {
-    incrDecrCommand(c,-1);
+    incrDecrCommand(c,-1, "decr");
 }
 
 void incrbyCommand(client *c) {
     long long incr;
 
     if (getLongLongFromObjectOrReply(c, c->argv[2], &incr, NULL) != C_OK) return;
-    incrDecrCommand(c,incr);
+    incrDecrCommand(c,incr, "incrby");
 }
 
 void decrbyCommand(client *c) {
@@ -666,7 +666,7 @@ void decrbyCommand(client *c) {
         addReplyError(c, "decrement would overflow");
         return;
     }
-    incrDecrCommand(c,-incr);
+    incrDecrCommand(c,-incr, "decrby");
 }
 
 void incrbyfloatCommand(client *c) {

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -643,18 +643,18 @@ void incrDecrCommand(client *c, long long incr, const char *event) {
 }
 
 void incrCommand(client *c) {
-    incrDecrCommand(c,1, "incr");
+    incrDecrCommand(c,1,"incr");
 }
 
 void decrCommand(client *c) {
-    incrDecrCommand(c,-1, "decr");
+    incrDecrCommand(c,-1,"decr");
 }
 
 void incrbyCommand(client *c) {
     long long incr;
 
     if (getLongLongFromObjectOrReply(c, c->argv[2], &incr, NULL) != C_OK) return;
-    incrDecrCommand(c,incr, "incrby");
+    incrDecrCommand(c,incr,"incrby");
 }
 
 void decrbyCommand(client *c) {
@@ -666,7 +666,7 @@ void decrbyCommand(client *c) {
         addReplyError(c, "decrement would overflow");
         return;
     }
-    incrDecrCommand(c,-incr, "decrby");
+    incrDecrCommand(c,-incr,"decrby");
 }
 
 void incrbyfloatCommand(client *c) {


### PR DESCRIPTION
I found out this small issue while navigating through the code. The event name `incrby` was being used by `INCR`, `DECR`, `INCRBY` and `DECRBY` commands.
It makes sense to think that the `incrby` event name cannot represent `INCR`, `DECR` or `DECRBY` operations.

Following the documentation of the function `notifyKeyspaceEvent`, it looks like it's not a good thing to have the same event name for 4 different functionalities. 

```c
/* The API provided to the rest of the Redis core is a simple function:
 *
 * notifyKeyspaceEvent(int type, char *event, robj *key, int dbid);
 *
 * 'type' is the notification class we define in `server.h`.
 * 'event' is a C string representing the event name.  <--------- 
 * 'key' is a Redis object representing the key name.
 * 'dbid' is the database ID where the key lives.  */
void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
```