### PR TITLE
Ensure RM_Call authenticated based on client

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -6239,6 +6239,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
         c->resp = ctx->client->resp;
     }
     if (ctx->module) ctx->module->in_call++;
+    c->authenticated = ctx->client->authenticated;
 
     user *user = NULL;
     if (flags & REDISMODULE_ARGV_RUN_AS_USER) {


### PR DESCRIPTION
I noticed strange behavior when calling specifically the `HELLO` command from within a module using `RedisModule_Call`. Regardless of authentication, the first `HELLO` command called by `RedisModule_Call` after the Redis Server starts up will always succeed, and regardless of authentication, all subsequent `HELLO` commands called by `RedisModule_Call` will fail for that given Redis Server process.

There is more information and recreation steps [in this repository](https://github.com/nirrattner/RedisModuleHelloExample/tree/main).

I believe the fix is for the `RM_Call` client to inherit the `authenticated` value from the module context client `authenticated` value, although I would appreciate scrutiny here because I'm not very familiar with this code.