### PR TITLE
Prevent deleting RDB read event after restarting RDB saving for other diskless replicas

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1568,15 +1568,17 @@ void rdbPipeReadHandler(struct aeEventLoop *eventLoop, int fd, void *clientData,
 
         if (stillAlive == 0) {
             serverLog(LL_WARNING,"Diskless rdb transfer, last replica dropped, killing fork child.");
+            aeDeleteFileEvent(server.el, server.rdb_pipe_read, AE_READABLE);
             killRDBChild();
         }
         /* Remove the pipe read handler if at least one write handler was set,
          * or if we are restarting a BGSAVE for other replicas. */
-        if (server.rdb_pipe_numconns_writing || (stillAlive == 0 && !hasActiveChildProcess())) {
-            if (server.rdb_pipe_read != -1)
-                aeDeleteFileEvent(server.el, server.rdb_pipe_read, AE_READABLE);
+        else if (server.rdb_pipe_numconns_writing) {
+            aeDeleteFileEvent(server.el, server.rdb_pipe_read, AE_READABLE);
             break;
         }
+
+
     }
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -1570,8 +1570,9 @@ void rdbPipeReadHandler(struct aeEventLoop *eventLoop, int fd, void *clientData,
             serverLog(LL_WARNING,"Diskless rdb transfer, last replica dropped, killing fork child.");
             killRDBChild();
         }
-        /*  Remove the pipe read handler if at least one write handler was set. */
-        if (server.rdb_pipe_numconns_writing || stillAlive == 0) {
+        /* Remove the pipe read handler if at least one write handler was set,
+         * or if we are restarting a BGSAVE for other replicas. */
+        if (server.rdb_pipe_numconns_writing || (stillAlive == 0 && !hasActiveChildProcess())) {
             if (server.rdb_pipe_read != -1)
                 aeDeleteFileEvent(server.el, server.rdb_pipe_read, AE_READABLE);
             break;


### PR DESCRIPTION
When we terminate the diskless RDB saving child process and, at the same time, we start a new BGSAVE for new replicas, we should not delete the RDB read event. Otherwise, these replicas will never receive a response.
this is a result of the recent change in https://github.com/redis/redis/pull/13361