### PR TITLE
Fix minor fd leak in rdbSaveToSlavesSockets

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3636,6 +3636,7 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
             }
             close(rdb_pipe_write);
             close(server.rdb_pipe_read);
+            close(server.rdb_child_exit_pipe);
             zfree(server.rdb_pipe_conns);
             server.rdb_pipe_conns = NULL;
             server.rdb_pipe_numconns = 0;


### PR DESCRIPTION
We should close server.rdb_child_exit_pipe when redisFork fails,
otherwise the pipe fd will be leaked.

Just a cleanup.
