### PR TITLE
[WIP] add "CACHEABLE_REPLY" command tip

### DIFF
--- a/src/commands/bitcount.json
+++ b/src/commands/bitcount.json
@@ -18,6 +18,9 @@
         "acl_categories": [
             "BITMAP"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/bitfield.json
+++ b/src/commands/bitfield.json
@@ -14,6 +14,9 @@
         "acl_categories": [
             "BITMAP"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "notes": "This command allows both access and modification of the key",

--- a/src/commands/bitfield.json
+++ b/src/commands/bitfield.json
@@ -14,9 +14,6 @@
         "acl_categories": [
             "BITMAP"
         ],
-        "command_tips": [
-            "CACHEABLE_REPLY"
-        ],
         "key_specs": [
             {
                 "notes": "This command allows both access and modification of the key",

--- a/src/commands/bitfield_ro.json
+++ b/src/commands/bitfield_ro.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "BITMAP"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/bitpos.json
+++ b/src/commands/bitpos.json
@@ -18,6 +18,9 @@
         "acl_categories": [
             "BITMAP"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/exists.json
+++ b/src/commands/exists.json
@@ -21,7 +21,8 @@
         ],
         "command_tips": [
             "REQUEST_POLICY:MULTI_SHARD",
-            "RESPONSE_POLICY:AGG_SUM"
+            "RESPONSE_POLICY:AGG_SUM",
+            "CACHEABLE_REPLY"
         ],
         "key_specs": [
             {

--- a/src/commands/geodist.json
+++ b/src/commands/geodist.json
@@ -12,6 +12,9 @@
         "acl_categories": [
             "GEO"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/geohash.json
+++ b/src/commands/geohash.json
@@ -12,6 +12,9 @@
         "acl_categories": [
             "GEO"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/geopos.json
+++ b/src/commands/geopos.json
@@ -12,6 +12,9 @@
         "acl_categories": [
             "GEO"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/georadius_ro.json
+++ b/src/commands/georadius_ro.json
@@ -27,6 +27,9 @@
         "acl_categories": [
             "GEO"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/georadiusbymember_ro.json
+++ b/src/commands/georadiusbymember_ro.json
@@ -27,6 +27,9 @@
         "acl_categories": [
             "GEO"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/geosearch.json
+++ b/src/commands/geosearch.json
@@ -18,6 +18,9 @@
         "acl_categories": [
             "GEO"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/get.json
+++ b/src/commands/get.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "STRING"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/getbit.json
+++ b/src/commands/getbit.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "BITMAP"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/getrange.json
+++ b/src/commands/getrange.json
@@ -12,6 +12,9 @@
         "acl_categories": [
             "STRING"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/hexists.json
+++ b/src/commands/hexists.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "HASH"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/hget.json
+++ b/src/commands/hget.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "HASH"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/hgetall.json
+++ b/src/commands/hgetall.json
@@ -13,7 +13,8 @@
             "HASH"
         ],
         "command_tips": [
-            "NONDETERMINISTIC_OUTPUT_ORDER"
+            "NONDETERMINISTIC_OUTPUT_ORDER",
+            "CACHEABLE_REPLY"
         ],
         "key_specs": [
             {

--- a/src/commands/hkeys.json
+++ b/src/commands/hkeys.json
@@ -13,7 +13,8 @@
             "HASH"
         ],
         "command_tips": [
-            "NONDETERMINISTIC_OUTPUT_ORDER"
+            "NONDETERMINISTIC_OUTPUT_ORDER",
+            "CACHEABLE_REPLY"
         ],
         "key_specs": [
             {

--- a/src/commands/hlen.json
+++ b/src/commands/hlen.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "HASH"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/hmget.json
+++ b/src/commands/hmget.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "HASH"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/hstrlen.json
+++ b/src/commands/hstrlen.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "HASH"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/hvals.json
+++ b/src/commands/hvals.json
@@ -13,7 +13,8 @@
             "HASH"
         ],
         "command_tips": [
-            "NONDETERMINISTIC_OUTPUT_ORDER"
+            "NONDETERMINISTIC_OUTPUT_ORDER",
+            "CACHEABLE_REPLY"
         ],
         "key_specs": [
             {

--- a/src/commands/lcs.json
+++ b/src/commands/lcs.json
@@ -12,6 +12,9 @@
         "acl_categories": [
             "STRING"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/lindex.json
+++ b/src/commands/lindex.json
@@ -12,6 +12,9 @@
         "acl_categories": [
             "LIST"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/llen.json
+++ b/src/commands/llen.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "LIST"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/lpos.json
+++ b/src/commands/lpos.json
@@ -12,6 +12,9 @@
         "acl_categories": [
             "LIST"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/lrange.json
+++ b/src/commands/lrange.json
@@ -12,6 +12,9 @@
         "acl_categories": [
             "LIST"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/mget.json
+++ b/src/commands/mget.json
@@ -14,7 +14,8 @@
             "STRING"
         ],
         "command_tips": [
-            "REQUEST_POLICY:MULTI_SHARD"
+            "REQUEST_POLICY:MULTI_SHARD",
+            "CACHEABLE_REPLY"
         ],
         "key_specs": [
             {

--- a/src/commands/pfcount.json
+++ b/src/commands/pfcount.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "HYPERLOGLOG"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "notes": "RW because it may change the internal representation of the key, and propagate to replicas",

--- a/src/commands/scard.json
+++ b/src/commands/scard.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "SET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/sdiff.json
+++ b/src/commands/sdiff.json
@@ -13,7 +13,8 @@
             "SET"
         ],
         "command_tips": [
-            "NONDETERMINISTIC_OUTPUT_ORDER"
+            "NONDETERMINISTIC_OUTPUT_ORDER",
+            "CACHEABLE_REPLY"
         ],
         "key_specs": [
             {

--- a/src/commands/sinter.json
+++ b/src/commands/sinter.json
@@ -13,7 +13,8 @@
             "SET"
         ],
         "command_tips": [
-            "NONDETERMINISTIC_OUTPUT_ORDER"
+            "NONDETERMINISTIC_OUTPUT_ORDER",
+            "CACHEABLE_REPLY"
         ],
         "key_specs": [
             {

--- a/src/commands/sismember.json
+++ b/src/commands/sismember.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "SET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/smembers.json
+++ b/src/commands/smembers.json
@@ -13,7 +13,8 @@
             "SET"
         ],
         "command_tips": [
-            "NONDETERMINISTIC_OUTPUT_ORDER"
+            "NONDETERMINISTIC_OUTPUT_ORDER",
+            "CACHEABLE_REPLY"
         ],
         "key_specs": [
             {

--- a/src/commands/smismember.json
+++ b/src/commands/smismember.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "SET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/sort_ro.json
+++ b/src/commands/sort_ro.json
@@ -16,6 +16,9 @@
             "LIST",
             "DANGEROUS"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/strlen.json
+++ b/src/commands/strlen.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "STRING"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/substr.json
+++ b/src/commands/substr.json
@@ -17,6 +17,9 @@
         "acl_categories": [
             "STRING"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/sunion.json
+++ b/src/commands/sunion.json
@@ -13,7 +13,8 @@
             "SET"
         ],
         "command_tips": [
-            "NONDETERMINISTIC_OUTPUT_ORDER"
+            "NONDETERMINISTIC_OUTPUT_ORDER",
+            "CACHEABLE_REPLY"
         ],
         "key_specs": [
             {

--- a/src/commands/zcard.json
+++ b/src/commands/zcard.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zcount.json
+++ b/src/commands/zcount.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zlexcount.json
+++ b/src/commands/zlexcount.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zmscore.json
+++ b/src/commands/zmscore.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zrange.json
+++ b/src/commands/zrange.json
@@ -18,6 +18,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zrangebylex.json
+++ b/src/commands/zrangebylex.json
@@ -17,6 +17,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zrangebyscore.json
+++ b/src/commands/zrangebyscore.json
@@ -23,6 +23,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zrank.json
+++ b/src/commands/zrank.json
@@ -19,6 +19,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zrevrange.json
+++ b/src/commands/zrevrange.json
@@ -17,6 +17,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zrevrangebylex.json
+++ b/src/commands/zrevrangebylex.json
@@ -17,6 +17,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zrevrangebyscore.json
+++ b/src/commands/zrevrangebyscore.json
@@ -23,6 +23,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zrevrank.json
+++ b/src/commands/zrevrank.json
@@ -19,6 +19,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zscore.json
+++ b/src/commands/zscore.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [

--- a/src/commands/zunion.json
+++ b/src/commands/zunion.json
@@ -13,6 +13,9 @@
         "acl_categories": [
             "SORTEDSET"
         ],
+        "command_tips": [
+            "CACHEABLE_REPLY"
+        ],
         "key_specs": [
             {
                 "flags": [


### PR DESCRIPTION
In general, these are the requirements for a command to be cacheable:
- it should operate on key(s) specified in the command arguments
- has the `READONLY` flag
- has deterministic output (does not have the `NONDETERMINISTIC_OUTPUT` flag)
- does not operate on metadata (such as expiration). ATM redis does invalidate when a key TTL is set, but I think that's a "bug in the design" rather than a feature (what do you think?)

Some hash and set commands have the `NONDETERMINISTIC_OUTPUT_ORDER` but are still considered cacheable:
- `HGETALL`
- `HKEYS`
- `HVALS`
- `SDIFF`
- `SINTER`
- `SMEMBERS`
- `SUNION`

Scripts/Functions (`EVAL_RO`/`FCALL_RO`/...) are not included because they might be non-deterministic and (currently) there is no way to mark them as such. ATM I think that the server does mark keys read by commands executed from a lua script/function, but I don't think it should.. (see https://github.com/redis/redis/blob/unstable/src/server.c#L3716)