### PR TITLE
Reducing memory consumption for cjson large-memory test

### DIFF
--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -331,9 +331,9 @@ start_server {tags {"scripting"}} {
     test {EVAL - JSON string encoding a string larger than 2GB} {
         run_script {
             local s = string.rep("a", 1024 * 1024 * 1024)
-            return #cjson.encode(s..s..s)
+            return #cjson.encode(s..s..'foo')
         } 0
-    } {3221225474} {large-memory} ;# length includes two double quotes at both ends
+    } {2147483653} {large-memory} ;# length includes two double quotes at both ends
 
     test {EVAL - JSON numeric decoding} {
         # We must return the table as a string because otherwise


### PR DESCRIPTION
`cjson.encode()` preallocate 6x memory in:
https://github.com/redis/redis/blob/d27c7413a95a0a271b94376f3ec64dae06326b29/deps/lua/src/lua_cjson.c#L478
Before this PR, this test encodes a 3gb string which will consume almost 18gb memory.
Now it will only consume almost 12gb of memory.