### PR TITLE
Fix get # option in sort command

### DIFF
--- a/src/sort.c
+++ b/src/sort.c
@@ -241,10 +241,11 @@ void sortCommandGeneric(client *c, int readonly) {
         } else if (!strcasecmp(c->argv[j]->ptr,"get") && leftargs >= 1) {
             /* If GET is specified with a real pattern, we can't accept it in cluster mode,
              * unless we can make sure the keys formed by the pattern are in the same slot 
-             * as the key to sort. */
+             * as the key to sort. The pattern # represents the key itself, so just skip
+             * pattern slot check. */
             if (server.cluster_enabled &&
-                patternHashSlot(c->argv[j+1]->ptr, sdslen(c->argv[j+1]->ptr)) != getKeySlot(c->argv[1]->ptr) &&
-                strcmp(c->argv[j+1]->ptr, "#"))
+                strcmp(c->argv[j+1]->ptr, "#") &&
+                patternHashSlot(c->argv[j+1]->ptr, sdslen(c->argv[j+1]->ptr)) != getKeySlot(c->argv[1]->ptr))
             {
                 addReplyError(c, "GET option of SORT denied in Cluster mode when "
                               "keys formed by the pattern may be in different slots.");

--- a/src/sort.c
+++ b/src/sort.c
@@ -244,7 +244,7 @@ void sortCommandGeneric(client *c, int readonly) {
              * as the key to sort. */
             if (server.cluster_enabled &&
                 patternHashSlot(c->argv[j+1]->ptr, sdslen(c->argv[j+1]->ptr)) != getKeySlot(c->argv[1]->ptr) &&
-                strcasecmp(c->argv[j]->ptr,"#"))
+                strcmp(c->argv[j+1]->ptr, "#"))
             {
                 addReplyError(c, "GET option of SORT denied in Cluster mode when "
                               "keys formed by the pattern may be in different slots.");

--- a/src/sort.c
+++ b/src/sort.c
@@ -242,7 +242,10 @@ void sortCommandGeneric(client *c, int readonly) {
             /* If GET is specified with a real pattern, we can't accept it in cluster mode,
              * unless we can make sure the keys formed by the pattern are in the same slot 
              * as the key to sort. */
-            if (server.cluster_enabled && patternHashSlot(c->argv[j+1]->ptr, sdslen(c->argv[j+1]->ptr)) != getKeySlot(c->argv[1]->ptr)) {
+            if (server.cluster_enabled &&
+                patternHashSlot(c->argv[j+1]->ptr, sdslen(c->argv[j+1]->ptr)) != getKeySlot(c->argv[1]->ptr) &&
+                strcasecmp(c->argv[j]->ptr,"#"))
+            {
                 addReplyError(c, "GET option of SORT denied in Cluster mode when "
                               "keys formed by the pattern may be in different slots.");
                 syntax_error++;

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -409,4 +409,9 @@ start_cluster 1 0 {tags {"external:skip cluster sort"}} {
         assert_match {ERR GET option of SORT denied in Cluster mode when *} $e
         r sort_ro "{a}mylist" by "{a}by*" get "{a}get*"
     } {30 200 100}
+
+    test "sort_ro get # in cluster mode" {
+        assert_equal [r sort_ro "{a}mylist" by "{a}by*" get # ] {3 1 2}
+        r sort_ro "{a}mylist" by "{a}by*" get "{a}get*" get #
+    } {30 3 200 1 100 2}
 }

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -398,7 +398,6 @@ start_cluster 1 0 {tags {"external:skip cluster sort"}} {
         r sort "{a}mylist" by "{a}by*" get "{a}get*" get #
     } {30 3 200 1 100 2}
 
-
     test "sort_ro by in cluster mode" {
         catch {r sort_ro "{a}mylist" by by*} e
         assert_match {ERR BY option of SORT denied in Cluster mode when *} $e

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -73,7 +73,7 @@ start_server {
     set result [create_random_dataset 16 lpush]
     test "SORT GET #" {
         assert_equal [lsort -integer $result] [r sort tosort GET #]
-    } {} {cluster:skip}
+    }
 
 foreach command {SORT SORT_RO} {
     test "$command GET <const>" {
@@ -392,6 +392,12 @@ start_cluster 1 0 {tags {"external:skip cluster sort"}} {
         assert_match {ERR GET option of SORT denied in Cluster mode when *} $e
         r sort "{a}mylist" by "{a}by*" get "{a}get*"
     } {30 200 100}
+
+    test "sort get # in cluster mode" {
+        assert_equal [r sort "{a}mylist" by "{a}by*" get # ] {3 1 2}
+        r sort "{a}mylist" by "{a}by*" get "{a}get*" get #
+    } {30 3 200 1 100 2}
+
 
     test "sort_ro by in cluster mode" {
         catch {r sort_ro "{a}mylist" by by*} e


### PR DESCRIPTION
From 7.4, Redis allows `GET` options in cluster mode when the pattern maps to
the same slot as the key, but GET # pattern that represents key itself is missed.
This commit resolves it.

fix https://github.com/redis/redis/issues/13607.