### PR TITLE
SCRIPT FLUSH run truly async, close lua interpreter in bio

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -269,12 +269,16 @@ void freeLuaScriptsSync(dict *lua_scripts, lua_State *lua) {
     dictRelease(lua_scripts);
     lua_close(lua);
 
-#if defined(__linux__) && !defined(__APPLE__) && !defined(USE_LIBC)
+#if !defined(USE_LIBC)
     /* The lua interpreter may hold a lot of memory internally, and lua is
      * using libc. libc may take a bit longer to return the memory to the OS,
      * so after lua_close, we call malloc_trim try to purge it earlier.
-     * We only do this if redis and lua use different allocators. */
-    malloc_trim(0);
+     *
+     * We do that only when Redis itself does not use libc. When Lua and Redis
+     * use different allocators, one won't use the fragmentation holes of the
+     * other, and released memory can take a long time until it is returned to
+     * the OS. */
+    zlibc_trim();
 #endif
 }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -267,12 +267,12 @@ void scriptingInit(int setup) {
 /* Release resources related to Lua scripting.
  * This function is used in order to reset the scripting environment. */
 void scriptingRelease(int async) {
-    if (async)
-        freeLuaScriptsAsync(lctx.lua_scripts);
-    else
+    if (async) {
+        freeLuaScriptsAsync(lctx.lua_scripts, lctx.lua);
+    } else {
         dictRelease(lctx.lua_scripts);
-    lctx.lua_scripts_mem = 0;
-    lua_close(lctx.lua);
+        lua_close(lctx.lua);
+    }
 }
 
 void scriptingReset(int async) {

--- a/src/eval.c
+++ b/src/eval.c
@@ -269,10 +269,11 @@ void freeLuaScriptsSync(dict *lua_scripts, lua_State *lua) {
     dictRelease(lua_scripts);
     lua_close(lua);
 
-#if defined(__linux__) && defined(USE_LIBC)
+#if defined(__linux__) && !defined(__APPLE__) && !defined(USE_LIBC)
     /* The lua interpreter may hold a lot of memory internally, and lua is
      * using libc. libc may take a bit longer to return the memory to the OS,
-     * so after lua_close, we call malloc_trim try to purge it earlier. */
+     * so after lua_close, we call malloc_trim try to purge it earlier.
+     * We only do this if redis and lua use different allocators. */
     malloc_trim(0);
 #endif
 }

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -44,8 +44,7 @@ void lazyFreeLuaScripts(void *args[]) {
     dict *lua_scripts = args[0];
     lua_State *lua = args[1];
     long long len = dictSize(lua_scripts);
-    dictRelease(lua_scripts);
-    lua_close(lua);
+    freeLuaScriptsSync(lua_scripts, lua);
     atomicDecr(lazyfree_objects,len);
     atomicIncr(lazyfreed_objects,len);
 }
@@ -204,8 +203,7 @@ void freeLuaScriptsAsync(dict *lua_scripts, lua_State *lua) {
         atomicIncr(lazyfree_objects,dictSize(lua_scripts));
         bioCreateLazyFreeJob(lazyFreeLuaScripts,2,lua_scripts,lua);
     } else {
-        dictRelease(lua_scripts);
-        lua_close(lua);
+        freeLuaScriptsSync(lua_scripts, lua);
     }
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -3381,6 +3381,7 @@ void ldbKillForkedSessions(void);
 int ldbPendingChildren(void);
 sds luaCreateFunction(client *c, robj *body);
 void luaLdbLineHook(lua_State *lua, lua_Debug *ar);
+void freeLuaScriptsSync(dict *lua_scripts, lua_State *lua);
 void freeLuaScriptsAsync(dict *lua_scripts, lua_State *lua);
 void freeFunctionsAsync(functionsLibCtx *lib_ctx);
 int ldbIsEnabled(void);

--- a/src/server.h
+++ b/src/server.h
@@ -3381,7 +3381,7 @@ void ldbKillForkedSessions(void);
 int ldbPendingChildren(void);
 sds luaCreateFunction(client *c, robj *body);
 void luaLdbLineHook(lua_State *lua, lua_Debug *ar);
-void freeLuaScriptsAsync(dict *lua_scripts);
+void freeLuaScriptsAsync(dict *lua_scripts, lua_State *lua);
 void freeFunctionsAsync(functionsLibCtx *lib_ctx);
 int ldbIsEnabled(void);
 void ldbLog(sds entry);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -50,7 +50,6 @@ void zlibc_free(void *ptr) {
 }
 
 #include <string.h>
-#include <pthread.h>
 #include "zmalloc.h"
 #include "atomicvar.h"
 
@@ -753,6 +752,15 @@ int jemalloc_purge(void) {
 }
 
 #endif
+
+/* This function provides us access to the libc malloc_trim(). */
+void zlibc_trim(void) {
+#if defined(__GLIBC__) && !defined(USE_LIBC)
+    malloc_trim(0);
+#else
+    return;
+#endif
+}
 
 #if defined(__APPLE__)
 /* For proc_pidinfo() used later in zmalloc_get_smap_bytes_by_field().

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -94,8 +94,8 @@
 #endif
 #endif
 
-/* Includes for malloc_trim(). */
-#if defined(__linux__) && !defined(__APPLE__) && !defined(USE_LIBC)
+/* Includes for malloc_trim(), see zlibc_trim(). */
+#if defined(__GLIBC__) && !defined(USE_LIBC)
 #include <malloc.h>
 #endif
 
@@ -136,6 +136,7 @@ size_t zmalloc_get_private_dirty(long pid);
 size_t zmalloc_get_smap_bytes_by_field(char *field, long pid);
 size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
+void zlibc_trim(void);
 void zmadvise_dontneed(void *ptr);
 
 #ifdef HAVE_DEFRAG

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -71,6 +71,7 @@
  */
 #ifndef ZMALLOC_LIB
 #define ZMALLOC_LIB "libc"
+#define USE_LIBC 1
 
 #if !defined(NO_MALLOC_USABLE_SIZE) && \
     (defined(__GLIBC__) || defined(__FreeBSD__) || \

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -94,6 +94,11 @@
 #endif
 #endif
 
+/* Includes for malloc_trim(). */
+#if defined(__linux__) && defined(USE_LIBC)
+#include <malloc.h>
+#endif
+
 /* We can enable the Redis defrag capabilities only if we are using Jemalloc
  * and the version used is our special version modified for Redis having
  * the ability to return per-allocation fragmentation hints. */

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -95,7 +95,7 @@
 #endif
 
 /* Includes for malloc_trim(). */
-#if defined(__linux__) && defined(USE_LIBC)
+#if defined(__linux__) && !defined(__APPLE__) && !defined(USE_LIBC)
 #include <malloc.h>
 #endif
 


### PR DESCRIPTION
Even if we have SCRIPT FLUSH ASYNC now, when there are a lot of
lua scripts, SCRIPT FLUSH ASYNC will still block the main thread.
This is because lua_close is executed in the main thread, and lua
heap needs to release a lot of memory.

In this PR, we take the current lua instance on lctx.lua and call
lua_close on it in a background thread, to close it in async way.
This is MeirShpilraien's idea.

This solves the first point in #13102.