### PR TITLE
Fix rehashingStarted miscalculating bucket_count in dict initialization

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -270,7 +270,7 @@ int _dictExpand(dict *d, unsigned long size, int* malloc_failed)
      * it can accept keys. */
     if (d->ht_table[0] == NULL || d->ht_used[0] == 0) {
         if (d->type->rehashingCompleted) d->type->rehashingCompleted(d);
-        if (d->ht_used[0] == 0) zfree(d->ht_table[0]);
+        if (d->ht_table[0] && d->ht_used[0] == 0) zfree(d->ht_table[0]);
         d->ht_size_exp[0] = new_ht_size_exp;
         d->ht_used[0] = new_ht_used;
         d->ht_table[0] = new_ht_table;

--- a/src/dict.c
+++ b/src/dict.c
@@ -270,7 +270,7 @@ int _dictExpand(dict *d, unsigned long size, int* malloc_failed)
      * it can accept keys. */
     if (d->ht_table[0] == NULL || d->ht_used[0] == 0) {
         if (d->type->rehashingCompleted) d->type->rehashingCompleted(d);
-        if (d->ht_table[0] && d->ht_used[0] == 0) zfree(d->ht_table[0]);
+        if (d->ht_table[0]) zfree(d->ht_table[0]);
         d->ht_size_exp[0] = new_ht_size_exp;
         d->ht_used[0] = new_ht_used;
         d->ht_table[0] = new_ht_table;

--- a/src/dict.c
+++ b/src/dict.c
@@ -238,7 +238,7 @@ int _dictExpand(dict *d, unsigned long size, int* malloc_failed)
     signed char new_ht_size_exp = _dictNextExp(size);
 
     /* Detect overflows */
-    size_t newsize = 1ul<<new_ht_size_exp;
+    size_t newsize = DICTHT_SIZE(new_ht_size_exp);
     if (newsize < size || newsize * sizeof(dictEntry*) < newsize)
         return DICT_ERR;
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -256,15 +256,18 @@ int _dictExpand(dict *d, unsigned long size, int* malloc_failed)
 
     new_ht_used = 0;
 
-    /* Prepare a second hash table for incremental rehashing. */
+    /* Prepare a second hash table for incremental rehashing.
+     * We do this even for the first initialization, so that we can trigger the
+     * rehashingStarted more conveniently, we will clean it up right after. */
     d->ht_size_exp[1] = new_ht_size_exp;
     d->ht_used[1] = new_ht_used;
     d->ht_table[1] = new_ht_table;
     d->rehashidx = 0;
     if (d->type->rehashingStarted) d->type->rehashingStarted(d);
 
-    /* Is this the first initialization or is the old ht empty? If so it's not really a rehashing
-     * we just set the first hash table so that it can accept keys. */
+    /* Is this the first initialization or is the first hash table empty? If so
+     * it's not really a rehashing, we can just set the first hash table so that
+     * it can accept keys. */
     if (d->ht_table[0] == NULL || d->ht_used[0] == 0) {
         if (d->type->rehashingCompleted) d->type->rehashingCompleted(d);
         if (d->ht_used[0] == 0) zfree(d->ht_table[0]);

--- a/src/dict.h
+++ b/src/dict.h
@@ -222,7 +222,7 @@ unsigned long dictScan(dict *d, unsigned long v, dictScanFunction *fn, void *pri
 unsigned long dictScanDefrag(dict *d, unsigned long v, dictScanFunction *fn, dictDefragFunctions *defragfns, void *privdata);
 uint64_t dictGetHash(dict *d, const void *key);
 dictEntry *dictFindEntryByPtrAndHash(dict *d, const void *oldptr, uint64_t hash);
-void dictRehashingInfo(dict *d, unsigned long long *from, unsigned long long *to);
+void dictRehashingInfo(dict *d, unsigned long long *from_size, unsigned long long *to_size);
 
 size_t dictGetStatsMsg(char *buf, size_t bufsize, dictStats *stats, int full);
 dictStats* dictGetStatsHt(dict *d, int htidx, int full);

--- a/src/server.c
+++ b/src/server.c
@@ -426,45 +426,42 @@ int dictExpandAllowed(size_t moreMem, double usedRatio) {
  * 
  * In non-cluster mode, bucket count can be retrieved directly from single dict bucket and
  * we don't need this list as there is only one dictionary per DB. */
-void dictRehashingStarted(dict *d) {
+void dictRehashingStartedByKeyType(dict *d, dbKeyType keyType) {
     if (!server.cluster_enabled) return;
 
     unsigned long long from, to;
     dictRehashingInfo(d, &from, &to);
-    server.db[0].sub_dict[DB_MAIN].bucket_count += to; /* Started rehashing (Add the new ht size) */
+    server.db[0].sub_dict[keyType].bucket_count += to; /* Started rehashing (Add the new ht size) */
     if (from == 0) return; /* No entries are to be moved. */
     if (server.activerehashing) {
-        listAddNodeTail(server.db[0].sub_dict[DB_MAIN].rehashing, d);
+        listAddNodeTail(server.db[0].sub_dict[keyType].rehashing, d);
     }
 }
 
 /* Updates the bucket count for the given dictionary in a DB. It removes
  * the old ht size of the dictionary from the total sum of buckets for a DB.  */
-void dictRehashingCompleted(dict *d) {
+void dictRehashingCompletedByKeyType(dict *d, dbKeyType keyType) {
     if (!server.cluster_enabled) return;
+
     unsigned long long from, to;
     dictRehashingInfo(d, &from, &to);
-    server.db[0].sub_dict[DB_MAIN].bucket_count -= from; /* Finished rehashing (Remove the old ht size) */
+    server.db[0].sub_dict[keyType].bucket_count -= from; /* Finished rehashing (Remove the old ht size) */
+}
+
+void dictRehashingStarted(dict *d) {
+    dictRehashingStartedByKeyType(d, DB_MAIN);
+}
+
+void dictRehashingCompleted(dict *d) {
+    dictRehashingCompletedByKeyType(d, DB_MAIN);
 }
 
 void dictRehashingStartedForExpires(dict *d) {
-    if (!server.cluster_enabled) return;
-
-    unsigned long long from, to;
-    dictRehashingInfo(d, &from, &to);
-    server.db[0].sub_dict[DB_EXPIRES].bucket_count += to; /* Started rehashing (Add the new ht size) */
-    if (from == 0) return; /* No entries are to be moved. */
-    if (server.activerehashing) {
-        listAddNodeTail(server.db[0].sub_dict[DB_EXPIRES].rehashing, d);
-    }
+    dictRehashingStartedByKeyType(d, DB_EXPIRES);
 }
 
 void dictRehashingCompletedForExpires(dict *d) {
-    if (!server.cluster_enabled) return;
-
-    unsigned long long from, to;
-    dictRehashingInfo(d, &from, &to);
-    server.db[0].sub_dict[DB_EXPIRES].bucket_count -= from; /* Finished rehashing (Remove the old ht size) */
+    dictRehashingCompletedByKeyType(d, DB_EXPIRES);
 }
 
 /* Generic hash table type where keys are Redis Objects, Values


### PR DESCRIPTION
In the old dictRehashingInfo implementation, for the initialization scenario,
it mistakenly directly set to_size to DICTHT_SIZE(DICT_HT_INITIAL_EXP), which
is 4 in our code by default.

In scenarios where dictExpand directly passes the target size as initialization,
the code will calculate bucket_count incorrectly. For example, in DEBUG POPULATE
or RDB load scenarios, it will cause the final bucket_count to be initialized to
65536 (16384 * 4), see:
```
before:
DB 0: 10000000 keys (0 volatile) in 65536 slots HT.

it should be:
DB 0: 10000000 keys (0 volatile) in 16777216 slots HT.
```

In PR, new ht will also be initialized before calling rehashingStarted in
_dictExpand, so that the calls in dictRehashingInfo can be unified.

Bug was introduced in #12697.