### PR TITLE
Disable aof for `Scripts do not block on waitaof` test

### DIFF
--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -266,6 +266,7 @@ start_server {tags {"scripting"}} {
     } {0}
 
     test {EVAL - Scripts do not block on waitaof} {
+        r config set appendonly no
         run_script {return redis.pcall('waitaof','0','1','0')} 0
     } {0 0}
 


### PR DESCRIPTION
The`Scripts do not block on waitaof` test keeps failing in the external CI: https://github.com/redis/redis/actions/runs/9875670156/job/27272955900?pr=13407

The main reason is that if AOF happens to be enabled, we get an acklocal of 1.







