### PR TITLE
Fixed tracking of command duration for multi/eval/module/wait

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -114,6 +114,7 @@ void updateStatsOnUnblock(client *c, long blocked_us, long reply_us, int had_err
         updateCommandLatencyHistogram(&(c->lastcmd->latency_histogram), total_cmd_duration*1000);
     /* Log the command into the Slow log if needed. */
     slowlogPushCurrentCommand(c, c->lastcmd, total_cmd_duration);
+    c->duration = 0;
     /* Log the reply duration event. */
     latencyAddSampleIfNeeded("command-unblocking",reply_us/1000);
 }

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -234,12 +234,10 @@ void replyToBlockedClientTimedOut(client *c) {
         updateStatsOnUnblock(c, 0, 0, 0);
     } else if (c->bstate.btype == BLOCKED_WAIT) {
         addReplyLongLong(c,replicationCountAcksByOffset(c->bstate.reploffset));
-        updateStatsOnUnblock(c, 0, 0, 0);
     } else if (c->bstate.btype == BLOCKED_WAITAOF) {
         addReplyArrayLen(c,2);
         addReplyLongLong(c,server.fsynced_reploff >= c->bstate.reploffset);
         addReplyLongLong(c,replicationCountAOFAcksByOffset(c->bstate.reploffset));
-        updateStatsOnUnblock(c, 0, 0, 0);
     } else if (c->bstate.btype == BLOCKED_MODULE) {
         moduleBlockedClientTimedOut(c);
     } else {

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -234,10 +234,12 @@ void replyToBlockedClientTimedOut(client *c) {
         updateStatsOnUnblock(c, 0, 0, 0);
     } else if (c->bstate.btype == BLOCKED_WAIT) {
         addReplyLongLong(c,replicationCountAcksByOffset(c->bstate.reploffset));
+        updateStatsOnUnblock(c, 0, 0, 0);
     } else if (c->bstate.btype == BLOCKED_WAITAOF) {
         addReplyArrayLen(c,2);
         addReplyLongLong(c,server.fsynced_reploff >= c->bstate.reploffset);
         addReplyLongLong(c,replicationCountAOFAcksByOffset(c->bstate.reploffset));
+        updateStatsOnUnblock(c, 0, 0, 0);
     } else if (c->bstate.btype == BLOCKED_MODULE) {
         moduleBlockedClientTimedOut(c);
     } else {

--- a/src/module.c
+++ b/src/module.c
@@ -8052,7 +8052,6 @@ int moduleUnblockClientByHandle(RedisModuleBlockedClient *bc, void *privdata) {
 void moduleUnblockClient(client *c) {
     RedisModuleBlockedClient *bc = c->bstate.module_blocked_handle;
     moduleUnblockClientByHandle(bc,NULL);
-    updateStatsOnUnblock(c, 0, 0, 0);
 }
 
 /* Return true if the client 'c' was blocked by a module using

--- a/src/module.c
+++ b/src/module.c
@@ -647,6 +647,7 @@ void moduleReleaseTempClient(client *c) {
     clearClientConnectionState(c);
     listEmpty(c->reply);
     c->reply_bytes = 0;
+    c->duration = 0;
     resetClient(c);
     c->bufpos = 0;
     c->flags = CLIENT_MODULE;

--- a/src/module.c
+++ b/src/module.c
@@ -8052,6 +8052,7 @@ int moduleUnblockClientByHandle(RedisModuleBlockedClient *bc, void *privdata) {
 void moduleUnblockClient(client *c) {
     RedisModuleBlockedClient *bc = c->bstate.module_blocked_handle;
     moduleUnblockClientByHandle(bc,NULL);
+    updateStatsOnUnblock(c, 0, 0, 0);
 }
 
 /* Return true if the client 'c' was blocked by a module using

--- a/src/networking.c
+++ b/src/networking.c
@@ -1583,6 +1583,8 @@ void freeClient(client *c) {
     c->querybuf = NULL;
 
     /* Deallocate structures used to block on blocking ops. */
+    /* If there is any in-flight command, we don't don't record their duration. */
+    c->duration = 0;
     if (c->flags & CLIENT_BLOCKED) unblockClient(c, 1);
     dictRelease(c->bstate.keys);
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -2039,7 +2039,6 @@ void resetClient(client *c) {
     c->multibulklen = 0;
     c->bulklen = -1;
     c->slot = -1;
-    c->duration = 0;
     c->flags &= ~CLIENT_EXECUTING_COMMAND;
 #ifdef LOG_REQ_RES
     reqresReset(c, 1);

--- a/src/networking.c
+++ b/src/networking.c
@@ -2040,6 +2040,9 @@ void resetClient(client *c) {
     c->bulklen = -1;
     c->slot = -1;
     c->flags &= ~CLIENT_EXECUTING_COMMAND;
+
+    /* Make sure the duration has been recorded to some command. */
+    serverAssert(c->duration == 0);
 #ifdef LOG_REQ_RES
     reqresReset(c, 1);
 #endif

--- a/src/networking.c
+++ b/src/networking.c
@@ -1583,7 +1583,7 @@ void freeClient(client *c) {
     c->querybuf = NULL;
 
     /* Deallocate structures used to block on blocking ops. */
-    /* If there is any in-flight command, we don't don't record their duration. */
+    /* If there is any in-flight command, we don't record their duration. */
     c->duration = 0;
     if (c->flags & CLIENT_BLOCKED) unblockClient(c, 1);
     dictRelease(c->bstate.keys);

--- a/src/replication.c
+++ b/src/replication.c
@@ -3606,6 +3606,7 @@ void unblockClientWaitingReplicas(client *c) {
     listNode *ln = listSearchKey(server.clients_waiting_acks,c);
     serverAssert(ln != NULL);
     listDelNode(server.clients_waiting_acks,ln);
+    updateStatsOnUnblock(c, 0, 0, 0);
 }
 
 /* Check if there are clients blocked in WAIT or WAITAOF that can be unblocked

--- a/src/server.c
+++ b/src/server.c
@@ -3596,8 +3596,8 @@ void call(client *c, int flags) {
     }
 
     /* The duration needs to be reset after each call except for a blocked command,
-     * which has its duration accumulated on the client between each call. */
-    if (!(c->flags & CLIENT_BLOCKED && c->flags & CLIENT_PENDING_COMMAND)) {
+     * which is expected to explicitly reset the duration after unblocking. */
+    if (!(c->flags & CLIENT_BLOCKED)) {
         c->duration = 0;
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -3728,6 +3728,10 @@ void afterCommand(client *c) {
      * reply to client before invalidating cache (makes more sense) */
     postExecutionUnitOperations();
     trackingHandlePendingKeyInvalidations();
+
+    /* The duration needs to be reset after each call except for a blocked command,
+     * which has its duration accumulated on the client between each call. */ 
+    if (!(c->flags & CLIENT_BLOCKED)) c->duration = 0;
 }
 
 /* Check if c->cmd exists, fills `err` with details in case it doesn't.

--- a/src/server.c
+++ b/src/server.c
@@ -3596,7 +3596,7 @@ void call(client *c, int flags) {
     }
 
     /* The duration needs to be reset after each call except for a blocked command,
-     * which is expected to explicitly reset the duration after unblocking. */
+     * which is expected to record and reset the duration after unblocking. */
     if (!(c->flags & CLIENT_BLOCKED)) {
         c->duration = 0;
     }


### PR DESCRIPTION
In https://github.com/redis/redis/pull/11012, we changed the way command durations were computed to handle the same command being executed multiple times. This commit fixes some misses from that commit.
1. Wait commands were not correctly reporting their duration if the timeout was reached.
2. Multi/scripts/and modules with RM_Call were not properly resetting the duration between inner calls, leading to them reporting cumulative duration.
3. When a blocked client is freed, the call and duration are always discarded. 

This commit also adds an assert if the duration is not properly reset, potentially indicating that a report to call statistics was missed. The assert potentially be removed in the future, as it's mainly intended to detect misses in tests.

## Before:
```
(error) ERR EXEC without MULTI
127.0.0.1:6379> multi
OK
127.0.0.1:6379> debug sleep 0.1
QUEUED
127.0.0.1:6379> debug sleep 0.1
QUEUED
127.0.0.1:6379> info commandstats
127.0.0.1:6379> exec
1) OK
2) OK
3) "# Commandstats\r\ncmdstat_exec:calls=1,usec=4,usec_per_call=4.00,rejected_calls=0,failed_calls=1\r\ncmdstat_debug:calls=2,usec=300206,usec_per_call=150103.00,rejected_calls=0,failed_calls=0\r\ncmdstat_multi:calls=1,usec=5,usec_per_call=5.00,rejected_calls=0,failed_calls=0\r\n"
```

## After:
```
127.0.0.1:6379> multi
OK
127.0.0.1:6379> debug sleep 0.1
QUEUED
127.0.0.1:6379> debug sleep 0.1
QUEUED
127.0.0.1:6379> exec
1) OK
2) OK
127.0.0.1:6379> info commandstats
# Commandstats
cmdstat_exec:calls=2,usec=200176,usec_per_call=100088.00,rejected_calls=0,failed_calls=1
cmdstat_info:calls=1,usec=35,usec_per_call=35.00,rejected_calls=0,failed_calls=0
cmdstat_debug:calls=2,usec=200132,usec_per_call=100066.00,rejected_calls=0,failed_calls=0
cmdstat_multi:calls=2,usec=4,usec_per_call=2.00,rejected_calls=0,failed_calls=0
```