### PR TITLE
redis.conf: Add data loss warning to "appendonly"

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1382,6 +1382,10 @@ disable-thp yes
 # If the AOF is enabled on startup Redis will load the AOF, that is the file
 # with the better durability guarantees.
 #
+# Note that changing this value in a config file of an existing database and
+# restarting the server can lead to data loss. A conversion needs to be done
+# by setting it via CONFIG command on a live server first.
+#
 # Please check https://redis.io/topics/persistence for more information.
 
 appendonly no


### PR DESCRIPTION
warning against editing the config file and restarting the server.
which will attempt to load an AOF file and disregard the RDB.

Fixes #12484