### PR TITLE
changed addReplyHumanLongDouble to addReplyDouble in georadiusGeneric and geoposCommand

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -796,8 +796,8 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
 
             if (withcoords) {
                 addReplyArrayLen(c, 2);
-                addReplyHumanLongDouble(c, gp->longitude);
-                addReplyHumanLongDouble(c, gp->latitude);
+                addReplyDouble(c,gp->longitude);
+                addReplyDouble(c,gp->latitude);
             }
         }
     } else {
@@ -959,8 +959,8 @@ void geoposCommand(client *c) {
                 continue;
             }
             addReplyArrayLen(c,2);
-            addReplyHumanLongDouble(c,xy[0]);
-            addReplyHumanLongDouble(c,xy[1]);
+            addReplyDouble(c,xy[0]);
+            addReplyDouble(c,xy[1]);
         }
     }
 }


### PR DESCRIPTION
# Summary 

- Addresses https://github.com/redis/redis/issues/11565
- Measured improvements of 30% and 37% on the simple use-case (GEOSEARCH and GEOPOS) (check https://github.com/redis/redis/pull/13494#issuecomment-2313668934), and of 66% on a dataset with >60M datapoints and pipeline 10 benchmark.

TODO:
- [x] Cover this on benchmark spec, and trigger it here.
- [x] Ensure all functional tests are green after the change. check https://github.com/redis/redis/pull/13494#issuecomment-2315284039

# Manual check on 60M datapoints dataset:
## unstable
```
$ memtier_benchmark --pipeline 10 --test-time 60 --command "GEOPOS key 1 2" --hide-histogram
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,  60 secs]  0 threads:    18822810 ops,  310818 (avg:  313635) ops/sec, 47.13MB/sec (avg: 47.56MB/sec),  6.42 (avg:  6.36) msec latency

4         Threads
50        Connections per thread
60        Seconds


ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Geoposs    313631.33         6.36543         6.52700        13.31100        20.22300     48698.62 
Totals     313631.33         6.36543         6.52700        13.31100        20.22300     97397.23 
```


## this PR
```
$ memtier_benchmark --pipeline 10 --test-time 60 --command "GEOPOS key 1 2" --hide-histogram
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,  60 secs]  0 threads:    31251690 ops,  529909 (avg:  520743) ops/sec, 77.32MB/sec (avg: 75.98MB/sec),  3.76 (avg:  3.83) msec latency

4         Threads
50        Connections per thread
60        Seconds


ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Geoposs    520719.80         3.82928         3.80700         8.51100        14.59100     77802.86 
Totals     520719.80         3.82928         3.80700         8.51100        14.59100    155605.72 
```