### PR TITLE
add -fno-omit-frame-pointer to default complication flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,9 @@ ifeq ($(OPTIMIZATION),-O3)
 	endif
 	REDIS_LDFLAGS+=-O3 -flto
 endif
+ifneq ($(OPTIMIZATION),-O0)
+	REDIS_CFLAGS+=-fno-omit-frame-pointer
+endif
 DEPENDENCY_TARGETS=hiredis linenoise lua hdr_histogram fpconv
 NODEPS:=clean distclean
 


### PR DESCRIPTION
Copy the discuss from #12861 :
Now redis use O3 level optimization that would remove the frame pointer in the target bin.

In the very old past, when gcc optimized at O1 and above levels, the frame pointer is deleted by default to improve performance. This saves the RBP registers and reduces the pop/push instructions. But it makes it difficult for us to observe the running status of the program. For example, the perf tool cannot be used effectively, especially the modern eBPF tools such as bcc/memleak.

# Concerns about performance degradation:
I tested the performance on Intel x64 CPU and Apple M1 CPU, there is no performance degradation was observed in get/set performance. I think modern CPUs, whether x64 or arm, already have enough registers. Therefore, the optimization of frame pointer is basically useless.

benchmark command:`memtier_benchmark -s IP -p PORT --key-prefix="TEST_" --key-maximum=1500000 --key-pattern=R:R  --test-time=60 -R -t 10 -c 20 --pipeline=10 --hide-histogram`

branch | round1 | round2 | round3
-- | -- | -- | --
unstable | 720242(P99=5.151) | 715648(P99=4.959) | 725698(P99=4.575)
this pr | 716576(P99=4.511) | 722407(P99=4.895) | 721903(P99=4.479)




# Other software:
Fedora38 also started to add -fno-omit-frame-pointer, we can refer to this blog [article,](https://fedoraproject.org/wiki/Changes/fno-omit-frame-pointer) which also mentioned:"Redis benchmarks do not seem to be significantly impacted when built with frame pointers."
It is said that Meta and Google also added frame pointers when compiling their internal software.