### PR TITLE
Replaced comment with excessive warning.

### DIFF
--- a/src/commands.h
+++ b/src/commands.h
@@ -19,7 +19,7 @@ typedef enum {
 #define CMD_ARG_MULTIPLE        (1<<1)
 #define CMD_ARG_MULTIPLE_TOKEN  (1<<2)
 
-/* WARNING! This struct must match RedisModuleCommandArg */
+/* Must be compatible with RedisModuleCommandArg. See moduleCopyCommandArgs. */
 typedef struct redisCommandArg {
     const char *name;
     redisCommandArgType type;


### PR DESCRIPTION
The data structures in the comment are not in sync and don't need to be. Referring to function that handles conversion.

Closes issue #12378 