### PR TITLE
Fix active expire timeout when db done the scanning

### DIFF
--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -898,5 +898,8 @@ start_cluster 1 0 {tags {"expire external:skip cluster slow"}} {
             flush stdout
             fail "Keys did not actively expire."
         }
+
+        # Make sure we don't have any timeouts.
+        assert_equal 0 [s 0 expired_time_cap_reached_count]
     } {} {needs:debug}
 }


### PR DESCRIPTION
When db->expires_cursor==0, it means the DB is done the scanning,
we should exit the loop to avoid the useless scanning.

It is easy to see the active expire timeout in the modified test,
for example, let's assume that there is only 1 expired key in the
DB, and the size / buckets ratio is less than 1%, which means that
we will skip it in isExpiryDictValidForSamplingCb, and the return
value of expires_cursor is 0.

Because `data.sampled == 0` is always true, so `repeat` is also
always true, we will keep scanning the DB, but every time it is
skipped by the previous judgment (expires_cursor = 0), until the
timelimit is finally exhausted.