### PR TITLE
Optimize the HELLO command reply

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -12463,10 +12463,15 @@ void modulePipeReadable(aeEventLoop *el, int fd, void *privdata, int mask) {
 /* Helper function for the MODULE and HELLO command: send the list of the
  * loaded modules to the client. */
 void addReplyLoadedModules(client *c) {
+    const long ln = dictSize(modules);
+    /* In case no module is load we avoid iterator creation */
+    addReplyArrayLen(c,ln);
+    if (ln == 0) {
+        return;
+    }
     dictIterator *di = dictGetIterator(modules);
     dictEntry *de;
 
-    addReplyArrayLen(c,dictSize(modules));
     while ((de = dictNext(di)) != NULL) {
         sds name = dictGetKey(de);
         struct RedisModule *module = dictGetVal(de);

--- a/src/networking.c
+++ b/src/networking.c
@@ -3662,29 +3662,30 @@ void helloCommand(client *c) {
     if (ver) c->resp = ver;
     addReplyMapLen(c,6 + !server.sentinel_mode);
 
-    addReplyBulkCBuffer(c,"server",strlen("server"));
-    addReplyBulkCBuffer(c,"redis",strlen("redis"));
+    ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"server");
+    ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"redis");
 
-    addReplyBulkCBuffer(c,"version",strlen("version"));
-    addReplyBulkCBuffer(c,REDIS_VERSION,strlen(REDIS_VERSION));
+    ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"version");
+    ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,REDIS_VERSION);
 
-    addReplyBulkCBuffer(c,"proto",strlen("proto"));
+    ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"proto");
+
     addReplyLongLong(c,c->resp);
 
-    addReplyBulkCBuffer(c,"id",strlen("id"));
+    ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"id");
     addReplyLongLong(c,c->id);
 
-    addReplyBulkCBuffer(c,"mode",strlen("mode"));
+    ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"mode");
     if (server.sentinel_mode) addReplyBulkCString(c,"sentinel");
     else if (server.cluster_enabled) addReplyBulkCString(c,"cluster");
     else addReplyBulkCString(c,"standalone");
 
     if (!server.sentinel_mode) {
-        addReplyBulkCBuffer(c,"role",strlen("role"));
+        ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"role");
         addReplyBulkCString(c,server.masterhost ? "replica" : "master");
     }
 
-    addReplyBulkCBuffer(c,"modules",strlen("modules"));
+    ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c,"modules");
     addReplyLoadedModules(c);
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -3662,29 +3662,29 @@ void helloCommand(client *c) {
     if (ver) c->resp = ver;
     addReplyMapLen(c,6 + !server.sentinel_mode);
 
-    addReplyBulkCString(c,"server");
-    addReplyBulkCString(c,"redis");
+    addReplyBulkCBuffer(c,"server",strlen("server"));
+    addReplyBulkCBuffer(c,"redis",strlen("redis"));
 
-    addReplyBulkCString(c,"version");
-    addReplyBulkCString(c,REDIS_VERSION);
+    addReplyBulkCBuffer(c,"version",strlen("version"));
+    addReplyBulkCBuffer(c,REDIS_VERSION,strlen(REDIS_VERSION));
 
-    addReplyBulkCString(c,"proto");
+    addReplyBulkCBuffer(c,"proto",strlen("proto"));
     addReplyLongLong(c,c->resp);
 
-    addReplyBulkCString(c,"id");
+    addReplyBulkCBuffer(c,"id",strlen("id"));
     addReplyLongLong(c,c->id);
 
-    addReplyBulkCString(c,"mode");
+    addReplyBulkCBuffer(c,"mode",strlen("mode"));
     if (server.sentinel_mode) addReplyBulkCString(c,"sentinel");
     else if (server.cluster_enabled) addReplyBulkCString(c,"cluster");
     else addReplyBulkCString(c,"standalone");
 
     if (!server.sentinel_mode) {
-        addReplyBulkCString(c,"role");
+        addReplyBulkCBuffer(c,"role",strlen("role"));
         addReplyBulkCString(c,server.masterhost ? "replica" : "master");
     }
 
-    addReplyBulkCString(c,"modules");
+    addReplyBulkCBuffer(c,"modules",strlen("modules"));
     addReplyLoadedModules(c);
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -2690,6 +2690,8 @@ void initThreadedIO(void);
 client *lookupClientByID(uint64_t id);
 int authRequired(client *c);
 void putClientInPendingWriteQueue(client *c);
+/* reply macros */
+#define ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c, str) addReplyBulkCBuffer(c, str, strlen(str))
 
 /* logreqres.c - logging of requests and responses */
 void reqresReset(client *c, int free_buf);


### PR DESCRIPTION
# Overall improvement

TBD ( current is approximately 6% on the achievable ops/sec), coming from:

-  In case of no module we can skip 1.3% CPU cycles on dict Iterator creation/deletion
- Use addReplyBulkCBuffer instead of addReplyBulkCString to avoid runtime strlen overhead within HELLO reply on string constants.



## Optimization 1:  In case of no module we can skip 1.3% CPU cycles on dict Iterator creation/deletion. 

```
Function Stack	CPU Time: Total	CPU Time: Self	Module	Function (Full)	Source File	Start Address
addReplyLoadedModules	1.3%	0.064s	redis-server	addReplyLoadedModules	module.c	0x82e09
  dictNext	0.5%	0.032s	redis-server	dictNext	dict.c	0x94c50
  dictGetIterator	0.4%	0.008s	redis-server	dictGetIterator	dict.c	0x94920
```

Manual validation:

Unstable (2b88db90aad82574541edae6329ef24053fb4188):
```
$ memtier_benchmark --command "HELLO 2 SETNAME __key__" --test-time 60 --json-out-file unstable.json --hide-histogram
Json file unstable.json created...
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,  60 secs]  0 threads:     7210047 ops,  126085 (avg:  120139) ops/sec, 25.36MB/sec (avg: 24.17MB/sec),  1.58 (avg:  1.66) msec latency

4         Threads
50        Connections per thread
60        Seconds


ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Hellos     120147.56         1.66119         1.50300         3.45500        10.36700     24747.84 
Totals     120147.56         1.66119         1.50300         3.45500        10.36700     49495.68 
Json file closed.
```

This PR (4bc619abb639deebeb7cda812976e0603c5b8b62) : 
```
$ memtier_benchmark --command "HELLO 2 SETNAME __key__" --test-time 60 --json-out-file pr-3.1.json --hide-histogram
Json file pr-3.1.json created...
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,  60 secs]  0 threads:     7286407 ops,  129223 (avg:  121414) ops/sec, 25.92MB/sec (avg: 24.36MB/sec),  1.54 (avg:  1.64) msec latency

4         Threads
50        Connections per thread
60        Seconds


ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Hellos     121501.80         1.64361         1.51100         3.34300        10.43100     24960.86 
Totals     121501.80         1.64361         1.51100         3.34300        10.43100     49921.72 
Json file closed.

```


## Optimization 2:  Use addReplyBulkCBuffer instead of addReplyBulkCString to avoid runtime strlen overhead within HELLO reply on string constants.

![image](https://github.com/user-attachments/assets/8dce7810-f97a-4e0b-81d8-a8518bb3fd44)


This PR commit a88f45aed24bb9dba0421e6d23935ceeaa051f4d
```
$ memtier_benchmark --command "HELLO 2 SETNAME __key__" --test-time 60 --json-out-file pr-3.2.json --hide-histogram
Json file pr-3.2.json created...
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,  60 secs]  0 threads:     7659586 ops,  129055 (avg:  127635) ops/sec, 25.89MB/sec (avg: 25.61MB/sec),  1.55 (avg:  1.56) msec latency

4         Threads
50        Connections per thread
60        Seconds


ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Hellos     127639.64         1.56376         1.43100         3.15100         9.27900     26221.85 
Totals     127639.64         1.56376         1.43100         3.15100         9.27900     52443.71 
Json file closed.

```

TODO:
- [x] Add HELLO command benchmark to the spec. https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-connection-hello.yml