### PR TITLE
Fix use-after free in non-swapdb diskless loading.

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2259,6 +2259,7 @@ void readSyncBulkPayload(connection *conn) {
              * replicationEmptyDbCallback() may yield back to event-loop to
              * reply -LOADING. */
             emptyData(-1, empty_db_flags, replicationEmptyDbCallback);
+            functions_lib_ctx = functionsLibCtxGetCurrent();
         }
         loadingFireEvent(RDBFLAGS_REPLICATION);
 


### PR DESCRIPTION
when diskless load is set to on-empty-db, we would have kept a pointer to the functions context, and use it after releasing that context and creating a new one

introduced in #13495 (Redis 8.0)