### PR TITLE
Fix Subexpiry Stat in HFE Lazy-Expiration Logic

### DIFF
--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -888,6 +888,23 @@ start_server {tags {"external:skip needs:debug"}} {
         }
     }
 
+    test "Lazy expiry of last HFE will update subexpiry statistics ($type)" {
+        r debug set-active-expire 0
+        r flushall
+        r hset myhash f1 v1 f2 v2 f3 v3
+        r hpexpire myhash 5 FIELDS 2 f1 f2
+        after 10
+        # Expected to count single hash with subexpiry
+        assert_match  [ get_stat_subexpiry r] 1
+        # Lazy expiry of f1
+        assert_equal "" [r hget myhash f1]
+        assert_match  [ get_stat_subexpiry r] 1
+        # Lazy expiry of f2
+        assert_equal "" [r hget myhash f2]
+        assert_match  [   get_stat_subexpiry r] 0
+        r debug set-active-expire 1
+    }
+
     r config set hash-max-listpack-entries 512
 }
 


### PR DESCRIPTION
In the HFE lazy-expiration logic, this fix ensures that if the removed hash field 
with an expiration is the last one in the hash, we correctly remove the hash 
from the global HFE data structure, which is crucial for maintaining accurate 
subexpiry statistics.

If there are remaining hash fields with expirations, no immediate update to the 
global HFE data structure is necessary. Active expiration will gracefully update 
the minimum expiration time for the hash in the global HFE data structure, 
optimizing performance by avoiding redundant updates for each individual field 
removal.
