### PR TITLE
Change mmap rand bits as a temporary mitigation to resolve asan bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,10 @@ jobs:
         # build with TLS module just for compilation coverage
         run: make SANITIZER=address REDIS_CFLAGS='-Werror -DDEBUG_ASSERTIONS' BUILD_TLS=module
       - name: testprep
-        run: sudo apt-get install tcl8.6 tclx -y
+        # Work around ASAN issue, see https://github.com/google/sanitizers/issues/1716
+        run: |
+          sudo apt-get install tcl8.6 tclx -y
+          sudo sysctl vm.mmap_rnd_bits=28
       - name: test
         run: ./runtest --verbose --tags -slow --dump-logs
       - name: module api test

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -589,9 +589,11 @@ jobs:
       - name: make
         run: make SANITIZER=address REDIS_CFLAGS='-DREDIS_TEST -Werror -DDEBUG_ASSERTIONS'
       - name: testprep
+        # Work around ASAN issue, see https://github.com/google/sanitizers/issues/1716
         run: |
           sudo apt-get update
           sudo apt-get install tcl8.6 tclx -y
+          sudo sysctl vm.mmap_rnd_bits=28
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'redis')
         run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}


### PR DESCRIPTION
There is a new change in linux kernel 6.6.6 that uses randomization of address space to harden security, but it interferes with the way ASAN works. Folks are working on a fix, but this is a temporary mitigation for us to get our CI to be green again.

See https://github.com/google/sanitizers/issues/1716 for more information

See https://github.com/redis/redis/actions/runs/8305126288/job/22731614306?pr=13149 for a recent failure