### PR TITLE
Fix crash in LSET command when replacing small list items with larger ones, creating listpacks larger than 4GB

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -794,6 +794,7 @@ void quicklistReplaceEntry(quicklistIter *iter, quicklistEntry *entry,
             unsigned char *p = lpSeek(entry->node->entry, -1);
             quicklistDelIndex(quicklist, entry->node, &p);
             entry->node->dont_compress = 0; /* Re-enable compression */
+            _quicklistMergeNodes(quicklist, entry->node);
             quicklistCompress(quicklist, entry->node);
             quicklistCompress(quicklist, entry->node->next);
         }

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -381,6 +381,16 @@ if {[lindex [r config get proto-max-bulk-len] 1] == 10000000000} {
        assert_equal [read_big_bulk {r rpop lst}] $str_length
    } {} {large-memory}
 
+    test {Test LSET on plain nodes with large elements under packed_threshold over 4GB} {
+        r flushdb
+        r rpush lst a b c d e
+        for {set i 0} {$i < 5} {incr i} {
+            r write "*4\r\n\$4\r\nlset\r\n\$3\r\nlst\r\n\$1\r\n$i\r\n"
+            write_big_bulk 1000000000
+        }
+        r ping
+    } {PONG} {large-memory}
+
    test {Test LMOVE on plain nodes over 4GB} {
        r flushdb
        r RPUSH lst2{t} "aa"

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -220,6 +220,7 @@ start_server [list overrides [list save ""] ] {
 
     # checking LSET in case ziplist needs to be split
     test {Test LSET with packed is split in the middle} {
+        set original_config [config_get_set list-max-listpack-size 4]
         r flushdb
         r debug quicklist-packed-threshold 5b
         r RPUSH lst "aa"
@@ -227,6 +228,7 @@ start_server [list overrides [list save ""] ] {
         r RPUSH lst "cc"
         r RPUSH lst "dd"
         r RPUSH lst "ee"
+        assert_encoding quicklist lst
         r lset lst 2 [string repeat e 10]
         assert_equal [r lpop lst] "aa"
         assert_equal [r lpop lst] "bb"
@@ -234,6 +236,7 @@ start_server [list overrides [list save ""] ] {
         assert_equal [r lpop lst] "dd"
         assert_equal [r lpop lst] "ee"
         r debug quicklist-packed-threshold 0
+        r config set list-max-listpack-size $original_config
     } {OK} {needs:debug}
 
 


### PR DESCRIPTION
Fix #12864

The main reason for this crash is that when replacing a element of a quicklist packed node with lpReplace() method,
if the final size is larger than 4GB, lpReplace() will fail and returns NULL, causing `node->entry` to be incorrectly set to NULL.

Since the inserted data is not a large element, we can't just replace it like a large element, first quicklistInsertAfter()
and then quicklistDelIndex(), because the current node may be merged and invalidated in quicklistInsertAfter().

The solution of this PR:
When replacing a node fails (listpack exceeds 4GB), split the current node, create a new node to put in the middle, and try to merge them.
This is the same as inserting a large element.
In the worst case, its size will not exceed 4GB.

```
Release notes:
Crash in LSET command when replacing small items and exceeding 4GB
```