### PR TITLE
Ensure correct compression for a node that was too small to compress but grows larger

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -281,7 +281,8 @@ REDIS_STATIC int __quicklistDecompressNode(quicklistNode *node) {
         }                                                                      \
     } while (0)
 
-/* Force node to not be immediately re-compressible */
+/* Force node to be immediately re-compressible. If the node was too small to
+ * compress before, we also allow it to be immediately re-compressible. */
 #define quicklistDecompressNodeForUse(_node)                                   \
     do {                                                                       \
         if ((_node)) {                                                         \

--- a/tests/unit/type/list-3.tcl
+++ b/tests/unit/type/list-3.tcl
@@ -143,7 +143,7 @@ start_server {
 
         config_set list-compress-depth $orig_depth
         config_set list-max-listpack-size $orig_fill
-    } {} {needs:debug}
+    } {} {needs:debug external:skip}
 
 foreach comp {2 1 0} {
     set cycles 1000


### PR DESCRIPTION
Following #12568
Discussion in https://github.com/redis/redis/pull/12568#discussion_r1322320773

When a node needs to be compressed but is too small to be compressed, if this node becomes big enough to be compressed, it should be correctly compressed.

Reproduction:
When we use `quicklistDecompressNodeForUse()` to decompress the node mentioned above, `recompress`
will be 0, thus when quicklistRecompressOnly() is used to recompress this node, it will not be recompressed again anyway.

Solution:
Enable the `attempted_compress` feature, no longer used only in REDIS_TEST.
When it is true, it means that the node needs to be compressed but failed.

When a node is compressed but fails, set `attempted_compress` to 1.
When using quicklistDecompressNodeForUse() and `attempted_compress` is 1, we will set recompress to 1, ensuring that when calling quicklistRecompressOnly(), this node can be correctly compressed.