### PR TITLE
Fix resize hash table dictionary iterator

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -608,8 +608,9 @@ void tryResizeHashTables(int dbid) {
     for (dbKeyType subdict = DB_MAIN; subdict <= DB_EXPIRES; subdict++) {
         dbIterator *dbit = dbIteratorInitFromSlot(db, subdict, db->sub_dict[subdict].resize_cursor);
         for (int i = 0; i < CRON_DBS_PER_CALL; i++) {
-            dict *d = dbIteratorNextDict(dbit);
+            dict *d = dbGetDictFromIterator(dbit);
             slot = dbIteratorGetCurrentSlot(dbit);
+            dbIteratorNextDict(dbit);
             if (!d) break;
             if (htNeedsResize(d))
                 dictResize(d);

--- a/src/server.h
+++ b/src/server.h
@@ -2428,6 +2428,7 @@ typedef struct dbIterator dbIterator;
 dbIterator *dbIteratorInit(redisDb *db, dbKeyType keyType);
 dbIterator *dbIteratorInitFromSlot(redisDb *db, dbKeyType keyType, int slot);
 dict *dbIteratorNextDict(dbIterator *dbit);
+dict *dbGetDictFromIterator(dbIterator *dbit);
 int dbIteratorGetCurrentSlot(dbIterator *dbit);
 dictEntry *dbIteratorNext(dbIterator *iter);
 

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -883,13 +883,6 @@ start_cluster 1 0 {tags {"expire external:skip cluster"}} {
         # put some data into slot 12182 and trigger the resize
         r psetex "{foo}0" 500 a
 
-        # Verify dict rehashing has completed
-        wait_for_condition 10 100 {
-            [string match {*table size: 4*} [r debug HTSTATS 0]]
-        } else {
-            fail "rehashing didn't complete"
-        }
-
         # Verify all keys have expired
         wait_for_condition 20 100 {
             [r dbsize] eq 0

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -884,7 +884,7 @@ start_cluster 1 0 {tags {"expire external:skip cluster slow"}} {
         r psetex "{foo}0" 500 a
 
         # Verify all keys have expired
-        wait_for_condition 20 100 {
+        wait_for_condition 200 100 {
             [r dbsize] eq 0
         } else {
             fail "Keys did not actively expire."

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -884,7 +884,7 @@ start_cluster 1 0 {tags {"expire external:skip cluster"}} {
         r psetex "{foo}0" 500 a
 
         # Verify all keys have expired
-        wait_for_condition 20 100 {
+        wait_for_condition 200 100 {
             [r dbsize] eq 0
         } else {
             fail "Keys did not actively expire."

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -882,17 +882,12 @@ start_cluster 1 0 {tags {"expire external:skip cluster"}} {
             fail "bgsave did not stop in time."
         }
 
-        # Verify dict is under rehashing
-        set htstats [r debug HTSTATS 0]
-        assert_match {*rehashing target*} $htstats
-
         # put some data into slot 12182 and trigger the resize
         r psetex "{foo}0" 500 a
 
         # Verify dict rehashing has completed
-        set htstats [r debug HTSTATS 0]
-        wait_for_condition 20 100 {
-            ![string match {*rehashing target*} $htstats]
+        wait_for_condition 10 100 {
+            [string match {*table size: 4*} [r debug HTSTATS 0]]
         } else {
             fail "rehashing didn't complete"
         }

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -834,7 +834,7 @@ start_server {tags {"expire"}} {
     } {} {needs:debug}
 }
 
-start_cluster 1 0 {tags {"expire external:skip cluster"}} {
+start_cluster 1 0 {tags {"expire external:skip cluster slow"}} {
     test "expire scan should skip dictionaries with lot's of empty buckets" {
         # Collect two slots to help determine the expiry scan logic is able
         # to go past certain slots which aren't valid for scanning at the given point of time.
@@ -884,7 +884,7 @@ start_cluster 1 0 {tags {"expire external:skip cluster"}} {
         r psetex "{foo}0" 500 a
 
         # Verify all keys have expired
-        wait_for_condition 200 100 {
+        wait_for_condition 20 100 {
             [r dbsize] eq 0
         } else {
             fail "Keys did not actively expire."

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -851,8 +851,6 @@ start_cluster 1 0 {tags {"expire external:skip cluster"}} {
         # hashslot(key) is 12539
         r psetex key 500 val
 
-        assert_equal 102 [r dbsize]
-
         # disable resizing
         r config set rdb-key-save-delay 10000000
         r bgsave


### PR DESCRIPTION
Dictionary iterator logic in the `tryResizeHashTables` method is picking the next (incorrect) dictionary while the cursor is at a given slot. This could lead to some dictionary/slot getting skipped from resizing.

Saw failure in recent run: https://github.com/redis/redis/commit/d27c7413a95a0a271b94376f3ec64dae06326b29

> Instead of affirming for resize message, rather validate for the final dictionary size.

On freebsd:
https://github.com/redis/redis/actions/runs/6540680776/job/17761013478
https://pipelinesghubeus22.actions.githubusercontent.com/2oDd4EuUudJqGKlOAB2KXZpKHTtseqbUa63unZUQGqUSgXNthI/_apis/pipelines/1/runs/40953/signedlogcontent/14?urlExpires=2023-10-17T02%3A07%3A01.6196538Z&urlSigningMethod=HMACV1&urlSignature=yOYvJogzR%2FbpT02XI2vr2Zc0DGBprgft3zKjtIIpfAk%3D

```
2023-10-17T00:11:35.6970430Z [err]: expire scan should skip dictionaries with lot's of empty buckets in tests/unit/expire.tcl
2023-10-17T00:11:35.7072700Z Expected '102' to be equal to '2' (context: type eval line 17 cmd {assert_equal 102 [r dbsize]} proc ::test)
```
> Removed the no. of keys/dbsize assertion

problem introduced recently in #11695