### PR TITLE
Record the time a replica attempts to connect with master

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2932,6 +2932,7 @@ write_error: /* Handle sendCommand() errors. */
 
 int connectWithMaster(void) {
     server.repl_transfer_s = connCreate(connTypeOfReplication());
+    server.repl_master_connect_time = server.unixtime;
     if (connConnect(server.repl_transfer_s, server.masterhost, server.masterport,
                 server.bind_source_addr, syncWithMaster) == C_ERR) {
         serverLog(LL_WARNING,"Unable to connect to MASTER: %s",
@@ -2940,7 +2941,6 @@ int connectWithMaster(void) {
         server.repl_transfer_s = NULL;
         return C_ERR;
     }
-
 
     server.repl_transfer_lastio = server.unixtime;
     server.repl_state = REPL_STATE_CONNECTING;

--- a/src/replication.c
+++ b/src/replication.c
@@ -2263,6 +2263,7 @@ void readSyncBulkPayload(connection *conn) {
     replicationCreateMasterClient(server.repl_transfer_s,rsi.repl_stream_db);
     server.repl_state = REPL_STATE_CONNECTED;
     server.repl_down_since = 0;
+    server.repl_up_since = server.unixtime;
 
     /* Fire the master link modules event. */
     moduleFireServerEvent(REDISMODULE_EVENT_MASTER_LINK_CHANGE,
@@ -3100,8 +3101,9 @@ void replicationUnsetMaster(void) {
      * failover if slaves do not connect immediately. */
     server.repl_no_slaves_since = server.unixtime;
     
-    /* Reset down time so it'll be ready for when we turn into replica again. */
+    /* Reset up and down time so it'll be ready for when we turn into replica again. */
     server.repl_down_since = 0;
+    server.repl_up_since = 0;
 
     /* Fire the role change modules event. */
     moduleFireServerEvent(REDISMODULE_EVENT_REPLICATION_ROLE_CHANGED,
@@ -3125,6 +3127,7 @@ void replicationHandleMasterDisconnection(void) {
     server.master = NULL;
     server.repl_state = REPL_STATE_CONNECT;
     server.repl_down_since = server.unixtime;
+    server.repl_up_since = 0;
     /* We lost connection with our master, don't disconnect slaves yet,
      * maybe we'll be able to PSYNC with our master later. We'll disconnect
      * the slaves only if we'll have to do a full resync with our master. */
@@ -3405,6 +3408,7 @@ void replicationResurrectCachedMaster(connection *conn) {
     server.master->lastinteraction = server.unixtime;
     server.repl_state = REPL_STATE_CONNECTED;
     server.repl_down_since = 0;
+    server.repl_up_since = server.unixtime;
 
     /* Fire the master link modules event. */
     moduleFireServerEvent(REDISMODULE_EVENT_MASTER_LINK_CHANGE,

--- a/src/server.c
+++ b/src/server.c
@@ -6006,7 +6006,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             } else {
                 info = sdscatprintf(info,
                     "master_link_up_since_seconds:%jd\r\n",
-                    server.repl_up_since ? // defensive code, should never be 0 when connected
+                    server.repl_up_since ? /* defensive code, should never be 0 when connected */
                     (intmax_t)(server.unixtime-server.repl_up_since) : -1);
             }
             info = sdscatprintf(info, FMTARGS(

--- a/src/server.c
+++ b/src/server.c
@@ -2210,6 +2210,7 @@ void initServerConfig(void) {
     server.repl_transfer_s = NULL;
     server.repl_syncio_timeout = CONFIG_REPL_SYNCIO_TIMEOUT;
     server.repl_down_since = 0; /* Never connected, repl is down since EVER. */
+    server.repl_master_connect_time = -1;
     server.master_repl_offset = 0;
     server.fsynced_reploff_pending = 0;
 
@@ -5977,6 +5978,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                 "master_host:%s\r\n", server.masterhost,
                 "master_port:%d\r\n", server.masterport,
                 "master_link_status:%s\r\n", (server.repl_state == REPL_STATE_CONNECTED) ? "up" : "down",
+                "master_connect_time:%jd\r\n", (intmax_t)server.repl_master_connect_time,
                 "master_last_io_seconds_ago:%d\r\n", server.master ? ((int)(server.unixtime-server.master->lastinteraction)) : -1,
                 "master_sync_in_progress:%d\r\n", server.repl_state == REPL_STATE_TRANSFER,
                 "slave_read_repl_offset:%lld\r\n", slave_read_repl_offset,

--- a/src/server.c
+++ b/src/server.c
@@ -2210,7 +2210,10 @@ void initServerConfig(void) {
     server.repl_transfer_s = NULL;
     server.repl_syncio_timeout = CONFIG_REPL_SYNCIO_TIMEOUT;
     server.repl_down_since = 0; /* Never connected, repl is down since EVER. */
+    server.repl_up_since = 0;
     server.repl_master_sync_attempts = 0;
+    server.repl_master_connect_time = 0;
+    server.repl_total_disconnect_time = 0;
     server.master_repl_offset = 0;
     server.fsynced_reploff_pending = 0;
 
@@ -5965,6 +5968,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         if (server.masterhost) {
             long long slave_repl_offset = 1;
             long long slave_read_repl_offset = 1;
+            long long current_disconnect_time = server.repl_master_connect_time ?
+                server.unixtime - server.repl_master_connect_time : 0;
 
             if (server.master) {
                 slave_repl_offset = server.master->reploff;
@@ -6009,6 +6014,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                     (intmax_t)(server.unixtime-server.repl_up_since) : -1);
             }
             info = sdscatprintf(info, FMTARGS(
+                "total_disconnect_time_sec:%lld\r\n", server.repl_total_disconnect_time + current_disconnect_time,
                 "slave_priority:%d\r\n", server.slave_priority,
                 "slave_read_only:%d\r\n", server.repl_slave_ro,
                 "replica_announced:%d\r\n", server.replica_announced));

--- a/src/server.c
+++ b/src/server.c
@@ -2210,6 +2210,7 @@ void initServerConfig(void) {
     server.repl_transfer_s = NULL;
     server.repl_syncio_timeout = CONFIG_REPL_SYNCIO_TIMEOUT;
     server.repl_down_since = 0; /* Never connected, repl is down since EVER. */
+    server.repl_up_since = 0;
     server.repl_master_connect_time = -1;
     server.master_repl_offset = 0;
     server.fsynced_reploff_pending = 0;
@@ -6002,6 +6003,11 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                     "master_link_down_since_seconds:%jd\r\n",
                     server.repl_down_since ?
                     (intmax_t)(server.unixtime-server.repl_down_since) : -1);
+            } else {
+                info = sdscatprintf(info,
+                    "master_link_up_since_seconds:%jd\r\n",
+                    server.repl_up_since ? // defensive code, should never be 0 when connected
+                    (intmax_t)(server.unixtime-server.repl_up_since) : -1);
             }
             info = sdscatprintf(info, FMTARGS(
                 "slave_priority:%d\r\n", server.slave_priority,

--- a/src/server.c
+++ b/src/server.c
@@ -5979,7 +5979,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                 "master_host:%s\r\n", server.masterhost,
                 "master_port:%d\r\n", server.masterport,
                 "master_link_status:%s\r\n", (server.repl_state == REPL_STATE_CONNECTED) ? "up" : "down",
-                "master_connect_time:%jd\r\n", (intmax_t)server.repl_master_connect_time,
+                "master_attempt_connect_time:%jd\r\n", (intmax_t)server.repl_master_connect_time,
                 "master_last_io_seconds_ago:%d\r\n", server.master ? ((int)(server.unixtime-server.master->lastinteraction)) : -1,
                 "master_sync_in_progress:%d\r\n", server.repl_state == REPL_STATE_TRANSFER,
                 "slave_read_repl_offset:%lld\r\n", slave_read_repl_offset,

--- a/src/server.c
+++ b/src/server.c
@@ -2210,8 +2210,7 @@ void initServerConfig(void) {
     server.repl_transfer_s = NULL;
     server.repl_syncio_timeout = CONFIG_REPL_SYNCIO_TIMEOUT;
     server.repl_down_since = 0; /* Never connected, repl is down since EVER. */
-    server.repl_up_since = 0;
-    server.repl_master_connect_time = -1;
+    server.repl_master_sync_attempts = 0;
     server.master_repl_offset = 0;
     server.fsynced_reploff_pending = 0;
 
@@ -5979,7 +5978,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                 "master_host:%s\r\n", server.masterhost,
                 "master_port:%d\r\n", server.masterport,
                 "master_link_status:%s\r\n", (server.repl_state == REPL_STATE_CONNECTED) ? "up" : "down",
-                "master_attempt_connect_time:%jd\r\n", (intmax_t)server.repl_master_connect_time,
+                "master_sync_attempts:%lld\r\n", server.repl_master_sync_attempts,
                 "master_last_io_seconds_ago:%d\r\n", server.master ? ((int)(server.unixtime-server.master->lastinteraction)) : -1,
                 "master_sync_in_progress:%d\r\n", server.repl_state == REPL_STATE_TRANSFER,
                 "slave_read_repl_offset:%lld\r\n", slave_read_repl_offset,

--- a/src/server.h
+++ b/src/server.h
@@ -1929,9 +1929,11 @@ struct redisServer {
     char *slave_announce_ip;        /* Give the master this ip address. */
     int propagation_error_behavior; /* Configures the behavior of the replica
                                      * when it receives an error on the replication stream */
-    int repl_ignore_disk_write_error;   /* Configures whether replicas panic when unable to
-                                         * persist writes to AOF. */
-    long long repl_master_sync_attempts;/* Total number of attempts to connect to a master  */
+    int repl_ignore_disk_write_error;     /* Configures whether replicas panic when unable to
+                                           * persist writes to AOF. */
+    long long repl_master_sync_attempts;  /* Total number of attempts to connect to a master  */
+    time_t repl_master_connect_time;      /* Unix time that master connection start */
+    long long repl_total_disconnect_time; /* The total cumulative time that a replica has been disconnected */
     /* The following two fields is where we store master PSYNC replid/offset
      * while the PSYNC is in progress. At the end we'll copy the fields into
      * the server->master client structure. */

--- a/src/server.h
+++ b/src/server.h
@@ -1917,6 +1917,7 @@ struct redisServer {
     int repl_transfer_fd;    /* Slave -> Master SYNC temp file descriptor */
     char *repl_transfer_tmpfile; /* Slave-> master SYNC temp file name */
     time_t repl_transfer_lastio; /* Unix time of the latest read, for timeout */
+    time_t repl_master_connect_time; /* Unix time of trying build Replica -> Master connection */
     int repl_serve_stale_data; /* Serve stale data when link is down? */
     int repl_slave_ro;          /* Slave is read only? */
     int repl_slave_ignore_maxmemory;    /* If true slaves do not evict. */

--- a/src/server.h
+++ b/src/server.h
@@ -1917,7 +1917,6 @@ struct redisServer {
     int repl_transfer_fd;    /* Slave -> Master SYNC temp file descriptor */
     char *repl_transfer_tmpfile; /* Slave-> master SYNC temp file name */
     time_t repl_transfer_lastio; /* Unix time of the latest read, for timeout */
-    time_t repl_master_connect_time; /* Unix time of trying build Replica -> Master connection */
     int repl_serve_stale_data; /* Serve stale data when link is down? */
     int repl_slave_ro;          /* Slave is read only? */
     int repl_slave_ignore_maxmemory;    /* If true slaves do not evict. */
@@ -1932,6 +1931,7 @@ struct redisServer {
                                      * when it receives an error on the replication stream */
     int repl_ignore_disk_write_error;   /* Configures whether replicas panic when unable to
                                          * persist writes to AOF. */
+    long long repl_master_sync_attempts;/* Total number of attempts to connect to a master  */
     /* The following two fields is where we store master PSYNC replid/offset
      * while the PSYNC is in progress. At the end we'll copy the fields into
      * the server->master client structure. */

--- a/src/server.h
+++ b/src/server.h
@@ -1922,6 +1922,7 @@ struct redisServer {
     int repl_slave_ro;          /* Slave is read only? */
     int repl_slave_ignore_maxmemory;    /* If true slaves do not evict. */
     time_t repl_down_since; /* Unix time at which link with master went down */
+    time_t repl_up_since;   /* Unix time that master link is fully up and healthy */
     int repl_disable_tcp_nodelay;   /* Disable TCP_NODELAY after SYNC? */
     int slave_priority;             /* Reported in INFO and used by Sentinel. */
     int replica_announced;          /* If true, replica is announced by Sentinel */


### PR DESCRIPTION
Some users want to monitor whether there have been any disconnections between master and replica. It is easy to determine if it is disconnected and has not been reestablished, for example, by observing the `master_link_status` or `master_link_down_since_seconds` information in the `info replication`. However, if the replication link quickly returns to normal, it is not possible to observe the occurrence of this interruption. Of course, analyzing the redis.log can provide information about master/replica connection lost, but it is not as intuitive. It would be more beneficial to observe the relevant information through the `info replication` command.

The PR adds three new metrics:
1. `master_sync_attempts` - total number of attempts to connect to a master since the last time we disconnected from a good connection (or a configuration change). any number greater than 1 (even if the link is currently up), indicates an issue.
2. `total_disconnect_time_sec` - the total cumulative time we've been disconnected  as a replica, visible when the link is up too.
3. `master_link_up_since_seconds` - the number of seconds since the link is down, just maintain symmetry with `master_link_down_since_seconds`.