### PR TITLE
add metric for pipeline in info command

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2612,7 +2612,7 @@ int processInputBuffer(client *c) {
     if (io_threads_op == IO_THREADS_OP_IDLE)
         updateClientMemUsageAndBucket(c);
     
-    if (!((c->flags & CLIENT_MASTER) && (c->flags & CLIENT_SCRIPT))) {
+    if (c->conn && !(c->flags & CLIENT_MASTER)) {
         atomicIncr(server.pipeline_requests, pipeline_requests);
         atomicIncr(server.pipeline_received, 1);
     }

--- a/src/server.h
+++ b/src/server.h
@@ -1720,7 +1720,7 @@ struct redisServer {
     durationStats duration_stats[EL_DURATION_TYPE_NUM];
     redisAtomic long long pipeline_requests; /* total number of requests received from the pipeline of clients */
     redisAtomic long long pipeline_received; /* total number of pipelines received */
-    double stat_requests_in_pipeline;  /* the average number of requests in per pipeline */
+    double stat_pipeline_average_last_sec;  /* the average number of requests in per pipeline */
 
     /* Configuration */
     int verbosity;                  /* Loglevel in redis.conf */

--- a/src/server.h
+++ b/src/server.h
@@ -1718,6 +1718,9 @@ struct redisServer {
        but excluding read, write and AOF, which are counted by other sets of metrics. */
     monotime el_cron_duration; 
     durationStats duration_stats[EL_DURATION_TYPE_NUM];
+    redisAtomic long long pipeline_requests; /* total number of requests received from the pipeline of clients */
+    redisAtomic long long pipeline_received; /* total number of pipelines received */
+    double stat_requests_in_pipeline;  /* the average number of requests in per pipeline */
 
     /* Configuration */
     int verbosity;                  /* Loglevel in redis.conf */


### PR DESCRIPTION
Pipelines can greatly improve the performance of Redis, but enough commands in the pipeline will only increase the latency without increasing the performance. Therefore, the change of pipeline is very important to the users or Redis proxy software.

I added a metric to `info stats` that represents the average number of commands in the pipeline over the last 1 second period, with a minimum value of 1.

demo
```
pipeline_average_last_sec:2.22
```