### PR TITLE
free client output buffer async

### DIFF
--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -93,6 +93,15 @@ void lazyFreeReplicationBacklogRefMem(void *args[]) {
     atomicIncr(lazyfreed_objects,len);
 }
 
+/* Release a list. */
+void lazyFreeList(void *args[]) {
+    list *l = (list *)args[0];
+    size_t len = listLength(l);
+    listRelease(l);
+    atomicDecr(lazyfree_objects, len);
+    atomicIncr(lazyfreed_objects, len);
+}
+
 /* Return the number of currently pending objects to free. */
 size_t lazyfreeGetPendingObjectsCount(void) {
     size_t aux;
@@ -270,5 +279,15 @@ void freeReplicationBacklogRefMemAsync(list *blocks, rax *index) {
     } else {
         listRelease(blocks);
         raxFree(index);
+    }
+}
+
+/* Free the output buffer of client in async way. */
+void freeClientOutputBufferAsync(client *c) {
+    if (listLength(c->reply) > LAZYFREE_THRESHOLD) {
+        atomicIncr(lazyfree_objects, listLength(c->reply));
+        bioCreateLazyFreeJob(lazyFreeList, 1, c->reply);
+    } else {
+        listRelease(c->reply);
     }
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -1767,7 +1767,16 @@ void freeClient(client *c) {
     dictRelease(c->pubsubshard_channels);
 
     /* Free data structures. */
-    listRelease(c->reply);
+    /* If redis is evicting clients, we don't want to free the output buffer
+     * synchronously, because we need to release the memory asap to avoid
+     * more clients being evicted. Otherwise, we can free the output buffer
+     * synchronously to avoid blocking server since the output buffer list
+     * may be very long. */
+    if (server.is_evicting_clients) {
+        listRelease(c->reply);
+    } else {
+        freeClientOutputBufferAsync(c);
+    }
     zfree(c->buf);
     freeReplicaReferencedReplBuffer(c);
     freeClientArgv(c);
@@ -4528,6 +4537,7 @@ void evictClients(void) {
     size_t client_eviction_limit = getClientEvictionLimit();
     if (client_eviction_limit == 0)
         return;
+    server.is_evicting_clients = 1;
     while (server.stat_clients_type_memory[CLIENT_TYPE_NORMAL] +
            server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB] >= client_eviction_limit) {
         listNode *ln = listNext(&bucket_iter);
@@ -4570,4 +4580,5 @@ void evictClients(void) {
             listRewind(server.client_mem_usage_buckets[curr_bucket].clients, &bucket_iter);
         }
     }
+    server.is_evicting_clients = 0;
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -1768,9 +1768,9 @@ void freeClient(client *c) {
 
     /* Free data structures. */
     /* If redis is evicting clients, we don't want to free the output buffer
-     * synchronously, because we need to release the memory asap to avoid
+     * asynchronously, because we need to release the memory asap to avoid
      * more clients being evicted. Otherwise, we can free the output buffer
-     * synchronously to avoid blocking server since the output buffer list
+     * asynchronously to avoid blocking server since the output buffer list
      * may be very long. */
     if (server.is_evicting_clients) {
         listRelease(c->reply);

--- a/src/server.c
+++ b/src/server.c
@@ -2875,6 +2875,7 @@ void initServer(void) {
 
     if (server.maxmemory_clients != 0)
         initServerClientMemUsageBuckets();
+    server.is_evicting_clients = 0;
 }
 
 void initListeners(void) {

--- a/src/server.h
+++ b/src/server.h
@@ -1738,6 +1738,7 @@ struct redisServer {
 
     /* Stuff for client mem eviction */
     clientMemUsageBucket* client_mem_usage_buckets;
+    int is_evicting_clients;    /* Is redis server evicting clients. */
 
     rax *clients_timeout_table; /* Radix tree for blocked clients timeouts. */
     int execution_nesting;      /* Execution nesting level.
@@ -2811,6 +2812,7 @@ void unprotectClient(client *c);
 client *lookupClientByID(uint64_t id);
 int authRequired(client *c);
 void putClientInPendingWriteQueue(client *c);
+void freeClientOutputBufferAsync(client *c);
 /* reply macros */
 #define ADD_REPLY_BULK_CBUFFER_STRING_CONSTANT(c, str) addReplyBulkCBuffer(c, str, strlen(str))
 


### PR DESCRIPTION
If the client does not read the reply in time and reaches the `client-output-buffer-limit`, a long list of replies needs to be released when the connection is closed. For example, a list with about 50K nodes, which took nearly 50 milliseconds to release

```
27393:M 14 Feb 2025 22:41:43.951 * Freeing client output buffer, length: 52448, memory: 1075393792, cost: 49542 us
```

so we can release client reply list in async way if it is more than specific length, but we can not do this if the client is being evicted since we need to release the memory asap to avoid more clients being evicted.

- [ ] do we need a new configuration to control this approach