### PR TITLE
More generalized error msg for sintercard and zintercard for limit option

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1462,7 +1462,7 @@ void sinterCardCommand(client *c) {
         if (!strcasecmp(opt, "LIMIT") && moreargs) {
             j++;
             if (getPositiveLongFromObjectOrReply(c, c->argv[j], &limit,
-                                                 "LIMIT can't be negative") != C_OK)
+                                                 "LIMIT is not a positive integer or out of range") != C_OK)
                 return;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2666,7 +2666,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
             {
                 j++; remaining--;
                 if (getPositiveLongFromObjectOrReply(c, c->argv[j], &limit,
-                                                     "LIMIT can't be negative") != C_OK)
+                                                     "LIMIT is not a positive integer or out of range") != C_OK)
                 {
                     zfree(src);
                     return;


### PR DESCRIPTION
It display same error " ERR LIMIT can't be negative" for string and out of range.
Changing the error msg so that it can be applicable to all the cases, i.e negative integer, string and outofrange

**Before** 
```
127.0.0.1:6379> ZINTERCARD 2 z1 z2 LIMIT a
(error) ERR LIMIT can't be negative
127.0.0.1:6379> ZINTERCARD 2 z1 z2 LIMIT 1111111111111111111111111111111111111111111111111111111111
(error) ERR LIMIT can't be negative
127.0.0.1:6379> sintercard 2 s1 s2 LIMIT a
(error) ERR LIMIT can't be negative
127.0.0.1:6379> sintercard 2 s1 s2 LIMIT 1111111111111111111111111111111111111111111111111111111111
(error) ERR LIMIT can't be negative
127.0.0.1:6379>
```

**After**
```
127.0.0.1:6379> ZINTERCARD 2 z1 z2 LIMIT a
(error) ERR LIMIT is not a positive integer or out of range
127.0.0.1:6379>  ZINTERCARD 2 z1 z2 LIMIT 1111111111111111111111111111111111111111111111111111111111
(error) ERR LIMIT is not a positive integer or out of range
127.0.0.1:6379>  sintercard 2 s1 s2 LIMIT a
(error) ERR LIMIT is not a positive integer or out of range
127.0.0.1:6379> sintercard 2 s1 s2 LIMIT 1111111111111111111111111111111111111111111111111111111111
(error) ERR LIMIT is not a positive integer or out of range
127.0.0.1:6379>
```