### PR TITLE
Fix forget to update the dict's node in the kvstore's rehashing list after defragment

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -46,7 +46,7 @@ void* activeDefragAlloc(void *ptr) {
     /* move this allocation to a new allocation.
      * make sure not to use the thread cache. so that we don't get back the same
      * pointers we try to free */
-    size = zmalloc_size(ptr);
+    size = zmalloc_usable_size(ptr);
     newptr = zmalloc_no_tcache(size);
     memcpy(newptr, ptr, size);
     zfree_no_tcache(ptr);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -871,23 +871,18 @@ void freeTestCallback(dict *d, void *val) {
 }
 
 void* defragAllocTest(void *ptr) {
-    size_t size;
-    void *newptr;
-    size = zmalloc_size(ptr);
-    newptr = zmalloc(size);
+    size_t size = zmalloc_size(ptr);
+    void *newptr = zmalloc(size);
     memcpy(newptr, ptr, size);
     zfree(ptr);
     return newptr;
 }
 
 dict *defragLUTTestCallback(dict *d) {
-    dictEntry **newtable;
     /* handle the dict struct */
     d = defragAllocTest(d);
     /* handle the first hash table */
-    newtable = defragAllocTest(d->ht_table[0]);
-    if (newtable)
-        d->ht_table[0] = newtable;
+    d->ht_table[0] = defragAllocTest(d->ht_table[0]);
     /* handle the second hash table */
     if (d->ht_table[1])
         d->ht_table[1] = defragAllocTest(d->ht_table[1]);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -784,9 +784,8 @@ void kvstoreDictLUTDefrag(kvstore *kvs, kvstoreDictLUTDefragFunction *defragfn) 
             /* After defragmenting the dict, update its corresponding
              * rehashing node in the kvstore's rehashing list. */
             kvstoreDictMetadata *metadata = (kvstoreDictMetadata *)dictMetadata(*d);
-            if (metadata->rehashing_node) {
+            if (metadata->rehashing_node)
                 metadata->rehashing_node->value = *d;
-            }
         }
     }
 }
@@ -1021,6 +1020,7 @@ int kvstoreTest(int argc, char **argv, int flags) {
             de = kvstoreDictAddRaw(kvs, 0, stringFromInt(i), NULL);
             if (listLength(kvs->rehashing)) break;
         }
+        assert(listLength(kvs->rehashing));
         kvstoreDictLUTDefrag(kvs, defragLUTTestCallback);
         while (kvstoreIncrementallyRehash(kvs, 1000)) {}
         kvstoreRelease(kvs);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -870,7 +870,7 @@ void freeTestCallback(dict *d, void *val) {
 }
 
 void* defragAllocTest(void *ptr) {
-    size_t size = zmalloc_usable_size(ptr);
+    size_t size = zmalloc_size(ptr);
     void *newptr = zmalloc(size);
     memcpy(newptr, ptr, size);
     zfree(ptr);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -870,7 +870,7 @@ void freeTestCallback(dict *d, void *val) {
 }
 
 void* defragAllocTest(void *ptr) {
-    size_t size = zmalloc_size(ptr);
+    size_t size = zmalloc_usable_size(ptr);
     void *newptr = zmalloc(size);
     memcpy(newptr, ptr, size);
     zfree(ptr);


### PR DESCRIPTION
Introducted by #13013

After defragmenting the dictionary in the kvstore, if the dict is reallocated, the value of its node in the kvstore rehashing list must be updated.
