### PR TITLE
Fix dict resize allow test

### DIFF
--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -415,7 +415,7 @@ test_slave_buffers {slave buffer are counted correctly} 1000000 10 0 1
 test_slave_buffers "replica buffer don't induce eviction" 100000 100 1 0
 
 start_server {tags {"maxmemory external:skip"}} {
-    test {Don't resize if used memory exceeds maxmemory after resize} {
+    test {Don't rehash if used memory exceeds maxmemory after rehash} {
         r config set latency-tracking no
         r config set maxmemory 0
         r config set maxmemory-policy allkeys-random
@@ -442,6 +442,8 @@ start_server {tags {"maxmemory external:skip"}} {
             fail "bgsave did not stop in time."
         }
 
+        # The dict has reached 4096, it can be resized in tryResizeHashTables in cron,
+        # or we add a key to let it check whether it can be resized.
         r set k1 v1
         # Next writing command will trigger evicting some keys if last
         # command trigger DB dict rehash

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -423,25 +423,12 @@ start_server {tags {"maxmemory external:skip"}} {
         # Next rehash size is 8192, that will eat 64k memory
         populate 4095 "" 1
 
-        # Before adding a key to meet the 1:1 radio, disable resize to
-        # prevent the dict from being resized in cron.
-        r config set rdb-key-save-delay 10000000
-        r bgsave
-        r set k0 v0
-
         set used [s used_memory]
         set limit [expr {$used + 10*1024}]
         r config set maxmemory $limit
 
-        # Enable resizing
-        r config set rdb-key-save-delay 0
-        catch {exec kill -9 [get_child_pid 0]}
-        wait_for_condition 1000 10 {
-            [s rdb_bgsave_in_progress] eq 0
-        } else {
-            fail "bgsave did not stop in time."
-        }
-
+        # Adding a key to meet the 1:1 radio.
+        r set k0 v0
         # The dict has reached 4096, it can be resized in tryResizeHashTables in cron,
         # or we add a key to let it check whether it can be resized.
         r set k1 v1


### PR DESCRIPTION
Ci report this failure:
```
*** [err]: Don't rehash if used memory exceeds maxmemory after rehash in tests/unit/maxmemory.tcl
Expected '4098' to equal or match '4002'

WARNING: the new maxmemory value set via CONFIG SET (1176088) is smaller than the current memory usage (1231083)
```

It can be seen from the log that used_memory changed before we set maxmemory.
The reason is that in #12819, in cron, in addition to trying to shrink, we will
also tyring to expand. The dict was expanded by cron before we set maxmemory,
causing the test to fail.

Before setting maxmemory, we only add 4095 keys to avoid triggering resize.