### PR TITLE
Optimize HSCAN/ZSCAN command in case of listpack encoding: avoid the usage of intermediate list

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1281,7 +1281,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
             replylen = addReplyDeferredLen(c);
         else {
             array_reply_len = o->type == OBJ_HASH ? hashTypeLength(o, 0) : zsetLength(o);
-            if (!no_values){
+            if (!no_values) {
                 array_reply_len *= 2;
             }
             addReplyArrayLen(c, array_reply_len);

--- a/src/db.c
+++ b/src/db.c
@@ -1307,7 +1307,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         addReplyBulkLongLong(c,0);
         /* In the case of OBJ_ENCODING_LISTPACK_EX we always defer the reply size given some fields might be expired */
         replylen = addReplyDeferredLen(c);
-        long cur_length = 0;
+        unsigned long cur_length = 0;
 
         while (p) {
             str = lpGet(p, &len, intbuf);
@@ -1337,6 +1337,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
             p = lpNext(lp, p);
         }
         setDeferredArrayLen(c,replylen,cur_length);
+        return;
     } else {
         serverPanic("Not handled encoding in SCAN.");
     }

--- a/src/db.c
+++ b/src/db.c
@@ -1246,7 +1246,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         unsigned char *p = lpFirst(o->ptr);
         unsigned char *str;
         int64_t len;
-        long array_reply_len = 0;
+        unsigned long array_reply_len = 0;
         unsigned char intbuf[LP_INTBUF_SIZE];
         void *replylen = NULL;
         listRelease(keys);
@@ -1265,7 +1265,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
             }
             addReplyArrayLen(c, array_reply_len);
         }
-        long cur_length = 0;
+        unsigned long cur_length = 0;
         while(p) {
             str = lpGet(p, &len, intbuf);
             /* point to the value */

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -922,7 +922,6 @@ test {corrupt payload: zset listpack encoded with invalid length causes zscan to
 
 test {corrupt payload: hash listpack encoded with invalid length causes hscan to hang} {
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
-        # In the past, it generated a broken protocol and left the client hung in smembers
         r config set sanitize-dump-payload no
         assert_equal {OK} [r restore _hash 0 "\x10\x17\x17\x00\x00\x00\x0e\x00\x82\x66\x31\x03\x82\x76\x31\x03\x82\x66\x32\x03\x82\x76\x32\x03\xff\x0c\x00\xf1\xc5\x36\x92\x29\x6a\x8c\xc5" replace]
         assert_encoding listpack _hash

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -911,7 +911,6 @@ test {corrupt payload: fuzzer findings - set with invalid length causes sscan to
 
 test {corrupt payload: zset listpack encoded with invalid length causes zscan to hang} {
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
-        # In the past, it generated a broken protocol and left the client hung in smembers
         r config set sanitize-dump-payload no
         assert_equal {OK} [r restore _zset 0 "\x11\x16\x16\x00\x00\x00\x1a\x00\x81\x61\x02\x01\x01\x81\x62\x02\x02\x01\x81\x63\x02\x03\x01\xff\x0c\x00\x81\xa7\xcd\x31\x22\x6c\xef\xf7" replace]
         assert_encoding listpack _zset
@@ -920,7 +919,6 @@ test {corrupt payload: zset listpack encoded with invalid length causes zscan to
         assert_equal [count_log_message 0 "ASSERTION FAILED"] 1
     }
 }
-
 
 test {corrupt payload: hash listpack encoded with invalid length causes hscan to hang} {
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -913,7 +913,7 @@ test {corrupt payload: zset listpack encoded with invalid length causes zscan to
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
         # In the past, it generated a broken protocol and left the client hung in smembers
         r config set sanitize-dump-payload no
-        assert_equal {OK} [r restore _zset 0 "\x11\x16\x16\x00\x00\x00\x1a\x00\x81a\x02\x01\x01\x81b\x02\x02\x01\x81c\x02\x03\x01\xff\x0c\x00\x81\xa7\xcd1\"l\xef\xf7" replace]
+        assert_equal {OK} [r restore _zset 0 "\x11\x16\x16\x00\x00\x00\x1a\x00\x81\x61\x02\x01\x01\x81\x62\x02\x02\x01\x81\x63\x02\x03\x01\xff\x0c\x00\x81\xa7\xcd\x31\x22\x6c\xef\xf7" replace]
         assert_encoding listpack _zset
         catch { r ZSCAN _zset 0 } err
         assert_equal [count_log_message 0 "crashed by signal"] 0

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -926,7 +926,7 @@ test {corrupt payload: hash listpack encoded with invalid length causes hscan to
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
         # In the past, it generated a broken protocol and left the client hung in smembers
         r config set sanitize-dump-payload no
-        assert_equal {OK} [r restore _hash 0 "\x10\x17\x17\x00\x00\x00\x0e\x00\x82f1\x03\x82v1\x03\x82f2\x03\x82v2\x03\xff\x0c\x00\xf1\xc56\x92)j\x8c\xc5" replace]
+        assert_equal {OK} [r restore _hash 0 "\x10\x17\x17\x00\x00\x00\x0e\x00\x82\x66\x31\x03\x82\x76\x31\x03\x82\x66\x32\x03\x82\x76\x32\x03\xff\x0c\x00\xf1\xc5\x36\x92\x29\x6a\x8c\xc5" replace]
         assert_encoding listpack _hash
         catch { r HSCAN _hash 0 } err
         assert_equal [count_log_message 0 "crashed by signal"] 0


### PR DESCRIPTION
Similar to #13530 , applied to HSCAN and ZSCAN in case of listpack encoding. 

**Preliminary benchmark results showcase an improvement of  108% on the achievable ops/sec for ZSCAN and 65% for HSCAN**. 


To test it we can simply focus on the scan.tcl
```
tclsh tests/test_helper.tcl --single unit/scan
tclsh tests/test_helper.tcl --single unit/type/hash-field-expire
```

Checks:
- [x] corrupted payload tests
- [x] green CI
- [ ] green daily: running https://github.com/filipecosta90/redis/actions/runs/10847197741
- [x] preliminary benchmarks


To benchmark:

```
pip3 install redis-benchmarks-specification==0.1.237
taskset -c 0 ./src/redis-server --save '' --protected-mode no --daemonize yes
redis-benchmarks-spec-client-runner --tests-regexp ".*zscan.*|.*hscan.*" --flushall_on_every_test_start --flushall_on_every_test_end  --cpuset_start_pos 2 --override-memtier-test-time 60
```


## Preliminary results

### Unstable (ac03e3721dd3b1c163fe374e7d654ff82af494ab) :

|                      Test Name                       |                 Metric JSON Path                 |Metric Value|
|------------------------------------------------------|--------------------------------------------------|-----------:|
|memtier_benchmark-1key-zset-100-elements-zscan        |"ALL STATS".Totals."Ops/sec"                      |   28224.300|
|memtier_benchmark-1key-zset-100-elements-zscan        |"ALL STATS".Totals."Latency"                      |       7.060|
|memtier_benchmark-1key-zset-100-elements-zscan        |"ALL STATS".Totals."Misses/sec"                   |       0.000|
|memtier_benchmark-1key-zset-100-elements-zscan        |"ALL STATS".Totals."Percentile Latencies"."p50.00"|       7.935|
|memtier_benchmark-1key-hash-hscan-50-fields-10B-values|"ALL STATS".Totals."Ops/sec"                      |   50587.330|
|memtier_benchmark-1key-hash-hscan-50-fields-10B-values|"ALL STATS".Totals."Latency"                      |       3.937|
|memtier_benchmark-1key-hash-hscan-50-fields-10B-values|"ALL STATS".Totals."Misses/sec"                   |       0.000|
|memtier_benchmark-1key-hash-hscan-50-fields-10B-values|"ALL STATS".Totals."Percentile Latencies"."p50.00"|       3.327|

### This PR (822a79a18e91dcf318f5de47ae9ab99a556afdd7) :

|                      Test Name                       |                 Metric JSON Path                 |Metric Value|
|------------------------------------------------------|--------------------------------------------------|-----------:|
|memtier_benchmark-1key-zset-100-elements-zscan        |"ALL STATS".Totals."Ops/sec"                      |   58939.000|
|memtier_benchmark-1key-zset-100-elements-zscan        |"ALL STATS".Totals."Latency"                      |       3.368|
|memtier_benchmark-1key-zset-100-elements-zscan        |"ALL STATS".Totals."Misses/sec"                   |       0.000|
|memtier_benchmark-1key-zset-100-elements-zscan        |"ALL STATS".Totals."Percentile Latencies"."p50.00"|       3.311|
|memtier_benchmark-1key-hash-hscan-50-fields-10B-values|"ALL STATS".Totals."Ops/sec"                      |   83676.260|
|memtier_benchmark-1key-hash-hscan-50-fields-10B-values|"ALL STATS".Totals."Latency"                      |       2.377|
|memtier_benchmark-1key-hash-hscan-50-fields-10B-values|"ALL STATS".Totals."Misses/sec"                   |       0.000|
|memtier_benchmark-1key-hash-hscan-50-fields-10B-values|"ALL STATS".Totals."Percentile Latencies"."p50.00"|       2.191|

