### PR TITLE
Fix tls port update not reflected in CLUSTER SLOTS

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2688,6 +2688,7 @@ static int applyTLSPort(const char **err) {
     listener->bindaddr_count = server.bindaddr_count;
     listener->port = server.tls_port;
     listener->ct = connectionByType(CONN_TYPE_TLS);
+    clusterUpdateMyselfAnnouncedPorts();
     if (changeListener(listener) == C_ERR) {
         *err = "Unable to listen on this port. Check server logs.";
         return 0;

--- a/tests/unit/cluster/announced-endpoints.tcl
+++ b/tests/unit/cluster/announced-endpoints.tcl
@@ -49,12 +49,21 @@ start_cluster 2 2 {tags {external:skip cluster}} {
     }
 
     test "CONFIG SET port updates cluster-announced port" {
+        set count [expr [llength $::servers] + 1]
         # Get the original port and change to new_port
-        set orig_port [lindex [R 0 config get port] 1]
+        if {$::tls} {
+            set orig_port [lindex [R 0 config get tls-port] 1]
+        } else {
+            set orig_port [lindex [R 0 config get port] 1]
+        }
         assert {$orig_port != ""}
+        set new_port [find_available_port $orig_port $count]
 
-        set new_port [find_available_port $baseport $count]
-        R 0 config set port $new_port
+        if {$::tls} {
+            R 0 config set tls-port $new_port
+        } else {
+            R 0 config set port $new_port
+        }
 
         # Verify that the new port appears in the output of cluster slots
         wait_for_condition 50 100 {


### PR DESCRIPTION
### Problem 

A previous PR (https://github.com/redis/redis/pull/13932) fixed the TCP port issue in CLUSTER SLOTS, but it seems the handling of the TLS port was overlooked.

There is this comment in the `addNodeToNodeReply` function in the `cluster.c` file:
```c
    /* Report TLS ports to TLS client, and report non-TLS port to non-TLS client. */
    addReplyLongLong(c, clusterNodeClientPort(node, shouldReturnTlsInfo()));
    addReplyBulkCBuffer(c, clusterNodeGetName(node), CLUSTER_NAMELEN);
```

### Fixed 

This PR fixes the TLS port issue and adds relevant tests.


