### PR TITLE
Fix the master-slave synchronization relationship of cluster shards cannot be restored due to network failure

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1514,7 +1514,12 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
                 node->pport = ntohs(g->pport);
                 node->cport = ntohs(g->cport);
                 node->flags &= ~CLUSTER_NODE_NOADDR;
-            }
+
+				/* Check if this is our master and we have to change the
+				 * replication target as well. */
+				if (nodeIsSlave(myself) && myself->slaveof == node)
+					replicationSetMaster(node->ip, node->port);
+				}
         } else {
             /* If it's not in NOADDR state and we don't have it, we
              * add it to our trusted dict with exact nodeid and flag.


### PR DESCRIPTION
In the cluster mode, when the slave nodes in the sharded cluster are pinged by the master node during the execution of the nodeUpdateAddressIfNeeded operation, the getpeername system call may fail due to an error, causing the server.masterhost variable to be incorrectly set to ?. The slave node reports an error every 1 second: "Connecting to MASTER ?:6379". Just at that time, the master node and the slave node experience a network partition, and the master status of the sharded node is marked as PFAILED. At this time, other nodes will send gossip messages to the sharded slave node to correct the IP information of the sharded master node, but the server.masterhost configuration information will not be updated, which will cause the synchronization relationship between the master and slave nodes to not recover after the getpeername system call restores.