### PR TITLE
Optimize zslUpdateScore to handle new score is the same of prev/next node case

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -285,8 +285,11 @@ zskiplistNode *zslUpdateScore(zskiplist *zsl, double curscore, sds ele, double n
     /* If the node, after the score update, would be still exactly
      * at the same position, we can just update the score without
      * actually removing and re-inserting the element in the skiplist. */
-    if ((x->backward == NULL || x->backward->score < newscore) &&
-        (x->level[0].forward == NULL || x->level[0].forward->score > newscore))
+    if ((x->backward == NULL || x->backward->score < newscore ||
+        (x->backward->score == newscore && sdscmp(x->backward->ele, ele) < 0))
+        &&
+        ((x->level[0].forward == NULL || x->level[0].forward->score > newscore) ||
+        (x->level[0].forward->score == newscore && sdscmp(x->level[0].forward->ele, ele) > 0)))
     {
         x->score = newscore;
         return x;


### PR DESCRIPTION
If the node, after the score update, would be still exactly at the
same position, we can just update the score without actually removing
and re-inserting the element in the skiplist.

When the new score is the same of prev/next node, the lexicographical
order kicks in, so we can check the ele of prev/next node and see
if the node still at the same position.

Simple benchmark show that this can improve performance by 10% in
specific case.

```
src/redis-server redis.conf --zset-max-listpack-entries 0
src/redis-benchmark -P 100 -n 400000 zadd zset 1 a 2 b 3 c 1 b 2 b 3 b
```

before:
```
Summary:
  throughput summary: 212992.55 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       23.317     4.712    22.511    25.583    64.767    65.279
```

after:
```
Summary:
  throughput summary: 239377.62 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       20.831     3.408    20.639    22.111    25.583    38.751
```