### PR TITLE
Minor optimization for expire dict in defragKey

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -685,11 +685,11 @@ void defragKey(defragCtx *ctx, dictEntry *de) {
     newsds = activeDefragSds(keysds);
     if (newsds) {
         kvstoreDictSetKey(db->keys, slot, de, newsds);
-        if (kvstoreSize(db->expires)) {
+        if (kvstoreDictSize(db->expires, slot)) {
             /* We can't search in db->expires for that key after we've released
              * the pointer it holds, since it won't be able to do the string
              * compare, but we can find the entry using key hash and pointer. */
-            uint64_t hash = kvstoreGetHash(db->keys, newsds);
+            uint64_t hash = kvstoreGetHash(db->expires, newsds);
             dictEntry *expire_de = kvstoreDictFindEntryByPtrAndHash(db->expires, slot, keysds, hash);
             if (expire_de) kvstoreDictSetKey(db->expires, slot, expire_de, newsds);
         }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -34,8 +34,6 @@
  */
 
 #include "server.h"
-#include "cluster.h"
-#include <time.h>
 #include <stddef.h>
 
 #ifdef HAVE_DEFRAG
@@ -148,7 +146,7 @@ luaScript *activeDefragLuaScript(luaScript *script) {
 
 /* Defrag helper for dict main allocations (dict struct, and hash tables).
  * receives a pointer to the dict* and implicitly updates it when the dict
- * struct itself was moved. Returns a stat of how many pointers were moved. */
+ * struct itself was moved. */
 void dictDefragTables(dict* d) {
     dictEntry **newtable;
     /* handle the first hash table */
@@ -672,8 +670,7 @@ void defragModule(redisDb *db, dictEntry *kde) {
 }
 
 /* for each key we scan in the main dict, this function will attempt to defrag
- * all the various pointers it has. Returns a stat of how many pointers were
- * moved. */
+ * all the various pointers it has. */
 void defragKey(defragCtx *ctx, dictEntry *de) {
     sds keysds = dictGetKey(de);
     robj *newob, *ob;


### PR DESCRIPTION
Since now a DB in cluster mode is divided into 16384 dicts, here
we directly check kvstoreDictSize instead of kvstoreSize, which
may have a higher probability that we can save the lookup.

The other change is a cleanup, obviously kvstoreGetHash should be
applied to the db->expires dicts.