### PR TITLE
Delete redundant declaration of handleDebugClusterCommand()

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -107,7 +107,6 @@ clusterNode *getMyClusterNode(void);
 char *getMyClusterId(void);
 int getClusterSize(void);
 int getMyShardSlotCount(void);
-int handleDebugClusterCommand(client *c);
 int clusterNodePending(clusterNode  *node);
 char **getClusterNodesList(size_t *numnodes);
 int clusterNodeIsMaster(clusterNode *n);


### PR DESCRIPTION
The function `handleDebugClusterCommand(client *c)` was already declared at line 87 in the file. I removed the duplicate declaration to avoid redundancy.