### PR TITLE
Sanitizer reported memory leak for '--invalid' option or port number is missed cases to redis-server.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -454,14 +454,13 @@ void loadServerConfigFromString(char *config) {
     const char *err = NULL;
     int linenum = 0, totlines, i;
     sds *lines;
+    sds *argv = NULL;
+    int argc;
 
     reading_config_file = 1;
     lines = sdssplitlen(config,strlen(config),"\n",1,&totlines);
 
     for (i = 0; i < totlines; i++) {
-        sds *argv;
-        int argc;
-
         linenum = i+1;
         lines[i] = sdstrim(lines[i]," \t\r\n");
 
@@ -489,7 +488,6 @@ void loadServerConfigFromString(char *config) {
              * Note that MULTI_ARG_CONFIGs need to validate arg count on their own */
             if (!(config->flags & MULTI_ARG_CONFIG) && argc != 2) {
                 err = "wrong number of arguments";
-                if (argv) sdsfreesplitres(argv,argc);
                 goto loaderr;
             }
 
@@ -501,14 +499,12 @@ void loadServerConfigFromString(char *config) {
                 int new_argc;
                 new_argv = sdssplitargs(argv[1], &new_argc);
                 if (!config->interface.set(config, new_argv, new_argc, &err)) {
-                    if (argv) sdsfreesplitres(argv,argc);
                     goto loaderr;
                 }
                 sdsfreesplitres(new_argv, new_argc);
             } else {
                 /* Set config using all arguments that follows */
                 if (!config->interface.set(config, &argv[1], argc-1, &err)) {
-                    if (argv) sdsfreesplitres(argv,argc);
                     goto loaderr;
                 }
             }
@@ -541,7 +537,6 @@ void loadServerConfigFromString(char *config) {
 
             if (!cmd) {
                 err = "No such command in rename-command";
-                if (argv) sdsfreesplitres(argv,argc);
                 goto loaderr;
             }
 
@@ -558,7 +553,6 @@ void loadServerConfigFromString(char *config) {
                 if (retval != DICT_OK) {
                     sdsfree(copy);
                     err = "Target command name already exists";
-                    if (argv) sdsfreesplitres(argv,argc);
                     goto loaderr;
                 }
             }
@@ -569,7 +563,6 @@ void loadServerConfigFromString(char *config) {
                 snprintf(buf,sizeof(buf),"Error in user declaration '%s': %s",
                     argv[argc_err],errmsg);
                 err = buf;
-                if (argv) sdsfreesplitres(argv,argc);
                 goto loaderr;
             }
         } else if (!strcasecmp(argv[0],"loadmodule") && argc >= 2) {
@@ -591,15 +584,12 @@ void loadServerConfigFromString(char *config) {
             if (argc != 1) {
                 if (!server.sentinel_mode) {
                     err = "sentinel directive while not in sentinel mode";
-                    if (argv) sdsfreesplitres(argv,argc);
                     goto loaderr;
                 }
                 queueSentinelConfig(argv+1,argc-1,linenum,lines[i]);
             }
         } else {
-            err = "Bad directive or wrong number of arguments";
-            if (argv) sdsfreesplitres(argv,argc);
-            goto loaderr;
+            err = "Bad directive or wrong number of arguments"; goto loaderr;
         }
         sdsfreesplitres(argv,argc);
     }
@@ -639,6 +629,7 @@ void loadServerConfigFromString(char *config) {
     return;
 
 loaderr:
+    if (argv) sdsfreesplitres(argv,argc);
     fprintf(stderr, "\n*** FATAL CONFIG FILE ERROR (Redis %s) ***\n",
         REDIS_VERSION);
     if (i < totlines) {

--- a/src/config.c
+++ b/src/config.c
@@ -489,6 +489,7 @@ void loadServerConfigFromString(char *config) {
              * Note that MULTI_ARG_CONFIGs need to validate arg count on their own */
             if (!(config->flags & MULTI_ARG_CONFIG) && argc != 2) {
                 err = "wrong number of arguments";
+                sdsfreesplitres(argv,argc);
                 goto loaderr;
             }
 
@@ -588,7 +589,9 @@ void loadServerConfigFromString(char *config) {
                 queueSentinelConfig(argv+1,argc-1,linenum,lines[i]);
             }
         } else {
-            err = "Bad directive or wrong number of arguments"; goto loaderr;
+            err = "Bad directive or wrong number of arguments";
+            sdsfreesplitres(argv,argc);
+            goto loaderr;
         }
         sdsfreesplitres(argv,argc);
     }

--- a/src/config.c
+++ b/src/config.c
@@ -552,8 +552,7 @@ void loadServerConfigFromString(char *config) {
                 retval = dictAdd(server.commands, copy, cmd);
                 if (retval != DICT_OK) {
                     sdsfree(copy);
-                    err = "Target command name already exists";
-                    goto loaderr;
+                    err = "Target command name already exists"; goto loaderr;
                 }
             }
         } else if (!strcasecmp(argv[0],"user") && argc >= 2) {
@@ -570,7 +569,6 @@ void loadServerConfigFromString(char *config) {
         } else if (strchr(argv[0], '.')) {
             if (argc < 2) {
                 err = "Module config specified without value";
-                if (argv) sdsfreesplitres(argv,argc);
                 goto loaderr;
             }
             sds name = sdsdup(argv[0]);

--- a/src/config.c
+++ b/src/config.c
@@ -477,6 +477,7 @@ void loadServerConfigFromString(char *config) {
         /* Skip this line if the resulting command vector is empty. */
         if (argc == 0) {
             sdsfreesplitres(argv,argc);
+            argv = NULL;
             continue;
         }
         sdstolower(argv[0]);
@@ -499,6 +500,7 @@ void loadServerConfigFromString(char *config) {
                 int new_argc;
                 new_argv = sdssplitargs(argv[1], &new_argc);
                 if (!config->interface.set(config, new_argv, new_argc, &err)) {
+                    if(new_argv) sdsfreesplitres(new_argv, new_argc);
                     goto loaderr;
                 }
                 sdsfreesplitres(new_argv, new_argc);
@@ -510,6 +512,7 @@ void loadServerConfigFromString(char *config) {
             }
 
             sdsfreesplitres(argv,argc);
+            argv = NULL;
             continue;
         } else {
             int match = 0;
@@ -524,6 +527,7 @@ void loadServerConfigFromString(char *config) {
             }
             if (match) {
                 sdsfreesplitres(argv,argc);
+                argv = NULL;
                 continue;
             }
         }
@@ -590,6 +594,7 @@ void loadServerConfigFromString(char *config) {
             err = "Bad directive or wrong number of arguments"; goto loaderr;
         }
         sdsfreesplitres(argv,argc);
+        argv = NULL;
     }
 
     if (server.logfile[0] != '\0') {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -652,6 +652,10 @@ start_server {tags {"introspection"}} {
     }
 
     test {redis-server command line arguments - error cases} {
+        # Take '--invalid' as the option.
+        catch {exec src/redis-server --invalid} err
+        assert_match {*Bad directive or wrong number of arguments*} $err
+
         catch {exec src/redis-server --port} err
         assert_match {*'port'*wrong number of arguments*} $err
 


### PR DESCRIPTION
Observed that the sanitizer reported memory leak as clean up is not done before the process termination in negative/following cases:

**- when we passed '--invalid' as option to redis-server.**

```
 -vm:~/mem-leak-issue/redis$ ./src/redis-server --invalid

*** FATAL CONFIG FILE ERROR (Redis 255.255.255) ***
Reading the configuration file, at line 2
>>> 'invalid'
Bad directive or wrong number of arguments

=================================================================
==865778==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f0985f65867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x558ec86686ec in ztrymalloc_usable_internal /home/ubuntu/mem-leak-issue/redis/src/zmalloc.c:117
    #2 0x558ec86686ec in ztrymalloc_usable /home/ubuntu/mem-leak-issue/redis/src/zmalloc.c:135
    #3 0x558ec86686ec in ztryrealloc_usable_internal /home/ubuntu/mem-leak-issue/redis/src/zmalloc.c:276
    #4 0x558ec86686ec in zrealloc /home/ubuntu/mem-leak-issue/redis/src/zmalloc.c:327
    #5 0x558ec865dd7e in sdssplitargs /home/ubuntu/mem-leak-issue/redis/src/sds.c:1172
    #6 0x558ec87a1be7 in loadServerConfigFromString /home/ubuntu/mem-leak-issue/redis/src/config.c:472
    #7 0x558ec87a13b3 in loadServerConfig /home/ubuntu/mem-leak-issue/redis/src/config.c:718
    #8 0x558ec85e6f15 in main /home/ubuntu/mem-leak-issue/redis/src/server.c:7258
    #9 0x7f09856e5d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 8 byte(s) leaked in 1 allocation(s).

```

**- when we pass '--port' as option and missed to add port number to redis-server.**

```
vm:~/mem-leak-issue/redis$ ./src/redis-server --port

*** FATAL CONFIG FILE ERROR (Redis 255.255.255) ***
Reading the configuration file, at line 2
>>> 'port'
wrong number of arguments

=================================================================
==865846==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7fdcdbb1f867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x557e8b04f6ec in ztrymalloc_usable_internal /home/ubuntu/mem-leak-issue/redis/src/zmalloc.c:117
    #2 0x557e8b04f6ec in ztrymalloc_usable /home/ubuntu/mem-leak-issue/redis/src/zmalloc.c:135
    #3 0x557e8b04f6ec in ztryrealloc_usable_internal /home/ubuntu/mem-leak-issue/redis/src/zmalloc.c:276
    #4 0x557e8b04f6ec in zrealloc /home/ubuntu/mem-leak-issue/redis/src/zmalloc.c:327
    #5 0x557e8b044d7e in sdssplitargs /home/ubuntu/mem-leak-issue/redis/src/sds.c:1172
    #6 0x557e8b188be7 in loadServerConfigFromString /home/ubuntu/mem-leak-issue/redis/src/config.c:472
    #7 0x557e8b1883b3 in loadServerConfig /home/ubuntu/mem-leak-issue/redis/src/config.c:718
    #8 0x557e8afcdf15 in main /home/ubuntu/mem-leak-issue/redis/src/server.c:7258
    #9 0x7fdcdb29fd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Indirect leak of 10 byte(s) in 1 object(s) allocated from:
    #0 0x7fdcdbb1fc18 in __interceptor_realloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:164
    #1 0x557e8b04f9aa in ztryrealloc_usable_internal /home/ubuntu/mem-leak-issue/redis/src/zmalloc.c:287
    #2 0x557e8b04f9aa in ztryrealloc_usable /home/ubuntu/mem-leak-issue/redis/src/zmalloc.c:317
    #3 0x557e8b04f9aa in zrealloc_usable /home/ubuntu/mem-leak-issue/redis/src/zmalloc.c:342
    #4 0x557e8b033f90 in _sdsMakeRoomFor /home/ubuntu/mem-leak-issue/redis/src/sds.c:271
    #5 0x557e8b033f90 in sdsMakeRoomFor /home/ubuntu/mem-leak-issue/redis/src/sds.c:295
    #6 0x557e8b033f90 in sdscatlen /home/ubuntu/mem-leak-issue/redis/src/sds.c:486
    #7 0x557e8b044e1f in sdssplitargs /home/ubuntu/mem-leak-issue/redis/src/sds.c:1165
    #8 0x557e8b188be7 in loadServerConfigFromString /home/ubuntu/mem-leak-issue/redis/src/config.c:472
    #9 0x557e8b1883b3 in loadServerConfig /home/ubuntu/mem-leak-issue/redis/src/config.c:718
    #10 0x557e8afcdf15 in main /home/ubuntu/mem-leak-issue/redis/src/server.c:7258
    #11 0x7fdcdb29fd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 18 byte(s) leaked in 2 allocation(s).

```

As part analysis found that the sdsfreesplitres is not called when this condition checks are being hit.

Output after the fix:


```
vm:~/mem-leak-issue/redis$ ./src/redis-server --invalid

*** FATAL CONFIG FILE ERROR (Redis 255.255.255) ***
Reading the configuration file, at line 2
>>> 'invalid'
Bad directive or wrong number of arguments
vm:~/mem-leak-issue/redis$

===========================================
vm:~/mem-leak-issue/redis$ ./src/redis-server --jdhg

*** FATAL CONFIG FILE ERROR (Redis 255.255.255) ***
Reading the configuration file, at line 2
>>> 'jdhg'
Bad directive or wrong number of arguments

---------------------------------------------------------------------------
vm:~/mem-leak-issue/redis$ ./src/redis-server --port

*** FATAL CONFIG FILE ERROR (Redis 255.255.255) ***
Reading the configuration file, at line 2
>>> 'port'
wrong number of arguments
```