### PR TITLE
add metrics on client shutdown reasons

### DIFF
--- a/src/timeout.c
+++ b/src/timeout.c
@@ -65,6 +65,7 @@ int clientsCronHandleTimeout(client *c, mstime_t now_ms) {
         (now - c->lastinteraction > server.maxidletime))
     {
         serverLog(LL_VERBOSE,"Closing idle client");
+        c->closed_reason = CLIENT_CLOSED_REASON_IDLE_TIMEOUT;
         freeClient(c);
         return 1;
     } else if (c->flags & CLIENT_BLOCKED) {


### PR DESCRIPTION
Now that we have four statistics on why clients are closed, I'd like to add two more, maybe will be  very useful for users:

1. Number of connections closed due to idle timeout: The connection may be actively closed by redis when the timeout is enabled. Users may receive `RST` errors if they re-use the link without configuring `testOnBorrow`, so we need to know these numbers

2. Number of clients still had unfinished requests when the client was closing: this is precisely the state of the client when it is closed rather than the cause of the closure, but I want to put it here, usually it is the user's initiative to close due to the timeout configuration of the client, this increase in the count can imply that there is a latency problem with redis itself or the network.

I did a little refactoring of the associated code and fixed a minor (almost impossible) bug: `client_query_buffer_limit_disconnections` might have concurrency issues when io-threads is enabled