### PR TITLE
Add missing REDIS_STATIC in quicklist

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -100,8 +100,8 @@ quicklistBookmark *_quicklistBookmarkFindByName(quicklist *ql, const char *name)
 quicklistBookmark *_quicklistBookmarkFindByNode(quicklist *ql, quicklistNode *node);
 void _quicklistBookmarkDelete(quicklist *ql, quicklistBookmark *bm);
 
-quicklistNode *_quicklistSplitNode(quicklistNode *node, int offset, int after);
-quicklistNode *_quicklistMergeNodes(quicklist *quicklist, quicklistNode *center);
+REDIS_STATIC quicklistNode *_quicklistSplitNode(quicklistNode *node, int offset, int after);
+REDIS_STATIC quicklistNode *_quicklistMergeNodes(quicklist *quicklist, quicklistNode *center);
 
 /* Simple way to give quicklistEntry structs default values with one call. */
 #define initEntry(e)                                                           \


### PR DESCRIPTION
Compiler complained when I tried to compile only quicklist.c.
Since static keyword is needed when a static function declaration is placed before its implementation. 

```
#ifndef REDIS_STATIC
#define REDIS_STATIC static
#endif
```

[How to solve static declaration follows non-static declaration in GCC C code?](https://stackoverflow.com/questions/3148244/how-to-solve-static-declaration-follows-non-static-declaration-in-gcc-c-code)