### PR TITLE
xinfo-stream add minimum to seen-time, skip logreqres in fuzzer

### DIFF
--- a/src/commands/xinfo-stream.json
+++ b/src/commands/xinfo-stream.json
@@ -283,8 +283,7 @@
                                             "properties": {
                                                 "active-time": {
                                                     "type": "integer",
-                                                    "description": "Last time this consumer was active (successful reading/claiming).",
-                                                    "minimum": 0
+                                                    "description": "Last time this consumer was active (successful reading/claiming)."
                                                 },
                                                 "name": {
                                                     "description": "consumer name",

--- a/src/commands/xinfo-stream.json
+++ b/src/commands/xinfo-stream.json
@@ -283,7 +283,8 @@
                                             "properties": {
                                                 "active-time": {
                                                     "type": "integer",
-                                                    "description": "Last time this consumer was active (successful reading/claiming)."
+                                                    "description": "Last time this consumer was active (successful reading/claiming).",
+                                                    "minimum": 0
                                                 },
                                                 "name": {
                                                     "description": "consumer name",
@@ -291,7 +292,8 @@
                                                 },
                                                 "seen-time": {
                                                     "description": "timestamp of the last interaction attempt of the consumer",
-                                                    "type": "integer"
+                                                    "type": "integer",
+                                                    "minimum": 0
                                                 },
                                                 "pel-count": {
                                                     "description": "number of unacknowledged entries that belong to the consumer",

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -1,7 +1,7 @@
 # tests of corrupt listpack payload with valid CRC
 
-# The fuzzer can cause corrupt the state in many places, which will bugs
-# that mess up the reply, so we decided to skip logreqres.
+# The fuzzer can cause corrupt the state in many places, which could
+# mess up the reply, so we decided to skip logreqres.
 tags {"dump" "corruption" "external:skip" "logreqres:skip"} {
 
 # catch sigterm so that in case one of the random command hangs the test,

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -1,6 +1,8 @@
 # tests of corrupt listpack payload with valid CRC
 
-tags {"dump" "corruption" "external:skip"} {
+# The fuzzer can cause corrupt the state in many places, which will bugs
+# that mess up the reply, so we decided to skip logreqres.
+tags {"dump" "corruption" "external:skip" "logreqres:skip"} {
 
 # catch sigterm so that in case one of the random command hangs the test,
 # usually due to redis not putting a response in the output buffers,


### PR DESCRIPTION
Recently I saw in CI that reply-schemas-validator fails here:
```
Failed validating 'minimum' in schema[1]['properties']['groups']['items']['properties']['consumers']['items']['properties']['active-time']:
    {'description': 'Last time this consumer was active (successful '
                    'reading/claiming).',
     'minimum': 0,
     'type': 'integer'}

On instance['groups'][0]['consumers'][0]['active-time']:
    -1729380548878722639
```

The reason is that in fuzzer, we may restore corrupted active-time,
which will cause the reply schema CI to fail.

The fuzzer can cause corrupt the state in many places, which will
bugs that mess up the reply, so we decided to skip logreqres.

Also, seen-time is the same type as active-time, adding the minimum.