### PR TITLE
Maintain determinstic ordering of replica(s) in `CLUSTER SLOTS` response

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1451,7 +1451,7 @@ int clusterNodeFailureReportsCount(clusterNode *node) {
 }
 
 static int clusterNodeNameComparator(const void *node1, const void *node2) {
-    return strncasecmp(((clusterNode *)node1)->name, ((clusterNode *)node2)->name, CLUSTER_NAMELEN);
+    return strncasecmp((*(clusterNode **)node1)->name, (*(clusterNode **)node2)->name, CLUSTER_NAMELEN);
 }
 
 int clusterNodeRemoveSlave(clusterNode *master, clusterNode *slave) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1470,15 +1470,28 @@ int clusterNodeRemoveSlave(clusterNode *master, clusterNode *slave) {
 }
 
 int clusterNodeAddSlave(clusterNode *master, clusterNode *slave) {
-    int j;
+    int j, pos = -1;
 
     /* If it's already a slave, don't add it again. */
-    for (j = 0; j < master->numslaves; j++)
+    for (j = 0; j < master->numslaves; j++) {
         if (master->slaves[j] == slave) return C_ERR;
-    master->slaves = zrealloc(master->slaves,
-        sizeof(clusterNode*)*(master->numslaves+1));
-    master->slaves[master->numslaves] = slave;
+        /* Find lexicographic order index for the slave. */
+        if (pos == -1 && strcasecmp(slave->name, master->slaves[j]->name) > 0) {
+            pos = j;
+        }
+    }
+    /* If no slave(s) are found or it's lexicographically smallest. */
+    if (pos == -1) pos = 0;
+
     master->numslaves++;
+    master->slaves = zrealloc(master->slaves, sizeof(clusterNode*)*(master->numslaves));
+    
+    /* Copy all remaining nodes to the right. */
+    int remaining_slaves = (master->numslaves - pos) - 1;
+    if (remaining_slaves > 0) {
+        memmove(master->slaves+(pos+1), master->slaves+pos, (sizeof(*master->slaves) * remaining_slaves));
+    }
+    master->slaves[pos] = slave;
     master->flags |= CLUSTER_NODE_MIGRATE_TO;
     return C_OK;
 }


### PR DESCRIPTION
Apply insertion sort logic while adding a new replica to the cluster on basis of `name`. This will enable deterministic ordering of replica(s) information in `CLUSTER SLOTS` response.

Before this change:

```
127.0.0.1:6380> CLUSTER SLOTS
1) 1) (integer) 0
   2) (integer) 16383
   3) 1) "127.0.0.1"
      2) (integer) 6379
      3) "fc72609a620c62d073a31eed9ddde5104c1fa302"
      4) (empty array)
   4) 1) "127.0.0.1"
      2) (integer) 6381
      3) "fac84bbf2ffc5cfcdebc92c06b8ead9c3cba4051"
      4) (empty array)
   5) 1) "127.0.0.1"
      2) (integer) 6380
      3) "b1249d394326f1485df0b895f2fd38e141aa5056"
      4) (empty array)
```

After this change:

```
127.0.0.1:6380> CLUSTER SLOTS
1) 1) (integer) 0
   2) (integer) 16383
   3) 1) "127.0.0.1"
      2) (integer) 6379
      3) "fc72609a620c62d073a31eed9ddde5104c1fa302"
      4) (empty array)
   4) 1) "127.0.0.1"
      2) (integer) 6380
      3) "b1249d394326f1485df0b895f2fd38e141aa5056"
      4) (empty array)
   5) 1) "127.0.0.1"
      2) (integer) 6381
      3) "fac84bbf2ffc5cfcdebc92c06b8ead9c3cba4051"
      4) (empty array)
```