### PR TITLE
Process loss of slot ownership in cluster bus

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2293,10 +2293,10 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
             }
         } else if (server.cluster->slots[j] == sender) {
             /* The slot is currently bound to the sender but the sender is no longer claiming it.
-            We don't want to unbind the slot yet as it can cause cluster to move to FAIL state and also throw client error.
-            Keeping the slot bound to the previous owner will cause a few client side redirects, but won't throw any errors.
-            We will keep track of the uncertainty in ownership to avoid propagating misinformation about this
-            slot's ownership using UPDATE messages. */
+             * We don't want to unbind the slot yet as it can cause cluster to move to FAIL state and also throw client error.
+             * Keeping the slot bound to the previous owner will cause a few client side redirects, but won't throw any errors.
+             * We will keep track of the uncertainty in ownership to avoid propagating misinformation about this
+             * slot's ownership using UPDATE messages. */
             bitmapSetBit(server.cluster->owner_not_owning_slot, j);
         }
     }

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -214,6 +214,12 @@ typedef struct clusterState {
     long long stats_pfail_nodes;    /* Number of nodes in PFAIL status,
                                        excluding nodes without address. */
     unsigned long long stat_cluster_links_buffer_limit_exceeded;  /* Total number of cluster links freed due to exceeding buffer limit */
+
+    /* Bit map for slots that are no longer claimed by the owner in cluster PING messages.
+    During slot migration, the owner will stop claiming the slot after the ownership transfer.
+    Set the bit corresponding to the slot when a node stops claiming the slot. This prevents
+    spreading incorrect information (that source still owns the slot) using UPDATE messages. */
+    unsigned char owner_not_owning_slot[CLUSTER_SLOTS/8];
 } clusterState;
 
 /* Redis cluster messages header */

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -216,9 +216,9 @@ typedef struct clusterState {
     unsigned long long stat_cluster_links_buffer_limit_exceeded;  /* Total number of cluster links freed due to exceeding buffer limit */
 
     /* Bit map for slots that are no longer claimed by the owner in cluster PING messages.
-    During slot migration, the owner will stop claiming the slot after the ownership transfer.
-    Set the bit corresponding to the slot when a node stops claiming the slot. This prevents
-    spreading incorrect information (that source still owns the slot) using UPDATE messages. */
+     * During slot migration, the owner will stop claiming the slot after the ownership transfer.
+     * Set the bit corresponding to the slot when a node stops claiming the slot. This prevents
+     * spreading incorrect information (that source still owns the slot) using UPDATE messages. */
     unsigned char owner_not_owning_slot[CLUSTER_SLOTS/8];
 } clusterState;
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -215,11 +215,12 @@ typedef struct clusterState {
                                        excluding nodes without address. */
     unsigned long long stat_cluster_links_buffer_limit_exceeded;  /* Total number of cluster links freed due to exceeding buffer limit */
 
-    /* Bit map for slots that are no longer claimed by the owner in cluster PING messages.
-     * During slot migration, the owner will stop claiming the slot after the ownership transfer.
-     * Set the bit corresponding to the slot when a node stops claiming the slot. This prevents
-     * spreading incorrect information (that source still owns the slot) using UPDATE messages. */
-    unsigned char owner_not_owning_slot[CLUSTER_SLOTS/8];
+    /* Bit map for slots that are no longer claimed by the owner in cluster PING
+     * messages. During slot migration, the owner will stop claiming the slot after
+     * the ownership transfer. Set the bit corresponding to the slot when a node
+     * stops claiming the slot. This prevents spreading incorrect information (that
+     * source still owns the slot) using UPDATE messages. */
+    unsigned char owner_not_claiming_slot[CLUSTER_SLOTS / 8];
 } clusterState;
 
 /* Redis cluster messages header */


### PR DESCRIPTION
When a node no longer owns a slot, it clears the bit corresponding to the slot in the cluster bus messages. The receiving nodes currently don't record the fact that the sender stopped claiming a slot until some other node in the cluster starts claiming the slot. This can cause a slot to go missing during slot migration when subjected to inopportune race with addition of new shards or a failover. This fix forces the receiving nodes to process the loss of ownership to avoid spreading wrong information.

This is a follow up PR from https://github.com/redis/redis/pull/12336#issuecomment-1604582374

```
Release notes
Fix a race condition where a slot migration might get reverted when another failover happened or a node was added to the cluster.
```