### PR TITLE
Validate cluster-announce-ip

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2392,6 +2392,16 @@ static int isValidAnnouncedNodename(char *val,const char **err) {
     return 1;
 }
 
+static int isValidIpOrEmpty(char *val, const char **err) {
+    if (val[0] == '\0') {
+        return 1; /* empty is OK */
+    } else if (anetResolve(NULL, val, NULL, 0, ANET_IP_ONLY) == ANET_ERR) {
+        *err = "Invalid IP address";
+        return 0;
+    }
+    return 1;
+}
+
 static int isValidAnnouncedHostname(char *val, const char **err) {
     if (strlen(val) >= NET_HOST_STR_LEN) {
         *err = "Hostnames must be less than "
@@ -3102,7 +3112,7 @@ standardConfig static_configs[] = {
     createStringConfig("pidfile", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.pidfile, NULL, NULL, NULL),
     createStringConfig("replica-announce-ip", "slave-announce-ip", MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.slave_announce_ip, NULL, NULL, NULL),
     createStringConfig("masteruser", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.masteruser, NULL, NULL, NULL),
-    createStringConfig("cluster-announce-ip", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_ip, NULL, NULL, updateClusterIp),
+    createStringConfig("cluster-announce-ip", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_ip, NULL, isValidIpOrEmpty, updateClusterIp),
     createStringConfig("cluster-config-file", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.cluster_configfile, "nodes.conf", NULL, NULL),
     createStringConfig("cluster-announce-hostname", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_hostname, NULL, isValidAnnouncedHostname, updateClusterHostname),
     createStringConfig("cluster-announce-human-nodename", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_human_nodename, NULL, isValidAnnouncedNodename, updateClusterHumanNodename),

--- a/tests/unit/cluster/announced-endpoints.tcl
+++ b/tests/unit/cluster/announced-endpoints.tcl
@@ -42,10 +42,16 @@ start_cluster 2 2 {tags {external:skip cluster}} {
 
     test "Test change cluster-announce-ip at runtime" {
         assert_error "ERR CONFIG SET failed*" {
-            R 0 config set cluster-announce-ip blablabla
+            R 0 config set cluster-announce-ip 127.0.0.1:1234
         }
+        assert_error "ERR CONFIG SET failed*" {
+            R 0 config set cluster-announce-ip redis.example.com:1234
+        }
+        # Check that we accept an IP or a hostname (for backward compatibility)
         assert_equal OK [R 0 config set cluster-announce-ip 127.0.0.1]
         assert_equal {cluster-announce-ip 127.0.0.1} [R 0 config get cluster-announce-ip]
+        assert_equal OK [R 0 config set cluster-announce-ip redis.example.com]
+        assert_equal {cluster-announce-ip redis.example.com} [R 0 config get cluster-announce-ip]
         assert_equal OK [R 0 config set cluster-announce-ip ""]
         assert_equal {cluster-announce-ip {}} [R 0 config get cluster-announce-ip]
     }

--- a/tests/unit/cluster/announced-endpoints.tcl
+++ b/tests/unit/cluster/announced-endpoints.tcl
@@ -39,4 +39,14 @@ start_cluster 2 2 {tags {external:skip cluster}} {
         R 0 config set cluster-announce-bus-port 0
         assert_match "*@$base_bus_port *" [R 0 CLUSTER NODES]
     }
+
+    test "Test change cluster-announce-ip at runtime" {
+        assert_error "ERR CONFIG SET failed*" {
+            R 0 config set cluster-announce-ip blablabla
+        }
+        assert_equal OK [R 0 config set cluster-announce-ip 127.0.0.1]
+        assert_equal {cluster-announce-ip 127.0.0.1} [R 0 config get cluster-announce-ip]
+        assert_equal OK [R 0 config set cluster-announce-ip ""]
+        assert_equal {cluster-announce-ip {}} [R 0 config get cluster-announce-ip]
+    }
 }


### PR DESCRIPTION
Validate the config `cluster-announce-ip`.

We have a user who set it as `"10.1.150.58:6380"`, i.e included the port in this config. It took us a while to figure out what was wrong. Redis accepted it, the cluster client lib accepted it in the CLUSTER SLOTS reply, but connecting to the node didn't work, obviously. Config validation catches this error as early as possible.

Accept IPv4 and IPv6 but also a hostname, because users have abused this config for hostnames before cluster-announce-hostname was introduced. Also validate the length, so the field isn't silently truncated when the config is used in static strings.