### PR TITLE
dump server longs on hang corrupt dump fuzzer test

### DIFF
--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -160,6 +160,10 @@ foreach sanitize_dump {no yes} {
                         set err [format "%s" $err] ;# convert to string for pattern matching
                         if {[string match "*SIGTERM*" $err]} {
                             puts "payload that caused test to hang: $printable_dump"
+                            if {$::dump_logs} {
+                                set srv [get_srv 0]
+                                dump_server_log $srv
+                            }
                             exit 1
                         }
                         # if the server terminated update stats and restart it


### PR DESCRIPTION
recently there are some incidents of hanged tests in the CI
when we try to reproduce them, we get an assertion, not a hang.
maybe the server logs will reveal some info.

example of a recent report:
https://github.com/redis/redis/actions/runs/6444207925/job/17496920213#step:7:4670