### PR TITLE
Detect accept4() on specific versions of various platforms

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -9,6 +9,8 @@
 #ifndef __CONFIG_H
 #define __CONFIG_H
 
+#include <sys/param.h>
+
 #ifdef __APPLE__
 #include <fcntl.h> // for fcntl(fd, F_FULLFSYNC)
 #include <AvailabilityMacros.h>
@@ -75,7 +77,9 @@
 #endif
 
 /* Test for accept4() */
-#if defined(__linux__) || defined(OpenBSD5_7) || \
+#if defined(__linux__) || \
+    defined(OpenBSD5_7) || \
+    __DragonFly_version >= 400305 || \
     (__FreeBSD__ >= 10 || __FreeBSD_version >= 1000000) || \
     (defined(NetBSD8_0) || __NetBSD_Version__ >= 800000000)
 #define HAVE_ACCEPT4 1


### PR DESCRIPTION
Follow up #13104

This PR will enable `accept4()` on DragonFlyBSD and fix the failures of determining the presence of `accept4()` due to the missing <sys/param.h>

### References
- [param.h in DragonFlyBSD](https://github.com/DragonFlyBSD/DragonFlyBSD/blob/7485684fa5c3fadb6c7a1da0d8bb6ea5da4e0f2f/sys/sys/param.h#L129-L257)
- [param.h in FreeBSD](https://github.com/freebsd/freebsd-src/blob/main/sys/sys/param.h#L46-L76)
- [param.h in NetBSD](https://github.com/NetBSD/src/blob/b5f8d2f930b7ef226d4dc1b4f7017e998c0e5cde/sys/sys/param.h#L53-L70)
- [param.h in OpenBSD](https://github.com/openbsd/src/blob/d9c286e032a7cee9baaecdd54eb0d43f658ae696/sys/sys/param.h#L40-L45)