### PR TITLE
POC for CSCAN that does incremental cluster scanning

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -1736,6 +1736,35 @@ struct COMMAND_ARG COPY_Args[] = {
 {MAKE_ARG("replace",ARG_TYPE_PURE_TOKEN,-1,"REPLACE",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
 };
 
+/********** CSCAN ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* CSCAN history */
+#define CSCAN_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* CSCAN tips */
+const char *CSCAN_Tips[] = {
+"nondeterministic_output",
+};
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* CSCAN key specs */
+keySpec CSCAN_Keyspecs[1] = {
+{NULL,CMD_KEY_NOT_KEY,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+};
+#endif
+
+/* CSCAN argument table */
+struct COMMAND_ARG CSCAN_Args[] = {
+{MAKE_ARG("cursor",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("pattern",ARG_TYPE_PATTERN,-1,"MATCH",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("count",ARG_TYPE_INTEGER,-1,"COUNT",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("type",ARG_TYPE_STRING,-1,"TYPE",NULL,NULL,CMD_ARG_OPTIONAL,0,NULL)},
+};
+
 /********** DEL ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -10606,6 +10635,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("select","Changes the selected database.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,SELECT_History,0,SELECT_Tips,0,selectCommand,2,CMD_LOADING|CMD_STALE|CMD_FAST,ACL_CATEGORY_CONNECTION,SELECT_Keyspecs,0,NULL,1),.args=SELECT_Args},
 /* generic */
 {MAKE_CMD("copy","Copies the value of a key to a new key.","O(N) worst case for collections, where N is the number of nested items. O(1) for string values.","6.2.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,COPY_History,0,COPY_Tips,0,copyCommand,-3,CMD_WRITE|CMD_DENYOOM,ACL_CATEGORY_KEYSPACE,COPY_Keyspecs,2,NULL,4),.args=COPY_Args},
+{MAKE_CMD("cscan","Placeholder text.","Placeholder text.","8.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,CSCAN_History,0,CSCAN_Tips,1,cscanCommand,-2,CMD_READONLY|CMD_TOUCHES_ARBITRARY_KEYS,ACL_CATEGORY_KEYSPACE,CSCAN_Keyspecs,1,NULL,4),.args=CSCAN_Args},
 {MAKE_CMD("del","Deletes one or more keys.","O(N) where N is the number of keys that will be removed. When a key to remove holds a value other than a string, the individual complexity for this key is O(M) where M is the number of elements in the list, set, sorted set or hash. Removing a single key that holds a string value is O(1).","1.0.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,DEL_History,0,DEL_Tips,2,delCommand,-2,CMD_WRITE,ACL_CATEGORY_KEYSPACE,DEL_Keyspecs,1,NULL,1),.args=DEL_Args},
 {MAKE_CMD("dump","Returns a serialized representation of the value stored at a key.","O(1) to access the key and additional O(N*M) to serialize it, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1).","2.6.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,DUMP_History,0,DUMP_Tips,1,dumpCommand,2,CMD_READONLY,ACL_CATEGORY_KEYSPACE,DUMP_Keyspecs,1,NULL,1),.args=DUMP_Args},
 {MAKE_CMD("exists","Determines whether one or more keys exist.","O(N) where N is the number of keys to check.","1.0.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,EXISTS_History,1,EXISTS_Tips,2,existsCommand,-2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_KEYSPACE,EXISTS_Keyspecs,1,NULL,1),.args=EXISTS_Args},

--- a/src/server.h
+++ b/src/server.h
@@ -3467,6 +3467,7 @@ void swapdbCommand(client *c);
 void randomkeyCommand(client *c);
 void keysCommand(client *c);
 void scanCommand(client *c);
+void cscanCommand(client *c);
 void dbsizeCommand(client *c);
 void lastsaveCommand(client *c);
 void saveCommand(client *c);

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -34,7 +34,7 @@ set ::redis_cluster::plain_commands {
     hgetall hexists hscan incrby decrby incrbyfloat getset move
     expire expireat pexpire pexpireat type ttl pttl persist restore
     dump bitcount bitpos pfadd pfcount cluster ssubscribe spublish
-    sunsubscribe
+    sunsubscribe cscan
 }
 
 # Create a cluster client. The nodes are given as a list of host:port. The TLS

--- a/tests/unit/cluster/cluster-scan.tcl
+++ b/tests/unit/cluster/cluster-scan.tcl
@@ -1,0 +1,22 @@
+source tests/support/cluster.tcl
+
+# Start a cluster with 3 masters
+start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-replica-no-failover yes}} {
+    test "Test keys distributed to mutiple nodes are all hit during cluster scan" {
+        # Cluster client handles redirection, so fill the cluster with 10000 keys
+        set cluster [redis_cluster [srv 0 host]:[srv 0 port]]
+        set total_keys 10000
+        for {set j 0} {$j < $total_keys} {incr j} {
+            $cluster set $j foo
+        }
+        
+        set key_count 0
+        set cursor [$cluster cscan "0"]
+        while {$cursor != "0"} {
+            set result [$cluster cscan $cursor]
+            set cursor [lindex $result 0]
+            set key_count [expr $key_count + [llength [lindex $result 1]]]
+        }
+        assert_equal $total_keys $key_count
+    }
+}


### PR DESCRIPTION
I wanted to show a PoC for my proposal for CSCAN from https://github.com/redis/redis/issues/2702.

Clients start by sending the cscan command with an initial cursor value of zero. The response will contain an initialized cursor that can be used to scan the cluster. The cursor takes the form:
`<version>-<hashed_cursor>-<slot-cursor`. The hashed_cursor is specifically formed so that it clients can route it as if it was a key. The key benefit is that most clients will know which node to send the next command to.

I didn't build this ontop of the new per-slot dictionary, so right now it always returns all of the keys from the slot.

The psuedo code for using it:
```
# Initial cursor call, does not return any elements but initializes the scan.
cursor = client.cscan("0")
# keep calling the cscan with the updated cursor. 
# Element 0 is the updated cursor, element 1 is the returned keys.
while cursor[0]!="0":
    keys = cursor[1]
    cursor = client.cscan(cursor[0])
```