### PR TITLE
Align RM_ReplyWithErrorFormat with RM_ReplyWithError

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -2997,7 +2997,7 @@ int RM_ReplyWithError(RedisModuleCtx *ctx, const char *err) {
 
 /* Reply with the error create from a printf format and arguments.
  *
- * Note that 'err' must contain all the error, including
+ * Note that 'fmt' must contain all the error, including
  * the initial error code. The function only provides the initial "-", so
  * the usage is, for example:
  *
@@ -3013,7 +3013,7 @@ int RM_ReplyWithErrorFormat(RedisModuleCtx *ctx, const char *fmt, ...) {
     client *c = moduleGetReplyClient(ctx);
     if (c == NULL) return REDISMODULE_OK;
 
-    int len = strlen(fmt) + 2; /* 1 for the \n and 1 for the hyphen */
+    int len = strlen(fmt) + 2; /* 1 for the \0 and 1 for the hyphen */
     char *hyphenfmt = zmalloc(len);
     snprintf(hyphenfmt, len, "-%s", fmt);
 

--- a/tests/unit/moduleapi/reply.tcl
+++ b/tests/unit/moduleapi/reply.tcl
@@ -128,13 +128,19 @@ start_server {tags {"modules"}} {
 
         test "RESP$proto: RM_ReplyWithErrorFormat: error format reply" {
             catch {r rw.error_format "An error: %s" foo} e
-            assert_match "ERR An error: foo" $e
+            assert_match "An error: foo" $e  ;# Should not be used by a user, but compatible with RM_ReplyError
 
             catch {r rw.error_format "-ERR An error: %s" foo2} e
-            assert_match "ERR An error: foo2" $e
+            assert_match "-ERR An error: foo2" $e  ;# Should not be used by a user, but compatible with RM_ReplyError (There are two hyphens, TCL removes the first one)
 
             catch {r rw.error_format "-WRONGTYPE A type error: %s" foo3} e
-            assert_match "WRONGTYPE A type error: foo3" $e
+            assert_match "-WRONGTYPE A type error: foo3" $e  ;# Should not be used by a user, but compatible with RM_ReplyError (There are two hyphens, TCL removes the first one)
+
+            catch {r rw.error_format "ERR An error: %s" foo4} e
+            assert_match "ERR An error: foo4" $e
+
+            catch {r rw.error_format "WRONGTYPE A type error: %s" foo5} e
+            assert_match "WRONGTYPE A type error: foo5" $e
         }
 
         r hello 2


### PR DESCRIPTION
Introduced by https://github.com/redis/redis/pull/11923 (Redis 7.2 RC2)

It's very weird and counterintuitive that `RM_ReplyWithError` requires the error-code **without** a hyphen while `RM_ReplyWithErrorFormat` requires either the error-code **with** a hyphen or no error-code at all
```
RedisModule_ReplyWithError(ctx, "BLA bla bla");
```
vs.
```
RedisModule_ReplyWithErrorFormat(ctx, "-BLA %s", "bla bla");
```

This commit aligns RM_ReplyWithErrorFormat to behvae like RM_ReplyWithError.
it's a breaking changes but it's done before 7.2 goes GA.