### PR TITLE
Set the correct id for tempDb

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -763,6 +763,7 @@ long long emptyData(int dbnum, int flags, void(callback)(dict*)) {
 redisDb *initTempDb(void) {
     redisDb *tempDb = zcalloc(sizeof(redisDb)*server.dbnum);
     for (int i=0; i<server.dbnum; i++) {
+        tempDb[i].id = i;
         tempDb[i].dict_count = (server.cluster_enabled) ? CLUSTER_SLOTS : 1;
         tempDb[i].dict = dictCreateMultiple(&dbDictType, tempDb[i].dict_count);
         tempDb[i].expires = dictCreateMultiple(&dbExpiresDictType, tempDb[i].dict_count);


### PR DESCRIPTION
background: some modules need to know the `dbid` information, such as the function used during RDB loading:

```
robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
....
        moduleInitIOContext(io,mt,rdb,&keyobj,dbid);
```

However, during replication, the "tempDb" created for diskless RDB loading is not correctly set with the dbid. This leads to passing the wrong dbid to the `rdbLoadObject` function (as tempDb uses zcalloc, all ids are 0).

```
disklessLoadInitTempDb()->rdbLoadRioWithLoadingCtx()->
        /* Read value */
        val = rdbLoadObject(type,rdb,key,db->id,&error);
```

To fix it, set the correct ID (relative index) for the tempdb.