### PR TITLE
Preallocate enough memory for the stream node if elements exceed stream_node_max_bytes

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -563,6 +563,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
         if (server.stream_node_max_bytes > 0 && server.stream_node_max_bytes < prealloc) {
             prealloc = server.stream_node_max_bytes;
         }
+        if (prealloc < totelelen) prealloc = totelelen;
         lp = lpNew(prealloc);
         lp = lpAppendInteger(lp,1); /* One item, the one we are adding. */
         lp = lpAppendInteger(lp,0); /* Zero deleted so far. */


### PR DESCRIPTION
When we use XADD to insert multiple entries whose total size exceeds `stream_node_max_bytes`, the stream node will exceed the `stream_node_max_bytes` limit.
But now we only preallocate stream node maximum `stream_node_max_bytes`, which will result in multiple `realloc()` when inserting the entries into the listpack.

benchmark:
start redis: `redis-server --save "`

```sh
memtier_benchmark --command="XADD test MAXLEN ~ 1000 * `python3 -c "for i in range(5): print(' foo ' + 'x'*4096)"`" --hide-histogram --test-time 30 -x 1 -c 100
```
Note: Use `MAXLEN ~ 1000` to avoid OOM.

Unstable:
```
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Xadds       75127.67         5.32315         4.70300         7.42300         9.21500   1515311.20 
Totals      75127.67         5.32315         4.70300         7.42300         9.21500   1515311.20
```

This PR:
```
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Xadds       83985.72         4.76197         4.19100         7.07100         9.66300   1693980.55 
Totals      83985.72         4.76197         4.19100         7.07100         9.66300   1693980.55
```