### PR TITLE
Calc total allocations when using freeReplicationBacklogRefMemAsync

### DIFF
--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -215,9 +215,7 @@ void freeFunctionsAsync(functionsLibCtx *functions_lib_ctx) {
 
 /* Free replication backlog referencing buffer blocks and rax index. */
 void freeReplicationBacklogRefMemAsync(list *blocks, rax *index) {
-    if (listLength(blocks) > LAZYFREE_THRESHOLD ||
-        raxSize(index) > LAZYFREE_THRESHOLD)
-    {
+    if (listLength(blocks) + raxSize(index) > LAZYFREE_THRESHOLD) {
         atomicIncr(lazyfree_objects,listLength(blocks)+raxSize(index));
         bioCreateLazyFreeJob(lazyFreeReplicationBacklogRefMem,2,blocks,index);
     } else {


### PR DESCRIPTION
Without this fix, when the total is greater than LAZYFREE_THRESHOLD
but each is less than LAZYFREE_THRESHOLD, we will free these in a
foreground way which could be inefficient (unlink how it works with
other structures).

LAZYFREE_THRESHOLD is more tied to the number of allocations, compute
the total for comparison.