### PR TITLE
Added missing test cases for substring

### DIFF
--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -474,6 +474,9 @@ start_server {tags {"string"}} {
         assert_equal "a" [r substr key 0 0]
         assert_equal "abcd" [r substr key 0 3]
         assert_equal "bcde" [r substr key -4 -1]
+        assert_equal "" [r substr key -1 -3]
+        assert_equal "" [r substr key 7 8]
+        assert_equal "" [r substr nokey 0 1]
     }
     
 if {[string match {*jemalloc*} [s mem_allocator]]} {


### PR DESCRIPTION
There is are some missing test cases for substr command.

Added 3 test case.
1.  start > stop
2.  start and stop both greater than string length
3.  when no key is present.
![image](https://user-images.githubusercontent.com/51993843/231789451-dc95883f-e86b-4a7f-a78c-98d7a6e3014e.png)
