### PR TITLE
BITCOUNT 'end' as optional argument for consistency with BITPOS

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -51,23 +51,28 @@ keySpec BITCOUNT_Keyspecs[1] = {
 };
 #endif
 
-/* BITCOUNT range unit argument table */
-struct COMMAND_ARG BITCOUNT_range_unit_Subargs[] = {
+/* BITCOUNT range end_unit_block unit argument table */
+struct COMMAND_ARG BITCOUNT_range_end_unit_block_unit_Subargs[] = {
 {MAKE_ARG("byte",ARG_TYPE_PURE_TOKEN,-1,"BYTE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("bit",ARG_TYPE_PURE_TOKEN,-1,"BIT",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
+/* BITCOUNT range end_unit_block argument table */
+struct COMMAND_ARG BITCOUNT_range_end_unit_block_Subargs[] = {
+{MAKE_ARG("end",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("unit",ARG_TYPE_ONEOF,-1,NULL,NULL,"7.0.0",CMD_ARG_OPTIONAL,2,NULL),.subargs=BITCOUNT_range_end_unit_block_unit_Subargs},
 };
 
 /* BITCOUNT range argument table */
 struct COMMAND_ARG BITCOUNT_range_Subargs[] = {
 {MAKE_ARG("start",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("end",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("unit",ARG_TYPE_ONEOF,-1,NULL,NULL,"7.0.0",CMD_ARG_OPTIONAL,2,NULL),.subargs=BITCOUNT_range_unit_Subargs},
+{MAKE_ARG("end-unit-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=BITCOUNT_range_end_unit_block_Subargs},
 };
 
 /* BITCOUNT argument table */
 struct COMMAND_ARG BITCOUNT_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,3,NULL),.subargs=BITCOUNT_range_Subargs},
+{MAKE_ARG("range",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=BITCOUNT_range_Subargs},
 };
 
 /********** BITFIELD ********************/

--- a/src/commands/bitcount.json
+++ b/src/commands/bitcount.json
@@ -54,24 +54,31 @@
                         "type": "integer"
                     },
                     {
-                        "name": "end",
-                        "type": "integer"
-                    },
-                    {
-                        "name": "unit",
-                        "type": "oneof",
+                        "name": "end-unit-block",
+                        "type": "block",
                         "optional": true,
-                        "since": "7.0.0",
                         "arguments": [
                             {
-                                "name": "byte",
-                                "type": "pure-token",
-                                "token": "BYTE"
+                                "name": "end",
+                                "type": "integer"
                             },
                             {
-                                "name": "bit",
-                                "type": "pure-token",
-                                "token": "BIT"
+                                "name": "unit",
+                                "type": "oneof",
+                                "optional": true,
+                                "since": "7.0.0",
+                                "arguments": [
+                                    {
+                                        "name": "byte",
+                                        "type": "pure-token",
+                                        "token": "BYTE"
+                                    },
+                                    {
+                                        "name": "bit",
+                                        "type": "pure-token",
+                                        "token": "BIT"
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/tests/unit/bitops.tcl
+++ b/tests/unit/bitops.tcl
@@ -128,6 +128,15 @@ start_server {tags {"bitops"}} {
         }
     }
 
+    test {BITCOUNT with start} {
+        set s "foobar"
+        r set s $s
+        assert_equal [r bitcount s 0] [count_bits "foobar"]
+        assert_equal [r bitcount s 1] [count_bits "oobar"]
+        assert_equal [r bitcount s -1] [count_bits "r"]
+        assert_equal [r bitcount s -2] [count_bits "ar"]
+    }
+
     test {BITCOUNT with start, end} {
         set s "foobar"
         r set s $s
@@ -150,12 +159,10 @@ start_server {tags {"bitops"}} {
     test {BITCOUNT with illegal arguments} {
         # Used to return 0 for non-existing key instead of errors
         r del s
-        assert_error {ERR *syntax*} {r bitcount s 0}
         assert_error {ERR *syntax*} {r bitcount s 0 1 hello}
         assert_error {ERR *syntax*} {r bitcount s 0 1 hello hello2}
 
         r set s 1
-        assert_error {ERR *syntax*} {r bitcount s 0}
         assert_error {ERR *syntax*} {r bitcount s 0 1 hello}
         assert_error {ERR *syntax*} {r bitcount s 0 1 hello hello2}
     }


### PR DESCRIPTION
I have found that something weird between BITPOS and BITCOUNT:
```
BITPOS key bit [start [end [BYTE | BIT]]]
BITCOUNT key [start end [BYTE | BIT]]
```

I think this might hurt consistency and can cause confusion in terms of usability.
The results below are the asis unstable build:
```
> get TEST:ABCD
"ABCD"
> BITPOS TEST:ABCD 1 0 -1
(integer) 1
> BITCOUNT TEST:ABCD 0 -1
(integer) 9
> BITPOS TEST:ABCD 1 0
(integer) 1
> BITCOUNT TEST:ABCD 0
(error) ERR syntax error
```

And these PR contains fixing of this issue:
```
> GET TEST:ABCD
"ABCD"
> BITPOS TEST:ABCD 1 0 -1
(integer) 1
> BITCOUNT TEST:ABCD 0 -1
(integer) 9
> BITPOS TEST:ABCD 1 0
(integer) 1
> BITCOUNT TEST:ABCD 0
(integer) 9
```

Syntax hint
```
# ASIS 
> BITCOUNT key [start end [BYTE|BIT]]
# TOBE
> BITCOUNT key [start [end [BYTE|BIT]]]
```

I think this minor fixes make redis more consistent, and this may not cause any breaks.