### PR TITLE
Some cleanups around function

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -118,10 +118,7 @@ dictType librariesDictType = {
 /* Dictionary of engines */
 static dict *engines = NULL;
 
-/* Libraries Ctx.
- * Contains the dictionary that map a library name to library object,
- * Contains the dictionary that map a function name to function object,
- * and the cache memory used by all the functions */
+/* Libraries Ctx. */
 static functionsLibCtx *curr_functions_lib_ctx = NULL;
 
 static size_t functionMallocSize(functionInfo *fi) {
@@ -499,7 +496,6 @@ static void functionListReplyFlags(client *c, functionInfo *fi) {
  * Return general information about all the libraries:
  * * Library name
  * * The engine used to run the Library
- * * Library description
  * * Functions list
  * * Library code (if WITHCODE is given)
  *
@@ -681,7 +677,6 @@ void fcallroCommand(client *c) {
  * is saved separately with the following information:
  * * Library name
  * * Engine name
- * * Library description
  * * Library code
  * RDB_OPCODE_FUNCTION2 is saved before each library to present
  * that the payload is a library.
@@ -840,7 +835,6 @@ void functionHelpCommand(client *c) {
 "    Return general information on all the libraries:",
 "    * Library name",
 "    * The engine used to run the Library",
-"    * Library description",
 "    * Functions list",
 "    * Library code (if WITHCODE is given)",
 "    It also possible to get only function that matches a pattern using LIBRARYNAME argument.",
@@ -894,9 +888,7 @@ static int functionsVerifyName(sds name) {
 
 int functionExtractLibMetaData(sds payload, functionsLibMataData *md, sds *err) {
     sds name = NULL;
-    sds desc = NULL;
     sds engine = NULL;
-    sds code = NULL;
     if (strncmp(payload, "#!", 2) != 0) {
         *err = sdsnew("Missing library metadata");
         return C_ERR;
@@ -948,9 +940,7 @@ int functionExtractLibMetaData(sds payload, functionsLibMataData *md, sds *err) 
 
 error:
     if (name) sdsfree(name);
-    if (desc) sdsfree(desc);
     if (engine) sdsfree(engine);
-    if (code) sdsfree(code);
     sdsfreesplitres(parts, numparts);
     return C_ERR;
 }
@@ -1084,15 +1074,15 @@ void functionLoadCommand(client *c) {
 unsigned long functionsMemory(void) {
     dictIterator *iter = dictGetIterator(engines);
     dictEntry *entry = NULL;
-    size_t engines_nemory = 0;
+    size_t engines_memory = 0;
     while ((entry = dictNext(iter))) {
         engineInfo *ei = dictGetVal(entry);
         engine *engine = ei->engine;
-        engines_nemory += engine->get_used_memory(engine->engine_ctx);
+        engines_memory += engine->get_used_memory(engine->engine_ctx);
     }
     dictReleaseIterator(iter);
 
-    return engines_nemory;
+    return engines_memory;
 }
 
 /* Return memory overhead of all the engines combine */
@@ -1119,7 +1109,7 @@ dict* functionsLibGet(void) {
     return curr_functions_lib_ctx->libraries;
 }
 
-size_t functionsLibCtxfunctionsLen(functionsLibCtx *functions_ctx) {
+size_t functionsLibCtxFunctionsLen(functionsLibCtx *functions_ctx) {
     return dictSize(functions_ctx->functions);
 }
 

--- a/src/functions.h
+++ b/src/functions.h
@@ -32,11 +32,16 @@
 
 /*
  * functions.c unit provides the Redis Functions API:
- * * FUNCTION CREATE
- * * FUNCTION CALL
+ * * FUNCTION LOAD
+ * * FUNCTION LIST
+ * * FUNCTION CALL (FCALL and FCALL_RO)
  * * FUNCTION DELETE
+ * * FUNCTION STATS
  * * FUNCTION KILL
- * * FUNCTION INFO
+ * * FUNCTION FLUSH
+ * * FUNCTION DUMP
+ * * FUNCTION RESTORE
+ * * FUNCTION HELP
  *
  * Also contains implementation for:
  * * Save/Load function from rdb
@@ -59,7 +64,7 @@ typedef struct engine {
      * code - the library code
      * timeout - timeout for the library creation (0 for no timeout)
      * err - description of error (if occurred)
-     * returns NULL on error and set sds to be the error message */
+     * returns C_ERR on error and set err to be the error message */
     int (*create)(void *engine_ctx, functionLibInfo *li, sds code, size_t timeout, sds *err);
 
     /* Invoking a function, r_ctx is an opaque object (from engine POV).
@@ -120,7 +125,7 @@ unsigned long functionsMemoryOverhead(void);
 unsigned long functionsNum(void);
 unsigned long functionsLibNum(void);
 dict* functionsLibGet(void);
-size_t functionsLibCtxfunctionsLen(functionsLibCtx *functions_ctx);
+size_t functionsLibCtxFunctionsLen(functionsLibCtx *functions_ctx);
 functionsLibCtx* functionsLibCtxGetCurrent(void);
 functionsLibCtx* functionsLibCtxCreate(void);
 void functionsLibCtxClearCurrent(int async);

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -55,7 +55,7 @@ void lazyFreeLuaScripts(void *args[]) {
 /* Release the functions ctx. */
 void lazyFreeFunctionsCtx(void *args[]) {
     functionsLibCtx *functions_lib_ctx = args[0];
-    size_t len = functionsLibCtxfunctionsLen(functions_lib_ctx);
+    size_t len = functionsLibCtxFunctionsLen(functions_lib_ctx);
     functionsLibCtxFree(functions_lib_ctx);
     atomicDecr(lazyfree_objects,len);
     atomicIncr(lazyfreed_objects,len);
@@ -227,8 +227,8 @@ void freeLuaScriptsAsync(dict *lua_scripts) {
 
 /* Free functions ctx, if the functions ctx contains enough functions, free it in async way. */
 void freeFunctionsAsync(functionsLibCtx *functions_lib_ctx) {
-    if (functionsLibCtxfunctionsLen(functions_lib_ctx) > LAZYFREE_THRESHOLD) {
-        atomicIncr(lazyfree_objects,functionsLibCtxfunctionsLen(functions_lib_ctx));
+    if (functionsLibCtxFunctionsLen(functions_lib_ctx) > LAZYFREE_THRESHOLD) {
+        atomicIncr(lazyfree_objects,functionsLibCtxFunctionsLen(functions_lib_ctx));
         bioCreateLazyFreeJob(lazyFreeFunctionsCtx,1,functions_lib_ctx);
     } else {
         functionsLibCtxFree(functions_lib_ctx);

--- a/src/server.c
+++ b/src/server.c
@@ -2878,7 +2878,10 @@ void initServer(void) {
     }
 
     scriptingInit(1);
-    functionsInit();
+    if (functionsInit() == C_ERR) {
+        serverPanic("Functions initialization failed, check the server logs.");
+        exit(1);
+    }
     slowlogInit();
     latencyMonitorInit();
 

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -64,7 +64,8 @@ start_server {tags {"scripting"}} {
     } {hello1}
 
     test {FUNCTION - test replace argument with failure keeps old libraries} {
-         catch {r function create LUA test REPLACE {error}}
+        catch {r function load REPLACE [get_function_code LUA test test {error}]} e
+        assert_match {ERR Error compiling function*} $e
         r fcall test 0
     } {hello1}
 


### PR DESCRIPTION
This PR did some cleanups around function:
- drop the comment about Libraries Ctx, since we do have comment
  in functionsLibCtx, no need to maintain multiple copies.
- remove outdated comment about the dropped Library description.
- remove unused desc and code vars in functionExtractLibMetaData.
- fix engines_nemory typo, changed it to engines_memory.
- remove outdated comment about FUNCTION CREATE and FUNCTION INFO,
  FUNCTION CREATE was renamed to FUNCTION LOAD.
- Check in initServer whether the return of functionsInit is OK.