### PR TITLE
avoid incorrect shrinking of querybuf when client is reading a big argv

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2341,6 +2341,7 @@ int processMultibulkBuffer(client *c) {
                     /* Hint the sds library about the amount of bytes this string is
                      * going to contain. */
                     c->querybuf = sdsMakeRoomForNonGreedy(c->querybuf,ll+2-sdslen(c->querybuf));
+                    if (c->querybuf_peak < (size_t)ll + 2) c->querybuf_peak = ll + 2;
                 }
             }
             c->bulklen = ll;
@@ -2635,6 +2636,7 @@ void readQueryFromClient(connection *conn) {
          * the query buffer, we also don't wanna use the greedy growth, in order
          * to avoid collision with the RESIZE_THRESHOLD mechanism. */
         c->querybuf = sdsMakeRoomForNonGreedy(c->querybuf, readlen);
+        if (c->querybuf_peak < qblen + readlen) c->querybuf_peak = qblen + readlen;
     } else {
         c->querybuf = sdsMakeRoomFor(c->querybuf, readlen);
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -2341,6 +2341,8 @@ int processMultibulkBuffer(client *c) {
                     /* Hint the sds library about the amount of bytes this string is
                      * going to contain. */
                     c->querybuf = sdsMakeRoomForNonGreedy(c->querybuf,ll+2-sdslen(c->querybuf));
+                    /* We later set the peak to the used portion of the buffer, but here we over
+                     * allocated because we know what we need, make sure it'll not be shrunk before used. */
                     if (c->querybuf_peak < (size_t)ll + 2) c->querybuf_peak = ll + 2;
                 }
             }
@@ -2636,6 +2638,8 @@ void readQueryFromClient(connection *conn) {
          * the query buffer, we also don't wanna use the greedy growth, in order
          * to avoid collision with the RESIZE_THRESHOLD mechanism. */
         c->querybuf = sdsMakeRoomForNonGreedy(c->querybuf, readlen);
+        /* We later set the peak to the used portion of the buffer, but here we over
+         * allocated because we know what we need, make sure it'll not be shrunk before used. */
         if (c->querybuf_peak < qblen + readlen) c->querybuf_peak = qblen + readlen;
     } else {
         c->querybuf = sdsMakeRoomFor(c->querybuf, readlen);

--- a/src/server.c
+++ b/src/server.c
@@ -744,7 +744,7 @@ int clientsCronResizeQueryBuffer(client *c) {
              *    sure not to resize to less than the bulk length. */
             size_t resize = sdslen(c->querybuf);
             if (resize < c->querybuf_peak) resize = c->querybuf_peak;
-            if (c->bulklen != -1 && resize < (size_t)c->bulklen) resize = c->bulklen;
+            if (c->bulklen != -1 && resize < (size_t)c->bulklen + 2) resize = c->bulklen + 2;
             c->querybuf = sdsResize(c->querybuf, resize, 1);
         }
     }
@@ -754,8 +754,7 @@ int clientsCronResizeQueryBuffer(client *c) {
     c->querybuf_peak = sdslen(c->querybuf);
     /* We reset to either the current used, or currently processed bulk size,
      * which ever is bigger. */
-    if (c->bulklen != -1 && (size_t)c->bulklen > c->querybuf_peak)
-        c->querybuf_peak = c->bulklen;
+    if (c->bulklen != -1 && (size_t)c->bulklen + 2 > c->querybuf_peak) c->querybuf_peak = c->bulklen + 2;
     return 0;
 }
 

--- a/tests/unit/querybuf.tcl
+++ b/tests/unit/querybuf.tcl
@@ -18,7 +18,7 @@ proc client_query_buffer {name} {
 }
 
 start_server {tags {"querybuf slow"}} {
-    #increase the execution frequency of clientsCron
+    # increase the execution frequency of clientsCron
     r config set hz 100
     # The test will run at least 2s to check if client query
     # buffer will be resized when client idle 2s.

--- a/tests/unit/querybuf.tcl
+++ b/tests/unit/querybuf.tcl
@@ -74,15 +74,16 @@ start_server {tags {"querybuf slow"}} {
         
         after 20
         if {[client_query_buffer test_client] < 1000000} {
-            fail "query buffer should not be shrinked when client idle time smaller than 2s"
+            fail "query buffer should not be resized when client idle time smaller than 2s"
         }
      
         # Check that the query buffer is resized after 2 sec
         wait_for_condition 1000 10 {
             [client_idle_sec test_client] >= 3 && [client_query_buffer test_client] < 1000000
         } else {
-            fail "query buffer should be shrinked when client idle time bigger than 2s"
+            fail "query buffer should be resized when client idle time bigger than 2s"
         }
+     
         $rd close
     }
 


### PR DESCRIPTION
this pr fix two wrongs：
1. When client’s querybuf is pre-allocated for a fat argv, we need to update the querybuf_peak of the client immediately to completely avoid the unexpected shrinking of querybuf in the next clientCron (before data arrives to set the peak).
2. the protocol's bulklen does not include `\r\n`, but the allocation and the data we read does. so in `clientsCronResizeQueryBuffer`, the `resize` or `querybuf_peak` should add these 2 bytes.

the first bug is likely to hit us on large payloads over slow connections, in which case transferring the payload can take longer and a cron event will be triggered (specifically if there are not a lot of clients)