### PR TITLE
change sentinel to repeatedly publishing +sdown messages to prevent redis instance stuck in "sdown"

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -683,11 +683,11 @@ void sentinelEvent(int level, char *type, sentinelRedisInstance *ri,
        ri (redis instance) will be stuck in "sdown" status
        and sentinels will not reach a consensus
     */
-    bool only_publish=false;
+    int only_publish=0;
     if (type[0]=='+' && (type[1]=='s' || type[1]=='o')
         && strcmp(type+2,"down")==0 && (ri->flags & (SRI_S_DOWN|SRI_O_DOWN)))
     {
-        only_publish=true;
+        only_publish=1;
         goto publish_message;
     }
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -679,7 +679,7 @@ void sentinelEvent(int level, char *type, sentinelRedisInstance *ri,
     }
 
     /* If the "+sdown" status is only published once
-       when a sentinel could not reach other sentinels at the current time and a +sdown occured
+       when a sentinel could not reach other sentinels at the current time and a +sdown occurred
        ri (redis instance) will be stuck in "sdown" status
        and sentinels will not reach a consensus
     */

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -679,15 +679,14 @@ void sentinelEvent(int level, char *type, sentinelRedisInstance *ri,
     }
 
     /* If the "+sdown" status is only published once
-       when a sentinel could not reach other sentinels at the current time and a +sdown occurred
-       ri (redis instance) will be stuck in "sdown" status
-       and sentinels will not reach a consensus
-    */
-    int only_publish=0;
-    if (type[0]=='+' && (type[1]=='s' || type[1]=='o')
-        && strcmp(type+2,"down")==0 && (ri->flags & (SRI_S_DOWN|SRI_O_DOWN)))
+     * when a sentinel could not reach other sentinels at the current time and a +sdown occurred
+     *  ri (redis instance) will be stuck in "sdown" status
+      * and sentinels will not reach a consensus. */
+    int only_publish = 0;
+    if (type[0] == '+' && (type[1] == 's' || type[1] == 'o')
+        && strcmp(type+2,"down") == 0 && (ri->flags & (SRI_S_DOWN|SRI_O_DOWN)))
     {
-        only_publish=1;
+        only_publish = 1;
         goto publish_message;
     }
 


### PR DESCRIPTION
The sentinel only publishes the "+sdown" message once. If other sentinels in the cluster do not successfully receive this message, the sentinels will not be able to perform the failover operation.

detail information: https://github.com/redis/redis/issues/13486