### PR TITLE
Simplify hllDenseRegHisto()

### DIFF
--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -504,28 +504,20 @@ void hllDenseRegHisto(uint8_t *registers, int* reghisto) {
      * we take a faster path with unrolled loops. */
     if (HLL_REGISTERS == 16384 && HLL_BITS == 6) {
         uint8_t *r = registers;
-        unsigned long r0, r1, r2, r3, r4, r5, r6, r7;
-        for (j = 0; j < 2048; j++) {
-            /* Handle 8 registers per iteration. */
+        unsigned long r0, r1, r2, r3;
+        for (j = 0; j < 4096; j++) {
+            /* Handle 4 registers per iteration. */
             r0 = r[0] & 63;
             r1 = (r[0] >> 6 | r[1] << 2) & 63;
             r2 = (r[1] >> 4 | r[2] << 4) & 63;
             r3 = (r[2] >> 2) & 63;
-            r4 = r[3] & 63;
-            r5 = (r[3] >> 6 | r[4] << 2) & 63;
-            r6 = (r[4] >> 4 | r[5] << 4) & 63;
-            r7 = (r[5] >> 2) & 63;
 
             reghisto[r0]++;
             reghisto[r1]++;
             reghisto[r2]++;
             reghisto[r3]++;
-            reghisto[r4]++;
-            reghisto[r5]++;
-            reghisto[r6]++;
-            reghisto[r7]++;
 
-            r += 6;
+            r += 3;
         }
     } else {
         for(j = 0; j < HLL_REGISTERS; j++) {

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -504,10 +504,9 @@ void hllDenseRegHisto(uint8_t *registers, int* reghisto) {
      * we take a faster path with unrolled loops. */
     if (HLL_REGISTERS == 16384 && HLL_BITS == 6) {
         uint8_t *r = registers;
-        unsigned long r0, r1, r2, r3, r4, r5, r6, r7, r8, r9,
-                      r10, r11, r12, r13, r14, r15;
-        for (j = 0; j < 1024; j++) {
-            /* Handle 16 registers per iteration. */
+        unsigned long r0, r1, r2, r3, r4, r5, r6, r7;
+        for (j = 0; j < 2048; j++) {
+            /* Handle 8 registers per iteration. */
             r0 = r[0] & 63;
             r1 = (r[0] >> 6 | r[1] << 2) & 63;
             r2 = (r[1] >> 4 | r[2] << 4) & 63;
@@ -516,14 +515,6 @@ void hllDenseRegHisto(uint8_t *registers, int* reghisto) {
             r5 = (r[3] >> 6 | r[4] << 2) & 63;
             r6 = (r[4] >> 4 | r[5] << 4) & 63;
             r7 = (r[5] >> 2) & 63;
-            r8 = r[6] & 63;
-            r9 = (r[6] >> 6 | r[7] << 2) & 63;
-            r10 = (r[7] >> 4 | r[8] << 4) & 63;
-            r11 = (r[8] >> 2) & 63;
-            r12 = r[9] & 63;
-            r13 = (r[9] >> 6 | r[10] << 2) & 63;
-            r14 = (r[10] >> 4 | r[11] << 4) & 63;
-            r15 = (r[11] >> 2) & 63;
 
             reghisto[r0]++;
             reghisto[r1]++;
@@ -533,16 +524,8 @@ void hllDenseRegHisto(uint8_t *registers, int* reghisto) {
             reghisto[r5]++;
             reghisto[r6]++;
             reghisto[r7]++;
-            reghisto[r8]++;
-            reghisto[r9]++;
-            reghisto[r10]++;
-            reghisto[r11]++;
-            reghisto[r12]++;
-            reghisto[r13]++;
-            reghisto[r14]++;
-            reghisto[r15]++;
 
-            r += 12;
+            r += 6;
         }
     } else {
         for(j = 0; j < HLL_REGISTERS; j++) {


### PR DESCRIPTION
In HyperLogLog, every register has 6 bits and every 8 registers can be processed with same logic. Therefore, the code for handling 16 registers can be simplified to only handle 8.

The comment "we take a faster path with unrolled loops" refers to replacing obtaining the value of each register individually, as opposed to duplicating the for loop logic twice. As seen in the this commit https://github.com/redis/redis/commit/3ed947fb30727aab198e164853cf3dcfc960429e.