### PR TITLE
Before evicted and before expired server events are not executed inside an execution unit.

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -682,6 +682,7 @@ int performEvictions(void) {
              *
              * AOF and Output buffer memory will be freed eventually so
              * we only care about memory used by the key space. */
+            enterExecutionUnit(1, 0);
             delta = (long long) zmalloc_used_memory();
             latencyStartMonitor(eviction_latency);
             dbGenericDelete(db,keyobj,server.lazyfree_lazy_eviction,DB_FLAG_KEY_EVICTED);
@@ -694,6 +695,7 @@ int performEvictions(void) {
             notifyKeyspaceEvent(NOTIFY_EVICTED, "evicted",
                 keyobj, db->id);
             propagateDeletion(db,keyobj,server.lazyfree_lazy_eviction);
+            exitExecutionUnit();
             postExecutionUnitOperations();
             decrRefCount(keyobj);
             keys_freed++;

--- a/src/expire.c
+++ b/src/expire.c
@@ -54,7 +54,7 @@
 int activeExpireCycleTryExpire(redisDb *db, dictEntry *de, long long now) {
     long long t = dictGetSignedIntegerVal(de);
     if (now > t) {
-    	enterExecutionUnit(1, 0);
+        enterExecutionUnit(1, 0);
         sds key = dictGetKey(de);
         robj *keyobj = createStringObject(key,sdslen(key));
         deleteExpiredKeyAndPropagate(db,keyobj);

--- a/src/expire.c
+++ b/src/expire.c
@@ -54,10 +54,12 @@
 int activeExpireCycleTryExpire(redisDb *db, dictEntry *de, long long now) {
     long long t = dictGetSignedIntegerVal(de);
     if (now > t) {
+    	enterExecutionUnit(1, 0);
         sds key = dictGetKey(de);
         robj *keyobj = createStringObject(key,sdslen(key));
         deleteExpiredKeyAndPropagate(db,keyobj);
         decrRefCount(keyobj);
+        exitExecutionUnit();
         return 1;
     } else {
         return 0;

--- a/tests/modules/postnotifications.c
+++ b/tests/modules/postnotifications.c
@@ -206,13 +206,15 @@ static void KeySpace_ServerEventCallback(RedisModuleCtx *ctx, RedisModuleEvent e
 
     const RedisModuleString *key_name = RedisModule_GetKeyNameFromModuleKey(((RedisModuleKeyInfo*)data)->key);
     const char *key_str = RedisModule_StringPtrLen(key_name, NULL);
-    const char *event = events[subevent];
-    size_t event_len = strlen(event);
-    if (strncmp(key_str, event , event_len) == 0) {
-        return; /* avoid loops */
+
+    for (int i = 0 ; i < 4 ; ++i) {
+        const char *event = events[i];
+        if (strncmp(key_str, event , strlen(event)) == 0) {
+            return; /* don't log any event on our tracking keys */
+        }
     }
 
-    RedisModuleString *new_key = RedisModule_CreateString(NULL, event, event_len);
+    RedisModuleString *new_key = RedisModule_CreateString(NULL, events[subevent], strlen(events[subevent]));
     RedisModule_AddPostNotificationJob(ctx, KeySpace_PostNotificationString, new_key, KeySpace_PostNotificationStringFreePD);
 }
 

--- a/tests/unit/moduleapi/async_rm_call.tcl
+++ b/tests/unit/moduleapi/async_rm_call.tcl
@@ -314,6 +314,15 @@ start_server {tags {"modules"}} {
         r lpush l a
         assert_equal [$rd read] {OK}
 
+        # Explanation of the first multi exec block:
+        # {lpop l} - pop the value by our blocking command 'blpop_and_set_multiple_keys'
+        # {set string_foo 1} - the action of our blocking command 'blpop_and_set_multiple_keys'
+        # {set string_bar 2} - the action of our blocking command 'blpop_and_set_multiple_keys'
+        # {incr before_deleted} - post notificaiton job registered on the before deleted event of list l that got empty
+        # {incr string_changed{string_foo}} - post notification job that was registered when 'string_foo' changed
+        # {incr string_changed{string_bar}} - post notification job that was registered when 'string_bar' changed
+        # {incr string_total} - post notification job that was registered when string_changed{string_foo} changed
+        # {incr string_total} - post notification job that was registered when string_changed{string_bar} changed
         assert_replication_stream $repl {
             {select *}
             {lpush l a}
@@ -356,6 +365,29 @@ start_server {tags {"modules"}} {
         r lpush l a
         assert_equal [$rd read] {OK}
 
+        # Explanation of the first multi exec block:
+        # {lpop l} - pop the value by our blocking command 'blpop_and_set_multiple_keys'
+        # {set string_foo 1} - the action of our blocking command 'blpop_and_set_multiple_keys'
+        # {set string_bar 2} - the action of our blocking command 'blpop_and_set_multiple_keys'
+        # {incr before_deleted} - post notificaiton job registered on the before deleted event of list l that got empty
+        # {incr string_changed{string_foo}} - post notification job that was registered when 'string_foo' changed
+        # {incr string_changed{string_bar}} - post notification job that was registered when 'string_bar' changed
+        # {incr string_total} - post notification job that was registered when string_changed{string_foo} changed
+        # {incr string_total} - post notification job that was registered when string_changed{string_bar} changed
+        #
+        # Explanation of the second multi exec block:
+        # {lpop l} - pop the value by our blocking command 'blpop_and_set_multiple_keys'
+        # {del string_foo} - lazy expiration of string_foo when 'blpop_and_set_multiple_keys' tries to write to it. 
+        # {set string_foo 1} - the action of our blocking command 'blpop_and_set_multiple_keys'
+        # {set string_bar 2} - the action of our blocking command 'blpop_and_set_multiple_keys'
+        # {incr before_deleted} - the post notification job, registered when the list got empty and deleted
+        # {incr before_expired} - the post notification job, registered just before string_foo got expired
+        # {incr expired} - the post notification job, registered after string_foo got expired
+        # {incr string_changed{string_foo}} - post notification job triggered when we set string_foo
+        # {incr before_overwritten} - post notification job triggered before we overwrite string_bar
+        # {incr string_changed{string_bar}} - post notification job triggered when we set string_bar
+        # {incr string_total} - post notification job triggered when we incr 'string_changed{string_foo}'
+        # {incr string_total} - post notification job triggered when we incr 'string_changed{string_bar}'
         assert_replication_stream $repl {
             {select *}
             {lpush l a}

--- a/tests/unit/moduleapi/async_rm_call.tcl
+++ b/tests/unit/moduleapi/async_rm_call.tcl
@@ -321,6 +321,7 @@ start_server {tags {"modules"}} {
             {lpop l}
             {set string_foo 1}
             {set string_bar 2}
+            {incr before_deleted}
             {incr string_changed{string_foo}}
             {incr string_changed{string_bar}}
             {incr string_total}
@@ -362,6 +363,7 @@ start_server {tags {"modules"}} {
             {lpop l}
             {set string_foo 1}
             {set string_bar 2}
+            {incr before_deleted}
             {incr string_changed{string_foo}}
             {incr string_changed{string_bar}}
             {incr string_total}
@@ -374,8 +376,11 @@ start_server {tags {"modules"}} {
             {del string_foo}
             {set string_foo 1}
             {set string_bar 2}
+            {incr before_deleted}
+            {incr before_expired}
             {incr expired}
             {incr string_changed{string_foo}}
+            {incr before_overwritten}
             {incr string_changed{string_bar}}
             {incr string_total}
             {incr string_total}

--- a/tests/unit/moduleapi/async_rm_call.tcl
+++ b/tests/unit/moduleapi/async_rm_call.tcl
@@ -318,7 +318,7 @@ start_server {tags {"modules"}} {
         # {lpop l} - pop the value by our blocking command 'blpop_and_set_multiple_keys'
         # {set string_foo 1} - the action of our blocking command 'blpop_and_set_multiple_keys'
         # {set string_bar 2} - the action of our blocking command 'blpop_and_set_multiple_keys'
-        # {incr before_deleted} - post notificaiton job registered on the before deleted event of list l that got empty
+        # {incr before_deleted} - post notification job registered on the before deleted event of list l that got empty
         # {incr string_changed{string_foo}} - post notification job that was registered when 'string_foo' changed
         # {incr string_changed{string_bar}} - post notification job that was registered when 'string_bar' changed
         # {incr string_total} - post notification job that was registered when string_changed{string_foo} changed
@@ -369,7 +369,7 @@ start_server {tags {"modules"}} {
         # {lpop l} - pop the value by our blocking command 'blpop_and_set_multiple_keys'
         # {set string_foo 1} - the action of our blocking command 'blpop_and_set_multiple_keys'
         # {set string_bar 2} - the action of our blocking command 'blpop_and_set_multiple_keys'
-        # {incr before_deleted} - post notificaiton job registered on the before deleted event of list l that got empty
+        # {incr before_deleted} - post notification job registered on the before deleted event of list l that got empty
         # {incr string_changed{string_foo}} - post notification job that was registered when 'string_foo' changed
         # {incr string_changed{string_bar}} - post notification job that was registered when 'string_bar' changed
         # {incr string_total} - post notification job that was registered when string_changed{string_foo} changed

--- a/tests/unit/moduleapi/async_rm_call.tcl
+++ b/tests/unit/moduleapi/async_rm_call.tcl
@@ -318,7 +318,6 @@ start_server {tags {"modules"}} {
         # {lpop l} - pop the value by our blocking command 'blpop_and_set_multiple_keys'
         # {set string_foo 1} - the action of our blocking command 'blpop_and_set_multiple_keys'
         # {set string_bar 2} - the action of our blocking command 'blpop_and_set_multiple_keys'
-        # {incr before_deleted} - post notification job registered on the before deleted event of list l that got empty
         # {incr string_changed{string_foo}} - post notification job that was registered when 'string_foo' changed
         # {incr string_changed{string_bar}} - post notification job that was registered when 'string_bar' changed
         # {incr string_total} - post notification job that was registered when string_changed{string_foo} changed
@@ -330,7 +329,6 @@ start_server {tags {"modules"}} {
             {lpop l}
             {set string_foo 1}
             {set string_bar 2}
-            {incr before_deleted}
             {incr string_changed{string_foo}}
             {incr string_changed{string_bar}}
             {incr string_total}
@@ -369,7 +367,6 @@ start_server {tags {"modules"}} {
         # {lpop l} - pop the value by our blocking command 'blpop_and_set_multiple_keys'
         # {set string_foo 1} - the action of our blocking command 'blpop_and_set_multiple_keys'
         # {set string_bar 2} - the action of our blocking command 'blpop_and_set_multiple_keys'
-        # {incr before_deleted} - post notification job registered on the before deleted event of list l that got empty
         # {incr string_changed{string_foo}} - post notification job that was registered when 'string_foo' changed
         # {incr string_changed{string_bar}} - post notification job that was registered when 'string_bar' changed
         # {incr string_total} - post notification job that was registered when string_changed{string_foo} changed
@@ -380,11 +377,8 @@ start_server {tags {"modules"}} {
         # {del string_foo} - lazy expiration of string_foo when 'blpop_and_set_multiple_keys' tries to write to it. 
         # {set string_foo 1} - the action of our blocking command 'blpop_and_set_multiple_keys'
         # {set string_bar 2} - the action of our blocking command 'blpop_and_set_multiple_keys'
-        # {incr before_deleted} - the post notification job, registered when the list got empty and deleted
-        # {incr before_expired} - the post notification job, registered just before string_foo got expired
         # {incr expired} - the post notification job, registered after string_foo got expired
         # {incr string_changed{string_foo}} - post notification job triggered when we set string_foo
-        # {incr before_overwritten} - post notification job triggered before we overwrite string_bar
         # {incr string_changed{string_bar}} - post notification job triggered when we set string_bar
         # {incr string_total} - post notification job triggered when we incr 'string_changed{string_foo}'
         # {incr string_total} - post notification job triggered when we incr 'string_changed{string_bar}'
@@ -395,7 +389,6 @@ start_server {tags {"modules"}} {
             {lpop l}
             {set string_foo 1}
             {set string_bar 2}
-            {incr before_deleted}
             {incr string_changed{string_foo}}
             {incr string_changed{string_bar}}
             {incr string_total}
@@ -408,11 +401,8 @@ start_server {tags {"modules"}} {
             {del string_foo}
             {set string_foo 1}
             {set string_bar 2}
-            {incr before_deleted}
-            {incr before_expired}
             {incr expired}
             {incr string_changed{string_foo}}
-            {incr before_overwritten}
             {incr string_changed{string_bar}}
             {incr string_total}
             {incr string_total}

--- a/tests/unit/moduleapi/postnotifications.tcl
+++ b/tests/unit/moduleapi/postnotifications.tcl
@@ -14,6 +14,7 @@ tags "modules" {
             assert_equal {2} [r get string_changed{string_x}]
             assert_equal {2} [r get string_total]
 
+            # the {incr before_overwritten} is a post notification job registered when 'string_x' was overwritten
             assert_replication_stream $repl {
                 {multi}
                 {select *}
@@ -64,6 +65,7 @@ tags "modules" {
                 fail "Failed waiting for x to expired"
             }
 
+            # the {incr before_expired} is a post notification job registered before 'x' got expired
             assert_replication_stream $repl {
                 {select *}
                 {set x 1}
@@ -87,6 +89,7 @@ tags "modules" {
             after 10
             assert_equal {} [r get x]
 
+            # the {incr before_expired} is a post notification job registered before 'x' got expired
             assert_replication_stream $repl {
                 {select *}
                 {set x 1}
@@ -111,6 +114,7 @@ tags "modules" {
             after 10
             assert_equal {OK} [r set read_x 1]
 
+            # the {incr before_expired} is a post notification job registered before 'x' got expired
             assert_replication_stream $repl {
                 {select *}
                 {set x 1}
@@ -152,6 +156,7 @@ tags "modules" {
 
             assert_error {OOM *} {r set y 1}
 
+            # the {incr before_evicted} is a post notification job registered before 'x' got evicted
             assert_replication_stream $repl {
                 {select *}
                 {set x 1}
@@ -186,6 +191,7 @@ tags "modules" {
             assert_equal {1} [r get string_changed{string1_x}]
             assert_equal {3} [r get string_total]
 
+            # the {incr before_overwritten} is a post notification job registered before 'string_x' got overwritten
             assert_replication_stream $repl {
                 {multi}
                 {select *}

--- a/tests/unit/moduleapi/postnotifications.tcl
+++ b/tests/unit/moduleapi/postnotifications.tcl
@@ -15,7 +15,7 @@ tags "modules" {
             assert_equal {2} [r get string_changed{string_x}]
             assert_equal {2} [r get string_total]
 
-            # the {incr before_overwritten} is a post notification job registered when 'string_x' was overwritten
+            # the {lpush before_overwritten string_x} is a post notification job registered when 'string_x' was overwritten
             assert_replication_stream $repl {
                 {multi}
                 {select *}
@@ -66,7 +66,7 @@ tags "modules" {
                 fail "Failed waiting for x to expired"
             }
 
-            # the {incr before_expired} is a post notification job registered before 'x' got expired
+            # the {lpush before_expired x} is a post notification job registered before 'x' got expired
             assert_replication_stream $repl {
                 {select *}
                 {set x 1}
@@ -90,7 +90,7 @@ tags "modules" {
             after 10
             assert_equal {} [r get x]
 
-            # the {incr before_expired} is a post notification job registered before 'x' got expired
+            # the {lpush before_expired x} is a post notification job registered before 'x' got expired
             assert_replication_stream $repl {
                 {select *}
                 {set x 1}
@@ -115,7 +115,7 @@ tags "modules" {
             after 10
             assert_equal {OK} [r set read_x 1]
 
-            # the {incr before_expired} is a post notification job registered before 'x' got expired
+            # the {lpush before_expired x} is a post notification job registered before 'x' got expired
             assert_replication_stream $repl {
                 {select *}
                 {set x 1}
@@ -157,7 +157,7 @@ tags "modules" {
 
             assert_error {OOM *} {r set y 1}
 
-            # the {incr before_evicted} is a post notification job registered before 'x' got evicted
+            # the {lpush before_evicted x} is a post notification job registered before 'x' got evicted
             assert_replication_stream $repl {
                 {select *}
                 {set x 1}
@@ -193,7 +193,7 @@ tags "modules" {
             assert_equal {1} [r get string_changed{string1_x}]
             assert_equal {3} [r get string_total]
 
-            # the {incr before_overwritten} is a post notification job registered before 'string_x' got overwritten
+            # the {lpush before_overwritten string_x} is a post notification job registered before 'string_x' got overwritten
             assert_replication_stream $repl {
                 {multi}
                 {select *}

--- a/tests/unit/moduleapi/postnotifications.tcl
+++ b/tests/unit/moduleapi/postnotifications.tcl
@@ -1,7 +1,8 @@
 set testmodule [file normalize tests/modules/postnotifications.so]
 
 tags "modules" {
-    start_server [list overrides [list loadmodule "$testmodule"]] {
+    start_server {} {
+        r module load $testmodule with_key_events
 
         test {Test write on post notification callback} {
             set repl [attach_to_replication_stream]
@@ -24,7 +25,7 @@ tags "modules" {
                 {exec}
                 {multi}
                 {set string_x 2}
-                {incr before_overwritten}
+                {lpush before_overwritten string_x}
                 {incr string_changed{string_x}}
                 {incr string_total}
                 {exec}
@@ -72,7 +73,7 @@ tags "modules" {
                 {pexpireat x *}
                 {multi}
                 {del x}
-                {incr before_expired}
+                {lpush before_expired x}
                 {incr expired}
                 {exec}
             }
@@ -96,7 +97,7 @@ tags "modules" {
                 {pexpireat x *}
                 {multi}
                 {del x}
-                {incr before_expired}
+                {lpush before_expired x}
                 {incr expired}
                 {exec}
             }
@@ -122,7 +123,7 @@ tags "modules" {
                 {multi}
                 {set read_x 1}
                 {del x}
-                {incr before_expired}
+                {lpush before_expired x}
                 {incr expired}
                 {exec}
             }
@@ -162,7 +163,7 @@ tags "modules" {
                 {set x 1}
                 {multi}
                 {del x}
-                {incr before_evicted}
+                {lpush before_evicted x}
                 {incr evicted}
                 {exec}
             }
@@ -174,7 +175,8 @@ tags "modules" {
 set testmodule2 [file normalize tests/modules/keyspace_events.so]
 
 tags "modules" {
-    start_server [list overrides [list loadmodule "$testmodule"]] {
+    start_server {} {
+        r module load $testmodule with_key_events
         r module load $testmodule2
         test {Test write on post notification callback} {
             set repl [attach_to_replication_stream]
@@ -201,7 +203,7 @@ tags "modules" {
                 {exec}
                 {multi}
                 {set string_x 2}
-                {incr before_overwritten}
+                {lpush before_overwritten string_x}
                 {incr string_changed{string_x}}
                 {incr string_total}
                 {exec}

--- a/tests/unit/moduleapi/postnotifications.tcl
+++ b/tests/unit/moduleapi/postnotifications.tcl
@@ -9,7 +9,7 @@ tags "modules" {
             r set string_x 1
             assert_equal {1} [r get string_changed{string_x}]
             assert_equal {1} [r get string_total]
-            
+
             r set string_x 2
             assert_equal {2} [r get string_changed{string_x}]
             assert_equal {2} [r get string_total]
@@ -23,6 +23,7 @@ tags "modules" {
                 {exec}
                 {multi}
                 {set string_x 2}
+                {incr before_overwritten}
                 {incr string_changed{string_x}}
                 {incr string_total}
                 {exec}
@@ -37,7 +38,7 @@ tags "modules" {
             assert_equal {OK} [r postnotification.async_set]
             assert_equal {1} [r get string_changed{string_x}]
             assert_equal {1} [r get string_total]
-            
+
             assert_replication_stream $repl {
                 {multi}
                 {select *}
@@ -69,6 +70,7 @@ tags "modules" {
                 {pexpireat x *}
                 {multi}
                 {del x}
+                {incr before_expired}
                 {incr expired}
                 {exec}
             }
@@ -91,6 +93,7 @@ tags "modules" {
                 {pexpireat x *}
                 {multi}
                 {del x}
+                {incr before_expired}
                 {incr expired}
                 {exec}
             }
@@ -115,6 +118,7 @@ tags "modules" {
                 {multi}
                 {set read_x 1}
                 {del x}
+                {incr before_expired}
                 {incr expired}
                 {exec}
             }
@@ -143,7 +147,7 @@ tags "modules" {
             r flushall
             set repl [attach_to_replication_stream]
             r set x 1
-            r config set maxmemory-policy allkeys-random 
+            r config set maxmemory-policy allkeys-random
             r config set maxmemory 1
 
             assert_error {OOM *} {r set y 1}
@@ -153,6 +157,7 @@ tags "modules" {
                 {set x 1}
                 {multi}
                 {del x}
+                {incr before_evicted}
                 {incr evicted}
                 {exec}
             }
@@ -172,7 +177,7 @@ tags "modules" {
             r set string_x 1
             assert_equal {1} [r get string_changed{string_x}]
             assert_equal {1} [r get string_total]
-            
+
             r set string_x 2
             assert_equal {2} [r get string_changed{string_x}]
             assert_equal {2} [r get string_total]
@@ -190,6 +195,7 @@ tags "modules" {
                 {exec}
                 {multi}
                 {set string_x 2}
+                {incr before_overwritten}
                 {incr string_changed{string_x}}
                 {incr string_total}
                 {exec}


### PR DESCRIPTION
Redis 7.2 (#9406) introduced a new modules event, `RedisModuleEvent_Key`. This new event allows the module to read the key data just before it is removed from the database (either deleted, expired, evicted, or overwritten).

When the key is removed from the database, either by active expire or eviction. The new event was not called as part of an execution unit. This can cause an issue if the module registers a post notification job inside the event. This job will not be executed atomically with the expiration/eviction operation and will not replicated inside a Multi/Exec. Moreover, the post notification job will be executed right after the event where it is still not safe to perform any write operation, this will violate the promise that post notification job will be called atomically with the operation that triggered it and **only when it is safe to write**.

This PR fixes the issue by wrapping each expiration/eviction of a key with an execution unit. This makes sure the entire operation will run atomically and all the post notification jobs will be executed at the end where it is safe to write.

Tests were modified to verify the fix.