### PR TITLE
Fix CI failure caused by PR #13231

### DIFF
--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -869,8 +869,8 @@ void freeTestCallback(dict *d, void *val) {
     zfree(val);
 }
 
-void* defragAllocTest(void *ptr) {
-    size_t size = zmalloc_size(ptr);
+void *defragAllocTest(void *ptr) {
+    size_t size = zmalloc_usable_size(ptr);
     void *newptr = zmalloc(size);
     memcpy(newptr, ptr, size);
     zfree(ptr);


### PR DESCRIPTION
For my mistake, in the last revert commit in #13231, I originally wanted to revert the last one, but reverted the penultimate fix.
Now that we have fix another potential memory read issue in [`743f1dd` (#13231)](https://github.com/redis/redis/pull/13231/commits/743f1dde79b433fdb8ea13de4fd73457d4fe25eb), now it just seems to avoid confusion, i will verify in the future whether it will have any impact, if so we will add this PR to backport.

Failed CI: https://github.com/sundb/redis/actions/runs/8826731960