### PR TITLE
Fix hfe reply schemas

### DIFF
--- a/src/commands/hexpire.json
+++ b/src/commands/hexpire.json
@@ -36,38 +36,30 @@
             }
         ],
         "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "Key does not exist.",
-                    "type": "null"
-                },
-                {
-                    "description": "Array of results",
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 4294967295,
-                    "items": {
-                        "oneOf": [
-                            {
-                                "description": "The field does not exist.",
-                                "const": -2
-                            },
-                            {
-                                "description": "Specified NX | XX | GT | LT condition not met",
-                                "const": 0
-                            },
-                            {
-                                "description": "Expiration time was set or updated.",
-                                "const": 1
-                            },
-                            {
-                                "description": "Field deleted because the specified expiration time is in the past.",
-                                "const": 2
-                            }
-                        ]
+            "description": "Array of results. Returns empty array if the key does not exist.",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 4294967295,
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "The field does not exist.",
+                        "const": -2
+                    },
+                    {
+                        "description": "Specified NX | XX | GT | LT condition not met",
+                        "const": 0
+                    },
+                    {
+                        "description": "Expiration time was set or updated.",
+                        "const": 1
+                    },
+                    {
+                        "description": "Field deleted because the specified expiration time is in the past.",
+                        "const": 2
                     }
-                }
-            ]
+                ]
+            }
         },
         "arguments": [
             {

--- a/src/commands/hexpireat.json
+++ b/src/commands/hexpireat.json
@@ -36,38 +36,30 @@
             }
         ],
         "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "Key does not exist.",
-                    "type": "null"
-                },
-                {
-                    "description": "Array of results",
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 4294967295,
-                    "items": {
-                        "oneOf": [
-                            {
-                                "description": "The field does not exist.",
-                                "const": -2
-                            },
-                            {
-                                "description": "Specified NX | XX | GT | LT condition not met",
-                                "const": 0
-                            },
-                            {
-                                "description": "Expiration time was set or updated.",
-                                "const": 1
-                            },
-                            {
-                                "description": "Field deleted because the specified expiration time is in the past.",
-                                "const": 2
-                            }
-                        ]
+            "description": "Array of results. Returns empty array if the key does not exist.",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 4294967295,
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "The field does not exist.",
+                        "const": -2
+                    },
+                    {
+                        "description": "Specified NX | XX | GT | LT condition not met",
+                        "const": 0
+                    },
+                    {
+                        "description": "Expiration time was set or updated.",
+                        "const": 1
+                    },
+                    {
+                        "description": "Field deleted because the specified expiration time is in the past.",
+                        "const": 2
                     }
-                }
-            ]
+                ]
+            }
         },
         "arguments": [
             {

--- a/src/commands/hexpiretime.json
+++ b/src/commands/hexpiretime.json
@@ -35,35 +35,27 @@
             }
         ],
         "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "Key does not exist.",
-                    "type": "null"
-                },
-                {
-                    "description": "Array of results",
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 4294967295,
-                    "items": {
-                        "oneOf": [
-                            {
-                                "description": "The field does not exist.",
-                                "const": -2
-                            },
-                            {
-                                "description": "The field exists but has no associated expire.",
-                                "const": -1
-                            },
-                            {
-                                "description": "Expiration Unix timestamp in seconds.",
-                                "type": "integer",
-                                "minimum": 1
-                            }
-                        ]
+            "description": "Array of results. Returns empty array if the key does not exist.",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 4294967295,
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "The field does not exist.",
+                        "const": -2
+                    },
+                    {
+                        "description": "The field exists but has no associated expire.",
+                        "const": -1
+                    },
+                    {
+                        "description": "Expiration Unix timestamp in seconds.",
+                        "type": "integer",
+                        "minimum": 1
                     }
-                }
-            ]
+                ]
+            }
         },
         "arguments": [
             {

--- a/src/commands/hpersist.json
+++ b/src/commands/hpersist.json
@@ -35,34 +35,26 @@
             }
         ],
         "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "Key does not exist.",
-                    "type": "null"
-                },
-                {
-                    "description": "Array of results",
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 4294967295,
-                    "items": {
-                        "oneOf": [
-                            {
-                                "description": "The field does not exist.",
-                                "const": -2
-                            },
-                            {
-                                "description": "The field exists but has no associated expire.",
-                                "const": -1
-                            },
-                            {
-                                "description": "Expiration time was removed",
-                                "const": 1
-                            }
-                        ]
+            "description": "Array of results. Returns empty array if the key does not exist.",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 4294967295,
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "The field does not exist.",
+                        "const": -2
+                    },
+                    {
+                        "description": "The field exists but has no associated expire.",
+                        "const": -1
+                    },
+                    {
+                        "description": "Expiration time was removed",
+                        "const": 1
                     }
-                }
-            ]
+                ]
+            }
         },
         "arguments": [
             {

--- a/src/commands/hpexpire.json
+++ b/src/commands/hpexpire.json
@@ -36,38 +36,30 @@
             }
         ],
         "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "Key does not exist.",
-                    "type": "null"
-                },
-                {
-                    "description": "Array of results",
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 4294967295,
-                    "items": {
-                        "oneOf": [
-                            {
-                                "description": "The field does not exist.",
-                                "const": -2
-                            },
-                            {
-                                "description": "Specified NX | XX | GT | LT condition not met",
-                                "const": 0
-                            },
-                            {
-                                "description": "Expiration time was set or updated.",
-                                "const": 1
-                            },
-                            {
-                                "description": "Field deleted because the specified expiration time is in the past.",
-                                "const": 2
-                            }
-                        ]
+            "description": "Array of results. Returns empty array if the key does not exist.",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 4294967295,
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "The field does not exist.",
+                        "const": -2
+                    },
+                    {
+                        "description": "Specified NX | XX | GT | LT condition not met",
+                        "const": 0
+                    },
+                    {
+                        "description": "Expiration time was set or updated.",
+                        "const": 1
+                    },
+                    {
+                        "description": "Field deleted because the specified expiration time is in the past.",
+                        "const": 2
                     }
-                }
-            ]
+                ]
+            }
         },
         "arguments": [
             {

--- a/src/commands/hpexpireat.json
+++ b/src/commands/hpexpireat.json
@@ -36,38 +36,30 @@
             }
         ],
         "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "Key does not exist.",
-                    "type": "null"
-                },
-                {
-                    "description": "Array of results",
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 4294967295,
-                    "items": {
-                        "oneOf": [
-                            {
-                                "description": "The field does not exist.",
-                                "const": -2
-                            },
-                            {
-                                "description": "Specified NX | XX | GT | LT condition not met",
-                                "const": 0
-                            },
-                            {
-                                "description": "Expiration time was set or updated.",
-                                "const": 1
-                            },
-                            {
-                                "description": "Field deleted because the specified expiration time is in the past.",
-                                "const": 2
-                            }
-                        ]
+            "description": "Array of results. Returns empty array if the key does not exist.",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 4294967295,
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "The field does not exist.",
+                        "const": -2
+                    },
+                    {
+                        "description": "Specified NX | XX | GT | LT condition not met",
+                        "const": 0
+                    },
+                    {
+                        "description": "Expiration time was set or updated.",
+                        "const": 1
+                    },
+                    {
+                        "description": "Field deleted because the specified expiration time is in the past.",
+                        "const": 2
                     }
-                }
-            ]
+                ]
+            }
         },
         "arguments": [
             {

--- a/src/commands/hpexpiretime.json
+++ b/src/commands/hpexpiretime.json
@@ -35,35 +35,27 @@
             }
         ],
         "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "Key does not exist.",
-                    "type": "null"
-                },
-                {
-                    "description": "The keyname, popped member, and its score.",
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 4294967295,
-                    "items": {
-                        "oneOf": [
-                            {
-                                "description": "The field does not exist.",
-                                "const": -2
-                            },
-                            {
-                                "description": "The field exists but has no associated expire.",
-                                "const": -1
-                            },
-                            {
-                                "description": "Expiration Unix timestamp in milliseconds.",
-                                "type": "integer",
-                                "minimum": 1
-                            }
-                        ]
+            "description": "Array of results. Returns empty array if the key does not exist.",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 4294967295,
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "The field does not exist.",
+                        "const": -2
+                    },
+                    {
+                        "description": "The field exists but has no associated expire.",
+                        "const": -1
+                    },
+                    {
+                        "description": "Expiration Unix timestamp in milliseconds.",
+                        "type": "integer",
+                        "minimum": 1
                     }
-                }
-            ]
+                ]
+            }
         },
         "arguments": [
             {

--- a/src/commands/hpttl.json
+++ b/src/commands/hpttl.json
@@ -35,35 +35,27 @@
             }
         ],
         "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "Key does not exist.",
-                    "type": "null"
-                },
-                {
-                    "description": "Array of results",
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 4294967295,
-                    "items": {
-                        "oneOf": [
-                            {
-                                "description": "The field does not exist.",
-                                "const": -2
-                            },
-                            {
-                                "description": "The field exists but has no associated expire.",
-                                "const": -1
-                            },
-                            {
-                                "description": "TTL in milliseconds.",
-                                "type": "integer",
-                                "minimum": 1
-                            }
-                        ]
+            "description": "Array of results. Returns empty array if the key does not exist.",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 4294967295,
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "The field does not exist.",
+                        "const": -2
+                    },
+                    {
+                        "description": "The field exists but has no associated expire.",
+                        "const": -1
+                    },
+                    {
+                        "description": "TTL in milliseconds.",
+                        "type": "integer",
+                        "minimum": 1
                     }
-                }
-            ]
+                ]
+            }
         },
         "arguments": [
             {

--- a/src/commands/httl.json
+++ b/src/commands/httl.json
@@ -35,35 +35,27 @@
             }
         ],
         "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "Key does not exist.",
-                    "type": "null"
-                },
-                {
-                    "description": "Array of results",
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 4294967295,
-                    "items": {
-                        "oneOf": [
-                            {
-                                "description": "The field does not exist.",
-                                "const": -2
-                            },
-                            {
-                                "description": "The field exists but has no associated expire.",
-                                "const": -1
-                            },
-                            {
-                                "description": "TTL in seconds.",
-                                "type": "integer",
-                                "minimum": 1
-                            }
-                        ]
+            "description": "Array of results. Returns empty array if the key does not exist.",
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 4294967295,
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "The field does not exist.",
+                        "const": -2
+                    },
+                    {
+                        "description": "The field exists but has no associated expire.",
+                        "const": -1
+                    },
+                    {
+                        "description": "TTL in seconds.",
+                        "type": "integer",
+                        "minimum": 1
                     }
-                }
-            ]
+                ]
+            }
         },
         "arguments": [
             {


### PR DESCRIPTION
In https://github.com/redis/redis/pull/13291, we've changed that hfe commands to return empty array if the key does not exist.
Forgot to update json schemas. 