### PR TITLE
Fix redis_check_rdb() hang when rdb is FIFO

### DIFF
--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -205,7 +205,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     static rio rdb; /* Pointed by global struct riostate. */
     struct stat sb;
 
-    if (is_fifo(rdbfilename)) {
+    if (isFifo(rdbfilename)) {
         /* Cannot check RDB over named pipe because fopen blocks until another process opens the FIFO for writing. */
         return 1;
     }

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -206,7 +206,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     struct stat sb;
 
     if (is_fifo(rdbfilename)) {
-        // Cannot check RDB over named pipe because fopen blocks until another process opens the FIFO for writing.
+        /* Cannot check RDB over named pipe because fopen blocks until another process opens the FIFO for writing. */
         return 1;
     }
 

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -186,7 +186,7 @@ void rdbCheckSetupSignals(void) {
     sigaction(SIGABRT, &act, NULL);
 }
 
-static int is_fifo(char *filename) {
+static int isFifo(char *filename) {
     struct stat stat_p;
     stat(filename, &stat_p);
     return S_ISFIFO(stat_p.st_mode);

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -186,6 +186,12 @@ void rdbCheckSetupSignals(void) {
     sigaction(SIGABRT, &act, NULL);
 }
 
+static int is_fifo(char *filename) {
+    struct stat stat_p;
+    stat(filename, &stat_p);
+    return S_ISFIFO(stat_p.st_mode);
+}
+
 /* Check the specified RDB file. Return 0 if the RDB looks sane, otherwise
  * 1 is returned.
  * The file is specified as a filename in 'rdbfilename' if 'fp' is not NULL,
@@ -198,6 +204,11 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     long long expiretime, now = mstime();
     static rio rdb; /* Pointed by global struct riostate. */
     struct stat sb;
+
+    if (is_fifo(rdbfilename)) {
+        // Cannot check RDB over named pipe because fopen blocks until another process opens the FIFO for writing.
+        return 1;
+    }
 
     int closefile = (fp == NULL);
     if (fp == NULL && (fp = fopen(rdbfilename,"r")) == NULL) return 1;


### PR DESCRIPTION
When loading RDB over the named piped, redis_check_rdb() is hung at fopen, because fopen blocks until another process opens the FIFO for writing. The fix is to check if RDB is FIFO. If yes, return an error.

Note: currently redis doesn't use this function on a FIFO.