### PR TITLE
change log match to line match in tcl sanitizer_errors_from_file.

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -62,8 +62,8 @@ proc sanitizer_errors_from_file {filename} {
         }
 
         # GCC UBSAN output does not contain 'Sanitizer' but 'runtime error'.
-        if {[string match {*runtime error*} $log] ||
-            [string match {*Sanitizer*} $log]} {
+        if {[string match {*runtime error*} $line] ||
+            [string match {*Sanitizer*} $line]} {
             return $log
         }
     }


### PR DESCRIPTION
In the tcl foreach loop, the function should compare line rather than the whole file.