### PR TITLE
Enable accept4() on *BSD

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -96,7 +96,9 @@
 #endif
 
 /* Test for accept4() */
-#ifdef __linux__
+#if defined(__linux__) || defined(OpenBSD5_7) || \
+    (__FreeBSD__ >= 10 || __FreeBSD_version >= 1000000) || \
+    (defined(NetBSD8_0) || __NetBSD_Version__ >= 800000000)
 #define HAVE_ACCEPT4 1
 #endif
 


### PR DESCRIPTION
Redis enabled `accept4` on Linux after #9177, reducing extra system calls for sockets.

`accept4` system call is also widely supported on *BSD and Solaris in addition to Linux. This PR enables `accept4` on all platforms that support it.

### References
- [accept4 on FreeBSD](https://man.freebsd.org/cgi/man.cgi?query=accept4&sektion=2&n=1)
- [accept4 on DragonFly](https://man.dragonflybsd.org/?command=accept&section=2)
- [accept4 on NetBSD](https://man.netbsd.org/accept.2)
- [accept4 on OpenBSD](https://man.openbsd.org/accept4.2)
- [accept4 on Solaris](https://docs.oracle.com/cd/E88353_01/html/E37843/accept4-3c.html)
