### PR TITLE
Redis - Fix “ERR CLIENT CACHING YES” Error in Client Tracking BCAST Mode

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3764,7 +3764,7 @@ NULL
 
         char *opt = c->argv[2]->ptr;
         if (!strcasecmp(opt,"yes")) {
-            if (c->flags & CLIENT_TRACKING_OPTIN) {
+            if (c->flags & CLIENT_TRACKING_OPTIN || c->flags & CLIENT_TRACKING_BCAST) {
                 c->flags |= CLIENT_TRACKING_CACHING;
             } else {
                 addReplyError(c,"CLIENT CACHING YES is only valid when tracking is enabled in OPTIN mode.");


### PR DESCRIPTION
## **Allow `CLIENT CACHING YES` in Both `OPTIN` and `BCAST` Modes**  

## **Bug Description**  
When using Redis client libraries such as **rueidis** and **go-redis** in **Broadcast mode**, the Redis server responds with the following error:  

```
ERR CLIENT CACHING YES is only valid when tracking is enabled in OPTIN mode.
```

Despite this error, Redis and the client continue to function correctly, and the client does not detect the issue. However, the **error count in `INFO ERRORSTATS` (server-side)** increases, which can impact monitoring and alerting systems.  

Bug is further described in this Rueidis GitHub Issue: https://github.com/redis/rueidis/issues/799

## **Fix**  
This update modifies the **Redis client command processing logic** to allow:  

```
CLIENT CACHING YES
```
to be executed in both:  

- `CLIENT TRACKING OPTIN`  
- `CLIENT TRACKING BCAST`  

### **Key Changes**  
- This fix **only modifies error reply behavior**.  
- It **does not alter the existing client tracking logic**, which is already functioning correctly.  

This change ensures that clients operating in **Broadcast mode** no longer trigger unnecessary errors while maintaining the expected caching behavior. 