### PR TITLE
Updating reply_schema for sentinal commands

### DIFF
--- a/src/commands/sentinel-masters.json
+++ b/src/commands/sentinel-masters.json
@@ -11,6 +11,16 @@
             "ADMIN",
             "SENTINEL",
             "ONLY_SENTINEL"
-        ]
+        ],
+	"reply_schema": {
+            "type": "array",
+            "description": "List of monitored Redis masters, and their state.",
+            "items": {
+                "type": "object",
+                "additionalProperties": {
+                "type": "string"
+                }
+            }
+        }
     }
 }

--- a/src/commands/sentinel-masters.json
+++ b/src/commands/sentinel-masters.json
@@ -12,13 +12,13 @@
             "SENTINEL",
             "ONLY_SENTINEL"
         ],
-	"reply_schema": {
+        "reply_schema": {
             "type": "array",
             "description": "List of monitored Redis masters, and their state.",
             "items": {
                 "type": "object",
                 "additionalProperties": {
-                "type": "string"
+                    "type": "string"
                 }
             }
         }

--- a/src/commands/sentinel-myid.json
+++ b/src/commands/sentinel-myid.json
@@ -11,6 +11,11 @@
             "ADMIN",
             "SENTINEL",
             "ONLY_SENTINEL"
-        ]
+        ],
+	"reply_schema": {
+            "description": "Node ID of the sentinel instance.",
+            "type": "string"
+        }
+
     }
 }

--- a/src/commands/sentinel-myid.json
+++ b/src/commands/sentinel-myid.json
@@ -12,10 +12,9 @@
             "SENTINEL",
             "ONLY_SENTINEL"
         ],
-	"reply_schema": {
+        "reply_schema": {
             "description": "Node ID of the sentinel instance.",
             "type": "string"
         }
-
     }
 }

--- a/src/commands/sentinel-sentinels.json
+++ b/src/commands/sentinel-sentinels.json
@@ -12,13 +12,13 @@
             "SENTINEL",
             "ONLY_SENTINEL"
         ],
-	"reply_schema": {
+        "reply_schema": {
             "type": "array",
             "description": "List of sentinel instances, and their state.",
             "items": {
                 "type": "object",
                 "additionalProperties": {
-                "type": "string"
+                    "type": "string"
                 }
             }
         },

--- a/src/commands/sentinel-sentinels.json
+++ b/src/commands/sentinel-sentinels.json
@@ -14,7 +14,7 @@
         ],
 	"reply_schema": {
             "type": "array",
-            "description": "List of sentinal instances, and their state.",
+            "description": "List of sentinel instances, and their state.",
             "items": {
                 "type": "object",
                 "additionalProperties": {

--- a/src/commands/sentinel-sentinels.json
+++ b/src/commands/sentinel-sentinels.json
@@ -12,6 +12,16 @@
             "SENTINEL",
             "ONLY_SENTINEL"
         ],
+	"reply_schema": {
+            "type": "array",
+            "description": "List of sentinal instances, and their state.",
+            "items": {
+                "type": "object",
+                "additionalProperties": {
+                "type": "string"
+                }
+            }
+        },
         "arguments": [
             {
                 "name": "master-name",

--- a/src/commands/sentinel-slaves.json
+++ b/src/commands/sentinel-slaves.json
@@ -17,6 +17,16 @@
             "SENTINEL",
             "ONLY_SENTINEL"
         ],
+	"reply_schema": {
+            "type": "array",
+            "description": "List of monitored replicas, and their state.",
+            "items": {
+                "type": "object",
+                "additionalProperties": {
+                "type": "string"
+                }
+            }
+        },
         "arguments": [
             {
                 "name": "master-name",

--- a/src/commands/sentinel-slaves.json
+++ b/src/commands/sentinel-slaves.json
@@ -17,13 +17,13 @@
             "SENTINEL",
             "ONLY_SENTINEL"
         ],
-	"reply_schema": {
+        "reply_schema": {
             "type": "array",
             "description": "List of monitored replicas, and their state.",
             "items": {
                 "type": "object",
                 "additionalProperties": {
-                "type": "string"
+                    "type": "string"
                 }
             }
         },

--- a/utils/req-res-log-validator.py
+++ b/utils/req-res-log-validator.py
@@ -337,7 +337,7 @@ if __name__ == '__main__':
     # We don't care about SENTINEL commands
     #not_hit = set(filter(lambda x: not x.startswith("sentinel"),
     #              set(docs.keys()) - set(command_counter.keys()) - set(IGNORED_COMMANDS)))
-    not_hit = set(filter(set(docs.keys()) - set(command_counter.keys()) - set(IGNORED_COMMANDS)))
+    not_hit = set(set(docs.keys()) - set(command_counter.keys()) - set(IGNORED_COMMANDS))
     if not_hit:
         if args.verbose:
             print("WARNING! The following commands were not hit at all:")

--- a/utils/req-res-log-validator.py
+++ b/utils/req-res-log-validator.py
@@ -335,8 +335,9 @@ if __name__ == '__main__':
     for k, v in sorted(command_counter.items()):
         print(f"  {k}: {v}")
     # We don't care about SENTINEL commands
-    not_hit = set(filter(lambda x: not x.startswith("sentinel"),
-                  set(docs.keys()) - set(command_counter.keys()) - set(IGNORED_COMMANDS)))
+    #not_hit = set(filter(lambda x: not x.startswith("sentinel"),
+    #              set(docs.keys()) - set(command_counter.keys()) - set(IGNORED_COMMANDS)))
+    not_hit = set(filter(set(docs.keys()) - set(command_counter.keys()) - set(IGNORED_COMMANDS)))
     if not_hit:
         if args.verbose:
             print("WARNING! The following commands were not hit at all:")

--- a/utils/req-res-log-validator.py
+++ b/utils/req-res-log-validator.py
@@ -334,9 +334,6 @@ if __name__ == '__main__':
     print("Hits per command:")
     for k, v in sorted(command_counter.items()):
         print(f"  {k}: {v}")
-    # We don't care about SENTINEL commands
-    #not_hit = set(filter(lambda x: not x.startswith("sentinel"),
-    #              set(docs.keys()) - set(command_counter.keys()) - set(IGNORED_COMMANDS)))
     not_hit = set(set(docs.keys()) - set(command_counter.keys()) - set(IGNORED_COMMANDS))
     if not_hit:
         if args.verbose:


### PR DESCRIPTION
Some sentinel subcommands are missing the reply_schema in the json file,
so add the proper reply_schema part in json file as sentinel replicas commands.

The schema validator was skipping coverage test for sentinel commands, this was initially
done just in order to focus on redis commands and leave sentinel coverage for later,
so this check is now removed.

sentinel commands that were missing reply schema:
* sentinel masters
* sentinel myid
* sentinel sentinels <master-name>
* sentinel slaves (deprecated)  <master-name> 