### PR TITLE
Fix: resolve compilation issue with pthread_rwlock_t

### DIFF
--- a/modules/vector-sets/Makefile
+++ b/modules/vector-sets/Makefile
@@ -26,6 +26,7 @@ uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
 
 # Shared library compile flags for linux / osx
 ifeq ($(uname_S),Linux)
+	CFLAGS += -D_POSIX_C_SOURCE=200809L -D_GNU_SOURCE
 	SHOBJ_CFLAGS ?= -W -Wall -fno-common -g -ggdb -std=c11 -O2
 	SHOBJ_LDFLAGS ?= -shared
 ifneq (,$(findstring armv,$(uname_M)))

--- a/modules/vector-sets/Makefile
+++ b/modules/vector-sets/Makefile
@@ -26,7 +26,6 @@ uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
 
 # Shared library compile flags for linux / osx
 ifeq ($(uname_S),Linux)
-	CFLAGS += -D_POSIX_C_SOURCE=200809L -D_GNU_SOURCE
 	SHOBJ_CFLAGS ?= -W -Wall -fno-common -g -ggdb -std=c11 -O2
 	SHOBJ_LDFLAGS ?= -shared
 ifneq (,$(findstring armv,$(uname_M)))

--- a/modules/vector-sets/w2v.c
+++ b/modules/vector-sets/w2v.c
@@ -10,6 +10,8 @@
  * Originally authored by: Salvatore Sanfilippo
  */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Adds #define _POSIX_C_SOURCE 200809L in w2v.c to make advanced pthread data structures 
like pthread_rwlock_t available during compilation.