### PR TITLE
Use std=gnu11 instead of std=c11.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -47,10 +47,10 @@ OPT=$(OPTIMIZATION)
 # NUMBER_SIGN_CHAR is a workaround to support both GNU Make 4.3 and older versions.
 NUMBER_SIGN_CHAR := \#
 C11_ATOMIC := $(shell sh -c 'echo "$(NUMBER_SIGN_CHAR)include <stdatomic.h>" > foo.c; \
-	$(CC) -std=c11 -c foo.c -o foo.o > /dev/null 2>&1; \
+	$(CC) -std=gnu11 -c foo.c -o foo.o > /dev/null 2>&1; \
 	if [ -f foo.o ]; then echo "yes"; rm foo.o; fi; rm foo.c')
 ifeq ($(C11_ATOMIC),yes)
-	STD+=-std=c11
+	STD+=-std=gnu11
 else
 	STD+=-std=c99
 endif


### PR DESCRIPTION
On recent alpine/musl systems, using `std=c11` breaks compilation, as none of the feature compatibility defines is being set. On other systems it's not necessary but doesn't seem incorrect.