### PR TITLE
Skip test for sdsRemoveFreeSpace when mem_allocator is not jemalloc

### DIFF
--- a/tests/modules/basics.c
+++ b/tests/modules/basics.c
@@ -417,17 +417,22 @@ int TestTrimString(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     size_t string_len = RedisModule_MallocSizeString(s);
     RedisModule_TrimStringAllocation(s);
     size_t len_after_trim = RedisModule_MallocSizeString(s);
-#if defined(USE_JEMALLOC)
-    if (len_after_trim < string_len)
-#else
-    /* Non-jemalloc memory allocators may keep the old size on realloc. */
-    if (len_after_trim <= string_len)
-#endif
+
+    /* Determine if using jemalloc memory allocator. */
+    RedisModuleServerInfoData *info = RedisModule_GetServerInfo(ctx, "memory");
+    const char *field = RedisModule_ServerInfoGetFieldC(info, "mem_allocator");
+    int use_jemalloc = !strncmp(field, "jemalloc", 8);
+
+    /* Jemalloc will reallocate `s` from 2k to 1k after RedisModule_TrimStringAllocation(),
+     * but non-jemalloc memory allocators may keep the old size. */
+    if ((use_jemalloc && len_after_trim < string_len) ||
+        (!use_jemalloc && len_after_trim <= string_len))
     {
         RedisModule_ReplyWithSimpleString(ctx, "OK");
     } else {
         RedisModule_ReplyWithError(ctx, "String was not trimmed as expected.");
     }
+    RedisModule_FreeServerInfo(ctx, info);
     RedisModule_Free(tmp);
     RedisModule_FreeString(ctx,s);
     return REDISMODULE_OK;

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -534,7 +534,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         # asset the value was trimmed
         assert {[r memory usage bar] < 42000}; # 42K to count for Jemalloc's additional memory overhead.
     }
-} ;# if
+} ;# if jemalloc
 
     test "Unload the module - misc" {
         assert_equal {OK} [r module unload misc]

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -525,6 +525,7 @@ start_server {tags {"modules"}} {
         assert_equal {0} [r test.get_n_events]
     }
 
+if {[string match {*jemalloc*} [s mem_allocator]]} {
     test {test RM_Call with large arg for SET command} {
         # set a big value to trigger increasing the query buf
         r set foo [string repeat A 100000]
@@ -533,6 +534,7 @@ start_server {tags {"modules"}} {
         # asset the value was trimmed
         assert {[r memory usage bar] < 42000}; # 42K to count for Jemalloc's additional memory overhead.
     }
+} ;# if
 
     test "Unload the module - misc" {
         assert_equal {OK} [r module unload misc]

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -469,7 +469,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         # asset the value was trimmed
         assert {[r memory usage key] < 42000}; # 42K to count for Jemalloc's additional memory overhead. 
     }
-} ;# if
+} ;# if jemalloc
 
     test {Extended SET can detect syntax errors} {
         set e {}

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -461,12 +461,14 @@ start_server {tags {"string"}} {
     }
     
     test {trim on SET with big value} {
+    if {[string match {*jemalloc*} [s mem_allocator]]} {
         # set a big value to trigger increasing the query buf
         r set key [string repeat A 100000] 
         # set a smaller value but > PROTO_MBULK_BIG_ARG (32*1024) Redis will try to save the query buf itself on the DB.
         r set key [string repeat A 33000]
         # asset the value was trimmed
         assert {[r memory usage key] < 42000}; # 42K to count for Jemalloc's additional memory overhead. 
+    } ;# if
     }
 
     test {Extended SET can detect syntax errors} {

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -460,16 +460,16 @@ start_server {tags {"string"}} {
         }
     }
     
+if {[string match {*jemalloc*} [s mem_allocator]]} {
     test {trim on SET with big value} {
-    if {[string match {*jemalloc*} [s mem_allocator]]} {
         # set a big value to trigger increasing the query buf
         r set key [string repeat A 100000] 
         # set a smaller value but > PROTO_MBULK_BIG_ARG (32*1024) Redis will try to save the query buf itself on the DB.
         r set key [string repeat A 33000]
         # asset the value was trimmed
         assert {[r memory usage key] < 42000}; # 42K to count for Jemalloc's additional memory overhead. 
-    } ;# if
     }
+} ;# if
 
     test {Extended SET can detect syntax errors} {
         set e {}


### PR DESCRIPTION
Test `trim on SET with big value` (introduced from #11817) fails under mac m1 with libc mem_allocator.
The reason is that malloc(33000) will allocate 65536 bytes(>42000).
This test still passes under ubuntu with libc mem_allocator.

```
*** [err]: trim on SET with big value in tests/unit/type/string.tcl
Expected [r memory usage key] < 42000 (context: type source line 471 file /Users/iospack/data/redis_fork/tests/unit/type/string.tcl cmd {assert {[r memory usage key] < 42000}} proc ::test)
```

simple test under mac m1 with libc mem_allocator:
```c
void *p = zmalloc(33000);
printf("malloc size: %zu\n", zmalloc_size(p));

# output
malloc size: 65536
```

