### PR TITLE
Increase threshold for flaky cache reclaim test

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -323,7 +323,7 @@ jobs:
         ./src/redis-cli -p 8080 save > /dev/null
         VMOUT=$(vmtouch -v /tmp/master/dump.rdb)
         echo $VMOUT
-        grep -q "0%" <<< $VMOUT 
+        grep -q " 0%" <<< $VMOUT 
         CACHE=$(grep -w file /sys/fs/cgroup/memory.stat | awk '{print $2}')
         echo "$CACHE"
         if [ "$(( $CACHE-$CACHE0 ))" -gt "8000000" ]; then exit 1; fi
@@ -334,10 +334,10 @@ jobs:
         sleep 1 # wait for the completion of cache reclaim bio
         VMOUT=$(vmtouch -v /tmp/master/dump.rdb)
         echo $VMOUT
-        grep -q "0%" <<< $VMOUT 
+        grep -q " 0%" <<< $VMOUT 
         VMOUT=$(vmtouch -v /tmp/slave/dump.rdb)
         echo $VMOUT
-        grep -q "0%" <<< $VMOUT 
+        grep -q " 0%" <<< $VMOUT 
         CACHE=$(grep -w file /sys/fs/cgroup/memory.stat | awk '{print $2}')
         echo "$CACHE"
         if [ "$(( $CACHE-$CACHE0 ))" -gt "8000000" ]; then exit 1; fi
@@ -351,7 +351,7 @@ jobs:
         sleep 1 # wait for the completion of cache reclaim bio
         VMOUT=$(vmtouch -v /tmp/master/dump.rdb)
         echo $VMOUT
-        grep -q "0%" <<< $VMOUT
+        grep -q " 0%" <<< $VMOUT
         CACHE=$(grep -w file /sys/fs/cgroup/memory.stat | awk '{print $2}')
         echo "$CACHE"
         if [ "$(( $CACHE-$CACHE0 ))" -gt "8000000" ]; then exit 1; fi

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -326,7 +326,7 @@ jobs:
         grep -q "0%" <<< $VMOUT 
         CACHE=$(grep -w file /sys/fs/cgroup/memory.stat | awk '{print $2}')
         echo "$CACHE"
-        if [ "$(( $CACHE-$CACHE0 ))" -gt "500000" ]; then exit 1; fi
+        if [ "$(( $CACHE-$CACHE0 ))" -gt "8000000" ]; then exit 1; fi
 
         echo "test replication doesn't increase cache"
         ./src/redis-cli -p 8081 REPLICAOF 127.0.0.1 8080 > /dev/null
@@ -340,7 +340,7 @@ jobs:
         grep -q "0%" <<< $VMOUT 
         CACHE=$(grep -w file /sys/fs/cgroup/memory.stat | awk '{print $2}')
         echo "$CACHE"
-        if [ "$(( $CACHE-$CACHE0 ))" -gt "500000" ]; then exit 1; fi
+        if [ "$(( $CACHE-$CACHE0 ))" -gt "8000000" ]; then exit 1; fi
         
         echo "test reboot doesn't increase cache"
         PID=$(cat /tmp/master/redis.pid)
@@ -354,7 +354,7 @@ jobs:
         grep -q "0%" <<< $VMOUT
         CACHE=$(grep -w file /sys/fs/cgroup/memory.stat | awk '{print $2}')
         echo "$CACHE"
-        if [ "$(( $CACHE-$CACHE0 ))" -gt "500000" ]; then exit 1; fi
+        if [ "$(( $CACHE-$CACHE0 ))" -gt "8000000" ]; then exit 1; fi
 
   test-valgrind-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This test produces 1GB of data and moves it around, and was expecting less than 500kb to be present in the system page cache.
It sometimes fails with up to some 6mb in the page cache (0 in the actual RDB files), increasing the threshold.
It looks like some background tasks in the container are occupying the page cache.

It is safe to ignore the above since we also explicitly check the pages of our dump.rdb are not cached (matching `vmtouch -v` to `0%`).
An additional fix is to match ` 0%` (add space), so that we don't successfully match `10%`.

details in https://github.com/redis/redis/pull/11818