### PR TITLE
Fix unexpected resize causing test failure

### DIFF
--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -439,8 +439,8 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
         r config set rdb-key-save-delay 10000000
         r bgsave
 
-        # delete data to have lot's (99%) of empty buckets
-        for {set j 1} {$j <= 127} {incr j} {
+        # delete data to have lot's (98%) of empty buckets
+        for {set j 1} {$j <= 125} {incr j} {
             r del "{foo}$j"
         }
         assert_match "*table size: 128*" [r debug HTSTATS 0]
@@ -470,7 +470,7 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
         r config set rdb-key-save-delay 10000000
         r bgsave
 
-        for {set j 1} {$j <= 127} {incr j} {
+        for {set j 1} {$j <= 125} {incr j} {
             r del "{alice}$j"
         }
 


### PR DESCRIPTION
Before #12850, we will only try to shrink the dict in serverCron,
which we can control by using a child process, but now every time
we delete a key, the shrink check will be called.

In these test (added in #12802), we meant to disable the resizing,
but druing the delete, the dict will meet the force shrink, like
2 / 128 = 0.015 < 0.2, the delete will trigger a force resize and
will cause the test to fail.

In this commit, we try to keep the load factor at 3 / 128 = 0.023,
that is, do not meet the force shrink.