### PR TITLE
Adding of O3 on linking stage for OPTIMIZATION=-O3 cases

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,7 +23,7 @@ ifeq ($(OPTIMIZATION),-O3)
 	else
 		REDIS_CFLAGS+=-flto=auto
 	endif
-	REDIS_LDFLAGS+=-flto
+	REDIS_LDFLAGS+=-O3 -flto
 endif
 DEPENDENCY_TARGETS=hiredis linenoise lua hdr_histogram fpconv
 NODEPS:=clean distclean


### PR DESCRIPTION
Added missing O3 flag to linking stage in default option "-O3 -flto". 
Flags doesn't lead to significant changes in performance:
- +0.21% in geomean for all benchmarks on ICX bare-metal (256 cpus)
- +0.33% in geomean for all benchmarks on m6i.2xlarge (16 cpus) 
Checked on redis from Mar'30 (commit 1f76bb17ddcb2adc484bf82f1b839c45e264524f ). Comparison file is attached. 

[O3_summary.xlsx](https://github.com/redis/redis/files/11850362/O3_summary.xlsx)
