### PR TITLE
Remove overhead.hashtable.slot-to-keys from memory-stats reply_schema

### DIFF
--- a/src/commands/memory-stats.json
+++ b/src/commands/memory-stats.json
@@ -108,9 +108,6 @@
                         },
                         "overhead.hashtable.expires": {
                             "type": "integer"
-                        },
-                        "overhead.hashtable.slot-to-keys": {
-                            "type": "integer"
                         }
                     },
                     "additionalProperties": false

--- a/src/object.c
+++ b/src/object.c
@@ -1600,7 +1600,6 @@ NULL
             addReplyLongLong(c,mh->db[j].overhead_ht_expires);
         }
 
-
         addReplyBulkCString(c,"overhead.total");
         addReplyLongLong(c,mh->overhead_total);
 


### PR DESCRIPTION
overhead.hashtable.slot-to-keys was added in 7.0 in #10017, then removed
in #11695. Now remove it from reply_schema.