### PR TITLE
Hiredis 1.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,8 +133,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install openssl redis@6.2
-          brew link redis@6.2 --force
+          brew install openssl redis@7.0
+          brew link redis@7.0 --force
 
       - name: Build hiredis
         run: USE_SSL=1 make

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
     - name: Install qemu
       if: matrix.emulator
-      run: sudo apt-get install -y qemu-user
+      run: sudo apt-get update && sudo apt-get install -y qemu-user
     - name: Install platform toolset
       if: matrix.toolset
       run: sudo apt-get install -y gcc-${{matrix.toolset}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,63 @@
+## [1.2.0](https://github.com/redis/hiredis/tree/v1.2.0) - (2023-06-04)
+
+Announcing Hiredis v1.2.0 with with new adapters, and a great many bug fixes.
+
+## 🚀 New Features
+
+- Add sdevent adapter @Oipo (#1144)
+- Allow specifying the keepalive interval @michael-grunder (#1168)
+- Add RedisModule adapter @tezc (#1182)
+- Helper for setting TCP_USER_TIMEOUT socket option @zuiderkwast (#1188)
+
+## 🐛 Bug Fixes
+
+- Fix a typo in b6a052f. @yossigo (#1190)
+- Fix wincrypt symbols conflict @hudayou (#1151)
+- Don't attempt to set a timeout if we are in an error state. @michael-grunder (#1180)
+- Accept -nan per the RESP3 spec recommendation. @michael-grunder (#1178)
+- Fix colliding option values @zuiderkwast (#1172)
+- Ensure functionality without `_MSC_VER` definition @windyakin (#1194)
+
+## 🧰 Maintenance
+
+- Add a test for the TCP_USER_TIMEOUT option. @michael-grunder (#1192)
+- Add -Werror as a default. @yossigo (#1193)
+- CI: Update homebrew Redis version. @yossigo (#1191)
+- Fix typo in makefile. @michael-grunder (#1179)
+- Write a version file for the CMake package @Neverlord (#1165)
+- CMakeLists.txt: respect BUILD_SHARED_LIBS @ffontaine (#1147)
+- Cmake static or shared @autoantwort (#1160)
+- fix typo @tillkruss (#1153)
+- Add a test ensuring we don't clobber connection error. @michael-grunder (#1181)
+- Search for openssl on macOS @michael-grunder (#1169)
+
+
+## Contributors
+We'd like to thank all the contributors who worked on this release!
+
+<a href="https://github.com/neverlord"><img src="https://github.com/neverlord.png" width="32" height="32"></a>
+<a href="https://github.com/Oipo"><img src="https://github.com/Oipo.png" width="32" height="32"></a>
+<a href="https://github.com/autoantwort"><img src="https://github.com/autoantwort.png" width="32" height="32"></a>
+<a href="https://github.com/ffontaine"><img src="https://github.com/ffontaine.png" width="32" height="32"></a>
+<a href="https://github.com/hudayou"><img src="https://github.com/hudayou.png" width="32" height="32"></a>
+<a href="https://github.com/michael-grunder"><img src="https://github.com/michael-grunder.png" width="32" height="32"></a>
+<a href="https://github.com/postgraph"><img src="https://github.com/postgraph.png" width="32" height="32"></a>
+<a href="https://github.com/tezc"><img src="https://github.com/tezc.png" width="32" height="32"></a>
+<a href="https://github.com/tillkruss"><img src="https://github.com/tillkruss.png" width="32" height="32"></a>
+<a href="https://github.com/vityafx"><img src="https://github.com/vityafx.png" width="32" height="32"></a>
+<a href="https://github.com/windyakin"><img src="https://github.com/windyakin.png" width="32" height="32"></a>
+<a href="https://github.com/yossigo"><img src="https://github.com/yossigo.png" width="32" height="32"></a>
+<a href="https://github.com/zuiderkwast"><img src="https://github.com/zuiderkwast.png" width="32" height="32"></a>
+
 ## [1.1.0](https://github.com/redis/hiredis/tree/v1.1.0) - (2022-11-15)
 
 Announcing Hiredis v1.1.0 GA with better SSL convenience, new async adapters and a great many bug fixes.
 
-**NOTE**:  Hiredis can now return `nan` in addition to `-inf` and `inf` when returning a `REDIS_REPLY_DOUBLE`. 
+**NOTE**:  Hiredis can now return `nan` in addition to `-inf` and `inf` when returning a `REDIS_REPLY_DOUBLE`.
 
 ## 🐛 Bug Fixes
 
-- Add support for nan in RESP3 double [@filipecosta90](https://github.com/filipecosta90) 
+- Add support for nan in RESP3 double [@filipecosta90](https://github.com/filipecosta90)
   ([\#1133](https://github.com/redis/hiredis/pull/1133))
 
 ## 🧰 Maintenance
@@ -14,7 +65,7 @@ Announcing Hiredis v1.1.0 GA with better SSL convenience, new async adapters and
 - Add an example that calls redisCommandArgv [@michael-grunder](https://github.com/michael-grunder)
   ([\#1140](https://github.com/redis/hiredis/pull/1140))
 - fix flag reference [@pata00](https://github.com/pata00) ([\#1136](https://github.com/redis/hiredis/pull/1136))
-- Make freeing a NULL redisAsyncContext a no op. [@michael-grunder](https://github.com/michael-grunder) 
+- Make freeing a NULL redisAsyncContext a no op. [@michael-grunder](https://github.com/michael-grunder)
   ([\#1135](https://github.com/redis/hiredis/pull/1135))
 - CI updates ([@bjosv](https://github.com/redis/bjosv) ([\#1139](https://github.com/redis/hiredis/pull/1139))
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ export REDIS_TEST_CONFIG
 CC:=$(shell sh -c 'type $${CC%% *} >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
 CXX:=$(shell sh -c 'type $${CXX%% *} >/dev/null 2>/dev/null && echo $(CXX) || echo g++')
 OPTIMIZATION?=-O3
-WARNINGS=-Wall -W -Wstrict-prototypes -Wwrite-strings -Wno-missing-field-initializers
+WARNINGS=-Wall -Wextra -Werror -Wstrict-prototypes -Wwrite-strings -Wno-missing-field-initializers
 DEBUG_FLAGS?= -g -ggdb
 REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CPPFLAGS) $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS) $(PLATFORM_FLAGS)
 REAL_LDFLAGS=$(LDFLAGS)
@@ -311,7 +311,7 @@ install: $(DYLIBNAME) $(STLIBNAME) $(PKGCONFNAME) $(SSL_INSTALL)
 	$(INSTALL) hiredis.h async.h read.h sds.h alloc.h sockcompat.h $(INSTALL_INCLUDE_PATH)
 	$(INSTALL) adapters/*.h $(INSTALL_INCLUDE_PATH)/adapters
 	$(INSTALL) $(DYLIBNAME) $(INSTALL_LIBRARY_PATH)/$(DYLIB_MINOR_NAME)
-	cd $(INSTALL_LIBRARY_PATH) && ln -sf $(DYLIB_MINOR_NAME) $(DYLIBNAME)
+	cd $(INSTALL_LIBRARY_PATH) && ln -sf $(DYLIB_MINOR_NAME) $(DYLIBNAME) && ln -sf $(DYLIB_MINOR_NAME) $(DYLIB_MAJOR_NAME)
 	$(INSTALL) $(STLIBNAME) $(INSTALL_LIBRARY_PATH)
 	mkdir -p $(INSTALL_PKGCONF_PATH)
 	$(INSTALL) $(PKGCONFNAME) $(INSTALL_PKGCONF_PATH)
@@ -320,7 +320,7 @@ install-ssl: $(SSL_DYLIBNAME) $(SSL_STLIBNAME) $(SSL_PKGCONFNAME)
 	mkdir -p $(INSTALL_INCLUDE_PATH) $(INSTALL_LIBRARY_PATH)
 	$(INSTALL) hiredis_ssl.h $(INSTALL_INCLUDE_PATH)
 	$(INSTALL) $(SSL_DYLIBNAME) $(INSTALL_LIBRARY_PATH)/$(SSL_DYLIB_MINOR_NAME)
-	cd $(INSTALL_LIBRARY_PATH) && ln -sf $(SSL_DYLIB_MINOR_NAME) $(SSL_DYLIBNAME)
+	cd $(INSTALL_LIBRARY_PATH) && ln -sf $(SSL_DYLIB_MINOR_NAME) $(SSL_DYLIBNAME) && ln -sf $(SSL_DYLIB_MINOR_NAME) $(SSL_DYLIB_MAJOR_NAME)
 	$(INSTALL) $(SSL_STLIBNAME) $(INSTALL_LIBRARY_PATH)
 	mkdir -p $(INSTALL_PKGCONF_PATH)
 	$(INSTALL) $(SSL_PKGCONFNAME) $(INSTALL_PKGCONF_PATH)

--- a/deps/README.md
+++ b/deps/README.md
@@ -63,6 +63,10 @@ Hiredis
 
 Hiredis is used by Sentinel, `redis-cli` and `redis-benchmark`. Like Redis, uses the SDS string library, but not necessarily the same version. In order to avoid conflicts, this version has all SDS identifiers prefixed by `hi`.
 
+1. `git subtree pull --prefix deps/hiredis https://github.com/redis/hiredis.git <version-tag> --squash`<br>
+This should hopefully merge the local changes into the new version.
+2. Conflicts will arise (due to our changes) you'll need to resolve them and commit.
+
 Linenoise
 ---
 

--- a/hiredis.c
+++ b/hiredis.c
@@ -392,12 +392,12 @@ int redisvFormatCommand(char **target, const char *format, va_list ap) {
                     while (*_p != '\0' && strchr(flags,*_p) != NULL) _p++;
 
                     /* Field width */
-                    while (*_p != '\0' && isdigit(*_p)) _p++;
+                    while (*_p != '\0' && isdigit((int) *_p)) _p++;
 
                     /* Precision */
                     if (*_p == '.') {
                         _p++;
-                        while (*_p != '\0' && isdigit(*_p)) _p++;
+                        while (*_p != '\0' && isdigit((int) *_p)) _p++;
                     }
 
                     /* Copy va_list before consuming with va_arg */

--- a/hiredis.h
+++ b/hiredis.h
@@ -46,9 +46,9 @@ typedef long long ssize_t;
 #include "alloc.h" /* for allocation wrappers */
 
 #define HIREDIS_MAJOR 1
-#define HIREDIS_MINOR 1
-#define HIREDIS_PATCH 1
-#define HIREDIS_SONAME 1.1.1-dev
+#define HIREDIS_MINOR 2
+#define HIREDIS_PATCH 0
+#define HIREDIS_SONAME 1.1.0
 
 /* Connection type can be blocking or non-blocking and is set in the
  * least significant bit of the flags field in redisContext. */

--- a/net.c
+++ b/net.c
@@ -234,9 +234,10 @@ int redisContextSetTcpUserTimeout(redisContext *c, unsigned int timeout) {
     res = setsockopt(c->fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &timeout, sizeof(timeout));
 #else
     res = -1;
+    errno = ENOTSUP;
     (void)timeout;
 #endif
-    if (res == -1); {
+    if (res == -1) {
         __redisSetErrorFromErrno(c,REDIS_ERR_IO,"setsockopt(TCP_USER_TIMEOUT)");
         redisNetClose(c);
         return REDIS_ERR;

--- a/sds.c
+++ b/sds.c
@@ -886,7 +886,7 @@ sds sdscatrepr(sds s, const char *p, size_t len) {
         case '\a': s = sdscatlen(s,"\\a",2); break;
         case '\b': s = sdscatlen(s,"\\b",2); break;
         default:
-            if (isprint(*p))
+            if (isprint((int) *p))
                 s = sdscatprintf(s,"%c",*p);
             else
                 s = sdscatprintf(s,"\\x%02x",(unsigned char)*p);
@@ -948,7 +948,7 @@ sds *sdssplitargs(const char *line, int *argc) {
     *argc = 0;
     while(1) {
         /* skip blanks */
-        while(*p && isspace(*p)) p++;
+        while(*p && isspace((int) *p)) p++;
         if (*p) {
             /* get a token */
             int inq=0;  /* set to 1 if we are in "quotes" */
@@ -959,8 +959,8 @@ sds *sdssplitargs(const char *line, int *argc) {
             while(!done) {
                 if (inq) {
                     if (*p == '\\' && *(p+1) == 'x' &&
-                                             isxdigit(*(p+2)) &&
-                                             isxdigit(*(p+3)))
+                                             isxdigit((int) *(p+2)) &&
+                                             isxdigit((int) *(p+3)))
                     {
                         unsigned char byte;
 
@@ -984,7 +984,7 @@ sds *sdssplitargs(const char *line, int *argc) {
                     } else if (*p == '"') {
                         /* closing quote must be followed by a space or
                          * nothing at all. */
-                        if (*(p+1) && !isspace(*(p+1))) goto err;
+                        if (*(p+1) && !isspace((int) *(p+1))) goto err;
                         done=1;
                     } else if (!*p) {
                         /* unterminated quotes */
@@ -999,7 +999,7 @@ sds *sdssplitargs(const char *line, int *argc) {
                     } else if (*p == '\'') {
                         /* closing quote must be followed by a space or
                          * nothing at all. */
-                        if (*(p+1) && !isspace(*(p+1))) goto err;
+                        if (*(p+1) && !isspace((int) *(p+1))) goto err;
                         done=1;
                     } else if (!*p) {
                         /* unterminated quotes */


### PR DESCRIPTION
supersedes #12406

This updates hiredis to the 1.2.0 release. Included are README updates on how to do so for future users, given the confusion.

To do:
- [x] remember to merge without squash / rebase