### PR TITLE
MOD-7645: Return module commands in ACL CAT

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2762,7 +2762,6 @@ void aclCatWithFlags(client *c, dict *commands, uint64_t cflag, int *arraylen) {
 
     while ((de = dictNext(di)) != NULL) {
         struct redisCommand *cmd = dictGetVal(de);
-        if (cmd->flags & CMD_MODULE) continue;
         if (cmd->acl_categories & cflag) {
             addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
             (*arraylen)++;


### PR DESCRIPTION
Currently, module commands are not returned for the `ACL CAT <category>` command, but skipped instead. Since now modules can add ACL categories they should no longer be skipped.