### PR TITLE
Fix setModuleStringConfig() to support NULL 

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -12639,7 +12639,7 @@ int setModuleBoolConfig(ModuleConfig *config, int val, const char **err) {
 
 int setModuleStringConfig(ModuleConfig *config, sds strval, const char **err) {
     RedisModuleString *error = NULL;
-    RedisModuleString *new = createStringObject(strval, sdslen(strval));
+    RedisModuleString *new = createStringObject(strval, strval ? sdslen(strval) : 0);
     int return_code = config->set_fn.set_string(config->name, new, config->privdata, &error);
     propagateErrorString(error, err);
     decrRefCount(new);


### PR DESCRIPTION
 This PR modifies `setModuleStringConfig()` to support the case where `strval` is NULL.

  
 **Details**
 Trying to use [Module Configurations API](https://redis.io/docs/latest/develop/reference/modules/modules-api-ref/#module-configurations-api) to register a string config with NULL as default value, the server crashes in `setModuleStringConfig()`, so, this PR just add the validation to check if strval is NULL before invoking `sdslen(strval)` 

This is the call to `RedisModule_RegisterStringConfig()` which caused the crash:
```c
RedisModule_RegisterStringConfig(
        ctx, "ext-load", NULL, REDISMODULE_CONFIG_IMMUTABLE, 
        get_ext_load, set_ext_load, NULL, NULL)
```


<details>

<summary>Stack trace</summary>

```python
      ------ STACK TRACE ------
      EIP:
      0   redis-server                        0x0000000104da47f0 setModuleStringConfig + 40
      
      Backtrace:
      0   libsystem_platform.dylib            0x0000000192e0a584 _sigtramp + 56
      1   redis-server                        0x0000000104da2408 RM_LoadConfigs + 676
      2   redis-server                        0x0000000104da2408 RM_LoadConfigs + 676
      3   redisearch.so                       0x0000000106e245ec RegisterModuleConfig + 4380
      4   redisearch.so                       0x0000000106e64148 RediSearch_InitModuleInternal + 76
      5   redisearch.so                       0x0000000106e6a254 RedisModule_OnLoad + 292
      6   redis-server                        0x0000000104da2e44 moduleLoad + 576
      7   redis-server                        0x0000000104cb5374 main + 13456
      8   dyld                                0x0000000192a4f154 start + 2476
      
      ------ STACK TRACE DONE ------
```

</details>


 I'm not sure if any tests or additional validation should be added. If any additional change is needed, please let me know. Thanks.