### PR TITLE
Fix returned value nextExpireTime by ebExpire()

### DIFF
--- a/src/ebuckets.h
+++ b/src/ebuckets.h
@@ -250,9 +250,9 @@ typedef struct ExpireInfo {
     uint64_t maxToExpire;         /* [INPUT ] Limit of number expired items to scan */
     void *ctx;                    /* [INPUT ] context to pass to onExpireItem */
     uint64_t now;                 /* [INPUT ] Current time in msec. */
-	uint64_t itemsExpired;        /* [OUTPUT] Returns the number of expired or updated items. */
+    uint64_t itemsExpired;        /* [OUTPUT] Returns the number of expired or updated items. */
     uint64_t nextExpireTime;      /* [OUTPUT] Next expiration time. Returns
-                                              EB_EXPIRE_TIME_INVALID if none left. */
+                                     EB_EXPIRE_TIME_INVALID if none left. */
 } ExpireInfo;
 
 /* ebuckets API */

--- a/src/ebuckets.h
+++ b/src/ebuckets.h
@@ -250,11 +250,9 @@ typedef struct ExpireInfo {
     uint64_t maxToExpire;         /* [INPUT ] Limit of number expired items to scan */
     void *ctx;                    /* [INPUT ] context to pass to onExpireItem */
     uint64_t now;                 /* [INPUT ] Current time in msec. */
-    uint64_t nextExpireTime;      /* [OUTPUT] Next expiration time. Return 0, if none left. */
-
-	/* TODO: Distinct between expired & updated */
 	uint64_t itemsExpired;        /* [OUTPUT] Returns the number of expired or updated items. */
-
+    uint64_t nextExpireTime;      /* [OUTPUT] Next expiration time. Returns
+                                              EB_EXPIRE_TIME_INVALID if none left. */
 } ExpireInfo;
 
 /* ebuckets API */


### PR DESCRIPTION
At `ebuckets` structure, On `ebExpire()`, if the callback indicated to update the item expiration time and return it back to ebuckets (`ACT_UPDATE_EXP_ITEM`), then returned value `nextExpireTime` should be updated, if needed. 
Invalid value of `nextExpireTime` was modified from 0 to `EB_EXPIRE_TIME_INVALID`.