### PR TITLE
Print time zone in server log.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -136,7 +136,8 @@ void serverLogRaw(int level, const char *msg) {
         struct tm tm;
         nolocks_localtime(&tm,tv.tv_sec,server.timezone,server.daylight_active);
         off = strftime(buf,sizeof(buf),"%d %b %Y %H:%M:%S.",&tm);
-        snprintf(buf+off,sizeof(buf)-off,"%03d",(int)tv.tv_usec/1000);
+        time_t zone = server.timezone / 3600;
+        snprintf(buf+off,sizeof(buf)-off,"%03d %c%02ld00",(int)tv.tv_usec/1000,zone>0?'-':'+',labs(zone));
         if (server.sentinel_mode) {
             role_char = 'X'; /* Sentinel. */
         } else if (pid != server.pid) {


### PR DESCRIPTION
To resolve #12932

Displaying time zone in the log is very helpful in many circumstances. And as a global cloud service provider, our customers often ask which time zone the time in the log is. 

#12934 is very good, but the discussion of configuration items is too complicated. I think we need to stick to the original problem. In this PR a brief solution to print time zone is proposed to meet user needs. Here we only discuss how to display time zone information to avoid complicating the issue.

Currently the implementation in this PR will result in a log format shown below.
```
113734:M 12 Jan 2024 16:52:25.692 +0800 * Server initialized
```