### PR TITLE
fix comment of aeProcessEvents

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -343,8 +343,8 @@ static int processTimeEvents(aeEventLoop *eventLoop) {
     return processed;
 }
 
-/* Process every pending time event, then every pending file event
- * (that may be registered by time event callbacks just processed).
+/* Process every pending file event, then every pending time event
+ * (that may be registered by file event callbacks just processed).
  * Without special flags the function sleeps until some file event
  * fires, or when the next time event occurs (if any).
  *


### PR DESCRIPTION
The implementation of aeProcessEvents seems have different behavior from the top comment.
The implementation process file events first, then process time events.