### PR TITLE
Fix typo in replication state log message

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -3017,7 +3017,7 @@ void syncWithMaster(connection *conn) {
     /* If reached this point, we should be in REPL_STATE_RECEIVE_PSYNC_REPLY. */
     if (server.repl_state != REPL_STATE_RECEIVE_PSYNC_REPLY) {
         serverLog(LL_WARNING,"syncWithMaster(): state machine error, "
-                             "state should be RECEIVE_PSYNC but is %d",
+                             "state should be RECEIVE_PSYNC_REPLY but is %d",
                              server.repl_state);
         goto error;
     }


### PR DESCRIPTION
The log message incorrectly referred to the expected state as `RECEIVE_PSYNC`, 
while it should be `RECEIVE_PSYNC_REPLY`. This aligns the log with the actual state check.