### PR TITLE
solve race conditions in tests

### DIFF
--- a/tests/integration/failover.tcl
+++ b/tests/integration/failover.tcl
@@ -33,6 +33,12 @@ start_server {overrides {save {}}} {
         $node_2 replicaof $node_0_host $node_0_port
         wait_for_sync $node_1
         wait_for_sync $node_2
+        # wait for both replicas to be online from the perspective of the master
+        wait_for_condition 50 100 {
+            [string match "*slave0:*,state=online*slave1:*,state=online*" [$node_0 info replication]]
+        } else {
+            fail "replica didn't online in time"
+        }
     }
 
     test {failover command fails with invalid host} {

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -93,6 +93,11 @@ start_server {} {
         set n [expr $maxmemory_clients_actual / 2]
         $rr write [join [list "*1\r\n\$$n\r\n" [string repeat v $n]] ""]
         $rr flush
+        wait_for_condition 100 10 {
+            [client_field $cname tot-mem] >= $n
+        } else {
+            fail "Failed to fill qbuf for test"
+        }
         set tot_mem [client_field $cname tot-mem]
         assert {$tot_mem >= $n && $tot_mem < $maxmemory_clients_actual}
 


### PR DESCRIPTION
[exception]: Executing test client: ERR FAILOVER target replica is not online.. ERR FAILOVER target replica is not online.
    while executing
"$node_0 failover to $node_1_host $node_1_port"
    ("uplevel" body line 16)
    invoked from within
"uplevel 1 $code"
    (procedure "test" line 58)
    invoked from within
"test {failover command to specific replica works} {

[err]: client evicted due to percentage of maxmemory in tests/unit/client-eviction.tcl
Expected 33622 >= 220200 && 33622 < 440401 (context: type eval line 17 cmd {assert {$tot_mem >= $n && $tot_mem < $maxmemory_clients_actual}} proc ::test)