### PR TITLE
Fix module unblock crash due to no timeout_callback

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -8438,7 +8438,12 @@ void moduleBlockedClientTimedOut(client *c, int from_module) {
     if (!from_module)
         prev_error_replies = server.stat_total_error_replies;
 
-    bc->timeout_callback(&ctx,(void**)c->argv,c->argc);
+    if (bc->timeout_callback) {
+        /* In theory, the user should always pass the timeout handler as an
+         * argument, but better to be safe than sorry. */
+        bc->timeout_callback(&ctx,(void**)c->argv,c->argc);
+    }
+
     moduleFreeContext(&ctx);
 
     if (!from_module)

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -278,7 +278,17 @@ foreach call_type {nested normal} {
     }
 
     test {Unblock by timer} {
+        # When the client is unlock, we will get the OK reply.
         assert_match "OK" [r unblock_by_timer 100]
+    }
+
+    test {block time is shorter than timer period} {
+        # This command does not have the reply.
+        set rd [redis_deferring_client]
+        $rd unblock_by_timer 100 10
+        # Wait for the client to unlock.
+        after 120
+        $rd close
     }
     
     test "Unload the module - blockedclient" {

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -279,7 +279,7 @@ foreach call_type {nested normal} {
 
     test {Unblock by timer} {
         # When the client is unlock, we will get the OK reply.
-        assert_match "OK" [r unblock_by_timer 100]
+        assert_match "OK" [r unblock_by_timer 100 0]
     }
 
     test {block time is shorter than timer period} {


### PR DESCRIPTION
The block timeout is passed in the test case, but we do not pass
in the timeout_callback, and it will crash when unlocking. In this
case, in moduleBlockedClientTimedOut we will check timeout_callback.
There is the stack:
```
beforeSleep
blockedBeforeSleep
handleBlockedClientsTimeout
checkBlockedClientTimeout
unblockClientOnTimeout
replyToBlockedClientTimedOut
moduleBlockedClientTimedOut
-- timeout_callback is NULL, invalidFunctionWasCalled
bc->timeout_callback(&ctx,(void**)c->argv,c->argc);
```