### PR TITLE
Update supported version list.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -26,7 +26,7 @@ Examples of unacceptable behavior include:
 advances of any kind
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others’ private information, such as a physical or email
+* Publishing others' private information, such as a physical or email
 address, without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
 professional setting
@@ -89,7 +89,7 @@ Attribution
 This Code of Conduct is adapted from the Contributor Covenant,
 version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
-Community Impact Guidelines were inspired by Mozilla’s code of conduct
+Community Impact Guidelines were inspired by Mozilla's code of conduct
 enforcement ladder.
 For answers to common questions about this code of conduct, see the FAQ at
 https://www.contributor-covenant.org/faq. Translations are available at

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,10 +11,10 @@ unless this is not possible or feasible with a reasonable effort.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 7.2.x   | :white_check_mark: |
 | 7.0.x   | :white_check_mark: |
 | 6.2.x   | :white_check_mark: |
-| 6.0.x   | :white_check_mark: |
-| < 6.0   | :x:                |
+| < 6.2   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,10 +18,10 @@ unless this is not possible or feasible with a reasonable effort.
 
 ## Reporting a Vulnerability
 
-If you believe you’ve discovered a serious vulnerability, please contact the
+If you believe you've discovered a serious vulnerability, please contact the
 Redis core team at redis@redis.io. We will evaluate your report and if
 necessary issue a fix and an advisory. If the issue was previously undisclosed,
-we’ll also mention your name in the credits.
+we'll also mention your name in the credits.
 
 ## Responsible Disclosure
 
@@ -36,7 +36,7 @@ embargo on public disclosure.
 
 Vendors on the list are individuals or organizations that maintain Redis
 distributions or provide Redis as a service, who have third party users who
-will benefit from the vendor’s ability to prepare for a new version or deploy a
+will benefit from the vendor's ability to prepare for a new version or deploy a
 fix early.
 
 If you believe you should be on the list, please contact us and we will

--- a/tests/integration/psync2-master-restart.tcl
+++ b/tests/integration/psync2-master-restart.tcl
@@ -14,7 +14,7 @@ start_server {} {
     # Make sure the server saves an RDB on shutdown
     $master config set save "3600 1"
 
-    # Because we will test partial resync later, we don’t want a timeout to cause
+    # Because we will test partial resync later, we don't want a timeout to cause
     # the master-replica disconnect, then the extra reconnections will break the
     # sync_partial_ok stat test
     $master config set repl-timeout 3600

--- a/tests/modules/infotest.c
+++ b/tests/modules/infotest.c
@@ -28,8 +28,8 @@ void InfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
 
     if (for_crash_report) {
         RedisModule_InfoAddSection(ctx, "Klingon");
-        RedisModule_InfoAddFieldCString(ctx, "one", "wa’");
-        RedisModule_InfoAddFieldCString(ctx, "two", "cha’");
+        RedisModule_InfoAddFieldCString(ctx, "one", "wa'");
+        RedisModule_InfoAddFieldCString(ctx, "two", "cha'");
         RedisModule_InfoAddFieldCString(ctx, "three", "wej");
     }
 


### PR DESCRIPTION
Add 7.2, drop 6.0 as per https://redis.io/docs/about/releases/
Also replace a few concordances of the `’` char, with standard `'`