### PR TITLE
Call emptyData when disk-based sync rdbLoad fails

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2236,6 +2236,10 @@ void readSyncBulkPayload(connection *conn) {
                                     "disabled");
                 bg_unlink(server.rdb_filename);
             }
+
+            /* If disk-based RDB loading fails, remove the half-loaded dataset. */
+            emptyData(-1, empty_db_flags, replicationEmptyDbCallback);
+
             /* Note that there's no point in restarting the AOF on sync failure,
                it'll be restarted when sync succeeds or replica promoted. */
             return;


### PR DESCRIPTION
We doing this in diskless on-empty-db mode, when diskless
loading fails, we will call emptyData to remove the half-loaded
data in case we started with an empty replica.

Now when a disk-based sync rdbLoad fails, we will call emptyData
too in case it loads partially incomplete data.

when the replica attempts another re-sync, it'll empty the dataset
again anyway, so this affects two things:
1. memory consumption in the time gap until the next rdb loading begins
2. if the unsynced replica is for some reason promoted, it would have kept
  the partial dataset instead of being empty.