### PR TITLE
redis-cli adds parameter of keypass of private key file

### DIFF
--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -81,6 +81,10 @@ int cliSecureConnection(redisContext *c, cliSSLconfig config, const char **err) 
             goto error;
         }
 
+        if (config.keyfile_pass) {
+            SSL_CTX_set_default_passwd_cb_userdata(ssl_ctx, (void *)config.keyfile_pass);
+        }
+
         if (config.key && !SSL_CTX_use_PrivateKey_file(ssl_ctx, config.key, SSL_FILETYPE_PEM)) {
             *err = "Invalid private key";
             goto error;

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -17,6 +17,8 @@ typedef struct cliSSLconfig {
     char *cert;
     /* Private key file to authenticate with, or NULL */
     char *key;
+    /* Keypass of Private key file to authenticate with, or NULL */
+    char *keyfile_pass;
     /* Preferred cipher list, or NULL (applies only to <= TLSv1.2) */
     char* ciphers;
     /* Preferred ciphersuites list, or NULL (applies only to TLSv1.3) */

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1557,6 +1557,8 @@ int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i],"--key")) {
             if (lastarg) goto invalid;
             config.sslconfig.key = strdup(argv[++i]);
+        } else if (!strcmp(argv[i],"--keyfile-pass") && !lastarg) {
+            config.sslconfig.keyfile_pass = argv[++i];
         } else if (!strcmp(argv[i],"--tls-ciphers")) {
             if (lastarg) goto invalid;
             config.sslconfig.ciphers = strdup(argv[++i]);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2883,6 +2883,8 @@ static int parseOptions(int argc, char **argv) {
             config.sslconfig.cert = argv[++i];
         } else if (!strcmp(argv[i],"--key") && !lastarg) {
             config.sslconfig.key = argv[++i];
+        } else if (!strcmp(argv[i],"--keyfile-pass") && !lastarg) {
+            config.sslconfig.keyfile_pass = argv[++i];
         } else if (!strcmp(argv[i],"--tls-ciphers") && !lastarg) {
             config.sslconfig.ciphers = argv[++i];
         } else if (!strcmp(argv[i],"--insecure")) {
@@ -2950,8 +2952,8 @@ static int parseOptions(int argc, char **argv) {
         exit(1);
     }
 
-    if (!config.no_auth_warning && config.conn_info.auth != NULL) {
-        fputs("Warning: Using a password with '-a' or '-u' option on the command"
+    if (!config.no_auth_warning && (config.conn_info.auth != NULL || config.sslconfig.keyfile_pass != NULL)) {
+        fputs("Warning: Using a password with '-a', '-u' or '--keyfile-pass' option on the command"
               " line interface may not be safe.\n", stderr);
     }
 
@@ -2995,6 +2997,7 @@ static void usage(int err) {
 "  --insecure         Allow insecure TLS connection by skipping cert validation.\n"
 "  --cert <file>      Client certificate to authenticate with.\n"
 "  --key <file>       Private key file to authenticate with.\n"
+"  --keyfile-pass     Keypass of Private key file to authenticate with.\n"
 "  --tls-ciphers <list> Sets the list of preferred ciphers (TLSv1.2 and below)\n"
 "                     in order of preference from highest to lowest separated by colon (\":\").\n"
 "                     See the ciphers(1ssl) manpage for more information about the syntax of this string.\n"

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2997,7 +2997,7 @@ static void usage(int err) {
 "  --insecure         Allow insecure TLS connection by skipping cert validation.\n"
 "  --cert <file>      Client certificate to authenticate with.\n"
 "  --key <file>       Private key file to authenticate with.\n"
-"  --keyfile-pass     Keypass of Private key file to authenticate with.\n"
+"  --keyfile-pass <password> Keypass of Private key file to authenticate with.\n"
 "  --tls-ciphers <list> Sets the list of preferred ciphers (TLSv1.2 and below)\n"
 "                     in order of preference from highest to lowest separated by colon (\":\").\n"
 "                     See the ciphers(1ssl) manpage for more information about the syntax of this string.\n"


### PR DESCRIPTION
this pr adds `--keyfile-pass`. the parameter is keypass of private key file and similar to `-a`. this can facilitate us to obtain redis information and  doesn't need enter keypass of private key. e.g.
![B311C650-95C8-4B93-88FB-85636FCB6BF2](https://github.com/redis/redis/assets/92571231/5bfb6dd0-0736-4314-8ce4-7a63b6c4c6da)
