### PR TITLE
Add composite channel type for event notifications.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -161,6 +161,12 @@ configEnum propagation_error_behavior_enum[] = {
     {NULL, 0}
 };
 
+configEnum notification_type_enum[] = {
+        {"classic", NOTIFICATION_TYPE_CLASSIC},
+        {"composite", NOTIFICATION_TYPE_COMPOSITE},
+        {NULL, 0},
+};
+
 /* Output buffer limits presets. */
 clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT] = {
     {0, 0, 0}, /* normal */
@@ -3106,7 +3112,7 @@ standardConfig static_configs[] = {
     createEnumConfig("propagation-error-behavior", NULL, MODIFIABLE_CONFIG, propagation_error_behavior_enum, server.propagation_error_behavior, PROPAGATION_ERR_BEHAVIOR_IGNORE, NULL, NULL),
     createEnumConfig("shutdown-on-sigint", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, shutdown_on_sig_enum, server.shutdown_on_sigint, 0, isValidShutdownOnSigFlags, NULL),
     createEnumConfig("shutdown-on-sigterm", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, shutdown_on_sig_enum, server.shutdown_on_sigterm, 0, isValidShutdownOnSigFlags, NULL),
-
+    createEnumConfig("notification-event-type", NULL, MODIFIABLE_CONFIG, notification_type_enum, server.notification_event_type, 0, NULL, NULL),
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */

--- a/src/server.h
+++ b/src/server.h
@@ -450,6 +450,11 @@ typedef enum {
                              * PSYNC FAILOVER request. */
 } failover_state;
 
+typedef enum {
+    NOTIFICATION_TYPE_CLASSIC = 0,
+    NOTIFICATION_TYPE_COMPOSITE
+} notificationType;
+
 /* State of slaves from the POV of the master. Used in client->replstate.
  * In SEND_BULK and ONLINE state the slave receives new updates
  * in its output queue. In the WAIT_BGSAVE states instead the server is waiting
@@ -1883,6 +1888,7 @@ struct redisServer {
     dict *pubsub_patterns;  /* A dict of pubsub_patterns */
     int notify_keyspace_events; /* Events to propagate via Pub/Sub. This is an
                                    xor of NOTIFY_... flags. */
+    int notification_event_type; /* Event notification on channel type i.e. classic/composite type. */
     dict *pubsubshard_channels;  /* Map shard channels to list of subscribed clients */
     /* Cluster */
     int cluster_enabled;      /* Is cluster enabled? */

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -976,6 +976,17 @@ start_server [list overrides [list "dir" $server_path "acl-pubsub-default" "allc
         r ACL deluser harry
         set e
     } {*NOPERM*channel*}
+
+    test "ACL restriction on composite notification channel" {
+        reconnect
+        r AUTH alice alice
+        r ACL setuser subread on nopass resetchannels &__keynotification@*__:get:* +psubscribe ~*
+        r config set notification-event-type composite
+        r config set notify-keyspace-events A
+        r AUTH subread anything
+        assert_error {*NOPERM*channel*} {r psubscribe __keynotification@9__:*}
+        r psubscribe __keynotification@*__:get:*
+    }
 }
 
 set server_path [tmpdir "resetchannels.acl"]

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -403,4 +403,71 @@ start_server {tags {"pubsub network"}} {
         assert_equal "pmessage * __keyevent@${db}__:new bar" [$rd1 read]
         $rd1 close
     }
+
+    test "Keyspace notifications composite/classic type" {
+        r config set notify-keyspace-events KEA
+        r config set notification-event-type composite
+        set rd1 [redis_deferring_client]
+        assert_equal {1} [psubscribe $rd1 *]
+        r set foo bar
+
+        assert_equal "pmessage * __keynotification@${db}__:set:foo set:foo" [$rd1 read]
+
+        # Switch back to classic type
+        r config set notification-event-type classic
+        r set foo bar
+        assert_equal "pmessage * __keyspace@${db}__:foo set" [$rd1 read]
+        assert_equal "pmessage * __keyevent@${db}__:set foo" [$rd1 read]
+        $rd1 close
+    }
+
+    test "No affect of KA flag in notify-keyspace-events for composite type" {
+        r config set notify-keyspace-events A
+        r config set notification-event-type composite
+
+        set rd1 [redis_deferring_client]
+        assert_equal {1} [psubscribe $rd1 *]
+        r set foo bar
+        assert_equal "pmessage * __keynotification@${db}__:set:foo set:foo" [$rd1 read]
+
+        r config set notify-keyspace-events EA
+        r set foo bar
+        assert_equal "pmessage * __keynotification@${db}__:set:foo set:foo" [$rd1 read]
+
+        r config set notify-keyspace-events KA
+        r set foo bar
+        assert_equal "pmessage * __keynotification@${db}__:set:foo set:foo" [$rd1 read]
+        $rd1 close
+    }
+
+    test "Validate notify-keyspace-events flags for composite notification type" {
+        r config set notification-event-type composite
+        r config set notify-keyspace-events A
+        set rd1 [redis_deferring_client]
+        assert_equal {1} [psubscribe $rd1 *]
+
+        # ZSET events
+        r zadd myzset 1 a 2 b
+        assert_equal "pmessage * __keynotification@${db}__:zadd:myzset zadd:myzset" [$rd1 read]
+
+        # Hash events
+        r hmset myhash yes 1 no 0
+        r hincrby myhash yes 10
+        assert_equal "pmessage * __keynotification@${db}__:hset:myhash hset:myhash" [$rd1 read]
+        assert_equal "pmessage * __keynotification@${db}__:hincrby:myhash hincrby:myhash" [$rd1 read]
+
+        # Stream events
+        r xgroup create mystream mygroup $ mkstream
+        r xgroup createconsumer mystream mygroup charles
+        set id [r xadd mystream 1 field1 A]
+        r xreadgroup group mygroup charles STREAMS mystream >
+        r xgroup delconsumer mystream mygroup charles
+
+        assert_equal "pmessage * __keynotification@${db}__:xgroup-create:mystream xgroup-create:mystream" [$rd1 read]
+        assert_equal "pmessage * __keynotification@${db}__:xgroup-createconsumer:mystream xgroup-createconsumer:mystream" [$rd1 read]
+        assert_equal "pmessage * __keynotification@${db}__:xadd:mystream xadd:mystream" [$rd1 read]
+        assert_equal "pmessage * __keynotification@${db}__:xgroup-delconsumer:mystream xgroup-delconsumer:mystream" [$rd1 read]
+
+        $rd1 close
+    }
 }


### PR DESCRIPTION
Solves #10627

Introduces a composite event notification type which provides a new channel naming structure `__keynotification@<db>__:<event>:<key>` and message `<event>:<key>`. This provides flexibility to client to use ACL channel restriction on accessing keyspace/keyevent notifications.

Considerations:
1. channel `__keynotification@<db>__:<event>:<key>` and message `<event>:<key>`
2. Adds a new config `notification-event-type` with `classic` and `composite` as valid options. Default is `classic` type. (backward compatible).
3. key is the last part in the channel name (as key can contain `:` unlike `event` and might be difficult for user to parse)
 
Tasks:

- [x] New channel representation
- [x] Config to enable `classic` / `composite`
- [x] TCL tests
- [ ] Default redis.conf update
- [ ] document update