### PR TITLE
Fix randomKey pathological case

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -330,7 +330,6 @@ void setKey(client *c, redisDb *db, robj *key, robj *val, int flags) {
 robj *dbRandomKey(redisDb *db) {
     dictEntry *de;
     int maxtries = 100;
-    int allvolatile = kvstoreSize(db->keys) == kvstoreSize(db->expires);
 
     while(1) {
         sds key;
@@ -342,7 +341,7 @@ robj *dbRandomKey(redisDb *db) {
         key = dictGetKey(de);
         keyobj = createStringObject(key,sdslen(key));
         if (dbFindExpires(db, key)) {
-            if (allvolatile && server.masterhost && --maxtries == 0) {
+            if (server.masterhost && --maxtries == 0) {
                 /* If the DB is composed only of keys with an expire set,
                  * it could happen that all the keys are already logically
                  * expired in the slave, so the function cannot stop because


### PR DESCRIPTION
Randomkey implemented such that if number of keys with expiration is equal to number of keys, then it only retries up-to 100 times to get a random, non-expired, key. If it fails, then it returns expired key. However, if the number of keys with expiration differed from the total number of keys, the function continue retrying until it success. This approach posed potential delays, particularly when a significant portion of keys were expired.

With this change, it will retry unconditionally 100 times.