### PR TITLE
[BUG]  COMMAND GETKEYS and COMMAND GETKEYSANDFLAG returns error for CLUSTER subcommand KEYSLOT

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5985,9 +5985,7 @@ NULL
                 strerror(errno));
     } else if (!strcasecmp(c->argv[1]->ptr,"keyslot") && c->argc == 3) {
         /* CLUSTER KEYSLOT <key> */
-        sds key = c->argv[2]->ptr;
-
-        addReplyLongLong(c,keyHashSlot(key,sdslen(key)));
+        addReplyLongLong(c, keyHashSlot((char*)c->argv[2]->ptr,sdslen(c->argv[2]->ptr)));
     } else if (!strcasecmp(c->argv[1]->ptr,"countkeysinslot") && c->argc == 3) {
         /* CLUSTER COUNTKEYSINSLOT <slot> */
         long long slot;

--- a/src/commands/cluster-keyslot.json
+++ b/src/commands/cluster-keyslot.json
@@ -4,16 +4,36 @@
         "complexity": "O(N) where N is the number of bytes in the key",
         "group": "cluster",
         "since": "3.0.0",
-        "arity": 3,
+        "arity": -3,
         "container": "CLUSTER",
         "function": "clusterCommand",
         "command_flags": [
-            "STALE"
+            "READONLY"
+        ],
+	"key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
         ],
         "arguments": [
             {
                 "name": "key",
-                "type": "string"
+                "type": "key",
+		"key_spec_index": 0
             }
         ],
         "reply_schema": {

--- a/src/server.c
+++ b/src/server.c
@@ -4929,21 +4929,10 @@ void addReplyCommandDocs(client *c, struct redisCommand *cmd) {
 
 /* Helper for COMMAND GETKEYS and GETKEYSANDFLAGS */
 void getKeysSubcommandImpl(client *c, int with_flags) {
-    //struct redisCommand *cmd = lookupCommand(c->argv+2,c->argc-2);
-    struct redisCommand *cmd = lookupCommandBySds(c->argv[2]->ptr);
+    struct redisCommand *cmd = lookupCommand(c->argv+2,c->argc-2);
     getKeysResult result = GETKEYS_RESULT_INIT;
     int j;
-    //we currently have only one subcommand which accept key as argument
-    if(cmd && !(strcmp(cmd->fullname,"cluster|keyslot"))){
-        if(c->argc != 4){
-            addReplyError(c,"Invalid number of arguments specified for command");
-            return;
-        } else {
-            addReplyArrayLen(c,1);
-            addReplyBulk(c,c->argv[3]);
-            return;
-        }
-    }
+
     if (!cmd) {
         addReplyError(c,"Invalid command specified");
         return;

--- a/src/server.c
+++ b/src/server.c
@@ -4929,10 +4929,21 @@ void addReplyCommandDocs(client *c, struct redisCommand *cmd) {
 
 /* Helper for COMMAND GETKEYS and GETKEYSANDFLAGS */
 void getKeysSubcommandImpl(client *c, int with_flags) {
-    struct redisCommand *cmd = lookupCommand(c->argv+2,c->argc-2);
+    //struct redisCommand *cmd = lookupCommand(c->argv+2,c->argc-2);
+    struct redisCommand *cmd = lookupCommandBySds(c->argv[2]->ptr);
     getKeysResult result = GETKEYS_RESULT_INIT;
     int j;
-
+    //we currently have only one subcommand which accept key as argument
+    if(cmd && !(strcmp(cmd->fullname,"cluster|keyslot"))){
+        if(c->argc != 4){
+            addReplyError(c,"Invalid number of arguments specified for command");
+            return;
+        } else {
+            addReplyArrayLen(c,1);
+            addReplyBulk(c,c->argv[3]);
+            return;
+        }
+    }
     if (!cmd) {
         addReplyError(c,"Invalid command specified");
         return;

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -137,6 +137,10 @@ start_server {tags {"introspection"}} {
         assert_equal {key} [r command getkeys memory usage key]
     }
 
+    test {COMMAND GETKEYS CLUSTER KEYSLOT} {
+        assert_equal {key} [r command getkeys cluster keyslot key]
+    }
+
     test {COMMAND GETKEYS XGROUP} {
         assert_equal {key} [r command getkeys xgroup create key groupname $]
     }


### PR DESCRIPTION
**Problem statement :** 
As a part of pr ( https://github.com/redis/redis/pull/9504 (Treat subcommands as commands) which was merged in last release) subcommands are also treated as command and it is now possible to use COMMAND directly on subcommands :

**Current behaviors:**
We have another subcommand "memory usage" which seems to work fine

**_127.0.0.1:6379> command getkeys memory usage key_**
**_1) "key"_**

**_127.0.0.1:6379> command getkeysandflags memory usage key_**
**_1) 1) "key"_**
    **_2) 1) RO_**

When I tried to run the command "COMMAND GETKEYS CLUSTER KEYSLOT key1" I have encountered the error 

**_127.0.0.1:6379> command getkeys CLUSTER KEYSLOT k
(error) ERR Invalid command specified_**

**_127.0.0.1:6379> command getkeysandflags CLUSTER KEYSLOT k
(error) ERR Invalid command specified_**

**Expected behavior :** 
_**127.0.0.1:6379> command getkeys CLUSTER KEYSLOT key**_
**_1) "key"_**
_**127.0.0.1:6379> command getkeysandflags CLUSTER KEYSLOT key**_
**_1) 1) "key"_**
    **_2) 1) RO_**

