### PR TITLE
Fix SCAN to reject empty cursor ("") instead of treating it as "0"

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -835,7 +835,7 @@ int parseScanCursorOrReply(client *c, robj *o, unsigned long *cursor) {
      * getLongLongFromObject() does not cover the whole cursor space. */
     errno = 0;
     *cursor = strtoul(o->ptr, &eptr, 10);
-    if (isspace(((char*)o->ptr)[0]) || eptr[0] != '\0' || errno == ERANGE)
+    if (sdslen(o->ptr) == 0 || isspace(((char*)o->ptr)[0]) || eptr[0] != '\0' || errno == ERANGE)
     {
         addReplyError(c, "invalid cursor");
         return C_ERR;

--- a/src/db.c
+++ b/src/db.c
@@ -835,7 +835,7 @@ int parseScanCursorOrReply(client *c, robj *o, unsigned long *cursor) {
      * getLongLongFromObject() does not cover the whole cursor space. */
     errno = 0;
     *cursor = strtoul(o->ptr, &eptr, 10);
-    if (sdslen(o->ptr) == 0 || isspace(((char*)o->ptr)[0]) || eptr[0] != '\0' || errno == ERANGE)
+    if (eptr == o->ptr || isspace(((char*)o->ptr)[0]) || eptr[0] != '\0' || errno == ERANGE)
     {
         addReplyError(c, "invalid cursor");
         return C_ERR;

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -283,6 +283,11 @@ start_server {tags {"scan network"}} {
         assert {$first_score != 0}
     }
 
+    test "scan with null string" {
+        catch {r scan ""} err
+        format $err
+    } {ERR invalid cursor}
+
     test "SCAN regression test for issue #4906" {
         for {set k 0} {$k < 100} {incr k} {
             r del set


### PR DESCRIPTION
the bug is that an empty string is successfully parsed as 0,
since eptr is set to the input string, and does equal to '\0'.

previous discussion: #11974