### PR TITLE
Fix crash with CLUSTER REPLICATE for replicas with slots

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4928,9 +4928,9 @@ int verifyClusterConfigWithData(void) {
  * If this node is currently a master, it is turned into a slave. */
 void clusterSetMaster(clusterNode *n) {
     serverAssert(n != myself);
-    serverAssert(myself->numslots == 0);
 
     if (nodeIsMaster(myself)) {
+        serverAssert(myself->numslots == 0);
         myself->flags &= ~(CLUSTER_NODE_MASTER|CLUSTER_NODE_MIGRATE_TO);
         myself->flags |= CLUSTER_NODE_SLAVE;
         clusterCloseAllSlots();

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -171,7 +171,7 @@ tags {"aof external:skip"} {
             assert_equal 1 [is_alive $srv]
         }
 
-        test "Fixed AOF: Keyspace should contain values that were parseable" {
+        test "Fixed AOF: Keyspace should contain values that were parsable" {
             set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
             wait_done_loading $client
             assert_equal "hello" [$client get foo]


### PR DESCRIPTION
In ac3850c, we allow replicas to switch master via CLUSTER REPLICATE.
If a replica has slots, using the command will crash the replica.

Replicas are by design not supposed to own any slots, in this PR, we update
the judgements to prevent the replica from trying to take ownership of slots.

Fixes #12268. Fixed #12717.