### PR TITLE
Add INCR type command against wrong argument test cases.

### DIFF
--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -482,6 +482,13 @@ start_server {tags {"hash"}} {
         list [r hincrby htest foo 2]
     } {2}
 
+    test {HINCRBY HINCRBYFLOAT against non-integer increment value} {
+        r del incrhash
+        r hset incrhash field 5
+        assert_error "*value is not an integer*" {r hincrby myhash field v}
+        assert_error "*value is not a*" {r hincrbyfloat myhash field v}
+    }
+
     test {HINCRBY against non existing hash key} {
         set rv {}
         r hdel smallhash tmp

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -485,8 +485,8 @@ start_server {tags {"hash"}} {
     test {HINCRBY HINCRBYFLOAT against non-integer increment value} {
         r del incrhash
         r hset incrhash field 5
-        assert_error "*value is not an integer*" {r hincrby myhash field v}
-        assert_error "*value is not a*" {r hincrbyfloat myhash field v}
+        assert_error "*value is not an integer*" {r hincrby incrhash field v}
+        assert_error "*value is not a*" {r hincrbyfloat incrhash field v}
     }
 
     test {HINCRBY against non existing hash key} {

--- a/tests/unit/type/incr.tcl
+++ b/tests/unit/type/incr.tcl
@@ -185,7 +185,8 @@ start_server {tags {"incr"}} {
 
     test {INCRBY INCRBYFLOAT DECRBY against unhappy path} {
         r del mykeyincr
-        r set mykeyincr 10
+        assert_error "*ERR wrong number of arguments*" {r incr mykeyincr v}
+        assert_error "*ERR wrong number of arguments*" {r decr mykeyincr v}
         assert_error "*value is not an integer or out of range*" {r incrby mykeyincr v}
         assert_error "*value is not an integer or out of range*" {r incrby mykeyincr 1.5}
         assert_error "*value is not an integer or out of range*" {r decrby mykeyincr v}

--- a/tests/unit/type/incr.tcl
+++ b/tests/unit/type/incr.tcl
@@ -183,6 +183,16 @@ start_server {tags {"incr"}} {
         r get foo
     } {0}
 
+    test {INCRBY INCRBYFLOAT DECRBY against unhappy path} {
+        r del mykeyincr
+        r set mykeyincr 10
+        assert_error "*value is not an integer or out of range*" {r incrby mykeyincr v}
+        assert_error "*value is not an integer or out of range*" {r incrby mykeyincr 1.5}
+        assert_error "*value is not an integer or out of range*" {r decrby mykeyincr v}
+        assert_error "*value is not an integer or out of range*" {r decrby mykeyincr 1.5}
+        assert_error "*value is not a valid float*" {r incrbyfloat mykeyincr v}
+    }
+
     foreach cmd {"incr" "decr" "incrby" "decrby"} {
         test "$cmd operation should update encoding from raw to int" {
             set res {}

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -308,6 +308,12 @@ start_server {tags {"zset"}} {
             assert_error "*NaN*" {r zincrby myzset -inf abc}
         }
 
+        test "ZINCRBY against invalid incr value - $encoding" {
+            r del zincr
+            r zadd zincr 1 "one"
+            assert_error "*value is not a valid*" {r zincrby zincr v "one"}
+        }
+
         test "ZADD - Variadic version base case - $encoding" {
             r del myzset
             list [r zadd myzset 10 a 20 b 30 c] [r zrange myzset 0 -1 withscores]


### PR DESCRIPTION
We have test cases for incr related commands with no key exist and spaces in key and wrong type of key. However, we dont have test cases covered for INCRBY INCRBYFLOAT DECRBY INCR DECR HINCRBY HINCRBYFLOAT ZINCRBY with valid key and invalid value as argument, and float value to incrby and decrby. So added test cases for the scenarios in incr.tcl.

Thank you!