### PR TITLE
improve performance for keys with expiration time

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1557,9 +1557,6 @@ void swapdbCommand(client *c) {
  *----------------------------------------------------------------------------*/
 
 int removeExpire(redisDb *db, robj *key) {
-    /* An expire may only be removed if there is a corresponding entry in the
-     * main dict. Otherwise, the key will never be freed. */
-    serverAssertWithInfo(NULL,key,dictFind(db->dict,key->ptr) != NULL);
     return dictDelete(db->expires,key->ptr) == DICT_OK;
 }
 
@@ -1590,9 +1587,6 @@ long long getExpire(redisDb *db, robj *key) {
     if (dictSize(db->expires) == 0 ||
        (de = dictFind(db->expires,key->ptr)) == NULL) return -1;
 
-    /* The entry was found in the expire dict, this means it should also
-     * be present in the main dict (safety check). */
-    serverAssertWithInfo(NULL,key,dictFind(db->dict,key->ptr) != NULL);
     return dictGetSignedIntegerVal(de);
 }
 


### PR DESCRIPTION
This change only affects keys with expiry time.
For SETEX, the average improvement is 5%, and for GET with expiation key, we gain a improvement of 13%.

When keys have expiration time, Redis has an assertion to look up the main dict every time when it touches the expires.
This comes with a performance const, especially during rehash. the damage will be double.

It looks like that assert was added some ten years old, maybe out of paranoia, and there's probably no reason to keep it at that cost.