### PR TITLE
Optimize SET/INCR*/DECR*/SETRANGE/APPEND by reducing duplicate computation

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -48,7 +48,9 @@ void updateLFU(robj *val) {
 /* Lookup a key for read or write operations, or return NULL if the key is not
  * found in the specified DB. This function implements the functionality of
  * lookupKeyRead(), lookupKeyWrite() and their ...WithFlags() variants.
- * The dictEntry reference input is optional, can be used if we already have one.
+ *
+ * 'deref' is an optional output dictEntry reference argument, to get the
+ * associated dictEntry* of the key in case the key is found.
  *
  * Side-effects of calling this function:
  *

--- a/src/db.c
+++ b/src/db.c
@@ -48,6 +48,7 @@ void updateLFU(robj *val) {
 /* Lookup a key for read or write operations, or return NULL if the key is not
  * found in the specified DB. This function implements the functionality of
  * lookupKeyRead(), lookupKeyWrite() and their ...WithFlags() variants.
+ * The dictEntry reference input is optional, can be used if we already have one.
  *
  * Side-effects of calling this function:
  *
@@ -474,14 +475,7 @@ int dbDelete(redisDb *db, robj *key) {
  * using an sdscat() call to append some data, or anything else.
  */
 robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o) {
-    serverAssert(o->type == OBJ_STRING);
-    if (o->refcount != 1 || o->encoding != OBJ_ENCODING_RAW) {
-        robj *decoded = getDecodedObject(o);
-        o = createRawStringObject(decoded->ptr, sdslen(decoded->ptr));
-        decrRefCount(decoded);
-        dbReplaceValue(db,key,o);
-    }
-    return o;
+    dbUnshareStringValueWithDictEntry(db,key,o,NULL);
 }
 
 

--- a/src/db.c
+++ b/src/db.c
@@ -477,7 +477,7 @@ int dbDelete(redisDb *db, robj *key) {
  * using an sdscat() call to append some data, or anything else.
  */
 robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o) {
-    dbUnshareStringValueWithDictEntry(db,key,o,NULL);
+    return dbUnshareStringValueWithDictEntry(db,key,o,NULL);
 }
 
 

--- a/src/db.c
+++ b/src/db.c
@@ -126,7 +126,7 @@ robj *lookupKey(redisDb *db, robj *key, int flags, dictEntry **deref) {
         /* TODO: Use separate misses stats and notify event for WRITE */
     }
 
-    if (deref) *deref = de;
+    if (val && deref) *deref = de;
     return val;
 }
 

--- a/src/db.c
+++ b/src/db.c
@@ -72,8 +72,8 @@ void updateLFU(robj *val) {
  * Even if the key expiry is master-driven, we can correctly report a key is
  * expired on replicas even if the master is lagging expiring our key via DELs
  * in the replication link. */
-robj *lookupKey(redisDb *db, robj *key, int flags, dictEntry *de) {
-    if (!de) de = dbFind(db, key->ptr);
+robj *lookupKey(redisDb *db, robj *key, int flags, dictEntry **deref) {
+    dictEntry *de = dbFind(db, key->ptr);
     robj *val = NULL;
     if (de) {
         val = dictGetVal(de);
@@ -123,6 +123,7 @@ robj *lookupKey(redisDb *db, robj *key, int flags, dictEntry *de) {
         /* TODO: Use separate misses stats and notify event for WRITE */
     }
 
+    if (deref) *deref = de;
     return val;
 }
 
@@ -163,8 +164,8 @@ robj *lookupKeyWrite(redisDb *db, robj *key) {
 /* Like lookupKeyWrite(), but accepts an optional dictEntry input,
  * which can be used if we already have one, thus saving the dbFind call.
  */
-robj *lookupKeyWriteWithDictEntry(redisDb *db, robj *key, dictEntry *de) {
-    return lookupKey(db, key, LOOKUP_NONE | LOOKUP_WRITE, de);
+robj *lookupKeyWriteWithDictEntry(redisDb *db, robj *key, dictEntry **deref) {
+    return lookupKey(db, key, LOOKUP_NONE | LOOKUP_WRITE, deref);
 }
 
 robj *lookupKeyReadOrReply(client *c, robj *key, robj *reply) {

--- a/src/db.c
+++ b/src/db.c
@@ -327,8 +327,7 @@ void setKey(client *c, redisDb *db, robj *key, robj *val, int flags) {
 }
 
 /* Like setKey(), but accepts an optional dictEntry input,
- * which can be used if we already have one, thus saving the dictFind call.
- */
+ * which can be used if we already have one, thus saving the dictFind call. */
 void setKeyWithDictEntry(client *c, redisDb *db, robj *key, robj *val, int flags, dictEntry *de) {
     int keyfound = 0;
 
@@ -486,8 +485,7 @@ robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o) {
 
 
 /* Like dbUnshareStringValue(), but accepts a optional dictEntry,
- * which can be used if we already have one, thus saving the dbFind call.
- */
+ * which can be used if we already have one, thus saving the dbFind call. */
 robj *dbUnshareStringValueWithDictEntry(redisDb *db, robj *key, robj *o, dictEntry *de) {
     serverAssert(o->type == OBJ_STRING);
     if (o->refcount != 1 || o->encoding != OBJ_ENCODING_RAW) {
@@ -1875,8 +1873,7 @@ void setExpire(client *c, redisDb *db, robj *key, long long when) {
 }
 
 /* Like setExpire(), but accepts an optional dictEntry input,
- * which can be used if we already have one, thus saving the kvstoreDictFind call.
- */
+ * which can be used if we already have one, thus saving the kvstoreDictFind call. */
 void setExpireWithDictEntry(client *c, redisDb *db, robj *key, long long when, dictEntry *kde) {
     dictEntry *de, *existing;
 

--- a/src/db.c
+++ b/src/db.c
@@ -323,6 +323,13 @@ void dbReplaceValueWithDictEntry(redisDb *db, robj *key, robj *val, dictEntry *d
  * The client 'c' argument may be set to NULL if the operation is performed
  * in a context where there is no clear client performing the operation. */
 void setKey(client *c, redisDb *db, robj *key, robj *val, int flags) {
+    setKeyWithDictEntry(c,db,key,val,flags,NULL);
+}
+
+/* Like setKey(), but accepts an optional dictEntry input,
+ * which can be used if we already have one, thus saving the dictFind call.
+ */
+void setKeyWithDictEntry(client *c, redisDb *db, robj *key, robj *val, int flags, dictEntry *de) {
     int keyfound = 0;
 
     if (flags & SETKEY_ALREADY_EXIST)
@@ -337,7 +344,7 @@ void setKey(client *c, redisDb *db, robj *key, robj *val, int flags) {
     } else if (keyfound<0) {
         dbAddInternal(db,key,val,1);
     } else {
-        dbSetValue(db,key,val,1,NULL);
+        dbSetValue(db,key,val,1,de);
     }
     incrRefCount(val);
     if (!(flags & SETKEY_KEEPTTL)) removeExpire(db,key);

--- a/src/db.c
+++ b/src/db.c
@@ -480,7 +480,6 @@ robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o) {
     return dbUnshareStringValueWithDictEntry(db,key,o,NULL);
 }
 
-
 /* Like dbUnshareStringValue(), but accepts a optional dictEntry,
  * which can be used if we already have one, thus saving the dbFind call. */
 robj *dbUnshareStringValueWithDictEntry(redisDb *db, robj *key, robj *o, dictEntry *de) {

--- a/src/db.c
+++ b/src/db.c
@@ -1876,7 +1876,7 @@ void setExpireWithDictEntry(client *c, redisDb *db, robj *key, long long when, d
 
     /* Reuse the sds from the main dict in the expire dict */
     int slot = getKeySlot(key->ptr);
-    if (!kde) kde = kvstoreDictFind(db->keys, slot, key->ptr);;
+    if (!kde) kde = kvstoreDictFind(db->keys, slot, key->ptr);
     serverAssertWithInfo(NULL,key,kde != NULL);
     de = kvstoreDictAddRaw(db->expires, slot, dictGetKey(kde), &existing);
     if (existing) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -970,6 +970,12 @@ void addReplyLongLong(client *c, long long ll) {
     }
 }
 
+void addReplyLongLongFromStr(client *c, robj* str) {
+    addReplyProto(c,":",1);
+    addReply(c,str);
+    addReplyProto(c,"\r\n",2);
+}
+
 void addReplyAggregateLen(client *c, long length, int prefix) {
     serverAssert(length >= 0);
     if (prepareClientToWrite(c) != C_OK) return;

--- a/src/networking.c
+++ b/src/networking.c
@@ -970,7 +970,7 @@ void addReplyLongLong(client *c, long long ll) {
     }
 }
 
-void addReplyLongLongFromStr(client *c, robj* str) {
+void addReplyLongLongFromStr(client *c, robj *str) {
     addReplyProto(c,":",1);
     addReply(c,str);
     addReplyProto(c,"\r\n",2);

--- a/src/server.h
+++ b/src/server.h
@@ -3387,6 +3387,7 @@ void dbReplaceValueWithDictEntry(redisDb *db, robj *key, robj *val, dictEntry *d
 #define SETKEY_DOESNT_EXIST 8
 #define SETKEY_ADD_OR_UPDATE 16 /* Key most likely doesn't exists */
 void setKey(client *c, redisDb *db, robj *key, robj *val, int flags);
+void setKeyWithDictEntry(client *c, redisDb *db, robj *key, robj *val, int flags, dictEntry *de);
 robj *dbRandomKey(redisDb *db);
 int dbGenericDelete(redisDb *db, robj *key, int async, int flags);
 int dbSyncDelete(redisDb *db, robj *key);

--- a/src/server.h
+++ b/src/server.h
@@ -3355,6 +3355,7 @@ void propagateDeletion(redisDb *db, robj *key, int lazy);
 int keyIsExpired(redisDb *db, robj *key);
 long long getExpire(redisDb *db, robj *key);
 void setExpire(client *c, redisDb *db, robj *key, long long when);
+void setExpireWithDictEntry(client *c, redisDb *db, robj *key, long long when, dictEntry *kde);
 int checkAlreadyExpired(long long when);
 int parseExtendedExpireArgumentsOrReply(client *c, int *flags);
 robj *lookupKeyRead(redisDb *db, robj *key);

--- a/src/server.h
+++ b/src/server.h
@@ -2627,6 +2627,7 @@ void addReplyDouble(client *c, double d);
 void addReplyBigNum(client *c, const char *num, size_t len);
 void addReplyHumanLongDouble(client *c, long double d);
 void addReplyLongLong(client *c, long long ll);
+void addReplyLongLongFromStr(client *c, robj* str);
 void addReplyArrayLen(client *c, long length);
 void addReplyMapLen(client *c, long length);
 void addReplySetLen(client *c, long length);

--- a/src/server.h
+++ b/src/server.h
@@ -3360,7 +3360,7 @@ int checkAlreadyExpired(long long when);
 int parseExtendedExpireArgumentsOrReply(client *c, int *flags);
 robj *lookupKeyRead(redisDb *db, robj *key);
 robj *lookupKeyWrite(redisDb *db, robj *key);
-robj *lookupKeyWriteWithDictEntry(redisDb *db, robj *key, dictEntry *de);
+robj *lookupKeyWriteWithDictEntry(redisDb *db, robj *key, dictEntry **deref);
 robj *lookupKeyReadOrReply(client *c, robj *key, robj *reply);
 robj *lookupKeyWriteOrReply(client *c, robj *key, robj *reply);
 robj *lookupKeyReadWithFlags(redisDb *db, robj *key, int flags);

--- a/src/server.h
+++ b/src/server.h
@@ -3359,6 +3359,7 @@ int checkAlreadyExpired(long long when);
 int parseExtendedExpireArgumentsOrReply(client *c, int *flags);
 robj *lookupKeyRead(redisDb *db, robj *key);
 robj *lookupKeyWrite(redisDb *db, robj *key);
+robj *lookupKeyWriteWithDictEntry(redisDb *db, robj *key, dictEntry *de);
 robj *lookupKeyReadOrReply(client *c, robj *key, robj *reply);
 robj *lookupKeyWriteOrReply(client *c, robj *key, robj *reply);
 robj *lookupKeyReadWithFlags(redisDb *db, robj *key, int flags);
@@ -3378,6 +3379,7 @@ int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle,
 dictEntry *dbAdd(redisDb *db, robj *key, robj *val);
 int dbAddRDBLoad(redisDb *db, sds key, robj *val);
 void dbReplaceValue(redisDb *db, robj *key, robj *val);
+void dbReplaceValueWithDictEntry(redisDb *db, robj *key, robj *val, dictEntry *de);
 
 #define SETKEY_KEEPTTL 1
 #define SETKEY_NO_SIGNAL 2

--- a/src/server.h
+++ b/src/server.h
@@ -3392,6 +3392,8 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags);
 int dbSyncDelete(redisDb *db, robj *key);
 int dbDelete(redisDb *db, robj *key);
 robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o);
+robj *dbUnshareStringValueWithDictEntry(redisDb *db, robj *key, robj *o, dictEntry *de);
+
 
 #define EMPTYDB_NO_FLAGS 0      /* No flags. */
 #define EMPTYDB_ASYNC (1<<0)    /* Reclaim memory in another thread. */

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -571,8 +571,8 @@ void msetnxCommand(client *c) {
 void incrDecrCommand(client *c, long long incr) {
     long long value, oldvalue;
     robj *o, *new;
-
-    o = lookupKeyWrite(c->db,c->argv[1]);
+    dictEntry *de = dbFind(c->db, c->argv[1]->ptr);
+    o = lookupKeyWriteWithDictEntry(c->db,c->argv[1],de);
     if (checkType(c,o,OBJ_STRING)) return;
     if (getLongLongFromObjectOrReply(c,o,&value,NULL) != C_OK) return;
 
@@ -593,7 +593,7 @@ void incrDecrCommand(client *c, long long incr) {
     } else {
         new = createStringObjectFromLongLongForValue(value);
         if (o) {
-            dbReplaceValue(c->db,c->argv[1],new);
+            dbReplaceValueWithDictEntry(c->db,c->argv[1],new,de);
         } else {
             dbAdd(c->db,c->argv[1],new);
         }

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -73,8 +73,8 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
         if (getGenericCommand(c) == C_ERR) return;
     }
 
-    dictEntry *de = dbFind(c->db, key->ptr);
-    found = (lookupKeyWriteWithDictEntry(c->db,key,de) != NULL);
+    dictEntry *de;
+    found = (lookupKeyWriteWithDictEntry(c->db,key,&de) != NULL);
 
     if ((flags & OBJ_SET_NX && found) ||
         (flags & OBJ_SET_XX && !found))
@@ -433,8 +433,8 @@ void setrangeCommand(client *c) {
         return;
     }
 
-    dictEntry *de = dbFind(c->db, c->argv[1]->ptr);
-    o = lookupKeyWriteWithDictEntry(c->db,c->argv[1],de);
+    dictEntry *de;
+    o = lookupKeyWriteWithDictEntry(c->db,c->argv[1],&de);
     if (o == NULL) {
         /* Return 0 when setting nothing on a non-existing string */
         if (value_len == 0) {
@@ -574,8 +574,8 @@ void msetnxCommand(client *c) {
 void incrDecrCommand(client *c, long long incr) {
     long long value, oldvalue;
     robj *o, *new;
-    dictEntry *de = dbFind(c->db, c->argv[1]->ptr);
-    o = lookupKeyWriteWithDictEntry(c->db,c->argv[1],de);
+    dictEntry *de;
+    o = lookupKeyWriteWithDictEntry(c->db,c->argv[1],&de);
     if (checkType(c,o,OBJ_STRING)) return;
     if (getLongLongFromObjectOrReply(c,o,&value,NULL) != C_OK) return;
 
@@ -640,8 +640,8 @@ void incrbyfloatCommand(client *c) {
     long double incr, value;
     robj *o, *new;
 
-    dictEntry *de = dbFind(c->db, c->argv[1]->ptr);
-    o = lookupKeyWriteWithDictEntry(c->db,c->argv[1],de);
+    dictEntry *de;
+    o = lookupKeyWriteWithDictEntry(c->db,c->argv[1],&de);
     if (checkType(c,o,OBJ_STRING)) return;
     if (getLongDoubleFromObjectOrReply(c,o,&value,NULL) != C_OK ||
         getLongDoubleFromObjectOrReply(c,c->argv[2],&incr,NULL) != C_OK)
@@ -674,8 +674,8 @@ void appendCommand(client *c) {
     size_t totlen;
     robj *o, *append;
 
-    dictEntry *de = dbFind(c->db, c->argv[1]->ptr);
-    o = lookupKeyWriteWithDictEntry(c->db,c->argv[1],de);
+    dictEntry *de;
+    o = lookupKeyWriteWithDictEntry(c->db,c->argv[1],&de);
     if (o == NULL) {
         /* Create the key */
         c->argv[2] = tryObjectEncoding(c->argv[2]);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -601,7 +601,9 @@ void incrDecrCommand(client *c, long long incr) {
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_STRING,"incrby",c->argv[1],c->db->id);
     server.dirty++;
-    addReplyLongLong(c, value);
+    addReplyProto(c,":",1);
+    addReply(c,new);
+    addReplyProto(c,"\r\n",2);
 }
 
 void incrCommand(client *c) {

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -73,7 +73,7 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
         if (getGenericCommand(c) == C_ERR) return;
     }
 
-    dictEntry *de;
+    dictEntry *de = NULL;
     found = (lookupKeyWriteWithDictEntry(c->db,key,&de) != NULL);
 
     if ((flags & OBJ_SET_NX && found) ||

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -74,8 +74,7 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
     }
 
     dictEntry *de = dbFind(c->db, key->ptr);
-    robj *o = lookupKeyWriteWithDictEntry(c->db,key,de);
-    found = (o != NULL);
+    found = (lookupKeyWriteWithDictEntry(c->db,key,de) != NULL);
 
     if ((flags & OBJ_SET_NX && found) ||
         (flags & OBJ_SET_XX && !found))

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -422,6 +422,7 @@ void setrangeCommand(client *c) {
     robj *o;
     long offset;
     sds value = c->argv[3]->ptr;
+    const size_t value_len = sdslen(value);
 
     if (getLongFromObjectOrReply(c,c->argv[2],&offset,NULL) != C_OK)
         return;
@@ -431,19 +432,20 @@ void setrangeCommand(client *c) {
         return;
     }
 
-    o = lookupKeyWrite(c->db,c->argv[1]);
+    dictEntry *de = dbFind(c->db, c->argv[1]->ptr);
+    o = lookupKeyWriteWithDictEntry(c->db,c->argv[1],de);
     if (o == NULL) {
         /* Return 0 when setting nothing on a non-existing string */
-        if (sdslen(value) == 0) {
+        if (value_len == 0) {
             addReply(c,shared.czero);
             return;
         }
 
         /* Return when the resulting string exceeds allowed size */
-        if (checkStringLength(c,offset,sdslen(value)) != C_OK)
+        if (checkStringLength(c,offset,value_len) != C_OK)
             return;
 
-        o = createObject(OBJ_STRING,sdsnewlen(NULL, offset+sdslen(value)));
+        o = createObject(OBJ_STRING,sdsnewlen(NULL, offset+value_len));
         dbAdd(c->db,c->argv[1],o);
     } else {
         size_t olen;
@@ -454,22 +456,22 @@ void setrangeCommand(client *c) {
 
         /* Return existing string length when setting nothing */
         olen = stringObjectLen(o);
-        if (sdslen(value) == 0) {
+        if (value_len == 0) {
             addReplyLongLong(c,olen);
             return;
         }
 
         /* Return when the resulting string exceeds allowed size */
-        if (checkStringLength(c,offset,sdslen(value)) != C_OK)
+        if (checkStringLength(c,offset,value_len) != C_OK)
             return;
 
         /* Create a copy when the object is shared or encoded. */
-        o = dbUnshareStringValue(c->db,c->argv[1],o);
+        o = dbUnshareStringValueWithDictEntry(c->db,c->argv[1],o,de);
     }
 
-    if (sdslen(value) > 0) {
-        o->ptr = sdsgrowzero(o->ptr,offset+sdslen(value));
-        memcpy((char*)o->ptr+offset,value,sdslen(value));
+    if (value_len > 0) {
+        o->ptr = sdsgrowzero(o->ptr,offset+value_len);
+        memcpy((char*)o->ptr+offset,value,value_len);
         signalModifiedKey(c,c->db,c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_STRING,
             "setrange",c->argv[1],c->db->id);
@@ -637,7 +639,8 @@ void incrbyfloatCommand(client *c) {
     long double incr, value;
     robj *o, *new;
 
-    o = lookupKeyWrite(c->db,c->argv[1]);
+    dictEntry *de = dbFind(c->db, c->argv[1]->ptr);
+    o = lookupKeyWriteWithDictEntry(c->db,c->argv[1],de);
     if (checkType(c,o,OBJ_STRING)) return;
     if (getLongDoubleFromObjectOrReply(c,o,&value,NULL) != C_OK ||
         getLongDoubleFromObjectOrReply(c,c->argv[2],&incr,NULL) != C_OK)
@@ -650,7 +653,7 @@ void incrbyfloatCommand(client *c) {
     }
     new = createStringObjectFromLongDouble(value,1);
     if (o)
-        dbReplaceValue(c->db,c->argv[1],new);
+        dbReplaceValueWithDictEntry(c->db,c->argv[1],new,de);
     else
         dbAdd(c->db,c->argv[1],new);
     signalModifiedKey(c,c->db,c->argv[1]);
@@ -670,7 +673,8 @@ void appendCommand(client *c) {
     size_t totlen;
     robj *o, *append;
 
-    o = lookupKeyWrite(c->db,c->argv[1]);
+    dictEntry *de = dbFind(c->db, c->argv[1]->ptr);
+    o = lookupKeyWriteWithDictEntry(c->db,c->argv[1],de);
     if (o == NULL) {
         /* Create the key */
         c->argv[2] = tryObjectEncoding(c->argv[2]);
@@ -684,12 +688,13 @@ void appendCommand(client *c) {
 
         /* "append" is an argument, so always an sds */
         append = c->argv[2];
-        if (checkStringLength(c,stringObjectLen(o),sdslen(append->ptr)) != C_OK)
+        const size_t append_len = sdslen(append->ptr);
+        if (checkStringLength(c,stringObjectLen(o),append_len) != C_OK)
             return;
 
         /* Append the value */
-        o = dbUnshareStringValue(c->db,c->argv[1],o);
-        o->ptr = sdscatlen(o->ptr,append->ptr,sdslen(append->ptr));
+        o = dbUnshareStringValueWithDictEntry(c->db,c->argv[1],o,de);
+        o->ptr = sdscatlen(o->ptr,append->ptr,append_len);
         totlen = sdslen(o->ptr);
     }
     signalModifiedKey(c,c->db,c->argv[1]);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -95,7 +95,7 @@ void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire,
     notifyKeyspaceEvent(NOTIFY_STRING,"set",key,c->db->id);
 
     if (expire) {
-        setExpire(c,c->db,key,milliseconds);
+        setExpireWithDictEntry(c,c->db,key,milliseconds,de);
         /* Propagate as SET Key Value PXAT millisecond-timestamp if there is
          * EX/PX/EXAT flag. */
         if (!(flags & OBJ_PXAT)) {

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -604,9 +604,7 @@ void incrDecrCommand(client *c, long long incr) {
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_STRING,"incrby",c->argv[1],c->db->id);
     server.dirty++;
-    addReplyProto(c,":",1);
-    addReply(c,new);
-    addReplyProto(c,"\r\n",2);
+    addReplyLongLongFromStr(c,new);
 }
 
 void incrCommand(client *c) {


### PR DESCRIPTION
- Avoid addReplyLongLong (which converts back to string) the value we already have as a robj, by using addReplyProto + addReply
- Avoid doing dbFind Twice for the same dictEntry on INCR*/DECR*/SETRANGE/APPEND commands.
- Avoid multiple sdslen calls with the same input on setrangeCommand and appendCommand
- Introduce setKeyWithDictEntry, which is like setKey(), but accepts an optional dictEntry input: Avoids the second dictFind in SET command

TODO: 
- [x] confirm green CI 
- [ ] confirm green daily
- [x] cover it on benchmark spec.
- [x] Update this PR with benchmark spec automated comment. check https://github.com/redis/redis/pull/13505#issuecomment-2322608048


------------------------------

## Hotspot data that triggered this effort 

Hotspots sample on incrDecr* commands (we can save 3.3% on the 2nd dictFind)

![image](https://github.com/user-attachments/assets/420f572d-9bf1-4d59-a332-49166a6295d9)

Hotspots on set command (we can save 2.1% on the 2nd dictFind)
![image](https://github.com/user-attachments/assets/e2dbdd5e-b306-4abd-b07c-2773f010422c)


# Measuring the improvements 


```
pip3 install redis-benchmarks-specification==0.1.222
redis-benchmarks-spec-client-runner --tests-regexp "memtier_benchmark-1Mkeys-string-append-1-100B|memtier_benchmark-1Mkeys-string-incrby|memtier_benchmark-1Mkeys-string-incrbyfloat|memtier_benchmark-1Mkeys-string-decr|memtier_benchmark-1Mkeys-string-setrange-100B|memtier_benchmark-1Mkeys-load-string-with-10B-values-pipeline-10|memtier_benchmark-1Mkeys-load-string-with-100B-values-pipeline-10" --flushall_on_every_test_start --flushall_on_every_test_end --override-memtier-test-time 60 --cpuset_start_pos 1
```

## Improvements on STRING SET command

Throughput 

Test Name | baseline unstable ( 3fcddfb61f903d7112da186cba8b1c93a99dc87f ) | comparison( 93fae760a0825c4d9c6fb4d0c089ec6f44d9344a ) | % change
-- | -- | -- | --
----------------------------------------------------------------- | -----------: | -----------: | -----------:
memtier_benchmark-1Mkeys-load-string-with-100B-values-pipeline-10 | 578505 | 592740 | 2.46%
memtier_benchmark-1Mkeys-load-string-with-10B-values-pipeline-10 | 644028 | 663759 | 3.06%

Avg. Latency 

Test Name | baseline unstable ( 3fcddfb61f903d7112da186cba8b1c93a99dc87f ) | comparison( 93fae760a0825c4d9c6fb4d0c089ec6f44d9344a ) | % change
-- | -- | -- | --
----------------------------------------------------------------- | -----------: | -----------: | -----------:
memtier_benchmark-1Mkeys-load-string-with-100B-values-pipeline-10 | 3.455 | 3.372 | 2.40%
memtier_benchmark-1Mkeys-load-string-with-10B-values-pipeline-10 | 3.103 | 3.011 | 2.96%


## Improvements on INCRBY command


Baseline
```
root@hpe10:~/redis# taskset -c 1-5 memtier_benchmark --pipeline 10 --test-time 60  --hide-histogram --command='INCRBY __key__ 1'
(...)
[RUN #1 100%,  60 secs]  0 threads:    45616940 ops,  750371 (avg:  760212) ops/sec, 36.42MB/sec (avg: 36.91MB/sec),  2.66 (avg:  2.63) msec latency

4         Threads
50        Connections per thread
60        Seconds


ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Incrbys    760212.36         2.62864         2.55900         5.15100         9.98300     37795.06 
Totals     760212.36         2.62864         2.55900         5.15100         9.98300     37795.06 
```

Comparison

```
root@hpe10:~/redis# taskset -c 1-5 memtier_benchmark --pipeline 10 --test-time 60  --hide-histogram --command='INCRBY __key__ 1'
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,  60 secs]  0 threads:    47423740 ops,  789698 (avg:  790317) ops/sec, 37.92MB/sec (avg: 37.95MB/sec),  2.53 (avg:  2.53) msec latency

4         Threads
50        Connections per thread
60        Seconds


ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Incrbys    790316.92         2.52839         2.44700         4.92700         9.91900     38860.38 
Totals     790316.92         2.52839         2.44700         4.92700         9.91900     38860.38 
```