### PR TITLE
Adding missing test cases for getrange command

### DIFF
--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -438,6 +438,11 @@ start_server {tags {"string"}} {
         assert_equal "" [r getrange mykey 0 -1]
     }
 
+    test "GETRANGE against wrong key type" {
+        r lpush lkey1 "list"
+        assert_error {WRONGTYPE Operation against a key holding the wrong kind of value*} {r getrange lkey1 0 -1}
+    }
+
     test "GETRANGE against string value" {
         r set mykey "Hello World"
         assert_equal "Hell" [r getrange mykey 0 3]


### PR DESCRIPTION
#Minor test case addition.
Currently GETRANGE command does not have the test case coverage for the scenarios: An error is returned when key exists but of different type
Added  missing test cases for getrange command.