### PR TITLE
add a new loglevel 'nothing' to disable logging

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -346,7 +346,7 @@ pidfile /var/run/redis_6379.pid
 # verbose (many rarely useful info, but not a mess like the debug level)
 # notice (moderately verbose, what you want in production probably)
 # warning (only very important / critical messages are logged)
-# nothing (nothing is logged, that is close the log)
+# nothing (nothing is logged)
 loglevel notice
 
 # Specify the log file name. Also the empty string can be used to force

--- a/redis.conf
+++ b/redis.conf
@@ -346,6 +346,7 @@ pidfile /var/run/redis_6379.pid
 # verbose (many rarely useful info, but not a mess like the debug level)
 # notice (moderately verbose, what you want in production probably)
 # warning (only very important / critical messages are logged)
+# nothing (nothing is logged, that is close the log)
 loglevel notice
 
 # Specify the log file name. Also the empty string can be used to force

--- a/src/config.c
+++ b/src/config.c
@@ -79,6 +79,7 @@ configEnum loglevel_enum[] = {
     {"verbose", LL_VERBOSE},
     {"notice", LL_NOTICE},
     {"warning", LL_WARNING},
+    {"nothing", LL_NOTHING},
     {NULL,0}
 };
 

--- a/src/server.h
+++ b/src/server.h
@@ -505,6 +505,7 @@ typedef enum {
 #define LL_VERBOSE 1
 #define LL_NOTICE 2
 #define LL_WARNING 3
+#define LL_NOTHING 4
 #define LL_RAW (1<<10) /* Modifier to log without timestamp */
 
 /* Supervision options */


### PR DESCRIPTION
Users can record logs of different levels by setting the `loglevel`. However, sometimes there are many logs even at the warning level, which can affect the performance of Redis.

For example, when a user accesses the tls-port using a non-encrypted link, Redis will log lots of "# Error accepting a client connection: ...".

We can provide the ability to disable logging so that users can temporarily turn off logging and turn it back on after the problem is resolved.