### PR TITLE
kvstoreIteratorNext() wrongly reset iterator twice

### DIFF
--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -602,16 +602,12 @@ dictEntry *kvstoreIteratorNext(kvstoreIterator *kvs_it) {
     if (!de) { /* No current dict or reached the end of the dictionary. */
 
         /* Before we move to the next dict, function kvstoreIteratorNextDict()
-         * reset the iter of the previous dict. */
+         * reset the iter of the previous dict & freeDictIfNeeded(). */
         dict *d = kvstoreIteratorNextDict(kvs_it);
 
         if (!d)
             return NULL;
 
-        if (kvs_it->di.d) {
-            /* In the safe iterator context, we may delete entries. */
-            freeDictIfNeeded(kvs_it->kvs, kvs_it->didx);
-        }
         dictInitSafeIterator(&kvs_it->di, d);
         de = dictNext(&kvs_it->di);
     }

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -568,7 +568,11 @@ void kvstoreIteratorRelease(kvstoreIterator *kvs_it) {
     zfree(kvs_it);
 }
 
-/* Returns next dictionary from the iterator, or NULL if iteration is complete. */
+
+/* Returns next dictionary from the iterator, or NULL if iteration is complete.
+ *
+ * - Takes care to reset the iter of the previous dict before moved to the next dict.
+ */
 dict *kvstoreIteratorNextDict(kvstoreIterator *kvs_it) {
     if (kvs_it->next_didx == -1)
         return NULL;
@@ -596,13 +600,15 @@ int kvstoreIteratorGetCurrentDictIndex(kvstoreIterator *kvs_it) {
 dictEntry *kvstoreIteratorNext(kvstoreIterator *kvs_it) {
     dictEntry *de = kvs_it->di.d ? dictNext(&kvs_it->di) : NULL;
     if (!de) { /* No current dict or reached the end of the dictionary. */
+
+        /* Before we move to the next dict, function kvstoreIteratorNextDict()
+         * reset the iter of the previous dict. */
         dict *d = kvstoreIteratorNextDict(kvs_it);
+
         if (!d)
             return NULL;
+
         if (kvs_it->di.d) {
-            /* Before we move to the next dict, reset the iter of the previous dict. */
-            dictIterator *iter = &kvs_it->di;
-            dictResetIterator(iter);
             /* In the safe iterator context, we may delete entries. */
             freeDictIfNeeded(kvs_it->kvs, kvs_it->didx);
         }


### PR DESCRIPTION
kvstoreIteratorNext() wrongly reset iterator twice. 
- It calls kvstoreIteratorNextDict() which eventually calls dictResumeRehashing()
- And then, on return, it calls dictResetIterator(iter) which calls dictResumeRehashing().
- We end up with pauserehash value decremented twice instead of once.

I encounter it because until now this var was int16, and i modified it, as 
part of hash-field expiration feature to be 15 bits of unsigned value.