### PR TITLE
fix comment in fucntion 'clusterSendPing'

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3661,8 +3661,8 @@ void clusterSendPing(clusterLink *link, int type) {
 
         /* In the gossip section don't include:
          * 1) Nodes in HANDSHAKE state.
-         * 3) Nodes with the NOADDR flag set.
-         * 4) Disconnected nodes if they don't have configured slots.
+         * 2) Nodes with the NOADDR flag set.
+         * 3) Disconnected nodes if they don't have configured slots.
          */
         if (this->flags & (CLUSTER_NODE_HANDSHAKE|CLUSTER_NODE_NOADDR) ||
             (this->link == NULL && this->numslots == 0))


### PR DESCRIPTION
This PR corrects the numbering in a comment within the gossip section logic. The original comment had incorrect numbering (skipping 2), which may cause confusion for developers reading the code. The updated comment now follows the correct sequential numbering for clarity.

https://github.com/redis/redis/blob/9906daf5c9fdb836a5b3f04829c75701a4e90eb4/src/cluster_legacy.c#L3662-L3666