### PR TITLE
Prevent PEJ on loading and on readonly replica.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -8616,9 +8616,10 @@ void firePostExecutionUnitJobs(void) {
  *
  * 'free_pd' can be NULL and in such case will not be used.
  *
- * Return REDISMODULE_OK on success and REDISMODULE_ERR if was called while loading data from disk (AOF or RDB) */
+ * Return REDISMODULE_OK on success and REDISMODULE_ERR if was called while loading data from disk (AOF or RDB) or
+ * if the instance is a readonly replica. */
 int RM_AddPostNotificationJob(RedisModuleCtx *ctx, RedisModulePostNotificationJobFunc callback, void *privdata, void (*free_privdata)(void*)) {
-    if (server.loading) {
+    if (server.loading|| (server.masterhost && server.repl_slave_ro)) {
         return REDISMODULE_ERR;
     }
     RedisModulePostExecUnitJob *job = zmalloc(sizeof(*job));

--- a/src/module.c
+++ b/src/module.c
@@ -8614,8 +8614,13 @@ void firePostExecutionUnitJobs(void) {
  * infinite loops by halting the execution could result in violation of the feature correctness
  * and so Redis will make no attempt to protect the module from infinite loops.
  *
- * 'free_pd' can be NULL and in such case will not be used. */
+ * 'free_pd' can be NULL and in such case will not be used.
+ *
+ * Return REDISMODULE_OK on success and REDISMODULE_ERR if was called while loading data from disk (AOF or RDB) */
 int RM_AddPostNotificationJob(RedisModuleCtx *ctx, RedisModulePostNotificationJobFunc callback, void *privdata, void (*free_privdata)(void*)) {
+    if (server.loading) {
+        return REDISMODULE_ERR;
+    }
     RedisModulePostExecUnitJob *job = zmalloc(sizeof(*job));
     job->module = ctx->module;
     job->callback = callback;


### PR DESCRIPTION
Fix #11643

While Redis loading data from disk (AOF or RDB), modules will get key space notifications. In such stage the module should not register any PEJ, the main reason this is forbidden is that PEJ purpose is to perform a write operation as a reaction to the key space notification. Write operations should not be performed while loading data and so there is no reason to register a PEJ. 

Same argument also apply to readonly replica. module should not perform any writes as a reaction to key space notifications and so it should not register a PEJ.

If a module need to perform some other task which is not involve writing, he can do it on the key space notification callback itself.