### PR TITLE
Revert "Change mmap rand bits as a temporary mitigation to resolve asan bug (#13150)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,7 @@ jobs:
         # build with TLS module just for compilation coverage
         run: make SANITIZER=address REDIS_CFLAGS='-Werror -DDEBUG_ASSERTIONS' BUILD_TLS=module
       - name: testprep
-        # Work around ASAN issue, see https://github.com/google/sanitizers/issues/1716
-        run: |
-          sudo apt-get install tcl8.6 tclx -y
-          sudo sysctl vm.mmap_rnd_bits=28
+        run: sudo apt-get install tcl8.6 tclx -y
       - name: test
         run: ./runtest --verbose --tags -slow --dump-logs
       - name: module api test

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -589,11 +589,9 @@ jobs:
       - name: make
         run: make SANITIZER=address REDIS_CFLAGS='-DREDIS_TEST -Werror -DDEBUG_ASSERTIONS'
       - name: testprep
-        # Work around ASAN issue, see https://github.com/google/sanitizers/issues/1716
         run: |
           sudo apt-get update
           sudo apt-get install tcl8.6 tclx -y
-          sudo sysctl vm.mmap_rnd_bits=28
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'redis')
         run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}


### PR DESCRIPTION
The kernel config `vm.mmap_rnd_bits` had been revert in https://github.com/actions/runner-images/issues/9491, so we can revert the changes from #13150.

CI only with ASAN passed: https://github.com/sundb/redis/actions/runs/9058263634