### PR TITLE
Fixed outdated documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you want to know more, this is a list of selected starting points:
 * Introduction to Redis data types. https://redis.io/topics/data-types-intro
 * Try Redis directly inside your browser. https://try.redis.io
 * The full list of Redis commands. https://redis.io/commands
-* There is much more inside the official Redis documentation. https://redis.io/documentation
+* There is much more inside the official Redis documentation. https://redis.io/docs/
 
 Building Redis
 --------------

--- a/utils/systemd-redis_multiple_servers@.service
+++ b/utils/systemd-redis_multiple_servers@.service
@@ -12,7 +12,7 @@
 
 [Unit]
 Description=Redis data structure server - instance %i
-Documentation=https://redis.io/documentation
+Documentation=https://redis.io/docs/
 # This template unit assumes your redis-server configuration file(s)
 # to live at /etc/redis/redis_server_<INSTANCE_NAME>.conf
 AssertPathExists=/etc/redis/redis_server_%i.conf

--- a/utils/systemd-redis_server.service
+++ b/utils/systemd-redis_server.service
@@ -17,7 +17,7 @@
 
 [Unit]
 Description=Redis data structure server
-Documentation=https://redis.io/documentation
+Documentation=https://redis.io/docs/
 #Before=your_application.service another_example_application.service
 #AssertPathExists=/var/lib/redis
 Wants=network-online.target


### PR DESCRIPTION
This pull request fixed the outdated Redis documentation URLs.

```diff
-https://redis.io/documentation
+https://redis.io/docs/
```

Checked by `grep` command:

```shell
grep -R 'https://redis.io/documentation' .
```