### PR TITLE
Fix test, disable expiration until empty buckets are formed

### DIFF
--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -836,6 +836,8 @@ start_server {tags {"expire"}} {
 
 start_cluster 1 0 {tags {"expire external:skip cluster"}} {
     test "expire scan should skip dictionaries with lot's of empty buckets" {
+        r debug set-active-expire 0
+
         # Collect two slots to help determine the expiry scan logic is able
         # to go past certain slots which aren't valid for scanning at the given point of time.
         # And the next non empyt slot after that still gets scanned and expiration happens.
@@ -862,7 +864,9 @@ start_cluster 1 0 {tags {"expire external:skip cluster"}} {
             r del "{foo}$j"
         }
 
-        # Verify {foo}5 still exists and remaining got cleaned up
+        r debug set-active-expire 1
+
+        # Verify {foo}100 still exists and remaining got cleaned up
         wait_for_condition 20 100 {
             [r dbsize] eq 1
         } else {
@@ -903,5 +907,5 @@ start_cluster 1 0 {tags {"expire external:skip cluster"}} {
         } else {
             fail "Keys did not actively expire."
         }
-    }
+    } {} {needs:debug}
 }


### PR DESCRIPTION
Test failure on freebsd CI:
https://github.com/redis/redis/actions/runs/6607001072/job/17943822780#step:4:8901
```
*** [err]: expire scan should skip dictionaries with lot's of empty buckets in tests/unit/expire.tcl
  scan didn't handle slot skipping logic.
```


Observation:

expiry of keys might happen before the empty buckets are formed and won't help with the expiry skip logic validation.

Solution:

Disable expiration until the empty buckets are formed.

Additional testing:

Added some wait between key deletion and observed the test was failing prior to this change.
```
        # delete data to have lot's (99%) of empty buckets (slot 12182 should be skipped)
        for {set j 1} {$j <= 99} {incr j} {
            after 100
            r del "{foo}$j"
        }
```