### PR TITLE
docs: Overhaul README for clarity, structure, and usability

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -1,0 +1,327 @@
+Redis internals
+===
+
+If you are reading this README you are likely in front of a GitHub page
+or you just untarred the Redis distribution tar ball. In both the cases
+you are basically one step away from the source code, so here we explain
+the Redis source code layout, what is in each file as a general idea, the
+most important functions and structures inside the Redis server and so forth.
+We keep all the discussion at a high level without digging into the details
+since this document would be huge otherwise and our code base changes
+continuously, but a general idea should be a good starting point to
+understand more. Moreover most of the code is heavily commented and easy
+to follow.
+
+Source code layout
+---
+
+The Redis root directory just contains this README, the Makefile which
+calls the real Makefile inside the `src` directory and an example
+configuration for Redis and Redis Sentinel. You can find a few shell
+scripts that are used in order to execute the Redis, Redis Cluster and
+Redis Sentinel unit tests, which are implemented inside the `tests`
+directory.
+
+Inside the root are the following important directories:
+
+* `src`: contains the Redis implementation, written in C.
+* `tests`: contains the unit tests, implemented in Tcl.
+* `deps`: contains libraries Redis uses. Everything needed to compile Redis
+is inside this directory; your system just needs to provide `libc`, a POSIX
+compatible interface and a C compiler. Notably `deps` contains a copy of
+`jemalloc`, which is the default allocator of Redis under Linux. Note that
+under `deps` there are also things which started with the Redis project, but
+for which the main repository is not `redis/redis`.
+
+There are a few more directories but they are not very important for our goals
+here. We'll focus mostly on `src`, where the Redis implementation is contained,
+exploring what there is inside each file. The order in which files are
+exposed is the logical one to follow in order to disclose different layers
+of complexity incrementally.
+
+Note: lately Redis was refactored quite a bit. Function names and file
+names have been changed, so you may find that this documentation reflects the
+`unstable` branch more closely. For instance, in Redis 3.0 the `server.c`
+and `server.h` files were named `redis.c` and `redis.h`. However the overall
+structure is the same. Keep in mind that all the new developments and pull
+requests should be performed against the `unstable` branch.
+
+server.h
+---
+
+The simplest way to understand how a program works is to understand the
+data structures it uses. So we'll start from the main header file of
+Redis, which is `server.h`.
+
+All the server configuration and in general all the shared state is
+defined in a global structure called `server`, of type `struct redisServer`.
+A few important fields in this structure are:
+
+* `server.db` is an array of Redis databases, where data is stored.
+* `server.commands` is the command table.
+* `server.clients` is a linked list of clients connected to the server.
+* `server.master` is a special client, the master, if the instance is a replica.
+
+There are tons of other fields. Most fields are commented directly inside
+the structure definition.
+
+Another important Redis data structure is the one defining a client.
+In the past it was called `redisClient`, now just `client`. The structure
+has many fields, here we'll just show the main ones:
+```c
+struct client {
+    int fd;
+    sds querybuf;
+    int argc;
+    robj **argv;
+    redisDb *db;
+    int flags;
+    list *reply;
+    // ... many other fields ...
+    char buf[PROTO_REPLY_CHUNK_BYTES];
+}
+```
+The client structure defines a *connected client*:
+
+* The `fd` field is the client socket file descriptor.
+* `argc` and `argv` are populated with the command the client is executing,
+so that functions implementing a given Redis command can read the arguments.
+* `querybuf` accumulates the requests from the client, which are parsed by the
+Redis server according to the Redis protocol and executed by calling the
+implementations of the commands the client is executing.
+* `reply` and `buf` are dynamic and static buffers that accumulate the replies
+the server sends to the client. These buffers are incrementally written to the
+socket as soon as the file descriptor is writable.
+
+As you can see in the client structure above, arguments in a command
+are described as `robj` structures. The following is the full `robj`
+structure, which defines a *Redis object*:
+
+```c
+struct redisObject {
+    unsigned type:4;
+    unsigned encoding:4;
+    unsigned lru:LRU_BITS; /* LRU time (relative to global lru_clock) or
+                            * LFU data (least significant 8 bits frequency
+                            * and most significant 16 bits access time). */
+    int refcount;
+    void *ptr;
+};
+```
+
+Basically this structure can represent all the basic Redis data types like
+strings, lists, sets, sorted sets and so forth. The interesting thing is that
+it has a `type` field, so that it is possible to know what type a given
+object has, and a `refcount`, so that the same object can be referenced
+in multiple places without allocating it multiple times. Finally the `ptr`
+field points to the actual representation of the object, which might vary
+even for the same type, depending on the `encoding` used.
+
+Redis objects are used extensively in the Redis internals, however in order
+to avoid the overhead of indirect accesses, recently in many places
+we just use plain dynamic strings not wrapped inside a Redis object.
+
+server.c
+---
+
+This is the entry point of the Redis server, where the `main()` function
+is defined. The following are the most important steps in order to startup
+the Redis server.
+
+* `initServerConfig()` sets up the default values of the `server` structure.
+* `initServer()` allocates the data structures needed to operate, setup the
+listening socket, and so forth.
+* `aeMain()` starts the event loop which listens for new connections.
+
+There are two special functions called periodically by the event loop:
+
+1. `serverCron()` is called periodically (according to `server.hz` frequency),
+and performs tasks that must be performed from time to time, like checking for
+timed out clients.
+2. `beforeSleep()` is called every time the event loop fired, Redis served a
+few requests, and is returning back into the event loop.
+
+Inside server.c you can find code that handles other vital things of the Redis
+server:
+
+* `call()` is used in order to call a given command in the context of a given
+client.
+* `activeExpireCycle()` handles eviction of keys with a time to live set via
+the `EXPIRE` command.
+* `performEvictions()` is called when a new write command should be performed
+but Redis is out of memory according to the `maxmemory` directive.
+* The global variable `redisCommandTable` defines all the Redis commands,
+specifying the name of the command, the function implementing the command, the
+number of arguments required, and other properties of each command.
+
+commands.c
+---
+This file is auto generated by utils/generate-command-code.py, the content is
+based on the JSON files in the src/commands folder.
+These are meant to be the single source of truth about the Redis commands, and
+all the metadata about them.
+These JSON files are not meant to be used by anyone directly, instead that
+metadata can be obtained via the `COMMAND` command.
+
+networking.c
+---
+
+This file defines all the I/O functions with clients, masters and replicas
+(which in Redis are just special clients):
+
+* `createClient()` allocates and initializes a new client.
+* The `addReply*()` family of functions are used by command implementations in
+order to append data to the client structure, that will be transmitted to the
+client as a reply for a given command executed.
+* `writeToClient()` transmits the data pending in the output buffers to the
+client and is called by the *writable event handler* `sendReplyToClient()`.
+* `readQueryFromClient()` is the *readable event handler* and accumulates data
+read from the client into the query buffer.
+* `processInputBuffer()` is the entry point in order to parse the client query
+buffer according to the Redis protocol. Once commands are ready to be processed,
+it calls `processCommand()` which is defined inside `server.c` in order to
+actually execute the command.
+* `freeClient()` deallocates, disconnects and removes a client.
+
+aof.c and rdb.c
+---
+
+As you can guess from the names, these files implement the RDB and AOF
+persistence for Redis. Redis uses a persistence model based on the `fork()`
+system call in order to create a process with the same (shared) memory
+content of the main Redis process. This secondary process dumps the content
+of the memory on disk. This is used by `rdb.c` to create the snapshots
+on disk and by `aof.c` in order to perform the AOF rewrite when the
+append only file gets too big.
+
+The implementation inside `aof.c` has additional functions in order to
+implement an API that allows commands to append new commands into the AOF
+file as clients execute them.
+
+The `call()` function defined inside `server.c` is responsible for calling
+the functions that in turn will write the commands into the AOF.
+
+db.c
+---
+
+Certain Redis commands operate on specific data types; others are general.
+Examples of generic commands are `DEL` and `EXPIRE`. They operate on keys
+and not on their values specifically. All those generic commands are
+defined inside `db.c`.
+
+Moreover `db.c` implements an API in order to perform certain operations
+on the Redis dataset without directly accessing the internal data structures.
+
+The most important functions inside `db.c` which are used in many command
+implementations are the following:
+
+* `lookupKeyRead()` and `lookupKeyWrite()` are used in order to get a pointer
+to the value associated to a given key, or `NULL` if the key does not exist.
+* `dbAdd()` and its higher level counterpart `setKey()` create a new key in a
+Redis database.
+* `dbDelete()` removes a key and its associated value.
+* `emptyData()` removes an entire single database or all the databases defined.
+
+The rest of the file implements the generic commands exposed to the client.
+
+object.c
+---
+
+The `robj` structure defining Redis objects was already described. Inside
+`object.c` there are all the functions that operate with Redis objects at
+a basic level, like functions to allocate new objects, handle the reference
+counting and so forth. Notable functions inside this file:
+
+* `incrRefCount()` and `decrRefCount()` are used in order to increment or
+decrement an object reference count. When it drops to 0 the object is finally
+freed.
+* `createObject()` allocates a new object. There are also specialized functions
+to allocate string objects having a specific content, like
+`createStringObjectFromLongLong()` and similar functions.
+
+This file also implements the `OBJECT` command.
+
+replication.c
+---
+
+This is one of the most complex files inside Redis, it is recommended to
+approach it only after getting a bit familiar with the rest of the code base.
+In this file there is the implementation of both the master and replica role
+of Redis.
+
+One of the most important functions inside this file is
+`replicationFeedSlaves()` that writes commands to the clients representing
+replica instances connected
+to our master, so that the replicas can get the writes performed by the clients:
+this way their data set will remain synchronized with the one in the master.
+
+This file also implements both the `SYNC` and `PSYNC` commands that are
+used in order to perform the first synchronization between masters and
+replicas, or to continue the replication after a disconnection.
+
+Script
+---
+
+The script unit is composed of 3 units:
+* `script.c` - integration of scripts with Redis (commands execution, set
+replication/resp, ...)
+* `script_lua.c` - responsible to execute Lua code, uses `script.c` to interact
+with Redis from within the Lua code.
+* `function_lua.c` - contains the Lua engine implementation, uses
+`script_lua.c` to execute the Lua code.
+* `functions.c` - contains Redis Functions implementation (`FUNCTION` command),
+uses `functions_lua.c` if the function it wants to invoke needs the Lua engine.
+* `eval.c` - contains the `eval` implementation using `script_lua.c` to invoke
+the Lua code.
+
+
+Other C files
+---
+
+* `t_hash.c`, `t_list.c`, `t_set.c`, `t_string.c`, `t_zset.c` and `t_stream.c`
+contains the implementation of the Redis data types. They implement both an API
+to access a given data type, and the client command implementations for these
+data types.
+* `ae.c` implements the Redis event loop, it's a self contained library which
+is simple to read and understand.
+* `sds.c` is the Redis string library, check https://github.com/antirez/sds for
+more information.
+* `anet.c` is a library to use POSIX networking in a simpler way compared to the
+raw interface exposed by the kernel.
+* `dict.c` is an implementation of a non-blocking hash table which rehashes
+incrementally.
+* `cluster.c` implements the Redis Cluster. Probably a good read only after
+being very familiar with the rest of the Redis code base. If you want to read
+`cluster.c` make sure to read the [Redis Cluster specification][4].
+
+[4]: https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/
+
+Anatomy of a Redis command
+---
+
+All the Redis commands are defined in the following way:
+
+```c
+void foobarCommand(client *c) {
+    printf("%s",c->argv[1]->ptr); /* Do something with the argument. */
+    addReply(c,shared.ok); /* Reply something to the client. */
+}
+```
+
+The command function is referenced by a JSON file, together with its metadata,
+see `commands.c` described above for details. The command flags are documented
+in the comment above the `struct redisCommand` in `server.h`. For other
+details, please refer to the `COMMAND` command.
+https://redis.io/commands/command/
+
+After the command operates in some way, it returns a reply to the client,
+usually using `addReply()` or a similar function defined inside `networking.c`.
+
+There are tons of command implementations inside the Redis source code
+that can serve as examples of actual commands implementations
+(e.g. pingCommand). Writing a few toy commands can be a good exercise to get
+familiar with the code base.
+
+There are also many other files not described here, but it is useless to
+cover everything. We just want to help you with the first steps.
+Eventually you'll find your way inside the Redis code base :-)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Automatically split your dataset among multiple nodes, continue operations
 when a subset of nodes fail or are unable to communicate with the rest of the
 cluster
 
-Finally, Redis has a wide range of [client libraries for most languages](https://redis.io/docs/latest/develop/clients/) 
+Finally, Redis has a wide range of [client libraries for most languages](https://redis.io/docs/latest/develop/clients/)
 so you can use Redis in your language of choice.
 
 Redis is often referred to as a *data structures* server. What this means is
@@ -125,8 +125,8 @@ memcached, where the operations are not just SETs and GETs, but operations that
 work with complex data types listed above.
 If you want to know more, this is a list of selected starting points:
 
-* The full list of Redis commands. https://redis.io/commands
-* The official Redis documentation. https://redis.io/docs
+* [**Full list of Redis commands**](https://redis.io/commands)
+* [**Official Redis documentation**](https://redis.io/docs)
 
 ### What is Redis Community Edition?
 
@@ -182,9 +182,9 @@ a wide variety of data management challenges.
 If you want to get up and running with Redis quickly without needing to build
 from source, use one of the following methods:
 
-* [Redis Cloud](https://cloud.redis.io/)
-* [Official Redis docker images](https://hub.docker.com/_/redis)
-* [Redis quick start guides](https://redis.io/docs/latest/develop/get-started/)
+* [**Redis Cloud**](https://cloud.redis.io/)
+* [**Official Redis docker images**](https://hub.docker.com/_/redis)
+* [**Redis quick start guides**](https://redis.io/docs/latest/develop/get-started/)
 
 ## Drivers
 
@@ -199,7 +199,7 @@ https://redis.io/docs/latest/develop/clients/)
 
 ## Cloud managed Redis
 
-[**Redis Cloud](https://redis.io/cloud/)
+[**Redis Cloud**](https://redis.io/cloud/)
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ database, cache, message broker, streaming engine, and vector store.
 and [CONTRIBUTING.md](./CONTRIBUTING.md)
 * Looking for detailed documentation? Navigate to [redis.io/docs](https://redis.io/docs/)
 
+## Table of contents
+
+- [Table of contents](#table-of-contents)
 - [What is Redis?](#what-is-redis)
   - [What is Redis Community Edition?](#what-is-redis-community-edition)
 - [Why use Redis?](#why-use-redis)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ and [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Table of contents
 
-- [Table of contents](#table-of-contents)
 - [What is Redis?](#what-is-redis)
   - [What is Redis Community Edition?](#what-is-redis-community-edition)
 - [Why use Redis?](#why-use-redis)
@@ -30,7 +29,7 @@ and [CONTRIBUTING.md](./CONTRIBUTING.md)
     - [Running Redis with TLS](#running-redis-with-tls)
   - [Playing with Redis](#playing-with-redis)
   - [Installing Redis](#installing-redis)
-  - [Code contributions](#code-contributions)
+- [Code contributions](#code-contributions)
 - [Redis Trademarks](#redis-trademarks)
 - [Redis internals](#redis-internals)
 
@@ -189,22 +188,22 @@ from source, use one of the following methods:
 
 ## Drivers
 
-Redis has client drivers for most programming languages:
-https://redis.io/docs/latest/develop/clients/
+Redis has [client drivers for most programming languages.](
+https://redis.io/docs/latest/develop/clients/)
 
 ## Learn Redis
 
-* **Documentation**: https://redis.io/docs/
-* **Developer Hub**: https://redis.io/learn/
-* **Redis University**: https://university.redis.io/
+* [**Official documentation**](https://redis.io/docs/)
+* [**Developer Hub**](https://redis.io/learn/)
+* [**Redis University**](https://university.redis.io/)
 
 ## Cloud managed Redis
 
-https://redis.io/cloud/
+[**Redis Cloud](https://redis.io/cloud/)
 
 ## Community
 
-https://redis.io/community/
+[**Redis Community Resources**](https://redis.io/community/)
 
 ## Building Redis From Source
 
@@ -431,7 +430,7 @@ system reboots.
 You'll be able to stop and start Redis using the script named
 `/etc/init.d/redis_<portnumber>`, for instance `/etc/init.d/redis_6379`.
 
-### Code contributions
+## Code contributions
 
 By contributing code to the Redis project in any form, including sending a pull
 request via GitHub, a code fragment or patch via private email or public

--- a/README.md
+++ b/README.md
@@ -42,71 +42,69 @@ in the class of NoSQL databases. It provides
 [data structures](https://redis.io/docs/latest/develop/data-types/)
 such as:
 
-* [strings](https://redis.io/docs/latest/develop/data-types/strings/): text,
+* [**strings**](https://redis.io/docs/latest/develop/data-types/strings/): text,
 serialized objects, or binary arrays used for caching, counters, and bitwise
 operations
-* [JSON](https://redis.io/docs/latest/develop/data-types/json/): nested JSON
+* [**JSON**](https://redis.io/docs/latest/develop/data-types/json/): nested JSON
 documents that are indexed and searchable using JSONPath expressions
-* [hashes](https://redis.io/docs/latest/develop/data-types/hashes/):
+* [**hashes**](https://redis.io/docs/latest/develop/data-types/hashes/):
 field-value maps used to represent basic objects and store groupings of
 key-value pairs
-* [lists](https://redis.io/docs/latest/develop/data-types/lists/): linked lists
+* [**lists**](https://redis.io/docs/latest/develop/data-types/lists/): linked lists
 of string values used as stacks and queues
-* [sets](https://redis.io/docs/latest/develop/data-types/sets/): unordered
+* [**sets**](https://redis.io/docs/latest/develop/data-types/sets/): unordered
 collection of unique strings used for tracking unique items, relations, and
 common set operations
-* [sorted sets](https://redis.io/docs/latest/develop/data-types/sorted-sets/):
+* [**sorted sets**](https://redis.io/docs/latest/develop/data-types/sorted-sets/):
 collection of unique strings ordered by an associated score used for
 leaderboards and rate limiters
-* [vector sets](https://redis.io/docs/latest/develop/data-types/vector-sets/):
+* [**vector sets**](https://redis.io/docs/latest/develop/data-types/vector-sets/):
 collection of vector strings used for semantic search, semantic caching,
 semantic routing, and Retrieval Augmented Generation (RAG)
-* [streams](https://redis.io/docs/latest/develop/data-types/streams/):
+* [**streams**](https://redis.io/docs/latest/develop/data-types/streams/):
 append-only log with random access capabilities used for event sourcing,
 sensor monitoring, and notifications
-* [geospatial indexes](https://redis.io/docs/latest/develop/data-types/geospatial/):
+* [**geospatial indexes**](https://redis.io/docs/latest/develop/data-types/geospatial/):
 coordinates used for finding nearby points within a given radius or bounding box
-* [bitmaps](https://redis.io/docs/latest/develop/data-types/bitmaps/): a set of
+* [**bitmaps**](https://redis.io/docs/latest/develop/data-types/bitmaps/): a set of
 bit-oriented operations defined on the string type used for efficient set
 representations and object permissions
-* [bitfields](https://redis.io/docs/latest/develop/data-types/bitfields/):
+* [**bitfields**](https://redis.io/docs/latest/develop/data-types/bitfields/):
 binary-encoded strings the let you set, increment, and get integer values of
 arbitrary bit length used for counters and similar numeric values
-* [probabilistic structures](https://redis.io/docs/latest/develop/data-types/probabilistic/):
+* [**probabilistic structures**](https://redis.io/docs/latest/develop/data-types/probabilistic/):
 collection of structures that give approximations of statistics such as counts,
 frequencies, and rankings useful for efficient calculations when absolute
 precision is not needed
-* [time series](https://redis.io/docs/latest/develop/data-types/timeseries/):
+* [**time series**](https://redis.io/docs/latest/develop/data-types/timeseries/):
 data points indexed in time order used for monitoring sensor data, asset
 tracking, and predictive analytics
 
 Redis also offers a number of built-in features that are natural to find in a
 database:
 
-* [replication](https://redis.io/topics/replication): high availability and
+* [**replication**](https://redis.io/topics/replication): high availability and
 failover with exact-copy replicas
-* [Lua scripting](https://redis.io/docs/latest/commands/eval/): enables running
+* [**Lua scripting**](https://redis.io/docs/latest/commands/eval/): enables running
 server-side scripts for lowest-latency operations and atomicity
-* [eviction](https://redis.io/docs/latest/develop/reference/eviction/): LRU,
+* [**eviction**](https://redis.io/docs/latest/develop/reference/eviction/): LRU,
 LFU, TTL, and random data eviction policies to manage memory usage and data
 expiration
-* [transactions](https://redis.io/docs/latest/develop/interact/transactions/):
+* [**transactions**](https://redis.io/docs/latest/develop/interact/transactions/):
 group commands in a single step guaranteeing serialization, sequential
 execution, and recoverability
-* [on-disk persistence](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/):
+* [**on-disk persistence**](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/):
 write data to durable storage such as SSDs using a range of persistence options
-* [high
-availability (Redis Sentinel)](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/):
+* [**high availability (Redis Sentinel)**](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/):
 monitoring, notifications, automatic failover, and configuration providing for
 high availability when not using Redis Cluster
-* [partitioning/clustering (Redis Cluster)](https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/):
+* [**partitioning/clustering (Redis Cluster)**](https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/):
 Automatically split your dataset among multiple nodes, continue operations
 when a subset of nodes fail or are unable to communicate with the rest of the
 cluster
 
-Finally, Redis has a wide range of [client libraries for most
-languages](https://redis.io/docs/latest/develop/clients/) so you can use Redis
-in your language of choice.
+Finally, Redis has a wide range of [client libraries for most languages](https://redis.io/docs/latest/develop/clients/) 
+so you can use Redis in your language of choice.
 
 Redis is often referred to as a *data structures* server. What this means is
 that Redis provides access to mutable data structures via a set of commands,
@@ -136,9 +134,9 @@ If you want to know more, this is a list of selected starting points:
 Redis OSS was renamed Redis Community Edition (CE) with the v7.4 release. Other
 Redis variants include:
 
-* [Redis Software](https://redis.io/software/): a self-managed software with
+* [**Redis Software**](https://redis.io/software/): a self-managed software with
 additional compliance, reliability, and resiliency for enterprise scaling
-* [Redis Cloud](https://redis.io/cloud/): a fully
+* [**Redis Cloud**](https://redis.io/cloud/): a fully
 managed service integrated with Google Cloud, Azure, and AWS for
 production-ready apps.
 
@@ -150,31 +148,31 @@ Redis is a popular choice for developers worldwide due to its combination of
 speed, flexibility, and rich feature set. Here's why you might choose Redis for
 either an existing project or your next project:
 
-* Performance: Because Redis keeps data primarily in memory and uses efficient
+* **Performance**: Because Redis keeps data primarily in memory and uses efficient
 data structures, it achieves extremely low latency (often sub-millisecond) for
 both read and write operations. This makes it ideal for applications demanding
 real-time responsiveness.
-* Flexibility: Redis isn't just a key-value store, it provides native support
+* **Flexibility**: Redis isn't just a key-value store, it provides native support
 for a wide range of data structures and capabilities listed in
 [What is Redis?](#what-is-redis)
-* Extensibility: Redis is not limited to the built-in data structures, it has a
+* **Extensibility**: Redis is not limited to the built-in data structures, it has a
 [modules API](https://redis.io/docs/latest/develop/reference/modules/) that
 makes it possible to extend Redis functionality and rapidly implement new
 Redis commands
-* Simplicity: Redis has a simple, text-based protocol and
+* **Simplicity**: Redis has a simple, text-based protocol and
 [well-documented command set](https://redis.io/docs/latest/commands/)
-* Ubiquity: Redis is battle tested in production workloads at a massive scale.
+* **Ubiquity**: Redis is battle tested in production workloads at a massive scale.
 There is a good chance you indirectly interact with Redis several times daily
 * Versatility: Redis is the de facto standard for use cases such as:
-  * Caching: quickly access frequently used data without needing to query your
+  * **Caching**: quickly access frequently used data without needing to query your
   primary database
-  * Session management: read and write user session data without hurting user
+  * **Session management**: read and write user session data without hurting user
   experience or slowing down every API call
-  * Querying, sorting, and analytics: perform deduplication, full text search,
+  * **Querying, sorting, and analytics**: perform deduplication, full text search,
   and secondary indexing on in-memory data as fast as possible
-  * Messaging and interservice communication: job queues, message brokering,
+  * **Messaging and interservice communication**: job queues, message brokering,
   pub/sub, and streams for communicating between services
-  * Vector database: Long-term and short-term LLM memory, RAG content retrieval,
+  * **Vector operations**: Long-term and short-term LLM memory, RAG content retrieval,
   semantic caching, semantic routing, and vector similarity search
 
 In summary, Redis provides a powerful, fast, and flexible toolkit for solving
@@ -196,9 +194,9 @@ https://redis.io/docs/latest/develop/clients/
 
 ## Learn Redis
 
-* Documentation - https://redis.io/docs/
-* Developer Hub - https://redis.io/learn/
-* Redis University - https://university.redis.io/
+* **Documentation**: https://redis.io/docs/
+* **Developer Hub**: https://redis.io/learn/
+* **Redis University**: https://university.redis.io/
 
 ## Cloud managed Redis
 

--- a/README.md
+++ b/README.md
@@ -1,39 +1,89 @@
 [![codecov](https://codecov.io/github/redis/redis/graph/badge.svg?token=6bVHb5fRuz)](https://codecov.io/github/redis/redis)
 
-This README is just a fast *quick start* document. You can find more detailed documentation at [redis.io](https://redis.io).
+This README is a fast *quick start* document. You can find more detailed
+documentation at [redis.io](https://redis.io/docs).
 
 What is Redis?
 ---
 
-Redis is often referred to as a *data structures* server. What this means is that Redis provides access to mutable data structures via a set of commands, which are sent using a *server-client* model with TCP sockets and a simple protocol. So different processes can query and modify the same data structures in a shared way.
+Redis is an **in-memory key-value database** in the class of NoSQL databases.
+It provides [data structures](https://redis.io/docs/latest/develop/data-types/)
+such as:
 
-Data structures implemented into Redis have a few special properties:
+* [strings](https://redis.io/docs/latest/develop/data-types/strings/)
+* [JSON](https://redis.io/docs/latest/develop/data-types/json/)
+* [hashes](https://redis.io/docs/latest/develop/data-types/hashes/)
+* [lists](https://redis.io/docs/latest/develop/data-types/lists/)
+* [sets](https://redis.io/docs/latest/develop/data-types/sets/)
+* [sorted sets](https://redis.io/docs/latest/develop/data-types/sorted-sets/)
+* [vector sets](https://redis.io/docs/latest/develop/data-types/vector-sets/)
+* [streams](https://redis.io/docs/latest/develop/data-types/streams/)
+* [geospatial indexes](https://redis.io/docs/latest/develop/data-types/geospatial/)
+* [bitmaps](https://redis.io/docs/latest/develop/data-types/bitmaps/)
+* [bitfields](https://redis.io/docs/latest/develop/data-types/bitfields/)
+* [probabilistic structures](https://redis.io/docs/latest/develop/data-types/probabilistic/)
+* [time series](https://redis.io/docs/latest/develop/data-types/timeseries/)
 
-* Redis cares to store them on disk, even if they are always served and modified into the server memory. This means that Redis is fast, but that it is also non-volatile.
-* The implementation of data structures emphasizes memory efficiency, so data structures inside Redis will likely use less memory compared to the same data structure modelled using a high-level programming language.
-* Redis offers a number of features that are natural to find in a database, like replication, tunable levels of durability, clustering, and high availability.
+Redis also offers a number of built-in features that are natural to find in a
+database:
 
-Another good example is to think of Redis as a more complex version of memcached, where the operations are not just SETs and GETs, but operations that work with complex data types like Lists, Sets, ordered data structures, and so forth.
+* [replication](https://redis.io/topics/replication)
+* [Lua scripting](https://redis.io/docs/latest/commands/eval/)
+* [eviction](https://redis.io/docs/latest/develop/reference/eviction/)
+* [transactions](https://redis.io/docs/latest/develop/interact/transactions/)
+* [on-disk persistence](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/)
+* [high
+availability](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/)
+* [partitioning/clustering](https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/)
 
+Finally, Redis has a wide range of [client libraries for most
+languages](https://redis.io/docs/latest/develop/clients/) so you can use Redis
+in your language of choice.
+
+Redis is often referred to as a *data structures* server. What this means is
+that Redis provides access to mutable data structures via a set of commands,
+which are sent using a *server-client* model with TCP sockets and a simple
+protocol. So different processes can query and modify the same data structures
+in a shared way.
+
+Data structures implemented into Redis have a couple special properties:
+
+* Redis cares to store them on disk, even if they are always served and
+modified into the server memory. This means that Redis is fast, but that it is
+also non-volatile.
+* The implementation of data structures emphasizes memory efficiency, so data
+structures inside Redis will likely use less memory compared to the same data
+structure modelled using a high-level programming language.
+
+Another good example is to think of Redis as a more complex version of
+memcached, where the operations are not just SETs and GETs, but operations that
+work with complex data types listed above.
 If you want to know more, this is a list of selected starting points:
 
-* Introduction to Redis data types. https://redis.io/docs/latest/develop/data-types/
-
 * The full list of Redis commands. https://redis.io/commands
-* There is much more inside the official Redis documentation. https://redis.io/documentation
+* The official Redis documentation. https://redis.io/docs
 
 What is Redis Community Edition?
 ---
 
 Redis OSS was renamed Redis Community Edition (CE) with the v7.4 release.
 
-Redis Ltd. also offers [Redis Software](https://redis.io/enterprise/), a self-managed software with additional compliance, reliability, and resiliency for enterprise scaling,
-and [Redis Cloud](https://redis.io/cloud/), a fully managed service integrated with Google Cloud, Azure, and AWS for production-ready apps.
+Redis Ltd. also offers [Redis Software](https://redis.io/software/), a
+self-managed software with additional compliance, reliability, and resiliency
+for enterprise scaling, and [Redis Cloud](https://redis.io/cloud/), a fully
+managed service integrated with Google Cloud, Azure, and AWS for
+production-ready apps.
 
-Read more about the differences between Redis Community Edition and Redis [here](https://redis.io/comparisons/oss-vs-enterprise/).
+Read more about the differences between Redis Community Edition and
+Redis [here](https://redis.io/compare/community-edition/).
 
 Building Redis
 ---
+
+This section refers to building Redis from source. If you want to get up and
+running with Redis quickly without needing to build from source you can find
+the [quick start guides](https://redis.io/docs/latest/develop/get-started/) on
+the official Redis docs site.
 
 Redis can be compiled and used on Linux, OSX, OpenBSD, NetBSD, FreeBSD.
 We support big endian and little endian architectures, and both 32 bit
@@ -52,7 +102,7 @@ libssl-dev on Debian/Ubuntu) and run:
 
     % make BUILD_TLS=yes
 
-To build with systemd support, you'll need systemd development libraries (such 
+To build with systemd support, you'll need systemd development libraries (such
 as libsystemd-dev on Debian/Ubuntu or systemd-devel on CentOS) and run:
 
     % make USE_SYSTEMD=yes
@@ -132,7 +182,7 @@ Monotonic clock
 
 By default, Redis will build using the POSIX clock_gettime function as the
 monotonic clock source.  On most modern systems, the internal processor clock
-can be used to improve performance.  Cautions can be found here: 
+can be used to improve performance.  Cautions can be found here:
     http://oliveryang.net/2015/09/pitfalls-of-TSC-usage/
 
 To build with support for the processor's internal instruction clock, use:
@@ -229,16 +279,20 @@ You'll be able to stop and start Redis using the script named
 Code contributions
 ---
 
-By contributing code to the Redis project in any form, including sending a pull request via GitHub,
-a code fragment or patch via private email or public discussion groups, you agree to release your
-code under the terms of the [Redis Software Grant and Contributor License Agreement][1]. Redis software
-contains contributions to the original Redis core project, which are owned by their contributors and
-licensed under the 3BSD license. Any copy of that license in this repository applies only to those
-contributions. Redis releases all Redis Community Edition versions from 7.4.x and thereafter under the
-RSALv2/SSPL dual-license as described in the [LICENSE.txt][2] file included in the Redis Community Edition source distribution.
+By contributing code to the Redis project in any form, including sending a pull
+request via GitHub, a code fragment or patch via private email or public
+discussion groups, you agree to release your code under the terms of the
+[Redis Software Grant and Contributor License Agreement][1]. Redis software
+contains contributions to the original Redis core project, which are owned by
+their contributors and licensed under the 3BSD license. Any copy of that
+license in this repository applies only to those contributions. Redis releases
+all Redis Community Edition versions from 7.4.x and thereafter under the
+RSALv2/SSPL dual-license as described in the [LICENSE.txt][2] file included in
+the Redis Community Edition source distribution.
 
-Please see the [CONTRIBUTING.md][1] file in this source distribution for more information. For
-security bugs and vulnerabilities, please see [SECURITY.md][3].
+Please see the [CONTRIBUTING.md][1] file in this source distribution for more
+information. For security bugs and vulnerabilities, please see
+[SECURITY.md][3].
 
 [1]: https://github.com/redis/redis/blob/unstable/CONTRIBUTING.md
 [2]: https://github.com/redis/redis/blob/unstable/LICENSE.txt
@@ -247,10 +301,11 @@ security bugs and vulnerabilities, please see [SECURITY.md][3].
 Redis Trademarks
 ---
 
-The purpose of a trademark is to identify the goods and services of a person or company without
-causing confusion. As the registered owner of its name and logo, Redis accepts certain limited uses
-of its trademarks but it has requirements that must be followed as described in its Trademark
-Guidelines available at: https://redis.com/legal/trademark-guidelines/.
+The purpose of a trademark is to identify the goods and services of a person
+or company without causing confusion. As the registered owner of its name and
+logo, Redis accepts certain limited uses of its trademarks but it has
+requirements that must be followed as described in its Trademark Guidelines
+available at: https://redis.com/legal/trademark-guidelines/.
 
 Redis internals
 ===
@@ -280,7 +335,12 @@ Inside the root are the following important directories:
 
 * `src`: contains the Redis implementation, written in C.
 * `tests`: contains the unit tests, implemented in Tcl.
-* `deps`: contains libraries Redis uses. Everything needed to compile Redis is inside this directory; your system just needs to provide `libc`, a POSIX compatible interface and a C compiler. Notably `deps` contains a copy of `jemalloc`, which is the default allocator of Redis under Linux. Note that under `deps` there are also things which started with the Redis project, but for which the main repository is not `redis/redis`.
+* `deps`: contains libraries Redis uses. Everything needed to compile Redis
+is inside this directory; your system just needs to provide `libc`, a POSIX
+compatible interface and a C compiler. Notably `deps` contains a copy of
+`jemalloc`, which is the default allocator of Redis under Linux. Note that
+under `deps` there are also things which started with the Redis project, but
+for which the main repository is not `redis/redis`.
 
 There are a few more directories but they are not very important for our goals
 here. We'll focus mostly on `src`, where the Redis implementation is contained,
@@ -333,9 +393,14 @@ struct client {
 The client structure defines a *connected client*:
 
 * The `fd` field is the client socket file descriptor.
-* `argc` and `argv` are populated with the command the client is executing, so that functions implementing a given Redis command can read the arguments.
-* `querybuf` accumulates the requests from the client, which are parsed by the Redis server according to the Redis protocol and executed by calling the implementations of the commands the client is executing.
-* `reply` and `buf` are dynamic and static buffers that accumulate the replies the server sends to the client. These buffers are incrementally written to the socket as soon as the file descriptor is writable.
+* `argc` and `argv` are populated with the command the client is executing,
+so that functions implementing a given Redis command can read the arguments.
+* `querybuf` accumulates the requests from the client, which are parsed by the
+Redis server according to the Redis protocol and executed by calling the
+implementations of the commands the client is executing.
+* `reply` and `buf` are dynamic and static buffers that accumulate the replies
+the server sends to the client. These buffers are incrementally written to the
+socket as soon as the file descriptor is writable.
 
 As you can see in the client structure above, arguments in a command
 are described as `robj` structures. The following is the full `robj`
@@ -373,26 +438,39 @@ is defined. The following are the most important steps in order to startup
 the Redis server.
 
 * `initServerConfig()` sets up the default values of the `server` structure.
-* `initServer()` allocates the data structures needed to operate, setup the listening socket, and so forth.
+* `initServer()` allocates the data structures needed to operate, setup the
+listening socket, and so forth.
 * `aeMain()` starts the event loop which listens for new connections.
 
 There are two special functions called periodically by the event loop:
 
-1. `serverCron()` is called periodically (according to `server.hz` frequency), and performs tasks that must be performed from time to time, like checking for timed out clients.
-2. `beforeSleep()` is called every time the event loop fired, Redis served a few requests, and is returning back into the event loop.
+1. `serverCron()` is called periodically (according to `server.hz` frequency),
+and performs tasks that must be performed from time to time, like checking for
+timed out clients.
+2. `beforeSleep()` is called every time the event loop fired, Redis served a
+few requests, and is returning back into the event loop.
 
-Inside server.c you can find code that handles other vital things of the Redis server:
+Inside server.c you can find code that handles other vital things of the Redis
+server:
 
-* `call()` is used in order to call a given command in the context of a given client.
-* `activeExpireCycle()` handles eviction of keys with a time to live set via the `EXPIRE` command.
-* `performEvictions()` is called when a new write command should be performed but Redis is out of memory according to the `maxmemory` directive.
-* The global variable `redisCommandTable` defines all the Redis commands, specifying the name of the command, the function implementing the command, the number of arguments required, and other properties of each command.
+* `call()` is used in order to call a given command in the context of a given
+client.
+* `activeExpireCycle()` handles eviction of keys with a time to live set via
+the `EXPIRE` command.
+* `performEvictions()` is called when a new write command should be performed
+but Redis is out of memory according to the `maxmemory` directive.
+* The global variable `redisCommandTable` defines all the Redis commands,
+specifying the name of the command, the function implementing the command, the
+number of arguments required, and other properties of each command.
 
 commands.c
 ---
-This file is auto generated by utils/generate-command-code.py, the content is based on the JSON files in the src/commands folder.
-These are meant to be the single source of truth about the Redis commands, and all the metadata about them.
-These JSON files are not meant to be used by anyone directly, instead that metadata can be obtained via the `COMMAND` command.
+This file is auto generated by utils/generate-command-code.py, the content is
+based on the JSON files in the src/commands folder.
+These are meant to be the single source of truth about the Redis commands, and
+all the metadata about them.
+These JSON files are not meant to be used by anyone directly, instead that
+metadata can be obtained via the `COMMAND` command.
 
 networking.c
 ---
@@ -401,10 +479,17 @@ This file defines all the I/O functions with clients, masters and replicas
 (which in Redis are just special clients):
 
 * `createClient()` allocates and initializes a new client.
-* The `addReply*()` family of functions are used by command implementations in order to append data to the client structure, that will be transmitted to the client as a reply for a given command executed.
-* `writeToClient()` transmits the data pending in the output buffers to the client and is called by the *writable event handler* `sendReplyToClient()`.
-* `readQueryFromClient()` is the *readable event handler* and accumulates data read from the client into the query buffer.
-* `processInputBuffer()` is the entry point in order to parse the client query buffer according to the Redis protocol. Once commands are ready to be processed, it calls `processCommand()` which is defined inside `server.c` in order to actually execute the command.
+* The `addReply*()` family of functions are used by command implementations in
+order to append data to the client structure, that will be transmitted to the
+client as a reply for a given command executed.
+* `writeToClient()` transmits the data pending in the output buffers to the
+client and is called by the *writable event handler* `sendReplyToClient()`.
+* `readQueryFromClient()` is the *readable event handler* and accumulates data
+read from the client into the query buffer.
+* `processInputBuffer()` is the entry point in order to parse the client query
+buffer according to the Redis protocol. Once commands are ready to be processed,
+it calls `processCommand()` which is defined inside `server.c` in order to
+actually execute the command.
 * `freeClient()` deallocates, disconnects and removes a client.
 
 aof.c and rdb.c
@@ -439,8 +524,10 @@ on the Redis dataset without directly accessing the internal data structures.
 The most important functions inside `db.c` which are used in many command
 implementations are the following:
 
-* `lookupKeyRead()` and `lookupKeyWrite()` are used in order to get a pointer to the value associated to a given key, or `NULL` if the key does not exist.
-* `dbAdd()` and its higher level counterpart `setKey()` create a new key in a Redis database.
+* `lookupKeyRead()` and `lookupKeyWrite()` are used in order to get a pointer
+to the value associated to a given key, or `NULL` if the key does not exist.
+* `dbAdd()` and its higher level counterpart `setKey()` create a new key in a
+Redis database.
 * `dbDelete()` removes a key and its associated value.
 * `emptyData()` removes an entire single database or all the databases defined.
 
@@ -454,8 +541,12 @@ The `robj` structure defining Redis objects was already described. Inside
 a basic level, like functions to allocate new objects, handle the reference
 counting and so forth. Notable functions inside this file:
 
-* `incrRefCount()` and `decrRefCount()` are used in order to increment or decrement an object reference count. When it drops to 0 the object is finally freed.
-* `createObject()` allocates a new object. There are also specialized functions to allocate string objects having a specific content, like `createStringObjectFromLongLong()` and similar functions.
+* `incrRefCount()` and `decrRefCount()` are used in order to increment or
+decrement an object reference count. When it drops to 0 the object is finally
+freed.
+* `createObject()` allocates a new object. There are also specialized functions
+to allocate string objects having a specific content, like
+`createStringObjectFromLongLong()` and similar functions.
 
 This file also implements the `OBJECT` command.
 
@@ -467,7 +558,9 @@ approach it only after getting a bit familiar with the rest of the code base.
 In this file there is the implementation of both the master and replica role
 of Redis.
 
-One of the most important functions inside this file is `replicationFeedSlaves()` that writes commands to the clients representing replica instances connected
+One of the most important functions inside this file is
+`replicationFeedSlaves()` that writes commands to the clients representing
+replica instances connected
 to our master, so that the replicas can get the writes performed by the clients:
 this way their data set will remain synchronized with the one in the master.
 
@@ -479,22 +572,36 @@ Script
 ---
 
 The script unit is composed of 3 units:
-* `script.c` - integration of scripts with Redis (commands execution, set replication/resp, ...)
-* `script_lua.c` - responsible to execute Lua code, uses `script.c` to interact with Redis from within the Lua code.
-* `function_lua.c` - contains the Lua engine implementation, uses `script_lua.c` to execute the Lua code.
-* `functions.c` - contains Redis Functions implementation (`FUNCTION` command), uses `functions_lua.c` if the function it wants to invoke needs the Lua engine.
-* `eval.c` - contains the `eval` implementation using `script_lua.c` to invoke the Lua code.
+* `script.c` - integration of scripts with Redis (commands execution, set
+replication/resp, ...)
+* `script_lua.c` - responsible to execute Lua code, uses `script.c` to interact
+with Redis from within the Lua code.
+* `function_lua.c` - contains the Lua engine implementation, uses
+`script_lua.c` to execute the Lua code.
+* `functions.c` - contains Redis Functions implementation (`FUNCTION` command),
+uses `functions_lua.c` if the function it wants to invoke needs the Lua engine.
+* `eval.c` - contains the `eval` implementation using `script_lua.c` to invoke
+the Lua code.
 
 
 Other C files
 ---
 
-* `t_hash.c`, `t_list.c`, `t_set.c`, `t_string.c`, `t_zset.c` and `t_stream.c` contains the implementation of the Redis data types. They implement both an API to access a given data type, and the client command implementations for these data types.
-* `ae.c` implements the Redis event loop, it's a self contained library which is simple to read and understand.
-* `sds.c` is the Redis string library, check https://github.com/antirez/sds for more information.
-* `anet.c` is a library to use POSIX networking in a simpler way compared to the raw interface exposed by the kernel.
-* `dict.c` is an implementation of a non-blocking hash table which rehashes incrementally.
-* `cluster.c` implements the Redis Cluster. Probably a good read only after being very familiar with the rest of the Redis code base. If you want to read `cluster.c` make sure to read the [Redis Cluster specification][4].
+* `t_hash.c`, `t_list.c`, `t_set.c`, `t_string.c`, `t_zset.c` and `t_stream.c`
+contains the implementation of the Redis data types. They implement both an API
+to access a given data type, and the client command implementations for these
+data types.
+* `ae.c` implements the Redis event loop, it's a self contained library which
+is simple to read and understand.
+* `sds.c` is the Redis string library, check https://github.com/antirez/sds for
+more information.
+* `anet.c` is a library to use POSIX networking in a simpler way compared to the
+raw interface exposed by the kernel.
+* `dict.c` is an implementation of a non-blocking hash table which rehashes
+incrementally.
+* `cluster.c` implements the Redis Cluster. Probably a good read only after
+being very familiar with the rest of the Redis code base. If you want to read
+`cluster.c` make sure to read the [Redis Cluster specification][4].
 
 [4]: https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/
 
@@ -510,19 +617,46 @@ void foobarCommand(client *c) {
 }
 ```
 
-The command function is referenced by a JSON file, together with its metadata, see `commands.c` described above for details.
-The command flags are documented in the comment above the `struct redisCommand` in `server.h`.
-For other details, please refer to the `COMMAND` command. https://redis.io/commands/command/
+The command function is referenced by a JSON file, together with its metadata,
+see `commands.c` described above for details. The command flags are documented
+in the comment above the `struct redisCommand` in `server.h`. For other
+details, please refer to the `COMMAND` command.
+https://redis.io/commands/command/
 
 After the command operates in some way, it returns a reply to the client,
 usually using `addReply()` or a similar function defined inside `networking.c`.
 
 There are tons of command implementations inside the Redis source code
-that can serve as examples of actual commands implementations (e.g. pingCommand). Writing
-a few toy commands can be a good exercise to get familiar with the code base.
+that can serve as examples of actual commands implementations
+(e.g. pingCommand). Writing a few toy commands can be a good exercise to get
+familiar with the code base.
 
 There are also many other files not described here, but it is useless to
 cover everything. We just want to help you with the first steps.
 Eventually you'll find your way inside the Redis code base :-)
 
 Enjoy!
+
+Drivers
+===
+
+Redis has client drivers for most programming languages:
+https://redis.io/docs/latest/develop/clients/
+
+Learn Redis
+===
+
+* Documentation - https://redis.io/docs/
+* Developer Hub - https://redis.io/learn/
+* Redis University - https://university.redis.io/
+
+Redis Cloud
+===
+
+https://redis.io/cloud/
+
+Community
+===
+
+https://redis.io/community/
+

--- a/README.md
+++ b/README.md
@@ -1,40 +1,105 @@
 [![codecov](https://codecov.io/github/redis/redis/graph/badge.svg?token=6bVHb5fRuz)](https://codecov.io/github/redis/redis)
 
-This README is a fast *quick start* document. You can find more detailed
-documentation at [redis.io](https://redis.io/docs).
+Redis is an open-source, in-memory data structure store. People use Redis as a
+database, cache, message broker, streaming engine, and vector store.
 
-What is Redis?
----
+* New to Redis? Start with [What is Redis](#what-is-redis) and [Getting Started](#getting-started)
+* Ready to build from source? Jump to [Building Redis from Source](#building-redis-from-source)
+* Want to contribute? See the [Code contributions](#code-contributions) section
+and [CONTRIBUTING.md](./CONTRIBUTING.md)
+* Looking for detailed documentation? Navigate to [redis.io/docs](https://redis.io/docs/)
 
-Redis is an **in-memory key-value database** in the class of NoSQL databases.
-It provides [data structures](https://redis.io/docs/latest/develop/data-types/)
+- [What is Redis?](#what-is-redis)
+  - [What is Redis Community Edition?](#what-is-redis-community-edition)
+- [Why use Redis?](#why-use-redis)
+- [Getting Started](#getting-started)
+- [Drivers](#drivers)
+- [Learn Redis](#learn-redis)
+- [Cloud managed Redis](#cloud-managed-redis)
+- [Community](#community)
+- [Building Redis From Source](#building-redis-from-source)
+  - [Fixing build problems with dependencies or cached build options](#fixing-build-problems-with-dependencies-or-cached-build-options)
+  - [Fixing problems building 32 bit binaries](#fixing-problems-building-32-bit-binaries)
+  - [Allocator](#allocator)
+  - [Monotonic clock](#monotonic-clock)
+  - [Verbose build](#verbose-build)
+  - [Running Redis](#running-redis)
+    - [Running Redis with TLS](#running-redis-with-tls)
+  - [Playing with Redis](#playing-with-redis)
+  - [Installing Redis](#installing-redis)
+  - [Code contributions](#code-contributions)
+- [Redis Trademarks](#redis-trademarks)
+- [Redis internals](#redis-internals)
+
+## What is Redis?
+
+Redis is an **in-memory key-value database** (with
+[persistence](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/))
+in the class of NoSQL databases. It provides
+[data structures](https://redis.io/docs/latest/develop/data-types/)
 such as:
 
-* [strings](https://redis.io/docs/latest/develop/data-types/strings/)
-* [JSON](https://redis.io/docs/latest/develop/data-types/json/)
-* [hashes](https://redis.io/docs/latest/develop/data-types/hashes/)
-* [lists](https://redis.io/docs/latest/develop/data-types/lists/)
-* [sets](https://redis.io/docs/latest/develop/data-types/sets/)
-* [sorted sets](https://redis.io/docs/latest/develop/data-types/sorted-sets/)
-* [vector sets](https://redis.io/docs/latest/develop/data-types/vector-sets/)
-* [streams](https://redis.io/docs/latest/develop/data-types/streams/)
-* [geospatial indexes](https://redis.io/docs/latest/develop/data-types/geospatial/)
-* [bitmaps](https://redis.io/docs/latest/develop/data-types/bitmaps/)
-* [bitfields](https://redis.io/docs/latest/develop/data-types/bitfields/)
-* [probabilistic structures](https://redis.io/docs/latest/develop/data-types/probabilistic/)
-* [time series](https://redis.io/docs/latest/develop/data-types/timeseries/)
+* [strings](https://redis.io/docs/latest/develop/data-types/strings/): text,
+serialized objects, or binary arrays used for caching, counters, and bitwise
+operations
+* [JSON](https://redis.io/docs/latest/develop/data-types/json/): nested JSON
+documents that are indexed and searchable using JSONPath expressions
+* [hashes](https://redis.io/docs/latest/develop/data-types/hashes/):
+field-value maps used to represent basic objects and store groupings of
+key-value pairs
+* [lists](https://redis.io/docs/latest/develop/data-types/lists/): linked lists
+of string values used as stacks and queues
+* [sets](https://redis.io/docs/latest/develop/data-types/sets/): unordered
+collection of unique strings used for tracking unique items, relations, and
+common set operations
+* [sorted sets](https://redis.io/docs/latest/develop/data-types/sorted-sets/):
+collection of unique strings ordered by an associated score used for
+leaderboards and rate limiters
+* [vector sets](https://redis.io/docs/latest/develop/data-types/vector-sets/):
+collection of vector strings used for semantic search, semantic caching,
+semantic routing, and Retrieval Augmented Generation (RAG)
+* [streams](https://redis.io/docs/latest/develop/data-types/streams/):
+append-only log with random access capabilities used for event sourcing,
+sensor monitoring, and notifications
+* [geospatial indexes](https://redis.io/docs/latest/develop/data-types/geospatial/):
+coordinates used for finding nearby points within a given radius or bounding box
+* [bitmaps](https://redis.io/docs/latest/develop/data-types/bitmaps/): a set of
+bit-oriented operations defined on the string type used for efficient set
+representations and object permissions
+* [bitfields](https://redis.io/docs/latest/develop/data-types/bitfields/):
+binary-encoded strings the let you set, increment, and get integer values of
+arbitrary bit length used for counters and similar numeric values
+* [probabilistic structures](https://redis.io/docs/latest/develop/data-types/probabilistic/):
+collection of structures that give approximations of statistics such as counts,
+frequencies, and rankings useful for efficient calculations when absolute
+precision is not needed
+* [time series](https://redis.io/docs/latest/develop/data-types/timeseries/):
+data points indexed in time order used for monitoring sensor data, asset
+tracking, and predictive analytics
 
 Redis also offers a number of built-in features that are natural to find in a
 database:
 
-* [replication](https://redis.io/topics/replication)
-* [Lua scripting](https://redis.io/docs/latest/commands/eval/)
-* [eviction](https://redis.io/docs/latest/develop/reference/eviction/)
-* [transactions](https://redis.io/docs/latest/develop/interact/transactions/)
-* [on-disk persistence](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/)
+* [replication](https://redis.io/topics/replication): high availability and
+failover with exact-copy replicas
+* [Lua scripting](https://redis.io/docs/latest/commands/eval/): enables running
+server-side scripts for lowest-latency operations and atomicity
+* [eviction](https://redis.io/docs/latest/develop/reference/eviction/): LRU,
+LFU, TTL, and random data eviction policies to manage memory usage and data
+expiration
+* [transactions](https://redis.io/docs/latest/develop/interact/transactions/):
+group commands in a single step guaranteeing serialization, sequential
+execution, and recoverability
+* [on-disk persistence](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/):
+write data to durable storage such as SSDs using a range of persistence options
 * [high
-availability](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/)
-* [partitioning/clustering](https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/)
+availability (Redis Sentinel)](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/):
+monitoring, notifications, automatic failover, and configuration providing for
+high availability when not using Redis Cluster
+* [partitioning/clustering (Redis Cluster)](https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/):
+Automatically split your dataset among multiple nodes, continue operations
+when a subset of nodes fail or are unable to communicate with the rest of the
+cluster
 
 Finally, Redis has a wide range of [client libraries for most
 languages](https://redis.io/docs/latest/develop/clients/) so you can use Redis
@@ -63,22 +128,84 @@ If you want to know more, this is a list of selected starting points:
 * The full list of Redis commands. https://redis.io/commands
 * The official Redis documentation. https://redis.io/docs
 
-What is Redis Community Edition?
----
+### What is Redis Community Edition?
 
-Redis OSS was renamed Redis Community Edition (CE) with the v7.4 release.
+Redis OSS was renamed Redis Community Edition (CE) with the v7.4 release. Other
+Redis variants include:
 
-Redis Ltd. also offers [Redis Software](https://redis.io/software/), a
-self-managed software with additional compliance, reliability, and resiliency
-for enterprise scaling, and [Redis Cloud](https://redis.io/cloud/), a fully
+* [Redis Software](https://redis.io/software/): a self-managed software with
+additional compliance, reliability, and resiliency for enterprise scaling
+* [Redis Cloud](https://redis.io/cloud/): a fully
 managed service integrated with Google Cloud, Azure, and AWS for
 production-ready apps.
 
-Read more about the differences between Redis Community Edition and
-Redis [here](https://redis.io/compare/community-edition/).
+For more details, see [which Redis is right for you](https://redis.io/compare/community-edition/).
 
-Building Redis
----
+## Why use Redis?
+
+Redis is a popular choice for developers worldwide due to its combination of
+speed, flexibility, and rich feature set. Here's why you might choose Redis for
+either an existing project or your next project:
+
+* Performance: Because Redis keeps data primarily in memory and uses efficient
+data structures, it achieves extremely low latency (often sub-millisecond) for
+both read and write operations. This makes it ideal for applications demanding
+real-time responsiveness.
+* Flexibility: Redis isn't just a key-value store, it provides native support
+for a wide range of data structures and capabilities listed in
+[What is Redis?](#what-is-redis)
+* Extensibility: Redis is not limited to the built-in data structures, it has a
+[modules API](https://redis.io/docs/latest/develop/reference/modules/) that
+makes it possible to extend Redis functionality and rapidly implement new
+Redis commands
+* Simplicity: Redis has a simple, text-based protocol and
+[well-documented command set](https://redis.io/docs/latest/commands/)
+* Ubiquity: Redis is battle tested in production workloads at a massive scale.
+There is a good chance you indirectly interact with Redis several times daily
+* Versatility: Redis is the de facto standard for use cases such as:
+  * Caching: quickly access frequently used data without needing to query your
+  primary database
+  * Session management: read and write user session data without hurting user
+  experience or slowing down every API call
+  * Querying, sorting, and analytics: perform deduplication, full text search,
+  and secondary indexing on in-memory data as fast as possible
+  * Messaging and interservice communication: job queues, message brokering,
+  pub/sub, and streams for communicating between services
+  * Vector database: Long-term and short-term LLM memory, RAG content retrieval,
+  semantic caching, semantic routing, and vector similarity search
+
+In summary, Redis provides a powerful, fast, and flexible toolkit for solving
+a wide variety of data management challenges.
+
+## Getting Started
+
+If you want to get up and running with Redis quickly without needing to build
+from source, use one of the following methods:
+
+* [Redis Cloud](https://cloud.redis.io/)
+* [Official Redis docker images](https://hub.docker.com/_/redis)
+* [Redis quick start guides](https://redis.io/docs/latest/develop/get-started/)
+
+## Drivers
+
+Redis has client drivers for most programming languages:
+https://redis.io/docs/latest/develop/clients/
+
+## Learn Redis
+
+* Documentation - https://redis.io/docs/
+* Developer Hub - https://redis.io/learn/
+* Redis University - https://university.redis.io/
+
+## Cloud managed Redis
+
+https://redis.io/cloud/
+
+## Community
+
+https://redis.io/community/
+
+## Building Redis From Source
 
 This section refers to building Redis from source. If you want to get up and
 running with Redis quickly without needing to build from source you can find
@@ -87,47 +214,60 @@ the official Redis docs site.
 
 Redis can be compiled and used on Linux, OSX, OpenBSD, NetBSD, FreeBSD.
 We support big endian and little endian architectures, and both 32 bit
-and 64 bit systems.
+and 64-bit systems.
 
 It may compile on Solaris derived systems (for instance SmartOS) but our
 support for this platform is *best effort* and Redis is not guaranteed to
-work as well as in Linux, OSX, and \*BSD.
+work as well as on Linux, OSX, and \*BSD.
 
 It is as simple as:
 
-    % make
+```bash
+make
+```
 
 To build with TLS support, you'll need OpenSSL development libraries (e.g.
 libssl-dev on Debian/Ubuntu) and run:
 
-    % make BUILD_TLS=yes
+```bash
+make BUILD_TLS=yes
+```
 
 To build with systemd support, you'll need systemd development libraries (such
 as libsystemd-dev on Debian/Ubuntu or systemd-devel on CentOS) and run:
 
-    % make USE_SYSTEMD=yes
+```bash
+make USE_SYSTEMD=yes
+```
 
 To append a suffix to Redis program names, use:
 
-    % make PROG_SUFFIX="-alt"
+```bash
+make PROG_SUFFIX="-alt"
+```
 
 You can build a 32 bit Redis binary using:
 
-    % make 32bit
+```bash
+make 32bit
+```
 
 After building Redis, it is a good idea to test it using:
 
-    % make test
+```bash
+make test
+```
 
 If TLS is built, running the tests with TLS enabled (you will need `tcl-tls`
 installed):
 
-    % ./utils/gen-test-certs.sh
-    % ./runtest --tls
+```bash
+./utils/gen-test-certs.sh
+./runtest --tls
+```
 
 
-Fixing build problems with dependencies or cached build options
----
+### Fixing build problems with dependencies or cached build options
 
 Redis has some dependencies which are included in the `deps` directory.
 `make` does not automatically rebuild dependencies even if something in
@@ -137,17 +277,18 @@ When you update the source code with `git pull` or when code inside the
 dependencies tree is modified in any other way, make sure to use the following
 command in order to really clean everything and rebuild from scratch:
 
-    % make distclean
+```bash
+make distclean
+```
 
 This will clean: jemalloc, lua, hiredis, linenoise and other dependencies.
 
-Also if you force certain build options like 32bit target, no C compiler
+Also, if you force certain build options like 32bit target, no C compiler
 optimizations (for debugging purposes), and other similar build time options,
 those options are cached indefinitely until you issue a `make distclean`
 command.
 
-Fixing problems building 32 bit binaries
----
+### Fixing problems building 32 bit binaries
 
 If after building Redis with a 32 bit target you need to rebuild it
 with a 64 bit target, or the other way around, you need to perform a
@@ -160,25 +301,27 @@ the following steps:
 * Try using the following command line instead of `make 32bit`:
   `make CFLAGS="-m32 -march=native" LDFLAGS="-m32"`
 
-Allocator
----
+### Allocator
 
 Selecting a non-default memory allocator when building Redis is done by setting
 the `MALLOC` environment variable. Redis is compiled and linked against libc
-malloc by default, with the exception of jemalloc being the default on Linux
+malloc by default, except for jemalloc being the default on Linux
 systems. This default was picked because jemalloc has proven to have fewer
 fragmentation problems than libc malloc.
 
 To force compiling against libc malloc, use:
 
-    % make MALLOC=libc
+```bash
+make MALLOC=libc
+```
 
 To compile against jemalloc on Mac OS X systems, use:
 
-    % make MALLOC=jemalloc
+```bash
+make MALLOC=jemalloc
+```
 
-Monotonic clock
----
+### Monotonic clock
 
 By default, Redis will build using the POSIX clock_gettime function as the
 monotonic clock source.  On most modern systems, the internal processor clock
@@ -187,73 +330,82 @@ can be used to improve performance.  Cautions can be found here:
 
 To build with support for the processor's internal instruction clock, use:
 
-    % make CFLAGS="-DUSE_PROCESSOR_CLOCK"
+```bash
+make CFLAGS="-DUSE_PROCESSOR_CLOCK"
+```
 
-Verbose build
----
+### Verbose build
 
 Redis will build with a user-friendly colorized output by default.
 If you want to see a more verbose output, use the following:
 
-    % make V=1
+```bash
+make V=1
+```
 
-Running Redis
----
+### Running Redis
 
 To run Redis with the default configuration, just type:
 
-    % cd src
-    % ./redis-server
+```bash
+cd src
+./redis-server
+```
 
 If you want to provide your redis.conf, you have to run it using an additional
 parameter (the path of the configuration file):
 
-    % cd src
-    % ./redis-server /path/to/redis.conf
+```bash
+cd src
+./redis-server /path/to/redis.conf
+```
 
 It is possible to alter the Redis configuration by passing parameters directly
 as options using the command line. Examples:
 
-    % ./redis-server --port 9999 --replicaof 127.0.0.1 6379
-    % ./redis-server /etc/redis/6379.conf --loglevel debug
+```bash
+./redis-server --port 9999 --replicaof 127.0.0.1 6379
+./redis-server /etc/redis/6379.conf --loglevel debug
+```
 
 All the options in redis.conf are also supported as options using the command
 line, with exactly the same name.
 
-Running Redis with TLS
----
+#### Running Redis with TLS
 
 Please consult the [TLS.md](TLS.md) file for more information on
 how to use Redis with TLS.
 
-Playing with Redis
----
+### Playing with Redis
 
 You can use redis-cli to play with Redis. Start a redis-server instance,
 then in another terminal try the following:
 
-    % cd src
-    % ./redis-cli
-    redis> ping
-    PONG
-    redis> set foo bar
-    OK
-    redis> get foo
-    "bar"
-    redis> incr mycounter
-    (integer) 1
-    redis> incr mycounter
-    (integer) 2
-    redis>
+```bash
+cd src
+./redis-cli
+redis> ping
+PONG
+redis> set foo bar
+OK
+redis> get foo
+"bar"
+redis> incr mycounter
+(integer) 1
+redis> incr mycounter
+(integer) 2
+redis>
+```
 
 You can find the list of all the available commands at https://redis.io/commands.
 
-Installing Redis
----
+### Installing Redis
 
-In order to install Redis binaries into /usr/local/bin, just use:
+In order to install Redis binaries into `/usr/local/bin`, just use:
 
-    % make install
+```bash
+make install
+```
 
 You can use `make PREFIX=/some/other/directory install` if you wish to use a
 different destination.
@@ -264,20 +416,21 @@ needed if you just want to play a bit with Redis, but if you are installing
 it the proper way for a production system, we have a script that does this
 for Ubuntu and Debian systems:
 
-    % cd utils
-    % ./install_server.sh
+```bash
+cd utils
+./install_server.sh
+```
 
 _Note_: `install_server.sh` will not work on Mac OSX; it is built for Linux only.
 
-The script will ask you a few questions and will setup everything you need
+The script will ask you a few questions and will set up everything you need
 to run Redis properly as a background daemon that will start again on
 system reboots.
 
 You'll be able to stop and start Redis using the script named
 `/etc/init.d/redis_<portnumber>`, for instance `/etc/init.d/redis_6379`.
 
-Code contributions
----
+### Code contributions
 
 By contributing code to the Redis project in any form, including sending a pull
 request via GitHub, a code fragment or patch via private email or public
@@ -298,365 +451,17 @@ information. For security bugs and vulnerabilities, please see
 [2]: https://github.com/redis/redis/blob/unstable/LICENSE.txt
 [3]: https://github.com/redis/redis/blob/unstable/SECURITY.md
 
-Redis Trademarks
----
+## Redis Trademarks
 
 The purpose of a trademark is to identify the goods and services of a person
 or company without causing confusion. As the registered owner of its name and
-logo, Redis accepts certain limited uses of its trademarks but it has
+logo, Redis accepts certain limited uses of its trademarks, but it has
 requirements that must be followed as described in its Trademark Guidelines
 available at: https://redis.com/legal/trademark-guidelines/.
 
-Redis internals
-===
+## Redis internals
 
-If you are reading this README you are likely in front of a GitHub page
-or you just untarred the Redis distribution tar ball. In both the cases
-you are basically one step away from the source code, so here we explain
-the Redis source code layout, what is in each file as a general idea, the
-most important functions and structures inside the Redis server and so forth.
-We keep all the discussion at a high level without digging into the details
-since this document would be huge otherwise and our code base changes
-continuously, but a general idea should be a good starting point to
-understand more. Moreover most of the code is heavily commented and easy
-to follow.
-
-Source code layout
----
-
-The Redis root directory just contains this README, the Makefile which
-calls the real Makefile inside the `src` directory and an example
-configuration for Redis and Redis Sentinel. You can find a few shell
-scripts that are used in order to execute the Redis, Redis Cluster and
-Redis Sentinel unit tests, which are implemented inside the `tests`
-directory.
-
-Inside the root are the following important directories:
-
-* `src`: contains the Redis implementation, written in C.
-* `tests`: contains the unit tests, implemented in Tcl.
-* `deps`: contains libraries Redis uses. Everything needed to compile Redis
-is inside this directory; your system just needs to provide `libc`, a POSIX
-compatible interface and a C compiler. Notably `deps` contains a copy of
-`jemalloc`, which is the default allocator of Redis under Linux. Note that
-under `deps` there are also things which started with the Redis project, but
-for which the main repository is not `redis/redis`.
-
-There are a few more directories but they are not very important for our goals
-here. We'll focus mostly on `src`, where the Redis implementation is contained,
-exploring what there is inside each file. The order in which files are
-exposed is the logical one to follow in order to disclose different layers
-of complexity incrementally.
-
-Note: lately Redis was refactored quite a bit. Function names and file
-names have been changed, so you may find that this documentation reflects the
-`unstable` branch more closely. For instance, in Redis 3.0 the `server.c`
-and `server.h` files were named `redis.c` and `redis.h`. However the overall
-structure is the same. Keep in mind that all the new developments and pull
-requests should be performed against the `unstable` branch.
-
-server.h
----
-
-The simplest way to understand how a program works is to understand the
-data structures it uses. So we'll start from the main header file of
-Redis, which is `server.h`.
-
-All the server configuration and in general all the shared state is
-defined in a global structure called `server`, of type `struct redisServer`.
-A few important fields in this structure are:
-
-* `server.db` is an array of Redis databases, where data is stored.
-* `server.commands` is the command table.
-* `server.clients` is a linked list of clients connected to the server.
-* `server.master` is a special client, the master, if the instance is a replica.
-
-There are tons of other fields. Most fields are commented directly inside
-the structure definition.
-
-Another important Redis data structure is the one defining a client.
-In the past it was called `redisClient`, now just `client`. The structure
-has many fields, here we'll just show the main ones:
-```c
-struct client {
-    int fd;
-    sds querybuf;
-    int argc;
-    robj **argv;
-    redisDb *db;
-    int flags;
-    list *reply;
-    // ... many other fields ...
-    char buf[PROTO_REPLY_CHUNK_BYTES];
-}
-```
-The client structure defines a *connected client*:
-
-* The `fd` field is the client socket file descriptor.
-* `argc` and `argv` are populated with the command the client is executing,
-so that functions implementing a given Redis command can read the arguments.
-* `querybuf` accumulates the requests from the client, which are parsed by the
-Redis server according to the Redis protocol and executed by calling the
-implementations of the commands the client is executing.
-* `reply` and `buf` are dynamic and static buffers that accumulate the replies
-the server sends to the client. These buffers are incrementally written to the
-socket as soon as the file descriptor is writable.
-
-As you can see in the client structure above, arguments in a command
-are described as `robj` structures. The following is the full `robj`
-structure, which defines a *Redis object*:
-
-```c
-struct redisObject {
-    unsigned type:4;
-    unsigned encoding:4;
-    unsigned lru:LRU_BITS; /* LRU time (relative to global lru_clock) or
-                            * LFU data (least significant 8 bits frequency
-                            * and most significant 16 bits access time). */
-    int refcount;
-    void *ptr;
-};
-```
-
-Basically this structure can represent all the basic Redis data types like
-strings, lists, sets, sorted sets and so forth. The interesting thing is that
-it has a `type` field, so that it is possible to know what type a given
-object has, and a `refcount`, so that the same object can be referenced
-in multiple places without allocating it multiple times. Finally the `ptr`
-field points to the actual representation of the object, which might vary
-even for the same type, depending on the `encoding` used.
-
-Redis objects are used extensively in the Redis internals, however in order
-to avoid the overhead of indirect accesses, recently in many places
-we just use plain dynamic strings not wrapped inside a Redis object.
-
-server.c
----
-
-This is the entry point of the Redis server, where the `main()` function
-is defined. The following are the most important steps in order to startup
-the Redis server.
-
-* `initServerConfig()` sets up the default values of the `server` structure.
-* `initServer()` allocates the data structures needed to operate, setup the
-listening socket, and so forth.
-* `aeMain()` starts the event loop which listens for new connections.
-
-There are two special functions called periodically by the event loop:
-
-1. `serverCron()` is called periodically (according to `server.hz` frequency),
-and performs tasks that must be performed from time to time, like checking for
-timed out clients.
-2. `beforeSleep()` is called every time the event loop fired, Redis served a
-few requests, and is returning back into the event loop.
-
-Inside server.c you can find code that handles other vital things of the Redis
-server:
-
-* `call()` is used in order to call a given command in the context of a given
-client.
-* `activeExpireCycle()` handles eviction of keys with a time to live set via
-the `EXPIRE` command.
-* `performEvictions()` is called when a new write command should be performed
-but Redis is out of memory according to the `maxmemory` directive.
-* The global variable `redisCommandTable` defines all the Redis commands,
-specifying the name of the command, the function implementing the command, the
-number of arguments required, and other properties of each command.
-
-commands.c
----
-This file is auto generated by utils/generate-command-code.py, the content is
-based on the JSON files in the src/commands folder.
-These are meant to be the single source of truth about the Redis commands, and
-all the metadata about them.
-These JSON files are not meant to be used by anyone directly, instead that
-metadata can be obtained via the `COMMAND` command.
-
-networking.c
----
-
-This file defines all the I/O functions with clients, masters and replicas
-(which in Redis are just special clients):
-
-* `createClient()` allocates and initializes a new client.
-* The `addReply*()` family of functions are used by command implementations in
-order to append data to the client structure, that will be transmitted to the
-client as a reply for a given command executed.
-* `writeToClient()` transmits the data pending in the output buffers to the
-client and is called by the *writable event handler* `sendReplyToClient()`.
-* `readQueryFromClient()` is the *readable event handler* and accumulates data
-read from the client into the query buffer.
-* `processInputBuffer()` is the entry point in order to parse the client query
-buffer according to the Redis protocol. Once commands are ready to be processed,
-it calls `processCommand()` which is defined inside `server.c` in order to
-actually execute the command.
-* `freeClient()` deallocates, disconnects and removes a client.
-
-aof.c and rdb.c
----
-
-As you can guess from the names, these files implement the RDB and AOF
-persistence for Redis. Redis uses a persistence model based on the `fork()`
-system call in order to create a process with the same (shared) memory
-content of the main Redis process. This secondary process dumps the content
-of the memory on disk. This is used by `rdb.c` to create the snapshots
-on disk and by `aof.c` in order to perform the AOF rewrite when the
-append only file gets too big.
-
-The implementation inside `aof.c` has additional functions in order to
-implement an API that allows commands to append new commands into the AOF
-file as clients execute them.
-
-The `call()` function defined inside `server.c` is responsible for calling
-the functions that in turn will write the commands into the AOF.
-
-db.c
----
-
-Certain Redis commands operate on specific data types; others are general.
-Examples of generic commands are `DEL` and `EXPIRE`. They operate on keys
-and not on their values specifically. All those generic commands are
-defined inside `db.c`.
-
-Moreover `db.c` implements an API in order to perform certain operations
-on the Redis dataset without directly accessing the internal data structures.
-
-The most important functions inside `db.c` which are used in many command
-implementations are the following:
-
-* `lookupKeyRead()` and `lookupKeyWrite()` are used in order to get a pointer
-to the value associated to a given key, or `NULL` if the key does not exist.
-* `dbAdd()` and its higher level counterpart `setKey()` create a new key in a
-Redis database.
-* `dbDelete()` removes a key and its associated value.
-* `emptyData()` removes an entire single database or all the databases defined.
-
-The rest of the file implements the generic commands exposed to the client.
-
-object.c
----
-
-The `robj` structure defining Redis objects was already described. Inside
-`object.c` there are all the functions that operate with Redis objects at
-a basic level, like functions to allocate new objects, handle the reference
-counting and so forth. Notable functions inside this file:
-
-* `incrRefCount()` and `decrRefCount()` are used in order to increment or
-decrement an object reference count. When it drops to 0 the object is finally
-freed.
-* `createObject()` allocates a new object. There are also specialized functions
-to allocate string objects having a specific content, like
-`createStringObjectFromLongLong()` and similar functions.
-
-This file also implements the `OBJECT` command.
-
-replication.c
----
-
-This is one of the most complex files inside Redis, it is recommended to
-approach it only after getting a bit familiar with the rest of the code base.
-In this file there is the implementation of both the master and replica role
-of Redis.
-
-One of the most important functions inside this file is
-`replicationFeedSlaves()` that writes commands to the clients representing
-replica instances connected
-to our master, so that the replicas can get the writes performed by the clients:
-this way their data set will remain synchronized with the one in the master.
-
-This file also implements both the `SYNC` and `PSYNC` commands that are
-used in order to perform the first synchronization between masters and
-replicas, or to continue the replication after a disconnection.
-
-Script
----
-
-The script unit is composed of 3 units:
-* `script.c` - integration of scripts with Redis (commands execution, set
-replication/resp, ...)
-* `script_lua.c` - responsible to execute Lua code, uses `script.c` to interact
-with Redis from within the Lua code.
-* `function_lua.c` - contains the Lua engine implementation, uses
-`script_lua.c` to execute the Lua code.
-* `functions.c` - contains Redis Functions implementation (`FUNCTION` command),
-uses `functions_lua.c` if the function it wants to invoke needs the Lua engine.
-* `eval.c` - contains the `eval` implementation using `script_lua.c` to invoke
-the Lua code.
-
-
-Other C files
----
-
-* `t_hash.c`, `t_list.c`, `t_set.c`, `t_string.c`, `t_zset.c` and `t_stream.c`
-contains the implementation of the Redis data types. They implement both an API
-to access a given data type, and the client command implementations for these
-data types.
-* `ae.c` implements the Redis event loop, it's a self contained library which
-is simple to read and understand.
-* `sds.c` is the Redis string library, check https://github.com/antirez/sds for
-more information.
-* `anet.c` is a library to use POSIX networking in a simpler way compared to the
-raw interface exposed by the kernel.
-* `dict.c` is an implementation of a non-blocking hash table which rehashes
-incrementally.
-* `cluster.c` implements the Redis Cluster. Probably a good read only after
-being very familiar with the rest of the Redis code base. If you want to read
-`cluster.c` make sure to read the [Redis Cluster specification][4].
-
-[4]: https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/
-
-Anatomy of a Redis command
----
-
-All the Redis commands are defined in the following way:
-
-```c
-void foobarCommand(client *c) {
-    printf("%s",c->argv[1]->ptr); /* Do something with the argument. */
-    addReply(c,shared.ok); /* Reply something to the client. */
-}
-```
-
-The command function is referenced by a JSON file, together with its metadata,
-see `commands.c` described above for details. The command flags are documented
-in the comment above the `struct redisCommand` in `server.h`. For other
-details, please refer to the `COMMAND` command.
-https://redis.io/commands/command/
-
-After the command operates in some way, it returns a reply to the client,
-usually using `addReply()` or a similar function defined inside `networking.c`.
-
-There are tons of command implementations inside the Redis source code
-that can serve as examples of actual commands implementations
-(e.g. pingCommand). Writing a few toy commands can be a good exercise to get
-familiar with the code base.
-
-There are also many other files not described here, but it is useless to
-cover everything. We just want to help you with the first steps.
-Eventually you'll find your way inside the Redis code base :-)
+Please see the [INTERNALS.md](./INTERNALS.md) file for more information about
+the Redis source code layout.
 
 Enjoy!
-
-Drivers
-===
-
-Redis has client drivers for most programming languages:
-https://redis.io/docs/latest/develop/clients/
-
-Learn Redis
-===
-
-* Documentation - https://redis.io/docs/
-* Developer Hub - https://redis.io/learn/
-* Redis University - https://university.redis.io/
-
-Redis Cloud
-===
-
-https://redis.io/cloud/
-
-Community
-===
-
-https://redis.io/community/
-


### PR DESCRIPTION
This PR revamps the README to provide more detail into Redis features, capabilities, and use-cases while still keeping things brief and adding links out to further documentation.

The existing README primarily focuses on building from source, which is important but also misses a flow for different audiences (new users, developers using Redis, contributors). It also mixes internal file structure with the main information about the project. This PR moves the internal file structure docs into it's own file (INTERNALS.md) and links to it.

Key changes:
* New structure & navigation
  * Added a TOC for easy nav
  * Restructured sections into a more logical flow (Intro -> What -> Why -> Getting started -> Deep dive -> Building -> Contributing -> Reference)
  * Added guidance for different personas of users (New to Redis? Ready to Build? Want to Contribute? etc.)
* Added content
  * Added a top-level brief project summary
  * Expanded "What is Redis?" section with descriptions and links to core data structures and capabilities
  * Added "Why use Redis?" section to highlight key benefits and common use cases for Redis
* Set consistent formatting
  * Reformatted code blocks to be easily copy/pasted
  * Used markdown link syntax consistently for better readability
  * Used consistent heading levels and syntax

Hopefully this PR improves the onboarding experience for users who stumble upon this repository and want to learn about Redis but aren't necessarily looking to build the source and learn the internals.