### PR TITLE
Fix multi dbs donot dbExpand when loading RDB

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3035,7 +3035,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
     uint64_t dbid = 0;
     int type, rdbver;
     uint64_t db_size = 0, expires_size = 0;
-    int should_expand_db = 1;
+    int should_expand_db = 0;
     redisDb *db = rdb_loading_ctx->dbarray+0;
     char buf[1024];
     int error;
@@ -3115,6 +3115,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                 goto eoferr;
             if ((expires_size = rdbLoadLen(rdb,NULL)) == RDB_LENERR)
                 goto eoferr;
+            should_expand_db = 1;
             continue; /* Read next opcode. */
         } else if (type == RDB_OPCODE_SLOT_INFO) {
             uint64_t slot_id, slot_size, expires_slot_size;


### PR DESCRIPTION
Currently, during RDB loading, once a `dbExpand` is performed, the `should_expand_db` flag is set to 0. This causes the remaining DBs unable to do `dbExpand` when there are multiple DBs.

To fix this issue, we need to set `should_expand_db` back to 1 whenever we encounter `RDB_OPCODE_RESIZEDB`. This ensures that each DB can perform `dbExpand` correctly.

Additionally, the initial value of `should_expand_db` should also be set to 0 to prevent invalid `dbExpand` in older versions of RDB where `RDB_OPCODE_RESIZEDB` is not present.

problem introduced in #11695