### PR TITLE
Solve race in CLIENT NO-TOUCH lru test

### DIFF
--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -41,7 +41,7 @@ start_server {tags {"introspection"}} {
         r set foo bar
         r client no-touch on
         set oldlru [getlru foo]
-        after 1000
+        after 1100
         r get foo
         set newlru [getlru foo]
         assert_equal $newlru $oldlru


### PR DESCRIPTION
I've seen it fail here (test-centos7-tls-module-no-tls and test-freebsd):
```
*** [err]: Operations in no-touch mode do not alter the last access time of a key in tests/unit/introspection-2.tcl
Expected '244296' to be more than '244296' (context: type eval line 12 cmd {assert_morethan $newlru $oldlru} proc ::test)
```

Our LRU_CLOCK_RESOLUTION value is 1000ms, and default hz is 10, so if the
test is really fast, or the timing is just right, newlru will be the same
as oldlru. We fixed this by changing `after 1000` to `after 1100`.