### PR TITLE
Allows modules to declare new ACL categories.

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -117,7 +117,8 @@ int ACLAddCommandCategory(const char *name, uint64_t flag) {
 void ACLInitCommandCategories(void) {
     ACLCommandCategories = zcalloc(sizeof(struct ACLCategoryItem) * (ACL_MAX_CATEGORIES +1));
     for (int j = 0; ACLDefaultCommandCategories[j].flag; j++) {
-        serverAssert(ACLAddCommandCategory(ACLDefaultCommandCategories[j].name, ACLDefaultCommandCategories[j].flag) == C_OK);
+        int result = ACLAddCommandCategory(ACLDefaultCommandCategories[j].name, ACLDefaultCommandCategories[j].flag);
+        serverAssert(result == C_OK);
     }
 }
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -96,6 +96,10 @@ static size_t nextCommandCategory = 0; /* Index of the next command category to 
  * also requires a bit in the acl_categories flag, there is a limit to the number that can be added.
  * The new ACL categories occupy the remaining bits of acl_categories flag, other than the bits
  * occupied by the default ACL command categories.
+ * 
+ * The optional `flag` argument allows the assignment of the `acl_categories` flag bit to the ACL category.
+ * When adding a new category, except for the default ACL command categories, this arguments should be `0`
+ * to allow the function to assign the next available `acl_categories` flag bit to the new ACL category.
  *
  * returns C_OK -> Added, C_ERR -> Failed (out of space)
  *

--- a/src/acl.c
+++ b/src/acl.c
@@ -95,7 +95,7 @@ struct ACLCategoryItem ACLDefaultCommandCategories[] = { /* See redis.conf for d
 
 /* Implements the ability to add to the list of ACL categories at runtime. Since each ACL category
  * also requires a bit in the acl_categories flag, there is a limit to the number that can be added.
- * The new ACL categories occupy the remaing bits of acl_categories flag, other than the bits
+ * The new ACL categories occupy the remaining bits of acl_categories flag, other than the bits
  * occupied by the default ACL command categories.
  *
  * returns C_OK -> Added, C_ERR -> Failed (out of space)

--- a/src/acl.c
+++ b/src/acl.c
@@ -64,8 +64,8 @@ static unsigned long nextid = 0; /* Next command id that has not been assigned *
 struct ACLCategoryItem {
     char *name;
     uint64_t flag;
-}; 
-static struct *ACLCommandCategories = NULL;
+};
+static struct ACLCategoryItem *ACLCommandCategories = NULL;
 
 static size_t nextCommandCategory = 0; /* Index of the next command category to be added */
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -64,12 +64,7 @@ static unsigned long nextid = 0; /* Next command id that has not been assigned *
 struct ACLCategoryItem {
     char *name;
     uint64_t flag;
-};
-static struct ACLCategoryItem *ACLCommandCategories = NULL;
-
-static size_t nextCommandCategory = 0; /* Index of the next command category to be added */
-
-struct ACLCategoryItem ACLDefaultCommandCategories[] = { /* See redis.conf for details on each category. */
+} ACLDefaultCommandCategories[] = { /* See redis.conf for details on each category. */
     {"keyspace", ACL_CATEGORY_KEYSPACE},
     {"read", ACL_CATEGORY_READ},
     {"write", ACL_CATEGORY_WRITE},
@@ -93,6 +88,9 @@ struct ACLCategoryItem ACLDefaultCommandCategories[] = { /* See redis.conf for d
     {"scripting", ACL_CATEGORY_SCRIPTING},
     {NULL,0} /* Terminator. */
 };
+
+static struct ACLCategoryItem *ACLCommandCategories = NULL;
+static size_t nextCommandCategory = 0; /* Index of the next command category to be added */
 
 /* Implements the ability to add to the list of ACL categories at runtime. Since each ACL category
  * also requires a bit in the acl_categories flag, there is a limit to the number that can be added.

--- a/src/acl.c
+++ b/src/acl.c
@@ -117,7 +117,7 @@ int ACLAddCommandCategory(const char *name, uint64_t flag) {
  * new ACL categories.
  */
 void ACLInitCommandCategories(void) {
-    ACLCommandCategories = zcalloc(sizeof(struct ACLCategoryItem) * (ACL_MAX_CATEGORIES +1));
+    ACLCommandCategories = zcalloc(sizeof(struct ACLCategoryItem) * (ACL_MAX_CATEGORIES + 1));
     for (int j = 0; ACLDefaultCommandCategories[j].flag; j++) {
         int result = ACLAddCommandCategory(ACLDefaultCommandCategories[j].name, ACLDefaultCommandCategories[j].flag);
         serverAssert(result == C_OK);

--- a/src/acl.c
+++ b/src/acl.c
@@ -64,7 +64,8 @@ static unsigned long nextid = 0; /* Next command id that has not been assigned *
 struct ACLCategoryItem {
     char *name;
     uint64_t flag;
-} static *ACLCommandCategories = NULL;
+}; 
+static struct *ACLCommandCategories = NULL;
 
 static size_t nextCommandCategory = 0; /* Index of the next command category to be added */
 
@@ -102,7 +103,7 @@ struct ACLCategoryItem ACLDefaultCommandCategories[] = { /* See redis.conf for d
  *
  * This function is present here to gain access to the ACLCommandCategories array and add a new ACL category.
  */
-int ACLAddCommandCategory(const char *name, int flag) {
+int ACLAddCommandCategory(const char *name, uint64_t flag) {
     if (nextCommandCategory >= ACL_MAX_CATEGORIES) return C_ERR;
     ACLCommandCategories[nextCommandCategory].name = zstrdup(name);
     ACLCommandCategories[nextCommandCategory].flag = flag != 0 ? flag : (1ULL<<nextCommandCategory);
@@ -110,7 +111,7 @@ int ACLAddCommandCategory(const char *name, int flag) {
     return C_OK;
 }
 
-/* Initializes ACLCommandCategories with default ACL categories and allocates space of 
+/* Initializes ACLCommandCategories with default ACL categories and allocates space for 
  * new ACL categories.
  */
 void ACLInitCommandCategories(void) {

--- a/src/module.c
+++ b/src/module.c
@@ -505,6 +505,10 @@ static struct redisCommandArg *moduleCopyCommandArgs(RedisModuleCommandArg *args
 static redisCommandArgType moduleConvertArgType(RedisModuleCommandArgType type, int *error);
 static int moduleConvertArgFlags(int flags);
 void moduleCreateContext(RedisModuleCtx *out_ctx, RedisModule *module, int ctx_flags);
+
+/* Common help fundctions. */
+int moduleVerifyName(const char *name);
+
 /* --------------------------------------------------------------------------
  * ## Heap allocation raw functions
  *
@@ -1445,25 +1449,6 @@ int populateArgsStructure(struct redisCommandArg *args) {
         args++;
     }
     return count;
-}
-
-int moduleVerifyName(const char *name) {
-    if (strlen(name) == 0) {
-        return REDISMODULE_ERR;
-    }
-
-    for (size_t i = 0; i < strlen(name); i++) {
-        char curr_char = name[i];
-        if ((curr_char >= 'a' && curr_char <= 'z') ||
-            (curr_char >= 'A' && curr_char <= 'Z') ||
-            (curr_char >= '0' && curr_char <= '9') ||
-            (curr_char == '_') || (curr_char == '-'))
-        {
-            continue;
-        }
-        return C_ERR;
-    }
-    return C_OK;
 }
 
 /* RedisModule_AddACLCategory can be used to add new ACL command categories. Category names
@@ -12482,6 +12467,25 @@ int moduleVerifyConfigFlags(unsigned int flags, configType type) {
         return REDISMODULE_ERR;
     }
     return REDISMODULE_OK;
+}
+
+int moduleVerifyName(const char *name) {
+    if (strlen(name) == 0) {
+        return REDISMODULE_ERR;
+    }
+
+    for (size_t i = 0; i < strlen(name); i++) {
+        char curr_char = name[i];
+        if ((curr_char >= 'a' && curr_char <= 'z') ||
+            (curr_char >= 'A' && curr_char <= 'Z') ||
+            (curr_char >= '0' && curr_char <= '9') ||
+            (curr_char == '_') || (curr_char == '-'))
+        {
+            continue;
+        }
+        return C_ERR;
+    }
+    return C_OK;
 }
 
 /* This is a series of set functions for each type that act as dispatchers for 

--- a/src/module.c
+++ b/src/module.c
@@ -12472,11 +12472,11 @@ int moduleVerifyConfigFlags(unsigned int flags, configType type) {
 /* Verify a module resource or name has only alphanumeric characters, underscores
  * or dashes. */
 int moduleVerifyResourceName(const char *name) {
-    if (strlen(name) == 0) {
+    if (name[0] == '\0') {
         return REDISMODULE_ERR;
     }
 
-    for (size_t i = 0; i < strlen(name); i++) {
+    for (size_t i = 0; name[i] != '\0'; i++) {
         char curr_char = name[i];
         if ((curr_char >= 'a' && curr_char <= 'z') ||
             (curr_char >= 'A' && curr_char <= 'Z') ||

--- a/src/module.c
+++ b/src/module.c
@@ -1452,7 +1452,7 @@ int moduleVerifyName(const char *name) {
         return REDISMODULE_ERR;
     }
 
-    for (size_t i = 0 ; i < strlen(name) ; ++i) {
+    for (size_t i = 0; i < strlen(name); i++) {
         char curr_char = name[i];
         if ((curr_char >= 'a' && curr_char <= 'z') ||
             (curr_char >= 'A' && curr_char <= 'Z') ||
@@ -1466,8 +1466,10 @@ int moduleVerifyName(const char *name) {
     return C_OK;
 }
 
-/* RedisModule_AddACLCategory can be used to add new ACL command categories.
- * This function can only be called during the RedisModule_OnLoad function.
+/* RedisModule_AddACLCategory can be used to add new ACL command categories. Category names
+ * can only contain alphanumeric characters, underscores, or dashes. Categories can only be added
+ * during the RedisModule_OnLoad function. Once a category has been added, it can not be removed. 
+ * Any module can register a command to any added categories using RedisModule_SetCommandACLCategories.
  * 
  * Returns:
  * - REDISMODULE_OK on successfully adding the new ACL category. 
@@ -1475,8 +1477,8 @@ int moduleVerifyName(const char *name) {
  * 
  * On error the errno is set to:
  * - EINVAL if the name contains invalid characters.
- * - EBUSY if categoty name already exists.
- * - ENOMEM if number of categories reach the max limit of 64 categories.
+ * - EBUSY if the category name is already in use.
+ * - ENOMEM if the number of categories reached the max limit of 64 categories.
  */
 int RM_AddACLCategory(RedisModuleCtx *ctx, const char *name) {
     if (!ctx->module->onload) {

--- a/src/module.c
+++ b/src/module.c
@@ -12476,7 +12476,7 @@ int moduleVerifyResourceName(const char *name) {
         return REDISMODULE_ERR;
     }
 
-    for (size_t i = 0 ; i < sdslen(name) ; ++i) {
+    for (size_t i = 0; i < strlen(name); i++) {
         char curr_char = name[i];
         if ((curr_char >= 'a' && curr_char <= 'z') ||
             (curr_char >= 'A' && curr_char <= 'Z') ||

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -968,6 +968,7 @@ REDISMODULE_API RedisModuleCommand *(*RedisModule_GetCommand)(RedisModuleCtx *ct
 REDISMODULE_API int (*RedisModule_CreateSubcommand)(RedisModuleCommand *parent, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandInfo)(RedisModuleCommand *command, const RedisModuleCommandInfo *info) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandACLCategories)(RedisModuleCommand *command, const char *ctgrsflags) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_AddACLCategory)(RedisModuleCtx *ctx, const char *name) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetModuleAttribs)(RedisModuleCtx *ctx, const char *name, int ver, int apiver) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsModuleNameBusy)(const char *name) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_WrongArity)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -1329,6 +1330,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(CreateSubcommand);
     REDISMODULE_GET_API(SetCommandInfo);
     REDISMODULE_GET_API(SetCommandACLCategories);
+    REDISMODULE_GET_API(AddACLCategory);
     REDISMODULE_GET_API(SetModuleAttribs);
     REDISMODULE_GET_API(IsModuleNameBusy);
     REDISMODULE_GET_API(WrongArity);

--- a/src/server.h
+++ b/src/server.h
@@ -2927,7 +2927,7 @@ int ACLSetUser(user *u, const char *op, ssize_t oplen);
 sds ACLStringSetUser(user *u, sds username, sds *argv, int argc);
 uint64_t ACLGetCommandCategoryFlagByName(const char *name);
 int ACLAddCommandCategory(const char *name, uint64_t flag);
-void ACLCleanupAddedCommandCategories(size_t num_acl_categories_added);
+void ACLCleanupCategoriesOnFailure(size_t num_acl_categories_added);
 int ACLAppendUserForLoading(sds *argv, int argc, int *argc_err);
 const char *ACLSetUserStringError(void);
 int ACLLoadConfiguredUsers(void);

--- a/src/server.h
+++ b/src/server.h
@@ -821,6 +821,7 @@ struct RedisModule {
     struct moduleLoadQueueEntry *loadmod; /* Module load arguments for config rewrite. */
     int num_commands_with_acl_categories; /* Number of commands in this module included in acl categories */
     int onload;     /* Flag to identify if the call is being made from Onload (0 or 1) */
+    size_t num_acl_categories_added; /* Number of acl categories added by this module. */
 };
 typedef struct RedisModule RedisModule;
 
@@ -2925,6 +2926,8 @@ int ACLCheckAllPerm(client *c, int *idxptr);
 int ACLSetUser(user *u, const char *op, ssize_t oplen);
 sds ACLStringSetUser(user *u, sds username, sds *argv, int argc);
 uint64_t ACLGetCommandCategoryFlagByName(const char *name);
+int ACLAddCommandCategory(const char *name, int flag);
+void ACLCleanupAddedCommandCategories(size_t num_acl_categories_added);
 int ACLAppendUserForLoading(sds *argv, int argc, int *argc_err);
 const char *ACLSetUserStringError(void);
 int ACLLoadConfiguredUsers(void);

--- a/src/server.h
+++ b/src/server.h
@@ -2926,7 +2926,7 @@ int ACLCheckAllPerm(client *c, int *idxptr);
 int ACLSetUser(user *u, const char *op, ssize_t oplen);
 sds ACLStringSetUser(user *u, sds username, sds *argv, int argc);
 uint64_t ACLGetCommandCategoryFlagByName(const char *name);
-int ACLAddCommandCategory(const char *name, int flag);
+int ACLAddCommandCategory(const char *name, uint64_t flag);
 void ACLCleanupAddedCommandCategories(size_t num_acl_categories_added);
 int ACLAppendUserForLoading(sds *argv, int argc, int *argc_err);
 const char *ACLSetUserStringError(void);

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -197,6 +197,9 @@ int commandBlockCheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     int result = RedisModule_CreateCommand(ctx,"command.that.should.fail", module_test_acl_category, "", 0, 0, 0);
     response_ok |= (result == REDISMODULE_OK);
 
+    result  = RedisModule_AddACLCategory(ctx,"blockedcategory");
+    response_ok |= (result == REDISMODULE_OK);
+    
     RedisModuleCommand *parent = RedisModule_GetCommand(ctx,"block.commands.outside.onload");
     result = RedisModule_SetCommandACLCategories(parent, "write");
     response_ok |= (result == REDISMODULE_OK);
@@ -204,7 +207,8 @@ int commandBlockCheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     result = RedisModule_CreateSubcommand(parent,"subcommand.that.should.fail",module_test_acl_category,"",0,0,0);
     response_ok |= (result == REDISMODULE_OK);
     
-    /* This validates that it's not possible to create commands outside OnLoad,
+    /* This validates that it's not possible to create commands or add
+     * a new ACL Category outside OnLoad function.
      * thus returns an error if they succeed. */
     if (response_ok) {
         RedisModule_ReplyWithError(ctx, "UNEXPECTEDOK");
@@ -215,11 +219,24 @@ int commandBlockCheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 }
 
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    REDISMODULE_NOT_USED(argv);
-    REDISMODULE_NOT_USED(argc);
 
     if (RedisModule_Init(ctx,"aclcheck",1,REDISMODULE_APIVER_1)== REDISMODULE_ERR)
         return REDISMODULE_ERR;
+
+    if (argc != 1) return RedisModule_WrongArity(ctx);
+
+    long long fail_flag = 0;
+    RedisModule_StringToLongLong(argv[0], &fail_flag);
+    if (fail_flag) {
+        for (size_t j = 0; j < 45; j++) {
+            RedisModuleString* name =  RedisModule_CreateStringPrintf(ctx, "customcategory%zu", j);
+            if (RedisModule_AddACLCategory(ctx, RedisModule_StringPtrLen(name, NULL)) == REDISMODULE_ERR) {
+                RedisModule_FreeString(ctx, name);
+                return REDISMODULE_ERR;
+            }
+            RedisModule_FreeString(ctx, name);
+        }
+    }
 
     if (RedisModule_CreateCommand(ctx,"aclcheck.set.check.key", set_aclcheck_key,"write",0,0,0) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
@@ -265,5 +282,15 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                                       "write",0,0,0) == REDISMODULE_ERR)
             return REDISMODULE_ERR;
 
+    if (RedisModule_AddACLCategory(ctx,"foocategory") == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    
+    if (RedisModule_CreateCommand(ctx,"aclcheck.module.command.test.add.new.aclcategories", module_test_acl_category,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    RedisModuleCommand *test_add_new_aclcategories = RedisModule_GetCommand(ctx,"aclcheck.module.command.test.add.new.aclcategories");
+
+    if (RedisModule_SetCommandACLCategories(test_add_new_aclcategories, "foocategory") == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    
     return REDISMODULE_OK;
 }

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -223,18 +223,20 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_Init(ctx,"aclcheck",1,REDISMODULE_APIVER_1)== REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
-    if (argc != 1) return RedisModule_WrongArity(ctx);
-
-    long long fail_flag = 0;
-    RedisModule_StringToLongLong(argv[0], &fail_flag);
-    if (fail_flag) {
-        for (size_t j = 0; j < 45; j++) {
-            RedisModuleString* name =  RedisModule_CreateStringPrintf(ctx, "customcategory%zu", j);
-            if (RedisModule_AddACLCategory(ctx, RedisModule_StringPtrLen(name, NULL)) == REDISMODULE_ERR) {
+    /* When that flag is passed, we try to create too many categories,
+     * and the test expects this to fail. */
+    if (argc == 1) {
+        long long fail_flag = 0;
+        RedisModule_StringToLongLong(argv[0], &fail_flag);
+        if (fail_flag) {
+            for (size_t j = 0; j < 45; j++) {
+                RedisModuleString* name =  RedisModule_CreateStringPrintf(ctx, "customcategory%zu", j);
+                if (RedisModule_AddACLCategory(ctx, RedisModule_StringPtrLen(name, NULL)) == REDISMODULE_ERR) {
+                    RedisModule_FreeString(ctx, name);
+                    return REDISMODULE_ERR;
+                }
                 RedisModule_FreeString(ctx, name);
-                return REDISMODULE_ERR;
             }
-            RedisModule_FreeString(ctx, name);
         }
     }
 

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -223,6 +223,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_Init(ctx,"aclcheck",1,REDISMODULE_APIVER_1)== REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
+    if (argc > 1) return RedisModule_WrongArity(ctx);
+    
     /* When that flag is passed, we try to create too many categories,
      * and the test expects this to fail. */
     if (argc == 1) {

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -197,7 +197,7 @@ int commandBlockCheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     int result = RedisModule_CreateCommand(ctx,"command.that.should.fail", module_test_acl_category, "", 0, 0, 0);
     response_ok |= (result == REDISMODULE_OK);
 
-    result  = RedisModule_AddACLCategory(ctx,"blockedcategory");
+    result = RedisModule_AddACLCategory(ctx,"blockedcategory");
     response_ok |= (result == REDISMODULE_OK);
     
     RedisModuleCommand *parent = RedisModule_GetCommand(ctx,"block.commands.outside.onload");

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -1,7 +1,7 @@
 set testmodule [file normalize tests/modules/aclcheck.so]
 
 start_server {tags {"modules acl"}} {
-    r module load $testmodule 0
+    r module load $testmodule
 
     test {test module check acl for command perm} {
         # by default all commands allowed
@@ -112,7 +112,7 @@ start_server {tags {"modules acl"}} {
 start_server {tags {"modules acl"}} {
     test {test existing users to have access to module commands loaded on runtime} {
         r acl SETUSER j3 on >password -@all +@WRITE
-        assert_equal [r module load $testmodule 0] OK
+        assert_equal [r module load $testmodule] OK
         assert_equal [r acl DRYRUN j3 aclcheck.module.command.aclcategories.write] OK
         assert_equal {OK} [r module unload aclcheck]
     }
@@ -122,7 +122,7 @@ start_server {tags {"modules acl"}} {
     test {test existing users without permissions, do not have access to module commands loaded on runtime.} {
         r acl SETUSER j4 on >password -@all +@READ
         r acl SETUSER j5 on >password -@all +@WRITE
-        assert_equal [r module load $testmodule 0] OK
+        assert_equal [r module load $testmodule] OK
         catch {r acl DRYRUN j4 aclcheck.module.command.aclcategories.write} e
         assert_equal {User j4 has no permissions to run the 'aclcheck.module.command.aclcategories.write' command} $e
         catch {r acl DRYRUN j5 aclcheck.module.command.aclcategories.write.function.read.category} e
@@ -154,6 +154,5 @@ start_server {tags {"modules acl"}} {
 start_server {tags {"modules acl"}} {
     test {test module load fails if exceeds the maximum number of adding acl categories} {
         assert_error {ERR Error loading the extension. Please check the server logs.} {r module load $testmodule 1}
-        assert_equal [r module load $testmodule 0] OK
     }
 }

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -1,7 +1,7 @@
 set testmodule [file normalize tests/modules/aclcheck.so]
 
 start_server {tags {"modules acl"}} {
-    r module load $testmodule
+    r module load $testmodule 0
 
     test {test module check acl for command perm} {
         # by default all commands allowed
@@ -104,18 +104,25 @@ start_server {tags {"modules acl"}} {
         assert_equal [r acl DRYRUN j2 aclcheck.module.command.aclcategories.read.only.category] OK
     }
 
-    test {test existing users to have access to module commands loaded on runtime} {
-        assert_equal [r module unload aclcheck] OK
-        r acl SETUSER j3 on >password -@all +@WRITE
-        assert_equal [r module load $testmodule] OK
-        assert_equal [r acl DRYRUN j3 aclcheck.module.command.aclcategories.write] OK
+    test {Unload the module - aclcheck} {
+        assert_equal {OK} [r module unload aclcheck]
     }
+}
 
+start_server {tags {"modules acl"}} {
+    test {test existing users to have access to module commands loaded on runtime} {
+        r acl SETUSER j3 on >password -@all +@WRITE
+        assert_equal [r module load $testmodule 0] OK
+        assert_equal [r acl DRYRUN j3 aclcheck.module.command.aclcategories.write] OK
+        assert_equal {OK} [r module unload aclcheck]
+    }
+}
+
+start_server {tags {"modules acl"}} {
     test {test existing users without permissions, do not have access to module commands loaded on runtime.} {
-        assert_equal [r module unload aclcheck] OK
         r acl SETUSER j4 on >password -@all +@READ
         r acl SETUSER j5 on >password -@all +@WRITE
-        assert_equal [r module load $testmodule] OK
+        assert_equal [r module load $testmodule 0] OK
         catch {r acl DRYRUN j4 aclcheck.module.command.aclcategories.write} e
         assert_equal {User j4 has no permissions to run the 'aclcheck.module.command.aclcategories.write' command} $e
         catch {r acl DRYRUN j5 aclcheck.module.command.aclcategories.write.function.read.category} e
@@ -131,7 +138,22 @@ start_server {tags {"modules acl"}} {
         assert_equal {User j7 has no permissions to run the 'aclcheck.module.command.aclcategories.write.function.read.category' command} $e
     }
 
-    test "Unload the module - aclcheck" {
+    test {test if foocategory acl categories is added} {
+        r acl SETUSER j8 on >password -@all +@foocategory
+        assert_equal [r acl DRYRUN j8 aclcheck.module.command.test.add.new.aclcategories] OK
+    }
+
+    test {test permission compaction and simplification for categories added by a module} {
+        r acl SETUSER j9 on >password -@all +@foocategory -@foocategory
+        catch {r ACL GETUSER j9} res
+        assert_equal {-@all -@foocategory} [lindex $res 5]
         assert_equal {OK} [r module unload aclcheck]
+    }
+}
+
+start_server {tags {"modules acl"}} {
+    test {test module load fails if exceeds the maximum number of adding acl categories} {
+        assert_error {ERR Error loading the extension. Please check the server logs.} {r module load $testmodule 1}
+        assert_equal [r module load $testmodule 0] OK
     }
 }


### PR DESCRIPTION
Related to issue #12428 

Recently, we added support for modules to include commands to existing ACL categories https://github.com/redis/redis/pull/11708. However, it is still not possible for modules to register new ACL categories for commands. This PR implements the ability to allow modules to create new ACL categories.

This PR adds a new Module API `int RM_AddACLCategory(RedisModuleCtx *ctx, const char *category_name)` to add a new ACL command category.

Here, we initialize the `ACLCommandCategories` array by allocating space for 64 categories and duplicate the 21 default categories from the predefined array 'ACLDefaultCommandCategories' into the `ACLCommandCategories` array while ACL initialization. Valid ACL category names can only contain alphanumeric characters, underscores, and dashes.

The API when called, checks for the onload flag, category name validity, and for duplicate category name if present. If the conditions are satisfied, the API adds the new category to the trailing end of the `ACLCommandCategories` array and assigns the `acl_categories` flag bit according to the index at which the category is added.

If any error is encountered the `errno` is set accordingly by the API.