### PR TITLE
zunionInterDiffGenericCommand use ztrycalloc to avoid OOM panic

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2666,8 +2666,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
     /* Try to allocate the src table, and abort on insufficient memory. */
     src = ztrycalloc(sizeof(zsetopsrc) * setnum);
     if (src == NULL) {
-        addReplyErrorFormat(c, "Insufficient memory, failed allocating transient memory for '%s' command",
-                            c->cmd->fullname);
+        addReplyError(c, "Insufficient memory, failed allocating transient memory, too many args.");
         return;
     }
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2663,8 +2663,15 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
         return;
     }
 
+    /* Try to allocate the src table, and abort on insufficient memory. */
+    src = ztrycalloc(sizeof(zsetopsrc) * setnum);
+    if (src == NULL) {
+        addReplyErrorFormat(c, "Insufficient memory, failed allocating transient memory for '%s' command",
+                            c->cmd->fullname);
+        return;
+    }
+
     /* read keys to be used for input */
-    src = zcalloc(sizeof(zsetopsrc) * setnum);
     for (i = 0, j = numkeysIndex+1; i < setnum; i++, j++) {
         robj *obj = lookupKeyRead(c->db, c->argv[j]);
         if (obj != NULL) {


### PR DESCRIPTION
In low memory situations, sending a big number of arguments (sets)
may cause OOM panic. Use ztrycalloc, like we do on LCS and XAUTOCLAIM,
and fail gracefully.

This change affects the following commands: ZUNION, ZINTER, ZDIFF,
ZUNIONSTORE, ZINTERSTORE, ZDIFFSTORE, ZINTERCARD.