### PR TITLE
Fix broken protocol when PUBLISH emits local push inside MULTI

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -417,7 +417,7 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
 
     /* If we're processing a push message into the current client (i.e. executing PUBLISH
      * to a channel which we are subscribed to, then we wanna postpone that message to be added
-     * after the command's reply (specifically important during multi-exec). the exception are
+     * after the command's reply (specifically important during multi-exec). the exception is
      * the SUBSCRIBE command family, which (currently) have a push message instead of a proper reply.
      * The check for executing_client also avoids affecting push messages that are part of eviction. */
     if (c == server.current_client && (c->flags & CLIENT_PUSHING) &&

--- a/src/server.h
+++ b/src/server.h
@@ -1928,6 +1928,7 @@ struct redisServer {
     unsigned int tracking_clients;  /* # of clients with tracking enabled.*/
     size_t tracking_table_max_keys; /* Max number of keys in tracking table. */
     list *tracking_pending_keys; /* tracking invalidation keys pending to flush */
+    list *pending_push_messages; /* pending publish or other push messages to flush */
     /* Sort parameters - qsort_r() is only available under BSD so we
      * have to take this state global, in order to pass it to sortCompare() */
     int sort_desc;

--- a/tests/modules/publish.c
+++ b/tests/modules/publish.c
@@ -5,6 +5,18 @@
 
 #define UNUSED(V) ((void) V)
 
+int cmd_publish_classic_multi(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+{
+    if (argc < 3)
+        return RedisModule_WrongArity(ctx);
+    RedisModule_ReplyWithArray(ctx, argc-2);
+    for (int i = 2; i < argc; i++) {
+        int receivers = RedisModule_PublishMessage(ctx, argv[1], argv[i]);
+        RedisModule_ReplyWithLongLong(ctx, receivers);
+    }
+    return REDISMODULE_OK;
+}
+
 int cmd_publish_classic(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 {
     if (argc != 3)
@@ -33,6 +45,9 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx,"publish.classic",cmd_publish_classic,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"publish.classic_multi",cmd_publish_classic_multi,"",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx,"publish.shard",cmd_publish_shard,"",0,0,0) == REDISMODULE_ERR)

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -148,6 +148,19 @@ start_server {overrides {save {900 1}} tags {"modules"}} {
         $rd_trk close
     }
 
+    test {publish inside rm_call} {
+        r hello 3
+        r subscribe foo
+
+        # published message comes after the response of the command that issued it.
+        assert_equal [r test.rm_call publish foo bar] {1}
+        assert_equal [r read] {message foo bar}
+
+        r unsubscribe foo
+        r hello 2
+        set _ ""
+    } {} {resp3}
+
     test {test module get/set client name by id api} {
         catch { r test.getname } e
         assert_equal "-ERR No name" $e

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -148,7 +148,7 @@ start_server {overrides {save {900 1}} tags {"modules"}} {
         $rd_trk close
     }
 
-    test {publish inside rm_call} {
+    test {publish to self inside rm_call} {
         r hello 3
         r subscribe foo
 

--- a/tests/unit/moduleapi/publish.tcl
+++ b/tests/unit/moduleapi/publish.tcl
@@ -17,7 +17,7 @@ start_server {tags {"modules"}} {
         $rd2 close
     }
 
-    test {module publish to self} {
+    test {module publish to self with multi message} {
         r hello 3
         r subscribe foo
 

--- a/tests/unit/moduleapi/publish.tcl
+++ b/tests/unit/moduleapi/publish.tcl
@@ -13,5 +13,22 @@ start_server {tags {"modules"}} {
         assert_equal 1 [r publish.classic chan1 world]
         assert_equal {smessage chan1 hello} [$rd1 read]
         assert_equal {message chan1 world} [$rd2 read]
+        $rd1 close
+        $rd2 close
     }
+
+    test {module publish to self} {
+        r hello 3
+        r subscribe foo
+
+        # published message comes after the response of the command that issued it.
+        assert_equal [r publish.classic_multi foo bar vaz] {1 1}
+        assert_equal [r read] {message foo bar}
+        assert_equal [r read] {message foo vaz}
+
+        r unsubscribe foo
+        r hello 2
+        set _ ""
+    } {} {resp3}
+
 }

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -452,7 +452,7 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
-    test "publish inside multi" {
+    test "publish to self inside multi" {
         r hello 3
         r subscribe foo
         r multi
@@ -465,7 +465,7 @@ start_server {tags {"pubsub network"}} {
         assert_equal [r read] {message foo vaz}
     } {} {resp3}
 
-    test "publish inside script" {
+    test "publish to self inside script" {
         r hello 3
         r subscribe foo
         set res [r eval {
@@ -479,7 +479,7 @@ start_server {tags {"pubsub network"}} {
         assert_equal [r read] {message foo vaz}
     } {} {resp3}
 
-    test "unsubscribe inside multi" {
+    test "unsubscribe inside multi, and publish to self" {
         r hello 3
 
         # Note: SUBSCRIBE and UNSUBSCRIBE with multiple channels in the same command,

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -188,7 +188,7 @@ start_server {tags {"pubsub network"}} {
         assert_equal {0} [punsubscribe $rd ch*]
 
         $rd close
-    }
+    } {0} {resp3}
 
     test "PUNSUBSCRIBE from non-subscribed channels" {
         set rd1 [redis_deferring_client]
@@ -463,7 +463,7 @@ start_server {tags {"pubsub network"}} {
         assert_equal [r exec] {abc 1 1 def}
         assert_equal [r read] {message foo bar}
         assert_equal [r read] {message foo vaz}
-    }
+    } {} {resp3}
 
     test "publish inside script" {
         r hello 3
@@ -477,7 +477,7 @@ start_server {tags {"pubsub network"}} {
         assert_equal $res {bla}
         assert_equal [r read] {message foo bar}
         assert_equal [r read] {message foo vaz}
-    }
+    } {} {resp3}
 
     test "unsubscribe inside multi" {
         r hello 3
@@ -498,9 +498,9 @@ start_server {tags {"pubsub network"}} {
         r ping def
         assert_equal [r exec] {abc {unsubscribe bar 2} {unsubscribe baz 1} def}
 
-        # published message comes before the publish command's response
-        assert_equal [r publish foo vaz] {message foo vaz}
-        assert_equal [r read] {1}
-    }
+        # published message comes after the publish command's response.
+        assert_equal [r publish foo vaz] {1}
+        assert_equal [r read] {message foo vaz}
+    } {} {resp3}
 
 }


### PR DESCRIPTION
When a connection that's subscribe to a channel emits PUBLISH inside MULTI-EXEC, the push notification messes up the EXEC response.

e.g. MULTI, PING, PUSH foo bar, PING, EXEC
the EXEC's response will contain: PONG, {message foo bar}, 1. and the second PONG will be delivered outside the EXEC's response.

Additionally, this PR changes the order of responses in case of a plain PUBLISH (when the current client also subscribed to it), by delivering the push after the command's response instead of before it.
This also affects modules calling RM_PublishMessage in a similar way, so that we don't run the risk of getting that push mixed together with the module command's response.