### PR TITLE
Fix RM_RdbLoad() to enable AOF after loading is completed

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -13070,7 +13070,7 @@ int RM_RdbLoad(RedisModuleCtx *ctx, RedisModuleRdbStream *stream, int flags) {
     int ret = rdbLoad(stream->data.filename,NULL,RDBFLAGS_NONE);
 
     if (server.current_client) unprotectClient(server.current_client);
-    if (server.aof_state != AOF_OFF) startAppendOnly();
+    if (server.aof_enabled) startAppendOnlyWithRetry();
 
     if (ret != RDB_OK) {
         errno = (ret == RDB_NOT_EXIST) ? ENOENT : EIO;

--- a/tests/unit/moduleapi/rdbloadsave.tcl
+++ b/tests/unit/moduleapi/rdbloadsave.tcl
@@ -83,6 +83,9 @@ start_server {tags {"modules"}} {
         # Verify the value in the loaded rdb
         assert_equal v1 [r get k]
 
+        # Verify aof is still enabled after RM_RdbLoad() call
+        assert_equal 1 [s aof_enabled]
+
         r flushdb
         r config set rdb-key-save-delay 0
         r config set appendonly no


### PR DESCRIPTION
RM_RdbLoad() disables AOF temporarily while loading RDB.
Later, it does not enable it back as it checks AOF state (disabled by then) rather than AOF config parameter.

Added a change to restart AOF according to config parameter. 