### PR TITLE
add expired event when expire command directly delete keys

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -655,6 +655,7 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         rewriteClientCommandVector(c,2,aux,key);
         signalModifiedKey(c,c->db,key);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"del",key,c->db->id);
+        notifyKeyspaceEvent(NOTIFY_EXPIRED, "expired", key, c->db->id);
         addReply(c, shared.cone);
         return;
     } else {


### PR DESCRIPTION
Past discussions: #12211 
The inconsistency of the expire notification caused users to fail to update these keys delete by expire command. I tried to work around but found difficult, so I want to add a expired event notification and still keep the `del` notification.

This looks like it will degrade the performance, but if the user does not subscribe to both `del` and `expired` events, the performance remains the same.

If the ttl have been expired, we can put the `dbGenericDelete` before `lookupKeyWrite` function, which can avoid redundant  lookupkey to improve performance. I'll make one another pr latter.
