### PR TITLE
Fix usleep compilation warning in auth.c

### DIFF
--- a/tests/modules/auth.c
+++ b/tests/modules/auth.c
@@ -1,3 +1,7 @@
+/* define macros for having usleep */
+#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
+
 #include "redismodule.h"
 
 #include <string.h>


### PR DESCRIPTION
There is a -Wimplicit-function-declaration warning in here:
```
auth.c: In function ‘AuthBlock_ThreadMain’:
auth.c:116:5: warning: implicit declaration of function ‘usleep’; did you mean ‘sleep’? [-Wimplicit-function-declaration]
  116 |     usleep(500000);
      |     ^~~~~~
      |     sleep
```