### PR TITLE
Fix kvstore unable to push resize_cursor for resize when dict is NULL

### DIFF
--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -578,11 +578,7 @@ void kvstoreTryResizeDicts(kvstore *kvs, int limit) {
     for (int i = 0; i < limit; i++) {
         int didx = kvs->resize_cursor;
         dict *d = kvstoreGetDict(kvs, didx);
-        if (!d) {
-            kvs->resize_cursor = (didx + 1) % kvs->num_dicts;
-            continue;
-        }
-        if (dictShrinkIfNeeded(d) == DICT_ERR) {
+        if (d && dictShrinkIfNeeded(d) == DICT_ERR) {
             dictExpandIfNeeded(d);
         }
         kvs->resize_cursor = (didx + 1) % kvs->num_dicts;

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -578,8 +578,10 @@ void kvstoreTryResizeDicts(kvstore *kvs, int limit) {
     for (int i = 0; i < limit; i++) {
         int didx = kvs->resize_cursor;
         dict *d = kvstoreGetDict(kvs, didx);
-        if (!d)
+        if (!d) {
+            kvs->resize_cursor = (didx + 1) % kvs->num_dicts;
             continue;
+        }
         if (dictShrinkIfNeeded(d) == DICT_ERR) {
             dictExpandIfNeeded(d);
         }


### PR DESCRIPTION
When the dict is NULL, we also need to push resize_cursor, otherwise it
will keep doing useless continue here, and there is no way to resize the
other dict behind it.

Introduced in #12822.