### PR TITLE
Fix crash due to cron argv release

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2508,8 +2508,8 @@ int processMultibulkBuffer(client *c) {
         } else {
             /* Check if we have space in argv, grow if needed */
             if (c->argc >= c->argv_len) {
-                c->argv_len = c->argv_len > 0 ? c->argv_len*2 : 1; /* argv_len might be 0 if argv was
-                                                                    * released due to client timeout */
+                c->argv_len = c->argv_len > 0 ? c->argv_len*2 : 1; /* argv_len might be 0 if argv was released
+                                                                    * due to client being idle for 2 seconds. */
                 c->argv_len = min(c->argv_len < INT_MAX/2 ? c->argv_len : INT_MAX, c->argc+c->multibulklen);
                 c->argv = zrealloc(c->argv, sizeof(robj*)*c->argv_len);
             }

--- a/src/networking.c
+++ b/src/networking.c
@@ -2508,9 +2508,9 @@ int processMultibulkBuffer(client *c) {
         } else {
             /* Check if we have space in argv, grow if needed */
             if (c->argc >= c->argv_len) {
-                c->argv_len = c->argv_len > 0 ? c->argv_len*2 : 1; /* argv_len might be 0 if argv was released
-                                                                    * due to client being idle for 2 seconds. */
-                c->argv_len = min(c->argv_len < INT_MAX/2 ? c->argv_len : INT_MAX, c->argc+c->multibulklen);
+                /* argv_len might be 0 if argv was released due to client being idle for 2 seconds. */
+                c->argv_len = c->argv_len > 0 ? (c->argv_len < INT_MAX/2 ? c->argv_len*2 : INT_MAX) : 1;
+                c->argv_len = min(c->argv_len, c->argc+c->multibulklen);
                 c->argv = zrealloc(c->argv, sizeof(robj*)*c->argv_len);
             }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -2508,7 +2508,9 @@ int processMultibulkBuffer(client *c) {
         } else {
             /* Check if we have space in argv, grow if needed */
             if (c->argc >= c->argv_len) {
-                c->argv_len = min(c->argv_len < INT_MAX/2 ? c->argv_len*2 : INT_MAX, c->argc+c->multibulklen);
+                c->argv_len = c->argv_len > 0 ? c->argv_len*2 : 1; /* argv_len might be 0 if argv was
+                                                                    * released due to client timeout */
+                c->argv_len = min(c->argv_len < INT_MAX/2 ? c->argv_len : INT_MAX, c->argc+c->multibulklen);
                 c->argv = zrealloc(c->argv, sizeof(robj*)*c->argv_len);
             }
 
@@ -3996,7 +3998,7 @@ void replaceClientCommandVector(client *c, int argc, robj **argv) {
     retainOriginalCommandVector(c);
     freeClientArgv(c);
     c->argv = argv;
-    c->argc = argc;
+    c->argc = c->argv_len = argc;
     c->argv_len_sum = 0;
     for (j = 0; j < c->argc; j++)
         if (c->argv[j])

--- a/src/networking.c
+++ b/src/networking.c
@@ -2508,9 +2508,8 @@ int processMultibulkBuffer(client *c) {
         } else {
             /* Check if we have space in argv, grow if needed */
             if (c->argc >= c->argv_len) {
-                /* argv_len might be 0 if argv was released due to client being idle for 2 seconds. */
-                c->argv_len = c->argv_len > 0 ? (c->argv_len < INT_MAX/2 ? c->argv_len*2 : INT_MAX) : 1;
-                c->argv_len = min(c->argv_len, c->argc+c->multibulklen);
+                serverAssert(c->argv_len); /* Ensure argv is not freed while the client is in the mid of parsing command. */
+                c->argv_len = min(c->argv_len < INT_MAX/2 ? c->argv_len*2 : INT_MAX, c->argc+c->multibulklen);
                 c->argv = zrealloc(c->argv, sizeof(robj*)*c->argv_len);
             }
 

--- a/src/server.c
+++ b/src/server.c
@@ -788,7 +788,8 @@ int clientsCronResizeQueryBuffer(client *c) {
 
 /* If the client has been idle for too long, free the client's arguments. */
 int clientsCronFreeArgvIfIdle(client *c) {
-    /* If the client is in the mid of parsing command, exit ASAP. */
+    /* If the client is in the middle of parsing a command, or if argv is in use
+     * (e.g. parsed in the IO thread but not yet executed, or blocked), exit ASAP. */
     if (!c->argv || c->multibulklen || c->argc) return 0;
     time_t idletime = server.unixtime - c->lastinteraction;
     if (idletime > 2) {

--- a/src/server.c
+++ b/src/server.c
@@ -788,8 +788,8 @@ int clientsCronResizeQueryBuffer(client *c) {
 
 /* If the client has been idle for too long, free the client's arguments. */
 int clientsCronFreeArgvIfIdle(client *c) {
-    /* If the arguments have already been freed or are still in use, exit ASAP. */
-    if (!c->argv || c->argc) return 0;
+    /* If the client is in the mid of parsing command, exit ASAP. */
+    if (!c->argv || c->multibulklen || c->argc) return 0;
     time_t idletime = server.unixtime - c->lastinteraction;
     if (idletime > 2) {
         c->argv_len = 0;

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -248,3 +248,14 @@ start_server {tags {"regression"}} {
         $rd close
     }
 }
+
+start_server {tags {"regression"}} {
+    test "Regression for a crash with cron release of client arguments" {
+        r write "*3\r\n"
+        r flush
+        after 3000
+        r write "\$3\r\nSET\r\n\$3\r\nkey\r\n\$1\r\n0\r\n"
+        r flush
+        r read
+    } {OK}
+}

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -253,7 +253,7 @@ start_server {tags {"regression"}} {
     test "Regression for a crash with cron release of client arguments" {
         r write "*3\r\n"
         r flush
-        after 3000
+        after 3000 ;# wait for c->argv to be released due to timeout
         r write "\$3\r\nSET\r\n\$3\r\nkey\r\n\$1\r\n0\r\n"
         r flush
         r read


### PR DESCRIPTION
Introduced by https://github.com/redis/redis/issues/13521

If the client argv was released due to a timeout before sending the complete command, `argv_len` will be reset to 0.
When argv is parsed again and resized, requesting a length of 0 may result in argv being NULL, then leading to a crash.

And fix a bug that `argv_len` is not updated correctly in `replaceClientCommandVector()`.