### PR TITLE
Fix memleak of SFLUSH experimental command

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -794,7 +794,10 @@ void flushallSyncBgDone(uint64_t client_id, void *sflush) {
     client *c = lookupClientByID(client_id);
 
     /* Verify that client still exists */
-    if (!c) return;
+    if (!c) {
+        zfree(sflush);
+        return;
+    }
 
     /* Update current_client (Called functions might rely on it) */
     client *old_client = server.current_client;


### PR DESCRIPTION
On flushallSyncBgDone, if client doesn't exists, take care release sflush struct.