### PR TITLE
Misuse of bool in redis

### DIFF
--- a/src/latency.c
+++ b/src/latency.c
@@ -34,6 +34,7 @@
  */
 
 #include "server.h"
+#include "hdr_histogram.h"
 
 /* Dictionary type for latency events. */
 int dictStringKeyCompare(dict *d, const void *key1, const void *key2) {

--- a/src/module.c
+++ b/src/module.c
@@ -58,6 +58,7 @@
 #include "monotonic.h"
 #include "script.h"
 #include "call_reply.h"
+#include "hdr_histogram.h"
 #include <dlfcn.h>
 #include <sys/stat.h>
 #include <sys/wait.h>

--- a/src/script.c
+++ b/src/script.c
@@ -130,7 +130,7 @@ uint64_t scriptFlagsToCmdFlags(uint64_t cmd_flags, uint64_t script_flags) {
 /* Prepare the given run ctx for execution */
 int scriptPrepareForRun(scriptRunCtx *run_ctx, client *engine_client, client *caller, const char *funcname, uint64_t script_flags, int ro) {
     serverAssert(!curr_run_ctx);
-    bool client_allow_oom = caller->flags & CLIENT_ALLOW_OOM;
+    int client_allow_oom = caller->flags & CLIENT_ALLOW_OOM;
 
     int running_stale = server.masterhost &&
             server.repl_state != REPL_STATE_CONNECTED &&

--- a/src/script.c
+++ b/src/script.c
@@ -130,7 +130,7 @@ uint64_t scriptFlagsToCmdFlags(uint64_t cmd_flags, uint64_t script_flags) {
 /* Prepare the given run ctx for execution */
 int scriptPrepareForRun(scriptRunCtx *run_ctx, client *engine_client, client *caller, const char *funcname, uint64_t script_flags, int ro) {
     serverAssert(!curr_run_ctx);
-    int client_allow_oom = caller->flags & CLIENT_ALLOW_OOM;
+    int client_allow_oom = !!(caller->flags & CLIENT_ALLOW_OOM);
 
     int running_stale = server.masterhost &&
             server.repl_state != REPL_STATE_CONNECTED &&

--- a/src/server.c
+++ b/src/server.c
@@ -36,6 +36,7 @@
 #include "atomicvar.h"
 #include "mt19937-64.h"
 #include "functions.h"
+#include "hdr_histogram.h"
 #include "syscheck.h"
 
 #include <time.h>

--- a/src/server.h
+++ b/src/server.h
@@ -53,7 +53,6 @@
 #include <sys/socket.h>
 #include <lua.h>
 #include <signal.h>
-#include "hdr_histogram.h"
 
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>
@@ -91,6 +90,8 @@ typedef struct redisObject robj;
 #include "sha1.h"
 #include "endianconv.h"
 #include "crc64.h"
+
+struct hdr_histogram;
 
 /* helpers */
 #define numElements(x) (sizeof(x)/sizeof((x)[0]))


### PR DESCRIPTION
We currently do not allow the use of bool type in redis project.

We didn't catch it in script.c because we included hdr_histogram.h in server.h

Removing it (but still having it in some c files) reducing the chance to miss the usage of bool type in the future and catch it in compiling stage.

It also removes the dependency on hdr_histogram for every unit that includes server.h