### PR TITLE
Fix replica node cannot expand dicts when loading legacy RDB

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -80,7 +80,7 @@ int clusterNodeIsMyself(clusterNode *n);
 clusterNode *getMyClusterNode(void);
 char *getMyClusterId(void);
 int getClusterSize(void);
-int getMyClusterSlotCount(void);
+int getMyShardSlotCount(void);
 int handleDebugClusterCommand(client *c);
 int clusterNodePending(clusterNode  *node);
 int clusterNodeIsMaster(clusterNode *n);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5781,8 +5781,14 @@ int getClusterSize(void) {
     return dictSize(server.cluster->nodes);
 }
 
-int getMyClusterSlotCount(void) {
-    return server.cluster->myself->numslots;
+int getMyShardSlotCount(void) {
+    if (!nodeIsSlave(server.cluster->myself)) {
+        return server.cluster->myself->numslots;
+    } else if (server.cluster->myself->slaveof) {
+        return server.cluster->myself->slaveof->numslots;
+    } else {
+        return 0;
+    }
 }
 
 char **getClusterNodesList(size_t *numnodes) {

--- a/src/db.c
+++ b/src/db.c
@@ -2215,7 +2215,7 @@ int dbExpand(const redisDb *db, uint64_t db_size, dbKeyType keyType, int try_exp
     if (server.cluster_enabled) {
         /* We don't know exact number of keys that would fall into each slot, but we can
          * approximate it, assuming even distribution, divide it by the number of slots. */
-        int slots = getMyClusterSlotCount();
+        int slots = getMyShardSlotCount();
         if (slots == 0) return C_OK;
         db_size = db_size / slots;
 


### PR DESCRIPTION
When loading RDB on cluster nodes, it is necessary to consider the scenario where a node is a replica.

For example, during a rolling upgrade, new version instances are often mounted as replicas on old version instances. In this case, the full synchronization legacy RDB does not contain slot information, and the new version instance, acting as a replica, should be able to handle the legacy RDB correctly for `dbExpand`.

Additionally, renaming `getMyClusterSlotCount` to `getMyShardSlotCount` would be appropriate.

Introduced in #11695