### PR TITLE
Fix cluster inconsistent slots mappings after slot migrating and failover occur simultaneously

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2907,7 +2907,7 @@ int clusterProcessPacket(clusterLink *link) {
          * updated separately. So is the sender's slots.
          * 
          * Otherwise, the slot will be guarded by a new config epoch of 
-         * the previous master. This config epoch maybe has been increased 
+         * the previous master. This config epoch maybe has been bumped 
          * after this slot was assigned to new master. 
          * 
          * The new master will fail to claim the slot because 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2908,7 +2908,7 @@ int clusterProcessPacket(clusterLink *link) {
          * 
          * Otherwise, the slot will be guarded by a new config epoch of 
          * the previous master. This config epoch maybe has been increased 
-         * after this slot was assigned to another master. 
+         * after this slot was assigned to new master. 
          * 
          * The new master will fail to claim the slot because 
          * senderConfigEpoch is smaller than server.cluster->slots[j]->configEpoch. 


### PR DESCRIPTION
### Background
`Node A(Master)` update `clusterState` based on `clusterMsg` from another `Node B(Master)`. This is a chance to cause slot mapping conflict between `Node A` and `Node B`, When:

- `Node C(Master)` was migrated(SETSLOT) `Slot S` from `Node B`
- `Node B` received updating from `Node C`. It's configEpoch collision with another node `Node D(Master)`. `Node B`'s node id is smaller, so `Node B` bumps to new configEpoch, which is maximum in the cluster.
- `Node A` received PONG from `Node B`. POV of `Node A`: **new configEpoch of `Node B` is updated but `Slot S` is not updated because it didn't belong to `Node A` anymore**
- `Node C(Master)`, which was assigned this slot, POV of `Node A` failed to assign it to `Node C` because its config epoch(senderConfigEpoch) is smaller than `server.cluster->slots[j]->configEpoch`.

As shown in the figure:

![image](https://github.com/cyningsun/redis-test/assets/5696973/9e8037c4-0761-4623-938b-d96a94cd6f98)

### How to fix it

Skip updating the sender's configEpoch and Slots before the migrated slot is claimed in POV. 

configEpoch acts as the guard of slots it owns in POV. If there is a migrated slot of the sender in POV pending claim by a new master, the sender's config epoch in POV cannot be updated separately. 

Otherwise, the slot will be guarded by a new config epoch of the previous master. This config epoch maybe has been bumped after this slot was assigned to another master. 

The new master will fail to claim the slot because `senderConfigEpoch` is smaller than `server.cluster->slots[j]->configEpoch`. 

### Example
Here is a cluster that has 5 shards, and each shard has 2 replicas, shown below before slot migrating. 
master nodeid | master node | config epoch | current epoch | slot 0 owner (configEpoch) | slot 16383 owner (configEpoch) | slave nodeid | slave node
-- |-- | -- | -- | -- | -- | -- | --
6ea4c2f8e7efe9180db83cf0adf1b055a557c74d | 10.53.52.144:6379 | 5 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | 626af417d334896000f5e23e6305f29242945948 | 10.53.52.144:6373
d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59 | 10.53.52.144:6378 | 2 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | 95e75b159b3bcb7c33a8df9db93b5443413dfccb | 10.53.52.144:6377
0c92e0b02f839260b508a6fdf258539a26e96903 | 10.53.52.144:6376 | 8 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | 900e489fcf28e0648272fc6c8b61f0bd998a01a0 | 10.53.52.144:6371
f567e9d0fb1ccbdfbfc6a5c505e1d84d224de0ef | 10.53.52.144:6374 | 3 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | f65353c097d7f7e0f44644a28ddb980c21fc37bf | 10.53.52.144:6380
c013fefabf931b77a5488e4e0fe1e81db1eaf4aa | 10.53.52.144:6375 | 1 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | 2ddaf93f230facc9893bc95bf9234a3d580d0291 | 10.53.52.144:6372

#### Operations
- Step 1: Slot 0 is migrated from `6ea4c2f8e7efe9180db83cf0adf1b055a557c74d 10.53.52.144:6379` to `d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59 10.53.52.144:6378`
- Step 2: Manual failover is sent to `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372`
- Step 3: Slot 16383 is migrated from `c013fefabf931b77a5488e4e0fe1e81db1eaf4aa 10.53.52.144:6375` to  `0c92e0b02f839260b508a6fdf258539a26e96903 10.53.52.144:6376`

Let's focus on how `Slot 16383` is conflicted in the cluster

#### Timeline

**1. failover election for `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372`**

failover_auth_epoch = 9

**2. After Slot 0 is SETSLOT to `d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59 10.53.52.144:6378`**

master nodeid | master node | config epoch | current epoch | slot 0 owner (configEpoch)  | slot 16383 owner (configEpoch)  | slave nodeid | slave node
-- |-- | -- | -- | -- | -- | -- | --
6ea4c2f8e7efe9180db83cf0adf1b055a557c74d | 10.53.52.144:6379 | 5 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | 626af417d334896000f5e23e6305f29242945948 | 10.53.52.144:6373
**d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59** | **10.53.52.144:6378** | **9** | **9** | **10.53.52.144:6378 (9)** | 10.53.52.144:6375 (1) | 95e75b159b3bcb7c33a8df9db93b5443413dfccb | 10.53.52.144:6377
0c92e0b02f839260b508a6fdf258539a26e96903 | 10.53.52.144:6376 | 8 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | 900e489fcf28e0648272fc6c8b61f0bd998a01a0 | 10.53.52.144:6371
f567e9d0fb1ccbdfbfc6a5c505e1d84d224de0ef | 10.53.52.144:6374 | 3 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | f65353c097d7f7e0f44644a28ddb980c21fc37bf | 10.53.52.144:6380
c013fefabf931b77a5488e4e0fe1e81db1eaf4aa | 10.53.52.144:6375 | 1 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | 2ddaf93f230facc9893bc95bf9234a3d580d0291 | 10.53.52.144:6372

**3. After slot 16383 is SETSLOT to `0c92e0b02f839260b508a6fdf258539a26e96903 10.53.52.144:6376`**

After `0c92e0b02f839260b508a6fdf258539a26e96903 10.53.52.144:6376` receiving `PONG` send by `d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59 10.53.52.144:6378`, configEpoch,currentEpoch is 9+1

master nodeid | master node | config epoch | current epoch | slot 0 owner (configEpoch)  | slot 16383 owner (configEpoch)  | slave nodeid | slave node
-- |-- | -- | -- | -- | -- | -- | --
6ea4c2f8e7efe9180db83cf0adf1b055a557c74d | 10.53.52.144:6379 | 5 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | 626af417d334896000f5e23e6305f29242945948 | 10.53.52.144:6373
d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59 | 10.53.52.144:6378 | 9 | 9 | 10.53.52.144:6378 (9) | 10.53.52.144:6375 (1) | 95e75b159b3bcb7c33a8df9db93b5443413dfccb | 10.53.52.144:6377
**0c92e0b02f839260b508a6fdf258539a26e96903** | **10.53.52.144:6376** | **10** | **10** | **10.53.52.144:6378 (9)** | **10.53.52.144:6376 (10)** | 900e489fcf28e0648272fc6c8b61f0bd998a01a0 | 10.53.52.144:6371
f567e9d0fb1ccbdfbfc6a5c505e1d84d224de0ef | 10.53.52.144:6374 | 3 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | f65353c097d7f7e0f44644a28ddb980c21fc37bf | 10.53.52.144:6380
c013fefabf931b77a5488e4e0fe1e81db1eaf4aa | 10.53.52.144:6375 | 1 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | 2ddaf93f230facc9893bc95bf9234a3d580d0291 | 10.53.52.144:6372


**4. After Failover is authed to `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372`**

master nodeid | master node | config epoch | current epoch | slot 0 owner (configEpoch)  | slot 16383 owner (configEpoch)  | slave nodeid | slave node
-- |-- | -- | -- | -- | -- | -- | --
6ea4c2f8e7efe9180db83cf0adf1b055a557c74d | 10.53.52.144:6379 | 5 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | 626af417d334896000f5e23e6305f29242945948 | 10.53.52.144:6373
d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59 | 10.53.52.144:6378 | 9 | 9 | 10.53.52.144:6378 (9) | 10.53.52.144:6375 (1) | 95e75b159b3bcb7c33a8df9db93b5443413dfccb | 10.53.52.144:6377
0c92e0b02f839260b508a6fdf258539a26e96903 | 10.53.52.144:6376 | 10 | 10 | 10.53.52.144:6378 (9) | 10.53.52.144:6376 (10) | 900e489fcf28e0648272fc6c8b61f0bd998a01a0 | 10.53.52.144:6371
f567e9d0fb1ccbdfbfc6a5c505e1d84d224de0ef | 10.53.52.144:6374 | 3 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6375 (1) | f65353c097d7f7e0f44644a28ddb980c21fc37bf | 10.53.52.144:6380
**2ddaf93f230facc9893bc95bf9234a3d580d0291** | **10.53.52.144:6372**  | **9** | **9** | 10.53.52.144:6379 (5) | **10.53.52.144:6372 (9)** | **c013fefabf931b77a5488e4e0fe1e81db1eaf4aa** | **10.53.52.144:6375**


**5. After other nodes receive `PONG` send by `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372`**

master nodeid | master node | config epoch | current epoch | slot 0 owner (configEpoch)  | slot 16383 owner (configEpoch)  | slave nodeid | slave node
-- |-- | -- | -- | -- | -- | -- | --
6ea4c2f8e7efe9180db83cf0adf1b055a557c74d | 10.53.52.144:6379 | 5 | **9** | 10.53.52.144:6379 (5) | **10.53.52.144:6372 (9)** | 626af417d334896000f5e23e6305f29242945948 | 10.53.52.144:6373
d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59 | 10.53.52.144:6378 | 9 | 9 | 10.53.52.144:6378 (9) | **10.53.52.144:6372 (9)** | 95e75b159b3bcb7c33a8df9db93b5443413dfccb | 10.53.52.144:6377
0c92e0b02f839260b508a6fdf258539a26e96903 | 10.53.52.144:6376 | 10 | 10 | 10.53.52.144:6378 (9) | 10.53.52.144:6376 (10) | 900e489fcf28e0648272fc6c8b61f0bd998a01a0 | 10.53.52.144:6371
f567e9d0fb1ccbdfbfc6a5c505e1d84d224de0ef | 10.53.52.144:6374 | 3 | **9** | 10.53.52.144:6379 (5) | **10.53.52.144:6372 (9)** | f65353c097d7f7e0f44644a28ddb980c21fc37bf | 10.53.52.144:6380
2ddaf93f230facc9893bc95bf9234a3d580d0291 | 10.53.52.144:6372  | 9 | 9 | 10.53.52.144:6379 (5) | 10.53.52.144:6372 (9) | c013fefabf931b77a5488e4e0fe1e81db1eaf4aa | 10.53.52.144:6375


**6. After `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372` receiving `PONG` send by `0c92e0b02f839260b508a6fdf258539a26e96903 10.53.52.144:6376`**

master nodeid | master node | config epoch | current epoch | slot 0 owner (configEpoch)  | slot 16383 owner (configEpoch)  | slave nodeid | slave node
-- |-- | -- | -- | -- | -- | -- | --
6ea4c2f8e7efe9180db83cf0adf1b055a557c74d | 10.53.52.144:6379 | 5 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6372 (9) | 626af417d334896000f5e23e6305f29242945948 | 10.53.52.144:6373
d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59 | 10.53.52.144:6378 | 9 | 9 | 10.53.52.144:6378 (9) | 10.53.52.144:6372 (9) | 95e75b159b3bcb7c33a8df9db93b5443413dfccb | 10.53.52.144:6377
0c92e0b02f839260b508a6fdf258539a26e96903 | 10.53.52.144:6376 | 10 | 10 | 10.53.52.144:6378 (9) | 10.53.52.144:6376 (10) | 900e489fcf28e0648272fc6c8b61f0bd998a01a0 | 10.53.52.144:6371
f567e9d0fb1ccbdfbfc6a5c505e1d84d224de0ef | 10.53.52.144:6374 | 3 | 8 | 10.53.52.144:6379 (5) | 10.53.52.144:6372 (9) | f65353c097d7f7e0f44644a28ddb980c21fc37bf | 10.53.52.144:6380
2ddaf93f230facc9893bc95bf9234a3d580d0291 | 10.53.52.144:6372  | 9 | **10** | **10.53.52.144:6378 (9)** | **10.53.52.144:6376 (10)** | c013fefabf931b77a5488e4e0fe1e81db1eaf4aa | 10.53.52.144:6375

**7. `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372` resolve configEpoch Collision and send `PONG` msg**

- configEpoch Collision between `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372` and `d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59 10.53.52.144:6378`
- `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372` has smaller Node ID

_slot 0 and 16383 ownership on other nodes will not be affected because `myslots` in `clusterMsg` header of `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372` don't have those two slots._

master nodeid | master node | config epoch | current epoch | slot 0 owner (configEpoch)  | slot 16383 owner (configEpoch)  | slave nodeid | slave node
-- |-- | -- | -- | -- | -- | -- | --
6ea4c2f8e7efe9180db83cf0adf1b055a557c74d | 10.53.52.144:6379 | 5 | 11 | 10.53.52.144:6379 (5) | 10.53.52.144:6372 (**11**) | 626af417d334896000f5e23e6305f29242945948 | 10.53.52.144:6373
d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59 | 10.53.52.144:6378 | 9 | 11 | 10.53.52.144:6378 (9) | 10.53.52.144:6372 (**11**) | 95e75b159b3bcb7c33a8df9db93b5443413dfccb | 10.53.52.144:6377
0c92e0b02f839260b508a6fdf258539a26e96903 | 10.53.52.144:6376 | 10 | 11 | 10.53.52.144:6378 (9) | 10.53.52.144:6376 (10) | 900e489fcf28e0648272fc6c8b61f0bd998a01a0 | 10.53.52.144:6371
f567e9d0fb1ccbdfbfc6a5c505e1d84d224de0ef | 10.53.52.144:6374 | 3 | 11 | 10.53.52.144:6379 (5) | 10.53.52.144:6372 (**11**) | f65353c097d7f7e0f44644a28ddb980c21fc37bf | 10.53.52.144:6380
2ddaf93f230facc9893bc95bf9234a3d580d0291 | 10.53.52.144:6372  | **11** | **11** | 10.53.52.144:6378 (9) | 10.53.52.144:6376 (10) | c013fefabf931b77a5488e4e0fe1e81db1eaf4aa | 10.53.52.144:6375


**8. `0c92e0b02f839260b508a6fdf258539a26e96903  10.53.52.144:6376` is reset by `CLUSTERMSG_TYPE_UPDATE` message**

- `0c92e0b02f839260b508a6fdf258539a26e96903  10.53.52.144:6376`: _slot 16383 ownership is reset because `0c92e0b02f839260b508a6fdf258539a26e96903  10.53.52.144:6376` [node's configEpoch(`senderConfigEpoch`) 10 which is smaller than `server.cluster->slots[j]->configEpoch` 11](https://github.com/redis/redis/blob/unstable/src/cluster.c#L2942), then other nodes will find it has an old configurations and send `CLUSTERMSG_TYPE_UPDATE` message to `0c92e0b02f839260b508a6fdf258539a26e96903  10.53.52.144:6376` ask it to reset the ownership to `6372`, and finally succeed because slot 16383 is guarded by configEpoch 10 is smaller than senderConfigEpoch\(11, [`it is not actually the "Sender" of the information`](https://github.com/redis/redis/blob/unstable/src/cluster.c#L2213), so it's 11 according by slot\)_

- `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372`: _slot 16383 ownership is not reset because_ 

     1. `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372` [not claimed slot 16383](https://github.com/redis/redis/blob/unstable/src/cluster.c#L2939)
     2. `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372` node's [configEpoch(`senderConfigEpoch`) 11 which is equal to `server.cluster->slots[j]->configEpoch` 11](https://github.com/redis/redis/blob/unstable/src/cluster.c#L2942)
     
     _so there is no `CLUSTERMSG_TYPE_UPDATE` message. And also, There is no Sender claim slot 16383 whose configEpoch is greater than 10, so there is no `clusterUpdateSlotsConfigWith` through `CLUSTERMSG_TYPE_PING/PONG`... messages_

master nodeid | master node | config epoch | current epoch | slot 0 owner (configEpoch)   | slot 16383 owner (configEpoch)  | slave nodeid | slave node
-- |-- | -- | -- | -- | -- | -- | --
6ea4c2f8e7efe9180db83cf0adf1b055a557c74d | 10.53.52.144:6379 | 5 | 11 | 10.53.52.144:6379 (5) | 10.53.52.144:6372 (11) | 626af417d334896000f5e23e6305f29242945948 | 10.53.52.144:6373
d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59 | 10.53.52.144:6378 | 9 | 11 | 10.53.52.144:6378 (9) | 10.53.52.144:6372 (11) | 95e75b159b3bcb7c33a8df9db93b5443413dfccb | 10.53.52.144:6377
0c92e0b02f839260b508a6fdf258539a26e96903 | 10.53.52.144:6376 | 10 | 11 | 10.53.52.144:6378 (9) | **10.53.52.144:6372 (11)** | 900e489fcf28e0648272fc6c8b61f0bd998a01a0 | 10.53.52.144:6371
f567e9d0fb1ccbdfbfc6a5c505e1d84d224de0ef | 10.53.52.144:6374 | 3 | 11 | 10.53.52.144:6379 (5) | 10.53.52.144:6372 (11) | f65353c097d7f7e0f44644a28ddb980c21fc37bf | 10.53.52.144:6380
2ddaf93f230facc9893bc95bf9234a3d580d0291 | 10.53.52.144:6372  | 11 | 11 | 10.53.52.144:6378 (9) | 10.53.52.144:6376 (10) | c013fefabf931b77a5488e4e0fe1e81db1eaf4aa | 10.53.52.144:6375


**9. Slot 0 finished Gossip among cluster**

master nodeid | master node | config epoch | current epoch | slot 0 owner (configEpoch)  | slot 16383 owner (configEpoch)  | slave nodeid | slave node
-- |-- | -- | -- | -- | -- | -- | --
6ea4c2f8e7efe9180db83cf0adf1b055a557c74d | 10.53.52.144:6379 | 5 | 11 | 10.53.52.144:6378 (9) | 10.53.52.144:6372 (11) | 626af417d334896000f5e23e6305f29242945948 | 10.53.52.144:6373
d69ae698cb4ec7af73e8c15eb64d6f8b6cde4f59 | 10.53.52.144:6378 | 9 | 11 | 10.53.52.144:6378 (9) | 10.53.52.144:6372 (11) | 95e75b159b3bcb7c33a8df9db93b5443413dfccb | 10.53.52.144:6377
0c92e0b02f839260b508a6fdf258539a26e96903 | 10.53.52.144:6376 | 10 | 11 | 10.53.52.144:6378 (9) | 10.53.52.144:6372 (11) | 900e489fcf28e0648272fc6c8b61f0bd998a01a0 | 10.53.52.144:6371
f567e9d0fb1ccbdfbfc6a5c505e1d84d224de0ef | 10.53.52.144:6374 | 3 | 11 | 10.53.52.144:6378 (9) | 10.53.52.144:6372  (11)| f65353c097d7f7e0f44644a28ddb980c21fc37bf | 10.53.52.144:6380
2ddaf93f230facc9893bc95bf9234a3d580d0291 | 10.53.52.144:6372  | 11 | 11 | 10.53.52.144:6378 (9) | 10.53.52.144:6376 (10) | c013fefabf931b77a5488e4e0fe1e81db1eaf4aa | 10.53.52.144:6375

#### Result
The cluster has **inconsistent slots mapping about slot 16383, between `2ddaf93f230facc9893bc95bf9234a3d580d0291 10.53.52.144:6372` and other nodes**