### PR TITLE
Implement TCP Keep-Alives across most Unix-like systems

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -147,12 +147,11 @@ int anetKeepAlive(char *err, int fd, int interval)
 
 /* There are platforms that are expected to support the full mechanism of TCP keep-alive,
  * we want the compiler to emit warnings of unused variables if the preprocessor directives 
- * somehow fail, and other than those platforms, the rest just omit them.
+ * somehow fail, and other than those platforms, just omit these warnings if they happen.
  */
 #if !(defined(_AIX) || defined(__APPLE__) || defined(__DragonFly__) || \
     defined(__FreeBSD__) || defined(__illumos__) || defined(__linux__) || \
     defined(__NetBSD__) || defined(__sun))
-    /* Prevent compiler from complaining unused variables warnings. */
     UNUSED(interval);
     UNUSED(idle);
     UNUSED(intvl);

--- a/src/anet.c
+++ b/src/anet.c
@@ -151,6 +151,14 @@ int anetKeepAlive(char *err, int fd, int interval)
         return ANET_ERR;
     }
 
+    /* If there is at least one option of TCP keep-alive is missing,
+     * we will just bail out from this process and just leave the default settings.
+     */
+#if (!defined(TCP_KEEPIDLE) && !defined(TCP_KEEPALIVE)) || !defined(TCP_KEEPINTVL) || !defined(TCP_KEEPCNT)
+    anetSetError(err, "anetKeepAlive: %s", "missing TCP keep-alive macros");
+    return;
+#endif
+
 /* The implementation of TCP keep-alive on Solaris/SmartOS is a bit unusual 
  * compared to other Unix-like systems. 
  * Thus, we need to specialize it on Solaris. */


### PR DESCRIPTION
## TCP Keep-Alives

[TCP Keep-Alives](https://datatracker.ietf.org/doc/html/rfc9293#name-tcp-keep-alives) provides a way to detect whether a TCP connection is alive or dead, which can be useful for reducing system resources by cleaning up dead connections.

There is full support of TCP Keep-Alives on Linux and partial support on macOS in `redis` at present.

This PR intends to complete the rest.

## Unix-like OS's support

`TCP_KEEPIDLE`, `TCP_KEEPINTVL`, and `TCP_KEEPCNT` are not included in the POSIX standard for `setsockopts`, while these three socket options are widely available on most Unix-like systems and Windows.

### References

- [AIX](https://www.ibm.com/support/pages/ibm-aix-tcp-keepalive-probes)
- [DragonflyBSD](https://man.dragonflybsd.org/?command=tcp&section=4)
- [FreeBSD](https://www.freebsd.org/cgi/man.cgi?query=tcp)
- [HP-UX](https://docstore.mik.ua/manuals/hp-ux/en/B2355-60130/TCP.7P.html)
- [illumos](https://illumos.org/man/4P/tcp)
- [Linux](https://man7.org/linux/man-pages/man7/tcp.7.html)
- [NetBSD](https://man.netbsd.org/NetBSD-8.0/tcp.4)
- [Windows](https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-tcp-socket-options)

### Mac OS

In earlier versions, macOS only supported setting `TCP_KEEPALIVE` (the equivalent of `TCP_KEEPIDLE` on other platforms), but since macOS 10.8 it has supported `TCP_KEEPINTVL` and `TCP_KEEPCNT`.

Check out [this mailing list](https://lists.apple.com/archives/macnetworkprog/2012/Jul/msg00005.html) and [the source code](https://github.com/apple/darwin-xnu/blob/main/bsd/netinet/tcp.h#L215-L230) for more details.

### Solaris

Solaris claimed it supported the TCP-Alives mechanism, but `TCP_KEEPIDLE`, `TCP_KEEPINTVL`, and `TCP_KEEPCNT` were not available on Solaris until the latest version 11.4. Therefore, we need to simulate the TCP-Alives mechanism on other platforms via `TCP_KEEPALIVE_THRESHOLD` + `TCP_KEEPALIVE_ABORT_THRESHOLD`.

- [Solaris 11.3](https://docs.oracle.com/cd/E86824_01/html/E54777/tcp-7p.html)
- [Solaris 11.4](https://docs.oracle.com/cd/E88353_01/html/E37851/tcp-4p.html)
