### PR TITLE
Update .gitignore to ingore .cache/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ Makefile.dep
 .ccls
 .ccls-cache/*
 compile_commands.json
+.cache/*
 redis.code-workspace


### PR DESCRIPTION
I found the .gitignore has considering the compile_commands.json ,usually clangd-server will also generate .cache/* files in the workspace, it will be good to ignore these files too by default.