### PR TITLE
Fix fd check in memtest_test_linux_anonymous_maps

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2076,7 +2076,7 @@ int memtest_test_linux_anonymous_maps(void) {
     int regions = 0, j;
 
     int fd = openDirectLogFiledes();
-    if (!fd) return 0;
+    if (fd == -1) return 0;
 
     fp = fopen("/proc/self/maps","r");
     if (!fp) {


### PR DESCRIPTION
The open function returns a fd on success or -1 on failure,
here we should check fd != -1, otherwise -1 will be judged
as success.

This closes #12938.