### PR TITLE
Minor change around the req-res validator, skip sentinel commands

### DIFF
--- a/src/logreqres.c
+++ b/src/logreqres.c
@@ -186,7 +186,8 @@ size_t reqresAppendRequest(client *c) {
 
     /* Ignore commands that have streaming non-standard response */
     sds cmd = argv[0]->ptr;
-    if (!strcasecmp(cmd,"sync") ||
+    if (!strcasecmp(cmd,"debug") || /* because of DEBUG SEGFAULT */
+        !strcasecmp(cmd,"sync") ||
         !strcasecmp(cmd,"psync") ||
         !strcasecmp(cmd,"monitor") ||
         !strcasecmp(cmd,"subscribe") ||
@@ -194,11 +195,7 @@ size_t reqresAppendRequest(client *c) {
         !strcasecmp(cmd,"ssubscribe") ||
         !strcasecmp(cmd,"sunsubscribe") ||
         !strcasecmp(cmd,"psubscribe") ||
-        !strcasecmp(cmd,"punsubscribe") ||
-        !strcasecmp(cmd,"debug") ||
-        !strcasecmp(cmd,"pfdebug") ||
-        !strcasecmp(cmd,"lolwut") ||
-        (!strcasecmp(cmd,"sentinel") && argc > 1 && !strcasecmp(argv[1]->ptr,"debug")))
+        !strcasecmp(cmd,"punsubscribe"))
     {
         return 0;
     }

--- a/utils/req-res-log-validator.py
+++ b/utils/req-res-log-validator.py
@@ -64,6 +64,11 @@ IGNORED_COMMANDS = {
     "sentinel|pending-scripts",
     "sentinel|reset",
     "sentinel|simulate-failure",
+    "sentinel|help",
+    "sentinel|masters",
+    "sentinel|myid",
+    "sentinel|sentinels",
+    "sentinel|slaves",
 }
 
 class Request(object):

--- a/utils/req-res-log-validator.py
+++ b/utils/req-res-log-validator.py
@@ -45,7 +45,7 @@ Future validations:
 
 IGNORED_COMMANDS = [
     # Commands that don't work in a req-res manner (see logreqres.c)
-    "debug",  # becuase of DEBUG SEGFAULT
+    "debug",  # because of DEBUG SEGFAULT
     "sync",
     "psync",
     "monitor",

--- a/utils/req-res-log-validator.py
+++ b/utils/req-res-log-validator.py
@@ -43,7 +43,7 @@ Future validations:
 1. Fail the script if one or more of the branches of the reply schema (e.g. oneOf, anyOf) was not hit.
 """
 
-IGNORED_COMMANDS = [
+IGNORED_COMMANDS = {
     # Commands that don't work in a req-res manner (see logreqres.c)
     "debug",  # because of DEBUG SEGFAULT
     "sync",
@@ -64,7 +64,7 @@ IGNORED_COMMANDS = [
     "sentinel|pending-scripts",
     "sentinel|reset",
     "sentinel|simulate-failure",
-]
+}
 
 class Request(object):
     """
@@ -221,6 +221,9 @@ def process_file(docs, path):
             command_counter[req.command] = command_counter.get(req.command, 0) + 1
 
             if res.error or res.queued:
+                continue
+
+            if req.command in IGNORED_COMMANDS:
                 continue
 
             try:

--- a/utils/req-res-log-validator.py
+++ b/utils/req-res-log-validator.py
@@ -44,6 +44,8 @@ Future validations:
 """
 
 IGNORED_COMMANDS = [
+    # Commands that don't work in a req-res manner (see logreqres.c)
+    "debug",  # becuase of DEBUG SEGFAULT
     "sync",
     "psync",
     "monitor",
@@ -53,11 +55,16 @@ IGNORED_COMMANDS = [
     "sunsubscribe",
     "psubscribe",
     "punsubscribe",
-    "debug",
+    # Commands to which we decided not write a reply schema
     "pfdebug",
     "lolwut",
+    # TODO: write a reply schema for the following commands
+    "sentinel|debug",
+    "sentinel|info-cache",
+    "sentinel|pending-scripts",
+    "sentinel|reset",
+    "sentinel|simulate-failure",
 ]
-
 
 class Request(object):
     """
@@ -286,16 +293,6 @@ if __name__ == '__main__':
 
     fetch_schemas(args.cli, args.port, redis_args, docs)
 
-    missing_schema = [k for k, v in docs.items()
-                      if "reply_schema" not in v and k not in IGNORED_COMMANDS]
-    if missing_schema:
-        print("WARNING! The following commands are missing a reply_schema:")
-        for k in sorted(missing_schema):
-            print(f"  {k}")
-        if args.fail_missing_reply_schemas:
-            print("ERROR! at least one command does not have a reply_schema")
-            sys.exit(1)
-
     # Fetch schemas from a sentinel
     print('Starting Redis sentinel')
 
@@ -306,6 +303,16 @@ if __name__ == '__main__':
     sentinel_args = [args.server, config_file, '--port', str(args.port), "--sentinel"]
     fetch_schemas(args.cli, args.port, sentinel_args, docs)
     os.unlink(config_file)
+
+    missing_schema = [k for k, v in docs.items()
+                      if "reply_schema" not in v and k not in IGNORED_COMMANDS]
+    if missing_schema:
+        print("WARNING! The following commands are missing a reply_schema:")
+        for k in sorted(missing_schema):
+            print(f"  {k}")
+        if args.fail_missing_reply_schemas:
+            print("ERROR! at least one command does not have a reply_schema")
+            sys.exit(1)
 
     start = time.time()
 


### PR DESCRIPTION
1. Check for missing schema only after the docs contain sentinel commands
2. The ignore-list in the C file contain only commands that cannot have a reply schema. The one in the py file is an extension of that list
3. Temp: skipsentinel commands don't have a schema or test coverage yet, add them to the py list

Solve CI error introduced by #12018