### PR TITLE
 reduce performance reccesion when db rehashing and delete metadata in db's main dict

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1392,7 +1392,7 @@ unsigned long dictScanDefrag(dict *d,
  * type has expandAllowed member function. */
 static int dictTypeExpandAllowed(dict *d) {
     if (d->type->expandAllowed == NULL) return 1;
-    return d->type->expandAllowed(
+    return d->type->expandAllowed(d,
                     DICTHT_SIZE(_dictNextExp(d->ht_used[0] + 1)) * sizeof(dictEntry*),
                     (double)d->ht_used[0] / DICTHT_SIZE(d->ht_size_exp[0]));
 }

--- a/src/dict.h
+++ b/src/dict.h
@@ -54,7 +54,7 @@ typedef struct dictType {
     int (*keyCompare)(dict *d, const void *key1, const void *key2);
     void (*keyDestructor)(dict *d, void *key);
     void (*valDestructor)(dict *d, void *obj);
-    int (*expandAllowed)(size_t moreMem, double usedRatio);
+    int (*expandAllowed)(dict *d, size_t moreMem, double usedRatio);
     /* Invoked at the start of dict initialization/rehashing (old and new ht are already created) */
     void (*rehashingStarted)(dict *d);
     /* Invoked at the end of dict initialization/rehashing of all the entries from old to new ht. Both ht still exists

--- a/src/server.c
+++ b/src/server.c
@@ -402,21 +402,19 @@ int dictExpandAllowed(dict *dict, size_t moreMem, double usedRatio) {
     if (usedRatio > HASHTABLE_MAX_LOAD_FACTOR) {
         return 1;
     }
-    if (overMaxmemoryAfterAlloc(moreMem))
-        return 0;
     if (server.cluster_enabled) {
         if (dict->type == &dbDictType || dict->type == &dbExpiresDictType) {
-            if (listLength(server.db[0].sub_dict[DB_MAIN].rehashing) ||
-                listLength(server.db[0].sub_dict[DB_EXPIRES].rehashing))
+            int rehashing = listLength(server.db[0].sub_dict[DB_MAIN].rehashing) +
+                            listLength(server.db[0].sub_dict[DB_EXPIRES].rehashing);
+            int slot = nodeIsMaster(server.cluster->myself) ? server.cluster->myself->numslots
+                                                            : server.cluster->myself->slaveof->numslots;
+            if (slot / 2 > rehashing)
                 return 0;
         }
     }
+    if (overMaxmemoryAfterAlloc(moreMem))
+        return 0;
     return 1;
-
-    /* Here we always update the dbid that will being rehashed,
-     * ignoring the db that was rehashed before, to prevent
-     * these db's from being rehashing maliciously for a long
-     * time, causing the other db's performance to degrade. */
 }
 
 /* Updates the bucket count in cluster-mode for the given dictionary in a DB. bucket count


### PR DESCRIPTION
To reduce performance reccesion, only half of the dicts  in the main dict are allowed to rehash at the a same time. 

When rehash occurs in db, the performance often drops sharply. Especially when rehash occurs in main dict and expire at the same time, the cpu usage may double, the latency also increases a lot(#11494 #12602), and simultaneous rehash may also bring some additional memory pressure.
