### PR TITLE
redis-cli - sendReadOnly() to work with Redis Cloud

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -9101,7 +9101,7 @@ static void sendReadOnly(void) {
         exit(1);
     } else if (read_reply->type == REDIS_REPLY_ERROR && 
                strcmp(read_reply->str, "ERR This instance has cluster support disabled") != 0 &&
-               strcmp(read_reply->str, "ERR unknown command 'READONLY'") != 0) {
+               strncmp(read_reply->str, "ERR unknown command", 19) != 0) {
         fprintf(stderr, "Error: %s\n", read_reply->str);
         exit(1);
     }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -9099,7 +9099,9 @@ static void sendReadOnly(void) {
     if (read_reply == NULL){
         fprintf(stderr, "\nI/O error\n");
         exit(1);
-    } else if (read_reply->type == REDIS_REPLY_ERROR && strcmp(read_reply->str, "ERR This instance has cluster support disabled") != 0) {
+    } else if (read_reply->type == REDIS_REPLY_ERROR && 
+               strcmp(read_reply->str, "ERR This instance has cluster support disabled") != 0 &&
+               strcmp(read_reply->str, "ERR unknown command 'READONLY'") != 0) {
         fprintf(stderr, "Error: %s\n", read_reply->str);
         exit(1);
     }


### PR DESCRIPTION
When using Redis Cloud, sendReadOnly() exit with `Error: ERR unknown command 'READONLY'`.
It is impacting `--memkeys`, `--bigkeys`, `--hotkeys`, and will impact `--keystats`.
Added one line to ignore this error.

issue introduced in #12735 (not yet released).