### PR TITLE
Fix conversion of numbers in lua args to redis args

### DIFF
--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -820,7 +820,9 @@ static robj **luaArgsToRedisArgv(lua_State *lua, int *argc, int *argv_len) {
              * since Lua uses a format specifier that loses precision. */
             lua_Number num = lua_tonumber(lua,j+1);
             /* Integer printing function is much faster, check if we can safely use it.
-             * This also avoids converting 100000000 to 1e9. */
+             * Since lua_Number is not explicitly an integer or a double, we need to make an effort
+             * to convert it as an integer when that's possible, since the string could later be used
+             * in a context that doesn't support scientific notation (e.g. 1e9 instead of 100000000). */
             long long lvalue;
             if (double2ll((double)num, &lvalue))
                 obj_len = ll2string(dbuf, sizeof(dbuf), lvalue);

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -146,6 +146,14 @@ start_server {tags {"scripting"}} {
         } 1 x
     } {number 1}
 
+    test {EVAL - Lua number -> Redis integer conversion} {
+        r set x 0
+        run_script {
+            local foo = redis.pcall('hincrby','hash','field',200000000)
+            return {type(foo),foo}
+        } 0
+    } {number 200000000}
+
     test {EVAL - Redis bulk -> Lua type conversion} {
         r set mykey myval
         run_script {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -147,7 +147,6 @@ start_server {tags {"scripting"}} {
     } {number 1}
 
     test {EVAL - Lua number -> Redis integer conversion} {
-        r set x 0
         run_script {
             local foo = redis.pcall('hincrby','hash','field',200000000)
             return {type(foo),foo}

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -147,6 +147,7 @@ start_server {tags {"scripting"}} {
     } {number 1}
 
     test {EVAL - Lua number -> Redis integer conversion} {
+        r del hash
         run_script {
             local foo = redis.pcall('hincrby','hash','field',200000000)
             return {type(foo),foo}


### PR DESCRIPTION
Since lua_Number is not explicitly an integer or a double, we need to make an effort
to convert it as an integer when that's possible, since the string could later be used
in a context that doesn't support scientific notation (e.g. 1e9 instead of 100000000).

Since fpconv_dtoa converts numbers with the equivalent of `%f` or `%e`, which ever is shorter,
this would break if we try to pass a long integer number to a command that takes integer.
we'll get an implicit conversion to string in Lua, and then the parsing in getLongLongFromObjectOrReply will fail.

```
> eval "redis.call('hincrby', 'key', 'field', '1000000000')" 0
(nil)
> eval "redis.call('hincrby', 'key', 'field', tonumber('1000000000'))" 0
(error) ERR value is not an integer or out of range script: ac99c32e4daf7e300d593085b611de261954a946, on @user_script:1.
```

Switch to using ll2string if the number can be safely represented as a
long long.

The problem was introduced in #10587 (Redis 7.2).
closes #13113.