### PR TITLE
optimize spopwithcount propagation

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -608,7 +608,7 @@ void saddCommand(client *c) {
 
     set = lookupKeyWrite(c->db,c->argv[1]);
     if (checkType(c,set,OBJ_SET)) return;
-
+    
     if (set == NULL) {
         set = setTypeCreate(c->argv[2]->ptr, c->argc - 2);
         dbAdd(c->db,c->argv[1],set);
@@ -888,6 +888,7 @@ void spopWithCountCommand(client *c) {
      * set). Then we return the elements left in the original set and
      * release it. */
         robj *newset = NULL;
+
         /* Create a new set with just the remaining elements. */
         if (set->encoding == OBJ_ENCODING_LISTPACK) {
             /* Specialized case for listpack. Traverse it only once. */
@@ -1485,7 +1486,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
     int encoding;
     int j, cardinality = 0;
     int diff_algo = 1;
-    int sameset = 0;
+    int sameset = 0; 
 
     for (j = 0; j < setnum; j++) {
         robj *setobj = lookupKeyRead(c->db, setkeys[j]);
@@ -1499,7 +1500,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
         }
         sets[j] = setobj;
         if (j > 0 && sets[0] == sets[j]) {
-            sameset = 1;
+            sameset = 1; 
         }
     }
 

--- a/tests/integration/replication-4.tcl
+++ b/tests/integration/replication-4.tcl
@@ -204,6 +204,29 @@ start_server {tags {"repl external:skip"}} {
             assert {[$master dbsize] > 0}
         }
 
+        test {spopwithcount rewrite srem command} {
+            $master del myset
+
+            set content {}
+            for {set j 0} {$j < 4000} {} {
+                lappend content [incr j]
+            }
+            $master sadd myset {*}$content
+            $master spop myset 1023
+            $master spop myset 1024
+            $master spop myset 1025
+
+            assert_match 928 [$master scard myset]
+            assert_match {*calls=3,*} [cmdrstat spop $master]
+
+            wait_for_condition 500 100 {
+                 [status $slave master_repl_offset] == [status $master master_repl_offset]
+            } else {
+                fail "SREM replication inconsistency."
+            }
+            assert_match {*calls=4,*} [cmdrstat srem $slave]
+        }
+
         test {Replication of SPOP command -- alsoPropagate() API} {
             $master del myset
             set size [expr 1+[randomInt 100]]

--- a/tests/integration/replication-4.tcl
+++ b/tests/integration/replication-4.tcl
@@ -219,12 +219,13 @@ start_server {tags {"repl external:skip"}} {
             assert_match 928 [$master scard myset]
             assert_match {*calls=3,*} [cmdrstat spop $master]
 
-            wait_for_condition 500 100 {
+            wait_for_condition 50 100 {
                  [status $slave master_repl_offset] == [status $master master_repl_offset]
             } else {
                 fail "SREM replication inconsistency."
             }
             assert_match {*calls=4,*} [cmdrstat srem $slave]
+            assert_match 928 [$slave scard myset]
         }
 
         test {Replication of SPOP command -- alsoPropagate() API} {


### PR DESCRIPTION
A single SPOP with command with count argument resulted in many SPOP commands being propagated to the replica.
This is inefficient because the key name is repeated many times, and is also being looked-up many times.
also it results in high QPS metrics on the replica.
To solve that, we flush batches of 1024 fields per SPOP command.

Fix #12053.