### PR TITLE
fix: correct comments in rax.h

### DIFF
--- a/src/rax.h
+++ b/src/rax.h
@@ -46,13 +46,13 @@
  *                  \
  *                  (o) "fo"
  *                    \
- *                  [t   b] "foo"
+ *                  [b   t] "foo"
  *                  /     \
- *         "foot" (e)     (a) "foob"
+ *         "foob" (a)     (e) "foot"
  *                /         \
- *      "foote" (r)         (r) "fooba"
+ *      "fooba" (r)         (r) "foote"
  *              /             \
- *    "footer" []             [] "foobar"
+ *    "foobar" []             [] "footer"
  *
  * However, this implementation implements a very common optimization where
  * successive nodes having a single child are "compressed" into the node
@@ -61,13 +61,13 @@
  * provided inside the representation. So the above representation is turned
  * into:
  *
- *                  ["foo"] ""
+ *                  ("foo") ""
  *                     |
- *                  [t   b] "foo"
+ *                  [b   t] "foo"
  *                  /     \
- *        "foot" ("er")    ("ar") "foob"
+ *        "foob" ("ar")    ("er") "foot"
  *                 /          \
- *       "footer" []          [] "foobar"
+ *       "foobar" []          [] "footer"
  *
  * However this optimization makes the implementation a bit more complex.
  * For instance if a key "first" is added in the above radix tree, a
@@ -82,11 +82,11 @@
  *                 /   \
  *    "firs"  ("rst")  (o) "fo"
  *              /        \
- *    "first" []       [t   b] "foo"
+ *    "first" []       [b   t] "foo"
  *                     /     \
- *           "foot" ("er")    ("ar") "foob"
+ *           "foob" ("ar")    ("er") "foot"
  *                    /          \
- *          "footer" []          [] "foobar"
+ *          "foobar" []          [] "footer"
  *
  * Similarly after deletion, if a new chain of nodes having a single child
  * is created (the chain must also not include nodes that represent keys),


### PR DESCRIPTION
When a node contains multiple characters, these characters should be sorted in ascending order. In the example given in the comment, the node [t b] should actually be [b t].

```
                ("foo") ""
                   |
                [t   b] "foo"
                /     \
      "foot" ("er")    ("ar") "foob"
               /          \
     "footer" []          [] "foobar"
```

```
                ("foo") ""
                   |
                [b   t] "foo"
                /     \
      "foob" ("ar")    ("er") "foot"
               /          \
     "foobar" []          [] "footer"
 ```