### PR TITLE
Fix a couple of compiler warnings

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6050,6 +6050,7 @@ static clusterManagerNode *clusterManagerNodeMasterRandom(void) {
     }
     /* Can not be reached */
     assert(0);
+    return NULL;
 }
 
 static int clusterManagerFixSlotsCoverage(char *all_slots) {

--- a/src/zipmap.c
+++ b/src/zipmap.c
@@ -56,6 +56,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 #include "zmalloc.h"
 #include "endianconv.h"
 
@@ -250,6 +251,7 @@ unsigned char *zipmapSet(unsigned char *zm, unsigned char *key, unsigned int kle
     /* Just write the key + value and we are done. */
     /* Key: */
     p += zipmapEncodeLength(p,klen);
+    assert(klen < freelen);
     memcpy(p,key,klen);
     p += klen;
     /* Value: */


### PR DESCRIPTION
Fix a couple of compiler warnings

1.  gcc-14 prints a warning:
    ```
    In function ‘memcpy’,
        inlined from ‘zipmapSet’ at zipmap.c:255:5:
    /usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:10: warning: ‘__builtin_memcpy’ writing between 254 and 4294967295 
    bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
       29 |   return __builtin___memcpy_chk (__dest, __src, __len,
          |          ^
    In function ‘zipmapSet’:
    lto1: note: destination object is likely at address zero
    ```
    
2. I occasionally get another  warning while building with different options:
    ```
   redis-cli.c: In function ‘clusterManagerNodeMasterRandom’:
   redis-cli.c:6053:1: warning: control reaches end of non-void function [-Wreturn-type]
    6053 | }
   ```