### PR TITLE
Change the threshold of dict expand, shrink and rehash

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -58,7 +58,7 @@
  *  - A hash table is still allowed to expand if the ratio between the number
  *    of elements and the buckets >= dict_force_resize_ratio.
  *  - A hash table is still allowed to shrink if the ratio between the number
- *    of elements and the buckets <= 100 / (HASHTABLE_MIN_FILL * dict_force_resize_ratio). */
+ *    of elements and the buckets <= 1 / (HASHTABLE_MIN_FILL * dict_force_resize_ratio). */
 static dictResizeEnable dict_can_resize = DICT_RESIZE_ENABLE;
 static unsigned int dict_force_resize_ratio = 4;
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -1753,7 +1753,7 @@ int dictTest(int argc, char **argv, int flags) {
     int retval;
     dict *dict = dictCreate(&BenchmarkDictType);
     long count = 0;
-    unsigned long newDictSize, currentDictUsed, remainKeys;
+    unsigned long new_dict_size, current_dict_used, remain_keys;
     int accurate = (flags & REDIS_TEST_ACCURATE);
 
     if (argc == 4) {
@@ -1786,58 +1786,58 @@ int dictTest(int argc, char **argv, int flags) {
             retval = dictAdd(dict,stringFromLongLong(j),(void*)j);
             assert(retval == DICT_OK);
         }
-        currentDictUsed = dict_force_resize_ratio * 16;
-        assert(dictSize(dict) == currentDictUsed);
+        current_dict_used = dict_force_resize_ratio * 16;
+        assert(dictSize(dict) == current_dict_used);
         assert(dictBuckets(dict) == 16);
     }
 
     TEST("Add one more key, trigger the dict resize") {
-        retval = dictAdd(dict,stringFromLongLong(currentDictUsed),(void*)(currentDictUsed));
+        retval = dictAdd(dict,stringFromLongLong(current_dict_used),(void*)(current_dict_used));
         assert(retval == DICT_OK);
-        currentDictUsed++;
-        newDictSize = 1UL << _dictNextExp(currentDictUsed);
-        assert(dictSize(dict) == currentDictUsed);
+        current_dict_used++;
+        new_dict_size = 1UL << _dictNextExp(current_dict_used);
+        assert(dictSize(dict) == current_dict_used);
         assert(DICTHT_SIZE(dict->ht_size_exp[0]) == 16);
-        assert(DICTHT_SIZE(dict->ht_size_exp[1]) == newDictSize);
+        assert(DICTHT_SIZE(dict->ht_size_exp[1]) == new_dict_size);
 
         /* Wait for rehashing. */
         dictSetResizeEnabled(DICT_RESIZE_ENABLE);
         while (dictIsRehashing(dict)) dictRehashMicroseconds(dict,1000);
-        assert(dictSize(dict) == currentDictUsed);
-        assert(DICTHT_SIZE(dict->ht_size_exp[0]) == newDictSize);
+        assert(dictSize(dict) == current_dict_used);
+        assert(DICTHT_SIZE(dict->ht_size_exp[0]) == new_dict_size);
         assert(DICTHT_SIZE(dict->ht_size_exp[1]) == 0);
     }
 
     TEST("Delete keys until we can trigger shrink in next test") {
         /* Delete keys until we can satisfy (1 / HASHTABLE_MIN_FILL) in the next test. */
-        for (j = newDictSize / HASHTABLE_MIN_FILL + 1; j < (int)currentDictUsed; j++) {
+        for (j = new_dict_size / HASHTABLE_MIN_FILL + 1; j < (int)current_dict_used; j++) {
             char *key = stringFromLongLong(j);
             retval = dictDelete(dict, key);
             zfree(key);
             assert(retval == DICT_OK);
         }
-        currentDictUsed = newDictSize / HASHTABLE_MIN_FILL + 1;
-        assert(dictSize(dict) == currentDictUsed);
-        assert(DICTHT_SIZE(dict->ht_size_exp[0]) == newDictSize);
+        current_dict_used = new_dict_size / HASHTABLE_MIN_FILL + 1;
+        assert(dictSize(dict) == current_dict_used);
+        assert(DICTHT_SIZE(dict->ht_size_exp[0]) == new_dict_size);
         assert(DICTHT_SIZE(dict->ht_size_exp[1]) == 0);
     }
 
     TEST("Delete one more key, trigger the dict resize") {
-        currentDictUsed--;
-        char *key = stringFromLongLong(currentDictUsed);
+        current_dict_used--;
+        char *key = stringFromLongLong(current_dict_used);
         retval = dictDelete(dict, key);
         zfree(key);
-        unsigned long oldDictSize = newDictSize;
-        newDictSize = 1UL << _dictNextExp(currentDictUsed);
+        unsigned long oldDictSize = new_dict_size;
+        new_dict_size = 1UL << _dictNextExp(current_dict_used);
         assert(retval == DICT_OK);
-        assert(dictSize(dict) == currentDictUsed);
+        assert(dictSize(dict) == current_dict_used);
         assert(DICTHT_SIZE(dict->ht_size_exp[0]) == oldDictSize);
-        assert(DICTHT_SIZE(dict->ht_size_exp[1]) == newDictSize);
+        assert(DICTHT_SIZE(dict->ht_size_exp[1]) == new_dict_size);
 
         /* Wait for rehashing. */
         while (dictIsRehashing(dict)) dictRehashMicroseconds(dict,1000);
-        assert(dictSize(dict) == currentDictUsed);
-        assert(DICTHT_SIZE(dict->ht_size_exp[0]) == newDictSize);
+        assert(dictSize(dict) == current_dict_used);
+        assert(DICTHT_SIZE(dict->ht_size_exp[0]) == new_dict_size);
         assert(DICTHT_SIZE(dict->ht_size_exp[1]) == 0);
     }
 
@@ -1856,34 +1856,34 @@ int dictTest(int argc, char **argv, int flags) {
         /* Use DICT_RESIZE_AVOID to disable the dict reset, and reduce
          * the number of keys until we can trigger shrinking in next test. */
         dictSetResizeEnabled(DICT_RESIZE_AVOID);
-        remainKeys = DICTHT_SIZE(dict->ht_size_exp[0]) / (HASHTABLE_MIN_FILL * dict_force_resize_ratio) + 1;
-        for (j = remainKeys; j < 128; j++) {
+        remain_keys = DICTHT_SIZE(dict->ht_size_exp[0]) / (HASHTABLE_MIN_FILL * dict_force_resize_ratio) + 1;
+        for (j = remain_keys; j < 128; j++) {
             char *key = stringFromLongLong(j);
             retval = dictDelete(dict, key);
             zfree(key);
             assert(retval == DICT_OK);
         }
-        currentDictUsed = remainKeys;
-        assert(dictSize(dict) == remainKeys);
+        current_dict_used = remain_keys;
+        assert(dictSize(dict) == remain_keys);
         assert(dictBuckets(dict) == 128);
     }
 
     TEST("Delete one more key, trigger the dict resize") {
-        currentDictUsed--;
-        char *key = stringFromLongLong(currentDictUsed);
+        current_dict_used--;
+        char *key = stringFromLongLong(current_dict_used);
         retval = dictDelete(dict, key);
         zfree(key);
-        newDictSize = 1UL << _dictNextExp(currentDictUsed);
+        new_dict_size = 1UL << _dictNextExp(current_dict_used);
         assert(retval == DICT_OK);
-        assert(dictSize(dict) == currentDictUsed);
+        assert(dictSize(dict) == current_dict_used);
         assert(DICTHT_SIZE(dict->ht_size_exp[0]) == 128);
-        assert(DICTHT_SIZE(dict->ht_size_exp[1]) == newDictSize);
+        assert(DICTHT_SIZE(dict->ht_size_exp[1]) == new_dict_size);
 
         /* Wait for rehashing. */
         dictSetResizeEnabled(DICT_RESIZE_ENABLE);
         while (dictIsRehashing(dict)) dictRehashMicroseconds(dict,1000);
-        assert(dictSize(dict) == currentDictUsed);
-        assert(DICTHT_SIZE(dict->ht_size_exp[0]) == newDictSize);
+        assert(dictSize(dict) == current_dict_used);
+        assert(DICTHT_SIZE(dict->ht_size_exp[0]) == new_dict_size);
         assert(DICTHT_SIZE(dict->ht_size_exp[1]) == 0);
     }
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -1782,7 +1782,7 @@ int dictTest(int argc, char **argv, int flags) {
          * the number of keys to (dict_force_resize_ratio * 16), so we can satisfy
          * dict_force_resize_ratio in next test. */
         dictSetResizeEnabled(DICT_RESIZE_AVOID);
-        for (j = 16; j < dict_force_resize_ratio * 16; j++) {
+        for (j = 16; j < (long)dict_force_resize_ratio * 16; j++) {
             retval = dictAdd(dict,stringFromLongLong(j),(void*)j);
             assert(retval == DICT_OK);
         }
@@ -1810,7 +1810,7 @@ int dictTest(int argc, char **argv, int flags) {
 
     TEST("Delete keys until we can trigger shrink in next test") {
         /* Delete keys until we can satisfy (1 / HASHTABLE_MIN_FILL) in the next test. */
-        for (j = new_dict_size / HASHTABLE_MIN_FILL + 1; j < (int)current_dict_used; j++) {
+        for (j = new_dict_size / HASHTABLE_MIN_FILL + 1; j < (long)current_dict_used; j++) {
             char *key = stringFromLongLong(j);
             retval = dictDelete(dict, key);
             zfree(key);

--- a/src/dict.h
+++ b/src/dict.h
@@ -45,7 +45,7 @@
 #define DICT_ERR 1
 
 /* Hash table parameters */
-#define HASHTABLE_MIN_FILL        10      /* Minimal hash table fill 10% */
+#define HASHTABLE_MIN_FILL        8      /* Minimal hash table fill 12.5%(100/8) */
 
 typedef struct dictEntry dictEntry; /* opaque */
 typedef struct dict dict;

--- a/src/server.c
+++ b/src/server.c
@@ -699,11 +699,11 @@ int htNeedsShrink(dict *dict) {
     size = dictBuckets(dict);
     used = dictSize(dict);
     return (size > DICT_HT_INITIAL_SIZE &&
-            (used*100 <= HASHTABLE_MIN_FILL*size));
+            (used * HASHTABLE_MIN_FILL <= size));
 }
 
 /* In cluster-enabled setup, this method traverses through all main/expires dictionaries (CLUSTER_SLOTS)
- * and triggers a resize if the percentage of used buckets in the HT reaches HASHTABLE_MIN_FILL
+ * and triggers a resize if the percentage of used buckets in the HT reaches (100 / HASHTABLE_MIN_FILL)
  * we resize the hash table to save memory.
  *
  * In non cluster-enabled setup, it resize main/expires dictionary based on the same condition described above. */

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -455,7 +455,7 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
         }
 
         after 200;# waiting for serverCron
-        assert_match "*table size: 4*" [r debug HTSTATS 0]
+        assert_match "*table size: 8*" [r debug HTSTATS 0]
     } {} {needs:debug}
 
     test "Redis can rewind and trigger smaller slot resizing" {
@@ -484,6 +484,6 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
         }
 
         after 200;# waiting for serverCron
-        assert_match "*table size: 8*" [r debug HTSTATS 0]
+        assert_match "*table size: 16*" [r debug HTSTATS 0]
     } {} {needs:debug}
 }

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -439,8 +439,8 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
         r config set rdb-key-save-delay 10000000
         r bgsave
 
-        # delete data to have lot's (98%) of empty buckets
-        for {set j 1} {$j <= 125} {incr j} {
+        # delete data to have lot's (96%) of empty buckets
+        for {set j 1} {$j <= 123} {incr j} {
             r del "{foo}$j"
         }
         assert_match "*table size: 128*" [r debug HTSTATS 0]
@@ -470,7 +470,7 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
         r config set rdb-key-save-delay 10000000
         r bgsave
 
-        for {set j 1} {$j <= 125} {incr j} {
+        for {set j 1} {$j <= 123} {incr j} {
             r del "{alice}$j"
         }
 


### PR DESCRIPTION
Before this change (most recently modified in https://github.com/redis/redis/pull/12850#discussion_r1421406393), The trigger for normal expand threshold was 100% utilization and the trigger for normal shrink threshold was 10% (HASHTABLE_MIN_FILL).
While during fork (DICT_RESIZE_AVOID), when we want to avoid rehash, the trigger thresholds were multiplied by 5 (`dict_force_resize_ratio`), meaning 500% for expand and 2% (100/10/5) for shrink. 

However, in `dictRehash` (the incremental rehashing), the rehashing threshold for shrinking during fork (DICT_RESIZE_AVOID) was 20% by mistake.
This meant that if a shrinking is triggered when `dict_can_resize` is `DICT_RESIZE_ENABLE` which the threshold is 10%, the rehashing can continue when `dict_can_resize` is `DICT_RESIZE_AVOID`.
This would cause unwanted CopyOnWrite damage.

It'll make sense to change the thresholds of the rehash trigger and the thresholds of the incremental rehashing the same, however, in one we compare the size of the hash table to the number of records, and in the other we compare the size of ht[0] to the size of ht[1], so the formula is not exactly the same.

to make things easier we change all the thresholds to powers of 2, so the normal shrinking threshold is changed from 100/10 (i.e. 10%) to 100/8 (i.e. 12.5%), and we change the threshold during forks from 5 to 4, i.e. from 500% to 400% for expand, and from 2% (100/10/5) to 3.125% (100/8/4)