### PR TITLE
Adding primary timestamp and replication lag

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3111,6 +3111,7 @@ standardConfig static_configs[] = {
     createBoolConfig("latency-tracking", NULL, MODIFIABLE_CONFIG, server.latency_tracking_enabled, 1, NULL, NULL),
     createBoolConfig("aof-disable-auto-gc", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.aof_disable_auto_gc, 0, NULL, updateAofAutoGCEnabled),
     createBoolConfig("replica-ignore-disk-write-errors", NULL, MODIFIABLE_CONFIG, server.repl_ignore_disk_write_error, 0, NULL, NULL),
+    createBoolConfig("repl-timestamp-enabled", NULL, MODIFIABLE_CONFIG, server.repl_time.timestamp_enabled, 1, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/replication.c
+++ b/src/replication.c
@@ -48,6 +48,11 @@ void replicationSendAck(void);
 int replicaPutOnline(client *slave);
 void replicaStartCommandStream(client *slave);
 int cancelReplicationHandshake(int reconnect);
+int replicationTimestampHandleMsg(robj *timestamp_obj);
+/*
+ * Update the latest_repl_master_timestamp and send it to replicas via REPLCONF TIMESTAMP messages.
+ */
+void replicationTimestampCron();
 
 /* We take a global flag to remember if this instance generated an RDB
  * because of replication, so that we can remove the RDB file in case
@@ -1275,6 +1280,17 @@ void replconfCommand(client *c) {
                 }
             }
             sdsfreesplitres(filters, filter_count);
+        } else if (!strcasecmp(c->argv[j]->ptr, "timestamp")) {
+            if (!(c->flags & CLIENT_MASTER)) {
+                addReplyError(c, "REPLCONF TIMESTAMP was called from a non master client. Ignoring it.");
+                return;
+            }
+            if (replicationTimestampHandleMsg(c->argv[j + 1]) != C_OK) {
+                addReplyErrorFormat(c,"Unrecognized REPLCONF TIMESTAMP option: %s",
+                    (char*)c->argv[j+1]->ptr);
+                return;
+            }
+            return;
         } else {
             addReplyErrorFormat(c,"Unrecognized REPLCONF option: %s",
                 (char*)c->argv[j]->ptr);
@@ -3793,6 +3809,8 @@ void replicationCron(void) {
         }
     }
 
+    replicationTimestampCron();
+
     /* Second, send a newline to all the slaves in pre-synchronization
      * stage, that is, slaves waiting for the master to create the RDB file.
      *
@@ -4244,4 +4262,100 @@ void updateFailoverStatus(void) {
         replicationSetMaster(server.target_replica_host,
             server.target_replica_port);
     }
+}
+
+// ------------ Replication lag info ------------
+#define MAX_REPLICATION_LAG 60 * 60 * 24 * 30
+
+static ReplTimeContext repl_time_context = {0};
+
+// ------------ Private utility methods ---------------
+
+static void updateLatestReplmasterTimestampOnmaster() {
+    serverAssert(server.masterhost == NULL);
+
+    mstime_t curtime = mstime();
+    if (curtime <= server.repl_time.latest_repl_master_timestamp) {
+        repl_time_context.latest_repl_master_timestamp_update_failure_count++;
+        repl_time_context.lag_behind_latest_repl_master_timestamp_ms = server.repl_time.latest_repl_master_timestamp - curtime;
+    } else {
+        /* We never update the latest_repl_master_timestamp to an earlier time,
+         * which ensures we will not record a smaller than current master timestamps to the replication stream */
+        server.repl_time.latest_repl_master_timestamp = curtime;
+        repl_time_context.lag_behind_latest_repl_master_timestamp_ms = 0;
+    }
+}
+
+/*
+ * Sends REPLCONF TIMESTAMP msg carrying the latest_repl_master_timestamp to replicas.
+ */
+static void replicationTimstampSendMsg() {
+    serverAssert(server.masterhost == NULL);
+
+    robj *argv[3];
+
+    const char *args[] = {"REPLCONF", "TIMESTAMP"};
+
+    argv[0] = createStringObject(args[0], strlen(args[0]));
+    argv[1] = createStringObject(args[1], strlen(args[1]));
+    argv[2] = createStringObjectFromLongLong(server.repl_time.latest_repl_master_timestamp);
+    replicationFeedSlaves(server.slaves, server.slaveseldb, argv, 3);
+
+    decrRefCount(argv[0]);
+    decrRefCount(argv[1]);
+    decrRefCount(argv[2]);
+}
+
+// ---------- Public API methods -----------
+
+void replicationTimestampCron() {
+    if (!server.repl_time.timestamp_enabled || !iAmMaster()) return;
+    updateLatestReplmasterTimestampOnmaster();
+    // Don't send timestamps when there is no connected replica or when a failover is in progress
+    if (!isManualFailoverOrPauseInProgress() && listLength(server.slaves)) {
+        replicationTimstampSendMsg();
+    }
+}
+
+int isManualFailoverOrPauseInProgress(void){
+    return ((server.cluster_enabled &&
+              clusterManualFailoverTimeLimit()) ||
+            server.failover_end_time) &&
+            isPausedActionsWithUpdate(PAUSE_ACTION_REPLICA);
+}
+
+int replicationTimestampHandleMsg(robj *timestamp_obj) {
+    serverAssert(server.masterhost != NULL);
+
+    mstime_t timestamp;
+    if (getLongLongFromObject(timestamp_obj, &timestamp) != C_OK) {
+        serverLog(LL_WARNING, "Unable to parse master replication timestamp");
+        return C_ERR;
+    }
+    if (timestamp <= server.repl_time.latest_repl_master_timestamp)
+        server.repl_time.latest_repl_master_timestamp = timestamp;
+
+    mstime_t time_diff = mstime() - timestamp;
+    if (time_diff < 0 || time_diff > (long long) MAX_REPLICATION_LAG) {
+        serverLog(LL_WARNING, "Unreasonable replication timestamp received from master: %lli ms, resulting in"
+                        " replication delay of %lli ms. Defaulting replication delay to 0 ms.", timestamp, time_diff);
+        time_diff = 0;
+    }
+    repl_time_context.replication_delay_ms = time_diff;
+    return C_OK;
+}
+
+sds ReplTime_info(sds info_str) {
+    info_str = sdscatprintf(info_str,
+                            "master_timestamp:%lld\r\n"
+                            "replication_lag:%lld\r\n"
+                            "master_timestamp_replication_delay_ms:%lld\r\n"
+                            "master_timestamp_update_failure_count:%lld\r\n"
+                            "lag_behind_master_timestamp_ms:%lld\r\n",
+                            server.repl_time.latest_repl_master_timestamp,
+                            server.repl_time.latest_repl_master_timestamp == 0 ? 0 : (mstime() - server.repl_time.latest_repl_master_timestamp),
+                            repl_time_context.replication_delay_ms,
+                            repl_time_context.latest_repl_master_timestamp_update_failure_count,
+                            repl_time_context.lag_behind_latest_repl_master_timestamp_ms);
+    return info_str;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -2729,6 +2729,7 @@ void initServer(void) {
     server.aof_last_write_status = C_OK;
     server.aof_last_write_errno = 0;
     server.repl_good_slaves_count = 0;
+    server.repl_time.latest_repl_master_timestamp = 0;
     server.last_sig_received = 0;
 
     /* Initiate acl info struct */
@@ -5498,6 +5499,7 @@ void totalNumberOfStatefulKeys(unsigned long *blocking_keys, unsigned long *bloc
         *watched_keys = wkeys;
 }
 
+extern ReplTimeContext repl_time_context;
 /* Create the string returned by the INFO command. This is decoupled
  * by the INFO command itself as we need to report the same information
  * on memory corruption problems. */
@@ -5929,6 +5931,10 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             info = sdscatprintf(info,
                 "min_slaves_good_slaves:%d\r\n",
                 server.repl_good_slaves_count);
+        }
+
+        if (server.masterhost) {
+            info = ReplTime_info(info);
         }
 
         if (listLength(server.slaves)) {

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1454,3 +1454,37 @@ start_server {tags {"repl external:skip"}} {
         }
     }
 }
+
+start_server {tags {"repl lag info"}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+    $master config set repl-timestamp-enabled yes
+    start_server {} {
+        set slave [srv 0 client]
+        $slave config set repl-timestamp-enabled yes
+        $slave slaveof $master_host $master_port
+
+        test "Test replication info" {
+            # wait for replication to be in sync
+            wait_for_condition 50 100 {
+                [lindex [$slave role] 0] eq {slave} &&
+                [string match {*master_link_status:up*} [$slave info replication]]
+            } else {
+                fail "Can't turn the instance into a replica"
+            }
+            set info [$slave info replication]
+            set rep_delay [getInfoProperty $info master_timestamp_replication_delay_ms]
+            assert {$rep_delay >= 0}
+
+            $master sadd s foo
+            $master pexpire s 1
+            after 10
+            $master sadd s foo
+            assert_equal 1 [$master wait 1 0]
+
+            assert_equal "set" [$master type s]
+            assert_equal "set" [$slave type s]
+        }
+    }
+}

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -522,6 +522,9 @@ proc start_server {options {code undefined}} {
         dict set config $directive $arguments
     }
 
+    # Turn off replication timestamp as it interferes with legacy tests
+    dict set config "repl-timestamp-enabled" "no"
+
     # remove directives that are marked to be omitted
     foreach directive $omit {
         dict unset config $directive


### PR DESCRIPTION
Adding a metric to show the lag between a primary and the replica. Also add the undelying mechanism for this metric
This includes:
*  master_timestamp
*  replication_lag
*  primary_timestamp_update_failure_count
*  lag_behind_primary_timestamp_ms

SIM: https://i.amazon.com/ELMO-68946
cr: https://code.amazon.com/reviews/CR-88166273

Adding lag time to OSS - conforming to OSS standards