### PR TITLE
Fix several bugs in quicklist:

### DIFF
--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -53,8 +53,7 @@ typedef struct quicklistNode {
     unsigned int container : 2;  /* PLAIN==1 or PACKED==2 */
     unsigned int recompress : 1; /* was this node previous compressed? */
     unsigned int attempted_compress : 1; /* node can't compress; too small */
-    unsigned int dont_compress : 1; /* prevent compression of entry that will be used later */
-    unsigned int extra : 9; /* more bits to steal for future usage */
+    unsigned int extra : 10; /* more bits to steal for future usage */
 } quicklistNode;
 
 /* quicklistLZF is a 8+N byte struct holding 'sz' followed by 'compressed'.


### PR DESCRIPTION
- As is disscussed in #12548: Certen call to function quicklistReplaceEntry(), quicklistInsertBefore() and quicklistInsertAfter() will cause a packed node violate size limit.
- As is disscussed in #12563: A node will not be compressed if it is not compress small enough. So node's member recompress will stay 0 after calling function quicklistDecompressNodeForUse(). If that node's entry is changed later, call function quicklistRecompressOnly() will not make that node compressed. In this situation, we should call function quicklistCompress() instead, I will take this approach in this commit, obviously it's not efficient. We should redesign 'recompress' to fundamentally solve the problem.
- struct quicklistNode's member dont_compress is removed.