### PR TITLE
HFE - count in command must match actual number of fields

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2929,8 +2929,8 @@ static void httlGenericCommand(client *c, const char *cmd, long long basetime, i
         return;
 
     /* Verify `numFields` is consistent with number of arguments */
-    if (numFields > (c->argc - numFieldsAt - 1)) {
-        addReplyError(c, "Parameter `numFields` is more than number of arguments");
+    if (numFields != (c->argc - numFieldsAt - 1)) {
+        addReplyError(c, "Parameter `numFields` is different than number of arguments");
         return;
     }
 
@@ -3078,6 +3078,7 @@ static void hexpireGenericCommand(client *c, const char *cmd, long long basetime
     /* Read the expiry time from command */
     if (getLongLongFromObjectOrReply(c, expireArg, &expire, NULL) != C_OK)
         return;
+
     if (expire < 0) {
         addReplyError(c,"invalid expire time, must be >= 0");
         return;
@@ -3121,8 +3122,8 @@ static void hexpireGenericCommand(client *c, const char *cmd, long long basetime
         return;
 
     /* Verify `numFields` is consistent with number of arguments */
-    if (numFields > (c->argc - numFieldsAt - 1)) {
-        addReplyError(c, "Parameter `numFields` is more than number of arguments");
+    if (numFields != (c->argc - numFieldsAt - 1)) {
+        addReplyError(c, "Parameter `numFields` is different than number of arguments");
         return;
     }
 
@@ -3249,8 +3250,8 @@ void hpersistCommand(client *c) {
         return;
 
     /* Verify `numFields` is consistent with number of arguments */
-    if (numFields > (c->argc - numFieldsAt - 1)) {
-        addReplyError(c, "Parameter `numFields` is more than number of arguments");
+    if (numFields != (c->argc - numFieldsAt - 1)) {
+        addReplyError(c, "Parameter `numFields` is different than number of arguments");
         return;
     }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2930,7 +2930,7 @@ static void httlGenericCommand(client *c, const char *cmd, long long basetime, i
 
     /* Verify `numFields` is consistent with number of arguments */
     if (numFields != (c->argc - numFieldsAt - 1)) {
-        addReplyError(c, "Parameter `numFields` is different than number of arguments");
+        addReplyError(c, "The `numfields` parameter must match the number of arguments");
         return;
     }
 
@@ -3123,7 +3123,7 @@ static void hexpireGenericCommand(client *c, const char *cmd, long long basetime
 
     /* Verify `numFields` is consistent with number of arguments */
     if (numFields != (c->argc - numFieldsAt - 1)) {
-        addReplyError(c, "Parameter `numFields` is different than number of arguments");
+        addReplyError(c, "The `numfields` parameter must match the number of arguments");
         return;
     }
 
@@ -3251,7 +3251,7 @@ void hpersistCommand(client *c) {
 
     /* Verify `numFields` is consistent with number of arguments */
     if (numFields != (c->argc - numFieldsAt - 1)) {
-        addReplyError(c, "Parameter `numFields` is different than number of arguments");
+        addReplyError(c, "The `numfields` parameter must match the number of arguments");
         return;
     }
 

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -150,8 +150,8 @@ start_server {tags {"external:skip needs:debug"}} {
             r hset myhash f1 v1
             assert_error {*Parameter `numFields` should be greater than 0} {r hpexpire myhash 1000 NX FIELDS 0 f1 f2 f3}
             # <count> not match with actual number of fields
-            assert_error {*is different than*} {r hpexpire myhash 1000 NX FIELDS 4 f1 f2 f3}
-            assert_error {*is different than*} {r hpexpire myhash 1000 NX FIELDS 2 f1 f2 f3}
+            assert_error {*parameter must match the number*} {r hpexpire myhash 1000 NX FIELDS 4 f1 f2 f3}
+            assert_error {*parameter must match the number*} {r hpexpire myhash 1000 NX FIELDS 2 f1 f2 f3}
         }
 
         test "HPEXPIRE - parameter expire-time near limit of  2^46 ($type)" {
@@ -265,8 +265,8 @@ start_server {tags {"external:skip needs:debug"}} {
             foreach cmd {HTTL HPTTL} {
                 assert_equal [r $cmd myhash FIELDS 2 field2 non_exists_field] "$T_NO_EXPIRY $T_NO_FIELD"
                 # <count> not match with actual number of fields
-                assert_error {*is different*} {r $cmd myhash FIELDS 1 non_exists_field1 non_exists_field2}
-                assert_error {*is different*} {r $cmd myhash FIELDS 3 non_exists_field1 non_exists_field2}
+                assert_error {*parameter must match the number*} {r $cmd myhash FIELDS 1 non_exists_field1 non_exists_field2}
+                assert_error {*parameter must match the number*} {r $cmd myhash FIELDS 3 non_exists_field1 non_exists_field2}
             }
         }
 
@@ -678,8 +678,8 @@ start_server {tags {"external:skip needs:debug"}} {
             assert_equal [r hpersist myhash FIELDS 2 f1 not-exists-field] "$P_OK $P_NO_FIELD"
             assert_equal [r hpersist myhash FIELDS 1 f2] "$P_NO_EXPIRY"
             # <count> not match with actual number of fields
-            assert_error {*is different*} {r hpersist myhash FIELDS 2 f1 f2 f3}
-            assert_error {*is different*} {r hpersist myhash FIELDS 4 f1 f2 f3}
+            assert_error {*parameter must match the number*} {r hpersist myhash FIELDS 2 f1 f2 f3}
+            assert_error {*parameter must match the number*} {r hpersist myhash FIELDS 4 f1 f2 f3}
         }
 
         test "HPERSIST - verify fields with TTL are persisted ($type)" {

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -1041,8 +1041,8 @@ start_server {tags {"external:skip needs:debug"}} {
 
                 # Verify HRANDFIELD deletes expired fields and propagates it
                 r hset h2 f1 v1 f2 v2
-                r hpexpire h2 1 FIELDS 1 f1
-                r hpexpire h2 50 FIELDS 1 f2
+                r hpexpire h2 1 FIELDS 2 f1 f2
+                after 5
                 assert_equal [r hrandfield h4 2] ""
                 after 200
 
@@ -1054,10 +1054,9 @@ start_server {tags {"external:skip needs:debug"}} {
                     {hpexpireat h1 * NX FIELDS 3 f3 f4 f5}
                     {hpexpireat h1 * FIELDS 1 f6}
                     {hset h2 f1 v1 f2 v2}
-                    {hpexpireat h2 * FIELDS 1 f1}
-                    {hpexpireat h2 * FIELDS 1 f2}
-                    {hdel h2 f1}
-                    {hdel h2 f2}
+                    {hpexpireat h2 * FIELDS 2 f1 f2}
+                    {hdel h2 *}
+                    {hdel h2 *}
                 }
 
                 array set keyAndFields1 [dumpAllHashes r]

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -150,8 +150,8 @@ start_server {tags {"external:skip needs:debug"}} {
             r hset myhash f1 v1
             assert_error {*Parameter `numFields` should be greater than 0} {r hpexpire myhash 1000 NX FIELDS 0 f1 f2 f3}
             # <count> not match with actual number of fields
-            assert_error {*is different than} {r hpexpire myhash 1000 NX FIELDS 4 f1 f2 f3}
-            assert_error {*is different than} {r hpexpire myhash 1000 NX FIELDS 2 f1 f2 f3}
+            assert_error {*is different than*} {r hpexpire myhash 1000 NX FIELDS 4 f1 f2 f3}
+            assert_error {*is different than*} {r hpexpire myhash 1000 NX FIELDS 2 f1 f2 f3}
         }
 
         test "HPEXPIRE - parameter expire-time near limit of  2^46 ($type)" {


### PR DESCRIPTION
There was wrong preliminary assumption that we can optionally provide vector of arguments more than count. 
This is error-prone approach that leaded to actual error in that case. This PR enforce that vector of argument match count.

Also fixed flaky HRANDFIELD test.