### PR TITLE
Move the replace exists check in RESTORE to the back

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -6606,13 +6606,6 @@ void restoreCommand(client *c) {
         }
     }
 
-    /* Make sure this key does not already exist here... */
-    robj *key = c->argv[1];
-    if (!replace && lookupKeyWrite(c->db,key) != NULL) {
-        addReplyErrorObject(c,shared.busykeyerr);
-        return;
-    }
-
     /* Check if the TTL value makes sense */
     if (getLongLongFromObjectOrReply(c,c->argv[2],&ttl,NULL) != C_OK) {
         return;
@@ -6625,6 +6618,13 @@ void restoreCommand(client *c) {
     if (verifyDumpPayload(c->argv[3]->ptr,sdslen(c->argv[3]->ptr),NULL) == C_ERR)
     {
         addReplyError(c,"DUMP payload version or checksum are wrong");
+        return;
+    }
+
+    /* Make sure this key does not already exist here... */
+    robj *key = c->argv[1];
+    if (!replace && lookupKeyWrite(c->db,key) != NULL) {
+        addReplyErrorObject(c,shared.busykeyerr);
         return;
     }
 

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -75,10 +75,12 @@ start_server {tags {"dump"}} {
 
     test {RESTORE returns an error of the key already exists} {
         r set foo bar
-        set e {}
-        catch {r restore foo 0 "..."} e
-        set e
-    } {*BUSYKEY*}
+        assert_error {*value is not an integer or out of range*} {r restore foo bad_ttl bad_serialized_value}
+        assert_error {*DUMP payload version or checksum are wrong*} {r restore foo 0 bad_serialized_value}
+
+        set encoded [r dump foo]
+        assert_error {*BUSYKEY Target key name already exists*} {r restore foo 0 $encoded}
+    }
 
     test {RESTORE can overwrite an existing key with REPLACE} {
         r set foo bar1


### PR DESCRIPTION
It is a better behavior to validate inputs and syntax
before doing any checks on the contents of the db or
the server configuration.

Before:
```
127.0.0.1:6379> restore non-existing bad_ttl bad_serialized_value
(error) ERR value is not an integer or out of range
127.0.0.1:6379> restore non-existing 100 bad_serialized_value
(error) ERR DUMP payload version or checksum are wrong

127.0.0.1:6379> set busy_key val
OK
127.0.0.1:6379> restore busy_key bad_ttl bad_serialized_value
(error) BUSYKEY Target key name already exists.
```

After:
```
127.0.0.1:6379> set busy_key val
OK
127.0.0.1:6379> restore busy_key bad_ttl bad_serialized_value
(error) ERR value is not an integer or out of range
127.0.0.1:6379> restore busy_key 1 bad_serialized_value
(error) ERR DUMP payload version or checksum are wrong
```