### PR TITLE
redis-cli fixes around help hints version filtering

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -745,8 +745,13 @@ static int versionIsSupported(sds version, sds since) {
         }
         versionPos = strchr(versionPos, '.');
         sincePos = strchr(sincePos, '.');
-        if (!versionPos || !sincePos)
-            return 1;
+
+        /* If we finished to parse both `version` and `since`, it means they are equal */
+        if (!versionPos && !sincePos) return 1;
+
+        /* Different number of digits considered as not supported */
+        if (!versionPos || !sincePos) return 0;
+
         versionPos++;
         sincePos++;
     }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -746,7 +746,7 @@ static int versionIsSupported(sds version, sds since) {
         versionPos = strchr(versionPos, '.');
         sincePos = strchr(sincePos, '.');
         if (!versionPos || !sincePos)
-            return 0;
+            return 1;
         versionPos++;
         sincePos++;
     }
@@ -763,7 +763,7 @@ static void removeUnsupportedArgs(struct cliCommandArg *args, int *numargs, sds 
             i++;
             continue;
         }
-        for (j = i; j != *numargs; j++) {
+        for (j = i; j != *numargs - 1; j++) {
             args[j] = args[j + 1];
         }
         (*numargs)--;


### PR DESCRIPTION
- In removeUnsupportedArgs, trying to access the next item after the last one and causing an out of bounds read.
- In versionIsSupported, when the 'version' is equal to 'since', the return value is 0 (not supported).
   Also, change the function to return `not supported` in case they have different numbers of digits

Both issues were found by `Non-interactive non-TTY CLI: Test command-line hinting - old server` under `test-sanitizer-address` (When changing the `src/version.h` locally to `8.0.0`)

The new `MAXAGE` argument inside `client-kill` triggered the issue (new argument at the end of the list) 