### PR TITLE
Block DEBUG POPULATE in loading and async-loading

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -716,6 +716,11 @@ NULL
         if (getPositiveLongFromObjectOrReply(c, c->argv[2], &keys, NULL) != C_OK)
             return;
 
+        if (server.loading || server.async_loading) {
+            addReplyErrorObject(c, shared.loadingerr);
+            return;
+        }
+
         if (dbExpand(c->db, keys, DB_MAIN, 1) == C_ERR) {
             addReplyError(c, "OOM in dictTryExpand");
             return;


### PR DESCRIPTION
When we are loading data, it is not safe to generate data
through DEBUG POPULATE. POPULATE may generate keys, causing
panic when loading data with duplicate keys.