### PR TITLE
[WIP] - No error or warning to the client when section is misspelled in info command.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6269,7 +6269,7 @@ void infoCommand(client *c) {
     char *sections[] = {
         "default", "all", "everything", "server", "clients", "memory", "persistence",
         "stats", "replication", "cpu", "module_list", "modules", "commandstats",
-        "errorstats", "latencystats", "cluster", "keyspace", "debug", NULL};
+        "errorstats", "latencystats", "cluster", "keyspace", "debug", "sentinel", NULL};
     int matched = 0;
     for (int i = 1; i < c->argc; i++) {
         matched = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -6266,6 +6266,24 @@ void infoCommand(client *c) {
     }
     int all_sections = 0;
     int everything = 0;
+    char *sections[] = {
+        "default", "all", "everything", "server", "clients", "memory", "persistence",
+        "stats", "replication", "cpu", "module_list", "modules", "commandstats",
+        "errorstats", "latencystats", "cluster", "keyspace", "debug", NULL};
+    int matched = 0;
+    for (int i = 1; i < c->argc; i++) {
+        matched = 0;
+        for (int j=0; sections[j] != NULL; j++) {
+            if (!strcasecmp(c->argv[i]->ptr, sections[j])) {
+                matched++;
+                break;
+            }
+        }
+        if (!matched) {
+            addReplyErrorFormat(c,"Invalid section '%s' to INFO [section [section ...]]",(char *)c->argv[i]->ptr);
+            return;
+        }
+    }
     dict *sections_dict = genInfoSectionDict(c->argv+1, c->argc-1, NULL, &all_sections, &everything);
     sds info = genRedisInfoString(sections_dict, all_sections, everything);
     addReplyVerbatim(c,info,sdslen(info),"txt");


### PR DESCRIPTION
No error for info command section was mispelled, added the check at the starting of the info command api for all the available options of the command. 

Actual results:

```
127.0.0.1:6379> info keyspaceee
127.0.0.1:6379>
127.0.0.1:6379> info keyspacer
127.0.0.1:6379> info cpuuu

```
After the changes:
```

127.0.0.1:6379> info cpuuu
ERR Invalid section 'cpuuu' to INFO [section [section ...]]
127.0.0.1:6379>
127.0.0.1:6379> info cpu
# CPU
used_cpu_sys:0.023133
used_cpu_user:0.024970
used_cpu_sys_children:0.000000
used_cpu_user_children:0.000000
used_cpu_sys_main_thread:0.021886
used_cpu_user_main_thread:0.025534
127.0.0.1:6379>
127.0.0.1:6379> info keyspacer
ERR Invalid section 'keyspacer' to INFO [section [section ...]]
127.0.0.1:6379>
127.0.0.1:6379> info keyspace
# Keyspace
127.0.0.1:6379>
127.0.0.1:6379> info clusters
ERR Invalid section 'clusters' to INFO [section [section ...]]
127.0.0.1:6379>
127.0.0.1:6379> info cluster
# Cluster
cluster_enabled:0
127.0.0.1:6379>

```