### PR TITLE
Making CH and INCR option mutually exclusive for ZADD command

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1758,6 +1758,12 @@ void zaddGenericCommand(client *c, int flags) {
     elements /= 2; /* Now this holds the number of score-element pairs. */
 
     /* Check for incompatible options. */
+    if(ch && incr){
+        addReplyError(c,
+            "CH and INCR options at the same time are not compatible");
+        return;
+    }
+
     if (nx && xx) {
         addReplyError(c,
             "XX and NX options at the same time are not compatible");

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -250,6 +250,12 @@ start_server {tags {"zset"}} {
             set err
         } {ERR*}
 
+        test "ZADD CH and INCR are not compatible - $encoding" {
+            r del ztmp
+            catch {r zadd ztmp CH INCR 10 x} err
+            set err
+        } {ERR*}
+
         test "ZADD INCR LT/GT replies with nill if score not updated - $encoding" {
             r del ztmp
             r zadd ztmp 28 x


### PR DESCRIPTION
**Issue Description**
When CH and INCR option used together in ZADD command, the CH option has no effect on output and the displayed output will be the score after the increment and not the the number of element changed. 

**Current behavior**

```
127.0.0.1:6379> zadd z2 XX CH INCR 2 2
"24"
127.0.0.1:6379> zadd z2 CH INCR 3 a
"3"
```

As per the design, Whenever the INCR option is specified , the return value will be the new score of member (a double precision floating point number) represented as string, or nil if the operation was aborted (when called with either the XX or the NX option).

Also INCR works with only one member so even we give more priority to CH over INCR, the output will always be 1.

**Proposed Solution** 
INCR and CH should be mutually exclusive to avoid the above state issue.

**After Changes**

```
127.0.0.1:6379> zadd z1 XX CH INCR e 10
(error) ERR CH and INCR at same time are not compatible
```
