### PR TITLE
Avoid starting defrag after config resetstat for defrag test

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -21,18 +21,6 @@ proc test_memory_efficiency {range} {
     return $efficiency
 }
 
-proc wait_for_defrag_stop {maxtries delay} {
-    wait_for_condition $maxtries $delay {
-        [s active_defrag_running] eq 0
-    } else {
-        after 120 ;# serverCron only updates the info once in 100ms
-        puts [r info memory]
-        puts [r info stats]
-        puts [r memory malloc-stats]
-        fail "defrag didn't stop."
-    }
-}
-
 start_server {tags {"memefficiency external:skip"}} {
     foreach {size_range expected_min_efficiency} {
         32    0.15
@@ -49,6 +37,17 @@ start_server {tags {"memefficiency external:skip"}} {
 }
 
 run_solo {defrag} {
+    proc wait_for_defrag_stop {maxtries delay} {
+    wait_for_condition $maxtries $delay {
+        [s active_defrag_running] eq 0
+    } else {
+        after 120 ;# serverCron only updates the info once in 100ms
+        puts [r info memory]
+        puts [r info stats]
+        puts [r memory malloc-stats]
+        fail "defrag didn't stop."
+    }
+}
     proc test_active_defrag {type} {
     if {[string match {*jemalloc*} [s mem_allocator]] && [r debug mallctl arenas.page] <= 8192} {
         test "Active defrag main dictionary: $type" {

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -186,7 +186,7 @@ run_solo {defrag} {
             r script flush sync
             r config set hz 100
             r config set activedefrag no
-            wait_for_defrag_stop 2000 100
+            wait_for_defrag_stop 500 100
             r config resetstat
             r config set active-defrag-threshold-lower 5
             r config set active-defrag-cycle-min 65
@@ -245,7 +245,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 2000 100
+                wait_for_defrag_stop 500 100
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms
@@ -265,7 +265,7 @@ run_solo {defrag} {
             r flushdb
             r config set hz 100
             r config set activedefrag no
-            wait_for_defrag_stop 2000 100
+            wait_for_defrag_stop 500 100
             r config resetstat
             r config set active-defrag-max-scan-fields 1000
             r config set active-defrag-threshold-lower 5
@@ -361,7 +361,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 2000 100
+                wait_for_defrag_stop 500 100
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms
@@ -400,7 +400,7 @@ run_solo {defrag} {
             r flushdb
             r config set hz 100
             r config set activedefrag no
-            wait_for_defrag_stop 2000 100
+            wait_for_defrag_stop 500 100
             r config resetstat
             r config set active-defrag-threshold-lower 5
             r config set active-defrag-cycle-min 65
@@ -460,7 +460,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 2000 100
+                wait_for_defrag_stop 500 100
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms
@@ -493,7 +493,7 @@ run_solo {defrag} {
             r flushdb
             r config set hz 100
             r config set activedefrag no
-            wait_for_defrag_stop 2000 100
+            wait_for_defrag_stop 500 100
             r config resetstat
             # TODO: Lower the threshold after defraging the ebuckets.
             # Now just to ensure that the reference is updated correctly.
@@ -568,7 +568,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 2000 100
+                wait_for_defrag_stop 500 100
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms
@@ -587,7 +587,7 @@ run_solo {defrag} {
             r flushdb
             r config set hz 100
             r config set activedefrag no
-            wait_for_defrag_stop 2000 100
+            wait_for_defrag_stop 500 100
             r config resetstat
             r config set active-defrag-max-scan-fields 1000
             r config set active-defrag-threshold-lower 5
@@ -642,7 +642,7 @@ run_solo {defrag} {
                 }
 
                 # wait for the active defrag to stop working
-                wait_for_defrag_stop 2000 100
+                wait_for_defrag_stop 500 100
 
                 # test the fragmentation is lower
                 after 120 ;# serverCron only updates the info once in 100ms
@@ -696,7 +696,7 @@ run_solo {defrag} {
                 r flushdb
                 r config set hz 100
                 r config set activedefrag no
-                wait_for_defrag_stop 2000 100
+                wait_for_defrag_stop 500 100
                 r config resetstat
                 r config set active-defrag-max-scan-fields 1000
                 r config set active-defrag-threshold-lower 5
@@ -763,7 +763,7 @@ run_solo {defrag} {
                     }
 
                     # wait for the active defrag to stop working
-                    wait_for_defrag_stop 2000 100
+                    wait_for_defrag_stop 500 100
 
                     # test the fragmentation is lower
                     after 120 ;# serverCron only updates the info once in 100ms

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -38,16 +38,17 @@ start_server {tags {"memefficiency external:skip"}} {
 
 run_solo {defrag} {
     proc wait_for_defrag_stop {maxtries delay} {
-    wait_for_condition $maxtries $delay {
-        [s active_defrag_running] eq 0
-    } else {
-        after 120 ;# serverCron only updates the info once in 100ms
-        puts [r info memory]
-        puts [r info stats]
-        puts [r memory malloc-stats]
-        fail "defrag didn't stop."
+        wait_for_condition $maxtries $delay {
+            [s active_defrag_running] eq 0
+        } else {
+            after 120 ;# serverCron only updates the info once in 100ms
+            puts [r info memory]
+            puts [r info stats]
+            puts [r memory malloc-stats]
+            fail "defrag didn't stop."
+        }
     }
-}
+
     proc test_active_defrag {type} {
     if {[string match {*jemalloc*} [s mem_allocator]] && [r debug mallctl arenas.page] <= 8192} {
         test "Active defrag main dictionary: $type" {


### PR DESCRIPTION
If `config resetstat` is executed and a defrag is started after it, the `total_active_defrag_time` will not be 0.
When we start the defrag again, we will skip the following steps:
1. waiting for the defrag to start. (s total_active_defrag_time is equal 0)
2. waiting for the test to complete. (active_defrag_running is euqal 0)
which result in the test failed.

failed CI (frequent failure): https://github.com/redis/redis/actions/runs/9769619502/job/26969402286