### PR TITLE
Fix parseScanCursorOrReply to reject empty strings instead of treating them the same as "0"

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,9 +15,14 @@
 release_hdr := $(shell sh -c './mkreleasehdr.sh')
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
+CLANG := $(findstring clang,$(shell sh -c '$(CC) --version | head -1'))
 OPTIMIZATION?=-O3
 ifeq ($(OPTIMIZATION),-O3)
-	REDIS_CFLAGS+=-flto=auto
+	ifeq (clang,$(CLANG))
+		REDIS_CFLAGS+=-flto
+	else
+		REDIS_CFLAGS+=-flto=auto
+	endif
 	REDIS_LDFLAGS+=-flto
 endif
 DEPENDENCY_TARGETS=hiredis linenoise lua hdr_histogram fpconv
@@ -28,7 +33,7 @@ STD=-pedantic -DREDIS_STATIC=''
 
 # Use -Wno-c11-extensions on clang, either where explicitly used or on
 # platforms we can assume it's being used.
-ifneq (,$(findstring clang,$(CC)))
+ifeq (clang,$(CLANG))
   STD+=-Wno-c11-extensions
 else
 ifneq (,$(findstring FreeBSD,$(uname_S)))

--- a/src/db.c
+++ b/src/db.c
@@ -835,7 +835,7 @@ int parseScanCursorOrReply(client *c, robj *o, unsigned long *cursor) {
      * getLongLongFromObject() does not cover the whole cursor space. */
     errno = 0;
     *cursor = strtoul(o->ptr, &eptr, 10);
-    if ((((char*)o->ptr)[0] == '\0') || isspace(((char*)o->ptr)[0]) || eptr[0] != '\0' || errno == ERANGE)
+    if (sdslen(o->ptr) == 0 || isspace(((char*)o->ptr)[0]) || eptr[0] != '\0' || errno == ERANGE)
     {
         addReplyError(c, "invalid cursor");
         return C_ERR;

--- a/src/db.c
+++ b/src/db.c
@@ -835,7 +835,7 @@ int parseScanCursorOrReply(client *c, robj *o, unsigned long *cursor) {
      * getLongLongFromObject() does not cover the whole cursor space. */
     errno = 0;
     *cursor = strtoul(o->ptr, &eptr, 10);
-    if (isspace(((char*)o->ptr)[0]) || eptr[0] != '\0' || errno == ERANGE)
+    if ((((char*)o->ptr)[0] == '\0') || isspace(((char*)o->ptr)[0]) || eptr[0] != '\0' || errno == ERANGE)
     {
         addReplyError(c, "invalid cursor");
         return C_ERR;

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -248,13 +248,13 @@ start_server {tags {"scan network"}} {
         r sadd set {*}$objects
         set res [r sscan set 0 MATCH *a* COUNT 100]
         assert_equal [lsort -unique [lindex $res 1]] {a}
-        set res [r sscan set 0 match *1* count 100]
+        set res [r sscan set 0 MATCH *1* COUNT 100]
         assert_equal [lsort -unique [lindex $res 1]] {1}
     }
     
     test "scan with null string" { 
-      catch {r scan ""} err
-      format $err
+       catch {r scan ""} err
+       format $err
     } {ERR invalid cursor}
 
     test "SSCAN with PATTERN" {

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -253,8 +253,8 @@ start_server {tags {"scan network"}} {
     }
     
     test "scan with null string" { 
-       catch {r scan ""} err
-       format $err
+      catch {r scan ""} err
+      format $err
     } {ERR invalid cursor}
 
     test "SSCAN with PATTERN" {

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -284,8 +284,7 @@ start_server {tags {"scan network"}} {
         set res [lindex [r zscan mykey 0] 1]
         set first_score [lindex $res 1]
         assert {$first_score != 0}
-    }
-    
+    } 
     test "SCAN regression test for issue #4906" {
         for {set k 0} {$k < 100} {incr k} {
             r del set

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -283,21 +283,6 @@ start_server {tags {"scan network"}} {
         assert {$first_score != 0}
     }
     
-    test "SCAN/SSCAN/ZSCAN/HSCAN with negative cursor" {
-      r flushall
-      lassign [r scan -1] cursor itmes
-      assert_equal $cursor 0
-
-      lassign [r sscan myset -1] cursor items
-      assert_equal $cursor 0
-
-      lassign [r zscan myset -1] cursor items
-      assert_equal $cursor 0
-
-      lassign[r hscan myset -1] cursor items
-      assert_equal $cursor 0
-    }
-
     test "SCAN regression test for issue #4906" {
         for {set k 0} {$k < 100} {incr k} {
             r del set

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -282,6 +282,22 @@ start_server {tags {"scan network"}} {
         set first_score [lindex $res 1]
         assert {$first_score != 0}
     }
+    
+    test "SCAN/SSCAN/ZSCAN/HSCAN with negative cursor" {
+      r flushall
+
+      lassign [r scan -1] cursor itmes
+      assert_equal $cursor 0
+
+      lassign [r sscan myset -1] cursor items
+      assert_equal $cursor 0
+
+      lassign [r zscan myset -1] cursor items
+      assert_equal $cursor 0
+
+      lassign[r hscan myset -1] cursor items
+      assert_equal $cursor 0
+    }
 
     test "SCAN regression test for issue #4906" {
         for {set k 0} {$k < 100} {incr k} {

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -248,9 +248,13 @@ start_server {tags {"scan network"}} {
         r sadd set {*}$objects
         set res [r sscan set 0 MATCH *a* COUNT 100]
         assert_equal [lsort -unique [lindex $res 1]] {a}
-        set res [r sscan set 0 MATCH *1* COUNT 100]
+        set res [r sscan set 0 match *1* count 100]
         assert_equal [lsort -unique [lindex $res 1]] {1}
     }
+    
+    test "scan with null string" { 
+       r scan "\0"
+    } {ERR*}
 
     test "SSCAN with PATTERN" {
         r del mykey
@@ -272,7 +276,7 @@ start_server {tags {"scan network"}} {
         set res [r zscan mykey 0 MATCH foo* COUNT 10000]
         lsort -unique [lindex $res 1]
     }
-
+    
     test "ZSCAN scores: regression test for issue #2175" {
         r del mykey
         for {set j 0} {$j < 500} {incr j} {

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -285,7 +285,6 @@ start_server {tags {"scan network"}} {
     
     test "SCAN/SSCAN/ZSCAN/HSCAN with negative cursor" {
       r flushall
-
       lassign [r scan -1] cursor itmes
       assert_equal $cursor 0
 

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -253,8 +253,9 @@ start_server {tags {"scan network"}} {
     }
     
     test "scan with null string" { 
-       r scan "\0"
-    } {ERR*}
+       catch {r scan ""} err
+       format $err
+    } {ERR invalid cursor}
 
     test "SSCAN with PATTERN" {
         r del mykey

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -270,14 +270,12 @@ start_server {tags {"scan network"}} {
         set res [r hscan mykey 0 MATCH foo* COUNT 10000]
         lsort -unique [lindex $res 1]
     } {1 10 foo foobar}
-
     test "ZSCAN with PATTERN" {
         r del mykey
         r zadd mykey 1 foo 2 fab 3 fiz 10 foobar
         set res [r zscan mykey 0 MATCH foo* COUNT 10000]
         lsort -unique [lindex $res 1]
     }
-    
     test "ZSCAN scores: regression test for issue #2175" {
         r del mykey
         for {set j 0} {$j < 500} {incr j} {


### PR DESCRIPTION
Modified the judgment statement if in parseScanCursorOrReply so that an empty string is considered an error.
For empty string, strtoul returns 0, and eptr is set to the end of the string (`'\0'`), the existing code would have treated that as success.