### PR TITLE
#12605 for redis 7.2 Update cluster.c

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -3607,6 +3607,25 @@ void clusterSendPing(clusterLink *link, int type) {
          * already, so we just gossip about other nodes. */
         if (this == myself) continue;
 
+	/* In k8s cluster, ip may change when pod restart. We need to make sure the ip is correct. */    
+	char resolve_ip[NET_IP_STR_LEN];
+	if (anetResolve(NULL, this->hostname, resolve_ip, sizeof(resolve_ip), ANET_NONE)== ANET_ERR)
+	{
+	    serverLog(LL_WARNING,"Invalid Ip address or hostname specified: %s", this->hostname);
+	    continue;
+	}   
+	if (strcmp(resolve_ip,this->ip) != 0)
+	{
+	    serverLog(LL_WARNING,"node %.40s change ip from %s to %s",this->name,this->ip,resolve_ip);
+	    redis_strlcpy(this->ip,resolve_ip,sizeof(resolve_ip));
+	}
+
+	if(this->tcp_port == 0 || this->cport == 0)
+	{
+	    serverLog(LL_WARNING,"tcp_port is %d, cport is %d.", this->tcp_port, this->cport);	
+	    continue;
+	}
+	    
         /* PFAIL nodes will be added later. */
         if (this->flags & CLUSTER_NODE_PFAIL) continue;
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2176,18 +2176,18 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
                 }
             }
 
-            /* If we already know this node, but it is not reachable, and
-             * we see a different address in the gossip section of a node that
-             * can talk with this other node, update the address, disconnect
+	    /* We see a different address in the gossip section of a node that 
+	     * can talk with this other node, or we already know this node, 
+	     * but it is not reachable, update the address, disconnect
              * the old link if any, so that we'll attempt to connect with the
              * new address. */
-            if (node->flags & (CLUSTER_NODE_FAIL|CLUSTER_NODE_PFAIL) &&
-                !(flags & CLUSTER_NODE_NOADDR) &&
-                !(flags & (CLUSTER_NODE_FAIL|CLUSTER_NODE_PFAIL)) &&
-                (strcasecmp(node->ip,g->ip) ||
+	    if ((strcasecmp(node->ip,g->ip) ||
                  node->tls_port != (server.tls_cluster ? ntohs(g->port) : ntohs(g->pport)) ||
                  node->tcp_port != (server.tls_cluster ? ntohs(g->pport) : ntohs(g->port)) ||
-                 node->cport != ntohs(g->cport)))
+		 node->cport != ntohs(g->cport)) ||
+		(node->flags & (CLUSTER_NODE_FAIL|CLUSTER_NODE_PFAIL) &&
+                !(flags & CLUSTER_NODE_NOADDR) &&
+                !(flags & (CLUSTER_NODE_FAIL|CLUSTER_NODE_PFAIL))))
             {
                 if (node->link) freeClusterLink(node->link);
                 memcpy(node->ip,g->ip,NET_IP_STR_LEN);
@@ -2195,6 +2195,7 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
                 node->tls_port = msg_tls_port;
                 node->cport = ntohs(g->cport);
                 node->flags &= ~CLUSTER_NODE_NOADDR;
+		clusterSaveConfigOrDie(1);
             }
         } else {
             /* If it's not in NOADDR state and we don't have it, we
@@ -2217,6 +2218,7 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
                 node->tls_port = msg_tls_port;
                 node->cport = ntohs(g->cport);
                 clusterAddNode(node);
+		clusterSaveConfigOrDie(1);
             }
         }
 


### PR DESCRIPTION
In k8s, redis cluster cannot work properly if the redis pod restarts and pod ip address changes.

redis 7.2, in the k8s cluster, if the pod restart ip changes, the redis cluster will not work properly. The log shows that the "port cport "information passed by gossip is correct, but the" ip:port@cport "in redis-node.conf is" 0@0 ". Using redi-cli --cluster check Cluster nodes are also abnormal. Redis didn't fix itself after a while.

SO for redis7.2，redis should send corret ip port when build send msg.