### PR TITLE
I/O thread Code optimization, reduces the number of OP_WRITE or OP_READ judgments

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -4228,16 +4228,20 @@ void *IOThreadMain(void *myid) {
         listIter li;
         listNode *ln;
         listRewind(io_threads_list[id],&li);
-        while((ln = listNext(&li))) {
-            client *c = listNodeValue(ln);
-            if (io_threads_op == IO_THREADS_OP_WRITE) {
+        if (io_threads_op == IO_THREADS_OP_WRITE) {
+            while((ln = listNext(&li))) {
+                client *c = listNodeValue(ln);
                 writeToClient(c,0);
-            } else if (io_threads_op == IO_THREADS_OP_READ) {
-                readQueryFromClient(c->conn);
-            } else {
-                serverPanic("io_threads_op value is unknown");
             }
+        } else if (io_threads_op == IO_THREADS_OP_READ) {
+            while((ln = listNext(&li))) {
+                client *c = listNodeValue(ln);
+                readQueryFromClient(c->conn);
+            }
+        } else {
+            serverPanic("io_threads_op value is unknown");
         }
+        
         listEmpty(io_threads_list[id]);
         setIOPendingCount(id, 0);
     }


### PR DESCRIPTION
if there are n clients per thread, the judgment is O(n),this optimization will reduce it to O(1)