### PR TITLE
Fix timing issue in lazyfree test

### DIFF
--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -182,11 +182,11 @@ start_server {tags {"lazyfree"}} {
         populate 50000 ;# Just to make flushdb async slower
         $rd flushdb
 
-        # Verify flushall run as lazyfree
+        # Verify flushdb run as lazyfree
         wait_for_condition 50 100 {
             [s lazyfree_pending_objects] > 0
         } else {
-            fail "Unexpected number of lazyfreed_objects: [s lazyfreed_objects]"
+            fail "FLUSHDB didn't run as lazyfree"
         }
 
         # Test that slaveof command unblocks clients without assertion failure

--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -184,7 +184,8 @@ start_server {tags {"lazyfree"}} {
 
         # Verify flushdb run as lazyfree
         wait_for_condition 50 100 {
-            [s lazyfree_pending_objects] > 0
+            [s lazyfree_pending_objects] > 0 ||
+            [s lazyfreed_objects] > 0
         } else {
             fail "FLUSHDB didn't run as lazyfree"
         }

--- a/tests/unit/lazyfree.tcl
+++ b/tests/unit/lazyfree.tcl
@@ -176,11 +176,19 @@ start_server {tags {"lazyfree"}} {
     }
 
     test "Unblocks client blocked on lazyfree via REPLICAOF command" {
+        r config resetstat
         set rd [redis_deferring_client]
 
         populate 50000 ;# Just to make flushdb async slower
         $rd flushdb
-        wait_for_blocked_client
+
+        # Verify flushall run as lazyfree
+        wait_for_condition 50 100 {
+            [s lazyfree_pending_objects] > 0
+        } else {
+            fail "Unexpected number of lazyfreed_objects: [s lazyfreed_objects]"
+        }
+
         # Test that slaveof command unblocks clients without assertion failure
         r slaveof 127.0.0.1 0
         assert_equal [$rd read] {OK}


### PR DESCRIPTION
This test was introduced by https://github.com/redis/redis/issues/13853
We determine if the client is in blocked status, but if async flushdb is completed before checking the blocked status, the test will fail.
So modify the test to only determine if `lazyfree_pending_objects` is correct to ensure that flushdb is async, that is, the client must be blocked.

Failed CI: https://github.com/redis/redis/actions/runs/14297983338/job/40067661367