### PR TITLE
Avoid double free of cluster link

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1182,19 +1182,10 @@ void freeClusterLink(clusterLink *link) {
         connClose(link->conn);
         link->conn = NULL;
     }
-
-    if (link->send_msg_queue) {
-        server.stat_cluster_links_memory -= sizeof(list) + listLength(link->send_msg_queue)*sizeof(listNode);
-        listRelease(link->send_msg_queue);
-        link->send_msg_queue = NULL;
-    }
-
-    if (link->rcvbuf) {
-        server.stat_cluster_links_memory -= link->rcvbuf_alloc;
-        zfree(link->rcvbuf);
-        link->rcvbuf = NULL;
-    }
-
+    server.stat_cluster_links_memory -= sizeof(list) + listLength(link->send_msg_queue)*sizeof(listNode);
+    listRelease(link->send_msg_queue);
+    server.stat_cluster_links_memory -= link->rcvbuf_alloc;
+    zfree(link->rcvbuf);
     if (link->node) {
         if (link->node->link == link) {
             serverAssert(!link->inbound);


### PR DESCRIPTION
Avoid crash while performing `DEBUG CLUSTERLINK KILL` mutliple times (cluster link might not be created/valid).

```
24240:M 09 Jan 2024 14:03:24.455 # Redis 255.255.255 crashed by signal: 11, si_code: 2
24240:M 09 Jan 2024 14:03:24.455 # Accessing address: 0x8
24240:M 09 Jan 2024 14:03:24.455 # Crashed running the instruction at: 0x1045de14c

------ STACK TRACE ------
EIP:
0   redis-server                        0x00000001045de14c freeClusterLink + 28

Backtrace:
0   libsystem_platform.dylib            0x00000001af5a42a4 _sigtramp + 56
1   redis-server                        0x00000001045cde84 debugCommand + 17480
2   redis-server                        0x00000001045cde84 debugCommand + 17480
3   redis-server                        0x000000010453755c call + 396
4   redis-server                        0x00000001045c58f4 execCommand + 632
5   redis-server                        0x000000010453755c call + 396
6   redis-server                        0x000000010453984c processCommand + 5048
7   redis-server                        0x00000001045526d0 processInputBuffer + 2568
8   redis-server                        0x00000001045515a0 readQueryFromClient + 1612
9   redis-server                        0x0000000104664e88 connSocketEventHandler + 448
10  redis-server                        0x0000000104525870 aeProcessEvents + 784
11  redis-server                        0x00000001045490f0 main + 23524
12  dyld                                0x00000001af24be50 start + 2544
```

```
------ CURRENT CLIENT INFO ------
argv[0]: '"DEBUG"'
argv[1]: '"CLUSTERLINK"'
argv[2]: '"KILL"'
argv[3]: '"TO"'
argv[4]: '"3d0b15178303cbd64afc09466ad0febe60b473ab"'
```