### PR TITLE
Disable flaky defrag tests affecting daily run

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -164,6 +164,7 @@ run_solo {defrag} {
         r config set appendonly no
         r config set key-load-delay 0
 
+        if {$type eq "standalone"} {
         test "Active defrag eval scripts: $type" {
             r flushdb
             r script flush sync
@@ -586,6 +587,7 @@ run_solo {defrag} {
                 assert {$digest eq $newdigest}
                 r save ;# saving an rdb iterates over all the data / pointers
             }
+        }
         }
     }
     }


### PR DESCRIPTION
Temporarily disabling few of the defrag tests in cluster mode to make the daily run stable:

1. Active defrag eval scripts
2. Active defrag big keys
3. Active defrag big list
4. Active defrag edge case

Few scenarios observed and I'm investigating:

1. `defrag not started` - Either the defrag scan got completed real quick or never started.
2. Actual fragmentation is lower than the expected fragmentation - Might require us to lower the fragmentation expectation or have separate threshold for cluster mode.
3. Max latency exceeds from the current set threshold.
4. `defrag didn't stop` - Sometimes allocator_frag_ratio reaches `1.06` and the test fails. Expectation is `1.05`.

Failure run: https://github.com/redis/redis/actions/runs/6527277037/job/17721912648
