### PR TITLE
Adding database index and ACL user name value in output of slowlog command

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -7424,6 +7424,7 @@ struct COMMAND_ARG SLAVEOF_Args[] = {
 /* SLOWLOG GET history */
 commandHistory SLOWLOG_GET_History[] = {
 {"4.0.0","Added client IP address, port and name to the reply."},
+{"7.2.0","Added database index and acl username to the reply."},
 };
 #endif
 
@@ -7505,7 +7506,7 @@ const char *SLOWLOG_RESET_Tips[] = {
 
 /* SLOWLOG command table */
 struct COMMAND_STRUCT SLOWLOG_Subcommands[] = {
-{MAKE_CMD("get","Returns the slow log's entries.","O(N) where N is the number of entries returned","2.2.12",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SLOWLOG_GET_History,1,SLOWLOG_GET_Tips,2,slowlogCommand,-2,CMD_ADMIN|CMD_LOADING|CMD_STALE,0,SLOWLOG_GET_Keyspecs,0,NULL,1),.args=SLOWLOG_GET_Args},
+{MAKE_CMD("get","Returns the slow log's entries.","O(N) where N is the number of entries returned","2.2.12",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SLOWLOG_GET_History,2,SLOWLOG_GET_Tips,2,slowlogCommand,-2,CMD_ADMIN|CMD_LOADING|CMD_STALE,0,SLOWLOG_GET_Keyspecs,0,NULL,1),.args=SLOWLOG_GET_Args},
 {MAKE_CMD("help","Show helpful text about the different subcommands","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SLOWLOG_HELP_History,0,SLOWLOG_HELP_Tips,0,slowlogCommand,2,CMD_LOADING|CMD_STALE,0,SLOWLOG_HELP_Keyspecs,0,NULL,0)},
 {MAKE_CMD("len","Returns the number of entries in the slow log.","O(1)","2.2.12",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SLOWLOG_LEN_History,0,SLOWLOG_LEN_Tips,3,slowlogCommand,2,CMD_ADMIN|CMD_LOADING|CMD_STALE,0,SLOWLOG_LEN_Keyspecs,0,NULL,0)},
 {MAKE_CMD("reset","Clears all entries from the slow log.","O(N) where N is the number of entries in the slowlog","2.2.12",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SLOWLOG_RESET_History,0,SLOWLOG_RESET_Tips,2,slowlogCommand,2,CMD_ADMIN|CMD_LOADING|CMD_STALE,0,SLOWLOG_RESET_Keyspecs,0,NULL,0)},

--- a/src/commands/slowlog-get.json
+++ b/src/commands/slowlog-get.json
@@ -11,6 +11,10 @@
             [
                 "4.0.0",
                 "Added client IP address, port and name to the reply."
+            ],
+            [
+                "7.2.0",
+                "Added database index and acl username to the reply."
             ]
         ],
         "command_flags": [
@@ -28,8 +32,8 @@
             "uniqueItems": true,
             "items": {
                 "type": "array",
-                "minItems": 6,
-                "maxItems": 6,
+                "minItems": 8,
+                "maxItems": 8,
                 "items": [
                     {
                         "type": "integer",
@@ -59,6 +63,14 @@
                     {
                         "type": "string",
                         "description": "Client name if set via the CLIENT SETNAME command."
+                    },
+                    {
+                        "type": "integer",
+                        "description": "database index value which represents which database client executes the command."
+                    },
+                    {
+                        "type": "string",
+                        "description": "acl username."
                     }
                 ]
             }

--- a/src/slowlog.h
+++ b/src/slowlog.h
@@ -42,6 +42,8 @@ typedef struct slowlogEntry {
     time_t time;        /* Unix time at which the query was executed. */
     sds cname;          /* Client name. */
     sds peerid;         /* Client network address. */
+    sds acluname;
+    int dbindex;
 } slowlogEntry;
 
 /* Exported API */

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -50,7 +50,6 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
     } {} {needs:debug}
 
     test {SLOWLOG - logged entry ACL and dbindex check} {
-        r SELECT 9
         r config set slowlog-log-slower-than 0
         r slowlog reset
         r set k1 0

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -49,12 +49,11 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         assert_equal {foobar} [lindex $e 5]
     } {} {needs:debug}
 
-    test {SLOWLOG - logged entry ACL and dbindex check} {
+    test {SLOWLOG - logged entry ACL username} {
         r config set slowlog-log-slower-than 0
         r slowlog reset
         r set k1 0
         set e [lindex [r slowlog get] 0]
-        assert_equal {9} [lindex $e 6]
         assert_equal {default} [lindex $e 7]
 
         r ACL setuser user1 +@all allkeys
@@ -62,7 +61,6 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         r AUTH user1 passwd1
         r set k1 0
         set e [lindex [r slowlog get] 0]
-        assert_equal {9} [lindex $e 6]
         assert_equal {user1} [lindex $e 7]
     }
 


### PR DESCRIPTION
Current slowlog get command return the following 6 values as below:

![image](https://github.com/redis/redis/assets/51993843/cb175feb-ad11-4568-8711-e1503fbc43c6)

We want to add another two Value. 
1. database index value which represents which database client executes the command
2. acl username (default username is "default")

Proposed output of slowlog
![acl proposed](https://github.com/redis/redis/assets/51993843/62be0fcc-938f-45bf-ab2c-76bbe7295f53)


