### PR TITLE
Fix string2d usage in case of hexadecimal strings parsing and overflow

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1544,7 +1544,6 @@ static void test_string2l(void) {
 #endif
 }
 
-
 static void test_string2d(void) {
     char buf[1024];
     double v;

--- a/src/util.c
+++ b/src/util.c
@@ -674,7 +674,7 @@ int string2d(const char *s, size_t slen, double *dp) {
     }
     if (unlikely(errno == EINVAL ||
         (errno == ERANGE &&
-        (*dp == HUGE_VAL || *dp == -HUGE_VAL || fpclassify(*dp) == FP_ZERO)) ||
+            (*dp == HUGE_VAL || *dp == -HUGE_VAL || fpclassify(*dp) == FP_ZERO)) ||
         isnan(*dp)))
         return 0;
     return 1;

--- a/src/util.c
+++ b/src/util.c
@@ -661,12 +661,21 @@ int string2d(const char *s, size_t slen, double *dp) {
     errno = 0;
     char *eptr;
     *dp = fast_float_strtod(s, &eptr);
-    if (slen == 0 ||
+    if (unlikely(slen == 0 ||
         isspace(((const char*)s)[0]) ||
-        (size_t)(eptr-(char*)s) != slen ||
-        (errno == ERANGE &&
-            (*dp == HUGE_VAL || *dp == -HUGE_VAL || fpclassify(*dp) == FP_ZERO)) ||
-        isnan(*dp))
+        isnan(*dp)))
+        return 0;
+    /* If `fast_float_strtod` didn't consume full input, try `strtod`
+     * Given fast_float does not support hexadecimal strings representation */
+    if (unlikely((size_t)(eptr - (char*)s) != slen)) {
+        char *fallback_eptr;
+        *dp = strtod(s, &fallback_eptr);
+        if ((size_t)(fallback_eptr - (char*)s) != slen) return 0;
+    }
+    if (unlikely(errno == ERANGE &&
+        (*dp == HUGE_VAL || *dp == -HUGE_VAL || fpclassify(*dp) == FP_ZERO)))
+        return 0;
+    if (unlikely(errno == EINVAL))
         return 0;
     return 1;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -660,11 +660,11 @@ int string2ld(const char *s, size_t slen, long double *dp) {
 int string2d(const char *s, size_t slen, double *dp) {
     errno = 0;
     char *eptr;
-    *dp = fast_float_strtod(s, &eptr);
+    /* Fast path to reject empty strings, or strings starting by space explicitly */
     if (unlikely(slen == 0 ||
-        isspace(((const char*)s)[0]) ||
-        isnan(*dp)))
+        isspace(((const char*)s)[0])))
         return 0;
+    *dp = fast_float_strtod(s, &eptr);
     /* If `fast_float_strtod` didn't consume full input, try `strtod`
      * Given fast_float does not support hexadecimal strings representation */
     if (unlikely((size_t)(eptr - (char*)s) != slen)) {
@@ -672,10 +672,10 @@ int string2d(const char *s, size_t slen, double *dp) {
         *dp = strtod(s, &fallback_eptr);
         if ((size_t)(fallback_eptr - (char*)s) != slen) return 0;
     }
-    if (unlikely(errno == ERANGE &&
-        (*dp == HUGE_VAL || *dp == -HUGE_VAL || fpclassify(*dp) == FP_ZERO)))
-        return 0;
-    if (unlikely(errno == EINVAL))
+    if (unlikely(errno == EINVAL ||
+        (errno == ERANGE &&
+        (*dp == HUGE_VAL || *dp == -HUGE_VAL || fpclassify(*dp) == FP_ZERO)) ||
+        isnan(*dp)))
         return 0;
     return 1;
 }
@@ -1557,6 +1557,45 @@ static void test_string2d(void) {
     redis_strlcpy(buf,"0x1p+0",sizeof(buf));
     assert(string2d(buf,strlen(buf),&v) == 1);
     assert(v == 1.0);
+
+    /* Valid floating-point numbers */
+    redis_strlcpy(buf, "1.5", sizeof(buf));
+    assert(string2d(buf, strlen(buf), &v) == 1);
+    assert(v == 1.5);
+
+    redis_strlcpy(buf, "-3.14", sizeof(buf));
+    assert(string2d(buf, strlen(buf), &v) == 1);
+    assert(v == -3.14);
+
+    redis_strlcpy(buf, "2.0e10", sizeof(buf));
+    assert(string2d(buf, strlen(buf), &v) == 1);
+    assert(v == 2.0e10);
+
+    redis_strlcpy(buf, "1e-3", sizeof(buf));
+    assert(string2d(buf, strlen(buf), &v) == 1);
+    assert(v == 0.001);
+
+    /* Valid integer */
+    redis_strlcpy(buf, "42", sizeof(buf));
+    assert(string2d(buf, strlen(buf), &v) == 1);
+    assert(v == 42.0);
+
+    /* Invalid cases */
+    /* Empty. */
+    redis_strlcpy(buf, "", sizeof(buf));
+    assert(string2d(buf, strlen(buf), &v) == 0);
+
+    /* Starting by space. */
+    redis_strlcpy(buf, " 1.23", sizeof(buf));
+    assert(string2d(buf, strlen(buf), &v) == 0);
+
+    /* Invalid hexadecimal format. */
+    redis_strlcpy(buf, "0x1.2g", sizeof(buf));
+    assert(string2d(buf, strlen(buf), &v) == 0);
+
+    /* Hexadecimal NaN */
+    redis_strlcpy(buf, "0xNan", sizeof(buf));
+    assert(string2d(buf, strlen(buf), &v) == 0);
 
     /* overflow. */
     redis_strlcpy(buf,"23456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789",sizeof(buf));

--- a/src/util.c
+++ b/src/util.c
@@ -1544,6 +1544,25 @@ static void test_string2l(void) {
 #endif
 }
 
+
+static void test_string2d(void) {
+    char buf[1024];
+    double v;
+
+    /* Valid hexadecimal value. */
+    redis_strlcpy(buf,"0x0p+0",sizeof(buf));
+    assert(string2d(buf,strlen(buf),&v) == 1);
+    assert(v == 0.0);
+
+    redis_strlcpy(buf,"0x1p+0",sizeof(buf));
+    assert(string2d(buf,strlen(buf),&v) == 1);
+    assert(v == 1.0);
+
+    /* overflow. */
+    redis_strlcpy(buf,"23456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789",sizeof(buf));
+    assert(string2d(buf,strlen(buf),&v) == 0);
+}
+
 static void test_ll2string(void) {
     char buf[32];
     long long v;
@@ -1702,6 +1721,7 @@ int utilTest(int argc, char **argv, int flags) {
 
     test_string2ll();
     test_string2l();
+    test_string2d();
     test_ll2string();
     test_ld2string();
     test_fixedpoint_d2string();

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -308,10 +308,28 @@ start_server {tags {"zset"}} {
             assert_error "*NaN*" {r zincrby myzset -inf abc}
         }
 
+        test "ZINCRBY accepts hexadecimal inputs - $encoding" {
+            r del zhexa
+
+            # Add some hexadecimal values to the sorted set 'zhexa'
+            r zadd zhexa 0x0p+0 "zero"
+            r zadd zhexa 0x1p+0 "one"
+
+            # Increment them
+            # 0 + 0 = 0
+            r zincrby zhexa 0x0p+0 "zero"
+            # 1 + 1 = 2
+            r zincrby zhexa 0x1p+0 "one"
+
+            assert_equal 0 [r zscore zhexa "zero"]
+            assert_equal 2 [r zscore zhexa "one"]
+        }
+
         test "ZINCRBY against invalid incr value - $encoding" {
             r del zincr
             r zadd zincr 1 "one"
             assert_error "*value is not a valid*" {r zincrby zincr v "one"}
+            assert_error "*value is not a valid float" {r zincrby zincr 23456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789 "one"}
         }
 
         test "ZADD - Variadic version base case - $encoding" {


### PR DESCRIPTION
Since https://github.com/redis/redis/pull/11884, what was previously accepted as a valid input (hexadecimal string) before 8.0 returned an error. This PR addresses it. To avoid performance penalties if hints the compiler that the fallbacks are not likely to happen.
Furthermore, we were ignoring std::result_out_of_range outputs from fast_float. This PR addresses it as well and includes tests for both identified scenarios. 

- [x] Daily of  [bc651bc](https://github.com/redis/redis/pull/13845/commits/bc651bc4b55e3006a12f2adf6c13743175692538) https://github.com/filipecosta90/redis/actions/runs/13704698760 
- [x] Daily of [8f56c21](https://github.com/redis/redis/pull/13845/commits/8f56c21ef20895f8c6e13f4891e673d2e3920ed2)  https://github.com/filipecosta90/redis/actions/runs/13746490630
- [ ] Daily of [e4d1ff9](https://github.com/redis/redis/pull/13845/commits/e4d1ff9ebb506b395e68f33ad7ea53eeafa2365e) https://github.com/filipecosta90/redis/actions/runs/13762410718


Benchmark notes:
- From the table bellow we can see that the overhead of the extra checks is 0.1% on the common case so the usual cases won be affected. (meaning we still > 10% even on simple ZADD use-cases vs 7.4)
- I've confirmed that the hexa fallback does not bring a regression vs 7.4.2 - in absolute numbers, even on the fallback use-case we're 4% better on this PR vs 7.4.2.

To benchmark:
```
pip3 install redis-benchmarks-specification==0.1.262
taskset -c 0 ./src/redis-server --save '' --protected-mode no 
redis-benchmarks-spec-client-runner --tests-regexp ".+zset.*-parsing.*" --flushall_on_every_test_start --flushall_on_every_test_end  --cpuset_start_pos 2 --override-memtier-test-time 30  --benchmark_local_install --override-test-runs 3
```

Benchmark details:

use-case | 7.4.2 | 8.0 a39ffc1fe906133686fcf28daf03e738b7890b23 | This PR e4d1ff9ebb506b395e68f33ad7ea53eeafa2365e | % Improvement vs 7.4.2 | % change vs 8.0 a39ffc1fe906133686fcf28daf03e738b7890b23
-- | -- | -- | -- | -- | --
ZADD float | 121047 | 134321 | 134234 | 10.9% | -0.1%
ZADD hexa | 116268 | N/A | 120973 | 4.0% | N/A
diff hexa vs float | -3.9% | N/A | -9.9% |  - |  -



