### PR TITLE
skip the rehashed entries in dictNext

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -951,7 +951,7 @@ dictEntry *dictNext(dictIterator *iter)
                 else
                     iter->fingerprint = dictFingerprint(iter->d);
 
-                // skip the rehashed entries in table[0]
+                /* skip the rehashed slots in table[0] */
                 if (dictIsRehashing(iter->d)) {
                     iter->index = iter->d->rehashidx - 1;
                 }

--- a/src/dict.c
+++ b/src/dict.c
@@ -950,6 +950,11 @@ dictEntry *dictNext(dictIterator *iter)
                     dictPauseRehashing(iter->d);
                 else
                     iter->fingerprint = dictFingerprint(iter->d);
+
+                // skip the rehashed entries in table[0]
+                if (dictIsRehashing(iter->d)) {
+                    iter->index = iter->d->rehashidx - 1;
+                }
             }
             iter->index++;
             if (iter->index >= (long) DICTHT_SIZE(iter->d->ht_size_exp[iter->table])) {


### PR DESCRIPTION
If dict is rehashing, the  entries in the head of table[0] is moved to table[1] and all entries in `table[0][0:rehashidx]` is NULL.

`dictNext` start looking for non-NULL entry from table 0 index 0, and the first call of `dictNext` on a rehashing dict will Iterate many times to skip those NULL entries.  We can easily skip those entries by setting `iter->index` as `iter->d->rehashidx` when dict is rehashing and it's the first call of dictNext (`iter->index == -1 && iter->table == 0`).

