### PR TITLE
fix CMD_CALL_FROM_MODULE value

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -591,9 +591,9 @@ typedef enum {
 #define CMD_CALL_PROPAGATE_AOF (1<<0)
 #define CMD_CALL_PROPAGATE_REPL (1<<1)
 #define CMD_CALL_REPROCESSING (1<<2)
+#define CMD_CALL_FROM_MODULE (1<<3)  /* From RM_Call */
 #define CMD_CALL_PROPAGATE (CMD_CALL_PROPAGATE_AOF|CMD_CALL_PROPAGATE_REPL)
 #define CMD_CALL_FULL (CMD_CALL_PROPAGATE)
-#define CMD_CALL_FROM_MODULE (1<<2)  /* From RM_Call */
 
 /* Command propagation flags, see propagateNow() function */
 #define PROPAGATE_NONE 0


### PR DESCRIPTION
CMD_CALL_FROM_MODULE overlapped CMD_CALL_REPROCESSING, changing its value to (1<<3)
This was introduced in 7.2, https://github.com/redis/redis/pull/11568
The implications were that commands executed via RM_Call would be missing from the MONITOR