### PR TITLE
Optimize hex_digit_to_int, hi_hex_digit_to_int performance

### DIFF
--- a/deps/hiredis/sds.c
+++ b/deps/hiredis/sds.c
@@ -900,25 +900,7 @@ hisds hi_sdscatrepr(hisds s, const char *p, size_t len) {
 /* Helper function for hi_sdssplitargs() that converts a hex digit into an
  * integer from 0 to 15 */
 static int hi_hex_digit_to_int(char c) {
-    switch(c) {
-    case '0': return 0;
-    case '1': return 1;
-    case '2': return 2;
-    case '3': return 3;
-    case '4': return 4;
-    case '5': return 5;
-    case '6': return 6;
-    case '7': return 7;
-    case '8': return 8;
-    case '9': return 9;
-    case 'a': case 'A': return 10;
-    case 'b': case 'B': return 11;
-    case 'c': case 'C': return 12;
-    case 'd': case 'D': return 13;
-    case 'e': case 'E': return 14;
-    case 'f': case 'F': return 15;
-    default: return 0;
-    }
+    return c - '0' - (c / 'A' * 7) - (c / 'a' * 32);
 }
 
 /* Split a line into arguments, where every argument can be in the

--- a/src/sds.c
+++ b/src/sds.c
@@ -942,25 +942,7 @@ int is_hex_digit(char c) {
 /* Helper function for sdssplitargs() that converts a hex digit into an
  * integer from 0 to 15 */
 int hex_digit_to_int(char c) {
-    switch(c) {
-    case '0': return 0;
-    case '1': return 1;
-    case '2': return 2;
-    case '3': return 3;
-    case '4': return 4;
-    case '5': return 5;
-    case '6': return 6;
-    case '7': return 7;
-    case '8': return 8;
-    case '9': return 9;
-    case 'a': case 'A': return 10;
-    case 'b': case 'B': return 11;
-    case 'c': case 'C': return 12;
-    case 'd': case 'D': return 13;
-    case 'e': case 'E': return 14;
-    case 'f': case 'F': return 15;
-    default: return 0;
-    }
+    return c - '0' - (c / 'A' * 7) - (c / 'a' * 32);
 }
 
 /* Split a line into arguments, where every argument can be in the


### PR DESCRIPTION
This is a very easy optimization, that avoids branch in hex_digit_to_int and hi_hex_digit_to_int in order to increase the performance of those two functions.

The following is the hex_digit_to_int time consuming. About 100% performance boost for this benchmark.
Test environment:
- CPU: Apple M1
- OS: Macos 14.6.1 (23G93)
Cases=100000000 origin=2.176300 optimized=0.750783
Cases=1000000000 origin=21.475641 optimized=7.282929
