### PR TITLE
Gradually reduce defrag CPU usage when defragmentation is ineffective

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1164,7 +1164,7 @@ void activeDefragCycle(void) {
 
                 /* If the last defragmented bytes in the last cycle is less than 1%, gradually
                  * reduce the decay rate by 10% for the next cycle to avoid excessive CPU usage. */
-                if (start_frag_bytes - frag_bytes && 
+                if (start_frag_bytes >= frag_bytes &&
                     (float)(start_frag_bytes - frag_bytes) / (start_frag_bytes + 1) < 0.01)
                 {
                     decay_rate *= 0.9;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1168,8 +1168,8 @@ void activeDefragCycle(void) {
                 /* When defragmentation efficiency is low, we gradually reduce the
                  * speed for the next cycle to avoid CPU waste. However, in the
                  * following two cases, we keep the normal speed:
-                 * 1) If the fragmentation rate has decreased and defragmentation hits are above 1%.
-                 * 2) If the fragmented percentage have increased by 5%. */
+                 * 1) If the fragmentation percentage has decreased and defragmentation hits are above 1%.
+                 * 2) If the fragmentation percentage have increased by 5%. */
                 if ((last_frag_pct_change < 0 && last_hits >= (last_hits + last_misses) * 0.01) ||
                     last_frag_pct_change > 0.05)
                 {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1070,6 +1070,7 @@ void activeDefragCycle(void) {
     static unsigned long defrag_cursor = 0;
     static redisDb *db = NULL;
     static long long start_scan, start_hits, start_misses;
+    static size_t start_frag_bytes;
     static float decay_rate = 1.0f;
     unsigned int iterations = 0;
     unsigned long long prev_defragged = server.stat_active_defrag_hits;
@@ -1161,14 +1162,19 @@ void activeDefragCycle(void) {
                 db = NULL;
                 server.active_defrag_running = 0;
 
-                /* If the last defragmented hits in the last cycle is less than 1%, gradually
-                 * reduce the decay rate by 10% for the next cycle to avoid excessive CPU usage. */
+                /* If the defragmentation hits and defragmented bytes are both
+                 * below 1%, which indicates low defragmentation efficiency.
+                 * Reduce the defragmentation speed by 10% for the next cycle. */
                 long long last_hits = server.stat_active_defrag_hits - start_hits;
                 long long last_misses = server.stat_active_defrag_misses - start_misses;
-                if ((float)(last_hits) / (last_hits + last_misses + 1) < 0.01)
+                if (last_hits < (last_hits + last_misses) * 0.01 &&
+                    start_frag_bytes >= frag_bytes &&
+                    (start_frag_bytes - frag_bytes) < start_frag_bytes * 0.01)
+                {
                     decay_rate *= 0.9;
-                else
+                } else {
                     decay_rate = 1.0f;
+                }
 
                 moduleDefragEnd();
 
@@ -1182,6 +1188,7 @@ void activeDefragCycle(void) {
                 start_scan = ustime();
                 start_hits = server.stat_active_defrag_hits;
                 start_misses = server.stat_active_defrag_misses;
+                getAllocatorFragmentation(&start_frag_bytes);
             }
 
             db = &server.db[current_db];

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1193,7 +1193,7 @@ void activeDefragCycle(void) {
             defrag_cursor = 0;
             slot = -1;
             defrag_later_item_in_progress = 0;
-            }
+        }
 
         /* This array of structures holds the parameters for all defragmentation stages. */
         typedef struct defragStage {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1024,7 +1024,7 @@ int defragLaterStep(redisDb *db, int slot, long long endtime) {
 #define LIMIT(y, min, max) ((y)<(min)? min: ((y)>(max)? max: (y)))
 
 /* decide if defrag is needed, and at what CPU effort to invest in it */
-void computeDefragCycles(void) {
+void computeDefragCycles(float decay_rate) {
     size_t frag_bytes;
     float frag_pct = getAllocatorFragmentation(&frag_bytes);
     /* If we're not already running, and below the threshold, exit. */
@@ -1040,6 +1040,7 @@ void computeDefragCycles(void) {
             server.active_defrag_threshold_upper,
             server.active_defrag_cycle_min,
             server.active_defrag_cycle_max);
+    cpu_pct *= decay_rate;
     cpu_pct = LIMIT(cpu_pct,
             server.active_defrag_cycle_min,
             server.active_defrag_cycle_max);
@@ -1069,6 +1070,8 @@ void activeDefragCycle(void) {
     static unsigned long defrag_cursor = 0;
     static redisDb *db = NULL;
     static long long start_scan, start_stat;
+    static size_t start_frag_bytes = 0;
+    static float decay_rate = 1.0f;
     unsigned int iterations = 0;
     unsigned long long prev_defragged = server.stat_active_defrag_hits;
     unsigned long long prev_scanned = server.stat_active_defrag_scanned;
@@ -1104,13 +1107,13 @@ void activeDefragCycle(void) {
     /* Once a second, check if the fragmentation justfies starting a scan
      * or making it more aggressive. */
     run_with_period(1000) {
-        computeDefragCycles();
+        computeDefragCycles(decay_rate);
     }
 
     /* Normally it is checked once a second, but when there is a configuration
      * change, we want to check it as soon as possible. */
     if (server.active_defrag_configuration_changed) {
-        computeDefragCycles();
+        computeDefragCycles(decay_rate);
         server.active_defrag_configuration_changed = 0;
     }
 
@@ -1159,9 +1162,20 @@ void activeDefragCycle(void) {
                 db = NULL;
                 server.active_defrag_running = 0;
 
+                /* If the last defragmented bytes in the last cycle is less than 1%, gradually
+                 * reduce the decay rate by 10% for the next cycle to avoid excessive CPU usage. */
+                if (start_frag_bytes - frag_bytes && 
+                    (float)(start_frag_bytes - frag_bytes) / (start_frag_bytes + 1) < 0.01)
+                {
+                    decay_rate *= 0.9;
+                } else {
+                    decay_rate = 1.0f;
+                }
+                start_frag_bytes = frag_bytes;
+
                 moduleDefragEnd();
 
-                computeDefragCycles(); /* if another scan is needed, start it right away */
+                computeDefragCycles(decay_rate); /* if another scan is needed, start it right away */
                 if (server.active_defrag_running != 0 && ustime() < endtime)
                     continue;
                 break;
@@ -1179,7 +1193,7 @@ void activeDefragCycle(void) {
             defrag_cursor = 0;
             slot = -1;
             defrag_later_item_in_progress = 0;
-        }
+            }
 
         /* This array of structures holds the parameters for all defragmentation stages. */
         typedef struct defragStage {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1171,7 +1171,7 @@ void activeDefragCycle(void) {
                  * 1) If the fragmentation percentage has decreased and defragmentation hits are above 1%.
                  * 2) If the fragmentation percentage have increased by 5%. */
                 if ((last_frag_pct_change < 0 && last_hits >= (last_hits + last_misses) * 0.01) ||
-                    last_frag_pct_change > 0.05)
+                    (last_frag_pct_change > 0 && last_frag_pct_change > 0.05))
                 {
                     decay_rate = 1.0f;
                 } else {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1069,8 +1069,7 @@ void activeDefragCycle(void) {
     static int defrag_stage = 0;
     static unsigned long defrag_cursor = 0;
     static redisDb *db = NULL;
-    static long long start_scan, start_stat;
-    static size_t start_frag_bytes = 0;
+    static long long start_scan, start_hits, start_misses;
     static float decay_rate = 1.0f;
     unsigned int iterations = 0;
     unsigned long long prev_defragged = server.stat_active_defrag_hits;
@@ -1151,7 +1150,7 @@ void activeDefragCycle(void) {
                 float frag_pct = getAllocatorFragmentation(&frag_bytes);
                 serverLog(LL_VERBOSE,
                     "Active defrag done in %dms, reallocated=%d, frag=%.0f%%, frag_bytes=%zu",
-                    (int)((now - start_scan)/1000), (int)(server.stat_active_defrag_hits - start_stat), frag_pct, frag_bytes);
+                    (int)((now - start_scan)/1000), (int)(server.stat_active_defrag_hits - start_hits), frag_pct, frag_bytes);
 
                 start_scan = now;
                 current_db = -1;
@@ -1162,16 +1161,14 @@ void activeDefragCycle(void) {
                 db = NULL;
                 server.active_defrag_running = 0;
 
-                /* If the last defragmented bytes in the last cycle is less than 1%, gradually
+                /* If the last defragmented hits in the last cycle is less than 1%, gradually
                  * reduce the decay rate by 10% for the next cycle to avoid excessive CPU usage. */
-                if (start_frag_bytes >= frag_bytes &&
-                    (float)(start_frag_bytes - frag_bytes) / (start_frag_bytes + 1) < 0.01)
-                {
+                long long last_hits = server.stat_active_defrag_hits - start_hits;
+                long long last_misses = server.stat_active_defrag_misses - start_misses;
+                if ((float)(last_hits) / (last_hits + last_misses + 1) < 0.01)
                     decay_rate *= 0.9;
-                } else {
+                else
                     decay_rate = 1.0f;
-                }
-                start_frag_bytes = frag_bytes;
 
                 moduleDefragEnd();
 
@@ -1183,7 +1180,8 @@ void activeDefragCycle(void) {
             else if (current_db==0) {
                 /* Start a scan from the first database. */
                 start_scan = ustime();
-                start_stat = server.stat_active_defrag_hits;
+                start_hits = server.stat_active_defrag_hits;
+                start_misses = server.stat_active_defrag_misses;
             }
 
             db = &server.db[current_db];

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1070,7 +1070,7 @@ void activeDefragCycle(void) {
     static unsigned long defrag_cursor = 0;
     static redisDb *db = NULL;
     static long long start_scan, start_hits, start_misses;
-    static size_t start_frag_bytes;
+    static float start_frag_pct;
     static float decay_rate = 1.0f;
     unsigned int iterations = 0;
     unsigned long long prev_defragged = server.stat_active_defrag_hits;
@@ -1162,18 +1162,20 @@ void activeDefragCycle(void) {
                 db = NULL;
                 server.active_defrag_running = 0;
 
-                /* If the defragmentation hits and defragmented bytes are both
-                 * below 1%, which indicates low defragmentation efficiency.
-                 * Reduce the defragmentation speed by 10% for the next cycle. */
                 long long last_hits = server.stat_active_defrag_hits - start_hits;
                 long long last_misses = server.stat_active_defrag_misses - start_misses;
-                if (last_hits < (last_hits + last_misses) * 0.01 &&
-                    start_frag_bytes >= frag_bytes &&
-                    (start_frag_bytes - frag_bytes) < start_frag_bytes * 0.01)
+                float last_frag_pct_change = start_frag_pct - frag_pct;
+                /* When defragmentation efficiency is low, we gradually reduce the
+                 * speed for the next cycle to avoid CPU waste. However, in the
+                 * following two cases, we keep the normal speed:
+                 * 1) If the fragmentation rate has decreased and defragmentation hits are above 1%.
+                 * 2) If the fragmented percentage have increased by 5%. */
+                if ((last_frag_pct_change < 0 && last_hits >= (last_hits + last_misses) * 0.01) ||
+                    last_frag_pct_change > 0.05)
                 {
-                    decay_rate *= 0.9;
-                } else {
                     decay_rate = 1.0f;
+                } else {
+                    decay_rate *= 0.9;
                 }
 
                 moduleDefragEnd();
@@ -1188,7 +1190,7 @@ void activeDefragCycle(void) {
                 start_scan = ustime();
                 start_hits = server.stat_active_defrag_hits;
                 start_misses = server.stat_active_defrag_misses;
-                getAllocatorFragmentation(&start_frag_bytes);
+                start_frag_pct = getAllocatorFragmentation(NULL);
             }
 
             db = &server.db[current_db];

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -14,6 +14,7 @@
 
 #include "server.h"
 #include <stddef.h>
+#include <math.h>
 
 #ifdef HAVE_DEFRAG
 
@@ -1168,10 +1169,11 @@ void activeDefragCycle(void) {
                 /* When defragmentation efficiency is low, we gradually reduce the
                  * speed for the next cycle to avoid CPU waste. However, in the
                  * following two cases, we keep the normal speed:
-                 * 1) If the fragmentation percentage has decreased and defragmentation hits are above 1%.
-                 * 2) If the fragmentation percentage have increased by 5%. */
-                if ((last_frag_pct_change < 0 && last_hits >= (last_hits + last_misses) * 0.01) ||
-                    (last_frag_pct_change > 0 && last_frag_pct_change > 0.05))
+                 * 1) If the fragmentation percentage has increased or decreased by more than 2%.
+                 * 2) If the fragmentation percentage decrease is small, but hits are above 1%,
+                 *    we still keep the normal speed. */
+                if (fabs(last_frag_pct_change) > 2 ||
+                    (last_frag_pct_change < 0 && last_hits >= (last_hits + last_misses) * 0.01))
                 {
                     decay_rate = 1.0f;
                 } else {

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -143,7 +143,7 @@ start_server {tags {"modules"}} {
             r config set hz 100
             r config set activedefrag no
             r config set active-defrag-threshold-lower 5
-            r config set active-defrag-cycle-min 1
+            r config set active-defrag-cycle-min 5
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 100kb
 
@@ -184,7 +184,7 @@ start_server {tags {"modules"}} {
 
                 assert_morethan [s allocator_frag_ratio] 1.4
                 # The cpu usage of defragment will drop to active-defrag-cycle-min
-                wait_for_log_messages 0 {"*Starting active defrag*cpu=1%*"} 0 10 1000
+                wait_for_log_messages 0 {"*Starting active defrag*cpu=5%*"} 0 10 1000
             }
         }
     }

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -193,9 +193,7 @@ start_server {tags {"modules"}} {
                 set end_time [expr {[clock seconds] + 10}]
                 set speed_restored 0
                 while {[clock seconds] < $end_time} {
-                    set action [expr {int(rand() * 3)}]
-
-                    switch $action {
+                    switch [expr {int(rand() * 3)}] {
                         0 {
                             # Randomly delete a key
                             set random_key [r RANDOMKEY]
@@ -207,14 +205,12 @@ start_server {tags {"modules"}} {
                             # Randomly overwrite a key
                             set random_key [r RANDOMKEY]
                             if {$random_key != ""} {
-                                set dummy "[string repeat x 400]"
                                 r datatype.set $random_key 1 $dummy
                             }
                         }
                         2 {
                             # Randomly generate a new key
                             set random_key "key_[expr {int(rand() * 10000)}]"
-                            set dummy "[string repeat x 400]"
                             r datatype.set $random_key 1 $dummy
                         }
                     }

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -143,7 +143,7 @@ start_server {tags {"modules"}} {
             r config set hz 100
             r config set activedefrag no
             r config set active-defrag-threshold-lower 5
-            r config set active-defrag-cycle-min 5
+            r config set active-defrag-cycle-min 25
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 100kb
 
@@ -181,28 +181,59 @@ start_server {tags {"modules"}} {
                     puts [r memory malloc-stats]
                     fail "defrag not started."
                 }
-
                 assert_morethan [s allocator_frag_ratio] 1.4
+
                 # The cpu usage of defragment will drop to active-defrag-cycle-min
                 wait_for_condition 1000 50 {
-                    [s active_defrag_running] == 5
+                    [s active_defrag_running] == 25
                 } else {
                     fail "Unable to reduce the defragmentation speed."
                 }
 
-                # Create some small traffic to verify it does not restore defragmentation speed
-                for {set i 0} {$i < 100} {incr i} { 
-                    r set k dummy
-                    r del k
-                }
-                assert_equal [s active_defrag_running] 5
+                # Fuzzy test to restore defragmentation speed to normal
+                set end_time [expr {[clock seconds] + 10}]
+                set speed_restored 0
+                while {[clock seconds] < $end_time} {
+                    set action [expr {int(rand() * 3)}]
 
-                # Create additional fragments to verify defragmentation speed will restore
-                set loglines [count_log_lines 0]
-                for {set i 20001} {$i < $n} {incr i 2} { $rd del k$i }
-                for {set j 20001} {$j < $n} {incr j 2} { $rd read } ; # Discard del replies
-                wait_for_log_messages 0 {"*Starting active defrag*cpu=10%*"} $loglines 10 1000
-                $rd close
+                    switch $action {
+                        0 {
+                            # Randomly delete a key
+                            set random_key [r RANDOMKEY]
+                            if {$random_key != ""} {
+                                r DEL $random_key
+                            }
+                        }
+                        1 {
+                            # Randomly overwrite a key
+                            set random_key [r RANDOMKEY]
+                            if {$random_key != ""} {
+                                set dummy "[string repeat x 400]"
+                                r datatype.set $random_key 1 $dummy
+                            }
+                        }
+                        2 {
+                            # Randomly generate a new key
+                            set random_key "key_[expr {int(rand() * 10000)}]"
+                            set dummy "[string repeat x 400]"
+                            r datatype.set $random_key 1 $dummy
+                        }
+                    }
+
+                    # Wait for defragmentation speed to restore.
+                    if {[s active_defrag_running] > 25} {
+                        set speed_restored 1
+                        break;
+                    }
+                }
+                assert_equal $speed_restored 1
+
+                # After the traffic disappears, the defragmentation speed will decrease again.
+                wait_for_condition 1000 50 {
+                    [s active_defrag_running] == 25
+                } else {
+                    fail "Unable to reduce the defragmentation speed."
+                } 
             }
         }
     }

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -147,8 +147,9 @@ start_server {tags {"modules"}} {
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 100kb
 
-            # Populate memory with interleaving hash field of same size
-            set n 20000
+            # Populate memory with interleaving field of same size, keeping the last 1000 to verify
+            # later that increasing fragmentation can restore defragmentation speed.
+            set n 21000
             set dummy "[string repeat x 400]"
             set rd [redis_deferring_client]
             for {set i 0} {$i < $n} {incr i} { $rd datatype.set k$i 1 $dummy }
@@ -163,9 +164,8 @@ start_server {tags {"modules"}} {
             }
             assert_lessthan [s allocator_frag_ratio] 1.05
 
-            for {set i 0} {$i < $n} {incr i 2} { $rd del k$i }
-            for {set j 0} {$j < $n} {incr j 2} { $rd read } ; # Discard del replies
-            $rd close
+            for {set i 0} {$i < 20000} {incr i 2} { $rd del k$i }
+            for {set j 0} {$j < 20000} {incr j 2} { $rd read } ; # Discard del replies
             after 120 ;# serverCron only updates the info once in 100ms
             assert_morethan [s allocator_frag_ratio] 1.4
 
@@ -189,6 +189,20 @@ start_server {tags {"modules"}} {
                 } else {
                     fail "Unable to reduce the defragmentation speed."
                 }
+
+                # Create some small traffic to verify it does not restore defragmentation speed
+                for {set i 0} {$i < 100} {incr i} { 
+                    r set k dummy
+                    r del k
+                }
+                assert_equal [s active_defrag_running] 5
+
+                # Create additional fragments to verify defragmentation speed will restore
+                set loglines [count_log_lines 0]
+                for {set i 20001} {$i < $n} {incr i 2} { $rd del k$i }
+                for {set j 20001} {$j < $n} {incr j 2} { $rd read } ; # Discard del replies
+                wait_for_log_messages 0 {"*Starting active defrag*cpu=10%*"} $loglines 10 1000
+                $rd close
             }
         }
     }

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -137,53 +137,55 @@ start_server {tags {"modules"}} {
         assert_equal 1 [llength $keys]
     }
 
-    test {Reduce defrag CPU usage when module data can't be defragged} {
-        r flushdb
-        r config set hz 100
-        r config set activedefrag no
-        r config set active-defrag-threshold-lower 5
-        r config set active-defrag-cycle-min 1
-        r config set active-defrag-cycle-max 75
-        r config set active-defrag-ignore-bytes 100kb
+    if {[string match {*jemalloc*} [s mem_allocator]] && [r debug mallctl arenas.page] <= 8192} {
+        test {Reduce defrag CPU usage when module data can't be defragged} {
+            r flushdb
+            r config set hz 100
+            r config set activedefrag no
+            r config set active-defrag-threshold-lower 5
+            r config set active-defrag-cycle-min 1
+            r config set active-defrag-cycle-max 75
+            r config set active-defrag-ignore-bytes 100kb
 
-        # Populate memory with interleaving hash field of same size
-        set n 10000
-        set dummy "[string repeat x 400]"
-        set rd [redis_deferring_client]
-        for {set i 0} {$i < $n} {incr i} { $rd datatype.set k$i 1 $dummy }
-        for {set i 0} {$i < [expr $n]} {incr i} { $rd read } ;# Discard replies
+            # Populate memory with interleaving hash field of same size
+            set n 10000
+            set dummy "[string repeat x 400]"
+            set rd [redis_deferring_client]
+            for {set i 0} {$i < $n} {incr i} { $rd datatype.set k$i 1 $dummy }
+            for {set i 0} {$i < [expr $n]} {incr i} { $rd read } ;# Discard replies
 
-        after 120 ;# serverCron only updates the info once in 100ms
-        if {$::verbose} {
-            puts "used [s allocator_allocated]"
-            puts "rss [s allocator_active]"
-            puts "frag [s allocator_frag_ratio]"
-            puts "frag_bytes [s allocator_frag_bytes]"
-        }
-        assert_lessthan [s allocator_frag_ratio] 1.05
-
-        for {set i 0} {$i < $n} {incr i 2} { $rd del k$i }
-        for {set j 0} {$j < $n} {incr j 2} { $rd read } ; # Discard del replies
-        $rd close
-        after 120 ;# serverCron only updates the info once in 100ms
-        assert_morethan [s allocator_frag_ratio] 1.4
-
-        catch {r config set activedefrag yes} e
-        if {[r config get activedefrag] eq "activedefrag yes"} {
-            # wait for the active defrag to start working (decision once a second)
-            wait_for_condition 50 100 {
-                [s total_active_defrag_time] ne 0
-            } else {
-                after 120 ;# serverCron only updates the info once in 100ms
-                puts [r info memory]
-                puts [r info stats]
-                puts [r memory malloc-stats]
-                fail "defrag not started."
+            after 120 ;# serverCron only updates the info once in 100ms
+            if {$::verbose} {
+                puts "used [s allocator_allocated]"
+                puts "rss [s allocator_active]"
+                puts "frag [s allocator_frag_ratio]"
+                puts "frag_bytes [s allocator_frag_bytes]"
             }
+            assert_lessthan [s allocator_frag_ratio] 1.05
 
-            assert_not_equal [s total_active_defrag_time] 0
+            for {set i 0} {$i < $n} {incr i 2} { $rd del k$i }
+            for {set j 0} {$j < $n} {incr j 2} { $rd read } ; # Discard del replies
+            $rd close
+            after 120 ;# serverCron only updates the info once in 100ms
             assert_morethan [s allocator_frag_ratio] 1.4
-            wait_for_log_messages 0 {"*Starting active defrag*cpu=1%*"} 0 10 1000
+
+            catch {r config set activedefrag yes} e
+            if {[r config get activedefrag] eq "activedefrag yes"} {
+                # wait for the active defrag to start working (decision once a second)
+                wait_for_condition 50 100 {
+                    [s total_active_defrag_time] ne 0
+                } else {
+                    after 120 ;# serverCron only updates the info once in 100ms
+                    puts [r info memory]
+                    puts [r info stats]
+                    puts [r memory malloc-stats]
+                    fail "defrag not started."
+                }
+
+                assert_not_equal [s total_active_defrag_time] 0
+                assert_morethan [s allocator_frag_ratio] 1.4
+                wait_for_log_messages 0 {"*Starting active defrag*cpu=1%*"} 0 10 1000
+            }
         }
     }
 }

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -136,4 +136,54 @@ start_server {tags {"modules"}} {
 
         assert_equal 1 [llength $keys]
     }
+
+    test {Reduce defrag CPU usage when module data can't be defragged} {
+        r flushdb
+        r config set hz 100
+        r config set activedefrag no
+        r config set active-defrag-threshold-lower 5
+        r config set active-defrag-cycle-min 1
+        r config set active-defrag-cycle-max 75
+        r config set active-defrag-ignore-bytes 100kb
+
+        # Populate memory with interleaving hash field of same size
+        set n 10000
+        set dummy "[string repeat x 400]"
+        set rd [redis_deferring_client]
+        for {set i 0} {$i < $n} {incr i} { $rd datatype.set k$i 1 $dummy }
+        for {set i 0} {$i < [expr $n]} {incr i} { $rd read } ;# Discard replies
+
+        after 120 ;# serverCron only updates the info once in 100ms
+        if {$::verbose} {
+            puts "used [s allocator_allocated]"
+            puts "rss [s allocator_active]"
+            puts "frag [s allocator_frag_ratio]"
+            puts "frag_bytes [s allocator_frag_bytes]"
+        }
+        assert_lessthan [s allocator_frag_ratio] 1.05
+
+        for {set i 0} {$i < $n} {incr i 2} { $rd del k$i }
+        for {set j 0} {$j < $n} {incr j 2} { $rd read } ; # Discard del replies
+        $rd close
+        after 120 ;# serverCron only updates the info once in 100ms
+        assert_morethan [s allocator_frag_ratio] 1.4
+
+        catch {r config set activedefrag yes} e
+        if {[r config get activedefrag] eq "activedefrag yes"} {
+            # wait for the active defrag to start working (decision once a second)
+            wait_for_condition 50 100 {
+                [s total_active_defrag_time] ne 0
+            } else {
+                after 120 ;# serverCron only updates the info once in 100ms
+                puts [r info memory]
+                puts [r info stats]
+                puts [r memory malloc-stats]
+                fail "defrag not started."
+            }
+
+            assert_not_equal [s total_active_defrag_time] 0
+            assert_morethan [s allocator_frag_ratio] 1.4
+            wait_for_log_messages 0 {"*Starting active defrag*cpu=1%*"} 0 10 1000
+        }
+    }
 }

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -184,7 +184,11 @@ start_server {tags {"modules"}} {
 
                 assert_morethan [s allocator_frag_ratio] 1.4
                 # The cpu usage of defragment will drop to active-defrag-cycle-min
-                wait_for_log_messages 0 {"*Starting active defrag*cpu=5%*"} 0 10 1000
+                wait_for_condition 1000 50 {
+                    [s active_defrag_running] == 5
+                } else {
+                    fail "Unable to reduce the defragmentation speed."
+                }
             }
         }
     }

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -147,9 +147,8 @@ start_server {tags {"modules"}} {
             r config set active-defrag-cycle-max 75
             r config set active-defrag-ignore-bytes 100kb
 
-            # Populate memory with interleaving field of same size, keeping the last 1000 to verify
-            # later that increasing fragmentation can restore defragmentation speed.
-            set n 21000
+            # Populate memory with interleaving field of same size.
+            set n 20000
             set dummy "[string repeat x 400]"
             set rd [redis_deferring_client]
             for {set i 0} {$i < $n} {incr i} { $rd datatype.set k$i 1 $dummy }
@@ -164,8 +163,8 @@ start_server {tags {"modules"}} {
             }
             assert_lessthan [s allocator_frag_ratio] 1.05
 
-            for {set i 0} {$i < 20000} {incr i 2} { $rd del k$i }
-            for {set j 0} {$j < 20000} {incr j 2} { $rd read } ; # Discard del replies
+            for {set i 0} {$i < $n} {incr i 2} { $rd del k$i }
+            for {set j 0} {$j < $n} {incr j 2} { $rd read } ; # Discard del replies
             after 120 ;# serverCron only updates the info once in 100ms
             assert_morethan [s allocator_frag_ratio] 1.4
 

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -227,7 +227,7 @@ start_server {tags {"modules"}} {
                 wait_for_condition 1000 50 {
                     [s active_defrag_running] == 25
                 } else {
-                    fail "Unable to reduce the defragmentation speed."
+                    fail "Unable to reduce the defragmentation speed after traffic disappears."
                 } 
             }
         }

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -148,7 +148,7 @@ start_server {tags {"modules"}} {
             r config set active-defrag-ignore-bytes 100kb
 
             # Populate memory with interleaving hash field of same size
-            set n 10000
+            set n 20000
             set dummy "[string repeat x 400]"
             set rd [redis_deferring_client]
             for {set i 0} {$i < $n} {incr i} { $rd datatype.set k$i 1 $dummy }
@@ -182,8 +182,8 @@ start_server {tags {"modules"}} {
                     fail "defrag not started."
                 }
 
-                assert_not_equal [s total_active_defrag_time] 0
                 assert_morethan [s allocator_frag_ratio] 1.4
+                # The cpu usage of defragment will drop to active-defrag-cycle-min
                 wait_for_log_messages 0 {"*Starting active defrag*cpu=1%*"} 0 10 1000
             }
         }


### PR DESCRIPTION
This PR addresses an issue where if a module does not provide a defragmentation callback, we cannot defragment the fragmentation it generates. However, the defragmentation process still considers a large amount of fragmentation to be present, leading to more aggressive defragmentation efforts that ultimately have no effect.

To mitigate this, the PR introduces a mechanism to gradually reduce the CPU consumption for defragmentation when the defragmentation effectiveness is poor. This occurs when the fragmentation rate drops below 2% and the hit ratio is less than 1%, or when the fragmentation rate increases by no more than 2%. The CPU consumption will be gradually decreased until it reaches the minimum threshold defined by `active-defrag-cycle-min`.