### PR TITLE
Fix compilation on compilers that do not support target attribute

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -23,6 +23,8 @@
     #else
         #define ATTRIBUTE_TARGET_POPCNT
     #endif
+#else
+    #define ATTRIBUTE_TARGET_POPCNT
 #endif
 
 ATTRIBUTE_TARGET_POPCNT

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -17,8 +17,8 @@
  * 'count' bytes. The implementation of this function is required to
  * work with an input string length up to 512 MB or more (server.proto_max_bulk_len) */
 #if defined(__x86_64__) && ((defined(__GNUC__) && __GNUC__ > 5) || (defined(__clang__)))
-    #if __has_attribute(target)
-        #define HAS_POPCNT
+    #if defined(__has_attribute) && __has_attribute(target)
+        #define HAVE_POPCNT
         #define ATTRIBUTE_TARGET_POPCNT __attribute__((target("popcnt")))
     #else
         #define ATTRIBUTE_TARGET_POPCNT
@@ -32,7 +32,7 @@ long long redisPopcount(void *s, long count) {
     long long bits = 0;
     unsigned char *p = s;
     uint32_t *p4;
-#if defined(HAS_POPCNT)
+#if defined(HAVE_POPCNT)
     int use_popcnt = __builtin_cpu_supports("popcnt"); /* Check if CPU supports POPCNT instruction. */
 #else
     int use_popcnt = 0; /* Assume CPU does not support POPCNT if

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -16,17 +16,6 @@
 /* Count number of bits set in the binary array pointed by 's' and long
  * 'count' bytes. The implementation of this function is required to
  * work with an input string length up to 512 MB or more (server.proto_max_bulk_len) */
-#if defined(__x86_64__) && ((defined(__GNUC__) && __GNUC__ > 5) || (defined(__clang__)))
-    #if defined(__has_attribute) && __has_attribute(target)
-        #define HAVE_POPCNT
-        #define ATTRIBUTE_TARGET_POPCNT __attribute__((target("popcnt")))
-    #else
-        #define ATTRIBUTE_TARGET_POPCNT
-    #endif
-#else
-    #define ATTRIBUTE_TARGET_POPCNT
-#endif
-
 ATTRIBUTE_TARGET_POPCNT
 long long redisPopcount(void *s, long count) {
     long long bits = 0;

--- a/src/config.h
+++ b/src/config.h
@@ -307,4 +307,15 @@ void setcpuaffinity(const char *cpulist);
 #define HAVE_FADVISE
 #endif
 
+#if defined(__x86_64__) && ((defined(__GNUC__) && __GNUC__ > 5) || (defined(__clang__)))
+    #if defined(__has_attribute) && __has_attribute(target)
+        #define HAVE_POPCNT
+        #define ATTRIBUTE_TARGET_POPCNT __attribute__((target("popcnt")))
+    #else
+        #define ATTRIBUTE_TARGET_POPCNT
+    #endif
+#else
+    #define ATTRIBUTE_TARGET_POPCNT
+#endif
+
 #endif


### PR DESCRIPTION
introduced by https://github.com/redis/redis/pull/13359
failure CI on ARM64: https://github.com/redis/redis-extra-ci/actions/runs/11377893230/job/31652773710

and verified the bechmark(same as https://github.com/redis/redis/pull/13359#issuecomment-2357941207) and didn't see regressions.