### PR TITLE
Performance improvement to ZADD and ZRANGESTORE, convert to skiplist and expand dict in advance

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -2976,7 +2976,6 @@ unsigned char *zzlFirstInRange(unsigned char *zl, zrangespec *range);
 unsigned char *zzlLastInRange(unsigned char *zl, zrangespec *range);
 unsigned long zsetLength(const robj *zobj);
 void zsetConvert(robj *zobj, int encoding);
-void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap);
 void zsetConvertToListpackIfNeeded(robj *zobj, size_t maxelelen, size_t totelelen);
 int zsetScore(robj *zobj, sds member, double *score);
 unsigned long zslGetRank(zskiplist *zsl, double score, sds o);

--- a/src/server.h
+++ b/src/server.h
@@ -2976,6 +2976,7 @@ unsigned char *zzlFirstInRange(unsigned char *zl, zrangespec *range);
 unsigned char *zzlLastInRange(unsigned char *zl, zrangespec *range);
 unsigned long zsetLength(const robj *zobj);
 void zsetConvert(robj *zobj, int encoding);
+void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap);
 void zsetConvertToListpackIfNeeded(robj *zobj, size_t maxelelen, size_t totelelen);
 int zsetScore(robj *zobj, sds member, double *score);
 unsigned long zslGetRank(zskiplist *zsl, double score, sds o);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1170,7 +1170,9 @@ unsigned long zsetLength(const robj *zobj) {
  *
  * The size hint indicates approximately how many items will be added,
  * and the value len hint indicates the approximate individual size of the added elements,
- * they are used to determine the initial representation. */
+ * they are used to determine the initial representation.
+ *
+ * If the hints are not known, and underestimation or 0 is suitable. */
 robj *zsetTypeCreate(size_t size_hint, size_t val_len_hint) {
     if (size_hint <= server.zset_max_listpack_entries &&
         val_len_hint <= server.zset_max_listpack_value)

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2955,8 +2955,12 @@ static void zrangeResultFinalizeClient(zrange_result_handler *handler,
 /* Result handler methods for storing the ZRANGESTORE to a zset. */
 static void zrangeResultBeginStore(zrange_result_handler *handler, long length)
 {
-    if (length > (long)server.zset_max_listpack_entries)
-        handler->dstobj = createZsetObject();
+    if (length > (long)server.zset_max_listpack_entries) {
+        robj *zobj = createZsetObject();
+        zset *zs = zobj->ptr;
+        dictExpand(zs->dict, length);
+        handler->dstobj = zobj;
+    }
     else
         handler->dstobj = createZsetListpackObject();
 }

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2285,7 +2285,9 @@ start_server {tags {"zset"}} {
         r config set zset-max-listpack-entries 0
         r del z1{t} z2{t}
         r zadd z1{t} 1 a
+        assert_encoding skiplist z1{t}
         assert_equal 1 [r zrangestore z2{t} z1{t} 0 -1]
+        assert_encoding skiplist z2{t}
         r config set zset-max-listpack-entries $original_max
     }
 
@@ -2615,5 +2617,38 @@ start_server {tags {"zset"}} {
         r config set set-max-intset-entries 512
         r config set set-max-listpack-entries 128
         r config set zset-max-listpack-entries 128
+    }
+
+    foreach type {single multiple single_multiple} {
+        test "ZADD overflows the maximum allowed elements in a listpack - $type" {
+            r del myzset
+
+            set max_entries 64
+            set original_max [lindex [r config get zset-max-listpack-entries] 1]
+            r config set zset-max-listpack-entries $max_entries
+
+            if {$type == "single"} {
+                # All are single zadd commands.
+                for {set i 0} {$i < $max_entries} {incr i} { r zadd myzset $i $i }
+            } elseif {$type == "multiple"} {
+                # One zadd command to add all elements.
+                set args {}
+                for {set i 0} {$i < $max_entries * 2} {incr i} { lappend args $i }
+                r zadd myzset {*}$args
+            } elseif {$type == "single_multiple"} {
+                # First one zadd adds an element (creates a key) and then one zadd adds all elements.
+                r zadd myzset 1 1
+                set args {}
+                for {set i 0} {$i < $max_entries * 2} {incr i} { lappend args $i }
+                r zadd myzset {*}$args
+            }
+
+            assert_encoding listpack myzset
+            assert_equal $max_entries [r zcard myzset]
+            assert_equal 1 [r zadd myzset 1 b]
+            assert_encoding skiplist myzset
+
+            r config set zset-max-listpack-entries $original_max
+        }
     }
 }


### PR DESCRIPTION
For zsets that will eventually be stored as the skiplist encoding (has a dict),
we can convert it to skiplist ahead of time. This change checks the number
of arguments in the ZADD command, and converts the data-structure
if the number of new entries exceeds the listpack-max-entries configuration.
This can cause us to over-allocate memory if there are duplicate entries in the
input, which is unexpected.

For ZRANGESTORE, we know the size of the zset, so we can expand
the dict in advance, to avoid the temporary dict from being rehashed
while it grows.

Simple benchmarks shows it provides some 4% improvement in ZADD and 20% in ZRANGESTORE

## ZADD
on a 1c2g machine, some very basic benchmarking using:
```
src/redis-benchmark -P 100 -n 100000 ZADD __rand_int__ `python -c "print(' '.join([str(a) for a in range(888)]))"`
```

unstable:
```
Summary:
  throughput summary: 9203.87 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       15.874    12.392    15.359    21.391    24.959    27.055
```

this branch:
```
Summary:
  throughput summary: 9563.89 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       15.336    12.224    14.615    21.791    24.959    28.271
```

## ZRANGESTORE

zrangestore benchmark: unstable took some 5.84 seconds, and this branch
took 4.57 seconds. so about a 20% improvement. (1c2g machine)
```
src/redis-cli zadd z 1 1 2 2 3 3 4 4 5 5 6 6 7 7 8 8 9 9 10 10 11 11 12 12 13 13 14 14 15 15 16 16 17 17 18 18 19 19 20 20 21 21 22 22 23 23 24 24 25 25 26 26 27 27 28 28 29 29 30 30 31 31 32 32 33 33 34 34 35 35 36 36 37 37 38 38 39 39 30 40
src/redis-cli config set zset-max-listpack-entries 38
src/redis-benchmark -P 100 -n 400000 zrangestore z2 z 0 -1
```