### PR TITLE
Remove outdated "Try Redis" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Another good example is to think of Redis as a more complex version of memcached
 If you want to know more, this is a list of selected starting points:
 
 * Introduction to Redis data types. https://redis.io/topics/data-types-intro
-* Try Redis directly inside your browser. https://try.redis.io
 * The full list of Redis commands. https://redis.io/commands
 * There is much more inside the official Redis documentation. https://redis.io/documentation
 


### PR DESCRIPTION
Remove the "Try Redis" link as it is broken.