### PR TITLE
Fix minor memory leak in rewriteSetObject

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1854,6 +1854,7 @@ int rewriteSetObject(rio *r, robj *key, robj *o) {
                 !rioWriteBulkString(r,"SADD",4) ||
                 !rioWriteBulkObject(r,key))
             {
+                setTypeReleaseIterator(si);
                 return 0;
             }
         }


### PR DESCRIPTION
It seems to be a leak caused by code refactoring in #11290.
it's a small leak, that only happens if there's an IO error.

