### PR TITLE
redis-cli: use previous hostip when not provided by redis cluster server

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2291,8 +2291,9 @@ static int cliReadReply(int output_raw_strings) {
         slot = atoi(s+1);
         s = strrchr(p+1,':');    /* MOVED 3999[P]127.0.0.1[S]6381 */
         *s = '\0';
-        if (p+1 != s) {         
-            /* Update hostip if target host is non-empty. See #12266. */
+        if (p+1 != s) {
+            /* Host might be empty, like 'MOVED 3999 :6381', if endpoint type is unknown. Only update the
+             * host if it's non-empty. */
             sdsfree(config.conn_info.hostip);
             config.conn_info.hostip = sdsnew(p+1);
         }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2291,8 +2291,13 @@ static int cliReadReply(int output_raw_strings) {
         slot = atoi(s+1);
         s = strrchr(p+1,':');    /* MOVED 3999[P]127.0.0.1[S]6381 */
         *s = '\0';
-        sdsfree(config.conn_info.hostip);
-        config.conn_info.hostip = sdsnew(p+1);
+        if (p+1 != s) {         
+            /* Do not update hostip if target host is empty. See #12266
+             * MOVE 3999[P][S]6381 
+             */
+            sdsfree(config.conn_info.hostip);
+            config.conn_info.hostip = sdsnew(p+1);
+        }
         config.conn_info.hostport = atoi(s+1);
         if (config.interactive)
             printf("-> Redirected to slot [%d] located at %s:%d\n",

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -2292,9 +2292,7 @@ static int cliReadReply(int output_raw_strings) {
         s = strrchr(p+1,':');    /* MOVED 3999[P]127.0.0.1[S]6381 */
         *s = '\0';
         if (p+1 != s) {         
-            /* Do not update hostip if target host is empty. See #12266
-             * MOVE 3999[P][S]6381 
-             */
+            /* Update hostip if target host is non-empty. See #12266. */
             sdsfree(config.conn_info.hostip);
             config.conn_info.hostip = sdsnew(p+1);
         }

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -84,20 +84,16 @@ start_multiple_servers 3 [list overrides $base_conf] {
     test "use previous hostip in \"cluster-preferred-endpoint-type unknown-endpoint\" mode" {
         
         # backup and set cluster-preferred-endpoint-type unknown-endpoint
-        $node1_rd CONFIG GET cluster-preferred-endpoint-type
-        set endpoint_type_before_set [lindex [split [$node1_rd read] " "] 1]
-        $node1_rd CONFIG SET cluster-preferred-endpoint-type unknown-endpoint
-        $node1_rd read
+        set endpoint_type_before_set [lindex [split [$node1 CONFIG GET cluster-preferred-endpoint-type] " "] 1]
+        $node1 CONFIG SET cluster-preferred-endpoint-type unknown-endpoint
 
         # when redis-cli not in cluster mode, return MOVE with empty host
         set slot_for_foo [$node1 CLUSTER KEYSLOT foo]
-        set set_foo_bar_result "[exec src/redis-cli -h 127.0.0.1 -p [srv 0 port] set foo bar]"
-        assert_match "MOVED $slot_for_foo :*" $set_foo_bar_result
+        assert_error "*MOVED $slot_for_foo :*" {$node1 set foo bar}
 
         # when in cluster mode, redirect using previous hostip
         assert_equal "[exec src/redis-cli -h 127.0.0.1 -p [srv 0 port] -c set foo bar]" {OK}
         assert_match "[exec src/redis-cli -h 127.0.0.1 -p [srv 0 port] -c get foo]" {bar}
-        
 
         $node1_rd CONFIG SET cluster-preferred-endpoint-type "$endpoint_type_before_set"
         assert_equal [$node1_rd read]  {OK}

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -81,15 +81,15 @@ start_multiple_servers 3 [list overrides $base_conf] {
 
     set node1_rd [redis_deferring_client 0]
 
-    test "use previous hostip at \"cluster-preferred-endpoint-type unknown-endpoint\" mode" {
+    test "use previous hostip in \"cluster-preferred-endpoint-type unknown-endpoint\" mode" {
         
-        # save and set cluster-preferred-endpoint-type unknown-endpoint
+        # backup and set cluster-preferred-endpoint-type unknown-endpoint
         $node1_rd CONFIG GET cluster-preferred-endpoint-type
         set endpoint_type_before_set [lindex [split [$node1_rd read] " "] 1]
         $node1_rd CONFIG SET cluster-preferred-endpoint-type unknown-endpoint
         $node1_rd read
 
-        # when not in cluster mode, returns MOVE with empty host
+        # when redis-cli not in cluster mode, return MOVE with empty host
         set slot_for_foo [exec src/redis-cli -c -p [srv 0 port] CLUSTER KEYSLOT foo]
         set set_foo_bar_result "[exec src/redis-cli -h 127.0.0.1 -p [srv 0 port] set foo bar]"
         assert_match "MOVED $slot_for_foo :*" $set_foo_bar_result

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -90,7 +90,7 @@ start_multiple_servers 3 [list overrides $base_conf] {
         $node1_rd read
 
         # when redis-cli not in cluster mode, return MOVE with empty host
-        set slot_for_foo [exec src/redis-cli -c -p [srv 0 port] CLUSTER KEYSLOT foo]
+        set slot_for_foo [$node1 CLUSTER KEYSLOT foo]
         set set_foo_bar_result "[exec src/redis-cli -h 127.0.0.1 -p [srv 0 port] set foo bar]"
         assert_match "MOVED $slot_for_foo :*" $set_foo_bar_result
 

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -95,8 +95,7 @@ start_multiple_servers 3 [list overrides $base_conf] {
         assert_equal "[exec src/redis-cli -h 127.0.0.1 -p [srv 0 port] -c set foo bar]" {OK}
         assert_match "[exec src/redis-cli -h 127.0.0.1 -p [srv 0 port] -c get foo]" {bar}
 
-        $node1_rd CONFIG SET cluster-preferred-endpoint-type "$endpoint_type_before_set"
-        assert_equal [$node1_rd read]  {OK}
+        assert_equal [$node1 CONFIG SET cluster-preferred-endpoint-type "$endpoint_type_before_set"]  {OK}
     }
 
     test "Sanity test push cmd after resharding" {

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -81,6 +81,28 @@ start_multiple_servers 3 [list overrides $base_conf] {
 
     set node1_rd [redis_deferring_client 0]
 
+    test "use previous hostip at \"cluster-preferred-endpoint-type unknown-endpoint\" mode" {
+        
+        # save and set cluster-preferred-endpoint-type unknown-endpoint
+        $node1_rd CONFIG GET cluster-preferred-endpoint-type
+        set endpoint_type_before_set [lindex [split [$node1_rd read] " "] 1]
+        $node1_rd CONFIG SET cluster-preferred-endpoint-type unknown-endpoint
+        $node1_rd read
+
+        # when not in cluster mode, returns MOVE with empty host
+        set slot_for_foo [exec src/redis-cli -c -p [srv 0 port] CLUSTER KEYSLOT foo]
+        set set_foo_bar_result "[exec src/redis-cli -h 127.0.0.1 -p [srv 0 port] set foo bar]"
+        assert_match "MOVED $slot_for_foo :*" $set_foo_bar_result
+
+        # when in cluster mode, redirect using previous hostip
+        assert_equal "[exec src/redis-cli -h 127.0.0.1 -p [srv 0 port] -c set foo bar]" {OK}
+        assert_match "[exec src/redis-cli -h 127.0.0.1 -p [srv 0 port] -c get foo]" {bar}
+        
+
+        $node1_rd CONFIG SET cluster-preferred-endpoint-type "$endpoint_type_before_set"
+        assert_equal [$node1_rd read]  {OK}
+    }
+
     test "Sanity test push cmd after resharding" {
         assert_error {*MOVED*} {$node3 lpush key9184688 v1}
 


### PR DESCRIPTION
See #12266 


When the redis server cluster running on `cluster-preferred-endpoint-type unknown-endpoint` mode, and receive a request that should be redirected to another redis server node, it does not reply the hostip, but a empty host like `MOVED 3999 :6381`. 

This is because cluster server choose "" as `PreferredEndpoint` [here](https://github.com/redis/redis/blob/unstable/src/cluster.c#L5249)
```
const char *getPreferredEndpoint(clusterNode *n) {
    switch(server.cluster_preferred_endpoint_type) {
    case CLUSTER_ENDPOINT_TYPE_IP: return n->ip;
    case CLUSTER_ENDPOINT_TYPE_HOSTNAME: return (sdslen(n->hostname) != 0) ? n->hostname : "?";
    case CLUSTER_ENDPOINT_TYPE_UNKNOWN_ENDPOINT: return "";
    }
    return "unknown";
}
```

And then, the redis-cli would try to connect to an address without a host, which cause the issue:
```
127.0.0.1:7002> set bar bar
-> Redirected to slot [5061] located at :7000
Could not connect to Redis at :7000: No address associated with hostname
Could not connect to Redis at :7000: No address associated with hostname
not connected> exit
```

In this case, the redis-cli should use the previous hostip when there's no host provided by the server.

```
Release notes (Tooling):
Allow redis-cli in cluster mode to handle `unknown-endpoint`.
```