### PR TITLE
Optimize CPU cache efficiency on dict while rehashing in `dictTwoPhaseUnlinkFind`

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -718,6 +718,7 @@ dictEntry *dictTwoPhaseUnlinkFind(dict *d, const void *key, dictEntry ***plink, 
 
     for (table = 0; table <= 1; table++) {
         idx = h & DICTHT_SIZE_MASK(d->ht_size_exp[table]);
+        if (table == 0 && (long)idx < d->rehashidx) continue;
         dictEntry **ref = &d->ht_table[table][idx];
         while (ref && *ref) {
             void *de_key = dictGetKey(*ref);


### PR DESCRIPTION
In #5692, we optimize CPU cache efficiency on dict while rehashing but it seems that we missed the modification in `dictTwoPhaseUnlinkFind`. 

This PR supplements it.