### PR TITLE
redis-cli, don't call COMMANDS DOCS if not TTY (not interactive)

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2621,7 +2621,7 @@ static void repl(void) {
     /* There is no need to initialize redis HELP when we are in lua debugger mode.
      * It has its own HELP and commands (COMMAND or COMMAND DOCS will fail and got nothing).
      * We will initialize the redis HELP after the Lua debugging session ended.*/
-    if (!config.eval_ldb) {
+    if ((!config.eval_ldb) && isatty(fileno(stdin))) {
         /* Initialize the help using the results of the COMMAND command. */
         cliInitHelp();
     }


### PR DESCRIPTION
Avoiding initializing the interactive help and the excessive call to the COMMAND command when using redis-cli with pipe.
e.g.
```
echo PING | redis-cli
```

See https://github.com/redis/redis/issues/3978#issuecomment-1446032572

