### PR TITLE
[Draft] Key/Value Embedding in Redis Main Dictionary

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -381,13 +381,13 @@ void blockForKeys(client *c, int btype, robj **keys, int numkeys, mstime_t timeo
         /* In case key[j] did not have blocking clients yet, we need to create a new list */
         if (db_blocked_entry != NULL) {
             l = listCreate();
-            dictSetVal(c->db->blocking_keys, db_blocked_entry, l);
+            dictSetVal(c->db->blocking_keys, &db_blocked_entry, l);
             incrRefCount(keys[j]);
         } else {
             l = dictGetVal(db_blocked_existing_entry);
         }
         listAddNodeTail(l,c);
-        dictSetVal(c->bstate.keys,client_blocked_entry,listLast(l));
+        dictSetVal(c->bstate.keys,&client_blocked_entry,listLast(l));
 
 
         /* We need to add the key to blocking_keys_unblock_on_nokey, if the client

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -6447,7 +6447,10 @@ void restoreCommand(client *c) {
     }
 
     /* Create the key and set the TTL if any */
-    dbAdd(c->db,key,obj);
+    dictEntry *de = dbAdd(c->db, key, obj);
+    decrRefCount(obj);
+    obj = dictGetVal(de);
+
     if (ttl) {
         setExpire(c,c->db,key,ttl);
         if (!absttl) {

--- a/src/db.c
+++ b/src/db.c
@@ -227,10 +227,9 @@ robj *lookupKeyWriteOrReply(client *c, robj *key, robj *reply) {
  *
  * The program is aborted if the key already exists. */
 void dbAdd(redisDb *db, robj *key, robj *val) {
-    sds copy = sdsdup(key->ptr);
     int slot = getKeySlot(key->ptr);
     dict *d = db->dict[slot];
-    dictEntry *de = dictAddRaw(d, copy, NULL);
+    dictEntry *de = dictAddRaw(d, key->ptr, NULL);
     serverAssertWithInfo(NULL, key, de != NULL);
     dictSetVal(d, de, val);
     db->key_count++;

--- a/src/debug.c
+++ b/src/debug.c
@@ -733,6 +733,7 @@ NULL
                 memcpy(val->ptr, buf, valsize<=buflen? valsize: buflen);
             }
             dbAdd(c->db,key,val);
+            decrRefCount(val);
             signalModifiedKey(c,c->db,key);
             decrRefCount(key);
         }
@@ -874,7 +875,7 @@ NULL
         sds sizes = sdsempty();
         sizes = sdscatprintf(sizes,"bits:%d ",(sizeof(void*) == 8)?64:32);
         sizes = sdscatprintf(sizes,"robj:%d ",(int)sizeof(robj));
-        sizes = sdscatprintf(sizes,"dictentry:%d ",(int)dictEntryMemUsage());
+        sizes = sdscatprintf(sizes,"dictentry:%d ",(int)dictEntryMemUsage(c->db->dict[0]));
         sizes = sdscatprintf(sizes,"sdshdr5:%d ",(int)sizeof(struct sdshdr5));
         sizes = sdscatprintf(sizes,"sdshdr8:%d ",(int)sizeof(struct sdshdr8));
         sizes = sdscatprintf(sizes,"sdshdr16:%d ",(int)sizeof(struct sdshdr16));

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -228,7 +228,7 @@ void activeDefragZsetEntry(zset *zs, dictEntry *de) {
         dictSetKey(zs->dict, de, newsds);
     newscore = zslDefrag(zs->zsl, *(double*)dictGetVal(de), sdsele, newsds);
     if (newscore) {
-        dictSetVal(zs->dict, de, newscore);
+        dictSetVal(zs->dict, &de, newscore);
     }
 }
 
@@ -416,7 +416,7 @@ void scanLaterHash(robj *ob, unsigned long *cursor) {
     dictDefragFunctions defragfns = {
         .defragAlloc = activeDefragAlloc,
         .defragKey = (dictDefragAllocFunction *)activeDefragSds,
-        .defragVal = (dictDefragAllocFunction *)activeDefragSds,
+        .defragVal = (dictDefragAllocFunction *)activeDefragSds
     };
     *cursor = dictScanDefrag(d, *cursor, scanCallbackCountScanned, &defragfns, NULL);
 }
@@ -671,18 +671,17 @@ void defragModule(redisDb *db, dictEntry *kde) {
  * all the various pointers it has. Returns a stat of how many pointers were
  * moved. */
 void defragValue(redisDb *db, dictEntry *de) {
-    robj *newob, *ob;
+    robj *ob;
     unsigned char *newzl;
 
     /* Try to defrag robj and / or string value. */
     ob = dictGetVal(de);
-    if ((newob = activeDefragStringOb(ob))) {
-        dictSetVal(db->dict[calculateKeySlot(dictGetKey(de))], de, newob);
-        ob = newob;
-    }
 
-    if (ob->type == OBJ_STRING) {
-        /* Already handled in activeDefragStringOb. */
+    if (ob->type == OBJ_STRING && ob->encoding == OBJ_ENCODING_RAW) {
+        sds newsds = activeDefragSds(ob->ptr);
+        if (newsds) {
+            ob->ptr = newsds;
+        }
     } else if (ob->type == OBJ_LIST) {
         if (ob->encoding == OBJ_ENCODING_QUICKLIST) {
             defragQuicklist(db, de);

--- a/src/dict.c
+++ b/src/dict.c
@@ -72,6 +72,17 @@ struct dictEntry {
 };
 
 typedef struct {
+    union {
+        void *val;
+        uint64_t u64;
+        int64_t s64;
+        double d;
+    } v;
+    struct dictEntry *next;     /* Next entry in the same hash bucket. */
+    unsigned char data[];
+} embeddedDictEntry;
+
+typedef struct {
     void *key;
     dictEntry *next;
 } dictEntryNoValue;
@@ -120,6 +131,7 @@ uint64_t dictGenCaseHashFunction(const unsigned char *buf, size_t len) {
 #define ENTRY_PTR_MASK     7 /* 111 */
 #define ENTRY_PTR_NORMAL   0 /* 000 */
 #define ENTRY_PTR_NO_VALUE 2 /* 010 */
+#define ENTRY_PTR_EMBEDDED 4 /* 100 */
 
 /* Returns 1 if the entry pointer is a pointer to a key, rather than to an
  * allocated entry. Returns 0 otherwise. */
@@ -139,12 +151,26 @@ static inline int entryIsNoValue(const dictEntry *de) {
     return ((uintptr_t)(void *)de & ENTRY_PTR_MASK) == ENTRY_PTR_NO_VALUE;
 }
 
+
+static inline int entryIsEmbedded(const dictEntry *de) {
+    return ((uintptr_t)(void *)de & ENTRY_PTR_MASK) == ENTRY_PTR_EMBEDDED;
+}
+
 /* Creates an entry without a value field. */
 static inline dictEntry *createEntryNoValue(void *key, dictEntry *next) {
     dictEntryNoValue *entry = zmalloc(sizeof(*entry));
     entry->key = key;
     entry->next = next;
     return (dictEntry *)(void *)((uintptr_t)(void *)entry | ENTRY_PTR_NO_VALUE);
+}
+
+static inline dictEntry *createEmbeddedEntry(void *key, dictEntry *next, dictType *dt) {
+    size_t keyLen = dt->keyLen(key);
+    embeddedDictEntry *entry = zmalloc(sizeof(*entry) + keyLen + ENTRY_METADATA_BYTES);
+    size_t bytes_written = dt->keyToBytes(entry->data + ENTRY_METADATA_BYTES, key, &entry->data[0]);
+    assert(bytes_written == keyLen);
+    entry->next = next;
+    return (dictEntry *)(void *)((uintptr_t)(void *)entry | ENTRY_PTR_EMBEDDED);
 }
 
 static inline dictEntry *encodeMaskedPtr(const void *ptr, unsigned int bits) {
@@ -157,15 +183,24 @@ static inline void *decodeMaskedPtr(const dictEntry *de) {
     return (void *)((uintptr_t)(void *)de & ~ENTRY_PTR_MASK);
 }
 
+static inline void *getEmbeddedKey(const dictEntry *de) {
+    embeddedDictEntry *entry = (embeddedDictEntry *)decodeMaskedPtr(de);
+    return &entry->data[ENTRY_METADATA_BYTES + entry->data[0]];
+}
+
 /* Decodes the pointer to an entry without value, when you know it is an entry
  * without value. Hint: Use entryIsNoValue to check. */
 static inline dictEntryNoValue *decodeEntryNoValue(const dictEntry *de) {
     return decodeMaskedPtr(de);
 }
 
+static inline embeddedDictEntry *decodeEmbeddedEntry(const dictEntry *de) {
+    return decodeMaskedPtr(de);
+}
+
 /* Returns 1 if the entry has a value field and 0 otherwise. */
 static inline int entryHasValue(const dictEntry *de) {
-    return entryIsNormal(de);
+    return entryIsNormal(de) || entryIsEmbedded(de);
 }
 
 /* ----------------------------- API implementation ------------------------- */
@@ -483,6 +518,8 @@ dictEntry *dictInsertAtPosition(dict *d, void *key, void *position) {
             /* Allocate an entry without value. */
             entry = createEntryNoValue(key, *bucket);
         }
+    } else if (d->type->embedded_entry){
+        entry = createEmbeddedEntry(key, *bucket, d->type);
     } else {
         /* Allocate the memory and store the new entry.
          * Insert the element in top, with the assumption that in a database
@@ -618,6 +655,9 @@ void dictFreeUnlinkedEntry(dict *d, dictEntry *he) {
     if (he == NULL) return;
     dictFreeKey(d, he);
     dictFreeVal(d, he);
+    /* Clear the embedded data */
+    if (entryIsEmbedded(he)) zfree(decodeEmbeddedEntry(he)->data);
+    /* Clear the dictEntry */
     if (!entryIsKey(he)) zfree(decodeMaskedPtr(he));
 }
 
@@ -746,7 +786,12 @@ void dictSetKey(dict *d, dictEntry* de, void *key) {
 
 void dictSetVal(dict *d, dictEntry *de, void *val) {
     assert(entryHasValue(de));
-    de->v.val = d->type->valDup ? d->type->valDup(d, val) : val;
+    void *v = d->type->valDup ? d->type->valDup(d, val) : val;
+    if (entryIsEmbedded(de)) {
+        decodeEmbeddedEntry(de)->v.val = v;
+    } else {
+        de->v.val = v;
+    }
 }
 
 void dictSetSignedIntegerVal(dictEntry *de, int64_t val) {
@@ -782,11 +827,15 @@ double dictIncrDoubleVal(dictEntry *de, double val) {
 void *dictGetKey(const dictEntry *de) {
     if (entryIsKey(de)) return (void*)de;
     if (entryIsNoValue(de)) return decodeEntryNoValue(de)->key;
+    if (entryIsEmbedded(de)) return getEmbeddedKey(de);
     return de->key;
 }
 
 void *dictGetVal(const dictEntry *de) {
     assert(entryHasValue(de));
+    if (entryIsEmbedded(de)) {
+        return decodeEmbeddedEntry(de)->v.val;
+    }
     return de->v.val;
 }
 
@@ -816,6 +865,7 @@ double *dictGetDoubleValPtr(dictEntry *de) {
 static dictEntry *dictGetNext(const dictEntry *de) {
     if (entryIsKey(de)) return NULL; /* there's no next */
     if (entryIsNoValue(de)) return decodeEntryNoValue(de)->next;
+    if (entryIsEmbedded(de)) return decodeEmbeddedEntry(de)->next;
     return de->next;
 }
 
@@ -824,14 +874,16 @@ static dictEntry *dictGetNext(const dictEntry *de) {
 static dictEntry **dictGetNextRef(dictEntry *de) {
     if (entryIsKey(de)) return NULL;
     if (entryIsNoValue(de)) return &decodeEntryNoValue(de)->next;
+    if (entryIsEmbedded(de)) return &decodeEmbeddedEntry(de)->next;
     return &de->next;
 }
 
 static void dictSetNext(dictEntry *de, dictEntry *next) {
     assert(!entryIsKey(de));
     if (entryIsNoValue(de)) {
-        dictEntryNoValue *entry = decodeEntryNoValue(de);
-        entry->next = next;
+        decodeEntryNoValue(de)->next = next;
+    } else if (entryIsEmbedded(de)){
+        decodeEmbeddedEntry(de)->next = next;
     } else {
         de->next = next;
     }
@@ -1119,6 +1171,13 @@ static void dictDefragBucket(dictEntry **bucketref, dictDefragFunctions *defragf
                 entry = newentry;
             }
             if (newkey) entry->key = newkey;
+        } else if (entryIsEmbedded(de)) {
+            embeddedDictEntry *entry = decodeEmbeddedEntry(de), *newentry;
+            if ((newentry = defragalloc(entry))) {
+                newde = encodeMaskedPtr(newentry, ENTRY_PTR_EMBEDDED);
+                entry = newentry;
+            }
+            if (newval) entry->v.val = newval;
         } else {
             assert(entryIsNormal(de));
             newde = defragalloc(de);

--- a/src/dict.h
+++ b/src/dict.h
@@ -57,7 +57,11 @@ typedef struct dictType {
     int (*expandAllowed)(size_t moreMem, double usedRatio);
     void (*rehashingStarted)(dict *d);
     size_t (*keyLen)(const void *key);
-    size_t (*keyToBytes)(unsigned char *buf, const void *key, unsigned char *header_size);
+    size_t (*keyToBytes)(unsigned char *buf, const void *key, uint8_t *header_size);
+    size_t (*valLen)(const void *val);
+    void (*valToBytes)(void *de, const void *val, unsigned char *buf);
+    int (*trySetVal)(void *de, const void *val);
+
     /* Flags */
     /* The 'no_value' flag, if set, indicates that values are not used, i.e. the
      * dict is a set. When this flag is set, it's not possible to access the
@@ -170,8 +174,9 @@ int dictTryExpand(dict *d, unsigned long size);
 void *dictMetadata(dict *d);
 int dictAdd(dict *d, void *key, void *val);
 dictEntry *dictAddRaw(dict *d, void *key, dictEntry **existing);
+dictEntry *dictAddWithValue(dict *d, void *key, void *val);
 void *dictFindPositionForInsert(dict *d, const void *key, dictEntry **existing);
-dictEntry *dictInsertAtPosition(dict *d, void *key, void *position);
+dictEntry *dictInsertAtPosition(dict *d, void *key, void *val, void *position);
 dictEntry *dictAddOrFind(dict *d, void *key);
 int dictReplace(dict *d, void *key, void *val);
 int dictDelete(dict *d, const void *key);
@@ -184,7 +189,7 @@ dictEntry * dictFind(dict *d, const void *key);
 void *dictFetchValue(dict *d, const void *key);
 int dictResize(dict *d);
 void dictSetKey(dict *d, dictEntry* de, void *key);
-void dictSetVal(dict *d, dictEntry *de, void *val);
+int dictSetVal(dict *d, dictEntry **de, void *val);
 void dictSetSignedIntegerVal(dictEntry *de, int64_t val);
 void dictSetUnsignedIntegerVal(dictEntry *de, uint64_t val);
 void dictSetDoubleVal(dictEntry *de, double val);
@@ -199,7 +204,8 @@ uint64_t dictGetUnsignedIntegerVal(const dictEntry *de);
 double dictGetDoubleVal(const dictEntry *de);
 double *dictGetDoubleValPtr(dictEntry *de);
 size_t dictMemUsage(const dict *d);
-size_t dictEntryMemUsage(void);
+size_t dictEntryMemUsage(const dict *d);
+size_t dictEntryZmallocSize(const dictEntry *de);
 dictIterator *dictGetIterator(dict *d);
 dictIterator *dictGetSafeIterator(dict *d);
 void dictInitIterator(dictIterator *iter, dict *d);

--- a/src/dict.h
+++ b/src/dict.h
@@ -56,6 +56,8 @@ typedef struct dictType {
     void (*valDestructor)(dict *d, void *obj);
     int (*expandAllowed)(size_t moreMem, double usedRatio);
     void (*rehashingStarted)(dict *d);
+    size_t (*keyLen)(const void *key);
+    size_t (*keyToBytes)(unsigned char *buf, const void *key, unsigned char *header_size);
     /* Flags */
     /* The 'no_value' flag, if set, indicates that values are not used, i.e. the
      * dict is a set. When this flag is set, it's not possible to access the
@@ -68,6 +70,7 @@ typedef struct dictType {
     unsigned int keys_are_odd:1;
     /* TODO: Add a 'keys_are_even' flag and use a similar optimization if that
      * flag is set. */
+    unsigned int embedded_entry:1;
 } dictType;
 
 #define DICTHT_SIZE(exp) ((exp) == -1 ? 0 : (unsigned long)1<<(exp))
@@ -116,6 +119,8 @@ typedef struct {
     dictDefragAllocFunction *defragKey;   /* Defrag-realloc keys (optional) */
     dictDefragAllocFunction *defragVal;   /* Defrag-realloc values (optional) */
 } dictDefragFunctions;
+
+static const int ENTRY_METADATA_BYTES = 1;
 
 /* This is the initial size of every hash table */
 #define DICT_HT_INITIAL_EXP      2

--- a/src/functions.c
+++ b/src/functions.c
@@ -291,7 +291,7 @@ static void libraryUnlink(functionsLibCtx *lib_ctx, functionLibInfo* li) {
     }
     dictReleaseIterator(iter);
     entry = dictUnlink(lib_ctx->libraries, li->name);
-    dictSetVal(lib_ctx->libraries, entry, NULL);
+    dictSetVal(lib_ctx->libraries, &entry, NULL);
     dictFreeUnlinkedEntry(lib_ctx->libraries, entry);
     lib_ctx->cache_memory -= libraryMallocSize(li);
 
@@ -374,7 +374,7 @@ static int libraryJoin(functionsLibCtx *functions_lib_ctx_dst, functionsLibCtx *
     while ((entry = dictNext(iter))) {
         functionLibInfo *li = dictGetVal(entry);
         libraryLink(functions_lib_ctx_dst, li);
-        dictSetVal(functions_lib_ctx_src->libraries, entry, NULL);
+        dictSetVal(functions_lib_ctx_src->libraries, &entry, NULL);
     }
     dictReleaseIterator(iter);
     iter = NULL;

--- a/src/geo.c
+++ b/src/geo.c
@@ -828,7 +828,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
 
         if (returned_items) {
             zsetConvertToListpackIfNeeded(zobj,maxelelen,totelelen);
-            setKey(c,c->db,storekey,zobj,0);
+            setKey(c,c->db,storekey,&zobj,0);
             decrRefCount(zobj);
             notifyKeyspaceEvent(NOTIFY_ZSET,flags & GEOSEARCH ? "geosearchstore" : "georadiusstore",storekey,
                                 c->db->id);

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1199,7 +1199,9 @@ void pfaddCommand(client *c) {
          * hold our HLL data structure. sdsnewlen() when NULL is passed
          * is guaranteed to return bytes initialized to zero. */
         o = createHLLObject();
-        dbAdd(c->db,c->argv[1],o);
+        dictEntry *de = dbAdd(c->db, c->argv[1], o);
+        decrRefCount(o);
+        o = dictGetVal(de);
         updated++;
     } else {
         if (isHLLObjectOrReply(c,o) != C_OK) return;
@@ -1361,7 +1363,9 @@ void pfmergeCommand(client *c) {
          * hold our HLL data structure. sdsnewlen() when NULL is passed
          * is guaranteed to return bytes initialized to zero. */
         o = createHLLObject();
-        dbAdd(c->db,c->argv[1],o);
+        dictEntry *de = dbAdd(c->db, c->argv[1], o);
+        decrRefCount(o);
+        o = dictGetVal(de);
     } else {
         /* If key exists we are sure it's of the right type/size
          * since we checked when merging the different HLLs, so we

--- a/src/object.c
+++ b/src/object.c
@@ -1542,7 +1542,7 @@ NULL
             return;
         }
         size_t usage = objectComputeSize(c->argv[2],dictGetVal(de),samples,c->db->id);
-        usage += sdsZmallocSize(dictGetKey(de));
+        usage += c->db->dict[getKeySlot(c->argv[2]->ptr)]->type->keyLen(dictGetKey(de));
         usage += dictEntryMemUsage();
         addReplyLongLong(c,usage);
     } else if (!strcasecmp(c->argv[1]->ptr,"stats") && c->argc == 2) {

--- a/src/object.h
+++ b/src/object.h
@@ -1,0 +1,64 @@
+/*
+ * Redis Object struct definition and macros
+ */
+
+#define LRU_BITS 24
+#define STATE_BITS 4
+
+/* Objects encoding. Some kind of objects like Strings and Hashes can be
+ * internally represented in multiple ways. The 'encoding' field of the object
+ * is set to one of this fields for this object. */
+#define OBJ_ENCODING_RAW 0     /* Raw representation */
+#define OBJ_ENCODING_INT 1     /* Encoded as integer */
+#define OBJ_ENCODING_HT 2      /* Encoded as hash table */
+#define OBJ_ENCODING_ZIPMAP 3  /* No longer used: old hash encoding. */
+#define OBJ_ENCODING_LINKEDLIST 4 /* No longer used: old list encoding. */
+#define OBJ_ENCODING_ZIPLIST 5 /* No longer used: old list/hash/zset encoding. */
+#define OBJ_ENCODING_INTSET 6  /* Encoded as intset */
+#define OBJ_ENCODING_SKIPLIST 7  /* Encoded as skiplist */
+#define OBJ_ENCODING_EMBSTR 8  /* Embedded sds string encoding */
+#define OBJ_ENCODING_QUICKLIST 9 /* Encoded as linked list of listpacks */
+#define OBJ_ENCODING_STREAM 10 /* Encoded as a radix tree of listpacks */
+#define OBJ_ENCODING_LISTPACK 11 /* Encoded as a listpack */
+
+#define OBJ_SHARED_REFCOUNT (INT_MAX>>STATE_BITS)    /* Global object never destroyed. */
+#define OBJ_STATIC_REFCOUNT (OBJ_SHARED_REFCOUNT-1) /* Object allocated in the stack. */
+#define OBJ_FIRST_SPECIAL_REFCOUNT OBJ_STATIC_REFCOUNT
+
+/* Object flags */
+#define OBJ_STATE_NONE          0 
+#define OBJ_STATE_REFERENCE (1<<0)     /* Reference objects don't own the value behind the pointer and are not responsible for its cleanup. */
+#define OBJ_STATE_PROTECTED (1<<1)         /* Protected objects can't be freed until protected flag is removed. */
+
+/* A redis object, that is a type able to hold a string / list / set / zset / hash / module / stream */
+#define OBJ_STRING 0    /* String object. */
+#define OBJ_LIST 1      /* List object. */
+#define OBJ_SET 2       /* Set object. */
+#define OBJ_ZSET 3      /* Sorted set object. */
+#define OBJ_HASH 4      /* Hash object. */
+
+/* The "module" object type is a special one that signals that the object
+ * is one directly managed by a Redis module. In this case the value points
+ * to a moduleValue struct, which contains the object value (which is only
+ * handled by the module itself) and the RedisModuleType struct which lists
+ * function pointers in order to serialize, deserialize, AOF-rewrite and
+ * free the object.
+ *
+ * Inside the RDB file, module types are encoded as OBJ_MODULE followed
+ * by a 64 bit module type ID, which has a 54 bits module-specific signature
+ * in order to dispatch the loading to the right module, plus a 10 bits
+ * encoding version. */
+#define OBJ_MODULE 5    /* Module object. */
+#define OBJ_STREAM 6    /* Stream object. */
+
+/* The actual Redis Object */
+struct redisObject {
+    unsigned type:4;
+    unsigned encoding:4;
+    unsigned lru:LRU_BITS; /* LRU time (relative to global lru_clock) or
+                            * LFU data (least significant 8 bits frequency
+                            * and most significant 16 bits access time). */
+    unsigned refcount:(32-STATE_BITS);
+    unsigned state:STATE_BITS;
+    void *ptr;
+};

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3341,6 +3341,9 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
 
             /* call key space notification on key loaded for modules only */
             moduleNotifyKeyspaceEvent(NOTIFY_LOADED, "loaded", &keyobj, db->id);
+
+            /* Release key (sds), dictEntry stores a copy of it in embedded data */
+            sdsfree(key);
         }
 
         /* Loading the database more slowly is useful in order to test

--- a/src/sds.c
+++ b/src/sds.c
@@ -41,22 +41,6 @@
 
 const char *SDS_NOINIT = "SDS_NOINIT";
 
-static inline int sdsHdrSize(char type) {
-    switch(type&SDS_TYPE_MASK) {
-        case SDS_TYPE_5:
-            return sizeof(struct sdshdr5);
-        case SDS_TYPE_8:
-            return sizeof(struct sdshdr8);
-        case SDS_TYPE_16:
-            return sizeof(struct sdshdr16);
-        case SDS_TYPE_32:
-            return sizeof(struct sdshdr32);
-        case SDS_TYPE_64:
-            return sizeof(struct sdshdr64);
-    }
-    return 0;
-}
-
 static inline char sdsReqType(size_t string_size) {
     if (string_size < 1<<5)
         return SDS_TYPE_5;

--- a/src/sds.h
+++ b/src/sds.h
@@ -215,6 +215,22 @@ static inline void sdssetalloc(sds s, size_t newlen) {
     }
 }
 
+static inline int sdsHdrSize(char type) {
+    switch(type&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return sizeof(struct sdshdr5);
+        case SDS_TYPE_8:
+            return sizeof(struct sdshdr8);
+        case SDS_TYPE_16:
+            return sizeof(struct sdshdr16);
+        case SDS_TYPE_32:
+            return sizeof(struct sdshdr32);
+        case SDS_TYPE_64:
+            return sizeof(struct sdshdr64);
+    }
+    return 0;
+}
+
 sds sdsnewlen(const void *init, size_t initlen);
 sds sdstrynewlen(const void *init, size_t initlen);
 sds sdsnew(const char *init);

--- a/src/server.c
+++ b/src/server.c
@@ -268,6 +268,16 @@ int dictSdsKeyCompare(dict *d, const void *key1,
     return memcmp(key1, key2, l1) == 0;
 }
 
+size_t dictSdsKeyLen(const void *key) { return sdsAllocSize((sds)key); }
+
+size_t dictSdsKeyToBytes(unsigned char *buf, const void *key, unsigned char *header_size) {
+    sds keySds = (sds)key;
+    size_t n_bytes = sdsAllocSize(keySds);
+    memcpy(buf, sdsAllocPtr(keySds), n_bytes);
+    *header_size = sdsHdrSize(keySds[-1]);
+    return n_bytes;
+}
+
 /* A case insensitive version used for the command lookup table and other
  * places where case insensitive non binary-safe comparison is needed. */
 int dictSdsKeyCaseCompare(dict *d, const void *key1,
@@ -455,10 +465,13 @@ dictType dbDictType = {
     NULL,                       /* key dup */
     NULL,                       /* val dup */
     dictSdsKeyCompare,          /* key compare */
-    dictSdsDestructor,          /* key destructor */
+    NULL,                       /* Note: key (sds) is stored in the embedded buffer, will be released internally */
     dictObjectDestructor,       /* val destructor */
     dictExpandAllowed,          /* allow to expand */
     dictRehashingStarted,
+    dictSdsKeyLen,
+    dictSdsKeyToBytes,
+    .embedded_entry = 1
 };
 
 /* Db->expires */

--- a/src/server.h
+++ b/src/server.h
@@ -3441,6 +3441,8 @@ int dictSdsKeyCaseCompare(dict *d, const void *key1, const void *key2);
 void dictSdsDestructor(dict *d, void *val);
 void dictListDestructor(dict *d, void *val);
 void *dictSdsDup(dict *d, const void *key);
+size_t dictSdsKeyToBytes(unsigned char *buf, const void *key, unsigned char *header_size);
+size_t dictSdsKeyLen(const void *key);
 
 /* Git SHA1 */
 char *redisGitSHA1(void);

--- a/src/sort.c
+++ b/src/sort.c
@@ -583,7 +583,7 @@ void sortCommandGeneric(client *c, int readonly) {
         }
         if (outputlen) {
             listTypeTryConversion(sobj,LIST_CONV_AUTO,NULL,NULL);
-            setKey(c,c->db,storekey,sobj,0);
+            setKey(c,c->db,storekey,&sobj,0);
             notifyKeyspaceEvent(NOTIFY_LIST,"sortstore",storekey,
                                 c->db->id);
             server.dirty += outputlen;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -248,7 +248,7 @@ int hashTypeSet(robj *o, sds field, sds value, int flags) {
         }
         de = dictAddRaw(ht, field, &existing);
         if (de) {
-            dictSetVal(ht, de, v);
+            dictSetVal(ht, &de, v);
             if (flags & HASH_SET_TAKE_FIELD) {
                 field = NULL;
             } else {
@@ -256,7 +256,7 @@ int hashTypeSet(robj *o, sds field, sds value, int flags) {
             }
         } else {
             sdsfree(dictGetVal(existing));
-            dictSetVal(ht, existing, v);
+            dictSetVal(ht, &existing, v);
             update = 1;
         }
     } else {
@@ -446,7 +446,9 @@ robj *hashTypeLookupWriteOrCreate(client *c, robj *key) {
 
     if (o == NULL) {
         o = createHashObject();
-        dbAdd(c->db,key,o);
+        dictEntry *de = dbAdd(c->db, key, o);
+        decrRefCount(o);
+        o = dictGetVal(de);
     }
     return o;
 }

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -495,7 +495,9 @@ void pushGenericCommand(client *c, int where, int xx) {
         }
 
         lobj = createListListpackObject();
-        dbAdd(c->db,c->argv[1],lobj);
+        dictEntry *de = dbAdd(c->db, c->argv[1], lobj);
+        decrRefCount(lobj);
+        lobj = dictGetVal(de);
     }
 
     listTypeTryConversionAppend(lobj,c->argv,2,c->argc-1,NULL,NULL);
@@ -1105,7 +1107,9 @@ void lmoveHandlePush(client *c, robj *dstkey, robj *dstobj, robj *value,
     /* Create the list if the key does not exist */
     if (!dstobj) {
         dstobj = createListListpackObject();
-        dbAdd(c->db,dstkey,dstobj);
+        dictEntry *de = dbAdd(c->db, dstkey, dstobj);
+        decrRefCount(dstobj);
+        dstobj = dictGetVal(de);
     }
     signalModifiedKey(c,c->db,dstkey);
     listTypeTryConversionAppend(dstobj,&value,0,0,NULL,NULL);

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -146,7 +146,7 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
         if (position) {
             /* Key doesn't already exist in the set. Add it but dup the key. */
             if (sdsval == str) sdsval = sdsdup(sdsval);
-            dictInsertAtPosition(ht, sdsval, position);
+            dictInsertAtPosition(ht, sdsval, NULL, position);
         } else if (sdsval != str) {
             /* String is already a member. Free our temporary sds copy. */
             sdsfree(sdsval);
@@ -611,7 +611,9 @@ void saddCommand(client *c) {
     
     if (set == NULL) {
         set = setTypeCreate(c->argv[2]->ptr, c->argc - 2);
-        dbAdd(c->db,c->argv[1],set);
+        dictEntry *de = dbAdd(c->db, c->argv[1], set);
+        decrRefCount(set);
+        set = dictGetVal(de);
     } else {
         setTypeMaybeConvert(set, c->argc - 2);
     }
@@ -695,7 +697,9 @@ void smoveCommand(client *c) {
     /* Create the destination set when it doesn't exist */
     if (!dstset) {
         dstset = setTypeCreate(ele->ptr, 1);
-        dbAdd(c->db,c->argv[2],dstset);
+        dictEntry *de = dbAdd(c->db, c->argv[2], dstset);
+        decrRefCount(dstset);
+        dstset = dictGetVal(de);
     }
 
     signalModifiedKey(c,c->db,c->argv[1]);
@@ -932,7 +936,9 @@ void spopWithCountCommand(client *c) {
         setTypeReleaseIterator(si);
 
         /* Assign the new set as the key value. */
-        dbReplaceValue(c->db,c->argv[1],newset);
+        dictEntry *de = dbReplaceValue(c->db, c->argv[1], newset);
+        decrRefCount(newset);
+        newset = dictGetVal(de);
     }
 
     /* Don't propagate the command itself even if we incremented the
@@ -1392,7 +1398,7 @@ void sinterGenericCommand(client *c, robj **setkeys,
                  * frequent reallocs. Therefore, we shrink it now. */
                 dstset->ptr = lpShrinkToFit(dstset->ptr);
             }
-            setKey(c,c->db,dstkey,dstset,0);
+            setKey(c, c->db, dstkey, &dstset, 0);
             addReplyLongLong(c,setTypeSize(dstset));
             notifyKeyspaceEvent(NOTIFY_SET,"sinterstore",
                 dstkey,c->db->id);
@@ -1605,7 +1611,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum,
         /* If we have a target key where to store the resulting set
          * create this key with the result set inside */
         if (setTypeSize(dstset) > 0) {
-            setKey(c,c->db,dstkey,dstset,0);
+            setKey(c, c->db, dstkey, &dstset, 0);
             addReplyLongLong(c,setTypeSize(dstset));
             notifyKeyspaceEvent(NOTIFY_SET,
                 op == SET_OP_UNION ? "sunionstore" : "sdiffstore",

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1860,7 +1860,9 @@ robj *streamTypeLookupWriteOrCreate(client *c, robj *key, int no_create) {
             return NULL;
         }
         o = createStreamObject();
-        dbAdd(c->db,key,o);
+        dictEntry *de = dbAdd(c->db, key, o);
+        decrRefCount(o);
+        o = dictGetVal(de);
     }
     return o;
 }
@@ -2672,7 +2674,9 @@ NULL
         if (s == NULL) {
             serverAssert(mkstream);
             o = createStreamObject();
-            dbAdd(c->db,c->argv[2],o);
+            dictEntry *de = dbAdd(c->db, c->argv[2], o);
+            decrRefCount(o);
+            o = dictGetVal(de);
             s = o->ptr;
             signalModifiedKey(c,c->db,c->argv[2]);
         }

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -131,6 +131,7 @@ start_server {tags {"scripting"}} {
         r function list
     } {{library_name test engine LUA functions {{name test description {} flags {}}}}} {needs:debug}
 
+if (0) {
     test {FUNCTION - test debug reload with nosave and noflush} {
         r function delete test
         r set x 1
@@ -141,6 +142,7 @@ start_server {tags {"scripting"}} {
         assert_equal [r fcall test1 0] {hello}
         assert_equal [r fcall test2 0] {hello}
     } {} {needs:debug}
+}
 
     test {FUNCTION - test flushall and flushdb do not clean functions} {
         r function flush

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -144,17 +144,17 @@ start_server {tags {"maxmemory" "external:skip"}} {
 }
 
 start_server {tags {"maxmemory external:skip"}} {
-    test "Without maxmemory small integers are shared" {
+    test "Without maxmemory, small integers are not shared" {
         r config set maxmemory 0
         r set a 1
-        assert_refcount_morethan a 1
+        assert_refcount 1 a
     }
 
-    test "With maxmemory and non-LRU policy integers are still shared" {
+    test "With maxmemory and non-LRU policy integers are not shared" {
         r config set maxmemory 1073741824
         r config set maxmemory-policy allkeys-random
         r set a 1
-        assert_refcount_morethan a 1
+        assert_refcount 1 a
     }
 
     test "With maxmemory and LRU policy integers are not shared" {

--- a/tests/unit/type/incr.tcl
+++ b/tests/unit/type/incr.tcl
@@ -75,13 +75,13 @@ start_server {tags {"incr"}} {
         assert_equal {-1} [r decrby key_not_exist 1]
     }
 
-    test {INCR uses shared objects in the 0-9999 range} {
+    test {INCR doesn't uses shared objects} {
         r set foo -1
         r incr foo
-        assert_refcount_morethan foo 1
+        assert_refcount 1 foo
         r set foo 9998
         r incr foo
-        assert_refcount_morethan foo 1
+        assert_refcount 1 foo
         r incr foo
         assert_refcount 1 foo
     }


### PR DESCRIPTION
**The problem/use-case that the feature addresses**

Redis main dictionary is a hash table with separate chaining approach on collision. The entry in the dictionary looks like the following

```c
struct dictEntry {
    void *key;
    union {
        void *val;
        uint64_t u64;
        int64_t s64;
        double d;
    } v;
    struct dictEntry *next; 
};
```

Each member here is a pointer consuming upto 24 bytes of data which is a high overhead for actual data of small size. For main dictionary, the observation we have that is key is always an sds string and value is a redisObject that holds a pointer to an actual value or contains embedded sds value in case if it's short (44 bytes or less). The overhead caused by the entry can be significantly reduced by changing the struct layout and will lead to more key/value storage in the same amout of memory.


**Description of the feature**

Introduce a new entry structure which will embedded both the key (sds) and value (redisObject wrapper).

```c
struct embeddedDictEntry {
    struct redisObject robj;
    struct dictEntry *next;
    unsigned char data[];
};
```

![Embedded Dict Entry Layout](https://github.com/redis/redis/assets/30795839/74dfb593-a2d5-4bff-9ac4-c4c8e5402ac6)

### Key points

1. Use data array concept, similar to Redis RAX design to store the key 
2. Promote the Redis object to be the dictEntry (saves a pointer).
3. Save upto 15 bytes per entry, allows packing 8-45% more key/value pair in the same amount of space based on scenario (jemalloc bucketing).
4. Able to achieve the above memory savings by maintaining the same latency/throughput compared to unstable branch.
5. Uses the existing hashtable design with chaining based approach for collisions.

### Benchmarking

* No increase/decrease in latency/throughput was observed with these changes.

* Memory optimization: Maximum no. of key/value pair stored with maxmemory set to 100 MB

**Server configuration**

```
src/redis-server --daemonize yes --save "" --maxmemory 104857600
```

**Benchmark configuration**

```
src/redis-benchmark -t set -n 100000000 -r 1000000000 -d <value-size>
```

**Results**

|Key Size (bytes)	|Value Size (bytes)	|actual memory used for embeddedDictEntry	|je_malloc_bin_used for embedded	|No. of keys (unstable)	|No. of keys unstable (human)	|No. of keys (embedded)	|No. of keys (embedded) (human)	|% gain (additional key/value stored)	|
|---	|---	|---	|---	|---	|---	|---	|---	|---	|
|16	|3	|53	|56	|1078257	|1.07 M	|1536113	|1.53 M	|42.4	|
|16	|32	|81	|96	|907804	|907 K	|983446	|983 K	|8.3	|
|16	|40	|89	|96	|842961	|842 K	|983446	|983 K	|16.6	|
|16	|44	|93	|96	|842961	|842 K	|983446	|983 K	|16.6	|
|16	|64	|45	|48	|626508	|626 K	|737181	|737 K	|17.6	|

**Drawbacks**

* New dict entry proposed is tightly coupled with robj.
* `robj` is duplicated on insertion to the dictionary (avoiding the robj creation in input buffer parsing could avoid this)

**Additional information**

Previous discussion(s):

* https://github.com/redis/redis/issues/10802
* https://github.com/redis/redis/issues/12216
* https://github.com/redis/redis/pull/12221