### PR TITLE
reset bucket_count when empty db

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -664,6 +664,7 @@ long long emptyDbStructure(redisDb *dbarray, int dbnum, int async,
             dbarray[j].sub_dict[subdict].key_count = 0;
             dbarray[j].sub_dict[subdict].resize_cursor = 0;
             if (server.cluster_enabled) {
+                dbarray[j].sub_dict[subdict].bucket_count = 0;
                 unsigned long long *slot_size_index = dbarray[j].sub_dict[subdict].slot_size_index;
                 memset(slot_size_index, 0, sizeof(unsigned long long) * (CLUSTER_SLOTS + 1));
             }


### PR DESCRIPTION
Introduced in #12697 , should reset `bucket_count` when empty db, or the overhead memory usage of db can be miscalculated.