### PR TITLE
Cluster: Don't crash when adding a forgotten node to blacklist twice

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2651,7 +2651,7 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
             clusterNode *n = clusterLookupNode(forgotten_node_ext->name, CLUSTER_NAMELEN);
             if (n && n != myself && !(nodeIsSlave(myself) && myself->slaveof == n)) {
                 sds id = sdsnewlen(forgotten_node_ext->name, CLUSTER_NAMELEN);
-                dictEntry *de = dictAddRaw(server.cluster->nodes_black_list, id, NULL);
+                dictEntry *de = dictAddOrFind(server.cluster->nodes_black_list, id);
                 serverAssert(de != NULL);
                 uint64_t expire = server.unixtime + ntohu64(forgotten_node_ext->ttl);
                 dictSetUnsignedIntegerVal(de, expire);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2652,7 +2652,6 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
             if (n && n != myself && !(nodeIsSlave(myself) && myself->slaveof == n)) {
                 sds id = sdsnewlen(forgotten_node_ext->name, CLUSTER_NAMELEN);
                 dictEntry *de = dictAddOrFind(server.cluster->nodes_black_list, id);
-                serverAssert(de != NULL);
                 uint64_t expire = server.unixtime + ntohu64(forgotten_node_ext->ttl);
                 dictSetUnsignedIntegerVal(de, expire);
                 clusterDelNode(n);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1131,6 +1131,9 @@ void clusterReset(int hard) {
     }
     dictReleaseIterator(di);
 
+    /* Empty the nodes blacklist. */
+    dictEmpty(server.cluster->nodes_black_list, NULL);
+
     /* Hard reset only: set epochs to 0, change node ID. */
     if (hard) {
         sds oldname;


### PR DESCRIPTION
Fixes #12701

This is defensive code to avoid the problem. I haven't reproduced the crash though.