### PR TITLE
Fix cluster human_nodename Getter data loss in nodes.conf

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -240,11 +240,11 @@ int auxHumanNodenameSetter(clusterNode *n, void *value, int length) {
 }
 
 sds auxHumanNodenameGetter(clusterNode *n, sds s) {
-    return sdscatprintf(s, "%.40s", n->human_nodename);
+    return sdscatprintf(s, "%s", n->human_nodename);
 }
 
 int auxHumanNodenamePresent(clusterNode *n) {
-    return strlen(n->human_nodename);
+    return sdslen(n->human_nodename);
 }
 
 /* clusterLink send queue blocks */


### PR DESCRIPTION
auxHumanNodenameGetter limited to %.40s, since we did not limit the
length of config cluster-announce-human-nodename, %.40s will cause
nodename data loss (we will persist it in nodes.conf).

Additional modified auxHumanNodenamePresent to use sdslen.

Introduced in #9564.