### PR TITLE
Return SFLUSH tests to CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -52,7 +52,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
+      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST -DEXPERIMENTAL_CMDS'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test

--- a/src/Makefile
+++ b/src/Makefile
@@ -344,12 +344,15 @@ QUIET_LINK = @printf '    %b %b\n' $(LINKCOLOR)LINK$(ENDCOLOR) $(BINCOLOR)$@$(EN
 QUIET_INSTALL = @printf '    %b %b\n' $(LINKCOLOR)INSTALL$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
 endif
 
+GEN_COMMANDS_FLAGS=
 ifneq (, $(findstring LOG_REQ_RES, $(REDIS_CFLAGS)))
 	COMMANDS_DEF_FILENAME=commands_with_reply_schema
-	GEN_COMMANDS_FLAGS=--with-reply-schema
+	GEN_COMMANDS_FLAGS+=--with-reply-schema
 else
 	COMMANDS_DEF_FILENAME=commands
-	GEN_COMMANDS_FLAGS=
+endif
+ifneq (, $(findstring EXPERIMENTAL_CMDS, $(REDIS_CFLAGS)))
+	GEN_COMMANDS_FLAGS+=--with-experimental-cmds
 endif
 
 REDIS_SERVER_NAME=redis-server$(PROG_SUFFIX)

--- a/src/server.h
+++ b/src/server.h
@@ -225,6 +225,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CMD_ALLOW_BUSY ((1ULL<<26))
 #define CMD_MODULE_GETCHANNELS (1ULL<<27)  /* Use the modules getchannels interface. */
 #define CMD_TOUCHES_ARBITRARY_KEYS (1ULL<<28)
+#define CMD_EXPERIMENTAL (1ULL<<29)
 
 /* Command flags that describe ACLs categories. */
 #define ACL_CATEGORY_KEYSPACE (1ULL<<0)

--- a/tests/unit/cluster/multi-slot-operations.tcl
+++ b/tests/unit/cluster/multi-slot-operations.tcl
@@ -108,75 +108,89 @@ test "DELSLOTSRANGE command with several boundary conditions test suite" {
 }
 } cluster_allocate_with_continuous_slots_local
 
-start_cluster 2 0 {tags {external:skip cluster experimental}} {
-
-set master1 [srv 0 "client"]
-set master2 [srv -1 "client"]
-
-test "SFLUSH - Errors and output validation" {
-    assert_match "* 0-8191*" [$master1 CLUSTER NODES]
-    assert_match "* 8192-16383*" [$master2 CLUSTER NODES]
-    assert_match "*0 8191*" [$master1 CLUSTER SLOTS]
-    assert_match "*8192 16383*" [$master2 CLUSTER SLOTS]
-
-    # make master1 non-continuous slots
-    $master1 cluster DELSLOTSRANGE 1000 2000
-
-    # Test SFLUSH errors validation
-    assert_error {ERR wrong number of arguments*}           {$master1 SFLUSH 4}
-    assert_error {ERR wrong number of arguments*}           {$master1 SFLUSH 4 SYNC}
-    assert_error {ERR Invalid or out of range slot}         {$master1 SFLUSH x 4}
-    assert_error {ERR Invalid or out of range slot}         {$master1 SFLUSH 0 12x}
-    assert_error {ERR Slot 3 specified multiple times}      {$master1 SFLUSH 2 4 3 5}
-    assert_error {ERR start slot number 8 is greater than*} {$master1 SFLUSH 8 4}
-    assert_error {ERR wrong number of arguments*}           {$master1 SFLUSH 4 8 10}
-    assert_error {ERR wrong number of arguments*}           {$master1 SFLUSH 0 999 2001 8191 ASYNCX}
-
-    # Test SFLUSH output validation
-    assert_match "" [$master1 SFLUSH 2 4]
-    assert_match "" [$master1 SFLUSH 0 4]
-    assert_match "" [$master2 SFLUSH 0 4]
-    assert_match "" [$master1 SFLUSH 1 8191]
-    assert_match "" [$master1 SFLUSH 0 8190]
-    assert_match "" [$master1 SFLUSH 0 998 2001 8191]
-    assert_match "" [$master1 SFLUSH 1 999 2001 8191]
-    assert_match "" [$master1 SFLUSH 0 999 2001 8190]
-    assert_match "" [$master1 SFLUSH 0 999 2002 8191]
-    assert_match "{0 999} {2001 8191}" [$master1 SFLUSH 0 999 2001 8191]
-    assert_match "{0 999} {2001 8191}" [$master1 SFLUSH 0 8191]
-    assert_match "{0 999} {2001 8191}" [$master1 SFLUSH 0 4000 4001 8191]
-    assert_match "" [$master2 SFLUSH 8193 16383]
-    assert_match "" [$master2 SFLUSH 8192 16382]
-    assert_match "{8192 16383}" [$master2 SFLUSH 8192 16383]
-    assert_match "{8192 16383}" [$master2 SFLUSH 8192 16383 SYNC]
-    assert_match "{8192 16383}" [$master2 SFLUSH 8192 16383 ASYNC]
-    assert_match "{8192 16383}" [$master2 SFLUSH 8192 9000 9001 16383]
-    assert_match "{8192 16383}" [$master2 SFLUSH 8192 9000 9001 16383 SYNC]
-    assert_match "{8192 16383}" [$master2 SFLUSH 8192 9000 9001 16383 ASYNC]
-
-    # restore master1 continuous slots
-    $master1 cluster ADDSLOTSRANGE 1000 2000
-}
-
-test "SFLUSH - Deletes the keys with argument <NONE>/SYNC/ASYNC" {
-    foreach op {"" "SYNC" "ASYNC"} {
-        for {set i 0} {$i < 100} {incr i} {
-            catch {$master1 SET key$i val$i}
-            catch {$master2 SET key$i val$i}
-        }
-
-        assert {[$master1 DBSIZE] > 0}
-        assert {[$master2 DBSIZE] > 0}
-        if {$op eq ""} {
-            assert_match "{0 8191}" [ $master1 SFLUSH 0 8191]
-        } else {
-            assert_match "{0 8191}" [ $master1 SFLUSH 0 8191 $op]
-        }
-        assert {[$master1 DBSIZE] == 0}
-        assert {[$master2 DBSIZE] > 0}
-        assert_match "{8192 16383}" [ $master2 SFLUSH 8192 16383]
-        assert {[$master2 DBSIZE] == 0}
+# Check if the experimental SFLUSH command available (more flexible than tags)
+proc isSflushSupported {} {
+    set server [srv 0 "client"]
+    set res [catch { [$server SFLUSH] } err]
+    if [string match "*wrong number of*" $err] {
+        puts $res
+        return 1
+    } else {
+        puts [colorstr yellow "Avoiding SFLUSH tests. This experimental command is unavailable"]
+        return 0
     }
 }
 
+start_cluster 2 0 {tags {external:skip cluster}} {
+    if {[isSflushSupported]} {
+    
+        set master1 [srv 0 "client"]
+        set master2 [srv -1 "client"]
+        
+        test "SFLUSH - Errors and output validation" {
+            assert_match "* 0-8191*" [$master1 CLUSTER NODES]
+            assert_match "* 8192-16383*" [$master2 CLUSTER NODES]
+            assert_match "*0 8191*" [$master1 CLUSTER SLOTS]
+            assert_match "*8192 16383*" [$master2 CLUSTER SLOTS]
+        
+            # make master1 non-continuous slots
+            $master1 cluster DELSLOTSRANGE 1000 2000
+        
+            # Test SFLUSH errors validation
+            assert_error {ERR wrong number of arguments*}           {$master1 SFLUSH 4}
+            assert_error {ERR wrong number of arguments*}           {$master1 SFLUSH 4 SYNC}
+            assert_error {ERR Invalid or out of range slot}         {$master1 SFLUSH x 4}
+            assert_error {ERR Invalid or out of range slot}         {$master1 SFLUSH 0 12x}
+            assert_error {ERR Slot 3 specified multiple times}      {$master1 SFLUSH 2 4 3 5}
+            assert_error {ERR start slot number 8 is greater than*} {$master1 SFLUSH 8 4}
+            assert_error {ERR wrong number of arguments*}           {$master1 SFLUSH 4 8 10}
+            assert_error {ERR wrong number of arguments*}           {$master1 SFLUSH 0 999 2001 8191 ASYNCX}
+        
+            # Test SFLUSH output validation
+            assert_match "" [$master1 SFLUSH 2 4]
+            assert_match "" [$master1 SFLUSH 0 4]
+            assert_match "" [$master2 SFLUSH 0 4]
+            assert_match "" [$master1 SFLUSH 1 8191]
+            assert_match "" [$master1 SFLUSH 0 8190]
+            assert_match "" [$master1 SFLUSH 0 998 2001 8191]
+            assert_match "" [$master1 SFLUSH 1 999 2001 8191]
+            assert_match "" [$master1 SFLUSH 0 999 2001 8190]
+            assert_match "" [$master1 SFLUSH 0 999 2002 8191]
+            assert_match "{0 999} {2001 8191}" [$master1 SFLUSH 0 999 2001 8191]
+            assert_match "{0 999} {2001 8191}" [$master1 SFLUSH 0 8191]
+            assert_match "{0 999} {2001 8191}" [$master1 SFLUSH 0 4000 4001 8191]
+            assert_match "" [$master2 SFLUSH 8193 16383]
+            assert_match "" [$master2 SFLUSH 8192 16382]
+            assert_match "{8192 16383}" [$master2 SFLUSH 8192 16383]
+            assert_match "{8192 16383}" [$master2 SFLUSH 8192 16383 SYNC]
+            assert_match "{8192 16383}" [$master2 SFLUSH 8192 16383 ASYNC]
+            assert_match "{8192 16383}" [$master2 SFLUSH 8192 9000 9001 16383]
+            assert_match "{8192 16383}" [$master2 SFLUSH 8192 9000 9001 16383 SYNC]
+            assert_match "{8192 16383}" [$master2 SFLUSH 8192 9000 9001 16383 ASYNC]
+        
+            # restore master1 continuous slots
+            $master1 cluster ADDSLOTSRANGE 1000 2000
+        }
+        
+        test "SFLUSH - Deletes the keys with argument <NONE>/SYNC/ASYNC" {
+            foreach op {"" "SYNC" "ASYNC"} {
+                for {set i 0} {$i < 100} {incr i} {
+                    catch {$master1 SET key$i val$i}
+                    catch {$master2 SET key$i val$i}
+                }
+        
+                assert {[$master1 DBSIZE] > 0}
+                assert {[$master2 DBSIZE] > 0}
+                if {$op eq ""} {
+                    assert_match "{0 8191}" [ $master1 SFLUSH 0 8191]
+                } else {
+                    assert_match "{0 8191}" [ $master1 SFLUSH 0 8191 $op]
+                }
+                assert {[$master1 DBSIZE] == 0}
+                assert {[$master2 DBSIZE] > 0}
+                assert_match "{8192 16383}" [ $master2 SFLUSH 8192 16383]
+                assert {[$master2 DBSIZE] == 0}
+            }
+        }
+    }
 }

--- a/utils/generate-command-code.py
+++ b/utils/generate-command-code.py
@@ -518,7 +518,8 @@ class Subcommand(Command):
 
 def create_command(name, desc):
     flags = desc.get("command_flags")
-    if flags and "EXPERIMENTAL" in flags:
+    
+    if (not args.with_experimental_cmds) and (flags and "EXPERIMENTAL" in flags):
         print("Command %s is experimental, skipping..." % name)
         return
 
@@ -537,6 +538,7 @@ srcdir = os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/../src")
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--with-reply-schema', action='store_true')
+parser.add_argument('--with-experimental-cmds', action='store_true')
 args = parser.parse_args()
 
 # Create all command objects


### PR DESCRIPTION
Following #13600, `SFLUSH` command was marked as `EXPERIMENTAL`. Its tests were also leftout 
from CI. To bring them back to CI, added another optional flag to `REDIS_CFLAGS`, named 
`EXPERIMENTAL_CMDS` that allows to compile redis with experimental commands as well. Usage:
```
make REDIS_CFLAGS='-Werror -DEXPERIMENTAL_CMDS'
```
(Since the test-tags in `runtest` might be cumbersome around `experimental`, As an 
alternative the test queries the server with dummy SFLUSH and resolves whether it support).