### PR TITLE
Fix the bug that CLIENT REPLY OFF|SKIP cannot receive push notifications

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -807,11 +807,12 @@ NULL
                 addReplyError(c,"RESP2 is not supported by this command");
                 return;
 	    }
+            uint64_t old_flags = c->flags;
             c->flags |= CLIENT_PUSHING;
             addReplyPushLen(c,2);
             addReplyBulkCString(c,"server-cpu-usage");
             addReplyLongLong(c,42);
-            c->flags &= ~CLIENT_PUSHING;
+            if (!(old_flags & CLIENT_PUSHING)) c->flags &= ~CLIENT_PUSHING;
             /* Push replies are not synchronous replies, so we emit also a
              * normal reply in order for blocking clients just discarding the
              * push reply, to actually consume the reply and continue. */

--- a/src/debug.c
+++ b/src/debug.c
@@ -807,6 +807,7 @@ NULL
                 addReplyError(c,"RESP2 is not supported by this command");
                 return;
 	    }
+            c->flags |= CLIENT_PUSHING;
             addReplyPushLen(c,2);
             addReplyBulkCString(c,"server-cpu-usage");
             addReplyLongLong(c,42);
@@ -814,6 +815,7 @@ NULL
              * normal reply in order for blocking clients just discarding the
              * push reply, to actually consume the reply and continue. */
             addReplyBulkCString(c,"Some real reply following the push reply");
+            c->flags &= ~CLIENT_PUSHING;
         } else if (!strcasecmp(name,"true")) {
             addReplyBool(c,1);
         } else if (!strcasecmp(name,"false")) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -811,11 +811,11 @@ NULL
             addReplyPushLen(c,2);
             addReplyBulkCString(c,"server-cpu-usage");
             addReplyLongLong(c,42);
+            c->flags &= ~CLIENT_PUSHING;
             /* Push replies are not synchronous replies, so we emit also a
              * normal reply in order for blocking clients just discarding the
              * push reply, to actually consume the reply and continue. */
             addReplyBulkCString(c,"Some real reply following the push reply");
-            c->flags &= ~CLIENT_PUSHING;
         } else if (!strcasecmp(name,"true")) {
             addReplyBool(c,1);
         } else if (!strcasecmp(name,"false")) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -311,12 +311,6 @@ int prepareClientToWrite(client *c) {
     if (!clientHasPendingReplies(c) && io_threads_op == IO_THREADS_OP_IDLE)
         putClientInPendingWriteQueue(c);
 
-    /* Make sure that any call to prepareClientToWrite when that client is
-     * not the executing_client, is done with the PUSHING flag set. */
-    if (server.executing_client != c) {
-        // serverAssertWithInfo(c, NULL, c->flags & CLIENT_PUSHING);
-    }
-
     /* Authorize the caller to queue in the output buffer of this client. */
     return C_OK;
 }
@@ -973,6 +967,7 @@ void addReplyAttributeLen(client *c, long length) {
 
 void addReplyPushLen(client *c, long length) {
     serverAssert(c->resp >= 3);
+    serverAssertWithInfo(c, NULL, c->flags & CLIENT_PUSHING);
     addReplyAggregateLen(c,length,'>');
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -287,12 +287,10 @@ int prepareClientToWrite(client *c) {
     /* If CLIENT_CLOSE_ASAP flag is set, we need not write anything. */
     if (c->flags & CLIENT_CLOSE_ASAP) return C_ERR;
 
-    if (c->flags & CLIENT_PUSHING) {
-        /* PUSH messages are not really a reply, and should not be skipped. */
-    } else {
-        /* CLIENT REPLY OFF / SKIP handling: don't send replies. */
-        if (c->flags & (CLIENT_REPLY_OFF|CLIENT_REPLY_SKIP)) return C_ERR;
-    }
+    /* CLIENT REPLY OFF / SKIP handling: don't send replies.
+     * CLIENT_PUSHING handling: disables the reply silencing flags. */
+    if ((c->flags & (CLIENT_REPLY_OFF|CLIENT_REPLY_SKIP)) &&
+        !(c->flags & CLIENT_PUSHING)) return C_ERR;
 
     /* Masters don't receive replies, unless CLIENT_MASTER_FORCE_REPLY flag
      * is set. */

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -105,6 +105,7 @@ pubsubtype pubSubShardType = {
  * to send a special message (for instance an Array type) by using the
  * addReply*() API family. */
 void addReplyPubsubMessage(client *c, robj *channel, robj *msg, robj *message_bulk) {
+    c->flags |= CLIENT_PUSHING;
     if (c->resp == 2)
         addReply(c,shared.mbulkhdr[3]);
     else
@@ -112,12 +113,14 @@ void addReplyPubsubMessage(client *c, robj *channel, robj *msg, robj *message_bu
     addReply(c,message_bulk);
     addReplyBulk(c,channel);
     if (msg) addReplyBulk(c,msg);
+    c->flags &= ~CLIENT_PUSHING;
 }
 
 /* Send a pubsub message of type "pmessage" to the client. The difference
  * with the "message" type delivered by addReplyPubsubMessage() is that
  * this message format also includes the pattern that matched the message. */
 void addReplyPubsubPatMessage(client *c, robj *pat, robj *channel, robj *msg) {
+    c->flags |= CLIENT_PUSHING;
     if (c->resp == 2)
         addReply(c,shared.mbulkhdr[4]);
     else
@@ -126,10 +129,12 @@ void addReplyPubsubPatMessage(client *c, robj *pat, robj *channel, robj *msg) {
     addReplyBulk(c,pat);
     addReplyBulk(c,channel);
     addReplyBulk(c,msg);
+    c->flags &= ~CLIENT_PUSHING;
 }
 
 /* Send the pubsub subscription notification to the client. */
 void addReplyPubsubSubscribed(client *c, robj *channel, pubsubtype type) {
+    c->flags |= CLIENT_PUSHING;
     if (c->resp == 2)
         addReply(c,shared.mbulkhdr[3]);
     else
@@ -137,6 +142,7 @@ void addReplyPubsubSubscribed(client *c, robj *channel, pubsubtype type) {
     addReply(c,*type.subscribeMsg);
     addReplyBulk(c,channel);
     addReplyLongLong(c,type.subscriptionCount(c));
+    c->flags &= ~CLIENT_PUSHING;
 }
 
 /* Send the pubsub unsubscription notification to the client.
@@ -144,6 +150,7 @@ void addReplyPubsubSubscribed(client *c, robj *channel, pubsubtype type) {
  * unsubscribe command but there are no channels to unsubscribe from: we
  * still send a notification. */
 void addReplyPubsubUnsubscribed(client *c, robj *channel, pubsubtype type) {
+    c->flags |= CLIENT_PUSHING;
     if (c->resp == 2)
         addReply(c,shared.mbulkhdr[3]);
     else
@@ -154,10 +161,12 @@ void addReplyPubsubUnsubscribed(client *c, robj *channel, pubsubtype type) {
     else
         addReplyNull(c);
     addReplyLongLong(c,type.subscriptionCount(c));
+    c->flags &= ~CLIENT_PUSHING;
 }
 
 /* Send the pubsub pattern subscription notification to the client. */
 void addReplyPubsubPatSubscribed(client *c, robj *pattern) {
+    c->flags |= CLIENT_PUSHING;
     if (c->resp == 2)
         addReply(c,shared.mbulkhdr[3]);
     else
@@ -165,6 +174,7 @@ void addReplyPubsubPatSubscribed(client *c, robj *pattern) {
     addReply(c,shared.psubscribebulk);
     addReplyBulk(c,pattern);
     addReplyLongLong(c,clientSubscriptionsCount(c));
+    c->flags &= ~CLIENT_PUSHING;
 }
 
 /* Send the pubsub pattern unsubscription notification to the client.
@@ -172,6 +182,7 @@ void addReplyPubsubPatSubscribed(client *c, robj *pattern) {
  * punsubscribe command but there are no pattern to unsubscribe from: we
  * still send a notification. */
 void addReplyPubsubPatUnsubscribed(client *c, robj *pattern) {
+    c->flags |= CLIENT_PUSHING;
     if (c->resp == 2)
         addReply(c,shared.mbulkhdr[3]);
     else
@@ -182,6 +193,7 @@ void addReplyPubsubPatUnsubscribed(client *c, robj *pattern) {
     else
         addReplyNull(c);
     addReplyLongLong(c,clientSubscriptionsCount(c));
+    c->flags &= ~CLIENT_PUSHING;
 }
 
 /*-----------------------------------------------------------------------------
@@ -464,19 +476,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
         listRewind(list,&li);
         while ((ln = listNext(&li)) != NULL) {
             client *c = ln->value;
-            uint64_t old_flags = c->flags;
-
-            /* We do not want to disable the reply in Pub/Sub messages. */
-            c->flags &= ~(CLIENT_REPLY_OFF|CLIENT_REPLY_SKIP);
-
             addReplyPubsubMessage(c,channel,message,*type.messageBulk);
-
-            /* Restore the old CLIENT_REPLY_* flags. */
-            if (old_flags & CLIENT_REPLY_OFF)
-                c->flags |= CLIENT_REPLY_OFF;
-            if (old_flags & CLIENT_REPLY_SKIP)
-                c->flags |= CLIENT_REPLY_SKIP;
-
             updateClientMemUsageAndBucket(c);
             receivers++;
         }

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -105,6 +105,7 @@ pubsubtype pubSubShardType = {
  * to send a special message (for instance an Array type) by using the
  * addReply*() API family. */
 void addReplyPubsubMessage(client *c, robj *channel, robj *msg, robj *message_bulk) {
+    uint64_t old_flags = c->flags;
     c->flags |= CLIENT_PUSHING;
     if (c->resp == 2)
         addReply(c,shared.mbulkhdr[3]);
@@ -113,13 +114,14 @@ void addReplyPubsubMessage(client *c, robj *channel, robj *msg, robj *message_bu
     addReply(c,message_bulk);
     addReplyBulk(c,channel);
     if (msg) addReplyBulk(c,msg);
-    c->flags &= ~CLIENT_PUSHING;
+    if (!(old_flags & CLIENT_PUSHING)) c->flags &= ~CLIENT_PUSHING;
 }
 
 /* Send a pubsub message of type "pmessage" to the client. The difference
  * with the "message" type delivered by addReplyPubsubMessage() is that
  * this message format also includes the pattern that matched the message. */
 void addReplyPubsubPatMessage(client *c, robj *pat, robj *channel, robj *msg) {
+    uint64_t old_flags = c->flags;
     c->flags |= CLIENT_PUSHING;
     if (c->resp == 2)
         addReply(c,shared.mbulkhdr[4]);
@@ -129,11 +131,12 @@ void addReplyPubsubPatMessage(client *c, robj *pat, robj *channel, robj *msg) {
     addReplyBulk(c,pat);
     addReplyBulk(c,channel);
     addReplyBulk(c,msg);
-    c->flags &= ~CLIENT_PUSHING;
+    if (!(old_flags & CLIENT_PUSHING)) c->flags &= ~CLIENT_PUSHING;
 }
 
 /* Send the pubsub subscription notification to the client. */
 void addReplyPubsubSubscribed(client *c, robj *channel, pubsubtype type) {
+    uint64_t old_flags = c->flags;
     c->flags |= CLIENT_PUSHING;
     if (c->resp == 2)
         addReply(c,shared.mbulkhdr[3]);
@@ -142,7 +145,7 @@ void addReplyPubsubSubscribed(client *c, robj *channel, pubsubtype type) {
     addReply(c,*type.subscribeMsg);
     addReplyBulk(c,channel);
     addReplyLongLong(c,type.subscriptionCount(c));
-    c->flags &= ~CLIENT_PUSHING;
+    if (!(old_flags & CLIENT_PUSHING)) c->flags &= ~CLIENT_PUSHING;
 }
 
 /* Send the pubsub unsubscription notification to the client.
@@ -150,6 +153,7 @@ void addReplyPubsubSubscribed(client *c, robj *channel, pubsubtype type) {
  * unsubscribe command but there are no channels to unsubscribe from: we
  * still send a notification. */
 void addReplyPubsubUnsubscribed(client *c, robj *channel, pubsubtype type) {
+    uint64_t old_flags = c->flags;
     c->flags |= CLIENT_PUSHING;
     if (c->resp == 2)
         addReply(c,shared.mbulkhdr[3]);
@@ -161,11 +165,12 @@ void addReplyPubsubUnsubscribed(client *c, robj *channel, pubsubtype type) {
     else
         addReplyNull(c);
     addReplyLongLong(c,type.subscriptionCount(c));
-    c->flags &= ~CLIENT_PUSHING;
+    if (!(old_flags & CLIENT_PUSHING)) c->flags &= ~CLIENT_PUSHING;
 }
 
 /* Send the pubsub pattern subscription notification to the client. */
 void addReplyPubsubPatSubscribed(client *c, robj *pattern) {
+    uint64_t old_flags = c->flags;
     c->flags |= CLIENT_PUSHING;
     if (c->resp == 2)
         addReply(c,shared.mbulkhdr[3]);
@@ -174,7 +179,7 @@ void addReplyPubsubPatSubscribed(client *c, robj *pattern) {
     addReply(c,shared.psubscribebulk);
     addReplyBulk(c,pattern);
     addReplyLongLong(c,clientSubscriptionsCount(c));
-    c->flags &= ~CLIENT_PUSHING;
+    if (!(old_flags & CLIENT_PUSHING)) c->flags &= ~CLIENT_PUSHING;
 }
 
 /* Send the pubsub pattern unsubscription notification to the client.
@@ -182,6 +187,7 @@ void addReplyPubsubPatSubscribed(client *c, robj *pattern) {
  * punsubscribe command but there are no pattern to unsubscribe from: we
  * still send a notification. */
 void addReplyPubsubPatUnsubscribed(client *c, robj *pattern) {
+    uint64_t old_flags = c->flags;
     c->flags |= CLIENT_PUSHING;
     if (c->resp == 2)
         addReply(c,shared.mbulkhdr[3]);
@@ -193,7 +199,7 @@ void addReplyPubsubPatUnsubscribed(client *c, robj *pattern) {
     else
         addReplyNull(c);
     addReplyLongLong(c,clientSubscriptionsCount(c));
-    c->flags &= ~CLIENT_PUSHING;
+    if (!(old_flags & CLIENT_PUSHING)) c->flags &= ~CLIENT_PUSHING;
 }
 
 /*-----------------------------------------------------------------------------

--- a/src/server.h
+++ b/src/server.h
@@ -391,6 +391,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_ALLOW_OOM (1ULL<<44) /* Client used by RM_Call is allowed to fully execute
                                        scripts even when in OOM */
 #define CLIENT_NO_TOUCH (1ULL<<45) /* This client will not touch LFU/LRU stats. */
+#define CLIENT_PUSHING (1ULL<<46) /* This client is pushing notifications. */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -275,9 +275,11 @@ void sendTrackingMessage(client *c, char *keyname, size_t keylen, int proto) {
              * are unable to send invalidation messages to the redirected
              * connection, because the client no longer exist. */
             if (c->resp > 2) {
+                c->flags |= CLIENT_PUSHING;
                 addReplyPushLen(c,2);
                 addReplyBulkCBuffer(c,"tracking-redir-broken",21);
                 addReplyLongLong(c,c->client_tracking_redirection);
+                c->flags &= ~CLIENT_PUSHING;
             }
             return;
         }
@@ -290,8 +292,10 @@ void sendTrackingMessage(client *c, char *keyname, size_t keylen, int proto) {
      * in Pub/Sub mode, we can support the feature with RESP 2 as well,
      * by sending Pub/Sub messages in the __redis__:invalidate channel. */
     if (c->resp > 2) {
+        c->flags |= CLIENT_PUSHING;
         addReplyPushLen(c,2);
         addReplyBulkCBuffer(c,"invalidate",10);
+        c->flags &= ~CLIENT_PUSHING;
     } else if (using_redirection && c->flags & CLIENT_PUBSUB) {
         /* We use a static object to speedup things, however we assume
          * that addReplyPubsubMessage() will not take a reference. */

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -285,8 +285,11 @@ void sendTrackingMessage(client *c, char *keyname, size_t keylen, int proto) {
             if (!(old_flags & CLIENT_PUSHING)) c->flags &= ~CLIENT_PUSHING;
             return;
         }
+        if (!(old_flags & CLIENT_PUSHING)) c->flags &= ~CLIENT_PUSHING;
         c = redir;
         using_redirection = 1;
+        old_flags = c->flags;
+        c->flags |= CLIENT_PUSHING;
     }
 
     /* Only send such info for clients in RESP version 3 or more. However

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -309,12 +309,14 @@ void sendTrackingMessage(client *c, char *keyname, size_t keylen, int proto) {
     }
 
     /* Send the "value" part, which is the array of keys. */
+    c->flags |= CLIENT_PUSHING;
     if (proto) {
         addReplyProto(c,keyname,keylen);
     } else {
         addReplyArrayLen(c,1);
         addReplyBulkCBuffer(c,keyname,keylen);
     }
+    c->flags &= ~CLIENT_PUSHING;
     updateClientMemUsageAndBucket(c);
 }
 

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -131,7 +131,7 @@ start_server {tags {"introspection"}} {
         assert_equal {OK} [$rd read] ;# OK from CLIENT REPLY ON command
 
         $rd ping
-        assert_equal {pong} [$rd read]
+        assert_equal {PONG} [$rd read]
 
         $rd close
     }

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -94,6 +94,48 @@ start_server {tags {"introspection"}} {
         }
     } {} {needs:save}
 
+    test "CLIENT REPLY OFF/ON: disable all commands reply" {
+        set rd [redis_deferring_client]
+
+        # These replies were silenced.
+        $rd client reply off
+        $rd ping pong
+        $rd ping pong2
+
+        $rd client reply on
+        assert_equal {OK} [$rd read]
+        $rd ping pong3
+        assert_equal {pong3} [$rd read]
+
+        $rd close
+    }
+
+    test "CLIENT REPLY SKIP: skip the next command reply" {
+        set rd [redis_deferring_client]
+
+        # The first pong reply was silenced.
+        $rd client reply skip
+        $rd ping pong
+
+        $rd ping pong2
+        assert_equal {pong2} [$rd read]
+
+        $rd close
+    }
+
+    test "CLIENT REPLY ON: unset SKIP flag" {
+        set rd [redis_deferring_client]
+
+        $rd client reply skip
+        $rd client reply on
+        assert_equal {OK} [$rd read] ;# OK from CLIENT REPLY ON command
+
+        $rd ping
+        assert_equal {pong} [$rd read]
+
+        $rd close
+    }
+
     test {MONITOR can log executed commands} {
         set rd [redis_deferring_client]
         $rd monitor

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -239,7 +239,7 @@ start_server {tags {"pubsub network"}} {
     test "Keyspace notifications: we receive keyspace notifications" {
         r config set notify-keyspace-events KA
         set rd1 [redis_deferring_client]
-        $rd1 CLIENT REPLY OFF ;# Test the event notification is ok
+        $rd1 CLIENT REPLY OFF ;# Make sure it works even if replies are silenced
         assert_equal {1} [psubscribe $rd1 *]
         r set foo bar
         assert_equal "pmessage * __keyspace@${db}__:foo set" [$rd1 read]
@@ -249,7 +249,7 @@ start_server {tags {"pubsub network"}} {
     test "Keyspace notifications: we receive keyevent notifications" {
         r config set notify-keyspace-events EA
         set rd1 [redis_deferring_client]
-        $rd1 CLIENT REPLY SKIP ;# Test the event notification is ok
+        $rd1 CLIENT REPLY SKIP ;# Make sure it works even if replies are silenced
         assert_equal {1} [psubscribe $rd1 *]
         r set foo bar
         assert_equal "pmessage * __keyevent@${db}__:set foo" [$rd1 read]
@@ -259,7 +259,7 @@ start_server {tags {"pubsub network"}} {
     test "Keyspace notifications: we can receive both kind of events" {
         r config set notify-keyspace-events KEA
         set rd1 [redis_deferring_client]
-        $rd1 CLIENT REPLY ON ;# Test the event notification is ok
+        $rd1 CLIENT REPLY ON ;# Just coverage
         assert_equal {OK} [$rd1 read]
         assert_equal {1} [psubscribe $rd1 *]
         r set foo bar

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -146,37 +146,28 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
-    foreach type {OFF SKIP} {
-        test "PubSub messages with CLIENT REPLY $type" {
-            set rd [redis_deferring_client]
-            $rd hello 3
-            $rd read ;# Discard the hello reply
+    test "PubSub messages with CLIENT REPLY OFF" {
+        set rd [redis_deferring_client]
+        $rd hello 3
+        $rd read ;# Discard the hello reply
 
-            # Test that the subscribe/psubscribe notification is ok
-            $rd client reply $type
-            assert_equal {1} [subscribe $rd channel]
-            assert_equal {2} [psubscribe $rd ch*]
+        # Test that the subscribe/psubscribe notification is ok
+        $rd client reply off
+        assert_equal {1} [subscribe $rd channel]
+        assert_equal {2} [psubscribe $rd ch*]
 
-            # Test that the publish notification is ok
-            $rd client reply $type
-            assert_equal 2 [r publish channel hello]
-            assert_equal {message channel hello} [$rd read]
-            assert_equal {pmessage ch* channel hello} [$rd read]
+        # Test that the publish notification is ok
+        $rd client reply off
+        assert_equal 2 [r publish channel hello]
+        assert_equal {message channel hello} [$rd read]
+        assert_equal {pmessage ch* channel hello} [$rd read]
 
-            # Test that the unsubscribe/punsubscribe notification is ok
-            $rd client reply $type
-            assert_equal {1} [unsubscribe $rd channel]
-            assert_equal {0} [punsubscribe $rd ch*]
+        # Test that the unsubscribe/punsubscribe notification is ok
+        $rd client reply off
+        assert_equal {1} [unsubscribe $rd channel]
+        assert_equal {0} [punsubscribe $rd ch*]
 
-            if {$type == "SKIP"} {
-                $rd client reply $type
-                $rd ping pong1
-                $rd ping pong2
-                assert_equal {pong2} [$rd read]
-            }
-
-            $rd close
-        }
+        $rd close
     }
 
     test "PUNSUBSCRIBE from non-subscribed channels" {

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -147,17 +147,29 @@ start_server {tags {"pubsub network"}} {
     }
 
     foreach type {OFF SKIP} {
-        test "PUBLISH/SUBSCRIBE with CLIENT REPLY $type" {
+        test "PubSub messages with CLIENT REPLY $type" {
             set rd [redis_deferring_client]
             $rd hello 3
             $rd read ;# Discard the hello reply
 
-            assert_equal {1} [subscribe $rd channel]
+            # Test that the subscribe/psubscribe notification is ok
             $rd client reply $type
-            assert_equal 1 [r publish channel hello]
+            assert_equal {1} [subscribe $rd channel]
+            assert_equal {2} [psubscribe $rd ch*]
+
+            # Test that the publish notification is ok
+            $rd client reply $type
+            assert_equal 2 [r publish channel hello]
             assert_equal {message channel hello} [$rd read]
+            assert_equal {pmessage ch* channel hello} [$rd read]
+
+            # Test that the unsubscribe/punsubscribe notification is ok
+            $rd client reply $type
+            assert_equal {1} [unsubscribe $rd channel]
+            assert_equal {0} [punsubscribe $rd ch*]
 
             if {$type == "SKIP"} {
+                $rd client reply $type
                 $rd ping pong1
                 $rd ping pong2
                 assert_equal {pong2} [$rd read]
@@ -227,6 +239,7 @@ start_server {tags {"pubsub network"}} {
     test "Keyspace notifications: we receive keyspace notifications" {
         r config set notify-keyspace-events KA
         set rd1 [redis_deferring_client]
+        $rd1 CLIENT REPLY OFF ;# Test the event notification is ok
         assert_equal {1} [psubscribe $rd1 *]
         r set foo bar
         assert_equal "pmessage * __keyspace@${db}__:foo set" [$rd1 read]
@@ -236,6 +249,7 @@ start_server {tags {"pubsub network"}} {
     test "Keyspace notifications: we receive keyevent notifications" {
         r config set notify-keyspace-events EA
         set rd1 [redis_deferring_client]
+        $rd1 CLIENT REPLY SKIP ;# Test the event notification is ok
         assert_equal {1} [psubscribe $rd1 *]
         r set foo bar
         assert_equal "pmessage * __keyevent@${db}__:set foo" [$rd1 read]
@@ -245,6 +259,8 @@ start_server {tags {"pubsub network"}} {
     test "Keyspace notifications: we can receive both kind of events" {
         r config set notify-keyspace-events KEA
         set rd1 [redis_deferring_client]
+        $rd1 CLIENT REPLY ON ;# Test the event notification is ok
+        assert_equal {OK} [$rd1 read]
         assert_equal {1} [psubscribe $rd1 *]
         r set foo bar
         assert_equal "pmessage * __keyspace@${db}__:foo set" [$rd1 read]

--- a/tests/unit/pubsubshard.tcl
+++ b/tests/unit/pubsubshard.tcl
@@ -110,34 +110,28 @@ start_server {tags {"pubsubshard external:skip"}} {
         $rd2 close
     }
 
-    foreach type {OFF SKIP} {
-        test "PubSubShard with CLIENT REPLY $type" {
-            set rd [redis_deferring_client]
-            $rd hello 3
-            $rd read ;# Discard the hello reply
+    test "PubSubShard with CLIENT REPLY OFF" {
+        set rd [redis_deferring_client]
+        $rd hello 3
+        $rd read ;# Discard the hello reply
 
-            # Test that the ssubscribe notification is ok
-            $rd client reply $type
-            assert_equal {1} [ssubscribe $rd channel]
+        # Test that the ssubscribe notification is ok
+        $rd client reply off
+        $rd ping
+        assert_equal {1} [ssubscribe $rd channel]
 
-            # Test that the spublish notification is ok
-            $rd client reply $type
-            assert_equal 1 [r spublish channel hello]
-            assert_equal {smessage channel hello} [$rd read]
+        # Test that the spublish notification is ok
+        $rd client reply off
+        $rd ping
+        assert_equal 1 [r spublish channel hello]
+        assert_equal {smessage channel hello} [$rd read]
 
-            # Test that sunsubscribe notification is ok
-            $rd client reply $type
-            assert_equal {0} [sunsubscribe $rd channel]
+        # Test that sunsubscribe notification is ok
+        $rd client reply off
+        $rd ping
+        assert_equal {0} [sunsubscribe $rd channel]
 
-            if {$type == "SKIP"} {
-                $rd client reply $type
-                $rd ping pong1
-                $rd ping pong2
-                assert_equal {pong2} [$rd read]
-            }
-
-            $rd close
-        }
+        $rd close
     }
 }
 

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -799,7 +799,7 @@ start_server {tags {"tracking network"}} {
 
             if {$resp == 3} {
                 assert_equal {invalidate foo} [$rd read]
-            }
+            } elseif {$resp == 2} { } ;# Just coverage
         }
     }
 

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -817,9 +817,6 @@ start_server {tags {"tracking network"}} {
         $rd_redir hello 3
         $rd_redir read
 
-        $rd_redir subscribe __redis__:invalidate
-        $rd_redir read
-
         $rd_redir client id
         set rd_redir_id [$rd_redir read]
 

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -780,6 +780,81 @@ start_server {tags {"tracking network"}} {
         r debug pause-cron 0
     } {OK} {needs:debug}
 
+    foreach resp {3 2} {
+        test "RESP$resp based basic invalidation with client reply off" {
+            clean_all
+
+            $rd hello $resp
+            $rd read
+            $rd client tracking on
+            $rd read
+
+            $rd_sg set foo bar
+            $rd get foo
+            $rd read
+
+            $rd client reply off
+
+            $rd_sg set foo bar2
+
+            if {$resp == 3} {
+                assert_equal {invalidate foo} [$rd read]
+            }
+        }
+    }
+
+    test {RESP3 based basic redirect invalidation with client reply off} {
+        clean_all
+
+        set rd_redir [redis_deferring_client]
+        $rd_redir hello 3
+        $rd_redir read
+
+        $rd_redir subscribe __redis__:invalidate
+        $rd_redir read
+
+        $rd_redir client id
+        set rd_redir_id [$rd_redir read]
+
+        $rd client tracking on redirect $rd_redir_id
+        $rd read
+
+        $rd_sg set foo bar
+        $rd get foo
+        $rd read
+
+        $rd_redir client reply off
+
+        $rd_sg set foo bar2
+        assert_equal {invalidate foo} [$rd_redir read]
+
+        $rd_redir close
+    }
+
+    test {RESP3 based basic tracking-redir-broken with client reply off} {
+        clean_all
+
+        $rd hello 3
+        $rd read
+        $rd client tracking on redirect $redir_id
+        $rd read
+
+        $rd_sg set foo bar
+        $rd get foo
+        $rd read
+
+        $rd client reply off
+
+        $rd_redirection quit
+        $rd_redirection read
+
+        $rd_sg set foo bar2
+
+        set res [lsearch -exact [$rd read] "tracking-redir-broken"]
+        assert_morethan_equal $res 0
+    }
+
     $rd_redirection close
+    $rd_sg close
     $rd close
 }

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -782,6 +782,7 @@ start_server {tags {"tracking network"}} {
 
     foreach resp {3 2} {
         test "RESP$resp based basic invalidation with client reply off" {
+            # This entire test is mostly irrelevant for RESP2, but we run it anyway just for some extra coverage.
             clean_all
 
             $rd hello $resp
@@ -800,6 +801,12 @@ start_server {tags {"tracking network"}} {
             if {$resp == 3} {
                 assert_equal {invalidate foo} [$rd read]
             } elseif {$resp == 2} { } ;# Just coverage
+
+            # Verify things didn't get messed up and no unexpected reply was pushed to the client.
+            $rd client reply on
+            assert_equal {OK} [$rd read]
+            $rd ping
+            assert_equal {PONG} [$rd read]
         }
     }
 
@@ -828,6 +835,12 @@ start_server {tags {"tracking network"}} {
         $rd_sg set foo bar2
         assert_equal {invalidate foo} [$rd_redir read]
 
+        # Verify things didn't get messed up and no unexpected reply was pushed to the client.
+        $rd_redir client reply on
+        assert_equal {OK} [$rd_redir read]
+        $rd_redir ping
+        assert_equal {PONG} [$rd_redir read]
+
         $rd_redir close
     }
 
@@ -852,6 +865,12 @@ start_server {tags {"tracking network"}} {
 
         set res [lsearch -exact [$rd read] "tracking-redir-broken"]
         assert_morethan_equal $res 0
+
+        # Verify things didn't get messed up and no unexpected reply was pushed to the client.
+        $rd client reply on
+        assert_equal {OK} [$rd read]
+        $rd ping
+        assert_equal {PONG} [$rd read]
     }
 
     $rd_redirection close


### PR DESCRIPTION
This bug seems to be there forever, CLIENT REPLY OFF|SKIP will
mark the client with CLIENT_REPLY_OFF or CLIENT_REPLY_SKIP flags.
With these flags, prepareClientToWrite called by addReply* will
return C_ERR directly. So the client can't receive the Pub/Sub
messages and any other push notifications, e.g client side tracking.

In this PR, we adding a CLIENT_PUSHING flag, disables the reply
silencing flags. When adding push replies, set the flag, after the reply,
clear the flag. Then add the flag check in prepareClientToWrite.

Fixes #11874

Note, the SUBSCRIBE command response is a bit awkward,
see https://github.com/redis/redis-doc/pull/2327