### PR TITLE
feat: reuse RedisModuleCronLoopV1 add activeRehashing hasActiveChildProcess 

### DIFF
--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -781,6 +781,16 @@ typedef struct RedisModuleCronLoopInfo {
     int32_t hz;             /* Approximate number of events per second. */
 } RedisModuleCronLoopV1;
 
+#define REDISMODULE_CRON_LOOP_VERSION_2 2
+typedef struct RedisModuleCronLoopInfoV2 {
+    uint64_t version; /* Not used since this structure is never passed
+                         from the module to the core right now. Here
+                         for future compatibility. */
+    int32_t hz;       /* Approximate number of events per second. */
+    int activeRehashing;
+    int hasActiveChildProcess;
+} RedisModuleCronLoopV2;
+
 #define RedisModuleCronLoop RedisModuleCronLoopV1
 
 #define REDISMODULE_LOADING_PROGRESS_VERSION 1

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -779,17 +779,9 @@ typedef struct RedisModuleCronLoopInfo {
                                from the module to the core right now. Here
                                for future compatibility. */
     int32_t hz;             /* Approximate number of events per second. */
-} RedisModuleCronLoopV1;
-
-#define REDISMODULE_CRON_LOOP_VERSION_2 2
-typedef struct RedisModuleCronLoopInfoV2 {
-    uint64_t version; /* Not used since this structure is never passed
-                         from the module to the core right now. Here
-                         for future compatibility. */
-    int32_t hz;       /* Approximate number of events per second. */
     int activeRehashing;
     int hasActiveChildProcess;
-} RedisModuleCronLoopV2;
+} RedisModuleCronLoopV1;
 
 #define RedisModuleCronLoop RedisModuleCronLoopV1
 

--- a/src/server.c
+++ b/src/server.c
@@ -1514,7 +1514,8 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     }
 
     /* Fire the cron loop modules event. */
-    RedisModuleCronLoopV1 ei = {REDISMODULE_CRON_LOOP_VERSION,server.hz};
+    //RedisModuleCronLoopV1 ei = {REDISMODULE_CRON_LOOP_VERSION,server.hz};
+    RedisModuleCronLoopV2 ei = {REDISMODULE_CRON_LOOP_VERSION,server.hz,server.activerehashing,hasActiveChildProcess()};
     moduleFireServerEvent(REDISMODULE_EVENT_CRON_LOOP,
                           0,
                           &ei);

--- a/src/server.c
+++ b/src/server.c
@@ -1514,8 +1514,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     }
 
     /* Fire the cron loop modules event. */
-    //RedisModuleCronLoopV1 ei = {REDISMODULE_CRON_LOOP_VERSION,server.hz};
-    RedisModuleCronLoopV2 ei = {REDISMODULE_CRON_LOOP_VERSION,server.hz,server.activerehashing,hasActiveChildProcess()};
+    RedisModuleCronLoop ei = {REDISMODULE_CRON_LOOP_VERSION,server.hz,server.activerehashing,hasActiveChildProcess()};
     moduleFireServerEvent(REDISMODULE_EVENT_CRON_LOOP,
                           0,
                           &ei);


### PR DESCRIPTION
reuse RedisModuleCronLoopV1 add activeRehashing hasActiveChildProcess ,
use RedisModule_SubscribeToServerEvent sub RedisModuleEvent_CronLoop to do resize, rehash dict, so want check `server.activerehashing`,`hasActiveChildProcess()`