### PR TITLE
Fix 'Client output buffer hard limit is enforced' test causing infinite loop

### DIFF
--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -37,7 +37,7 @@ start_server {tags {"obuf-limits external:skip logreqres:skip"}} {
 
         set omem 0
         while 1 {
-            r publish foo bar
+            r publish foo [string repeat bar 50]
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]
             if {![regexp {omem=([0-9]+)} $c - omem]} break

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -37,7 +37,7 @@ start_server {tags {"obuf-limits external:skip logreqres:skip"}} {
 
         set omem 0
         while 1 {
-            #The larger content size ensures that client.buf gets filled more quickly,
+            # The larger content size ensures that client.buf gets filled more quickly,
             # allowing us to correctly observe the gradual increase of `omem`
             r publish foo [string repeat bar 50]
             set clients [split [r client list] "\r\n"]

--- a/tests/unit/obuf-limits.tcl
+++ b/tests/unit/obuf-limits.tcl
@@ -37,6 +37,8 @@ start_server {tags {"obuf-limits external:skip logreqres:skip"}} {
 
         set omem 0
         while 1 {
+            #The larger content size ensures that client.buf gets filled more quickly,
+            # allowing us to correctly observe the gradual increase of `omem`
             r publish foo [string repeat bar 50]
             set clients [split [r client list] "\r\n"]
             set c [split [lindex $clients 1] " "]


### PR DESCRIPTION
This PR fixes an issue in the CI test for client-output-buffer-limit, which was causing an infinite loop when running on macOS 15.4.

### Problem

This test start two clients, R and R1:
```c
R1 subscribe foo
R publish foo bar
```

When R executes `PUBLISH foo bar`, the server first stores the message `bar` in R1‘s buf. Only when the space in buf is insufficient does it call `_addReplyProtoToList`.
Inside this function, `closeClientOnOutputBufferLimitReached` is invoked to check whether the client’s  R1 output buffer has reached its configured limit. 
On macOS 15.4, because the server writes to the client at a high speed, R1’s buf never gets full. As a result, `closeClientOnOutputBufferLimitReached`  in the test is never triggered, causing the test to never exit and fall into an infinite loop.

I modify the test like this, print client information and the number of loop iterations:
```
test {Client output buffer hard limit is enforced} {
    r config set client-output-buffer-limit {pubsub 100000 0 0}
    set rd1 [redis_deferring_client]

    $rd1 subscribe foo
    set reply [$rd1 read]
    assert {$reply eq "subscribe foo 1"}

    set omem 0
    set loopTime 0
    while 1 {
        incr loopTime
        puts "---currentLoop: $loopTime---"
        r publish foo bar
        set clients [split [r client list] "\r\n"]
        set c [split [lindex $clients 1] " "]
        puts "clients: $clients"
        if {![ regexp {omem=([0-9]+)} $c - omem]} break
        if {$omem > 200000} break
    }
    assert {$omem >= 70000 && $omem < 200000}
    $rd1 close
}
```

The run test `./runtest --single "unit/obuf-limits" --only "Client output buffer hard limit is enforced"`

#### Run on ubuntu:

```shell
---currentLoop: 34230---
clients: {id=5 addr=127.0.0.1:33185 laddr=127.0.0.1:21111 fd=12 name= age=6 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=20448 argv-mem=10 multi-mem=0 rbs=1024 rbp=621 obl=0 oll=0 omem=0 tot-mem=22426 events=r cmd=client|list user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {id=6 addr=127.0.0.1:41367 laddr=127.0.0.1:21111 fd=13 name= age=6 idle=0 flags=P db=9 sub=1 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=0 argv-mem=0 multi-mem=0 rbs=2048 rbp=1024 obl=1024 oll=4 omem=82016 tot-mem=85016 events=rw cmd=subscribe user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {}
---currentLoop: 34231---
clients: {id=5 addr=127.0.0.1:33185 laddr=127.0.0.1:21111 fd=12 name= age=6 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=20448 argv-mem=10 multi-mem=0 rbs=1024 rbp=621 obl=0 oll=0 omem=0 tot-mem=22426 events=r cmd=client|list user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {id=6 addr=127.0.0.1:41367 laddr=127.0.0.1:21111 fd=13 name= age=6 idle=0 flags=P db=9 sub=1 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=0 argv-mem=0 multi-mem=0 rbs=2048 rbp=1024 obl=1024 oll=4 omem=82016 tot-mem=85016 events=rw cmd=subscribe user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {}
---currentLoop: 34232---
clients: {id=5 addr=127.0.0.1:33185 laddr=127.0.0.1:21111 fd=12 name= age=6 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=20448 argv-mem=10 multi-mem=0 rbs=1024 rbp=621 obl=0 oll=0 omem=0 tot-mem=22426 events=r cmd=client|list user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {}
[ok]: Client output buffer hard limit is enforced (6629 ms)
```
The `omem` increases correctly, and the client will be killed.

#### Run on macOS

```shell
---currentLoop: 2220600---
clients: {id=5 addr=127.0.0.1:61497 laddr=127.0.0.1:21111 fd=14 name= age=270 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=16864 argv-mem=10 multi-mem=0 rbs=1024 rbp=614 obl=0 oll=0 omem=0 tot-mem=18746 events=r cmd=client|list user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {id=6 addr=127.0.0.1:61498 laddr=127.0.0.1:21111 fd=15 name= age=270 idle=0 flags=P db=9 sub=1 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=0 argv-mem=0 multi-mem=0 rbs=1024 rbp=35 obl=0 oll=0 omem=0 tot-mem=1880 events=r cmd=subscribe user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {}
---currentLoop: 2220601---
clients: {id=5 addr=127.0.0.1:61497 laddr=127.0.0.1:21111 fd=14 name= age=270 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=16864 argv-mem=10 multi-mem=0 rbs=1024 rbp=614 obl=0 oll=0 omem=0 tot-mem=18746 events=r cmd=client|list user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {id=6 addr=127.0.0.1:61498 laddr=127.0.0.1:21111 fd=15 name= age=270 idle=0 flags=P db=9 sub=1 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=0 argv-mem=0 multi-mem=0 rbs=1024 rbp=35 obl=0 oll=0 omem=0 tot-mem=1880 events=r cmd=subscribe user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {}
---currentLoop: 2220602---
clients: {id=5 addr=127.0.0.1:61497 laddr=127.0.0.1:21111 fd=14 name= age=270 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=16864 argv-mem=10 multi-mem=0 rbs=1024 rbp=614 obl=0 oll=0 omem=0 tot-mem=18746 events=r cmd=client|list user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {id=6 addr=127.0.0.1:61498 laddr=127.0.0.1:21111 fd=15 name= age=270 idle=0 flags=P db=9 sub=1 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=0 argv-mem=0 multi-mem=0 rbs=1024 rbp=35 obl=0 oll=0 omem=0 tot-mem=1880 events=r cmd=subscribe user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {}
---currentLoop: 2220603---
......
```
The `omem` is always 0 and the loop never ends.


### Fixed

I changed `r publish foo bar` to `r publish foo [string repeat bar 50]`  to ensure the buffer is filled, which correctly reproduces the scenario where omem increases.

New test with printf content:
```shell
test {Client output buffer hard limit is enforced} {
    r config set client-output-buffer-limit {pubsub 100000 0 0}
    set rd1 [redis_deferring_client]

    $rd1 subscribe foo
    set reply [$rd1 read]
    assert {$reply eq "subscribe foo 1"}

    set omem 0
    set loopTime 0
    while 1 {
        incr loopTime
        puts "---currentLoop: $loopTime---"
        r publish foo [string repeat bar 50]
        set clients [split [r client list] "\r\n"]
        set c [split [lindex $clients 1] " "]
        puts "clients: $clients"
        if {![ regexp {omem=([0-9]+)} $c - omem]} break
        if {$omem > 200000} break
    }
    assert {$omem >= 70000 && $omem < 200000}
    $rd1 close
}
```

Test result:
```
---currentLoop: 3495---
clients: {id=5 addr=127.0.0.1:63060 laddr=127.0.0.1:21111 fd=14 name= age=0 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=16864 argv-mem=10 multi-mem=0 rbs=1024 rbp=621 obl=0 oll=0 omem=0 tot-mem=18746 events=r cmd=client|list user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {id=6 addr=127.0.0.1:63061 laddr=127.0.0.1:21111 fd=15 name= age=0 idle=0 flags=P db=9 sub=1 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=0 argv-mem=0 multi-mem=0 rbs=1024 rbp=1024 obl=1024 oll=5 omem=84600 tot-mem=86480 events=rw cmd=subscribe user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {}
---currentLoop: 3496---
clients: {id=5 addr=127.0.0.1:63060 laddr=127.0.0.1:21111 fd=14 name= age=0 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=16864 argv-mem=10 multi-mem=0 rbs=1024 rbp=621 obl=0 oll=0 omem=0 tot-mem=18746 events=r cmd=client|list user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {id=6 addr=127.0.0.1:63061 laddr=127.0.0.1:21111 fd=15 name= age=0 idle=0 flags=P db=9 sub=1 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=0 argv-mem=0 multi-mem=0 rbs=1024 rbp=1024 obl=1024 oll=5 omem=84600 tot-mem=86480 events=rw cmd=subscribe user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {}
---currentLoop: 3497---
clients: {id=5 addr=127.0.0.1:63060 laddr=127.0.0.1:21111 fd=14 name= age=0 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=16864 argv-mem=10 multi-mem=0 rbs=1024 rbp=621 obl=0 oll=0 omem=0 tot-mem=18746 events=r cmd=client|list user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {id=6 addr=127.0.0.1:63061 laddr=127.0.0.1:21111 fd=15 name= age=0 idle=0 flags=P db=9 sub=1 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=0 argv-mem=0 multi-mem=0 rbs=1024 rbp=1024 obl=1024 oll=5 omem=84600 tot-mem=86480 events=rw cmd=subscribe user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {}
---currentLoop: 3498---
clients: {id=5 addr=127.0.0.1:63060 laddr=127.0.0.1:21111 fd=14 name= age=0 idle=0 flags=N db=9 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=16864 argv-mem=10 multi-mem=0 rbs=1024 rbp=621 obl=0 oll=0 omem=0 tot-mem=18746 events=r cmd=client|list user=default redir=-1 resp=2 lib-name= lib-ver= io-thread=0} {}
[ok]: Client output buffer hard limit is enforced (434 ms)
```
