### PR TITLE
Fix potential infinite loop of RANDOMKEY during client pause

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -446,7 +446,7 @@ robj *dbRandomKey(redisDb *db) {
 
         key = dictGetKey(de);
         keyobj = createStringObject(key,sdslen(key));
-        if (allvolatile && server.masterhost && --maxtries == 0) {
+        if (allvolatile && (server.masterhost || isPausedActions(PAUSE_ACTION_EXPIRE)) && --maxtries == 0) {
             /* If the DB is composed only of keys with an expire set,
              * it could happen that all the keys are already logically
              * expired in the slave, so the function cannot stop because

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -361,8 +361,11 @@ start_server {tags {"pause network"}} {
 
     test "Test the randomkey command will not cause the server to get into an infinite loop during the client pause write" {
         r flushall
+
+        r multi
         r set key value px 3
         r client pause 10000 write
+        r exec
         
         after 5
 

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -361,10 +361,10 @@ start_server {tags {"pause network"}} {
 
     test "Test the randomkey command will not cause the server to get into an infinite loop during the client pause write" {
         r flushall
-        r set key value ex 3
+        r set key value px 3
         r client pause 10000 write
         
-        after 5000
+        after 5
 
         wait_for_condition 50 100 {
             [r randomkey] == "key"
@@ -372,7 +372,7 @@ start_server {tags {"pause network"}} {
             fail "execute randomkey failed, caused by the infinite loop"
         }
 
-        after 6000
+        r client unpause
         assert_equal [r randomkey] {}
     }
 

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -359,6 +359,23 @@ start_server {tags {"pause network"}} {
         } {bar2}
     }
 
+    test "Test the randomkey command will not cause the server to get into an infinite loop during the client pause write" {
+        r flushall
+        r set key value ex 3
+        r client pause 10000 write
+        
+        after 5000
+
+        wait_for_condition 50 100 {
+            [r randomkey] == "key"
+        } else {
+            fail "execute randomkey failed, caused by the infinite loop"
+        }
+
+        after 6000
+        assert_equal [r randomkey] {}
+    }
+
     # Make sure we unpause at the end
     r client unpause
 }


### PR DESCRIPTION
The bug mentioned in this [#13862](https://github.com/redis/redis/issues/13862) has been fixed.