### PR TITLE
Fix 'load corrupted rdb with no CRC' test

### DIFF
--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -146,7 +146,7 @@ test {corrupt payload: load corrupted rdb with no CRC - #3505} {
 
     # wait for termination
     wait_for_condition 100 50 {
-        ! [is_alive $srv]
+        ! [is_alive [dict get $srv pid]]
     } else {
         fail "rdb loading didn't fail"
     }


### PR DESCRIPTION
After the change in #12626 (2e0f6724e), the is_alive proc gets pid and not server config.

This PR aligns it in 'load corrupted rdb with no CRC' test.