### PR TITLE
test suite: clean server pids after server crashed

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -60,6 +60,10 @@ proc kill_server config {
         }
 
         check_sanitizer_errors [dict get $config stderr]
+
+        # Remove this pid from the set of active pids in the test server.
+        send_data_packet $::test_server_fd server-killed $pid
+
         return
     }
 


### PR DESCRIPTION
when a server in the test suite crashes and is restarted by redstart_server, we didn't clean it's pid from the list.
we can see that when the corrupt-dump-fuzzer hangs, it has a long list of servers to lean, but in fact they're all already dead.
https://github.com/redis/redis/actions/runs/6444207925/job/17496920213#step:7:4860