### PR TITLE
Added new defrag API to allocate and free raw memory.

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1089,6 +1089,7 @@ void activeDefragCycle(void) {
             slot = -1;
             defrag_later_item_in_progress = 0;
             db = NULL;
+            moduleDefragEnd();
             goto update_metrics;
         }
         return;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1269,6 +1269,16 @@ void *activeDefragAlloc(void *ptr) {
     return NULL;
 }
 
+void *activeDefragAllocRaw(size_t size) {
+    /* fallback to regular allocation */
+    return zmalloc(size);
+}
+
+void activeDefragFreeRaw(void *ptr) {
+    /* fallback to regular free */
+    zfree(ptr);
+}
+
 robj *activeDefragStringOb(robj *ob) {
     UNUSED(ob);
     return NULL;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -54,6 +54,16 @@ void* activeDefragAlloc(void *ptr) {
     return newptr;
 }
 
+/* Raw memory allocation for defrag, avoid using tcache. */
+void *activeDefragAllocRaw(size_t size) {
+    return zmalloc_no_tcache(size);
+}
+
+/* Raw memory free for defrag, avoid using tcache. */
+void activeDefragFreeRaw(void *ptr) {
+    zfree_no_tcache(ptr);
+}
+
 /*Defrag helper for sds strings
  *
  * returns NULL in case the allocation wasn't moved.

--- a/src/dict.h
+++ b/src/dict.h
@@ -257,6 +257,18 @@ dictStats* dictGetStatsHt(dict *d, int htidx, int full);
 void dictCombineStats(dictStats *from, dictStats *into);
 void dictFreeStats(dictStats *stats);
 
+#define dictForEach(d, ty, m, ...) do { \
+    dictIterator *di = dictGetIterator(d); \
+    dictEntry *de; \
+    while ((de = dictNext(di)) != NULL) { \
+        ty *m = dictGetVal(de); \
+        do { \
+            __VA_ARGS__ \
+        } while(0); \
+    } \
+    dictReleaseIterator(di); \
+} while(0);
+
 #ifdef REDIS_TEST
 int dictTest(int argc, char *argv[], int flags);
 #endif

--- a/src/module.c
+++ b/src/module.c
@@ -13644,21 +13644,9 @@ int moduleDefragValue(robj *key, robj *value, int dbid) {
     return 1;
 }
 
-#define modulesForEach(...) do { \
-    dictIterator *di = dictGetIterator(modules); \
-    dictEntry *de; \
-    while ((de = dictNext(di)) != NULL) { \
-        struct RedisModule *module = dictGetVal(de); \
-        do { \
-            __VA_ARGS__ \
-        } while(0); \
-    } \
-    dictReleaseIterator(di); \
-} while(0);
-
 /* Call registered module API defrag functions */
 void moduleDefragGlobals(void) {
-    modulesForEach(
+    dictForEach(modules, struct RedisModule, module, 
         if (module->defrag_cb) {
             RedisModuleDefragCtx defrag_ctx = { 0, NULL, NULL, -1};
             module->defrag_cb(&defrag_ctx);
@@ -13668,7 +13656,7 @@ void moduleDefragGlobals(void) {
 
 /* Call registered module API defrag start functions */
 void moduleDefragStart(void) {
-    modulesForEach(
+    dictForEach(modules, struct RedisModule, module, 
         if (module->defrag_start_cb) {
             RedisModuleDefragCtx defrag_ctx = { 0, NULL, NULL, -1};
             module->defrag_start_cb(&defrag_ctx);
@@ -13678,7 +13666,7 @@ void moduleDefragStart(void) {
 
 /* Call registered module API defrag end functions */
 void moduleDefragEnd(void) {
-    modulesForEach(
+    dictForEach(modules, struct RedisModule, module, 
         if (module->defrag_end_cb) {
             RedisModuleDefragCtx defrag_ctx = { 0, NULL, NULL, -1};
             module->defrag_end_cb(&defrag_ctx);

--- a/src/module.c
+++ b/src/module.c
@@ -13453,21 +13453,13 @@ int RM_RegisterDefragFunc(RedisModuleCtx *ctx, RedisModuleDefragFunc cb) {
     return REDISMODULE_OK;
 }
 
-/* Register a defrag callback that will be called when defrag operation starts.
+/* Register a defrag callbacks that will be called when defrag operation starts and ends.
  *
- * The callback supports anything as on `RM_RegisterDefragFunc` but the user
- * can also assume the callback is called when the defrag operation starts. */
-int RM_RegisterDefragStartFunc(RedisModuleCtx *ctx, RedisModuleDefragFunc cb) {
-    ctx->module->defrag_start_cb = cb;
-    return REDISMODULE_OK;
-}
-
-/* Register a defrag callback that will be called when defrag operation ends.
- *
- * The callback supports anything as on `RM_RegisterDefragFunc` but the user
- * can also assume the callback is called when the defrag operation ends. */
-int RM_RegisterDefragEndFunc(RedisModuleCtx *ctx, RedisModuleDefragFunc cb) {
-    ctx->module->defrag_end_cb = cb;
+ * The callbacks are the same as `RM_RegisterDefragFunc` but the user
+ * can also assume the callbacks are called when the defrag operation starts and ends. */
+int RM_RegisterDefragCallbacks(RedisModuleCtx *ctx, RedisModuleDefragFunc start, RedisModuleDefragFunc end) {
+    ctx->module->defrag_start_cb = start;
+    ctx->module->defrag_end_cb = end;
     return REDISMODULE_OK;
 }
 
@@ -14051,8 +14043,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(GetCurrentCommandName);
     REGISTER_API(GetTypeMethodVersion);
     REGISTER_API(RegisterDefragFunc);
-    REGISTER_API(RegisterDefragStartFunc);
-    REGISTER_API(RegisterDefragEndFunc);
+    REGISTER_API(RegisterDefragCallbacks);
     REGISTER_API(DefragAlloc);
     REGISTER_API(DefragAllocRaw);
     REGISTER_API(DefragFreeRaw);

--- a/src/module.c
+++ b/src/module.c
@@ -13529,6 +13529,16 @@ void *RM_DefragAlloc(RedisModuleDefragCtx *ctx, void *ptr) {
     return activeDefragAlloc(ptr);
 }
 
+void *RM_DefragAllocRaw(RedisModuleDefragCtx *ctx, size_t size) {
+    UNUSED(ctx);
+    return activeDefragAllocRaw(size);
+}
+
+void RM_DefragFreeRaw(RedisModuleDefragCtx *ctx, void *ptr) {
+    UNUSED(ctx);
+    activeDefragFreeRaw(ptr);
+}
+
 /* Defrag a RedisModuleString previously allocated by RM_Alloc, RM_Calloc, etc.
  * See RM_DefragAlloc() for more information on how the defragmentation process
  * works.
@@ -13981,6 +13991,8 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(GetTypeMethodVersion);
     REGISTER_API(RegisterDefragFunc);
     REGISTER_API(DefragAlloc);
+    REGISTER_API(DefragAllocRaw);
+    REGISTER_API(DefragFreeRaw);
     REGISTER_API(DefragRedisModuleString);
     REGISTER_API(DefragShouldStop);
     REGISTER_API(DefragCursorSet);

--- a/src/module.c
+++ b/src/module.c
@@ -13529,11 +13529,25 @@ void *RM_DefragAlloc(RedisModuleDefragCtx *ctx, void *ptr) {
     return activeDefragAlloc(ptr);
 }
 
+/* Allocate memory for defrag purposes
+ *
+ * On the common cases user simply want to reallocate a pointer with a single
+ * owner. For such usecase RM_DefragAlloc is enough. But on some usecases the user
+ * might want to replace a pointer with multiple owners in different keys.
+ * In such case, an in place replacement can not work because the other key still
+ * keep a pointer to the old value. 
+ * 
+ * RM_DefragAllocRaw and RM_DefragFreeRaw allows to control when the memory
+ * for defrag purposes will be allocated and when it will be freed,
+ * allow to support more complex defrag usecases. */
 void *RM_DefragAllocRaw(RedisModuleDefragCtx *ctx, size_t size) {
     UNUSED(ctx);
     return activeDefragAllocRaw(size);
 }
 
+/* Free memory for defrag purposes
+ * 
+ * See RM_DefragAllocRaw for more information. */
 void RM_DefragFreeRaw(RedisModuleDefragCtx *ctx, void *ptr) {
     UNUSED(ctx);
     activeDefragFreeRaw(ptr);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1296,6 +1296,8 @@ REDISMODULE_API int *(*RedisModule_GetCommandKeys)(RedisModuleCtx *ctx, RedisMod
 REDISMODULE_API int *(*RedisModule_GetCommandKeysWithFlags)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *num_keys, int **out_flags) REDISMODULE_ATTR;
 REDISMODULE_API const char *(*RedisModule_GetCurrentCommandName)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RegisterDefragFunc)(RedisModuleCtx *ctx, RedisModuleDefragFunc func) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_RegisterDefragStartFunc)(RedisModuleCtx *ctx, RedisModuleDefragFunc func) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_RegisterDefragEndFunc)(RedisModuleCtx *ctx, RedisModuleDefragFunc func) REDISMODULE_ATTR;
 REDISMODULE_API void *(*RedisModule_DefragAlloc)(RedisModuleDefragCtx *ctx, void *ptr) REDISMODULE_ATTR;
 REDISMODULE_API void *(*RedisModule_DefragAllocRaw)(RedisModuleDefragCtx *ctx, size_t size) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_DefragFreeRaw)(RedisModuleDefragCtx *ctx, void *ptr) REDISMODULE_ATTR;
@@ -1664,6 +1666,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(GetCommandKeysWithFlags);
     REDISMODULE_GET_API(GetCurrentCommandName);
     REDISMODULE_GET_API(RegisterDefragFunc);
+    REDISMODULE_GET_API(RegisterDefragStartFunc);
+    REDISMODULE_GET_API(RegisterDefragEndFunc);
     REDISMODULE_GET_API(DefragAlloc);
     REDISMODULE_GET_API(DefragAllocRaw);
     REDISMODULE_GET_API(DefragFreeRaw);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1296,8 +1296,7 @@ REDISMODULE_API int *(*RedisModule_GetCommandKeys)(RedisModuleCtx *ctx, RedisMod
 REDISMODULE_API int *(*RedisModule_GetCommandKeysWithFlags)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *num_keys, int **out_flags) REDISMODULE_ATTR;
 REDISMODULE_API const char *(*RedisModule_GetCurrentCommandName)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RegisterDefragFunc)(RedisModuleCtx *ctx, RedisModuleDefragFunc func) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RegisterDefragStartFunc)(RedisModuleCtx *ctx, RedisModuleDefragFunc func) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RegisterDefragEndFunc)(RedisModuleCtx *ctx, RedisModuleDefragFunc func) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_RegisterDefragCallbacks)(RedisModuleCtx *ctx, RedisModuleDefragFunc start, RedisModuleDefragFunc end) REDISMODULE_ATTR;
 REDISMODULE_API void *(*RedisModule_DefragAlloc)(RedisModuleDefragCtx *ctx, void *ptr) REDISMODULE_ATTR;
 REDISMODULE_API void *(*RedisModule_DefragAllocRaw)(RedisModuleDefragCtx *ctx, size_t size) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_DefragFreeRaw)(RedisModuleDefragCtx *ctx, void *ptr) REDISMODULE_ATTR;
@@ -1666,8 +1665,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(GetCommandKeysWithFlags);
     REDISMODULE_GET_API(GetCurrentCommandName);
     REDISMODULE_GET_API(RegisterDefragFunc);
-    REDISMODULE_GET_API(RegisterDefragStartFunc);
-    REDISMODULE_GET_API(RegisterDefragEndFunc);
+    REDISMODULE_GET_API(RegisterDefragCallbacks);
     REDISMODULE_GET_API(DefragAlloc);
     REDISMODULE_GET_API(DefragAllocRaw);
     REDISMODULE_GET_API(DefragFreeRaw);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1297,6 +1297,8 @@ REDISMODULE_API int *(*RedisModule_GetCommandKeysWithFlags)(RedisModuleCtx *ctx,
 REDISMODULE_API const char *(*RedisModule_GetCurrentCommandName)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RegisterDefragFunc)(RedisModuleCtx *ctx, RedisModuleDefragFunc func) REDISMODULE_ATTR;
 REDISMODULE_API void *(*RedisModule_DefragAlloc)(RedisModuleDefragCtx *ctx, void *ptr) REDISMODULE_ATTR;
+REDISMODULE_API void *(*RedisModule_DefragAllocRaw)(RedisModuleDefragCtx *ctx, size_t size) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_DefragFreeRaw)(RedisModuleDefragCtx *ctx, void *ptr) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString *(*RedisModule_DefragRedisModuleString)(RedisModuleDefragCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_DefragShouldStop)(RedisModuleDefragCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_DefragCursorSet)(RedisModuleDefragCtx *ctx, unsigned long cursor) REDISMODULE_ATTR;
@@ -1663,6 +1665,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(GetCurrentCommandName);
     REDISMODULE_GET_API(RegisterDefragFunc);
     REDISMODULE_GET_API(DefragAlloc);
+    REDISMODULE_GET_API(DefragAllocRaw);
+    REDISMODULE_GET_API(DefragFreeRaw);
     REDISMODULE_GET_API(DefragRedisModuleString);
     REDISMODULE_GET_API(DefragShouldStop);
     REDISMODULE_GET_API(DefragCursorSet);

--- a/src/server.h
+++ b/src/server.h
@@ -3127,6 +3127,8 @@ void checkChildrenDone(void);
 int setOOMScoreAdj(int process_class);
 void rejectCommandFormat(client *c, const char *fmt, ...);
 void *activeDefragAlloc(void *ptr);
+void *activeDefragAllocRaw(size_t size);
+void activeDefragFreeRaw(void *ptr);
 robj *activeDefragStringOb(robj* ob);
 void dismissSds(sds s);
 void dismissMemory(void* ptr, size_t size_hint);

--- a/src/server.h
+++ b/src/server.h
@@ -820,6 +820,8 @@ struct RedisModule {
     int blocked_clients;         /* Count of RedisModuleBlockedClient in this module. */
     RedisModuleInfoFunc info_cb; /* Callback for module to add INFO fields. */
     RedisModuleDefragFunc defrag_cb;    /* Callback for global data defrag. */
+    RedisModuleDefragFunc defrag_start_cb;    /* Callback indicating defrag started. */
+    RedisModuleDefragFunc defrag_end_cb;      /* Callback indicating defrag ended. */
     struct moduleLoadQueueEntry *loadmod; /* Module load arguments for config rewrite. */
     int num_commands_with_acl_categories; /* Number of commands in this module included in acl categories */
     int onload;     /* Flag to identify if the call is being made from Onload (0 or 1) */
@@ -2555,6 +2557,8 @@ robj *moduleTypeDupOrReply(client *c, robj *fromkey, robj *tokey, int todb, robj
 int moduleDefragValue(robj *key, robj *obj, int dbid);
 int moduleLateDefrag(robj *key, robj *value, unsigned long *cursor, long long endtime, int dbid);
 void moduleDefragGlobals(void);
+void moduleDefragStart(void);
+void moduleDefragEnd(void);
 void *moduleGetHandleByName(char *modulename);
 int moduleIsModuleCommand(void *module_handle, struct redisCommand *cmd);
 

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -258,8 +258,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     RedisModule_RegisterInfoFunc(ctx, FragInfo);
     RedisModule_RegisterDefragFunc(ctx, defragGlobalStrings);
-    RedisModule_RegisterDefragStartFunc(ctx, defragStart);
-    RedisModule_RegisterDefragEndFunc(ctx, defragEnd);
+    RedisModule_RegisterDefragCallbacks(ctx, defragStart, defragEnd);
 
     return REDISMODULE_OK;
 }

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -22,6 +22,8 @@ unsigned long int datatype_raw_defragged = 0;
 unsigned long int datatype_resumes = 0;
 unsigned long int datatype_wrong_cursor = 0;
 unsigned long int global_attempts = 0;
+unsigned long int defrag_started = 0;
+unsigned long int defrag_ended = 0;
 unsigned long int global_defragged = 0;
 
 int global_strings_len = 0;
@@ -49,6 +51,16 @@ static void defragGlobalStrings(RedisModuleDefragCtx *ctx)
     }
 }
 
+static void defragStart(RedisModuleDefragCtx *ctx) {
+    REDISMODULE_NOT_USED(ctx);
+    defrag_started++;
+}
+
+static void defragEnd(RedisModuleDefragCtx *ctx) {
+    REDISMODULE_NOT_USED(ctx);
+    defrag_ended++;
+}
+
 static void FragInfo(RedisModuleInfoCtx *ctx, int for_crash_report) {
     REDISMODULE_NOT_USED(for_crash_report);
 
@@ -60,6 +72,8 @@ static void FragInfo(RedisModuleInfoCtx *ctx, int for_crash_report) {
     RedisModule_InfoAddFieldLongLong(ctx, "datatype_wrong_cursor", datatype_wrong_cursor);
     RedisModule_InfoAddFieldLongLong(ctx, "global_attempts", global_attempts);
     RedisModule_InfoAddFieldLongLong(ctx, "global_defragged", global_defragged);
+    RedisModule_InfoAddFieldLongLong(ctx, "defrag_started", defrag_started);
+    RedisModule_InfoAddFieldLongLong(ctx, "defrag_ended", defrag_ended);
 }
 
 struct FragObject *createFragObject(unsigned long len, unsigned long size, int maxstep) {
@@ -87,6 +101,8 @@ static int fragResetStatsCommand(RedisModuleCtx *ctx, RedisModuleString **argv, 
     datatype_wrong_cursor = 0;
     global_attempts = 0;
     global_defragged = 0;
+    defrag_started = 0;
+    defrag_ended = 0;
 
     RedisModule_ReplyWithSimpleString(ctx, "OK");
     return REDISMODULE_OK;
@@ -242,6 +258,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     RedisModule_RegisterInfoFunc(ctx, FragInfo);
     RedisModule_RegisterDefragFunc(ctx, defragGlobalStrings);
+    RedisModule_RegisterDefragStartFunc(ctx, defragStart);
+    RedisModule_RegisterDefragEndFunc(ctx, defragEnd);
 
     return REDISMODULE_OK;
 }

--- a/tests/unit/moduleapi/defrag.tcl
+++ b/tests/unit/moduleapi/defrag.tcl
@@ -18,6 +18,7 @@ start_server {tags {"modules"} overrides {{save ""}}} {
             set info [r info defragtest_stats]
             assert {[getInfoProperty $info defragtest_datatype_attempts] > 0}
             assert_equal 0 [getInfoProperty $info defragtest_datatype_resumes]
+            assert_morethan [getInfoProperty $info defragtest_datatype_raw_defragged] 0
         }
 
         test {Module defrag: late defrag with cursor works} {
@@ -32,6 +33,7 @@ start_server {tags {"modules"} overrides {{save ""}}} {
             set info [r info defragtest_stats]
             assert {[getInfoProperty $info defragtest_datatype_resumes] > 10}
             assert_equal 0 [getInfoProperty $info defragtest_datatype_wrong_cursor]
+            assert_morethan [getInfoProperty $info defragtest_datatype_raw_defragged] 0
         }
 
         test {Module defrag: global defrag works} {

--- a/tests/unit/moduleapi/defrag.tcl
+++ b/tests/unit/moduleapi/defrag.tcl
@@ -19,6 +19,8 @@ start_server {tags {"modules"} overrides {{save ""}}} {
             assert {[getInfoProperty $info defragtest_datatype_attempts] > 0}
             assert_equal 0 [getInfoProperty $info defragtest_datatype_resumes]
             assert_morethan [getInfoProperty $info defragtest_datatype_raw_defragged] 0
+            assert_morethan [getInfoProperty $info defragtest_defrag_started] 0
+            assert_morethan [getInfoProperty $info defragtest_defrag_ended] 0
         }
 
         test {Module defrag: late defrag with cursor works} {
@@ -34,6 +36,8 @@ start_server {tags {"modules"} overrides {{save ""}}} {
             assert {[getInfoProperty $info defragtest_datatype_resumes] > 10}
             assert_equal 0 [getInfoProperty $info defragtest_datatype_wrong_cursor]
             assert_morethan [getInfoProperty $info defragtest_datatype_raw_defragged] 0
+            assert_morethan [getInfoProperty $info defragtest_defrag_started] 0
+            assert_morethan [getInfoProperty $info defragtest_defrag_ended] 0
         }
 
         test {Module defrag: global defrag works} {
@@ -43,6 +47,8 @@ start_server {tags {"modules"} overrides {{save ""}}} {
             after 2000
             set info [r info defragtest_stats]
             assert {[getInfoProperty $info defragtest_global_attempts] > 0}
+            assert_morethan [getInfoProperty $info defragtest_defrag_started] 0
+            assert_morethan [getInfoProperty $info defragtest_defrag_ended] 0
         }
     }
 }


### PR DESCRIPTION
All the defrag allocations API expects to get a value and replace it, leaving the old value untouchable. In some cases a value might be shared between multiple keys, in such cases we can not simply replace it when the defrag callback is called.

To allow support such use cases, the PR adds two new API's to the defrag API:

1. `RM_DefragAllocRaw` - allocate memory base on a given size.
2. `RM_DefragFreeRaw` - Free the given pointer.

Those API's avoid using tcache so they operate just like `RM_DefragAlloc` but allows the user to split the allocation and the memory free operations into two stages and control when those happen.

In addition the PR adds new API to allow the module to receive notifications when defrag start and end: `RM_RegisterDefragCallbacks`
Those callbacks are the same as `RM_RegisterDefragFunc` but promised to be called and the start and the end of the defrag process.