### PR TITLE
Sharded pubsub message propagation via replication link

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3096,6 +3096,7 @@ standardConfig static_configs[] = {
     createBoolConfig("appendonly", NULL, MODIFIABLE_CONFIG | DENY_LOADING_CONFIG, server.aof_enabled, 0, NULL, updateAppendonly),
     createBoolConfig("cluster-allow-reads-when-down", NULL, MODIFIABLE_CONFIG, server.cluster_allow_reads_when_down, 0, NULL, NULL),
     createBoolConfig("cluster-allow-pubsubshard-when-down", NULL, MODIFIABLE_CONFIG, server.cluster_allow_pubsubshard_when_down, 1, NULL, NULL),
+    createBoolConfig("cluster-allow-pubsubshard-publish-replica", NULL, MODIFIABLE_CONFIG, server.cluster_allow_pubsubshard_publish_replica, 0, NULL, NULL),
     createBoolConfig("crash-log-enabled", NULL, MODIFIABLE_CONFIG, server.crashlog_enabled, 1, NULL, updateSighandlerEnabled),
     createBoolConfig("crash-memcheck-enabled", NULL, MODIFIABLE_CONFIG, server.memcheck_enabled, 1, NULL, NULL),
     createBoolConfig("use-exit-on-panic", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.use_exit_on_panic, 0, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3096,7 +3096,7 @@ standardConfig static_configs[] = {
     createBoolConfig("appendonly", NULL, MODIFIABLE_CONFIG | DENY_LOADING_CONFIG, server.aof_enabled, 0, NULL, updateAppendonly),
     createBoolConfig("cluster-allow-reads-when-down", NULL, MODIFIABLE_CONFIG, server.cluster_allow_reads_when_down, 0, NULL, NULL),
     createBoolConfig("cluster-allow-pubsubshard-when-down", NULL, MODIFIABLE_CONFIG, server.cluster_allow_pubsubshard_when_down, 1, NULL, NULL),
-    createBoolConfig("cluster-allow-pubsubshard-publish-replica", NULL, MODIFIABLE_CONFIG, server.cluster_allow_pubsubshard_publish_replica, 0, NULL, NULL),
+    createBoolConfig("cluster-allow-pubsubshard-publish-replica", NULL, MODIFIABLE_CONFIG, server.cluster_allow_pubsubshard_publish_replica, 1, NULL, NULL),
     createBoolConfig("crash-log-enabled", NULL, MODIFIABLE_CONFIG, server.crashlog_enabled, 1, NULL, updateSighandlerEnabled),
     createBoolConfig("crash-memcheck-enabled", NULL, MODIFIABLE_CONFIG, server.memcheck_enabled, 1, NULL, NULL),
     createBoolConfig("use-exit-on-panic", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.use_exit_on_panic, 0, NULL, NULL),

--- a/src/server.h
+++ b/src/server.h
@@ -2078,6 +2078,7 @@ struct redisServer {
     int failover_state; /* Failover state */
     int cluster_allow_pubsubshard_when_down; /* Is pubsubshard allowed when the cluster
                                                 is down, doesn't affect pubsub global. */
+    int cluster_allow_pubsubshard_publish_replica; /* Allow sharded pubsub PUBLISH on replica. */
     long reply_buffer_peak_reset_time; /* The amount of time (in milliseconds) to wait between reply buffer peak resets */
     int reply_buffer_resizing_enabled; /* Is reply buffer resizing enabled (1 by default) */
     /* Local environment */

--- a/tests/unit/cluster/sharded-pubsub.tcl
+++ b/tests/unit/cluster/sharded-pubsub.tcl
@@ -1,0 +1,25 @@
+start_cluster 1 1 {tags {external:skip cluster}} {
+        set primary_id 0
+        set replica1_id 1
+        
+        set primary [Rn $primary_id]
+        set replica [Rn $replica1_id]
+
+    test "Sharded pubsub publish behavior on a replica" {
+        $replica CONFIG SET cluster-allow-pubsubshard-publish-replica no
+        set channelname ch3
+        assert_error "*MOVED*" {$replica spublish $channelname "hello"}
+        $replica CONFIG SET cluster-allow-pubsubshard-publish-replica yes
+        assert_equal 0 [$replica spublish $channelname "hello"]
+    }
+
+    test "Sharded pubsub publish behavior on a primary" {
+        # For a primary, the behavior is the same regardless of the config value.
+        $primary CONFIG SET cluster-allow-pubsubshard-publish-replica no
+        set channelname ch3
+        $primary spublish $channelname "hello"
+        assert_equal 0 [$replica spublish $channelname "hello"]
+        $primary CONFIG SET cluster-allow-pubsubshard-publish-replica yes
+        assert_equal 0 [$replica spublish $channelname "hello"]
+    }
+}


### PR DESCRIPTION
Addresses #12196

Sharded pubsub uses the cluster link for message propagation across the nodes. Cluster link has a high payload overhead and is particularly expensive if the message to be propagated is comparatively small. 

As the sharded pubsub message needs to be propagated only within a shard, if the message from client is received on a primary, replication link can be used for propagation as compared to cluster link. There are two benefits we can yield from it.

1. Throughput will be higher compared to the initial implementation.
2. Message delivery guarantee will better as the message will be accumulated in client output buffer in case of disconnectio n of replication link and will be retried.

This will be inline with how message propagation is performed in cluster disabled mode.

Benchmark:

Setup:

* 1 Primary (6379) + 1 Replica (6380)
* No client subscription

Scenario 1: Message(s) published on primary:

Request:

```
src/redis-benchmark  -h 127.0.0.1 -l -p 6379 -n 10000000 -P 20 SPUBLISH hello world
```
Summary:

```
  throughput summary: 798148.25 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        1.184     0.264     1.199     1.391     1.455    12.159
 ```

Scenario 2: Message(s) published on replica:

Request:

```
src/redis-benchmark  -h 127.0.0.1 -l -p 6380 -n 10000000 -P 20 SPUBLISH hello world
```

Summary:
```
  throughput summary: 556916.94 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        1.732     0.528     1.487     1.663     1.727   153.471
 ```
Note: Also, observed similar behavior on unstable for message published on primary. 

Gain: 43% on using replication link over cluster link.

Open Questions:

1. Should we keep the `SPUBLISH` command still allowed on replica(s)? Keeping it enabled provides backward compatibility. However, the delivery guarantee, performance and message propagation behavior will vary.

Alternative approach:

Another slightly nuanced approach which could make both classic pubsub and sharded pubsub perform better is to Introduce an internal command like `ipublish type 0|1 channel message` and propagate that efficiently using replication link/cluster link. 

* Any primary receiving it would propagate the message with it's replicas.
* Any replica receiving it won't deal with further command propagation.

Expanding on a scenario:
In classic pubsub if client sends `PUBLISH hello world` on primary, use replication-link to send `IPUBLISH type 0 hello world` to all replicas in shard and via cluster-link to all other primaries. Each primary sends `PUBLISH hello world` to their respective replicas. 