### PR TITLE
Fix unauthenticated client query buffer 1MB limit

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2726,7 +2726,7 @@ void readQueryFromClient(connection *conn) {
          *
          * For unauthenticated clients, the query buffer cannot exceed 1MB at most. */
         (c->mstate.argv_len_sums + sdslen(c->querybuf) > server.client_max_querybuf_len ||
-         (c->mstate.argv_len_sums + sdslen(c->querybuf) > 1024*1024*1024 && authRequired(c)))) {
+         (c->mstate.argv_len_sums + sdslen(c->querybuf) > 1024*1024 && authRequired(c)))) {
         sds ci = catClientInfoString(sdsempty(),c), bytes = sdsempty();
 
         bytes = sdscatrepr(bytes,c->querybuf,64);


### PR DESCRIPTION
Code incorrectly set the limit value to 1024MB.
Introduced in #12961.