### PR TITLE
redis-benchmark: single primary node setup in cluster mode is valid configuration

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1787,11 +1787,6 @@ int main(int argc, char **argv) {
             }
             exit(1);
         }
-        if (config.cluster_node_count <= 1) {
-            fprintf(stderr, "Invalid cluster: %d node(s).\n",
-                    config.cluster_node_count);
-            exit(1);
-        }
         printf("Cluster has %d master nodes:\n\n", config.cluster_node_count);
         int i = 0;
         for (; i < config.cluster_node_count; i++) {


### PR DESCRIPTION
Before:

```
src/redis-benchmark -n 1 --cluster set k1 v1
Invalid cluster: 1 node(s).
```

After:
```
src/redis-benchmark -n 1 --cluster set k1 v1
Cluster has 1 master nodes:

Master 0: c7adb9ffa6ec89333d2d8df537ca25bec7692d45 127.0.0.1:6379

k1 v1: rps=108250.0 (overall: 108091.1) avg_msec=0.237 (overall: 0.238)
```
