### PR TITLE
Fix rdbLoadObject() empty hash

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -240,7 +240,7 @@ void restoreCommand(client *c) {
 
     rioInitWithBuffer(&payload,c->argv[3]->ptr);
     if (((type = rdbLoadObjectType(&payload)) == -1) ||
-        ((obj = rdbLoadObject(type,&payload,key->ptr,c->db,NULL, &minExpiredField)) == NULL))
+        ((obj = rdbLoadObject(type,&payload,key->ptr,c->db->id,NULL, &minExpiredField)) == NULL))
     {
         addReplyError(c,"Bad data format");
         return;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -176,7 +176,6 @@ void dumpCommand(client *c) {
 
 /* RESTORE key ttl serialized-value [REPLACE] [ABSTTL] [IDLETIME seconds] [FREQ frequency] */
 void restoreCommand(client *c) {
-    uint64_t minExpiredField = EB_EXPIRE_TIME_INVALID;
     long long ttl, lfu_freq = -1, lru_idle = -1, lru_clock = -1;
     rio payload;
     int j, type, replace = 0, absttl = 0;
@@ -240,7 +239,7 @@ void restoreCommand(client *c) {
 
     rioInitWithBuffer(&payload,c->argv[3]->ptr);
     if (((type = rdbLoadObjectType(&payload)) == -1) ||
-        ((obj = rdbLoadObject(type,&payload,key->ptr,c->db->id,NULL, &minExpiredField)) == NULL))
+        ((obj = rdbLoadObject(type,&payload,key->ptr,c->db->id,NULL)) == NULL))
     {
         addReplyError(c,"Bad data format");
         return;
@@ -270,8 +269,11 @@ void restoreCommand(client *c) {
 
     /* If minExpiredField was set, then the object is hash with expiration
      * on fields and need to register it in global HFE DS */
-    if (minExpiredField != EB_EXPIRE_TIME_INVALID)
-        hashTypeAddToExpires(c->db, dictGetKey(de), obj, minExpiredField);
+    if (obj->type == OBJ_HASH) {
+        uint64_t minExpiredField = hashTypeGetNextTimeToExpire(obj);
+        if (minExpiredField != EB_EXPIRE_TIME_INVALID)
+            hashTypeAddToExpires(c->db, dictGetKey(de), obj, minExpiredField);
+    }
 
     if (ttl) {
         setExpire(c,c->db,key,ttl);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2242,7 +2242,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb* db, int *error,
         serverAssert(len == 0);
     } else if (rdbtype == RDB_TYPE_HASH_METADATA) {
         size_t fieldLen;
-        sds value, field;
+        sds value;
+        hfield field;
         uint64_t expireAt;
         dict *dupSearchDict = NULL;
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1900,7 +1900,7 @@ int lpValidateIntegrityAndDups(unsigned char *lp, size_t size, int deep, int tup
 robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error,
                     uint64_t *minExpiredField)
 {
-    uint64_t minExpField = EB_EXPIRE_TIME_INVALID;
+    uint64_t minExpField = EB_EXPIRE_TIME_INVALID; /* counterpart of minExpiredField */
     robj *o = NULL, *ele, *dec;
     uint64_t len;
     unsigned int i;
@@ -2305,7 +2305,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error,
                 return NULL;
             }
 
-            /* keep the nearest expiration to connect listpack object to db expiry */
             if ((expireAt != 0) && (expireAt < minExpField)) minExpField = expireAt;
 
             /* store the values read - either to listpack or dict */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2241,7 +2241,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb* db, int *error,
         /* All pairs should be read by now */
         serverAssert(len == 0);
     } else if (rdbtype == RDB_TYPE_HASH_METADATA) {
-        size_t fieldLen;
         sds value;
         hfield field;
         uint64_t expireAt;
@@ -2286,9 +2285,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb* db, int *error,
 
             /* if needed create field with TTL metadata  */
             if (expireAt !=0)
-                field = rdbGenericLoadStringObject(rdb, RDB_LOAD_HFLD_TTL, &fieldLen);
+                field = rdbGenericLoadStringObject(rdb, RDB_LOAD_HFLD_TTL, NULL);
             else
-                field = rdbGenericLoadStringObject(rdb, RDB_LOAD_HFLD, &fieldLen);
+                field = rdbGenericLoadStringObject(rdb, RDB_LOAD_HFLD, NULL);
 
             if (field == NULL) {
                 serverLog(LL_WARNING, "failed reading hash field");

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2378,11 +2378,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb* db, int *error,
 
         if (dupSearchDict != NULL) dictRelease(dupSearchDict);
 
-        /* check for empty key (if all fields were expired) */
-        if (hashTypeLength(o, 0) == 0) {
-            decrRefCount(o);
-            goto emptykey;
-        }
     } else if (rdbtype == RDB_TYPE_LIST_QUICKLIST || rdbtype == RDB_TYPE_LIST_QUICKLIST_2) {
         if ((len = rdbLoadLen(rdb,NULL)) == RDB_LENERR) return NULL;
         if (len == 0) goto emptykey;

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -142,7 +142,7 @@ int rdbSaveToFile(const char *filename);
 int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags);
 ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid);
 size_t rdbSavedObjectLen(robj *o, robj *key, int dbid);
-robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, uint64_t *minExpiredField);
+robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error);
 void backgroundSaveDoneHandler(int exitcode, int bysignal);
 int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime,int dbid);
 ssize_t rdbSaveSingleModuleAux(rio *rdb, int when, moduleType *mt);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -121,8 +121,7 @@
 /* When rdbLoadObject() returns NULL, the err flag is
  * set to hold the type of error that occurred */
 #define RDB_LOAD_ERR_EMPTY_KEY       1   /* Error of empty key */
-#define RDB_LOAD_ERR_EXPIRED_HASH    2   /* Expired hash since all its fields are expired */
-#define RDB_LOAD_ERR_OTHER           3   /* Any other errors */
+#define RDB_LOAD_ERR_OTHER           2   /* Any other errors */
 
 ssize_t rdbWriteRaw(rio *rdb, void *p, size_t len);
 int rdbSaveType(rio *rdb, unsigned char type);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -142,7 +142,7 @@ int rdbSaveToFile(const char *filename);
 int rdbSave(int req, char *filename, rdbSaveInfo *rsi, int rdbflags);
 ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid);
 size_t rdbSavedObjectLen(robj *o, robj *key, int dbid);
-robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, redisDb *db, int *error, uint64_t *minExpiredField);
+robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, uint64_t *minExpiredField);
 void backgroundSaveDoneHandler(int exitcode, int bysignal);
 int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime,int dbid);
 ssize_t rdbSaveSingleModuleAux(rio *rdb, int when, moduleType *mt);

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -175,6 +175,7 @@ void rdbCheckSetupSignals(void) {
  * otherwise the already open file 'fp' is checked. */
 int redis_check_rdb(char *rdbfilename, FILE *fp) {
     uint64_t dbid;
+    int selected_dbid = -1;
     int type, rdbver;
     char buf[1024];
     long long expiretime, now = mstime();
@@ -246,6 +247,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             if ((dbid = rdbLoadLen(&rdb,NULL)) == RDB_LENERR)
                 goto eoferr;
             rdbCheckInfo("Selecting DB ID %llu", (unsigned long long)dbid);
+            selected_dbid = dbid;
             continue; /* Read type again. */
         } else if (type == RDB_OPCODE_RESIZEDB) {
             /* RESIZEDB: Hint about the size of the keys in the currently
@@ -331,7 +333,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         rdbstate.keys++;
         /* Read value */
         rdbstate.doing = RDB_CHECK_DOING_READ_OBJECT_VALUE;
-        if ((val = rdbLoadObject(type,&rdb,key->ptr,NULL,NULL,NULL)) == NULL)
+        if ((val = rdbLoadObject(type,&rdb,key->ptr,selected_dbid,NULL,NULL)) == NULL)
             goto eoferr;
         /* Check if the key already expired. */
         if (expiretime != -1 && expiretime < now)

--- a/src/redis-check-rdb.c
+++ b/src/redis-check-rdb.c
@@ -333,7 +333,7 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
         rdbstate.keys++;
         /* Read value */
         rdbstate.doing = RDB_CHECK_DOING_READ_OBJECT_VALUE;
-        if ((val = rdbLoadObject(type,&rdb,key->ptr,selected_dbid,NULL,NULL)) == NULL)
+        if ((val = rdbLoadObject(type,&rdb,key->ptr,selected_dbid,NULL)) == NULL)
             goto eoferr;
         /* Check if the key already expired. */
         if (expiretime != -1 && expiretime < now)

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1853,7 +1853,9 @@ static ExpireAction hashTypeActiveExpire(eItem _hashObj, void *ctx) {
 /* Return the next/minimum expiry time of the hash-field. This is useful if a
  * field with the minimum expiry is deleted, and you want to get the next
  * minimum expiry. Otherwise, consider using hashTypeGetMinExpire() which will
- * be faster. If there is no field with expiry, returns EB_EXPIRE_TIME_INVALID */
+ * be faster but less accurate.
+ *
+ * Return next min expiry. If none return EB_EXPIRE_TIME_INVALID  */
 uint64_t hashTypeGetNextTimeToExpire(robj *o) {
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
         return EB_EXPIRE_TIME_INVALID;


### PR DESCRIPTION
As part of HFE feature, the logic of rdbLoadObject() was wrongly modified to indicate of loaded empty hash from RDB as hash that all its fields got expired. Rollback to `emptykey` logic. This function should load blindly all fields, expired or not.

Manually verified:
```
605548:M 16 Jun 2024 09:20:54.278 * Server initialized
605548:M 16 Jun 2024 09:20:54.278 * Loading RDB produced by version 255.255.255
605548:M 16 Jun 2024 09:20:54.278 * RDB age 484889 seconds
605548:M 16 Jun 2024 09:20:54.278 * RDB memory usage when created 1.11 Mb
605548:M 16 Jun 2024 09:20:54.278 * rdbLoadObject skipping empty key: myhash0123456789
```

Few more minor fixes:
- remove hash double check of emptyKey
- Fix from `sds` to `hfield` in rdbLoadObject() (not really a bug. Both are of type char*)
- Revert code rdbLoadObject() to get dbid instead of db
