### PR TITLE
Introduce listSearchDel to simplify some code

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1304,11 +1304,9 @@ int ACLSetUser(user *u, const char *op, ssize_t oplen) {
             }
             delpass = sdsnewlen(op+1,oplen-1);
         }
-        listNode *ln = listSearchKey(u->passwords,delpass);
+        int result = listSearchDel(u->passwords,delpass);
         sdsfree(delpass);
-        if (ln) {
-            listDelNode(u->passwords,ln);
-        } else {
+        if (!result) {
             errno = ENODEV;
             return C_ERR;
         }

--- a/src/adlist.c
+++ b/src/adlist.c
@@ -338,6 +338,19 @@ listNode *listSearchKey(list *list, void *key)
     return NULL;
 }
 
+/* Search the list for a node matching the given key, and delete
+ * it if found. The search is performed the same listSearchKey.
+ *
+ * Returns 1 if the key was found and deleted, 0 otherwise. */
+int listSearchDel(list *list, void *key)
+{
+    listNode *ln = listSearchKey(list, key);
+    if (!ln)
+        return 0;
+    listDelNode(list, ln);
+    return 1;
+}
+
 /* Return the element at the specified zero-based index
  * where 0 is the head, 1 is the element next to head
  * and so on. Negative integers are used in order to count

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -82,6 +82,7 @@ listNode *listNext(listIter *iter);
 void listReleaseIterator(listIter *iter);
 list *listDup(list *orig);
 listNode *listSearchKey(list *list, void *key);
+int listSearchDel(list *list, void *key);
 listNode *listIndex(list *list, long index);
 void listRewind(list *list, listIter *li);
 void listRewindTail(list *list, listIter *li);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4896,7 +4896,10 @@ int clusterDelSlot(int slot) {
     /* Cleanup the channels in master/replica as part of slot deletion. */
     list *nodes_for_slot = clusterGetNodesInMyShard(n);
     serverAssert(nodes_for_slot != NULL);
-    listSearchDel(nodes_for_slot, myself);
+    listNode *ln = listSearchKey(nodes_for_slot, myself);
+    if (ln != NULL) {
+        removeChannelsInSlot(slot);
+    }
     serverAssert(clusterNodeClearSlotBit(n,slot) == 1);
     server.cluster->slots[slot] = NULL;
     return C_OK;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1685,10 +1685,7 @@ void clusterRemoveNodeFromShard(clusterNode *node) {
     dictEntry *de = dictFind(server.cluster->shards, s);
     if (de != NULL) {
         list *l = dictGetVal(de);
-        listNode *ln = listSearchKey(l, node);
-        if (ln != NULL) {
-            listDelNode(l, ln);
-        }
+        listSearchDel(l, node);
         if (listLength(l) == 0) {
             dictDelete(server.cluster->shards, s);
         }
@@ -4899,10 +4896,7 @@ int clusterDelSlot(int slot) {
     /* Cleanup the channels in master/replica as part of slot deletion. */
     list *nodes_for_slot = clusterGetNodesInMyShard(n);
     serverAssert(nodes_for_slot != NULL);
-    listNode *ln = listSearchKey(nodes_for_slot, myself);
-    if (ln != NULL) {
-        removeChannelsInSlot(slot);
-    }
+    listSearchDel(nodes_for_slot, myself);
     serverAssert(clusterNodeClearSlotBit(n,slot) == 1);
     server.cluster->slots[slot] = NULL;
     return C_OK;

--- a/src/eval.c
+++ b/src/eval.c
@@ -857,12 +857,7 @@ void ldbEndSession(client *c) {
  * forked debugging sessions, it is removed from the children list.
  * If the pid was found non-zero is returned. */
 int ldbRemoveChild(pid_t pid) {
-    listNode *ln = listSearchKey(ldb.children,(void*)(unsigned long)pid);
-    if (ln) {
-        listDelNode(ldb.children,ln);
-        return 1;
-    }
-    return 0;
+    return listSearchDel(ldb.children,(void*)(unsigned long)pid);
 }
 
 /* Return the number of children we still did not receive termination

--- a/src/module.c
+++ b/src/module.c
@@ -10635,16 +10635,13 @@ RedisModuleCommandFilter *RM_RegisterCommandFilter(RedisModuleCtx *ctx, RedisMod
 /* Unregister a command filter.
  */
 int RM_UnregisterCommandFilter(RedisModuleCtx *ctx, RedisModuleCommandFilter *filter) {
-    int result;
-
     /* A module can only remove its own filters */
     if (filter->module != ctx->module) return REDISMODULE_ERR;
 
-    result = listSearchDel(moduleCommandFilters,filter);
-    if (!result) return REDISMODULE_ERR;
+    if (!listSearchDel(moduleCommandFilters,filter)) return REDISMODULE_ERR;
 
-    result = listSearchDel(ctx->module->filters,filter);
-    if (!result) return REDISMODULE_ERR;    /* Shouldn't happen */
+    /* This should always succeed, but adding a defensive return here. */
+    if (!listSearchDel(ctx->module->filters,filter)) return REDISMODULE_ERR;
 
     zfree(filter);
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1485,8 +1485,8 @@ void unlinkClient(client *c) {
     /* When client was just unblocked because of a blocking operation,
      * remove it from the list of unblocked clients. */
     if (c->flags & CLIENT_UNBLOCKED) {
-        int result = listSearchDel(server.unblocked_clients,c);
-        serverAssert(result);
+        int deleted = listSearchDel(server.unblocked_clients,c);
+        serverAssert(deleted);
         c->flags &= ~CLIENT_UNBLOCKED;
     }
 

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -273,7 +273,6 @@ int pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
 int pubsubUnsubscribeChannel(client *c, robj *channel, int notify, pubsubtype type) {
     dictEntry *de;
     list *clients;
-    listNode *ln;
     int retval = 0;
 
     /* Remove the channel from the client -> channels hash table */
@@ -285,9 +284,8 @@ int pubsubUnsubscribeChannel(client *c, robj *channel, int notify, pubsubtype ty
         de = dictFind(*type.serverPubSubChannels, channel);
         serverAssertWithInfo(c,NULL,de != NULL);
         clients = dictGetVal(de);
-        ln = listSearchKey(clients,c);
-        serverAssertWithInfo(c,NULL,ln != NULL);
-        listDelNode(clients,ln);
+        int result = listSearchDel(clients,c);
+        serverAssertWithInfo(c,NULL,result);
         if (listLength(clients) == 0) {
             /* Free the list and associated hash entry at all if this was
              * the latest client, so that it will be possible to abuse
@@ -369,7 +367,6 @@ int pubsubSubscribePattern(client *c, robj *pattern) {
 int pubsubUnsubscribePattern(client *c, robj *pattern, int notify) {
     dictEntry *de;
     list *clients;
-    listNode *ln;
     int retval = 0;
 
     incrRefCount(pattern); /* Protect the object. May be the same we remove */
@@ -379,9 +376,8 @@ int pubsubUnsubscribePattern(client *c, robj *pattern, int notify) {
         de = dictFind(server.pubsub_patterns,pattern);
         serverAssertWithInfo(c,NULL,de != NULL);
         clients = dictGetVal(de);
-        ln = listSearchKey(clients,c);
-        serverAssertWithInfo(c,NULL,ln != NULL);
-        listDelNode(clients,ln);
+        int result = listSearchDel(clients,c);
+        serverAssertWithInfo(c,NULL,result);
         if (listLength(clients) == 0) {
             /* Free the list and associated hash entry at all if this was
              * the latest client. */

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -370,7 +370,6 @@ static void freeRedisConfig(redisConfig *cfg) {
 
 static void freeClient(client c) {
     aeEventLoop *el = CLIENT_GET_EVENTLOOP(c);
-    listNode *ln;
     aeDeleteFileEvent(el,c->context->fd,AE_WRITABLE);
     aeDeleteFileEvent(el,c->context->fd,AE_READABLE);
     if (c->thread_id >= 0) {
@@ -387,9 +386,8 @@ static void freeClient(client c) {
     zfree(c);
     if (config.num_threads) pthread_mutex_lock(&(config.liveclients_mutex));
     config.liveclients--;
-    ln = listSearchKey(config.clients,c);
-    assert(ln != NULL);
-    listDelNode(config.clients,ln);
+    int result = listSearchDel(config.clients,c);
+    assert(result);
     if (config.num_threads) pthread_mutex_unlock(&(config.liveclients_mutex));
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -3603,9 +3603,8 @@ void waitaofCommand(client *c) {
  * waiting for replica acks. Never call it directly, call unblockClient()
  * instead. */
 void unblockClientWaitingReplicas(client *c) {
-    listNode *ln = listSearchKey(server.clients_waiting_acks,c);
-    serverAssert(ln != NULL);
-    listDelNode(server.clients_waiting_acks,ln);
+    int result = listSearchDel(server.clients_waiting_acks,c);
+    serverAssert(result);
     updateStatsOnUnblock(c, 0, 0, 0);
 }
 


### PR DESCRIPTION
Minor cleanup. While messing around with a prototype I implemented this API, but ended up scrapping the prototype.

Introduce a lisetSearchDel API, which takes in a key and uses the built in search to find and delete it. This is a common pattern in our codebase.