### PR TITLE
Optimize addReplyBulk on sds/int encoded strings: 2.2% to 4% reduction of CPU Time on GET high pipeline use-cases

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1078,8 +1078,23 @@ void addReplyBulkLen(client *c, robj *obj) {
 
 /* Add a Redis Object as a bulk reply */
 void addReplyBulk(client *c, robj *obj) {
-    addReplyBulkLen(c,obj);
-    addReply(c,obj);
+    if (prepareClientToWrite(c) != C_OK) return;
+
+    if (sdsEncodedObject(obj)) {
+        const size_t len = sdslen(obj->ptr);
+        _addReplyLongLongBulk(c, len);
+        _addReplyToBufferOrList(c,obj->ptr,len);
+    } else if (obj->encoding == OBJ_ENCODING_INT) {
+        /* For integer encoded strings we just convert it into a string
+         * using our optimized function, and attach the resulting string
+         * to the output buffer. */
+        char buf[32];
+        size_t len = ll2string(buf,sizeof(buf),(long)obj->ptr);
+        _addReplyLongLongBulk(c, len);
+        _addReplyToBufferOrList(c,buf,len);
+    } else {
+        serverPanic("Wrong obj->encoding in addReply()");
+    }
     addReplyProto(c,"\r\n",2);
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1084,18 +1084,20 @@ void addReplyBulk(client *c, robj *obj) {
         const size_t len = sdslen(obj->ptr);
         _addReplyLongLongBulk(c, len);
         _addReplyToBufferOrList(c,obj->ptr,len);
+        _addReplyToBufferOrList(c,"\r\n",2);
     } else if (obj->encoding == OBJ_ENCODING_INT) {
         /* For integer encoded strings we just convert it into a string
          * using our optimized function, and attach the resulting string
          * to the output buffer. */
-        char buf[32];
+        char buf[34];
         size_t len = ll2string(buf,sizeof(buf),(long)obj->ptr);
+        buf[len+1] = '\r';
+        buf[len+2] = '\n';
         _addReplyLongLongBulk(c, len);
-        _addReplyToBufferOrList(c,buf,len);
+        _addReplyToBufferOrList(c,buf,len+2);
     } else {
         serverPanic("Wrong obj->encoding in addReply()");
     }
-    addReplyProto(c,"\r\n",2);
 }
 
 /* Add a C buffer as bulk reply */


### PR DESCRIPTION
### Summary 


By profing 1KiB 100% GET's use-case, on high pipeline use-cases, we can see that addReplyBulk and it's inner calls takes 8.30% of the CPU cycles. This PR reduces from 2.2% to 4% the CPU time spent on addReplyBulk. Specifically for GET use-cases, we saw an improvement from 2.7% to 9.1% on the achievable ops/sec 

### Improvement 
By reducing the duplicate work we can improve by around 2.7% on sds encoded strings, and around 9% on int encoded strings. This PR does the following:
- Avoid duplicate sdslen on addReplyBulk() for sds enconded objects
- Avoid duplicate sdigits10() call on int incoded objects on addReplyBulk()
- avoid final "\r\n" addReplyProto() in the OBJ_ENCODING_INT type on addReplyBulk

Altogether this improvements results in the following improvement on the achievable ops/sec :

Encoding | unstable (commit 9906daf5c9fdb836a5b3f04829c75701a4e90eb4) | this PR | % improvement
-- | -- | -- | --
1KiB Values string SDS encoded | 1478081.88 | 1517635.38 | 2.7%
Values string "1" OBJ_ENCODING_INT | 1521139.36 | 1658876.59 | 9.1%

### CPU Time: Total of addReplyBulk 

Encoding | unstable (commit 9906daf5c9fdb836a5b3f04829c75701a4e90eb4) | this PR | reduction of CPU Time: Total
-- | -- | -- | --
1KiB Values string SDS encoded | 8.30% | 6.10% | 2.2%
Values string "1" OBJ_ENCODING_INT | 7.20% | 3.20% | 4.0%




### To reproduce

Run redis with unix socket enabled
```
taskset -c 0 /root/redis/src/redis-server  --unixsocket /tmp/1.socket --save '' --enable-debug-command local
```

#### 1KiB Values string SDS encoded

Load data
```
taskset -c 2-5 memtier_benchmark  --ratio 1:0 -n allkeys --key-pattern P:P --key-maximum 1000000  --hide-histogram  --pipeline 10 -S /tmp/1.socket

```

Benchmark
```
taskset -c 2-6 memtier_benchmark --ratio 0:1 -c 1 -t 5 --test-time 60 --hide-histogram -d 1000 --pipeline 500  -S /tmp/1.socket --key-maximum 1000000 --json-out-file results.json
```

#### Values string "1" OBJ_ENCODING_INT 


Load data
```
$ taskset -c 2-5 memtier_benchmark  --command "SET __key__ 1" -n allkeys --command-key-pattern P --key-maximum 1000000  --hide-histogram -c 1 -t 1  --pipeline 100 -S /tmp/1.socket

# confirm we have the expected reply and format 
$ redis-cli get memtier-1
"1"

$ redis-cli debug object memtier-1
Value at:0x7f14cec57570 refcount:2147483647 encoding:int serializedlength:2 lru:2861503 lru_seconds_idle:8

```

Benchmark
```
taskset -c 2-6 memtier_benchmark --ratio 0:1 -c 1 -t 5 --test-time 60 --hide-histogram -d 1000 --pipeline 500  -S /tmp/1.socket --key-maximum 1000000 --json-out-file results.json
```

