### PR TITLE
Sync the new loglevel nothing to sentinel

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -25,6 +25,7 @@ pidfile /var/run/redis-sentinel.pid
 # verbose (many rarely useful info, but not a mess like the debug level)
 # notice (moderately verbose, what you want in production probably)
 # warning (only very important / critical messages are logged)
+# nothing (nothing is logged)
 loglevel notice
 
 # Specify the log file name. Also the empty string can be used to force

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3192,6 +3192,7 @@ const char* getLogLevel(void) {
     case LL_VERBOSE: return "verbose";
     case LL_NOTICE: return "notice";
     case LL_WARNING: return "warning";
+    case LL_NOTHING: return "nothing";
     }
     return "unknown";
 }
@@ -3252,7 +3253,8 @@ void sentinelConfigSetCommand(client *c) {
                 numval < 0 || numval > 65535) goto badfmt;
         } else if (!strcasecmp(option, "loglevel")) {
             if (!(!strcasecmp(val->ptr, "debug") || !strcasecmp(val->ptr, "verbose") ||
-                !strcasecmp(val->ptr, "notice") || !strcasecmp(val->ptr, "warning"))) goto badfmt;
+                !strcasecmp(val->ptr, "notice") || !strcasecmp(val->ptr, "warning") ||
+                !strcasecmp(val->ptr, "nothing"))) goto badfmt;
         }
     }
 
@@ -3270,6 +3272,8 @@ void sentinelConfigSetCommand(client *c) {
                 server.verbosity = LL_NOTICE;
             else if (!strcasecmp(val->ptr, "warning"))
                 server.verbosity = LL_WARNING;
+            else if (!strcasecmp(val->ptr, "nothing"))
+                server.verbosity = LL_NOTHING;
         } else if (!strcasecmp(option, "resolve-hostnames") && moreargs > 0) {
             val = c->argv[++i];
             numval = yesnotoi(val->ptr);

--- a/tests/sentinel/tests/01-conf-update.tcl
+++ b/tests/sentinel/tests/01-conf-update.tcl
@@ -41,7 +41,10 @@ test "New master [join $addr {:}] role matches" {
 test "Update log level" {
     set current_loglevel [S 0 SENTINEL CONFIG GET loglevel]
     assert {[lindex $current_loglevel 1] == {notice}}
-    S 0 SENTINEL CONFIG SET loglevel warning
-    set updated_loglevel [S 0 SENTINEL CONFIG GET loglevel]
-    assert {[lindex $updated_loglevel 1] == {warning}}
+
+    foreach {loglevel} {debug verbose notice warning nothing} {
+        S 0 SENTINEL CONFIG SET loglevel $loglevel
+        set updated_loglevel [S 0 SENTINEL CONFIG GET loglevel]
+        assert {[lindex $updated_loglevel 1] == $loglevel}
+    }
 }


### PR DESCRIPTION
We add a new loglevel 'nothing' to disable logging in #12133.
This PR syncs that config change to sentinel. Because in #11214
we support modifying loglevel in runtime.

Although I think sentinel doesn't need this nothing config,
it's better to be consistent.