### PR TITLE
Replace wrongly free with zfree in redis-cli

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -3695,7 +3695,7 @@ static int evalMode(int argc, char **argv) {
         int eval_ldb = config.eval_ldb; /* Save it, may be reverted. */
         retval = issueCommand(argc+3-got_comma, argv2);
         for (j = 0; j < argc+3-got_comma; j++) sdsfree(argv2[j]);
-        free(argv2);
+        zfree(argv2);
         if (eval_ldb) {
             if (!config.eval_ldb) {
                 /* If the debugging session ended immediately, there was an

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -808,6 +808,12 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
         assert_equal 3 [exec {*}$cmdline ZCARD new_zset]
         assert_equal "a\n1\nb\n2\nc\n3" [exec {*}$cmdline ZRANGE new_zset 0 -1 WITHSCORES]
     }
+
+    test "Send eval command by using --eval option" {
+        set tmpfile [write_tmpfile "return ARGV\[1\]"]
+        set cmdline [rediscli [srv host] [srv port]]
+        assert_equal "foo" [exec {*}$cmdline --eval $tmpfile , foo]
+    }
 }
 
 start_server {tags {"cli external:skip"}} {

--- a/tests/integration/redis-cli.tcl
+++ b/tests/integration/redis-cli.tcl
@@ -810,7 +810,7 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
     }
 
     test "Send eval command by using --eval option" {
-        set tmpfile [write_tmpfile "return ARGV\[1\]"]
+        set tmpfile [write_tmpfile {return ARGV[1]}]
         set cmdline [rediscli [srv host] [srv port]]
         assert_equal "foo" [exec {*}$cmdline --eval $tmpfile , foo]
     }


### PR DESCRIPTION
#13258 Incorrect use of free instead of zfree