### PR TITLE
Create global data before test instead of module load for module defrag test

### DIFF
--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -54,6 +54,7 @@ static int defragGlobalStrings(RedisModuleDefragCtx *ctx)
     unsigned long cursor = 0;
     RedisModule_DefragCursorGet(ctx, &cursor);
 
+    if (!global_strings_len) return 0;
     RedisModule_Assert(cursor < global_strings_len);
     for (; cursor < global_strings_len; cursor++) {
         RedisModuleString *str = global_strings[cursor];
@@ -191,8 +192,9 @@ static int defragGlobalDicts(RedisModuleDefragCtx *ctx) {
         global_dicts_resumes++;
     }
 
+    if (global_dicts_len == 0) return 0;
     RedisModule_Assert(dict_index < global_dicts_len);
-    for (; dict_index < global_strings_len; dict_index++) {
+    for (; dict_index < global_dicts_len; dict_index++) {
         RedisModuleDict *dict = global_dicts[dict_index];
         if (!dict) continue;
         RedisModuleDict *new = RedisModule_DefragRedisModuleDict(ctx, dict, defragGlobalDictValueCB, &seekTo);
@@ -339,9 +341,16 @@ static int fragCreateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 /* FRAG.create_frag_global */
 static int fragCreateGlobalCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     UNUSED(argv);
-    if (argc != 1)
+    if (argc != 2)
         return RedisModule_WrongArity(ctx);
 
+    long long glen;
+    if ((RedisModule_StringToLongLong(argv[1], &glen) != REDISMODULE_OK)) {
+        return RedisModule_ReplyWithError(ctx, "ERR invalid len");
+    }
+
+    createGlobalStrings(ctx, glen);
+    createGlobalDicts(ctx, glen);
     createFragGlobalStrings(ctx);
     createFragGlobalDicts(ctx);
     RedisModule_ReplyWithSimpleString(ctx, "OK");
@@ -435,14 +444,6 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     if (RedisModule_GetTypeMethodVersion() < REDISMODULE_TYPE_METHOD_VERSION) {
         return REDISMODULE_ERR;
     }
-
-    long long glen;
-    if (argc != 1 || RedisModule_StringToLongLong(argv[0], &glen) == REDISMODULE_ERR) {
-        return REDISMODULE_ERR;
-    }
-
-    createGlobalStrings(ctx, glen);
-    createGlobalDicts(ctx, glen);
 
     RedisModuleTypeMethods tm = {
             .version = REDISMODULE_TYPE_METHOD_VERSION,

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -338,7 +338,7 @@ static int fragCreateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     return REDISMODULE_OK;
 }
 
-/* FRAG.create_frag_global */
+/* FRAG.create_frag_global len */
 static int fragCreateGlobalCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     UNUSED(argv);
     if (argc != 2)

--- a/tests/modules/defragtest.c
+++ b/tests/modules/defragtest.c
@@ -54,7 +54,7 @@ static int defragGlobalStrings(RedisModuleDefragCtx *ctx)
     unsigned long cursor = 0;
     RedisModule_DefragCursorGet(ctx, &cursor);
 
-    if (!global_strings_len) return 0;
+    if (!global_strings_len) return 0; /* strings is empty. */
     RedisModule_Assert(cursor < global_strings_len);
     for (; cursor < global_strings_len; cursor++) {
         RedisModuleString *str = global_strings[cursor];
@@ -192,7 +192,7 @@ static int defragGlobalDicts(RedisModuleDefragCtx *ctx) {
         global_dicts_resumes++;
     }
 
-    if (global_dicts_len == 0) return 0;
+    if (!global_dicts_len) return 0; /* dicts is empty. */
     RedisModule_Assert(dict_index < global_dicts_len);
     for (; dict_index < global_dicts_len; dict_index++) {
         RedisModuleDict *dict = global_dicts[dict_index];

--- a/tests/unit/moduleapi/defrag.tcl
+++ b/tests/unit/moduleapi/defrag.tcl
@@ -19,6 +19,8 @@ start_server {tags {"modules"} overrides {{save ""}}} {
                 fail "Unable to wait for active defrag to stop"
             }
 
+            r flushdb
+            r frag.resetstats
             r frag.create key1 1 1000 0
 
             r config set activedefrag yes

--- a/tests/unit/moduleapi/defrag.tcl
+++ b/tests/unit/moduleapi/defrag.tcl
@@ -1,7 +1,7 @@
 set testmodule [file normalize tests/modules/defragtest.so]
 
 start_server {tags {"modules"} overrides {{save ""}}} {
-    r module load $testmodule 50000
+    r module load $testmodule
     r config set hz 100
     r config set active-defrag-ignore-bytes 1
     r config set active-defrag-threshold-lower 0
@@ -76,7 +76,7 @@ start_server {tags {"modules"} overrides {{save ""}}} {
 
             r flushdb
             r frag.resetstats
-            r frag.create_frag_global
+            r frag.create_frag_global 50000
             r config set activedefrag yes
 
             wait_for_condition 200 50 {


### PR DESCRIPTION
After #13816, we added defragmentation support for moduleDict, which significantly increased global data size.
As a result, the defragmentation tests for non-global data were affected.
Now, we move the creation of global data to before the global data test to avoid it interfering with other tests.
Fixed the simple key test failure due to forgetting to reset stats.