### PR TITLE
Test infra adjustments for external CI runs

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -42,7 +42,7 @@ jobs:
       run: make REDIS_CFLAGS=-Werror
     - name: Start redis-server
       run: |
-        ./src/redis-server --cluster-enabled yes --daemonize yes --save "" --logfile external-redis.log \
+        ./src/redis-server --cluster-enabled yes --daemonize yes --save "" --logfile external-redis-cluster.log \
           --enable-protected-configs yes --enable-debug-command yes --enable-module-command yes
     - name: Create a single node cluster
       run: ./src/redis-cli cluster addslots $(for slot in {0..16383}; do echo $slot; done); sleep 5
@@ -58,7 +58,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test-external-cluster-log
-        path: external-redis.log
+        path: external-redis-cluster.log
 
   test-external-nodebug:
     runs-on: ubuntu-latest
@@ -70,7 +70,7 @@ jobs:
         run: make REDIS_CFLAGS=-Werror
       - name: Start redis-server
         run: |
-          ./src/redis-server --daemonize yes --save "" --logfile external-redis.log
+          ./src/redis-server --daemonize yes --save "" --logfile external-redis-nodebug.log
       - name: Run external test
         run: |
           ./runtest \
@@ -81,5 +81,5 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: test-external-redis-log
-          path: external-redis.log
+          name: test-external-redis-nodebug-log
+          path: external-redis-nodebug.log

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -369,10 +369,14 @@ proc run_external_server_test {code overrides} {
     r flushall
     r function flush
 
-    # store overrides
+    # store configs
     set saved_config {}
+    foreach {param val} [r config get *] {
+        dict set saved_config $param $val
+    }
+
+    # apply overrides
     foreach {param val} $overrides {
-        dict set saved_config $param [lindex [r config get $param] 1]
         r config set $param $val
 
         # If we enable appendonly, wait for for rewrite to complete. This is
@@ -400,7 +404,8 @@ proc run_external_server_test {code overrides} {
 
     # restore overrides
     dict for {param val} $saved_config {
-        r config set $param $val
+        # some may fail, specifically immutable ones.
+        catch {r config set $param $val}
     }
 
     set srv [lpop ::servers]

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -30,7 +30,7 @@ set test_dirs {
 foreach test_dir $test_dirs {
     set files [glob -nocomplain $dir/tests/$test_dir/*.tcl]
 
-    foreach file $files {
+    foreach file [lsort $files] {
         lappend ::all_tests $test_dir/[file root [file tail $file]]
     }
 }


### PR DESCRIPTION
- when uploading server logs, make sure they don't overwrite each other.
- sort the test units to get consistent order between them (following #13220)
- backup and restore the entire server configuration, to protect one unit from config changes another unit performs