### PR TITLE
Add ability for modules to know which client is being cmd filtered

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -356,6 +356,7 @@ typedef struct RedisModuleCommandFilterCtx {
     RedisModuleString **argv;
     int argv_len;
     int argc;
+    client *c;
 } RedisModuleCommandFilterCtx;
 
 typedef void (*RedisModuleCommandFilterFunc) (RedisModuleCommandFilterCtx *filter);
@@ -10634,7 +10635,8 @@ void moduleCallCommandFilters(client *c) {
     RedisModuleCommandFilterCtx filter = {
         .argv = c->argv,
         .argv_len = c->argv_len,
-        .argc = c->argc
+        .argc = c->argc,
+        .c = c
     };
 
     while((ln = listNext(&li))) {
@@ -10725,6 +10727,12 @@ int RM_CommandFilterArgDelete(RedisModuleCommandFilterCtx *fctx, int pos)
     fctx->argc--;
 
     return REDISMODULE_OK;
+}
+
+/* Get Client ID for client that issued the command we are filtering */
+unsigned long long RM_CommandFilterGetClientId(RedisModuleCommandFilterCtx *fctx)
+{
+    return fctx->c->id;
 }
 
 /* For a given pointer allocated via RedisModule_Alloc() or
@@ -13711,6 +13719,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(CommandFilterArgInsert);
     REGISTER_API(CommandFilterArgReplace);
     REGISTER_API(CommandFilterArgDelete);
+    REGISTER_API(CommandFilterGetClientId);
     REGISTER_API(Fork);
     REGISTER_API(SendChildHeartbeat);
     REGISTER_API(ExitFromChild);

--- a/src/module.c
+++ b/src/module.c
@@ -10730,8 +10730,7 @@ int RM_CommandFilterArgDelete(RedisModuleCommandFilterCtx *fctx, int pos)
 }
 
 /* Get Client ID for client that issued the command we are filtering */
-unsigned long long RM_CommandFilterGetClientId(RedisModuleCommandFilterCtx *fctx)
-{
+unsigned long long RM_CommandFilterGetClientId(RedisModuleCommandFilterCtx *fctx) {
     return fctx->c->id;
 }
 

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1259,6 +1259,7 @@ REDISMODULE_API RedisModuleString * (*RedisModule_CommandFilterArgGet)(RedisModu
 REDISMODULE_API int (*RedisModule_CommandFilterArgInsert)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CommandFilterArgReplace)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CommandFilterArgDelete)(RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;
+REDISMODULE_API unsigned long long (*RedisModule_CommandFilterGetClientId)(RedisModuleCommandFilterCtx *fctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_Fork)(RedisModuleForkDoneHandler cb, void *user_data) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SendChildHeartbeat)(double progress) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExitFromChild)(int retcode) REDISMODULE_ATTR;
@@ -1619,6 +1620,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(CommandFilterArgInsert);
     REDISMODULE_GET_API(CommandFilterArgReplace);
     REDISMODULE_GET_API(CommandFilterArgDelete);
+    REDISMODULE_GET_API(CommandFilterGetClientId);
     REDISMODULE_GET_API(Fork);
     REDISMODULE_GET_API(SendChildHeartbeat);
     REDISMODULE_GET_API(ExitFromChild);

--- a/tests/unit/moduleapi/commandfilter.tcl
+++ b/tests/unit/moduleapi/commandfilter.tcl
@@ -139,6 +139,8 @@ test {Blocking Commands don't run through command filter when reprocessed} {
         assert_equal [$rd read] 1
         # validate that we moved the correct elements to the correct side of the list
         assert_equal [r lpop list2{t}] 1
+
+        $rd close
     }
 }
 
@@ -146,9 +148,8 @@ test {Filtering based on client id} {
     start_server {tags {"modules"}} {
         r module load $testmodule log-key 0
 
-        set rd [redis_deferring_client]
-        $rd client id
-        set cid [$rd read]
+        set rr [redis_client]
+        set cid [$rr client id]
         r unfilter_clientid $cid
 
         r rpush mylist elem1 @replaceme elem2
@@ -156,9 +157,9 @@ test {Filtering based on client id} {
 
         r del mylist
 
-        $rd rpush mylist elem1 @replaceme elem2
-        assert_equal [$rd read] 3
-        $rd lrange mylist 0 -1
-        assert_equal [$rd read] {elem1 @replaceme elem2}
+        assert_equal [$rr rpush mylist elem1 @replaceme elem2] 3
+        assert_equal [r lrange mylist 0 -1] {elem1 @replaceme elem2}
+
+        $rr close
     }
 }


### PR DESCRIPTION
Adds API
- RedisModule_CommandFilterGetClientId()

Includes addition to commandfilter test module to validate that it works by performing the same command from 2 different clients