### PR TITLE
Minor optimization in kvstoreDictAddRaw when dict exists

### DIFF
--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -42,7 +42,7 @@ dictEntry *kvstoreIteratorNext(kvstoreIterator *kvs_it);
 
 /* Rehashing */
 void kvstoreTryResizeDicts(kvstore *kvs, int limit);
-uint64_t kvstoreIncrementallyRehash(kvstore *kvs, uint64_t threshold_ms);
+uint64_t kvstoreIncrementallyRehash(kvstore *kvs, uint64_t threshold_us);
 
 /* Specific dict access by dict-index */
 unsigned long kvstoreDictSize(kvstore *kvs, int didx);


### PR DESCRIPTION
Usually, the probability that a dict exists is much greater than the
probability that it does not exist. In kvstoreDictAddRaw, we will call
kvstoreGetDict multiple times. Based on this assumption, we change
createDictIfNeeded to something like get or create function:
```
before:
dict exist: 2 kvstoreGetDict
dict non-exist: 2 kvstoreGetDict

after:
dict exist: 1 kvstoreGetDict
dict non-exist: 1 kvstoreGetDict
```

A possible 3% performance improvement was observed:
```
./src/redis-benchmark -n 10000000 -P 32 -r 10000000 set foo bar

before:
1224739
1227747
1231678
1231830
1239771
1240540
1248907
1251094
1240387
1250468

after:
1235025
1247193
1265983
1269841
1271779
1281558
1287664
1288825
1296344
```

In addition, some typos/comments i saw have been cleaned up.