### PR TITLE
Prevent repetitive backlog trimming

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -420,9 +420,9 @@ void feedReplicationBuffer(char *s, size_t len) {
             createReplicationBacklogIndex(listLast(server.repl_buffer_blocks));
 
             /* It is important to trim after adding replication data to keep the backlog size close to
-            * repl_backlog_size in the common case. We wait until we add a new block to avoid repeated
-            * unnecessary trimming attempts when small amounts of data are added. See comments in
-            * freeMemoryGetNotCountedMemory() for details on replication backlog memory tracking. */
+             * repl_backlog_size in the common case. We wait until we add a new block to avoid repeated
+             * unnecessary trimming attempts when small amounts of data are added. See comments in
+             * freeMemoryGetNotCountedMemory() for details on replication backlog memory tracking. */
             incrementalTrimReplicationBacklog(REPL_BACKLOG_TRIM_BLOCKS_PER_CALL);
         }
     }


### PR DESCRIPTION
When `replicationFeedSlaves()` serializes a command, it repeatedly calls `feedReplicationBuffer()` to feed it to the replication backlog piece by piece. It is unnecessary to call `incrementalTrimReplicationBacklog()` for every small amount of data added with `feedReplicationBuffer()` as the chance of the conditions being met for trimming are very low and these frequent calls add up to a notable performance cost. Instead, we will only attempt trimming when a new block is added to the replication backlog.

Using redis-benchmark to saturate a local redis server indicated a performance improvement of around 3-3.5% for 100 byte SET commands with this change.

`./redis-benchmark -p 6379 -t set -n 100000000 -c 1000 -d 100 -P 100`

**Baseline Example**

```
Summary:
  throughput summary: 988415.81 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       95.715    11.600    98.815   108.735   112.319   128.703
```

**Preventing Repetitive Trimming Example**
```
Summary:
  throughput summary: 1021606.94 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       92.407    11.960    95.359   105.407   108.927   166.015
```

**Performance Improvement: 3.35%**


