### PR TITLE
Adjust io-threads number in runtime to fully utilize multi I/O threads

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1592,8 +1592,8 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
         migrateCloseTimedoutSockets();
     }
 
-    /* Stop the I/O threads if we don't have enough pending work. */
-    stopThreadedIOIfNeeded();
+    /* Adjust the I/O threads according to the realtime workloads. */
+    adjustThreadedIOIfNeeded();
 
     /* Resize tracking keys table if needed. This is also done at every
      * command execution, but we want to be sure that if the last command
@@ -2721,6 +2721,7 @@ void initServer(void) {
     server.slaves = listCreate();
     server.monitors = listCreate();
     server.clients_pending_write = listCreate();
+    server.clients_pending_write_avg_num = 0;
     server.clients_pending_read = listCreate();
     server.clients_timeout_table = raxNew();
     server.replication_allowed = 1;
@@ -5644,7 +5645,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "lru_clock:%u\r\n", server.lruclock,
             "executable:%s\r\n", server.executable ? server.executable : "",
             "config_file:%s\r\n", server.configfile ? server.configfile : "",
-            "io_threads_active:%i\r\n", server.io_threads_active));
+            "io_threads_active_num:%i\r\n", server.io_threads_active_num));
 
         /* Conditional properties */
         if (isShutdownInitiated()) {

--- a/src/server.h
+++ b/src/server.h
@@ -1623,6 +1623,7 @@ struct redisServer {
     list *clients;              /* List of active clients */
     list *clients_to_close;     /* Clients to close asynchronously */
     list *clients_pending_write; /* There is to write or install handler. */
+    int clients_pending_write_avg_num; /* State of last x rounds pending write requests. */
     list *clients_pending_read;  /* Client has pending read socket buffers. */
     list *slaves, *monitors;    /* List of slaves and MONITORs */
     client *current_client;     /* The client that triggered the command execution (External or AOF). */
@@ -1648,9 +1649,9 @@ struct redisServer {
     dict *migrate_cached_sockets;/* MIGRATE cached sockets */
     redisAtomic uint64_t next_client_id; /* Next client unique ID. Incremental. */
     int protected_mode;         /* Don't accept external connections. */
-    int io_threads_num;         /* Number of IO threads to use. */
+    int io_threads_num;         /* Maximum number of IO threads to use. */
     int io_threads_do_reads;    /* Read and parse from IO threads? */
-    int io_threads_active;      /* Is IO threads currently active? */
+    int io_threads_active_num;  /* Number of active IO threads to use. */
     long long events_processed_while_blocked; /* processEventsWhileBlocked() */
     int enable_protected_configs;    /* Enable the modification of protected configs, see PROTECTED_ACTION_ALLOWED_* */
     int enable_debug_cmd;            /* Enable DEBUG commands, see PROTECTED_ACTION_ALLOWED_* */
@@ -2683,7 +2684,7 @@ void blockingOperationEnds(void);
 int handleClientsWithPendingWrites(void);
 int handleClientsWithPendingWritesUsingThreads(void);
 int handleClientsWithPendingReadsUsingThreads(void);
-int stopThreadedIOIfNeeded(void);
+int adjustThreadedIOIfNeeded(void);
 int clientHasPendingReplies(client *c);
 int updateClientMemUsageAndBucket(client *c);
 void removeClientFromMemUsageBucket(client *c, int allow_eviction);


### PR DESCRIPTION
## Description
This patch try to fix the issue when large io-threads number is configured, io-threads will be stopped according below logic, this will cause the io-threads useless  and longer latency. 
```c
int stopThreadedIOIfNeeded(void) {
    int pending = listLength(server.clients_pending_write);

    /* Return ASAP if IO threads are disabled (single threaded mode). */
    if (server.io_threads_num == 1) return 1;

    if (pending < (server.io_threads_num*2)) {
        if (server.io_threads_active) stopThreadedIO();
        return 1;
    } else {
        return 0;
    }
}
```
With this patch, it will dynamically adjust the /IO threads number in runtime according to real workloads to tradeoff between the latency and CPU efficiency. We use decay rate formula based on `clients_pending_writes` to make throughput stable. 

## Benchmark Result
### Test Environment

- OS: CentOS Stream 8
- Kernel: 6.2.0
- Platform: Intel Xeon Platinum 8380
- Redis Base: 85a834bfa2a31cd7c5754fe1611cf059657c0fb4 

### Test Steps 
#### Start Redis-Server
Start redis-server `taskset -c 0-3 ~/src/redis-server /tmp/redis_1.conf` with below config.

```
port 9001
bind * -::*
daemonize yes
protected-mode no
save ""
io-threads 4
io-threads-do-reads yes
```
#### Test from throughput perspective 
Start redis-benchmark in localhost with below commands:
`taskset -c 4-7 ./src/redis-benchmark -p 9001 -t set -d 128 -r 5000000 -n 10000000 --threads 2 -c 10` 
`taskset -c 4-7 ./src/redis-benchmark -p 9001 -t get -d 128 -r 5000000 -n 10000000 --threads 2 -c 10` 
to measure the **SET** **GET** performance gap correspondingly, results are listed as below: 
we can find that the io-threads is not used due to `clients_pending_write < (server.io_threads_num*2)`, the throughput is limited by only single thread even more CPU resources were allocated. 

**NOTE: QPS will use relative value instead of absolute value.**
**CPU utilized:**  perf stat -p \`pidof redis-server\` sleep 5
||Base CPU utilized|Opt CPU utilized|QPS Gain(Opt/Base-1)|
|-|-|-|-|
|SET|1|2|23%|
|GET|1|2|25%|

#### Test from CPU efficiency perspective
If we increase the requests number by below commands to make origin io-threads work, throughput increased as expected, but all CPU are fully utilized. With this patch, we can make CPU more efficiency by reducing the active io-threads number.
`taskset -c 4-7 ./src/redis-benchmark -p 9001 -t set -d 128 -r 5000000 -n 10000000 --threads 2 -c 15` 
`taskset -c 4-7 ./src/redis-benchmark -p 9001 -t get -d 128 -r 5000000 -n 10000000 --threads 2 -c 15` 

||Base CPU utilized|Opt CPU utilized|QPS Gain(Opt/Base-1)|
|-|-|-|-|
|SET|3.999|2.908|8%|
|GET|3.999|2.918|3%|



