### PR TITLE
Fix compile lto-wrapper warning for aarch64

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
 OPTIMIZATION?=-O3
 ifeq ($(OPTIMIZATION),-O3)
-	REDIS_CFLAGS+=-flto
+	REDIS_CFLAGS+=-flto=auto
 	REDIS_LDFLAGS+=-flto
 endif
 DEPENDENCY_TARGETS=hiredis linenoise lua hdr_histogram fpconv


### PR DESCRIPTION
Use -flto=auto to use GNU make's job server, if available, or otherwise fall back to autodetection of the number of CPU threads present in your system.

  Warnings:
```
  lto-wrapper: warning: using serial compilation of 2 LTRANS jobs
  lto-wrapper: note: see the ‘-flto’ option documentation for more information
  lto-wrapper: warning: using serial compilation of 4 LTRANS jobs
  lto-wrapper: note: see the ‘-flto’ option documentation for more information
  lto-wrapper: warning: using serial compilation of 31 LTRANS jobs
  lto-wrapper: note: see the ‘-flto’ option documentation for more information
```