### PR TITLE
Fix race in temp rdb delete shutdown test

### DIFF
--- a/tests/unit/shutdown.tcl
+++ b/tests/unit/shutdown.tcl
@@ -3,12 +3,16 @@ start_server {tags {"shutdown external:skip"}} {
         for {set i 0} {$i < 20} {incr i} {
             r set $i $i
         }
-        # It will cost 2s(20 * 100ms) to dump rdb
-        r config set rdb-key-save-delay 100000
+        r config set rdb-key-save-delay 10000000
 
         # Child is dumping rdb
         r bgsave
-        after 100
+        wait_for_condition 1000 10 {
+            [s rdb_bgsave_in_progress] eq 1
+        } else {
+            fail "bgsave did not start in time"
+        }
+
         set dir [lindex [r config get dir] 1]
         set child_pid [get_child_pid 0]
         set temp_rdb [file join [lindex [r config get dir] 1] temp-${child_pid}.rdb]

--- a/tests/unit/shutdown.tcl
+++ b/tests/unit/shutdown.tcl
@@ -7,12 +7,12 @@ start_server {tags {"shutdown external:skip"}} {
 
         # Child is dumping rdb
         r bgsave
-        after 100
         wait_for_condition 1000 10 {
             [s rdb_bgsave_in_progress] eq 1
         } else {
             fail "bgsave did not start in time"
         }
+        after 100 ;# give the child a bit of time for the file to be created
 
         set dir [lindex [r config get dir] 1]
         set child_pid [get_child_pid 0]

--- a/tests/unit/shutdown.tcl
+++ b/tests/unit/shutdown.tcl
@@ -7,6 +7,7 @@ start_server {tags {"shutdown external:skip"}} {
 
         # Child is dumping rdb
         r bgsave
+        after 100
         wait_for_condition 1000 10 {
             [s rdb_bgsave_in_progress] eq 1
         } else {


### PR DESCRIPTION
I saw this error once, in the FreeBSD Daily CI:
```
*** [err]: Temp rdb will be deleted if we use bg_unlink when shutdown in tests/unit/shutdown.tcl
Expected [file exists /xxx/temp-10336.rdb] (context: type eval line 15 cmd {assert {[file exists $temp_rdb]}} proc ::test)
```

The log shows that bgsave was executed, and it was successfully executed in the end:
```
Starting test Temp rdb will be deleted if we use bg_unlink when shutdown in tests/unit/shutdown.tcl
10251:M 22 Feb 2023 11:37:25.441 * Background saving started by pid 10336
10336:C 22 Feb 2023 11:37:27.949 * DB saved on disk
10336:C 22 Feb 2023 11:37:27.949 * Fork CoW for RDB: current 0 MB, peak 0 MB, average 0 MB
10251:M 22 Feb 2023 11:37:28.060 * Background saving terminated with success
```

There may be two reasons:
1. The child process has been created, but it has not created
   the temp rdb file yet, so [file exists $temp_rdb] check failed.
2. The child process bgsave has been executed successfully and the
   temp file has been deleted, so [file exists $temp_rdb] check failed.

From the logs pint, it should be the case 2, case 1 is too extreme,
set rdb-key-save-delay to a higher value to ensure bgsave does not
succeed early to avoid this case.