### PR TITLE
Fix sort_ro get-keys function return wrong key number

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2294,7 +2294,8 @@ int sortROGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult
     keys = getKeysPrepareResult(result, 1);
     keys[0].pos = 1; /* <sort-key> is always present. */
     keys[0].flags = CMD_KEY_RO | CMD_KEY_ACCESS;
-    return 1;
+    result->numkeys = 1;
+    return result->numkeys;
 }
 
 /* Helper function to extract keys from the SORT command.

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -109,6 +109,10 @@ start_server {
     test "SORT extracts STORE correctly" {
         r command getkeys sort abc store def
     } {abc def}
+    
+    test "SORT_RO get keys" {
+        r command getkeys sort_ro abc
+    } {abc}
 
     test "SORT extracts multiple STORE correctly" {
         r command getkeys sort abc store invalid store stillbad store def


### PR DESCRIPTION
Before：
```
127.0.0.1:6379> command getkeys sort_ro key
(empty array)
127.0.0.1:6379>
```
After:
```
127.0.0.1:6379> command getkeys sort_ro key
1) "key"
127.0.0.1:6379>
```

This change also affects ACL, Redis may grant users executing this command access to keys that are not
explicitly authorized by the ACL configuration. (CVE-2023-41053)