### PR TITLE
Pick random slot for a node to distribute operation across slots in redis-benchmark

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -166,7 +166,6 @@ typedef struct clusterNode {
     sds replicate;  /* Master ID if node is a slave */
     int *slots;
     int slots_count;
-    int current_slot_index;
     int *updated_slots;         /* Used by updateClusterSlotsConfiguration */
     int updated_slots_count;    /* Used by updateClusterSlotsConfiguration */
     int replicas_count;
@@ -417,7 +416,6 @@ static void setClusterKeyHashTag(client c) {
     assert(c->thread_id >= 0);
     clusterNode *node = c->cluster_node;
     assert(node);
-    assert(node->current_slot_index < node->slots_count);
     int is_updating_slots = 0;
     atomicGet(config.is_updating_slots, is_updating_slots);
     /* If updateClusterSlotsConfiguration is updating the slots array,
@@ -427,8 +425,7 @@ static void setClusterKeyHashTag(client c) {
      * updateClusterSlotsConfiguration won't actually do anything, since
      * the updated_slots_count array will be already NULL. */
     if (is_updating_slots) updateClusterSlotsConfiguration();
-    node->current_slot_index = rand() % node->slots_count;
-    int slot = node->slots[node->current_slot_index];
+    int slot = node->slots[rand() % node->slots_count];
     const char *tag = crc16_slot_table[slot];
     int taglen = strlen(tag);
     size_t i;
@@ -1048,7 +1045,6 @@ static clusterNode *createClusterNode(char *ip, int port) {
     node->replicas_count = 0;
     node->slots = zmalloc(CLUSTER_SLOTS * sizeof(int));
     node->slots_count = 0;
-    node->current_slot_index = 0;
     node->updated_slots = NULL;
     node->updated_slots_count = 0;
     node->migrating = NULL;
@@ -1371,7 +1367,6 @@ static void updateClusterSlotsConfiguration(void) {
             int *oldslots = node->slots;
             node->slots = node->updated_slots;
             node->slots_count = node->updated_slots_count;
-            node->current_slot_index = 0;
             node->updated_slots = NULL;
             node->updated_slots_count = 0;
             zfree(oldslots);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -427,6 +427,7 @@ static void setClusterKeyHashTag(client c) {
      * updateClusterSlotsConfiguration won't actually do anything, since
      * the updated_slots_count array will be already NULL. */
     if (is_updating_slots) updateClusterSlotsConfiguration();
+    node->current_slot_index = rand() % node->slots_count;
     int slot = node->slots[node->current_slot_index];
     const char *tag = crc16_slot_table[slot];
     int taglen = strlen(tag);


### PR DESCRIPTION
Distribute operations via `redis-benchmark` on different slots owned by node.

`current_slot_index` is never updated hence the value is always `0` and the tag used is always the first slot owned by the node. Hence any read/write operation via `redis-benchmark` in cluster mode always happens on a particular slot. 

This is inconvenient to load data uniformly  via `redis-benchmark`. Hence, the fix.

Cluster setup:

```
127.0.0.1:6379> CLUSTER NODES
7f2bdc810e3a3e9f5e7103f3523dce99d9797135 127.0.0.1:6379@16379 myself,master - 0 0 1 connected 0-8191
9e0ff4c2a7c1e0e670dff584c1598707726e31c2 127.0.0.1:6380@16380 master - 0 1706147369905 0 connected 8192-16383
```

Test command:

```
 src/redis-benchmark -n 100 -k 1 -c 2 -r 100000 -t set --cluster
 ```
 
 unstable:
 
 ```
 127.0.0.1:6379> KEYS *
 1) "key:{06S}:000000052136"
 2) "key:{06S}:000000007735"
 3) "key:{06S}:000000021661"
 ...
 ```
 
 with this change:
 
 ```
127.0.0.1:6379> KEYS *
 1) "key:{499}:000000005118"
 2) "key:{5Kp}:000000079065"
 3) "key:{570}:000000006562"
...
```
Note: This will be a change in behavior however I think this should be the default.

```
Release notes
Fix redis-benchmark so it sends requests to all slots that a node owns instead of just a single slot.
```