### PR TITLE
Fix crash caused by pubsubShardUnsubscribeAllChannelsInSlot not deleting the client

### DIFF
--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -295,8 +295,10 @@ int pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
         d_ptr = type.serverPubSubChannels(slot);
         if (*d_ptr == NULL) {
             *d_ptr = dictCreate(&keylistDictType);
+            de = NULL;
+        } else {
+            de = dictFind(*d_ptr, channel);
         }
-        de = dictFind(*d_ptr, channel);
         if (de == NULL) {
             clients = listCreate();
             dictAdd(*d_ptr, channel, clients);
@@ -387,6 +389,7 @@ void pubsubShardUnsubscribeAllChannelsInSlot(unsigned int slot) {
             if (clientTotalPubSubSubscriptionCount(c) == 0) {
                 unmarkClientAsPubSub(c);
             }
+            listDelNode(clients, ln);
         }
         server.shard_channel_count--;
         dictDelete(d, channel);


### PR DESCRIPTION
The code does not delete the corresponding node when traversing clients,
resulting in a loop, causing the dictDelete() == DICT_OK assertion to fail.

In addition, did a cleanup, in the dictCreate scenario, we can avoid a
dictFind call since the dict is empty.

Issue was introduced in #12804.
