### PR TITLE
Add the actual keys' values hint instead of only hint word key for GET command.

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1522,7 +1522,7 @@ static void addActualKeysValuesHint(const sds* secondArgv, hisds* hint) {
         redisReply *reply = NULL;
         unsigned int cur = 0, cnt = 0;
         do {
-            reply = redisCommand(context,"SCAN %d MATCH %s COUNT 1",cur, matchPattern);
+            reply = redisCommand(context,"SCAN %d MATCH %s COUNT 10000",cur, matchPattern);
             cur = atoi(reply->element[0]->str);
             reply = reply->element[1];
 

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1507,7 +1507,7 @@ static helpEntry* findHelpEntry(int argc, char **argv) {
  * 1) The hint value to be "key"
  * 2) SCAN command(since: v2.8.0) with pattern[PREFIX*]
  * 
- * The default hints_keys_values is '0' (OFF).
+ * By default hints_keys_values is OFF.
  * The default hints_keys_values_count is 5 keys.
  */
 static void addActualKeysValuesHint(const sds* secondArgv, hisds* hint) {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -281,8 +281,15 @@ static struct config {
 
 /* User preferences. */
 static struct pref {
-    int hints;
+    // Hints
+    char hints;
+    char hints_keys_values;
+    unsigned int hints_keys_values_count;
 } pref;
+#define HINTS_ON                    '1'
+#define HINTS_OFF                   '0'
+#define HINTS_KEYS_VALUES_COUNT     5
+#define HINTS_KEYS_VALUES_COUNT_MAX 20
 
 static volatile sig_atomic_t force_cancel_loop = 0;
 static void usage(int err);
@@ -974,6 +981,9 @@ static void cliOutputGenericHelp(void) {
         "To set redis-cli preferences:\n"
         "      \":set hints\" enable online hints\n"
         "      \":set nohints\" disable online hints\n"
+        "      \":set hints-keys-values\" enable online hints of actual keys' values\n"
+        "      \":set nohints-keys-values\" enable online hints of actual keys' values\n"
+        "      \":set hints-keys-value-counts X\" set online hints of actual keys' values to X items (default: 5, max: 20)\n"
         "Set your preferences in ~/.redisclirc\n",
         version
     );
@@ -1491,11 +1501,58 @@ static helpEntry* findHelpEntry(int argc, char **argv) {
     return entry;
 }
 
+/* Add the actual keys' values hint instead of only hint word "key" for GET command.
+ *
+ * This method depends on:
+ * 1) The hint value to be "key"
+ * 2) SCAN command(since: v2.8.0) with pattern[PREFIX*]
+ *  
+ * The default hints_keys_values_count is 5 keys.
+ */
+static void addActualKeysValuesHint(const sds* secondArgv, hisds* hint) {
+
+    if (*secondArgv && *hint && strcmp((*hint), "key") == 0) {
+
+        (*hint) = sdsnew("key: [ ");
+
+        // Form pattern: e.g. "GET X" pattern will be "X*"
+        sds matchPattern = sdsnew((*secondArgv));
+        matchPattern = sdscat(matchPattern, "*");
+        
+        redisReply *reply = NULL;
+        unsigned int cur = 0, cnt = 0;
+        do {
+            reply = redisCommand(context,"SCAN %d MATCH %s COUNT 1",cur, matchPattern);
+            cur = atoi(reply->element[0]->str);
+            reply = reply->element[1];
+
+            for (unsigned int j = 0; j < reply->elements; j++) {
+                (*hint) = sdscat((*hint), reply->element[j]->str);
+                (*hint) = sdscat((*hint), ", ");
+                if (++cnt >= pref.hints_keys_values_count) {
+                    cur = 0;
+                    break;
+                }
+            }
+        } while(cur != 0 && cnt < pref.hints_keys_values_count);
+
+        (*hint) = sdscat((*hint), "]");
+
+        sdsfree(matchPattern);
+        freeReplyObject(reply);
+    }
+}
+
 /* Returns the command-line hint string for a given partial input. */
 static sds getHintForInput(const char *charinput) {
     sds hint = NULL;
+
     int inputargc, inputlen = strlen(charinput);
     sds *inputargv = sdssplitargs(charinput, &inputargc);
+
+    int secondArgc;
+    sds *secondArgv = sdssplitargs(charinput+3, &secondArgc);
+
     int endspace = inputlen && isspace(charinput[inputlen-1]);
 
     /* Don't match the last word until the user has typed a space after it. */
@@ -1505,13 +1562,20 @@ static sds getHintForInput(const char *charinput) {
     if (entry) {
        hint = makeHint(inputargv, matchargc, entry->argc, entry->docs);
     }
+    
+    if (pref.hints_keys_values == HINTS_ON && !endspace && *secondArgv) {
+        addActualKeysValuesHint(secondArgv, &hint);
+    }
+
     sdsfreesplitres(inputargv, inputargc);
+    sdsfreesplitres(secondArgv, secondArgc);
+
     return hint;
 }
 
 /* Linenoise hints callback. */
 static char *hintsCallback(const char *buf, int *color, int *bold) {
-    if (!pref.hints) return NULL;
+    if (pref.hints != HINTS_ON) return NULL;
 
     sds hint = getHintForInput(buf);
     if (hint == NULL) {
@@ -3219,8 +3283,21 @@ static sds *cliSplitArgs(char *line, int *argc) {
  * set user preferences. */
 void cliSetPreferences(char **argv, int argc, int interactive) {
     if (!strcasecmp(argv[0],":set") && argc >= 2) {
-        if (!strcasecmp(argv[1],"hints")) pref.hints = 1;
-        else if (!strcasecmp(argv[1],"nohints")) pref.hints = 0;
+        if (!strcasecmp(argv[1],"hints")) pref.hints = HINTS_ON;
+        else if (!strcasecmp(argv[1],"nohints")) pref.hints = HINTS_OFF;
+        else if (!strcasecmp(argv[1],"hints-keys-values")) pref.hints_keys_values = HINTS_ON;
+        else if (!strcasecmp(argv[1],"hints-keys-values-count")){
+            if (argc >= 3) {
+                int hints_keys_values_count_value = atoi(argv[2]);
+                if (hints_keys_values_count_value < 1 || hints_keys_values_count_value > HINTS_KEYS_VALUES_COUNT_MAX) {
+                    hints_keys_values_count_value = HINTS_KEYS_VALUES_COUNT;
+                }
+                pref.hints_keys_values_count = hints_keys_values_count_value;
+            } else {
+                pref.hints_keys_values_count = HINTS_KEYS_VALUES_COUNT;
+            }
+        }
+        else if (!strcasecmp(argv[1],"nohints-keys-values")) pref.hints_keys_values = HINTS_OFF;
         else {
             printf("%sunknown redis-cli preference '%s'\n",
                 interactive ? "" : ".redisclirc: ",
@@ -9820,7 +9897,9 @@ int main(int argc, char **argv) {
     config.cluster_manager_command.threshold =
         CLUSTER_MANAGER_REBALANCE_THRESHOLD;
     config.cluster_manager_command.backup_dir = NULL;
-    pref.hints = 1;
+    pref.hints = HINTS_ON;
+    pref.hints_keys_values = HINTS_ON;
+    pref.hints_keys_values_count = HINTS_KEYS_VALUES_COUNT;
 
     spectrum_palette = spectrum_palette_color;
     spectrum_palette_size = spectrum_palette_color_size;


### PR DESCRIPTION
## redis-cli key values hints

```c
/* Add the actual keys' values hint instead of only hint word "key" for GET command.
 *
 * This method depends on:
 * 1) The hint value to be "key"
 * 2) SCAN command(since: v2.8.0) with pattern[PREFIX*]
 * 
 * By default hints_keys_values is OFF.
 * The default hints_keys_values_count is 5 keys.
 */
 ```


-------------------------------------------------------------

<center>


Here is a screencast demo:


https://github.com/khaledalam/redis-cli-key-values-hints/assets/8682067/89aba5ae-0784-4a3e-ac80-ed3e36e46499

</center>


It's like chating with server while typing before hit Enter but it works like that only if:
- User allow that by adding `:set hints-keys-values` in CLI preferences `~/.redisclirc` file  (i just changed the default value of this mechanism to be OFF)
- GET command is used
- Original hint value is the word `key`

### Example:
if we have stored pairs values like this:<br/>

<small>_MSET a test1 aa test2 aab test3 aaz test4 abc test5 aah test6 baa test7 bab test8 bbb test9 bbz test10_</small>

```
[
    "a":    "test1",
    "aa":   "test2",
    "aab":  "test3",
    "aaz":  "test4",
    "abc":  "test5",
    "aah":  "test6",
    "baa":  "test7",
    "bab":  "test8",
    "bbb":  "test9",
    "bbz":  "test10",
]
```


While writing in redis-cli `GET aa` the hint will be like this:

$ GET aa <span style="color:gray;">key: [ aa, aah, aaz, aab, ]</span>
<img width="368" alt="redis-key-values-hints1" src="https://github.com/redis/redis/assets/8682067/838b2fbb-1e27-429d-9524-e673591f01d8">

While writing in redis-cli `GET b` the hint will be like this:

$ GET b <span style="color:gray;">key: [ bbb, bba, bab, bbz, ]</span>
<img width="365" alt="redis-key-values-hints2" src="https://github.com/redis/redis/assets/8682067/e5340ccd-2dc1-4920-a5a5-68918e13972f">

While writing in redis-cli `GET ba` the hint will be like this:

$ GET ba <span style="color:gray;">key: [ baa, bab, ]</span>
<img width="309" alt="redis-key-values-hints3" src="https://github.com/redis/redis/assets/8682067/c38fecbb-be23-4b7c-9cce-b9cd6f28b91b">
## User preferences

- Added the ability of setting the actual key' values hint ON and OFF using `:set hints_keys_values` in `~/.redisclirc` file. (by default it's OFF)
- Added the ability of setting number of actual key' values items count (default: 5, max: 20) using `:set hints_keys_values_count X` in `~/.redisclirc` file.


