### PR TITLE
Fix a race condition issue in the cache_memory of functionsLibCtx

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -171,7 +171,7 @@ void functionsLibCtxClear(functionsLibCtx *lib_ctx) {
         stats->n_lib = 0;
     }
     dictReleaseIterator(iter);
-    curr_functions_lib_ctx->cache_memory = 0;
+    lib_ctx->cache_memory = 0;
 }
 
 void functionsLibCtxClearCurrent(int async) {


### PR DESCRIPTION
This is a missing of the PR https://github.com/redis/redis/pull/13383.
We will call `functionsLibCtxClear()` in bio, so we shouldn't touch `curr_functions_lib_ctx` in it.

Reproduce:
```
make distclean && make SANITIZER=thread && ./runtest --config io-threads 4 --config io-threads-do-reads yes --single unit/functions
```

Report:
```
WARNING: ThreadSanitizer: data race (pid=19476)
  Write of size 8 at 0x7f73cadcead0 by thread T3:
    #0 functionsLibCtxClear /home/sundb/data/redis_fork/src/functions.c:174 (redis-server+0x224aac)
    #1 functionsLibCtxFree /home/sundb/data/redis_fork/src/functions.c:191 (redis-server+0x224aac)
    #2 lazyFreeFunctionsCtx /home/sundb/data/redis_fork/src/lazyfree.c:77 (redis-server+0x224aac)
    #3 bioProcessBackgroundJobs /home/sundb/data/redis_fork/src/bio.c:335 (redis-server+0x1e7908)

  Previous write of size 8 at 0x7f73cadcead0 by main thread (mutexes: write M65, write M134, write M136, write M138):
    #0 libraryUnlink /home/sundb/data/redis_fork/src/functions.c:281 (redis-server+0x2c3f50)
    #1 functionsCreateWithLibraryCtx /home/sundb/data/redis_fork/src/functions.c:978 (redis-server+0x2ca98c)
    #2 functionLoadCommand /home/sundb/data/redis_fork/src/functions.c:1054 (redis-server+0x2cb5f2)
    #3 call /home/sundb/data/redis_fork/src/server.c:3575 (redis-server+0xba513)
    #4 processCommand /home/sundb/data/redis_fork/src/server.c:4206 (redis-server+0xbd5ef)
    #5 processCommandAndResetClient /home/sundb/data/redis_fork/src/networking.c:2505 (redis-server+0xf7133)
    #6 processInputBuffer /home/sundb/data/redis_fork/src/networking.c:2613 (redis-server+0xf7133)
    #7 readQueryFromClient /home/sundb/data/redis_fork/src/networking.c:2759 (redis-server+0xf7f2f)
    #8 callHandler /home/sundb/data/redis_fork/src/connhelpers.h:58 (redis-server+0x2b4a72)
    #9 connSocketEventHandler /home/sundb/data/redis_fork/src/socket.c:277 (redis-server+0x2b4a72)
    #10 aeProcessEvents /home/sundb/data/redis_fork/src/ae.c:417 (redis-server+0x9a805)
    #11 aeMain /home/sundb/data/redis_fork/src/ae.c:477 (redis-server+0x9a805)
    #12 main /home/sundb/data/redis_fork/src/server.c:7251 (redis-server+0x886c5)
```