### PR TITLE
Stabilization and improvements around aof tests

### DIFF
--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -38,7 +38,7 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.2.incr.aof seq 2 type i\n"
         }
 
-        start_server_aof_ex [list dir $server_path] [list short_life true] {
+        start_server_aof_ex [list dir $server_path] [list wait_ready false] {
             wait_for_condition 100 50 {
                 ! [is_alive [srv pid]]
             } else {
@@ -65,7 +65,7 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i\n"
         }
 
-        start_server_aof_ex [list dir $server_path] [list short_life true] {
+        start_server_aof_ex [list dir $server_path] [list wait_ready false] {
             wait_for_condition 100 50 {
                 ! [is_alive [srv pid]]
             } else {
@@ -93,7 +93,7 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.3.incr.aof seq 3 type i\n"
         }
 
-        start_server_aof_ex [list dir $server_path] [list short_life true] {
+        start_server_aof_ex [list dir $server_path] [list wait_ready false] {
             wait_for_condition 100 50 {
                 ! [is_alive [srv pid]]
             } else {
@@ -125,7 +125,7 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i\n"
         }
 
-        start_server_aof_ex [list dir $server_path] [list short_life true] {
+        start_server_aof_ex [list dir $server_path] [list wait_ready false] {
             wait_for_condition 100 50 {
                 ! [is_alive [srv pid]]
             } else {
@@ -152,7 +152,7 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i\n"
         }
 
-        start_server_aof_ex [list dir $server_path] [list short_life true] {
+        start_server_aof_ex [list dir $server_path] [list wait_ready false] {
             wait_for_condition 100 50 {
                 ! [is_alive [srv pid]]
             } else {
@@ -179,7 +179,7 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i\n"
         }
 
-        start_server_aof_ex [list dir $server_path] [list short_life true] {
+        start_server_aof_ex [list dir $server_path] [list wait_ready false] {
             wait_for_condition 100 50 {
                 ! [is_alive [srv pid]]
             } else {
@@ -206,7 +206,7 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof type i\n"
         }
 
-        start_server_aof_ex [list dir $server_path] [list short_life true] {
+        start_server_aof_ex [list dir $server_path] [list wait_ready false] {
             wait_for_condition 100 50 {
                 ! [is_alive [srv pid]]
             } else {
@@ -233,7 +233,7 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i\n"
         }
 
-        start_server_aof_ex [list dir $server_path] [list short_life true] {
+        start_server_aof_ex [list dir $server_path] [list wait_ready false] {
             wait_for_condition 100 50 {
                 ! [is_alive [srv pid]]
             } else {
@@ -260,7 +260,7 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i newkey\n"
         }
 
-        start_server_aof_ex [list dir $server_path] [list short_life true] {
+        start_server_aof_ex [list dir $server_path] [list wait_ready false] {
             wait_for_condition 100 50 {
                 ! [is_alive [srv pid]]
             } else {
@@ -277,7 +277,7 @@ tags {"external:skip"} {
         create_aof_manifest $aof_dirpath $aof_manifest_file {
         }
 
-        start_server_aof_ex [list dir $server_path] [list short_life true] {
+        start_server_aof_ex [list dir $server_path] [list wait_ready false] {
             wait_for_condition 100 50 {
                 ! [is_alive [srv pid]]
             } else {
@@ -577,7 +577,7 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof seq 1 type b\n"
         }
 
-        start_server_aof_ex [list dir $server_path] [list short_life true] {
+        start_server_aof_ex [list dir $server_path] [list wait_ready false] {
             wait_for_condition 100 50 {
                 ! [is_alive [srv pid]]
             } else {

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -38,9 +38,9 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.2.incr.aof seq 2 type i\n"
         }
 
-        start_server_aof [list dir $server_path] {
+        start_server_aof_ex [list dir $server_path] [list short_life true] {
             wait_for_condition 100 50 {
-                ! [is_alive $srv]
+                ! [is_alive [srv pid]]
             } else {
                 fail "AOF loading didn't fail"
             }
@@ -65,9 +65,9 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i\n"
         }
 
-        start_server_aof [list dir $server_path] {
+        start_server_aof_ex [list dir $server_path] [list short_life true] {
             wait_for_condition 100 50 {
-                ! [is_alive $srv]
+                ! [is_alive [srv pid]]
             } else {
                 fail "AOF loading didn't fail"
             }
@@ -93,9 +93,9 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.3.incr.aof seq 3 type i\n"
         }
 
-        start_server_aof [list dir $server_path] {
+        start_server_aof_ex [list dir $server_path] [list short_life true] {
             wait_for_condition 100 50 {
-                ! [is_alive $srv]
+                ! [is_alive [srv pid]]
             } else {
                 fail "AOF loading didn't fail"
             }
@@ -125,9 +125,9 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i\n"
         }
 
-        start_server_aof [list dir $server_path] {
+        start_server_aof_ex [list dir $server_path] [list short_life true] {
             wait_for_condition 100 50 {
-                ! [is_alive $srv]
+                ! [is_alive [srv pid]]
             } else {
                 fail "AOF loading didn't fail"
             }
@@ -152,9 +152,9 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i\n"
         }
 
-        start_server_aof [list dir $server_path] {
+        start_server_aof_ex [list dir $server_path] [list short_life true] {
             wait_for_condition 100 50 {
-                ! [is_alive $srv]
+                ! [is_alive [srv pid]]
             } else {
                 fail "AOF loading didn't fail"
             }
@@ -179,9 +179,9 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i\n"
         }
 
-        start_server_aof [list dir $server_path] {
+        start_server_aof_ex [list dir $server_path] [list short_life true] {
             wait_for_condition 100 50 {
-                ! [is_alive $srv]
+                ! [is_alive [srv pid]]
             } else {
                 fail "AOF loading didn't fail"
             }
@@ -206,9 +206,9 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof type i\n"
         }
 
-        start_server_aof [list dir $server_path] {
+        start_server_aof_ex [list dir $server_path] [list short_life true] {
             wait_for_condition 100 50 {
-                ! [is_alive $srv]
+                ! [is_alive [srv pid]]
             } else {
                 fail "AOF loading didn't fail"
             }
@@ -233,9 +233,9 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i\n"
         }
 
-        start_server_aof [list dir $server_path] {
+        start_server_aof_ex [list dir $server_path] [list short_life true] {
             wait_for_condition 100 50 {
-                ! [is_alive $srv]
+                ! [is_alive [srv pid]]
             } else {
                 fail "AOF loading didn't fail"
             }
@@ -260,9 +260,9 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof.1.incr.aof seq 1 type i newkey\n"
         }
 
-        start_server_aof [list dir $server_path] {
+        start_server_aof_ex [list dir $server_path] [list short_life true] {
             wait_for_condition 100 50 {
-                ! [is_alive $srv]
+                ! [is_alive [srv pid]]
             } else {
                 fail "AOF loading didn't fail"
             }
@@ -277,9 +277,9 @@ tags {"external:skip"} {
         create_aof_manifest $aof_dirpath $aof_manifest_file {
         }
 
-        start_server_aof [list dir $server_path] {
+        start_server_aof_ex [list dir $server_path] [list short_life true] {
             wait_for_condition 100 50 {
-                ! [is_alive $srv]
+                ! [is_alive [srv pid]]
             } else {
                 fail "AOF loading didn't fail"
             }
@@ -292,9 +292,9 @@ tags {"external:skip"} {
 
     test {Multi Part AOF can start when no aof and no manifest} {
         start_server_aof [list dir $server_path] {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
 
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
 
             assert_equal OK [$client set k1 v1]
             assert_equal v1 [$client get k1]
@@ -307,7 +307,7 @@ tags {"external:skip"} {
         create_aof_dir $aof_dirpath
 
         start_server_aof [list dir $server_path] {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
         }
     }
 
@@ -331,8 +331,8 @@ tags {"external:skip"} {
         }
 
         start_server_aof [list dir $server_path] {
-            assert_equal 1 [is_alive $srv]
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            assert_equal 1 [is_alive [srv pid]]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal v1 [$client get k1]
@@ -363,8 +363,8 @@ tags {"external:skip"} {
         }
 
         start_server_aof [list dir $server_path] {
-            assert_equal 1 [is_alive $srv]
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            assert_equal 1 [is_alive [srv pid]]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal v1 [$client get k1]
@@ -394,8 +394,8 @@ tags {"external:skip"} {
         }
 
         start_server_aof [list dir $server_path] {
-            assert_equal 1 [is_alive $srv]
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            assert_equal 1 [is_alive [srv pid]]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal v1 [$client get k1]
@@ -414,9 +414,9 @@ tags {"external:skip"} {
         }
 
         start_server_aof [list dir $server_path] {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
 
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal v1 [$client get k1]
@@ -455,9 +455,9 @@ tags {"external:skip"} {
     test {Multi Part AOF can load data from old version redis (rdb preamble yes)} {
         exec cp tests/assets/rdb-preamble.aof $aof_old_name_old_path
         start_server_aof [list dir $server_path] {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
 
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             # k1 k2 in rdb header and k3 in AOF tail
@@ -507,9 +507,9 @@ tags {"external:skip"} {
         }
 
         start_server_aof [list dir $server_path] {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
 
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal v1 [$client get k1]
@@ -546,9 +546,9 @@ tags {"external:skip"} {
         }
 
         start_server_aof [list dir $server_path] {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
 
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal 0 [$client exists k1]
@@ -577,9 +577,9 @@ tags {"external:skip"} {
             append_to_manifest "file appendonly.aof seq 1 type b\n"
         }
 
-        start_server_aof [list dir $server_path] {
+        start_server_aof_ex [list dir $server_path] [list short_life true] {
             wait_for_condition 100 50 {
-                ! [is_alive $srv]
+                ! [is_alive [srv pid]]
             } else {
                 fail "AOF loading didn't fail"
             }
@@ -604,7 +604,7 @@ tags {"external:skip"} {
         }
 
         start_server_aof [list dir $server_path] {
-            set redis1 [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set redis1 [redis [srv host] [srv port] 0 $::tls]
 
             start_server [list overrides [list dir $server_path appendonly yes appendfilename appendonly.aof2]] {
                 set redis2 [redis [srv host] [srv port] 0 $::tls]
@@ -702,7 +702,7 @@ tags {"external:skip"} {
 
     test {Multi Part AOF can create BASE (RDB format) when redis starts from empty} {
         start_server_aof [list dir $server_path] {
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.1${::base_aof_sufix}${::rdb_format_suffix}"]
@@ -725,7 +725,7 @@ tags {"external:skip"} {
 
     test {Multi Part AOF can create BASE (AOF format) when redis starts from empty} {
         start_server_aof [list dir $server_path aof-use-rdb-preamble no] {
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.1${::base_aof_sufix}${::aof_format_suffix}"]

--- a/tests/integration/aof-race.tcl
+++ b/tests/integration/aof-race.tcl
@@ -7,8 +7,8 @@ tags {"aof external:skip"} {
     # cleaned after a child responsible for an AOF rewrite exited. This buffer
     # was subsequently appended to the new AOF, resulting in duplicate commands.
     start_server_aof [list dir $server_path] {
-        set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
-        set bench [open "|src/redis-benchmark -q -s [dict get $srv unixsocket] -c 20 -n 20000 incr foo" "r+"]
+        set client [redis [srv host] [srv port] 0 $::tls]
+        set bench [open "|src/redis-benchmark -q -s [srv unixsocket] -c 20 -n 20000 incr foo" "r+"]
 
         wait_for_condition 100 1 {
             [$client get foo] > 0
@@ -30,7 +30,7 @@ tags {"aof external:skip"} {
 
     # Restart server to replay AOF
     start_server_aof [list dir $server_path] {
-        set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+        set client [redis [srv host] [srv port] 0 $::tls]
         wait_done_loading $client
         assert_equal 20000 [$client get foo]
     }

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -73,7 +73,7 @@ tags {"aof external:skip"} {
         append_to_aof [formatCommand set foo hello]
     }
 
-    start_server_aof_ex [list dir $server_path aof-load-truncated yes] [list short_life true] {
+    start_server_aof_ex [list dir $server_path aof-load-truncated yes] [list wait_ready false] {
         test "Bad format: Server should have logged an error" {
             wait_for_log_messages 0 {"*Bad file format reading the append only file*"} 0 10 1000
         }
@@ -86,7 +86,7 @@ tags {"aof external:skip"} {
         append_to_aof [formatCommand set bar world]
     }
 
-    start_server_aof_ex [list dir $server_path aof-load-truncated no] [list short_life true] {
+    start_server_aof_ex [list dir $server_path aof-load-truncated no] [list wait_ready false] {
         test "Unfinished MULTI: Server should have logged an error" {
             wait_for_log_messages 0 {"*Unexpected end of file reading the append only file*"} 0 10 1000
         }
@@ -98,7 +98,7 @@ tags {"aof external:skip"} {
         append_to_aof [string range [formatCommand set bar world] 0 end-1]
     }
 
-    start_server_aof_ex [list dir $server_path aof-load-truncated no] [list short_life true] {
+    start_server_aof_ex [list dir $server_path aof-load-truncated no] [list wait_ready false] {
         test "Short read: Server should have logged an error" {
             wait_for_log_messages 0 {"*Unexpected end of file reading the append only file*"} 0 10 1000
         }
@@ -257,7 +257,7 @@ tags {"aof external:skip"} {
         append_to_aof [formatCommand set foo hello]
     }
 
-    start_server_aof_ex [list dir $server_path aof-load-truncated yes] [list short_life true] {
+    start_server_aof_ex [list dir $server_path aof-load-truncated yes] [list wait_ready false] {
         test "Unknown command: Server should have logged an error" {
             wait_for_log_messages 0 {"*Unknown command 'bla' reading the append only file*"} 0 10 1000
         }

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -23,7 +23,7 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path aof-load-truncated yes] {
         test "Unfinished MULTI: Server should start if load-truncated is yes" {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
         }
     }
 
@@ -39,11 +39,11 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path aof-load-truncated yes] {
         test "Short read: Server should start if load-truncated is yes" {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
         }
 
         test "Truncated AOF loaded: we expect foo to be equal to 5" {
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert {[$client get foo] eq "5"}
         }
@@ -56,11 +56,11 @@ tags {"aof external:skip"} {
     # Now the AOF file is expected to be correct
     start_server_aof [list dir $server_path aof-load-truncated yes] {
         test "Short read + command: Server should start" {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
         }
 
         test "Truncated AOF loaded: we expect foo to be equal to 6 now" {
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert {[$client get foo] eq "6"}
         }
@@ -73,21 +73,9 @@ tags {"aof external:skip"} {
         append_to_aof [formatCommand set foo hello]
     }
 
-    start_server_aof [list dir $server_path aof-load-truncated yes] {
+    start_server_aof_ex [list dir $server_path aof-load-truncated yes] [list short_life true] {
         test "Bad format: Server should have logged an error" {
-            set pattern "*Bad file format reading the append only file*"
-            set retry 10
-            while {$retry} {
-                set result [exec tail -1 < [dict get $srv stdout]]
-                if {[string match $pattern $result]} {
-                    break
-                }
-                incr retry -1
-                after 1000
-            }
-            if {$retry == 0} {
-                error "assertion:expected error not found on config file"
-            }
+            wait_for_log_messages 0 {"*Bad file format reading the append only file*"} 0 10 1000
         }
     }
 
@@ -98,21 +86,9 @@ tags {"aof external:skip"} {
         append_to_aof [formatCommand set bar world]
     }
 
-    start_server_aof [list dir $server_path aof-load-truncated no] {
+    start_server_aof_ex [list dir $server_path aof-load-truncated no] [list short_life true] {
         test "Unfinished MULTI: Server should have logged an error" {
-            set pattern "*Unexpected end of file reading the append only file*"
-            set retry 10
-            while {$retry} {
-                set result [exec tail -1 < [dict get $srv stdout]]
-                if {[string match $pattern $result]} {
-                    break
-                }
-                incr retry -1
-                after 1000
-            }
-            if {$retry == 0} {
-                error "assertion:expected error not found on config file"
-            }
+            wait_for_log_messages 0 {"*Unexpected end of file reading the append only file*"} 0 10 1000
         }
     }
 
@@ -122,21 +98,9 @@ tags {"aof external:skip"} {
         append_to_aof [string range [formatCommand set bar world] 0 end-1]
     }
 
-    start_server_aof [list dir $server_path aof-load-truncated no] {
+    start_server_aof_ex [list dir $server_path aof-load-truncated no] [list short_life true] {
         test "Short read: Server should have logged an error" {
-            set pattern "*Unexpected end of file reading the append only file*"
-            set retry 10
-            while {$retry} {
-                set result [exec tail -1 < [dict get $srv stdout]]
-                if {[string match $pattern $result]} {
-                    break
-                }
-                incr retry -1
-                after 1000
-            }
-            if {$retry == 0} {
-                error "assertion:expected error not found on config file"
-            }
+            wait_for_log_messages 0 {"*Unexpected end of file reading the append only file*"} 0 10 1000
         }
     }
 
@@ -168,11 +132,11 @@ tags {"aof external:skip"} {
     ## Test that the server can be started using the truncated AOF
     start_server_aof [list dir $server_path aof-load-truncated no] {
         test "Fixed AOF: Server should have been started" {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
         }
 
         test "Fixed AOF: Keyspace should contain values that were parseable" {
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert_equal "hello" [$client get foo]
             assert_equal "" [$client get bar]
@@ -188,11 +152,11 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path aof-load-truncated no] {
         test "AOF+SPOP: Server should have been started" {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
         }
 
         test "AOF+SPOP: Set should have 1 member" {
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert_equal 1 [$client scard set]
         }
@@ -208,11 +172,11 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path] {
         test "AOF+SPOP: Server should have been started" {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
         }
 
         test "AOF+SPOP: Set should have 1 member" {
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert_equal 1 [$client scard set]
         }
@@ -227,11 +191,11 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path aof-load-truncated no] {
         test "AOF+EXPIRE: Server should have been started" {
-            assert_equal 1 [is_alive $srv]
+            assert_equal 1 [is_alive [srv pid]]
         }
 
         test "AOF+EXPIRE: List should be empty" {
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert_equal 0 [$client llen list]
         }
@@ -293,21 +257,9 @@ tags {"aof external:skip"} {
         append_to_aof [formatCommand set foo hello]
     }
 
-    start_server_aof [list dir $server_path aof-load-truncated yes] {
+    start_server_aof_ex [list dir $server_path aof-load-truncated yes] [list short_life true] {
         test "Unknown command: Server should have logged an error" {
-            set pattern "*Unknown command 'bla' reading the append only file*"
-            set retry 10
-            while {$retry} {
-                set result [exec tail -1 < [dict get $srv stdout]]
-                if {[string match $pattern $result]} {
-                    break
-                }
-                incr retry -1
-                after 1000
-            }
-            if {$retry == 0} {
-                error "assertion:expected error not found on config file"
-            }
+            wait_for_log_messages 0 {"*Unknown command 'bla' reading the append only file*"} 0 10 1000
         }
     }
 
@@ -320,8 +272,8 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path aof-load-truncated no] {
         test "AOF+LMPOP/BLMPOP: pop elements from the list" {
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
-            set client2 [redis [dict get $srv host] [dict get $srv port] 1 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
+            set client2 [redis [srv host] [srv port] 1 $::tls]
             wait_done_loading $client
 
             # Pop all elements from mylist, should be blmpop delete mylist.
@@ -347,7 +299,7 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path aof-load-truncated no] {
         test "AOF+LMPOP/BLMPOP: after pop elements from the list" {
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             # mylist and mylist2 no longer exist.
@@ -367,8 +319,8 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path aof-load-truncated no] {
         test "AOF+ZMPOP/BZMPOP: pop elements from the zset" {
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
-            set client2 [redis [dict get $srv host] [dict get $srv port] 1 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
+            set client2 [redis [srv host] [srv port] 1 $::tls]
             wait_done_loading $client
 
             # Pop all elements from myzset, should be bzmpop delete myzset.
@@ -394,7 +346,7 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path aof-load-truncated no] {
         test "AOF+ZMPOP/BZMPOP: after pop elements from the zset" {
-            set client [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set client [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             # myzset and myzset2 no longer exist.
@@ -435,7 +387,7 @@ tags {"aof external:skip"} {
     }
     start_server_aof [list dir $server_path] {
         test {Successfully load AOF which has timestamp annotations inside} {
-            set c [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set c [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $c
             assert_equal "bar1" [$c get foo1]
             assert_equal "bar2" [$c get foo2]
@@ -447,7 +399,7 @@ tags {"aof external:skip"} {
         # truncate to timestamp 1628217473
         exec src/redis-check-aof --truncate-to-timestamp 1628217473 $aof_manifest_file
         start_server_aof [list dir $server_path] {
-            set c [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set c [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $c
             assert_equal "bar1" [$c get foo1]
             assert_equal "bar2" [$c get foo2]
@@ -457,7 +409,7 @@ tags {"aof external:skip"} {
         # truncate to timestamp 1628217471
         exec src/redis-check-aof --truncate-to-timestamp 1628217471 $aof_manifest_file
         start_server_aof [list dir $server_path] {
-            set c [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set c [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $c
             assert_equal "bar1" [$c get foo1]
             assert_equal "bar2" [$c get foo2]
@@ -467,7 +419,7 @@ tags {"aof external:skip"} {
         # truncate to timestamp 1628217470
         exec src/redis-check-aof --truncate-to-timestamp 1628217470 $aof_manifest_file
         start_server_aof [list dir $server_path] {
-            set c [redis [dict get $srv host] [dict get $srv port] 0 $::tls]
+            set c [redis [srv host] [srv port] 0 $::tls]
             wait_done_loading $c
             assert_equal "bar1" [$c get foo1]
             assert_equal "" [$c get foo2]
@@ -479,7 +431,7 @@ tags {"aof external:skip"} {
     }
 
     test {EVAL timeout with slow verbatim Lua script from AOF} {
-        start_server [list overrides [list dir $server_path appendonly yes lua-time-limit 1 aof-use-rdb-preamble no]] {  
+        start_server [list overrides [list dir $server_path appendonly yes lua-time-limit 1 aof-use-rdb-preamble no]] {
             # generate a long running script that is propagated to the AOF as script
             # make sure that the script times out during loading
             create_aof $aof_dirpath $aof_file {
@@ -554,7 +506,7 @@ tags {"aof external:skip"} {
 
         catch {
             exec src/redis-check-aof $aof_manifest_file
-        } result   
+        } result
         assert_match "*Start checking Multi Part AOF*Start to check BASE AOF (RESP format)*BASE AOF*is valid*Start to check INCR files*INCR AOF*is valid*All AOF files and manifest are valid*" $result
     }
 
@@ -595,12 +547,12 @@ tags {"aof external:skip"} {
         }
 
         catch {
-            exec src/redis-check-aof $aof_manifest_file 
+            exec src/redis-check-aof $aof_manifest_file
         } result
         assert_match "*not valid*" $result
 
         catch {
-            exec src/redis-check-aof --fix $aof_manifest_file 
+            exec src/redis-check-aof --fix $aof_manifest_file
         } result
         assert_match "*Failed to truncate AOF*because it is not the last file*" $result
     }
@@ -628,7 +580,7 @@ tags {"aof external:skip"} {
         }
 
         catch {
-            exec src/redis-check-aof --truncate-to-timestamp 1628217473 $aof_manifest_file 
+            exec src/redis-check-aof --truncate-to-timestamp 1628217473 $aof_manifest_file
         } result
         assert_match "*Failed to truncate AOF*to timestamp*because it is not the last file*" $result
     }

--- a/tests/support/aofmanifest.tcl
+++ b/tests/support/aofmanifest.tcl
@@ -161,9 +161,13 @@ proc create_aof_dir {dir_path} {
 }
 
 proc start_server_aof {overrides code} {
+    upvar defaults defaults srv srv server_path server_path aof_basename aof_basename aof_dirpath aof_dirpath aof_manifest_file aof_manifest_file aof_manifest_file2 aof_manifest_file2
+    set config [concat $defaults $overrides]
+    start_server [list overrides $config keep_persistence true] $code
+}
+
+proc start_server_aof_ex {overrides options code} {
     upvar defaults defaults srv srv server_path server_path
     set config [concat $defaults $overrides]
-    set srv [start_server [list overrides $config]]
-    uplevel 1 $code
-    kill_server $srv
+    start_server [concat [list overrides $config keep_persistence true] $options] $code
 }

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -416,9 +416,8 @@ proc start_server {options {code undefined}} {
     set keep_persistence false
     set config_lines {}
 
-    # The server is expected to exit on startup (e.g. loading corrupted AOF/RDB), so some
-    # checks about server liveness/client connectivity are skipped.
-    set short_life false
+    # Wait for the server to be ready and check for server liveness/client connectivity before starting the test.
+    set wait_ready true
 
     # parse options
     foreach {option value} $options {
@@ -447,8 +446,8 @@ proc start_server {options {code undefined}} {
             "keep_persistence" {
                 set keep_persistence $value
             }
-            "short_life" {
-                set short_life $value
+            "wait_ready" {
+                set wait_ready $value
             }
             default {
                 error "Unknown option $option"
@@ -590,7 +589,7 @@ proc start_server {options {code undefined}} {
         }
 
         if {$::valgrind} {set retrynum 1000} else {set retrynum 100}
-        if {$code ne "undefined" && !$short_life} {
+        if {$code ne "undefined" && $wait_ready} {
             set serverisup [server_is_up $::host $port $retrynum]
         } else {
             set serverisup 1
@@ -639,7 +638,7 @@ proc start_server {options {code undefined}} {
         # append the server to the stack
         lappend ::servers $srv
 
-        if {!$short_life} {
+        if {$wait_ready} {
             while 1 {
                 # check that the server actually started and is ready for connections
                 if {[count_message_lines $stdout "Ready to accept"] > $previous_ready_count} {


### PR DESCRIPTION
In some tests, the code manually searches for a log message, and it uses tail -1 with a delay of 1 second, which can miss the expected line.

Also, because the aof tests use start_server_aof and not start_server, the test name doesn't log into the server log.

To fix the above, I made the following changes:
- Change the start_server_aof to wrap the start_server. This will add the created aof server to the servers list, and make srv() and wait_for_log_messages() available for the tests.

- Introduce a new option for start_server.
   'wait_ready' - an option to let the caller start the test code without waiting for the server to be ready.
   useful for tests on a server that is expected to exit on startup.

- Create a new start_server_aof_ex.
   The new proc also accept options as argument and make use of the new 'short_life' option for tests that are expected to exit on startup because of some error in the aof file(s).

Because of the above, I had to change many lines and replace every local srv variable (a server config) usage with the srv().