### PR TITLE
Optimize SCAN with MATCH when pattern implies cluster slot

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -403,6 +403,7 @@ unsigned long getClusterConnectionsCount(void);
 int clusterSendModuleMessageToTarget(const char *target, uint64_t module_id, uint8_t type, const char *payload, uint32_t len);
 void clusterPropagatePublish(robj *channel, robj *message, int sharded);
 unsigned int keyHashSlot(char *key, int keylen);
+int patternHashSlot(char *pattern, int length);
 void clusterUpdateMyselfFlags(void);
 void clusterUpdateMyselfIp(void);
 void slotToChannelAdd(sds channel);

--- a/src/expire.c
+++ b/src/expire.c
@@ -275,7 +275,7 @@ void activeExpireCycle(int type) {
             long checked_buckets = 0;
 
             while (data.sampled < num && checked_buckets < max_buckets) {
-                db->expires_cursor = dbScan(db, DB_EXPIRES, db->expires_cursor, expireScanCallback, isExpiryDictValidForSamplingCb, &data);
+                db->expires_cursor = dbScan(db, DB_EXPIRES, db->expires_cursor, -1, expireScanCallback, isExpiryDictValidForSamplingCb, &data);
                 if (db->expires_cursor == 0) {
                     break;
                 }

--- a/src/module.c
+++ b/src/module.c
@@ -10981,7 +10981,7 @@ int RM_Scan(RedisModuleCtx *ctx, RedisModuleScanCursor *cursor, RedisModuleScanC
     }
     int ret = 1;
     ScanCBData data = { ctx, privdata, fn };
-    cursor->cursor = dbScan(ctx->client->db, DB_MAIN, cursor->cursor, moduleScanCallback, NULL, &data);
+    cursor->cursor = dbScan(ctx->client->db, DB_MAIN, cursor->cursor, -1, moduleScanCallback, NULL, &data);
     if (cursor->cursor == 0) {
         cursor->done = 1;
         ret = 0;

--- a/src/server.h
+++ b/src/server.h
@@ -3118,7 +3118,9 @@ int calculateKeySlot(sds key);
 unsigned long dbBuckets(redisDb *db, dbKeyType keyType);
 size_t dbMemUsage(redisDb *db, dbKeyType keyType);
 dictEntry *dbFind(redisDb *db, void *key, dbKeyType keyType);
-unsigned long long dbScan(redisDb *db, dbKeyType keyType, unsigned long long cursor, dictScanFunction *fn, int (dictScanValidFunction)(dict *d), void *privdata);
+unsigned long long dbScan(redisDb *db, dbKeyType keyType, unsigned long long cursor,
+                          int onlyslot, dictScanFunction *fn,
+                          int (dictScanValidFunction)(dict *d), void *privdata);
 int dbExpand(const redisDb *db, uint64_t db_size, dbKeyType keyType, int try_expand);
 unsigned long long cumulativeKeyCountRead(redisDb *db, int idx, dbKeyType keyType);
 int getFairRandomSlot(redisDb *db, dbKeyType keyType);

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -430,6 +430,29 @@ proc test_scan {type} {
             }
         }
     }
+
+    test "{$type} SCAN MATCH pattern implies cluster slot" {
+        # Tests the code path for an optimization for patterns like "{foo}-*"
+        # which implies that all matching keys belong to one slot.
+        r flushdb
+        for {set j 0} {$j < 100} {incr j} {
+            r set "{foo}-$j" "foo"
+            r set "{bar}-$j" "bar"
+        }
+
+        set cursor 0
+        set keys {}
+        while 1 {
+            set res [r scan $cursor match "{foo}-*"]
+            set cursor [lindex $res 0]
+            set k [lindex $res 1]
+            lappend keys {*}$k
+            if {$cursor == 0} break
+        }
+
+        set keys [lsort -unique $keys]
+        assert_equal 100 [llength $keys]
+    }
 }
 
 start_server {tags {"scan network standalone"}} {

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -436,8 +436,9 @@ proc test_scan {type} {
         # which implies that all matching keys belong to one slot.
         r flushdb
         for {set j 0} {$j < 100} {incr j} {
-            r set "{foo}-$j" "foo"
-            r set "{bar}-$j" "bar"
+            r set "{foo}-$j" "foo"; # slot 12182
+            r set "{bar}-$j" "bar"; # slot 5061
+            r set "{boo}-$j" "boo"; # slot 13142
         }
 
         set cursor 0


### PR DESCRIPTION
This is the optimization part of #2702. No API changes, just optimization.

```
Release notes
Optimize the performance of the SCAN command when a match pattern can only contain keys from a single slot in cluster mode.
```