### PR TITLE
Fix some memory leaks in redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3593,7 +3593,7 @@ static int evalMode(int argc, char **argv) {
         /* Call it */
         int eval_ldb = config.eval_ldb; /* Save it, may be reverted. */
         retval = issueCommand(argc+3-got_comma, argv2);
-        for (j = 0; j < argc+3-got_comma; j++) sdsfree(argv2[i]);
+        for (j = 0; j < argc+3-got_comma; j++) sdsfree(argv2[j]);
         free(argv2);
         if (eval_ldb) {
             if (!config.eval_ldb) {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3593,6 +3593,7 @@ static int evalMode(int argc, char **argv) {
         /* Call it */
         int eval_ldb = config.eval_ldb; /* Save it, may be reverted. */
         retval = issueCommand(argc+3-got_comma, argv2);
+        free(argv2);
         if (eval_ldb) {
             if (!config.eval_ldb) {
                 /* If the debugging session ended immediately, there was an

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3593,7 +3593,7 @@ static int evalMode(int argc, char **argv) {
         /* Call it */
         int eval_ldb = config.eval_ldb; /* Save it, may be reverted. */
         retval = issueCommand(argc+3-got_comma, argv2);
-        for (j = 0; i < argc+3-got_comma; i++) sdsfree(argv2[i]);
+        for (j = 0; j < argc+3-got_comma; j++) sdsfree(argv2[i]);
         free(argv2);
         if (eval_ldb) {
             if (!config.eval_ldb) {

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -5978,6 +5978,7 @@ static int clusterManagerFixSlotsCoverage(char *all_slots) {
                 if (!clusterManagerCheckRedisReply(n, reply, NULL)) {
                     fixed = -1;
                     if (reply) freeReplyObject(reply);
+                    if (slot_nodes) listRelease(slot_nodes);
                     goto cleanup;
                 }
                 assert(reply->type == REDIS_REPLY_ARRAY);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3593,6 +3593,7 @@ static int evalMode(int argc, char **argv) {
         /* Call it */
         int eval_ldb = config.eval_ldb; /* Save it, may be reverted. */
         retval = issueCommand(argc+3-got_comma, argv2);
+        for (j = 0; i < argc+3-got_comma; i++) sdsfree(argv2[i]);
         free(argv2);
         if (eval_ldb) {
             if (!config.eval_ldb) {


### PR DESCRIPTION
Fix memory leak related to variable slot_nodes in the clusterManagerFixSlotsCoverage() function