### PR TITLE
Optimize List Conversion Efficiency and Improve Code Clarity

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -36,19 +36,23 @@ static void listTypeTryConvertListpack(robj *o, robj **argv, int start, int end,
         add_length = end - start + 1;
     }
 
+    size_t lp_cur_bytes = lpBytes(o->ptr);
+    unsigned long lp_cur_length = lpLength(o->ptr);
+
     if (quicklistNodeExceedsLimit(server.list_max_listpack_size,
-            lpBytes(o->ptr) + add_bytes, lpLength(o->ptr) + add_length))
+            lp_cur_bytes + add_bytes, lp_cur_length + add_length))
     {
-        /* Invoke callback before conversion. */
+        /* Invoke callback before conversion */
         if (fn) fn(data);
 
         quicklist *ql = quicklistNew(server.list_max_listpack_size, server.list_compress_depth);
 
-        /* Append listpack to quicklist if it's not empty, otherwise release it. */
-        if (lpLength(o->ptr))
+        /* Append listpack to quicklist if it's not empty, otherwise release it */
+        if (lp_cur_length != 0)
             quicklistAppendListpack(ql, o->ptr);
         else
             lpFree(o->ptr);
+
         o->ptr = ql;
         o->encoding = OBJ_ENCODING_QUICKLIST;
     }

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -21,7 +21,7 @@ static int checkStringLength(client *c, long long size, long long append) {
         return C_OK;
     /* 'uint64_t' cast is there just to prevent undefined behavior on overflow */
     long long total = (uint64_t)size + append;
-    /* Test configured max-bulk-len represending a limit of the biggest string object,
+    /* Test configured max-bulk-len representing a limit of the biggest string object,
      * and also test for overflow. */
     if (total > server.proto_max_bulk_len || total < size || total < append) {
         addReplyError(c,"string exceeds maximum allowed size (proto-max-bulk-len)");
@@ -61,7 +61,7 @@ static int checkStringLength(client *c, long long size, long long append) {
 static int getExpireMillisecondsOrReply(client *c, robj *expire, int flags, int unit, long long *milliseconds);
 
 void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire, int unit, robj *ok_reply, robj *abort_reply) {
-    long long milliseconds = 0; /* initialized to avoid any harmness warning */
+    long long milliseconds = 0; /* initialized to avoid any harmless warning */
     int found = 0;
     int setkey_flags = 0;
 

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -21,7 +21,7 @@ static int checkStringLength(client *c, long long size, long long append) {
         return C_OK;
     /* 'uint64_t' cast is there just to prevent undefined behavior on overflow */
     long long total = (uint64_t)size + append;
-    /* Test configured max-bulk-len representing a limit of the biggest string object,
+    /* Test configured max-bulk-len represending a limit of the biggest string object,
      * and also test for overflow. */
     if (total > server.proto_max_bulk_len || total < size || total < append) {
         addReplyError(c,"string exceeds maximum allowed size (proto-max-bulk-len)");
@@ -61,7 +61,7 @@ static int checkStringLength(client *c, long long size, long long append) {
 static int getExpireMillisecondsOrReply(client *c, robj *expire, int flags, int unit, long long *milliseconds);
 
 void setGenericCommand(client *c, int flags, robj *key, robj *val, robj *expire, int unit, robj *ok_reply, robj *abort_reply) {
-    long long milliseconds = 0; /* initialized to avoid any harmless warning */
+    long long milliseconds = 0; /* initialized to avoid any harmness warning */
     int found = 0;
     int setkey_flags = 0;
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Code optimization
> This PR focuses on improving the efficiency of list conversion operations from listpack to quicklist by caching the results of lpLength, thereby reducing redundant function calls. Additionally, minor refactoring has been performed to enhance code clarity, including renaming variables for improved readability.