### PR TITLE
Do not send NL if replica client is already closed

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -4581,7 +4581,7 @@ void replicationCron(void) {
             (slave->replstate == SLAVE_STATE_WAIT_BGSAVE_END &&
              server.rdb_child_type != RDB_CHILD_TYPE_SOCKET));
 
-        if (is_presync) {
+        if (is_presync && !(slave->flags & CLIENT_CLOSE_ASAP)) {
             connWrite(slave->conn, "\n", 1);
         }
     }


### PR DESCRIPTION
In case a replica connection was closed mid-RDB, we should not send a \n to that replica, otherwise, it may reach the replica BEFORE it realizes that the RDB transfer failed, causing it to treat the \n as if it was read from the RDB stream.

This problem is rather rare, and when it happens, there's a chance for the replica to abort (exit on rdbReportCorruptRDB), rather than try to resync (rdbReportReadError)