### PR TITLE
RED-129256, Fix TOUCH command from script in no-touch mode

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -102,7 +102,7 @@ robj *lookupKey(redisDb *db, robj *key, int flags) {
          * Don't do it if we have a saving child, as this will trigger
          * a copy on write madness. */
         if (server.current_client && server.current_client->flags & CLIENT_NO_TOUCH &&
-            server.current_client->cmd->proc != touchCommand)
+            server.executing_client->cmd->proc != touchCommand)
             flags |= LOOKUP_NOTOUCH;
         if (!hasActiveChildProcess() && !(flags & LOOKUP_NOTOUCH)){
             if (server.maxmemory_policy & MAXMEMORY_FLAG_LFU) {

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -51,6 +51,26 @@ start_server {tags {"introspection"}} {
         assert_morethan $newlru $oldlru
     } {} {needs:debug}
 
+    test {Operations in no-touch mode TOUCH alters the last access time of a key} {
+        r set foo bar
+        r client no-touch on
+        set oldlru [getlru foo]
+        after 1100
+        r touch foo
+        set newlru [getlru foo]
+        assert_morethan $newlru $oldlru
+    } {} {needs:debug}
+
+    test {Operations in no-touch mode TOUCH from script alters the last access time of a key} {
+        r set foo bar
+        r client no-touch on
+        set oldlru [getlru foo]
+        after 1100
+        assert_equal {1} [r eval "return redis.call('touch', 'foo')" 0]
+        set newlru [getlru foo]
+        assert_morethan $newlru $oldlru
+    } {} {needs:debug}
+
     test {TOUCH returns the number of existing keys specified} {
         r flushdb
         r set key1{t} 1


### PR DESCRIPTION
When a client in no-touch mode issues a TOUCH command on a key, the key’s access time should be updated, but in scripts, and module's RM_Call, it isn’t updated.
Command proc should be matched to the executing client, not the current client.