### PR TITLE
Offload `lookupCommand` into IO threads when threaded IO is enabled

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -277,6 +277,12 @@ int _dictResize(dict *d, unsigned long size, int* malloc_failed)
         return DICT_OK;
     }
 
+    /* Force a full rehashing of the dictionary */
+    if (d->type->force_full_rehash) {
+        while (dictRehash(d, 1000)) {
+            /* Continue rehashing */
+        }
+    }
     return DICT_OK;
 }
 

--- a/src/dict.h
+++ b/src/dict.h
@@ -62,6 +62,10 @@ typedef struct dictType {
     unsigned int keys_are_odd:1;
     /* TODO: Add a 'keys_are_even' flag and use a similar optimization if that
      * flag is set. */
+
+    /* Ensures that the entire hash table is rehashed at once if set. */
+    unsigned int force_full_rehash:1;
+
     /* Sometimes we want the ability to store a key in a given way inside the hash
      * function, and lookup it in some other way without resorting to any kind of
      * conversion. For instance the key may be stored as a structure also

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -195,7 +195,7 @@ static int PausedIOThreads[IO_THREADS_MAX_NUM] = {0};
 
 /* Pause the specific range of io threads, and wait for them to be paused. */
 void pauseIOThreadsRange(int start, int end) {
-    if (server.io_threads_num <= 1) return;
+    if (!server.io_threads_active) return;
     serverAssert(start >= 1 && end < server.io_threads_num && start <= end);
     serverAssert(pthread_equal(pthread_self(), server.main_thread_id));
 
@@ -227,7 +227,7 @@ void pauseIOThreadsRange(int start, int end) {
 
 /* Resume the specific range of io threads, and wait for them to be resumed. */
 void resumeIOThreadsRange(int start, int end) {
-    if (server.io_threads_num <= 1) return;
+    if (!server.io_threads_active) return;
     serverAssert(start >= 1 && end < server.io_threads_num && start <= end);
     serverAssert(pthread_equal(pthread_self(), server.main_thread_id));
 

--- a/src/server.c
+++ b/src/server.c
@@ -521,7 +521,8 @@ dictType commandTableDictType = {
     dictSdsKeyCaseCompare,      /* key compare */
     dictSdsDestructor,          /* key destructor */
     NULL,                       /* val destructor */
-    NULL                        /* allow to expand */
+    NULL,                       /* allow to expand */
+    .force_full_rehash = 1,     /* force full rehashing */
 };
 
 /* Hash type hash table (note that small hashes are represented with listpacks) */
@@ -3988,7 +3989,8 @@ int processCommand(client *c) {
      * In case we are reprocessing a command after it was blocked,
      * we do not have to repeat the same checks */
     if (!client_reprocessing_command) {
-        c->cmd = c->lastcmd = c->realcmd = lookupCommand(c->argv,c->argc);
+        c->cmd = c->lastcmd = c->realcmd = c->iolookedcmd ? c->iolookedcmd :
+                                           lookupCommand(c->argv,c->argc);
         sds err;
         if (!commandCheckExistence(c, &err)) {
             rejectCommandSds(c, err);

--- a/src/server.h
+++ b/src/server.h
@@ -1215,6 +1215,7 @@ typedef struct client {
     robj **original_argv;   /* Arguments of original command if arguments were rewritten. */
     size_t argv_len_sum;    /* Sum of lengths of objects in argv list. */
     struct redisCommand *cmd, *lastcmd;  /* Last command executed. */
+    struct redisCommand *iolookedcmd;    /* Command looked up in IO threads. */
     struct redisCommand *realcmd; /* The original command that was executed by the client,
                                      Used to update error stats in case the c->cmd was modified
                                      during the command invocation (like on GEOADD for example). */


### PR DESCRIPTION
<img width="1280" src="https://github.com/user-attachments/assets/e79bf9c7-bd32-4f9b-9ca1-4e8225afe9e9" />
From flame graph, we could see `lookupCommand` in main thread costs much CPU, so we can let IO threads to perform `lookupCommand`.

To avoid race condition among multiple IO threads, made the following changes:
- Pause all IO threads when register or unregister commands
- Force a full rehashing of the command table dict when resizing