### PR TITLE
Free current client asynchronously after user permissions changes

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -485,15 +485,7 @@ void ACLFreeUserAndKillClients(user *u) {
              * this may result in some security hole: it's much
              * more defensive to set the default user and put
              * it in non authenticated mode. */
-            c->user = DefaultUser;
-            c->authenticated = 0;
-            /* We will write replies to this client later, so we can't
-             * close it directly even if async. */
-            if (c == server.current_client) {
-                c->flags |= CLIENT_CLOSE_AFTER_COMMAND;
-            } else {
-                freeClientAsync(c);
-            }
+            deauthenticateAndCloseClient(c);
         }
     }
     ACLFreeUser(u);
@@ -2010,7 +2002,7 @@ void ACLKillPubsubClientsIfNeeded(user *new, user *original) {
         if (c->user != original)
             continue;
         if (ACLShouldKillPubsubClient(c, channels))
-            freeClient(c);
+            deauthenticateAndCloseClient(c);
     }
 
     listRelease(channels);
@@ -2433,6 +2425,9 @@ sds ACLLoadFromFile(const char *filename) {
         listRewind(server.clients,&li);
         while ((ln = listNext(&li)) != NULL) {
             client *c = listNodeValue(ln);
+            /* a MASTER client can do everything (and user = NULL) so we can skip it */
+            if (c->flags & CLIENT_MASTER)
+                continue;
             user *original = c->user;
             list *channels = NULL;
             user *new = ACLGetUserByName(c->user->name, sdslen(c->user->name));
@@ -2444,7 +2439,7 @@ sds ACLLoadFromFile(const char *filename) {
             }
             /* When the new channel list is NULL, it means the new user's channel list is a superset of the old user's list. */
             if (!new || (channels && ACLShouldKillPubsubClient(c, channels))) {
-                freeClient(c);
+                deauthenticateAndCloseClient(c);
                 continue;
             }
             c->user = new;

--- a/src/module.c
+++ b/src/module.c
@@ -9537,15 +9537,7 @@ void revokeClientAuthentication(client *c) {
      * is eventually freed we don't rely on the module to still exist. */
     moduleNotifyUserChanged(c);
 
-    c->user = DefaultUser;
-    c->authenticated = 0;
-    /* We will write replies to this client later, so we can't close it
-     * directly even if async. */
-    if (c == server.current_client) {
-        c->flags |= CLIENT_CLOSE_AFTER_COMMAND;
-    } else {
-        freeClientAsync(c);
-    }
+    deauthenticateAndCloseClient(c);
 }
 
 /* Cleanup all clients that have been authenticated with this module. This

--- a/src/networking.c
+++ b/src/networking.c
@@ -1541,6 +1541,18 @@ void clearClientConnectionState(client *c) {
                   CLIENT_REPLY_SKIP_NEXT|CLIENT_NO_TOUCH|CLIENT_NO_EVICT);
 }
 
+void deauthenticateAndCloseClient(client *c) {
+    c->user = DefaultUser;
+    c->authenticated = 0;
+    /* We will write replies to this client later, so we can't
+     * close it directly even if async. */
+    if (c == server.current_client) {
+        c->flags |= CLIENT_CLOSE_AFTER_COMMAND;
+    } else {
+        freeClientAsync(c);
+    }
+}
+
 void freeClient(client *c) {
     listNode *ln;
 

--- a/src/server.h
+++ b/src/server.h
@@ -2555,6 +2555,7 @@ void redisSetCpuAffinity(const char *cpulist);
 client *createClient(connection *conn);
 void freeClient(client *c);
 void freeClientAsync(client *c);
+void deauthenticateAndCloseClient(client *c);
 void logInvalidUseAndFreeClientAsync(client *c, const char *fmt, ...);
 int beforeNextClient(client *c);
 void clearClientConnectionState(client *c);


### PR DESCRIPTION
The crash happens when the user that triggers the permission changes should be affected (and should be disconnected eventually).

To handle such a scenario, we should use the `CLIENT_CLOSE_AFTER_COMMAND` flag.

This commit encapsulates all the places that should be handled in the same way in `deauthenticateAndCloseClient`

Also:
* bugfix: during the ACL LOAD we ignore clients that are marked as `CLIENT MASTER`