### PR TITLE
Fix race in HFE tests

### DIFF
--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -1014,6 +1014,7 @@ start_server {tags {"external:skip needs:debug"}} {
             start_server {overrides {appendonly {yes} appendfsync always} tags {external:skip}} {
 
                 set aof [get_last_incr_aof_path r]
+                r debug set-active-expire 0 ;# Prevent fields from being expired during data preparation
 
                 # Time is in the past so it should propagate HDELs to replica
                 # and delete the fields
@@ -1040,6 +1041,7 @@ start_server {tags {"external:skip needs:debug"}} {
                 r hpexpireat h2 [expr [clock seconds]*1000+100000] LT FIELDS 1 f3
                 r hexpireat h2 [expr [clock seconds]+10] NX FIELDS 1 f4
 
+                r debug set-active-expire 1
                 wait_for_condition 50 100 {
                     [r hlen h2] eq 2
                 } else {
@@ -1068,7 +1070,7 @@ start_server {tags {"external:skip needs:debug"}} {
                     {hdel h2 f2}
                 }
             }
-        }
+        } {} {needs:debug}
 
         test "Lazy Expire - fields are lazy deleted and propagated to replicas ($type)" {
             start_server {overrides {appendonly {yes} appendfsync always} tags {external:skip}} {

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -199,12 +199,12 @@ start_server {tags {"external:skip needs:debug"}} {
             set hash_sizes {1 15 16 17 31 32 33 40}
             foreach h $hash_sizes {
                 for {set i 1} {$i <= $h} {incr i} {
-                    # random expiration time
+                    # Random expiration time (Take care expired not after "mix$h")
                     r hset hrand$h f$i v$i
-                    r hpexpire hrand$h [expr {50 + int(rand() * 50)}] FIELDS 1 f$i
+                    r hpexpire hrand$h [expr {70 + int(rand() * 30)}] FIELDS 1 f$i
                     assert_equal 1 [r HEXISTS hrand$h f$i]
 
-                    # same expiration time
+                    # Same expiration time (Take care expired not after "mix$h")
                     r hset same$h f$i v$i
                     r hpexpire same$h 100 FIELDS 1 f$i
                     assert_equal 1 [r HEXISTS same$h f$i]
@@ -286,10 +286,9 @@ start_server {tags {"external:skip needs:debug"}} {
         test "HEXPIRETIME - returns TTL in Unix timestamp ($type)" {
             r del myhash
             r HSET myhash field1 value1
-            r HPEXPIRE myhash 1000 NX FIELDS 1 field1
-
             set lo [expr {[clock seconds] + 1}]
             set hi [expr {[clock seconds] + 2}]
+            r HPEXPIRE myhash 1000 NX FIELDS 1 field1
             assert_range [r HEXPIRETIME myhash FIELDS 1 field1] $lo $hi
             assert_range [r HPEXPIRETIME myhash FIELDS 1 field1] [expr $lo*1000] [expr $hi*1000]
         }


### PR DESCRIPTION
Test 1 - give more time for expiration
Test 2 - Evaluate expiration time boundaries [+1,+2] before setting expiration [+1]
Test 3 - Avoid race on test HFEs propagated to replica 