### PR TITLE
Fix dict use-after-free problem in kvs->rehashing

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -706,6 +706,10 @@ int _dictClear(dict *d, int htidx, void(callback)(dict*)) {
 /* Clear & Release the hash table */
 void dictRelease(dict *d)
 {
+    /* Someone may be monitoring a dict that started rehashing, before
+     * destroying the dict fake completion. */
+    if (dictIsRehashing(d) && d->type->rehashingCompleted)
+        d->type->rehashingCompleted(d);
     _dictClear(d,0,NULL);
     _dictClear(d,1,NULL);
     zfree(d);

--- a/src/dict.c
+++ b/src/dict.c
@@ -1592,6 +1592,10 @@ void *dictFindPositionForInsert(dict *d, const void *key, dictEntry **existing) 
 }
 
 void dictEmpty(dict *d, void(callback)(dict*)) {
+    /* Someone may be monitoring a dict that started rehashing, before
+     * destroying the dict fake completion. */
+    if (dictIsRehashing(d) && d->type->rehashingCompleted)
+        d->type->rehashingCompleted(d);
     _dictClear(d,0,callback);
     _dictClear(d,1,callback);
     d->rehashidx = -1;

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -186,7 +186,10 @@ static void freeDictIfNeeded(kvstore *kvs, int didx) {
         kvstoreDictSize(kvs, didx) != 0 ||
         kvstoreDictIsRehashingPaused(kvs, didx))
         return;
-    dictRelease(kvs->dicts[didx]);
+    dict *d = kvstoreGetDict(kvs, didx);
+    if (dictIsRehashing(d) && d->type->rehashingCompleted) 
+        d->type->rehashingCompleted(d);
+    dictRelease(d);
     kvs->dicts[didx] = NULL;
     kvs->allocated_dicts--;
 }


### PR DESCRIPTION
In https://github.com/sundb/redis/actions/runs/8325132244/job/22781563626, we find server may crash because of NULL ptr in `kvstoreIncrementallyRehash`. the reason is that we use two phase unlink in `dbGenericDelete`. After `kvstoreDictTwoPhaseUnlinkFind`, the dict may be in rehashing and only have one element in ht[0] of `db->keys`.

When we delete the last element in `db->keys` meanwhile `db->keys` is in rehashing, we may free the dict in `kvstoreDictTwoPhaseUnlinkFree` without deleting the node in `kvs->rehashing`. Then we may use this freed ptr in `kvstoreIncrementallyRehash` in the `serverCron` and cause the crash. This is indeed a use-after-free problem.
Problem introduced in #13072

The fix is to call rehashingCompleted in dictRelease and dictEmpty, so that every call for rehashingStarted is always matched with a rehashingCompleted.

Adding a test in the unit test to catch it consistently