### PR TITLE
Do not call _dictClear()'s callback for the first 65k items

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -697,8 +697,9 @@ int _dictClear(dict *d, int htidx, void(callback)(dict*)) {
     /* Free all the elements */
     for (i = 0; i < DICTHT_SIZE(d->ht_size_exp[htidx]) && d->ht_used[htidx] > 0; i++) {
         dictEntry *he, *nextHe;
-
-        if (callback && (i & 65535) == 0) callback(d);
+        /* Callback will be called once for every 65535 deletions. Beware,
+         * if dict has less than 65535 items, it will not be called at all.*/
+        if (callback && i != 0 && (i & 65535) == 0) callback(d);
 
         if ((he = d->ht_table[htidx][i]) == NULL) continue;
         while(he) {


### PR DESCRIPTION
In https://github.com/redis/redis/pull/13495, we introduced a feature to reply -LOADING while flushing a large db on a replica.
While `_dictClear()` is in progress, it calls a callback for every 65k items and we yield back to eventloop to reply -LOADING.

This change has made some tests unstable as those tests don't expect new -LOADING reply. 
One observation, inside `_dictClear()`, we call the callback even if db has a few keys. Most tests run with small amount of keys. So, each replication and cluster test has to handle potential -LOADING reply now. 

This PR changes this behavior, skips calling callback when `i=0` to stabilize replication tests. 
Callback will be called after the first 65k items. Most tests use less than 65k keys and they won't get -LOADING reply.   