### PR TITLE
Fix dict resize ratio checks, avoid precision loss from integer division

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1477,7 +1477,7 @@ static void _dictShrinkIfNeeded(dict *d)
     if ((dict_can_resize == DICT_RESIZE_ENABLE &&
          d->ht_used[0] * 100 <= HASHTABLE_MIN_FILL * DICTHT_SIZE(d->ht_size_exp[0])) ||
         (dict_can_resize != DICT_RESIZE_FORBID &&
-         d->ht_used[0] * 100 <= HASHTABLE_MIN_FILL / dict_force_resize_ratio * DICTHT_SIZE(d->ht_size_exp[0])))
+         d->ht_used[0] * 100 * dict_force_resize_ratio <= HASHTABLE_MIN_FILL * DICTHT_SIZE(d->ht_size_exp[0])))
     {
         if (!dictTypeResizeAllowed(d))
             return;

--- a/src/dict.h
+++ b/src/dict.h
@@ -45,7 +45,7 @@
 #define DICT_ERR 1
 
 /* Hash table parameters */
-#define HASHTABLE_MIN_FILL        0.1      /* Minimal hash table fill 10% */
+#define HASHTABLE_MIN_FILL        10      /* Minimal hash table fill 10% */
 
 typedef struct dictEntry dictEntry; /* opaque */
 typedef struct dict dict;

--- a/src/dict.h
+++ b/src/dict.h
@@ -45,7 +45,7 @@
 #define DICT_ERR 1
 
 /* Hash table parameters */
-#define HASHTABLE_MIN_FILL        10      /* Minimal hash table fill 10% */
+#define HASHTABLE_MIN_FILL        0.1      /* Minimal hash table fill 10% */
 
 typedef struct dictEntry dictEntry; /* opaque */
 typedef struct dict dict;

--- a/src/server.c
+++ b/src/server.c
@@ -699,7 +699,7 @@ int htNeedsShrink(dict *dict) {
     size = dictBuckets(dict);
     used = dictSize(dict);
     return (size > DICT_HT_INITIAL_SIZE &&
-            ((double)used/size < HASHTABLE_MIN_FILL));
+            (used*100 <= HASHTABLE_MIN_FILL*size));
 }
 
 /* In cluster-enabled setup, this method traverses through all main/expires dictionaries (CLUSTER_SLOTS)

--- a/src/server.c
+++ b/src/server.c
@@ -699,7 +699,7 @@ int htNeedsShrink(dict *dict) {
     size = dictBuckets(dict);
     used = dictSize(dict);
     return (size > DICT_HT_INITIAL_SIZE &&
-            (used*100/size < HASHTABLE_MIN_FILL));
+            ((double)used/size < HASHTABLE_MIN_FILL));
 }
 
 /* In cluster-enabled setup, this method traverses through all main/expires dictionaries (CLUSTER_SLOTS)


### PR DESCRIPTION
In the past we used integers to compare ratios, let us assume that
we have the following data in expanding:
```
used / size > 5
`80 / 16 > 5` is false
`81 / 16 > 5` is false
`95 / 16 > 5` is false
`96 / 16 > 5` is true
```

Because the integer result is rounded, our resize breaks the ratio
constraint, this has existed since the beginning, which resulted in
us not strictly following the ratio (shrink also has the same issue).

This PR change it to multiplication to avoid floating point calculations. 