### PR TITLE
Dump server logs when corrupt fuzzer reports crash

### DIFF
--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -170,7 +170,7 @@ foreach sanitize_dump {no yes} {
 
                         if {$by_signal != 0 || $sanitize_dump == yes} {
                             if {$::dump_logs} {
-                                set srv [get_server 0]
+                                set srv [get_srv 0]
                                 dump_server_log $srv
                             }
 

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -169,6 +169,11 @@ foreach sanitize_dump {no yes} {
                         incr stat_terminated_by_signal $by_signal
 
                         if {$by_signal != 0 || $sanitize_dump == yes} {
+                            if {$::dump_logs} {
+                                set srv [get_server 0]
+                                dump_server_log $srv
+                            }
+
                             puts "Server crashed (by signal: $by_signal), with payload: $printable_dump"
                             set print_commands true
                         }

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -735,8 +735,13 @@ proc start_multiple_servers {num options code} {
     uplevel 1 $code
 }
 
-proc restart_server {level wait_ready rotate_logs {reconnect 1} {shutdown sigterm}} {
+proc get_server {level} {
     set srv [lindex $::servers end+$level]
+    return $srv
+}
+
+proc restart_server {level wait_ready rotate_logs {reconnect 1} {shutdown sigterm}} {
+    set srv [get_server $level]
     if {$shutdown ne {sigterm}} {
         catch {[dict get $srv "client"] shutdown $shutdown}
     }

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -735,13 +735,8 @@ proc start_multiple_servers {num options code} {
     uplevel 1 $code
 }
 
-proc get_server {level} {
-    set srv [lindex $::servers end+$level]
-    return $srv
-}
-
 proc restart_server {level wait_ready rotate_logs {reconnect 1} {shutdown sigterm}} {
-    set srv [get_server $level]
+    set srv [lindex $::servers end+$level]
     if {$shutdown ne {sigterm}} {
         catch {[dict get $srv "client"] shutdown $shutdown}
     }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -197,6 +197,12 @@ proc srv {args} {
     dict get $srv $property
 }
 
+# Take an index to get a srv.
+proc get_srv {level} {
+    set srv [lindex $::servers end+$level]
+    return $srv
+}
+
 # Provide easy access to the client for the inner server. It's possible to
 # prepend the argument list with a negative level to access clients for
 # servers running in outer blocks.


### PR DESCRIPTION
Recently we found some signal crashes, but unable to reproduce them.
It is a good idea to dump the server logs when a failure happends.