### PR TITLE
coverity.yml: Upload should go to project redis-unstable

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
           tar czvf cov-int.tgz cov-int
           curl \
-            --form project=redis \
+            --form project=redis-unstable \
             --form email=${{ secrets.COVERITY_SCAN_EMAIL }} \
             --form token=${{ secrets.COVERITY_SCAN_TOKEN }} \
             --form file=@cov-int.tgz \


### PR DESCRIPTION
Coverity project name was changed from redis to redis-unstable. Fix the upload destination to also go to redis-unstable.

Continuation of #12807