### PR TITLE
Fix empty rehashing list in swapdb mode

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -684,7 +684,8 @@ long long emptyDbStructure(redisDb *dbarray, int dbnum, int async,
             dbarray[j].sub_dict[subdict].key_count = 0;
             dbarray[j].sub_dict[subdict].resize_cursor = 0;
             if (server.cluster_enabled) {
-                listEmpty(dbarray[j].sub_dict[subdict].rehashing);
+                if (dbarray[j].sub_dict[subdict].rehashing)
+                    listEmpty(dbarray[j].sub_dict[subdict].rehashing);
                 dbarray[j].sub_dict[subdict].bucket_count = 0;
                 unsigned long long *slot_size_index = dbarray[j].sub_dict[subdict].slot_size_index;
                 memset(slot_size_index, 0, sizeof(unsigned long long) * (CLUSTER_SLOTS + 1));


### PR DESCRIPTION
In swapdb mode, the temp db does not init the rehashing list,
the change added in #12764 caused cluster ci to fail.