### PR TITLE
Tests: Do not save an RDB by default

### DIFF
--- a/tests/assets/default.conf
+++ b/tests/assets/default.conf
@@ -13,8 +13,9 @@ databases 16
 latency-monitor-threshold 1
 repl-diskless-sync-delay 0
 
+# Turn off RDB by default (to speedup tests)
 # Note the infrastructure in server.tcl uses a dict, we can't provide several save directives
-save 900 1
+save ''
 
 rdbcompression yes
 dbfilename dump.rdb
@@ -31,3 +32,6 @@ enable-debug-command yes
 enable-module-command yes
 
 propagation-error-behavior panic
+
+# Make sure shutdown doesn't fail if there's an initial AOFRW
+shutdown-on-sigterm force

--- a/tests/integration/psync2-master-restart.tcl
+++ b/tests/integration/psync2-master-restart.tcl
@@ -11,6 +11,9 @@ start_server {} {
 
     set sub_replica [srv -2 client]
 
+    # Make sure the server saves an RDB on shutdown
+    $master config set save "3600 1"
+
     # Because we will test partial resync later, we don’t want a timeout to cause
     # the master-replica disconnect, then the extra reconnections will break the
     # sync_partial_ok stat test

--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -355,6 +355,8 @@ start_server {} {
         set sync_partial [status $R($master_id) sync_partial_ok]
         set sync_partial_err [status $R($master_id) sync_partial_err]
         catch {
+            # Make sure the server saves an RDB on shutdown
+            $R($slave_id) config set save "900 1"
             $R($slave_id) config rewrite
             restart_server [expr {0-$slave_id}] true false
             set R($slave_id) [srv [expr {0-$slave_id}] client]

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -173,7 +173,7 @@ start_server {} {
 }
 
 test {client freed during loading} {
-    start_server [list overrides [list key-load-delay 50 loading-process-events-interval-bytes 1024 rdbcompression no]] {
+    start_server [list overrides [list key-load-delay 50 loading-process-events-interval-bytes 1024 rdbcompression no save "900 1"]] {
         # create a big rdb that will take long to load. it is important
         # for keys to be big since the server processes events only once in 2mb.
         # 100mb of rdb, 100k keys will load in more than 5 seconds
@@ -370,6 +370,9 @@ start_server [list overrides [list "dir" $server_path "dbfilename" "scriptbackup
 
 start_server {} {
     test "failed bgsave prevents writes" {
+        # Make sure the server saves an RDB on shutdown
+        r config set save "900 1"
+
         r config set rdb-key-save-delay 10000000
         populate 1000
         r set x x

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -362,18 +362,13 @@ start_server {tags {"introspection"}} {
             assert_match [r config get save] {save {100 100}}
         }
 
-        # First "save" keyword in default config file
-        start_server {config "default.conf"} {
-            assert_match [r config get save] {save {900 1}}
-        }
-
         # First "save" keyword appends default from config file
-        start_server {config "default.conf" args {--save 100 100}} {
+        start_server {config "default.conf" overrides {save {900 1}} args {--save 100 100}} {
             assert_match [r config get save] {save {900 1 100 100}}
         }
 
         # Empty "save" keyword resets all
-        start_server {config "default.conf" args {--save {}}} {
+        start_server {config "default.conf" overrides {save {900 1}} args {--save {}}} {
             assert_match [r config get save] {save {}}
         }
     } {} {external:skip}
@@ -789,7 +784,7 @@ start_server {config "minimal.conf" tags {"introspection external:skip"} overrid
 }
 
 test {config during loading} {
-    start_server [list overrides [list key-load-delay 50 loading-process-events-interval-bytes 1024 rdbcompression no]] {
+    start_server [list overrides [list key-load-delay 50 loading-process-events-interval-bytes 1024 rdbcompression no save "900 1"]] {
         # create a big rdb that will take long to load. it is important
         # for keys to be big since the server processes events only once in 2mb.
         # 100mb of rdb, 100k keys will load in more than 5 seconds

--- a/tests/unit/shutdown.tcl
+++ b/tests/unit/shutdown.tcl
@@ -30,7 +30,7 @@ start_server {tags {"shutdown external:skip"}} {
     }
 }
 
-start_server {tags {"shutdown external:skip"}} {
+start_server {tags {"shutdown external:skip"} overrides {save {900 1}}} {
     test {SHUTDOWN ABORT can cancel SIGTERM} {
         r debug pause-cron 1
         set pid [s process_id]
@@ -72,7 +72,7 @@ start_server {tags {"shutdown external:skip"}} {
     }
 }
 
-start_server {tags {"shutdown external:skip"}} {
+start_server {tags {"shutdown external:skip"} overrides {save {900 1}}} {
     set pid [s process_id]
     set dump_rdb [file join [lindex [r config get dir] 1] dump.rdb]
 


### PR DESCRIPTION
Handles https://github.com/redis/redis/pull/12013#discussion_r1161699047

In order to speed up tests, avoid saving an RDB (most notable on shutdown), except for tests that explicitly test the RDB mechanism

In addition, use `shutdown-on-sigterm force` to prevent shutdown from failing in case the server is in the middle of the initial AOFRW