### PR TITLE
Fix PONG message processing for primary-ship tracking during failovers

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2992,7 +2992,7 @@ int clusterProcessPacket(clusterLink *link) {
                 if (clusterNodeIsMaster(sender)) {
                     /* Master turned into a slave! Reconfigure the node. */
                     if (master && !memcmp(master->shard_id, sender->shard_id, CLUSTER_NAMELEN)) {
-                        /* 'sender' was a primary and was in the same shard as `master`, its new primary */
+                        /* `sender` was a primary and was in the same shard as `master`, its new primary */
                         if (sender->configEpoch > senderConfigEpoch) {
                             serverLog(LL_NOTICE,
                                     "Ignore stale message from %.40s (%s) in shard %.40s;"

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4958,8 +4958,9 @@ int clusterDelSlot(int slot) {
     return C_OK;
 }
 
-/* Delete all the slots associated with the specified node.
- * The number of deleted slots is returned. */
+/* Transfer slots from `from_node` to `to_node`.
+ * Iterates over all cluster slots, transferring each slot covered by `from_node` to `to_node`.
+ * Counts and returns the number of slots transferred.  */
 int clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node) {
     int processed = 0;
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2995,7 +2995,7 @@ int clusterProcessPacket(clusterLink *link) {
                         /* 'sender' was a primary and was in the same shard as `master`, its new primary */
                         if (sender->configEpoch > senderConfigEpoch) {
                             serverLog(LL_NOTICE,
-                                    "Ignore stale gossip message from %.40s (%s) in shard %.40s;"
+                                    "Ignore stale message from %.40s (%s) in shard %.40s;"
                                     " gossip config epoch: %llu, current config epoch: %llu", 
                                     sender->name,
                                     sender->human_nodename,

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3019,7 +3019,7 @@ int clusterProcessPacket(clusterLink *link) {
                         /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
                         int slots = clusterDelNodeSlots(sender);
                         serverLog(LL_NOTICE, "Node %.40s (%s) is no longer master of shard %.40s;"
-                                "removed all %d slot(s) it used to own",
+                                " removed all %d slot(s) it used to own",
                                 sender->name,
                                 sender->human_nodename,
                                 sender->shard_id,

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3006,19 +3006,34 @@ int clusterProcessPacket(clusterLink *link) {
                             /* A failover occurred in the shard where `sender` belongs to and `sender` is no longer
                              * a primary. Update slot assignment to `master`, which is the new primary in the shard */
                             int slots = clusterMoveNodeSlots(sender, master);
-                            serverLog(LL_NOTICE, "A failover occurred in shard %.40s; node %.40s (%s) lost %d slot(s) to node %.40s (%s)",
-                                    sender->shard_id, sender->name, sender->human_nodename, slots, master->name, master->human_nodename);
+                            serverLog(LL_NOTICE, "A failover occurred in shard %.40s; node %.40s (%s)"
+                                    " lost %d slot(s) to node %.40s (%s)",
+                                    sender->shard_id,
+                                    sender->name,
+                                    sender->human_nodename,
+                                    slots,
+                                    master->name,
+                                    master->human_nodename);
                         }
                     } else {
                         int slots = clusterDelNodeSlots(sender);
                         if (master != NULL) {
                             /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
-                            serverLog(LL_NOTICE, "Node %.40s (%s) moved from shard %.40s to shard %.40s and became a slave; removed all %d slot(s) it used to own",
-                                    sender->name, sender->human_nodename, sender->shard_id, master->shard_id, slots);
+                            serverLog(LL_NOTICE, "Node %.40s (%s) moved from shard %.40s to shard %.40s"
+                                    " and became a slave; removed all %d slot(s) it used to own",
+                                    sender->name,
+                                    sender->human_nodename,
+                                    sender->shard_id,
+                                    master->shard_id,
+                                    slots);
                         } else {
                             /* We have no knowledge of `master` */
-                            serverLog(LL_NOTICE, "Node %.40s (%s) is not longer a master in shard %.40s; removed all %d slot(s) it used to own",
-                                    sender->name, sender->human_nodename, sender->shard_id, slots);
+                            serverLog(LL_NOTICE, "Node %.40s (%s) is not longer a master in shard %.40s;"
+                                    " removed all %d slot(s) it used to own",
+                                    sender->name,
+                                    sender->human_nodename,
+                                    sender->shard_id,
+                                    slots);
                         }
                     }
                     sender->flags &= ~(CLUSTER_NODE_MASTER|

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2995,7 +2995,7 @@ int clusterProcessPacket(clusterLink *link) {
                         /* 'sender' was a primary and was in the same shard as `master`, its new primary */
                         if (sender->configEpoch > senderConfigEpoch) {
                             serverLog(LL_WARNING,
-                                    "Ignore stale gossipe message from %.40s (%s) in shard %.40s;"
+                                    "Ignore stale gossip message from %.40s (%s) in shard %.40s;"
                                     " gossip config epoch: %llu, current config epoch: %llu", 
                                     sender->name,
                                     sender->human_nodename,

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3019,22 +3019,13 @@ int clusterProcessPacket(clusterLink *link) {
                         /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
 
                         int slots = clusterDelNodeSlots(sender);
-                        if (master != NULL) {
-                            serverLog(LL_NOTICE, "Node %.40s (%s) moved from shard %.40s to shard %.40s"
-                                    " and became a slave; removed all %d slot(s) it used to own",
-                                    sender->name,
-                                    sender->human_nodename,
-                                    sender->shard_id,
-                                    master->shard_id,
-                                    slots);
-                        } else {
-                            /* We have no knowledge of `master` */
-                            serverLog(LL_NOTICE, "Node %.40s (%s) is no longer a master in shard %.40s;"
-                                    " removed all %d slot(s) it used to own",
+                            serverLog(LL_NOTICE, "Node %.40s (%s) is no longer master of shard %.40s; removed all %d slot(s) it used to own",
                                     sender->name,
                                     sender->human_nodename,
                                     sender->shard_id,
                                     slots);
+                       if (master != NULL) {
+                           serverLog(LL_NOTICE, "Node %.40s (%s) is now part of shard %.40s, ... whatever);
                         }
                     }
                     sender->flags &= ~(CLUSTER_NODE_MASTER|

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2994,7 +2994,7 @@ int clusterProcessPacket(clusterLink *link) {
                     if (master && !memcmp(master->shard_id, sender->shard_id, CLUSTER_NAMELEN)) {
                         /* 'sender' was a primary and was in the same shard as `master`, its new primary */
                         if (sender->configEpoch > senderConfigEpoch) {
-                            serverLog(LL_WARNING,
+                            serverLog(LL_NOTICE,
                                     "Ignore stale gossip message from %.40s (%s) in shard %.40s;"
                                     " gossip config epoch: %llu, current config epoch: %llu", 
                                     sender->name,

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3028,7 +3028,7 @@ int clusterProcessPacket(clusterLink *link) {
                                     slots);
                         } else {
                             /* We have no knowledge of `master` */
-                            serverLog(LL_NOTICE, "Node %.40s (%s) is not longer a master in shard %.40s;"
+                            serverLog(LL_NOTICE, "Node %.40s (%s) is no longer a master in shard %.40s;"
                                     " removed all %d slot(s) it used to own",
                                     sender->name,
                                     sender->human_nodename,

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3016,9 +3016,10 @@ int clusterProcessPacket(clusterLink *link) {
                                     master->human_nodename);
                         }
                     } else {
+                        /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
+
                         int slots = clusterDelNodeSlots(sender);
                         if (master != NULL) {
-                            /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
                             serverLog(LL_NOTICE, "Node %.40s (%s) moved from shard %.40s to shard %.40s"
                                     " and became a slave; removed all %d slot(s) it used to own",
                                     sender->name,

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3017,15 +3017,18 @@ int clusterProcessPacket(clusterLink *link) {
                         }
                     } else {
                         /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
-
                         int slots = clusterDelNodeSlots(sender);
-                            serverLog(LL_NOTICE, "Node %.40s (%s) is no longer master of shard %.40s; removed all %d slot(s) it used to own",
-                                    sender->name,
-                                    sender->human_nodename,
-                                    sender->shard_id,
-                                    slots);
+                        serverLog(LL_NOTICE, "Node %.40s (%s) is no longer master of shard %.40s;"
+                                "removed all %d slot(s) it used to own",
+                                sender->name,
+                                sender->human_nodename,
+                                sender->shard_id,
+                                slots);
                        if (master != NULL) {
-                           serverLog(LL_NOTICE, "Node %.40s (%s) is now part of shard %.40s, ... whatever);
+                           serverLog(LL_NOTICE, "Node %.40s (%s) is now part of shard %.40s",
+                                   sender->name,
+                                   sender->human_nodename,
+                                   master->shard_id);
                         }
                     }
                     sender->flags &= ~(CLUSTER_NODE_MASTER|

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3006,14 +3006,18 @@ int clusterProcessPacket(clusterLink *link) {
                             /* A failover occurred in the shard where `sender` belongs to and `sender` is no longer
                              * a primary. Update slot assignment to `master`, which is the new primary in the shard */
                             int slots = clusterMoveNodeSlots(sender, master);
+                            /* `master` is still a `slave` in this observer node's view; update its role and configEpoch */
+                            clusterSetNodeAsMaster(master);
+                            master->configEpoch = senderConfigEpoch;
                             serverLog(LL_NOTICE, "A failover occurred in shard %.40s; node %.40s (%s)"
-                                    " lost %d slot(s) to node %.40s (%s)",
+                                    " lost %d slot(s) to node %.40s (%s) with a config epoch of %llu",
                                     sender->shard_id,
                                     sender->name,
                                     sender->human_nodename,
                                     slots,
                                     master->name,
-                                    master->human_nodename);
+                                    master->human_nodename,
+                                    (unsigned long long) master->configEpoch);
                         }
                     } else {
                         /* `sender` was moved to another shard and has become a replica, remove its slot assignment */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3005,11 +3005,21 @@ int clusterProcessPacket(clusterLink *link) {
                         } else {
                             /* A failover occurred in the shard where `sender` belongs to and `sender` is no longer
                              * a primary. Update slot assignment to `master`, which is the new primary in the shard */
-                            clusterMoveNodeSlots(sender, master);
+                            int slots = clusterMoveNodeSlots(sender, master);
+                            serverLog(LL_NOTICE, "A failover occurred in shard %.40s; node %.40s (%s) lost %d slot(s) to node %.40s (%s)",
+                                    sender->shard_id, sender->name, sender->human_nodename, slots, master->name, master->human_nodename);
                         }
                     } else {
-                        /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
-                        clusterDelNodeSlots(sender);
+                        int slots = clusterDelNodeSlots(sender);
+                        if (master != NULL) {
+                            /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
+                            serverLog(LL_NOTICE, "Node %.40s (%s) moved from shard %.40s to shard %.40s and became a slave; removed all %d slot(s) it used to own",
+                                    sender->name, sender->human_nodename, sender->shard_id, master->shard_id, slots);
+                        } else {
+                            /* We have no knowledge of `master` */
+                            serverLog(LL_NOTICE, "Node %.40s (%s) is not longer a master in shard %.40s; removed all %d slot(s) it used to own",
+                                    sender->name, sender->human_nodename, sender->shard_id, slots);
+                        }
                     }
                     sender->flags &= ~(CLUSTER_NODE_MASTER|
                                        CLUSTER_NODE_MIGRATE_TO);


### PR DESCRIPTION
This commit updates the processing of PONG gossip messages in the cluster. When a node (B) becomes a replica due to a failover, its PONG messages include its new primary node's (A) information and B's configuration epoch is aligned with A's. This allows observer nodes to identify changes in primary-ship, addressing issues of intermediate states and enhancing cluster state consistency during topology changes.

Fix #13018