### PR TITLE
Fix test failure due to differing reply format of XREADGROUP under RESP3 in MULTI

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -1150,3 +1150,12 @@ proc system_backtrace_supported {} {
     }
     return 0
 }
+
+# Check if something is a dict.
+# From https://wiki.tcl-lang.org/page/isDict.
+proc is_dict {d} {
+    expr {[string is list $d]
+        && !([llength $d] % 2)
+        && ((2 * [llength [dict keys $d]]) == [llength $d])
+    }
+}

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -1150,12 +1150,3 @@ proc system_backtrace_supported {} {
     }
     return 0
 }
-
-# Check if something is a dict.
-# From https://wiki.tcl-lang.org/page/isDict.
-proc is_dict {d} {
-    expr {[string is list $d]
-        && !([llength $d] % 2)
-        && ((2 * [llength [dict keys $d]]) == [llength $d])
-    }
-}

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -1395,16 +1395,26 @@ start_server {
         test {XREADGROUP from PEL inside MULTI} {
             # This scenario used to cause propagation of EXEC without MULTI in 6.2
             $replica config set propagation-error-behavior panic
-            $master hello 3
             $master del mystream
             $master xadd mystream 1-0 a b c d e f
             $master xgroup create mystream mygroup 0
             $master xreadgroup group mygroup ryan count 1 streams mystream >
             $master multi
             $master xreadgroup group mygroup ryan count 1 streams mystream 0
-            set reply [$master exec]
+            set reply [lindex [$master exec] 0]
+            # If using RESP3, we transform a map response into array of tuples
+            # to ensure consistency with RESP2 response.
+            if {[is_dict $reply]} {
+                set tuparray {}
+                foreach {key val} $reply {
+                    set tmp {}
+                    lappend tmp $key
+                    lappend tmp $val
+                    lappend tuparray $tmp
+                }
+                set reply $tuparray
+            }
             assert_equal $reply {{mystream {{1-0 {a b c d e f}}}}}
-            $master hello 2
         }
     }
 

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -1398,23 +1398,10 @@ start_server {
             $master del mystream
             $master xadd mystream 1-0 a b c d e f
             $master xgroup create mystream mygroup 0
-            $master xreadgroup group mygroup ryan count 1 streams mystream >
+            assert_equal [$master xreadgroup group mygroup ryan count 1 streams mystream >] {{mystream {{1-0 {a b c d e f}}}}}
             $master multi
             $master xreadgroup group mygroup ryan count 1 streams mystream 0
-            set reply [lindex [$master exec] 0]
-            # If using RESP3, we transform a map response into array of tuples
-            # to ensure consistency with RESP2 response.
-            if {[is_dict $reply]} {
-                set tuparray {}
-                foreach {key val} $reply {
-                    set tmp {}
-                    lappend tmp $key
-                    lappend tmp $val
-                    lappend tuparray $tmp
-                }
-                set reply $tuparray
-            }
-            assert_equal $reply {{mystream {{1-0 {a b c d e f}}}}}
+            $master exec
         }
     }
 

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -1395,6 +1395,7 @@ start_server {
         test {XREADGROUP from PEL inside MULTI} {
             # This scenario used to cause propagation of EXEC without MULTI in 6.2
             $replica config set propagation-error-behavior panic
+            $master hello 3
             $master del mystream
             $master xadd mystream 1-0 a b c d e f
             $master xgroup create mystream mygroup 0
@@ -1402,7 +1403,8 @@ start_server {
             $master multi
             $master xreadgroup group mygroup ryan count 1 streams mystream 0
             set reply [$master exec]
-            assert_equal $reply {{{mystream {{1-0 {a b c d e f}}}}}}
+            assert_equal $reply {{mystream {{1-0 {a b c d e f}}}}}
+            $master hello 2
         }
     }
 


### PR DESCRIPTION
This test was introducted by #13251.
Normally we auto transform the reply format of XREADGROUP to array under RESP3 (see trasformer_funcs).
But when we execute XREADGROUP command in multi it can't work, which cause the new test failed.
The solution is to verity the reply of XREADGROUP in advance rather than in MULTI.

Failed validate schema CI: https://github.com/redis/redis/actions/runs/9025128323/job/24800285684