### PR TITLE
redis has no `rw` in `/run` but `/run/redis/` in default

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -152,7 +152,7 @@ tcp-backlog 511
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
 #
-# unixsocket /run/redis.sock
+# unixsocket /run/redis/redis.sock
 # unixsocketperm 700
 
 # Close the connection after a client is idle for N seconds (0 to disable)


### PR DESCRIPTION
fix [#issue-1627953579](https://github.com/redis/redis/issues/11928#issue-1627953579)