### PR TITLE
Prevent nodes with invalid IDs from being propagated through gossip

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2090,7 +2090,7 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
      * the nodes dictionary. An invalid ID indicates memory corruption on the sender side. */
     int invalid_ids = verifyGossipSectionNodeIds(g, count);
     if (invalid_ids) {
-        serverLog(LL_WARNING, "Node %.40s gossiped %d nodes with invalid IDs.", sender->name, invalid_ids);
+        serverLog(LL_WARNING, "Node %.40s (%s) gossiped %d nodes with invalid IDs.", sender->name, sender->human_nodename, invalid_ids);
         return;
     }
 


### PR DESCRIPTION
There have been occasional instances of memory corruption leading to invalid node information being gossiped around. One simple way to help prevent this invalid information spreading is to verify the node IDs in received gossip are in an acceptable format, and disregard any gossiped nodes with invalid IDs. This PR uses the existing `verifyClusterNodeId` function to check the validity of the gossiped node IDs and if an invalid one is encountered, logs raw byte information to help debug the corruption.

Invalid Node IDs can be sticky and require manual intervention to remove.