### PR TITLE
Delete unreachable code in _quicklistInsert()

### DIFF
--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -1015,21 +1015,6 @@ REDIS_STATIC void _quicklistInsert(quicklistIter *iter, quicklistEntry *entry,
     quicklistNode *node = entry->node;
     quicklistNode *new_node = NULL;
 
-    if (!node) {
-        /* we have no reference node, so let's create only node in the list */
-        D("No node given!");
-        if (unlikely(isLargeElement(sz, quicklist->fill))) {
-            __quicklistInsertPlainNode(quicklist, quicklist->tail, value, sz, after);
-            return;
-        }
-        new_node = quicklistCreateNode();
-        new_node->entry = lpPrepend(lpNew(0), value, sz);
-        __quicklistInsertNode(quicklist, NULL, new_node, after);
-        new_node->count++;
-        quicklist->count++;
-        return;
-    }
-
     /* Populate accounting flags for easier boolean checks later */
     if (!_quicklistNodeAllowInsert(node, fill, sz)) {
         D("Current node is full with count %d with requested fill %d",


### PR DESCRIPTION
This PR might be same issue with https://github.com/redis/redis/issues/12613
The point is that in `void _quicklistInsert()`, the condition `if (!node) { ... }` is unreachable.

## Analysis
Following the function calls,  the only two use _quicklistInsert() like below:
- [LINSERT key <BEFORE | AFTER> pivot element](https://redis.io/commands/linsert/)
- `RM_ListInsert()` from module.c
- `quicklistTest()` from quicklist.c

<img width="1371" alt="image" src="https://github.com/redis/redis/assets/38001238/52973ffd-59e0-4e74-b5ff-c39e4de8507b">

### `LINSERT`
During checking next node, if the current node is NULL, then it just return 0, so that we cannot reach it.

``` c
void linsertCommand(client *c) {
    // ...
    iter = listTypeInitIterator(subject,0,LIST_TAIL);
    while (listTypeNext(iter,&entry)) {  // check entry exists
        if (listTypeEqual(&entry,c->argv[3])) {
            listTypeInsert(&entry,c->argv[4],where);
            inserted = 1;
            break;
        }
    }
    // ...
}

int listTypeNext(listTypeIterator *li, listTypeEntry *entry) {
    // ...
    if (li->encoding == OBJ_ENCODING_QUICKLIST) {  // if quicklist, check next
        return quicklistNext(li->iter, &entry->entry);
    }
    // ...
}

int quicklistNext(quicklistIter *iter, quicklistEntry *entry) {
    // ...
    entry->node = iter->current;

    if (!iter->current) {  // if entry node is NULL, return 0, so that listTypeInsert() cannot be executed
        D("Returning because current node is NULL"); 
        return 0;
    }
    // ...
```

### `RM_ListInsert()`
Similar with `linsertCommand()`, iterator already check if key exists or pivot exists,
so that we will not encounter `if (!node) { ... }`.
``` c
int moduleListIteratorSeek(RedisModuleKey *key, long index, int mode) {
    if (!key) {
        errno = EINVAL;
        return 0;
    } else if (!key->value || key->value->type != OBJ_LIST) {
        errno = ENOTSUP;
        return 0;
    } if (!(key->mode & mode)) {
        errno = EBADF;
        return 0;
    }

    long length = listTypeLength(key->value);
    if (index < -length || index >= length) {
        errno = EDOM; /* Invalid index */
        return 0;
    }
    // ...
```

### `quicklistTest()`
This is for test and callable from other files.
This function calls `quicklistInsertBefore()` and `quicklistInsertAfter()` directly, but always following after `quicklistGetIteratorEntryAtIdx()` or `quicklistNext()`, so `if (!node) { ... }` is unreachable.


## what I have done
I'm finally sure that `if (!node) { ... }` from `_quicklistInsert()` is unreachable, so I have deleted it.
If I missed something, then please let me know.
Thanks a lot.
