### PR TITLE
Optimize SSCAN command in case of listpack or intset encoding: avoid the usage of intermediate list. From 2N to N iterations

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1234,7 +1234,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         addReplyArrayLen(c, 2);
         /* Cursor is always 0 given we iterate over all set */
         addReplyBulkLongLong(c,0);
-        /* If there is no pattern the lenght is the entire set size, otherwise we defer the reply size */
+        /* If there is no pattern the length is the entire set size, otherwise we defer the reply size */
         if (use_pattern)
             replylen = addReplyDeferredLen(c);
         else


### PR DESCRIPTION
On SSCAN, in case of listpack and intset encoding we actually reply the entire set, and always reply with the cursor 0.

For those cases, we don't need to accumulate the replies in a list and can completely avoid the overhead of list appending and then iterating over the list again -- meaning we do N iterations instead of 2N iterations over the SET and save intermediate memory as well. 

Preliminary benchmarks, `SSCAN set:100 0`, showcased an improvement of 60% as visible bellow on a SET with 100 string elements (listpack encoded). 

Checks:
- [x] green CI
- [x] green Daily https://github.com/sundb/redis/actions/runs/10829772632
- [x] preliminary benchmarks  


To test it we can simply focus on the scan.tcl and corrupt-dump tests
```
tclsh tests/test_helper.tcl --single unit/scan
tclsh tests/test_helper.tcl --single integration/corrupt-dump
```

To benchmark:
```
pip3 install redis-benchmarks-specification==0.1.236
taskset -c 0 ./src/redis-server --save '' --protected-mode no --daemonize yes
redis-benchmarks-spec-client-runner --tests-regexp ".*sscan.*" --flushall_on_every_test_start --flushall_on_every_test_end  --cpuset_start_pos 2 --override-memtier-test-time 60
```

## Preliminary results

### Unstable (ac03e3721dd3b1c163fe374e7d654ff82af494ab) :

|                  Test Name                  |                 Metric JSON Path                 |Metric Value|
|---------------------------------------------|--------------------------------------------------|-----------:|
|memtier_benchmark-1key-set-100-elements-sscan|"ALL STATS".Totals."Ops/sec"                      |   49707.050|
|memtier_benchmark-1key-set-100-elements-sscan|"ALL STATS".Totals."Latency"                      |       4.011|
|memtier_benchmark-1key-set-100-elements-sscan|"ALL STATS".Totals."Misses/sec"                   |       0.000|
|memtier_benchmark-1key-set-100-elements-sscan|"ALL STATS".Totals."Percentile Latencies"."p50.00"|       3.791|

### This PR (0512f7c4f4523bb3bb55dc22afe985bbb279a17b) :

|                  Test Name                  |                 Metric JSON Path                 |Metric Value|
|---------------------------------------------|--------------------------------------------------|-----------:|
|memtier_benchmark-1key-set-100-elements-sscan|"ALL STATS".Totals."Ops/sec"                      |   79908.480|
|memtier_benchmark-1key-set-100-elements-sscan|"ALL STATS".Totals."Latency"                      |       2.491|
|memtier_benchmark-1key-set-100-elements-sscan|"ALL STATS".Totals."Misses/sec"                   |       0.000|
|memtier_benchmark-1key-set-100-elements-sscan|"ALL STATS".Totals."Percentile Latencies"."p50.00"|       2.367|