### PR TITLE
Fix timing issue in CLUSTER SLAVE / REPLICAS consistent test

### DIFF
--- a/tests/cluster/tests/05-slave-selection.tcl
+++ b/tests/cluster/tests/05-slave-selection.tcl
@@ -25,8 +25,11 @@ test "The first master has actually two slaves" {
 test "CLUSTER SLAVES and CLUSTER REPLICAS output is consistent" {
     # Because we already have command output that cover CLUSTER REPLICAS elsewhere,
     # here we simply judge whether their output is consistent to cover CLUSTER SLAVES.
-    set res [R 0 cluster slaves [R 0 CLUSTER MYID]]
-    set res2 [R 0 cluster replicas [R 0 CLUSTER MYID]]
+    set myid [R 0 CLUSTER MYID]
+    R 0 multi
+    R 0 cluster slaves $myid
+    R 0 cluster replicas $myid
+    lassign [R 0 exec] res res2
     assert_equal $res $res2
 }
 


### PR DESCRIPTION
CI reports that this test failed, the reason is because during
the command processing, the node processed PING/PONG, resulting
in ping_sent or pong_received mismatch.

Change to use MULTI to avoid timing issue. The test was introduced
in #12224.