### PR TITLE
Fixed unit test failed in arm64

### DIFF
--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -774,7 +774,7 @@ start_server {tags {"hash"}} {
     # 1.23 cannot be represented correctly with 64 bit doubles, so we skip
     # the test, since we are only testing pretty printing here and is not
     # a bug if the program outputs things like 1.299999...
-    if {!$::valgrind && [string match *x86_64* [exec uname -a]]} {
+    if {!$::valgrind && ![string match *arm64* [exec file /bin/bash]]} {
         test {Test HINCRBYFLOAT for correct float representation (issue #2846)} {
             r del myhash
             assert {[r hincrbyfloat myhash float 1.23] eq {1.23}}


### PR DESCRIPTION
Fixed issue #3768


I use Macbook m1. It seems the Tcl doesn't support arm64. The command `uname -a` will return x86_64 and make it error.

```
% exec uname -a
Darwin Kernel Version 21.6.0: Thu Mar  9 20:12:21 PST 2023; root:xnu-8020.240.18.700.8~1/RELEASE_ARM64_T6000 x86_64
% exec file /bin/bash
/bin/bash: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64
- Mach-O 64-bit executable x86_64] [arm64e:Mach-O 64-bit executable arm64e
- Mach-O 64-bit executable arm64e]
/bin/bash (for architecture x86_64):	Mach-O 64-bit executable x86_64
/bin/bash (for architecture arm64e):	Mach-O 64-bit executable arm64e
```

Change "uname -a" into "file /bin/bash" to get architecture correctly. 
Test: Test HINCRBYFLOAT for correct float representation (issue #2846)