### PR TITLE
[New command] CLUSTER KEYSHARD key

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -6047,10 +6047,7 @@ NULL
         addReplyBulkCString(c, "nodes");
         if(node == NULL || (node == myself && lookupKeyRead(c->db,c->argv[2]) == NULL)){
             addReply(c,shared.emptyarray);
-        }
-
-        else
-        {
+        } else {
             addReplyArrayLen(c, node->numslaves+1);
             getKeyShardReply(c,node);
             for (int i = 0; i < node->numslaves; i++) {

--- a/src/commands/cluster-keyshard.json
+++ b/src/commands/cluster-keyshard.json
@@ -22,7 +22,7 @@
             "NONDETERMINISTIC_OUTPUT"
         ],
    "reply_schema": {
-            "description": "a nested list of a map of hash ranges and shard nodes describing individual shards",
+            "description": "a list of key and shard nodes details where the key exist.",
             "type": "array",
             "items": {
                 "type": "object",
@@ -36,7 +36,7 @@
 			 }
                     },
                     "nodes": {
-                        "description": "nodes where key exist",
+                        "description": "list of shard nodes where key exist",
                         "type": "array",
                         "items": { 
 			    "oneOf": [

--- a/src/commands/cluster-keyshard.json
+++ b/src/commands/cluster-keyshard.json
@@ -1,0 +1,85 @@
+{
+    "KEYSHARD": {
+        "summary": "Returns the shard details of the specified keys",
+        "complexity": "O(N) where N is the number of bytes in the key",
+        "group": "cluster",
+        "since": "7.0.0",
+        "arity": 3,
+        "container": "CLUSTER",
+        "function": "clusterCommand",
+        "command_flags": [
+            "STALE"
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+		"key_spec_index": 0
+            }
+
+        ],
+		"command_tips": [
+            "NONDETERMINISTIC_OUTPUT"
+        ],
+   "reply_schema": {
+            "description": "a nested list of a map of hash ranges and shard nodes describing individual shards",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "key": {
+                        "description": "an array specifying key name",
+                        "type": "array",
+			"items":{
+			    "type": "string"
+			 }
+                    },
+                    "nodes": {
+                        "description": "nodes where key exist",
+                        "type": "array",
+                        "items": { 
+			    "oneOf": [
+			        {
+				    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "id": {
+                                            "type": "string"
+                                        },
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "tls-port": {
+                                            "type": "integer"
+                                        },
+                                        "ip": {
+                                            "type": "string"
+                                        },
+                                        "hostname": {
+                                            "type": "string"
+                                        },
+                                        "role": {
+                                            "oneOf": [
+                                                {
+                                                    "const": "master"
+                                                },
+                                                {
+                                                    "const": "replica"
+                                                }
+                                            ]
+                                        }
+                                    }
+				},
+				{
+				    "type": "null",
+                                    "description": "Key does not exist."
+				}
+			    ]
+			}
+		    }
+                }
+            }
+        }
+    }
+}

--- a/tests/cluster/tests/30-cluster-keyshard.tcl
+++ b/tests/cluster/tests/30-cluster-keyshard.tcl
@@ -1,0 +1,123 @@
+source "../tests/includes/init-tests.tcl"
+
+# Create a cluster with 2 master and 2 slaves, so that we have 1
+# slaves for each master.
+test "Create a 2 nodes cluster" {
+    create_cluster 2 2
+}
+
+test "Cluster is up" {
+    assert_cluster_state ok
+}
+
+set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+
+proc get_cluster_replicanodes {cluster id} {
+    set lines [split [$cluster CLUSTER REPLICAS $id] "\r\n"]
+    set nodes {}
+    foreach l $lines {
+        set l [string trim $l]
+        if {$l eq {}} continue
+        set args [split $l]
+	set node [dict create \
+		ip [lindex [split [lindex [split [lindex $args 1] @] 0] :] 0] \
+		port [lindex [split [lindex [split [lindex $args 1] @] 0] :] 1] \
+		shardid [lindex [split [lsearch -inline [split [lindex $args 1] ,] {shard-id=*}] =] 1] \
+		]
+	lappend nodes $node
+    }
+    return $nodes
+}
+
+proc get_cluster_keyshard {id key type} {
+    set keyshard_response [R $id CLUSTER KEYSHARD $key]
+    foreach keyshard_response $keyshard_response {
+	set keyshard_nodes [dict get $keyshard_response nodes]
+        set keyshard_master [lindex $keyshard_nodes 0]
+        set keyshard_replica [lindex $keyshard_nodes 1]
+    }
+    if {$type eq "master"} {
+        return $keyshard_master
+    } elseif {$type eq "replica"} {
+	return $keyshard_replica
+    } elseif {$type eq "nodes"} {
+        return $keyshard_nodes
+    }
+    return {}
+}
+
+test "cluster keyshard response in node with key slot and empty key" {
+    set key key1
+    set slot [$cluster cluster keyslot $key]
+    array set nodefrom [$cluster masternode_for_slot $slot]
+    #array set nodeto [$cluster masternode_notfor_slot $slot]
+    set nodeid $nodefrom(id)
+    for {set j 0} {$j < $::cluster_master_nodes + $::cluster_replica_nodes} {incr j} {
+        set myid [R $j CLUSTER MYID]
+	if {$myid == $nodeid} { set id $j}
+    }
+    set nodes [get_cluster_keyshard $id $key "nodes"]
+    puts "nodes : $nodes"
+
+    set nodelen [llength $nodes]
+    assert_equal $nodelen 0
+}
+
+test "cluster keyshard response in node where key and key slot exist" {
+    set key key1
+    set slot [$cluster cluster keyslot $key]
+    array set nodefrom [$cluster masternode_for_slot $slot]
+    array set nodeto [$cluster masternode_notfor_slot $slot]
+    set nodeid $nodefrom(id)
+    for {set j 0} {$j < $::cluster_master_nodes + $::cluster_replica_nodes} {incr j} {
+        set myid [R $j CLUSTER MYID]
+	if {$myid == $nodeid} {
+	    R $j SET $key $j
+	    set id $j
+	    break 
+	}
+    }
+    set keyshard_master [get_cluster_keyshard $id $key "master"]
+    set keyshard_replica [get_cluster_keyshard $id $key "replica"] 
+
+    set replicas [get_cluster_replicanodes $cluster $nodeid]
+    assert_equal "127.0.0.1" [dict get $keyshard_master ip]
+    assert_equal "3000$id" [dict get $keyshard_master port]
+    assert_equal [R $j cluster myshardid] [dict get $keyshard_master shard-id]
+    assert_equal "master" [dict get $keyshard_master role] 
+    foreach replica $replicas {
+	assert_equal [dict get $replica ip] [dict get $keyshard_replica ip]
+        assert_equal [dict get $replica port] [dict get $keyshard_replica port]
+        assert_equal [dict get $replica shardid] [dict get $keyshard_replica shard-id]
+	assert_equal "replica" [dict get $keyshard_replica role]
+     }
+}
+
+
+test "cluster keyshard response in node where key slot doesn't exist" {
+    set key key1
+    set slot [$cluster cluster keyslot $key]
+    array set nodefrom [$cluster masternode_for_slot $slot]
+    array set nodeto [$cluster masternode_notfor_slot $slot]
+    set nodefromid $nodefrom(id)
+    set nodetoid $nodeto(id)
+    for {set j 0} {$j < $::cluster_master_nodes + $::cluster_replica_nodes} {incr j} {
+        set myid [R $j CLUSTER MYID]
+        if {$myid == $nodefromid} {set p $j}
+        if {$myid == $nodetoid} {set id $j}
+    }
+    set keyshard_master [get_cluster_keyshard $id $key "master"]
+    set keyshard_replica [get_cluster_keyshard $id $key "replica"]
+    set replicas [get_cluster_replicanodes $cluster $nodeid]
+    assert_equal "127.0.0.1" [dict get $keyshard_master ip]
+    assert_equal "3000$p" [dict get $keyshard_master port]
+    assert_equal [R $p cluster myshardid] [dict get $keyshard_master shard-id]
+    assert_equal "master" [dict get $keyshard_master role]
+    foreach replica $replicas {
+        assert_equal [dict get $replica ip] [dict get $keyshard_replica ip]
+        assert_equal [dict get $replica port] [dict get $keyshard_replica port]
+        assert_equal [dict get $replica shardid] [dict get $keyshard_replica shard-id]
+	assert_equal "replica" [dict get $keyshard_replica role]
+     }
+}
+


### PR DESCRIPTION
Feature description

Currently we don't have any procedure to directly retrieve the shard details where the key exist.
If we want to know the shard details we would first need to get the slot details by using "CLUSTER KEYSLOT key" command and then check where that particular slot belong.

We want to introduce new command  CLUSTER KEYSHARD key , which can fetch the shard details of given key at once.

By using this command user can directly get the details of shard of given key.
1. If the key belongs to same client and its does not exist it will return empty string .
2. If key belongs to same client and it exist it will return the shard details.
3. If key belong to some other node on cluster , it will return the shard details of that node.

![clusterkeyshard](https://user-images.githubusercontent.com/51993843/230417715-075a2c2b-b342-48f4-904a-032752e232b7.jpg)


