### PR TITLE
Check user's oom_score_adj write permission for oom-score-adj test

### DIFF
--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -1,5 +1,4 @@
 set system_name [string tolower [exec uname -s]]
-set user_id [exec id -u]
 
 if {$system_name eq {linux}} {
     start_server {tags {"oom-score-adj external:skip"}} {
@@ -62,7 +61,7 @@ if {$system_name eq {linux}} {
             puts $fd -1000
             close $fd
         } e
-        if {$user_id != 0 && [string match "*permission denied*" $e]} {
+        if {[string match "*permission denied*" $e]} {
             test {CONFIG SET oom-score-adj handles configuration failures} {
                 # Bad config
                 r config set oom-score-adj no

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -57,7 +57,12 @@ if {$system_name eq {linux}} {
         }
 
         # Failed oom-score-adj tests can only run unprivileged
-        if {$user_id != 0} {
+        catch {
+            set fd [open "/proc/self/oom_score_adj" "w"]
+            puts $fd -1000
+            close $fd
+        } e
+        if {$user_id != 0 && [string match "*permission denied*" $e]} {
             test {CONFIG SET oom-score-adj handles configuration failures} {
                 # Bad config
                 r config set oom-score-adj no


### PR DESCRIPTION
`CONFIG SET oom-score-adj handles configuration failures` test failed in some CI jobs today.
Failed CI: https://github.com/redis/redis/actions/runs/8152519326

Not sure why the github action's docker image perssions have changed, but the issue is similar to #12887,
where we can't assume the range of oom_score_adj that a user can change.

## Solution:
Modify the way of determining whether the current user has no privileges or not,
instead of relying on whether the user id is 0 or not.