### PR TITLE
Drop replication backlog after restarting with expired if RDB doesn't have replication info

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6701,6 +6701,7 @@ void loadDataFromDisk(void) {
         rdbSaveInfo rsi = RDB_SAVE_INFO_INIT;
         errno = 0; /* Prevent a stale value from affecting error checking */
         int rdb_flags = RDBFLAGS_NONE;
+        long long master_rsi_repl_offset = 0;
         if (iAmMaster()) {
             /* Master may delete expired keys when loading, we should
              * propagate expire to replication backlog. */
@@ -6735,6 +6736,7 @@ void loadDataFromDisk(void) {
                     memcpy(server.replid2,rsi.repl_id,sizeof(server.replid));
                     server.second_replid_offset = rsi.repl_offset+1;
                     /* Rebase master_repl_offset from rsi.repl_offset. */
+                    master_rsi_repl_offset = rsi.repl_offset;
                     server.master_repl_offset += rsi.repl_offset;
                     serverAssert(server.repl_backlog);
                     server.repl_backlog->offset = server.master_repl_offset -
@@ -6753,7 +6755,7 @@ void loadDataFromDisk(void) {
          * if RDB doesn't have replication info or there is no rdb, it is not
          * possible to support partial resynchronization, to avoid extra memory
          * of replication backlog, we drop it. */
-        if (server.master_repl_offset == 0 && server.repl_backlog)
+        if (master_rsi_repl_offset == 0 && server.repl_backlog)
             freeReplicationBacklog();
     }
 }

--- a/tests/integration/psync2-master-restart.tcl
+++ b/tests/integration/psync2-master-restart.tcl
@@ -183,3 +183,16 @@ start_server {} {
         assert {$digest eq [$sub_replica debug digest]}
     }
 }}}
+
+start_server {tags {"psync2 external:skip"}} {
+    test {Drop replication backlog after restarting with expired if RDB doesn't have replication info} {
+        r debug set-active-expire 0
+        r set k v px 10
+        after 20
+        r save
+
+        restart_server 0 true false
+        assert_equal 0 [s repl_backlog_active]
+        assert_equal 0 [s repl_backlog_histlen]
+    }
+}


### PR DESCRIPTION
After #8015, When restarting a mater instance, before loading the rdb, we create the repl backlog in advance to ensure that any keys that have expired in the meantime are also propagated to the replication.
After #9166, We will determine whether `server.master_repl_offset` is 0 after loading RDB to decide whether to release the unnecessary repl baklog.
The problem is that if we restart an instance without any replication and have expired keys, the repl backlog will be created and will not be released after loading the RDB until times out (default server.repl_backlog_time_limit).

## Solutio
Should use `repl_offset` from RDB info to determine if need to release the repl backlog, as the comment `if RDB doesn't have replication info or there is no rdb, it is not possible to support partial resynchronization`.
