### PR TITLE
re-enable defrag tests in cluster mode

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -168,7 +168,6 @@ run_solo {defrag} {
         r config set appendonly no
         r config set key-load-delay 0
 
-        if {$type eq "standalone"} {
         test "Active defrag eval scripts: $type" {
             r flushdb
             r script flush sync
@@ -607,7 +606,6 @@ run_solo {defrag} {
                 assert {$digest eq $newdigest}
                 r save ;# saving an rdb iterates over all the data / pointers
             }
-        }
         }
     }
     }

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -395,6 +395,7 @@ run_solo {defrag} {
             r save ;# saving an rdb iterates over all the data / pointers
         } {OK}
 
+        if {$type eq "standalone"} { ;# skip in cluster mode
         test "Active defrag big list: $type" {
             r flushdb
             r config resetstat
@@ -606,6 +607,7 @@ run_solo {defrag} {
                 assert {$digest eq $newdigest}
                 r save ;# saving an rdb iterates over all the data / pointers
             }
+        } ;# standalone
         }
     }
     }


### PR DESCRIPTION
Related to https://github.com/redis/redis/pull/12694#issuecomment-1786686345

This PR reverts the skipping defrag tests in cluster mode (done in #12672.
instead it skips only some defrag tests that are relevant for cluster modes.
The test now run well after investigating and making the changes in #12674 and #12694.