### PR TITLE
Fix redis-cli cluster test timing issue

### DIFF
--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -36,7 +36,7 @@ proc wait_for_cluster_propagation {} {
 
 # Wait for cluster size to be consistent across nodes.
 proc wait_for_cluster_size {cluster_size} {
-    wait_for_condition 50 100 {
+    wait_for_condition 1000 50 {
         [cluster_size_consistent $cluster_size] eq 1
     } else {
         fail "cluster size did not reach a consistent size $cluster_size"


### PR DESCRIPTION
This test fails sporadically:
```
*** [err]: Migrate the last slot away from a node using redis-cli in tests/unit/cluster/cli.tcl
cluster size did not reach a consistent size 4
```

I guess the time (5s) of wait_for_cluster_size is not enough,
usually, the waiting time for our other tests for cluster
consistency is 50s, so also changing it to 50s.