### PR TITLE
Print command tokens on a crash when hide-user-data-from-log is enabled

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1150,6 +1150,7 @@ static void cmdParserClearMatchedArgs(cmdParserArg *args, int numargs) {
     }
 }
 
+/* Save token position. pos indicates offset in client argv[]. */
 static void cmdParserSaveToken(cmdParserCtx *ctx, int pos, cmdParserArg *arg) {
     /* Validate token position. If we can't pass this check, it means there is
      * something wrong in the parser. */

--- a/tests/modules/crash.c
+++ b/tests/modules/crash.c
@@ -21,19 +21,291 @@ void segfaultCrash(RedisModuleInfoCtx *ctx, int for_crash_report) {
     *p = 'x';
 }
 
+int cmd_crash(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    UNUSED(ctx);
+    UNUSED(argv);
+    UNUSED(argc);
+
+    RedisModule_Assert(0);
+    return REDISMODULE_OK;
+}
+
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
-    if (RedisModule_Init(ctx,"infocrash",1,REDISMODULE_APIVER_1)
+    if (RedisModule_Init(ctx,"modulecrash",1,REDISMODULE_APIVER_1)
             == REDISMODULE_ERR) return REDISMODULE_ERR;
-    RedisModule_Assert(argc == 1);
-    if (!strcasecmp(RedisModule_StringPtrLen(argv[0], NULL), "segfault")) {
-        if (RedisModule_RegisterInfoFunc(ctx, segfaultCrash) == REDISMODULE_ERR) return REDISMODULE_ERR;
-    } else if(!strcasecmp(RedisModule_StringPtrLen(argv[0], NULL), "assert")) {
-        if (RedisModule_RegisterInfoFunc(ctx, assertCrash) == REDISMODULE_ERR) return REDISMODULE_ERR;
-    } else {
-        return REDISMODULE_ERR;
+
+    if (argc >= 1) {
+        if (!strcasecmp(RedisModule_StringPtrLen(argv[0], NULL), "segfault")) {
+            if (RedisModule_RegisterInfoFunc(ctx, segfaultCrash) == REDISMODULE_ERR) return REDISMODULE_ERR;
+        } else if (!strcasecmp(RedisModule_StringPtrLen(argv[0], NULL),"assert")) {
+            if (RedisModule_RegisterInfoFunc(ctx, assertCrash) == REDISMODULE_ERR) return REDISMODULE_ERR;
+        }
     }
+
+    /* Create modulecrash.xadd command which is similar to xadd command.
+     * It will crash in the command handler to verify we print command tokens
+     * when hide-user-data-from-log config is enabled */
+    RedisModuleCommandInfo info = {
+            .version = REDISMODULE_COMMAND_INFO_VERSION,
+            .arity = -5,
+            .key_specs = (RedisModuleCommandKeySpec[]){
+                    {
+                            .notes = "UPDATE instead of INSERT because of the optional trimming feature",
+                            .flags = REDISMODULE_CMD_KEY_RW | REDISMODULE_CMD_KEY_UPDATE,
+                            .begin_search_type = REDISMODULE_KSPEC_BS_INDEX,
+                            .bs.index.pos = 1,
+                            .find_keys_type = REDISMODULE_KSPEC_FK_RANGE,
+                            .fk.range = {0,1,0}
+                    },
+                    {0}
+            },
+            .args = (RedisModuleCommandArg[]){
+                    {
+                            .name = "key",
+                            .type = REDISMODULE_ARG_TYPE_KEY,
+                            .key_spec_index = 0
+                    },
+                    {
+                            .name = "nomkstream",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                            .token = "NOMKSTREAM",
+                            .since = "6.2.0",
+                            .flags = REDISMODULE_CMD_ARG_OPTIONAL
+                    },
+                    {
+                            .name = "trim",
+                            .type = REDISMODULE_ARG_TYPE_BLOCK,
+                            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                            .subargs = (RedisModuleCommandArg[]){
+                                    {
+                                            .name = "strategy",
+                                            .type = REDISMODULE_ARG_TYPE_ONEOF,
+                                            .subargs = (RedisModuleCommandArg[]){
+                                                    {
+                                                            .name = "maxlen",
+                                                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                                            .token = "MAXLEN",
+                                                    },
+                                                    {
+                                                            .name = "minid",
+                                                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                                            .token = "MINID",
+                                                            .since = "6.2.0",
+                                                    },
+                                                    {0}
+                                            }
+                                    },
+                                    {
+                                            .name = "operator",
+                                            .type = REDISMODULE_ARG_TYPE_ONEOF,
+                                            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                                            .subargs = (RedisModuleCommandArg[]){
+                                                    {
+                                                            .name = "equal",
+                                                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                                            .token = "="
+                                                    },
+                                                    {
+                                                            .name = "approximately",
+                                                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                                            .token = "~"
+                                                    },
+                                                    {0}
+                                            }
+                                    },
+                                    {
+                                            .name = "threshold",
+                                            .type = REDISMODULE_ARG_TYPE_STRING,
+                                            .display_text = "threshold" /* Just for coverage, doesn't have a visible effect */
+                                    },
+                                    {
+                                            .name = "count",
+                                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                                            .token = "LIMIT",
+                                            .since = "6.2.0",
+                                            .flags = REDISMODULE_CMD_ARG_OPTIONAL
+                                    },
+                                    {0}
+                            }
+                    },
+                    {
+                            .name = "id-selector",
+                            .type = REDISMODULE_ARG_TYPE_ONEOF,
+                            .subargs = (RedisModuleCommandArg[]){
+                                    {
+                                            .name = "auto-id",
+                                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                            .token = "*"
+                                    },
+                                    {
+                                            .name = "id",
+                                            .type = REDISMODULE_ARG_TYPE_STRING,
+                                    },
+                                    {0}
+                            }
+                    },
+                    {
+                            .name = "data",
+                            .type = REDISMODULE_ARG_TYPE_BLOCK,
+                            .flags = REDISMODULE_CMD_ARG_MULTIPLE,
+                            .subargs = (RedisModuleCommandArg[]){
+                                    {
+                                            .name = "field",
+                                            .type = REDISMODULE_ARG_TYPE_STRING,
+                                    },
+                                    {
+                                            .name = "value",
+                                            .type = REDISMODULE_ARG_TYPE_STRING,
+                                    },
+                                    {0}
+                            }
+                    },
+                    {0}
+            }
+    };
+
+    RedisModuleCommand *cmd;
+
+    if (RedisModule_CreateCommand(ctx,"modulecrash.xadd", cmd_crash,"write deny-oom random fast",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    cmd = RedisModule_GetCommand(ctx,"modulecrash.xadd");
+    if (RedisModule_SetCommandInfo(cmd, &info) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    /* Create a subcommand: modulecrash.parent sub
+     * It will crash in the command handler to verify we print subcommand name
+     * when hide-user-data-from-log config is enabled */
+    RedisModuleCommandInfo subcommand_info = {
+            .version = REDISMODULE_COMMAND_INFO_VERSION,
+            .arity = -5,
+            .key_specs = (RedisModuleCommandKeySpec[]){
+                    {
+                            .flags = REDISMODULE_CMD_KEY_RW | REDISMODULE_CMD_KEY_UPDATE,
+                            .begin_search_type = REDISMODULE_KSPEC_BS_INDEX,
+                            .bs.index.pos = 1,
+                            .find_keys_type = REDISMODULE_KSPEC_FK_RANGE,
+                            .fk.range = {0,1,0}
+                    },
+                    {0}
+            },
+            .args = (RedisModuleCommandArg[]){
+                    {
+                            .name = "key",
+                            .type = REDISMODULE_ARG_TYPE_KEY,
+                            .key_spec_index = 0
+                    },
+                    {
+                            .name = "token",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                            .token = "TOKEN",
+                            .flags = REDISMODULE_CMD_ARG_OPTIONAL
+                    },
+                    {
+                            .name = "data",
+                            .type = REDISMODULE_ARG_TYPE_BLOCK,
+                            .subargs = (RedisModuleCommandArg[]){
+                                    {
+                                            .name = "field",
+                                            .type = REDISMODULE_ARG_TYPE_STRING,
+                                    },
+                                    {
+                                            .name = "value",
+                                            .type = REDISMODULE_ARG_TYPE_STRING,
+                                    },
+                                    {0}
+                            }
+                    },
+                    {0}
+            }
+    };
+
+    if (RedisModule_CreateCommand(ctx,"modulecrash.parent",NULL,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    RedisModuleCommand *parent = RedisModule_GetCommand(ctx,"modulecrash.parent");
+
+    if (RedisModule_CreateSubcommand(parent,"subcmd",cmd_crash,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    cmd = RedisModule_GetCommand(ctx,"modulecrash.parent|subcmd");
+    if (RedisModule_SetCommandInfo(cmd, &subcommand_info) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    /* Create modulecrash.zunion command which is similar to zunion command.
+    * It will crash in the command handler to verify we print command tokens
+    * when hide-user-data-from-log config is enabled */
+    RedisModuleCommandInfo zunioninfo = {
+            .version = REDISMODULE_COMMAND_INFO_VERSION,
+            .arity = -5,
+            .key_specs = (RedisModuleCommandKeySpec[]){
+                    {
+                            .flags = REDISMODULE_CMD_KEY_RO,
+                            .begin_search_type = REDISMODULE_KSPEC_BS_INDEX,
+                            .bs.index.pos = 1,
+                            .find_keys_type = REDISMODULE_KSPEC_FK_KEYNUM,
+                            .fk.keynum = {0,1,1}
+                    },
+                    {0}
+            },
+            .args = (RedisModuleCommandArg[]){
+                    {
+                            .name = "numkeys",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                    },
+                    {
+                            .name = "key",
+                            .type = REDISMODULE_ARG_TYPE_KEY,
+                            .key_spec_index = 0,
+                            .flags = REDISMODULE_CMD_ARG_MULTIPLE
+                    },
+                    {
+                            .name = "weights",
+                            .type = REDISMODULE_ARG_TYPE_INTEGER,
+                            .token = "WEIGHTS",
+                            .flags = REDISMODULE_CMD_ARG_OPTIONAL | REDISMODULE_CMD_ARG_MULTIPLE
+                    },
+                    {
+                            .name = "aggregate",
+                            .type = REDISMODULE_ARG_TYPE_ONEOF,
+                            .token = "AGGREGATE",
+                            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                            .subargs = (RedisModuleCommandArg[]){
+                                    {
+                                            .name = "sum",
+                                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                            .token = "sum"
+                                    },
+                                    {
+                                            .name = "min",
+                                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                            .token = "min"
+                                    },
+                                    {
+                                            .name = "max",
+                                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                            .token = "max"
+                                    },
+                                    {0}
+                            }
+                    },
+                    {
+                            .name = "withscores",
+                            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                            .token = "WITHSCORES",
+                            .flags = REDISMODULE_CMD_ARG_OPTIONAL
+                    },
+                    {0}
+            }
+    };
+
+    if (RedisModule_CreateCommand(ctx,"modulecrash.zunion", cmd_crash,"readonly",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    cmd = RedisModule_GetCommand(ctx,"modulecrash.zunion");
+    if (RedisModule_SetCommandInfo(cmd, &zunioninfo) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
 
     return REDISMODULE_OK;
 }

--- a/tests/unit/moduleapi/crash.tcl
+++ b/tests/unit/moduleapi/crash.tcl
@@ -64,7 +64,7 @@ if {!$::valgrind} {
     start_server {tags {"modules"}} {
         r module load $testmodule
 
-        test {Test command tokens are printed when hide-user-data-from-log is enabled} {
+        test {Test command tokens are printed when hide-user-data-from-log is enabled (xadd)} {
             r config set hide-user-data-from-log yes
             catch {r 0 modulecrash.xadd key NOMKSTREAM MAXLEN ~ 1000 * a b}
 
@@ -83,23 +83,7 @@ if {!$::valgrind} {
     start_server {tags {"modules"}} {
         r module load $testmodule
 
-        test {Test subcommand name is printed when hide-user-data-from-log is enabled} {
-            r config set hide-user-data-from-log yes
-            catch {r 0 modulecrash.parent subcmd key TOKEN a b}
-
-            wait_for_log_messages 0 {"*argv*0*: *modulecrash.parent*"} 0 10 1000
-            wait_for_log_messages 0 {"*argv*1*: *subcmd*"} 0 10 1000
-            wait_for_log_messages 0 {"*argv*2*: *redacted*"} 0 10 1000
-            wait_for_log_messages 0 {"*argv*3*: *TOKEN*"} 0 10 1000
-            wait_for_log_messages 0 {"*argv*4*: *redacted*"} 0 10 1000
-            wait_for_log_messages 0 {"*argv*5*: *redacted*"} 0 10 1000
-        }
-    }
-
-    start_server {tags {"modules"}} {
-        r module load $testmodule
-
-        test {Test command tokens are printed when hide-user-data-from-log is enabled with zunion command} {
+        test {Test command tokens are printed when hide-user-data-from-log is enabled (zunion)} {
             r config set hide-user-data-from-log yes
             catch {r 0 modulecrash.zunion 2 zset1 zset2 WEIGHTS 1 2 WITHSCORES somedata}
 
@@ -115,6 +99,22 @@ if {!$::valgrind} {
             # We don't expect arguments after WITHSCORE but just in case there
             # is we rather not print it
             wait_for_log_messages 0 {"*argv*8*: *redacted*"} 0 10 1000
+        }
+    }
+
+    start_server {tags {"modules"}} {
+        r module load $testmodule
+
+        test {Test subcommand name is printed when hide-user-data-from-log is enabled} {
+            r config set hide-user-data-from-log yes
+            catch {r 0 modulecrash.parent subcmd key TOKEN a b}
+
+            wait_for_log_messages 0 {"*argv*0*: *modulecrash.parent*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*1*: *subcmd*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*2*: *redacted*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*3*: *TOKEN*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*4*: *redacted*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*5*: *redacted*"} 0 10 1000
         }
     }
 }

--- a/tests/unit/moduleapi/crash.tcl
+++ b/tests/unit/moduleapi/crash.tcl
@@ -8,7 +8,7 @@ if {!$::valgrind} {
     start_server {tags {"modules"}} {
         r module load $testmodule assert
         test {Test module crash when info crashes with an assertion } {
-            catch {r 0 info infocrash}
+            catch {r 0 info modulecrash}
             set res [wait_for_log_messages 0 {"*=== REDIS BUG REPORT START: Cut & paste starting from here ===*"} 0 10 1000]
             set loglines [lindex $res 1]
 
@@ -34,7 +34,7 @@ if {!$::valgrind} {
     start_server {tags {"modules"}} {
         r module load $testmodule segfault
         test {Test module crash when info crashes with a segfault} {
-            catch {r 0 info infocrash}
+            catch {r 0 info modulecrash}
             set res [wait_for_log_messages 0 {"*=== REDIS BUG REPORT START: Cut & paste starting from here ===*"} 0 10 1000]
             set loglines [lindex $res 1]
 
@@ -58,6 +58,63 @@ if {!$::valgrind} {
                 assert_equal 3 [count_log_message 0 "modulesCollectInfo"]
             }
             assert_equal 1 [count_log_message 0 "=== REDIS BUG REPORT START: Cut & paste starting from here ==="]
+        }
+    }
+
+    start_server {tags {"modules"}} {
+        r module load $testmodule
+
+        test {Test command tokens are printed when hide-user-data-from-log is enabled} {
+            r config set hide-user-data-from-log yes
+            catch {r 0 modulecrash.xadd key NOMKSTREAM MAXLEN ~ 1000 * a b}
+
+            wait_for_log_messages 0 {"*argv*0*: *modulecrash.xadd*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*1*: *redacted*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*2*: *NOMKSTREAM*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*3*: *MAXLEN*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*4*: *~*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*5*: *redacted*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*6*: *\**"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*7*: *redacted*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*8*: *redacted*"} 0 10 1000
+        }
+    }
+
+    start_server {tags {"modules"}} {
+        r module load $testmodule
+
+        test {Test subcommand name is printed when hide-user-data-from-log is enabled} {
+            r config set hide-user-data-from-log yes
+            catch {r 0 modulecrash.parent subcmd key TOKEN a b}
+
+            wait_for_log_messages 0 {"*argv*0*: *modulecrash.parent*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*1*: *subcmd*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*2*: *redacted*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*3*: *TOKEN*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*4*: *redacted*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*5*: *redacted*"} 0 10 1000
+        }
+    }
+
+    start_server {tags {"modules"}} {
+        r module load $testmodule
+
+        test {Test command tokens are printed when hide-user-data-from-log is enabled with zunion command} {
+            r config set hide-user-data-from-log yes
+            catch {r 0 modulecrash.zunion 2 zset1 zset2 WEIGHTS 1 2 WITHSCORES somedata}
+
+            wait_for_log_messages 0 {"*argv*0*: *modulecrash.zunion*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*1*: *redacted*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*2*: *redacted*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*3*: *redacted*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*4*: *WEIGHTS*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*5*: *redacted*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*6*: *redacted*"} 0 10 1000
+            wait_for_log_messages 0 {"*argv*7*: *WITHSCORES*"} 0 10 1000
+
+            # We don't expect arguments after WITHSCORE but just in case there
+            # is we rather not print it
+            wait_for_log_messages 0 {"*argv*8*: *redacted*"} 0 10 1000
         }
     }
 }


### PR DESCRIPTION
If hide-user-data-from-log config is enabled, we don't print client argv in the crashlog to avoid leaking user info.
Though, debugging a crash becomes harder as we don't see the command arguments causing the crash.

With this PR, adding a parser to run on a crash to detect command tokens and print them to the log.
Parser is based on json schema parser that we have in redis-cli ([link](https://github.com/redis/redis/blob/4b29be3f36b05c4e2479a80712f2c73f216ae031/src/redis-cli.c#L1460)). There are a few improvements on top of it. 
Although, it is hard to make it %100 accurate, it is able to parse most of the existing commands. 
It can be improved over time. 

e.g. 
`SET key value GET EX 10`   ---> we'll print   `SET * * GET EX *` in the log. 

TODO: 
- Take new improvements back to redis-cli or find a way to share same parser code. 