### PR TITLE
[Draft] Key embedding into main dictionary

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -227,10 +227,9 @@ robj *lookupKeyWriteOrReply(client *c, robj *key, robj *reply) {
  *
  * The program is aborted if the key already exists. */
 void dbAdd(redisDb *db, robj *key, robj *val) {
-    sds copy = sdsdup(key->ptr);
     int slot = getKeySlot(key->ptr);
     dict *d = db->dict[slot];
-    dictEntry *de = dictAddRaw(d, copy, NULL);
+    dictEntry *de = dictAddRaw(d, key->ptr, NULL);
     serverAssertWithInfo(NULL, key, de != NULL);
     dictSetVal(d, de, val);
     db->key_count++;

--- a/src/dict.c
+++ b/src/dict.c
@@ -72,6 +72,17 @@ struct dictEntry {
 };
 
 typedef struct {
+    union {
+        void *val;
+        uint64_t u64;
+        int64_t s64;
+        double d;
+    } v;
+    struct dictEntry *next;     /* Next entry in the same hash bucket. */
+    unsigned char data[];
+} embeddedDictEntry;
+
+typedef struct {
     void *key;
     dictEntry *next;
 } dictEntryNoValue;
@@ -120,6 +131,7 @@ uint64_t dictGenCaseHashFunction(const unsigned char *buf, size_t len) {
 #define ENTRY_PTR_MASK     7 /* 111 */
 #define ENTRY_PTR_NORMAL   0 /* 000 */
 #define ENTRY_PTR_NO_VALUE 2 /* 010 */
+#define ENTRY_PTR_EMBEDDED 4 /* 100 */
 
 /* Returns 1 if the entry pointer is a pointer to a key, rather than to an
  * allocated entry. Returns 0 otherwise. */
@@ -139,12 +151,26 @@ static inline int entryIsNoValue(const dictEntry *de) {
     return ((uintptr_t)(void *)de & ENTRY_PTR_MASK) == ENTRY_PTR_NO_VALUE;
 }
 
+
+static inline int entryIsEmbedded(const dictEntry *de) {
+    return ((uintptr_t)(void *)de & ENTRY_PTR_MASK) == ENTRY_PTR_EMBEDDED;
+}
+
 /* Creates an entry without a value field. */
 static inline dictEntry *createEntryNoValue(void *key, dictEntry *next) {
     dictEntryNoValue *entry = zmalloc(sizeof(*entry));
     entry->key = key;
     entry->next = next;
     return (dictEntry *)(void *)((uintptr_t)(void *)entry | ENTRY_PTR_NO_VALUE);
+}
+
+static inline dictEntry *createEmbeddedEntry(void *key, dictEntry *next, dictType *dt) {
+    size_t keyLen = dt->keyLen(key);
+    embeddedDictEntry *entry = zmalloc(sizeof(*entry) + keyLen + ENTRY_METADATA_BYTES);
+    size_t bytes_written = dt->keyToBytes(entry->data + ENTRY_METADATA_BYTES, key, &entry->data[0]);
+    assert(bytes_written == keyLen);
+    entry->next = next;
+    return (dictEntry *)(void *)((uintptr_t)(void *)entry | ENTRY_PTR_EMBEDDED);
 }
 
 static inline dictEntry *encodeMaskedPtr(const void *ptr, unsigned int bits) {
@@ -157,15 +183,24 @@ static inline void *decodeMaskedPtr(const dictEntry *de) {
     return (void *)((uintptr_t)(void *)de & ~ENTRY_PTR_MASK);
 }
 
+static inline void *getEmbeddedKey(const dictEntry *de) {
+    embeddedDictEntry *entry = (embeddedDictEntry *)decodeMaskedPtr(de);
+    return &entry->data[ENTRY_METADATA_BYTES + entry->data[0]];
+}
+
 /* Decodes the pointer to an entry without value, when you know it is an entry
  * without value. Hint: Use entryIsNoValue to check. */
 static inline dictEntryNoValue *decodeEntryNoValue(const dictEntry *de) {
     return decodeMaskedPtr(de);
 }
 
+static inline embeddedDictEntry *decodeEmbeddedEntry(const dictEntry *de) {
+    return decodeMaskedPtr(de);
+}
+
 /* Returns 1 if the entry has a value field and 0 otherwise. */
 static inline int entryHasValue(const dictEntry *de) {
-    return entryIsNormal(de);
+    return entryIsNormal(de) || entryIsEmbedded(de);
 }
 
 /* ----------------------------- API implementation ------------------------- */
@@ -483,6 +518,8 @@ dictEntry *dictInsertAtPosition(dict *d, void *key, void *position) {
             /* Allocate an entry without value. */
             entry = createEntryNoValue(key, *bucket);
         }
+    } else if (d->type->embedded_entry){
+        entry = createEmbeddedEntry(key, *bucket, d->type);
     } else {
         /* Allocate the memory and store the new entry.
          * Insert the element in top, with the assumption that in a database
@@ -746,7 +783,12 @@ void dictSetKey(dict *d, dictEntry* de, void *key) {
 
 void dictSetVal(dict *d, dictEntry *de, void *val) {
     assert(entryHasValue(de));
-    de->v.val = d->type->valDup ? d->type->valDup(d, val) : val;
+    void *v = d->type->valDup ? d->type->valDup(d, val) : val;
+    if (entryIsEmbedded(de)) {
+        decodeEmbeddedEntry(de)->v.val = v;
+    } else {
+        de->v.val = v;
+    }
 }
 
 void dictSetSignedIntegerVal(dictEntry *de, int64_t val) {
@@ -782,11 +824,15 @@ double dictIncrDoubleVal(dictEntry *de, double val) {
 void *dictGetKey(const dictEntry *de) {
     if (entryIsKey(de)) return (void*)de;
     if (entryIsNoValue(de)) return decodeEntryNoValue(de)->key;
+    if (entryIsEmbedded(de)) return getEmbeddedKey(de);
     return de->key;
 }
 
 void *dictGetVal(const dictEntry *de) {
     assert(entryHasValue(de));
+    if (entryIsEmbedded(de)) {
+        return decodeEmbeddedEntry(de)->v.val;
+    }
     return de->v.val;
 }
 
@@ -816,6 +862,7 @@ double *dictGetDoubleValPtr(dictEntry *de) {
 static dictEntry *dictGetNext(const dictEntry *de) {
     if (entryIsKey(de)) return NULL; /* there's no next */
     if (entryIsNoValue(de)) return decodeEntryNoValue(de)->next;
+    if (entryIsEmbedded(de)) return decodeEmbeddedEntry(de)->next;
     return de->next;
 }
 
@@ -824,14 +871,16 @@ static dictEntry *dictGetNext(const dictEntry *de) {
 static dictEntry **dictGetNextRef(dictEntry *de) {
     if (entryIsKey(de)) return NULL;
     if (entryIsNoValue(de)) return &decodeEntryNoValue(de)->next;
+    if (entryIsEmbedded(de)) return &decodeEmbeddedEntry(de)->next;
     return &de->next;
 }
 
 static void dictSetNext(dictEntry *de, dictEntry *next) {
     assert(!entryIsKey(de));
     if (entryIsNoValue(de)) {
-        dictEntryNoValue *entry = decodeEntryNoValue(de);
-        entry->next = next;
+        decodeEntryNoValue(de)->next = next;
+    } else if (entryIsEmbedded(de)){
+        decodeEmbeddedEntry(de)->next = next;
     } else {
         de->next = next;
     }

--- a/src/dict.c
+++ b/src/dict.c
@@ -892,12 +892,12 @@ static void dictSetNext(dictEntry *de, dictEntry *next) {
 /* Returns the memory usage in bytes of the dict, excluding the size of the keys
  * and values. */
 size_t dictMemUsage(const dict *d) {
-    return dictSize(d) * sizeof(embeddedDictEntry) +
-        dictSlots(d) * sizeof(embeddedDictEntry*);
+    return dictSize(d) * sizeof(dictEntry) +
+        dictSlots(d) * sizeof(dictEntry*);
 }
 
 size_t dictEntryMemUsage(void) {
-    return sizeof(embeddedDictEntry);
+    return sizeof(dictEntry);
 }
 
 /* A fingerprint is a 64 bit number that represents the state of the dictionary
@@ -1153,11 +1153,10 @@ unsigned int dictGetSomeKeys(dict *d, dictEntry **des, unsigned int count) {
 
 /* Reallocate the dictEntry, key and value allocations in a bucket using the
  * provided allocation functions in order to defrag them. */
-static void dictDefragBucket(dictType *dt, dictEntry **bucketref, dictDefragFunctions *defragfns) {
+static void dictDefragBucket(dictEntry **bucketref, dictDefragFunctions *defragfns) {
     dictDefragAllocFunction *defragalloc = defragfns->defragAlloc;
     dictDefragAllocFunction *defragkey = defragfns->defragKey;
     dictDefragAllocFunction *defragval = defragfns->defragVal;
-    dictDefragAllocFunction *defragEmbeddedData = defragfns->defragEmbeddedData;
     while (bucketref && *bucketref) {
         dictEntry *de = *bucketref, *newde = NULL;
         void *newkey = defragkey ? defragkey(dictGetKey(de)) : NULL;
@@ -1174,11 +1173,11 @@ static void dictDefragBucket(dictType *dt, dictEntry **bucketref, dictDefragFunc
             if (newkey) entry->key = newkey;
         } else if (entryIsEmbedded(de)) {
             embeddedDictEntry *entry = decodeEmbeddedEntry(de), *newentry;
-            if (defragEmbeddedData && (newentry = defragEmbeddedData(entry))) {
-                memcpy(newentry->data, entry->data, dt->keyLen(de->key) + ENTRY_METADATA_BYTES);
+            if ((newentry = defragalloc(entry))) {
                 newde = encodeMaskedPtr(newentry, ENTRY_PTR_EMBEDDED);
                 entry = newentry;
             }
+            if (newval) entry->v.val = newval;
         } else {
             assert(entryIsNormal(de));
             newde = defragalloc(de);
@@ -1350,7 +1349,7 @@ unsigned long dictScanDefrag(dict *d,
 
         /* Emit entries at cursor */
         if (defragfns) {
-            dictDefragBucket(d->type, &d->ht_table[htidx0][v & m0], defragfns);
+            dictDefragBucket(&d->ht_table[htidx0][v & m0], defragfns);
         }
         de = d->ht_table[htidx0][v & m0];
         while (de) {
@@ -1383,7 +1382,7 @@ unsigned long dictScanDefrag(dict *d,
 
         /* Emit entries at cursor */
         if (defragfns) {
-            dictDefragBucket(d->type, &d->ht_table[htidx0][v & m0], defragfns);
+            dictDefragBucket(&d->ht_table[htidx0][v & m0], defragfns);
         }
         de = d->ht_table[htidx0][v & m0];
         while (de) {
@@ -1397,7 +1396,7 @@ unsigned long dictScanDefrag(dict *d,
         do {
             /* Emit entries at cursor */
             if (defragfns) {
-                dictDefragBucket(d->type, &d->ht_table[htidx1][v & m1], defragfns);
+                dictDefragBucket(&d->ht_table[htidx1][v & m1], defragfns);
             }
             de = d->ht_table[htidx1][v & m1];
             while (de) {

--- a/src/dict.c
+++ b/src/dict.c
@@ -655,6 +655,9 @@ void dictFreeUnlinkedEntry(dict *d, dictEntry *he) {
     if (he == NULL) return;
     dictFreeKey(d, he);
     dictFreeVal(d, he);
+    /* Clear the embedded data */
+    if (entryIsEmbedded(he)) zfree(decodeEmbeddedEntry(he)->data);
+    /* Clear the dictEntry */
     if (!entryIsKey(he)) zfree(decodeMaskedPtr(he));
 }
 

--- a/src/dict.h
+++ b/src/dict.h
@@ -118,7 +118,6 @@ typedef struct {
     dictDefragAllocFunction *defragAlloc; /* Used for entries etc. */
     dictDefragAllocFunction *defragKey;   /* Defrag-realloc keys (optional) */
     dictDefragAllocFunction *defragVal;   /* Defrag-realloc values (optional) */
-    dictDefragAllocFunction *defragEmbeddedData; /* Defrag-realloc embedded data (optional) */
 } dictDefragFunctions;
 
 static const int ENTRY_METADATA_BYTES = 1;

--- a/src/dict.h
+++ b/src/dict.h
@@ -118,6 +118,7 @@ typedef struct {
     dictDefragAllocFunction *defragAlloc; /* Used for entries etc. */
     dictDefragAllocFunction *defragKey;   /* Defrag-realloc keys (optional) */
     dictDefragAllocFunction *defragVal;   /* Defrag-realloc values (optional) */
+    dictDefragAllocFunction *defragEmbeddedData; /* Defrag-realloc embedded data (optional) */
 } dictDefragFunctions;
 
 static const int ENTRY_METADATA_BYTES = 1;

--- a/src/dict.h
+++ b/src/dict.h
@@ -56,6 +56,8 @@ typedef struct dictType {
     void (*valDestructor)(dict *d, void *obj);
     int (*expandAllowed)(size_t moreMem, double usedRatio);
     void (*rehashingStarted)(dict *d);
+    size_t (*keyLen)(const void *key);
+    size_t (*keyToBytes)(unsigned char *buf, const void *key, unsigned char *header_size);
     /* Flags */
     /* The 'no_value' flag, if set, indicates that values are not used, i.e. the
      * dict is a set. When this flag is set, it's not possible to access the
@@ -68,6 +70,7 @@ typedef struct dictType {
     unsigned int keys_are_odd:1;
     /* TODO: Add a 'keys_are_even' flag and use a similar optimization if that
      * flag is set. */
+    unsigned int embedded_entry:1;
 } dictType;
 
 #define DICTHT_SIZE(exp) ((exp) == -1 ? 0 : (unsigned long)1<<(exp))
@@ -116,6 +119,8 @@ typedef struct {
     dictDefragAllocFunction *defragKey;   /* Defrag-realloc keys (optional) */
     dictDefragAllocFunction *defragVal;   /* Defrag-realloc values (optional) */
 } dictDefragFunctions;
+
+static const int ENTRY_METADATA_BYTES = 1;
 
 /* This is the initial size of every hash table */
 #define DICT_HT_INITIAL_EXP      2

--- a/src/object.c
+++ b/src/object.c
@@ -1542,7 +1542,7 @@ NULL
             return;
         }
         size_t usage = objectComputeSize(c->argv[2],dictGetVal(de),samples,c->db->id);
-        usage += sdsZmallocSize(dictGetKey(de));
+        usage += c->db->dict[getKeySlot(c->argv[2]->ptr)]->type->keyLen(de);
         usage += dictEntryMemUsage();
         addReplyLongLong(c,usage);
     } else if (!strcasecmp(c->argv[1]->ptr,"stats") && c->argc == 2) {

--- a/src/object.c
+++ b/src/object.c
@@ -1542,7 +1542,7 @@ NULL
             return;
         }
         size_t usage = objectComputeSize(c->argv[2],dictGetVal(de),samples,c->db->id);
-        usage += c->db->dict[getKeySlot(c->argv[2]->ptr)]->type->keyLen(de);
+        usage += c->db->dict[getKeySlot(c->argv[2]->ptr)]->type->keyLen(dictGetKey(de));
         usage += dictEntryMemUsage();
         addReplyLongLong(c,usage);
     } else if (!strcasecmp(c->argv[1]->ptr,"stats") && c->argc == 2) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3341,6 +3341,9 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
 
             /* call key space notification on key loaded for modules only */
             moduleNotifyKeyspaceEvent(NOTIFY_LOADED, "loaded", &keyobj, db->id);
+
+            /* Release key (sds), dictEntry stores a copy of it in embedded data */
+            sdsfree(key);
         }
 
         /* Loading the database more slowly is useful in order to test

--- a/src/sds.c
+++ b/src/sds.c
@@ -41,22 +41,6 @@
 
 const char *SDS_NOINIT = "SDS_NOINIT";
 
-static inline int sdsHdrSize(char type) {
-    switch(type&SDS_TYPE_MASK) {
-        case SDS_TYPE_5:
-            return sizeof(struct sdshdr5);
-        case SDS_TYPE_8:
-            return sizeof(struct sdshdr8);
-        case SDS_TYPE_16:
-            return sizeof(struct sdshdr16);
-        case SDS_TYPE_32:
-            return sizeof(struct sdshdr32);
-        case SDS_TYPE_64:
-            return sizeof(struct sdshdr64);
-    }
-    return 0;
-}
-
 static inline char sdsReqType(size_t string_size) {
     if (string_size < 1<<5)
         return SDS_TYPE_5;

--- a/src/sds.h
+++ b/src/sds.h
@@ -215,6 +215,22 @@ static inline void sdssetalloc(sds s, size_t newlen) {
     }
 }
 
+static inline int sdsHdrSize(char type) {
+    switch(type&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return sizeof(struct sdshdr5);
+        case SDS_TYPE_8:
+            return sizeof(struct sdshdr8);
+        case SDS_TYPE_16:
+            return sizeof(struct sdshdr16);
+        case SDS_TYPE_32:
+            return sizeof(struct sdshdr32);
+        case SDS_TYPE_64:
+            return sizeof(struct sdshdr64);
+    }
+    return 0;
+}
+
 sds sdsnewlen(const void *init, size_t initlen);
 sds sdstrynewlen(const void *init, size_t initlen);
 sds sdsnew(const char *init);

--- a/src/server.c
+++ b/src/server.c
@@ -268,6 +268,16 @@ int dictSdsKeyCompare(dict *d, const void *key1,
     return memcmp(key1, key2, l1) == 0;
 }
 
+size_t dictSdsKeyLen(const void *key) { return sdsAllocSize((sds)key); }
+
+size_t dictSdsKeyToBytes(unsigned char *buf, const void *key, unsigned char *header_size) {
+    sds keySds = (sds)key;
+    size_t n_bytes = sdsAllocSize(keySds);
+    memcpy(buf, sdsAllocPtr(keySds), n_bytes);
+    *header_size = sdsHdrSize(keySds[-1]);
+    return n_bytes;
+}
+
 /* A case insensitive version used for the command lookup table and other
  * places where case insensitive non binary-safe comparison is needed. */
 int dictSdsKeyCaseCompare(dict *d, const void *key1,
@@ -459,6 +469,9 @@ dictType dbDictType = {
     dictObjectDestructor,       /* val destructor */
     dictExpandAllowed,          /* allow to expand */
     dictRehashingStarted,
+    dictSdsKeyLen,
+    dictSdsKeyToBytes,
+    .embedded_entry = 1
 };
 
 /* Db->expires */

--- a/src/server.c
+++ b/src/server.c
@@ -465,7 +465,7 @@ dictType dbDictType = {
     NULL,                       /* key dup */
     NULL,                       /* val dup */
     dictSdsKeyCompare,          /* key compare */
-    dictSdsDestructor,          /* key destructor */
+    NULL,                       /* Note: key (sds) is stored in the embedded buffer, will be released internally */
     dictObjectDestructor,       /* val destructor */
     dictExpandAllowed,          /* allow to expand */
     dictRehashingStarted,

--- a/src/server.h
+++ b/src/server.h
@@ -3441,6 +3441,8 @@ int dictSdsKeyCaseCompare(dict *d, const void *key1, const void *key2);
 void dictSdsDestructor(dict *d, void *val);
 void dictListDestructor(dict *d, void *val);
 void *dictSdsDup(dict *d, const void *key);
+size_t dictSdsKeyToBytes(unsigned char *buf, const void *key, unsigned char *header_size);
+size_t dictSdsKeyLen(const void *key);
 
 /* Git SHA1 */
 char *redisGitSHA1(void);


### PR DESCRIPTION
This PR incorporates changes related to key embedding described in the https://github.com/redis/redis/issues/12216, it is built incrementally on top of https://github.com/redis/redis/pull/11695

Key changes:
1. New dict entry type introduced, which is now used as an entry for the main dictionary:
```
typedef struct {
    union {
        void *val;
        uint64_t u64;
        int64_t s64;
        double d;
    } v;
    struct dictEntry *next;     /* Next entry in the same hash bucket. */
    unsigned char data[];
} embeddedDictEntry;
```
2. Two new functions been added to the dictType:
```
size_t dictSdsKeyToBytes(unsigned char *buf, const void *key, unsigned char *header_size);
size_t dictSdsKeyLen(const void *key);
```
3. Change is opt-in per dict type, hence sets, hashes and other types that are using dictionary are not impacted.

With this change main dictionary now owns the data, so copy on insert in `dbAdd` is no longer needed.
I've done some brief performance testing and it doesn't show any performance degradation, more benchrmarking is needed.

Currently in a draft state, more testing is needed, feedback is welcome.