### PR TITLE
Fix flaky replication tests

### DIFF
--- a/tests/cluster/tests/14-consistency-check.tcl
+++ b/tests/cluster/tests/14-consistency-check.tcl
@@ -32,6 +32,13 @@ proc get_one_of_my_replica {id} {
     }
     set replica_port [lindex [lindex [lindex [R $id role] 2] 0] 1]
     set replica_id_num [get_instance_id_by_port redis $replica_port]
+
+    # To avoid -LOADING reply, wait until replica syncs with master.
+    wait_for_condition 1000 50 {
+        [RI $replica_id_num master_link_status] eq {up}
+    } else {
+        fail "Replica did not sync in time."
+    }
     return $replica_id_num
 }
 

--- a/tests/cluster/tests/14-consistency-check.tcl
+++ b/tests/cluster/tests/14-consistency-check.tcl
@@ -59,9 +59,16 @@ proc test_slave_load_expired_keys {aof} {
     test "Slave expired keys is loaded when restarted: appendonly=$aof" {
         set master_id [find_non_empty_master]
         set replica_id [get_one_of_my_replica $master_id]
+        set replica_id2 $replica_id
+        set replica_id3 $replica_id
+        set replica_id4 $replica_id
+        set replica_id5 $replica_id
+        set replica_id6 $replica_id
+
+        puts "Starting blabla..."
 
         set master_dbsize_0 [R $master_id dbsize]
-        set replica_dbsize_0 [R $replica_id dbsize]
+        set replica_dbsize_0 [R $replica_id2 dbsize]
         assert_equal $master_dbsize_0 $replica_dbsize_0
 
         # config the replica persistency and rewrite the config file to survive restart
@@ -78,12 +85,12 @@ proc test_slave_load_expired_keys {aof} {
         # wait for replica to be in sync with master
         wait_for_condition 500 10 {
             [RI $replica_id master_link_status] eq {up} &&
-            [R $replica_id dbsize] eq [R $master_id dbsize]
+            [R $replica_id3 dbsize] eq [R $master_id dbsize]
         } else {
             fail "replica didn't sync"
         }
         
-        set replica_dbsize_1 [R $replica_id dbsize]
+        set replica_dbsize_1 [R $replica_id4 dbsize]
         assert {$replica_dbsize_1 > $replica_dbsize_0}
 
         # make replica create persistence file
@@ -113,7 +120,7 @@ proc test_slave_load_expired_keys {aof} {
         restart_instance redis $replica_id
 
         # make sure the keys are still there
-        set replica_dbsize_3 [R $replica_id dbsize]
+        set replica_dbsize_3 [R $replica_id5 dbsize]
         assert {$replica_dbsize_3 > $replica_dbsize_0}
         
         # restore settings
@@ -122,7 +129,7 @@ proc test_slave_load_expired_keys {aof} {
         # wait for the master to expire all keys and replica to get the DELs
         wait_for_condition 500 10 {
             [RI $replica_id master_link_status] eq {up} &&
-            [R $replica_id dbsize] eq $master_dbsize_0
+            [R $replica_id6 dbsize] eq $master_dbsize_0
         } else {
             fail "keys didn't expire"
         }

--- a/tests/cluster/tests/14-consistency-check.tcl
+++ b/tests/cluster/tests/14-consistency-check.tcl
@@ -59,16 +59,9 @@ proc test_slave_load_expired_keys {aof} {
     test "Slave expired keys is loaded when restarted: appendonly=$aof" {
         set master_id [find_non_empty_master]
         set replica_id [get_one_of_my_replica $master_id]
-        set replica_id2 $replica_id
-        set replica_id3 $replica_id
-        set replica_id4 $replica_id
-        set replica_id5 $replica_id
-        set replica_id6 $replica_id
-
-        puts "Starting blabla..."
 
         set master_dbsize_0 [R $master_id dbsize]
-        set replica_dbsize_0 [R $replica_id2 dbsize]
+        set replica_dbsize_0 [R $replica_id dbsize]
         assert_equal $master_dbsize_0 $replica_dbsize_0
 
         # config the replica persistency and rewrite the config file to survive restart
@@ -85,12 +78,12 @@ proc test_slave_load_expired_keys {aof} {
         # wait for replica to be in sync with master
         wait_for_condition 500 10 {
             [RI $replica_id master_link_status] eq {up} &&
-            [R $replica_id3 dbsize] eq [R $master_id dbsize]
+            [R $replica_id dbsize] eq [R $master_id dbsize]
         } else {
             fail "replica didn't sync"
         }
         
-        set replica_dbsize_1 [R $replica_id4 dbsize]
+        set replica_dbsize_1 [R $replica_id dbsize]
         assert {$replica_dbsize_1 > $replica_dbsize_0}
 
         # make replica create persistence file
@@ -119,8 +112,15 @@ proc test_slave_load_expired_keys {aof} {
         # start the replica again (loading an RDB or AOF file)
         restart_instance redis $replica_id
 
+        # Replica may start a full sync after restart, trying in a loop to avoid
+        # -LOADING reply in that case.
+        wait_for_condition 1000 50 {
+            [catch {set replica_dbsize_3 [R $replica_id dbsize]} e] == 0
+        } else {
+            fail "Replica is not up."
+        }
+
         # make sure the keys are still there
-        set replica_dbsize_3 [R $replica_id5 dbsize]
         assert {$replica_dbsize_3 > $replica_dbsize_0}
         
         # restore settings
@@ -129,7 +129,7 @@ proc test_slave_load_expired_keys {aof} {
         # wait for the master to expire all keys and replica to get the DELs
         wait_for_condition 500 10 {
             [RI $replica_id master_link_status] eq {up} &&
-            [R $replica_id6 dbsize] eq $master_dbsize_0
+            [R $replica_id dbsize] eq $master_dbsize_0
         } else {
             fail "keys didn't expire"
         }

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -2069,6 +2069,14 @@ start_server {tags {"scripting"}} {
             } 1 x
 
             r replicaof [srv -1 host] [srv -1 port]
+
+            # To avoid -LOADING reply, wait until replica syncs with master.
+            wait_for_condition 50 100 {
+                [s master_link_status] eq {up}
+            } else {
+                fail "Replica did not sync in time."
+            }
+
             assert_error {EXECABORT Transaction discarded because of: READONLY *} {$rr exec}
             assert_error {READONLY You can't write against a read only replica. script: *} {$rr2 exec}
             $rr close


### PR DESCRIPTION
https://github.com/redis/redis/pull/13495 introduced a change to reply -LOADING while flushing existing db on a replica.
Some of our tests are sensitive to this change and do no expect -LOADING reply. 

Fixing a couple of tests that fail time to time. 
