### PR TITLE
Remove variable expired in expireSlaveKeys() to prevent confusing the compiler

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -410,12 +410,10 @@ void expireSlaveKeys(void) {
             if ((dbids & 1) != 0) {
                 redisDb *db = server.db+dbid;
                 dictEntry *expire = dbFindExpires(db, keyname);
-                int expired = 0;
 
                 if (expire &&
                     activeExpireCycleTryExpire(server.db+dbid,expire,start))
                 {
-                    expired = 1;
                     /* Propagate the DEL (writable replicas do not propagate anything to other replicas,
                      * but they might propagate to AOF) and trigger module hooks. */
                     postExecutionUnitOperations();
@@ -425,7 +423,7 @@ void expireSlaveKeys(void) {
                  * corresponding bit in the new bitmap we set as value.
                  * At the end of the loop if the bitmap is zero, it means we
                  * no longer need to keep track of this key. */
-                if (expire && !expired) {
+                else if (expire) {
                     noexpire++;
                     new_dbids |= (uint64_t)1 << dbid;
                 }


### PR DESCRIPTION
This change prevents missed optimization for some compilers: https://godbolt.org/z/W66h86E13 (the reduced intermediate form in optimization).
And the semantics still look clear to me. If it breaks the readability, let me know, please.