### PR TITLE
Add test case for APPEND command usage on integer value

### DIFF
--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -274,7 +274,7 @@ start_server {tags {"other"}} {
         assert_equal "encoding:int" $encoding 
 
         assert_equal [r get foo] [r get bar]
-    }
+    } {} {needs:debug}
 
     test {APPEND fuzzing} {
         set err {}

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -258,6 +258,24 @@ start_server {tags {"other"}} {
         lappend res [r get foo]
     } {12 12}
 
+    test {APPEND modifies the encoding from int to raw} {
+        r del foo
+        r set foo 1
+        r append foo 2
+
+        # append command undergoes a operation dbUnshareStringValue which
+        # converts the value to a sds object of encoding raw type.  
+        assert_equal 12 [r get foo]
+        set encoding [lindex [split [r debug object foo]] 3]
+        assert_equal "encoding:raw" $encoding 
+
+        r set bar 12
+        set encoding [lindex [split [r debug object bar]] 3]
+        assert_equal "encoding:int" $encoding 
+
+        assert_equal [r get foo] [r get bar]
+    }
+
     test {APPEND fuzzing} {
         set err {}
         foreach type {binary alpha compr} {

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -266,12 +266,10 @@ start_server {tags {"other"}} {
         # append command undergoes a operation dbUnshareStringValue which
         # converts the value to a sds object of encoding raw type.  
         assert_equal 12 [r get foo]
-        set encoding [lindex [split [r debug object foo]] 3]
-        assert_equal "encoding:raw" $encoding 
+        assert_encoding "raw" foo
 
         r set bar 12
-        set encoding [lindex [split [r debug object bar]] 3]
-        assert_equal "encoding:int" $encoding 
+        assert_encoding "int" bar
 
         assert_equal [r get foo] [r get bar]
     } {} {needs:debug}

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -258,22 +258,6 @@ start_server {tags {"other"}} {
         lappend res [r get foo]
     } {12 12}
 
-    test {APPEND modifies the encoding from int to raw} {
-        r del foo
-        r set foo 1
-        r append foo 2
-
-        # append command undergoes a operation dbUnshareStringValue which
-        # converts the value to a sds object of encoding raw type.  
-        assert_equal 12 [r get foo]
-        assert_encoding "raw" foo
-
-        r set bar 12
-        assert_encoding "int" bar
-
-        assert_equal [r get foo] [r get bar]
-    } {} {needs:debug}
-
     test {APPEND fuzzing} {
         set err {}
         foreach type {binary alpha compr} {

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -656,4 +656,19 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
            }
         }
     }
+
+    test {APPEND modifies the encoding from int to raw} {
+        r del foo
+        r set foo 1
+        assert_encoding "int" foo
+        r append foo 2
+
+        assert_equal 12 [r get foo]
+        assert_encoding "raw" foo
+        
+        r set bar 12
+        assert_encoding "int" bar
+
+        r mget foo bar
+    } {12 12}
 }

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -663,12 +663,12 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         assert_encoding "int" foo
         r append foo 2
 
-        assert_equal 12 [r get foo]
+        set res {}
+        lappend res [r get foo]
         assert_encoding "raw" foo
         
         r set bar 12
         assert_encoding "int" bar
-
-        r mget foo bar
+        lappend res [r get bar]
     } {12 12}
 }


### PR DESCRIPTION
Add test coverage to validate object encoding update on APPEND command usage on a integer value

### Observations

#### SET command behavior (same with INCR/DECR operation)
```
127.0.0.1:6379> set test 10
OK
127.0.0.1:6379> get test
"10"
127.0.0.1:6379> debug object test
Value at:0x1d88c40 refcount:2147483647 encoding:int serializedlength:2 lru:12177111 lru_seconds_idle:7
```

#### APPEND command behavior 
```
127.0.0.1:6379> set test1 10
OK
127.0.0.1:6379> debug object test1
Value at:0x1d88c40 refcount:2147483647 encoding:int serializedlength:2 lru:12177111 lru_seconds_idle:29
127.0.0.1:6379> append object test1
(integer) 5
127.0.0.1:6379> append test1 10
(integer) 4
127.0.0.1:6379> debug object test1
Value at:0x1e2a9b0 refcount:1 encoding:raw serializedlength:3 lru:12177165 lru_seconds_idle:9
```
I presume no optimization (`int`/`embstr`) is made for SDS generated from append command as the SDS is expected to grow in size (used for timeseries use cases).