### PR TITLE
Make the sampling logic in eviction clearer

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -598,18 +598,18 @@ int performEvictions(void) {
                  * every DB. */
                 for (i = 0; i < server.dbnum; i++) {
                     db = server.db+i;
-                    if ((keys = dbSize(db, keyType)) != 0) {
-                        total_keys += keys;
-                        unsigned long sampled_keys = 0;
-                        do {
-                            int slot = getFairRandomSlot(db, keyType);
-                            dict = (keyType == DB_MAIN ? db->dict[slot] : db->expires[slot]);
-                            if (dictSize(dict) != 0) {
-                                sampled_keys += evictionPoolPopulate(i, slot, dict, db->dict[slot], pool);
-                            }
-                        } while (keys > (unsigned long) server.maxmemory_samples*10 &&
-                                 sampled_keys < (unsigned long) server.maxmemory_samples);
-                    }
+                    if ((keys = dbSize(db, keyType)) == 0) continue;
+
+                    total_keys += keys;
+                    unsigned long sampled_keys = 0;
+                    do {
+                        int slot = getFairRandomSlot(db, keyType);
+                        dict = (keyType == DB_MAIN ? db->dict[slot] : db->expires[slot]);
+                        if (dictSize(dict) != 0) {
+                            sampled_keys += evictionPoolPopulate(i, slot, dict, db->dict[slot], pool);
+                        }
+                    } while (keys > (unsigned long) server.maxmemory_samples*10 &&
+                             sampled_keys < (unsigned long) server.maxmemory_samples);
                 }
                 if (!total_keys) break; /* No keys to evict. */
 

--- a/src/evict.c
+++ b/src/evict.c
@@ -575,7 +575,7 @@ int performEvictions(void) {
     /* Evictions are performed on random keys that have nothing to do with the current command slot. */
 
     while (mem_freed < (long long)mem_tofree) {
-        int j, k, i, l;
+        int j, k, i;
         static unsigned int next_db = 0;
         sds bestkey = NULL;
         int bestdbid;
@@ -603,7 +603,9 @@ int performEvictions(void) {
                     if (current_db_keys == 0) continue;
 
                     total_keys += current_db_keys;
-                    for (l = 0; l < dbNonEmptySlots(db, keyType); l++) {
+                    int l = dbNonEmptySlots(db, keyType);
+                    /* Do not exceed the number of non-empty slots when looping. */
+                    while (l--) {
                         int slot = getFairRandomSlot(db, keyType);
                         dict = (keyType == DB_MAIN ? db->dict[slot] : db->expires[slot]);
                         sampled_keys += evictionPoolPopulate(i, slot, dict, db->dict[slot], pool);

--- a/src/evict.c
+++ b/src/evict.c
@@ -143,8 +143,7 @@ void evictionPoolAlloc(void) {
  * We insert keys on place in ascending order, so keys with the smaller
  * idle time are on the left, and keys with the higher idle time on the
  * right. */
-
-void evictionPoolPopulate(int dbid, int slot, dict *sampledict, redisDb *db, struct evictionPoolEntry *pool) {
+int evictionPoolPopulate(int dbid, int slot, dict *sampledict, dict *keydict, struct evictionPoolEntry *pool) {
     int j, k, count;
     dictEntry *samples[server.maxmemory_samples];
 
@@ -162,7 +161,7 @@ void evictionPoolPopulate(int dbid, int slot, dict *sampledict, redisDb *db, str
          * dictionary (but the expires one) we need to lookup the key
          * again in the key dictionary to obtain the value object. */
         if (server.maxmemory_policy != MAXMEMORY_VOLATILE_TTL) {
-            if (!(server.maxmemory_policy & MAXMEMORY_FLAG_ALLKEYS)) de = dictFind(db->dict[slot], key);
+            if (sampledict != keydict) de = dictFind(keydict, key);
             o = dictGetVal(de);
         }
 
@@ -240,6 +239,8 @@ void evictionPoolPopulate(int dbid, int slot, dict *sampledict, redisDb *db, str
         pool[k].dbid = dbid;
         pool[k].slot = slot;
     }
+
+    return count;
 }
 
 /* ----------------------------------------------------------------------------
@@ -586,6 +587,8 @@ int performEvictions(void) {
             server.maxmemory_policy == MAXMEMORY_VOLATILE_TTL)
         {
             struct evictionPoolEntry *pool = EvictionPoolLRU;
+            dbKeyType keyType = (server.maxmemory_policy & MAXMEMORY_FLAG_ALLKEYS ?
+                                 DB_MAIN : DB_EXPIRES);
 
             while (bestkey == NULL) {
                 unsigned long total_keys = 0, keys;
@@ -595,24 +598,18 @@ int performEvictions(void) {
                  * every DB. */
                 for (i = 0; i < server.dbnum; i++) {
                     db = server.db+i;
-                    do {
-                        int slot = 0;
-                        if (server.maxmemory_policy & MAXMEMORY_FLAG_ALLKEYS) {
-                            slot = getFairRandomSlot(db, DB_MAIN);
-                            dict = db->dict[slot];
-                        } else {
-                            slot = getFairRandomSlot(db, DB_EXPIRES);
-                            dict = db->expires[slot];
-                        }
-                        if ((keys = dictSize(dict)) != 0) {
-                            evictionPoolPopulate(i, slot, dict, db, pool);
-                            total_keys += keys;
-                        }
-                    /* Since keys are distributed across smaller slot-specific dictionaries in cluster mode, we may need to
-                     * visit more than one dictionary in order to populate required number of samples into eviction pool. */
-                    } while (server.cluster_enabled && keys != 0 && server.maxmemory_policy & MAXMEMORY_FLAG_ALLKEYS &&
-                        total_keys < (unsigned long) server.maxmemory_samples
-                    );
+                    if ((keys = dbSize(db, keyType)) != 0) {
+                        total_keys += keys;
+                        unsigned long sampled_keys = 0;
+                        do {
+                            int slot = getFairRandomSlot(db, keyType);
+                            dict = (keyType == DB_MAIN ? db->dict[slot] : db->expires[slot]);
+                            if (dictSize(dict) != 0) {
+                                sampled_keys += evictionPoolPopulate(i, slot, dict, db->dict[slot], pool);
+                            }
+                        } while (keys > (unsigned long) server.maxmemory_samples*10 &&
+                                 sampled_keys < (unsigned long) server.maxmemory_samples);
+                    }
                 }
                 if (!total_keys) break; /* No keys to evict. */
 

--- a/src/evict.c
+++ b/src/evict.c
@@ -591,16 +591,16 @@ int performEvictions(void) {
                                  DB_MAIN : DB_EXPIRES);
 
             while (bestkey == NULL) {
-                unsigned long total_keys = 0, keys;
+                unsigned long total_keys = 0, current_db_keys;
 
                 /* We don't want to make local-db choices when expiring keys,
                  * so to start populate the eviction pool sampling keys from
                  * every DB. */
                 for (i = 0; i < server.dbnum; i++) {
                     db = server.db+i;
-                    if ((keys = dbSize(db, keyType)) == 0) continue;
+                    if ((current_db_keys = dbSize(db, keyType)) == 0) continue;
 
-                    total_keys += keys;
+                    total_keys += current_db_keys;
                     unsigned long sampled_keys = 0;
                     do {
                         int slot = getFairRandomSlot(db, keyType);
@@ -614,7 +614,7 @@ int performEvictions(void) {
                      *
                      * To avoid the situation where the number of keys in a single slot
                      * in cluster mode is too low to meet the sampling requirements. */
-                    } while (keys > (unsigned long) server.maxmemory_samples*10 &&
+                    } while (current_db_keys > (unsigned long) server.maxmemory_samples*10 &&
                              sampled_keys < (unsigned long) server.maxmemory_samples);
                 }
                 if (!total_keys) break; /* No keys to evict. */

--- a/src/evict.c
+++ b/src/evict.c
@@ -608,6 +608,9 @@ int performEvictions(void) {
                         if (dictSize(dict) != 0) {
                             sampled_keys += evictionPoolPopulate(i, slot, dict, db->dict[slot], pool);
                         }
+                    /* If there are a sufficient number of keys in the current database
+                     * (e.g., 10 times the value of maxmemory_samples), it is necessary
+                     * to ensure that enough keys are sampled. */
                     } while (keys > (unsigned long) server.maxmemory_samples*10 &&
                              sampled_keys < (unsigned long) server.maxmemory_samples);
                 }

--- a/src/evict.c
+++ b/src/evict.c
@@ -610,7 +610,10 @@ int performEvictions(void) {
                         }
                     /* If there are a sufficient number of keys in the current database
                      * (e.g., 10 times the value of maxmemory_samples), it is necessary
-                     * to ensure that enough keys are sampled. */
+                     * to ensure that enough keys are sampled.
+                     *
+                     * To avoid the situation where the number of keys in a single slot
+                     * in cluster mode is too low to meet the sampling requirements. */
                     } while (keys > (unsigned long) server.maxmemory_samples*10 &&
                              sampled_keys < (unsigned long) server.maxmemory_samples);
                 }

--- a/src/evict.c
+++ b/src/evict.c
@@ -610,8 +610,8 @@ int performEvictions(void) {
                         /* If there are not a lot of keys in the current db, dict/s may be very
                          * sparsely populated, exit the loop without meeting the sampling
                          * requirement. */
-                         if (current_db_keys < (unsigned long) server.maxmemory_samples*10)
-                             break;
+                        if (current_db_keys < (unsigned long) server.maxmemory_samples*10)
+                            break;
                     } while (sampled_keys < (unsigned long) server.maxmemory_samples);
                 }
                 if (!total_keys) break; /* No keys to evict. */

--- a/src/server.c
+++ b/src/server.c
@@ -2636,6 +2636,7 @@ void makeThreadKillable(void) {
 void initDbState(redisDb *db){
     for (dbKeyType subdict = DB_MAIN; subdict <= DB_EXPIRES; subdict++) {
         db->sub_dict[subdict].rehashing = listCreate();
+        db->sub_dict[subdict].non_empty_slots = 0;
         db->sub_dict[subdict].key_count = 0;
         db->sub_dict[subdict].resize_cursor = 0;
         db->sub_dict[subdict].slot_size_index = server.cluster_enabled ? zcalloc(sizeof(unsigned long long) * (CLUSTER_SLOTS + 1)) : NULL;

--- a/src/server.h
+++ b/src/server.h
@@ -971,6 +971,7 @@ typedef struct replBufBlock {
 typedef struct dbDictState {
     list *rehashing;                       /* List of dictionaries in this DB that are currently rehashing. */
     int resize_cursor;                     /* Cron job uses this cursor to gradually resize dictionaries (only used for cluster-enabled). */
+    int non_empty_slots;                   /* The number of non-empty slots. */
     unsigned long long key_count;          /* Total number of keys in this DB. */
     unsigned long long bucket_count;       /* Total number of buckets in this DB across dictionaries (only used for cluster-enabled). */
     unsigned long long *slot_size_index;   /* Binary indexed tree (BIT) that describes cumulative key frequencies up until given slot. */
@@ -3124,6 +3125,7 @@ void dismissMemoryInChild(void);
 #define RESTART_SERVER_CONFIG_REWRITE (1<<1) /* CONFIG REWRITE before restart.*/
 int restartServer(int flags, mstime_t delay);
 unsigned long long int dbSize(redisDb *db, dbKeyType keyType);
+int dbNonEmptySlots(redisDb *db, dbKeyType keyType);
 int getKeySlot(sds key);
 int calculateKeySlot(sds key);
 unsigned long dbBuckets(redisDb *db, dbKeyType keyType);


### PR DESCRIPTION
Additional optimizations for the eviction logic in #11695:

To make the eviction logic clearer and decouple the number of sampled keys from the running mode (cluster or standalone).
* When sampling in each database, we only care about the number of keys in the current database (not the dicts we sampled from).
* If there are a insufficient number of keys in the current database (e.g. 10 times the value of `maxmemory_samples`), we can break out sooner (to avoid looping on a sparse database).
* We'll never try to sample the db dicts more times than the number of non-empty dicts in the db (max 1 in non-cluster mode).

And it also ensures that each database has a sufficient amount of sampled keys, so even if unsharded-cluster supports multiple databases, there won't be any issues.

other changes:
1. keep track of the number of non-empty dicts in each database.
2. move key_count tracking into cumulativeKeyCountAdd rather than all it's callers