### PR TITLE
Remove unnecessary argument(tp) in gettimeofday() call for retrieving timezone

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -993,10 +993,9 @@ long getTimeZone(void) {
 #if defined(__linux__) || defined(__sun)
     return timezone;
 #else
-    struct timeval tv;
     struct timezone tz;
 
-    gettimeofday(&tv, &tz);
+    gettimeofday(NULL, &tz);
 
     return tz.tz_minuteswest * 60L;
 #endif


### PR DESCRIPTION
Releated to #12719 .

This PR changes the `gettimeofday` caller, by removing an unused optional output argument.

It would take 2 benefits:

- simplify code, discard unnecessary arg.
- possibly faster due to the implementation in kernel.