### PR TITLE
Add new hexpired notification for HFE

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -3195,6 +3195,8 @@ typedef struct dictExpireMetadata {
 #define HFE_LAZY_EXPIRE           (0) /* Delete expired field, and if last field also the hash */
 #define HFE_LAZY_AVOID_FIELD_DEL  (1<<0) /* Avoid deleting expired field */
 #define HFE_LAZY_AVOID_HASH_DEL   (1<<1) /* Avoid deleting hash if the field is the last one */
+#define HFE_LAZY_NO_NOTIFICATION  (1<<2) /* Do not send notification, used when multiple fields
+                                          * may expire and only one notification is desired. */
 
 void hashTypeConvert(robj *o, int enc, ebuckets *hexpires);
 void hashTypeTryConversion(redisDb *db, robj *subject, robj **argv, int start, int end);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2227,7 +2227,7 @@ void hmgetCommand(client *c) {
             deleted += (res == GETF_EXPIRED_HASH);
         } else {
             /* If hash got lazy expired since all fields are expired (o is invalid),
-            * then fill the rest with trivial nulls and return */
+             * then fill the rest with trivial nulls and return. */
             addReplyNull(c);
         }
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -754,7 +754,6 @@ GetFieldRes hashTypeGetValue(redisDb *db, robj *o, sds field, unsigned char **vs
     robj *keyObj = createStringObject(key, sdslen(key));
     notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", keyObj, db->id);
     if ((hashTypeLength(o, 0) == 0) && (!(hfeFlags & HFE_LAZY_AVOID_HASH_DEL))) {
-        robj *keyObj = createStringObject(key, sdslen(key));
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", keyObj, db->id);
         dbDelete(db,keyObj);
         res = GETF_EXPIRED_HASH;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2212,7 +2212,7 @@ void hmgetCommand(client *c) {
     GetFieldRes res = GETF_OK;
     robj *o;
     int i;
-    int expired = 0, deleted = 0;;
+    int expired = 0, deleted = 0;
 
     /* Don't abort when the key cannot be found. Non-existing keys are empty
      * hashes, where HMGET should respond with a series of null bulks. */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1157,6 +1157,7 @@ void hashTypeSetExDone(HashTypeSetEx *ex) {
         if (ex->fieldDeleted && hashTypeLength(ex->hashObj, 0) == 0) {
             dbDelete(ex->db,ex->key);
             signalModifiedKey(ex->c, ex->db, ex->key);
+            notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", ex->key, ex->db->id);
             notifyKeyspaceEvent(NOTIFY_GENERIC,"del",ex->key, ex->db->id);
         } else {
             signalModifiedKey(ex->c, ex->db, ex->key);

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -392,7 +392,7 @@ start_server {tags {"pubsub network"}} {
         r hmget myhash f1 f2 ;# Trigger lazy expire
         # We should get only one `hexpired` notification even two fields was expired.
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
-        # We should get a `del` notificaion after all fields were expired.
+        # We should get a `del` notification after all fields were expired.
         assert_equal "pmessage * __keyspace@${db}__:myhash del" [$rd1 read]
         r debug set-active-expire 1
 

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -392,7 +392,7 @@ start_server {tags {"pubsub network"}} {
         assert_equal "pmessage * __keyspace@${db}__:myhash hdel" [$rd1 read]
 
         # Test that we will get `hexpired` notification when
-        # a hash field is removed by lazy active.
+        # a hash field is removed by lazy expire.
         r debug set-active-expire 0
         r hpexpire myhash 10 FIELDS 2 f1 f2
         after 20

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -360,7 +360,7 @@ start_server {tags {"pubsub network"}} {
         r del myhash
         set rd1 [redis_deferring_client]
         assert_equal {1} [psubscribe $rd1 *]
-        r hmset myhash yes 1 no 0 f1 1 f2 2 f3_hdel 1
+        r hmset myhash yes 1 no 0 f1 1 f2 2 f3_hdel 3
         r hincrby myhash yes 10
         r hexpire myhash 999999 FIELDS 1 yes
         r hexpireat myhash [expr {[clock seconds] + 999999}] NX FIELDS 1 no

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -360,7 +360,7 @@ start_server {tags {"pubsub network"}} {
         r del myhash
         set rd1 [redis_deferring_client]
         assert_equal {1} [psubscribe $rd1 *]
-        r hmset myhash yes 1 no 0 f1 1 f2 2
+        r hmset myhash yes 1 no 0 f1 1 f2 2 f3_hdel 1
         r hincrby myhash yes 10
         r hexpire myhash 999999 FIELDS 1 yes
         r hexpireat myhash [expr {[clock seconds] + 999999}] NX FIELDS 1 no
@@ -379,17 +379,25 @@ start_server {tags {"pubsub network"}} {
         # Test that we will get `hexpired` notification when
         # a hash field is removed by active expire.
         r hpexpire myhash 10 FIELDS 1 no
-        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         after 100 ;# Wait for active expire
+        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
+
+        # Test that when a field with TTL is deleted by commands like hdel without
+        # updating the global DS, active expire will not send a notification.
+        r hpexpire myhash 100 FIELDS 1 f3_hdel
+        r hdel myhash f3_hdel
+        after 200 ;# Wait for active expire
+        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
+        assert_equal "pmessage * __keyspace@${db}__:myhash hdel" [$rd1 read]
 
         # Test that we will get `hexpired` notification when
         # a hash field is removed by lazy active.
         r debug set-active-expire 0
         r hpexpire myhash 10 FIELDS 2 f1 f2
-        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         after 20
         r hmget myhash f1 f2 ;# Trigger lazy expire
+        assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         # We should get only one `hexpired` notification even two fields was expired.
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
         # We should get a `del` notification after all fields were expired.

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -394,7 +394,7 @@ start_server {tags {"pubsub network"}} {
         r debug set-active-expire 1
 
         $rd1 close
-    }
+    } {0} {needs:debug}
     } ;# foreach
 
     test "Keyspace notifications: stream events test" {

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -376,15 +376,15 @@ start_server {tags {"pubsub network"}} {
         assert_equal "pmessage * __keyspace@${db}__:myhash hpersist" [$rd1 read]
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
 
-        # Test that we wll get `hexpired` notification when
-        # a hash fied is removed by active expire.
+        # Test that we will get `hexpired` notification when
+        # a hash field is removed by active expire.
         r hpexpire myhash 10 FIELDS 1 f1
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         after 100 ;# Wait for active expire
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
 
-        # Test that we wll get `hexpired` notification when
-        # a hash fied is removed by lazy active.
+        # Test that we will get `hexpired` notification when
+        # a hash field is removed by lazy active.
         r debug set-active-expire 0
         r hpexpire myhash 10 FIELDS 1 f2
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]


### PR DESCRIPTION
When the hash field expired, we will send a new `hexpired` notification.
It mainly includes the following three cases:
1. When field expired by active expiration.
2. When field expired by lazy expiration.
3. When the user uses the `h(p)expire(at)` command, the user will also get a `hexpired` notification if the field expires during the command.

## Improvement
1. Now if more than one field expires in the hmget command, we will only send a `hexpired` notification.
2. When a field with TTL is deleted by commands like hdel without updating the global DS, active expire will not send a notification.