### PR TITLE
RedisModuleClient - enables MULTI/EXEC/WATCH in RM_Call()

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -55,4 +55,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/async_rm_call \
 --single unit/moduleapi/moduleauth \
 --single unit/moduleapi/rdbloadsave \
+--single unit/moduleapi/persistentclient \
 "${@}"

--- a/src/module.c
+++ b/src/module.c
@@ -5997,12 +5997,11 @@ void RM_SetContextUser(RedisModuleCtx *ctx, const RedisModuleUser *user)
     ctx->user = user;
 }
 
-RedisModuleClient *RM_CreateModuleClient(RedisModuleCtx *ctx, const RedisModuleUser *rmu)
+RedisModuleClient *RM_CreateModuleClient(RedisModuleCtx *ctx)
 {
     UNUSED(ctx);
 
-    user *u = rmu ? rmu->user : NULL;
-    client *c = moduleAllocTempClient(u);
+    client *c = moduleAllocTempClient(NULL);
 
     RedisModuleClient *rmc = zmalloc(sizeof(RedisModuleClient));
     rmc->client = c;

--- a/src/module.c
+++ b/src/module.c
@@ -665,7 +665,7 @@ void moduleReleaseTempClient(client *c) {
     if (c->flags & CLIENT_MODULE_PERSISTENT) {
         /* if a persistent client, only reset flags and free argv
          * don't reset client in general or return to pool */
-        c->flags &= ~(CLIENT_DENY_BLOCKING||CLIENT_ALLOW_OOM|CLIENT_READONLY|CLIENT_ASKING);
+        c->flags &= ~(CLIENT_DENY_BLOCKING|CLIENT_ALLOW_OOM|CLIENT_READONLY|CLIENT_ASKING);
         moduleFreeArgv(c->argv, c->argc);
         c->argv = NULL;
         c->argc = 0;

--- a/src/module.c
+++ b/src/module.c
@@ -691,9 +691,9 @@ void moduleReleaseTempClient(client *c) {
     c->cmd = c->lastcmd = c->realcmd = NULL;
 
     /* reset client stat that can persist */
-    pubsubUnsubscribeAllChannels(c,0);
+    pubsubUnsubscribeAllChannels(c, 0);
     pubsubUnsubscribeShardAllChannels(c, 0);
-    pubsubUnsubscribeAllPatterns(c,0);
+    pubsubUnsubscribeAllPatterns(c, 0);
     freeClientMultiState(c);
 
     moduleTempClients[moduleTempClientCount++] = c;

--- a/src/module.c
+++ b/src/module.c
@@ -6279,7 +6279,14 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
 
     user *user = NULL;
     if (flags & REDISMODULE_ARGV_RUN_AS_USER) {
-        user = ctx->user ? ctx->user->user : ctx->client->user;
+        user = ctx->client->user;
+        if (ctx->persistent_client) {
+            /* only used for ACL check */
+            user = ctx->persistent_client->client->user;
+        } else if (ctx->user) {
+            user = ctx->user->user;
+        }
+
         if (!user) {
             errno = ENOTSUP;
             if (error_as_call_replies) {

--- a/src/module.c
+++ b/src/module.c
@@ -6019,6 +6019,15 @@ void RM_FreeModuleClient(RedisModuleCtx *ctx, RedisModuleClient *client)
     zfree(client);
 }
 
+void RM_SetClientUser(RedisModuleClient *client, RedisModuleUser *user)
+{
+    if (user) {
+        client->client->user = user->user;
+    } else {
+        client->client->user = NULL;
+    }
+}
+
 void RM_SetContextClient(RedisModuleCtx *ctx, RedisModuleClient *client)
 {
     ctx->persistent_client = client;
@@ -13888,4 +13897,5 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(FreeModuleClient);
     REGISTER_API(SetContextClient);
     REGISTER_API(GetClientFlags);
+    REGISTER_API(SetClientUser);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -668,6 +668,7 @@ void moduleReleaseTempClient(client *c) {
         /* if a persistent client, only reset flags and free argv
          * don't reset client in general or return to pool */
         c->flags &= ~(c->reset_flags);
+        c->reset_flags = 0;
         moduleFreeArgv(c->argv, c->argc);
         c->argv = NULL;
         c->argc = 0;
@@ -6036,6 +6037,7 @@ RedisModuleClient *RM_CreateModuleClient(RedisModuleCtx *ctx) {
 
     client *c = moduleAllocTempClient(NULL);
     c->flags |= CLIENT_MODULE_PERSISTENT;
+    c->reset_flags = 0;
 
     RedisModuleClient *rmc = zmalloc(sizeof(RedisModuleClient));
     rmc->client = c;

--- a/src/module.c
+++ b/src/module.c
@@ -6028,7 +6028,7 @@ void RM_SetContextUser(RedisModuleCtx *ctx, const RedisModuleUser *user) {
 /* Returns an object that provides a client that can be attached to a
  * RedisModuleContet object to provide a persistent client usage
  * between multiple RM_Calls.  This simulates a network connected
- * client and enables modules to use WATCH/MULTI/Exec transaction
+ * client and enables modules to use WATCH/MULTI/EXEC transaction
  */
 RedisModuleClient *RM_CreateModuleClient(RedisModuleCtx *ctx) {
     UNUSED(ctx);

--- a/src/module.c
+++ b/src/module.c
@@ -6050,7 +6050,7 @@ RedisModuleClient *RM_CreateModuleClient(RedisModuleCtx *ctx) {
  *
  * Note that the client must not be released if it has an outstanding command running.
  * A blocked RM_Call (using the 'K' flag), requires calling RM_CallReplyPromiseAbort
- * first, and wait for the unblock handler to be called. */
+ * successfully or wait for the unblock handler to be called. */
 int RM_FreeModuleClient(RedisModuleCtx *ctx, RedisModuleClient *client) {
     UNUSED(ctx);
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1318,6 +1318,7 @@ REDISMODULE_API RedisModuleClient * (*RedisModule_CreateModuleClient)(RedisModul
 REDISMODULE_API void (*RedisModule_FreeModuleClient)(RedisModuleCtx *ctx, RedisModuleClient *client) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetContextClient)(RedisModuleCtx *ctx, RedisModuleClient *client) REDISMODULE_ATTR;
 REDISMODULE_API uint64_t (*RedisModule_GetClientFlags)(RedisModuleClient *client) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SetClientUser)(RedisModuleClient *client, RedisModuleUser *user) REDISMODULE_ATTR;
 
 #define RedisModule_IsAOFClient(id) ((id) == UINT64_MAX)
 
@@ -1682,6 +1683,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(FreeModuleClient);
     REDISMODULE_GET_API(SetContextClient);
     REDISMODULE_GET_API(GetClientFlags);
+
 
     if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;
     RedisModule_SetModuleAttribs(ctx,name,ver,apiver);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -309,6 +309,10 @@ typedef uint64_t RedisModuleTimerID;
  * Use RedisModule_GetModuleOptionsAll instead. */
 #define _REDISMODULE_OPTIONS_FLAGS_NEXT (1<<4)
 
+/* RM_GetClientFlags */
+#define REDISMODULE_CLIENT_FLAG_DIRTY_CAS (1<<0)   /* Watched keys modified. EXEC will fail. */
+#define REDISMODULE_CLIENT_FLAG_DIRTY_EXEC (1<<1)  /* EXEC will fail for errors while queueing */
+
 /* Definitions for RedisModule_SetCommandInfo. */
 
 typedef enum {
@@ -880,6 +884,7 @@ typedef struct RedisModuleCommandFilter RedisModuleCommandFilter;
 typedef struct RedisModuleServerInfoData RedisModuleServerInfoData;
 typedef struct RedisModuleScanCursor RedisModuleScanCursor;
 typedef struct RedisModuleUser RedisModuleUser;
+typedef struct RedisModuleClient RedisModuleClient;
 typedef struct RedisModuleKeyOptCtx RedisModuleKeyOptCtx;
 typedef struct RedisModuleRdbStream RedisModuleRdbStream;
 
@@ -1309,6 +1314,10 @@ REDISMODULE_API RedisModuleRdbStream *(*RedisModule_RdbStreamCreateFromFile)(con
 REDISMODULE_API void (*RedisModule_RdbStreamFree)(RedisModuleRdbStream *stream) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RdbLoad)(RedisModuleCtx *ctx, RedisModuleRdbStream *stream, int flags) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RdbSave)(RedisModuleCtx *ctx, RedisModuleRdbStream *stream, int flags) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleClient * (*RedisModule_CreateModuleClient)(RedisModuleCtx *ctx, const RedisModuleUser *rmu) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_FreeModuleClient)(RedisModuleCtx *ctx, RedisModuleClient *client) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_SetContextClient)(RedisModuleCtx *ctx, RedisModuleClient *client) REDISMODULE_ATTR;
+REDISMODULE_API uint64_t (*RedisModule_GetClientFlags)(RedisModuleClient *client) REDISMODULE_ATTR;
 
 #define RedisModule_IsAOFClient(id) ((id) == UINT64_MAX)
 
@@ -1669,6 +1678,10 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(RdbStreamFree);
     REDISMODULE_GET_API(RdbLoad);
     REDISMODULE_GET_API(RdbSave);
+    REDISMODULE_GET_API(CreateModuleClient);
+    REDISMODULE_GET_API(FreeModuleClient);
+    REDISMODULE_GET_API(SetContextClient);
+    REDISMODULE_GET_API(GetClientFlags);
 
     if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;
     RedisModule_SetModuleAttribs(ctx,name,ver,apiver);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -312,6 +312,10 @@ typedef uint64_t RedisModuleTimerID;
 /* RM_GetClientFlags */
 #define REDISMODULE_CLIENT_FLAG_DIRTY_CAS (1<<0)   /* Watched keys modified. EXEC will fail. */
 #define REDISMODULE_CLIENT_FLAG_DIRTY_EXEC (1<<1)  /* EXEC will fail for errors while queueing */
+/* Next client flag, must be updated when adding new flags above!
+This flag should not be used directly by the module.
+ * Use RedisModule_GetClientFlagsAll instead. */
+#define _REDISMODULE_CLIENT_FLAGS_NEXT (1<<2)
 
 /* Definitions for RedisModule_SetCommandInfo. */
 
@@ -1318,6 +1322,7 @@ REDISMODULE_API RedisModuleClient * (*RedisModule_CreateModuleClient)(RedisModul
 REDISMODULE_API int (*RedisModule_FreeModuleClient)(RedisModuleCtx *ctx, RedisModuleClient *client) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetContextClient)(RedisModuleCtx *ctx, RedisModuleClient *client) REDISMODULE_ATTR;
 REDISMODULE_API uint64_t (*RedisModule_GetClientFlags)(RedisModuleClient *client) REDISMODULE_ATTR;
+REDISMODULE_API uint64_t (*RedisModule_GetClientFlagsAll)(void) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetClientUser)(RedisModuleClient *client, RedisModuleUser *user) REDISMODULE_ATTR;
 
 #define RedisModule_IsAOFClient(id) ((id) == UINT64_MAX)
@@ -1683,6 +1688,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(FreeModuleClient);
     REDISMODULE_GET_API(SetContextClient);
     REDISMODULE_GET_API(GetClientFlags);
+    REDISMODULE_GET_API(GetClientFlagsAll);
     REDISMODULE_GET_API(SetClientUser);
 
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1314,7 +1314,7 @@ REDISMODULE_API RedisModuleRdbStream *(*RedisModule_RdbStreamCreateFromFile)(con
 REDISMODULE_API void (*RedisModule_RdbStreamFree)(RedisModuleRdbStream *stream) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RdbLoad)(RedisModuleCtx *ctx, RedisModuleRdbStream *stream, int flags) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RdbSave)(RedisModuleCtx *ctx, RedisModuleRdbStream *stream, int flags) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleClient * (*RedisModule_CreateModuleClient)(RedisModuleCtx *ctx, const RedisModuleUser *rmu) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleClient * (*RedisModule_CreateModuleClient)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_FreeModuleClient)(RedisModuleCtx *ctx, RedisModuleClient *client) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetContextClient)(RedisModuleCtx *ctx, RedisModuleClient *client) REDISMODULE_ATTR;
 REDISMODULE_API uint64_t (*RedisModule_GetClientFlags)(RedisModuleClient *client) REDISMODULE_ATTR;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1683,6 +1683,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(FreeModuleClient);
     REDISMODULE_GET_API(SetContextClient);
     REDISMODULE_GET_API(GetClientFlags);
+    REDISMODULE_GET_API(SetClientUser);
 
 
     if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1315,7 +1315,7 @@ REDISMODULE_API void (*RedisModule_RdbStreamFree)(RedisModuleRdbStream *stream) 
 REDISMODULE_API int (*RedisModule_RdbLoad)(RedisModuleCtx *ctx, RedisModuleRdbStream *stream, int flags) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RdbSave)(RedisModuleCtx *ctx, RedisModuleRdbStream *stream, int flags) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleClient * (*RedisModule_CreateModuleClient)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_FreeModuleClient)(RedisModuleCtx *ctx, RedisModuleClient *client) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_FreeModuleClient)(RedisModuleCtx *ctx, RedisModuleClient *client) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetContextClient)(RedisModuleCtx *ctx, RedisModuleClient *client) REDISMODULE_ATTR;
 REDISMODULE_API uint64_t (*RedisModule_GetClientFlags)(RedisModuleClient *client) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetClientUser)(RedisModuleClient *client, RedisModuleUser *user) REDISMODULE_ATTR;

--- a/src/server.c
+++ b/src/server.c
@@ -3771,11 +3771,12 @@ uint64_t getCommandFlags(client *c) {
 
 int isMultiQueuedCommand(client *c) {
     if (c->cmd->proc == execCommand ||
-    c->cmd->proc == discardCommand ||
-    c->cmd->proc == multiCommand ||
-    c->cmd->proc == watchCommand ||
-    c->cmd->proc == quitCommand ||
-    c->cmd->proc == resetCommand) {
+        c->cmd->proc == discardCommand ||
+        c->cmd->proc == multiCommand ||
+        c->cmd->proc == watchCommand ||
+        c->cmd->proc == quitCommand ||
+        c->cmd->proc == resetCommand)
+    {
         return 0;
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -3376,7 +3376,7 @@ void postExecutionUnitOperations(void) {
 
 /* Increment the command failure counters (either rejected_calls or failed_calls).
  * The decision which counter to increment is done using the flags argument, options are:
- * * ERROR_COMMAND_REJECTED - update rejected_calls
+ * * ERROR_COMMAND_REJECTED - update rejected_callsb
  * * ERROR_COMMAND_FAILED - update failed_calls
  *
  * The function also reset the prev_err_count to make sure we will not count the same error

--- a/src/server.c
+++ b/src/server.c
@@ -3376,7 +3376,7 @@ void postExecutionUnitOperations(void) {
 
 /* Increment the command failure counters (either rejected_calls or failed_calls).
  * The decision which counter to increment is done using the flags argument, options are:
- * * ERROR_COMMAND_REJECTED - update rejected_callsb
+ * * ERROR_COMMAND_REJECTED - update rejected_calls
  * * ERROR_COMMAND_FAILED - update failed_calls
  *
  * The function also reset the prev_err_count to make sure we will not count the same error
@@ -3769,6 +3769,19 @@ uint64_t getCommandFlags(client *c) {
     return cmd_flags;
 }
 
+int isMultiQueuedCommand(client *c) {
+    if (c->cmd->proc == execCommand ||
+    c->cmd->proc == discardCommand ||
+    c->cmd->proc == multiCommand ||
+    c->cmd->proc == watchCommand ||
+    c->cmd->proc == quitCommand ||
+    c->cmd->proc == resetCommand) {
+        return 0;
+    }
+
+    return 1;
+}
+
 /* If this function gets called we already read a whole
  * command, arguments are in the client argv/argc fields.
  * processCommand() execute the command or prepare the
@@ -4099,13 +4112,7 @@ int processCommand(client *c) {
     }
 
     /* Exec the command */
-    if (c->flags & CLIENT_MULTI &&
-        c->cmd->proc != execCommand &&
-        c->cmd->proc != discardCommand &&
-        c->cmd->proc != multiCommand &&
-        c->cmd->proc != watchCommand &&
-        c->cmd->proc != quitCommand &&
-        c->cmd->proc != resetCommand)
+    if (c->flags & CLIENT_MULTI && isMultiQueuedCommand(c))
     {
         queueMultiCommand(c, cmd_flags);
         addReply(c,shared.queued);

--- a/src/server.c
+++ b/src/server.c
@@ -4113,8 +4113,7 @@ int processCommand(client *c) {
     }
 
     /* Exec the command */
-    if (c->flags & CLIENT_MULTI && isMultiQueuedCommand(c))
-    {
+    if (c->flags & CLIENT_MULTI && isMultiQueuedCommand(c)) {
         queueMultiCommand(c, cmd_flags);
         addReply(c,shared.queued);
     } else {

--- a/src/server.h
+++ b/src/server.h
@@ -398,6 +398,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
                                                     auth had been authenticated from the Module. */
 #define CLIENT_MODULE_PREVENT_AOF_PROP (1ULL<<48) /* Module client do not want to propagate to AOF */
 #define CLIENT_MODULE_PREVENT_REPL_PROP (1ULL<<49) /* Module client do not want to propagate to replica */
+#define CLIENT_MODULE_PERSISTENT (1ULL<<50) /* Module client created by RM_CreateModuleClient */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/src/server.h
+++ b/src/server.h
@@ -1150,6 +1150,7 @@ typedef struct {
 typedef struct client {
     uint64_t id;            /* Client incremental unique ID. */
     uint64_t flags;         /* Client flags: CLIENT_* macros. */
+    uint64_t reset_flags;   /* flags to reset in persistent clients after each execution, generally set by RM_Call */
     connection *conn;
     int resp;               /* RESP protocol version. Can be 2 or 3. */
     redisDb *db;            /* Pointer to currently SELECTed DB. */

--- a/src/server.h
+++ b/src/server.h
@@ -1150,7 +1150,6 @@ typedef struct {
 typedef struct client {
     uint64_t id;            /* Client incremental unique ID. */
     uint64_t flags;         /* Client flags: CLIENT_* macros. */
-    uint64_t reset_flags;   /* flags to reset in persistent clients after each execution, generally set by RM_Call */
     connection *conn;
     int resp;               /* RESP protocol version. Can be 2 or 3. */
     redisDb *db;            /* Pointer to currently SELECTed DB. */
@@ -1268,6 +1267,7 @@ typedef struct client {
     int bufpos;
     size_t buf_usable_size; /* Usable size of buffer. */
     char *buf;
+    uint64_t reset_flags;   /* flags to reset in persistent clients after each execution, generally set by RM_Call */
 #ifdef LOG_REQ_RES
     clientReqResInfo reqres;
 #endif

--- a/src/server.h
+++ b/src/server.h
@@ -2704,6 +2704,7 @@ void touchAllWatchedKeysInDb(redisDb *emptied, redisDb *replaced_with);
 void discardTransaction(client *c);
 void flagTransaction(client *c);
 void execCommandAbort(client *c, sds error);
+int isMultiQueuedCommand(client *c);
 
 /* Redis object implementation */
 void decrRefCount(robj *o);

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -62,7 +62,8 @@ TEST_MODULES = \
     usercall.so \
     postnotifications.so \
     moduleauthtwo.so \
-    rdbloadsave.so
+    rdbloadsave.so \
+    persistentclient.so
 
 .PHONY: all
 

--- a/tests/modules/persistentclient.c
+++ b/tests/modules/persistentclient.c
@@ -1,7 +1,12 @@
 
 #include "redismodule.h"
 
+#include <strings.h>
+#include <string.h>
+
 RedisModuleClient *client = NULL;
+RedisModuleUser *ctx_user = NULL;
+RedisModuleUser *client_user = NULL;
 
 int mc_create(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
@@ -12,6 +17,82 @@ int mc_create(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
 
     RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+int mc_reset_users(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (ctx_user != NULL) {
+        RedisModule_FreeModuleUser(ctx_user);
+    }
+
+    ctx_user = RedisModule_CreateModuleUser("context-user");
+
+    if (client_user != NULL) {
+        RedisModule_FreeModuleUser(client_user);
+    }
+
+    client_user = RedisModule_CreateModuleUser("client-user");
+
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+int mc_free_users(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (ctx_user != NULL) {
+        RedisModule_FreeModuleUser(ctx_user);
+    }
+    ctx_user = NULL;
+
+    if (client_user != NULL) {
+        RedisModule_FreeModuleUser(client_user);
+    }
+    client_user = NULL;
+
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+
+}
+
+int mc_set_user_acl(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 3) {
+        return RedisModule_WrongArity(ctx);
+    }
+
+    RedisModuleUser *user;
+
+    size_t userstr_len;
+    const char *userstr = RedisModule_StringPtrLen(argv[1], &userstr_len);
+
+    if (strncasecmp("context-user", userstr, userstr_len) == 0) {
+        user = ctx_user;
+    } else if (strncasecmp("client-user", userstr, userstr_len) == 0) {
+        user = client_user;
+    } else {
+        RedisModule_ReplyWithError(ctx, "unrecognized user type");;
+        return REDISMODULE_OK;
+    }
+
+    size_t acl_len;
+    const char *acl = RedisModule_StringPtrLen(argv[2], &acl_len);
+
+    RedisModuleString *error;
+    int ret = RedisModule_SetModuleUserACLString(ctx, user, acl, &error);
+    if (ret) {
+        size_t len;
+        const char * e = RedisModule_StringPtrLen(error, &len);
+        RedisModule_ReplyWithError(ctx, e);
+        RedisModule_FreeString(NULL, error);
+        return REDISMODULE_OK;
+    }
+
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+
     return REDISMODULE_OK;
 }
 
@@ -28,6 +109,48 @@ int mc_delete(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return REDISMODULE_OK;
 }
 
+int do_exec(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int user_client, int user_context) {
+    size_t cmdstr_len;
+    const char *cmdstr = RedisModule_StringPtrLen(argv[1], &cmdstr_len);
+    char flags[4] = {0};
+
+    if (user_client) {
+        printf("setting client user\n");
+        RedisModule_SetClientUser(client, client_user);
+    }
+
+    if (user_context) {
+        printf("setting context user\n");
+        RedisModule_SetContextUser(ctx, ctx_user);
+    }
+
+    RedisModule_SetContextClient(ctx, client);
+
+    if (user_client || user_context) {
+        strncpy(flags, "CEv", sizeof(flags));
+    } else {
+        strncpy(flags, "Ev", sizeof(flags));
+    }
+
+    RedisModuleCallReply *reply = RedisModule_Call(ctx, cmdstr, flags, argv+2, argc-2);
+
+    RedisModule_SetContextClient(ctx, NULL);
+
+    if (user_client) {
+        RedisModule_SetClientUser(client, NULL);
+    }
+
+    if (user_context) {
+        RedisModule_SetContextUser(ctx, NULL);
+    }
+
+    RedisModule_ReplyWithCallReply(ctx, reply);
+    RedisModule_FreeCallReply(reply);
+
+    return REDISMODULE_OK;
+
+}
+
 int mc_exec(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (client == NULL) {
         RedisModule_ReplyWithError(ctx, "Client not already allocated");
@@ -39,19 +162,35 @@ int mc_exec(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_OK;
     }
 
-    size_t cmdstr_len;
-    const char *cmdstr = RedisModule_StringPtrLen(argv[1], &cmdstr_len);
+    return do_exec(ctx, argv, argc, 0, 0);
+}
 
-    RedisModule_SetContextClient(ctx, client);
+int mc_exec_with_client_user(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (client == NULL) {
+        RedisModule_ReplyWithError(ctx, "Client not already allocated");
+        return REDISMODULE_OK;
+    }
 
-    RedisModuleCallReply *reply = RedisModule_Call(ctx, cmdstr, "v", argv+2, argc-2);
+    if (argc <= 1) {
+        RedisModule_ReplyWithError(ctx, "not enough arguments");
+        return REDISMODULE_OK;
+    }
 
-    RedisModule_SetContextClient(ctx, NULL);
+    return do_exec(ctx, argv, argc, 1, 0);
+}
 
-    RedisModule_ReplyWithCallReply(ctx, reply);
-    RedisModule_FreeCallReply(reply);
+int mc_exec_with_client_and_ctx_user(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (client == NULL) {
+        RedisModule_ReplyWithError(ctx, "Client not already allocated");
+        return REDISMODULE_OK;
+    }
 
-    return REDISMODULE_OK;
+    if (argc <= 1) {
+        RedisModule_ReplyWithError(ctx, "not enough arguments");
+        return REDISMODULE_OK;
+    }
+
+    return do_exec(ctx, argv, argc, 1, 1);
 }
 
 int mc_getflags(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -126,10 +265,25 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_CreateCommand(ctx,"mc.exec", mc_exec,"write",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
+    if (RedisModule_CreateCommand(ctx,"mc.exec_with_client_user", mc_exec_with_client_user,"write",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"mc.exec_with_client_and_ctx_user", mc_exec_with_client_and_ctx_user,"write",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
     if (RedisModule_CreateCommand(ctx,"mc.getflags", mc_getflags,"write",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx, "mc.exec_async", mc_async, "write", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "mc.set_user_acl", mc_set_user_acl, "write", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "mc.reset_users", mc_reset_users, "write", 0, 0, 0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "mc.free_users", mc_free_users, "write", 0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     return REDISMODULE_OK;

--- a/tests/modules/persistentclient.c
+++ b/tests/modules/persistentclient.c
@@ -2,16 +2,13 @@
 #include "redismodule.h"
 
 RedisModuleClient *client = NULL;
-RedisModuleUser *user = NULL;
 
 int mc_create(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
 
     if (client == NULL) {
-        user = RedisModule_CreateModuleUser("mc-test-user");
-        RedisModule_Assert(RedisModule_SetModuleUserACLString(ctx, user, "allcommands allkeys", NULL) == REDISMODULE_OK);
-        client = RedisModule_CreateModuleClient(ctx, user);
+        client = RedisModule_CreateModuleClient(ctx);
     }
 
     RedisModule_ReplyWithSimpleString(ctx, "OK");
@@ -25,8 +22,6 @@ int mc_delete(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (client != NULL) {
         RedisModule_FreeModuleClient(ctx, client);
         client = NULL;
-        RedisModule_FreeModuleUser(user);
-        user = NULL;
     }
 
     RedisModule_ReplyWithSimpleString(ctx, "OK");

--- a/tests/modules/persistentclient.c
+++ b/tests/modules/persistentclient.c
@@ -1,0 +1,95 @@
+
+#include "redismodule.h"
+
+RedisModuleClient *client = NULL;
+RedisModuleUser *user = NULL;
+
+int mc_create(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (client == NULL) {
+        user = RedisModule_CreateModuleUser("mc-test-user");
+        RedisModule_Assert(RedisModule_SetModuleUserACLString(ctx, user, "allcommands allkeys", NULL) == REDISMODULE_OK);
+        client = RedisModule_CreateModuleClient(ctx, user);
+    }
+
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+int mc_delete(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (client != NULL) {
+        RedisModule_FreeModuleClient(ctx, client);
+        client = NULL;
+        RedisModule_FreeModuleUser(user);
+        user = NULL;
+    }
+
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
+}
+
+int mc_exec(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (client == NULL) {
+        RedisModule_ReplyWithError(ctx, "Client not already allocated");
+        return REDISMODULE_OK;
+    }
+
+    if (argc <= 1) {
+        RedisModule_ReplyWithError(ctx, "not enough arguments");
+        return REDISMODULE_OK;
+    }
+
+    size_t cmdstr_len;
+    const char *cmdstr = RedisModule_StringPtrLen(argv[1], &cmdstr_len);
+
+    RedisModule_SetContextClient(ctx, client);
+
+    RedisModuleCallReply *reply = RedisModule_Call(ctx, cmdstr, "v", argv+2, argc-2);
+
+    RedisModule_SetContextClient(ctx, NULL);
+
+    RedisModule_ReplyWithCallReply(ctx, reply);
+    RedisModule_FreeCallReply(reply);
+
+    return REDISMODULE_OK;
+}
+
+int mc_getflags(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (client == NULL) {
+        RedisModule_ReplyWithError(ctx, "Client not already allocated");
+        return REDISMODULE_OK;
+    }
+
+    RedisModule_ReplyWithLongLong(ctx, RedisModule_GetClientFlags(client));
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx,"moduleclient",1,REDISMODULE_APIVER_1)== REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"mc.create", mc_create,"write",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"mc.delete", mc_delete,"write",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"mc.exec", mc_exec,"write",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"mc.getflags", mc_getflags,"write",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    return REDISMODULE_OK;
+}

--- a/tests/modules/persistentclient.c
+++ b/tests/modules/persistentclient.c
@@ -67,6 +67,49 @@ int mc_getflags(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return REDISMODULE_OK;
 }
 
+static void rm_call_async_send_reply(RedisModuleCtx *ctx, RedisModuleCallReply *reply) {
+    RedisModule_ReplyWithCallReply(ctx, reply);
+    RedisModule_FreeCallReply(reply);
+}
+
+static void rm_call_async_on_unblocked(RedisModuleCtx *ctx, RedisModuleCallReply *reply, void *private_data) {
+    REDISMODULE_NOT_USED(ctx);
+
+    RedisModuleBlockedClient *bc = private_data;
+    RedisModuleCtx *bctx = RedisModule_GetThreadSafeContext(bc);
+    rm_call_async_send_reply(bctx, reply);
+    RedisModule_FreeThreadSafeContext(bctx);
+    RedisModule_UnblockClient(bc, RedisModule_BlockClientGetPrivateData(bc));
+}
+
+static void do_rm_call_async_free_pd(RedisModuleCtx * ctx, void *pd) {
+    REDISMODULE_NOT_USED(ctx);
+
+    RedisModule_FreeCallReply(pd);
+}
+
+int mc_async(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 2) {
+        return RedisModule_WrongArity(ctx);
+    }
+
+    const char *cmd = RedisModule_StringPtrLen(argv[1], NULL);
+
+    RedisModule_SetContextClient(ctx, client);
+    RedisModuleCallReply* rep = RedisModule_Call(ctx, cmd, "KEv", argv + 2, argc - 2);
+    RedisModule_SetContextClient(ctx, NULL);
+
+    if(RedisModule_CallReplyType(rep) != REDISMODULE_REPLY_PROMISE) {
+        rm_call_async_send_reply(ctx, rep);
+    } else {
+        RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, do_rm_call_async_free_pd, 0);
+        RedisModule_BlockClientSetPrivateData(bc, rep);
+        RedisModule_CallReplyPromiseSetUnblockHandler(rep, rm_call_async_on_unblocked, bc);
+    }
+
+    return REDISMODULE_OK;
+}
+
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
@@ -84,6 +127,9 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx,"mc.getflags", mc_getflags,"write",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx, "mc.exec_async", mc_async, "write", 0, 0, 0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     return REDISMODULE_OK;

--- a/tests/unit/moduleapi/persistentclient.tcl
+++ b/tests/unit/moduleapi/persistentclient.tcl
@@ -57,7 +57,7 @@ start_server {tags {"modules persistentclient"}} {
         r mc.create
         r set y 1
         r mc.exec multi
-        r mc.exec blpop x 0
+        r mc.exec_async blpop x 0
         r mc.exec get y
         assert { [r mc.exec exec] == {{} 1} }
     }

--- a/tests/unit/moduleapi/persistentclient.tcl
+++ b/tests/unit/moduleapi/persistentclient.tcl
@@ -1,0 +1,45 @@
+set testmodule [file normalize tests/modules/persistentclient.so]
+
+start_server {tags {"modules persistentclient"}} {
+    r module load $testmodule
+
+    test {test basic persistent client exec} {
+        r del x
+        r mc.create
+        r set x 1
+        assert_equal [r mc.exec get x] 1
+        r mc.delete
+    }
+
+    test {test persistent client watch} {
+        r del x
+        r mc.create
+        r mc.exec watch x
+        r set x 1
+        assert_equal [r mc.getflags] 1
+        r mc.delete
+    }
+
+    test {test persistent client multi/exec watch} {
+        r set x 1
+        r mc.create
+        r mc.exec watch x
+        r mc.exec multi
+        r mc.exec get x
+        r mc.exec get x
+        assert { [r mc.exec exec] == {1 1} }
+        r mc.delete
+    }
+
+    test {test persistent client multi/exec with watch failure} {
+        r set x 1
+        r mc.create
+        r mc.exec watch x
+        r mc.exec multi
+        r mc.exec get x
+        r mc.exec get x
+        r set x 2
+        assert { [r mc.exec exec] == {} }
+        r mc.delete
+    }
+}

--- a/tests/unit/moduleapi/persistentclient.tcl
+++ b/tests/unit/moduleapi/persistentclient.tcl
@@ -44,19 +44,21 @@ start_server {tags {"modules persistentclient"}} {
     }
 
     test {test persistent client with blocking command} {
+        r del x
         r mc.create
         set rd [redis_deferring_client]
         $rd mc.exec_async blpop x 0
         r lpush x 1
-        assert_equal [$rd read] {"x" 1"}
+        assert_equal [$rd read] {x 1}
     }
 
     test {test persistent client with blocking command inside multi} {
+        r del x
         r mc.create
         r set y 1
         r mc.exec multi
         r mc.exec blpop x 0
         r mc.exec get y
-        assert { [r mc.exec exec]  = { {} 1 } }
+        assert { [r mc.exec exec] == {{} 1} }
     }
 }

--- a/tests/unit/moduleapi/persistentclient.tcl
+++ b/tests/unit/moduleapi/persistentclient.tcl
@@ -42,4 +42,21 @@ start_server {tags {"modules persistentclient"}} {
         assert { [r mc.exec exec] == {} }
         r mc.delete
     }
+
+    test {test persistent client with blocking command} {
+        r mc.create
+        set rd [redis_deferring_client]
+        $rd mc.exec_async blpop x 0
+        r lpush x 1
+        assert_equal [$rd read] {"x" 1"}
+    }
+
+    test {test persistent client with blocking command inside multi} {
+        r mc.create
+        r set y 1
+        r mc.exec multi
+        r mc.exec blpop x 0
+        r mc.exec get y
+        assert { [r mc.exec exec]  = { {} 1 } }
+    }
 }

--- a/tests/unit/moduleapi/persistentclient.tcl
+++ b/tests/unit/moduleapi/persistentclient.tcl
@@ -5,6 +5,7 @@ start_server {tags {"modules persistentclient"}} {
 
     test {test basic persistent client exec} {
         r del x
+        r mc.delete
         r mc.create
         r set x 1
         assert_equal [r mc.exec get x] 1
@@ -13,6 +14,7 @@ start_server {tags {"modules persistentclient"}} {
 
     test {test persistent client watch} {
         r del x
+        r mc.delete
         r mc.create
         r mc.exec watch x
         r set x 1
@@ -22,6 +24,7 @@ start_server {tags {"modules persistentclient"}} {
 
     test {test persistent client multi/exec watch} {
         r set x 1
+        r mc.delete
         r mc.create
         r mc.exec watch x
         r mc.exec multi
@@ -33,6 +36,7 @@ start_server {tags {"modules persistentclient"}} {
 
     test {test persistent client multi/exec with watch failure} {
         r set x 1
+        r mc.delete
         r mc.create
         r mc.exec watch x
         r mc.exec multi
@@ -45,11 +49,13 @@ start_server {tags {"modules persistentclient"}} {
 
     test {test persistent client with blocking command} {
         r del x
+        r mc.delete
         r mc.create
         set rd [redis_deferring_client]
         $rd mc.exec_async blpop x 0
         r lpush x 1
         assert_equal [$rd read] {x 1}
+        r mc.delete
     }
 
     test {test persistent client with blocking command inside multi} {
@@ -60,5 +66,32 @@ start_server {tags {"modules persistentclient"}} {
         r mc.exec_async blpop x 0
         r mc.exec get y
         assert { [r mc.exec exec] == {{} 1} }
+        r mc.delete
+    }
+
+    test {test persistent client with user acl} {
+        r del x
+        r set x 1
+        r mc.delete
+        r mc.create
+        r mc.reset_users
+        r mc.set_user_acl client-user "~* &* +@all -set"
+        assert_equal [r mc.exec_with_client_user get x] 1
+        catch {r mc.exec_with_client_user set x 1} e
+        assert_match {*NOPERM User client-user has no permissions to run the 'set' command*} $e
+        r mc.free_users
+    }
+
+    test {test persistent client with user and ctx with user} {
+        r del x
+        r set x 1
+        r mc.delete
+        r mc.create
+        r mc.reset_users
+        r mc.set_user_acl client-user "~* &* +@all -set"
+        r mc.set_user_acl context-user "~* &* +@all -get"
+        catch {r mc.exec_with_client_and_ctx_user get x} e
+        assert_match {*NOPERM User context-user has no permissions to run the 'get' command*} $e
+        r mc.free_users
     }
 }


### PR DESCRIPTION
This enables modules to use WATCH / MULTI / EXEC to benefit from Redis's conception of transactions.

Current RM_Call uses a dedicated temporary client per each call, which makes each call an isolated call. Despite this behaviour for modules, Redis has a concept of dependency between commands, such in Redis transactions. This PR introduces a way to connect between several calls by having a new persistent client: `RedisModuleClient`. This client should be maintained by the module itself in cases persistence is needed. A common use case for modules can be transactions: a  persistent client will enable modules to call `MULTI`- transaction commands -`EXEC` one by one with RM_Call and preserve the logic of transactions, or to call `WATCH` and use the same client for the whole transaction execution to support watched keys concept.

It adds 6 new RM_ APIs

- RM_CreateModuleClient() - creates the object.
- RM_FreeModuleClient() - frees the object.
- RM_SetClientUser() - associate a RedisModuleUser object with the client for ACL validation purposes.
- RM_SetContextClient() - associates object with a given context so that RM_Call will use it instead of a temp client.
- RM_GetClientFlags() - gets the flag set that the RM API exposes (not all flags, currently just the 2 dirty flags).
- RM_GetClientFlagsAll() - used for modules to determine what flags are supported.