### PR TITLE
A few fix-ups for macOS and PowerPC

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -19,7 +19,7 @@
 #include <fcntl.h>
 #endif
 
-#if defined(__APPLE__) && defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+#if defined(__APPLE__) && defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
 #define MAC_OS_10_6_DETECTED
 #endif
 
@@ -286,7 +286,7 @@ void setproctitle(const char *fmt, ...);
 #include <kernel/OS.h>
 #define redis_set_thread_title(name) rename_thread(find_thread(0), name)
 #else
-#if (defined __APPLE__ && defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)
+#if (defined __APPLE__ && defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)
 int pthread_setname_np(const char *name);
 #include <pthread.h>
 #define redis_set_thread_title(name) pthread_setname_np(name)

--- a/src/debug.c
+++ b/src/debug.c
@@ -1210,14 +1210,15 @@ static void* getAndSetMcontextEip(ucontext_t *uc, void *eip) {
     } \
     return old_val; \
 } while(0)
-#if defined(__APPLE__) && !defined(MAC_OS_10_6_DETECTED)
-    /* OSX < 10.6 */
+#if defined(__APPLE__) && defined(__POWERPC__)
+    /* OSX on PowerPC */
+    GET_SET_RETURN(uc->uc_mcontext->__ss.__srr0, eip);
+#elif defined(__APPLE__) && !defined(MAC_OS_10_6_DETECTED)
+    /* OSX < 10.6 on x86 */
     #if defined(__x86_64__)
     GET_SET_RETURN(uc->uc_mcontext->__ss.__rip, eip);
     #elif defined(__i386__)
     GET_SET_RETURN(uc->uc_mcontext->__ss.__eip, eip);
-    #else
-    GET_SET_RETURN(uc->uc_mcontext->__ss.__srr0, eip);
     #endif
 #elif defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)
     /* OSX >= 10.6 */

--- a/src/debug.c
+++ b/src/debug.c
@@ -1373,7 +1373,7 @@ void logRegisters(ucontext_t *uc) {
         (unsigned long) uc->uc_mcontext->__ss.__gs
     );
     logStackContent((void**)uc->uc_mcontext->__ss.__esp);
-    #else
+    #elif !defined(__ppc__)
     /* OSX ARM64 */
     serverLog(LL_WARNING,
     "\n"
@@ -1422,6 +1422,8 @@ void logRegisters(ucontext_t *uc) {
         (unsigned long) uc->uc_mcontext->__ss.__cpsr
     );
     logStackContent((void**) arm_thread_state64_get_sp(uc->uc_mcontext->__ss));
+    #else
+	NOT_SUPPORTED();
     #endif
 /* Linux */
 #elif defined(__linux__)

--- a/src/debug.c
+++ b/src/debug.c
@@ -1424,7 +1424,7 @@ void logRegisters(ucontext_t *uc) {
     );
     logStackContent((void**) arm_thread_state64_get_sp(uc->uc_mcontext->__ss));
     #else
-	NOT_SUPPORTED();
+        NOT_SUPPORTED();
     #endif
 /* Linux */
 #elif defined(__linux__)


### PR DESCRIPTION
The PR fixes two bugs and improves code style a bit.

1. `AvailabilityMacros.h` uses underscore-unprefixed macros, so the current version has exactly the opposite effect to the desired one: `MAC_OS_10_6_DETECTED` is _not_ defined on 10.6, because `__MAC_OS_X_VERSION_MAX_ALLOWED` evaluates to zero.
2. `debug.c` code falls back to ARM case without using correct macros for PowerPC, which obviously cannot work.

Non-functional improvements:
1. There is no need to check if `MAC_OS_X_VERSION_MAX_ALLOWED` is defined when the following comparison is `MAC_OS_X_VERSION_MAX_ALLOWED >= 1060`. If it is not defined, it evaluates to 0, so result of the comparison is false.
2. I do not understand why `MAC_OS_10_6_DETECTED` is needed in `debug.c` at all. In either case the code for i386 is identical, as well as the code for x86_64. What is the need to have those repeated twice? (Maybe x86_64 should go before i386, please tell me if that is the case.)

P. S. Notice, that `debug.c` code will not compile on 10.4, which does not add underscores (i.e. `ss.srr0` instead of `__ss.__srr0` etc.). But I am not particularly interested in supporting 10.4 on either arch, so this is just for the record.