### PR TITLE
Fix the missing rax itself when estimating Radix tree memory usage

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -987,7 +987,7 @@ char *strEncoding(int encoding) {
  * to compress prefixes. */
 size_t streamRadixTreeMemoryUsage(rax *rax) {
     size_t size = sizeof(*rax);
-    size = rax->numele * sizeof(streamID);
+    size += rax->numele * sizeof(streamID);
     size += rax->numnodes * sizeof(raxNode);
     /* Add a fixed overhead due to the aux data pointer, children, ... */
     size += rax->numnodes * sizeof(long)*30;


### PR DESCRIPTION
This is a simple fix.
~~Actually I'm curious why the estimated memory usage of radix node is `sizeof(long)*30`~~

After testing, the stream key with a size of 677MiB in the RDB file calculates that the memory usage is 9385MiB, and the redis server only allocates 4GiB memory.