### PR TITLE
fix crash in crash-report and other improvements

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1055,6 +1055,7 @@ NULL
 
 /* =========================== Crash handling  ============================== */
 
+__attribute__ ((noinline)) 
 void _serverAssert(const char *estr, const char *file, int line) {
     bugReportStart();
     serverLog(LL_WARNING,"=== ASSERTION FAILED ===");
@@ -1144,6 +1145,7 @@ void _serverAssertWithInfo(const client *c, const robj *o, const char *estr, con
     _serverAssert(estr,file,line);
 }
 
+__attribute__ ((noinline)) 
 void _serverPanic(const char *file, int line, const char *msg, ...) {
     va_list ap;
     va_start(ap,msg);
@@ -1837,7 +1839,7 @@ typedef struct {
     void *trace[BACKTRACE_MAX_SIZE];
 } stacktrace_data;
 
-static void *collect_stacktrace_data(void) {
+__attribute__ ((noinline)) static void *collect_stacktrace_data(void) {
     /* allocate stacktrace_data struct */
     stacktrace_data *trace_data = zmalloc(sizeof(stacktrace_data));
 
@@ -1854,6 +1856,7 @@ static void *collect_stacktrace_data(void) {
     return trace_data;
 }
 
+__attribute__ ((noinline)) 
 static void writeStacktraces(int fd, int uplevel) {
     /* get the list of all the process's threads that don't block or ignore the THREADS_SIGNAL */
     pid_t pid = getpid();
@@ -1914,7 +1917,7 @@ static void writeStacktraces(int fd, int uplevel) {
 }
 
 #else /* __linux__*/
-
+__attribute__ ((noinline))
 static void writeStacktraces(int fd, int uplevel) {
     void *trace[BACKTRACE_MAX_SIZE];
 
@@ -1930,7 +1933,10 @@ static void writeStacktraces(int fd, int uplevel) {
  * to be called from signal handlers safely.
  * The eip argument is optional (can take NULL).
  * The uplevel argument indicates how many of the calling functions to skip.
+ * Functions that are taken in consideration in "uplevel" should be declared with
+ * __attribute__ ((noinline)) to make sure the compiler won't inline them.
  */
+__attribute__ ((noinline)) 
 void logStackTrace(void *eip, int uplevel) {
     int fd = openDirectLogFiledes();
     char *msg;
@@ -2220,6 +2226,7 @@ void invalidFunctionWasCalled(void) {}
 
 typedef void (*invalidFunctionWasCalledType)(void);
 
+__attribute__ ((noinline)) 
 static void sigsegvHandler(int sig, siginfo_t *info, void *secret) {
     UNUSED(secret);
     UNUSED(info);

--- a/src/debug.c
+++ b/src/debug.c
@@ -1871,7 +1871,6 @@ static void writeStacktraces(int fd, int uplevel) {
 
     size_t skipped = 0;
 
-
     char buff[MAX_BUFF_LENGTH];
     pid_t calling_tid = syscall(SYS_gettid);
     /* for backtrace_data in backtraces_data: */
@@ -1909,7 +1908,7 @@ static void writeStacktraces(int fd, int uplevel) {
     }
     zfree(stacktraces_data);
 
-    snprintf(buff, MAX_BUFF_LENGTH, "\n%lu/%lu expected stacktraces.\n", len_tids - skipped, len_tids);
+    snprintf(buff, MAX_BUFF_LENGTH, "\n%zu/%zu expected stacktraces.\n", len_tids - skipped, len_tids);
     if (write(fd,buff,strlen(buff)) == -1) {/* Avoid warning. */};
 
 }

--- a/src/threads_mngr.c
+++ b/src/threads_mngr.c
@@ -83,6 +83,7 @@ void ThreadsManager_init(void) {
     sigaction(SIGUSR2, &act, NULL);
 }
 
+__attribute__ ((noinline)) 
 void **ThreadsManager_runOnThreads(pid_t *tids, size_t tids_len, run_on_thread_cb callback) {
     /* Check if it is safe to start running. If not - return */
     if(test_and_start() == IN_PROGRESS) {
@@ -132,6 +133,7 @@ static int test_and_start(void) {
     return prev_state;
 }
 
+__attribute__ ((noinline)) 
 static void invoke_callback(int sig) {
     UNUSED(sig);
 

--- a/src/threads_mngr.c
+++ b/src/threads_mngr.c
@@ -64,7 +64,7 @@ static void invoke_callback(int sig);
 /* returns 0 if it is safe to start, IN_PROGRESS otherwise. */
 static int test_and_start(void);
 static void wait_threads(void);
-/* Clean up global variable. 
+/* Clean up global variable.
 Assuming we are under the g_in_progress protection, this is not a thread-safe function */
 static void ThreadsManager_cleanups(void);
 
@@ -95,7 +95,7 @@ void **ThreadsManager_runOnThreads(pid_t *tids, size_t tids_len, run_on_thread_c
     g_tids_len = tids_len;
 
     /* Allocate the output buffer */
-    g_output_array = zmalloc(sizeof(void*) * tids_len);
+    g_output_array = zcalloc(sizeof(void*) * tids_len);
 
     /* Initialize a semaphore that we will be waiting on for the threads
     use pshared = 0 to indicate the semaphore is shared between the process's threads (and not between processes),
@@ -160,12 +160,6 @@ static void wait_threads(void) {
     while ((status = sem_timedwait(&wait_for_threads_sem, &ts)) == -1 && errno == EINTR) {
         serverLog(LL_WARNING, "threads_mngr: waiting for threads' output was interrupted by signal. Continue waiting.");
         continue;
-    }
-
-    if (status == -1) {
-        if (errno == ETIMEDOUT) {
-            serverLog(LL_WARNING, "threads_mngr: waiting for threads' output timed out");
-        }
     }
 }
 

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -41,6 +41,23 @@ if {$backtrace_supported} {
             if {$::verbose} { puts $res }
         }
     }
+
+    set server_path [tmpdir server3.log]
+    start_server [list overrides [list dir $server_path]] {
+        test "Generate stacktrace on assertion" {
+            catch {r debug assert}
+            # If the stacktrace is printed more than once, it means we crashed.
+            assert_equal [count_log_message 0 "STACK TRACE"] 1
+
+            set pattern "*redis-server *main*"
+            set res [wait_for_log_messages 0 \"$pattern\" 0 100 100]
+            if {$::verbose} { puts $res }
+            set pattern "*debugCommand*"
+            set res [wait_for_log_messages 0 \"$pattern\" 0 100 100]
+            if {$::verbose} { puts $res }
+        }
+            
+    }
 }
 
 # Valgrind will complain that the process terminated by a signal, skip it.

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -19,16 +19,23 @@ if {$system_name eq {darwin}} {
     }
 }
 
-proc check_log_backtrace {} {
-    # If the stacktrace is printed more than once, it means we crashed.
+proc check_log_backtrace_for_debug {log_pattern} {
+    set res [wait_for_log_messages 0 \"$log_pattern\" 0 100 100]
+    if {$::verbose} { puts $res}          
+   
+    # If the stacktrace is printed more than once, it means redis crashed during crash report generation
     assert_equal [count_log_message 0 "STACK TRACE"] 1
 
-    set pattern "*redis-server *main*"
-    set res [wait_for_log_messages 0 \"$pattern\" 0 100 100]
-    if {$::verbose} { puts $res }
     set pattern "*debugCommand*"
     set res [wait_for_log_messages 0 \"$pattern\" 0 100 100]
     if {$::verbose} { puts $res}    
+    
+}
+
+# used when backtrace_supported == 0
+proc check_crash_log {log_pattern} {
+    set res [wait_for_log_messages 0 \"$log_pattern\" 0 50 100]
+    if {$::verbose} { puts $res }
 }
 
 if {$backtrace_supported} {
@@ -44,37 +51,31 @@ if {$backtrace_supported} {
                 assert_equal [count_log_message 0 "threads_mngr: waiting for threads' output timed out"] 0
                 assert_equal [count_log_message 0 "bioProcessBackgroundJobs"] 3
             }
-            
-            check_log_backtrace
+            check_log_backtrace_for_debug "*WATCHDOG TIMER EXPIRED*"
+            # make sure redis is still alive
+            assert_equal "PONG" [r ping]
         }
-    }
-
-    set server_path [tmpdir server3.log]
-    # Use exit() instead of abort() upon assertion so Valgrind tests won't fail.
-    start_server [list overrides [list dir $server_path use-exit-on-panic yes crash-memcheck-enabled no]] {
-        test "Generate stacktrace on assertion" {
-            catch {r debug assert}
-            check_log_backtrace
-        }
-            
     }
 }
 
 # Valgrind will complain that the process terminated by a signal, skip it.
 if {!$::valgrind} {
     if {$backtrace_supported} {
-        set crash_pattern "*STACK TRACE*"
-    } else {
-        set crash_pattern "*crashed by signal*"
+        set check_cb check_log_backtrace_for_debug
+    } else {  
+        set check_cb check_crash_log
     }
 
     set server_path [tmpdir server1.log]
     start_server [list overrides [list dir $server_path crash-memcheck-enabled no]] {
         test "Crash report generated on SIGABRT" {
             set pid [s process_id]
+            r deferred 1
+            r debug sleep 10
+            r flush
+            after 100 # wait for redis to get into the SLEEP
             exec kill -SIGABRT $pid
-            set res [wait_for_log_messages 0 \"$crash_pattern\" 0 50 100]
-            if {$::verbose} { puts $res }
+            $check_cb "*crashed by signal*"
         }
     }
 
@@ -82,13 +83,37 @@ if {!$::valgrind} {
     start_server [list overrides [list dir $server_path crash-memcheck-enabled no]] {
         test "Crash report generated on DEBUG SEGFAULT" {
             catch {r debug segfault}
-            if {$backtrace_supported} {
-                check_log_backtrace
-            } else {
-                set res [wait_for_log_messages 0 \"$crash_pattern\" 0 50 100]
-                if {$::verbose} { puts $res }
-            }
+            $check_cb "*crashed by signal*"
         }
+    }
+
+    set server_path [tmpdir server3.log]
+    start_server [list overrides [list dir $server_path]] {
+        test "Stacktraces generated on SIGALRM" {
+            set pid [s process_id]
+            r deferred 1
+            r debug sleep 10
+            r flush
+            after 100 # wait for redis to get into the SLEEP
+            exec kill -SIGALRM $pid
+            $check_cb "*Received SIGALRM*"
+            r read
+            r deferred 0
+            # make sure redis is still alive
+            assert_equal "PONG" [r ping]
+        }
+    }
+}
+
+if {$backtrace_supported} {
+    set server_path [tmpdir server4.log]
+    # Use exit() instead of abort() upon assertion so Valgrind tests won't fail.
+    start_server [list overrides [list dir $server_path use-exit-on-panic yes crash-memcheck-enabled no]] {
+        test "Generate stacktrace on assertion" {
+            catch {r debug assert}
+            check_log_backtrace_for_debug "*ASSERTION FAILED*"
+        }
+            
     }
 }
 

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -44,7 +44,7 @@ if {$backtrace_supported} {
 
     set server_path [tmpdir server3.log]
     # Use exit() instead of abort() upon assertion so Valgrind tests won't fail.
-    start_server [list overrides [list dir $server_path use-exit-on-panic yes]] {
+    start_server [list overrides [list dir $server_path use-exit-on-panic yes crash-memcheck-enabled no]] {
         test "Generate stacktrace on assertion" {
             catch {r debug assert}
             # If the stacktrace is printed more than once, it means we crashed.

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -43,7 +43,8 @@ if {$backtrace_supported} {
     }
 
     set server_path [tmpdir server3.log]
-    start_server [list overrides [list dir $server_path]] {
+    # Use exit() instead of abort() upon assertion so Valgrind tests won't fail.
+    start_server [list overrides [list dir $server_path use-exit-on-panic yes]] {
         test "Generate stacktrace on assertion" {
             catch {r debug assert}
             # If the stacktrace is printed more than once, it means we crashed.


### PR DESCRIPTION
## Crash fix
### Current behavior
We might crash if we fail to collect some of the threads' output. If it exceeds timeout for example.

The threads mngr API guarantees that the output array length will be `tids_len`, however, some indices can be NULL, in case it fails to collect some of the threads' outputs.

When we use the threads mngr to collect the threads' stacktraces, we rely on this and skip NULL entries. Since the output array was allocated with malloc, instead of NULL, it contained garbage, so we got a segmentation fault when trying to read this garbage. (in debug.c:writeStacktraces() )

### fix
Allocate the global output array with zcalloc.

### To reproduce the bug, you'll have to change the code:
**in threadsmngr:ThreadsManager_runOnThreads():**
make sure the g_output_array allocation is initialized with garbage and not 0s 
(add `memset(g_output_array, 2, sizeof(void*) * tids_len);` below the allocation).

Force one of the threads to write to the array:
add a global var: `static redisAtomic size_t return_now = 0;` 
add to `invoke_callback()` before writing to the output array:
```
    size_t i_return;
    atomicGetIncr(return_now, i_return, 1);
    if(i_return == 1) return;
```
compile, start the server with `--enable-debug-command local` and run `redis-cli debug assert` The assertion triggers the the stacktrace collection. 
Expect to get 2 prints of the stack trace - since we get the segmentation fault after we return from the threads mngr, it can be safely triggered again.

## Added global variables r/w lock in ThreadsManager
To avoid a situation where the main thread runs `ThreadsManager_cleanups` while threads are still invoking the signal handler, we use a r/w lock.
For cleanups, we will acquire the write lock.
The threads will acquire the read lock to enable them to write simultaneously.
If we fail to acquire the read lock, it means cleanups are in progress and we return immediately. After acquiring the lock we can safely check that the global output array wasn't nullified and proceed to write to it.
This way we ensure the threads are not modifying the global variables/ trying to write to the output array after they were zeroed/nullified/destroyed(the semaphore).

## other minor logging change
1. removed logging if the semaphore times out because the threads can still write to the output array after this check. Instead, we print the total number of printed stacktraces compared to the exacted number (len_tids).
2. use noinline attribute to make sure the uplevel number of ignored stack trace entries stays correct.
3. improve testing