### PR TITLE
Report AOF failure status to systemd in shutdown

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4330,6 +4330,8 @@ int finishShutdown(void) {
                 serverLog(LL_WARNING, "Writing initial AOF. Exit anyway.");
             } else {
                 serverLog(LL_WARNING, "Writing initial AOF, can't exit.");
+                if (server.supervised_mode == SUPERVISED_SYSTEMD)
+                    redisCommunicateSystemd("STATUS=Writing initial AOF, can't exit.\n");
                 goto error;
             }
         }


### PR DESCRIPTION
Since we do report the RDB error in below:
```
serverLog(LL_WARNING,"Error trying to save the DB, can't exit.");
if (server.supervised_mode == SUPERVISED_SYSTEMD)
    redisCommunicateSystemd("STATUS=Error trying to save the DB, can't exit.\n");
goto error;
```

This may be an overlook in #6052