### PR TITLE
Only rebuild server when src or deps are modified

### DIFF
--- a/src/mkreleasehdr.sh
+++ b/src/mkreleasehdr.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 GIT_SHA1=`(git show-ref --head --hash=8 2> /dev/null || echo 00000000) | head -n1`
-GIT_DIRTY=`git diff --no-ext-diff 2> /dev/null | wc -l`
+GIT_DIRTY=`git diff --no-ext-diff -- src deps 2> /dev/null | wc -l`
 BUILD_ID=`uname -n`"-"`date +%s`
 if [ -n "$SOURCE_DATE_EPOCH" ]; then
   BUILD_ID=$(date -u -d "@$SOURCE_DATE_EPOCH" +%s 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" +%s 2>/dev/null || date -u +%s)


### PR DESCRIPTION
I noticed while messing with tests that `make test` will sometimes unnecessary rebuild `redis-server` since release.h was updated because I made a change in tests. This scopes down when we re-generate release.h to only when actual source files are modified.