### PR TITLE
Return empty string when client list is empty

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3090,8 +3090,7 @@ NULL
         if(!sdslen(o)) {
             addReplyArrayLen(c,1);
             addReplyBulkCString(c,"\"\" \n");
-        }
-        else {
+        } else {
             addReplyVerbatim(c,o,sdslen(o),"txt");
         }
         sdsfree(o);

--- a/src/networking.c
+++ b/src/networking.c
@@ -3087,7 +3087,13 @@ NULL
 
         if (!o)
             o = getAllClientsInfoString(type);
-        addReplyVerbatim(c,o,sdslen(o),"txt");
+        if(!sdslen(o)) {
+            addReplyArrayLen(c,1);
+            addReplyBulkCString(c,"\"\" \n");
+        }
+        else {
+            addReplyVerbatim(c,o,sdslen(o),"txt");
+        }
         sdsfree(o);
     } else if (!strcasecmp(c->argv[1]->ptr,"reply") && c->argc == 3) {
         /* CLIENT REPLY ON|OFF|SKIP */


### PR DESCRIPTION
**Description**
Client list command doesn't returns anything when the client list is empty for the particular type.
```
127.0.0.1:6379> client list type normal
id=3 addr=127.0.0.1:58112 laddr=127.0.0.1:6379 fd=8 name= age=22 idle=0 flags=N db=0 sub=0 psub=0 ssub=0 multi=-1 qbuf=48 qbuf-free=16336 argv-mem=20 multi-mem=0 rbs=1024 rbp=0 obl=0 oll=0 omem=0 tot-mem=18242 events=r cmd=client|list user=default redir=-1 resp=2 lib-name= lib-ver=
127.0.0.1:6379> client list type master
127.0.0.1:6379> client list type replica
127.0.0.1:6379> client list type pubsub
127.0.0.1:6379>
```

I was expecting empty string or (nil) when the client list is empty.
_IMO printing empty string is better._

```
127.0.0.1:6379> client list type master
""
```

OR

```
127.0.0.1:6379> client list type master
(nil)
```

**Current behavior after changes :**
```
127.0.0.1:6379> client list type pubsub
""
127.0.0.1:6379> client list type replica
""
```