### PR TITLE
Use a fixed 1% cpu time to db's rehashing in serverCron to prevent the throughput capacity of the redis from dropping too much due to a high hz

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -377,25 +377,30 @@ int dictRehash(dict *d, int n) {
     return 1;
 }
 
-long long timeInMilliseconds(void) {
+long long timeInMicroseconds(void) {
     struct timeval tv;
 
     gettimeofday(&tv,NULL);
-    return (((long long)tv.tv_sec)*1000)+(tv.tv_usec/1000);
+    return (((long long)tv.tv_sec) * 1000 * 1000) + tv.tv_usec;
 }
 
 /* Rehash in ms+"delta" milliseconds. The value of "delta" is larger 
  * than 0, and is smaller than 1 in most cases. The exact upper bound 
  * depends on the running time of dictRehash(d,100).*/
 int dictRehashMilliseconds(dict *d, int ms) {
+    return dictRehashMicroseconds(d, ms * 1000);
+}
+
+/* similar with dictRehashMilliseconds, but running time unit is microsecond */
+int dictRehashMicroseconds(dict *d, int us) {
     if (d->pauserehash > 0) return 0;
 
-    long long start = timeInMilliseconds();
+    long long start = timeInMicroseconds();
     int rehashes = 0;
 
     while(dictRehash(d,100)) {
         rehashes += 100;
-        if (timeInMilliseconds()-start > ms) break;
+        if (timeInMicroseconds() - start > us) break;
     }
     return rehashes;
 }

--- a/src/dict.h
+++ b/src/dict.h
@@ -217,6 +217,7 @@ void dictEmpty(dict *d, void(callback)(dict*));
 void dictSetResizeEnabled(dictResizeEnable enable);
 int dictRehash(dict *d, int n);
 int dictRehashMilliseconds(dict *d, int ms);
+int dictRehashMicroseconds(dict *d, int us);
 void dictSetHashFunctionSeed(uint8_t *seed);
 uint8_t *dictGetHashFunctionSeed(void);
 unsigned long dictScan(dict *d, unsigned long v, dictScanFunction *fn, void *privdata);

--- a/src/server.c
+++ b/src/server.c
@@ -609,21 +609,21 @@ void tryResizeHashTables(int dbid) {
 
 /* Our hash table implementation performs rehashing incrementally while
  * we write/read from the hash table. Still if the server is idle, the hash
- * table will use two tables for a long time. So we try to use 1 millisecond
+ * table will use two tables for a long time. So we try to use some microseconds
  * of CPU time at every call of this function to perform some rehashing.
  *
  * The function returns 1 if some rehashing was performed, otherwise 0
  * is returned. */
-int incrementallyRehash(int dbid) {
+int incrementallyRehash(int dbid, int us) {
     /* Keys dictionary */
     if (dictIsRehashing(server.db[dbid].dict)) {
-        dictRehashMilliseconds(server.db[dbid].dict,1);
-        return 1; /* already used our millisecond for this loop... */
+        dictRehashMicroseconds(server.db[dbid].dict, us);
+        return 1; /* already used our microseconds for this loop... */
     }
     /* Expires */
     if (dictIsRehashing(server.db[dbid].expires)) {
-        dictRehashMilliseconds(server.db[dbid].expires,1);
-        return 1; /* already used our millisecond for this loop... */
+        dictRehashMicroseconds(server.db[dbid].expires, us);
+        return 1; /* already used our microseconds for this loop... */
     }
     return 0;
 }
@@ -1043,6 +1043,8 @@ void clientsCron(void) {
     }
 }
 
+#define DATABASE_REHASH_TIME_PERC 1 /* Max % of CPU to use for databases rehash. */
+
 /* This function handles 'background' operations we are required to do
  * incrementally in Redis databases, such as active key expiring, resizing,
  * rehashing. */
@@ -1080,11 +1082,14 @@ void databasesCron(void) {
             tryResizeHashTables(resize_db % server.dbnum);
             resize_db++;
         }
-
+        /* use at max 'DATABASE_REHASH_TIME_PERC' percentage of CPU
+         * time per iteration, ensure that the service throughput capacity
+         * will not change during rehash due to dynamic hz*/
+        int rehashtime = DATABASE_REHASH_TIME_PERC * 1000000 / server.hz / 100;
         /* Rehash */
         if (server.activerehashing) {
             for (j = 0; j < dbs_per_call; j++) {
-                int work_done = incrementallyRehash(rehash_db);
+                int work_done = incrementallyRehash(rehash_db, rehashtime);
                 if (work_done) {
                     /* If the function did some work, stop here, we'll do
                      * more at the next cron loop. */


### PR DESCRIPTION
When the db is rehashing, it will take 1ms to process each time in ServerCron. This only took 1% of the cpu time when the user was using the default 10hz . But when the user uses dynamic hz, or configures it as 100 (this is our scenario, for lower latency), it may take more than 10% of the cpu time, resulting in a decrease in the throughput of redis.

Therefore, in this pr, no matter what value `HZ` is , rehash only uses a fixed 1% of cpu time.
