### PR TITLE
Tests: Do not save an RDB by default and add a SIGTERM default AOFRW test

### DIFF
--- a/tests/assets/default.conf
+++ b/tests/assets/default.conf
@@ -13,8 +13,9 @@ databases 16
 latency-monitor-threshold 1
 repl-diskless-sync-delay 0
 
+# Turn off RDB by default (to speedup tests)
 # Note the infrastructure in server.tcl uses a dict, we can't provide several save directives
-save 900 1
+save ''
 
 rdbcompression yes
 dbfilename dump.rdb
@@ -31,3 +32,6 @@ enable-debug-command yes
 enable-module-command yes
 
 propagation-error-behavior panic
+
+# Make sure shutdown doesn't fail if there's an initial AOFRW
+shutdown-on-sigterm force

--- a/tests/cluster/run.tcl
+++ b/tests/cluster/run.tcl
@@ -17,6 +17,7 @@ proc main {} {
         "appendonly yes"
         "enable-protected-configs yes"
         "enable-debug-command yes"
+        "save ''"
     }
     run_tests
     cleanup

--- a/tests/integration/psync2-master-restart.tcl
+++ b/tests/integration/psync2-master-restart.tcl
@@ -11,6 +11,9 @@ start_server {} {
 
     set sub_replica [srv -2 client]
 
+    # Make sure the server saves an RDB on shutdown
+    $master config set save "3600 1"
+
     # Because we will test partial resync later, we don’t want a timeout to cause
     # the master-replica disconnect, then the extra reconnections will break the
     # sync_partial_ok stat test

--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -355,6 +355,8 @@ start_server {} {
         set sync_partial [status $R($master_id) sync_partial_ok]
         set sync_partial_err [status $R($master_id) sync_partial_err]
         catch {
+            # Make sure the server saves an RDB on shutdown
+            $R($slave_id) config set save "900 1"
             $R($slave_id) config rewrite
             restart_server [expr {0-$slave_id}] true false
             set R($slave_id) [srv [expr {0-$slave_id}] client]

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -173,7 +173,7 @@ start_server {} {
 }
 
 test {client freed during loading} {
-    start_server [list overrides [list key-load-delay 50 loading-process-events-interval-bytes 1024 rdbcompression no]] {
+    start_server [list overrides [list key-load-delay 50 loading-process-events-interval-bytes 1024 rdbcompression no save "900 1"]] {
         # create a big rdb that will take long to load. it is important
         # for keys to be big since the server processes events only once in 2mb.
         # 100mb of rdb, 100k keys will load in more than 5 seconds
@@ -370,6 +370,9 @@ start_server [list overrides [list "dir" $server_path "dbfilename" "scriptbackup
 
 start_server {} {
     test "failed bgsave prevents writes" {
+        # Make sure the server saves an RDB on shutdown
+        r config set save "900 1"
+
         r config set rdb-key-save-delay 10000000
         populate 1000
         r set x x

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -17,7 +17,6 @@ proc main {} {
         "sentinel deny-scripts-reconfig no"
         "enable-protected-configs yes"
         "enable-debug-command yes"
-        "save ''"
     } "../tests/includes/sentinel.conf"
 
     spawn_instance redis $::redis_base_port $::instances_count {

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -17,11 +17,13 @@ proc main {} {
         "sentinel deny-scripts-reconfig no"
         "enable-protected-configs yes"
         "enable-debug-command yes"
+        "save ''"
     } "../tests/includes/sentinel.conf"
 
     spawn_instance redis $::redis_base_port $::instances_count {
         "enable-protected-configs yes"
         "enable-debug-command yes"
+        "save ''"
     }
     run_tests
     cleanup

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -362,18 +362,13 @@ start_server {tags {"introspection"}} {
             assert_match [r config get save] {save {100 100}}
         }
 
-        # First "save" keyword in default config file
-        start_server {config "default.conf"} {
-            assert_match [r config get save] {save {900 1}}
-        }
-
         # First "save" keyword appends default from config file
-        start_server {config "default.conf" args {--save 100 100}} {
+        start_server {config "default.conf" overrides {save {900 1}} args {--save 100 100}} {
             assert_match [r config get save] {save {900 1 100 100}}
         }
 
         # Empty "save" keyword resets all
-        start_server {config "default.conf" args {--save {}}} {
+        start_server {config "default.conf" overrides {save {900 1}} args {--save {}}} {
             assert_match [r config get save] {save {}}
         }
     } {} {external:skip}
@@ -789,7 +784,7 @@ start_server {config "minimal.conf" tags {"introspection external:skip"} overrid
 }
 
 test {config during loading} {
-    start_server [list overrides [list key-load-delay 50 loading-process-events-interval-bytes 1024 rdbcompression no]] {
+    start_server [list overrides [list key-load-delay 50 loading-process-events-interval-bytes 1024 rdbcompression no save "900 1"]] {
         # create a big rdb that will take long to load. it is important
         # for keys to be big since the server processes events only once in 2mb.
         # 100mb of rdb, 100k keys will load in more than 5 seconds

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -1,6 +1,6 @@
 set testmodule [file normalize tests/modules/misc.so]
 
-start_server {tags {"modules"}} {
+start_server {overrides {save {900 1}} tags {"modules"}} {
     r module load $testmodule
 
     test {test RM_Call} {

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -61,13 +61,13 @@ tags "modules" {
     # 7 == 0111 - use aux_save2 before and after key space with data
     test {modules are able to persist globals before and after} {
         set server_path [tmpdir "server.module-testrdb"]
-        start_server [list overrides [list loadmodule "$testmodule $test_case" "dir" $server_path] keep_persistence true] {
+        start_server [list overrides [list loadmodule "$testmodule $test_case" "dir" $server_path "save" "900 1"] keep_persistence true] {
             r testrdb.set.before global1
             r testrdb.set.after global2
             assert_equal "global1" [r testrdb.get.before]
             assert_equal "global2" [r testrdb.get.after]
         }
-        start_server [list overrides [list loadmodule "$testmodule $test_case" "dir" $server_path]] {
+        start_server [list overrides [list loadmodule "$testmodule $test_case" "dir" $server_path "save" "900 1"]] {
             assert_equal "global1" [r testrdb.get.before]
             assert_equal "global2" [r testrdb.get.after]
         }
@@ -80,11 +80,11 @@ tags "modules" {
     # 5 == 0101 - use aux_save2 after key space with data
     test {modules are able to persist globals just after} {
         set server_path [tmpdir "server.module-testrdb"]
-        start_server [list overrides [list loadmodule "$testmodule $test_case" "dir" $server_path] keep_persistence true] {
+        start_server [list overrides [list loadmodule "$testmodule $test_case" "dir" $server_path "save" "900 1"] keep_persistence true] {
             r testrdb.set.after global2
             assert_equal "global2" [r testrdb.get.after]
         }
-        start_server [list overrides [list loadmodule "$testmodule $test_case" "dir" $server_path]] {
+        start_server [list overrides [list loadmodule "$testmodule $test_case" "dir" $server_path "save" "900 1"]] {
             assert_equal "global2" [r testrdb.get.after]
         }
     }

--- a/tests/unit/shutdown.tcl
+++ b/tests/unit/shutdown.tcl
@@ -30,7 +30,7 @@ start_server {tags {"shutdown external:skip"}} {
     }
 }
 
-start_server {tags {"shutdown external:skip"}} {
+start_server {tags {"shutdown external:skip"} overrides {save {900 1}}} {
     test {SHUTDOWN ABORT can cancel SIGTERM} {
         r debug pause-cron 1
         set pid [s process_id]
@@ -72,7 +72,7 @@ start_server {tags {"shutdown external:skip"}} {
     }
 }
 
-start_server {tags {"shutdown external:skip"}} {
+start_server {tags {"shutdown external:skip"} overrides {save {900 1}}} {
     set pid [s process_id]
     set dump_rdb [file join [lindex [r config get dir] 1] dump.rdb]
 

--- a/tests/unit/shutdown.tcl
+++ b/tests/unit/shutdown.tcl
@@ -48,7 +48,7 @@ start_server {tags {"shutdown external:skip"} overrides {save {900 1}}} {
         }
         # It will cost 2s (20 * 100ms) to dump rdb
         r config set rdb-key-save-delay 100000
-        
+
         set pid [s process_id]
         set temp_rdb [file join [lindex [r config get dir] 1] temp-${pid}.rdb]
 
@@ -105,5 +105,29 @@ start_server {tags {"shutdown external:skip"} overrides {save {900 1}}} {
     }
     test {Clean up rdb same named folder} {
         exec rm -r $dump_rdb
+    }
+}
+
+
+start_server {tags {"shutdown external:skip"} overrides {appendonly no}} {
+    test {SHUTDOWN SIGTERM will abort if there's an initial AOFRW - default} {
+        r config set shutdown-on-sigterm default
+        r config set rdb-key-save-delay 10000000
+        for {set i 0} {$i < 10} {incr i} {
+            r set $i $i
+        }
+
+        r config set appendonly yes
+        wait_for_condition 1000 10 {
+            [s aof_rewrite_in_progress] eq 1
+        } else {
+            fail "aof rewrite did not start in time"
+        }
+
+        set pid [s process_id]
+        exec kill -SIGTERM $pid
+        wait_for_log_messages 0 {"*Writing initial AOF, can't exit*"} 0 1000 10
+
+        r config set shutdown-on-sigterm force
     }
 }


### PR DESCRIPTION
In order to speed up tests, avoid saving an RDB (mostly notable on shutdown),
except for tests that explicitly test the RDB mechanism

In addition, use `shutdown-on-sigterm force` to prevetn shutdown from failing
in case the server is in the middle of the initial AOFRW

Also a a test that checks that the `shutdown-on-sigterm default` is to refuse
shutdown if there's an initial AOFRW

Base on #12049 and refresh it