### PR TITLE
Fix crash due to unblock client during slot migration

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4008,6 +4008,7 @@ int processCommand(client *c) {
                 flagTransaction(c);
             }
             clusterRedirectClient(c,n,c->slot,error_code);
+            c->duration = 0;
             c->cmd->rejected_calls++;
             return C_OK;
         }


### PR DESCRIPTION
In #13224, we found a crash during cluster slot migration but don't know why. So i check all the return C_OK in processCommand to see if we are missing some duration reset and see this.

This fix is like #12247, when we reject the command, we should reset the duration. I test it and verify it can fix #13224.

So the reason may because we are using stream block and then during the slot migration, it got a redirect and then crash the server.