### PR TITLE
Update LINDEX return value to better response

### DIFF
--- a/src/commands/lindex.json
+++ b/src/commands/lindex.json
@@ -35,7 +35,7 @@
         "reply_schema": {
             "oneOf": [
                 {
-                    "type": "null",
+                    "type": "string",
                     "description": "Index is out of range"
                 },
                 {

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -592,7 +592,7 @@ void llenCommand(client *c) {
 
 /* LINDEX <key> <index> */
 void lindexCommand(client *c) {
-    robj *o = lookupKeyReadOrReply(c,c->argv[1],shared.null[c->resp]);
+    robj *o = lookupKeyReadOrReply(c,c->argv[1],shared.nokeyerr);
     if (o == NULL || checkType(c,o,OBJ_LIST)) return;
     long index;
 
@@ -613,7 +613,7 @@ void lindexCommand(client *c) {
             addReplyBulkLongLong(c, lval);
         }
     } else {
-        addReplyNull(c);
+        addReplyErrorObject(c,shared.outofrangeerr);
     }
 
     listTypeReleaseIterator(iter);

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -512,7 +512,7 @@ foreach {type large} [array get largevalue] {
         assert_equal $large [r lindex mylist1 0]
         assert_equal b [r lindex mylist1 1]
         assert_equal c [r lindex mylist1 2]
-        assert_equal {} [r lindex mylist1 3]
+        assert_error ERR* {r lindex mylist1 3}
         assert_equal c [r rpop mylist1]
         assert_equal $large [r lpop mylist1]
 
@@ -526,7 +526,7 @@ foreach {type large} [array get largevalue] {
         assert_equal c [r lindex mylist2 0]
         assert_equal b [r lindex mylist2 1]
         assert_equal $large [r lindex mylist2 2]
-        assert_equal {} [r lindex mylist2 3]
+        assert_error ERR* {r lindex mylist2 3}
         assert_equal $large [r rpop mylist2]
         assert_equal c [r lpop mylist2]
     }
@@ -1479,7 +1479,7 @@ foreach type {listpack quicklist} {
     }
 
     test {LINDEX against non existing key} {
-        assert_equal "" [r lindex not-a-key 10]
+        assert_error ERR* {r lindex not-a-key 10}
     }
 
     test {LPUSH against non-list value error} {

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -512,7 +512,7 @@ foreach {type large} [array get largevalue] {
         assert_equal $large [r lindex mylist1 0]
         assert_equal b [r lindex mylist1 1]
         assert_equal c [r lindex mylist1 2]
-        assert_equal {} [r lindex mylist1 3]
+        assert_error ERR* {r lindex mylist1 3}
         assert_equal c [r rpop mylist1]
         assert_equal $large [r lpop mylist1]
 
@@ -526,7 +526,7 @@ foreach {type large} [array get largevalue] {
         assert_equal c [r lindex mylist2 0]
         assert_equal b [r lindex mylist2 1]
         assert_equal $large [r lindex mylist2 2]
-        assert_equal {} [r lindex mylist2 3]
+        assert_error ERR* {r lindex mylist2 3}
         assert_equal $large [r rpop mylist2]
         assert_equal c [r lpop mylist2]
     }
@@ -1481,7 +1481,7 @@ foreach type {listpack quicklist} {
     }
 
     test {LINDEX against non existing key} {
-        assert_equal "" [r lindex not-a-key 10]
+        assert_error ERR* {r lindex not-a-key 10}
     }
 
     test {LPUSH against non-list value error} {


### PR DESCRIPTION
We want to send client better and much clear response as what LSET command does:

Now the LSET command format is: LSET key index element: 

**1. If key does not exist, return (error) ERR no such key
2. If key exists, but index out of range return (error) ERR index out of range
3. If key exists, but type not match, return (error) WRONGTYPE Operation against a key holding the wrong kind of value**

LINDEX format:  LINDEX key index :
current return value:

**1. If key does not exist, return nil
2. If key exists, but index out of range, return nil
3. If key exists, but type not match, return (error) WRONGTYPE Operation against a key holding the wrong kind of value**

client has no way to distinguish the case 1 and case 2.
In this PR, we make the LINDEX has the same return value as LSET :
Following is the example:

**127.0.0.1:6379> LPUSH mylist "World"
(integer) 1
127.0.0.1:6379> LPUSH mylist "Hello"
(integer) 2
127.0.0.1:6379> LIndex a 0
(error) ERR no such key
127.0.0.1:6379> LIndex mylist 3
(error) ERR index out of range
127.0.0.1:6379> set a 1
OK
127.0.0.1:6379> LIndex a 3
(error) WRONGTYPE Operation against a key holding the wrong kind of value**

