### PR TITLE
Use Reservoir Sampling for random sampling of dict, and fix hang during fork

### DIFF
--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1087,7 +1087,7 @@ foreach type {single multiple single_multiple} {
                 lappend allkey $ele
             }
         }
-        # df = 29, 73 means 0.00001 probability
+        # validate even distribution of random sampling (df = 29, 73 means 0.00001 probability)
         assert_lessthan [chi_square_value $allkey] 73
 
         r config set save $origin_save

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1051,7 +1051,7 @@ foreach type {single multiple single_multiple} {
         catch {exec kill -9 $pid1}
         waitForBgsave r
 
-        # 7) Check that eventually all the elements are returned.
+        # 7) Check that eventually, SRANDMEMBER returns all elements.
         array set myset {}
         foreach ele [r smembers myset] {
             set myset($ele) 1

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1052,9 +1052,9 @@ foreach type {single multiple single_multiple} {
         waitForBgsave r
 
         # 7) Check that eventually, SRANDMEMBER returns all elements.
-        array set myset {}
+        array set allmyset {}
         foreach ele [r smembers myset] {
-            set myset($ele) 1
+            set allmyset($ele) 1
         }
         unset -nocomplain auxset
         set iterations 1000
@@ -1064,7 +1064,7 @@ foreach type {single multiple single_multiple} {
             foreach ele $res {
                 set auxset($ele) 1
             }
-            if {[lsort [array names myset]] eq
+            if {[lsort [array names allmyset]] eq
                 [lsort [array names auxset]]} {
                 break;
             }

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1022,7 +1022,7 @@ foreach type {single multiple single_multiple} {
             r srandmember myset 100
         }
 
-        # 3) Turn off the rehashing of this set, and remove the members to 1000.
+        # 3) Turn off the rehashing of this set, and remove the members to 500.
         r bgsave
         rem_hash_set_top_N myset [expr {[r scard myset] - 500}]
         assert_equal [r scard myset] 500

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1077,7 +1077,7 @@ foreach type {single multiple single_multiple} {
         assert_equal [r scard myset] 30
         assert {[is_rehashing myset]}
 
-        # 9) Use positive count (PATH 4).
+        # 9) Use positive count (PATH 4) to get 10 elements (out of 30) each time.
         unset -nocomplain allkey
         set iterations 1000
         while {$iterations != 0} {

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1077,6 +1077,12 @@ foreach type {single multiple single_multiple} {
         assert_equal [r scard myset] 30
         assert {[is_rehashing myset]}
 
+        # Now that we have a hash set with only one long chain bucket.
+        set htstats [r debug HTSTATS-KEY myset full]
+        assert {[regexp {different slots: ([0-9]+)} $htstats - different_slots]}
+        assert {[regexp {max chain length: ([0-9]+)} $htstats - max_chain_length]}
+        assert {$different_slots == 1 && $max_chain_length == 30}
+
         # 9) Use positive count (PATH 4) to get 10 elements (out of 30) each time.
         unset -nocomplain allkey
         set iterations 1000

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -978,6 +978,122 @@ foreach type {single multiple single_multiple} {
         }
     }
 
+    proc is_rehashing {myset} {
+        set htstats [r debug HTSTATS-KEY $myset]
+        return [string match {*rehashing target*} $htstats]
+    }
+
+    proc rem_hash_set_top_N {myset n} {
+        set cursor 0
+        set members {}
+        set enough 0
+        while 1 {
+            set res [r sscan $myset $cursor]
+            set cursor [lindex $res 0]
+            set k [lindex $res 1]
+            foreach m $k {
+                lappend members $m
+                if {[llength $members] >= $n} {
+                    set enough 1
+                    break
+                }
+            }
+            if {$enough} {
+                break
+            }
+        }
+        r srem $myset {*}$members
+    }
+
+    test "SRANDMEMBER with a dict containing long chain" {
+        set origin_save [config_get_set save ""]
+        set origin_max_lp [config_get_set set-max-listpack-entries 0]
+        set origin_save_delay [config_get_set rdb-key-save-delay 2147483647]
+
+        # 1) Create a hash set with 100000 members.
+        set members {}
+        for {set i 0} {$i < 100000} {incr i} {
+            lappend members [format "m:%d" $i]
+        }
+        create_set myset $members
+
+        # 2) Wait for the hash set rehashing to finish.
+        while {[is_rehashing myset]} {
+            r srandmember myset 100
+        }
+
+        # 3) Turn off the rehashing of this set, and remove the members to 1000.
+        r bgsave
+        rem_hash_set_top_N myset [expr {[r scard myset] - 500}]
+        assert_equal [r scard myset] 500
+
+        # 4) Kill RDB child process to restart rehashing.
+        set pid1 [get_child_pid 0]
+        catch {exec kill -9 $pid1}
+        waitForBgsave r
+
+        # 5) Let the set hash to start rehashing
+        r spop myset 1
+        assert [is_rehashing myset]
+
+        # 6) Verify that when rdb saving is in progress, rehashing will still be performed.
+        r bgsave
+
+        while {[is_rehashing myset]} {
+            r srandmember myset 1
+        }
+        if {$::verbose} {
+            puts [r debug HTSTATS-KEY myset full]
+        }
+
+        set pid1 [get_child_pid 0]
+        catch {exec kill -9 $pid1}
+        waitForBgsave r
+
+        # 7) Check that eventually all the elements are returned.
+        array set myset {}
+        foreach ele [r smembers myset] {
+            set myset($ele) 1
+        }
+        unset -nocomplain auxset
+        set iterations 1000
+        while {$iterations != 0} {
+            incr iterations -1
+            set res [r srandmember myset -10]
+            foreach ele $res {
+                set auxset($ele) 1
+            }
+            if {[lsort [array names myset]] eq
+                [lsort [array names auxset]]} {
+                break;
+            }
+        }
+        assert {$iterations != 0}
+
+        # 8) Remove the members to 30 in order to calculate the value of Chi-Square Distribution,
+        #    otherwise we would need more iterations.
+        rem_hash_set_top_N myset [expr {[r scard myset] - 30}]
+        assert_equal [r scard myset] 30
+        assert {[is_rehashing myset]}
+
+        # 9) Use positive count (PATH 4).
+        unset -nocomplain allkey
+        set iterations 1000
+        while {$iterations != 0} {
+            incr iterations -1
+            set res [r srandmember myset 10]
+            foreach ele $res {
+                lappend allkey $ele
+            }
+        }
+        # df = 29, 73 means 0.00001 probability
+        assert_lessthan [chi_square_value $allkey] 73
+
+        r config set save $origin_save
+        r config set set-max-listpack-entries $origin_max_lp
+        r config set rdb-key-save-delay $origin_save_delay
+    } {OK} {needs:debug slow}
+
     proc setup_move {} {
         r del myset3{t} myset4{t}
         create_set myset1{t} {1 a b}

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -998,7 +998,7 @@ foreach type {single multiple single_multiple} {
                     break
                 }
             }
-            if {$enough} {
+            if {$enough || $cursor == 0} {
                 break
             }
         }

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1036,7 +1036,8 @@ foreach type {single multiple single_multiple} {
         r spop myset 1
         assert [is_rehashing myset]
 
-        # 6) Verify that when rdb saving is in progress, rehashing will still be performed.
+        # 6) Verify that when rdb saving is in progress, rehashing will still be performed (because
+        # the ratio is extreme) by waiting for it to finish during an active bgsave.
         r bgsave
 
         while {[is_rehashing myset]} {


### PR DESCRIPTION
## Issue
When a dict has a long chain or the length of the chain is longer than the number of samples, we will never be able to sample the elements at the end of the chain using dictGetSomeKeys().
This means that there's an unfair random sampling affecting: RANDOMKEY, SRANDMEMBER, SPOP, ZRANDMEMBER, HRANDFIELD, and the eviction mechanism.

## Severe issue
This could mean that SRANDMEMBER, ZRANDMEMBER and HRANDFIELD (when used with `<count>`) can be hang in and endless loop.
The most severe case, is the pathological case of when someone uses SCAN+DEL or SSCAN+SREM creating an unevenly distributed dict.

## Recent regression
The above was amplified by the recent change in #11692 which prevented a down-sizing rehashing while there is a fork.
So in a pathological case of SSCAN+SREM causing an uneven hash table, followed by down-sizing of the hash table, if the rehashing would be suspended during a fork, and then calling SRANDMEMBER with `<count>` can lead to a hang.

## Solution
1. Before, we will stop sampling when we reach the maximum number of samples, even if there is more data after the current chain.
Now when we reach the maximum we use the Reservoir Sampling algorithm to fairly sample the end of the chain that cannot be sampled
2. Fix the rehashing code, so that the same as it allows rehashing for up-sizing during fork when the ratio is extreme, it will allow it for down-sizing as well.

Fix #12200