### PR TITLE
Fix sdscatprintf error of the in output of `info stats`

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6140,7 +6140,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
             "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION)));
         info = genRedisInfoStringACLStats(info);
         if (!server.cluster_enabled && server.cluster_compatibility_sample_ratio) {
-            sdscatprintf(info, "cluster_incompatible_ops:%lld\r\n", server.stat_cluster_incompatible_ops);
+            info = sdscatprintf(info, "cluster_incompatible_ops:%lld\r\n", server.stat_cluster_incompatible_ops);
         }
     }
 


### PR DESCRIPTION
CI failed, https://github.com/redis/redis/actions/runs/13981749993/job/39148249096, since i don't reassign `info` after `sdscatprintf(info, xxx)`
Thanks to @sundb for spotting this
introduced in https://github.com/redis/redis/pull/13846