### PR TITLE
minor optimization for slowlog get

### DIFF
--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -198,7 +198,7 @@ NULL
             for (j = 0; j < se->argc; j++)
                 addReplyBulk(c,se->argv[j]);
             addReplyBulkCBuffer(c,se->peerid,sdslen(se->peerid));
-            addReplyBulkCBuffer(c, se->cname, sdslen(se->cname));
+            addReplyBulkCBuffer(c,se->cname,sdslen(se->cname));
         }
     } else {
         addReplySubcommandSyntaxError(c);

--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -162,9 +162,8 @@ NULL
     } else if ((c->argc == 2 || c->argc == 3) &&
                !strcasecmp(c->argv[1]->ptr,"get"))
     {
-        long count = 10, sent = 0;
+        long count = 10;
         listIter li;
-        void *totentries;
         listNode *ln;
         slowlogEntry *se;
 
@@ -181,11 +180,15 @@ NULL
             }
         }
 
-        listRewind(server.slowlog,&li);
-        totentries = addReplyDeferredLen(c);
-        while(count-- && (ln = listNext(&li))) {
+        if (count > (long)listLength(server.slowlog)) {
+            count = listLength(server.slowlog);
+        }
+        addReplyArrayLen(c, count);
+        listRewind(server.slowlog, &li);
+        while (count--) {
             int j;
 
+            ln = listNext(&li);
             se = ln->value;
             addReplyArrayLen(c,6);
             addReplyLongLong(c,se->id);
@@ -195,10 +198,8 @@ NULL
             for (j = 0; j < se->argc; j++)
                 addReplyBulk(c,se->argv[j]);
             addReplyBulkCBuffer(c,se->peerid,sdslen(se->peerid));
-            addReplyBulkCBuffer(c,se->cname,sdslen(se->cname));
-            sent++;
+            addReplyBulkCBuffer(c, se->cname, sdslen(se->cname));
         }
-        setDeferredArrayLen(c,totentries,sent);
     } else {
         addReplySubcommandSyntaxError(c);
     }

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -24,8 +24,11 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
     } {10}
 
     test {SLOWLOG - GET optional argument to limit output len works} {
-        llength [r slowlog get 5]
-    } {5}
+        
+        assert_equal 5  [llength [r slowlog get 5]]
+        assert_equal 10 [llength [r slowlog get -1]]
+        assert_equal 10 [llength [r slowlog get 20]]
+    }
 
     test {SLOWLOG - RESET subcommand works} {
         r config set slowlog-log-slower-than 100000
@@ -39,7 +42,7 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         set e [lindex [r slowlog get] 0]
         assert_equal [llength $e] 6
         if {!$::external} {
-            assert_equal [lindex $e 0] 105
+            assert_equal [lindex $e 0] 107
         }
         assert_equal [expr {[lindex $e 2] > 100000}] 1
         assert_equal [lindex $e 3] {debug sleep 0.2}


### PR DESCRIPTION
We can always know the array length of the response, so there is no need to use `addReplyDeferredLen` which may  introduce some additional overheads.