### PR TITLE
Allocate Lua VM code with jemalloc instead of libc, and count it used memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,9 +458,9 @@ Script
 
 The script unit is composed of 3 units:
 * `script.c` - integration of scripts with Redis (commands execution, set replication/resp, ...)
-* `script_lua.c` - responsible to execute Lua code, uses script.c to interact with Redis from within the Lua code.
-* `function_lua.c` - contains the Lua engine implementation, uses script_lua.c to execute the Lua code.
-* `functions.c` - contains Redis Functions implementation (FUNCTION command), uses functions_lua.c if the function it wants to invoke needs the Lua engine.
+* `script_lua.c` - responsible to execute Lua code, uses `script.c` to interact with Redis from within the Lua code.
+* `function_lua.c` - contains the Lua engine implementation, uses `script_lua.c` to execute the Lua code.
+* `functions.c` - contains Redis Functions implementation (`FUNCTION` command), uses `functions_lua.c` if the function it wants to invoke needs the Lua engine.
 * `eval.c` - contains the `eval` implementation using `script_lua.c` to invoke the Lua code.
 
 

--- a/deps/jemalloc/src/stats.c
+++ b/deps/jemalloc/src/stats.c
@@ -321,7 +321,7 @@ stats_arena_bins_print(emitter_t *emitter, bool mutex, unsigned i,
 
 	COL_HDR(row, size, NULL, right, 20, size)
 	COL_HDR(row, ind, NULL, right, 4, unsigned)
-	COL_HDR(row, allocated, NULL, right, 13, uint64)
+	COL_HDR(row, allocated, NULL, right, 13, size)
 	COL_HDR(row, nmalloc, NULL, right, 13, uint64)
 	COL_HDR(row, nmalloc_ps, "(#/sec)", right, 8, uint64)
 	COL_HDR(row, ndalloc, NULL, right, 13, uint64)

--- a/deps/jemalloc/src/stats.c
+++ b/deps/jemalloc/src/stats.c
@@ -321,7 +321,7 @@ stats_arena_bins_print(emitter_t *emitter, bool mutex, unsigned i,
 
 	COL_HDR(row, size, NULL, right, 20, size)
 	COL_HDR(row, ind, NULL, right, 4, unsigned)
-	COL_HDR(row, allocated, NULL, right, 13, size)
+	COL_HDR(row, allocated, NULL, right, 13, uint64)
 	COL_HDR(row, nmalloc, NULL, right, 13, uint64)
 	COL_HDR(row, nmalloc_ps, "(#/sec)", right, 8, uint64)
 	COL_HDR(row, ndalloc, NULL, right, 13, uint64)

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -788,7 +788,7 @@ void defragScanCallback(void *privdata, const dictEntry *de) {
  * without the possibility of getting any results. */
 float getAllocatorFragmentation(size_t *out_frag_bytes) {
     size_t resident, active, allocated, frag_smallbins_bytes;
-    zmalloc_get_allocator_info(&allocated, &active, &resident, NULL, NULL, &frag_smallbins_bytes);
+    zmalloc_get_allocator_info(&allocated, &active, &resident, NULL, NULL, &frag_smallbins_bytes, server.lua_arena);
 
     /* Calculate the fragmentation ratio as the proportion of wasted memory in small
      * bins (which are defraggable) relative to the total allocated memory (including large bins).

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -787,6 +787,8 @@ void defragScanCallback(void *privdata, const dictEntry *de) {
  * or not, a false detection can cause the defragmenter to waste a lot of CPU
  * without the possibility of getting any results. */
 float getAllocatorFragmentation(size_t *out_frag_bytes) {
+    zmalloc_update_epoch();
+
     size_t resident, active, allocated, frag_smallbins_bytes;
     zmalloc_get_allocator_info(&allocated, &active, &resident, NULL, NULL, &frag_smallbins_bytes);
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -787,14 +787,12 @@ void defragScanCallback(void *privdata, const dictEntry *de) {
  * or not, a false detection can cause the defragmenter to waste a lot of CPU
  * without the possibility of getting any results. */
 float getAllocatorFragmentation(size_t *out_frag_bytes) {
-    zmalloc_update_epoch();
-
     size_t resident, active, allocated, frag_smallbins_bytes;
-    zmalloc_get_allocator_info(&allocated, &active, &resident, NULL, NULL, &frag_smallbins_bytes);
+    zmalloc_get_allocator_info(1, &allocated, &active, &resident, NULL, NULL, &frag_smallbins_bytes);
 
     if (server.lua_arena != UINT_MAX) {
         size_t lua_resident, lua_active, lua_allocated, lua_frag_smallbins_bytes;
-        zmalloc_get_allocator_info_by_arena(server.lua_arena, &lua_allocated, &lua_active, &lua_resident, &lua_frag_smallbins_bytes);
+        zmalloc_get_allocator_info_by_arena(server.lua_arena, 0, &lua_allocated, &lua_active, &lua_resident, &lua_frag_smallbins_bytes);
         resident -= lua_resident;
         active -= lua_active;
         allocated -= lua_allocated;

--- a/src/eval.c
+++ b/src/eval.c
@@ -201,6 +201,15 @@ void scriptingSetup(void) {
         exit(1);
     }
     server.lua_arena = arena;
+
+    unsigned int tcache;
+    sz = sizeof(unsigned int);
+    err = je_mallctl("tcache.create", (void *)&tcache, &sz, NULL, 0);
+    if (err) {
+        serverLog(LL_WARNING, "Failed creating the lua jemalloc tcache.");
+        exit(1);
+    }
+    server.lua_tcache = tcache;
 }
 
 #else
@@ -229,6 +238,7 @@ void scriptingInit(int setup) {
     if (setup) {
         lctx.lua_client = NULL;
         server.lua_arena = UINT_MAX;
+        server.lua_tcache = UINT_MAX;
         server.script_disable_deny_script = 0;
         ldbInit();
         scriptingSetup();

--- a/src/eval.c
+++ b/src/eval.c
@@ -178,10 +178,10 @@ static void *luaAlloc(void *ud, void *ptr, size_t osize, size_t nsize) {
     UNUSED(ud);
     UNUSED(osize);
     if (nsize == 0) {
-        zfree_with_flags(ptr, MALLOCX_ARENA(server.lua_arena));
+        zfree_with_flags(ptr, MALLOCX_ARENA(server.lua_arena) | MALLOCX_TCACHE_NONE);
         return NULL;
     } else {
-        return zrealloc_with_flags(ptr, nsize, MALLOCX_ARENA(server.lua_arena));
+        return zrealloc_with_flags(ptr, nsize, MALLOCX_ARENA(server.lua_arena) | MALLOCX_TCACHE_NONE);
     }
 }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -178,10 +178,10 @@ static void *luaAlloc(void *ud, void *ptr, size_t osize, size_t nsize) {
     UNUSED(ud);
     UNUSED(osize);
     if (nsize == 0) {
-        zfree_with_flags(ptr, MALLOCX_ARENA(server.lua_arena) | MALLOCX_TCACHE_NONE);
+        zfree_with_flags(ptr, MALLOCX_ARENA(server.lua_arena) | MALLOCX_TCACHE(server.lua_tcache));
         return NULL;
     } else {
-        return zrealloc_with_flags(ptr, nsize, MALLOCX_ARENA(server.lua_arena) | MALLOCX_TCACHE_NONE);
+        return zrealloc_with_flags(ptr, nsize, MALLOCX_ARENA(server.lua_arena) | MALLOCX_TCACHE(server.lua_tcache));
     }
 }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -172,8 +172,8 @@ int luaRedisReplicateCommandsCommand(lua_State *lua) {
     return 1;
 }
 
-/* When lua uses jemalloc, pass in luaAlloc as a parameter of lua_newstate. */
 #if defined(USE_JEMALLOC)
+/* When lua uses jemalloc, pass in luaAlloc as a parameter of lua_newstate. */
 static void *luaAlloc(void *ud, void *ptr, size_t osize, size_t nsize) {
     UNUSED(ud);
     UNUSED(osize);
@@ -184,28 +184,15 @@ static void *luaAlloc(void *ud, void *ptr, size_t osize, size_t nsize) {
         return zrealloc_with_flags(ptr, nsize, MALLOCX_ARENA(server.lua_arena));
     }
 }
-#endif
 
+/* Create a lua interpreter, and use jemalloc as lua memory allocator. */
 lua_State *createLuaState(void) {
-#if defined(USE_JEMALLOC)
-    /* Use jemalloc as lua memory allocator. */
-    lua_State *lua = lua_newstate(luaAlloc, NULL);
-#else
-    /* Use glibc (default) as lua memory allocator. */
-    lua_State *lua = lua_open();
-#endif
-
-    return lua;
+    return lua_newstate(luaAlloc, NULL);
 }
 
-/* This function is called the first time at server startup. */
+/* Under jemalloc we need to create a new arena for lua to avoid blocking
+ * defragger. */
 void scriptingSetup(void) {
-    lctx.lua_client = NULL;
-    server.lua_arena = UINT_MAX;
-    server.script_disable_deny_script = 0;
-    ldbInit();
-
-#if defined(USE_JEMALLOC)
     unsigned int arena;
     size_t sz = sizeof(unsigned int);
     int err = je_mallctl("arenas.create", (void *)&arena, &sz, NULL, 0);
@@ -214,8 +201,19 @@ void scriptingSetup(void) {
         exit(1);
     }
     server.lua_arena = arena;
-#endif
 }
+
+#else
+
+/* Create a lua interpreter and use glibc (default) as lua memory allocator. */
+lua_State *createLuaState(void) {
+    return lua_open();
+}
+
+/* There is nothing to set up under glib. */
+void scriptingSetup(void) {}
+
+#endif
 
 /* Initialize the scripting environment.
  *
@@ -228,7 +226,13 @@ void scriptingSetup(void) {
  *
  * However it is simpler to just call scriptingReset() that does just that. */
 void scriptingInit(int setup) {
-    if (setup) scriptingSetup();
+    if (setup) {
+        lctx.lua_client = NULL;
+        server.lua_arena = UINT_MAX;
+        server.script_disable_deny_script = 0;
+        ldbInit();
+        scriptingSetup();
+    }
 
     lua_State *lua = createLuaState();
 

--- a/src/function_lua.c
+++ b/src/function_lua.c
@@ -423,7 +423,7 @@ static int luaRegisterFunction(lua_State *lua) {
 /* Initialize Lua engine, should be called once on start. */
 int luaEngineInitEngine(void) {
     luaEngineCtx *lua_engine_ctx = zmalloc(sizeof(*lua_engine_ctx));
-    lua_engine_ctx->lua = lua_open();
+    lua_engine_ctx->lua = createLuaState();
 
     luaRegisterRedisAPI(lua_engine_ctx->lua);
 

--- a/src/script.c
+++ b/src/script.c
@@ -31,6 +31,9 @@
 #include "script.h"
 #include "cluster.h"
 
+#include <lua.h>
+#include <lauxlib.h>
+
 scriptFlag scripts_flags_def[] = {
     {.flag = SCRIPT_FLAG_NO_WRITES, .str = "no-writes"},
     {.flag = SCRIPT_FLAG_ALLOW_OOM, .str = "allow-oom"},
@@ -59,6 +62,63 @@ static void enterScriptTimedoutMode(scriptRunCtx *run_ctx) {
     run_ctx->flags |= SCRIPT_TIMEDOUT;
     blockingOperationStarts();
 }
+
+#if defined(USE_JEMALLOC)
+/* When lua uses jemalloc, pass in luaAlloc as a parameter of lua_newstate. */
+static void *luaAlloc(void *ud, void *ptr, size_t osize, size_t nsize) {
+    UNUSED(osize);
+
+    unsigned int tcache = (unsigned int)(uintptr_t)ud;
+    if (nsize == 0) {
+        zfree_with_flags(ptr, MALLOCX_ARENA(server.lua_arena) | MALLOCX_TCACHE(tcache));
+        return NULL;
+    } else {
+        return zrealloc_with_flags(ptr, nsize, MALLOCX_ARENA(server.lua_arena) | MALLOCX_TCACHE(tcache));
+    }
+}
+
+/* Create a lua interpreter, and use jemalloc as lua memory allocator. */
+lua_State *createLuaState(void) {
+    /* Every time a lua VM is created, a new private tcache is created for use.
+     * This private tcache will be destroyed after the lua VM is closed. */
+    unsigned int tcache;
+    size_t sz = sizeof(unsigned int);
+    int err = je_mallctl("tcache.create", (void *)&tcache, &sz, NULL, 0);
+    if (err) {
+        serverLog(LL_WARNING, "Failed creating the lua jemalloc tcache.");
+        exit(1);
+    }
+
+    /* We pass tcache as ud so that it is not bound to the server. */
+    return lua_newstate(luaAlloc, (void *)(uintptr_t)tcache);
+}
+
+/* Under jemalloc we need to create a new arena for lua to avoid blocking
+ * defragger. */
+void luaEnvInit(void) {
+    unsigned int arena;
+    size_t sz = sizeof(unsigned int);
+    int err = je_mallctl("arenas.create", (void *)&arena, &sz, NULL, 0);
+    if (err) {
+        serverLog(LL_WARNING, "Failed creating the lua jemalloc arena.");
+        exit(1);
+    }
+    server.lua_arena = arena;
+}
+
+#else
+
+/* Create a lua interpreter and use glibc (default) as lua memory allocator. */
+lua_State *createLuaState(void) {
+    return lua_open();
+}
+
+/* There is nothing to set up under glib. */
+void luaEnvInit(void) {
+    server.lua_arena = UINT_MAX;
+}
+
+#endif
 
 int scriptIsTimedout(void) {
     return scriptIsRunning() && (curr_run_ctx->flags & SCRIPT_TIMEDOUT);

--- a/src/script.h
+++ b/src/script.h
@@ -93,6 +93,8 @@ typedef struct scriptFlag {
 
 extern scriptFlag scripts_flags_def[];
 
+void luaEnvInit(void);
+lua_State *createLuaState(void);
 uint64_t scriptFlagsToCmdFlags(uint64_t cmd_flags, uint64_t script_flags);
 int scriptPrepareForRun(scriptRunCtx *r_ctx, client *engine_client, client *caller, const char *funcname, uint64_t script_flags, int ro);
 void scriptResetRun(scriptRunCtx *r_ctx);

--- a/src/server.c
+++ b/src/server.c
@@ -1243,12 +1243,8 @@ void cronUpdateMemoryStats(void) {
         }
         /* in case the allocator isn't providing these stats, fake them so that
          * fragmentation info still shows some (inaccurate metrics) */
-        if (!server.cron_malloc_stats.allocator_resident) {
-            /* Starting with redis 8.0, LUA memory is part of zmalloc_used.
-             * so we don't need to deduct it in order to be able to calculate correct
-             * "allocator fragmentation" ratio */
+        if (!server.cron_malloc_stats.allocator_resident)
             server.cron_malloc_stats.allocator_resident = server.cron_malloc_stats.process_rss;
-        }
         if (!server.cron_malloc_stats.allocator_active)
             server.cron_malloc_stats.allocator_active = server.cron_malloc_stats.allocator_resident;
         if (!server.cron_malloc_stats.allocator_allocated)

--- a/src/server.c
+++ b/src/server.c
@@ -1226,6 +1226,7 @@ void cronUpdateMemoryStats(void) {
          * The fragmentation ratio it'll show is potentially more accurate
          * it excludes other RSS pages such as: shared libraries, LUA and other non-zmalloc
          * allocations, and allocator reserved pages that can be pursed (all not actual frag) */
+        zmalloc_update_epoch();
         zmalloc_get_allocator_info(&server.cron_malloc_stats.allocator_allocated,
                                    &server.cron_malloc_stats.allocator_active,
                                    &server.cron_malloc_stats.allocator_resident,
@@ -1245,7 +1246,7 @@ void cronUpdateMemoryStats(void) {
             /* LUA memory isn't part of zmalloc_used, but it is part of the process RSS,
              * so we must deduct it in order to be able to calculate correct
              * "allocator fragmentation" ratio */
-            size_t lua_memory = server.lua_arena != UINT_MAX ? 0 : evalMemory();
+            size_t lua_memory = evalMemory();
             server.cron_malloc_stats.allocator_resident = server.cron_malloc_stats.process_rss - lua_memory;
         }
         if (!server.cron_malloc_stats.allocator_active)

--- a/src/server.c
+++ b/src/server.c
@@ -1226,8 +1226,8 @@ void cronUpdateMemoryStats(void) {
          * The fragmentation ratio it'll show is potentially more accurate
          * it excludes other RSS pages such as: shared libraries, LUA and other non-zmalloc
          * allocations, and allocator reserved pages that can be pursed (all not actual frag) */
-        zmalloc_update_epoch();
-        zmalloc_get_allocator_info(&server.cron_malloc_stats.allocator_allocated,
+        zmalloc_get_allocator_info(1,
+                                   &server.cron_malloc_stats.allocator_allocated,
                                    &server.cron_malloc_stats.allocator_active,
                                    &server.cron_malloc_stats.allocator_resident,
                                    NULL,
@@ -1235,6 +1235,7 @@ void cronUpdateMemoryStats(void) {
                                    &server.cron_malloc_stats.allocator_frag_smallbins_bytes);
         if (server.lua_arena != UINT_MAX) {
             zmalloc_get_allocator_info_by_arena(server.lua_arena,
+                                                0,
                                                 &server.cron_malloc_stats.lua_allocator_allocated,
                                                 &server.cron_malloc_stats.lua_allocator_active,
                                                 &server.cron_malloc_stats.lua_allocator_resident,

--- a/src/server.c
+++ b/src/server.c
@@ -1231,15 +1231,21 @@ void cronUpdateMemoryStats(void) {
                                    &server.cron_malloc_stats.allocator_resident,
                                    NULL,
                                    &server.cron_malloc_stats.allocator_muzzy,
-                                   &server.cron_malloc_stats.allocator_frag_smallbins_bytes,
-                                   server.lua_arena);
+                                   &server.cron_malloc_stats.allocator_frag_smallbins_bytes);
+        if (server.lua_arena != UINT_MAX) {
+            zmalloc_get_allocator_info_by_arena(server.lua_arena,
+                                                &server.cron_malloc_stats.lua_allocator_allocated,
+                                                &server.cron_malloc_stats.lua_allocator_active,
+                                                &server.cron_malloc_stats.lua_allocator_resident,
+                                                &server.cron_malloc_stats.lua_allocator_frag_smallbins_bytes);
+        }
         /* in case the allocator isn't providing these stats, fake them so that
          * fragmentation info still shows some (inaccurate metrics) */
         if (!server.cron_malloc_stats.allocator_resident) {
             /* LUA memory isn't part of zmalloc_used, but it is part of the process RSS,
              * so we must deduct it in order to be able to calculate correct
              * "allocator fragmentation" ratio */
-            size_t lua_memory = evalMemory();
+            size_t lua_memory = server.lua_arena != UINT_MAX ? 0 : evalMemory();
             server.cron_malloc_stats.allocator_resident = server.cron_malloc_stats.process_rss - lua_memory;
         }
         if (!server.cron_malloc_stats.allocator_active)

--- a/src/server.c
+++ b/src/server.c
@@ -5704,6 +5704,9 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "allocator_active:%zu\r\n", server.cron_malloc_stats.allocator_active,
             "allocator_resident:%zu\r\n", server.cron_malloc_stats.allocator_resident,
             "allocator_muzzy:%zu\r\n", server.cron_malloc_stats.allocator_muzzy,
+            "allocator_allocated_lua:%zu\r\n", server.cron_malloc_stats.lua_allocator_allocated,
+            "allocator_active_lua:%zu\r\n", server.cron_malloc_stats.lua_allocator_active,
+            "allocator_resident_lua:%zu\r\n", server.cron_malloc_stats.lua_allocator_resident,
             "total_system_memory:%lu\r\n", (unsigned long)total_system_mem,
             "total_system_memory_human:%s\r\n", total_system_hmem,
             "used_memory_lua:%lld\r\n", memory_lua, /* deprecated, renamed to used_memory_vm_eval */
@@ -5723,7 +5726,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "maxmemory_human:%s\r\n", maxmemory_hmem,
             "maxmemory_policy:%s\r\n", evict_policy,
             "allocator_frag_ratio:%.2f\r\n", mh->allocator_frag,
-            "allocator_frag_bytes:%zu\r\n", mh->allocator_frag_bytes,
+            "allocator_frag_bytes:%zu\r\n", mh->allocator_frag_bytes, /* not include lua */
+            "allocator_frag_bytes_lua:%zu\r\n", server.cron_malloc_stats.lua_allocator_frag_smallbins_bytes,
             "allocator_rss_ratio:%.2f\r\n", mh->allocator_rss,
             "allocator_rss_bytes:%zd\r\n", mh->allocator_rss_bytes,
             "rss_overhead_ratio:%.2f\r\n", mh->rss_extra,

--- a/src/server.c
+++ b/src/server.c
@@ -2784,6 +2784,7 @@ void initServer(void) {
         server.maxmemory_policy = MAXMEMORY_NO_EVICTION;
     }
 
+    luaEnvInit();
     scriptingInit(1);
     if (functionsInit() == C_ERR) {
         serverPanic("Functions initialization failed, check the server logs.");

--- a/src/server.c
+++ b/src/server.c
@@ -1244,11 +1244,10 @@ void cronUpdateMemoryStats(void) {
         /* in case the allocator isn't providing these stats, fake them so that
          * fragmentation info still shows some (inaccurate metrics) */
         if (!server.cron_malloc_stats.allocator_resident) {
-            /* LUA memory isn't part of zmalloc_used, but it is part of the process RSS,
-             * so we must deduct it in order to be able to calculate correct
+            /* Starting with redis 8.0, LUA memory is part of zmalloc_used.
+             * so we don't need to deduct it in order to be able to calculate correct
              * "allocator fragmentation" ratio */
-            size_t lua_memory = evalMemory();
-            server.cron_malloc_stats.allocator_resident = server.cron_malloc_stats.process_rss - lua_memory;
+            server.cron_malloc_stats.allocator_resident = server.cron_malloc_stats.process_rss;
         }
         if (!server.cron_malloc_stats.allocator_active)
             server.cron_malloc_stats.allocator_active = server.cron_malloc_stats.allocator_resident;

--- a/src/server.c
+++ b/src/server.c
@@ -5700,9 +5700,6 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "allocator_active:%zu\r\n", server.cron_malloc_stats.allocator_active,
             "allocator_resident:%zu\r\n", server.cron_malloc_stats.allocator_resident,
             "allocator_muzzy:%zu\r\n", server.cron_malloc_stats.allocator_muzzy,
-            "allocator_allocated_lua:%zu\r\n", server.cron_malloc_stats.lua_allocator_allocated,
-            "allocator_active_lua:%zu\r\n", server.cron_malloc_stats.lua_allocator_active,
-            "allocator_resident_lua:%zu\r\n", server.cron_malloc_stats.lua_allocator_resident,
             "total_system_memory:%lu\r\n", (unsigned long)total_system_mem,
             "total_system_memory_human:%s\r\n", total_system_hmem,
             "used_memory_lua:%lld\r\n", memory_lua, /* deprecated, renamed to used_memory_vm_eval */
@@ -5722,8 +5719,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "maxmemory_human:%s\r\n", maxmemory_hmem,
             "maxmemory_policy:%s\r\n", evict_policy,
             "allocator_frag_ratio:%.2f\r\n", mh->allocator_frag,
-            "allocator_frag_bytes:%zu\r\n", mh->allocator_frag_bytes, /* not include lua */
-            "allocator_frag_bytes_lua:%zu\r\n", server.cron_malloc_stats.lua_allocator_frag_smallbins_bytes,
+            "allocator_frag_bytes:%zu\r\n", mh->allocator_frag_bytes,
             "allocator_rss_ratio:%.2f\r\n", mh->allocator_rss,
             "allocator_rss_bytes:%zd\r\n", mh->allocator_rss_bytes,
             "rss_overhead_ratio:%.2f\r\n", mh->rss_extra,
@@ -6148,7 +6144,11 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "eventloop_duration_aof_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_AOF].sum,
             "eventloop_duration_cron_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_CRON].sum,
             "eventloop_duration_max:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_EL].max,
-            "eventloop_cmd_per_cycle_max:%lld\r\n", server.el_cmd_cnt_max));
+            "eventloop_cmd_per_cycle_max:%lld\r\n", server.el_cmd_cnt_max,
+            "allocator_allocated_lua:%zu\r\n", server.cron_malloc_stats.lua_allocator_allocated,
+            "allocator_active_lua:%zu\r\n", server.cron_malloc_stats.lua_allocator_active,
+            "allocator_resident_lua:%zu\r\n", server.cron_malloc_stats.lua_allocator_resident,
+            "allocator_frag_bytes_lua:%zu\r\n", server.cron_malloc_stats.lua_allocator_frag_smallbins_bytes));
     }
 
     return info;

--- a/src/server.c
+++ b/src/server.c
@@ -1231,7 +1231,8 @@ void cronUpdateMemoryStats(void) {
                                    &server.cron_malloc_stats.allocator_resident,
                                    NULL,
                                    &server.cron_malloc_stats.allocator_muzzy,
-                                   &server.cron_malloc_stats.allocator_frag_smallbins_bytes);
+                                   &server.cron_malloc_stats.allocator_frag_smallbins_bytes,
+                                   server.lua_arena);
         /* in case the allocator isn't providing these stats, fake them so that
          * fragmentation info still shows some (inaccurate metrics) */
         if (!server.cron_malloc_stats.allocator_resident) {

--- a/src/server.h
+++ b/src/server.h
@@ -2026,6 +2026,7 @@ struct redisServer {
                                    * dropping packets of a specific type */
     /* Scripting */
     unsigned int lua_arena;         /* eval lua arena used in jemalloc. */
+    unsigned int lua_tcache;        /* eval lua tcache used in jemalloc. */
     mstime_t busy_reply_threshold;  /* Script / module timeout in milliseconds */
     int pre_command_oom_state;         /* OOM before command (script?) was started */
     int script_disable_deny_script;    /* Allow running commands marked "noscript" inside a script. */

--- a/src/server.h
+++ b/src/server.h
@@ -2026,7 +2026,6 @@ struct redisServer {
                                    * dropping packets of a specific type */
     /* Scripting */
     unsigned int lua_arena;         /* eval lua arena used in jemalloc. */
-    unsigned int lua_tcache;        /* eval lua tcache used in jemalloc. */
     mstime_t busy_reply_threshold;  /* Script / module timeout in milliseconds */
     int pre_command_oom_state;         /* OOM before command (script?) was started */
     int script_disable_deny_script;    /* Allow running commands marked "noscript" inside a script. */

--- a/src/server.h
+++ b/src/server.h
@@ -2021,6 +2021,7 @@ struct redisServer {
     int cluster_drop_packet_filter; /* Debug config that allows tactically
                                    * dropping packets of a specific type */
     /* Scripting */
+    unsigned int lua_arena;         /* eval lua arena used in jemalloc. */
     mstime_t busy_reply_threshold;  /* Script / module timeout in milliseconds */
     int pre_command_oom_state;         /* OOM before command (script?) was started */
     int script_disable_deny_script;    /* Allow running commands marked "noscript" inside a script. */

--- a/src/server.h
+++ b/src/server.h
@@ -1469,6 +1469,10 @@ struct malloc_stats {
     size_t allocator_resident;
     size_t allocator_muzzy;
     size_t allocator_frag_smallbins_bytes;
+    size_t lua_allocator_allocated;
+    size_t lua_allocator_active;
+    size_t lua_allocator_resident;
+    size_t lua_allocator_frag_smallbins_bytes;
 };
 
 /*-----------------------------------------------------------------------------

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -849,19 +849,21 @@ int jemalloc_purge(void) {
 
 #else
 
-int zmalloc_get_allocator_info(size_t *allocated, size_t *active, size_t *resident,
+int zmalloc_get_allocator_info(int refresh_stats, size_t *allocated, size_t *active, size_t *resident,
                                size_t *retained, size_t *muzzy, size_t *frag_smallbins_bytes)
 {
+    UNUSED(refresh_stats);
     *allocated = *resident = *active = *frag_smallbins_bytes = 0;
     if (retained) *retained = 0;
     if (muzzy) *muzzy = 0;
     return 1;
 }
 
-int zmalloc_get_allocator_info_by_arena(unsigned int arena, size_t *allocated, size_t *active,
-                                        size_t *resident, size_t *frag_smallbins_bytes)
+int zmalloc_get_allocator_info_by_arena(unsigned int arena, int refresh_stats, size_t *allocated,
+                                        size_t *active, size_t *resident, size_t *frag_smallbins_bytes)
 {
     UNUSED(arena);
+    UNUSED(refresh_stats);
     *allocated = *resident = *active = *frag_smallbins_bytes = 0;
     return 1;
 }

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -882,6 +882,15 @@ int zmalloc_get_allocator_info(size_t *allocated, size_t *active, size_t *reside
     return 1;
 }
 
+int zmalloc_get_allocator_info_by_arena(unsigned int arena, size_t *allocated, size_t *active,
+                                        size_t *resident, size_t *frag_smallbins_bytes)
+{
+    UNUSED(arena);
+    *allocated = *resident = *active = *frag_smallbins_bytes = 0;
+    return 1;
+}
+
+
 void set_jemalloc_bg_thread(int enable) {
     ((void)(enable));
 }

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -848,7 +848,7 @@ int jemalloc_purge(void) {
 
 #else
 
-void zmalloc_get_allocator_info(void) {}
+void zmalloc_update_epoch(void) {}
 
 int zmalloc_get_allocator_info(size_t *allocated, size_t *active, size_t *resident,
                                size_t *retained, size_t *muzzy, size_t *frag_smallbins_bytes)

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -879,15 +879,6 @@ int jemalloc_purge(void) {
 
 #endif
 
-/* This function provides us access to the libc malloc_trim(). */
-void zlibc_trim(void) {
-#if defined(__GLIBC__) && !defined(USE_LIBC)
-    malloc_trim(0);
-#else
-    return;
-#endif
-}
-
 #if defined(__APPLE__)
 /* For proc_pidinfo() used later in zmalloc_get_smap_bytes_by_field().
  * Note that this file cannot be included in zmalloc.h because it includes

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -733,7 +733,7 @@ size_t zmalloc_get_frag_smallbins_by_arena(unsigned int arena) {
 /* Compute the total memory wasted in fragmentation of inside small arena bins.
  * Done by summing the memory in unused regs in all slabs of all small bins. */
 size_t zmalloc_get_frag_smallbins(void) {
-    return zmalloc_get_frag_smallbins_by_arena(UINT_MAX);
+    return zmalloc_get_frag_smallbins_by_arena(MALLCTL_ARENAS_ALL);
 }
 
 /* Get memory allocation information from allocator.

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -128,6 +128,7 @@ __attribute__((malloc)) char *zstrdup(const char *s);
 size_t zmalloc_used_memory(void);
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t));
 size_t zmalloc_get_rss(void);
+void zmalloc_update_epoch(void);
 int zmalloc_get_allocator_info(size_t *allocated, size_t *active, size_t *resident,
                                size_t *retained, size_t *muzzy, size_t *frag_smallbins_bytes);
 int zmalloc_get_allocator_info_by_arena(unsigned int arena, size_t *allocated, size_t *active,

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -71,7 +71,6 @@
  */
 #ifndef ZMALLOC_LIB
 #define ZMALLOC_LIB "libc"
-#define USE_LIBC 1
 
 #if !defined(NO_MALLOC_USABLE_SIZE) && \
     (defined(__GLIBC__) || defined(__FreeBSD__) || \
@@ -92,11 +91,6 @@
 #define zmalloc_size(p) malloc_usable_size(p)
 
 #endif
-#endif
-
-/* Includes for malloc_trim(), see zlibc_trim(). */
-#if defined(__GLIBC__) && !defined(USE_LIBC)
-#include <malloc.h>
 #endif
 
 /* We can enable the Redis defrag capabilities only if we are using Jemalloc
@@ -138,7 +132,6 @@ size_t zmalloc_get_private_dirty(long pid);
 size_t zmalloc_get_smap_bytes_by_field(char *field, long pid);
 size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
-void zlibc_trim(void);
 void zmadvise_dontneed(void *ptr);
 
 #if defined(USE_JEMALLOC)

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -129,7 +129,8 @@ size_t zmalloc_used_memory(void);
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t));
 size_t zmalloc_get_rss(void);
 int zmalloc_get_allocator_info(size_t *allocated, size_t *active, size_t *resident,
-                               size_t *retained, size_t *muzzy, size_t *frag_smallbins_bytes);
+                               size_t *retained, size_t *muzzy, size_t *frag_smallbins_bytes,
+                               unsigned int lua_arena);
 void set_jemalloc_bg_thread(int enable);
 int jemalloc_purge(void);
 size_t zmalloc_get_private_dirty(long pid);
@@ -138,6 +139,12 @@ size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
 void zlibc_trim(void);
 void zmadvise_dontneed(void *ptr);
+
+#if defined(USE_JEMALLOC)
+void *zmalloc_with_flags(size_t size, int flags);
+void *zrealloc_with_flags(void *ptr, size_t size, int flags);
+void zfree_with_flags(void *ptr, int flags);
+#endif
 
 #ifdef HAVE_DEFRAG
 void zfree_no_tcache(void *ptr);

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -129,8 +129,9 @@ size_t zmalloc_used_memory(void);
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t));
 size_t zmalloc_get_rss(void);
 int zmalloc_get_allocator_info(size_t *allocated, size_t *active, size_t *resident,
-                               size_t *retained, size_t *muzzy, size_t *frag_smallbins_bytes,
-                               unsigned int lua_arena);
+                               size_t *retained, size_t *muzzy, size_t *frag_smallbins_bytes);
+int zmalloc_get_allocator_info_by_arena(unsigned int arena, size_t *allocated, size_t *active,
+                                        size_t *resident, size_t *frag_smallbins_bytes);
 void set_jemalloc_bg_thread(int enable);
 int jemalloc_purge(void);
 size_t zmalloc_get_private_dirty(long pid);

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -128,11 +128,10 @@ __attribute__((malloc)) char *zstrdup(const char *s);
 size_t zmalloc_used_memory(void);
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t));
 size_t zmalloc_get_rss(void);
-void zmalloc_update_epoch(void);
-int zmalloc_get_allocator_info(size_t *allocated, size_t *active, size_t *resident,
+int zmalloc_get_allocator_info(int refresh_stats, size_t *allocated, size_t *active, size_t *resident,
                                size_t *retained, size_t *muzzy, size_t *frag_smallbins_bytes);
-int zmalloc_get_allocator_info_by_arena(unsigned int arena, size_t *allocated, size_t *active,
-                                        size_t *resident, size_t *frag_smallbins_bytes);
+int zmalloc_get_allocator_info_by_arena(unsigned int arena, int refresh_stats, size_t *allocated,
+                                        size_t *active, size_t *resident, size_t *frag_smallbins_bytes);
 void set_jemalloc_bg_thread(int enable);
 int jemalloc_purge(void);
 size_t zmalloc_get_private_dirty(long pid);

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -585,12 +585,16 @@ run_solo {defrag} {
                     }
                 }
                 if {$::verbose} {
+                    puts "used [s allocator_allocated]"
+                    puts "rss [s allocator_active]"
+                    puts "frag_bytes [s allocator_frag_bytes]"
                     puts "frag $frag"
                     puts "misses: $misses"
                     puts "hits: $hits"
                     puts "max latency $max_latency"
                     puts [r latency latest]
                     puts [r latency history active-defrag-cycle]
+                    puts [r memory malloc-stats]
                 }
                 assert {$frag < 1.1}
                 # due to high fragmentation, 100hz, and active-defrag-cycle-max set to 75,
@@ -720,11 +724,11 @@ run_solo {defrag} {
     }
     }
 
-    start_cluster 1 0 {tags {"defrag external:skip cluster"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save ""}} {
+    start_cluster 1 0 {tags {"defrag external:skip cluster"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save "" loglevel debug}} {
         test_active_defrag "cluster"
     }
 
-    start_server {tags {"defrag external:skip standalone"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save ""}} {
+    start_server {tags {"defrag external:skip standalone"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save "" loglevel debug}} {
         test_active_defrag "standalone"
     }
 } ;# run_solo


### PR DESCRIPTION
## Background
1. Currently Lua memory control does not pass through Redis's zmalloc.c.
Redis maxmemory cannot limit memory problems caused by users abusing lua
since these lua VM memory is not part of used_memory.

2. Since jemalloc is much better (fragmentation and speed), and also we know it and trust it. we are
going to use jemalloc instead of libc to allocate the Lua VM code and
count it used memory.

## Process:
In this PR, we will use jemalloc in lua. 
1. Create an arena for all lua vm (script and function), which is shared, in order to avoid blocking defragger.
2. Create a bound tcache for the lua VM, since the lua VM and the main thread are by default in the same tcache, and if there is no isolated tcache, lua may request memory from the tcache which has just been freed by main thread, and vice versa
    On the other hand, since lua vm might be release in bio thread, but tcache is not thread-safe, we need to recreate
    the tcache every time we recreate the lua vm.
3. Remove lua memory statistics from memory fragmentation statistics to avoid the effects of lua memory fragmentation

## Other
Add the following new fields to `INFO DEBUG` (we may promote them to INFO MEMORY some day)
1. allocator_allocated_lua: total number of bytes allocated of lua arena
2. allocator_active_lua: total number of bytes in active pages allocated in lua arena
3. allocator_resident_lua: maximum number of bytes in physically resident data pages mapped in lua arena
4. allocator_frag_bytes_lua: fragment bytes in lua arena

This is oranagra's idea, and i got some help from sundb.

This solves the third point in #13102.