### PR TITLE
The history described by json is inconsistent with the website

### DIFF
--- a/src/commands/monitor.json
+++ b/src/commands/monitor.json
@@ -5,7 +5,20 @@
         "since": "1.0.0",
         "arity": 1,
         "function": "monitorCommand",
-        "history": [],
+        "history": [
+          [
+            "6.0.0",
+            "`AUTH` excluded from the command's output."
+          ],
+          [
+            "6.2.0",
+            "`RESET` can be called to exit monitor mode."
+          ],
+          [
+            "6.2.4",
+            "`AUTH`, `HELLO`, `EVAL`, `EVAL_RO`, `EVALSHA` and `EVALSHA_RO` included in the command's output."
+          ]
+        ],
         "command_flags": [
             "ADMIN",
             "NOSCRIPT",

--- a/src/commands/psubscribe.json
+++ b/src/commands/psubscribe.json
@@ -6,6 +6,12 @@
         "since": "2.0.0",
         "arity": -2,
         "function": "psubscribeCommand",
+        "history": [
+          [
+            "6.2.0",
+            "`RESET` can be called to exit subscribed state."
+          ]
+        ],
         "command_flags": [
             "PUBSUB",
             "NOSCRIPT",

--- a/src/commands/subscribe.json
+++ b/src/commands/subscribe.json
@@ -6,7 +6,12 @@
         "since": "2.0.0",
         "arity": -2,
         "function": "subscribeCommand",
-        "history": [],
+        "history": [
+          [
+            "6.2.0",
+            "`RESET` can be called to exit subscribed state."
+          ]
+        ],
         "command_flags": [
             "PUBSUB",
             "NOSCRIPT",


### PR DESCRIPTION
The command `SUBSCRIBE` and `PSUBSCIRBE` described on the official website are inconsistent with those in the JSON file

website says:
Behavior change history
- SUBSCRIBE
	\>= 6.2.0: RESET can be called to exit subscribed state.
- PSUBSCRIBE
	\>= 6.2.0: RESET can be called to exit subscribed state.