### PR TITLE
Fix CLIENAT KILL MAXAGE test timing issue

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
           ./runtest \
             --host 127.0.0.1 --port 6379 \
+            --verbose \
             --tags -slow
     - name: Archive redis log
       if: ${{ failure() }}
@@ -49,6 +50,7 @@ jobs:
       run: |
           ./runtest \
             --host 127.0.0.1 --port 6379 \
+            --verbose \
             --cluster-mode \
             --tags -slow
     - name: Archive redis log
@@ -73,6 +75,7 @@ jobs:
         run: |
           ./runtest \
             --host 127.0.0.1 --port 6379 \
+            --verbose \
             --tags "-slow -needs:debug"
       - name: Archive redis log
         if: ${{ failure() }}


### PR DESCRIPTION
This test fails occasionally:
```
*** [err]: CLIENT KILL maxAGE will kill old clients in tests/unit/introspection.tcl
Expected 2 == 1 (context: type eval line 14 cmd {assert {$res == 1}} proc ::test)
```

This test is very likely to do a false positive if the execute time
takes longer than the max age, for example, if the execution time
between sleep and kill exceeds 1s, rd2 will also be killed due to
the max age.

The test can adjust the order of execution statements to increase
the probability of passing, but this is still will be a timing issue
in some slow machines, so decided give it a few more chances.

The test was introduced in #12299.