### PR TITLE
Fix various KEYSIZES enumeration issues

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -79,22 +79,33 @@ void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, in
 
     if (oldLen > 0) {
         int old_bin = log2ceil(oldLen) + 1;
-        debugServerAssertWithInfo(server.current_client, NULL, old_bin < MAX_KEYSIZES_BINS);        
+        debugServerAssert(old_bin < MAX_KEYSIZES_BINS);
         /* If following a key deletion it is last one in slot's dict, then
          * slot's dict might get released as well. Verify if metadata is not NULL. */
-        if(dictMeta) dictMeta->keysizes_hist[type][old_bin]--;
+        if(dictMeta) {
+            dictMeta->keysizes_hist[type][old_bin]--;
+            debugServerAssert(dictMeta->keysizes_hist[type][old_bin] >= 0);
+        }
         kvstoreMeta->keysizes_hist[type][old_bin]--;
+        debugServerAssert(kvstoreMeta->keysizes_hist[type][old_bin] >= 0);
     } else {
         /* here, oldLen can be either 0 or -1 */
         if (oldLen == 0) {
-            if (dictMeta) dictMeta->keysizes_hist[type][0]--;
+            /* Only strings can be empty. Yet, a command flow might temporarily 
+               dbAdd() empty collection, and only after add elements. */
+
+            if (dictMeta) {
+                dictMeta->keysizes_hist[type][0]--;
+                debugServerAssert(dictMeta->keysizes_hist[type][0] >= 0);
+            }
             kvstoreMeta->keysizes_hist[type][0]--;
+            debugServerAssert(kvstoreMeta->keysizes_hist[type][0] >= 0);
         }
     }
     
     if (newLen > 0) {
         int new_bin = log2ceil(newLen) + 1;
-        debugServerAssertWithInfo(server.current_client, NULL, new_bin < MAX_KEYSIZES_BINS);
+        debugServerAssert(new_bin < MAX_KEYSIZES_BINS);
         /* If following a key deletion it is last one in slot's dict, then
          * slot's dict might get released as well. Verify if metadata is not NULL. */
         if(dictMeta) dictMeta->keysizes_hist[type][new_bin]++;
@@ -102,6 +113,9 @@ void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, in
     } else {
         /* here, newLen can be either 0 or -1 */
         if (newLen == 0) {
+            /* Only strings can be empty. Yet, a command flow might temporarily 
+               dbAdd() empty collection, and only after add elements. */
+            
             if (dictMeta) dictMeta->keysizes_hist[type][0]++;
             kvstoreMeta->keysizes_hist[type][0]++;
         }
@@ -476,7 +490,8 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
         robj *val = dictGetVal(de);
 
         /* remove key from histogram */
-        updateKeysizesHist(db, slot, val->type, getObjectLength(val), -1);
+        if(!(flags & DB_FLAG_NO_UPDATE_KEYSIZES))
+            updateKeysizesHist(db, slot, val->type, (int64_t) getObjectLength(val), -1);
 
         /* If hash object with expiry on fields, remove it from HFE DS of DB */
         if (val->type == OBJ_HASH)
@@ -523,6 +538,18 @@ int dbAsyncDelete(redisDb *db, robj *key) {
  * configuration. Deletes the key synchronously or asynchronously. */
 int dbDelete(redisDb *db, robj *key) {
     return dbGenericDelete(db, key, server.lazyfree_lazy_server_del, DB_FLAG_KEY_DELETED);
+}
+
+/* Similar to dbDelete(), but does not update the keysizes histogram.
+ * This is used when we want to delete a key without affecting the histogram,
+ * typically in cases where a command flow deletes elements from a collection
+ * and then deletes the collection itself. In such cases, using dbDelete()
+ * would incorrectly decrement bin #0. A corresponding test should be added
+ * to `info-keysizes.tcl`.
+ */
+int dbDeleteSkipKeysizesUpdate(redisDb *db, robj *key) {
+    return dbGenericDelete(db, key,server.lazyfree_lazy_server_del,
+                    DB_FLAG_KEY_DELETED | DB_FLAG_NO_UPDATE_KEYSIZES);
 }
 
 /* Prepare the string object stored at 'key' to be modified destructively

--- a/src/db.c
+++ b/src/db.c
@@ -496,9 +496,10 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
         robj *val = dictGetVal(de);
 
         int64_t oldlen = (int64_t) getObjectLength(val);
+        int type = val->type; 
 
         /* If hash object with expiry on fields, remove it from HFE DS of DB */
-        if (val->type == OBJ_HASH)
+        if (type == OBJ_HASH)
             hashTypeRemoveFromExpires(&db->hexpires, val);
 
         /* RM_StringDMA may call dbUnshareStringValue which may free val, so we
@@ -507,7 +508,7 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
         /* Tells the module that the key has been unlinked from the database. */
         moduleNotifyKeyUnlink(key,val,db->id,flags);
         /* We want to try to unblock any module clients or clients using a blocking XREADGROUP */
-        signalDeletedKeyAsReady(db,key,val->type);
+        signalDeletedKeyAsReady(db,key,type);
         /* We should call decr before freeObjAsync. If not, the refcount may be
          * greater than 1, so freeObjAsync doesn't work */
         decrRefCount(val);
@@ -524,7 +525,7 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
 
         /* remove key from histogram */
         if(!(flags & DB_FLAG_NO_UPDATE_KEYSIZES))
-            updateKeysizesHist(db, slot, val->type, oldlen, -1);
+            updateKeysizesHist(db, slot, type, oldlen, -1);
 
         return 1;
     } else {

--- a/src/db.c
+++ b/src/db.c
@@ -93,7 +93,7 @@ void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, in
         /* here, oldLen can be either 0 or -1 */
         if (oldLen == 0) {
             /* Only strings can be empty. Yet, a command flow might temporarily 
-               dbAdd() empty collection, and only after add elements. */
+             * dbAdd() empty collection, and only after add elements. */
 
             if (dictMeta) {
                 dictMeta->keysizes_hist[type][0]--;
@@ -115,7 +115,7 @@ void updateKeysizesHist(redisDb *db, int didx, uint32_t type, int64_t oldLen, in
         /* here, newLen can be either 0 or -1 */
         if (newLen == 0) {
             /* Only strings can be empty. Yet, a command flow might temporarily 
-               dbAdd() empty collection, and only after add elements. */
+             * dbAdd() empty collection, and only after add elements. */
             
             if (dictMeta) dictMeta->keysizes_hist[type][0]++;
             kvstoreMeta->keysizes_hist[type][0]++;
@@ -556,10 +556,9 @@ int dbDelete(redisDb *db, robj *key) {
  * typically in cases where a command flow deletes elements from a collection
  * and then deletes the collection itself. In such cases, using dbDelete()
  * would incorrectly decrement bin #0. A corresponding test should be added
- * to `info-keysizes.tcl`.
- */
+ * to `info-keysizes.tcl`. */
 int dbDeleteSkipKeysizesUpdate(redisDb *db, robj *key) {
-    return dbGenericDelete(db, key,server.lazyfree_lazy_server_del,
+    return dbGenericDelete(db, key, server.lazyfree_lazy_server_del,
                     DB_FLAG_KEY_DELETED | DB_FLAG_NO_UPDATE_KEYSIZES);
 }
 

--- a/src/db.c
+++ b/src/db.c
@@ -352,8 +352,7 @@ static void dbSetValue(redisDb *db, robj *key, robj *val, int overwrite, dictEnt
     serverAssertWithInfo(NULL,key,de != NULL);
     robj *old = dictGetVal(de);
 
-    /* Remove old key from keysizes histogram */
-    updateKeysizesHist(db, slot, old->type, getObjectLength(old), -1); /* remove hist */
+    int64_t oldlen = (int64_t) getObjectLength(old);
 
     val->lru = old->lru;
 
@@ -373,8 +372,15 @@ static void dbSetValue(redisDb *db, robj *key, robj *val, int overwrite, dictEnt
     }
     kvstoreDictSetVal(db->keys, slot, de, val);
 
-    /* Add new key to keysizes histogram */
-    updateKeysizesHist(db, slot, val->type, -1, getObjectLength(val));
+    /* Remove old key and add new key to KEYSIZES histogram */
+    int64_t newlen = (int64_t) getObjectLength(val);
+    /* Save one call if old and new are the same type */
+    if (old->type == val->type) {
+        updateKeysizesHist(db, slot, old->type, oldlen, newlen);
+    } else {        
+        updateKeysizesHist(db, slot, old->type, oldlen, -1); 
+        updateKeysizesHist(db, slot, val->type, -1, newlen);
+    }
 
     /* if hash with HFEs, take care to remove from global HFE DS */
     if (old->type == OBJ_HASH)
@@ -489,9 +495,7 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
     if (de) {
         robj *val = dictGetVal(de);
 
-        /* remove key from histogram */
-        if(!(flags & DB_FLAG_NO_UPDATE_KEYSIZES))
-            updateKeysizesHist(db, slot, val->type, (int64_t) getObjectLength(val), -1);
+        int64_t oldlen = (int64_t) getObjectLength(val);
 
         /* If hash object with expiry on fields, remove it from HFE DS of DB */
         if (val->type == OBJ_HASH)
@@ -517,6 +521,11 @@ int dbGenericDelete(redisDb *db, robj *key, int async, int flags) {
         kvstoreDictDelete(db->expires, slot, key->ptr);
 
         kvstoreDictTwoPhaseUnlinkFree(db->keys, slot, de, plink, table);
+
+        /* remove key from histogram */
+        if(!(flags & DB_FLAG_NO_UPDATE_KEYSIZES))
+            updateKeysizesHist(db, slot, val->type, oldlen, -1);
+
         return 1;
     } else {
         return 0;

--- a/src/db.c
+++ b/src/db.c
@@ -378,7 +378,7 @@ static void dbSetValue(redisDb *db, robj *key, robj *val, int overwrite, dictEnt
     /* Save one call if old and new are the same type */
     if (old->type == val->type) {
         updateKeysizesHist(db, slot, old->type, oldlen, newlen);
-    } else {        
+    } else {
         updateKeysizesHist(db, slot, old->type, oldlen, -1); 
         updateKeysizesHist(db, slot, val->type, -1, newlen);
     }

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1432,7 +1432,7 @@ void pfaddCommand(client *c) {
 
     /* HLL might change from sparse to dense. No way to predict KEYSIZES diff. 
      * Update as if the key is being removed. After the for-loop update it back */ 
-    updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, stringObjectLen(o), -1);
+    int64_t oldlen = stringObjectLen(o);
 
     /* Perform the low level ADD operation for every element. */
     for (j = 2; j < c->argc; j++) {
@@ -1447,8 +1447,8 @@ void pfaddCommand(client *c) {
             return;
         }
     }
-    
-    updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, -1, stringObjectLen(o));
+
+    updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, oldlen, stringObjectLen(o));
     hdr = o->ptr;
     if (updated) {
         HLL_INVALIDATE_CACHE(hdr);

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1413,7 +1413,6 @@ invalid:
 
 /* PFADD var ele ele ele ... ele => :0 or :1 */
 void pfaddCommand(client *c) {
-    uint64_t oldLen;
     robj *o = lookupKeyWrite(c->db,c->argv[1]);
     struct hllhdr *hdr;
     int updated = 0, j;
@@ -1429,7 +1428,10 @@ void pfaddCommand(client *c) {
         if (isHLLObjectOrReply(c,o) != C_OK) return;
         o = dbUnshareStringValue(c->db,c->argv[1],o);
     }
-    oldLen = stringObjectLen(o);
+
+    /* HLL might change from sparse to dense. No way to predict KEYSIZES diff. 
+     * Update as if the key is being removed. After the for-loop update it back */ 
+    updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, stringObjectLen(o), -1);
 
     /* Perform the low level ADD operation for every element. */
     for (j = 2; j < c->argc; j++) {
@@ -1444,13 +1446,14 @@ void pfaddCommand(client *c) {
             return;
         }
     }
+    
+    updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, -1, stringObjectLen(o));
     hdr = o->ptr;
     if (updated) {
         HLL_INVALIDATE_CACHE(hdr);
         signalModifiedKey(c,c->db,c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_STRING,"pfadd",c->argv[1],c->db->id);
         server.dirty += updated;
-        updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, oldLen, stringObjectLen(o));
     }
     addReply(c, updated ? shared.cone : shared.czero);
 }
@@ -1856,10 +1859,17 @@ void pfdebugCommand(client *c) {
         if (c->argc != 3) goto arityerr;
 
         if (hdr->encoding == HLL_SPARSE) {
+
+            /* No way to predict the KEYSIZES diff. Update as if the key is being 
+             * removed. After hllSparseToDense() update it back */
+
+            updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, stringObjectLen(o), -1);
+            
             if (hllSparseToDense(o) == C_ERR) {
                 addReplyError(c,invalid_hll_err);
                 return;
             }
+            updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, -1, stringObjectLen(o));
             conv = 1;
             server.dirty++; /* Force propagation on encoding change. */
         }

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1860,17 +1860,12 @@ void pfdebugCommand(client *c) {
         if (c->argc != 3) goto arityerr;
 
         if (hdr->encoding == HLL_SPARSE) {
-
-            /* No way to predict the KEYSIZES diff. Update as if the key is being 
-             * removed. After hllSparseToDense() update it back */
-
-            updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, stringObjectLen(o), -1);
-            
+            int64_t oldlen = (int64_t) stringObjectLen(o);
             if (hllSparseToDense(o) == C_ERR) {
                 addReplyError(c,invalid_hll_err);
                 return;
             }
-            updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, -1, stringObjectLen(o));
+            updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_STRING, oldlen, stringObjectLen(o));
             conv = 1;
             server.dirty++; /* Force propagation on encoding change. */
         }

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -24,12 +24,12 @@
 /* When creating kvstore with flag `KVSTORE_ALLOC_META_KEYS_HIST`, then kvstore 
  * alloc and memset struct kvstoreMetadata on init, yet, managed outside kvstore */
 typedef struct {
-    uint64_t keysizes_hist[MAX_KEYSIZES_TYPES][MAX_KEYSIZES_BINS];
+    int64_t keysizes_hist[MAX_KEYSIZES_TYPES][MAX_KEYSIZES_BINS];
 } kvstoreMetadata;
 
 /* Like kvstoreMetadata, this one per dict */
 typedef struct {
-    uint64_t keysizes_hist[MAX_KEYSIZES_TYPES][MAX_KEYSIZES_BINS];
+    int64_t keysizes_hist[MAX_KEYSIZES_TYPES][MAX_KEYSIZES_BINS];
 } kvstoreDictMetadata;
 
 typedef struct _kvstore kvstore;

--- a/src/module.c
+++ b/src/module.c
@@ -4564,6 +4564,8 @@ int RM_ListPush(RedisModuleKey *key, int where, RedisModuleString *ele) {
     listTypeTryConversionAppend(key->value, &ele, 0, 0, moduleFreeListIterator, key);
     listTypePush(key->value, ele,
         (where == REDISMODULE_LIST_HEAD) ? LIST_HEAD : LIST_TAIL);
+    int64_t l = listTypeLength(key->value);
+    updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l-1, l);
     return REDISMODULE_OK;
 }
 
@@ -4595,6 +4597,8 @@ RedisModuleString *RM_ListPop(RedisModuleKey *key, int where) {
         (where == REDISMODULE_LIST_HEAD) ? LIST_HEAD : LIST_TAIL);
     robj *decoded = getDecodedObject(ele);
     decrRefCount(ele);
+    int64_t l = (int64_t) listTypeLength(key->value);
+    updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_LIST, l+1, l);
     if (!moduleDelKeyIfEmpty(key))
         listTypeTryConversion(key->value, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
     autoMemoryAdd(key->ctx,REDISMODULE_AM_STRING,decoded);
@@ -4726,6 +4730,8 @@ int RM_ListInsert(RedisModuleKey *key, long index, RedisModuleString *value) {
 int RM_ListDelete(RedisModuleKey *key, long index) {
     if (moduleListIteratorSeek(key, index, REDISMODULE_WRITE)) {
         listTypeDelete(key->iter, &key->u.list.entry);
+        int64_t l = (int64_t) listTypeLength(key->value); 
+        updateKeysizesHist(key->db, getKeySlot(key->value->ptr), OBJ_LIST, l+1, l);
         if (moduleDelKeyIfEmpty(key)) return REDISMODULE_OK;
         listTypeTryConversion(key->value, LIST_CONV_SHRINKING, moduleFreeListIterator, key);
         if (!key->iter) return REDISMODULE_OK; /* Return ASAP if iterator has been freed */
@@ -4822,6 +4828,8 @@ int RM_ZsetAdd(RedisModuleKey *key, double score, RedisModuleString *ele, int *f
         return REDISMODULE_ERR;
     }
     if (flagsptr) *flagsptr = moduleZsetAddFlagsFromCoreFlags(out_flags);
+    int64_t l = (int64_t) zsetLength(key->value);
+    updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_ZSET, l-1, l);
     return REDISMODULE_OK;
 }
 
@@ -4850,6 +4858,10 @@ int RM_ZsetIncrby(RedisModuleKey *key, double score, RedisModuleString *ele, int
         moduleDelKeyIfEmpty(key);
         return REDISMODULE_ERR;
     }
+    if (out_flags & ZADD_OUT_ADDED) {
+        int64_t l = (int64_t) zsetLength(key->value);
+        updateKeysizesHist(key->db, getKeySlot(key->value->ptr), OBJ_ZSET, l-1, l);
+    }
     if (flagsptr) *flagsptr = moduleZsetAddFlagsFromCoreFlags(out_flags);
     return REDISMODULE_OK;
 }
@@ -4877,6 +4889,8 @@ int RM_ZsetRem(RedisModuleKey *key, RedisModuleString *ele, int *deleted) {
     if (key->value && key->value->type != OBJ_ZSET) return REDISMODULE_ERR;
     if (key->value != NULL && zsetDel(key->value,ele->ptr)) {
         if (deleted) *deleted = 1;
+        int64_t l = (int64_t) zsetLength(key->value);
+        updateKeysizesHist(key->db, getKeySlot(key->value->ptr), OBJ_ZSET, l+1, l);
         moduleDelKeyIfEmpty(key);
     } else {
         if (deleted) *deleted = 0;
@@ -5295,6 +5309,8 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
         return 0;
     }
     if (key->value == NULL) moduleCreateEmptyKey(key,REDISMODULE_KEYTYPE_HASH);
+    
+    int64_t oldlen = (int64_t) getObjectLength(key->value);
 
     int count = 0;
     va_start(ap, flags);
@@ -5313,7 +5329,7 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
 
         /* Handle XX and NX */
         if (flags & (REDISMODULE_HASH_XX|REDISMODULE_HASH_NX)) {
-            int hfeFlags = HFE_LAZY_AVOID_HASH_DEL; /* Avoid invalidate the key */
+            int hfeFlags = HFE_LAZY_AVOID_HASH_DEL | HFE_LAZY_NO_UPDATE_KEYSIZES; 
 
             /*
              * The hash might contain expired fields. If we lazily delete expired
@@ -5363,6 +5379,9 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
         }
     }
     va_end(ap);
+    updateKeysizesHist(key->db, getKeySlot(key->key->ptr), OBJ_HASH, oldlen, 
+                       (int64_t) hashTypeLength(key->value, 0));
+    
     moduleDelKeyIfEmpty(key);
     if (count == 0) errno = ENOENT;
     return count;
@@ -5420,7 +5439,7 @@ int RM_HashSet(RedisModuleKey *key, int flags, ...) {
  * RedisModule_FreeString(), or by enabling automatic memory management.
  */
 int RM_HashGet(RedisModuleKey *key, int flags, ...) {
-    int hfeFlags = HFE_LAZY_AVOID_FIELD_DEL | HFE_LAZY_AVOID_HASH_DEL;
+    int hfeFlags = HFE_LAZY_AVOID_FIELD_DEL | HFE_LAZY_AVOID_HASH_DEL | HFE_LAZY_NO_UPDATE_KEYSIZES;
     va_list ap;
     if (key->value && key->value->type != OBJ_HASH) return REDISMODULE_ERR;
 

--- a/src/server.c
+++ b/src/server.c
@@ -6390,7 +6390,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
                 continue;
             
             for (int type = 0; type < OBJ_TYPE_BASIC_MAX; type++) {
-                uint64_t *kvstoreHist = kvstoreGetMetadata(server.db[dbnum].keys)->keysizes_hist[type];
+                int64_t *kvstoreHist = kvstoreGetMetadata(server.db[dbnum].keys)->keysizes_hist[type];
                 char buf[10000];
                 int cnt = 0, buflen = 0;
 

--- a/src/server.h
+++ b/src/server.h
@@ -296,6 +296,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define DB_FLAG_KEY_EXPIRED (1ULL<<1)
 #define DB_FLAG_KEY_EVICTED (1ULL<<2)
 #define DB_FLAG_KEY_OVERWRITE (1ULL<<3)
+#define DB_FLAG_NO_UPDATE_KEYSIZES (1ULL<<4) /* Don't update keysizes histograms */
 
 /* Channel flags share the same flag space as the key flags */
 #define CMD_CHANNEL_PATTERN (1ULL<<11)     /* The argument is a channel pattern */
@@ -736,8 +737,10 @@ typedef enum {
  * assertions that are too computationally expensive or dangerous to run during normal operations.  */
 #ifdef DEBUG_ASSERTIONS
 #define debugServerAssertWithInfo(...) serverAssertWithInfo(__VA_ARGS__)
+#define debugServerAssert(...) serverAssert(__VA_ARGS__)
 #else
 #define debugServerAssertWithInfo(...)
+#define debugServerAssert(...)
 #endif
 
 /* latency histogram per command init settings */
@@ -3597,6 +3600,7 @@ robj *dbRandomKey(redisDb *db);
 int dbGenericDelete(redisDb *db, robj *key, int async, int flags);
 int dbSyncDelete(redisDb *db, robj *key);
 int dbDelete(redisDb *db, robj *key);
+int dbDeleteSkipKeysizesUpdate(redisDb *db, robj *key);
 robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o);
 robj *dbUnshareStringValueWithDictEntry(redisDb *db, robj *key, robj *o, dictEntry *de);
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2783,7 +2783,7 @@ void hgetexCommand(client *c) {
     int expired = 0, deleted = 0, updated = 0;
     int num_fields_pos = 3, cond = 0;
     long num_fields;
-    int64_t oldlen = 0, newlen = 0;
+    int64_t oldlen = 0, newlen = -1;
     long long expire_time = 0;
     robj *o;
     HashTypeSetEx setex;
@@ -2924,7 +2924,7 @@ void hgetexCommand(client *c) {
     updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH,
                            oldlen, newlen);
     if (newlen == 0) {
-        dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
+        dbDelete(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
     }
 }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2756,7 +2756,7 @@ void hgetdelCommand(client *c) {
     }
 
     /* Key may have become empty because of deleting fields or lazy expire. */
-    int64_t  newlen = (int64_t) hashTypeLength(o, 0);
+    int64_t newlen = (int64_t) hashTypeLength(o, 0);
     if (newlen == 0) {
         newlen = -1;
         /* Del key but don't update KEYSIZES. else it will decr wrong bin in histogram */
@@ -2922,8 +2922,7 @@ void hgetexCommand(client *c) {
      * or the new expiration time is in the past.*/
     newlen = hashTypeLength(o, 0);
     
-    updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH,
-                           oldlen, newlen);
+    updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, oldlen, newlen);
     if (newlen == 0) {
         dbDelete(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2387,7 +2387,7 @@ void hsetexCommand(client *c) {
     int flags = 0, first_field_pos = 0, field_count = 0, expire_time_pos = -1;
     int updated = 0, deleted = 0, set_expiry;
     long long expire_time = EB_EXPIRE_TIME_INVALID;
-    unsigned long oldlen, newlen;
+    int64_t oldlen, newlen;
     robj *o;
     HashTypeSetEx setex;
 
@@ -2407,7 +2407,7 @@ void hsetexCommand(client *c) {
         o = createHashObject();
         dbAdd(c->db, c->argv[1], o);
     }
-    oldlen = hashTypeLength(o, 0);
+    oldlen = (int64_t) hashTypeLength(o, 0);
 
     if (flags & (HFE_FXX | HFE_FNX)) {
         int found = 0;
@@ -2494,9 +2494,11 @@ void hsetexCommand(client *c) {
 out:
     /* Key may become empty due to lazy expiry in hashTypeExists()
      * or the new expiration time is in the past.*/
-    newlen = hashTypeLength(o, 0);
+    newlen = (int64_t) hashTypeLength(o, 0);
     if (newlen == 0) {
-        dbDelete(c->db, c->argv[1]);
+        newlen = -1;
+        /* Del key but don't update KEYSIZES. else it will decr wrong bin in histogram */
+        dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
     }
     if (oldlen != newlen)
@@ -2682,7 +2684,7 @@ void hmgetCommand(client *c) {
  */
 void hgetdelCommand(client *c) {
     int res = 0, hfe = 0, deleted = 0, expired = 0;
-    unsigned long oldlen = 0, newlen= 0;
+    int64_t oldlen = -1; /* not exists as long as it is not set */
     long num_fields = 0;
     robj *o;
 
@@ -2753,9 +2755,11 @@ void hgetdelCommand(client *c) {
     }
 
     /* Key may have become empty because of deleting fields or lazy expire. */
-    newlen = hashTypeLength(o, 0);
+    int64_t  newlen = (int64_t) hashTypeLength(o, 0);
     if (newlen == 0) {
-        dbDelete(c->db, c->argv[1]);
+        newlen = -1;
+        /* Del key but don't update KEYSIZES. else it will decr wrong bin in histogram */
+        dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
     } else if (hfe && (hashTypeIsFieldsWithExpire(o) == 0)) { /*is it last HFE*/
         ebRemove(&c->db->hexpires, &hashExpireBucketsType, o);
@@ -2779,7 +2783,7 @@ void hgetexCommand(client *c) {
     int expired = 0, deleted = 0, updated = 0;
     int num_fields_pos = 3, cond = 0;
     long num_fields;
-    unsigned long oldlen = 0, newlen = 0;
+    int64_t oldlen = 0, newlen = 0;
     long long expire_time = 0;
     robj *o;
     HashTypeSetEx setex;
@@ -2875,7 +2879,9 @@ void hgetexCommand(client *c) {
      * or the new expiration time is in the past.*/
     newlen = hashTypeLength(o, 0);
     if (newlen == 0) {
-        dbDelete(c->db, c->argv[1]);
+        newlen = -1;
+        /* Del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
+        dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
     }
     if (oldlen != newlen)
@@ -2932,7 +2938,7 @@ void hdelCommand(client *c) {
     if ((o = lookupKeyWriteOrReply(c,c->argv[1],shared.czero)) == NULL ||
         checkType(c,o,OBJ_HASH)) return;
 
-    unsigned long oldLen = hashTypeLength(o, 0);
+    int64_t oldLen = (int64_t) hashTypeLength(o, 0);
     
     /* Hash field expiration is optimized to avoid frequent update global HFE DS for
      * each field deletion. Eventually active-expiration will run and update or remove
@@ -2946,15 +2952,15 @@ void hdelCommand(client *c) {
         if (hashTypeDelete(o,c->argv[j]->ptr,1)) {
             deleted++;
             if (hashTypeLength(o, 0) == 0) {
-                dbDelete(c->db,c->argv[1]);
+                /* del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
+                dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
                 keyremoved = 1;
                 break;
             }
         }
     }
     if (deleted) {
-        updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, oldLen, oldLen - deleted);
-
+        int64_t newLen = -1; /* The value -1 indicates that the key is deleted. */
         signalModifiedKey(c,c->db,c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_HASH,"hdel",c->argv[1],c->db->id);
         if (keyremoved) {
@@ -2962,8 +2968,9 @@ void hdelCommand(client *c) {
         } else {
             if (isHFE && (hashTypeIsFieldsWithExpire(o) == 0)) /* is it last HFE */
                 ebRemove(&c->db->hexpires, &hashExpireBucketsType, o);
+            newLen = oldLen - deleted;
         }
-
+        updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_HASH, oldLen, newLen);
         server.dirty += deleted;
     }
     addReplyLongLong(c,deleted);
@@ -3710,7 +3717,7 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
     long numFields = 0, numFieldsAt = 4;
     long long expire; /* unix time in msec */
     int fieldAt, fieldsNotSet = 0, expireSetCond = 0, updated = 0, deleted = 0;
-    unsigned long oldlen, newlen;
+    int64_t oldlen, newlen;
     robj *hashObj, *keyArg = c->argv[1], *expireArg = c->argv[2];
 
     /* Read the hash object */
@@ -3793,9 +3800,11 @@ static void hexpireGenericCommand(client *c, long long basetime, int unit) {
                             keyArg, c->db->id);
     }
 
-    newlen = hashTypeLength(hashObj, 0);
+    newlen = (int64_t) hashTypeLength(hashObj, 0);
     if (newlen == 0) {
-        dbDelete(c->db, keyArg);
+        newlen = -1;
+        /* Del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
+        dbDeleteSkipKeysizesUpdate(c->db, keyArg);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", keyArg, c->db->id);
     }
 

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -914,8 +914,9 @@ void ltrimCommand(client *c) {
 
     notifyKeyspaceEvent(NOTIFY_LIST,"ltrim",c->argv[1],c->db->id);
     if ((llenNew = listTypeLength(o)) == 0) {
-        dbDelete(c->db,c->argv[1]);
+        dbDeleteSkipKeysizesUpdate(c->db,c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"del",c->argv[1],c->db->id);
+        llenNew = -1; /* Indicate key deleted to updateKeysizesHist() */
     } else {
         listTypeTryConversion(o,LIST_CONV_SHRINKING,NULL,NULL);
     }

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1099,9 +1099,6 @@ void lmoveHandlePush(client *c, robj *dstkey, robj *dstobj, robj *value,
     listTypePush(dstobj,value,where);
     signalModifiedKey(c,c->db,dstkey);
 
-    long ll = listTypeLength(dstobj);
-    updateKeysizesHist(c->db, getKeySlot(dstkey->ptr), OBJ_LIST, ll - 1, ll);
-
     notifyKeyspaceEvent(NOTIFY_LIST,
                         where == LIST_HEAD ? "lpush" : "rpush",
                         dstkey,
@@ -1141,15 +1138,23 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
          * versions of Redis delete keys of empty lists. */
         addReplyNull(c);
     } else {
-        robj *dobj = lookupKeyWrite(c->db,c->argv[2]);
-        robj *touchedkey = c->argv[1];
-
-        if (checkType(c,dobj,OBJ_LIST)) return;
+        robj *dobj, *skey = c->argv[1];
+        int64_t oldlen = 0, newlen = 1; /* init lengths assuming new dst object */
+        
+        if ((dobj = lookupKeyWrite(c->db,c->argv[2])) != NULL) {
+            if (checkType(c,dobj,OBJ_LIST)) return;
+            /* dst object exists */
+            oldlen = (int64_t) listTypeLength(dobj);
+            newlen = oldlen + 1;
+        }
+        
         value = listTypePop(sobj,wherefrom);
         serverAssert(value); /* assertion for valgrind (avoid NPD) */
         lmoveHandlePush(c,c->argv[2],dobj,value,whereto);
-        listElementsRemoved(c,touchedkey,wherefrom,sobj,1,1,NULL);
-
+        /* Update dst obj cardinality in KEYSIZES */
+        updateKeysizesHist(c->db, getKeySlot(c->argv[2]->ptr), OBJ_LIST, oldlen, newlen);
+        /* Update src obj cardinality in KEYSIZES by listElementsRemoved() */
+        listElementsRemoved(c,skey,wherefrom,sobj,1,1,NULL);
         /* listTypePop returns an object with its refcount incremented */
         decrRefCount(value);
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -625,20 +625,23 @@ void sremCommand(client *c) {
         if (setTypeRemove(set,c->argv[j]->ptr)) {
             deleted++;
             if (setTypeSize(set) == 0) {
-                dbDelete(c->db,c->argv[1]);
+                dbDeleteSkipKeysizesUpdate(c->db, c->argv[1]);
                 keyremoved = 1;
                 break;
             }
         }
     }
     if (deleted) {
+        int64_t newSize = oldSize - deleted;  
         
-        updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, oldSize, oldSize - deleted);
         signalModifiedKey(c,c->db,c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_SET,"srem",c->argv[1],c->db->id);
-        if (keyremoved)
-            notifyKeyspaceEvent(NOTIFY_GENERIC,"del",c->argv[1],
+        if (keyremoved) {
+            notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1],
                                 c->db->id);
+            newSize = -1; /* removed */
+        }
+        updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, oldSize, newSize);
         server.dirty += deleted;
     }
     addReplyLongLong(c,deleted);
@@ -676,14 +679,15 @@ void smoveCommand(client *c) {
     notifyKeyspaceEvent(NOTIFY_SET,"srem",c->argv[1],c->db->id);
 
     /* Update keysizes histogram */
-    unsigned long srcLen = setTypeSize(srcset); 
-    updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, srcLen + 1, srcLen);
+    int64_t srcNewLen = setTypeSize(srcset), srcOldLen = srcNewLen + 1;
 
     /* Remove the src set from the database when empty */
-    if (srcLen == 0) {
-        dbDelete(c->db,c->argv[1]);
+    if (srcNewLen == 0) {
+        dbDeleteSkipKeysizesUpdate(c->db,c->argv[1]);
+        srcNewLen = -1; /* removed */
         notifyKeyspaceEvent(NOTIFY_GENERIC,"del",c->argv[1],c->db->id);
     }
+    updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, srcOldLen, srcNewLen);
 
     /* Create the destination set when it doesn't exist */
     if (!dstset) {
@@ -780,8 +784,7 @@ void spopWithCountCommand(client *c) {
     /* Generate an SPOP keyspace notification */
     notifyKeyspaceEvent(NOTIFY_SET,"spop",c->argv[1],c->db->id);
     server.dirty += toRemove;
-    updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - toRemove);
-
+    
     /* CASE 1:
      * The number of requested elements is greater than or equal to
      * the number of elements inside the set: simply return the whole set. */
@@ -801,6 +804,7 @@ void spopWithCountCommand(client *c) {
         signalModifiedKey(c,c->db,c->argv[1]);
         return;
     }
+    updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - toRemove);
 
     /* Case 2 and 3 require to replicate SPOP as a set of SREM commands.
      * Prepare our replication argument vector. Also send the array length

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -804,8 +804,7 @@ void spopWithCountCommand(client *c) {
         signalModifiedKey(c,c->db,c->argv[1]);
         return;
     }
-    updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - toRemove);
-
+    
     /* Case 2 and 3 require to replicate SPOP as a set of SREM commands.
      * Prepare our replication argument vector. Also send the array length
      * which is common to both the code paths. */
@@ -866,6 +865,7 @@ void spopWithCountCommand(client *c) {
         lp = lpBatchDelete(lp, ps, count);
         zfree(ps);
         set->ptr = lp;
+        updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - count);
     } else if (remaining*SPOP_MOVE_STRATEGY_MUL > count) {
         for (unsigned long i = 0; i < count; i++) {
             propargv[propindex] = setTypePopRandom(set);
@@ -880,6 +880,7 @@ void spopWithCountCommand(client *c) {
                 propindex = 2;
             }
         }
+        updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_SET, size, size - count);
     } else {
     /* CASE 3: The number of elements to return is very big, approaching
      * the size of the set itself. After some time extracting random elements
@@ -944,7 +945,7 @@ void spopWithCountCommand(client *c) {
         }
         setTypeReleaseIterator(si);
 
-        /* Assign the new set as the key value. */
+        /* Assign the new set as the key value (Also update KEYSIZES histogram) */
         dbReplaceValue(c->db,c->argv[1],newset);
     }
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -638,7 +638,7 @@ void sremCommand(client *c) {
         signalModifiedKey(c,c->db,c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_SET,"srem",c->argv[1],c->db->id);
         if (keyremoved) {
-            notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1],
+            notifyKeyspaceEvent(NOTIFY_GENERIC,"del",c->argv[1],
                                 c->db->id);
             newSize = -1; /* removed */
         }
@@ -805,7 +805,7 @@ void spopWithCountCommand(client *c) {
         signalModifiedKey(c,c->db,c->argv[1]);
         return;
     }
-    
+
     /* Case 2 and 3 require to replicate SPOP as a set of SREM commands.
      * Prepare our replication argument vector. Also send the array length
      * which is common to both the code paths. */

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -420,7 +420,7 @@ void getsetCommand(client *c) {
 }
 
 void setrangeCommand(client *c) {
-    size_t oldLen = 0, newLen;
+    int64_t oldLen = -1, newLen;
     robj *o;
     long offset;
     sds value = c->argv[3]->ptr;
@@ -680,7 +680,7 @@ void incrbyfloatCommand(client *c) {
 }
 
 void appendCommand(client *c) {
-    size_t totlen, append_len;
+    size_t totlen;
     robj *o, *append;
 
     dictEntry *de;
@@ -690,7 +690,7 @@ void appendCommand(client *c) {
         c->argv[2] = tryObjectEncoding(c->argv[2]);
         dbAdd(c->db,c->argv[1],c->argv[2]);
         incrRefCount(c->argv[2]);
-        append_len = totlen = stringObjectLen(c->argv[2]);
+        totlen = stringObjectLen(c->argv[2]);
     } else {
         /* Key exists, check type */
         if (checkType(c,o,OBJ_STRING))
@@ -698,7 +698,7 @@ void appendCommand(client *c) {
 
         /* "append" is an argument, so always an sds */
         append = c->argv[2];
-        append_len = sdslen(append->ptr);
+        size_t append_len = sdslen(append->ptr);
         if (checkStringLength(c,stringObjectLen(o),append_len) != C_OK)
             return;
 
@@ -706,11 +706,13 @@ void appendCommand(client *c) {
         o = dbUnshareStringValueWithDictEntry(c->db,c->argv[1],o,de);
         o->ptr = sdscatlen(o->ptr,append->ptr,append_len);
         totlen = sdslen(o->ptr);
+        int64_t oldlen = totlen - append_len;
+        updateKeysizesHist(c->db,getKeySlot(c->argv[1]->ptr),OBJ_STRING, oldlen, totlen);
     }
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_STRING,"append",c->argv[1],c->db->id);
     server.dirty++;
-    updateKeysizesHist(c->db,getKeySlot(c->argv[1]->ptr),OBJ_STRING, totlen - append_len, totlen);
+    
     addReplyLongLong(c,totlen);
 }
 

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -604,11 +604,17 @@ void incrDecrCommand(client *c, long long incr) {
     {
         new = o;
         o->ptr = (void*)((long)value);
+        updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr),
+                           OBJ_STRING,
+                           (int64_t) sdigits10(oldvalue),
+                           (int64_t) sdigits10(value));
     } else {
         new = createStringObjectFromLongLongForValue(value);
         if (o) {
+            /* replace value in db and also update keysizes hist */
             dbReplaceValueWithDictEntry(c->db,c->argv[1],new,de);
         } else {
+            /* Add new key to db and also update keysizes hist */
             dbAdd(c->db,c->argv[1],new);
         }
     }

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -714,7 +714,7 @@ void appendCommand(client *c) {
         o->ptr = sdscatlen(o->ptr,append->ptr,append_len);
         totlen = sdslen(o->ptr);
         int64_t oldlen = totlen - append_len;
-        updateKeysizesHist(c->db,getKeySlot(c->argv[1]->ptr),OBJ_STRING, oldlen, totlen);
+        updateKeysizesHist(c->db, getKeySlot(c->argv[1]->ptr), OBJ_STRING, oldlen, totlen);
     }
     signalModifiedKey(c,c->db,c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_STRING,"append",c->argv[1],c->db->id);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1898,24 +1898,26 @@ void zremCommand(client *c) {
     if ((zobj = lookupKeyWriteOrReply(c,key,shared.czero)) == NULL ||
         checkType(c,zobj,OBJ_ZSET)) return;
 
+    int64_t oldlen = (int64_t) zsetLength(zobj);
     for (j = 2; j < c->argc; j++) {
         if (zsetDel(zobj,c->argv[j]->ptr)) deleted++;
         if (zsetLength(zobj) == 0) {
-            dbDelete(c->db,key);
+            /* Del key but don't update KEYSIZES. Else it will decr wrong bin in histogram */
+            dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
             break;
         }
     }
 
     if (deleted) {
+        int64_t newlen = oldlen - deleted;
         notifyKeyspaceEvent(NOTIFY_ZSET,"zrem",key,c->db->id);
-        if (keyremoved) {            
+        if (keyremoved) {
             notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
-            /* No need updateKeysizesHist(). dbDelete() done it already. */
-        } else {
-            unsigned long len =  zsetLength(zobj);
-            updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, len + deleted, len);
+            newlen = -1; /* means key got deleted */
         }
+        
+        updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, oldlen, newlen);
         signalModifiedKey(c,c->db,key);
         server.dirty += deleted;
     }
@@ -1997,7 +1999,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
             break;
         }
         if (zzlLength(zobj->ptr) == 0) {
-            dbDelete(c->db,key);
+            dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
@@ -2017,7 +2019,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
         }
         dictResumeAutoResize(zs->dict);
         if (dictSize(zs->dict) == 0) {
-            dbDelete(c->db,key);
+            dbDeleteSkipKeysizesUpdate(c->db, key);
             keyremoved = 1;
         } else {
             dictShrinkIfNeeded(zs->dict);
@@ -2028,15 +2030,18 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
 
     /* Step 4: Notifications and reply. */
     if (deleted) {
+        int64_t  oldlen, newlen;
         signalModifiedKey(c,c->db,key);
         notifyKeyspaceEvent(NOTIFY_ZSET,notify_type,key,c->db->id);
         if (keyremoved) {
             notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
-            /* No need updateKeysizesHist(). dbDelete() done it already. */
+            newlen = -1;
+            oldlen = deleted;
         } else {
-            unsigned long len =  zsetLength(zobj);
-            updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, len + deleted, len);
+            newlen = zsetLength(zobj);
+            oldlen = newlen + deleted;
         }
+        updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, oldlen, newlen);
     }
     server.dirty += deleted;
     addReplyLongLong(c,deleted);
@@ -4036,17 +4041,19 @@ void genericZpopCommand(client *c, robj **keyv, int keyc, int where, int emitkey
         sdsfree(ele);
         ++result_count;
     } while(--rangelen);
+    
+    int64_t oldlen = llen, newlen = llen - result_count;
 
     /* Remove the key, if indeed needed. */
     if (zsetLength(zobj) == 0) {
         if (deleted) *deleted = 1;
 
-        dbDelete(c->db,key);
+        dbDeleteSkipKeysizesUpdate(c->db, key);
         notifyKeyspaceEvent(NOTIFY_GENERIC,"del",key,c->db->id);
-        /* No need updateKeysizesHist(). dbDelete() done it already. */
-    } else {
-        updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, llen, llen - result_count);
+
+        newlen = -1; 
     }
+    updateKeysizesHist(c->db, getKeySlot(key->ptr), OBJ_ZSET, oldlen, newlen);
     signalModifiedKey(c,c->db,key);
 
     if (c->cmd->proc == zmpopCommand) {

--- a/tests/unit/info-keysizes.tcl
+++ b/tests/unit/info-keysizes.tcl
@@ -3,15 +3,6 @@
 # The command returns a histogram of the sizes of keys in the database.
 ################################################################################
 
-# Query and Strip result of "info keysizes" from header, spaces, and newlines.
-proc get_stripped_info {server} {
-    set infoStripped [string map {
-        "# Keysizes" ""
-        " " "" "\n" "" "\r" ""
-    } [$server info keysizes] ]
-    return $infoStripped
-}
-
 # Verify output of "info keysizes" command is as expected.
 #
 # Arguments:
@@ -34,6 +25,42 @@ proc get_stripped_info {server} {
 #                  as well. Otherwise, just run the command on the leader and verify 
 #                  the output.
 proc run_cmd_verify_hist {cmd expOutput {waitCond 0}} {
+
+    #################### internal funcs ################
+    proc build_exp_hist {server expOutput} {
+        if {[regexp {^__EVAL_DB_HIST__\s+(\d+)$} $expOutput -> dbid]} {
+            set expOutput [eval_db_histogram $server $dbid]
+        }
+    
+        # Replace all placeholders with the actual values. Remove spaces & newlines.
+        set res [string map {
+            "STR" "distrib_strings_sizes"
+            "LIST" "distrib_lists_items"
+            "SET" "distrib_sets_items"
+            "ZSET" "distrib_zsets_items"
+            "HASH" "distrib_hashes_items"
+            " " "" "\n" "" "\r" ""
+        } $expOutput]
+        return $res
+    }
+    proc verify_histogram { server expOutput cmd {retries 1} } {
+         wait_for_condition 50 $retries {
+            [build_exp_hist $server $expOutput] eq [get_info_hist_stripped $server]
+        } else {
+            fail "Expected: \n`[build_exp_hist $server $expOutput]` \
+                Actual: `[get_info_hist_stripped $server]`. \nFailed after command: $cmd"
+        }
+    }
+    # Query and Strip result of "info keysizes" from header, spaces, and newlines.
+    proc get_info_hist_stripped {server} {
+        set infoStripped [string map {
+            "# Keysizes" ""
+            " " "" "\n" "" "\r" ""
+        } [$server info keysizes] ]
+        return $infoStripped
+    }
+    #################### EOF internal funcs ################
+
     uplevel 1 $cmd
     global replicaMode
 
@@ -45,46 +72,13 @@ proc run_cmd_verify_hist {cmd expOutput {waitCond 0}} {
         set server [srv 0 client]
     }
 
-    # If need eval expected histogram by reading all the keys & lengths from the
-    # server.
-    if {[regexp {^__EVAL_DB_HIST__\s+(\d+)$} $expOutput -> dbid]} {
-        set expOutput [eval_db_histogram $server $dbid]
-    }
-
-    # Replace all placeholders with the actual values. Remove spaces & newlines.
-    set expStripped [string map {
-        "STR" "distrib_strings_sizes"
-        "LIST" "distrib_lists_items"
-        "SET" "distrib_sets_items"
-        "ZSET" "distrib_zsets_items"
-        "HASH" "distrib_hashes_items"
-        " " "" "\n" "" "\r" ""
-    } $expOutput]
-
     # Compare the stripped expected output with the actual output from the server
-    if {$waitCond} {
-        wait_for_condition 50 50 {
-            $expStripped eq [get_stripped_info $server]
-        } else {
-            fail "Expected: \n`$expStripped` \
-               \nActual:\n`[get_stripped_info $server]`. \nFailed after command: $cmd"
-        }
-    } else {
-        set infoStripped [get_stripped_info $server]
-        if {$expStripped ne $infoStripped} {
-            fail "Expected: \n`$expStripped` \
-               \nActual:\n`[get_stripped_info $server]`. \nFailed after command: $cmd"
-        }
-    }
+    set retries [expr { $waitCond ? 20 : 1}]
+    verify_histogram $server $expOutput $cmd $retries
 
     # If we are testing `replicaMode` then need to wait for the replica to catch up
     if {$replicaMode eq 1} {
-        wait_for_condition 50 50 {
-            $expStripped eq [get_stripped_info $replica]
-        } else {
-            fail "Expected: \n`$expStripped` \
-                Actual: `[get_stripped_info $replica]`. \nFailed after command: $cmd"
-        }
+        verify_histogram $replica $expOutput $cmd 20
     }
 }
 
@@ -92,6 +86,7 @@ proc run_cmd_verify_hist {cmd expOutput {waitCond 0}} {
 # reading all the keys from the server, query for their length, and computing
 # the expected output.
 proc eval_db_histogram {server dbid} {
+    $server select $dbid
     array set type_counts {}
 
     set keys [$server keys *]
@@ -177,7 +172,7 @@ proc test_all_keysizes { {replMode 0} } {
         }
     }
 
-    test "KEYSIZES - Histogram of values of Bytes, Kilo and Mega $suffixRepl" {
+    test "KEYSIZES - Histogram values of Bytes, Kilo and Mega $suffixRepl" {
         run_cmd_verify_hist {$server FLUSHALL} {}
         run_cmd_verify_hist {$server set x 0123456789ABCDEF} {db0_STR:16=1}
         run_cmd_verify_hist {$server APPEND x [$server get x]} {db0_STR:32=1}

--- a/tests/unit/info-keysizes.tcl
+++ b/tests/unit/info-keysizes.tcl
@@ -66,14 +66,14 @@ proc run_cmd_verify_hist {cmd expOutput {waitCond 0}} {
         wait_for_condition 50 50 {
             $expStripped eq [get_stripped_info $server]
         } else {
-            fail "Unexpected KEYSIZES. Expected: `$expStripped` \
-                but got: `[get_stripped_info $server]`. Failed after command: $cmd"
+            fail "Expected: \n`$expStripped` \
+               \nActual:\n`[get_stripped_info $server]`. \nFailed after command: $cmd"
         }
     } else {
         set infoStripped [get_stripped_info $server]
         if {$expStripped ne $infoStripped} {
-            fail "Unexpected KEYSIZES. Expected: `$expStripped` \
-                but got: `$infoStripped`. Failed after command: $cmd"
+            fail "Expected: \n`$expStripped` \
+               \nActual:\n`[get_stripped_info $server]`. \nFailed after command: $cmd"
         }
     }
 
@@ -82,15 +82,15 @@ proc run_cmd_verify_hist {cmd expOutput {waitCond 0}} {
         wait_for_condition 50 50 {
             $expStripped eq [get_stripped_info $replica]
         } else {
-            fail "Unexpected replica KEYSIZES. Expected: `$expStripped` \
-                but got: `[get_stripped_info $replica]`. Failed after command: $cmd"
+            fail "Expected: \n`$expStripped` \
+                Actual: `[get_stripped_info $replica]`. \nFailed after command: $cmd"
         }
     }
 }
 
-## eval_db_histogram - eval The expected histogram for current db, by
-## reading all the keys from the server, query for their length, and computing
-## the expected output.
+# eval_db_histogram - eval The expected histogram for current db, by
+# reading all the keys from the server, query for their length, and computing
+# the expected output.
 proc eval_db_histogram {server dbid} {
     array set type_counts {}
 
@@ -125,6 +125,7 @@ proc eval_db_histogram {server dbid} {
 
         set power 1
         while { ($power * 2) <= $value } { set power [expr {$power * 2}] }
+        if {$value == 0} { set power 0}
         # Store counts by type and size bucket
         incr type_counts($type,$power)
     }
@@ -146,7 +147,7 @@ proc eval_db_histogram {server dbid} {
         }
     }
 
-    return [join $result " | "]
+    return [join $result " "]
 }
 
 proc test_all_keysizes { {replMode 0} } {
@@ -274,10 +275,15 @@ proc test_all_keysizes { {replMode 0} } {
         run_cmd_verify_hist {$server FLUSHALL} {}
         run_cmd_verify_hist {$server RPUSH l7 1 2 3 4} {db0_LIST:4=1}
         run_cmd_verify_hist {$server LPOP l7} {db0_LIST:2=1}
+        run_cmd_verify_hist {$server LPOP l7} {db0_LIST:2=1}
+        run_cmd_verify_hist {$server LPOP l7} {db0_LIST:1=1}
+        run_cmd_verify_hist {$server LPOP l7} {}
         # LREM
         run_cmd_verify_hist {$server FLUSHALL} {}
-        run_cmd_verify_hist {$server RPUSH l8 1 x 3 x 5 x 7 x 9 10} {db0_LIST:8=1}
+        run_cmd_verify_hist {$server RPUSH l8 y x y x y x y x y y} {db0_LIST:8=1}
         run_cmd_verify_hist {$server LREM l8 3 x} {db0_LIST:4=1}        
+        run_cmd_verify_hist {$server LREM l8 0 y} {db0_LIST:1=1}
+        run_cmd_verify_hist {$server LREM l8 0 x} {}
         # EXPIRE 
         run_cmd_verify_hist {$server FLUSHALL} {}
         run_cmd_verify_hist {$server RPUSH l9 1 2 3 4} {db0_LIST:4=1}
@@ -303,17 +309,21 @@ proc test_all_keysizes { {replMode 0} } {
         run_cmd_verify_hist {$server SPOP s3} {db0_SET:1=1,8=1}
         run_cmd_verify_hist {$server SPOP s2} {db0_SET:8=1}
         run_cmd_verify_hist {$server SPOP s1} {db0_SET:4=1}
-        run_cmd_verify_hist {$server del s1} {}
-        
+        run_cmd_verify_hist {$server SPOP s1 7} {}
+        run_cmd_verify_hist {$server SADD s2 1} {db0_SET:1=1}
+        run_cmd_verify_hist {$server SMOVE s2 s4 1} {db0_SET:1=1}
+        run_cmd_verify_hist {$server SREM s4 1} {}
         # SDIFFSTORE
         run_cmd_verify_hist {$server flushall} {}
         run_cmd_verify_hist {$server SADD s1 1 2 3 4 5 6 7 8} {db0_SET:8=1}
         run_cmd_verify_hist {$server SADD s2 6 7 8 9 A B C D} {db0_SET:8=2}
+        run_cmd_verify_hist {$server SADD s3 x} {db0_SET:1=1,8=2}
         run_cmd_verify_hist {$server SDIFFSTORE s3 s1 s2} {db0_SET:4=1,8=2}        
         #SINTERSTORE
         run_cmd_verify_hist {$server flushall} {}
         run_cmd_verify_hist {$server SADD s1 1 2 3 4 5 6 7 8} {db0_SET:8=1}
         run_cmd_verify_hist {$server SADD s2 6 7 8 9 A B C D} {db0_SET:8=2}
+        run_cmd_verify_hist {$server SADD s3 x} {db0_SET:1=1,8=2}
         run_cmd_verify_hist {$server SINTERSTORE s3 s1 s2} {db0_SET:2=1,8=2}        
         #SUNIONSTORE
         run_cmd_verify_hist {$server flushall} {}
@@ -345,12 +355,16 @@ proc test_all_keysizes { {replMode 0} } {
         run_cmd_verify_hist {$server ZADD z1 6 f 7 g 8 h 9 i} {db0_ZSET:8=1}
         run_cmd_verify_hist {$server ZADD z2 1 a} {db0_ZSET:1=1,8=1}
         run_cmd_verify_hist {$server ZREM z1 a} {db0_ZSET:1=1,8=1}
-        run_cmd_verify_hist {$server ZREM z1 b} {db0_ZSET:1=1,4=1}        
+        run_cmd_verify_hist {$server ZREM z1 b} {db0_ZSET:1=1,4=1}
+        run_cmd_verify_hist {$server ZREM z1 c d e f g h i} {db0_ZSET:1=1}
+        run_cmd_verify_hist {$server ZREM z2 a} {}
         # ZREMRANGEBYSCORE
         run_cmd_verify_hist {$server FLUSHALL} {}
         run_cmd_verify_hist {$server ZADD z1 1 a 2 b 3 c 4 d 5 e} {db0_ZSET:4=1}
         run_cmd_verify_hist {$server ZREMRANGEBYSCORE z1 -inf (2} {db0_ZSET:4=1}
-        run_cmd_verify_hist {$server ZREMRANGEBYSCORE z1 -inf (3} {db0_ZSET:2=1}        
+        run_cmd_verify_hist {$server ZREMRANGEBYSCORE z1 -inf (3} {db0_ZSET:2=1}
+        run_cmd_verify_hist {$server ZREMRANGEBYSCORE z1 -inf +inf} {}
+                
         # ZREMRANGEBYRANK
         run_cmd_verify_hist {$server FLUSHALL} {}
         run_cmd_verify_hist {$server ZADD z1 1 a 2 b 3 c 4 d 5 e 6 f} {db0_ZSET:4=1}
@@ -384,7 +398,9 @@ proc test_all_keysizes { {replMode 0} } {
         run_cmd_verify_hist {$server FLUSHALL} {}
         run_cmd_verify_hist {$server ZADD z1 1 a 2 b 3 c 4 d 5 e} {db0_ZSET:4=1}
         run_cmd_verify_hist {$server ZADD z2 3 c 4 d 5 e 6 f} {db0_ZSET:4=2}
-        run_cmd_verify_hist {$server ZINTERSTORE z3 2 z1 z2} {db0_ZSET:2=1,4=2}
+        run_cmd_verify_hist {$server ZADD z3 1 x} {db0_ZSET:1=1,4=2}
+        run_cmd_verify_hist {$server ZINTERSTORE z4 2 z1 z2} {db0_ZSET:1=1,2=1,4=2}
+        run_cmd_verify_hist {$server ZINTERSTORE z4 2 z1 z3} {db0_ZSET:1=1,4=2}        
         # DEL
         run_cmd_verify_hist {$server FLUSHALL} {}
         run_cmd_verify_hist {$server ZADD z1 1 a 2 b 3 c 4 d 5 e} {db0_ZSET:4=1}
@@ -399,6 +415,12 @@ proc test_all_keysizes { {replMode 0} } {
         run_cmd_verify_hist {$server ZADD z1 1 a 2 b 3 c 4 d 5 e} {db0_ZSET:4=1}
         run_cmd_verify_hist {$server SET z1 1234567} {db0_STR:4=1}
         run_cmd_verify_hist {$server DEL z1} {}
+        # ZMPOP
+        run_cmd_verify_hist {$server FLUSHALL} {}
+        run_cmd_verify_hist {$server ZADD z1 1 a 2 b 3 c} {db0_ZSET:2=1}
+        run_cmd_verify_hist {$server ZMPOP 1 z1 MIN} {db0_ZSET:2=1}
+        run_cmd_verify_hist {$server ZMPOP 1 z1 MAX COUNT 2} {}
+        
     } {} {cluster:skip}    
     
     test "KEYSIZES - Test STRING $suffixRepl" {        
@@ -424,8 +446,7 @@ proc test_all_keysizes { {replMode 0} } {
         run_cmd_verify_hist {$server SET s1 1024} {db0_STR:4=1}
         run_cmd_verify_hist {$server SET s1 842} {db0_STR:2=1}
         run_cmd_verify_hist {$server SET s1 2} {db0_STR:1=1}
-        run_cmd_verify_hist {$server SET s1 1234567} {db0_STR:4=1}        
-
+        run_cmd_verify_hist {$server SET s1 1234567} {db0_STR:4=1}
         # SET (string of length 0)
         run_cmd_verify_hist {$server FLUSHALL} {}
         run_cmd_verify_hist {$server SET s1 ""} {db0_STR:0=1}
@@ -438,7 +459,21 @@ proc test_all_keysizes { {replMode 0} } {
         run_cmd_verify_hist {$server DEL h} {db0_STR:0=2}
         run_cmd_verify_hist {$server DEL s2} {db0_STR:0=1}
         run_cmd_verify_hist {$server DEL s1} {}
+        # APPEND
+        run_cmd_verify_hist {$server FLUSHALL} {}
+        run_cmd_verify_hist {$server APPEND s1 x} {db0_STR:1=1}
+        run_cmd_verify_hist {$server APPEND s2 y} {db0_STR:1=2}
 
+    } {} {cluster:skip}
+    
+    test "KEYSIZES - Test complex dataset $suffixRepl" {
+        run_cmd_verify_hist {$server FLUSHALL} {}
+        createComplexDataset $server 1000
+        run_cmd_verify_hist {} {__EVAL_DB_HIST__ 0}
+        
+        run_cmd_verify_hist {$server FLUSHALL} {}
+        createComplexDataset $server 1000 {useexpire usehexpire}
+        run_cmd_verify_hist {} {__EVAL_DB_HIST__ 0} 1
     } {} {cluster:skip}
     
     foreach type {listpackex hashtable} {
@@ -460,6 +495,8 @@ proc test_all_keysizes { {replMode 0} } {
             run_cmd_verify_hist {$server HSET h2 2 2} {db0_HASH:2=1}
             run_cmd_verify_hist {$server HDEL h2 1}   {db0_HASH:1=1}
             run_cmd_verify_hist {$server HDEL h2 2}   {}
+            run_cmd_verify_hist {$server HSET h2 1 1 2 2} {db0_HASH:2=1}
+            run_cmd_verify_hist {$server HDEL h2 1 2}   {}
             # HGETDEL
             run_cmd_verify_hist {$server FLUSHALL} {}
             run_cmd_verify_hist {$server HSETEX h2 FIELDS 1 1 1} {db0_HASH:1=1}


### PR DESCRIPTION
There are several issues with maintaining histogram counters.

Ideally, the hooks would be placed in the low-level datatype implementations. However, this logic is triggered in various contexts and doesn’t always map directly to a stored DB key. As a result, the hooks sit closer to the high-level commands layer. It’s a bit messy, but the right way to ensure histogram counters behave correctly is through broad test coverage.

* Fix inaccuracies around deletion scenarios.
* Fix inaccuracies around modules calls. Added corresponding tests.
* The info-keysizes.tcl test has been extended to operate on meaningful datasets
* Validate histogram correctness in edge cases involving collection deletions.
* Add new macro debugServerAssert(). Effective only if compiled with DEBUG_ASSERTIONS.
