### PR TITLE
use pthread_cond_wait instead of for loop

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -4159,6 +4159,8 @@ int io_threads_op;      /* IO_THREADS_OP_IDLE, IO_THREADS_OP_READ or IO_THREADS_
  * used. We spawn io_threads_num-1 threads, since one is the main thread
  * itself. */
 list *io_threads_list[IO_THREADS_MAX_NUM];
+pthread_mutex_t io_threads_cond_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t io_threads_cond_var = PTHREAD_COND_INITIALIZER;
 
 static inline unsigned long getIOPendingCount(int i) {
     unsigned long count = 0;
@@ -4183,8 +4185,12 @@ void *IOThreadMain(void *myid) {
 
     while(1) {
         /* Wait for start */
-        for (int j = 0; j < 1000000; j++) {
-            if (getIOPendingCount(id) != 0) break;
+        if (getIOPendingCount(id) == 0) {
+            pthread_mutex_lock(&io_threads_cond_mutex);
+            if (getIOPendingCount(id) == 0) {
+                pthread_cond_wait(&io_threads_cond_var, &io_threads_cond_mutex);
+            }
+            pthread_mutex_unlock(&io_threads_cond_mutex);
         }
 
         /* Give the main thread a chance to stop this thread. */
@@ -4365,6 +4371,9 @@ int handleClientsWithPendingWritesUsingThreads(void) {
         int count = listLength(io_threads_list[j]);
         setIOPendingCount(j, count);
     }
+    pthread_mutex_lock(&io_threads_cond_mutex);
+    pthread_cond_broadcast(&io_threads_cond_var);
+    pthread_mutex_unlock(&io_threads_cond_mutex);
 
     /* Also use the main thread to process a slice of clients. */
     listRewind(io_threads_list[0],&li);
@@ -4464,6 +4473,9 @@ int handleClientsWithPendingReadsUsingThreads(void) {
         int count = listLength(io_threads_list[j]);
         setIOPendingCount(j, count);
     }
+    pthread_mutex_lock(&io_threads_cond_mutex);
+    pthread_cond_broadcast(&io_threads_cond_var);
+    pthread_mutex_unlock(&io_threads_cond_mutex);
 
     /* Also use the main thread to process a slice of clients. */
     listRewind(io_threads_list[0],&li);


### PR DESCRIPTION
i test find io-thread use lots of cpu because of for loop to getIOPendingCount. I just want to reduce cpu use, so use pthread_cond_wait instead of for loop.

i viewed issue [7441](https://github.com/redis/redis/pull/7441) and issue 7239 https://github.com/redis/redis/issues/7239,  io-thread may change a lot to improve. now I just want to reduce cpu use in my environment