### PR TITLE
Fix port update not reflected in CLUSTER SLOTS

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2450,12 +2450,6 @@ static int updateHZ(const char **err) {
     return 1;
 }
 
-static int updateClusterAnnouncedPort(const char **err) {
-    UNUSED(err);
-    clusterUpdateMyselfAnnouncedPorts();
-    return 1;
-}
-
 static int updatePort(const char **err) {
     connListener *listener = listenerByType(CONN_TYPE_SOCKET);
 
@@ -2463,7 +2457,7 @@ static int updatePort(const char **err) {
     listener->bindaddr = server.bindaddr;
     listener->bindaddr_count = server.bindaddr_count;
     listener->port = server.port;
-    updateClusterAnnouncedPort(err);
+    clusterUpdateMyselfAnnouncedPorts();
     listener->ct = connectionByType(CONN_TYPE_SOCKET);
     if (changeListener(listener) == C_ERR) {
         *err = "Unable to listen on this port. Check server logs.";
@@ -2639,6 +2633,12 @@ static int applyBind(const char **err) {
 int updateClusterFlags(const char **err) {
     UNUSED(err);
     clusterUpdateMyselfFlags();
+    return 1;
+}
+
+static int updateClusterAnnouncedPort(const char **err) {
+    UNUSED(err);
+    clusterUpdateMyselfAnnouncedPorts();
     return 1;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -2450,6 +2450,12 @@ static int updateHZ(const char **err) {
     return 1;
 }
 
+static int updateClusterAnnouncedPort(const char **err) {
+    UNUSED(err);
+    clusterUpdateMyselfAnnouncedPorts();
+    return 1;
+}
+
 static int updatePort(const char **err) {
     connListener *listener = listenerByType(CONN_TYPE_SOCKET);
 
@@ -2457,6 +2463,7 @@ static int updatePort(const char **err) {
     listener->bindaddr = server.bindaddr;
     listener->bindaddr_count = server.bindaddr_count;
     listener->port = server.port;
+    updateClusterAnnouncedPort(err);
     listener->ct = connectionByType(CONN_TYPE_SOCKET);
     if (changeListener(listener) == C_ERR) {
         *err = "Unable to listen on this port. Check server logs.";
@@ -2632,12 +2639,6 @@ static int applyBind(const char **err) {
 int updateClusterFlags(const char **err) {
     UNUSED(err);
     clusterUpdateMyselfFlags();
-    return 1;
-}
-
-static int updateClusterAnnouncedPort(const char **err) {
-    UNUSED(err);
-    clusterUpdateMyselfAnnouncedPorts();
     return 1;
 }
 

--- a/tests/unit/cluster/announced-endpoints.tcl
+++ b/tests/unit/cluster/announced-endpoints.tcl
@@ -52,7 +52,8 @@ test "CONFIG SET port updates cluster-announced port" {
         # Get the original port and change to new_port
         set orig_port [lindex [R 0 config get port] 1]
         assert {$orig_port != ""}
-        set new_port [expr {$orig_port + 100}]
+
+        set new_port [find_available_port $baseport $count]
         R 0 config set port $new_port
 
         # Verify that the new port appears in the output of cluster slots

--- a/tests/unit/cluster/announced-endpoints.tcl
+++ b/tests/unit/cluster/announced-endpoints.tcl
@@ -49,9 +49,8 @@ start_cluster 2 2 {tags {external:skip cluster}} {
     }
 
 test "CONFIG SET port updates cluster-announced port" {
-
         # Get the original port and change to new_port
-        set orig_port  [lindex [R 0 config get port] 1]
+        set orig_port [lindex [R 0 config get port] 1]
         assert {$orig_port != ""}
         set new_port [expr {$orig_port + 100}]
         R 0 config set port $new_port
@@ -62,6 +61,5 @@ test "CONFIG SET port updates cluster-announced port" {
         } else {
             fail "Cluster announced port was not updated in cluster slots"
         }
-
     }
 }

--- a/tests/unit/cluster/announced-endpoints.tcl
+++ b/tests/unit/cluster/announced-endpoints.tcl
@@ -48,7 +48,7 @@ start_cluster 2 2 {tags {external:skip cluster}} {
         assert_match "*@$base_bus_port *" [R 0 CLUSTER NODES]
     }
 
-test "CONFIG SET port updates cluster-announced port" {
+    test "CONFIG SET port updates cluster-announced port" {
         # Get the original port and change to new_port
         set orig_port [lindex [R 0 config get port] 1]
         assert {$orig_port != ""}

--- a/tests/unit/cluster/announced-endpoints.tcl
+++ b/tests/unit/cluster/announced-endpoints.tcl
@@ -47,4 +47,21 @@ start_cluster 2 2 {tags {external:skip cluster}} {
         R 0 config set cluster-announce-bus-port 0
         assert_match "*@$base_bus_port *" [R 0 CLUSTER NODES]
     }
+
+test "CONFIG SET port updates cluster-announced port" {
+
+        # Get the original port and change to new_port
+        set orig_port  [lindex [R 0 config get port] 1]
+        assert {$orig_port != ""}
+        set new_port [expr {$orig_port + 100}]
+        R 0 config set port $new_port
+
+        # Verify that the new port appears in the output of cluster slots
+        wait_for_condition 50 100 {
+            [string match "*$new_port*" [R 0 cluster slots]]
+        } else {
+            fail "Cluster announced port was not updated in cluster slots"
+        }
+
+    }
 }


### PR DESCRIPTION
Close https://github.com/redis/redis/issues/13892 
config set port cmd updates server.port. cluster slot retrieves information about cluster slots and their associated nodes. the fix updates this info when config set port cmd is done, so cluster slots cmd returns the right value.
