### PR TITLE
Signal handler attributes

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2528,9 +2528,9 @@ static int updateAofAutoGCEnabled(const char **err) {
 static int updateSighandlerEnabled(const char **err) {
     UNUSED(err);
     if (server.crashlog_enabled)
-        setupSignalHandlers();
+        setupSigSegvHandler();
     else
-        removeSignalHandlers();
+        removeSigSegvHandlers();
     return 1;
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -2184,8 +2184,7 @@ static void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     bugReportEnd(1, sig);
 }
 
-void setupSignalHandlers(void) {
-
+void setupSigSegvHandler(void) {
     /* Initialize the signal handler lock. 
     Attempting to initialize an already initialized mutex or mutexattr results in undefined behavior. */
     if (!signal_handler_lock_initialized) {
@@ -2210,7 +2209,6 @@ void setupSignalHandlers(void) {
         sigaction(SIGILL, &act, NULL);
         sigaction(SIGABRT, &act, NULL);
     }
-
 }
 
 void printCrashReport(void) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -2119,7 +2119,7 @@ void invalidFunctionWasCalled(void) {}
 
 typedef void (*invalidFunctionWasCalledType)(void);
 
-void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
+static void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     UNUSED(secret);
     UNUSED(info);
     /* Check if it is safe to enter the signal handler. second thread crashing at the same time will deadlock. */
@@ -2184,17 +2184,33 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     bugReportEnd(1, sig);
 }
 
-int isDebugReady(void) {
-    return signal_handler_lock_initialized;
-}
+void setupSignalHandlers(void) {
 
-void initDebug(void) {
-    /* Set signal handler with error checking attribute. re-lock within the same thread will error. */
-    pthread_mutexattr_init(&signal_handler_lock_attr);
-    pthread_mutexattr_settype(&signal_handler_lock_attr, PTHREAD_MUTEX_ERRORCHECK);
-    pthread_mutex_init(&signal_handler_lock, &signal_handler_lock_attr);
+    /* Initialize the signal handler lock. 
+    Attempting to initialize an already initialized mutex or mutexattr results in undefined behavior. */
+    if (!signal_handler_lock_initialized) {
+        /* Set signal handler with error checking attribute. re-lock within the same thread will error. */
+        pthread_mutexattr_init(&signal_handler_lock_attr);
+        pthread_mutexattr_settype(&signal_handler_lock_attr, PTHREAD_MUTEX_ERRORCHECK);
+        pthread_mutex_init(&signal_handler_lock, &signal_handler_lock_attr);
+        signal_handler_lock_initialized = 1;
+    }
 
-    signal_handler_lock_initialized = 1;
+    struct sigaction act;
+
+    sigemptyset(&act.sa_mask);
+    /* Set SA_NODEFER to disable adding the signal to the signal mask of the
+     * calling process on entry to the signal handler unless it is included in the sa_mask field. */
+    act.sa_flags = SA_NODEFER | SA_SIGINFO;
+    act.sa_sigaction = sigsegvHandler;
+    if(server.crashlog_enabled) {
+        sigaction(SIGSEGV, &act, NULL);
+        sigaction(SIGBUS, &act, NULL);
+        sigaction(SIGFPE, &act, NULL);
+        sigaction(SIGILL, &act, NULL);
+        sigaction(SIGABRT, &act, NULL);
+    }
+
 }
 
 void printCrashReport(void) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -66,10 +66,9 @@ typedef ucontext_t sigcontext_t;
 /* Globals */
 static int bug_report_start = 0; /* True if bug report header was already logged. */
 static pthread_mutex_t bug_report_start_mutex = PTHREAD_MUTEX_INITIALIZER;
-/* Mutex for a case when two threads crash at the same time.
- * Set signal handler with error checking attribute. re-lock within the same thread will error. */
-static pthread_mutex_t signal_handler_lock = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
-
+/* Mutex for a case when two threads crash at the same time. */
+static pthread_mutex_t signal_handler_lock;
+static pthread_mutexattr_t signal_handler_lock_attr;
 /* Forward declarations */
 void bugReportStart(void);
 void printCrashReport(void);
@@ -2119,7 +2118,7 @@ void invalidFunctionWasCalled(void) {}
 
 typedef void (*invalidFunctionWasCalledType)(void);
 
-void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
+static void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     UNUSED(secret);
     UNUSED(info);
     /* Check if it is safe to enter the signal handler. second thread crashing at the same time will deadlock. */
@@ -2182,6 +2181,28 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
 #endif
 
     bugReportEnd(1, sig);
+}
+
+void setupSigSegvHandler(void) {
+    /* Set signal handler with error checking attribute. re-lock within the same thread will error. */
+    pthread_mutexattr_init(&signal_handler_lock_attr);
+    pthread_mutexattr_settype(&signal_handler_lock_attr, PTHREAD_MUTEX_ERRORCHECK);
+    pthread_mutex_init(&signal_handler_lock, &signal_handler_lock_attr);
+    
+    struct sigaction act;
+
+    sigemptyset(&act.sa_mask);
+    /* Set SA_NODEFER to disable adding the signal to the signal mask of the
+     * calling process on entry to the signal handler unless it is included in the sa_mask field. */
+    act.sa_flags = SA_NODEFER | SA_SIGINFO;
+    act.sa_sigaction = sigsegvHandler;
+    if(server.crashlog_enabled) {
+        sigaction(SIGSEGV, &act, NULL);
+        sigaction(SIGBUS, &act, NULL);
+        sigaction(SIGFPE, &act, NULL);
+        sigaction(SIGILL, &act, NULL);
+        sigaction(SIGABRT, &act, NULL);
+    }
 }
 
 void printCrashReport(void) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -69,6 +69,7 @@ static pthread_mutex_t bug_report_start_mutex = PTHREAD_MUTEX_INITIALIZER;
 /* Mutex for a case when two threads crash at the same time. */
 static pthread_mutex_t signal_handler_lock;
 static pthread_mutexattr_t signal_handler_lock_attr;
+static volatile int signal_handler_lock_initialized = 0;
 /* Forward declarations */
 void bugReportStart(void);
 void printCrashReport(void);
@@ -2183,11 +2184,17 @@ void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     bugReportEnd(1, sig);
 }
 
+int isDebugReady(void) {
+    return signal_handler_lock_initialized;
+}
+
 void initDebug(void) {
     /* Set signal handler with error checking attribute. re-lock within the same thread will error. */
     pthread_mutexattr_init(&signal_handler_lock_attr);
     pthread_mutexattr_settype(&signal_handler_lock_attr, PTHREAD_MUTEX_ERRORCHECK);
     pthread_mutex_init(&signal_handler_lock, &signal_handler_lock_attr);
+
+    signal_handler_lock_initialized = 1;
 }
 
 void printCrashReport(void) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -1066,7 +1066,7 @@ void _serverAssert(const char *estr, const char *file, int line) {
     }
 
     // remove the signal handler so on abort() we will output the crash report.
-    removeSignalHandlers();
+    removeSigSegvHandlers();
     bugReportEnd(0, 0);
 }
 
@@ -1162,7 +1162,7 @@ void _serverPanic(const char *file, int line, const char *msg, ...) {
     }
 
     // remove the signal handler so on abort() we will output the crash report.
-    removeSignalHandlers();
+    removeSigSegvHandlers();
     bugReportEnd(0, 0);
 }
 
@@ -2209,6 +2209,18 @@ void setupSigSegvHandler(void) {
         sigaction(SIGILL, &act, NULL);
         sigaction(SIGABRT, &act, NULL);
     }
+}
+
+void removeSigSegvHandlers(void) {
+    struct sigaction act;
+    sigemptyset(&act.sa_mask);
+    act.sa_flags = SA_NODEFER | SA_RESETHAND;
+    act.sa_handler = SIG_DFL;
+    sigaction(SIGSEGV, &act, NULL);
+    sigaction(SIGBUS, &act, NULL);
+    sigaction(SIGFPE, &act, NULL);
+    sigaction(SIGILL, &act, NULL);
+    sigaction(SIGABRT, &act, NULL);
 }
 
 void printCrashReport(void) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -2198,8 +2198,10 @@ void setupSigSegvHandler(void) {
     struct sigaction act;
 
     sigemptyset(&act.sa_mask);
-    /* Set SA_NODEFER to disable adding the signal to the signal mask of the
+    /* SA_NODEFER to disables adding the signal to the signal mask of the
      * calling process on entry to the signal handler unless it is included in the sa_mask field. */
+    /* SA_SIGINFO flag is set to raise the function defined in sa_sigaction.
+     * Otherwise, sa_handler is used. */
     act.sa_flags = SA_NODEFER | SA_SIGINFO;
     act.sa_sigaction = sigsegvHandler;
     if(server.crashlog_enabled) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -66,6 +66,9 @@ typedef ucontext_t sigcontext_t;
 /* Globals */
 static int bug_report_start = 0; /* True if bug report header was already logged. */
 static pthread_mutex_t bug_report_start_mutex = PTHREAD_MUTEX_INITIALIZER;
+/* Set signal handler with error checking attribute.
+A thread attempting to relock this mutex without first unlocking it shall return with an error. */
+static pthread_mutex_t signal_handler_lock = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
 
 /* Forward declarations */
 void bugReportStart(void);
@@ -2119,6 +2122,16 @@ typedef void (*invalidFunctionWasCalledType)(void);
 void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     UNUSED(secret);
     UNUSED(info);
+    // Check if it is safe to enter the signal handler
+    if(pthread_mutex_lock(&signal_handler_lock) == EDEADLK) {
+        // If this thread already owns the lock (meaning we crashed during handling a signal)
+        // log that the crash report can't be generated.
+        serverLog(LL_WARNING,
+            "Crashed running signal handler. Can't continue to generate the crash report");
+        // gracefully exit
+        bugReportEnd(1, sig);
+        return;
+    }
 
     bugReportStart();
     serverLog(LL_WARNING,
@@ -2218,7 +2231,7 @@ void bugReportEnd(int killViaSignal, int sig) {
     /* Make sure we exit with the right signal at the end. So for instance
      * the core will be dumped if enabled. */
     sigemptyset (&act.sa_mask);
-    act.sa_flags = SA_NODEFER | SA_ONSTACK | SA_RESETHAND;
+    act.sa_flags = 0;
     act.sa_handler = SIG_DFL;
     sigaction (sig, &act, NULL);
     kill(getpid(),sig);

--- a/src/debug.c
+++ b/src/debug.c
@@ -2118,7 +2118,7 @@ void invalidFunctionWasCalled(void) {}
 
 typedef void (*invalidFunctionWasCalledType)(void);
 
-static void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
+void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     UNUSED(secret);
     UNUSED(info);
     /* Check if it is safe to enter the signal handler. second thread crashing at the same time will deadlock. */
@@ -2183,26 +2183,11 @@ static void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     bugReportEnd(1, sig);
 }
 
-void setupSigSegvHandler(void) {
+void initDebug(void) {
     /* Set signal handler with error checking attribute. re-lock within the same thread will error. */
     pthread_mutexattr_init(&signal_handler_lock_attr);
     pthread_mutexattr_settype(&signal_handler_lock_attr, PTHREAD_MUTEX_ERRORCHECK);
     pthread_mutex_init(&signal_handler_lock, &signal_handler_lock_attr);
-    
-    struct sigaction act;
-
-    sigemptyset(&act.sa_mask);
-    /* Set SA_NODEFER to disable adding the signal to the signal mask of the
-     * calling process on entry to the signal handler unless it is included in the sa_mask field. */
-    act.sa_flags = SA_NODEFER | SA_SIGINFO;
-    act.sa_sigaction = sigsegvHandler;
-    if(server.crashlog_enabled) {
-        sigaction(SIGSEGV, &act, NULL);
-        sigaction(SIGBUS, &act, NULL);
-        sigaction(SIGFPE, &act, NULL);
-        sigaction(SIGILL, &act, NULL);
-        sigaction(SIGABRT, &act, NULL);
-    }
 }
 
 void printCrashReport(void) {

--- a/src/server.c
+++ b/src/server.c
@@ -2562,7 +2562,6 @@ void initServer(void) {
 
     signal(SIGHUP, SIG_IGN);
     signal(SIGPIPE, SIG_IGN);
-    initDebug();
     setupSignalHandlers();
     makeThreadKillable();
 
@@ -6525,24 +6524,7 @@ void setupSignalHandlers(void) {
     sigaction(SIGTERM, &act, NULL);
     sigaction(SIGINT, &act, NULL);
 
-    /* Check that the debug resources were intialized proprely */
-    if(!isDebugReady()) {
-        serverLog(LL_WARNING, "Warning: Debug resources were not initialized. Skipping registration to sigsegv handler.");
-        return;
-    }
-
-    sigemptyset(&act.sa_mask);
-    /* Set SA_NODEFER to disable adding the signal to the signal mask of the
-     * calling process on entry to the signal handler unless it is included in the sa_mask field. */
-    act.sa_flags = SA_NODEFER | SA_SIGINFO;
-    act.sa_sigaction = sigsegvHandler;
-    if(server.crashlog_enabled) {
-        sigaction(SIGSEGV, &act, NULL);
-        sigaction(SIGBUS, &act, NULL);
-        sigaction(SIGFPE, &act, NULL);
-        sigaction(SIGILL, &act, NULL);
-        sigaction(SIGABRT, &act, NULL);
-    }
+    setupSignalHandlers();
 }
 
 void removeSignalHandlers(void) {

--- a/src/server.c
+++ b/src/server.c
@@ -6524,7 +6524,7 @@ void setupSignalHandlers(void) {
     sigaction(SIGTERM, &act, NULL);
     sigaction(SIGINT, &act, NULL);
 
-    setupSignalHandlers();
+    setupSigSegvHandler();
 }
 
 void removeSignalHandlers(void) {

--- a/src/server.c
+++ b/src/server.c
@@ -6527,18 +6527,6 @@ void setupSignalHandlers(void) {
     setupSigSegvHandler();
 }
 
-void removeSignalHandlers(void) {
-    struct sigaction act;
-    sigemptyset(&act.sa_mask);
-    act.sa_flags = SA_NODEFER | SA_RESETHAND;
-    act.sa_handler = SIG_DFL;
-    sigaction(SIGSEGV, &act, NULL);
-    sigaction(SIGBUS, &act, NULL);
-    sigaction(SIGFPE, &act, NULL);
-    sigaction(SIGILL, &act, NULL);
-    sigaction(SIGABRT, &act, NULL);
-}
-
 /* This is the signal handler for children process. It is currently useful
  * in order to track the SIGUSR1, that we send to a child in order to terminate
  * it in a clean way, without the parent detecting an error and stop

--- a/src/server.c
+++ b/src/server.c
@@ -6525,6 +6525,12 @@ void setupSignalHandlers(void) {
     sigaction(SIGTERM, &act, NULL);
     sigaction(SIGINT, &act, NULL);
 
+    /* Check that the debug resources were intialized proprely */
+    if(!isDebugReady()) {
+        serverLog(LL_WARNING, "Warning: Debug resources were not initialized. Skipping registration to sigsegv handler.");
+        return;
+    }
+
     sigemptyset(&act.sa_mask);
     /* Set SA_NODEFER to disable adding the signal to the signal mask of the
      * calling process on entry to the signal handler unless it is included in the sa_mask field. */

--- a/src/server.c
+++ b/src/server.c
@@ -6516,8 +6516,6 @@ static void sigShutdownHandler(int sig) {
 void setupSignalHandlers(void) {
     struct sigaction act;
 
-    /* When the SA_SIGINFO flag is set in sa_flags then sa_sigaction is used.
-     * Otherwise, sa_handler is used. */
     sigemptyset(&act.sa_mask);
     act.sa_flags = 0;
     act.sa_handler = sigShutdownHandler;

--- a/src/server.c
+++ b/src/server.c
@@ -6525,7 +6525,9 @@ void setupSignalHandlers(void) {
     sigaction(SIGINT, &act, NULL);
 
     sigemptyset(&act.sa_mask);
-    act.sa_flags = SA_NODEFER | SA_RESETHAND | SA_SIGINFO;
+    /* Set SA_NODEFER to disable adding the signal to the signal mask of the
+     * calling process on entry to the signal handler unless it is included in the sa_mask field. */
+    act.sa_flags = SA_NODEFER | SA_SIGINFO;
     act.sa_sigaction = sigsegvHandler;
     if(server.crashlog_enabled) {
         sigaction(SIGSEGV, &act, NULL);

--- a/src/server.c
+++ b/src/server.c
@@ -6524,19 +6524,7 @@ void setupSignalHandlers(void) {
     sigaction(SIGTERM, &act, NULL);
     sigaction(SIGINT, &act, NULL);
 
-    sigemptyset(&act.sa_mask);
-    /* Set SA_NODEFER to disable adding the signal to the signal mask of the
-     * calling process on entry to the signal handler unless it is included in the sa_mask field. */
-    act.sa_flags = SA_NODEFER | SA_SIGINFO;
-    act.sa_sigaction = sigsegvHandler;
-    if(server.crashlog_enabled) {
-        sigaction(SIGSEGV, &act, NULL);
-        sigaction(SIGBUS, &act, NULL);
-        sigaction(SIGFPE, &act, NULL);
-        sigaction(SIGILL, &act, NULL);
-        sigaction(SIGABRT, &act, NULL);
-    }
-    return;
+    setupSigSegvHandler();
 }
 
 void removeSignalHandlers(void) {

--- a/src/server.h
+++ b/src/server.h
@@ -3016,7 +3016,6 @@ int processCommand(client *c);
 int processPendingCommandAndInputBuffer(client *c);
 int processCommandAndResetClient(client *c);
 void setupSignalHandlers(void);
-void removeSignalHandlers(void);
 int createSocketAcceptHandler(connListener *sfd, aeFileProc *accept_handler);
 connListener *listenerByType(const char *typename);
 int changeListener(connListener *listener);
@@ -3705,6 +3704,7 @@ void _serverPanic(const char *file, int line, const char *msg, ...);
 #endif
 void serverLogObjectDebugInfo(const robj *o);
 void setupSigSegvHandler(void);
+void removeSigSegvHandlers(void);
 const char *getSafeInfoString(const char *s, size_t len, char **tmp);
 dict *genInfoSectionDict(robj **argv, int argc, char **defaults, int *out_all, int *out_everything);
 void releaseInfoSectionDict(dict *sec);

--- a/src/server.h
+++ b/src/server.h
@@ -3705,6 +3705,7 @@ void _serverPanic(const char *file, int line, const char *msg, ...);
 #endif
 void serverLogObjectDebugInfo(const robj *o);
 void initDebug(void);
+int isDebugReady(void);
 void sigsegvHandler(int sig, siginfo_t *info, void *secret);
 const char *getSafeInfoString(const char *s, size_t len, char **tmp);
 dict *genInfoSectionDict(robj **argv, int argc, char **defaults, int *out_all, int *out_everything);

--- a/src/server.h
+++ b/src/server.h
@@ -3704,7 +3704,7 @@ void _serverPanic(const char *file, int line, const char *msg, ...)
 void _serverPanic(const char *file, int line, const char *msg, ...);
 #endif
 void serverLogObjectDebugInfo(const robj *o);
-void sigsegvHandler(int sig, siginfo_t *info, void *secret);
+void setupSigSegvHandler(void);
 const char *getSafeInfoString(const char *s, size_t len, char **tmp);
 dict *genInfoSectionDict(robj **argv, int argc, char **defaults, int *out_all, int *out_everything);
 void releaseInfoSectionDict(dict *sec);

--- a/src/server.h
+++ b/src/server.h
@@ -3704,7 +3704,7 @@ void _serverPanic(const char *file, int line, const char *msg, ...)
 void _serverPanic(const char *file, int line, const char *msg, ...);
 #endif
 void serverLogObjectDebugInfo(const robj *o);
-void setupSignalHandlers(void);
+void setupSigSegvHandler(void);
 const char *getSafeInfoString(const char *s, size_t len, char **tmp);
 dict *genInfoSectionDict(robj **argv, int argc, char **defaults, int *out_all, int *out_everything);
 void releaseInfoSectionDict(dict *sec);

--- a/src/server.h
+++ b/src/server.h
@@ -3704,7 +3704,8 @@ void _serverPanic(const char *file, int line, const char *msg, ...)
 void _serverPanic(const char *file, int line, const char *msg, ...);
 #endif
 void serverLogObjectDebugInfo(const robj *o);
-void setupSigSegvHandler(void);
+void initDebug(void);
+void sigsegvHandler(int sig, siginfo_t *info, void *secret);
 const char *getSafeInfoString(const char *s, size_t len, char **tmp);
 dict *genInfoSectionDict(robj **argv, int argc, char **defaults, int *out_all, int *out_everything);
 void releaseInfoSectionDict(dict *sec);

--- a/src/server.h
+++ b/src/server.h
@@ -3704,9 +3704,7 @@ void _serverPanic(const char *file, int line, const char *msg, ...)
 void _serverPanic(const char *file, int line, const char *msg, ...);
 #endif
 void serverLogObjectDebugInfo(const robj *o);
-void initDebug(void);
-int isDebugReady(void);
-void sigsegvHandler(int sig, siginfo_t *info, void *secret);
+void setupSignalHandlers(void);
 const char *getSafeInfoString(const char *s, size_t len, char **tmp);
 dict *genInfoSectionDict(robj **argv, int argc, char **defaults, int *out_all, int *out_everything);
 void releaseInfoSectionDict(dict *sec);


### PR DESCRIPTION
This PR purpose is to make the crash report process thread safe.
main changes include:

1. `setupSigSegvHandler()` is introduced to initialize the signal handler. This function first initializes the signal handler mutex (if not initialized yet) and then registers the process to the signal handler. 

2. **sigsegvHandler** flags :
SA_NODEFER - don't add the signal to the process signal mask. We use this flag because we want to be able to handle a second call to the signal manually.
removed SA_RESETHAND: this flag resets the signal handler function upon the first entrance to the registered function. The reason to use this flag is to protect from recursively entering the signal handler by the same thread. But, it also means that if a second thread crashes while handling a signal, the process will be terminated immediately and we won't get the crash report.
In this PR we discard this flag. The signal handler guard described below purpose is to solve the above issues.

3. Add a **signal handler lock** with ERRORCHECK attributes. 
The lock's purpose is to ensure that only one thread generates a crash report. Once a second thread enters the signal handler it will be blocked.
We use the ERRORCHECK lock in order to protect from possible deadlock in case the thread handling the crash gets a signal. In the latest scenario, we log what we have collected until the handler crashed.

At the end of the crash report we reset the signal handler SIG_DFL, with no flags, and rethrow the signal to generate a core dump (if enabled) and exit the process.

During the work on this PR we wanted to understand the historical reasons for how crash is handled.
With respect to the choice of the flag, we believe the **SA_RESETHAND** was not added for any specific purpose.
**SA_ONSTACK** which is removed here from bugReportEnd(), was originally also set in the initial registration to signal handler, but removed [in this commit](https://github.com/redis/redis/commit/3ada43e732678e1f1ed0830c7407eef99ad63c46). In addition, it was removed from another location [by this commit](https://github.com/redis/redis/commit/deee2c1ef2249120ae7db0e7523bfad4041b21a6) with the following description, which is also relevant to why it should be removed from bugReportEnd:

> it seems to be some valgrind bug with SA_ONSTACK.
> SA_ONSTACK seems unneeded since WD is not recursive (SA_NODEFER was removed),
> also, not sure if it's even valid without a call to sigaltstack()

