### PR TITLE
Test coverage for objectComputeSize api's set, zset and stream code part.

### DIFF
--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -23,8 +23,7 @@ start_server {
         assert_encoding $type myset
 
         # coverage for objectComputeSize
-        assert_range [r memory usage myset] 50 12000 ;# sum of the size of each element in $initelems
-                                                      # for listpack 59 and hashtable 6081
+        assert_range [r memory usage myset] 50 7000 ;# can't be lower than one byte per item, or higher than 50 bytes overhead beyond the sum of the actual strings.
         assert_equal 1 [r sadd myset bar]
         assert_equal 0 [r sadd myset bar]
         assert_equal [expr [llength $initelems($type)] + 1] [r scard myset]
@@ -45,8 +44,7 @@ start_server {
         assert_encoding intset myset
 
         # coverage for objectComputeSize
-        assert_range [r memory usage myset] 50 100 ;# sum of the size of element for myset:57
-
+        assert_range [r memory usage myset] 50 100 ;# can't be lower than one byte per item, or higher than 50 bytes of overhead of sum of all the items.
         assert_equal 1 [r sadd myset 16]
         assert_equal 0 [r sadd myset 16]
         assert_equal 2 [r scard myset]

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -25,7 +25,7 @@ start_server {
        }
        create_set myset $memelems($type)
        assert_encoding $type myset
-       assert_range [r memory usage myset] 130 7000 ;# can't be lower than one byte per item, or higher than 50 bytes overhead beyond the sum of the actual strings.
+       assert_range [r memory usage myset] 130 7000 ;# Generlly, can't be lower than one byte per item, or higher than 50 bytes overhead beyond the sum of the actual strings.
     }
 
     test "SADD, SCARD, SISMEMBER, SMISMEMBER, SMEMBERS basics - $type" {
@@ -51,7 +51,7 @@ start_server {
         assert_encoding intset myset
 
         # coverage for objectComputeSize
-        assert_range [r memory usage myset] 50 100 ;# can't be lower than one byte per item, or higher than 50 bytes of overhead of sum of all the items.
+        assert_range [r memory usage myset] 1 60 ;# Generally, can't be lower than one byte per item, or higher than sum of all the items memory.
         assert_equal 1 [r sadd myset 16]
         assert_equal 0 [r sadd myset 16]
         assert_equal 2 [r scard myset]

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -23,12 +23,8 @@ start_server {
         assert_encoding $type myset
 
         # coverage for objectComputeSize
-        if {$type == "listpack"} {
-            assert_morethan [r memory usage myset] 58
-        } elseif {$type == "hashtable"} {
-            assert_morethan [r memory usage myset] 6080
-        }
-
+        assert_range [r memory usage myset] 50 12000 ;# sum of the size of each element in $initelems
+                                                      # for listpack 59 and hashtable 6081
         assert_equal 1 [r sadd myset bar]
         assert_equal 0 [r sadd myset bar]
         assert_equal [expr [llength $initelems($type)] + 1] [r scard myset]
@@ -49,7 +45,7 @@ start_server {
         assert_encoding intset myset
 
         # coverage for objectComputeSize
-        assert_morethan [r memory usage myset] 56
+        assert_range [r memory usage myset] 50 100 ;# sum of the size of element for myset:57
 
         assert_equal 1 [r sadd myset 16]
         assert_equal 0 [r sadd myset 16]

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -51,7 +51,7 @@ start_server {
         assert_encoding intset myset
 
         # coverage for objectComputeSize
-        assert_range [r memory usage myset] 1 60 ;# Generally, can't be lower than one byte per item, or higher than sum of all the items memory.
+        assert_range [r memory usage myset] 1 80 ;# Generally, can't be lower than one byte per item, or higher than sum of all the items memory.
         assert_equal 1 [r sadd myset 16]
         assert_equal 0 [r sadd myset 16]
         assert_equal 2 [r scard myset]

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -21,6 +21,10 @@ start_server {
     test "SADD, SCARD, SISMEMBER, SMISMEMBER, SMEMBERS basics - $type" {
         create_set myset $initelems($type)
         assert_encoding $type myset
+
+        # coverage for objectComputeSize
+        assert_morethan [memory_usage myset] 0
+
         assert_equal 1 [r sadd myset bar]
         assert_equal 0 [r sadd myset bar]
         assert_equal [expr [llength $initelems($type)] + 1] [r scard myset]

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -23,7 +23,11 @@ start_server {
         assert_encoding $type myset
 
         # coverage for objectComputeSize
-        assert_morethan [memory_usage myset] 0
+        if {$type == "listpack"} {
+            assert_morethan [r memory usage myset] 58
+        } elseif {$type == "hashtable"} {
+            assert_morethan [r memory usage myset] 6080
+        }
 
         assert_equal 1 [r sadd myset bar]
         assert_equal 0 [r sadd myset bar]
@@ -43,6 +47,10 @@ start_server {
     test {SADD, SCARD, SISMEMBER, SMISMEMBER, SMEMBERS basics - intset} {
         create_set myset {17}
         assert_encoding intset myset
+
+        # coverage for objectComputeSize
+        assert_morethan [r memory usage myset] 56
+
         assert_equal 1 [r sadd myset 16]
         assert_equal 0 [r sadd myset 16]
         assert_equal 2 [r scard myset]

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -63,7 +63,7 @@ start_server {
         r XADD mystream * item 2 value b
 
         # coverage for objectComputeSize
-        assert_morethan [memory_usage mystream] 0
+        assert_morethan [r memory usage mystream] 4729
 
         assert_equal 2 [r XLEN mystream]
         set items [r XRANGE mystream - +]

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -63,7 +63,7 @@ start_server {
         r XADD mystream * item 2 value b
 
         # coverage for objectComputeSize
-        assert_range [r memory usage mystream] 4720 9400 ;# mystream size: 4730
+        assert_range [r memory usage mystream] 4700 5000 ;# Range cant be lower than 20bytes lower than actual stream and higher than 50 bytes; mystream size here is 4730
 
         assert_equal 2 [r XLEN mystream]
         set items [r XRANGE mystream - +]

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -242,7 +242,7 @@ start_server {
     test {STREAM & GROUP against memory usage} {
         r DEL mystream
         insert_into_stream_key mystream
-        assert_range [r memory usage mystream] 165000 200000 ;# mystream memory varies between 167000 to 194000 for 10000 item so added overhead around actual values. it varies as insert_into_stream_key uses the rand to generate items.
+        assert_range [r memory usage mystream] 165000 210000 ;# mystream memory varies between 167000 to 194000 for 10000 item so added overhead around actual values. it varies as insert_into_stream_key uses the rand to generate items.
         r DEL mystream_group
         r XGROUP CREATE mystream_group mygroup $ MKSTREAM
         r XADD mystream_group * a 1

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -63,7 +63,7 @@ start_server {
         r XADD mystream * item 2 value b
 
         # coverage for objectComputeSize
-        assert_morethan [r memory usage mystream] 4729
+        assert_range [r memory usage mystream] 4720 9400 ;# mystream size: 4730
 
         assert_equal 2 [r XLEN mystream]
         set items [r XRANGE mystream - +]

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -61,6 +61,10 @@ start_server {
     test {XADD can add entries into a stream that XRANGE can fetch} {
         r XADD mystream * item 1 value a
         r XADD mystream * item 2 value b
+
+        # coverage for objectComputeSize
+        assert_morethan [memory_usage mystream] 0
+
         assert_equal 2 [r XLEN mystream]
         set items [r XRANGE mystream - +]
         assert_equal [lindex $items 0 1] {item 1 value a}

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -63,7 +63,7 @@ start_server {
         r XADD mystream * item 2 value b
 
         # coverage for objectComputeSize
-        assert_range [r memory usage mystream] 4700 5000 ;# Range cant be lower than 20bytes lower than actual stream and higher than 50 bytes; mystream size here is 4730
+        assert_range [r memory usage mystream] 4700 5000 ;# Range can't be lower than 20bytes lower than actual stream and higher than 50 bytes; mystream size here is 4730
 
         assert_equal 2 [r XLEN mystream]
         set items [r XRANGE mystream - +]

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -123,6 +123,9 @@ start_server {tags {"zset"}} {
             r zadd ztmp 30 z
             assert_equal {x y z} [r zrange ztmp 0 -1]
 
+            # coverage for objectComputeSize
+            assert_morethan [memory_usage ztmp] 0
+
             r zadd ztmp 1 y
             assert_equal {y x z} [r zrange ztmp 0 -1]
         }

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -124,11 +124,7 @@ start_server {tags {"zset"}} {
             assert_equal {x y z} [r zrange ztmp 0 -1]
 
             # coverage for objectComputeSize
-            if {$encoding == "listpack"} {
-                assert_morethan [r memory usage ztmp] 67
-            } elseif {$encoding == "skiplist"} {
-                assert_morethan [r memory usage ztmp] 918
-            }
+            assert_range [r memory usage ztmp] 60 2000 ;#ztmp size for listpack:68; skiplist:919
 
             r zadd ztmp 1 y
             assert_equal {y x z} [r zrange ztmp 0 -1]

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -124,7 +124,11 @@ start_server {tags {"zset"}} {
             assert_equal {x y z} [r zrange ztmp 0 -1]
 
             # coverage for objectComputeSize
-            assert_morethan [memory_usage ztmp] 0
+            if {$encoding == "listpack"} {
+                assert_morethan [r memory usage ztmp] 67
+            } elseif {$encoding == "skiplist"} {
+                assert_morethan [r memory usage ztmp] 918
+            }
 
             r zadd ztmp 1 y
             assert_equal {y x z} [r zrange ztmp 0 -1]

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -124,8 +124,7 @@ start_server {tags {"zset"}} {
             assert_equal {x y z} [r zrange ztmp 0 -1]
 
             # coverage for objectComputeSize
-            assert_range [r memory usage ztmp] 60 1200 ;# can't be lower than one byte per item, or higher than 50 bytes overhead.
-
+            assert_range [r memory usage ztmp] 60 1200 ;# Generally, value can't be lower than one byte per item, or higher than 50 bytes overhead, However values are dependant on type of encoding.
             r zadd ztmp 1 y
             assert_equal {y x z} [r zrange ztmp 0 -1]
         }

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -124,7 +124,7 @@ start_server {tags {"zset"}} {
             assert_equal {x y z} [r zrange ztmp 0 -1]
 
             # coverage for objectComputeSize
-            assert_range [r memory usage ztmp] 60 2000 ;#ztmp size for listpack:68; skiplist:919
+            assert_range [r memory usage ztmp] 60 1000 ;# can't be lower than one byte per item, or higher than 50 bytes overhead.
 
             r zadd ztmp 1 y
             assert_equal {y x z} [r zrange ztmp 0 -1]

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -124,7 +124,7 @@ start_server {tags {"zset"}} {
             assert_equal {x y z} [r zrange ztmp 0 -1]
 
             # coverage for objectComputeSize
-            assert_range [r memory usage ztmp] 60 1200 ;# Generally, value can't be lower than one byte per item, or higher than 50 bytes overhead, However values are dependant on type of encoding.
+            assert_range [r memory usage ztmp] 60 1200 ;# Generally, value can't be lower than one byte per item, or higher than 50 bytes overhead, However values are dependent on type of encoding.
             r zadd ztmp 1 y
             assert_equal {y x z} [r zrange ztmp 0 -1]
         }

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -124,7 +124,7 @@ start_server {tags {"zset"}} {
             assert_equal {x y z} [r zrange ztmp 0 -1]
 
             # coverage for objectComputeSize
-            assert_range [r memory usage ztmp] 60 1000 ;# can't be lower than one byte per item, or higher than 50 bytes overhead.
+            assert_range [r memory usage ztmp] 60 1200 ;# can't be lower than one byte per item, or higher than 50 bytes overhead.
 
             r zadd ztmp 1 y
             assert_equal {y x z} [r zrange ztmp 0 -1]


### PR DESCRIPTION
We have test coverage for List and Hash memory usage(objectComputeSize) code part, But there was coverage missing for below code. So added the test cases for missing.

```
1002 size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
1003     sds ele, ele2;
=================
034     } else if (o->type == OBJ_SET) {
1035         if (o->encoding == OBJ_ENCODING_HT) {
1036             d = o->ptr;
1037             di = dictGetIterator(d);
1038             asize = sizeof(*o)+sizeof(dict)+(sizeof(struct dictEntry*)*dictSlots(d));
1039             while((de = dictNext(di)) != NULL && samples < sample_size) {
1040                 ele = dictGetKey(de);
1041                 elesize += dictEntryMemUsage() + sdsZmallocSize(ele);
1042                 samples++;
1043             }
1044             dictReleaseIterator(di);
1045             if (samples) asize += (double)elesize/samples*dictSize(d);
1046         } else if (o->encoding == OBJ_ENCODING_INTSET) {
1047             asize = sizeof(*o)+zmalloc_size(o->ptr);
1048         } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
1049             asize = sizeof(*o)+zmalloc_size(o->ptr);
1050         } else {
1051             serverPanic("Unknown set encoding");
1052         }
1053     } else if (o->type == OBJ_ZSET) {
1054         if (o->encoding == OBJ_ENCODING_LISTPACK) {
1055             asize = sizeof(*o)+zmalloc_size(o->ptr);
1056         } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
1057             d = ((zset*)o->ptr)->dict;
1058             zskiplist *zsl = ((zset*)o->ptr)->zsl;
1059             zskiplistNode *znode = zsl->header->level[0].forward;
1060             asize = sizeof(*o)+sizeof(zset)+sizeof(zsk

```
