### PR TITLE
Ensure validity of myself as master or replica when loading cluster config

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -634,6 +634,8 @@ int clusterLoadConfig(char *filename) {
     }
     /* Config sanity check */
     if (server.cluster->myself == NULL) goto fmterr;
+    if (!(myself->flags & (CLUSTER_NODE_MASTER | CLUSTER_NODE_SLAVE))) goto fmterr;
+    if (nodeIsSlave(myself) && myself->slaveof == NULL) goto fmterr;
 
     zfree(line);
     fclose(fp);


### PR DESCRIPTION
First, we need to ensure that `curmaster` in `clusterUpdateSlotsConfigWith()` is not NULL in the line https://github.com/redis/redis/blob/82f00f5179720c8cee6cd650763d184ba943be92/src/cluster_legacy.c#L2320 otherwise, it will crash in the https://github.com/redis/redis/blob/82f00f5179720c8cee6cd650763d184ba943be92/src/cluster_legacy.c#L2395

So when loading cluster node config, we need to ensure that the following conditions are met:
1. A node must be at least one of the master or replica.
2. If a node is replica, its master can't be NULL.

In the following two nodes conf, we did not specify myself as master or slave, or set it as slave but did not set the master node, which could cause the above crash below.

this crash is same as https://github.com/redis/redis/issues/12441, but i'm sure if this is also caused by the same reason.

invalid conf1:
```
bbe6dea077542cae00bfb065f8d994b6a2ed6dab 127.0.0.1:30001@40001 master - 0 1721879042695 0 connected
3db5d0bf79d3621b1471b548e3d1c08260185f57 127.0.0.1:7001@17001 myself - 0 0 1 connected
vars currentEpoch 1 lastVoteEpoch 0
```

invalid conf2:
```
bbe6dea077542cae00bfb065f8d994b6a2ed6dab 127.0.0.1:30001@40001 master - 0 1721879042695 0 connected
3db5d0bf79d3621b1471b548e3d1c08260185f57 127.0.0.1:7001@17001 myself,slave - 0 0 1 connected
vars currentEpoch 1 lastVoteEpoch 0
```

### Reproduce steps:

1) Start a cluster

nodes_master.conf
```
bbe6dea077542cae00bfb065f8d994b6a2ed6dab 127.0.0.1:30001@40001 myself,master - 0 0 1 connected 0-16383
vars currentEpoch 1 lastVoteEpoch 0
```

start a master node
```
./src/redis-server --cluster-enabled yes --port 30001 --cluster-config-file nodes_master.conf
```

2) start a slave node

nodes_slave.conf
```
bbe6dea077542cae00bfb065f8d994b6a2ed6dab 127.0.0.1:30001@40001 master - 0 1721879042695 0 connected
3db5d0bf79d3621b1471b548e3d1c08260185f57 127.0.0.1:7001@17001 myself - 0 0 1 connected
vars currentEpoch 1 lastVoteEpoch 0
```

start the slave node
```
./src/redis-server --port 7001 --cluster-enabled yes  --cluster-config-file nodes_slave.conf
```

then the slave will crash:
```
140617:M 25 Jul 2024 14:11:44.202 * Node configuration loaded, I'm 3db5d0bf79d3621b1471b548e3d1c08260185f57
140617:M 25 Jul 2024 14:11:44.202 * Server initialized
140617:M 25 Jul 2024 14:11:44.202 . The AOF manifest file appendonly.aof.manifest doesn't exist
140617:M 25 Jul 2024 14:11:44.202 * Loading RDB produced by version 255.255.255
140617:M 25 Jul 2024 14:11:44.202 * RDB age 35 seconds
140617:M 25 Jul 2024 14:11:44.202 * RDB memory usage when created 2.18 Mb
140617:M 25 Jul 2024 14:11:44.202 * Done loading RDB, keys loaded: 0, keys expired: 0.
140617:M 25 Jul 2024 14:11:44.202 * DB loaded from disk: 0.000 seconds
140617:M 25 Jul 2024 14:11:44.202 * Ready to accept connections tcp
140617:M 25 Jul 2024 14:11:44.203 . 0 clients connected (0 replicas), 2281704 bytes in use
140617:M 25 Jul 2024 14:11:44.203 . Connecting with Node bbe6dea077542cae00bfb065f8d994b6a2ed6dab at 127.0.0.1:40001
140617:M 25 Jul 2024 14:11:44.203 . --- Processing packet of type pong, 2304 bytes
140617:M 25 Jul 2024 14:11:44.203 . pong packet received: bbe6dea077542cae00bfb065f8d994b6a2ed6dab


=== REDIS BUG REPORT START: Cut & paste starting from here ===
140617:M 25 Jul 2024 14:11:44.204 # Redis 255.255.255 crashed by signal: 11, si_code: 1
140617:M 25 Jul 2024 14:11:44.204 # Accessing address: 0x874
140617:M 25 Jul 2024 14:11:44.204 # Crashed running the instruction at: 0x5f3c2749f482

------ STACK TRACE ------
EIP:
./src/redis-server 127.0.0.1:7001 [cluster](clusterUpdateSlotsConfigWith+0x142)[0x5f3c2749f482]

140618 bio_close_file
/lib/x86_64-linux-gnu/libc.so.6(+0x98d61)[0x7b821fa98d61]
/lib/x86_64-linux-gnu/libc.so.6(pthread_cond_wait+0x20d)[0x7b821fa9b7dd]
./src/redis-server 127.0.0.1:7001 [cluster](bioProcessBackgroundJobs+0x1c2)[0x5f3c274b3e22]
/lib/x86_64-linux-gnu/libc.so.6(+0x9ca94)[0x7b821fa9ca94]
/lib/x86_64-linux-gnu/libc.so.6(+0x129c3c)[0x7b821fb29c3c]

140620 bio_lazy_free
/lib/x86_64-linux-gnu/libc.so.6(+0x98d61)[0x7b821fa98d61]
/lib/x86_64-linux-gnu/libc.so.6(pthread_cond_wait+0x20d)[0x7b821fa9b7dd]
./src/redis-server 127.0.0.1:7001 [cluster](bioProcessBackgroundJobs+0x1c2)[0x5f3c274b3e22]
/lib/x86_64-linux-gnu/libc.so.6(+0x9ca94)[0x7b821fa9ca94]
/lib/x86_64-linux-gnu/libc.so.6(+0x129c3c)[0x7b821fb29c3c]
```