### PR TITLE
Allow bigger tolerance in eventloop duration test.

### DIFF
--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -290,9 +290,9 @@ start_server {tags {"info" "external:skip"}} {
             assert_morethan $cycle2 $cycle1
             assert_lessthan $cycle2 [expr $cycle1+10] ;# we expect 2 or 3 cycles here, but allow some tolerance
             assert_morethan $el_sum2 $el_sum1
-            assert_lessthan $el_sum2 [expr $el_sum1+5000] ;# we expect roughly 100ms here, but allow some tolerance
+            assert_lessthan $el_sum2 [expr $el_sum1+10000] ;# we expect roughly 100ms here, but allow some tolerance
             assert_morethan $cmd_sum2 $cmd_sum1
-            assert_lessthan $cmd_sum2 [expr $cmd_sum1+3000] ;# we expect about tens of ms here, but allow some tolerance
+            assert_lessthan $cmd_sum2 [expr $cmd_sum1+5000] ;# we expect about tens of ms here, but allow some tolerance
         }
  
         test {stats: instantaneous metrics} {


### PR DESCRIPTION
In #11963, some new tests about eventloop duration were added, which includes time measurement in TCL scripts. This has caused some unexpected CI failures, such as #12169 and #12177, due to slow test servers or some performance jittering.