### PR TITLE
Print strerror when bio initialization fails

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -142,7 +142,7 @@ void bioInit(void) {
     for (j = 0; j < BIO_WORKER_NUM; j++) {
         void *arg = (void*)(unsigned long) j;
         if (pthread_create(&thread,&attr,bioProcessBackgroundJobs,arg) != 0) {
-            serverLog(LL_WARNING,"Fatal: Can't initialize Background Jobs.");
+            serverLog(LL_WARNING, "Fatal: Can't initialize Background Jobs. Error message: %s", strerror(errno));
             exit(1);
         }
         bio_threads[j] = thread;


### PR DESCRIPTION
Now we can see something like this:
```
Fatal: Can't initialize Background Jobs. Error message: Cannot allocate memory
```