### PR TITLE
Stabilize test suite, backport recent test and makefile changes to old release branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,20 @@ jobs:
     - name: make
       run: make REDIS_CFLAGS='-Werror' MALLOC=libc
 
-  build-centos7-jemalloc:
+  build-old-chain-jemalloc:
     runs-on: ubuntu-latest
-    container: centos:7
+    container: ubuntu:20.04
     steps:
     - uses: actions/checkout@v2
     - name: make
       run: |
-        yum -y install gcc make
-        make REDIS_CFLAGS='-Werror'
+        apt-get update
+        apt-get install -y gnupg2
+        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
+        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
+        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
+        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
+        apt-get update
+        apt-get install -y make gcc-4.8
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
+        make CC=gcc REDIS_CFLAGS='-Werror'

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -175,21 +175,29 @@ jobs:
     - name: module api test
       run: ./runtest-moduleapi --valgrind --no-latency --verbose --clients 1
 
-  test-centos7-jemalloc:
+  test-old-chain-jemalloc:
     runs-on: ubuntu-latest
     if: github.repository == 'redis/redis'
-    container: centos:7
+    container: ubuntu:20.04
     timeout-minutes: 14400
     steps:
     - uses: actions/checkout@v2
     - name: make
       run: |
-        yum -y install gcc make
-        make
+        apt-get update
+        apt-get install -y gnupg2
+        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
+        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
+        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
+        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
+        apt-get update
+        apt-get install -y make gcc-4.8
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
+        make CC=gcc REDIS_CFLAGS='-Werror'
+    - name: testprep
+      run: apt-get install -y tcl tcltls tclx
     - name: test
-      run: |
-        yum -y install which tcl
-        ./runtest --accurate --verbose --dump-logs
+      run: ./runtest --accurate --verbose --dump-logs
     - name: module api test
       run: ./runtest-moduleapi --verbose
     - name: sentinel tests
@@ -197,22 +205,31 @@ jobs:
     - name: cluster tests
       run: ./runtest-cluster
 
-  test-centos7-tls:
+  test-old-chain-tls:
     runs-on: ubuntu-latest
     if: github.repository == 'redis/redis'
-    container: centos:7
+    container: ubuntu:20.04
     timeout-minutes: 14400
     steps:
     - uses: actions/checkout@v2
     - name: make
       run: |
-        yum -y install centos-release-scl epel-release
-        yum -y install devtoolset-7 openssl-devel openssl
-        scl enable devtoolset-7 "make BUILD_TLS=yes"
+        apt-get update
+        apt-get install -y gnupg2
+        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
+        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
+        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
+        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
+        apt-get update
+        apt-get install -y make gcc-4.8 openssl libssl-dev
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
+        make CC=gcc BUILD_TLS=yes REDIS_CFLAGS='-Werror'
+    - name: testprep
+      run: |
+        apt-get install -y tcl tcltls tclx
+        ./utils/gen-test-certs.sh
     - name: test
       run: |
-        yum -y install tcl tcltls
-        ./utils/gen-test-certs.sh
         ./runtest --accurate --verbose --tls --dump-logs
         ./runtest --accurate --verbose --dump-logs
     - name: module api test

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -270,18 +270,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: test
-      uses: vmactions/freebsd-vm@v0.3.0
+      uses: cross-platform-actions/action@v0.22.0
       with:
-        usesh: true
-        sync: rsync
-        copyback: false
-        prepare: pkg install -y bash gmake lang/tcl86
-        run: >
-          gmake &&
-          ./runtest --accurate --verbose --no-latency --tags -large-memory --dump-logs &&
-          MAKE=gmake ./runtest-moduleapi --verbose &&
-          ./runtest-sentinel &&
-          ./runtest-cluster
+        operating_system: freebsd
+        environment_variables: MAKE
+        version: 13.2
+        shell: bash
+        run: |
+          sudo pkg install -y bash gmake lang/tcl86 lang/tclx gcc
+          gmake
+          ./runtest --single unit/keyspace --single unit/auth --single unit/networking --single unit/protocol
 
   test-alpine-jemalloc:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -264,7 +264,7 @@ jobs:
       run: ./runtest-cluster
 
   test-freebsd:
-    runs-on: macos-12
+    runs-on: macos-13
     if: github.repository == 'redis/redis'
     timeout-minutes: 14400
     steps:

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,7 @@ ifneq (,$(findstring FreeBSD,$(uname_S)))
   STD+=-Wno-c11-extensions
 endif
 endif
-WARN=-Wall -W -Wno-missing-field-initializers
+WARN=-Wall -W -Wno-missing-field-initializers -Wno-strict-prototypes
 OPT=$(OPTIMIZATION)
 
 # Detect if the compiler supports C11 _Atomic.

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -36,6 +36,14 @@ start_server {tags {"repl network"}} {
             }
         }
 
+        test {Slave enters wait_bgsave} {
+            wait_for_condition 50 1000 {
+                [string match *state=wait_bgsave* [$master info replication]]
+            } else {
+                fail "Replica does not enter wait_bgsave state"
+            }
+        }
+
         # But make the master unable to send
         # the periodic newlines to refresh the connection. The slave
         # should detect the timeout.

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -118,7 +118,7 @@ start_server {tags {"defrag"} overrides {appendonly yes auto-aof-rewrite-percent
             if {[r config get activedefrag] eq "activedefrag yes"} {
                 # reset stats and load the AOF file
                 r config resetstat
-                r config set key-load-delay -50 ;# sleep on average 1/50 usec
+                r config set key-load-delay -25 ;# sleep on average 1/25 usec
                 r debug loadaof
                 r config set activedefrag no
                 # measure hits and misses right after aof loading

--- a/tests/unit/oom-score-adj.tcl
+++ b/tests/unit/oom-score-adj.tcl
@@ -1,5 +1,4 @@
 set system_name [string tolower [exec uname -s]]
-set user_id [exec id -u]
 
 if {$system_name eq {linux}} {
     start_server {tags {"oom-score-adj"}} {
@@ -47,8 +46,15 @@ if {$system_name eq {linux}} {
             }
         }
 
+        # Determine whether the current user is unprivileged
+        set original_value [exec cat /proc/self/oom_score_adj]
+        catch {
+            set fd [open "/proc/self/oom_score_adj" "w"]
+            puts $fd -1000
+            close $fd
+        } e
         # Failed oom-score-adj tests can only run unprivileged
-        if {$user_id != 0} {
+        if {[string match "*permission denied*" $e]} {
             test {CONFIG SET oom-score-adj handles configuration failures} {
                 # Bad config
                 r config set oom-score-adj no
@@ -72,6 +78,11 @@ if {$system_name eq {linux}} {
                 # Make sure previous values remain
                 assert {[r config get oom-score-adj-values] == {oom-score-adj-values {0 100 100}}}
             }
+        } else {
+            # Restore the original oom_score_adj value
+            set fd [open "/proc/self/oom_score_adj" "w"]
+            puts $fd $original_value
+            close $fd
         }
     }
 }


### PR DESCRIPTION
In order to stabilize ci for version 6.2 we need to pick the following PRs and make some patches:

1. Disable -Wstrict-prototypes warning

failed CI: https://github.com/redis/redis/actions/runs/12630448615/job/35190275893?pr=13728
```
In file included from adlist.c:34:
./zmalloc.h:119:19: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
int jemalloc_purge();
```

2. https://github.com/redis/redis/pull/13394
failed CI: https://github.com/redis/redis/actions/runs/12630448615/job/35190275508?pr=13728
```
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib6[4](https://github.com/redis/redis/actions/runs/12630448615/job/35190275508?pr=13728#step:7:4)/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.2[5](https://github.com/redis/redis/actions/runs/12630448615/job/35190275508?pr=13728#step:7:5)' not found (required by /__e/node20/bin/node)
```

3. https://github.com/redis/redis/pull/13669
failed CI: https://github.com/redis/redis/actions/runs/12630448618/job/35190278211?pr=13728

4. https://github.com/redis/redis/pull/13111
failed CI: https://github.com/redis/redis/actions/runs/12630448615/job/35190276250?pr=13728
```
*** [err]: CONFIG SET oom-score-adj handles configuration failures in tests/unit/oom-score-adj.tcl
Expected 'OK' to match '*Failed to set*' (context: type eval line 8 cmd {assert_match {*Failed to set*} $e} proc ::test)
```

5. https://github.com/redis/redis/pull/11773
failed CI: https://github.com/redis/redis/actions/runs/12630448618/job/35190276266?pr=13728
```
*** [err]: Active defrag in tests/unit/memefficiency.tcl
Expected 1.52 < 1.4 (context: type eval line 109 cmd {assert {$frag < 1.4}} proc ::test)
```

6. https://github.com/redis/redis/pull/11598
failed CI: https://github.com/sundb/redis/actions/runs/12760443698/job/35565904180
```
*** [err]: Active defrag in tests/unit/memefficiency.tcl
Expected 1.51 < 1.4 (context: type eval line 109 cmd {assert {$frag < 1.4}} proc ::test)
```

7. Fix broken freebsd CI
failed CI: https://github.com/redis/redis/actions/runs/12768586806/job/35589266719?pr=13745