### PR TITLE
Changed activeExpireCycle server.masterhost check to iAmMaster in beforeSleep

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1658,7 +1658,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
 
     /* Run a fast expire cycle (the called function will return
      * ASAP if a fast cycle is not needed). */
-    if (server.active_expire_enabled && server.masterhost == NULL)
+    if (server.active_expire_enabled && iAmMaster())
         activeExpireCycle(ACTIVE_EXPIRE_CYCLE_FAST);
 
     /* Unblock all the clients blocked for synchronous replication


### PR DESCRIPTION
In cluster mode, when a node restart as a replica, it doesn't immediately
sync with the master, replication is enabled in clusterCron. It means that
sometime server.masterhost is NULL and we wrongly judge it in beforeSleep.

In this case, we may trigger a fast activeExpireCycle in beforeSleep, but the
node's flag is actually a replica, that can lead to data inconsistency.  In this
PR, we use iAmMaster to replace the `server.masterhost == NULL`

This is an overlook in #7001, and more discussion in #11783.