### PR TITLE
Stabilize tcl test cases

### DIFF
--- a/tests/integration/dismiss-mem.tcl
+++ b/tests/integration/dismiss-mem.tcl
@@ -89,6 +89,7 @@ start_server {tags {"dismiss external:skip"}} {
         start_server {} {
             r slaveof [srv -1 host] [srv -1 port]
             wait_for_sync r
+            waitForBgsave $master
 
             set bigstr [string repeat A 8192]
             for {set i 0} {$i < 20} {incr i} {

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -1200,8 +1200,8 @@ start_server {tags {"external:skip needs:debug"}} {
         test "HSETEX - Test 'EXAT' flag ($type)" {
             r del myhash
             r hset myhash f1 v1 f2 v2
-            assert_equal [r hsetex myhash EXAT 4000000000 FIELDS 1 f3 v3] 1
-            assert_range [expr [r httl myhash FIELDS 1 f3] + [clock seconds]] 3900000000 4000000000
+            assert_equal [r hsetex myhash EXAT [expr [clock seconds] + 10] FIELDS 1 f3 v3] 1
+            assert_range [r httl myhash FIELDS 1 f3] 5 10
         }
 
         test "HSETEX - Test 'PX' flag ($type)" {
@@ -1213,8 +1213,8 @@ start_server {tags {"external:skip needs:debug"}} {
         test "HSETEX - Test 'PXAT' flag ($type)" {
             r del myhash
             r hset myhash f1 v2 f2 v2 f3 v3
-            assert_equal [r hsetex myhash PXAT 4000000000000 FIELDS 1 f2 v2] 1
-            assert_range [expr [r httl myhash FIELDS 1 f2] + [clock seconds]] 3900000000 4000000000
+            assert_equal [r hsetex myhash PXAT [expr [clock milliseconds] + 10000] FIELDS 1 f2 v2] 1
+            assert_range [r httl myhash FIELDS 1 f2] 5 10
         }
 
         test "HSETEX - Test 'KEEPTTL' flag ($type)" {

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -937,8 +937,8 @@ start_server {tags {"external:skip needs:debug"}} {
         test "HGETEX - Test 'EXAT' flag ($type)" {
             r del myhash
             r hset myhash field1 value1 field2 value2 field3 value3
-            assert_equal [r hgetex myhash EXAT 4000000000 FIELDS 1 field2] [list "value2"]
-            assert_range [expr [r httl myhash FIELDS 1 field2] + [clock seconds]] 3900000000 4000000000
+            assert_equal [r hgetex myhash EXAT [expr [clock seconds] + 10] FIELDS 1 field2] [list "value2"]
+            assert_range [r httl myhash FIELDS 1 field2] 5 10
         }
 
         test "HGETEX - Test 'PX' flag ($type)" {
@@ -951,8 +951,8 @@ start_server {tags {"external:skip needs:debug"}} {
         test "HGETEX - Test 'PXAT' flag ($type)" {
             r del myhash
             r hset myhash field1 value1 field2 value2 field3 value3
-            assert_equal [r hgetex myhash PXAT 4000000000000 FIELDS 1 field3] [list "value3"]
-            assert_range [expr [r httl myhash FIELDS 1 field3] + [clock seconds]] 3900000000 4000000000
+            assert_equal [r hgetex myhash PXAT [expr [clock milliseconds] + 10000] FIELDS 1 field3] [list "value3"]
+            assert_range [r httl myhash FIELDS 1 field3] 5 10
         }
 
         test "HGETEX - Test 'PERSIST' flag ($type)" {


### PR DESCRIPTION
recently i encountered some errors as bellow,

HGETEX/HSETEX with PXAT/EXAT option, after getting ttl, we calculate current time by `[clock seconds]` that may have a delay that causes results greater than expected

```
*** [err]: HGETEX - Test 'PXAT' flag (listpackex) in tests/unit/type/hash-field-expire.tcl
Expected '4000000001' to be between to '3900000000' and '4000000000' (context: type eval line 5 cmd {assert_range [expr [r httl myhash FIELDS 1 field3] + [clock seconds]] 3900000000 4000000000} proc ::test)

*** [err]: HGETEX - Test 'EXAT' flag (listpackex) in tests/unit/type/hash-field-expire.tcl
Expected '4000000001' to be between to '3900000000' and '4000000000' (context: type eval line 5 cmd {assert_range [expr [r httl myhash FIELDS 1 field2] + [clock seconds]] 3900000000 4000000000} proc ::test)
```

Dismiss memory test error, now we introduced rdb-channel replication, the full synchronization might finish before the child process exits. so we may fail if calling `bgsave` immediately after full sync
```
Executing test client: ERR Background save already in progress.
ERR Background save already in progress
    while executing
"$master bgsave"
    ("uplevel" body line 10)
    invoked from within
"uplevel 1 $code "
    (procedure "start_server" line 2)
    invoked from within
"start_server {} {
            r slaveof [srv -1 host] [srv -1 port]
            wait_for_sync r
            #waitForBgsave $master

            set bi..."
    ("uplevel" body line 3)
    invoked from within
```

full replication logs are as bellow
```
14074:M 25 Feb 2025 12:01:35.421 * Replica 127.0.0.1:6380 asks for synchronization
14074:M 25 Feb 2025 12:01:35.421 * Full resync requested by replica 127.0.0.1:6380 (rdb-channel)
14074:M 25 Feb 2025 12:01:35.421 * Delay next BGSAVE for diskless SYNC
14074:M 25 Feb 2025 12:01:40.522 * Starting BGSAVE for SYNC with target: replicas sockets (rdb-channel)
14074:M 25 Feb 2025 12:01:40.522 * Starting to deliver RDB and replication stream to replica: 127.0.0.1:6380
14074:M 25 Feb 2025 12:01:40.522 * Background RDB transfer started by pid 14189 to replica socket
14189:C 25 Feb 2025 12:01:40.523 * Fork CoW for RDB: current 0 MB, peak 0 MB, average 0 MB
14074:M 25 Feb 2025 12:01:40.532 * Connection with replica (rdbchannel) 127.0.0.1:6380 lost.
14074:M 25 Feb 2025 12:01:40.532 * Synchronization with replica 127.0.0.1:6380 succeeded
14074:M 25 Feb 2025 12:01:40.623 * Background RDB transfer terminated with success
```