### PR TITLE
Revert zrangeGenericCommand negative offset check

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3630,7 +3630,7 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
     long opt_end = 0;
     int opt_withscores = 0;
     long opt_offset = 0;
-    long opt_limit = -1; /* A negative limit returns all elements from the offset. */
+    long opt_limit = -1;
 
     /* Step 1: Skip the <src> <min> <max> args and parse remaining optional arguments. */
     for (int j=argc_start + 3; j < c->argc; j++) {
@@ -3638,12 +3638,11 @@ void zrangeGenericCommand(zrange_result_handler *handler, int argc_start, int st
         if (!store && !strcasecmp(c->argv[j]->ptr,"withscores")) {
             opt_withscores = 1;
         } else if (!strcasecmp(c->argv[j]->ptr,"limit") && leftargs >= 2) {
-            if (getRangeLongFromObjectOrReply(c, c->argv[j+1], 0, LONG_MAX,
-                                              &opt_offset, "offset should be greater than or equal to 0") != C_OK)
+            if ((getLongFromObjectOrReply(c, c->argv[j+1], &opt_offset, NULL) != C_OK) ||
+                (getLongFromObjectOrReply(c, c->argv[j+2], &opt_limit, NULL) != C_OK))
+            {
                 return;
-
-            if (getLongFromObjectOrReply(c, c->argv[j+2], &opt_limit, NULL) != C_OK)
-                return;
+            }
             j += 2;
         } else if (direction == ZRANGE_DIRECTION_AUTO &&
                    !strcasecmp(c->argv[j]->ptr,"rev"))

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -370,28 +370,6 @@ start_server {tags {"zset"}} {
             r zrem ztmp a b c d e f g
         } {3}
 
-        test "ZRANGE* with wrong offset or limit should throw error" {
-            r del src{t} dst{t}
-
-            foreach offset {-1 -100 str NaN} {
-                assert_error "ERR*offset*" {r ZRANGE src{t} 0 -1 byscore limit $offset 1}
-                assert_error "ERR*offset*" {r ZRANGESTORE dst{t} src{t} 0 -1 byscore limit $offset 4}
-                assert_error "ERR*offset*" {r ZRANGEBYLEX src{t} (az (b limit $offset 5}
-                assert_error "ERR*offset*" {r ZRANGEBYSCORE src{t} 0 -1 limit $offset 2}
-                assert_error "ERR*offset*" {r ZREVRANGEBYLEX src{t} (az (b limit $offset 6}
-                assert_error "ERR*offset*" {r ZREVRANGEBYSCORE src{t} -1 0 limit $offset 3}
-            }
-
-            foreach limit {str NaN} {
-                assert_error "ERR value*" {r ZRANGE src{t} 0 -1 byscore limit 0 $limit}
-                assert_error "ERR value*" {r ZRANGESTORE dst{t} src{t} 0 -1 byscore limit 0 $limit}
-                assert_error "ERR value*" {r ZRANGEBYLEX src{t} (az (b limit 0 $limit}
-                assert_error "ERR value*" {r ZRANGEBYSCORE src{t} 0 -1 limit 0 $limit}
-                assert_error "ERR value*" {r ZREVRANGEBYLEX src{t} (az (b limit 0 $limit}
-                assert_error "ERR value*" {r ZREVRANGEBYSCORE src{t} -1 0 limit 0 $limit}
-            }
-        }
-
         test "ZRANGE basics - $encoding" {
             r del ztmp
             r zadd ztmp 1 a


### PR DESCRIPTION
The negative offset check was added in #9052, we realized
that this is a non-mandatory breaking change and we would
like to add it only in 8.0.

This reverts PR #9052, will be re-introduced later in 8.0.