### PR TITLE
Avoid importing memory aligned malloc

### DIFF
--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -4,8 +4,13 @@
  * Copyright (c) 2014-Present, Redis Ltd.
  * All rights reserved.
  *
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
+ *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2) or the Server Side Public License v1 (SSPLv1).
+ *
+ * Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
  */
 
 #include "server.h"
@@ -14,6 +19,9 @@
 #include <math.h>
 
 #ifdef HAVE_AVX2
+/* Define __MM_MALLOC_H to prevent importing the memory aligned
+ * allocation functions, which we don't use. */
+#define __MM_MALLOC_H
 #include <immintrin.h>
 #endif
 


### PR DESCRIPTION
This PR is based on the commits from PR https://github.com/valkey-io/valkey/pull/1442.

We deprecate the usage of classic malloc and free, but under certain circumstances they might get imported from intrinsics. The original thought is we should just override malloc and free to use zmalloc and zfree, but I think we should continue to deprecate it to avoid accidental imports of allocations.

---------

Co-authored-by: Madelyn Olson <madelyneolson@gmail.com>