### PR TITLE
assert in case resize output buffer will attempt to shrink too much

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -789,6 +789,8 @@ int clientsCronResizeOutputBuffer(client *c, mstime_t now_ms) {
         server.stat_reply_buffer_expands++;
     }
 
+    serverAssertWithInfo(c, NULL, (!new_buffer_size) || (new_buffer_size >= (size_t)c->bufpos));
+
     /* reset the peak value each server.reply_buffer_peak_reset_time seconds. in case the client will be idle
      * it will start to shrink.
      */


### PR DESCRIPTION
Currently there is no BUG. However during some internal code changes I found that it can happen (for example in case new code will not update the buf_peak) which can currently lead to memory overrun which is much harder to detect and root cause.

Why did I please the assert here? The reason is to be able to have the buf_peak value without the risk of it being overriden by the peak_reset