### PR TITLE
Fix ZRANK/ZREVRANK reply_schema description

### DIFF
--- a/src/commands/zrank.json
+++ b/src/commands/zrank.json
@@ -47,11 +47,11 @@
                 },
                 {
                     "type": "integer",
-                    "description": "The rank of the member when 'WITHSCORES' is not used."
+                    "description": "The rank of the member when 'WITHSCORE' is not used."
                 },
                 {
                     "type": "array",
-                    "description": "The rank and score of the member when 'WITHSCORES' is used.",
+                    "description": "The rank and score of the member when 'WITHSCORE' is used.",
                     "minItems": 2,
                     "maxItems": 2,
                     "items": [

--- a/src/commands/zrevrank.json
+++ b/src/commands/zrevrank.json
@@ -47,11 +47,11 @@
                 },
                 {
                     "type": "integer",
-                    "description": "The rank of the member when 'WITHSCORES' is not used."
+                    "description": "The rank of the member when 'WITHSCORE' is not used."
                 },
                 {
                     "type": "array",
-                    "description": "The rank and score of the member when 'WITHSCORES' is used.",
+                    "description": "The rank and score of the member when 'WITHSCORE' is used.",
                     "minItems": 2,
                     "maxItems": 2,
                     "items": [

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -450,7 +450,7 @@ start_server {tags {"zset"}} {
             assert_equal $nullres [r zrevrank zranktmp foo]
             r readraw 0
 
-            # withscores
+            # withscore
             set nullres {*-1}
             if {$::force_resp3} {
                 set nullres {_}


### PR DESCRIPTION
The parameter name is WITHSCORE instead of WITHSCORES.