### PR TITLE
Fix flaky replication test

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -49,7 +49,7 @@ start_server {tags {"repl network external:skip"}} {
             # 'debug sleep' occurring during the rdbchannel handshake.
             wait_for_condition 50 1000 {
                 [string match *state=wait_bgsave* [$master info replication]] &&
-                [llength [split [$master client list type slave] "\n"]] - 1 == 2
+                [llength [split [string trim [$master client list type slave]] "\r\n"]] == 2
             } else {
                 fail "Replica does not enter wait_bgsave state"
             }

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -45,8 +45,11 @@ start_server {tags {"repl network external:skip"}} {
         }
 
         test {Slave enters wait_bgsave} {
+            # Wait until the rdbchannel is connected to prevent the following
+            # 'debug sleep' occurring during the rdbchannel handshake.
             wait_for_condition 50 1000 {
-                [string match *state=wait_bgsave* [$master info replication]]
+                [string match *state=wait_bgsave* [$master info replication]] &&
+                [llength [split [$master client list type slave] "\n"]] - 1 == 2
             } else {
                 fail "Replica does not enter wait_bgsave state"
             }


### PR DESCRIPTION
Test fails time to time: https://github.com/redis/redis/actions/runs/13846995211/job/38747385033
```
*** [err]: Slave is able to detect timeout during handshake in tests/integration/replication.tcl
Replica is not able to detect timeout
```


Depending on the timing, "debug sleep" may occur during rdbchannel handshake and required log statement won't be printed to the log in that case. Better to wait after rdbchannel handshake.  