### PR TITLE
Update dict.c dict_can_resize comment

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -52,9 +52,9 @@
  * for Redis, as we use copy-on-write and don't want to move too much memory
  * around when there is a child performing saving operations.
  *
- * Note that even when dict_can_resize is set to 0, not all resizes are
- * prevented: a hash table is still allowed to grow if the ratio between
- * the number of elements and the buckets > dict_force_resize_ratio. */
+ * Note that even when dict_can_resize is set to DICT_RESIZE_AVOID, not all
+ * resizes are prevented: a hash table is still allowed to grow if the ratio
+ * between the number of elements and the buckets > dict_force_resize_ratio. */
 static dictResizeEnable dict_can_resize = DICT_RESIZE_ENABLE;
 static unsigned int dict_force_resize_ratio = 5;
 


### PR DESCRIPTION
The comment for dict_can_resize in dict.c should be updated. Currently 0 means DICT_RESIZE_ENABLE, but should actually be DICT_RESIZE_AVOID or 1.