### PR TITLE
Minor performance improvement to SADD and HSET

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -3101,7 +3101,7 @@ void dismissMemoryInChild(void);
 int restartServer(int flags, mstime_t delay);
 
 /* Set data type */
-robj *setTypeCreate(sds value);
+robj *setTypeCreate(sds value, size_t size_hint);
 int setTypeAdd(robj *subject, sds value);
 int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sds);
 int setTypeRemove(robj *subject, sds value);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -42,9 +42,14 @@ void hashTypeTryConversion(robj *o, robj **argv, int start, int end) {
     size_t sum = 0;
 
     if (o->encoding != OBJ_ENCODING_LISTPACK) return;
-    size_t args_length = end - start + 1;
-    if (args_length/2 > server.hash_max_listpack_entries) {
+
+    /* We guess that most of the values in the input are unique, so
+     * if there are enough arguments we create a pre-sized hash, which
+     * might overallocate memory if their are duplicates. */
+    size_t new_fields = (end - start + 1) / 2;
+    if (new_fields > server.hash_max_listpack_entries) {
         hashTypeConvert(o, OBJ_ENCODING_HT);
+        dictExpand(o->ptr, new_fields);
         return;
     }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -43,6 +43,11 @@ void hashTypeTryConversion(robj *o, robj **argv, int start, int end) {
 
     if (o->encoding != OBJ_ENCODING_LISTPACK) return;
 
+    if (end - start + 1 > server.hash_max_listpack_entries) {
+        hashTypeConvert(o, OBJ_ENCODING_HT);
+        return;
+    }
+
     for (i = start; i <= end; i++) {
         if (!sdsEncodedObject(argv[i]))
             continue;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -42,8 +42,8 @@ void hashTypeTryConversion(robj *o, robj **argv, int start, int end) {
     size_t sum = 0;
 
     if (o->encoding != OBJ_ENCODING_LISTPACK) return;
-
-    if (end - start + 1 > server.hash_max_listpack_entries) {
+    size_t args_length = end - start + 1;
+    if (args_length > server.hash_max_listpack_entries) {
         hashTypeConvert(o, OBJ_ENCODING_HT);
         return;
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -43,7 +43,7 @@ void hashTypeTryConversion(robj *o, robj **argv, int start, int end) {
 
     if (o->encoding != OBJ_ENCODING_LISTPACK) return;
     size_t args_length = end - start + 1;
-    if (args_length > server.hash_max_listpack_entries) {
+    if (args_length/2 > server.hash_max_listpack_entries) {
         hashTypeConvert(o, OBJ_ENCODING_HT);
         return;
     }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -41,8 +41,8 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
  * an integer-encodable value, an intset will be returned. Otherwise a regular
  * hash table.
  *
- * The size hint indicates approximately how many items will be added, -1 should be
- * used if the size not known. */
+ * The size hint indicates approximately how many items will be added which is
+ * used to determine the initial representation. */
 robj *setTypeCreate(sds value, size_t size_hint) {
     if (isSdsRepresentableAsLongLong(value,NULL) == C_OK && size_hint < server.set_max_intset_entries)
         return createIntsetObject();

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -53,11 +53,11 @@ robj *setTypeCreate(sds value, size_t size_hint) {
 
 /* Check if the existing set should be converted to another encoding based off the
  * the size hint. */
-void setTypeTryConvert(robj *set, size_t size_hint) {
+void setTypeMaybeConvert(robj *set, size_t size_hint) {
     if ((set->encoding == OBJ_ENCODING_LISTPACK && size_hint >= server.set_max_listpack_entries)
         || (set->encoding == OBJ_ENCODING_INTSET && size_hint >= server.set_max_intset_entries))
     {
-        setTypeConvert(set, OBJ_ENCODING_HT);
+        setTypeConvertAndExpand(set, OBJ_ENCODING_HT, size_hint, 1);
     }
 }
 
@@ -608,7 +608,7 @@ void saddCommand(client *c) {
         set = setTypeCreate(c->argv[2]->ptr, c->argc - 2);
         dbAdd(c->db,c->argv[1],set);
     } else {
-        setTypeTryConvert(set, c->argc - 2);
+        setTypeMaybeConvert(set, c->argc - 2);
     }
 
     for (j = 2; j < c->argc; j++) {

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -677,7 +677,7 @@ void smoveCommand(client *c) {
 
     /* Create the destination set when it doesn't exist */
     if (!dstset) {
-        dstset = setTypeCreate(ele->ptr, c->argc - 2);
+        dstset = setTypeCreate(ele->ptr, 1);
         dbAdd(c->db,c->argv[2],dstset);
     }
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -48,7 +48,12 @@ robj *setTypeCreate(sds value, size_t size_hint) {
         return createIntsetObject();
     if (size_hint < server.set_max_listpack_entries)
         return createSetListpackObject();
-    return createSetObject();
+
+    /* We may oversize the set by using the hint if the hint is not accurate,
+     * but we will assume this is accpetable to maximize performance. */
+    robj *o = createSetObject();
+    dictExpand(o->ptr, size_hint);
+    return o;
 }
 
 /* Check if the existing set should be converted to another encoding based off the


### PR DESCRIPTION
For sets and hashes that will eventually be stores as the hash encoding, it's much faster to immediately convert them to their hash encoding and then perform the insertions since it avoids the O(N) search and frequent reallocations. This change checks the number of arguments in the incoming command, and converts the data-structure if the number of new entries exceeds the listpack-max-entries configuration. This can cause us to over-allocate memory if their are duplicate entries in the input, which is unexpected. 

Some very basic benchmarking using 
```
redis-benchmark -r 1000000 -n 100000 HSET __rand_int__ `python -c "print(' '.join([str(a) for a in range(1300)]))"`
```

unstable
```
Summary:
  throughput summary: 805.54 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       61.908    25.680    68.351    73.279    75.967    79.295
```

hset-improvement
```
Summary:
  throughput summary: 4701.46 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       10.546     0.832    11.959    12.471    13.119    14.967
```

This change was originally inspired by an AWS user who was running into performance bottlenecks because they were were inserting 600 hash entries. In the end these were being stored as a hashmap, but while inserting they were being stored as a listpack. These hashes are incrementally inserted into, so there was 600 O(N) searches to see if the element was in the list and then ~600 O(N) copies of the data to realloc the new item into it. We solved their problem by having them update the max_list_pack entry to 1 so the conversion happens sooner, but it seems unnecessary to use the expensive listpack insertions at all. So this change just immediately converts to a hashmap if the number of elements in the ARGV is larger than the conversion.


There is probably a lot more smart optimizations we could do here. I think there is two use cases:
1. Creating a new record. (This seems not well optimized)
2. Updating a single record in an existing field. (This seems fine)

```
Release notes
Optimize the performance of inserting entries toto hashes and sets that exceed the max size for listpacks.
```