### PR TITLE
Makefile respect user's REDIS_CFLAGS and OPT

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,6 +16,10 @@ release_hdr := $(shell sh -c './mkreleasehdr.sh')
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
 CLANG := $(findstring clang,$(shell sh -c '$(CC) --version | head -1'))
+
+# Optimization flags. To override, the OPTIMIZATION variable can be passed, but
+# some automatic defaults are added to it. To specify optimization flags
+# explicitly without any defaults added, pass the OPT variable instead.
 OPTIMIZATION?=-O3
 ifeq ($(OPTIMIZATION),-O3)
 	ifeq (clang,$(CLANG))

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,14 +19,13 @@ CLANG := $(findstring clang,$(shell sh -c '$(CC) --version | head -1'))
 OPTIMIZATION?=-O3
 ifeq ($(OPTIMIZATION),-O3)
 	ifeq (clang,$(CLANG))
-		REDIS_CFLAGS+=-flto
+		OPTIMIZATION+=-flto
 	else
-		REDIS_CFLAGS+=-flto=auto
+		OPTIMIZATION+=-flto=auto
 	endif
-	REDIS_LDFLAGS+=-O3 -flto
 endif
 ifneq ($(OPTIMIZATION),-O0)
-	REDIS_CFLAGS+=-fno-omit-frame-pointer
+	OPTIMIZATION+=-fno-omit-frame-pointer
 endif
 DEPENDENCY_TARGETS=hiredis linenoise lua hdr_histogram fpconv
 NODEPS:=clean distclean
@@ -120,7 +119,7 @@ endif
 -include .make-settings
 
 FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
-FINAL_LDFLAGS=$(LDFLAGS) $(REDIS_LDFLAGS) $(DEBUG)
+FINAL_LDFLAGS=$(LDFLAGS) $(OPT) $(REDIS_LDFLAGS) $(DEBUG)
 FINAL_LIBS=-lm
 DEBUG=-g -ggdb
 


### PR DESCRIPTION
This change to the Makefile makes it possible to opt out of `-fno-omit-frame-pointer` added in #12973 and `-flto` (#11350). Those features were implemented by conditionally modifying the `REDIS_CFLAGS` and `REDIS_LDFLAGS` variables. Historically, those variables provided a way for users to pass options to the compiler and linker unchanged.

Instead of conditionally appending optimization flags to REDIS_CFLAGS and REDIS_LDFLAGS, I want to append them to the OPTIMIZATION variable.

Later in the Makefile, we have `OPT=$(OPTIMIZATION)` (meaning OPTIMIZATION is only a default for OPT, but OPT can be overridden by the user), and later the flags are combined like this:

    FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
    FINAL_LDFLAGS=$(LDFLAGS) $(OPT) $(REDIS_LDFLAGS) $(DEBUG)

This makes it possible for the the user to override all optimization flags with e.g. `make OPT=-O1` or just `make OPT=`.

For some reason `-O3` was also already added to REDIS_LDFLAGS by default in #12339, so I added OPT to FINAL_LDFLAGS to avoid more complex logic (such as introducing a separate LD_OPT variable).