### PR TITLE
Use shard-id of the master if the replica is inconsistent with master

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -928,19 +928,12 @@ static void updateShardId(clusterNode *node, const char *shard_id) {
             for (int i = 0; i < clusterNodeNumSlaves(node); i++) {
                 clusterNode *slavenode = clusterNodeGetSlave(node, i);
                 if (memcmp(slavenode->shard_id, shard_id, CLUSTER_NAMELEN) != 0)
-                    assignShardIdToNode(slavenode, shard_id, CLUSTER_TODO_SAVE_CONFIG);
+                    assignShardIdToNode(slavenode, shard_id, CLUSTER_TODO_SAVE_CONFIG|CLUSTER_TODO_FSYNC_CONFIG);
             }
         } else {
             clusterNode *masternode = node->slaveof;
             if (memcmp(masternode->shard_id, shard_id, CLUSTER_NAMELEN) != 0)
-                assignShardIdToNode(masternode, shard_id, CLUSTER_TODO_SAVE_CONFIG);
-        }
-    }
-    if (shard_id && myself != node && myself->slaveof == node) {
-        if (memcmp(myself->shard_id, shard_id, CLUSTER_NAMELEN) != 0) {
-            /* shard-id can diverge right after a rolling upgrade
-             * from pre-7.2 releases */
-            assignShardIdToNode(myself, shard_id, CLUSTER_TODO_SAVE_CONFIG|CLUSTER_TODO_FSYNC_CONFIG);
+                assignShardIdToNode(masternode, shard_id, CLUSTER_TODO_SAVE_CONFIG|CLUSTER_TODO_FSYNC_CONFIG);
         }
     }
 }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -916,17 +916,17 @@ static void updateShardId(clusterNode *node, const char *shard_id) {
         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
 
         /* If the replica or master does not support shard-id (old version),
-        * we still need to make our best effort to keep their shard-id consistent.
-        *
-        * 1. Master supports but the replica does not.
-        *    We might first update the replica's shard-id to the master's randomly
-        *    generated shard-id. Then, when the master's shard-id arrives, we must
-        *    also update all its replicas.
-        * 2. If the master does not support but the replica does.
-        *    We also need to synchronize the master's shard-id with the replica.
-        * 3. If neither of master and replica supports it.
-        *    The master will have a randomly generated shard-id and will update
-        *    the replica to match the master's shard-id. */
+         * we still need to make our best effort to keep their shard-id consistent.
+         *
+         * 1. Master supports but the replica does not.
+         *    We might first update the replica's shard-id to the master's randomly
+         *    generated shard-id. Then, when the master's shard-id arrives, we must
+         *    also update all its replicas.
+         * 2. If the master does not support but the replica does.
+         *    We also need to synchronize the master's shard-id with the replica.
+         * 3. If neither of master and replica supports it.
+         *    The master will have a randomly generated shard-id and will update
+         *    the replica to match the master's shard-id. */
         if (node->slaveof == NULL) {
             for (int i = 0; i < clusterNodeNumSlaves(node); i++) {
                 clusterNode *slavenode = clusterNodeGetSlave(node, i);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -930,15 +930,13 @@ static void updateShardId(clusterNode *node, const char *shard_id) {
         if (node->slaveof == NULL) {
             for (int i = 0; i < clusterNodeNumSlaves(node); i++) {
                 clusterNode *slavenode = clusterNodeGetSlave(node, i);
-                if (memcmp(slavenode->shard_id, shard_id, CLUSTER_NAMELEN) != 0) {
+                if (memcmp(slavenode->shard_id, shard_id, CLUSTER_NAMELEN) != 0)
                     assignShardToNode(slavenode, shard_id, CLUSTER_TODO_SAVE_CONFIG);
-                }
             }
         } else {
             clusterNode *masternode = node->slaveof;
-            if (memcmp(masternode->shard_id, shard_id, CLUSTER_NAMELEN) != 0) {
+            if (memcmp(masternode->shard_id, shard_id, CLUSTER_NAMELEN) != 0)
                 assignShardToNode(masternode, shard_id, CLUSTER_TODO_SAVE_CONFIG);
-            }
         }
     }
     if (shard_id && myself != node && myself->slaveof == node) {


### PR DESCRIPTION
After #12805
Fix #12761

### Issue
1. If the master is an older version, the node will not send the shard-id extension, it will use a randomly generated shard-id.
2. If the replica is a newer version but its master is an older version, the node will send the shard-id.
    However, before this PR, we would update its shard-id, leading to a discrepancy between the master and replica nodes' shard-id, causing the replica to fail when loading the cluster node conf on restart.

### Solution
If the replica's shard -id is found to be inconsistent with the master's, update it to match the master's shard-id