### PR TITLE
Fix memory leak on rdbload error

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2332,6 +2332,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error)
                 rdbReportCorruptRDB("invalid expireAt time: %llu",
                                     (unsigned long long) expireAt);
                 decrRefCount(o);
+                if (dupSearchDict != NULL) dictRelease(dupSearchDict);
                 return NULL;
             }
 


### PR DESCRIPTION
On RDB load error, if an invalid `expireAt` value is read, `dupSearchDict` is not released.