### PR TITLE
remove unnecessary memcpy

### DIFF
--- a/src/rax.c
+++ b/src/rax.c
@@ -933,10 +933,8 @@ void *raxFind(rax *rax, unsigned char *s, size_t len) {
  * memory without any bound checking). */
 raxNode **raxFindParentLink(raxNode *parent, raxNode *child) {
     raxNode **cp = raxNodeFirstChildPtr(parent);
-    raxNode *c;
     while(1) {
-        memcpy(&c,cp,sizeof(c));
-        if (c == child) break;
+        if (*cp == child) break;
         cp++;
     }
     return cp;


### PR DESCRIPTION
#12718 
```
raxNode **raxFindParentLink(raxNode *parent, raxNode *child) {
    raxNode **cp = raxNodeFirstChildPtr(parent);
    raxNode *c;
    while(1) {
        memcpy(&c,cp,sizeof(c));
        if (c == child) break;
        cp++;
    }
    return cp;
}
```
the "memcpy" is unnecessary and will be removed by compiler optimization ( gcc-12.1 -O2 ), the corresponding disassembly is:
```
/home/redis-stable/src/rax.c:939
  4faff6:	48 3b 30             	cmp    (%rax),%rsi    # %rax keep the value of `cp`, I have checked the debug info
  4faff9:	74 0e                	je     4fb009 <raxFindParentLink+0x29>
  4faffb:	0f 1f 44 00 00       	nopl   0x0(%rax,%rax,1)
/home/redis-stable/src/rax.c:940
  4fb000:	48 83 c0 08          	add    $0x8,%rax
/home/redis-stable/src/rax.c:939
  4fb004:	48 3b 30             	cmp    (%rax),%rsi
  4fb007:	75 f7                	jne    4fb000 <raxFindParentLink+0x20>
```
so we can substitute it with "*cp", to make it simpler.