### PR TITLE
Refactor/rename checkChildrenDone

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3531,7 +3531,7 @@ void killRDBChild(void) {
     kill(server.child_pid, SIGUSR1);
     /* Because we are not using here waitpid (like we have in killAppendOnlyChild
      * and TerminateModuleForkChild), all the cleanup operations is done by
-     * checkChildrenDone, that later will find that the process killed.
+     * handleCompletedChildren, that later will find that the process killed.
      * This includes:
      * - resetChildState
      * - rdbRemoveTempFile */

--- a/src/replication.c
+++ b/src/replication.c
@@ -1228,8 +1228,9 @@ void replconfCommand(client *c) {
              * There's a chance the ACK got to us before we detected that the
              * bgsave is done (since that depends on cron ticks), so run a
              * quick check first (instead of waiting for the next ACK. */
-            if (server.child_type == CHILD_TYPE_RDB && c->replstate == SLAVE_STATE_WAIT_BGSAVE_END)
-                checkChildrenDone();
+            if (server.child_type == CHILD_TYPE_RDB && c->replstate == SLAVE_STATE_WAIT_BGSAVE_END &&
+                handleCompletedChildren())
+                replicationStartPendingFork();                
             if (c->repl_start_cmd_stream_on_ack && c->replstate == SLAVE_STATE_ONLINE)
                 replicaStartCommandStream(c);
             /* Note: this command does not reply anything! */

--- a/src/server.c
+++ b/src/server.c
@@ -1262,7 +1262,7 @@ void exitExecutionUnit(void) {
     --server.execution_nesting;
 }
 
-void checkChildrenDone(void) {
+int handleCompletedChildren(void) {
     int statloc = 0;
     pid_t pid;
 
@@ -1307,10 +1307,9 @@ void checkChildrenDone(void) {
                           (long) pid);
             }
         }
-
-        /* start any pending forks immediately. */
-        replicationStartPendingFork();
+        return 1;
     }
+    return 0;
 }
 
 /* Called from serverCron and cronUpdateMemoryStats to update cached memory metrics. */
@@ -1499,7 +1498,7 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     if (hasActiveChildProcess() || ldbPendingChildren())
     {
         run_with_period(1000) receiveChildInfo();
-        checkChildrenDone();
+        handleCompletedChildren();
     } else {
         /* If there is not a background saving/rewrite in progress check if
          * we have to save/rewrite now. */

--- a/src/server.h
+++ b/src/server.h
@@ -3129,7 +3129,7 @@ unsigned int LRU_CLOCK(void);
 const char *evictPolicyToString(void);
 struct redisMemOverhead *getMemoryOverheadData(void);
 void freeMemoryOverheadData(struct redisMemOverhead *mh);
-void checkChildrenDone(void);
+int handleCompletedChildren(void);
 int setOOMScoreAdj(int process_class);
 void rejectCommandFormat(client *c, const char *fmt, ...);
 void *activeDefragAlloc(void *ptr);


### PR DESCRIPTION
The name checkChildrenDone is misleading; it suggests a read-only operation but actually modifies a state.

I changed the function name to handleCompletedChildren. I also removed the invocation of replicationStartPendingFork, as the function should only be limited to what the name suggests. The function returns 1 if it handled a completed process, and 0 i otherwise. Code callers should check the return code and invoke replicationStartPendingFork if needed.

serverCron invokes handleCompletedChildren but there's no need to check the return code and invoke replicationStartPendingFork because replicationCron does that.