### PR TITLE
connection.c: Fix potential out-of-bounds write in connTypeRegister

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -49,7 +49,7 @@ int connTypeRegister(ConnectionType *ct) {
     
     /* Check if we exhausted connTypes without finding an empty slot */
     if (type == CONN_TYPE_MAX) {
-        serverLog(LL_WARNING, "Could not find an slot to register connection type %s", typename);
+        serverLog(LL_WARNING, "Could not find a slot to register connection type %s", typename);
         return C_ERR;
     }
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -46,6 +46,12 @@ int connTypeRegister(ConnectionType *ct) {
             return C_ERR;
         }
     }
+    
+    /* Check if we exhausted connTypes without finding an empty slot */
+    if (type == CONN_TYPE_MAX) {
+        serverLog(LL_WARNING, "Could not find an slot to register connection type %s", typename);
+        return C_ERR;
+    }
 
     serverLog(LL_VERBOSE, "Connection type %s registered", typename);
     connTypes[type] = ct;


### PR DESCRIPTION
Fix potential out-of-bounds write in connTypeRegister, in situations where all connTypes are exhausted without finding an empty slot to store the connection type.