### PR TITLE
Expose lua os.clock() api

### DIFF
--- a/deps/lua/src/loslib.c
+++ b/deps/lua/src/loslib.c
@@ -234,10 +234,17 @@ static const luaL_Reg syslib[] = {
 
 /* }====================================================== */
 
+#define UNUSED(V) ((void) V)
 
+/* Only a subset is loaded currently, for sandboxing concerns. */
+static const luaL_Reg sandbox_syslib[] = {
+  {"clock",     os_clock},
+  {NULL, NULL}
+};
 
 LUALIB_API int luaopen_os (lua_State *L) {
-  luaL_register(L, LUA_OSLIBNAME, syslib);
+  UNUSED(syslib);
+  luaL_register(L, LUA_OSLIBNAME, sandbox_syslib);
   return 1;
 }
 

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -1212,24 +1212,6 @@ static int luaSetResp(lua_State *lua) {
     return 0;
 }
 
-/* redis.elapsed_start() */
-static int redis_elapsed_start(lua_State *L) {
-    monotime *timer = lua_newuserdata(L, sizeof(monotime));
-    *timer = getMonotonicUs();
-    return 1;
-}
-
-/* redis.elapsed_us() */
-static int redis_elapsed_us(lua_State *L) {
-    if (lua_gettop(L) != 1)
-        return luaL_error(L, "Wrong number of arguments for redis.elapsed_us");
-
-    monotime *timer = (monotime *)lua_touserdata(L, -1);
-    if (!timer) return luaL_error(L, "Invalid timer object");
-    lua_pushnumber(L, (lua_Number)elapsedUs(*timer));
-    return 1;
-}
-
 /* ---------------------------------------------------------------------------
  * Lua engine initialization and reset.
  * ------------------------------------------------------------------------- */
@@ -1472,14 +1454,6 @@ void luaRegisterRedisAPI(lua_State* lua) {
     /* redis.set_repl and associated flags. */
     lua_pushstring(lua,"set_repl");
     lua_pushcfunction(lua,luaRedisSetReplCommand);
-    lua_settable(lua,-3);
-
-    lua_pushstring(lua,"elapsed_start");
-    lua_pushcfunction(lua,redis_elapsed_start);
-    lua_settable(lua,-3);
-
-    lua_pushstring(lua,"elapsed_us");
-    lua_pushcfunction(lua,redis_elapsed_us);
     lua_settable(lua,-3);
 
     lua_pushstring(lua,"REPL_NONE");

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -51,6 +51,7 @@ static char *libraries_allow_list[] = {
     "math",
     "table",
     "struct",
+    "os",
     NULL,
 };
 
@@ -1211,6 +1212,12 @@ static int luaSetResp(lua_State *lua) {
     return 0;
 }
 
+/* redis.monotonic() */
+static int redis_monotonic(lua_State *L) {
+    lua_pushnumber(L, (lua_Number)getMonotonicUs());
+    return 1;
+}
+
 /* ---------------------------------------------------------------------------
  * Lua engine initialization and reset.
  * ------------------------------------------------------------------------- */
@@ -1232,6 +1239,7 @@ static void luaLoadLibraries(lua_State *lua) {
     luaLoadLib(lua, LUA_STRLIBNAME, luaopen_string);
     luaLoadLib(lua, LUA_MATHLIBNAME, luaopen_math);
     luaLoadLib(lua, LUA_DBLIBNAME, luaopen_debug);
+    luaLoadLib(lua, LUA_OSLIBNAME, luaopen_os);
     luaLoadLib(lua, "cjson", luaopen_cjson);
     luaLoadLib(lua, "struct", luaopen_struct);
     luaLoadLib(lua, "cmsgpack", luaopen_cmsgpack);
@@ -1239,7 +1247,6 @@ static void luaLoadLibraries(lua_State *lua) {
 
 #if 0 /* Stuff that we don't load currently, for sandboxing concerns. */
     luaLoadLib(lua, LUA_LOADLIBNAME, luaopen_package);
-    luaLoadLib(lua, LUA_OSLIBNAME, luaopen_os);
 #endif
 }
 
@@ -1453,6 +1460,10 @@ void luaRegisterRedisAPI(lua_State* lua) {
     /* redis.set_repl and associated flags. */
     lua_pushstring(lua,"set_repl");
     lua_pushcfunction(lua,luaRedisSetReplCommand);
+    lua_settable(lua,-3);
+
+    lua_pushstring(lua,"monotonic");
+    lua_pushcfunction(lua,redis_monotonic);
     lua_settable(lua,-3);
 
     lua_pushstring(lua,"REPL_NONE");

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -621,15 +621,12 @@ start_server {tags {"scripting"}} {
     }
 
     test "os.clock() measures elapsed time" {
-        set start [clock seconds]
-        set escape [run_script {
+        set escaped [run_script {
             local start = os.clock()
-            for i=1,100 do redis.call('ping') end
-            local escape = os.clock() - start
-            return {double=escape}
+            while os.clock() - start < 1 do end
+            return {double = os.clock() - start}
         } 0]
-        assert_morethan $escape 0
-        assert_lessthan $escape [expr [clock seconds]-$start]
+        assert_morethan_equal $escaped 1
     }
 
     test "Prohibited dangerous lua methods in sandbox" {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -653,11 +653,11 @@ start_server {tags {"scripting"}} {
             -- If an allowed method is found, it's removed from 'allowed_functions'.
             -- If 'allowed_functions' is empty at the end, all allowed methods were found.
             for key, value in pairs(os) do
-                if type(value) == "function" then
-                    local index = indexOf(allowed_methods, key)
-                    if index == nil then return "Disallowed function:"..key end
-                    table.remove(allowed_methods, index)
+                local index = indexOf(allowed_methods, key)
+                if index == nil or type(value) ~= "function" then
+                    return "Disallowed "..type(value)..":"..key
                 end
+                table.remove(allowed_methods, index)
             end
             if #allowed_methods ~= 0 then
                 return "Expected method not found: "..table.concat(allowed_methods, ",")

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -616,20 +616,6 @@ start_server {tags {"scripting"}} {
              [run_script {return redis.sha1hex('Pizza & Mandolino')} 0]
     } {da39a3ee5e6b4b0d3255bfef95601890afd80709 74822d82031af7493c20eefa13bd07ec4fada82f}
 
-    test "Measures elapsed time with redis.elapsed_start() and redis.elapsed_us()" {
-        # Test if redis.elapsed_us() correctly handles incorrect number of arguments and invalid timer object
-        assert_error {ERR* Wrong number of arguments for redis.elapsed_us*} {run_script {redis.elapsed_us()} 0}
-        assert_error {ERR* Invalid timer object*} {run_script {redis.elapsed_us("invalid")} 0}
-
-        # Test accurate calculation of Lua script execution time.
-        set escaped [run_script {
-            local start_timer = redis.elapsed_start()
-            while redis.elapsed_us(start_timer) < 1000000 do end
-            return {double = redis.elapsed_us(start_timer)}
-        } 0]
-        assert_morethan_equal $escaped 1000000 ;# 1 second (1 second = 1000000 microseconds)
-    }
-
     test "Measures elapsed time os.clock()" {
         set escaped [run_script {
             local start = os.clock()

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -639,7 +639,7 @@ start_server {tags {"scripting"}} {
         assert_morethan_equal $escaped 1 ;# 1 second
     }
 
-    test "Prohibited dangerous lua methods in sandbox" {
+    test "Prohibit dangerous lua methods in sandbox" {
         assert_equal "" [run_script {
             local allowed_methods = {"clock"}
             -- Find a value from a tuple and return the position.

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -650,8 +650,8 @@ start_server {tags {"scripting"}} {
                 return nil
             end
             -- Check for disallowed methods and verify all allowed methods exist.
-            -- If an allowed method is found, it's removed from 'allowed_functions'.
-            -- If 'allowed_functions' is empty at the end, all allowed methods were found.
+            -- If an allowed method is found, it's removed from 'allowed_methods'.
+            -- If 'allowed_methods' is empty at the end, all allowed methods were found.
             for key, value in pairs(os) do
                 local index = indexOf(allowed_methods, key)
                 if index == nil or type(value) ~= "function" then

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -652,6 +652,16 @@ start_server {tags {"scripting"}} {
         } 0]
     }
 
+    test "Verify execution of prohibit dangerous Lua methods will fail" {
+        assert_error {ERR *attempt to call field 'execute'*} {run_script {os.execute()} 0}
+        assert_error {ERR *attempt to call field 'exit'*} {run_script {os.exit()} 0}
+        assert_error {ERR *attempt to call field 'getenv'*} {run_script {os.getenv()} 0}
+        assert_error {ERR *attempt to call field 'remove'*} {run_script {os.remove()} 0}
+        assert_error {ERR *attempt to call field 'rename'*} {run_script {os.rename()} 0}
+        assert_error {ERR *attempt to call field 'setlocale'*} {run_script {os.setlocale()} 0}
+        assert_error {ERR *attempt to call field 'tmpname'*} {run_script {os.tmpname()} 0}
+    }
+
     test {Globals protection reading an undeclared global variable} {
         catch {run_script {return a} 0} e
         set e


### PR DESCRIPTION
Implement #12699

This PR exposing Lua os.clock() api for getting the elapsed time of Lua code execution.

Using:
```lua
local start = os.clock()
...
do something
...
local elpased = os.clock() - start
```

