### PR TITLE
Add TLS configuration parameters to SENTINEL CONFIG

### DIFF
--- a/src/commands/sentinel-config.json
+++ b/src/commands/sentinel-config.json
@@ -11,6 +11,10 @@
             [
                 "7.2.0",
                 "Added the ability to set and get multiple parameters in one call."
+            ],
+            [
+                "7.2.0",
+                "Added the ability configure TLS parameters at runtime."
             ]
         ],
         "command_flags": [
@@ -77,6 +81,9 @@
                                     "const": "unknown"
                                 }
                             ]
+                        },
+                        "tls-ca-cert-file": {
+                            "type": "string"
                         },
                         "tls-cert-file": {
                             "type": "string"

--- a/src/commands/sentinel-config.json
+++ b/src/commands/sentinel-config.json
@@ -77,6 +77,12 @@
                                     "const": "unknown"
                                 }
                             ]
+                        },
+                        "tls-cert-file": {
+                            "type": "string"
+                        },
+                        "tls-key-file": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false

--- a/tests/sentinel/tests/15-config-set-config-get.tcl
+++ b/tests/sentinel/tests/15-config-set-config-get.tcl
@@ -58,5 +58,5 @@ test "SENTINEL CONFIG SET, wrong number of arguments" {
 }
 
 test "SENTINEL CONFIG SET with TLS update" {
-   # assert_equal {OK} [S 1 SENTINEL CONFIG SET tls-ca-cert-file ${::tlsdir}/ca.crt tls-cert-file ${::tlsdir}/server.crt tls-key-file ${::tlsdir}/server.key ]
+    assert_equal {OK} [S 1 SENTINEL CONFIG SET tls-ca-cert-file [file normalize ${::tlsdir}/ca.crt] tls-cert-file [file normalize ${::tlsdir}/server.crt] tls-key-file [file normalize ${::tlsdir}/server.key]]
 }

--- a/tests/sentinel/tests/15-config-set-config-get.tcl
+++ b/tests/sentinel/tests/15-config-set-config-get.tcl
@@ -56,3 +56,7 @@ test "SENTINEL CONFIG SET, wrong number of arguments" {
         fail "Expected to return Missing argument error"
     }
 }
+
+test "SENTINEL CONFIG SET with TLS update" {
+   # assert_equal {OK} [S 1 SENTINEL CONFIG SET tls-ca-cert-file ${::tlsdir}/ca.crt tls-cert-file ${::tlsdir}/server.crt tls-key-file ${::tlsdir}/server.key ]
+}


### PR DESCRIPTION
This PR allows `tls-ca-cert-file`, `tls-cert-file` and `tls-key-file` to be updated without restarting Sentinel by extending `CONFIG SET`, which facilitates key rotation.  

Fixes #12028 