### PR TITLE
SLOWLOG: log user name

### DIFF
--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -90,6 +90,7 @@ slowlogEntry *slowlogCreateEntry(client *c, robj **argv, int argc, long long dur
     se->id = server.slowlog_entry_id++;
     se->peerid = sdsnew(getClientPeerId(c));
     se->cname = c->name ? sdsnew(c->name->ptr) : sdsempty();
+    se->uname = c->user ? sdsdup(c->user->name) : sdsnew("(superuser)");
     return se;
 }
 
@@ -106,6 +107,7 @@ void slowlogFreeEntry(void *septr) {
     zfree(se->argv);
     sdsfree(se->peerid);
     sdsfree(se->cname);
+    sdsfree(se->uname);
     zfree(se);
 }
 
@@ -190,7 +192,7 @@ NULL
 
             ln = listNext(&li);
             se = ln->value;
-            addReplyArrayLen(c,6);
+            addReplyArrayLen(c,7);
             addReplyLongLong(c,se->id);
             addReplyLongLong(c,se->time);
             addReplyLongLong(c,se->duration);
@@ -199,6 +201,7 @@ NULL
                 addReplyBulk(c,se->argv[j]);
             addReplyBulkCBuffer(c,se->peerid,sdslen(se->peerid));
             addReplyBulkCBuffer(c,se->cname,sdslen(se->cname));
+            addReplyBulkCBuffer(c,se->uname,sdslen(se->uname));
         }
     } else {
         addReplySubcommandSyntaxError(c);

--- a/src/slowlog.h
+++ b/src/slowlog.h
@@ -42,6 +42,7 @@ typedef struct slowlogEntry {
     time_t time;        /* Unix time at which the query was executed. */
     sds cname;          /* Client name. */
     sds peerid;         /* Client network address. */
+    sds uname;          /* User name. */
 } slowlogEntry;
 
 /* Exported API */

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -40,13 +40,14 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         r client setname foobar
         r debug sleep 0.2
         set e [lindex [r slowlog get] 0]
-        assert_equal [llength $e] 6
+        assert_equal [llength $e] 7
         if {!$::external} {
             assert_equal [lindex $e 0] 107
         }
         assert_equal [expr {[lindex $e 2] > 100000}] 1
         assert_equal [lindex $e 3] {debug sleep 0.2}
         assert_equal {foobar} [lindex $e 5]
+        assert_equal {default} [lindex $e 6]
     } {} {needs:debug}
 
     test {SLOWLOG - Certain commands are omitted that contain sensitive information} {
@@ -168,6 +169,17 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         assert {[llength [r slowlog get]] == 1}
         set e [lindex [r slowlog get] 0]
         assert_equal {lastentry_client} [lindex $e 5]
+    } {} {needs:debug}
+
+    test {SLOWLOG - can log new user name} {
+        r config set slowlog-max-len 1
+        r ACL setuser slowlog_user on nopass +debug
+        r auth slowlog_user x
+        r debug sleep 0.2
+        r auth default x
+        assert {[llength [r slowlog get]] == 1}
+        set e [lindex [r slowlog get] 0]
+        assert_equal {slowlog_user} [lindex $e 6]
     } {} {needs:debug}
 
     test {SLOWLOG - can be disabled} {


### PR DESCRIPTION
Not sure if it's a breaking change, but I have a vague memory that PHP or some other client became incompatible after we added client address and name.