### PR TITLE
Fixed crashes due to missed slotToKeyInit() and missed expires_cursor reset

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -941,6 +941,7 @@ void activeDefragCycle(void) {
             defrag_later_cursor = 0;
             current_db = -1;
             cursor = 0;
+            expires_cursor = 0;
             db = NULL;
             goto update_metrics;
         }

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -178,7 +178,10 @@ void emptyDbAsync(redisDb *db) {
     dict *oldht1 = db->dict, *oldht2 = db->expires;
     db->dict = dictCreate(&dbDictType);
     db->expires = dictCreate(&dbExpiresDictType);
-    if (server.cluster_enabled) slotToKeyInit(db);
+    if (server.cluster_enabled) {
+        slotToKeyDestroy(db);
+        slotToKeyInit(db);
+    }
     atomicIncr(lazyfree_objects,dictSize(oldht1));
     bioCreateLazyFreeJob(lazyfreeFreeDatabase,2,oldht1,oldht2);
 }

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -2,6 +2,7 @@
 #include "bio.h"
 #include "atomicvar.h"
 #include "functions.h"
+#include "cluster.h"
 
 static redisAtomic size_t lazyfree_objects = 0;
 static redisAtomic size_t lazyfreed_objects = 0;
@@ -177,6 +178,7 @@ void emptyDbAsync(redisDb *db) {
     dict *oldht1 = db->dict, *oldht2 = db->expires;
     db->dict = dictCreate(&dbDictType);
     db->expires = dictCreate(&dbExpiresDictType);
+    if (server.cluster_enabled) slotToKeyInit(db);
     atomicIncr(lazyfree_objects,dictSize(oldht1));
     bioCreateLazyFreeJob(lazyfreeFreeDatabase,2,oldht1,oldht2);
 }

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -161,6 +161,7 @@ run_solo {defrag} {
         r config set appendonly no
         r config set key-load-delay 0
         
+        if {$type eq "standalone"} { ;# skip in cluster mode
         test "Active defrag eval scripts: $type" {
             r flushdb
             r script flush sync
@@ -372,7 +373,6 @@ run_solo {defrag} {
             r save ;# saving an rdb iterates over all the data / pointers
         } {OK}
 
-        if {$type eq "standalone"} { ;# skip in cluster mode
         test "Active defrag big list: $type" {
             r flushdb
             r config resetstat
@@ -576,8 +576,8 @@ run_solo {defrag} {
                 assert {$digest eq $newdigest}
                 r save ;# saving an rdb iterates over all the data / pointers
             }
-        } ;# standalone
         }
+        } ;# standalone
     }
     }
 

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -39,7 +39,7 @@ start_server {tags {"memefficiency external:skip"}} {
 run_solo {defrag} {
     proc test_active_defrag {type} {
     if {[string match {*jemalloc*} [s mem_allocator]] && [r debug mallctl arenas.page] <= 8192} {
-        test "Active defrag" {
+        test "Active defrag: $type" {
             r flushdb async
             r config set hz 100
             r config set activedefrag no
@@ -161,7 +161,7 @@ run_solo {defrag} {
         r config set appendonly no
         r config set key-load-delay 0
         
-        test "Active defrag eval scripts" {
+        test "Active defrag eval scripts: $type" {
             r flushdb
             r script flush sync
             r config resetstat
@@ -243,7 +243,7 @@ run_solo {defrag} {
             r script flush sync
         } {OK}
 
-        test "Active defrag big keys" {
+        test "Active defrag big keys: $type" {
             r flushdb
             r config resetstat
             r config set hz 100
@@ -373,7 +373,7 @@ run_solo {defrag} {
         } {OK}
 
         if {$type eq "standalone"} { ;# skip in cluster mode
-        test "Active defrag big list" {
+        test "Active defrag big list: $type" {
             r flushdb
             r config resetstat
             r config set hz 100
@@ -475,7 +475,7 @@ run_solo {defrag} {
             r del biglist1 ;# coverage for quicklistBookmarksClear
         } {1}
 
-        test "Active defrag edge case" {
+        test "Active defrag edge case: $type" {
             # there was an edge case in defrag where all the slabs of a certain bin are exact the same
             # % utilization, with the exception of the current slab from which new allocations are made
             # if the current slab is lower in utilization the defragger would have ended up in stagnation,


### PR DESCRIPTION
this PR fixes two crashes:

1. Fix missing slotToKeyInit() when using `flushdb async` under cluster mode.
    https://github.com/redis/redis/issues/13205

2. Fix missing expires_cursor reset when stopping active defrag in the middle of defragment.
    https://github.com/redis/redis/issues/13307
    If we stop active defrag in the middle of defragging db->expires, if `expires_cursor` is not reset to 0, the next time we enable active defrag again, defragLaterStep(db, ...) will be entered.  However, at this time, `db` has been reset to NULL, which results in crash.

The affected code were removed by #11695 and #13058 in usntable, so we just need backport this to 7.2.