### PR TITLE
Prevent lua error_reply abuse from causing errorstats to become larger

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1563,6 +1563,7 @@ struct redisServer {
     dict *orig_commands;        /* Command table before command renaming. */
     aeEventLoop *el;
     rax *errors;                /* Errors table */
+    int errors_enabled;         /* If true, errorstats is enabled, and we will add new errors. */
     unsigned int lruclock; /* Clock for LRU eviction */
     volatile sig_atomic_t shutdown_asap; /* Shutdown ordered by signal handler. */
     mstime_t shutdown_mstime;   /* Timestamp to limit graceful shutdown. */
@@ -2703,6 +2704,7 @@ void trackingHandlePendingKeyInvalidations(void);
 void trackingInvalidateKeysOnFlush(int async);
 void freeTrackingRadixTree(rax *rt);
 void freeTrackingRadixTreeAsync(rax *rt);
+void freeErrorsRadixTreeAsync(rax *errors);
 void trackingLimitUsedSlots(void);
 uint64_t trackingGetTotalItems(void);
 uint64_t trackingGetTotalKeys(void);

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -283,13 +283,13 @@ start_server {tags {"info" "external:skip"}} {
             }
 
             assert_equal [count_log_message 0 "Errorstats stopped adding new errors"] 1
+            assert_equal [count_log_message 0 "Current errors code list"] 1
+            assert_equal "count=1" [errorstat ERRORSTATS_DISABLED]
 
             # Since we currently have no metrics exposed for server.errors, we use lazyfree
-            # to verify that we only have 1k errors. Noted that resetErrorTableStats now is
-            # after resetServerStats, so we can still count lazyfree after reset.
-            r config resetstat
+            # to verify that we only have 128 errors.
             wait_for_condition 50 100 {
-                [s lazyfreed_objects] eq 1000
+                [s lazyfreed_objects] eq 128
             } else {
                 fail "errorstats resetstat lazyfree error"
             }


### PR DESCRIPTION
Users who abuse lua error_reply will generate a new error object on each
error call, which can make server.errors get bigger and bigger. This will
cause the server to block when calling INFO (we also return errorstats by
default).

To prevent the damage it can cause, when a misuse is detected, we will
print a warning log and disable the errorstats to avoid adding more new
errors. It can be re-enabled via CONFIG RESETSTAT.

Because server.errors may be very large (it may be better now since we
have the limit), config resetstat may block for a while. So in
resetErrorTableStats, we will try to lazyfree server.errors.

See the related discussion at the end of #8217.

log output:
```
89253:M 18 Mar 2024 16:56:08.886 # Errorstats stopped adding new errors because the number of errors reached the limit, may be misuse of lua error_reply, please check INFO ERRORSTATS, this can be re-enabled via CONFIG RESETSTAT.
89253:M 18 Mar 2024 16:56:08.886 # Current errors code list: 1, 10, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 11, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 12, 120, 121, 122, 123, 124, 125, 126, 127, 128, 13, 14, 15, 16, 17, 18, 19, 2, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 3, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 4, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 5, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 6, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 7, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 8, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 9, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99
```

after disabled, info errorstats output:
```
# Errorstats
errorstat_ERRORSTATS_DISABLED:count=1
```