### PR TITLE
Replace `emptyDb()` with new `emptyData()` in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ implementations are the following:
 * `lookupKeyRead()` and `lookupKeyWrite()` are used in order to get a pointer to the value associated to a given key, or `NULL` if the key does not exist.
 * `dbAdd()` and its higher level counterpart `setKey()` create a new key in a Redis database.
 * `dbDelete()` removes a key and its associated value.
-* `emptyDb()` removes an entire single database or all the databases defined.
+* `emptyData()` removes an entire single database or all the databases defined.
 
 The rest of the file implements the generic commands exposed to the client.
 

--- a/src/db.c
+++ b/src/db.c
@@ -630,7 +630,7 @@ void signalFlushedDb(int dbid, int async) {
  * Type agnostic commands operating on the key space
  *----------------------------------------------------------------------------*/
 
-/* Return the set of flags to use for the emptyDb() call for FLUSHALL
+/* Return the set of flags to use for the emptyData() call for FLUSHALL
  * and FLUSHDB commands.
  *
  * sync: flushes the database in an sync manner.

--- a/src/replication.c
+++ b/src/replication.c
@@ -1736,7 +1736,7 @@ int slaveIsInHandshakeState(void) {
  * not, since the byte is indivisible.
  *
  * The function is called in two contexts: while we flush the current
- * data with emptyDb(), and while we load the new data received as an
+ * data with emptyData(), and while we load the new data received as an
  * RDB file from the master. */
 void replicationSendNewlineToMaster(void) {
     static time_t newline_sent;
@@ -1747,7 +1747,7 @@ void replicationSendNewlineToMaster(void) {
     }
 }
 
-/* Callback used by emptyDb() while flushing away old data to load
+/* Callback used by emptyData() while flushing away old data to load
  * the new dataset received by the master and by discardTempDb()
  * after loading succeeded or failed. */
 void replicationEmptyDbCallback(dict *d) {


### PR DESCRIPTION
The function was renamed, but the comments were outdated.
Fix for https://github.com/redis/redis/issues/12644