### PR TITLE
XREADGROUP: Redundant dirty++ edge case

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1576,6 +1576,7 @@ void streamPropagateXCLAIM(client *c, robj *key, streamCG *group, robj *groupnam
     argv[13] = createObjectFromStreamID(&group->last_id);
 
     alsoPropagate(c->db->id,argv,14,PROPAGATE_AOF|PROPAGATE_REPL);
+    server.dirty++;
 
     decrRefCount(argv[3]);
     decrRefCount(argv[7]);
@@ -1600,6 +1601,7 @@ void streamPropagateGroupID(client *c, robj *key, streamCG *group, robj *groupna
     argv[6] = createStringObjectFromLongLong(group->entries_read);
 
     alsoPropagate(c->db->id,argv,7,PROPAGATE_AOF|PROPAGATE_REPL);
+    server.dirty++;
 
     decrRefCount(argv[4]);
     decrRefCount(argv[6]);
@@ -1837,6 +1839,7 @@ size_t streamReplyWithRangeFromConsumerPEL(client *c, stream *s, streamID *start
             streamNACK *nack = ri.data;
             nack->delivery_time = commandTimeSnapshot();
             nack->delivery_count++;
+            server.dirty++;
         }
         arraylen++;
     }
@@ -2391,7 +2394,6 @@ void xreadCommand(client *c) {
             streamReplyWithRange(c,s,&start,NULL,count,0,
                                  groups ? groups[i] : NULL,
                                  consumer, flags, &spi);
-            if (groups) server.dirty++;
         }
     }
 
@@ -3240,7 +3242,6 @@ void xclaimCommand(client *c) {
                 /* Propagate this change (we are going to delete the NACK). */
                 streamPropagateXCLAIM(c,c->argv[1],group,c->argv[2],c->argv[j],nack);
                 propagate_last_id = 0; /* Will be propagated by XCLAIM itself. */
-                server.dirty++;
                 /* Release the NACK */
                 raxRemove(group->pel,buf,sizeof(buf),NULL);
                 raxRemove(nack->consumer->pel,buf,sizeof(buf),NULL);
@@ -3305,13 +3306,11 @@ void xclaimCommand(client *c) {
             /* Propagate this change. */
             streamPropagateXCLAIM(c,c->argv[1],group,c->argv[2],c->argv[j],nack);
             propagate_last_id = 0; /* Will be propagated by XCLAIM itself. */
-            server.dirty++;
         }
     }
-    if (propagate_last_id) {
+    if (propagate_last_id)
         streamPropagateGroupID(c,c->argv[1],group,c->argv[2]);
-        server.dirty++;
-    }
+
     setDeferredArrayLen(c,arraylenptr,arraylen);
     preventCommandPropagation(c);
 cleanup:
@@ -3429,7 +3428,6 @@ void xautoclaimCommand(client *c) {
             robj *idstr = createObjectFromStreamID(&id);
             streamPropagateXCLAIM(c,c->argv[1],group,c->argv[2],idstr,nack);
             decrRefCount(idstr);
-            server.dirty++;
             /* Clear this entry from the PEL, it no longer exists */
             raxRemove(group->pel,ri.key,ri.key_len,NULL);
             raxRemove(nack->consumer->pel,ri.key,ri.key_len,NULL);
@@ -3482,7 +3480,6 @@ void xautoclaimCommand(client *c) {
         robj *idstr = createObjectFromStreamID(&id);
         streamPropagateXCLAIM(c,c->argv[1],group,c->argv[2],idstr,nack);
         decrRefCount(idstr);
-        server.dirty++;
     }
 
     /* We need to return the next entry as a cursor for the next XAUTOCLAIM call */

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -1160,6 +1160,33 @@ start_server {
         assert_equal [dict get $consumer seen-time] [dict get $consumer active-time]
     }
 
+    test {XREADGROUP of PEL history and the dirty counter} {
+        r DEL x
+        r XADD x 1-1 f v
+        r XGROUP CREATE x g 0
+        r XGROUP CREATECONSUMER x g Alice
+
+        # First XREADGROUP, should propagate XCLAIM
+        set dirty [s rdb_changes_since_last_save]
+        assert_equal [r XREADGROUP group g Alice streams x >] {{x {{1-1 {f v}}}}}
+        set dirty2 [s rdb_changes_since_last_save]
+        assert {$dirty2 == $dirty + 1}
+
+        # Second XREADGROUP (history), should not propagate anything, but it does update delivery time and count
+        set dirty [s rdb_changes_since_last_save]
+        assert_equal [r XREADGROUP group g Alice streams x 0] {{x {{1-1 {f v}}}}}
+        set dirty2 [s rdb_changes_since_last_save]
+        assert {$dirty2 == $dirty + 1}
+
+        r XDEL x 1-1
+
+        # Third XREADGROUP (history), entry doesn't exist so the dataset doesn't change at all
+        set dirty [s rdb_changes_since_last_save]
+        assert_equal [r XREADGROUP group g Alice streams x 0] {{x {{1-1 {}}}}}
+        set dirty2 [s rdb_changes_since_last_save]
+        assert {$dirty2 == $dirty}
+    }
+
     start_server {tags {"external:skip"}} {
         set master [srv -1 client]
         set master_host [srv -1 host]


### PR DESCRIPTION
In case the PEL has only deleted entries we do not need to increment server.dirty because the key didn't change at all

This commit moves server.dirty++ next to the propagation of XCLAIM/XGROUP SETID rather than in the command proc()