### PR TITLE
Tracking clients memory more accurate

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -985,10 +985,6 @@ static inline clientMemUsageBucket *getMemUsageBucket(size_t mem) {
  * This method updates the client memory usage and update the
  * server stats for client type.
  *
- * This method is called from the clientsCron to have updated
- * stats for non CLIENT_TYPE_NORMAL/PUBSUB clients to accurately
- * provide information around clients memory usage.
- *
  * It is also used in updateClientMemUsageAndBucket to have latest
  * client memory usage information to place it into appropriate client memory
  * usage bucket.
@@ -1039,24 +1035,19 @@ void removeClientFromMemUsageBucket(client *c, int allow_eviction) {
  * all clients with roughly the same amount of memory. This way we group
  * together clients consuming about the same amount of memory and can quickly
  * free them in case we reach maxmemory-clients (client eviction).
- *
- * Note: This function filters clients of type no-evict, master or replica regardless
- * of whether the eviction is enabled or not, so the memory usage we get from these
- * types of clients via the INFO command may be out of date.
- *
- * returns 1 if client eviction for this client is allowed, 0 otherwise.
  */
-int updateClientMemUsageAndBucket(client *c) {
+void updateClientMemUsageAndBucket(client *c) {
     serverAssert(io_threads_op == IO_THREADS_OP_IDLE && c->conn);
+
+    /* Update client memory usage. */
+    updateClientMemoryUsage(c);
+
     int allow_eviction = clientEvictionAllowed(c);
     removeClientFromMemUsageBucket(c, allow_eviction);
 
     if (!allow_eviction) {
-        return 0;
+        return;
     }
-
-    /* Update client memory usage. */
-    updateClientMemoryUsage(c);
 
     /* Update the client in the mem usage buckets */
     clientMemUsageBucket *bucket = getMemUsageBucket(c->last_memory_usage);
@@ -1069,7 +1060,6 @@ int updateClientMemUsageAndBucket(client *c) {
         listAddNodeTail(bucket->clients, c);
         c->mem_usage_bucket_node = listLast(bucket->clients);
     }
-    return 1;
 }
 
 /* Return the max samples in the memory usage of clients tracked by
@@ -1149,18 +1139,7 @@ void clientsCron(void) {
         if (clientsCronHandleTimeout(c,now)) continue;
         if (clientsCronResizeQueryBuffer(c)) continue;
         if (clientsCronResizeOutputBuffer(c,now)) continue;
-
         if (clientsCronTrackExpansiveClients(c, curr_peak_mem_usage_slot)) continue;
-
-        /* Iterating all the clients in getMemoryOverheadData() is too slow and
-         * in turn would make the INFO command too slow. So we perform this
-         * computation incrementally and track the (not instantaneous but updated
-         * to the second) total memory used by clients using clientsCron() in
-         * a more incremental way (depending on server.hz).
-         * If client eviction is enabled, update the bucket as well. */
-        if (!updateClientMemUsageAndBucket(c))
-            updateClientMemoryUsage(c);
-
         if (closeClientOnOutputBufferLimitReached(c, 0)) continue;
     }
 }

--- a/src/server.h
+++ b/src/server.h
@@ -2685,7 +2685,7 @@ int handleClientsWithPendingWritesUsingThreads(void);
 int handleClientsWithPendingReadsUsingThreads(void);
 int stopThreadedIOIfNeeded(void);
 int clientHasPendingReplies(client *c);
-int updateClientMemUsageAndBucket(client *c);
+void updateClientMemUsageAndBucket(client *c);
 void removeClientFromMemUsageBucket(client *c, int allow_eviction);
 void unlinkClient(client *c);
 int writeToClient(client *c, int handler_installed);


### PR DESCRIPTION
After client-eviction (#8687) and its optimization (#11348), we have the ability to real-time and accurately track the total amount of memory used by all clients. However, there are some minor improvements needed to make this mechanism work better:

1. The client memory usage and client-evict's `mem_usage_bucket` are not dependent on each other. Therefore, in the `updateClientMemUsageAndBucket` function, we can execute `updateClientMemoryUsage` for all clients (coming from the network) without checking `clientEvictionAllowed`.
    * This way, we can accurately track the memory usage of all clients in real-time, without `clientsCron`.

2. When a client (coming from the network) is created, we should also track its memory usage in `linkClient`.
    * Then idle clients can be accurately and instantly tracked. Although the previous `clientsCron` could achieve this, it was not real-time enough and also resulted in idle clients not being able to be evicted.
    * Additionally, this allows the special clients work properly. Currently, the master client is initially created as a fake client and then, after replication is established, `linkClient` is called in `replicationResurrectCachedMaster`.

3. When a client (coming from the network) is released, we should also release its memory and `mem_usage_bucket` in `unlinkClient` to prevent any statistical errors.
    * On one hand, this is to maintain symmetry with `linkClient`. On the other hand, when a replication connection is disconnected, we do not call `freeClient` on the master client, but instead execute `unlinkClient`. This also helps to minimize some risks.
