### PR TITLE
Pause cron to prevent premature shrinking in querybuf test

### DIFF
--- a/tests/unit/querybuf.tcl
+++ b/tests/unit/querybuf.tcl
@@ -70,7 +70,7 @@ start_server {tags {"querybuf slow"}} {
         # Validate qbuf shrunk but isn't 0 since we maintain room based on latest peak
         assert {[client_query_buffer test_client] > 0 && [client_query_buffer test_client] < $orig_test_client_qbuf}
         $rd close
-    }
+    } {0} {needs:debug}
 
     test "query buffer resized correctly with fat argv" {
         set rd [redis_client]


### PR DESCRIPTION
Tests occasionally fail since #12000:
```
*** [err]: query buffer resized correctly when not idle in tests/unit/querybuf.tcl
Expected 0 > 32768 (context: type eval line 11 cmd {assert {$orig_test_client_qbuf > 32768}} proc ::test)

*** [err]: query buffer resized correctly with fat argv in tests/unit/querybuf.tcl
query buffer should not be resized when client idle time smaller than 2s
```

The reason may be because we set hz to 100, querybuf shrinks before we count
client_query_buffer. We avoid this problem by setting pause-cron to 1.