### PR TITLE
Implement defragmentation for pubsub kvstore

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1128,7 +1128,7 @@ void activeDefragCycle(void) {
             if (!defrag_later_item_in_progress) {
                 /* Continue defragmentation from the previous stage.
                  * If slot is -1, it means this stage starts from the beginning. */
-                if (slot == -1) slot = kvstoreFindDictIndexByKeyIndex(current_stage->kvs, 1);
+                if (slot == -1) slot = kvstoreGetFirstNonEmptyDictIndex(current_stage->kvs);
                 defrag_cursor = kvstoreDictScanDefrag(current_stage->kvs, slot, defrag_cursor,
                     current_stage->scanfn, &defragfns, &(defragCtx){current_stage->privdata, slot});
             }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1127,7 +1127,7 @@ void activeDefragCycle(void) {
 
             if (!defrag_later_item_in_progress) {
                 /* Continue defragmentation from the previous stage.
-                 * If slot is -1, it means this stage starts from the beginning. */
+                 * If slot is -1, it means this stage starts from the first non-empty slot. */
                 if (slot == -1) slot = kvstoreGetFirstNonEmptyDictIndex(current_stage->kvs);
                 defrag_cursor = kvstoreDictScanDefrag(current_stage->kvs, slot, defrag_cursor,
                     current_stage->scanfn, &defragfns, &(defragCtx){current_stage->privdata, slot});

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1115,34 +1115,30 @@ void activeDefragCycle(void) {
             if (!defrag_later_item_in_progress) {
                 switch (defrag_state) {
                     case DEFRAG_KEYS: {
-                        cursor = kvstoreDictScanDefrag(db->keys, slot, cursor,
-                                                       defragScanCallback,
-                                                    &defragfns, &ctx);
+                        cursor = kvstoreDictScanDefrag(db->keys, slot, cursor, defragScanCallback,
+                                                       &defragfns, &ctx);
                         if (!cursor) defrag_state = DEFRAG_EXPIRES;
                         __attribute__((fallthrough));
                     }
                     case DEFRAG_EXPIRES: {
                         expires_cursor = kvstoreDictScanDefrag(db->expires, slot, expires_cursor,
-                                                               scanCallbackCountScanned,
-                                                               &defragfns, NULL);
+                                                               scanCallbackCountScanned, &defragfns, NULL);
                         if (!expires_cursor) defrag_state = DEFRAG_KEYS;
                         __attribute__((fallthrough));
                     }
                     case DEFRAG_PUBSUB: {
                         if (slot == 0) {
-                            defragPubSubCtx ctx_pubsub = { .pubsub_channels = server.pubsub_channels,
-                                .clientPubSubChannels = getClientPubSubChannels, .slot = slot };
-                            pubsub_cursor = kvstoreDictScanDefrag(server.pubsub_channels, slot, pubsub_cursor,
-                                defragPubsubScanCallback, &defragfns, &ctx_pubsub);
+                            defragPubSubCtx ctx_pubsub = { server.pubsub_channels, getClientPubSubChannels, slot };
+                            pubsub_cursor = kvstoreDictScanDefrag(server.pubsub_channels, slot,
+                                pubsub_cursor, defragPubsubScanCallback, &defragfns, &ctx_pubsub);
                         }
                         if (!pubsub_cursor) defrag_state = DEFRAG_PUBSUBSHARD;
                         __attribute__((fallthrough));
                     }
                     case DEFRAG_PUBSUBSHARD: {
-                        defragPubSubCtx ctx_pubsub_shard = { .pubsub_channels = server.pubsubshard_channels,
-                            .clientPubSubChannels = getClientPubSubShardChannels, .slot = slot };
-                        pubsubshard_cursor = kvstoreDictScanDefrag(server.pubsubshard_channels, slot, pubsubshard_cursor,
-                            defragPubsubScanCallback, &defragfns, &ctx_pubsub_shard);
+                        defragPubSubCtx ctx_pubsub_shard = { server.pubsubshard_channels, getClientPubSubShardChannels, slot };
+                        pubsubshard_cursor = kvstoreDictScanDefrag(server.pubsubshard_channels, slot,
+                            pubsubshard_cursor, defragPubsubScanCallback, &defragfns, &ctx_pubsub_shard);
                         if (!pubsubshard_cursor) defrag_state = DEFRAG_KEYS;
                         break;
                     }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1145,14 +1145,19 @@ void activeDefragCycle(void) {
                     defrag_stage++;
                 defrag_later_item_in_progress = 0;
             }
+
+            /* Check if all defragmentation stages have been processed.
+             * If so, mark as finished and reset the stage counter to move on to next database. */
+            if (defrag_stage == num_stages) {
+                all_stages_finished = 1;
+                defrag_stage = 0;
+            }
     
             /* Once in 16 scan iterations, 512 pointer reallocations. or 64 keys
              * (if we have a lot of pointers in one hash bucket or rehashing),
              * check if we reached the time limit.
              * But regardless, don't start a new db in this loop, this is because after
              * the last db we call defragOtherGlobals, which must be done in one cycle */
-            all_stages_finished = (defrag_stage == num_stages);
-            if (defrag_stage == num_stages) defrag_stage = 0;
             if (all_stages_finished ||
                 ++iterations > 16 ||
                 server.stat_active_defrag_hits - prev_defragged > 512 ||

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -162,11 +162,11 @@ luaScript *activeDefragLuaScript(luaScript *script) {
 }
 
 /* Defrag helper for dict main allocations (dict struct, and hash tables).
- * receives a pointer to the dict* and implicitly updates it when the dict
+ * Receives a pointer to the dict* and return a new dict* when the dict
  * struct itself was moved.
  * 
- * returns NULL in case the allocation wasn't moved.
- * when it returns a non-null value, the old pointer was already released
+ * Returns NULL in case the allocation wasn't moved.
+ * When it returns a non-null value, the old pointer was already released
  * and should NOT be accessed. */
 dict *dictDefragTables(dict *d) {
     dict *ret = NULL;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -824,7 +824,7 @@ void defragPubsubScanCallback(void *privdata, const dictEntry *de) {
             client *c = dictGetKey(clientde);
             dictEntry *pubsub_channel = dictFind(ctx->clientPubSubChannels(c), newchannel);
             serverAssert(pubsub_channel);
-            dictSetKey(c->pubsub_channels, pubsub_channel, newchannel);
+            dictSetKey(ctx->clientPubSubChannels(c), pubsub_channel, newchannel);
         }
         dictReleaseIterator(di);
     }
@@ -1136,11 +1136,11 @@ void activeDefragCycle(void) {
                 if (defrag_state == DEFRAG_EXPIRES) {
                     expires_cursor = kvstoreDictScanDefrag(db->expires, slot, expires_cursor,
                                                            scanCallbackCountScanned, &defragfns, NULL);
-                    if (!expires_cursor) defrag_state = DEFRAG_KEYS;
+                    if (!expires_cursor) defrag_state = DEFRAG_PUBSUB;
                 }
 
                 if (defrag_state == DEFRAG_PUBSUB) {
-                    if (slot == 0) {
+                    if (current_db == 0 && slot == 0) {
                         defragPubSubCtx ctx_pubsub = { server.pubsub_channels, getClientPubSubChannels, slot };
                         pubsub_cursor = kvstoreDictScanDefrag(server.pubsub_channels, slot,
                             pubsub_cursor, defragPubsubScanCallback, &defragfns, &ctx_pubsub);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -802,7 +802,7 @@ float getAllocatorFragmentation(size_t *out_frag_bytes) {
     return frag_pct;
 }
 
-/* Defrag scan callback for the main db dictionary. */
+/* Defrag scan callback for the pubsub dictionary. */
 void defragPubsubScanCallback(void *privdata, const dictEntry *de) {
     defragPubSubCtx *ctx = privdata;
     kvstore *pubsub_channels = ctx->pubsub_channels;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -92,6 +92,13 @@ sds activeDefragSds(sds sdsptr) {
     return NULL;
 }
 
+/* Defrag helper for robj and/or string objects with expected refcount.
+ *
+ * Like activeDefragStringOb, but it requires the caller to pass in the expected
+ * reference count. In some cases, the caller needs to update a robj whose
+ * reference count is not 1, in these cases, the caller must explicitly pass
+ * in the reference count, otherwise defragmentation will not be performed.
+ * Note that the caller is responsible for updating any other references to the robj. */
 robj *activeDefragStringObEx(robj* ob, int expected_refcount) {
     robj *ret = NULL;
     if (ob->refcount!=expected_refcount)

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -527,6 +527,10 @@ int kvstoreFindDictIndexByKeyIndex(kvstore *kvs, unsigned long target) {
 
 /* Returns next non-empty dict index strictly after given one, or -1 if provided didx is the last one. */
 int kvstoreGetNextNonEmptyDictIndex(kvstore *kvs, int didx) {
+    if (kvs->num_dicts == 1) {
+        assert(didx == 0);
+        return -1;
+    }
     unsigned long long next_key = cumulativeKeyCountRead(kvs, didx) + 1;
     return next_key <= kvstoreSize(kvs) ? kvstoreFindDictIndexByKeyIndex(kvs, next_key) : -1;
 }

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -726,10 +726,11 @@ unsigned long kvstoreDictScanDefrag(kvstore *kvs, int didx, unsigned long v, dic
  * that callback can reallocate. */
 void kvstoreDictLUTDefrag(kvstore *kvs, kvstoreDictLUTDefragFunction *defragfn) {
     for (int didx = 0; didx < kvs->num_dicts; didx++) {
-        dict **d = kvstoreGetDictRef(kvs, didx);
+        dict **d = kvstoreGetDictRef(kvs, didx), *newd;
         if (!*d)
             continue;
-        *d = defragfn(*d);
+        if ((newd = defragfn(*d)))
+            *d = newd;
     }
 }
 

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -729,7 +729,7 @@ void kvstoreDictLUTDefrag(kvstore *kvs, kvstoreDictLUTDefragFunction *defragfn) 
         dict **d = kvstoreGetDictRef(kvs, didx);
         if (!*d)
             continue;
-        defragfn(d);
+        *d = defragfn(*d);
     }
 }
 

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -525,6 +525,11 @@ int kvstoreFindDictIndexByKeyIndex(kvstore *kvs, unsigned long target) {
     return result;
 }
 
+/* Wrapper for kvstoreFindDictIndexByKeyIndex to get the first non-empty dict index in the kvstore. */
+int kvstoreGetFirstNonEmptyDictIndex(kvstore *kvs) {
+    return kvstoreFindDictIndexByKeyIndex(kvs, 1);
+}
+
 /* Returns next non-empty dict index strictly after given one, or -1 if provided didx is the last one. */
 int kvstoreGetNextNonEmptyDictIndex(kvstore *kvs, int didx) {
     if (kvs->num_dicts == 1) {
@@ -554,7 +559,7 @@ kvstoreIterator *kvstoreIteratorInit(kvstore *kvs) {
     kvstoreIterator *kvs_it = zmalloc(sizeof(*kvs_it));
     kvs_it->kvs = kvs;
     kvs_it->didx = -1;
-    kvs_it->next_didx = kvstoreFindDictIndexByKeyIndex(kvs_it->kvs, 1); /* Finds first non-empty dict index. */
+    kvs_it->next_didx = kvstoreGetFirstNonEmptyDictIndex(kvs_it->kvs); /* Finds first non-empty dict index. */
     dictInitSafeIterator(&kvs_it->di, NULL);
     return kvs_it;
 }

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -56,7 +56,7 @@ dictEntry *kvstoreDictFindEntryByPtrAndHash(kvstore *kvs, int didx, const void *
 unsigned int kvstoreDictGetSomeKeys(kvstore *kvs, int didx, dictEntry **des, unsigned int count);
 int kvstoreDictExpand(kvstore *kvs, int didx, unsigned long size);
 unsigned long kvstoreDictScanDefrag(kvstore *kvs, int didx, unsigned long v, dictScanFunction *fn, dictDefragFunctions *defragfns, void *privdata);
-typedef void (kvstoreDictLUTDefragFunction)(dict **d);
+typedef dict *(kvstoreDictLUTDefragFunction)(dict *d);
 void kvstoreDictLUTDefrag(kvstore *kvs, kvstoreDictLUTDefragFunction *defragfn);
 void *kvstoreDictFetchValue(kvstore *kvs, int didx, const void *key);
 dictEntry *kvstoreDictFind(kvstore *kvs, int didx, void *key);

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -28,6 +28,7 @@ int kvstoreGetFairRandomDictIndex(kvstore *kvs);
 void kvstoreGetStats(kvstore *kvs, char *buf, size_t bufsize, int full);
 
 int kvstoreFindDictIndexByKeyIndex(kvstore *kvs, unsigned long target);
+int kvstoreGetFirstNonEmptyDictIndex(kvstore *kvs);
 int kvstoreGetNextNonEmptyDictIndex(kvstore *kvs, int didx);
 int kvstoreNumNonEmptyDicts(kvstore *kvs);
 int kvstoreNumAllocatedDicts(kvstore *kvs);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -263,27 +263,28 @@ int pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
     unsigned int slot = 0;
 
     /* Add the channel to the client -> channels hash table */
-    if (dictAdd(type.clientPubSubChannels(c),channel,NULL) == DICT_OK) {
+    void *position = dictFindPositionForInsert(type.clientPubSubChannels(c),channel,NULL);
+    if (position) { /* Not yet subscribed to this channel */
         retval = 1;
-        incrRefCount(channel);
         /* Add the client to the channel -> list of clients hash table */
         if (server.cluster_enabled && type.shard) {
             slot = getKeySlot(channel->ptr);
         }
 
-        robj *channel_copy = dupStringObject(channel); /* Copy the channel name to avoid references
-                                                        * that could prevent memory defragmentation. */
-        de = kvstoreDictAddRaw(*type.serverPubSubChannels, slot, channel_copy, &existing);
+        de = kvstoreDictAddRaw(*type.serverPubSubChannels, slot, channel, &existing);
 
         if (existing) {
             clients = dictGetVal(existing);
-            decrRefCount(channel_copy);
+            channel = dictGetKey(existing);
         } else {
             clients = dictCreate(&clientDictType);
             kvstoreDictSetVal(*type.serverPubSubChannels, slot, de, clients);
+            incrRefCount(channel);
         }
 
         serverAssert(dictAdd(clients, c, NULL) != DICT_ERR);
+        serverAssert(dictInsertAtPosition(type.clientPubSubChannels(c), channel, position));
+        incrRefCount(channel);
     }
     /* Notify the client */
     addReplyPubsubSubscribed(c,channel,type);

--- a/src/server.h
+++ b/src/server.h
@@ -3177,6 +3177,8 @@ int serverPubsubShardSubscriptionCount(void);
 size_t pubsubMemOverhead(client *c);
 void unmarkClientAsPubSub(client *c);
 int pubsubTotalSubscriptions(void);
+dict *getClientPubSubChannels(client *c);
+dict *getClientPubSubShardChannels(client *c);
 
 /* Keyspace events notification */
 void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid);

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -470,7 +470,7 @@ run_solo {defrag} {
 
                 # wait for the active defrag to stop working
                 wait_for_condition 2000 100 {
-                    [s allocator_frag_ratio] <= 1.05
+                    [s active_defrag_running] eq 0
                 } else {
                     after 120 ;# serverCron only updates the info once in 100ms
                     puts [r info memory]

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -512,7 +512,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_condition 500 1000 {
+                wait_for_condition 500 100 {
                     [s active_defrag_running] eq 0
                 } else {
                     after 120 ;# serverCron only updates the info once in 100ms

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -730,7 +730,7 @@ run_solo {defrag} {
         test_active_defrag "cluster"
     }
 
-    start_server {tags {"defrag external:skip standalone"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save "" loglevel debug}} {
+    start_server {tags {"defrag external:skip standalone"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save ""}} {
         test_active_defrag "standalone"
     }
 } ;# run_solo

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -427,8 +427,6 @@ run_solo {defrag} {
                 $rd_pubsub ssubscribe $channel_name
                 $rd_pubsub read ; # Discard ssubscribe replies
                 $rd set k$j $channel_name
-            }
-            for {set j 0} {$j < $n} {incr j} {
                 $rd read ; # Discard set replies
             }
 
@@ -493,12 +491,10 @@ run_solo {defrag} {
             # we didn't break the data structure.
             for {set j 0} {$j < $n} {incr j} {
                 set channel "$dummy_channel[format "%06d" $j]"
-
                 r publish $channel "hello"
                 assert_equal "message $channel hello" [$rd_pubsub read] 
                 $rd_pubsub unsubscribe $channel
                 $rd_pubsub read
-
                 r spublish $channel "hello"
                 assert_equal "smessage $channel hello" [$rd_pubsub read] 
                 $rd_pubsub sunsubscribe $channel
@@ -724,11 +720,11 @@ run_solo {defrag} {
     }
     }
 
-    start_cluster 1 0 {tags {"defrag external:skip cluster"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save "" loglevel debug}} {
+    start_cluster 1 0 {tags {"defrag external:skip cluster"} overrides {appendonly yes auto-aof-rewrite-percentage 0}} {
         test_active_defrag "cluster"
     }
 
-    start_server {tags {"defrag external:skip standalone"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save "" loglevel debug}} {
+    start_server {tags {"defrag external:skip standalone"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save}} {
         test_active_defrag "standalone"
     }
 } ;# run_solo

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -720,11 +720,11 @@ run_solo {defrag} {
     }
     }
 
-    start_cluster 1 0 {tags {"defrag external:skip cluster"} overrides {appendonly yes auto-aof-rewrite-percentage 0}} {
+    start_cluster 1 0 {tags {"defrag external:skip cluster"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save ""}} {
         test_active_defrag "cluster"
     }
 
-    start_server {tags {"defrag external:skip standalone"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save}} {
+    start_server {tags {"defrag external:skip standalone"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save ""}} {
         test_active_defrag "standalone"
     }
 } ;# run_solo

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -469,7 +469,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_condition 2000 100 {
+                wait_for_condition 500 100 {
                     [s active_defrag_running] eq 0
                 } else {
                     after 120 ;# serverCron only updates the info once in 100ms

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -183,7 +183,7 @@ run_solo {defrag} {
             r config resetstat
             r config set hz 100
             r config set activedefrag no
-            r config set active-defrag-threshold-lower 7
+            r config set active-defrag-threshold-lower 5
             r config set active-defrag-cycle-min 65
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 1500kb


### PR DESCRIPTION
After #13013

### This PR make effort to defrag the pubsub kvstore in the following ways:

1. Till now server.pubsub(shard)_channels only share channel name obj with the first subscribed client, now change it so that the clients and the pubsub kvstore share the channel name robj.
   This would save a lot of memory when there are many subscribers to the same channel.
   It also means that we only need to defrag the channel name robj in the pubsub kvstore, and then update
    all client references for the current channel, avoiding the need to iterate through all the clients to do the same things.
    
2. Refactor the code to defragment pubsub(shard) in the same way as defragment of keys and EXPIRES, with the exception that we only defragment pubsub(without shard) when slot is zero.


### Other
Fix an overlook in #11695, if defragment doesn't reach the end time, we should wait for the current
db's keys and expires, pubsub and pubsubshard to finish before leaving, now it's possible to exit
early when the keys are defragmented.