### PR TITLE
Client argv object pool

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2769,7 +2769,6 @@ int processInputBuffer(client *c) {
 
         /* Multibulk processing could see a <= 0 length. */
         if (c->argc == 0) {
-            freeClientArgvInternal(c, 0);
             c->reqtype = 0;
             c->multibulklen = 0;
             c->bulklen = -1;

--- a/src/networking.c
+++ b/src/networking.c
@@ -1453,7 +1453,7 @@ void freeClientOriginalArgv(client *c) {
 static inline void freeClientArgvInternal(client *c, int free_argv) {
     int j;
     for (j = 0; j < c->argc; j++)
-        decrRefCount(c->argv[j]);
+        tryFreeObjectToArgvOjectPool(c->argv[j]);
     c->argc = 0;
     c->cmd = NULL;
     c->iolookedcmd = NULL;
@@ -2528,8 +2528,9 @@ int processMultibulkBuffer(client *c) {
                 c->querybuf = sdsnewlen(SDS_NOINIT,c->bulklen+2);
                 sdsclear(c->querybuf);
             } else {
-                c->argv[c->argc++] =
-                    createStringObject(c->querybuf+c->qb_pos,c->bulklen);
+                c->argv[c->argc++] = c->running_tid == IOTHREAD_MAIN_THREAD_ID ?
+                    tryAllocObjectFromArgvOjectPool(c->querybuf+c->qb_pos, c->bulklen) :
+                    createStringObject(c->querybuf+c->qb_pos, c->bulklen);
                 c->argv_len_sum += c->bulklen;
                 c->qb_pos += c->bulklen+2;
             }

--- a/src/object.c
+++ b/src/object.c
@@ -713,84 +713,56 @@ robj *getDecodedObject(robj *o) {
 }
 
 /* We create string object pools for client argv object to avoid memory allocation
- * and deallocation. These string objects use EMBSTR encoding to save memory.
- * As the header of string object with EMBSTR encoding has the fixed size of 20
- * bytes, and memory allocators are typically aligned to 8 bytes, the size of
- * string object with EMBSTR encoding will be 24, 32, 40, 48, 56, or 64 bytes.
- * so the significant length for storing data is 4, 12, 20, 28, 36, or 44 bytes.
- * We create a pool of string objects with different sizes, now we have 4 pools,
- * the object size is not larger than 48 bytes, i.e., the significant length is
- * not larger than 28 bytes.
- *
- * Typically used for commands, keys or fields with sizes smaller than 28, and
- * must not be no lager than OBJ_ENCODING_EMBSTR_SIZE_LIMIT. */
-#define CLIENT_ARGV_OBJECT_SIZE_LIMIT 28
-#define CLIENT_ARGV_OBJECT_POOL_BUCKETS 4
-#define CLIENT_ARGV_OBJECT_POOL_INIT_SIZE 16
-#define CLIENT_ARGV_OBJECT_POOL_MAX_SIZE 256
+ * and deallocation. The string objects use EMBSTR encoding to avoid memory waste.
+ * As memory allocators are typically aligned to 8 bytes, the size of string object
+ * with EMBSTR encoding will be 24, 32, 40, 48, 56, or 64 bytes. We create pools of
+ * string objects with different sizes, now we have 6 pools to cover all EMBSTR
+ * encoding string object with different sizes. */
+#define CLIENT_ARGV_OBJECT_POOL_NUM 6
+#define CLIENT_ARGV_OBJECT_POOL_INIT_COUNT 16
+#define CLIENT_ARGV_OBJECT_POOL_CAPACITY   256
 
 /* Create client argv object pools and initialize them. */
 clientArgvOjectPool *createClientArgvObjectPools(void) {
-    serverAssert(CLIENT_ARGV_OBJECT_SIZE_LIMIT <= OBJ_ENCODING_EMBSTR_SIZE_LIMIT);
-    serverAssert(CLIENT_ARGV_OBJECT_POOL_BUCKETS > 0 &&
-        (CLIENT_ARGV_OBJECT_POOL_BUCKETS-1)*8+4 >= CLIENT_ARGV_OBJECT_SIZE_LIMIT);
-
     clientArgvOjectPool *pools = zmalloc(sizeof(clientArgvOjectPool) *
-                                         CLIENT_ARGV_OBJECT_POOL_BUCKETS);
-    for (int i = 0; i < CLIENT_ARGV_OBJECT_POOL_BUCKETS; i++) {
+                                         CLIENT_ARGV_OBJECT_POOL_NUM);
+    for (int i = 0; i < CLIENT_ARGV_OBJECT_POOL_NUM; i++) {
         clientArgvOjectPool *pool = pools + i;
         pool->object_size = 4 + i*8;
-        pool->alloc_queue = zcalloc(sizeof(robj*)*CLIENT_ARGV_OBJECT_POOL_MAX_SIZE);
-        pool->alloc_index = 0;
-        pool->alloc_size = CLIENT_ARGV_OBJECT_POOL_INIT_SIZE;
-        for (int i = 0; i < pool->alloc_size; i++) {
-            pool->alloc_queue[i] =
-                createStringObject(SDS_NOINIT, pool->object_size);
+        pool->object_queue = zcalloc(sizeof(robj*)*CLIENT_ARGV_OBJECT_POOL_CAPACITY);
+        for (int i = 0; i < CLIENT_ARGV_OBJECT_POOL_INIT_COUNT; i++) {
+            pool->object_queue[i] = createStringObject(SDS_NOINIT, pool->object_size);
         }
-        pool->free_queue = zcalloc(sizeof(robj*)*CLIENT_ARGV_OBJECT_POOL_MAX_SIZE);
-        pool->free_size = 0;
-        pool->free_index = 0;
+        pool->head = 0;
+        pool->tail = CLIENT_ARGV_OBJECT_POOL_INIT_COUNT;
+        pool->count = CLIENT_ARGV_OBJECT_POOL_INIT_COUNT;
+        pool->capacity = CLIENT_ARGV_OBJECT_POOL_CAPACITY;
     }
     return pools;
 }
 
-/* Try to alloc a client argv object from the pool, if the length of the string
- * is larger than CLIENT_ARGV_OBJECT_SIZE_LIMIT, create a new string object.
+/* Try to get a client argv object from the pool, if the length of the string
+ * is larger than OBJ_ENCODING_EMBSTR_SIZE_LIMIT, create a new string object.
  * If the pool is empty, we try to alloc a new object. If the pool has objects,
  * just return the object from the pool. */
 robj *tryAllocObjectFromArgvOjectPool(const char *ptr, size_t len) {
-    if (len > CLIENT_ARGV_OBJECT_SIZE_LIMIT) return createStringObject(ptr, len);
+    if (len > OBJ_ENCODING_EMBSTR_SIZE_LIMIT) return createStringObject(ptr, len);
 
     robj* o = NULL;
-    struct sdshdr8 *sh = NULL;
     int pool_index = len <= 4 ? 0 : ((len-5)>>3)+1;
     clientArgvOjectPool *pool = &server.client_argv_object_pools[pool_index];
 
-    if (likely(pool->alloc_size > 0)) {
-        o = pool->alloc_queue[pool->alloc_index];
-        pool->alloc_queue[pool->alloc_index] = NULL;
-        pool->alloc_index++;
-        pool->alloc_size--;
+    if (likely(pool->count > 0)) {
+        o = pool->object_queue[pool->head];
+        pool->head = (pool->head + 1) % pool->capacity;
+        pool->count--;
     } else {
-        if (pool->free_size == 0) {
-            /* If both alloc queue and free queue are empty, create a new object
-             * with the specific size, so it will be replenished into the free
-             * queue when freeing. */
-            o = createStringObject(SDS_NOINIT, pool->object_size);
-        } else {
-            /* If alloc queue is empty, but free queue is not empty, then swap
-             * the alloc_queue and free_queue, and reset the index and size. */
-            robj **queue = pool->alloc_queue;
-            pool->alloc_queue = pool->free_queue;
-            pool->alloc_size = pool->free_size;
-            pool->alloc_index = 0;
-            pool->free_queue = queue;
-            pool->free_size = 0;
-            pool->free_index = 0;
-            return tryAllocObjectFromArgvOjectPool(ptr, len);
-        }
+        /* If object queue is empty, create a new object with the specific size,
+         * so it will be put into the object queue when freeing. */
+        o = createStringObject(SDS_NOINIT, pool->object_size);
     }
-    sh = (void*)(o + 1);
+
+    struct sdshdr8 *sh = (void*)(o + 1);
     sh->len = len;
     memcpy(sh->buf, ptr, len);
     sh->buf[len] = '\0';
@@ -798,27 +770,22 @@ robj *tryAllocObjectFromArgvOjectPool(const char *ptr, size_t len) {
 }
 
 /* Try to return an object to the pool when freeing a client argv object. */
-void tryFreeObjectToArgvOjectPool(robj *obj) {
-    int alloc_size;
-    if (obj->refcount > 1 || obj->encoding != OBJ_ENCODING_EMBSTR ||
-        (alloc_size = sdsalloc(obj->ptr)) > CLIENT_ARGV_OBJECT_SIZE_LIMIT)
-    {
-        decrRefCount(obj);
+void tryFreeObjectToArgvOjectPool(robj *o) {
+    if (o->refcount > 1 || o->encoding != OBJ_ENCODING_EMBSTR) {
+        decrRefCount(o);
         return;
     }
 
+    int alloc_size = sdsalloc(o->ptr);
     clientArgvOjectPool *pool = &server.client_argv_object_pools[alloc_size >> 3];
-    if (pool->object_size != alloc_size ||
-        pool->free_size >= CLIENT_ARGV_OBJECT_POOL_MAX_SIZE)
-    {
-        decrRefCount(obj);
+    if (pool->object_size != alloc_size || pool->count >= pool->capacity) {
+        decrRefCount(o);
         return;
     }
-    pool->free_queue[pool->free_index] = obj;
-    pool->free_index++;
-    pool->free_size++;
+    pool->object_queue[pool->tail] = o;
+    pool->tail = (pool->tail + 1) % pool->capacity;
+    pool->count++;
 }
-
 
 /* Compare two string objects via strcmp() or strcoll() depending on flags.
  * Note that the objects may be integer-encoded. In such a case we

--- a/src/object.c
+++ b/src/object.c
@@ -729,14 +729,14 @@ clientArgvOjectPool *createClientArgvObjectPools(void) {
     for (int i = 0; i < CLIENT_ARGV_OBJECT_POOL_NUM; i++) {
         clientArgvOjectPool *pool = pools + i;
         pool->object_size = 4 + i*8;
-        pool->object_queue = zcalloc(sizeof(robj*)*CLIENT_ARGV_OBJECT_POOL_CAPACITY);
-        for (int i = 0; i < CLIENT_ARGV_OBJECT_POOL_INIT_COUNT; i++) {
+        pool->count = CLIENT_ARGV_OBJECT_POOL_INIT_COUNT;
+        pool->capacity = CLIENT_ARGV_OBJECT_POOL_CAPACITY;
+        pool->object_queue = zcalloc(sizeof(robj*) * pool->capacity);
+        for (int i = 0; i < pool->count; i++) {
             pool->object_queue[i] = createStringObject(SDS_NOINIT, pool->object_size);
         }
         pool->head = 0;
-        pool->tail = CLIENT_ARGV_OBJECT_POOL_INIT_COUNT;
-        pool->count = CLIENT_ARGV_OBJECT_POOL_INIT_COUNT;
-        pool->capacity = CLIENT_ARGV_OBJECT_POOL_CAPACITY;
+        pool->tail = pool->count % pool->capacity;
     }
     return pools;
 }

--- a/src/object.c
+++ b/src/object.c
@@ -714,29 +714,33 @@ robj *getDecodedObject(robj *o) {
 
 /* We create string object pools for client argv object to avoid memory allocation
  * and deallocation. The string objects use EMBSTR encoding to avoid memory waste.
- * As memory allocators are typically aligned to 8 bytes, the size of string object
- * with EMBSTR encoding will be 24, 32, 40, 48, 56, or 64 bytes. We create pools of
- * string objects with different sizes, now we have 6 pools to cover all EMBSTR
- * encoding string object with different sizes. */
+ * As the header of string object with EMBSTR encoding has the fixed size of 20 bytes,
+ * and memory allocators are typically aligned to 8 bytes, the size of string object
+ * with EMBSTR encoding will be 24, 32, 40, 48, 56, or 64 bytes, so the significant
+ * length for storing data is 4, 12, 20, 28, 36, or 44 bytes. Now we create 6 pools
+ * to cover all EMBSTR encoding string object with different sizes. */
 #define CLIENT_ARGV_OBJECT_POOL_NUM 6
-#define CLIENT_ARGV_OBJECT_POOL_INIT_COUNT 16
-#define CLIENT_ARGV_OBJECT_POOL_CAPACITY   256
+#define CLIENT_ARGV_OBJECT_POOL_INIT_LOG 4 /* 16 */
+#define CLIENT_ARGV_OBJECT_POOL_CAPACITY_LOG 8 /* 256, powers of 2 allow fast % with & */
 
 /* Create client argv object pools and initialize them. */
 clientArgvOjectPool *createClientArgvObjectPools(void) {
+    serverAssert((CLIENT_ARGV_OBJECT_POOL_NUM-1)*8+4 == OBJ_ENCODING_EMBSTR_SIZE_LIMIT);
+    serverAssert(CLIENT_ARGV_OBJECT_POOL_INIT_LOG <= CLIENT_ARGV_OBJECT_POOL_CAPACITY_LOG);
+
     clientArgvOjectPool *pools = zmalloc(sizeof(clientArgvOjectPool) *
                                          CLIENT_ARGV_OBJECT_POOL_NUM);
     for (int i = 0; i < CLIENT_ARGV_OBJECT_POOL_NUM; i++) {
         clientArgvOjectPool *pool = pools + i;
         pool->object_size = 4 + i*8;
-        pool->count = CLIENT_ARGV_OBJECT_POOL_INIT_COUNT;
-        pool->capacity = CLIENT_ARGV_OBJECT_POOL_CAPACITY;
+        pool->count = 1 << CLIENT_ARGV_OBJECT_POOL_INIT_LOG;
+        pool->capacity = 1 << CLIENT_ARGV_OBJECT_POOL_CAPACITY_LOG;
         pool->object_queue = zcalloc(sizeof(robj*) * pool->capacity);
         for (int i = 0; i < pool->count; i++) {
             pool->object_queue[i] = createStringObject(SDS_NOINIT, pool->object_size);
         }
         pool->head = 0;
-        pool->tail = pool->count % pool->capacity;
+        pool->tail = pool->count & (pool->capacity - 1);
     }
     return pools;
 }
@@ -754,7 +758,7 @@ robj *tryAllocObjectFromArgvOjectPool(const char *ptr, size_t len) {
 
     if (likely(pool->count > 0)) {
         o = pool->object_queue[pool->head];
-        pool->head = (pool->head + 1) % pool->capacity;
+        pool->head = (pool->head + 1) & (pool->capacity - 1);
         pool->count--;
     } else {
         /* If object queue is empty, create a new object with the specific size,
@@ -783,7 +787,7 @@ void tryFreeObjectToArgvOjectPool(robj *o) {
         return;
     }
     pool->object_queue[pool->tail] = o;
-    pool->tail = (pool->tail + 1) % pool->capacity;
+    pool->tail = (pool->tail + 1) & (pool->capacity - 1);
     pool->count++;
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -712,6 +712,114 @@ robj *getDecodedObject(robj *o) {
     }
 }
 
+/* We create string object pools for client argv object to avoid memory allocation
+ * and deallocation. These string objects use EMBSTR encoding to save memory.
+ * As the header of string object with EMBSTR encoding has the fixed size of 20
+ * bytes, and memory allocators are typically aligned to 8 bytes, the size of
+ * string object with EMBSTR encoding will be 24, 32, 40, 48, 56, or 64 bytes.
+ * so the significant length for storing data is 4, 12, 20, 28, 36, or 44 bytes.
+ * We create a pool of string objects with different sizes, now we have 4 pools,
+ * the object size is not larger than 48 bytes, i.e., the significant length is
+ * not larger than 28 bytes.
+ *
+ * Typically used for commands, keys or fields with sizes smaller than 28, and
+ * must not be no lager than OBJ_ENCODING_EMBSTR_SIZE_LIMIT. */
+#define CLIENT_ARGV_OBJECT_SIZE_LIMIT 28
+#define CLIENT_ARGV_OBJECT_POOL_BUCKETS 4
+#define CLIENT_ARGV_OBJECT_POOL_INIT_SIZE 16
+#define CLIENT_ARGV_OBJECT_POOL_MAX_SIZE 256
+
+/* Create client argv object pools and initialize them. */
+clientArgvOjectPool *createClientArgvObjectPools(void) {
+    serverAssert(CLIENT_ARGV_OBJECT_SIZE_LIMIT <= OBJ_ENCODING_EMBSTR_SIZE_LIMIT);
+    serverAssert(CLIENT_ARGV_OBJECT_POOL_BUCKETS > 0 &&
+        (CLIENT_ARGV_OBJECT_POOL_BUCKETS-1)*8+4 >= CLIENT_ARGV_OBJECT_SIZE_LIMIT);
+
+    clientArgvOjectPool *pools = zmalloc(sizeof(clientArgvOjectPool) *
+                                         CLIENT_ARGV_OBJECT_POOL_BUCKETS);
+    for (int i = 0; i < CLIENT_ARGV_OBJECT_POOL_BUCKETS; i++) {
+        clientArgvOjectPool *pool = pools + i;
+        pool->object_size = 4 + i*8;
+        pool->alloc_queue = zcalloc(sizeof(robj*)*CLIENT_ARGV_OBJECT_POOL_MAX_SIZE);
+        pool->alloc_index = 0;
+        pool->alloc_size = CLIENT_ARGV_OBJECT_POOL_INIT_SIZE;
+        for (int i = 0; i < pool->alloc_size; i++) {
+            pool->alloc_queue[i] =
+                createStringObject(SDS_NOINIT, pool->object_size);
+        }
+        pool->free_queue = zcalloc(sizeof(robj*)*CLIENT_ARGV_OBJECT_POOL_MAX_SIZE);
+        pool->free_size = 0;
+        pool->free_index = 0;
+    }
+    return pools;
+}
+
+/* Try to alloc a client argv object from the pool, if the length of the string
+ * is larger than CLIENT_ARGV_OBJECT_SIZE_LIMIT, create a new string object.
+ * If the pool is empty, we try to alloc a new object. If the pool has objects,
+ * just return the object from the pool. */
+robj *tryAllocObjectFromArgvOjectPool(const char *ptr, size_t len) {
+    if (len > CLIENT_ARGV_OBJECT_SIZE_LIMIT) return createStringObject(ptr, len);
+
+    robj* o = NULL;
+    struct sdshdr8 *sh = NULL;
+    int pool_index = len <= 4 ? 0 : ((len-5)>>3)+1;
+    clientArgvOjectPool *pool = &server.client_argv_object_pools[pool_index];
+
+    if (likely(pool->alloc_size > 0)) {
+        o = pool->alloc_queue[pool->alloc_index];
+        pool->alloc_queue[pool->alloc_index] = NULL;
+        pool->alloc_index++;
+        pool->alloc_size--;
+    } else {
+        if (pool->free_size == 0) {
+            /* If both alloc queue and free queue are empty, create a new object
+             * with the specific size, so it will be replenished into the free
+             * queue when freeing. */
+            o = createStringObject(SDS_NOINIT, pool->object_size);
+        } else {
+            /* If alloc queue is empty, but free queue is not empty, then swap
+             * the alloc_queue and free_queue, and reset the index and size. */
+            robj **queue = pool->alloc_queue;
+            pool->alloc_queue = pool->free_queue;
+            pool->alloc_size = pool->free_size;
+            pool->alloc_index = 0;
+            pool->free_queue = queue;
+            pool->free_size = 0;
+            pool->free_index = 0;
+            return tryAllocObjectFromArgvOjectPool(ptr, len);
+        }
+    }
+    sh = (void*)(o + 1);
+    sh->len = len;
+    memcpy(sh->buf, ptr, len);
+    sh->buf[len] = '\0';
+    return o;
+}
+
+/* Try to return an object to the pool when freeing a client argv object. */
+void tryFreeObjectToArgvOjectPool(robj *obj) {
+    int alloc_size;
+    if (obj->refcount > 1 || obj->encoding != OBJ_ENCODING_EMBSTR ||
+        (alloc_size = sdsalloc(obj->ptr)) > CLIENT_ARGV_OBJECT_SIZE_LIMIT)
+    {
+        decrRefCount(obj);
+        return;
+    }
+
+    clientArgvOjectPool *pool = &server.client_argv_object_pools[alloc_size >> 3];
+    if (pool->object_size != alloc_size ||
+        pool->free_size >= CLIENT_ARGV_OBJECT_POOL_MAX_SIZE)
+    {
+        decrRefCount(obj);
+        return;
+    }
+    pool->free_queue[pool->free_index] = obj;
+    pool->free_index++;
+    pool->free_size++;
+}
+
+
 /* Compare two string objects via strcmp() or strcoll() depending on flags.
  * Note that the objects may be integer-encoded. In such a case we
  * use ll2string() to get a string representation of the numbers on the stack

--- a/src/server.c
+++ b/src/server.c
@@ -2709,6 +2709,7 @@ void initServer(void) {
     server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
     server.reply_buffer_resizing_enabled = 1;
     server.client_mem_usage_buckets = NULL;
+    server.client_argv_object_pools = createClientArgvObjectPools();
     resetReplicationBuffer();
 
     /* Make sure the locale is set on startup based on the config file. */

--- a/src/server.h
+++ b/src/server.h
@@ -1193,12 +1193,11 @@ typedef struct {
 #endif
 
 typedef struct {
-    int alloc_size;       /* Number of allocated objects. */
-    int alloc_index;      /* Index of the next slot to get an allocated object. */
-    robj **alloc_queue;   /* Queue of allocated objects. */
-    int free_size;        /* Number of freeing objects. */
-    int free_index;       /* Index of the next slot to store a freeing object. */
-    robj **free_queue;    /* Queue of freeing objects. */
+    int head;             /* Index of the getting object in pool. */
+    int tail;             /* Index of the putting object in pool. */
+    int count;            /* Number of objects in pool. */
+    int capacity;         /* Capacity of the pool. */
+    robj **object_queue;  /* Queue of objects. */
     int object_size;      /* Size of the object in this pool. */
 } clientArgvOjectPool;
 

--- a/src/server.h
+++ b/src/server.h
@@ -1192,6 +1192,16 @@ typedef struct {
 } clientReqResInfo;
 #endif
 
+typedef struct {
+    int alloc_size;       /* Number of allocated objects. */
+    int alloc_index;      /* Index of the next slot to get an allocated object. */
+    robj **alloc_queue;   /* Queue of allocated objects. */
+    int free_size;        /* Number of freeing objects. */
+    int free_index;       /* Index of the next slot to store a freeing object. */
+    robj **free_queue;    /* Queue of freeing objects. */
+    int object_size;      /* Size of the object in this pool. */
+} clientArgvOjectPool;
+
 typedef struct client {
     uint64_t id;            /* Client incremental unique ID. */
     uint64_t flags;         /* Client flags: CLIENT_* macros. */
@@ -1673,6 +1683,7 @@ struct redisServer {
     list *slaves, *monitors;    /* List of slaves and MONITORs */
     client *current_client;     /* The client that triggered the command execution (External or AOF). */
     client *executing_client;   /* The client executing the current command (possibly script or module). */
+    clientArgvOjectPool *client_argv_object_pools; /* Pools for client argv objects. */
 
 #ifdef LOG_REQ_RES
     char *req_res_logfile; /* Path of log file for logging all requests and their replies. If NULL, no logging will be performed */
@@ -2884,6 +2895,9 @@ robj *createZsetObject(void);
 robj *createZsetListpackObject(void);
 robj *createStreamObject(void);
 robj *createModuleObject(moduleType *mt, void *value);
+clientArgvOjectPool *createClientArgvObjectPools(void);
+robj *tryAllocObjectFromArgvOjectPool(const char *ptr, size_t len);
+void tryFreeObjectToArgvOjectPool(robj *obj);
 int getLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg);
 int getPositiveLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg);
 int getRangeLongFromObjectOrReply(client *c, robj *o, long min, long max, long *target, const char *msg);


### PR DESCRIPTION
### Introduction
From flame graph, we can see redis costs much CPU to create argv objects when parsing requests and free argv objects after command processed. For most commands, argv objects just are temporary variables and their size is a little small, so we create string object pools for client argv object to avoid memory allocation and deallocation, and these string objects use EMBSTR encoding to avoid memory waste.

As the header of string object with EMBSTR encoding has the fixed size of 20 bytes, and memory allocators are typically aligned to 8 bytes, the size of string object with EMBSTR encoding will be 24, 32, 40, 48, 56, or 64 bytes, so the significant length for storing data is 4, 12, 20, 28, 36, or 44 bytes. We create pools of string objects with different sizes, now we have 6 pools to cover all EMBSTR encoding string object with different sizes. Max total memory of all pool is 256*(24+32+40+48+56+64)= 67,584, init memory is 16*(24+32+40+48+56+64)=4,224.

For the implementation of client argv object pool, we adopt the circle queue method, we get an object from the object queue when allocing a new object for client argv, and try to return an object to the object queue when freeing a client argv object.

### Testing
**Single Thread**
About 10% improvement for `hset` pipeline mode, 2.7% for `set,get` pipeline mode
```
memtier_benchmark --test-time 180 "--pipeline" "10" "--data-size" "10" --command "HSET __key__ field1 __data__ field2 __data__ field3 __data__ field4 __data__ field5
 __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 10000000 -c 50 -t 4 --hide-histogram

Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Hsets      433628.00         4.60237         3.57500         9.94300        83.39100     78717.03 
Totals     433628.00         4.60237         3.57500         9.94300        83.39100    157434.06 

Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Hsets      479008.93         4.16619         3.30300         9.27100        82.30300     86956.29 
Totals     479008.93         4.16619         3.30300         9.27100        82.30300    173912.57



memtier_benchmark --test-time 180 "--pipeline" "10" --ratio 1:1 --key-pattern P:P --key-minimum=1 --key-maximum 3000000  -c 50 -t 4 --hide-histogram

Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets       415337.97          ---          ---         2.40386         2.27900         4.70300        33.47100     31892.46 
Gets       415337.97    415337.97         0.00         2.40386         2.27900         4.70300        33.47100     29864.45 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals     830675.94    415337.97         0.00         2.40386         2.27900         4.70300        33.47100     61756.91

Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets       426810.15          ---          ---         2.33951         2.23900         4.56700        32.38300     32772.98 
Gets       426810.15    426810.15         0.00         2.33951         2.23900         4.56700        32.38300     30688.94 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals     853620.30    426810.15         0.00         2.33951         2.23900         4.56700        32.38300     63461.92 
```

**Multi IO Thread**
About 13.6% improvement for `hset` pipeline mode, 3.85% for `set,get` pipeline mode
```
memtier_benchmark --test-time 180 "--pipeline" "10" "--data-size" "10" --command "HSET __key__ field1 __data__ field2 __data__ field3 __data__ field4 __data__ field5
 __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 10000000 -c 50 -t 4 --hide-histogram

Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Hsets      526326.80         3.79103         3.67900         7.96700        80.63900     95545.21 
Totals     526326.80         3.79103         3.67900         7.96700        80.63900    191090.42

Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
--------------------------------------------------------------------------------------------------
Hsets      598091.31         3.33615         3.14300         7.31100        79.29500    108572.84 
Totals     598091.31         3.33615         3.14300         7.31100        79.29500    217145.69 


memtier_benchmark --test-time 180 "--pipeline" "10" --ratio 1:1 --key-pattern P:P --key-minimum=1 --key-maximum 3000000  -c 50 -t 4 --hide-histogram
Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets       608945.86          ---          ---         1.63880         1.43900         2.56700        28.33500     46759.47 
Gets       608945.86    608945.86         0.00         1.63880         1.43900         2.56700        28.33500     43786.10 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals    1217891.72    608945.86         0.00         1.63880         1.43900         2.56700        28.33500     90545.57

Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets       632439.93          ---          ---         1.57785         1.37500         2.49500        27.67900     48562.86 
Gets       632439.93    632439.93         0.00         1.57785         1.37500         2.49500        27.67900     45474.77 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals    1264879.86    632439.93         0.00         1.57785         1.37500         2.49500        27.67900     94037.63
```