### PR TITLE
Fix oom-score-adj test due to no permission

### DIFF
--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -101,23 +101,27 @@ if {$system_name eq {linux}} {
 
         test {CONFIG SET oom score restored on disable} {
             r config set oom-score-adj no
-            set_oom_score_adj 22
-            assert_equal [get_oom_score_adj] 22
+            set custom_oom [expr [get_oom_score_adj] + 1]
+            set_oom_score_adj $custom_oom
+            assert_equal [get_oom_score_adj] $custom_oom
 
             r config set oom-score-adj-values "9 9 9" oom-score-adj yes
-            assert_equal [get_oom_score_adj] [expr 9+22]
+            assert_equal [get_oom_score_adj] [expr 9+$custom_oom]
 
             r config set oom-score-adj no
-            assert_equal [get_oom_score_adj] 22
+            assert_equal [get_oom_score_adj] $custom_oom
         }
 
         test {CONFIG SET oom score relative and absolute} {
-            set custom_oom 9
+            set custom_oom [expr [get_oom_score_adj] + 1]
             r config set oom-score-adj no
             set base_oom [get_oom_score_adj]
 
             r config set oom-score-adj-values "$custom_oom $custom_oom $custom_oom" oom-score-adj relative
-            assert_equal [get_oom_score_adj] [expr $base_oom+$custom_oom]
+            # Check that current oom_score_adj is between base_oom and base_oom+custom_oom,
+            # which may exceed the limit.
+            set current_oom [get_oom_score_adj]
+            assert {$current_oom > $base_oom && $current_oom <= [expr $base_oom+$custom_oom]}
 
             r config set oom-score-adj absolute
             assert_equal [get_oom_score_adj] $custom_oom

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -113,17 +113,18 @@ if {$system_name eq {linux}} {
         }
 
         test {CONFIG SET oom score relative and absolute} {
-            set custom_oom [expr [get_oom_score_adj] + 1]
             r config set oom-score-adj no
             set base_oom [get_oom_score_adj]
 
+            set custom_oom 9
             r config set oom-score-adj-values "$custom_oom $custom_oom $custom_oom" oom-score-adj relative
             # Check that current oom_score_adj is between base_oom and base_oom+custom_oom,
             # which may exceed the limit.
             set current_oom [get_oom_score_adj]
             assert {$current_oom > $base_oom && $current_oom <= [expr $base_oom+$custom_oom]}
 
-            r config set oom-score-adj absolute
+            set custom_oom [expr [get_oom_score_adj] + 1]
+            r config set "$custom_oom $custom_oom $custom_oom" oom-score-adj absolute
             assert_equal [get_oom_score_adj] $custom_oom
         }
 

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -121,7 +121,7 @@ if {$system_name eq {linux}} {
             assert_equal [get_oom_score_adj] [expr $base_oom+$custom_oom]
 
             set custom_oom [expr [get_oom_score_adj] + 1]
-             config set oom-score-adj-values "$custom_oom $custom_oom $custom_oom" oom-score-adj absolute
+            r config set oom-score-adj-values "$custom_oom $custom_oom $custom_oom" oom-score-adj absolute
             assert_equal [get_oom_score_adj] $custom_oom
         }
 

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -118,13 +118,10 @@ if {$system_name eq {linux}} {
 
             set custom_oom 9
             r config set oom-score-adj-values "$custom_oom $custom_oom $custom_oom" oom-score-adj relative
-            # Check that current oom_score_adj is between base_oom and base_oom+custom_oom,
-            # which may exceed the limit.
-            set current_oom [get_oom_score_adj]
-            assert {$current_oom > $base_oom && $current_oom <= [expr $base_oom+$custom_oom]}
+            assert_equal [get_oom_score_adj] [expr $base_oom+$custom_oom]
 
             set custom_oom [expr [get_oom_score_adj] + 1]
-            r config set "$custom_oom $custom_oom $custom_oom" oom-score-adj absolute
+             config set oom-score-adj-values "$custom_oom $custom_oom $custom_oom" oom-score-adj absolute
             assert_equal [get_oom_score_adj] $custom_oom
         }
 


### PR DESCRIPTION
Fix #12792

On ubuntu 23(lunar), non-root users will not be allowed to change the oom_score_adj of a process to a value that is too low.
Since terminal's default oom_score_adj is 200, if we run the test on terminal, we won't be able to set the oom_score_adj of the redis process to 9 or 22, which is too low.

Reproduction on ubuntu 23(lunar) terminal:
```sh
$ cat /proc/`pgrep redis-server`/oom_score_adj
200
$ echo 100 > /proc/`pgrep redis-server`/oom_score_adj
# success without error
$ echo 99 > /proc/`pgrep redis-server`/oom_score_adj
echo: write error: Permission denied
```

As from the output above, we can only set the minimum oom score of redis processes to 100.
By modifying the test, make oom_score_adj only increase upwards and not decrease.