### PR TITLE
HFE - Fix statistic to count also lazy expired and rename INFO params

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2524,7 +2524,7 @@ void resetServerStats(void) {
     server.stat_numcommands = 0;
     server.stat_numconnections = 0;
     server.stat_expiredkeys = 0;
-    server.stat_expired_hash_fields = 0;
+    server.stat_expired_subkeys = 0;
     server.stat_expired_stale_perc = 0;
     server.stat_expired_time_cap_reached_count = 0;
     server.stat_expire_cycle_time_used = 0;
@@ -5877,7 +5877,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "sync_full:%lld\r\n", server.stat_sync_full,
             "sync_partial_ok:%lld\r\n", server.stat_sync_partial_ok,
             "sync_partial_err:%lld\r\n", server.stat_sync_partial_err,
-            "expired_hash_fields:%lld\r\n", server.stat_expired_hash_fields,
+            "expired_subkeys:%lld\r\n", server.stat_expired_subkeys,
             "expired_keys:%lld\r\n", server.stat_expiredkeys,
             "expired_stale_perc:%.2f\r\n", server.stat_expired_stale_perc*100,
             "expired_time_cap_reached_count:%lld\r\n", server.stat_expired_time_cap_reached_count,
@@ -6124,7 +6124,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
 
             if (keys || vkeys) {
                 info = sdscatprintf(info,
-                    "db%d:keys=%lld,expires=%lld,avg_ttl=%lld,hashes_with_expiry_fields=%lld\r\n",
+                    "db%d:keys=%lld,expires=%lld,avg_ttl=%lld,subexpiry=%lld\r\n",
                     j, keys, vkeys, server.db[j].avg_ttl, hexpires);
             }
         }

--- a/src/server.h
+++ b/src/server.h
@@ -1651,7 +1651,7 @@ struct redisServer {
     long long stat_numcommands;     /* Number of processed commands */
     long long stat_numconnections;  /* Number of connections received */
     long long stat_expiredkeys;     /* Number of expired keys */
-    long long stat_expired_hash_fields; /* Number of expired hash-fields */
+    long long stat_expired_subkeys; /* Number of expired subkeys (Currently only hash-fields) */
     double stat_expired_stale_perc; /* Percentage of keys probably expired */
     long long stat_expired_time_cap_reached_count; /* Early expire cycle stops.*/
     long long stat_expire_cycle_time_used; /* Cumulative microseconds used. */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -414,7 +414,7 @@ void listpackExExpire(redisDb *db, robj *o, ExpireInfo *info) {
             break;
 
         propagateHashFieldDeletion(db, ((listpackEx *) o->ptr)->key, (char *)((fref) ? fref : intbuf), flen);
-        server.stat_expired_hash_fields++;
+        server.stat_expired_subkeys++;
 
         ptr = lpNext(lpt->lp, ptr);
 
@@ -546,7 +546,7 @@ SetExRes hashTypeSetExpiryListpack(HashTypeSetEx *ex, sds field,
     if (unlikely(checkAlreadyExpired(expireAt))) {
         propagateHashFieldDeletion(ex->db, ex->key->ptr, field, sdslen(field));
         hashTypeDelete(ex->hashObj, field, 1);
-        server.stat_expired_hash_fields++;
+        server.stat_expired_subkeys++;
         ex->fieldDeleted++;
         return HSETEX_DELETED;
     }
@@ -760,7 +760,7 @@ GetFieldRes hashTypeGetValue(redisDb *db, robj *o, sds field, unsigned char **vs
     /* delete the field and propagate the deletion */
     serverAssert(hashTypeDelete(o, field, 1) == 1);
     propagateHashFieldDeletion(db, key, field, sdslen(field));
-    server.stat_expired_hash_fields++;
+    server.stat_expired_subkeys++;
 
     /* If the field is the last one in the hash, then the hash will be deleted */
     res = GETF_EXPIRED;
@@ -1045,7 +1045,7 @@ SetExRes hashTypeSetExpiryHT(HashTypeSetEx *exInfo, sds field, uint64_t expireAt
         /* replicas should not initiate deletion of fields */
         propagateHashFieldDeletion(exInfo->db, exInfo->key->ptr, field, sdslen(field));
         hashTypeDelete(exInfo->hashObj, field, 1);
-        server.stat_expired_hash_fields++;
+        server.stat_expired_subkeys++;
         exInfo->fieldDeleted++;
         return HSETEX_DELETED;
     }
@@ -2890,7 +2890,7 @@ static ExpireAction onFieldExpire(eItem item, void *ctx) {
     dictExpireMetadata *dictExpireMeta = (dictExpireMetadata *) dictMetadata(d);
     propagateHashFieldDeletion(expCtx->db, dictExpireMeta->key, hf, hfieldlen(hf));
     serverAssert(hashTypeDelete(expCtx->hashObj, hf, 0) == 1);
-    server.stat_expired_hash_fields++;
+    server.stat_expired_subkeys++;
     return ACT_REMOVE_EXP_ITEM;
 }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -414,6 +414,7 @@ void listpackExExpire(redisDb *db, robj *o, ExpireInfo *info) {
             break;
 
         propagateHashFieldDeletion(db, ((listpackEx *) o->ptr)->key, (char *)((fref) ? fref : intbuf), flen);
+        server.stat_expired_hash_fields++;
 
         ptr = lpNext(lpt->lp, ptr);
 
@@ -545,6 +546,7 @@ SetExRes hashTypeSetExpiryListpack(HashTypeSetEx *ex, sds field,
     if (unlikely(checkAlreadyExpired(expireAt))) {
         propagateHashFieldDeletion(ex->db, ex->key->ptr, field, sdslen(field));
         hashTypeDelete(ex->hashObj, field, 1);
+        server.stat_expired_hash_fields++;
         ex->fieldDeleted++;
         return HSETEX_DELETED;
     }
@@ -758,6 +760,7 @@ GetFieldRes hashTypeGetValue(redisDb *db, robj *o, sds field, unsigned char **vs
     /* delete the field and propagate the deletion */
     serverAssert(hashTypeDelete(o, field, 1) == 1);
     propagateHashFieldDeletion(db, key, field, sdslen(field));
+    server.stat_expired_hash_fields++;
 
     /* If the field is the last one in the hash, then the hash will be deleted */
     res = GETF_EXPIRED;
@@ -1042,6 +1045,7 @@ SetExRes hashTypeSetExpiryHT(HashTypeSetEx *exInfo, sds field, uint64_t expireAt
         /* replicas should not initiate deletion of fields */
         propagateHashFieldDeletion(exInfo->db, exInfo->key->ptr, field, sdslen(field));
         hashTypeDelete(exInfo->hashObj, field, 1);
+        server.stat_expired_hash_fields++;
         exInfo->fieldDeleted++;
         return HSETEX_DELETED;
     }
@@ -1833,7 +1837,6 @@ static uint64_t hashTypeExpire(robj *o, ExpireCtx *expireCtx, int updateGlobalHF
                 .itemsExpired = 0};
 
         listpackExExpire(db, o, &info);
-        server.stat_expired_hash_fields += info.itemsExpired;
         keystr = ((listpackEx*)o->ptr)->key;
     } else {
         serverAssert(o->encoding == OBJ_ENCODING_HT);

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -446,11 +446,11 @@ start_server [list overrides [list "dir" $server_path]] {
             assert_equal [r hpexpiretime key FIELDS 3 a b c] {2524600800000 65755674080852 -1}
             assert_equal [s rdb_last_load_keys_loaded] 1
 
-            # wait until expired_hash_fields equals 2
+            # wait until expired_subkeys equals 2
             wait_for_condition 10 100 {
-                [s expired_hash_fields] == 2
+                [s expired_subkeys] == 2
             } else {
-                fail "Value of expired_hash_fields is not as expected"
+                fail "Value of expired_subkeys is not as expected"
             }
         }
     }
@@ -562,9 +562,9 @@ foreach {type lp_entries} {listpack 512 dict 0} {
 
             # wait at most 2 secs to make sure 'c' and 'd' will active-expire
             wait_for_condition 20 100 {
-                [s expired_hash_fields] == 2
+                [s expired_subkeys] == 2
             } else {
-                fail "expired hash fields is [s expired_hash_fields] != 2"
+                fail "expired hash fields is [s expired_subkeys] != 2"
             }
 
             assert_equal [s rdb_last_load_keys_loaded] 1
@@ -597,7 +597,7 @@ foreach {type lp_entries} {listpack 512 dict 0} {
             after 500
 
             assert_equal [s rdb_last_load_keys_loaded] 1
-            assert_equal [s expired_hash_fields] 0
+            assert_equal [s expired_subkeys] 0
 
             # hgetall will lazy expire fields, so it's only called after the stat asserts
             assert_equal [lsort [r hgetall key]] "1 2 5 6 a b e f"

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -442,7 +442,13 @@ start_server [list overrides [list "dir" $server_path]] {
             restart_server 0 true false
             wait_done_loading r
 
-            assert_equal [lsort [r hgetall key]] "1 2 3 a b c"
+            # Never be sure when active-expire kicks in into action
+            wait_for_condition 10 10 {
+                [lsort [r hgetall key]] == "1 2 3 a b c"
+            } else {
+                fail "hgetall of key is not as expected"
+            }
+
             assert_equal [r hpexpiretime key FIELDS 3 a b c] {2524600800000 65755674080852 -1}
             assert_equal [s rdb_last_load_keys_loaded] 1
 

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -443,7 +443,7 @@ start_server [list overrides [list "dir" $server_path]] {
             wait_done_loading r
 
             # Never be sure when active-expire kicks in into action
-            wait_for_condition 10 10 {
+            wait_for_condition 100 10 {
                 [lsort [r hgetall key]] == "1 2 3 a b c"
             } else {
                 fail "hgetall of key is not as expected"

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -293,7 +293,6 @@ proc findKeyWithType {r type} {
 
 proc createComplexDataset {r ops {opt {}}} {
     set useexpire [expr {[lsearch -exact $opt useexpire] != -1}]
-    # TODO: Remove usehexpire on next commit, when RDB will support replication
     set usehexpire [expr {[lsearch -exact $opt usehexpire] != -1}]
 
     if {[lsearch -exact $opt usetag] != -1} {

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -163,9 +163,6 @@ start_server {tags {"external:skip needs:debug"}} {
         }
 
         test "Lazy Expire - fields are lazy deleted ($type)" {
-
-            # TODO remove the SELECT once dbid will be embedded inside dict/listpack
-            r select 0
             r debug set-active-expire 0
             r del myhash
 

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -1046,7 +1046,7 @@ start_server {tags {"external:skip needs:debug"}} {
 
                 # Verify HRANDFIELD deletes expired fields and propagates it
                 r hset h2 f1 v1 f2 v2
-                r hpexpire h2 1 FIELDS 1 f1
+                r hpexpire h2 10 FIELDS 1 f1
                 r hpexpire h2 50 FIELDS 1 f2
                 assert_equal [r hrandfield h4 2] ""
                 after 200
@@ -1066,8 +1066,6 @@ start_server {tags {"external:skip needs:debug"}} {
                 }
 
                 array set keyAndFields1 [dumpAllHashes r]
-                # Let some time pass and reload data from AOF
-                after 2000
                 r debug loadaof
                 array set keyAndFields2 [dumpAllHashes r]
 


### PR DESCRIPTION
* INFO command : rename `hashes_with_expiry_fields` to `subexpiry`
* INFO command : rename `expired_hash_fields` to `expired_subkeys`
* Fix statistic of `expired_subkeys` to count also lazy expired
* Remove TODOs comments leftover in TCL
* Fix potential flaky test of rdb load of hash-field-expiration 