### PR TITLE
Move prepareClientToWrite out of loop for lrange command to reduce the redundant call.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -858,6 +858,16 @@ void setDeferredPushLen(client *c, void *node, long length) {
     setDeferredAggregateLen(c,node,length,'>');
 }
 
+/* Prepare a client for future writes. This is used so that we can
+ * skip a large number of calls to prepareClientToWrite when
+ * a command produces a lot of discrete elements in its output. */
+writePreparedClient *prepareClientForFutureWrites(client *c) {
+    if (prepareClientToWrite(c) == C_OK) {
+        return (writePreparedClient *)c;
+    }
+    return NULL;
+}
+
 /* Add a double as a bulk reply */
 void addReplyDouble(client *c, double d) {
     if (c->resp == 3) {
@@ -1009,6 +1019,11 @@ void addReplyArrayLen(client *c, long length) {
     _addReplyLongLongMBulk(c, length);
 }
 
+void addWritePreparedReplyArrayLen(writePreparedClient *c, long length) {
+    serverAssert(length >= 0);
+    _addReplyLongLongWithPrefix(c, length, '*');
+}
+
 void addReplyMapLen(client *c, long length) {
     int prefix = c->resp == 2 ? '*' : '%';
     if (c->resp == 2) length *= 2;
@@ -1098,6 +1113,12 @@ void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
     _addReplyToBufferOrList(c, "\r\n", 2);
 }
 
+void addWritePreparedReplyBulkCBuffer(writePreparedClient *c, const void *p, size_t len) {
+    _addReplyLongLongWithPrefix(c, len, '$');
+    _addReplyToBufferOrList(c, p, len);
+    _addReplyToBufferOrList(c, "\r\n", 2);
+}
+
 /* Add sds to reply (takes ownership of sds and frees it) */
 void addReplyBulkSds(client *c, sds s) {
     if (prepareClientToWrite(c) != C_OK) {
@@ -1134,6 +1155,14 @@ void addReplyBulkLongLong(client *c, long long ll) {
 
     len = ll2string(buf,64,ll);
     addReplyBulkCBuffer(c,buf,len);
+}
+
+void addWritePreparedReplyBulkLongLong(writePreparedClient *c, long long ll) {
+    char buf[64];
+    int len;
+
+    len = ll2string(buf, 64, ll);
+    addWritePreparedReplyBulkCBuffer(c, buf, len);
 }
 
 /* Reply with a verbatim type having the specified extension.

--- a/src/server.h
+++ b/src/server.h
@@ -1280,6 +1280,12 @@ typedef struct client {
 #endif
 } client;
 
+/* When a command generates a lot of discrete elements to the client output buffer, it is much faster to
+ * skip certain types of initialization. This type is used to indicate a client that has been initialized
+ * and can be used with addWritePreparedReply* functions. A client can be cast into this type with
+ * prepareClientForFutureWrites(client *c). */
+typedef client writePreparedClient;
+
 /* ACL information */
 typedef struct aclInfo {
     long long user_auth_failures; /* Auth failure counts on user level */
@@ -2601,6 +2607,7 @@ int processInputBuffer(client *c);
 void acceptCommonHandler(connection *conn, int flags, char *ip);
 void readQueryFromClient(connection *conn);
 int prepareClientToWrite(client *c);
+writePreparedClient *prepareClientForFutureWrites(client *c);
 void addReplyNull(client *c);
 void addReplyNullArray(client *c);
 void addReplyBool(client *c, int b);
@@ -2610,7 +2617,9 @@ void AddReplyFromClient(client *c, client *src);
 void addReplyBulk(client *c, robj *obj);
 void addReplyBulkCString(client *c, const char *s);
 void addReplyBulkCBuffer(client *c, const void *p, size_t len);
+void addWritePreparedReplyBulkCBuffer(writePreparedClient *c, const void *p, size_t len);
 void addReplyBulkLongLong(client *c, long long ll);
+void addWritePreparedReplyBulkLongLong(writePreparedClient *c, long long ll);
 void addReply(client *c, robj *obj);
 void addReplyStatusLength(client *c, const char *s, size_t len);
 void addReplySds(client *c, sds s);
@@ -2633,6 +2642,7 @@ void addReplyHumanLongDouble(client *c, long double d);
 void addReplyLongLong(client *c, long long ll);
 void addReplyLongLongFromStr(client *c, robj* str);
 void addReplyArrayLen(client *c, long length);
+void addWritePreparedReplyArrayLen(writePreparedClient *c, long length);
 void addReplyMapLen(client *c, long length);
 void addReplySetLen(client *c, long length);
 void addReplyAttributeLen(client *c, long length);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -662,8 +662,10 @@ void listPopRangeAndReplyWithKey(client *c, robj *o, robj *key, int where, long 
  * Note that the purpose is to make the methods small so that the
  * code in the loop can be inlined better to improve performance. */
 void addListQuicklistRangeReply(client *c, robj *o, int from, int rangelen, int reverse) {
+    writePreparedClient *wpc = prepareClientForFutureWrites(c);
+    if (!wpc) return;
     /* Return the result in form of a multi-bulk reply */
-    addReplyArrayLen(c,rangelen);
+    addWritePreparedReplyArrayLen(wpc, rangelen);
 
     int direction = reverse ? AL_START_TAIL : AL_START_HEAD;
     quicklistIter *iter = quicklistGetIteratorAtIdx(o->ptr, direction, from);
@@ -671,9 +673,9 @@ void addListQuicklistRangeReply(client *c, robj *o, int from, int rangelen, int 
         quicklistEntry qe;
         serverAssert(quicklistNext(iter, &qe)); /* fail on corrupt data */
         if (qe.value) {
-            addReplyBulkCBuffer(c,qe.value,qe.sz);
+            addWritePreparedReplyBulkCBuffer(wpc, qe.value, qe.sz);
         } else {
-            addReplyBulkLongLong(c,qe.longval);
+            addWritePreparedReplyBulkLongLong(wpc, qe.longval);
         }
     }
     quicklistReleaseIterator(iter);
@@ -683,19 +685,20 @@ void addListQuicklistRangeReply(client *c, robj *o, int from, int rangelen, int 
  * Note that the purpose is to make the methods small so that the
  * code in the loop can be inlined better to improve performance. */
 void addListListpackRangeReply(client *c, robj *o, int from, int rangelen, int reverse) {
+    writePreparedClient *wpc = prepareClientForFutureWrites(c);
+    if (!wpc) return;
+    /* Return the result in form of a multi-bulk reply */
+    addWritePreparedReplyArrayLen(wpc, rangelen);
     unsigned char *lp = o->ptr;
     unsigned char *p = lpSeek(lp, from);
     const size_t lpbytes = lpBytes(lp);
     int64_t vlen;
 
-    /* Return the result in form of a multi-bulk reply */
-    addReplyArrayLen(c,rangelen);
-
     while(rangelen--) {
         serverAssert(p); /* fail on corrupt data */
         unsigned char buf[LP_INTBUF_SIZE];
         unsigned char *vstr = lpGet(p,&vlen,buf);
-        addReplyBulkCBuffer(c,vstr,vlen);
+        addWritePreparedReplyBulkCBuffer(wpc, vstr, vlen);
         p = reverse ? lpPrev(lp,p) : lpNextWithBytes(lp,p,lpbytes);
     }
 }


### PR DESCRIPTION
This PR is based on https://github.com/valkey-io/valkey/pull/860

To test it we can simply:
```
tclsh tests/test_helper.tcl --single unit/type/list
```

Confirmation from daily:
- [x] https://github.com/filipecosta90/redis/actions/runs/12284037494


## benchmark results

Achievable ops/sec impact:

test name | unstable (c51c96656bf1f1801ae90a376f71890cbcdea4b4) | This PR (fe663b25747d81a57e067d5b87b8a31788ca1811) | % change
-- | -- | -- | --
memtier_benchmark-1key-list-2K-elements-quicklist-lrange-all-elements-longs | 7375 | 7585 | 2.85%
memtier_benchmark-1key-list-10-elements-lrange-all-elements | 138237 | 139930 | 1.22%
memtier_benchmark-1key-list-100-elements-lrange-all-elements | 94086 | 98308 | 4.49%
memtier_benchmark-1key-list-100-elements-lrange-all-elements-pipeline-10 | 174020 | 188612 | 8.39%
memtier_benchmark-1key-list-100-elements-int-7bit-uint-lrange-all-elements-pipeline-10 | 176989 | 191658 | 8.29%
memtier_benchmark-1key-list-100-elements-int-lrange-all-elements-pipeline-10 | 134978 | 138316 | 2.47%
memtier_benchmark-1key-list-1K-elements-lrange-all-elements-pipeline-10 | 19616 | 20727 | 5.66%
memtier_benchmark-1key-list-10-elements-lrange-all-elements-pipeline-10 | 636411 | 648292 | 1.87%
memtier_benchmark-1key-list-1K-elements-lrange-all-elements | 19572 | 21250 | 8.57%


To reproduce:

```
taskset -c 0 /root/redis/src/redis-server  --unixsocket /tmp/1.socket --save '' --enable-debug-command local
pip3 install redis-benchmarks-specification
redis-benchmarks-spec-client-runner --tests-regexp ".*lrange.*" --flushall_on_every_test_start --flushall_on_every_test_end  --cpuset_start_pos 2 --override-memtier-test-time 60
```
