### PR TITLE
do not call handleClientsBlockedOnKeys inside yielding command

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4158,7 +4158,7 @@ int processCommand(client *c) {
         int flags = CMD_CALL_FULL;
         if (client_reprocessing_command) flags |= CMD_CALL_REPROCESSING;
         call(c,flags);
-        if (listLength(server.ready_keys))
+        if (listLength(server.ready_keys) && !isInsideYieldingLongCommand())
             handleClientsBlockedOnKeys();
     }
 

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1113,7 +1113,7 @@ start_server {tags {"scripting"}} {
     } {PONG}
 
     test {Timedout scripts and unblocked command} {
-        # make sure a command that's allowed during BUSY doens't trigger an unblocked command
+        # make sure a command that's allowed during BUSY doesn't trigger an unblocked command
 
         # enable AOF to also expose an assertion if the bug would happen
         r flushall


### PR DESCRIPTION
Fix the assertion when a busy script (timeout) signal ready keys (like LPUSH), and then an arbitrary client's `allow-busy` command steps into `handleClientsBlockedOnKeys` try wake up clients blocked on keys (like BLPOP).

```
=== REDIS BUG REPORT START: Cut & paste starting from here ===
34266:M 03 Aug 2023 16:59:07.807 # === ASSERTION FAILED ===
34266:M 03 Aug 2023 16:59:07.807 # ==> blocked.c:326 'server.also_propagate.numops == 0' is not true

------ STACK TRACE ------

Backtrace:
./redis-server *:6379[0x4c624e]
./redis-server *:6379(processCommand+0xa8f)[0x580e5f]
./redis-server *:6379(processInputBuffer+0xe1)[0x569c21]
./redis-server *:6379(readQueryFromClient+0x300)[0x55d910]
./redis-server *:6379[0x46a9c8]
./redis-server *:6379(aeProcessEvents+0xba)[0x58f09a]
./redis-server *:6379(processEventsWhileBlocked+0xa1)[0x55b171]
./redis-server *:6379(scriptInterrupt+0x133)[0x4640c3]
./redis-server *:6379[0x4658fb]
./redis-server *:6379[0x5a0825]
./redis-server *:6379[0x5aa0aa]
./redis-server *:6379[0x5a0fc5]
./redis-server *:6379[0x5a0358]
./redis-server *:6379[0x5a114d]
./redis-server *:6379(lua_pcall+0x46)[0x59eb06]
./redis-server *:6379(luaCallFunction+0x1c1)[0x4655d1]
./redis-server *:6379(evalGenericCommand+0x16e)[0x4e327e]
./redis-server *:6379(call+0x140)[0x57fd60]
./redis-server *:6379(processCommand+0xa78)[0x580e48]
./redis-server *:6379(processInputBuffer+0xe1)[0x569c21]
./redis-server *:6379(readQueryFromClient+0x300)[0x55d910]
./redis-server *:6379[0x46a9c8]
./redis-server *:6379(aeMain+0xf9)[0x585b29]
./redis-server *:6379(main+0x395)[0x4527f5]
/lib64/libc.so.6(__libc_start_main+0xf5)[0x7f588d2e6555]
./redis-server *:6379[0x452f39]

------ CLIENT LIST OUTPUT ------
id=5 addr=127.0.0.1:51834 laddr=127.0.0.1:6379 fd=8 name= age=8 idle=8 flags=b db=0 sub=0 psub=0 ssub=0 multi=-1 qbuf=0 qbuf-free=0 argv-mem=7 multi-mem=0 rbs=1024 rbp=0 obl=0 oll=0 omem=0 tot-mem=1959 events=r cmd=blpop user=default redir=-1 resp=2 lib-name= lib-ver=
id=6 addr=127.0.0.1:51846 laddr=127.0.0.1:6379 fd=9 name= age=5 idle=5 flags=N db=0 sub=0 psub=0 ssub=0 multi=-1 qbuf=87 qbuf-free=20387 argv-mem=64 multi-mem=0 rbs=16384 rbp=16384 obl=0 oll=0 omem=0 tot-mem=37848 events= cmd=eval user=default redir=-1 resp=2 lib-name= lib-ver=
id=7 addr=127.0.0.1:51852 laddr=127.0.0.1:6379 fd=10 name= age=0 idle=0 flags=N db=0 sub=0 psub=0 ssub=0 multi=-1 qbuf=21 qbuf-free=20453 argv-mem=5 multi-mem=0 rbs=16384 rbp=16384 obl=127 oll=0 omem=0 tot-mem=37781 events=r cmd=auth user=default redir=-1 resp=2 lib-name= lib-ver=

------ CURRENT CLIENT INFO ------
id=7 addr=127.0.0.1:51852 laddr=127.0.0.1:6379 fd=10 name= age=0 idle=0 flags=N db=0 sub=0 psub=0 ssub=0 multi=-1 qbuf=21 qbuf-free=20453 argv-mem=5 multi-mem=0 rbs=16384 rbp=16384 obl=127 oll=0 omem=0 tot-mem=37781 events=r cmd=auth user=default redir=-1 resp=2 lib-name= lib-ver=
argc: '2'
argv[0]: '"auth"'
34266:M 03 Aug 2023 16:59:07.809 # key 'a' found in DB containing the following object:
34266:M 03 Aug 2023 16:59:07.809 # Object type: 1
34266:M 03 Aug 2023 16:59:07.809 # Object encoding: 11
34266:M 03 Aug 2023 16:59:07.809 # Object refcount: 1

------ EXECUTING CLIENT INFO ------
id=6 addr=127.0.0.1:51846 laddr=127.0.0.1:6379 fd=9 name= age=5 idle=5 flags=N db=0 sub=0 psub=0 ssub=0 multi=-1 qbuf=87 qbuf-free=20387 argv-mem=64 multi-mem=0 rbs=16384 rbp=16384 obl=0 oll=0 omem=0 tot-mem=37848 events= cmd=eval user=default redir=-1 resp=2 lib-name= lib-ver=
argc: '3'
argv[0]: '"eval"'
argv[1]: '"redis.call('lpush','a','b') local a=1 while(1) do a=a+1 end"'
argv[2]: '"0"'
```

Reproduction process:
1. start a redis with aof
    `./redis-server --appendonly yes`
2. exec blpop
    `127.0.0.1:6379> blpop a 0`
3. use another client call a busy script and this script push the blocked key
    `127.0.0.1:6379> eval "redis.call('lpush','a','b') while(1) do end" 0`
4. user a new client call an allow-busy command like auth
    `127.0.0.1:6379> auth a`

BTW, this issue also break the atomicity of script.

This bug has been around for many years, the old versions only have the atomic problem, only 7.0/7.2 has the assertion problem.