### PR TITLE
Add new function lpTrim to optimize ltrimCommand

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1127,7 +1127,8 @@ unsigned char *lpTrim(unsigned char *lp, unsigned long ltrim, unsigned long rtri
     unsigned long rangelen = llen - ltrim - rtrim;
     unsigned char *first, *tail; /* first points to the first byte we want to save, 
                                     and tail points to the byte after the last byte we want to save */
-    if ((first = lpSeek(lp, ltrim)) == NULL) return lp;
+    first = lpSeek(lp, ltrim);
+    assert(first != NULL);
     tail = lp + bytes - 1; /* When rtrim is zero, tail points to the EOF char */
     if (rtrim) {
         if (rangelen < rtrim) {

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1127,7 +1127,7 @@ unsigned char *lpTrim(unsigned char *lp, unsigned long ltrim, unsigned long rtri
     unsigned long rangelen = llen - ltrim - rtrim;
     unsigned char *first, *tail; /* first points to the first byte we want to save, 
                                     and tail points to the byte after the last byte we want to save */
-    first = lpSeek(lp, ltrim);
+    if ((first = lpSeek(lp, ltrim)) == NULL) return lp;
     tail = lp + bytes - 1; /* When rtrim is zero, tail points to the EOF char */
     if (rtrim) {
         if (rangelen < rtrim) {

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -71,6 +71,7 @@ unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **new
 unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsigned long num);
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num);
 unsigned char *lpBatchDelete(unsigned char *lp, unsigned char **ps, unsigned long count);
+unsigned char *lpTrim(unsigned char *lp, unsigned long ltrim, unsigned long rtrim);
 unsigned char *lpMerge(unsigned char **first, unsigned char **second);
 unsigned char *lpDup(unsigned char *lp);
 unsigned long lpLength(unsigned char *lp);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -923,8 +923,7 @@ void ltrimCommand(client *c) {
         quicklistDelRange(o->ptr,0,ltrim);
         quicklistDelRange(o->ptr,-rtrim,rtrim);
     } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
-        o->ptr = lpDeleteRange(o->ptr,0,ltrim);
-        o->ptr = lpDeleteRange(o->ptr,-rtrim,rtrim);
+        o->ptr = lpTrim(o->ptr, ltrim, rtrim);
     } else {
         serverPanic("Unknown list encoding");
     }


### PR DESCRIPTION
This PR introduces a new function called lpTrim in order to optimize the current implementation of the ltrim command.

In the current implementation, we call lpDeleteRange twice, separately removing from the left and right sides. However, when removing from the left side, we use memmove to move not only the bytes we want to save but also the bytes we need to remove from the right side later, resulting in wastage.

In the new function, we directly move the bytes we want to save to the beginning of the listpack, eliminating the need for the memmove function to handle the bytes on the right side.  Additionally, we only call realloc once instead of twice.