### PR TITLE
Crash report: Use more chars for argv

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2071,7 +2071,7 @@ void logCurrentClient(client *cc, const char *title) {
         }
         robj *decoded;
         decoded = getDecodedObject(cc->argv[j]);
-        sds repr = sdscatrepr(sdsempty(),decoded->ptr, min(sdslen(decoded->ptr), 128));
+        sds repr = sdscatrepr(sdsempty(),decoded->ptr, min(sdslen(decoded->ptr), 1024));
         serverLog(LL_WARNING|LL_RAW,"argv[%d]: '%s'\n", j, (char*)repr);
         if (!strcasecmp(decoded->ptr, "auth") || !strcasecmp(decoded->ptr, "auth2")) {
             sdsfree(repr);


### PR DESCRIPTION
128 is not enough chars when we're talking about commands like RESTORE Of course, it's impossible to find the perfect number, but 1024 is better than 128, and it's not obscenely large