### PR TITLE
Check shard_id pointer validity in updateShardId

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -938,13 +938,13 @@ static void updateAnnouncedHumanNodename(clusterNode *node, char *new) {
 
 
 static void updateShardId(clusterNode *node, const char *shard_id) {
-    if (memcmp(node->shard_id, shard_id, CLUSTER_NAMELEN) != 0) {
+    if (shard_id && memcmp(node->shard_id, shard_id, CLUSTER_NAMELEN) != 0) {
         clusterRemoveNodeFromShard(node);
         memcpy(node->shard_id, shard_id, CLUSTER_NAMELEN);
         clusterAddNodeToShard(shard_id, node);
         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
     }
-    if (myself != node && myself->slaveof == node) {
+    if (shard_id && myself != node && myself->slaveof == node) {
         if (memcmp(myself->shard_id, shard_id, CLUSTER_NAMELEN) != 0) {
             /* shard-id can diverge right after a rolling upgrade
              * from pre-7.2 releases */


### PR DESCRIPTION
Hello. While testing upgrade on sharded cluster from 7.0 to 7.2 we got the segmentation fault in updateShardId.
It seems that 7.0 nodes have no shard id in ping extensions.
Backtrace with gdb:
```
gdb /tmp/redis-server-asan /var/cores/redis-server-asan-26343-S11.core
Reading symbols from /tmp/redis-server-asan...
[New LWP 26343]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `/tmp/redis-server-asan *:6379 [cluster]     '.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f139f43f75b in kill () from /lib/x86_64-linux-gnu/libc.so.6
(gdb) bt
#0  0x00007f139f43f75b in kill () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x0000555c46cd6b4f in bugReportEnd (killViaSignal=1, sig=11) at /home/secwall/redis/src/debug.c:2224
#2  <signal handler called>
#3  0x0000555c46ce10eb in updateShardId (node=0x555c47df2b20, shard_id=0x0) at /home/secwall/redis/src/cluster.c:941
#4  0x0000555c46cec076 in clusterProcessPacket (link=link@entry=0x555c47df0990) at /home/secwall/redis/src/cluster.c:3099
#5  0x0000555c46ceca96 in clusterReadHandler (conn=0x555c47df09f0) at /home/secwall/redis/src/cluster.c:3389
#6  0x0000555c46d77e6c in callHandler (handler=<optimized out>, conn=0x555c47df09f0) at /home/secwall/redis/src/connhelpers.h:79
#7  connSocketEventHandler (el=<optimized out>, fd=<optimized out>, clientData=0x555c47df09f0, mask=<optimized out>) at /home/secwall/redis/src/socket.c:298
#8  0x0000555c46c41469 in aeProcessEvents (flags=27, eventLoop=0x555c47d46670) at /home/secwall/redis/src/ae.c:436
#9  aeMain (eventLoop=0x555c47d46670) at /home/secwall/redis/src/ae.c:496
#10 0x0000555c46c35b9f in main (argc=2, argv=<optimized out>) at /home/secwall/redis/src/server.c:7378
```

This should fix issue #12507