### PR TITLE
Update the listpack object free method

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1952,7 +1952,7 @@ int listpackTest(int argc, char *argv[], int flags) {
         assert(lpLength(lp) == 0);
         assert(lp[LP_HDR_SIZE] == LP_EOF);
         assert(lpBytes(lp) == (LP_HDR_SIZE + 1));
-        zfree(lp);
+        lpFree(lp);
 
         lp = createList();
         unsigned char *ptr = lpFirst(lp);
@@ -1960,7 +1960,7 @@ int listpackTest(int argc, char *argv[], int flags) {
         assert(lpLength(lp) == 0);
         assert(lp[LP_HDR_SIZE] == LP_EOF);
         assert(lpBytes(lp) == (LP_HDR_SIZE + 1));
-        zfree(lp);
+        lpFree(lp);
     }
 
     TEST("Delete whole listpack with negative index");
@@ -1970,7 +1970,7 @@ int listpackTest(int argc, char *argv[], int flags) {
         assert(lpLength(lp) == 0);
         assert(lp[LP_HDR_SIZE] == LP_EOF);
         assert(lpBytes(lp) == (LP_HDR_SIZE + 1));
-        zfree(lp);
+        lpFree(lp);
 
         lp = createList();
         unsigned char *ptr = lpSeek(lp, -4);
@@ -1978,7 +1978,7 @@ int listpackTest(int argc, char *argv[], int flags) {
         assert(lpLength(lp) == 0);
         assert(lp[LP_HDR_SIZE] == LP_EOF);
         assert(lpBytes(lp) == (LP_HDR_SIZE + 1));
-        zfree(lp);
+        lpFree(lp);
     }
 
     TEST("Delete inclusive range 0,0");
@@ -1987,14 +1987,14 @@ int listpackTest(int argc, char *argv[], int flags) {
         lp = lpDeleteRange(lp, 0, 1);
         assert(lpLength(lp) == 3);
         assert(lpSkip(lpLast(lp))[0] == LP_EOF); /* check set LP_EOF correctly */
-        zfree(lp);
+        lpFree(lp);
 
         lp = createList();
         unsigned char *ptr = lpFirst(lp);
         lp = lpDeleteRangeWithEntry(lp, &ptr, 1);
         assert(lpLength(lp) == 3);
         assert(lpSkip(lpLast(lp))[0] == LP_EOF); /* check set LP_EOF correctly */
-        zfree(lp);
+        lpFree(lp);
     }
 
     TEST("Delete inclusive range 0,1");
@@ -2003,14 +2003,14 @@ int listpackTest(int argc, char *argv[], int flags) {
         lp = lpDeleteRange(lp, 0, 2);
         assert(lpLength(lp) == 2);
         verifyEntry(lpFirst(lp), (unsigned char*)mixlist[2], strlen(mixlist[2]));
-        zfree(lp);
+        lpFree(lp);
 
         lp = createList();
         unsigned char *ptr = lpFirst(lp);
         lp = lpDeleteRangeWithEntry(lp, &ptr, 2);
         assert(lpLength(lp) == 2);
         verifyEntry(lpFirst(lp), (unsigned char*)mixlist[2], strlen(mixlist[2]));
-        zfree(lp);
+        lpFree(lp);
     }
 
     TEST("Delete inclusive range 1,2");
@@ -2019,14 +2019,14 @@ int listpackTest(int argc, char *argv[], int flags) {
         lp = lpDeleteRange(lp, 1, 2);
         assert(lpLength(lp) == 2);
         verifyEntry(lpFirst(lp), (unsigned char*)mixlist[0], strlen(mixlist[0]));
-        zfree(lp);
+        lpFree(lp);
 
         lp = createList();
         unsigned char *ptr = lpSeek(lp, 1);
         lp = lpDeleteRangeWithEntry(lp, &ptr, 2);
         assert(lpLength(lp) == 2);
         verifyEntry(lpFirst(lp), (unsigned char*)mixlist[0], strlen(mixlist[0]));
-        zfree(lp);
+        lpFree(lp);
     }
     
     TEST("Delete with start index out of range");
@@ -2034,7 +2034,7 @@ int listpackTest(int argc, char *argv[], int flags) {
         lp = createList();
         lp = lpDeleteRange(lp, 5, 1);
         assert(lpLength(lp) == 4);
-        zfree(lp);
+        lpFree(lp);
     }
 
     TEST("Delete with num overflow");
@@ -2043,14 +2043,14 @@ int listpackTest(int argc, char *argv[], int flags) {
         lp = lpDeleteRange(lp, 1, 5);
         assert(lpLength(lp) == 1);
         verifyEntry(lpFirst(lp), (unsigned char*)mixlist[0], strlen(mixlist[0]));
-        zfree(lp);
+        lpFree(lp);
 
         lp = createList();
         unsigned char *ptr = lpSeek(lp, 1);
         lp = lpDeleteRangeWithEntry(lp, &ptr, 5);
         assert(lpLength(lp) == 1);
         verifyEntry(lpFirst(lp), (unsigned char*)mixlist[0], strlen(mixlist[0]));
-        zfree(lp);
+        lpFree(lp);
     }
 
     TEST("Batch delete") {
@@ -2169,7 +2169,7 @@ int listpackTest(int argc, char *argv[], int flags) {
         /* Merge two empty listpacks, get empty result back. */
         lp1 = lpMerge(&lp1, &lp2);
         assert(lpLength(lp1) == 0);
-        zfree(lp1);
+        lpFree(lp1);
     }
 
     TEST("lpMerge two listpacks - first larger than second") {
@@ -2190,7 +2190,7 @@ int listpackTest(int argc, char *argv[], int flags) {
         verifyEntry(lpSeek(lp3, 5), (unsigned char*)"much much longer non integer", 28);
         verifyEntry(lpSeek(lp3, 6), (unsigned char*)"hello", 5);
         verifyEntry(lpSeek(lp3, -1), (unsigned char*)"1024", 4);
-        zfree(lp3);
+        lpFree(lp3);
     }
 
     TEST("lpMerge two listpacks - second larger than first") {
@@ -2211,7 +2211,7 @@ int listpackTest(int argc, char *argv[], int flags) {
         verifyEntry(lpSeek(lp3, 3), (unsigned char*)"1024", 4);
         verifyEntry(lpSeek(lp3, 4), (unsigned char*)"4294967296", 10);
         verifyEntry(lpSeek(lp3, -1), (unsigned char*)"much much longer non integer", 28);
-        zfree(lp3);
+        lpFree(lp3);
     }
 
     TEST("lpNextRandom normal usage") {

--- a/src/object.c
+++ b/src/object.c
@@ -328,8 +328,10 @@ void freeSetObject(robj *o) {
         dictRelease((dict*) o->ptr);
         break;
     case OBJ_ENCODING_INTSET:
-    case OBJ_ENCODING_LISTPACK:
         zfree(o->ptr);
+        break;
+    case OBJ_ENCODING_LISTPACK:
+        lpFree(o->ptr);
         break;
     default:
         serverPanic("Unknown set encoding type");
@@ -346,7 +348,7 @@ void freeZsetObject(robj *o) {
         zfree(zs);
         break;
     case OBJ_ENCODING_LISTPACK:
-        zfree(o->ptr);
+        lpFree(o->ptr);
         break;
     default:
         serverPanic("Unknown sorted set encoding");

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2210,7 +2210,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                 if (!lpValidateIntegrity(lp, encoded_len, deep_integrity_validation, NULL, NULL)) {
                     rdbReportCorruptRDB("Listpack integrity check failed.");
                     decrRefCount(o);
-                    zfree(lp);
+                    lpFree(lp);
                     return NULL;
                 }
             } else {
@@ -2221,7 +2221,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                     rdbReportCorruptRDB("Ziplist integrity check failed.");
                     decrRefCount(o);
                     zfree(data);
-                    zfree(lp);
+                    lpFree(lp);
                     return NULL;
                 }
                 zfree(data);
@@ -2230,7 +2230,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
 
             /* Silently skip empty ziplists, if we'll end up with empty quicklist we'll fail later. */
             if (lpLength(lp) == 0) {
-                zfree(lp);
+                lpFree(lp);
                 continue;
             } else {
                 quicklistAppendListpack(o->ptr, lp);
@@ -2390,7 +2390,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                     unsigned char *lp = lpNew(encoded_len);
                     if (!ziplistPairsConvertAndValidateIntegrity(encoded, encoded_len, &lp)) {
                         rdbReportCorruptRDB("Zset ziplist integrity check failed.");
-                        zfree(lp);
+                        lpFree(lp);
                         zfree(encoded);
                         o->ptr = NULL;
                         decrRefCount(o);
@@ -2436,7 +2436,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                     unsigned char *lp = lpNew(encoded_len);
                     if (!ziplistPairsConvertAndValidateIntegrity(encoded, encoded_len, &lp)) {
                         rdbReportCorruptRDB("Hash ziplist integrity check failed.");
-                        zfree(lp);
+                        lpFree(lp);
                         zfree(encoded);
                         o->ptr = NULL;
                         decrRefCount(o);
@@ -2528,7 +2528,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                 rdbReportCorruptRDB("Stream listpack integrity check failed.");
                 sdsfree(nodekey);
                 decrRefCount(o);
-                zfree(lp);
+                lpFree(lp);
                 return NULL;
             }
 
@@ -2540,7 +2540,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                 rdbReportCorruptRDB("Empty listpack inside stream");
                 sdsfree(nodekey);
                 decrRefCount(o);
-                zfree(lp);
+                lpFree(lp);
                 return NULL;
             }
 
@@ -2551,7 +2551,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             if (!retval) {
                 rdbReportCorruptRDB("Listpack re-added with existing key");
                 decrRefCount(o);
-                zfree(lp);
+                lpFree(lp);
                 return NULL;
             }
         }


### PR DESCRIPTION
During the object release process in listpack, in the PR https://github.com/redis/redis/pull/9366, the corresponding free method was not modified to lpfree. Even though there are currently no exceptions, to avoid potential issues in the future, the free method was standardized and updated to lpfree.