### PR TITLE
Fix loading rdb opcode RDB_OPCODE_SLOT_INFO

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3127,7 +3127,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             }
             /* In cluster mode we resize individual slot specific dictionaries based on the number of keys that slot holds. */
             kvstoreDictExpand(db->keys, slot_id, slot_size);
-            kvstoreDictExpand(db->expires, slot_id, slot_size);
+            kvstoreDictExpand(db->expires, slot_id, expires_slot_size);
             should_expand_db = 0;
             continue; /* Read next opcode. */
         } else if (type == RDB_OPCODE_AUX) {


### PR DESCRIPTION
Following the changes introduced by 8cd62f82c, the kvstoreDictExpand for the expires kvstore used the slot_size instead of expires_slot_size.