### PR TITLE
Handle all CLUSTER_REDIR_ error code when verifying Lua.

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -431,7 +431,9 @@ static int scriptVerifyClusterState(scriptRunCtx *run_ctx, client *c, client *or
     int hashslot = -1;
     if (getNodeByQuery(c, c->cmd, c->argv, c->argc, &hashslot, &error_code) != server.cluster->myself) {
         if (error_code == CLUSTER_REDIR_CROSS_SLOT) {
-            *err = sdsnew("Script attempted to access keys don't hash to the same slot");
+            *err = sdscatfmt(sdsempty(), 
+                             "Command '%S' in script attempted to access keys don't hash to the same slot",
+                             c->argv[0]->ptr);
         } else if (error_code == CLUSTER_REDIR_UNSTABLE) {
             /* The request spawns multiple keys in the same slot,
              * but the slot is not "stable" currently as there is

--- a/src/script.c
+++ b/src/script.c
@@ -433,12 +433,15 @@ static int scriptVerifyClusterState(scriptRunCtx *run_ctx, client *c, client *or
         if (error_code == CLUSTER_REDIR_CROSS_SLOT) {
             *err = sdscatfmt(sdsempty(), 
                              "Command '%S' in script attempted to access keys don't hash to the same slot",
-                             c->argv[0]->ptr);
+                             c->cmd->fullname);
         } else if (error_code == CLUSTER_REDIR_UNSTABLE) {
             /* The request spawns multiple keys in the same slot,
              * but the slot is not "stable" currently as there is
              * a migration or import in progress. */
-            *err = sdsnew("Script requested multiple keys during rehashing of slot");
+            *err = sdscatfmt(sdsempty(),
+                             "Unable to execute command '%S' in script "
+                             "because undeclared keys were accessed during rehashing of slot",
+                             c->cmd->fullname);
         } else if (error_code == CLUSTER_REDIR_DOWN_STATE) {
             *err = sdsnew("Script attempted to execute a command while the "
                     "cluster is down");


### PR DESCRIPTION
In function `scriptVerifyClusterState`, not all error code generated by `getNodeByQuery` are handled.

This may be misleading sometimes: when executing `mget a b`, Redis returns `-CROSSSLOT` error, but when executing `EVAL "redis.call('mget','a','b')" 0`, Redis returns "Script attempted to access a non local key in a cluster node" regardless of which specific error it was. now each error case has it's own error message.