### PR TITLE
Reset later item flag after defrag later is done

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1053,6 +1053,7 @@ void activeDefragCycle(void) {
                     continue;
                 }
                 slot = dbGetNextNonEmptySlot(db, slot, DB_MAIN);
+                defrag_later_item_in_progress = 0;
                 ctx.slot = slot;
             }
     


### PR DESCRIPTION
Fixing issues described in https://github.com/redis/redis/pull/12672, started after https://github.com/redis/redis/pull/11695
Related to #12674 

Fixes the `defrag didn't stop' issue.

In some cases of how the keys were stored in memory defrag_later_item_in_progress was not getting reset once we finish defragging the later items and we move to the next slot. This stopped the scan to happen in the later slots and did not get defragged.

