### PR TITLE
Fix DB iterator not resetting pauserehash causing dict being unable to rehash

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -2328,12 +2328,12 @@ int rewriteAppendOnlyFileRio(rio *aof) {
             if (server.rdb_key_save_delay)
                 debugDelay(server.rdb_key_save_delay);
         }
-        zfree(dbit);
+        dbReleaseIterator(dbit);
     }
     return C_OK;
 
 werr:
-    if (dbit) zfree(dbit);
+    if (dbit) dbReleaseIterator(dbit);
     return C_ERR;
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -315,7 +315,7 @@ void computeDatasetDigest(unsigned char *final) {
             xorDigest(final,digest,20);
             decrRefCount(keyobj);
         }
-        zfree(dbit);
+        dbReleaseIterator(dbit);
     }
 }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1368,11 +1368,11 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter) {
             }
         }
     }
-    zfree(dbit);
+    dbReleaseIterator(dbit);
     return written;
 
 werr:
-    if (dbit) zfree(dbit);
+    if (dbit) dbReleaseIterator(dbit);
     return -1;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -654,7 +654,7 @@ void tryResizeHashTables(int dbid) {
         }
         /* Save current iterator position in the resize_cursor. */
         db->sub_dict[subdict].resize_cursor = slot;
-        zfree(dbit);
+        dbReleaseIterator(dbit);
     }
 }
 
@@ -1510,7 +1510,6 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     /* Just for the sake of defensive programming, to avoid forgetting to
      * call this function when needed. */
     updateDictResizePolicy();
-
 
     /* AOF postponed flush: Try at every cron cycle if the slow fsync
      * completed. */

--- a/src/server.h
+++ b/src/server.h
@@ -997,7 +997,7 @@ typedef struct redisDb {
     long long avg_ttl;          /* Average TTL, just for stats */
     unsigned long expires_cursor; /* Cursor of the active expire cycle. */
     list *defrag_later;         /* List of key names to attempt to defrag one by one, gradually. */
-    int dict_count;             /* Indicates total number of dictionaires owned by this DB, 1 dict per slot in cluster mode. */
+    int dict_count;             /* Indicates total number of dictionaries owned by this DB, 1 dict per slot in cluster mode. */
     dbDictState sub_dict[2];  /* Metadata for main and expires dictionaries */
 } redisDb;
 
@@ -2436,6 +2436,7 @@ typedef struct dbIterator dbIterator;
 /* DB iterator specific functions */
 dbIterator *dbIteratorInit(redisDb *db, dbKeyType keyType);
 dbIterator *dbIteratorInitFromSlot(redisDb *db, dbKeyType keyType, int slot);
+void dbReleaseIterator(dbIterator *dbit);
 dict *dbIteratorNextDict(dbIterator *dbit);
 dict *dbGetDictFromIterator(dbIterator *dbit);
 int dbIteratorGetCurrentSlot(dbIterator *dbit);

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -840,7 +840,7 @@ start_cluster 1 0 {tags {"expire external:skip cluster slow"}} {
 
         # Collect two slots to help determine the expiry scan logic is able
         # to go past certain slots which aren't valid for scanning at the given point of time.
-        # And the next non empyt slot after that still gets scanned and expiration happens.
+        # And the next non empty slot after that still gets scanned and expiration happens.
 
         # hashslot(alice) is 749
         r psetex alice 500 val
@@ -861,6 +861,9 @@ start_cluster 1 0 {tags {"expire external:skip cluster slow"}} {
         for {set j 1} {$j <= 99} {incr j} {
             r del "{foo}$j"
         }
+
+        # Trigger a full traversal of all dictionaries.
+        r keys *
 
         r debug set-active-expire 1
 


### PR DESCRIPTION
When using DB iterator, it will use dictInitSafeIterator to init a old safe
dict iterator. When dbIteratorNext is used, it will jump to the next slot db
dict when we are done a dict. During this process, we do not have any calls to
dictResumeRehashing, which causes the dict's pauserehash to always be > 0.

And at last, it will be returned directly in dictRehashMilliseconds, which causes
us to have slot dict in a state where rehash cannot be completed.

In the "expire scan should skip dictionaries with lot's of empty buckets" test,
adding a `keys *` can reproduce the problem stably. `keys *` will call dbIteratorNext
to trigger a traversal of all slot dicts.

Added dbReleaseIterator function to call dictResetIterator.
Issue was introduced in #11695.