### PR TITLE
Update old Debian CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
   build-debian-old:
     runs-on: ubuntu-latest
-    container: debian:oldoldstable
+    container: debian:buster
     steps:
     - uses: actions/checkout@v3
     - name: make


### PR DESCRIPTION
We were using `oldstable` Debian as a CI with an older toolchain, but that image is now offline so move to debian:buster

```
E: Failed to fetch http://security.debian.org/debian-security/dists/oldoldstable/updates/main/binary-amd64/Packages 404 Not Found [IP: 151.101.2.132 80]
```