### PR TITLE
Use usleep() instead of sched_yield() to yield cpu

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -2424,7 +2424,7 @@ void RM_Yield(RedisModuleCtx *ctx, int flags, const char *busy_reply) {
                     /* Release the GIL, yielding CPU to give the main thread an opportunity to start
                      * event processing, and then acquire the GIL again until the main thread releases it. */
                     moduleReleaseGIL();
-                    sched_yield();
+                    usleep(0);
                     moduleAcquireGIL();
                 }
             } else {


### PR DESCRIPTION
when the main thread and the module thread are in the same thread, sched_yield() can work well.
when they are both bind to different cpus, sched_yield() will look for the thread with the highest priority, and if the module thread is always the highest priority on a cpu, it will take a long time to let the main thread to reacquire the GIL.

ref https://man7.org/linux/man-pages/man2/sched_yield.2.html
```
If the calling thread is the only thread in the highest priority
list at that time, it will continue to run after a call to
sched_yield().
```
