### PR TITLE
Fix that slot return in CLUSTER SHARDS should be integer

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -5703,7 +5703,7 @@ void addShardReplyForClusterShards(client *c, list *nodes) {
         serverAssert((n->slot_info_pairs_count % 2) == 0);
         addReplyArrayLen(c, n->slot_info_pairs_count);
         for (int i = 0; i < n->slot_info_pairs_count; i++)
-            addReplyBulkLongLong(c, (unsigned long)n->slot_info_pairs[i]);
+            addReplyLongLong(c, (unsigned long)n->slot_info_pairs[i]);
     } else {
         /* If no slot info pair is provided, the node owns no slots */
         addReplyArrayLen(c, 0);

--- a/src/commands/cluster-shards.json
+++ b/src/commands/cluster-shards.json
@@ -26,7 +26,7 @@
                         "description": "an even number element array specifying the start and end slot numbers for slot ranges owned by this shard",
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "type": "integer"
                         }
                     },
                     "nodes": {


### PR DESCRIPTION
An unintentional change was introduced in #10536, we used
to use addReplyLongLong and now it is addReplyBulkLonglong,
revert it back the previous behavior.

It's already released in 7.2, so it might be a breaking change.

```
Release notes
Fix the return type of the slot number in cluster shards to integer, which maxes it consistent with past behavior.
```