### PR TITLE
Add a full stop to a script running a disallowed command error message

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -400,7 +400,7 @@ static int scriptVerifyWriteCommandAllow(scriptRunCtx *run_ctx, char **err) {
     if (run_ctx->flags & SCRIPT_READ_ONLY &&
         (run_ctx->c->cmd->flags & (CMD_WRITE|CMD_MAY_REPLICATE)))
     {
-        *err = sdsnew("Write commands are not allowed from read-only scripts.");
+        *err = sdsnew("Write commands are not allowed from read-only scripts");
         return C_ERR;
     }
 

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -1668,7 +1668,7 @@ void luaCallFunction(scriptRunCtx* run_ctx, lua_State *lua, robj** keys, size_t 
             final_msg = sdscatfmt(final_msg, "-%s",
                                   err_info.msg);
             if (err_info.line && err_info.source) {
-                final_msg = sdscatfmt(final_msg, " script: %s, on %s:%s.",
+                final_msg = sdscatfmt(final_msg, ". script: %s, on %s:%s.",
                                       run_ctx->funcname,
                                       err_info.source,
                                       err_info.line);

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -2345,7 +2345,7 @@ start_server {tags {"scripting"}} {
         assert_equal [
             r eval_ro {
                 local t = redis.pcall('set','x','y')
-                if t['err'] == "ERR Write commands are not allowed from read-only scripts." then
+                if t['err'] == "ERR Write commands are not allowed from read-only scripts" then
                     return 1
                 else
                     return 0


### PR DESCRIPTION
Right now the error looks like that in the `redis-cli`: (notice the absence of a full stop between two "script"s)
```
127.0.0.1:7500> SCRIPT LOAD "return redis.call('EVAL', 'return 123', 0)"
"2375bc7adf41c05f7846378e6f625d500ffae60d"
127.0.0.1:7500> evalsha 2375bc7adf41c05f7846378e6f625d500ffae60d 0
(error) ERR This Redis command is not allowed from script script: 2375bc7adf41c05f7846378e6f625d500ffae60d, on @user_script:1.
```

This PR fixes this by adding the full stop at the end of an error message