### PR TITLE
redis-check-aof.c: Avoid leaking file handle if file is zero bytes

### DIFF
--- a/src/redis-check-aof.c
+++ b/src/redis-check-aof.c
@@ -238,6 +238,7 @@ int checkSingleAof(char *aof_filename, char *aof_filepath, int last_file, int fi
 
     off_t size = sb.st_size;
     if (size == 0) {
+        fclose(fp);
         return AOF_CHECK_EMPTY;
     }
 


### PR DESCRIPTION
If fopen() is successful, but redis_fstat() determines the file is zero bytes, the file handle stored in fp will leak. This change closes the filehandle stored in fp if the file is zero bytes.