### PR TITLE
Fix overflow on 32-bit systems when calculating idle time for eviction

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -162,7 +162,7 @@ int evictionPoolPopulate(redisDb *db, kvstore *samplekvs, struct evictionPoolEnt
             idle = 255-LFUDecrAndReturn(o);
         } else if (server.maxmemory_policy == MAXMEMORY_VOLATILE_TTL) {
             /* In this case the sooner the expire the better. */
-            idle = ULLONG_MAX - (long)dictGetVal(de);
+            idle = ULLONG_MAX - dictGetSignedIntegerVal(de);
         } else {
             serverPanic("Unknown eviction policy in evictionPoolPopulate()");
         }


### PR DESCRIPTION
Hello, I found that the `dictGetSignedIntegerVal` function should be used here, because in some cases (especially on 32-bit systems) long may be 4 bytes, and the ttl time saved in expires is a unix timestamp (millisecond value), which is more than 4 bytes. In this case, we may not be able to get the correct idle time, which may cause eviction disorder, in other words, keys that should be evicted later may be evicted earlier.