### PR TITLE
Fix 'RESTORE can set LFU' test

### DIFF
--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -84,7 +84,6 @@ start_server {tags {"dump"}} {
 
         r get foo
         assert_equal [r get foo] {bar}
-
         r config set maxmemory-policy noeviction
     } {OK} {needs:config-maxmemory}
 

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -73,7 +73,7 @@ start_server {tags {"dump"}} {
         set freq [r object freq foo]
         set end [clock format [clock seconds] -format %M]
 
-        if { $remainder_before == $remainder_after } {
+        if { $start == $end } {
             # If the minutes haven't changed (i.e., the restore and object happened within the same minute),
             # the freq should remain 100 as no decay has occurred yet.
             assert {$freq == 100}

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -69,7 +69,7 @@ start_server {tags {"dump"}} {
 
         # We need to determine whether the `object` operation happens within the same minute or crosses into a new one
         # This will help us verify if the freq remains 100 or decays due to a minute transition
-        set remainder_before [clock format [clock seconds] -format %M]
+        set start [clock format [clock seconds] -format %M]
         set freq [r object freq foo]
         set remainder_after [clock format [clock seconds] -format %M]
 

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -62,39 +62,39 @@ start_server {tags {"dump"}} {
 
 
      test {smoking test RESTORE can set LFU} {
-            r set foo bar
-            set encoded [r dump foo]
-            r del foo
-            r config set maxmemory-policy allkeys-lfu
-            r restore foo 0 $encoded freq 100
+        r set foo bar
+        set encoded [r dump foo]
+        r del foo
+        r config set maxmemory-policy allkeys-lfu
+        r restore foo 0 $encoded freq 100
 
-            # We need to determine whether the `object` operation happens within the same minute or crosses into a new one
-            # This will help us verify if the freq remains 100 or decays due to a minute transition
-            set remainder_before [clock format [clock seconds] -format %M]
+        # We need to determine whether the `object` operation happens within the same minute or crosses into a new one
+        # This will help us verify if the freq remains 100 or decays due to a minute transition
+        set remainder_before [clock format [clock seconds] -format %M]
 
-            set continue_loop 1
-            while { $continue_loop } {
-                set time_result [r time]
-                set server_unixtime [lindex $time_result 0]
-                set remainder [expr $server_unixtime % 60]
-                if { $remainder >= 58 } {
-                    set continue_loop 0
-                } else {
-                    after 500
-                }
+        set continue_loop 1
+        while { $continue_loop } {
+            set time_result [r time]
+            set server_unixtime [lindex $time_result 0]
+            set remainder [expr $server_unixtime % 60]
+            if { $remainder >= 58 } {
+                set continue_loop 0
+            } else {
+                after 500
             }
-            after 2000
+        }
+        after 2000
 
-            set freq [r object freq foo]
-            set remainder_after [clock format [clock seconds] -format %M]
+        set freq [r object freq foo]
+        set remainder_after [clock format [clock seconds] -format %M]
 
-            assert { $remainder_before != $remainder_after }
-            assert {($freq == 100)
+        assert { $remainder_before != $remainder_after }
+        assert {($freq == 100)}
 
-            r get foo
-            assert_equal [r get foo] {bar}
-            r config set maxmemory-policy noeviction
-        } {OK} {needs:config-maxmemory}
+        r get foo
+        assert_equal [r get foo] {bar}
+        r config set maxmemory-policy noeviction
+     } {OK} {needs:config-maxmemory}
     
     test {RESTORE can set LFU} {
         r set foo bar

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -59,32 +59,61 @@ start_server {tags {"dump"}} {
         assert_equal [r get foo] {bar}
         r config set maxmemory-policy noeviction
     } {OK} {needs:config-maxmemory}
-    
-    test {RESTORE can set LFU} {
+
+    test {RESTORE can set LFU and freq not decayed yet} {
+        r set fooa bara
+        set encoded [r dump fooa]
+        r del fooa
+
+        r config set maxmemory-policy allkeys-lfu
+
+        set continueLoop 1
+        while { $continueLoop } {
+            set time_result [r time]
+            set server_unixtime [lindex $time_result 0]
+            set remainder [expr $server_unixtime % 60]  ;
+            if { $remainder < 58 } {
+                set continueLoop 0
+            } else {
+                after 500
+            }
+        }
+
+        r restore fooa 0 $encoded freq 100
+        after 2000
+        set freq [r object freq fooa]
+        assert {$freq == 100}
+        r get fooa
+        assert_equal [r get fooa] {bara}
+
+        r config set maxmemory-policy noeviction
+    } {OK} {needs:config-maxmemory}
+
+    test {RESTORE can set LFU and freq decay} {
         r set foo bar
         set encoded [r dump foo]
         r del foo
 
         r config set maxmemory-policy allkeys-lfu
-        r config set lfu-decay-time 0
+
+        set continueLoop 1
+        while { $continueLoop } {
+            set time_result [r time]
+            set server_unixtime [lindex $time_result 0]
+            set remainder [expr $server_unixtime % 60]  ;
+            if { $remainder >= 58 } {
+                set continueLoop 0
+            } else {
+                after 500
+            }
+        }
+
         r restore foo 0 $encoded freq 100
-        after 60000
+        after 2000
         set freq [r object freq foo]
-        assert {$freq == 100}
+        assert {$freq == 99}
         r get foo
         assert_equal [r get foo] {bar}
-
-        r set fooa bara
-        set encoded [r dump fooa]
-        r del fooa
-        r config set maxmemory-policy allkeys-lfu
-        r config set lfu-decay-time 1
-        r restore fooa 0 $encoded freq 100
-        after 60000
-        set freq [r object freq fooa]
-        assert {$freq <= 99}
-        r get fooa
-        assert_equal [r get fooa] {bara}
 
         r config set maxmemory-policy noeviction
     } {OK} {needs:config-maxmemory}

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -110,6 +110,8 @@ start_server {tags {"dump"}} {
         set remainder_after [clock format [clock seconds] -format %M]
 
         if { $remainder_before == $remainder_after } {
+            # If the minutes haven't changed (i.e., the restore and object happened within the same minute),
+            # the freq should remain 100 as no decay has occurred yet.
             assert {$freq == 100}
         } else {
             # If the object operation crosses into a new minute, freq may have already decayed by 1 (99),

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -60,7 +60,7 @@ start_server {tags {"dump"}} {
         r config set maxmemory-policy noeviction
     } {OK} {needs:config-maxmemory}
 
-    test {RESTORE can set LFU and freq not decayed yet} {
+    test {RESTORE can set LFU and freq not decayed} {
         r set fooa bara
         set encoded [r dump fooa]
         r del fooa
@@ -71,7 +71,7 @@ start_server {tags {"dump"}} {
         while { $continueLoop } {
             set time_result [r time]
             set server_unixtime [lindex $time_result 0]
-            set remainder [expr $server_unixtime % 60]  ;
+            set remainder [expr $server_unixtime % 60]
             if { $remainder < 58 } {
                 set continueLoop 0
             } else {
@@ -100,7 +100,7 @@ start_server {tags {"dump"}} {
         while { $continueLoop } {
             set time_result [r time]
             set server_unixtime [lindex $time_result 0]
-            set remainder [expr $server_unixtime % 60]  ;
+            set remainder [expr $server_unixtime % 60]
             if { $remainder >= 58 } {
                 set continueLoop 0
             } else {

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -59,7 +59,7 @@ start_server {tags {"dump"}} {
         assert_equal [r get foo] {bar}
         r config set maxmemory-policy noeviction
     } {OK} {needs:config-maxmemory}
-
+    
     test {RESTORE can set LFU} {
         r set foo bar
         set encoded [r dump foo]

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -71,7 +71,7 @@ start_server {tags {"dump"}} {
         # This will help us verify if the freq remains 100 or decays due to a minute transition
         set start [clock format [clock seconds] -format %M]
         set freq [r object freq foo]
-        set remainder_after [clock format [clock seconds] -format %M]
+        set end [clock format [clock seconds] -format %M]
 
         if { $remainder_before == $remainder_after } {
             # If the minutes haven't changed (i.e., the restore and object happened within the same minute),

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -60,42 +60,6 @@ start_server {tags {"dump"}} {
         r config set maxmemory-policy noeviction
     } {OK} {needs:config-maxmemory}
 
-
-     test {smoking test RESTORE can set LFU} {
-        r set foo bar
-        set encoded [r dump foo]
-        r del foo
-        r config set maxmemory-policy allkeys-lfu
-        r restore foo 0 $encoded freq 100
-
-        # We need to determine whether the `object` operation happens within the same minute or crosses into a new one
-        # This will help us verify if the freq remains 100 or decays due to a minute transition
-        set remainder_before [clock format [clock seconds] -format %M]
-
-        set continue_loop 1
-        while { $continue_loop } {
-            set time_result [r time]
-            set server_unixtime [lindex $time_result 0]
-            set remainder [expr $server_unixtime % 60]
-            if { $remainder >= 58 } {
-                set continue_loop 0
-            } else {
-                after 500
-            }
-        }
-        after 2000
-
-        set freq [r object freq foo]
-        set remainder_after [clock format [clock seconds] -format %M]
-
-        assert { $remainder_before != $remainder_after }
-        assert {($freq == 100)}
-
-        r get foo
-        assert_equal [r get foo] {bar}
-        r config set maxmemory-policy noeviction
-     } {OK} {needs:config-maxmemory}
-    
     test {RESTORE can set LFU} {
         r set foo bar
         set encoded [r dump foo]

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -67,13 +67,13 @@ start_server {tags {"dump"}} {
 
         r config set maxmemory-policy allkeys-lfu
 
-        set continueLoop 1
-        while { $continueLoop } {
+        set continue_loop 1
+        while { $continue_loop } {
             set time_result [r time]
             set server_unixtime [lindex $time_result 0]
             set remainder [expr $server_unixtime % 60]
             if { $remainder < 58 } {
-                set continueLoop 0
+                set continue_loop 0
             } else {
                 after 500
             }
@@ -96,13 +96,13 @@ start_server {tags {"dump"}} {
 
         r config set maxmemory-policy allkeys-lfu
 
-        set continueLoop 1
-        while { $continueLoop } {
+        set continue_loop 1
+        while { $continue_loop } {
             set time_result [r time]
             set server_unixtime [lindex $time_result 0]
             set remainder [expr $server_unixtime % 60]
             if { $remainder >= 58 } {
-                set continueLoop 0
+                set continue_loop 0
             } else {
                 after 500
             }

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -64,12 +64,28 @@ start_server {tags {"dump"}} {
         r set foo bar
         set encoded [r dump foo]
         r del foo
+
         r config set maxmemory-policy allkeys-lfu
+        r config set lfu-decay-time 0
         r restore foo 0 $encoded freq 100
+        after 60000
         set freq [r object freq foo]
         assert {$freq == 100}
         r get foo
         assert_equal [r get foo] {bar}
+
+        r set fooa bara
+        set encoded [r dump fooa]
+        r del fooa
+        r config set maxmemory-policy allkeys-lfu
+        r config set lfu-decay-time 1
+        r restore fooa 0 $encoded freq 100
+        after 60000
+        set freq [r object freq fooa]
+        assert {$freq <= 99}
+        r get fooa
+        assert_equal [r get fooa] {bara}
+
         r config set maxmemory-policy noeviction
     } {OK} {needs:config-maxmemory}
 

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -69,9 +69,9 @@ start_server {tags {"dump"}} {
 
         # We need to determine whether the `object` operation happens within the same minute or crosses into a new one
         # This will help us verify if the freq remains 100 or decays due to a minute transition
-        set remainder_before [expr [lindex [r time] 0] / 60]
+        set remainder_before [clock format [clock seconds] -format %M]
         set freq [r object freq foo]
-        set remainder_after [expr [lindex [r time] 0] / 60]
+        set remainder_after [clock format [clock seconds] -format %M]
 
         if { $remainder_before == $remainder_after } {
             assert {$freq == 100}

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -64,7 +64,6 @@ start_server {tags {"dump"}} {
         r set foo bar
         set encoded [r dump foo]
         r del foo
-
         r config set maxmemory-policy allkeys-lfu
         r restore foo 0 $encoded freq 100
 

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -59,6 +59,42 @@ start_server {tags {"dump"}} {
         assert_equal [r get foo] {bar}
         r config set maxmemory-policy noeviction
     } {OK} {needs:config-maxmemory}
+
+
+     test {smoking test RESTORE can set LFU} {
+            r set foo bar
+            set encoded [r dump foo]
+            r del foo
+            r config set maxmemory-policy allkeys-lfu
+            r restore foo 0 $encoded freq 100
+
+            # We need to determine whether the `object` operation happens within the same minute or crosses into a new one
+            # This will help us verify if the freq remains 100 or decays due to a minute transition
+            set remainder_before [clock format [clock seconds] -format %M]
+
+            set continue_loop 1
+            while { $continue_loop } {
+                set time_result [r time]
+                set server_unixtime [lindex $time_result 0]
+                set remainder [expr $server_unixtime % 60]
+                if { $remainder >= 58 } {
+                    set continue_loop 0
+                } else {
+                    after 500
+                }
+            }
+            after 2000
+
+            set freq [r object freq foo]
+            set remainder_after [clock format [clock seconds] -format %M]
+
+            assert { $remainder_before != $remainder_after }
+            assert {($freq == 100)
+
+            r get foo
+            assert_equal [r get foo] {bar}
+            r config set maxmemory-policy noeviction
+        } {OK} {needs:config-maxmemory}
     
     test {RESTORE can set LFU} {
         r set foo bar

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -60,58 +60,29 @@ start_server {tags {"dump"}} {
         r config set maxmemory-policy noeviction
     } {OK} {needs:config-maxmemory}
 
-    test {RESTORE can set LFU and freq not decayed} {
-        r set fooa bara
-        set encoded [r dump fooa]
-        r del fooa
-
-        r config set maxmemory-policy allkeys-lfu
-
-        set continue_loop 1
-        while { $continue_loop } {
-            set time_result [r time]
-            set server_unixtime [lindex $time_result 0]
-            set remainder [expr $server_unixtime % 60]
-            if { $remainder < 58 } {
-                set continue_loop 0
-            } else {
-                after 500
-            }
-        }
-
-        r restore fooa 0 $encoded freq 100
-        after 2000
-        set freq [r object freq fooa]
-        assert {$freq == 100}
-        r get fooa
-        assert_equal [r get fooa] {bara}
-
-        r config set maxmemory-policy noeviction
-    } {OK} {needs:config-maxmemory}
-
-    test {RESTORE can set LFU and freq decay} {
+    test {RESTORE can set LFU} {
         r set foo bar
         set encoded [r dump foo]
         r del foo
 
         r config set maxmemory-policy allkeys-lfu
+        r restore foo 0 $encoded freq 100
 
-        set continue_loop 1
-        while { $continue_loop } {
-            set time_result [r time]
-            set server_unixtime [lindex $time_result 0]
-            set remainder [expr $server_unixtime % 60]
-            if { $remainder >= 58 } {
-                set continue_loop 0
-            } else {
-                after 500
-            }
+        # We need to determine whether the `object` operation happens within the same minute or crosses into a new one
+        # This will help us verify if the freq remains 100 or decays due to a minute transition
+        set remainder_before [expr [lindex [r time] 0] / 60]
+        set freq [r object freq foo]
+        set remainder_after [expr [lindex [r time] 0] / 60]
+
+        if { $remainder_before == $remainder_after } {
+            assert {$freq == 100}
+        } else {
+            # If the object operation crosses into a new minute, freq may have already decayed by 1 (99),
+            # or it may still be 100 if the minute update hasn't been applied yet when the operation is performed.
+            # The decay might only take effect after the operation completes and the minute is updated.
+            assert {($freq == 100) || ($freq == 99)}
         }
 
-        r restore foo 0 $encoded freq 100
-        after 2000
-        set freq [r object freq foo]
-        assert {$freq == 99}
         r get foo
         assert_equal [r get foo] {bar}
 


### PR DESCRIPTION
The failed daily CI: https://github.com/redis/redis/actions/runs/14095883794/job/39483009887

When the `restore foo 0 $encoded freq 100` command and `set freq [r object freq foo]` run in different minute timestamps (i.e., when server.unixtime/60 changes between these operations), the assertion may fail due to the LFU decay.

This PR updates the “RESTORE can set LFU” test to verify the actual freq value based on minute timestamps. 