### PR TITLE
Add flag for ability of a module context to execute debug commands

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3993,7 +3993,8 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
     if (listLength(server.loadmodule_queue) > 0)
         flags |= REDISMODULE_CTX_FLAGS_SERVER_STARTUP;
 
-    if (server.enable_debug_cmd) {
+    /* If debug commands are completely enabled */
+    if (server.enable_debug_cmd == PROTECTED_ACTION_ALLOWED_YES) {
         flags |= REDISMODULE_CTX_FLAGS_DEBUG_ENABLED;
     }
 

--- a/src/module.c
+++ b/src/module.c
@@ -3923,6 +3923,9 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
         if (c && (c->flags & (CLIENT_DIRTY_CAS|CLIENT_DIRTY_EXEC))) {
             flags |= REDISMODULE_CTX_FLAGS_MULTI_DIRTY;
         }
+        if (c && allowProtectedAction(server.enable_debug_cmd, c)) {
+            flags |= REDISMODULE_CTX_FLAGS_DEBUG_ENABLED;
+        }
     }
 
     if (scriptIsRunning())
@@ -3989,6 +3992,10 @@ int RM_GetContextFlags(RedisModuleCtx *ctx) {
     /* Non-empty server.loadmodule_queue means that Redis is starting. */
     if (listLength(server.loadmodule_queue) > 0)
         flags |= REDISMODULE_CTX_FLAGS_SERVER_STARTUP;
+
+    if (server.enable_debug_cmd) {
+        flags |= REDISMODULE_CTX_FLAGS_DEBUG_ENABLED;
+    }
 
     return flags;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -3901,6 +3901,9 @@ int RM_GetSelectedDb(RedisModuleCtx *ctx) {
  *                                 context is using RESP3.
  *
  *  * REDISMODULE_CTX_FLAGS_SERVER_STARTUP: The Redis instance is starting
+ *
+ *  * REDISMODULE_CTX_FLAGS_DEBUG_ENABLED: Debug commands are enabled for this
+ *                                         context.
  */
 int RM_GetContextFlags(RedisModuleCtx *ctx) {
     int flags = 0;

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -208,11 +208,13 @@ typedef struct RedisModuleStreamID {
 #define REDISMODULE_CTX_FLAGS_ASYNC_LOADING (1<<23)
 /* Redis is starting. */
 #define REDISMODULE_CTX_FLAGS_SERVER_STARTUP (1<<24)
+/* This context can call execute debug commands. */
+#define REDISMODULE_CTX_FLAGS_DEBUG_ENABLED (1<<25)
 
 /* Next context flag, must be updated when adding new flags above!
 This flag should not be used directly by the module.
  * Use RedisModule_GetContextFlagsAll instead. */
-#define _REDISMODULE_CTX_FLAGS_NEXT (1<<25)
+#define _REDISMODULE_CTX_FLAGS_NEXT (1<<26)
 
 /* Keyspace changes notification classes. Every class is associated with a
  * character for configuration purposes.

--- a/tests/modules/basics.c
+++ b/tests/modules/basics.c
@@ -794,6 +794,19 @@ int TestAssertIntegerReply(RedisModuleCtx *ctx, RedisModuleCallReply *reply, lon
     return 1;
 }
 
+/* Replies "yes", "no" otherwise if the context may execute debug commands */
+int TestCanDebug(RedisModuleCtx *ctx) {
+    int flags = RedisModule_GetContextFlags(ctx);
+    int allFlags = RedisModule_GetContextFlagsAll();
+    if ((allFlags & REDISMODULE_CTX_FLAGS_DEBUG_ENABLED) &&
+        (flags & REDISMODULE_CTX_FLAGS_DEBUG_ENABLED)) {
+        RedisModule_ReplyWithSimpleString(ctx, "yes");
+    } else {
+        RedisModule_ReplyWithSimpleString(ctx, "no");
+    }
+    return REDISMODULE_OK;
+}
+
 #define T(name,...) \
     do { \
         RedisModule_Log(ctx,"warning","Testing %s", name); \
@@ -802,7 +815,7 @@ int TestAssertIntegerReply(RedisModuleCtx *ctx, RedisModuleCallReply *reply, lon
 
 /* TEST.BASICS -- Run all the tests.
  * Note: it is useful to run these tests from the module rather than TCL
- * since it's easier to check the reply types like that (make a distinction
+ * since it's easier to check the reply types like that make a distinction
  * between 0 and "0", etc. */
 int TestBasics(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
@@ -1015,6 +1028,10 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     if (RedisModule_CreateCommand(ctx,"test.getresp",
         TestGetResp,"readonly",1,1,1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"test.candebug",
+        TestCanDebug,"readonly",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     RedisModule_SubscribeToKeyspaceEvents(ctx,

--- a/tests/modules/basics.c
+++ b/tests/modules/basics.c
@@ -795,7 +795,9 @@ int TestAssertIntegerReply(RedisModuleCtx *ctx, RedisModuleCallReply *reply, lon
 }
 
 /* Replies "yes", "no" otherwise if the context may execute debug commands */
-int TestCanDebug(RedisModuleCtx *ctx) {
+int TestCanDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
     int flags = RedisModule_GetContextFlags(ctx);
     int allFlags = RedisModule_GetContextFlagsAll();
     if ((allFlags & REDISMODULE_CTX_FLAGS_DEBUG_ENABLED) &&

--- a/tests/unit/moduleapi/basics.tcl
+++ b/tests/unit/moduleapi/basics.tcl
@@ -67,6 +67,4 @@ start_server {tags {"modules external:skip"} overrides {enable-debug-command loc
     test {debug commands are enabled for local connection} {
         assert_equal {yes} [r test.candebug]
     }
-
-    # TODO: Non-local case - can we test here?
 }

--- a/tests/unit/moduleapi/basics.tcl
+++ b/tests/unit/moduleapi/basics.tcl
@@ -44,3 +44,29 @@ start_server {tags {"modules external:skip"} overrides {enable-module-command no
        assert_error "ERR *MODULE command not allowed*" {r module load $testmodule}
     }
 }
+
+start_server {tags {"modules external:skip"} overrides {enable-debug-command no}} {
+    r module load $testmodule
+
+    test {debug command disabled} {
+        assert_equal {no} [r test.candebug]
+    }
+}
+
+start_server {tags {"modules external:skip"} overrides {enable-debug-command yes}} {
+    r module load $testmodule
+
+    test {debug command enabled} {
+        assert_equal {yes} [r test.candebug]
+    }
+}
+
+start_server {tags {"modules external:skip"} overrides {enable-debug-command local}} {
+    r module load $testmodule
+
+    test {debug commands are enabled for local connection} {
+        assert_equal {yes} [r test.candebug]
+    }
+
+    # TODO: Non-local case - can we test here?
+}


### PR DESCRIPTION
This PR adds a flag to the `RM_GetContextFlags` module-API function that depicts whether the context may execute debug commands, according to redis's standards.