### PR TITLE
Improve error handling in connSocketBlockingConnect for various connction failures

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -361,6 +361,7 @@ static int connSocketBlockingConnect(connection *conn, const char *addr, int por
     if ((aeWait(fd, AE_WRITABLE, timeout) & AE_WRITABLE) == 0) {
         conn->state = CONN_STATE_ERROR;
         conn->last_errno = ETIMEDOUT;
+        return C_ERR;
     }
 
     conn->fd = fd;


### PR DESCRIPTION
This commit addresses a problem in connSocketBlockingConnect where different types of connection failures, including timeouts and other errors, were not consistently handled. Previously, the function did not return C_ERR immediately after detecting a connection failure, which could lead to inconsistent states and misinterpretation of the connection status.

With this update, connSocketBlockingConnect now correctly returns C_ERR upon encountering any connection error, ensuring that all types of connection failures are handled consistently and the behavior of the function aligns with expected outcomes in case of connection issues.

Closes #12900