### PR TITLE
fix bug:fat argv caused oom reply even redis had enough memory

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -402,6 +402,10 @@ int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *lev
     mem_reported = zmalloc_used_memory();
     if (total) *total = mem_reported;
 
+    if (server.stat_peak_memory < mem_reported) {
+        server.stat_peak_memory = mem_reported;
+    }
+
     /* We may return ASAP if there is no need to compute the level. */
     if (!server.maxmemory) {
         if (level) *level = 0;

--- a/src/evict.c
+++ b/src/evict.c
@@ -402,6 +402,8 @@ int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *lev
     mem_reported = zmalloc_used_memory();
     if (total) *total = mem_reported;
 
+    /* here we should immediately update memory peak, so when eviction occured,
+     * we can see that used_memory_peak is indeed greater than maxmemory */
     if (server.stat_peak_memory < mem_reported) {
         server.stat_peak_memory = mem_reported;
     }

--- a/src/evict.c
+++ b/src/evict.c
@@ -402,7 +402,7 @@ int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *lev
     mem_reported = zmalloc_used_memory();
     if (total) *total = mem_reported;
 
-    /* here we should immediately update memory peak, so when eviction occured,
+    /* here we should immediately update memory peak, so when eviction occurred,
      * we can see that used_memory_peak is indeed greater than maxmemory */
     if (server.stat_peak_memory < mem_reported) {
         server.stat_peak_memory = mem_reported;

--- a/src/networking.c
+++ b/src/networking.c
@@ -2322,7 +2322,7 @@ int processMultibulkBuffer(client *c) {
                 sdsIncrLen(c->querybuf,-2); /* remove CRLF */
                 /* Assume that if we saw a fat argument we'll see another one
                  * likely... */
-                c->querybuf = sdsnewlen(SDS_NOINIT,c->bulklen+2);
+                c->querybuf = sdsnewlen(SDS_NOINIT,c->bulklen+2 < PROTO_MBULK_BIG_ARG*2 ? c->bulklen+2:PROTO_MBULK_BIG_ARG*2);
                 sdsclear(c->querybuf);
             } else {
                 c->argv[c->argc++] =

--- a/src/networking.c
+++ b/src/networking.c
@@ -2321,7 +2321,7 @@ int processMultibulkBuffer(client *c) {
                 c->argv_len_sum += c->bulklen;
                 sdsIncrLen(c->querybuf,-2); /* remove CRLF */
                 /* Assume that if we saw a fat argument we'll see another one
-                 * likely... */
+                 * likely, But we also need to consider the cost of predicting */
                 c->querybuf = sdsnewlen(SDS_NOINIT,c->bulklen+2 < PROTO_MBULK_BIG_ARG*2 ? c->bulklen+2:PROTO_MBULK_BIG_ARG*2);
                 sdsclear(c->querybuf);
             } else {

--- a/src/networking.c
+++ b/src/networking.c
@@ -2322,7 +2322,8 @@ int processMultibulkBuffer(client *c) {
                 sdsIncrLen(c->querybuf,-2); /* remove CRLF */
                 /* Assume that if we saw a fat argument we'll see another one
                  * likely, But we also need to consider the cost of predicting */
-                c->querybuf = sdsnewlen(SDS_NOINIT,c->bulklen+2 < PROTO_MBULK_BIG_ARG*2 ? c->bulklen+2:PROTO_MBULK_BIG_ARG*2);
+                c->querybuf =
+                    sdsnewlen(SDS_NOINIT, c->bulklen + 2 < PROTO_MBULK_BIG_ARG * 2 ? c->bulklen + 2 : PROTO_IOBUF_LEN);
                 sdsclear(c->querybuf);
             } else {
                 c->argv[c->argc++] =

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -571,3 +571,11 @@ start_server {tags {"maxmemory" "external:skip"}} {
         r config set maxmemory-policy noeviction
     }
 }
+
+start_server {tags {"maxmemory" "external:skip"}} {
+    test {client with big values don't cause oom when values litter than maxmemory} {
+        r config set maxmemory 2MB
+        set val [randstring 1024000 1024000 alpha]
+        r set foo $val
+    } {OK}
+}


### PR DESCRIPTION
This pr limits the memory and cpu overhead of predicting the length of querybuf, which may lead to performance degradation when next bulk indeed have the same length with current bulk, but can also improve performance and memory if prediction failures.

fixed #11830 