### PR TITLE
Hide unnecessary comma in front of empty hostname in the return of CLUSTER NODES.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5230,12 +5230,12 @@ sds clusterGenNodeDescription(client *c, clusterNode *node, int tls_primary) {
     if (sdslen(node->hostname) != 0) {
         ci = sdscatfmt(ci,",%s", node->hostname);
     }
-    if (sdslen(node->hostname) == 0) {
-        ci = sdscatfmt(ci,",", 1);
-    }
     /* Don't expose aux fields to any clients yet but do allow them
      * to be persisted to nodes.conf */
     if (c == NULL) {
+        if (sdslen(node->hostname) == 0) {
+            ci = sdscatfmt(ci,",", 1);
+        }
         for (int i = af_count-1; i >=0; i--) {
             if ((tls_primary && i == af_tls_port) || (!tls_primary && i == af_tcp_port)) {
                 continue;


### PR DESCRIPTION
According to the format shown in https://redis.io/commands/cluster-nodes/
```
<ip:port@cport[,hostname[,auxiliary_field=value]*]>
```
when there is no hostname, and the auxiliary fields are hidden, the cluster topology should be
```
<ip:port@cport>
```
However in the code we always print the hostname even when it is an empty string, leaving an unnecessary comma tailing after cport, which is weird and conflicts with the doc.
```
94ca2f6cf85228a49fde7b738ee1209de7bee325 127.0.0.1:6379@16379, myself,master - 0 0 0 connected 0-16383
```

```
Release notes:
The response of cluster nodes was unnecessarily adding an extra comma when no hostname was present. This impacts all RC candidates of 7.2.
```