### PR TITLE
[New command] `CONFIG SET io-threads <N>`

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2454,6 +2454,14 @@ static int updatePort(const char **err) {
     return 1;
 }
 
+static int updateIOThreads(const char **err) {
+    if (updateThreadedIO() == C_ERR) {
+        *err = "Unable to update the number of threads.";
+        return 0;
+    }
+    return 1;
+}
+
 static int updateJemallocBgThread(const char **err) {
     UNUSED(err);
     set_jemalloc_bg_thread(server.jemalloc_bg_thread);
@@ -3127,7 +3135,7 @@ standardConfig static_configs[] = {
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */
-    createIntConfig("io-threads", NULL, DEBUG_CONFIG | IMMUTABLE_CONFIG, 1, 128, server.io_threads_num, 1, INTEGER_CONFIG, NULL, NULL), /* Single threaded by default */
+    createIntConfig("io-threads", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1, 128, server.io_threads_num, 1, INTEGER_CONFIG, NULL, updateIOThreads), /* Single threaded by default */
     createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_slave_validity_factor, 10, INTEGER_CONFIG, NULL, NULL), /* Slave max data age factor. */
     createIntConfig("list-max-listpack-size", "list-max-ziplist-size", MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.list_max_listpack_size, -2, INTEGER_CONFIG, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3135,7 +3135,7 @@ standardConfig static_configs[] = {
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.port, 6379, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */
-    createIntConfig("io-threads", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1, 128, server.io_threads_num, 1, INTEGER_CONFIG, NULL, updateIOThreads), /* Single threaded by default */
+    createIntConfig("io-threads", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1, 128, server.config_io_threads_num, 1, INTEGER_CONFIG, NULL, updateIOThreads), /* Single threaded by default */
     createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_slave_validity_factor, 10, INTEGER_CONFIG, NULL, NULL), /* Slave max data age factor. */
     createIntConfig("list-max-listpack-size", "list-max-ziplist-size", MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.list_max_listpack_size, -2, INTEGER_CONFIG, NULL, NULL),

--- a/src/networking.c
+++ b/src/networking.c
@@ -4302,7 +4302,7 @@ int updateThreadedIO(void) {
         current_threads++;
 
         /* Return ASAP when trying to decrease the number of threads */
-        if(current_threads > server.io_threads_num - 1) return C_ERR;
+        if (current_threads > server.io_threads_num - 1) return C_ERR;
     }
 
     /* Create the list of clients for the main thread if not created already */
@@ -4312,11 +4312,11 @@ int updateThreadedIO(void) {
     for (int i = current_threads + 1; i < server.io_threads_num; i++) {
         io_threads_list[i] = listCreate();
         pthread_t tid;
-        pthread_mutex_init(&io_threads_mutex[i],NULL);
+        pthread_mutex_init(&io_threads_mutex[i], NULL);
         setIOPendingCount(i, 0);
         pthread_mutex_lock(&io_threads_mutex[i]);
-        if (pthread_create(&tid,NULL,IOThreadMain,(void*)(long)i) != 0) {
-            serverLog(LL_WARNING,"Fatal: Can't initialize IO thread.");
+        if (pthread_create(&tid, NULL, IOThreadMain, (void*)(long)i) != 0) {
+            serverLog(LL_WARNING, "Fatal: Can't initialize IO thread.");
             exit(1);
         }
         io_threads[i] = tid;

--- a/src/networking.c
+++ b/src/networking.c
@@ -4296,31 +4296,27 @@ int stopThreadedIOIfNeeded(void) {
  * It returns C_OK when the update is successful, otherwise it returns
  * C_ERR when trying to decrease the number of threads. */
 int updateThreadedIO(void) {
-    int current_threads = 0;
-
-    for (int i = 1; i <= IO_THREADS_MAX_NUM && io_threads[i]; i++) {
-        current_threads++;
-
-        /* Return ASAP when trying to decrease the number of threads */
-        if (current_threads > server.io_threads_num - 1) return C_ERR;
-    }
+    /* Return when trying to decrease the number of threads */
+    if (server.io_threads_num > server.config_io_threads_num) return C_ERR;
 
     /* Create the list of clients for the main thread if not created already */
     if (!io_threads_list[0]) io_threads_list[0] = listCreate();
 
     /* Create new threads */
-    for (int i = current_threads + 1; i < server.io_threads_num; i++) {
+    for (int i = server.io_threads_num; i < server.config_io_threads_num; i++) {
         io_threads_list[i] = listCreate();
         pthread_t tid;
         pthread_mutex_init(&io_threads_mutex[i], NULL);
         setIOPendingCount(i, 0);
-        pthread_mutex_lock(&io_threads_mutex[i]);
+        if (!server.io_threads_active)
+            pthread_mutex_lock(&io_threads_mutex[i]);
         if (pthread_create(&tid, NULL, IOThreadMain, (void*)(long)i) != 0) {
             serverLog(LL_WARNING, "Fatal: Can't initialize IO thread.");
             exit(1);
         }
         io_threads[i] = tid;
     }
+    server.io_threads_num = server.config_io_threads_num;
     return C_OK;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -2039,6 +2039,7 @@ void initServerConfig(void) {
                                       updated later after loading the config.
                                       This value may be used before the server
                                       is initialized. */
+    server.io_threads_num = server.config_io_threads_num;
     server.timezone = getTimeZone(); /* Initialized by tzset(). */
     server.configfile = NULL;
     server.executable = NULL;
@@ -2592,6 +2593,7 @@ void initServer(void) {
     server.aof_state = server.aof_enabled ? AOF_ON : AOF_OFF;
     server.fsynced_reploff = server.aof_enabled ? 0 : -1;
     server.hz = server.config_hz;
+    server.io_threads_num = server.config_io_threads_num;
     server.pid = getpid();
     server.in_fork_child = CHILD_TYPE_NONE;
     server.main_thread_id = pthread_self();

--- a/src/server.h
+++ b/src/server.h
@@ -2636,6 +2636,7 @@ void linkClient(client *c);
 void protectClient(client *c);
 void unprotectClient(client *c);
 void initThreadedIO(void);
+int updateThreadedIO(void);
 client *lookupClientByID(uint64_t id);
 int authRequired(client *c);
 void putClientInPendingWriteQueue(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -1620,6 +1620,7 @@ struct redisServer {
     redisAtomic uint64_t next_client_id; /* Next client unique ID. Incremental. */
     int protected_mode;         /* Don't accept external connections. */
     int io_threads_num;         /* Number of IO threads to use. */
+    int config_io_threads_num;  /* Configured io-threads value. Used in the CONFIG SET io-threads command */
     int io_threads_do_reads;    /* Read and parse from IO threads? */
     int io_threads_active;      /* Is IO threads currently active? */
     long long events_processed_while_blocked; /* processEventsWhileBlocked() */


### PR DESCRIPTION
We implemented the feature discussed in #11529, which makes it possible to increase the number of threads via the command line without restarting the Redis service.