### PR TITLE
Use shard-id of the master if the replica does not support shard-id

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -89,7 +89,7 @@ int clusterNodeIsMaster(clusterNode *n);
 char *clusterNodeIp(clusterNode *node);
 int clusterNodeIsSlave(clusterNode *node);
 clusterNode *clusterNodeGetSlaveof(clusterNode *node);
-clusterNode *clusterNodeGetSlaveofMaster(clusterNode *node);
+clusterNode *clusterNodeGetMaster(clusterNode *node);
 char *clusterNodeGetName(clusterNode *node);
 int clusterNodeTimedOut(clusterNode *node);
 int clusterNodeIsFailing(clusterNode *node);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -89,6 +89,7 @@ int clusterNodeIsMaster(clusterNode *n);
 char *clusterNodeIp(clusterNode *node);
 int clusterNodeIsSlave(clusterNode *node);
 clusterNode *clusterNodeGetSlaveof(clusterNode *node);
+clusterNode *clusterNodeGetSlaveofMaster(clusterNode *node);
 char *clusterNodeGetName(clusterNode *node);
 int clusterNodeTimedOut(clusterNode *node);
 int clusterNodeIsFailing(clusterNode *node);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2611,7 +2611,7 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
      *
      * If sender is a replica, set the shard_id to the shard_id of its master.
      * Otherwise, we'll set it now. */
-    if (ext_shardid == NULL) ext_shardid = clusterNodeGetSlaveofMaster(sender)->shard_id;
+    if (ext_shardid == NULL) ext_shardid = clusterNodeGetMaster(sender)->shard_id;
 
     updateShardId(sender, ext_shardid);
 }
@@ -5555,7 +5555,7 @@ void addShardReplyForClusterShards(client *c, list *nodes) {
     addReplyBulkCString(c, "slots");
 
     /* Use slot_info_pairs from the primary only */
-    n = clusterNodeGetSlaveofMaster(n);
+    n = clusterNodeGetMaster(n);
 
     if (n->slot_info_pairs != NULL) {
         serverAssert((n->slot_info_pairs_count % 2) == 0);
@@ -5868,7 +5868,7 @@ clusterNode *clusterNodeGetSlaveof(clusterNode *node) {
     return node->slaveof;
 }
 
-clusterNode *clusterNodeGetSlaveofMaster(clusterNode *node) {
+clusterNode *clusterNodeGetMaster(clusterNode *node) {
     while (node->slaveof != NULL) node = node->slaveof;
     return node;
 }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2596,11 +2596,16 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
         /* We know this will be valid since we validated it ahead of time */
         ext = getNextPingExt(ext);
     }
+
     /* If the node did not send us a hostname extension, assume
      * they don't have an announced hostname. Otherwise, we'll
      * set it now. */
     updateAnnouncedHostname(sender, ext_hostname);
     updateAnnouncedHumanNodename(sender, ext_humannodename);
+    /* If the node did not send us a shard-id extension, it means the sender does not
+     * support it, node->shard_id is randomly generated. If sender is a replica, set
+     * the shard_id to the shard_id of its master. Otherwise, we'll set it now. */
+    if (ext_shardid == NULL && sender->slaveof) ext_shardid = sender->slaveof->shard_id;
     updateShardId(sender, ext_shardid);
 }
 


### PR DESCRIPTION
If there are nodes in the cluster that do not support shard-id, they
will gossip shard-id. From the perspective of nodes that support shard-id,
their shard-id is meaningless (since shard-id is randomly generated when
we create a node.)

Nodes that support shard-id will save the shard-id information in nodes.conf.
If the node is restarted according to nodes.conf, the server will report a
`corrupted cluster config file` error. Because auxShardIdSetter will reject
configurations with inconsistent master-replica shard-ids.

A cluster-wide consensus for the node's shard_id is not necessary. The key
is maintaining consistency of the shard_id on each individual 7.2 node.
As the cluster progressively upgrades to version 7.2, we can expect the
shard_ids across all nodes to naturally converge and align.

In this PR, when process the gossip, if sender is a replica and does not
support shard-id, set the shard_id to the shard_id of its master.

This fix #12761.

```
Release notes
Fix a crash related to rebalancing clusters when running nodes on both 7.0 and 7.2.
```