### PR TITLE
remove heap allocations from signal handlers.

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1869,7 +1869,7 @@ static void writeStacktraces(int fd, int uplevel) {
     pid_t tids[TIDS_MAX_SIZE];
     size_t len_tids = get_ready_to_signal_threads_tids(pid, THREADS_SIGNAL, tids);
     if (!len_tids) {
-        (LL_WARNING, "writeStacktraces(): Failed to get the process's threads.");
+        serverLogFromHandler(LL_WARNING, "writeStacktraces(): Failed to get the process's threads.");
     }
 
     stacktrace_data stacktraces[len_tids];

--- a/src/threads_mngr.c
+++ b/src/threads_mngr.c
@@ -49,8 +49,6 @@ static const clock_t RUN_ON_THREADS_TIMEOUT = 2;
 
 static run_on_thread_cb g_callback = NULL;
 static volatile size_t g_tids_len = 0;
-static void **g_output_array = NULL;
-static redisAtomic size_t g_thread_ids = 0;
 static redisAtomic size_t g_num_threads_done = 0;
 
 static sem_t wait_for_threads_sem;
@@ -83,11 +81,11 @@ void ThreadsManager_init(void) {
     sigaction(SIGUSR2, &act, NULL);
 }
 
-__attribute__ ((noinline)) 
-void **ThreadsManager_runOnThreads(pid_t *tids, size_t tids_len, run_on_thread_cb callback) {
+__attribute__ ((noinline))
+int ThreadsManager_runOnThreads(pid_t *tids, size_t tids_len, run_on_thread_cb callback) {
     /* Check if it is safe to start running. If not - return */
     if(test_and_start() == IN_PROGRESS) {
-        return NULL;
+        return 0;
     }
 
     /* Update g_callback */
@@ -95,9 +93,6 @@ void **ThreadsManager_runOnThreads(pid_t *tids, size_t tids_len, run_on_thread_c
 
     /* Set g_tids_len */
     g_tids_len = tids_len;
-
-    /* Allocate the output buffer */
-    g_output_array = zcalloc(sizeof(void*) * tids_len);
 
     /* Initialize a semaphore that we will be waiting on for the threads
     use pshared = 0 to indicate the semaphore is shared between the process's threads (and not between processes),
@@ -113,12 +108,10 @@ void **ThreadsManager_runOnThreads(pid_t *tids, size_t tids_len, run_on_thread_c
     /* Wait for all the threads to write to the output array, or until timeout is reached */
     wait_threads();
 
-    void **ret = g_output_array;
-
     /* Cleanups to allow next execution */
     ThreadsManager_cleanups();
 
-    return ret;
+    return 1;
 }
 
 /*============================ Internal functions implementations ========================== */
@@ -133,7 +126,7 @@ static int test_and_start(void) {
     return prev_state;
 }
 
-__attribute__ ((noinline)) 
+__attribute__ ((noinline))
 static void invoke_callback(int sig) {
     UNUSED(sig);
 
@@ -143,10 +136,8 @@ static void invoke_callback(int sig) {
         return;
     }
 
-    if (g_output_array) {
-        size_t thread_id;
-        atomicGetIncr(g_thread_ids, thread_id, 1);
-        g_output_array[thread_id] = g_callback();
+    if (g_callback) {
+        g_callback();
         size_t curr_done_count;
         atomicIncrGet(g_num_threads_done, curr_done_count, 1);
 
@@ -181,8 +172,6 @@ static void ThreadsManager_cleanups(void) {
 
     g_callback = NULL;
     g_tids_len = 0;
-    g_output_array = NULL;
-    g_thread_ids = 0;
     g_num_threads_done = 0;
     sem_destroy(&wait_for_threads_sem);
 
@@ -197,7 +186,7 @@ void ThreadsManager_init(void) {
     /* DO NOTHING */
 }
 
-void **ThreadsManager_runOnThreads(pid_t *tids, size_t tids_len, run_on_thread_cb callback) {
+int ThreadsManager_runOnThreads(pid_t *tids, size_t tids_len, run_on_thread_cb callback) {
     /* DO NOTHING */
     UNUSED(tids);
     UNUSED(tids_len);

--- a/src/threads_mngr.c
+++ b/src/threads_mngr.c
@@ -191,7 +191,7 @@ int ThreadsManager_runOnThreads(pid_t *tids, size_t tids_len, run_on_thread_cb c
     UNUSED(tids);
     UNUSED(tids_len);
     UNUSED(callback);
-    return NULL;
+    return 1;
 }
 
 #endif /* __linux__ */

--- a/src/threads_mngr.h
+++ b/src/threads_mngr.h
@@ -42,7 +42,7 @@
 #define THREADS_SIGNAL SIGUSR2
 
 /* Callback signature */
-typedef void*(*run_on_thread_cb)(void);
+typedef void(*run_on_thread_cb)(void);
 
 /* Register the process to THREADS_SIGNAL */
 void ThreadsManager_init(void);
@@ -62,15 +62,8 @@ void ThreadsManager_init(void);
  *
  * The function returns only when @param tids_len threads have returned from @param callback.
  *
- * @return NULL If ThreadsManager_runOnThreads is already in the middle of execution.
- * Otherwise, it returns an array of the threads return value from @param callback.
- * NOTES:
- * The indices of the outputs in the output array are NOT associated with the threads indices in @param tids.
+ * @return 1 if successful, 0 If ThreadsManager_runOnThreads is already in the middle of execution.
  *
- * The returned array length will be @param tids_len, but some of the entries might be set to NULL if the
- * invocation of @param callback was unsuccessful.
- *
- * The output array should be freed by the caller by calling zfree().
 **/
 
-void **ThreadsManager_runOnThreads(pid_t *tids, size_t tids_len, run_on_thread_cb callback);
+int ThreadsManager_runOnThreads(pid_t *tids, size_t tids_len, run_on_thread_cb callback);


### PR DESCRIPTION
Using heap allocation during signal handlers is unsafe.
This PR purpose is to replace all the heap allocations done within the signal handlers raised upon server crash and assertions.
These were added in #12453.

writeStacktraces(): allocates the stacktraces output array on the calling thread's stack and assigns the address to a global variable.
It calls `ThreadsManager_runOnThreads()` that invokes `collect_stacktrace_data()` by each thread: each thread writes to a different location in the above array to allow sync writes.

get_ready_to_signal_threads_tids(): instead of allocating the `tids` array, it receives it as a fixed size array parameter, allocated on on the stack of the calling function, and returns the number of valid threads. The array size is hard-coded to 50.

`ThreadsManager_runOnThreads():` To avoid the outputs array allocation, the **callback signature** was changed. Now it should return void. This function return type has also changed to int - returns 1 if successful, and 0 otherwise.

Other unsafe calls will be handled in following PRs