### PR TITLE
redis-cli - add option --count for scan

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2525,8 +2525,8 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
             }
 
             /* Store database number when SELECT was successfully executed. */
-            if (!strcasecmp(command,"select") && argc == 2 &&) 
-                config.last_cmd_type != REDIS_REPLY_ERROR)) 
+            if (!strcasecmp(command,"select") && argc == 2 && 
+                config.last_cmd_type != REDIS_REPLY_ERROR) 
             {
                 config.conn_info.input_dbnum = config.dbnum = atoi(argv[1]);
                 cliRefreshPrompt();

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -334,7 +334,7 @@ static void cliRefreshPrompt(void) {
         prompt = sdscatfmt(prompt,"[%i]",config.dbnum);
 
     /* Add TX if in transaction state*/
-    if (config.in_multi)
+    if (config.in_multi)  
         prompt = sdscatlen(prompt,"(TX)",4);
 
     if (config.pubsub_mode)
@@ -668,7 +668,7 @@ static helpEntry *cliInitCommandHelpEntry(char *cmdname, char *subcommandname,
 static size_t cliCountCommands(redisReply* commandTable) {
     size_t numCommands = commandTable->elements / 2;
 
-    /* The command docs table maps command names to a map of their specs. */
+    /* The command docs table maps command names to a map of their specs. */    
     for (size_t i = 0; i < commandTable->elements; i += 2) {
         assert(commandTable->element[i]->type == REDIS_REPLY_STRING);  /* Command name. */
         assert(commandTable->element[i + 1]->type == REDIS_REPLY_MAP ||
@@ -790,7 +790,7 @@ static helpEntry *cliLegacyInitCommandHelpEntry(char *cmdname, char *subcommandn
                                                 dict *groups, sds version) {
     helpEntry *help = next++;
     cliFillInCommandHelpEntry(help, cmdname, subcommandname);
-
+    
     help->docs.summary = sdsnew(command->summary);
     help->docs.since = sdsnew(command->since);
     help->docs.group = sdsnew(command->group);
@@ -886,7 +886,7 @@ static sds cliGetServerVersion() {
 
 static void cliLegacyInitHelp(dict *groups) {
     sds serverVersion = cliGetServerVersion();
-
+    
     /* Scan the commandDocs array and fill in the entries */
     helpEntriesLen = cliLegacyCountCommands(redisCommandTable, serverVersion);
     helpEntries = zmalloc(sizeof(helpEntry)*helpEntriesLen);
@@ -1095,7 +1095,7 @@ static sds addHintForArguments(sds hint, cliCommandArg *args, int numargs, char 
         /* The rule is that successive "optional" arguments can appear in any order.
          * But if they are followed by a required argument, no more of those optional arguments
          * can appear after that.
-         *
+         * 
          * This code handles all successive optional args together. This lets us show the
          * completion of the currently-incomplete optional arg first, if there is one.
          */
@@ -1110,7 +1110,7 @@ static sds addHintForArguments(sds hint, cliCommandArg *args, int numargs, char 
         }
 
         /* If the following non-optional arg has not been matched, add hints for
-         * any remaining optional args in this group.
+         * any remaining optional args in this group. 
          */
         if (j == numargs || args[j].matched == 0) {
             for (; i < j; i++) {
@@ -1138,7 +1138,7 @@ static sds addHintForRepeatedArgument(sds hint, cliCommandArg *arg) {
      * so we can safely clear its matched flags before printing it.
      */
     clearMatchedArgs(arg, 1);
-
+        
     if (hint[0] != '\0') {
         hint = sdscat(hint, " ");
     }
@@ -2166,7 +2166,7 @@ static sds cliFormatReplyJson(sds out, redisReply *r, int mode) {
                 out = cliFormatReplyJson(out,key,mode);
             } else {
                 /* According to JSON spec, JSON map keys must be strings,
-                 * and in RESP3, they can be other types.
+                 * and in RESP3, they can be other types. 
                  * The first one(cliFormatReplyJson) is to convert non string type to string
                  * The Second one(escapeJsonString) is to escape the converted string */
                 sds keystr = cliFormatReplyJson(sdsempty(),key,mode);
@@ -2302,8 +2302,8 @@ static int cliReadReply(int output_raw_strings) {
             config.cluster_send_asking = 1;
         }
         cliRefreshPrompt();
-    } else if (!config.interactive && config.set_errcode &&
-        reply->type == REDIS_REPLY_ERROR)
+    } else if (!config.interactive && config.set_errcode && 
+        reply->type == REDIS_REPLY_ERROR) 
     {
         fprintf(stderr,"%s\n",reply->str);
         exit(1);
@@ -2525,15 +2525,15 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
             }
 
             /* Store database number when SELECT was successfully executed. */
-            if (!strcasecmp(command,"select") && argc == 2 &&
-                config.last_cmd_type != REDIS_REPLY_ERROR)
+            if (!strcasecmp(command,"select") && argc == 2 &&) 
+                config.last_cmd_type != REDIS_REPLY_ERROR)) 
             {
                 config.conn_info.input_dbnum = config.dbnum = atoi(argv[1]);
                 cliRefreshPrompt();
             } else if (!strcasecmp(command,"auth") && (argc == 2 || argc == 3)) {
                 cliSelect();
             } else if (!strcasecmp(command,"multi") && argc == 1 &&
-                config.last_cmd_type != REDIS_REPLY_ERROR)
+                config.last_cmd_type != REDIS_REPLY_ERROR) 
             {
                 config.in_multi = 1;
                 config.pre_multi_dbnum = config.dbnum;
@@ -2546,8 +2546,8 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
                     config.conn_info.input_dbnum = config.dbnum = config.pre_multi_dbnum;
                 }
                 cliRefreshPrompt();
-            } else if (!strcasecmp(command,"discard") && argc == 1 &&
-                config.last_cmd_type != REDIS_REPLY_ERROR)
+            } else if (!strcasecmp(command,"discard") && argc == 1 && 
+                config.last_cmd_type != REDIS_REPLY_ERROR) 
             {
                 config.in_multi = 0;
                 config.conn_info.input_dbnum = config.dbnum = config.pre_multi_dbnum;
@@ -2959,7 +2959,7 @@ static int parseOptions(int argc, char **argv) {
         fprintf(stderr,"Option --functions-rdb and --rdb are mutually exclusive.\n");
         exit(1);
     }
-
+ 
     if (config.stdin_lastarg && config.stdin_tag_arg) {
         fprintf(stderr, "Options -x and -X are mutually exclusive.\n");
         exit(1);
@@ -7864,7 +7864,7 @@ static int clusterManagerCommandImport(int argc, char **argv) {
                 src_port, src_ctx->errstr);
         goto cleanup;
     }
-    // Auth for the source node.
+    // Auth for the source node. 
     char *from_user = config.cluster_manager_command.from_user;
     char *from_pass = config.cluster_manager_command.from_pass;
     if (cliAuth(src_ctx, from_user, from_pass) == REDIS_ERR) {
@@ -7914,7 +7914,7 @@ static int clusterManagerCommandImport(int argc, char **argv) {
     cmdfmt = sdsnew("MIGRATE %s %d %s %d %d");
     if (config.conn_info.auth) {
         if (config.conn_info.user) {
-            cmdfmt = sdscatfmt(cmdfmt," AUTH2 %s %s", config.conn_info.user, config.conn_info.auth);
+            cmdfmt = sdscatfmt(cmdfmt," AUTH2 %s %s", config.conn_info.user, config.conn_info.auth); 
         } else {
             cmdfmt = sdscatfmt(cmdfmt," AUTH %s", config.conn_info.auth);
         }
@@ -9716,7 +9716,7 @@ void testHintSuite(char *filename) {
         }
 
         /* Strip trailing spaces from hint - they don't matter. */
-        while (hint != NULL && sdslen(hint) > 0 && hint[sdslen(hint) - 1] == ' ') {
+        while (hint != NULL && sdslen(hint) > 0 && hint[sdslen(hint) - 1] == ' ') {            
             sdssetlen(hint, sdslen(hint) - 1);
             hint[sdslen(hint)] = '\0';
         }
@@ -9732,7 +9732,7 @@ void testHintSuite(char *filename) {
         sdsfree(hint);
     }
     fclose(fp);
-
+    
     printf("%s: %d/%d passed\n", fail == 0 ? "SUCCESS" : "FAILURE", pass, pass + fail);
     exit(fail);
 }


### PR DESCRIPTION
When using scan in redis-cli, the SCAN COUNT is fixed, which means the
full scan can take a long time if there are a lot of keys, this will let users specify
a bigger COUNT option.