### PR TITLE
Test coverage for incr/decr operation on robj encoding type optimization

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -614,15 +614,12 @@ void incrDecrCommand(client *c, long long incr) {
     }
     value += incr;
 
-    if (o && o->refcount == 1 && (value < 0 || value >= OBJ_SHARED_INTEGERS) &&
-        value >= LONG_MIN && value <= LONG_MAX) {
-        if (o->encoding == OBJ_ENCODING_INT) {
-            new = o;
-            o->ptr = (void*)((long)value);
-        } else {
-            new = createStringObjectFromLongLongForValue(value);
-            dbReplaceValue(c->db, c->argv[1], new);
-        }
+    if (o && o->refcount == 1 && o->encoding == OBJ_ENCODING_INT &&
+        (value < 0 || value >= OBJ_SHARED_INTEGERS) &&
+        value >= LONG_MIN && value <= LONG_MAX)
+    {
+        new = o;
+        o->ptr = (void*)((long)value);
     } else {
         new = createStringObjectFromLongLongForValue(value);
         if (o) {

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -614,12 +614,15 @@ void incrDecrCommand(client *c, long long incr) {
     }
     value += incr;
 
-    if (o && o->refcount == 1 && o->encoding == OBJ_ENCODING_INT &&
-        (value < 0 || value >= OBJ_SHARED_INTEGERS) &&
-        value >= LONG_MIN && value <= LONG_MAX)
-    {
-        new = o;
-        o->ptr = (void*)((long)value);
+    if (o && o->refcount == 1 && (value < 0 || value >= OBJ_SHARED_INTEGERS) &&
+        value >= LONG_MIN && value <= LONG_MAX) {
+        if (o->encoding == OBJ_ENCODING_INT) {
+            new = o;
+            o->ptr = (void*)((long)value);
+        } else {
+            new = createStringObjectFromLongLongForValue(value);
+            dbReplaceValue(c->db, c->argv[1], new);
+        }
     } else {
         new = createStringObjectFromLongLongForValue(value);
         if (o) {

--- a/tests/unit/type/incr.tcl
+++ b/tests/unit/type/incr.tcl
@@ -193,8 +193,6 @@ start_server {tags {"incr"}} {
         }
 
         test "$cmd operation should update encoding from raw to int" {
-            r del foo
-
             r set foo 1
             assert_encoding "int" foo
             lappend res [r get foo]

--- a/tests/unit/type/incr.tcl
+++ b/tests/unit/type/incr.tcl
@@ -192,7 +192,7 @@ start_server {tags {"incr"}} {
             lappend expected 11
         }
 
-        test {INCR[BY]/DECR[BY] operation should update encoding from raw to int} {
+        test "$cmd operation should update encoding from raw to int" {
             r del foo
 
             r set foo 1
@@ -210,7 +210,7 @@ start_server {tags {"incr"}} {
             }
             assert_encoding "int" foo
             lappend res [r get foo]
+            assert_equal $res $expected
         }
-        assert_equal $res $expected
     }
 }

--- a/tests/unit/type/incr.tcl
+++ b/tests/unit/type/incr.tcl
@@ -182,4 +182,35 @@ start_server {tags {"incr"}} {
         r incrbyfloat foo [expr double(-1)/41]
         r get foo
     } {0}
+
+    foreach cmd {"incr" "decr" "incrby" "decrby"} {
+        set res {}
+        set expected {1 12}
+        if {[string match {*incr*} $cmd]} {
+            lappend expected 13
+        } else {
+            lappend expected 11
+        }
+
+        test {INCR[BY]/DECR[BY] operation should update encoding from raw to int} {
+            r del foo
+
+            r set foo 1
+            assert_encoding "int" foo
+            lappend res [r get foo]
+
+            r append foo 2
+            assert_encoding "raw" foo
+            lappend res [r get foo]
+
+            if {[string match {*by*} $cmd]} {
+                r $cmd foo 1
+            } else {
+                r $cmd foo
+            }
+            assert_encoding "int" foo
+            lappend res [r get foo]
+        }
+        assert_equal $res $expected
+    }
 }

--- a/tests/unit/type/incr.tcl
+++ b/tests/unit/type/incr.tcl
@@ -184,15 +184,15 @@ start_server {tags {"incr"}} {
     } {0}
 
     foreach cmd {"incr" "decr" "incrby" "decrby"} {
-        set res {}
-        set expected {1 12}
-        if {[string match {*incr*} $cmd]} {
-            lappend expected 13
-        } else {
-            lappend expected 11
-        }
-
         test "$cmd operation should update encoding from raw to int" {
+            set res {}
+            set expected {1 12}
+            if {[string match {*incr*} $cmd]} {
+                lappend expected 13
+            } else {
+                lappend expected 11
+            }
+
             r set foo 1
             assert_encoding "int" foo
             lappend res [r get foo]


### PR DESCRIPTION
Additional test coverage for incr/decr operation.

integer number could be present in `raw` encoding format due to operation like `append`. A `incr`/`decr` operation following it optimize the string to `int` encoding format. 
For e.g.

```
127.0.0.1:6379> set foo 1
OK
127.0.0.1:6379> object encoding foo
"int"
127.0.0.1:6379> append foo 2
(integer) 2
127.0.0.1:6379> object encoding foo
"raw"
127.0.0.1:6379> incr foo
(integer) 13
127.0.0.1:6379> object encoding foo
"int"
```