### PR TITLE
add post callback function for RedisModuleCommandFilter

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -10749,7 +10749,7 @@ void moduleCallCommandPostFilters(client *c, int is_dirty) {
 
     listIter li;
     listNode *ln;
-    listRewind(moduleCommandFilters,&li);
+    listRewindTail(moduleCommandFilters,&li);
 
     RedisModuleCommandFilterCtx ctx = {
         .argv = c->argv,
@@ -10767,16 +10767,10 @@ void moduleCallCommandPostFilters(client *c, int is_dirty) {
          */
         if ((f->flags & REDISMODULE_CMDFILTER_NOSELF) && f->module->in_call) continue;
 
-        /* RedisModuleCtx out_ctx;
-        moduleCreateContext(&out_ctx, f->module, REDISMODULE_CTX_THREAD_SAFE|REDISMODULE_CTX_NEW_CLIENT);
-        ctx.module_ctx = &out_ctx; */
-
         /* Call filter */
         if (f->post_callback != NULL) {
             f->post_callback(&ctx);
         }
-
-        //moduleFreeContext(&out_ctx);
     }
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -10681,6 +10681,7 @@ RedisModuleCommandFilter *RM_RegisterCommandFilter(RedisModuleCtx *ctx, RedisMod
     RedisModuleCommandFilter *filter = zmalloc(sizeof(*filter));
     filter->module = ctx->module;
     filter->pre_callback = callback;
+    filter->post_callback = NULL;
     filter->flags = flags;
 
     listAddNodeTail(moduleCommandFilters, filter);
@@ -10691,6 +10692,7 @@ RedisModuleCommandFilter *RM_RegisterCommandFilter(RedisModuleCtx *ctx, RedisMod
 RedisModuleCommandFilter *RM_RegisterCommandPostFilter(RedisModuleCtx *ctx, RedisModuleCommandFilterFunc callback, int flags) {
     RedisModuleCommandFilter *filter = zmalloc(sizeof(*filter));
     filter->module = ctx->module;
+    filter->pre_callback = NULL;
     filter->post_callback = callback;
     filter->flags = flags;
 
@@ -13838,6 +13840,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ExportSharedAPI);
     REGISTER_API(GetSharedAPI);
     REGISTER_API(RegisterCommandFilter);
+    REGISTER_API(RegisterCommandPostFilter);
     REGISTER_API(UnregisterCommandFilter);
     REGISTER_API(CommandFilterArgsCount);
     REGISTER_API(CommandFilterArgGet);

--- a/src/module.c
+++ b/src/module.c
@@ -357,7 +357,7 @@ typedef struct RedisModuleCommandFilterCtx {
     int argv_len;
     int argc;
     client *c;
-    int is_dirty;
+    int is_dirty;  /* indicates the data has been changed. */
 } RedisModuleCommandFilterCtx;
 
 typedef void (*RedisModuleCommandFilterFunc) (RedisModuleCommandFilterCtx *filter);

--- a/src/networking.c
+++ b/src/networking.c
@@ -2464,7 +2464,10 @@ int processCommandAndResetClient(client *c) {
     int deadclient = 0;
     client *old_client = server.current_client;
     server.current_client = c;
+    long long old_dirty = server.dirty;
     if (processCommand(c) == C_OK) {
+        /* Call command post filters */
+        moduleCallCommandPostFilters(c, server.dirty == old_dirty ? 0 : 1);
         commandProcessed(c);
         /* Update the client's memory to include output buffer growth following the
          * processed command. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -2464,10 +2464,7 @@ int processCommandAndResetClient(client *c) {
     int deadclient = 0;
     client *old_client = server.current_client;
     server.current_client = c;
-    long long old_dirty = server.dirty;
     if (processCommand(c) == C_OK) {
-        /* Call command post filters */
-        moduleCallCommandPostFilters(c, server.dirty == old_dirty ? 0 : 1);
         commandProcessed(c);
         /* Update the client's memory to include output buffer growth following the
          * processed command. */

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1262,6 +1262,8 @@ REDISMODULE_API int (*RedisModule_CommandFilterArgInsert)(RedisModuleCommandFilt
 REDISMODULE_API int (*RedisModule_CommandFilterArgReplace)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CommandFilterArgDelete)(RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_CommandFilterGetClientId)(RedisModuleCommandFilterCtx *fctx) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_CommandFilterCmdIsSucceeded)(RedisModuleCommandFilterCtx *fctx) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_CommandFilterDataIsDirty)(RedisModuleCommandFilterCtx *fctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_Fork)(RedisModuleForkDoneHandler cb, void *user_data) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SendChildHeartbeat)(double progress) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExitFromChild)(int retcode) REDISMODULE_ATTR;
@@ -1625,6 +1627,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(CommandFilterArgReplace);
     REDISMODULE_GET_API(CommandFilterArgDelete);
     REDISMODULE_GET_API(CommandFilterGetClientId);
+    REDISMODULE_GET_API(CommandFilterCmdIsSucceeded);
+    REDISMODULE_GET_API(CommandFilterDataIsDirty);
     REDISMODULE_GET_API(Fork);
     REDISMODULE_GET_API(SendChildHeartbeat);
     REDISMODULE_GET_API(ExitFromChild);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1253,7 +1253,8 @@ REDISMODULE_API void (*RedisModule_SetDisconnectCallback)(RedisModuleBlockedClie
 REDISMODULE_API void (*RedisModule_SetClusterFlags)(RedisModuleCtx *ctx, uint64_t flags) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExportSharedAPI)(RedisModuleCtx *ctx, const char *apiname, void *func) REDISMODULE_ATTR;
 REDISMODULE_API void * (*RedisModule_GetSharedAPI)(RedisModuleCtx *ctx, const char *apiname) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCommandFilter * (*RedisModule_RegisterCommandFilter)(RedisModuleCtx *ctx, RedisModuleCommandFilterFunc pre_cb, RedisModuleCommandFilterFunc post_cb, int flags) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleCommandFilter * (*RedisModule_RegisterCommandFilter)(RedisModuleCtx *ctx, RedisModuleCommandFilterFunc cb, int flags) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleCommandFilter * (*RedisModule_RegisterCommandPostFilter)(RedisModuleCtx *ctx, RedisModuleCommandFilterFunc cb, int flags) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_UnregisterCommandFilter)(RedisModuleCtx *ctx, RedisModuleCommandFilter *filter) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CommandFilterArgsCount)(RedisModuleCommandFilterCtx *fctx) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_CommandFilterArgGet)(RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1617,6 +1617,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ExportSharedAPI);
     REDISMODULE_GET_API(GetSharedAPI);
     REDISMODULE_GET_API(RegisterCommandFilter);
+    REDISMODULE_GET_API(RegisterCommandPostFilter);
     REDISMODULE_GET_API(UnregisterCommandFilter);
     REDISMODULE_GET_API(CommandFilterArgsCount);
     REDISMODULE_GET_API(CommandFilterArgGet);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1253,7 +1253,7 @@ REDISMODULE_API void (*RedisModule_SetDisconnectCallback)(RedisModuleBlockedClie
 REDISMODULE_API void (*RedisModule_SetClusterFlags)(RedisModuleCtx *ctx, uint64_t flags) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ExportSharedAPI)(RedisModuleCtx *ctx, const char *apiname, void *func) REDISMODULE_ATTR;
 REDISMODULE_API void * (*RedisModule_GetSharedAPI)(RedisModuleCtx *ctx, const char *apiname) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCommandFilter * (*RedisModule_RegisterCommandFilter)(RedisModuleCtx *ctx, RedisModuleCommandFilterFunc cb, int flags) REDISMODULE_ATTR;
+REDISMODULE_API RedisModuleCommandFilter * (*RedisModule_RegisterCommandFilter)(RedisModuleCtx *ctx, RedisModuleCommandFilterFunc pre_cb, RedisModuleCommandFilterFunc post_cb, int flags) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_UnregisterCommandFilter)(RedisModuleCtx *ctx, RedisModuleCommandFilter *filter) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CommandFilterArgsCount)(RedisModuleCommandFilterCtx *fctx) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_CommandFilterArgGet)(RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;

--- a/src/server.c
+++ b/src/server.c
@@ -3591,8 +3591,8 @@ void call(client *c, int flags) {
 
     /* Update failed command calls if required. */
 
-    int is_failed = incrCommandStatsOnError(real_cmd, ERROR_COMMAND_FAILED);
-    if (!is_failed && c->deferred_reply_errors) {
+    int failed = incrCommandStatsOnError(real_cmd, ERROR_COMMAND_FAILED);
+    if (!failed && c->deferred_reply_errors) {
         /* When call is used from a module client, error stats, and total_error_replies
          * isn't updated since these errors, if handled by the module, are internal,
          * and not reflected to users. however, the commandstats does show these calls
@@ -3728,13 +3728,13 @@ void call(client *c, int flags) {
     if (zmalloc_used > server.stat_peak_memory)
         server.stat_peak_memory = zmalloc_used;
 
-    /* Do some maintenance job and cleanup */
-    afterCommand(c);
-
     /* Call command post filters */
     if (server.execution_nesting == 0 && !(c->flags & CLIENT_BLOCKED)) {
-        moduleCallCommandPostFilters(c, dirty, is_failed || c->deferred_reply_errors);
+        moduleCallCommandPostFilters(c, dirty, failed || c->deferred_reply_errors);
     }
+
+    /* Do some maintenance job and cleanup */
+    afterCommand(c);
 
     /* Remember the replication offset of the client, right after its last
      * command that resulted in propagation. */

--- a/src/server.c
+++ b/src/server.c
@@ -3730,6 +3730,11 @@ void call(client *c, int flags) {
     /* Do some maintenance job and cleanup */
     afterCommand(c);
 
+    /* Call command post filters */
+    if (server.execution_nesting == 0 && !(c->flags & CLIENT_BLOCKED)) {    
+        moduleCallCommandPostFilters(c, dirty);
+    }
+
     /* Remember the replication offset of the client, right after its last
      * command that resulted in propagation. */
     if (old_master_repl_offset != server.master_repl_offset)

--- a/src/server.c
+++ b/src/server.c
@@ -3592,8 +3592,6 @@ void call(client *c, int flags) {
     /* Update failed command calls if required. */
 
     int is_failed = incrCommandStatsOnError(real_cmd, ERROR_COMMAND_FAILED);
-    is_failed = is_failed || c->deferred_reply_errors;
-    
     if (!is_failed && c->deferred_reply_errors) {
         /* When call is used from a module client, error stats, and total_error_replies
          * isn't updated since these errors, if handled by the module, are internal,
@@ -3735,7 +3733,7 @@ void call(client *c, int flags) {
 
     /* Call command post filters */
     if (server.execution_nesting == 0 && !(c->flags & CLIENT_BLOCKED)) {
-        moduleCallCommandPostFilters(c, dirty, is_failed);
+        moduleCallCommandPostFilters(c, dirty, is_failed || c->deferred_reply_errors);
     }
 
     /* Remember the replication offset of the client, right after its last

--- a/src/server.h
+++ b/src/server.h
@@ -2516,6 +2516,7 @@ void moduleReleaseGIL(void);
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
 void firePostExecutionUnitJobs(void);
 void moduleCallCommandFilters(client *c);
+void moduleCallCommandPostFilters(client *c, int is_dirty);
 void modulePostExecutionUnitOperations(void);
 void ModuleForkDoneHandler(int exitcode, int bysignal);
 int TerminateModuleForkChild(int child_pid, int wait);

--- a/src/server.h
+++ b/src/server.h
@@ -2516,7 +2516,7 @@ void moduleReleaseGIL(void);
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
 void firePostExecutionUnitJobs(void);
 void moduleCallCommandFilters(client *c);
-void moduleCallCommandPostFilters(client *c, int is_dirty);
+void moduleCallCommandPostFilters(client *c, long long dirty);
 void modulePostExecutionUnitOperations(void);
 void ModuleForkDoneHandler(int exitcode, int bysignal);
 int TerminateModuleForkChild(int child_pid, int wait);

--- a/src/server.h
+++ b/src/server.h
@@ -2516,7 +2516,7 @@ void moduleReleaseGIL(void);
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
 void firePostExecutionUnitJobs(void);
 void moduleCallCommandFilters(client *c);
-void moduleCallCommandPostFilters(client *c, long long dirty);
+void moduleCallCommandPostFilters(client *c, long long dirty, int is_succeeded);
 void modulePostExecutionUnitOperations(void);
 void ModuleForkDoneHandler(int exitcode, int bysignal);
 int TerminateModuleForkChild(int child_pid, int wait);

--- a/src/server.h
+++ b/src/server.h
@@ -2516,7 +2516,7 @@ void moduleReleaseGIL(void);
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
 void firePostExecutionUnitJobs(void);
 void moduleCallCommandFilters(client *c);
-void moduleCallCommandPostFilters(client *c, long long dirty, int is_succeeded);
+void moduleCallCommandPostFilters(client *c, long long dirty, int is_failed);
 void modulePostExecutionUnitOperations(void);
 void ModuleForkDoneHandler(int exitcode, int bysignal);
 int TerminateModuleForkChild(int child_pid, int wait);

--- a/tests/modules/commandfilter.c
+++ b/tests/modules/commandfilter.c
@@ -222,11 +222,11 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                 CommandFilter_UnfilteredClientdId, "admin", 1,1,1) == REDISMODULE_ERR)
             return REDISMODULE_ERR;
 
-    if ((filter = RedisModule_RegisterCommandFilter(ctx, CommandFilter_CommandFilter, 
+    if ((filter = RedisModule_RegisterCommandFilter(ctx, CommandFilter_CommandFilter, NULL, 
                     noself ? REDISMODULE_CMDFILTER_NOSELF : 0))
             == NULL) return REDISMODULE_ERR;
 
-    if ((filter1 = RedisModule_RegisterCommandFilter(ctx, CommandFilter_BlmoveSwap, 0)) == NULL)
+    if ((filter1 = RedisModule_RegisterCommandFilter(ctx, CommandFilter_BlmoveSwap, NULL, 0)) == NULL)
         return REDISMODULE_ERR;
 
     return REDISMODULE_OK;

--- a/tests/modules/commandfilter.c
+++ b/tests/modules/commandfilter.c
@@ -222,11 +222,11 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                 CommandFilter_UnfilteredClientdId, "admin", 1,1,1) == REDISMODULE_ERR)
             return REDISMODULE_ERR;
 
-    if ((filter = RedisModule_RegisterCommandFilter(ctx, CommandFilter_CommandFilter, NULL, 
+    if ((filter = RedisModule_RegisterCommandFilter(ctx, CommandFilter_CommandFilter, 
                     noself ? REDISMODULE_CMDFILTER_NOSELF : 0))
             == NULL) return REDISMODULE_ERR;
 
-    if ((filter1 = RedisModule_RegisterCommandFilter(ctx, CommandFilter_BlmoveSwap, NULL, 0)) == NULL)
+    if ((filter1 = RedisModule_RegisterCommandFilter(ctx, CommandFilter_BlmoveSwap, 0)) == NULL)
         return REDISMODULE_ERR;
 
     return REDISMODULE_OK;

--- a/tests/unit/moduleapi/commandfilter.tcl
+++ b/tests/unit/moduleapi/commandfilter.tcl
@@ -63,7 +63,7 @@ start_server {tags {"modules"}} {
         # cmd execute fail and data not changed
         assert_error "WRONGTYPE*" {r hset mykey myfield myvalue}
         r del mykey
-    } {}
+    }
 
     test {Command Filter is unregistered implicitly on module unload} {
         r del log-key

--- a/tests/unit/moduleapi/commandfilter.tcl
+++ b/tests/unit/moduleapi/commandfilter.tcl
@@ -54,6 +54,17 @@ start_server {tags {"modules"}} {
         r commandfilter.retained
     } {my-retained-string}
 
+    test {Command Filter post callback} {
+        r del mykey
+        # cmd execute succeed and data had been changed
+        r set mykey myvalue
+        # cmd execute succeed and data not change
+        r set mykey myvalue nx
+        # cmd execute fail and data not changed
+        assert_error "WRONGTYPE*" {r hset mykey myfield myvalue}
+        r del mykey
+    } {}
+
     test {Command Filter is unregistered implicitly on module unload} {
         r del log-key
         r module unload commandfilter


### PR DESCRIPTION
For ISSUE #12060 

Add a extra callback function `post_callback` for RedisModuleCommandFilter, this function is invoked after the command is executed.

For compatibility, if only want a pre_callback, the post_callback function needs to be set to null.

Modifications:
- add post_callback to RedisModuleCommandFilter
- rename the original `callback` to `pre_callback` in order to differentiate
- change API `RegisterCommandFilter` 
- the post_callback will be called after `processCommand()`
  ```I'm not sure this is the right place```
- add a field `is_dirty` indicates the data set changed by current command