### PR TITLE
Remove dead code around should_expand_db

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2204,11 +2204,11 @@ int dbExpand(const redisDb *db, uint64_t db_size, dbKeyType keyType, int try_exp
                 }
                 int result = try_expand ? dictTryExpand(d, db_size) : dictExpand(d, db_size);
                 if (try_expand && result == DICT_ERR) {
-                    serverLog(LL_WARNING, "Dict expansion failed for type :%s slot: %d",
+                    serverLog(LL_WARNING, "Dict expansion failed for db type: %s, slot: %d",
                                 keyType == DB_MAIN ? "main" : "expires", i);
                     return C_ERR;
                 } else if (result == DICT_ERR) {
-                    serverLog(LL_DEBUG, "Dict expansion skipped for type :%s slot: %d",
+                    serverLog(LL_DEBUG, "Dict expansion skipped for db type: %s, slot: %d",
                                 keyType == DB_MAIN ? "main" : "expires", i);
                 }
             }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3263,14 +3263,8 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
         /* If there is no slot info, it means that it's either not cluster mode or we are trying to load legacy RDB file.
          * In this case we want to estimate number of keys per slot and resize accordingly. */
         if (should_expand_db) {
-            if (dbExpand(db, db_size, DB_MAIN, 1) == C_ERR) {
-                serverLog(LL_WARNING, "OOM in dict expand of main dict");
-                return C_ERR;
-            }
-            if (dbExpand(db, expires_size, DB_EXPIRES, 1) == C_ERR) {
-                serverLog(LL_WARNING, "OOM in dict expand of expire dict");
-                return C_ERR;
-            }
+            dbExpand(db, db_size, DB_MAIN, 0);
+            dbExpand(db, expires_size, DB_EXPIRES, 0);
             should_expand_db = 0;
         }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3263,11 +3263,11 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
         /* If there is no slot info, it means that it's either not cluster mode or we are trying to load legacy RDB file.
          * In this case we want to estimate number of keys per slot and resize accordingly. */
         if (should_expand_db) {
-            if (dbExpand(db, db_size, DB_MAIN, 0) == C_ERR) {
+            if (dbExpand(db, db_size, DB_MAIN, 1) == C_ERR) {
                 serverLog(LL_WARNING, "OOM in dict expand of main dict");
                 return C_ERR;
             }
-            if (dbExpand(db, expires_size, DB_EXPIRES, 0) == C_ERR) {
+            if (dbExpand(db, expires_size, DB_EXPIRES, 1) == C_ERR) {
                 serverLog(LL_WARNING, "OOM in dict expand of expire dict");
                 return C_ERR;
             }


### PR DESCRIPTION
when dbExpand is called from rdb.c with try_expand set to 0, it will either panic panic on OOM, or be non-fatal (should not fail RDB loading)

At the same time, the log text has been slightly adjusted to make it more unified.