### PR TITLE
Fix set with invalid length causes smembers to hang

### DIFF
--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1447,7 +1447,7 @@ void smembersCommand(client *c) {
         length--;
     }
     setTypeReleaseIterator(si);
-    serverAssert(length == 0);
+    serverAssert(length == 0); /* fail on corrupt data */
 }
 
 /* SINTERCARD numkeys key [key ...] [LIMIT limit] */

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1434,17 +1434,20 @@ void smembersCommand(client *c) {
     }
 
     /* Prepare the response. */
-    addReplySetLen(c,setTypeSize(setobj));
-
+    unsigned long length = setTypeSize(setobj);
+    addReplySetLen(c,length);
     /* Iterate through the elements of the set. */
     si = setTypeInitIterator(setobj);
+
     while (setTypeNext(si, &str, &len, &intobj) != -1) {
         if (str != NULL)
             addReplyBulkCBuffer(c, str, len);
         else
             addReplyBulkLongLong(c, intobj);
+        length--;
     }
     setTypeReleaseIterator(si);
+    serverAssert(length == 0);
 }
 
 /* SINTERCARD numkeys key [key ...] [LIMIT limit] */

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -887,9 +887,6 @@ test {corrupt payload: fuzzer findings - set with duplicate elements causes sdif
 
 test {corrupt payload: fuzzer findings - set with invalid length causes smembers to hang} {
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
-        r config set sanitize-dump-payload no
-        r debug set-skip-checksum-validation 1
-
         # In the past, it generated a broken protocol and left the client hung in smembers
         r config set sanitize-dump-payload no
         assert_equal {OK} [r restore _set 0 "\x14\x16\x16\x00\x00\x00\x0c\x00\x81\x61\x02\x81\x62\x02\x81\x63\x02\x01\x01\x02\x01\x03\x01\xff\x0c\x00\x91\x00\x56\x73\xc1\x82\xd5\xbd" replace]

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -885,5 +885,20 @@ test {corrupt payload: fuzzer findings - set with duplicate elements causes sdif
     }
 } {} {logreqres:skip} ;# This test violates {"uniqueItems": true}
 
+test {corrupt payload: fuzzer findings - set with invalid length causes smembers to hang} {
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        r config set sanitize-dump-payload no
+        r debug set-skip-checksum-validation 1
+
+        # In the past, it generated a broken protocol and left the client hung in smembers
+        r config set sanitize-dump-payload no
+        assert_equal {OK} [r restore _set 0 "\x14\x16\x16\x00\x00\x00\x0c\x00\x81\x61\x02\x81\x62\x02\x81\x63\x02\x01\x01\x02\x01\x03\x01\xff\x0c\x00\x91\x00\x56\x73\xc1\x82\xd5\xbd" replace]
+        assert_encoding listpack _set
+        catch { r SMEMBERS _set } err
+        assert_equal [count_log_message 0 "crashed by signal"] 0
+        assert_equal [count_log_message 0 "ASSERTION FAILED"] 1
+    }
+}
+
 } ;# tags
 


### PR DESCRIPTION
After https://github.com/redis/redis/pull/13499, If the length set by `addReplySetLen()` does not match the actual number of elements in the reply, it will cause protocol broken and result in the client hanging.

failed CI: https://github.com/redis/redis/actions/runs/10692581371