### PR TITLE
Improve listpack Handling and Decoding Efficiency: 16.3% improvement on LRANGE command

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -115,7 +115,7 @@
     assert((p) >= (lp)+LP_HDR_SIZE && (p)+(len) < (lp)+lpGetTotalBytes((lp))); \
 } while (0)
 
-static inline void lpAssertValidEntry(const unsigned char* lp, const size_t lpbytes, unsigned char *p);
+static inline void lpAssertValidEntry(unsigned char* lp, size_t lpbytes, unsigned char *p);
 
 /* Don't let listpacks grow over 1GB in any case, don't wanna risk overflow in
  * Total Bytes header field */
@@ -459,7 +459,7 @@ unsigned char *lpSkip(unsigned char *p) {
 /* If 'p' points to an element of the listpack, calling lpNext() will return
  * the pointer to the next element (the one on the right), or NULL if 'p'
  * already pointed to the last element of the listpack. */
-unsigned char *lpNextWithBytes(const unsigned char *lp, const size_t lpbytes, unsigned char *p) {
+unsigned char *lpNextWithBytes(unsigned char *lp, const size_t lpbytes, unsigned char *p) {
     assert(p);
     p = lpSkip(p);
     if (p[0] == LP_EOF) return NULL;
@@ -1587,7 +1587,7 @@ unsigned char *lpValidateFirst(unsigned char *lp) {
  * The input argument 'pp' is a reference to the current record and is advanced on exit.
  *  the data pointed to by 'lp' will not be modified by the function.
  * Returns 1 if valid, 0 if invalid. */
-int lpValidateNext(const unsigned char *lp, unsigned char **pp, const size_t lpbytes) {
+int lpValidateNext(unsigned char *lp, unsigned char **pp, size_t lpbytes) {
 #define OUT_OF_RANGE(p) ( \
         (p) < lp + LP_HDR_SIZE || \
         (p) > lp + lpbytes - 1)
@@ -1636,7 +1636,7 @@ int lpValidateNext(const unsigned char *lp, unsigned char **pp, const size_t lpb
 }
 
 /* Validate that the entry doesn't reach outside the listpack allocation. */
-static inline void lpAssertValidEntry(const unsigned char* lp, const size_t lpbytes, unsigned char *p) {
+static inline void lpAssertValidEntry(unsigned char* lp, size_t lpbytes, unsigned char *p) {
     assert(lpValidateNext(lp, &p, lpbytes));
 }
 

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -676,8 +676,7 @@ static inline unsigned char *lpGetWithSize(unsigned char *p, int64_t *count, uns
 /* Return the listpack element pointed by 'p'.
  *
  * The function has the same behaviour as lpGetWithSize when 'entry_size' is NULL,
- * but avoids a lot of unecesarry branching performance penalties.
- * */
+ * but avoids a lot of unecesarry branching performance penalties. */
 static inline unsigned char *lpGetWithBuf(unsigned char *p, int64_t *count, unsigned char *intbuf) {
     int64_t val;
     uint64_t uval, negstart, negmax;

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -373,15 +373,14 @@ static inline unsigned long lpEncodeBacklen(unsigned char *buf, uint64_t l) {
  * 5 bytes are used), UINT64_MAX is returned to report the problem. */
 static inline uint64_t lpDecodeBacklen(unsigned char *p) {
     uint64_t val = 0;
-    uint64_t shift = 0;
-    do {
-        val |= (uint64_t)(p[0] & 127) << shift;
-        if (!(p[0] & 128)) break;
-        shift += 7;
-        p--;
-        if (shift > 28) return UINT64_MAX;
-    } while(1);
-    return val;
+    for (uint64_t shift = 0; shift <= 28; shift += 7) {
+        val |= (uint64_t)(*p & 127) << shift;
+        if (!(*p & 128)) {
+            return val;
+        }
+        p--;  // Move to the previous byte
+    }
+    return UINT64_MAX;  // Invalid encoding if we exceed 5 bytes
 }
 
 /* Encode the string element pointed by 's' of size 'len' in the target

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -373,14 +373,15 @@ static inline unsigned long lpEncodeBacklen(unsigned char *buf, uint64_t l) {
  * 5 bytes are used), UINT64_MAX is returned to report the problem. */
 static inline uint64_t lpDecodeBacklen(unsigned char *p) {
     uint64_t val = 0;
-    for (uint64_t shift = 0; shift <= 28; shift += 7) {
-        val |= (uint64_t)(*p & 127) << shift;
-        if (!(*p & 128)) {
-            return val;
-        }
-        p--;  // Move to the previous byte
-    }
-    return UINT64_MAX;  // Invalid encoding if we exceed 5 bytes
+    uint64_t shift = 0;
+    do {
+        val |= (uint64_t)(p[0] & 127) << shift;
+        if (!(p[0] & 128)) break;
+        shift += 7;
+        p--;
+        if (shift > 28) return UINT64_MAX;
+    } while(1);
+    return val;
 }
 
 /* Encode the string element pointed by 's' of size 'len' in the target

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -431,17 +431,17 @@ static inline uint32_t lpCurrentEncodedSizeUnsafe(unsigned char *p) {
  * This includes just the encoding byte, and the bytes needed to encode the length
  * of the element (excluding the element data itself)
  * If the element encoding is wrong then 0 is returned. */
-static inline uint32_t lpCurrentEncodedSizeBytes(unsigned char *p) {
-    if (LP_ENCODING_IS_7BIT_UINT(p[0])) return 1;
-    if (LP_ENCODING_IS_6BIT_STR(p[0])) return 1;
-    if (LP_ENCODING_IS_13BIT_INT(p[0])) return 1;
-    if (LP_ENCODING_IS_16BIT_INT(p[0])) return 1;
-    if (LP_ENCODING_IS_24BIT_INT(p[0])) return 1;
-    if (LP_ENCODING_IS_32BIT_INT(p[0])) return 1;
-    if (LP_ENCODING_IS_64BIT_INT(p[0])) return 1;
-    if (LP_ENCODING_IS_12BIT_STR(p[0])) return 2;
-    if (LP_ENCODING_IS_32BIT_STR(p[0])) return 5;
-    if (p[0] == LP_EOF) return 1;
+static inline uint32_t lpCurrentEncodedSizeBytes(const unsigned char encoding) {
+    if (LP_ENCODING_IS_7BIT_UINT(encoding)) return 1;
+    if (LP_ENCODING_IS_6BIT_STR(encoding)) return 1;
+    if (LP_ENCODING_IS_13BIT_INT(encoding)) return 1;
+    if (LP_ENCODING_IS_16BIT_INT(encoding)) return 1;
+    if (LP_ENCODING_IS_24BIT_INT(encoding)) return 1;
+    if (LP_ENCODING_IS_32BIT_INT(encoding)) return 1;
+    if (LP_ENCODING_IS_64BIT_INT(encoding)) return 1;
+    if (LP_ENCODING_IS_12BIT_STR(encoding)) return 2;
+    if (LP_ENCODING_IS_32BIT_STR(encoding)) return 5;
+    if (encoding == LP_EOF) return 1;
     return 0;
 }
 
@@ -1506,7 +1506,7 @@ int lpValidateNext(unsigned char *lp, unsigned char **pp, size_t lpbytes) {
     }
 
     /* check that we can read the encoded size */
-    uint32_t lenbytes = lpCurrentEncodedSizeBytes(p);
+    uint32_t lenbytes = lpCurrentEncodedSizeBytes(p[0]);
     if (!lenbytes)
         return 0;
 
@@ -1859,7 +1859,7 @@ void lpRepr(unsigned char *lp) {
         
     p = lpFirst(lp);
     while(p) {
-        uint32_t encoded_size_bytes = lpCurrentEncodedSizeBytes(p);
+        uint32_t encoded_size_bytes = lpCurrentEncodedSizeBytes(p[0]);
         uint32_t encoded_size = lpCurrentEncodedSizeUnsafe(p);
         unsigned long back_len = lpEncodeBacklen(NULL, encoded_size);
         printf(

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -683,24 +683,13 @@ static inline unsigned char *lpGetWithBuf(unsigned char *p, int64_t *count, unsi
     const unsigned char encoding = p[0];
 
     assert(p); /* assertion for valgrind (avoid NPD) */
-    /* string encoding */
-    if (LP_ENCODING_IS_6BIT_STR(encoding)) {
-        *count = LP_ENCODING_6BIT_STR_LEN(p);
-        return p+1;
-    }
-    if (LP_ENCODING_IS_12BIT_STR(encoding)) {
-        *count = LP_ENCODING_12BIT_STR_LEN(p);
-        return p+2;
-    }
-    if (LP_ENCODING_IS_32BIT_STR(encoding)) {
-        *count = LP_ENCODING_32BIT_STR_LEN(p);
-        return p+5;
-    }
-    /* int encoding */
     if (LP_ENCODING_IS_7BIT_UINT(encoding)) {
         negstart = UINT64_MAX; /* 7 bit ints are always positive. */
         negmax = 0;
         uval = encoding & 0x7f;
+    } else if (LP_ENCODING_IS_6BIT_STR(encoding)) {
+        *count = LP_ENCODING_6BIT_STR_LEN(p);
+        return p+1;
     } else if (LP_ENCODING_IS_13BIT_INT(encoding)) {
         uval = ((encoding&0x1f)<<8) | p[1];
         negstart = (uint64_t)1<<12;
@@ -734,6 +723,13 @@ static inline unsigned char *lpGetWithBuf(unsigned char *p, int64_t *count, unsi
                (uint64_t)p[8]<<56;
         negstart = (uint64_t)1<<63;
         negmax = UINT64_MAX;
+    } else if (LP_ENCODING_IS_12BIT_STR(encoding)) {
+        *count = LP_ENCODING_12BIT_STR_LEN(p);
+        return p+2;
+    }
+    if (LP_ENCODING_IS_32BIT_STR(encoding)) {
+        *count = LP_ENCODING_32BIT_STR_LEN(p);
+        return p+5;
     } else {
         uval = 12345678900000000ULL + encoding;
         negstart = UINT64_MAX;

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -456,9 +456,7 @@ unsigned char *lpSkip(unsigned char *p) {
     return p;
 }
 
-/* If 'p' points to an element of the listpack, calling lpNext() will return
- * the pointer to the next element (the one on the right), or NULL if 'p'
- * already pointed to the last element of the listpack. */
+/* This is similar to lpNext() but avoids the inner call to lpBytes when you already know the listpack size. */
 unsigned char *lpNextWithBytes(unsigned char *lp, const size_t lpbytes, unsigned char *p) {
     assert(p);
     p = lpSkip(p);
@@ -658,6 +656,11 @@ static inline unsigned char *lpGetWithSize(unsigned char *p, int64_t *count, uns
     }
 }
 
+/* Return the listpack element pointed by 'p'.
+ *
+ * The function has the same behaviour as lpGetWithSize when 'entry_size' is NULL,
+ * but avoids a lot of unecesarry branching performance penalties.
+ * */
 static inline unsigned char *lpGetWithBuf(unsigned char *p, int64_t *count, unsigned char *intbuf) {
     int64_t val;
     uint64_t uval, negstart, negmax;

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -683,13 +683,24 @@ static inline unsigned char *lpGetWithBuf(unsigned char *p, int64_t *count, unsi
     const unsigned char encoding = p[0];
 
     assert(p); /* assertion for valgrind (avoid NPD) */
+    /* string encoding */
+    if (LP_ENCODING_IS_6BIT_STR(encoding)) {
+        *count = LP_ENCODING_6BIT_STR_LEN(p);
+        return p+1;
+    }
+    if (LP_ENCODING_IS_12BIT_STR(encoding)) {
+        *count = LP_ENCODING_12BIT_STR_LEN(p);
+        return p+2;
+    }
+    if (LP_ENCODING_IS_32BIT_STR(encoding)) {
+        *count = LP_ENCODING_32BIT_STR_LEN(p);
+        return p+5;
+    }
+    /* int encoding */
     if (LP_ENCODING_IS_7BIT_UINT(encoding)) {
         negstart = UINT64_MAX; /* 7 bit ints are always positive. */
         negmax = 0;
         uval = encoding & 0x7f;
-    } else if (LP_ENCODING_IS_6BIT_STR(encoding)) {
-        *count = LP_ENCODING_6BIT_STR_LEN(p);
-        return p+1;
     } else if (LP_ENCODING_IS_13BIT_INT(encoding)) {
         uval = ((encoding&0x1f)<<8) | p[1];
         negstart = (uint64_t)1<<12;
@@ -723,13 +734,6 @@ static inline unsigned char *lpGetWithBuf(unsigned char *p, int64_t *count, unsi
                (uint64_t)p[8]<<56;
         negstart = (uint64_t)1<<63;
         negmax = UINT64_MAX;
-    } else if (LP_ENCODING_IS_12BIT_STR(encoding)) {
-        *count = LP_ENCODING_12BIT_STR_LEN(p);
-        return p+2;
-    }
-    if (LP_ENCODING_IS_32BIT_STR(encoding)) {
-        *count = LP_ENCODING_32BIT_STR_LEN(p);
-        return p+5;
     } else {
         uval = 12345678900000000ULL + encoding;
         negstart = UINT64_MAX;

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -457,7 +457,7 @@ unsigned char *lpSkip(unsigned char *p) {
 }
 
 /* This is similar to lpNext() but avoids the inner call to lpBytes when you already know the listpack size. */
-unsigned char *lpNextWithBytes(unsigned char *lp, const size_t lpbytes, unsigned char *p) {
+unsigned char *lpNextWithBytes(unsigned char *lp, unsigned char *p, const size_t lpbytes) {
     assert(p);
     p = lpSkip(p);
     if (p[0] == LP_EOF) return NULL;

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -115,7 +115,7 @@
     assert((p) >= (lp)+LP_HDR_SIZE && (p)+(len) < (lp)+lpGetTotalBytes((lp))); \
 } while (0)
 
-static inline void lpAssertValidEntry(unsigned char* lp, size_t lpbytes, unsigned char *p);
+static inline void lpAssertValidEntry(const unsigned char* lp, const size_t lpbytes, unsigned char *p);
 
 /* Don't let listpacks grow over 1GB in any case, don't wanna risk overflow in
  * Total Bytes header field */
@@ -459,6 +459,17 @@ unsigned char *lpSkip(unsigned char *p) {
 /* If 'p' points to an element of the listpack, calling lpNext() will return
  * the pointer to the next element (the one on the right), or NULL if 'p'
  * already pointed to the last element of the listpack. */
+unsigned char *lpNextWithBytes(const unsigned char *lp, const size_t lpbytes, unsigned char *p) {
+    assert(p);
+    p = lpSkip(p);
+    if (p[0] == LP_EOF) return NULL;
+    lpAssertValidEntry(lp, lpbytes, p);
+    return p;
+}
+
+/* If 'p' points to an element of the listpack, calling lpNext() will return
+ * the pointer to the next element (the one on the right), or NULL if 'p'
+ * already pointed to the last element of the listpack. */
 unsigned char *lpNext(unsigned char *lp, unsigned char *p) {
     assert(p);
     p = lpSkip(p);
@@ -647,8 +658,95 @@ static inline unsigned char *lpGetWithSize(unsigned char *p, int64_t *count, uns
     }
 }
 
+static inline unsigned char *lpGetWithBuf(unsigned char *p, int64_t *count, unsigned char *intbuf) {
+    int64_t val;
+    uint64_t uval, negstart, negmax;
+    const unsigned char encoding = p[0];
+
+    assert(p); /* assertion for valgrind (avoid NPD) */
+    /* string encoding */
+    if (LP_ENCODING_IS_6BIT_STR(encoding)) {
+        *count = LP_ENCODING_6BIT_STR_LEN(p);
+        return p+1;
+    }
+    if (LP_ENCODING_IS_12BIT_STR(encoding)) {
+        *count = LP_ENCODING_12BIT_STR_LEN(p);
+        return p+2;
+    }
+    if (LP_ENCODING_IS_32BIT_STR(encoding)) {
+        *count = LP_ENCODING_32BIT_STR_LEN(p);
+        return p+5;
+    }
+    /* int encoding */
+    if (LP_ENCODING_IS_7BIT_UINT(encoding)) {
+        negstart = UINT64_MAX; /* 7 bit ints are always positive. */
+        negmax = 0;
+        uval = encoding & 0x7f;
+    } else if (LP_ENCODING_IS_13BIT_INT(encoding)) {
+        uval = ((encoding&0x1f)<<8) | p[1];
+        negstart = (uint64_t)1<<12;
+        negmax = 8191;
+    } else if (LP_ENCODING_IS_16BIT_INT(encoding)) {
+        uval = (uint64_t)p[1] |
+               (uint64_t)p[2]<<8;
+        negstart = (uint64_t)1<<15;
+        negmax = UINT16_MAX;
+    } else if (LP_ENCODING_IS_24BIT_INT(encoding)) {
+        uval = (uint64_t)p[1] |
+               (uint64_t)p[2]<<8 |
+               (uint64_t)p[3]<<16;
+        negstart = (uint64_t)1<<23;
+        negmax = UINT32_MAX>>8;
+    } else if (LP_ENCODING_IS_32BIT_INT(encoding)) {
+        uval = (uint64_t)p[1] |
+               (uint64_t)p[2]<<8 |
+               (uint64_t)p[3]<<16 |
+               (uint64_t)p[4]<<24;
+        negstart = (uint64_t)1<<31;
+        negmax = UINT32_MAX;
+    } else if (LP_ENCODING_IS_64BIT_INT(encoding)) {
+        uval = (uint64_t)p[1] |
+               (uint64_t)p[2]<<8 |
+               (uint64_t)p[3]<<16 |
+               (uint64_t)p[4]<<24 |
+               (uint64_t)p[5]<<32 |
+               (uint64_t)p[6]<<40 |
+               (uint64_t)p[7]<<48 |
+               (uint64_t)p[8]<<56;
+        negstart = (uint64_t)1<<63;
+        negmax = UINT64_MAX;
+    } else {
+        uval = 12345678900000000ULL + encoding;
+        negstart = UINT64_MAX;
+        negmax = 0;
+    }
+
+    /* We reach this code path only for integer encodings.
+     * Convert the unsigned value to the signed one using two's complement
+     * rule. */
+    if (uval >= negstart) {
+        /* This three steps conversion should avoid undefined behaviors
+         * in the unsigned -> signed conversion. */
+        uval = negmax-uval;
+        val = uval;
+        val = -val-1;
+    } else {
+        val = uval;
+    }
+
+    /* Return the string representation of the integer or the value itself
+     * depending on intbuf being NULL or not. */
+    if (intbuf) {
+        *count = ll2string((char*)intbuf,LP_INTBUF_SIZE,(long long)val);
+        return intbuf;
+    } else {
+        *count = val;
+        return NULL;
+    }
+}
+
 unsigned char *lpGet(unsigned char *p, int64_t *count, unsigned char *intbuf) {
-    return lpGetWithSize(p, count, intbuf, NULL);
+    return lpGetWithBuf(p, count, intbuf);
 }
 
 /* This is just a wrapper to lpGet() that is able to get entry value directly.
@@ -1487,8 +1585,9 @@ unsigned char *lpValidateFirst(unsigned char *lp) {
 
 /* Validate the integrity of a single listpack entry and move to the next one.
  * The input argument 'pp' is a reference to the current record and is advanced on exit.
+ *  the data pointed to by 'lp' will not be modified by the function.
  * Returns 1 if valid, 0 if invalid. */
-int lpValidateNext(unsigned char *lp, unsigned char **pp, size_t lpbytes) {
+int lpValidateNext(const unsigned char *lp, unsigned char **pp, const size_t lpbytes) {
 #define OUT_OF_RANGE(p) ( \
         (p) < lp + LP_HDR_SIZE || \
         (p) > lp + lpbytes - 1)
@@ -1537,7 +1636,7 @@ int lpValidateNext(unsigned char *lp, unsigned char **pp, size_t lpbytes) {
 }
 
 /* Validate that the entry doesn't reach outside the listpack allocation. */
-static inline void lpAssertValidEntry(unsigned char* lp, size_t lpbytes, unsigned char *p) {
+static inline void lpAssertValidEntry(const unsigned char* lp, const size_t lpbytes, unsigned char *p) {
     assert(lpValidateNext(lp, &p, lpbytes));
 }
 

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -369,6 +369,23 @@ static inline unsigned long lpEncodeBacklen(unsigned char *buf, uint64_t l) {
     }
 }
 
+/* Calculate the number of bytes required to reverse-encode a variable length
+ * field representing the length of the previous element of size 'l', ranging
+ * from 1 to 5. */
+static inline unsigned long lpEncodeBacklenBytes(uint64_t l) {
+    if (l <= 127) {
+        return 1;
+    } else if (l < 16383) {
+        return 2;
+    } else if (l < 2097151) {
+        return 3;
+    } else if (l < 268435455) {
+        return 4;
+    } else {
+        return 5;
+    }
+}
+
 /* Decode the backlen and returns it. If the encoding looks invalid (more than
  * 5 bytes are used), UINT64_MAX is returned to report the problem. */
 static inline uint64_t lpDecodeBacklen(unsigned char *p) {
@@ -449,9 +466,9 @@ static inline uint32_t lpCurrentEncodedSizeBytes(const unsigned char encoding) {
  * function if the current element is the EOF element at the end of the
  * listpack, however, while this function is used to implement lpNext(),
  * it does not return NULL when the EOF element is encountered. */
-unsigned char *lpSkip(unsigned char *p) {
+static inline unsigned char *lpSkip(unsigned char *p) {
     unsigned long entrylen = lpCurrentEncodedSizeUnsafe(p);
-    entrylen += lpEncodeBacklen(NULL,entrylen);
+    entrylen += lpEncodeBacklenBytes(entrylen);
     p += entrylen;
     return p;
 }
@@ -484,7 +501,7 @@ unsigned char *lpPrev(unsigned char *lp, unsigned char *p) {
     if (p-lp == LP_HDR_SIZE) return NULL;
     p--; /* Seek the first backlen byte of the last element. */
     uint64_t prevlen = lpDecodeBacklen(p);
-    prevlen += lpEncodeBacklen(NULL,prevlen);
+    prevlen += lpEncodeBacklenBytes(prevlen);
     p -= prevlen-1; /* Seek the first byte of the previous entry. */
     lpAssertValidEntry(lp, lpBytes(lp), p);
     return p;
@@ -578,7 +595,7 @@ static inline unsigned char *lpGetWithSize(unsigned char *p, int64_t *count, uns
         if (entry_size) *entry_size = LP_ENCODING_7BIT_UINT_ENTRY_SIZE;
     } else if (LP_ENCODING_IS_6BIT_STR(p[0])) {
         *count = LP_ENCODING_6BIT_STR_LEN(p);
-        if (entry_size) *entry_size = 1 + *count + lpEncodeBacklen(NULL, *count + 1);
+        if (entry_size) *entry_size = 1 + *count + lpEncodeBacklenBytes(*count + 1);
         return p+1;
     } else if (LP_ENCODING_IS_13BIT_INT(p[0])) {
         uval = ((p[0]&0x1f)<<8) | p[1];
@@ -620,11 +637,11 @@ static inline unsigned char *lpGetWithSize(unsigned char *p, int64_t *count, uns
         if (entry_size) *entry_size = LP_ENCODING_64BIT_INT_ENTRY_SIZE;
     } else if (LP_ENCODING_IS_12BIT_STR(p[0])) {
         *count = LP_ENCODING_12BIT_STR_LEN(p);
-        if (entry_size) *entry_size = 2 + *count + lpEncodeBacklen(NULL, *count + 2);
+        if (entry_size) *entry_size = 2 + *count + lpEncodeBacklenBytes(*count + 2);
         return p+2;
     } else if (LP_ENCODING_IS_32BIT_STR(p[0])) {
         *count = LP_ENCODING_32BIT_STR_LEN(p);
-        if (entry_size) *entry_size = 5 + *count + lpEncodeBacklen(NULL, *count + 5);
+        if (entry_size) *entry_size = 5 + *count + lpEncodeBacklenBytes(*count + 5);
         return p+5;
     } else {
         uval = 12345678900000000ULL + p[0];
@@ -981,7 +998,7 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char 
     uint32_t replaced_len  = 0;
     if (where == LP_REPLACE) {
         replaced_len = lpCurrentEncodedSizeUnsafe(p);
-        replaced_len += lpEncodeBacklen(NULL,replaced_len);
+        replaced_len += lpEncodeBacklenBytes(replaced_len);
         ASSERT_INTEGRITY_LEN(lp, p, replaced_len);
     }
 
@@ -1521,7 +1538,7 @@ size_t lpBytes(unsigned char *lp) {
 size_t lpEntrySizeInteger(long long lval) {
     uint64_t enclen;
     lpEncodeIntegerGetType(lval, NULL, &enclen);
-    unsigned long backlen = lpEncodeBacklen(NULL, enclen);
+    unsigned long backlen = lpEncodeBacklenBytes(enclen);
     return enclen + backlen;
 }
 
@@ -1618,7 +1635,7 @@ int lpValidateNext(unsigned char *lp, unsigned char **pp, size_t lpbytes) {
 
     /* get the entry length and encoded backlen. */
     unsigned long entrylen = lpCurrentEncodedSizeUnsafe(p);
-    unsigned long encodedBacklen = lpEncodeBacklen(NULL,entrylen);
+    unsigned long encodedBacklen = lpEncodeBacklenBytes(entrylen);
     entrylen += encodedBacklen;
 
     /* make sure the entry doesn't reach outside the edge of the listpack */
@@ -1963,7 +1980,7 @@ void lpRepr(unsigned char *lp) {
     while(p) {
         uint32_t encoded_size_bytes = lpCurrentEncodedSizeBytes(p[0]);
         uint32_t encoded_size = lpCurrentEncodedSizeUnsafe(p);
-        unsigned long back_len = lpEncodeBacklen(NULL, encoded_size);
+        unsigned long back_len = lpEncodeBacklenBytes(encoded_size);
         printf(
             "{\n"
                 "\taddr: 0x%08lx,\n"

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -680,9 +680,9 @@ static inline unsigned char *lpGetWithSize(unsigned char *p, int64_t *count, uns
 static inline unsigned char *lpGetWithBuf(unsigned char *p, int64_t *count, unsigned char *intbuf) {
     int64_t val;
     uint64_t uval, negstart, negmax;
+    assert(p); /* assertion for valgrind (avoid NPD) */
     const unsigned char encoding = p[0];
 
-    assert(p); /* assertion for valgrind (avoid NPD) */
     /* string encoding */
     if (LP_ENCODING_IS_6BIT_STR(encoding)) {
         *count = LP_ENCODING_6BIT_STR_LEN(p);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -65,7 +65,7 @@ unsigned char *lpFindCb(unsigned char *lp, unsigned char *p, void *user, lpCmp c
 unsigned char *lpFirst(unsigned char *lp);
 unsigned char *lpLast(unsigned char *lp);
 unsigned char *lpNext(unsigned char *lp, unsigned char *p);
-unsigned char *lpNextWithBytes(const unsigned char *lp, const size_t lpbytes, unsigned char *p);
+unsigned char *lpNextWithBytes(unsigned char *lp, const size_t lpbytes, unsigned char *p);
 unsigned char *lpPrev(unsigned char *lp, unsigned char *p);
 size_t lpBytes(unsigned char *lp);
 size_t lpEntrySizeInteger(long long lval);
@@ -75,7 +75,7 @@ typedef int (*listpackValidateEntryCB)(unsigned char *p, unsigned int head_count
 int lpValidateIntegrity(unsigned char *lp, size_t size, int deep,
                         listpackValidateEntryCB entry_cb, void *cb_userdata);
 unsigned char *lpValidateFirst(unsigned char *lp);
-int lpValidateNext(const unsigned char *lp, unsigned char **pp, const size_t lpbytes);
+int lpValidateNext(unsigned char *lp, unsigned char **pp, size_t lpbytes);
 unsigned int lpCompare(unsigned char *p, unsigned char *s, uint32_t slen);
 void lpRandomPair(unsigned char *lp, unsigned long total_count,
                   listpackEntry *key, listpackEntry *val, int tuple_len);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -65,7 +65,7 @@ unsigned char *lpFindCb(unsigned char *lp, unsigned char *p, void *user, lpCmp c
 unsigned char *lpFirst(unsigned char *lp);
 unsigned char *lpLast(unsigned char *lp);
 unsigned char *lpNext(unsigned char *lp, unsigned char *p);
-unsigned char *lpNextWithBytes(unsigned char *lp, const size_t lpbytes, unsigned char *p);
+unsigned char *lpNextWithBytes(unsigned char *lp, unsigned char *p, const size_t lpbytes);
 unsigned char *lpPrev(unsigned char *lp, unsigned char *p);
 size_t lpBytes(unsigned char *lp);
 size_t lpEntrySizeInteger(long long lval);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -65,6 +65,7 @@ unsigned char *lpFindCb(unsigned char *lp, unsigned char *p, void *user, lpCmp c
 unsigned char *lpFirst(unsigned char *lp);
 unsigned char *lpLast(unsigned char *lp);
 unsigned char *lpNext(unsigned char *lp, unsigned char *p);
+unsigned char *lpNextWithBytes(const unsigned char *lp, const size_t lpbytes, unsigned char *p);
 unsigned char *lpPrev(unsigned char *lp, unsigned char *p);
 size_t lpBytes(unsigned char *lp);
 size_t lpEntrySizeInteger(long long lval);
@@ -74,7 +75,7 @@ typedef int (*listpackValidateEntryCB)(unsigned char *p, unsigned int head_count
 int lpValidateIntegrity(unsigned char *lp, size_t size, int deep,
                         listpackValidateEntryCB entry_cb, void *cb_userdata);
 unsigned char *lpValidateFirst(unsigned char *lp);
-int lpValidateNext(unsigned char *lp, unsigned char **pp, size_t lpbytes);
+int lpValidateNext(const unsigned char *lp, unsigned char **pp, const size_t lpbytes);
 unsigned int lpCompare(unsigned char *p, unsigned char *s, uint32_t slen);
 void lpRandomPair(unsigned char *lp, unsigned long total_count,
                   listpackEntry *key, listpackEntry *val, int tuple_len);

--- a/src/networking.c
+++ b/src/networking.c
@@ -317,27 +317,19 @@ int prepareClientToWrite(client *c) {
  * Low level functions to add more data to output buffers.
  * -------------------------------------------------------------------------- */
 
-/* Attempts to add the reply to the static buffer in the client struct.
- * Returns the length of data that is added to the reply buffer.
+/* Adds reply to the static buffer in the client struct.
  *
  * Sanitizer suppression: client->buf_usable_size determined by
  * zmalloc_usable_size() call. Writing beyond client->buf boundaries confuses
  * sanitizer and generates a false positive out-of-bounds error */
 REDIS_NO_SANITIZE("bounds")
-size_t _addReplyToBuffer(client *c, const char *s, size_t len) {
-    size_t available = c->buf_usable_size - c->bufpos;
-
-    /* If there already are entries in the reply list, we cannot
-     * add anything more to the static buffer. */
-    if (listLength(c->reply) > 0) return 0;
-
-    size_t reply_len = len > available ? available : len;
+static inline void _addReplyToBuffer(client *c, const char *s, size_t len) {
+    const size_t available = c->buf_usable_size - c->bufpos;
+    const size_t reply_len = len > available ? available : len;
     memcpy(c->buf+c->bufpos,s,reply_len);
     c->bufpos+=reply_len;
     /* We update the buffer peak after appending the reply to the buffer */
-    if(c->buf_peak < (size_t)c->bufpos)
-        c->buf_peak = (size_t)c->bufpos;
-    return reply_len;
+    c->buf_peak = max(c->buf_peak,(size_t)c->bufpos);
 }
 
 /* Adds the reply to the reply linked list.
@@ -419,8 +411,12 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
         return;
     }
 
-    size_t reply_len = _addReplyToBuffer(c,s,len);
-    if (len > reply_len) _addReplyProtoToList(c,c->reply,s+reply_len,len-reply_len);
+    /* If there already are entries in the reply list, we cannot
+     * add anything more to the static buffer. */
+    if (listLength(c->reply) > 0)
+        _addReplyProtoToList(c,c->reply,s,len);
+    else
+        _addReplyToBuffer(c,s,len);
 }
 
 /* -----------------------------------------------------------------------------

--- a/src/networking.c
+++ b/src/networking.c
@@ -317,17 +317,6 @@ int prepareClientToWrite(client *c) {
  * Low level functions to add more data to output buffers.
  * -------------------------------------------------------------------------- */
 
-/* Adds reply to the static buffer in the client struct.
- *
- * Sanitizer suppression: client->buf_usable_size determined by
- * zmalloc_usable_size() call. Writing beyond client->buf boundaries confuses
- * sanitizer and generates a false positive out-of-bounds error */
-REDIS_NO_SANITIZE("bounds")
-static inline void _addReplyToBuffer(client *c, const char *s, size_t reply_len) {
-    memcpy(c->buf+c->bufpos,s,reply_len);
-    c->bufpos+=reply_len;
-}
-
 /* Adds the reply to the reply linked list.
  * Note: some edits to this function need to be relayed to AddReplyFromClient. */
 void _addReplyProtoToList(client *c, list *reply_list, const char *s, size_t len) {
@@ -407,16 +396,20 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
         return;
     }
 
+    /* We update the buffer peak always */
+    const size_t available = c->buf_usable_size - c->bufpos;
+    c->buf_peak = max(c->buf_peak,(size_t)available);
+
     /* If there already are entries in the reply list or the added length surpasses the buffer,
      * we cannot add anything more to the static buffer. */
-    const size_t available = c->buf_usable_size - c->bufpos;
-    /* We update the buffer peak always */
-    c->buf_peak = max(c->buf_peak,(size_t)available);
     const int out_buffer_boundary = len > available;
     if (listLength(c->reply) > 0 || out_buffer_boundary)
         _addReplyProtoToList(c,c->reply,s,len);
-    else
-        _addReplyToBuffer(c,s,len);
+    else {
+        /* Add reply to the static buffer in the client struct. */
+        memcpy(c->buf+c->bufpos,s,len);
+        c->bufpos+=len;
+    }
 }
 
 /* -----------------------------------------------------------------------------

--- a/src/networking.c
+++ b/src/networking.c
@@ -323,9 +323,7 @@ int prepareClientToWrite(client *c) {
  * zmalloc_usable_size() call. Writing beyond client->buf boundaries confuses
  * sanitizer and generates a false positive out-of-bounds error */
 REDIS_NO_SANITIZE("bounds")
-static inline void _addReplyToBuffer(client *c, const char *s, size_t len) {
-    const size_t available = c->buf_usable_size - c->bufpos;
-    const size_t reply_len = len > available ? available : len;
+static inline void _addReplyToBuffer(client *c, const char *s, size_t reply_len) {
     memcpy(c->buf+c->bufpos,s,reply_len);
     c->bufpos+=reply_len;
     /* We update the buffer peak after appending the reply to the buffer */
@@ -411,9 +409,10 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
         return;
     }
 
-    /* If there already are entries in the reply list, we cannot
-     * add anything more to the static buffer. */
-    if (listLength(c->reply) > 0)
+    /* If there already are entries in the reply list or the added length surpasses the buffer,
+     * we cannot add anything more to the static buffer. */
+    const int out_buffer_boundary = len > (c->buf_usable_size - c->bufpos);
+    if (listLength(c->reply) > 0 || out_buffer_boundary)
         _addReplyProtoToList(c,c->reply,s,len);
     else
         _addReplyToBuffer(c,s,len);

--- a/src/networking.c
+++ b/src/networking.c
@@ -399,18 +399,18 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
     /* We update the buffer peak always */
     const size_t available = c->buf_usable_size - c->bufpos;
 
-    /* If there already are entries in the reply list or the added length surpasses the buffer,
-     * we cannot add anything more to the static buffer. */
-    const int out_buffer_boundary = len > available;
-    if (listLength(c->reply) > 0 || out_buffer_boundary)
-        _addReplyProtoToList(c,c->reply,s,len);
-    else {
-        /* Add reply to the static buffer in the client struct. */
-        memcpy(c->buf+c->bufpos,s,len);
-        c->bufpos+=len;
+    size_t reply_len = 0;
+    /* If there already are entries in the reply list, we cannot
+     * add anything more to the static buffer. */
+    if (listLength(c->reply) < 1) {
+        reply_len = len > available ? available : len;
+        memcpy(c->buf+c->bufpos,s,reply_len);
+        c->bufpos+=reply_len;
         /* We update the buffer peak after appending the reply to the buffer */
         c->buf_peak = max(c->buf_peak,(size_t)c->bufpos);
     }
+
+    if (len > reply_len) _addReplyProtoToList(c,c->reply,s+reply_len,len-reply_len);
 }
 
 /* -----------------------------------------------------------------------------

--- a/src/networking.c
+++ b/src/networking.c
@@ -398,7 +398,6 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
 
     /* We update the buffer peak always */
     const size_t available = c->buf_usable_size - c->bufpos;
-    c->buf_peak = max(c->buf_peak,(size_t)available);
 
     /* If there already are entries in the reply list or the added length surpasses the buffer,
      * we cannot add anything more to the static buffer. */
@@ -409,6 +408,8 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
         /* Add reply to the static buffer in the client struct. */
         memcpy(c->buf+c->bufpos,s,len);
         c->bufpos+=len;
+        /* We update the buffer peak after appending the reply to the buffer */
+        c->buf_peak = max(c->buf_peak,(size_t)available);
     }
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -409,7 +409,7 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
         memcpy(c->buf+c->bufpos,s,len);
         c->bufpos+=len;
         /* We update the buffer peak after appending the reply to the buffer */
-        c->buf_peak = max(c->buf_peak,(size_t)available);
+        c->buf_peak = max(c->buf_peak,(size_t)c->bufpos);
     }
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -326,8 +326,6 @@ REDIS_NO_SANITIZE("bounds")
 static inline void _addReplyToBuffer(client *c, const char *s, size_t reply_len) {
     memcpy(c->buf+c->bufpos,s,reply_len);
     c->bufpos+=reply_len;
-    /* We update the buffer peak after appending the reply to the buffer */
-    c->buf_peak = max(c->buf_peak,(size_t)c->bufpos);
 }
 
 /* Adds the reply to the reply linked list.
@@ -411,7 +409,10 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
 
     /* If there already are entries in the reply list or the added length surpasses the buffer,
      * we cannot add anything more to the static buffer. */
-    const int out_buffer_boundary = len > (c->buf_usable_size - c->bufpos);
+    const size_t available = c->buf_usable_size - c->bufpos;
+    /* We update the buffer peak always */
+    c->buf_peak = max(c->buf_peak,(size_t)available);
+    const int out_buffer_boundary = len > available;
     if (listLength(c->reply) > 0 || out_buffer_boundary)
         _addReplyProtoToList(c,c->reply,s,len);
     else

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -683,23 +683,20 @@ void addListQuicklistRangeReply(client *c, robj *o, int from, int rangelen, int 
  * Note that the purpose is to make the methods small so that the
  * code in the loop can be inlined better to improve performance. */
 void addListListpackRangeReply(client *c, robj *o, int from, int rangelen, int reverse) {
-    unsigned char *p = lpSeek(o->ptr, from);
-    unsigned char *vstr;
-    unsigned int vlen;
-    long long lval;
+    unsigned char *lp = o->ptr;
+    unsigned char *p = lpSeek(lp, from);
+    const size_t lpbytes = lpBytes(lp);
+    int64_t vlen;
 
     /* Return the result in form of a multi-bulk reply */
     addReplyArrayLen(c,rangelen);
 
     while(rangelen--) {
         serverAssert(p); /* fail on corrupt data */
-        vstr = lpGetValue(p, &vlen, &lval);
-        if (vstr) {
-            addReplyBulkCBuffer(c,vstr,vlen);
-        } else {
-            addReplyBulkLongLong(c,lval);
-        }
-        p = reverse ? lpPrev(o->ptr,p) : lpNext(o->ptr,p);
+        unsigned char buf[LP_INTBUF_SIZE];
+        unsigned char *vstr = lpGet(p,&vlen,buf);
+        addReplyBulkCBuffer(c,vstr,vlen);
+        p = reverse ? lpPrev(lp,p) : lpNextWithBytes(lp,lpbytes,p);
     }
 }
 

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -696,7 +696,7 @@ void addListListpackRangeReply(client *c, robj *o, int from, int rangelen, int r
         unsigned char buf[LP_INTBUF_SIZE];
         unsigned char *vstr = lpGet(p,&vlen,buf);
         addReplyBulkCBuffer(c,vstr,vlen);
-        p = reverse ? lpPrev(lp,p) : lpNextWithBytes(lp,lpbytes,p);
+        p = reverse ? lpPrev(lp,p) : lpNextWithBytes(lp,p,lpbytes);
     }
 }
 


### PR DESCRIPTION
This PR focused on refining listpack encoding/decoding functions and optimizing reply handling mechanisms related to it. 
Each commit has the measured improvement up until the last accumulated improvement of 16.3% on [memtier_benchmark-1key-list-100-elements-lrange-all-elements-pipeline-10](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-100-elements-lrange-all-elements-pipeline-10.yml) benchmark. 

Connection mode | CE Baseline  (Nov 14th) 701f06657d20ec42f0cf78de0ac9d7197e44c00c | CE PR #13652 | CE PR vs CE Unstable
-- | -- | -- | --
TCP | 155696 | 178874 | 14.9%
Unix socket | 169743 | 197428 | 16.3%






To test it we can simply focus on the scan.tcl

```
tclsh tests/test_helper.tcl --single unit/replybufsize
```

### Commit details:
- 2e58d048fd9d1365c56292ebd69f2ed141bfeda1 + 29c6c86c6b96376f807656f203b61d0e7fcb65a4 : Eliminate an indirect memory access on lpCurrentEncodedSizeBytes and completely avoid passing p* fully to lpCurrentEncodedSizeBytes + Add lpNextWithBytes helper function and optimize addListListpackRangeReply 

    **- Improvement of 3.1%, from 168969.88 ops/sec to 174239.75 ops/sec**
- af52aacff86e2809f3451e2561043d532b9ee223 Refactor lpDecodeBacklen for loop-based decoding, improving readability and branch efficiency.
    **- NO CHANGE. REVERTED in 09f6680ba0d0b5acabca537c651008f0c8ec061b**
    
- 048bfe4edaaf5671f7f06b06d1492f81e6af3e59 + 03e8ff3af70891cbd3d53ca865558976459bb38e : reducing condition checks in _addReplyToBuffer, inlining it, and avoid entering it when there are there already entries in the reply list
 and check if the reply length exceeds available buffer space before calling _addReplyToBuffer 
    **- accumulated Improvement of 12.4%, from 168969.88 ops/sec to 189726.81 ops/sec**

- 9a63d4d6a9fa946505e31ecce4c7796845fc022c:  always update the buf_peak on _addReplyToBufferOrList
    **- accumulated Improvement of 14.2%, from 168969.88 ops/sec to 193887 ops/sec**

- b544ade67628a1feaf714d6cfd114930e0c7670b:  Introduce lpEncodeBacklenBytes to avoid any indirect memory access on previous usage of lpEncodeBacklen(NULL,...). inline lpEncodeBacklenBytes().
    **- accumulated Improvement of 16.3%, from 168969.88 ops/sec to 197427.70 ops/sec**

### To replicate:

Populate key with 100 entries lp encoded
```
redis-cli -p 6380 "LPUSH" "list:100" "vyoomgwuzv" "xamjodnbpf" "ewomnmugfa" "ljcgdooafo" "pcxdhdjwnf" "djetcyfxuc" "licotqplim" "alqlzsvuuz" "ijsmoyesvd" "whmotknaff" "rkaznetutk" "ksqpdywgdd" "gorgpnnqwr" "gekntrykfh" "rjkknoigmu" "luemuetmia" "gxephxbdru" "ncjfckgkcl" "hhjclfbbka" "cgoeihlnei" "zwnitejtpg" "upodnpqenn" "mibvtmqxcy" "htvbwmfyic" "rqvryfvlie" "nxcdcaqgit" "gfdqdrondm" "lysbgqqfqw" "nxzsnkmxvi" "nsxaigrnje" "cwaveajmcz" "xsepfhdizi" "owtkxlzaci" "agsdggdghc" "tcjvjofxtd" "kgqrovsxce" "ouuybhtvyb" "ueyrvldzwl" "vpbkvwgxsf" "pytrnqdhvs" "qbiwbqiubb" "ssjqrsluod" "urvgxwbiiz" "ujrxcmpvsq" "mtccjerdon" "xczfmrxrja" "imyizmhzjk" "oguwnmniig" "mxwgdcutnb" "pqyurbvifk" "ccagtnjilc" "mbxohpancs" "lgrkndhekf" "eqlgkwosie" "jxoxtnzujs" "lbtpbknelm" "ichqzmiyot" "mbgehjiauu" "aovfsvbwjg" "nmgxcctxpn" "vyqqkuszzh" "rojeolnopp" "ibhohmfxzt" "qbyhorvill" "nhfnbxqgol" "wkbasfyzqz" "mjjuylgssm" "imdqxmkzdj" "oapbvnisyq" "bqntlsaqjb" "ocrcszcznp" "hhniikmtsx" "hlpdstpvzw" "wqiwdbncmt" "vymjzlzqcn" "hhjchwjlmc" "ypfeltycpy" "qjyeqcfhjj" "uapsgmizgh" "owbbdezgxn" "qrosceblyo" "sahqeskveq" "dapacykoah" "wvcnqbvlnf" "perfwnpvkl" "ulbrotlhze" "fhuvzpxjbc" "holjcdpijr" "onzjrteqmu" "pquewclxuy" "vpmpffdoqz" "eouliovvra" "vxcbagyymm" "jekkafodvk" "ypekeuutef" "dlbqcynhrn" "erxulvebrj" "qwxrsgafzy" "dlsjwmqzhx" "exvhmqxvvp"
(integer) 100
```

Benchmark 
```
memtier_benchmark -S /tmp/2.socket --pipeline 10 --command="LRANGE list:100 0 -1"  --hide-histogram --test-time 60
```

#### results

Baseline
```
root@hpe10:~/redis# taskset -c 2-5 memtier_benchmark -S /tmp/2.socket --pipeline 10 --command="LRANGE list:100 0 -1"  --hide-histogram --test-time 60
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,  60 secs]  0 threads:    10140346 ops,  168711 (avg:  168966) ops/sec, 281.73MB/sec (avg: 282.15MB/sec), 11.74 (avg: 11.73) msec latency

4         Threads
50        Connections per thread
60        Seconds


ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Lranges    168969.88        11.72828        11.90300        17.02300        21.50300    288931.90 
Totals     168969.88        11.72828        11.90300        17.02300        21.50300    577863.80 
```

Change 1:
```
root@hpe10:~/redis# taskset -c 2-5 memtier_benchmark -S /tmp/1.socket --pipeline 10 --command="LRANGE list:100 0 -1"  --hide-histogram --test-time 60
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,  60 secs]  0 threads:    10456617 ops,  174327 (avg:  174243) ops/sec, 291.11MB/sec (avg: 290.97MB/sec), 11.36 (avg: 11.37) msec latency

4         Threads
50        Connections per thread
60        Seconds


ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Lranges    174239.75        11.36966        11.51900        16.51100        21.11900    297943.17 
Totals     174239.75        11.36966        11.51900        16.51100        21.11900    595886.33 

```

Change 3:

```
root@hpe10:~/redis# taskset -c 2-5 memtier_benchmark -S /tmp/1.socket --pipeline 10 --command="LRANGE list:100 0 -1"  --hide-histogram --test-time 60
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,  60 secs]  0 threads:    11386130 ops,  189935 (avg:  189733) ops/sec, 317.17MB/sec (avg: 316.83MB/sec), 10.42 (avg: 10.43) msec latency

4         Threads
50        Connections per thread
60        Seconds


ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Lranges    189726.81        10.43341        10.62300        15.16700        20.22300    324425.43 
Totals     189726.81        10.43341        10.62300        15.16700        20.22300    648850.86 

```


Change 4, commit 9a63d4d6a9fa946505e31ecce4c7796845fc022c:

```
root@hpe10:~/redis# taskset -c 2-5 memtier_benchmark -S /tmp/1.socket --pipeline 10 --command="LRANGE list:100 0 -1"  --hide-histogram --test-time 60
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,  60 secs]  0 threads:    11940572 ops,  199017 (avg:  198971) ops/sec, 332.34MB/sec (avg: 332.26MB/sec),  9.94 (avg:  9.94) msec latency

4         Threads
50        Connections per thread
60        Seconds


ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Lranges    198967.57         9.94374        10.11100        14.59100        19.58300    340226.77 
Totals     198967.57         9.94374        10.11100        14.59100        19.58300    680453.54 
```

Change 5, commit b544ade67628a1feaf714d6cfd114930e0c7670b:

```
root@hpe10:~/redis# taskset -c 2-5 memtier_benchmark -S /tmp/1.socket --pipeline 10 --command="LRANGE list:100 0 -1"  --hide-histogram --test-time 60
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,  60 secs]  0 threads:    11848352 ops,  197298 (avg:  197436) ops/sec, 329.47MB/sec (avg: 329.70MB/sec), 10.03 (avg: 10.02) msec latency

4         Threads
50        Connections per thread
60        Seconds


ALL STATS
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Lranges    197427.70        10.02192        10.17500        14.71900        19.71100    337593.65 
Totals     197427.70        10.02192        10.17500        14.71900        19.71100    675187.31 

```

