### PR TITLE
Increase timeout for expiry cluster tests

### DIFF
--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -888,9 +888,11 @@ start_cluster 1 0 {tags {"expire external:skip cluster slow"}} {
         r psetex "{foo}0" 500 a
 
         # Verify all keys have expired
-        wait_for_condition 200 100 {
+        wait_for_condition 400 100 {
             [r dbsize] eq 0
         } else {
+            puts [r dbsize]
+            flush stdout
             fail "Keys did not actively expire."
         }
     } {} {needs:debug}


### PR DESCRIPTION
Test failure: https://github.com/redis/redis/actions/runs/6805492700/job/18505125252

Locally with valgrind the test finishes within 1.5 sec(s). Couldn't find any issue due to lack of reproducibility. Increasing the timeout and adding an additional log to the test to understand how many keys were left at the end.