### PR TITLE
fix hincrbyfloat not to create a key if the new value is invalid (#11149）

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -605,6 +605,10 @@ void hincrbyfloatCommand(client *c) {
     unsigned int vlen;
 
     if (getLongDoubleFromObjectOrReply(c,c->argv[3],&incr,NULL) != C_OK) return;
+    if (an(incr) || isinf(incr)) {
+        addReplyError(c,"value is NaN or Infinity");
+        return;
+    }
     if ((o = hashTypeLookupWriteOrCreate(c,c->argv[1])) == NULL) return;
     if (hashTypeGetValue(o,c->argv[2]->ptr,&vstr,&vlen,&ll) == C_OK) {
         if (vstr) {


### PR DESCRIPTION
Here is a vulnerability which is fixed in the 6.0 branch https://github.com/redis/redis/commit/c924ac3fdf8fe544891dc66c88018e259ee4be87, but is not fixed in the branch of 5.0, maybe it should be backported?