### PR TITLE
Fix invalid dictNext usage when pubsubshard_channels became empty

### DIFF
--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -350,6 +350,9 @@ void pubsubShardUnsubscribeAllChannelsInSlot(unsigned int slot) {
         }
         dictReleaseIterator(iter);
         kvstoreDictDelete(server.pubsubshard_channels, slot, channel);
+        /* After the dict becomes empty, the dict will be deleted.
+         * We break out without calling dictNext. */
+        if (!kvstoreDictSize(server.pubsubshard_channels, slot)) break;
     }
     dictReleaseIterator(di);
 }


### PR DESCRIPTION
After #12822, when pubsubshard_channels became empty, kvstoreDictDelete
will delete the dict (which is the only one currently deleting dicts that
become empty) and in the next loop, we will make an invalid call to dictNext.

After the dict becomes empty, we break out of the loop without calling dictNext.