### PR TITLE
Optimize finding slot for a given key count in a fenwick tree

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -520,7 +520,7 @@ int findSlotByKeyIndex(redisDb *db, unsigned long target, dbKeyType keyType) {
     for (int i = bit_mask; i != 0; i >>= 1) {
         int current = result + i;
         /* When the target index is greater than 'current' node value the we will update
-         * the target and serach in the 'current' node tree. */
+         * the target and search in the 'current' node tree. */
         if (target > db->sub_dict[keyType].slot_size_index[current]) {
             target -= db->sub_dict[keyType].slot_size_index[current];
             result = current;

--- a/src/db.c
+++ b/src/db.c
@@ -526,12 +526,9 @@ int findSlotByKeyIndex(redisDb *db, unsigned long target, dbKeyType keyType) {
             result = current;
         }
     }
-    /* After the search if the target index is non zero, the target key at the index will be in the next node. */
-    if (target != 0) {
-        result++;
-    }
-
-    return result-1; /* Unlike BIT, slots are 0-based, so we need to subtract 1. */
+    /* Unlike BIT, slots are 0-based, so we need to subtract 1, but we also need to add 1,
+     * since we want the next slot. */
+    return result;
 }
 
 /* Helper for sync and async delete. */

--- a/src/db.c
+++ b/src/db.c
@@ -507,9 +507,10 @@ int getFairRandomSlot(redisDb *db, dbKeyType keyType) {
  * 
  * This function is 1 based and the range of the target is [1..dbSize], dbSize inclusive.
  * 
- * To find the slot, we start with the root node of the binary index tree and search through its children from the highest index (2^14 in our case) to the lowest index. 
- * At each node, we check if the target value is greater than the node's value. 
- * If it is, we remove the node's value from the target and recursively search for the new target using the current node as the parent.
+ * To find the slot, we start with the root node of the binary index tree and search through its children
+ * from the highest index (2^14 in our case) to the lowest index. At each node, we check if the target 
+ * value is greater than the node's value. If it is, we remove the node's value from the target and recursively
+ * search for the new target using the current node as the parent.
  * Time complexity of this function is O(log(CLUSTER_SLOTS))
  */
 int findSlotByKeyIndex(redisDb *db, unsigned long target, dbKeyType keyType) {


### PR DESCRIPTION
Related to https://github.com/redis/redis/issues/12654

This PR optimizes the time complexity of `findSlotByKeyIndex` from O(log^2(N)) to O(log(N)).