### PR TITLE
WIP : Adding multiple element support for SMOVE command

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -7837,7 +7837,9 @@ struct COMMAND_ARG SMISMEMBER_Args[] = {
 
 #ifndef SKIP_CMD_HISTORY_TABLE
 /* SMOVE history */
-#define SMOVE_History NULL
+commandHistory SMOVE_History[] = {
+{"7.2.0","Accepts multiple `member` arguments."},
+};
 #endif
 
 #ifndef SKIP_CMD_TIPS_TABLE
@@ -7856,7 +7858,7 @@ keySpec SMOVE_Keyspecs[2] = {
 struct COMMAND_ARG SMOVE_Args[] = {
 {MAKE_ARG("source",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("destination",ARG_TYPE_KEY,1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("member",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("member",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,0,NULL)},
 };
 
 /********** SPOP ********************/
@@ -10741,7 +10743,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("sismember","Determines whether a member belongs to a set.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"set",COMMAND_GROUP_SET,SISMEMBER_History,0,SISMEMBER_Tips,0,sismemberCommand,3,CMD_READONLY|CMD_FAST,ACL_CATEGORY_SET,SISMEMBER_Keyspecs,1,NULL,2),.args=SISMEMBER_Args},
 {MAKE_CMD("smembers","Returns all members of a set.","O(N) where N is the set cardinality.","1.0.0",CMD_DOC_NONE,NULL,NULL,"set",COMMAND_GROUP_SET,SMEMBERS_History,0,SMEMBERS_Tips,1,sinterCommand,2,CMD_READONLY,ACL_CATEGORY_SET,SMEMBERS_Keyspecs,1,NULL,1),.args=SMEMBERS_Args},
 {MAKE_CMD("smismember","Determines whether multiple members belong to a set.","O(N) where N is the number of elements being checked for membership","6.2.0",CMD_DOC_NONE,NULL,NULL,"set",COMMAND_GROUP_SET,SMISMEMBER_History,0,SMISMEMBER_Tips,0,smismemberCommand,-3,CMD_READONLY|CMD_FAST,ACL_CATEGORY_SET,SMISMEMBER_Keyspecs,1,NULL,2),.args=SMISMEMBER_Args},
-{MAKE_CMD("smove","Moves a member from one set to another.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"set",COMMAND_GROUP_SET,SMOVE_History,0,SMOVE_Tips,0,smoveCommand,4,CMD_WRITE|CMD_FAST,ACL_CATEGORY_SET,SMOVE_Keyspecs,2,NULL,3),.args=SMOVE_Args},
+{MAKE_CMD("smove","Moves one or more member from one set to another.Deletes the source set if the last member was moved.","O(N) where N is the number of members to be moved.","1.0.0",CMD_DOC_NONE,NULL,NULL,"set",COMMAND_GROUP_SET,SMOVE_History,1,SMOVE_Tips,0,smoveCommand,-4,CMD_WRITE|CMD_FAST,ACL_CATEGORY_SET,SMOVE_Keyspecs,2,NULL,3),.args=SMOVE_Args},
 {MAKE_CMD("spop","Returns one or more random members from a set after removing them. Deletes the set if the last member was popped.","Without the count argument O(1), otherwise O(N) where N is the value of the passed count.","1.0.0",CMD_DOC_NONE,NULL,NULL,"set",COMMAND_GROUP_SET,SPOP_History,1,SPOP_Tips,1,spopCommand,-2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_SET,SPOP_Keyspecs,1,NULL,2),.args=SPOP_Args},
 {MAKE_CMD("srandmember","Get one or multiple random members from a set","Without the count argument O(1), otherwise O(N) where N is the absolute value of the passed count.","1.0.0",CMD_DOC_NONE,NULL,NULL,"set",COMMAND_GROUP_SET,SRANDMEMBER_History,1,SRANDMEMBER_Tips,1,srandmemberCommand,-2,CMD_READONLY,ACL_CATEGORY_SET,SRANDMEMBER_Keyspecs,1,NULL,2),.args=SRANDMEMBER_Args},
 {MAKE_CMD("srem","Removes one or more members from a set. Deletes the set if the last member was removed.","O(N) where N is the number of members to be removed.","1.0.0",CMD_DOC_NONE,NULL,NULL,"set",COMMAND_GROUP_SET,SREM_History,1,SREM_Tips,0,sremCommand,-3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_SET,SREM_Keyspecs,1,NULL,2),.args=SREM_Args},

--- a/src/commands/smove.json
+++ b/src/commands/smove.json
@@ -1,11 +1,17 @@
 {
     "SMOVE": {
-        "summary": "Moves a member from one set to another.",
-        "complexity": "O(1)",
+        "summary": "Moves one or more member from one set to another.Deletes the source set if the last member was moved.",
+        "complexity": "O(N) where N is the number of members to be moved.",
         "group": "set",
         "since": "1.0.0",
-        "arity": 4,
+        "arity": -4,
         "function": "smoveCommand",
+        "history": [
+            [
+                "7.2.0",
+                "Accepts multiple `member` arguments."
+            ]
+        ],
         "command_flags": [
             "WRITE",
             "FAST"
@@ -56,7 +62,7 @@
             "oneOf": [
                 {
                     "const": 1,
-                    "description": "Element is moved."
+                    "description": "One or more element is moved."
                 },
                 {
                     "const": 0,
@@ -77,7 +83,8 @@
             },
             {
                 "name": "member",
-                "type": "string"
+                "type": "string",
+                "multiple": true
             }
         ]
     }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -712,12 +712,6 @@ void smoveCommand(client *c) {
         notifyKeyspaceEvent(NOTIFY_GENERIC,"del",c->argv[1],c->db->id);
     }
 
-    /* Create the destination set when it doesn't exist */
-    if (!dstset) {
-        dstset = setTypeCreate(ele->ptr, 1);
-        dbAdd(c->db,c->argv[2],dstset);
-    }
-
     signalModifiedKey(c,c->db,c->argv[1]);
     server.dirty++;
     /* An extra key has changed when ele was successfully added to dstset */

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -659,7 +659,7 @@ void smoveCommand(client *c) {
     robj *srcset, *dstset, *ele;
     srcset = lookupKeyWrite(c->db,c->argv[1]);
     dstset = lookupKeyWrite(c->db,c->argv[2]);
-    int added =0, removed =0;
+    int added = 0, removed = 0;
     /* If the source key does not exist return 0 */
     if (srcset == NULL) {
         addReply(c,shared.czero);
@@ -673,7 +673,7 @@ void smoveCommand(client *c) {
 
     /* If srcset and dstset are equal, SMOVE is a no-op */
     if (srcset == dstset) {
-        int member =0;
+        int member = 0;
         for (int j = 3; j < c->argc; j++) {
             ele = c->argv[j];
             /*even if one element is present in src set, we will return 1*/
@@ -695,12 +695,12 @@ void smoveCommand(client *c) {
     /* If none of the element can be removed from the src set, return 0. */
     for (int j = 3; j < c->argc; j++) {
         if (setTypeRemove(srcset,c->argv[j]->ptr)) {
-            removed ++;
+            removed++;
             /*we only add the item which can be removed from src set*/
             if (setTypeAdd(dstset,c->argv[j]->ptr)) added++;
         }
     }
-    if (removed==0) {
+    if (removed == 0) {
         addReply(c,shared.czero);
         return;
     }

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -929,7 +929,7 @@ start_server {
 
     proc setup_move {} {
         r del myset3{t} myset4{t}
-        create_set myset1{t} {1 a b}
+        create_set myset1{t} {1 5 a b c d}
         create_set myset2{t} {2 3 4}
         assert_encoding listpack myset1{t}
         assert_encoding intset myset2{t}
@@ -939,31 +939,58 @@ start_server {
         # move a non-integer element to an intset should convert encoding
         setup_move
         assert_equal 1 [r smove myset1{t} myset2{t} a]
-        assert_equal {1 b} [lsort [r smembers myset1{t}]]
+        assert_equal {1 5 b c d} [lsort [r smembers myset1{t}]]
         assert_equal {2 3 4 a} [lsort [r smembers myset2{t}]]
+        assert_encoding listpack myset2{t}
+
+        #move multiple non-integer element to an intset should convert encoding
+	setup_move
+        assert_equal 1 [r smove myset1{t} myset2{t} a b c]
+        assert_equal {1 5 d} [lsort [r smembers myset1{t}]]
+        assert_equal {2 3 4 a b c} [lsort [r smembers myset2{t}]]
         assert_encoding listpack myset2{t}
 
         # move an integer element should not convert the encoding
         setup_move
         assert_equal 1 [r smove myset1{t} myset2{t} 1]
-        assert_equal {a b} [lsort [r smembers myset1{t}]]
+        assert_equal {5 a b c d} [lsort [r smembers myset1{t}]]
         assert_equal {1 2 3 4} [lsort [r smembers myset2{t}]]
         assert_encoding intset myset2{t}
+
+	# move multiple integer element should not convert the encoding
+        setup_move
+        assert_equal 1 [r smove myset1{t} myset2{t} 1 5]
+        assert_equal {a b c d} [lsort [r smembers myset1{t}]]
+        assert_equal {1 2 3 4 5} [lsort [r smembers myset2{t}]]
+        assert_encoding intset myset2{t}
+
     }
 
     test "SMOVE basics - from intset to regular set" {
         setup_move
         assert_equal 1 [r smove myset2{t} myset1{t} 2]
-        assert_equal {1 2 a b} [lsort [r smembers myset1{t}]]
+        assert_equal {1 2 5 a b c d} [lsort [r smembers myset1{t}]]
         assert_equal {3 4} [lsort [r smembers myset2{t}]]
+        #move multiple elements
+        assert_equal 1 [r smove myset2{t} myset1{t} 3 4]
+        assert_equal {1 2 3 4 5 a b c d} [lsort [r smembers myset1{t}]]
+        assert_equal {} [r smembers myset2{t}]
     }
 
     test "SMOVE non existing key" {
         setup_move
         assert_equal 0 [r smove myset1{t} myset2{t} foo]
         assert_equal 0 [r smove myset1{t} myset1{t} foo]
-        assert_equal {1 a b} [lsort [r smembers myset1{t}]]
+        assert_equal {1 5 a b c d} [lsort [r smembers myset1{t}]]
         assert_equal {2 3 4} [lsort [r smembers myset2{t}]]
+    }
+
+    test "SMOVE non existing key and existing key" {
+        setup_move
+	assert_equal 0 [r smove myset1{t} myset2{t} foo]
+        assert_equal 1 [r smove myset1{t} myset2{t} foo 1 5]
+        assert_equal {a b c d} [lsort [r smembers myset1{t}]]
+        assert_equal {1 2 3 4 5} [r smembers myset2{t}]
     }
 
     test "SMOVE non existing src set" {
@@ -974,17 +1001,17 @@ start_server {
 
     test "SMOVE from regular set to non existing destination set" {
         setup_move
-        assert_equal 1 [r smove myset1{t} myset3{t} a]
-        assert_equal {1 b} [lsort [r smembers myset1{t}]]
-        assert_equal {a} [lsort [r smembers myset3{t}]]
+        assert_equal 1 [r smove myset1{t} myset3{t} a b]
+        assert_equal {1 5 c d} [lsort [r smembers myset1{t}]]
+        assert_equal {a b} [lsort [r smembers myset3{t}]]
         assert_encoding listpack myset3{t}
     }
 
     test "SMOVE from intset to non existing destination set" {
         setup_move
-        assert_equal 1 [r smove myset2{t} myset3{t} 2]
-        assert_equal {3 4} [lsort [r smembers myset2{t}]]
-        assert_equal {2} [lsort [r smembers myset3{t}]]
+        assert_equal 1 [r smove myset2{t} myset3{t} 2 3]
+        assert_equal {4} [lsort [r smembers myset2{t}]]
+        assert_equal {2 3} [lsort [r smembers myset3{t}]]
         assert_encoding intset myset3{t}
     }
 
@@ -1000,10 +1027,11 @@ start_server {
 
     test "SMOVE with identical source and destination" {
         r del set{t}
-        r sadd set{t} a b c
-        r smove set{t} set{t} b
-        lsort [r smembers set{t}]
-    } {a b c}
+        r sadd set{t} a b c d e
+        assert_equal 1 [r smove set{t} set{t} b c]
+	assert_equal 0 [r smove set{t} set{t} nokey]
+	assert_equal {a b c d e} [lsort [r smembers set{t}]]
+    }
 
     test "SMOVE only notify dstset when the addition is successful" {
         r del srcset{t}


### PR DESCRIPTION
**Current Command**
"SMOVE source destination member" command returns 
1 if the element is moved.
0 if the element is not a member of source and no operation was performed

**Proposed Command**
SMOVE source destination member [member..]
Returns
1 if at least one element is moved.
0 if the none of the element is a member of source and no operation was performed

![smove1](https://user-images.githubusercontent.com/51993843/236577736-60a2e6c0-d321-4d0b-8af2-253d82c78bc0.jpg)

![smove 2](https://user-images.githubusercontent.com/51993843/236577748-42441912-e7ac-441f-a037-0e638b6c7189.jpg)

![smove 3](https://user-images.githubusercontent.com/51993843/236577766-c0f9528b-4f9b-42ca-a679-d645b47d94d4.jpg)
