### PR TITLE
On active expire, factor maxToExpire based on Hertz

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -94,7 +94,8 @@ int activeExpireCycleTryExpire(redisDb *db, dictEntry *de, long long now) {
 #define ACTIVE_EXPIRE_CYCLE_SLOW_TIME_PERC 25 /* Max % of CPU to use. */
 #define ACTIVE_EXPIRE_CYCLE_ACCEPTABLE_STALE 10 /* % of stale keys after which
                                                    we do extra efforts. */
-#define HFE_ACTIVE_EXPIRE_CYCLE_FIELDS 1000
+
+#define HFE_DB_BASE_ACTIVE_EXPIRE_FIELDS_PER_SEC 10000
 
 /* Data used by the expire dict scan callback. */
 typedef struct {
@@ -161,12 +162,8 @@ static inline void activeExpireHashFieldCycle(int type) {
         return;
     }
 
-    /* Maximum number of fields to actively expire in a single call.
-     * - Give higher factor if server.hz is low
-     * - Or if number of configured DBs is 1 */
-    uint32_t maxToExpire = HFE_ACTIVE_EXPIRE_CYCLE_FIELDS *
-            ((server.hz >= 16) ? 1 : 20/server.hz) *
-            (server.dbnum == 1 ? 1 : 2);
+    /* Maximum number of fields to actively expire on a single call */
+    uint32_t maxToExpire = HFE_DB_BASE_ACTIVE_EXPIRE_FIELDS_PER_SEC / server.hz;
 
     /* If running for a while and didn't manage to active-expire all expired fields of
      * currentDb (i.e. activeExpirySequence becomes significant) then adjust maxToExpire */


### PR DESCRIPTION
Although the frequency of active expiration executions per second is determined 
by `Hz`, this modification simplifies the process by hardcoding the maximum number 
of expired fields to expire per second. The value is then divided by `Hz` to determine 
how many fields to expire during each active-expire invocation.