### PR TITLE
Fix bug: LPOS RANK LONG_ MIN causes overflow

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -971,7 +971,7 @@ void lposCommand(client *c) {
 
         if (!strcasecmp(opt,"RANK") && moreargs) {
             j++;
-            if (getLongFromObjectOrReply(c, c->argv[j], &rank, NULL) != C_OK)
+            if (getRangeLongFromObjectOrReply(c, c->argv[j], -LONG_MAX, LONG_MAX, &rank, NULL) != C_OK)
                 return;
             if (rank == 0) {
                 addReplyError(c,"RANK can't be zero: use 1 to start from "

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -464,6 +464,7 @@ foreach {type large} [array get largevalue] {
         assert {[r LPOS mylist c RANK -1] == 7}
         assert {[r LPOS mylist c RANK -2] == 6}
         assert_error "*RANK can't be zero: use 1 to start from the first match, 2 from the second ... or use negative to start*" {r LPOS mylist c RANK 0}
+        assert_error "*value is out of range*" {r LPOS mylist c RANK -9223372036854775808}
     }
 
     test {LPOS COUNT option} {


### PR DESCRIPTION
Fix a minor bug reported by #12165 

Limit the range of `RANK` to `-LONG_ MAX ~ LONG_ MAX`.
Without this limit, passing -9223372036854775808 would effectively be the same as passing -1.