### PR TITLE
util.c: Don't leak directory handle if recursive call to dirRemove fails

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1061,6 +1061,7 @@ int dirRemove(char *dname) {
 
         if (S_ISDIR(stat_entry.st_mode) != 0) {
             if (dirRemove(full_path) == -1) {
+                closedir(dir);
                 return -1;
             }
             continue;


### PR DESCRIPTION
If a recursive call to dirRemove() returns -1, dirRemove() the directory handle stored in dir will leak. This change closes the directory handle stored in dir even if the recursive call to dirRemove() returns -1.

Fixed Coverity 371073