### PR TITLE
Implement a new Redis policy to limit the valid duration of auth sessions #12096

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -158,6 +158,9 @@ tcp-backlog 511
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout 0
 
+# Close the connection if a client does not re-authenticate for N seconds (0 to disable)
+max-auth-age 0
+
 # TCP keepalive.
 #
 # If non-zero, use SO_KEEPALIVE to send TCP ACKs to clients in absence

--- a/src/acl.c
+++ b/src/acl.c
@@ -1484,6 +1484,7 @@ int ACLAuthenticateUser(client *c, robj *username, robj *password, robj **err) {
     if (result == AUTH_NOT_HANDLED) {
         result = checkPasswordBasedAuth(c, username, password);
     }
+    if (result == AUTH_OK) c->last_auth_time = server.unixtime;
     return result;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -3143,6 +3143,7 @@ standardConfig static_configs[] = {
     createIntConfig("maxmemory-samples", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.maxmemory_samples, 5, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("maxmemory-eviction-tenacity", NULL, MODIFIABLE_CONFIG, 0, 100, server.maxmemory_eviction_tenacity, 10, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.maxidletime, 0, INTEGER_CONFIG, NULL, NULL), /* Default client timeout: infinite */
+    createIntConfig("max-auth-age", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.max_auth_age, 0, INTEGER_CONFIG, NULL, NULL), /* Default client reauth timeout: infinite */
     createIntConfig("replica-announce-port", "slave-announce-port", MODIFIABLE_CONFIG, 0, 65535, server.slave_announce_port, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("tcp-backlog", NULL, IMMUTABLE_CONFIG, 0, INT_MAX, server.tcp_backlog, 511, INTEGER_CONFIG, NULL, NULL), /* TCP listen backlog. */
     createIntConfig("cluster-port", NULL, IMMUTABLE_CONFIG, 0, 65535, server.cluster_port, 0, INTEGER_CONFIG, NULL, NULL),    

--- a/src/networking.c
+++ b/src/networking.c
@@ -173,9 +173,11 @@ client *createClient(connection *conn) {
     c->flags = 0;
     c->slot = -1;
     c->ctime = c->lastinteraction = server.unixtime;
-    /* Initializes the last_auth_time to the creation time to simplify the
-     * max-auth-age enforcement. The last_auth_time field will be properly
-     * updated when the client is successfully authenticated */
+    /* Initialize the last_auth_time to the creation time to simplify the
+     * max-auth-age enforcement. Users without passwords are implicitly
+     * authenticated, so this approach streamlines the process. For users
+     * with passwords, the last_auth_time field will be updated accordingly
+     * when the client is successfully authenticated. */
     c->last_auth_time = c->ctime;
     c->duration = 0;
     clientSetDefaultAuth(c);

--- a/src/server.h
+++ b/src/server.h
@@ -1180,6 +1180,7 @@ typedef struct client {
     size_t sentlen;         /* Amount of bytes already sent in the current
                                buffer or object being sent. */
     time_t ctime;           /* Client creation time. */
+    time_t last_auth_time;  /* Client last authenticated time */
     long duration;          /* Current command duration. Used for measuring latency of blocking/non-blocking cmds */
     int slot;               /* The slot the client is executing against. Set to -1 if no slot is being used */
     dictEntry *cur_script;  /* Cached pointer to the dictEntry of the script being executed. */
@@ -1706,6 +1707,8 @@ struct redisServer {
     /* Configuration */
     int verbosity;                  /* Loglevel in redis.conf */
     int maxidletime;                /* Client timeout in seconds */
+    int max_auth_age;               /* max duration in seconds a client can remain connected before requiring
+                                       re-authentication for security purposes. */
     int tcpkeepalive;               /* Set SO_KEEPALIVE if non-zero. */
     int active_expire_enabled;      /* Can be disabled for testing purposes. */
     int active_expire_effort;       /* From 1 (default) to 10, active effort. */
@@ -2626,6 +2629,7 @@ void protectClient(client *c);
 void unprotectClient(client *c);
 void initThreadedIO(void);
 client *lookupClientByID(uint64_t id);
+int userAuthRequired (user *u);
 int authRequired(client *c);
 void putClientInPendingWriteQueue(client *c);
 


### PR DESCRIPTION
This update introduces a new Redis config named "max-auth-age". When enabled, it will reset the authenticated state for clients that need to authenticate with Redis. However, this policy does not apply to clients using the default user account or any user account without password requirements.