### PR TITLE
Clear owner_not_claiming_slot bit for the slot in clusterDelSlot

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4930,6 +4930,8 @@ int clusterDelSlot(int slot) {
     }
     serverAssert(clusterNodeClearSlotBit(n,slot) == 1);
     server.cluster->slots[slot] = NULL;
+    /* Make owner_not_claiming_slot flag consistent with slot ownership information. */
+    bitmapClearBit(server.cluster->owner_not_claiming_slot, slot);
     return C_OK;
 }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2394,7 +2394,6 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                 }
                 clusterDelSlot(j);
                 clusterAddSlot(sender,j);
-                bitmapClearBit(server.cluster->owner_not_claiming_slot, j);
                 clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG|
                                      CLUSTER_TODO_UPDATE_STATE|
                                      CLUSTER_TODO_FSYNC_CONFIG);


### PR DESCRIPTION
Clear owner_not_claiming_slot bit for the slot in clusterDelSlot to keep it consistent with slot ownership information.

This was pointed out by @nandihalli in https://github.com/redis/redis/pull/12344

Writing unit tests for this change is not straightforward with the current test framework as it handles an edge case. The change is straightforward to reason about, so I didn't add a test.

```
Release notes
Fix an issue where slot ownership was not being properly handled when deleting a slot from a node.
```