### PR TITLE
PUBSUB SHARDNUMSUB should enforce same slot

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -4573,7 +4573,9 @@ struct COMMAND_ARG PUBSUB_SHARDCHANNELS_Args[] = {
 
 #ifndef SKIP_CMD_KEY_SPECS_TABLE
 /* PUBSUB SHARDNUMSUB key specs */
-#define PUBSUB_SHARDNUMSUB_Keyspecs NULL
+keySpec PUBSUB_SHARDNUMSUB_Keyspecs[1] = {
+{NULL,CMD_KEY_NOT_KEY,KSPEC_BS_INDEX,.bs.index={2},KSPEC_FK_RANGE,.fk.range={-1,1,0}}
+};
 #endif
 
 /* PUBSUB SHARDNUMSUB argument table */
@@ -4588,7 +4590,7 @@ struct COMMAND_STRUCT PUBSUB_Subcommands[] = {
 {MAKE_CMD("numpat","Returns a count of unique pattern subscriptions.","O(1)","2.8.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,PUBSUB_NUMPAT_History,0,PUBSUB_NUMPAT_Tips,0,pubsubCommand,2,CMD_PUBSUB|CMD_LOADING|CMD_STALE,0,PUBSUB_NUMPAT_Keyspecs,0,NULL,0)},
 {MAKE_CMD("numsub","Returns a count of subscribers to channels.","O(N) for the NUMSUB subcommand, where N is the number of requested channels","2.8.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,PUBSUB_NUMSUB_History,0,PUBSUB_NUMSUB_Tips,0,pubsubCommand,-2,CMD_PUBSUB|CMD_LOADING|CMD_STALE,0,PUBSUB_NUMSUB_Keyspecs,0,NULL,1),.args=PUBSUB_NUMSUB_Args},
 {MAKE_CMD("shardchannels","Returns the active shard channels.","O(N) where N is the number of active shard channels, and assuming constant time pattern matching (relatively short shard channels).","7.0.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,PUBSUB_SHARDCHANNELS_History,0,PUBSUB_SHARDCHANNELS_Tips,0,pubsubCommand,-2,CMD_PUBSUB|CMD_LOADING|CMD_STALE,0,PUBSUB_SHARDCHANNELS_Keyspecs,0,NULL,1),.args=PUBSUB_SHARDCHANNELS_Args},
-{MAKE_CMD("shardnumsub","Returns the count of subscribers of shard channels.","O(N) for the SHARDNUMSUB subcommand, where N is the number of requested shard channels","7.0.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,PUBSUB_SHARDNUMSUB_History,0,PUBSUB_SHARDNUMSUB_Tips,0,pubsubCommand,-2,CMD_PUBSUB|CMD_LOADING|CMD_STALE,0,PUBSUB_SHARDNUMSUB_Keyspecs,0,NULL,1),.args=PUBSUB_SHARDNUMSUB_Args},
+{MAKE_CMD("shardnumsub","Returns the count of subscribers of shard channels.","O(N) for the SHARDNUMSUB subcommand, where N is the number of requested shard channels","7.0.0",CMD_DOC_NONE,NULL,NULL,"pubsub",COMMAND_GROUP_PUBSUB,PUBSUB_SHARDNUMSUB_History,0,PUBSUB_SHARDNUMSUB_Tips,0,pubsubCommand,-2,CMD_PUBSUB|CMD_LOADING|CMD_STALE,0,PUBSUB_SHARDNUMSUB_Keyspecs,1,NULL,1),.args=PUBSUB_SHARDNUMSUB_Args},
 {0}
 };
 

--- a/src/commands/pubsub-shardnumsub.json
+++ b/src/commands/pubsub-shardnumsub.json
@@ -20,6 +20,25 @@
                 "multiple": true
             }
         ],
+        "key_specs": [
+            {
+                "flags": [
+                    "NOT_KEY"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 2
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
         "reply_schema": {
             "description": "the number of subscribers per shard channel, each even element (including 0th) is channel name, each odd element is the number of subscribers",
             "type": "array"

--- a/tests/cluster/tests/26-pubsubshard.tcl
+++ b/tests/cluster/tests/26-pubsubshard.tcl
@@ -43,6 +43,11 @@ test "Pub/Sub shard basics" {
     $anotherclient close
 }
 
+test "PUBSUB SHARDNUMSUB blocks CROSSSLOT" {
+    catch {$cluster pubsub shardnumsub channel.0 channel.1} err
+    assert_match {CROSSSLOT Keys*} $err
+}
+
 test "client can't subscribe to multiple shard channels across different slots in same call" {
     catch {$cluster ssubscribe channel.0 channel.1} err
     assert_match {CROSSSLOT Keys*} $err

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -34,7 +34,7 @@ set ::redis_cluster::plain_commands {
     hgetall hexists hscan incrby decrby incrbyfloat getset move
     expire expireat pexpire pexpireat type ttl pttl persist restore
     dump bitcount bitpos pfadd pfcount cluster ssubscribe spublish
-    sunsubscribe
+    sunsubscribe pubsub
 }
 
 # Create a cluster client. The nodes are given as a list of host:port. The TLS

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -34,7 +34,7 @@ set ::redis_cluster::plain_commands {
     hgetall hexists hscan incrby decrby incrbyfloat getset move
     expire expireat pexpire pexpireat type ttl pttl persist restore
     dump bitcount bitpos pfadd pfcount cluster ssubscribe spublish
-    sunsubscribe pubsub
+    sunsubscribe
 }
 
 # Create a cluster client. The nodes are given as a list of host:port. The TLS
@@ -269,6 +269,11 @@ proc ::redis_cluster::get_keys_from_command {cmd argv} {
         eval {return [lrange $argv 2 1+[lindex $argv 1]]}
         evalsha {return [lrange $argv 2 1+[lindex $argv 1]]}
         spublish {return [list [lindex $argv 1]]}
+        pubsub {
+            if {[lindex $argv 0] eq "shardnumsub"} {
+                return [list [lindex $argv 1]]
+            }
+        }
     }
 
     # All the remaining commands are not handled.


### PR DESCRIPTION
Unlike `SSUBSCRIBE`, `PUBSUB SHARDNUMSUB` allowed multiple shard channels from different hash-slots. This change is to get `PUBSUB SHARDNUMSUB` aligned with `SSUBSCRIBE`, so it will return CROSSSLOT error.