### PR TITLE
Add Statistics hashes_with_expiry_fields to INFO

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6104,14 +6104,16 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         if (sections++) info = sdscat(info,"\r\n");
         info = sdscatprintf(info, "# Keyspace\r\n");
         for (j = 0; j < server.dbnum; j++) {
-            long long keys, vkeys;
+            long long keys, vkeys, hexpires;
 
             keys = kvstoreSize(server.db[j].keys);
             vkeys = kvstoreSize(server.db[j].expires);
+            hexpires = ebGetTotalItems(server.db[j].hexpires, &hashExpireBucketsType);
+
             if (keys || vkeys) {
                 info = sdscatprintf(info,
-                    "db%d:keys=%lld,expires=%lld,avg_ttl=%lld\r\n",
-                    j, keys, vkeys, server.db[j].avg_ttl);
+                    "db%d:keys=%lld,expires=%lld,avg_ttl=%lld,hashes_with_expiry_fields=%lld\r\n",
+                    j, keys, vkeys, server.db[j].avg_ttl, hexpires);
             }
         }
     }

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -1255,7 +1255,6 @@ start_server {tags {"external:skip needs:debug"}} {
         r hset myhash f1 v1 f2 v2 f3 v3 f4 v4 f5 v5
         r hpexpire myhash 100 1 f1 f2 f3
 
-        puts [s db:9]
         assert_match  [get_hashes_with_expiry_fields r] 1
         r hset myhash2 f1 v1 f2 v2 f3 v3 f4 v4 f5 v5
         assert_match  [get_hashes_with_expiry_fields r] 1

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -24,6 +24,19 @@ set S_FIELD_AND_TTL 3
 
 ############################### AUX FUNCS ######################################
 
+proc get_hashes_with_expiry_fields {r} {
+    set input_string [r info keyspace]
+    set hash_count 0
+
+    foreach line [split $input_string \n] {
+        if {[regexp {hashes_with_expiry_fields=(\d+)} $line -> value]} {
+            return $value
+        }
+    }
+
+    return 0
+}
+
 proc create_hash {key entries} {
     r del $key
     foreach entry $entries {
@@ -1234,5 +1247,25 @@ start_server {tags {"external:skip needs:debug"}} {
         assert_equal [lsort [r hgetall myhash]] [lsort "f2 f3 f4 v2 $payload1 v4"]
 
         r config set hash-max-listpack-value 64
+    }
+
+    test "Statistics - Hashes with HFEs" {
+        r config resetstat
+        r del myhash
+        r hset myhash f1 v1 f2 v2 f3 v3 f4 v4 f5 v5
+        r hpexpire myhash 100 1 f1 f2 f3
+
+        puts [s db:9]
+        assert_match  [get_hashes_with_expiry_fields r] 1
+        r hset myhash2 f1 v1 f2 v2 f3 v3 f4 v4 f5 v5
+        assert_match  [get_hashes_with_expiry_fields r] 1
+        r hpexpire myhash2 100 1 f1 f2 f3
+        assert_match  [get_hashes_with_expiry_fields r] 2
+
+        wait_for_condition 50 50 {
+                [get_hashes_with_expiry_fields r] == 0
+        } else {
+                fail "Hash field expiry statistics failed"
+        }
     }
 }


### PR DESCRIPTION
Added hashes_with_expiry_fields.
Optimially it would better to have statistic of that counts all fields with expiry. But it requires careful logic and  computation to follow and deep dive listpacks and hashes. This statistics is trivial to achieve and reflected by global HFE DS that has builtin enumeration of all the hashes that are registered in it.