### PR TITLE
Rdb channel replication

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -727,6 +727,24 @@ repl-disable-tcp-nodelay no
 #
 # repl-backlog-ttl 3600
 
+# During a fullsync, the master may decide to send both the RDB file and the
+# replication stream to the replica in parallel. This approach shifts the
+# responsibility of buffering the replication stream to the replica during the
+# fullsync process. The replica accumulates the replication stream data until
+# the RDB file is fully loaded. Once the RDB delivery is completed and
+# successfully loaded, the replica begins processing and applying the
+# accumulated replication data to the db. The configuration below controls how
+# much replication data the replica can accumulate during a fullsync.
+#
+# When the replica reaches this limit, it will stop accumulating further data.
+# At this point, additional data accumulation may occur on the master side
+# depending on the 'client-output-buffer-limit <replica>' config of master.
+#
+# A value of 0 means replica inherits 'client-output-buffer-limit <replica>'
+# configuration to limit accumulation size.
+#
+# replica-full-sync-buffer-limit 0
+
 # The replica priority is an integer number published by Redis in the INFO
 # output. It is used by Redis Sentinel in order to select a replica to promote
 # into a master if the master is no longer working correctly.

--- a/redis.conf
+++ b/redis.conf
@@ -740,8 +740,8 @@ repl-disable-tcp-nodelay no
 # At this point, additional data accumulation may occur on the master side
 # depending on the 'client-output-buffer-limit <replica>' config of master.
 #
-# A value of 0 means replica inherits 'client-output-buffer-limit <replica>'
-# configuration to limit accumulation size.
+# A value of 0 means replica inherits hard limit of
+# 'client-output-buffer-limit <replica>' config to limit accumulation size.
 #
 # replica-full-sync-buffer-limit 0
 

--- a/src/config.c
+++ b/src/config.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2009-Present, Redis Ltd.
  * All rights reserved.
  *
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
+ *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2) or the Server Side Public License v1 (SSPLv1).
  *

--- a/src/config.c
+++ b/src/config.c
@@ -3076,6 +3076,7 @@ standardConfig static_configs[] = {
     createBoolConfig("lazyfree-lazy-user-flush", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_user_flush , 0, NULL, NULL),
     createBoolConfig("repl-disable-tcp-nodelay", NULL, MODIFIABLE_CONFIG, server.repl_disable_tcp_nodelay, 0, NULL, NULL),
     createBoolConfig("repl-diskless-sync", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.repl_diskless_sync, 1, NULL, NULL),
+    createBoolConfig("repl-rdb-channel", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.repl_rdb_channel, 1, NULL, NULL),
     createBoolConfig("aof-rewrite-incremental-fsync", NULL, MODIFIABLE_CONFIG, server.aof_rewrite_incremental_fsync, 1, NULL, NULL),
     createBoolConfig("no-appendfsync-on-rewrite", NULL, MODIFIABLE_CONFIG, server.aof_no_fsync_on_rewrite, 0, NULL, NULL),
     createBoolConfig("cluster-require-full-coverage", NULL, MODIFIABLE_CONFIG, server.cluster_require_full_coverage, 1, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3222,6 +3222,7 @@ standardConfig static_configs[] = {
     createLongLongConfig("proto-max-bulk-len", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024*1024, LONG_MAX, server.proto_max_bulk_len, 512ll*1024*1024, MEMORY_CONFIG, NULL, NULL), /* Bulk request max size */
     createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.repl_backlog_size, 1024*1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 1mb */
+    createLongLongConfig("replica-full-sync-buffer-limit", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.repl_full_sync_buffer_limit, 0, MEMORY_CONFIG, NULL, NULL), /* Default: Inherits 'client-output-buffer-limit <replica>' */
 
     /* Unsigned Long Long configs */
     createULongLongConfig("maxmemory", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory, 0, MEMORY_CONFIG, NULL, updateMaxmemory),

--- a/src/debug.c
+++ b/src/debug.c
@@ -2,6 +2,9 @@
  * Copyright (c) 2009-Present, Redis Ltd.
  * All rights reserved.
  *
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
+ *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2) or the Server Side Public License v1 (SSPLv1).
  *
@@ -483,6 +486,10 @@ void debugCommand(client *c) {
 "    In case RESET is provided the peak reset time will be restored to the default value",
 "REPLYBUFFER RESIZING <0|1>",
 "    Enable or disable the reply buffer resize cron job",
+"REPL-PAUSE <clear|after-fork|before-main-conn-psync|on-streaming-repl-buf>",
+"    Pause the server's main process during various replication steps.",
+"DELAY-RDB-CLIENT-FREE <seconds>",
+"    Grace period in seconds for replica main channel to establish psync.",
 "DICT-RESIZING <0|1>",
 "    Enable or disable the main dict and expire dict resizing.",
 "SCRIPT <LIST|<sha>>",
@@ -1017,6 +1024,23 @@ NULL
             addReplySubcommandSyntaxError(c);
             return;
         }
+        addReply(c, shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr, "repl-pause") && c->argc == 3) {
+        if (!strcasecmp(c->argv[2]->ptr, "clear")) {
+            server.repl_debug_pause = REPL_DEBUG_PAUSE_NONE;
+        } else if (!strcasecmp(c->argv[2]->ptr,"after-fork")) {
+            server.repl_debug_pause |= REPL_DEBUG_AFTER_FORK;
+        } else if (!strcasecmp(c->argv[2]->ptr, "before-main-conn-psync")) {
+            server.repl_debug_pause |= REPL_DEBUG_BEFORE_MAIN_CONN_PSYNC;
+        } else if (!strcasecmp(c->argv[2]->ptr, "on-streaming-repl-buf")) {
+            server.repl_debug_pause |= REPL_DEBUG_ON_STREAMING_REPL_BUF;
+        } else {
+            addReplySubcommandSyntaxError(c);
+            return;
+        }
+        addReply(c, shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr, "delay-rdb-client-free") && c->argc == 3) {
+        server.repl_delay_rdb_client_free = atoi(c->argv[2]->ptr);
         addReply(c, shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr, "dict-resizing") && c->argc == 3) {
         server.dict_resizing = atoi(c->argv[2]->ptr);
@@ -2581,6 +2605,12 @@ void applyWatchdogPeriod(void) {
         if (server.watchdog_period < min_period) server.watchdog_period = min_period;
         watchdogScheduleSignal(server.watchdog_period); /* Adjust the current timer. */
     }
+}
+
+void debugPauseProcess(void) {
+    serverLog(LL_NOTICE, "Process is about to stop.");
+    raise(SIGSTOP);
+    serverLog(LL_NOTICE, "Process has been continued.");
 }
 
 /* Positive input is sleep time in microseconds. Negative input is fractions

--- a/src/debug.c
+++ b/src/debug.c
@@ -486,10 +486,8 @@ void debugCommand(client *c) {
 "    In case RESET is provided the peak reset time will be restored to the default value",
 "REPLYBUFFER RESIZING <0|1>",
 "    Enable or disable the reply buffer resize cron job",
-"REPL-PAUSE <clear|after-fork|before-main-conn-psync|on-streaming-repl-buf>",
+"REPL-PAUSE <clear|after-fork|before-rdb-channel|on-streaming-repl-buf>",
 "    Pause the server's main process during various replication steps.",
-"DELAY-RDB-CLIENT-FREE <seconds>",
-"    Grace period in seconds for replica main channel to establish psync.",
 "DICT-RESIZING <0|1>",
 "    Enable or disable the main dict and expire dict resizing.",
 "SCRIPT <LIST|<sha>>",
@@ -1030,17 +1028,14 @@ NULL
             server.repl_debug_pause = REPL_DEBUG_PAUSE_NONE;
         } else if (!strcasecmp(c->argv[2]->ptr,"after-fork")) {
             server.repl_debug_pause |= REPL_DEBUG_AFTER_FORK;
-        } else if (!strcasecmp(c->argv[2]->ptr, "before-main-conn-psync")) {
-            server.repl_debug_pause |= REPL_DEBUG_BEFORE_MAIN_CONN_PSYNC;
+        } else if (!strcasecmp(c->argv[2]->ptr,"before-rdb-channel")) {
+            server.repl_debug_pause |= REPL_DEBUG_BEFORE_RDB_CHANNEL;
         } else if (!strcasecmp(c->argv[2]->ptr, "on-streaming-repl-buf")) {
             server.repl_debug_pause |= REPL_DEBUG_ON_STREAMING_REPL_BUF;
         } else {
             addReplySubcommandSyntaxError(c);
             return;
         }
-        addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "delay-rdb-client-free") && c->argc == 3) {
-        server.repl_delay_rdb_client_free = atoi(c->argv[2]->ptr);
         addReply(c, shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr, "dict-resizing") && c->argc == 3) {
         server.dict_resizing = atoi(c->argv[2]->ptr);

--- a/src/networking.c
+++ b/src/networking.c
@@ -1543,8 +1543,8 @@ void unlinkClient(client *c) {
         if (server.child_type) {
             /* connShutdown() may access TLS state. If this is a rdbchannel
              * client, bgsave fork is writing to the connection and TLS state in
-             * the main process is stale. To avoid accessing TLS state, calling
-             * shutdown() directly.*/
+             * the main process is stale. SSL_shutdown() involves a handshake,
+             * and it may block the caller when used with stale TLS state.*/
             if (c->flags & CLIENT_REPL_RDB_CHANNEL)
                 shutdown(c->conn->fd, SHUT_RDWR);
             else

--- a/src/networking.c
+++ b/src/networking.c
@@ -3086,6 +3086,7 @@ sds catClientInfoString(sds s, client *client) {
     if (client->flags & CLIENT_READONLY) *p++ = 'r';
     if (client->flags & CLIENT_NO_EVICT) *p++ = 'e';
     if (client->flags & CLIENT_NO_TOUCH) *p++ = 'T';
+    if (client->flags & CLIENT_REPL_RDB_CHANNEL) *p++ = 'C';
     if (p == flags) *p++ = 'N';
     *p++ = '\0';
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1750,7 +1750,7 @@ void freeClient(client *c) {
     /* Free data structures. */
     listRelease(c->reply);
     zfree(c->buf);
-    freeReplicaReferences(c);
+    freeReplicaReferencedReplBuffer(c);
     freeClientArgv(c);
     freeClientOriginalArgv(c);
     if (c->deferred_reply_errors)
@@ -1852,7 +1852,7 @@ void freeClientAsync(client *c) {
     c->flags |= CLIENT_CLOSE_ASAP;
     /* Replicas that was marked as CLIENT_CLOSE_ASAP should not keep the
      * replication backlog from been trimmed. */
-    if (c->flags & CLIENT_SLAVE) freeReplicaReferences(c);
+    if (c->flags & CLIENT_SLAVE) freeReplicaReferencedReplBuffer(c);
     listAddNodeTail(server.clients_to_close,c);
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -249,7 +249,7 @@ void putClientInPendingWriteQueue(client *c) {
      * writes at this stage. */
     if (!(c->flags & CLIENT_PENDING_WRITE) &&
         (c->replstate == REPL_STATE_NONE ||
-         c->replstate == SLAVE_STATE_BG_RDB_TRANSFER ||
+         c->replstate == SLAVE_STATE_SEND_BULK_AND_STREAM ||
          (c->replstate == SLAVE_STATE_ONLINE && !c->repl_start_cmd_stream_on_ack)))
     {
         /* Here instead of installing the write handler, we just flag the
@@ -4281,7 +4281,7 @@ void flushSlavesOutputBuffers(void) {
          *
          * 3. Obviously if the slave is not ONLINE.
          */
-        if ((slave->replstate == SLAVE_STATE_ONLINE || slave->replstate == SLAVE_STATE_BG_RDB_TRANSFER) &&
+        if ((slave->replstate == SLAVE_STATE_ONLINE || slave->replstate == SLAVE_STATE_SEND_BULK_AND_STREAM) &&
             !(slave->flags & CLIENT_CLOSE_ASAP) &&
             can_receive_writes &&
             !slave->repl_start_cmd_stream_on_ack &&

--- a/src/networking.c
+++ b/src/networking.c
@@ -184,8 +184,7 @@ client *createClient(connection *conn) {
     c->slave_addr = NULL;
     c->slave_capa = SLAVE_CAPA_NONE;
     c->slave_req = SLAVE_REQ_NONE;
-    c->rdb_client_id = 0;
-    c->rdb_client_disconnect_time = 0;
+    c->main_ch_client_id = 0;
     c->reply = listCreate();
     c->deferred_reply_errors = NULL;
     c->reply_bytes = 0;
@@ -1661,7 +1660,7 @@ void freeClient(client *c) {
 
     /* If a client is protected, yet we need to free it right now, make sure
      * to at least use asynchronous freeing. */
-    if (c->flags & (CLIENT_PROTECTED | CLIENT_PROTECTED_RDB_CHANNEL)) {
+    if (c->flags & CLIENT_PROTECTED) {
         freeClientAsync(c);
         return;
     }
@@ -1718,8 +1717,8 @@ void freeClient(client *c) {
 
     /* Log link disconnection with slave */
     if (clientTypeIsSlave(c)) {
-        const char *type = c->flags & CLIENT_REPL_RDB_CHANNEL ? "(rdbchannel)" : "";
-        serverLog(LL_NOTICE,"Connection with replica %s %s lost.", type,
+        const char *type = c->flags & CLIENT_REPL_RDB_CHANNEL ? " (rdbchannel)" : "";
+        serverLog(LL_NOTICE,"Connection with replica%s %s lost.", type,
             replicationGetSlaveName(c));
     }
 
@@ -1751,7 +1750,7 @@ void freeClient(client *c) {
     /* Free data structures. */
     listRelease(c->reply);
     zfree(c->buf);
-    freeReplicaReferencedReplBuffer(c);
+    freeReplicaReferences(c);
     freeClientArgv(c);
     freeClientOriginalArgv(c);
     if (c->deferred_reply_errors)
@@ -1853,8 +1852,7 @@ void freeClientAsync(client *c) {
     c->flags |= CLIENT_CLOSE_ASAP;
     /* Replicas that was marked as CLIENT_CLOSE_ASAP should not keep the
      * replication backlog from been trimmed. */
-    if (c->flags & CLIENT_SLAVE && !(c->flags & CLIENT_PROTECTED_RDB_CHANNEL))
-        freeReplicaReferencedReplBuffer(c);
+    if (c->flags & CLIENT_SLAVE) freeReplicaReferences(c);
     listAddNodeTail(server.clients_to_close,c);
 }
 
@@ -1912,31 +1910,6 @@ int freeClientsInAsyncFreeQueue(void) {
     listRewind(server.clients_to_close,&li);
     while ((ln = listNext(&li)) != NULL) {
         client *c = listNodeValue(ln);
-
-        if (c->flags & CLIENT_PROTECTED_RDB_CHANNEL) {
-            /* Check if it's safe to remove RDB connection protection during
-             * synchronization. The master gives a grace period before freeing
-             * this client because it serves as a reference to the first
-             * required replication data block for this replica */
-            if (!c->rdb_client_disconnect_time) {
-                if (c->conn)
-                    connSetReadHandler(c->conn, NULL);
-                c->rdb_client_disconnect_time = server.unixtime;
-                serverLog(LL_VERBOSE, "Postponed RDB client id=%"PRIu64" (%s) free for %d seconds",
-                          c->id, replicationGetSlaveName(c),
-                          server.repl_delay_rdb_client_free);
-            }
-
-            time_t time_passed = server.unixtime - c->rdb_client_disconnect_time;
-            if (time_passed <= server.repl_delay_rdb_client_free)
-                continue;
-
-            serverLog(LL_NOTICE,
-                      "Replica main channel failed to establish PSYNC within the grace period (%lld seconds). "
-                      "Freeing RDB client: %"PRIu64".",
-                      (long long int) time_passed, c->id);
-            c->flags &= ~CLIENT_PROTECTED_RDB_CHANNEL;
-        }
 
         if (c->flags & CLIENT_PROTECTED) continue;
 
@@ -4258,13 +4231,11 @@ int closeClientOnOutputBufferLimitReached(client *c, int async) {
     /* Note that c->reply_bytes is irrelevant for replica clients
      * (they use the global repl buffers). */
     if ((c->reply_bytes == 0 && !clientTypeIsSlave(c)) ||
-        (c->flags & CLIENT_CLOSE_ASAP && !(c->flags & CLIENT_PROTECTED_RDB_CHANNEL)))
-           return 0;
+        c->flags & CLIENT_CLOSE_ASAP) return 0;
     if (checkClientOutputBufferLimits(c)) {
         sds client = catClientInfoString(sdsempty(),c);
 
-        if (async || c->flags & CLIENT_PROTECTED_RDB_CHANNEL) {
-            c->flags &= ~CLIENT_PROTECTED_RDB_CHANNEL;
+        if (async) {
             freeClientAsync(c);
             serverLog(LL_WARNING,
                       "Client %s scheduled to be closed ASAP for overcoming of output buffer limits.",

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2,6 +2,9 @@
  * Copyright (c) 2009-Present, Redis Ltd.
  * All rights reserved.
  *
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
+ *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2) or the Server Side Public License v1 (SSPLv1).
  */
@@ -3803,15 +3806,17 @@ static void backgroundSaveDoneHandlerSocket(int exitcode, int bysignal) {
         serverLog(LL_NOTICE,
             "Background RDB transfer terminated with success");
     } else if (!bysignal && exitcode != 0) {
-        serverLog(LL_WARNING, "Background transfer error");
+        serverLog(LL_WARNING, "Background RDB transfer error");
     } else {
         serverLog(LL_WARNING,
-            "Background transfer terminated by signal %d", bysignal);
+            "Background RDB transfer terminated by signal %d", bysignal);
     }
     if (server.rdb_child_exit_pipe!=-1)
         close(server.rdb_child_exit_pipe);
-    aeDeleteFileEvent(server.el, server.rdb_pipe_read, AE_READABLE);
-    close(server.rdb_pipe_read);
+    if (server.rdb_pipe_read != -1) {
+        aeDeleteFileEvent(server.el, server.rdb_pipe_read, AE_READABLE);
+        close(server.rdb_pipe_read);
+    }
     server.rdb_child_exit_pipe = -1;
     server.rdb_pipe_read = -1;
     zfree(server.rdb_pipe_conns);
@@ -3875,7 +3880,8 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
     listNode *ln;
     listIter li;
     pid_t childpid;
-    int pipefds[2], rdb_pipe_write, safe_to_exit_pipe;
+    int pipefds[2], rdb_pipe_write = 0, safe_to_exit_pipe = 0;
+    int rdb_channel = (req & SLAVE_REQ_RDB_CHANNEL);
 
     if (hasActiveChildProcess()) return C_ERR;
 
@@ -3883,29 +3889,30 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
      * drained the pipe. */
     if (server.rdb_pipe_conns) return C_ERR;
 
-    /* Before to fork, create a pipe that is used to transfer the rdb bytes to
-     * the parent, we can't let it write directly to the sockets, since in case
-     * of TLS we must let the parent handle a continuous TLS state when the
-     * child terminates and parent takes over. */
-    if (anetPipe(pipefds, O_NONBLOCK, 0) == -1) return C_ERR;
-    server.rdb_pipe_read = pipefds[0]; /* read end */
-    rdb_pipe_write = pipefds[1]; /* write end */
+    if (!rdb_channel) {
+        /* Before to fork, create a pipe that is used to transfer the rdb bytes to
+         * the parent, we can't let it write directly to the sockets, since in case
+         * of TLS we must let the parent handle a continuous TLS state when the
+         * child terminates and parent takes over. */
+        if (anetPipe(pipefds, O_NONBLOCK, 0) == -1) return C_ERR;
+        server.rdb_pipe_read = pipefds[0]; /* read end */
+        rdb_pipe_write = pipefds[1]; /* write end */
 
-    /* create another pipe that is used by the parent to signal to the child
-     * that it can exit. */
-    if (anetPipe(pipefds, 0, 0) == -1) {
-        close(rdb_pipe_write);
-        close(server.rdb_pipe_read);
-        return C_ERR;
+        /* create another pipe that is used by the parent to signal to the child
+         * that it can exit. */
+        if (anetPipe(pipefds, 0, 0) == -1) {
+            close(rdb_pipe_write);
+            close(server.rdb_pipe_read);
+            return C_ERR;
+        }
+        safe_to_exit_pipe = pipefds[0]; /* read end */
+        server.rdb_child_exit_pipe = pipefds[1]; /* write end */
     }
-    safe_to_exit_pipe = pipefds[0]; /* read end */
-    server.rdb_child_exit_pipe = pipefds[1]; /* write end */
 
     /* Collect the connections of the replicas we want to transfer
-     * the RDB to, which are i WAIT_BGSAVE_START state. */
-    server.rdb_pipe_conns = zmalloc(sizeof(connection *)*listLength(server.slaves));
-    server.rdb_pipe_numconns = 0;
-    server.rdb_pipe_numconns_writing = 0;
+     * the RDB to, which are in WAIT_BGSAVE_START state. */
+    int numconns = 0;
+    connection **conns = zmalloc(sizeof(*conns) * listLength(server.slaves));
     listRewind(server.slaves,&li);
     while((ln = listNext(&li))) {
         client *slave = ln->value;
@@ -3913,9 +3920,20 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
             /* Check slave has the exact requirements */
             if (slave->slave_req != req)
                 continue;
-            server.rdb_pipe_conns[server.rdb_pipe_numconns++] = slave->conn;
-            replicationSetupSlaveForFullResync(slave,getPsyncInitialOffset());
+            replicationSetupSlaveForFullResync(slave, getPsyncInitialOffset());
+            conns[numconns++] = slave->conn;
+            if (rdb_channel) {
+                /* Put the socket in blocking mode to simplify RDB transfer. */
+                connSendTimeout(slave->conn, server.repl_timeout * 1000);
+                connBlock(slave->conn);
+            }
         }
+    }
+
+    if (!rdb_channel) {
+        server.rdb_pipe_conns = conns;
+        server.rdb_pipe_numconns = numconns;
+        server.rdb_pipe_numconns_writing = 0;
     }
 
     /* Create the child process. */
@@ -3924,11 +3942,14 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
         int retval, dummy;
         rio rdb;
 
-        rioInitWithFd(&rdb,rdb_pipe_write);
-
-        /* Close the reading part, so that if the parent crashes, the child will
-         * get a write error and exit. */
-        close(server.rdb_pipe_read);
+        if (rdb_channel) {
+            rioInitWithConnset(&rdb, conns, numconns);
+        } else {
+            rioInitWithFd(&rdb,rdb_pipe_write);
+            /* Close the reading part, so that if the parent crashes, the child
+             * will get a write error and exit. */
+            close(server.rdb_pipe_read);
+        }
 
         redisSetProcTitle("redis-rdb-to-slaves");
         redisSetCpuAffinity(server.bgsave_cpulist);
@@ -3941,14 +3962,19 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
             sendChildCowInfo(CHILD_INFO_TYPE_RDB_COW_SIZE, "RDB");
         }
 
-        rioFreeFd(&rdb);
-        /* wake up the reader, tell it we're done. */
-        close(rdb_pipe_write);
-        close(server.rdb_child_exit_pipe); /* close write end so that we can detect the close on the parent. */
-        /* hold exit until the parent tells us it's safe. we're not expecting
-         * to read anything, just get the error when the pipe is closed. */
-        dummy = read(safe_to_exit_pipe, pipefds, 1);
-        UNUSED(dummy);
+        if (rdb_channel) {
+            rioFreeConnset(&rdb);
+        } else {
+            rioFreeFd(&rdb);
+            /* wake up the reader, tell it we're done. */
+            close(rdb_pipe_write);
+            close(server.rdb_child_exit_pipe); /* close write end so that we can detect the close on the parent. */
+            /* hold exit until the parent tells us it's safe. we're not expecting
+             * to read anything, just get the error when the pipe is closed. */
+            dummy = read(safe_to_exit_pipe, pipefds, 1);
+            UNUSED(dummy);
+        }
+        zfree(conns);
         exitFromChild((retval == C_OK) ? 0 : 1);
     } else {
         /* Parent */
@@ -3966,24 +3992,33 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
                     slave->replstate = SLAVE_STATE_WAIT_BGSAVE_START;
                 }
             }
-            close(rdb_pipe_write);
-            close(server.rdb_pipe_read);
-            close(server.rdb_child_exit_pipe);
-            zfree(server.rdb_pipe_conns);
-            server.rdb_pipe_conns = NULL;
-            server.rdb_pipe_numconns = 0;
-            server.rdb_pipe_numconns_writing = 0;
+
+            if (!rdb_channel)  {
+                close(rdb_pipe_write);
+                close(server.rdb_pipe_read);
+                close(server.rdb_child_exit_pipe);
+                zfree(server.rdb_pipe_conns);
+                server.rdb_pipe_conns = NULL;
+                server.rdb_pipe_numconns = 0;
+                server.rdb_pipe_numconns_writing = 0;
+            }
         } else {
-            serverLog(LL_NOTICE,"Background RDB transfer started by pid %ld",
-                (long) childpid);
+            serverLog(LL_NOTICE, "Background RDB transfer started by pid %ld to %s", (long)childpid,
+                      rdb_channel ? "replica socket" : "parent process pipe");
             server.rdb_save_time_start = time(NULL);
             server.rdb_child_type = RDB_CHILD_TYPE_SOCKET;
-            close(rdb_pipe_write); /* close write in parent so that it can detect the close on the child. */
-            if (aeCreateFileEvent(server.el, server.rdb_pipe_read, AE_READABLE, rdbPipeReadHandler,NULL) == AE_ERR) {
-                serverPanic("Unrecoverable error creating server.rdb_pipe_read file event.");
+            if (!rdb_channel) {
+                close(rdb_pipe_write); /* close write in parent so that it can detect the close on the child. */
+                if (aeCreateFileEvent(server.el, server.rdb_pipe_read, AE_READABLE, rdbPipeReadHandler,NULL) == AE_ERR) {
+                    serverPanic("Unrecoverable error creating server.rdb_pipe_read file event.");
+                }
             }
         }
-        close(safe_to_exit_pipe);
+        if (rdb_channel)
+            zfree(conns);
+        else
+            close(safe_to_exit_pipe);
+
         return (childpid == -1) ? C_ERR : C_OK;
     }
     return C_OK; /* Unreached. */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3806,10 +3806,10 @@ static void backgroundSaveDoneHandlerSocket(int exitcode, int bysignal) {
         serverLog(LL_NOTICE,
             "Background RDB transfer terminated with success");
     } else if (!bysignal && exitcode != 0) {
-        serverLog(LL_WARNING, "Background RDB transfer error");
+        serverLog(LL_WARNING, "Background transfer error");
     } else {
         serverLog(LL_WARNING,
-            "Background RDB transfer terminated by signal %d", bysignal);
+            "Background transfer terminated by signal %d", bysignal);
     }
     if (server.rdb_child_exit_pipe!=-1)
         close(server.rdb_child_exit_pipe);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -7,6 +7,8 @@
  *
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2) or the Server Side Public License v1 (SSPLv1).
+ *
+ * Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
  */
 
 #include "server.h"

--- a/src/replication.c
+++ b/src/replication.c
@@ -3606,7 +3606,7 @@ static int rdbChannelHandleReplconfReply(connection *conn, sds *err) {
 /* Replication: Replica side. */
 static int rdbChannelHandleFullresyncReply(connection *conn, sds *err) {
     long long reploff = 0;
-    uint64_t rdb_client_id = 0;
+    unsigned long long rdb_client_id = 0;
     char replid[CONFIG_RUN_ID_SIZE + 1] = {0};
 
     *err = receiveSynchronousResponse(conn);
@@ -3620,7 +3620,7 @@ static int rdbChannelHandleFullresyncReply(connection *conn, sds *err) {
     }
 
     /* Parse +FULLRESYNC reply */
-    if (sscanf(*err, "+FULLRESYNC %40s %lld %"PRIu64"",
+    if (sscanf(*err, "+FULLRESYNC %40s %lld %llu",
                replid, &reploff, &rdb_client_id) != 3)
     {
         serverLog(LL_WARNING, "Received unexpected psync reply: %s", *err);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1204,7 +1204,7 @@ void syncCommand(client *c) {
  * the master can accurately lists replicas and their listening ports in the
  * INFO output.
  *
- * - capa <eof|psync2>
+ * - capa <eof|psync2|rdb-channel-repl>
  * What is the capabilities of this instance.
  * eof: supports EOF-style RDB transfer for diskless replication.
  * psync2: supports PSYNC v2, so understands +CONTINUE <new repl ID>.

--- a/src/replication.c
+++ b/src/replication.c
@@ -12,6 +12,19 @@
  * Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
  */
 
+/*
+ * replication.c - Replication Management
+ *
+ * This file contains the implementation of Redis's replication logic, which
+ * enables data synchronization between master and replica instances.
+ * It handles:
+ * - Master-to-replica synchronization
+ * - Full and partial resynchronizations
+ * - Replication backlog management
+ * - State machines for replica operations
+ * - RDB Channel for Full Sync  (lookup "rdb channel for full sync")
+ */
+
 #include "server.h"
 #include "cluster.h"
 #include "bio.h"
@@ -31,11 +44,26 @@ void replicationSendAck(void);
 int replicaPutOnline(client *slave);
 void replicaStartCommandStream(client *slave);
 int cancelReplicationHandshake(int reconnect);
+static void rdbChannelAttachToBacklog(client *slave);
+static void rdbChannelAttachReplicasToBacklog(void);
+static void rdbChannelSetupMainConnForPsync(connection *conn);
+static void rdbChannelHandleRdbLoadCompletion(void);
+static void rdbChannelFullSyncWithMaster(connection *conn);
+static client *rdbChannelLookupRdbClient(uint64_t id);
+static int rdbChannelAbortRdbTransfer(void);
 
 /* We take a global flag to remember if this instance generated an RDB
  * because of replication, so that we can remove the RDB file in case
  * the instance is configured to have no persistence. */
 int RDBGeneratedByReplication = 0;
+
+
+/* A reference to diskless loading rio to abort it asynchronously. It's needed
+ * for rdbchannel replication. While loading from rdbchannel connection, we may
+ * yield back to eventloop. If main channel connection detects a network problem
+ * we want to abort loading. It calls rioAbort() in this case, so next rioRead()
+ * from rdbchannel connection will return error to cancel loading safely. */
+static rio *diskless_loading_rio = NULL;
 
 /* --------------------------- Utility functions ---------------------------- */
 static ConnectionType *connTypeOfReplication(void) {
@@ -307,6 +335,17 @@ void freeReplicaReferencedReplBuffer(client *replica) {
     }
     replica->ref_repl_buf_node = NULL;
     replica->ref_block_pos = 0;
+
+    if (replica->flags & CLIENT_REPL_RDB_CHANNEL) {
+        if (raxRemove(server.replicas_waiting_psync,
+                      (unsigned char *)&replica->id, sizeof(replica->id), NULL))
+        {
+            serverLog(LL_DEBUG, "Removed replica %s with client_id=%"PRIu64""
+                                " from psync waiting list.",
+                                replicationGetSlaveName(replica), replica->id);
+        }
+        replica->flags &= ~CLIENT_PROTECTED_RDB_CHANNEL;
+    }
 }
 
 /* Append bytes into the global replication buffer list, replication backlog and
@@ -325,6 +364,7 @@ void feedReplicationBuffer(char *s, size_t len) {
         int add_new_block = 0; /* Create new block if current block is total used. */
         listNode *ln = listLast(server.repl_buffer_blocks);
         replBufBlock *tail = ln ? listNodeValue(ln) : NULL;
+        int empty_backlog = (tail == NULL);
 
         /* Append to tail string when possible. */
         if (tail && tail->size > tail->used) {
@@ -372,13 +412,18 @@ void feedReplicationBuffer(char *s, size_t len) {
             server.master_repl_offset += copy;
             server.repl_backlog->histlen += copy;
         }
+        if (empty_backlog && raxSize(server.replicas_waiting_psync) > 0) {
+            /* This is the first block. Attach replicas to it. */
+            rdbChannelAttachReplicasToBacklog();
+        }
 
         /* For output buffer of replicas. */
         listIter li;
         listRewind(server.slaves,&li);
         while((ln = listNext(&li))) {
             client *slave = ln->value;
-            if (!canFeedReplicaReplBuffer(slave)) continue;
+            if (!canFeedReplicaReplBuffer(slave) && !(slave->flags & CLIENT_PROTECTED_RDB_CHANNEL))
+                continue;
 
             /* Update shared replication buffer start position. */
             if (slave->ref_repl_buf_node == NULL) {
@@ -689,7 +734,7 @@ long long getPsyncInitialOffset(void) {
  * BGSAVE for replication was started, or when there is one already in
  * progress that we attached our slave to. */
 int replicationSetupSlaveForFullResync(client *slave, long long offset) {
-    char buf[128];
+    char buf[256];
     int buflen;
 
     slave->psync_initial_offset = offset;
@@ -702,8 +747,16 @@ int replicationSetupSlaveForFullResync(client *slave, long long offset) {
     /* Don't send this reply to slaves that approached us with
      * the old SYNC command. */
     if (!(slave->flags & CLIENT_PRE_PSYNC)) {
-        buflen = snprintf(buf,sizeof(buf),"+FULLRESYNC %s %lld\r\n",
-                          server.replid,offset);
+        if (slave->slave_req & SLAVE_REQ_RDB_CHANNEL) {
+            rdbChannelAttachToBacklog(slave);
+            buflen = snprintf(buf,sizeof(buf),"+FULLRESYNC %s %lld %llu\r\n",
+                              server.replid,offset,
+                              (unsigned long long) slave->id);
+        } else {
+            buflen = snprintf(buf,sizeof(buf),"+FULLRESYNC %s %lld\r\n",
+                              server.replid,offset);
+        }
+
         if (connWrite(slave->conn,buf,buflen) != buflen) {
             freeClientAsync(slave);
             return C_ERR;
@@ -748,8 +801,9 @@ int masterTryPartialResynchronization(client *c, long long psync_offset) {
                     "up to %lld", psync_offset, server.second_replid_offset);
             }
         } else {
-            serverLog(LL_NOTICE,"Full resync requested by replica %s",
-                replicationGetSlaveName(c));
+            serverLog(LL_NOTICE,"Full resync requested by replica %s %s",
+                replicationGetSlaveName(c),
+                c->flags & CLIENT_REPL_RDB_CHANNEL ? "(rdbchannel)" : "");
         }
         goto need_full_resync;
     }
@@ -773,9 +827,15 @@ int masterTryPartialResynchronization(client *c, long long psync_offset) {
      * 2) Inform the client we can continue with +CONTINUE
      * 3) Send the backlog data (from the offset to the end) to the slave. */
     c->flags |= CLIENT_SLAVE;
-    c->replstate = SLAVE_STATE_ONLINE;
     c->repl_ack_time = server.unixtime;
     c->repl_start_cmd_stream_on_ack = 0;
+    /* Rdb channel holds a reference to the backlog to prevent it being freed
+     * until main channel establishes psync. Check if there is an associated
+     * rdb channel with this replica. If so, it means psync from main channel
+     * has been established. After attaching main channel to the backlog, we can
+     * remove the rdb channel reference.*/
+    client *rdb_client = rdbChannelLookupRdbClient(c->rdb_client_id);
+    c->replstate = rdb_client ? SLAVE_STATE_BG_RDB_TRANSFER: SLAVE_STATE_ONLINE;
     listAddNodeTail(server.slaves,c);
     /* We can't use the connection buffers since they are used to accumulate
      * new commands at this stage. But we are sure the socket send buffer is
@@ -798,12 +858,16 @@ int masterTryPartialResynchronization(client *c, long long psync_offset) {
      * to -1 to force the master to emit SELECT, since the slave already
      * has this state from the previous connection with the master. */
 
-    refreshGoodSlavesCount();
+    if (c->replstate == SLAVE_STATE_BG_RDB_TRANSFER) {
+        freeReplicaReferencedReplBuffer(rdb_client);
+    } else {
+        refreshGoodSlavesCount();
 
-    /* Fire the replica change modules event. */
-    moduleFireServerEvent(REDISMODULE_EVENT_REPLICA_CHANGE,
-                          REDISMODULE_SUBEVENT_REPLICA_CHANGE_ONLINE,
-                          NULL);
+        /* Fire the replica change modules event. */
+        moduleFireServerEvent(REDISMODULE_EVENT_REPLICA_CHANGE,
+                              REDISMODULE_SUBEVENT_REPLICA_CHANGE_ONLINE,
+                              NULL);
+    }
 
     return C_OK; /* The caller can return, no full resync needed. */
 
@@ -846,8 +910,9 @@ int startBgsaveForReplication(int mincapa, int req) {
     /* `SYNC` should have failed with error if we don't support socket and require a filter, assert this here */
     serverAssert(socket_target || !(req & SLAVE_REQ_RDB_MASK));
 
-    serverLog(LL_NOTICE,"Starting BGSAVE for SYNC with target: %s",
-        socket_target ? "replicas sockets" : "disk");
+    serverLog(LL_NOTICE,"Starting BGSAVE for SYNC with target: %s%s",
+        socket_target ? "replicas sockets" : "disk",
+        (req & SLAVE_REQ_RDB_CHANNEL) ? " (rdb-channel)." : ".");
 
     rdbSaveInfo rsi, *rsiptr;
     rsiptr = rdbPopulateSaveInfo(&rsi);
@@ -860,6 +925,8 @@ int startBgsaveForReplication(int mincapa, int req) {
             /* Keep the page cache since it'll get used soon */
             retval = rdbSaveBackground(req, server.rdb_filename, rsiptr, RDBFLAGS_REPLICATION | RDBFLAGS_KEEP_CACHE);
         }
+        if (server.repl_debug_pause & REPL_DEBUG_AFTER_FORK)
+            debugPauseProcess();
     } else {
         serverLog(LL_WARNING,"BGSAVE for replication: replication information not available, can't generate the RDB file right now. Try later.");
         retval = C_ERR;
@@ -1007,6 +1074,17 @@ void syncCommand(client *c) {
              * resync on purpose when they are not able to partially
              * resync. */
             if (master_replid[0] != '?') server.stat_sync_partial_err++;
+            if (c->slave_capa & SLAVE_CAPA_RDB_CHANNEL_REPL) {
+                serverLog(LL_NOTICE,
+                          "Replica %s is capable of rdb channel synchronization, and partial sync isn't possible. "
+                          "Full sync will continue with dedicated RDB channel.",
+                          replicationGetSlaveName(c));
+                const char *buf = "+RDBCHANNELSYNC\r\n";
+                if (connWrite(c->conn, buf, strlen(buf)) != (int)strlen(buf))
+                    freeClientAsync(c);
+
+                return;
+            }
         }
     } else {
         /* If a slave uses SYNC, we are dealing with an old implementation
@@ -1146,7 +1224,11 @@ void syncCommand(client *c) {
  * - rdb-filter-only <include-filters>
  * Define "include" filters for the RDB snapshot. Currently we only support
  * a single include filter: "functions". Passing an empty string "" will
- * result in an empty RDB. */
+ * result in an empty RDB.
+ *
+ * - set-rdb-client-id <client-id>
+ * Replica's main channel informs master that this is the main channel of the
+ * rdb channel identified by the client-id. */
 void replconfCommand(client *c) {
     int j;
 
@@ -1182,6 +1264,10 @@ void replconfCommand(client *c) {
                 c->slave_capa |= SLAVE_CAPA_EOF;
             else if (!strcasecmp(c->argv[j+1]->ptr,"psync2"))
                 c->slave_capa |= SLAVE_CAPA_PSYNC2;
+            else if (!strcasecmp(c->argv[j+1]->ptr,"rdb-channel-repl") && server.repl_rdb_channel &&
+                     server.repl_diskless_sync) {
+                c->slave_capa |= SLAVE_CAPA_RDB_CHANNEL_REPL;
+            }
         } else if (!strcasecmp(c->argv[j]->ptr,"ack")) {
             /* REPLCONF ACK is used by slave to inform the master the amount
              * of replication stream that it processed so far. It is an
@@ -1212,6 +1298,8 @@ void replconfCommand(client *c) {
                 checkChildrenDone();
             if (c->repl_start_cmd_stream_on_ack && c->replstate == SLAVE_STATE_ONLINE)
                 replicaStartCommandStream(c);
+            if (c->replstate == SLAVE_STATE_BG_RDB_TRANSFER)
+                replicaPutOnline(c);
             /* Note: this command does not reply anything! */
             return;
         } else if (!strcasecmp(c->argv[j]->ptr,"getack")) {
@@ -1255,6 +1343,28 @@ void replconfCommand(client *c) {
                 }
             }
             sdsfreesplitres(filters, filter_count);
+        } else if (!strcasecmp(c->argv[j]->ptr, "rdb-channel")) {
+            long rdb_channel = 0;
+            if (getRangeLongFromObjectOrReply(c, c->argv[j + 1], 0, 1, &rdb_channel, NULL) != C_OK)
+                return;
+            if (rdb_channel == 1) {
+                c->flags |= CLIENT_REPL_RDB_CHANNEL;
+                c->slave_req |= SLAVE_REQ_RDB_CHANNEL;
+            } else {
+                c->flags &= ~CLIENT_REPL_RDB_CHANNEL;
+                c->slave_req &= ~SLAVE_REQ_RDB_CHANNEL;
+            }
+        } else if (!strcasecmp(c->argv[j]->ptr, "set-rdb-client-id")) {
+            /* REPLCONF set-rdb-client-id <client-id> is used to identify the
+             * current replica main channel with existing rdb-connection. */
+            long long client_id = 0;
+            if (getLongLongFromObjectOrReply(c, c->argv[j + 1], &client_id, NULL) != C_OK)
+                return;
+            if (!rdbChannelLookupRdbClient(client_id)) {
+                addReplyErrorFormat(c, "Unrecognized RDB client id: %lld", client_id);
+                return;
+            }
+            c->rdb_client_id = (uint64_t)client_id;
         } else {
             addReplyErrorFormat(c,"Unrecognized REPLCONF option: %s",
                 (char*)c->argv[j]->ptr);
@@ -1713,6 +1823,19 @@ void shiftReplicationId(void) {
 
 /* ----------------------------------- SLAVE -------------------------------- */
 
+/* Replication: Replica side. */
+void slaveGetPortStr(char *buf, size_t size) {
+    long long port;
+    if (server.slave_announce_port) {
+        port = server.slave_announce_port;
+    } else if (server.tls_replication && server.tls_port) {
+        port = server.tls_port;
+    } else {
+        port = server.port;
+    }
+    ll2string(buf, size, port);
+}
+
 /* Returns 1 if the given replication state is a handshake state,
  * 0 otherwise. */
 int slaveIsInHandshakeState(void) {
@@ -1830,6 +1953,26 @@ void disklessLoadDiscardTempDb(redisDb *tempDb) {
     discardTempDb(tempDb);
 }
 
+static void replicationFullSyncCompleted(void) {
+    replicationCreateMasterClient(server.repl_transfer_s,
+                                  server.repl_loaded_rdb_dbid);
+    server.repl_state = REPL_STATE_CONNECTED;
+    server.repl_down_since = 0;
+
+    /* Fire the master link modules event. */
+    moduleFireServerEvent(REDISMODULE_EVENT_MASTER_LINK_CHANGE,
+                          REDISMODULE_SUBEVENT_MASTER_LINK_UP,
+                          NULL);
+
+    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Finished with success");
+    if (server.supervised_mode == SUPERVISED_SYSTEMD)
+        redisCommunicateSystemd("STATUS=MASTER <-> REPLICA sync: Finished with success. Ready to accept connections in read-write mode.\n");
+
+    /* Send the initial ACK immediately to put this replica in online state. */
+    if (!(server.master->flags & CLIENT_PRE_PSYNC))
+        replicationSendAck();
+}
+
 /* If we know we got an entirely different data set from our master
  * we have no way to incrementally feed our replicas after that.
  * We want our replicas to resync with us as well, if we have any sub-replicas.
@@ -1852,6 +1995,7 @@ void readSyncBulkPayload(connection *conn) {
     int use_diskless_load = useDisklessLoad();
     redisDb *diskless_load_tempDb = NULL;
     functionsLibCtx* temp_functions_lib_ctx = NULL;
+    int rdbchannel = (conn == server.repl_rdb_transfer_s);
     int empty_db_flags = server.repl_slave_lazy_flush ? EMPTYDB_ASYNC :
                                                         EMPTYDB_NO_FLAGS;
     off_t left;
@@ -2086,6 +2230,7 @@ void readSyncBulkPayload(connection *conn) {
             functionsLibCtxClear(functions_lib_ctx);
         }
 
+        diskless_loading_rio = &rdb;
         loadingSetFlags(NULL, server.repl_transfer_size, asyncLoading);
         if (server.repl_diskless_load != REPL_DISKLESS_LOAD_SWAPDB) {
             serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Flushing old data");
@@ -2120,9 +2265,9 @@ void readSyncBulkPayload(connection *conn) {
                 loadingFailed = 1;
             }
         }
+        diskless_loading_rio = NULL;
 
         if (loadingFailed) {
-            cancelReplicationHandshake(1);
             rioFreeConn(&rdb, NULL);
 
             if (server.repl_diskless_load == REPL_DISKLESS_LOAD_SWAPDB) {
@@ -2143,6 +2288,10 @@ void readSyncBulkPayload(connection *conn) {
              * loop to reply -LOADING if flushing the db takes a long time. So,
              * stopLoading() must be called after emptyData() above. */
             stopLoading(0);
+
+            /* This must be called after stopLoading(0) as it checks loading
+             * flag in case of rdbchannel replication. */
+            cancelReplicationHandshake(1);
 
             /* Note that there's no point in restarting the AOF on SYNC
              * failure, it'll be restarted when sync succeeds or the replica
@@ -2250,36 +2399,25 @@ void readSyncBulkPayload(connection *conn) {
         server.repl_transfer_tmpfile = NULL;
     }
 
-    /* Final setup of the connected slave <- master link */
-    replicationCreateMasterClient(server.repl_transfer_s,rsi.repl_stream_db);
-    server.repl_state = REPL_STATE_CONNECTED;
-    server.repl_down_since = 0;
-
-    /* Fire the master link modules event. */
-    moduleFireServerEvent(REDISMODULE_EVENT_MASTER_LINK_CHANGE,
-                          REDISMODULE_SUBEVENT_MASTER_LINK_UP,
-                          NULL);
-
     /* After a full resynchronization we use the replication ID and
      * offset of the master. The secondary ID / offset are cleared since
      * we are starting a new history. */
-    memcpy(server.replid,server.master->replid,sizeof(server.replid));
-    server.master_repl_offset = server.master->reploff;
+    memcpy(server.replid, server.master_replid, sizeof(server.replid));
+    server.master_repl_offset = server.master_initial_offset;
     clearReplicationId2();
+    /* Save dbid of the rdb, we'll use it while creating master client. */
+    server.repl_loaded_rdb_dbid = rsi.repl_stream_db;
 
     /* Let's create the replication backlog if needed. Slaves need to
      * accumulate the backlog regardless of the fact they have sub-slaves
      * or not, in order to behave correctly if they are promoted to
      * masters after a failover. */
     if (server.repl_backlog == NULL) createReplicationBacklog();
-    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Finished with success");
 
-    if (server.supervised_mode == SUPERVISED_SYSTEMD) {
-        redisCommunicateSystemd("STATUS=MASTER <-> REPLICA sync: Finished with success. Ready to accept connections in read-write mode.\n");
-    }
-
-    /* Send the initial ACK immediately to put this replica in online state. */
-    if (usemark) replicationSendAck();
+    if (!rdbchannel)
+        replicationFullSyncCompleted();
+    else
+        rdbChannelHandleRdbLoadCompletion();
 
     /* Restart the AOF subsystem now that we finished the sync. This
      * will trigger an AOF rewrite, and when done will start appending
@@ -2440,6 +2578,7 @@ char *sendCommandArgv(connection *conn, int argc, char **argv, size_t *argv_lens
 #define PSYNC_FULLRESYNC 3
 #define PSYNC_NOT_SUPPORTED 4
 #define PSYNC_TRY_LATER 5
+#define PSYNC_FULLRESYNC_RDBCHANNEL 6
 int slaveTryPartialResynchronization(connection *conn, int read_reply) {
     char *psync_replid;
     char psync_offset[32];
@@ -2452,9 +2591,16 @@ int slaveTryPartialResynchronization(connection *conn, int read_reply) {
          * a FULL resync using the PSYNC command we'll set the offset at the
          * right value, so that this information will be propagated to the
          * client structure representing the master into server.master. */
-        server.master_initial_offset = -1;
+        if (server.repl_rdb_ch_state == REPL_RDB_CH_STATE_NONE)
+            server.master_initial_offset = -1;
 
-        if (server.cached_master) {
+        if (server.repl_rdb_ch_state != REPL_RDB_CH_STATE_NONE) {
+            /* Use replid and offset from +FULLRESYNC reply of rdb channel. */
+            psync_replid = server.master_replid;
+            snprintf(psync_offset, sizeof(psync_offset), "%lld", server.master_initial_offset + 1);
+            serverLog(LL_NOTICE, "Trying a partial resynchronization using main channel (request %s:%s).",
+                      psync_replid, psync_offset);
+        } else if (server.cached_master) {
             psync_replid = server.cached_master->replid;
             snprintf(psync_offset,sizeof(psync_offset),"%lld", server.cached_master->reploff+1);
             serverLog(LL_NOTICE,"Trying a partial resynchronization (request %s:%s).", psync_replid, psync_offset);
@@ -2531,7 +2677,22 @@ int slaveTryPartialResynchronization(connection *conn, int read_reply) {
         return PSYNC_FULLRESYNC;
     }
 
+    if (!strncmp(reply, "+RDBCHANNELSYNC", strlen("+RDBCHANNELSYNC"))) {
+        /* A response of +RDBCHANNELSYNC from the master implies that partial
+         * synchronization is not possible and that the master supports full
+         * sync using dedicated RDB channel. Full sync will continue that way.*/
+        serverLog(LL_NOTICE, "PSYNC is not possible, initialize RDB channel.");
+        sdsfree(reply);
+        return PSYNC_FULLRESYNC_RDBCHANNEL;
+    }
+
     if (!strncmp(reply,"+CONTINUE",9)) {
+        if (server.repl_rdb_ch_state != REPL_RDB_CH_STATE_NONE) {
+            /* master_replid and master_initial_offset is already set
+             * in rdbChannelHandleFullresyncReply() */
+            sdsfree(reply);
+            return PSYNC_CONTINUE;
+        }
         /* Partial resync was accepted. */
         serverLog(LL_NOTICE,
             "Successful partial resynchronization with master.");
@@ -2607,6 +2768,19 @@ int slaveTryPartialResynchronization(connection *conn, int read_reply) {
     }
     sdsfree(reply);
     return PSYNC_NOT_SUPPORTED;
+}
+
+sds getTryPsyncString(int result) {
+    switch (result) {
+        case PSYNC_WRITE_ERROR: return sdsnew("PSYNC_WRITE_ERROR");
+        case PSYNC_WAIT_REPLY: return sdsnew("PSYNC_WAIT_REPLY");
+        case PSYNC_CONTINUE: return sdsnew("PSYNC_CONTINUE");
+        case PSYNC_FULLRESYNC: return sdsnew("PSYNC_FULLRESYNC");
+        case PSYNC_NOT_SUPPORTED: return sdsnew("PSYNC_NOT_SUPPORTED");
+        case PSYNC_TRY_LATER: return sdsnew("PSYNC_TRY_LATER");
+        case PSYNC_FULLRESYNC_RDBCHANNEL: return sdsnew("PSYNC_FULLRESYNC_RDBCHANNEL");
+        default: return sdsnew("Unknown result");
+    }
 }
 
 /* This handler fires when the non blocking connect was able to
@@ -2696,17 +2870,11 @@ void syncWithMaster(connection *conn) {
         /* Set the slave port, so that Master's INFO command can list the
          * slave listening port correctly. */
         {
-            int port;
-            if (server.slave_announce_port)
-                port = server.slave_announce_port;
-            else if (server.tls_replication && server.tls_port)
-                port = server.tls_port;
-            else
-                port = server.port;
-            sds portstr = sdsfromlonglong(port);
+            char buf[LONG_STR_SIZE];
+
+            slaveGetPortStr(buf, sizeof(buf));
             err = sendCommand(conn,"REPLCONF",
-                    "listening-port",portstr, NULL);
-            sdsfree(portstr);
+                    "listening-port",buf, NULL);
             if (err) goto write_error;
         }
 
@@ -2726,7 +2894,9 @@ void syncWithMaster(connection *conn) {
          *
          * The master will ignore capabilities it does not understand. */
         err = sendCommand(conn,"REPLCONF",
-                "capa","eof","capa","psync2",NULL);
+                          "capa","eof","capa","psync2",
+                          server.repl_rdb_channel ? "capa" : NULL, "rdb-channel-repl", NULL);
+
         if (err) goto write_error;
 
         server.repl_state = REPL_STATE_RECEIVE_AUTH_REPLY;
@@ -2829,7 +2999,10 @@ void syncWithMaster(connection *conn) {
      * but there is nothing technically wrong with a full resync which
      * could happen in edge cases. */
     if (server.failover_state == FAILOVER_IN_PROGRESS) {
-        if (psync_result == PSYNC_CONTINUE || psync_result == PSYNC_FULLRESYNC) {
+        if (psync_result == PSYNC_CONTINUE ||
+            psync_result == PSYNC_FULLRESYNC ||
+            psync_result == PSYNC_FULLRESYNC_RDBCHANNEL)
+        {
             clearFailoverState();
         } else {
             abortFailover("Failover target rejected psync request");
@@ -2883,6 +3056,26 @@ void syncWithMaster(connection *conn) {
         server.repl_transfer_fd = dfd;
     }
 
+    server.repl_transfer_size = -1;
+    server.repl_transfer_read = 0;
+    server.repl_transfer_last_fsync_off = 0;
+    server.repl_transfer_lastio = server.unixtime;
+
+    /* Using rdb channel replication, the master responded +RDBCHANNELSYNC.
+     * We need to initialize the RDB channel. */
+    if (psync_result == PSYNC_FULLRESYNC_RDBCHANNEL) {
+        /* Create RDB connection */
+        server.repl_rdb_transfer_s = connCreate(server.el, connTypeOfReplication());
+        if (connConnect(server.repl_rdb_transfer_s, server.masterhost,
+                        server.masterport, server.bind_source_addr,
+                        rdbChannelFullSyncWithMaster) == C_ERR) {
+            serverLog(LL_WARNING, "Unable to connect to master: %s", connGetLastError(server.repl_rdb_transfer_s));
+            goto error;
+        }
+        server.repl_rdb_ch_state = REPL_RDB_CH_SEND_HANDSHAKE;
+        return;
+    }
+
     /* Setup the non blocking download of the bulk file. */
     if (connSetReadHandler(conn, readSyncBulkPayload)
             == C_ERR)
@@ -2895,10 +3088,6 @@ void syncWithMaster(connection *conn) {
     }
 
     server.repl_state = REPL_STATE_TRANSFER;
-    server.repl_transfer_size = -1;
-    server.repl_transfer_read = 0;
-    server.repl_transfer_last_fsync_off = 0;
-    server.repl_transfer_lastio = server.unixtime;
     return;
 
 no_response_error: /* Handle receiveSynchronousResponse() error when master has no reply */
@@ -2908,6 +3097,9 @@ no_response_error: /* Handle receiveSynchronousResponse() error when master has 
 error:
     if (dfd != -1) close(dfd);
     connClose(conn);
+    if (server.repl_rdb_transfer_s)
+        connClose(server.repl_rdb_transfer_s);
+    server.repl_rdb_transfer_s = NULL;
     server.repl_transfer_s = NULL;
     if (server.repl_transfer_fd != -1)
         close(server.repl_transfer_fd);
@@ -2975,6 +3167,9 @@ void replicationAbortSyncTransfer(void) {
  *
  * Otherwise zero is returned and no operation is performed at all. */
 int cancelReplicationHandshake(int reconnect) {
+    if (rdbChannelAbortRdbTransfer() != C_OK)
+        return 1;
+
     if (server.repl_state == REPL_STATE_TRANSFER) {
         replicationAbortSyncTransfer();
         server.repl_state = REPL_STATE_CONNECT;
@@ -3133,6 +3328,738 @@ void replicationHandleMasterDisconnection(void) {
             server.masterhost, server.masterport);
         connectWithMaster();
     }
+}
+
+/* Rdb channel for full sync
+ *
+ * - During a full sync, when master is delivering RDB to the replica, incoming
+ *   write commands are kept in a replication buffer in order to be sent to the
+ *   replica once RDB delivery is completed. If RDB delivery takes a long time,
+ *   it might create memory pressure on master. Also, once a replica connection
+ *   accumulates replication data which is larger than output buffer limits,
+ *   master will kill replica connection. This may cause a replication failure.
+ *
+ *   The main benefit of the rdb channel replication is streaming incoming
+ *   commands in parallel to the RDB delivery. This approach shifts replication
+ *   stream buffering to the replica and reduces load on master. We do this by
+ *   opening another connection for RDB delivery. The main channel on replica
+ *   will be receiving replication stream while rdb channel is receiving the RDB.
+ *
+ *   This feature also helps to reduce master's main process CPU load. By
+ *   opening a dedicated connection for the RDB transfer, the bgsave process has
+ *   direct access to the new connection and it will stream RDB directly to the
+ *   replicas. Before this change, due to TLS connection restriction, the bgsave
+ *   process was writing RDB bytes to a pipe and the main process was forwarding
+ *   it to the replica. This is no longer necessary, the main process can avoid
+ *   these expensive socket read/write syscalls.
+ *
+ *  Implementation
+ *  - When replica connects to the master, it sends 'rdb-channel-repl' as part
+ *    of capability exchange to let master to know replica supports rdb channel.
+ *  - When replica lacks sufficient data for PSYNC, master sends +RDBCHANNELSYNC
+ *    reply. As the next step, the replica opens a new connection (rdb-channel)
+ *    and configures it against the master with the appropriate capabilities
+ *    and requirements. Then, replica requests fullsync using the RDB channel.
+ *  - Prior to forking, master sends the snapshot's end repl-offset and
+ *    rdbchannel's client id to the replica rdbchannel. Then, master attaches
+ *    the replica to the replication backlog to keep replication data until the
+ *    replica requests psync starting at the snapshot end offset. The replica
+ *    sends rdbchannel client id using the main channel so, master can associate
+ *    replica's channels. After that, replica request a PSYNC.
+ *  - The master main process sends replication stream via the main channel,
+ *    while the bgsave process sends the RDB directly to the replica via the
+ *    rdb-channel. Replica accumulates replication stream in a local buffer,
+ *    while the RDB is being loaded into the memory.
+ *  - Once the replica completes loading the rdb, it drops the rdb channel and
+ *    streams the accumulated replication stream into the db. Sync is completed.
+ *
+ * * Replica state machine *
+ * ┌───────────────────┐             Rdb channel sync
+ * │RECEIVE_PING_REPLY │          ┌──────────────────────────────────────────────────────────────┐
+ * └────────┬──────────┘          │     RDB channel state                Main channel state      │
+ *          │+PONG                │     ┌────────────────────────────┐   ┌───────────────────┐   │
+ * ┌────────▼──────────┐        ┌─┼─────►RDB_CH_SEND_HANDSHAKE       │ ┌─►SEND_HANDSHAKE     │   │
+ * │SEND_HANDSHAKE     │        │ │     └────┬───────────────────────┘ │ └──┬────────────────┘   │
+ * └────────┬──────────┘        │ │          │                         │    │REPLCONF set-rdb-client-id <clientid>
+ *          │                   │ │  ┌───────▼───────────────────────┐ │ ┌──▼────────────────┐   │
+ * ┌────────▼──────────┐        │ │  │ RDB_CH_RECEIVE_AUTH_REPLY     │ │ │RECEIVE_CAPA_REPLY │   │
+ * │RECEIVE_AUTH_REPLY │        │ │  └───────┬───────────────────────┘ │ └──┬────────────────┘   │
+ * └────────┬──────────┘        │ │          │+OK                      │    │+OK                 │
+ *          │+OK                │ │  ┌───────▼───────────────────────┐ │ ┌──▼────────────────┐   │
+ * ┌────────▼──────────┐        │ │  │ RDB_CH_RECEIVE_REPLCONF_REPLY │ │ │SEND_PSYNC         │   │
+ * │RECEIVE_PORT_REPLY │        │ │  └───────┬───────────────────────┘ │ └──┬────────────────┘   │
+ * └────────┬──────────┘        │ │          │+OK                      │    │PSYNC use snapshot  │
+ *          │+OK                │ │  ┌───────▼───────────────────────┐ │    │end-offset provided │
+ * ┌────────▼──────────┐        │ │  │ RDB_CH_RECEIVE_FULLRESYNC     │ │    │by the master       │
+ * │RECEIVE_IP_REPLY   │        │ │  └───────┬───────────────────────┘ │ ┌──▼────────────────┐   │
+ * └────────┬──────────┘        │ │          │FULLRESYNC .. <clientid> │ │RECEIVE_PSYNC_REPLY│   │
+ *          │+OK                │ │          ├─────────────────────────┘ └──┬────────────────┘   │
+ * ┌────────▼──────────┐        │ │          │                              │+CONTINUE           │
+ * │RECEIVE_IP_REPLY   │        │ │  ┌───────▼───────────────┐           ┌──▼────────────────┐   │
+ * └────────┬──────────┘        │ │  │REPL_RDB_CH_RDB_LOAD   │           │TRANSFER           │   │
+ *          │+OK                │ │  └───────┬───────────────┘           └─────┬─────────────┘   │
+ * ┌────────▼──────────┐        │ │          │Done loading                     │                 │
+ * │RECEIVE_CAPA_REPLY │        │ │  ┌───────▼───────────────┐                 │                 │
+ * └────────┬──────────┘        │ │  │REPL_RDB_CH_RDB_LOADED │                 │                 │
+ *          │                   │ │  └───────┬───────────────┘                 │                 │
+ * ┌────────▼───┐               │ │          │                                 │                 │
+ * │SEND_PSYNC  │               │ │          │Replica loads local replication  │                 │
+ * └─┬──────────┘               │ │          │buffer into memory               │                 │
+ *   │PSYNC (use cached-master) │ │          └─────────┬───────────────────────┘                 │
+ * ┌─▼─────────────────┐        │ │                    │                                         │
+ * │RECEIVE_PSYNC_REPLY│        │ └────────────────────┼─────────────────────────────────────────┘
+ * └────────┬─┬────────┘        │                      │
+ * +CONTINUE│ │+RDBCHANNELSYNC  │                      │
+ *   │      │ └─────────────────┘                      │
+ *   │      │+FULLRESYNC                               │
+ *   │    ┌─▼─────────────────┐                   ┌────▼──────────────┐
+ *   │    │TRANSFER           ├───────────────────►CONNECTED          │
+ *   │    └───────────────────┘                   └────▲──────────────┘
+ *   │                                                 │
+ *   └─────────────────────────────────────────────────┘
+ */
+
+/* On the master side, this function is called for rdb channel replica just
+ * before forking for rdb delivery. It attaches rdbchannel client to the backlog
+ * to prevent it being freed until main channel establishes psync for the
+ * current offset.
+ *
+ * Association occurs in two forms:
+ * 1. If there's an existing buffer block at fork time, the replica is
+ *    attached to the tail.
+ * 2. If there's no tail, the replica is attached when a new buffer block is
+ *    created (see rdbChannelAttachReplicasToBacklog())
+ * The replica RDB client ID is used as a unique key for this association.
+ * If a client output buffer overrun occurs, the association is deleted and the
+ * RDB connection is dropped. Otherwise, on a successful run, rdbchannel replica
+ * association will be deleted in masterTryPartialResynchronization() once
+ * main channel establishes psync. */
+static void rdbChannelAttachToBacklog(client *slave) {
+    listNode *ln = listLast(server.repl_buffer_blocks);
+    replBufBlock *tail = ln ? listNodeValue(ln) : NULL;
+
+    if (tail)
+        tail->refcount++;
+
+    /* Prevent rdb client from being freed before psync is established. */
+    slave->flags |= CLIENT_PROTECTED_RDB_CHANNEL;
+    slave->ref_repl_buf_node = tail ? ln : NULL;
+    raxInsert(server.replicas_waiting_psync,
+              (unsigned char *)&slave->id, sizeof(slave->id), slave, NULL);
+
+    serverLog(LL_DEBUG, "Added rdb replica %s to the psync waiting list. "
+                        "(cid = %"PRIu64") (tail = %d)",
+                        replicationGetSlaveName(slave),
+                        slave->id, tail != NULL);
+}
+
+/* Replication: master side. Returns a client by ID, or NULL if the client ID
+ * is not in psync waiting clients list. */
+static client *rdbChannelLookupRdbClient(uint64_t id) {
+    void *c = NULL;
+    if (id == 0)
+        return NULL;
+    raxFind(server.replicas_waiting_psync, (unsigned char *)&id, sizeof(id), &c);
+    return c;
+}
+
+/* Replication: master side.
+ * Attach psync waiting replicas to the new replication backlog head. */
+static void rdbChannelAttachReplicasToBacklog(void) {
+    raxIterator iter;
+    listNode *ln = listFirst(server.repl_buffer_blocks);
+    replBufBlock *head = ln ? listNodeValue(ln) : NULL;
+
+    if (head == NULL)
+        return;
+
+    raxStart(&iter, server.replicas_waiting_psync);
+    raxSeek(&iter, "^", NULL, 0);
+    while (raxNext(&iter)) {
+        client *rdb_client = iter.data;
+        if (rdb_client->ref_repl_buf_node)
+            continue;
+
+        rdb_client->ref_repl_buf_node = ln;
+        head->refcount++;
+        serverLog(LL_DEBUG, "Attached replica rdb client %"PRIu64
+                            " to repl buf block", rdb_client->id);
+    }
+    raxStop(&iter);
+}
+
+/* Replication: Replica side. */
+static int rdbChannelSendHandshake(connection *conn, sds *err) {
+    /* AUTH with the master if required. */
+    if (server.masterauth) {
+        char *args[] = {"AUTH", NULL, NULL};
+        size_t lens[] = {4, 0, 0};
+        int argc = 1;
+        if (server.masteruser) {
+            args[argc] = server.masteruser;
+            lens[argc] = strlen(server.masteruser);
+            argc++;
+        }
+        args[argc] = server.masterauth;
+        lens[argc] = sdslen(server.masterauth);
+        argc++;
+        *err = sendCommandArgv(conn, argc, args, lens);
+        if (*err) {
+            serverLog(LL_WARNING, "Error sending AUTH to master in rdb channel replication handshake: %s", *err);
+            return C_ERR;
+        }
+    }
+
+    char buf[LONG_STR_SIZE];
+    slaveGetPortStr(buf, sizeof(buf));
+
+    *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1",
+                       "rdb-channel", "1", "listening-port", buf, NULL);
+    if (*err) {
+        serverLog(LL_WARNING, "Error sending REPLCONF command to master in rdb channel handshake: %s", *err);
+        return C_ERR;
+    }
+
+    if (connSetReadHandler(conn, rdbChannelFullSyncWithMaster) == C_ERR) {
+        char conninfo[CONN_INFO_LEN];
+        serverLog(LL_WARNING, "Can't create readable event for SYNC: %s (%s)",
+                  strerror(errno), connGetInfo(conn, conninfo, sizeof(conninfo)));
+        return C_ERR;
+    }
+    return C_OK;
+}
+
+/* Replication: Replica side. */
+static int rdbChannelHandleAuthReply(connection *conn, sds *err) {
+    *err = receiveSynchronousResponse(conn);
+    if (*err == NULL) {
+        serverLog(LL_WARNING, "Master did not respond to auth command during rdb channel handshake");
+        return C_ERR;
+    }
+    if ((*err)[0] == '-') {
+        serverLog(LL_WARNING, "Unable to AUTH to master: %s", *err);
+        return C_ERR;
+    }
+    server.repl_rdb_ch_state = REPL_RDB_CH_RECEIVE_REPLCONF_REPLY;
+    return C_OK;
+}
+
+/* Replication: Replica side. */
+static int rdbChannelHandleReplconfReply(connection *conn, sds *err) {
+    *err = receiveSynchronousResponse(conn);
+    if (*err == NULL) {
+        serverLog(LL_WARNING, "Master did not respond to replconf command during rdb channel handshake");
+        return C_ERR;
+    }
+    if (*err[0] == '-') {
+        serverLog(LL_WARNING, "Master replied error to replconf: %s", *err);
+        return C_ERR;
+    }
+    sdsfree(*err);
+
+    /* Request rdb from master */
+    *err = sendCommand(conn, "PSYNC", "?", "-1", NULL);
+    if (*err) {
+        serverLog(LL_WARNING, "I/O error writing to Master: %s", *err);
+        return C_ERR;
+    }
+
+    return C_OK;
+}
+
+/* Replication: Replica side. */
+static int rdbChannelHandleFullresyncReply(connection *conn, sds *err) {
+    long long reploff = 0;
+    uint64_t rdb_client_id = 0;
+    char replid[CONFIG_RUN_ID_SIZE + 1] = {0};
+
+    *err = receiveSynchronousResponse(conn);
+    if (*err == NULL)
+        return C_ERR;
+
+    if (*err[0] == '\0') {
+        /* Retry again later */
+        serverLog(LL_DEBUG, "Received empty psync reply");
+        return C_RETRY;
+    }
+
+    /* Parse +FULLRESYNC reply */
+    if (sscanf(*err, "+FULLRESYNC %40s %lld %"PRIu64"",
+               replid, &reploff, &rdb_client_id) != 3)
+    {
+        serverLog(LL_WARNING, "Received unexpected psync reply: %s", *err);
+        return C_ERR;
+    }
+
+    /* Save replid, reploff and rdb_client id */
+    memcpy(server.master_replid, replid, sizeof(replid));
+    server.master_initial_offset = reploff;
+    server.repl_rdbchannel_client_id = rdb_client_id;
+
+    /* Now that we have the snapshot end-offset, we can ask for psync from that
+     * offset. Prepare the main and rdb channels accordingly.*/
+    server.repl_state = REPL_STATE_SEND_HANDSHAKE;
+
+    if (connSetReadHandler(server.repl_transfer_s,
+                           rdbChannelSetupMainConnForPsync) != C_OK)
+    {
+        char inf[CONN_INFO_LEN];
+        serverLog(LL_WARNING,
+                  "Can't create readable event for main channel connection: %s (%s)",
+                  strerror(errno), connGetInfo(conn, inf, sizeof(inf)));
+        return C_ERR;
+    }
+
+    /* Prepare RDB channel connection for RDB download. */
+    if (connSetReadHandler(server.repl_rdb_transfer_s,
+                           readSyncBulkPayload) != C_OK)
+    {
+        char inf[CONN_INFO_LEN];
+        serverLog(LL_WARNING,
+                  "Can't create readable event for rdb channel connection: %s (%s)",
+                  strerror(errno),
+                  connGetInfo(server.repl_rdb_transfer_s, inf, sizeof(inf)));
+        return C_ERR;
+    }
+
+    rdbChannelSetupMainConnForPsync(server.repl_transfer_s);
+    return C_OK;
+}
+
+/* Replication: Replica side.
+ * This connection handler is used to initialize the RDB channel connection.*/
+static void rdbChannelFullSyncWithMaster(connection *conn) {
+    int ret = 0;
+    char *err = NULL;
+    serverAssert(conn == server.repl_rdb_transfer_s);
+
+    /* Check for errors in the socket: after a non blocking connect() we
+     * may find that the socket is in error state. */
+    if (connGetState(conn) != CONN_STATE_CONNECTED) {
+        serverLog(LL_WARNING, "Error condition on socket for rdb channel replication: %s",
+                  connGetLastError(conn));
+        goto error;
+    }
+    switch (server.repl_rdb_ch_state) {
+        case REPL_RDB_CH_SEND_HANDSHAKE:
+            ret = rdbChannelSendHandshake(conn, &err);
+            if (ret == C_OK)
+                server.repl_rdb_ch_state = REPL_RDB_CH_RECEIVE_AUTH_REPLY;
+            break;
+        case REPL_RDB_CH_RECEIVE_AUTH_REPLY:
+            if (server.masterauth) {
+                ret = rdbChannelHandleAuthReply(conn, &err);
+                if (ret == C_OK)
+                    server.repl_rdb_ch_state = REPL_RDB_CH_RECEIVE_REPLCONF_REPLY;
+                /* Wait for next bulk before trying to read replconf reply. */
+                break;
+            }
+            server.repl_rdb_ch_state = REPL_RDB_CH_RECEIVE_REPLCONF_REPLY;
+            /* fall through */
+        case REPL_RDB_CH_RECEIVE_REPLCONF_REPLY:
+            ret = rdbChannelHandleReplconfReply(conn, &err);
+            if (ret == C_OK)
+                server.repl_rdb_ch_state = REPL_RDB_CH_RECEIVE_FULLRESYNC;
+            break;
+        case REPL_RDB_CH_RECEIVE_FULLRESYNC:
+            ret = rdbChannelHandleFullresyncReply(conn, &err);
+            if (ret == C_OK)
+                server.repl_rdb_ch_state = REPL_RDB_CH_RDB_LOADING;
+            break;
+        default:
+            serverPanic("Unknown rdb channel state: %d", server.repl_rdb_ch_state);
+    }
+
+    if (ret == C_ERR)
+        goto error;
+
+    sdsfree(err);
+    return;
+
+error:
+    if (err) {
+        serverLog(LL_WARNING, "rdb channel sync failed with error: %s", err);
+        sdsfree(err);
+    }
+    if (server.repl_transfer_s) {
+        connClose(server.repl_transfer_s);
+        server.repl_transfer_s = NULL;
+    }
+    server.repl_state = REPL_STATE_CONNECT;
+    rdbChannelAbortRdbTransfer();
+}
+
+/* Replication: Replica side.
+ * Initialize replica's local replication buffer to accumulate repl stream
+ * during rdb channel sync. */
+static void rdbChannelReplDataBufInit(void) {
+    serverAssert(server.repl_pending_data.blocks == NULL);
+    server.repl_pending_data.size = 0;
+    server.repl_pending_data.used = 0;
+    server.repl_pending_data.blocks = listCreate();
+    server.repl_pending_data.blocks->free = zfree;
+}
+
+/* Replication: Replica side.
+ * Free replica's local replication buffer */
+static void rdbChannelReplDataBufFree(void) {
+    listRelease(server.repl_pending_data.blocks);
+    server.repl_pending_data.blocks = NULL;
+    server.repl_pending_data.size = 0;
+    server.repl_pending_data.used = 0;
+}
+
+/* Replication: Replica side.
+ * Reads replication data from master connection into the repl buffer block */
+int rdbChannelReadIntoBuf(connection *conn, replDataBufBlock *b) {
+    atomicIncr(server.stat_io_reads_processed[IOTHREAD_MAIN_THREAD_ID], 1);
+
+    int nread = connRead(conn, b->buf + b->used, b->size - b->used);
+    if (nread <= 0) {
+        if (nread == 0 || connGetState(conn) != CONN_STATE_CONNECTED) {
+            serverLog(LL_WARNING, "Main channel error while reading from master: %s",
+                      connGetLastError(conn));
+            cancelReplicationHandshake(1);
+        }
+        return -1;
+    }
+
+    b->used += nread;
+    server.repl_pending_data.used += nread;
+    atomicIncr(server.stat_net_repl_input_bytes, nread);
+
+    return nread;
+}
+
+/* Replication: Replica side.
+ * Read handler for buffering incoming repl data during RDB download/loading. */
+void rdbChannelBufferReplData(connection *conn) {
+    const int buflen = 1024 * 1024;
+    const int minread = 16 * 1024;
+    int nread = 0;
+    int needs_read = 1;
+
+    listNode *ln = listLast(server.repl_pending_data.blocks);
+    replDataBufBlock *tail = ln ? listNodeValue(ln) : NULL;
+
+    /* Try to append last node. */
+    if (tail && tail->size > tail->used) {
+        nread = rdbChannelReadIntoBuf(conn, tail);
+        if (nread <= 0)
+            return;
+
+        /* If buffer is filled fully, there might be more data in socket buffer.
+         * Only read again if we've read small amount (less than minread). */
+        needs_read = (tail->size == tail->used) && nread < minread;
+    }
+
+    if (needs_read) {
+        unsigned long long limit;
+        size_t usable_size;
+
+        limit = server.client_obuf_limits[CLIENT_TYPE_SLAVE].hard_limit_bytes;
+        if (limit != 0 && server.repl_pending_data.size > limit) {
+            serverLog(LL_NOTICE, "Replication buffer limit has been reached (%llu bytes), "
+                                 "stopped buffering replication stream. Further accumulation may occur on master side. ", limit);
+            connSetReadHandler(conn, NULL);
+            return;
+        }
+
+        tail = zmalloc_usable(buflen, &usable_size);
+        tail->size = usable_size - sizeof(replDataBufBlock);
+        tail->used = 0;
+
+        listAddNodeTail(server.repl_pending_data.blocks, tail);
+        server.repl_pending_data.size += tail->size;
+
+        /* Update buffer's peak */
+        if (server.repl_pending_data.peak < server.repl_pending_data.size)
+            server.repl_pending_data.peak = server.repl_pending_data.size;
+
+        rdbChannelReadIntoBuf(conn, tail);
+    }
+}
+
+/* Replication: Replica side.
+ * Streams accumulated replication data into the database. */
+int rdbChannelStreamReplDataToDb(client *c) {
+    int ret = C_OK;
+    size_t size, used, offset = 0;
+    listNode *n = NULL;
+    replDataBufBlock *o;
+
+    serverAssert(c->flags & CLIENT_MASTER);
+
+    if (!server.repl_pending_data.blocks)
+        return C_OK;
+
+    blockingOperationStarts();
+    protectClient(c);
+    while ((n = listFirst(server.repl_pending_data.blocks))) {
+        o = listNodeValue(n);
+        size = o->size;
+        used = o->used;
+        c->querybuf = sdscatlen(c->querybuf, o->buf, used);
+        c->read_reploff += (long long int) used;
+        listDelNode(server.repl_pending_data.blocks, n);
+
+        /* We don't expect error return value but just in case. */
+        ret = processInputBuffer(c);
+        if (ret != C_OK)
+            break;
+
+        server.repl_pending_data.used -= used;
+        server.repl_pending_data.size -= size;
+
+        if (server.repl_debug_pause & REPL_DEBUG_ON_STREAMING_REPL_BUF)
+            debugPauseProcess();
+
+        /* Check if we should yield back to the event loop */
+        if (server.loading_process_events_interval_bytes &&
+            ((offset + used) / server.loading_process_events_interval_bytes >
+             offset / server.loading_process_events_interval_bytes))
+        {
+            replicationSendNewlineToMaster();
+            processEventsWhileBlocked();
+        }
+
+        offset += used;
+        /* Check if master client was freed in processEventsWhileBlocked().
+         * It can happen if we receive 'replicaof' command or 'client kill'
+         * command for the master. */
+        if (c->flags & CLIENT_CLOSE_ASAP || !server.repl_pending_data.blocks) {
+            ret = C_ERR;
+            break;
+        }
+    }
+    unprotectClient(c);
+    blockingOperationEnds();
+
+    if (ret != C_OK) {
+        serverLog(LL_WARNING, "Master client was freed while streaming accumulated replication data to db.");
+        return C_ERR;
+    }
+
+    return C_OK;
+}
+
+/* Replication: Replica side.
+ * On rdb channel failure, close rdb-connection and reset state.
+ * Return C_OK if cleanup is done. Otherwise, returns C_ERR which means cleanup
+ * will be done asynchronously. */
+static int rdbChannelAbortRdbTransfer(void) {
+    if (server.repl_rdb_ch_state == REPL_RDB_CH_STATE_NONE)
+        return C_OK;
+
+    if (server.repl_rdb_transfer_s) {
+        if (server.loading) {
+            /* If loading flag is set, we want to handle cleanup asynchronously.
+             * We set REPL_RDB_CH_STATE_CLOSE_ASAP so it will be handled just
+             * outside loading loop.*/
+            serverLog(LL_NOTICE, "Aborting rdb channel sync while loading the RDB.");
+
+            if (diskless_loading_rio)
+                /* Mark rio with abort flag, next rioRead() will return error.*/
+                rioAbort(diskless_loading_rio);
+            else {
+                /* For disk based loading, we can wait until loading is done.
+                 * This way, replica will have a chance for a successful psync
+                 * later.*/
+                serverLog(LL_NOTICE, "After loading RDB, replica will try psync with master.");
+            }
+
+            if (server.repl_transfer_s)
+                connSetReadHandler(server.repl_transfer_s, NULL);
+
+            server.repl_rdb_ch_state = REPL_RDB_CH_STATE_CLOSE_ASAP;
+            return C_ERR;
+        }
+        connClose(server.repl_rdb_transfer_s);
+        server.repl_rdb_transfer_s = NULL;
+    }
+
+    serverLog(LL_NOTICE, "Aborting rdb channel sync");
+
+    if (server.repl_transfer_fd != -1) {
+        close(server.repl_transfer_fd);
+        server.repl_transfer_fd = -1;
+    }
+    if (server.repl_transfer_tmpfile) {
+        bg_unlink(server.repl_transfer_tmpfile);
+        zfree(server.repl_transfer_tmpfile);
+        server.repl_transfer_tmpfile = NULL;
+    }
+    rdbChannelReplDataBufFree();
+    server.repl_rdb_ch_state = REPL_RDB_CH_STATE_NONE;
+    return C_OK;
+}
+
+/* Replication: Replica side. After loading the rdb, create a master client and
+ * stream replication buffer to the db. */
+void rdbChannelSuccess(void) {
+    replicationFullSyncCompleted();
+
+    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Starting to stream replication buffer into the db"
+                         " (%zu bytes).", server.repl_pending_data.used);
+    if (rdbChannelStreamReplDataToDb(server.master) == C_ERR) {
+        serverLog(LL_WARNING, "Failed to stream local replication buffer into the db");
+
+        rdbChannelAbortRdbTransfer();
+        if (server.master)
+            freeClientAsync(server.master);
+        return;
+    }
+    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Successfully streamed replication buffer into the db");
+
+    rdbChannelReplDataBufFree();
+    server.repl_rdb_ch_state = REPL_RDB_CH_STATE_NONE;
+}
+
+/* Replication: Replica side.
+ * RDB channel done loading the RDB. Check whether the main channel has
+ * completed its part and act accordingly. */
+void rdbChannelHandleRdbLoadCompletion(void) {
+    int close_asap;
+
+    if (server.repl_rdb_transfer_s) {
+        connClose(server.repl_rdb_transfer_s);
+        server.repl_rdb_transfer_s = NULL;
+    }
+
+    /* At this point, RDB is loaded. If state is REPL_RDB_CH_STATE_CLOSE_ASAP,
+     * it means main channel faced a problem while RDB is being loaded. It
+     * stopped replication stream buffering. It's okay though. We'll stream
+     * whatever we have into the db, then replica will try psync from the index
+     * that it has. */
+    close_asap = (server.repl_rdb_ch_state == REPL_RDB_CH_STATE_CLOSE_ASAP);
+    if (!close_asap && server.repl_state != REPL_STATE_TRANSFER) {
+        /* Main channel isn't done yet. We'll finalize fullsync once main
+         * channel establishes psync. See rdbChannelMainConnRecvPsyncReply()*/
+        server.repl_rdb_ch_state = REPL_RDB_CH_RDB_LOADED;
+        return;
+    }
+    /* Finalize fullsync */
+    rdbChannelSuccess();
+
+    /* Main channel connection was broken. Let's trigger a psync with master. */
+    if (close_asap && server.master)
+        freeClientAsync(server.master);
+}
+
+/* Replication: Replica side. */
+int rdbChannelMainConnSendHandshake(connection *conn, sds *err) {
+    char llstr[LONG_STR_SIZE];
+    ull2string(llstr, sizeof(llstr), server.repl_rdbchannel_client_id);
+    *err = sendCommand(conn, "REPLCONF", "set-rdb-client-id", llstr, NULL);
+    return *err ? C_ERR : C_OK;
+}
+
+/* Replication: Replica side. */
+int rdbChannelMainConnRecvCapaReply(connection *conn, sds *err) {
+    *err = receiveSynchronousResponse(conn);
+    if (*err == NULL)
+        return C_ERR;
+
+    if ((*err)[0] == '-') {
+        serverLog(LL_WARNING, "Master does not understand REPLCONF set-rdb-client-id: %s", *err);
+        return C_ERR;
+    }
+    return C_OK;
+}
+
+/* Replication: Replica side. */
+int rdbChannelMainConnSendPsync(connection *conn, sds *err) {
+    if (server.repl_debug_pause & REPL_DEBUG_BEFORE_MAIN_CONN_PSYNC)
+        debugPauseProcess();
+
+    if (slaveTryPartialResynchronization(conn, 0) == PSYNC_WRITE_ERROR) {
+        serverLog(LL_WARNING, "Aborting rdb channel sync. Write error.");
+        *err = sdsnew(connGetLastError(conn));
+        return C_ERR;
+    }
+    return C_OK;
+}
+
+/* Replication: Replica side. */
+int rdbChannelMainConnRecvPsyncReply(connection *conn, sds *err) {
+    int psync_result = slaveTryPartialResynchronization(conn, 1);
+    if (psync_result == PSYNC_WAIT_REPLY)
+        return C_OK; /* Try again later... */
+
+    if (psync_result != PSYNC_CONTINUE) {
+        *err = getTryPsyncString(psync_result);
+        return C_ERR;
+    }
+
+    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Master accepted a Partial Resynchronization%s",
+              server.repl_rdb_transfer_s != NULL ? ", RDB load in background." : ".");
+
+    if (server.repl_rdb_ch_state < REPL_RDB_CH_RDB_LOADED) {
+        /* RDB is still loading. Setup connection to accumulate repl data.  */
+        if (connSetReadHandler(server.repl_transfer_s,
+                               rdbChannelBufferReplData) != C_OK)
+        {
+            serverLog(LL_WARNING, "Can't set read handler for main channel: %s",
+                      strerror(errno));
+            return C_ERR;
+        }
+        rdbChannelReplDataBufInit();
+        return C_OK;
+    }
+    serverLog(LL_DEBUG, "Main channel established psync after rdb load.");
+
+    /* RDB is already loaded. Time to finalize fullsync. */
+    rdbChannelSuccess();
+    return C_OK;
+}
+
+/* Replication: Replica side.
+ * This connection handler fires after rdb-connection was initialized. We use it
+ * to adjust the replica main connection for accumulating replication stream
+ * into the local buffer. */
+void rdbChannelSetupMainConnForPsync(connection *conn) {
+    int ret;
+    char *err = NULL;
+
+    switch (server.repl_state) {
+        case REPL_STATE_SEND_HANDSHAKE:
+            ret = rdbChannelMainConnSendHandshake(conn, &err);
+            if (ret == C_OK)
+                server.repl_state = REPL_STATE_RECEIVE_CAPA_REPLY;
+            break;
+        case REPL_STATE_RECEIVE_CAPA_REPLY:
+            ret = rdbChannelMainConnRecvCapaReply(conn, &err);
+            if (ret == C_ERR)
+                break;
+
+            if (ret == C_OK)
+                server.repl_state = REPL_STATE_SEND_PSYNC;
+            sdsfree(err);
+            err = NULL;
+            /* fall through */
+        case REPL_STATE_SEND_PSYNC:
+            ret = rdbChannelMainConnSendPsync(conn, &err);
+            if (ret == C_OK)
+                server.repl_state = REPL_STATE_RECEIVE_PSYNC_REPLY;
+            break;
+        case REPL_STATE_RECEIVE_PSYNC_REPLY:
+            ret = rdbChannelMainConnRecvPsyncReply(conn, &err);
+            if (ret == C_OK && server.repl_rdb_ch_state != REPL_RDB_CH_STATE_NONE)
+                server.repl_state = REPL_STATE_TRANSFER;
+            /* In case the RDB is already loaded, the repl_state will be set
+             * during rdbChannelSuccess(). */
+            break;
+        default:
+            serverPanic("Unexpected replication state: %d", server.repl_state);
+    }
+
+    if (ret == C_ERR) {
+        serverLog(LL_WARNING, "Aborting rdb channel sync. "
+                              "Main channel psync result = %d, errmsg = %s",
+                              ret, err ? err : "none");
+        cancelReplicationHandshake(1);
+    }
+    sdsfree(err);
 }
 
 void replicaofCommand(client *c) {

--- a/src/replication.c
+++ b/src/replication.c
@@ -3575,7 +3575,6 @@ static int rdbChannelHandleFullresyncReply(connection *conn, sds *err) {
     server.repl_state = REPL_STATE_TRANSFER;
     rdbChannelReplDataBufInit();
 
-    serverLog(LL_NOTICE, "Fullresync reply from master: %s", *err);
     serverLog(LL_NOTICE, "Starting to receive RDB and replication stream in parallel.");
 
     /* RDB is still loading. Setup connection to accumulate repl data.  */

--- a/src/replication.c
+++ b/src/replication.c
@@ -2717,7 +2717,7 @@ int slaveTryPartialResynchronization(connection *conn, int read_reply) {
     }
 
     if (!strncmp(reply, "+RDBCHANNELSYNC", strlen("+RDBCHANNELSYNC"))) {
-        char *client_id = client_id = strchr(reply,' ');
+        char *client_id = strchr(reply,' ');
         if (client_id)
             client_id++;
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -780,7 +780,7 @@ int replicationSetupSlaveForFullResync(client *slave, long long offset) {
             uint64_t id = slave->main_ch_client_id;
             client *c = lookupClientByID(id);
             if (c && c->replstate == SLAVE_STATE_WAIT_RDB_CHANNEL) {
-                c->replstate = SLAVE_STATE_BG_RDB_TRANSFER;
+                c->replstate = SLAVE_STATE_SEND_BULK_AND_STREAM;
                 serverLog(LL_NOTICE, "Starting to deliver RDB and replication stream to replica: %s",
                           replicationGetSlaveName(c));
             } else {
@@ -1329,7 +1329,7 @@ void replconfCommand(client *c) {
                 checkChildrenDone();
             if (c->repl_start_cmd_stream_on_ack && c->replstate == SLAVE_STATE_ONLINE)
                 replicaStartCommandStream(c);
-            if (c->replstate == SLAVE_STATE_BG_RDB_TRANSFER)
+            if (c->replstate == SLAVE_STATE_SEND_BULK_AND_STREAM)
                 replicaPutOnline(c);
             /* Note: this command does not reply anything! */
             return;

--- a/src/replication.c
+++ b/src/replication.c
@@ -45,7 +45,6 @@ int replicaPutOnline(client *slave);
 void replicaStartCommandStream(client *slave);
 int cancelReplicationHandshake(int reconnect);
 static void rdbChannelFullSyncWithMaster(connection *conn);
-static client *rdbChannelLookupMainChannelClient(uint64_t id);
 static int rdbChannelAbortRdbTransfer(void);
 static void rdbChannelBufferReplData(connection *conn);
 static void rdbChannelReplDataBufInit(void);
@@ -69,19 +68,13 @@ static rio *disklessLoadingRio = NULL;
 /* Returns 1 if the replica is rdbchannel and there is an associated main
  * channel slave with that. */
 int replicationCheckHasMainChannel(client *replica) {
-    listNode *ln;
-    listIter li;
-
-    if (!(replica->flags & CLIENT_REPL_RDB_CHANNEL))
+    if (!(replica->flags & CLIENT_REPL_RDB_CHANNEL) ||
+        !replica->main_ch_client_id ||
+        lookupClientByID(replica->main_ch_client_id) == NULL)
+    {
         return 0;
-
-    listRewind(server.slaves,&li);
-    while ((ln = listNext(&li))) {
-        client *c = listNodeValue(ln);
-        if (replica->main_ch_client_id && replica->main_ch_client_id == c->id)
-            return 1;
     }
-    return 0;
+    return 1;
 }
 
 /* During rdb channel replication, replica opens two connections. From master
@@ -374,12 +367,8 @@ void incrementalTrimReplicationBacklog(size_t max_blocks) {
                               server.repl_backlog->histlen + 1;
 }
 
-/* Free replication buffer blocks that are referenced by this client.
- * Also, removes replica from rdbchannel waiting list. */
-void freeReplicaReferences(client *replica) {
-    raxRemove(server.replicas_waiting_rdbchannel,
-              (unsigned char*) &replica->id, sizeof(replica->id), NULL);
-
+/* Free replication buffer blocks that are referenced by this client. */
+void freeReplicaReferencedReplBuffer(client *replica) {
     if (replica->ref_repl_buf_node != NULL) {
         /* Decrease the start buffer node reference count. */
         replBufBlock *o = listNodeValue(replica->ref_repl_buf_node);
@@ -789,11 +778,9 @@ int replicationSetupSlaveForFullResync(client *slave, long long offset) {
              * change its state so we can deliver replication stream from now
              * on, in parallel to rdb. */
             uint64_t id = slave->main_ch_client_id;
-            client *c = rdbChannelLookupMainChannelClient(id);
-            if (c) {
+            client *c = lookupClientByID(id);
+            if (c && c->replstate == SLAVE_STATE_WAIT_RDB_CHANNEL) {
                 c->replstate = SLAVE_STATE_BG_RDB_TRANSFER;
-                raxRemove(server.replicas_waiting_rdbchannel,
-                          (unsigned char*) &id, sizeof(id), NULL);
                 serverLog(LL_NOTICE, "Starting to deliver RDB and replication stream to replica: %s",
                           replicationGetSlaveName(c));
             } else {
@@ -1124,9 +1111,6 @@ void syncCommand(client *c) {
                 listAddNodeTail(server.slaves, c);
                 createReplicationBacklogIfNeeded();
 
-                /* Add replica to waiting rdbchannel list. */
-                raxInsert(server.replicas_waiting_rdbchannel,
-                          (unsigned char*)&c->id, sizeof(c->id), c, NULL);
                 serverLog(LL_NOTICE,
                           "Replica %s is capable of rdb channel synchronization, and partial sync isn't possible. "
                           "Full sync will continue with dedicated rdb channel.",
@@ -1406,9 +1390,11 @@ void replconfCommand(client *c) {
              * the current replica rdb channel with existing main channel
              * connection. */
             long long client_id = 0;
+            client *main_ch;
             if (getLongLongFromObjectOrReply(c, c->argv[j + 1], &client_id, NULL) != C_OK)
                 return;
-            if (!rdbChannelLookupMainChannelClient(client_id)) {
+            main_ch = lookupClientByID(client_id);
+            if (!main_ch || main_ch->replstate != SLAVE_STATE_WAIT_RDB_CHANNEL) {
                 addReplyErrorFormat(c, "Unrecognized RDB client id: %lld", client_id);
                 return;
             }
@@ -3117,6 +3103,7 @@ void syncWithMaster(connection *conn) {
             goto error;
         }
         server.repl_rdb_ch_state = REPL_RDB_CH_SEND_HANDSHAKE;
+        connSetReadHandler(server.repl_transfer_s, NULL);
         return;
     }
 
@@ -3467,14 +3454,6 @@ void replicationHandleMasterDisconnection(void) {
  *   │  +CONTINUE                                   │
  *   └──────────────────────────────────────────────┘
  */
-
-static client *rdbChannelLookupMainChannelClient(uint64_t id) {
-    void *c = NULL;
-    if (id == 0)
-        return NULL;
-    raxFind(server.replicas_waiting_rdbchannel, (unsigned char *)&id, sizeof(id), &c);
-    return c;
-}
 
 /* Replication: Replica side. */
 static int rdbChannelSendHandshake(connection *conn, sds *err) {

--- a/src/replication.c
+++ b/src/replication.c
@@ -3668,20 +3668,20 @@ error:
  * Initialize replica's local replication buffer to accumulate repl stream
  * during rdb channel sync. */
 static void rdbChannelReplDataBufInit(void) {
-    serverAssert(server.repl_pending_data.blocks == NULL);
-    server.repl_pending_data.size = 0;
-    server.repl_pending_data.used = 0;
-    server.repl_pending_data.blocks = listCreate();
-    server.repl_pending_data.blocks->free = zfree;
+    serverAssert(server.repl_full_sync_buffer.blocks == NULL);
+    server.repl_full_sync_buffer.size = 0;
+    server.repl_full_sync_buffer.used = 0;
+    server.repl_full_sync_buffer.blocks = listCreate();
+    server.repl_full_sync_buffer.blocks->free = zfree;
 }
 
 /* Replication: Replica side.
  * Free replica's local replication buffer */
 static void rdbChannelReplDataBufFree(void) {
-    listRelease(server.repl_pending_data.blocks);
-    server.repl_pending_data.blocks = NULL;
-    server.repl_pending_data.size = 0;
-    server.repl_pending_data.used = 0;
+    listRelease(server.repl_full_sync_buffer.blocks);
+    server.repl_full_sync_buffer.blocks = NULL;
+    server.repl_full_sync_buffer.size = 0;
+    server.repl_full_sync_buffer.used = 0;
 }
 
 /* Replication: Replica side.
@@ -3700,7 +3700,7 @@ int rdbChannelReadIntoBuf(connection *conn, replDataBufBlock *b) {
     }
 
     b->used += nread;
-    server.repl_pending_data.used += nread;
+    server.repl_full_sync_buffer.used += nread;
     atomicIncr(server.stat_net_repl_input_bytes, nread);
 
     return nread;
@@ -3714,7 +3714,7 @@ void rdbChannelBufferReplData(connection *conn) {
     int nread = 0;
     int needs_read = 1;
 
-    listNode *ln = listLast(server.repl_pending_data.blocks);
+    listNode *ln = listLast(server.repl_full_sync_buffer.blocks);
     replDataBufBlock *tail = ln ? listNodeValue(ln) : NULL;
 
     /* Try to append last node. */
@@ -3732,8 +3732,14 @@ void rdbChannelBufferReplData(connection *conn) {
         unsigned long long limit;
         size_t usable_size;
 
-        limit = server.client_obuf_limits[CLIENT_TYPE_SLAVE].hard_limit_bytes;
-        if (limit != 0 && server.repl_pending_data.size > limit) {
+        /* For accumulation limit, if 'replica-full-sync-buffer-limit' is set,
+         * we'll use it. Otherwise, 'client-output-buffer-limit <replica>' is
+         * the limit.*/
+        limit = server.repl_full_sync_buffer_limit;
+        if (limit == 0)
+             limit = server.client_obuf_limits[CLIENT_TYPE_SLAVE].hard_limit_bytes;
+
+        if (limit != 0 && server.repl_full_sync_buffer.size > limit) {
             serverLog(LL_NOTICE, "Replication buffer limit has been reached (%llu bytes), "
                                  "stopped buffering replication stream. Further accumulation may occur on master side. ", limit);
             connSetReadHandler(conn, NULL);
@@ -3744,12 +3750,12 @@ void rdbChannelBufferReplData(connection *conn) {
         tail->size = usable_size - sizeof(replDataBufBlock);
         tail->used = 0;
 
-        listAddNodeTail(server.repl_pending_data.blocks, tail);
-        server.repl_pending_data.size += tail->size;
+        listAddNodeTail(server.repl_full_sync_buffer.blocks, tail);
+        server.repl_full_sync_buffer.size += tail->size;
 
         /* Update buffer's peak */
-        if (server.repl_pending_data.peak < server.repl_pending_data.size)
-            server.repl_pending_data.peak = server.repl_pending_data.size;
+        if (server.repl_full_sync_buffer.peak < server.repl_full_sync_buffer.size)
+            server.repl_full_sync_buffer.peak = server.repl_full_sync_buffer.size;
 
         rdbChannelReadIntoBuf(conn, tail);
     }
@@ -3765,26 +3771,26 @@ int rdbChannelStreamReplDataToDb(client *c) {
 
     serverAssert(c->flags & CLIENT_MASTER);
 
-    if (!server.repl_pending_data.blocks)
+    if (!server.repl_full_sync_buffer.blocks)
         return C_OK;
 
     blockingOperationStarts();
     protectClient(c);
-    while ((n = listFirst(server.repl_pending_data.blocks))) {
+    while ((n = listFirst(server.repl_full_sync_buffer.blocks))) {
         o = listNodeValue(n);
         size = o->size;
         used = o->used;
         c->querybuf = sdscatlen(c->querybuf, o->buf, used);
         c->read_reploff += (long long int) used;
-        listDelNode(server.repl_pending_data.blocks, n);
+        listDelNode(server.repl_full_sync_buffer.blocks, n);
 
         /* We don't expect error return value but just in case. */
         ret = processInputBuffer(c);
         if (ret != C_OK)
             break;
 
-        server.repl_pending_data.used -= used;
-        server.repl_pending_data.size -= size;
+        server.repl_full_sync_buffer.used -= used;
+        server.repl_full_sync_buffer.size -= size;
 
         if (server.repl_debug_pause & REPL_DEBUG_ON_STREAMING_REPL_BUF)
             debugPauseProcess();
@@ -3802,7 +3808,7 @@ int rdbChannelStreamReplDataToDb(client *c) {
         /* Check if master client was freed in processEventsWhileBlocked().
          * It can happen if we receive 'replicaof' command or 'client kill'
          * command for the master. */
-        if (c->flags & CLIENT_CLOSE_ASAP || !server.repl_pending_data.blocks) {
+        if (c->flags & CLIENT_CLOSE_ASAP || !server.repl_full_sync_buffer.blocks) {
             ret = C_ERR;
             break;
         }
@@ -3872,7 +3878,7 @@ static int rdbChannelAbortRdbTransfer(void) {
 /* Replica side. After loading the rdb, stream replication buffer to the db. */
 static void rdbChannelSuccess(void) {
     serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Starting to stream replication buffer into the db"
-                         " (%zu bytes).", server.repl_pending_data.used);
+                         " (%zu bytes).", server.repl_full_sync_buffer.used);
 
     if (rdbChannelStreamReplDataToDb(server.master) == C_ERR) {
         serverLog(LL_WARNING, "Failed to stream local replication buffer into the db");

--- a/src/replication.c
+++ b/src/replication.c
@@ -44,13 +44,12 @@ void replicationSendAck(void);
 int replicaPutOnline(client *slave);
 void replicaStartCommandStream(client *slave);
 int cancelReplicationHandshake(int reconnect);
-static void rdbChannelAttachToBacklog(client *slave);
-static void rdbChannelAttachReplicasToBacklog(void);
-static void rdbChannelSetupMainConnForPsync(connection *conn);
-static void rdbChannelHandleRdbLoadCompletion(void);
 static void rdbChannelFullSyncWithMaster(connection *conn);
-static client *rdbChannelLookupRdbClient(uint64_t id);
+static client *rdbChannelLookupMainChannelClient(uint64_t id);
 static int rdbChannelAbortRdbTransfer(void);
+static void rdbChannelBufferReplData(connection *conn);
+static void rdbChannelReplDataBufInit(void);
+static void rdbChannelSuccess(void);
 
 /* We take a global flag to remember if this instance generated an RDB
  * because of replication, so that we can remove the RDB file in case
@@ -77,9 +76,9 @@ int replicationCheckHasMainChannel(client *replica) {
         return 0;
 
     listRewind(server.slaves,&li);
-    while((ln = listNext(&li))) {
+    while ((ln = listNext(&li))) {
         client *c = listNodeValue(ln);
-        if (c->rdb_client_id != 0 && c->rdb_client_id == replica->id)
+        if (replica->main_ch_client_id && replica->main_ch_client_id == c->id)
             return 1;
     }
     return 0;
@@ -255,7 +254,8 @@ int canFeedReplicaReplBuffer(client *replica) {
     if (replica->flags & CLIENT_REPL_RDBONLY) return 0;
 
     /* Don't feed replicas that are still waiting for BGSAVE to start. */
-    if (replica->replstate == SLAVE_STATE_WAIT_BGSAVE_START) return 0;
+    if (replica->replstate == SLAVE_STATE_WAIT_BGSAVE_START ||
+        replica->replstate == SLAVE_STATE_WAIT_RDB_CHANNEL) return 0;
 
     /* Don't feed replicas that are going to be closed ASAP. */
     if (replica->flags & CLIENT_CLOSE_ASAP) return 0;
@@ -263,6 +263,20 @@ int canFeedReplicaReplBuffer(client *replica) {
     return 1;
 }
 
+/* Create the replication backlog if needed. */
+void createReplicationBacklogIfNeeded(void) {
+    if (listLength(server.slaves) == 1 && server.repl_backlog == NULL) {
+        /* When we create the backlog from scratch, we always use a new
+         * replication ID and clear the ID2, since there is no valid
+         * past history. */
+        changeReplicationId();
+        clearReplicationId2();
+        createReplicationBacklog();
+        serverLog(LL_NOTICE,"Replication backlog created, my new "
+                            "replication IDs are '%s' and '%s'",
+                            server.replid, server.replid2);
+    }
+}
 /* Similar with 'prepareClientToWrite', note that we must call this function
  * before feeding replication stream into global replication buffer, since
  * clientHasPendingReplies in prepareClientToWrite will access the global
@@ -360,8 +374,12 @@ void incrementalTrimReplicationBacklog(size_t max_blocks) {
                               server.repl_backlog->histlen + 1;
 }
 
-/* Free replication buffer blocks that are referenced by this client. */
-void freeReplicaReferencedReplBuffer(client *replica) {
+/* Free replication buffer blocks that are referenced by this client.
+ * Also, removes replica from rdbchannel waiting list. */
+void freeReplicaReferences(client *replica) {
+    raxRemove(server.replicas_waiting_rdbchannel,
+              (unsigned char*) &replica->id, sizeof(replica->id), NULL);
+
     if (replica->ref_repl_buf_node != NULL) {
         /* Decrease the start buffer node reference count. */
         replBufBlock *o = listNodeValue(replica->ref_repl_buf_node);
@@ -371,17 +389,6 @@ void freeReplicaReferencedReplBuffer(client *replica) {
     }
     replica->ref_repl_buf_node = NULL;
     replica->ref_block_pos = 0;
-
-    if (replica->flags & CLIENT_REPL_RDB_CHANNEL) {
-        if (raxRemove(server.replicas_waiting_psync,
-                      (unsigned char *)&replica->id, sizeof(replica->id), NULL))
-        {
-            serverLog(LL_DEBUG, "Removed replica %s with client_id=%"PRIu64""
-                                " from psync waiting list.",
-                                replicationGetSlaveName(replica), replica->id);
-        }
-        replica->flags &= ~CLIENT_PROTECTED_RDB_CHANNEL;
-    }
 }
 
 /* Append bytes into the global replication buffer list, replication backlog and
@@ -400,7 +407,6 @@ void feedReplicationBuffer(char *s, size_t len) {
         int add_new_block = 0; /* Create new block if current block is total used. */
         listNode *ln = listLast(server.repl_buffer_blocks);
         replBufBlock *tail = ln ? listNodeValue(ln) : NULL;
-        int empty_backlog = (tail == NULL);
 
         /* Append to tail string when possible. */
         if (tail && tail->size > tail->used) {
@@ -448,18 +454,13 @@ void feedReplicationBuffer(char *s, size_t len) {
             server.master_repl_offset += copy;
             server.repl_backlog->histlen += copy;
         }
-        if (empty_backlog && raxSize(server.replicas_waiting_psync) > 0) {
-            /* This is the first block. Attach replicas to it. */
-            rdbChannelAttachReplicasToBacklog();
-        }
 
         /* For output buffer of replicas. */
         listIter li;
         listRewind(server.slaves,&li);
         while((ln = listNext(&li))) {
             client *slave = ln->value;
-            if (!canFeedReplicaReplBuffer(slave) && !(slave->flags & CLIENT_PROTECTED_RDB_CHANNEL))
-                continue;
+            if (!canFeedReplicaReplBuffer(slave)) continue;
 
             /* Update shared replication buffer start position. */
             if (slave->ref_repl_buf_node == NULL) {
@@ -770,7 +771,7 @@ long long getPsyncInitialOffset(void) {
  * BGSAVE for replication was started, or when there is one already in
  * progress that we attached our slave to. */
 int replicationSetupSlaveForFullResync(client *slave, long long offset) {
-    char buf[256];
+    char buf[128];
     int buflen;
 
     slave->psync_initial_offset = offset;
@@ -784,15 +785,25 @@ int replicationSetupSlaveForFullResync(client *slave, long long offset) {
      * the old SYNC command. */
     if (!(slave->flags & CLIENT_PRE_PSYNC)) {
         if (slave->slave_req & SLAVE_REQ_RDB_CHANNEL) {
-            rdbChannelAttachToBacklog(slave);
-            buflen = snprintf(buf,sizeof(buf),"+FULLRESYNC %s %lld %llu\r\n",
-                              server.replid,offset,
-                              (unsigned long long) slave->id);
-        } else {
-            buflen = snprintf(buf,sizeof(buf),"+FULLRESYNC %s %lld\r\n",
-                              server.replid,offset);
+            /* This slave is rdbchannel. Find its associated main channel and
+             * change its state so we can deliver replication stream from now
+             * on, in parallel to rdb. */
+            uint64_t id = slave->main_ch_client_id;
+            client *c = rdbChannelLookupMainChannelClient(id);
+            if (c) {
+                c->replstate = SLAVE_STATE_BG_RDB_TRANSFER;
+                raxRemove(server.replicas_waiting_rdbchannel,
+                          (unsigned char*) &id, sizeof(id), NULL);
+                serverLog(LL_NOTICE, "Starting to deliver RDB and replication stream to replica: %s",
+                          replicationGetSlaveName(c));
+            } else {
+                serverLog(LL_WARNING, "Starting to deliver RDB to replica %s"
+                                      " but it has no associated main channel",
+                                      replicationGetSlaveName(slave));
+            }
         }
-
+        buflen = snprintf(buf,sizeof(buf),"+FULLRESYNC %s %lld\r\n",
+                          server.replid,offset);
         if (connWrite(slave->conn,buf,buflen) != buflen) {
             freeClientAsync(slave);
             return C_ERR;
@@ -839,7 +850,7 @@ int masterTryPartialResynchronization(client *c, long long psync_offset) {
         } else {
             serverLog(LL_NOTICE,"Full resync requested by replica %s %s",
                 replicationGetSlaveName(c),
-                c->flags & CLIENT_REPL_RDB_CHANNEL ? "(rdbchannel)" : "");
+                c->flags & CLIENT_REPL_RDB_CHANNEL ? "(rdb-channel)" : "");
         }
         goto need_full_resync;
     }
@@ -863,15 +874,9 @@ int masterTryPartialResynchronization(client *c, long long psync_offset) {
      * 2) Inform the client we can continue with +CONTINUE
      * 3) Send the backlog data (from the offset to the end) to the slave. */
     c->flags |= CLIENT_SLAVE;
+    c->replstate = SLAVE_STATE_ONLINE;
     c->repl_ack_time = server.unixtime;
     c->repl_start_cmd_stream_on_ack = 0;
-    /* Rdb channel holds a reference to the backlog to prevent it being freed
-     * until main channel establishes psync. Check if there is an associated
-     * rdb channel with this replica. If so, it means psync from main channel
-     * has been established. After attaching main channel to the backlog, we can
-     * remove the rdb channel reference.*/
-    client *rdb_client = rdbChannelLookupRdbClient(c->rdb_client_id);
-    c->replstate = rdb_client ? SLAVE_STATE_BG_RDB_TRANSFER: SLAVE_STATE_ONLINE;
     listAddNodeTail(server.slaves,c);
     /* We can't use the connection buffers since they are used to accumulate
      * new commands at this stage. But we are sure the socket send buffer is
@@ -894,16 +899,12 @@ int masterTryPartialResynchronization(client *c, long long psync_offset) {
      * to -1 to force the master to emit SELECT, since the slave already
      * has this state from the previous connection with the master. */
 
-    if (c->replstate == SLAVE_STATE_BG_RDB_TRANSFER) {
-        freeReplicaReferencedReplBuffer(rdb_client);
-    } else {
-        refreshGoodSlavesCount();
+    refreshGoodSlavesCount();
 
-        /* Fire the replica change modules event. */
-        moduleFireServerEvent(REDISMODULE_EVENT_REPLICA_CHANGE,
-                              REDISMODULE_SUBEVENT_REPLICA_CHANGE_ONLINE,
-                              NULL);
-    }
+    /* Fire the replica change modules event. */
+    moduleFireServerEvent(REDISMODULE_EVENT_REPLICA_CHANGE,
+                          REDISMODULE_SUBEVENT_REPLICA_CHANGE_ONLINE,
+                          NULL);
 
     return C_OK; /* The caller can return, no full resync needed. */
 
@@ -948,7 +949,7 @@ int startBgsaveForReplication(int mincapa, int req) {
 
     serverLog(LL_NOTICE,"Starting BGSAVE for SYNC with target: %s%s",
         socket_target ? "replicas sockets" : "disk",
-        (req & SLAVE_REQ_RDB_CHANNEL) ? " (rdb-channel)." : ".");
+        (req & SLAVE_REQ_RDB_CHANNEL) ? " (rdb-channel)" : "");
 
     rdbSaveInfo rsi, *rsiptr;
     rsiptr = rdbPopulateSaveInfo(&rsi);
@@ -1111,12 +1112,32 @@ void syncCommand(client *c) {
              * resync. */
             if (master_replid[0] != '?') server.stat_sync_partial_err++;
             if (c->slave_capa & SLAVE_CAPA_RDB_CHANNEL_REPL) {
+                int len;
+                char buf[128];
+                /* Replica is capable of rdbchannel replication. This is
+                 * replica's main channel. Let replica know full sync is needed.
+                 * Replica will open another connection (rdbchannel). Once rdb
+                 * delivery starts, we'll stream repl data to the main channel.*/
+                c->flags |= CLIENT_SLAVE;
+                c->replstate = SLAVE_STATE_WAIT_RDB_CHANNEL;
+                c->repl_ack_time = server.unixtime;
+                listAddNodeTail(server.slaves, c);
+                createReplicationBacklogIfNeeded();
+
+                /* Add replica to waiting rdbchannel list. */
+                raxInsert(server.replicas_waiting_rdbchannel,
+                          (unsigned char*)&c->id, sizeof(c->id), c, NULL);
                 serverLog(LL_NOTICE,
                           "Replica %s is capable of rdb channel synchronization, and partial sync isn't possible. "
-                          "Full sync will continue with dedicated RDB channel.",
+                          "Full sync will continue with dedicated rdb channel.",
                           replicationGetSlaveName(c));
-                const char *buf = "+RDBCHANNELSYNC\r\n";
-                if (connWrite(c->conn, buf, strlen(buf)) != (int)strlen(buf))
+
+                /* Send +RDBCHANNELSYNC with client id. Rdbchannel of replica
+                 * will call 'replconf set-main-ch-id <client-id>' so we can
+                 * associate replica connections on master.*/
+                len = snprintf(buf, sizeof(buf), "+RDBCHANNELSYNC %llu\r\n",
+                               (unsigned long long) c->id);
+                if (connWrite(c->conn, buf, strlen(buf)) != len)
                     freeClientAsync(c);
 
                 return;
@@ -1142,17 +1163,7 @@ void syncCommand(client *c) {
     listAddNodeTail(server.slaves,c);
 
     /* Create the replication backlog if needed. */
-    if (listLength(server.slaves) == 1 && server.repl_backlog == NULL) {
-        /* When we create the backlog from scratch, we always use a new
-         * replication ID and clear the ID2, since there is no valid
-         * past history. */
-        changeReplicationId();
-        clearReplicationId2();
-        createReplicationBacklog();
-        serverLog(LL_NOTICE,"Replication backlog created, my new "
-                            "replication IDs are '%s' and '%s'",
-                            server.replid, server.replid2);
-    }
+    createReplicationBacklogIfNeeded();
 
     /* CASE 1: BGSAVE is in progress, with disk target. */
     if (server.child_type == CHILD_TYPE_RDB &&
@@ -1262,7 +1273,7 @@ void syncCommand(client *c) {
  * a single include filter: "functions". Passing an empty string "" will
  * result in an empty RDB.
  *
- * - set-rdb-client-id <client-id>
+ * - main-ch-client-id <client-id>
  * Replica's main channel informs master that this is the main channel of the
  * rdb channel identified by the client-id. */
 void replconfCommand(client *c) {
@@ -1390,17 +1401,18 @@ void replconfCommand(client *c) {
                 c->flags &= ~CLIENT_REPL_RDB_CHANNEL;
                 c->slave_req &= ~SLAVE_REQ_RDB_CHANNEL;
             }
-        } else if (!strcasecmp(c->argv[j]->ptr, "set-rdb-client-id")) {
-            /* REPLCONF set-rdb-client-id <client-id> is used to identify the
-             * current replica main channel with existing rdb-connection. */
+        } else if (!strcasecmp(c->argv[j]->ptr, "main-ch-client-id")) {
+            /* REPLCONF main-ch-client-id <client-id> is used to identify
+             * the current replica rdb channel with existing main channel
+             * connection. */
             long long client_id = 0;
             if (getLongLongFromObjectOrReply(c, c->argv[j + 1], &client_id, NULL) != C_OK)
                 return;
-            if (!rdbChannelLookupRdbClient(client_id)) {
+            if (!rdbChannelLookupMainChannelClient(client_id)) {
                 addReplyErrorFormat(c, "Unrecognized RDB client id: %lld", client_id);
                 return;
             }
-            c->rdb_client_id = (uint64_t)client_id;
+            c->main_ch_client_id = (uint64_t)client_id;
         } else {
             addReplyErrorFormat(c,"Unrecognized REPLCONF option: %s",
                 (char*)c->argv[j]->ptr);
@@ -1989,26 +2001,6 @@ void disklessLoadDiscardTempDb(redisDb *tempDb) {
     discardTempDb(tempDb);
 }
 
-static void replicationFullSyncCompleted(void) {
-    replicationCreateMasterClient(server.repl_transfer_s,
-                                  server.repl_loaded_rdb_dbid);
-    server.repl_state = REPL_STATE_CONNECTED;
-    server.repl_down_since = 0;
-
-    /* Fire the master link modules event. */
-    moduleFireServerEvent(REDISMODULE_EVENT_MASTER_LINK_CHANGE,
-                          REDISMODULE_SUBEVENT_MASTER_LINK_UP,
-                          NULL);
-
-    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Finished with success");
-    if (server.supervised_mode == SUPERVISED_SYSTEMD)
-        redisCommunicateSystemd("STATUS=MASTER <-> REPLICA sync: Finished with success. Ready to accept connections in read-write mode.\n");
-
-    /* Send the initial ACK immediately to put this replica in online state. */
-    if (!(server.master->flags & CLIENT_PRE_PSYNC))
-        replicationSendAck();
-}
-
 /* If we know we got an entirely different data set from our master
  * we have no way to incrementally feed our replicas after that.
  * We want our replicas to resync with us as well, if we have any sub-replicas.
@@ -2435,25 +2427,57 @@ void readSyncBulkPayload(connection *conn) {
         server.repl_transfer_tmpfile = NULL;
     }
 
+    /* Final setup of the connected slave <- master link */
+    replicationCreateMasterClient(server.repl_transfer_s,rsi.repl_stream_db);
+    server.repl_state = REPL_STATE_CONNECTED;
+    server.repl_down_since = 0;
+
+    /* Fire the master link modules event. */
+    moduleFireServerEvent(REDISMODULE_EVENT_MASTER_LINK_CHANGE,
+                          REDISMODULE_SUBEVENT_MASTER_LINK_UP,
+                          NULL);
+
     /* After a full resynchronization we use the replication ID and
      * offset of the master. The secondary ID / offset are cleared since
      * we are starting a new history. */
-    memcpy(server.replid, server.master_replid, sizeof(server.replid));
-    server.master_repl_offset = server.master_initial_offset;
+    memcpy(server.replid,server.master->replid,sizeof(server.replid));
+    server.master_repl_offset = server.master->reploff;
     clearReplicationId2();
-    /* Save dbid of the rdb, we'll use it while creating master client. */
-    server.repl_loaded_rdb_dbid = rsi.repl_stream_db;
 
     /* Let's create the replication backlog if needed. Slaves need to
      * accumulate the backlog regardless of the fact they have sub-slaves
      * or not, in order to behave correctly if they are promoted to
      * masters after a failover. */
     if (server.repl_backlog == NULL) createReplicationBacklog();
+    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Finished with success");
 
-    if (!rdbchannel)
-        replicationFullSyncCompleted();
-    else
-        rdbChannelHandleRdbLoadCompletion();
+    if (server.supervised_mode == SUPERVISED_SYSTEMD) {
+        redisCommunicateSystemd("STATUS=MASTER <-> REPLICA sync: Finished with success. Ready to accept connections in read-write mode.\n");
+    }
+
+    /* Send the initial ACK immediately to put this replica in online state. */
+    if (usemark) replicationSendAck();
+
+    if (rdbchannel) {
+        int close_asap;
+
+        if (server.repl_rdb_transfer_s) {
+            connClose(server.repl_rdb_transfer_s);
+            server.repl_rdb_transfer_s = NULL;
+        }
+        /* At this point, RDB is loaded. If state is REPL_RDB_CH_STATE_CLOSE_ASAP,
+         * it means main channel faced a problem while RDB is being loaded. It
+         * stopped replication stream buffering. It's okay though. We'll stream
+         * whatever we have into the db, then replica will try psync from the
+         * index that it has. */
+        close_asap = (server.repl_rdb_ch_state == REPL_RDB_CH_STATE_CLOSE_ASAP);
+        /* Finalize fullsync */
+        rdbChannelSuccess();
+
+        /* Main channel connection was broken. Let's trigger a psync with master. */
+        if (close_asap && server.master)
+            freeClientAsync(server.master);
+    }
 
     /* Restart the AOF subsystem now that we finished the sync. This
      * will trigger an AOF rewrite, and when done will start appending
@@ -2627,16 +2651,9 @@ int slaveTryPartialResynchronization(connection *conn, int read_reply) {
          * a FULL resync using the PSYNC command we'll set the offset at the
          * right value, so that this information will be propagated to the
          * client structure representing the master into server.master. */
-        if (server.repl_rdb_ch_state == REPL_RDB_CH_STATE_NONE)
-            server.master_initial_offset = -1;
+        server.master_initial_offset = -1;
 
-        if (server.repl_rdb_ch_state != REPL_RDB_CH_STATE_NONE) {
-            /* Use replid and offset from +FULLRESYNC reply of rdb channel. */
-            psync_replid = server.master_replid;
-            snprintf(psync_offset, sizeof(psync_offset), "%lld", server.master_initial_offset + 1);
-            serverLog(LL_NOTICE, "Trying a partial resynchronization using main channel (request %s:%s).",
-                      psync_replid, psync_offset);
-        } else if (server.cached_master) {
+        if (server.cached_master) {
             psync_replid = server.cached_master->replid;
             snprintf(psync_offset,sizeof(psync_offset),"%lld", server.cached_master->reploff+1);
             serverLog(LL_NOTICE,"Trying a partial resynchronization (request %s:%s).", psync_replid, psync_offset);
@@ -2714,6 +2731,16 @@ int slaveTryPartialResynchronization(connection *conn, int read_reply) {
     }
 
     if (!strncmp(reply, "+RDBCHANNELSYNC", strlen("+RDBCHANNELSYNC"))) {
+        char *client_id = client_id = strchr(reply,' ');
+        if (client_id)
+            client_id++;
+
+        if (!client_id) {
+            serverLog(LL_WARNING,
+                      "Master replied with wrong +RDBCHANNELSYNC syntax: %s", reply);
+            return PSYNC_NOT_SUPPORTED;
+        }
+        server.repl_main_ch_client_id = strtoll(client_id, NULL, 10);;
         /* A response of +RDBCHANNELSYNC from the master implies that partial
          * synchronization is not possible and that the master supports full
          * sync using dedicated RDB channel. Full sync will continue that way.*/
@@ -2723,12 +2750,6 @@ int slaveTryPartialResynchronization(connection *conn, int read_reply) {
     }
 
     if (!strncmp(reply,"+CONTINUE",9)) {
-        if (server.repl_rdb_ch_state != REPL_RDB_CH_STATE_NONE) {
-            /* master_replid and master_initial_offset is already set
-             * in rdbChannelHandleFullresyncReply() */
-            sdsfree(reply);
-            return PSYNC_CONTINUE;
-        }
         /* Partial resync was accepted. */
         serverLog(LL_NOTICE,
             "Successful partial resynchronization with master.");
@@ -2804,19 +2825,6 @@ int slaveTryPartialResynchronization(connection *conn, int read_reply) {
     }
     sdsfree(reply);
     return PSYNC_NOT_SUPPORTED;
-}
-
-sds getTryPsyncString(int result) {
-    switch (result) {
-        case PSYNC_WRITE_ERROR: return sdsnew("PSYNC_WRITE_ERROR");
-        case PSYNC_WAIT_REPLY: return sdsnew("PSYNC_WAIT_REPLY");
-        case PSYNC_CONTINUE: return sdsnew("PSYNC_CONTINUE");
-        case PSYNC_FULLRESYNC: return sdsnew("PSYNC_FULLRESYNC");
-        case PSYNC_NOT_SUPPORTED: return sdsnew("PSYNC_NOT_SUPPORTED");
-        case PSYNC_TRY_LATER: return sdsnew("PSYNC_TRY_LATER");
-        case PSYNC_FULLRESYNC_RDBCHANNEL: return sdsnew("PSYNC_FULLRESYNC_RDBCHANNEL");
-        default: return sdsnew("Unknown result");
-    }
 }
 
 /* This handler fires when the non blocking connect was able to
@@ -3393,15 +3401,15 @@ void replicationHandleMasterDisconnection(void) {
  *  - When replica connects to the master, it sends 'rdb-channel-repl' as part
  *    of capability exchange to let master to know replica supports rdb channel.
  *  - When replica lacks sufficient data for PSYNC, master sends +RDBCHANNELSYNC
- *    reply. As the next step, the replica opens a new connection (rdb-channel)
- *    and configures it against the master with the appropriate capabilities
- *    and requirements. Then, replica requests fullsync using the RDB channel.
- *  - Prior to forking, master sends the snapshot's end repl-offset and
- *    rdbchannel's client id to the replica rdbchannel. Then, master attaches
- *    the replica to the replication backlog to keep replication data until the
- *    replica requests psync starting at the snapshot end offset. The replica
- *    sends rdbchannel client id using the main channel so, master can associate
- *    replica's channels. After that, replica request a PSYNC.
+ *    reply with replica's client id. As the next step, the replica opens a new
+ *    connection (rdb-channel) and configures it against the master with the
+ *    appropriate capabilities and requirements. It also sends given client id
+ *    back to master over rdbchannel so that master can associate these
+ *    channels (initial replica connection will be referred as main-channel)
+ *    Then, replica requests fullsync using the RDB channel.
+ *  - Prior to forking, master attaches the replica's main channel to the
+ *    replication backlog to deliver replication stream starting at the snapshot
+ *    end offset.
  *  - The master main process sends replication stream via the main channel,
  *    while the bgsave process sends the RDB directly to the replica via the
  *    rdb-channel. Replica accumulates replication stream in a local buffer,
@@ -3410,118 +3418,62 @@ void replicationHandleMasterDisconnection(void) {
  *    streams the accumulated replication stream into the db. Sync is completed.
  *
  * * Replica state machine *
- * ┌───────────────────┐             Rdb channel sync
- * │REPL_STATE_CONNECT │          ┌──────────────────────────────────────────────────────────────┐
- * └────────┬──────────┘          │     RDB channel state                Main channel state      │
- *          │                     │     ┌────────────────────────────┐   ┌───────────────────┐   │
- * ┌───────────────────┐        ┌─┼─────►RDB_CH_SEND_HANDSHAKE       │ ┌─►SEND_HANDSHAKE     │   │
- * │RECEIVE_PING_REPLY │        │ │     └────┬───────────────────────┘ │ └──┬────────────────┘   │
- * └────────┬──────────┘        │ │          │                         │    │REPLCONF set-rdb-client-id <clientid>
- *          │ +PONG             │ │  ┌───────▼───────────────────────┐ │ ┌──▼────────────────┐   │
- * ┌────────▼──────────┐        │ │  │ RDB_CH_RECEIVE_AUTH_REPLY     │ │ │RECEIVE_CAPA_REPLY │   │
- * │SEND_HANDSHAKE     │        │ │  └───────┬───────────────────────┘ │ └──┬────────────────┘   │
- * └────────┬──────────┘        │ │          │+OK                      │    │+OK                 │
- *          │+OK                │ │  ┌───────▼───────────────────────┐ │ ┌──▼────────────────┐   │
- * ┌────────▼──────────┐        │ │  │ RDB_CH_RECEIVE_REPLCONF_REPLY │ │ │SEND_PSYNC         │   │
- * │RECEIVE_AUTH_REPLY │        │ │  └───────┬───────────────────────┘ │ └──┬────────────────┘   │
- * └────────┬──────────┘        │ │          │+OK                      │    │PSYNC use snapshot  │
- *          │+OK                │ │  ┌───────▼───────────────────────┐ │    │end-offset provided │
- * ┌────────▼──────────┐        │ │  │ RDB_CH_RECEIVE_FULLRESYNC     │ │    │by the master       │
- * │RECEIVE_PORT_REPLY │        │ │  └───────┬───────────────────────┘ │ ┌──▼────────────────┐   │
- * └────────┬──────────┘        │ │          │FULLRESYNC .. <clientid> │ │RECEIVE_PSYNC_REPLY│   │
- *          │+OK                │ │          ├─────────────────────────┘ └──┬────────────────┘   │
- * ┌────────▼──────────┐        │ │          │                              │+CONTINUE           │
- * │RECEIVE_IP_REPLY   │        │ │  ┌───────▼───────────────┐           ┌──▼────────────────┐   │
- * └────────┬──────────┘        │ │  │REPL_RDB_CH_RDB_LOAD   │           │TRANSFER           │   │
- *          │+OK                │ │  └───────┬───────────────┘           └─────┬─────────────┘   │
- * ┌────────▼──────────┐        │ │          │Done loading                     │                 │
- * │RECEIVE_CAPA_REPLY │        │ │  ┌───────▼───────────────┐                 │                 │
- * └────────┬──────────┘        │ │  │REPL_RDB_CH_RDB_LOADED │                 │                 │
- *          │                   │ │  └───────┬───────────────┘                 │                 │
- * ┌────────▼───┐               │ │          │                                 │                 │
- * │SEND_PSYNC  │               │ │          │Replica loads local replication  │                 │
- * └─┬──────────┘               │ │          │buffer into memory               │                 │
- *   │PSYNC (use cached-master) │ │          └─────────┬───────────────────────┘                 │
- * ┌─▼─────────────────┐        │ │                    │                                         │
- * │RECEIVE_PSYNC_REPLY│        │ └────────────────────┼─────────────────────────────────────────┘
- * └────────┬─┬────────┘        │                      │
- * +CONTINUE│ │+RDBCHANNELSYNC  │                      │
- *   │      │ └─────────────────┘                      │
- *   │      │+FULLRESYNC                               │
- *   │    ┌─▼─────────────────┐                   ┌────▼──────────────┐
- *   │    │TRANSFER           ├───────────────────►CONNECTED          │
- *   │    └───────────────────┘                   └────▲──────────────┘
- *   │                                                 │
- *   └─────────────────────────────────────────────────┘
+ *
+ * Main channel state
+ * ┌───────────────────┐
+ * │RECEIVE_PING_REPLY │
+ * └────────┬──────────┘
+ *          │ +PONG
+ * ┌────────▼──────────┐
+ * │SEND_HANDSHAKE     │                     RDB channel state
+ * └────────┬──────────┘            ┌───────────────────────────────┐
+ *          │+OK                ┌───► RDB_CH_SEND_HANDSHAKE         │
+ * ┌────────▼──────────┐        │   └──────────────┬────────────────┘
+ * │RECEIVE_AUTH_REPLY │        │    REPLCONF main-ch-client-id <clientid>
+ * └────────┬──────────┘        │   ┌──────────────▼────────────────┐
+ *          │+OK                │   │ RDB_CH_RECEIVE_AUTH_REPLY     │
+ * ┌────────▼──────────┐        │   └──────────────┬────────────────┘
+ * │RECEIVE_PORT_REPLY │        │                  │ +OK
+ * └────────┬──────────┘        │   ┌──────────────▼────────────────┐
+ *          │+OK                │   │  RDB_CH_RECEIVE_REPLCONF_REPLY│
+ * ┌────────▼──────────┐        │   └──────────────┬────────────────┘
+ * │RECEIVE_IP_REPLY   │        │                  │ +OK
+ * └────────┬──────────┘        │   ┌──────────────▼────────────────┐
+ *          │+OK                │   │ RDB_CH_RECEIVE_FULLRESYNC     │
+ * ┌────────▼──────────┐        │   └──────────────┬────────────────┘
+ * │RECEIVE_CAPA_REPLY │        │                  │+FULLRESYNC
+ * └────────┬──────────┘        │                  │Rdb delivery
+ *          │                   │   ┌──────────────▼────────────────┐
+ * ┌────────▼──────────┐        │   │ RDB_CH_RDB_LOADING            │
+ * │SEND_PSYNC         │        │   └──────────────┬────────────────┘
+ * └─┬─────────────────┘        │                  │ Done loading
+ *   │PSYNC (use cached-master) │                  │
+ * ┌─▼─────────────────┐        │                  │
+ * │RECEIVE_PSYNC_REPLY│        │    ┌────────────►│ Replica streams replication
+ * └─┬─────────────────┘        │    │             │ buffer into memory
+ *   │                          │    │             │
+ *   │+RDBCHANNELSYNC client-id │    │             │
+ *   ├──────┬───────────────────┘    │             │
+ *   │      │ Main channel           │             │
+ *   │      │ accumulates repl data  │             │
+ *   │   ┌──▼────────────────┐       │     ┌───────▼───────────┐
+ *   │   │ REPL_TRANSFER     ├───────┘     │    CONNECTED      │
+ *   │   └───────────────────┘             └────▲───▲──────────┘
+ *   │                                          │   │
+ *   │                                          │   │
+ *   │  +FULLRESYNC    ┌───────────────────┐    │   │
+ *   ├────────────────► REPL_TRANSFER      ├────┘   │
+ *   │                 └───────────────────┘        │
+ *   │  +CONTINUE                                   │
+ *   └──────────────────────────────────────────────┘
  */
 
-/* On the master side, this function is called for rdb channel replica just
- * before forking for rdb delivery. It attaches rdbchannel client to the backlog
- * to prevent it being freed until main channel establishes psync for the
- * current offset.
- *
- * Association occurs in two forms:
- * 1. If there's an existing buffer block at fork time, the replica is
- *    attached to the tail.
- * 2. If there's no tail, the replica is attached when a new buffer block is
- *    created (see rdbChannelAttachReplicasToBacklog())
- * The replica RDB client ID is used as a unique key for this association.
- * If a client output buffer overrun occurs, the association is deleted and the
- * RDB connection is dropped. Otherwise, on a successful run, rdbchannel replica
- * association will be deleted in masterTryPartialResynchronization() once
- * main channel establishes psync. */
-static void rdbChannelAttachToBacklog(client *slave) {
-    listNode *ln = listLast(server.repl_buffer_blocks);
-    replBufBlock *tail = ln ? listNodeValue(ln) : NULL;
-
-    if (tail)
-        tail->refcount++;
-
-    /* Prevent rdb client from being freed before psync is established. */
-    slave->flags |= CLIENT_PROTECTED_RDB_CHANNEL;
-    slave->ref_repl_buf_node = tail ? ln : NULL;
-    raxInsert(server.replicas_waiting_psync,
-              (unsigned char *)&slave->id, sizeof(slave->id), slave, NULL);
-
-    serverLog(LL_DEBUG, "Added rdb replica %s to the psync waiting list. "
-                        "(cid = %"PRIu64") (tail = %d)",
-                        replicationGetSlaveName(slave),
-                        slave->id, tail != NULL);
-}
-
-/* Replication: master side. Returns a client by ID, or NULL if the client ID
- * is not in psync waiting clients list. */
-static client *rdbChannelLookupRdbClient(uint64_t id) {
+static client *rdbChannelLookupMainChannelClient(uint64_t id) {
     void *c = NULL;
     if (id == 0)
         return NULL;
-    raxFind(server.replicas_waiting_psync, (unsigned char *)&id, sizeof(id), &c);
+    raxFind(server.replicas_waiting_rdbchannel, (unsigned char *)&id, sizeof(id), &c);
     return c;
-}
-
-/* Replication: master side.
- * Attach psync waiting replicas to the new replication backlog head. */
-static void rdbChannelAttachReplicasToBacklog(void) {
-    raxIterator iter;
-    listNode *ln = listFirst(server.repl_buffer_blocks);
-    replBufBlock *head = ln ? listNodeValue(ln) : NULL;
-
-    if (head == NULL)
-        return;
-
-    raxStart(&iter, server.replicas_waiting_psync);
-    raxSeek(&iter, "^", NULL, 0);
-    while (raxNext(&iter)) {
-        client *rdb_client = iter.data;
-        if (rdb_client->ref_repl_buf_node)
-            continue;
-
-        rdb_client->ref_repl_buf_node = ln;
-        head->refcount++;
-        serverLog(LL_DEBUG, "Attached replica rdb client %"PRIu64
-                            " to repl buf block", rdb_client->id);
-    }
-    raxStop(&iter);
 }
 
 /* Replication: Replica side. */
@@ -3549,8 +3501,12 @@ static int rdbChannelSendHandshake(connection *conn, sds *err) {
     char buf[LONG_STR_SIZE];
     slaveGetPortStr(buf, sizeof(buf));
 
+    char cid[LONG_STR_SIZE];
+    ull2string(cid, sizeof(cid), server.repl_main_ch_client_id);
+
     *err = sendCommand(conn, "REPLCONF", "capa", "eof", "rdb-only", "1",
-                       "rdb-channel", "1", "listening-port", buf, NULL);
+                       "rdb-channel", "1", "main-ch-client-id", cid,
+                       "listening-port", buf, NULL);
     if (*err) {
         serverLog(LL_WARNING, "Error sending REPLCONF command to master in rdb channel handshake: %s", *err);
         return C_ERR;
@@ -3593,6 +3549,9 @@ static int rdbChannelHandleReplconfReply(connection *conn, sds *err) {
     }
     sdsfree(*err);
 
+    if (server.repl_debug_pause & REPL_DEBUG_BEFORE_RDB_CHANNEL)
+        debugPauseProcess();
+
     /* Request rdb from master */
     *err = sendCommand(conn, "PSYNC", "?", "-1", NULL);
     if (*err) {
@@ -3605,9 +3564,7 @@ static int rdbChannelHandleReplconfReply(connection *conn, sds *err) {
 
 /* Replication: Replica side. */
 static int rdbChannelHandleFullresyncReply(connection *conn, sds *err) {
-    long long reploff = 0;
-    unsigned long long rdb_client_id = 0;
-    char replid[CONFIG_RUN_ID_SIZE + 1] = {0};
+    char *replid = NULL, *offset = NULL;
 
     *err = receiveSynchronousResponse(conn);
     if (*err == NULL)
@@ -3619,30 +3576,35 @@ static int rdbChannelHandleFullresyncReply(connection *conn, sds *err) {
         return C_RETRY;
     }
 
-    /* Parse +FULLRESYNC reply */
-    if (sscanf(*err, "+FULLRESYNC %40s %lld %llu",
-               replid, &reploff, &rdb_client_id) != 3)
-    {
+    /* FULL RESYNC, parse the reply in order to extract the replid
+     * and the replication offset. */
+    replid = strchr(*err,' ');
+    if (replid) {
+        replid++;
+        offset = strchr(replid, ' ');
+        if (offset) offset++;
+    }
+    if (!replid || !offset || (offset-replid-1) != CONFIG_RUN_ID_SIZE) {
         serverLog(LL_WARNING, "Received unexpected psync reply: %s", *err);
         return C_ERR;
     }
+    memcpy(server.master_replid, replid, offset-replid-1);
+    server.master_replid[CONFIG_RUN_ID_SIZE] = '\0';
+    server.master_initial_offset = strtoll(offset,NULL,10);
 
-    /* Save replid, reploff and rdb_client id */
-    memcpy(server.master_replid, replid, sizeof(replid));
-    server.master_initial_offset = reploff;
-    server.repl_rdbchannel_client_id = rdb_client_id;
+    /* Prepare the main and rdb channels for rdb and repl stream delivery.*/
+    server.repl_state = REPL_STATE_TRANSFER;
+    rdbChannelReplDataBufInit();
 
-    /* Now that we have the snapshot end-offset, we can ask for psync from that
-     * offset. Prepare the main and rdb channels accordingly.*/
-    server.repl_state = REPL_STATE_SEND_HANDSHAKE;
+    serverLog(LL_NOTICE, "Fullresync reply from master: %s", *err);
+    serverLog(LL_NOTICE, "Starting to receive RDB and replication stream in parallel.");
 
+    /* RDB is still loading. Setup connection to accumulate repl data.  */
     if (connSetReadHandler(server.repl_transfer_s,
-                           rdbChannelSetupMainConnForPsync) != C_OK)
+                           rdbChannelBufferReplData) != C_OK)
     {
-        char inf[CONN_INFO_LEN];
-        serverLog(LL_WARNING,
-                  "Can't create readable event for main channel connection: %s (%s)",
-                  strerror(errno), connGetInfo(conn, inf, sizeof(inf)));
+        serverLog(LL_WARNING, "Can't set read handler for main channel: %s",
+                  strerror(errno));
         return C_ERR;
     }
 
@@ -3658,7 +3620,6 @@ static int rdbChannelHandleFullresyncReply(connection *conn, sds *err) {
         return C_ERR;
     }
 
-    rdbChannelSetupMainConnForPsync(server.repl_transfer_s);
     return C_OK;
 }
 
@@ -3930,13 +3891,11 @@ static int rdbChannelAbortRdbTransfer(void) {
     return C_OK;
 }
 
-/* Replication: Replica side. After loading the rdb, create a master client and
- * stream replication buffer to the db. */
-void rdbChannelSuccess(void) {
-    replicationFullSyncCompleted();
-
+/* Replica side. After loading the rdb, stream replication buffer to the db. */
+static void rdbChannelSuccess(void) {
     serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Starting to stream replication buffer into the db"
                          " (%zu bytes).", server.repl_pending_data.used);
+
     if (rdbChannelStreamReplDataToDb(server.master) == C_ERR) {
         serverLog(LL_WARNING, "Failed to stream local replication buffer into the db");
 
@@ -3945,157 +3904,10 @@ void rdbChannelSuccess(void) {
             freeClientAsync(server.master);
         return;
     }
-    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Successfully streamed replication buffer into the db");
 
+    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Successfully streamed replication buffer into the db");
     rdbChannelReplDataBufFree();
     server.repl_rdb_ch_state = REPL_RDB_CH_STATE_NONE;
-}
-
-/* Replication: Replica side.
- * RDB channel done loading the RDB. Check whether the main channel has
- * completed its part and act accordingly. */
-void rdbChannelHandleRdbLoadCompletion(void) {
-    int close_asap;
-
-    if (server.repl_rdb_transfer_s) {
-        connClose(server.repl_rdb_transfer_s);
-        server.repl_rdb_transfer_s = NULL;
-    }
-
-    /* At this point, RDB is loaded. If state is REPL_RDB_CH_STATE_CLOSE_ASAP,
-     * it means main channel faced a problem while RDB is being loaded. It
-     * stopped replication stream buffering. It's okay though. We'll stream
-     * whatever we have into the db, then replica will try psync from the index
-     * that it has. */
-    close_asap = (server.repl_rdb_ch_state == REPL_RDB_CH_STATE_CLOSE_ASAP);
-    if (!close_asap && server.repl_state != REPL_STATE_TRANSFER) {
-        /* Main channel isn't done yet. We'll finalize fullsync once main
-         * channel establishes psync. See rdbChannelMainConnRecvPsyncReply()*/
-        server.repl_rdb_ch_state = REPL_RDB_CH_RDB_LOADED;
-        return;
-    }
-    /* Finalize fullsync */
-    rdbChannelSuccess();
-
-    /* Main channel connection was broken. Let's trigger a psync with master. */
-    if (close_asap && server.master)
-        freeClientAsync(server.master);
-}
-
-/* Replication: Replica side. */
-int rdbChannelMainConnSendHandshake(connection *conn, sds *err) {
-    char llstr[LONG_STR_SIZE];
-    ull2string(llstr, sizeof(llstr), server.repl_rdbchannel_client_id);
-    *err = sendCommand(conn, "REPLCONF", "set-rdb-client-id", llstr, NULL);
-    return *err ? C_ERR : C_OK;
-}
-
-/* Replication: Replica side. */
-int rdbChannelMainConnRecvCapaReply(connection *conn, sds *err) {
-    *err = receiveSynchronousResponse(conn);
-    if (*err == NULL)
-        return C_ERR;
-
-    if ((*err)[0] == '-') {
-        serverLog(LL_WARNING, "Master does not understand REPLCONF set-rdb-client-id: %s", *err);
-        return C_ERR;
-    }
-    return C_OK;
-}
-
-/* Replication: Replica side. */
-int rdbChannelMainConnSendPsync(connection *conn, sds *err) {
-    if (server.repl_debug_pause & REPL_DEBUG_BEFORE_MAIN_CONN_PSYNC)
-        debugPauseProcess();
-
-    if (slaveTryPartialResynchronization(conn, 0) == PSYNC_WRITE_ERROR) {
-        serverLog(LL_WARNING, "Aborting rdb channel sync. Write error.");
-        *err = sdsnew(connGetLastError(conn));
-        return C_ERR;
-    }
-    return C_OK;
-}
-
-/* Replication: Replica side. */
-int rdbChannelMainConnRecvPsyncReply(connection *conn, sds *err) {
-    int psync_result = slaveTryPartialResynchronization(conn, 1);
-    if (psync_result == PSYNC_WAIT_REPLY)
-        return C_OK; /* Try again later... */
-
-    if (psync_result != PSYNC_CONTINUE) {
-        *err = getTryPsyncString(psync_result);
-        return C_ERR;
-    }
-
-    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Master accepted a Partial Resynchronization%s",
-              server.repl_rdb_transfer_s != NULL ? ", RDB load in background." : ".");
-
-    if (server.repl_rdb_ch_state < REPL_RDB_CH_RDB_LOADED) {
-        /* RDB is still loading. Setup connection to accumulate repl data.  */
-        if (connSetReadHandler(server.repl_transfer_s,
-                               rdbChannelBufferReplData) != C_OK)
-        {
-            serverLog(LL_WARNING, "Can't set read handler for main channel: %s",
-                      strerror(errno));
-            return C_ERR;
-        }
-        rdbChannelReplDataBufInit();
-        return C_OK;
-    }
-    serverLog(LL_DEBUG, "Main channel established psync after rdb load.");
-
-    /* RDB is already loaded. Time to finalize fullsync. */
-    rdbChannelSuccess();
-    return C_OK;
-}
-
-/* Replication: Replica side.
- * This connection handler fires after rdb-connection was initialized. We use it
- * to adjust the replica main connection for accumulating replication stream
- * into the local buffer. */
-void rdbChannelSetupMainConnForPsync(connection *conn) {
-    int ret;
-    char *err = NULL;
-
-    switch (server.repl_state) {
-        case REPL_STATE_SEND_HANDSHAKE:
-            ret = rdbChannelMainConnSendHandshake(conn, &err);
-            if (ret == C_OK)
-                server.repl_state = REPL_STATE_RECEIVE_CAPA_REPLY;
-            break;
-        case REPL_STATE_RECEIVE_CAPA_REPLY:
-            ret = rdbChannelMainConnRecvCapaReply(conn, &err);
-            if (ret == C_ERR)
-                break;
-
-            if (ret == C_OK)
-                server.repl_state = REPL_STATE_SEND_PSYNC;
-            sdsfree(err);
-            err = NULL;
-            /* fall through */
-        case REPL_STATE_SEND_PSYNC:
-            ret = rdbChannelMainConnSendPsync(conn, &err);
-            if (ret == C_OK)
-                server.repl_state = REPL_STATE_RECEIVE_PSYNC_REPLY;
-            break;
-        case REPL_STATE_RECEIVE_PSYNC_REPLY:
-            ret = rdbChannelMainConnRecvPsyncReply(conn, &err);
-            if (ret == C_OK && server.repl_rdb_ch_state != REPL_RDB_CH_STATE_NONE)
-                server.repl_state = REPL_STATE_TRANSFER;
-            /* In case the RDB is already loaded, the repl_state will be set
-             * during rdbChannelSuccess(). */
-            break;
-        default:
-            serverPanic("Unexpected replication state: %d", server.repl_state);
-    }
-
-    if (ret == C_ERR) {
-        serverLog(LL_WARNING, "Aborting rdb channel sync. "
-                              "Main channel psync result = %d, errmsg = %s",
-                              ret, err ? err : "none");
-        cancelReplicationHandshake(1);
-    }
-    sdsfree(err);
 }
 
 void replicaofCommand(client *c) {

--- a/src/rio.c
+++ b/src/rio.c
@@ -520,7 +520,7 @@ static size_t rioConnsetRead(rio *r, void *buf, size_t len) {
     return 0; /* Error, this target does not support reading. */
 }
 
-/* Returns read/write position in file. */
+/* Returns the number of sent bytes. */
 static off_t rioConnsetTell(rio *r) {
     return r->io.connset.pos;
 }

--- a/src/rio.c
+++ b/src/rio.c
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2009-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2) or the Server Side Public License v1 (SSPLv1).
+ *
+ * Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
+ */
+
 /* rio.c is a simple stream-oriented I/O abstraction that provides an interface
  * to write code that can consume/produce data using different concrete input
  * and output devices. For instance the same rdb.c code using the rio
@@ -14,35 +27,6 @@
  * for the current checksum.
  *
  * ----------------------------------------------------------------------------
- *
- * Copyright (c) 2009-2012, Pieter Noordhuis <pcnoordhuis at gmail dot com>
- * Copyright (c) 2009-current, Redis Ltd.
- * Copyright (c) 2024-present, Valkey contributors.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *   * Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *   * Neither the name of Redis nor the names of its contributors may be used
- *     to endorse or promote products derived from this software without
- *     specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 

--- a/src/rio.h
+++ b/src/rio.h
@@ -1,32 +1,14 @@
 /*
- * Copyright (c) 2009-2012, Pieter Noordhuis <pcnoordhuis at gmail dot com>
- * Copyright (c) 2009-current, Redis Ltd.
+ * Copyright (c) 2009-Present, Redis Ltd.
+ * All rights reserved.
+ *
  * Copyright (c) 2024-present, Valkey contributors.
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2) or the Server Side Public License v1 (SSPLv1).
  *
- *   * Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *   * Neither the name of Redis nor the names of its contributors may be used
- *     to endorse or promote products derived from this software without
- *     specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
  */
 
 

--- a/src/server.c
+++ b/src/server.c
@@ -6139,7 +6139,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                     "slave%d:ip=%s,port=%d,state=%s,"
                     "offset=%lld,lag=%ld\r\n",
                     slaveid,slaveip,slave->slave_listening_port,state,
-                                    slave->repl_ack_off, lag);
+                    slave->repl_ack_off, lag);
                 slaveid++;
             }
         }

--- a/src/server.c
+++ b/src/server.c
@@ -2180,6 +2180,10 @@ void initServerConfig(void) {
     server.cached_master = NULL;
     server.master_initial_offset = -1;
     server.repl_state = REPL_STATE_NONE;
+    server.repl_rdb_ch_state = REPL_RDB_CH_STATE_NONE;
+    server.repl_rdbchannel_client_id = 0;
+    server.repl_loaded_rdb_dbid = -1;
+    server.repl_pending_data = (struct replDataBuf) {0};
     server.repl_transfer_tmpfile = NULL;
     server.repl_transfer_fd = -1;
     server.repl_transfer_s = NULL;
@@ -2676,6 +2680,8 @@ void initServer(void) {
     server.hz = server.config_hz;
     server.pid = getpid();
     server.in_fork_child = CHILD_TYPE_NONE;
+    server.rdb_pipe_read = -1;
+    server.rdb_child_exit_pipe = -1;
     server.main_thread_id = pthread_self();
     server.current_client = NULL;
     server.errors = raxNew();
@@ -2686,6 +2692,8 @@ void initServer(void) {
     server.clients_to_close = listCreate();
     server.slaves = listCreate();
     server.monitors = listCreate();
+    server.replicas_waiting_psync = raxNew();
+    server.repl_delay_rdb_client_free = REPL_DELAY_RDB_CLIENT_FREE;
     server.clients_pending_write = listCreate();
     server.clients_pending_read = listCreate();
     server.clients_timeout_table = raxNew();
@@ -5456,6 +5464,8 @@ const char *replstateToString(int replstate) {
     case SLAVE_STATE_WAIT_BGSAVE_START:
     case SLAVE_STATE_WAIT_BGSAVE_END:
         return "wait_bgsave";
+    case SLAVE_STATE_BG_RDB_TRANSFER:
+        return "bg_rdb_transfer";
     case SLAVE_STATE_SEND_BULK:
         return "send_bulk";
     case SLAVE_STATE_ONLINE:
@@ -6053,7 +6063,9 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                 "master_last_io_seconds_ago:%d\r\n", server.master ? ((int)(server.unixtime-server.master->lastinteraction)) : -1,
                 "master_sync_in_progress:%d\r\n", server.repl_state == REPL_STATE_TRANSFER,
                 "slave_read_repl_offset:%lld\r\n", slave_read_repl_offset,
-                "slave_repl_offset:%lld\r\n", slave_repl_offset));
+                "slave_repl_offset:%lld\r\n", slave_repl_offset,
+                "replica_repl_pending_data_size:%zu\r\n", server.repl_pending_data.size,
+                "replica_repl_pending_data_peak:%zu\r\n", server.repl_pending_data.peak));
 
             if (server.repl_state == REPL_STATE_TRANSFER) {
                 double perc = 0;
@@ -6117,13 +6129,17 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
 
                 info = sdscatprintf(info,
                     "slave%d:ip=%s,port=%d,state=%s,"
-                    "offset=%lld,lag=%ld\r\n",
+                    "offset=%lld,lag=%ld,type=%s\r\n",
                     slaveid,slaveip,slave->slave_listening_port,state,
-                    slave->repl_ack_off, lag);
+                                    slave->repl_ack_off, lag,
+                                    slave->flags & CLIENT_REPL_RDB_CHANNEL
+                                        ? "rdb-channel" : slave->replstate == SLAVE_STATE_BG_RDB_TRANSFER
+                                                                                ? "main-channel" : "replica");
                 slaveid++;
             }
         }
         info = sdscatprintf(info, FMTARGS(
+            "replicas_waiting_psync:%"PRIu64"\r\n", raxSize(server.replicas_waiting_psync),
             "master_failover_state:%s\r\n", getFailoverStateString(),
             "master_replid:%s\r\n", server.replid,
             "master_replid2:%s\r\n", server.replid2,

--- a/src/server.c
+++ b/src/server.c
@@ -2181,8 +2181,6 @@ void initServerConfig(void) {
     server.master_initial_offset = -1;
     server.repl_state = REPL_STATE_NONE;
     server.repl_rdb_ch_state = REPL_RDB_CH_STATE_NONE;
-    server.repl_rdbchannel_client_id = 0;
-    server.repl_loaded_rdb_dbid = -1;
     server.repl_pending_data = (struct replDataBuf) {0};
     server.repl_transfer_tmpfile = NULL;
     server.repl_transfer_fd = -1;
@@ -2692,8 +2690,7 @@ void initServer(void) {
     server.clients_to_close = listCreate();
     server.slaves = listCreate();
     server.monitors = listCreate();
-    server.replicas_waiting_psync = raxNew();
-    server.repl_delay_rdb_client_free = REPL_DELAY_RDB_CLIENT_FREE;
+    server.replicas_waiting_rdbchannel = raxNew();
     server.clients_pending_write = listCreate();
     server.clients_pending_read = listCreate();
     server.clients_timeout_table = raxNew();
@@ -5463,6 +5460,7 @@ const char *replstateToString(int replstate) {
     switch (replstate) {
     case SLAVE_STATE_WAIT_BGSAVE_START:
     case SLAVE_STATE_WAIT_BGSAVE_END:
+    case SLAVE_STATE_WAIT_RDB_CHANNEL:
         return "wait_bgsave";
     case SLAVE_STATE_BG_RDB_TRANSFER:
         return "bg_rdb_transfer";
@@ -6144,7 +6142,6 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             }
         }
         info = sdscatprintf(info, FMTARGS(
-            "replicas_waiting_psync:%"PRIu64"\r\n", raxSize(server.replicas_waiting_psync),
             "master_failover_state:%s\r\n", getFailoverStateString(),
             "master_replid:%s\r\n", server.replid,
             "master_replid2:%s\r\n", server.replid2,

--- a/src/server.c
+++ b/src/server.c
@@ -2181,7 +2181,7 @@ void initServerConfig(void) {
     server.master_initial_offset = -1;
     server.repl_state = REPL_STATE_NONE;
     server.repl_rdb_ch_state = REPL_RDB_CH_STATE_NONE;
-    server.repl_pending_data = (struct replDataBuf) {0};
+    server.repl_full_sync_buffer = (struct replDataBuf) {0};
     server.repl_transfer_tmpfile = NULL;
     server.repl_transfer_fd = -1;
     server.repl_transfer_s = NULL;
@@ -6061,8 +6061,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                 "master_sync_in_progress:%d\r\n", server.repl_state == REPL_STATE_TRANSFER,
                 "slave_read_repl_offset:%lld\r\n", slave_read_repl_offset,
                 "slave_repl_offset:%lld\r\n", slave_repl_offset,
-                "replica_repl_pending_data_size:%zu\r\n", server.repl_pending_data.size,
-                "replica_repl_pending_data_peak:%zu\r\n", server.repl_pending_data.peak));
+                "replica_full_sync_buffer_size:%zu\r\n", server.repl_full_sync_buffer.size,
+                "replica_full_sync_buffer_peak:%zu\r\n", server.repl_full_sync_buffer.peak));
 
             if (server.repl_state == REPL_STATE_TRANSFER) {
                 double perc = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -5461,8 +5461,8 @@ const char *replstateToString(int replstate) {
     case SLAVE_STATE_WAIT_BGSAVE_END:
     case SLAVE_STATE_WAIT_RDB_CHANNEL:
         return "wait_bgsave";
-    case SLAVE_STATE_BG_RDB_TRANSFER:
-        return "bg_rdb_transfer";
+    case SLAVE_STATE_SEND_BULK_AND_STREAM:
+        return "send_bulk_and_stream";
     case SLAVE_STATE_SEND_BULK:
         return "send_bulk";
     case SLAVE_STATE_ONLINE:

--- a/src/server.c
+++ b/src/server.c
@@ -2690,7 +2690,6 @@ void initServer(void) {
     server.clients_to_close = listCreate();
     server.slaves = listCreate();
     server.monitors = listCreate();
-    server.replicas_waiting_rdbchannel = raxNew();
     server.clients_pending_write = listCreate();
     server.clients_pending_read = listCreate();
     server.clients_timeout_table = raxNew();

--- a/src/server.h
+++ b/src/server.h
@@ -3017,6 +3017,8 @@ void clearFailoverState(void);
 void updateFailoverStatus(void);
 void abortFailover(const char *err);
 const char *getFailoverStateString(void);
+int replicationCheckHasMainChannel(client *slave);
+unsigned long replicationLogicalReplicaCount(void);
 
 /* Generic persistence functions */
 void startLoadingFile(size_t size, char* filename, int rdbflags);

--- a/src/server.h
+++ b/src/server.h
@@ -92,6 +92,7 @@ struct hdr_histogram;
 /* Error codes */
 #define C_OK                    0
 #define C_ERR                   -1
+#define C_RETRY                 -2
 
 /* Static server configuration */
 #define CONFIG_DEFAULT_HZ        10             /* Time interrupt calls/sec. */
@@ -394,6 +395,16 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_MODULE_PREVENT_AOF_PROP (1ULL<<48) /* Module client do not want to propagate to AOF */
 #define CLIENT_MODULE_PREVENT_REPL_PROP (1ULL<<49) /* Module client do not want to propagate to replica */
 #define CLIENT_REPROCESSING_COMMAND (1ULL<<50) /* The client is re-processing the command. */
+#define CLIENT_REPL_RDB_CHANNEL (1ULL<<51)      /* Rdb channel replication sync: track a connection which is used for rdb delivery */
+#define CLIENT_PROTECTED_RDB_CHANNEL (1ULL<<52) /* Rdb channel replication sync: Protects the RDB client from premature
+                                                 * release during full sync. This flag is used to ensure that the RDB client, which
+                                                 * references the first replication data block required by the replica, is not
+                                                 * released prematurely. Protecting the client is crucial for prevention of
+                                                 * synchronization failures. If the RDB client is released before the replica initiates
+                                                 * PSYNC, the master will reduce the reference count (o->refcount) of the block needed
+                                                 * by the replica. This could potentially lead to the removal of the required data block,
+                                                 * resulting in synchronization failures.By using this flag, we ensure that the RDB client
+                                                 * remains intact until the replica has successfully initiated PSYNC. */
 
 /* Any flag that does not let optimize FLUSH SYNC to run it in bg as blocking client ASYNC */
 #define CLIENT_AVOID_BLOCKING_ASYNC_FLUSH (CLIENT_DENY_BLOCKING|CLIENT_MULTI|CLIENT_LUA_DEBUG|CLIENT_LUA_DEBUG_SYNC|CLIENT_MODULE)
@@ -473,6 +484,26 @@ typedef enum {
     REPL_STATE_CONNECTED,       /* Connected to master */
 } repl_state;
 
+/* Replica rdb channel replication state. Used in server.repl_rdb_ch_state for
+ * replicas to remember what to do next. */
+typedef enum {
+    REPL_RDB_CH_STATE_CLOSE_ASAP = -1,  /* Async error state */
+    REPL_RDB_CH_STATE_NONE = 0,         /* No active rdb channel sync */
+    REPL_RDB_CH_SEND_HANDSHAKE,         /* Send handshake sequence to master */
+    REPL_RDB_CH_RECEIVE_AUTH_REPLY,     /* Wait for AUTH reply */
+    REPL_RDB_CH_RECEIVE_REPLCONF_REPLY, /* Wait for REPLCONF reply */
+    REPL_RDB_CH_RECEIVE_FULLRESYNC,     /* Wait for +FULLRESYNC reply */
+    REPL_RDB_CH_RDB_LOADING,            /* Loading rdb using rdb channel */
+    REPL_RDB_CH_RDB_LOADED,             /* RDB is loaded */
+} repl_rdb_channel_state;
+
+/* Replication debug flags for testing. */
+#define REPL_DEBUG_PAUSE_NONE             (1 << 0)
+#define REPL_DEBUG_AFTER_FORK             (1 << 1)
+#define REPL_DEBUG_BEFORE_MAIN_CONN_PSYNC (1 << 2)
+#define REPL_DEBUG_ON_STREAMING_REPL_BUF  (1 << 3)
+
+
 /* The state of an in progress coordinated failover */
 typedef enum {
     NO_FAILOVER = 0,        /* No failover in progress */
@@ -491,16 +522,21 @@ typedef enum {
 #define SLAVE_STATE_ONLINE 9 /* RDB file transmitted, sending just updates. */
 #define SLAVE_STATE_RDB_TRANSMITTED 10 /* RDB file transmitted - This state is used only for
                                         * a replica that only wants RDB without replication buffer  */
+#define SLAVE_STATE_BG_RDB_TRANSFER 11 /* Main channel of a replica which uses rdb channel replication.
+                                        * Sending RDB file and replication stream in parallel. */
 
 /* Slave capabilities. */
-#define SLAVE_CAPA_NONE 0
-#define SLAVE_CAPA_EOF (1<<0)    /* Can parse the RDB EOF streaming format. */
-#define SLAVE_CAPA_PSYNC2 (1<<1) /* Supports PSYNC2 protocol. */
+#define SLAVE_CAPA_NONE             0
+#define SLAVE_CAPA_EOF              (1<<0) /* Can parse the RDB EOF streaming format. */
+#define SLAVE_CAPA_PSYNC2           (1<<1) /* Supports PSYNC2 protocol. */
+#define SLAVE_CAPA_RDB_CHANNEL_REPL (1<<2) /* Supports rdb channel replication during full sync */
+
 
 /* Slave requirements */
-#define SLAVE_REQ_NONE 0
-#define SLAVE_REQ_RDB_EXCLUDE_DATA (1 << 0)      /* Exclude data from RDB */
+#define SLAVE_REQ_NONE                  0
+#define SLAVE_REQ_RDB_EXCLUDE_DATA      (1 << 0) /* Exclude data from RDB */
 #define SLAVE_REQ_RDB_EXCLUDE_FUNCTIONS (1 << 1) /* Exclude functions from RDB */
+#define SLAVE_REQ_RDB_CHANNEL           (1 << 2) /* Use rdb channel replication */
 /* Mask of all bits in the slave requirements bitfield that represent non-standard (filtered) RDB requirements */
 #define SLAVE_REQ_RDB_MASK (SLAVE_REQ_RDB_EXCLUDE_DATA | SLAVE_REQ_RDB_EXCLUDE_FUNCTIONS)
 
@@ -513,6 +549,9 @@ typedef enum {
 /* In order to quickly find the requested offset for PSYNC requests,
  * we index some nodes in the replication buffer linked list into a rax. */
 #define REPL_BACKLOG_INDEX_PER_BLOCKS 64
+
+/* Grace period in seconds for replica main channel to establish psync. */
+#define REPL_DELAY_RDB_CLIENT_FREE 60
 
 /* List related stuff */
 #define LIST_HEAD 0
@@ -1162,6 +1201,23 @@ typedef struct replBacklog {
                                   * byte in the replication backlog buffer.*/
 } replBacklog;
 
+/* Used by replDataBuf during rdb channel replication to accumulate replication
+ * stream on replica side. */
+typedef struct replDataBufBlock {
+    size_t used; /* Used bytes in the buf */
+    size_t size; /* Size of the buf */
+    char buf[];  /* Replication data */
+} replDataBufBlock;
+
+/* Linked list of replDataBufBlock structs, holds replication stream during
+ * rdb channel replication on replica side. */
+typedef struct replDataBuf {
+    list *blocks; /* List of replDataBufBlock */
+    size_t size;  /* Total number of bytes available in all blocks. */
+    size_t used;  /* Total number of bytes actually used in all blocks. */
+    size_t peak;  /* Peak number of bytes stored in all blocks. */
+} replDataBuf;
+
 typedef struct {
     list *clients;
     size_t mem_usage_sum;
@@ -1258,6 +1314,8 @@ typedef struct client {
     char *slave_addr;       /* Optionally given by REPLCONF ip-address */
     int slave_capa;         /* Slave capabilities: SLAVE_CAPA_* bitwise OR. */
     int slave_req;          /* Slave requirements: SLAVE_REQ_* */
+    uint64_t rdb_client_id; /* The client id of this replica's rdb connection */
+    time_t rdb_client_disconnect_time; /* Time of the first freeClient call on this client. Used for delaying free. */
     multiState mstate;      /* MULTI/EXEC state */
     blockingState bstate;     /* blocking state */
     long long woff;         /* Last write global replication offset. */
@@ -1671,6 +1729,7 @@ struct redisServer {
     list *clients_pending_write; /* There is to write or install handler. */
     list *clients_pending_read;  /* Client has pending read socket buffers. */
     list *slaves, *monitors;    /* List of slaves and MONITORs */
+    rax *replicas_waiting_psync;/* List of rdb channel clients until their main channel establishes pysnc. */
     client *current_client;     /* The client that triggered the command execution (External or AOF). */
     client *executing_client;   /* The client executing the current command (possibly script or module). */
 
@@ -1936,6 +1995,7 @@ struct redisServer {
     int repl_ping_slave_period;     /* Master pings the slave every N seconds */
     replBacklog *repl_backlog;      /* Replication backlog for partial syncs */
     long long repl_backlog_size;    /* Backlog circular buffer size */
+    replDataBuf repl_pending_data;  /* Accumulated replication data for rdb channel replication */
     time_t repl_backlog_time_limit; /* Time without slaves after the backlog
                                        gets released. */
     time_t repl_no_slaves_since;    /* We have no slaves since that time.
@@ -1949,6 +2009,11 @@ struct redisServer {
     int repl_diskless_sync_delay;   /* Delay to start a diskless repl BGSAVE. */
     int repl_diskless_sync_max_replicas;/* Max replicas for diskless repl BGSAVE
                                          * delay (start sooner if they all connect). */
+    int repl_rdb_channel;           /* Config used to determine if the replica should
+                                     * use rdb channel replication for full syncs. */
+    int repl_delay_rdb_client_free; /* Grace period in seconds for replica main channel
+                                      * to establish psync. */
+    int repl_debug_pause;           /* Debug config to force the main process to pause. */
     size_t repl_buffer_mem;         /* The memory of replication buffer. */
     list *repl_buffer_blocks;       /* Replication buffers blocks list
                                      * (serving replica clients and repl backlog) */
@@ -1962,10 +2027,14 @@ struct redisServer {
     client *cached_master; /* Cached master to be reused for PSYNC. */
     int repl_syncio_timeout; /* Timeout for synchronous I/O calls */
     int repl_state;          /* Replication status if the instance is a slave */
+    int repl_rdb_ch_state; /* State of the replica's rdb channel during rdb channel replication */
+    int repl_loaded_rdb_dbid; /* dbid in the loaded rdb */
+    uint64_t repl_rdbchannel_client_id; /* rdbchannel client id as defined on master side */
     off_t repl_transfer_size; /* Size of RDB to read from master during sync. */
     off_t repl_transfer_read; /* Amount of RDB read from master during sync. */
     off_t repl_transfer_last_fsync_off; /* Offset when we fsync-ed last time. */
     connection *repl_transfer_s;     /* Slave -> Master SYNC connection */
+    connection *repl_rdb_transfer_s; /* Slave -> Master FULL SYNC connection (RDB download) */
     int repl_transfer_fd;    /* Slave -> Master SYNC temp file descriptor */
     char *repl_transfer_tmpfile; /* Slave-> master SYNC temp file name */
     time_t repl_transfer_lastio; /* Unix time of the latest read, for timeout */
@@ -3972,6 +4041,7 @@ void killThreads(void);
 void makeThreadKillable(void);
 void swapMainDbWithTempDb(redisDb *tempDb);
 sds getVersion(void);
+void debugPauseProcess(void);
 
 /* Use macro for checking log level to avoid evaluating arguments in cases log
  * should be ignored due to low level. */

--- a/src/server.h
+++ b/src/server.h
@@ -1980,7 +1980,8 @@ struct redisServer {
     int repl_ping_slave_period;     /* Master pings the slave every N seconds */
     replBacklog *repl_backlog;      /* Replication backlog for partial syncs */
     long long repl_backlog_size;    /* Backlog circular buffer size */
-    replDataBuf repl_pending_data;  /* Accumulated replication data for rdb channel replication */
+    long long repl_full_sync_buffer_limit; /* Accumulated repl data limit during rdb channel replication */
+    replDataBuf repl_full_sync_buffer;  /* Accumulated replication data for rdb channel replication */
     time_t repl_backlog_time_limit; /* Time without slaves after the backlog
                                        gets released. */
     time_t repl_no_slaves_since;    /* We have no slaves since that time.

--- a/src/server.h
+++ b/src/server.h
@@ -395,16 +395,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_MODULE_PREVENT_AOF_PROP (1ULL<<48) /* Module client do not want to propagate to AOF */
 #define CLIENT_MODULE_PREVENT_REPL_PROP (1ULL<<49) /* Module client do not want to propagate to replica */
 #define CLIENT_REPROCESSING_COMMAND (1ULL<<50) /* The client is re-processing the command. */
-#define CLIENT_REPL_RDB_CHANNEL (1ULL<<51)      /* Rdb channel replication sync: track a connection which is used for rdb delivery */
-#define CLIENT_PROTECTED_RDB_CHANNEL (1ULL<<52) /* Rdb channel replication sync: Protects the RDB client from premature
-                                                 * release during full sync. This flag is used to ensure that the RDB client, which
-                                                 * references the first replication data block required by the replica, is not
-                                                 * released prematurely. Protecting the client is crucial for prevention of
-                                                 * synchronization failures. If the RDB client is released before the replica initiates
-                                                 * PSYNC, the master will reduce the reference count (o->refcount) of the block needed
-                                                 * by the replica. This could potentially lead to the removal of the required data block,
-                                                 * resulting in synchronization failures.By using this flag, we ensure that the RDB client
-                                                 * remains intact until the replica has successfully initiated PSYNC. */
+#define CLIENT_REPL_RDB_CHANNEL (1ULL<<51)      /* Client which is used for rdb delivery as part of rdb channel replication */
 
 /* Any flag that does not let optimize FLUSH SYNC to run it in bg as blocking client ASYNC */
 #define CLIENT_AVOID_BLOCKING_ASYNC_FLUSH (CLIENT_DENY_BLOCKING|CLIENT_MULTI|CLIENT_LUA_DEBUG|CLIENT_LUA_DEBUG_SYNC|CLIENT_MODULE)
@@ -494,15 +485,13 @@ typedef enum {
     REPL_RDB_CH_RECEIVE_REPLCONF_REPLY, /* Wait for REPLCONF reply */
     REPL_RDB_CH_RECEIVE_FULLRESYNC,     /* Wait for +FULLRESYNC reply */
     REPL_RDB_CH_RDB_LOADING,            /* Loading rdb using rdb channel */
-    REPL_RDB_CH_RDB_LOADED,             /* RDB is loaded */
 } repl_rdb_channel_state;
 
 /* Replication debug flags for testing. */
 #define REPL_DEBUG_PAUSE_NONE             (1 << 0)
 #define REPL_DEBUG_AFTER_FORK             (1 << 1)
-#define REPL_DEBUG_BEFORE_MAIN_CONN_PSYNC (1 << 2)
+#define REPL_DEBUG_BEFORE_RDB_CHANNEL     (1 << 2)
 #define REPL_DEBUG_ON_STREAMING_REPL_BUF  (1 << 3)
-
 
 /* The state of an in progress coordinated failover */
 typedef enum {
@@ -522,7 +511,9 @@ typedef enum {
 #define SLAVE_STATE_ONLINE 9 /* RDB file transmitted, sending just updates. */
 #define SLAVE_STATE_RDB_TRANSMITTED 10 /* RDB file transmitted - This state is used only for
                                         * a replica that only wants RDB without replication buffer  */
-#define SLAVE_STATE_BG_RDB_TRANSFER 11 /* Main channel of a replica which uses rdb channel replication.
+#define SLAVE_STATE_WAIT_RDB_CHANNEL 11 /* Main channel of replica is connected,
+                                         * we are waiting rdbchannel connection to start delivery.*/
+#define SLAVE_STATE_BG_RDB_TRANSFER 12 /* Main channel of a replica which uses rdb channel replication.
                                         * Sending RDB file and replication stream in parallel. */
 
 /* Slave capabilities. */
@@ -530,7 +521,6 @@ typedef enum {
 #define SLAVE_CAPA_EOF              (1<<0) /* Can parse the RDB EOF streaming format. */
 #define SLAVE_CAPA_PSYNC2           (1<<1) /* Supports PSYNC2 protocol. */
 #define SLAVE_CAPA_RDB_CHANNEL_REPL (1<<2) /* Supports rdb channel replication during full sync */
-
 
 /* Slave requirements */
 #define SLAVE_REQ_NONE                  0
@@ -549,9 +539,6 @@ typedef enum {
 /* In order to quickly find the requested offset for PSYNC requests,
  * we index some nodes in the replication buffer linked list into a rax. */
 #define REPL_BACKLOG_INDEX_PER_BLOCKS 64
-
-/* Grace period in seconds for replica main channel to establish psync. */
-#define REPL_DELAY_RDB_CLIENT_FREE 60
 
 /* List related stuff */
 #define LIST_HEAD 0
@@ -1314,8 +1301,7 @@ typedef struct client {
     char *slave_addr;       /* Optionally given by REPLCONF ip-address */
     int slave_capa;         /* Slave capabilities: SLAVE_CAPA_* bitwise OR. */
     int slave_req;          /* Slave requirements: SLAVE_REQ_* */
-    uint64_t rdb_client_id; /* The client id of this replica's rdb connection */
-    time_t rdb_client_disconnect_time; /* Time of the first freeClient call on this client. Used for delaying free. */
+    uint64_t main_ch_client_id; /* The client id of this replica's main channel */
     multiState mstate;      /* MULTI/EXEC state */
     blockingState bstate;     /* blocking state */
     long long woff;         /* Last write global replication offset. */
@@ -1729,7 +1715,7 @@ struct redisServer {
     list *clients_pending_write; /* There is to write or install handler. */
     list *clients_pending_read;  /* Client has pending read socket buffers. */
     list *slaves, *monitors;    /* List of slaves and MONITORs */
-    rax *replicas_waiting_psync;/* List of rdb channel clients until their main channel establishes pysnc. */
+    rax *replicas_waiting_rdbchannel;/* List of main channel clients until their rdb channel connects. */
     client *current_client;     /* The client that triggered the command execution (External or AOF). */
     client *executing_client;   /* The client executing the current command (possibly script or module). */
 
@@ -2011,8 +1997,6 @@ struct redisServer {
                                          * delay (start sooner if they all connect). */
     int repl_rdb_channel;           /* Config used to determine if the replica should
                                      * use rdb channel replication for full syncs. */
-    int repl_delay_rdb_client_free; /* Grace period in seconds for replica main channel
-                                      * to establish psync. */
     int repl_debug_pause;           /* Debug config to force the main process to pause. */
     size_t repl_buffer_mem;         /* The memory of replication buffer. */
     list *repl_buffer_blocks;       /* Replication buffers blocks list
@@ -2028,8 +2012,7 @@ struct redisServer {
     int repl_syncio_timeout; /* Timeout for synchronous I/O calls */
     int repl_state;          /* Replication status if the instance is a slave */
     int repl_rdb_ch_state; /* State of the replica's rdb channel during rdb channel replication */
-    int repl_loaded_rdb_dbid; /* dbid in the loaded rdb */
-    uint64_t repl_rdbchannel_client_id; /* rdbchannel client id as defined on master side */
+    uint64_t repl_main_ch_client_id; /* Main channel client id received in +RDBCHANNELSYNC reply. */
     off_t repl_transfer_size; /* Size of RDB to read from master during sync. */
     off_t repl_transfer_read; /* Amount of RDB read from master during sync. */
     off_t repl_transfer_last_fsync_off; /* Offset when we fsync-ed last time. */
@@ -2980,7 +2963,7 @@ void replicationFeedSlaves(list *slaves, int dictid, robj **argv, int argc);
 void replicationFeedStreamFromMasterStream(char *buf, size_t buflen);
 void resetReplicationBuffer(void);
 void feedReplicationBuffer(char *buf, size_t len);
-void freeReplicaReferencedReplBuffer(client *replica);
+void freeReplicaReferences(client *replica);
 void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv, int argc);
 void updateSlavesWaitingBgsave(int bgsaveerr, int type);
 void replicationCron(void);

--- a/src/server.h
+++ b/src/server.h
@@ -513,8 +513,8 @@ typedef enum {
                                         * a replica that only wants RDB without replication buffer  */
 #define SLAVE_STATE_WAIT_RDB_CHANNEL 11 /* Main channel of replica is connected,
                                          * we are waiting rdbchannel connection to start delivery.*/
-#define SLAVE_STATE_BG_RDB_TRANSFER 12 /* Main channel of a replica which uses rdb channel replication.
-                                        * Sending RDB file and replication stream in parallel. */
+#define SLAVE_STATE_SEND_BULK_AND_STREAM 12 /* Main channel of a replica which uses rdb channel replication.
+                                             * Sending RDB file and replication stream in parallel. */
 
 /* Slave capabilities. */
 #define SLAVE_CAPA_NONE             0

--- a/src/server.h
+++ b/src/server.h
@@ -1715,7 +1715,6 @@ struct redisServer {
     list *clients_pending_write; /* There is to write or install handler. */
     list *clients_pending_read;  /* Client has pending read socket buffers. */
     list *slaves, *monitors;    /* List of slaves and MONITORs */
-    rax *replicas_waiting_rdbchannel;/* List of main channel clients until their rdb channel connects. */
     client *current_client;     /* The client that triggered the command execution (External or AOF). */
     client *executing_client;   /* The client executing the current command (possibly script or module). */
 
@@ -2963,7 +2962,7 @@ void replicationFeedSlaves(list *slaves, int dictid, robj **argv, int argc);
 void replicationFeedStreamFromMasterStream(char *buf, size_t buflen);
 void resetReplicationBuffer(void);
 void feedReplicationBuffer(char *buf, size_t len);
-void freeReplicaReferences(client *replica);
+void freeReplicaReferencedReplBuffer(client *replica);
 void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv, int argc);
 void updateSlavesWaitingBgsave(int bgsaveerr, int type);
 void replicationCron(void);

--- a/tests/cluster/tests/12-replica-migration-2.tcl
+++ b/tests/cluster/tests/12-replica-migration-2.tcl
@@ -46,7 +46,7 @@ test "Resharding all the master #0 slots away from it" {
 }
 
 test "Master #0 who lost all slots should turn into a replica without replicas" {
-    wait_for_condition 1000 50 {
+    wait_for_condition 2000 50 {
         [RI 0 role] == "slave" && [RI 0 connected_slaves] == 0
     } else {
         puts [R 0 info replication]

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -2,17 +2,23 @@ source tests/support/redis.tcl
 
 set ::tlsdir "tests/tls"
 
-proc gen_write_load {host port seconds tls} {
+# Continuously sends SET commands to the server. If key is omitted, a random key
+# is used for every SET command. The value is always random.
+proc gen_write_load {host port seconds tls {key ""}} {
     set start_time [clock seconds]
     set r [redis $host $port 1 $tls]
     $r client setname LOAD_HANDLER
     $r select 9
     while 1 {
-        $r set [expr rand()] [expr rand()]
+        if {$key == ""} {
+            $r set [expr rand()] [expr rand()]
+        } else {
+            $r set $key [expr rand()]
+        }
         if {[clock seconds]-$start_time > $seconds} {
             exit 0
         }
     }
 }
 
-gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3]
+gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4]

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -1,3 +1,16 @@
+#
+# Copyright (c) 2009-Present, Redis Ltd.
+# All rights reserved.
+#
+# Copyright (c) 2024-present, Valkey contributors.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2) or the Server Side Public License v1 (SSPLv1).
+#
+# Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
+#
+
 source tests/support/redis.tcl
 
 set ::tlsdir "tests/tls"

--- a/tests/integration/psync2-master-restart.tcl
+++ b/tests/integration/psync2-master-restart.tcl
@@ -217,7 +217,7 @@ start_server {} {
 
         # Replication backlog is full
         assert {[status $master repl_backlog_first_byte_offset] > [status $master second_repl_offset]}
-        assert {[status $master sync_partial_ok] == 0}
+        assert {[status $master sync_partial_ok] == 1}
         assert {[status $master sync_full] == 1}
         assert {[status $master rdb_last_load_keys_expired] == 2048}
         assert {[status $replica sync_full] == 1}

--- a/tests/integration/psync2-master-restart.tcl
+++ b/tests/integration/psync2-master-restart.tcl
@@ -217,7 +217,7 @@ start_server {} {
 
         # Replication backlog is full
         assert {[status $master repl_backlog_first_byte_offset] > [status $master second_repl_offset]}
-        assert {[status $master sync_partial_ok] == 1}
+        assert {[status $master sync_partial_ok] == 0}
         assert {[status $master sync_full] == 1}
         assert {[status $master rdb_last_load_keys_expired] == 2048}
         assert {[status $replica sync_full] == 1}

--- a/tests/integration/replication-buffer.tcl
+++ b/tests/integration/replication-buffer.tcl
@@ -1,6 +1,7 @@
 # This test group aims to test that all replicas share one global replication buffer,
 # two replicas don't make replication buffer size double, and when there is no replica,
 # replica buffer will shrink.
+foreach rdbchannel {"yes" "no"} {
 start_server {tags {"repl external:skip"}} {
 start_server {} {
 start_server {} {
@@ -8,6 +9,10 @@ start_server {} {
     set replica1 [srv -3 client]
     set replica2 [srv -2 client]
     set replica3 [srv -1 client]
+
+    $replica1 config set repl-rdb-channel $rdbchannel
+    $replica2 config set repl-rdb-channel $rdbchannel
+    $replica3 config set repl-rdb-channel $rdbchannel
 
     set master [srv 0 client]
     set master_host [srv 0 host]
@@ -18,6 +23,7 @@ start_server {} {
     $master config set repl-diskless-sync-delay 5
     $master config set repl-diskless-sync-max-replicas 1
     $master config set client-output-buffer-limit "replica 0 0 0"
+    $master config set repl-rdb-channel $rdbchannel
 
     # Make sure replica3 is synchronized with master
     $replica3 replicaof $master_host $master_port
@@ -39,7 +45,7 @@ start_server {} {
         fail "fail to sync with replicas"
     }
 
-    test {All replicas share one global replication buffer} {
+    test "All replicas share one global replication buffer rdbchannel=$rdbchannel" {
         set before_used [s used_memory]
         populate 1024 "" 1024 ; # Write extra 1M data
         # New data uses 1M memory, but all replicas use only one
@@ -47,19 +53,31 @@ start_server {} {
         # more than double of replication buffer.
         set repl_buf_mem [s mem_total_replication_buffers]
         set extra_mem [expr {[s used_memory]-$before_used-1024*1024}]
-        assert {$extra_mem < 2*$repl_buf_mem}
+        if {$rdbchannel == "yes"} {
+            # master's replication buffers should not grow
+            assert {$extra_mem < 1024*1024}
+            assert {$repl_buf_mem < 1024*1024}
+        } else {
+            assert {$extra_mem < 2*$repl_buf_mem}
+        }
 
         # Kill replica1, replication_buffer will not become smaller
         catch {$replica1 shutdown nosave}
+        set replica_count 2
+        if {$rdbchannel == "yes"} {
+            # replica3 is connected, replica2 is syncing (has two connections)
+            set replica_count 3
+        }
+
         wait_for_condition 50 100 {
-            [s connected_slaves] eq {2}
+            [s connected_slaves] eq $replica_count
         } else {
             fail "replica doesn't disconnect with master"
         }
         assert_equal $repl_buf_mem [s mem_total_replication_buffers]
     }
 
-    test {Replication buffer will become smaller when no replica uses} {
+    test "Replication buffer will become smaller when no replica uses rdbchannel=$rdbchannel" {
         # Make sure replica3 catch up with the master
         wait_for_ofs_sync $master $replica3
 
@@ -71,8 +89,14 @@ start_server {} {
         } else {
             fail "replica2 doesn't disconnect with master"
         }
-        assert {[expr $repl_buf_mem - 1024*1024] > [s mem_total_replication_buffers]}
+        if {$rdbchannel == "yes"} {
+            # master's replication buffers should not grow
+            assert {1024*512 > [s mem_total_replication_buffers]}
+        } else {
+            assert {[expr $repl_buf_mem - 1024*1024] > [s mem_total_replication_buffers]}
+        }
     }
+}
 }
 }
 }
@@ -84,6 +108,7 @@ start_server {} {
 # partial re-synchronization. Of course, replication backlog memory also can
 # become smaller when master disconnects with slow replicas since output buffer
 # limit is reached.
+foreach rdbchannel {"yes" "no"} {
 start_server {tags {"repl external:skip"}} {
 start_server {} {
 start_server {} {
@@ -98,6 +123,7 @@ start_server {} {
 
     $master config set save ""
     $master config set repl-backlog-size 16384
+    $master config set repl-rdb-channel $rdbchannel
     $master config set client-output-buffer-limit "replica 0 0 0"
 
     # Executing 'debug digest' on master which has many keys costs much time
@@ -105,12 +131,16 @@ start_server {} {
     # with master.
     $master config set repl-timeout 1000
     $replica1 config set repl-timeout 1000
+    $replica1 config set repl-rdb-channel $rdbchannel
+    $replica1 config set client-output-buffer-limit "replica 1024 0 0"
     $replica2 config set repl-timeout 1000
+    $replica2 config set client-output-buffer-limit "replica 1024 0 0"
+    $replica2 config set repl-rdb-channel $rdbchannel
 
     $replica1 replicaof $master_host $master_port
     wait_for_sync $replica1
 
-    test {Replication backlog size can outgrow the backlog limit config} {
+    test "Replication backlog size can outgrow the backlog limit config rdbchannel=$rdbchannel" {
         # Generating RDB will take 1000 seconds
         $master config set rdb-key-save-delay 1000000
         populate 1000 master 10000
@@ -124,7 +154,7 @@ start_server {} {
         }
         # Replication actual backlog grow more than backlog setting since
         # the slow replica2 kept replication buffer.
-        populate 10000 master 10000
+        populate 20000 master 10000
         assert {[s repl_backlog_histlen] > [expr 10000*10000]}
     }
 
@@ -135,7 +165,7 @@ start_server {} {
         fail "Replica offset didn't catch up with the master after too long time"
     }
 
-    test {Replica could use replication buffer (beyond backlog config) for partial resynchronization} {
+    test "Replica could use replication buffer (beyond backlog config) for partial resynchronization rdbchannel=$rdbchannel" {
         # replica1 disconnects with master
         $replica1 replicaof [srv -1 host] [srv -1 port]
         # Write a mass of data that exceeds repl-backlog-size
@@ -151,13 +181,25 @@ start_server {} {
         # replica2 still waits for bgsave ending
         assert {[s rdb_bgsave_in_progress] eq {1} && [lindex [$replica2 role] 3] eq {sync}}
         # master accepted replica1 partial resync
-        assert_equal [s sync_partial_ok] {1}
+        if {$rdbchannel == "yes"} {
+            # 2 psync as part of 2 full syncs
+            # 1 psync as part of partial resync
+            assert_equal [s sync_partial_ok] {3}
+        } else {
+            assert_equal [s sync_partial_ok] {1}
+        }
         assert_equal [$master debug digest] [$replica1 debug digest]
     }
 
-    test {Replication backlog memory will become smaller if disconnecting with replica} {
+    test "Replication backlog memory will become smaller if disconnecting with replica rdbchannel=$rdbchannel" {
         assert {[s repl_backlog_histlen] > [expr 2*10000*10000]}
-        assert_equal [s connected_slaves] {2}
+        if {$rdbchannel == "yes"} {
+            # replica1 has one connection
+            # replica2 is syncing (has two connections)
+            assert_equal [s connected_slaves] {3}
+        } else {
+            assert_equal [s connected_slaves] {2}
+        }
 
         pause_process $replica2_pid
         r config set client-output-buffer-limit "replica 128k 0 0"
@@ -166,7 +208,9 @@ start_server {} {
         # master will close replica2's connection since replica2's output
         # buffer limit is reached, so there only is replica1.
         wait_for_condition 100 100 {
-            [s connected_slaves] eq {1}
+            [s connected_slaves] eq {1} ||
+            ([s connected_slaves] eq {2} &&
+            [string match {*slave*state=wait_bgsave*type=rdb-channel*} [$master info]])
         } else {
             fail "master didn't disconnect with replica2"
         }
@@ -185,15 +229,19 @@ start_server {} {
 }
 }
 }
+}
 
-test {Partial resynchronization is successful even client-output-buffer-limit is less than repl-backlog-size} {
+foreach rdbchannel {"yes" "no"} {
+test "Partial resynchronization is successful even client-output-buffer-limit is less than repl-backlog-size rdbchannel=$rdbchannel" {
     start_server {tags {"repl external:skip"}} {
         start_server {} {
             r config set save ""
             r config set repl-backlog-size 100mb
             r config set client-output-buffer-limit "replica 512k 0 0"
+            r config set repl-rdb-channel $rdbchannel
 
             set replica [srv -1 client]
+            $replica config set repl-rdb-channel $rdbchannel
             $replica replicaof [srv 0 host] [srv 0 port]
             wait_for_sync $replica
 
@@ -211,7 +259,12 @@ test {Partial resynchronization is successful even client-output-buffer-limit is
             wait_for_ofs_sync r $replica
             # master accepted replica partial resync
             assert_equal [s sync_full] {1}
-            assert_equal [s sync_partial_ok] {1}
+            set psync_count 1
+            if {$rdbchannel == "yes"} {
+                # One on full sync, another on reconnect.
+                set psync_count 2
+            }
+            assert_equal [s sync_partial_ok] $psync_count
 
             r multi
             r set key $big_str
@@ -225,13 +278,13 @@ test {Partial resynchronization is successful even client-output-buffer-limit is
                 fail "Replica offset didn't catch up with the master after too long time"
             }
             assert_equal [s sync_full] {1}
-            assert_equal [s sync_partial_ok] {1}
+            assert_equal [s sync_partial_ok] $psync_count
         }
     }
 }
 
 # This test was added to make sure big keys added to the backlog do not trigger psync loop.
-test {Replica client-output-buffer size is limited to backlog_limit/16 when no replication data is pending} {
+test "Replica client-output-buffer size is limited to backlog_limit/16 when no replication data is pending rdbchannel=$rdbchannel" {
     proc client_field {r type f} {
         set client [$r client list type $type]
         if {![regexp $f=(\[a-zA-Z0-9-\]+) $client - res]} {
@@ -252,6 +305,8 @@ test {Replica client-output-buffer size is limited to backlog_limit/16 when no r
 
             $master config set repl-backlog-size 16384
             $master config set client-output-buffer-limit "replica 32768 32768 60"
+            $master config set repl-rdb-channel $rdbchannel
+            $replica config set repl-rdb-channel $rdbchannel
             # Key has has to be larger than replica client-output-buffer limit.
             set keysize [expr 256*1024]
 
@@ -290,7 +345,11 @@ test {Replica client-output-buffer size is limited to backlog_limit/16 when no r
 
             # now we expect the replica to re-connect but fail partial sync (it doesn't have large
             # enough COB limit and must result in a full-sync)
-            assert {[status $master sync_partial_ok] == 0}
+            if {$rdbchannel == "yes"} {
+                assert {[status $master sync_partial_ok] == [status $master sync_full]}
+            } else {
+                assert {[status $master sync_partial_ok] == 0}
+            }
 
             # Before this fix (#11905), the test would trigger an assertion in 'o->used >= c->ref_block_pos'
             test {The update of replBufBlock's repl_offset is ok - Regression test for #11666} {
@@ -303,5 +362,6 @@ test {Replica client-output-buffer size is limited to backlog_limit/16 when no r
             }
         }
     }
+}
 }
 

--- a/tests/integration/replication-buffer.tcl
+++ b/tests/integration/replication-buffer.tcl
@@ -1,3 +1,16 @@
+#
+# Copyright (c) 2009-Present, Redis Ltd.
+# All rights reserved.
+#
+# Copyright (c) 2024-present, Valkey contributors.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2) or the Server Side Public License v1 (SSPLv1).
+#
+# Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
+#
+
 # This test group aims to test that all replicas share one global replication buffer,
 # two replicas don't make replication buffer size double, and when there is no replica,
 # replica buffer will shrink.

--- a/tests/integration/replication-psync.tcl
+++ b/tests/integration/replication-psync.tcl
@@ -8,7 +8,7 @@
 # If reconnect is > 0, the test actually try to break the connection and
 # reconnect with the master, otherwise just the initial synchronization is
 # checked for consistency.
-proc test_psync {descr duration backlog_size backlog_ttl delay cond mdl sdl reconnect} {
+proc test_psync {descr duration backlog_size backlog_ttl delay cond mdl sdl reconnect rdbchannel} {
     start_server {tags {"repl"} overrides {save {}}} {
         start_server {overrides {save {}}} {
 
@@ -21,7 +21,9 @@ proc test_psync {descr duration backlog_size backlog_ttl delay cond mdl sdl reco
             $master config set repl-backlog-ttl $backlog_ttl
             $master config set repl-diskless-sync $mdl
             $master config set repl-diskless-sync-delay 1
+            $master config set repl-rdb-channel $rdbchannel
             $slave config set repl-diskless-load $sdl
+            $slave config set repl-rdb-channel $rdbchannel
 
             set load_handle0 [start_bg_complex_data $master_host $master_port 9 100000]
             set load_handle1 [start_bg_complex_data $master_host $master_port 11 100000]
@@ -46,7 +48,7 @@ proc test_psync {descr duration backlog_size backlog_ttl delay cond mdl sdl reco
                 }
             }
 
-            test "Test replication partial resync: $descr (diskless: $mdl, $sdl, reconnect: $reconnect)" {
+            test "Test replication partial resync: $descr (diskless: $mdl, $sdl, reconnect: $reconnect, rdbchannel: $rdbchannel)" {
                 # Now while the clients are writing data, break the maste-slave
                 # link multiple times.
                 if ($reconnect) {
@@ -120,24 +122,31 @@ proc test_psync {descr duration backlog_size backlog_ttl delay cond mdl sdl reco
 tags {"external:skip"} {
 foreach mdl {no yes} {
     foreach sdl {disabled swapdb} {
-        test_psync {no reconnection, just sync} 6 1000000 3600 0 {
-        } $mdl $sdl 0
+        foreach rdbchannel {yes no} {
+            if {$rdbchannel == "yes" && $mdl == "no"} {
+                # rdbchannel replication requires repl-diskless-sync enabled
+                continue
+            }
 
-        test_psync {ok psync} 6 100000000 3600 0 {
-        assert {[s -1 sync_partial_ok] > 0}
-        } $mdl $sdl 1
+            test_psync {no reconnection, just sync} 6 1000000 3600 0 {
+            } $mdl $sdl 0 $rdbchannel
 
-        test_psync {no backlog} 6 100 3600 0.5 {
-        assert {[s -1 sync_partial_err] > 0}
-        } $mdl $sdl 1
+            test_psync {ok psync} 6 100000000 3600 0 {
+            assert {[s -1 sync_partial_ok] > 0}
+            } $mdl $sdl 1 $rdbchannel
 
-        test_psync {ok after delay} 3 100000000 3600 3 {
-        assert {[s -1 sync_partial_ok] > 0}
-        } $mdl $sdl 1
+            test_psync {no backlog} 6 100 3600 0.5 {
+            assert {[s -1 sync_partial_err] > 0}
+            } $mdl $sdl 1 $rdbchannel
 
-        test_psync {backlog expired} 3 100000000 1 3 {
-        assert {[s -1 sync_partial_err] > 0}
-        } $mdl $sdl 1
+            test_psync {ok after delay} 3 100000000 3600 3 {
+            assert {[s -1 sync_partial_ok] > 0}
+            } $mdl $sdl 1 $rdbchannel
+
+            test_psync {backlog expired} 3 100000000 1 3 {
+            assert {[s -1 sync_partial_err] > 0}
+            } $mdl $sdl 1 $rdbchannel
+        }
     }
 }
 }

--- a/tests/integration/replication-psync.tcl
+++ b/tests/integration/replication-psync.tcl
@@ -1,3 +1,16 @@
+#
+# Copyright (c) 2009-Present, Redis Ltd.
+# All rights reserved.
+#
+# Copyright (c) 2024-present, Valkey contributors.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2) or the Server Side Public License v1 (SSPLv1).
+#
+# Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
+#
+
 # Creates a master-slave pair and breaks the link continuously to force
 # partial resyncs attempts, all this while flooding the master with
 # write queries.

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -138,8 +138,9 @@ start_server {tags {"repl external:skip"}} {
         # Reuse this test to verify large key delivery
         $master config set rdbcompression no
         populate 1000 prefix1 10
-        populate 10 prefix2 2000000
-        populate 10 prefix3 1000000
+        populate 5 prefix2 3000000
+        populate 5 prefix3 2000000
+        populate 5 prefix4 1000000
 
         # On master info output, we should see state transition in this order:
         # 1. Replica opens rdbchannel: wait_bgsave
@@ -929,11 +930,7 @@ start_server {tags {"repl external:skip"}} {
 
             set loglines [count_log_lines -1]
 
-            # There will be two client ids for the two channels. We expect first
-            # one to be main-channel and the second one to be rdbchannel as
-            # rdbchannel connection is established later. We kill the other id
-            # in the next test. So, even if the order changes later, we'll be
-            # killing both channels.
+            # Kill rdb channel client
             set id [get_replica_client_id $master yes]
             $master client kill id $id
 
@@ -960,11 +957,7 @@ start_server {tags {"repl external:skip"}} {
         test "Test replica recovers when main channel connection is killed" {
             set loglines [count_log_lines -1]
 
-            # There will be two client ids for the two channels. We expect first
-            # one to be main-channel and the second one to be rdbchannel as
-            # rdbchannel connection is established later. We kill the other id
-            # in the previous test. So, even if the order changes later, we'll
-            # be killing both channels.
+            # Kill main channel client
             set id [get_replica_client_id $master yes]
             $master client kill id $id
 
@@ -1013,7 +1006,6 @@ start_server {tags {"repl external:skip"}} {
             # Just after replica loads RDB, it will stream repl buffer into the
             # db. During streaming, we kill the master connection. Replica
             # will abort streaming and then try another psync with master.
-
             $master config set rdb-key-save-delay 1000
             $master config set repl-rdb-channel yes
             $master config set repl-diskless-sync yes

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -1,0 +1,1099 @@
+# Returns list of replica client ids
+proc get_replica_client_ids {master} {
+    set ids {}
+    set input [$master client list type replica]
+
+    foreach line [split $input "\n"] {
+        if {[regexp {id=(\d+)} $line match id]} {
+            # Add the extracted id to the list
+            lappend ids $id
+        }
+    }
+    if {[llength $ids] != 2} {
+        # We expect two replicas: main channel and rdb channel
+        error "Found [llength $ids] replicas: $ids"
+    }
+    return $ids
+}
+
+start_server {tags {"repl external:skip"}} {
+    set replica1 [srv 0 client]
+
+    start_server {} {
+        set replica2 [srv 0 client]
+
+        start_server {} {
+            set master [srv 0 client]
+            set master_host [srv 0 host]
+            set master_port [srv 0 port]
+
+            $master config set repl-diskless-sync yes
+            $master config set repl-rdb-channel yes
+            populate 1000 master 10
+
+            test "Test replication with multiple replicas (rdbchannel enabled on both)" {
+                $replica1 config set repl-rdb-channel yes
+                $replica1 replicaof $master_host $master_port
+
+                $replica2 config set repl-rdb-channel yes
+                $replica2 replicaof $master_host $master_port
+
+                wait_replica_online $master 0
+                wait_replica_online $master 1
+
+                $master set x 1
+
+                # Wait until replicas catch master
+                wait_for_ofs_sync $master $replica1
+                wait_for_ofs_sync $master $replica2
+
+                # Verify db's are identical
+                assert_morethan [$master dbsize] 0
+                assert_equal [$master get x] 1
+                assert_equal [$master debug digest] [$replica1 debug digest]
+                assert_equal [$master debug digest] [$replica2 debug digest]
+            }
+
+            test "Test replication with multiple replicas (rdbchannel enabled on one of them)" {
+                # Allow both replicas to ask for sync
+                $master config set repl-diskless-sync-delay 5
+
+                $replica1 replicaof no one
+                $replica2 replicaof no one
+                $replica1 config set repl-rdb-channel yes
+                $replica2 config set repl-rdb-channel no
+
+                set prev_forks [s 0 total_forks]
+                $master set x 2
+
+                # There will be two forks subsequently, one for rdbchannel
+                # replica another for the replica without rdbchannel config.
+                $replica1 replicaof $master_host $master_port
+                $replica2 replicaof $master_host $master_port
+
+                set res [wait_for_log_messages 0 {"*Starting BGSAVE* replicas sockets (rdb-channel).*"} 0 2000 10]
+                set loglines [lindex $res 1]
+                wait_for_log_messages 0 {"*Starting BGSAVE* replicas sockets.*"} $loglines 2000 10
+
+                wait_replica_online $master 0
+                wait_replica_online $master 1
+
+                # Verify two new forks.
+                assert_equal [s 0 total_forks] [expr $prev_forks + 2]
+
+                wait_for_ofs_sync $master $replica1
+                wait_for_ofs_sync $master $replica2
+
+                # Verify db's are identical
+                assert_equal [$replica1 get x] 2
+                assert_equal [$replica2 get x] 2
+                assert_equal [$master debug digest] [$replica1 debug digest]
+                assert_equal [$master debug digest] [$replica2 debug digest]
+            }
+
+            test "Test rdbchannel is not used if repl-diskless-sync config is disabled on master" {
+                $replica1 replicaof no one
+                $replica2 replicaof no one
+
+                $master config set repl-diskless-sync-delay 0
+                $master config set repl-diskless-sync no
+
+                $master set x 3
+                set prev_partial_ok [status $master sync_partial_ok]
+
+                $replica1 replicaof $master_host $master_port
+
+                # Verify log message does not mention rdbchannel
+                wait_for_log_messages 0 {"*Starting BGSAVE for SYNC with target: disk.*"} 0 2000 1
+
+                wait_replica_online $master 0
+                wait_for_ofs_sync $master $replica1
+
+                # Verify db's are identical
+                assert_equal [$replica1 get x] 3
+                assert_equal [$master debug digest] [$replica1 debug digest]
+
+                # rdbchannel replication would have increased psync count.
+                assert_equal [status $master sync_partial_ok] $prev_partial_ok
+            }
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set replica [srv 0 client]
+
+    start_server {} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        $master config set repl-rdb-channel yes
+        $replica config set repl-rdb-channel yes
+
+        test "Test master memory does not increase during replication" {
+            # Put some delay to rdb generation. If master doesn't forward
+            # incoming traffic to replica, master's replication buffer will grow
+            $master config set rdb-key-save-delay 200
+            $master config set repl-backlog-size 5mb
+            populate 10000 master 10000
+
+            # Start write traffic
+            set load_handle [start_write_load $master_host $master_port 100 "key1"]
+            set prev_used [s 0 used_memory]
+
+            $replica replicaof $master_host $master_port
+            set backlog_size [lindex [$master config get repl-backlog-size] 1]
+
+            # Verify used_memory stays low
+            set max_retry 1000
+            set prev_buf_size 0
+            while {$max_retry} {
+                assert_lessthan [expr [s 0 used_memory] - $prev_used] 20000000
+                assert_lessthan_equal [s 0 mem_total_replication_buffers] [expr {$backlog_size + 1000000}]
+
+                # Check replica state
+                if {[string match *slave0*state=online* [$master info]] &&
+                    [s -1 master_link_status] == "up"} {
+                    break
+                } else {
+                    incr max_retry -1
+                    after 10
+                }
+            }
+            if {$max_retry == 0} {
+                error "assertion:Replica not in sync after 10 seconds"
+            }
+
+            stop_write_load $load_handle
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set replica [srv 0 client]
+    set replica_pid [srv 0 pid]
+
+    start_server {} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+        set backlog_size [expr {10 ** 5}]
+
+        $master config set repl-diskless-sync yes
+        $master config set repl-rdb-channel yes
+        $master config set repl-backlog-size $backlog_size
+        $master config set loglevel debug
+        $master config set rdb-key-save-delay 200
+
+        $replica config set repl-rdb-channel yes
+        $replica config set loglevel debug
+
+        test "Test master backlog can grow beyond its configured limit" {
+            # Simulate slow consumer. If replica does not consume fast enough,
+            # master's backlog will grow.
+
+            # Populate db with some keys, delivery will take some time.
+            populate 10000 master 10000
+
+            # Pause replica before psync, so replica will not consume backlog
+            $replica debug repl-pause before-main-conn-psync
+
+            # Start write traffic
+            set load_handle [start_write_load $master_host $master_port 100 "key"]
+            $replica replicaof $master_host $master_port
+
+            # Verify repl backlog can grow
+            wait_for_condition 1000 20 {
+                [s 0 mem_total_replication_buffers] > [expr {3 * $backlog_size}]
+            } else {
+                fail "Master should allow backlog to grow beyond its limits during replication"
+            }
+
+            # resume replica
+            resume_process $replica_pid
+
+            stop_write_load $load_handle
+
+            # Verify recovery. Wait until replica catches up
+            wait_replica_online $master 0 100 1000
+            wait_for_ofs_sync $master $replica
+
+            # Verify db's are identical
+            assert_morethan [$master dbsize] 0
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+   }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set replica [srv 0 client]
+
+    start_server {} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        $master config set repl-rdb-channel yes
+        $replica config set repl-rdb-channel yes
+
+        test "Test replication stream buffer becomes full on replica" {
+            # For replication stream accumulation, replica inherits slave output
+            # buffer limit as the size limit. In this test, we create traffic to
+            # fill the buffer fully. Once the limit is reached, accumulation
+            # will stop. This is not a failure scenario though. From that point,
+            # further accumulation may occur on master side. Replication should
+            # be completed successfully.
+
+            # Create some artificial delay for rdb delivery and load. We'll
+            # generate some traffic meanwhile to fill replication buffer.
+            $master config set rdb-key-save-delay 1000
+            $replica config set key-load-delay 1000
+            $replica config set client-output-buffer-limit "replica 64kb 64kb 0"
+            populate 2000 master 1
+
+            set prev_sync_full [s 0 sync_full]
+            $replica replicaof $master_host $master_port
+
+            # Wait for replica to establish psync using main channel
+            wait_for_condition 500 1000 {
+                [string match "*state=bg_rdb_transfer*type=main-channel*" [s 0 slave1]]
+            } else {
+                fail "replica didn't start sync"
+            }
+
+            # Create some traffic on replication stream
+            populate 100 master 100000
+
+            # Wait for replica's buffer limit reached
+            wait_for_log_messages -1 {"*Replication buffer limit has been reached*"} 0 1000 10
+
+            # Speed up loading
+            $replica config set key-load-delay 0
+
+            # Wait until sync is successful
+            wait_for_condition 200 200 {
+                [status $master master_repl_offset] eq [status $replica master_repl_offset] &&
+                [status $master master_repl_offset] eq [status $replica slave_repl_offset]
+            } else {
+                fail "replica offsets didn't match in time"
+            }
+
+            # Verify sync was not interrupted.
+            assert_equal [s 0 sync_full] [expr $prev_sync_full + 1]
+
+            # Verify db's are identical
+            assert_morethan [$master dbsize] 0
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set replica1 [srv 0 client]
+    set replica1_pid  [srv 0 pid]
+
+    start_server {} {
+        set replica2 [srv 0 client]
+        set replica2_pid  [srv 0 pid]
+
+        start_server {} {
+            set master [srv 0 client]
+            set master_host [srv 0 host]
+            set master_port [srv 0 port]
+
+            test "Test replicas are attached to backlog" {
+                # Once rdb delivery starts, rdb channel slave keeps a reference
+                # to backlog on master, so main channel psync attempt will be
+                # successful. In this test, we verify replicas rdbchannel
+                # connections are attached to backlog successfully.
+                $master config set repl-diskless-sync yes
+                $master config set repl-rdb-channel yes
+                $master config set loglevel debug
+
+                $replica1 config set repl-rdb-channel yes
+                $replica2 config set repl-rdb-channel yes
+
+                # Replicas will sleep before establishing psync. On master,
+                # their rdbchannel connection will maintain a reference to the
+                # backlog.
+                $replica1 debug repl-pause before-main-conn-psync
+                $replica2 debug repl-pause before-main-conn-psync
+
+                # Populate db
+                populate 1000 master 10
+
+                set loglines [count_log_lines -1]
+                set load_handle [start_write_load $master_host $master_port 20]
+                $replica1 replicaof $master_host $master_port
+
+                # For the first replica, there is no backlog on the master.
+                # It will be lazily attached to backlog once the first backlog
+                # object is created.
+                wait_for_log_messages 0 {"*Added rdb replica*to the psync waiting list*tail = 0*"} $loglines 2000 1
+
+                # Wait until first backlog node is created
+                set res [wait_for_log_messages 0 {"*Attached replica rdb client*"} $loglines 2000 1]
+                set loglines [lindex $res 1]
+                incr $loglines
+
+                # Second replica will be attached to backlog tail.
+                $replica2 replicaof $master_host $master_port
+                wait_for_log_messages 0 {"*Added rdb replica*to the psync waiting list*tail = 1*"} $loglines 2000 1
+
+                # Resume replicas and verify the recovery
+                resume_process $replica1_pid
+                resume_process $replica2_pid
+
+                stop_write_load $load_handle
+
+                # Wait until replication is completed
+                wait_for_ofs_sync $master $replica1
+                wait_for_ofs_sync $master $replica2
+
+                assert_equal [s 0 replicas_waiting_psync] 0
+
+                # Verify db's are identical
+                assert_equal [$master debug digest] [$replica1 debug digest]
+                assert_equal [$master debug digest] [$replica2 debug digest]
+            }
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set replica [srv 0 client]
+    set replica_pid [srv 0 pid]
+
+    start_server {} {
+        set master [srv 0 client]
+        set master_pid  [srv 0 pid]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        # Create small enough db to be loaded before replica establishes psync
+        $master set key1 val1
+
+        $master config set repl-diskless-sync yes
+        $master config set repl-rdb-channel yes
+        $master config set loglevel debug
+
+        $replica config set repl-rdb-channel yes
+        $replica config set loglevel debug
+
+        test "Test rdb is loaded before main channel establishes psync (success scenario)" {
+            # Steps:
+            #  1. Replica initiates synchronization via RDB channel.
+            #  2. Master's main process is suspended. RDB is delivered by the fork.
+            #  3. Replica completes RDB loading, closes RDB channel.
+            #  4. Replica pauses before establishing psync.
+            #  5. Master resumes operation and detects closed RDB channel.
+            #  6. Replica resumes operation and establishes pysnc.
+            #
+            #  We expect master to keep rdbchannel reference to the backlog so
+            #  psync at step-6 can be successful.
+
+            # Pause master main process after fork
+            $master debug repl-pause after-fork
+
+            # Give replica five second grace period before disconnection
+            $master debug delay-rdb-client-free 5
+            $replica config set repl-timeout 10
+
+            set loglines [count_log_lines -1]
+
+            # Start some write traffic. If master does not prevent backlog
+            # trimming, replicas psync attempt will fail.
+            set load_handle [start_write_load $master_host $master_port 20]
+
+            $replica replicaof $master_host $master_port
+
+            # Wait until replica loads rdb
+            wait_for_log_messages -1 {"*Done loading RDB*"} $loglines 1000 10
+
+            # Pause replica and resume master
+            pause_process $replica_pid
+            resume_process $master_pid
+
+            # Master will wait until replica main channel establishes psync
+            wait_for_log_messages 0 {"*Postponed RDB client*free*"} 0 1000 10
+            wait_for_condition 50 100 {
+                [s 0 replicas_waiting_psync] == 1
+            } else {
+                fail "Master freed RDB client before psync was established"
+            }
+
+            # Resume replica and verify it establishes psync
+            resume_process $replica_pid
+            wait_for_log_messages -1 {"*Main channel established psync after rdb load*"} 0 1000 10
+
+            wait_replica_online $master 0
+            wait_for_condition 50 100 {
+                [s 0 replicas_waiting_psync] == 0
+            } else {
+                fail "Master did not delete rdb client from the psync list"
+            }
+
+            stop_write_load $load_handle
+
+            # Verify system is operational.
+            $master set x 1
+            $master set y 2
+            wait_replica_online $master 0 200 500
+            wait_for_ofs_sync $master $replica
+
+            # Verify db's are identical after sync
+            assert_morethan [$master dbsize] 0
+            assert_equal [$replica get x] 1
+            assert_equal [$replica get y] 2
+            wait_for_ofs_sync $master $replica
+            assert_equal [$master dbsize] [$replica dbsize]
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set replica [srv 0 client]
+    set replica_pid [srv 0 pid]
+
+    start_server {} {
+        set master [srv 0 client]
+        set master_pid  [srv 0 pid]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        # Create small enough db to be loaded before replica establishes psync
+        $master set key1 val1
+
+        $master config set repl-diskless-sync yes
+        $master config set repl-rdb-channel yes
+        $master config set loglevel debug
+
+        $replica config set repl-rdb-channel yes
+        $replica config set loglevel debug
+
+        test "Test rdb is loaded before main channel establishes psync (fail scenario)" {
+             # Steps:
+             #  1. Replica initiates synchronization via RDB channel.
+             #  2. Master's main process is suspended. RDB is delivered by the fork.
+             #  3. Replica completes RDB loading, closes RDB channel.
+             #  4. Replica pauses before establishing psync.
+             #  5. Master resumes operation and detects closed RDB channel.
+             #  6. Replica is too late to establish psync, master drops rdbchannel
+             #     client and its backlog reference.
+             #  7. Replica resumes operation and pysnc will fail.
+
+             # Pause master main process after fork
+             $master debug repl-pause after-fork
+
+             # Replica has three seconds to establish psync after rdb delivery
+             # is completed.
+             $master debug delay-rdb-client-free 3
+
+             set loglines [count_log_lines -1]
+             set load_handle [start_write_load $master_host $master_port 20]
+
+             $replica replicaof $master_host $master_port
+
+             # Wait until replica loads rdb
+             wait_for_log_messages -1 {"*Done loading RDB*"} $loglines 1000 10
+
+             # Pause replica and resume master
+             pause_process $replica_pid
+             resume_process $master_pid
+
+             wait_for_condition 50 100 {
+                 [s 0 replicas_waiting_psync] == 1
+             } else {
+                 fail "Master deleted RDB client before psync was established"
+             }
+
+             # Master will free rdbchannel client and drop its reference to the
+             # backlog. Replicas psync attempt will fail.
+             set res [wait_for_log_messages 0 {"*Replica main channel failed to establish PSYNC within the grace period*"} 0 1000 10]
+             wait_for_condition 50 100 {
+                 [s 0 replicas_waiting_psync] == 0
+             } else {
+                 fail "Master did not delete waiting psync replica after grace period"
+             }
+
+             $master debug repl-pause clear
+
+             # Create some traffic, backlog will move on to some other offset
+             populate 200 master 10000
+
+             # Sync should fail once the replica ask for PSYNC using main channel
+             set prev_partial_err [s 0 sync_partial_err]
+             resume_process $replica_pid
+
+             wait_for_condition 50 200 {
+                 [s 0 sync_partial_err] > $prev_partial_err
+             } else {
+                 puts "sync_partial_err: [s 0 sync_partial_err],
+                       prev_partial_err: $prev_partial_err"
+                 fail "Replica psync request should have failed"
+             }
+
+             stop_write_load $load_handle
+
+            # Verify system is operational.
+            $master set x 1
+            $master set y 2
+            wait_replica_online $master 0 200 500
+            wait_for_ofs_sync $master $replica
+
+            # Verify db's are identical after sync
+            assert_morethan [$master dbsize] 0
+            assert_equal [$replica get x] 1
+            assert_equal [$replica get y] 2
+            wait_for_ofs_sync $master $replica
+            assert_equal [$master dbsize] [$replica dbsize]
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+    set master_pid  [srv 0 pid]
+    set loglines [count_log_lines 0]
+
+    $master config set repl-diskless-sync yes
+    $master config set repl-rdb-channel yes
+    $master config set repl-backlog-size 1mb
+    $master config set client-output-buffer-limit "replica 100k 0 0"
+    $master config set loglevel debug
+    $master config set repl-diskless-sync-delay 3
+
+    start_server {} {
+        set replica [srv 0 client]
+        set replica_pid [srv 0 pid]
+
+        $replica config set repl-rdb-channel yes
+        $replica config set loglevel debug
+        $replica config set repl-timeout 10
+
+        test "Test master disconnects replica when output buffer limit is reached (after rdb delivery)" {
+            # Steps:
+            #  1. Replica initiates synchronization via RDB channel.
+            #  2. Master's main process is suspended. RDB is delivered by the fork.
+            #  3. Replica completes RDB loading, closes RDB channel.
+            #  4. Replica pauses before establishing psync.
+            #  5. Master resumes operation.
+            #  6. As replica hasn't established psync yet, master will accumulate backlog.
+            #  7. When client output buffer limit is reached, master will disconnect replica.
+
+            # Pause master main process after fork
+            $master debug repl-pause after-fork
+
+            $replica replicaof $master_host $master_port
+            # Wait until replica loads RDB
+            wait_for_log_messages 0 {"*Done loading RDB*"} 0 1000 10
+
+            # At this point rdb is loaded but psync hasn't been established yet.
+            # Pause the replica so the master main process will wake up while
+            # the replica is unresponsive. We expect the main process to fill
+            # the client output buffer and disconnect the replica.
+            pause_process $replica_pid
+            resume_process $master_pid
+
+            # Disable pause flag
+            $master debug repl-pause clear
+
+            # Generate some traffic for backlog ~2mb
+            populate 200 master 10000 -1
+
+            set res [wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 1000 10]
+            set loglines [lindex $res 1]
+
+            # Verify master deletes replica from psync waiting list.
+            wait_for_condition 50 100 {
+                [s -1 replicas_waiting_psync] == 0
+            } else {
+                fail "Master did not delete replica from psync waiting list"
+            }
+
+            # Resume replica and verify it fails to establish psync.
+            resume_process $replica_pid
+            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 2000 100]
+            set loglines [lindex $res 1]
+
+            # Wait until replica catches up
+            wait_replica_online $master 0 1000 100
+        }
+
+        test "Test master disconnects replica when output buffer limit is reached (during rdb delivery)" {
+            # Steps:
+            #  1. Replica initiates synchronization via RDB channel.
+            #  2. Master starts delivering RDB.
+            #  3. Replica pauses before establishing psync.
+            #  4. Backlog grows on master as replica does not consume it.
+            #  5. When client output buffer limit is reached, master will disconnect replica.
+
+            $replica replicaof no one
+            $replica debug repl-pause before-main-conn-psync
+
+            # Set master with a slow rdb generation, so that we can easily
+            # intercept loading 10ms per key, with 20000 keys is 200 seconds
+            $master config set rdb-key-save-delay 10000
+            populate 20000 master 100
+
+            set client_disconnected [s -1 client_output_buffer_limit_disconnections]
+            $replica replicaof $master_host $master_port
+
+            # RDB delivery starts
+            wait_for_condition 50 100 {
+                [s -1 rdb_bgsave_in_progress] == 1
+            } else {
+                fail "Sync did not start"
+            }
+
+            # Create some traffic on backlog ~2mb
+            populate 200 master 10000 -1
+
+            # Verify master kills replica connection.
+            wait_for_condition 50 10 {
+                [s -1 client_output_buffer_limit_disconnections] == $client_disconnected + 1
+            } else {
+                fail "Master should disconnect replica"
+            }
+            set res [wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 1000 10]
+            set loglines [lindex $res 1]
+
+            wait_for_condition 50 100 {
+                [s -1 replicas_waiting_psync] == 0
+            } else {
+                fail "Master did not delete replica from psync waiting list"
+            }
+
+            # Resume replica
+            resume_process $replica_pid
+
+            wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 2000 10
+
+            # Speed up replication
+            $replica debug repl-pause clear
+            $master config set repl-diskless-sync-delay 0
+            $master config set rdb-key-save-delay 0
+        }
+
+        test "Test replication recovers after output buffer failures" {
+            # Verify system is operational
+            $master set x 1
+
+            # Wait until replica catches up
+            wait_replica_online $master 0 1000 100
+            wait_for_ofs_sync $master $replica
+
+            # Verify db's are identical
+            assert_morethan [$master dbsize] 0
+            assert_equal [$replica get x] 1
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+
+    $master config set repl-diskless-sync yes
+    $master config set repl-rdb-channel yes
+    $master config set rdb-key-save-delay 300
+    $master config set client-output-buffer-limit "replica 0 0 0"
+    $master config set repl-diskless-sync-delay 4
+    $master config set loglevel debug
+
+    populate 10000 master 1
+
+    start_server {} {
+        set replica1 [srv 0 client]
+        $replica1 config set repl-rdb-channel yes
+        $replica1 config set loglevel debug
+
+        start_server {} {
+            set replica2 [srv 0 client]
+            $replica2 config set repl-rdb-channel yes
+            $replica2 config set loglevel debug
+
+            set load_handle [start_write_load $master_host $master_port 100 "key"]
+
+            test "Test master continues RDB delivery if not all replicas are dropped" {
+                $replica1 replicaof $master_host $master_port
+                $replica2 replicaof $master_host $master_port
+
+                wait_for_condition 50 100 {
+                    [s -2 rdb_bgsave_in_progress] == 1
+                } else {
+                    fail "Sync did not start"
+                }
+
+                # Wait for both replicas main conns to establish psync
+                wait_for_condition 500 100 {
+                    [s -2 sync_partial_ok] == 2
+                } else {
+                    fail "Replicas didn't establish psync:
+                          sync_partial_ok: [s -2 sync_partial_ok]"
+                }
+
+                # kill one of the replicas
+                catch {$replica1 shutdown nosave}
+
+                # Wait until replica completes full sync
+                # Verify there is no other full sync attempt
+                wait_for_condition 50 1000 {
+                    [s 0 master_link_status] == "up" &&
+                    [s -2 sync_full] == 2 &&
+                    [s -2 sync_partial_ok] == 2 &&
+                    [s -2 connected_slaves] == 1
+                } else {
+                    fail "Sync session did not continue
+                          master_link_status: [s 0 master_link_status]
+                          sync_full:[s -2 sync_full]
+                          sync_partial_ok:[s -2 sync_partial_ok]
+                          connected_slaves: [s -2 connected_slaves]"
+                }
+            }
+
+            test "Test master aborts rdb delivery if all replicas are dropped" {
+                $replica2 replicaof no one
+
+                # Start replicaof
+                set cur_psync [status $master sync_partial_ok]
+                $replica2 replicaof $master_host $master_port
+
+                wait_for_condition 50 1000 {
+                    [s -2 rdb_bgsave_in_progress] == 1
+                } else {
+                    fail "Sync did not start"
+                }
+
+                # Wait replica main connection to establish psync
+                wait_for_condition 50 1000 {
+                    [s -2 sync_partial_ok] == $cur_psync + 1
+                } else {
+                    fail "No new psync, sync_partial_ok: [s -2 sync_partial_ok]"
+                }
+
+                set loglines [count_log_lines -2]
+
+                # kill replica
+                catch {$replica2 shutdown nosave}
+
+                # Verify master aborts rdb save
+                wait_for_condition 50 1000 {
+                    [s -2 rdb_bgsave_in_progress] == 0 &&
+                    [s -2 connected_slaves] == 0
+                } else {
+                    fail "Master should abort the sync
+                          rdb_bgsave_in_progress:[s -2 rdb_bgsave_in_progress]
+                          connected_slaves: [s -2 connected_slaves]"
+                }
+
+                wait_for_log_messages -2 {"*Background RDB transfer error*"} $loglines 1000 10
+            }
+
+            stop_write_load $load_handle
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+
+    $master config set repl-diskless-sync yes
+    $master config set repl-rdb-channel yes
+    $master config set loglevel debug
+    $master config set rdb-key-save-delay 1000
+
+    populate 3000 prefix1 1
+    populate 100 prefix2 100000
+
+    start_server {} {
+        set replica [srv 0 client]
+        set replica_pid [srv 0 pid]
+
+        $replica config set repl-rdb-channel yes
+        $replica config set loglevel debug
+        $replica config set repl-timeout 10
+
+        set load_handle [start_write_load $master_host $master_port 100 "key"]
+
+        test "Test replica recovers when rdb channel connection is killed" {
+            $replica replicaof $master_host $master_port
+
+            # Wait for sync session to start
+            wait_for_condition 500 200 {
+                [string match "*state=wait_bgsave*type=rdb-channel*" [s -1 slave0]] &&
+                [string match "*state=bg_rdb_transfer*type=main-channel*" [s -1 slave1]] &&
+                [s -1 rdb_bgsave_in_progress] eq 1
+            } else {
+                fail "replica didn't start sync session in time"
+            }
+
+            set loglines [count_log_lines -1]
+
+            # There will be two client ids for the two channels. We expect first
+            # one to be main-channel and the second one to be rdbchannel as
+            # rdbchannel connection is established later. We kill the other id
+            # in the next test. So, even if the order changes later, we'll be
+            # killing both channels.
+            set id [lindex [get_replica_client_ids $master] 1]
+            $master client kill id $id
+
+            # Wait for master to abort the sync
+            wait_for_condition 500 100 {
+                [s -1 replicas_waiting_psync] == 0
+            } else {
+                fail "Master did not delete replica from psync waiting list"
+            }
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
+
+            # Verify master rejects set-rdb-client-id after connection is killed
+            assert_error {*Unrecognized*} {$master replconf set-rdb-client-id $id}
+
+            # Replica should retry
+            wait_for_condition 500 200 {
+                [string match "*state=wait_bgsave*type=rdb-channel*" [s -1 slave0]] &&
+                [string match "*state=bg_rdb_transfer*type=main-channel*" [s -1 slave1]] &&
+                [s -1 rdb_bgsave_in_progress] eq 1
+            } else {
+                fail "replica didn't retry after connection close"
+            }
+        }
+
+        test "Test replica recovers when main channel connection is killed" {
+            set loglines [count_log_lines -1]
+
+            # There will be two client ids for the two channels. We expect first
+            # one to be main-channel and the second one to be rdbchannel as
+            # rdbchannel connection is established later. We kill the other id
+            # in the previous test. So, even if the order changes later, we'll
+            # be killing both channels.
+            set id [lindex [get_replica_client_ids $master] 0]
+            $master client kill id $id
+
+            # Wait for master to abort the sync
+            wait_for_condition 50 1000 {
+                [s -1 replicas_waiting_psync] == 0
+            } else {
+                fail "replicas_waiting_psync did not become zero"
+            }
+
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 20
+
+            # Replica should retry
+            wait_for_condition 500 2000 {
+                [string match "*state=wait_bgsave*type=rdb-channel*" [s -1 slave0]] &&
+                [string match "*state=bg_rdb_transfer*type=main-channel*" [s -1 slave1]] &&
+                [s -1 rdb_bgsave_in_progress] eq 1
+            } else {
+                fail "replica didn't retry after connection close"
+            }
+        }
+
+        stop_write_load $load_handle
+
+        test "Test replica recovers connection failures" {
+            # Wait until replica catches up
+            wait_replica_online $master 0 1000 100
+            wait_for_ofs_sync $master $replica
+
+            # Verify db's are identical
+            assert_morethan [$master dbsize] 0
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set replica [srv 0 client]
+    set replica_pid  [srv 0 pid]
+
+    start_server {} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        test "Test master connection drops while streaming repl buffer into the db" {
+            # Just after replica loads RDB, it will stream repl buffer into the
+            # db. During streaming, we kill the master connection. Replica
+            # will abort streaming and then try another psync with master.
+
+            $master config set rdb-key-save-delay 1000
+            $master config set repl-rdb-channel yes
+            $master config set repl-diskless-sync yes
+            $replica config set repl-rdb-channel yes
+            $replica config set loading-process-events-interval-bytes 1024
+
+            # Populate db and start write traffic
+            populate 2000 master 1000
+            set load_handle [start_write_load $master_host $master_port 100 "key1"]
+
+            # Replica will pause in the loop of repl buffer streaming
+            $replica debug repl-pause on-streaming-repl-buf
+            $replica replicaof $master_host $master_port
+
+            # Check if repl stream accumulation is started.
+            wait_for_condition 50 1000 {
+                [s -1 replica_repl_pending_data_size] > 0
+            } else {
+                fail "repl stream accumulation not started"
+            }
+
+            # Wait until replica starts streaming repl buffer
+            wait_for_log_messages -1 {"*Starting to stream replication buffer*"} 0 2000 10
+            stop_write_load $load_handle
+            $master config set rdb-key-save-delay 0
+
+            # Kill master connection and resume the process
+            $replica deferred 1
+            $replica client kill type master
+            $replica debug repl-pause clear
+            resume_process $replica_pid
+            $replica read
+            $replica read
+            $replica deferred 0
+
+            wait_for_log_messages -1 {"*Master client was freed while streaming*"} 0 500 10
+
+            # Quick check for stats test coverage
+            assert_morethan_equal [s -1 replica_repl_pending_data_peak] [s -1 replica_repl_pending_data_size]
+
+            # Wait until replica recovers and verify db's are identical
+            wait_replica_online $master 0 1000 10
+            wait_for_ofs_sync $master $replica
+
+            assert_morethan [$master dbsize] 0
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set replica [srv 0 client]
+    set replica_pid  [srv 0 pid]
+
+    start_server {} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        test "Test main channel connection drops while loading rdb (disk based)" {
+            # While loading rdb, we kill main channel connection.
+            # We expect replica to complete loading RDB and then try psync
+            # with the master.
+            $master config set repl-rdb-channel yes
+            $replica config set repl-rdb-channel yes
+            $replica config set repl-diskless-load disabled
+            $replica config set key-load-delay 10000
+            $replica config set loading-process-events-interval-bytes 1024
+
+            # Populate db and start write traffic
+            populate 10000 master 100
+            $replica replicaof $master_host $master_port
+
+            # Wait until replica starts loading
+            wait_for_condition 50 200 {
+                [s -1 loading] == 1
+            } else {
+                fail "replica did not start loading"
+            }
+
+            # Kill replica connections
+            $master client kill type replica
+            $master set x 1
+
+            # At this point, we expect replica to complete loading RDB. Then,
+            # it will try psync with master.
+            wait_for_log_messages -1 {"*Aborting rdb channel sync while loading the RDB*"} 0 2000 10
+            wait_for_log_messages -1 {"*After loading RDB, replica will try psync with master*"} 0 2000 10
+
+            # Speed up loading
+            $replica config set key-load-delay 0
+
+            # Wait until replica becomes online
+            wait_replica_online $master 0 100 100
+
+            # Verify there is another successful psync and no other full sync
+            wait_for_condition 50 200 {
+                [s 0 sync_full] == 1 &&
+                [s 0 sync_partial_ok] == 2
+            } else {
+                fail "psync was not successful [s 0 sync_full] [s 0 sync_partial_ok]"
+            }
+
+            # Verify db's are identical after recovery
+            wait_for_ofs_sync $master $replica
+            assert_morethan [$master dbsize] 0
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set replica [srv 0 client]
+    set replica_pid  [srv 0 pid]
+
+    start_server {} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        test "Test main channel connection drops while loading rdb (diskless)" {
+            # While loading rdb, kill both main and rdbchannel connections.
+            # We expect replica to abort sync and later retry again.
+            $master config set repl-rdb-channel yes
+            $replica config set repl-rdb-channel yes
+            $replica config set repl-diskless-load swapdb
+            $replica config set key-load-delay 10000
+            $replica config set loading-process-events-interval-bytes 1024
+
+            # Populate db and start write traffic
+            populate 10000 master 100
+
+            $replica replicaof $master_host $master_port
+
+            # Wait until replica starts loading
+            wait_for_condition 50 200 {
+                [s -1 loading] == 1
+            } else {
+                fail "replica did not start loading"
+            }
+
+            # Kill replica connections
+            $master client kill type replica
+            $master set x 1
+
+            # At this point, we expect replica to abort loading RDB.
+            wait_for_log_messages -1 {"*Aborting rdb channel sync while loading the RDB*"} 0 2000 10
+            wait_for_log_messages -1 {"*Failed trying to load the MASTER synchronization DB from socket*"} 0 2000 10
+
+            # Speed up loading
+            $replica config set key-load-delay 0
+            stop_write_load $load_handle
+
+            # Wait until replica recovers and becomes online
+            wait_replica_online $master 0 100 100
+
+            # Verify replica attempts another full sync
+            wait_for_condition 50 200 {
+                [s 0 sync_full] == 2 &&
+                [s 0 sync_partial_ok] == 2
+            } else {
+                fail "sync was not successful [s 0 sync_full] [s 0 sync_partial_ok]"
+            }
+
+            # Verify db's are identical after recovery
+            wait_for_ofs_sync $master $replica
+            assert_morethan [$master dbsize] 0
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -137,6 +137,7 @@ start_server {tags {"repl external:skip"}} {
 
         # Reuse this test to verify large key delivery
         $master config set rdbcompression no
+        $master config set rdb-key-save-delay 3000
         populate 1000 prefix1 10
         populate 5 prefix2 3000000
         populate 5 prefix3 2000000
@@ -179,7 +180,6 @@ start_server {tags {"repl external:skip"}} {
             resume_process $replica_pid
 
             wait_for_condition 50 200 {
-                [s 0 rdb_bgsave_in_progress] == 1 &&
                 [s 0 connected_slaves] == 1 &&
                 [string match "*bg_rdb_transfer*" [s 0 slave0]]
             } else {

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -260,7 +260,7 @@ start_server {tags {"repl external:skip"}} {
 
             # Wait for replica to establish psync using main channel
             wait_for_condition 500 1000 {
-                [string match "*state=bg_rdb_transfer*type=main-channel*" [s 0 slave1]]
+                [string match "*state=bg_rdb_transfer*" [s 0 slave0]]
             } else {
                 fail "replica didn't start sync"
             }
@@ -833,8 +833,7 @@ start_server {tags {"repl external:skip"}} {
 
             # Wait for sync session to start
             wait_for_condition 500 200 {
-                [string match "*state=wait_bgsave*type=rdb-channel*" [s -1 slave0]] &&
-                [string match "*state=bg_rdb_transfer*type=main-channel*" [s -1 slave1]] &&
+                [string match "*state=bg_rdb_transfer*" [s -1 slave0]] &&
                 [s -1 rdb_bgsave_in_progress] eq 1
             } else {
                 fail "replica didn't start sync session in time"
@@ -863,8 +862,7 @@ start_server {tags {"repl external:skip"}} {
 
             # Replica should retry
             wait_for_condition 500 200 {
-                [string match "*state=wait_bgsave*type=rdb-channel*" [s -1 slave0]] &&
-                [string match "*state=bg_rdb_transfer*type=main-channel*" [s -1 slave1]] &&
+                [string match "*state=bg_rdb_transfer*" [s -1 slave0]] &&
                 [s -1 rdb_bgsave_in_progress] eq 1
             } else {
                 fail "replica didn't retry after connection close"
@@ -893,8 +891,7 @@ start_server {tags {"repl external:skip"}} {
 
             # Replica should retry
             wait_for_condition 500 2000 {
-                [string match "*state=wait_bgsave*type=rdb-channel*" [s -1 slave0]] &&
-                [string match "*state=bg_rdb_transfer*type=main-channel*" [s -1 slave1]] &&
+                [string match "*state=bg_rdb_transfer*" [s -1 slave0]] &&
                 [s -1 rdb_bgsave_in_progress] eq 1
             } else {
                 fail "replica didn't retry after connection close"

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -364,11 +364,6 @@ start_server {tags {"repl external:skip"}} {
             # Make sure config is used, we accumulated more than
             # client-output-buffer-limit
             assert_morethan [s -1 replica_full_sync_buffer_size] 1024
-
-            # Speed up loading and verify db's are identical
-            $replica config set key-load-delay 0
-            wait_for_ofs_sync $master $replica
-            assert_equal [$master debug digest] [$replica debug digest]
         }
     }
 }

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -294,7 +294,7 @@ start_server {tags {"repl external:skip"}} {
             # be completed successfully.
 
             # Create some artificial delay for rdb delivery and load. We'll
-            # generate some traffic meanwhile to fill replication buffer.
+            # generate some traffic to fill the replication buffer.
             $master config set rdb-key-save-delay 1000
             $replica config set key-load-delay 1000
             $replica config set client-output-buffer-limit "replica 64kb 64kb 0"
@@ -334,6 +334,42 @@ start_server {tags {"repl external:skip"}} {
             assert_morethan [$master dbsize] 0
             assert_equal [$master debug digest] [$replica debug digest]
         }
+
+        test "Test replication stream buffer config replica-full-sync-buffer-limit" {
+            # By default, replica inherits client-output-buffer-limit of replica
+            # to limit accumulated repl data during rdbchannel sync.
+            # replica-full-sync-buffer-limit should override it if it is set.
+            $replica replicaof no one
+
+            # Create some artificial delay for rdb delivery and load. We'll
+            # generate some traffic to fill the replication buffer.
+            $master config set rdb-key-save-delay 1000
+            $replica config set key-load-delay 1000
+            $replica config set client-output-buffer-limit "replica 1024 1024 0"
+            $replica config set replica-full-sync-buffer-limit 20mb
+            populate 2000 master 1
+
+            $replica replicaof $master_host $master_port
+
+            # Wait until replication starts
+            wait_for_condition 500 1000 {
+                [string match "*state=send_bulk_and_stream*" [s 0 slave0]]
+            } else {
+                fail "replica didn't start sync"
+            }
+
+            # Create some traffic on replication stream
+            populate 100 master 100000
+
+            # Make sure config is used, we accumulated more than
+            # client-output-buffer-limit
+            assert_morethan [s -1 replica_full_sync_buffer_size] 1024
+
+            # Speed up loading and verify db's are identical
+            $replica config set key-load-delay 0
+            wait_for_ofs_sync $master $replica
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
     }
 }
 
@@ -362,7 +398,6 @@ start_server {tags {"repl external:skip"}} {
         $replica config set loading-process-events-interval-bytes 1024
 
         test "Test master disconnects replica when output buffer limit is reached" {
-            # Pause master main process after fork
             populate 20000 master 100 -1
 
             $replica replicaof $master_host $master_port
@@ -608,7 +643,7 @@ start_server {tags {"repl external:skip"}} {
 
             # Check if repl stream accumulation is started.
             wait_for_condition 50 1000 {
-                [s -1 replica_repl_pending_data_size] > 0
+                [s -1 replica_full_sync_buffer_size] > 0
             } else {
                 fail "repl stream accumulation not started"
             }
@@ -630,7 +665,7 @@ start_server {tags {"repl external:skip"}} {
             wait_for_log_messages -1 {"*Master client was freed while streaming*"} 0 500 10
 
             # Quick check for stats test coverage
-            assert_morethan_equal [s -1 replica_repl_pending_data_peak] [s -1 replica_repl_pending_data_size]
+            assert_morethan_equal [s -1 replica_full_sync_buffer_peak] [s -1 replica_full_sync_buffer_size]
 
             # Wait until replica recovers and verify db's are identical
             wait_replica_online $master 0 1000 10

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -520,7 +520,7 @@ start_server {tags {"repl external:skip"}} {
                           rdb_bgsave_in_progress:[s -2 rdb_bgsave_in_progress]
                           connected_slaves: [s -2 connected_slaves]"
                 }
-                wait_for_log_messages -2 {"*Background transfer error*"} $loglines 1000 10
+                wait_for_log_messages -2 {"*Background transfer error*"} $loglines 1000 50
             }
 
             stop_write_load $load_handle

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -1,3 +1,16 @@
+#
+# Copyright (c) 2009-Present, Redis Ltd.
+# All rights reserved.
+#
+# Copyright (c) 2024-present, Valkey contributors.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2) or the Server Side Public License v1 (SSPLv1).
+#
+# Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
+#
+
 # Returns either main or rdbchannel client id
 # Assumes there is one replica with two channels
 proc get_replica_client_id {master rdbchannel} {

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -74,12 +74,12 @@ start_server {tags {"repl external:skip"}} {
                 $replica1 replicaof $master_host $master_port
                 $replica2 replicaof $master_host $master_port
 
-                set res [wait_for_log_messages 0 {"*Starting BGSAVE* replicas sockets (rdb-channel).*"} 0 2000 10]
+                set res [wait_for_log_messages 0 {"*Starting BGSAVE* replicas sockets (rdb-channel)*"} 0 2000 10]
                 set loglines [lindex $res 1]
-                wait_for_log_messages 0 {"*Starting BGSAVE* replicas sockets.*"} $loglines 2000 10
+                wait_for_log_messages 0 {"*Starting BGSAVE* replicas sockets*"} $loglines 2000 10
 
-                wait_replica_online $master 0
-                wait_replica_online $master 1
+                wait_replica_online $master 0 100 100
+                wait_replica_online $master 1 100 100
 
                 # Verify two new forks.
                 assert_equal [s 0 total_forks] [expr $prev_forks + 2]
@@ -102,12 +102,10 @@ start_server {tags {"repl external:skip"}} {
                 $master config set repl-diskless-sync no
 
                 $master set x 3
-                set prev_partial_ok [status $master sync_partial_ok]
-
                 $replica1 replicaof $master_host $master_port
 
                 # Verify log message does not mention rdbchannel
-                wait_for_log_messages 0 {"*Starting BGSAVE for SYNC with target: disk.*"} 0 2000 1
+                wait_for_log_messages 0 {"*Starting BGSAVE for SYNC with target: disk*"} 0 2000 1
 
                 wait_replica_online $master 0
                 wait_for_ofs_sync $master $replica1
@@ -115,9 +113,6 @@ start_server {tags {"repl external:skip"}} {
                 # Verify db's are identical
                 assert_equal [$replica1 get x] 3
                 assert_equal [$master debug digest] [$replica1 debug digest]
-
-                # rdbchannel replication would have increased psync count.
-                assert_equal [status $master sync_partial_ok] $prev_partial_ok
             }
         }
     }
@@ -144,19 +139,31 @@ start_server {tags {"repl external:skip"}} {
         populate 5 prefix4 1000000
 
         # On master info output, we should see state transition in this order:
-        # 1. Replica opens rdbchannel: wait_bgsave
-        # 2. Replica establishes psync: bg_rdb_transfer
-        # 3. Sync is completed: online
+        # 1. wait_bgsave: Replica receives psync error (+RDBCHANNELSYNC)
+        # 2. bg_rdb_transfer: Replica opens rdbchannel and delivery started
+        # 3. online: Sync is completed
         test "Test replica state should start with wait_bgsave" {
             $replica config set key-load-delay 100000
-            # Pause replica before psync
-            $replica debug repl-pause before-main-conn-psync
+            # Pause replica before opening rdb channel conn
+            $replica debug repl-pause before-rdb-channel
             $replica replicaof $master_host $master_port
 
             wait_for_condition 50 200 {
-                [s 0 rdb_bgsave_in_progress] == 1 &&
                 [s 0 connected_slaves] == 1 &&
                 [string match "*wait_bgsave*" [s 0 slave0]]
+            } else {
+                fail "replica failed"
+            }
+        }
+
+        test "Test replica state advances to bg_rdb_transfer when rdbchannel connects" {
+            $master set x 1
+            resume_process $replica_pid
+
+            wait_for_condition 50 200 {
+                [s 0 connected_slaves] == 1 &&
+                [s 0 rdb_bgsave_in_progress] == 1 &&
+                [string match "*bg_rdb_transfer*" [s 0 slave0]]
             } else {
                 fail "replica failed"
             }
@@ -165,29 +172,22 @@ start_server {tags {"repl external:skip"}} {
         test "Test replica rdbchannel client has SC flag on client list output" {
             set input [$master client list type replica]
 
+            # There will two replicas, second one should be rdbchannel
             set trimmed_input [string trimright $input]
-            if {[string first "\n" $trimmed_input] >= 0} {
-                error "there are more than one replicas"
+            set lines [split $trimmed_input "\n"]
+            if {[llength $lines] < 2} {
+                error "There is no second line in the input: $input"
             }
+            set second_line [lindex $lines 1]
 
-            if {![regexp {flags=SC} $input]} {
-                error "Flags are not 'SC': $input"
-            }
-        }
-
-        test "Test replica state advances to bg_rdb_transfer on main channel psync" {
-            $master set x 1
-            resume_process $replica_pid
-
-            wait_for_condition 50 200 {
-                [s 0 connected_slaves] == 1 &&
-                [string match "*bg_rdb_transfer*" [s 0 slave0]]
-            } else {
-                fail "replica failed"
+            # Check if 'flags=SC' exists in the second line
+            if {![regexp {flags=SC} $second_line]} {
+                error "Flags are not 'SC' in the second line: $second_line"
             }
         }
 
         test "Test replica state advances to online when fullsync is completed" {
+            # Speed up loading
             $replica config set key-load-delay 0
 
             wait_replica_online $master 0 100 1000
@@ -263,62 +263,6 @@ start_server {tags {"repl external:skip"}} {
 
 start_server {tags {"repl external:skip"}} {
     set replica [srv 0 client]
-    set replica_pid [srv 0 pid]
-
-    start_server {} {
-        set master [srv 0 client]
-        set master_host [srv 0 host]
-        set master_port [srv 0 port]
-        set backlog_size [expr {10 ** 5}]
-
-        $master config set repl-diskless-sync yes
-        $master config set repl-rdb-channel yes
-        $master config set repl-backlog-size $backlog_size
-        $master config set loglevel debug
-        $master config set rdb-key-save-delay 200
-
-        $replica config set repl-rdb-channel yes
-        $replica config set loglevel debug
-
-        test "Test master backlog can grow beyond its configured limit" {
-            # Simulate slow consumer. If replica does not consume fast enough,
-            # master's backlog will grow.
-
-            # Populate db with some keys, delivery will take some time.
-            populate 10000 master 10000
-
-            # Pause replica before psync, so replica will not consume backlog
-            $replica debug repl-pause before-main-conn-psync
-
-            # Start write traffic
-            set load_handle [start_write_load $master_host $master_port 100 "key"]
-            $replica replicaof $master_host $master_port
-
-            # Verify repl backlog can grow
-            wait_for_condition 1000 20 {
-                [s 0 mem_total_replication_buffers] > [expr {3 * $backlog_size}]
-            } else {
-                fail "Master should allow backlog to grow beyond its limits during replication"
-            }
-
-            # resume replica
-            resume_process $replica_pid
-
-            stop_write_load $load_handle
-
-            # Verify recovery. Wait until replica catches up
-            wait_replica_online $master 0 100 1000
-            wait_for_ofs_sync $master $replica
-
-            # Verify db's are identical
-            assert_morethan [$master dbsize] 0
-            assert_equal [$master debug digest] [$replica debug digest]
-        }
-   }
-}
-
-start_server {tags {"repl external:skip"}} {
-    set replica [srv 0 client]
 
     start_server {} {
         set master [srv 0 client]
@@ -381,271 +325,6 @@ start_server {tags {"repl external:skip"}} {
 }
 
 start_server {tags {"repl external:skip"}} {
-    set replica1 [srv 0 client]
-    set replica1_pid  [srv 0 pid]
-
-    start_server {} {
-        set replica2 [srv 0 client]
-        set replica2_pid  [srv 0 pid]
-
-        start_server {} {
-            set master [srv 0 client]
-            set master_host [srv 0 host]
-            set master_port [srv 0 port]
-
-            test "Test replicas are attached to backlog" {
-                # Once rdb delivery starts, rdb channel slave keeps a reference
-                # to backlog on master, so main channel psync attempt will be
-                # successful. In this test, we verify replicas rdbchannel
-                # connections are attached to backlog successfully.
-                $master config set repl-diskless-sync yes
-                $master config set repl-rdb-channel yes
-                $master config set loglevel debug
-
-                $replica1 config set repl-rdb-channel yes
-                $replica2 config set repl-rdb-channel yes
-
-                # Replicas will sleep before establishing psync. On master,
-                # their rdbchannel connection will maintain a reference to the
-                # backlog.
-                $replica1 debug repl-pause before-main-conn-psync
-                $replica2 debug repl-pause before-main-conn-psync
-
-                # Populate db
-                populate 1000 master 10
-
-                set loglines [count_log_lines -1]
-                set load_handle [start_write_load $master_host $master_port 20]
-                $replica1 replicaof $master_host $master_port
-
-                # For the first replica, there is no backlog on the master.
-                # It will be lazily attached to backlog once the first backlog
-                # object is created.
-                wait_for_log_messages 0 {"*Added rdb replica*to the psync waiting list*tail = 0*"} $loglines 2000 1
-
-                # Wait until first backlog node is created
-                set res [wait_for_log_messages 0 {"*Attached replica rdb client*"} $loglines 2000 1]
-                set loglines [lindex $res 1]
-                incr $loglines
-
-                # Second replica will be attached to backlog tail.
-                $replica2 replicaof $master_host $master_port
-                wait_for_log_messages 0 {"*Added rdb replica*to the psync waiting list*tail = 1*"} $loglines 2000 1
-
-                # Resume replicas and verify the recovery
-                resume_process $replica1_pid
-                resume_process $replica2_pid
-
-                stop_write_load $load_handle
-
-                # Wait until replication is completed
-                wait_for_ofs_sync $master $replica1
-                wait_for_ofs_sync $master $replica2
-
-                assert_equal [s 0 replicas_waiting_psync] 0
-
-                # Verify db's are identical
-                assert_equal [$master debug digest] [$replica1 debug digest]
-                assert_equal [$master debug digest] [$replica2 debug digest]
-            }
-        }
-    }
-}
-
-start_server {tags {"repl external:skip"}} {
-    set replica [srv 0 client]
-    set replica_pid [srv 0 pid]
-
-    start_server {} {
-        set master [srv 0 client]
-        set master_pid  [srv 0 pid]
-        set master_host [srv 0 host]
-        set master_port [srv 0 port]
-
-        # Create small enough db to be loaded before replica establishes psync
-        $master set key1 val1
-
-        $master config set repl-diskless-sync yes
-        $master config set repl-rdb-channel yes
-        $master config set loglevel debug
-
-        $replica config set repl-rdb-channel yes
-        $replica config set loglevel debug
-
-        test "Test rdb is loaded before main channel establishes psync (success scenario)" {
-            # Steps:
-            #  1. Replica initiates synchronization via RDB channel.
-            #  2. Master's main process is suspended. RDB is delivered by the fork.
-            #  3. Replica completes RDB loading, closes RDB channel.
-            #  4. Replica pauses before establishing psync.
-            #  5. Master resumes operation and detects closed RDB channel.
-            #  6. Replica resumes operation and establishes pysnc.
-            #
-            #  We expect master to keep rdbchannel reference to the backlog so
-            #  psync at step-6 can be successful.
-
-            # Pause master main process after fork
-            $master debug repl-pause after-fork
-
-            # Give replica five second grace period before disconnection
-            $master debug delay-rdb-client-free 5
-            $replica config set repl-timeout 10
-
-            set loglines [count_log_lines -1]
-
-            # Start some write traffic. If master does not prevent backlog
-            # trimming, replicas psync attempt will fail.
-            set load_handle [start_write_load $master_host $master_port 20]
-
-            $replica replicaof $master_host $master_port
-
-            # Wait until replica loads rdb
-            wait_for_log_messages -1 {"*Done loading RDB*"} $loglines 1000 10
-
-            # Pause replica and resume master
-            pause_process $replica_pid
-            resume_process $master_pid
-
-            # Master will wait until replica main channel establishes psync
-            wait_for_log_messages 0 {"*Postponed RDB client*free*"} 0 1000 10
-            wait_for_condition 50 100 {
-                [s 0 replicas_waiting_psync] == 1
-            } else {
-                fail "Master freed RDB client before psync was established"
-            }
-
-            # Resume replica and verify it establishes psync
-            resume_process $replica_pid
-            wait_for_log_messages -1 {"*Main channel established psync after rdb load*"} 0 1000 10
-
-            wait_replica_online $master 0
-            wait_for_condition 50 100 {
-                [s 0 replicas_waiting_psync] == 0
-            } else {
-                fail "Master did not delete rdb client from the psync list"
-            }
-
-            stop_write_load $load_handle
-
-            # Verify system is operational.
-            $master set x 1
-            $master set y 2
-            wait_replica_online $master 0 200 500
-            wait_for_ofs_sync $master $replica
-
-            # Verify db's are identical after sync
-            assert_morethan [$master dbsize] 0
-            assert_equal [$replica get x] 1
-            assert_equal [$replica get y] 2
-            wait_for_ofs_sync $master $replica
-            assert_equal [$master dbsize] [$replica dbsize]
-            assert_equal [$master debug digest] [$replica debug digest]
-        }
-    }
-}
-
-start_server {tags {"repl external:skip"}} {
-    set replica [srv 0 client]
-    set replica_pid [srv 0 pid]
-
-    start_server {} {
-        set master [srv 0 client]
-        set master_pid  [srv 0 pid]
-        set master_host [srv 0 host]
-        set master_port [srv 0 port]
-
-        # Create small enough db to be loaded before replica establishes psync
-        $master set key1 val1
-
-        $master config set repl-diskless-sync yes
-        $master config set repl-rdb-channel yes
-        $master config set loglevel debug
-
-        $replica config set repl-rdb-channel yes
-        $replica config set loglevel debug
-
-        test "Test rdb is loaded before main channel establishes psync (fail scenario)" {
-             # Steps:
-             #  1. Replica initiates synchronization via RDB channel.
-             #  2. Master's main process is suspended. RDB is delivered by the fork.
-             #  3. Replica completes RDB loading, closes RDB channel.
-             #  4. Replica pauses before establishing psync.
-             #  5. Master resumes operation and detects closed RDB channel.
-             #  6. Replica is too late to establish psync, master drops rdbchannel
-             #     client and its backlog reference.
-             #  7. Replica resumes operation and pysnc will fail.
-
-             # Pause master main process after fork
-             $master debug repl-pause after-fork
-
-             # Replica has three seconds to establish psync after rdb delivery
-             # is completed.
-             $master debug delay-rdb-client-free 3
-
-             set loglines [count_log_lines -1]
-             set load_handle [start_write_load $master_host $master_port 20]
-
-             $replica replicaof $master_host $master_port
-
-             # Wait until replica loads rdb
-             wait_for_log_messages -1 {"*Done loading RDB*"} $loglines 1000 10
-
-             # Pause replica and resume master
-             pause_process $replica_pid
-             resume_process $master_pid
-
-             wait_for_condition 50 100 {
-                 [s 0 replicas_waiting_psync] == 1
-             } else {
-                 fail "Master deleted RDB client before psync was established"
-             }
-
-             # Master will free rdbchannel client and drop its reference to the
-             # backlog. Replicas psync attempt will fail.
-             set res [wait_for_log_messages 0 {"*Replica main channel failed to establish PSYNC within the grace period*"} 0 1000 10]
-             wait_for_condition 50 100 {
-                 [s 0 replicas_waiting_psync] == 0
-             } else {
-                 fail "Master did not delete waiting psync replica after grace period"
-             }
-
-             $master debug repl-pause clear
-
-             # Create some traffic, backlog will move on to some other offset
-             populate 200 master 10000
-
-             # Sync should fail once the replica ask for PSYNC using main channel
-             set prev_partial_err [s 0 sync_partial_err]
-             resume_process $replica_pid
-
-             wait_for_condition 50 200 {
-                 [s 0 sync_partial_err] > $prev_partial_err
-             } else {
-                 puts "sync_partial_err: [s 0 sync_partial_err],
-                       prev_partial_err: $prev_partial_err"
-                 fail "Replica psync request should have failed"
-             }
-
-             stop_write_load $load_handle
-
-            # Verify system is operational.
-            $master set x 1
-            $master set y 2
-            wait_replica_online $master 0 200 500
-            wait_for_ofs_sync $master $replica
-
-            # Verify db's are identical after sync
-            assert_morethan [$master dbsize] 0
-            assert_equal [$replica get x] 1
-            assert_equal [$replica get y] 2
-            wait_for_ofs_sync $master $replica
-            assert_equal [$master dbsize] [$replica dbsize]
-            assert_equal [$master debug digest] [$replica debug digest]
-        }
-    }
-}
-
-start_server {tags {"repl external:skip"}} {
     set master [srv 0 client]
     set master_host [srv 0 host]
     set master_port [srv 0 port]
@@ -666,109 +345,29 @@ start_server {tags {"repl external:skip"}} {
         $replica config set repl-rdb-channel yes
         $replica config set loglevel debug
         $replica config set repl-timeout 10
+        $replica config set key-load-delay 10000
+        $replica config set loading-process-events-interval-bytes 1024
 
-        test "Test master disconnects replica when output buffer limit is reached (after rdb delivery)" {
-            # Steps:
-            #  1. Replica initiates synchronization via RDB channel.
-            #  2. Master's main process is suspended. RDB is delivered by the fork.
-            #  3. Replica completes RDB loading, closes RDB channel.
-            #  4. Replica pauses before establishing psync.
-            #  5. Master resumes operation.
-            #  6. As replica hasn't established psync yet, master will accumulate backlog.
-            #  7. When client output buffer limit is reached, master will disconnect replica.
-
+        test "Test master disconnects replica when output buffer limit is reached" {
             # Pause master main process after fork
-            $master debug repl-pause after-fork
+            populate 20000 master 100 -1
 
             $replica replicaof $master_host $master_port
-            # Wait until replica loads RDB
-            wait_for_log_messages 0 {"*Done loading RDB*"} 0 1000 10
-
-            # At this point rdb is loaded but psync hasn't been established yet.
-            # Pause the replica so the master main process will wake up while
-            # the replica is unresponsive. We expect the main process to fill
-            # the client output buffer and disconnect the replica.
-            pause_process $replica_pid
-            resume_process $master_pid
-
-            # Disable pause flag
-            $master debug repl-pause clear
+            wait_for_condition 50 200 {
+                [s 0 loading] == 1
+            } else {
+                fail "[s 0 loading] sdsdad"
+            }
 
             # Generate some traffic for backlog ~2mb
-            populate 200 master 10000 -1
+            populate 20 master 1000000 -1
 
             set res [wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 1000 10]
             set loglines [lindex $res 1]
+            $replica config set key-load-delay 0
 
-            # Verify master deletes replica from psync waiting list.
-            wait_for_condition 50 100 {
-                [s -1 replicas_waiting_psync] == 0
-            } else {
-                fail "Master did not delete replica from psync waiting list"
-            }
-
-            # Resume replica and verify it fails to establish psync.
-            resume_process $replica_pid
-            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 2000 100]
-            set loglines [lindex $res 1]
-
-            # Wait until replica catches up
-            wait_replica_online $master 0 1000 100
-        }
-
-        test "Test master disconnects replica when output buffer limit is reached (during rdb delivery)" {
-            # Steps:
-            #  1. Replica initiates synchronization via RDB channel.
-            #  2. Master starts delivering RDB.
-            #  3. Replica pauses before establishing psync.
-            #  4. Backlog grows on master as replica does not consume it.
-            #  5. When client output buffer limit is reached, master will disconnect replica.
-
-            $replica replicaof no one
-            $replica debug repl-pause before-main-conn-psync
-
-            # Set master with a slow rdb generation, so that we can easily
-            # intercept loading 10ms per key, with 20000 keys is 200 seconds
-            $master config set rdb-key-save-delay 10000
-            populate 20000 master 100
-
-            set client_disconnected [s -1 client_output_buffer_limit_disconnections]
-            $replica replicaof $master_host $master_port
-
-            # RDB delivery starts
-            wait_for_condition 50 100 {
-                [s -1 rdb_bgsave_in_progress] == 1
-            } else {
-                fail "Sync did not start"
-            }
-
-            # Create some traffic on backlog ~2mb
-            populate 200 master 10000 -1
-
-            # Verify master kills replica connection.
-            wait_for_condition 50 10 {
-                [s -1 client_output_buffer_limit_disconnections] == $client_disconnected + 1
-            } else {
-                fail "Master should disconnect replica"
-            }
-            set res [wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 1000 10]
-            set loglines [lindex $res 1]
-
-            wait_for_condition 50 100 {
-                [s -1 replicas_waiting_psync] == 0
-            } else {
-                fail "Master did not delete replica from psync waiting list"
-            }
-
-            # Resume replica
-            resume_process $replica_pid
-
-            wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 2000 10
-
-            # Speed up replication
-            $replica debug repl-pause clear
-            $master config set repl-diskless-sync-delay 0
-            $master config set rdb-key-save-delay 0
+            # Wait until replica loads RDB
+            wait_for_log_messages 0 {"*Done loading RDB*"} 0 1000 10
         }
 
         test "Test replication recovers after output buffer failures" {
@@ -825,7 +424,6 @@ start_server {tags {"repl external:skip"}} {
 
                 # Wait for both replicas main conns to establish psync
                 wait_for_condition 500 100 {
-                    [s -2 sync_partial_ok] == 2 &&
                     [s -2 connected_slaves] == 2
                 } else {
                     fail "Replicas didn't establish psync:
@@ -840,13 +438,11 @@ start_server {tags {"repl external:skip"}} {
                 wait_for_condition 50 1000 {
                     [s 0 master_link_status] == "up" &&
                     [s -2 sync_full] == 2 &&
-                    [s -2 sync_partial_ok] == 2 &&
                     [s -2 connected_slaves] == 1
                 } else {
                     fail "Sync session did not continue
                           master_link_status: [s 0 master_link_status]
                           sync_full:[s -2 sync_full]
-                          sync_partial_ok:[s -2 sync_partial_ok]
                           connected_slaves: [s -2 connected_slaves]"
                 }
             }
@@ -854,8 +450,7 @@ start_server {tags {"repl external:skip"}} {
             test "Test master aborts rdb delivery if all replicas are dropped" {
                 $replica2 replicaof no one
 
-                # Start replicaof
-                set cur_psync [status $master sync_partial_ok]
+                # Start replication
                 $replica2 replicaof $master_host $master_port
 
                 wait_for_condition 50 1000 {
@@ -863,14 +458,6 @@ start_server {tags {"repl external:skip"}} {
                 } else {
                     fail "Sync did not start"
                 }
-
-                # Wait replica main connection to establish psync
-                wait_for_condition 50 1000 {
-                    [s -2 sync_partial_ok] == $cur_psync + 1
-                } else {
-                    fail "No new psync, sync_partial_ok: [s -2 sync_partial_ok]"
-                }
-
                 set loglines [count_log_lines -2]
 
                 # kill replica
@@ -885,8 +472,7 @@ start_server {tags {"repl external:skip"}} {
                           rdb_bgsave_in_progress:[s -2 rdb_bgsave_in_progress]
                           connected_slaves: [s -2 connected_slaves]"
                 }
-
-                wait_for_log_messages -2 {"*Background RDB transfer error*"} $loglines 1000 10
+                wait_for_log_messages -2 {"*Background transfer error*"} $loglines 1000 10
             }
 
             stop_write_load $load_handle
@@ -934,16 +520,10 @@ start_server {tags {"repl external:skip"}} {
             set id [get_replica_client_id $master yes]
             $master client kill id $id
 
-            # Wait for master to abort the sync
-            wait_for_condition 500 100 {
-                [s -1 replicas_waiting_psync] == 0
-            } else {
-                fail "Master did not delete replica from psync waiting list"
-            }
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
+            wait_for_log_messages -1 {"*Background transfer error*"} $loglines 1000 10
 
-            # Verify master rejects set-rdb-client-id after connection is killed
-            assert_error {*Unrecognized*} {$master replconf set-rdb-client-id $id}
+            # Verify master rejects main-ch-client-id after connection is killed
+            assert_error {*Unrecognized*} {$master replconf main-ch-client-id $id}
 
             # Replica should retry
             wait_for_condition 500 200 {
@@ -961,14 +541,7 @@ start_server {tags {"repl external:skip"}} {
             set id [get_replica_client_id $master yes]
             $master client kill id $id
 
-            # Wait for master to abort the sync
-            wait_for_condition 50 1000 {
-                [s -1 replicas_waiting_psync] == 0
-            } else {
-                fail "replicas_waiting_psync did not become zero"
-            }
-
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 20
+            wait_for_log_messages -1 {"*Background transfer error*"} $loglines 1000 20
 
             # Replica should retry
             wait_for_condition 500 2000 {
@@ -1104,7 +677,7 @@ start_server {tags {"repl external:skip"}} {
             # Verify there is another successful psync and no other full sync
             wait_for_condition 50 200 {
                 [s 0 sync_full] == 1 &&
-                [s 0 sync_partial_ok] == 2
+                [s 0 sync_partial_ok] == 1
             } else {
                 fail "psync was not successful [s 0 sync_full] [s 0 sync_partial_ok]"
             }
@@ -1165,7 +738,7 @@ start_server {tags {"repl external:skip"}} {
             # Verify replica attempts another full sync
             wait_for_condition 50 200 {
                 [s 0 sync_full] == 2 &&
-                [s 0 sync_partial_ok] == 2
+                [s 0 sync_partial_ok] == 0
             } else {
                 fail "sync was not successful [s 0 sync_full] [s 0 sync_partial_ok]"
             }

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -140,7 +140,7 @@ start_server {tags {"repl external:skip"}} {
 
         # On master info output, we should see state transition in this order:
         # 1. wait_bgsave: Replica receives psync error (+RDBCHANNELSYNC)
-        # 2. bg_rdb_transfer: Replica opens rdbchannel and delivery started
+        # 2. send_bulk_and_stream: Replica opens rdbchannel and delivery started
         # 3. online: Sync is completed
         test "Test replica state should start with wait_bgsave" {
             $replica config set key-load-delay 100000
@@ -156,14 +156,14 @@ start_server {tags {"repl external:skip"}} {
             }
         }
 
-        test "Test replica state advances to bg_rdb_transfer when rdbchannel connects" {
+        test "Test replica state advances to send_bulk_and_stream when rdbchannel connects" {
             $master set x 1
             resume_process $replica_pid
 
             wait_for_condition 50 200 {
                 [s 0 connected_slaves] == 1 &&
                 [s 0 rdb_bgsave_in_progress] == 1 &&
-                [string match "*bg_rdb_transfer*" [s 0 slave0]]
+                [string match "*send_bulk_and_stream*" [s 0 slave0]]
             } else {
                 fail "replica failed"
             }
@@ -292,7 +292,7 @@ start_server {tags {"repl external:skip"}} {
 
             # Wait for replica to establish psync using main channel
             wait_for_condition 500 1000 {
-                [string match "*state=bg_rdb_transfer*" [s 0 slave0]]
+                [string match "*state=send_bulk_and_stream*" [s 0 slave0]]
             } else {
                 fail "replica didn't start sync"
             }
@@ -508,7 +508,7 @@ start_server {tags {"repl external:skip"}} {
 
             # Wait for sync session to start
             wait_for_condition 500 200 {
-                [string match "*state=bg_rdb_transfer*" [s -1 slave0]] &&
+                [string match "*state=send_bulk_and_stream*" [s -1 slave0]] &&
                 [s -1 rdb_bgsave_in_progress] eq 1
             } else {
                 fail "replica didn't start sync session in time"
@@ -527,7 +527,7 @@ start_server {tags {"repl external:skip"}} {
 
             # Replica should retry
             wait_for_condition 500 200 {
-                [string match "*state=bg_rdb_transfer*" [s -1 slave0]] &&
+                [string match "*state=send_bulk_and_stream*" [s -1 slave0]] &&
                 [s -1 rdb_bgsave_in_progress] eq 1
             } else {
                 fail "replica didn't retry after connection close"
@@ -545,7 +545,7 @@ start_server {tags {"repl external:skip"}} {
 
             # Replica should retry
             wait_for_condition 500 2000 {
-                [string match "*state=bg_rdb_transfer*" [s -1 slave0]] &&
+                [string match "*state=send_bulk_and_stream*" [s -1 slave0]] &&
                 [s -1 rdb_bgsave_in_progress] eq 1
             } else {
                 fail "replica didn't retry after connection close"

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1278,7 +1278,8 @@ start_server {tags {"repl external:skip"}} {
                 r slaveof $master2_host $master2_port
                 wait_for_condition 50 100 {
                     ([s -2 rdb_bgsave_in_progress] == 1) &&
-                    ([string match "*wait_bgsave*" [s -2 slave0]])
+                        ([string match "*wait_bgsave*" [s -2 slave0]] ||
+                         [string match "*bg_rdb_transfer*" [s -2 slave0]])
                 } else {
                     fail "full sync didn't start"
                 }

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1279,7 +1279,7 @@ start_server {tags {"repl external:skip"}} {
                 wait_for_condition 50 100 {
                     ([s -2 rdb_bgsave_in_progress] == 1) &&
                         ([string match "*wait_bgsave*" [s -2 slave0]] ||
-                         [string match "*bg_rdb_transfer*" [s -2 slave0]])
+                         [string match "*send_bulk_and_stream*" [s -2 slave0]])
                 } else {
                     fail "full sync didn't start"
                 }

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1308,10 +1308,8 @@ start_server {tags {"repl external:skip"}} {
                     assert_equal [s master_replid] [s -1 master_replid]
                     assert ![log_file_matches [srv -1 stdout] "*Connection with master lost*"]
                     # Sub replica just has one full sync, no partial resync.
-                    # Though, full sync will include a single partial sync as
-                    # there will be two connections in parallel.
                     assert_equal 1 [s sync_full]
-                    assert_equal 1 [s sync_partial_ok]
+                    assert_equal 0 [s sync_partial_ok]
                 }
             }
         }

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1,3 +1,16 @@
+#
+# Copyright (c) 2009-Present, Redis Ltd.
+# All rights reserved.
+#
+# Copyright (c) 2024-present, Valkey contributors.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2) or the Server Side Public License v1 (SSPLv1).
+#
+# Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
+#
+
 proc log_file_matches {log pattern} {
     set fp [open $log r]
     set content [read $fp]

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -118,11 +118,11 @@ proc wait_for_sync r {
     }
 }
 
-proc wait_replica_online r {
-    wait_for_condition 50 100 {
-        [string match "*slave0:*,state=online*" [$r info replication]]
+proc wait_replica_online {r {replica_id 0} {maxtries 50} {delay 100}} {
+    wait_for_condition $maxtries $delay {
+        [string match "*slave$replica_id:*,state=online*" [$r info replication]]
     } else {
-        fail "replica didn't online in time"
+        fail "replica $replica_id did not become online in time"
     }
 }
 
@@ -565,10 +565,11 @@ proc find_valgrind_errors {stderr on_termination} {
 }
 
 # Execute a background process writing random data for the specified number
-# of seconds to the specified Redis instance.
-proc start_write_load {host port seconds} {
+# of seconds to the specified Redis instance. If key is omitted, a random key
+# is used for every SET command.
+proc start_write_load {host port seconds {key ""}} {
     set tclsh [info nameofexecutable]
-    exec $tclsh tests/helpers/gen_write_load.tcl $host $port $seconds $::tls &
+    exec $tclsh tests/helpers/gen_write_load.tcl $host $port $seconds $::tls $key &
 }
 
 # Stop a process generating write load executed with start_write_load.
@@ -677,6 +678,12 @@ proc pause_process pid {
 }
 
 proc resume_process pid {
+    wait_for_condition 50 1000 {
+        [string match "T*" [exec ps -o state= -p $pid]]
+    } else {
+        puts [exec ps j $pid]
+        fail "process was not stopped"
+    }
     exec kill -SIGCONT $pid
 }
 

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -1,3 +1,16 @@
+#
+# Copyright (c) 2009-Present, Redis Ltd.
+# All rights reserved.
+#
+# Copyright (c) 2024-present, Valkey contributors.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2) or the Server Side Public License v1 (SSPLv1).
+#
+# Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
+#
+
 proc randstring {min max {type binary}} {
     set len [expr {$min+int(rand()*($max-$min+1))}]
     set output {}

--- a/tests/unit/auth.tcl
+++ b/tests/unit/auth.tcl
@@ -65,24 +65,29 @@ start_server {tags {"auth_binary_password external:skip"}} {
         set master_port [srv -1 port]
         set slave [srv 0 client]
 
-        test {MASTERAUTH test with binary password} {
-            $master config set requirepass "abc\x00def"
+        foreach rdbchannel {yes no} {
+            test "MASTERAUTH test with binary password rdbchannel=$rdbchannel" {
+                $slave slaveof no one
+                $master config set requirepass "abc\x00def"
+                $master config set repl-rdb-channel $rdbchannel
 
-            # Configure the replica with masterauth
-            set loglines [count_log_lines 0]
-            $slave config set masterauth "abc"
-            $slave slaveof $master_host $master_port
+                # Configure the replica with masterauth
+                set loglines [count_log_lines 0]
+                $slave config set masterauth "abc"
+                $slave config set repl-rdb-channel $rdbchannel
+                $slave slaveof $master_host $master_port
 
-            # Verify replica is not able to sync with master
-            wait_for_log_messages 0 {"*Unable to AUTH to MASTER*"} $loglines 1000 10
-            assert_equal {down} [s 0 master_link_status]
-            
-            # Test replica with the correct masterauth
-            $slave config set masterauth "abc\x00def"
-            wait_for_condition 50 100 {
-                [s 0 master_link_status] eq {up}
-            } else {
-                fail "Can't turn the instance into a replica"
+                # Verify replica is not able to sync with master
+                wait_for_log_messages 0 {"*Unable to AUTH to MASTER*"} $loglines 1000 10
+                assert_equal {down} [s 0 master_link_status]
+
+                # Test replica with the correct masterauth
+                $slave config set masterauth "abc\x00def"
+                wait_for_condition 50 100 {
+                    [s 0 master_link_status] eq {up}
+                } else {
+                    fail "Can't turn the instance into a replica"
+                }
             }
         }
     }

--- a/tests/unit/auth.tcl
+++ b/tests/unit/auth.tcl
@@ -1,3 +1,16 @@
+#
+# Copyright (c) 2009-Present, Redis Ltd.
+# All rights reserved.
+#
+# Copyright (c) 2024-present, Valkey contributors.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2) or the Server Side Public License v1 (SSPLv1).
+#
+# Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
+#
+
 start_server {tags {"auth external:skip"}} {
     test {AUTH fails if there is no password configured server side} {
         catch {r auth foo} err


### PR DESCRIPTION
This PR is based on:

https://github.com/redis/redis/pull/12109
https://github.com/valkey-io/valkey/pull/60

Closes: https://github.com/redis/redis/issues/11678

**Motivation**

During a full sync, when master is delivering RDB to the replica, incoming write commands are kept in a replication buffer in order to be sent to the replica once RDB delivery is completed. If RDB delivery takes a long time, it might create memory pressure on master. Also, once a replica connection accumulates replication data which is larger than output buffer limits, master will kill replica connection. This may cause a replication failure.

The main benefit of the rdb channel replication is streaming incoming commands in parallel to the RDB delivery. This approach shifts replication stream buffering to the replica and reduces load on master. We do this by opening another connection for RDB delivery. The main channel on replica will be receiving replication stream while rdb channel is receiving the RDB.

This feature also helps to reduce master's main process CPU load. By opening a dedicated connection for the RDB transfer, the bgsave process has access to the new connection and it will stream RDB directly to the replicas. Before this change, due to TLS connection restriction, the bgsave process was writing RDB bytes to a pipe and the main process was forwarding
it to the replica. This is no longer necessary, the main process can avoid these expensive socket read/write syscalls. It also means RDB delivery to replica will be faster as it avoids this step.

In summary, replication will be faster and master's performance during full syncs will improve.


**Implementation steps**

1. When replica connects to the master, it sends 'rdb-channel-repl' as part of capability exchange to let master to know replica supports rdb channel.
2. When replica lacks sufficient data for PSYNC, master sends +RDBCHANNELSYNC reply with replica's client id. As the next step, the replica opens a new connection (rdb-channel) and configures it against the master with the appropriate capabilities and requirements. It also sends given client id back to master over rdbchannel, so that master can associate these channels. (initial replica connection will be referred as main-channel) Then, replica requests fullsync using the RDB channel.
3. Prior to forking, master attaches the replica's main channel to the replication backlog to deliver replication stream starting at the snapshot end offset.
4. The master main process sends replication stream via the main channel, while the bgsave process sends the RDB directly to the replica via the rdb-channel. Replica accumulates replication stream in a local buffer, while the RDB is being loaded into the memory.
5. Once the replica completes loading the rdb, it drops the rdb channel and streams the accumulated replication stream into the db. Sync is completed.

**Some details**
- Currently, rdbchannel replication is supported only if `repl-diskless-sync` is enabled on master. Otherwise, replication will happen over a single connection as in before. 
- On replica, there is a limit to replication stream buffering. Replica uses a new config `replica-full-sync-buffer-limit` to limit number of bytes to accumulate. If it is not set, replica inherits `client-output-buffer-limit <replica>` hard limit config. If we reach this limit, replica stops accumulating. This is not a failure scenario though. Further accumulation will happen on master side. Depending on the configured limits on master, master may kill the replica connection.

**API changes in INFO output:**

1. New replica state: `send_bulk_and_stream`. Indicates full sync is still in progress for this replica. It is receiving replication stream and rdb in parallel.
```
slave0:ip=127.0.0.1,port=5002,state=send_bulk_and_stream,offset=0,lag=0
```
Replica state changes in steps:
 - First, replica sends psync and receives +RDBCHANNELSYNC :`state=wait_bgsave`
 - After replica connects with rdbchannel and delivery starts: `state=send_bulk_and_stream`
 - After full sync: `state=online`

2. On replica side, replication stream buffering metrics:
 - replica_full_sync_buffer_size: Currently accumulated replication stream data in bytes. 
 - replica_full_sync_buffer_peak: Peak number of bytes that this instance accumulated in the lifetime of the process. 

```
replica_full_sync_buffer_size:20485             
replica_full_sync_buffer_peak:1048560
```

**API changes in CLIENT LIST**

In `client list` output, rdbchannel clients will have 'C' flag in addition to 'S' replica flag:
```
id=11 addr=127.0.0.1:39108 laddr=127.0.0.1:5001 fd=14 name= age=5 idle=5 flags=SC db=0 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=0 argv-mem=0 multi-mem=0 rbs=1024 rbp=0 obl=0 oll=0 omem=0 tot-mem=1920 events=r cmd=psync user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0
```

**Config changes:**
- `replica-full-sync-buffer-limit`: Controls how much replication data replica can accumulate during rdbchannel replication. If it is not set, a value of 0 means replica will inherit `client-output-buffer-limit <replica>` hard limit config to limit accumulated data.
- `repl-rdb-channel` config is added as a hidden config. This is mostly for testing as we need to support both rdbchannel replication and the older single connection replication (to keep compatibility with older versions and rdbchannel replication will not be enabled if repl-diskless-sync is not enabled). it affects both the master (not to respond to rdb channel requests), and the replica (not to declare capability)

**Internal API changes:**
Changes that were introduced to Redis replication:
- New replication capability is added to replconf command: `capa rdb-channel-repl`. Indicates replica is capable of rdb channel replication. Replica sends it when it connects to master along with other capabilities.
- If replica needs fullsync, master replies `+RDBCHANNELSYNC <client-id>` to the replica's PSYNC request. 
- When replica opens rdbchannel connection, as part of replconf command, it sends `rdb-channel 1`  to let master know this is rdb channel. Also, it sends `main-ch-client-id <client-id>` as part of replconf command so master can associate channels.
  
**Testing:**
  As rdbchannel replication is enabled by default, we run whole test suite with it. Though, as we need to support both rdbchannel and single connection replication, we'll be running some tests twice with `repl-rdb-channel yes/no` config. 

**Replica state diagram**
```
* * Replica state machine *
 *
 * Main channel state
 * ┌───────────────────┐
 * │RECEIVE_PING_REPLY │
 * └────────┬──────────┘
 *          │ +PONG
 * ┌────────▼──────────┐
 * │SEND_HANDSHAKE     │                     RDB channel state
 * └────────┬──────────┘            ┌───────────────────────────────┐
 *          │+OK                ┌───► RDB_CH_SEND_HANDSHAKE         │
 * ┌────────▼──────────┐        │   └──────────────┬────────────────┘
 * │RECEIVE_AUTH_REPLY │        │    REPLCONF main-ch-client-id <clientid>
 * └────────┬──────────┘        │   ┌──────────────▼────────────────┐
 *          │+OK                │   │ RDB_CH_RECEIVE_AUTH_REPLY     │
 * ┌────────▼──────────┐        │   └──────────────┬────────────────┘
 * │RECEIVE_PORT_REPLY │        │                  │ +OK
 * └────────┬──────────┘        │   ┌──────────────▼────────────────┐
 *          │+OK                │   │  RDB_CH_RECEIVE_REPLCONF_REPLY│
 * ┌────────▼──────────┐        │   └──────────────┬────────────────┘
 * │RECEIVE_IP_REPLY   │        │                  │ +OK
 * └────────┬──────────┘        │   ┌──────────────▼────────────────┐
 *          │+OK                │   │ RDB_CH_RECEIVE_FULLRESYNC     │
 * ┌────────▼──────────┐        │   └──────────────┬────────────────┘
 * │RECEIVE_CAPA_REPLY │        │                  │+FULLRESYNC
 * └────────┬──────────┘        │                  │Rdb delivery
 *          │                   │   ┌──────────────▼────────────────┐
 * ┌────────▼──────────┐        │   │ RDB_CH_RDB_LOADING            │
 * │SEND_PSYNC         │        │   └──────────────┬────────────────┘
 * └─┬─────────────────┘        │                  │ Done loading
 *   │PSYNC (use cached-master) │                  │
 * ┌─▼─────────────────┐        │                  │
 * │RECEIVE_PSYNC_REPLY│        │    ┌────────────►│ Replica streams replication
 * └─┬─────────────────┘        │    │             │ buffer into memory
 *   │                          │    │             │
 *   │+RDBCHANNELSYNC client-id │    │             │
 *   ├──────┬───────────────────┘    │             │
 *   │      │ Main channel           │             │
 *   │      │ accumulates repl data  │             │
 *   │   ┌──▼────────────────┐       │     ┌───────▼───────────┐
 *   │   │ REPL_TRANSFER     ├───────┘     │    CONNECTED      │
 *   │   └───────────────────┘             └────▲───▲──────────┘
 *   │                                          │   │
 *   │                                          │   │
 *   │  +FULLRESYNC    ┌───────────────────┐    │   │
 *   ├────────────────► REPL_TRANSFER      ├────┘   │
 *   │                 └───────────────────┘        │
 *   │  +CONTINUE                                   │
 *   └──────────────────────────────────────────────┘
 */
 ```
 -----
 This PR also contains changes and ideas from: 
https://github.com/valkey-io/valkey/pull/837
https://github.com/valkey-io/valkey/pull/1173
https://github.com/valkey-io/valkey/pull/804
https://github.com/valkey-io/valkey/pull/945
https://github.com/valkey-io/valkey/pull/989

------
Co-authored-by: Yuan Wang <wangyuancode@163.com>
Co-authored-by: debing.sun <debing.sun@redis.com>
Co-authored-by: Moti Cohen <moticless@gmail.com>
Co-authored-by: naglera <anagler123@gmail.com>
Co-authored-by: Amit Nagler <58042354+naglera@users.noreply.github.com>
Co-authored-by: Madelyn Olson <madelyneolson@gmail.com>
Co-authored-by: Binbin <binloveplay1314@qq.com>
Co-authored-by: Viktor Söderqvist <viktor.soderqvist@est.tech>
Co-authored-by: Ping Xie <pingxie@outlook.com>
Co-authored-by: Ran Shidlansik <ranshid@amazon.com>
Co-authored-by: ranshid <88133677+ranshid@users.noreply.github.com>
Co-authored-by: xbasel <103044017+xbasel@users.noreply.github.com>