### PR TITLE
Remove the restriction that redis-cli --cluster create requires at least 3 master nodes

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6936,8 +6936,10 @@ static int clusterManagerCommandCreate(int argc, char **argv) {
     int masters_count = CLUSTER_MANAGER_MASTERS_COUNT(node_len, replicas);
     if (masters_count < 3) {
         int ignore_force = 0;
+        clusterManagerLogInfo("Requested to create a cluster with %d masters and "
+                              "%d replicas per master.\n", masters_count, replicas);
         if (!confirmWithYes("Redis Cluster requires at least 3 master nodes for "
-                            "automatic failover, are you sure?", ignore_force))
+                            "automatic failover. Are you sure?", ignore_force))
             return 0;
     }
     clusterManagerLogInfo(">>> Performing hash slots allocation "

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6935,17 +6935,13 @@ static int clusterManagerCommandCreate(int argc, char **argv) {
     int replicas = config.cluster_manager_command.replicas;
     int masters_count = CLUSTER_MANAGER_MASTERS_COUNT(node_len, replicas);
     if (masters_count < 3) {
-        clusterManagerLogErr(
-            "*** ERROR: Invalid configuration for cluster creation.\n"
-            "*** Redis Cluster requires at least 3 master nodes.\n"
-            "*** This is not possible with %d nodes and %d replicas per node.",
-            node_len, replicas);
-        clusterManagerLogErr("\n*** At least %d nodes are required.\n",
-                             3 * (replicas + 1));
-        return 0;
+        int ignore_force = 0;
+        if (!confirmWithYes("Redis Cluster requires at least 3 master nodes for "
+                            "automatic failover, are you sure?", ignore_force))
+            return 0;
     }
     clusterManagerLogInfo(">>> Performing hash slots allocation "
-                          "on %d nodes...\n", node_len);
+                          "on %d node(s)...\n", node_len);
     int interleaved_len = 0, ip_count = 0;
     clusterManagerNode **interleaved = zcalloc(node_len*sizeof(**interleaved));
     char **ips = zcalloc(node_len * sizeof(char*));


### PR DESCRIPTION
There is no limitation in Redis to create a cluster with 1 or 2 masters,
only that it cannot do automatic failover. Remove this restriction and
add `are you sure` prompt to prompt the user.

This was suggested in #12892.