### PR TITLE
passwords printed in the crash log

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1859,12 +1859,13 @@ void logCurrentClient(client *cc, const char *title) {
     client = catClientInfoString(sdsempty(),cc);
     serverLog(LL_WARNING|LL_RAW,"%s\n", client);
     sdsfree(client);
+    serverLog(LL_WARNING|LL_RAW,"argc: '%d'\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
         robj *decoded;
         decoded = getDecodedObject(cc->argv[j]);
         sds repr = sdscatrepr(sdsempty(),decoded->ptr, min(sdslen(decoded->ptr), 128));
         serverLog(LL_WARNING|LL_RAW,"argv[%d]: '%s'\n", j, (char*)repr);
-        if (!strcasecmp(decoded->ptr, "auth")) {
+        if (!strcasecmp(decoded->ptr, "auth") || !strcasecmp(decoded->ptr, "auth2")) {
             sdsfree(repr);
             decrRefCount(decoded);
             break;

--- a/src/debug.c
+++ b/src/debug.c
@@ -1864,6 +1864,11 @@ void logCurrentClient(client *cc, const char *title) {
         decoded = getDecodedObject(cc->argv[j]);
         sds repr = sdscatrepr(sdsempty(),decoded->ptr, min(sdslen(decoded->ptr), 128));
         serverLog(LL_WARNING|LL_RAW,"argv[%d]: '%s'\n", j, (char*)repr);
+        if (!strcasecmp(decoded->ptr, "auth")) {
+            sdsfree(repr);
+            decrRefCount(decoded);
+            break;
+        }
         sdsfree(repr);
         decrRefCount(decoded);
     }


### PR DESCRIPTION
When the server crashes during the AUTH command, or another command with an AUTH argument, the password was recorded in the log.

Now, when the `auth` keyword is detected (could be in HELLO or MIGRATE, etc), the loop exits before printing any additional arguments.

```
------ CURRENT CLIENT INFO ------
id=3 addr=127.0.0.1:33162 laddr=127.0.0.1:9091 fd=7 name= age=3 idle=0 flags=N db=0 sub=0 psub=0 ssub=0 multi=-1 qbuf=23 qbuf-free=20451 argv-mem=7 multi-mem=0 rbs=1024 rbp=0 obl=0 oll=0 omem=0 tot-mem=22295 events=r cmd=auth user=default redir=-1 resp=2
argv[0]: '"auth"'
argv[1]: '"123"'

------ EXECUTING CLIENT INFO ------
id=3 addr=127.0.0.1:33162 laddr=127.0.0.1:9091 fd=7 name= age=3 idle=0 flags=N db=0 sub=0 psub=0 ssub=0 multi=-1 qbuf=23 qbuf-free=20451 argv-mem=7 multi-mem=0 rbs=1024 rbp=0 obl=0 oll=0 omem=0 tot-mem=22295 events=r cmd=auth user=default redir=-1 resp=2
argv[0]: '"auth"'
argv[1]: '"123"'

```
