### PR TITLE
Hfe serialization listpack

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -237,7 +237,7 @@ void restoreCommand(client *c) {
 
     rioInitWithBuffer(&payload,c->argv[3]->ptr);
     if (((type = rdbLoadObjectType(&payload)) == -1) ||
-        ((obj = rdbLoadObject(type,&payload,key->ptr,c->db,NULL, 0)) == NULL))
+        ((obj = rdbLoadObject(type,&payload,key->ptr,c->db,0,NULL)) == NULL))
     {
         addReplyError(c,"Bad data format");
         return;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -237,7 +237,7 @@ void restoreCommand(client *c) {
 
     rioInitWithBuffer(&payload,c->argv[3]->ptr);
     if (((type = rdbLoadObjectType(&payload)) == -1) ||
-        ((obj = rdbLoadObject(type,&payload,key->ptr,c->db->id,NULL)) == NULL))
+        ((obj = rdbLoadObject(type,&payload,key->ptr,c->db,c->db->id,NULL)) == NULL))
     {
         addReplyError(c,"Bad data format");
         return;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -237,7 +237,7 @@ void restoreCommand(client *c) {
 
     rioInitWithBuffer(&payload,c->argv[3]->ptr);
     if (((type = rdbLoadObjectType(&payload)) == -1) ||
-        ((obj = rdbLoadObject(type,&payload,key->ptr,c->db,c->db->id,NULL)) == NULL))
+        ((obj = rdbLoadObject(type,&payload,key->ptr,c->db,NULL, 0)) == NULL))
     {
         addReplyError(c,"Bad data format");
         return;

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -1403,7 +1403,8 @@ int ebRemove(ebuckets *eb, EbucketsType *type, eItem item) {
  * @param item - The eItem to be added to the ebucket.
  * @param expireTime - The expiration time of the item.
  *
- * @return 0 if the item was successfully added; Otherwise, return 1 on failure.
+ * @return 0 (C_OK) if the item was successfully added;
+ *         Otherwise, return -1 (C_ERR) on failure.
  */
 int ebAdd(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTime) {
     int res;

--- a/src/ebuckets.c
+++ b/src/ebuckets.c
@@ -1403,7 +1403,7 @@ int ebRemove(ebuckets *eb, EbucketsType *type, eItem item) {
  * @param item - The eItem to be added to the ebucket.
  * @param expireTime - The expiration time of the item.
  *
- * @return 1 if the item was successfully added; Otherwise, return 0 on failure.
+ * @return 0 if the item was successfully added; Otherwise, return 1 on failure.
  */
 int ebAdd(ebuckets *eb, EbucketsType *type, eItem item, uint64_t expireTime) {
     int res;

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1209,6 +1209,7 @@ size_t lpBytes(unsigned char *lp) {
     return lpGetTotalBytes(lp);
 }
 
+/* Returns the size 'lval' will require when encoded, in bytes */
 size_t lpEntrySizeInteger(long long lval) {
     uint64_t enclen;
     lpEncodeIntegerGetType(lval, NULL, &enclen);

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -219,6 +219,7 @@ int lpStringToInt64(const char *s, unsigned long slen, int64_t *value) {
  * */
 unsigned char *lpNew(size_t capacity) {
     unsigned char *lp = lp_malloc(capacity > LP_HDR_SIZE+1 ? capacity : LP_HDR_SIZE+1);
+    if (lp == NULL) return NULL;
     lpSetTotalBytes(lp,LP_HDR_SIZE+1);
     lpSetNumElements(lp,0);
     lp[LP_HDR_SIZE] = LP_EOF;
@@ -1208,7 +1209,7 @@ size_t lpBytes(unsigned char *lp) {
     return lpGetTotalBytes(lp);
 }
 
-size_t lpEstimateBytesInteger(long long lval) {
+size_t lpEntrySizeInteger(long long lval) {
     uint64_t enclen;
     lpEncodeIntegerGetType(lval, NULL, &enclen);
     unsigned long backlen = lpEncodeBacklen(NULL, enclen);
@@ -1217,7 +1218,7 @@ size_t lpEstimateBytesInteger(long long lval) {
 
 /* Returns the size of a listpack consisting of an integer repeated 'rep' times. */
 size_t lpEstimateBytesRepeatedInteger(long long lval, unsigned long rep) {
-    return LP_HDR_SIZE + lpEstimateBytesInteger(lval) * rep + 1;
+    return LP_HDR_SIZE + lpEntrySizeInteger(lval) * rep + 1;
 }
 
 /* Seek the specified element and returns the pointer to the seeked element.

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -61,7 +61,7 @@ unsigned char *lpLast(unsigned char *lp);
 unsigned char *lpNext(unsigned char *lp, unsigned char *p);
 unsigned char *lpPrev(unsigned char *lp, unsigned char *p);
 size_t lpBytes(unsigned char *lp);
-size_t lpEstimateBytesInteger(long long lval);
+size_t lpEntrySizeInteger(long long lval);
 size_t lpEstimateBytesRepeatedInteger(long long lval, unsigned long rep);
 unsigned char *lpSeek(unsigned char *lp, long index);
 typedef int (*listpackValidateEntryCB)(unsigned char *p, unsigned int head_count, void *userdata);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -61,6 +61,7 @@ unsigned char *lpLast(unsigned char *lp);
 unsigned char *lpNext(unsigned char *lp, unsigned char *p);
 unsigned char *lpPrev(unsigned char *lp, unsigned char *p);
 size_t lpBytes(unsigned char *lp);
+size_t lpEstimateBytesInteger(long long lval);
 size_t lpEstimateBytesRepeatedInteger(long long lval, unsigned long rep);
 unsigned char *lpSeek(unsigned char *lp, long index);
 typedef int (*listpackValidateEntryCB)(unsigned char *p, unsigned int head_count, void *userdata);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2287,7 +2287,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb* db, int rdbflags,
             * created in memory (because it is created on the first valid field), and
             * thus the key would be discarded as an "empty key" */
             if (expire != 0 && iAmMaster() && ((mstime_t)expire < now) &&  /* note: expire was saved to RDB as unix-time in milliseconds */
-                !(rdbflags & RDBFLAGS_AOF_PREAMBLE)) {
+                !(rdbflags & RDBFLAGS_AOF_PREAMBLE))
+            {
                 /* TODO: consider replication (like in rdbLoadAddKeyToDb) */
                 server.rdb_last_load_hash_fields_expired++;
                 sdsfree(field);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2254,8 +2254,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb* db, int rdbflags,
                 serverLog(LL_WARNING, "failed reading hash TTL");
                 decrRefCount(o);
                 if (dupSearchDict != NULL) dictRelease(dupSearchDict);
-                sdsfree(value);
-                sdsfree(field);
                 return NULL;
             }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -956,7 +956,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
             int withTtl = 0; /* whether there is at least one field with a valid TTL */
             uint64_t ttl = 0;
 
-            /* save number of fileds in hash */
+            /* save number of fields in hash */
             if ((n = rdbSaveLen(rdb,dictSize((dict*)o->ptr))) == -1) {
                 dictReleaseIterator(di);
                 return -1;
@@ -1862,11 +1862,11 @@ static int _lpEntryValidation(unsigned char *p, unsigned int head_count, void *u
 /* Validate the integrity of the listpack structure.
  * when `deep` is 0, only the integrity of the header is validated.
  * when `deep` is 1, we scan all the entries one by one.
- * uniqness_factor indicates which elemnts should be verified for uniquness.
- * when it's 1, each elemnt should be unique (set)
+ * uniqueness_factor indicates which elements should be verified for uniqueness.
+ * when it's 1, each element should be unique (set)
  * when it's 2, each second element should be unique (key-value map)
  * when it's 3, each third element should be unique (key-value-ttl map) */
-int lpValidateIntegrityAndDups(unsigned char *lp, size_t size, int deep, int uniqeness_factor) {
+int lpValidateIntegrityAndDups(unsigned char *lp, size_t size, int deep, int uniqueness_factor) {
     if (!deep)
         return lpValidateIntegrity(lp, size, 0, NULL, NULL);
 
@@ -1875,12 +1875,12 @@ int lpValidateIntegrityAndDups(unsigned char *lp, size_t size, int deep, int uni
         int uniqeness_factor;
         long count;
         dict *fields; /* Initialisation at the first callback. */
-    } data = {uniqeness_factor, 0, NULL};
+    } data = {uniqueness_factor, 0, NULL};
 
     int ret = lpValidateIntegrity(lp, size, 1, _lpEntryValidation, &data);
 
-    /* the number of redorcds should be a multiple of the uniqueness factor */
-    if (data.count % uniqeness_factor != 0)
+    /* the number of records should be a multiple of the uniqueness factor */
+    if (data.count % uniqueness_factor != 0)
         ret = 0;
 
     if (data.fields) dictRelease(data.fields);
@@ -2310,13 +2310,13 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb* db, int dbid, int *
             /* Check if the hash field already expired. This function is used when
             * loading an RDB file from disk, either at startup, or when an RDB was
             * received from the master. In the latter case, the master is
-            * responsible for hash field expiry. If we would expire hash fiedls here,
+            * responsible for hash field expiry. If we would expire hash fields here,
             * the snapshot taken by the master may not be reflected on the slave.
             * Similarly, if the base AOF is RDB format, we want to load all
             * the hash fields there are, since the log of operations in the incr AOF
             * is assumed to work in the exact keyspace state.
-            * Expired hash fields on the master are silenlty discarded.
-            * Note that if all fileds in a hash has expired, the hash would not be
+            * Expired hash fields on the master are silently discarded.
+            * Note that if all fields in a hash has expired, the hash would not be
             * created in memory (because it is created on the first valid field), and
             * thus the key would be discarded as an "empty key" */
             if (ttl != 0 && iAmMaster() && ((mstime_t)ttl < now)) { /* note: TTL was saved to RDB as unix-time in milliseconds */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2359,6 +2359,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb* db, int *error,
                         return NULL;
                     }
                 }
+                sdsfree(field);
+                sdsfree(value);
             }
         }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -956,7 +956,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
             dictEntry *de;
             /* Determine the hash layout to use based on the presence of at least
              * one field with a valid TTL. If such a field exists, employ the
-             * RDB_TYPE_HASH_METADATA layout, including tuples of [field][value][ttl].
+             * RDB_TYPE_HASH_METADATA layout, including tuples of [ttl][field][value].
              * Otherwise, use the standard RDB_TYPE_HASH layout containing only
              * the tuples [field][value]. */
             int with_ttl = (hashTypeGetMinExpire(o) != EB_EXPIRE_TIME_INVALID);
@@ -2229,6 +2229,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb* db, int rdbflags,
         len = rdbLoadLen(rdb, NULL);
         if (len == RDB_LENERR) return NULL;
         if (len == 0) goto emptykey;
+        /* TODO: create listpackEx or HT directly*/
         o = createHashObject();
         /* Too many entries? Use a hash table right from the start. */
         if (len > server.hash_max_listpack_entries) {

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -141,7 +141,7 @@ int rdbSaveToFile(const char *filename);
 int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags);
 ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid);
 size_t rdbSavedObjectLen(robj *o, robj *key, int dbid);
-robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb* db, int dbid, int *error);
+robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb *db, int dbid, int *error);
 void backgroundSaveDoneHandler(int exitcode, int bysignal);
 int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime,int dbid);
 ssize_t rdbSaveSingleModuleAux(rio *rdb, int when, moduleType *mt);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -122,10 +122,6 @@
 #define RDB_LOAD_ERR_EMPTY_KEY  1   /* Error of empty key */
 #define RDB_LOAD_ERR_OTHER      2   /* Any other errors */
 
-/* Flags for hash entry content when reading/writing a RDB_TYPE_HASH_METADATA */
-#define RDB_HASH_ENTRY_VALUE (1<<0) /* this hash entry contains a value */
-#define RDB_HASH_ENTRY_TTL   (1<<1) /* this hash entry contains a TTL */
-
 ssize_t rdbWriteRaw(rio *rdb, void *p, size_t len);
 int rdbSaveType(rio *rdb, unsigned char type);
 int rdbLoadType(rio *rdb);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -74,10 +74,11 @@
 #define RDB_TYPE_SET_LISTPACK  20
 #define RDB_TYPE_STREAM_LISTPACKS_3 21
 #define RDB_TYPE_HASH_METADATA 22
+#define RDB_TYPE_HASH_LISTPACK_TTL 23
 /* NOTE: WHEN ADDING NEW RDB TYPE, UPDATE rdbIsObjectType(), and rdb_type_string[] */
 
 /* Test if a type is an object type. */
-#define rdbIsObjectType(t) (((t) >= 0 && (t) <= 7) || ((t) >= 9 && (t) <= 22))
+#define rdbIsObjectType(t) (((t) >= 0 && (t) <= 7) || ((t) >= 9 && (t) <= 23))
 
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
 #define RDB_OPCODE_SLOT_INFO  244   /* Individual slot info, such as slot id and size (cluster mode only). */
@@ -144,7 +145,7 @@ int rdbSaveToFile(const char *filename);
 int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags);
 ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid);
 size_t rdbSavedObjectLen(robj *o, robj *key, int dbid);
-robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error);
+robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb* db, int dbid, int *error);
 void backgroundSaveDoneHandler(int exitcode, int bysignal);
 int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime,int dbid);
 ssize_t rdbSaveSingleModuleAux(rio *rdb, int when, moduleType *mt);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -141,7 +141,7 @@ int rdbSaveToFile(const char *filename);
 int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags);
 ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid);
 size_t rdbSavedObjectLen(robj *o, robj *key, int dbid);
-robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb *db, int *error, int rdbflags);
+robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb *db, int rdbflags, int *error);
 void backgroundSaveDoneHandler(int exitcode, int bysignal);
 int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime,int dbid);
 ssize_t rdbSaveSingleModuleAux(rio *rdb, int when, moduleType *mt);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -73,10 +73,11 @@
 #define RDB_TYPE_STREAM_LISTPACKS_2 19
 #define RDB_TYPE_SET_LISTPACK  20
 #define RDB_TYPE_STREAM_LISTPACKS_3 21
+#define RDB_TYPE_HASH_METADATA 22
 /* NOTE: WHEN ADDING NEW RDB TYPE, UPDATE rdbIsObjectType(), and rdb_type_string[] */
 
 /* Test if a type is an object type. */
-#define rdbIsObjectType(t) (((t) >= 0 && (t) <= 7) || ((t) >= 9 && (t) <= 21))
+#define rdbIsObjectType(t) (((t) >= 0 && (t) <= 7) || ((t) >= 9 && (t) <= 22))
 
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
 #define RDB_OPCODE_SLOT_INFO  244   /* Individual slot info, such as slot id and size (cluster mode only). */
@@ -119,6 +120,10 @@
  * set to hold the type of error that occurred */
 #define RDB_LOAD_ERR_EMPTY_KEY  1   /* Error of empty key */
 #define RDB_LOAD_ERR_OTHER      2   /* Any other errors */
+
+/* Flags for hash entry content when reading/writing a RDB_TYPE_HASH_METADATA */
+#define RDB_HASH_ENTRY_VALUE (1<<0) /* this hash entry contains a value */
+#define RDB_HASH_ENTRY_TTL   (1<<1) /* this hash entry contains a TTL */
 
 ssize_t rdbWriteRaw(rio *rdb, void *p, size_t len);
 int rdbSaveType(rio *rdb, unsigned char type);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -74,7 +74,7 @@
 #define RDB_TYPE_SET_LISTPACK  20
 #define RDB_TYPE_STREAM_LISTPACKS_3 21
 #define RDB_TYPE_HASH_METADATA 22
-#define RDB_TYPE_HASH_LISTPACK_TTL 23
+#define RDB_TYPE_HASH_LISTPACK_EX 23
 /* NOTE: WHEN ADDING NEW RDB TYPE, UPDATE rdbIsObjectType(), and rdb_type_string[] */
 
 /* Test if a type is an object type. */
@@ -141,7 +141,7 @@ int rdbSaveToFile(const char *filename);
 int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags);
 ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid);
 size_t rdbSavedObjectLen(robj *o, robj *key, int dbid);
-robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb *db, int dbid, int *error);
+robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb *db, int *error, int rdbflags);
 void backgroundSaveDoneHandler(int exitcode, int bysignal);
 int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime,int dbid);
 ssize_t rdbSaveSingleModuleAux(rio *rdb, int when, moduleType *mt);

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -80,6 +80,8 @@ char *rdb_type_string[] = {
     "stream-v2",
     "set-listpack",
     "stream-v3",
+    "hash-md-hashtable",
+    "hash-md-listpack",
 };
 
 /* Show a few stats collected into 'rdbstate' */

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -331,7 +331,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         rdbstate.keys++;
         /* Read value */
         rdbstate.doing = RDB_CHECK_DOING_READ_OBJECT_VALUE;
-        if ((val = rdbLoadObject(type,&rdb,key->ptr,selected_dbid,NULL)) == NULL) goto eoferr;
+        if ((val = rdbLoadObject(type,&rdb,key->ptr,NULL,selected_dbid,NULL)) == NULL) goto eoferr;
         /* Check if the key already expired. */
         if (expiretime != -1 && expiretime < now)
             rdbstate.already_expired++;

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -80,8 +80,8 @@ char *rdb_type_string[] = {
     "stream-v2",
     "set-listpack",
     "stream-v3",
-    "hash-md-hashtable",
-    "hash-md-listpack",
+    "hash-hashtable-md",
+    "hash-listpack-md",
 };
 
 /* Show a few stats collected into 'rdbstate' */
@@ -331,7 +331,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         rdbstate.keys++;
         /* Read value */
         rdbstate.doing = RDB_CHECK_DOING_READ_OBJECT_VALUE;
-        if ((val = rdbLoadObject(type,&rdb,key->ptr,NULL,NULL,0)) == NULL) goto eoferr;
+        if ((val = rdbLoadObject(type,&rdb,key->ptr,NULL,0,NULL)) == NULL) goto eoferr;
         /* Check if the key already expired. */
         if (expiretime != -1 && expiretime < now)
             rdbstate.already_expired++;

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -175,7 +175,6 @@ void rdbCheckSetupSignals(void) {
  * otherwise the already open file 'fp' is checked. */
 int redis_check_rdb(char *rdbfilename, FILE *fp) {
     uint64_t dbid;
-    int selected_dbid = -1;
     int type, rdbver;
     char buf[1024];
     long long expiretime, now = mstime();
@@ -247,7 +246,6 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             if ((dbid = rdbLoadLen(&rdb,NULL)) == RDB_LENERR)
                 goto eoferr;
             rdbCheckInfo("Selecting DB ID %llu", (unsigned long long)dbid);
-            selected_dbid = dbid;
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_RESIZEDB) {
             /* RESIZEDB: Hint about the size of the keys in the currently
@@ -333,7 +331,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         rdbstate.keys++;
         /* Read value */
         rdbstate.doing = RDB_CHECK_DOING_READ_OBJECT_VALUE;
-        if ((val = rdbLoadObject(type,&rdb,key->ptr,NULL,selected_dbid,NULL)) == NULL) goto eoferr;
+        if ((val = rdbLoadObject(type,&rdb,key->ptr,NULL,NULL,0)) == NULL) goto eoferr;
         /* Check if the key already expired. */
         if (expiretime != -1 && expiretime < now)
             rdbstate.already_expired++;

--- a/src/server.c
+++ b/src/server.c
@@ -2707,6 +2707,7 @@ void initServer(void) {
     server.rdb_save_time_start = -1;
     server.rdb_last_load_keys_expired = 0;
     server.rdb_last_load_keys_loaded = 0;
+    server.rdb_last_load_hash_fields_expired = 0;
     server.dirty = 0;
     resetServerStats();
     /* A few stats we don't want to reset: server startup time, and peak mem. */
@@ -5770,6 +5771,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "rdb_last_cow_size:%zu\r\n", server.stat_rdb_cow_bytes,
             "rdb_last_load_keys_expired:%lld\r\n", server.rdb_last_load_keys_expired,
             "rdb_last_load_keys_loaded:%lld\r\n", server.rdb_last_load_keys_loaded,
+            "rdb_last_load_hash_fields_expired:%lld\r\n", server.rdb_last_load_hash_fields_expired,
             "aof_enabled:%d\r\n", server.aof_state != AOF_OFF,
             "aof_rewrite_in_progress:%d\r\n", server.child_type == CHILD_TYPE_AOF,
             "aof_rewrite_scheduled:%d\r\n", server.aof_rewrite_scheduled,

--- a/src/server.h
+++ b/src/server.h
@@ -3202,9 +3202,7 @@ uint64_t hashTypeGetMinExpire(robj *o);
 void hashTypeUpdateKeyRef(robj *o, sds newkey);
 ebuckets *hashTypeGetDictMetaHFE(dict *d);
 void listpackExExpire(robj *o, ExpireInfo *info);
-void *HashTypeGroupSetInit(sds key, robj *o, redisDb *db);
-int hashTypeGroupSet(void* ctx, redisDb *db, robj *o, sds field, sds value, uint64_t expire_at);
-void hashTypeGroupSetDone(void *ctx);
+int hashTypeSetExRdb(redisDb *db, robj *o, sds field, sds value, uint64_t expire_at);
 uint64_t hashTypeGetMinExpire(robj *keyObj);
 
 /* Hash-Field data type (of t_hash.c) */

--- a/src/server.h
+++ b/src/server.h
@@ -3206,6 +3206,8 @@ int hashTypeSetExRdb(redisDb *db, robj *o, sds field, sds value, uint64_t expire
 uint64_t hashTypeGetMinExpire(robj *keyObj);
 uint64_t hashTypeGetNextTimeToExpire(robj *o);
 void initDictExpireMetadata(sds key, robj *o);
+struct listpackEx *listpackExCreate(void);
+void listpackExAddNew(robj *o, sds field, sds value, uint64_t expireAt);
 
 /* Hash-Field data type (of t_hash.c) */
 hfield hfieldNew(const void *field, size_t fieldlen, int withExpireMeta);

--- a/src/server.h
+++ b/src/server.h
@@ -3205,6 +3205,7 @@ void listpackExExpire(robj *o, ExpireInfo *info);
 void *HashTypeGroupSetInit(sds key, robj *o, redisDb *db);
 int hashTypeGroupSet(void* ctx, redisDb *db, robj *o, sds field, sds value, uint64_t expire_at);
 void hashTypeGroupSetDone(void *ctx);
+uint64_t hashTypeGetMinExpire(robj *keyObj);
 
 /* Hash-Field data type (of t_hash.c) */
 hfield hfieldNew(const void *field, size_t fieldlen, int withExpireMeta);

--- a/src/server.h
+++ b/src/server.h
@@ -3206,6 +3206,9 @@ void *listpackExCreateFromListpack(void *lp);
 void *listpackExGetListpack(const robj *o);
 void listpackExUpdateListpack(const robj *o, void *lp);
 void listpackExExpire(robj *o, ExpireInfo *info, long long *expire_stat);
+void *HashTypeGroupSetInit(sds key, robj *o, redisDb *db);
+int hashTypeGroupSet(void* ctx, redisDb *db, robj *o, sds field, sds value, uint64_t expire_at);
+void hashTypeGroupSetDone(void *ctx);
 
 /* Hash-Field data type (of t_hash.c) */
 hfield hfieldNew(const void *field, size_t fieldlen, int withExpireMeta);

--- a/src/server.h
+++ b/src/server.h
@@ -3198,9 +3198,14 @@ void hashTypeAddToExpires(redisDb *db, sds key, robj *hashObj, uint64_t expireTi
 void hashTypeFree(robj *o);
 int hashTypeIsExpired(const robj *o, uint64_t expireAt);
 unsigned char *hashTypeListpackGetLp(robj *o);
+
 uint64_t hashTypeGetMinExpire(robj *o);
 void hashTypeUpdateKeyRef(robj *o, sds newkey);
 ebuckets *hashTypeGetDictMetaHFE(dict *d);
+void *listpackExCreateFromListpack(void *lp);
+void *listpackExGetListpack(const robj *o);
+void listpackExUpdateListpack(const robj *o, void *lp);
+void listpackExExpire(robj *o, ExpireInfo *info, long long *expire_stat);
 
 /* Hash-Field data type (of t_hash.c) */
 hfield hfieldNew(const void *field, size_t fieldlen, int withExpireMeta);

--- a/src/server.h
+++ b/src/server.h
@@ -3204,6 +3204,7 @@ ebuckets *hashTypeGetDictMetaHFE(dict *d);
 void listpackExExpire(robj *o, ExpireInfo *info);
 int hashTypeSetExRdb(redisDb *db, robj *o, sds field, sds value, uint64_t expire_at);
 uint64_t hashTypeGetMinExpire(robj *keyObj);
+uint64_t hashTypeGetNextTimeToExpire(robj *o);
 
 /* Hash-Field data type (of t_hash.c) */
 hfield hfieldNew(const void *field, size_t fieldlen, int withExpireMeta);

--- a/src/server.h
+++ b/src/server.h
@@ -1802,6 +1802,7 @@ struct redisServer {
     long long dirty_before_bgsave;  /* Used to restore dirty on failed BGSAVE */
     long long rdb_last_load_keys_expired;  /* number of expired keys when loading RDB */
     long long rdb_last_load_keys_loaded;   /* number of loaded keys when loading RDB */
+    long long rdb_last_load_hash_fields_expired; /* number of expired hash fields when loading RDB */
     struct saveparam *saveparams;   /* Save points array for RDB */
     int saveparamslen;              /* Number of saving points */
     char *rdb_filename;             /* Name of RDB file */
@@ -3210,6 +3211,7 @@ uint64_t hfieldGetExpireTime(hfield field);
 static inline void hfieldFree(hfield field) { mstrFree(&mstrFieldKind, field); }
 static inline void *hfieldGetAllocPtr(hfield field) { return mstrGetAllocPtr(&mstrFieldKind, field); }
 static inline size_t hfieldlen(hfield field) { return mstrlen(field);}
+uint64_t hfieldGetExpireTime(hfield field);
 
 /* Pub / Sub */
 int pubsubUnsubscribeAllChannels(client *c, int notify);

--- a/src/server.h
+++ b/src/server.h
@@ -3205,6 +3205,7 @@ void listpackExExpire(robj *o, ExpireInfo *info);
 int hashTypeSetExRdb(redisDb *db, robj *o, sds field, sds value, uint64_t expire_at);
 uint64_t hashTypeGetMinExpire(robj *keyObj);
 uint64_t hashTypeGetNextTimeToExpire(robj *o);
+void initDictExpireMetadata(sds key, robj *o);
 
 /* Hash-Field data type (of t_hash.c) */
 hfield hfieldNew(const void *field, size_t fieldlen, int withExpireMeta);

--- a/src/server.h
+++ b/src/server.h
@@ -3198,14 +3198,10 @@ void hashTypeAddToExpires(redisDb *db, sds key, robj *hashObj, uint64_t expireTi
 void hashTypeFree(robj *o);
 int hashTypeIsExpired(const robj *o, uint64_t expireAt);
 unsigned char *hashTypeListpackGetLp(robj *o);
-
 uint64_t hashTypeGetMinExpire(robj *o);
 void hashTypeUpdateKeyRef(robj *o, sds newkey);
 ebuckets *hashTypeGetDictMetaHFE(dict *d);
-void *listpackExCreateFromListpack(void *lp);
-void *listpackExGetListpack(const robj *o);
-void listpackExUpdateListpack(const robj *o, void *lp);
-void listpackExExpire(robj *o, ExpireInfo *info, long long *expire_stat);
+void listpackExExpire(robj *o, ExpireInfo *info);
 void *HashTypeGroupSetInit(sds key, robj *o, redisDb *db);
 int hashTypeGroupSet(void* ctx, redisDb *db, robj *o, sds field, sds value, uint64_t expire_at);
 void hashTypeGroupSetDone(void *ctx);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -23,6 +23,7 @@ static ExpireAction hashTypeActiveExpire(eItem hashObj, void *ctx);
 static void hfieldPersist(robj *hashObj, hfield field);
 static void updateGlobalHfeDs(redisDb *db, robj *o, uint64_t minExpire, uint64_t minExpireFields);
 static uint64_t hashTypeGetNextTimeToExpire(robj *o);
+static uint64_t hashTypeGetMinExpire(robj *keyObj);
 
 /* hash dictType funcs */
 static int dictHfieldKeyCompare(dict *d, const void *key1, const void *key2);
@@ -2650,6 +2651,7 @@ static ExpireMeta* hfieldGetExpireMeta(const eItem field) {
     return mstrMetaRef(field, &mstrFieldKind, (int) HFIELD_META_EXPIRE);
 }
 
+/* returned value is unix time in milliseconds */
 uint64_t hfieldGetExpireTime(hfield field) {
     if (!hfieldIsExpireAttached(field))
         return EB_EXPIRE_TIME_INVALID;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -22,7 +22,6 @@ static void hexpireGenericCommand(client *c, const char *cmd, long long basetime
 static ExpireAction hashTypeActiveExpire(eItem hashObj, void *ctx);
 static void hfieldPersist(robj *hashObj, hfield field);
 static void updateGlobalHfeDs(redisDb *db, robj *o, uint64_t minExpire, uint64_t minExpireFields);
-static uint64_t hashTypeGetNextTimeToExpire(robj *o);
 
 /* hash dictType funcs */
 static int dictHfieldKeyCompare(dict *d, const void *key1, const void *key2);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1682,7 +1682,7 @@ void hashTypeConvertListpackEx(robj *o, int enc, ebuckets *hexpires) {
     }
 }
 
-/* NOTE: hexpires can be NULL (Won't attept to register in global HFE DS) */
+/* NOTE: hexpires can be NULL (Won't attempt to register in global HFE DS) */
 void hashTypeConvert(robj *o, int enc, ebuckets *hexpires) {
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
         hashTypeConvertListpack(o, enc);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1033,7 +1033,6 @@ SetExRes hashTypeSetEx(redisDb *db, robj *o, sds field, HashTypeSet *setKeyVal,
 
     /* If need to set value */
     if (isSetKeyValue) {
-        redisDebug("going to set value %s for field %s", setKeyVal->value, field);
         if (flags & HASH_SET_TAKE_VALUE) {
             dictSetVal(ht, de, setKeyVal->value);
             flags &= ~HASH_SET_TAKE_VALUE;
@@ -1091,16 +1090,6 @@ void initDictExpireMetadata(sds key, robj *o) {
  *
  * Don't have to provide client and "cmd". If provided, then notification once
  * done by function hashTypeSetExDone().
- *
- * NOTE: when calling from RDB reading process, the key is not yet available
- * in the DB. Therefore, it is not possible to retrieve a pointer to the key to
- * be used in the expire meta struct.
- * The expireMeta struct needs to hold a pointer to the key string that is
- * persistent for the key lifetime. When reading RDB, the key was already read
- * and the string it was read into will be later used in the DB. However,
- * if calling this function from any place else and using this flag, you'll need
- * to provide a key string in the key robj that will remain persistent for as
- * long as the key itself is.
  */
 int hashTypeSetExInit(robj *key, robj *o, client *c, redisDb *db, const char *cmd, FieldSetCond fieldSetCond,
                       FieldGet fieldGet, ExpireSetCond expireSetCond,
@@ -1693,7 +1682,7 @@ void hashTypeConvertListpackEx(robj *o, int enc, ebuckets *hexpires) {
     }
 }
 
-/* NOTE: hexpires might be NULL */
+/* NOTE: hexpires can be NULL (Won't attept to register in global HFE DS) */
 void hashTypeConvert(robj *o, int enc, ebuckets *hexpires) {
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
         hashTypeConvertListpack(o, enc);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -23,7 +23,6 @@ static ExpireAction hashTypeActiveExpire(eItem hashObj, void *ctx);
 static void hfieldPersist(robj *hashObj, hfield field);
 static void updateGlobalHfeDs(redisDb *db, robj *o, uint64_t minExpire, uint64_t minExpireFields);
 static uint64_t hashTypeGetNextTimeToExpire(robj *o);
-static uint64_t hashTypeGetMinExpire(robj *keyObj);
 
 /* hash dictType funcs */
 static int dictHfieldKeyCompare(dict *d, const void *key1, const void *key2);
@@ -326,6 +325,24 @@ static struct listpackEx *listpackExCreate(void) {
     return lpt;
 }
 
+void *listpackExCreateFromListpack(void *lp) {
+    listpackEx *lpt = zcalloc(sizeof(*lpt));
+    lpt->lp = lp;
+    lpt->meta.trash = 1;
+    lpt->key = NULL;
+    return lpt;
+}
+
+void *listpackExGetListpack(const robj *o) {
+    listpackEx *lpt = o->ptr;
+    return lpt->lp;
+}
+
+void listpackExUpdateListpack(const robj *o, void *lp) {
+    listpackEx *lpt = o->ptr;
+    lpt->lp = lp;
+}
+
 static void listpackExFree(listpackEx *lpt) {
     lpFree(lpt->lp);
     zfree(lpt);
@@ -385,7 +402,7 @@ static uint64_t listpackExGetMinExpire(robj *o) {
 }
 
 /* Walk over fields and delete the expired ones. */
-static void listpackExExpire(robj *o, ExpireInfo *info) {
+void listpackExExpire(robj *o, ExpireInfo *info, long long *expire_stat) {
     serverAssert(o->encoding == OBJ_ENCODING_LISTPACK_EX);
     uint64_t min = EB_EXPIRE_TIME_INVALID;
     unsigned char *ptr, *field, *s;
@@ -409,7 +426,7 @@ static void listpackExExpire(robj *o, ExpireInfo *info) {
         if (val == HASH_LP_NO_TTL || (uint64_t) val > info->now)
             break;
 
-        server.stat_expired_hash_fields++;
+        (*expire_stat)++;
         lpt->lp = lpDeleteRangeWithEntry(lpt->lp, &field, 3);
         ptr = field;
         info->itemsExpired++;
@@ -1816,8 +1833,7 @@ static ExpireAction hashTypeActiveExpire(eItem _hashObj, void *ctx) {
                 .now = commandTimeSnapshot(),
                 .itemsExpired = 0};
 
-        listpackExExpire(hashObj, &info);
-        keystr = ((listpackEx*)hashObj->ptr)->key;
+        listpackExExpire(hashObj, &info, &server.stat_expired_hash_fields);
     } else {
         serverAssert(hashObj->encoding == OBJ_ENCODING_HT);
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1686,6 +1686,7 @@ void hashTypeConvertListpackEx(robj *o, int enc, ebuckets *hexpires) {
     }
 }
 
+/* NOTE: hexpires might be NULL */
 void hashTypeConvert(robj *o, int enc, ebuckets *hexpires) {
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
         hashTypeConvertListpack(o, enc);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -967,6 +967,9 @@ SetExRes hashTypeSetExpiry(HashTypeSetEx *ex, sds field, uint64_t expireAt, dict
  *
  * Take care to call first hashTypeSetExInit() and then call this function.
  * Finally, call hashTypeSetExDone() to notify and update global HFE DS.
+ *
+ * NOTE: this functions is also called during RDB load to set dict-encoded
+ *       fields with and without expiration.
  */
 SetExRes hashTypeSetEx(redisDb *db, robj *o, sds field, HashTypeSet *setKeyVal,
                        uint64_t expireAt, HashTypeSetEx *exInfo)

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1888,6 +1888,7 @@ static ExpireAction hashTypeActiveExpire(eItem _hashObj, void *ctx) {
                 .itemsExpired = 0};
 
         listpackExExpire(hashObj, &info, &server.stat_expired_hash_fields);
+        keystr = ((listpackEx*)hashObj->ptr)->key;
     } else {
         serverAssert(hashObj->encoding == OBJ_ENCODING_HT);
 

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -581,7 +581,7 @@ foreach type {listpack dict} {
 
             r FLUSHALL
 
-            r HMSET key a 1 b 2 c 3 d 4
+            r HMSET key a 1 b 2 c 3 d 4 e 5 f 6
             r HEXPIREAT key 2524600800 2 a b
             r HPEXPIRE key 200 2 c d
 
@@ -596,8 +596,8 @@ foreach type {listpack dict} {
             assert_equal [s expired_hash_fields] 2
 
             # hgetall might lazy expire fields, so it's only called after the stat asserts
-            assert_equal [lsort [r hgetall key]] "1 2 a b"
-            assert_equal [r hexpiretime key 4 a b c d] {2524600800 2524600800 -2 -2}
+            assert_equal [lsort [r hgetall key]] "1 2 5 6 a b e f"
+            assert_equal [r hexpiretime key 6 a b c d e f] {2524600800 2524600800 -2 -2 -1 -1}
         }
     }
 }

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -441,10 +441,7 @@ start_server [list overrides [list "dir" $server_path]] {
             restart_server 0 true false
             wait_done_loading r
 
-            assert_equal [r hget key a] 1
-            assert_equal [r hget key b] 2
-            assert_equal [r hget key c] 3
-            assert_equal [r hget key d] {}
+            assert_equal [lsort [r hgetall key]] "1 2 3 a b c"
             assert_equal [r hexpiretime key 3 a b c] {2524600800 2524600800 -1}
         }
     }
@@ -527,10 +524,7 @@ test "save listpack, load dict" {
         r config set hash-max-listpack-entries 0
         r debug reload
 
-        assert_equal [r hget key a] 1
-        assert_equal [r hget key b] 2
-        assert_equal [r hget key c] 3
-        assert_equal [r hget key d] {}
+        assert_equal [lsort [r hgetall key]] "1 2 3 a b c"
         assert_match "*encoding:hashtable*" [r debug object key]
     }
 }
@@ -555,10 +549,7 @@ test "save dict, load listpack" {
         r config set hash-max-listpack-entries 512
         r debug reload
 
-        assert_equal [r hget key a] 1
-        assert_equal [r hget key b] 2
-        assert_equal [r hget key c] 3
-        assert_equal [r hget key d] {}
+        assert_equal [lsort [r hgetall key]] "1 2 3 a b c"
         assert_match "*encoding:listpack*" [r debug object key]
     }
 }

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -420,13 +420,9 @@ set server_path [tmpdir "server.partial-hfield-exp-test"]
 
 # verifies writing and reading hash key with expiring and persistent fields
 start_server [list overrides [list "dir" $server_path]] {
-    foreach type {listpack dict} {
+    foreach {type lp_entries} {listpack 512 dict 0} {
         test "hash field expiration save and load rdb one expired field, ($type)" {
-            if {$type eq "dict"} {
-                r config set hash-max-listpack-entries 0
-            } else {
-                r config set hash-max-listpack-entries 512
-            }
+            r config set hash-max-listpack-entries $lp_entries
 
             r FLUSHALL
 
@@ -456,13 +452,9 @@ set server_path [tmpdir "server.all-hfield-exp-test"]
 
 # verifies writing hash with several expired keys, and active-expiring it on load
 start_server [list overrides [list "dir" $server_path]] {
-    foreach type {listpack dict} {
+    foreach {type lp_entries} {listpack 512 dict 0} {
         test "hash field expiration save and load rdb all fields expired, ($type)" {
-            if {$type eq "dict"} {
-                r config set hash-max-listpack-entries 0
-            } else {
-                r config set hash-max-listpack-entries 512
-            }
+            r config set hash-max-listpack-entries $lp_entries
 
             r FLUSHALL
 
@@ -495,13 +487,9 @@ set server_path [tmpdir "server.long-ttl-test"]
 
 # verifies a long TTL value (6 bytes) is saved and loaded correctly
 start_server [list overrides [list "dir" $server_path]] {
-    foreach type {listpack dict} {
+    foreach {type lp_entries} {listpack 512 dict 0} {
         test "hash field expiration save and load rdb long TTL, ($type)" {
-            if {$type eq "dict"} {
-                r config set hash-max-listpack-entries 0
-            } else {
-                r config set hash-max-listpack-entries 512
-            }
+            r config set hash-max-listpack-entries $lp_entries
 
             r FLUSHALL
 
@@ -570,14 +558,10 @@ test "save dict, load listpack" {
 set server_path [tmpdir "server.active-expiry-after-load"]
 
 # verifies a field is correctly expired by active expiry AFTER loading from RDB
-foreach type {listpack dict} {
+foreach {type lp_entries} {listpack 512 dict 0} {
     start_server [list overrides [list "dir" $server_path enable-debug-command yes]] {
         test "active field expiry after load, ($type)" {
-            if {$type eq "dict"} {
-                r config set hash-max-listpack-entries 0
-            } else {
-                r config set hash-max-listpack-entries 512
-            }
+            r config set hash-max-listpack-entries $lp_entries
 
             r FLUSHALL
 
@@ -604,14 +588,10 @@ foreach type {listpack dict} {
 
 set server_path [tmpdir "server.lazy-expiry-after-load"]
 
-foreach type {listpack dict} {
+foreach {type lp_entries} {listpack 512 dict 0} {
     start_server [list overrides [list "dir" $server_path enable-debug-command yes]] {
         test "lazy field expiry after load, ($type)" {
-            if {$type eq "dict"} {
-                r config set hash-max-listpack-entries 0
-            } else {
-                r config set hash-max-listpack-entries 512
-            }
+            r config set hash-max-listpack-entries $lp_entries
             r debug set-active-expire 0
 
             r FLUSHALL
@@ -639,9 +619,10 @@ foreach type {listpack dict} {
 
 set server_path [tmpdir "server.unexpired-items-rax-list-boundary"]
 
-foreach type {listpack dict} {
+foreach {type lp_entries} {listpack 512 dict 0} {
     start_server [list overrides [list "dir" $server_path enable-debug-command yes]] {
         test "load un-expired items below and above rax-list boundary, ($type)" {
+            r config set hash-max-listpack-entries $lp_entries
 
             r flushall
 

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -570,8 +570,8 @@ test "save dict, load listpack" {
 set server_path [tmpdir "server.active-expiry-after-load"]
 
 # verifies a field is correctly expired by active expiry AFTER loading from RDB
-start_server [list overrides [list "dir" $server_path]] {
-    foreach type {listpack dict} {
+foreach type {listpack dict} {
+    start_server [list overrides [list "dir" $server_path enable-debug-command yes]] {
         test "active field expiry after load, ($type)" {
             if {$type eq "dict"} {
                 r config set hash-max-listpack-entries 0
@@ -586,8 +586,7 @@ start_server [list overrides [list "dir" $server_path]] {
             r HPEXPIRE key 200 2 c d
 
             r save
-            restart_server 0 true false
-            wait_done_loading r
+            r debug reload
 
             # sleep 1 sec to make sure 'c' and 'd' will active-expire
             after 1000

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -484,7 +484,7 @@ start_server [list overrides [list "dir" $server_path]] {
                 assert_equal [s rdb_last_load_hash_fields_expired] 0
             }
 
-            # in listpack encoding, the fileds (and key) will be expired by
+            # in listpack encoding, the fields (and key) will be expired by
             # lazy expiry
             assert_equal [r hgetall key] {}
         }
@@ -571,7 +571,7 @@ set server_path [tmpdir "server.active-expiry-after-load"]
 
 # verifies a field is correctly expired by active expiry AFTER loading from RDB
 start_server [list overrides [list "dir" $server_path]] {
-    foreach type {listapck dict} {
+    foreach type {listpack dict} {
         test "active field expiry after load, ($type)" {
             if {$type eq "dict"} {
                 r config set hash-max-listpack-entries 0

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -419,7 +419,6 @@ start_server {} {
 set server_path [tmpdir "server.partial-hfield-exp-test"]
 
 # verifies writing and reading hash key with expiring and persistent fields
-# TODO: re-visit when removing active expiration on load for listpack
 start_server [list overrides [list "dir" $server_path]] {
     foreach type {listpack dict} {
         test "hash field expiration save and load rdb one expired field, ($type)" {
@@ -450,7 +449,6 @@ start_server [list overrides [list "dir" $server_path]] {
 set server_path [tmpdir "server.all-hfield-exp-test"]
 
 # verifies writing hash with several expired keys, and active-expiring it on load
-# TODO: re-visit when removing active expiration on load for listpack
 start_server [list overrides [list "dir" $server_path]] {
     foreach type {listpack dict} {
         test "hash field expiration save and load rdb all fields expired, ($type)" {
@@ -477,7 +475,7 @@ start_server [list overrides [list "dir" $server_path]] {
     }
 }
 
-set server_path [tmpdir "server.all-hfield-exp-test"]
+set server_path [tmpdir "server.long-ttl-test"]
 
 # verifies a long TTL value (6 bytes) is saved and loaded correctly
 start_server [list overrides [list "dir" $server_path]] {
@@ -524,14 +522,13 @@ test "save listpack, load dict" {
         r config set hash-max-listpack-entries 0
         r debug reload
 
-        assert_equal [lsort [r hgetall key]] "1 2 3 a b c"
+        assert_equal [lsort [r hgetall key]] "1 2 3 4 a b c d"
         assert_match "*encoding:hashtable*" [r debug object key]
     }
 }
 
 set server_path [tmpdir "server.dict-to-listpack-test"]
 
-# TODO: re-visit when removing active expiration on load for listpack
 test "save dict, load listpack" {
     start_server [list overrides [list "dir" $server_path  enable-debug-command yes]] {
         r config set hash-max-listpack-entries 0

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -438,8 +438,14 @@ proc csvdump r {
                 hash {
                     set fields [{*}$r hgetall $k]
                     set newfields {}
-                    foreach {k v} $fields {
-                        lappend newfields [list $k $v]
+                    foreach {f v} $fields {
+                        set expirylist [{*}$r hexpiretime $k 1 $f]
+                        if {$expirylist eq (-1)} {
+                            lappend newfields [list $f $v]
+                        } else {
+                            set e [lindex $expirylist 0]
+                            lappend newfields [list $f $e $v] # TODO: extract the actual ttl value from the list in $e
+                        }
                     }
                     set fields [lsort -index 0 $newfields]
                     foreach kv $fields {


### PR DESCRIPTION
Add RDB de/serialization for HFE

This PR adds two new RDB types: `RDB_TYPE_HASH_METADATA` and `RDB_TYPE_HASH_LISTPACK_TTL` to save HFE data.
When the hash RAM encoding is dict, it will be saved in the former, and when it is listpack it will be saved in the latter.
Both formats just add the TTL value for each field after the data that was previously saved, i.e HASH_METADATA will save the number of entries and, for each entry, key, value and TTL, whereas listpack is saved as a blob.
On read, the usual dict <--> listpack conversion takes place if required.
In addition, when reading a hash that was saved as a dict fields are actively expired if expiry is due. Currently this slao holds for listpack encoding, but it is supposed to be removed.

Until Ozan's listpack implementation will be merged to the integ branch, review should be done by commits.

TODO:
Remove active expiry on load when loading from listpack format (unless we'll decide to keep it)