### PR TITLE
Fix client blocked on authentication from being disconnected when cluster is down

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1254,6 +1254,10 @@ int clusterRedirectBlockedClientIfNeeded(client *c) {
         dictEntry *de;
         dictIterator *di;
 
+        /* If the client is blocked on module authentication, don't unblock it */    
+        if (c->bstate.btype == BLOCKED_MODULE && clientHasModuleAuthInProgress(c))
+            return 0;
+
         /* If the cluster is down, unblock the client with the right error.
          * If the cluster is configured to allow reads on cluster down, we
          * still want to emit this error since a write will be required


### PR DESCRIPTION
Fix for https://github.com/redis/redis/issues/13330

Ensure that a client blocked on module authentication is not disconnected by the client timeout cron.