### PR TITLE
Avoid cluster.nodes load corruption due to shard-id generation

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -200,7 +200,7 @@ int auxShardIdSetter(clusterNode *n, void *value, int length) {
     }
     memcpy(n->shard_id, value, CLUSTER_NAMELEN);
     /* if n already has replicas, make sure they all use
-     * use the primary shard id */
+     * the primary shard id */
     for (int i = 0; i < n->numslaves; i++) {
         if (memcmp(n->slaves[i]->shard_id, n->shard_id, CLUSTER_NAMELEN) != 0)
             updateShardId(n->slaves[i], n->shard_id);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -928,19 +928,12 @@ static void updateShardId(clusterNode *node, const char *shard_id) {
             for (int i = 0; i < clusterNodeNumSlaves(node); i++) {
                 clusterNode *slavenode = clusterNodeGetSlave(node, i);
                 if (memcmp(slavenode->shard_id, shard_id, CLUSTER_NAMELEN) != 0)
-                    assignShardIdToNode(slavenode, shard_id, CLUSTER_TODO_SAVE_CONFIG);
+                    assignShardIdToNode(slavenode, shard_id, CLUSTER_TODO_SAVE_CONFIG|CLUSTER_TODO_FSYNC_CONFIG);
             }
         } else {
             clusterNode *masternode = node->slaveof;
             if (memcmp(masternode->shard_id, shard_id, CLUSTER_NAMELEN) != 0)
-                assignShardIdToNode(masternode, shard_id, CLUSTER_TODO_SAVE_CONFIG);
-        }
-    }
-    if (shard_id && myself != node && myself->slaveof == node) {
-        if (memcmp(myself->shard_id, shard_id, CLUSTER_NAMELEN) != 0) {
-            /* shard-id can diverge right after a rolling upgrade
-             * from pre-7.2 releases */
-            assignShardIdToNode(myself, shard_id, CLUSTER_TODO_SAVE_CONFIG|CLUSTER_TODO_FSYNC_CONFIG);
+                assignShardIdToNode(masternode, shard_id, CLUSTER_TODO_SAVE_CONFIG|CLUSTER_TODO_FSYNC_CONFIG);
         }
     }
 }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -544,9 +544,11 @@ int clusterLoadConfig(char *filename) {
                 master = createClusterNode(argv[3],0);
                 clusterAddNode(master);
             }
-            /* ignore the replica shard_id in the file, use the primary,
-               if replica comes before primary in file, it will be corrected
-               later by the auxShardIdSetter */
+            /* shard_id can be absent if we are loading a nodes.conf generated
+             * by an older version of Redis; 
+             * ignore replica's shard_id in the file, only use the primary's.
+             * If replica precedes primary in file, it will be corrected
+             * later by the auxShardIdSetter */
             memcpy(n->shard_id, master->shard_id, CLUSTER_NAMELEN);
             clusterAddNodeToShard(master->shard_id, n);
             n->slaveof = master;

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -916,17 +916,17 @@ static void updateShardId(clusterNode *node, const char *shard_id) {
         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
 
         /* If the replica or master does not support shard-id (old version),
-        * we still need to make our best effort to keep their shard-id consistent.
-        *
-        * 1. Master supports but the replica does not.
-        *    We might first update the replica's shard-id to the master's randomly
-        *    generated shard-id. Then, when the master's shard-id arrives, we must
-        *    also update all its replicas.
-        * 2. If the master does not support but the replica does.
-        *    We also need to synchronize the master's shard-id with the replica.
-        * 3. If neither of master and replica supports it.
-        *    The master will have a randomly generated shard-id and will update
-        *    the replica to match the master's shard-id. */
+         * we still need to make our best effort to keep their shard-id consistent.
+         *
+         * 1. Master supports but the replica does not.
+         *    We might first update the replica's shard-id to the master's randomly
+         *    generated shard-id. Then, when the master's shard-id arrives, we must
+         *    also update all its replicas.
+         * 2. If the master does not support but the replica does.
+         *    We also need to synchronize the master's shard-id with the replica.
+         * 3. If neither of master and replica supports it.
+         *    The master will have a randomly generated shard-id and will update
+         *    the replica to match the master's shard-id. */
         if (node->slaveof == NULL) {
             for (int i = 0; i < clusterNodeNumSlaves(node); i++) {
                 clusterNode *slavenode = clusterNodeGetSlave(node, i);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -930,15 +930,13 @@ static void updateShardId(clusterNode *node, const char *shard_id) {
         if (node->slaveof == NULL) {
             for (int i = 0; i < clusterNodeNumSlaves(node); i++) {
                 clusterNode *slavenode = clusterNodeGetSlave(node, i);
-                if (memcmp(slavenode->shard_id, shard_id, CLUSTER_NAMELEN) != 0) {
+                if (memcmp(slavenode->shard_id, shard_id, CLUSTER_NAMELEN) != 0)
                     assignShardToNode(slavenode, shard_id, CLUSTER_TODO_SAVE_CONFIG);
-                }
             }
         } else {
             clusterNode *masternode = node->slaveof;
-            if (memcmp(masternode->shard_id, shard_id, CLUSTER_NAMELEN) != 0) {
+            if (memcmp(masternode->shard_id, shard_id, CLUSTER_NAMELEN) != 0)
                 assignShardToNode(masternode, shard_id, CLUSTER_TODO_SAVE_CONFIG);
-            }
         }
     }
     if (shard_id && myself != node && myself->slaveof == node) {


### PR DESCRIPTION
PR #13428 doesn't fully resolve an issue where corruption errors can still occur on loading of cluster.nodes file - seen on upgrade where there was no shard_ids (from old Redis), 7.2.5 loading generated new random ones, and persisted them to the file before gossip/handshake could propagate the correct ones (or some other nodes unreachable).
This results in a primary/replica having differing shard_id in the cluster.nodes and then the server cannot startup - reports corruption.

This PR builds on #13428 by simply ignoring the replica's shard_id in cluster.nodes (if it exists), and uses the replica's primary's shard_id.
Additional handling was necessary to cover the case where the replica appears before the primary in cluster.nodes, where it will first use a generated shard_id for the primary, and then correct after it loads the primary cluster.nodes entry.
