### PR TITLE
Optimize LREM, LPOS, LINSERT, LINDEX: Avoid N-1 sdslen() calls on listTypeEqual

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -2748,7 +2748,7 @@ robj *listTypeGet(listTypeEntry *entry);
 unsigned char *listTypeGetValue(listTypeEntry *entry, size_t *vlen, long long *lval);
 void listTypeInsert(listTypeEntry *entry, robj *value, int where);
 void listTypeReplace(listTypeEntry *entry, robj *value);
-int listTypeEqual(listTypeEntry *entry, robj *o);
+int listTypeEqual(listTypeEntry *entry, robj *o, size_t object_len);
 void listTypeDelete(listTypeIterator *iter, listTypeEntry *entry);
 robj *listTypeDup(robj *o);
 void listTypeDelRange(robj *o, long start, long stop);


### PR DESCRIPTION
This is a very easy optimization, that avoids duplicate computation of the object length for LREM, LPOS, LINSERT na LINDEX. 

We can see that sdslen takes 7.7% of the total CPU cycles of the benchmarks.

Function Stack | CPU Time: Total | CPU Time: Self | Module | Function (Full) | Source File | Start Address
-- | -- | -- | -- | -- | -- | --
listTypeEqual | 15.50% | 2.346s | redis-server | listTypeEqual | t_list.c | 0x845dd
sdslen | 7.70% | 2.300s | redis-server | sdslen | sds.h | 0x845e4

![image](https://github.com/user-attachments/assets/48720345-70f0-4ed0-9ac4-c32f049ffeb7)




Preliminary data showcases 4% improvement on the achieavable ops/sec of LPOS in string elements, and 2% in int elements. 

Checks:
- [x] green CI
- [x] green daily: https://github.com/sundb/redis/actions/runs/10773095972 

To benchmark:

```
pip3 install redis-benchmarks-specification==0.1.235
taskset -c 0 ./src/redis-server --save '' --protected-mode no --daemonize yes
redis-benchmarks-spec-client-runner --tests-regexp ".*lpos.*" --flushall_on_every_test_start --flushall_on_every_test_end  --cpuset_start_pos 2 --override-memtier-test-time 60
```

## Preliminary benchmark:

### Unstable ac03e3721dd3b1c163fe374e7d654ff82af494ab :

|                      Test Name                      |                 Metric JSON Path                 |Metric Value|
|-----------------------------------------------------|--------------------------------------------------|-----------:|
|memtier_benchmark-1key-list-10K-elements-lpos-string |"ALL STATS".Totals."Ops/sec"                      |    5446.820|
|memtier_benchmark-1key-list-10K-elements-lpos-string |"ALL STATS".Totals."Latency"                      |      36.711|
|memtier_benchmark-1key-list-10K-elements-lpos-string |"ALL STATS".Totals."Misses/sec"                   |       0.000|
|memtier_benchmark-1key-list-10K-elements-lpos-string |"ALL STATS".Totals."Percentile Latencies"."p50.00"|      35.839|
|memtier_benchmark-1key-list-10K-elements-lpos-integer|"ALL STATS".Totals."Ops/sec"                      |    4157.120|
|memtier_benchmark-1key-list-10K-elements-lpos-integer|"ALL STATS".Totals."Latency"                      |      48.095|
|memtier_benchmark-1key-list-10K-elements-lpos-integer|"ALL STATS".Totals."Misses/sec"                   |       0.000|
|memtier_benchmark-1key-list-10K-elements-lpos-integer|"ALL STATS".Totals."Percentile Latencies"."p50.00"|      47.103|


### This PR e7fed24506c397f82126419eeafdec63a4fa79bf :

|                      Test Name                      |                 Metric JSON Path                 |Metric Value|
|-----------------------------------------------------|--------------------------------------------------|-----------:|
|memtier_benchmark-1key-list-10K-elements-lpos-string |"ALL STATS".Totals."Ops/sec"                      |    5661.890|
|memtier_benchmark-1key-list-10K-elements-lpos-string |"ALL STATS".Totals."Latency"                      |      35.317|
|memtier_benchmark-1key-list-10K-elements-lpos-string |"ALL STATS".Totals."Misses/sec"                   |       0.000|
|memtier_benchmark-1key-list-10K-elements-lpos-string |"ALL STATS".Totals."Percentile Latencies"."p50.00"|      34.303|
|memtier_benchmark-1key-list-10K-elements-lpos-integer|"ALL STATS".Totals."Ops/sec"                      |    4245.360|
|memtier_benchmark-1key-list-10K-elements-lpos-integer|"ALL STATS".Totals."Latency"                      |      47.100|
|memtier_benchmark-1key-list-10K-elements-lpos-integer|"ALL STATS".Totals."Misses/sec"                   |       0.000|
|memtier_benchmark-1key-list-10K-elements-lpos-integer|"ALL STATS".Totals."Percentile Latencies"."p50.00"|      46.079|