### PR TITLE
Modules: Unblock from within a timer coverage

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1667,11 +1667,6 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
      * sets of metrics. */
     monotime cron_start_time_before_aof = getMonotonicUs();
 
-    if (moduleCount())
-        moduleFireServerEvent(REDISMODULE_EVENT_EVENTLOOP,
-                              REDISMODULE_SUBEVENT_EVENTLOOP_BEFORE_SLEEP,
-                              NULL);
-
     /* Call the Redis Cluster before sleep function. Note that this function
      * may change the state of Redis Cluster (from ok to fail or vice versa),
      * so it's a good idea to call it before serving the unblocked clients
@@ -1682,6 +1677,12 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
      * ASAP if a fast cycle is not needed). */
     if (server.active_expire_enabled && iAmMaster())
         activeExpireCycle(ACTIVE_EXPIRE_CYCLE_FAST);
+
+    if (moduleCount()) {
+        moduleFireServerEvent(REDISMODULE_EVENT_EVENTLOOP,
+                              REDISMODULE_SUBEVENT_EVENTLOOP_BEFORE_SLEEP,
+                              NULL);
+    }
 
     /* Send all the slaves an ACK request if at least one client blocked
      * during the previous event loop iteration. Note that we do this after

--- a/src/server.h
+++ b/src/server.h
@@ -3383,7 +3383,7 @@ void signalDeletedKeyAsReady(redisDb *db, robj *key, int type);
 void updateStatsOnUnblock(client *c, long blocked_us, long reply_us, int had_errors);
 void scanDatabaseForDeletedKeys(redisDb *emptied, redisDb *replaced_with);
 void totalNumberOfBlockingKeys(unsigned long *blocking_keys, unsigned long *bloking_keys_on_nokey);
-
+void blockedBeforeSleep(void);
 
 /* timeout.c -- Blocked clients timeout and connections timeout. */
 void addClientToTimeoutTable(client *c);

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -276,6 +276,10 @@ foreach call_type {nested normal} {
             assert_equal [$replica hget bk1 foo] bar
         }
     }
+
+    test {Unblock by timer} {
+        assert_match "OK" [r unblock_by_timer 100]
+    }
     
     test "Unload the module - blockedclient" {
         assert_equal {OK} [r module unload blockedclient]

--- a/tests/unit/moduleapi/blockonkeys.tcl
+++ b/tests/unit/moduleapi/blockonkeys.tcl
@@ -34,6 +34,21 @@ start_server {tags {"modules"}} {
         assert_equal {42} [r fsl.getall src]
     }
 
+    test "Module client blocked on keys: BPOPPUSH unblocked by timer" {
+        set rd1 [redis_deferring_client]
+
+        r del src dst
+
+        $rd1 fsl.bpoppush src dst 0
+        wait_for_blocked_clients_count 1
+
+        r fsl.pushtimer9000 src 10
+        wait_for_blocked_clients_count 0
+
+        assert_equal {9000} [r fsl.getall dst]
+        assert_equal {} [r fsl.getall src]
+    }
+
     test {Module client blocked on keys (no metadata): No block} {
         r del k
         r fsl.push k 33

--- a/tests/unit/moduleapi/blockonkeys.tcl
+++ b/tests/unit/moduleapi/blockonkeys.tcl
@@ -39,15 +39,25 @@ start_server {tags {"modules"}} {
 
         r del src dst
 
+        set repl [attach_to_replication_stream]
+
         $rd1 fsl.bpoppush src dst 0
         wait_for_blocked_clients_count 1
 
-        r fsl.pushtimer9000 src 10
+        r fsl.pushtimer src 9000 10
         wait_for_blocked_clients_count 0
 
         assert_equal {9000} [r fsl.getall dst]
         assert_equal {} [r fsl.getall src]
-    }
+
+        assert_replication_stream $repl {
+            {select *}
+            {fsl.push src 9000}
+            {fsl.bpoppush src dst 0}
+        }
+
+        close_replication_stream $repl
+    } {} {needs:repl}
 
     test {Module client blocked on keys (no metadata): No block} {
         r del k


### PR DESCRIPTION
Apart from adding the missing coverage, this PR also adds `blockedBeforeSleep` that gathers all block-related functions from `beforeSleep`

The order inside `blockedBeforeSleep` is different: now `handleClientsBlockedOnKeys` (which may unblock clients) is called before `processUnblockedClients` (which handles unblocked clients).
It makes sense to have this order.

There are no visible effects of the wrong ordering, except some cleanups of the now-unblocked client would have  happen in the next `beforeSleep` (will now happen in the current one)

The reason we even got into it is because i triggers an assertion in logresreq.c (breaking the assumption that `unblockClient` is called **before** actually flushing the reply to the socket):
`handleClientsBlockedOnKeys` is called, then it calls `moduleUnblockClientOnKey`, which calls `moduleUnblockClient`, which adds the client to `moduleUnblockedClients`
back to `beforeSleep`, we call `handleClientsWithPendingWritesUsingThreads`, it writes the data of buf to the client, so `client->bufpos` became 0
On the next `beforeSleep`, we call `moduleHandleBlockedClients`, which calls `unblockClient`, which calls `reqresAppendResponse`, triggering the assert. (because the `bufpos` is 0) - see https://github.com/redis/redis/pull/12301#discussion_r1226386716