### PR TITLE
Port security patches in newer version of Lua to Redis

### DIFF
--- a/deps/lua/src/ldebug.c
+++ b/deps/lua/src/ldebug.c
@@ -93,9 +93,12 @@ LUA_API int lua_getstack (lua_State *L, int level, lua_Debug *ar) {
     status = 1;
     ar->i_ci = cast_int(ci - L->base_ci);
   }
-  else if (level < 0) {  /* level is of a lost tail call? */
-    status = 1;
-    ar->i_ci = 0;
+  else if (level < 0) {
+    if (ci == L->ci) status = 0;  /* level was negative? */
+    else {  /* level is of a lost tail call */
+      status = 1;
+      ar->i_ci = NULL;
+    }
   }
   else status = 0;  /* no such level */
   lua_unlock(L);
@@ -110,6 +113,7 @@ static Proto *getluaproto (CallInfo *ci) {
 
 static const char *findlocal (lua_State *L, CallInfo *ci, int n) {
   const char *name;
+  if (ci == NULL) return NULL;  /* tail call? */
   Proto *fp = getluaproto(ci);
   if (fp && (name = luaF_getlocalname(fp, n, currentpc(L, ci))) != NULL)
     return name;  /* is a local variable in a Lua function */

--- a/deps/lua/src/ldo.c
+++ b/deps/lua/src/ldo.c
@@ -246,8 +246,10 @@ static StkId tryfuncTM (lua_State *L, StkId func) {
   const TValue *tm = luaT_gettmbyobj(L, func, TM_CALL);
   StkId p;
   ptrdiff_t funcr = savestack(L, func);
-  if (!ttisfunction(tm))
+  if (!ttisfunction(tm)) {
+    luaD_checkstack(L, 1);
     luaG_typeerror(L, func, "call");
+  }
   /* Open a hole inside the stack at `func' */
   for (p = L->top; p > func; p--) setobjs2s(L, p, p-1);
   incr_top(L);

--- a/deps/lua/src/ldo.c
+++ b/deps/lua/src/ldo.c
@@ -226,6 +226,7 @@ static StkId adjust_varargs (lua_State *L, Proto *p, int actual) {
   }
 #endif
   /* move fixed parameters to final position */
+  luaD_checkstack(L, p->maxstacksize);  /* check again for new 'base' */
   fixed = L->top - actual;  /* first fixed argument */
   base = L->top;  /* final position of first argument */
   for (i=0; i<nfixargs; i++) {

--- a/deps/lua/src/ltable.c
+++ b/deps/lua/src/ltable.c
@@ -435,7 +435,7 @@ static TValue *newkey (lua_State *L, Table *t, const TValue *key) {
 */
 const TValue *luaH_getnum (Table *t, int key) {
   /* (1 <= key && key <= t->sizearray) */
-  if (cast(unsigned int, key-1) < cast(unsigned int, t->sizearray))
+  if (cast(unsigned int, key)-1 < cast(unsigned int, t->sizearray))
     return &t->array[key-1];
   else {
     lua_Number nk = cast_num(key);


### PR DESCRIPTION
Certain security updates in Lua (refer to the commits below) have not been integrated into Redis. According to my discussion with Oran Agra, it appears that Redis is not utilizing the specific vulnerable components of Lua, and / or these fixes are for issues introduced in a more recent Lua versions. Nevertheless, incorporating security updates poses no harm and can prevent potential future issues. Note that I have tested all these changes and they passed all regression tests.

The following commit IDs in Lua pertain to the updates I am mentioning in this commit.
b114c99a60cd87f7a7b2e5608b9492235b499d80
bfa0898312e1a36087fa10fa8020a706a2e8e885
8950e0c049cc51025d501453b85f501b15c5317a