### PR TITLE
Change dictGetSafeIterator to dictGetIterator in pubsub

### DIFF
--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -375,7 +375,7 @@ void pubsubShardUnsubscribeAllChannelsInSlot(unsigned int slot) {
         robj *channel = dictGetKey(de);
         dict *clients = dictGetVal(de);
         /* For each client subscribed to the channel, unsubscribe it. */
-        dictIterator *iter = dictGetSafeIterator(clients);
+        dictIterator *iter = dictGetIterator(clients);
         dictEntry *entry;
         while ((entry = dictNext(iter)) != NULL) {
             client *c = dictGetKey(entry);
@@ -527,7 +527,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
     if (de) {
         dict *clients = dictGetVal(de);
         dictEntry *entry;
-        dictIterator *iter = dictGetSafeIterator(clients);
+        dictIterator *iter = dictGetIterator(clients);
         while ((entry = dictNext(iter)) != NULL) {
             client *c = dictGetKey(entry);
             addReplyPubsubMessage(c,channel,message,*type.messageBulk);
@@ -555,7 +555,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
                                 sdslen(channel->ptr),0)) continue;
 
             dictEntry *entry;
-            dictIterator *iter = dictGetSafeIterator(clients);
+            dictIterator *iter = dictGetIterator(clients);
             while ((entry = dictNext(iter)) != NULL) {
                 client *c = dictGetKey(entry);
                 addReplyPubsubPatMessage(c,pattern,channel,message);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -543,7 +543,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
     }
 
     /* Send to clients listening to matching channels */
-    di = dictGetSafeIterator(server.pubsub_patterns);
+    di = dictGetIterator(server.pubsub_patterns);
     if (di) {
         channel = getDecodedObject(channel);
         while((de = dictNext(di)) != NULL) {
@@ -741,7 +741,7 @@ void channelList(client *c, sds pat, dict **pubsub_channels, int is_sharded) {
         if (pubsub_channels[i] == NULL) {
             continue;
         }
-        dictIterator *di = dictGetSafeIterator(pubsub_channels[i]);
+        dictIterator *di = dictGetIterator(pubsub_channels[i]);
         dictEntry *de;
         while((de = dictNext(di)) != NULL) {
             robj *cobj = dictGetKey(de);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -374,7 +374,6 @@ void pubsubShardUnsubscribeAllChannelsInSlot(unsigned int slot) {
     while ((de = dictNext(di)) != NULL) {
         robj *channel = dictGetKey(de);
         dict *clients = dictGetVal(de);
-        if (dictSize(clients) == 0) goto cleanup;
         /* For each client subscribed to the channel, unsubscribe it. */
         dictIterator *iter = dictGetSafeIterator(clients);
         dictEntry *entry;
@@ -390,7 +389,6 @@ void pubsubShardUnsubscribeAllChannelsInSlot(unsigned int slot) {
             }
         }
         dictReleaseIterator(iter);
-cleanup:
         server.shard_channel_count--;
         dictDelete(d, channel);
     }
@@ -545,7 +543,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
     }
 
     /* Send to clients listening to matching channels */
-    di = dictGetIterator(server.pubsub_patterns);
+    di = dictGetSafeIterator(server.pubsub_patterns);
     if (di) {
         channel = getDecodedObject(channel);
         while((de = dictNext(di)) != NULL) {
@@ -743,7 +741,7 @@ void channelList(client *c, sds pat, dict **pubsub_channels, int is_sharded) {
         if (pubsub_channels[i] == NULL) {
             continue;
         }
-        dictIterator *di = dictGetIterator(pubsub_channels[i]);
+        dictIterator *di = dictGetSafeIterator(pubsub_channels[i]);
         dictEntry *de;
         while((de = dictNext(di)) != NULL) {
             robj *cobj = dictGetKey(de);

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -504,27 +504,3 @@ start_server {tags {"pubsub network"}} {
     } {} {resp3}
 
 }
-
-start_server {tags {"pubsub external:skip logreqres:skip"}} {
-    # This test is for PUBLISH/PSUBSCRIBE.
-    # PUBLISH/SUBSCRIBE test is in obuf-limits named "Client output buffer hard limit is enforced".
-    test "PUBLISH/PSUBSCRIBE when client-output-buffer-limit hard limit is reached" {
-        r config set client-output-buffer-limit {pubsub 100000 0 0}
-        set rd1 [redis_deferring_client]
-
-        $rd1 psubscribe fo*
-        set reply [$rd1 read]
-        assert {$reply eq "psubscribe fo* 1"}
-
-        set omem 0
-        while 1 {
-            r publish foo bar
-            set clients [split [r client list] "\r\n"]
-            set c [split [lindex $clients 1] " "]
-            if {![regexp {omem=([0-9]+)} $c - omem]} break
-            if {$omem > 200000} break
-        }
-        assert {$omem >= 70000 && $omem < 200000}
-        $rd1 close
-    }
-}

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -245,6 +245,28 @@ start_server {tags {"pubsub network"}} {
         concat $reply1 $reply2
     } {punsubscribe {} 0 unsubscribe {} 0}
 
+    # This test is for PUBLISH/PSUBSCRIBE.
+    # PUBLISH/SUBSCRIBE test is in obuf-limits named "Client output buffer hard limit is enforced".
+    test "PUBLISH/PSUBSCRIBE when client-output-buffer-limit hard limit is reached" {
+        r config set client-output-buffer-limit {pubsub 100000 0 0}
+        set rd1 [redis_deferring_client]
+
+        $rd1 psubscribe fo*
+        set reply [$rd1 read]
+        assert {$reply eq "psubscribe fo* 1"}
+
+        set omem 0
+        while 1 {
+            r publish foo bar
+            set clients [split [r client list] "\r\n"]
+            set c [split [lindex $clients 1] " "]
+            if {![regexp {omem=([0-9]+)} $c - omem]} break
+            if {$omem > 200000} break
+        }
+        assert {$omem >= 70000 && $omem < 200000}
+        $rd1 close
+    }
+
     ### Keyspace events notification tests
 
     test "Keyspace notifications: we receive keyspace notifications" {


### PR DESCRIPTION
In #12838, we misuse the safe iterator of the client dict, so we can't catch the synchronous release of the client if there is a bug.

Since we realize that clients (even subscribers) are released with async free, we change the safe iterators of the client dict into unsafe iterators in `pubsub.c`. And I also remove redundant code.