### PR TITLE
avoid possible use-after-free with module KSN changes

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -612,10 +612,10 @@ void incrDecrCommand(client *c, long long incr) {
             dbAdd(c->db,c->argv[1],new);
         }
     }
+    addReplyLongLongFromStr(c,new);
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_STRING,"incrby",c->argv[1],c->db->id);
     server.dirty++;
-    addReplyLongLongFromStr(c,new);
 }
 
 void incrCommand(client *c) {

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -3,6 +3,10 @@ set testmodule [file normalize tests/modules/keyspace_events.so]
 tags "modules" {
     start_server [list overrides [list loadmodule "$testmodule"]] {
 
+        # avoid using shared integers, to increase the chance of detection heap issues
+        r config set maxmemory-policy allkeys-lru
+        r config set maxmemory 1gb
+
         test {Test loaded key space event} {
             r set x 1
             r hset y f v


### PR DESCRIPTION
in #13505, we changed the code to use the string value of the key rather than the integer value on the stack, but we have a test in unit/moduleapi/keyspace_events that uses keyspace notification hook to modify the value with RM_StringDMA, which can cause this value to be released before used. the reason it didn't happen so far is because we were using shared integers, so releasing the object doesn't free it.