### PR TITLE
Implement listpack garbage collection for XDEL and XTRIM

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1380,6 +1380,64 @@ unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num) {
     return lp;
 }
 
+/**
+ * Delete ranges of items. The ranges are determined by the callback function `getNextRange`.
+ * This callback receives pointers to the listpack and the current item, indicating that the
+ * search for the next range should begin at the given item.
+ * The callback function's output pointer (`unsigned char **`) points to the start of the range,
+ * and the return value indicates the number of items in that range. If there is no more range to
+ * delete, the output pointer is set to NULL and return 0.
+ * We delete the specified ranges and preserve the bytes between these ranges by moving them 
+ * to the end of the preserved region.
+ */
+unsigned char *lpDeleteRanges(unsigned char *lp, unsigned char *p, uint32_t (*getNextRange)(unsigned char *, unsigned char *, unsigned char **, void *), void *arg) {
+    unsigned char *preserved_end, *range_start, *eofptr;
+    size_t bytes = lpBytes(lp), move_size;
+    uint32_t numele = lpGetNumElements(lp), range_ele;
+    lpAssertValidEntry(lp, bytes, p);
+    preserved_end = range_start = NULL;
+    eofptr = lp + bytes - 1;
+    while (p[0] != LP_EOF) {
+        range_ele = getNextRange(lp, p, &range_start, arg);
+        assert(numele >= range_ele);
+        if (range_start == NULL) {
+            /* No more deleted range. */
+            break;
+        }
+        lpAssertValidEntry(lp, bytes, range_start);
+        assert(range_start >= p);
+        if (preserved_end == NULL) {
+            /* This is the first range to delete, so we preserve all bytes before range_start (exclusive)
+             * by setting preserved_end to range_start. */
+            preserved_end = range_start;
+        } else if (range_start > p) {
+            /* Bytes in the range [p, range_start) should be preserved. */
+            move_size = range_start - p;
+            memmove(preserved_end, p, move_size);
+            preserved_end += move_size;
+        }
+        /* Move p to the first byte after the deleted range and continue searching for the next range
+         * to delete in the next loop. */
+        p = range_start;
+        for (uint32_t i = 0; i < range_ele; i++) {
+            p = lpSkip(p);
+            numele--;
+            if (p[0] == LP_EOF) break;
+            lpAssertValidEntry(lp, bytes, p);
+        }
+    }
+    if (preserved_end != NULL) {
+        /* Preserve the bytes after the last deleted range. */
+        move_size = eofptr + 1 - p;
+        memmove(preserved_end, p, move_size);
+        preserved_end += move_size;
+        lpSetTotalBytes(lp, preserved_end - lp);
+        lpSetNumElements(lp, numele);
+        lp = lpShrinkToFit(lp);
+    }
+    return lp;
+}
+
 /* Delete the elements 'ps' passed as an array of 'count' element pointers and
  * return the resulting listpack. The elements must be given in the same order
  * as they apper in the listpack. */
@@ -2056,6 +2114,83 @@ static unsigned char *createIntList(void) {
     return lp;
 }
 
+/* Callback function for lpDeleteRanges(), it can be used to delete ranges in intlist */
+static uint32_t deleteAllPositiveIntegers(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+    (void)arg;
+    long long val;
+    unsigned char *last = lpLast(lp);
+    while (1) {
+        if (lpGetIntegerValue(p, &val)) {
+            if (val >= 0) {
+                *range_start = p;
+                return 1;
+            }
+        }
+        if (p == last) break;
+        p = lpSkip(p);
+    }
+    *range_start = NULL;
+    return 0;
+}
+
+/* Callback functions for lpDeleteRanges(), they can be used to delete ranges in mixlist */
+static uint32_t delete1stTo3rdRange(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+    (void)lp;
+    int *deleted = (int *)arg;
+    /* Only one range to delete in this case. We use 'deleted' to ensure the range is returned only once. */
+    if (*deleted == 0) {
+        *range_start = p;
+        *deleted = 1;
+        return 3;
+    }
+    *range_start = NULL;
+    return 0;
+}
+static uint32_t delete1stAnd3rdItems(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+    int *idx = (int *)arg;
+    while (1) {
+        (*idx)++;
+        if (*idx == 1 || *idx == 3) {
+            *range_start = p;
+            return 1;
+        }
+        if (p == lpLast(lp)) break;
+        p = lpNext(lp, p);
+    }
+    *range_start = NULL;
+    return 0;
+}
+
+static uint32_t delete1stAnd2ndAnd4thItems(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+    int *idx = (int *)arg;
+    while (1) {
+        (*idx)++;
+        if (*idx == 1) {
+            *range_start = p;
+            (*idx)++;
+            return 2;
+        }
+        if (*idx == 4) {
+            *range_start = p;
+            return 1;
+        }
+        if (p == lpLast(lp)) break;
+        p = lpNext(lp, p);
+    }
+    *range_start = NULL;
+    return 0;
+}
+
+static uint32_t deleteAll(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+    (void)arg;
+    if (p == lpFirst(lp)) {
+        *range_start = p;
+        return lpLength(lp);
+    }
+    *range_start = NULL;
+    return 0;
+}
+
 static long long usec(void) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
@@ -2411,6 +2546,97 @@ int listpackTest(int argc, char *argv[], int flags) {
         lp = lpDeleteRangeWithEntry(lp, &ptr, 5);
         assert(lpLength(lp) == 1);
         verifyEntry(lpFirst(lp), (unsigned char*)mixlist[0], strlen(mixlist[0]));
+        zfree(lp);
+    }
+
+    TEST("Delete ranges: all positive integers") {
+        lp = createIntList();
+        lp = lpDeleteRanges(lp, lpFirst(lp), deleteAllPositiveIntegers, NULL);
+        assert(lpLength(lp) == 3);
+        p = lpFirst(lp);
+        long long val;
+        for (int i = 0; i < 3; i++) {
+            if (lpGetIntegerValue(p, &val)) {
+                assert(val < 0);
+            }
+            p = lpSkip(p);
+        }
+        zfree(lp);
+    }
+
+    TEST("Delete ranges: all positive integers (larger data set)") {
+        lp = lpNew(0);
+        int run = 3;
+        while (run--) {
+            for (int i = -500; i < 0; i += 10) {
+                lp = lpAppendInteger(lp, i);
+            }
+            for (int i = 100; i < 300; i += 10) {
+                lp = lpAppendInteger(lp, i);
+            }
+            for (int i = -987654321; i < 0; i += 10000000) {
+                lp = lpAppendInteger(lp, i);
+            }
+            for (int i = 123456789; i < 999999999; i += 10000000) {
+                lp = lpAppendInteger(lp, i);
+            }
+            lp = lpDeleteRanges(lp, lpFirst(lp), deleteAllPositiveIntegers, NULL);
+            p = lpFirst(lp);
+            long long val;
+            int len = (int)lpLength(lp);
+            for (int i = 0; i < len; i++) {
+                if (lpGetIntegerValue(p, &val)) {
+                    assert(val < 0);
+                }
+                p = lpSkip(p);
+            }
+        }
+        zfree(lp);
+    }
+
+    TEST("Delete ranges: 1st to 3rd range(index range[0, 2])") {
+        lp = createList();
+        int deleted = 0;
+        lp = lpDeleteRanges(lp, lpFirst(lp), delete1stTo3rdRange, (void *)&deleted);
+        assert(lpLength(lp) == 1);
+        verifyEntry(lpFirst(lp), (unsigned char *)mixlist[3], strlen(mixlist[3]));
+        zfree(lp);
+    }
+
+    TEST("Delete ranges: 1st and 3rd items(index 0 and 2)") {
+        lp = createList();
+        int idx = 0;
+        lp = lpDeleteRanges(lp, lpFirst(lp), delete1stAnd3rdItems, (void *)&idx);
+        assert(lpLength(lp) == 2);
+        p = lpFirst(lp);
+        verifyEntry(p, (unsigned char *)mixlist[1], strlen(mixlist[1]));
+        p = lpSkip(p);
+        verifyEntry(p, (unsigned char *)mixlist[3], strlen(mixlist[3]));
+        zfree(lp);
+    }
+
+    TEST("Delete ranges: 1st and 2nd and 4th items(index 0 and 1 and 3)") {
+        lp = createList();
+        int idx = 0;
+        lp = lpDeleteRanges(lp, lpFirst(lp), delete1stAnd2ndAnd4thItems, (void *)&idx);
+        assert(lpLength(lp) == 1);
+        p = lpFirst(lp);
+        verifyEntry(p, (unsigned char *)mixlist[2], strlen(mixlist[2]));
+        zfree(lp);
+    }
+
+    TEST("Delete ranges: delete all items and result in empty list") {
+        lp = createList();
+        assert(lpLength(lp) == 4);
+        lp = lpDeleteRanges(lp, lpFirst(lp), deleteAll, NULL);
+        assert(lpLength(lp) == 0);
+
+        for (int i = 1; i <= 10; i++) {
+            lp = lpAppendInteger(lp, i); /* append positive integers */
+        }
+        assert(lpLength(lp) == 10);
+        lp = lpDeleteRanges(lp, lpFirst(lp), deleteAllPositiveIntegers, NULL);
+        assert(lpLength(lp) == 0);
         zfree(lp);
     }
 

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -926,6 +926,10 @@ unsigned char *lpFind(unsigned char *lp, unsigned char *p, unsigned char *s,
  * The element is inserted before, after, or replaces the element pointed
  * by 'p' depending on the 'where' argument, that can be LP_BEFORE, LP_AFTER
  * or LP_REPLACE.
+ *
+ * LP_REPLACE_SAME_LEN functions like LP_REPLACE, but with a stricter constraint:
+ * it only replaces the item if the new item has exactly the same length as the original.
+ * If the lengths differ, the listpack remains unchanged and NULL is returned.
  * 
  * If both 'elestr' and `eleint` are NULL, the function removes the element
  * pointed by 'p' instead of inserting one.
@@ -959,6 +963,12 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char 
      * zero-length element. So whatever we get passed as 'where', set
      * it to LP_REPLACE. */
     if (delete) where = LP_REPLACE;
+
+    int replace_same_len = 0;
+    if (where == LP_REPLACE_SAME_LEN) {
+        where = LP_REPLACE;
+        replace_same_len = 1;
+    }
 
     /* If we need to insert after the current element, we just jump to the
      * next element (that could be the EOF one) and handle the case of
@@ -1004,6 +1014,9 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *elestr, unsigned char 
         replaced_len = lpCurrentEncodedSizeUnsafe(p);
         replaced_len += lpEncodeBacklenBytes(replaced_len);
         ASSERT_INTEGRITY_LEN(lp, p, replaced_len);
+        if (replace_same_len && enclen + backlen_size != replaced_len) {
+            return NULL;
+        }
     }
 
     uint64_t new_listpack_bytes = old_listpack_bytes + enclen + backlen_size
@@ -1305,6 +1318,15 @@ unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long 
     return lpInsertInteger(lp, lval, *p, LP_REPLACE, p);
 }
 
+int lpReplaceIntegerSameLen(unsigned char *lp, unsigned char *p, long long lval) {
+    unsigned char *replaced = lpInsertInteger(lp, lval, p, LP_REPLACE_SAME_LEN, NULL);
+    if (replaced == NULL) {
+        return 0;
+    }
+    assert(replaced == lp);
+    return 1;
+}
+
 /* Remove the element pointed by 'p', and return the resulting listpack.
  * If 'newp' is not NULL, the next element pointer (to the right of the
  * deleted one) is returned by reference. If the deleted element was the
@@ -1389,17 +1411,26 @@ unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num) {
  * delete, the output pointer is set to NULL and return 0.
  * We delete the specified ranges and preserve the bytes between these ranges by moving them 
  * to the end of the preserved region.
+ * The deletion process can be aborted by setting cancel to 1 in the callback, but this is only
+ * valid if no bytes have been moved — i.e., all previously deleted ranges are contiguous and 
+ * form a single large range.
  */
-unsigned char *lpDeleteRanges(unsigned char *lp, unsigned char *p, uint32_t (*getNextRange)(unsigned char *, unsigned char *, unsigned char **, void *), void *arg) {
+unsigned char *lpDeleteRanges(unsigned char *lp, unsigned char *p, uint32_t (*getNextRange)(unsigned char *, unsigned char *, unsigned char **, int *, void *), void *arg) {
     unsigned char *preserved_end, *range_start, *eofptr;
     size_t bytes = lpBytes(lp), move_size;
     uint32_t numele = lpGetNumElements(lp), range_ele;
+    int cancel = 0, has_moved = 0;
     lpAssertValidEntry(lp, bytes, p);
     preserved_end = range_start = NULL;
     eofptr = lp + bytes - 1;
     while (p[0] != LP_EOF) {
-        range_ele = getNextRange(lp, p, &range_start, arg);
+        range_ele = getNextRange(lp, p, &range_start, &cancel, arg);
         assert(numele >= range_ele);
+        if (cancel == 1) {
+            assert(!has_moved);
+            /* Cancel the deletion. */
+            return lp;
+        }
         if (range_start == NULL) {
             /* No more deleted range. */
             break;
@@ -1415,6 +1446,7 @@ unsigned char *lpDeleteRanges(unsigned char *lp, unsigned char *p, uint32_t (*ge
             move_size = range_start - p;
             memmove(preserved_end, p, move_size);
             preserved_end += move_size;
+            has_moved = 1;
         }
         /* Move p to the first byte after the deleted range and continue searching for the next range
          * to delete in the next loop. */
@@ -2115,7 +2147,8 @@ static unsigned char *createIntList(void) {
 }
 
 /* Callback function for lpDeleteRanges(), it can be used to delete ranges in intlist */
-static uint32_t deleteAllPositiveIntegers(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+static uint32_t deleteAllPositiveIntegers(unsigned char *lp, unsigned char *p, unsigned char **range_start, int *cancel, void *arg) {
+    (void)cancel;
     (void)arg;
     long long val;
     unsigned char *last = lpLast(lp);
@@ -2134,7 +2167,8 @@ static uint32_t deleteAllPositiveIntegers(unsigned char *lp, unsigned char *p, u
 }
 
 /* Callback functions for lpDeleteRanges(), they can be used to delete ranges in mixlist */
-static uint32_t delete1stTo3rdRange(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+static uint32_t delete1stTo3rdRange(unsigned char *lp, unsigned char *p, unsigned char **range_start, int *cancel, void *arg) {
+    (void)cancel;
     (void)lp;
     int *deleted = (int *)arg;
     /* Only one range to delete in this case. We use 'deleted' to ensure the range is returned only once. */
@@ -2146,7 +2180,8 @@ static uint32_t delete1stTo3rdRange(unsigned char *lp, unsigned char *p, unsigne
     *range_start = NULL;
     return 0;
 }
-static uint32_t delete1stAnd3rdItems(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+static uint32_t delete1stAnd3rdItems(unsigned char *lp, unsigned char *p, unsigned char **range_start, int *cancel, void *arg) {
+    (void)cancel;
     int *idx = (int *)arg;
     while (1) {
         (*idx)++;
@@ -2161,7 +2196,8 @@ static uint32_t delete1stAnd3rdItems(unsigned char *lp, unsigned char *p, unsign
     return 0;
 }
 
-static uint32_t delete1stAnd2ndAnd4thItems(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+static uint32_t delete1stAnd2ndAnd4thItems(unsigned char *lp, unsigned char *p, unsigned char **range_start, int *cancel, void *arg) {
+    (void)cancel;
     int *idx = (int *)arg;
     while (1) {
         (*idx)++;
@@ -2181,7 +2217,8 @@ static uint32_t delete1stAnd2ndAnd4thItems(unsigned char *lp, unsigned char *p, 
     return 0;
 }
 
-static uint32_t deleteAll(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+static uint32_t deleteAll(unsigned char *lp, unsigned char *p, unsigned char **range_start, int *cancel, void *arg) {
+    (void)cancel;
     (void)arg;
     if (p == lpFirst(lp)) {
         *range_start = p;
@@ -2189,6 +2226,21 @@ static uint32_t deleteAll(unsigned char *lp, unsigned char *p, unsigned char **r
     }
     *range_start = NULL;
     return 0;
+}
+
+static uint32_t cancelDeletion(unsigned char *lp, unsigned char *p, unsigned char **range_start, int *cancel, void *arg) {
+     (void)lp;
+    int *idx = (int *)arg;
+    if (*idx < 3) {
+        *range_start = p;
+        (*idx)++;
+        return 1;
+    }
+    /* Cancel the deletion of previous ranges*/
+    *cancel = 1;
+    *range_start = NULL;
+    return 0;
+
 }
 
 static long long usec(void) {
@@ -2640,6 +2692,14 @@ int listpackTest(int argc, char *argv[], int flags) {
         zfree(lp);
     }
 
+    TEST("Delete ranges: cancel deletion") {
+        lp = createList();
+        assert(lpLength(lp) == 4);
+        int idx = 0;
+        assert(lp == lpDeleteRanges(lp, lpFirst(lp), cancelDeletion, (void *)&idx));
+        assert(lpLength(lp) == 4);
+    }
+
     TEST("Batch append") {
         listpackEntry ent[6] = {
                 {.sval = (unsigned char*)mixlist[0], .slen = strlen(mixlist[0])},
@@ -2802,6 +2862,19 @@ int listpackTest(int argc, char *argv[], int flags) {
                         "\xc4\x00\x02" "\xff",
                         27));
         lpFree(lp);
+    }
+
+    TEST("Replace by lpReplaceIntegerSameLen") {
+        lp = createIntList(); /* 4294967296, -100, ... */
+        p = lpFirst(lp);
+        long long x = 4294967295, lval;
+        assert(lpReplaceIntegerSameLen(lp, p, x)); /* successfully replace */
+        lpGetIntegerValue(p, &lval);
+        assert(lval == x);
+        p = lpNext(lp, p);
+        assert(!lpReplaceIntegerSameLen(lp, p, x)); /* fail to replace */
+        lpGetIntegerValue(p, &lval);
+        assert(lval == -100);
     }
 
     TEST("Regression test for >255 byte strings") {

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -50,6 +50,7 @@ unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long 
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp);
 unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsigned long num);
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num);
+unsigned char *lpDeleteRanges(unsigned char *lp, unsigned char *p, uint32_t (*getNextRange)(unsigned char *, unsigned char *, unsigned char **, void *), void *arg);
 unsigned char *lpBatchAppend(unsigned char *lp, listpackEntry *entries, unsigned long len);
 unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
                              listpackEntry *entries, unsigned int len, unsigned char **newp);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -23,6 +23,7 @@
 #define LP_BEFORE 0
 #define LP_AFTER 1
 #define LP_REPLACE 2
+#define LP_REPLACE_SAME_LEN 4
 
 /* Each entry in the listpack is either a string or an integer. */
 typedef struct {
@@ -47,10 +48,11 @@ unsigned char *lpAppend(unsigned char *lp, unsigned char *s, uint32_t slen);
 unsigned char *lpAppendInteger(unsigned char *lp, long long lval);
 unsigned char *lpReplace(unsigned char *lp, unsigned char **p, unsigned char *s, uint32_t slen);
 unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long lval);
+int lpReplaceIntegerSameLen(unsigned char *lp, unsigned char *p, long long lval);
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp);
 unsigned char *lpDeleteRangeWithEntry(unsigned char *lp, unsigned char **p, unsigned long num);
 unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num);
-unsigned char *lpDeleteRanges(unsigned char *lp, unsigned char *p, uint32_t (*getNextRange)(unsigned char *, unsigned char *, unsigned char **, void *), void *arg);
+unsigned char *lpDeleteRanges(unsigned char *lp, unsigned char *p, uint32_t (*getNextRange)(unsigned char *, unsigned char *, unsigned char **, int *, void *), void *arg);
 unsigned char *lpBatchAppend(unsigned char *lp, listpackEntry *entries, unsigned long len);
 unsigned char *lpBatchInsert(unsigned char *lp, unsigned char *p, int where,
                              listpackEntry *entries, unsigned int len, unsigned char **newp);

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -38,6 +38,7 @@ void streamFreeNACK(streamNACK *na);
 size_t streamReplyWithRangeFromConsumerPEL(client *c, stream *s, streamID *start, streamID *end, size_t count, streamConsumer *consumer);
 int streamParseStrictIDOrReply(client *c, robj *o, streamID *id, uint64_t missing_seq, int *seq_given);
 int streamParseIDOrReply(client *c, robj *o, streamID *id, uint64_t missing_seq);
+static uint32_t listpackGetNextDeletedRange(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg);
 
 /* -----------------------------------------------------------------------
  * Low level stream encoding: a radix tree of listpacks.
@@ -829,15 +830,30 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         lp = lpReplaceInteger(lp,&p,entries-deleted_from_lp);
         p = lpNext(lp,p); /* Skip deleted field. */
         int64_t marked_deleted = lpGetInteger(p);
-        lp = lpReplaceInteger(lp,&p,marked_deleted+deleted_from_lp);
-        p = lpNext(lp,p); /* Skip num-of-fields in the master entry. */
 
         /* Here we should perform garbage collection in case at this point
          * there are too many entries deleted inside the listpack. */
         entries -= deleted_from_lp;
         marked_deleted += deleted_from_lp;
+        
+        int needGarbageCollection = 0;
         if (entries + marked_deleted > 10 && marked_deleted > entries/2) {
-            /* TODO: perform a garbage collection. */
+            needGarbageCollection = 1;
+            lp = lpReplaceInteger(lp, &p, 0);
+        } else {
+            lp = lpReplaceInteger(lp,&p,marked_deleted);
+        }
+        p = lpNext(lp,p); /* Skip num-of-fields in the master entry. */
+
+        if (needGarbageCollection) {
+            /* Perform a garbage collection. */
+            int64_t aux = lpGetInteger(p);
+            serverAssert(aux >= 0 && aux <= (int64_t)UINT32_MAX);
+            uint32_t master_fields = (uint32_t)aux;
+            for (uint32_t i = 0; i < 2 + master_fields; i++) {
+                p = lpNext(lp, p);
+            }
+            lp = lpDeleteRanges(lp, p, listpackGetNextDeletedRange, (void *)&master_fields);
         }
 
         /* Update the listpack with the new pointer. */
@@ -1258,7 +1274,7 @@ void streamIteratorGetField(streamIterator *si, unsigned char **fieldptr, unsign
  * with GetID(). */
 void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     unsigned char *lp = si->lp;
-    int64_t aux;
+    int64_t numele, deleted, num_fields;
 
     /* We do not really delete the entry here. Instead we mark it as
      * deleted by flagging it, and also incrementing the count of the
@@ -1271,19 +1287,35 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
 
     /* Change the valid/deleted entries count in the master entry. */
     unsigned char *p = lpFirst(lp);
-    aux = lpGetInteger(p);
+    numele = lpGetInteger(p);
 
-    if (aux == 1) {
+    if (numele == 1) {
         /* If this is the last element in the listpack, we can remove the whole
          * node. */
         lpFree(lp);
         raxRemove(si->stream->rax,si->ri.key,si->ri.key_len,NULL);
     } else {
         /* In the base case we alter the counters of valid/deleted entries. */
-        lp = lpReplaceInteger(lp,&p,aux-1);
+        numele--;
+        lp = lpReplaceInteger(lp,&p,numele);
         p = lpNext(lp,p); /* Seek deleted field. */
-        aux = lpGetInteger(p);
-        lp = lpReplaceInteger(lp,&p,aux+1);
+        deleted = lpGetInteger(p) + 1;
+        if (numele + deleted <= 10 || deleted <= numele / 2) {
+            lp = lpReplaceInteger(lp,&p,deleted);
+        } else {
+            /* Perform garbage collection when total entries > 10 and deleted entries > valid entries / 2 */
+            lp = lpReplaceInteger(lp,&p,0);
+            p = lpNext(lp, p);
+            num_fields = lpGetInteger(p);
+            serverAssert(num_fields >= 0 && num_fields <= (int64_t)UINT32_MAX);
+            uint32_t master_fields = (uint32_t)num_fields;
+            /* Skip num-fields, master fields and ending zero */
+            for (int64_t i = 0; i < num_fields + 2; i++) {
+                p = lpNext(lp, p);
+            }
+            /* Delete all the entries marked as deleted */
+            lp = lpDeleteRanges(lp, p, listpackGetNextDeletedRange, (void *)&master_fields);
+        }
 
         /* Update the listpack with the new pointer. */
         if (si->lp != lp)
@@ -1304,9 +1336,56 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     }
     streamIteratorStop(si);
     streamIteratorStart(si,si->stream,&start,&end,si->rev);
+}
 
-    /* TODO: perform a garbage collection here if the ratio between
-     * deleted and valid goes over a certain limit. */
+/**
+ * Callback function for lpDeleteRanges.
+ *
+ * @param p Pointer to the start of an entry.
+ * @param range_start Output pointer set to the start of the deleted entry (range).
+ * @return The number of items that make up the deleted entry.
+ *
+ * This function searches for the next deleted entry, which is treated as a range of items
+ * to delete from the listpack.
+ */
+static uint32_t listpackGetNextDeletedRange(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+    int64_t flags, num_fields;
+    uint32_t master_fields = *((uint32_t *)arg);
+    uint32_t fields_values_num; /* Number of listpack items that together represent the fields and values of an entry */
+    unsigned char *last = lpLast(lp);
+    while (1) {
+        flags = lpGetInteger(p);
+        if (flags & STREAM_ITEM_FLAG_DELETED) {
+            *range_start = p;
+            if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) {
+                /* 3 heading items(flags + entry-id-ms + entry-id-seq) + values + lp-count */
+                return 3 + master_fields + 1;
+            }
+        }
+        p = lpNext(lp, p); /* p points to entry-id ms */
+        p = lpNext(lp, p); /* p points to entry-id seq */
+        if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) {
+            fields_values_num = master_fields;
+        } else {
+            p = lpNext(lp, p); /* p points to num-fields */
+            num_fields = lpGetInteger(p);
+            serverAssert(num_fields >= 0 && num_fields * 2 <= (int64_t)UINT32_MAX);
+            fields_values_num = (uint32_t)num_fields * 2;
+        }
+        if (flags & STREAM_ITEM_FLAG_DELETED) {
+            /* 3 heading items(flags + entry-id-ms + entry-id-seq) + num-fields + field and value pairs + lp-count */
+            return 3 + 1 + fields_values_num + 1;
+        }
+        p = lpNext(lp, p); /* p points to the first field(value) */
+        while (fields_values_num--) {
+            p = lpNext(lp, p);
+        }
+        if (p == last) break;
+        /* Skip lp-count and continue searching for deleted entries in the next loop */
+        p = lpNext(lp, p);
+    }
+    *range_start = NULL;
+    return 0;
 }
 
 /* Stop the stream iterator. The only cleanup we need is to free the rax

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -38,7 +38,8 @@ void streamFreeNACK(streamNACK *na);
 size_t streamReplyWithRangeFromConsumerPEL(client *c, stream *s, streamID *start, streamID *end, size_t count, streamConsumer *consumer);
 int streamParseStrictIDOrReply(client *c, robj *o, streamID *id, uint64_t missing_seq, int *seq_given);
 int streamParseIDOrReply(client *c, robj *o, streamID *id, uint64_t missing_seq);
-static uint32_t listpackGetNextDeletedRange(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg);
+static uint32_t listpackGetNextDeletedRange(unsigned char *lp, unsigned char *p, unsigned char **range_start, int *cancel, void *arg);
+static uint32_t listpackGetNextDeletedRangeInXTrim(unsigned char *lp, unsigned char *p, unsigned char **range_start, int *cancel, void *arg);
 
 /* -----------------------------------------------------------------------
  * Low level stream encoding: a radix tree of listpacks.
@@ -676,6 +677,19 @@ typedef struct {
 #define TRIM_STRATEGY_MAXLEN 1
 #define TRIM_STRATEGY_MINID 2
 
+/* Used in callback for lpDeleteRanges() */
+struct trimContext {
+    int perform_garbage_collection;
+    int processed_all_trimmed_entries;
+    uint32_t master_fields;
+    stream *s;
+    streamID *id;
+    streamID *master_id;
+    size_t maxlen;
+    int trim_strategy;
+    uint32_t num_entries, num_deleted, num_deleted_by_trim;
+};
+
 /* Trim the stream 's' according to args->trim_strategy, and return the
  * number of elements removed from the stream. The 'approx' option, if non-zero,
  * specifies that the trimming must be performed in a approximated way in
@@ -755,14 +769,17 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
          * stop here. */
         if (approx) break;
 
-        /* Now we have to trim entries from within 'lp' */
-        int64_t deleted_from_lp = 0;
-
+        /* Now we have to trim entries from within 'lp'. */
         p = lpNext(lp, p); /* Skip deleted field. */
+        
+        /* 'lp' might has entries marked as deleted, we need to count them. */
+        int64_t num_deleted = lpGetInteger(p);
+
         p = lpNext(lp, p); /* Skip num-of-fields in the master entry. */
 
         /* Skip all the master fields. */
         int64_t master_fields_count = lpGetInteger(p);
+        serverAssert(master_fields_count >= 0 && master_fields_count < (int64_t)UINT32_MAX);
         p = lpNext(lp,p); /* Skip the first field. */
         for (int64_t j = 0; j < master_fields_count; j++)
             p = lpNext(lp,p); /* Skip all master fields. */
@@ -770,93 +787,35 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
 
         /* 'p' is now pointing to the first entry inside the listpack.
          * We have to run entry after entry, marking entries as deleted
-         * if they are already not deleted. */
-        while (p) {
-            /* We keep a copy of p (which point to flags part) in order to
-             * update it after (and if) we actually remove the entry */
-            unsigned char *pcopy = p;
-
-            int64_t flags = lpGetInteger(p);
-            p = lpNext(lp, p); /* Skip flags. */
-            int64_t to_skip;
-
-            int64_t ms_delta = lpGetInteger(p);
-            p = lpNext(lp, p); /* Skip ID ms delta */
-            int64_t seq_delta = lpGetInteger(p);
-            p = lpNext(lp, p); /* Skip ID seq delta */
-
-            streamID currid = {0}; /* For MINID */
-            if (trim_strategy == TRIM_STRATEGY_MINID) {
-                currid.ms = master_id.ms + ms_delta;
-                currid.seq = master_id.seq + seq_delta;
-            }
-
-            int stop;
-            if (trim_strategy == TRIM_STRATEGY_MAXLEN) {
-                stop = s->length <= maxlen;
-            } else {
-                /* Following IDs will definitely be greater because the rax
-                 * tree is sorted, no point of continuing. */
-                stop = streamCompareID(&currid, id) >= 0;
-            }
-            if (stop)
-                break;
-
-            if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) {
-                to_skip = master_fields_count;
-            } else {
-                to_skip = lpGetInteger(p); /* Get num-fields. */
-                p = lpNext(lp,p); /* Skip num-fields. */
-                to_skip *= 2; /* Fields and values. */
-            }
-
-            while(to_skip--) p = lpNext(lp,p); /* Skip the whole entry. */
-            p = lpNext(lp,p); /* Skip the final lp-count field. */
-
-            /* Mark the entry as deleted. */
-            if (!(flags & STREAM_ITEM_FLAG_DELETED)) {
-                intptr_t delta = p - lp;
-                flags |= STREAM_ITEM_FLAG_DELETED;
-                lp = lpReplaceInteger(lp, &pcopy, flags);
-                deleted_from_lp++;
-                s->length--;
-                p = lp + delta;
-            }
-        }
-        deleted += deleted_from_lp;
-
+         * if they are already not deleted and perform a garbage collection
+         * if necessary. */
+        struct trimContext context = {
+            .perform_garbage_collection = 0,
+            .processed_all_trimmed_entries = 0,
+            .master_fields = (uint32_t)master_fields_count,
+            .s = s,
+            .id = id,
+            .master_id = &master_id,
+            .maxlen = maxlen,
+            .trim_strategy = trim_strategy,
+            .num_entries = entries,
+            .num_deleted = num_deleted,
+            .num_deleted_by_trim = 0
+        };
+        lp = lpDeleteRanges(lp, p, listpackGetNextDeletedRangeInXTrim, (void *)&context);
+        deleted += context.num_deleted_by_trim;
+        
         /* Now we update the entries/deleted counters. */
         p = lpFirst(lp);
-        lp = lpReplaceInteger(lp,&p,entries-deleted_from_lp);
+        lp = lpReplaceInteger(lp, &p, context.num_entries);
         p = lpNext(lp,p); /* Skip deleted field. */
-        int64_t marked_deleted = lpGetInteger(p);
-
-        /* Here we should perform garbage collection in case at this point
-         * there are too many entries deleted inside the listpack. */
-        entries -= deleted_from_lp;
-        marked_deleted += deleted_from_lp;
         
-        int needGarbageCollection = 0;
-        if (entries + marked_deleted > 10 && marked_deleted > entries/2) {
-            needGarbageCollection = 1;
+        if (context.perform_garbage_collection) {
             lp = lpReplaceInteger(lp, &p, 0);
         } else {
-            lp = lpReplaceInteger(lp,&p,marked_deleted);
-        }
-        p = lpNext(lp,p); /* Skip num-of-fields in the master entry. */
-
-        if (needGarbageCollection) {
-            /* Perform a garbage collection. */
-            int64_t aux = lpGetInteger(p);
-            serverAssert(aux >= 0 && aux <= (int64_t)UINT32_MAX);
-            uint32_t master_fields = (uint32_t)aux;
-            for (uint32_t i = 0; i < 2 + master_fields; i++) {
-                p = lpNext(lp, p);
-            }
-            lp = lpDeleteRanges(lp, p, listpackGetNextDeletedRange, (void *)&master_fields);
+            lp = lpReplaceInteger(lp, &p, context.num_deleted);
         }
 
-        /* Update the listpack with the new pointer. */
         raxInsert(s->rax,ri.key,ri.key_len,lp,NULL);
 
         break; /* If we are here, there was enough to delete in the current
@@ -1348,7 +1307,8 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
  * This function searches for the next deleted entry, which is treated as a range of items
  * to delete from the listpack.
  */
-static uint32_t listpackGetNextDeletedRange(unsigned char *lp, unsigned char *p, unsigned char **range_start, void *arg) {
+static uint32_t listpackGetNextDeletedRange(unsigned char *lp, unsigned char *p, unsigned char **range_start, int *cancel, void *arg) {
+    (void)cancel;
     int64_t flags, num_fields;
     uint32_t master_fields = *((uint32_t *)arg);
     uint32_t fields_values_num; /* Number of listpack items that together represent the fields and values of an entry */
@@ -1386,6 +1346,89 @@ static uint32_t listpackGetNextDeletedRange(unsigned char *lp, unsigned char *p,
     }
     *range_start = NULL;
     return 0;
+}
+
+/*
+ * This callback is used in xtrim to handle deletion of listpack items that correspond
+ * to entries needing trimming, or that were previously marked as STREAM_ITEM_FLAG_DELETED
+ * if garbage collection is required. If garbage collection is not needed, the deletion is
+ * canceled, but all trimmed entries are still marked as STREAM_ITEM_FLAG_DELETED.
+
+ * Marking entries with STREAM_ITEM_FLAG_DELETED does not change the encoding of the flag
+ * integer, ensuring the listpack is not reallocated and remains safe. However, if the
+ * encoding were to change in the future (e.g., due to modifications in the flag format),
+ * the flag is left unchanged and garbage collection is performed instead as a fallback.
+ */
+static uint32_t listpackGetNextDeletedRangeInXTrim(unsigned char *lp, unsigned char *p, unsigned char **range_start, int *cancel, void *arg) {
+    struct trimContext *context = (struct trimContext *)arg;
+    if (context->processed_all_trimmed_entries) {
+        return listpackGetNextDeletedRange(lp, p, range_start, cancel, &(context->master_fields));
+    }
+    unsigned char *pcopy = p;
+
+    int64_t flags = lpGetInteger(p);
+    p = lpNext(lp, p); /* Skip flags. */
+    uint32_t fields_values_num; /* Number of listpack items that together represent the fields and values of an entry */
+
+    int64_t ms_delta = lpGetInteger(p);
+    p = lpNext(lp, p); /* Skip ID ms delta */
+    int64_t seq_delta = lpGetInteger(p);
+    p = lpNext(lp, p); /* Skip ID seq delta */
+
+    streamID currid = {0}; /* For MINID */
+    if (context->trim_strategy == TRIM_STRATEGY_MINID) {
+        currid.ms = context->master_id->ms + ms_delta;
+        currid.seq = context->master_id->seq + seq_delta;
+    }
+
+    int stop;
+    if (context->trim_strategy == TRIM_STRATEGY_MAXLEN) {
+        stop = context->s->length <= context->maxlen;
+    } else {
+        /* Following IDs will definitely be greater because the rax
+         * tree is sorted, no point of continuing. */
+        stop = streamCompareID(&currid, context->id) >= 0;
+    }
+    if (!stop) {
+        /* The current entry needs to be trimmed; therefore, the range
+         * of listpack items constituting this entry is returned.*/
+        if (!(flags & STREAM_ITEM_FLAG_DELETED)) {
+            flags |= STREAM_ITEM_FLAG_DELETED;
+            /* We update the flag since it's still unclear whether garbage collection is needed. */
+            if (unlikely(!lpReplaceIntegerSameLen(lp, pcopy, flags))) {
+                /* We do not want lp change to another pointer, perform a garbage collection. */
+                context->perform_garbage_collection = 1;
+            }
+            context->num_deleted_by_trim++;
+            context->s->length--;
+        }
+        *range_start = pcopy;
+        if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) {
+           /* 3 heading items(flags + entry-id-ms + entry-id-seq) + values + lp-count */ 
+            return 3 + context->master_fields + 1;
+        } else {
+            int64_t num_fields = lpGetInteger(p); /* Get num-fields. */
+            serverAssert(num_fields >= 0 && num_fields * 2 <= (int64_t)UINT32_MAX);
+            fields_values_num = (uint32_t)num_fields * 2;
+            /* 3 heading items(flags + entry-id-ms + entry-id-seq) + num-fields + field and value pairs + lp-count */
+            return 3 + 1 + fields_values_num + 1;
+        }
+    }
+    /* We have reached the first untrimmed entry.
+     * If GC is needed, the following ranges can be searched via listpackGetNextDeletedRange;
+     * otherwise, return -1 to cancel deletion.
+     * (Safe to do: trimmed entries are contiguous at the beginning, and no bytes have been moved.) */
+    context->num_deleted += context->num_deleted_by_trim;
+    context->num_entries -= context->num_deleted_by_trim;
+    if (context->perform_garbage_collection
+            || (context->num_entries + context->num_deleted > 10 && context->num_deleted > context->num_entries/2)) {
+        context->perform_garbage_collection = 1;
+        context->processed_all_trimmed_entries = 1;
+        return listpackGetNextDeletedRange(lp, pcopy, range_start, cancel, &(context->master_fields));
+    } else {
+        *cancel = 1;
+        return 0;
+    }
 }
 
 /* Stop the stream iterator. The only cleanup we need is to free the rax

--- a/tests/unit/type/stream.tcl
+++ b/tests/unit/type/stream.tcl
@@ -612,6 +612,24 @@ start_server {
         assert {[lindex $result 1 1 1] eq {value2}}
     }
 
+    test {XDEL trigger listpack garbage collection } {
+        r del somestream
+        for {set j 0} {$j < 25} {incr j} {
+            r xadd somestream * foo1 val1_$j foo2 val2_$j
+            r xadd somestream * foo3 val3_$j foo4 val4_$j
+        }
+        assert {[r xlen somestream] == 50}
+        set beforeDelMemory [r memory usage somestream]
+        set result [r xrange somestream - +]
+        for {set j 0} {$j < 20} {incr j} {
+            set id [lindex $result $j 0]
+            r xdel somestream $id
+        }
+        assert {[r xlen somestream] == 30}
+        set afterDelMemory [r memory usage somestream]
+        assert {$beforeDelMemory > $afterDelMemory}
+    }
+
     test {XDEL multiply id test} {
         r del somestream
         r xadd somestream 1-1 a 1
@@ -798,6 +816,20 @@ start_server {
         }
         assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 1] == 0}
         assert {[r XTRIM mystream MAXLEN ~ 0 LIMIT 2] == 2}
+    }
+
+    test {XTRIM trigger listpack garbage collection} {
+        r del mystream
+        for {set j 0} {$j < 25} {incr j} {
+            r XADD mystream * foo1 val1_$j foo2 val2_$j
+            r XADD mystream * foo3 val3_$j foo4 val4_$j
+        }
+        assert {[r XLEN mystream] == 50}
+        set beforeDelMemory [r MEMORY USAGE mystream]
+        assert {[r XTRIM mystream MAXLEN 30] == 20}
+        assert {[r XLEN mystream] == 30}
+        set afterDelMemory [r MEMORY USAGE mystream]
+        assert {$beforeDelMemory > $afterDelMemory}
     }
 }
 


### PR DESCRIPTION
This PR implements two previously marked TODOs by enabling listpack garbage collection in the `XDEL` and `XTRIM` commands  when necessary.

The algorithm is straightforward: it removes all the items corresponding to deleted entries from the listpack.   However, using `lpDeleteRange` involves repeated `memmove` operations on same listpack memory regions.   On the other hand, `lpBatchDelete` requires an array to store pointers to all items in the deleted ranges, which can be inefficient in terms of memory usage.

To address these, this PR introduces a new function, `lpDeleteRanges`, which leverages a callback function to determine the ranges to delete.  This callback receives a pointer to a specific item and starts searching from that item to find the next range to delete. Once a range is identified, the callback is invoked again with the item immediately following the deleted range, and we get the next deleted range. This process continues, allowing us to traverse the entire listpack and collect all the ranges that need to be deleted.   The approach avoids redundant memory operations by only moving the bytes between deleted ranges (and the bytes after the final deleted range) and avoids the allocation of memory to store the pointers.

From a memory optimization perspective, when there are no valid entries marked with `SAMEFIELDS`, the master fields become redundant and could, in theory, be replaced with another set of entry fields.   However, implementing this would significantly increase both time and code complexity, so it is intentionally left out of this PR.