### PR TITLE
replica redirect read&write to master in standalone mode

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -823,6 +823,18 @@ replica-priority 100
 # replica-announce-ip 5.5.5.5
 # replica-announce-port 1234
 
+# You can configure a replica instance to redirect data access commands
+# to its master or not, excluding commands such as:
+# INFO, AUTH, ROLE, SUBSCRIBE, UNSUBSCRIBE, PUBLISH.
+#
+# When enable it, a replica instance will reply "-MOVE -1 master-ip:port"
+# for data access commands. Normally they are write or read commands, if
+# you want to run read commands while replica-enable-redirect is enabled,
+# please apply READONLY command at first.
+#
+# This config only takes effect in standalone mode.
+replica-enable-redirect no
+
 ############################### KEYS TRACKING #################################
 
 # Redis implements server assisted support for client side caching of values.

--- a/redis.conf
+++ b/redis.conf
@@ -827,10 +827,10 @@ replica-priority 100
 # to its master or not, excluding commands such as:
 # INFO, AUTH, ROLE, SUBSCRIBE, UNSUBSCRIBE, PUBLISH.
 #
-# When enable it, a replica instance will reply "-MOVE -1 master-ip:port"
-# for data access commands. Normally they are write or read commands, if
+# When enabled, a replica instance will reply "-MOVED -1 master-ip:port"
+# for data access commands. Normally these are write or read commands, if
 # you want to run read commands while replica-enable-redirect is enabled,
-# please apply READONLY command at first.
+# use the READONLY command first.
 #
 # This config only takes effect in standalone mode.
 replica-enable-redirect no

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -6942,20 +6942,12 @@ void askingCommand(client *c) {
  * In this mode slaves will not redirect clients as long as clients access
  * with read-only commands to keys that are served by the slave's master. */
 void readonlyCommand(client *c) {
-    if (server.cluster_enabled == 0) {
-        addReplyError(c,"This instance has cluster support disabled");
-        return;
-    }
     c->flags |= CLIENT_READONLY;
     addReply(c,shared.ok);
 }
 
 /* The READWRITE command just clears the READONLY command state. */
 void readwriteCommand(client *c) {
-    if (server.cluster_enabled == 0) {
-        addReplyError(c,"This instance has cluster support disabled");
-        return;
-    }
     c->flags &= ~CLIENT_READONLY;
     addReply(c,shared.ok);
 }

--- a/src/config.c
+++ b/src/config.c
@@ -3058,7 +3058,7 @@ standardConfig static_configs[] = {
     createBoolConfig("replica-serve-stale-data", "slave-serve-stale-data", MODIFIABLE_CONFIG, server.repl_serve_stale_data, 1, NULL, NULL),
     createBoolConfig("replica-read-only", "slave-read-only", DEBUG_CONFIG | MODIFIABLE_CONFIG, server.repl_slave_ro, 1, NULL, NULL),
     createBoolConfig("replica-ignore-maxmemory", "slave-ignore-maxmemory", MODIFIABLE_CONFIG, server.repl_slave_ignore_maxmemory, 1, NULL, NULL),
-    createBoolConfig("replica-redirect-read-write", NULL, MODIFIABLE_CONFIG, server.repl_replica_redirect_rw, 0, NULL, NULL),
+    createBoolConfig("replica-enable-redirect", NULL, MODIFIABLE_CONFIG, server.repl_replica_enable_redirect, 0, NULL, NULL),
     createBoolConfig("jemalloc-bg-thread", NULL, MODIFIABLE_CONFIG, server.jemalloc_bg_thread, 1, NULL, updateJemallocBgThread),
     createBoolConfig("activedefrag", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.active_defrag_enabled, 0, isValidActiveDefrag, NULL),
     createBoolConfig("syslog-enabled", NULL, IMMUTABLE_CONFIG, server.syslog_enabled, 0, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3058,6 +3058,7 @@ standardConfig static_configs[] = {
     createBoolConfig("replica-serve-stale-data", "slave-serve-stale-data", MODIFIABLE_CONFIG, server.repl_serve_stale_data, 1, NULL, NULL),
     createBoolConfig("replica-read-only", "slave-read-only", DEBUG_CONFIG | MODIFIABLE_CONFIG, server.repl_slave_ro, 1, NULL, NULL),
     createBoolConfig("replica-ignore-maxmemory", "slave-ignore-maxmemory", MODIFIABLE_CONFIG, server.repl_slave_ignore_maxmemory, 1, NULL, NULL),
+    createBoolConfig("replica-redirect-read-write", NULL, MODIFIABLE_CONFIG, server.repl_replica_redirect_rw, 0, NULL, NULL),
     createBoolConfig("jemalloc-bg-thread", NULL, MODIFIABLE_CONFIG, server.jemalloc_bg_thread, 1, NULL, updateJemallocBgThread),
     createBoolConfig("activedefrag", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.active_defrag_enabled, 0, isValidActiveDefrag, NULL),
     createBoolConfig("syslog-enabled", NULL, IMMUTABLE_CONFIG, server.syslog_enabled, 0, NULL, NULL),

--- a/src/server.c
+++ b/src/server.c
@@ -3968,6 +3968,17 @@ int processCommand(client *c) {
         }
     }
 
+    if (!server.cluster_enabled &&
+        server.masterhost &&
+        !mustObeyClient(c) &&
+        server.repl_replica_redirect_rw &&
+        (is_write_command ||
+         (is_read_command && !(c->flags & CLIENT_READONLY)))) {
+        addReplyErrorSds(c,sdscatprintf(sdsempty(), "-MOVED -1 %s:%d",
+                                                    server.masterhost, server.masterport));
+        return C_OK;
+    }
+
     /* Disconnect some clients if total clients memory is too high. We do this
      * before key eviction, after the last command was executed and consumed
      * some client output buffer memory. */

--- a/src/server.c
+++ b/src/server.c
@@ -3971,7 +3971,7 @@ int processCommand(client *c) {
     if (!server.cluster_enabled &&
         server.masterhost &&
         !mustObeyClient(c) &&
-        server.repl_replica_redirect_rw &&
+        server.repl_replica_enable_redirect &&
         (is_write_command ||
          (is_read_command && !(c->flags & CLIENT_READONLY)))) {
         addReplyErrorSds(c,sdscatprintf(sdsempty(), "-MOVED -1 %s:%d",

--- a/src/server.h
+++ b/src/server.h
@@ -1886,6 +1886,7 @@ struct redisServer {
     int repl_serve_stale_data; /* Serve stale data when link is down? */
     int repl_slave_ro;          /* Slave is read only? */
     int repl_slave_ignore_maxmemory;    /* If true slaves do not evict. */
+    int repl_replica_redirect_rw;       /* If true replica would redirect read&write commands to master. */
     time_t repl_down_since; /* Unix time at which link with master went down */
     int repl_disable_tcp_nodelay;   /* Disable TCP_NODELAY after SYNC? */
     int slave_priority;             /* Reported in INFO and used by Sentinel. */

--- a/src/server.h
+++ b/src/server.h
@@ -1886,7 +1886,7 @@ struct redisServer {
     int repl_serve_stale_data; /* Serve stale data when link is down? */
     int repl_slave_ro;          /* Slave is read only? */
     int repl_slave_ignore_maxmemory;    /* If true slaves do not evict. */
-    int repl_replica_redirect_rw;       /* If true replica would redirect read&write commands to master. */
+    int repl_replica_enable_redirect;   /* If true replica would redirect read&write commands to master. */
     time_t repl_down_since; /* Unix time at which link with master went down */
     int repl_disable_tcp_nodelay;   /* Disable TCP_NODELAY after SYNC? */
     int slave_priority;             /* Reported in INFO and used by Sentinel. */

--- a/tests/integration/replica-redirect.tcl
+++ b/tests/integration/replica-redirect.tcl
@@ -1,0 +1,31 @@
+start_server {tags {needs:repl external:skip}} {
+    start_server {} {
+        set master_host [srv -1 host]
+        set master_port [srv -1 port]
+
+        r replicaof $master_host $master_port
+        wait_for_condition 50 100 {
+            [s 0 master_link_status] eq {up}
+        } else {
+            fail "Replicas not replicating from master"
+        }
+
+        test {replica allow read command by default} {
+            r get foo
+        } {}
+
+        test {replica reply READONLY error for write command by default} {
+            assert_error {READONLY*} {r set foo bar}
+        }
+
+        test {replica redirect read and write command when enable replica-enable-redirect} {
+            r config set replica-enable-redirect yes
+            assert_error "MOVED -1 $master_host:$master_port" {r set foo bar}
+            assert_error "MOVED -1 $master_host:$master_port" {r get foo}
+        }
+
+        test {non-data access commands are not redirected} {
+            r ping
+        } {PONG}
+    }
+}

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -67,6 +67,7 @@ set ::all_tests {
     integration/redis-cli
     integration/redis-benchmark
     integration/dismiss-mem
+    integration/replica-redirect
     unit/pubsub
     unit/pubsubshard
     unit/slowlog


### PR DESCRIPTION
To implement #12097

1. replica is able to redirect read and write commands to it's master in standalone mode
    * reply with "-MOVED -1 master-ip:port"
2. add a config `replica-enable-redirect` to control whether to redirect or not, with the default setting being off
    * when enabled, the data access commands(read and write) will be redirected
3. allow `readonly` and `readwrite` command in standalone mode, may be a breaking change
    * use READONLY command can allow read commands on a replica when `replica-enable-redirect` enabled

other tips:
1. pubsub commands are not redirected
2. the tls&tcp multi ports problem are not addressed