### PR TITLE
Fix timing issue in HEXPIREAT test

### DIFF
--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -324,9 +324,9 @@ start_server {tags {"external:skip needs:debug"}} {
             r del myhash
             r hset myhash field1 value1
 
-            r hexpireat myhash [expr {[clock seconds] + 10}] NX FIELDS 1 field1
-            assert_range [r hpttl myhash FIELDS 1 field1] 5000 10000
-            assert_range [r httl myhash FIELDS 1 field1] 5 10
+            r hexpireat myhash [expr {[clock seconds] + 2}] NX FIELDS 1 field1
+            assert_range [r hpttl myhash FIELDS 1 field1] 500 2000
+            assert_range [r httl myhash FIELDS 1 field1] 1 2
 
             r hexpireat myhash [expr {[clock seconds] + 5}] XX FIELDS 1 field1
             assert_range [r httl myhash FIELDS 1 field1] 4 5

--- a/tests/unit/type/hash-field-expire.tcl
+++ b/tests/unit/type/hash-field-expire.tcl
@@ -324,9 +324,9 @@ start_server {tags {"external:skip needs:debug"}} {
             r del myhash
             r hset myhash field1 value1
 
-            r hexpireat myhash [expr {[clock seconds] + 2}] NX FIELDS 1 field1
-            assert_range [r hpttl myhash FIELDS 1 field1] 1000 2000
-            assert_range [r httl myhash FIELDS 1 field1] 1 2
+            r hexpireat myhash [expr {[clock seconds] + 10}] NX FIELDS 1 field1
+            assert_range [r hpttl myhash FIELDS 1 field1] 5000 10000
+            assert_range [r httl myhash FIELDS 1 field1] 5 10
 
             r hexpireat myhash [expr {[clock seconds] + 5}] XX FIELDS 1 field1
             assert_range [r httl myhash FIELDS 1 field1] 4 5


### PR DESCRIPTION
This fixes an error occurs in the job [test-valgrind-no-malloc-usable-size-test](https://github.com/redis/redis/actions/runs/13912357739/job/38929051397) of the Daily workflow:

```
*** [err]: HEXPIREAT - Set time and then get TTL (listpackex) in tests/unit/type/hash-field-expire.tcl
Expected '999' to be between to '1000' and '2000' (context: type eval line 6 cmd {assert_range [r hpttl myhash FIELDS 1 field1] 1000 2000} proc ::test)
```

It's not a perfect solution but stabilize the test case.