### PR TITLE
fix false success and a memory leak for ACL selector with bad parenthesis combination

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1990,7 +1990,8 @@ sds *ACLMergeSelectorArguments(sds *argv, int argc, int *merged_argc, int *inval
     for (int j = 0; j < argc; j++) {
         char *op = argv[j];
 
-        if (op[0] == '(' && op[sdslen(op) - 1] != ')') {
+        if (open_bracket_start == -1 &&
+            (op[0] == '(' && op[sdslen(op) - 1] != ')')) {
             selector = sdsdup(argv[j]);
             open_bracket_start = j;
             continue;

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -47,6 +47,15 @@ start_server {tags {"acl external:skip"}} {
         catch {r ACL SETUSER selector-syntax on (&* &fail)} e
         assert_match "*ERR Error in ACL SETUSER modifier '(*)*Adding a pattern after the*" $e
 
+        catch {r ACL SETUSER selector-syntax on (+PING (+SELECT (+DEL} e
+        assert_match "*ERR Unmatched parenthesis in acl selector*" $e
+
+        catch {r ACL SETUSER selector-syntax on (+PING (+SELECT (+DEL ) ) ) } e
+        assert_match "*ERR Error in ACL SETUSER modifier*" $e
+
+        catch {r ACL SETUSER selector-syntax on (+PING (+SELECT (+DEL ) } e
+        assert_match "*ERR Error in ACL SETUSER modifier*" $e
+
         assert_equal "" [r ACL GETUSER selector-syntax]
     }
 


### PR DESCRIPTION
When doing merge selector, we should check whether the merge has started (i.e., whether open_bracket_start is -1) every time. Otherwise, encountering an illegal selector pattern could succeed and also cause memory leaks, for example:

```
acl setuser test1 (+PING (+SELECT (+DEL )
```

The above would leak memory and succeed with only DEL being applied, and would now error after the fix.