### PR TITLE
Support by/get options for sort(_ro) in cluster mode when pattern implies slot.

### DIFF
--- a/src/sort.c
+++ b/src/sort.c
@@ -244,7 +244,7 @@ void sortCommandGeneric(client *c, int readonly) {
                     addReplyError(c, "BY option of SORT denied in Cluster mode when "
                                  "keys formed by the pattern may be in different slots.");
                     syntax_error++;
-                    break;                   
+                    break;
                 }
                 /* If BY is specified with a real pattern, we can't accept
                  * it if no full ACL key access is applied for this command. */
@@ -254,7 +254,7 @@ void sortCommandGeneric(client *c, int readonly) {
                     break;
                 }
             }
-            j++;                                                                                                                                                                 
+            j++;
         } else if (!strcasecmp(c->argv[j]->ptr,"get") && leftargs >= 1) {
             /* If GET is specified with a real pattern, we can't accept it in cluster mode,
              * unless we can make sure the keys formed by the pattern are in the same slot 

--- a/src/sort.c
+++ b/src/sort.c
@@ -239,8 +239,7 @@ void sortCommandGeneric(client *c, int readonly) {
                 /* If BY is specified with a real pattern, we can't accept it in cluster mode,
                  * unless we can make sure the keys formed by the pattern are in the same slot 
                  * as the key to sort. */
-                int key_slot = keyHashSlot(c->argv[1]->ptr, sdslen(c->argv[1]->ptr));
-                if (server.cluster_enabled && patternHashSlot(sortby->ptr, sdslen(sortby->ptr)) != key_slot) {
+                if (server.cluster_enabled && patternHashSlot(sortby->ptr, sdslen(sortby->ptr)) != c->slot) {
                     addReplyError(c, "BY option of SORT denied in Cluster mode when "
                                  "keys formed by the pattern may be in different slots.");
                     syntax_error++;
@@ -259,11 +258,10 @@ void sortCommandGeneric(client *c, int readonly) {
             /* If GET is specified with a real pattern, we can't accept it in cluster mode,
              * unless we can make sure the keys formed by the pattern are in the same slot 
              * as the key to sort. */
-            int key_slot = keyHashSlot(c->argv[1]->ptr, sdslen(c->argv[1]->ptr));
-            if (server.cluster_enabled && patternHashSlot(c->argv[j+1]->ptr, sdslen(c->argv[j+1]->ptr)) != key_slot) {
+            if (server.cluster_enabled && patternHashSlot(c->argv[j+1]->ptr, sdslen(c->argv[j+1]->ptr)) != c->slot) {
                 addReplyError(c, "GET option of SORT denied in Cluster mode when "
                               "keys formed by the pattern may be in different slots.");
-                syntax_error++;    
+                syntax_error++;
                 break;
             }
             if (!user_has_full_key_access) {

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -378,9 +378,9 @@ start_cluster 1 0 {tags {"external:skip cluster sort"}} {
     test "sort get in cluster mode" {
         catch {r sort "{a}mylist" by "{a}by*" get get*} e
         assert_match {ERR GET option of SORT denied in Cluster mode when *} $e
-        r sort "{a}mylist" by "{a}by*" get "{a}get*"             
+        r sort "{a}mylist" by "{a}by*" get "{a}get*"
     } {30 200 100}
-    
+
     test "sort_ro by in cluster mode" {
         catch {r sort_ro "{a}mylist" by by*} e
         assert_match {ERR BY option of SORT denied in Cluster mode when *} $e
@@ -390,6 +390,6 @@ start_cluster 1 0 {tags {"external:skip cluster sort"}} {
     test "sort_ro get in cluster mode" {
         catch {r sort_ro "{a}mylist" by "{a}by*" get get*} e
         assert_match {ERR GET option of SORT denied in Cluster mode when *} $e
-        r sort_ro "{a}mylist" by "{a}by*" get "{a}get*"             
+        r sort_ro "{a}mylist" by "{a}by*" get "{a}get*"
     } {30 200 100}
 }

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -357,3 +357,39 @@ foreach command {SORT SORT_RO} {
         }
     }
 }
+
+start_cluster 1 0 {tags {"external:skip cluster sort"}} {
+
+    r flushall
+    r lpush "{a}mylist" 1 2 3
+    r set "{a}by1" 20
+    r set "{a}by2" 30
+    r set "{a}by3" 0
+    r set "{a}get1" 200
+    r set "{a}get2" 100
+    r set "{a}get3" 30
+
+    test "sort by in cluster mode" {
+        catch {r sort "{a}mylist" by by*} e
+        assert_match {ERR BY option of SORT denied in Cluster mode when *} $e
+        r sort "{a}mylist" by "{a}by*"
+    } {3 1 2}
+
+    test "sort get in cluster mode" {
+        catch {r sort "{a}mylist" by "{a}by*" get get*} e
+        assert_match {ERR GET option of SORT denied in Cluster mode when *} $e
+        r sort "{a}mylist" by "{a}by*" get "{a}get*"             
+    } {30 200 100}
+    
+    test "sort_ro by in cluster mode" {
+        catch {r sort_ro "{a}mylist" by by*} e
+        assert_match {ERR BY option of SORT denied in Cluster mode when *} $e
+        r sort_ro "{a}mylist" by "{a}by*"
+    } {3 1 2}
+
+    test "sort_ro get in cluster mode" {
+        catch {r sort_ro "{a}mylist" by "{a}by*" get get*} e
+        assert_match {ERR GET option of SORT denied in Cluster mode when *} $e
+        r sort_ro "{a}mylist" by "{a}by*" get "{a}get*"             
+    } {30 200 100}
+}


### PR DESCRIPTION
The by/get options of sort/sort_ro command used to be forbidden in cluster mode, since we are not sure which slot the pattern may be in.

As the optimization done in #12536, patterns now can be mapped to slots, we should allow by/get options in cluster mode when the pattern maps to the same slot as the key.