### PR TITLE
Added a shared secret over Redis cluster.

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -131,6 +131,7 @@ char *clusterNodeHostname(clusterNode *node);
 const char *clusterNodePreferredEndpoint(clusterNode *n);
 long long clusterNodeReplOffset(clusterNode *node);
 clusterNode *clusterLookupNode(const char *name, int length);
+const char *clusterGetSecret(size_t *len);
 
 /* functions with shared implementations */
 clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, int argc, int *hashslot, uint64_t cmd_flags, int *error_code);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1622,6 +1622,9 @@ clusterNode *clusterLookupNode(const char *name, int length) {
 
 const char *clusterGetSecret(size_t *len) {
     const char *min_secret = NULL;
+    if (!server.cluster) {
+        return NULL;
+    }
     dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
     dictEntry *de = NULL;
     while((de = dictNext(di)) != NULL) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -90,10 +90,15 @@ int auxTcpPortPresent(clusterNode *n);
 int auxTlsPortSetter(clusterNode *n, void *value, int length);
 sds auxTlsPortGetter(clusterNode *n, sds s);
 int auxTlsPortPresent(clusterNode *n);
+int auxInternalSecretSetter(clusterNode *n, void *value, int length);
+sds auxInternalSecretGetter(clusterNode *n, sds s);
+int auxInternalSecretPresent(clusterNode *n);
 static void clusterBuildMessageHdr(clusterMsg *hdr, int type, size_t msglen);
 void freeClusterLink(clusterLink *link);
 int verifyClusterNodeId(const char *name, int length);
 static void updateShardId(clusterNode *node, const char *shard_id);
+static void setInternalSecret(clusterNode *node, char *internal_secret);
+static void generateRandomSecret(clusterNode *node);
 
 int getNodeDefaultClientPort(clusterNode *n) {
     return server.tls_cluster ? n->tls_port : n->tcp_port;
@@ -185,6 +190,7 @@ typedef enum {
     af_human_nodename,
     af_tcp_port,
     af_tls_port,
+    af_internal_secret,
     af_count,
 } auxFieldIndex;
 
@@ -197,6 +203,7 @@ auxFieldHandler auxFieldHandlers[] = {
     {"nodename", auxHumanNodenameSetter, auxHumanNodenameGetter, auxHumanNodenamePresent},
     {"tcp-port", auxTcpPortSetter, auxTcpPortGetter, auxTcpPortPresent},
     {"tls-port", auxTlsPortSetter, auxTlsPortGetter, auxTlsPortPresent},
+    {"internal-secret", auxInternalSecretSetter, auxInternalSecretGetter, auxInternalSecretPresent},
 };
 
 int auxShardIdSetter(clusterNode *n, void *value, int length) {
@@ -282,6 +289,22 @@ sds auxTlsPortGetter(clusterNode *n, sds s) {
 
 int auxTlsPortPresent(clusterNode *n) {
     return n->tls_port >= 0 && n->tls_port < 65536;
+}
+
+int auxInternalSecretSetter(clusterNode *n, void *value, int length) {
+    if (length != CLUSTER_INTERNALSECRETLEN) {
+        return C_ERR;
+    }
+    setInternalSecret(n, (char*)value);
+    return C_OK;
+}
+
+sds auxInternalSecretGetter(clusterNode *n, sds s) {
+    return sdscatprintf(s, "%s", n->internal_secret);
+}
+
+int auxInternalSecretPresent(clusterNode *n) {
+    return n->internal_secret[0] != '\0';
 }
 
 /* clusterLink send queue blocks */
@@ -514,6 +537,9 @@ int clusterLoadConfig(char *filename) {
                 serverAssert(server.cluster->myself == NULL);
                 myself = server.cluster->myself = n;
                 n->flags |= CLUSTER_NODE_MYSELF;
+                if (n->internal_secret[0] == '\0') {
+                    generateRandomSecret(n);
+                }
             } else if (!strcasecmp(s,"master")) {
                 n->flags |= CLUSTER_NODE_MASTER;
             } else if (!strcasecmp(s,"slave")) {
@@ -1302,6 +1328,16 @@ unsigned long getClusterConnectionsCount(void) {
            ((dictSize(server.cluster->nodes)-1)*2) : 0;
 }
 
+static void generateRandomSecret(clusterNode *node) {
+    getRandomHexChars(node->internal_secret, CLUSTER_INTERNALSECRETLEN);
+    node->internal_secret[CLUSTER_INTERNALSECRETLEN] = '\0';
+}
+
+static void setInternalSecret(clusterNode *node, char *internal_secret) {
+    memcpy(node->internal_secret, internal_secret, CLUSTER_INTERNALSECRETLEN);
+    node->internal_secret[CLUSTER_INTERNALSECRETLEN] = '\0';
+}
+
 /* -----------------------------------------------------------------------------
  * CLUSTER node API
  * -------------------------------------------------------------------------- */
@@ -1321,6 +1357,11 @@ clusterNode *createClusterNode(char *nodename, int flags) {
     else
         getRandomHexChars(node->name, CLUSTER_NAMELEN);
     getRandomHexChars(node->shard_id, CLUSTER_NAMELEN);
+    if (flags & CLUSTER_NODE_MYSELF) {
+        generateRandomSecret(node);
+    } else {
+        memset(node->internal_secret, 0, CLUSTER_INTERNALSECRETLEN + 1);
+    }
     node->ctime = mstime();
     node->configEpoch = 0;
     node->flags = flags;
@@ -1577,6 +1618,32 @@ clusterNode *clusterLookupNode(const char *name, int length) {
     sdsfree(s);
     if (de == NULL) return NULL;
     return dictGetVal(de);
+}
+
+const char *clusterGetSecret(size_t *len) {
+    const char *min_secret = NULL;
+    dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
+    dictEntry *de = NULL;
+    while((de = dictNext(di)) != NULL) {
+        clusterNode *node = dictGetVal(de);
+
+        if (node->internal_secret[0] == '\0') {
+            continue;
+        }
+        if (!min_secret) {
+            min_secret = node->internal_secret;
+        } else {
+            if (memcmp(node->internal_secret, min_secret, CLUSTER_INTERNALSECRETLEN) > 0) {
+                min_secret = node->internal_secret;
+            }
+        }
+    }
+    dictReleaseIterator(di);
+
+    if (min_secret) {
+        *len = CLUSTER_INTERNALSECRETLEN;
+    }
+    return min_secret;
 }
 
 /* Get all the nodes in my shard.
@@ -2503,6 +2570,14 @@ uint32_t getShardIdPingExtSize(void) {
     return getAlignedPingExtSize(sizeof(clusterMsgPingExtShardId));
 }
 
+uint32_t getInternalSecretPingExtSize(void) {
+    return getAlignedPingExtSize(sizeof(clusterMsgPingExtInternalSecret));
+}
+
+uint32_t getGossipInternalSecretPingExtSize(void) {
+    return getAlignedPingExtSize(sizeof(clusterMsgPingExtGossipInternalSecret));
+}
+
 uint32_t getForgottenNodeExtSize(void) {
     return getAlignedPingExtSize(sizeof(clusterMsgPingExtForgottenNode));
 }
@@ -2594,6 +2669,36 @@ uint32_t writePingExt(clusterMsg *hdr, int gossipcount)  {
     totlen += getShardIdPingExtSize();
     extensions++;
 
+    /* Populate insternal secret */
+    if (cursor != NULL) {
+        clusterMsgPingExtInternalSecret *ext = preparePingExt(cursor, CLUSTERMSG_EXT_TYPE_INTERNALSECRET, getInternalSecretPingExtSize());
+        memcpy(ext->internal_secret, myself->internal_secret, CLUSTER_INTERNALSECRETLEN);
+
+        /* Move the write cursor */
+        cursor = nextPingExt(cursor);
+    }
+    totlen += getInternalSecretPingExtSize();
+    extensions++;
+
+    for (int i = 0 ; i < gossipcount ; ++i) {
+        /* Write internal secrets of the nodes we know about */
+        if (cursor != NULL) {
+            clusterMsgDataGossip *g_msg = hdr->data.ping.gossip + i;
+            clusterNode *n = clusterLookupNode(g_msg->nodename, CLUSTER_NAMELEN);
+            if (n->internal_secret[0] == '\0') {
+                continue;
+            }
+            clusterMsgPingExtGossipInternalSecret *ext = preparePingExt(cursor, CLUSTERMSG_EXT_TYPE_GOSSIPINTERNALSECRET, getGossipInternalSecretPingExtSize());
+            memcpy(ext->name, n->name, CLUSTER_NAMELEN);
+            memcpy(ext->internal_secret, n->internal_secret, CLUSTER_INTERNALSECRETLEN);
+
+            /* Move the write cursor */
+            cursor = nextPingExt(cursor);
+        }
+        totlen += getGossipInternalSecretPingExtSize();
+        extensions++;
+    }
+
     if (hdr != NULL) {
         hdr->extensions = htons(extensions);
     }
@@ -2634,9 +2739,18 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
         } else if (type == CLUSTERMSG_EXT_TYPE_SHARDID) {
             clusterMsgPingExtShardId *shardid_ext = (clusterMsgPingExtShardId *) &(ext->ext[0].shard_id);
             ext_shardid = shardid_ext->shard_id;
+        } else if (type == CLUSTERMSG_EXT_TYPE_INTERNALSECRET) {
+            clusterMsgPingExtInternalSecret *internal_secret_ext = (clusterMsgPingExtInternalSecret *) &(ext->ext[0].internal_secret);
+            setInternalSecret(sender, internal_secret_ext->internal_secret);
+        } else if (type == CLUSTERMSG_EXT_TYPE_GOSSIPINTERNALSECRET) {
+            clusterMsgPingExtGossipInternalSecret *gossip_internal_secret_ext = (clusterMsgPingExtGossipInternalSecret *) &(ext->ext[0].gossip_internal_secret);
+            clusterNode *node = clusterLookupNode(gossip_internal_secret_ext->name, CLUSTER_NAMELEN);
+            if (node) {
+                setInternalSecret(node, gossip_internal_secret_ext->internal_secret);
+            }
         } else {
             /* Unknown type, we will ignore it but log what happened. */
-            serverLog(LL_WARNING, "Received unknown extension type %d", type);
+            serverLog(LL_VERBOSE, "Received unknown extension type %d", type);
         }
 
         /* We know this will be valid since we validated it ahead of time */
@@ -3633,7 +3747,7 @@ void clusterSendPing(clusterLink *link, int type) {
     estlen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
     estlen += (sizeof(clusterMsgDataGossip)*(wanted + pfail_wanted));
     if (link->node && nodeSupportsExtensions(link->node)) {
-        estlen += writePingExt(NULL, 0);
+        estlen += writePingExt(NULL, wanted);
     }
     /* Note: clusterBuildMessageHdr() expects the buffer to be always at least
      * sizeof(clusterMsg) or more. */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -90,15 +90,10 @@ int auxTcpPortPresent(clusterNode *n);
 int auxTlsPortSetter(clusterNode *n, void *value, int length);
 sds auxTlsPortGetter(clusterNode *n, sds s);
 int auxTlsPortPresent(clusterNode *n);
-int auxInternalSecretSetter(clusterNode *n, void *value, int length);
-sds auxInternalSecretGetter(clusterNode *n, sds s);
-int auxInternalSecretPresent(clusterNode *n);
 static void clusterBuildMessageHdr(clusterMsg *hdr, int type, size_t msglen);
 void freeClusterLink(clusterLink *link);
 int verifyClusterNodeId(const char *name, int length);
 static void updateShardId(clusterNode *node, const char *shard_id);
-static void setInternalSecret(clusterNode *node, char *internal_secret);
-static void generateRandomSecret(clusterNode *node);
 
 int getNodeDefaultClientPort(clusterNode *n) {
     return server.tls_cluster ? n->tls_port : n->tcp_port;
@@ -190,7 +185,6 @@ typedef enum {
     af_human_nodename,
     af_tcp_port,
     af_tls_port,
-    af_internal_secret,
     af_count,
 } auxFieldIndex;
 
@@ -203,7 +197,6 @@ auxFieldHandler auxFieldHandlers[] = {
     {"nodename", auxHumanNodenameSetter, auxHumanNodenameGetter, auxHumanNodenamePresent},
     {"tcp-port", auxTcpPortSetter, auxTcpPortGetter, auxTcpPortPresent},
     {"tls-port", auxTlsPortSetter, auxTlsPortGetter, auxTlsPortPresent},
-    {"internal-secret", auxInternalSecretSetter, auxInternalSecretGetter, auxInternalSecretPresent},
 };
 
 int auxShardIdSetter(clusterNode *n, void *value, int length) {
@@ -289,22 +282,6 @@ sds auxTlsPortGetter(clusterNode *n, sds s) {
 
 int auxTlsPortPresent(clusterNode *n) {
     return n->tls_port >= 0 && n->tls_port < 65536;
-}
-
-int auxInternalSecretSetter(clusterNode *n, void *value, int length) {
-    if (length != CLUSTER_INTERNALSECRETLEN) {
-        return C_ERR;
-    }
-    setInternalSecret(n, (char*)value);
-    return C_OK;
-}
-
-sds auxInternalSecretGetter(clusterNode *n, sds s) {
-    return sdscatprintf(s, "%s", n->internal_secret);
-}
-
-int auxInternalSecretPresent(clusterNode *n) {
-    return n->internal_secret[0] != '\0';
 }
 
 /* clusterLink send queue blocks */
@@ -537,9 +514,6 @@ int clusterLoadConfig(char *filename) {
                 serverAssert(server.cluster->myself == NULL);
                 myself = server.cluster->myself = n;
                 n->flags |= CLUSTER_NODE_MYSELF;
-                if (n->internal_secret[0] == '\0') {
-                    generateRandomSecret(n);
-                }
             } else if (!strcasecmp(s,"master")) {
                 n->flags |= CLUSTER_NODE_MASTER;
             } else if (!strcasecmp(s,"slave")) {
@@ -1056,6 +1030,8 @@ void clusterInit(void) {
     clusterUpdateMyselfIp();
     clusterUpdateMyselfHostname();
     clusterUpdateMyselfHumanNodename();
+
+    getRandomHexChars(server.cluster->internal_secret, CLUSTER_INTERNALSECRETLEN);
 }
 
 void clusterInitLast(void) {
@@ -1328,16 +1304,6 @@ unsigned long getClusterConnectionsCount(void) {
            ((dictSize(server.cluster->nodes)-1)*2) : 0;
 }
 
-static void generateRandomSecret(clusterNode *node) {
-    getRandomHexChars(node->internal_secret, CLUSTER_INTERNALSECRETLEN);
-    node->internal_secret[CLUSTER_INTERNALSECRETLEN] = '\0';
-}
-
-static void setInternalSecret(clusterNode *node, char *internal_secret) {
-    memcpy(node->internal_secret, internal_secret, CLUSTER_INTERNALSECRETLEN);
-    node->internal_secret[CLUSTER_INTERNALSECRETLEN] = '\0';
-}
-
 /* -----------------------------------------------------------------------------
  * CLUSTER node API
  * -------------------------------------------------------------------------- */
@@ -1357,11 +1323,6 @@ clusterNode *createClusterNode(char *nodename, int flags) {
     else
         getRandomHexChars(node->name, CLUSTER_NAMELEN);
     getRandomHexChars(node->shard_id, CLUSTER_NAMELEN);
-    if (flags & CLUSTER_NODE_MYSELF) {
-        generateRandomSecret(node);
-    } else {
-        memset(node->internal_secret, 0, CLUSTER_INTERNALSECRETLEN + 1);
-    }
     node->ctime = mstime();
     node->configEpoch = 0;
     node->flags = flags;
@@ -1621,32 +1582,11 @@ clusterNode *clusterLookupNode(const char *name, int length) {
 }
 
 const char *clusterGetSecret(size_t *len) {
-    const char *min_secret = NULL;
     if (!server.cluster) {
         return NULL;
     }
-    dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
-    dictEntry *de = NULL;
-    while((de = dictNext(di)) != NULL) {
-        clusterNode *node = dictGetVal(de);
-
-        if (node->internal_secret[0] == '\0') {
-            continue;
-        }
-        if (!min_secret) {
-            min_secret = node->internal_secret;
-        } else {
-            if (memcmp(node->internal_secret, min_secret, CLUSTER_INTERNALSECRETLEN) > 0) {
-                min_secret = node->internal_secret;
-            }
-        }
-    }
-    dictReleaseIterator(di);
-
-    if (min_secret) {
-        *len = CLUSTER_INTERNALSECRETLEN;
-    }
-    return min_secret;
+    *len = CLUSTER_INTERNALSECRETLEN;
+    return server.cluster->internal_secret;
 }
 
 /* Get all the nodes in my shard.
@@ -2577,10 +2517,6 @@ uint32_t getInternalSecretPingExtSize(void) {
     return getAlignedPingExtSize(sizeof(clusterMsgPingExtInternalSecret));
 }
 
-uint32_t getGossipInternalSecretPingExtSize(void) {
-    return getAlignedPingExtSize(sizeof(clusterMsgPingExtGossipInternalSecret));
-}
-
 uint32_t getForgottenNodeExtSize(void) {
     return getAlignedPingExtSize(sizeof(clusterMsgPingExtForgottenNode));
 }
@@ -2675,32 +2611,13 @@ uint32_t writePingExt(clusterMsg *hdr, int gossipcount)  {
     /* Populate insternal secret */
     if (cursor != NULL) {
         clusterMsgPingExtInternalSecret *ext = preparePingExt(cursor, CLUSTERMSG_EXT_TYPE_INTERNALSECRET, getInternalSecretPingExtSize());
-        memcpy(ext->internal_secret, myself->internal_secret, CLUSTER_INTERNALSECRETLEN);
+        memcpy(ext->internal_secret, server.cluster->internal_secret, CLUSTER_INTERNALSECRETLEN);
 
         /* Move the write cursor */
         cursor = nextPingExt(cursor);
     }
     totlen += getInternalSecretPingExtSize();
     extensions++;
-
-    for (int i = 0 ; i < gossipcount ; ++i) {
-        /* Write internal secrets of the nodes we know about */
-        if (cursor != NULL) {
-            clusterMsgDataGossip *g_msg = hdr->data.ping.gossip + i;
-            clusterNode *n = clusterLookupNode(g_msg->nodename, CLUSTER_NAMELEN);
-            if (n->internal_secret[0] == '\0') {
-                continue;
-            }
-            clusterMsgPingExtGossipInternalSecret *ext = preparePingExt(cursor, CLUSTERMSG_EXT_TYPE_GOSSIPINTERNALSECRET, getGossipInternalSecretPingExtSize());
-            memcpy(ext->name, n->name, CLUSTER_NAMELEN);
-            memcpy(ext->internal_secret, n->internal_secret, CLUSTER_INTERNALSECRETLEN);
-
-            /* Move the write cursor */
-            cursor = nextPingExt(cursor);
-        }
-        totlen += getGossipInternalSecretPingExtSize();
-        extensions++;
-    }
 
     if (hdr != NULL) {
         hdr->extensions = htons(extensions);
@@ -2744,12 +2661,8 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
             ext_shardid = shardid_ext->shard_id;
         } else if (type == CLUSTERMSG_EXT_TYPE_INTERNALSECRET) {
             clusterMsgPingExtInternalSecret *internal_secret_ext = (clusterMsgPingExtInternalSecret *) &(ext->ext[0].internal_secret);
-            setInternalSecret(sender, internal_secret_ext->internal_secret);
-        } else if (type == CLUSTERMSG_EXT_TYPE_GOSSIPINTERNALSECRET) {
-            clusterMsgPingExtGossipInternalSecret *gossip_internal_secret_ext = (clusterMsgPingExtGossipInternalSecret *) &(ext->ext[0].gossip_internal_secret);
-            clusterNode *node = clusterLookupNode(gossip_internal_secret_ext->name, CLUSTER_NAMELEN);
-            if (node) {
-                setInternalSecret(node, gossip_internal_secret_ext->internal_secret);
+            if (memcmp(server.cluster->internal_secret, internal_secret_ext->internal_secret, CLUSTER_INTERNALSECRETLEN) < 0 ) {
+                memcpy(server.cluster->internal_secret, internal_secret_ext->internal_secret, CLUSTER_INTERNALSECRETLEN);
             }
         } else {
             /* Unknown type, we will ignore it but log what happened. */
@@ -3750,7 +3663,7 @@ void clusterSendPing(clusterLink *link, int type) {
     estlen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
     estlen += (sizeof(clusterMsgDataGossip)*(wanted + pfail_wanted));
     if (link->node && nodeSupportsExtensions(link->node)) {
-        estlen += writePingExt(NULL, wanted);
+        estlen += writePingExt(NULL, 0);
     }
     /* Note: clusterBuildMessageHdr() expects the buffer to be always at least
      * sizeof(clusterMsg) or more. */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2661,7 +2661,7 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
             ext_shardid = shardid_ext->shard_id;
         } else if (type == CLUSTERMSG_EXT_TYPE_INTERNALSECRET) {
             clusterMsgPingExtInternalSecret *internal_secret_ext = (clusterMsgPingExtInternalSecret *) &(ext->ext[0].internal_secret);
-            if (memcmp(server.cluster->internal_secret, internal_secret_ext->internal_secret, CLUSTER_INTERNALSECRETLEN) < 0 ) {
+            if (memcmp(server.cluster->internal_secret, internal_secret_ext->internal_secret, CLUSTER_INTERNALSECRETLEN) > 0 ) {
                 memcpy(server.cluster->internal_secret, internal_secret_ext->internal_secret, CLUSTER_INTERNALSECRETLEN);
             }
         } else {

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -149,7 +149,6 @@ typedef enum {
     CLUSTERMSG_EXT_TYPE_FORGOTTEN_NODE,
     CLUSTERMSG_EXT_TYPE_SHARDID,
     CLUSTERMSG_EXT_TYPE_INTERNALSECRET,
-    CLUSTERMSG_EXT_TYPE_GOSSIPINTERNALSECRET,
 } clusterMsgPingtypes;
 
 /* Helper function for making sure extensions are eight byte aligned. */
@@ -180,12 +179,6 @@ typedef struct {
 } clusterMsgPingExtInternalSecret;
 
 typedef struct {
-    char name[CLUSTER_NAMELEN];
-    char internal_secret[CLUSTER_INTERNALSECRETLEN]; /* Current shard internal secret */
-} clusterMsgPingExtGossipInternalSecret;
-
-
-typedef struct {
     uint32_t length; /* Total length of this extension message (including this header) */
     uint16_t type; /* Type of this extension message (see clusterMsgPingExtTypes) */
     uint16_t unused; /* 16 bits of padding to make this structure 8 byte aligned. */
@@ -195,7 +188,6 @@ typedef struct {
         clusterMsgPingExtForgottenNode forgotten_node;
         clusterMsgPingExtShardId shard_id;
         clusterMsgPingExtInternalSecret internal_secret;
-        clusterMsgPingExtGossipInternalSecret gossip_internal_secret;
     } ext[]; /* Actual extension information, formatted so that the data is 8
               * byte aligned, regardless of its content. */
 } clusterMsgPingExt;
@@ -305,7 +297,6 @@ struct _clusterNode {
     mstime_t ctime; /* Node object creation time. */
     char name[CLUSTER_NAMELEN]; /* Node name, hex string, sha1-size */
     char shard_id[CLUSTER_NAMELEN]; /* shard id, hex string, sha1-size */
-    char internal_secret[CLUSTER_INTERNALSECRETLEN + 1]; /* Internal secret of the current node (+1 for the \0) */
     int flags;      /* CLUSTER_NODE_... */
     uint64_t configEpoch; /* Last configEpoch observed for this node */
     unsigned char slots[CLUSTER_SLOTS/8]; /* slots handled by this node */
@@ -349,6 +340,7 @@ struct clusterState {
     clusterNode *migrating_slots_to[CLUSTER_SLOTS];
     clusterNode *importing_slots_from[CLUSTER_SLOTS];
     clusterNode *slots[CLUSTER_SLOTS];
+    char internal_secret[CLUSTER_INTERNALSECRETLEN];
     /* The following fields are used to take the slave state on elections. */
     mstime_t failover_auth_time; /* Time of previous or next election. */
     int failover_auth_count;    /* Number of votes received so far. */

--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -5,8 +5,9 @@ proc cluster_config_consistent {} {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
         if {$j == 0} {
             set base_cfg [R $j cluster slots]
+            set base_secret [R $j debug internal_secret]
         } else {
-            if {[R $j cluster slots] != $base_cfg} {
+            if {[R $j cluster slots] != $base_cfg || [R $j debug internal_secret] != $base_secret} {
                 return 0
             }
         }

--- a/tests/unit/cluster/internal-secret.tcl
+++ b/tests/unit/cluster/internal-secret.tcl
@@ -1,0 +1,71 @@
+proc num_unique_secrets {num_nodes} {
+    set secrets [list]
+    for {set i 0} {$i < $num_nodes} {incr i} {
+        lappend secrets [R $i debug internal_secret]
+    }
+    set num_secrets [llength [lsort -unique $secrets]]
+    return $num_secrets
+}
+
+proc wait_for_secret_sync {maxtries delay num_nodes} {
+    wait_for_condition $maxtries $delay {
+        [num_unique_secrets $num_nodes] eq 1
+    } else {
+        fail "Failed waiting for secrets to sync"
+    }
+}
+
+start_cluster 10 10 {tags {external:skip cluster}} {
+    test "Test internal secret sync" {
+        wait_for_secret_sync 50 100 20
+    }
+
+    
+    set first_shard_host [srv 0 host]
+    set first_shard_port [srv 0 port]
+    
+    if {$::verbose} {
+        puts {cluster internal secret:}
+        puts [R 1 debug internal_secret]
+    }
+
+    test "Join a node to the cluster and make sure it gets the same secret" {
+        start_server {tags {"external:skip"} overrides {cluster-enabled {yes}}} {
+            r cluster meet $first_shard_host $first_shard_port
+            wait_for_condition 50 100 {
+                [r debug internal_secret] eq [R 1 debug internal_secret]
+            } else {
+                puts [r debug internal_secret]
+                puts [R 1 debug internal_secret]
+                fail "Secrets not match"
+            }
+        }
+    }
+
+    test "Join another cluster, make sure clusters sync on the internal secret" {
+        start_server {tags {"external:skip"} overrides {cluster-enabled {yes}}} {
+            set new_shard_host [srv 0 host]
+            set new_shard_port [srv 0 port]
+            start_server {tags {"external:skip"} overrides {cluster-enabled {yes}}} {
+                r cluster meet $new_shard_host $new_shard_port
+                wait_for_condition 50 100 {
+                    [r debug internal_secret] eq [r -1 debug internal_secret]
+                } else {
+                    puts [r debug internal_secret]
+                    puts [r -1 debug internal_secret]
+                    fail "Secrets not match"
+                }
+                if {$::verbose} {
+                    puts {new cluster internal secret:}
+                    puts [r -1 debug internal_secret]
+                }
+                r cluster meet $first_shard_host $first_shard_port
+                wait_for_secret_sync 50 100 22
+                if {$::verbose} {
+                    puts {internal secret after join to bigger cluster:}
+                    puts [r -1 debug internal_secret]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The PR introduces a new shared secret that is shared over all the nodes on the Redis cluster. The main idea is to leverage the cluster bus to share a secret between all the nodes such that later the nodes will be able to authenticate using this secret and send internal commands to each other (see #13740 for more information about internal commands).

The way the shared secret is chosen is the following:
1. Each node, when start, randomly generate its own internal secret.
2. Each node share its internal secret over the cluster ping messages.
3. If a node gets a ping message with secret smaller then his current secret, it embrace it.
4. Eventually all nodes should embrace the minimal secret

The converges of the secret is as good as the topology converges.

To extend the ping messages to contain the secret, we leverage the extension mechanism. Nodes that runs an older Redis version will just ignore those extensions.

Specific tests were added to verify that eventually all nodes see the secrets. In addition, a verification was added to the test infra to verify the secret on `cluster_config_consistent` and to `assert_cluster_state`.