### PR TITLE
Fix race condition in tests/unit/auth.tcl

### DIFF
--- a/tests/unit/auth.tcl
+++ b/tests/unit/auth.tcl
@@ -70,8 +70,8 @@ start_server {tags {"auth_binary_password external:skip"}} {
 
             # Configure the replica with masterauth
             set loglines [count_log_lines 0]
-            $slave slaveof $master_host $master_port
             $slave config set masterauth "abc"
+            $slave slaveof $master_host $master_port
 
             # Verify replica is not able to sync with master
             wait_for_log_messages 0 {"*Unable to AUTH to MASTER*"} $loglines 1000 10


### PR DESCRIPTION
Changing the masterauth while turning into a replica is racy.

Turn into replica after changing the masterauth instead.