### PR TITLE
fix scripts access wrong slot if they disagree with pre-declared keys

### DIFF
--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -290,7 +290,7 @@ int pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
         incrRefCount(channel);
         /* Add the client to the channel -> list of clients hash table */
         if (server.cluster_enabled && type.shard) {
-            slot = c->slot;
+            slot = getKeySlot(channel->ptr);
         }
         d_ptr = type.serverPubSubChannels(slot);
         if (*d_ptr == NULL) {
@@ -333,7 +333,7 @@ int pubsubUnsubscribeChannel(client *c, robj *channel, int notify, pubsubtype ty
         retval = 1;
         /* Remove the client from the channel -> clients list hash table */
         if (server.cluster_enabled && type.shard) {
-            slot = c->slot != -1 ? c->slot : (int)keyHashSlot(channel->ptr, sdslen(channel->ptr));
+            slot = getKeySlot(channel->ptr);
         }
         d = *type.serverPubSubChannels(slot);
         serverAssertWithInfo(c,NULL,d != NULL);

--- a/src/script.h
+++ b/src/script.h
@@ -74,6 +74,7 @@ struct scriptRunCtx {
     int flags;
     int repl_flags;
     monotime start_time;
+    int slot;
 };
 
 /* Scripts flags */

--- a/src/sort.c
+++ b/src/sort.c
@@ -239,7 +239,7 @@ void sortCommandGeneric(client *c, int readonly) {
                 /* If BY is specified with a real pattern, we can't accept it in cluster mode,
                  * unless we can make sure the keys formed by the pattern are in the same slot 
                  * as the key to sort. */
-                if (server.cluster_enabled && patternHashSlot(sortby->ptr, sdslen(sortby->ptr)) != c->slot) {
+                if (server.cluster_enabled && patternHashSlot(sortby->ptr, sdslen(sortby->ptr)) != getKeySlot(c->argv[1]->ptr)) {
                     addReplyError(c, "BY option of SORT denied in Cluster mode when "
                                  "keys formed by the pattern may be in different slots.");
                     syntax_error++;
@@ -258,7 +258,7 @@ void sortCommandGeneric(client *c, int readonly) {
             /* If GET is specified with a real pattern, we can't accept it in cluster mode,
              * unless we can make sure the keys formed by the pattern are in the same slot 
              * as the key to sort. */
-            if (server.cluster_enabled && patternHashSlot(c->argv[j+1]->ptr, sdslen(c->argv[j+1]->ptr)) != c->slot) {
+            if (server.cluster_enabled && patternHashSlot(c->argv[j+1]->ptr, sdslen(c->argv[j+1]->ptr)) != getKeySlot(c->argv[1]->ptr)) {
                 addReplyError(c, "GET option of SORT denied in Cluster mode when "
                               "keys formed by the pattern may be in different slots.");
                 syntax_error++;

--- a/tests/unit/cluster/scripting.tcl
+++ b/tests/unit/cluster/scripting.tcl
@@ -62,6 +62,10 @@ start_cluster 1 0 {tags {external:skip cluster}} {
             } 1 bar}
     }
 
+    test {Cross slot commands are allowed by default if they disagree with pre-declared keys} {
+        r 0 eval "redis.call('set', 'foo', 'bar')" 1 bar
+    }
+
     test "Function no-cluster flag" {
         R 0 function load {#!lua name=test
             redis.register_function{function_name='f1', callback=function() return 'hello' end, flags={'no-cluster'}}

--- a/tests/unit/cluster/scripting.tcl
+++ b/tests/unit/cluster/scripting.tcl
@@ -63,7 +63,12 @@ start_cluster 1 0 {tags {external:skip cluster}} {
     }
 
     test {Cross slot commands are allowed by default if they disagree with pre-declared keys} {
+        r 0 flushall
         r 0 eval "redis.call('set', 'foo', 'bar')" 1 bar
+
+        # Make sure the script writes to the right slot
+        assert_equal 1 [r 0 cluster COUNTKEYSINSLOT 12182] ;# foo slot
+        assert_equal 0 [r 0 cluster COUNTKEYSINSLOT 5061] ;# bar slot
     }
 
     test "Function no-cluster flag" {


### PR DESCRIPTION
Regarding how to obtain the hash slot of a key, there is an optimization in `getKeySlot()`, it is used to avoid redundant hash calculations for keys: when the current client is in the process of executing a command, it can directly use the slot of the current client because the slot to access has already been calculated in advance in `processCommand()`.

However, scripts are a special case where, in default mode or with `allow-cross-slot-keys` enabled, they are allowed to access keys beyond the pre-declared range. This means that the keys they operate on may not belong to the slot of the pre-declared keys. Currently, when the commands in a script are executed, the slot of the original client (i.e., the current client) is not correctly updated, leading to subsequent access to the wrong slot.

This PR fixes the above issue. When checking the cluster constraints in a script, the slot to be accessed by the current command is set for the original client (i.e., the current client). This ensures that `getKeySlot()` gets the correct slot cache.

Additionally, the following modifications are made:

1. The 'sort' and 'sort_ro' commands use `getKeySlot()` instead of `c->slot` because the client could be an engine client in a script and can lead to potential bug.
2. `getKeySlot()` is also used in pubsub to obtain the slot for the channel, standardizing the way slots are retrieved.