### PR TITLE
Allow non-denyoom commands in MULTI on OOM

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4076,12 +4076,13 @@ int processCommand(client *c) {
         if (server.current_client == NULL) return C_ERR;
 
         int reject_cmd_on_oom = is_denyoom_command;
-        /* If client is in MULTI/EXEC context, queuing may consume an unlimited
-         * amount of memory, so we want to stop that.
+        /* If client is in MULTI/EXEC context, even if no DENYOOM command is used, 
+         * we want to limit the amount of memory used for queuing.
          * However, we never want to reject DISCARD, or even EXEC (unless it
          * contains denied commands, in which case is_denyoom_command is already
          * set. */
         if (c->flags & CLIENT_MULTI &&
+            c->mstate.argv_len_sums > MULTI_MAX_BYTES_ON_OOM && 
             c->cmd->proc != execCommand &&
             c->cmd->proc != discardCommand &&
             c->cmd->proc != quitCommand &&

--- a/src/server.h
+++ b/src/server.h
@@ -138,6 +138,7 @@ struct hdr_histogram;
 #define CONFIG_MIN_RESERVED_FDS 32
 #define CONFIG_DEFAULT_PROC_TITLE_TEMPLATE "{title} {listen-addr} {server-mode}"
 #define INCREMENTAL_REHASHING_THRESHOLD_US 1000
+#define MULTI_MAX_BYTES_ON_OOM (1024*32)
 
 /* Bucket sizes for client eviction pools. Each bucket stores clients with
  * memory usage of up to twice the size of the bucket below it. */


### PR DESCRIPTION
Allow queuing of multi commands up to 32kb when server is at maxmemory as long as there are no DENY-OOM commands.
Fixes: https://github.com/redis/redis/issues/9926