### PR TITLE
Fixed passing incorrect endtime value for module context

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1229,7 +1229,7 @@ static doneStatus defragModuleGlobals(void *ctx, monotime endtime) {
 
     /* Set up context for the module's defrag callback. */
     defrag_module_ctx->module_ctx->endtime = endtime;
-    serverAssert(!endtime || endtime - getMonotonicUs() < 3600000000LL); /* interval shouldn't exceed 1 hour  */
+    serverAssert(!endtime || endtime - getMonotonicUs() < 3600000LL); /* interval shouldn't exceed 1 hour  */
     defrag_module_ctx->module_ctx->cursor = &defrag_module_ctx->cursor;
 
     /* Call appropriate version of module's defrag callback:

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1229,7 +1229,8 @@ static doneStatus defragModuleGlobals(void *ctx, monotime endtime) {
 
     /* Set up context for the module's defrag callback. */
     defrag_module_ctx->module_ctx->endtime = endtime;
-    serverAssert(!endtime || endtime - getMonotonicUs() < 60*60*1000*1000LL); /* interval shouldn't exceed 1 hour  */
+    /* Interval shouldn't exceed 1 hour  */
+    serverAssert(!endtime || llabs((long long)endtime - (long long)getMonotonicUs()) < 60*60*1000*1000LL);
     defrag_module_ctx->module_ctx->cursor = &defrag_module_ctx->cursor;
 
     /* Call appropriate version of module's defrag callback:

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1229,7 +1229,7 @@ static doneStatus defragModuleGlobals(void *ctx, monotime endtime) {
 
     /* Set up context for the module's defrag callback. */
     defrag_module_ctx->module_ctx->endtime = endtime;
-    serverAssert(!endtime || endtime - getMonotonicUs() < 3600000LL); /* interval shouldn't exceed 1 hour  */
+    serverAssert(!endtime || endtime - getMonotonicUs() < 60*60*1000*1000LL); /* interval shouldn't exceed 1 hour  */
     defrag_module_ctx->module_ctx->cursor = &defrag_module_ctx->cursor;
 
     /* Call appropriate version of module's defrag callback:

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1226,11 +1226,11 @@ static doneStatus defragModuleGlobals(void *ctx, monotime endtime) {
         /* Module has been unloaded, nothing to defrag. */
         return DEFRAG_DONE;
     }
+    /* Interval shouldn't exceed 1 hour  */
+    serverAssert(!endtime || llabs((long long)endtime - (long long)getMonotonicUs()) < 60*60*1000*1000LL);
 
     /* Set up context for the module's defrag callback. */
     defrag_module_ctx->module_ctx->endtime = endtime;
-    /* Interval shouldn't exceed 1 hour  */
-    serverAssert(!endtime || llabs((long long)endtime - (long long)getMonotonicUs()) < 60*60*1000*1000LL);
     defrag_module_ctx->module_ctx->cursor = &defrag_module_ctx->cursor;
 
     /* Call appropriate version of module's defrag callback:

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1007,10 +1007,9 @@ int defragLaterItem(dictEntry *de, unsigned long *cursor, monotime endtime, int 
         } else if (ob->type == OBJ_STREAM) {
             return scanLaterStreamListpacks(ob, cursor, endtime);
         } else if (ob->type == OBJ_MODULE) {
-            long long endtimeWallClock = ustime() + (endtime - getMonotonicUs());
             robj keyobj;
             initStaticStringObject(keyobj, dictGetKey(de));
-            return moduleLateDefrag(&keyobj, ob, cursor, endtimeWallClock, dbid);
+            return moduleLateDefrag(&keyobj, ob, cursor, endtime, dbid);
         } else {
             *cursor = 0; /* object type may have changed since we schedule it for later */
         }
@@ -1230,6 +1229,7 @@ static doneStatus defragModuleGlobals(void *ctx, monotime endtime) {
 
     /* Set up context for the module's defrag callback. */
     defrag_module_ctx->module_ctx->endtime = endtime;
+    serverAssert(!endtime || endtime - getMonotonicUs() < 3600000000LL); /* interval shouldn't exceed 1 hour  */
     defrag_module_ctx->module_ctx->cursor = &defrag_module_ctx->cursor;
 
     /* Call appropriate version of module's defrag callback:

--- a/src/module.c
+++ b/src/module.c
@@ -14010,7 +14010,8 @@ int moduleLateDefrag(robj *key, robj *value, unsigned long *cursor, monotime end
     moduleType *mt = mv->type;
 
     RedisModuleDefragCtx defrag_ctx = { endtime, cursor, key, dbid};
-    serverAssert(!endtime || endtime - getMonotonicUs() < 60*60*1000*1000LL); /* interval shouldn't exceed 1 hour  */
+    /* Interval shouldn't exceed 1 hour. */
+    serverAssert(!endtime || llabs((long long)endtime - (long long)getMonotonicUs()) < 60*60*1000*1000LL);
 
     /* Invoke callback. Note that the callback may be missing if the key has been
      * replaced with a different type since our last visit.

--- a/src/module.c
+++ b/src/module.c
@@ -14010,6 +14010,7 @@ int moduleLateDefrag(robj *key, robj *value, unsigned long *cursor, monotime end
     moduleType *mt = mv->type;
 
     RedisModuleDefragCtx defrag_ctx = { endtime, cursor, key, dbid};
+    serverAssert(!endtime || endtime - getMonotonicUs() < 3600000000LL); /* interval shouldn't exceed 1 hour  */
 
     /* Invoke callback. Note that the callback may be missing if the key has been
      * replaced with a different type since our last visit.

--- a/src/module.c
+++ b/src/module.c
@@ -14010,7 +14010,7 @@ int moduleLateDefrag(robj *key, robj *value, unsigned long *cursor, monotime end
     moduleType *mt = mv->type;
 
     RedisModuleDefragCtx defrag_ctx = { endtime, cursor, key, dbid};
-    serverAssert(!endtime || endtime - getMonotonicUs() < 3600000000LL); /* interval shouldn't exceed 1 hour  */
+    serverAssert(!endtime || endtime - getMonotonicUs() < 3600000LL); /* interval shouldn't exceed 1 hour  */
 
     /* Invoke callback. Note that the callback may be missing if the key has been
      * replaced with a different type since our last visit.

--- a/src/module.c
+++ b/src/module.c
@@ -14009,9 +14009,10 @@ int moduleLateDefrag(robj *key, robj *value, unsigned long *cursor, monotime end
     moduleValue *mv = value->ptr;
     moduleType *mt = mv->type;
 
-    RedisModuleDefragCtx defrag_ctx = { endtime, cursor, key, dbid};
     /* Interval shouldn't exceed 1 hour. */
     serverAssert(!endtime || llabs((long long)endtime - (long long)getMonotonicUs()) < 60*60*1000*1000LL);
+
+    RedisModuleDefragCtx defrag_ctx = { endtime, cursor, key, dbid};
 
     /* Invoke callback. Note that the callback may be missing if the key has been
      * replaced with a different type since our last visit.

--- a/src/module.c
+++ b/src/module.c
@@ -14010,7 +14010,7 @@ int moduleLateDefrag(robj *key, robj *value, unsigned long *cursor, monotime end
     moduleType *mt = mv->type;
 
     RedisModuleDefragCtx defrag_ctx = { endtime, cursor, key, dbid};
-    serverAssert(!endtime || endtime - getMonotonicUs() < 3600000LL); /* interval shouldn't exceed 1 hour  */
+    serverAssert(!endtime || endtime - getMonotonicUs() < 60*60*1000*1000LL); /* interval shouldn't exceed 1 hour  */
 
     /* Invoke callback. Note that the callback may be missing if the key has been
      * replaced with a different type since our last visit.

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -27,7 +27,6 @@ unsigned long int defrag_started = 0;
 unsigned long int defrag_ended = 0;
 unsigned long int global_strings_attempts = 0;
 unsigned long int global_strings_defragged = 0;
-unsigned long int global_strings_pauses = 0;
 unsigned long int global_dicts_resumes = 0;  /* Number of dict defragmentation resumed from a previous break */
 unsigned long int global_dicts_attempts = 0; /* Number of attempts to defragment dictionary */
 unsigned long int global_dicts_defragged = 0; /* Number of dictionaries successfully defragmented */
@@ -65,7 +64,6 @@ static int defragGlobalStrings(RedisModuleDefragCtx *ctx)
         }
 
         if (RedisModule_DefragShouldStop(ctx)) {
-            global_strings_pauses++;
             RedisModule_DefragCursorSet(ctx, cursor);
             return 1;
         }
@@ -216,7 +214,6 @@ static void FragInfo(RedisModuleInfoCtx *ctx, int for_crash_report) {
     RedisModule_InfoAddFieldLongLong(ctx, "datatype_wrong_cursor", datatype_wrong_cursor);
     RedisModule_InfoAddFieldLongLong(ctx, "global_strings_attempts", global_strings_attempts);
     RedisModule_InfoAddFieldLongLong(ctx, "global_strings_defragged", global_strings_defragged);
-    RedisModule_InfoAddFieldLongLong(ctx, "global_strings_pauses", global_strings_pauses);
     RedisModule_InfoAddFieldLongLong(ctx, "global_dicts_resumes", global_dicts_resumes);
     RedisModule_InfoAddFieldLongLong(ctx, "global_dicts_attempts", global_dicts_attempts);
     RedisModule_InfoAddFieldLongLong(ctx, "global_dicts_defragged", global_dicts_defragged);
@@ -249,7 +246,6 @@ static int fragResetStatsCommand(RedisModuleCtx *ctx, RedisModuleString **argv, 
     datatype_wrong_cursor = 0;
     global_strings_attempts = 0;
     global_strings_defragged = 0;
-    global_strings_pauses = 0;
     global_dicts_resumes = 0;
     global_dicts_attempts = 0;
     global_dicts_defragged = 0;

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -43,8 +43,7 @@ static void createGlobalStrings(RedisModuleCtx *ctx, unsigned long count)
     global_strings = RedisModule_Alloc(sizeof(RedisModuleString *) * count);
 
     for (unsigned long i = 0; i < count; i++) {
-        char buf[64] = {0};
-        global_strings[i] = RedisModule_CreateString(ctx, buf, 64);
+        global_strings[i] = RedisModule_CreateStringFromLongLong(ctx, i);
     }
 }
 
@@ -75,7 +74,7 @@ static int defragGlobalStrings(RedisModuleDefragCtx *ctx)
 static void createFragGlobalStrings(RedisModuleCtx *ctx) {
     for (unsigned long i = 0; i < global_strings_len; i++) {
         if (i % 2 == 1) {
-            RedisModule_FreeString(ctx, global_strings[i]);
+            RedisModule_FreeString(NULL, global_strings[i]);
             global_strings[i] = NULL;
         }
     }
@@ -179,18 +178,18 @@ static int defragGlobalDicts(RedisModuleDefragCtx *ctx) {
 typedef enum { DEFRAG_NOT_START, DEFRAG_STRING, DEFRAG_DICT } defrag_module_stage;
 static int defragGlobal(RedisModuleDefragCtx *ctx) {
     static defrag_module_stage stage = DEFRAG_NOT_START;
-    if (stage == DEFRAG_NOT_START) {
-        stage = DEFRAG_STRING; /* Start a new global defrag. */
-    }
+    // if (stage == DEFRAG_NOT_START) {
+    //     stage = DEFRAG_STRING; /* Start a new global defrag. */
+    // }
 
-    if (stage == DEFRAG_STRING) {
+    // if (stage == DEFRAG_STRING) {
         if (defragGlobalStrings(ctx) != 0) return 1;
-        stage = DEFRAG_DICT;
-    }
-    if (stage == DEFRAG_DICT) {
-        if (defragGlobalDicts(ctx) != 0) return 1;
-        stage = DEFRAG_NOT_START;
-    }
+    //     stage = DEFRAG_DICT;
+    // }
+    // if (stage == DEFRAG_DICT) {
+    //     if (defragGlobalDicts(ctx) != 0) return 1;
+    //     stage = DEFRAG_NOT_START;
+    // }
     return 0;
 }
 
@@ -300,7 +299,7 @@ static int fragCreateGlobalCommand(RedisModuleCtx *ctx, RedisModuleString **argv
         return RedisModule_WrongArity(ctx);
 
     createFragGlobalStrings(ctx);
-    createFragGlobalDicts(ctx);
+    // createFragGlobalDicts(ctx);
     RedisModule_ReplyWithSimpleString(ctx, "OK");
     return REDISMODULE_OK;
 }

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -74,7 +74,7 @@ static int defragGlobalStrings(RedisModuleDefragCtx *ctx)
 static void createFragGlobalStrings(RedisModuleCtx *ctx) {
     for (unsigned long i = 0; i < global_strings_len; i++) {
         if (i % 2 == 1) {
-            RedisModule_FreeString(NULL, global_strings[i]);
+            RedisModule_FreeString(ctx, global_strings[i]);
             global_strings[i] = NULL;
         }
     }

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -43,7 +43,8 @@ static void createGlobalStrings(RedisModuleCtx *ctx, unsigned long count)
     global_strings = RedisModule_Alloc(sizeof(RedisModuleString *) * count);
 
     for (unsigned long i = 0; i < count; i++) {
-        global_strings[i] = RedisModule_CreateStringFromLongLong(ctx, i);
+        char buf[64] = {0};
+        global_strings[i] = RedisModule_CreateString(ctx, buf, 64);
     }
 }
 

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -178,18 +178,18 @@ static int defragGlobalDicts(RedisModuleDefragCtx *ctx) {
 typedef enum { DEFRAG_NOT_START, DEFRAG_STRING, DEFRAG_DICT } defrag_module_stage;
 static int defragGlobal(RedisModuleDefragCtx *ctx) {
     static defrag_module_stage stage = DEFRAG_NOT_START;
-    // if (stage == DEFRAG_NOT_START) {
-    //     stage = DEFRAG_STRING; /* Start a new global defrag. */
-    // }
+    if (stage == DEFRAG_NOT_START) {
+        stage = DEFRAG_STRING; /* Start a new global defrag. */
+    }
 
-    // if (stage == DEFRAG_STRING) {
+    if (stage == DEFRAG_STRING) {
         if (defragGlobalStrings(ctx) != 0) return 1;
-    //     stage = DEFRAG_DICT;
-    // }
-    // if (stage == DEFRAG_DICT) {
-    //     if (defragGlobalDicts(ctx) != 0) return 1;
-    //     stage = DEFRAG_NOT_START;
-    // }
+        stage = DEFRAG_DICT;
+    }
+    if (stage == DEFRAG_DICT) {
+        if (defragGlobalDicts(ctx) != 0) return 1;
+        stage = DEFRAG_NOT_START;
+    }
     return 0;
 }
 
@@ -299,7 +299,7 @@ static int fragCreateGlobalCommand(RedisModuleCtx *ctx, RedisModuleString **argv
         return RedisModule_WrongArity(ctx);
 
     createFragGlobalStrings(ctx);
-    // createFragGlobalDicts(ctx);
+    createFragGlobalDicts(ctx);
     RedisModule_ReplyWithSimpleString(ctx, "OK");
     return REDISMODULE_OK;
 }

--- a/tests/unit/moduleapi/datatype.tcl
+++ b/tests/unit/moduleapi/datatype.tcl
@@ -193,6 +193,7 @@ start_server {tags {"modules"}} {
                 set end_time [expr {[clock seconds] + 10}]
                 set speed_restored 0
                 while {[clock seconds] < $end_time} {
+                    for {set i 0} {$i < 500} {incr i} {
                     switch [expr {int(rand() * 3)}] {
                         0 {
                             # Randomly delete a key
@@ -213,14 +214,16 @@ start_server {tags {"modules"}} {
                             set random_key "key_[expr {int(rand() * 10000)}]"
                             r datatype.set $random_key 1 $dummy
                         }
-                    }
+                    } ;# end of switch
+                    } ;# end of for
 
                     # Wait for defragmentation speed to restore.
-                    if {[s active_defrag_running] > 25} {
+                    if {{[count_log_message $loglines "*Starting active defrag, frag=*%, frag_bytes=*, cpu=5?%*"]} > 1} {
                         set speed_restored 1
                         break;
                     }
                 }
+                # Make sure the speed is restored
                 assert_equal $speed_restored 1
 
                 # After the traffic disappears, the defragmentation speed will decrease again.

--- a/tests/unit/moduleapi/defrag.tcl
+++ b/tests/unit/moduleapi/defrag.tcl
@@ -61,7 +61,7 @@ start_server {tags {"modules"} overrides {{save ""}}} {
 
             set info [r info defragtest_stats]
             assert {[getInfoProperty $info defragtest_global_strings_attempts] > 0}
-            assert {[getInfoProperty $info defragtest_global_strings_pauses] > 0}
+            assert {[getInfoProperty $info defragtest_global_strings_defragged] > 0}
             assert {[getInfoProperty $info defragtest_global_dicts_attempts] > 0}
             assert {[getInfoProperty $info defragtest_global_dicts_defragged] > 0}
             assert_morethan [getInfoProperty $info defragtest_defrag_started] 0

--- a/tests/unit/moduleapi/defrag.tcl
+++ b/tests/unit/moduleapi/defrag.tcl
@@ -61,7 +61,6 @@ start_server {tags {"modules"} overrides {{save ""}}} {
 
             set info [r info defragtest_stats]
             assert {[getInfoProperty $info defragtest_global_strings_attempts] > 0}
-            assert {[getInfoProperty $info defragtest_global_strings_defragged] > 0}
             assert {[getInfoProperty $info defragtest_global_dicts_attempts] > 0}
             assert {[getInfoProperty $info defragtest_global_dicts_defragged] > 0}
             assert_morethan [getInfoProperty $info defragtest_defrag_started] 0


### PR DESCRIPTION
1) Fix a bug that passing an incorrect endtime to module.
   This bug was found by @ShooterIT.
   After #13814, all endtime will be monotonic time, and we should no longer convert it to ustime relative.
   Add assertions to prevent endtime from being much larger thatn the current time.

2) Fix a race in test `Reduce defrag CPU usage when module data can't be defragged`