### PR TITLE
Add help for `DEBUG SCRIPT` command

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -483,7 +483,7 @@ void debugCommand(client *c) {
 "DICT-RESIZING <0|1>",
 "    Enable or disable the main dict and expire dict resizing.",
 "SCRIPT <LIST|<sha>>",
-"    Output SHA and content of all scripts or of a specific script with its SHA. ",
+"    Output SHA and content of all scripts or of a specific script with its SHA.",
 NULL
         };
         addExtendedReplyHelp(c, help, clusterDebugCommandExtendedHelp());

--- a/src/debug.c
+++ b/src/debug.c
@@ -482,6 +482,8 @@ void debugCommand(client *c) {
 "    Enable or disable the reply buffer resize cron job",
 "DICT-RESIZING <0|1>",
 "    Enable or disable the main dict and expire dict resizing.",
+"SCRIPT <LIST|<sha>>",
+"    Output SHA and content of all scripts or of a specific script with its SHA. ",
 NULL
         };
         addExtendedReplyHelp(c, help, clusterDebugCommandExtendedHelp());
@@ -1016,7 +1018,7 @@ NULL
         addReply(c, shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"script") && c->argc == 3) {
         if (!strcasecmp(c->argv[2]->ptr,"list")) {
-            dictIterator *di = dictGetIterator(getLuaScripts());
+            dictIterator *di = dictGetIterator(evalScriptsDict());
             dictEntry *de;
             while ((de = dictNext(di)) != NULL) {
                 luaScript *script = dictGetVal(de);
@@ -1026,7 +1028,7 @@ NULL
             dictReleaseIterator(di);
         } else if (sdslen(c->argv[2]->ptr) == 40) {
             dictEntry *de;
-            if ((de = dictFind(getLuaScripts(), c->argv[2]->ptr)) == NULL) {
+            if ((de = dictFind(evalScriptsDict(), c->argv[2]->ptr)) == NULL) {
                 addReplyErrorObject(c, shared.noscripterr);
                 return;
             }

--- a/src/eval.c
+++ b/src/eval.c
@@ -1737,7 +1737,3 @@ void luaLdbLineHook(lua_State *lua, lua_Debug *ar) {
         rctx->start_time = getMonotonicUs();
     }
 }
-
-dict *getLuaScripts(void) {
-    return lctx.lua_scripts;
-}

--- a/src/script.h
+++ b/src/script.h
@@ -74,7 +74,6 @@ extern scriptFlag scripts_flags_def[];
 
 void luaEnvInit(void);
 lua_State *createLuaState(void);
-dict *getLuaScripts(void);
 uint64_t scriptFlagsToCmdFlags(uint64_t cmd_flags, uint64_t script_flags);
 int scriptPrepareForRun(scriptRunCtx *r_ctx, client *engine_client, client *caller, const char *funcname, uint64_t script_flags, int ro);
 void scriptResetRun(scriptRunCtx *r_ctx);


### PR DESCRIPTION
1. Add help for `DEBUG SCRIPT` command.
2. Remove a duplicate `getLuaScripts()` which is same as `evalScriptsDict()`.