### PR TITLE
Fix memory leak when RM_Call's RUN_AS_USER fails

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -6094,6 +6094,12 @@ fmterr:
     return NULL;
 }
 
+static void moduleFreeArgv(robj **argv, int argc) {
+    for (int j = 0; j < argc; j++)
+        decrRefCount(argv[j]);
+    zfree(argv);
+}
+
 /* Exported API to call any Redis command from modules.
  *
  * * **cmdname**: The Redis command to call.
@@ -6224,6 +6230,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
                 sds msg = sdsnew("cannot run as user, no user directly attached to context or context's client");
                 reply = callReplyCreateError(msg, ctx);
             }
+            moduleFreeArgv(argv, argc);
             return reply;
         }
     }

--- a/src/module.c
+++ b/src/module.c
@@ -620,7 +620,7 @@ void *RM_PoolAlloc(RedisModuleCtx *ctx, size_t bytes) {
  * Helpers for modules API implementation
  * -------------------------------------------------------------------------- */
 
-client *moduleAllocTempClient() {
+client *moduleAllocTempClient(void) {
     client *c = NULL;
 
     if (moduleTempClientCount > 0) {

--- a/src/module.c
+++ b/src/module.c
@@ -6215,7 +6215,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
     error_as_call_replies = flags & REDISMODULE_ARGV_CALL_REPLIES_AS_ERRORS;
     va_end(ap);
 
-    c = moduleAllocTempClient(user);
+    c = moduleAllocTempClient(NULL);
 
     if (!(flags & REDISMODULE_ARGV_ALLOW_BLOCK)) {
         /* We do not want to allow block, the module do not expect it */
@@ -6246,6 +6246,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
             }
             goto cleanup;
         }
+	c->user = user;
     }
 
     /* We handle the above format error only when the client is setup so that

--- a/src/module.c
+++ b/src/module.c
@@ -6246,7 +6246,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
             }
             goto cleanup;
         }
-	c->user = user;
+        c->user = user;
     }
 
     /* We handle the above format error only when the client is setup so that


### PR DESCRIPTION
previously the argv wasn't freed so would leak.  not a common case, but should be handled.

Solution: move RUN_AS_USER setup and error exit to the right place.
this way, when we do `goto cleanup` (instead of return) it'll automatically do the right thing (including autoMemoryAdd)
Removed the user argument from moduleAllocTempClient (reverted to the state before 6e993a5)

fixes: #12157 