### PR TITLE
Add quick path for KEYS command if following pattern can be expanded.

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -32,6 +32,7 @@
 
 #include <stdint.h>
 #include "sds.h"
+#include "adlist.h"
 
 /* The maximum number of characters needed to represent a long double
  * as a string (long double has a huge range of some 4952 chars, see LDBL_MAX).
@@ -58,6 +59,7 @@ typedef enum {
 } ld2string_mode;
 
 int stringmatchlen(const char *p, int plen, const char *s, int slen, int nocase);
+list *stringmatch_quickpath(const char *pattern, int patternLen);
 int stringmatch(const char *p, const char *s, int nocase);
 int stringmatchlen_fuzz_test(void);
 unsigned long long memtoull(const char *p, int *err);


### PR DESCRIPTION
1. Use GET similar operation for the glob pattern that have certain permutations, like `[a-c], [abc]`. To avoid full scan the whole database, especially for large set keys.
```
KEYS hello                   
    = GET hello
KEYS h[ae]llo
    = GET hallo 
      GET hello
KEYS h[a-e]llo
    = GET hallo
      GET hbllo
      GET hcllo
      GET hdllo
      GET hello
```
2. For the uncertain permutations if pattern include `* ? ^` wildcard character, keep using full iteration.