### PR TITLE
Fix index error of CRLF when replying with integer-encoded strings

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1080,8 +1080,8 @@ void addReplyBulk(client *c, robj *obj) {
          * to the output buffer. */
         char buf[34];
         size_t len = ll2string(buf,sizeof(buf),(long)obj->ptr);
-        buf[len+1] = '\r';
-        buf[len+2] = '\n';
+        buf[len] = '\r';
+        buf[len+1] = '\n';
         _addReplyLongLongBulk(c, len);
         _addReplyToBufferOrList(c,buf,len+2);
     } else {

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -135,6 +135,59 @@ start_server {tags {"protocol network"}} {
         assert_equal [r read] {a}
     }
 
+    test "bulk reply protocol" {
+        # value=2 (int encoding)
+        r set crlf 2
+        assert_equal [r rawread 5] "+OK\r\n"
+        r get crlf
+        assert_equal [r rawread 7] "\$1\r\n2\r\n"
+        r object encoding crlf
+        assert_equal [r rawread 9] "\$3\r\nint\r\n"
+
+        # value=9223372036854775807 (int encoding)
+        r set crlf 9223372036854775807
+        assert_equal [r rawread 5] "+OK\r\n"
+        r get crlf
+        assert_equal [r rawread 26] "\$19\r\n9223372036854775807\r\n"
+        r object encoding crlf
+        assert_equal [r rawread 9] "\$3\r\nint\r\n"
+
+        # value=-9223372036854775808 (int encoding)
+        r set crlf -9223372036854775808
+        assert_equal [r rawread 5] "+OK\r\n"
+        r get crlf
+        assert_equal [r rawread 27] "\$20\r\n-9223372036854775808\r\n"
+        r object encoding crlf
+        assert_equal [r rawread 9] "\$3\r\nint\r\n"
+
+        # value=-9223372036854775809 (embstr encoding)
+        r set crlf -9223372036854775809
+        assert_equal [r rawread 5] "+OK\r\n"
+        r get crlf
+        assert_equal [r rawread 27] "\$20\r\n-9223372036854775809\r\n"
+        r object encoding crlf
+        assert_equal [r rawread 12] "\$6\r\nembstr\r\n"
+
+        # value=9223372036854775808 (embstr encoding)
+        r set crlf 9223372036854775808
+        assert_equal [r rawread 5] "+OK\r\n"
+        r get crlf
+        assert_equal [r rawread 26] "\$19\r\n9223372036854775808\r\n"
+        r object encoding crlf
+        assert_equal [r rawread 12] "\$6\r\nembstr\r\n"
+
+        # normal sds (embstr encoding)
+        r set crlf aaaaaaaaaaaaaaaa
+        assert_equal [r rawread 5] "+OK\r\n"
+        r get crlf
+        assert_equal [r rawread 23] "\$16\r\naaaaaaaaaaaaaaaa\r\n"
+        r object encoding crlf
+        assert_equal [r rawread 12] "\$6\r\nembstr\r\n"
+
+        r del crlf
+        assert_equal [r rawread 4] ":1\r\n"
+    }
+
     # restore connection settings
     r readraw 0
     r deferred 0

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -144,19 +144,19 @@ start_server {tags {"protocol network"}} {
         r object encoding crlf
         assert_equal [r rawread 9] "\$3\r\nint\r\n"
 
-        # value=9223372036854775807 (int encoding)
-        r set crlf 9223372036854775807
+        # value=2147483647 (int encoding)
+        r set crlf 2147483647
         assert_equal [r rawread 5] "+OK\r\n"
         r get crlf
-        assert_equal [r rawread 26] "\$19\r\n9223372036854775807\r\n"
+        assert_equal [r rawread 17] "\$10\r\n2147483647\r\n"
         r object encoding crlf
         assert_equal [r rawread 9] "\$3\r\nint\r\n"
 
-        # value=-9223372036854775808 (int encoding)
-        r set crlf -9223372036854775808
+        # value=-2147483648 (int encoding)
+        r set crlf -2147483648
         assert_equal [r rawread 5] "+OK\r\n"
         r get crlf
-        assert_equal [r rawread 27] "\$20\r\n-9223372036854775808\r\n"
+        assert_equal [r rawread 18] "\$11\r\n-2147483648\r\n"
         r object encoding crlf
         assert_equal [r rawread 9] "\$3\r\nint\r\n"
 

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -184,6 +184,15 @@ start_server {tags {"protocol network"}} {
         r object encoding crlf
         assert_equal [r rawread 12] "\$6\r\nembstr\r\n"
 
+        # normal sds (raw string encoding) with 45 'a'
+        set rawstr [string repeat "a" 45]
+        r set crlf $rawstr
+        assert_equal [r rawread 5] "+OK\r\n"
+        r get crlf
+        assert_equal [r rawread 52] "\$45\r\n$rawstr\r\n"
+        r object encoding crlf
+        assert_equal [r rawread 9] "\$3\r\nraw\r\n"
+
         r del crlf
         assert_equal [r rawread 4] ":1\r\n"
     }


### PR DESCRIPTION
close #13709 

fix the index error of CRLF character in addReplyBulk function.