### PR TITLE
Input output traffic stats and command process count for each client.

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -3,9 +3,14 @@
  * Copyright (c) 2009-Present, Redis Ltd.
  * All rights reserved.
  *
+ * Copyright (c) 2024-present, Valkey contributors.
+ * All rights reserved.
+ *
  * Licensed under your choice of (a) the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).
+ *
+ * Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
  *
  * ---------------------------------------------------------------------------
  *
@@ -88,6 +93,7 @@ void updateStatsOnUnblock(client *c, long blocked_us, long reply_us, int had_err
     const ustime_t total_cmd_duration = c->duration + blocked_us + reply_us;
     c->lastcmd->microseconds += total_cmd_duration;
     c->lastcmd->calls++;
+    c->commands_processed++;
     server.stat_numcommands++;
     if (had_errors)
         c->lastcmd->failed_calls++;

--- a/src/server.c
+++ b/src/server.c
@@ -3819,8 +3819,14 @@ void call(client *c, int flags) {
         }
     }
 
-    if (!(c->flags & CLIENT_BLOCKED))
+    if (!(c->flags & CLIENT_BLOCKED)) {
+        /* Modules may call commands in cron, in which case server.current_client
+         * is not set. */
+        if (server.current_client) {
+            server.current_client->commands_processed++;
+        }
         server.stat_numcommands++;
+    }
 
     /* Record peak memory after each command and before the eviction that runs
      * before the next command. */

--- a/src/server.h
+++ b/src/server.h
@@ -1413,6 +1413,9 @@ typedef struct client {
 #ifdef LOG_REQ_RES
     clientReqResInfo reqres;
 #endif
+    unsigned long long net_input_bytes;    /* Total network input bytes read from this client. */
+    unsigned long long net_output_bytes;   /* Total network output bytes sent to this client. */
+    unsigned long long commands_processed; /* Total count of commands this client executed. */
 } client;
 
 typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1,3 +1,16 @@
+#
+# Copyright (c) 2009-Present, Redis Ltd.
+# All rights reserved.
+#
+# Copyright (c) 2024-present, Valkey contributors.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2) or the Server Side Public License v1 (SSPLv1).
+#
+# Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
+#
+
 start_server {tags {"introspection"}} {
     test "PING" {
         assert_equal {PONG} [r ping]
@@ -8,9 +21,9 @@ start_server {tags {"introspection"}} {
     test {CLIENT LIST} {
         set client_list [r client list]
         if {[lindex [r config get io-threads] 1] == 1} {
-            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=*} $client_list
+            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=*} $client_list
         } else {
-            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=*} $client_list
+            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=*} $client_list
         }
     }
 
@@ -23,11 +36,80 @@ start_server {tags {"introspection"}} {
     test {CLIENT INFO} {
         set client [r client info]
         if {[lindex [r config get io-threads] 1] == 1} {
-            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=*} $client
+            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=*} $client
         } else {
-            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=*} $client
+            assert_match {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* io-thread=* tot-net-in=* tot-net-out=* tot-cmds=*} $client
         }
     } 
+
+    proc get_field_in_client_info {info field} {
+        set info [string trim $info]
+        foreach item [split $info " "] {
+            set kv [split $item "="]
+            set k [lindex $kv 0]
+            if {[string match $field $k]} {
+                return [lindex $kv 1]   
+            }
+        }
+        return ""
+    }
+
+    proc get_field_in_client_list {id client_list filed} {
+        set list [split $client_list "\r\n"]
+        foreach info $list {
+            if {[string match "id=$id *" $info] } {
+                return [get_field_in_client_info $info $filed]
+            }
+        }
+        return ""
+    }
+
+    test {client input output and command process statistics} {
+        set info1 [r client info]
+        set input1 [get_field_in_client_info $info1 "tot-net-in"]
+        set output1 [get_field_in_client_info $info1 "tot-net-out"]
+        set cmd1 [get_field_in_client_info $info1 "tot-cmds"]
+        set info2 [r client info]
+        set input2 [get_field_in_client_info $info2 "tot-net-in"]
+        set output2 [get_field_in_client_info $info2 "tot-net-out"]
+        set cmd2 [get_field_in_client_info $info2 "tot-cmds"]
+        assert_equal [expr $input1+26] $input2
+        assert {[expr $output1+300] < $output2}
+        assert_equal [expr $cmd1+1] $cmd2
+        # test blocking command
+        r del mylist
+        set rd [redis_deferring_client]
+        $rd client id
+        set rd_id [$rd read]
+        set info_list [r client list]
+        set input3 [get_field_in_client_list $rd_id $info_list "tot-net-in"]
+        set output3 [get_field_in_client_list $rd_id $info_list "tot-net-out"]
+        set cmd3 [get_field_in_client_list $rd_id $info_list "tot-cmds"]
+        $rd blpop mylist 0
+        set info_list [r client list]
+        set input4 [get_field_in_client_list $rd_id $info_list "tot-net-in"]
+        set output4 [get_field_in_client_list $rd_id $info_list "tot-net-out"]
+        set cmd4 [get_field_in_client_list $rd_id $info_list "tot-cmds"]
+        assert_equal [expr $input3+34] $input4
+        assert_equal $output3 $output4
+        assert_equal $cmd3 $cmd4
+        r lpush mylist a
+        set info_list [r client list]
+        set input5 [get_field_in_client_list $rd_id $info_list "tot-net-in"]
+        set output5 [get_field_in_client_list $rd_id $info_list "tot-net-out"]
+        set cmd5 [get_field_in_client_list $rd_id $info_list "tot-cmds"]
+        assert_equal $input4 $input5
+        assert_equal [expr $output4+23] $output5
+        assert_equal [expr $cmd4+1] $cmd5
+        $rd close
+        # test recursive command
+        set info [r client info]
+        set cmd6 [get_field_in_client_info $info "tot-cmds"]
+        r eval "redis.call('ping')" 0
+        set info [r client info]
+        set cmd7 [get_field_in_client_info $info "tot-cmds"]
+        assert_equal [expr $cmd6+3] $cmd7
+    }
 
     test {CLIENT KILL with illegal arguments} {
         assert_error "ERR wrong number of arguments for 'client|kill' command" {r client kill}

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -99,7 +99,7 @@ start_server {tags {"introspection"}} {
         $rd blpop mylist 0
 
         # Make sure to wait for the $rd client to be blocked
-        #wait_for_blocked_client
+        wait_for_blocked_client
 
         # Check if input stats have changed for $rd. Since command is blocking
         # and has not been unblocked yet we expect no change in output/cmds-processed

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -64,51 +64,81 @@ start_server {tags {"introspection"}} {
         return ""
     }
 
-    test {client input output and command process statistics} {
+    test {CLIENT INFO input/output/cmds-processed stats} {
         set info1 [r client info]
         set input1 [get_field_in_client_info $info1 "tot-net-in"]
         set output1 [get_field_in_client_info $info1 "tot-net-out"]
         set cmd1 [get_field_in_client_info $info1 "tot-cmds"]
+
+        # Run a command by that client and test if the stats change correctly
         set info2 [r client info]
         set input2 [get_field_in_client_info $info2 "tot-net-in"]
         set output2 [get_field_in_client_info $info2 "tot-net-out"]
         set cmd2 [get_field_in_client_info $info2 "tot-cmds"]
-        assert_equal [expr $input1+26] $input2
-        assert {[expr $output1+300] < $output2}
-        assert_equal [expr $cmd1+1] $cmd2
-        # test blocking command
+
+        # NOTE if CLIENT INFO changes it's stats the output_bytes here and in the
+        # other related tests will need to be updated.
+        set input_bytes 26 ; # CLIENT INFO request
+        set output_bytes 361 ; # CLIENT INFO result
+        set cmds_processed 1 ; # processed the command CLIENT INFO
+        assert_equal [expr $input1+$input_bytes] $input2
+        assert_equal [expr $output1+$output_bytes] $output2
+        assert_equal [expr $cmd1+$cmds_processed] $cmd2
+    }
+
+    test {CLIENT INFO input/output/cmds-processed stats for blocking command} {
         r del mylist
         set rd [redis_deferring_client]
         $rd client id
         set rd_id [$rd read]
+ 
+        set info_list [r client list]
+        set input1 [get_field_in_client_list $rd_id $info_list "tot-net-in"]
+        set output1 [get_field_in_client_list $rd_id $info_list "tot-net-out"]
+        set cmd1 [get_field_in_client_list $rd_id $info_list "tot-cmds"]
+        $rd blpop mylist 0
+
+        # Make sure to wait for the $rd client to be blocked
+        #wait_for_blocked_client
+
+        # Check if input stats have changed for $rd. Since command is blocking
+        # and has not been unblocked yet we expect no change in output/cmds-processed
+        # stats.
+        set info_list [r client list]
+        set input2 [get_field_in_client_list $rd_id $info_list "tot-net-in"]
+        set output2 [get_field_in_client_list $rd_id $info_list "tot-net-out"]
+        set cmd2 [get_field_in_client_list $rd_id $info_list "tot-cmds"]
+        assert_equal [expr $input1+34] $input2
+        assert_equal $output1 $output2
+        assert_equal $cmd1 $cmd2
+
+        # Unblock the $rd client (which will send a reply and thus update output
+        # and cmd-processed stats).
+        r lpush mylist a
+
+        # Note that the per-client stats are from the POV of the server. The
+        # deferred client may have not read the response yet, but the stats
+        # are still updated.
         set info_list [r client list]
         set input3 [get_field_in_client_list $rd_id $info_list "tot-net-in"]
         set output3 [get_field_in_client_list $rd_id $info_list "tot-net-out"]
         set cmd3 [get_field_in_client_list $rd_id $info_list "tot-cmds"]
-        $rd blpop mylist 0
-        set info_list [r client list]
-        set input4 [get_field_in_client_list $rd_id $info_list "tot-net-in"]
-        set output4 [get_field_in_client_list $rd_id $info_list "tot-net-out"]
-        set cmd4 [get_field_in_client_list $rd_id $info_list "tot-cmds"]
-        assert_equal [expr $input3+34] $input4
-        assert_equal $output3 $output4
-        assert_equal $cmd3 $cmd4
-        r lpush mylist a
-        set info_list [r client list]
-        set input5 [get_field_in_client_list $rd_id $info_list "tot-net-in"]
-        set output5 [get_field_in_client_list $rd_id $info_list "tot-net-out"]
-        set cmd5 [get_field_in_client_list $rd_id $info_list "tot-cmds"]
-        assert_equal $input4 $input5
-        assert_equal [expr $output4+23] $output5
-        assert_equal [expr $cmd4+1] $cmd5
+        assert_equal $input2 $input3
+        assert_equal [expr $output2+23] $output3
+        assert_equal [expr $cmd2+1] $cmd3
+
         $rd close
-        # test recursive command
+    }
+
+    test {CLIENT INFO cmds-processed stats for recursive command} {
         set info [r client info]
-        set cmd6 [get_field_in_client_info $info "tot-cmds"]
+        set tot_cmd_before [get_field_in_client_info $info "tot-cmds"]
         r eval "redis.call('ping')" 0
         set info [r client info]
-        set cmd7 [get_field_in_client_info $info "tot-cmds"]
-        assert_equal [expr $cmd6+3] $cmd7
+        set tot_cmd_after [get_field_in_client_info $info "tot-cmds"]
+
+        # We executed 3 commands - EVAL, which in turn executed PING and finally CLIENT INFO
+        assert_equal [expr $tot_cmd_before+3] $tot_cmd_after
     }
 
     test {CLIENT KILL with illegal arguments} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -79,10 +79,10 @@ start_server {tags {"introspection"}} {
         # NOTE if CLIENT INFO changes it's stats the output_bytes here and in the
         # other related tests will need to be updated.
         set input_bytes 26 ; # CLIENT INFO request
-        set output_bytes 361 ; # CLIENT INFO result
+        set output_bytes 300 ; # CLIENT INFO result
         set cmds_processed 1 ; # processed the command CLIENT INFO
         assert_equal [expr $input1+$input_bytes] $input2
-        assert_equal [expr $output1+$output_bytes] $output2
+        assert {[expr $output1+$output_bytes] < $output2}
         assert_equal [expr $cmd1+$cmds_processed] $cmd2
     }
 


### PR DESCRIPTION
We already have global stats for input traffic, output traffic and how many commands have been executed.

However, some users have the difficulty of locating the IP(s) which have heavy network traffic. So here some stats for single client are introduced.
```
tot-net-in   // Total network input bytes read from the client
tot-net-out  // Total network output bytes sent to the client
tot-cmds     // Total commands the client has executed
```
These three stats are shown in `CLIENT LIST` and `CLIENT INFO`.

Discussion about this was started as redis PR: https://github.com/redis/redis/pull/12640 and was merged in valkey with: https://github.com/valkey-io/valkey/pull/327

Co-authored-by Chen Tianjie <TJ_Chen@outlook.com>