### PR TITLE
Provide instantaneous command duration metrics in INFO

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1381,6 +1381,8 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
                                  current_time, factor);
         trackInstantaneousMetric(STATS_METRIC_EL_DURATION, server.duration_stats[EL_DURATION_TYPE_EL].sum,
                                  server.duration_stats[EL_DURATION_TYPE_EL].cnt, 1);
+        trackInstantaneousMetric(STATS_METRIC_CMD_DURATION, server.duration_stats[EL_DURATION_TYPE_CMD].sum,
+                                 server.duration_stats[EL_DURATION_TYPE_CMD].cnt, 1);
     }
 
     /* We have just LRU_BITS bits per object for LRU information.
@@ -5910,7 +5912,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "eventloop_duration_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_EL].sum,
             "eventloop_duration_cmd_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_CMD].sum,
             "instantaneous_eventloop_cycles_per_sec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_CYCLE),
-            "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION)));
+            "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION),
+            "instantaneous_command_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_CMD_DURATION)));
         info = genRedisInfoStringACLStats(info);
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -170,7 +170,8 @@ struct hdr_histogram;
 #define STATS_METRIC_NET_OUTPUT_REPLICATION 4   /* Bytes written to network during replication. */
 #define STATS_METRIC_EL_CYCLE 5     /* Number of eventloop cycled. */
 #define STATS_METRIC_EL_DURATION 6  /* Eventloop duration. */
-#define STATS_METRIC_COUNT 7
+#define STATS_METRIC_CMD_DURATION 7  /* Command duration. */
+#define STATS_METRIC_COUNT 8
 
 /* Protocol and I/O related defines */
 #define PROTO_IOBUF_LEN         (1024*16)  /* Generic I/O buffer size */


### PR DESCRIPTION
I was hoping to expose some instantaneous metrics related to command latency, and it looks like most of the infrastructure is in place to do so. This PR extends the established pattern of calculating and reporting instantaneous metrics to the existing command duration measurements.