### PR TITLE
Fix dict don't rehash when there is child test

### DIFF
--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -381,7 +381,7 @@ start_server {tags {"other external:skip"}} {
         } else {
             fail "hash table did not rehash after child process killed"
         }
-    } {} {needs:debug}
+    } {} {needs:debug needs:local-process}
 }
 
 proc read_proc_title {pid} {

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -360,7 +360,7 @@ start_server {tags {"other external:skip"}} {
         r config set save ""
         r config set rdb-key-save-delay 1000000
 
-        populate 4096 "" 1
+        populate 4095 "" 1
         r bgsave
         wait_for_condition 10 100 {
             [s rdb_bgsave_in_progress] eq 1
@@ -375,13 +375,13 @@ start_server {tags {"other external:skip"}} {
         waitForBgsave r
 
         # Hash table should rehash since there is no child process,
-        # size is power of two and over 4098, so it is 8192
+        # size is power of two and over 4096, so it is 8192
         wait_for_condition 50 100 {
             [string match "*table size: 8192*" [r debug HTSTATS 9]]
         } else {
             fail "hash table did not rehash after child process killed"
         }
-    } {} {needs:debug needs:local-process}
+    } {} {needs:debug}
 }
 
 proc read_proc_title {pid} {


### PR DESCRIPTION
The reason is the same as #13016. The reason is that in #12819,
in cron, in addition to trying to shrink, we will also tyring
to expand. The dict was expanded by cron before we trigger the
bgsave since we do have the enough keys (4096) to hit the radio.

Before the bgsave, we only add 4095 keys to avoid this issue.