### PR TITLE
Fix crash due to merge of quicklist node introduced by #12955

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -381,6 +381,15 @@ REDIS_STATIC void __quicklistCompress(const quicklist *quicklist,
     quicklistCompressNode(reverse);
 }
 
+/* This macro is used to compress a node.
+ *
+ * If the 'recompress' flag of the node is true, we compress it directly without
+ * checking whether it is within the range of compress depth.
+ * However, it's important to ensure that the 'recompress' flag of head and tail
+ * is always false, as we always assume that head and tail are not compressed.
+ * 
+ * If the 'recompress' flag of the node is false, we check whether the node is
+ * within the range of compress depth before compressing it. */
 #define quicklistCompress(_ql, _node)                                          \
     do {                                                                       \
         if ((_node)->recompress)                                               \
@@ -795,6 +804,10 @@ void quicklistReplaceEntry(quicklistIter *iter, quicklistEntry *entry,
             quicklistDelIndex(quicklist, entry->node, &p);
             entry->node->dont_compress = 0; /* Re-enable compression */
             new_node = _quicklistMergeNodes(quicklist, new_node);
+            /* We can't know if the current node and its sibling nodes are correctly compressed,
+             * and we don't know if they are within the range of compress depth, so we need to
+             * use quicklistCompress() for compression, which checks if node is within compress
+             * depth before compressing. */
             quicklistCompress(quicklist, new_node);
             quicklistCompress(quicklist, new_node->prev);
             if (new_node->next) quicklistCompress(quicklist, new_node->next);

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -391,8 +391,10 @@ if {[lindex [r config get proto-max-bulk-len] 1] == 10000000000} {
             r write "*4\r\n\$4\r\nlset\r\n\$3\r\nlst\r\n\$1\r\n$i\r\n"
             write_big_bulk 1000000000
         }
-        assert_equal "PONG" [r ping]
+        r ping
+    } {PONG} {large-memory}
 
+    test {Test LSET splits a quicklist node, and then merge} {
         # Test when a quicklist node can't be inserted and is split, the split
         # node merges with the node before it and the `before` node is kept.
         r flushdb
@@ -410,8 +412,10 @@ if {[lindex [r config get proto-max-bulk-len] 1] == 10000000000} {
             write_big_bulk 1000000000
         }
         assert_equal "g" [r lindex lst 1]
-        assert_equal "PONG" [r ping]
+        r ping
+    } {PONG} {large-memory}
 
+    test {Test LSET splits a LZF compressed quicklist node, and then merge} {
         # Test when a LZF compressed quicklist node can't be inserted and is split,
         # the split node merges with the node before it and the split node is kept.
         r flushdb
@@ -436,7 +440,7 @@ if {[lindex [r config get proto-max-bulk-len] 1] == 10000000000} {
         r ping
     } {PONG} {large-memory}
 
-   test {Test LMOVE on plain nodes over 4GB} {
+    test {Test LMOVE on plain nodes over 4GB} {
        r flushdb
        r RPUSH lst2{t} "aa"
        r RPUSH lst2{t} "bb"

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -391,6 +391,48 @@ if {[lindex [r config get proto-max-bulk-len] 1] == 10000000000} {
             r write "*4\r\n\$4\r\nlset\r\n\$3\r\nlst\r\n\$1\r\n$i\r\n"
             write_big_bulk 1000000000
         }
+        assert_equal "PONG" [r ping]
+
+        # Test when a quicklist node can't be inserted and is split, the split
+        # node merges with the node before it and the `before` node is kept.
+        r flushdb
+        r rpush lst [string repeat "x" 4096]
+        r lpush lst a b c d e f g
+        r lpush lst [string repeat "y" 4096]
+        # now: [y...]    [g f e d c b a x...]
+        #      (node0)        (node1)
+        # Keep inserting elements into node1 until node1 is split into two
+        # nodes([g] [...]), eventually node0 will merge with the [g] node.
+        # Since node0 is larger, after the merge node0 will be kept and
+        # the [g] node will be deleted.
+        for {set i 7} {$i >= 3} {incr i -1} {
+            r write "*4\r\n\$4\r\nlset\r\n\$3\r\nlst\r\n\$1\r\n$i\r\n"
+            write_big_bulk 1000000000
+        }
+        assert_equal "g" [r lindex lst 1]
+        assert_equal "PONG" [r ping]
+
+        # Test when a LZF compressed quicklist node can't be inserted and is split,
+        # the split node merges with the node before it and the split node is kept.
+        r flushdb
+        r config set list-compress-depth 1
+        r lpush lst [string repeat "x" 2000]
+        r rpush lst [string repeat "y" 7000]
+        r rpush lst a b c d e f g
+        r rpush lst [string repeat "z" 8000]
+        r lset lst 0 h
+        # now: [h]     [y... a b c d e f g] [z...]
+        #      node0        node1(LZF)
+        # Keep inserting elements into node1 until node1 is split into two
+        # nodes([y...] [...]), eventually node0 will merge with the [y...] node.
+        # Since [y...] node is larger, after the merge node0 will be deleted and
+        # the [y...] node will be kept.
+        for {set i 7} {$i >= 3} {incr i -1} {
+            r write "*4\r\n\$4\r\nlset\r\n\$3\r\nlst\r\n\$1\r\n$i\r\n"
+            write_big_bulk 1000000000
+        }
+        assert_equal "h" [r lindex lst 0]
+        r config set list-compress-depth 0
         r ping
     } {PONG} {large-memory}
 


### PR DESCRIPTION
Fix two crash introducted by #12955

When a quicklist node can't be inserted and split, we eventually merge the current node with its neighboring 
nodes after inserting, and compress the current node and its siblings.

1. When the current node is merged with another node, the current node may become invalid and can no longer be used.

   Solution: let `_quicklistMergeNodes()` return the merged nodes.

3. If the current node is a LZF quicklist node, its recompress will be 1. If the split node can be merged with a sibling node to become head or tail, recompress may cause the head and tail to be compressed, which is not allowed.

    Solution: always recompress to 0 after merging.