### PR TITLE
Fix HFE notification test timing caused by field expiration in hexpire command

### DIFF
--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -364,7 +364,7 @@ start_server {tags {"pubsub network"}} {
         r hincrby myhash yes 10
         r hexpire myhash 999999 FIELDS 1 yes
         r hexpireat myhash [expr {[clock seconds] + 999999}] NX FIELDS 1 no
-        r hpexpire myhash 5 FIELDS 1 yes
+        r hpexpire myhash 999999 FIELDS 1 yes
         r hpersist myhash FIELDS 1 yes
         assert_encoding $type myhash
         assert_equal "pmessage * __keyspace@${db}__:myhash hset" [$rd1 read]


### PR DESCRIPTION
In the old test, we give the `hexpire` a very short expire time, which caused the filed to be deleted by the time `hpersist` command was executed. As a result, the `hpersist` command won't be able to give a `hpersist` notification, leading to test stuck.

fail CI: https://github.com/redis/redis/actions/runs/9342175887/job/25709886471