### PR TITLE
Prevent negative expire parameter in HEXPIRE/HEXPIREAT/HPEXPIRE/HPEXPIREAT commands

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2985,12 +2985,6 @@ static void hexpireGenericCommand(client *c, const char *cmd, long long basetime
     if (getLongLongFromObjectOrReply(c, expireArg, &expire, NULL) != C_OK)
         return;
 
-    /* Check expire overflow */
-    if (expire > (long long) EB_EXPIRE_TIME_MAX) {
-        addReplyErrorExpireTime(c);
-        return;
-    }
-
     if (unit == UNIT_SECONDS) {
         if (expire > (long long) EB_EXPIRE_TIME_MAX / 1000) {
             addReplyErrorExpireTime(c);
@@ -2999,6 +2993,7 @@ static void hexpireGenericCommand(client *c, const char *cmd, long long basetime
         expire *= 1000;
     } else {
         if (expire > (long long) EB_EXPIRE_TIME_MAX) {
+            /* Check expire overflow */
             addReplyErrorExpireTime(c);
             return;
         }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2870,7 +2870,7 @@ static void httlGenericCommand(client *c, const char *cmd, long long basetime, i
 
     /* Verify `numFields` is consistent with number of arguments */
     if (numFields > (c->argc - numFieldsAt - 1)) {
-        addReplyError(c, "Parameter `numFileds` is more than number of arguments");
+        addReplyError(c, "Parameter `numFields` is more than number of arguments");
         return;
     }
 
@@ -3027,7 +3027,7 @@ static void hexpireGenericCommand(client *c, const char *cmd, long long basetime
 
     /* Verify `numFields` is consistent with number of arguments */
     if (numFields > (c->argc - numFieldsAt - 1)) {
-        addReplyError(c, "Parameter `numFileds` is more than number of arguments");
+        addReplyError(c, "Parameter `numFields` is more than number of arguments");
         return;
     }
 
@@ -3124,7 +3124,7 @@ void hpersistCommand(client *c) {
 
     /* Verify `numFields` is consistent with number of arguments */
     if (numFields > (c->argc - numFieldsAt - 1)) {
-        addReplyError(c, "Parameter `numFileds` is more than number of arguments");
+        addReplyError(c, "Parameter `numFields` is more than number of arguments");
         return;
     }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2984,6 +2984,10 @@ static void hexpireGenericCommand(client *c, const char *cmd, long long basetime
     /* Read the expiry time from command */
     if (getLongLongFromObjectOrReply(c, expireArg, &expire, NULL) != C_OK)
         return;
+    if (expire < 0) {
+        addReplyError(c,"invalid expire time, must be >= 0");
+        return;
+    }
 
     if (unit == UNIT_SECONDS) {
         if (expire > (long long) EB_EXPIRE_TIME_MAX / 1000) {
@@ -2991,12 +2995,6 @@ static void hexpireGenericCommand(client *c, const char *cmd, long long basetime
             return;
         }
         expire *= 1000;
-    } else {
-        if (expire > (long long) EB_EXPIRE_TIME_MAX) {
-            /* Check expire overflow */
-            addReplyErrorExpireTime(c);
-            return;
-        }
     }
 
     if (expire > (long long) EB_EXPIRE_TIME_MAX - basetime) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2997,6 +2997,7 @@ static void hexpireGenericCommand(client *c, const char *cmd, long long basetime
         expire *= 1000;
     }
 
+    /* Ensure that the final absolute Unix timestamp does not exceed EB_EXPIRE_TIME_MAX. */
     if (expire > (long long) EB_EXPIRE_TIME_MAX - basetime) {
         addReplyErrorExpireTime(c);
         return;

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -205,7 +205,7 @@ start_server {tags {"external:skip needs:debug"}} {
             r del myhash
             r hset myhash f1 v1
             assert_error {*Parameter `numFields` should be greater than 0} {r hpexpire myhash 1000 NX FIELDS 0 f1 f2 f3}
-            assert_error {*Parameter `numFileds` is more than number of arguments} {r hpexpire myhash 1000 NX FIELDS 4 f1 f2 f3}
+            assert_error {*Parameter `numFields` is more than number of arguments} {r hpexpire myhash 1000 NX FIELDS 4 f1 f2 f3}
         }
 
         test "HPEXPIRE - parameter expire-time near limit of  2^48 ($type)" {

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -969,45 +969,45 @@ start_server {tags {"external:skip needs:debug"}} {
             r config set hash-max-listpack-entries 512
         }
 
-        # test "Command rewrite and expired hash fields are propagated to replica ($type)" {
-        #     start_server {overrides {appendonly {yes} appendfsync always} tags {external:skip}} {
+        test "Command rewrite and expired hash fields are propagated to replica ($type)" {
+            start_server {overrides {appendonly {yes} appendfsync always} tags {external:skip}} {
 
-        #         set aof [get_last_incr_aof_path r]
-        #         r hset h1 f1 v1 f2 v2
+                set aof [get_last_incr_aof_path r]
+                r hset h1 f1 v1 f2 v2
 
-        #         r hpexpire h1 20 FIELDS 1 f1
-        #         r hpexpire h1 30 FIELDS 1 f2
-        #         r hpexpire h1 30 FIELDS 1 non_exists_field
-        #         r hset h2 f1 v1 f2 v2 f3 v3 f4 v4
-        #         r hpexpire h2 40 FIELDS 2 f1 non_exists_field
-        #         r hpexpire h2 50 FIELDS 1 f2
-        #         r hpexpireat h2 [expr [clock seconds]*1000+100000] LT FIELDS 1 f3
-        #         r hexpireat h2 [expr [clock seconds]+10] NX FIELDS 1 f4
+                r hpexpire h1 20 FIELDS 1 f1
+                r hpexpire h1 30 FIELDS 1 f2
+                r hpexpire h1 30 FIELDS 1 non_exists_field
+                r hset h2 f1 v1 f2 v2 f3 v3 f4 v4
+                r hpexpire h2 40 FIELDS 2 f1 non_exists_field
+                r hpexpire h2 50 FIELDS 1 f2
+                r hpexpireat h2 [expr [clock seconds]*1000+100000] LT FIELDS 1 f3
+                r hexpireat h2 [expr [clock seconds]+10] NX FIELDS 1 f4
 
-        #         wait_for_condition 50 100 {
-        #             [r hlen h2] eq 2
-        #         } else {
-        #             fail "Field f2 of hash h2 wasn't deleted"
-        #         }
+                wait_for_condition 50 100 {
+                    [r hlen h2] eq 2
+                } else {
+                    fail "Field f2 of hash h2 wasn't deleted"
+                }
 
-        #         # Assert that each TTL-related command are persisted with absolute timestamps in AOF
-        #         assert_aof_content $aof {
-        #             {select *}
-        #             {hset h1 f1 v1 f2 v2}
-        #             {hpexpireat h1 * FIELDS 1 f1}
-        #             {hpexpireat h1 * FIELDS 1 f2}
-        #             {hset h2 f1 v1 f2 v2 f3 v3 f4 v4}
-        #             {hpexpireat h2 * FIELDS 2 f1 non_exists_field}
-        #             {hpexpireat h2 * FIELDS 1 f2}
-        #             {hpexpireat h2 * FIELDS 1 f3}
-        #             {hpexpireat h2 * FIELDS 1 f4}
-        #             {hdel h1 f1}
-        #             {hdel h1 f2}
-        #             {hdel h2 f1}
-        #             {hdel h2 f2}
-        #         }
-        #     }
-        # }
+                # Assert that each TTL-related command are persisted with absolute timestamps in AOF
+                assert_aof_content $aof {
+                    {select *}
+                    {hset h1 f1 v1 f2 v2}
+                    {hpexpireat h1 * FIELDS 1 f1}
+                    {hpexpireat h1 * FIELDS 1 f2}
+                    {hset h2 f1 v1 f2 v2 f3 v3 f4 v4}
+                    {hpexpireat h2 * FIELDS 2 f1 non_exists_field}
+                    {hpexpireat h2 * FIELDS 1 f2}
+                    {hpexpireat h2 * FIELDS 1 f3}
+                    {hpexpireat h2 * FIELDS 1 f4}
+                    {hdel h1 f1}
+                    {hdel h1 f2}
+                    {hdel h2 f1}
+                    {hdel h2 f2}
+                }
+            }
+        }
 
         test "Lazy Expire - fields are lazy deleted and propagated to replicas ($type)" {
             start_server {overrides {appendonly {yes} appendfsync always} tags {external:skip}} {

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -128,6 +128,19 @@ start_server {tags {"external:skip needs:debug"}} {
             r readraw 0
         }
 
+        test "HEXPIRE/HEXPIREAT/HPEXPIRE/HPEXPIREAT - Verify that the expire time is overflow" {
+            r del myhash
+            r hset myhash f1 v1
+            # The expire time can't be negative.
+            assert_error {ERR invalid expire time, must be >= 0} {r HEXPIRE myhash -1 FIELDS 1 f1}
+            assert_error {ERR invalid expire time, must be >= 0} {r HEXPIRE myhash -9223372036854775808 FIELDS 1 f1}
+            # The expire time cann't be greater than the EB_EXPIRE_TIME_MAX
+            assert_error {ERR invalid expire time in 'hexpire' command} {r HEXPIRE myhash [expr (1<<48) / 1000] FIELDS 1 f1}
+            assert_error {ERR invalid expire time in 'hexpireat' command} {r HEXPIREAT myhash [expr (1<<48) / 1000 + [clock seconds] + 100] FIELDS 1 f1}
+            assert_error {ERR invalid expire time in 'hpexpire' command} {r HPEXPIRE myhash [expr (1<<48)] FIELDS 1 f1}
+            assert_error {ERR invalid expire time in 'hpexpireat' command} {r HPEXPIREAT myhash [expr (1<<48) + [clock milliseconds] + 100] FIELDS 1 f1}
+        }
+
         test "HPEXPIRE(AT) - Test 'NX' flag ($type)" {
             r del myhash
             r hset myhash field1 value1 field2 value2 field3 value3
@@ -956,45 +969,45 @@ start_server {tags {"external:skip needs:debug"}} {
             r config set hash-max-listpack-entries 512
         }
 
-        test "Command rewrite and expired hash fields are propagated to replica ($type)" {
-            start_server {overrides {appendonly {yes} appendfsync always} tags {external:skip}} {
+        # test "Command rewrite and expired hash fields are propagated to replica ($type)" {
+        #     start_server {overrides {appendonly {yes} appendfsync always} tags {external:skip}} {
 
-                set aof [get_last_incr_aof_path r]
-                r hset h1 f1 v1 f2 v2
+        #         set aof [get_last_incr_aof_path r]
+        #         r hset h1 f1 v1 f2 v2
 
-                r hpexpire h1 20 FIELDS 1 f1
-                r hpexpire h1 30 FIELDS 1 f2
-                r hpexpire h1 30 FIELDS 1 non_exists_field
-                r hset h2 f1 v1 f2 v2 f3 v3 f4 v4
-                r hpexpire h2 40 FIELDS 2 f1 non_exists_field
-                r hpexpire h2 50 FIELDS 1 f2
-                r hpexpireat h2 [expr [clock seconds]*1000+100000] LT FIELDS 1 f3
-                r hexpireat h2 [expr [clock seconds]+10] NX FIELDS 1 f4
+        #         r hpexpire h1 20 FIELDS 1 f1
+        #         r hpexpire h1 30 FIELDS 1 f2
+        #         r hpexpire h1 30 FIELDS 1 non_exists_field
+        #         r hset h2 f1 v1 f2 v2 f3 v3 f4 v4
+        #         r hpexpire h2 40 FIELDS 2 f1 non_exists_field
+        #         r hpexpire h2 50 FIELDS 1 f2
+        #         r hpexpireat h2 [expr [clock seconds]*1000+100000] LT FIELDS 1 f3
+        #         r hexpireat h2 [expr [clock seconds]+10] NX FIELDS 1 f4
 
-                wait_for_condition 50 100 {
-                    [r hlen h2] eq 2
-                } else {
-                    fail "Field f2 of hash h2 wasn't deleted"
-                }
+        #         wait_for_condition 50 100 {
+        #             [r hlen h2] eq 2
+        #         } else {
+        #             fail "Field f2 of hash h2 wasn't deleted"
+        #         }
 
-                # Assert that each TTL-related command are persisted with absolute timestamps in AOF
-                assert_aof_content $aof {
-                    {select *}
-                    {hset h1 f1 v1 f2 v2}
-                    {hpexpireat h1 * FIELDS 1 f1}
-                    {hpexpireat h1 * FIELDS 1 f2}
-                    {hset h2 f1 v1 f2 v2 f3 v3 f4 v4}
-                    {hpexpireat h2 * FIELDS 2 f1 non_exists_field}
-                    {hpexpireat h2 * FIELDS 1 f2}
-                    {hpexpireat h2 * FIELDS 1 f3}
-                    {hpexpireat h2 * FIELDS 1 f4}
-                    {hdel h1 f1}
-                    {hdel h1 f2}
-                    {hdel h2 f1}
-                    {hdel h2 f2}
-                }
-            }
-        }
+        #         # Assert that each TTL-related command are persisted with absolute timestamps in AOF
+        #         assert_aof_content $aof {
+        #             {select *}
+        #             {hset h1 f1 v1 f2 v2}
+        #             {hpexpireat h1 * FIELDS 1 f1}
+        #             {hpexpireat h1 * FIELDS 1 f2}
+        #             {hset h2 f1 v1 f2 v2 f3 v3 f4 v4}
+        #             {hpexpireat h2 * FIELDS 2 f1 non_exists_field}
+        #             {hpexpireat h2 * FIELDS 1 f2}
+        #             {hpexpireat h2 * FIELDS 1 f3}
+        #             {hpexpireat h2 * FIELDS 1 f4}
+        #             {hdel h1 f1}
+        #             {hdel h1 f2}
+        #             {hdel h2 f1}
+        #             {hdel h2 f2}
+        #         }
+        #     }
+        # }
 
         test "Lazy Expire - fields are lazy deleted and propagated to replicas ($type)" {
             start_server {overrides {appendonly {yes} appendfsync always} tags {external:skip}} {

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -134,7 +134,7 @@ start_server {tags {"external:skip needs:debug"}} {
             # The expire time can't be negative.
             assert_error {ERR invalid expire time, must be >= 0} {r HEXPIRE myhash -1 FIELDS 1 f1}
             assert_error {ERR invalid expire time, must be >= 0} {r HEXPIRE myhash -9223372036854775808 FIELDS 1 f1}
-            # The expire time cann't be greater than the EB_EXPIRE_TIME_MAX
+            # The expire time can't be greater than the EB_EXPIRE_TIME_MAX
             assert_error {ERR invalid expire time in 'hexpire' command} {r HEXPIRE myhash [expr (1<<48) / 1000] FIELDS 1 f1}
             assert_error {ERR invalid expire time in 'hexpireat' command} {r HEXPIREAT myhash [expr (1<<48) / 1000 + [clock seconds] + 100] FIELDS 1 f1}
             assert_error {ERR invalid expire time in 'hpexpire' command} {r HPEXPIRE myhash [expr (1<<48)] FIELDS 1 f1}

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -128,7 +128,7 @@ start_server {tags {"external:skip needs:debug"}} {
             r readraw 0
         }
 
-        test "HEXPIRE/HEXPIREAT/HPEXPIRE/HPEXPIREAT - Verify that the expire time is overflow" {
+        test "HEXPIRE/HEXPIREAT/HPEXPIRE/HPEXPIREAT - Verify that the expire time does not overflow" {
             r del myhash
             r hset myhash f1 v1
             # The expire time can't be negative.


### PR DESCRIPTION
1. Don't allow HEXPIRE/HEXPIREAT/HPEXPIRE/HPEXPIREAT command expire parameters is negative

2. Remove a dead code reported from Coverity.
when `unit` is not `UNIT_SECONDS`, the second `if (expire > (long long) EB_EXPIRE_TIME_MAX)` will be dead code.
```c
# t_hash.c
2988    /* Check expire overflow */
      	cond_at_most: Condition expire > 281474976710655LL, taking false branch. Now the value of expire is at most 281474976710655.
2989    if (expire > (long long) EB_EXPIRE_TIME_MAX) {
2990        addReplyErrorExpireTime(c);
2991        return;
2992    }

2994    if (unit == UNIT_SECONDS) {
2995        if (expire > (long long) EB_EXPIRE_TIME_MAX / 1000) {
2996            addReplyErrorExpireTime(c);
2997            return;
2998        }
2999        expire *= 1000;
3000    } else {
      	at_most: At condition expire > 281474976710655LL, the value of expire must be at most 281474976710655.
      	dead_error_condition: The condition expire > 281474976710655LL cannot be true.
3001        if (expire > (long long) EB_EXPIRE_TIME_MAX) {
      	
CID 494223: (#1 of 1): Logically dead code (DEADCODE)
dead_error_begin: Execution cannot reach this statement: addReplyErrorExpireTime(c);.
3002            addReplyErrorExpireTime(c);
3003            return;
3004        }
3005    }
```