### PR TITLE
Resolve bounds checks on cluster_legacy.c

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -52,7 +52,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
+      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST' OPTIMIZATION=-O2
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -94,7 +94,7 @@ jobs:
     - name: make
       run: |
         apt-get update && apt-get install -y make gcc g++
-        make CC=gcc REDIS_CFLAGS='-Werror -DREDIS_TEST -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3'
+        make CC=gcc REDIS_CFLAGS='-Werror -DREDIS_TEST -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3' OPTIMIZATION=-O2
     - name: testprep
       run: sudo apt-get install -y tcl8.6 tclx procps
     - name: test
@@ -134,7 +134,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make MALLOC=libc REDIS_CFLAGS='-Werror'
+      run: make MALLOC=libc REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -171,7 +171,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make MALLOC=libc CFLAGS=-DNO_MALLOC_USABLE_SIZE REDIS_CFLAGS='-Werror'
+      run: make MALLOC=libc CFLAGS=-DNO_MALLOC_USABLE_SIZE REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -210,7 +210,7 @@ jobs:
     - name: make
       run: |
         sudo apt-get update && sudo apt-get install libc6-dev-i386 g++ gcc-multilib g++-multilib
-        make 32bit REDIS_CFLAGS='-Werror -DREDIS_TEST'
+        make 32bit REDIS_CFLAGS='-Werror -DREDIS_TEST' OPTIMIZATION=-O2
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -253,7 +253,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        make BUILD_TLS=yes REDIS_CFLAGS='-Werror'
+        make BUILD_TLS=yes REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
     - name: testprep
       run: |
         sudo apt-get install tcl8.6 tclx tcl-tls
@@ -297,7 +297,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        make BUILD_TLS=yes REDIS_CFLAGS='-Werror'
+        make BUILD_TLS=yes REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
     - name: testprep
       run: |
         sudo apt-get install tcl8.6 tclx tcl-tls
@@ -341,7 +341,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        make REDIS_CFLAGS='-Werror'
+        make REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -373,7 +373,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        make REDIS_CFLAGS='-Werror'
+        make REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
     - name: testprep
       run: |
         sudo apt-get install vmtouch
@@ -450,7 +450,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind REDIS_CFLAGS='-Werror -DREDIS_TEST'
+      run: make valgrind REDIS_CFLAGS='-Werror -DREDIS_TEST' OPTIMIZATION=-O2
     - name: testprep
       run: |
         sudo apt-get update
@@ -480,7 +480,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind REDIS_CFLAGS='-Werror -DREDIS_TEST'
+      run: make valgrind REDIS_CFLAGS='-Werror -DREDIS_TEST' OPTIMIZATION=-O2
     - name: testprep
       run: |
         sudo apt-get update
@@ -515,7 +515,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE -DREDIS_TEST" REDIS_CFLAGS='-Werror'
+      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE -DREDIS_TEST" REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
     - name: testprep
       run: |
         sudo apt-get update
@@ -545,7 +545,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE -DREDIS_TEST" REDIS_CFLAGS='-Werror'
+      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE -DREDIS_TEST" REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
     - name: testprep
       run: |
         sudo apt-get update
@@ -585,7 +585,7 @@ jobs:
           repository: ${{ env.GITHUB_REPOSITORY }}
           ref: ${{ env.GITHUB_HEAD_REF }}
       - name: make
-        run: make SANITIZER=address REDIS_CFLAGS='-DREDIS_TEST -Werror -DDEBUG_ASSERTIONS'
+        run: make SANITIZER=address REDIS_CFLAGS='-DREDIS_TEST -Werror -DDEBUG_ASSERTIONS' OPTIMIZATION=-O2
       - name: testprep
         run: |
           sudo apt-get update
@@ -632,7 +632,7 @@ jobs:
           repository: ${{ env.GITHUB_REPOSITORY }}
           ref: ${{ env.GITHUB_HEAD_REF }}
       - name: make
-        run: make SANITIZER=undefined REDIS_CFLAGS='-DREDIS_TEST -Werror' SKIP_VEC_SETS=yes LUA_DEBUG=yes # we (ab)use this flow to also check Lua C API violations
+        run: make SANITIZER=undefined REDIS_CFLAGS='-DREDIS_TEST -Werror' SKIP_VEC_SETS=yes LUA_DEBUG=yes OPTIMIZATION=-O2 # we (ab)use this flow to also check Lua C API violations
       - name: testprep
         run: |
           sudo apt-get update
@@ -897,7 +897,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
+      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST' OPTIMIZATION=-O2
 
   test-freebsd:
     runs-on: macos-13
@@ -927,7 +927,7 @@ jobs:
         shell: bash
         run: |
           sudo pkg install -y bash gmake lang/tcl86 lang/tclx gcc
-          gmake
+          gmake OPTIMIZATION=-O2
           ./runtest --single unit/keyspace --single unit/auth --single unit/networking --single unit/protocol
 
   test-alpine-jemalloc:
@@ -953,7 +953,7 @@ jobs:
     - name: make
       run: |
           apk add build-base
-          make REDIS_CFLAGS='-Werror'
+          make REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
     - name: testprep
       run: apk add tcl procps tclx
     - name: test
@@ -992,7 +992,7 @@ jobs:
     - name: make
       run: |
           apk add build-base
-          make REDIS_CFLAGS='-Werror' USE_JEMALLOC=no CFLAGS=-DUSE_MALLOC_USABLE_SIZE
+          make REDIS_CFLAGS='-Werror' USE_JEMALLOC=no CFLAGS=-DUSE_MALLOC_USABLE_SIZE OPTIMIZATION=-O2
     - name: testprep
       run: apk add tcl procps tclx
     - name: test
@@ -1029,7 +1029,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror -DLOG_REQ_RES'
+      run: make REDIS_CFLAGS='-Werror -DLOG_REQ_RES' OPTIMIZATION=-O2
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -1084,7 +1084,7 @@ jobs:
         apt-get install -y make gcc-4.8 g++-4.8
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
-        make CC=gcc REDIS_CFLAGS='-Werror'
+        make CC=gcc REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
     - name: testprep
       run: apt-get install -y tcl tcltls tclx
     - name: test
@@ -1133,7 +1133,7 @@ jobs:
         apt-get install -y make gcc-4.8 g++-4.8 openssl libssl-dev
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
-        make CC=gcc CXX=g++ BUILD_TLS=module REDIS_CFLAGS='-Werror'
+        make CC=gcc CXX=g++ BUILD_TLS=module REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
     - name: testprep
       run: |
         apt-get install -y tcl tcltls tclx
@@ -1188,7 +1188,7 @@ jobs:
         apt-get install -y make gcc-4.8 g++-4.8 openssl libssl-dev
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
-        make BUILD_TLS=module CC=gcc REDIS_CFLAGS='-Werror'
+        make BUILD_TLS=module CC=gcc REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
     - name: testprep
       run: |
         apt-get install -y tcl tcltls tclx

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -52,7 +52,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST' OPTIMIZATION=-O2
+      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -94,7 +94,7 @@ jobs:
     - name: make
       run: |
         apt-get update && apt-get install -y make gcc g++
-        make CC=gcc REDIS_CFLAGS='-Werror -DREDIS_TEST -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3' OPTIMIZATION=-O2
+        make CC=gcc REDIS_CFLAGS='-Werror -DREDIS_TEST -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3'
     - name: testprep
       run: sudo apt-get install -y tcl8.6 tclx procps
     - name: test
@@ -134,7 +134,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make MALLOC=libc REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
+      run: make MALLOC=libc REDIS_CFLAGS='-Werror'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -171,7 +171,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make MALLOC=libc CFLAGS=-DNO_MALLOC_USABLE_SIZE REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
+      run: make MALLOC=libc CFLAGS=-DNO_MALLOC_USABLE_SIZE REDIS_CFLAGS='-Werror'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -210,7 +210,7 @@ jobs:
     - name: make
       run: |
         sudo apt-get update && sudo apt-get install libc6-dev-i386 g++ gcc-multilib g++-multilib
-        make 32bit REDIS_CFLAGS='-Werror -DREDIS_TEST' OPTIMIZATION=-O2
+        make 32bit REDIS_CFLAGS='-Werror -DREDIS_TEST'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -253,7 +253,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        make BUILD_TLS=yes REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
+        make BUILD_TLS=yes REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         sudo apt-get install tcl8.6 tclx tcl-tls
@@ -297,7 +297,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        make BUILD_TLS=yes REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
+        make BUILD_TLS=yes REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         sudo apt-get install tcl8.6 tclx tcl-tls
@@ -341,7 +341,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        make REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
+        make REDIS_CFLAGS='-Werror'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -373,7 +373,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        make REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
+        make REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         sudo apt-get install vmtouch
@@ -450,7 +450,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind REDIS_CFLAGS='-Werror -DREDIS_TEST' OPTIMIZATION=-O2
+      run: make valgrind REDIS_CFLAGS='-Werror -DREDIS_TEST'
     - name: testprep
       run: |
         sudo apt-get update
@@ -480,7 +480,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind REDIS_CFLAGS='-Werror -DREDIS_TEST' OPTIMIZATION=-O2
+      run: make valgrind REDIS_CFLAGS='-Werror -DREDIS_TEST'
     - name: testprep
       run: |
         sudo apt-get update
@@ -515,7 +515,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE -DREDIS_TEST" REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
+      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE -DREDIS_TEST" REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         sudo apt-get update
@@ -545,7 +545,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE -DREDIS_TEST" REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
+      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE -DREDIS_TEST" REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         sudo apt-get update
@@ -585,7 +585,7 @@ jobs:
           repository: ${{ env.GITHUB_REPOSITORY }}
           ref: ${{ env.GITHUB_HEAD_REF }}
       - name: make
-        run: make SANITIZER=address REDIS_CFLAGS='-DREDIS_TEST -Werror -DDEBUG_ASSERTIONS' OPTIMIZATION=-O2
+        run: make SANITIZER=address REDIS_CFLAGS='-DREDIS_TEST -Werror -DDEBUG_ASSERTIONS'
       - name: testprep
         run: |
           sudo apt-get update
@@ -632,7 +632,7 @@ jobs:
           repository: ${{ env.GITHUB_REPOSITORY }}
           ref: ${{ env.GITHUB_HEAD_REF }}
       - name: make
-        run: make SANITIZER=undefined REDIS_CFLAGS='-DREDIS_TEST -Werror' SKIP_VEC_SETS=yes LUA_DEBUG=yes OPTIMIZATION=-O2 # we (ab)use this flow to also check Lua C API violations
+        run: make SANITIZER=undefined REDIS_CFLAGS='-DREDIS_TEST -Werror' SKIP_VEC_SETS=yes LUA_DEBUG=yes # we (ab)use this flow to also check Lua C API violations
       - name: testprep
         run: |
           sudo apt-get update
@@ -897,7 +897,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST' OPTIMIZATION=-O2
+      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
 
   test-freebsd:
     runs-on: macos-13
@@ -927,7 +927,7 @@ jobs:
         shell: bash
         run: |
           sudo pkg install -y bash gmake lang/tcl86 lang/tclx gcc
-          gmake OPTIMIZATION=-O2
+          gmake
           ./runtest --single unit/keyspace --single unit/auth --single unit/networking --single unit/protocol
 
   test-alpine-jemalloc:
@@ -953,7 +953,7 @@ jobs:
     - name: make
       run: |
           apk add build-base
-          make REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
+          make REDIS_CFLAGS='-Werror'
     - name: testprep
       run: apk add tcl procps tclx
     - name: test
@@ -992,7 +992,7 @@ jobs:
     - name: make
       run: |
           apk add build-base
-          make REDIS_CFLAGS='-Werror' USE_JEMALLOC=no CFLAGS=-DUSE_MALLOC_USABLE_SIZE OPTIMIZATION=-O2
+          make REDIS_CFLAGS='-Werror' USE_JEMALLOC=no CFLAGS=-DUSE_MALLOC_USABLE_SIZE
     - name: testprep
       run: apk add tcl procps tclx
     - name: test
@@ -1029,7 +1029,7 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror -DLOG_REQ_RES' OPTIMIZATION=-O2
+      run: make REDIS_CFLAGS='-Werror -DLOG_REQ_RES'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -1084,7 +1084,7 @@ jobs:
         apt-get install -y make gcc-4.8 g++-4.8
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
-        make CC=gcc REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
+        make CC=gcc REDIS_CFLAGS='-Werror'
     - name: testprep
       run: apt-get install -y tcl tcltls tclx
     - name: test
@@ -1133,7 +1133,7 @@ jobs:
         apt-get install -y make gcc-4.8 g++-4.8 openssl libssl-dev
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
-        make CC=gcc CXX=g++ BUILD_TLS=module REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
+        make CC=gcc CXX=g++ BUILD_TLS=module REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         apt-get install -y tcl tcltls tclx
@@ -1188,7 +1188,7 @@ jobs:
         apt-get install -y make gcc-4.8 g++-4.8 openssl libssl-dev
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
-        make BUILD_TLS=module CC=gcc REDIS_CFLAGS='-Werror' OPTIMIZATION=-O2
+        make BUILD_TLS=module CC=gcc REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         apt-get install -y tcl tcltls tclx

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -288,8 +288,13 @@ int auxTlsPortPresent(clusterNode *n) {
 typedef struct {
     size_t totlen; /* Total length of this block including the message */
     int refcount;  /* Number of cluster link send msg queues containing the message */
-    clusterMsg msg;
+    clusterMsg msg[];
 } clusterMsgSendBlock;
+
+/* Helper function to extract a normal message from a send block. */
+static clusterMsg *getMessageFromSendBlock(clusterMsgSendBlock *msgblock) {
+    return &msgblock->msg[0];
+}
 
 /* -----------------------------------------------------------------------------
  * Initialization
@@ -1129,12 +1134,12 @@ void clusterReset(int hard) {
  * CLUSTER communication link
  * -------------------------------------------------------------------------- */
 static clusterMsgSendBlock *createClusterMsgSendBlock(int type, uint32_t msglen) {
-    uint32_t blocklen = msglen + sizeof(clusterMsgSendBlock) - sizeof(clusterMsg);
+    uint32_t blocklen = msglen + sizeof(clusterMsgSendBlock);
     clusterMsgSendBlock *msgblock = zcalloc(blocklen);
     msgblock->refcount = 1;
     msgblock->totlen = blocklen;
     server.stat_cluster_links_memory += blocklen;
-    clusterBuildMessageHdr(&msgblock->msg,type,msglen);
+    clusterBuildMessageHdr(getMessageFromSendBlock(msgblock),type,msglen);
     return msgblock;
 }
 
@@ -3303,7 +3308,7 @@ void clusterWriteHandler(connection *conn) {
     while (totwritten < NET_MAX_WRITES_PER_EVENT && listLength(link->send_msg_queue) > 0) {
         listNode *head = listFirst(link->send_msg_queue);
         clusterMsgSendBlock *msgblock = (clusterMsgSendBlock*)head->value;
-        clusterMsg *msg = &msgblock->msg;
+        clusterMsg *msg = getMessageFromSendBlock(msgblock);
         size_t msg_offset = link->head_msg_send_offset;
         size_t msg_len = ntohl(msg->totlen);
 
@@ -3477,7 +3482,7 @@ void clusterSendMessage(clusterLink *link, clusterMsgSendBlock *msgblock) {
     if (!link) {
         return;
     }
-    if (listLength(link->send_msg_queue) == 0 && msgblock->msg.totlen != 0)
+    if (listLength(link->send_msg_queue) == 0 && getMessageFromSendBlock(msgblock)->totlen != 0)
         connSetWriteHandlerWithBarrier(link->conn, clusterWriteHandler, 1);
 
     listAddNodeTail(link->send_msg_queue, msgblock);
@@ -3488,7 +3493,7 @@ void clusterSendMessage(clusterLink *link, clusterMsgSendBlock *msgblock) {
     server.stat_cluster_links_memory += sizeof(listNode);
 
     /* Populate sent messages stats. */
-    uint16_t type = ntohs(msgblock->msg.type);
+    uint16_t type = ntohs(getMessageFromSendBlock(msgblock)->type);
     if (type < CLUSTERMSG_TYPE_COUNT)
         server.cluster->stats_bus_messages_sent[type]++;
 }
@@ -3663,7 +3668,7 @@ void clusterSendPing(clusterLink *link, int type) {
      * sizeof(clusterMsg) or more. */
     if (estlen < (int)sizeof(clusterMsg)) estlen = sizeof(clusterMsg);
     clusterMsgSendBlock *msgblock = createClusterMsgSendBlock(type, estlen);
-    clusterMsg *hdr = &msgblock->msg;
+    clusterMsg *hdr = getMessageFromSendBlock(msgblock);
 
     if (!link->inbound && type == CLUSTERMSG_TYPE_PING)
         link->node->ping_sent = mstime();
@@ -3798,7 +3803,7 @@ clusterMsgSendBlock *clusterCreatePublishMsgBlock(robj *channel, robj *message, 
     msglen += sizeof(clusterMsgDataPublish) - 8 + channel_len + message_len;
     clusterMsgSendBlock *msgblock = createClusterMsgSendBlock(type, msglen);
 
-    clusterMsg *hdr = &msgblock->msg;
+    clusterMsg *hdr = getMessageFromSendBlock(msgblock);
     hdr->data.publish.msg.channel_len = htonl(channel_len);
     hdr->data.publish.msg.message_len = htonl(message_len);
     memcpy(hdr->data.publish.msg.bulk_data,channel->ptr,sdslen(channel->ptr));
@@ -3821,7 +3826,7 @@ void clusterSendFail(char *nodename) {
         + sizeof(clusterMsgDataFail);
     clusterMsgSendBlock *msgblock = createClusterMsgSendBlock(CLUSTERMSG_TYPE_FAIL, msglen);
 
-    clusterMsg *hdr = &msgblock->msg;
+    clusterMsg *hdr = getMessageFromSendBlock(msgblock);
     memcpy(hdr->data.fail.about.nodename,nodename,CLUSTER_NAMELEN);
 
     clusterBroadcastMessage(msgblock);
@@ -3838,7 +3843,7 @@ void clusterSendUpdate(clusterLink *link, clusterNode *node) {
         + sizeof(clusterMsgDataUpdate);
     clusterMsgSendBlock *msgblock = createClusterMsgSendBlock(CLUSTERMSG_TYPE_UPDATE, msglen);
 
-    clusterMsg *hdr = &msgblock->msg;
+    clusterMsg *hdr = getMessageFromSendBlock(msgblock);
     memcpy(hdr->data.update.nodecfg.nodename,node->name,CLUSTER_NAMELEN);
     hdr->data.update.nodecfg.configEpoch = htonu64(node->configEpoch);
     memcpy(hdr->data.update.nodecfg.slots,node->slots,sizeof(node->slots));
@@ -3860,7 +3865,7 @@ void clusterSendModule(clusterLink *link, uint64_t module_id, uint8_t type,
     msglen += sizeof(clusterMsgModule) - 3 + len;
     clusterMsgSendBlock *msgblock = createClusterMsgSendBlock(CLUSTERMSG_TYPE_MODULE, msglen);
 
-    clusterMsg *hdr = &msgblock->msg;
+    clusterMsg *hdr = getMessageFromSendBlock(msgblock);
     hdr->data.module.msg.module_id = module_id; /* Already endian adjusted. */
     hdr->data.module.msg.type = type;
     hdr->data.module.msg.len = htonl(len);
@@ -3942,11 +3947,10 @@ void clusterRequestFailoverAuth(void) {
     uint32_t msglen = sizeof(clusterMsg)-sizeof(union clusterMsgData);
     clusterMsgSendBlock *msgblock = createClusterMsgSendBlock(CLUSTERMSG_TYPE_FAILOVER_AUTH_REQUEST, msglen);
 
-    clusterMsg *hdr = &msgblock->msg;
     /* If this is a manual failover, set the CLUSTERMSG_FLAG0_FORCEACK bit
      * in the header to communicate the nodes receiving the message that
      * they should authorized the failover even if the master is working. */
-    if (server.cluster->mf_end) hdr->mflags[0] |= CLUSTERMSG_FLAG0_FORCEACK;
+    if (server.cluster->mf_end) msgblock->msg[0].mflags[0] |= CLUSTERMSG_FLAG0_FORCEACK;
     clusterBroadcastMessage(msgblock);
     clusterMsgSendBlockDecrRefCount(msgblock);
 }

--- a/src/crc64.c
+++ b/src/crc64.c
@@ -174,7 +174,7 @@ long long _ustime(void) {
 }
 
 static int bench_crc64(unsigned char *data, uint64_t size, long long passes, uint64_t check, char *name, int csv) {
-    uint64_t min = size, hash;
+    uint64_t min = size, hash = 0;
     long long original_start = _ustime(), original_end;
     for (long long i=passes; i > 0; i--) {
         hash = crc64(0, data, size);


### PR DESCRIPTION
Based on https://github.com/valkey-io/valkey/pull/1463 and https://github.com/valkey-io/valkey/pull/1481

In the failure of fully CI(https://github.com/redis/redis/actions/runs/14595343452/job/40979173087?pr=13965) in version 7.0 we are getting a number of errors like:
```
array subscript ‘clusterMsg[0]’ is partly outside array bounds of ‘unsigned char[2272]’
```

Which is basically GCC telling us that we have an object which is longer than the underlying storage of the allocation. We actually do this a lot, but GCC is generally not aware of how big the underlying allocation is, so it doesn't throw this error. We are specifically getting this error because the msgBlock can be of variable length depending on the type of message, but GCC assumes it's the longest one possible. The solution I went with here was make the message type optional, so that it wasn't included in the size. I think this also makes some sense, since it's really just a helper for us to easily cast the object around.

This compilation warning only occurs in version 7.2, because in [this PR](https://github.com/redis/redis/pull/13073), we started passing `-flto` to `CFLAGS` by default. It seems that in this case, GCC is unable to detect such warnings. However, this change is not present in version 7.2.
So, to reproduce this compilation warning in versions after 7.2, we can pass `OPTIMIZATION=-O2` manually.

---------

Co-authored-by: madolson <34459052+madolson@users.noreply.github.com>