### PR TITLE
SUNSUBSCRIBE on replica should not return MOVED to master

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1131,8 +1131,9 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
         margv = ms->commands[i].argv;
 
         /* Only valid for sharded pubsub as regular pubsub can operate on any node and bypasses this layer. */
-        if (!pubsubshard_included &&
-            doesCommandHaveChannelsWithFlags(mcmd, CMD_CHANNEL_PUBLISH | CMD_CHANNEL_SUBSCRIBE))
+        if (!pubsubshard_included && (mcmd->proc == ssubscribeCommand ||
+                                      mcmd->proc == sunsubscribeCommand ||
+                                      mcmd->proc == spublishCommand))
         {
             pubsubshard_included = 1;
         }

--- a/tests/unit/cluster/sharded-pubsub.tcl
+++ b/tests/unit/cluster/sharded-pubsub.tcl
@@ -63,4 +63,12 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         catch {[$replica EXEC]} err
         assert_match {EXECABORT*} $err
     }
+
+    test "Sharded pubsub sunsubscribe behavior on replica" {
+        $replica SUNSUBSCRIBE foo
+
+        $replica MULTI
+        $replica SUNSUBSCRIBE foo
+        $replica EXEC
+    }
 }


### PR DESCRIPTION
The previous PR [#13276](https://github.com/redis/redis/pull/13276) fixed the behavior of `spublish` when it is executed on the replica, the performance should be the same regardless of whether it is in a mutli context. However, this modification will cause the `sunsubscribe` command to always return MOVED on the replica. Since we allow `ssubscribe` on the replica, `sunsubscribe` should also be allowed.