### PR TITLE
Change crc16 slot table to be fixed size to save ~128kb of memory

### DIFF
--- a/src/crc16_slottable.h
+++ b/src/crc16_slottable.h
@@ -7,8 +7,9 @@
  * The array indexes are slot numbers, so that given a desired slot, this string is guaranteed
  * to make redis cluster route a request to the shard holding this slot 
  */
+typedef char crc16_alphastring[4];
 
-const char *crc16_slot_table[] = {
+const crc16_alphastring crc16_slot_table[] = {
 "06S", "Qi", "5L5", "4Iu", "4gY", "460", "1Y7", "1LV", "0QG", "ru", "7Ok", "4ji", "4DE", "65n", "2JH", "I8", "F9", "SX", "7nF", "4KD", 
 "4eh", "6PK", "2ke", "1Ng", "0Sv", "4L", "491", "4hX", "4Ft", "5C4", "2Hy", "09R", "021", "0cX", "4Xv", "6mU", "6Cy", "42R", "0Mt", "nF", 
 "cv", "1Pe", "5kK", "6NI", "74L", "4UF", "0nh", "MZ", "2TJ", "0ai", "4ZG", "6od", "6AH", "40c", "0OE", "lw", "aG", "0Bu", "5iz", "6Lx", 


### PR DESCRIPTION
This function is only used for reverse engineering a crc16 string in the redis-benchmark. Since the actual values are so short, we can just store them in a uniform array instead. This saves about 128kb of memory and should improve the performance as well since we should have much better memory locality.

A thought for https://github.com/redis/redis/pull/13069.