### PR TITLE
Clang: fix for -flto argument

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,11 @@ uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
 OPTIMIZATION?=-O3
 ifeq ($(OPTIMIZATION),-O3)
-	REDIS_CFLAGS+=-flto=auto
+	ifneq (,$(findstring clang,$(CC)))
+		REDIS_CFLAGS+=-flto=auto
+	else
+		REDIS_CFLAGS+=-flto
+	endif
 	REDIS_LDFLAGS+=-flto
 endif
 DEPENDENCY_TARGETS=hiredis linenoise lua hdr_histogram fpconv

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,12 +15,17 @@
 release_hdr := $(shell sh -c './mkreleasehdr.sh')
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
+ifneq (,$(findstring clang,$(shell $(CC) --version | head -1)))
+CLANG=clang
+else
+CLANG=
+endif
 OPTIMIZATION?=-O3
 ifeq ($(OPTIMIZATION),-O3)
-	ifneq (,$(findstring clang,$(CC)))
-		REDIS_CFLAGS+=-flto=auto
-	else
+	ifeq (clang,$(CLANG))
 		REDIS_CFLAGS+=-flto
+	else
+		REDIS_CFLAGS+=-flto=auto
 	endif
 	REDIS_LDFLAGS+=-flto
 endif
@@ -32,7 +37,7 @@ STD=-pedantic -DREDIS_STATIC=''
 
 # Use -Wno-c11-extensions on clang, either where explicitly used or on
 # platforms we can assume it's being used.
-ifneq (,$(findstring clang,$(CC)))
+ifeq (clang,$(CLANG))
   STD+=-Wno-c11-extensions
 else
 ifneq (,$(findstring FreeBSD,$(uname_S)))

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@
 release_hdr := $(shell sh -c './mkreleasehdr.sh')
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
-CLANG := $(findstring clang,$(shell $(CC) --version | head -1))
+CLANG := $(findstring clang,$(shell sh -c '$(CC) --version | head -1'))
 OPTIMIZATION?=-O3
 ifeq ($(OPTIMIZATION),-O3)
 	ifeq (clang,$(CLANG))

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,11 +15,7 @@
 release_hdr := $(shell sh -c './mkreleasehdr.sh')
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
-ifneq (,$(findstring clang,$(shell $(CC) --version | head -1)))
-CLANG=clang
-else
-CLANG=
-endif
+CLANG := $(findstring clang,$(shell $(CC) --version | head -1))
 OPTIMIZATION?=-O3
 ifeq ($(OPTIMIZATION),-O3)
 	ifeq (clang,$(CLANG))


### PR DESCRIPTION
Starting with the recent #11926 Makefile specifies `-flto=auto` which is unsupported on clang.
Additionally, detecting clang correctly requires actually running it, since on MacOS gcc can be an alias for clang.