### PR TITLE
Fix WAITAOF mix-use last_offset and last_numreplicas

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -3612,7 +3612,9 @@ void unblockClientWaitingReplicas(client *c) {
  * since we received enough ACKs from slaves. */
 void processClientsWaitingReplicas(void) {
     long long last_offset = 0;
+    long long last_aof_offset = 0;
     int last_numreplicas = 0;
+    int last_aof_numreplicas = 0;
 
     listIter li;
     listNode *ln;
@@ -3628,7 +3630,7 @@ void processClientsWaitingReplicas(void) {
         if (is_wait_aof && c->bstate.numlocal && !server.aof_enabled) {
             addReplyError(c, "WAITAOF cannot be used when numlocal is set but appendonly is disabled.");
             unblockClient(c);
-            return;
+            continue;
         }
 
         /* Every time we find a client that is satisfied for a given
@@ -3636,10 +3638,14 @@ void processClientsWaitingReplicas(void) {
          * may be unblocked without calling replicationCountAcksByOffset()
          * or calling replicationCountAOFAcksByOffset()
          * if the requested offset / replicas were equal or less. */
-        if (last_offset && last_offset >= c->bstate.reploffset &&
+        if (!is_wait_aof && last_offset && last_offset >= c->bstate.reploffset &&
                            last_numreplicas >= c->bstate.numreplicas)
         {
             numreplicas = last_numreplicas;
+        } else if (is_wait_aof && last_aof_offset && last_aof_offset >= c->bstate.reploffset &&
+                    last_aof_numreplicas >= c->bstate.numreplicas)
+        {
+            numreplicas = last_aof_numreplicas;
         } else {
             numreplicas = is_wait_aof ?
                 replicationCountAOFAcksByOffset(c->bstate.reploffset) :
@@ -3648,8 +3654,13 @@ void processClientsWaitingReplicas(void) {
             /* Check if the number of replicas is satisfied. */
             if (numreplicas < c->bstate.numreplicas) continue;
 
-            last_offset = c->bstate.reploffset;
-            last_numreplicas = numreplicas;
+            if (is_wait_aof) {
+                last_aof_offset = c->bstate.reploffset;
+                last_aof_numreplicas = numreplicas;
+            } else {
+                last_offset = c->bstate.reploffset;
+                last_numreplicas = numreplicas;
+            }
         }
 
         /* Check if the local constraint of WAITAOF is served */
@@ -3667,7 +3678,6 @@ void processClientsWaitingReplicas(void) {
         } else {
             addReplyLongLong(c, numreplicas);
         }
-
         unblockClient(c);
     }
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -3678,6 +3678,7 @@ void processClientsWaitingReplicas(void) {
         } else {
             addReplyLongLong(c, numreplicas);
         }
+
         unblockClient(c);
     }
 }

--- a/src/server.h
+++ b/src/server.h
@@ -1009,7 +1009,7 @@ typedef struct blockingState {
     /* BLOCKED_LIST, BLOCKED_ZSET and BLOCKED_STREAM or any other Keys related blocking */
     dict *keys;                 /* The keys we are blocked on */
 
-    /* BLOCKED_WAIT */
+    /* BLOCKED_WAIT and BLOCKED_WAITAOF */
     int numreplicas;        /* Number of replicas we are waiting for ACK. */
     int numlocal;           /* Indication if WAITAOF is waiting for local fsync. */
     long long reploffset;   /* Replication offset to reach. */


### PR DESCRIPTION
There be a situation that satisfies WAIT, and then wrongly unblock
WAITAOF because we mix-use last_offset and last_numreplicas.

We update last_offset and last_numreplicas only when the condition
matches. i.e. output of either replicationCountAOFAcksByOffset or
replicationCountAcksByOffset is right.

In this case, we need to have separate last_ variables for each of
them. Added a last_aof_offset and last_aof_numreplicas for WAITAOF.

WAITAOF was added in #11713. Found while coding #11917.
A Test was added to validate that case.