### PR TITLE
Add an API to load default configuration values

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -439,7 +439,6 @@ typedef int (*RedisModuleConfigApplyFunc)(RedisModuleCtx *ctx, void *privdata, R
 struct ModuleConfig {
     sds name;           /* Fullname of the config (as it appears in the config file) */
     sds alias;          /* Optional alias for the configuration. NULL if none exists */
-    int defaultWasSet;  /* Indicates if the default value was set for the configuration */
     int unprefixedFlag; /* Indicates if the REDISMODULE_CONFIG_UNPREFIXED flag was set. 
                          * If the configuration name was prefixed,during get_fn/set_fn 
                          * callbacks, it should be reported without the prefix */

--- a/src/module.c
+++ b/src/module.c
@@ -439,6 +439,7 @@ typedef int (*RedisModuleConfigApplyFunc)(RedisModuleCtx *ctx, void *privdata, R
 struct ModuleConfig {
     sds name;           /* Fullname of the config (as it appears in the config file) */
     sds alias;          /* Optional alias for the configuration. NULL if none exists */
+
     int unprefixedFlag; /* Indicates if the REDISMODULE_CONFIG_UNPREFIXED flag was set. 
                          * If the configuration name was prefixed,during get_fn/set_fn 
                          * callbacks, it should be reported without the prefix */

--- a/src/module.c
+++ b/src/module.c
@@ -12465,7 +12465,7 @@ int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loa
     ctx.module->onload = 0;
 
     int post_load_err = 0;
-    if (listLength(ctx.module->module_configs) && !(ctx.module->configs_initialized & MODULE_ONLOAD_CONFIG)) {
+    if (listLength(ctx.module->module_configs) && !(ctx.module->configs_initialized & MODULE_NON_DEFAULT_CONFIG)) {
         serverLogRaw(LL_WARNING, "Module Configurations were not set, missing LoadConfigs call. Unloading the module.");
         post_load_err = 1;
     }
@@ -12908,7 +12908,7 @@ int loadModuleConfigs(RedisModule *module) {
             return REDISMODULE_ERR;
         }
     }
-    module->configs_initialized |= (MODULE_DEFAULT_CONFIG | MODULE_ONLOAD_CONFIG);
+    module->configs_initialized |= (MODULE_DEFAULT_CONFIG | MODULE_NON_DEFAULT_CONFIG);
     return REDISMODULE_OK;
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -13259,7 +13259,7 @@ int RM_LoadDefaultConfigs(RedisModuleCtx *ctx) {
         return REDISMODULE_ERR;
     }
     RedisModule *module = ctx->module;
-    /* Load configs from conf file or arguments from loadex */
+    /* Load default configs of the module */
     return loadModuleDefaultConfigs(module);
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -12879,7 +12879,6 @@ int loadModuleSingleConfig(dictEntry *config_queue_entry, ModuleConfig *module_c
 int loadModuleDefaultConfigs(RedisModule *module) {
     listIter li;
     listNode *ln;
-    const char *err = NULL;
     listRewind(module->module_configs, &li);
     while ((ln = listNext(&li))) {
         ModuleConfig *module_config = listNodeValue(ln);

--- a/src/module.c
+++ b/src/module.c
@@ -14343,6 +14343,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(RegisterNumericConfig);
     REGISTER_API(RegisterStringConfig);
     REGISTER_API(RegisterEnumConfig);
+    REGISTER_API(LoadDefaultConfigs);
     REGISTER_API(LoadConfigs);
     REGISTER_API(RegisterAuthCallback);
     REGISTER_API(RdbStreamCreateFromFile);

--- a/src/module.c
+++ b/src/module.c
@@ -13252,11 +13252,8 @@ int RM_RegisterNumericConfig(RedisModuleCtx *ctx, const char *name, long long de
 /* Applies all default configurations for the parameters the module registered.
  * Only call this function if the module would like to make changes to the
  * configuration values before the actual values are applied by RedisModule_LoadConfigs.
- * Otherwise continue calling RedisModule_LoadConfigs, it should already set the default values if needed.
- * This sets an ordering for the possible source of a configuration value:
- * 1. config values - e.g from the config file or CONFIG during loadex
- * 2. module values - e.g from the module arguments
- * 3. default values - if no other value was set
+ * Otherwise it's sufficient to call RedisModule_LoadConfigs, it should already set the default values if needed.
+ * This makes it possible to distinguish between default values and user provided values and apply other changes between setting the defaults and the user values.```
  * This will return REDISMODULE_ERR if it is called:
  * 1. outside RedisModule_OnLoad
  * 2. more than once

--- a/src/module.c
+++ b/src/module.c
@@ -12465,7 +12465,7 @@ int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loa
     ctx.module->onload = 0;
 
     int post_load_err = 0;
-    if (listLength(ctx.module->module_configs) && !(ctx.module->configs_initialized & MODULE_NON_DEFAULT_CONFIG)) {
+    if (listLength(ctx.module->module_configs) && !(ctx.module->configs_initialized & MODULE_CONFIGS_USER_VALS)) {
         serverLogRaw(LL_WARNING, "Module Configurations were not set, missing LoadConfigs call. Unloading the module.");
         post_load_err = 1;
     }
@@ -12856,37 +12856,19 @@ long long getModuleNumericConfig(ModuleConfig *module_config) {
     return module_config->get_fn.get_numeric(rname, module_config->privdata);
 }
 
-int loadModuleSingleConfig(dictEntry *config_queue_entry, ModuleConfig *module_config, bool set_default_if_missing) {
-    const char *err = NULL;
-    if (config_queue_entry) {
-        if (!performModuleConfigSetFromName(dictGetKey(config_queue_entry), dictGetVal(config_queue_entry), &err)) {
-            serverLog(LL_WARNING, "Issue during loading of configuration %s : %s", (sds) dictGetKey(config_queue_entry), err);
-            dictFreeUnlinkedEntry(server.module_configs_queue, config_queue_entry);
-            dictEmpty(server.module_configs_queue, NULL);
-            return REDISMODULE_ERR;
-        }
-        dictFreeUnlinkedEntry(server.module_configs_queue, config_queue_entry);
-    } else if (set_default_if_missing) {
-        if (!performModuleConfigSetDefaultFromName(module_config->name, &err)) {
-            serverLog(LL_WARNING, "Issue attempting to set default value of configuration %s : %s", module_config->name, err);
-            dictEmpty(server.module_configs_queue, NULL);
-            return REDISMODULE_ERR;
-        }
-    }
-    return REDISMODULE_OK;
-}
-
 int loadModuleDefaultConfigs(RedisModule *module) {
     listIter li;
     listNode *ln;
+    const char *err = NULL;
     listRewind(module->module_configs, &li);
     while ((ln = listNext(&li))) {
         ModuleConfig *module_config = listNodeValue(ln);
-        if (loadModuleSingleConfig(NULL, module_config, true) != REDISMODULE_OK) {
+        if (!performModuleConfigSetDefaultFromName(module_config->name, &err)) {
+            serverLog(LL_WARNING, "Issue attempting to set default value of configuration %s : %s", module_config->name, err);
             return REDISMODULE_ERR;
         }
     }
-    module->configs_initialized |= MODULE_DEFAULT_CONFIG;
+    module->configs_initialized |= MODULE_CONFIGS_DEFAULTS;
     return REDISMODULE_OK;
 }
 
@@ -12895,20 +12877,33 @@ int loadModuleDefaultConfigs(RedisModule *module) {
 int loadModuleConfigs(RedisModule *module) {
     listIter li;
     listNode *ln;
+    const char *err = NULL;
     listRewind(module->module_configs, &li);
-    const bool set_default_if_missing = !(module->configs_initialized & MODULE_DEFAULT_CONFIG);
+    const int set_default_if_missing = !(module->configs_initialized & MODULE_CONFIGS_DEFAULTS);
     while ((ln = listNext(&li))) {
         ModuleConfig *module_config = listNodeValue(ln);
         dictEntry *de = dictUnlink(server.module_configs_queue, module_config->name);
         if ((!de) && (module_config->alias))
             de = dictUnlink(server.module_configs_queue, module_config->alias);
 
-        /* If found in the queue, set the value. Otherwise, set the default value if set_default_if_missing is true. */
-        if (loadModuleSingleConfig(de, module_config, set_default_if_missing) != REDISMODULE_OK) {
-            return REDISMODULE_ERR;
+        /* If found in the queue, set the value. Otherwise, set the default value. */
+        if (de) {
+            if (!performModuleConfigSetFromName(dictGetKey(de), dictGetVal(de), &err)) {
+                serverLog(LL_WARNING, "Issue during loading of configuration %s : %s", (sds) dictGetKey(de), err);
+                dictFreeUnlinkedEntry(server.module_configs_queue, de);
+                dictEmpty(server.module_configs_queue, NULL);
+                return REDISMODULE_ERR;
+            }
+            dictFreeUnlinkedEntry(server.module_configs_queue, de);
+        } else if (set_default_if_missing) {
+            if (!performModuleConfigSetDefaultFromName(module_config->name, &err)) {
+                serverLog(LL_WARNING, "Issue attempting to set default value of configuration %s : %s", module_config->name, err);
+                dictEmpty(server.module_configs_queue, NULL);
+                return REDISMODULE_ERR;
+            }
         }
     }
-    module->configs_initialized |= (MODULE_DEFAULT_CONFIG | MODULE_NON_DEFAULT_CONFIG);
+    module->configs_initialized = MODULE_CONFIGS_ALL_APPLIED;
     return REDISMODULE_OK;
 }
 
@@ -13254,8 +13249,17 @@ int RM_RegisterNumericConfig(RedisModuleCtx *ctx, const char *name, long long de
     return REDISMODULE_OK;
 }
 
+/* Applies all default configurations on the module load.
+ * Only call this function if the module would like to make changes to the
+ * configuration values before the actual values are applied by RedisModule_LoadConfigs.
+ * Otherwise continue calling RedisModule_LoadConfigs, it should already set the default values if needed.
+ * This sets an ordering for the possible source of a configuration value:
+ * 1. config values - e.g from the config file or CONFIG during loadex
+ * 2. module values - e.g from the module arguments
+ * 3. default values - if no other value was set
+ * This will return REDISMODULE_ERR if it is called outside RedisModule_OnLoad or more than once or after the LoadConfis call. */
 int RM_LoadDefaultConfigs(RedisModuleCtx *ctx) {
-    if (!ctx || !ctx->module || !ctx->module->onload) {
+    if (!ctx || !ctx->module || !ctx->module->onload || ctx->module->configs_initialized) {
         return REDISMODULE_ERR;
     }
     RedisModule *module = ctx->module;

--- a/src/module.c
+++ b/src/module.c
@@ -13260,7 +13260,7 @@ int RM_RegisterNumericConfig(RedisModuleCtx *ctx, const char *name, long long de
  * This will return REDISMODULE_ERR if it is called:
  * 1. outside RedisModule_OnLoad
  * 2. more than once
- * 3. after the LoadConfis call */
+ * 3. after the RedisModule_LoadConfigs call */
 int RM_LoadDefaultConfigs(RedisModuleCtx *ctx) {
     if (!ctx || !ctx->module || !ctx->module->onload || ctx->module->configs_initialized) {
         return REDISMODULE_ERR;

--- a/src/module.c
+++ b/src/module.c
@@ -13249,7 +13249,7 @@ int RM_RegisterNumericConfig(RedisModuleCtx *ctx, const char *name, long long de
     return REDISMODULE_OK;
 }
 
-/* Applies all default configurations on the module load.
+/* Applies all default configurations for the parameters the module registered.
  * Only call this function if the module would like to make changes to the
  * configuration values before the actual values are applied by RedisModule_LoadConfigs.
  * Otherwise continue calling RedisModule_LoadConfigs, it should already set the default values if needed.
@@ -13257,7 +13257,10 @@ int RM_RegisterNumericConfig(RedisModuleCtx *ctx, const char *name, long long de
  * 1. config values - e.g from the config file or CONFIG during loadex
  * 2. module values - e.g from the module arguments
  * 3. default values - if no other value was set
- * This will return REDISMODULE_ERR if it is called outside RedisModule_OnLoad or more than once or after the LoadConfis call. */
+ * This will return REDISMODULE_ERR if it is called:
+ * 1. outside RedisModule_OnLoad
+ * 2. more than once
+ * 3. after the LoadConfis call */
 int RM_LoadDefaultConfigs(RedisModuleCtx *ctx) {
     if (!ctx || !ctx->module || !ctx->module->onload || ctx->module->configs_initialized) {
         return REDISMODULE_ERR;

--- a/src/module.c
+++ b/src/module.c
@@ -13253,7 +13253,7 @@ int RM_RegisterNumericConfig(RedisModuleCtx *ctx, const char *name, long long de
  * Only call this function if the module would like to make changes to the
  * configuration values before the actual values are applied by RedisModule_LoadConfigs.
  * Otherwise it's sufficient to call RedisModule_LoadConfigs, it should already set the default values if needed.
- * This makes it possible to distinguish between default values and user provided values and apply other changes between setting the defaults and the user values.```
+ * This makes it possible to distinguish between default values and user provided values and apply other changes between setting the defaults and the user values.
  * This will return REDISMODULE_ERR if it is called:
  * 1. outside RedisModule_OnLoad
  * 2. more than once

--- a/src/module.c
+++ b/src/module.c
@@ -439,7 +439,7 @@ typedef int (*RedisModuleConfigApplyFunc)(RedisModuleCtx *ctx, void *privdata, R
 struct ModuleConfig {
     sds name;           /* Fullname of the config (as it appears in the config file) */
     sds alias;          /* Optional alias for the configuration. NULL if none exists */
-    
+    int defaultWasSet;  /* Indicates if the default value was set for the configuration */
     int unprefixedFlag; /* Indicates if the REDISMODULE_CONFIG_UNPREFIXED flag was set. 
                          * If the configuration name was prefixed,during get_fn/set_fn 
                          * callbacks, it should be reported without the prefix */
@@ -12465,8 +12465,8 @@ int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loa
     ctx.module->onload = 0;
 
     int post_load_err = 0;
-    if (listLength(ctx.module->module_configs) && !ctx.module->configs_initialized) {
-        serverLogRaw(LL_WARNING, "Module Configurations were not set, likely a missing LoadConfigs call. Unloading the module.");
+    if (listLength(ctx.module->module_configs) && !(ctx.module->configs_initialized & MODULE_ONLOAD_CONFIG)) {
+        serverLogRaw(LL_WARNING, "Module Configurations were not set, missing LoadConfigs call. Unloading the module.");
         post_load_err = 1;
     }
 
@@ -12856,37 +12856,60 @@ long long getModuleNumericConfig(ModuleConfig *module_config) {
     return module_config->get_fn.get_numeric(rname, module_config->privdata);
 }
 
-/* This function takes a module and a list of configs stored as sds NAME VALUE pairs.
- * It attempts to call set on each of these configs. */
-int loadModuleConfigs(RedisModule *module) {
+int loadModuleSingleConfig(dictEntry *config_queue_entry, ModuleConfig *module_config, bool set_default_if_missing) {
+    const char *err = NULL;
+    if (config_queue_entry) {
+        if (!performModuleConfigSetFromName(dictGetKey(config_queue_entry), dictGetVal(config_queue_entry), &err)) {
+            serverLog(LL_WARNING, "Issue during loading of configuration %s : %s", (sds) dictGetKey(config_queue_entry), err);
+            dictFreeUnlinkedEntry(server.module_configs_queue, config_queue_entry);
+            dictEmpty(server.module_configs_queue, NULL);
+            return REDISMODULE_ERR;
+        }
+        dictFreeUnlinkedEntry(server.module_configs_queue, config_queue_entry);
+    } else if (set_default_if_missing) {
+        if (!performModuleConfigSetDefaultFromName(module_config->name, &err)) {
+            serverLog(LL_WARNING, "Issue attempting to set default value of configuration %s : %s", module_config->name, err);
+            dictEmpty(server.module_configs_queue, NULL);
+            return REDISMODULE_ERR;
+        }
+    }
+    return REDISMODULE_OK;
+}
+
+int loadModuleDefaultConfigs(RedisModule *module) {
     listIter li;
     listNode *ln;
     const char *err = NULL;
     listRewind(module->module_configs, &li);
     while ((ln = listNext(&li))) {
         ModuleConfig *module_config = listNodeValue(ln);
+        if (loadModuleSingleConfig(NULL, module_config, true) != REDISMODULE_OK) {
+            return REDISMODULE_ERR;
+        }
+    }
+    module->configs_initialized |= MODULE_DEFAULT_CONFIG;
+    return REDISMODULE_OK;
+}
+
+/* This function takes a module and a list of configs stored as sds NAME VALUE pairs.
+ * It attempts to call set on each of these configs. */
+int loadModuleConfigs(RedisModule *module) {
+    listIter li;
+    listNode *ln;
+    listRewind(module->module_configs, &li);
+    const bool set_default_if_missing = !(module->configs_initialized & MODULE_DEFAULT_CONFIG);
+    while ((ln = listNext(&li))) {
+        ModuleConfig *module_config = listNodeValue(ln);
         dictEntry *de = dictUnlink(server.module_configs_queue, module_config->name);
         if ((!de) && (module_config->alias))
             de = dictUnlink(server.module_configs_queue, module_config->alias);
-        
-        /* If found in the queue, set the value. Otherwise, set the default value. */                
-        if (de) {
-            if (!performModuleConfigSetFromName(dictGetKey(de), dictGetVal(de), &err)) {
-                serverLog(LL_WARNING, "Issue during loading of configuration %s : %s", (sds) dictGetKey(de), err);
-                dictFreeUnlinkedEntry(server.module_configs_queue, de);
-                dictEmpty(server.module_configs_queue, NULL);
-                return REDISMODULE_ERR;
-            }
-            dictFreeUnlinkedEntry(server.module_configs_queue, de);
-        } else {
-            if (!performModuleConfigSetDefaultFromName(module_config->name, &err)) {
-                serverLog(LL_WARNING, "Issue attempting to set default value of configuration %s : %s", module_config->name, err);
-                dictEmpty(server.module_configs_queue, NULL);
-                return REDISMODULE_ERR;
-            }
+
+        /* If found in the queue, set the value. Otherwise, set the default value if set_default_if_missing is true. */
+        if (loadModuleSingleConfig(de, module_config, set_default_if_missing) != REDISMODULE_OK) {
+            return REDISMODULE_ERR;
         }
     }
-    module->configs_initialized = 1;
+    module->configs_initialized |= (MODULE_DEFAULT_CONFIG | MODULE_ONLOAD_CONFIG);
     return REDISMODULE_OK;
 }
 
@@ -13232,6 +13255,15 @@ int RM_RegisterNumericConfig(RedisModuleCtx *ctx, const char *name, long long de
     return REDISMODULE_OK;
 }
 
+int RM_LoadDefaultConfigs(RedisModuleCtx *ctx) {
+    if (!ctx || !ctx->module || !ctx->module->onload) {
+        return REDISMODULE_ERR;
+    }
+    RedisModule *module = ctx->module;
+    /* Load configs from conf file or arguments from loadex */
+    return loadModuleDefaultConfigs(module);
+}
+
 /* Applies all pending configurations on the module load. This should be called
  * after all of the configurations have been registered for the module inside of RedisModule_OnLoad.
  * This will return REDISMODULE_ERR if it is called outside RedisModule_OnLoad.
@@ -13243,8 +13275,7 @@ int RM_LoadConfigs(RedisModuleCtx *ctx) {
     }
     RedisModule *module = ctx->module;
     /* Load configs from conf file or arguments from loadex */
-    if (loadModuleConfigs(module)) return REDISMODULE_ERR;
-    return REDISMODULE_OK;
+    return loadModuleConfigs(module);
 }
 
 /* --------------------------------------------------------------------------

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1692,8 +1692,8 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(RegisterNumericConfig);
     REDISMODULE_GET_API(RegisterStringConfig);
     REDISMODULE_GET_API(RegisterEnumConfig);
-    REDISMODULE_GET_API(LoadDefaultConfigs);
     REDISMODULE_GET_API(LoadConfigs);
+    REDISMODULE_GET_API(LoadDefaultConfigs);
     REDISMODULE_GET_API(RdbStreamCreateFromFile);
     REDISMODULE_GET_API(RdbStreamFree);
     REDISMODULE_GET_API(RdbLoad);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1692,6 +1692,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(RegisterNumericConfig);
     REDISMODULE_GET_API(RegisterStringConfig);
     REDISMODULE_GET_API(RegisterEnumConfig);
+    REDISMODULE_GET_API(LoadDefaultConfigs);
     REDISMODULE_GET_API(LoadConfigs);
     REDISMODULE_GET_API(RdbStreamCreateFromFile);
     REDISMODULE_GET_API(RdbStreamFree);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1321,6 +1321,7 @@ REDISMODULE_API int (*RedisModule_RegisterNumericConfig)(RedisModuleCtx *ctx, co
 REDISMODULE_API int (*RedisModule_RegisterStringConfig)(RedisModuleCtx *ctx, const char *name, const char *default_val, unsigned int flags, RedisModuleConfigGetStringFunc getfn, RedisModuleConfigSetStringFunc setfn, RedisModuleConfigApplyFunc applyfn, void *privdata) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RegisterEnumConfig)(RedisModuleCtx *ctx, const char *name, int default_val, unsigned int flags, const char **enum_values, const int *int_values, int num_enum_vals, RedisModuleConfigGetEnumFunc getfn, RedisModuleConfigSetEnumFunc setfn, RedisModuleConfigApplyFunc applyfn, void *privdata) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_LoadConfigs)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_LoadDefaultConfigs)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleRdbStream *(*RedisModule_RdbStreamCreateFromFile)(const char *filename) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_RdbStreamFree)(RedisModuleRdbStream *stream) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RdbLoad)(RedisModuleCtx *ctx, RedisModuleRdbStream *stream, int flags) REDISMODULE_ATTR;

--- a/src/server.h
+++ b/src/server.h
@@ -866,8 +866,8 @@ typedef struct moduleValue {
 
 typedef enum {
     MODULE_DEFAULT_CONFIG = 0x1,
-    MODULE_ONLOAD_CONFIG = 0x2,
-    MODULE_CONFIGURED = MODULE_DEFAULT_CONFIG | MODULE_ONLOAD_CONFIG
+    MODULE_NON_DEFAULT_CONFIG = 0x2,
+    MODULE_CONFIGURED = MODULE_DEFAULT_CONFIG | MODULE_NON_DEFAULT_CONFIG
 } ModuleConfigFlags;
 
 /* This structure represents a module inside the system. */

--- a/src/server.h
+++ b/src/server.h
@@ -864,6 +864,12 @@ typedef struct moduleValue {
     void *value;
 } moduleValue;
 
+typedef enum {
+    MODULE_DEFAULT_CONFIG = 0x1,
+    MODULE_ONLOAD_CONFIG = 0x2,
+    MODULE_CONFIGURED = MODULE_DEFAULT_CONFIG | MODULE_ONLOAD_CONFIG
+} ModuleConfigFlags;
+
 /* This structure represents a module inside the system. */
 struct RedisModule {
     void *handle;   /* Module dlopen() handle. */
@@ -875,7 +881,7 @@ struct RedisModule {
     list *using;    /* List of modules we use some APIs of. */
     list *filters;  /* List of filters the module has registered. */
     list *module_configs; /* List of configurations the module has registered */
-    int configs_initialized; /* Have the module configurations been initialized? */
+    ModuleConfigFlags configs_initialized; /* Have the module configurations been initialized? */
     int in_call;    /* RM_Call() nesting level */
     int in_hook;    /* Hooks callback nesting level for this module (0 or 1). */
     int options;    /* Module options and capabilities. */

--- a/src/server.h
+++ b/src/server.h
@@ -864,11 +864,12 @@ typedef struct moduleValue {
     void *value;
 } moduleValue;
 
+/* Describe the state of the module during loading, and the indication which configs were loaded / applied already. */
 typedef enum {
-    MODULE_DEFAULT_CONFIG = 0x1,
-    MODULE_NON_DEFAULT_CONFIG = 0x2,
-    MODULE_CONFIGURED = MODULE_DEFAULT_CONFIG | MODULE_NON_DEFAULT_CONFIG
-} ModuleConfigFlags;
+    MODULE_CONFIGS_DEFAULTS = 0x1, /* The registered defaults were applied. */
+    MODULE_CONFIGS_USER_VALS  = 0x2, /* The user provided values were applied. */
+    MODULE_CONFIGS_ALL_APPLIED = 0x3 /* Both of the above applied. */
+} ModuleConfigsApplied;
 
 /* This structure represents a module inside the system. */
 struct RedisModule {
@@ -881,7 +882,7 @@ struct RedisModule {
     list *using;    /* List of modules we use some APIs of. */
     list *filters;  /* List of filters the module has registered. */
     list *module_configs; /* List of configurations the module has registered */
-    ModuleConfigFlags configs_initialized; /* Have the module configurations been initialized? */
+    ModuleConfigsApplied configs_initialized; /* Have the module configurations been initialized? */
     int in_call;    /* RM_Call() nesting level */
     int in_hook;    /* Hooks callback nesting level for this module (0 or 1). */
     int options;    /* Module options and capabilities. */

--- a/tests/modules/moduleconfigs.c
+++ b/tests/modules/moduleconfigs.c
@@ -252,10 +252,11 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     size_t len;
     if (argc && !strcasecmp(RedisModule_StringPtrLen(argv[0], &len), "noload")) {
         return REDISMODULE_OK;
-    } else if (RedisModule_LoadDefaultConfigs(ctx) == REDISMODULE_ERR) {
-        RedisModule_Log(ctx, "warning", "Failed to load default configuration");
-        goto err;
-    } else if (argc && !strcasecmp(RedisModule_StringPtrLen(argv[0], &len), "override")) {
+    } if (argc && !strcasecmp(RedisModule_StringPtrLen(argv[0], &len), "override-default")) {
+        if (RedisModule_LoadDefaultConfigs(ctx) == REDISMODULE_ERR) {
+            RedisModule_Log(ctx, "warning", "Failed to load default configuration");
+            goto err;
+        }
         // simulate configuration values being overwritten by the command line
         RedisModule_Log(ctx, "debug", "Overriding configuration values");
         if (strval) RedisModule_FreeString(ctx, strval);

--- a/tests/modules/moduleconfigs.c
+++ b/tests/modules/moduleconfigs.c
@@ -252,7 +252,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     size_t len;
     if (argc && !strcasecmp(RedisModule_StringPtrLen(argv[0], &len), "noload")) {
         return REDISMODULE_OK;
-    } if (argc && !strcasecmp(RedisModule_StringPtrLen(argv[0], &len), "override-default")) {
+    } else if (argc && !strcasecmp(RedisModule_StringPtrLen(argv[0], &len), "override-default")) {
         if (RedisModule_LoadDefaultConfigs(ctx) == REDISMODULE_ERR) {
             RedisModule_Log(ctx, "warning", "Failed to load default configuration");
             goto err;

--- a/tests/modules/moduleconfigs.c
+++ b/tests/modules/moduleconfigs.c
@@ -165,6 +165,17 @@ int registerBlockCheck(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     return REDISMODULE_OK;
 }
 
+void cleanup(RedisModuleCtx *ctx) {
+    if (strval) {
+        RedisModule_FreeString(ctx, strval);
+        strval = NULL;
+    }
+    if (strval2) {
+        RedisModule_FreeString(ctx, strval2);
+        strval2 = NULL;
+    }
+}
+
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
@@ -264,22 +275,12 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
   
     return REDISMODULE_OK;
 err:
-    if (strval) {
-        RedisModule_FreeString(ctx, strval);
-        strval = NULL;
-    }
+    cleanup(ctx);
     return REDISMODULE_ERR;
 }
 
 int RedisModule_OnUnload(RedisModuleCtx *ctx) {
     REDISMODULE_NOT_USED(ctx);
-    if (strval) {
-        RedisModule_FreeString(ctx, strval);
-        strval = NULL;
-    }
-    if (strval2) {
-        RedisModule_FreeString(ctx, strval2);
-        strval2 = NULL;
-    }
+    cleanup(ctx);
     return REDISMODULE_OK;
 }

--- a/tests/modules/moduleconfigs.c
+++ b/tests/modules/moduleconfigs.c
@@ -226,6 +226,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     size_t len;
     if (argc && !strcasecmp(RedisModule_StringPtrLen(argv[0], &len), "noload")) {
         return REDISMODULE_OK;
+    } else if (RedisModule_LoadDefaultConfigs(ctx) == REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
     } else if (RedisModule_LoadConfigs(ctx) == REDISMODULE_ERR) {
         if (strval) {
             RedisModule_FreeString(ctx, strval);

--- a/tests/modules/moduleconfigs.c
+++ b/tests/modules/moduleconfigs.c
@@ -169,16 +169,22 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     REDISMODULE_NOT_USED(argv);
     REDISMODULE_NOT_USED(argc);
 
-    if (RedisModule_Init(ctx, "moduleconfigs", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR) return REDISMODULE_ERR;
+    if (RedisModule_Init(ctx, "moduleconfigs", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to init module");
+        return REDISMODULE_ERR;
+    }
 
     if (RedisModule_RegisterBoolConfig(ctx, "mutable_bool", 1, REDISMODULE_CONFIG_DEFAULT, getBoolConfigCommand, setBoolConfigCommand, boolApplyFunc, &mutable_bool_val) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register mutable_bool");
         return REDISMODULE_ERR;
     }
     /* Immutable config here. */
     if (RedisModule_RegisterBoolConfig(ctx, "immutable_bool", 0, REDISMODULE_CONFIG_IMMUTABLE, getBoolConfigCommand, setBoolConfigCommand, boolApplyFunc, &immutable_bool_val) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register immutable_bool");
         return REDISMODULE_ERR;
     }
     if (RedisModule_RegisterStringConfig(ctx, "string", "secret password", REDISMODULE_CONFIG_DEFAULT, getStringConfigCommand, setStringConfigCommand, NULL, NULL) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register string");
         return REDISMODULE_ERR;
     }
 
@@ -187,59 +193,82 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     const int int_vals[] = {0, 5, 1, 2, 4};
 
     if (RedisModule_RegisterEnumConfig(ctx, "enum", 1, REDISMODULE_CONFIG_DEFAULT, enum_vals, int_vals, 5, getEnumConfigCommand, setEnumConfigCommand, NULL, NULL) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register enum");
         return REDISMODULE_ERR;
     }
     if (RedisModule_RegisterEnumConfig(ctx, "flags", 3, REDISMODULE_CONFIG_DEFAULT | REDISMODULE_CONFIG_BITFLAGS, enum_vals, int_vals, 5, getFlagsConfigCommand, setFlagsConfigCommand, NULL, NULL) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register flags");
         return REDISMODULE_ERR;
     }
     /* Memory config here. */
     if (RedisModule_RegisterNumericConfig(ctx, "memory_numeric", 1024, REDISMODULE_CONFIG_DEFAULT | REDISMODULE_CONFIG_MEMORY, 0, 3000000, getNumericConfigCommand, setNumericConfigCommand, longlongApplyFunc, &memval) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register memory_numeric");
         return REDISMODULE_ERR;
     }
     if (RedisModule_RegisterNumericConfig(ctx, "numeric", -1, REDISMODULE_CONFIG_DEFAULT, -5, 2000, getNumericConfigCommand, setNumericConfigCommand, longlongApplyFunc, &longval) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register numeric");
         return REDISMODULE_ERR;
     }
 
     /*** unprefixed and aliased configuration ***/
     if (RedisModule_RegisterBoolConfig(ctx, "unprefix-bool|unprefix-bool-alias", 1, REDISMODULE_CONFIG_DEFAULT|REDISMODULE_CONFIG_UNPREFIXED, 
                                        getBoolConfigCommand, setBoolConfigCommand, NULL, &no_prefix_bool) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register unprefix-bool");
         return REDISMODULE_ERR;
     }
     if (RedisModule_RegisterBoolConfig(ctx, "unprefix-noalias-bool", 1, REDISMODULE_CONFIG_DEFAULT|REDISMODULE_CONFIG_UNPREFIXED,
                                        getBoolConfigCommand, setBoolConfigCommand, NULL, &no_prefix_bool2) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register unprefix-noalias-bool");
         return REDISMODULE_ERR;
     }    
     if (RedisModule_RegisterNumericConfig(ctx, "unprefix.numeric|unprefix.numeric-alias", -1, REDISMODULE_CONFIG_DEFAULT|REDISMODULE_CONFIG_UNPREFIXED, 
                                           -5, 2000, getNumericConfigCommand, setNumericConfigCommand, NULL, &no_prefix_longval) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register unprefix.numeric");
         return REDISMODULE_ERR;
     }    
     if (RedisModule_RegisterStringConfig(ctx, "unprefix-string|unprefix.string-alias", "secret unprefix", REDISMODULE_CONFIG_DEFAULT|REDISMODULE_CONFIG_UNPREFIXED, 
                                          getStringConfigUnprefix, setStringConfigUnprefix, NULL, NULL) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register unprefix-string");
         return REDISMODULE_ERR;
     }    
     if (RedisModule_RegisterEnumConfig(ctx, "unprefix-enum|unprefix-enum-alias", 1, REDISMODULE_CONFIG_DEFAULT|REDISMODULE_CONFIG_UNPREFIXED, 
                                        enum_vals, int_vals, 5, getEnumConfigUnprefix, setEnumConfigUnprefix, NULL, NULL) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register unprefix-enum");
         return REDISMODULE_ERR;
     }
 
-    
+    RedisModule_Log(ctx, "debug", "Registered configuration");
     size_t len;
     if (argc && !strcasecmp(RedisModule_StringPtrLen(argv[0], &len), "noload")) {
         return REDISMODULE_OK;
     } else if (RedisModule_LoadDefaultConfigs(ctx) == REDISMODULE_ERR) {
-        return REDISMODULE_ERR;
-    } else if (RedisModule_LoadConfigs(ctx) == REDISMODULE_ERR) {
-        if (strval) {
-            RedisModule_FreeString(ctx, strval);
-            strval = NULL;
-        }
-        return REDISMODULE_ERR;
+        RedisModule_Log(ctx, "warning", "Failed to load default configuration");
+        goto err;
+    } else if (argc && !strcasecmp(RedisModule_StringPtrLen(argv[0], &len), "override")) {
+        // simulate configuration values being overwritten by the command line
+        RedisModule_Log(ctx, "debug", "Overriding configuration values");
+        if (strval) RedisModule_FreeString(ctx, strval);
+        strval = RedisModule_CreateString(ctx, "foo", 3);
+        longval = memval = 123;
+    }
+    RedisModule_Log(ctx, "debug", "Loading configuration");
+    if (RedisModule_LoadConfigs(ctx) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to load configuration");
+        goto err;
     }
     /* Creates a command which registers configs outside OnLoad() function. */
-    if (RedisModule_CreateCommand(ctx,"block.register.configs.outside.onload", registerBlockCheck, "write", 0, 0, 0) == REDISMODULE_ERR)
-        return REDISMODULE_ERR;
+    if (RedisModule_CreateCommand(ctx,"block.register.configs.outside.onload", registerBlockCheck, "write", 0, 0, 0) == REDISMODULE_ERR) {
+        RedisModule_Log(ctx, "warning", "Failed to register command");
+        goto err;
+    }
   
     return REDISMODULE_OK;
+err:
+    if (strval) {
+        RedisModule_FreeString(ctx, strval);
+        strval = NULL;
+    }
+    return REDISMODULE_ERR;
 }
 
 int RedisModule_OnUnload(RedisModuleCtx *ctx) {

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -350,7 +350,7 @@ start_server {tags {"modules"}} {
             CONFIG moduleconfigs.memory_numeric 2mb \
             ARGS override-default
 
-        # Verify CONFIG values took precedence over the pseudo values that
+        # Verify CONFIG values took precedence over the values that override-default would have caused the module to set
         assert_equal [r config get moduleconfigs.string] "moduleconfigs.string goo"
         assert_equal [r config get moduleconfigs.memory_numeric] "moduleconfigs.memory_numeric 2097152"
 

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -346,13 +346,12 @@ start_server {tags {"modules"}} {
     test {loadmodule CONFIG values take precedence over loadmoduleex ARGS values} {
         # Load module with conflicting CONFIG and ARGS values
         r module loadex $testmodule \
-            CONFIG moduleconfigs.mutable_bool yes \
+            CONFIG moduleconfigs.string foo \
             CONFIG moduleconfigs.memory_numeric 2mb \
-            ARGS moduleconfigs.mutable_bool no \
-            ARGS moduleconfigs.memory_numeric 4mb
+            ARGS override
 
-        # Verify CONFIG values took precedence
-        assert_equal [r config get moduleconfigs.mutable_bool] "moduleconfigs.mutable_bool yes"
+        # Verify CONFIG values took precedence over the pseudo values that
+        assert_equal [r config get moduleconfigs.string] "moduleconfigs.string foo"
         assert_equal [r config get moduleconfigs.memory_numeric] "moduleconfigs.memory_numeric 2097152"
 
         r module unload moduleconfigs
@@ -361,29 +360,26 @@ start_server {tags {"modules"}} {
     # Test: Ensure that modified configuration values from ARGS are correctly written to the config file
     test {Modified ARGS values are persisted after config rewrite when set through CONFIG commands} {
         # Load module with non-default ARGS values
-        r module loadex $testmodule \
-            ARGS moduleconfigs.memory_numeric 4mb \
-            ARGS moduleconfigs.string_setting "custom_value"
+        r module loadex $testmodule ARGS override
 
-        # Verify the initial ARGS values
-        assert_equal [r config get moduleconfigs.memory_numeric] "moduleconfigs.memory_numeric 4194304"
-        assert_equal [r config get moduleconfigs.string_setting] "moduleconfigs.string_setting custom_value"
+        # Verify the initial values were overwritten
+        assert_equal [r config get moduleconfigs.memory_numeric] "moduleconfigs.memory_numeric 123"
+        assert_equal [r config get moduleconfigs.string] "moduleconfigs.string foo"
 
         # Set new values to simulate user configuration changes
-        r config set moduleconfigs.memory_numeric 8mb
-        r config set moduleconfigs.string_setting "modified_value"
+        r config set moduleconfigs.memory_numeric 1mb
+        r config set moduleconfigs.string "modified_value"
 
         # Verify that the changes took effect
-        assert_equal [r config get moduleconfigs.memory_numeric] "moduleconfigs.memory_numeric 8388608"
-        assert_equal [r config get moduleconfigs.string_setting] "moduleconfigs.string_setting modified_value"
+        assert_equal [r config get moduleconfigs.memory_numeric] "moduleconfigs.memory_numeric 1048576"
+        assert_equal [r config get moduleconfigs.string] "moduleconfigs.string modified_value"
 
         # Perform a config rewrite
         r config rewrite
 
-        # Read and verify config file contents to check for persistence
-        set config_contents [file read [config_path]]
-        assert_contains "moduleconfigs.memory_numeric 8388608" $config_contents
-        assert_contains "moduleconfigs.string_setting modified_value" $config_contents
+        restart_server 0 true false
+        assert_equal [r config get moduleconfigs.memory_numeric] "moduleconfigs.memory_numeric 1048576"
+        assert_equal [r config get moduleconfigs.string] "moduleconfigs.string modified_value"
         r module unload moduleconfigs
     }
 }

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -346,7 +346,7 @@ start_server {tags {"modules"}} {
     test {loadmodule CONFIG values take precedence over loadmoduleex ARGS values} {
         # Load module with conflicting CONFIG and ARGS values
         r module loadex $testmodule \
-            CONFIG moduleconfigs.string foo \
+            CONFIG moduleconfigs.string goo \
             CONFIG moduleconfigs.memory_numeric 2mb \
             ARGS override
 

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -351,7 +351,7 @@ start_server {tags {"modules"}} {
             ARGS override
 
         # Verify CONFIG values took precedence over the pseudo values that
-        assert_equal [r config get moduleconfigs.string] "moduleconfigs.string foo"
+        assert_equal [r config get moduleconfigs.string] "moduleconfigs.string goo"
         assert_equal [r config get moduleconfigs.memory_numeric] "moduleconfigs.memory_numeric 2097152"
 
         r module unload moduleconfigs

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -343,7 +343,7 @@ start_server {tags {"modules"}} {
         }
     }
 
-    test {loadmodule CONFIG values take precedence over loadmoduleex ARGS values} {
+    test {loadmodule CONFIG values take precedence over module loadex ARGS values} {
         # Load module with conflicting CONFIG and ARGS values
         r module loadex $testmodule \
             CONFIG moduleconfigs.string goo \

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -348,7 +348,7 @@ start_server {tags {"modules"}} {
         r module loadex $testmodule \
             CONFIG moduleconfigs.string goo \
             CONFIG moduleconfigs.memory_numeric 2mb \
-            ARGS override
+            ARGS override-default
 
         # Verify CONFIG values took precedence over the pseudo values that
         assert_equal [r config get moduleconfigs.string] "moduleconfigs.string goo"
@@ -360,7 +360,7 @@ start_server {tags {"modules"}} {
     # Test: Ensure that modified configuration values from ARGS are correctly written to the config file
     test {Modified ARGS values are persisted after config rewrite when set through CONFIG commands} {
         # Load module with non-default ARGS values
-        r module loadex $testmodule ARGS override
+        r module loadex $testmodule ARGS override-default
 
         # Verify the initial values were overwritten
         assert_equal [r config get moduleconfigs.memory_numeric] "moduleconfigs.memory_numeric 123"

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -319,7 +319,7 @@ start_server {tags {"modules"}} {
 
         # missing LoadConfigs call
         catch {exec src/redis-server --loadmodule "$testmodule" noload --moduleconfigs.string "hello"} err
-        assert_match {*Module Configurations were not set, likely a missing LoadConfigs call. Unloading the module.*} $err
+        assert_match {*Module Configurations were not set, missing LoadConfigs call. Unloading the module.*} $err
 
         # successful
         start_server [list overrides [list loadmodule "$testmodule" moduleconfigs.string "bootedup" moduleconfigs.enum two moduleconfigs.flags "two four"]] {


### PR DESCRIPTION
Currently we have `RedisModule_LoadConfigs` which the module is expected to call during OnLoad which sets the configuration values from the config queue or it sets the default value.

The problem is that the module might still want to support loading values from the command line.
If we want to give precedence to the config file values then it means the module needs to set the values before calling the Load Config function.

The problem is that then the API overrides the variables which were set from the module command line with default values.

The new API should solve that in the following way.
1. Module registers its configuration parameters with redis
2. Module calls `RedisModule_LoadDefaultConfigs` which loads the default values for all the registered configuration parameters of the module
3. Module sets the variables internally using the values it got from the command line
4. Module calls `RedisModule_LoadConfigs` which will set the values based on the redis configuration file.

This allows for the default values to be set, for the module to override them and for redis to override what the module wrote.
In short it determines a logical flow and ordering of where the values for the parameters should come from.