### PR TITLE
Fix tail->repl_offset update in feedReplicationBuffer

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -921,7 +921,7 @@ typedef struct clientReplyBlock {
  *      |                                            /       \
  *      |                                           /         \
  *      |                                          /           \
- *  Repl Backlog                               Replia_A      Replia_B
+ *  Repl Backlog                               Replica_A    Replica_B
  * 
  * Each replica or replication backlog increments only the refcount of the
  * 'ref_repl_buf_node' which it points to. So when replica walks to the next


### PR DESCRIPTION
In #11666, we added a while loop and will split a big reply
node to multiple nodes. The update of tail->repl_offset may
be wrong. Like before #11666, we would have created at most
one new reply node, and now we will create multiple nodes if
it is a big reply node.

Now we are creating more than one node, and the tail->repl_offset
of all the nodes except the last one are incorrect. Because we
update master_repl_offset at the beginning, and then use it to
update the tail->repl_offset. This would have lead to an assertion
during PSYNC, a test was added to validate that case.

Besides that, the calculation of size was adjusted to fix
tests that failed due to a combination of a very low backlog size,
and some thresholds of that get violated because of the relatively
high overhead of replBufBlock. So now if the backlog size / 16 is too
small, we'll take PROTO_REPLY_CHUNK_BYTES instead.
This size fix was provided by Oran.
```
*** [err]: slave buffer are counted correctly in tests/unit/maxmemory.tcl
Expected 814808 < 500000 && 814808 > -500000 (context: type eval line 80 cmd {assert {$delta < $delta_max && $delta > -$delta_max}} proc ::test)

*** [err]: replica buffer don't induce eviction in tests/unit/maxmemory.tcl
Expected [::redis::redisHandle147 dbsize] == 100 (context: type eval line 77 cmd {assert {[$master dbsize] == 100}} proc ::test)

*** [err]: All replicas share one global replication buffer in tests/integration/replication-buffer.tcl
Expected '1153280' to be equal to '1148928' (context: type eval line 18 cmd {assert_equal $repl_buf_mem [s mem_total_replication_buffers]} proc ::test)
```