### PR TITLE
KSN: HEXPIRE-like commands should emit hdel if expire-time is in the past

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1171,11 +1171,11 @@ void hashTypeSetExDone(HashTypeSetEx *ex) {
         if (ex->fieldDeleted && hashTypeLength(ex->hashObj, 0) == 0) {
             dbDelete(ex->db,ex->key);
             signalModifiedKey(ex->c, ex->db, ex->key);
-            notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", ex->key, ex->db->id);
+            notifyKeyspaceEvent(NOTIFY_HASH, "hdel", ex->key, ex->db->id);
             notifyKeyspaceEvent(NOTIFY_GENERIC,"del",ex->key, ex->db->id);
         } else {
             signalModifiedKey(ex->c, ex->db, ex->key);
-            notifyKeyspaceEvent(NOTIFY_HASH, ex->fieldDeleted ? "hexpired" : "hexpire",
+            notifyKeyspaceEvent(NOTIFY_HASH, ex->fieldDeleted ? "hdel" : "hexpire",
                                 ex->key, ex->db->id);
 
             /* If minimum HFE of the hash is smaller than expiration time of the

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -374,7 +374,7 @@ start_server {tags {"pubsub network"}} {
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         assert_equal "pmessage * __keyspace@${db}__:myhash hexpire" [$rd1 read]
         assert_equal "pmessage * __keyspace@${db}__:myhash hpersist" [$rd1 read]
-        assert_equal "pmessage * __keyspace@${db}__:myhash hexpired" [$rd1 read]
+        assert_equal "pmessage * __keyspace@${db}__:myhash hdel" [$rd1 read]
 
         # Test that we will get `hexpired` notification when
         # a hash field is removed by active expire.


### PR DESCRIPTION
To be more similar to EXPIRE-like commands, which emit a "del" notification if the expire-time is in the past