### PR TITLE
Fix wait in cluster test 03-failover-loop

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -605,6 +605,10 @@ proc set_instance_attrib {type id attrib newval} {
     lset ::${type}_instances $id $d
 }
 
+proc get_instance_addr {type id} {
+    return [get_instance_attrib $type $id host]:[get_instance_attrib $type $id port]
+}
+
 # Create a master-slave cluster of the given number of total instances.
 # The first instance "0" is the master, all others are configured as
 # slaves.

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -196,6 +196,11 @@ proc ::redis_cluster::__method__masternode_notfor_slot {id slot} {
     error "Slot $slot is everywhere"
 }
 
+proc ::redis_cluster::__method__get_link {id node_addr} {
+    set node [dict get $::redis_cluster::nodes($id) $node_addr]
+    return [dict get $node link]
+}
+
 proc ::redis_cluster::__dispatch__ {id method args} {
     if {[info command ::redis_cluster::__method__$method] eq {}} {
         # Get the keys from the command.
@@ -221,8 +226,7 @@ proc ::redis_cluster::__dispatch__ {id method args} {
         set asking 0
         while {[incr retry -1]} {
             if {$retry < 5} {after 100}
-            set node [dict get $::redis_cluster::nodes($id) $node_addr]
-            set link [dict get $node link]
+            set link [::redis_cluster::__method__get_link $id $node_addr]
             if {$asking} {
                 $link ASKING
                 set asking 0


### PR DESCRIPTION
Before killing a master node, the test uses a WAIT command to make sure all writes have been propagated to the corresponding replica.

For the WAIT command to be effective for this purpose, it needs to be sent from the same client that performed the writes, as a WAIT command only waits for the propagation of writes that came from the same client that's requesting the wait.

This change fixes the test to send the wait through the same link as the writes before killing a master node.