### PR TITLE
Memory Usage command LIST accuracy fix

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -1017,7 +1017,6 @@ size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
             serverPanic("Unknown list encoding");
         }
     } else if (o->type == OBJ_SET) {
-
         if (o->encoding == OBJ_ENCODING_HT) {
             d = o->ptr;
             di = dictGetIterator(d);

--- a/src/object.c
+++ b/src/object.c
@@ -988,7 +988,7 @@ size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
     dict *d;
     dictIterator *di;
     struct dictEntry *de;
-    size_t asize = 0, elesize = 0, samples = 0;
+    size_t asize = 0, elesize = 0, elecount = 0, samples = 0;
 
     if (o->type == OBJ_STRING) {
         if(o->encoding == OBJ_ENCODING_INT) {
@@ -1007,15 +1007,17 @@ size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
             asize = sizeof(*o)+sizeof(quicklist);
             do {
                 elesize += sizeof(quicklistNode)+zmalloc_size(node->entry);
+                elecount += node->count;
                 samples++;
             } while ((node = node->next) && samples < sample_size);
-            asize += (double)elesize/samples*ql->len;
+            asize += (double)elesize/elecount*ql->count;
         } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
             asize = sizeof(*o)+zmalloc_size(o->ptr);
         } else {
             serverPanic("Unknown list encoding");
         }
     } else if (o->type == OBJ_SET) {
+
         if (o->encoding == OBJ_ENCODING_HT) {
             d = o->ptr;
             di = dictGetIterator(d);


### PR DESCRIPTION
MEMORY USAGE on a List samples quicklist entries, but does not account to how many elements are in each sampled node. This can skew the calculation when the sampled nodes are not balanced.  
The fix calculate the average element size in the sampled nodes instead of the average node size.

For example, a list with 1M equal 128B elements:
```
127.0.0.1:6379>1000000 lpush mylist2 blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblah
```

Before:
```
127.0.0.1:6579> memory usage mylist2 samples 1
(integer) 59411952
127.0.0.1:6579> memory usage mylist2 samples 10
(integer) 127401148
127.0.0.1:6579> memory usage mylist2 samples 100
(integer) 134200068
127.0.0.1:6579> memory usage mylist2 samples 1000
(integer) 134879960
127.0.0.1:6579> memory usage mylist2 samples 10000
(integer) 134947949
127.0.0.1:6579> memory usage mylist2 samples 100000
(integer) 134950896
127.0.0.1:6579> memory usage mylist2 samples 1000000
(integer) 134950896
127.0.0.1:6579> memory usage mylist2
(integer) 119846793
127.0.0.1:6579> debug object mylist2
Value at:0x100f040d0 refcount:1 encoding:quicklist serializedlength:1934448 lru:10572985 lru_seconds_idle:179 ql_nodes:16394 ql_avg_node:61.00 ql_listpack_max:-2 ql_compressed:0 ql_uncompressed_size:132114758
```

After:

```
127.0.0.1:6379> memory usage mylist2 samples 1
(integer) 139384711
127.0.0.1:6379> memory usage mylist2 samples 10
(integer) 135151400
127.0.0.1:6379> memory usage mylist2 samples 100
(integer) 134969922
127.0.0.1:6379> memory usage mylist2 samples 1000
(integer) 134952806
127.0.0.1:6379> memory usage mylist2 samples 10000
(integer) 134951104
127.0.0.1:6379> memory usage mylist2 samples 100000
(integer) 134950896
127.0.0.1:6379> memory usage mylist2 samples 1000000
(integer) 134950896
127.0.0.1:6379> memory usage mylist2
(integer) 135377873
127.0.0.1:6379> debug object mylist2
Value at:0x102b04190 refcount:1 encoding:quicklist serializedlength:1934448 lru:10572991 lru_seconds_idle:227 ql_nodes:16394 ql_avg_node:61.00 ql_listpack_max:-2 ql_compressed:0 ql_uncompressed_size:132114758
```