### PR TITLE
Adding geo command's missing test cases

### DIFF
--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -99,6 +99,18 @@ proc verify_geo_edge_response_bymember {expected_response expected_store_respons
     assert_match $expected_store_response $response
 }
 
+proc verify_geo_edge_response_generic {expected_response} {
+    catch {r geodist src{t} member 1 km} response
+    assert_match $expected_response $response
+
+    catch {r geohash src{t} member} response
+    assert_match $expected_response $response
+
+    catch {r geopos src{t} member} response
+    assert_match $expected_response $response
+}
+
+
 # The following list represents sets of random seed, search position
 # and radius that caused bugs in the past. It is used by the randomized
 # test later as a starting point. When the regression vectors are scanned
@@ -128,6 +140,7 @@ start_server {tags {"geo"}} {
 
         verify_geo_edge_response_bylonlat "WRONGTYPE*" "WRONGTYPE*"
         verify_geo_edge_response_bymember "WRONGTYPE*" "WRONGTYPE*"
+        verify_geo_edge_response_generic "WRONGTYPE*"
     }
 
     test {GEO with non existing src key} {


### PR DESCRIPTION
For geosearch and georadius we have already test coverage for wrong type, but we dont have for geodist, geohash, geopos commands. So adding the wrong type test cases for geodist, geohash, geopos commands.

Existing code, we have verify_geo_edge_response_bymember function for wrong type test cases which has member as an option. But the function is being called in other test cases where the output is not inline with these commnds(geodist, geohash, geopos). So I could not include these commands(geodist, geohash, geopos) as part of existing function, hence implemented a new function verify_geo_edge_response_generic and called from the test case.