### PR TITLE
Ensure that the function load timeout is disabled during loading from RDB/AOF and on replicas.

### DIFF
--- a/src/functions.h
+++ b/src/functions.h
@@ -53,9 +53,14 @@ typedef struct engine {
     /* engine specific context */
     void *engine_ctx;
 
-    /* Create function callback, get the engine_ctx, and function code.
+    /* Create function callback, get the engine_ctx, and function code
+     * engine_ctx - opaque stuct that was created on engine initialization
+     * li - library information that need to be provided and when add functions
+     * code - the library code
+     * timeout - timeout for the library creation (0 for no timeout)
+     * err - description of error (if occurred)
      * returns NULL on error and set sds to be the error message */
-    int (*create)(void *engine_ctx, functionLibInfo *li, sds code, sds *err);
+    int (*create)(void *engine_ctx, functionLibInfo *li, sds code, size_t timeout, sds *err);
 
     /* Invoking a function, r_ctx is an opaque object (from engine POV).
      * The r_ctx should be used by the engine to interaction with Redis,
@@ -109,7 +114,7 @@ struct functionLibInfo {
 };
 
 int functionsRegisterEngine(const char *engine_name, engine *engine_ctx);
-sds functionsCreateWithLibraryCtx(sds code, int replace, sds* err, functionsLibCtx *lib_ctx);
+sds functionsCreateWithLibraryCtx(sds code, int replace, sds* err, functionsLibCtx *lib_ctx, size_t timeout);
 unsigned long functionsMemory(void);
 unsigned long functionsMemoryOverhead(void);
 unsigned long functionsNum(void);

--- a/src/functions.h
+++ b/src/functions.h
@@ -54,7 +54,7 @@ typedef struct engine {
     void *engine_ctx;
 
     /* Create function callback, get the engine_ctx, and function code
-     * engine_ctx - opaque stuct that was created on engine initialization
+     * engine_ctx - opaque struct that was created on engine initialization
      * li - library information that need to be provided and when add functions
      * code - the library code
      * timeout - timeout for the library creation (0 for no timeout)

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2981,7 +2981,7 @@ int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx* lib_ctx, int rdbflags, s
 
     if (lib_ctx) {
         sds library_name = NULL;
-        if (!(library_name = functionsCreateWithLibraryCtx(final_payload, rdbflags & RDBFLAGS_ALLOW_DUP, &error, lib_ctx))) {
+        if (!(library_name = functionsCreateWithLibraryCtx(final_payload, rdbflags & RDBFLAGS_ALLOW_DUP, &error, lib_ctx, 0))) {
             if (!error) {
                 error = sdsnew("Failed creating the library");
             }


### PR DESCRIPTION
When loading a function from either RDB/AOF or a replica, it is essential not to fail on timeout errors. The loading time may vary due to various factors, such as hardware specifications or the system's workload during the loading process. Once a function has been successfully loaded, it should be allowed to load from persistence or on replicas without encountering a timeout failure.

To maintain a clear separation between the engine and Redis internals, the implementation avoid from directly checking the state of Redis within the engine itself. Instead, the engine receives the desired timeout as part of the library creation and must respects this timeout value. If Redis wishes to disable any timeout, it can simply send a value of 0.