### PR TITLE
Input output traffic stats and command process count for each client.

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -107,6 +107,7 @@ void updateStatsOnUnblock(client *c, long blocked_us, long reply_us, int had_err
     const ustime_t total_cmd_duration = c->duration + blocked_us + reply_us;
     c->lastcmd->microseconds += total_cmd_duration;
     c->lastcmd->calls++;
+    c->commands_processed++;
     server.stat_numcommands++;
     if (had_errors)
         c->lastcmd->failed_calls++;

--- a/src/networking.c
+++ b/src/networking.c
@@ -2854,7 +2854,7 @@ sds catClientInfoString(sds s, client *client) {
         " lib-ver=%s", client->lib_ver ? (char*)client->lib_ver->ptr : "",
         " tot-input=%U", client->net_input_bytes,
         " tot-output=%U", client->net_output_bytes,
-        " cmd-proc=%U", client->commands_processed));
+        " tot-cmds=%U", client->commands_processed));
     return ret;
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -2854,7 +2854,7 @@ sds catClientInfoString(sds s, client *client) {
         " lib-ver=%s", client->lib_ver ? (char*)client->lib_ver->ptr : "",
         " tot-input=%U", client->net_input_bytes,
         " tot-output=%U", client->net_output_bytes,
-        " cmd_proc=%U", client->commands_processed));
+        " cmd-proc=%U", client->commands_processed));
     return ret;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -3675,8 +3675,10 @@ void call(client *c, int flags) {
         }
     }
 
-    if (!(c->flags & CLIENT_BLOCKED))
+    if (!(c->flags & CLIENT_BLOCKED)) {
         server.stat_numcommands++;
+        c->commands_processed++;
+    }
 
     /* Record peak memory after each command and before the eviction that runs
      * before the next command. */

--- a/src/server.h
+++ b/src/server.h
@@ -1274,6 +1274,9 @@ typedef struct client {
 #ifdef LOG_REQ_RES
     clientReqResInfo reqres;
 #endif
+    unsigned long long net_input_bytes;
+    unsigned long long net_output_bytes;
+    unsigned long long commands_processed;
 } client;
 
 /* ACL information */

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -7,7 +7,7 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT LIST} {
         r client list
-    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* tot-input=* tot-output=* cmd-proc=*}
+    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* tot-input=* tot-output=* tot-cmds=*}
 
     test {CLIENT LIST with IDs} {
         set myid [r client id]
@@ -17,7 +17,7 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT INFO} {
         r client info
-    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* tot-input=* tot-output=* cmd-proc=*}
+    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* tot-input=* tot-output=* tot-cmds=*}
 
     proc get_field_in_client_info {info field} {
         set info [string trim $info]
@@ -35,11 +35,11 @@ start_server {tags {"introspection"}} {
         set info1 [r client info]
         set input1 [get_field_in_client_info $info1 "tot-input"]
         set output1 [get_field_in_client_info $info1 "tot-output"]
-        set cmd1 [get_field_in_client_info $info1 "cmd-proc"]
+        set cmd1 [get_field_in_client_info $info1 "tot-cmds"]
         set info2 [r client info]
         set input2 [get_field_in_client_info $info2 "tot-input"]
         set output2 [get_field_in_client_info $info2 "tot-output"]
-        set cmd2 [get_field_in_client_info $info2 "cmd-proc"]
+        set cmd2 [get_field_in_client_info $info2 "tot-cmds"]
         assert_equal [expr $input1+26] $input2
         assert {[expr $output1+300] < $output2}
         assert_equal [expr $cmd1+1] $cmd2

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -7,7 +7,7 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT LIST} {
         r client list
-    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=*}
+    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* tot-input=* tot-output=* cmd-proc=*}
 
     test {CLIENT LIST with IDs} {
         set myid [r client id]
@@ -17,7 +17,33 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT INFO} {
         r client info
-    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=*}
+    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* tot-input=* tot-output=* cmd-proc=*}
+
+    proc get_field_in_client_info {info field} {
+        set info [string trim $info]
+        foreach item [split $info " "] {
+            set kv [split $item "="]
+            set k [lindex $kv 0]
+            if {[string match $field $k]} {
+                return [lindex $kv 1]   
+            }
+        }
+        return ""
+    }
+    
+    test {client input output and command process statistics} {
+        set info1 [r client info]
+        set input1 [get_field_in_client_info $info1 "tot-input"]
+        set output1 [get_field_in_client_info $info1 "tot-output"]
+        set cmd1 [get_field_in_client_info $info1 "cmd-proc"]
+        set info2 [r client info]
+        set input2 [get_field_in_client_info $info2 "tot-input"]
+        set output2 [get_field_in_client_info $info2 "tot-output"]
+        set cmd2 [get_field_in_client_info $info2 "cmd-proc"]
+        assert_equal [expr $input1+26] $input2
+        assert {[expr $output1+300] < $output2}
+        assert_equal [expr $cmd1+1] $cmd2
+    }
 
     test {CLIENT KILL with illegal arguments} {
         assert_error "ERR wrong number of arguments for 'client|kill' command" {r client kill}


### PR DESCRIPTION
In Redis we have global stats for input traffic, output traffic and how many commnands have been executed.

However, some users have the problem of being unable to locate the links (IPs) they are performing operations on, and need to locate the traffic in the link dimension. So here some stats for single client are              introduced.
```              
tot-input   // Total bytes the client has read
tot-output  // Total bytes the server has sent to the client
tot-cmds    // Total commands the client has executed         
```                             
These three stats are shown in `CLIENT LIST` and `CLIENT INFO`.