### PR TITLE
Fix WAITAOF reply when using last_offset and last_numreplicas

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -3575,7 +3575,7 @@ void waitaofCommand(client *c) {
         return;
     }
     if (numlocal && !server.aof_enabled) {
-        addReplyError(c,"WAITAOF cannot be used when appendonly is disabled");
+        addReplyError(c, "WAITAOF cannot be used when numlocal is set but appendonly is disabled.");
         return;
     }
 
@@ -3626,8 +3626,8 @@ void processClientsWaitingReplicas(void) {
         int is_wait_aof = c->bstate.btype == BLOCKED_WAITAOF;
 
         if (is_wait_aof && c->bstate.numlocal && !server.aof_enabled) {
+            addReplyError(c, "WAITAOF cannot be used when numlocal is set but appendonly is disabled.");
             unblockClient(c);
-            addReplyError(c,"WAITAOF cannot be used when appendonly is disabled");
             return;
         }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -3650,7 +3650,6 @@ void processClientsWaitingReplicas(void) {
             } else {
                 addReplyLongLong(c,last_numreplicas);
             }
-            addReplyLongLong(c,last_numreplicas);
             unblockClient(c);
         } else {
             int numreplicas = is_wait_aof ?

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -886,9 +886,9 @@ proc wait_for_blocked_client {{idx 0}} {
     }
 }
 
-proc wait_for_blocked_clients_count {count {maxtries 100} {delay 10}} {
+proc wait_for_blocked_clients_count {count {maxtries 100} {delay 10} {idx 0}} {
     wait_for_condition $maxtries $delay  {
-        [s blocked_clients] == $count
+        [s $idx blocked_clients] == $count
     } else {
         fail "Timeout waiting for blocked clients"
     }

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -68,6 +68,30 @@ start_server {} {
         exec kill -SIGCONT $slave_pid
         assert {[$master wait 1 1000] == 1}
     }
+
+    test {WAIT replica multiple clients unblock - reuse last result} {
+        set rd [redis_deferring_client -1]
+        set rd2 [redis_deferring_client -1]
+
+        exec kill -SIGSTOP $slave_pid
+
+        $rd incr foo
+        $rd read
+
+        $rd2 incr foo
+        $rd2 read
+
+        $rd wait 1 0
+        $rd2 wait 1 0
+
+        exec kill -SIGCONT $slave_pid
+
+        assert_equal [$rd read] {1}
+        assert_equal [$rd2 read] {1}
+
+        $rd close
+        $rd2 close
+    }
 }}
 
 

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -83,6 +83,7 @@ start_server {} {
 
         $rd wait 1 0
         $rd2 wait 1 0
+        wait_for_blocked_clients_count 2 100 10 -1
 
         exec kill -SIGCONT $slave_pid
 
@@ -207,6 +208,7 @@ tags {"wait aof network external:skip"} {
 
                 $rd waitaof 0 1 0
                 $rd2 waitaof 0 1 0
+                wait_for_blocked_clients_count 2 100 10 -1
 
                 exec kill -SIGCONT $replica_pid
 

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -89,6 +89,11 @@ start_server {} {
         assert_equal [$rd read] {1}
         assert_equal [$rd2 read] {1}
 
+        $rd ping
+        assert_equal [$rd read] {PONG}
+        $rd2 ping
+        assert_equal [$rd2 read] {PONG}
+
         $rd close
         $rd2 close
     }
@@ -207,6 +212,11 @@ tags {"wait aof network external:skip"} {
 
                 assert_equal [$rd read] {1 1}
                 assert_equal [$rd2 read] {1 1}
+
+                $rd ping
+                assert_equal [$rd read] {PONG}
+                $rd2 ping
+                assert_equal [$rd2 read] {PONG}
 
                 $rd close
                 $rd2 close

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -18,20 +18,20 @@ start_server {} {
             fail "Replication not started."
         }
     }
-    
+
     test {WAIT out of range timeout (milliseconds)} {
         # Timeout is parsed as milliseconds by getLongLongFromObjectOrReply().
         # Verify we get out of range message if value is behind LLONG_MAX
         # (decimal value equals to 0x8000000000000000)
          assert_error "*or out of range*" {$master wait 2 9223372036854775808}
-                  
+
          # expected to fail by later overflow condition after addition
          # of mstime(). (decimal value equals to 0x7FFFFFFFFFFFFFFF)
          assert_error "*timeout is out of range*" {$master wait 2 9223372036854775807}
-         
-         assert_error "*timeout is negative*" {$master wait 2 -1}         
+
+         assert_error "*timeout is negative*" {$master wait 2 -1}
     }
-    
+
     test {WAIT should acknowledge 1 additional copy of the data} {
         $master set foo 0
         $master incr foo
@@ -162,6 +162,30 @@ tags {"wait aof network external:skip"} {
                 assert_equal [$master waitaof 0 1 50] {1 0} ;# exits on timeout
                 exec kill -SIGCONT $replica_pid
                 assert_equal [$master waitaof 0 1 0] {1 1}
+            }
+
+            test {WAITAOF replica multiple clients unblock - reuse last result} {
+                set rd [redis_deferring_client -1]
+                set rd2 [redis_deferring_client -1]
+
+                exec kill -SIGSTOP $replica_pid
+
+                $rd incr foo
+                $rd read
+
+                $rd2 incr foo
+                $rd2 read
+
+                $rd waitaof 0 1 0
+                $rd2 waitaof 0 1 0
+
+                exec kill -SIGCONT $replica_pid
+
+                assert_equal [$rd read] {1 1}
+                assert_equal [$rd2 read] {1 1}
+
+                $rd close
+                $rd2 close
             }
 
             test {WAITAOF on promoted replica} {

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -222,35 +222,6 @@ tags {"wait aof network external:skip"} {
                 $rd2 close
             }
 
-            test {WAITAOF replica multiple clients unblock - reuse last result} {
-                set rd [redis_deferring_client -1]
-                set rd2 [redis_deferring_client -1]
-
-                exec kill -SIGSTOP $replica_pid
-
-                $rd incr foo
-                $rd read
-
-                $rd2 incr foo
-                $rd2 read
-
-                $rd waitaof 0 1 0
-                $rd2 waitaof 0 1 0
-
-                exec kill -SIGCONT $replica_pid
-
-                assert_equal [$rd read] {1 1}
-                assert_equal [$rd2 read] {1 1}
-
-                $rd ping
-                assert_equal [$rd read] {PONG}
-                $rd2 ping
-                assert_equal [$rd2 read] {PONG}
-
-                $rd close
-                $rd2 close
-            }
-
             test {WAITAOF on promoted replica} {
                 $replica replicaof no one
                 $replica incr foo


### PR DESCRIPTION
WAITAOF wad added in #11713, its return is an array.
But forget to handle WAITAOF in last_offset and last_numreplicas,
causing WAITAOF to return a WAIT like reply.

Tests was added to validate that case (both WAIT and WAITAOF).
This PR also refactored processClientsWaitingReplicas a bit for better
maintainability and readability.