### PR TITLE
Implement listpack garbage collection for XDEL and XTRIM

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1380,6 +1380,63 @@ unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num) {
     return lp;
 }
 
+/**
+ * Delete ranges of items. The ranges are determined by the callback function `getNextRange`.
+ * This callback receives pointers to the listpack and the current item, indicating that the
+ * search for the next range should begin at the given item.
+ * The callback function's output pointer (`unsigned char **`) points to the start of the range,
+ * and the return value indicates the number of items in that range.
+ * We delete the specified ranges and preserve the bytes between these ranges by moving them 
+ * to the end of the preserved region.
+ */
+unsigned char *lpDeleteRanges(unsigned char *lp, unsigned char *p, uint32_t (*getNextRange)(unsigned char *, unsigned char *, unsigned char **, void *), void *arg) {
+    unsigned char *preserved_end, *range_start, *eofptr;
+    size_t bytes = lpBytes(lp), move_size;
+    uint32_t numele = lpGetNumElements(lp), range_ele;
+    lpAssertValidEntry(lp, bytes, p);
+    preserved_end = range_start = NULL;
+    eofptr = lp + bytes - 1;
+    while (p[0] != LP_EOF) {
+        range_ele = getNextRange(lp, p, &range_start, arg);
+        assert(numele >= range_ele);
+        if (range_start == NULL) {
+            /* No more deleted range. */
+            break;
+        }
+        lpAssertValidEntry(lp, bytes, range_start);
+        assert(range_start >= p);
+        if (preserved_end == NULL) {
+            /* This is the first range to delete, so we preserve all bytes before range_start (exclusive)
+             * by setting preserved_end to range_start. */
+            preserved_end = range_start;
+        } else if (range_start > p) {
+            /* Bytes in the range [p, range_start) should be preserved. */
+            move_size = range_start - p;
+            memmove(preserved_end, p, move_size);
+            preserved_end += move_size;
+        }
+        /* Move p to the first byte after the deleted range and continue searching for the next range
+         * to delete in the next loop. */
+        p = range_start;
+        for (uint32_t i = 0; i < range_ele; i++) {
+            p = lpSkip(p);
+            numele--;
+            if (p[0] == LP_EOF) break;
+            lpAssertValidEntry(lp, bytes, p);
+        }
+    }
+    if (preserved_end != NULL) {
+        /* Preserve the bytes after the last deleted range. */
+        move_size = eofptr + 1 - p;
+        memmove(preserved_end, p, move_size);
+        preserved_end += move_size;
+        lpSetTotalBytes(lp, preserved_end - lp);
+        lpSetNumElements(lp, numele);
+        lp = lpShrinkToFit(lp);
+    }
+    return lp;
+}
+
 /* Delete the elements 'ps' passed as an array of 'count' element pointers and
  * return the resulting listpack. The elements must be given in the same order
  * as they apper in the listpack. */
@@ -2056,6 +2113,83 @@ static unsigned char *createIntList(void) {
     return lp;
 }
 
+/* Callback function for lpDeleteRanges(), it can be used to delete ranges in intlist */
+static uint32_t deleteAllPositiveIntegers(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+    (void)arg;
+    long long val;
+    unsigned char *last = lpLast(lp);
+    while (1) {
+        if (lpGetIntegerValue(p, &val)) {
+            if (val >= 0) {
+                *range_start = p;
+                return 1;
+            }
+        }
+        if (p == last) break;
+        p = lpSkip(p);
+    }
+    *range_start = NULL;
+    return 0;
+}
+
+/* Callback functions for lpDeleteRanges(), they can be used to delete ranges in mixlist */
+static uint32_t delete1stTo3rdRange(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+    (void)lp;
+    int *deleted = (int *)arg;
+    /* Only one range to delete in this case. We use 'deleted' to ensure the range is returned only once. */
+    if (*deleted == 0) {
+        *range_start = p;
+        *deleted = 1;
+        return 3;
+    }
+    *range_start = NULL;
+    return 0;
+}
+static uint32_t delete1stAnd3rdItems(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+    int *idx = (int *)arg;
+    while (1) {
+        (*idx)++;
+        if (*idx == 1 || *idx == 3) {
+            *range_start = p;
+            return 1;
+        }
+        if (p == lpLast(lp)) break;
+        p = lpNext(lp, p);
+    }
+    *range_start = NULL;
+    return 0;
+}
+
+static uint32_t delete1stAnd2ndAnd4thItems(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+    int *idx = (int *)arg;
+    while (1) {
+        (*idx)++;
+        if (*idx == 1) {
+            *range_start = p;
+            (*idx)++;
+            return 2;
+        }
+        if (*idx == 4) {
+            *range_start = p;
+            return 1;
+        }
+        if (p == lpLast(lp)) break;
+        p = lpNext(lp, p);
+    }
+    *range_start = NULL;
+    return 0;
+}
+
+static uint32_t deleteAll(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+    (void)arg;
+    if (p == lpFirst(lp)) {
+        *range_start = p;
+        return lpLength(lp);
+    }
+    *range_start = NULL;
+    return 0;
+}
+
 static long long usec(void) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
@@ -2411,6 +2545,97 @@ int listpackTest(int argc, char *argv[], int flags) {
         lp = lpDeleteRangeWithEntry(lp, &ptr, 5);
         assert(lpLength(lp) == 1);
         verifyEntry(lpFirst(lp), (unsigned char*)mixlist[0], strlen(mixlist[0]));
+        zfree(lp);
+    }
+
+    TEST("Delete ranges: all positive integers") {
+        lp = createIntList();
+        lp = lpDeleteRanges(lp, lpFirst(lp), deleteAllPositiveIntegers, NULL);
+        assert(lpLength(lp) == 3);
+        p = lpFirst(lp);
+        long long val;
+        for (int i = 0; i < 3; i++) {
+            if (lpGetIntegerValue(p, &val)) {
+                assert(val < 0);
+            }
+            p = lpSkip(p);
+        }
+        zfree(lp);
+    }
+
+    TEST("Delete ranges: all positive integers (larger data set)") {
+        lp = lpNew(0);
+        int run = 3;
+        while (run--) {
+            for (int i = -500; i < 0; i += 10) {
+                lp = lpAppendInteger(lp, i);
+            }
+            for (int i = 100; i < 300; i += 10) {
+                lp = lpAppendInteger(lp, i);
+            }
+            for (int i = -987654321; i < 0; i += 10000000) {
+                lp = lpAppendInteger(lp, i);
+            }
+            for (int i = 123456789; i < 999999999; i += 10000000) {
+                lp = lpAppendInteger(lp, i);
+            }
+            lp = lpDeleteRanges(lp, lpFirst(lp), deleteAllPositiveIntegers, NULL);
+            p = lpFirst(lp);
+            long long val;
+            int len = (int)lpLength(lp);
+            for (int i = 0; i < len; i++) {
+                if (lpGetIntegerValue(p, &val)) {
+                    assert(val < 0);
+                }
+                p = lpSkip(p);
+            }
+        }
+        zfree(lp);
+    }
+
+    TEST("Delete ranges: 1st to 3rd range(index range[0, 2])") {
+        lp = createList();
+        int deleted = 0;
+        lp = lpDeleteRanges(lp, lpFirst(lp), delete1stTo3rdRange, (void *)&deleted);
+        assert(lpLength(lp) == 1);
+        verifyEntry(lpFirst(lp), (unsigned char *)mixlist[3], strlen(mixlist[3]));
+        zfree(lp);
+    }
+
+    TEST("Delete ranges: 1st and 3rd items(index 0 and 2)") {
+        lp = createList();
+        int idx = 0;
+        lp = lpDeleteRanges(lp, lpFirst(lp), delete1stAnd3rdItems, (void *)&idx);
+        assert(lpLength(lp) == 2);
+        p = lpFirst(lp);
+        verifyEntry(p, (unsigned char *)mixlist[1], strlen(mixlist[1]));
+        p = lpSkip(p);
+        verifyEntry(p, (unsigned char *)mixlist[3], strlen(mixlist[3]));
+        zfree(lp);
+    }
+
+    TEST("Delete ranges: 1st and 2nd and 4th items(index 0 and 1 and 3)") {
+        lp = createList();
+        int idx = 0;
+        lp = lpDeleteRanges(lp, lpFirst(lp), delete1stAnd2ndAnd4thItems, (void *)&idx);
+        assert(lpLength(lp) == 1);
+        p = lpFirst(lp);
+        verifyEntry(p, (unsigned char *)mixlist[2], strlen(mixlist[2]));
+        zfree(lp);
+    }
+
+    TEST("Delete ranges: delete all items and result in empty list") {
+        lp = createList();
+        assert(lpLength(lp) == 4);
+        lp = lpDeleteRanges(lp, lpFirst(lp), deleteAll, NULL);
+        assert(lpLength(lp) == 0);
+
+        for (int i = 1; i <= 10; i++) {
+            lp = lpAppendInteger(lp, i); /* append positive integers */
+        }
+        assert(lpLength(lp) == 10);
+        lp = lpDeleteRanges(lp, lpFirst(lp), deleteAllPositiveIntegers, NULL);
+        assert(lpLength(lp) == 0);
         zfree(lp);
     }
 

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -50,6 +50,7 @@ unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long 
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp);
 unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsigned long num);
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num);
+unsigned char *lpDeleteRanges(unsigned char *lp, unsigned char *p, uint32_t (*getNextRange)(unsigned char *, unsigned char *, unsigned char **, void *), void *arg);
 unsigned char *lpBatchAppend(unsigned char *lp, listpackEntry *entries, unsigned long len);
 unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
                              listpackEntry *entries, unsigned int len, unsigned char **newp);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -38,6 +38,7 @@ void streamFreeNACK(streamNACK *na);
 size_t streamReplyWithRangeFromConsumerPEL(client *c, stream *s, streamID *start, streamID *end, size_t count, streamConsumer *consumer);
 int streamParseStrictIDOrReply(client *c, robj *o, streamID *id, uint64_t missing_seq, int *seq_given);
 int streamParseIDOrReply(client *c, robj *o, streamID *id, uint64_t missing_seq);
+static uint32_t listpackGetNextDeletedRange(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg);
 
 /* -----------------------------------------------------------------------
  * Low level stream encoding: a radix tree of listpacks.
@@ -829,15 +830,30 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         lp = lpReplaceInteger(lp,&p,entries-deleted_from_lp);
         p = lpNext(lp,p); /* Skip deleted field. */
         int64_t marked_deleted = lpGetInteger(p);
-        lp = lpReplaceInteger(lp,&p,marked_deleted+deleted_from_lp);
-        p = lpNext(lp,p); /* Skip num-of-fields in the master entry. */
 
         /* Here we should perform garbage collection in case at this point
          * there are too many entries deleted inside the listpack. */
         entries -= deleted_from_lp;
         marked_deleted += deleted_from_lp;
+        
+        int needGarbageCollection = 0;
         if (entries + marked_deleted > 10 && marked_deleted > entries/2) {
-            /* TODO: perform a garbage collection. */
+            needGarbageCollection = 1;
+            lp = lpReplaceInteger(lp, &p, 0);
+        } else {
+            lp = lpReplaceInteger(lp,&p,marked_deleted);
+        }
+        p = lpNext(lp,p); /* Skip num-of-fields in the master entry. */
+
+        if (needGarbageCollection) {
+            /* Perform a garbage collection. */
+            int64_t aux = lpGetInteger(p);
+            serverAssert(aux >= 0 && aux <= (int64_t)UINT32_MAX);
+            uint32_t master_fields = (uint32_t)aux;
+            for (uint32_t i = 0; i < 2 + master_fields; i++) {
+                p = lpNext(lp, p);
+            }
+            lp = lpDeleteRanges(lp, p, listpackGetNextDeletedRange, (void *)&master_fields);
         }
 
         /* Update the listpack with the new pointer. */
@@ -1258,7 +1274,7 @@ void streamIteratorGetField(streamIterator *si, unsigned char **fieldptr, unsign
  * with GetID(). */
 void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     unsigned char *lp = si->lp;
-    int64_t aux;
+    int64_t numele, deleted, num_fields;
 
     /* We do not really delete the entry here. Instead we mark it as
      * deleted by flagging it, and also incrementing the count of the
@@ -1271,19 +1287,35 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
 
     /* Change the valid/deleted entries count in the master entry. */
     unsigned char *p = lpFirst(lp);
-    aux = lpGetInteger(p);
+    numele = lpGetInteger(p);
 
-    if (aux == 1) {
+    if (numele == 1) {
         /* If this is the last element in the listpack, we can remove the whole
          * node. */
         lpFree(lp);
         raxRemove(si->stream->rax,si->ri.key,si->ri.key_len,NULL);
     } else {
         /* In the base case we alter the counters of valid/deleted entries. */
-        lp = lpReplaceInteger(lp,&p,aux-1);
+        numele--;
+        lp = lpReplaceInteger(lp,&p,numele);
         p = lpNext(lp,p); /* Seek deleted field. */
-        aux = lpGetInteger(p);
-        lp = lpReplaceInteger(lp,&p,aux+1);
+        deleted = lpGetInteger(p) + 1;
+        if (numele + deleted <= 10 || deleted <= numele / 2) {
+            lp = lpReplaceInteger(lp,&p,deleted);
+        } else {
+            /* Perform garbage collection when total entries > 10 and deleted entries > valid entries / 2 */
+            lp = lpReplaceInteger(lp,&p,0);
+            p = lpNext(lp, p);
+            num_fields = lpGetInteger(p);
+            serverAssert(num_fields >= 0 && num_fields <= (int64_t)UINT32_MAX);
+            uint32_t master_fields = (uint32_t)num_fields;
+            /* Skip num-fields, master fields and ending zero */
+            for (int64_t i = 0; i < num_fields + 2; i++) {
+                p = lpNext(lp, p);
+            }
+            /* Delete all the entries marked as deleted */
+            lp = lpDeleteRanges(lp, p, listpackGetNextDeletedRange, (void *)&master_fields);
+        }
 
         /* Update the listpack with the new pointer. */
         if (si->lp != lp)
@@ -1304,9 +1336,56 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     }
     streamIteratorStop(si);
     streamIteratorStart(si,si->stream,&start,&end,si->rev);
+}
 
-    /* TODO: perform a garbage collection here if the ratio between
-     * deleted and valid goes over a certain limit. */
+/**
+ * Callback function for lpDeleteRanges.
+ *
+ * @param p Pointer to the start of an entry.
+ * @param range_start Output pointer set to the start of the deleted entry (range).
+ * @return The number of items that make up the deleted entry.
+ *
+ * This function searches for the next deleted entry, which is treated as a range of items
+ * to delete from the listpack.
+ */
+static uint32_t listpackGetNextDeletedRange(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+    int64_t flags, num_fields;
+    uint32_t master_fields = *((uint32_t *)arg);
+    uint32_t fields_values_num; /* Number of listpack items that together represent the fields and values of an entry */
+    unsigned char *last = lpLast(lp);
+    while (1) {
+        flags = lpGetInteger(p);
+        if (flags & STREAM_ITEM_FLAG_DELETED) {
+            *range_start = p;
+            if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) {
+                /* 3 heading items(flags + entry-id-ms + entry-id-seq) + values + lp-count */
+                return 3 + master_fields + 1;
+            }
+        }
+        p = lpNext(lp, p); /* p points to entry-id ms */
+        p = lpNext(lp, p); /* p points to entry-id seq */
+        if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) {
+            fields_values_num = master_fields;
+        } else {
+            p = lpNext(lp, p); /* p points to num-fields */
+            num_fields = lpGetInteger(p);
+            serverAssert(num_fields >= 0 && num_fields * 2 <= (int64_t)UINT32_MAX);
+            fields_values_num = (uint32_t)num_fields * 2;
+        }
+        if (flags & STREAM_ITEM_FLAG_DELETED) {
+            /* 3 heading items(flags + entry-id-ms + entry-id-seq) + num-fields + field and value pairs + lp-count */
+            return 3 + 1 + fields_values_num + 1;
+        }
+        p = lpNext(lp, p); /* p points to the first field(value) */
+        while (fields_values_num--) {
+            p = lpNext(lp, p);
+        }
+        if (p == last) break;
+        /* Skip lp-count and continue searching for deleted entries in the next loop */
+        p = lpNext(lp, p);
+    }
+    *range_start = NULL;
+    return 0;
 }
 
 /* Stop the stream iterator. The only cleanup we need is to free the rax

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -612,6 +612,24 @@ start_server {
         assert {[lindex $result 1 1 1] eq {value2}}
     }
 
+    test {XDEL trigger listpack garbage collection } {
+        r del somestream
+        for {set j 0} {$j < 25} {incr j} {
+            r xadd somestream * foo1 val1_$j foo2 val2_$j
+            r xadd somestream * foo3 val3_$j foo4 val4_$j
+        }
+        assert {[r xlen somestream] == 50}
+        set beforeDelMemory [r memory usage somestream]
+        set result [r xrange somestream - +]
+        for {set j 0} {$j < 20} {incr j} {
+            set id [lindex $result $j 0]
+            r xdel somestream $id
+        }
+        assert {[r xlen somestream] == 30}
+        set afterDelMemory [r memory usage somestream]
+        assert {$beforeDelMemory > $afterDelMemory}
+    }
+
     test {XDEL multiply id test} {
         r del somestream
         r xadd somestream 1-1 a 1
@@ -798,6 +816,20 @@ start_server {
         }
         assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 1] == 0}
         assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 2] == 2}
+    }
+
+    test {XTRIM trigger listpack garbage collection} {
+        r del mystream
+        for {set j 0} {$j < 25} {incr j} {
+            r XADD mystream * foo1 val1_$j foo2 val2_$j
+            r XADD mystream * foo3 val3_$j foo4 val4_$j
+        }
+        assert {[r XLEN mystream] == 50}
+        set beforeDelMemory [r MEMORY USAGE mystream]
+        assert {[r XTRIM mystream MAXLEN 30] == 20}
+        assert {[r XLEN mystream] == 30}
+        set afterDelMemory [r MEMORY USAGE mystream]
+        assert {$beforeDelMemory > $afterDelMemory}
     }
 }
 


### PR DESCRIPTION
This PR implements two previously marked TODOs by enabling listpack garbage collection when necessary in the `XDEL` and `XTRIM` commands.

