### PR TITLE
Add GNUC minor version check for redis_unreachable

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -131,7 +131,7 @@
 #endif
 #endif
 
-#if __GNUC__ >= 4
+#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 5
 #define redis_unreachable __builtin_unreachable
 #else
 #define redis_unreachable abort

--- a/src/config.h
+++ b/src/config.h
@@ -131,7 +131,7 @@
 #endif
 #endif
 
-#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 5
+#if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
 #define redis_unreachable __builtin_unreachable
 #else
 #define redis_unreachable abort


### PR DESCRIPTION
__builtin_unreachable is added for the first time in GCC 4.5.

The following error may occur in versions before GCC 4.5.

GCC 4.4:
`undefined reference to __builtin_unreachable`

Add a minor version check to ensure that can fallback to `abort`




