### PR TITLE
Add logreqres:skip flag to new INFO obuf limit test

### DIFF
--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -362,6 +362,6 @@ start_server {tags {"info" "external:skip"}} {
             set info [r info stats]
             assert_equal [getInfoProperty $info client_output_buffer_limit_disconnections] {1}
             r config set client-output-buffer-limit $org_outbuf_limit
-        }
+        } {OK} {logreqres:skip} ;# same as obuf-limits.tcl, skip logreqres
     }
 }


### PR DESCRIPTION
The new test added in #12476 causes reply-schemas-validator to fail.
When doing `catch {r get key}`, the req-res output is:
```
3
get
3
key
12
__argv_end__
$100000
aaaaaaaaaaaaaaaaaaaa...4
info
5
stats
12
__argv_end__
=1670
txt:# Stats
...
```

And we can see the link after `$100000`, there is a 4 in the last,
it break the req-res-log-validator script since the format is wrong.

The reason i guess is after the client reconnection (after the output
buf limit), we will not add newlines, but append args directly.
Since obuf-limits.tcl is doing the same thing, and it had the logreqres:skip
flag, so this PR is following it.