### PR TITLE
Document syslog directives in sentinel.conf.

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -32,6 +32,16 @@ loglevel notice
 # output for logging but daemonize, logs will be sent to /dev/null
 logfile ""
 
+# To enable logging to the system logger, just set 'syslog-enabled' to yes,
+# and optionally update the other syslog parameters to suit your needs.
+# syslog-enabled no
+
+# Specify the syslog identity.
+# syslog-ident sentinel
+
+# Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
+# syslog-facility local0
+
 # sentinel announce-ip <ip>
 # sentinel announce-port <port>
 #


### PR DESCRIPTION
Redis supports syslog integration via these directives, documented in [redis.conf](https://github.com/redis/redis/blob/6.2/redis.conf#L306-L314):

```
syslog-enabled no
syslog-ident redis
syslog-facility local0
```
 
While these directives are not documented in [sentinel.conf](https://github.com/redis/redis/blob/6.2/sentinel.conf), they do work with Redis-Sentinel. It took me a while to realize this.

How about documenting those in sentinel.conf, just to make it clear they can be used with Sentinel ?