### PR TITLE
fix flaky replication test

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1641,7 +1641,7 @@ start_server {tags {"repl external:skip"}} {
             $replica replicaof $master_host $master_port
 
             # Wait until replication is completed
-            wait_replica_online $master 0 1000 100
+            wait_for_sync $replica
             wait_for_ofs_sync $master $replica
 
             # Sanity check


### PR DESCRIPTION
from the master's perspective, the replica can become online before it's actually done loading the rdb file.
this was always like that, in disk-based repl, and thus ok with diskless and rdb channel.
in this test, because all the keys are added before the backlog is created, the replication offset is 0, so the test proceeds and could get a LOADING error when trying to run the function.