### PR TITLE
config.c: Avoid leaking file handle if file is 0 bytes

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1128,7 +1128,14 @@ struct rewriteConfigState *rewriteConfigReadOldFile(char *path) {
     int linenum = -1;
     struct rewriteConfigState *state = rewriteConfigCreateState();
 
-    if (fp == NULL || sb.st_size == 0) return state;
+    if (fp == NULL) {
+        return state;
+    }
+
+    if (sb.st_size == 0) {
+        fclose(fp);
+        return state;
+    } 
 
     /* Load the file content */
     sds config = sdsnewlen(SDS_NOINIT,sb.st_size);


### PR DESCRIPTION
If fopen() is successful and redis_fstat determines that the file is 0 bytes, the file handle stored in fp will leak. This change closes the filehandle stored in fp if the file is 0 bytes.

Second attempt at fixing Coverity 390029

This is a follow-up to #12796