### PR TITLE
Fix crash during SLAVEOF when clients are blocked on lazyfree

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -270,6 +270,7 @@ void disconnectAllBlockedClients(void) {
 
             if (c->bstate.btype == BLOCKED_LAZYFREE) {
                 addReply(c, shared.ok); /* No reason lazy-free to fail */
+                updateStatsOnUnblock(c, 0, 0, 0);
                 c->flags &= ~CLIENT_PENDING_COMMAND;
                 unblockClient(c, 1);
             } else {

--- a/src/db.c
+++ b/src/db.c
@@ -812,8 +812,8 @@ void flushallSyncBgDone(uint64_t client_id, void *sflush) {
     SlotsFlush *slotsFlush = sflush;
     client *c = lookupClientByID(client_id);
 
-    /* Verify that client still exists */
-    if (!c) {
+    /* Verify that client still exists and being blocked. */
+    if (!(c && c->flags & CLIENT_BLOCKED)) {
         zfree(sflush);
         return;
     }

--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -174,4 +174,17 @@ start_server {tags {"lazyfree"}} {
         assert_equal [s lazyfreed_objects] 2
         $rd close
     }
+
+    test "Unblocks client blocked on lazyfree via REPLICAOF command" {
+        set rd [redis_deferring_client]
+
+        r debug populate 100000 key 1000
+        $rd flushdb
+        wait_for_blocked_client
+        # Test that slaveof command unblocks clients without assertion failure
+        r slaveof 127.0.0.1 0
+        r ping
+        $rd close
+        r slaveof no one
+    }
 }

--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -178,7 +178,7 @@ start_server {tags {"lazyfree"}} {
     test "Unblocks client blocked on lazyfree via REPLICAOF command" {
         set rd [redis_deferring_client]
 
-        populate 50000
+        populate 50000 ;# Just to make flushdb async slower
         $rd flushdb
         wait_for_blocked_client
         # Test that slaveof command unblocks clients without assertion failure

--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -178,13 +178,14 @@ start_server {tags {"lazyfree"}} {
     test "Unblocks client blocked on lazyfree via REPLICAOF command" {
         set rd [redis_deferring_client]
 
-        r debug populate 100000 key 1000
+        populate 50000
         $rd flushdb
         wait_for_blocked_client
         # Test that slaveof command unblocks clients without assertion failure
         r slaveof 127.0.0.1 0
-        r ping
+        assert_equal [$rd read] {OK}
         $rd close
+        r ping
         r slaveof no one
-    } {0} {external:skip needs:debug}
+    } {OK} {external:skip}
 }

--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -186,5 +186,5 @@ start_server {tags {"lazyfree"}} {
         r ping
         $rd close
         r slaveof no one
-    }
+    } {0} {needs:debug}
 }

--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -186,5 +186,5 @@ start_server {tags {"lazyfree"}} {
         r ping
         $rd close
         r slaveof no one
-    } {0} {needs:debug}
+    } {0} {external:skip needs:debug}
 }


### PR DESCRIPTION
After https://github.com/redis/redis/pull/13167, when a client calls `FLUSHDB` comand, we still async empty database, and the client was blocked until the lazyfree completes.

1) If another client calls `SLAVEOF` command during this time, the server will unblock all blocked clients, including those blocked by the lazyfree. However, when unblocking a lazyfree blocked client, we forgot to call `updateStatsOnUnblock()`, which ultimately triggered the following assertion.


```
Logged crash report (pid 281628):
=== REDIS BUG REPORT START: Cut & paste starting from here ===
281628:M 11 Mar 2025 22:05:26.489 # === ASSERTION FAILED ===
281628:M 11 Mar 2025 22:05:26.489 # ==> networking.c:2244 'c->duration == 0' is not true

------ STACK TRACE ------

281632 bio_lazy_free
/lib/x86_64-linux-gnu/libc.so.6(clock_nanosleep+0xbf)[0x7f3e9aeecadf]
/lib/x86_64-linux-gnu/libc.so.6(nanosleep+0x17)[0x7f3e9aef9a27]
/lib/x86_64-linux-gnu/libc.so.6(sleep+0x43)[0x7f3e9af0ec63]
src/redis-server 127.0.0.1:21111(bioProcessBackgroundJobs+0x48c)[0x55b023c3030c]
/lib/x86_64-linux-gnu/libc.so.6(+0x9caa4)[0x7f3e9ae9caa4]
/lib/x86_64-linux-gnu/libc.so.6(+0x129c3c)[0x7f3e9af29c3c]

281628 redis-server *
src/redis-server 127.0.0.1:21111(unblockClient+0x400)[0x55b023c53c30]
src/redis-server 127.0.0.1:21111(disconnectAllBlockedClients+0xcf)[0x55b023c53fbf]
src/redis-server 127.0.0.1:21111(replicationSetMaster+0x4c)[0x55b023ba15dc]
src/redis-server 127.0.0.1:21111(replicaofCommand+0xd0)[0x55b023ba21d0]
src/redis-server 127.0.0.1:21111(call+0x71c)[0x55b023b581cc]
src/redis-server 127.0.0.1:21111(processCommand+0xae5)[0x55b023b59005]
src/redis-server 127.0.0.1:21111(processInputBuffer+0xe9)[0x55b023b7bae9]
src/redis-server 127.0.0.1:21111(readQueryFromClient+0x368)[0x55b023b808d8]
src/redis-server 127.0.0.1:21111(+0x20a9c4)[0x55b023cb69c4]
src/redis-server 127.0.0.1:21111(aeMain+0xf9)[0x55b023b42029]
src/redis-server 127.0.0.1:21111(main+0x46d)[0x55b023b3556d]
/lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca)[0x7f3e9ae2a1ca]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b)[0x7f3e9ae2a28b]
src/redis-server 127.0.0.1:21111(_start+0x25)[0x55b023b36e05]

281630 bio_close_file
/lib/x86_64-linux-gnu/libc.so.6(+0x98d71)[0x7f3e9ae98d71]
/lib/x86_64-linux-gnu/libc.so.6(pthread_cond_wait+0x20d)[0x7f3e9ae9b7ed]
src/redis-server 127.0.0.1:21111(bioProcessBackgroundJobs+0x1ff)[0x55b023c3007f]
/lib/x86_64-linux-gnu/libc.so.6(+0x9caa4)[0x7f3e9ae9caa4]
/lib/x86_64-linux-gnu/libc.so.6(+0x129c3c)[0x7f3e9af29c3c]

281631 bio_aof
/lib/x86_64-linux-gnu/libc.so.6(+0x98d71)[0x7f3e9ae98d71]
/lib/x86_64-linux-gnu/libc.so.6(pthread_cond_wait+0x20d)[0x7f3e9ae9b7ed]
src/redis-server 127.0.0.1:21111(bioProcessBackgroundJobs+0x1ff)[0x55b023c3007f]
/lib/x86_64-linux-gnu/libc.so.6(+0x9caa4)[0x7f3e9ae9caa4]
/lib/x86_64-linux-gnu/libc.so.6(+0x129c3c)[0x7f3e9af29c3c]
```

2) If a client blocked by Lazyfree is unblocked midway, and at this point the `bio_comp_list` has already received the completion notification for the bio, we might end up processing a client that has already been unblocked in `flushallSyncBgDone()`. Therefore, we need to filter it out.

failed CI: https://github.com/sundb/redis/actions/runs/13802290567/job/38606761833