### PR TITLE
Fix hfe RDB tests by adding FIELDS keyword to hexpire commands

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -439,7 +439,7 @@ proc csvdump r {
                     set fields [{*}$r hgetall $k]
                     set newfields {}
                     foreach {f v} $fields {
-                        set expirylist [{*}$r hexpiretime $k 1 $f]
+                        set expirylist [{*}$r hexpiretime $k FIELDS 1 $f]
                         if {$expirylist eq (-1)} {
                             lappend newfields [list $f $v]
                         } else {


### PR DESCRIPTION
FIELDS keyword was added as part of [#13270](https://github.com/redis/redis/pull/13270). It was missing in [#13243](https://github.com/redis/redis/pull/13243)