### PR TITLE
Improve replication buffering on replica and fix a related bug

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3247,7 +3247,7 @@ standardConfig static_configs[] = {
     /* Other configs */
     createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60*60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */
     createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64*1024*1024, MEMORY_CONFIG, NULL, NULL),
-    createOffTConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1024, INT_MAX, server.loading_process_events_interval_bytes, 1024*1024*2, INTEGER_CONFIG, NULL, NULL),
+    createOffTConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1024, INT_MAX, server.loading_process_events_interval_bytes, 1024*512, INTEGER_CONFIG, NULL, NULL),
 
     createIntConfig("tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.tls_port, 0, INTEGER_CONFIG, NULL, applyTLSPort), /* TCP port. */
     createIntConfig("tls-session-cache-size", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_size, 20*1024, INTEGER_CONFIG, NULL, applyTlsCfg),

--- a/src/replication.c
+++ b/src/replication.c
@@ -48,7 +48,8 @@ static void rdbChannelFullSyncWithMaster(connection *conn);
 static int rdbChannelAbortRdbTransfer(void);
 static void rdbChannelBufferReplData(connection *conn);
 static void rdbChannelReplDataBufInit(void);
-static void rdbChannelSuccess(void);
+static void rdbChannelStreamReplDataToDb(void);
+static void rdbChannelCleanup(void);
 
 /* We take a global flag to remember if this instance generated an RDB
  * because of replication, so that we can remove the RDB file in case
@@ -2238,6 +2239,11 @@ void readSyncBulkPayload(connection *conn) {
             }
         }
 
+        /* Set disklessLoadingRio before calling emptyData() which may yield
+         * back to networking. */
+        rioInitWithConn(&rdb,conn,server.repl_transfer_size);
+        disklessLoadingRio = &rdb;
+
         /* Empty db */
         loadingSetFlags(NULL, server.repl_transfer_size, asyncLoading);
         if (server.repl_diskless_load != REPL_DISKLESS_LOAD_SWAPDB) {
@@ -2257,9 +2263,6 @@ void readSyncBulkPayload(connection *conn) {
             functions_lib_ctx = functionsLibCtxGetCurrent();
             functionsLibCtxClear(functions_lib_ctx);
         }
-
-        rioInitWithConn(&rdb,conn,server.repl_transfer_size);
-        disklessLoadingRio = &rdb;
 
         /* Put the socket in blocking mode to simplify RDB transfer.
          * We'll restore it when the RDB is received. */
@@ -2456,25 +2459,13 @@ void readSyncBulkPayload(connection *conn) {
         startAppendOnlyWithRetry();
     }
 
+    /* Stream accumulated replication buffer to the db and finalize fullsync */
     if (rdbchannel) {
-        int close_asap;
-
         if (server.repl_rdb_transfer_s) {
             connClose(server.repl_rdb_transfer_s);
             server.repl_rdb_transfer_s = NULL;
         }
-        /* At this point, RDB is loaded. If state is REPL_RDB_CH_STATE_CLOSE_ASAP,
-         * it means main channel faced a problem while RDB is being loaded. It
-         * stopped replication stream buffering. It's okay though. We'll stream
-         * whatever we have into the db, then replica will try psync from the
-         * index that it has. */
-        close_asap = (server.repl_rdb_ch_state == REPL_RDB_CH_STATE_CLOSE_ASAP);
-        /* Finalize fullsync */
-        rdbChannelSuccess();
-
-        /* Main channel connection was broken. Let's trigger a psync with master. */
-        if (close_asap && server.master)
-            freeClientAsync(server.master);
+        rdbChannelStreamReplDataToDb();
     }
 
     return;
@@ -3353,6 +3344,15 @@ void replicationHandleMasterDisconnection(void) {
     server.master = NULL;
     server.repl_state = REPL_STATE_CONNECT;
     server.repl_down_since = server.unixtime;
+    server.repl_num_master_disconnection++;
+
+    /* If we are in the loop of streaming accumulated buffers, discard the
+     * buffer and clean up the rdbchannel state. The outer loop will abort once
+     * it detects that the master client has been disconnected. For details,
+     * see rdbChannelStreamReplDataToDb() */
+    if (server.repl_main_ch_state & REPL_MAIN_CH_STREAMING_BUF)
+        rdbChannelCleanup();
+
     /* We lost connection with our master, don't disconnect slaves yet,
      * maybe we'll be able to PSYNC with our master later. We'll disconnect
      * the slaves only if we'll have to do a full resync with our master. */
@@ -3582,7 +3582,8 @@ static int rdbChannelHandleFullresyncReply(connection *conn, sds *err) {
 
     serverLog(LL_NOTICE, "Starting to receive RDB and replication stream in parallel.");
 
-    /* RDB is still loading. Setup connection to accumulate repl data.  */
+    /* Setup connection to accumulate repl data.  */
+    server.repl_main_ch_state = REPL_MAIN_CH_NONE;
     if (connSetReadHandler(server.repl_transfer_s,
                            rdbChannelBufferReplData) != C_OK)
     {
@@ -3676,6 +3677,7 @@ static void rdbChannelReplDataBufInit(void) {
     serverAssert(server.repl_full_sync_buffer.blocks == NULL);
     server.repl_full_sync_buffer.size = 0;
     server.repl_full_sync_buffer.used = 0;
+    server.repl_full_sync_buffer.peak_num_blocks = 0;
     server.repl_full_sync_buffer.mem_used = 0;
     server.repl_full_sync_buffer.blocks = listCreate();
     server.repl_full_sync_buffer.blocks->free = zfree;
@@ -3688,6 +3690,7 @@ static void rdbChannelReplDataBufFree(void) {
     server.repl_full_sync_buffer.blocks = NULL;
     server.repl_full_sync_buffer.size = 0;
     server.repl_full_sync_buffer.used = 0;
+    server.repl_full_sync_buffer.peak_num_blocks = 0;
     server.repl_full_sync_buffer.mem_used = 0;
 }
 
@@ -3723,6 +3726,18 @@ void rdbChannelBufferReplData(connection *conn) {
 
     listNode *ln = listLast(server.repl_full_sync_buffer.blocks);
     replDataBufBlock *tail = ln ? listNodeValue(ln) : NULL;
+
+    if (server.repl_main_ch_state & REPL_MAIN_CH_STREAMING_BUF) {
+        /* While streaming accumulated buffers, we continue reading from the
+         * master to prevent accumulation on master side as much as possible.
+         * However, we aim to drain buffer eventually. To ensure we consume more
+         * than we read, we'll read at most one block after two blocks of
+         * buffers are consumed. */
+        replDataBuf *buf = &server.repl_full_sync_buffer;
+        if (listLength(buf->blocks) + 2 > buf->peak_num_blocks)
+            return;
+        buf->peak_num_blocks = listLength(buf->blocks);
+    }
 
     /* Try to append last node. */
     if (tail && tail->size > tail->used) {
@@ -3771,66 +3786,122 @@ void rdbChannelBufferReplData(connection *conn) {
 
 /* Replication: Replica side.
  * Streams accumulated replication data into the database. */
-int rdbChannelStreamReplDataToDb(client *c) {
-    int ret = C_OK;
-    size_t size, used, offset = 0;
+static void rdbChannelStreamReplDataToDb(void) {
+    int ret = C_OK, master_disconnected = 0;
+    size_t offset = 0;
     listNode *n = NULL;
-    replDataBufBlock *o;
+    replDataBufBlock *o = NULL;
+    client *c = server.master;
 
-    serverAssert(c->flags & CLIENT_MASTER);
+    /* Save repl_num_master_disconnection to figure out if master gets
+     * disconnected when we yield back to processEventsWhileBlocked() */
+    uint64_t seq = server.repl_num_master_disconnection;
 
+    /* At this point, RDB is loaded. If main channel state is CLOSE_ASAP,
+     * it means main channel faced a problem while RDB is being loaded. It
+     * stopped replication stream buffering. It's okay though. We'll stream
+     * whatever we have into the db, then replica will try psync from the
+     * index that it has. */
+    int close_asap = (server.repl_main_ch_state & REPL_MAIN_CH_CLOSE_ASAP);
+
+    server.repl_main_ch_state |= REPL_MAIN_CH_STREAMING_BUF;
+    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Starting to stream replication buffer into the db"
+                         " (%zu bytes).", server.repl_full_sync_buffer.used);
     if (!server.repl_full_sync_buffer.blocks)
-        return C_OK;
+        goto out;
+
+    /* Mark the peek buffer block count. We'll use it to verify we consume
+     * faster than we read from the master. */
+    server.repl_full_sync_buffer.peak_num_blocks = listLength(server.repl_full_sync_buffer.blocks);
+    /* Set read handler to continue accumulating during streaming */
+    connSetReadHandler(c->conn, rdbChannelBufferReplData);
 
     blockingOperationStarts();
-    protectClient(c);
     while ((n = listFirst(server.repl_full_sync_buffer.blocks))) {
         o = listNodeValue(n);
-        size = o->size;
-        used = o->used;
-        c->querybuf = sdscatlen(c->querybuf, o->buf, used);
-        c->read_reploff += (long long int) used;
-        listDelNode(server.repl_full_sync_buffer.blocks, n);
+        listUnlinkNode(server.repl_full_sync_buffer.blocks, n);
+        zfree(n);
 
-        /* We don't expect error return value but just in case. */
-        ret = processInputBuffer(c);
+        size_t processed = 0;
+        while (processed < o->used) {
+            size_t bytes = min(16384, o->used - processed);
+            c->querybuf = sdscatlen(c->querybuf, &o->buf[processed], bytes);
+            c->read_reploff += (long long int) bytes;
+
+            /* We don't expect error return value but just in case. */
+            ret = processInputBuffer(c);
+            if (ret != C_OK)
+                break;
+
+            processed += bytes;
+            server.repl_full_sync_buffer.used -= bytes;
+
+            if (server.repl_debug_pause & REPL_DEBUG_ON_STREAMING_REPL_BUF)
+                debugPauseProcess();
+
+            /* Check if we should yield back to the event loop */
+            if (server.loading_process_events_interval_bytes &&
+                ((offset + bytes) / server.loading_process_events_interval_bytes >
+                  offset / server.loading_process_events_interval_bytes))
+            {
+                replicationSendNewlineToMaster();
+                processEventsWhileBlocked();
+            }
+
+            offset += bytes;
+            /* Check if master client was freed in processEventsWhileBlocked().
+             * It can happen if we receive 'replicaof' command or 'client kill'
+             * command for the master. */
+            master_disconnected = (seq != server.repl_num_master_disconnection);
+            if (master_disconnected ||
+                !server.repl_full_sync_buffer.blocks ||
+                c->flags & CLIENT_CLOSE_ASAP)
+            {
+                ret = C_ERR;
+                break;
+            }
+        }
+        size_t size = o->size;
+        zfree(o);
+
+        /* Break the loop if there is an error. */
         if (ret != C_OK)
             break;
-
-        server.repl_full_sync_buffer.used -= used;
+        /* Update stats */
         server.repl_full_sync_buffer.size -= size;
         server.repl_full_sync_buffer.mem_used -= (size + sizeof(listNode) +
-                                                    sizeof(replDataBufBlock));
-        if (server.repl_debug_pause & REPL_DEBUG_ON_STREAMING_REPL_BUF)
-            debugPauseProcess();
-
-        /* Check if we should yield back to the event loop */
-        if (server.loading_process_events_interval_bytes &&
-            ((offset + used) / server.loading_process_events_interval_bytes >
-             offset / server.loading_process_events_interval_bytes))
-        {
-            replicationSendNewlineToMaster();
-            processEventsWhileBlocked();
-        }
-
-        offset += used;
-        /* Check if master client was freed in processEventsWhileBlocked().
-         * It can happen if we receive 'replicaof' command or 'client kill'
-         * command for the master. */
-        if (c->flags & CLIENT_CLOSE_ASAP || !server.repl_full_sync_buffer.blocks) {
-            ret = C_ERR;
-            break;
-        }
+                                                  sizeof(replDataBufBlock));
     }
-    unprotectClient(c);
     blockingOperationEnds();
 
-    if (ret != C_OK) {
+out:
+    if (ret == C_OK) {
+        serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Successfully streamed replication buffer into the db (%zu bytes in total)", offset);
+        /* Revert the read handler */
+        if (connSetReadHandler(c->conn, readQueryFromClient) != C_OK) {
+            serverLog(LL_WARNING,
+                      "Can't create readable event for master client: %s",
+                      strerror(errno));
+            close_asap = 1;
+        }
+    } else {
         serverLog(LL_WARNING, "Master client was freed while streaming accumulated replication data to db.");
-        return C_ERR;
+        close_asap = 1;
     }
 
-    return C_OK;
+    /* If master_disconnected is set, state should have been cleaned up
+     * already. Otherwise, we do it here. */
+    if (!master_disconnected) {
+        rdbChannelCleanup();
+        if (server.master && close_asap)
+            freeClient(server.master);
+    }
+}
+
+static void rdbChannelCleanup(void) {
+    server.repl_rdb_ch_state = REPL_RDB_CH_STATE_NONE;
+    server.repl_main_ch_state = REPL_MAIN_CH_NONE;
+    rdbChannelReplDataBufFree();
 }
 
 /* Replication: Replica side.
@@ -3841,11 +3912,24 @@ static int rdbChannelAbortRdbTransfer(void) {
     if (server.repl_rdb_ch_state == REPL_RDB_CH_STATE_NONE)
         return C_OK;
 
-    if (server.repl_rdb_transfer_s) {
-        if (server.loading) {
-            /* If loading flag is set, we want to handle cleanup asynchronously.
-             * We set REPL_RDB_CH_STATE_CLOSE_ASAP so it will be handled just
-             * outside loading loop.*/
+    /* This function may also be called if a problem is detected on the main
+     * channel. In this case, we handle the situation differently based on
+     * the current state:
+     * - If we started loading the RDB file and the RDB is disk-based, we mark
+     *   the main channel's state as CLOSE_ASAP and defer the failure handling
+     *   until after the RDB has been loaded. This way we allow the replica to
+     *   retry psync after the RDB is loaded.
+     * - For diskless loading, we cannot safely free the rdb channel connection
+     *   object. Instead, we mark the RIO object as aborted so the next
+     *   rioRead() will fail safely.
+     * - If the RDB has already been loaded, and we are streaming the
+     *   accumulated buffer to the database, we mark the main connection
+     *   as CLOSE_ASAP and wait until the accumulated buffer is drained.
+     *   Once done, the replica can attempt psync with the offset it has. */
+    int async_cleanup = (server.repl_rdb_transfer_s && server.loading) ||
+                        (server.repl_main_ch_state & REPL_MAIN_CH_STREAMING_BUF);
+    if (async_cleanup) {
+        if (server.repl_rdb_transfer_s && server.loading) {
             serverLog(LL_NOTICE, "Aborting rdb channel sync while loading the RDB.");
 
             if (disklessLoadingRio)
@@ -3857,19 +3941,21 @@ static int rdbChannelAbortRdbTransfer(void) {
                  * later.*/
                 serverLog(LL_NOTICE, "After loading RDB, replica will try psync with master.");
             }
-
-            if (server.repl_transfer_s)
-                connSetReadHandler(server.repl_transfer_s, NULL);
-
-            server.repl_rdb_ch_state = REPL_RDB_CH_STATE_CLOSE_ASAP;
-            return C_ERR;
         }
-        connClose(server.repl_rdb_transfer_s);
-        server.repl_rdb_transfer_s = NULL;
+
+        if (server.repl_transfer_s)
+            connSetReadHandler(server.repl_transfer_s, NULL);
+
+        server.repl_main_ch_state |= REPL_MAIN_CH_CLOSE_ASAP;
+        return C_ERR;
     }
 
     serverLog(LL_NOTICE, "Aborting rdb channel sync");
 
+    if (server.repl_rdb_transfer_s) {
+        connClose(server.repl_rdb_transfer_s);
+        server.repl_rdb_transfer_s = NULL;
+    }
     if (server.repl_transfer_fd != -1) {
         close(server.repl_transfer_fd);
         server.repl_transfer_fd = -1;
@@ -3879,28 +3965,8 @@ static int rdbChannelAbortRdbTransfer(void) {
         zfree(server.repl_transfer_tmpfile);
         server.repl_transfer_tmpfile = NULL;
     }
-    rdbChannelReplDataBufFree();
-    server.repl_rdb_ch_state = REPL_RDB_CH_STATE_NONE;
+    rdbChannelCleanup();
     return C_OK;
-}
-
-/* Replica side. After loading the rdb, stream replication buffer to the db. */
-static void rdbChannelSuccess(void) {
-    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Starting to stream replication buffer into the db"
-                         " (%zu bytes).", server.repl_full_sync_buffer.used);
-
-    if (rdbChannelStreamReplDataToDb(server.master) == C_ERR) {
-        serverLog(LL_WARNING, "Failed to stream local replication buffer into the db");
-
-        rdbChannelAbortRdbTransfer();
-        if (server.master)
-            freeClientAsync(server.master);
-        return;
-    }
-
-    serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Successfully streamed replication buffer into the db");
-    rdbChannelReplDataBufFree();
-    server.repl_rdb_ch_state = REPL_RDB_CH_STATE_NONE;
 }
 
 void replicaofCommand(client *c) {

--- a/src/replication.c
+++ b/src/replication.c
@@ -3677,7 +3677,7 @@ static void rdbChannelReplDataBufInit(void) {
     serverAssert(server.repl_full_sync_buffer.blocks == NULL);
     server.repl_full_sync_buffer.size = 0;
     server.repl_full_sync_buffer.used = 0;
-    server.repl_full_sync_buffer.peak_num_blocks = 0;
+    server.repl_full_sync_buffer.last_num_blocks = 0;
     server.repl_full_sync_buffer.mem_used = 0;
     server.repl_full_sync_buffer.blocks = listCreate();
     server.repl_full_sync_buffer.blocks->free = zfree;
@@ -3690,7 +3690,7 @@ static void rdbChannelReplDataBufFree(void) {
     server.repl_full_sync_buffer.blocks = NULL;
     server.repl_full_sync_buffer.size = 0;
     server.repl_full_sync_buffer.used = 0;
-    server.repl_full_sync_buffer.peak_num_blocks = 0;
+    server.repl_full_sync_buffer.last_num_blocks = 0;
     server.repl_full_sync_buffer.mem_used = 0;
 }
 
@@ -3734,9 +3734,9 @@ void rdbChannelBufferReplData(connection *conn) {
          * than we read, we'll read at most one block after two blocks of
          * buffers are consumed. */
         replDataBuf *buf = &server.repl_full_sync_buffer;
-        if (listLength(buf->blocks) + 1 >= buf->peak_num_blocks)
+        if (listLength(buf->blocks) + 1 >= buf->last_num_blocks)
             return;
-        buf->peak_num_blocks = listLength(buf->blocks);
+        buf->last_num_blocks = listLength(buf->blocks);
     }
 
     /* Try to append last node. */
@@ -3787,7 +3787,7 @@ void rdbChannelBufferReplData(connection *conn) {
 /* Replication: Replica side.
  * Streams accumulated replication data into the database. */
 static void rdbChannelStreamReplDataToDb(void) {
-    int ret = C_OK, master_disconnected = 0;
+    int ret = C_OK, master_disconnected = 0, close_asap = 0;
     size_t offset = 0;
     listNode *n = NULL;
     replDataBufBlock *o = NULL;
@@ -3797,13 +3797,6 @@ static void rdbChannelStreamReplDataToDb(void) {
      * disconnected when we yield back to processEventsWhileBlocked() */
     uint64_t seq = server.repl_num_master_disconnection;
 
-    /* At this point, RDB is loaded. If main channel state is CLOSE_ASAP,
-     * it means main channel faced a problem while RDB is being loaded. It
-     * stopped replication stream buffering. It's okay though. We'll stream
-     * whatever we have into the db, then replica will try psync from the
-     * index that it has. */
-    int close_asap = (server.repl_main_ch_state & REPL_MAIN_CH_CLOSE_ASAP);
-
     server.repl_main_ch_state |= REPL_MAIN_CH_STREAMING_BUF;
     serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Starting to stream replication buffer into the db"
                          " (%zu bytes).", server.repl_full_sync_buffer.used);
@@ -3812,7 +3805,7 @@ static void rdbChannelStreamReplDataToDb(void) {
 
     /* Mark the peek buffer block count. We'll use it to verify we consume
      * faster than we read from the master. */
-    server.repl_full_sync_buffer.peak_num_blocks = listLength(server.repl_full_sync_buffer.blocks);
+    server.repl_full_sync_buffer.last_num_blocks = listLength(server.repl_full_sync_buffer.blocks);
     /* Set read handler to continue accumulating during streaming */
     connSetReadHandler(c->conn, rdbChannelBufferReplData);
 
@@ -3875,10 +3868,17 @@ static void rdbChannelStreamReplDataToDb(void) {
     blockingOperationEnds();
 
 out:
+    /* If main channel state is CLOSE_ASAP, it means main channel faced a
+     * problem while RDB is being loaded or while we are applying the
+     * accumulated buffer. It stopped replication stream buffering. It's okay
+     * though. We streamed whatever we have into the db, now we can free master
+     * client and replica can try psync. */
+    close_asap = (server.repl_main_ch_state & REPL_MAIN_CH_CLOSE_ASAP);
+
     if (ret == C_OK) {
         serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Successfully streamed replication buffer into the db (%zu bytes in total)", offset);
         /* Revert the read handler */
-        if (connSetReadHandler(c->conn, readQueryFromClient) != C_OK) {
+        if (!close_asap && connSetReadHandler(c->conn, readQueryFromClient) != C_OK) {
             serverLog(LL_WARNING,
                       "Can't create readable event for master client: %s",
                       strerror(errno));

--- a/src/replication.c
+++ b/src/replication.c
@@ -3583,7 +3583,7 @@ static int rdbChannelHandleFullresyncReply(connection *conn, sds *err) {
     serverLog(LL_NOTICE, "Starting to receive RDB and replication stream in parallel.");
 
     /* Setup connection to accumulate repl data.  */
-    server.repl_main_ch_state = REPL_MAIN_CH_NONE;
+    server.repl_main_ch_state = REPL_MAIN_CH_ACCUMULATE_BUF;
     if (connSetReadHandler(server.repl_transfer_s,
                            rdbChannelBufferReplData) != C_OK)
     {
@@ -3734,7 +3734,7 @@ void rdbChannelBufferReplData(connection *conn) {
          * than we read, we'll read at most one block after two blocks of
          * buffers are consumed. */
         replDataBuf *buf = &server.repl_full_sync_buffer;
-        if (listLength(buf->blocks) + 2 > buf->peak_num_blocks)
+        if (listLength(buf->blocks) + 1 >= buf->peak_num_blocks)
             return;
         buf->peak_num_blocks = listLength(buf->blocks);
     }
@@ -3824,7 +3824,7 @@ static void rdbChannelStreamReplDataToDb(void) {
 
         size_t processed = 0;
         while (processed < o->used) {
-            size_t bytes = min(16384, o->used - processed);
+            size_t bytes = min(PROTO_IOBUF_LEN, o->used - processed);
             c->querybuf = sdscatlen(c->querybuf, &o->buf[processed], bytes);
             c->read_reploff += (long long int) bytes;
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -45,7 +45,7 @@ int replicaPutOnline(client *slave);
 void replicaStartCommandStream(client *slave);
 int cancelReplicationHandshake(int reconnect);
 static void rdbChannelFullSyncWithMaster(connection *conn);
-static int rdbChannelAbortRdbTransfer(void);
+static int rdbChannelAbort(void);
 static void rdbChannelBufferReplData(connection *conn);
 static void rdbChannelReplDataBufInit(void);
 static void rdbChannelStreamReplDataToDb(void);
@@ -3194,7 +3194,7 @@ void replicationAbortSyncTransfer(void) {
  *
  * Otherwise zero is returned and no operation is performed at all. */
 int cancelReplicationHandshake(int reconnect) {
-    if (rdbChannelAbortRdbTransfer() != C_OK)
+    if (rdbChannelAbort() != C_OK)
         return 1;
 
     if (server.repl_state == REPL_STATE_TRANSFER) {
@@ -3667,7 +3667,7 @@ error:
         server.repl_transfer_s = NULL;
     }
     server.repl_state = REPL_STATE_CONNECT;
-    rdbChannelAbortRdbTransfer();
+    rdbChannelAbort();
 }
 
 /* Replication: Replica side.
@@ -3908,7 +3908,7 @@ static void rdbChannelCleanup(void) {
  * On rdb channel failure, close rdb-connection and reset state.
  * Return C_OK if cleanup is done. Otherwise, returns C_ERR which means cleanup
  * will be done asynchronously. */
-static int rdbChannelAbortRdbTransfer(void) {
+static int rdbChannelAbort(void) {
     if (server.repl_rdb_ch_state == REPL_RDB_CH_STATE_NONE)
         return C_OK;
 

--- a/src/server.c
+++ b/src/server.c
@@ -2195,6 +2195,7 @@ void initServerConfig(void) {
     server.master_initial_offset = -1;
     server.repl_state = REPL_STATE_NONE;
     server.repl_rdb_ch_state = REPL_RDB_CH_STATE_NONE;
+    server.repl_num_master_disconnection = 0;
     server.repl_full_sync_buffer = (struct replDataBuf) {0};
     server.repl_transfer_tmpfile = NULL;
     server.repl_transfer_fd = -1;

--- a/src/server.h
+++ b/src/server.h
@@ -1236,7 +1236,7 @@ typedef struct replDataBuf {
     size_t size;  /* Total number of bytes available in all blocks. */
     size_t used;  /* Total number of bytes actually used in all blocks. */
     size_t peak;  /* Peak number of bytes stored in all blocks. */
-    size_t peak_num_blocks; /* Used to verify we consume more than we read from
+    size_t last_num_blocks; /* Used to verify we consume more than we read from
                              * the master connection while streaming buffer to
                              * the db. */
 } replDataBuf;

--- a/src/server.h
+++ b/src/server.h
@@ -480,7 +480,6 @@ typedef enum {
 /* Replica rdb channel replication state. Used in server.repl_rdb_ch_state for
  * replicas to remember what to do next. */
 typedef enum {
-    REPL_RDB_CH_STATE_CLOSE_ASAP = -1,  /* Async error state */
     REPL_RDB_CH_STATE_NONE = 0,         /* No active rdb channel sync */
     REPL_RDB_CH_SEND_HANDSHAKE,         /* Send handshake sequence to master */
     REPL_RDB_CH_RECEIVE_AUTH_REPLY,     /* Wait for AUTH reply */
@@ -488,6 +487,10 @@ typedef enum {
     REPL_RDB_CH_RECEIVE_FULLRESYNC,     /* Wait for +FULLRESYNC reply */
     REPL_RDB_CH_RDB_LOADING,            /* Loading rdb using rdb channel */
 } repl_rdb_channel_state;
+
+#define REPL_MAIN_CH_NONE          (1 << 0)
+#define REPL_MAIN_CH_STREAMING_BUF (1 << 1)
+#define REPL_MAIN_CH_CLOSE_ASAP    (1 << 2)
 
 /* Replication debug flags for testing. */
 #define REPL_DEBUG_PAUSE_NONE             (1 << 0)
@@ -1232,6 +1235,9 @@ typedef struct replDataBuf {
     size_t size;  /* Total number of bytes available in all blocks. */
     size_t used;  /* Total number of bytes actually used in all blocks. */
     size_t peak;  /* Peak number of bytes stored in all blocks. */
+    size_t peak_num_blocks; /* Used to verify we consume more than we read from
+                             * the master connection while streaming buffer to
+                             * the db. */
 } replDataBuf;
 
 typedef struct {
@@ -2057,6 +2063,8 @@ struct redisServer {
     int repl_syncio_timeout; /* Timeout for synchronous I/O calls */
     int repl_state;          /* Replication status if the instance is a slave */
     int repl_rdb_ch_state; /* State of the replica's rdb channel during rdb channel replication */
+    int repl_main_ch_state; /* State of the replica's main channel during rdb channel replication */
+    uint64_t repl_num_master_disconnection; /* Number of master connection was disconnected */
     uint64_t repl_main_ch_client_id; /* Main channel client id received in +RDBCHANNELSYNC reply. */
     off_t repl_transfer_size; /* Size of RDB to read from master during sync. */
     off_t repl_transfer_read; /* Amount of RDB read from master during sync. */

--- a/src/server.h
+++ b/src/server.h
@@ -488,9 +488,10 @@ typedef enum {
     REPL_RDB_CH_RDB_LOADING,            /* Loading rdb using rdb channel */
 } repl_rdb_channel_state;
 
-#define REPL_MAIN_CH_NONE          (1 << 0)
-#define REPL_MAIN_CH_STREAMING_BUF (1 << 1)
-#define REPL_MAIN_CH_CLOSE_ASAP    (1 << 2)
+#define REPL_MAIN_CH_NONE           (1 << 0)
+#define REPL_MAIN_CH_ACCUMULATE_BUF (1 << 1)
+#define REPL_MAIN_CH_STREAMING_BUF  (1 << 2)
+#define REPL_MAIN_CH_CLOSE_ASAP     (1 << 3)
 
 /* Replication debug flags for testing. */
 #define REPL_DEBUG_PAUSE_NONE             (1 << 0)

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -17,7 +17,7 @@ set ::tlsdir "tests/tls"
 
 # Continuously sends SET commands to the server. If key is omitted, a random key
 # is used for every SET command. The value is always random.
-proc gen_write_load {host port seconds tls {key ""} {size 0}} {
+proc gen_write_load {host port seconds tls {key ""} {size 0} {sleep 0}} {
     set start_time [clock seconds]
     set r [redis $host $port 1 $tls]
     $r client setname LOAD_HANDLER
@@ -41,7 +41,10 @@ proc gen_write_load {host port seconds tls {key ""} {size 0}} {
         if {[clock seconds]-$start_time > $seconds} {
             exit 0
         }
+        if {$sleep ne 0} {
+            after $sleep
+        }
     }
 }
 
-gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5]
+gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5] [lindex $argv 6]

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -17,16 +17,26 @@ set ::tlsdir "tests/tls"
 
 # Continuously sends SET commands to the server. If key is omitted, a random key
 # is used for every SET command. The value is always random.
-proc gen_write_load {host port seconds tls {key ""}} {
+proc gen_write_load {host port seconds tls {key ""} {size 0}} {
     set start_time [clock seconds]
     set r [redis $host $port 1 $tls]
     $r client setname LOAD_HANDLER
     $r select 9
+
+    # fixed size value
+    if {$size != 0} {
+        set value [string repeat "x" $size]
+    }
+
     while 1 {
+        if {$size == 0} {
+            set value [expr rand()]
+        }
+
         if {$key == ""} {
-            $r set [expr rand()] [expr rand()]
+            $r set [expr rand()] $value
         } else {
-            $r set $key [expr rand()]
+            $r set $key $value
         }
         if {[clock seconds]-$start_time > $seconds} {
             exit 0
@@ -34,4 +44,4 @@ proc gen_write_load {host port seconds tls {key ""}} {
     }
 }
 
-gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4]
+gen_write_load [lindex $argv 0] [lindex $argv 1] [lindex $argv 2] [lindex $argv 3] [lindex $argv 4] [lindex $argv 5]

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -241,7 +241,7 @@ start_server {tags {"repl external:skip"}} {
             # Put some delay to rdb generation. If master doesn't forward
             # incoming traffic to replica, master's replication buffer will grow
             $master config set repl-diskless-sync-delay 0
-            $master config set rdb-key-save-delay 500 ;# 200us delay and 10k keys means at least 5 seconds replication
+            $master config set rdb-key-save-delay 500 ;# 500us delay and 10k keys means at least 5 seconds replication
             $master config set repl-backlog-size 5mb
             $replica config set replica-full-sync-buffer-limit 200mb
             populate 10000 master 10000 ;# 10k keys of 10k, means 100mb

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -240,27 +240,56 @@ start_server {tags {"repl external:skip"}} {
         test "Test master memory does not increase during replication" {
             # Put some delay to rdb generation. If master doesn't forward
             # incoming traffic to replica, master's replication buffer will grow
-            $master config set rdb-key-save-delay 200
+            $master config set repl-diskless-sync-delay 0
+            # 500us delay and 10k keys means at least 5 seconds replication
+            $master config set rdb-key-save-delay 500
             $master config set repl-backlog-size 5mb
-            populate 10000 master 10000
+            populate 10000 master 10000 ;# 10k keys of 10k, means 100mb
+
+            # process events every 1mb of rdb or command stream
+            $replica config set loading-process-events-interval-bytes 1048576
+            $replica config set replica-full-sync-buffer-limit 600mb
 
             # Start write traffic
-            set load_handle [start_write_load $master_host $master_port 100 "key1"]
+            set load_handle [start_write_load $master_host $master_port 100 "key1" 50]
+
             set prev_used [s 0 used_memory]
 
             $replica replicaof $master_host $master_port
             set backlog_size [lindex [$master config get repl-backlog-size] 1]
 
             # Verify used_memory stays low
-            set max_retry 1000
-            set prev_buf_size 0
-            while {$max_retry} {
-                assert_lessthan [expr [s 0 used_memory] - $prev_used] 20000000
-                assert_lessthan_equal [s 0 mem_total_replication_buffers] [expr {$backlog_size + 1000000}]
+            set max_retry 2000
+            set peak_replica_buf_size 0
+            set peak_master_slave_buf_size 0
+            set peak_master_client_buf_size 0
+            set peak_master_used_mem 0
+            set peak_master_rpl_buf 0
 
-                # Check replica state
+            while {$max_retry} {
+                set replica_buf_size [s -1 replica_full_sync_buffer_size]
+                set master_slave_buf_size [s mem_clients_slaves]
+                set master_client_buf_size [s mem_clients_normal]
+                set master_rpl_buf [s mem_total_replication_buffers]
+                set master_used_mem [s used_memory]
+
+                if {$replica_buf_size > $peak_replica_buf_size} {set peak_replica_buf_size $replica_buf_size}
+                if {$master_slave_buf_size > $peak_master_slave_buf_size} {set peak_master_slave_buf_size $master_slave_buf_size}
+                if {$master_rpl_buf > $peak_master_rpl_buf} {set peak_master_rpl_buf $master_rpl_buf}
+
+                # note: client output buffer of load handler client might become
+                # big (a few megabytes), decrementing it from the used memory.
+                set master_used_mem_adjusted [expr $master_used_mem - $master_client_buf_size]
+                if {$master_used_mem_adjusted > $peak_master_used_mem} {set peak_master_used_mem $master_used_mem_adjusted}
+
+                if {$::verbose} {
+                    puts "[clock format [clock seconds] -format %H:%M:%S] master: $master_slave_buf_size replica: $replica_buf_size"
+                }
+
+                # Wait for the replica to finish reading the rdb (also from the master's perspective), and also consume much of the replica buffer
                 if {[string match *slave0*state=online* [$master info]] &&
-                    [s -1 master_link_status] == "up"} {
+                    [s -1 master_link_status] == "up" &&
+                    $replica_buf_size < 100000} {
                     break
                 } else {
                     incr max_retry -1
@@ -268,8 +297,24 @@ start_server {tags {"repl external:skip"}} {
                 }
             }
             if {$max_retry == 0} {
-                error "assertion:Replica not in sync after 10 seconds"
+                error "assertion:Replica not in sync after 20 seconds"
             }
+
+            if {$::verbose} {
+                puts "peak_master_used_mem $peak_master_used_mem"
+                puts "peak_master_rpl_buf $peak_master_rpl_buf"
+                puts "peak_master_slave_buf_size $peak_master_slave_buf_size"
+                puts "peak_master_client_buf_size $peak_master_client_buf_size"
+                puts "peak_replica_buf_size $peak_replica_buf_size"
+            }
+
+            # memory on the master is less than 1mb
+            assert_lessthan [expr $peak_master_used_mem - $prev_used - $backlog_size] 1000000
+            assert_lessthan $peak_master_rpl_buf [expr {$backlog_size + 1000000}]
+            assert_lessthan $peak_master_slave_buf_size 1000000
+
+            # buffers in the replica are more than 3mb
+            assert_morethan $peak_replica_buf_size 3000000
 
             stop_write_load $load_handle
         }
@@ -798,6 +843,84 @@ start_server {tags {"repl external:skip"}} {
             wait_for_ofs_sync $master $replica
             assert_morethan [$master dbsize] 0
             assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip"}} {
+    set master2 [srv 0 client]
+    set master2_host [srv 0 host]
+    set master2_port [srv 0 port]
+    start_server {tags {"repl external:skip"}} {
+        set replica [srv 0 client]
+        set replica_pid  [srv 0 pid]
+
+        start_server {} {
+            set master [srv 0 client]
+            set master_host [srv 0 host]
+            set master_port [srv 0 port]
+
+            test "Test replicaof command while streaming repl buffer into the db" {
+                # After replica loads the RDB, it will stream repl buffer into
+                # the db. During streaming, replica receives command
+                # "replicaof newmaster". Replica will abort streaming and then
+                # should be able to connect to the new master.
+                $master config set rdb-key-save-delay 1000
+                $master config set repl-rdb-channel yes
+                $master config set repl-diskless-sync yes
+                $replica config set repl-rdb-channel yes
+                $replica config set loading-process-events-interval-bytes 1024
+
+                # Populate db and start write traffic
+                populate 2000 master 1000
+                set load_handle [start_write_load $master_host $master_port 100 "key1"]
+
+                # Replica will pause in the loop of repl buffer streaming
+                $replica debug repl-pause on-streaming-repl-buf
+                $replica replicaof $master_host $master_port
+
+                # Check if repl stream accumulation is started.
+                wait_for_condition 50 1000 {
+                    [s -1 replica_full_sync_buffer_size] > 0
+                } else {
+                    fail "repl stream accumulation not started"
+                }
+
+                # Wait until replica starts streaming repl buffer
+                wait_for_log_messages -1 {"*Starting to stream replication buffer*"} 0 2000 10
+                stop_write_load $load_handle
+                $master config set rdb-key-save-delay 0
+
+                # Populate the other master
+                populate 100 master2 100 -2
+
+                # Send "replicaof newmaster" command and resume the process
+                $replica deferred 1
+                $replica replicaof $master2_host $master2_port
+                $replica debug repl-pause clear
+                resume_process $replica_pid
+                $replica read
+                $replica read
+                $replica deferred 0
+
+                wait_for_log_messages -1 {"*Master client was freed while streaming*"} 0 500 10
+
+                # Wait until replica recovers and verify db's are identical
+                wait_replica_online $master2 0 1000 10
+                wait_for_ofs_sync $master2 $replica
+                assert_morethan [$master2 dbsize] 0
+                assert_equal [$master2 debug digest] [$replica debug digest]
+
+                # Try replication once more to be sure everything is okay.
+                $replica replicaof no one
+                $master2 set x 100
+
+                $replica replicaof $master2_host $master2_port
+                wait_replica_online $master2 0 1000 10
+                wait_for_ofs_sync $master2 $replica
+                assert_morethan [$master2 dbsize] 0
+                assert_equal [$master2 debug digest] [$replica debug digest]
+            }
         }
     }
 }

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -241,17 +241,15 @@ start_server {tags {"repl external:skip"}} {
             # Put some delay to rdb generation. If master doesn't forward
             # incoming traffic to replica, master's replication buffer will grow
             $master config set repl-diskless-sync-delay 0
-            # 500us delay and 10k keys means at least 5 seconds replication
-            $master config set rdb-key-save-delay 500
+            $master config set rdb-key-save-delay 500 ;# 200us delay and 10k keys means at least 5 seconds replication
             $master config set repl-backlog-size 5mb
+            $replica config set replica-full-sync-buffer-limit 200mb
             populate 10000 master 10000 ;# 10k keys of 10k, means 100mb
+            $replica config set loading-process-events-interval-bytes 262144 ;# process events every 256kb of rdb or command stream
 
-            # process events every 1mb of rdb or command stream
-            $replica config set loading-process-events-interval-bytes 1048576
-            $replica config set replica-full-sync-buffer-limit 600mb
+            # Start write traffic writing at most 5mbps
 
-            # Start write traffic
-            set load_handle [start_write_load $master_host $master_port 100 "key1" 50]
+            set load_handle [start_write_load $master_host $master_port 100 "key1" 10000 2]
 
             set prev_used [s 0 used_memory]
 
@@ -259,29 +257,20 @@ start_server {tags {"repl external:skip"}} {
             set backlog_size [lindex [$master config get repl-backlog-size] 1]
 
             # Verify used_memory stays low
-            set max_retry 2000
+            set max_retry 1000
             set peak_replica_buf_size 0
             set peak_master_slave_buf_size 0
-            set peak_master_client_buf_size 0
             set peak_master_used_mem 0
             set peak_master_rpl_buf 0
-
             while {$max_retry} {
                 set replica_buf_size [s -1 replica_full_sync_buffer_size]
                 set master_slave_buf_size [s mem_clients_slaves]
-                set master_client_buf_size [s mem_clients_normal]
-                set master_rpl_buf [s mem_total_replication_buffers]
                 set master_used_mem [s used_memory]
-
+                set master_rpl_buf [s mem_total_replication_buffers]
                 if {$replica_buf_size > $peak_replica_buf_size} {set peak_replica_buf_size $replica_buf_size}
                 if {$master_slave_buf_size > $peak_master_slave_buf_size} {set peak_master_slave_buf_size $master_slave_buf_size}
+                if {$master_used_mem > $peak_master_used_mem} {set peak_master_used_mem $master_used_mem}
                 if {$master_rpl_buf > $peak_master_rpl_buf} {set peak_master_rpl_buf $master_rpl_buf}
-
-                # note: client output buffer of load handler client might become
-                # big (a few megabytes), decrementing it from the used memory.
-                set master_used_mem_adjusted [expr $master_used_mem - $master_client_buf_size]
-                if {$master_used_mem_adjusted > $peak_master_used_mem} {set peak_master_used_mem $master_used_mem_adjusted}
-
                 if {$::verbose} {
                     puts "[clock format [clock seconds] -format %H:%M:%S] master: $master_slave_buf_size replica: $replica_buf_size"
                 }
@@ -289,7 +278,7 @@ start_server {tags {"repl external:skip"}} {
                 # Wait for the replica to finish reading the rdb (also from the master's perspective), and also consume much of the replica buffer
                 if {[string match *slave0*state=online* [$master info]] &&
                     [s -1 master_link_status] == "up" &&
-                    $replica_buf_size < 100000} {
+                    $replica_buf_size < 1000000} {
                     break
                 } else {
                     incr max_retry -1
@@ -297,24 +286,21 @@ start_server {tags {"repl external:skip"}} {
                 }
             }
             if {$max_retry == 0} {
-                error "assertion:Replica not in sync after 20 seconds"
+                error "assertion:Replica not in sync after 10 seconds"
             }
 
             if {$::verbose} {
                 puts "peak_master_used_mem $peak_master_used_mem"
                 puts "peak_master_rpl_buf $peak_master_rpl_buf"
                 puts "peak_master_slave_buf_size $peak_master_slave_buf_size"
-                puts "peak_master_client_buf_size $peak_master_client_buf_size"
                 puts "peak_replica_buf_size $peak_replica_buf_size"
             }
-
             # memory on the master is less than 1mb
             assert_lessthan [expr $peak_master_used_mem - $prev_used - $backlog_size] 1000000
             assert_lessthan $peak_master_rpl_buf [expr {$backlog_size + 1000000}]
             assert_lessthan $peak_master_slave_buf_size 1000000
-
-            # buffers in the replica are more than 3mb
-            assert_morethan $peak_replica_buf_size 3000000
+            # buffers in the replica are more than 10mb
+            assert_morethan $peak_replica_buf_size 10000000
 
             stop_write_load $load_handle
         }

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -580,9 +580,9 @@ proc find_valgrind_errors {stderr on_termination} {
 # Execute a background process writing random data for the specified number
 # of seconds to the specified Redis instance. If key is omitted, a random key
 # is used for every SET command.
-proc start_write_load {host port seconds {key ""}} {
+proc start_write_load {host port seconds {key ""} {size 0}} {
     set tclsh [info nameofexecutable]
-    exec $tclsh tests/helpers/gen_write_load.tcl $host $port $seconds $::tls $key &
+    exec $tclsh tests/helpers/gen_write_load.tcl $host $port $seconds $::tls $key $size &
 }
 
 # Stop a process generating write load executed with start_write_load.

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -580,9 +580,9 @@ proc find_valgrind_errors {stderr on_termination} {
 # Execute a background process writing random data for the specified number
 # of seconds to the specified Redis instance. If key is omitted, a random key
 # is used for every SET command.
-proc start_write_load {host port seconds {key ""} {size 0}} {
+proc start_write_load {host port seconds {key ""} {size 0} {sleep 0}} {
     set tclsh [info nameofexecutable]
-    exec $tclsh tests/helpers/gen_write_load.tcl $host $port $seconds $::tls $key $size &
+    exec $tclsh tests/helpers/gen_write_load.tcl $host $port $seconds $::tls $key $size $sleep &
 }
 
 # Stop a process generating write load executed with start_write_load.


### PR DESCRIPTION
With RDB channel replication, we introduced parallel replication stream and RDB delivery to the replica during a full sync. Currently, after the replica loads the RDB and begins streaming the accumulated buffer to the database, it does not read from the master connection during this period. Although streaming the local buffer is generally a fast operation, it can take some time if the buffer is large. This PR introduces buffering during the streaming of the local buffer. One important consideration is ensuring that we consume more than we read during this operation; otherwise, it could take indefinitely. To guarantee that it will eventually complete, we limit the read to at most half of what we consume, e.g. read at most 1 mb once we consume at least 2 mb. 

**Additional changes**

**Bug fix**
- Currently, when replica starts draining accumulated buffer, we call protectClient() for the master client as we occasionally yield back to event loop via processEventsWhileBlocked(). So, it prevents freeing the master client. While we are in this loop, if replica receives "replicaof newmaster" command, we call replicaSetMaster() which expects to free the master client and trigger a new connection attempt. As the client object is protected, its destruction will happen asynchronously. Though, a new connection attempt to new master will be made immediately. Later, when the replication buffer is drained, we realize master client was marked as CLOSE_ASAP, and freeing master client triggers another connection attempt to the new master. In most cases, we realize something is wrong in the replication state machine and abort the second attempt later. So, the bug may go undetected. Fix is not calling protectClient() for the master client. Instead, trying to detect if master client is disconnected during processEventsWhileBlocked() and if so, breaking the loop immediately. 

**Related improvement:** 
- Currently, the replication buffer is a linked list of buffers, each of which is 1 MB in size. While consuming the buffer, we process one buffer at a time and check if we need to yield back to `processEventsWhileBlocked()`. However, if `loading-process-events-interval-bytes` is set to less than 1 MB, this approach doesn't handle it well. To improve this, I've modified the code to process 16KB at a time and check `loading-process-events-interval-bytes` more frequently. This way, depending on the configuration, we may yield back to networking more often.

- In replication.c, `disklessLoadingRio` will be set before a call to `emptyData()`. This change should not introduce any behavioral change but it is logically more correct as emptyData() may yield to networking and we may need to call rioAbort() on disklessLoadingRio. Otherwise, failure of main channel may go undetected until a failure on rdb channel on a corner case. 

**Config changes**
- The default value for the `loading-process-events-interval-bytes` configuration is being lowered from 2MB to 512KB. This configuration primarily used for testing and controls the frequency of networking during the loading phase, specifically when loading the RDB or applying accumulated buffers during a full sync on the replica side.

  Before the introduction of RDB channel replication, the 2MB value was sufficient for occasionally yielding to networking, mainly to reply -loading to the clients. However, with RDB channel replication, during a full sync on the replica side (either while loading the RDB or applying the accumulated buffer), we need to yield back to networking more frequently to continue accumulating the replication stream. If this doesn’t happen often enough, the replication stream can accumulate on the master side, which is undesirable.
  
  To address this, we’ve decided to lower the default value to 512KB. One concern with frequent yielding to networking is the potential performance impact, as each call to processEventsWhileBlocked() involves 4 syscalls, which could slow down the RDB loading phase. However, benchmarking with various configuration values has shown that using 512KB or higher does not negatively impact RDB loading performance. Based on these results, 512KB is now selected as the default value.

**Test changes**
- Added improved version of a replication test which checks memory usage on master during full sync.
