### PR TITLE
Fix typo in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1355,7 +1355,7 @@ oom-score-adj-values 0 200 800
 #################### KERNEL transparent hugepage CONTROL ######################
 
 # Usually the kernel Transparent Huge Pages control is set to "madvise" or
-# or "never" by default (/sys/kernel/mm/transparent_hugepage/enabled), in which
+# "never" by default (/sys/kernel/mm/transparent_hugepage/enabled), in which
 # case this config has no effect. On systems in which it is set to "always",
 # redis will attempt to disable it specifically for the redis process in order
 # to avoid latency problems specifically with fork(2) and CoW.


### PR DESCRIPTION
unnecessarily and repetitive "OR"