### PR TITLE
Fix oldTC CI dk.archive.ubuntu.com  could not connect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
       run: |
         apt-get update
         apt-get install -y gnupg2
-        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
-        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1076,8 +1076,8 @@ jobs:
       run: |
         apt-get update
         apt-get install -y gnupg2
-        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
-        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update
@@ -1125,8 +1125,8 @@ jobs:
       run: |
         apt-get update
         apt-get install -y gnupg2
-        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
-        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update
@@ -1180,8 +1180,8 @@ jobs:
       run: |
         apt-get update
         apt-get install -y gnupg2 
-        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
-        echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update


### PR DESCRIPTION
### Problem

I found that the failure of the oldTC daily CI was caused by a connection issue to dk.archive.ubuntu.com:80.
Here’s the CI result for reference: https://github.com/redis/redis/actions/runs/14564587666/job/40851998865

This is a screenshot of the detailed failure information:
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/14dc9755-c3c8-4657-9679-2789b6112af5" />


I have check the `dk.archive.ubuntu.com`：
```shell
> curl -v http://dk.archive.ubuntu.com
* Host dk.archive.ubuntu.com:80 was resolved.
* IPv6: (none)
* IPv4: 198.18.1.251
*   Trying 198.18.1.251:80...
* Connected to dk.archive.ubuntu.com (198.18.1.251) port 80
> GET / HTTP/1.1
> Host: dk.archive.ubuntu.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
* Empty reply from server
* Closing connection
curl: (52) Empty reply from server
```

As of April 21, 2025, the Danish Ubuntu mirror dk.archive.ubuntu.com, hosted by Dotsrc.org, is officially recognized and was last verified on April 19, 2025. Here is the ubuntu mirror detail of `dk.archive.ubuntu.com`: 
https://launchpad.net/ubuntu/%2Bmirror/mirrors.dotsrc.org-archive

Dotsrc.org released a message on April 20th regarding taking `mirrors.dotsrc.org` offline: https://dotsrc.org/news/2025-04-20_hardware_failure/

> We are currently seing failure on one of our disk enclosures, meaning we have to take mirrors.dotsrc.org offline 😢.
> It is currently not clear how big the issue is, however, we might be offline for some time to diagnose and fix this issue. More info will be posted here.
> We are sorry for the inconvenience, and hope to be online again soon.


### Fixed 

We can switch the domain from `dk.archive.ubuntu.com` to the main ubuntu archive domain `archive.ubuntu.com`.

```shell
> curl -I http://archive.ubuntu.com/ubuntu/
HTTP/1.1 200 OK
Date: Mon, 21 Apr 2025 06:14:20 GMT
Server: Apache/2.4.52 (Ubuntu)
Content-Type: text/html;charset=UTF-8
```

Here is the CI running result of `archive.ubuntu.com`: https://github.com/vitahlin/redis/actions/runs/14567320042

