### PR TITLE
impove performance when expire command using a expired time

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -593,6 +593,27 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
     }
     when += basetime;
 
+    if (checkAlreadyExpired(when)) {
+        robj *aux;
+
+        int deleted = dbGenericDelete(c->db, key, server.lazyfree_lazy_expire, DB_FLAG_KEY_EXPIRED);
+        /* key not exist */
+        if (!deleted) {
+            addReply(c, shared.czero);
+            return;
+        }
+
+        server.dirty++;
+
+        /* Replicate/AOF this as an explicit DEL or UNLINK. */
+        aux = server.lazyfree_lazy_expire ? shared.unlink : shared.del;
+        rewriteClientCommandVector(c, 2, aux, key);
+        signalModifiedKey(c, c->db, key);
+        notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
+        addReply(c, shared.cone);
+        return;
+    }
+
     /* No key, return zero. */
     if (lookupKeyWrite(c->db,key) == NULL) {
         addReply(c,shared.czero);
@@ -643,21 +664,6 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         }
     }
 
-    if (checkAlreadyExpired(when)) {
-        robj *aux;
-
-        int deleted = dbGenericDelete(c->db,key,server.lazyfree_lazy_expire,DB_FLAG_KEY_EXPIRED);
-        serverAssertWithInfo(c,key,deleted);
-        server.dirty++;
-
-        /* Replicate/AOF this as an explicit DEL or UNLINK. */
-        aux = server.lazyfree_lazy_expire ? shared.unlink : shared.del;
-        rewriteClientCommandVector(c,2,aux,key);
-        signalModifiedKey(c,c->db,key);
-        notifyKeyspaceEvent(NOTIFY_GENERIC,"del",key,c->db->id);
-        addReply(c, shared.cone);
-        return;
-    } else {
         setExpire(c,c->db,key,when);
         addReply(c,shared.cone);
         /* Propagate as PEXPIREAT millisecond-timestamp
@@ -677,7 +683,6 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         notifyKeyspaceEvent(NOTIFY_GENERIC,"expire",key,c->db->id);
         server.dirty++;
         return;
-    }
 }
 
 /* EXPIRE key seconds [ NX | XX | GT | LT] */


### PR DESCRIPTION
follow #12833 
When the time argument in the expire command is less than the current time, it means that we can directly try to delete the key and avoid lookupkey

update benchmark result:
step1: 
populate 2M keys:`memtier_benchmark -p 6379 -s 127.0.0.1 --key-maximum=2000000 --key-pattern=P:P -n allkeys --ratio=1:0 --hide-histogram`
step2: 
delete all keys by expire command: `memtier_benchmark -p 6379 -s 127.0.0.1 --key-maximum=2000000 --hide-histogram --command="expire __key__ -1" --command-key-pattern=P`

This branch reach 78083 ops/s, and unstable branch have 70401 ops/s, we can get a 11% performance improvement.
