### PR TITLE
Removing duplicated tests

### DIFF
--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -275,27 +275,6 @@ start_server {tags {"introspection"}} {
         r client list
     } {*name= *}
 
-    test {Coverage: Basic CLIENT CACHING} {
-        set rd_redirection [redis_deferring_client]
-        $rd_redirection client id
-        set redir_id [$rd_redirection read]
-        r CLIENT TRACKING on OPTIN REDIRECT $redir_id
-        r CLIENT CACHING yes
-        r CLIENT TRACKING off
-    } {OK}
-
-    test {Coverage: Basic CLIENT REPLY} {
-        r CLIENT REPLY on
-    } {OK}
-
-    test {Coverage: Basic CLIENT TRACKINGINFO} {
-        r CLIENT TRACKINGINFO
-    } {flags off redirect -1 prefixes {}}
-
-    test {Coverage: Basic CLIENT GETREDIR} {
-        r CLIENT GETREDIR
-    } {-1}
-
     test {CLIENT SETNAME does not accept spaces} {
         catch {r client setname "foo bar"} e
         set e


### PR DESCRIPTION
In 4ba47d2d2 the following tests added in both tracking.tcl and introspection.tcl

- Coverage: Basic CLIENT CACHING
- Coverage: Basic CLIENT REPLY
- Coverage: Basic CLIENT TRACKINGINFO
- Coverage: Basic CLIENT GETREDIR