### PR TITLE
update summary of lpop, lpushx, rpop, rpushx commands in json file

### DIFF
--- a/src/commands/lpop.json
+++ b/src/commands/lpop.json
@@ -1,6 +1,6 @@
 {
     "LPOP": {
-        "summary": "Remove and get the first elements in a list",
+        "summary": "Remove and get one or multiple elements from the beginning of a list",
         "complexity": "O(N) where N is the number of elements returned",
         "group": "list",
         "since": "1.0.0",

--- a/src/commands/lpushx.json
+++ b/src/commands/lpushx.json
@@ -1,6 +1,6 @@
 {
     "LPUSHX": {
-        "summary": "Prepend an element to a list, only if the list exists",
+        "summary": "Prepend one or multiple elements to a list, only if the list exists",
         "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
         "group": "list",
         "since": "2.2.0",

--- a/src/commands/rpop.json
+++ b/src/commands/rpop.json
@@ -1,6 +1,6 @@
 {
     "RPOP": {
-        "summary": "Remove and get the last elements in a list",
+        "summary": "Remove and get one or multiple elements from the end of a list",
         "complexity": "O(N) where N is the number of elements returned",
         "group": "list",
         "since": "1.0.0",

--- a/src/commands/rpushx.json
+++ b/src/commands/rpushx.json
@@ -1,6 +1,6 @@
 {
     "RPUSHX": {
-        "summary": "Append an element to a list, only if the list exists",
+        "summary": "Append one or multiple elements to a list, only if the list exists",
         "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
         "group": "list",
         "since": "2.2.0",


### PR DESCRIPTION
We want to update the summary of Lpop, lpushx, rpop and rpushx commands in json file.

Current summary values : 
"LPOP":  "summary": "Remove and get the first elements in a list",
"LPUSHX":  "summary": "Prepend an element to a list, only if the list exists",
"RPOP":  "summary": "Remove and get the last elements in a list",
"RPUSHX":   "summary": "Append an element to a list, only if the list exists",

LPOP and RPOP command can pop one or more element (if count is mentioned)
LPUSHX and RPUSHX command can push one or multiple element.

In this pull request , we have updated the summary of Lpop, lpushx, rpop and rpushx commands
Updated summary values:
"LPOP":  "summary": "Remove and get one or multiple elements from the beginning of a list",
"LPUSHX":  "summary": "Prepend one or multiple elements to a list, only if the list exists",
"RPOP":  "summary": "Remove and get one or multiple elements from the end of a list",
"RPUSHX":   "Append one or multiple elements to a list, only if the list exists",

