### PR TITLE
Replace bit shift with __builtin_ctzll in HyperLogLog

### DIFF
--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -429,7 +429,7 @@ uint64_t MurmurHash64A (const void * key, int len, unsigned int seed) {
  * of the pattern 000..1 of the element hash. As a side effect 'regp' is
  * set to the register index this element hashes to. */
 int hllPatLen(unsigned char *ele, size_t elesize, long *regp) {
-    uint64_t hash, bit, index;
+    uint64_t hash, index;
     int count;
 
     /* Count the number of zeroes starting from bit HLL_REGISTERS
@@ -448,12 +448,10 @@ int hllPatLen(unsigned char *ele, size_t elesize, long *regp) {
     hash >>= HLL_P; /* Remove bits used to address the register. */
     hash |= ((uint64_t)1<<HLL_Q); /* Make sure the loop terminates
                                      and count will be <= Q+1. */
-    bit = 1;
-    count = 1; /* Initialized to 1 since we count the "00000...1" pattern. */
-    while((hash & bit) == 0) {
-        count++;
-        bit <<= 1;
-    }
+
+    /* Initialized to 1 since we count the "00000...1" pattern. */
+    count = __builtin_ctzll(hash) + 1;
+
     *regp = (int) index;
     return count;
 }

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -440,9 +440,7 @@ int hllPatLen(unsigned char *ele, size_t elesize, long *regp) {
      * included in the count, so if we find "001" the count is 3, and
      * the smallest count possible is no zeroes at all, just a 1 bit
      * at the first position, that is a count of 1.
-     *
-     * This may sound like inefficient, but actually in the average case
-     * there are high probabilities to find a 1 after a few iterations. */
+     */
     hash = MurmurHash64A(ele,elesize,0xadc83b19ULL);
     index = hash & HLL_P_MASK; /* Register index. */
     hash >>= HLL_P; /* Remove bits used to address the register. */

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -449,7 +449,6 @@ int hllPatLen(unsigned char *ele, size_t elesize, long *regp) {
     hash |= ((uint64_t)1<<HLL_Q); /* Make sure the loop terminates
                                      and count will be <= Q+1. */
 
-    /* Initialized to 1 since we count the "00000...1" pattern. */
     count = __builtin_ctzll(hash) + 1;
 
     *regp = (int) index;

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -450,7 +450,6 @@ int hllPatLen(unsigned char *ele, size_t elesize, long *regp) {
                                      and count will be <= Q+1. */
 
     count = __builtin_ctzll(hash) + 1;
-
     *regp = (int) index;
     return count;
 }

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -439,8 +439,7 @@ int hllPatLen(unsigned char *ele, size_t elesize, long *regp) {
      * Note that the final "1" ending the sequence of zeroes must be
      * included in the count, so if we find "001" the count is 3, and
      * the smallest count possible is no zeroes at all, just a 1 bit
-     * at the first position, that is a count of 1.
-     */
+     * at the first position, that is a count of 1. */
     hash = MurmurHash64A(ele,elesize,0xadc83b19ULL);
     index = hash & HLL_P_MASK; /* Register index. */
     hash >>= HLL_P; /* Remove bits used to address the register. */


### PR DESCRIPTION
## Replace bit shift with `__builtin_ctzll` in HyperLogLog

Builtin function `__builtin_ctzll` is more effective than bit shift even though "in the average case there are high probabilities to find a 1 after a few iterations" mentioned in the source file comment.

I wrote a program to test whether it's more effective. Let me try to explain the test cases and the result.

[Here](https://github.com/panzhongxian/learning-redis/blob/main/hyperloglog-with-debruijn/comparison.c) is the source code.

There are 4 `define` cases in the program:

- `RANDOM`:  just generate random uint64_t. This is a base time cost when the next two cases is run.
- `BITSHIFT`: counting the trailing zeros of the random numbers with bit shift method.
- `BUILTIN`: counting the trailing zeros of the random numbers with builtin `__builtin_ctzll`
- `CHECK`: call two functions and compare their results; print out the distribution of tailing zeros length.

More explainations:

- `ret` storing the sum of trailing zeros length, is use to void skipping the process when `-O2` flag is used.
- It is less posible to get a longer trailing zeros. To make the `CHECK` case can cover more long trailing zeros numbers, I left-shift the random number: `num = (num << (n % 50)) | ((uint64_t)1 << 51);`

Now let me show the result:

### 1. Run first 3 cases and compare the time

The result is as following:

```bash
> gcc -DRANDOM -O2 comparison.c && ./a.out
time consume: 10.820000 seconds
ret: 0xfa55d526137dcde3

> gcc -DBITSHIFT -O2 comparison.c && ./a.out
time consume: 14.440000 seconds
ret: 0x2fb03566

> gcc -DBUILTIN -O2 t.c && ./a.out
time consume: 10.720000 seconds
ret: 0x2fb03566
```

After removing the random number generating costs, we got this(much faster):

| random generation | Bit Shift | __builtin_ctzll |
| :---------------: | :-------: | :-------: |
|      include      |  14.44 s  |  10.72 s  |
|      exclude      |  3.62 s   |   -0.1s (almost same with only random number generation)  |

Meanwhile the `ret` of two cases is the same on. This means the correction of the new method.

### 2. Run check case

As mentioned before,  I left shifted the number. The result of two different counting method for each random number is same. And the distribution of trailing zeros length is as following:

```
> gcc -DCHECK -O2 comparison.c && ./a.out
time consume: 19.620000 seconds
 0: 0
 1: 3999773
 2: 6001116
 3: 6998319
 4: 7499012
 5: 7752334
 6: 7874867
 7: 7940717
 8: 7967613
 9: 7979342
10: 7995361
11: 7994381
12: 8001097
13: 7998487
14: 7998411
15: 8001045
16: 7998618
17: 7996643
18: 8000381
19: 8002905
20: 7994363
21: 8001226
22: 8004708
23: 8000645
24: 7996479
25: 8002017
26: 7996515
27: 8003087
28: 7999442
29: 7995457
30: 8002225
31: 8000386
32: 8000367
33: 7997993
34: 8001343
35: 7998145
36: 8006298
37: 7999528
38: 8000649
39: 7999591
40: 7998841
41: 7998956
42: 7997533
43: 7997693
44: 7998085
45: 8004006
46: 8000330
47: 8001280
48: 7998936
49: 8001060
50: 8000476
51: 8001918
```

### 3. Conclusion

The builtin function `__builtin_ctzll ` is correct in our case and much more effective than raw bit shift.

A replacement will bring a significant help.
