### PR TITLE
Add ZREMRANGEBYLEX basics tests to fix reply-schemas daily

### DIFF
--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -755,6 +755,29 @@ start_server {tags {"zset"}} {
             assert_equal 0 [r exists zset]
         }
 
+        test "ZREMRANGEBYLEX basics - $encoding" {
+            proc remrangebylex {min max} {
+                create_default_lex_zset
+                assert_equal 1 [r exists zset]
+                r zremrangebylex zset $min $max
+            }
+
+            # inclusive range
+            assert_equal 3 [remrangebylex - \[cool]
+            assert_equal 3 [remrangebylex \[bar \[down]
+            assert_equal 3 [remrangebylex \[g +]
+
+            # exclusive range
+            assert_equal 2 [remrangebylex - (cool]
+            assert_equal 1 [remrangebylex (bar (down]
+            assert_equal 2 [remrangebylex (great +]
+
+            # inclusive and exclusive
+            assert_equal 0 [remrangebylex (az (b]
+            assert_equal 0 [remrangebylex (z +]
+            assert_equal 0 [remrangebylex - \[aaaa]
+        }
+
         test "ZUNIONSTORE against non-existing key doesn't set destination - $encoding" {
             r del zseta{t}
             assert_equal 0 [r zunionstore dst_key{t} 1 zseta{t}]

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -764,18 +764,35 @@ start_server {tags {"zset"}} {
 
             # inclusive range
             assert_equal 3 [remrangebylex - \[cool]
+            assert_equal {down elephant foo great hill omega} [r zrange zset 0 -1]
             assert_equal 3 [remrangebylex \[bar \[down]
+            assert_equal {alpha elephant foo great hill omega} [r zrange zset 0 -1]
             assert_equal 3 [remrangebylex \[g +]
+            assert_equal {alpha bar cool down elephant foo} [r zrange zset 0 -1]
+            assert_equal 6 [r zcard zset]
 
             # exclusive range
             assert_equal 2 [remrangebylex - (cool]
+            assert_equal {cool down elephant foo great hill omega} [r zrange zset 0 -1]
             assert_equal 1 [remrangebylex (bar (down]
+            assert_equal {alpha bar down elephant foo great hill omega} [r zrange zset 0 -1]
             assert_equal 2 [remrangebylex (great +]
+            assert_equal {alpha bar cool down elephant foo great} [r zrange zset 0 -1]
+            assert_equal 7 [r zcard zset]
 
             # inclusive and exclusive
             assert_equal 0 [remrangebylex (az (b]
+            assert_equal {alpha bar cool down elephant foo great hill omega} [r zrange zset 0 -1]
             assert_equal 0 [remrangebylex (z +]
+            assert_equal {alpha bar cool down elephant foo great hill omega} [r zrange zset 0 -1]
             assert_equal 0 [remrangebylex - \[aaaa]
+            assert_equal {alpha bar cool down elephant foo great hill omega} [r zrange zset 0 -1]
+            assert_equal 9 [r zcard zset]
+
+            # destroy when empty
+            assert_equal 9 [remrangebylex - +]
+            assert_equal 0 [r zcard zset]
+            assert_equal 0 [r exists zset]
         }
 
         test "ZUNIONSTORE against non-existing key doesn't set destination - $encoding" {


### PR DESCRIPTION
We do have ZREMRANGEBYLEX tests, but it is a stress test
marked with slow tag and then skipped in reply-schemas daily.

In the past, we were able to succeed on a daily, i guess
it was because there were some random command executions,
such as corrupt-dump-fuzzy, which might call it.

These test examples are taken from ZRANGEBYLEX basics test.