### PR TITLE
Reclaim page cache memory used by the AOF file after loading

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1725,6 +1725,9 @@ cleanup:
     server.current_client = old_cur_client;
     server.executing_client = old_exec_client;
     fclose(fp);
+    /* Reclaim page cache memory used by the AOF file in background. */
+    int fd = open(aof_filepath, O_RDONLY);
+    if (fd >= 0) bioCreateCloseJob(fd, 0, 1);
     sdsfree(aof_filepath);
     return ret;
 }

--- a/src/aof.c
+++ b/src/aof.c
@@ -1724,9 +1724,9 @@ cleanup:
     if (fakeClient) freeClient(fakeClient);
     server.current_client = old_cur_client;
     server.executing_client = old_exec_client;
+    int fd = dup(fileno(fp));
     fclose(fp);
     /* Reclaim page cache memory used by the AOF file in background. */
-    int fd = open(aof_filepath, O_RDONLY);
     if (fd >= 0) bioCreateCloseJob(fd, 0, 1);
     sdsfree(aof_filepath);
     return ret;


### PR DESCRIPTION
We can reclaim page cache memory used by the AOF file after loading, since we don't read AOF again, corresponding to https://github.com/redis/redis/pull/11248

There is a test after loading 9.5GB AOF, this PR uses much less `buff/cache` than unstable.
**Unstable**
```
$ free -m
               total        used        free      shared  buff/cache   available
Mem:           31293       16181        4562          13       10958       15111
Swap:              0           0           0
```
**This PR**
```
$ free -m
               total        used        free      shared  buff/cache   available
Mem:           31293       15391       15854          13         439       15902
Swap:              0           0           0
```