### PR TITLE
Inconsistent memory size for bitfields, when bitfields are set in different order.

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -1010,7 +1010,7 @@ size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
         if(o->encoding == OBJ_ENCODING_INT) {
             asize = sizeof(*o);
         } else if(o->encoding == OBJ_ENCODING_RAW) {
-            asize = sdsZmallocSize(o->ptr)+sizeof(*o);
+            asize = stringObjectLen(o)+sizeof(*o);
         } else if(o->encoding == OBJ_ENCODING_EMBSTR) {
             asize = zmalloc_size((void *)o);
         } else {

--- a/tests/unit/bitfield.tcl
+++ b/tests/unit/bitfield.tcl
@@ -42,6 +42,17 @@ start_server {tags {"bitops"}} {
         r get bits
     } {ABC}
 
+    test {BITFIELD against memory size for set bit in different order} {
+        r del bits
+        r bitfield bits set u32 #0 1
+        r bitfield bits set u32 #22 1
+        set res [r memory usage bits]
+        r del bits
+        r bitfield bits set u32 #22 1
+        r bitfield bits set u32 #0 1
+        assert_equal $res [r memory usage bits]
+    }
+
     test {BITFIELD basic INCRBY form} {
         r del bits
         set results {}


### PR DESCRIPTION
This is reference of : https://github.com/redis/redis/issues/6309

We could see different size of memory when bitfiled are set in different order as stated in https://github.com/redis/redis/issues/6309, This happened due to objectComputeSize is retrieving the size by calling malloc_usable_size API. As we know malloc_usable_size returns the more bytes compared to requested because it is depends on the alignment. Bitfield falled in string and RAW encoding type looks equal to string length of the key and object size. Thought it would be more consistent for the client if we use stringObjectLen instead of sdsZmallocSize (sdsZmallocSize -> zmalloc_size -> malloc_usable_size or malloc_size).

Before changing the api:

```
127.0.0.1:6379> DEL abc
(integer) 1
127.0.0.1:6379>
127.0.0.1:6379> bitfield abc set u32 #0 1
1) (integer) 0
127.0.0.1:6379> bitfield abc set u32 #22 1
1) (integer) 0
127.0.0.1:6379>
127.0.0.1:6379> MEMORY USAGE abc
(integer) 233
127.0.0.1:6379> del abc
(integer) 1
127.0.0.1:6379> bitfield abc set u32 #22 1
1) (integer) 0
127.0.0.1:6379>
127.0.0.1:6379> bitfield abc set u32 #0 1
1) (integer) 0
127.0.0.1:6379>
127.0.0.1:6379> MEMORY USAGE abc
(integer) 141

```
Result after api is changed:

```
127.0.0.1:6379> del abc
(integer) 1
127.0.0.1:6379>
127.0.0.1:6379> bitfield abc set u32 #0 1
1) (integer) 0
127.0.0.1:6379>
127.0.0.1:6379> bitfield abc set u32 #22 1
1) (integer) 0
127.0.0.1:6379>
127.0.0.1:6379> memory usage abc
(integer) 137
127.0.0.1:6379>
127.0.0.1:6379> del abc
(integer) 1
127.0.0.1:6379>
127.0.0.1:6379>  bitfield abc set u32 #22 1
1) (integer) 0
127.0.0.1:6379> bitfield abc set u32 #0 1
1) (integer) 0
127.0.0.1:6379>
127.0.0.1:6379> memory usage abc
(integer) 137
127.0.0.1:6379>

```