### PR TITLE
Fix compilation errors on macos with sdk 13.5.2

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -790,15 +790,12 @@ jobs:
         ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
   test-macos-latest:
-    runs-on: macos-13
+    runs-on: macos-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !(contains(github.event.inputs.skiptests, 'redis') && contains(github.event.inputs.skiptests, 'modules'))
     timeout-minutes: 14400
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest
     - name: prep
       if: github.event_name == 'workflow_dispatch'
       run: |
@@ -822,15 +819,12 @@ jobs:
       run: ./runtest-moduleapi --verbose --verbose --clients 1 --no-latency --dump-logs ${{github.event.inputs.test_args}}
 
   test-macos-latest-sentinel:
-    runs-on: macos-13
+    runs-on: macos-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !contains(github.event.inputs.skiptests, 'sentinel')
     timeout-minutes: 14400
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest
     - name: prep
       if: github.event_name == 'workflow_dispatch'
       run: |
@@ -851,15 +845,12 @@ jobs:
       run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
 
   test-macos-latest-cluster:
-    runs-on: macos-13
+    runs-on: macos-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !contains(github.event.inputs.skiptests, 'cluster')
     timeout-minutes: 14400
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest
     - name: prep
       if: github.event_name == 'workflow_dispatch'
       run: |

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -790,12 +790,15 @@ jobs:
         ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
   test-macos-latest:
-    runs-on: macos-latest
+    runs-on: macos-13
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !(contains(github.event.inputs.skiptests, 'redis') && contains(github.event.inputs.skiptests, 'modules'))
     timeout-minutes: 14400
     steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest
     - name: prep
       if: github.event_name == 'workflow_dispatch'
       run: |
@@ -819,12 +822,15 @@ jobs:
       run: ./runtest-moduleapi --verbose --verbose --clients 1 --no-latency --dump-logs ${{github.event.inputs.test_args}}
 
   test-macos-latest-sentinel:
-    runs-on: macos-latest
+    runs-on: macos-13
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !contains(github.event.inputs.skiptests, 'sentinel')
     timeout-minutes: 14400
     steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest
     - name: prep
       if: github.event_name == 'workflow_dispatch'
       run: |
@@ -845,12 +851,15 @@ jobs:
       run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
 
   test-macos-latest-cluster:
-    runs-on: macos-latest
+    runs-on: macos-13
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !contains(github.event.inputs.skiptests, 'cluster')
     timeout-minutes: 14400
     steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest
     - name: prep
       if: github.event_name == 'workflow_dispatch'
       run: |

--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -55,7 +55,7 @@
 #define _POSIX_C_SOURCE 199506L
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
 #define _DARWIN_C_SOURCE
 #endif
 

--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -55,6 +55,10 @@
 #define _POSIX_C_SOURCE 199506L
 #endif
 
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#endif
+
 #define _LARGEFILE_SOURCE
 #define _FILE_OFFSET_BITS 64
 


### PR DESCRIPTION
Fix #12585
macOS version definitions were removed from `AvailabilityMacros.h` since macOS SDK 13.5.2,
which resulted in the compiler not knowing the macOS version and using `fstat64` instead of `fstat`.
Add `_DARWIN_C_SOURCE` define to make the version be recognized.

CI with commit(fail) https://github.com/redis/redis/commit/aa40f1b01b749e9adc65ca10616733475e1ec5c5
https://github.com/sundb/redis/actions/runs/6271451836

CI with commit(success) https://github.com/redis/redis/commit/90f50d5ce97df34c68787609549af17fb395803f
https://github.com/sundb/redis/actions/runs/6273719849