### PR TITLE
Reorder signalModifiedKey in xaddCommand.

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2052,7 +2052,6 @@ void xaddCommand(client *c) {
     sds replyid = createStreamIDString(&id);
     addReplyBulkCBuffer(c, replyid, sdslen(replyid));
 
-    signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_STREAM,"xadd",c->argv[1],c->db->id);
     server.dirty++;
 
@@ -2071,6 +2070,8 @@ void xaddCommand(client *c) {
             streamRewriteTrimArgument(c,s,parsed_args.trim_strategy,parsed_args.trim_strategy_arg_idx);
         }
     }
+
+    signalModifiedKey(c,c->db,c->argv[1]);
 
     /* Let's rewrite the ID argument with the one actually generated for
      * AOF/replication propagation. */


### PR DESCRIPTION
This PR is a supplement to #11144, moving `signalModifiedKey` in `xaddCommand` after the trimming, to ensure the state of key eventual consistency. Currently there is no problem with Redis, but it is better to avoid issues in future development on Redis.