### PR TITLE
Fix reply schemas validator build issue due to new regular expression

### DIFF
--- a/src/commands/memory-stats.json
+++ b/src/commands/memory-stats.json
@@ -112,7 +112,7 @@
                 }
             },
             "patternProperties": {
-                "^db\\\\.\\\\d+$": {
+                "^db\\.\\d+$": {
                     "type": "object",
                     "properties": {
                         "overhead.hashtable.main": {

--- a/src/commands/memory-stats.json
+++ b/src/commands/memory-stats.json
@@ -112,7 +112,7 @@
                 }
             },
             "patternProperties": {
-                "^db\\.\\d+$": {
+                "^db\\\\.\\\\d+$": {
                     "type": "object",
                     "properties": {
                         "overhead.hashtable.main": {

--- a/utils/generate-command-code.py
+++ b/utils/generate-command-code.py
@@ -243,7 +243,7 @@ class Argument(object):
 def to_c_name(str):
     return str.replace(":", "").replace(".", "_").replace("$", "_")\
         .replace("^", "_").replace("*", "_").replace("-", "_") \
-        .replace("\\d", "_").replace("+", "_").replace("\\", "_")
+        .replace("\\", "_").replace("+", "_")
 
 
 class ReplySchema(object):
@@ -286,7 +286,7 @@ class ReplySchema(object):
                 t = "JSON_TYPE_INTEGER"
                 vstr = ".value.integer=%d" % v
             
-            return "%s,\"%s\",%s" % (t, k, vstr)
+            return "%s,%s,%s" % (t, json.dumps(k), vstr)
 
         for k, v in self.schema.items():
             if isinstance(v, ReplySchema):

--- a/utils/generate-command-code.py
+++ b/utils/generate-command-code.py
@@ -242,7 +242,8 @@ class Argument(object):
 
 def to_c_name(str):
     return str.replace(":", "").replace(".", "_").replace("$", "_")\
-        .replace("^", "_").replace("*", "_").replace("-", "_")
+        .replace("^", "_").replace("*", "_").replace("-", "_") \
+        .replace("\\d", "_").replace("+", "_").replace("\\", "_")
 
 
 class ReplySchema(object):


### PR DESCRIPTION
The new regular expression break the validator:
```
In file included from commands.c:10:
commands_with_reply_schema.def:14528:72: error: stray ‘\’ in program
14528 | struct jsonObjectElement MEMORY_STATS_ReplySchema_patternProperties__db\_\d+__properties_overhead_hashtable_main_elements[] = {
```

The reason is that special characters are not added to to_c_name,
causes special characters to appear in the structure name, causing
c file compilation to fail.

Broken by #12913