### PR TITLE
Optimize range deletion in zset encoded with listpack 

### DIFF
--- a/src/listpack.h
+++ b/src/listpack.h
@@ -69,6 +69,7 @@ unsigned char *lpReplace(unsigned char *lp, unsigned char **p, unsigned char *s,
 unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long lval);
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp);
 unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsigned long num);
+unsigned char *lpDeleteRangeWithEntryPtr(unsigned char *lp, unsigned char **first, unsigned char *tail, unsigned long num);
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num);
 unsigned char *lpBatchDelete(unsigned char *lp, unsigned char **ps, unsigned long count);
 unsigned char *lpMerge(unsigned char **first, unsigned char **second);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1161,19 +1161,21 @@ unsigned char *zzlDeleteRangeByScore(unsigned char *zl, zrangespec *range, unsig
     eptr = zzlFirstInRange(zl,range);
     if (eptr == NULL) return zl;
 
+    unsigned char* first_ele = eptr;
     /* When the tail of the listpack is deleted, eptr will be NULL. */
     while (eptr && (sptr = lpNext(zl,eptr)) != NULL) {
         score = zzlGetScore(sptr);
         if (zslValueLteMax(score,range)) {
-            /* Delete both the element and the score. */
-            zl = lpDeleteRangeWithEntry(zl,&eptr,2);
             num++;
+            eptr = lpNext(zl,sptr);
         } else {
             /* No longer in range. */
             break;
         }
     }
-
+    if (num) {
+        zl = lpDeleteRangeWithEntry(zl, &first_ele, 2 * num);
+    }
     if (deleted != NULL) *deleted = num;
     return zl;
 }
@@ -1187,18 +1189,20 @@ unsigned char *zzlDeleteRangeByLex(unsigned char *zl, zlexrangespec *range, unsi
     eptr = zzlFirstInLexRange(zl,range);
     if (eptr == NULL) return zl;
 
+    unsigned char* first_ele = eptr;
     /* When the tail of the listpack is deleted, eptr will be NULL. */
     while (eptr && (sptr = lpNext(zl,eptr)) != NULL) {
         if (zzlLexValueLteMax(eptr,range)) {
-            /* Delete both the element and the score. */
-            zl = lpDeleteRangeWithEntry(zl,&eptr,2);
             num++;
+            eptr = lpNext(zl,sptr);
         } else {
             /* No longer in range. */
             break;
         }
     }
-
+    if (num) {
+        zl = lpDeleteRangeWithEntry(zl, &first_ele, 2 * num);
+    }
     if (deleted != NULL) *deleted = num;
     return zl;
 }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1174,7 +1174,8 @@ unsigned char *zzlDeleteRangeByScore(unsigned char *zl, zrangespec *range, unsig
         }
     }
     if (num)
-        zl = lpDeleteRangeWithEntry(zl, &first_ele, 2 * num);
+        zl = lpDeleteRangeWithEntryPtr(zl, &first_ele, eptr, 2*num);
+        // zl = lpDeleteRangeWithEntry(zl, &first_ele, 2 * num);
     if (deleted != NULL) *deleted = num;
     return zl;
 }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4051,9 +4051,12 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
 
             /* There must be an element in the sorted set. */
             serverAssertWithInfo(c,zobj,zln != NULL);
+            /* Avoid the unnecessary copy of sds. */
             ele = result_count == 0 ? sdsdup(zln->ele) : zln->ele;
             score = zln->score;
-            /* Avoid the unnecessary copy of sds. */
+            /* In previous versions, we call notifyKeyspaceEvent after the first entry is deleted. 
+             * Here we have to be compatible with this behavior. Otherwise we can delete all entries 
+             * in one zslDeleteRangeByRank. */
             if (result_count == 0) {
                 serverAssertWithInfo(c, zobj, zsetRemoveFromSkiplist(zs, ele));
             }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1161,7 +1161,7 @@ unsigned char *zzlDeleteRangeByScore(unsigned char *zl, zrangespec *range, unsig
     eptr = zzlFirstInRange(zl,range);
     if (eptr == NULL) return zl;
 
-    unsigned char* first_ele = eptr;
+    unsigned char *first_ele = eptr;
     /* When the tail of the listpack is deleted, eptr will be NULL. */
     while (eptr && (sptr = lpNext(zl,eptr)) != NULL) {
         score = zzlGetScore(sptr);
@@ -1173,9 +1173,8 @@ unsigned char *zzlDeleteRangeByScore(unsigned char *zl, zrangespec *range, unsig
             break;
         }
     }
-    if (num) {
+    if (num)
         zl = lpDeleteRangeWithEntry(zl, &first_ele, 2 * num);
-    }
     if (deleted != NULL) *deleted = num;
     return zl;
 }
@@ -1189,7 +1188,7 @@ unsigned char *zzlDeleteRangeByLex(unsigned char *zl, zlexrangespec *range, unsi
     eptr = zzlFirstInLexRange(zl,range);
     if (eptr == NULL) return zl;
 
-    unsigned char* first_ele = eptr;
+    unsigned char *first_ele = eptr;
     /* When the tail of the listpack is deleted, eptr will be NULL. */
     while (eptr && (sptr = lpNext(zl,eptr)) != NULL) {
         if (zzlLexValueLteMax(eptr,range)) {
@@ -1200,9 +1199,8 @@ unsigned char *zzlDeleteRangeByLex(unsigned char *zl, zlexrangespec *range, unsi
             break;
         }
     }
-    if (num) {
+    if (num)
         zl = lpDeleteRangeWithEntry(zl, &first_ele, 2 * num);
-    }
     if (deleted != NULL) *deleted = num;
     return zl;
 }


### PR DESCRIPTION
In past, if we delete a range of elements in `zset` encoded with `listpack`, we call `lpDeleteRangeWithEntry` repeatedly. But `lpDeleteRangeWithEntry` calls `lpShrinkToFit` in which `realloc` is called. This means we call many unnecessary `realloc`. 

In this PR, we optimize `zremrangeby[score|lex]` and `zpop[min|max]` by deleting all elements once to avoid redundant `realloc`.  We add a new function named `lpDeleteRangeWithEntryPtr` to delete the range of elements from the start address to the tail address and avoid duplicate traversal search.

The result shows that the performance of `zremrangeby[score|lex]` can improve about 70% and the performance of `zpop[min|max]` can improve about 8%.

### zremrangebyscore
I set 500,000 zset keys and each has 100 elements. Then I use `zremrangebyscore` to delete all. The result is as follow. The performance of range deletion increases about 70%.
**Unstable**
```
Summary:
  throughput summary: 39326.73 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        1.180     0.280     1.167     1.591     2.375     4.447
```

**This PR**
```
Summary:
  throughput summary: 68101.34 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        0.658     0.160     0.639     0.871     0.927     3.063
```
### zpopmin
`zpop[min|max]` has the same problem. I set 500,000 zset keys and each has 100 elements. Then I use `zpopmin` to delete all. The result is as follow. The performance of range deletion increases about 8%.
**Unstable**
```
Summary:
  throughput summary: 21452.78 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        1.894     0.696     1.847     2.743     2.935     4.855
```

**This PR**
```
Summary:
  throughput summary: 23104.83 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        1.105     0.528     1.095     1.167     1.511     4.471
```