### PR TITLE
Bump actions/upload-artifact from 3 to 4

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -27,7 +27,7 @@ jobs:
             --tags -slow
     - name: Archive redis log
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-external-redis-log
         path: external-redis.log
@@ -55,7 +55,7 @@ jobs:
             --tags -slow
     - name: Archive redis log
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-external-cluster-log
         path: external-redis-cluster.log
@@ -79,7 +79,7 @@ jobs:
             --tags "-slow -needs:debug"
       - name: Archive redis log
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-external-redis-nodebug-log
           path: external-redis-nodebug.log


### PR DESCRIPTION
Update `upload-artifact` from v3 to v4 to avoid the failure of `External Server Tests` (I encountered this error when opening [#13779](https://github.com/redis/redis/pull/13779)):

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/