### PR TITLE
Optimize performance when many clients [p|s]unsubscribe simultaneously

### DIFF
--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -284,7 +284,7 @@ int pubsubUnsubscribeChannel(client *c, robj *channel, int notify, pubsubtype ty
         de = dictFind(*type.serverPubSubChannels, channel);
         serverAssertWithInfo(c,NULL,de != NULL);
         clients = dictGetVal(de);
-        serverAssertWithInfo(c,NULL,dictDelete(clients, c) == DICT_OK);
+        serverAssertWithInfo(c, NULL, dictDelete(clients, c) == DICT_OK);
         if (dictSize(clients) == 0) {
             /* Free the list and associated hash entry at all if this was
              * the latest client, so that it will be possible to abuse
@@ -376,7 +376,7 @@ int pubsubUnsubscribePattern(client *c, robj *pattern, int notify) {
         de = dictFind(server.pubsub_patterns,pattern);
         serverAssertWithInfo(c,NULL,de != NULL);
         clients = dictGetVal(de);
-        serverAssertWithInfo(c,NULL,dictDelete(clients, c) == DICT_OK);
+        serverAssertWithInfo(c, NULL, dictDelete(clients, c) == DICT_OK);
         if (dictSize(clients) == 0) {
             /* Free the list and associated hash entry at all if this was
              * the latest client. */
@@ -498,6 +498,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
                                 sdslen(pattern->ptr),
                                 (char*)channel->ptr,
                                 sdslen(channel->ptr),0)) continue;
+
             dictEntry *entry;
             dictIterator *iter = dictGetSafeIterator(clients);
             while ((entry = dictNext(iter)) != NULL) {
@@ -640,10 +641,10 @@ NULL
 
         addReplyArrayLen(c,(c->argc-2)*2);
         for (j = 2; j < c->argc; j++) {
-            dict *l = dictFetchValue(server.pubsub_channels,c->argv[j]);
+            dict *d = dictFetchValue(server.pubsub_channels, c->argv[j]);
 
             addReplyBulk(c,c->argv[j]);
-            addReplyLongLong(c,l ? dictSize(l) : 0);
+            addReplyLongLong(c,d ? dictSize(d) : 0);
         }
     } else if (!strcasecmp(c->argv[1]->ptr,"numpat") && c->argc == 2) {
         /* PUBSUB NUMPAT */
@@ -660,10 +661,10 @@ NULL
 
         addReplyArrayLen(c, (c->argc-2)*2);
         for (j = 2; j < c->argc; j++) {
-            dict *l = dictFetchValue(server.pubsubshard_channels, c->argv[j]);
+            dict *d = dictFetchValue(server.pubsubshard_channels, c->argv[j]);
 
             addReplyBulk(c,c->argv[j]);
-            addReplyLongLong(c,l ? dictSize(l) : 0);
+            addReplyLongLong(c,d ? dictSize(d) : 0);
         }
     } else {
         addReplySubcommandSyntaxError(c);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -261,7 +261,7 @@ int pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
         } else {
             clients = dictGetVal(de);
         }
-        serverAssert(dictAdd(clients, c, NULL) != NULL);
+        serverAssert(dictAdd(clients, c, NULL) != DICT_ERR);
     }
     /* Notify the client */
     addReplyPubsubSubscribed(c,channel,type);
@@ -355,7 +355,7 @@ int pubsubSubscribePattern(client *c, robj *pattern) {
         } else {
             clients = dictGetVal(de);
         }
-        serverAssert(dictAdd(clients, c, NULL) != NULL);
+        serverAssert(dictAdd(clients, c, NULL) != DICT_ERR);
     }
     /* Notify the client */
     addReplyPubsubPatSubscribed(c,pattern);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -95,28 +95,6 @@ pubsubtype pubSubShardType = {
     .messageBulk = &shared.smessagebulk,
 };
 
-uint64_t clientHash(const void *key) {
-    return ((client *)key)->id;
-}
-
-int clientKeyCompare(dict *d, const void *key1, const void *key2) {
-    uint64_t l1,l2;
-    UNUSED(d);
-
-    l1 = ((client *)key1)->id;
-    l2 = ((client *)key2)->id;
-    return l1 == l2;
-}
-
-/* Set dictionary type. Keys are client, values are not used. */
-dictType clientDictType = {
-    clientHash,               /* hash function */
-    NULL,                     /* key dup */
-    NULL,                     /* val dup */
-    clientKeyCompare,         /* key compare */
-    .no_value = 1             /* no values in this dict */
-};
-
 /*-----------------------------------------------------------------------------
  * Pubsub client replies API
  *----------------------------------------------------------------------------*/
@@ -283,7 +261,7 @@ int pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
         } else {
             clients = dictGetVal(de);
         }
-        serverAssert(dictAddRaw(clients, c, NULL) != NULL);
+        serverAssert(dictAdd(clients, c, NULL) != NULL);
     }
     /* Notify the client */
     addReplyPubsubSubscribed(c,channel,type);
@@ -377,7 +355,7 @@ int pubsubSubscribePattern(client *c, robj *pattern) {
         } else {
             clients = dictGetVal(de);
         }
-        serverAssert(dictAddRaw(clients, c, NULL) != NULL);
+        serverAssert(dictAdd(clients, c, NULL) != NULL);
     }
     /* Notify the client */
     addReplyPubsubPatSubscribed(c,pattern);
@@ -519,7 +497,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
             if (!stringmatchlen((char*)pattern->ptr,
                                 sdslen(pattern->ptr),
                                 (char*)channel->ptr,
-                                sdslen(channel->ptr),0)) continue;            
+                                sdslen(channel->ptr),0)) continue;
             dictEntry *entry;
             dictIterator *iter = dictGetSafeIterator(clients);
             while ((entry = dictNext(iter)) != NULL) {

--- a/src/server.c
+++ b/src/server.c
@@ -364,12 +364,8 @@ uint64_t dictClientHash(const void *key) {
 
 /* Dict compare function for client */
 int dictClientKeyCompare(dict *d, const void *key1, const void *key2) {
-    uint64_t l1,l2;
     UNUSED(d);
-
-    l1 = ((client *)key1)->id;
-    l2 = ((client *)key2)->id;
-    return l1 == l2;
+    return ((client *)key1)->id == ((client *)key2)->id;
 }
 
 /* Dict compare function for null terminated string */
@@ -608,7 +604,7 @@ dictType keylistDictType = {
 
 /* KeyDict hash table type has unencoded redis objects as keys and
  * dicts as values. It's used for PUBSUB command to track clients subscribing the channels. */
-dictType keydictDictType = {
+dictType objToDictDictType = {
     dictObjHash,                /* hash function */
     NULL,                       /* key dup */
     NULL,                       /* val dup */
@@ -679,11 +675,11 @@ dictType sdsHashDictType = {
 
 /* Client Set dictionary type. Keys are client, values are not used. */
 dictType clientDictType = {
-    dictClientHash,               /* hash function */
-    NULL,                     /* key dup */
-    NULL,                     /* val dup */
-    dictClientKeyCompare,         /* key compare */
-    .no_value = 1             /* no values in this dict */
+    dictClientHash,             /* hash function */
+    NULL,                       /* key dup */
+    NULL,                       /* val dup */
+    dictClientKeyCompare,       /* key compare */
+    .no_value = 1               /* no values in this dict */
 };
 
 int htNeedsResize(dict *dict) {
@@ -2795,9 +2791,9 @@ void initServer(void) {
         listSetFreeMethod(server.db[j].defrag_later,(void (*)(void*))sdsfree);
     }
     evictionPoolAlloc(); /* Initialize the LRU keys pool. */
-    server.pubsub_channels = dictCreate(&keydictDictType);
-    server.pubsub_patterns = dictCreate(&keydictDictType);
-    server.pubsubshard_channels = dictCreate(&keydictDictType);
+    server.pubsub_channels = dictCreate(&objToDictDictType);
+    server.pubsub_patterns = dictCreate(&objToDictDictType);
+    server.pubsubshard_channels = dictCreate(&objToDictDictType);
     server.cronloops = 0;
     server.in_exec = 0;
     server.busy_module_yield_flags = BUSY_MODULE_YIELD_NONE;

--- a/src/server.c
+++ b/src/server.c
@@ -357,6 +357,21 @@ uint64_t dictCStrCaseHash(const void *key) {
     return dictGenCaseHashFunction((unsigned char*)key, strlen((char*)key));
 }
 
+/* Dict hash function for client */
+uint64_t dictClientHash(const void *key) {
+    return ((client *)key)->id;
+}
+
+/* Dict compare function for client */
+int dictClientKeyCompare(dict *d, const void *key1, const void *key2) {
+    uint64_t l1,l2;
+    UNUSED(d);
+
+    l1 = ((client *)key1)->id;
+    l2 = ((client *)key2)->id;
+    return l1 == l2;
+}
+
 /* Dict compare function for null terminated string */
 int dictCStrKeyCompare(dict *d, const void *key1, const void *key2) {
     int l1,l2;
@@ -660,6 +675,15 @@ dictType sdsHashDictType = {
     dictSdsDestructor,          /* key destructor */
     dictVanillaFree,            /* val destructor */
     NULL                        /* allow to expand */
+};
+
+/* Client Set dictionary type. Keys are client, values are not used. */
+dictType clientDictType = {
+    dictClientHash,               /* hash function */
+    NULL,                     /* key dup */
+    NULL,                     /* val dup */
+    dictClientKeyCompare,         /* key compare */
+    .no_value = 1             /* no values in this dict */
 };
 
 int htNeedsResize(dict *dict) {

--- a/src/server.h
+++ b/src/server.h
@@ -2487,6 +2487,7 @@ extern dictType hashDictType;
 extern dictType stringSetDictType;
 extern dictType externalStringType;
 extern dictType sdsHashDictType;
+extern dictType clientDictType;
 extern dictType dbExpiresDictType;
 extern dictType modulesDictType;
 extern dictType sdsReplyDictType;


### PR DESCRIPTION
I'm testing the performance of Pub/Sub command recently. I find if many clients unsubscribe or are killed simultaneously, Redis needs a long time to deal with it. 

In my experiment, I set 5000 clients and each client subscribes 100 channels. Then I call `client kill type pubsub` to simulate the situation where clients unsubscribe all channels at the same time and calculate the execution time. The result shows that it takes about 23s. I use the _perf_ and find that `listSearchKey` in `pubsubUnsubscribeChannel` costs more than 90% cpu time. I think we can optimize this situation.

In this PR, I replace list with dict to track the clients subscribing the channel more efficiently. It changes O(N) to O(1) in the search phase. Then I repeat the experiment as above. The results are as follows.

|              | Execution Time(s) |used_memory(MB) |
| :---------------- | :------: | :----: |
| unstable(1bd0b54)        |   23.734   | 65.41 |
| optimize-pubsub           |   0.288   | 67.66 |

Thanks for #11595 , I use a no-value dict and the results shows that the performance improves significantly but the memory usage only increases slightly.

Notice:

- This PR will cause the performance degradation about 20% in `[p|s]subscribe` command but won't freeze Redis.

