### PR TITLE
Update CentOS 7 repo URL for EOL and macOS GitHub Action for deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,12 @@ jobs:
     container: centos:7
     steps:
     - uses: actions/checkout@v3
+    - name: fix centos7 EOL
+      run: |
+        sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
     - name: make
       run: |
-        # Workaround the fact that CentOS 7 is EOL
-        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-        yum-config-manager --disable centos-sclo-rh
         yum -y install gcc make
         make REDIS_CFLAGS='-Werror'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: make
       run: |
+        # Workaround the fact that CentOS 7 is EOL
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+        yum-config-manager --disable centos-sclo-rh
         yum -y install gcc make
         make REDIS_CFLAGS='-Werror'
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -655,12 +655,12 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: ./src/redis-server test all --accurate
 
-  test-centos-jemalloc:
+  test-centos7-jemalloc:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'centos')
-    container: centos:8
+    container: centos:7
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -678,6 +678,10 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
+        # Workaround the fact that CentOS 7 is EOL
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+        yum-config-manager --disable centos-sclo-rh
         yum -y install gcc make
         make REDIS_CFLAGS='-Werror'
     - name: testprep
@@ -695,12 +699,12 @@ jobs:
       if: true && !contains(github.event.inputs.skiptests, 'cluster')
       run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
-  test-centos-tls-module:
+  test-centos7-tls-module:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
-    container: centos:8
+    container: centos:7
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -718,6 +722,10 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
+        # Workaround the fact that CentOS 7 is EOL
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+        yum-config-manager --disable centos-sclo-rh
         yum -y install centos-release-scl epel-release
         yum -y install devtoolset-7 openssl-devel openssl
         scl enable devtoolset-7 "make BUILD_TLS=module REDIS_CFLAGS='-Werror'"
@@ -742,12 +750,12 @@ jobs:
       run: |
         ./runtest-cluster --tls-module ${{github.event.inputs.cluster_test_args}}
 
-  test-centos-tls-module-no-tls:
+  test-centos7-tls-module-no-tls:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
-    container: centos:8
+    container: centos:7
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -765,6 +773,10 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
+        # Workaround the fact that CentOS 7 is EOL
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+        yum-config-manager --disable centos-sclo-rh
         yum -y install centos-release-scl epel-release
         yum -y install devtoolset-7 openssl-devel openssl
         scl enable devtoolset-7 "make BUILD_TLS=module REDIS_CFLAGS='-Werror'"
@@ -873,7 +885,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-11, macos-13]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -873,7 +873,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-11, macos-13]
+        os: [macos-12, macos-14]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -676,12 +676,12 @@ jobs:
       with:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
+    - name: fix centos7 EOL
+      run: |
+        sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
     - name: make
       run: |
-        # Workaround the fact that CentOS 7 is EOL
-        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-        yum-config-manager --disable centos-sclo-rh
         yum -y install gcc make
         make REDIS_CFLAGS='-Werror'
     - name: testprep
@@ -720,13 +720,17 @@ jobs:
       with:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
+    - name: fix centos7 EOL
+      run: |
+        sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+        yum -y install centos-release-scl epel-release
+        yum clean all
+        rm -rf /var/cache/yum/*
+        sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-SCLo*.repo
+        sed -i -r 's|# ?baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-SCLo*.repo
     - name: make
       run: |
-        # Workaround the fact that CentOS 7 is EOL
-        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-        yum-config-manager --disable centos-sclo-rh
-        yum -y install centos-release-scl epel-release
         yum -y install devtoolset-7 openssl-devel openssl
         scl enable devtoolset-7 "make BUILD_TLS=module REDIS_CFLAGS='-Werror'"
     - name: testprep
@@ -771,13 +775,17 @@ jobs:
       with:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
+    - name: fix centos7 EOL
+      run: |
+        sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+        yum -y install centos-release-scl epel-release
+        yum clean all
+        rm -rf /var/cache/yum/*
+        sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-SCLo*.repo
+        sed -i -r 's|# ?baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-SCLo*.repo
     - name: make
       run: |
-        # Workaround the fact that CentOS 7 is EOL
-        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-        yum-config-manager --disable centos-sclo-rh
-        yum -y install centos-release-scl epel-release
         yum -y install devtoolset-7 openssl-devel openssl
         scl enable devtoolset-7 "make BUILD_TLS=module REDIS_CFLAGS='-Werror'"
     - name: testprep
@@ -885,7 +893,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-11, macos-13]
+        os: [macos-12, macos-14]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -655,12 +655,12 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: ./src/redis-server test all --accurate
 
-  test-centos7-jemalloc:
+  test-centos-jemalloc:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'centos')
-    container: centos:7
+    container: centos:8
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -695,12 +695,12 @@ jobs:
       if: true && !contains(github.event.inputs.skiptests, 'cluster')
       run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
-  test-centos7-tls-module:
+  test-centos-tls-module:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
-    container: centos:7
+    container: centos:8
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -742,12 +742,12 @@ jobs:
       run: |
         ./runtest-cluster --tls-module ${{github.event.inputs.cluster_test_args}}
 
-  test-centos7-tls-module-no-tls:
+  test-centos-tls-module-no-tls:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
-    container: centos:7
+    container: centos:8
     timeout-minutes: 14400
     steps:
     - name: prep


### PR DESCRIPTION
1. Update macOS version in GitHub Actions due to deprecation of macOS 11 
CI for macos-11 has been skipped recently: https://github.com/redis/redis/actions/runs/9654139542/job/26627800999

Because the macOS 11 runner image will be removed by 06/28/2024.
https://github.com/actions/runner-images?elqTrackId=5abf21fe48d743178dd1e8101d7df1e9&elq=b4c0088cf3394beebfd08de751d532fd&elqaid=4097&elqat=1&elqCampaignId=4284

Run a CI just for macos: https://github.com/sundb/redis/actions/runs/9654939953

2. CentOS has arrived at EOL, we need to update the yum repo to new url.
failed CI: https://github.com/redis/redis/actions/runs/9752728820/job/26916763636

