### PR TITLE
Add parameter to determine whether to load RDB when AOF is off

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3098,6 +3098,7 @@ standardConfig static_configs[] = {
     createBoolConfig("latency-tracking", NULL, MODIFIABLE_CONFIG, server.latency_tracking_enabled, 1, NULL, NULL),
     createBoolConfig("aof-disable-auto-gc", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.aof_disable_auto_gc, 0, NULL, updateAofAutoGCEnabled),
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
+    createBoolConfig("load-rdb-when-aof-off", NULL, MODIFIABLE_CONFIG | DENY_LOADING_CONFIG, server.load_rdb_when_aof_off, 1, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/server.c
+++ b/src/server.c
@@ -6635,7 +6635,7 @@ void loadDataFromDisk(void) {
             exit(1);
         if (ret != AOF_NOT_EXIST)
             serverLog(LL_NOTICE, "DB loaded from append only file: %.3f seconds", (float)(ustime()-start)/1000000);
-    } else {
+    } else if (server.load_rdb_when_aof_off) {
         rdbSaveInfo rsi = RDB_SAVE_INFO_INIT;
         int rsi_is_valid = 0;
         errno = 0; /* Prevent a stale value from affecting error checking */

--- a/src/server.h
+++ b/src/server.h
@@ -1840,6 +1840,7 @@ struct redisServer {
     int key_load_delay;             /* Delay in microseconds between keys while
                                      * loading aof or rdb. (for testings). negative
                                      * value means fractions of microseconds (on average). */
+    int load_rdb_when_aof_off;      /* Load rdb when aof is off */
     /* Pipe and data structures for child -> parent info sharing. */
     int child_info_pipe[2];         /* Pipe used to write the child_info_data. */
     int child_info_nread;           /* Num of bytes of the last read from pipe */

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -416,4 +416,18 @@ start_server {} {
     } {OK}
 }
 
+start_server [list overrides [list "appendonly" "no" "load-rdb-when-aof-off" "no"]] {
+    test {Test don't load RDB when load-rdb-when-aof-off is yes} {
+        r debug populate 1000
+        r bgsave
+        waitForBgsave r
+        assert_not_equal [r debug digest] {0000000000000000000000000000000000000000}
+
+        restart_server 0 true false
+        wait_done_loading r
+
+        assert_equal [r debug digest] {0000000000000000000000000000000000000000}
+    }
+}
+
 } ;# tags


### PR DESCRIPTION
Redis can't perform reading or writing while loading. If Redis crashed for some reason, users using Redis as a cache system don't want to load data but provide service as fast as possible because data loading may leads to a long time of unavailability. Even if users disables AOF, Redis tries to load RDB which may be produced by replication or offline analysis.

As mentioned above, I think we may need a new parameter to control data loading when Redis starts. I named it 'load-rdb-when-aof-off', meaning whether to load RDB when AOF is off. Its default value is yes to be compatible with the current behavior.

I'm new to Redis. Hope for any opinions and discussions.



