### PR TITLE
Add new command MEXISTS to return list of existing at the specified keys

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -1945,6 +1945,32 @@ struct COMMAND_ARG KEYS_Args[] = {
 {MAKE_ARG("pattern",ARG_TYPE_PATTERN,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
+/********** MEXISTS ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* MEXISTS history */
+#define MEXISTS_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* MEXISTS tips */
+const char *MEXISTS_Tips[] = {
+"request_policy:multi_shard",
+};
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* MEXISTS key specs */
+keySpec MEXISTS_Keyspecs[1] = {
+{NULL,CMD_KEY_RO,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={-1,1,0}}
+};
+#endif
+
+/* MEXISTS argument table */
+struct COMMAND_ARG MEXISTS_Args[] = {
+{MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_MULTIPLE,0,NULL)},
+};
+
 /********** MIGRATE ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -10667,6 +10693,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("expireat","Sets the expiration time of a key to a Unix timestamp.","O(1)","1.2.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,EXPIREAT_History,1,EXPIREAT_Tips,0,expireatCommand,-3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_KEYSPACE,EXPIREAT_Keyspecs,1,NULL,3),.args=EXPIREAT_Args},
 {MAKE_CMD("expiretime","Returns the expiration time of a key as a Unix timestamp.","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,EXPIRETIME_History,0,EXPIRETIME_Tips,0,expiretimeCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_KEYSPACE,EXPIRETIME_Keyspecs,1,NULL,1),.args=EXPIRETIME_Args},
 {MAKE_CMD("keys","Returns all key names that match a pattern.","O(N) with N being the number of keys in the database, under the assumption that the key names in the database and the given pattern have limited length.","1.0.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,KEYS_History,0,KEYS_Tips,2,keysCommand,2,CMD_READONLY,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,KEYS_Keyspecs,0,NULL,1),.args=KEYS_Args},
+{MAKE_CMD("mexists","Determines whether one or more keys exist but returns list of existing at the specified keys","O(N) where N is the number of keys to check.","8.0.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,MEXISTS_History,0,MEXISTS_Tips,1,mexistsCommand,-2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_KEYSPACE,MEXISTS_Keyspecs,1,NULL,1),.args=MEXISTS_Args},
 {MAKE_CMD("migrate","Atomically transfers a key from one Redis instance to another.","This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.","2.6.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,MIGRATE_History,4,MIGRATE_Tips,1,migrateCommand,-6,CMD_WRITE,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,MIGRATE_Keyspecs,2,migrateGetKeys,9),.args=MIGRATE_Args},
 {MAKE_CMD("move","Moves a key to another database.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,MOVE_History,0,MOVE_Tips,0,moveCommand,3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_KEYSPACE,MOVE_Keyspecs,1,NULL,2),.args=MOVE_Args},
 {MAKE_CMD("object","A container for object introspection commands.","Depends on subcommand.","2.2.3",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,OBJECT_History,0,OBJECT_Tips,0,NULL,-2,0,0,OBJECT_Keyspecs,0,NULL,0),.subcommands=OBJECT_Subcommands},

--- a/src/commands/mexists.json
+++ b/src/commands/mexists.json
@@ -1,0 +1,57 @@
+{
+    "MEXISTS": {
+        "summary": "Determines whether one or more keys exist but returns list of existing at the specified keys",
+        "complexity": "O(N) where N is the number of keys to check.",
+        "group": "generic",
+        "since": "8.0.0",
+        "arity": -2,
+        "function": "mexistsCommand",
+        "history": [],
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "KEYSPACE"
+        ],
+        "command_tips": [
+            "REQUEST_POLICY:MULTI_SHARD"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": -1,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "List of existing at the specified keys.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "boolean"
+            }
+
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0,
+                "multiple": true
+            }
+        ]
+    }
+}

--- a/src/db.c
+++ b/src/db.c
@@ -977,6 +977,21 @@ void existsCommand(client *c) {
     addReplyLongLong(c,count);
 }
 
+/* MEXISTS key1 key2 ... key_N.
+ * Return value is the list of existing at the specified keys */
+void mexistsCommand(client *c) {
+    int j;
+
+    addReplyArrayLen(c, c->argc-1);
+    for (j = 1; j < c->argc; j++) {
+        if (lookupKeyReadWithFlags(c->db,c->argv[j],LOOKUP_NOTOUCH)) {
+          addReplyBool(c, 1);
+        } else {
+          addReplyBool(c, 0);
+        }
+    }
+}
+
 void selectCommand(client *c) {
     int id;
 

--- a/src/server.h
+++ b/src/server.h
@@ -3517,6 +3517,7 @@ void getdelCommand(client *c);
 void delCommand(client *c);
 void unlinkCommand(client *c);
 void existsCommand(client *c);
+void mexistsCommand(client *c);
 void setbitCommand(client *c);
 void getbitCommand(client *c);
 void bitfieldCommand(client *c);

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -71,6 +71,12 @@ start_server {tags {"keyspace"}} {
         append res [r exists emptykey]
     } {10}
 
+    test {MEXISTS} {
+        r set a 1
+        r set b 2
+        r mexists a b c d
+    } {1 1 0 0}
+
     test {Commands pipelining} {
         set fd [r channel]
         puts -nonewline $fd "SET k1 xyzk\r\nGET k1\r\nPING\r\n"

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -72,6 +72,7 @@ start_server {tags {"keyspace"}} {
     } {10}
 
     test {MEXISTS} {
+        r del a{t} b{t} c{t} d{t}
         r set a{t} 1
         r set b{t} 2
         r mexists a{t} b{t} c{t} d{t}

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -72,9 +72,9 @@ start_server {tags {"keyspace"}} {
     } {10}
 
     test {MEXISTS} {
-        r set a 1
-        r set b 2
-        r mexists a b c d
+        r set a{t} 1
+        r set b{t} 2
+        r mexists a{t} b{t} c{t} d{t}
     } {1 1 0 0}
 
     test {Commands pipelining} {


### PR DESCRIPTION
This closes #12890 

Currently, the EXISTS command accepts multiple keys
but returns the total number of existing keys. In most scenarios,
we want to know which keys exist, so add the MEXISTS command
to resolve this.

```
redis-cli > SET a 1
OK
redis-cli > SET b 2
OK
redis-cli > MEXISTS a b c d
1) 1
2) 1
3) 0
4) 0
```