### PR TITLE
Replace gettimeofday with clock_gettime

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -9642,8 +9642,8 @@ static void intrinsicLatencyMode(void) {
         }
 
         if (force_cancel_loop || end > test_end) {
-           double avg_ns = (double)run_time/runs;
-           printf("\n%lld total runs "
+            double avg_ns = (double)run_time/runs;
+            printf("\n%lld total runs "
                 "(avg latency: "
                 "%.4f microseconds / %.2f nanoseconds per run).\n",
                 runs, (avg_ns/1e3), avg_ns);


### PR DESCRIPTION
First, gettimeofday will be obsolete.
(https://man7.org/linux/man-pages/man2/gettimeofday.2.html)

Second, gettimeofday is a systemcall.
But clock_gettime is in libc library in libc and faster.

**AND I am not able to test code for MAC because I don't have it.
Please forgive me to upload not-tested code.
I hope somebody test it.**
