### PR TITLE
 Replace usage of _addReplyLongLongWithPrefix with specific bulk/mbulk functions to reduce condition checks in hotpath.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -931,7 +931,9 @@ void addReplyHumanLongDouble(client *c, long double d) {
     }
 }
 
-static inline void _addReplyLongLongSharedHdr(client *c, long long ll, char prefix, robj **shared_hdr) {
+static inline void _addReplyLongLongSharedHdr(client *c, long long ll, char prefix,
+                                              robj *shared_hdr[OBJ_SHARED_BULKHDR_LEN])
+{
     char buf[128];
     int len;
     const int opt_hdr = ll < OBJ_SHARED_BULKHDR_LEN && ll >= 0;

--- a/src/networking.c
+++ b/src/networking.c
@@ -930,7 +930,7 @@ void addReplyHumanLongDouble(client *c, long double d) {
     }
 }
 
-#define ADD_REPLY_WITH_PREFIX(c, ll, prefix, shared_hdr) do {       \
+#define ADD_REPLY_LONG_LONG_WITH_PREFIX(c, ll, prefix, shared_hdr) do {       \
     char buf[128];                                                  \
     int len;                                                        \
     const int opt_hdr = ll < OBJ_SHARED_BULKHDR_LEN && ll >= 0;     \
@@ -946,11 +946,11 @@ void addReplyHumanLongDouble(client *c, long double d) {
 } while(0)
 
 static inline void _addReplyLongLongBulk(client *c, long long ll) {
-    ADD_REPLY_WITH_PREFIX(c, ll, '$', shared.bulkhdr);
+    ADD_REPLY_LONG_LONG_WITH_PREFIX(c, ll, '$', shared.bulkhdr);
 }
 
 static inline void _addReplyLongLongMBulk(client *c, long long ll) {
-    ADD_REPLY_WITH_PREFIX(c, ll, '*', shared.mbulkhdr);
+    ADD_REPLY_LONG_LONG_WITH_PREFIX(c, ll, '*', shared.mbulkhdr);
 }
 
 /* Add a long long as integer reply or bulk len / multi bulk count.


### PR DESCRIPTION
Instead of adding runtime logic to decide which prefix/shared object to use when doing the reply we can simply use an inline method to avoid runtime overhead of condition checks, and also keep the code change small. 
Preliminary data show improvements on commands that heavily rely on bulk/mbulk replies (example of LRANGE).

TODO:
- [x] validate green CI
- [ ] validate green daily
    - https://github.com/filipecosta90/redis/actions/runs/10865104532
- [x] preliminary benchmark results. max improvement of up to 10% for > 100 element replies.

## preliminary data on LRANGE related benchmarks

To reproduce:
```
redis-benchmarks-spec-client-runner --tests-regexp ".*lrange.*" --flushall_on_every_test_start --flushall_on_every_test_end  --cpuset_start_pos 2 --override-memtier-test-time 60
```

Test Name | Metric JSON Path | baseline unstable branch (569584d) | comparison this PR addreplyprefix (86a9d3f) | % change
-- | -- | -- | -- | --
memtier_benchmark-1key-list-1K-elements-lrange-all-elements-pipeline-10 | ALL STATS.Totals."Ops/sec" | 15563 | 15313 | -1.6%
memtier_benchmark-1key-list-1K-elements-lrange-all-elements-pipeline-10 | ALL STATS.Totals."Percentile Latencies"."p50.00" | 124.927 | 125.951 | -0.8%
memtier_benchmark-1key-list-1K-elements-lrange-all-elements | ALL STATS.Totals."Ops/sec" | 16324 | 17322 | 6.1%
memtier_benchmark-1key-list-1K-elements-lrange-all-elements | ALL STATS.Totals."Percentile Latencies"."p50.00" | 12.159 | 11.391 | 6.3%
memtier_benchmark-1key-list-2K-elements-quicklist-lrange-all-elements-longs | ALL STATS.Totals."Ops/sec" | 6241 | 6875 | 10.1%
memtier_benchmark-1key-list-2K-elements-quicklist-lrange-all-elements-longs | ALL STATS.Totals."Percentile Latencies"."p50.00" | 32.127 | 29.183 | 9.2%
memtier_benchmark-1key-list-100-elements-lrange-all-elements | ALL STATS.Totals."Ops/sec" | 80464 | 84520 | 5.0%
memtier_benchmark-1key-list-100-elements-lrange-all-elements | ALL STATS.Totals."Percentile Latencies"."p50.00" | 2.367 | 2.255 | 4.7%
memtier_benchmark-1key-list-10-elements-lrange-all-elements-pipeline-10 | ALL STATS.Totals."Ops/sec" | 552733 | 561571 | 1.6%
memtier_benchmark-1key-list-10-elements-lrange-all-elements-pipeline-10 | ALL STATS.Totals."Percentile Latencies"."p50.00" | 3.135 | 3.103 | 1.0%
memtier_benchmark-1key-list-100-elements-lrange-all-elements-pipeline-10 | ALL STATS.Totals."Ops/sec" | 137747 | 152548 | 10.7%
memtier_benchmark-1key-list-100-elements-lrange-all-elements-pipeline-10 | ALL STATS.Totals."Percentile Latencies"."p50.00" | 15.423 | 13.823 | 10.4%
memtier_benchmark-1key-list-10-elements-lrange-all-elements | ALL STATS.Totals."Ops/sec" | 134326 | 134295 | 0.0%
memtier_benchmark-1key-list-10-elements-lrange-all-elements | ALL STATS.Totals."Percentile Latencies"."p50.00" | 1.463 | 1.471 | -0.5%

