### PR TITLE
redis-cli - fix sscanf incorrect return-value check warnings

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -1247,7 +1247,7 @@ static int matchNoTokenArg(char **nextword, int numwords, cliCommandArg *arg) {
     case ARG_TYPE_INTEGER:
     case ARG_TYPE_UNIX_TIME: {
         long long value;
-        if (sscanf(*nextword, "%lld", &value)) {
+        if (sscanf(*nextword, "%lld", &value) == 1) {
             arg->matched += 1;
             arg->matched_name = 1;
             arg->matched_all = 1;
@@ -1261,7 +1261,7 @@ static int matchNoTokenArg(char **nextword, int numwords, cliCommandArg *arg) {
 
     case ARG_TYPE_DOUBLE: {
         double value;
-        if (sscanf(*nextword, "%lf", &value)) {
+        if (sscanf(*nextword, "%lf", &value) == 1) {
             arg->matched += 1;
             arg->matched_name = 1;
             arg->matched_all = 1;


### PR DESCRIPTION
From CodeQL: The result of scanf is only checked against 0, but
it can also return EOF.

Reported in https://github.com/redis/redis/security/code-scanning/38.
Reported in https://github.com/redis/redis/security/code-scanning/39.