### PR TITLE
Reduce the call of ERR_clear_error

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -636,10 +636,9 @@ static void tlsHandleEvent(tls_connection *conn, int mask) {
             conn->c.fd, conn->c.state, mask, conn->c.read_handler != NULL, conn->c.write_handler != NULL,
             conn->flags);
 
-    ERR_clear_error();
-
     switch (conn->c.state) {
         case CONN_STATE_CONNECTING:
+            ERR_clear_error();
             conn_error = anetGetError(conn->c.fd);
             if (conn_error) {
                 conn->c.last_errno = conn_error;
@@ -673,6 +672,7 @@ static void tlsHandleEvent(tls_connection *conn, int mask) {
             conn->c.conn_handler = NULL;
             break;
         case CONN_STATE_ACCEPTING:
+            ERR_clear_error();
             ret = SSL_accept(conn->ssl);
             if (ret <= 0) {
                 WantIOType want = 0;
@@ -1011,6 +1011,7 @@ static int connTLSBlockingConnect(connection *conn_, const char *addr, int port,
      * which means the specified timeout will not be enforced accurately. */
     SSL_set_fd(conn->ssl, conn->c.fd);
     setBlockingTimeout(conn, timeout);
+    ERR_clear_error();
 
     if ((ret = SSL_connect(conn->ssl)) <= 0) {
         conn->c.state = CONN_STATE_ERROR;


### PR DESCRIPTION
From flame graph, we can find `ERR_clear_error` costs much cpu in tls mode, some calls of `ERR_clear_error` are duplicate, in function `tlsHandleEvent`, we call `ERR_clear_error` but we also call `ERR_clear_error` when reading and writing, so it is not necessary.

<img width="1224" alt="截屏2025-03-31 11 52 02" src="https://github.com/user-attachments/assets/e905e7d9-57f8-4a79-986d-8d5975b81db1" />

from benchmark, this commit can bring 2-3% performance improvement.

```
 memtier_benchmark --ratio 1:0 -c 10 -t 16 --hide-histogram -d 1000 --pipeline 10 --key-minimum 1 --key-maximum 1000000 -s  xxx --distinct-client-seed --test-time 60  -a perf -p 7000 --tls --tls-skip-verify -x 3
```

before
```
AGGREGATED AVERAGE RESULTS (3 runs)
============================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets       109509.22          ---          ---        14.51915        14.52700        15.93500        17.27900    112063.96 
Gets            0.00         0.00         0.00             ---             ---             ---             ---         0.00 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals     109509.22         0.00         0.00        14.51915        14.52700        15.93500        17.27900    112063.96 
```

after


```
AGGREGATED AVERAGE RESULTS (3 runs)
============================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets       112497.41          ---          ---        14.21754        14.20700        15.29500        16.76700    115121.86 
Gets            0.00         0.00         0.00             ---             ---             ---             ---         0.00 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals     112497.41         0.00         0.00        14.21754        14.20700        15.29500        16.76700    115121.86 
```