### PR TITLE
Optimize hash and zset with lpBatchAppend

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -922,9 +922,13 @@ int hashTypeSet(redisDb *db, robj *o, sds field, sds value, int flags) {
         }
 
         if (!update) {
+            listpackEntry entries[2] = {
+                {.sval = (unsigned char*) field, .slen = sdslen(field)},
+                {.sval = (unsigned char*) value, .slen = sdslen(value)},
+            };
+
             /* Push new field/value pair onto the tail of the listpack */
-            zl = lpAppend(zl, (unsigned char*)field, sdslen(field));
-            zl = lpAppend(zl, (unsigned char*)value, sdslen(value));
+            zl = lpBatchAppend(zl, entries, 2);
         }
         o->ptr = zl;
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1074,29 +1074,29 @@ unsigned char *zzlDelete(unsigned char *zl, unsigned char *eptr) {
 }
 
 unsigned char *zzlInsertAt(unsigned char *zl, unsigned char *eptr, sds ele, double score) {
-    unsigned char *sptr;
     char scorebuf[MAX_D2STRING_CHARS];
     int scorelen = 0;
     long long lscore;
     int score_is_long = double2ll(score, &lscore);
     if (!score_is_long)
         scorelen = d2string(scorebuf,sizeof(scorebuf),score);
-    if (eptr == NULL) {
-        zl = lpAppend(zl,(unsigned char*)ele,sdslen(ele));
-        if (score_is_long)
-            zl = lpAppendInteger(zl,lscore);
-        else
-            zl = lpAppend(zl,(unsigned char*)scorebuf,scorelen);
-    } else {
-        /* Insert member before the element 'eptr'. */
-        zl = lpInsertString(zl,(unsigned char*)ele,sdslen(ele),eptr,LP_BEFORE,&sptr);
 
-        /* Insert score after the member. */
-        if (score_is_long)
-            zl = lpInsertInteger(zl,lscore,sptr,LP_AFTER,NULL);
-        else
-            zl = lpInsertString(zl,(unsigned char*)scorebuf,scorelen,sptr,LP_AFTER,NULL);
+    listpackEntry entries[2];
+    entries[0].sval = (unsigned char*)ele;
+    entries[0].slen = sdslen(ele);
+    if (score_is_long) {
+        entries[1].sval = NULL;
+        entries[1].lval = lscore;
+    } else {
+        entries[1].sval = (unsigned char*)scorebuf;
+        entries[1].slen = scorelen;
     }
+
+    if (eptr == NULL)
+        zl = lpBatchAppend(zl, entries, 2);
+    else
+        zl = lpBatchInsert(zl, eptr, LP_BEFORE, entries, 2, NULL);
+
     return zl;
 }
 


### PR DESCRIPTION
# Description

Use lpBatchAppend/Insert instead of multiple calls to lpAppend/Insert in hash and zset

# Results

For testing I ran two servers
branch `unstable` on default port
branch `lp-batch` on port 5002
Tested on MacOS M4 Max

## Hash

### Script

```
./src/redis-cli flushall
./src/redis-cli -p 5002 flushall

echo UNSTABLE: && memtier_benchmark --test-time 60 "--data-size" "64" --command="DEL key" --command "HSET key field:1 __data__ field:2 __data__ field:3 __data__ field:4 __data__ field:5 __data__ field:6 __data__ field:7 __data__ field:8 __data__ field:9 __data__ field:10 __data__ field:11 __data__ field:12 __data__ field:13 __data__ field:14 __data__ field:15 __data__ field:16 __data__ field:17 __data__ field:18 __data__ field:19 __data__ field:20 __data__ field:21 __data__ field:22 __data__ field:23 __data__ field:24 __data__ field:25 __data__ field:26 __data__ field:27 __data__ field:28 __data__ field:29 __data__ field:30 __data__ field:31 __data__ field:32 __data__ field:33 __data__ field:34 __data__ field:35 __data__ field:36 __data__ field:37 __data__ field:38 __data__ field:39 __data__ field:40 __data__ field:41 __data__ field:42 __data__ field:43 __data__ field:44 __data__ field:45 __data__ field:46 __data__ field:47 __data__ field:48 __data__ field:49 __data__ field:50 __data__" -c 50 -t 4 --hide-histogram --pipeline 10 | tail -n 2 | head -n 1
echo BATCH: && memtier_benchmark --test-time 60 "--data-size" "64" --command="DEL key" --command "HSET key field:1 __data__ field:2 __data__ field:3 __data__ field:4 __data__ field:5 __data__ field:6 __data__ field:7 __data__ field:8 __data__ field:9 __data__ field:10 __data__ field:11 __data__ field:12 __data__ field:13 __data__ field:14 __data__ field:15 __data__ field:16 __data__ field:17 __data__ field:18 __data__ field:19 __data__ field:20 __data__ field:21 __data__ field:22 __data__ field:23 __data__ field:24 __data__ field:25 __data__ field:26 __data__ field:27 __data__ field:28 __data__ field:29 __data__ field:30 __data__ field:31 __data__ field:32 __data__ field:33 __data__ field:34 __data__ field:35 __data__ field:36 __data__ field:37 __data__ field:38 __data__ field:39 __data__ field:40 __data__ field:41 __data__ field:42 __data__ field:43 __data__ field:44 __data__ field:45 __data__ field:46 __data__ field:47 __data__ field:48 __data__ field:49 __data__ field:50 __data__" -c 50 -t 4 --hide-histogram --pipeline 10 --port 5002 | tail -n 2 | head -n 1
```

### Bench

```
========================================================================================================
Type                Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------------
Hsets-before       66755.51        14.97826        11.19900        21.63100        29.56700    278428.01
Hsets-after        70161.54        14.25133        17.27900        20.35100        27.51900    292634.94
```

## Sorted Set

Show a little bit of improvement for the insert case and seemingly little difference for the append case.

## Insert

### Script

```
./src/redis-cli flushall
./src/redis-cli zadd key 100000 a 200000 b 300000 c 400000 d 500000 e 600000 f
./src/redis-cli -p 5002 flushall
./src/redis-cli -p 5002 zadd key 100000 a 200000 b 300000 c 400000 d 500000 e 600000 f

echo UNSTABLE: && memtier_benchmark --command="zadd key __key__ c" --key-prefix="" --command-key-pattern=S --hide-histogram --key-minimum=300001 --test-time 180 --pipeline 10 | tail -n 2 | head -n 1
echo BATCH: && memtier_benchmark --command="zadd key __key__ c" --key-prefix="" --command-key-pattern=S --hide-histogram --key-minimum=300001 --test-time 180 --pipeline 10 --port 5002 | tail -n 2 | head -n 1
``` 

### Results

```
==================================================================================================
Type              Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Zadds-before      1249850.63         1.59968         1.59100         2.70300         3.39100     56606.65
Zadds-after       1287818.39         1.55250         1.53500         2.71900         3.31100     58349.31
```

## Append

### Script

```
./src/redis-cli flushall
./src/redis-cli zadd key 100000 a 200000 b 300000 c 400000 d 500000 e 600000 f
./src/redis-cli -p 5002 flushall
./src/redis-cli -p 5002 zadd key 100000 a 200000 b 300000 c 400000 d 500000 e 600000 f

echo UNSTABLE: && memtier_benchmark --command="zadd key __key__ c" --key-prefix="" --command-key-pattern=S --hide-histogram --key-minimum=600001 --test-time 180 --pipeline 10 | tail -n 2 | head -n 1
echo BATCH: && memtier_benchmark --command="zadd key __key__ c" --key-prefix="" --command-key-pattern=S --hide-histogram --key-minimum=600001 --test-time 180 --pipeline 10 --port 5002 | tail -n 2 | head -n 1
```

### Results

```
==================================================================================================
Type               Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Zadds-before       1249664.05         1.59991         1.58300         2.81500         3.40700     56923.61
Zadds-after        1258994.60         1.58803         1.56700         2.86300         3.37500     57351.86
```