### PR TITLE
Disconnect pub-sub subscribers when revoking `allchannels` permission

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1891,6 +1891,13 @@ void ACLKillPubsubClientsIfNeeded(user *new, user *original) {
     listRewind(original->selectors,&li);
     while((ln = listNext(&li)) && match) {
         aclSelector *s = (aclSelector *) listNodeValue(ln);
+        /* If any of the original selectors has the all-channels permission, but
+         * the new ones don't (this is checked earlier in this function), then the
+         * new list is not a strict superset of the original.  */
+        if (s->flags & SELECTOR_FLAG_ALLCHANNELS) {
+            match = 0;
+            break;
+        }
         listRewind(s->channels, &lpi);
         while((lpn = listNext(&lpi)) && match) {
             if (!listSearchKey(upcoming, listNodeValue(lpn))) {

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -289,6 +289,20 @@ start_server {tags {"acl external:skip"}} {
         $rd close
     } {0}
 
+    test {Subscribers are killed when revoked of allchannels permission} {
+            set rd [redis_deferring_client]
+            r ACL setuser psuser allchannels
+            $rd AUTH psuser pspass
+            $rd read
+            $rd CLIENT SETNAME deathrow
+            $rd read
+            $rd PSUBSCRIBE foo
+            $rd read
+            r ACL setuser psuser resetchannels
+            assert_no_match {*deathrow*} [r CLIENT LIST]
+            $rd close
+        } {0}
+
     test {Subscribers are pardoned if literal permissions are retained and/or gaining allchannels} {
         set rd [redis_deferring_client]
         r ACL setuser psuser resetchannels &foo:1 &bar:* &orders

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -290,18 +290,18 @@ start_server {tags {"acl external:skip"}} {
     } {0}
 
     test {Subscribers are killed when revoked of allchannels permission} {
-            set rd [redis_deferring_client]
-            r ACL setuser psuser allchannels
-            $rd AUTH psuser pspass
-            $rd read
-            $rd CLIENT SETNAME deathrow
-            $rd read
-            $rd PSUBSCRIBE foo
-            $rd read
-            r ACL setuser psuser resetchannels
-            assert_no_match {*deathrow*} [r CLIENT LIST]
-            $rd close
-        } {0}
+        set rd [redis_deferring_client]
+        r ACL setuser psuser allchannels
+        $rd AUTH psuser pspass
+        $rd read
+        $rd CLIENT SETNAME deathrow
+        $rd read
+        $rd PSUBSCRIBE foo
+        $rd read
+        r ACL setuser psuser resetchannels
+        assert_no_match {*deathrow*} [r CLIENT LIST]
+        $rd close
+    } {0}
 
     test {Subscribers are pardoned if literal permissions are retained and/or gaining allchannels} {
         set rd [redis_deferring_client]


### PR DESCRIPTION
The existing logic for killing pub-sub clients did not handle the `allchannels` permission correctly. For example, if you:

    ACL SETUSER foo allchannels

Have a client authenticate as the user `foo` and subscribe to a channel, and then:

    ACL SETUSER foo resetchannels

The subscribed client would not be disconnected, though new clients under that user would be blocked from subscribing to any channels.

This was caused by an incomplete optimization in `ACLKillPubsubClientsIfNeeded` checking whether the new channel permissions were a strict superset of the old ones.