### PR TITLE
Correcting the Copied test case without changing command.

### DIFF
--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -132,7 +132,7 @@ start_server {tags {"zset"}} {
         }
 
         test "ZSET element can't be set to NaN with ZINCRBY - $encoding" {
-            assert_error "*not*float*" {r zadd myzset nan abc}
+            assert_error "*not*float*" {r zincrby myzset nan abc}
         }
 
         test "ZADD with options syntax error with incomplete pair - $encoding" {


### PR DESCRIPTION
Looks like the Zadd test case was copied to create Zincrby test case ,but missed to change the command.

**Before :**
 test "ZSET element can't be set to NaN with ZADD - $encoding" {
            assert_error "*not*float*" {r zadd myzset nan abc}
 }
 test "ZSET element can't be set to NaN with **ZINCRBY** - $encoding" {
            assert_error "*not*float*" {r **zadd** myzset nan abc}
 }

**After.**
 test "ZSET element can't be set to NaN with ZADD - $encoding" {
            assert_error "*not*float*" {r zadd myzset nan abc}
 }
 test "ZSET element can't be set to NaN with **ZINCRBY** - $encoding" {
            assert_error "*not*float*" {r **zincrby** myzset nan abc}
 }