### PR TITLE
multi.tcl: reset readraw at the end of the test

### DIFF
--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -891,7 +891,7 @@ start_server {tags {"multi"}} {
         set res [r read]
         assert_equal $res "+OK"
         set res [r read]
-        r readraw 1
+        r readraw 0
         set _ $res
     } {*CONFIG SET failed*}
     

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -897,8 +897,8 @@ start_server {tags {"multi"}} {
     
     test "Flushall while watching several keys by one client" {
         r flushall
-        r mset a a b b
-        r watch b a
+        r mset a{t} a b{t} b
+        r watch b{t} a{t}
         r flushall
         r ping
      }


### PR DESCRIPTION
1. reset the readraw mode after a test that uses it. undetected since the
  only test after that on the same server didn't read any replies.
2. fix a cross slot issue that was undetected in cluster mode because
  readraw doesn't throw exceptions on errors.