### PR TITLE
Fix timing issue in module defrag test

### DIFF
--- a/tests/unit/moduleapi/defrag.tcl
+++ b/tests/unit/moduleapi/defrag.tcl
@@ -22,7 +22,7 @@ start_server {tags {"modules"} overrides {{save ""}}} {
             r frag.create key1 1 1000 0
 
             r config set activedefrag yes
-            wait_for_condition 100 50 {
+            wait_for_condition 200 50 {
                 [getInfoProperty [r info defragtest_stats] defragtest_defrag_ended] > 0
             } else {
                 fail "Unable to wait for a complete defragmentation cycle to finish"
@@ -52,7 +52,7 @@ start_server {tags {"modules"} overrides {{save ""}}} {
             r frag.create key2 10000 100 1000
 
             r config set activedefrag yes
-            wait_for_condition 100 50 {
+            wait_for_condition 200 50 {
                 [getInfoProperty [r info defragtest_stats] defragtest_defrag_ended] > 0
             } else {
                 fail "Unable to wait for a complete defragmentation cycle to finish"
@@ -79,7 +79,7 @@ start_server {tags {"modules"} overrides {{save ""}}} {
             r frag.create_frag_global
             r config set activedefrag yes
 
-            wait_for_condition 100 50 {
+            wait_for_condition 200 50 {
                 [getInfoProperty [r info defragtest_stats] defragtest_defrag_ended] > 0
             } else {
                 fail "Unable to wait for a complete defragmentation cycle to finish"


### PR DESCRIPTION
After #13840, the data we populate becomes more complex and slower, we always wait for a defragmentation cycle to end before verifying that the test is okay.
However, in some slow environments, an entire defragmentation cycle can exceed 5 seconds, and in my local test using 'taskset -c 0' it can reach 6 seconds, so increase the threshold to avoid test failures.

failed test: https://github.com/redis/redis/actions/runs/13783101882/job/38544947853?pr=13851