### PR TITLE
Optimize SET PXAT to reduce calls of rewriteClientCommandVector

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -116,10 +116,12 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
     if (expire) {
         setExpire(c,c->db,key,milliseconds);
         /* Propagate as SET Key Value PXAT millisecond-timestamp if there is
-         * EX/PX/EXAT/PXAT flag. */
-        robj *milliseconds_obj = createStringObjectFromLongLong(milliseconds);
-        rewriteClientCommandVector(c, 5, shared.set, key, val, shared.pxat, milliseconds_obj);
-        decrRefCount(milliseconds_obj);
+         * EX/PX/EXAT flag. */
+        if (!(flags & OBJ_PXAT)) {
+            robj *milliseconds_obj = createStringObjectFromLongLong(milliseconds);
+            rewriteClientCommandVector(c, 5, shared.set, key, val, shared.pxat, milliseconds_obj);
+            decrRefCount(milliseconds_obj);
+        }
         notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);
     }
 

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -321,7 +321,7 @@ start_server {tags {"expire"}} {
             r set foo1 bar ex 100
             r set foo2 bar px 100000
             r set foo3 bar exat [expr [clock seconds]+100]
-            r set foo4 bar pxat [expr [clock milliseconds]+100000]
+            r set foo4 bar PXAT [expr [clock milliseconds]+100000]
             r setex foo5 100 bar
             r psetex foo6 100000 bar
             # EXPIRE-family commands
@@ -491,7 +491,7 @@ start_server {tags {"expire"}} {
             {set foo1 bar PXAT *}
             {set foo1 bar PXAT *}
             {set foo1 bar PXAT *}
-            {set foo1 bar PXAT *}
+            {set foo1 bar pxat *}
             {set foo1 bar PXAT *}
             {set foo1 bar PXAT *}
             {set foo2 bar}


### PR DESCRIPTION
In PXAT case, there is no need to do the rewriteClientCommandVector,
a simply benchmark show we gain a improvement of 10%.