### PR TITLE
Fix typo in repl-ping-replica-period comment in redis.conf

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -668,7 +668,7 @@ repl-diskless-sync-max-replicas 0
 repl-diskless-load disabled
 
 # Master send PINGs to its replicas in a predefined interval. It's possible to
-# change this interval with the repl_ping_replica_period option. The default
+# change this interval with the repl-ping-replica-period option. The default
 # value is 10 seconds.
 #
 # repl-ping-replica-period 10


### PR DESCRIPTION
The comment for the `repl-ping-replica-period` option in `redis.conf` mistakenly refers to `repl_ping_replica_period` (with underscores). This PR corrects it to use the proper format with dashes, as per the actual configuration option.

Category: Documentation
