### PR TITLE
Fix overflow calculation for next timer event

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -333,7 +333,7 @@ static int processTimeEvents(aeEventLoop *eventLoop) {
             processed++;
             now = getMonotonicUs();
             if (retval != AE_NOMORE) {
-                te->when = now + (uint64_t)retval * 1000;
+                te->when = now + (monotime)retval * 1000;
             } else {
                 te->id = AE_DELETED_EVENT_ID;
             }

--- a/src/ae.c
+++ b/src/ae.c
@@ -333,7 +333,7 @@ static int processTimeEvents(aeEventLoop *eventLoop) {
             processed++;
             now = getMonotonicUs();
             if (retval != AE_NOMORE) {
-                te->when = now + retval * 1000;
+                te->when = now + (uint64_t)retval * 1000;
             } else {
                 te->id = AE_DELETED_EVENT_ID;
             }


### PR DESCRIPTION
Proposing a fix for an overflow bug when calculating the next event for a timer. 

Please find a Redis module which recreates the issue here: https://github.com/nirrattner/RedisModuleTimerExample

The `retval` variable is defined as an `int`, so with 4 bytes, it cannot properly represent microsecond values greater than the equivalent of about 35 minutes. 

This bug shouldn't impact standard Redis behavior because I don't believe Redis has timer events that are scheduled as far as 35 minutes out, but it may affect custom Redis modules which interact with the event timers via the [`RedisModule_CreateTimer`](https://redis.io/docs/reference/modules/modules-api-ref/#redismodule_createtimer) functionality.

The impact is that [`usUntilEarliestTimer` may return 0](https://github.com/redis/redis/blob/7c179f9bf4390512196b3a2b2ad6d0f4cb625c8a/src/ae.c#L276) for as long as `retval` is scaled to an overflowing value. While `usUntilEarliestTimer` continues to return `0`, `aeApiPoll` will have a zero timeout, and so Redis will use significantly more CPU iterating through its event loop without pause. For timers scheduled far enough into the future, Redis will cycle between ~35 minute periods of high CPU usage and ~35 minute periods of standard CPU usage.