### PR TITLE
Fix incorrect lag and entries-read value with tombstone

### DIFF
--- a/src/stream.h
+++ b/src/stream.h
@@ -141,6 +141,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 int streamDeleteItem(stream *s, streamID *id);
 void streamGetEdgeID(stream *s, int first, int skip_tombstones, streamID *edge_id);
 long long streamEstimateDistanceFromFirstEverEntry(stream *s, streamID *id);
+long long streamEstimateDistance(stream *s, streamCG *cg, streamID *next_id);
 int64_t streamTrimByLength(stream *s, long long maxlen, int approx);
 int64_t streamTrimByID(stream *s, streamID minid, int approx);
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1683,10 +1683,10 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
     while(streamIteratorGetID(&si,&id,&numfields)) {
         /* Update the group last_id if needed. */
         if (group && streamCompareID(&id,&group->last_id) > 0) {
-            if (group->entries_read != SCG_INVALID_ENTRIES_READ && !streamRangeHasTombstones(s,&group->last_id,&id)) {
-                /* A valid counter and no future tombstones mean we can 
-                 * increment the read counter to keep tracking the group's
-                 * progress. */
+            if (group->entries_read != SCG_INVALID_ENTRIES_READ && !streamRangeHasTombstones(s,&group->last_id,NULL)) {
+                /* A valid counter and no tombstones between the group's last-delivered-id
+                 * and the stream's last-generated-id mean we can increment the read counter
+                 * to keep tracking the group's progress. */
                 group->entries_read++;
             } else if (s->entries_added) {
                 /* The group's counter may be invalid, so we try to obtain it. */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1405,7 +1405,6 @@ int streamRangeHasTombstones(stream *s, streamID *start, streamID *end) {
         return 0;
     }
 
-
     if (start) {
         start_id = *start;
     } else {
@@ -1497,6 +1496,10 @@ long long streamEstimateDistanceFromFirstEverEntry(stream *s, streamID *id) {
     if (!s->length && streamCompareID(id,&s->last_id) < 1) {
         return s->entries_added;
     }
+
+    /* There are fragmentations between the `id` and the stream's last-generated-id. */
+    if (!streamIDEqZero(id) && streamCompareID(id,&s->max_deleted_entry_id) < 0)
+        return SCG_INVALID_ENTRIES_READ;
 
     int cmp_last = streamCompareID(id,&s->last_id);
     if (cmp_last == 0) {

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1405,10 +1405,6 @@ int streamRangeHasTombstones(stream *s, streamID *start, streamID *end) {
         return 0;
     }
 
-    if (streamCompareID(&s->first_id,&s->max_deleted_entry_id) > 0) {
-        /* The latest tombstone is before the first entry. */
-        return 0;
-    }
 
     if (start) {
         start_id = *start;
@@ -1684,7 +1680,7 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
     while(streamIteratorGetID(&si,&id,&numfields)) {
         /* Update the group last_id if needed. */
         if (group && streamCompareID(&id,&group->last_id) > 0) {
-            if (group->entries_read != SCG_INVALID_ENTRIES_READ && !streamRangeHasTombstones(s,&id,NULL)) {
+            if (group->entries_read != SCG_INVALID_ENTRIES_READ && !streamRangeHasTombstones(s,&group->last_id,&id)) {
                 /* A valid counter and no future tombstones mean we can 
                  * increment the read counter to keep tracking the group's
                  * progress. */

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -1239,6 +1239,31 @@ start_server {
         assert_equal [dict get $group lag] 2
     }
 
+    test {Consumer Group Lag with XDELs and tombstone after the last_id of consume group} {
+        r DEL x
+        r XGROUP CREATE x g1 $ MKSTREAM
+        r XADD x 1-0 data a
+        r XREADGROUP GROUP g1 alice STREAMS x > ;# Read one entry
+        r XADD x 2-0 data c
+        r XADD x 3-0 data d
+        r XDEL x 1-0
+        r XDEL x 2-0
+        # Now the latest tombstone(2-0) is before the first entry(3-0), but there is still
+        # a tombstone(2-0) after the last_id of the consume group.
+        set reply [r XINFO STREAM x FULL]
+        set group [lindex [dict get $reply groups] 0]
+        assert_equal [dict get $group entries-read] 1
+        assert_equal [dict get $group lag] 1
+
+        # Now there is a tombstone(2-0) after the last_id of the consume group, so after consuming
+        # entry(3-0), the group's counter will be invalid.
+        r XREADGROUP GROUP g1 alice STREAMS x > 
+        set reply [r XINFO STREAM x FULL]
+        set group [lindex [dict get $reply groups] 0]
+        assert_equal [dict get $group entries-read] 3
+        assert_equal [dict get $group lag] 0
+    }
+
     test {Loading from legacy (Redis <= v6.2.x, rdb_ver < 10) persistence} {
         # The payload was DUMPed from a v5 instance after:
         # XADD x 1-0 data a

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -1253,7 +1253,7 @@ start_server {
         set reply [r XINFO STREAM x FULL]
         set group [lindex [dict get $reply groups] 0]
         assert_equal [dict get $group entries-read] 1
-        assert_equal [dict get $group lag] 1
+        assert_equal [dict get $group lag] {}
 
         # Now there is a tombstone(2-0) after the last_id of the consume group, so after consuming
         # entry(3-0), the group's counter will be invalid.


### PR DESCRIPTION
fix: https://github.com/redis/redis/issues/13337
rebase: https://github.com/redis/redis/pull/13338

- Fixed the incorrect entries-read count in the case of an empty stream.
- Ensured the real-time accuracy of the entries-read value in XINFO, preventing inconsistencies between lag and entries-read. Consequently, the return results of some unit tests (UT) have been modified.
- Fixed the counting error when last-id < max_deleted_entry_id < first_id.