### PR TITLE
Let ping use resp protocol in benchmark

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1874,7 +1874,7 @@ int main(int argc, char **argv) {
         genBenchmarkRandomData(data, config.datasize);
         data[config.datasize] = '\0';
 
-        if (test_is_selected("ping_inline") || test_is_selected("ping"))
+        if (test_is_selected("ping_inline"))
             benchmark("PING_INLINE","PING\r\n",6);
 
         if (test_is_selected("ping_mbulk") || test_is_selected("ping")) {


### PR DESCRIPTION
The `ping` command is defined to use resp protocol later (on line 1880). Guess line 1877 is forgot to modify.