### PR TITLE
Fix race in slot dict resize test

### DIFF
--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -469,11 +469,6 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
         # disable resizing
         r config set rdb-key-save-delay 10000000
         r bgsave
-        wait_for_condition 1000 10 {
-            [s rdb_bgsave_in_progress] eq 1
-        } else {
-            fail "bgsave did not start in time"
-        }
 
         for {set j 1} {$j <= 127} {incr j} {
             r del "{alice}$j"

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -438,11 +438,6 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
         # disable resizing
         r config set rdb-key-save-delay 10000000
         r bgsave
-        wait_for_condition 1000 10 {
-            [s rdb_bgsave_in_progress] eq 1
-        } else {
-            fail "bgsave did not start in time"
-        }
 
         # delete data to have lot's (99%) of empty buckets
         for {set j 1} {$j <= 127} {incr j} {

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -438,6 +438,11 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
         # disable resizing
         r config set rdb-key-save-delay 10000000
         r bgsave
+        wait_for_condition 1000 10 {
+            [s rdb_bgsave_in_progress] eq 1
+        } else {
+            fail "bgsave did not start in time"
+        }
 
         # delete data to have lot's (99%) of empty buckets
         for {set j 1} {$j <= 127} {incr j} {
@@ -459,13 +464,33 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
     } {} {needs:debug}
 
     test "Redis can rewind and trigger smaller slot resizing" {
+        # hashslot(foo) is 12182
         # hashslot(alice) is 749, smaller than hashslot(foo),
         # attempt to trigger a resize on it, see details in #12802.
         for {set j 1} {$j <= 128} {incr j} {
             r set "{alice}$j" a
         }
+
+        # disable resizing
+        r config set rdb-key-save-delay 10000000
+        r bgsave
+        wait_for_condition 1000 10 {
+            [s rdb_bgsave_in_progress] eq 1
+        } else {
+            fail "bgsave did not start in time"
+        }
+
         for {set j 1} {$j <= 127} {incr j} {
             r del "{alice}$j"
+        }
+
+        # enable resizing
+        r config set rdb-key-save-delay 0
+        catch {exec kill -9 [get_child_pid 0]}
+        wait_for_condition 1000 10 {
+            [s rdb_bgsave_in_progress] eq 0
+        } else {
+            fail "bgsave did not stop in time."
         }
 
         after 200;# waiting for serverCron


### PR DESCRIPTION
The test have a race:
```
*** [err]: Redis can rewind and trigger smaller slot resizing in tests/unit/other.tcl
Expected '[Dictionary HT]
Hash table 0 stats (main hash table):
 table size: 12
 number of elements: 2
[Expires HT]
Hash table 0 stats (main hash table):
No stats available for empty dictionaries
' to match '*table size: 8*' (context: type eval line 12 cmd {assert_match "*table size: 8*" [r debug HTSTATS 0]} proc ::test)
```

When `r del "{alice}$j"` is executed in the loop, when the key is
deleted to [9, 12], the load factor has meet HASHTABLE_MIN_FILL,
if serverCron happens to trigger slot dict resize, then the test
will fail. Because there is not way to meet HASHTABLE_MIN_FILL in
the subsequent dels.

The solution is to avoid triggering the resize in advance. We can
use multi to delete them at once, or we can disable the resize.
Since we disabled resize in the previous test, the fix also uses
the method of disabling resize.

The test is introduced in #12802.