### PR TITLE
fix build error, missing struct "Dl_info" under windows in cygwin

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -39,6 +39,10 @@
 
 #include <arpa/inet.h>
 #include <signal.h>
+
+#ifdef __CYGWIN__
+#define __GNU_VISIBLE   1
+#endif
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <sys/mman.h>


### PR DESCRIPTION
fix: #11843  by: define __GNU_VISIBLE 1 under __CYGWIN__





