### PR TITLE
dynamically list test files

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -1150,3 +1150,10 @@ proc system_backtrace_supported {} {
     }
     return 0
 }
+
+proc generate_largevalue_test_array {} {
+    array set largevalue {}
+    set largevalue(listpack) "hello"
+    set largevalue(quicklist) [string repeat "x" 8192]
+    return [array get largevalue]
+}

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -17,98 +17,22 @@ source tests/support/tmpfile.tcl
 source tests/support/test.tcl
 source tests/support/util.tcl
 
-set ::all_tests {
-    unit/printver
-    unit/dump
-    unit/auth
-    unit/protocol
-    unit/keyspace
-    unit/scan
-    unit/info
-    unit/info-command
-    unit/type/string
-    unit/type/incr
-    unit/type/list
-    unit/type/list-2
-    unit/type/list-3
-    unit/type/set
-    unit/type/zset
-    unit/type/hash
-    unit/type/stream
-    unit/type/stream-cgroups
-    unit/sort
-    unit/expire
-    unit/other
-    unit/multi
-    unit/quit
-    unit/aofrw
-    unit/acl
-    unit/acl-v2
-    unit/latency-monitor
-    integration/block-repl
-    integration/replication
-    integration/replication-2
-    integration/replication-3
-    integration/replication-4
-    integration/replication-psync
-    integration/replication-buffer
-    integration/shutdown
-    integration/aof
-    integration/aof-race
-    integration/aof-multi-part
-    integration/rdb
-    integration/corrupt-dump
-    integration/corrupt-dump-fuzzer
-    integration/convert-zipmap-hash-on-load
-    integration/convert-ziplist-hash-on-load
-    integration/convert-ziplist-zset-on-load
-    integration/logging
-    integration/psync2
-    integration/psync2-reg
-    integration/psync2-pingoff
-    integration/psync2-master-restart
-    integration/failover
-    integration/redis-cli
-    integration/redis-benchmark
-    integration/dismiss-mem
-    unit/pubsub
-    unit/pubsubshard
-    unit/slowlog
-    unit/scripting
-    unit/functions
-    unit/maxmemory
-    unit/introspection
-    unit/introspection-2
-    unit/limits
-    unit/obuf-limits
-    unit/bitops
-    unit/bitfield
-    unit/geo
-    unit/memefficiency
-    unit/hyperloglog
-    unit/lazyfree
-    unit/wait
-    unit/pause
-    unit/querybuf
-    unit/tls
-    unit/tracking
-    unit/oom-score-adj
-    unit/shutdown
-    unit/networking
-    unit/client-eviction
-    unit/violations
-    unit/replybufsize
-    unit/cluster/announced-endpoints
-    unit/cluster/misc
-    unit/cluster/cli
-    unit/cluster/scripting
-    unit/cluster/hostnames
-    unit/cluster/human-announced-nodename
-    unit/cluster/multi-slot-operations
-    unit/cluster/slot-ownership
-    unit/cluster/links
-    unit/cluster/cluster-response-tls
-    unit/cluster/failure-marking
+set dir [pwd]
+set ::all_tests []
+
+set test_dirs {
+    unit
+    unit/type
+    unit/cluster
+    integration
+}
+
+foreach test_dir $test_dirs {
+    set files [glob -nocomplain $dir/tests/$test_dir/*.tcl]
+
+    foreach file $files {
+        lappend ::all_tests $test_dir/[file root [file tail $file]]
+    }
 }
 # Index to the next test to run in the ::all_tests list.
 set ::next_test 0

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -326,6 +326,7 @@ foreach {type large} [array get largevalue] {
     }
 
     test {COPY basic usage for listpack hash} {
+        r config set hash-max-listpack-entries 512
         r del hash1{t} newhash1{t}
         r hset hash1{t} tmp 17179869184
         assert_encoding listpack hash1{t}

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -252,7 +252,7 @@ start_server {tags {"keyspace"}} {
         assert {[r get mynewkey{t}] eq "foobar"}
     }
 
-source "tests/unit/type/list-common.tcl"
+array set largevalue [generate_largevalue_test_array]
 foreach {type large} [array get largevalue] {
     set origin_config [config_get_set list-max-listpack-size -1]
     test "COPY basic usage for list - $type" {

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -486,7 +486,6 @@ start_server {tags {"hash"}} {
     } {1 0 1 0}
 
     test {Is a ziplist encoded Hash promoted on big payload?} {
-        r config set hash-max-listpack-value 64
         r hset smallhash foo [string repeat a 1024]
         r debug object smallhash
     } {*hashtable*} {needs:debug}

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -1,4 +1,7 @@
 start_server {tags {"hash"}} {
+    r config set hash-max-listpack-value 64
+    r config set hash-max-listpack-entries 512
+
     test {HSET/HLEN - Small hash creation} {
         array set smallhash {}
         for {set i 0} {$i < 8} {incr i} {

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -483,6 +483,7 @@ start_server {tags {"hash"}} {
     } {1 0 1 0}
 
     test {Is a ziplist encoded Hash promoted on big payload?} {
+        r config set hash-max-listpack-value 64
         r hset smallhash foo [string repeat a 1024]
         r debug object smallhash
     } {*hashtable*} {needs:debug}

--- a/tests/unit/type/list-2.tcl
+++ b/tests/unit/type/list-2.tcl
@@ -4,7 +4,7 @@ start_server {
         "list-max-ziplist-size" 4
     }
 } {
-    source "tests/unit/type/list-common.tcl"
+    array set largevalue [generate_largevalue_test_array]
 
     foreach {type large} [array get largevalue] {
         tags {"slow"} {

--- a/tests/unit/type/list-common.tcl
+++ b/tests/unit/type/list-common.tcl
@@ -1,4 +1,0 @@
-# We need a value to make sure the list has the right encoding when it is inserted.
-array set largevalue {}
-set largevalue(listpack) "hello"
-set largevalue(quicklist) [string repeat "x" 8192]

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -448,7 +448,7 @@ start_server {
         "list-max-ziplist-size" -1
     }
 } {
-    source "tests/unit/type/list-common.tcl"
+    array set largevalue [generate_largevalue_test_array]
 
     # A helper function to execute either B*POP or BLMPOP* with one input key.
     proc bpop_command {rd pop key timeout} {


### PR DESCRIPTION
**Related issue**
https://github.com/redis/redis/issues/13219

**Motivation**
Currently we have to manually update the all_tests variable when introducing new test files.

**Modification**
I have modified it to list test files dynamically, but instead of modifying it to add all test files, I have modified it to only add only test files from the following 4 paths

- unit
- unit/type
- unit/cluster
- integration

so that it doesn't deviate too much from what we already do

**Result**
- dynamically list test files to all_tests variable
- close issue https://github.com/redis/redis/issues/13219

**Additional information**
- removed `list-common.tcl` file and added `generate_largevalue_test_array` proc in `util.tcl`. because `list-common.tcl` is not a test file
-  There is an order dependency. So I added a code to the "Is a ziplist encoded Hash promoted on big payload?" test that resets hash-max-listpack-value to the default (64).