### PR TITLE
Sanitize TCP_KEEPINTVL and simplify TCP_KEEPALIVE_ABORT_THRESHOLD on Solaris

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -194,6 +194,7 @@ int anetKeepAlive(char *err, int fd, int interval)
     }
 
     intvl = idle/3;
+    if (intvl < 10) intvl = 10; // kernel expects at least 10 seconds
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl))) {
         anetSetError(err, "setsockopt TCP_KEEPINTVL: %s\n", strerror(errno));
         return ANET_ERR;
@@ -216,9 +217,7 @@ int anetKeepAlive(char *err, int fd, int interval)
 
     /* Note that the consequent probes will not be sent at equal intervals on Solaris,
      * but will be sent using the exponential backoff algorithm. */
-    intvl = idle/3;
-    cnt = 3;
-    int time_to_abort = intvl * cnt;
+    int time_to_abort = idle;
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE_ABORT_THRESHOLD, &time_to_abort, sizeof(time_to_abort))) {
         anetSetError(err, "setsockopt TCP_KEEPCNT: %s\n", strerror(errno));
         return ANET_ERR;

--- a/src/anet.c
+++ b/src/anet.c
@@ -194,7 +194,7 @@ int anetKeepAlive(char *err, int fd, int interval)
     }
 
     intvl = idle/3;
-    if (intvl < 10) intvl = 10; // kernel expects at least 10 seconds
+    if (intvl < 10) intvl = 10; /* kernel expects at least 10 seconds */
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl))) {
         anetSetError(err, "setsockopt TCP_KEEPINTVL: %s\n", strerror(errno));
         return ANET_ERR;


### PR DESCRIPTION
Two things:

1. Avoid invalid value being set to `TCP_KEEPINTVL` and raising an error
2. Simplify setting `TCP_KEEPALIVE_ABORT_THRESHOLD` by eliminating the needless calculations

> The time between each consequent probes is set by TCP_KEEPINTVL in seconds. The minimum value is ten seconds. The maximum is ten days, while the default is two hours.

From [TCP on Solaris](https://docs.oracle.com/cd/E88353_01/html/E37851/tcp-4p.html)