### PR TITLE
Add new allocator.muzzy field to memory-stats reply schema

### DIFF
--- a/src/commands/memory-stats.json
+++ b/src/commands/memory-stats.json
@@ -74,6 +74,9 @@
                 "allocator.resident": {
                     "type": "integer"
                 },
+                "allocator.muzzy": {
+                    "type": "integer"
+                },
                 "allocator-fragmentation.ratio": {
                     "type": "number"
                 },


### PR DESCRIPTION
This field was added in #12996 but forgot to add it in json file.
This also causes reply-schemas-validator to fail.