### PR TITLE
Optimize zunion[store] command by avoiding the duplicate copy of dict

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2609,16 +2609,6 @@ static void zdiff(zsetopsrc *src, long setnum, zset *dstzset, size_t *maxelelen,
     }
 }
 
-dictType setAccumulatorDictType = {
-    dictSdsHash,               /* hash function */
-    NULL,                      /* key dup */
-    NULL,                      /* val dup */
-    dictSdsKeyCompare,         /* key compare */
-    NULL,                      /* key destructor */
-    NULL,                      /* val destructor */
-    NULL                       /* allow to expand */
-};
-
 /* The zunionInterDiffGenericCommand() function is called in order to implement the
  * following commands: ZUNION, ZINTER, ZDIFF, ZUNIONSTORE, ZINTERSTORE, ZDIFFSTORE,
  * ZINTERCARD.
@@ -2814,7 +2804,6 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
             zuiClearIterator(&src[0]);
         }
     } else if (op == SET_OP_UNION) {
-        dict *accumulator = dictCreate(&setAccumulatorDictType);
         dictIterator *di;
         dictEntry *de, *existing;
         double score;
@@ -2822,7 +2811,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
         if (setnum) {
             /* Our union is at least as large as the largest set.
              * Resize the dictionary ASAP to avoid useless rehashing. */
-            dictExpand(accumulator,zuiLength(&src[setnum-1]));
+            dictExpand(dstzset->dict, zuiLength(&src[setnum-1]));
         }
 
         /* Step 1: Create a dictionary of elements -> aggregated-scores
@@ -2837,7 +2826,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
                 if (isnan(score)) score = 0;
 
                 /* Search for this element in the accumulating dictionary. */
-                de = dictAddRaw(accumulator,zuiSdsFromValue(&zval),&existing);
+                de = dictAddRaw(dstzset->dict, zuiSdsFromValue(&zval), &existing);
                 /* If we don't have it, we need to create a new entry. */
                 if (!existing) {
                     tmp = zuiNewSdsFromValue(&zval);
@@ -2847,7 +2836,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
                      totelelen += sdslen(tmp);
                      if (sdslen(tmp) > maxelelen) maxelelen = sdslen(tmp);
                     /* Update the element with its initial score. */
-                    dictSetKey(accumulator, de, tmp);
+                    dictSetKey(dstzset->dict, de, tmp);
                     dictSetDoubleVal(de,score);
                 } else {
                     /* Update the score with the score of the new instance
@@ -2864,21 +2853,15 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
         }
 
         /* Step 2: convert the dictionary into the final sorted set. */
-        di = dictGetIterator(accumulator);
-
-        /* We now are aware of the final size of the resulting sorted set,
-         * let's resize the dictionary embedded inside the sorted set to the
-         * right size, in order to save rehashing time. */
-        dictExpand(dstzset->dict,dictSize(accumulator));
+        di = dictGetIterator(dstzset->dict);
 
         while((de = dictNext(di)) != NULL) {
             sds ele = dictGetKey(de);
             score = dictGetDoubleVal(de);
             znode = zslInsert(dstzset->zsl,score,ele);
-            dictAdd(dstzset->dict,ele,&znode->score);
+            dictSetVal(dstzset->dict, de, &znode->score);
         }
         dictReleaseIterator(di);
-        dictRelease(accumulator);
     } else if (op == SET_OP_DIFF) {
         zdiff(src, setnum, dstzset, &maxelelen, &totelelen);
     } else {


### PR DESCRIPTION
In the past `zunion` and `zunionstore` command, we first constructed a  `accumulator` dict and then converted it into the final sorted set. But we can use the dict in `dstobj` directly to avoid the cost of constructing a new dict during converting to improve performance.

In this PR, I removed the `accumulator` dict and replace it with the dict in `dstobj`.

I made a test on `zunion` and `zunionstore` command. I first add two zsets each with 100 unique elements. Then I call `zunion` or `zunionstore` on these zsets. The result shows the performance can improve about 18%.
### zunion
**unstable**
```
Summary:
  throughput summary: 6488.24 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        7.253     0.976     7.207     8.087     8.335    11.039
```
**This PR**
```
Summary:
  throughput summary: 7651.99 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        6.083     0.976     6.031     6.935     7.191    10.991
```
### zunionstore
**unstable**
```
Summary:
  throughput summary: 7036.55 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        7.015     0.992     7.943     8.543     8.767    17.887
```
**This PR**
```
Summary:
  throughput summary: 8353.52 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        5.896     0.968     6.663     7.263     7.559    16.111
```