### PR TITLE
Call finalizerProc when free the aeTimeEvent in ae

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -149,6 +149,8 @@ void aeDeleteEventLoop(aeEventLoop *eventLoop) {
     aeTimeEvent *next_te, *te = eventLoop->timeEventHead;
     while (te) {
         next_te = te->next;
+        if (te->finalizerProc)
+            te->finalizerProc(eventLoop, te->clientData);
         zfree(te);
         te = next_te;
     }


### PR DESCRIPTION
Supplement to #6189, we also need to call finalizerProc.
This is a minor cleanup, no one currently uses this finalizerProc feature.