### PR TITLE
Avoid unnecessary dict shrink in zremrangeGenericCommand

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1985,7 +1985,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
          * The range is empty when start > end or start >= length. */
         if (start > end || start >= llen) {
             addReply(c,shared.czero);
-            return;
+            goto cleanup;
         }
         if (end >= llen) end = llen-1;
     }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1985,6 +1985,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
          * The range is empty when start > end or start >= length. */
         if (start > end || start >= llen) {
             addReply(c,shared.czero);
+            return;
         }
         if (end >= llen) end = llen-1;
     }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1985,7 +1985,6 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
          * The range is empty when start > end or start >= length. */
         if (start > end || start >= llen) {
             addReply(c,shared.czero);
-            goto cleanup;
         }
         if (end >= llen) end = llen-1;
     }
@@ -2024,10 +2023,11 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
             break;
         }
         dictResumeAutoResize(zs->dict);
-        dictShrinkIfNeeded(zs->dict);
         if (dictSize(zs->dict) == 0) {
             dbDelete(c->db,key);
             keyremoved = 1;
+        } else {
+            dictShrinkIfNeeded(zs->dict);
         }
     } else {
         serverPanic("Unknown sorted set encoding");


### PR DESCRIPTION
If the skiplist is emptied, there is no need to shrink the dict in skiplist, it can be deleted directly.