### PR TITLE
modules API: Add test for ACL check of empty prefix

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -217,7 +217,7 @@ int prefixmatch(const char *pattern, int patternLen,
      * it can match any suffix of the string beyond the prefix. This check
      * remains outside stringmatchlen_impl() to keep its complexity manageable.
      */
-    if (pattern[patternLen - 1] != '*' || patternLen == 0)
+    if (patternLen == 0 || pattern[patternLen - 1] != '*' )
         return 0;
 
     /* Count backward the number of consecutive backslashes preceding the '*'

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -50,7 +50,7 @@ start_server {tags {"modules acl"}} {
         catch {r aclcheck.set.check.prefixkey "~" ESCAPED_STAR* ESCAPED_STAR* 5} e
         assert_match "*DENIED KEY*" $e        
         assert_equal [r aclcheck.set.check.prefixkey "~" NON_ESCAPED_STAR\\ NON_ESCAPED_STAR\\clothes 5] OK
-    }    
+    }
     
     test {check ACL permissions versus empty string prefix} {
         # The empty string should should match all keys permissions    

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -51,6 +51,19 @@ start_server {tags {"modules acl"}} {
         assert_match "*DENIED KEY*" $e        
         assert_equal [r aclcheck.set.check.prefixkey "~" NON_ESCAPED_STAR\\ NON_ESCAPED_STAR\\clothes 5] OK
     }    
+    
+    test {check ACL permissions versus empty string prefix} {
+        # The empty string should should match all keys permissions    
+        r acl setuser default +set resetkeys %R~* %W~* ~*
+        assert_equal [r aclcheck.set.check.prefixkey "~" "" CART_BOOKS_12 5] OK
+        assert_equal [r aclcheck.set.check.prefixkey "W" "" ORDER_2024_564879 5] OK
+        assert_equal [r aclcheck.set.check.prefixkey "R" "" PRODUCT_BOOKS_753376 5] OK
+        
+        # The empty string perfix should not match if cannot access all keys 
+        r acl setuser default +set resetkeys %R~x* %W~x* ~x*        
+        catch {r aclcheck.set.check.prefixkey "~" "" CART_BOOKS_12 5} e
+        assert_match "*DENIED KEY*" $e
+    }
 
     test {test module check acl for key perm} {
         # give permission for SET and block all keys but x(READ+WRITE), y(WRITE), z(READ)

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -59,7 +59,7 @@ start_server {tags {"modules acl"}} {
         assert_equal [r aclcheck.set.check.prefixkey "W" "" ORDER_2024_564879 5] OK
         assert_equal [r aclcheck.set.check.prefixkey "R" "" PRODUCT_BOOKS_753376 5] OK
         
-        # The empty string perfix should not match if cannot access all keys 
+        # The empty string prefix should not match if cannot access all keys 
         r acl setuser default +set resetkeys %R~x* %W~x* ~x*        
         catch {r aclcheck.set.check.prefixkey "~" "" CART_BOOKS_12 5} e
         assert_match "*DENIED KEY*" $e

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -53,7 +53,7 @@ start_server {tags {"modules acl"}} {
     }
     
     test {check ACL permissions versus empty string prefix} {
-        # The empty string should should match all keys permissions    
+        # The empty string should should match all keys permissions
         r acl setuser default +set resetkeys %R~* %W~* ~*
         assert_equal [r aclcheck.set.check.prefixkey "~" "" CART_BOOKS_12 5] OK
         assert_equal [r aclcheck.set.check.prefixkey "W" "" ORDER_2024_564879 5] OK

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -60,7 +60,7 @@ start_server {tags {"modules acl"}} {
         assert_equal [r aclcheck.set.check.prefixkey "R" "" PRODUCT_BOOKS_753376 5] OK
         
         # The empty string prefix should not match if cannot access all keys 
-        r acl setuser default +set resetkeys %R~x* %W~x* ~x*        
+        r acl setuser default +set resetkeys %R~x* %W~x* ~x*
         catch {r aclcheck.set.check.prefixkey "~" "" CART_BOOKS_12 5} e
         assert_match "*DENIED KEY*" $e
     }


### PR DESCRIPTION
- Add empty string test for the new API `RedisModule_ACLCheckKeyPrefixPermissions`.
- Fix order of checks: `(pattern[patternLen - 1] != '*' || patternLen == 0)`
