### PR TITLE
Avoid expiration and eviction during data syncing

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -762,6 +762,13 @@ replica-priority 100
 #
 # replica-ignore-disk-write-errors no
 
+# Make the master behave like a replica, which forbids expiration and evcition.
+# This is useful for sync tools, because expiration and evcition may cause the data corruption.
+# Sync tools can set their connections into 'pseudo-master' state by REPLCONF PSEUDO-MASTER to
+# behave like a master(i.e. visit expired keys). 
+#
+# pseudo-replica no
+
 # -----------------------------------------------------------------------------
 # By default, Redis Sentinel includes all replicas in its reports. A replica
 # can be excluded from Redis Sentinel's announcements. An unannounced replica

--- a/src/config.c
+++ b/src/config.c
@@ -3111,6 +3111,7 @@ standardConfig static_configs[] = {
     createBoolConfig("latency-tracking", NULL, MODIFIABLE_CONFIG, server.latency_tracking_enabled, 1, NULL, NULL),
     createBoolConfig("aof-disable-auto-gc", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.aof_disable_auto_gc, 0, NULL, updateAofAutoGCEnabled),
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
+    createBoolConfig("pseudo-replica", NULL, MODIFIABLE_CONFIG, server.pseudo_replica, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/db.c
+++ b/src/db.c
@@ -1835,7 +1835,9 @@ int expireIfNeeded(redisDb *db, robj *key, int flags) {
     } else if (server.pseudo_replica) {
         /* If we are in 'pseudo_replica' mode, we stop expiration.
          * If the client is a pseudo master, keys are never considered expired. */
-        if (server.current_client && (server.current_client->flags & CLIENT_PSEUDO_MASTER)) return 0;
+        if (server.current_client && (server.current_client->flags & CLIENT_PSEUDO_MASTER)) {
+            return 0;
+        }
         return 1;
     }
 

--- a/src/db.c
+++ b/src/db.c
@@ -1834,7 +1834,7 @@ int expireIfNeeded(redisDb *db, robj *key, int flags) {
         if (!(flags & EXPIRE_FORCE_DELETE_EXPIRED)) return 1;
     } else if (server.pseudo_replica_enabled) {
         /* If we are in 'pseudo_replica' mode, we stop expiration.
-         * If the client is a pseudo matser, keys are never considered expired. */
+         * If the client is a pseudo master, keys are never considered expired. */
         if (server.current_client && (server.current_client->flags & CLIENT_PSEUDO_MASTER)) return 0;
         return 1;
     }

--- a/src/db.c
+++ b/src/db.c
@@ -355,7 +355,7 @@ robj *dbRandomKey(redisDb *db) {
         key = dictGetKey(de);
         keyobj = createStringObject(key,sdslen(key));
         if (dbFindExpires(db, key)) {
-            if (allvolatile && (server.masterhost || server.pseudo_replica_enabled) && --maxtries == 0) {
+            if (allvolatile && (server.masterhost || server.pseudo_replica) && --maxtries == 0) {
                 /* If the DB is composed only of keys with an expire set,
                  * it could happen that all the keys are already logically
                  * expired in the slave, so the function cannot stop because
@@ -1832,7 +1832,7 @@ int expireIfNeeded(redisDb *db, robj *key, int flags) {
     if (server.masterhost != NULL) {
         if (server.current_client && (server.current_client->flags & CLIENT_MASTER)) return 0;
         if (!(flags & EXPIRE_FORCE_DELETE_EXPIRED)) return 1;
-    } else if (server.pseudo_replica_enabled) {
+    } else if (server.pseudo_replica) {
         /* If we are in 'pseudo_replica' mode, we stop expiration.
          * If the client is a pseudo master, keys are never considered expired. */
         if (server.current_client && (server.current_client->flags & CLIENT_PSEUDO_MASTER)) return 0;

--- a/src/evict.c
+++ b/src/evict.c
@@ -556,7 +556,7 @@ int performEvictions(void) {
         goto update_metrics;
     }
 
-    if (server.maxmemory_policy == MAXMEMORY_NO_EVICTION || server.pseudo_replica_enabled) {
+    if (server.maxmemory_policy == MAXMEMORY_NO_EVICTION || server.pseudo_replica) {
         result = EVICT_FAIL;  /* We need to free memory, but policy forbids or we are in 'pseudo-replica' mode. */
         goto update_metrics;
     }

--- a/src/evict.c
+++ b/src/evict.c
@@ -556,8 +556,8 @@ int performEvictions(void) {
         goto update_metrics;
     }
 
-    if (server.maxmemory_policy == MAXMEMORY_NO_EVICTION) {
-        result = EVICT_FAIL;  /* We need to free memory, but policy forbids. */
+    if (server.maxmemory_policy == MAXMEMORY_NO_EVICTION || server.pseudo_replica_enabled) {
+        result = EVICT_FAIL;  /* We need to free memory, but policy forbids or we are in 'pseudo-replica' mode. */
         goto update_metrics;
     }
 

--- a/src/expire.c
+++ b/src/expire.c
@@ -532,7 +532,7 @@ int checkAlreadyExpired(long long when) {
      *
      * Instead we add the already expired key to the database with expire time
      * (possibly in the past) and wait for an explicit DEL from the master. */
-    return (when <= commandTimeSnapshot() && !server.loading && !server.masterhost && !server.pseudo_replica_enabled);
+    return (when <= commandTimeSnapshot() && !server.loading && !server.masterhost && !server.pseudo_replica);
 }
 
 #define EXPIRE_NX (1<<0)

--- a/src/expire.c
+++ b/src/expire.c
@@ -532,7 +532,7 @@ int checkAlreadyExpired(long long when) {
      *
      * Instead we add the already expired key to the database with expire time
      * (possibly in the past) and wait for an explicit DEL from the master. */
-    return (when <= commandTimeSnapshot() && !server.loading && !server.masterhost);
+    return (when <= commandTimeSnapshot() && !server.loading && !server.masterhost && !server.pseudo_replica_enabled);
 }
 
 #define EXPIRE_NX (1<<0)

--- a/src/server.c
+++ b/src/server.c
@@ -1055,7 +1055,7 @@ void clientsCron(void) {
 void databasesCron(void) {
     /* Expire keys by random sampling. Not required for slaves
      * as master will synthesize DELs for us. */
-    if (server.active_expire_enabled) {
+    if (server.active_expire_enabled && !server.pseudo_replica_enabled) {
         if (iAmMaster()) {
             activeExpireCycle(ACTIVE_EXPIRE_CYCLE_SLOW);
         } else {
@@ -1679,7 +1679,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
 
     /* Run a fast expire cycle (the called function will return
      * ASAP if a fast cycle is not needed). */
-    if (server.active_expire_enabled && iAmMaster())
+    if (server.active_expire_enabled && !server.pseudo_replica_enabled && iAmMaster())
         activeExpireCycle(ACTIVE_EXPIRE_CYCLE_FAST);
 
     if (moduleCount()) {
@@ -2083,6 +2083,7 @@ void initServerConfig(void) {
     server.page_size = sysconf(_SC_PAGESIZE);
     server.pause_cron = 0;
     server.dict_resizing = 1;
+    server.pseudo_replica_enabled = 0;
 
     server.latency_tracking_info_percentiles_len = 3;
     server.latency_tracking_info_percentiles = zmalloc(sizeof(double)*(server.latency_tracking_info_percentiles_len));

--- a/src/server.c
+++ b/src/server.c
@@ -1055,7 +1055,7 @@ void clientsCron(void) {
 void databasesCron(void) {
     /* Expire keys by random sampling. Not required for slaves
      * as master will synthesize DELs for us. */
-    if (server.active_expire_enabled && !server.pseudo_replica_enabled) {
+    if (server.active_expire_enabled && !server.pseudo_replica) {
         if (iAmMaster()) {
             activeExpireCycle(ACTIVE_EXPIRE_CYCLE_SLOW);
         } else {
@@ -1679,7 +1679,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
 
     /* Run a fast expire cycle (the called function will return
      * ASAP if a fast cycle is not needed). */
-    if (server.active_expire_enabled && !server.pseudo_replica_enabled && iAmMaster())
+    if (server.active_expire_enabled && !server.pseudo_replica && iAmMaster())
         activeExpireCycle(ACTIVE_EXPIRE_CYCLE_FAST);
 
     if (moduleCount()) {
@@ -2083,7 +2083,7 @@ void initServerConfig(void) {
     server.page_size = sysconf(_SC_PAGESIZE);
     server.pause_cron = 0;
     server.dict_resizing = 1;
-    server.pseudo_replica_enabled = 0;
+    server.pseudo_replica = 0;
 
     server.latency_tracking_info_percentiles_len = 3;
     server.latency_tracking_info_percentiles = zmalloc(sizeof(double)*(server.latency_tracking_info_percentiles_len));

--- a/src/server.h
+++ b/src/server.h
@@ -1922,7 +1922,7 @@ struct redisServer {
     long long master_initial_offset;           /* Master PSYNC offset. */
     int repl_slave_lazy_flush;          /* Lazy FLUSHALL before loading DB? */
     /* Pseudo Replica */
-    int pseudo_replica_enabled;
+    int pseudo_replica;                 /* If true, server is a pseudo replica. */
     /* Synchronous replication. */
     list *clients_waiting_acks;         /* Clients waiting in WAIT or WAITAOF. */
     int get_ack_from_slaves;            /* If true we send REPLCONF GETACK. */

--- a/src/server.h
+++ b/src/server.h
@@ -402,6 +402,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_MODULE_PREVENT_AOF_PROP (1ULL<<48) /* Module client do not want to propagate to AOF */
 #define CLIENT_MODULE_PREVENT_REPL_PROP (1ULL<<49) /* Module client do not want to propagate to replica */
 #define CLIENT_REPROCESSING_COMMAND (1ULL<<50) /* The client is re-processing the command. */
+#define CLIENT_PSEUDO_MASTER (1ULL<<51)  /* This client is a pseudo master */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */
@@ -1920,6 +1921,8 @@ struct redisServer {
     char master_replid[CONFIG_RUN_ID_SIZE+1];  /* Master PSYNC runid. */
     long long master_initial_offset;           /* Master PSYNC offset. */
     int repl_slave_lazy_flush;          /* Lazy FLUSHALL before loading DB? */
+    /* Pseudo Replica */
+    int pseudo_replica_enabled;
     /* Synchronous replication. */
     list *clients_waiting_acks;         /* Clients waiting in WAIT or WAITAOF. */
     int get_ack_from_slaves;            /* If true we send REPLCONF GETACK. */

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -836,7 +836,8 @@ start_server {tags {"expire"}} {
     test {Pseudo-replica mode should forbid active expiration} {
         r flushall
 
-        assert_equal [r replconf pseudo-replica 1] {OK}
+        r config set pseudo-replica yes
+        assert_equal [r replconf pseudo-master 1] {OK}
 
         r set foo1 bar PX 1
         r set foo2 bar PX 1
@@ -844,7 +845,8 @@ start_server {tags {"expire"}} {
 
         assert_equal [r dbsize] {2}
 
-        assert_equal [r replconf pseudo-replica 0] {OK}
+        assert_equal [r replconf pseudo-master 0] {OK}
+        r config set pseudo-replica no
 
         # Verify all keys have expired
         wait_for_condition 40 100 {
@@ -858,7 +860,8 @@ start_server {tags {"expire"}} {
         r flushall
         r debug set-active-expire 0 
 
-        assert_equal [r replconf pseudo-replica 1] {OK}
+        r config set pseudo-replica yes
+        assert_equal [r replconf pseudo-master 1] {OK}
 
         r set foo1 bar PX 1
         after 10
@@ -867,7 +870,8 @@ start_server {tags {"expire"}} {
 
         assert_equal [r dbsize] {1}
 
-        assert_equal [r replconf pseudo-replica 0] {OK}
+        assert_equal [r replconf pseudo-master 0] {OK}
+        r config set pseudo-replica no
 
         r get foo1
 
@@ -879,7 +883,8 @@ start_server {tags {"expire"}} {
     test {RANDOMKEY can return expired key in Pseudo-replica mode} {
         r flushall
 
-        assert_equal [r replconf pseudo-replica 1] {OK}
+        r config set pseudo-replica yes
+        assert_equal [r replconf pseudo-master 1] {OK}
 
         r set foo1 bar PX 1
         after 10
@@ -892,7 +897,8 @@ start_server {tags {"expire"}} {
 
         assert_equal [r randomkey] {foo1}
 
-        assert_equal [r replconf pseudo-replica 0] {OK}
+        assert_equal [r replconf pseudo-master 0] {OK}
+        r config set pseudo-replica no
 
         # Verify all keys have expired
         wait_for_condition 40 100 {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -885,7 +885,9 @@ start_server {tags {"expire"}} {
         after 10
 
         set client [redis [srv "host"] [srv "port"] 0 $::tls]
-        $client select 9
+        if {!$::singledb} {
+            $client select 9
+        }
         assert_equal [$client ttl foo1] {-2}
 
         assert_equal [r randomkey] {foo1}

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -593,3 +593,18 @@ start_server {tags {"maxmemory" "external:skip"}} {
         assert {[r object freq foo] == 5}
     }
 }
+
+start_server {tags {"maxmemory" "external:skip"}} {
+    test {Pseudo-replica mode should forbid eviction} {
+        r set key val
+        assert_equal [r replconf pseudo-replica 1] {OK}  
+        r config set maxmemory-policy allkeys-lru
+        r config set maxmemory 1      
+
+        after 100
+        assert_equal [r dbsize] {1}
+        assert_error {OOM command not allowed*} {r set key1 val1}
+
+        assert_equal [r replconf pseudo-replica 0] {OK}  
+    }
+}

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -597,7 +597,8 @@ start_server {tags {"maxmemory" "external:skip"}} {
 start_server {tags {"maxmemory" "external:skip"}} {
     test {Pseudo-replica mode should forbid eviction} {
         r set key val
-        assert_equal [r replconf pseudo-replica 1] {OK}  
+        r config set pseudo-replica yes
+        assert_equal [r replconf pseudo-master 1] {OK}  
         r config set maxmemory-policy allkeys-lru
         r config set maxmemory 1      
 
@@ -605,6 +606,7 @@ start_server {tags {"maxmemory" "external:skip"}} {
         assert_equal [r dbsize] {1}
         assert_error {OOM command not allowed*} {r set key1 val1}
 
-        assert_equal [r replconf pseudo-replica 0] {OK}  
+        assert_equal [r replconf pseudo-master 0] {OK}  
+        r config set pseudo-replica no
     }
 }


### PR DESCRIPTION
When we sync data from the source Redis to the destination Redis using some sync tools like [redis-shake](https://github.com/tair-opensource/RedisShake), the destination Redis think it's a master and can perform expiration and eviction, which may cause data corruption like what @oranagra said in https://github.com/redis/redis/discussions/9760#discussioncomment-1681041.

In standalone mode, we can use writable replica to simplify the sync process. However, in cluster mode, we still need a sync tool to help us transfer the source data to the destination. The sync tool usually work as a normal client so the destination works as a master which keep expiration and eviction.

In this PR, we add a new mode for master named 'pseudo-replica'. In this mode, server stop expiration and eviction just like a replica. Notice that this mode exists only in sync state to avoid data inconsistency caused by expiration and eviction.