### PR TITLE
Remove unnecessary `fsync` when sentinel flushs config file

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -2272,12 +2272,8 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state) {
 /* This function uses the config rewriting Redis engine in order to persist
  * the state of the Sentinel in the current configuration file.
  *
- * Before returning the function calls fsync() against the generated
- * configuration file to make sure changes are committed to disk.
- *
  * On failure the function logs a warning on the Redis log. */
 int sentinelFlushConfig(void) {
-    int fd = -1;
     int saved_hz = server.hz;
     int rewrite_status;
 
@@ -2285,17 +2281,13 @@ int sentinelFlushConfig(void) {
     rewrite_status = rewriteConfig(server.configfile, 0);
     server.hz = saved_hz;
 
-    if (rewrite_status == -1) goto werr;
-    if ((fd = open(server.configfile,O_RDONLY)) == -1) goto werr;
-    if (fsync(fd) == -1) goto werr;
-    if (close(fd) == EOF) goto werr;
-    serverLog(LL_NOTICE,"Sentinel new configuration saved on disk");
-    return C_OK;
-
-werr:
-    serverLog(LL_WARNING,"WARNING: Sentinel was not able to save the new configuration on disk!!!: %s", strerror(errno));
-    if (fd != -1) close(fd);
-    return C_ERR;
+    if (rewrite_status == -1) {
+        serverLog(LL_WARNING,"WARNING: Sentinel was not able to save the new configuration on disk!!!: %s", strerror(errno));
+        return C_ERR;
+    } else {
+        serverLog(LL_NOTICE,"Sentinel new configuration saved on disk");
+        return C_OK;
+    }
 }
 
 /* Call sentinelFlushConfig() produce a success/error reply to the


### PR DESCRIPTION
`rewriteConfig` already calls `fsync` to make sure changes are committed to disk,
so it is no need to call `fsync` again here.