### PR TITLE
[BUG] Incorrect error msg for XREAD command

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2208,7 +2208,7 @@ void xreadCommand(client *c) {
             streams_arg = i+1;
             streams_count = (c->argc-streams_arg);
             if ((streams_count % 2) != 0) {
-                char symbol = (strcasecmp(c->cmd->fullname,"XREAD") == 0) ? '$' :'>';
+                char symbol = xreadgroup ? '>' : '$';
                 addReplyErrorFormat(c,"Unbalanced '%s' list of streams: "
                                       "for each stream key an ID or '%c' must be "
                                       "specified.", c->cmd->fullname,symbol);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2208,9 +2208,10 @@ void xreadCommand(client *c) {
             streams_arg = i+1;
             streams_count = (c->argc-streams_arg);
             if ((streams_count % 2) != 0) {
+                char symbol = (strcasecmp(c->cmd->fullname,"XREAD") == 0) ? '$' :'>';
                 addReplyErrorFormat(c,"Unbalanced '%s' list of streams: "
-                                      "for each stream key an ID or '>' must be "
-                                      "specified.", c->cmd->fullname);
+                                      "for each stream key an ID or '%c' must be "
+                                      "specified.", c->cmd->fullname,symbol);
                 return;
             }
             streams_count /= 2; /* We have two arguments for each stream. */

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -314,6 +314,14 @@ start_server {
         $rd close
     } {0} {external:skip}
 
+    test {XREAD and XREADGROUP against wrong parameter} {
+        r DEL mystream
+        r XADD mystream 666 f v
+        r XGROUP CREATE mystream mygroup $
+        assert_error "ERR Unbalanced 'xreadgroup' list of streams: for each stream key an ID or '>' must be specified." {r XREADGROUP GROUP mygroup Alice COUNT 1 STREAMS mystream }
+        assert_error "ERR Unbalanced 'xread' list of streams: for each stream key an ID or '$' must be specified." {r XREAD COUNT 1 STREAMS mystream }
+    }
+
     test {Blocking XREAD: key deleted} {
         r DEL mystream
         r XADD mystream 666 f v


### PR DESCRIPTION
XREAD only supports a special ID of $ and XREADGROUP only supports ^.
make sure not to suggest the wrong one when rerunning an error about unbalanced ID arguments

**Current Behavior**

XREAD display wrong error message for use of the special ID and >. But when we try to use > with XREAD its display the error message as "  ERR The > ID can be specified only when calling XREADGROUP using the GROUP <group> <consumer> option."

![image](https://github.com/redis/redis/assets/51993843/3435a8cc-1157-4f0c-a79b-bed76cb6d0d7)

Expected Behaviour
XREAD should display "ERR Unbalanced 'xread' list of streams: for each stream key an ID or '$' must be specified."
![xadd 2](https://github.com/redis/redis/assets/51993843/40f77609-bc66-4baa-8074-f40ec815042b)

