### PR TITLE
Only run redis_docs_sync.yaml on latest release

### DIFF
--- a/.github/workflows/redis_docs_sync.yaml
+++ b/.github/workflows/redis_docs_sync.yaml
@@ -21,4 +21,15 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           RELEASE_NAME: ${{ github.event.release.tag_name }}
         run: |
-          gh workflow run -R redis/docs redis_docs_sync.yaml -f release="${RELEASE_NAME}"
+          LATEST_RELEASE=$(
+              curl -Ls \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/redis/redis/releases/latest \
+              | jq -r '.tag_name'
+          )
+
+          if [[ "${LATEST_RELEASE}" == "${RELEASE_NAME}" ]]; then
+            gh workflow run -R redis/docs redis_docs_sync.yaml -f release="${RELEASE_NAME}"
+          fi


### PR DESCRIPTION
We only want to trigger the workflow on the documentation repository for the latest release