### PR TITLE
 Adding missing SWAPDB related test cases.

### DIFF
--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -159,6 +159,45 @@ start_server {tags {"introspection"}} {
         $rd close
     }
 
+    test {Coverage: basic SWAPDB test and unhappy path} {
+       r del swapkey
+       r select 0
+       r set swapkey v1
+       r select 1
+       assert_match 0 [r dbsize] ;#verify DB[1] has 0 keys
+       r swapdb 0 1
+       assert_match 1 [r dbsize]
+       r select 0
+       assert_match 0 [r dbsize] ;#verify DB[0] has 0 keys
+       r flushall
+       assert_error "ERR DB index is out of range*" {r swapdb 44 55}
+       assert_error "ERR invalid second DB index*" {r swapdb 44 a}
+       assert_error "ERR invalid first DB index*" {r swapdb a 55}
+       assert_error "ERR invalid first DB index*" {r swapdb a b}
+       assert_match "OK" [r swapdb 0 0]
+    }
+
+    test {Coverage: SWAPDB and FLUSHDB} {
+       # set a key in each db and swapdb one of 2 with different db
+       # and flushdb on swapped db.
+       r del swapkey
+       r select 0
+       r set swapkey v1
+       r select 1
+       r set swapkey1 v1
+       assert_no_match "*db2:keys=*" [r info keyspace]
+       r swapdb 0 2
+       r select 0
+       assert_match 0 [r dbsize]
+       assert_no_match "*db0:keys=*" [r info keyspace]
+       r select 2
+       r flushdb
+       assert_match 0 [r dbsize]
+       assert_no_match "*db0:keys=*" [r info keyspace]
+       assert_no_match "*db2:keys=*" [r info keyspace]
+       r flushall
+    }
+
     test {MONITOR can log executed commands} {
         set rd [redis_deferring_client]
         $rd monitor

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -160,6 +160,7 @@ start_server {tags {"introspection"}} {
     }
 
     test {Coverage: basic SWAPDB test and unhappy path} {
+       r flushall
        r del swapkey
        r select 0
        r set swapkey v1
@@ -193,6 +194,7 @@ start_server {tags {"introspection"}} {
        r select 2
        r flushdb
        assert_match 0 [r dbsize]
+       assert_match "*db1:keys=*" [r info keyspace]
        assert_no_match "*db0:keys=*" [r info keyspace]
        assert_no_match "*db2:keys=*" [r info keyspace]
        r flushall

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -159,46 +159,6 @@ start_server {tags {"introspection"}} {
         $rd close
     }
 
-    test {Coverage: basic SWAPDB test and unhappy path} {
-       r flushall
-       r select 0
-       r set swapkey v1
-       r select 1
-       assert_match 0 [r dbsize] ;#verify DB[1] has 0 keys
-       r swapdb 0 1
-       assert_match 1 [r dbsize]
-       r select 0
-       assert_match 0 [r dbsize] ;#verify DB[0] has 0 keys
-       r flushall
-       assert_error "ERR DB index is out of range*" {r swapdb 44 55}
-       assert_error "ERR invalid second DB index*" {r swapdb 44 a}
-       assert_error "ERR invalid first DB index*" {r swapdb a 55}
-       assert_error "ERR invalid first DB index*" {r swapdb a b}
-       assert_match "OK" [r swapdb 0 0]
-    } {} {singledb:skip}
-
-    test {Coverage: SWAPDB and FLUSHDB} {
-       # set a key in each db and swapdb one of 2 with different db
-       # and flushdb on swapped db.
-       r flushall
-       r select 0
-       r set swapkey v1
-       r select 1
-       r set swapkey1 v1
-       assert_no_match "*db2:keys=*" [r info keyspace]
-       r swapdb 0 2
-       r select 0
-       assert_match 0 [r dbsize]
-       assert_no_match "*db0:keys=*" [r info keyspace]
-       r select 2
-       r flushdb
-       assert_match 0 [r dbsize]
-       assert_match "*db1:keys=*" [r info keyspace]
-       assert_no_match "*db0:keys=*" [r info keyspace]
-       assert_no_match "*db2:keys=*" [r info keyspace]
-       r flushall
-    } {OK} {singledb:skip}
-
     test {MONITOR can log executed commands} {
         set rd [redis_deferring_client]
         $rd monitor

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -175,7 +175,7 @@ start_server {tags {"introspection"}} {
        assert_error "ERR invalid first DB index*" {r swapdb a 55}
        assert_error "ERR invalid first DB index*" {r swapdb a b}
        assert_match "OK" [r swapdb 0 0]
-    }
+    } {} {singledb:skip}
 
     test {Coverage: SWAPDB and FLUSHDB} {
        # set a key in each db and swapdb one of 2 with different db
@@ -196,7 +196,7 @@ start_server {tags {"introspection"}} {
        assert_no_match "*db0:keys=*" [r info keyspace]
        assert_no_match "*db2:keys=*" [r info keyspace]
        r flushall
-    }
+    } {OK} {singledb:skip}
 
     test {MONITOR can log executed commands} {
         set rd [redis_deferring_client]

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -161,7 +161,6 @@ start_server {tags {"introspection"}} {
 
     test {Coverage: basic SWAPDB test and unhappy path} {
        r flushall
-       r del swapkey
        r select 0
        r set swapkey v1
        r select 1
@@ -181,7 +180,7 @@ start_server {tags {"introspection"}} {
     test {Coverage: SWAPDB and FLUSHDB} {
        # set a key in each db and swapdb one of 2 with different db
        # and flushdb on swapped db.
-       r del swapkey
+       r flushall
        r select 0
        r set swapkey v1
        r select 1


### PR DESCRIPTION
We have some test cases of swapdb with watchkey but missing seperate basic swapdb test cases, unhappy path and flushdb after swapdb. So added the test cases in keyspace.tcl.  