### PR TITLE
Fix fd leak causing deleted files to remain open and eat disk space

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2250,6 +2250,7 @@ void readSyncBulkPayload(connection *conn) {
         }
 
         zfree(server.repl_transfer_tmpfile);
+        close(server.repl_transfer_fd);
         server.repl_transfer_fd = -1;
         server.repl_transfer_tmpfile = NULL;
     }


### PR DESCRIPTION
This was introduced in v7.2 by #11248
Causes a deleted files to remain open, preventing the release of disk space until the process is restarted.
Happens on the replica process, after each full sync (unless `repl-diskless-load` is used)

Fixes #12678