### PR TITLE
Enable the callback to be NULL for RM_DefragRedisModuleDict() and reduce the system calls of RM_DefragShouldStop()

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -13830,7 +13830,9 @@ int RM_DefragShouldStop(RedisModuleDefragCtx *ctx) {
     if (!ctx->endtime) /* Return if no time limit set */
         return 0;
 
-    /* Check time when any threshold is reached. */
+    /* We use certain thresholds to avoid excessive system calls.
+     * Time checks are only performed when any threshold is reached,
+     * which means we might slightly exceed the expected end time. */
     if (server.stat_active_defrag_hits - ctx->last_stop_check_hits >= 512 ||
         server.stat_active_defrag_misses - ctx->last_stop_check_misses >= 1024)
     {

--- a/src/module.c
+++ b/src/module.c
@@ -13983,9 +13983,11 @@ RedisModuleDict *RM_DefragRedisModuleDict(RedisModuleDefragCtx *ctx, RedisModule
     }
 
     while (raxNext(&ri)) {
-        void *newdata = valueCB(ctx, ri.data, ri.key, ri.key_len);
-        if (newdata)
-            raxSetData(ri.node, ri.data=newdata);
+        if (valueCB) {
+            void *newdata = valueCB(ctx, ri.data, ri.key, ri.key_len);
+            if (newdata)
+                raxSetData(ri.node, ri.data=newdata);
+        }
         if (RM_DefragShouldStop(ctx)) {
             if (*seekTo) RM_FreeString(NULL, *seekTo);
             *seekTo = RM_CreateString(NULL, (const char *)ri.key, ri.key_len);

--- a/src/module.c
+++ b/src/module.c
@@ -13828,7 +13828,27 @@ int RM_RegisterDefragCallbacks(RedisModuleCtx *ctx, RedisModuleDefragFunc start,
  * so it generally makes sense to do small batches of work in between calls.
  */
 int RM_DefragShouldStop(RedisModuleDefragCtx *ctx) {
-    return (ctx->endtime != 0 && ctx->endtime <= getMonotonicUs());
+    if (ctx->stopping) /* Return immediately if already stopping */
+        return 1;
+    if (!ctx->endtime) /* Return if no time limit set */
+        return 0;
+        
+    /* Check if we need to stop, but to avoid excessive system calls,
+     * only check time when any threshold is reached. */
+    if (++ctx->ops_count > 128 ||
+        (ctx->last_stop_check_hits != -1 && server.stat_active_defrag_hits - ctx->last_stop_check_hits >= 512) ||
+        (ctx->last_stop_check_misses != -1 && server.stat_active_defrag_misses - ctx->last_stop_check_misses >= 1024))
+    {
+        if (ctx->endtime <= getMonotonicUs()) {
+            ctx->stopping = 1;
+            return 1;
+        }
+        ctx->ops_count = 0;
+    }
+
+    ctx->last_stop_check_hits = server.stat_active_defrag_hits;
+    ctx->last_stop_check_misses = server.stat_active_defrag_misses;
+    return 0;
 }
 
 /* Store an arbitrary cursor value for future re-use.
@@ -14014,7 +14034,7 @@ int moduleLateDefrag(robj *key, robj *value, unsigned long *cursor, monotime end
     /* Interval shouldn't exceed 1 hour. */
     serverAssert(!endtime || llabs((long long)endtime - (long long)getMonotonicUs()) < 60*60*1000*1000LL);
 
-    RedisModuleDefragCtx defrag_ctx = { endtime, cursor, key, dbid};
+    RedisModuleDefragCtx defrag_ctx = { endtime, cursor, key, dbid, -1, -1};
 
     /* Invoke callback. Note that the callback may be missing if the key has been
      * replaced with a different type since our last visit.
@@ -14063,7 +14083,7 @@ int moduleDefragValue(robj *key, robj *value, int dbid) {
         return 0;  /* Defrag later */
     }
 
-    RedisModuleDefragCtx defrag_ctx = { 0, NULL, key, dbid };
+    RedisModuleDefragCtx defrag_ctx = { 0, NULL, key, dbid, -1, -1 };
     mt->defrag(&defrag_ctx, key, &mv->value);
     return 1;
 }
@@ -14072,7 +14092,7 @@ int moduleDefragValue(robj *key, robj *value, int dbid) {
 void moduleDefragStart(void) {
     dictForEach(modules, struct RedisModule, module, 
         if (module->defrag_start_cb) {
-            RedisModuleDefragCtx defrag_ctx = { 0, NULL, NULL, -1};
+            RedisModuleDefragCtx defrag_ctx = { 0, NULL, NULL, -1, -1, -1 };
             module->defrag_start_cb(&defrag_ctx);
         }
     );
@@ -14082,7 +14102,7 @@ void moduleDefragStart(void) {
 void moduleDefragEnd(void) {
     dictForEach(modules, struct RedisModule, module, 
         if (module->defrag_end_cb) {
-            RedisModuleDefragCtx defrag_ctx = { 0, NULL, NULL, -1};
+            RedisModuleDefragCtx defrag_ctx = { 0, NULL, NULL, -1, -1, -1 };
             module->defrag_end_cb(&defrag_ctx);
         }
     );

--- a/src/module.c
+++ b/src/module.c
@@ -13824,8 +13824,9 @@ int RM_RegisterDefragCallbacks(RedisModuleCtx *ctx, RedisModuleDefragFunc start,
  * When stopped and more work is left to be done, the callback should
  * return 1. Otherwise, it should return 0.
  *
- * NOTE: Modules should consider the frequency in which this function is called,
- * so it generally makes sense to do small batches of work in between calls.
+ * NOTE: We use certain thresholds to avoid excessive system calls.
+ * Time checks are only performed when any threshold is reached,
+ * which means we might slightly exceed the expected end time.
  */
 int RM_DefragShouldStop(RedisModuleDefragCtx *ctx) {
     if (ctx->stopping) /* Return immediately if already stopping */
@@ -13833,8 +13834,7 @@ int RM_DefragShouldStop(RedisModuleDefragCtx *ctx) {
     if (!ctx->endtime) /* Return if no time limit set */
         return 0;
         
-    /* Check if we need to stop, but to avoid excessive system calls,
-     * only check time when any threshold is reached. */
+    /* Check time when any threshold is reached. */
     if (++ctx->ops_count > 128 ||
         (ctx->last_stop_check_hits != -1 && server.stat_active_defrag_hits - ctx->last_stop_check_hits >= 512) ||
         (ctx->last_stop_check_misses != -1 && server.stat_active_defrag_misses - ctx->last_stop_check_misses >= 1024))

--- a/src/module.c
+++ b/src/module.c
@@ -13823,31 +13823,24 @@ int RM_RegisterDefragCallbacks(RedisModuleCtx *ctx, RedisModuleDefragFunc start,
  *
  * When stopped and more work is left to be done, the callback should
  * return 1. Otherwise, it should return 0.
- *
- * NOTE: We use certain thresholds to avoid excessive system calls.
- * Time checks are only performed when any threshold is reached,
- * which means we might slightly exceed the expected end time.
  */
 int RM_DefragShouldStop(RedisModuleDefragCtx *ctx) {
     if (ctx->stopping) /* Return immediately if already stopping */
         return 1;
     if (!ctx->endtime) /* Return if no time limit set */
         return 0;
-        
+
     /* Check time when any threshold is reached. */
-    if (++ctx->ops_count > 128 ||
-        (ctx->last_stop_check_hits != -1 && server.stat_active_defrag_hits - ctx->last_stop_check_hits >= 512) ||
-        (ctx->last_stop_check_misses != -1 && server.stat_active_defrag_misses - ctx->last_stop_check_misses >= 1024))
+    if (server.stat_active_defrag_hits - ctx->last_stop_check_hits >= 512 ||
+        server.stat_active_defrag_misses - ctx->last_stop_check_misses >= 1024)
     {
         if (ctx->endtime <= getMonotonicUs()) {
             ctx->stopping = 1;
             return 1;
         }
-        ctx->ops_count = 0;
+        ctx->last_stop_check_hits = server.stat_active_defrag_hits;
+        ctx->last_stop_check_misses = server.stat_active_defrag_misses;
     }
-
-    ctx->last_stop_check_hits = server.stat_active_defrag_hits;
-    ctx->last_stop_check_misses = server.stat_active_defrag_misses;
     return 0;
 }
 
@@ -14034,7 +14027,7 @@ int moduleLateDefrag(robj *key, robj *value, unsigned long *cursor, monotime end
     /* Interval shouldn't exceed 1 hour. */
     serverAssert(!endtime || llabs((long long)endtime - (long long)getMonotonicUs()) < 60*60*1000*1000LL);
 
-    RedisModuleDefragCtx defrag_ctx = { endtime, cursor, key, dbid, -1, -1};
+    RedisModuleDefragCtx defrag_ctx = INIT_MODULE_DEFRAG_CTX(endtime, cursor, key, dbid);
 
     /* Invoke callback. Note that the callback may be missing if the key has been
      * replaced with a different type since our last visit.
@@ -14083,7 +14076,7 @@ int moduleDefragValue(robj *key, robj *value, int dbid) {
         return 0;  /* Defrag later */
     }
 
-    RedisModuleDefragCtx defrag_ctx = { 0, NULL, key, dbid, -1, -1 };
+    RedisModuleDefragCtx defrag_ctx = INIT_MODULE_DEFRAG_CTX(0, NULL, key, dbid);
     mt->defrag(&defrag_ctx, key, &mv->value);
     return 1;
 }
@@ -14092,7 +14085,7 @@ int moduleDefragValue(robj *key, robj *value, int dbid) {
 void moduleDefragStart(void) {
     dictForEach(modules, struct RedisModule, module, 
         if (module->defrag_start_cb) {
-            RedisModuleDefragCtx defrag_ctx = { 0, NULL, NULL, -1, -1, -1 };
+            RedisModuleDefragCtx defrag_ctx = INIT_MODULE_DEFRAG_CTX(0, NULL, NULL, -1);
             module->defrag_start_cb(&defrag_ctx);
         }
     );
@@ -14102,7 +14095,7 @@ void moduleDefragStart(void) {
 void moduleDefragEnd(void) {
     dictForEach(modules, struct RedisModule, module, 
         if (module->defrag_end_cb) {
-            RedisModuleDefragCtx defrag_ctx = { 0, NULL, NULL, -1, -1, -1 };
+            RedisModuleDefragCtx defrag_ctx = INIT_MODULE_DEFRAG_CTX(0, NULL, NULL, -1);
             module->defrag_end_cb(&defrag_ctx);
         }
     );

--- a/src/server.h
+++ b/src/server.h
@@ -912,8 +912,13 @@ struct RedisModuleDefragCtx {
     long long last_stop_check_hits; /* Number of defrag hits at last check. */
     long long last_stop_check_misses; /* Number of defrag misses at last check. */
     int stopping; /* Flag indicating if defrag should stop. */
-    int ops_count; /* Counter for operations since last time check. */
 };
+#define INIT_MODULE_DEFRAG_CTX(endtime, cursor, key, dbid) \
+    ((RedisModuleDefragCtx) {               \
+        (endtime), (cursor), (key), (dbid), \
+        server.stat_active_defrag_hits,     \
+        server.stat_active_defrag_misses    \
+    })
 
 /* This is a wrapper for the 'rio' streams used inside rdb.c in Redis, so that
  * the user does not have to take the total count of the written bytes nor

--- a/src/server.h
+++ b/src/server.h
@@ -909,6 +909,10 @@ struct RedisModuleDefragCtx {
     unsigned long *cursor;
     struct redisObject *key; /* Optional name of key processed, NULL when unknown. */
     int dbid;                /* The dbid of the key being processed, -1 when unknown. */
+    long last_stop_check_hits; /* Number of successful defrag hits at last check. */
+    long last_stop_check_misses; /* Number of defrag misses at last check. */
+    int stopping; /* Flag indicating if defrag should stop. */
+    int ops_count; /* Counter for operations since last time check. */
 };
 
 /* This is a wrapper for the 'rio' streams used inside rdb.c in Redis, so that

--- a/src/server.h
+++ b/src/server.h
@@ -909,7 +909,7 @@ struct RedisModuleDefragCtx {
     unsigned long *cursor;
     struct redisObject *key; /* Optional name of key processed, NULL when unknown. */
     int dbid;                /* The dbid of the key being processed, -1 when unknown. */
-    long last_stop_check_hits; /* Number of successful defrag hits at last check. */
+    long last_stop_check_hits; /* Number of defrag hits at last check. */
     long last_stop_check_misses; /* Number of defrag misses at last check. */
     int stopping; /* Flag indicating if defrag should stop. */
     int ops_count; /* Counter for operations since last time check. */

--- a/src/server.h
+++ b/src/server.h
@@ -909,8 +909,8 @@ struct RedisModuleDefragCtx {
     unsigned long *cursor;
     struct redisObject *key; /* Optional name of key processed, NULL when unknown. */
     int dbid;                /* The dbid of the key being processed, -1 when unknown. */
-    long last_stop_check_hits; /* Number of defrag hits at last check. */
-    long last_stop_check_misses; /* Number of defrag misses at last check. */
+    long long last_stop_check_hits; /* Number of defrag hits at last check. */
+    long long last_stop_check_misses; /* Number of defrag misses at last check. */
     int stopping; /* Flag indicating if defrag should stop. */
     int ops_count; /* Counter for operations since last time check. */
 };

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -30,6 +30,7 @@ unsigned long int global_strings_defragged = 0;
 unsigned long int global_dicts_resumes = 0;  /* Number of dict defragmentation resumed from a previous break */
 unsigned long int global_dicts_attempts = 0; /* Number of attempts to defragment dictionary */
 unsigned long int global_dicts_defragged = 0; /* Number of dictionaries successfully defragmented */
+unsigned long int global_dicts_items_defragged = 0; /* Number of dictionaries items successfully defragmented */
 
 unsigned long global_strings_len = 0;
 RedisModuleString **global_strings = NULL;
@@ -132,7 +133,9 @@ static void *defragGlobalDictValueCB(RedisModuleDefragCtx *ctx, void *data, unsi
     REDISMODULE_NOT_USED(key);
     REDISMODULE_NOT_USED(keylen);
     if (!data) return NULL;
-    return RedisModule_DefragRedisModuleString(ctx, data);
+    void *new = RedisModule_DefragAlloc(ctx, data);
+    if (new) global_dicts_items_defragged++;
+    return new;
 }
 
 static int defragGlobalDicts(RedisModuleDefragCtx *ctx) {
@@ -217,6 +220,7 @@ static void FragInfo(RedisModuleInfoCtx *ctx, int for_crash_report) {
     RedisModule_InfoAddFieldLongLong(ctx, "global_dicts_resumes", global_dicts_resumes);
     RedisModule_InfoAddFieldLongLong(ctx, "global_dicts_attempts", global_dicts_attempts);
     RedisModule_InfoAddFieldLongLong(ctx, "global_dicts_defragged", global_dicts_defragged);
+    RedisModule_InfoAddFieldLongLong(ctx, "global_dicts_items_defragged", global_dicts_items_defragged);
     RedisModule_InfoAddFieldLongLong(ctx, "defrag_started", defrag_started);
     RedisModule_InfoAddFieldLongLong(ctx, "defrag_ended", defrag_ended);
 }
@@ -249,6 +253,7 @@ static int fragResetStatsCommand(RedisModuleCtx *ctx, RedisModuleString **argv, 
     global_dicts_resumes = 0;
     global_dicts_attempts = 0;
     global_dicts_defragged = 0;
+    global_dicts_items_defragged = 0;
     defrag_started = 0;
     defrag_ended = 0;
 

--- a/tests/unit/moduleapi/defrag.tcl
+++ b/tests/unit/moduleapi/defrag.tcl
@@ -63,6 +63,7 @@ start_server {tags {"modules"} overrides {{save ""}}} {
             assert {[getInfoProperty $info defragtest_global_strings_attempts] > 0}
             assert {[getInfoProperty $info defragtest_global_dicts_attempts] > 0}
             assert {[getInfoProperty $info defragtest_global_dicts_defragged] > 0}
+            assert {[getInfoProperty $info defragtest_global_dicts_items_defragged] > 0}
             assert_morethan [getInfoProperty $info defragtest_defrag_started] 0
             assert_morethan [getInfoProperty $info defragtest_defrag_ended] 0
             assert_morethan [getInfoProperty $info defragtest_global_dicts_resumes] [getInfoProperty $info defragtest_defrag_ended]


### PR DESCRIPTION
1) Enable the callback to be NULL for RM_DefragRedisModuleDict()
    Because the dictionary may store only the key without the value.

2) Reduce the system calls of RM_DefragShouldStop()
     The API checks the following thresholds before performing a time check: over 512 defrag hits, or over 1024 defrag misses, and performs the time judgment if any of these thresholds are reached.

3) Added defragmentation statistics for dictionary items to cover the associated code for RM_DefragRedisModuleDict().

4) Removed `module_ctx` from `defragModuleCtx` struct, which can be replaced by a temporary variable.