### PR TITLE
Ensure that the permission of the db file remains unchanged

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -2351,7 +2351,6 @@ int rewriteAppendOnlyFile(char *filename) {
     rio aof;
     FILE *fp = NULL;
     char tmpfile[256];
-    struct stat fileStat;
 
     /* Note that we have to use a different temp name here compared to the
      * one used by rewriteAppendOnlyFileBackground() function. */
@@ -2391,10 +2390,6 @@ int rewriteAppendOnlyFile(char *filename) {
     if (fclose(fp)) { fp = NULL; goto werr; }
     fp = NULL;
 
-    /*Ensure that the permission on the DB file remains unchanged.*/
-    if (stat(filename, &fileStat) == 0) {
-        chmod(tmpfile, fileStat.st_mode);
-    }
     /* Use RENAME to make sure the DB file is changed atomically only
      * if the generate DB file is ok. */
     if (rename(tmpfile,filename) == -1) {

--- a/src/aof.c
+++ b/src/aof.c
@@ -2351,6 +2351,7 @@ int rewriteAppendOnlyFile(char *filename) {
     rio aof;
     FILE *fp = NULL;
     char tmpfile[256];
+    struct stat fileStat;
 
     /* Note that we have to use a different temp name here compared to the
      * one used by rewriteAppendOnlyFileBackground() function. */
@@ -2390,6 +2391,10 @@ int rewriteAppendOnlyFile(char *filename) {
     if (fclose(fp)) { fp = NULL; goto werr; }
     fp = NULL;
 
+    /*Ensure that the permission on the DB file remains unchanged.*/
+    if (stat(filename, &fileStat) == 0) {
+        chmod(tmpfile, fileStat.st_mode);
+    }
     /* Use RENAME to make sure the DB file is changed atomically only
      * if the generate DB file is ok. */
     if (rename(tmpfile,filename) == -1) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1527,6 +1527,7 @@ int rdbSaveToFile(const char *filename) {
 int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags) {
     char tmpfile[256];
     char cwd[MAXPATHLEN]; /* Current working dir path for error messages. */
+    struct stat fileStat;
 
     startSaving(RDBFLAGS_NONE);
     snprintf(tmpfile,256,"temp-%d.rdb", (int) getpid());
@@ -1536,6 +1537,10 @@ int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags) {
         return C_ERR;
     }
     
+    /*Ensure that the permission on the DB file file remains unchanged.*/
+    if (stat(filename, &fileStat) == 0) {
+        chmod(tmpfile, fileStat.st_mode);
+    }
     /* Use RENAME to make sure the DB file is changed atomically only
      * if the generate DB file is ok. */
     if (rename(tmpfile,filename) == -1) {


### PR DESCRIPTION
changed the permission of the db file.  after `bgsave` , the permission on the rdb file is changed.
![image](https://github.com/redis/redis/assets/92571231/f64da158-70e0-46b2-b276-68bb2a57b31d)

this pr ensure that the permission of the db file remains unchanged before and after the change.
