### PR TITLE
delete stale comment about "define redis_fsync"

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -93,7 +93,6 @@
 #endif
 #endif
 
-/* Define redis_fsync to fdatasync() in Linux and fsync() for all the rest */
 #if defined(__linux__)
 #define redis_fsync(fd) fdatasync(fd)
 #elif defined(__APPLE__)


### PR DESCRIPTION
See this stale comment when read source code.