### PR TITLE
GH Workflows: Create CI job for Coverity scan

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@main
     - name: Download and extract the Coverity Build Tool
       run: |
-          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=moshekaplan/redis" -O cov-analysis-linux64.tar.gz
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=redis" -O cov-analysis-linux64.tar.gz
           mkdir cov-analysis-linux64
           tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
     - name: Install Redis dependencies

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,32 @@
+# Creates and uploads a Coverity build on a schedule
+name: Coverity Scan
+on:
+  #schedule:
+  #  # Run twice daily, since below 500k LOC can have 21 builds per week, per https://scan.coverity.com/faq#frequency
+  #  - cron: '0 */12 * * *'
+  # Support manual execution
+  workflow_dispatch:
+jobs:
+  coverity:
+    if: github.repository == 'redis/redis'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - name: Download and extract the Coverity Build Tool
+      run: |
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=moshekaplan/redis" -O cov-analysis-linux64.tar.gz
+          mkdir cov-analysis-linux64
+          tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
+    - name: Install Redis dependencies
+      run: sudo apt install -y gcc tcl8.6 tclx procps libssl-dev
+    - name: Build with cov-build
+      run: cov-analysis-linux64/bin/cov-build --dir cov-int make
+    - name: Upload the result
+      run: |
+          tar czvf cov-int.tgz cov-int
+          curl \
+            --form project=redis \
+            --form email=${{ secrets.COVERITY_SCAN_EMAIL }} \
+            --form token=${{ secrets.COVERITY_SCAN_TOKEN }} \
+            --form file=@cov-int.tgz \
+            https://scan.coverity.com/builds

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -2,8 +2,8 @@
 name: Coverity Scan
 on:
   schedule:
-  # Run twice daily, since below 500k LOC can have 21 builds per week, per https://scan.coverity.com/faq#frequency
-  - cron: '0 */12 * * *'
+  # Run once daily, since below 500k LOC can have 21 builds per week, per https://scan.coverity.com/faq#frequency
+  - cron: '0 0 * * *'
   # Support manual execution
   workflow_dispatch:
 jobs:
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@main
     - name: Download and extract the Coverity Build Tool
       run: |
-          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=redis" -O cov-analysis-linux64.tar.gz
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=redis-unstable" -O cov-analysis-linux64.tar.gz
           mkdir cov-analysis-linux64
           tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
     - name: Install Redis dependencies

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,9 +1,9 @@
 # Creates and uploads a Coverity build on a schedule
 name: Coverity Scan
 on:
-  #schedule:
-  #  # Run twice daily, since below 500k LOC can have 21 builds per week, per https://scan.coverity.com/faq#frequency
-  #  - cron: '0 */12 * * *'
+  schedule:
+  # Run twice daily, since below 500k LOC can have 21 builds per week, per https://scan.coverity.com/faq#frequency
+  - cron: '0 */12 * * *'
   # Support manual execution
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
I've noticed that https://scan.coverity.com/projects/redis already exists, but appears to be only updated on an ad-hoc basis. creating [redis-unstable](https://scan.coverity.com/projects/redis-unstable?tab=project_settings) project in coverity for this CI.

This PR adds a GitHub Action-based CI job to create a new Coverity build once daily, so that there is always a recent scan available.

This is  within the limit, as Redis is ~150K LOC and per https://scan.coverity.com/faq#frequency :

> Up to 21 builds per week, with a maximum of 3 builds per day, for projects with 100K to 500K lines of code

Before this is merged in, two new secrets will need to be created:

COVERITY_SCAN_EMAIL with the email address used for accessing Coverity COVERITY_SCAN_TOKEN with the Project token from https://scan.coverity.com/projects/redis-unstable?tab=project_settings