### PR TITLE
freeDictIfNeeded when kvstoreEmpty

### DIFF
--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -277,6 +277,7 @@ void kvstoreEmpty(kvstore *kvs, void(callback)(dict*)) {
         if (metadata->rehashing_node)
             metadata->rehashing_node = NULL;
         dictEmpty(d, callback);
+        freeDictIfNeeded(kvs, didx);
     }
 
     listEmpty(kvs->rehashing);


### PR DESCRIPTION
just like `kvstoreDictDelete`, we need check `freeDictIfNeeded` when `kvstoreEmpty`.