### PR TITLE
Fix possible memory corruption in FLUSHALL when a client watches more than one key

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -458,9 +458,9 @@ void touchAllWatchedKeysInDb(redisDb *emptied, redisDb *replaced_with) {
                 }
                 client *c = wk->client;
                 c->flags |= CLIENT_DIRTY_CAS;
-                /* As the client is marked as dirty, there is no point in getting here
-                 * again for others keys (or keep the memory overhead till EXEC). */
-                unwatchAllKeys(c);
+                /* Note - we could potentially call unwatchAllKeys for this specific client in order to reduce
+                 * the total number of iterations. BUT this could also free the current next entry pointer
+                 * held by the iterator and can lead to use-after-free. */
             }
         }
     }

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -900,17 +900,7 @@ start_server {tags {"multi"}} {
         r mset a a b b
         r watch b a
         r flushall
-        
-        if {!$::external} {
-            # check valgrind and asan report for invalid reads after execute
-            # command so that we have a report that is easier to reproduce
-            set valgrind_errors [find_valgrind_errors [srv 0 stderr] false]
-            set asan_errors [sanitizer_errors_from_file [srv 0 stderr]]
-            if {$valgrind_errors != "" || $asan_errors != ""} {
-                puts "valgrind or asan found an issue"
-                set print_commands true
-            }
-        }
+        r ping
      }
 }
 

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -895,7 +895,7 @@ start_server {tags {"multi"}} {
         set _ $res
     } {*CONFIG SET failed*}
     
-    test "Flushall while watching serveral keys by one client" {
+    test "Flushall while watching several keys by one client" {
         r flushall
         r mset a a b b
         r watch b a


### PR DESCRIPTION
Avoid calling unwatchAllKeys when running touchAllWatchedKeysInDb (which was unnecessary)
This can potentially lead to use-after-free and memory corruption when the next entry pointer held by the watched keys iterator is freed when unwatching all keys of a specific client.
found with address sanitizer, added a test which will not always fail (depending on the random dict hashing seed)
problem introduced in #9829 (Reids 7.0)