### PR TITLE
Warning message when servers are running in WSL without the cluster-announce-ip 

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6152,8 +6152,10 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info,
         "# Cluster\r\n"
-        "cluster_enabled:%d\r\n",
-        server.cluster_enabled);
+        "cluster_enabled:%d\r\n"
+        "cluster_announce_ip:%s\r\n",
+        server.cluster_enabled,
+        server.cluster_announce_ip ? server.cluster_announce_ip : "0");
     }
 
     /* Key space */


### PR DESCRIPTION
We came across a similar issue to #11763 but we're using WSL2 instead. When creating a cluster with 3 nodes binding to the same IP (127.0.0.2) and different ports (6371, 6372, 6373) the redis-cli gets stuck "Waiting for the cluster to join":

![waiting](https://user-images.githubusercontent.com/47857786/236242694-097b0892-9f43-459a-9294-9acd1f115259.png)

This happens with every IP in the loopback network except for 127.0.0.1 because in WSL2, by default, the only loopback address accessible is 127.0.0.1 which is discussed here: https://github.com/microsoft/WSL/issues/4349 .

This issue can be solved by adding the cluster-announce-ip configuration to the server nodes but we thought it would be beneficial to show a warning when this happens so newcomers can know what is happening instead of staying in a waiting loop forever.

![warning](https://user-images.githubusercontent.com/47857786/236238859-a00c4496-b001-4cbc-986d-669d9d2633c7.png)

We think this solution can be extended to docker and other containers as well.
