### PR TITLE
Remove redundant statement call and add comment about mf_slave

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1020,7 +1020,8 @@ void clusterInit(void) {
      * discover the IP address via MEET messages. */
     deriveAnnouncedPorts(&myself->tcp_port, &myself->tls_port, &myself->cport);
 
-    server.cluster->mf_end = 0;
+    /* resetManualFailover performs an action based on the value of mf_slave before nullifying it,
+     * and the struct is allocated with zmalloc (not zeroed), so we need to set it to NULL here. */
     server.cluster->mf_slave = NULL;
     resetManualFailover();
     clusterUpdateMyselfFlags();


### PR DESCRIPTION
mf_end statement call is included in resetManualFailover, so remove it.
And add a comment to explain that mf_slave must be set to NULL in here.
