### PR TITLE
Refactor: delete parentheses based on operator priority

### DIFF
--- a/deps/lua/src/lobject.c
+++ b/deps/lua/src/lobject.c
@@ -45,7 +45,7 @@ int luaO_int2fb (unsigned int x) {
 
 /* converts back */
 int luaO_fb2int (int x) {
-  int e = (x >> 3) & 31;
+  int e = x >> 3 & 31;
   if (e == 0) return x;
   else return ((x & 7)+8) << (e - 1);
 }

--- a/deps/lua/src/lobject.c
+++ b/deps/lua/src/lobject.c
@@ -35,11 +35,11 @@ const TValue luaO_nilobject_ = {{NULL}, LUA_TNIL};
 int luaO_int2fb (unsigned int x) {
   int e = 0;  /* expoent */
   while (x >= 16) {
-    x = (x+1) >> 1;
+    x = x+1 >> 1;
     e++;
   }
   if (x < 8) return x;
-  else return ((e+1) << 3) | (cast_int(x) - 8);
+  else return (e+1 << 3) | (cast_int(x) - 8);
 }
 
 

--- a/src/intset.c
+++ b/src/intset.c
@@ -135,7 +135,7 @@ static uint8_t intsetSearch(intset *is, int64_t value, uint32_t *pos) {
     }
 
     while(max >= min) {
-        mid = ((unsigned int)min + (unsigned int)max) >> 1;
+        mid = (unsigned int)min + (unsigned int)max >> 1;
         cur = _intsetGet(is,mid);
         if (value > cur) {
             min = mid+1;


### PR DESCRIPTION
This PR introduces code readability improvements.

- plus operator has higher priority than the bit shift operator, parentheses must be removed.
- bitwise shift operator has a higher precedence than the AND operator, so the parentheses can be removed.

Changing this will improve code readability.






