### PR TITLE
Rebuild function engines for function flush command

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -655,12 +655,12 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: ./src/redis-server test all --accurate
 
-  test-centos-jemalloc:
+  test-centos7-jemalloc:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'centos')
-    container: centos:8
+    container: centos:7
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -695,12 +695,12 @@ jobs:
       if: true && !contains(github.event.inputs.skiptests, 'cluster')
       run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
-  test-centos-tls-module:
+  test-centos7-tls-module:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
-    container: centos:8
+    container: centos:7
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -742,12 +742,12 @@ jobs:
       run: |
         ./runtest-cluster --tls-module ${{github.event.inputs.cluster_test_args}}
 
-  test-centos8-tls-module-no-tls:
+  test-centos7-tls-module-no-tls:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
-    container: centos:8
+    container: centos:7
     timeout-minutes: 14400
     steps:
     - name: prep

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -655,12 +655,12 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: ./src/redis-server test all --accurate
 
-  test-centos7-jemalloc:
+  test-centos-jemalloc:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'centos')
-    container: centos:7
+    container: centos:8
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -695,12 +695,12 @@ jobs:
       if: true && !contains(github.event.inputs.skiptests, 'cluster')
       run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
-  test-centos7-tls-module:
+  test-centos-tls-module:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
-    container: centos:7
+    container: centos:8
     timeout-minutes: 14400
     steps:
     - name: prep
@@ -742,12 +742,12 @@ jobs:
       run: |
         ./runtest-cluster --tls-module ${{github.event.inputs.cluster_test_args}}
 
-  test-centos7-tls-module-no-tls:
+  test-centos8-tls-module-no-tls:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
-    container: centos:7
+    container: centos:8
     timeout-minutes: 14400
     steps:
     - name: prep

--- a/src/function_lua.c
+++ b/src/function_lua.c
@@ -183,6 +183,12 @@ static void luaEngineFreeFunction(void *engine_ctx, void *compiled_function) {
     zfree(f_ctx);
 }
 
+static void luaEngineFreeCtx(void *engine_ctx) {
+    luaEngineCtx *lua_engine_ctx = engine_ctx;
+    lua_close(lua_engine_ctx->lua);
+    zfree(lua_engine_ctx);
+}
+
 static void luaRegisterFunctionArgsInitialize(registerFunctionArgs *register_f_args,
     sds name,
     sds desc,
@@ -480,6 +486,7 @@ int luaEngineInitEngine(void) {
         .get_function_memory_overhead = luaEngineFunctionMemoryOverhead,
         .get_engine_memory_overhead = luaEngineMemoryOverhead,
         .free_function = luaEngineFreeFunction,
+        .free_ctx = luaEngineFreeCtx,
     };
     return functionsRegisterEngine(LUA_ENGINE_NAME, lua_engine);
 }

--- a/src/functions.h
+++ b/src/functions.h
@@ -67,6 +67,9 @@ typedef struct engine {
 
     /* free the given function */
     void (*free_function)(void *engine_ctx, void *compiled_function);
+
+    /* Free the engine context. */
+    void (*free_ctx)(void *engine_ctx);
 } engine;
 
 /* Hold information about an engine.
@@ -98,6 +101,7 @@ struct functionLibInfo {
 };
 
 int functionsRegisterEngine(const char *engine_name, engine *engine_ctx);
+void functionsEngineCtxClear(dict *engs);
 sds functionsCreateWithLibraryCtx(sds code, int replace, sds* err, functionsLibCtx *lib_ctx, size_t timeout);
 unsigned long functionsMemory(void);
 unsigned long functionsMemoryOverhead(void);
@@ -116,5 +120,6 @@ int functionLibCreateFunction(sds name, void *function, functionLibInfo *li, sds
 
 int luaEngineInitEngine(void);
 int functionsInit(void);
+void functionsFree(functionsLibCtx *lib_ctx, dict *engs);
 
 #endif /* __FUNCTIONS_H_ */

--- a/src/functions.h
+++ b/src/functions.h
@@ -101,7 +101,6 @@ struct functionLibInfo {
 };
 
 int functionsRegisterEngine(const char *engine_name, engine *engine_ctx);
-void functionsEngineCtxClear(dict *engs);
 sds functionsCreateWithLibraryCtx(sds code, int replace, sds* err, functionsLibCtx *lib_ctx, size_t timeout);
 unsigned long functionsMemory(void);
 unsigned long functionsMemoryOverhead(void);

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -75,6 +75,7 @@ void lazyFreeFunctionsCtx(void *args[]) {
     dict *engs = args[1];
     size_t len = functionsLibCtxFunctionsLen(functions_lib_ctx);
     functionsLibCtxFree(functions_lib_ctx);
+    len += dictSize(engs);
     dictRelease(engs);
     atomicDecr(lazyfree_objects,len);
     atomicIncr(lazyfreed_objects,len);

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -252,7 +252,7 @@ void freeLuaScriptsAsync(dict *lua_scripts, list *lua_scripts_lru_list, lua_Stat
 /* Free functions ctx, if the functions ctx contains enough functions, free it in async way. */
 void freeFunctionsAsync(functionsLibCtx *functions_lib_ctx, dict *engs) {
     if (functionsLibCtxFunctionsLen(functions_lib_ctx) > LAZYFREE_THRESHOLD) {
-        atomicIncr(lazyfree_objects,functionsLibCtxFunctionsLen(functions_lib_ctx));
+        atomicIncr(lazyfree_objects,functionsLibCtxFunctionsLen(functions_lib_ctx)+dictSize(engs));
         bioCreateLazyFreeJob(lazyFreeFunctionsCtx,2,functions_lib_ctx,engs);
     } else {
         functionsLibCtxFree(functions_lib_ctx);

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -72,8 +72,10 @@ void lazyFreeLuaScripts(void *args[]) {
 /* Release the functions ctx. */
 void lazyFreeFunctionsCtx(void *args[]) {
     functionsLibCtx *functions_lib_ctx = args[0];
+    dict *engs = args[1];
     size_t len = functionsLibCtxFunctionsLen(functions_lib_ctx);
     functionsLibCtxFree(functions_lib_ctx);
+    functionsEngineCtxClear(engs);
     atomicDecr(lazyfree_objects,len);
     atomicIncr(lazyfreed_objects,len);
 }
@@ -247,12 +249,12 @@ void freeLuaScriptsAsync(dict *lua_scripts, list *lua_scripts_lru_list, lua_Stat
 }
 
 /* Free functions ctx, if the functions ctx contains enough functions, free it in async way. */
-void freeFunctionsAsync(functionsLibCtx *functions_lib_ctx) {
+void freeFunctionsAsync(functionsLibCtx *functions_lib_ctx, dict *engs) {
     if (functionsLibCtxFunctionsLen(functions_lib_ctx) > LAZYFREE_THRESHOLD) {
         atomicIncr(lazyfree_objects,functionsLibCtxFunctionsLen(functions_lib_ctx));
-        bioCreateLazyFreeJob(lazyFreeFunctionsCtx,1,functions_lib_ctx);
+        bioCreateLazyFreeJob(lazyFreeFunctionsCtx,2,functions_lib_ctx,engs);
     } else {
-        functionsLibCtxFree(functions_lib_ctx);
+        functionsFree(functions_lib_ctx, engs);
     }
 }
 

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -75,7 +75,7 @@ void lazyFreeFunctionsCtx(void *args[]) {
     dict *engs = args[1];
     size_t len = functionsLibCtxFunctionsLen(functions_lib_ctx);
     functionsLibCtxFree(functions_lib_ctx);
-    functionsEngineCtxClear(engs);
+    dictRelease(engs);
     atomicDecr(lazyfree_objects,len);
     atomicIncr(lazyfreed_objects,len);
 }
@@ -254,7 +254,8 @@ void freeFunctionsAsync(functionsLibCtx *functions_lib_ctx, dict *engs) {
         atomicIncr(lazyfree_objects,functionsLibCtxFunctionsLen(functions_lib_ctx));
         bioCreateLazyFreeJob(lazyFreeFunctionsCtx,2,functions_lib_ctx,engs);
     } else {
-        functionsFree(functions_lib_ctx, engs);
+        functionsLibCtxFree(functions_lib_ctx);
+        dictRelease(engs);
     }
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -3467,7 +3467,7 @@ int ldbPendingChildren(void);
 void luaLdbLineHook(lua_State *lua, lua_Debug *ar);
 void freeLuaScriptsSync(dict *lua_scripts, list *lua_scripts_lru_list, lua_State *lua);
 void freeLuaScriptsAsync(dict *lua_scripts, list *lua_scripts_lru_list, lua_State *lua);
-void freeFunctionsAsync(functionsLibCtx *lib_ctx);
+void freeFunctionsAsync(functionsLibCtx *lib_ctx, dict *engines);
 int ldbIsEnabled(void);
 void ldbLog(sds entry);
 void ldbLogRedisReply(char *reply);

--- a/src/server.h
+++ b/src/server.h
@@ -3467,7 +3467,7 @@ int ldbPendingChildren(void);
 void luaLdbLineHook(lua_State *lua, lua_Debug *ar);
 void freeLuaScriptsSync(dict *lua_scripts, list *lua_scripts_lru_list, lua_State *lua);
 void freeLuaScriptsAsync(dict *lua_scripts, list *lua_scripts_lru_list, lua_State *lua);
-void freeFunctionsAsync(functionsLibCtx *lib_ctx, dict *engines);
+void freeFunctionsAsync(functionsLibCtx *functions_lib_ctx, dict *engines);
 int ldbIsEnabled(void);
 void ldbLog(sds entry);
 void ldbLogRedisReply(char *reply);

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -288,6 +288,22 @@ start_server {tags {"scripting"}} {
         r function flush async
         assert_match {} [r function list]
 
+        # LAZYFREE_THRESHOLD is 64
+        for {set i 0} {$i < 100} {incr i} {
+            r function load REPLACE [get_function_code lua test$i test$i {local a = 1 while true do a = a + 1 end}]
+        }
+        assert_morethan [s used_memory_vm_functions] 100000
+        r config resetstat
+        r function flush async
+        # Wait for the completion of the lazy free
+        wait_for_condition 50 100 {
+            [s lazyfreed_objects] == 100
+        } else {
+            fail "Unexpected number of lazyfreed_objects: [s lazyfreed_objects]"
+        }
+        assert_match {} [r function list]
+        assert_lessthan [s used_memory_vm_functions] 40000
+
         r function load REPLACE [get_function_code lua test test {local a = 1 while true do a = a + 1 end}]
         assert_match {{library_name test engine LUA functions {{name test description {} flags {}}}}} [r function list]
         r function flush sync

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -292,7 +292,7 @@ start_server {tags {"scripting"}} {
         for {set i 0} {$i < 100} {incr i} {
             r function load REPLACE [get_function_code lua test$i test$i {local a = 1 while true do a = a + 1 end}]
         }
-        assert_morethan [s used_memory_vm_functions] 100000
+        assert_morethan [s used_memory_vm_functions] 70000
         r config resetstat
         r function flush async
         # Wait for the completion of lazy free for both functions and engines.

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -302,6 +302,8 @@ start_server {tags {"scripting"}} {
         assert_morethan [s used_memory_vm_functions] 70000
         r config resetstat
         r function flush async
+        assert_lessthan [s used_memory_vm_functions] 40000
+
         # Wait for the completion of lazy free for both functions and engines.
         set start_time [clock seconds]
         while {1} {
@@ -315,7 +317,6 @@ start_server {tags {"scripting"}} {
             error "Timeout or unexpected number of lazyfreed_objects: [s lazyfreed_objects]"
         }
         assert_match {{library_name test engine LUA functions {{name test description {} flags {}}}}} [r function list]
-        assert_lessthan [s used_memory_vm_functions] 40000
     }
 
     test {FUNCTION - test function wrong argument} {

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -297,11 +297,12 @@ start_server {tags {"scripting"}} {
         r function flush async
         # Wait for the completion of lazy free for both functions and engines.
         set start_time [clock seconds]
-        set i 0
-        while {[s lazyfreed_objects] < 101 && [expr {[clock seconds] - $start_time}] <= 5} {
-            incr i
-            # Tests for race conditions between async function flushes and main thread Lua vm operations.
+        while {1} {
+            # Tests for race conditions between async function flushes and main thread Lua VM operations.
             r function load REPLACE [get_function_code lua test test {local a = 1 while true do a = a + 1 end}]
+            if {[s lazyfreed_objects] == 101 || [expr {[clock seconds] - $start_time}] > 5} {
+                break
+            }
         }
         if {[s lazyfreed_objects] != 101} {
             error "Timeout or unexpected number of lazyfreed_objects: [s lazyfreed_objects]"


### PR DESCRIPTION
### Issue
The current implementation of `FUNCTION FLUSH` command uses `lua_unref()` to unreference script closures in Lua vm. However, invoking `lua_unref()` during lazy free (`ASYNC` argument) is risky since it is not thread-safe.

Another issue is that using `lua_unref()` to unreference references does not trigger GC, This can result in the Lua VM leaves a significant amount of garbage, which may never be cleaned up if not properly GC.

### Solution
The proposed solution is to completely rebuild the engines, resulting in a brand new Lua VM.