### PR TITLE
Upgrade ubuntu and mac version in action

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -922,7 +922,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: test
-      uses: cross-platform-actions/action@v0.22.0
+      uses: cross-platform-actions/action@v0.25.0
       with:
         operating_system: freebsd
         environment_variables: MAKE

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -903,7 +903,7 @@ jobs:
       run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
 
   test-freebsd:
-    runs-on: macos-13
+    runs-on: macos-14
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'freebsd')

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -903,7 +903,7 @@ jobs:
       run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
 
   test-freebsd:
-    runs-on: macos-12
+    runs-on: macos-14
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'freebsd')

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -876,7 +876,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -903,7 +903,7 @@ jobs:
       run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
 
   test-freebsd:
-    runs-on: macos-14
+    runs-on: macos-13
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'freebsd')

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -76,7 +76,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
       !contains(github.event.inputs.skipjobs, 'fortify')
-    container: ubuntu:lunar
+    container: ubuntu:plucky
     timeout-minutes: 14400
     steps:
     - name: prep


### PR DESCRIPTION
1. Ubuntu version lunar reached End of Life on January 25, 2024, upgrade to the version plucky to pass the action  `test-ubuntu-jemalloc-fortify` in daily.ci
2. The macOS-12 environment is deprecated, upgrade to macOS-15 to avoid warning in action `build-macos` and `test-freebsd`
