### PR TITLE
Fix incorrect lag due to trimming stream via XTRIM or XADD command

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1695,7 +1695,10 @@ size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end
     while(streamIteratorGetID(&si,&id,&numfields)) {
         /* Update the group last_id if needed. */
         if (group && streamCompareID(&id,&group->last_id) > 0) {
-            if (group->entries_read != SCG_INVALID_ENTRIES_READ && !streamRangeHasTombstones(s,&group->last_id,NULL)) {
+            if (group->entries_read != SCG_INVALID_ENTRIES_READ &&
+                streamCompareID(&group->last_id, &s->first_id) >= 0 &&
+                !streamRangeHasTombstones(s,&group->last_id,NULL))
+            {
                 /* A valid counter and no tombstones between the group's last-delivered-id
                  * and the stream's last-generated-id mean we can increment the read counter
                  * to keep tracking the group's progress. */

--- a/tests/unit/type/stream-cgroups.tcl
+++ b/tests/unit/type/stream-cgroups.tcl
@@ -1300,6 +1300,19 @@ start_server {
         assert_equal [dict get $group entries-read] 1
         assert_equal [dict get $group lag] 1
 
+        # When all the entries are read, the lag is always 0.
+        r XREADGROUP GROUP mygroup alice STREAMS x >
+        set reply [r XINFO STREAM x FULL]
+        set group [lindex [dict get $reply groups] 0]
+        assert_equal [dict get $group entries-read] 5
+        assert_equal [dict get $group lag] 0
+
+        r XADD x 6-0 data f
+        set reply [r XINFO STREAM x FULL]
+        set group [lindex [dict get $reply groups] 0]
+        assert_equal [dict get $group entries-read] 5
+        assert_equal [dict get $group lag] 1
+
         # When all the entries were deleted, the lag is always 0.
         r XTRIM x MAXLEN 0
         set reply [r XINFO STREAM x FULL]


### PR DESCRIPTION
This PR fix the lag calculation by ensuring that when consumer group's last_id
is behind the first entry, the consumer group's entries read is considered 
invalid and recalculated from the start of the stream

Supplement to PR #13473 

Close #13957