### PR TITLE
fix `GEORADIUS[BYMEMBER]` `STORE` & `STOREDIST` args spec

### DIFF
--- a/src/commands/georadius.json
+++ b/src/commands/georadius.json
@@ -186,20 +186,24 @@
                 ]
             },
             {
-                "token": "STORE",
-                "name": "storekey",
-                "display": "key",
-                "type": "key",
+                "name": "store",
+                "type": "oneof",
                 "key_spec_index": 1,
-                "optional": true
-            },
-            {
-                "token": "STOREDIST",
-                "name": "storedistkey",
-                "display": "key",
-                "type": "key",
-                "key_spec_index": 2,
-                "optional": true
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "STORE",
+                        "name": "storekey",
+                        "display": "key",
+                        "type": "key"
+                    },
+                    {
+                        "token": "STOREDIST",
+                        "name": "storedistkey",
+                        "display": "key",
+                        "type": "key"
+                    }
+                ]
             }
         ],
         "reply_schema": {

--- a/src/commands/georadius.json
+++ b/src/commands/georadius.json
@@ -188,20 +188,21 @@
             {
                 "name": "store",
                 "type": "oneof",
-                "key_spec_index": 1,
                 "optional": true,
                 "arguments": [
                     {
                         "token": "STORE",
                         "name": "storekey",
                         "display": "key",
-                        "type": "key"
+                        "type": "key",
+                        "key_spec_index": 1
                     },
                     {
                         "token": "STOREDIST",
                         "name": "storedistkey",
                         "display": "key",
-                        "type": "key"
+                        "type": "key",
+                        "key_spec_index": 1
                     }
                 ]
             }

--- a/src/commands/georadius.json
+++ b/src/commands/georadius.json
@@ -202,7 +202,7 @@
                         "name": "storedistkey",
                         "display": "key",
                         "type": "key",
-                        "key_spec_index": 1
+                        "key_spec_index": 2
                     }
                 ]
             }

--- a/src/commands/georadiusbymember.json
+++ b/src/commands/georadiusbymember.json
@@ -193,7 +193,7 @@
                         "name": "storedistkey",
                         "display": "key",
                         "type": "key",
-                        "key_spec_index": 1
+                        "key_spec_index": 2
                     }
                 ]
             }

--- a/src/commands/georadiusbymember.json
+++ b/src/commands/georadiusbymember.json
@@ -179,20 +179,21 @@
             {
                 "name": "store",
                 "type": "oneof",
-                "key_spec_index": 1,
                 "optional": true,
                 "arguments": [
                     {
                         "token": "STORE",
                         "name": "storekey",
                         "display": "key",
-                        "type": "key"
+                        "type": "key",
+                        "key_spec_index": 1
                     },
                     {
                         "token": "STOREDIST",
                         "name": "storedistkey",
                         "display": "key",
-                        "type": "key"
+                        "type": "key",
+                        "key_spec_index": 1
                     }
                 ]
             }

--- a/src/commands/georadiusbymember.json
+++ b/src/commands/georadiusbymember.json
@@ -177,20 +177,24 @@
                 ]
             },
             {
-                "token": "STORE",
-                "name": "storekey",
-                "display": "key",
-                "type": "key",
+                "name": "store",
+                "type": "oneof",
                 "key_spec_index": 1,
-                "optional": true
-            },
-            {
-                "token": "STOREDIST",
-                "name": "storedistkey",
-                "display": "key",
-                "type": "key",
-                "key_spec_index": 2,
-                "optional": true
+                "optional": true,
+                "arguments": [
+                    {
+                        "token": "STORE",
+                        "name": "storekey",
+                        "display": "key",
+                        "type": "key"
+                    },
+                    {
+                        "token": "STOREDIST",
+                        "name": "storedistkey",
+                        "display": "key",
+                        "type": "key"
+                    }
+                ]
             }
         ],
         "reply_schema": {

--- a/src/db.c
+++ b/src/db.c
@@ -2315,7 +2315,7 @@ int migrateGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResul
 
 /* Helper function to extract keys from following commands:
  * GEORADIUS key x y radius unit [WITHDIST] [WITHHASH] [WITHCOORD] [ASC|DESC]
- *                             [COUNT count] [STORE key] [STOREDIST key]
+ *                             [COUNT count] [STORE key | STOREDIST key]
  * GEORADIUSBYMEMBER key member radius unit ... options ...
  * 
  * This command has a fully defined keyspec, so returning flags isn't needed. */

--- a/src/db.c
+++ b/src/db.c
@@ -2315,7 +2315,7 @@ int migrateGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResul
 
 /* Helper function to extract keys from following commands:
  * GEORADIUS key x y radius unit [WITHDIST] [WITHHASH] [WITHCOORD] [ASC|DESC]
- *                             [COUNT count] [STORE key | STOREDIST key]
+ *                             [COUNT count] [STORE key|STOREDIST key]
  * GEORADIUSBYMEMBER key member radius unit ... options ...
  * 
  * This command has a fully defined keyspec, so returning flags isn't needed. */

--- a/src/geo.c
+++ b/src/geo.c
@@ -513,7 +513,7 @@ void geoaddCommand(client *c) {
 #define GEOSEARCHSTORE (1<<4)   /* GEOSEARCHSTORE just accept STOREDIST option */
 
 /* GEORADIUS key x y radius unit [WITHDIST] [WITHHASH] [WITHCOORD] [ASC|DESC]
- *                               [COUNT count [ANY]] [STORE key | STOREDIST key]
+ *                               [COUNT count [ANY]] [STORE key|STOREDIST key]
  * GEORADIUSBYMEMBER key member radius unit ... options ...
  * GEOSEARCH key [FROMMEMBER member] [FROMLONLAT long lat] [BYRADIUS radius unit]
  *               [BYBOX width height unit] [WITHCOORD] [WITHDIST] [WITHASH] [COUNT count [ANY]] [ASC|DESC]

--- a/src/geo.c
+++ b/src/geo.c
@@ -513,7 +513,7 @@ void geoaddCommand(client *c) {
 #define GEOSEARCHSTORE (1<<4)   /* GEOSEARCHSTORE just accept STOREDIST option */
 
 /* GEORADIUS key x y radius unit [WITHDIST] [WITHHASH] [WITHCOORD] [ASC|DESC]
- *                               [COUNT count [ANY]] [STORE key] [STOREDIST key]
+ *                               [COUNT count [ANY]] [STORE key | STOREDIST key]
  * GEORADIUSBYMEMBER key member radius unit ... options ...
  * GEOSEARCH key [FROMMEMBER member] [FROMLONLAT long lat] [BYRADIUS radius unit]
  *               [BYBOX width height unit] [WITHCOORD] [WITHDIST] [WITHASH] [COUNT count [ANY]] [ASC|DESC]

--- a/tests/assets/test_cli_hint_suite.txt
+++ b/tests/assets/test_cli_hint_suite.txt
@@ -86,17 +86,17 @@
 # Incorrect type for EX 'seconds' parameter - stop hinting.
 "SET key value EX sec " ""
 
-# Reordering partially-matched optional argument: GEORADIUS key longitude latitude radius M|KM|FT|MI [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count [ANY]] [ASC|DESC] [STORE key] [STOREDIST key]
-"GEORADIUS key " "longitude latitude radius M|KM|FT|MI [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count [ANY]] [ASC|DESC] [STORE key] [STOREDIST key]"
-"GEORADIUS key 1 2 3 M " "[WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count [ANY]] [ASC|DESC] [STORE key] [STOREDIST key]"
-"GEORADIUS key 1 2 3 M COUNT " "count [ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key] [STOREDIST key]"
-"GEORADIUS key 1 2 3 M COUNT 12 " "[ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key] [STOREDIST key]"
-"GEORADIUS key 1 2 3 M COUNT 12 " "[ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key] [STOREDIST key]"
-"GEORADIUS key 1 -2.345 3 M COUNT 12 " "[ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key] [STOREDIST key]"" ""
+# Reordering partially-matched optional argument: GEORADIUS key longitude latitude radius M|KM|FT|MI [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count [ANY]] [ASC|DESC] [STORE key | STOREDIST key]
+"GEORADIUS key " "longitude latitude radius M|KM|FT|MI [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count [ANY]] [ASC|DESC] [STORE key | STOREDIST key]"
+"GEORADIUS key 1 2 3 M " "[WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count [ANY]] [ASC|DESC] [STORE key | STOREDIST key]"
+"GEORADIUS key 1 2 3 M COUNT " "count [ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key | STOREDIST key]"
+"GEORADIUS key 1 2 3 M COUNT 12 " "[ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key | STOREDIST key]"
+"GEORADIUS key 1 2 3 M COUNT 12 " "[ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key | STOREDIST key]"
+"GEORADIUS key 1 -2.345 3 M COUNT 12 " "[ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key | STOREDIST key]"" ""
 # Wrong data type: latitude must be a double. Hinting fails.
 "GEORADIUS key 1 X " ""
 # Once the next optional argument is started, the [ANY] hint completing the COUNT argument disappears.
-"GEORADIUS key 1 2 3 M COUNT 12 ASC " "[WITHCOORD] [WITHDIST] [WITHHASH] [STORE key] [STOREDIST key]"
+"GEORADIUS key 1 2 3 M COUNT 12 ASC " "[WITHCOORD] [WITHDIST] [WITHHASH] [STORE key | STOREDIST key]"
 
 # Incorrect argument type for double-valued token parameter.
 "GEOSEARCH k FROMLONLAT " "longitude latitude BYRADIUS radius M|KM|FT|MI|BYBOX width height M|KM|FT|MI [ASC|DESC] [COUNT count [ANY]] [WITHCOORD] [WITHDIST] [WITHHASH]"

--- a/tests/assets/test_cli_hint_suite.txt
+++ b/tests/assets/test_cli_hint_suite.txt
@@ -86,17 +86,17 @@
 # Incorrect type for EX 'seconds' parameter - stop hinting.
 "SET key value EX sec " ""
 
-# Reordering partially-matched optional argument: GEORADIUS key longitude latitude radius M|KM|FT|MI [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count [ANY]] [ASC|DESC] [STORE key | STOREDIST key]
-"GEORADIUS key " "longitude latitude radius M|KM|FT|MI [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count [ANY]] [ASC|DESC] [STORE key | STOREDIST key]"
-"GEORADIUS key 1 2 3 M " "[WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count [ANY]] [ASC|DESC] [STORE key | STOREDIST key]"
-"GEORADIUS key 1 2 3 M COUNT " "count [ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key | STOREDIST key]"
-"GEORADIUS key 1 2 3 M COUNT 12 " "[ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key | STOREDIST key]"
-"GEORADIUS key 1 2 3 M COUNT 12 " "[ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key | STOREDIST key]"
-"GEORADIUS key 1 -2.345 3 M COUNT 12 " "[ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key | STOREDIST key]"" ""
+# Reordering partially-matched optional argument: GEORADIUS key longitude latitude radius M|KM|FT|MI [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count [ANY]] [ASC|DESC] [STORE key|STOREDIST key]
+"GEORADIUS key " "longitude latitude radius M|KM|FT|MI [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count [ANY]] [ASC|DESC] [STORE key|STOREDIST key]"
+"GEORADIUS key 1 2 3 M " "[WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count [ANY]] [ASC|DESC] [STORE key|STOREDIST key]"
+"GEORADIUS key 1 2 3 M COUNT " "count [ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key|STOREDIST key]"
+"GEORADIUS key 1 2 3 M COUNT 12 " "[ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key|STOREDIST key]"
+"GEORADIUS key 1 2 3 M COUNT 12 " "[ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key|STOREDIST key]"
+"GEORADIUS key 1 -2.345 3 M COUNT 12 " "[ANY] [WITHCOORD] [WITHDIST] [WITHHASH] [ASC|DESC] [STORE key|STOREDIST key]"" ""
 # Wrong data type: latitude must be a double. Hinting fails.
 "GEORADIUS key 1 X " ""
 # Once the next optional argument is started, the [ANY] hint completing the COUNT argument disappears.
-"GEORADIUS key 1 2 3 M COUNT 12 ASC " "[WITHCOORD] [WITHDIST] [WITHHASH] [STORE key | STOREDIST key]"
+"GEORADIUS key 1 2 3 M COUNT 12 ASC " "[WITHCOORD] [WITHDIST] [WITHHASH] [STORE key|STOREDIST key]"
 
 # Incorrect argument type for double-valued token parameter.
 "GEOSEARCH k FROMLONLAT " "longitude latitude BYRADIUS radius M|KM|FT|MI|BYBOX width height M|KM|FT|MI [ASC|DESC] [COUNT count [ANY]] [WITHCOORD] [WITHDIST] [WITHHASH]"


### PR DESCRIPTION
in GEO commands, `STORE` and `STOREDIST` are mutually exclusive.
use `oneof` block to contain them
