### PR TITLE
Optimize dictTypeResizeAllowed to avoid mistaken OOM judgement.

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1420,10 +1420,10 @@ unsigned long dictScanDefrag(dict *d,
 /* Because we may need to allocate huge memory chunk at once when dict
  * expands, we will check this allocation is allowed or not if the dict
  * type has expandAllowed member function. */
-static int dictTypeResizeAllowed(dict *d) {
+static int dictTypeResizeAllowed(dict *d, int expanding) {
     if (d->type->resizeAllowed == NULL) return 1;
     return d->type->resizeAllowed(
-                    DICTHT_SIZE(_dictNextExp(d->ht_used[0] + 1)) * sizeof(dictEntry*),
+                    DICTHT_SIZE(_dictNextExp(d->ht_used[0] + expanding?1:0)) * sizeof(dictEntry*),
                     (double)d->ht_used[0] / DICTHT_SIZE(d->ht_size_exp[0]));
 }
 
@@ -1451,7 +1451,7 @@ static void _dictExpandIfNeeded(dict *d)
         (dict_can_resize != DICT_RESIZE_FORBID &&
          d->ht_used[0] / DICTHT_SIZE(d->ht_size_exp[0]) > dict_force_resize_ratio))
     {
-        if (!dictTypeResizeAllowed(d))
+        if (!dictTypeResizeAllowed(d, 1))
             return;
         dictExpand(d, d->ht_used[0] + 1);
     }
@@ -1476,7 +1476,7 @@ static void _dictShrinkIfNeeded(dict *d)
         (dict_can_resize != DICT_RESIZE_FORBID &&
          d->ht_used[0] * 100 / DICTHT_SIZE(d->ht_size_exp[0]) < HASHTABLE_MIN_FILL / dict_force_resize_ratio))
     {
-        if (!dictTypeResizeAllowed(d))
+        if (!dictTypeResizeAllowed(d, 0))
             return;
         dictShrink(d, d->ht_used[0]);
     }

--- a/src/dict.c
+++ b/src/dict.c
@@ -1423,7 +1423,7 @@ unsigned long dictScanDefrag(dict *d,
 static int dictTypeResizeAllowed(dict *d, int expanding) {
     if (d->type->resizeAllowed == NULL) return 1;
     return d->type->resizeAllowed(
-                    DICTHT_SIZE(_dictNextExp(d->ht_used[0] + expanding?1:0)) * sizeof(dictEntry*),
+                    DICTHT_SIZE(_dictNextExp(d->ht_used[0] + (expanding ? 1 : 0))) * sizeof(dictEntry*),
                     (double)d->ht_used[0] / DICTHT_SIZE(d->ht_size_exp[0]));
 }
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -1418,8 +1418,8 @@ unsigned long dictScanDefrag(dict *d,
 /* ------------------------- private functions ------------------------------ */
 
 /* Because we may need to allocate huge memory chunk at once when dict
- * expands, we will check this allocation is allowed or not if the dict
- * type has expandAllowed member function. */
+ * resizes, we will check this allocation is allowed or not if the dict
+ * type has resizeAllowed member function. */
 static int dictTypeResizeAllowed(dict *d, int expanding) {
     if (d->type->resizeAllowed == NULL) return 1;
     return d->type->resizeAllowed(


### PR DESCRIPTION
When doing dict resizing, dictTypeResizeAllowed is used to judge whether the new allocated memory for rehashing would cause OOM.

However when shrinking, we alloc `_dictNextExp(d->ht_used[0])` bytes of memory, while in `dictTypeResizeAllowed` we still use `_dictNextExp(d->ht_used[0]+1)` as the new allocated memory size. This will overestimate the memory used by shrinking at special conditions, causing a false OOM judgement.