### PR TITLE
Replcae sentinel commands sanity check with infrastructure work test

### DIFF
--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -21,10 +21,13 @@ test "Sentinel command flag infrastructure works correctly" {
             assert_not_equal [lsearch $command_list $cmd] -1
         }
 
-        foreach cmd {save bgrewriteaof blpop replicaof client|no-touch} {
+        foreach cmd {save bgrewriteaof blpop replicaof} {
             assert_equal [S $id command docs $cmd] {}
             assert_equal [lsearch $command_list $cmd] -1
+            assert_error {ERR unknown command*} {S $id $cmd}
         }
+
+        assert_error {ERR unknown subcommand*} {S $id client no-touch}
     }
 }
 

--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -12,10 +12,19 @@ if {$::simulate_error} {
     }
 }
 
-test "Sentinel commands sanity check" {
+test "Sentinel command flag infrastructure works correctly" {
     foreach_sentinel_id id {
-        assert_equal {72} [llength [S $id command list]]
-        assert_equal {15} [S $id command count]
+        set command_list [S $id command list]
+
+        foreach cmd {ping info subscribe client|setinfo} {
+            assert_not_equal [S $id command docs $cmd] {}
+            assert_not_equal [lsearch $command_list $cmd] -1
+        }
+
+        foreach cmd {save bgrewriteaof blpop replicaof client|no-touch} {
+            assert_equal [S $id command docs $cmd] {}
+            assert_equal [lsearch $command_list $cmd] -1
+        }
     }
 }
 


### PR DESCRIPTION
The sanity check test intention was to detect that when a command is
added to sentinel it is on purpose. This test is easily broken, like
CLIENT SETINFO introduced by #11758.

We replace it with a test that validates that a few specific commands
are either there or missing (to test the infrastructure works correctly).