### PR TITLE
Optimize KEYS when pattern includes hashtag and implies a single slot.

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -997,7 +997,7 @@ void keysCommand(client *c) {
     int plen = sdslen(pattern), allkeys, pslot = -1;
     long numkeys = 0;
     void *replylen = addReplyDeferredLen(c);
-    allkeys = pattern[0] == '*' && plen == 1;
+    allkeys = (pattern[0] == '*' && plen == 1);
     if (!allkeys) {
         pslot = patternHashSlot(pattern, plen);
     }

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -38,8 +38,8 @@ start_server {tags {"keyspace"}} {
         foreach key {"{a}x" "{a}y" "{a}z" "{b}a" "{b}b" "{b}c"} {
             r set $key hello
         }
-        assert_equal [lsort [r keys "{a}*"]] {{{a}x} {{a}y} {{a}z}}
-        assert_equal [lsort [r keys "*{b}*"]] {{{b}a} {{b}b} {{b}c}}
+        assert_equal [lsort [r keys "{a}*"]] [list "{a}x" "{a}y" "{a}z"]
+        assert_equal [lsort [r keys "*{b}*"]] [list "{b}a" "{b}b" "{b}c"]
     } 
 
     test {DEL all keys} {

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -34,6 +34,14 @@ start_server {tags {"keyspace"}} {
         r dbsize
     } {6}
 
+    test {KEYS with hashtag} {
+        foreach key {"{a}x" "{a}y" "{a}z" "{b}a" "{b}b" "{b}c"} {
+            r set $key hello
+        }
+        assert_equal [lsort [r keys "{a}*"]] {{{a}x} {{a}y} {{a}z}}
+        assert_equal [lsort [r keys "*{b}*"]] {{{b}a} {{b}b} {{b}c}}
+    } 
+
     test {DEL all keys} {
         foreach key [r keys *] {r del $key}
         r dbsize


### PR DESCRIPTION
in #12536 we made a similar optimization for SCAN, now that hashtags in patterns. When we can make sure all keys matching the pettern will be in the same slot, we can limit the iteration to run only one one.