### PR TITLE
Fix GETEX db delete call to emit DB_FLAG_KEY_EXPIRED on expiration

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -388,8 +388,7 @@ void getexCommand(client *c) {
     if (((flags & OBJ_PXAT) || (flags & OBJ_EXAT)) && checkAlreadyExpired(milliseconds)) {
         /* When PXAT/EXAT absolute timestamp is specified, there can be a chance that timestamp
          * has already elapsed so delete the key in that case. */
-        int deleted = server.lazyfree_lazy_expire ? dbAsyncDelete(c->db, c->argv[1]) :
-                      dbSyncDelete(c->db, c->argv[1]);
+        int deleted = dbGenericDelete(c->db, c->argv[1], server.lazyfree_lazy_expire, DB_FLAG_KEY_EXPIRED);
         serverAssert(deleted);
         robj *aux = server.lazyfree_lazy_expire ? shared.unlink : shared.del;
         rewriteClientCommandVector(c,2,aux,c->argv[1]);


### PR DESCRIPTION
We should emit DB_FLAG_KEY_EXPIRED instead of DB_FLAG_KEY_DELETED.
This is an overlook in #9406.