### PR TITLE
Optimize the efficiency of active expiration when databases exceeds 16.

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -172,6 +172,7 @@ void activeExpireCycle(int type) {
 
     int j, iteration = 0;
     int dbs_per_call = CRON_DBS_PER_CALL;
+    int dbs_performed = 0;
     long long start = ustime(), timelimit, elapsed;
 
     /* If 'expire' action is paused, for whatever reason, then don't expire any key.
@@ -224,7 +225,12 @@ void activeExpireCycle(int type) {
     /* Try to smoke-out bugs (server.also_propagate should be empty here) */
     serverAssert(server.also_propagate.numops == 0);
 
-    for (j = 0; j < dbs_per_call && timelimit_exit == 0; j++) {
+    /* Stop iteration when one of the following conditions is met:
+     *
+     * 1) We have checked a sufficient number of databases with expiration time.
+     * 2) The time limit has been exceeded.
+     * 3) All databases have been traversed. */
+    for (j = 0; dbs_performed < dbs_per_call && timelimit_exit == 0 && j < server.dbnum; j++) {
         /* Scan callback data including expired and checked count per iteration. */
         expireScanData data;
 
@@ -235,6 +241,8 @@ void activeExpireCycle(int type) {
          * in the current DB we'll restart from the next. This allows to
          * distribute the time evenly across DBs. */
         current_db++;
+
+        if (dbSize(db, DB_EXPIRES)) dbs_performed++;
 
         /* Continue to expire if at the end of the cycle there are still
          * a big percentage of keys to expire, compared to the number of keys


### PR DESCRIPTION
We have received some user's feedback indicating that the efficiency of cleaning expired keys is relatively low when the databases exceeds 16.

The reason is that by default only 16 databases are scanned when attempting to clean expired keys (`CRON_DBS_PER_CALL` is 16). But users may set databases higher than 16, such as 256, but it does not necessarily mean that all 256 databases have expiration time set. If only one database has expiration time set, this database needs 16 `activeExpireCycle` rounds in order to be scanned once, and 15 of those rounds are meaningless.

Some possible solutions include:
1. Set `dbs_per_call` to `server.dbnum` to ensure that all databases are traversed in each scan. Alternatively, add a configuration to allow users to control the number of databases scanned per call.
2. Similar to `incrementallyRehash`, prioritize databases with more expired keys and continue scanning them instead of switching to other databases.
3. Use `dbs_per_call` to control the number of databases with expired keys being scanned. Additionally, add a condition to limit the maximum number of rounds to `server.dbnum` to prevent excessive spinning. This ensures that even if only one database has expired keys, it can be triggered within a single cron job.

Currently in this PR, I just implemented method 3. However, other suggestions, including the first two methods or even more, can be discussed too.