### PR TITLE
Add new loglevel nothing to sentinel-config.json

### DIFF
--- a/src/commands/sentinel-config.json
+++ b/src/commands/sentinel-config.json
@@ -71,6 +71,9 @@
                                     "const": "warning"
                                 },
                                 {
+                                    "const": "nothing"
+                                },
+                                {
                                     "const": "unknown"
                                 }
                             ]


### PR DESCRIPTION
It was missing in #12223, and the reply-schemas daily
was failing:
```
jsonschema.exceptions.ValidationError: 'nothing' is not valid under any of the given schemas

Failed validating 'oneOf' in schema[0]['properties']['loglevel']:
    {'oneOf': [{'const': 'debug'},
               {'const': 'verbose'},
               {'const': 'notice'},
               {'const': 'warning'},
               {'const': 'unknown'}]}

On instance['loglevel']:
    'nothing'
```