### PR TITLE
Improve performance of hfe listpack

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -786,7 +786,7 @@ unsigned char *lpFind(unsigned char *lp, unsigned char *p, unsigned char *s,
  * The element is inserted before, after, or replaces the element pointed
  * by 'p' depending on the 'where' argument, that can be LP_BEFORE, LP_AFTER
  * or LP_REPLACE.
- *
+ * 
  * If both 'elestr' and `eleint` are NULL, the function removes the element
  * pointed by 'p' instead of inserting one.
  * If `eleint` is non-NULL, 'size' is the length of 'eleint', the function insert

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -938,7 +938,6 @@ unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
 
     /* Update header. */
     if (n_added != n_deleted) {
-        assert(len < INT64_MAX);
         int64_t diff = (int64_t) n_added - (int64_t) n_deleted;
 
         uint32_t num_elements = lpGetNumElements(lp);

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1031,13 +1031,14 @@ unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
             lpEncodeIntegerGetType(e->lval, enc[i].intenc, &enc[i].enclen);
         }
         addedlen += enc[i].enclen;
+
+        /* We need to also encode the backward-parsable length of the element
+         * and append it to the end: this allows to traverse the listpack from
+         * the end to the start. */
         enc[i].backlen_size = lpEncodeBacklen(enc[i].backlen, enc[i].enclen);
         addedlen += enc[i].backlen_size;
     }
 
-    /* We need to also encode the backward-parsable length of the element
-     * and append it to the end: this allows to traverse the listpack from
-     * the end to the start. */
     uint64_t old_listpack_bytes = lpGetTotalBytes(lp);
     uint64_t new_listpack_bytes = old_listpack_bytes + addedlen;
     if (new_listpack_bytes > UINT32_MAX) return NULL;

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -18,8 +18,6 @@
 #include <stdint.h>
 
 #define LP_INTBUF_SIZE 21 /* 20 digits of -2^63 + 1 null term = 21. */
-#define LP_MAX_BACKLEN_SIZE 5
-#define LP_MAX_INT_ENCODING_LEN 9
 
 /* lpInsert() where argument possible values: */
 #define LP_BEFORE 0
@@ -33,13 +31,6 @@ typedef struct {
     uint32_t slen;
     /* When integer is used, 'sval' is NULL, and lval holds the value. */
     long long lval;
-
-    /* These variables are used internally by lpInsert() */
-    int enctype;
-    uint64_t enclen;
-    unsigned char intenc[LP_MAX_INT_ENCODING_LEN];
-    unsigned long backlen_size;
-    unsigned char backlen[LP_MAX_BACKLEN_SIZE];
 } listpackEntry;
 
 unsigned char *lpNew(size_t capacity);
@@ -60,7 +51,7 @@ unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsi
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num);
 unsigned char *lpBatchAppend(unsigned char *lp, listpackEntry *entries, unsigned long len);
 unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
-                             listpackEntry *entries, unsigned long len, unsigned char **newp);
+                             listpackEntry *entries, unsigned int len, unsigned char **newp);
 unsigned char *lpBatchDelete(unsigned char *lp, unsigned char **ps, unsigned long count);
 unsigned char *lpMerge(unsigned char **first, unsigned char **second);
 unsigned char *lpDup(unsigned char *lp);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -18,6 +18,8 @@
 #include <stdint.h>
 
 #define LP_INTBUF_SIZE 21 /* 20 digits of -2^63 + 1 null term = 21. */
+#define LP_MAX_BACKLEN_SIZE 5
+#define LP_MAX_INT_ENCODING_LEN 9
 
 /* lpInsert() where argument possible values: */
 #define LP_BEFORE 0
@@ -31,6 +33,13 @@ typedef struct {
     uint32_t slen;
     /* When integer is used, 'sval' is NULL, and lval holds the value. */
     long long lval;
+
+    /* These variables are used internally by lpInsert() */
+    int enctype;
+    uint64_t enclen;
+    unsigned char intenc[LP_MAX_INT_ENCODING_LEN];
+    unsigned long backlen_size;
+    unsigned char backlen[LP_MAX_BACKLEN_SIZE];
 } listpackEntry;
 
 unsigned char *lpNew(size_t capacity);
@@ -49,6 +58,9 @@ unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long 
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp);
 unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsigned long num);
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num);
+unsigned char *lpBatchAppend(unsigned char *lp, listpackEntry *entries, unsigned long len);
+unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
+                             listpackEntry *entries, unsigned long len, unsigned char **newp);
 unsigned char *lpBatchDelete(unsigned char *lp, unsigned char **ps, unsigned long count);
 unsigned char *lpMerge(unsigned char **first, unsigned char **second);
 unsigned char *lpDup(unsigned char *lp);
@@ -56,6 +68,8 @@ unsigned long lpLength(unsigned char *lp);
 unsigned char *lpGet(unsigned char *p, int64_t *count, unsigned char *intbuf);
 unsigned char *lpGetValue(unsigned char *p, unsigned int *slen, long long *lval);
 unsigned char *lpFind(unsigned char *lp, unsigned char *p, unsigned char *s, uint32_t slen, unsigned int skip);
+typedef int (*lpCmp)(const unsigned char *lp, unsigned char *p, void *user, unsigned char *s, long long slen);
+unsigned char *lpFindCb(unsigned char *lp, unsigned char *p, void *user, lpCmp cmp, unsigned int skip);
 unsigned char *lpFirst(unsigned char *lp);
 unsigned char *lpLast(unsigned char *lp);
 unsigned char *lpNext(unsigned char *lp, unsigned char *p);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -342,7 +342,7 @@ struct lpFingArgs {
  * active expiry or when trying to find the position for the new field according
  * to its expiry time.*/
 static int cbFindInListpack(const unsigned char *lp, unsigned char *p,
-                              void *user, unsigned char *s, long long slen)
+                            void *user, unsigned char *s, long long slen)
 {
     (void) lp;
     struct lpFingArgs *r = user;
@@ -376,8 +376,8 @@ static uint64_t listpackExExpireDryRun(const robj *o) {
     listpackEx *lpt = o->ptr;
 
     struct lpFingArgs r = {
-            .max_to_search = UINT64_MAX,
-            .expire_time = commandTimeSnapshot(),
+        .max_to_search = UINT64_MAX,
+        .expire_time = commandTimeSnapshot(),
     };
 
     lpFindCb(lpt->lp, NULL, &r, cbFindInListpack, 0);
@@ -414,8 +414,8 @@ void listpackExExpire(robj *o, ExpireInfo *info) {
     listpackEx *lpt = o->ptr;
 
     struct lpFingArgs r = {
-            .max_to_search = info->maxToExpire,
-            .expire_time = info->now
+        .max_to_search = info->maxToExpire,
+        .expire_time = info->now
     };
 
     lpFindCb(lpt->lp, NULL, &r, cbFindInListpack, 0);
@@ -457,9 +457,9 @@ static void listpackExAddInternal(robj *o, listpackEntry ent[3]) {
 /* Add new field ordered by expire time. */
 void listpackExAddNew(robj *o, sds field, sds value, uint64_t expireAt) {
     listpackEntry ent[3] = {
-            {.sval = (unsigned char*) field, .slen = sdslen(field)},
-            {.sval = (unsigned char*) value, .slen = sdslen(value)},
-            {.lval = expireAt}
+        {.sval = (unsigned char*) field, .slen = sdslen(field)},
+        {.sval = (unsigned char*) value, .slen = sdslen(value)},
+        {.lval = expireAt}
     };
 
     listpackExAddInternal(o, ent);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -350,7 +350,7 @@ static int cbFindInListpack(const unsigned char *lp, unsigned char *p,
     r->index++;
 
     if (r->max_to_search == 0)
-        return 1;
+        return 0; /* Break the loop and return */
 
     if (r->index % 3 == 1) {
         r->fptr = p;  /* First item of the tuple. */
@@ -358,15 +358,15 @@ static int cbFindInListpack(const unsigned char *lp, unsigned char *p,
         serverAssert(!s);
 
         /* Third item of a tuple is expiry time */
-        if (slen == HASH_LP_NO_TTL || (uint64_t) slen >= r->expire_time ) {
+        if (slen == HASH_LP_NO_TTL || (uint64_t) slen >= r->expire_time) {
             r->p = r->fptr;
-            return 1;
+            return 0; /* Break the loop and return */
         }
         r->expired++;
         r->max_to_search--;
     }
 
-    return 0;
+    return 1;
 }
 
 /* Returns number of expired fields. */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -329,34 +329,59 @@ static void listpackExFree(listpackEx *lpt) {
     zfree(lpt);
 }
 
+struct lpFingArgs {
+    uint64_t max_to_search; /* [in] Max number of tuples to search */
+    uint64_t expire_time;   /* [in] Find the tuple that has a TTL larger than expire_time */
+    unsigned char *p;       /* [out] First item of the tuple that has a TTL larger than expire_time */
+    int expired;            /* [out] Number of tuples that have TTLs less than expire_time */
+    int index;              /* Internally used */
+    unsigned char *fptr;    /* Internally used, temp ptr */
+};
+
+/* Callback for lpFindCb(). Used to find number of expired fields as part of
+ * active expiry or when trying to find the position for the new field according
+ * to its expiry time.*/
+static int cbFindInListpack(const unsigned char *lp, unsigned char *p,
+                              void *user, unsigned char *s, long long slen)
+{
+    (void) lp;
+    struct lpFingArgs *r = user;
+
+    r->index++;
+
+    if (r->max_to_search == 0)
+        return 1;
+
+    if (r->index % 3 == 1) {
+        r->fptr = p;  /* First item of the tuple. */
+    } else if (r->index % 3 == 0) {
+        serverAssert(!s);
+
+        /* Third item of a tuple is expiry time */
+        if (slen == HASH_LP_NO_TTL || (uint64_t) slen >= r->expire_time ) {
+            r->p = r->fptr;
+            return 1;
+        }
+        r->expired++;
+        r->max_to_search--;
+    }
+
+    return 0;
+}
+
 /* Returns number of expired fields. */
 static uint64_t listpackExExpireDryRun(const robj *o) {
     serverAssert(o->encoding == OBJ_ENCODING_LISTPACK_EX);
 
-    uint64_t expired = 0;
-    unsigned char *fptr, *s;
     listpackEx *lpt = o->ptr;
 
-    fptr = lpFirst(lpt->lp);
-    while (fptr != NULL) {
-        long long val;
+    struct lpFingArgs r = {
+            .max_to_search = UINT64_MAX,
+            .expire_time = commandTimeSnapshot(),
+    };
 
-        fptr = lpNext(lpt->lp, fptr);
-        serverAssert(fptr);
-        fptr = lpNext(lpt->lp, fptr);
-        serverAssert(fptr);
-
-        s = lpGetValue(fptr, NULL, &val);
-        serverAssert(!s);
-
-        if (!hashTypeIsExpired(o, val))
-            break;
-
-        expired++;
-        fptr = lpNext(lpt->lp, fptr);
-    }
-
-    return expired;
+    lpFindCb(lpt->lp, NULL, &r, cbFindInListpack, 0);
+    return r.expired;
 }
 
 /* Returns the expiration time of the item with the nearest expiration. */
@@ -386,77 +411,58 @@ static uint64_t listpackExGetMinExpire(robj *o) {
 void listpackExExpire(robj *o, ExpireInfo *info) {
     serverAssert(o->encoding == OBJ_ENCODING_LISTPACK_EX);
     uint64_t min = EB_EXPIRE_TIME_INVALID;
-    unsigned char *ptr, *field, *s;
     listpackEx *lpt = o->ptr;
 
-    ptr = lpFirst(lpt->lp);
-    while (ptr != NULL && (info->itemsExpired < info->maxToExpire)) {
-        long long val;
+    struct lpFingArgs r = {
+            .max_to_search = info->maxToExpire,
+            .expire_time = info->now
+    };
 
-        field = ptr;
-        ptr = lpNext(lpt->lp, ptr);
-        serverAssert(ptr);
-        ptr = lpNext(lpt->lp, ptr);
-        serverAssert(ptr);
+    lpFindCb(lpt->lp, NULL, &r, cbFindInListpack, 0);
+    info->itemsExpired += r.expired;
 
-        s = lpGetValue(ptr, NULL, &val);
-        serverAssert(!s);
-
-        /* Fields are ordered by expiry time. If we reached to a non-expired
-         * field or a non-volatile field, we know rest is not yet expired. */
-        if (val == HASH_LP_NO_TTL || (uint64_t) val > info->now)
-            break;
-
-        lpt->lp = lpDeleteRangeWithEntry(lpt->lp, &field, 3);
-        ptr = field;
-        info->itemsExpired++;
-    }
+    /* Delete all the expired fields in one go */
+    if (r.expired > 0)
+        lpt->lp = lpDeleteRange(lpt->lp, 0, r.expired * 3);
 
     min = hashTypeGetNextTimeToExpire(o);
     info->nextExpireTime = (min != EB_EXPIRE_TIME_INVALID) ? min : 0;
 }
 
-/* Remove TTL from the field. */
-static void listpackExPersist(robj *o, sds field, unsigned char *fptr,
-                              unsigned char *vptr)
-{
-    serverAssert(o->encoding == OBJ_ENCODING_LISTPACK_EX);
-
-    unsigned char tmp[512];
-    unsigned int slen;
-    long long val;
-    unsigned char *s;
-    sds p = NULL;
+static void listpackExAddInternal(robj *o, listpackEntry ent[3]) {
     listpackEx *lpt = o->ptr;
 
-    /* To persist a field, we have to delete it first and append to the end as
-     * we want to maintain order by expiry time. Before deleting it, copy the
-     * value if it is stored as string. */
-    s = lpGetValue(vptr, &slen, &val);
-    if (s) {
-        /* Normally, item length in the listpack is limited by
-         * 'hash-max-listpack-value' config. It is unlikely, but it might be
-         * larger than sizeof(tmp). */
-        if (slen > sizeof(tmp))
-            p = sdsnewlen(s, slen);
-        else
-            memcpy(tmp, s, slen);
+    /* Shortcut, just append at the end if this is a non-volatile field. */
+    if (ent[2].lval == HASH_LP_NO_TTL) {
+        lpt->lp = lpBatchAppend(lpt->lp, ent, 3);
+        return;
     }
 
-    /* Delete field name, value and expiry time.  */
-    lpt->lp = lpDeleteRangeWithEntry(lpt->lp, &fptr, 3);
+    struct lpFingArgs r = {
+            .max_to_search = UINT64_MAX,
+            .expire_time = ent[2].lval,
+    };
 
-    /* Append field to the end as it does not have expiry time. */
-    lpt->lp = lpAppend(lpt->lp, (unsigned char*)field, sdslen(field));
+    /* Check if there is a field with a larger TTL. */
+    lpFindCb(lpt->lp, NULL, &r, cbFindInListpack, 0);
 
-    if (s)
-        lpt->lp = lpAppend(lpt->lp, p ? (unsigned char*) p : tmp, slen);
+    /* If list is empty or there is no field with a larger TTL, result will be
+     * NULL. Otherwise, just insert before the found item.*/
+    if (r.p)
+        lpt->lp = lpBatchInsert(lpt->lp, r.p, LP_BEFORE, ent, 3, NULL);
     else
-        lpt->lp = lpAppendInteger(lpt->lp, val);
+        lpt->lp = lpBatchAppend(lpt->lp, ent, 3);
+}
 
-    lpt->lp = lpAppendInteger(lpt->lp, HASH_LP_NO_TTL);
+/* Add new field ordered by expire time. */
+void listpackExAddNew(robj *o, sds field, sds value, uint64_t expireAt) {
+    listpackEntry ent[3] = {
+            {.sval = (unsigned char*) field, .slen = sdslen(field)},
+            {.sval = (unsigned char*) value, .slen = sdslen(value)},
+            {.lval = expireAt}
+    };
 
-    sdsfree(p);
+    listpackExAddInternal(o, ent);
 }
 
 /* If expiry time is changed, this function will place field into the correct
@@ -465,13 +471,13 @@ static void listpackExPersist(robj *o, sds field, unsigned char *fptr,
 static void listpackExUpdateExpiry(robj *o, sds field,
                                    unsigned char *fptr,
                                    unsigned char *vptr,
-                                   uint64_t expireAt) {
-    unsigned int slen;
-    long long val;
+                                   uint64_t expire_at) {
+    unsigned int slen = 0;
+    long long val = 0;
     unsigned char tmp[512] = {0};
-    unsigned char *valstr, *s, *elem;
-    listpackEx *lpt = o->ptr;
+    unsigned char *valstr;
     sds tmpval = NULL;
+    listpackEx *lpt = o->ptr;
 
     /* Copy value */
     valstr = lpGetValue(vptr, &slen, &val);
@@ -488,103 +494,21 @@ static void listpackExUpdateExpiry(robj *o, sds field,
     /* Delete field name, value and expiry time */
     lpt->lp = lpDeleteRangeWithEntry(lpt->lp, &fptr, 3);
 
-    /* Insert to the listpack */
-    fptr = lpFirst(lpt->lp);
-    while (fptr) {
-        long long currExpiry;
+    listpackEntry ent[3] = {{0}};
 
-        elem = fptr; /* Keep a pointer to field name */
-        fptr = lpNext(lpt->lp, fptr);
-        serverAssert(fptr);
-        fptr = lpNext(lpt->lp, fptr);
-        serverAssert(fptr);
+    ent[0].sval = (unsigned char*) field;
+    ent[0].slen = sdslen(field);
 
-        s = lpGetValue(fptr, NULL, &currExpiry);
-        serverAssert(!s);
-
-        if (currExpiry == HASH_LP_NO_TTL || (uint64_t) currExpiry >= expireAt) {
-            /* Found a field with no expiry time or with a higher expiry time.
-             * Insert new field just before it. */
-            lpt->lp = lpInsertString(lpt->lp, (unsigned char*) field,
-                                     sdslen(field), elem, LP_BEFORE, &fptr);
-
-            /* Insert value after field name */
-            if (valstr) {
-                lpt->lp = lpInsertString(lpt->lp,
-                                         tmpval ? (unsigned char*) tmpval : tmp,
-                                         slen, fptr, LP_AFTER, &fptr);
-            } else {
-                lpt->lp = lpInsertInteger(lpt->lp, val, fptr, LP_AFTER, &fptr);
-            }
-
-            /* Insert expiry time after value. */
-            lpt->lp = lpInsertInteger(lpt->lp, (long long) expireAt, fptr,
-                                      LP_AFTER, NULL);
-            goto out;
-        }
-
-        fptr = lpNext(lpt->lp, fptr);
+    if (valstr) {
+        ent[1].sval = tmpval ? (unsigned char *) tmpval : tmp;
+        ent[1].slen = slen;
+    } else {
+        ent[1].lval = val;
     }
+    ent[2].lval = expire_at;
 
-    /* Listpack is empty, append new item */
-    lpt->lp = lpAppend(lpt->lp, (unsigned char*)field, sdslen(field));
-    if (valstr)
-        lpt->lp = lpAppend(lpt->lp, tmpval ? (unsigned char*) tmpval : tmp, slen);
-    else
-        lpt->lp = lpAppendInteger(lpt->lp, val);
-
-    lpt->lp = lpAppendInteger(lpt->lp, (long long) expireAt);
-
-out:
+    listpackExAddInternal(o, ent);
     sdsfree(tmpval);
-}
-
-/* Add new field ordered by expire time. */
-void listpackExAddNew(robj *o, sds field, sds value, uint64_t expireAt) {
-    unsigned char *fptr, *s, *elem;
-    listpackEx *lpt = o->ptr;
-
-    /* Shortcut, just append at the end if this is a non-volatile field. */
-    if (expireAt == HASH_LP_NO_TTL) {
-        goto append;
-    }
-
-    fptr = lpFirst(lpt->lp);
-    while (fptr) {
-        long long currExpiry;
-
-        elem = fptr; /* Keep a pointer to field name */
-        fptr = lpNext(lpt->lp, fptr);
-        serverAssert(fptr);
-        fptr = lpNext(lpt->lp, fptr);
-        serverAssert(fptr);
-
-        s = lpGetValue(fptr, NULL, &currExpiry);
-        serverAssert(!s);
-
-        if (currExpiry == HASH_LP_NO_TTL || (uint64_t) currExpiry >= expireAt) {
-            /* Found a field with no expiry time or with a higher expiry time.
-             * Insert new field just before it. */
-            lpt->lp = lpInsertString(lpt->lp, (unsigned char*) field,
-                                     sdslen(field), elem, LP_BEFORE, &fptr);
-
-            lpt->lp = lpInsertString(lpt->lp,(unsigned char*) value, sdslen(value),
-                                     fptr, LP_AFTER, &fptr);
-
-            /* Insert expiry time after value. */
-            lpt->lp = lpInsertInteger(lpt->lp, (long long) expireAt, fptr,
-                                      LP_AFTER, NULL);
-            return;
-        }
-
-        fptr = lpNext(lpt->lp, fptr);
-    }
-
-    /* Either listpack is empty or field expiry time is HASH_LP_NO_TTL */
-append:
-    lpt->lp = lpAppend(lpt->lp, (unsigned char*)field, sdslen(field));
-    lpt->lp = lpAppend(lpt->lp, (unsigned char*)value, sdslen(value));
-    lpt->lp = lpAppendInteger(lpt->lp, (long long) expireAt);
 }
 
 /* Update field expire time. */
@@ -1230,7 +1154,7 @@ static SetExRes hashTypeSetExListpack(redisDb *db, robj *o, sds field, HashTypeS
                         goto out;
                 } else if (res == HSET_UPDATE && expireTime != HASH_LP_NO_TTL) {
                     /* Clear TTL */
-                    listpackExPersist(o, field, fptr, vptr);
+                    listpackExUpdateExpiry(o, field, fptr, vptr, HASH_LP_NO_TTL);
                 }
             }
         }
@@ -3086,7 +3010,7 @@ void hpersistCommand(client *c) {
                 continue;
             }
 
-            listpackExPersist(hashObj, field, fptr, vptr);
+            listpackExUpdateExpiry(hashObj, field, fptr, vptr, HASH_LP_NO_TTL);
             addReplyLongLong(c, HFE_PERSIST_OK);
             changed = 1;
         }
@@ -3504,10 +3428,8 @@ static int hgetfReplyValueAndSetExpiry(client *c, robj *o, sds field, int flag,
             ebAdd(&meta->hfe, &hashFieldExpireBucketsType, hf, expireAt);
         }
     } else {
-        if (flag & HFE_CMD_PERSIST)
-            listpackExPersist(o, field, fptr, vptr);
-        else
-            listpackExUpdateExpiry(o, field, fptr, vptr, expireAt);
+        uint64_t exp = flag & HFE_CMD_PERSIST ? HASH_LP_NO_TTL : expireAt;
+        listpackExUpdateExpiry(o, field, fptr, vptr, exp);
     }
 
     return 1;
@@ -3691,25 +3613,26 @@ static int hsetfSetFieldAndReply(client *c, robj *o, sds field, sds value,
                 }
             }
         } else {
-            lpt->lp = lpReplace(lpt->lp, &vptr, (unsigned char *) value, sdslen(value));
-            fptr = lpPrev(lpt->lp, vptr); /* Update fptr as above line invalidates it. */
-            serverAssert(fptr != NULL);
+            if (ret != HSETF_FIELD_AND_TTL) {
+                /* We just set the field value without updating the TTL */
+                lpt->lp = lpReplace(lpt->lp, &vptr, (unsigned char *) value, sdslen(value));
+            } else {
+                /* We are going to update TTL. Delete the field first and then
+                 * insert again according to new TTL if necessary. */
+                lpt->lp = lpDeleteRangeWithEntry(lpt->lp, &fptr, 3);
 
-            if (ret == HSETF_FIELD_AND_TTL) {
                 if (*minPrevExp > prevExpire)
                     *minPrevExp = prevExpire;
 
                 if (!(flag & HFE_CMD_EXPIRY_MASK)) {
                     /* If none of EX,EXAT,PX,PXAT,KEEPTTL is specified, TTL is
                      * discarded. */
-                    listpackExPersist(o, field, fptr, vptr);
-                } else if (checkAlreadyExpired(expireAt)) {
-                    hashTypeDelete(o, field);
-                } else {
+                    listpackExAddNew(o, field, value, HASH_LP_NO_TTL);
+                } else if (!checkAlreadyExpired(expireAt)){
                     if (*minPrevExp > expireAt)
                         *minPrevExp = expireAt;
 
-                    listpackExUpdateExpiry(o, field, fptr, vptr, expireAt);
+                    listpackExAddNew(o, field, value, expireAt);
                 }
             }
         }


### PR DESCRIPTION
This PR contains a few optimizations for hfe listpack.
- Hfe fields are ordered by TTL in the listpack.  There are two cases that we want to search listpack according to TTLs: 
  - As part of active-expiry, we need to find the fields that are expired. e.g. find fields that have smaller TTLs than given timestamp. 
  - When we want to add a new field, we need to find the correct position to maintain the order by TTL. e.g. find the field that has a higher TTL than the one we want to insert. 
  
  Iterating with lpNext() to compare TTLs has a performance cost as lpNext() calls lpValidateIntegrity() for each entry. Instead, this PR adds `lpFindCb()` to the listpack which accepts a comparator callback. It preserves same validation logic of lpFind() which is faster than search with lpNext(). 
  
- We have field name, value, ttl for a single hfe field. Inserting these items one by one to listpack is costly. Especially, as we place fields according to TTL, most additions will end up in the middle of the listpack. Each insert causes realloc + memmove. This PR introduces `lpBatchInsert()` to add multiple items in one go. 

- For hsetf, if we are going to update value and TTL at the same time, currently, we update the value first and later update the TTL (two distinct listpack operation). This PR improves it by doing it with a single update operation. 