### PR TITLE
Increase tolerance range to block reprocess tests to avoid timing issues

### DIFF
--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1265,8 +1265,8 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
         assert_equal {} [$rd read]
         set end [clock milliseconds]
 
-        # In the past, this time would have been 1000+200, in order to avoid
-        # timing issues, we increase the range a bit.
+        # Before the fix in #13004, this time would have been 1200+ (i.e. more than 1200ms),
+        # now it should be 1000, but in order to avoid timing issues, we increase the range a bit.
         assert_range [expr $end-$start] 1000 1150
 
         r debug set-active-expire 1

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1267,7 +1267,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
 
         # In the past, this time would have been 1000+200, in order to avoid
         # timing issues, we increase the range a bit.
-        assert_range [expr $end-$start] 1000 1100
+        assert_range [expr $end-$start] 1000 1150
 
         r debug set-active-expire 1
         $rd close

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -518,8 +518,8 @@ start_server {
         assert_equal {} [$rd2 read]
         set end [clock milliseconds]
 
-        # In the past, this time would have been 1000+200, in order to avoid
-        # timing issues, we increase the range a bit.
+        # Before the fix in #13004, this time would have been 1200+ (i.e. more than 1200ms),
+        # now it should be 1000, but in order to avoid timing issues, we increase the range a bit.
         assert_range [expr $end-$start] 1000 1150
 
         $rd1 close

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -520,7 +520,7 @@ start_server {
 
         # In the past, this time would have been 1000+200, in order to avoid
         # timing issues, we increase the range a bit.
-        assert_range [expr $end-$start] 1000 1100
+        assert_range [expr $end-$start] 1000 1150
 
         $rd1 close
         $rd2 close

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2009,8 +2009,8 @@ start_server {tags {"zset"}} {
             assert_equal {} [$rd read]
             set end [clock milliseconds]
 
-            # In the past, this time would have been 1000+200, in order to avoid
-            # timing issues, we increase the range a bit.
+            # Before the fix in #13004, this time would have been 1200+ (i.e. more than 1200ms),
+            # now it should be 1000, but in order to avoid timing issues, we increase the range a bit.
             assert_range [expr $end-$start] 1000 1150
 
             r debug set-active-expire 1

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2011,7 +2011,7 @@ start_server {tags {"zset"}} {
 
             # In the past, this time would have been 1000+200, in order to avoid
             # timing issues, we increase the range a bit.
-            assert_range [expr $end-$start] 1000 1100
+            assert_range [expr $end-$start] 1000 1150
 
             r debug set-active-expire 1
             $rd close


### PR DESCRIPTION
These tests have all failed in daily CI:
```
*** [err]: Blocking XREADGROUP for stream key that has clients blocked on stream - reprocessing command in tests/unit/type/stream-cgroups.tcl
Expected '1101' to be between to '1000' and '1100' (context: type eval line 23 cmd {assert_range [expr $end-$start] 1000 1100} proc ::test)

*** [err]: BLPOP unblock but the key is expired and then block again - reprocessing command in tests/unit/type/list.tcl
Expected '1101' to be between to '1000' and '1100' (context: type eval line 23 cmd {assert_range [expr $end-$start] 1000 1100} proc ::test)

*** [err]: BZPOPMIN unblock but the key is expired and then block again - reprocessing command in tests/unit/type/zset.tcl
Expected '1103' to be between to '1000' and '1100' (context: type eval line 23 cmd {assert_range [expr $end-$start] 1000 1100} proc ::test)
```

Increase the range to avoid failures, and improve the comment to be clearer.
tests was introduced in #13004.
