### PR TITLE
Optimizing `zslRandomLevel` for P = 1/4 and MAXLEVEL = 32 with ctz

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -518,8 +518,8 @@ typedef enum {
 /* Anti-warning macro... */
 #define UNUSED(V) ((void) V)
 
-#define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
-#define ZSKIPLIST_P_DENOMINATOR 4      /* Skiplist P = 1/4 */
+#define ZSKIPLIST_MAXLEVEL 32     /* Should be enough for 2^64 elements */
+#define ZSKIPLIST_P_DENOMINATOR 4 /* Skiplist P = 1/4 */
 #define ZSKIPLIST_MAX_SEARCH 10
 
 /* Append only defines */

--- a/src/server.h
+++ b/src/server.h
@@ -518,7 +518,7 @@ typedef enum {
 /* Anti-warning macro... */
 #define UNUSED(V) ((void) V)
 
-#define ZSKIPLIST_MAXLEVEL 32     /* Should be enough for 2^64 elements */
+#define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
 #define ZSKIPLIST_P_DENOMINATOR 4 /* Skiplist P = 1/4 */
 #define ZSKIPLIST_MAX_SEARCH 10
 

--- a/src/server.h
+++ b/src/server.h
@@ -519,7 +519,7 @@ typedef enum {
 #define UNUSED(V) ((void) V)
 
 #define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
-#define ZSKIPLIST_P 0.25      /* Skiplist P = 1/4 */
+#define ZSKIPLIST_P_DENOMINATOR 4      /* Skiplist P = 1/4 */
 #define ZSKIPLIST_MAX_SEARCH 10
 
 /* Append only defines */


### PR DESCRIPTION
The idea is that since `random()` generates uniformly distributed random numbers in the range `[0, 2^31-1]`, we can assume that each bit in a generated number has a 50% chance of being 0.
Therefore, the probability that a random number has its last `2k` bits all set to 0 is `1/(2^(2k))` = `1/(4^k)`.
In the case of a skip list where `P = 1/4`, this probability aligns perfectly with the probability of a random level.

