### PR TITLE
Add sender NULL check in clusterProcessGossipSection invalid_ids case

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2091,7 +2091,11 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
      * the nodes dictionary. An invalid ID indicates memory corruption on the sender side. */
     int invalid_ids = verifyGossipSectionNodeIds(g, count);
     if (invalid_ids) {
-        serverLog(LL_WARNING, "Node %.40s (%s) gossiped %d nodes with invalid IDs.", sender->name, sender->human_nodename, invalid_ids);
+        if (sender) {
+            serverLog(LL_WARNING, "Node %.40s (%s) gossiped %d nodes with invalid IDs.", sender->name, sender->human_nodename, invalid_ids);
+        } else {
+            serverLog(LL_WARNING, "Unknown node gossiped %d nodes with invalid IDs.", invalid_ids);
+        }
         return;
     }
 


### PR DESCRIPTION
In the following case sender may be unknown, so we need to set up a
NULL check for sender:
```
/* If this is a MEET packet from an unknown node, we still process
 * the gossip section here since we have to trust the sender because
 * of the message type. */
if (!sender && type == CLUSTERMSG_TYPE_MEET)
    clusterProcessGossipSection(hdr,link);
```

Introduced in #12921.