### PR TITLE
Replace slots_to_channels radix tree with slot specific dictionaries for shard channels.

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1915,7 +1915,7 @@ void ACLKillPubsubClientsIfNeeded(user *new, user *original) {
     /* Do nothing if there are no subscribers. */
     if (!dictSize(server.pubsub_patterns) &&
         !dictSize(server.pubsub_channels) &&
-        !dictSize(server.pubsubshard_channels))
+        !server.shard_channel_count)
         return;
 
     listIter li, lpi;

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -48,8 +48,6 @@ void clusterUpdateMyselfHostname(void);
 void clusterUpdateMyselfAnnouncedPorts(void);
 void clusterUpdateMyselfHumanNodename(void);
 
-void slotToChannelAdd(sds channel);
-void slotToChannelDel(sds channel);
 void clusterPropagatePublish(robj *channel, robj *message, int sharded);
 
 unsigned long getClusterConnectionsCount(void);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5663,16 +5663,7 @@ sds genClusterInfoString(void) {
 void removeChannelsInSlot(unsigned int slot) {
     if (countChannelsInSlot(slot) == 0) return;
 
-    /* Unsubscribe all clients for each channel in the slot. */
-    dict *d = server.pubsubshard_channels[slot];
-    if (!d) return;
-    dictIterator *di = dictGetSafeIterator(d);
-    dictEntry *de;
-    while ((de = dictNext(di)) != NULL) {
-        robj *channel = dictGetKey(de);
-        pubsubShardUnsubscribeAllClients(slot, channel);
-    }
-    dictReleaseIterator(di);
+    pubsubShardUnsubscribeAllClientsInSlot(slot);
 }
 
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5661,24 +5661,18 @@ sds genClusterInfoString(void) {
 
 
 void removeChannelsInSlot(unsigned int slot) {
-    unsigned int channelcount = countChannelsInSlot(slot);
-    if (channelcount == 0) return;
+    if (countChannelsInSlot(slot) == 0) return;
 
-    /* Retrieve all the channels for the slot. */
-    robj **channels = zmalloc(sizeof(robj*)*channelcount);
-    int j = 0;
+    /* Unsubscribe all clients for each channel in the slot. */
     dict *d = server.pubsubshard_channels[slot];
     if (!d) return;
     dictIterator *di = dictGetSafeIterator(d);
     dictEntry *de;
     while ((de = dictNext(di)) != NULL) {
         robj *channel = dictGetKey(de);
-        channels[j++] = channel;
-        incrRefCount(channel);
+        pubsubShardUnsubscribeAllClients(slot, channel);
     }
     dictReleaseIterator(di);
-    pubsubUnsubscribeShardChannels(channels, channelcount);
-    zfree(channels);
 }
 
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5664,6 +5664,7 @@ void removeChannelsInSlot(unsigned int slot) {
     robj **channels = zmalloc(sizeof(robj*)*channelcount);
     int j = 0;
     dict *d = server.pubsubshard_channels[slot];
+    if (!d) return;
     dictIterator *di = dictGetSafeIterator(d);
     dictEntry *de;
     while ((de = dictNext(di)) != NULL) {
@@ -5708,7 +5709,8 @@ unsigned int delKeysInSlot(unsigned int hashslot) {
 
 /* Get the count of the channels for a given slot. */
 unsigned int countChannelsInSlot(unsigned int hashslot) {
-    return dictSize(server.pubsubshard_channels[hashslot]);
+    dict *d = server.pubsubshard_channels[hashslot];
+    return d ? dictSize(d) : 0;
 }
 
 int clusterNodeIsMyself(clusterNode *n) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5663,7 +5663,7 @@ sds genClusterInfoString(void) {
 void removeChannelsInSlot(unsigned int slot) {
     if (countChannelsInSlot(slot) == 0) return;
 
-    pubsubShardUnsubscribeAllClientsInSlot(slot);
+    pubsubShardUnsubscribeAllChannelsInSlot(slot);
 }
 
 

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -318,7 +318,6 @@ struct clusterState {
     clusterNode *migrating_slots_to[CLUSTER_SLOTS];
     clusterNode *importing_slots_from[CLUSTER_SLOTS];
     clusterNode *slots[CLUSTER_SLOTS];
-    rax *slots_to_channels;
     /* The following fields are used to take the slave state on elections. */
     mstime_t failover_auth_time; /* Time of previous or next election. */
     int failover_auth_count;    /* Number of votes received so far. */

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -331,7 +331,7 @@ int pubsubUnsubscribeChannel(client *c, robj *channel, int notify, pubsubtype ty
         retval = 1;
         /* Remove the client from the channel -> clients list hash table */
         if (server.cluster_enabled && type.shard) {
-            slot = c->slot;
+            slot = c->slot != -1 ? c->slot : keyHashSlot(channel->ptr, sdslen(channel->ptr));
         }
         d = *type.serverPubSubChannels(slot);
         serverAssertWithInfo(c,NULL,d != NULL);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -264,7 +264,7 @@ int clientTotalPubSubSubscriptionCount(client *c) {
 /* Subscribe a client to a channel. Returns 1 if the operation succeeded, or
  * 0 if the client was already subscribed to that channel. */
 int pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
-    dict **pd;
+    dict **d_ptr;
     dictEntry *de;
     list *clients = NULL;
     int retval = 0;
@@ -278,14 +278,14 @@ int pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
         if (server.cluster_enabled && type.shard) {
             slot = keyHashSlot(channel->ptr, sdslen(channel->ptr));
         }
-        pd = type.serverPubSubChannels(slot);
-        if (*pd == NULL) {
-            *pd = dictCreate(&keylistDictType);
+        d_ptr = type.serverPubSubChannels(slot);
+        if (*d_ptr == NULL) {
+            *d_ptr = dictCreate(&keylistDictType);
         }
-        de = dictFind(*pd, channel);
+        de = dictFind(*d_ptr, channel);
         if (de == NULL) {
             clients = listCreate();
-            dictAdd(*pd, channel, clients);
+            dictAdd(*d_ptr, channel, clients);
             incrRefCount(channel);
             if (type.shard) {
                 server.shard_channel_count++;

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -402,6 +402,19 @@ void pubsubShardUnsubscribeAllClients(unsigned int slot, robj *channel) {
     decrRefCount(channel); /* it is finally safe to release it */
 }
 
+void pubsubShardUnsubscribeAllClientsInSlot(unsigned int slot) {
+    dict *d = server.pubsubshard_channels[slot];
+    if (!d) {
+        return;
+    }
+    dictIterator *di = dictGetSafeIterator(d);
+    dictEntry *de;
+    while ((de = dictNext(di)) != NULL) {
+        robj *channel = dictGetKey(de);
+        pubsubShardUnsubscribeAllClients(slot, channel);
+    }
+    dictReleaseIterator(di);
+}
 
 /* Subscribe a client to a pattern. Returns 1 if the operation succeeded, or 0 if the client was already subscribed to that pattern. */
 int pubsubSubscribePattern(client *c, robj *pattern) {

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -335,8 +335,8 @@ int pubsubUnsubscribeChannel(client *c, robj *channel, int notify, pubsubtype ty
             if (type.shard) {
                 if (dictSize(d) == 0) {
                     dictRelease(d);
-                    dict **pd = type.serverPubSubChannels(slot);
-                    *pd = NULL;
+                    dict **d_ptr = type.serverPubSubChannels(slot);
+                    *d_ptr = NULL;
                 }
                 server.shard_channel_count--;
             }

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -331,7 +331,7 @@ int pubsubUnsubscribeChannel(client *c, robj *channel, int notify, pubsubtype ty
         retval = 1;
         /* Remove the client from the channel -> clients list hash table */
         if (server.cluster_enabled && type.shard) {
-            slot = c->slot != -1 ? c->slot : keyHashSlot(channel->ptr, sdslen(channel->ptr));
+            slot = c->slot != -1 ? (unsigned int)c->slot : keyHashSlot(channel->ptr, sdslen(channel->ptr));
         }
         d = *type.serverPubSubChannels(slot);
         serverAssertWithInfo(c,NULL,d != NULL);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -741,6 +741,9 @@ void channelList(client *c, sds pat, dict **pubsub_channels, int is_sharded) {
 
     replylen = addReplyDeferredLen(c);
     for (unsigned int i = 0; i < slot_cnt; i++) {
+        if (pubsub_channels[i] == NULL) {
+            continue;
+        }
         dictIterator *di = dictGetIterator(pubsub_channels[i]);
         dictEntry *de;
         while((de = dictNext(di)) != NULL) {

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -331,7 +331,7 @@ int pubsubUnsubscribeChannel(client *c, robj *channel, int notify, pubsubtype ty
         retval = 1;
         /* Remove the client from the channel -> clients list hash table */
         if (server.cluster_enabled && type.shard) {
-            slot = c->slot != -1 ? c->slot : keyHashSlot(channel->ptr, sdslen(channel->ptr));
+            slot = c->slot != -1 ? c->slot : (int)keyHashSlot(channel->ptr, sdslen(channel->ptr));
         }
         d = *type.serverPubSubChannels(slot);
         serverAssertWithInfo(c,NULL,d != NULL);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -712,12 +712,9 @@ NULL
     } else if (!strcasecmp(c->argv[1]->ptr,"shardnumsub") && c->argc >= 2) {
         /* PUBSUB SHARDNUMSUB [ShardChannel_1 ... ShardChannel_N] */
         int j;
-        unsigned int slot = 0;
         addReplyArrayLen(c, (c->argc-2)*2);
         for (j = 2; j < c->argc; j++) {
-            if (server.cluster_enabled) {
-                slot = keyHashSlot(c->argv[j]->ptr, sdslen(c->argv[j]->ptr));
-            }
+            unsigned int slot = calculateKeySlot(c->argv[j]->ptr);
             dict *d = server.pubsubshard_channels[slot];
             list *l = d ? dictFetchValue(d, c->argv[j]) : NULL;
 

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -251,7 +251,8 @@ dict **getServerPubSubChannels(unsigned int slot) {
 }
 
 dict **getServerPubSubShardChannels(unsigned int slot) {
-    return &server.pubsubshard_channels[server.cluster_enabled ? slot : 0];
+    serverAssert(server.cluster_enabled || slot == 0);
+    return &server.pubsubshard_channels[slot];
 }
 
 /* Return the number of pubsub + pubsub shard level channels

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -276,7 +276,7 @@ int pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
         incrRefCount(channel);
         /* Add the client to the channel -> list of clients hash table */
         if (server.cluster_enabled && type.shard) {
-            slot = keyHashSlot(channel->ptr, sdslen(channel->ptr));
+            slot = c->slot;
         }
         d_ptr = type.serverPubSubChannels(slot);
         if (*d_ptr == NULL) {
@@ -317,7 +317,7 @@ int pubsubUnsubscribeChannel(client *c, robj *channel, int notify, pubsubtype ty
         retval = 1;
         /* Remove the client from the channel -> clients list hash table */
         if (server.cluster_enabled && type.shard) {
-            slot = keyHashSlot(channel->ptr, sdslen(channel->ptr));
+            slot = c->slot;
         }
         d = *type.serverPubSubChannels(slot);
         serverAssertWithInfo(c,NULL,d != NULL);

--- a/src/server.c
+++ b/src/server.c
@@ -2737,7 +2737,7 @@ void initServer(void) {
     evictionPoolAlloc(); /* Initialize the LRU keys pool. */
     server.pubsub_channels = dictCreate(&keylistDictType);
     server.pubsub_patterns = dictCreate(&keylistDictType);
-    server.pubsubshard_channels = dictCreateMultiple(&keylistDictType, slotCount);
+    server.pubsubshard_channels = zcalloc(sizeof(dict *) * slotCount);
     server.shard_channel_count = 0;
     server.cronloops = 0;
     server.in_exec = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -2718,10 +2718,10 @@ void initServer(void) {
     server.db = zmalloc(sizeof(redisDb)*server.dbnum);
 
     /* Create the Redis databases, and initialize other internal state. */
-    int slotCount = (server.cluster_enabled) ? CLUSTER_SLOTS : 1;
+    int slot_count = (server.cluster_enabled) ? CLUSTER_SLOTS : 1;
     for (j = 0; j < server.dbnum; j++) {  
-        server.db[j].dict = dictCreateMultiple(&dbDictType, slotCount);
-        server.db[j].expires = dictCreateMultiple(&dbExpiresDictType,slotCount);
+        server.db[j].dict = dictCreateMultiple(&dbDictType, slot_count);
+        server.db[j].expires = dictCreateMultiple(&dbExpiresDictType,slot_count);
         server.db[j].expires_cursor = 0;
         server.db[j].blocking_keys = dictCreate(&keylistDictType);
         server.db[j].blocking_keys_unblock_on_nokey = dictCreate(&objectKeyPointerValueDictType);
@@ -2730,14 +2730,14 @@ void initServer(void) {
         server.db[j].id = j;
         server.db[j].avg_ttl = 0;
         server.db[j].defrag_later = listCreate();
-        server.db[j].dict_count = slotCount;
+        server.db[j].dict_count = slot_count;
         initDbState(&server.db[j]);
         listSetFreeMethod(server.db[j].defrag_later,(void (*)(void*))sdsfree);
     }
     evictionPoolAlloc(); /* Initialize the LRU keys pool. */
     server.pubsub_channels = dictCreate(&keylistDictType);
     server.pubsub_patterns = dictCreate(&keylistDictType);
-    server.pubsubshard_channels = zcalloc(sizeof(dict *) * slotCount);
+    server.pubsubshard_channels = zcalloc(sizeof(dict *) * slot_count);
     server.shard_channel_count = 0;
     server.cronloops = 0;
     server.in_exec = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -2718,8 +2718,8 @@ void initServer(void) {
     server.db = zmalloc(sizeof(redisDb)*server.dbnum);
 
     /* Create the Redis databases, and initialize other internal state. */
-    for (j = 0; j < server.dbnum; j++) {
-        int slotCount = (server.cluster_enabled) ? CLUSTER_SLOTS : 1;
+    int slotCount = (server.cluster_enabled) ? CLUSTER_SLOTS : 1;
+    for (j = 0; j < server.dbnum; j++) {  
         server.db[j].dict = dictCreateMultiple(&dbDictType, slotCount);
         server.db[j].expires = dictCreateMultiple(&dbExpiresDictType,slotCount);
         server.db[j].expires_cursor = 0;
@@ -2737,7 +2737,8 @@ void initServer(void) {
     evictionPoolAlloc(); /* Initialize the LRU keys pool. */
     server.pubsub_channels = dictCreate(&keylistDictType);
     server.pubsub_patterns = dictCreate(&keylistDictType);
-    server.pubsubshard_channels = dictCreate(&keylistDictType);
+    server.pubsubshard_channels = dictCreateMultiple(&keylistDictType, slotCount);
+    server.shard_channel_count = 0;
     server.cronloops = 0;
     server.in_exec = 0;
     server.busy_module_yield_flags = BUSY_MODULE_YIELD_NONE;
@@ -5868,7 +5869,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "keyspace_misses:%lld\r\n", server.stat_keyspace_misses,
             "pubsub_channels:%ld\r\n", dictSize(server.pubsub_channels),
             "pubsub_patterns:%lu\r\n", dictSize(server.pubsub_patterns),
-            "pubsubshard_channels:%lu\r\n", dictSize(server.pubsubshard_channels),
+            "pubsubshard_channels:%llu\r\n", server.shard_channel_count,
             "latest_fork_usec:%lld\r\n", server.stat_fork_time,
             "total_forks:%lld\r\n", server.stat_total_forks,
             "migrate_cached_sockets:%ld\r\n", dictSize(server.migrate_cached_sockets),

--- a/src/server.h
+++ b/src/server.h
@@ -2492,6 +2492,7 @@ extern dictType sdsHashDictType;
 extern dictType dbExpiresDictType;
 extern dictType modulesDictType;
 extern dictType sdsReplyDictType;
+extern dictType keylistDictType;
 extern dict *modules;
 
 /*-----------------------------------------------------------------------------

--- a/src/server.h
+++ b/src/server.h
@@ -3194,7 +3194,7 @@ robj *hashTypeDup(robj *o);
 /* Pub / Sub */
 int pubsubUnsubscribeAllChannels(client *c, int notify);
 int pubsubUnsubscribeShardAllChannels(client *c, int notify);
-void pubsubUnsubscribeShardChannels(robj **channels, unsigned int count);
+void pubsubShardUnsubscribeAllClients(unsigned int slot, robj *channel);
 int pubsubUnsubscribeAllPatterns(client *c, int notify);
 int pubsubPublishMessage(robj *channel, robj *message, int sharded);
 int pubsubPublishMessageAndPropagateToCluster(robj *channel, robj *message, int sharded);

--- a/src/server.h
+++ b/src/server.h
@@ -3194,7 +3194,7 @@ robj *hashTypeDup(robj *o);
 /* Pub / Sub */
 int pubsubUnsubscribeAllChannels(client *c, int notify);
 int pubsubUnsubscribeShardAllChannels(client *c, int notify);
-void pubsubShardUnsubscribeAllClients(unsigned int slot, robj *channel);
+void pubsubShardUnsubscribeAllClientsInSlot(unsigned int slot);
 int pubsubUnsubscribeAllPatterns(client *c, int notify);
 int pubsubPublishMessage(robj *channel, robj *message, int sharded);
 int pubsubPublishMessageAndPropagateToCluster(robj *channel, robj *message, int sharded);

--- a/src/server.h
+++ b/src/server.h
@@ -3194,7 +3194,7 @@ robj *hashTypeDup(robj *o);
 /* Pub / Sub */
 int pubsubUnsubscribeAllChannels(client *c, int notify);
 int pubsubUnsubscribeShardAllChannels(client *c, int notify);
-void pubsubShardUnsubscribeAllClientsInSlot(unsigned int slot);
+void pubsubShardUnsubscribeAllChannelsInSlot(unsigned int slot);
 int pubsubUnsubscribeAllPatterns(client *c, int notify);
 int pubsubPublishMessage(robj *channel, robj *message, int sharded);
 int pubsubPublishMessageAndPropagateToCluster(robj *channel, robj *message, int sharded);

--- a/src/server.h
+++ b/src/server.h
@@ -1987,7 +1987,8 @@ struct redisServer {
     dict *pubsub_patterns;  /* A dict of pubsub_patterns */
     int notify_keyspace_events; /* Events to propagate via Pub/Sub. This is an
                                    xor of NOTIFY_... flags. */
-    dict *pubsubshard_channels;  /* Map shard channels to list of subscribed clients */
+    dict **pubsubshard_channels;  /* Map shard channels in every slot to list of subscribed clients */
+    unsigned long long shard_channel_count;
     /* Cluster */
     int cluster_enabled;      /* Is cluster enabled? */
     int cluster_port;         /* Set the cluster port for a node. */

--- a/tests/cluster/tests/26-pubsubshard.tcl
+++ b/tests/cluster/tests/26-pubsubshard.tcl
@@ -56,7 +56,7 @@ test "client can subscribe to multiple shard channels across different slots in 
     $cluster sunsubscribe ch7
 }
 
-test "sunsubscribe without specifying any channel would unsubscribe all shard channels subscirbed" {
+test "sunsubscribe without specifying any channel would unsubscribe all shard channels subscribed" {
     set publishclient [redis_client_by_addr $publishnode(host) $publishnode(port)]
     set subscribeclient [redis_deferring_client_by_addr $publishnode(host) $publishnode(port)]
     

--- a/tests/cluster/tests/26-pubsubshard.tcl
+++ b/tests/cluster/tests/26-pubsubshard.tcl
@@ -56,6 +56,21 @@ test "client can subscribe to multiple shard channels across different slots in 
     $cluster sunsubscribe ch7
 }
 
+test "sunsubscribe without specifying any channel would unsubscribe all shard channels subscirbed" {
+    set publishclient [redis_client_by_addr $publishnode(host) $publishnode(port)]
+    set subscribeclient [redis_deferring_client_by_addr $publishnode(host) $publishnode(port)]
+    
+    set sub_res [ssubscribe $subscribeclient [list "\{channel.0\}1" "\{channel.0\}2" "\{channel.0\}3"]]
+    assert_equal [list 1 2 3] $sub_res
+    sunsubscribe $subscribeclient                  
+   
+    assert_equal 0 [$publishclient spublish "\{channel.0\}1" hello] 
+    assert_equal 0 [$publishclient spublish "\{channel.0\}2" hello] 
+    assert_equal 0 [$publishclient spublish "\{channel.0\}3" hello]                                 
+         
+    $publishclient close
+    $subscribeclient close                                                                                                                   
+}                                      
 
 test "Verify Pub/Sub and Pub/Sub shard no overlap" {
     set slot [$cluster cluster keyslot "channel.0"]

--- a/tests/cluster/tests/26-pubsubshard.tcl
+++ b/tests/cluster/tests/26-pubsubshard.tcl
@@ -59,18 +59,18 @@ test "client can subscribe to multiple shard channels across different slots in 
 test "sunsubscribe without specifying any channel would unsubscribe all shard channels subscribed" {
     set publishclient [redis_client_by_addr $publishnode(host) $publishnode(port)]
     set subscribeclient [redis_deferring_client_by_addr $publishnode(host) $publishnode(port)]
-    
+
     set sub_res [ssubscribe $subscribeclient [list "\{channel.0\}1" "\{channel.0\}2" "\{channel.0\}3"]]
     assert_equal [list 1 2 3] $sub_res
-    sunsubscribe $subscribeclient                  
-   
-    assert_equal 0 [$publishclient spublish "\{channel.0\}1" hello] 
-    assert_equal 0 [$publishclient spublish "\{channel.0\}2" hello] 
-    assert_equal 0 [$publishclient spublish "\{channel.0\}3" hello]                                 
-         
+    sunsubscribe $subscribeclient
+
+    assert_equal 0 [$publishclient spublish "\{channel.0\}1" hello]
+    assert_equal 0 [$publishclient spublish "\{channel.0\}2" hello]
+    assert_equal 0 [$publishclient spublish "\{channel.0\}3" hello]
+
     $publishclient close
-    $subscribeclient close                                                                                                                   
-}                                      
+    $subscribeclient close
+}
 
 test "Verify Pub/Sub and Pub/Sub shard no overlap" {
     set slot [$cluster cluster keyslot "channel.0"]
@@ -106,4 +106,25 @@ test "Verify Pub/Sub and Pub/Sub shard no overlap" {
     $publishclient close
     $subscribeclient close
     $subscribeshardclient close
+}
+
+test "PUBSUB channels/shardchannels" {
+    set subscribeclient [redis_deferring_client_by_addr $publishnode(host) $publishnode(port)]
+    set subscribeclient2 [redis_deferring_client_by_addr $publishnode(host) $publishnode(port)]
+    set subscribeclient3 [redis_deferring_client_by_addr $publishnode(host) $publishnode(port)]
+    set publishclient [redis_client_by_addr  $publishnode(host) $publishnode(port)]
+
+    ssubscribe $subscribeclient [list "\{channel.0\}1"]
+    ssubscribe $subscribeclient2 [list "\{channel.0\}2"]
+    ssubscribe $subscribeclient3 [list "\{channel.0\}3"]
+    assert_equal {3} [llength [$publishclient pubsub shardchannels]]
+
+    subscribe $subscribeclient [list "\{channel.0\}4"]
+    assert_equal {3} [llength [$publishclient pubsub shardchannels]]
+
+    sunsubscribe $subscribeclient
+    set channel_list [$publishclient pubsub shardchannels]
+    assert_equal {2} [llength $channel_list]
+    assert {[lsearch -exact $channel_list "\{channel.0\}2"] >= 0}
+    assert {[lsearch -exact $channel_list "\{channel.0\}3"] >= 0}
 }


### PR DESCRIPTION
We have achieved replacing `slots_to_keys` radix tree with key->slot linked list (#9356), and then replacing the list with slot specific dictionaries for keys (#11695).

Shard channels behave just like keys in many ways, and we also need a slots->channels mapping. Currently this is still done by using a radix tree. So we should split `server.pubsubshard_channels` into 16384 dicts and drop the radix tree, just like what we did to DBs.

Some benefits (basically the benefits of what we've done to DBs):
1. Optimize counting channels in a slot. This is currently used only in removing channels in a slot. But this is potentially more useful: sometimes we need to know how many channels there are in a specific slot when doing slot migration. Counting is now implemented by traversing the radix tree, and with this PR it will be as simple as calling `dictSize`, from O(n) to O(1).
2. The radix tree in the cluster has been removed. The shard channel names no longer require additional storage, which can save memory.
3. Potentially useful in slot migration, as shard channels are logically split by slots, thus making it easier to migrate, remove or add as a whole.
4. Avoid rehashing a big dict when there is a large number of channels.

Drawbacks:
1. Takes more memory than using radix tree when there are relatively few shard channels.

What this PR does:
1. in cluster mode, split `server.pubsubshard_channels` into 16384 dicts, in standalone mode, still use only one dict.
2. drop the `slots_to_channels` radix tree.
3. to save memory (to solve the drawback above), all 16384 dicts are created lazily, which means only when a channel is about to be inserted to the dict will the dict be initialized, and when all channels are deleted, the dict would delete itself.
5. use `server.shard_channel_count` to keep track of the number of all shard channels.