### PR TITLE
Fix integer overflow during calculation of next time event of module timer

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -305,7 +305,7 @@ static int processTimeEvents(aeEventLoop *eventLoop) {
         }
 
         if (te->when <= now) {
-            int retval;
+            long long retval;
 
             id = te->id;
             te->refcount++;

--- a/src/ae.h
+++ b/src/ae.h
@@ -43,7 +43,7 @@ struct aeEventLoop;
 
 /* Types and data structures */
 typedef void aeFileProc(struct aeEventLoop *eventLoop, int fd, void *clientData, int mask);
-typedef int aeTimeProc(struct aeEventLoop *eventLoop, long long id, void *clientData);
+typedef long long aeTimeProc(struct aeEventLoop *eventLoop, long long id, void *clientData);
 typedef void aeEventFinalizerProc(struct aeEventLoop *eventLoop, void *clientData);
 typedef void aeBeforeSleepProc(struct aeEventLoop *eventLoop);
 

--- a/src/evict.c
+++ b/src/evict.c
@@ -434,7 +434,7 @@ int overMaxmemoryAfterAlloc(size_t moremem) {
  * eviction cycles until the "maxmemory" condition has resolved or there are no
  * more evictable items.  */
 static int isEvictionProcRunning = 0;
-static int evictionTimeProc(
+static long long evictionTimeProc(
         struct aeEventLoop *eventLoop, long long id, void *clientData) {
     UNUSED(eventLoop);
     UNUSED(id);

--- a/src/module.c
+++ b/src/module.c
@@ -9149,7 +9149,7 @@ typedef struct RedisModuleTimer {
 
 /* This is the timer handler that is called by the main event loop. We schedule
  * this timer to be called when the nearest of our module timers will expire. */
-int moduleTimerHandler(struct aeEventLoop *eventLoop, long long id, void *clientData) {
+static long long moduleTimerHandler(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     UNUSED(eventLoop);
     UNUSED(id);
     UNUSED(clientData);

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -177,8 +177,7 @@ static redisContext *getRedisContext(const char *ip, int port,
 static void freeRedisConfig(redisConfig *cfg);
 static int fetchClusterSlotsConfiguration(client c);
 static void updateClusterSlotsConfiguration(void);
-int showThroughput(struct aeEventLoop *eventLoop, long long id,
-                   void *clientData);
+static long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData);
 
 /* Dict callbacks */
 static uint64_t dictSdsHash(const void *key);
@@ -1633,7 +1632,7 @@ tls_usage,
     exit(exit_status);
 }
 
-int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData) {
+static long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     UNUSED(eventLoop);
     UNUSED(id);
     benchmarkThread *thread = (benchmarkThread *)clientData;

--- a/src/server.c
+++ b/src/server.c
@@ -1270,7 +1270,7 @@ void cronUpdateMemoryStats(void) {
  * a macro is used: run_with_period(milliseconds) { .... }
  */
 
-int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
+static long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     int j;
     UNUSED(eventLoop);
     UNUSED(id);


### PR DESCRIPTION
This pull requests completes fix of PR #12474 regarding an integer overflow in [processTimeEvents](https://github.com/redis/redis/blob/unstable/src/ae.c#L261) of **ae.c**
Although the major effect of maximizing the CPU usage was handled, the integer overflow could still happen for calculated next periods > `INT_MAX` resulting in wrong calculation of the next period of the time event


**Problem description**
[moduleTimerHandler](https://github.com/redis/redis/blob/unstable/src/module.c#L9148) of **module.c** calculated next expiration period with `uint64_t` value, but the function prototype of [aeTimeProc](https://github.com/redis/redis/blob/unstable/src/ae.h#L46)defines a callback with `int` return value, leading to an overflow and an erroneous calculation of next period when next timer has an expiration time > `INT_MAX`


**Impact**
This overflow does not impact normal redis since in order to be triggered module timers need to exist, with large expiration values


**How to reproduce**
-- To reproduce the problem, I have created a dedicated repository containing a versioning module. Please find it [here](https://github.com/agaraleas/redis-overflow-reproducer): 
When _run.sh_ runs, a docker image of redis will be built, with an added assertion which catches negative return values of  `moduleTimerHandler` revealing the overflow 
-- `moduleTimerHandler` returns either `-1` in case of no more or a positive value, so any negative value other than `-1` would indicate an overflow, so the assertion pinpoints the problem


**PR description**
The proposed PR fixes the overflow by changing the return type of handling function to long long

**Tests**
Changes were tested again with the help of a dedicated module here: https://github.com/agaraleas/redis-overflow-reproducer
on the branch 'test-fix' 


