### PR TITLE
[MINOR] Remove redundency code in sentinal.

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -5395,11 +5395,6 @@ void sentinelHandleRedisInstance(sentinelRedisInstance *ri) {
     /* Every kind of instance */
     sentinelCheckSubjectivelyDown(ri);
 
-    /* Masters and slaves */
-    if (ri->flags & (SRI_MASTER|SRI_SLAVE)) {
-        /* Nothing so far. */
-    }
-
     /* Only masters */
     if (ri->flags & SRI_MASTER) {
         sentinelCheckObjectivelyDown(ri);


### PR DESCRIPTION
part of sentinelHandleRedisInstance we have a check for master or slave, don't have any operations in the block. this code is added very long back in 6b5daa2df2 . 

```
     sentinelCheckSubjectivelyDown(ri);

    /* Masters and slaves */
    if (ri->flags & (SRI_MASTER|SRI_SLAVE)) {
        /* Nothing so far. */
    }

     /* Only masters */

```

Since we dont have any oprations under the condition so removing the redundency code.