### PR TITLE
Fix potential infinite loop of RANDOMKEY during client pause

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -295,7 +295,7 @@ robj *dbRandomKey(redisDb *db) {
         key = dictGetKey(de);
         keyobj = createStringObject(key,sdslen(key));
         if (dictFind(db->expires,key)) {
-            if (allvolatile && server.masterhost && --maxtries == 0) {
+            if (allvolatile && (server.masterhost || server.client_pause_type == CLIENT_PAUSE_WRITE) && --maxtries == 0) {
                 /* If the DB is composed only of keys with an expire set,
                  * it could happen that all the keys are already logically
                  * expired in the slave, so the function cannot stop because

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -320,6 +320,26 @@ start_server {tags {"pause network"}} {
         } {bar2}
     }
 
+    test "Test the randomkey command will not cause the server to get into an infinite loop during the client pause write" {
+        r flushall
+
+        r multi
+        r set key value px 3
+        r client pause 10000 write
+        r exec
+
+        after 5
+
+        wait_for_condition 50 100 {
+            [r randomkey] == "key"
+        } else {
+            fail "execute randomkey failed, caused by the infinite loop"
+        }
+
+        r client unpause
+        assert_equal [r randomkey] {}
+    }
+
     # Make sure we unpause at the end
     r client unpause
 }


### PR DESCRIPTION
Fixed https://github.com/redis/redis/issues/13862, which can backport to 6.2.