### PR TITLE
Fix Uninitialised value error in createSparklineSequence (LATENCY GRAPH)

### DIFF
--- a/src/sparkline.c
+++ b/src/sparkline.c
@@ -57,7 +57,10 @@ static int label_margin_top = 1;
 struct sequence *createSparklineSequence(void) {
     struct sequence *seq = zmalloc(sizeof(*seq));
     seq->length = 0;
+    seq->labels = 0;
     seq->samples = NULL;
+    seq->min = 0.0f;
+    seq->max = 0.0f;
     return seq;
 }
 

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -71,6 +71,7 @@ start_server {tags {"latency-monitor needs:latency"}} {
         assert {[string length [r latency histogram blabla set get]] > 0}
     }
 
+tags {"needs:debug"} {
     test {Test latency events logging} {
         r debug sleep 0.3
         after 1100
@@ -78,7 +79,7 @@ start_server {tags {"latency-monitor needs:latency"}} {
         after 1100
         r debug sleep 0.5
         assert {[r latency history command] >= 3}
-    } {} {needs:debug}
+    }
 
     test {LATENCY HISTORY output is ok} {
         set min 250
@@ -116,6 +117,7 @@ start_server {tags {"latency-monitor needs:latency"}} {
         assert_range $high 500 600
         assert_range $low 300 400
     }
+} ;# tag
 
     test {LATENCY of expire events are correctly collected} {
         r config set latency-monitor-threshold 20

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -111,7 +111,7 @@ tags {"needs:debug"} {
         set res [r latency graph command]
         assert_match {*command*high*low*} $res
 
-        # TThese number are taken from the "Test latency events logging" test.
+        # These numbers are taken from the "Test latency events logging" test.
         # (debug sleep 0.3) and (debug sleep 0.5), increase it by 100 to prevent timing issue.
         regexp "command - high (.*?) ms, low (.*?) ms" $res -> high low
         assert_range $high 500 600

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -106,6 +106,17 @@ start_server {tags {"latency-monitor needs:latency"}} {
         }
     }
 
+    test {LATENCY GRAPH can output the event graph} {
+        set res [r latency graph command]
+        assert_match {*command*high*low*} $res
+
+        # TThese number are taken from the "Test latency events logging" test.
+        # (debug sleep 0.3) and (debug sleep 0.5), increase it by 100 to prevent timing issue.
+        regexp "command - high (.*?) ms, low (.*?) ms" $res -> high low
+        assert_range $high 500 600
+        assert_range $low 300 400
+    }
+
     test {LATENCY of expire events are correctly collected} {
         r config set latency-monitor-threshold 20
         r flushdb
@@ -124,6 +135,11 @@ start_server {tags {"latency-monitor needs:latency"}} {
             fail "key wasn't expired"
         }
         assert_match {*expire-cycle*} [r latency latest]
+
+        test {LATENCY GRAPH can output the expire event graph} {
+             assert_match {*expire-cycle*high*low*} [r latency graph expire-cycle]
+        }
+
         r config set latency-monitor-threshold 200
     }
 

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -112,10 +112,10 @@ tags {"needs:debug"} {
         assert_match {*command*high*low*} $res
 
         # These numbers are taken from the "Test latency events logging" test.
-        # (debug sleep 0.3) and (debug sleep 0.5), increase it by 100 to prevent timing issue.
+        # (debug sleep 0.3) and (debug sleep 0.5), using range to prevent timing issue.
         regexp "command - high (.*?) ms, low (.*?) ms" $res -> high low
-        assert_range $high 500 600
-        assert_range $low 300 400
+        assert_morethan_equal $high 500
+        assert_morethan_equal $low 300
     }
 } ;# tag
 


### PR DESCRIPTION
This was exposed by a new LATENCY GRAPH valgrind test.
There are no security implications, fix by initializing
these members.