### PR TITLE
testsuite --dump-logs works on servers started before the test

### DIFF
--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -217,6 +217,7 @@ proc test {name code {okpattern undefined} {tags {}}} {
 
     send_data_packet $::test_server_fd testing $name
 
+    set failed false
     set test_start_time [clock milliseconds]
     if {[catch {set retval [uplevel 1 $code]} error]} {
         set assertion [string match "assertion:*" $error]
@@ -231,6 +232,7 @@ proc test {name code {okpattern undefined} {tags {}}} {
             lappend ::tests_failed $details
 
             incr ::num_failed
+            set failed true
             send_data_packet $::test_server_fd err [join $details "\n"]
 
             if {$::stop_on_failure} {
@@ -253,7 +255,14 @@ proc test {name code {okpattern undefined} {tags {}}} {
             lappend ::tests_failed $details
 
             incr ::num_failed
+            set failed true
             send_data_packet $::test_server_fd err [join $details "\n"]
+        }
+    }
+
+    if {$::dump_logs && $failed} {
+        foreach srv $::servers {
+            dump_server_log $srv
         }
     }
 


### PR DESCRIPTION
so far ./runtest --dump-logs used work for servers started within the test proc.
now it'll also work on servers started outside the test proc scope.
the downside is that these logs can be huge if they served many tests and not just the failing one.
but for some rare failures, we rather have that than nothing.
this feature isn't enabled y default, but is used by our GH actions.