### PR TITLE
Correct bytes_per_key computing.

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -1274,7 +1274,7 @@ struct redisMemOverhead *getMemoryOverheadData(void) {
     if (zmalloc_used > mh->startup_allocated)
         net_usage = zmalloc_used - mh->startup_allocated;
     mh->dataset_perc = (float)mh->dataset*100/net_usage;
-    mh->bytes_per_key = mh->total_keys ? (net_usage / mh->total_keys) : 0;
+    mh->bytes_per_key = mh->total_keys ? (mh->dataset / mh->total_keys) : 0;
 
     return mh;
 }


### PR DESCRIPTION
Change the calculation method of `bytes_per_key` to make it closer to the true average key size. The calculation method is as follows:
```
mh->bytes_per_key = mh->total_keys ? (mh->dataset / mh->total_keys) : 0;
```