### PR TITLE
Cleanup nested module keyspace notifications

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -8763,11 +8763,12 @@ void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid)
             /* mark the handler as active to avoid reentrant loops.
              * If the subscriber performs an action triggering itself,
              * it will not be notified about it. */
+            int prev_active = sub->active;
             sub->active = 1;
             server.lazy_expire_disabled++;
             sub->notify_callback(&ctx, type, event, key);
             server.lazy_expire_disabled--;
-            sub->active = 0;
+            sub->active = prev_active;
             moduleFreeContext(&ctx);
         }
     }


### PR DESCRIPTION
Recently we added a way for the module to declare that it wishes to receive nested KSN, by setting ALLOW_NESTED_KEYSPACE_NOTIFICATIONS. but it looks like this flow has a bug, clearing the `active` member when it was previously set. however, since nesting is permitted, this bug has no implications, since regardless of the active member, the notification is permitted.