### PR TITLE
Make shutdown command more intuitively with syntax

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -7431,18 +7431,28 @@ commandHistory SHUTDOWN_History[] = {
 #define SHUTDOWN_Keyspecs NULL
 #endif
 
-/* SHUTDOWN save_selector argument table */
-struct COMMAND_ARG SHUTDOWN_save_selector_Subargs[] = {
+/* SHUTDOWN abort_selector save_selector_block save_selector argument table */
+struct COMMAND_ARG SHUTDOWN_abort_selector_save_selector_block_save_selector_Subargs[] = {
 {MAKE_ARG("nosave",ARG_TYPE_PURE_TOKEN,-1,"NOSAVE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("save",ARG_TYPE_PURE_TOKEN,-1,"SAVE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
-/* SHUTDOWN argument table */
-struct COMMAND_ARG SHUTDOWN_Args[] = {
-{MAKE_ARG("save-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=SHUTDOWN_save_selector_Subargs},
+/* SHUTDOWN abort_selector save_selector_block argument table */
+struct COMMAND_ARG SHUTDOWN_abort_selector_save_selector_block_Subargs[] = {
+{MAKE_ARG("save-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=SHUTDOWN_abort_selector_save_selector_block_save_selector_Subargs},
 {MAKE_ARG("now",ARG_TYPE_PURE_TOKEN,-1,"NOW",NULL,"7.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("force",ARG_TYPE_PURE_TOKEN,-1,"FORCE",NULL,"7.0.0",CMD_ARG_OPTIONAL,0,NULL)},
-{MAKE_ARG("abort",ARG_TYPE_PURE_TOKEN,-1,"ABORT",NULL,"7.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+};
+
+/* SHUTDOWN abort_selector argument table */
+struct COMMAND_ARG SHUTDOWN_abort_selector_Subargs[] = {
+{MAKE_ARG("save-selector-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,3,NULL),.subargs=SHUTDOWN_abort_selector_save_selector_block_Subargs},
+{MAKE_ARG("abort",ARG_TYPE_PURE_TOKEN,-1,"ABORT",NULL,"7.0.0",CMD_ARG_NONE,0,NULL)},
+};
+
+/* SHUTDOWN argument table */
+struct COMMAND_ARG SHUTDOWN_Args[] = {
+{MAKE_ARG("abort-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=SHUTDOWN_abort_selector_Subargs},
 };
 
 /********** SLAVEOF ********************/
@@ -10798,7 +10808,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("restore-asking","An internal command for migrating keys in a cluster.","O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).","3.0.0",CMD_DOC_SYSCMD,NULL,NULL,"server",COMMAND_GROUP_SERVER,RESTORE_ASKING_History,3,RESTORE_ASKING_Tips,0,restoreCommand,-4,CMD_WRITE|CMD_DENYOOM|CMD_ASKING,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,RESTORE_ASKING_Keyspecs,1,NULL,7),.args=RESTORE_ASKING_Args},
 {MAKE_CMD("role","Returns the replication role.","O(1)","2.8.12",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,ROLE_History,0,ROLE_Tips,0,roleCommand,1,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_FAST|CMD_SENTINEL,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS,ROLE_Keyspecs,0,NULL,0)},
 {MAKE_CMD("save","Synchronously saves the database(s) to disk.","O(N) where N is the total number of keys in all databases","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SAVE_History,0,SAVE_Tips,0,saveCommand,1,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT|CMD_NO_MULTI,0,SAVE_Keyspecs,0,NULL,0)},
-{MAKE_CMD("shutdown","Synchronously saves the database(s) to disk and shuts down the Redis server.","O(N) when saving, where N is the total number of keys in all databases when saving data, otherwise O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SHUTDOWN_History,1,SHUTDOWN_Tips,0,shutdownCommand,-1,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_NO_MULTI|CMD_SENTINEL|CMD_ALLOW_BUSY,0,SHUTDOWN_Keyspecs,0,NULL,4),.args=SHUTDOWN_Args},
+{MAKE_CMD("shutdown","Synchronously saves the database(s) to disk and shuts down the Redis server.","O(N) when saving, where N is the total number of keys in all databases when saving data, otherwise O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SHUTDOWN_History,1,SHUTDOWN_Tips,0,shutdownCommand,-1,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_NO_MULTI|CMD_SENTINEL|CMD_ALLOW_BUSY,0,SHUTDOWN_Keyspecs,0,NULL,1),.args=SHUTDOWN_Args},
 {MAKE_CMD("slaveof","Sets a Redis server as a replica of another, or promotes it to being a master.","O(1)","1.0.0",CMD_DOC_DEPRECATED,"`REPLICAOF`","5.0.0","server",COMMAND_GROUP_SERVER,SLAVEOF_History,0,SLAVEOF_Tips,0,replicaofCommand,3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT|CMD_STALE,0,SLAVEOF_Keyspecs,0,NULL,1),.args=SLAVEOF_Args},
 {MAKE_CMD("slowlog","A container for slow log commands.","Depends on subcommand.","2.2.12",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SLOWLOG_History,0,SLOWLOG_Tips,0,NULL,-2,0,0,SLOWLOG_Keyspecs,0,NULL,0),.subcommands=SLOWLOG_Subcommands},
 {MAKE_CMD("swapdb","Swaps two Redis databases.","O(N) where N is the count of clients watching or blocking on keys from both databases.","4.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SWAPDB_History,0,SWAPDB_Tips,0,swapdbCommand,3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,SWAPDB_Keyspecs,0,NULL,2),.args=SWAPDB_Args},

--- a/src/commands/shutdown.json
+++ b/src/commands/shutdown.json
@@ -23,42 +23,54 @@
         ],
         "arguments": [
             {
-                "name": "save-selector",
+                "name": "abort-selector",
                 "type": "oneof",
                 "optional": true,
                 "arguments": [
                     {
-                        "name": "nosave",
-                        "type": "pure-token",
-                        "token": "NOSAVE"
+                        "name": "save-selector-block",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "save-selector",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                    {
+                                        "name": "nosave",
+                                        "type": "pure-token",
+                                        "token": "NOSAVE"
+                                    },
+                                    {
+                                        "name": "save",
+                                        "type": "pure-token",
+                                        "token": "SAVE"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "now",
+                                "type": "pure-token",
+                                "token": "NOW",
+                                "optional": true,
+                                "since": "7.0.0"
+                            },
+                            {
+                                "name": "force",
+                                "type": "pure-token",
+                                "token": "FORCE",
+                                "optional": true,
+                                "since": "7.0.0"
+                            }
+                        ]
                     },
                     {
-                        "name": "save",
+                        "name": "abort",
                         "type": "pure-token",
-                        "token": "SAVE"
+                        "token": "ABORT",
+                        "since": "7.0.0"
                     }
                 ]
-            },
-            {
-                "name": "now",
-                "type": "pure-token",
-                "token": "NOW",
-                "optional": true,
-                "since": "7.0.0"
-            },
-            {
-                "name": "force",
-                "type": "pure-token",
-                "token": "FORCE",
-                "optional": true,
-                "since": "7.0.0"
-            },
-            {
-                "name": "abort",
-                "type": "pure-token",
-                "token": "ABORT",
-                "optional": true,
-                "since": "7.0.0"
             }
         ],
         "reply_schema": {

--- a/src/db.c
+++ b/src/db.c
@@ -1221,6 +1221,7 @@ void typeCommand(client *c) {
     addReplyStatus(c, getObjectTypeName(o));
 }
 
+/* SHUTDOWN [[NOSAVE | SAVE] [NOW] [FORCE] | [ABORT]] */
 void shutdownCommand(client *c) {
     int flags = SHUTDOWN_NOFLAGS;
     int abort = 0;

--- a/src/db.c
+++ b/src/db.c
@@ -1221,7 +1221,7 @@ void typeCommand(client *c) {
     addReplyStatus(c, getObjectTypeName(o));
 }
 
-/* SHUTDOWN [[NOSAVE | SAVE] [NOW] [FORCE] | [ABORT]] */
+/* SHUTDOWN [[NOSAVE | SAVE] [NOW] [FORCE] | ABORT] */
 void shutdownCommand(client *c) {
     int flags = SHUTDOWN_NOFLAGS;
     int abort = 0;


### PR DESCRIPTION
This PR contains fix about missing syntax hint in https://github.com/redis/redis/pull/9872, which is added from Redis 7.0.

--

The point is that we cannot use ABORT with others.
```
ABORT cancels an ongoing shutdown and cannot be combined with other flags.
```

But [refer to redis.io,](https://redis.io/commands/shutdown/) Syntax of command SHUTDOWN is below:
`SHUTDOWN [NOSAVE | SAVE] [NOW] [FORCE] [ABORT]`

Now in redis-cli of unstable branch, hint of shutdown does not seem properly like below:
![image](https://github.com/redis/redis/assets/38001238/7ee4936b-593e-4ce1-bc0e-aa4ab612a809)

When using `abort` with other flags, of course it is syntax error, but it seems like that we can use it together.
``` c
// src/db.c

if ((abort && flags != SHUTDOWN_NOFLAGS) ||
    (flags & SHUTDOWN_NOSAVE && flags & SHUTDOWN_SAVE))
{
    /* Illegal combo. */
    addReplyErrorObject(c,shared.syntaxerr);
    return;
}
```
![image](https://github.com/redis/redis/assets/38001238/82e93930-87a3-4345-beb6-74c2fcf4452f)

--

### What have been fixed
So, I wrote this minor fix PR to let us know right syntax properly:
![image](https://github.com/redis/redis/assets/38001238/d07947a3-2879-4d89-8a52-cff25eae5671)

When using one of `nosave, save, now, and force`, then `abort` will be disappeared in hint:
![image](https://github.com/redis/redis/assets/38001238/38b5a06a-3ee3-4270-af14-4b9b38b03e60)

Contrary, when using `abort`, then all of other flags will be disappeared:
![image](https://github.com/redis/redis/assets/38001238/684c4da1-66ae-4b6a-b65e-8ddeabf32adc)

If I missed naming rule of argument in `src/commands/shutdown.json`, then please let me know.

Best regards,