### PR TITLE
Document aof-disable-auto-gc in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1521,6 +1521,10 @@ aof-use-rdb-preamble yes
 # the AOF format in a way that may not be compatible with existing AOF parsers.
 aof-timestamp-enabled no
 
+# By default, previous AOF base and incremental files are removed after AOF
+# rewrite. Set aof-disable-auto-gc to "yes" to retain these files.
+aof-disable-auto-gc no
+
 ################################ SHUTDOWN #####################################
 
 # Maximum time to wait for replicas when shutting down, in seconds.


### PR DESCRIPTION
It appears that currently this configuration directive is not mentioned anywhere outside of the codebase, so documenting it in redis.conf would make it more visible to users.