### PR TITLE
Don't send pingext when cluster node doesn't support extension data

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2718,6 +2718,7 @@ int clusterProcessPacket(clusterLink *link) {
         /* If there is extension data, which doesn't have a fixed length,
          * loop through them and validate the length of it now. */
         if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
+            flags |= CLUSTER_NODE_EXT;
             clusterMsgPingExt *ext = getInitialPingExt(hdr, count);
             while (extensions--) {
                 uint16_t extlen = getPingExtLength(ext);
@@ -2769,6 +2770,10 @@ int clusterProcessPacket(clusterLink *link) {
     }
 
     sender = getNodeFromLinkAndMsg(link, hdr);
+
+    /* Copy the CLUSTER_NODE_EXT flag if there is extension data. */
+    if (sender && (flags & CLUSTER_NODE_EXT))
+        sender->flags &= CLUSTER_NODE_EXT;
 
     /* Update the last time we saw any data from this node. We
      * use this in order to avoid detecting a timeout from a node that
@@ -3612,7 +3617,8 @@ void clusterSendPing(clusterLink *link, int type) {
      * to put inside the packet. */
     estlen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
     estlen += (sizeof(clusterMsgDataGossip)*(wanted + pfail_wanted));
-    estlen += writePingExt(NULL, 0);
+    if (link->node && (link->node->flags & CLUSTER_NODE_EXT))
+        estlen += writePingExt(NULL, 0);
     /* Note: clusterBuildMessageHdr() expects the buffer to be always at least
      * sizeof(clusterMsg) or more. */
     if (estlen < (int)sizeof(clusterMsg)) estlen = sizeof(clusterMsg);
@@ -3682,7 +3688,7 @@ void clusterSendPing(clusterLink *link, int type) {
 
     /* Compute the actual total length and send! */
     uint32_t totlen = 0;
-    if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA)
+    if (link->node && link->node->flags & CLUSTER_NODE_EXT)
         totlen += writePingExt(hdr, gossipcount);
     totlen += sizeof(clusterMsg)-sizeof(union clusterMsgData);
     totlen += (sizeof(clusterMsgDataGossip)*gossipcount);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3682,7 +3682,8 @@ void clusterSendPing(clusterLink *link, int type) {
 
     /* Compute the actual total length and send! */
     uint32_t totlen = 0;
-    totlen += writePingExt(hdr, gossipcount);
+    if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA)
+        totlen += writePingExt(hdr, gossipcount);
     totlen += sizeof(clusterMsg)-sizeof(union clusterMsgData);
     totlen += (sizeof(clusterMsgDataGossip)*gossipcount);
     serverAssert(gossipcount < USHRT_MAX);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2769,7 +2769,6 @@ int clusterProcessPacket(clusterLink *link) {
     sender = getNodeFromLinkAndMsg(link, hdr);
 
     /* Copy the CLUSTER_NODE_EXT_DATA flag if there is extension data. */
-    serverAssert(flags & CLUSTER_NODE_EXT_DATA);
     if (sender && (flags & CLUSTER_NODE_EXT_DATA))
         sender->flags |= CLUSTER_NODE_EXT_DATA;
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2715,7 +2715,6 @@ int clusterProcessPacket(clusterLink *link) {
         /* If there is extension data, which doesn't have a fixed length,
          * loop through them and validate the length of it now. */
         if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
-            flags |= CLUSTER_NODE_EXT_DATA;
             clusterMsgPingExt *ext = getInitialPingExt(hdr, count);
             while (extensions--) {
                 uint16_t extlen = getPingExtLength(ext);
@@ -2768,8 +2767,8 @@ int clusterProcessPacket(clusterLink *link) {
 
     sender = getNodeFromLinkAndMsg(link, hdr);
 
-    /* Copy the CLUSTER_NODE_EXT_DATA flag if there is extension data. */
-    if (sender && (flags & CLUSTER_NODE_EXT_DATA))
+    /* Mark this node as CLUSTER_NODE_EXT_DATA if it supports extension data. */
+    if (sender && (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA))
         sender->flags |= CLUSTER_NODE_EXT_DATA;
 
     /* Update the last time we saw any data from this node. We

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2718,7 +2718,7 @@ int clusterProcessPacket(clusterLink *link) {
         /* If there is extension data, which doesn't have a fixed length,
          * loop through them and validate the length of it now. */
         if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
-            flags |= CLUSTER_NODE_EXT;
+            flags |= CLUSTER_NODE_EXT_DATA;
             clusterMsgPingExt *ext = getInitialPingExt(hdr, count);
             while (extensions--) {
                 uint16_t extlen = getPingExtLength(ext);
@@ -2771,9 +2771,9 @@ int clusterProcessPacket(clusterLink *link) {
 
     sender = getNodeFromLinkAndMsg(link, hdr);
 
-    /* Copy the CLUSTER_NODE_EXT flag if there is extension data. */
-    if (sender && (flags & CLUSTER_NODE_EXT))
-        sender->flags &= CLUSTER_NODE_EXT;
+    /* Copy the CLUSTER_NODE_EXT_DATA flag if there is extension data. */
+    if (sender && (flags & CLUSTER_NODE_EXT_DATA))
+        sender->flags &= CLUSTER_NODE_EXT_DATA;
 
     /* Update the last time we saw any data from this node. We
      * use this in order to avoid detecting a timeout from a node that
@@ -3617,7 +3617,7 @@ void clusterSendPing(clusterLink *link, int type) {
      * to put inside the packet. */
     estlen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
     estlen += (sizeof(clusterMsgDataGossip)*(wanted + pfail_wanted));
-    if (link->node && (link->node->flags & CLUSTER_NODE_EXT))
+    if (link->node && (link->node->flags & CLUSTER_NODE_EXT_DATA))
         estlen += writePingExt(NULL, 0);
     /* Note: clusterBuildMessageHdr() expects the buffer to be always at least
      * sizeof(clusterMsg) or more. */
@@ -3688,7 +3688,7 @@ void clusterSendPing(clusterLink *link, int type) {
 
     /* Compute the actual total length and send! */
     uint32_t totlen = 0;
-    if (link->node && link->node->flags & CLUSTER_NODE_EXT)
+    if (link->node && link->node->flags & CLUSTER_NODE_EXT_DATA)
         totlen += writePingExt(hdr, gossipcount);
     totlen += sizeof(clusterMsg)-sizeof(union clusterMsgData);
     totlen += (sizeof(clusterMsgDataGossip)*gossipcount);

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -51,7 +51,7 @@ typedef struct clusterLink {
 #define CLUSTER_NODE_MEET 128     /* Send a MEET message to this node */
 #define CLUSTER_NODE_MIGRATE_TO 256 /* Master eligible for replica migration. */
 #define CLUSTER_NODE_NOFAILOVER 512 /* Slave will not try to failover. */
-#define CLUSTER_NODE_EXT 1024
+#define CLUSTER_NODE_EXT_DATA 1024 /* This node supports extension data. */
 #define CLUSTER_NODE_NULL_NAME "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
 
 #define nodeIsSlave(n) ((n)->flags & CLUSTER_NODE_SLAVE)

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -51,6 +51,7 @@ typedef struct clusterLink {
 #define CLUSTER_NODE_MEET 128     /* Send a MEET message to this node */
 #define CLUSTER_NODE_MIGRATE_TO 256 /* Master eligible for replica migration. */
 #define CLUSTER_NODE_NOFAILOVER 512 /* Slave will not try to failover. */
+#define CLUSTER_NODE_EXT 1024
 #define CLUSTER_NODE_NULL_NAME "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
 
 #define nodeIsSlave(n) ((n)->flags & CLUSTER_NODE_SLAVE)

--- a/tests/unit/cluster/hostnames.tcl
+++ b/tests/unit/cluster/hostnames.tcl
@@ -145,13 +145,12 @@ test "Verify the nodes configured with prefer hostname only show hostname for ne
     # to accept our isolated nodes connections. At this point they will
     # start showing up in cluster slots. 
     wait_for_condition 50 100 {
-        [llength [R 6 CLUSTER SLOTS]] eq 2
+        [llength [R 6 CLUSTER SLOTS]] eq 2 &&
+        [lindex [get_slot_field [R 6 CLUSTER SLOTS] 0 2 3] 1] eq "shard-2.com" &&
+        [lindex [get_slot_field [R 6 CLUSTER SLOTS] 1 2 3] 1] eq "shard-3.com"
     } else {
         fail "Node did not learn about the 2 shards it can talk to"
     }
-    set slot_result [R 6 CLUSTER SLOTS]
-    assert_equal [lindex [get_slot_field $slot_result 0 2 3] 1] "shard-2.com"
-    assert_equal [lindex [get_slot_field $slot_result 1 2 3] 1] "shard-3.com"
 
     # Also make sure we know about the isolated master, we 
     # just can't reach it.
@@ -166,14 +165,13 @@ test "Verify the nodes configured with prefer hostname only show hostname for ne
     # This operation sometimes spikes to around 5 seconds to resolve the state,
     # so it has a higher timeout. 
     wait_for_condition 50 500 {
-        [llength [R 6 CLUSTER SLOTS]] eq 3
+        [llength [R 6 CLUSTER SLOTS]] eq 3 &&
+        [lindex [get_slot_field [R 6 CLUSTER SLOTS] 0 2 3] 1] eq "shard-1.com" &&
+        [lindex [get_slot_field [R 6 CLUSTER SLOTS] 1 2 3] 1] eq "shard-2.com" &&
+        [lindex [get_slot_field [R 6 CLUSTER SLOTS] 2 2 3] 1] eq "shard-3.com"
     } else {
         fail "Node did not learn about the 2 shards it can talk to"
     }
-    set slot_result [R 6 CLUSTER SLOTS]
-    assert_equal [lindex [get_slot_field $slot_result 0 2 3] 1] "shard-1.com"
-    assert_equal [lindex [get_slot_field $slot_result 1 2 3] 1] "shard-2.com"
-    assert_equal [lindex [get_slot_field $slot_result 2 2 3] 1] "shard-3.com"
 }
 
 test "Test restart will keep hostname information" {


### PR DESCRIPTION
Close #13401

### Description
This PR addresses an issue where handshake failures occur between new version nodes and older version nodes (<7.0) due to the lack of support for extension data in the older nodes.
When a new version node attempts to handshake with an older version node or opposite, the handshake will fail because the older node can't validate the length of the ping message containing extension data.

## Solution
Avoid sending ping messages with extension data to nodes that do not support it, ensuring compatibility and successful handshakes between mixed-version clusters.