### PR TITLE
Fix defrag CI for 32bit after merge of jemalloc 5.3

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -329,7 +329,8 @@ void mallctl_int(client *c, robj **argv, int argc) {
     }
     size_t sz = sizeof(old);
     while (sz > 0) {
-        if ((ret=je_mallctl(argv[0]->ptr, &old, &sz, argc > 1? &val: NULL, argc > 1?sz: 0))) {
+        size_t zz = sz;
+        if ((ret=je_mallctl(argv[0]->ptr, &old, &zz, argc > 1? &val: NULL, argc > 1?sz: 0))) {
             if (ret == EPERM && argc > 1) {
                 /* if this option is write only, try just writing to it. */
                 if (!(ret=je_mallctl(argv[0]->ptr, NULL, 0, &val, sz))) {


### PR DESCRIPTION
The new mallctl seems to set the output sz when EINVAL occors. that messes up the retry mechanism that does /2 on each iteration.